### PR TITLE
Generar docs API desde CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,11 @@ cobra ejecutar programa.cobra --depurar --formatear
 cobra modulos listar
 cobra modulos instalar ruta/al/modulo.cobra
 cobra modulos remover modulo.cobra
+# Generar documentación HTML y API
+cobra docs
 ```
+
+El subcomando `docs` ejecuta `sphinx-apidoc` para generar la documentación de la API antes de compilar el HTML.
 
 
 Si no se pasa un subcomando se abrirá el modo interactivo. Usa `cobra --help` para más detalles.

--- a/backend/src/cli/commands/docs_cmd.py
+++ b/backend/src/cli/commands/docs_cmd.py
@@ -19,5 +19,9 @@ class DocsCommand(BaseCommand):
         )
         source = os.path.join(raiz, "frontend", "docs")
         build = os.path.join(raiz, "frontend", "build", "html")
+        api = os.path.join(source, "api")
+        codigo = os.path.join(raiz, "backend", "src")
+
+        subprocess.run(["sphinx-apidoc", "-o", api, codigo], check=True)
         subprocess.run(["sphinx-build", "-b", "html", source, build], check=True)
         print(f"Documentación generada en {build}")

--- a/backend/src/tests/test_cli_docs.py
+++ b/backend/src/tests/test_cli_docs.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, call
 from src.cli.cli import main
 
 
@@ -9,11 +9,21 @@ def test_cli_docs_invokes_sphinx():
         raiz = Path(__file__).resolve().parents[3]
         source = raiz / "frontend" / "docs"
         build = raiz / "frontend" / "build" / "html"
-        mock_run.assert_called_with([
-            "sphinx-build",
-            "-b",
-            "html",
-            str(source),
-            str(build),
-        ], check=True)
+        api = raiz / "frontend" / "docs" / "api"
+        codigo = raiz / "backend" / "src"
+        mock_run.assert_has_calls([
+            call([
+                "sphinx-apidoc",
+                "-o",
+                str(api),
+                str(codigo),
+            ], check=True),
+            call([
+                "sphinx-build",
+                "-b",
+                "html",
+                str(source),
+                str(build),
+            ], check=True),
+        ])
 


### PR DESCRIPTION
## Summary
- execute sphinx-apidoc before sphinx-build in docs command
- update CLI doc test with the new call
- document automatic API generation in README

## Testing
- `pytest backend/src/tests/test_cli_docs.py -q`
- `pytest -q` *(all tests)*

------
https://chatgpt.com/codex/tasks/task_e_6857a91e387c8327afc1681cad2a5741