### PR TITLE
Add Python transpiler support for 'usar' with tests

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/python_nodes/usar.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/usar.py
@@ -1,0 +1,11 @@
+from src.cobra.usar_loader import obtener_modulo
+
+
+def visit_usar(self, nodo):
+    """Genera el código para la instrucción ``usar``."""
+
+    ind = self.obtener_indentacion()
+    self.codigo += (
+        f"{ind}from src.cobra.usar_loader import obtener_modulo\n"
+        f"{ind}{nodo.modulo} = obtener_modulo('{nodo.modulo}')\n"
+    )

--- a/backend/src/cobra/transpilers/transpiler/to_python.py
+++ b/backend/src/cobra/transpilers/transpiler/to_python.py
@@ -41,6 +41,7 @@ from .python_nodes.metodo import visit_metodo as _visit_metodo
 from .python_nodes.try_catch import visit_try_catch as _visit_try_catch
 from .python_nodes.throw import visit_throw as _visit_throw
 from .python_nodes.importar import visit_import as _visit_import
+from .python_nodes.usar import visit_usar as _visit_usar
 from .python_nodes.hilo import visit_hilo as _visit_hilo
 from .python_nodes.instancia import visit_instancia as _visit_instancia
 from .python_nodes.atributo import visit_atributo as _visit_atributo
@@ -158,6 +159,7 @@ TranspiladorPython.visit_metodo = _visit_metodo
 TranspiladorPython.visit_try_catch = _visit_try_catch
 TranspiladorPython.visit_throw = _visit_throw
 TranspiladorPython.visit_import = _visit_import
+TranspiladorPython.visit_usar = _visit_usar
 TranspiladorPython.visit_hilo = _visit_hilo
 TranspiladorPython.visit_instancia = _visit_instancia
 TranspiladorPython.visit_atributo = _visit_atributo

--- a/backend/src/tests/test_to_python_extras.py
+++ b/backend/src/tests/test_to_python_extras.py
@@ -1,0 +1,45 @@
+import pytest
+from src.core.ast_nodes import (
+    NodoTryCatch,
+    NodoThrow,
+    NodoImprimir,
+    NodoIdentificador,
+    NodoValor,
+    NodoImport,
+    NodoUsar,
+)
+from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+
+
+def test_transpilar_try_catch_throw():
+    nodo = NodoTryCatch(
+        [NodoThrow(NodoValor("1"))],
+        "e",
+        [NodoImprimir(NodoIdentificador("e"))],
+    )
+    codigo = TranspiladorPython().transpilar([nodo])
+    esperado = (
+        "from src.core.nativos import *\n"
+        "try:\n    raise Exception(1)\nexcept Exception as e:\n    print(e)\n"
+    )
+    assert codigo == esperado
+
+
+def test_transpilar_import(tmp_path):
+    mod = tmp_path / "mod.cobra"
+    mod.write_text("var dato = 5")
+    nodo = NodoImport(str(mod))
+    codigo = TranspiladorPython().transpilar([nodo])
+    esperado = "from src.core.nativos import *\ndato = 5\n"
+    assert codigo == esperado
+
+
+def test_transpilar_usar():
+    nodo = NodoUsar("math")
+    codigo = TranspiladorPython().transpilar([nodo])
+    esperado = (
+        "from src.core.nativos import *\n"
+        "from src.cobra.usar_loader import obtener_modulo\n"
+        "math = obtener_modulo('math')\n"
+    )
+    assert codigo == esperado


### PR DESCRIPTION
## Summary
- support `NodoUsar` in TranspiladorPython
- cover `NodoTryCatch`, `NodoThrow`, `NodoImport` and `NodoUsar` in new tests

## Testing
- `pytest -q` *(fails: AttributeError/NameError in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68590bde3b0883279a36c3d0707d94e3