### PR TITLE
Add empaquetar command

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ cobra modulos instalar ruta/al/modulo.cobra
 cobra modulos remover modulo.cobra
 # Generar documentación HTML y API
 cobra docs
+# Crear un ejecutable independiente
+cobra empaquetar --output dist
 ```
 
 El subcomando `docs` ejecuta `sphinx-apidoc` para generar la documentación de la API antes de compilar el HTML.

--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -9,6 +9,7 @@ from .commands.execute_cmd import ExecuteCommand
 from .commands.interactive_cmd import InteractiveCommand
 from .commands.modules_cmd import ModulesCommand
 from .commands.dependencias_cmd import DependenciasCommand
+from .commands.empaquetar_cmd import EmpaquetarCommand
 
 # La configuración de logging solo debe activarse cuando la CLI se ejecuta
 # directamente para evitar modificar la configuración global al importar este
@@ -32,6 +33,7 @@ def main(argv=None):
         ModulesCommand(),
         DependenciasCommand(),
         DocsCommand(),
+        EmpaquetarCommand(),
         InteractiveCommand(),
     ]
 

--- a/backend/src/cli/commands/empaquetar_cmd.py
+++ b/backend/src/cli/commands/empaquetar_cmd.py
@@ -1,0 +1,52 @@
+import os
+import subprocess
+
+from .base import BaseCommand
+
+
+class EmpaquetarCommand(BaseCommand):
+    """Empaqueta la CLI en un ejecutable."""
+
+    name = "empaquetar"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(
+            self.name, help="Crea un ejecutable para la CLI usando PyInstaller"
+        )
+        parser.add_argument(
+            "--output",
+            default="dist",
+            help="Directorio donde colocar el ejecutable generado",
+        )
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        raiz = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+        )
+        cli_path = os.path.join(raiz, "backend", "src", "cli", "cli.py")
+        output = args.output
+        try:
+            subprocess.run(
+                [
+                    "pyinstaller",
+                    "--onefile",
+                    "-n",
+                    "cobra",
+                    cli_path,
+                    "--distpath",
+                    output,
+                ],
+                check=True,
+            )
+            print(f"Ejecutable generado en {os.path.join(output, 'cobra')}")
+            return 0
+        except FileNotFoundError:
+            print(
+                "PyInstaller no está instalado. Ejecuta 'pip install pyinstaller'."
+            )
+            return 1
+        except subprocess.CalledProcessError as e:
+            print(f"Error empaquetando la CLI: {e}")
+            return 1

--- a/backend/src/tests/test_cli_empaquetar.py
+++ b/backend/src/tests/test_cli_empaquetar.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from io import StringIO
+from unittest.mock import patch, call
+
+from src.cli.cli import main
+
+
+def test_cli_empaquetar_invoca_pyinstaller(tmp_path):
+    with patch("subprocess.run") as mock_run:
+        main(["empaquetar", f"--output={tmp_path}"])
+        raiz = Path(__file__).resolve().parents[3]
+        cli_path = raiz / "backend" / "src" / "cli" / "cli.py"
+        mock_run.assert_called_once_with(
+            [
+                "pyinstaller",
+                "--onefile",
+                "-n",
+                "cobra",
+                str(cli_path),
+                "--distpath",
+                str(tmp_path),
+            ],
+            check=True,
+        )
+
+
+def test_cli_empaquetar_sin_pyinstaller(tmp_path):
+    with patch("subprocess.run", side_effect=FileNotFoundError), \
+            patch("sys.stdout", new_callable=StringIO) as out:
+        main(["empaquetar", f"--output={tmp_path}"])
+    assert "PyInstaller no está instalado" in out.getvalue()

--- a/frontend/docs/empaquetar.rst
+++ b/frontend/docs/empaquetar.rst
@@ -1,0 +1,22 @@
+Empaquetar la CLI
+=================
+
+Este proyecto puede distribuirse como un ejecutable independiente usando
+`PyInstaller <https://pyinstaller.org>`_.
+
+Para generar el ejecutable ejecuta:
+
+.. code-block:: bash
+
+   cobra empaquetar --output dist
+
+Esto creará un archivo ``cobra`` (o ``cobra.exe`` en Windows) en el directorio
+``dist``. Se necesita tener ``pyinstaller`` instalado previamente. Puedes
+instalarlo con ``pip install pyinstaller``.
+
+Requisitos de plataforma
+------------------------
+
+PyInstaller está disponible para Windows, macOS y Linux. El ejecutable sólo
+funciona en el mismo sistema operativo donde se creó. Si deseas distribuir para
+varias plataformas, debes empaquetar el proyecto en cada una de ellas.

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -22,6 +22,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    referencia
    validador
    modo_seguro
+   empaquetar
    api/modules
 
 Introducción

--- a/frontend/docs/referencia.rst
+++ b/frontend/docs/referencia.rst
@@ -32,8 +32,10 @@ El comando ``cobra`` cuenta con varias subopciones:
    cobra ejecutar archivo.cobra --depurar
    cobra modulos listar
    cobra docs
+   cobra empaquetar --output dist
 
 La opción ``--seguro`` puede añadirse a ``ejecutar`` o al modo interactivo para
 bloquear primitivas peligrosas e importaciones no permitidas.
 
 El subcomando ``docs`` genera la documentación del proyecto en ``frontend/build/html``.
+``empaquetar`` crea un ejecutable independiente usando PyInstaller.


### PR DESCRIPTION
## Summary
- add empaquetar command to package CLI via PyInstaller
- document new command usage in README and docs
- explain packaging process in new rst file
- include unit tests for new command

## Testing
- `pytest backend/src/tests/test_cli_empaquetar.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6857f6b0e1e083279c3f0986fa043218