### PR TITLE
Refactor CLI with command classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,14 @@ cobra modulos remover modulo.cobra
 
 Si no se pasa un subcomando se abrirá el modo interactivo. Usa `cobra --help` para más detalles.
 
+### Diseño extensible de la CLI
+
+La CLI está organizada en clases dentro de `backend/src/cli/commands`. Cada subcomando
+hereda de `BaseCommand` y define su nombre, los argumentos que acepta y la acción
+a ejecutar. En `src/cli/cli.py` se instancian automáticamente y se registran en
+`argparse`, por lo que para añadir un nuevo comando solo es necesario crear un
+archivo con la nueva clase y llamar a `register_subparser` y `run`.
+
 ## Modo seguro (--seguro)
 
 Tanto el intérprete como la CLI aceptan la opción `--seguro`, que ejecuta el código bajo restricciones adicionales. Al activarla se valida el AST y se prohíben primitivas como `leer_archivo`, `escribir_archivo`, `obtener_url` y `hilo`. Asimismo, las instrucciones `import` solo están permitidas para módulos instalados o incluidos en `IMPORT_WHITELIST`. Si el programa intenta utilizar estas funciones o importar otros archivos se lanzará `PrimitivaPeligrosaError`.

--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -1,222 +1,16 @@
 import argparse
 import logging
 import os
-import shutil
-import subprocess
 import sys
 
