### PR TITLE
Generate API docs via autosummary

### DIFF
--- a/frontend/docs/api/modules.rst
+++ b/frontend/docs/api/modules.rst
@@ -1,0 +1,7 @@
+src
+===
+
+.. toctree::
+   :maxdepth: 4
+
+   src

--- a/frontend/docs/api/src.cli.commands.rst
+++ b/frontend/docs/api/src.cli.commands.rst
@@ -1,0 +1,61 @@
+src.cli.commands package
+========================
+
+Submodules
+----------
+
+src.cli.commands.base module
+----------------------------
+
+.. automodule:: src.cli.commands.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.cli.commands.compile\_cmd module
+------------------------------------
+
+.. automodule:: src.cli.commands.compile_cmd
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.cli.commands.docs\_cmd module
+---------------------------------
+
+.. automodule:: src.cli.commands.docs_cmd
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.cli.commands.execute\_cmd module
+------------------------------------
+
+.. automodule:: src.cli.commands.execute_cmd
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.cli.commands.interactive\_cmd module
+----------------------------------------
+
+.. automodule:: src.cli.commands.interactive_cmd
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.cli.commands.modules\_cmd module
+------------------------------------
+
+.. automodule:: src.cli.commands.modules_cmd
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: src.cli.commands
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.cli.rst
+++ b/frontend/docs/api/src.cli.rst
@@ -1,0 +1,29 @@
+src.cli package
+===============
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   src.cli.commands
+
+Submodules
+----------
+
+src.cli.cli module
+------------------
+
+.. automodule:: src.cli.cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: src.cli
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.holobits.rst
+++ b/frontend/docs/api/src.core.holobits.rst
@@ -1,0 +1,45 @@
+src.core.holobits package
+=========================
+
+Submodules
+----------
+
+src.core.holobits.graficar module
+---------------------------------
+
+.. automodule:: src.core.holobits.graficar
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.holobits.holobit module
+--------------------------------
+
+.. automodule:: src.core.holobits.holobit
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.holobits.proyection module
+-----------------------------------
+
+.. automodule:: src.core.holobits.proyection
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.holobits.transformacion module
+---------------------------------------
+
+.. automodule:: src.core.holobits.transformacion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: src.core.holobits
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.memoria.rst
+++ b/frontend/docs/api/src.core.memoria.rst
@@ -1,0 +1,29 @@
+src.core.memoria package
+========================
+
+Submodules
+----------
+
+src.core.memoria.estrategia\_memoria module
+-------------------------------------------
+
+.. automodule:: src.core.memoria.estrategia_memoria
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.memoria.gestor\_memoria module
+---------------------------------------
+
+.. automodule:: src.core.memoria.gestor_memoria
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: src.core.memoria
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.nativos.rst
+++ b/frontend/docs/api/src.core.nativos.rst
@@ -1,0 +1,37 @@
+src.core.nativos package
+========================
+
+Submodules
+----------
+
+src.core.nativos.estructuras module
+-----------------------------------
+
+.. automodule:: src.core.nativos.estructuras
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.nativos.io module
+--------------------------
+
+.. automodule:: src.core.nativos.io
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.nativos.matematicas module
+-----------------------------------
+
+.. automodule:: src.core.nativos.matematicas
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: src.core.nativos
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.rst
+++ b/frontend/docs/api/src.core.rst
@@ -1,0 +1,81 @@
+src.core package
+================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   src.core.holobits
+   src.core.memoria
+   src.core.nativos
+   src.core.semantic_validators
+   src.core.transpiler
+
+Submodules
+----------
+
+src.core.ast\_nodes module
+--------------------------
+
+.. automodule:: src.core.ast_nodes
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.interpreter module
+---------------------------
+
+.. automodule:: src.core.interpreter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.lexer module
+---------------------
+
+.. automodule:: src.core.lexer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.main module
+--------------------
+
+.. automodule:: src.core.main
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.parser module
+----------------------
+
+.. automodule:: src.core.parser
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.semantic\_validator module
+-----------------------------------
+
+.. automodule:: src.core.semantic_validator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.visitor module
+-----------------------
+
+.. automodule:: src.core.visitor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: src.core
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.semantic_validators.rst
+++ b/frontend/docs/api/src.core.semantic_validators.rst
@@ -1,0 +1,37 @@
+src.core.semantic\_validators package
+=====================================
+
+Submodules
+----------
+
+src.core.semantic\_validators.base module
+-----------------------------------------
+
+.. automodule:: src.core.semantic_validators.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.semantic\_validators.import\_seguro module
+---------------------------------------------------
+
+.. automodule:: src.core.semantic_validators.import_seguro
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.semantic\_validators.primitiva\_peligrosa module
+---------------------------------------------------------
+
+.. automodule:: src.core.semantic_validators.primitiva_peligrosa
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: src.core.semantic_validators
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.transpiler.js_nodes.rst
+++ b/frontend/docs/api/src.core.transpiler.js_nodes.rst
@@ -1,0 +1,221 @@
+src.core.transpiler.js\_nodes package
+=====================================
+
+Submodules
+----------
+
+src.core.transpiler.js\_nodes.asignacion module
+-----------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.asignacion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.atributo module
+---------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.atributo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.bucle\_mientras module
+----------------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.bucle_mientras
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.clase module
+------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.clase
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.condicional module
+------------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.condicional
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.diccionario module
+------------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.diccionario
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.elemento module
+---------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.elemento
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.for\_ module
+------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.for_
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.funcion module
+--------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.funcion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.hilo module
+-----------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.hilo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.holobit module
+--------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.holobit
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.identificador module
+--------------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.identificador
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.importar module
+---------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.importar
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.imprimir module
+---------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.imprimir
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.instancia module
+----------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.instancia
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.lista module
+------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.lista
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.llamada\_funcion module
+-----------------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.llamada_funcion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.llamada\_metodo module
+----------------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.llamada_metodo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.metodo module
+-------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.metodo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.operacion\_binaria module
+-------------------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.operacion_binaria
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.operacion\_unaria module
+------------------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.operacion_unaria
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.para module
+-----------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.para
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.retorno module
+--------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.retorno
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.throw module
+------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.throw
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.try\_catch module
+-----------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.try_catch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.js\_nodes.valor module
+------------------------------------------
+
+.. automodule:: src.core.transpiler.js_nodes.valor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: src.core.transpiler.js_nodes
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.transpiler.python_nodes.rst
+++ b/frontend/docs/api/src.core.transpiler.python_nodes.rst
@@ -1,0 +1,213 @@
+src.core.transpiler.python\_nodes package
+=========================================
+
+Submodules
+----------
+
+src.core.transpiler.python\_nodes.asignacion module
+---------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.asignacion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.atributo module
+-------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.atributo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.bucle\_mientras module
+--------------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.bucle_mientras
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.clase module
+----------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.clase
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.condicional module
+----------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.condicional
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.diccionario module
+----------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.diccionario
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.for\_ module
+----------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.for_
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.funcion module
+------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.funcion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.hilo module
+---------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.hilo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.holobit module
+------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.holobit
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.identificador module
+------------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.identificador
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.importar module
+-------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.importar
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.imprimir module
+-------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.imprimir
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.instancia module
+--------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.instancia
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.lista module
+----------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.lista
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.llamada\_funcion module
+---------------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.llamada_funcion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.llamada\_metodo module
+--------------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.llamada_metodo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.metodo module
+-----------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.metodo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.operacion\_binaria module
+-----------------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.operacion_binaria
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.operacion\_unaria module
+----------------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.operacion_unaria
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.para module
+---------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.para
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.retorno module
+------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.retorno
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.throw module
+----------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.throw
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.try\_catch module
+---------------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.try_catch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.python\_nodes.valor module
+----------------------------------------------
+
+.. automodule:: src.core.transpiler.python_nodes.valor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: src.core.transpiler.python_nodes
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.transpiler.rst
+++ b/frontend/docs/api/src.core.transpiler.rst
@@ -1,0 +1,38 @@
+src.core.transpiler package
+===========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   src.core.transpiler.js_nodes
+   src.core.transpiler.python_nodes
+
+Submodules
+----------
+
+src.core.transpiler.to\_js module
+---------------------------------
+
+.. automodule:: src.core.transpiler.to_js
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.transpiler.to\_python module
+-------------------------------------
+
+.. automodule:: src.core.transpiler.to_python
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: src.core.transpiler
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.rst
+++ b/frontend/docs/api/src.rst
@@ -1,0 +1,20 @@
+src package
+===========
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   src.cli
+   src.core
+   src.tests
+
+Module contents
+---------------
+
+.. automodule:: src
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.tests.rst
+++ b/frontend/docs/api/src.tests.rst
@@ -1,0 +1,301 @@
+src.tests package
+=================
+
+Submodules
+----------
+
+src.tests.test\_cli module
+--------------------------
+
+.. automodule:: src.tests.test_cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_cli2 module
+---------------------------
+
+.. automodule:: src.tests.test_cli2
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_cli\_docs module
+--------------------------------
+
+.. automodule:: src.tests.test_cli_docs
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_gestor\_memoria module
+--------------------------------------
+
+.. automodule:: src.tests.test_gestor_memoria
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_gestor\_memoria2 module
+---------------------------------------
+
+.. automodule:: src.tests.test_gestor_memoria2
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_hilos module
+----------------------------
+
+.. automodule:: src.tests.test_hilos
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_import module
+-----------------------------
+
+.. automodule:: src.tests.test_import
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_interpreter module
+----------------------------------
+
+.. automodule:: src.tests.test_interpreter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_interpreter\_memoria module
+-------------------------------------------
+
+.. automodule:: src.tests.test_interpreter_memoria
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_interpreter\_objects module
+-------------------------------------------
+
+.. automodule:: src.tests.test_interpreter_objects
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_lexer module
+----------------------------
+
+.. automodule:: src.tests.test_lexer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_lexer2 module
+-----------------------------
+
+.. automodule:: src.tests.test_lexer2
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_operadores module
+---------------------------------
+
+.. automodule:: src.tests.test_operadores
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_parser module
+-----------------------------
+
+.. automodule:: src.tests.test_parser
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_parser2 module
+------------------------------
+
+.. automodule:: src.tests.test_parser2
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_parser3 module
+------------------------------
+
+.. automodule:: src.tests.test_parser3
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_parser4 module
+------------------------------
+
+.. automodule:: src.tests.test_parser4
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_parser5 module
+------------------------------
+
+.. automodule:: src.tests.test_parser5
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_parser\_factories module
+----------------------------------------
+
+.. automodule:: src.tests.test_parser_factories
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_parser\_holobit module
+--------------------------------------
+
+.. automodule:: src.tests.test_parser_holobit
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_reserved\_identifiers module
+--------------------------------------------
+
+.. automodule:: src.tests.test_reserved_identifiers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_retornos module
+-------------------------------
+
+.. automodule:: src.tests.test_retornos
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_safe\_mode module
+---------------------------------
+
+.. automodule:: src.tests.test_safe_mode
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_semantic\_validator module
+------------------------------------------
+
+.. automodule:: src.tests.test_semantic_validator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_to\_js module
+-----------------------------
+
+.. automodule:: src.tests.test_to_js
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_to\_js2 module
+------------------------------
+
+.. automodule:: src.tests.test_to_js2
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_to\_js3 module
+------------------------------
+
+.. automodule:: src.tests.test_to_js3
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_to\_js4 module
+------------------------------
+
+.. automodule:: src.tests.test_to_js4
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_to\_js\_objects module
+--------------------------------------
+
+.. automodule:: src.tests.test_to_js_objects
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_to\_python module
+---------------------------------
+
+.. automodule:: src.tests.test_to_python
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_to\_python2 module
+----------------------------------
+
+.. automodule:: src.tests.test_to_python2
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_to\_python3 module
+----------------------------------
+
+.. automodule:: src.tests.test_to_python3
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_to\_python4 module
+----------------------------------
+
+.. automodule:: src.tests.test_to_python4
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_to\_python\_objects module
+------------------------------------------
+
+.. automodule:: src.tests.test_to_python_objects
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_try\_catch module
+---------------------------------
+
+.. automodule:: src.tests.test_try_catch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.tests.test\_unicode\_identifiers module
+-------------------------------------------
+
+.. automodule:: src.tests.test_unicode_identifiers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: src.tests
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/conf.py
+++ b/frontend/docs/conf.py
@@ -40,7 +40,7 @@ extensions = [
               ]
 
 # Habilitar la generación automática de autosummary
-autosummary_generate = False
+autosummary_generate = True
 
 templates_path = ['_templates']
 exclude_patterns = []

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -22,6 +22,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    referencia
    validador
    modo_seguro
+   api/modules
 
 Introducción
 --------------------


### PR DESCRIPTION
## Summary
- enable autosummary generation in Sphinx config
- generate `frontend/docs/api/` via `sphinx-apidoc`
- include API documentation in toctree

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857a8010dd08327be8c844f8f847f06