### PR TITLE
Move logging config to runtime

### DIFF
--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -9,12 +9,15 @@ from .commands.execute_cmd import ExecuteCommand
 from .commands.interactive_cmd import InteractiveCommand
 from .commands.modules_cmd import ModulesCommand
 
-# Configuración de logging
-logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s")
+# La configuración de logging solo debe activarse cuando la CLI se ejecuta
+# directamente para evitar modificar la configuración global al importar este
+# módulo desde las pruebas u otros paquetes.
 
 
 def main(argv=None):
     """Punto de entrada principal de la CLI."""
+    logging.basicConfig(level=logging.DEBUG,
+                        format="%(asctime)s - %(levelname)s - %(message)s")
     parser = argparse.ArgumentParser(prog="cobra", description="CLI para Cobra")
     parser.add_argument("--formatear", action="store_true", help="Formatea el archivo antes de procesarlo")
     parser.add_argument("--depurar", action="store_true", help="Muestra mensajes de depuración")


### PR DESCRIPTION
## Summary
- configure logging inside `main()` instead of at import time

## Testing
- `pytest backend/src/tests/test_cli.py backend/src/tests/test_cli2.py backend/src/tests/test_cli_docs.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6857d46ea7e88327a668f699e54ca049