### PR TITLE
Add pytest.ini for timeout marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    timeout: tiempo máximo de ejecución de una prueba


### PR DESCRIPTION
## Summary
- add `pytest.ini` to register custom `timeout` marker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68569771bf1c8327a57342d1d54a096e