### PR TITLE
Add object support to interpreter and transpilers

### DIFF
--- a/src/core/parser.py
+++ b/src/core/parser.py
@@ -19,14 +19,12 @@ class NodoAsignacion(NodoAST):
         super().__init__()
         if isinstance(variable, Token):
             nombre = variable.valor
+            self.identificador = str(nombre)
+            self.variable = self.identificador
         else:
             nombre = variable
-
-        # Nombre del identificador como cadena de texto
-        self.identificador = str(nombre)
-
-        # Mantener compatibilidad con versiones previas
-        self.variable = self.identificador
+            self.identificador = nombre
+            self.variable = nombre
 
         self.expresion = expresion
 
@@ -103,6 +101,34 @@ class NodoMetodo(NodoAST):
         self.nombre = nombre
         self.parametros = parametros
         self.cuerpo = cuerpo
+
+
+class NodoInstancia(NodoAST):
+    """Representa la creación de una instancia de una clase."""
+
+    def __init__(self, nombre_clase, argumentos=None):
+        super().__init__()
+        self.nombre_clase = nombre_clase
+        self.argumentos = argumentos or []
+
+
+class NodoAtributo(NodoAST):
+    """Acceso o referencia a un atributo de un objeto."""
+
+    def __init__(self, objeto, nombre):
+        super().__init__()
+        self.objeto = objeto
+        self.nombre = nombre
+
+
+class NodoLlamadaMetodo(NodoAST):
+    """Representa la llamada a un método de un objeto."""
+
+    def __init__(self, objeto, nombre_metodo, argumentos=None):
+        super().__init__()
+        self.objeto = objeto
+        self.nombre_metodo = nombre_metodo
+        self.argumentos = argumentos or []
 
 
 class NodoOperacionBinaria(NodoAST):

--- a/src/tests/test_interpreter_objects.py
+++ b/src/tests/test_interpreter_objects.py
@@ -1,0 +1,57 @@
+from src.core.interpreter import InterpretadorCobra
+from src.core.parser import (
+    NodoClase,
+    NodoMetodo,
+    NodoInstancia,
+    NodoAsignacion,
+    NodoLlamadaMetodo,
+    NodoAtributo,
+    NodoIdentificador,
+    NodoValor,
+    NodoRetorno,
+)
+
+
+def test_creacion_instancia_y_metodo():
+    inter = InterpretadorCobra()
+
+    metodo = NodoMetodo("saludar", ["self"], [NodoRetorno(NodoValor("hola"))])
+    clase = NodoClase("Persona", [metodo])
+    inter.ejecutar_nodo(clase)
+
+    inter.ejecutar_nodo(NodoAsignacion("p", NodoInstancia("Persona")))
+    res = inter.ejecutar_nodo(
+        NodoLlamadaMetodo(NodoIdentificador("p"), "saludar", [])
+    )
+    assert res == "hola"
+
+
+def test_atributos_en_instancia():
+    inter = InterpretadorCobra()
+
+    set_nombre = NodoMetodo(
+        "set_nombre",
+        ["self", "nombre"],
+        [
+            NodoAsignacion(
+                NodoAtributo(NodoIdentificador("self"), "nombre"),
+                NodoIdentificador("nombre"),
+            )
+        ],
+    )
+    get_nombre = NodoMetodo(
+        "get_nombre",
+        ["self"],
+        [NodoRetorno(NodoAtributo(NodoIdentificador("self"), "nombre"))],
+    )
+    clase = NodoClase("Persona", [set_nombre, get_nombre])
+    inter.ejecutar_nodo(clase)
+
+    inter.ejecutar_nodo(NodoAsignacion("p", NodoInstancia("Persona")))
+    inter.ejecutar_nodo(
+        NodoLlamadaMetodo(NodoIdentificador("p"), "set_nombre", [NodoValor("Ana")])
+    )
+    nombre = inter.ejecutar_nodo(
+        NodoLlamadaMetodo(NodoIdentificador("p"), "get_nombre", [])
+    )
+    assert nombre == "Ana"

--- a/src/tests/test_to_js_objects.py
+++ b/src/tests/test_to_js_objects.py
@@ -1,0 +1,16 @@
+from src.core.transpiler.to_js import TranspiladorJavaScript
+from src.core.parser import NodoInstancia, NodoLlamadaMetodo, NodoIdentificador, NodoValor
+
+
+def test_transpilar_instancia():
+    nodo = NodoInstancia("Clase")
+    transpiler = TranspiladorJavaScript()
+    result = transpiler.transpilar([nodo])
+    assert result == "new Clase();"
+
+
+def test_transpilar_llamada_metodo():
+    nodo = NodoLlamadaMetodo(NodoIdentificador("obj"), "metodo", [NodoValor(1)])
+    transpiler = TranspiladorJavaScript()
+    result = transpiler.transpilar([nodo])
+    assert result == "obj.metodo(1);"

--- a/src/tests/test_to_python_objects.py
+++ b/src/tests/test_to_python_objects.py
@@ -1,0 +1,16 @@
+from src.core.transpiler.to_python import TranspiladorPython
+from src.core.parser import NodoInstancia, NodoLlamadaMetodo, NodoIdentificador, NodoValor
+
+
+def test_transpilar_instancia():
+    nodo = NodoInstancia("Clase")
+    transpiler = TranspiladorPython()
+    result = transpiler.transpilar([nodo])
+    assert result == "Clase()\n"
+
+
+def test_transpilar_llamada_metodo():
+    nodo = NodoLlamadaMetodo(NodoIdentificador("obj"), "metodo", [NodoValor(1)])
+    transpiler = TranspiladorPython()
+    result = transpiler.transpilar([nodo])
+    assert result == "obj.metodo(1)\n"


### PR DESCRIPTION
## Summary
- implement object instantiation and method call nodes
- extend interpreter to handle classes, attributes and methods
- update Python and JS transpilers for new nodes
- add tests covering object behaviour and transpilation

## Testing
- `pytest src/tests/test_interpreter_objects.py -q`
- `pytest src/tests/test_to_python_objects.py -q`
- `pytest src/tests/test_to_js_objects.py -q`
- `pytest -q src/tests/test_interpreter.py src/tests/test_to_python.py src/tests/test_to_js.py src/tests/test_interpreter_objects.py src/tests/test_to_python_objects.py src/tests/test_to_js_objects.py`

------
https://chatgpt.com/codex/tasks/task_e_68557acb8eb08327a2d20fb9aab77e96