### PR TITLE
Implementar try/catch/throw

### DIFF
--- a/src/core/interpreter.py
+++ b/src/core/interpreter.py
@@ -17,7 +17,15 @@ from src.core.parser import (
     NodoRetorno,
     NodoOperacionBinaria,
     NodoOperacionUnaria,
+    NodoTryCatch,
+    NodoThrow,
 )
+
+
+class ExcepcionCobra(Exception):
+    def __init__(self, valor):
+        super().__init__(valor)
+        self.valor = valor
 
 
 class InterpretadorCobra:
@@ -83,6 +91,10 @@ class InterpretadorCobra:
                         print(f"Variable '{valor}' no definida")
             else:
                 print(valor)
+        elif isinstance(nodo, NodoTryCatch):
+            return self.ejecutar_try_catch(nodo)
+        elif isinstance(nodo, NodoThrow):
+            raise ExcepcionCobra(self.evaluar_expresion(nodo.expresion))
         elif isinstance(nodo, NodoHolobit):
             return self.ejecutar_holobit(nodo)
         elif isinstance(nodo, NodoRetorno):
@@ -193,6 +205,20 @@ class InterpretadorCobra:
         # Ejecuta el bucle mientras la condición sea verdadera
         while self.evaluar_expresion(nodo.condicion):
             for instruccion in nodo.cuerpo:
+                resultado = self.ejecutar_nodo(instruccion)
+                if resultado is not None:
+                    return resultado
+
+    def ejecutar_try_catch(self, nodo):
+        try:
+            for instruccion in nodo.bloque_try:
+                resultado = self.ejecutar_nodo(instruccion)
+                if resultado is not None:
+                    return resultado
+        except ExcepcionCobra as exc:
+            if nodo.nombre_excepcion:
+                self.variables[nodo.nombre_excepcion] = exc.valor
+            for instruccion in nodo.bloque_catch:
                 resultado = self.ejecutar_nodo(instruccion)
                 if resultado is not None:
                     return resultado

--- a/src/core/lexer.py
+++ b/src/core/lexer.py
@@ -26,6 +26,9 @@ class TipoToken:
     PROYECTAR = 'PROYECTAR'
     TRANSFORMAR = 'TRANSFORMAR'
     GRAFICAR = 'GRAFICAR'
+    TRY = 'TRY'
+    CATCH = 'CATCH'
+    THROW = 'THROW'
     ENTERO = 'ENTERO'
     FLOTANTE = 'FLOTANTE'
     CADENA = 'CADENA'
@@ -94,6 +97,9 @@ class Lexer:
             (TipoToken.PROYECTAR, r'\bproyectar\b'),
             (TipoToken.TRANSFORMAR, r'\btransformar\b'),
             (TipoToken.GRAFICAR, r'\bgraficar\b'),
+            (TipoToken.TRY, r'\btry\b'),
+            (TipoToken.CATCH, r'\bcatch\b'),
+            (TipoToken.THROW, r'\bthrow\b'),
             (TipoToken.IMPRIMIR, r'\bimprimir\b'),  # Reconoce 'imprimir'
             (TipoToken.FLOTANTE, r'\d+\.\d+'),
             (TipoToken.ENTERO, r'\d+'),

--- a/src/core/transpiler/to_js.py
+++ b/src/core/transpiler/to_js.py
@@ -93,6 +93,10 @@ class TranspiladorJavaScript:
             self.transpilar_llamada_metodo(nodo)
         elif nodo_tipo == "NodoRetorno":
             self.transpilar_retorno(nodo)
+        elif nodo_tipo == "NodoTryCatch":
+            self.transpilar_try_catch(nodo)
+        elif nodo_tipo == "NodoThrow":
+            self.transpilar_throw(nodo)
         elif nodo_tipo in ("NodoOperacionBinaria", "NodoOperacionUnaria"):
             self.agregar_linea(self.obtener_valor(nodo))
         else:
