### PR TITLE
Implement plugin loading system

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,23 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
 - Realiza tus cambios y haz commit (`git commit -m 'Añadir nueva característica'`).
 - Envía un pull request.
 
+## Desarrollo de plugins
+
+La CLI puede ampliarse mediante plugins externos. Para crear uno, define una
+clase que herede de `PluginCommand` e incluye una entrada en el grupo
+`cobra.plugins` de tu `setup.py`:
+
+```python
+entry_points={
+    'cobra.plugins': [
+        'saludo = mi_paquete.mi_modulo:SaludoCommand',
+    ],
+}
+```
+
+Tras instalar el paquete con `pip install -e .`, Cobra detectará automáticamente
+el nuevo comando.
+
 # Licencia
 
 Este proyecto está bajo la [Licencia MIT](LICENSE).

--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -7,6 +7,7 @@ from .commands.compile_cmd import CompileCommand
 from .commands.docs_cmd import DocsCommand
 from .commands.execute_cmd import ExecuteCommand
 from .commands.interactive_cmd import InteractiveCommand
+from .plugin_loader import descubrir_plugins
 from .commands.modules_cmd import ModulesCommand
 from .commands.dependencias_cmd import DependenciasCommand
 from .commands.empaquetar_cmd import EmpaquetarCommand
@@ -36,6 +37,7 @@ def main(argv=None):
         EmpaquetarCommand(),
         InteractiveCommand(),
     ]
+    comandos.extend(descubrir_plugins())
 
     command_map = {}
     for cmd in comandos:

--- a/backend/src/cli/plugin_loader.py
+++ b/backend/src/cli/plugin_loader.py
@@ -1,0 +1,29 @@
+import logging
+from importlib.metadata import entry_points
+
+from .commands.base import BaseCommand
+
+
+class PluginCommand(BaseCommand):
+    """Clase base para comandos de plugins."""
+    pass
+
+
+def descubrir_plugins():
+    """Descubre e instancia los plugins registrados bajo ``cobra.plugins``."""
+    plugins = []
+    try:
+        eps = entry_points(group="cobra.plugins")
+    except TypeError:  # Compatibilidad con versiones antiguas
+        eps = entry_points().get("cobra.plugins", [])
+
+    for ep in eps:
+        try:
+            plugin_cls = ep.load()
+            if not issubclass(plugin_cls, PluginCommand):
+                logging.warning(f"El plugin {ep.name} no es PluginCommand")
+                continue
+            plugins.append(plugin_cls())
+        except Exception as exc:
+            logging.error(f"Error cargando plugin {ep.name}: {exc}")
+    return plugins

--- a/backend/src/tests/test_plugin_loader.py
+++ b/backend/src/tests/test_plugin_loader.py
@@ -1,0 +1,22 @@
+import importlib.metadata
+from unittest.mock import patch
+
+from src.cli.plugin_loader import descubrir_plugins, PluginCommand
+
+class DummyPlugin(PluginCommand):
+    name = "dummy"
+    def register_subparser(self, subparsers):
+        pass
+    def run(self, args):
+        pass
+
+def test_descubrir_plugins_carga_plugins():
+    ep = importlib.metadata.EntryPoint(
+        name="dummy",
+        value="src.tests.test_plugin_loader:DummyPlugin",
+        group="cobra.plugins",
+    )
+    with patch("src.cli.plugin_loader.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+        plugins = descubrir_plugins()
+    assert len(plugins) == 1
+    assert isinstance(plugins[0], DummyPlugin)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ setup(
         'console_scripts': [
             'cobra=src.cli.cli:main',
         ],
+        'cobra.plugins': [
+            # Se registrarán plugins externos aquí
+        ],
     },
 
     classifiers=[


### PR DESCRIPTION
## Summary
- add `plugin_loader` with `PluginCommand` and `descubrir_plugins`
- load discovered plugins in CLI
- expose plugin entry point group in setup.py
- describe how to create plugins in README
- test plugin discovery logic

## Testing
- `PYTHONPATH=backend pytest backend/src/tests/test_cli.py backend/src/tests/test_cli2.py backend/src/tests/test_cli_commands_extra.py backend/src/tests/test_cli_docs.py backend/src/tests/test_cli_empaquetar.py backend/src/tests/test_cli_dependencias.py backend/src/tests/test_plugin_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685809fb42708327815be6368965cb94