### PR TITLE
Optimiza validación semántica

### DIFF
--- a/backend/src/core/semantic_validators/__init__.py
+++ b/backend/src/core/semantic_validators/__init__.py
@@ -1,17 +1,35 @@
 """Cadena de validadores semánticos para el modo seguro de Cobra."""
 
-from .primitiva_peligrosa import PrimitivaPeligrosaError, ValidadorPrimitivaPeligrosa
+from .primitiva_peligrosa import (
+    PrimitivaPeligrosaError,
+    ValidadorPrimitivaPeligrosa,
+)
 from .import_seguro import ValidadorImportSeguro
+
+# Instancia por defecto reutilizable de la cadena de validación
+_CADENA_DEFECTO = None
 
 
 def construir_cadena(extra_validators=None):
-    """Construye la cadena de validadores por defecto."""
+    """Devuelve la cadena de validadores por defecto.
+
+    Si no se proporcionan validadores extra, la cadena se crea una única vez y
+    se reutiliza en llamadas sucesivas.
+    """
+    global _CADENA_DEFECTO
+
+    if extra_validators is None and _CADENA_DEFECTO is not None:
+        return _CADENA_DEFECTO
+
     primero = ValidadorPrimitivaPeligrosa()
     actual = primero.set_siguiente(ValidadorImportSeguro())
 
     if extra_validators:
         for val in extra_validators:
             actual = actual.set_siguiente(val)
+
+    if extra_validators is None:
+        _CADENA_DEFECTO = primero
 
     return primero
 

--- a/backend/src/tests/test_validator_optimization.py
+++ b/backend/src/tests/test_validator_optimization.py
@@ -1,0 +1,40 @@
+import importlib
+from unittest.mock import patch
+
+from src.core.semantic_validators import construir_cadena, ValidadorPrimitivaPeligrosa
+
+
+def test_construir_cadena_reutiliza_instancias():
+    contador = 0
+
+    original_init = ValidadorPrimitivaPeligrosa.__init__
+
+    def cuenta_init(self):
+        nonlocal contador
+        contador += 1
+        original_init(self)
+
+    with patch.object(ValidadorPrimitivaPeligrosa, "__init__", cuenta_init):
+        construir_cadena()  # Primera vez crea la cadena
+        construir_cadena()  # Debe reutilizarla
+
+    assert contador == 1
+
+
+def test_construir_cadena_sin_reutilizar(monkeypatch):
+    contador = 0
+    original_init = ValidadorPrimitivaPeligrosa.__init__
+
+    def cuenta_init(self):
+        nonlocal contador
+        contador += 1
+        original_init(self)
+
+    with patch.object(ValidadorPrimitivaPeligrosa, "__init__", cuenta_init):
+        import src.core.semantic_validators as sv
+        monkeypatch.setattr(sv, "_CADENA_DEFECTO", None)
+        construir_cadena()
+        monkeypatch.setattr(sv, "_CADENA_DEFECTO", None)
+        construir_cadena()
+
+    assert contador == 2


### PR DESCRIPTION
## Summary
- reutilizar la cadena de validadores al almacenarla en un singleton
- añadir pruebas de reutilización de la cadena de validadores

## Testing
- `pytest backend/src/tests/test_validator_optimization.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6857f9a25c488327932d307edf1c8b37