### PR TITLE
Add reserved keyword checks

### DIFF
--- a/backend/src/core/parser.py
+++ b/backend/src/core/parser.py
@@ -2,7 +2,57 @@ import logging
 import json
 from src.core.lexer import TipoToken, Token
 
-from src.core.ast_nodes import (NodoAsignacion, NodoHolobit, NodoCondicional, NodoBucleMientras, NodoFuncion, NodoLlamadaFuncion, NodoHilo, NodoClase, NodoMetodo, NodoInstancia, NodoAtributo, NodoLlamadaMetodo, NodoOperacionBinaria, NodoOperacionUnaria, NodoValor, NodoIdentificador, NodoImprimir, NodoRetorno, NodoPara, NodoTryCatch, NodoThrow, NodoImport, NodoLista, NodoDiccionario, NodoFor)
+from src.core.ast_nodes import (
+    NodoAsignacion,
+    NodoHolobit,
+    NodoCondicional,
+    NodoBucleMientras,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoHilo,
+    NodoClase,
+    NodoMetodo,
+    NodoInstancia,
+    NodoAtributo,
+    NodoLlamadaMetodo,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoValor,
+    NodoIdentificador,
+    NodoImprimir,
+    NodoRetorno,
+    NodoPara,
+    NodoTryCatch,
+    NodoThrow,
+    NodoImport,
+    NodoLista,
+    NodoDiccionario,
+    NodoFor,
+)
+
+# Palabras reservadas que no pueden usarse como identificadores
+PALABRAS_RESERVADAS = {
+    "var",
+    "func",
+    "rel",
+    "si",
+    "sino",
+    "mientras",
+    "para",
+    "import",
+    "try",
+    "catch",
+    "throw",
+    "hilo",
+    "retorno",
+    "fin",
+    "in",
+    "holobit",
+    "imprimir",
+    "proyectar",
+    "transformar",
+    "graficar",
+}
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -186,14 +236,19 @@ class Parser:
     def declaracion_asignacion(self):
         variable_token = None
         if self.token_actual().tipo == TipoToken.VAR:
-            variable_token = self.token_actual()
             self.comer(TipoToken.VAR)  # Consume el token 'var' si está presente
-            if self.token_actual().tipo == TipoToken.IDENTIFICADOR:
-                variable_token = self.token_actual()
-                self.comer(TipoToken.IDENTIFICADOR)
-        else:
-            variable_token = self.token_actual()
-            self.comer(TipoToken.IDENTIFICADOR)
+        
+        variable_token = self.token_actual()
+        # Comprobación de palabras reservadas antes de validar el tipo
+        if variable_token.valor in PALABRAS_RESERVADAS:
+            raise SyntaxError(
+                f"El identificador '{variable_token.valor}' es una palabra reservada"
+            )
+
+        if self.token_actual().tipo != TipoToken.IDENTIFICADOR:
+            raise SyntaxError("Se esperaba un identificador en la asignación")
+
+        self.comer(TipoToken.IDENTIFICADOR)
         self.comer(TipoToken.ASIGNAR)
         valor = self.expresion()
         # Si la expresión es un holobit, completar su nombre con la variable
@@ -292,9 +347,14 @@ class Parser:
         self.comer(TipoToken.FUNC)
 
         # Captura el nombre de la función
-        if self.token_actual().tipo != TipoToken.IDENTIFICADOR:
+        nombre_token = self.token_actual()
+        if nombre_token.valor in PALABRAS_RESERVADAS:
+            raise SyntaxError(
+                f"El nombre de función '{nombre_token.valor}' es una palabra reservada"
+            )
+        if nombre_token.tipo != TipoToken.IDENTIFICADOR:
             raise SyntaxError("Se esperaba un nombre para la función después de 'func'")
-        nombre = self.token_actual().valor
+        nombre = nombre_token.valor
         self.comer(TipoToken.IDENTIFICADOR)
 
         # Captura los parámetros

--- a/backend/src/tests/test_reserved_identifiers.py
+++ b/backend/src/tests/test_reserved_identifiers.py
@@ -1,0 +1,22 @@
+import pytest
+from src.core.lexer import Lexer
+from src.core.parser import Parser
+
+
+def test_variable_nombre_reservado():
+    codigo = "var si = 1"
+    tokens = Lexer(codigo).analizar_token()
+    parser = Parser(tokens)
+    with pytest.raises(SyntaxError, match="palabra reservada"):
+        parser.parsear()
+
+
+def test_funcion_nombre_reservado():
+    codigo = """
+    func mientras():
+        fin
+    """
+    tokens = Lexer(codigo).analizar_token()
+    parser = Parser(tokens)
+    with pytest.raises(SyntaxError, match="palabra reservada"):
+        parser.parsear()

--- a/frontend/docs/sintaxis.rst
+++ b/frontend/docs/sintaxis.rst
@@ -9,12 +9,16 @@ var nombre = "Cobra"
 var numero = 10
 var año = 1  # Identificadores Unicode permitidos
 
+Los nombres de variables no pueden ser palabras reservadas como ``si`` o ``mientras``. Usarlas como identificador generará un ``SyntaxError``.
+
 **2. Funciones**
 
 Las funciones se declaran con `func` y el cuerpo se delimita con `:`  :
 
 func sumar(a, b) :
     return a + b
+
+Al igual que con las variables, el nombre de la función no puede coincidir con palabras reservadas.
 
 **3. Funciones relativas (rel)**
 


### PR DESCRIPTION
## Summary
- define `PALABRAS_RESERVADAS` in the parser
- forbid reserved words as variable or function names
- test reserved identifiers raise `SyntaxError`
- document these restrictions in syntax docs

## Testing
- `pytest backend/src/tests/test_reserved_identifiers.py -q`
- `pytest -q` *(fails: test_cli_with_holobit, test_cli_for_loop, test_import_transpiler, test_interpreter_operaciones, test_transpiladores_operaciones)*

------
https://chatgpt.com/codex/tasks/task_e_68567f3854e0832791edeb484ce31dd2