### PR TITLE
Add docstrings in backend core modules

### DIFF
--- a/backend/src/core/__init__.py
+++ b/backend/src/core/__init__.py
@@ -1,3 +1,10 @@
+"""Facilita el acceso a los nodos y utilidades principales del backend.
+
+Al importar :mod:`src.core` se exponen todas las clases que componen el
+árbol de sintaxis abstracta junto con el visitante base ``NodeVisitor``.
+Esto simplifica el uso de la biblioteca desde otros módulos.
+"""
+
 from .ast_nodes import *
 from .visitor import NodeVisitor
 

--- a/backend/src/core/ast_nodes.py
+++ b/backend/src/core/ast_nodes.py
@@ -1,3 +1,5 @@
+"""Definiciones de los nodos del árbol de sintaxis abstracta de Cobra."""
+
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 
@@ -16,6 +18,8 @@ class NodoAST:
 class NodoAsignacion(NodoAST):
     variable: Any
     expresion: Any
+
+    """Representa la asignación de una expresión a una variable."""
 
     def __post_init__(self):
         if isinstance(self.variable, Token):
@@ -36,6 +40,8 @@ class NodoHolobit(NodoAST):
     nombre: Optional[str] = None
     valores: Optional[List[Any]] = None
 
+    """Define un holobit, una colección de valores numéricos."""
+
     def __post_init__(self):
         if self.valores is None and isinstance(self.nombre, list):
             self.valores = self.nombre
@@ -50,11 +56,15 @@ class NodoCondicional(NodoAST):
     bloque_si: List[Any]
     bloque_sino: List[Any] = field(default_factory=list)
 
+    """Bloque ``si`` opcionalmente acompañado de un bloque ``sino``."""
+
 
 @dataclass
 class NodoBucleMientras(NodoAST):
     condicion: Any
     cuerpo: List[Any]
+
+    """Representa un bucle ``mientras`` con su condición y cuerpo."""
 
 
 @dataclass
@@ -63,15 +73,21 @@ class NodoFor(NodoAST):
     iterable: Any
     cuerpo: List[Any]
 
+    """Estructura de control ``para`` que itera sobre un iterable."""
+
 
 @dataclass
 class NodoLista(NodoAST):
     elementos: List[Any]
 
+    """Literal de lista de expresiones."""
+
 
 @dataclass
 class NodoDiccionario(NodoAST):
     elementos: Any
+
+    """Literal de diccionario ``clave: valor``."""
 
 
 @dataclass
@@ -80,11 +96,15 @@ class NodoFuncion(NodoAST):
     parametros: List[str]
     cuerpo: List[Any]
 
+    """Declaración de una función definida por el usuario."""
+
 
 @dataclass
 class NodoClase(NodoAST):
     nombre: str
     metodos: List[Any]
+
+    """Definición de una clase y sus métodos."""
 
 
 @dataclass
@@ -93,17 +113,23 @@ class NodoMetodo(NodoAST):
     parametros: List[str]
     cuerpo: List[Any]
 
+    """Método perteneciente a una clase."""
+
 
 @dataclass
 class NodoInstancia(NodoAST):
     nombre_clase: str
     argumentos: List[Any] = field(default_factory=list)
 
+    """Instanciación de una clase."""
+
 
 @dataclass
 class NodoAtributo(NodoAST):
     objeto: Any
     nombre: str
+
+    """Acceso a un atributo de un objeto."""
 
 
 @dataclass
@@ -112,12 +138,16 @@ class NodoLlamadaMetodo(NodoAST):
     nombre_metodo: str
     argumentos: List[Any] = field(default_factory=list)
 
+    """Invocación de un método de un objeto."""
+
 
 @dataclass
 class NodoOperacionBinaria(NodoAST):
     izquierda: Any
     operador: Token
     derecha: Any
+
+    """Operación que combina dos expresiones mediante un operador."""
 
     def __repr__(self):
         return f"({self.izquierda} {self.operador.valor} {self.derecha})"
@@ -128,6 +158,8 @@ class NodoOperacionUnaria(NodoAST):
     operador: Token
     operando: Any
 
+    """Operación aplicada a un único operando."""
+
     def __repr__(self):
         return f"({self.operador.valor}{self.operando})"
 
