### PR TITLE
Add docs for transpiler usage

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -60,6 +60,32 @@ imprimir('principal')
 - Compila a Python o JavaScript con `cobra compilar archivo.cobra --tipo python`.
 - Ejecuta directamente con `cobra ejecutar archivo.cobra`.
 
+### Ejemplo de transpilación a Python
+
+```bash
+cobra compilar ejemplo.cobra --tipo python
+```
+
+Si prefieres usar las clases del proyecto, llama al módulo
+[`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler)
+de la siguiente forma:
+
+```python
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.parser.parser import Parser
+
+codigo = "imprimir('hola')"
+parser = Parser(codigo)
+arbol = parser.parsear()
+print(TranspiladorPython().transpilar(arbol))
+```
+
+### Características aún no soportadas
+
+- Decoradores y generadores de Python.
+- Herencia múltiple en clases.
+- Macros o metaprogramación avanzada.
+
 ## 7. Modo seguro
 
 - Añade `--seguro` para evitar operaciones peligrosas como `leer_archivo` o `hilo`.

--- a/README.md
+++ b/README.md
@@ -186,8 +186,31 @@ modulo.cobra:
 ```
 
 Si una entrada no se encuentra, el transpilador cargará directamente el archivo
-indicada en la instrucción `import`. Para añadir o modificar rutas basta con
+indicado en la instrucción `import`. Para añadir o modificar rutas basta con
 editar `cobra.mod` y volver a ejecutar las pruebas.
+
+## Invocar el transpilador
+
+La carpeta [`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler)
+contiene la implementación de los transpiladores a Python y JavaScript. Una vez
+instaladas las dependencias, puedes llamar al transpilador desde tu propio
+script de la siguiente manera:
+
+```python
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.parser.parser import Parser
+
+codigo = "imprimir('hola')"
+parser = Parser(codigo)
+arbol = parser.parsear()
+transpiler = TranspiladorPython()
+resultado = transpiler.transpilar(arbol)
+print(resultado)
+```
+
+Requiere tener instalado el paquete en modo editable y todas las dependencias
+de `requirements.txt`. Si necesitas generar archivos a partir de módulos Cobra,
+consulta el mapeo definido en `cobra.mod`.
 
 ## Ejemplo de concurrencia
 


### PR DESCRIPTION
## Summary
- explain how to call the transpiler from Python in README
- add simple transpilation example in MANUAL_COBRA

## Testing
- `pytest backend/src/tests` *(fails: AttributeError errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859145365a48327b9154a80ed6b95fe