### PR TITLE
Implement dependencias CLI command with tests

### DIFF
--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -8,6 +8,7 @@ from .commands.docs_cmd import DocsCommand
 from .commands.execute_cmd import ExecuteCommand
 from .commands.interactive_cmd import InteractiveCommand
 from .commands.modules_cmd import ModulesCommand
+from .commands.dependencias_cmd import DependenciasCommand
 
 # La configuración de logging solo debe activarse cuando la CLI se ejecuta
 # directamente para evitar modificar la configuración global al importar este
@@ -29,6 +30,7 @@ def main(argv=None):
         CompileCommand(),
         ExecuteCommand(),
         ModulesCommand(),
+        DependenciasCommand(),
         DocsCommand(),
         InteractiveCommand(),
     ]

--- a/backend/src/cli/commands/dependencias_cmd.py
+++ b/backend/src/cli/commands/dependencias_cmd.py
@@ -1,0 +1,61 @@
+import os
+import subprocess
+from .base import BaseCommand
+
+
+class DependenciasCommand(BaseCommand):
+    """Gestiona las dependencias del proyecto."""
+
+    name = "dependencias"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(
+            self.name, help="Gestiona las dependencias del proyecto"
+        )
+        dep_sub = parser.add_subparsers(dest="accion")
+        dep_sub.add_parser("listar", help="Lista las dependencias")
+        dep_sub.add_parser("instalar", help="Instala las dependencias")
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        accion = args.accion
+        if accion == "listar":
+            return self._listar_dependencias()
+        elif accion == "instalar":
+            return self._instalar_dependencias()
+        else:
+            print("Acci\u00f3n de dependencias no reconocida")
+            return 1
+
+    @staticmethod
+    def _ruta_requirements():
+        return os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "requirements.txt")
+        )
+
+    @classmethod
+    def _listar_dependencias(cls):
+        archivo = cls._ruta_requirements()
+        if not os.path.exists(archivo):
+            print("No se encontr\u00f3 requirements.txt")
+            return 1
+        with open(archivo, "r") as f:
+            deps = [l.strip() for l in f if l.strip() and not l.startswith("#")]
+        if not deps:
+            print("No hay dependencias listadas")
+        else:
+            for dep in deps:
+                print(dep)
+        return 0
+
+    @classmethod
+    def _instalar_dependencias(cls):
+        archivo = cls._ruta_requirements()
+        try:
+            subprocess.run(["pip", "install", "-r", archivo], check=True)
+            print("Dependencias instaladas")
+            return 0
+        except subprocess.CalledProcessError as e:
+            print(f"Error instalando dependencias: {e}")
+            return 1

--- a/backend/src/tests/test_cli_dependencias.py
+++ b/backend/src/tests/test_cli_dependencias.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from unittest.mock import patch
+from src.cli.cli import main
+
+
+def test_cli_dependencias_instalar_invoca_pip():
+    with patch("subprocess.run") as mock_run:
+        main(["dependencias", "instalar"])
+        req = Path(__file__).resolve().parents[3] / "requirements.txt"
+        mock_run.assert_called_once_with(["pip", "install", "-r", str(req)], check=True)
+
+
+def test_cli_dependencias_listar_muestra_paquetes(tmp_path, monkeypatch):
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text("paqueteA==1.0\npaqueteB==2.0\n")
+    monkeypatch.setattr(
+        "src.cli.commands.dependencias_cmd.DependenciasCommand._ruta_requirements",
+        lambda: str(req_file),
+    )
+
+    with patch("sys.stdout", new_callable=lambda: __import__("io").StringIO()) as out:
+        main(["dependencias", "listar"])
+    salida = out.getvalue().strip().splitlines()
+    assert salida == ["paqueteA==1.0", "paqueteB==2.0"]


### PR DESCRIPTION
## Summary
- add new `dependencias` command with actions `instalar` and `listar`
- register new command in the CLI dispatcher
- test dependency handling and pip invocation

## Testing
- `pytest backend/src/tests/test_cli_dependencias.py -q`
- `pytest backend/src/tests/test_cli_docs.py backend/src/tests/test_cli_commands_extra.py backend/src/tests/test_cli_exit_codes.py backend/src/tests/test_cli_dependencias.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f41baa7883279e3a089264eed053