@@ -279,3 +283,32 @@ class TranspiladorJavaScript:
         if self.usa_indentacion:
             self.indentacion -= 1
         self.agregar_linea("}")
+
+    def transpilar_try_catch(self, nodo):
+        self.agregar_linea("try {")
+        if self.usa_indentacion:
+            self.indentacion += 1
+        for instruccion in nodo.bloque_try:
+            self.transpilar_nodo(instruccion)
+        if self.usa_indentacion:
+            self.indentacion -= 1
+        if nodo.bloque_catch:
+            catch_var = nodo.nombre_excepcion or ""
+            if self.usa_indentacion:
+                self.agregar_linea(f"}} catch ({catch_var}) {{")
+            else:
+                self.agregar_linea("}")
+                self.agregar_linea(f"catch ({catch_var}) {{")
+            if self.usa_indentacion:
+                self.indentacion += 1
+            for instruccion in nodo.bloque_catch:
+                self.transpilar_nodo(instruccion)
+            if self.usa_indentacion:
+                self.indentacion -= 1
+            self.agregar_linea("}")
+        else:
+            self.agregar_linea("}")
+
+    def transpilar_throw(self, nodo):
+        valor = self.obtener_valor(nodo.expresion)
+        self.agregar_linea(f"throw {valor};")

--- a/src/core/transpiler/to_python.py
+++ b/src/core/transpiler/to_python.py
@@ -1,9 +1,18 @@
 from src.core.parser import (
     NodoAsignacion, NodoCondicional, NodoBucleMientras, NodoFuncion,
     NodoLlamadaFuncion, NodoHolobit, NodoFor, NodoLista, NodoDiccionario,
-    NodoClase, NodoMetodo, NodoValor, NodoRetorno,
-    NodoOperacionBinaria, NodoOperacionUnaria, NodoIdentificador,
-    NodoInstancia, NodoLlamadaMetodo, NodoAtributo
+    NodoClase,
+    NodoMetodo,
+    NodoValor,
+    NodoRetorno,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoIdentificador,
+    NodoInstancia,
+    NodoLlamadaMetodo,
+    NodoAtributo,
+    NodoTryCatch,
+    NodoThrow,
 )
 from src.core.lexer import TipoToken
 
@@ -82,6 +91,10 @@ class TranspiladorPython:
             self.transpilar_imprimir(nodo)
         elif isinstance(nodo, NodoRetorno) or type(nodo).__name__ == "NodoRetorno":
             self.transpilar_retorno(nodo)
