### PR TITLE
Add 'usar' instruction support

### DIFF
--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -34,6 +34,7 @@ class TipoToken:
     MIENTRAS = 'MIENTRAS'
     PARA = 'PARA'
     IMPORT = 'IMPORT'
+    USAR = 'USAR'
     HOLOBIT = 'HOLOBIT'
     PROYECTAR = 'PROYECTAR'
     TRANSFORMAR = 'TRANSFORMAR'
@@ -111,6 +112,7 @@ class Lexer:
             (TipoToken.MIENTRAS, r'\bmientras\b'),
             (TipoToken.PARA, r'\bpara\b'),
             (TipoToken.IMPORT, r'\bimport\b'),
+            (TipoToken.USAR, r'\busar\b'),
             (TipoToken.HILO, r'\bhilo\b'),
             (TipoToken.IN, r'\bin\b'),  # Define el token 'in'
             (TipoToken.HOLOBIT, r'\bholobit\b'),

--- a/backend/src/cobra/parser/parser.py
+++ b/backend/src/cobra/parser/parser.py
@@ -22,6 +22,7 @@ from src.core.ast_nodes import (
     NodoTryCatch,
     NodoThrow,
     NodoImport,
+    NodoUsar,
 )
 
 # Palabras reservadas que no pueden usarse como identificadores
@@ -46,6 +47,7 @@ PALABRAS_RESERVADAS = {
     "proyectar",
     "transformar",
     "graficar",
+    "usar",
 }
 
 
@@ -69,6 +71,7 @@ class Parser:
             TipoToken.MIENTRAS: self.declaracion_mientras,
             TipoToken.FUNC: self.declaracion_funcion,
             TipoToken.IMPORT: self.declaracion_import,
+            TipoToken.USAR: self.declaracion_usar,
             TipoToken.IMPRIMIR: self.declaracion_imprimir,
             TipoToken.HILO: self.declaracion_hilo,
             TipoToken.TRY: self.declaracion_try_catch,
@@ -417,6 +420,15 @@ class Parser:
         ruta = self.token_actual().valor
         self.comer(TipoToken.CADENA)
         return NodoImport(ruta)
+
+    def declaracion_usar(self):
+        """Parsea una declaración 'usar' para importar módulos."""
+        self.comer(TipoToken.USAR)
+        if self.token_actual().tipo != TipoToken.CADENA:
+            raise SyntaxError("Se esperaba una ruta de módulo entre comillas")
+        ruta = self.token_actual().valor
+        self.comer(TipoToken.CADENA)
+        return NodoUsar(ruta)
 
     def declaracion_hilo(self):
         """Parsea la creación de un hilo que ejecuta una función."""

--- a/backend/src/core/__init__.py
+++ b/backend/src/core/__init__.py
@@ -33,6 +33,7 @@ __all__ = [
     'NodoThrow',
     'NodoTryCatch',
     'NodoImport',
+    'NodoUsar',
     'NodoPara',
     'NodoImprimir',
     'NodeVisitor',

--- a/backend/src/core/ast_nodes.py
+++ b/backend/src/core/ast_nodes.py
@@ -247,6 +247,13 @@ class NodoImport(NodoAST):
 
 
 @dataclass
+class NodoUsar(NodoAST):
+    modulo: str
+
+    """Instrucción para usar un módulo especificado."""
+
+
+@dataclass
 class NodoPara(NodoAST):
     variable: Any
     iterable: Any
@@ -295,6 +302,7 @@ __all__ = [
     'NodoThrow',
     'NodoTryCatch',
     'NodoImport',
+    'NodoUsar',
     'NodoPara',
     'NodoImprimir',
 ]


### PR DESCRIPTION
## Summary
- extend lexer with `USAR` token
- parse `usar` statements and map to new `NodoUsar`
- expose `NodoUsar` from AST modules

## Testing
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6858332d32348327b1fc165f0305e654