### PR TITLE
Add examples for printing, holobits and loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,27 @@ codigo_python = transpiler.transpilar(arbol)
 print(codigo_python)
 ````
 
+## Ejemplo de imprimir, holobits y bucles
+
+A continuación se muestra un fragmento que utiliza `imprimir`, holobits y bucles:
+
+````cobra
+codigo = '''
+var h = holobit([0.8, -0.5, 1.2])
+imprimir(h)
+
+var contador = 0
+mientras contador < 3 :
+    imprimir(contador)
+    contador += 1
+
+para var i en rango(2) :
+    imprimir(i)
+'''
+````
+
+Al transpilar a Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. El tipo `holobit` se transfiere a la llamada `holobit([...])` en Python o `new Holobit([...])` en JavaScript.
+
 
 ## Uso desde la CLI
 

--- a/source/caracteristicas.rst
+++ b/source/caracteristicas.rst
@@ -20,3 +20,12 @@ imprimir(rotado)
 
 # Graficar el holobit
 graficar(x)
+
+# Bucles de ejemplo
+var contador = 0
+mientras contador < 2 :
+    imprimir(contador)
+    contador += 1
+
+para var i en rango(2) :
+    imprimir(i)

--- a/source/sintaxis.rst
+++ b/source/sintaxis.rst
@@ -42,3 +42,16 @@ mientras x < 5 :
 para var i en rango(5) :
     imprimir(i)
 
+**6. Holobits**
+
+Los holobits permiten trabajar con datos multidimensionales:
+
+var h = holobit([0.8, -0.5, 1.2])
+imprimir(h)
+
+**Transpilación a Python y JavaScript**
+
+- `imprimir` se transpila a `print` en Python y a `console.log` en JavaScript.
+- Los bucles `mientras` y `para` se convierten en `while` y `for` respectivamente.
+- La construcción `holobit` se traduce a `holobit([...])` en Python o `new Holobit([...])` en JavaScript.
+


### PR DESCRIPTION
## Summary
- expand README with printing, holobit and loops sample
- show how these statements transpile to Python and JavaScript
- extend documentation with loops example and holobit section

## Testing
- `pytest -q` *(fails: AssertionError in CLI tests)*

------
https://chatgpt.com/codex/tasks/task_e_68556793f8a48327befb59235a4ad335