### PR TITLE
Actualizar docs sobre modo seguro

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,12 @@ cobra modulos instalar ruta/al/modulo.cobra
 cobra modulos remover modulo.cobra
 ```
 
-Si no se pasa un subcomando se abrirá el modo interactivo. Usa `cobra --help` pa
-ra más detalles.
+
+Si no se pasa un subcomando se abrirá el modo interactivo. Usa `cobra --help` para más detalles.
+
+## Modo seguro (--seguro)
+
+Tanto el intérprete como la CLI aceptan la opción `--seguro`, que ejecuta el código bajo restricciones adicionales. Al activarla se valida el AST y se prohíben primitivas como `leer_archivo`, `escribir_archivo`, `obtener_url` y `hilo`. Asimismo, las instrucciones `import` solo están permitidas para módulos instalados o incluidos en `IMPORT_WHITELIST`. Si el programa intenta utilizar estas funciones o importar otros archivos se lanzará `PrimitivaPeligrosaError`.
 
 # Pruebas
 

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -21,6 +21,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    ejemplos
    referencia
    validador
+   modo_seguro
 
 Introducción
 --------------------

--- a/frontend/docs/modo_seguro.rst
+++ b/frontend/docs/modo_seguro.rst
@@ -1,0 +1,19 @@
+Modo seguro
+===========
+
+La herramienta ``cobra`` permite ejecutar programas en modo seguro mediante la
+opción ``--seguro``. Esta modalidad activa el ``ValidadorSemantico`` para
+revisar el AST y bloquear primitivas peligrosas como ``leer_archivo``,
+``escribir_archivo``, ``obtener_url`` y ``hilo``. También restringe las
+instrucciones ``import`` a los módulos instalados o listados en
+``IMPORT_WHITELIST``.
+
+Si se intenta utilizar alguna de estas operaciones se lanzará
+``PrimitivaPeligrosaError`` antes de ejecutar el código.
+
+Ejemplo de uso
+--------------
+
+.. code-block:: bash
+
+   cobra ejecutar programa.cobra --seguro

--- a/frontend/docs/referencia.rst
+++ b/frontend/docs/referencia.rst
@@ -33,4 +33,7 @@ El comando ``cobra`` cuenta con varias subopciones:
    cobra modulos listar
    cobra docs
 
+La opción ``--seguro`` puede añadirse a ``ejecutar`` o al modo interactivo para
+bloquear primitivas peligrosas e importaciones no permitidas.
+
 El subcomando ``docs`` genera la documentación del proyecto en ``frontend/build/html``.


### PR DESCRIPTION
## Resumen
- explicar la bandera `--seguro` en README y docs
- documentar limitaciones de funciones e imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856e01e36088327a6878cd4a8fb04db