### PR TITLE
Add PR labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+feature/*: feature
+bugfix/*: bug
+doc/*: documentation

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,11 @@
+name: Label PRs by branch
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
 
 - Haz un fork del proyecto.
 - Crea una nueva rama (`git checkout -b feature/nueva-caracteristica`).
+- Las ramas que comiencen con `feature/`, `bugfix/` o `doc/` recibirán etiquetas
+  automáticas al abrir un pull request.
 - Realiza tus cambios y haz commit (`git commit -m 'Añadir nueva característica'`).
 - Envía un pull request.
 


### PR DESCRIPTION
## Summary
- add branch rules for PR labels
- add workflow to run actions/labeler
- mention automatic labels in the contribution guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f1e032748327b22b720f3f2da0dc