### PR TITLE
Mejora CLI con códigos de salida

### DIFF
--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -48,8 +48,9 @@ def main(argv=None):
 
     args = parser.parse_args(argv)
     command = getattr(args, "cmd", command_map["interactive"])
-    command.run(args)
+    resultado = command.run(args)
+    return 0 if resultado is None else resultado
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -26,7 +26,7 @@ class CompileCommand(BaseCommand):
         transpilador = args.tipo
         if not os.path.exists(archivo):
             print(f"Error: El archivo '{archivo}' no existe.")
-            return
+            return 1
 
         with open(archivo, "r") as f:
             codigo = f.read()
@@ -48,12 +48,16 @@ class CompileCommand(BaseCommand):
                 resultado = transp.transpilar(ast)
                 print(f"Código generado ({transp.__class__.__name__}):")
                 print(resultado)
+                return 0
             except PrimitivaPeligrosaError as pe:
                 logging.error(f"Primitiva peligrosa: {pe}")
                 print(f"Error: {pe}")
+                return 1
             except SyntaxError as se:
                 logging.error(f"Error de sintaxis durante la transpilación: {se}")
                 print(f"Error durante la transpilación: {se}")
+                return 1
             except Exception as e:
                 logging.error(f"Error general durante la transpilación: {e}")
                 print(f"Error durante la transpilación: {e}")
+                return 1

--- a/backend/src/cli/commands/docs_cmd.py
+++ b/backend/src/cli/commands/docs_cmd.py
@@ -22,6 +22,11 @@ class DocsCommand(BaseCommand):
         api = os.path.join(source, "api")
         codigo = os.path.join(raiz, "backend", "src")
 
-        subprocess.run(["sphinx-apidoc", "-o", api, codigo], check=True)
-        subprocess.run(["sphinx-build", "-b", "html", source, build], check=True)
-        print(f"Documentación generada en {build}")
+        try:
+            subprocess.run(["sphinx-apidoc", "-o", api, codigo], check=True)
+            subprocess.run(["sphinx-build", "-b", "html", source, build], check=True)
+            print(f"Documentación generada en {build}")
+            return 0
+        except subprocess.CalledProcessError as e:
+            print(f"Error generando la documentación: {e}")
+            return 1

--- a/backend/src/cli/commands/execute_cmd.py
+++ b/backend/src/cli/commands/execute_cmd.py
@@ -27,7 +27,7 @@ class ExecuteCommand(BaseCommand):
 
         if not os.path.exists(archivo):
             print(f"El archivo '{archivo}' no existe")
-            return
+            return 1
         if formatear:
             self._formatear_codigo(archivo)
         if depurar:
@@ -46,8 +46,14 @@ class ExecuteCommand(BaseCommand):
         except PrimitivaPeligrosaError as pe:
             logging.error(f"Primitiva peligrosa: {pe}")
             print(f"Error: {pe}")
-            return
-        InterpretadorCobra(safe_mode=seguro).ejecutar_ast(ast)
+            return 1
+        try:
+            InterpretadorCobra(safe_mode=seguro).ejecutar_ast(ast)
+            return 0
+        except Exception as e:
+            logging.error(f"Error ejecutando el script: {e}")
+            print(f"Error ejecutando el script: {e}")
+            return 1
 
     @staticmethod
     def _formatear_codigo(archivo):

--- a/backend/src/cli/commands/interactive_cmd.py
+++ b/backend/src/cli/commands/interactive_cmd.py
@@ -68,3 +68,4 @@ class InteractiveCommand(BaseCommand):
             except Exception as e:
                 logging.error(f"Error general procesando la entrada: {e}")
                 print(f"Error procesando la entrada: {e}")
+        return 0

--- a/backend/src/cli/commands/modules_cmd.py
+++ b/backend/src/cli/commands/modules_cmd.py
@@ -25,13 +25,14 @@ class ModulesCommand(BaseCommand):
     def run(self, args):
         accion = args.accion
         if accion == "listar":
-            self._listar_modulos()
+            return self._listar_modulos()
         elif accion == "instalar":
-            self._instalar_modulo(args.ruta)
+            return self._instalar_modulo(args.ruta)
         elif accion == "remover":
-            self._remover_modulo(args.nombre)
+            return self._remover_modulo(args.nombre)
         else:
             print("Acción de módulos no reconocida")
+            return 1
 
     @staticmethod
     def _listar_modulos():
@@ -41,15 +42,17 @@ class ModulesCommand(BaseCommand):
         else:
             for m in mods:
                 print(m)
+        return 0
 
     @staticmethod
     def _instalar_modulo(ruta):
         if not os.path.exists(ruta):
             print(f"No se encontró el módulo {ruta}")
-            return
+            return 1
         destino = os.path.join(MODULES_PATH, os.path.basename(ruta))
         shutil.copy(ruta, destino)
         print(f"Módulo instalado en {destino}")
+        return 0
 
     @staticmethod
     def _remover_modulo(nombre):
@@ -57,5 +60,7 @@ class ModulesCommand(BaseCommand):
         if os.path.exists(archivo):
             os.remove(archivo)
             print(f"Módulo {nombre} eliminado")
+            return 0
         else:
             print(f"El módulo {nombre} no existe")
+            return 1

--- a/backend/src/tests/test_cli_exit_codes.py
+++ b/backend/src/tests/test_cli_exit_codes.py
@@ -1,0 +1,35 @@
+import sys
+from io import StringIO
+from unittest.mock import patch
+import pytest
+
+from src.cli.cli import main
+from src.cli.commands import modules_cmd
+
+
+def _run_sys_exit(args):
+    with patch("sys.stdout", new_callable=StringIO):
+        with pytest.raises(SystemExit) as exc:
+            sys.exit(main(args))
+    return exc.value.code
+
+
+@pytest.mark.timeout(5)
+def test_exit_code_compile_missing(tmp_path):
+    archivo = tmp_path / "no.cobra"
+    code = _run_sys_exit(["compilar", str(archivo)])
+    assert code != 0
+
+
+@pytest.mark.timeout(5)
+def test_exit_code_execute_missing(tmp_path):
+    archivo = tmp_path / "no.cobra"
+    code = _run_sys_exit(["ejecutar", str(archivo)])
+    assert code != 0
+
+
+@pytest.mark.timeout(5)
+def test_exit_code_module_remove_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(modules_cmd, "MODULES_PATH", str(tmp_path))
+    code = _run_sys_exit(["modulos", "remover", "algo.cobra"])
+    assert code != 0


### PR DESCRIPTION
## Summary
- return exit status codes from CLI subcommands
- pass exit codes back in `main()`
- exit with the code when running the CLI as a script
- add tests that verify the CLI fails with non-zero exit codes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857dcaa605083278c318cd47410891a