### PR TITLE
Implementación de 'usar' con instalación dinámica

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ El proyecto se organiza en las siguientes carpetas y módulos:
 - Transpiladores a Python y JavaScript: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
 - Soporte de Estructuras Avanzadas: Permite la declaración de variables, funciones, clases, listas y diccionarios, así como el uso de bucles y condicionales.
 - Módulos nativos con funciones de E/S, utilidades matemáticas y estructuras de datos para usar directamente desde Cobra.
+- Instalación de paquetes en tiempo de ejecución mediante la instrucción `usar`.
 - Manejo de Errores: El sistema captura y reporta errores de sintaxis, facilitando la depuración.
 - Visualización y Depuración: Salida detallada de tokens, AST y errores de sintaxis para un desarrollo más sencillo.
 - Ejemplos de Código y Documentación: Ejemplos prácticos que ilustran el uso del lexer, parser y transpiladores.
@@ -156,6 +157,13 @@ imprimir(saludo)
 ````
 
 Al ejecutar `programa.cobra`, se procesará primero `modulo.cobra` y luego se imprimirá `Hola desde módulo`.
+
+## Instrucción `usar` para dependencias dinámicas
+
+La sentencia `usar "paquete"` intenta importar un módulo de Python. Si el
+paquete no está disponible, Cobra ejecutará `pip install paquete` para
+instalarlo y luego lo cargará en tiempo de ejecución. El módulo queda
+registrado en el entorno bajo el mismo nombre para su uso posterior.
 
 ## Archivo de mapeo de módulos
 

--- a/backend/src/cobra/usar_loader.py
+++ b/backend/src/cobra/usar_loader.py
@@ -1,0 +1,22 @@
+import importlib
+import subprocess
+
+
+def obtener_modulo(nombre: str):
+    """Importa y devuelve un módulo. Si no está instalado intenta
+    instalarlo usando pip y lo importa nuevamente.
+    """
+    try:
+        return importlib.import_module(nombre)
+    except ModuleNotFoundError:
+        print(f"Paquete '{nombre}' no encontrado. Instalando...")
+        try:
+            subprocess.run(["pip", "install", nombre], check=True)
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(f"Fallo al instalar '{nombre}': {exc}") from exc
+        try:
+            return importlib.import_module(nombre)
+        except ModuleNotFoundError as exc:
+            raise ImportError(
+                f"No se pudo importar el módulo '{nombre}' tras la instalación"
+            ) from exc

--- a/backend/src/core/interpreter.py
+++ b/backend/src/core/interpreter.py
@@ -25,6 +25,7 @@ from src.core.ast_nodes import (
     NodoTryCatch,
     NodoThrow,
     NodoImport,
+    NodoUsar,
 )
 from src.cobra.parser.parser import Parser
 from src.core.memoria.gestor_memoria import GestorMemoriaGenetico
@@ -156,6 +157,8 @@ class InterpretadorCobra:
                 print(valor)
         elif isinstance(nodo, NodoImport):
             return self.ejecutar_import(nodo)
+        elif isinstance(nodo, NodoUsar):
+            return self.ejecutar_usar(nodo)
         elif isinstance(nodo, NodoTryCatch):
             return self.ejecutar_try_catch(nodo)
         elif isinstance(nodo, NodoThrow):
@@ -408,6 +411,16 @@ class InterpretadorCobra:
             resultado = self.ejecutar_nodo(subnodo)
             if resultado is not None:
                 return resultado
+
+    def ejecutar_usar(self, nodo):
+        """Importa un módulo de Python instalándolo si es necesario."""
+        from src.cobra.usar_loader import obtener_modulo
+
+        try:
+            modulo = obtener_modulo(nodo.modulo)
+            self.variables[nodo.modulo] = modulo
+        except Exception as exc:
+            print(f"Error al usar el módulo '{nodo.modulo}': {exc}")
 
     def ejecutar_holobit(self, nodo):
         """Simula la ejecución de un holobit y devuelve sus valores."""

--- a/backend/src/tests/test_usar.py
+++ b/backend/src/tests/test_usar.py
@@ -1,0 +1,27 @@
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+from src.core.interpreter import InterpretadorCobra
+from src.core.ast_nodes import NodoUsar
+from src.cobra import usar_loader
+
+
+def test_obtener_modulo_instala_si_no_existe():
+    mock_mod = ModuleType('demo')
+    with patch.object(usar_loader.importlib, 'import_module', side_effect=[ModuleNotFoundError(), mock_mod]) as mock_import, \
+         patch.object(usar_loader.subprocess, 'run') as mock_run:
+        mock_run.return_value.returncode = 0
+        mod = usar_loader.obtener_modulo('demo')
+    mock_run.assert_called_once_with(['pip', 'install', 'demo'], check=True)
+    assert mod is mock_mod
+
+
+@pytest.mark.timeout(5)
+def test_interpreter_usar_registra_modulo(monkeypatch):
+    mod = ModuleType('math')
+    monkeypatch.setattr(usar_loader, 'obtener_modulo', lambda name: mod)
+    interp = InterpretadorCobra()
+    interp.ejecutar_nodo(NodoUsar('math'))
+    assert interp.variables['math'] is mod


### PR DESCRIPTION
## Summary
- add `usar_loader` to cargar módulos e instalarlos con pip si es necesario
- soportar nodo `NodoUsar` en el intérprete
- documentar la instrucción `usar` en el README
- pruebas unitarias para el loader y el intérprete

## Testing
- `pytest backend/src/tests/test_usar.py -q`
- `pytest backend/src/tests/test_interpreter.py::test_interpretador_asignacion_y_llamada_funcion -q`
- `pytest backend/src/tests/test_import.py::test_import_interpreter -q`
- `pytest backend/src/tests/test_cli_dependencias.py::test_cli_dependencias_instalar_invoca_pip -q`


------
https://chatgpt.com/codex/tasks/task_e_685834c74d0083278b6bb91f448e17a0