-from src.core.interpreter import InterpretadorCobra
-from src.core.lexer import Lexer
-from src.core.parser import Parser
-from src.core.transpiler.to_js import TranspiladorJavaScript
-from src.core.transpiler.to_python import TranspiladorPython
-from src.core.semantic_validator import (
-    PrimitivaPeligrosaError,
-    ValidadorSemantico,
-)
-
-# Ruta donde se almacenan los módulos instalados
-MODULES_PATH = os.path.join(os.path.dirname(__file__), "modules")
-os.makedirs(MODULES_PATH, exist_ok=True)
+from .commands.compile_cmd import CompileCommand
+from .commands.docs_cmd import DocsCommand
+from .commands.execute_cmd import ExecuteCommand
+from .commands.interactive_cmd import InteractiveCommand
+from .commands.modules_cmd import ModulesCommand
 
 # Configuración de logging
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-)
-
-
-def ejecutar_cobra_interactivamente(seguro: bool = False):
-    """Ejecuta Cobra en modo interactivo."""
-    interpretador = InterpretadorCobra(safe_mode=seguro)
-    validador = ValidadorSemantico()
-
-    while True:
-        try:
-            linea = input("cobra> ").strip()
-            if linea in ["salir", "salir()"]:  # Permitir ambas variantes para salir
-                break
-            elif linea == "tokens":
-                tokens = Lexer(linea).tokenizar()
-                print("Tokens generados:")
-                for token in tokens:
-                    print(token)
-                continue
-            elif linea == "ast":
-                tokens = Lexer(linea).tokenizar()
-                ast = Parser(tokens).parsear()
-                try:
-                    for nodo in ast:
-                        nodo.aceptar(validador)
-                except PrimitivaPeligrosaError as pe:
-                    logging.error(f"Primitiva peligrosa: {pe}")
-                    print(f"Error: {pe}")
-                    continue
-                print("AST generado:")
-                print(ast)
-                continue
-            elif linea:  # Procesar una entrada normal
-                tokens = Lexer(linea).tokenizar()
-                logging.debug(f"Tokens generados: {tokens}")
-                ast = Parser(tokens).parsear()
-                logging.debug(f"AST generado: {ast}")
-                try:
-                    for nodo in ast:
-                        nodo.aceptar(validador)
-                except PrimitivaPeligrosaError as pe:
-                    logging.error(f"Primitiva peligrosa: {pe}")
-                    print(f"Error: {pe}")
-                    continue
-                interpretador.ejecutar_ast(ast)
-        except SyntaxError as se:
-            logging.error(f"Error de sintaxis: {se}")
-            print(f"Error procesando la entrada: {se}")
-        except RuntimeError as re:
-            logging.error(f"Error crítico: {re}")
-            print(f"Error crítico: {re}")
-        except Exception as e:
-            logging.error(f"Error general procesando la entrada: {e}")
-            print(f"Error procesando la entrada: {e}")
-
-
-def transpilar_archivo(archivo, transpilador):
-    """Transpila un archivo Cobra a Python o JavaScript."""
-    if not os.path.exists(archivo):
-        print(f"Error: El archivo '{archivo}' no existe.")
-        return
-
-    with open(archivo, 'r') as f:
-        codigo = f.read()
-        try:
-            tokens = Lexer(codigo).tokenizar()
-            ast = Parser(tokens).parsear()
-
-            validador = ValidadorSemantico()
-            for nodo in ast:
-                nodo.aceptar(validador)
-
-            if transpilador == "python":
-                transpilador = TranspiladorPython()
-            elif transpilador == "js":
-                transpilador = TranspiladorJavaScript()
-            else:
-                raise ValueError("Transpilador no soportado.")
-
-            resultado = transpilador.transpilar(ast)
-            print(f"Código generado ({transpilador.__class__.__name__}):")
-            print(resultado)
-        except PrimitivaPeligrosaError as pe:
-            logging.error(f"Primitiva peligrosa: {pe}")
-            print(f"Error: {pe}")
-        except SyntaxError as se:
-            logging.error(f"Error de sintaxis durante la transpilación: {se}")
-            print(f"Error durante la transpilación: {se}")
-        except Exception as e:
-            logging.error(f"Error general durante la transpilación: {e}")
-            print(f"Error durante la transpilación: {e}")
-
-
-def inspeccionar_archivo(archivo, modo):
-    """Inspecciona un archivo Cobra generando tokens o un AST."""
-    if not os.path.exists(archivo):
-        print(f"Error: El archivo '{archivo}' no existe.")
-        return
-
-    with open(archivo, 'r') as f:
-        codigo = f.read()
-        try:
-            tokens = Lexer(codigo).tokenizar()
-            if modo == "tokens":
-                print("Tokens generados:")
-                for token in tokens:
-                    print(token)
-            elif modo == "ast":
-                ast = Parser(tokens).parsear()
-                print("AST generado:")
-                print(ast)
-        except SyntaxError as se:
-            logging.error(f"Error de sintaxis durante la inspección: {se}")
-            print(f"Error durante la inspección: {se}")
-        except Exception as e:
-            logging.error(f"Error general durante la inspección: {e}")
-            print(f"Error durante la inspección: {e}")
-
-
-def formatear_codigo(archivo):
-    """Formatea un archivo Cobra usando black si está disponible."""
-    try:
-        subprocess.run(["black", archivo], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    except FileNotFoundError:
-        print("Herramienta de formateo no encontrada. Asegúrate de tener 'black' instalado.")
-
-
-def generar_documentacion():
-    """Genera la documentación HTML usando Sphinx."""
-    # Ruta al directorio raíz del proyecto
-    raiz = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir)
-    )
-    fuente = os.path.join(raiz, "frontend", "docs")
-    destino = os.path.join(raiz, "frontend", "build", "html")
-    subprocess.run(["sphinx-build", "-b", "html", fuente, destino], check=True)
-    print(f"Documentación generada en {destino}")
-
-
-def ejecutar_archivo(archivo, depurar: bool = False, formatear: bool = False, seguro: bool = False):
-    """Ejecuta un script Cobra desde un archivo."""
-    if not os.path.exists(archivo):
-        print(f"El archivo '{archivo}' no existe")
-        return
-    if formatear:
-        formatear_codigo(archivo)
-    if depurar:
-        logging.getLogger().setLevel(logging.DEBUG)
-    else:
-        logging.getLogger().setLevel(logging.ERROR)
-
-    with open(archivo, "r") as f:
-        codigo = f.read()
-    tokens = Lexer(codigo).tokenizar()
-    ast = Parser(tokens).parsear()
-    try:
-        validador = ValidadorSemantico()
-        for nodo in ast:
-            nodo.aceptar(validador)
-    except PrimitivaPeligrosaError as pe:
-        logging.error(f"Primitiva peligrosa: {pe}")
-        print(f"Error: {pe}")
-        return
-    InterpretadorCobra(safe_mode=seguro).ejecutar_ast(ast)
-
-
-def listar_modulos():
-    """Lista los módulos instalados."""
-    mods = [f for f in os.listdir(MODULES_PATH) if f.endswith(".cobra")]
-    if not mods:
-        print("No hay módulos instalados")
-    else:
-        for m in mods:
-            print(m)
-
-
-def instalar_modulo(ruta):
-    """Instala un módulo copiándolo a MODULES_PATH."""
-    if not os.path.exists(ruta):
-        print(f"No se encontró el módulo {ruta}")
-        return
-    destino = os.path.join(MODULES_PATH, os.path.basename(ruta))
-    shutil.copy(ruta, destino)
-    print(f"Módulo instalado en {destino}")
-
-
-def remover_modulo(nombre):
-    """Elimina un módulo instalado."""
-    archivo = os.path.join(MODULES_PATH, nombre)
-    if os.path.exists(archivo):
-        os.remove(archivo)
-        print(f"Módulo {nombre} eliminado")
-    else:
-        print(f"El módulo {nombre} no existe")
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
 def main(argv=None):