@@ -136,10 +168,14 @@ class NodoOperacionUnaria(NodoAST):
 class NodoValor(NodoAST):
     valor: Any
 
+    """Representa un valor literal ya evaluado."""
+
 
 @dataclass
 class NodoIdentificador(NodoAST):
     nombre: str
+
+    """Uso de una variable o identificador."""
 
     def __post_init__(self):
         self.valor = self.nombre
@@ -158,6 +194,8 @@ class NodoLlamadaFuncion(NodoAST):
     nombre: str
     argumentos: List[Any]
 
+    """Invocación de una función existente."""
+
     def __repr__(self):
         return f"NodoLlamadaFuncion(nombre={self.nombre}, argumentos={self.argumentos})"
 
@@ -165,6 +203,8 @@ class NodoLlamadaFuncion(NodoAST):
 @dataclass
 class NodoHilo(NodoAST):
     llamada: NodoLlamadaFuncion
+
+    """Ejecución de una llamada en un hilo separado."""
 
     def __repr__(self):
         return f"NodoHilo(llamada={self.llamada})"
@@ -174,6 +214,8 @@ class NodoHilo(NodoAST):
 class NodoRetorno(NodoAST):
     expresion: Any
 
+    """Valor devuelto por una función."""
+
     def __repr__(self):
         return f"NodoRetorno(expresion={self.expresion})"
 
@@ -181,6 +223,8 @@ class NodoRetorno(NodoAST):
 @dataclass
 class NodoThrow(NodoAST):
     expresion: Any
+
+    """Lanza una excepción durante la ejecución."""
 
     def __repr__(self):
         return f"NodoThrow(expresion={self.expresion})"
@@ -192,10 +236,14 @@ class NodoTryCatch(NodoAST):
     nombre_excepcion: Optional[str] = None
     bloque_catch: List[Any] = field(default_factory=list)
 
+    """Bloque ``try`` con manejo opcional de excepciones."""
+
 
 @dataclass
 class NodoImport(NodoAST):
     ruta: str
+
+    """Importación de un módulo externo."""
 
 
 @dataclass
@@ -203,6 +251,8 @@ class NodoPara(NodoAST):
     variable: Any
     iterable: Any
     cuerpo: List[Any]
