### PR TITLE
Implementa extensión .co y comando crear

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -34,11 +34,11 @@ mientras x < 3 :
 
 ## 4. Trabajar con módulos
 
-- Usa `import` para cargar archivos `.cobra` o módulos nativos.
+- Usa `import` para cargar archivos `.co` o módulos nativos.
 - Los módulos nativos ofrecen funciones de E/S y estructuras de datos.
 
 ```cobra
-import 'modulo.cobra'
+import 'modulo.co'
 imprimir(saludo)
 ```
 
@@ -57,13 +57,13 @@ imprimir('principal')
 
 ## 6. Transpilación y ejecución
 
-- Compila a Python o JavaScript con `cobra compilar archivo.cobra --tipo python`.
-- Ejecuta directamente con `cobra ejecutar archivo.cobra`.
+- Compila a Python o JavaScript con `cobra compilar archivo.co --tipo python`.
+- Ejecuta directamente con `cobra ejecutar archivo.co`.
 
 ### Ejemplo de transpilación a Python
 
 ```bash
-cobra compilar ejemplo.cobra --tipo python
+cobra compilar ejemplo.co --tipo python
 ```
 
 Si prefieres usar las clases del proyecto, llama al módulo
@@ -91,7 +91,7 @@ print(TranspiladorPython().transpilar(arbol))
 - Añade `--seguro` para evitar operaciones peligrosas como `leer_archivo` o `hilo`.
 
 ```bash
-cobra ejecutar programa.cobra --seguro
+cobra ejecutar programa.co --seguro
 ```
 
 ## 8. Próximos pasos

--- a/README.md
+++ b/README.md
@@ -154,15 +154,15 @@ Al transpilar a Python, `imprimir` se convierte en `print`, `mientras` en `while
 Puedes dividir el código en varios archivos y cargarlos con `import`:
 
 ````cobra
-# modulo.cobra
+# modulo.co
 var saludo = 'Hola desde módulo'
 
-# programa.cobra
-import 'modulo.cobra'
+# programa.co
+import 'modulo.co'
 imprimir(saludo)
 ````
 
-Al ejecutar `programa.cobra`, se procesará primero `modulo.cobra` y luego se imprimirá `Hola desde módulo`.
+Al ejecutar `programa.co`, se procesará primero `modulo.co` y luego se imprimirá `Hola desde módulo`.
 
 ## Instrucción `usar` para dependencias dinámicas
 
@@ -180,7 +180,7 @@ módulo Cobra y sus valores indican las rutas de los archivos generados.
 Ejemplo de formato:
 
 ```yaml
-modulo.cobra:
+modulo.co:
   python: modulo.py
   js: modulo.js
 ```
@@ -233,15 +233,15 @@ Una vez instalado el paquete, la herramienta `cobra` ofrece varios subcomandos:
 
 ```bash
 # Compilar un archivo a Python o JavaScript
-cobra compilar programa.cobra --tipo python
+cobra compilar programa.co --tipo python
 
 # Ejecutar directamente un script Cobra
-cobra ejecutar programa.cobra --depurar --formatear
+cobra ejecutar programa.co --depurar --formatear
 
 # Gestionar módulos instalados
 cobra modulos listar
-cobra modulos instalar ruta/al/modulo.cobra
-cobra modulos remover modulo.cobra
+cobra modulos instalar ruta/al/modulo.co
+cobra modulos remover modulo.co
 # Generar documentación HTML y API
 cobra docs
 # Crear un ejecutable independiente
@@ -283,11 +283,11 @@ de error.
 ### Ejemplos de subcomandos
 
 ````bash
-cobra compilar programa.cobra --tipo=python
+cobra compilar programa.co --tipo=python
 echo $?  # 0 al compilar sin problemas
 
-cobra ejecutar inexistente.cobra
-# El archivo 'inexistente.cobra' no existe
+cobra ejecutar inexistente.co
+# El archivo 'inexistente.co' no existe
 echo $?  # 1
 ````
 

--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -12,6 +12,7 @@ from .plugin_loader import descubrir_plugins
 from .commands.modules_cmd import ModulesCommand
 from .commands.dependencias_cmd import DependenciasCommand
 from .commands.empaquetar_cmd import EmpaquetarCommand
+from .commands.crear_cmd import CrearCommand
 
 # La configuración de logging solo debe activarse cuando la CLI se ejecuta
 # directamente para evitar modificar la configuración global al importar este
