### PR TITLE
Añadir script para generar docs con pdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ Puedes compilar la documentación de dos maneras:
 2. **Con Make**. Desde la raíz del proyecto, ejecuta `make html` para
    compilar los archivos ubicados en `frontend/docs`.
 
+3. **Con pdoc**. Para generar documentación de la API con [pdoc](https://pdoc.dev),
+   ejecuta `python scripts/generar_pdoc.py`. El resultado se guardará en
+   `frontend/build/pdoc`.
+
 A partir de esta versión, la API se genera de forma automática antes de
 cada compilación para mantener la documentación actualizada.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ deap==1.3.1                      # Para algoritmos evolutivos
 requests==2.32.0                 # Para realizar peticiones HTTP (si es necesario)
 sphinx==7.2.6                     # Para generar documentación
 sphinx-rtd-theme==1.3.0           # Tema por defecto de la documentación
+pdoc==15.0.4                      # Generador de documentación de la API

--- a/scripts/generar_pdoc.py
+++ b/scripts/generar_pdoc.py
@@ -1,0 +1,17 @@
+import subprocess
+from pathlib import Path
+
+OUTPUT_DIR = Path('frontend/build/pdoc')
+
+
+def main():
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    subprocess.run([
+        'pdoc',
+        'backend/src',
+        '--output-dir', str(OUTPUT_DIR)
+    ], check=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Resumen
- crear `scripts/generar_pdoc.py` para invocar pdoc sobre `backend/src`
- documentar el uso del script en el README
- añadir pdoc a `requirements.txt`

## Testing
- `python scripts/generar_pdoc.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857ac8ca9ac83278279e2ff526429a3