### PR TITLE
Add Unicode identifier support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ El proyecto se organiza en las siguientes carpetas y módulos:
 - Manejo de Errores: El sistema captura y reporta errores de sintaxis, facilitando la depuración.
 - Visualización y Depuración: Salida detallada de tokens, AST y errores de sintaxis para un desarrollo más sencillo.
 - Ejemplos de Código y Documentación: Ejemplos prácticos que ilustran el uso del lexer, parser y transpiladores.
+- Identificadores en Unicode: Puedes nombrar variables y funciones utilizando
+  caracteres como `á`, `ñ` o `Ω` para una mayor flexibilidad.
 
 # Uso
 

--- a/backend/src/core/lexer.py
+++ b/backend/src/core/lexer.py
@@ -111,7 +111,7 @@ class Lexer:
             (TipoToken.BOOLEANO, r'\b(verdadero|falso)\b'),
             (TipoToken.DOSPUNTOS, r':'),
             (TipoToken.FIN, r'\bfin\b'),
-            (TipoToken.IDENTIFICADOR, r'[A-Za-z_][A-Za-z0-9_]*'),
+            (TipoToken.IDENTIFICADOR, r'[^\W\d_][\w]*'),
             (TipoToken.MAYORIGUAL, r'>='),
             (TipoToken.MENORIGUAL, r'<='),
             (TipoToken.IGUAL, r'=='),
@@ -142,7 +142,7 @@ class Lexer:
         while self.posicion < len(self.codigo_fuente):
             matched = False
             for tipo, patron in especificacion_tokens:
-                regex = re.compile(patron)
+                regex = re.compile(patron, re.UNICODE)
                 coincidencia = regex.match(self.codigo_fuente[self.posicion:])
                 if coincidencia:
                     if tipo:

--- a/backend/src/tests/test_unicode_identifiers.py
+++ b/backend/src/tests/test_unicode_identifiers.py
@@ -1,0 +1,24 @@
+from src.core.lexer import Lexer, TipoToken
+
+
+def test_unicode_identifiers():
+    codigo = """var año = 1
+var niño = 2
+var Ωmega = 3"""
+    lexer = Lexer(codigo)
+    tokens = lexer.analizar_token()
+    assert [(t.tipo, t.valor) for t in tokens] == [
+        (TipoToken.VAR, 'var'),
+        (TipoToken.IDENTIFICADOR, 'año'),
+        (TipoToken.ASIGNAR, '='),
+        (TipoToken.ENTERO, 1),
+        (TipoToken.VAR, 'var'),
+        (TipoToken.IDENTIFICADOR, 'niño'),
+        (TipoToken.ASIGNAR, '='),
+        (TipoToken.ENTERO, 2),
+        (TipoToken.VAR, 'var'),
+        (TipoToken.IDENTIFICADOR, 'Ωmega'),
+        (TipoToken.ASIGNAR, '='),
+        (TipoToken.ENTERO, 3),
+        (TipoToken.EOF, None),
+    ]

--- a/frontend/docs/caracteristicas.rst
+++ b/frontend/docs/caracteristicas.rst
@@ -5,6 +5,7 @@ Caracteristicas principales de Cobra
 - **Gestion de memoria automatica**: Cobra incorpora un sistema de manejo de memoria basado en algoritmos genéticos que optimiza el uso de los recursos durante la ejecución.
 - **Soporte para holobits**: Un tipo de dato multidimensional que permite trabajar con datos de alta complejidad.
 - **Transpiler a Python y JavaScript**: Los programas escritos en Cobra pueden ser transpilados a Python o JavaScript, lo que permite su ejecucion en una variedad de plataformas.
+- **Nombres Unicode**: Los identificadores aceptan caracteres como `á`, `ñ` o `Ω`.
 
 **Ejemplo basico**
 

--- a/frontend/docs/sintaxis.rst
+++ b/frontend/docs/sintaxis.rst
@@ -7,6 +7,7 @@ Para declarar variables en Cobra, usamos `var`:
 
 var nombre = "Cobra"
 var numero = 10
+var año = 1  # Identificadores Unicode permitidos
 
 **2. Funciones**
 


### PR DESCRIPTION
## Summary
- allow Unicode letters in lexer identifier token
- compile regex patterns with re.UNICODE
- document Unicode identifier support in README and Sphinx docs
- add lexer tests for Unicode identifiers

## Testing
- `PYTHONPATH=backend pytest backend/src/tests/test_unicode_identifiers.py -q`
- `PYTHONPATH=backend pytest -q` *(fails: test_cli2.py, test_import.py, test_lexer.py::test_lexer_transformacion_holobit, test_operadores.py)*

------
https://chatgpt.com/codex/tasks/task_e_685669241cc083279b30a450143f10ad