@@ -36,6 +37,7 @@ def main(argv=None):
         DependenciasCommand(),
         DocsCommand(),
         EmpaquetarCommand(),
+        CrearCommand(),
         JupyterCommand(),
         InteractiveCommand(),
     ]

--- a/backend/src/cli/commands/crear_cmd.py
+++ b/backend/src/cli/commands/crear_cmd.py
@@ -1,0 +1,57 @@
+import os
+from .base import BaseCommand
+
+
+class CrearCommand(BaseCommand):
+    """Crea archivos o proyectos Cobra con extensión .co."""
+
+    name = "crear"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help="Crea archivos o proyectos")
+        sub = parser.add_subparsers(dest="accion")
+        arch = sub.add_parser("archivo", help="Crea un archivo .co")
+        arch.add_argument("ruta")
+        carp = sub.add_parser("carpeta", help="Crea una carpeta")
+        carp.add_argument("ruta")
+        proy = sub.add_parser("proyecto", help="Crea un proyecto básico")
+        proy.add_argument("ruta")
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        accion = args.accion
+        if accion == "archivo":
+            return self._crear_archivo(args.ruta)
+        elif accion == "carpeta":
+            return self._crear_carpeta(args.ruta)
+        elif accion == "proyecto":
+            return self._crear_proyecto(args.ruta)
+        else:
+            print("Acción no reconocida")
+            return 1
+
+    @staticmethod
+    def _crear_archivo(ruta):
+        if not ruta.endswith(".co"):
+            ruta += ".co"
+        os.makedirs(os.path.dirname(ruta) or ".", exist_ok=True)
+        with open(ruta, "w", encoding="utf-8"):
+            pass
+        print(f"Archivo creado: {ruta}")
+        return 0
+
+    @staticmethod
+    def _crear_carpeta(ruta):
+        os.makedirs(ruta, exist_ok=True)
+        print(f"Carpeta creada: {ruta}")
+        return 0
+
+    @staticmethod
+    def _crear_proyecto(ruta):
+        os.makedirs(ruta, exist_ok=True)
+        main = os.path.join(ruta, "main.co")
+        with open(main, "w", encoding="utf-8"):
+            pass
+        print(f"Proyecto Cobra creado en {ruta}")
+        return 0

--- a/backend/src/cli/commands/modules_cmd.py
+++ b/backend/src/cli/commands/modules_cmd.py
@@ -36,7 +36,7 @@ class ModulesCommand(BaseCommand):
 
     @staticmethod
     def _listar_modulos():
-        mods = [f for f in os.listdir(MODULES_PATH) if f.endswith(".cobra")]
+        mods = [f for f in os.listdir(MODULES_PATH) if f.endswith(".co")]
         if not mods:
             print("No hay módulos instalados")
         else:

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/importar.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/importar.py
@@ -13,7 +13,7 @@ def visit_import(self, nodo):
     except FileNotFoundError:
         raise FileNotFoundError(f"Módulo no encontrado: {ruta}")
 
-    if ruta.endswith(".cobra"):
+    if ruta.endswith(".co"):
         lexer = Lexer(codigo)
         tokens = lexer.analizar_token()
         ast = Parser(tokens).parsear()

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/importar.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/importar.py
@@ -14,7 +14,7 @@ def visit_import(self, nodo):
     except FileNotFoundError:
         raise FileNotFoundError(f"Módulo no encontrado: {ruta}")
 
-    if ruta.endswith(".cobra"):
+    if ruta.endswith(".co"):
         lexer = Lexer(codigo)
         tokens = lexer.analizar_token()
         ast = Parser(tokens).parsear()

--- a/backend/src/jupyter_kernel/__init__.py
+++ b/backend/src/jupyter_kernel/__init__.py
@@ -21,7 +21,7 @@ class CobraKernel(Kernel):
     language_info = {
         "name": "cobra",
         "mimetype": "text/plain",
-        "file_extension": ".cobra",
+        "file_extension": ".co",
     }
     banner = "Cobra kernel"
 

--- a/backend/src/tests/test_cli_commands_extra.py
+++ b/backend/src/tests/test_cli_commands_extra.py
@@ -32,7 +32,7 @@ from src.cli.commands import modules_cmd
     ],
 )
 def test_cli_compilar_generates_output(tmp_path, tipo, esperado):
-    archivo = tmp_path / "c.cobra"
+    archivo = tmp_path / "c.co"
     archivo.write_text("var x = 5")
     with patch("sys.stdout", new_callable=StringIO) as out:
         main(["compilar", str(archivo), f"--tipo={tipo}"])
