### PR TITLE
Add docs for semantic validator

### DIFF
--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -20,6 +20,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    modulos_nativos
    ejemplos
    referencia
+   validador
 
 Introducción
 --------------------

--- a/frontend/docs/validador.rst
+++ b/frontend/docs/validador.rst
@@ -1,0 +1,27 @@
+Validador semantico
+===================
+
+El validador semantico recorre el arbol de sintaxis abstracta (AST) para detectar llamadas
+que utilizan primitivas consideradas peligrosas. Su finalidad es prevenir que programas
+Cobra ejecuten acciones que puedan comprometer al sistema o realicen operaciones
+no deseadas durante la fase de analisis.
+
+Primitivas peligrosas
+---------------------
+Las primitivas actualmente marcadas como peligrosas son:
+
+- ``leer_archivo``
+- ``escribir_archivo``
+- ``obtener_url``
+- ``hilo``
+
+Si se detecta el uso de alguna de estas primitivas, se lanza la excepcion
+``PrimitivaPeligrosaError`` antes de que el codigo sea interpretado o transpilado.
+
+Ejemplo de deteccion
+--------------------
+
+.. code-block:: cobra
+
+   leer_archivo('datos.txt')  # Lanzara PrimitivaPeligrosaError
+   imprimir('hola')           # Esta linea se considera segura


### PR DESCRIPTION
## Summary
- documentar el validador semántico en la documentación
- enlazar la nueva sección desde el índice

## Testing
- `pytest backend/src/tests/test_semantic_validator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6856b65da6cc8327a79659bed5195dd9