### PR TITLE
Añadir documento de arquitectura a la documentación

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pip install -e .
 El proyecto se organiza en las siguientes carpetas y módulos:
 
 - `backend/src/`: Contiene la lógica Python del proyecto.
-- `frontend/docs/` y `frontend/build/`: Carpetas donde se genera y aloja la documentación.
+- `frontend/docs/` y `frontend/build/`: Carpetas donde se genera y aloja la documentación. El archivo `frontend/docs/arquitectura.rst` describe la estructura interna del lenguaje.
 - `tests/`: Incluye pruebas unitarias para asegurar el correcto funcionamiento del código.
 - `README.md`: Documentación del proyecto.
 - `requirements.txt`: Archivo que lista las dependencias del proyecto.

--- a/frontend/docs/arquitectura.rst
+++ b/frontend/docs/arquitectura.rst
@@ -1,0 +1,44 @@
+Arquitectura de Cobra
+=====================
+
+El proyecto se divide en distintos componentes que interactúan para
+ofrecer una experiencia completa de desarrollo:
+
+CLI
+---
+La interfaz de línea de comandos permite ejecutar programas Cobra,
+compilar a otros lenguajes y gestionar módulos instalados.
+
+Core
+----
+Contiene el corazón del lenguaje: lexer, parser, intérprete y
+transpiladores a Python y JavaScript. Estos elementos trabajan en
+conjunto para analizar el código fuente y transformarlo en otras
+representaciones o ejecutarlo de forma directa.
+
+Módulos nativos
+---------------
+Bibliotecas básicas que amplían la funcionalidad de Cobra con
+operaciones de E/S, utilidades matemáticas y estructuras de datos.
+
+Sistema de memoria
+------------------
+Gestiona de forma automática los recursos durante la ejecución para
+optimizar el rendimiento y evitar fugas de memoria.
+
+.. graphviz::
+   :caption: Relación entre los módulos
+
+   digraph cobra {
+       rankdir=LR;
+       subgraph cluster_core {
+           label="Core";
+           Lexer -> Parser -> AST;
+           AST -> Interprete;
+           AST -> Transpiladores;
+       }
+       CLI -> Lexer;
+       Interprete -> Memoria;
+       Interprete -> ModulosNativos;
+       Transpiladores -> {Python JS};
+   }

--- a/frontend/docs/conf.py
+++ b/frontend/docs/conf.py
@@ -35,7 +35,8 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
-    'sphinx.ext.todo'
+    'sphinx.ext.todo',
+    'sphinx.ext.graphviz'
               ]
 
 # Habilitar la generación automática de autosummary

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -13,6 +13,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    :caption: Contenidos:
 
    caracteristicas
+   arquitectura
    sintaxis
    avances
    proximos_pasos


### PR DESCRIPTION
## Summary
- documentar la arquitectura en `frontend/docs/arquitectura.rst`
- habilitar `sphinx.ext.graphviz`
- incluir la nueva página en el índice
- mencionar el archivo de arquitectura en el README

## Testing
- `sphinx-build -b html frontend/docs frontend/build/html`

------
https://chatgpt.com/codex/tasks/task_e_685666988bc88327a353bd9897f39671