### PR TITLE
Add semantic validator tests

### DIFF
--- a/backend/src/tests/test_semantic_validator.py
+++ b/backend/src/tests/test_semantic_validator.py
@@ -1,0 +1,30 @@
+import pytest
+from src.core.lexer import Lexer
+from src.core.parser import Parser
+from src.core.semantic_validator import ValidadorSemantico, PrimitivaPeligrosaError
+
+
+def generar_ast(codigo: str):
+    tokens = Lexer(codigo).analizar_token()
+    parser = Parser(tokens)
+    return parser.parsear()
+
+
+def test_primitiva_peligrosa_detectada():
+    codigo = "leer_archivo('x.txt')"
+    ast = generar_ast(codigo)
+    validador = ValidadorSemantico()
+
+    with pytest.raises(PrimitivaPeligrosaError):
+        for nodo in ast:
+            nodo.aceptar(validador)
+
+
+def test_codigo_seguro_no_lanza_error():
+    codigo = "imprimir('hola')"
+    ast = generar_ast(codigo)
+    validador = ValidadorSemantico()
+
+    # No debe lanzar excepciones
+    for nodo in ast:
+        nodo.aceptar(validador)


### PR DESCRIPTION
## Summary
- add tests for ValidadorSemantico validating dangerous primitives

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856b41f12788327a84b6625809ac2af