### PR TITLE
Detectar holobit dentro de términos

### DIFF
--- a/src/core/parser.py
+++ b/src/core/parser.py
@@ -580,6 +580,9 @@ class Parser:
                 return self.llamada_funcion()
             self.comer(TipoToken.IDENTIFICADOR)
             return NodoIdentificador(token.valor)
+        elif token.tipo == TipoToken.HOLOBIT:
+            # Permitir el uso de 'holobit' dentro de expresiones
+            return self.declaracion_holobit()
         else:
             raise SyntaxError(f"Token inesperado en término: {token.tipo}")
 


### PR DESCRIPTION
## Resumen
- actualizar `termino()` del parser para reconocer `TipoToken.HOLOBIT`
- se invoca `declaracion_holobit` cuando aparece este token

## Testing
- `pytest src/tests/test_parser_holobit.py::test_parser_holobit src/tests/test_parser3.py::test_asignacion_holobit -q`

------
https://chatgpt.com/codex/tasks/task_e_6855540e1418832786109b6f32025901