### PR TITLE
Soporte de comentarios en Lexer

### DIFF
--- a/src/core/lexer.py
+++ b/src/core/lexer.py
@@ -72,6 +72,14 @@ class Lexer:
         self.tokens = []
 
     def tokenizar(self):
+        # Elimina comentarios de una línea y bloques de comentarios
+        codigo_sin_bloques = re.sub(r'/\*.*?\*/', '', self.codigo_fuente, flags=re.DOTALL)
+        codigo_sin_doble = re.sub(r'//.*?$', '', codigo_sin_bloques, flags=re.MULTILINE)
+        codigo_limpio = re.sub(r'#.*?$', '', codigo_sin_doble, flags=re.MULTILINE)
+
+        self.codigo_fuente = codigo_limpio
+        self.posicion = 0
+
         especificacion_tokens = [
             (TipoToken.VAR, r'\bvar\b'),
             (TipoToken.FUNC, r'\bfunc\b'),

--- a/src/tests/test_lexer.py
+++ b/src/tests/test_lexer.py
@@ -53,3 +53,26 @@ def test_lexer_transformacion_holobit():
         (TipoToken.EOF, None),
     ]
 
+
+def test_lexer_con_comentarios():
+    codigo = """
+    # Comentario inicial
+    var x = 10 // asignar valor
+    imprimir(x) /* comentario de bloque */
+    """
+
+    lexer = Lexer(codigo)
+    tokens = lexer.analizar_token()
+
+    assert [(t.tipo, t.valor) for t in tokens] == [
+        (TipoToken.VAR, 'var'),
+        (TipoToken.IDENTIFICADOR, 'x'),
+        (TipoToken.ASIGNAR, '='),
+        (TipoToken.ENTERO, 10),
+        (TipoToken.IMPRIMIR, 'imprimir'),
+        (TipoToken.LPAREN, '('),
+        (TipoToken.IDENTIFICADOR, 'x'),
+        (TipoToken.RPAREN, ')'),
+        (TipoToken.EOF, None),
+    ]
+


### PR DESCRIPTION
## Summary
- soporte para comentarios `#`, `//` y `/* */` en el lexer
- prueba unitaria para verificar que los comentarios se ignoran

## Testing
- `pytest -q` *(errored: 7 failed, 13 passed)*


------
https://chatgpt.com/codex/tasks/task_e_685575b6f880832798e1e223f0fb4d2d