### PR TITLE
Implement YAML module mapping for transpilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,24 @@ imprimir(saludo)
 
 Al ejecutar `programa.cobra`, se procesará primero `modulo.cobra` y luego se imprimirá `Hola desde módulo`.
 
+## Archivo de mapeo de módulos
+
+Los transpiladores consultan `module_map.yaml` para resolver las importaciones.
+Este archivo sigue un esquema YAML sencillo donde cada clave es la ruta del
+módulo Cobra y sus valores indican las rutas de los archivos generados.
+
+Ejemplo de formato:
+
+```yaml
+modulo.cobra:
+  python: modulo.py
+  js: modulo.js
+```
+
+Si una entrada no se encuentra, el transpilador cargará directamente el archivo
+indicada en la instrucción `import`. Para añadir o modificar rutas basta con
+editar `module_map.yaml` y volver a ejecutar las pruebas.
+
 ## Ejemplo de concurrencia
 
 Es posible lanzar funciones en hilos con la palabra clave `hilo`:

--- a/backend/src/cobra/transpilers/module_map.py
+++ b/backend/src/cobra/transpilers/module_map.py
@@ -1,0 +1,22 @@
+import os
+import yaml
+
+MODULE_MAP_PATH = os.environ.get(
+    'COBRA_MODULE_MAP',
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'module_map.yaml')
+    ),
+)
+
+_cache = None
+
+def get_map():
+    global _cache
+    if _cache is None:
+        if os.path.exists(MODULE_MAP_PATH):
+            with open(MODULE_MAP_PATH, 'r', encoding='utf-8') as f:
+                data = yaml.safe_load(f) or {}
+        else:
+            data = {}
+        _cache = data
+    return _cache

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/importar.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/importar.py
@@ -1,16 +1,23 @@
 from src.cobra.lexico.lexer import Lexer
 from src.cobra.parser.parser import Parser
+from ...module_map import get_map
 
 def visit_import(self, nodo):
-    """Carga y transpila el módulo indicado."""
+    """Carga y transpila el módulo indicado usando el mapeo."""
+    mapa = get_map()
+    ruta = mapa.get(nodo.ruta, {}).get("js", nodo.ruta)
+
     try:
-        with open(nodo.ruta, "r", encoding="utf-8") as f:
+        with open(ruta, "r", encoding="utf-8") as f:
             codigo = f.read()
     except FileNotFoundError:
-        raise FileNotFoundError(f"Módulo no encontrado: {nodo.ruta}")
+        raise FileNotFoundError(f"Módulo no encontrado: {ruta}")
 
-    lexer = Lexer(codigo)
-    tokens = lexer.analizar_token()
-    ast = Parser(tokens).parsear()
-    for subnodo in ast:
-        subnodo.aceptar(self)
+    if ruta.endswith(".cobra"):
+        lexer = Lexer(codigo)
+        tokens = lexer.analizar_token()
+        ast = Parser(tokens).parsear()
+        for subnodo in ast:
+            subnodo.aceptar(self)
+    else:
+        self.codigo.extend(codigo.splitlines())

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/importar.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/importar.py
@@ -1,17 +1,24 @@
 from src.cobra.lexico.lexer import Lexer
 from src.cobra.parser.parser import Parser
+from ...module_map import get_map
 
 
 def visit_import(self, nodo):
-    """Transpila una declaración de importación cargando y procesando el módulo."""
+    """Transpila una declaración de importación consultando el mapeo."""
+    mapa = get_map()
+    ruta = mapa.get(nodo.ruta, {}).get("python", nodo.ruta)
+
     try:
-        with open(nodo.ruta, "r", encoding="utf-8") as f:
+        with open(ruta, "r", encoding="utf-8") as f:
             codigo = f.read()
     except FileNotFoundError:
-        raise FileNotFoundError(f"Módulo no encontrado: {nodo.ruta}")
+        raise FileNotFoundError(f"Módulo no encontrado: {ruta}")
 
