### PR TITLE
Add FIN token handling in tests

### DIFF
--- a/src/tests/test_parser.py
+++ b/src/tests/test_parser.py
@@ -52,6 +52,7 @@ def test_parser_condicional_si_sino():
         proyectar(x, "2D")
     sino :
         graficar(x)
+    fin
     '''
 
     # Inicializamos el lexer

--- a/src/tests/test_parser2.py
+++ b/src/tests/test_parser2.py
@@ -64,6 +64,7 @@ def test_parser_condicional():
         Token(TipoToken.LPAREN, '('),
         Token(TipoToken.IDENTIFICADOR, 'x'),
         Token(TipoToken.RPAREN, ')'),
+        Token(TipoToken.FIN, 'fin'),
         Token(TipoToken.EOF, None)
     ]
     parser = Parser(tokens)
@@ -86,6 +87,7 @@ def test_parser_bucle_mientras():
         Token(TipoToken.IDENTIFICADOR, 'x'),
         Token(TipoToken.RESTA, '-'),
         Token(TipoToken.ENTERO, 1),
+        Token(TipoToken.FIN, 'fin'),
         Token(TipoToken.EOF, None)
     ]
     parser = Parser(tokens)
@@ -113,6 +115,7 @@ def test_parser_funcion():
         Token(TipoToken.COMA, ','),
         Token(TipoToken.CADENA, "'2D'"),
         Token(TipoToken.RPAREN, ')'),
+        Token(TipoToken.FIN, 'fin'),
         Token(TipoToken.EOF, None)
     ]
     parser = Parser(tokens)

--- a/src/tests/test_parser3.py
+++ b/src/tests/test_parser3.py
@@ -60,6 +60,7 @@ def test_condicional():
         (TipoToken.IDENTIFICADOR, "hacer_algo"),
         (TipoToken.LPAREN, "("),
         (TipoToken.RPAREN, ")"),
+        (TipoToken.FIN, "fin"),
         (TipoToken.EOF, None)
     )
     parser = Parser(tokens)
@@ -82,6 +83,7 @@ def test_bucle_mientras():
         (TipoToken.IDENTIFICADOR, "hacer_algo"),
         (TipoToken.LPAREN, "("),
         (TipoToken.RPAREN, ")"),
+        (TipoToken.FIN, "fin"),
         (TipoToken.EOF, None)
     )
     parser = Parser(tokens)
@@ -107,6 +109,7 @@ def test_funcion():
         (TipoToken.IDENTIFICADOR, "hacer_algo"),
         (TipoToken.LPAREN, "("),
         (TipoToken.RPAREN, ")"),
+        (TipoToken.FIN, "fin"),
         (TipoToken.EOF, None)
     )
     parser = Parser(tokens)


### PR DESCRIPTION
## Summary
- update tests to include closing `fin` tokens

## Testing
- `pytest -q` *(fails: KeyboardInterrupt, test failures)*

------
https://chatgpt.com/codex/tasks/task_e_685564edb9e88327b5fec4a05e3b6422