### PR TITLE
Add advanced examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ El proyecto se organiza en las siguientes carpetas y módulos:
 - Manejo de Errores: El sistema captura y reporta errores de sintaxis, facilitando la depuración.
 - Visualización y Depuración: Salida detallada de tokens, AST y errores de sintaxis para un desarrollo más sencillo.
 - Ejemplos de Código y Documentación: Ejemplos prácticos que ilustran el uso del lexer, parser y transpiladores.
+- Ejemplos Avanzados: Revisa `frontend/docs/ejemplos_avanzados.rst` para conocer casos con clases, hilos y manejo de errores.
 - Identificadores en Unicode: Puedes nombrar variables y funciones utilizando
   caracteres como `á`, `ñ` o `Ω` para una mayor flexibilidad.
 

--- a/frontend/docs/ejemplos_avanzados.rst
+++ b/frontend/docs/ejemplos_avanzados.rst
@@ -1,0 +1,54 @@
+Ejemplos Avanzados
+===================
+
+En esta sección se presentan programas más complejos escritos en Cobra. Se
+incluyen ejemplos con clases, uso de hilos y manejo de errores para ilustrar las
+capacidades del lenguaje.
+
+Clases
+------
+.. code-block:: cobra
+
+   clase Persona:
+       func __init__(self, nombre):
+           self.nombre = nombre
+       fin
+
+       func saludar(self):
+           imprimir("Hola, soy " + self.nombre)
+       fin
+   fin
+
+   var p = Persona("Ada")
+   p.saludar()
+
+Hilos
+-----
+.. code-block:: cobra
+
+   func contar():
+       para var i en rango(3):
+           imprimir(i)
+       fin
+   fin
+
+   hilo contar()
+   hilo contar()
+
+Manejo de errores
+-----------------
+.. code-block:: cobra
+
+   func dividir(a, b):
+       si b == 0:
+           throw "Division por cero"
+       sino:
+           return a / b
+       fin
+   fin
+
+   try:
+       imprimir(dividir(10, 0))
+   catch e:
+       imprimir("Error:" + e)
+   fin

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -19,6 +19,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    proximos_pasos
    modulos_nativos
    ejemplos
+   ejemplos_avanzados
    referencia
    validador
    modo_seguro


### PR DESCRIPTION
## Summary
- document advanced examples of classes, threads and errors
- link the new docs page from index.rst
- mention advanced examples in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580376a1808327be127f523b00c6d4