### PR TITLE
Fix CLI entry point in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'cobra = core.main:main',  # Asumiendo que el archivo main.py está en src/core
-            'cobra=src.cli:main',
+            'cobra=src.cli.cli:main',
         ],
     },
 


### PR DESCRIPTION
## Summary
- fix `entry_points` to use `cobra=src.cli.cli:main`

## Testing
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_684559813d808327aacfafae0313da76