### PR TITLE
Add FIN token and parser fixes

### DIFF
--- a/src/core/lexer.py
+++ b/src/core/lexer.py
@@ -84,6 +84,7 @@ class Lexer:
             (TipoToken.CADENA, r"'[^']*'|\"[^\"]*\""),
             (TipoToken.BOOLEANO, r'\b(verdadero|falso)\b'),
             (TipoToken.DOSPUNTOS, r':'),
+            (TipoToken.FIN, r'\bfin\b'),
             (TipoToken.IDENTIFICADOR, r'[A-Za-z_][A-Za-z0-9_]*'),
             (TipoToken.ASIGNAR, r'='),
             (TipoToken.SUMA, r'\+'),
@@ -121,6 +122,8 @@ class Lexer:
                             valor = float(valor)
                         elif tipo == TipoToken.ENTERO:
                             valor = int(valor)
+                        elif tipo == TipoToken.CADENA:
+                            valor = valor[1:-1]
                         self.tokens.append(Token(tipo, valor))
 
                     self.posicion += len(coincidencia.group(0))


### PR DESCRIPTION
## Summary
- recognize `fin` keyword in the lexer
- normalize string tokens by stripping quotes
- adapt AST nodes and parser logic for tests using `fin`

## Testing
- `pytest src/tests/test_parser5.py::test_declaracion_para -q -vv`
- `pytest src/tests/test_parser5.py::test_declaracion_imprimir -q -vv`
- `pytest src/tests/test_parser5.py::test_funcion_y_para -q -vv`
- `pytest src/tests/test_parser4.py::test_parser_mientras -q -vv`
- `pytest src/tests/test_parser4.py::test_parser_condicional -q -vv`
- `pytest src/tests/test_parser4.py::test_parser_asignacion -q -vv`
- `pytest src/tests/test_parser4.py::test_parser_funcion_con_retorno -q -vv`
- `pytest src/tests/test_parser4.py::test_parser_funcion_sin_retorno -q -vv`
- `pytest src/tests/test_parser4.py::test_parser_errores -q -vv`
- `pytest src/tests/test_parser4.py::test_parser_definir_funcion -q -vv`


------
https://chatgpt.com/codex/tasks/task_e_685551c2cd2883279da4fe0a7b5966f9