-    lexer = Lexer(codigo)
-    tokens = lexer.analizar_token()
-    ast = Parser(tokens).parsear()
-    for subnodo in ast:
-        subnodo.aceptar(self)
+    if ruta.endswith(".cobra"):
+        lexer = Lexer(codigo)
+        tokens = lexer.analizar_token()
+        ast = Parser(tokens).parsear()
+        for subnodo in ast:
+            subnodo.aceptar(self)
+    else:
+        self.codigo += codigo + "\n"

--- a/backend/src/tests/test_module_map.py
+++ b/backend/src/tests/test_module_map.py
@@ -1,0 +1,59 @@
+import yaml
+from unittest.mock import patch
+
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from src.cobra.transpilers import module_map
+
+
+def test_transpilador_mapeo_python(tmp_path, monkeypatch):
+    mod = tmp_path / "m.cobra"
+    mod.write_text("var x = 1")
+    py_out = tmp_path / "m.py"
+    py_out.write_text("x = 1\n")
+
+    mapping = {str(mod): {"python": str(py_out)}}
+    mapfile = tmp_path / "map.yaml"
+    mapfile.write_text(yaml.safe_dump(mapping))
+
+    monkeypatch.setenv("COBRA_MODULE_MAP", str(mapfile))
+    module_map._cache = None
+
+    codigo = f"import '{mod}'\nimprimir(x)"
+    tokens = Lexer(codigo).analizar_token()
+    ast = Parser(tokens).parsear()
+
+    resultado = TranspiladorPython().transpilar(ast)
+    esperado = f"from src.core.nativos import *\n{py_out.read_text()}print(x)\n"
+    assert resultado == esperado
+
+
+def test_transpilador_mapeo_js(tmp_path, monkeypatch):
+    mod = tmp_path / "m.cobra"
+    mod.write_text("var x = 2")
+    js_out = tmp_path / "m.js"
+    js_out.write_text("let x = 2;\n")
+
+    mapping = {str(mod): {"js": str(js_out)}}
+    mapfile = tmp_path / "map.yaml"
+    mapfile.write_text(yaml.safe_dump(mapping))
+
+    monkeypatch.setenv("COBRA_MODULE_MAP", str(mapfile))
+    module_map._cache = None
+
+    codigo = f"import '{mod}'\nimprimir(x)"
+    tokens = Lexer(codigo).analizar_token()
+    ast = Parser(tokens).parsear()
+
+    resultado = TranspiladorJavaScript().transpilar(ast)
+    esperado = (
+        "import * as io from './nativos/io.js';\n"
+        "import * as net from './nativos/io.js';\n"
+        "import * as matematicas from './nativos/matematicas.js';\n"
+        "import { Pila, Cola } from './nativos/estructuras.js';\n"
+        "let x = 2;\n"
+        "console.log(x);"
+    )
+    assert resultado == esperado

--- a/module_map.yaml
+++ b/module_map.yaml
@@ -1,0 +1,8 @@
+# Mapeo de módulos Cobra a archivos transpilados
+# La clave es la ruta usada en la instrucción `import`.
+# Cada entrada puede especificar rutas para los archivos generados en Python o JavaScript.
+# Por ejemplo:
+#   modulo.cobra:
+#     python: modulo.py
+#     js: modulo.js
+{}

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ sphinx==7.2.6                     # Para generar documentación
 sphinx-rtd-theme==1.3.0           # Tema por defecto de la documentación
 pdoc==15.0.4                      # Generador de documentación de la API
 ipykernel==6.29.5
+PyYAML==6.0.1


### PR DESCRIPTION
## Summary
- add `module_map.yaml` to map Cobra modules to Python/JS outputs
- load mapping in new helper `module_map.py`
- modify transpilers to read this mapping when importing
- document YAML file usage in README
- include dependency `PyYAML`
- add tests for mapping logic

## Testing
- `pytest backend/src/tests/test_module_map.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582d38466c83279f6315aa8ef5a794