### PR TITLE
Implementación de nombre en NodoHolobit

### DIFF
--- a/src/core/interpreter.py
+++ b/src/core/interpreter.py
@@ -75,6 +75,8 @@ class InterpretadorCobra:
         elif isinstance(expresion, NodoAsignacion):
             # Resuelve asignaciones anidadas, si existieran
             self.ejecutar_asignacion(expresion)
+        elif isinstance(expresion, NodoHolobit):
+            return self.ejecutar_holobit(expresion)
         else:
             raise ValueError(f"Expresión no soportada: {expresion}")
 
@@ -129,3 +131,10 @@ class InterpretadorCobra:
 
     def ejecutar_holobit(self, nodo):
         print(f"Simulando holobit: {nodo.nombre}")
+        valores = []
+        for v in nodo.valores:
+            if isinstance(v, NodoValor):
+                valores.append(v.valor)
+            else:
+                valores.append(v)
+        return valores

--- a/src/core/parser.py
+++ b/src/core/parser.py
@@ -36,14 +36,15 @@ class NodoAsignacion(NodoAST):
 
 
 class NodoHolobit(NodoAST):
-    def __init__(self, *args):
+    def __init__(self, nombre=None, valores=None):
         super().__init__()
-        if len(args) == 1:
+        # Permitir inicializaciones flexibles manteniendo compatibilidad
+        if valores is None and isinstance(nombre, list):
             self.nombre = None
-            self.valores = args[0]
+            self.valores = nombre
         else:
-            self.nombre = args[0]
-            self.valores = args[1]
+            self.nombre = nombre
+            self.valores = valores if valores is not None else []
 
 
 class NodoCondicional(NodoAST):
@@ -384,6 +385,9 @@ class Parser:
             self.comer(TipoToken.IDENTIFICADOR)
         self.comer(TipoToken.ASIGNAR)
         valor = self.expresion()
+        # Si la expresión es un holobit, completar su nombre con la variable
+        if isinstance(valor, NodoHolobit) and valor.nombre is None:
+            valor.nombre = variable_token.valor
         # El identificador se pasa como cadena de texto
         return NodoAsignacion(variable_token.valor, valor)
 
@@ -427,7 +431,7 @@ class Parser:
                 self.comer(TipoToken.COMA)
         self.comer(TipoToken.RBRACKET)
         self.comer(TipoToken.RPAREN)
-        return NodoHolobit(valores)
+        return NodoHolobit(valores=valores)
 
     def declaracion_condicional(self):
         """Parsea un bloque condicional."""

--- a/src/core/transpiler/to_python.py
+++ b/src/core/transpiler/to_python.py
@@ -182,23 +182,11 @@ class TranspiladorPython:
         self.codigo += f"{nodo.nombre}({argumentos})\n"
 
     def transpilar_holobit(self, nodo):
-        if hasattr(nodo, "nombre") and nodo.nombre is not None:
-            if hasattr(nodo, "valores"):
-                valores = ", ".join(
-                    self.obtener_valor(valor) for valor in nodo.valores
-                )
-                self.codigo += f"{nodo.nombre} = holobit([{valores}])\n"
-            else:
-                self.codigo += f"holobit({nodo.nombre})\n"
+        valores = ", ".join(self.obtener_valor(v) for v in nodo.valores)
+        if nodo.nombre:
+            self.codigo += f"{nodo.nombre} = holobit([{valores}])\n"
         else:
-            valores = getattr(nodo, "valores", None)
-            if isinstance(valores, str):
-                self.codigo += f"{valores} = holobit([0.8, -0.5, 1.2])\n"
-            else:
-                valores_str = ", ".join(
-                    self.obtener_valor(valor) for valor in (valores or [])
-                )
-                self.codigo += f"holobit([{valores_str}])\n"
+            self.codigo += f"holobit([{valores}])\n"
 
     def transpilar_lista(self, nodo):
         elementos = ", ".join(

--- a/src/tests/test_to_python.py
+++ b/src/tests/test_to_python.py
@@ -43,7 +43,7 @@ def test_transpilador_llamada_funcion():
 
 
 def test_transpilador_holobit():
-    ast = [NodoHolobit("miHolobit")]
+    ast = [NodoHolobit("miHolobit", [0.8, -0.5, 1.2])]
     transpilador = TranspiladorPython()
     resultado = transpilador.transpilar(ast)
     expected = "miHolobit = holobit([0.8, -0.5, 1.2])"

--- a/src/tests/test_to_python2.py
+++ b/src/tests/test_to_python2.py
@@ -35,8 +35,9 @@ class NodoLlamadaFuncion:
 
 
 class NodoHolobit:
-    def __init__(self, nombre):
+    def __init__(self, nombre, valores=None):
         self.nombre = nombre
+        self.valores = valores or []
 
 
 # Pruebas para el transpilador a Python
@@ -80,7 +81,7 @@ def test_transpilar_llamada_funcion():
 
 
 def test_transpilar_holobit():
-    nodo = NodoHolobit("miHolobit")
+    nodo = NodoHolobit("miHolobit", [1, 2, 3])
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    assert result == "holobit(miHolobit)\n", "Error en la transpilación de Holobit"
+    assert result == "miHolobit = holobit([1, 2, 3])\n", "Error en la transpilación de Holobit"

--- a/src/tests/test_to_python3.py
+++ b/src/tests/test_to_python3.py
@@ -35,8 +35,9 @@ class NodoLlamadaFuncion:
 
 
 class NodoHolobit:
-    def __init__(self, nombre):
+    def __init__(self, nombre, valores=None):
         self.nombre = nombre
+        self.valores = valores or []
 
 
 # Nuevos nodos avanzados para pruebas
@@ -111,10 +112,10 @@ def test_transpilar_llamada_funcion():
 
 
 def test_transpilar_holobit():
-    nodo = NodoHolobit("miHolobit")
+    nodo = NodoHolobit("miHolobit", [1, 2, 3])
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    assert result == "holobit(miHolobit)\n", "Error en la transpilación de Holobit"
+    assert result == "miHolobit = holobit([1, 2, 3])\n", "Error en la transpilación de Holobit"
 
 
 # Pruebas para nuevas estructuras avanzadas


### PR DESCRIPTION
## Summary
- permitir `nombre` en `NodoHolobit` y rellenarlo en asignaciones
- actualizar parser y transpilers para manejar este nombre
- actualizar intérprete para procesar holobits con nombre
- adaptar pruebas a la nueva interfaz

## Testing
- `pytest src/tests/test_to_python.py::test_transpilador_holobit -q`
- `pytest src/tests/test_to_python2.py::test_transpilar_holobit -q`
- `pytest src/tests/test_to_python3.py::test_transpilar_holobit -q`
- `pytest src/tests/test_to_js.py::test_transpilador_holobit -q`


------
https://chatgpt.com/codex/tasks/task_e_68555fca729c8327831c21cd4cf96208