### PR TITLE
Add basic concurrency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,21 @@ imprimir(saludo)
 
 Al ejecutar `programa.cobra`, se procesará primero `modulo.cobra` y luego se imprimirá `Hola desde módulo`.
 
+## Ejemplo de concurrencia
+
+Es posible lanzar funciones en hilos con la palabra clave `hilo`:
+
+````cobra
+func tarea():
+    imprimir('trabajo')
+fin
+
+hilo tarea()
+imprimir('principal')
+````
+
+Al transpilarlas, se generan llamadas `asyncio.create_task` en Python y `Promise.resolve().then` en JavaScript.
+
 ## Uso desde la CLI
 
 Una vez instalado el paquete, puedes ejecutar archivos Cobra con:

--- a/src/core/interpreter.py
+++ b/src/core/interpreter.py
@@ -7,6 +7,7 @@ from src.core.parser import (
     NodoLlamadaFuncion,
     NodoLlamadaMetodo,
     NodoHolobit,
+    NodoHilo,
     NodoClase,
     NodoMetodo,
     NodoInstancia,
@@ -128,6 +129,8 @@ class InterpretadorCobra:
             raise ExcepcionCobra(self.evaluar_expresion(nodo.expresion))
         elif isinstance(nodo, NodoHolobit):
             return self.ejecutar_holobit(nodo)
+        elif isinstance(nodo, NodoHilo):
+            return self.ejecutar_hilo(nodo)
         elif isinstance(nodo, NodoRetorno):
             return self.evaluar_expresion(nodo.expresion)
         elif isinstance(nodo, NodoValor):
@@ -363,3 +366,14 @@ class InterpretadorCobra:
             else:
                 valores.append(v)
         return valores
+
+    def ejecutar_hilo(self, nodo):
+        """Ejecuta una función en un hilo separado."""
+        import threading
+
+        def destino():
+            self.ejecutar_llamada_funcion(nodo.llamada)
+
+        hilo = threading.Thread(target=destino)
+        hilo.start()
+        return hilo

--- a/src/core/lexer.py
+++ b/src/core/lexer.py
@@ -58,6 +58,7 @@ class TipoToken:
     FIN = 'FIN'
     EOF = 'EOF'
     IMPRIMIR = 'IMPRIMIR'  # Añadido soporte para 'imprimir'
+    HILO = 'HILO'
 
 
 class Token:
@@ -94,6 +95,7 @@ class Lexer:
             (TipoToken.MIENTRAS, r'\bmientras\b'),
             (TipoToken.PARA, r'\bpara\b'),
             (TipoToken.IMPORT, r'\bimport\b'),
+            (TipoToken.HILO, r'\bhilo\b'),
             (TipoToken.IN, r'\bin\b'),  # Define el token 'in'
             (TipoToken.HOLOBIT, r'\bholobit\b'),
             (TipoToken.PROYECTAR, r'\bproyectar\b'),

--- a/src/core/transpiler/to_js.py
+++ b/src/core/transpiler/to_js.py
@@ -8,6 +8,7 @@ from src.core.parser import (
     NodoAtributo,
     NodoInstancia,
     NodoLlamadaMetodo,
+    NodoHilo,
     NodoImport,
     Parser,
 )
@@ -81,6 +82,8 @@ class TranspiladorJavaScript:
             self.transpilar_funcion(nodo)
         elif nodo_tipo == "NodoLlamadaFuncion":
             self.transpilar_llamada_funcion(nodo)
+        elif nodo_tipo == "NodoHilo":
+            self.transpilar_hilo(nodo)
         elif nodo_tipo == "NodoImprimir":
             self.transpilar_imprimir(nodo)
         elif nodo_tipo == "NodoHolobit":
@@ -195,6 +198,10 @@ class TranspiladorJavaScript:
         """Transpila una llamada a función en JavaScript."""
         parametros = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
         self.agregar_linea(f"{nodo.nombre}({parametros});")
+
+    def transpilar_hilo(self, nodo):
+        args = ", ".join(self.obtener_valor(a) for a in nodo.llamada.argumentos)
+        self.agregar_linea(f"Promise.resolve().then(() => {nodo.llamada.nombre}({args}));")
 
     def transpilar_llamada_metodo(self, nodo):
         args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)

--- a/src/tests/test_hilos.py
+++ b/src/tests/test_hilos.py
@@ -1,0 +1,43 @@
+from io import StringIO
+from unittest.mock import patch
+
+from src.core.lexer import Token, TipoToken
+from src.core.parser import Parser, NodoHilo, NodoLlamadaFuncion, NodoValor, NodoAsignacion, NodoFuncion
+from src.core.interpreter import InterpretadorCobra
+from src.core.transpiler.to_python import TranspiladorPython
+from src.core.transpiler.to_js import TranspiladorJavaScript
+
+
+def test_parser_hilo():
+    tokens = [
+        Token(TipoToken.HILO, 'hilo'),
+        Token(TipoToken.IDENTIFICADOR, 'tarea'),
+        Token(TipoToken.LPAREN, '('),
+        Token(TipoToken.RPAREN, ')'),
+        Token(TipoToken.EOF, None),
+    ]
+    ast = Parser(tokens).parsear()
+    assert isinstance(ast[0], NodoHilo)
+    assert ast[0].llamada.nombre == 'tarea'
+
+
+def test_interpreter_hilo():
+    interp = InterpretadorCobra()
+    funcion = NodoFuncion('marca', [], [NodoLlamadaFuncion('imprimir', [NodoValor('ok')])])
+    interp.ejecutar_funcion(funcion)
+    with patch('sys.stdout', new_callable=StringIO) as out:
+        hilo = interp.ejecutar_hilo(NodoHilo(NodoLlamadaFuncion('marca', [])))
+        hilo.join()
+        assert out.getvalue().strip() == 'ok'
+
+
+def test_transpiler_python_hilo():
+    ast = [NodoHilo(NodoLlamadaFuncion('tarea', []))]
+    code = TranspiladorPython().transpilar(ast)
+    assert 'asyncio.create_task(tarea())' in code
+
+
+def test_transpiler_js_hilo():
+    ast = [NodoHilo(NodoLlamadaFuncion('tarea', []))]
+    code = TranspiladorJavaScript().transpilar(ast)
+    assert 'Promise.resolve().then(() => tarea());' in code


### PR DESCRIPTION
## Summary
- implement `NodoHilo` AST node and parser rule
- add new token `hilo` in the lexer
- implement `ejecutar_hilo` in interpreter
- handle `NodoHilo` in Python and JavaScript transpilers
- document concurrency usage in README
- add unit tests for threads/coroutines

## Testing
- `pytest -q src/tests/test_hilos.py`
- `pytest -q` *(fails: test_cli_interactive, test_cli_transpilador, test_cli2_interactive, test_cli2_transpilador, test_cli2_with_holobit, test_cli2_for_loop, test_import_transpiler, test_lexer_transformacion_holobit, test_operadores_operaciones)*

------
https://chatgpt.com/codex/tasks/task_e_68558ee06bf883279afab5e3e0dadf1c