### PR TITLE
Mejora manejo de errores léxicos

### DIFF
--- a/backend/src/tests/test_lexer.py
+++ b/backend/src/tests/test_lexer.py
@@ -1,4 +1,5 @@
-from src.core.lexer import Lexer, TipoToken
+import pytest
+from src.core.lexer import Lexer, TipoToken, LexerError
 
 
 def test_lexer_asignacion_variable():
@@ -24,6 +25,9 @@ def test_lexer_asignacion_variable():
         (TipoToken.EOF, None),
     ]
 
+    assert tokens[0].linea == 1 and tokens[0].columna == 1
+    assert tokens[2].columna == 7
+
 
 def test_lexer_transformacion_holobit():
     codigo = 'transformar(holobit([1.0, 2.0, -0.5]), "rotar", 45)'
@@ -46,7 +50,7 @@ def test_lexer_transformacion_holobit():
         (TipoToken.RBRACKET, ']'),
         (TipoToken.RPAREN, ')'),
         (TipoToken.COMA, ','),
-        (TipoToken.CADENA, '"rotar"'),
+        (TipoToken.CADENA, 'rotar'),
         (TipoToken.COMA, ','),
         (TipoToken.ENTERO, 45),
         (TipoToken.RPAREN, ')'),
@@ -75,4 +79,14 @@ def test_lexer_con_comentarios():
         (TipoToken.RPAREN, ')'),
         (TipoToken.EOF, None),
     ]
+
+
+def test_lexer_error_posicion():
+    codigo = "var x = $"
+    lexer = Lexer(codigo)
+    with pytest.raises(LexerError) as exc:
+        lexer.tokenizar()
+    err = exc.value
+    assert err.linea == 1
+    assert err.columna == 9
 

--- a/frontend/docs/arquitectura.rst
+++ b/frontend/docs/arquitectura.rst
@@ -38,7 +38,13 @@ optimizar el rendimiento y evitar fugas de memoria.
            AST -> Transpiladores;
        }
        CLI -> Lexer;
-       Interprete -> Memoria;
-       Interprete -> ModulosNativos;
-       Transpiladores -> {Python JS};
+   Interprete -> Memoria;
+   Interprete -> ModulosNativos;
+   Transpiladores -> {Python JS};
    }
+
+Reporte de errores léxicos
+--------------------------
+El lexer genera tokens mientras mantiene un conteo de línea y columna.
+Si encuentra un símbolo no reconocido detiene el proceso y lanza
+``LexerError`` indicando la posición exacta del problema.


### PR DESCRIPTION
## Summary
- agrega clase `LexerError` para reportar tokens inválidos con línea y columna
- amplía `Token` para guardar la posición
- reporta inmediatamente los errores en `Lexer.tokenizar`
- actualiza pruebas de lexer con la nueva funcionalidad
- documenta la forma de reportar errores léxicos

## Testing
- `pytest backend/src/tests/test_lexer.py -q`
- `pytest -q` *(falla: test_cli_with_holobit, test_cli_for_loop, test_import_transpiler, test_transpiladores_operaciones)*

------
https://chatgpt.com/codex/tasks/task_e_68566ced1d648327b956cb5cb56a037c