### PR TITLE
Agregar cobertura con Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install sphinx sphinx-rtd-theme
+          pip install sphinx sphinx-rtd-theme pytest-cov codecov
       - name: Run tests
-        run: pytest -q
+        run: pytest --cov=backend/src --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
       - name: Build docs
         run: sphinx-build -b html frontend/docs frontend/build/html
       - name: Upload docs


### PR DESCRIPTION
## Summary
- incluye `pytest-cov` y `codecov` en la instalación de dependencias del workflow
- ejecuta pruebas con reportes de cobertura
- sube `coverage.xml` a Codecov automáticamente

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857c72f7218832781c9c0fcabe3a29c