### PR TITLE
Add analizar_token wrapper

### DIFF
--- a/src/core/lexer.py
+++ b/src/core/lexer.py
@@ -152,4 +152,11 @@ class Lexer:
         if error_tokens:
             raise ValueError(f"Tokens no reconocidos encontrados: {error_tokens}")
 
+        # Añade un token EOF al final para indicar el fin del código fuente
+        self.tokens.append(Token(TipoToken.EOF, None))
+
         return self.tokens
+
+    def analizar_token(self):
+        """Mantiene compatibilidad con versiones previas."""
+        return self.tokenizar()


### PR DESCRIPTION
## Summary
- implement `analizar_token` wrapper for backwards compatibility
- append EOF token in lexer output

## Testing
- `pytest -k lexer -q`

------
https://chatgpt.com/codex/tasks/task_e_6845667067748327b568b2189595fe17