### PR TITLE
Fix flake8 warnings parcialmente

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 88
+exclude = venv
+
+ignore = F403,F405

--- a/backend/src/cli/commands/docs_cmd.py
+++ b/backend/src/cli/commands/docs_cmd.py
@@ -9,7 +9,9 @@ class DocsCommand(BaseCommand):
     name = "docs"
 
     def register_subparser(self, subparsers):
-        parser = subparsers.add_parser(self.name, help="Genera la documentación del proyecto")
+        parser = subparsers.add_parser(
+            self.name, help="Genera la documentación del proyecto"
+        )
         parser.set_defaults(cmd=self)
         return parser
 

--- a/backend/src/cli/commands/execute_cmd.py
+++ b/backend/src/cli/commands/execute_cmd.py
@@ -66,5 +66,6 @@ class ExecuteCommand(BaseCommand):
             ], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except FileNotFoundError:
             print(
-                "Herramienta de formateo no encontrada. Asegúrate de tener 'black' instalado."
+                "Herramienta de formateo no encontrada. "
+                "Asegúrate de tener 'black' instalado."
             )

--- a/backend/src/core/interpreter.py
+++ b/backend/src/core/interpreter.py
@@ -13,7 +13,6 @@ from src.core.ast_nodes import (
     NodoHolobit,
     NodoHilo,
     NodoClase,
-    NodoMetodo,
     NodoInstancia,
     NodoAtributo,
     NodoIdentificador,
@@ -314,7 +313,10 @@ class InterpretadorCobra:
                 else:
                     valor = self.evaluar_expresion(arg)
                 print(valor)
-        elif nodo.nombre in self.variables and isinstance(self.variables[nodo.nombre], NodoFuncion):
+        elif (
+            nodo.nombre in self.variables
+            and isinstance(self.variables[nodo.nombre], NodoFuncion)
+        ):
             funcion = self.variables[nodo.nombre]
             if len(funcion.parametros) != len(nodo.argumentos):
                 print(f"Error: se esperaban {len(funcion.parametros)} argumentos")
@@ -359,7 +361,9 @@ class InterpretadorCobra:
         if not isinstance(objeto, dict) or "__clase__" not in objeto:
             raise ValueError("Objeto inv\u00e1lido en llamada a m\u00e9todo")
         clase = objeto["__clase__"]
-        metodo = next((m for m in clase.metodos if m.nombre == nodo.nombre_metodo), None)
+        metodo = next(
+            (m for m in clase.metodos if m.nombre == nodo.nombre_metodo), None
+        )
         if metodo is None:
             raise ValueError(f"M\u00e9todo '{nodo.nombre_metodo}' no encontrado")
 

--- a/backend/src/core/parser.py
+++ b/backend/src/core/parser.py
@@ -12,11 +12,6 @@ from src.core.ast_nodes import (
     NodoFuncion,
     NodoLlamadaFuncion,
     NodoHilo,
-    NodoClase,
-    NodoMetodo,
-    NodoInstancia,
-    NodoAtributo,
-    NodoLlamadaMetodo,
     NodoOperacionBinaria,
     NodoOperacionUnaria,
     NodoValor,
@@ -27,9 +22,6 @@ from src.core.ast_nodes import (
     NodoTryCatch,
     NodoThrow,
     NodoImport,
-    NodoLista,
-    NodoDiccionario,
-    NodoFor,
 )
 
 # Palabras reservadas que no pueden usarse como identificadores

--- a/backend/src/core/transpiler/to_js.py
+++ b/backend/src/core/transpiler/to_js.py
@@ -9,13 +9,8 @@ from src.core.ast_nodes import (
     NodoIdentificador,
     NodoAtributo,
     NodoInstancia,
-    NodoLlamadaMetodo,
-    NodoHilo,
-    NodoImport,
-    NodoImprimir
 )
-from src.core.parser import Parser
-from src.core.lexer import TipoToken, Lexer
+from src.core.lexer import TipoToken
 from src.core.visitor import NodeVisitor
 
 from .js_nodes.asignacion import visit_asignacion as _visit_asignacion


### PR DESCRIPTION
## Summary
- agregar archivo `.flake8`
- envolver argumentos largos en `docs_cmd` y `execute_cmd`
- ajustar condiciones en `interpreter`
- limpiar imports en `parser` y `to_js`

## Testing
- `flake8 backend/src`
- `pytest backend/src/tests/test_cli_commands_extra.py::test_cli_compilar_generates_output[python-esperado0] -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e7ac91248327aa44825486c417d2