+        elif isinstance(nodo, NodoTryCatch):
+            self.transpilar_try_catch(nodo)
+        elif isinstance(nodo, NodoThrow):
+            self.transpilar_throw(nodo)
         elif hasattr(nodo, "valores") or (
             hasattr(nodo, "nombre")
             and not any(
@@ -282,3 +295,21 @@ class TranspiladorPython:
         for instruccion in nodo.cuerpo:
             self.transpilar_nodo(instruccion)
         self.nivel_indentacion -= 1
+
+    def transpilar_try_catch(self, nodo):
+        self.codigo += f"{self.obtener_indentacion()}try:\n"
+        self.nivel_indentacion += 1
+        for instruccion in nodo.bloque_try:
+            self.transpilar_nodo(instruccion)
+        self.nivel_indentacion -= 1
+        if nodo.bloque_catch:
+            nombre = f" as {nodo.nombre_excepcion}" if nodo.nombre_excepcion else ""
+            self.codigo += f"{self.obtener_indentacion()}except Exception{nombre}:\n"
+            self.nivel_indentacion += 1
+            for instruccion in nodo.bloque_catch:
+                self.transpilar_nodo(instruccion)
+            self.nivel_indentacion -= 1
+
+    def transpilar_throw(self, nodo):
+        valor = self.obtener_valor(nodo.expresion)
+        self.codigo += f"{self.obtener_indentacion()}raise Exception({valor})\n"

--- a/src/tests/test_try_catch.py
+++ b/src/tests/test_try_catch.py
@@ -1,0 +1,81 @@
+import pytest
+from io import StringIO
+from unittest.mock import patch
+
+from src.core.lexer import Token, TipoToken
+from src.core.parser import (
+    Parser,
+    NodoTryCatch,
+    NodoThrow,
+    NodoImprimir,
+    NodoIdentificador,
+    NodoValor,
+)
+from src.core.interpreter import InterpretadorCobra
+from src.core.transpiler.to_python import TranspiladorPython
+from src.core.transpiler.to_js import TranspiladorJavaScript
+
+
+def generar_tokens(*args):
+    return [Token(t, v) for t, v in args]
+
+
+def test_parser_try_catch_throw():
+    tokens = generar_tokens(
+        (TipoToken.TRY, "try"),
+        (TipoToken.DOSPUNTOS, ":"),
+        (TipoToken.THROW, "throw"),
+        (TipoToken.CADENA, "error"),
+        (TipoToken.CATCH, "catch"),
+        (TipoToken.IDENTIFICADOR, "e"),
+        (TipoToken.DOSPUNTOS, ":"),
+        (TipoToken.IMPRIMIR, "imprimir"),
+        (TipoToken.LPAREN, "("),
+        (TipoToken.IDENTIFICADOR, "e"),
+        (TipoToken.RPAREN, ")"),
+        (TipoToken.FIN, "fin"),
+        (TipoToken.EOF, None),
+    )
+    parser = Parser(tokens)
+    ast = parser.parsear()
+    assert len(ast) == 1
+    nodo = ast[0]
+    assert isinstance(nodo, NodoTryCatch)
+    assert isinstance(nodo.bloque_try[0], NodoThrow)
+    assert isinstance(nodo.bloque_catch[0], NodoImprimir)
+
+
+def test_interpreter_try_catch():
+    nodo = NodoTryCatch(
+        [NodoThrow(NodoIdentificador("mensaje"))],
+        "e",
+        [NodoImprimir(NodoIdentificador("e"))],
+    )
+    interp = InterpretadorCobra()
+    interp.variables["mensaje"] = "hola"
+    interp.ejecutar_nodo(nodo)
+    assert interp.variables["e"] == "hola"
+
+
+def test_transpiler_python_try_catch():
+    nodo = NodoTryCatch(
+        [NodoThrow(NodoValor("1"))],
+        "e",
+        [NodoImprimir(NodoIdentificador("e"))],
+    )
+    tr = TranspiladorPython()
+    codigo = tr.transpilar([nodo])
+    esperado = "try:\n    raise Exception(1)\nexcept Exception as e:\n    print(e)\n"
+    assert codigo == esperado
+
+
+def test_transpiler_js_try_catch():
+    nodo = NodoTryCatch(
+        [NodoThrow(NodoValor("1"))],
+        "e",
+        [NodoImprimir(NodoIdentificador("e"))],
+    )
+    tr = TranspiladorJavaScript()
+    codigo = tr.transpilar([nodo])
+    esperado = "try {\nthrow 1;\n}\ncatch (e) {\nconsole.log(e);\n}"
+    assert codigo == esperado


### PR DESCRIPTION
## Summary
- añadir tokens `try`, `catch` y `throw` en el lexer
- crear nodos `NodoTryCatch` y `NodoThrow` en el parser y parsear bloques try/catch
- propagar excepciones y manejarlas en el intérprete
- traducir la estructura a Python y JavaScript en los transpiladores
- agregar pruebas unitarias de parsing, ejecución e impresión

## Testing
- `pytest -q` *(failing: test_cli, test_lexer, test_operadores, etc.)*
- `pytest -q src/tests/test_try_catch.py`

------
https://chatgpt.com/codex/tasks/task_e_68558016b1488327a85556e99e977138