### PR TITLE
Implement print node transpilation

### DIFF
--- a/src/core/transpiler/to_js.py
+++ b/src/core/transpiler/to_js.py
@@ -32,6 +32,8 @@ class TranspiladorJavaScript:
             self.transpilar_funcion(nodo)
         elif nodo_tipo == "NodoLlamadaFuncion":
             self.transpilar_llamada_funcion(nodo)
+        elif nodo_tipo == "NodoImprimir":
+            self.transpilar_imprimir(nodo)
         elif nodo_tipo == "NodoHolobit":
             self.transpilar_holobit(nodo)
         elif nodo_tipo == "NodoFor":
@@ -124,6 +126,12 @@ class TranspiladorJavaScript:
         """Transpila una llamada a función en JavaScript."""
         parametros = ", ".join(nodo.argumentos)
         self.agregar_linea(f"{nodo.nombre}({parametros});")
+
+    def transpilar_imprimir(self, nodo):
+        valor = getattr(nodo.expresion, "valor", nodo.expresion)
+        if isinstance(valor, NodoLista) or isinstance(valor, NodoDiccionario):
+            valor = self.transpilar_elemento(nodo.expresion)
+        self.agregar_linea(f"console.log({valor});")
 
     def transpilar_holobit(self, nodo):
         """Transpila una asignación de Holobit en JavaScript."""

--- a/src/core/transpiler/to_python.py
+++ b/src/core/transpiler/to_python.py
@@ -71,6 +71,8 @@ class TranspiladorPython:
             self.transpilar_funcion(nodo)
         elif hasattr(nodo, "nombre") and hasattr(nodo, "argumentos"):
             self.transpilar_llamada_funcion(nodo)
+        elif type(nodo).__name__ == "NodoImprimir":
+            self.transpilar_imprimir(nodo)
         elif hasattr(nodo, "valores") or (
             hasattr(nodo, "nombre")
             and not any(
@@ -180,6 +182,10 @@ class TranspiladorPython:
     def transpilar_llamada_funcion(self, nodo):
         argumentos = ", ".join(nodo.argumentos)
         self.codigo += f"{nodo.nombre}({argumentos})\n"
+
+    def transpilar_imprimir(self, nodo):
+        valor = self.obtener_valor(getattr(nodo, "expresion", nodo))
+        self.codigo += f"{self.obtener_indentacion()}print({valor})\n"
 
     def transpilar_holobit(self, nodo):
         valores = ", ".join(self.obtener_valor(v) for v in nodo.valores)


### PR DESCRIPTION
## Summary
- add NodeImprimir support to Python and JavaScript transpilers
- call new methods from node dispatcher

## Testing
- `pytest -q` *(fails: AssertionError in CLI and lexer tests)*

------
https://chatgpt.com/codex/tasks/task_e_685562918040832780b37df98bcf8a32