### PR TITLE
Fix docs path in CLI

### DIFF
--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -126,7 +126,10 @@ def formatear_codigo(archivo):
 
 def generar_documentacion():
     """Genera la documentación HTML usando Sphinx."""
-    raiz = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+    # Ruta al directorio raíz del proyecto
+    raiz = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir)
+    )
     fuente = os.path.join(raiz, "frontend", "docs")
     destino = os.path.join(raiz, "frontend", "build", "html")
     subprocess.run(["sphinx-build", "-b", "html", fuente, destino], check=True)

--- a/backend/src/tests/test_cli_docs.py
+++ b/backend/src/tests/test_cli_docs.py
@@ -6,7 +6,9 @@ from src.cli.cli import main
 def test_cli_docs_invokes_sphinx():
     with patch("subprocess.run") as mock_run:
         main(["docs"])
-        raiz = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+        raiz = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir)
+        )
         source = os.path.join(raiz, "frontend", "docs")
         build = os.path.join(raiz, "frontend", "build", "html")
         mock_run.assert_called_with(["sphinx-build", "-b", "html", source, build], check=True)


### PR DESCRIPTION
## Summary
- adjust path calculation for docs build
- update tests to use new docs path

## Testing
- `pip install -q -r requirements.txt` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*
- `pytest -q` *(fails: 3 failed, 19 passed, 10 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68565a7236d8832794ce8ef8c077bb60