@@ -42,7 +42,7 @@ def test_cli_compilar_generates_output(tmp_path, tipo, esperado):
 
 @pytest.mark.timeout(5)
 def test_cli_compilar_archivo_inexistente(tmp_path):
-    archivo = tmp_path / "no.cobra"
+    archivo = tmp_path / "no.co"
     with patch("sys.stdout", new_callable=StringIO) as out:
         main(["compilar", str(archivo)])
     assert f"Error: El archivo '{archivo}' no existe." == out.getvalue().strip()
@@ -50,7 +50,7 @@ def test_cli_compilar_archivo_inexistente(tmp_path):
 
 @pytest.mark.timeout(5)
 def test_cli_ejecutar_imprime(tmp_path):
-    archivo = tmp_path / "p.cobra"
+    archivo = tmp_path / "p.co"
     archivo.write_text("var x = 3\nimprimir(x)")
     with patch("sys.stdout", new_callable=StringIO) as out:
         main(["ejecutar", str(archivo)])
@@ -59,7 +59,7 @@ def test_cli_ejecutar_imprime(tmp_path):
 
 @pytest.mark.timeout(5)
 def test_cli_ejecutar_flag_seguro(tmp_path):
-    archivo = tmp_path / "p.cobra"
+    archivo = tmp_path / "p.co"
     archivo.write_text("imprimir(1)")
     with patch("src.cli.commands.execute_cmd.InterpretadorCobra") as mock_interp:
         main(["--seguro", "ejecutar", str(archivo)])
@@ -73,7 +73,7 @@ def test_cli_modulos_comandos(tmp_path, monkeypatch):
     mods_dir.mkdir()
     monkeypatch.setattr(modules_cmd, "MODULES_PATH", str(mods_dir))
 
-    modulo = tmp_path / "m.cobra"
+    modulo = tmp_path / "m.co"
     modulo.write_text("var d = 1")
 
     with patch("sys.stdout", new_callable=StringIO) as out:
@@ -98,3 +98,20 @@ def test_cli_modulos_comandos(tmp_path, monkeypatch):
     with patch("sys.stdout", new_callable=StringIO) as out:
         main(["modulos", "listar"])
     assert out.getvalue().strip() == "No hay módulos instalados"
+
+@pytest.mark.timeout(5)
+def test_cli_crear_archivo(tmp_path):
+    ruta = tmp_path / "nuevo"
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["crear", "archivo", str(ruta)])
+    assert (tmp_path / "nuevo.co").exists()
+    assert out.getvalue().strip() == f"Archivo creado: {ruta}.co"
+
+
+@pytest.mark.timeout(5)
+def test_cli_crear_proyecto(tmp_path):
+    ruta = tmp_path / "proj"
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["crear", "proyecto", str(ruta)])
+    assert (ruta / "main.co").exists()
+    assert "Proyecto Cobra creado" in out.getvalue()

--- a/backend/src/tests/test_cli_exit_codes.py
+++ b/backend/src/tests/test_cli_exit_codes.py
@@ -16,14 +16,14 @@ def _run_sys_exit(args):
 
 @pytest.mark.timeout(5)
 def test_exit_code_compile_missing(tmp_path):
-    archivo = tmp_path / "no.cobra"
+    archivo = tmp_path / "no.co"
     code = _run_sys_exit(["compilar", str(archivo)])
     assert code != 0
 
 
 @pytest.mark.timeout(5)
 def test_exit_code_execute_missing(tmp_path):
-    archivo = tmp_path / "no.cobra"
+    archivo = tmp_path / "no.co"
     code = _run_sys_exit(["ejecutar", str(archivo)])
     assert code != 0
 
@@ -31,5 +31,5 @@ def test_exit_code_execute_missing(tmp_path):
 @pytest.mark.timeout(5)
 def test_exit_code_module_remove_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(modules_cmd, "MODULES_PATH", str(tmp_path))
-    code = _run_sys_exit(["modulos", "remover", "algo.cobra"])
+    code = _run_sys_exit(["modulos", "remover", "algo.co"])
     assert code != 0

--- a/backend/src/tests/test_import.py
+++ b/backend/src/tests/test_import.py
@@ -14,7 +14,7 @@ from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 
 @pytest.mark.timeout(5)
 def test_import_interpreter(tmp_path):
-    mod = tmp_path / "mod.cobra"
+    mod = tmp_path / "mod.co"
     mod.write_text("var dato = 5")
 
     IMPORT_WHITELIST.add(str(mod))