+
+    """Bucle ``para`` que itera sobre un iterable."""
 
     def __repr__(self):
         return (
@@ -213,6 +263,8 @@ class NodoPara(NodoAST):
 @dataclass
 class NodoImprimir(NodoAST):
     expresion: Any
+
+    """Impresión de una expresión en la salida estándar."""
 
     def __repr__(self):
         return f"NodoImprimir(expresion={self.expresion})"

--- a/backend/src/core/holobits/__init__.py
+++ b/backend/src/core/holobits/__init__.py
@@ -1,3 +1,5 @@
+"""Funciones de manipulación básica de objetos ``Holobit``."""
+
 from .holobit import Holobit
 from .graficar import graficar
 from .proyection import proyectar

--- a/backend/src/core/holobits/graficar.py
+++ b/backend/src/core/holobits/graficar.py
@@ -1,3 +1,5 @@
+"""Funciones de ejemplo para graficar objetos ``Holobit``."""
+
 from .holobit import Holobit
 
 

--- a/backend/src/core/holobits/holobit.py
+++ b/backend/src/core/holobits/holobit.py
@@ -1,3 +1,6 @@
+"""Tipos de datos y operaciones para manipular holobits."""
+
+
 class Holobit:
     """Representa un conjunto de valores numericos para operaciones 3D/2D."""
 

--- a/backend/src/core/holobits/proyection.py
+++ b/backend/src/core/holobits/proyection.py
@@ -1,3 +1,5 @@
+"""Operaciones para proyectar holobits en diferentes modos."""
+
 from .holobit import Holobit
 
 

--- a/backend/src/core/holobits/transformacion.py
+++ b/backend/src/core/holobits/transformacion.py
@@ -1,3 +1,5 @@
+"""Ejemplos de transformaciones aplicables a un ``Holobit``."""
+
 from .holobit import Holobit
 
 

--- a/backend/src/core/interpreter.py
+++ b/backend/src/core/interpreter.py
@@ -1,3 +1,5 @@
+"""Implementación del intérprete del lenguaje Cobra."""
+
 import os
 
 from src.core.lexer import Token, TipoToken, Lexer
@@ -169,6 +171,7 @@ class InterpretadorCobra:
             raise ValueError(f"Nodo no soportado: {type(nodo)}")
 
     def ejecutar_asignacion(self, nodo):
+        """Evalúa una asignación de variable o atributo."""
         nombre = getattr(nodo, "identificador", getattr(nodo, "variable", None))
         valor_nodo = getattr(nodo, "expresion", getattr(nodo, "valor", None))
         valor = self.evaluar_expresion(valor_nodo)
@@ -189,6 +192,7 @@ class InterpretadorCobra:
             self.variables[nombre] = valor
 
     def evaluar_expresion(self, expresion):
+        """Resuelve el valor de una expresión de forma recursiva."""
         if isinstance(expresion, NodoValor):
             return expresion.valor  # Obtiene el valor directo si es un NodoValor
         elif isinstance(expresion, Token) and expresion.tipo in {
@@ -273,7 +277,7 @@ class InterpretadorCobra:
                     return resultado
 
     def ejecutar_mientras(self, nodo):
-        # Ejecuta el bucle mientras la condición sea verdadera
+        """Ejecuta un bucle ``mientras`` hasta que la condición sea falsa."""
         while self.evaluar_expresion(nodo.condicion):
             for instruccion in nodo.cuerpo:
                 resultado = self.ejecutar_nodo(instruccion)
@@ -281,6 +285,7 @@ class InterpretadorCobra:
                     return resultado
 
     def ejecutar_try_catch(self, nodo):
+        """Ejecuta un bloque ``try`` con manejo de excepciones Cobra."""
         try:
             for instruccion in nodo.bloque_try:
                 resultado = self.ejecutar_nodo(instruccion)
@@ -295,10 +300,11 @@ class InterpretadorCobra:
                     return resultado
 
     def ejecutar_funcion(self, nodo):
-        # Almacena las funciones definidas por el usuario en el diccionario `variables`
+        """Registra una función definida por el usuario."""
         self.variables[nodo.nombre] = nodo
 
     def ejecutar_llamada_funcion(self, nodo):
+        """Ejecuta la invocación de una función, interna o del usuario."""
         if nodo.nombre == "imprimir":
             for arg in nodo.argumentos:
                 if isinstance(arg, Token) and arg.tipo == TipoToken.IDENTIFICADOR:
@@ -337,15 +343,18 @@ class InterpretadorCobra:
             print(f"Funci\u00f3n '{nodo.nombre}' no implementada")
 
     def ejecutar_clase(self, nodo):
+        """Registra una clase definida por el usuario."""
         self.variables[nodo.nombre] = nodo
 
     def ejecutar_instancia(self, nodo):
+        """Crea una instancia de la clase indicada."""
         clase = self.obtener_variable(nodo.nombre_clase)
         if not isinstance(clase, NodoClase):
             raise ValueError(f"Clase '{nodo.nombre_clase}' no definida")
         return {"__clase__": clase, "__atributos__": {}}
 
     def ejecutar_llamada_metodo(self, nodo):
+        """Invoca un método de un objeto instanciado."""
         objeto = self.evaluar_expresion(nodo.objeto)
         if not isinstance(objeto, dict) or "__clase__" not in objeto:
             raise ValueError("Objeto inv\u00e1lido en llamada a m\u00e9todo")
@@ -395,6 +404,7 @@ class InterpretadorCobra:
                 return resultado
 
     def ejecutar_holobit(self, nodo):
+        """Simula la ejecución de un holobit y devuelve sus valores."""
         print(f"Simulando holobit: {nodo.nombre}")
         valores = []
         for v in nodo.valores:

--- a/backend/src/core/lexer.py
+++ b/backend/src/core/lexer.py
@@ -1,3 +1,5 @@
+"""Analizador léxico para el lenguaje Cobra."""
+
 import logging
 import re
 
@@ -83,6 +85,8 @@ class Token:
 
 
 class Lexer:
+    """Convierte código fuente en una secuencia de tokens."""
+
     def __init__(self, codigo_fuente):
         self.codigo_fuente = codigo_fuente
         self.posicion = 0

--- a/backend/src/core/main.py
+++ b/backend/src/core/main.py
@@ -1,4 +1,8 @@
+"""Punto de entrada mínimo para ejecutar un saludo de prueba."""
+
+
 def main():
+    """Imprime un mensaje de bienvenida."""
     print("¡Hola desde Cobra!")
 
 

--- a/backend/src/core/memoria/__init__.py
+++ b/backend/src/core/memoria/__init__.py
@@ -1,0 +1,2 @@
+"""Submódulo con las estrategias y gestores de memoria utilizados por Cobra."""
+

--- a/backend/src/core/memoria/estrategia_memoria.py
+++ b/backend/src/core/memoria/estrategia_memoria.py
@@ -1,3 +1,5 @@
+"""Estrategias de asignación y liberación de bloques de memoria."""
+
 import random
 
 

--- a/backend/src/core/memoria/gestor_memoria.py
+++ b/backend/src/core/memoria/gestor_memoria.py
@@ -1,3 +1,5 @@
+"""Gestor que aplica un algoritmo genético para optimizar la memoria."""
+
 import random
 
 from .estrategia_memoria import EstrategiaMemoria

--- a/backend/src/core/nativos/__init__.py
+++ b/backend/src/core/nativos/__init__.py
@@ -1,3 +1,5 @@
+"""Colección de primitivas nativas disponibles para los programas Cobra."""
+
 from .io import leer_archivo, escribir_archivo, obtener_url
 from .matematicas import sumar, promedio, potencia
 from .estructuras import Pila, Cola

--- a/backend/src/core/parser.py
+++ b/backend/src/core/parser.py
@@ -1,3 +1,5 @@
+"""Parser del lenguaje Cobra que genera un AST a partir de tokens."""
+
 import logging
 import json
 from src.core.lexer import TipoToken, Token
@@ -60,6 +62,8 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 class Parser:
+    """Convierte una lista de tokens en nodos del AST."""
+
     def __init__(self, tokens):
         self.tokens = tokens
         self.posicion = 0

--- a/backend/src/core/semantic_validators/__init__.py
+++ b/backend/src/core/semantic_validators/__init__.py
@@ -1,3 +1,5 @@
+"""Cadena de validadores semánticos para el modo seguro de Cobra."""
+
 from .primitiva_peligrosa import PrimitivaPeligrosaError, ValidadorPrimitivaPeligrosa
 from .import_seguro import ValidadorImportSeguro
 

--- a/backend/src/core/transpiler/__init__.py
+++ b/backend/src/core/transpiler/__init__.py
@@ -1,0 +1,2 @@
+"""Herramientas para convertir el AST de Cobra a otros lenguajes."""
+

--- a/backend/src/core/transpiler/to_js.py
+++ b/backend/src/core/transpiler/to_js.py
@@ -1,3 +1,5 @@
+"""Transpilador que genera código JavaScript a partir de Cobra."""
+
 from src.core.ast_nodes import (
     NodoLista,
     NodoDiccionario,

--- a/backend/src/core/transpiler/to_python.py
+++ b/backend/src/core/transpiler/to_python.py
@@ -1,3 +1,5 @@
+"""Transpilador que convierte código Cobra en código Python."""
+
 from src.core.ast_nodes import (
     NodoAsignacion, NodoCondicional, NodoBucleMientras, NodoFuncion,
     NodoLlamadaFuncion, NodoHolobit, NodoFor, NodoLista, NodoDiccionario,

--- a/backend/src/core/visitor.py
+++ b/backend/src/core/visitor.py
@@ -1,3 +1,5 @@
+"""Visitante base que implementa el patrón *visitor* para el AST."""
+
 import re
 
 


### PR DESCRIPTION
## Summary
- add module documentation to backend core modules and subpackages
- document public classes and methods without descriptions
- generate docs with pdoc to ensure docstrings are processed

## Testing
- `pytest -q`
- `pdoc backend/src/core -o /tmp/docs`

------
https://chatgpt.com/codex/tasks/task_e_6856ec034ad883278b97196093763bb2