### PR TITLE
Corrige test de documentación

### DIFF
--- a/backend/src/tests/test_cli_docs.py
+++ b/backend/src/tests/test_cli_docs.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from unittest.mock import patch
 from src.cli.cli import main
 
@@ -6,10 +6,14 @@ from src.cli.cli import main
 def test_cli_docs_invokes_sphinx():
     with patch("subprocess.run") as mock_run:
         main(["docs"])
-        raiz = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir)
-        )
-        source = os.path.join(raiz, "frontend", "docs")
-        build = os.path.join(raiz, "frontend", "build", "html")
-        mock_run.assert_called_with(["sphinx-build", "-b", "html", source, build], check=True)
+        raiz = Path(__file__).resolve().parents[3]
+        source = raiz / "frontend" / "docs"
+        build = raiz / "frontend" / "build" / "html"
+        mock_run.assert_called_with([
+            "sphinx-build",
+            "-b",
+            "html",
+            str(source),
+            str(build),
+        ], check=True)
 


### PR DESCRIPTION
## Summary
- actualiza `test_cli_docs.py` usando `pathlib.Path`
- se calculan las rutas `frontend/docs` y `frontend/build/html` correctamente

## Testing
- `pytest backend/src/tests/test_cli_docs.py -q`
- `pytest -q` *(fails: test_cli2, test_import, test_lexer, test_operadores)*

------
https://chatgpt.com/codex/tasks/task_e_68565e4c9fc88327913b843502ee5df9