@@ -34,7 +34,7 @@ def test_import_interpreter(tmp_path):
 
 @pytest.mark.timeout(5)
 def test_import_transpiler(tmp_path):
-    mod = tmp_path / "m.cobra"
+    mod = tmp_path / "m.co"
     mod.write_text("var valor = 3")
 
     codigo = f"import '{mod}'\nimprimir(valor)"

--- a/backend/src/tests/test_module_map.py
+++ b/backend/src/tests/test_module_map.py
@@ -9,7 +9,7 @@ from src.cobra.transpilers import module_map
 
 
 def test_transpilador_mapeo_python(tmp_path, monkeypatch):
-    mod = tmp_path / "m.cobra"
+    mod = tmp_path / "m.co"
     mod.write_text("var x = 1")
     py_out = tmp_path / "m.py"
     py_out.write_text("x = 1\n")
@@ -31,7 +31,7 @@ def test_transpilador_mapeo_python(tmp_path, monkeypatch):
 
 
 def test_transpilador_mapeo_js(tmp_path, monkeypatch):
-    mod = tmp_path / "m.cobra"
+    mod = tmp_path / "m.co"
     mod.write_text("var x = 2")
     js_out = tmp_path / "m.js"
     js_out.write_text("let x = 2;\n")

--- a/backend/src/tests/test_semantic_validator.py
+++ b/backend/src/tests/test_semantic_validator.py
@@ -33,7 +33,7 @@ def test_codigo_seguro_no_lanza_error():
 
 
 def test_import_no_permitido():
-    codigo = "import 'malicioso.cobra'"
+    codigo = "import 'malicioso.co'"
     ast = generar_ast(codigo)
     validador = construir_cadena()
 

--- a/backend/src/tests/test_to_python_extras.py
+++ b/backend/src/tests/test_to_python_extras.py
@@ -26,7 +26,7 @@ def test_transpilar_try_catch_throw():
 
 
 def test_transpilar_import(tmp_path):
-    mod = tmp_path / "mod.cobra"
+    mod = tmp_path / "mod.co"
     mod.write_text("var dato = 5")
     nodo = NodoImport(str(mod))
     codigo = TranspiladorPython().transpilar([nodo])

--- a/cobra.mod
+++ b/cobra.mod
@@ -2,7 +2,7 @@
 # La clave es la ruta usada en la instrucción `import`.
 # Cada entrada puede especificar rutas para los archivos generados en Python o JavaScript.
 # Por ejemplo:
-#   modulo.cobra:
+#   modulo.co:
 #     python: modulo.py
 #     js: modulo.js
 # Actualmente no existen módulos transpilados a registrar.

--- a/frontend/docs/modo_seguro.rst
+++ b/frontend/docs/modo_seguro.rst
@@ -16,4 +16,4 @@ Ejemplo de uso
 
 .. code-block:: bash
 
-   cobra ejecutar programa.cobra --seguro
+   cobra ejecutar programa.co --seguro

--- a/frontend/docs/referencia.rst
+++ b/frontend/docs/referencia.rst
@@ -28,8 +28,8 @@ El comando ``cobra`` cuenta con varias subopciones:
 
 .. code-block:: bash
 
-   cobra compilar archivo.cobra --tipo python
-   cobra ejecutar archivo.cobra --depurar
+   cobra compilar archivo.co --tipo python
+   cobra ejecutar archivo.co --depurar
    cobra modulos listar
    cobra docs
    cobra empaquetar --output dist

--- a/frontend/docs/sintaxis.rst
+++ b/frontend/docs/sintaxis.rst
@@ -60,7 +60,7 @@ Puedes dividir tu código en varios archivos y cargarlos con ``import``:
 
 .. code-block:: cobra
 
-   import 'utilidades.cobra'
+   import 'utilidades.co'
    imprimir(variable_definida_en_utilidades)
 
 **8. Manejo de excepciones**


### PR DESCRIPTION
## Summary
- permite que los archivos cobra utilicen extensión `.co`
- agrega el subcomando `crear` para generar archivos, carpetas o proyectos
- actualiza documentación y ejemplos para reflejar la nueva extensión
- ajusta tests y módulos para trabajar con la extensión `.co`

## Testing
- `pip install -r requirements.txt`
- `pytest backend/src/tests/test_cli_commands_extra.py -q`
- `pytest` *(falla: 46 failed, 138 passed, 1 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_6858f2e096f88327b1bad2c5c31f68f1