### PR TITLE
Add return statement support

### DIFF
--- a/src/core/transpiler/to_js.py
+++ b/src/core/transpiler/to_js.py
@@ -46,6 +46,8 @@ class TranspiladorJavaScript:
             self.transpilar_clase(nodo)
         elif nodo_tipo == "NodoMetodo":
             self.transpilar_metodo(nodo)
+        elif nodo_tipo == "NodoRetorno":
+            self.transpilar_retorno(nodo)
         else:
             raise TypeError(f"Tipo de nodo no soportado: {nodo_tipo}")
 
@@ -132,6 +134,12 @@ class TranspiladorJavaScript:
         if isinstance(valor, NodoLista) or isinstance(valor, NodoDiccionario):
             valor = self.transpilar_elemento(nodo.expresion)
         self.agregar_linea(f"console.log({valor});")
+
+    def transpilar_retorno(self, nodo):
+        valor = getattr(nodo.expresion, "valor", nodo.expresion)
+        if isinstance(valor, NodoLista) or isinstance(valor, NodoDiccionario):
+            valor = self.transpilar_elemento(nodo.expresion)
+        self.agregar_linea(f"return {valor};")
 
     def transpilar_holobit(self, nodo):
         """Transpila una asignación de Holobit en JavaScript."""

--- a/src/core/transpiler/to_python.py
+++ b/src/core/transpiler/to_python.py
@@ -1,7 +1,7 @@
 from src.core.parser import (
     NodoAsignacion, NodoCondicional, NodoBucleMientras, NodoFuncion,
     NodoLlamadaFuncion, NodoHolobit, NodoFor, NodoLista, NodoDiccionario,
-    NodoClase, NodoMetodo, NodoValor
+    NodoClase, NodoMetodo, NodoValor, NodoRetorno
 )
 
 
@@ -73,6 +73,8 @@ class TranspiladorPython:
             self.transpilar_llamada_funcion(nodo)
         elif type(nodo).__name__ == "NodoImprimir":
             self.transpilar_imprimir(nodo)
+        elif isinstance(nodo, NodoRetorno) or type(nodo).__name__ == "NodoRetorno":
+            self.transpilar_retorno(nodo)
         elif hasattr(nodo, "valores") or (
             hasattr(nodo, "nombre")
             and not any(
@@ -186,6 +188,10 @@ class TranspiladorPython:
     def transpilar_imprimir(self, nodo):
         valor = self.obtener_valor(getattr(nodo, "expresion", nodo))
         self.codigo += f"{self.obtener_indentacion()}print({valor})\n"
+
+    def transpilar_retorno(self, nodo):
+        valor = self.obtener_valor(getattr(nodo, "expresion", nodo.expresion))
+        self.codigo += f"{self.obtener_indentacion()}return {valor}\n"
 
     def transpilar_holobit(self, nodo):
         valores = ", ".join(self.obtener_valor(v) for v in nodo.valores)

--- a/src/tests/test_retornos.py
+++ b/src/tests/test_retornos.py
@@ -1,0 +1,26 @@
+import pytest
+from src.core.interpreter import InterpretadorCobra
+from src.core.parser import NodoFuncion, NodoRetorno, NodoValor, NodoLlamadaFuncion
+from src.core.transpiler.to_python import TranspiladorPython
+from src.core.transpiler.to_js import TranspiladorJavaScript
+
+
+def test_interpreter_funcion_con_retorno():
+    inter = InterpretadorCobra()
+    func = NodoFuncion("dame_cinco", [], [NodoRetorno(NodoValor(5))])
+    inter.ejecutar_funcion(func)
+    resultado = inter.ejecutar_llamada_funcion(NodoLlamadaFuncion("dame_cinco", []))
+    assert resultado == 5
+
+
+def test_transpiladores_retorno():
+    nodo_ret = NodoRetorno(NodoValor(7))
+    func = NodoFuncion("valor", [], [nodo_ret])
+
+    py = TranspiladorPython()
+    codigo_py = py.transpilar([func])
+    assert "return 7" in codigo_py
+
+    js = TranspiladorJavaScript()
+    codigo_js = js.transpilar([func])
+    assert "return 7;" in codigo_js


### PR DESCRIPTION
## Summary
- propagate return values in the interpreter
- handle `NodoRetorno` in Python and JavaScript transpilers
- test interpreter return behaviour and transpiler code generation

## Testing
- `pytest -q src/tests/test_retornos.py`
- `pytest -q` *(fails: test_cli_interactive, test_cli_transpilador, test_cli2_interactive, test_cli2_transpilador, test_cli2_with_holobit, test_cli2_for_loop, test_lexer_transformacion_holobit)*

------
https://chatgpt.com/codex/tasks/task_e_68556f6e21c48327959d978e4192dfbb