### PR TITLE
Implementación básica de Holobits

### DIFF
--- a/src/core/holobits/__init__.py
+++ b/src/core/holobits/__init__.py
@@ -1,0 +1,6 @@
+from .holobit import Holobit
+from .graficar import graficar
+from .proyection import proyectar
+from .transformacion import transformar
+
+__all__ = ["Holobit", "graficar", "proyectar", "transformar"]

--- a/src/core/holobits/graficar.py
+++ b/src/core/holobits/graficar.py
@@ -1,0 +1,9 @@
+from .holobit import Holobit
+
+
+def graficar(hb: Holobit):
+    """Funcion placeholder para graficar un Holobit."""
+    if not isinstance(hb, Holobit):
+        raise TypeError("graficar espera una instancia de Holobit")
+    # Comportamiento simulado
+    return f"Graficando {hb}"

--- a/src/core/holobits/holobit.py
+++ b/src/core/holobits/holobit.py
@@ -1,0 +1,16 @@
+class Holobit:
+    """Representa un conjunto de valores numericos para operaciones 3D/2D."""
+
+    def __init__(self, valores):
+        if not hasattr(valores, "__iter__"):
+            raise TypeError("'valores' debe ser iterable")
+        self.valores = [float(v) for v in valores]
+
+    def __repr__(self):
+        return f"Holobit({self.valores})"
+
+    def __len__(self):
+        return len(self.valores)
+
+    def __getitem__(self, index):
+        return self.valores[index]

--- a/src/core/holobits/proyection.py
+++ b/src/core/holobits/proyection.py
@@ -1,0 +1,8 @@
+from .holobit import Holobit
+
+
+def proyectar(hb: Holobit, modo: str):
+    """Funcion placeholder para proyectar un Holobit."""
+    if not isinstance(hb, Holobit):
+        raise TypeError("proyectar espera una instancia de Holobit")
+    return f"Proyectando {hb} en {modo}"

--- a/src/core/holobits/transformacion.py
+++ b/src/core/holobits/transformacion.py
@@ -1,0 +1,8 @@
+from .holobit import Holobit
+
+
+def transformar(hb: Holobit, operacion: str, *parametros):
+    """Funcion placeholder para transformar un Holobit."""
+    if not isinstance(hb, Holobit):
+        raise TypeError("transformar espera una instancia de Holobit")
+    return f"Transformar {hb} con {operacion} {parametros}"


### PR DESCRIPTION
## Summary
- crear clase `Holobit` para manejar valores numéricos
- añadir funciones placeholder `graficar`, `proyectar` y `transformar`
- exponer estos símbolos desde `holobits.__init__`

## Testing
- `pytest -q` *(falló: varios tests no relacionados)*

------
https://chatgpt.com/codex/tasks/task_e_68552e4d72e883278f37774ec31ce3f2