### PR TITLE
Improve reliability of tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 
 # Dependencias para pruebas
 pytest==7.4.0
+pytest-timeout==2.4.0
 
 # Dependencias para la implementación del parser y lexer
 antlr4-python3-runtime==4.9.3  # Si estás usando ANTLR

--- a/src/tests/test_interpreter.py
+++ b/src/tests/test_interpreter.py
@@ -1,4 +1,7 @@
 import pytest
+from io import StringIO
+from unittest.mock import patch
+
 from src.core.interpreter import InterpretadorCobra
 from src.core.lexer import Token, TipoToken
 from src.core.parser import NodoAsignacion, NodoValor, NodoLlamadaFuncion


### PR DESCRIPTION
## Summary
- fix missing imports in interpreter test
- add pytest-timeout to requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845685fc5788327ae62712451c29d87