### PR TITLE
Add Jupyter kernel integration

### DIFF
--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -7,6 +7,7 @@ from .commands.compile_cmd import CompileCommand
 from .commands.docs_cmd import DocsCommand
 from .commands.execute_cmd import ExecuteCommand
 from .commands.interactive_cmd import InteractiveCommand
+from .commands.jupyter_cmd import JupyterCommand
 from .plugin_loader import descubrir_plugins
 from .commands.modules_cmd import ModulesCommand
 from .commands.dependencias_cmd import DependenciasCommand
@@ -35,6 +36,7 @@ def main(argv=None):
         DependenciasCommand(),
         DocsCommand(),
         EmpaquetarCommand(),
+        JupyterCommand(),
         InteractiveCommand(),
     ]
     comandos.extend(descubrir_plugins())

--- a/backend/src/cli/commands/jupyter_cmd.py
+++ b/backend/src/cli/commands/jupyter_cmd.py
@@ -1,0 +1,27 @@
+import subprocess
+import sys
+from .base import BaseCommand
+
+
+class JupyterCommand(BaseCommand):
+    """Lanza Jupyter Notebook con el kernel Cobra instalado."""
+
+    name = "jupyter"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help="Inicia Jupyter Notebook")
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        try:
+            subprocess.run([sys.executable, "-m", "cobra.jupyter_kernel", "install"], check=True)
+            subprocess.run([
+                "jupyter",
+                "notebook",
+                "--KernelManager.default_kernel_name=cobra",
+            ], check=True)
+            return 0
+        except subprocess.CalledProcessError as e:
+            print(f"Error lanzando Jupyter: {e}")
+            return 1

--- a/backend/src/cobra/__init__.py
+++ b/backend/src/cobra/__init__.py
@@ -1,0 +1,8 @@
+"""Paquete de compatibilidad para ejecutar módulos de Cobra."""
+import importlib
+import sys
+
+# Exponer jupyter_kernel desde el paquete raiz
+_jk = importlib.import_module('jupyter_kernel')
+sys.modules[__name__ + '.jupyter_kernel'] = _jk
+

--- a/backend/src/jupyter_kernel/__init__.py
+++ b/backend/src/jupyter_kernel/__init__.py
@@ -1,0 +1,81 @@
+import sys
+import io
+import contextlib
+from ipykernel.kernelbase import Kernel
+from src.core.lexer import Lexer
+from src.core.parser import Parser, PALABRAS_RESERVADAS
+from src.core.interpreter import InterpretadorCobra
+
+
+def install(user=True):
+    """Instala el kernel de Cobra para Jupyter."""
+    from ipykernel.kernelspec import install as ipy_install
+    return ipy_install(user=user, kernel_name="cobra", display_name="Cobra")
+
+
+class CobraKernel(Kernel):
+    implementation = "Cobra"
+    implementation_version = "0.1"
+    language = "cobra"
+    language_version = "0.1"
+    language_info = {
+        "name": "cobra",
+        "mimetype": "text/plain",
+        "file_extension": ".cobra",
+    }
+    banner = "Cobra kernel"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.interpreter = InterpretadorCobra()
+
+    def do_execute(self, code, silent, store_history=True, user_expressions=None, allow_stdin=False):
+        stdout = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(stdout):
+                tokens = Lexer(code).tokenizar()
+                ast = Parser(tokens).parsear()
+                result = self.interpreter.ejecutar_ast(ast)
+            output = stdout.getvalue()
+            if not silent:
+                if output:
+                    self.send_response(self.iopub_socket, "stream", {"name": "stdout", "text": output})
+                if result is not None and not output:
+                    self.send_response(self.iopub_socket, "execute_result", {
+                        "execution_count": self.execution_count,
+                        "data": {"text/plain": str(result)},
+                        "metadata": {},
+                    })
+            return {"status": "ok", "execution_count": self.execution_count, "payload": [], "user_expressions": {}}
+        except Exception as e:
+            if not silent:
+                self.send_response(self.iopub_socket, "stream", {"name": "stderr", "text": f"{e}\n"})
+            return {
+                "status": "error",
+                "execution_count": self.execution_count,
+                "ename": e.__class__.__name__,
+                "evalue": str(e),
+                "traceback": [],
+            }
+
+    def do_complete(self, code, cursor_pos):
+        prefix = code[:cursor_pos].split()[-1]
+        matches = [w for w in PALABRAS_RESERVADAS if w.startswith(prefix)]
+        matches += [n for n in self.interpreter.variables.keys() if isinstance(n, str) and n.startswith(prefix)]
+        start = cursor_pos - len(prefix)
+        return {
+            "matches": matches,
+            "cursor_start": start,
+            "cursor_end": cursor_pos,
+            "metadata": {},
+            "status": "ok",
+        }
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "install":
+        install()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/src/tests/test_cli_jupyter.py
+++ b/backend/src/tests/test_cli_jupyter.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch, call
+import sys
+from src.cli.cli import main
+
+
+def test_cli_jupyter_installs_kernel():
+    with patch("subprocess.run") as mock_run:
+        main(["jupyter"])
+        mock_run.assert_has_calls([
+            call([sys.executable, "-m", "cobra.jupyter_kernel", "install"], check=True),
+            call([
+                "jupyter",
+                "notebook",
+                "--KernelManager.default_kernel_name=cobra",
+            ], check=True),
+        ])

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -24,6 +24,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    validador
    modo_seguro
    empaquetar
+   jupyter
    api/modules
 
 Introducción

--- a/frontend/docs/jupyter.rst
+++ b/frontend/docs/jupyter.rst
@@ -1,0 +1,14 @@
+Uso del kernel Jupyter
+======================
+
+Para ejecutar código Cobra en Jupyter Notebook primero instala el kernel:
+
+.. code-block:: bash
+
+   python -m cobra.jupyter_kernel install
+
+Una vez instalado puedes lanzar el cuaderno con:
+
+.. code-block:: bash
+
+   cobra jupyter

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ requests==2.32.0                 # Para realizar peticiones HTTP (si es necesari
 sphinx==7.2.6                     # Para generar documentación
 sphinx-rtd-theme==1.3.0           # Tema por defecto de la documentación
 pdoc==15.0.4                      # Generador de documentación de la API
+ipykernel==6.29.5

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'tensorflow>=2.6.0',
         'dask>=2021.09.0',
         'DEAP>=1.3.1',
+        'ipykernel>=6.0.0',
         # Agrega más requisitos según sea necesario
     ],
     tests_require=[


### PR DESCRIPTION
## Summary
- implement CobraKernel based on ipykernel
- alias module cobra.jupyter_kernel to new package
- add `cobra jupyter` command to launch Jupyter Notebook
- document kernel installation and use
- require `ipykernel`
- tests for new command

## Testing
- `pytest backend/src/tests/test_cli_jupyter.py -q`
- `pytest -q` *(fails: KeyboardInterrupt after success)*

------
https://chatgpt.com/codex/tasks/task_e_68580e0880688327b319baf02936d72f