### PR TITLE
Update CLI to ignore extraneous arguments

### DIFF
--- a/src/cli/cli.py
+++ b/src/cli/cli.py
@@ -117,7 +117,7 @@ def main():
     parser.add_argument("--inspeccionar", choices=["tokens", "ast"],
                         help="Opcional: Inspecciona los tokens o AST de un archivo.")
 
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
 
     if args.archivo and args.transpilador:
         transpilar_archivo(args.archivo, args.transpilador)


### PR DESCRIPTION
## Summary
- handle unknown arguments in CLI by using `parse_known_args`

## Testing
- `timeout 10s pytest src/tests/test_cli.py src/tests/test_cli2.py -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68455a564814832782f1368ec7c3df4b