### PR TITLE
Add pytest-cov and codecov to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@
 # Dependencias para pruebas
 pytest==7.4.0
 pytest-timeout==2.4.0
+pytest-cov==6.2.1
+codecov==2.1.13
 
 # Dependencias para la implementación del parser y lexer
 antlr4-python3-runtime==4.9.3  # Si estás usando ANTLR

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ setup(
         'DEAP>=1.3.1',
         # Agrega más requisitos según sea necesario
     ],
+    tests_require=[
+        'pytest-cov',
+    ],
     entry_points={
         'console_scripts': [
             'cobra=src.cli.cli:main',


### PR DESCRIPTION
## Summary
- include `pytest-cov` and `codecov` for test coverage support
- declare `pytest-cov` as a test dependency in `setup.py`

## Testing
- `pip install pytest-cov==6.2.1 codecov==2.1.13`
- `pip check`
- `pytest -q` *(interrupted after finish)*

------
https://chatgpt.com/codex/tasks/task_e_6857c091ab908327966e9ad394d3d0f8