@@ -228,26 +22,20 @@ def main(argv=None):
 
     subparsers = parser.add_subparsers(dest="comando")
 
-    # Subcomando compilar
-    comp = subparsers.add_parser("compilar", help="Transpila un archivo")
-    comp.add_argument("archivo")
-    comp.add_argument("--tipo", choices=["python", "js"], default="python")
+    comandos = [
+        CompileCommand(),
+        ExecuteCommand(),
+        ModulesCommand(),
+        DocsCommand(),
+        InteractiveCommand(),
+    ]
 
-    # Subcomando ejecutar
-    run = subparsers.add_parser("ejecutar", help="Ejecuta un script Cobra")
-    run.add_argument("archivo")
+    command_map = {}
+    for cmd in comandos:
+        cmd.register_subparser(subparsers)
+        command_map[cmd.name] = cmd
 
-    # Subcomando modulos
-    mods = subparsers.add_parser("modulos", help="Gestiona módulos instalados")
-    mod_sub = mods.add_subparsers(dest="accion")
-    mod_sub.add_parser("listar", help="Lista módulos")
-    inst = mod_sub.add_parser("instalar", help="Instala un módulo")
-    inst.add_argument("ruta")
-    rem = mod_sub.add_parser("remover", help="Elimina un módulo")
-    rem.add_argument("nombre")
-
-    # Subcomando docs
-    subparsers.add_parser("docs", help="Genera la documentación del proyecto")
+    parser.set_defaults(cmd=command_map["interactive"])
 
     if argv is None:
         if "PYTEST_CURRENT_TEST" in os.environ:
@@ -255,30 +43,9 @@ def main(argv=None):
         else:
             argv = sys.argv[1:]
 
-    args, _ = parser.parse_known_args(argv)
-
-    if args.comando == "compilar":
-        transpilar_archivo(args.archivo, args.tipo)
-    elif args.comando == "ejecutar":
-        ejecutar_archivo(
-            args.archivo,
-            depurar=args.depurar,
-            formatear=args.formatear,
-            seguro=args.seguro,
-        )
-    elif args.comando == "modulos":
-        if args.accion == "listar":
-            listar_modulos()
-        elif args.accion == "instalar":
-            instalar_modulo(args.ruta)
-        elif args.accion == "remover":
-            remover_modulo(args.nombre)
-        else:
-            print("Acción de módulos no reconocida")
-    elif args.comando == "docs":
-        generar_documentacion()
-    else:
-        ejecutar_cobra_interactivamente(seguro=args.seguro)
+    args = parser.parse_args(argv)
+    command = getattr(args, "cmd", command_map["interactive"])
+    command.run(args)
 
 
 if __name__ == "__main__":

--- a/backend/src/cli/commands/base.py
+++ b/backend/src/cli/commands/base.py
@@ -1,0 +1,13 @@
+class BaseCommand:
+    """Clase base para subcomandos de la CLI."""
+
+    #: Nombre del subcomando
+    name: str = ""
+
+    def register_subparser(self, subparsers):
+        """Registra los argumentos del subcomando en el parser."""
+        raise NotImplementedError
+
+    def run(self, args):
+        """Ejecuta la lógica del comando."""
+        raise NotImplementedError

