### PR TITLE
Actualiza manejo de identificadores en NodoAsignacion

### DIFF
--- a/src/core/interpreter.py
+++ b/src/core/interpreter.py
@@ -41,9 +41,12 @@ class InterpretadorCobra:
 
     def ejecutar_asignacion(self, nodo):
         # Resuelve el valor de la expresión en el nodo
-        valor = self.evaluar_expresion(nodo.expresion)
+        nombre = getattr(nodo, "identificador", getattr(nodo, "variable", None))
+        valor_nodo = getattr(nodo, "expresion", getattr(nodo, "valor", None))
+        # Resuelve el valor de la expresión en el nodo
+        valor = self.evaluar_expresion(valor_nodo)
         # Almacena el valor en el diccionario de variables
-        self.variables[nodo.variable] = valor
+        self.variables[nombre] = valor
 
     def evaluar_expresion(self, expresion):
         if isinstance(expresion, NodoValor):

--- a/src/core/parser.py
+++ b/src/core/parser.py
@@ -18,12 +18,20 @@ class NodoAsignacion(NodoAST):
     def __init__(self, variable, expresion):
         super().__init__()
         if isinstance(variable, Token):
-            self.variable = variable.valor
+            nombre = variable.valor
         else:
-            self.variable = variable
+            nombre = variable
+
+        # Nombre del identificador como cadena de texto
+        self.identificador = str(nombre)
+
+        # Mantener compatibilidad con versiones previas
+        self.variable = self.identificador
+
         self.expresion = expresion
+
         # Compatibilidad con pruebas antiguas
-        self.nombre = self.variable
+        self.nombre = self.identificador
         self.valor = expresion
 
 
@@ -393,10 +401,8 @@ class Parser:
             self.comer(TipoToken.IDENTIFICADOR)
         self.comer(TipoToken.ASIGNAR)
         valor = self.expresion()
-        nombre_variable = (
-            variable_token.valor if isinstance(variable_token, Token) else variable_token
-        )
-        return NodoAsignacion(nombre_variable, valor)
+        # El identificador se pasa como cadena de texto
+        return NodoAsignacion(variable_token.valor, valor)
 
     def declaracion_mientras(self):
         """Parsea un bucle mientras."""

--- a/src/core/transpiler/to_js.py
+++ b/src/core/transpiler/to_js.py
@@ -52,8 +52,8 @@ class TranspiladorJavaScript:
     def transpilar_asignacion(self, nodo):
         """Transpila una asignación en JavaScript."""
         if self.usa_indentacion is None:
-            self.usa_indentacion = hasattr(nodo, "variable")
-        nombre = getattr(nodo, "variable", getattr(nodo, "identificador", None))
+            self.usa_indentacion = hasattr(nodo, "variable") or hasattr(nodo, "identificador")
+        nombre = getattr(nodo, "identificador", getattr(nodo, "variable", None))
         valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
         if hasattr(valor, "__dict__"):
             valor = str(valor)

--- a/src/core/transpiler/to_python.py
+++ b/src/core/transpiler/to_python.py
@@ -52,9 +52,11 @@ class TranspiladorPython:
         return str(nodo.valor) if isinstance(nodo, NodoValor) else str(nodo)
 
     def transpilar_asignacion(self, nodo):
+        nombre = getattr(nodo, "identificador", getattr(nodo, "variable", None))
+        valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
         self.codigo += (
-            f"{self.obtener_indentacion()}{nodo.variable} = "
-            f"{self.obtener_valor(nodo.expresion)}\n"
+            f"{self.obtener_indentacion()}{nombre} = "
+            f"{self.obtener_valor(valor)}\n"
         )
 
     def transpilar_condicional(self, nodo):


### PR DESCRIPTION
## Summary
- almacena el identificador en `NodoAsignacion` como cadena y añade compatibilidad
- pasa el valor del token en `declaracion_asignacion`
- ajusta transpiler a Python y JavaScript para usar `identificador`
- corrige el intérprete para leer el nuevo atributo

## Testing
- `pytest -q src/tests/test_parser2.py::test_parser_asignacion_variable`
- `pytest -q` *(failing: test_cli_interactive, test_cli_transpilador, test_cli2_*, test_lexer_transformacion_holobit)*

------
https://chatgpt.com/codex/tasks/task_e_685554f79168832798f3a05c770cd03b