### PR TITLE
Add visitor base class and update docs

### DIFF
--- a/backend/src/core/__init__.py
+++ b/backend/src/core/__init__.py
@@ -1,4 +1,5 @@
 from .ast_nodes import *
+from .visitor import NodeVisitor
 
 __all__ = [
     'NodoAST',
@@ -27,4 +28,5 @@ __all__ = [
     'NodoImport',
     'NodoPara',
     'NodoImprimir',
+    'NodeVisitor',
 ]

--- a/backend/src/core/ast_nodes.py
+++ b/backend/src/core/ast_nodes.py
@@ -8,7 +8,8 @@ class NodoAST:
     """Clase base para todos los nodos del AST."""
 
     def aceptar(self, visitante):
-        raise NotImplementedError("Este método debe ser implementado por subclases.")
+        """Acepta un visitante y delega la operación a éste."""
+        return visitante.visit(self)
 
 
 @dataclass

--- a/backend/src/core/visitor.py
+++ b/backend/src/core/visitor.py
@@ -1,0 +1,14 @@
+class NodeVisitor:
+    """Recorre nodos del AST despachando al método adecuado."""
+
+    def visit(self, node):
+        """Llama al método ``visit_<Clase>`` correspondiente para ``node``."""
+        method_name = f"visit_{node.__class__.__name__}"
+        visitor = getattr(self, method_name, self.generic_visit)
+        return visitor(node)
+
+    def generic_visit(self, node):
+        """Método llamado si no existe un ``visit_<Clase>`` específico."""
+        raise NotImplementedError(
+            f"No se ha implementado visit_{node.__class__.__name__}"
+        )

--- a/frontend/docs/arquitectura.rst
+++ b/frontend/docs/arquitectura.rst
@@ -16,6 +16,9 @@ transpiladores a Python y JavaScript. Estos elementos trabajan en
 conjunto para analizar el código fuente y transformarlo en otras
 representaciones o ejecutarlo de forma directa.
 Las clases que componen el AST se definen en ``src.core.ast_nodes`` para facilitar su reutilización.
+El recorrido de estos nodos puede realizarse mediante la clase ``NodeVisitor``
+ubicada en ``src.core.visitor``, que despacha automáticamente al método
+``visit_<Clase>`` correspondiente.
 
 Módulos nativos
 ---------------


### PR DESCRIPTION
## Summary
- add NodeVisitor dispatching visitor
- make NodoAST.aceptar call visitante.visit
- export NodeVisitor in core package
- document visitor in architecture docs

## Testing
- `pytest -q` *(fails: AssertionError in cli and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68568295beb8832784b76853cdb336eb