--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -1,0 +1,59 @@
+import logging
+import os
+from .base import BaseCommand
+
+from src.core.lexer import Lexer
+from src.core.parser import Parser
+from src.core.semantic_validator import PrimitivaPeligrosaError, ValidadorSemantico
+from src.core.transpiler.to_js import TranspiladorJavaScript
+from src.core.transpiler.to_python import TranspiladorPython
+
+
+class CompileCommand(BaseCommand):
+    """Transpila un archivo Cobra."""
+
+    name = "compilar"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help="Transpila un archivo")
+        parser.add_argument("archivo")
+        parser.add_argument("--tipo", choices=["python", "js"], default="python")
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        archivo = args.archivo
+        transpilador = args.tipo
+        if not os.path.exists(archivo):
+            print(f"Error: El archivo '{archivo}' no existe.")
+            return
+
+        with open(archivo, "r") as f:
+            codigo = f.read()
+            try:
+                tokens = Lexer(codigo).tokenizar()
+                ast = Parser(tokens).parsear()
+
+                validador = ValidadorSemantico()
+                for nodo in ast:
+                    nodo.aceptar(validador)
+
+                if transpilador == "python":
+                    transp = TranspiladorPython()
+                elif transpilador == "js":
+                    transp = TranspiladorJavaScript()
+                else:
+                    raise ValueError("Transpilador no soportado.")
+
+                resultado = transp.transpilar(ast)
+                print(f"Código generado ({transp.__class__.__name__}):")
+                print(resultado)
+            except PrimitivaPeligrosaError as pe:
+                logging.error(f"Primitiva peligrosa: {pe}")
+                print(f"Error: {pe}")
+            except SyntaxError as se:
+                logging.error(f"Error de sintaxis durante la transpilación: {se}")
+                print(f"Error durante la transpilación: {se}")
+            except Exception as e:
+                logging.error(f"Error general durante la transpilación: {e}")
+                print(f"Error durante la transpilación: {e}")

--- a/backend/src/cli/commands/docs_cmd.py
+++ b/backend/src/cli/commands/docs_cmd.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+from .base import BaseCommand
+
+
+class DocsCommand(BaseCommand):
+    """Genera la documentación HTML del proyecto."""
+
+    name = "docs"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help="Genera la documentación del proyecto")
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        raiz = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+        )
+        source = os.path.join(raiz, "frontend", "docs")
+        build = os.path.join(raiz, "frontend", "build", "html")
+        subprocess.run(["sphinx-build", "-b", "html", source, build], check=True)
+        print(f"Documentación generada en {build}")

--- a/backend/src/cli/commands/execute_cmd.py
+++ b/backend/src/cli/commands/execute_cmd.py
@@ -1,0 +1,64 @@
+import logging
+import os
+from .base import BaseCommand
+
+from src.core.interpreter import InterpretadorCobra
+from src.core.lexer import Lexer
+from src.core.parser import Parser
+from src.core.semantic_validator import PrimitivaPeligrosaError, ValidadorSemantico
+
+
+class ExecuteCommand(BaseCommand):
+    """Ejecuta un script Cobra desde un archivo."""
+
+    name = "ejecutar"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help="Ejecuta un script Cobra")
+        parser.add_argument("archivo")
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        archivo = args.archivo
+        depurar = getattr(args, "depurar", False)
+        formatear = getattr(args, "formatear", False)
+        seguro = getattr(args, "seguro", False)
+
+        if not os.path.exists(archivo):
+            print(f"El archivo '{archivo}' no existe")
+            return
+        if formatear:
+            self._formatear_codigo(archivo)
+        if depurar:
+            logging.getLogger().setLevel(logging.DEBUG)
+        else:
+            logging.getLogger().setLevel(logging.ERROR)
+
+        with open(archivo, "r") as f:
+            codigo = f.read()
+        tokens = Lexer(codigo).tokenizar()
+        ast = Parser(tokens).parsear()
+        try:
+            validador = ValidadorSemantico()
+            for nodo in ast:
+                nodo.aceptar(validador)
+        except PrimitivaPeligrosaError as pe:
+            logging.error(f"Primitiva peligrosa: {pe}")
+            print(f"Error: {pe}")
+            return
+        InterpretadorCobra(safe_mode=seguro).ejecutar_ast(ast)
+
+    @staticmethod
+    def _formatear_codigo(archivo):
+        try:
+            import subprocess
+
+            subprocess.run([
+                "black",
+                archivo,
+            ], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        except FileNotFoundError:
+            print(
+                "Herramienta de formateo no encontrada. Asegúrate de tener 'black' instalado."
+            )

--- a/backend/src/cli/commands/interactive_cmd.py
+++ b/backend/src/cli/commands/interactive_cmd.py
@@ -1,0 +1,70 @@
+import logging
+from .base import BaseCommand
+
+from src.core.interpreter import InterpretadorCobra
+from src.core.lexer import Lexer
+from src.core.parser import Parser
+from src.core.semantic_validator import PrimitivaPeligrosaError, ValidadorSemantico
+
+
+class InteractiveCommand(BaseCommand):
+    """Modo interactivo del lenguaje Cobra."""
+
+    name = "interactive"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help="Inicia el modo interactivo")
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        seguro = getattr(args, "seguro", False)
+        interpretador = InterpretadorCobra(safe_mode=seguro)
+        validador = ValidadorSemantico()
+
+        while True:
+            try:
+                linea = input("cobra> ").strip()
+                if linea in ["salir", "salir()"]:
+                    break
+                elif linea == "tokens":
+                    tokens = Lexer(linea).tokenizar()
+                    print("Tokens generados:")
+                    for token in tokens:
+                        print(token)
+                    continue
+                elif linea == "ast":
+                    tokens = Lexer(linea).tokenizar()
+                    ast = Parser(tokens).parsear()
+                    try:
+                        for nodo in ast:
+                            nodo.aceptar(validador)
+                    except PrimitivaPeligrosaError as pe:
+                        logging.error(f"Primitiva peligrosa: {pe}")
+                        print(f"Error: {pe}")
+                        continue
+                    print("AST generado:")
+                    print(ast)
+                    continue
+                elif linea:
+                    tokens = Lexer(linea).tokenizar()
+                    logging.debug(f"Tokens generados: {tokens}")
+                    ast = Parser(tokens).parsear()
+                    logging.debug(f"AST generado: {ast}")
+                    try:
+                        for nodo in ast:
+                            nodo.aceptar(validador)
+                    except PrimitivaPeligrosaError as pe:
+                        logging.error(f"Primitiva peligrosa: {pe}")
+                        print(f"Error: {pe}")
+                        continue
+                    interpretador.ejecutar_ast(ast)
+            except SyntaxError as se:
+                logging.error(f"Error de sintaxis: {se}")
+                print(f"Error procesando la entrada: {se}")
+            except RuntimeError as re:
+                logging.error(f"Error crítico: {re}")
+                print(f"Error crítico: {re}")
+            except Exception as e:
+                logging.error(f"Error general procesando la entrada: {e}")
+                print(f"Error procesando la entrada: {e}")

