### PR TITLE
Elimina clase redundante NodoMientras

### DIFF
--- a/src/core/parser.py
+++ b/src/core/parser.py
@@ -167,23 +167,6 @@ class NodoRetorno(NodoAST):
         return f"NodoRetorno(expresion={self.expresion})"
 
 
-class NodoMientras:
-    """Representa un nodo de bucle 'mientras' en el AST."""
-
-    def __init__(self, condicion, cuerpo):
-        """
-        Inicializa el nodo de bucle mientras.
-
-        :param condicion: Nodo que representa la condición del bucle.
-        :param cuerpo: Lista de nodos que representan el cuerpo del bucle.
-        """
-        self.condicion = condicion
-        self.cuerpo = cuerpo
-
-    def __repr__(self):
-        return f"NodoMientras(condicion={self.condicion}, cuerpo={self.cuerpo})"
-
-
 class NodoPara:
     """Nodo AST para representar bucles 'para'."""
 
@@ -430,7 +413,7 @@ class Parser:
         self.comer(TipoToken.FIN)
 
         logging.debug(f"Cuerpo del bucle mientras: {cuerpo}")
-        return NodoMientras(condicion, cuerpo)
+        return NodoBucleMientras(condicion, cuerpo)
 
     def declaracion_holobit(self):
         self.comer(TipoToken.HOLOBIT)

--- a/src/tests/test_parser4.py
+++ b/src/tests/test_parser4.py
@@ -1,7 +1,14 @@
 import pytest
 
 from src.core.lexer import Token, TipoToken
-from src.core.parser import NodoAsignacion, NodoCondicional, NodoFuncion, NodoRetorno, NodoMientras, NodoValor
+from src.core.parser import (
+    NodoAsignacion,
+    NodoCondicional,
+    NodoFuncion,
+    NodoRetorno,
+    NodoBucleMientras,
+    NodoValor,
+)
 from src.core.parser import Parser
 
 
@@ -44,7 +51,7 @@ def test_parser_mientras():
     ast = parser.parsear()
 
     assert len(ast) == 1
-    assert isinstance(ast[0], NodoMientras)
+    assert isinstance(ast[0], NodoBucleMientras)
     assert ast[0].condicion.operador.tipo == TipoToken.MAYORQUE
     assert ast[0].condicion.izquierda.valor == "x"
     assert ast[0].condicion.derecha.valor == 0


### PR DESCRIPTION
## Summary
- remove `NodoMientras` AST node
- return `NodoBucleMientras` in parser
- adjust tests to import and check `NodoBucleMientras`

## Testing
- `pytest -q src/tests/test_parser4.py::test_parser_mientras -q`
- `pytest -q` *(fails: test_cli_interactive, test_cli_transpilador, test_cli2 and test_lexer)*

------
https://chatgpt.com/codex/tasks/task_e_68555d70467483278dd8e6ede75fb314