### PR TITLE
Support multiple node styles in JS transpiler

### DIFF
--- a/src/core/parser.py
+++ b/src/core/parser.py
@@ -22,9 +22,14 @@ class NodoAsignacion(NodoAST):
 
 
 class NodoHolobit(NodoAST):
-    def __init__(self, valores):
+    def __init__(self, *args):
         super().__init__()
-        self.valores = valores
+        if len(args) == 1:
+            self.nombre = None
+            self.valores = args[0]
+        else:
+            self.nombre = args[0]
+            self.valores = args[1]
 
 
 class NodoCondicional(NodoAST):


### PR DESCRIPTION
## Summary
- extend `NodoHolobit` to accept optional name parameter
- add indentation and prefix logic to JavaScript transpiler
- allow transpiler to work with nodes that expose different attribute names
- ensure dictionaries and classes handle alternative attribute names

## Testing
- `pytest src/tests/test_to_js*.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68455dd4030c8327961c3c95386e729e