--- a/backend/src/cli/commands/modules_cmd.py
+++ b/backend/src/cli/commands/modules_cmd.py
@@ -1,0 +1,61 @@
+import os
+import shutil
+from .base import BaseCommand
+
+MODULES_PATH = os.path.join(os.path.dirname(__file__), "..", "modules")
+os.makedirs(MODULES_PATH, exist_ok=True)
+
+
+class ModulesCommand(BaseCommand):
+    """Gestiona los módulos instalados."""
+
+    name = "modulos"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help="Gestiona módulos instalados")
+        mod_sub = parser.add_subparsers(dest="accion")
+        mod_sub.add_parser("listar", help="Lista módulos")
+        inst = mod_sub.add_parser("instalar", help="Instala un módulo")
+        inst.add_argument("ruta")
+        rem = mod_sub.add_parser("remover", help="Elimina un módulo")
+        rem.add_argument("nombre")
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        accion = args.accion
+        if accion == "listar":
+            self._listar_modulos()
+        elif accion == "instalar":
+            self._instalar_modulo(args.ruta)
+        elif accion == "remover":
+            self._remover_modulo(args.nombre)
+        else:
+            print("Acción de módulos no reconocida")
+
+    @staticmethod
+    def _listar_modulos():
+        mods = [f for f in os.listdir(MODULES_PATH) if f.endswith(".cobra")]
+        if not mods:
+            print("No hay módulos instalados")
+        else:
+            for m in mods:
+                print(m)
+
+    @staticmethod
+    def _instalar_modulo(ruta):
+        if not os.path.exists(ruta):
+            print(f"No se encontró el módulo {ruta}")
+            return
+        destino = os.path.join(MODULES_PATH, os.path.basename(ruta))
+        shutil.copy(ruta, destino)
+        print(f"Módulo instalado en {destino}")
+
+    @staticmethod
+    def _remover_modulo(nombre):
+        archivo = os.path.join(MODULES_PATH, nombre)
+        if os.path.exists(archivo):
+            os.remove(archivo)
+            print(f"Módulo {nombre} eliminado")
+        else:
+            print(f"El módulo {nombre} no existe")


### PR DESCRIPTION
## Summary
- create `commands` package under CLI with BaseCommand
- implement commands: compile, execute, modules, docs and interactive
- refactor `src.cli.cli` to register commands dynamically
- document extensible design in README

## Testing
- `pytest backend/src/tests/test_cli_docs.py backend/src/tests/test_cli.py backend/src/tests/test_cli2.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6856e27dbaa083278a2fb75362ae2a37