### PR TITLE
Refactor TranspiladorPython to visitor pattern

### DIFF
--- a/backend/src/core/visitor.py
+++ b/backend/src/core/visitor.py
@@ -1,9 +1,17 @@
+import re
+
+
 class NodeVisitor:
     """Recorre nodos del AST despachando al método adecuado."""
 
+    def _camel_to_snake(self, nombre):
+        """Convierte ``NombreClase`` en ``nombre_clase``."""
+        nombre = re.sub(r"^Nodo", "", nombre)
+        return re.sub(r"(?<!^)(?=[A-Z])", "_", nombre).lower()
+
     def visit(self, node):
-        """Llama al método ``visit_<Clase>`` correspondiente para ``node``."""
-        method_name = f"visit_{node.__class__.__name__}"
+        """Llama al método ``visit_<nombre>`` correspondiente para ``node``."""
+        method_name = f"visit_{self._camel_to_snake(node.__class__.__name__)}"
         visitor = getattr(self, method_name, self.generic_visit)
         return visitor(node)
 


### PR DESCRIPTION
## Summary
- extend `TranspiladorPython` from `NodeVisitor`
- implement visitor methods for every AST node
- dispatch using `nodo.aceptar(self)` when transpiling
- support snake_case visit methods in `NodeVisitor`

## Testing
- `pytest backend/src/tests/test_to_python.py -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_685684f4ce348327b89086edf62a1862