### PR TITLE
Add Agix suggestion command

### DIFF
--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -8,6 +8,7 @@ from .commands.docs_cmd import DocsCommand
 from .commands.execute_cmd import ExecuteCommand
 from .commands.interactive_cmd import InteractiveCommand
 from .commands.jupyter_cmd import JupyterCommand
+from .commands.agix_cmd import AgixCommand
 from .plugin_loader import descubrir_plugins
 from .commands.modules_cmd import ModulesCommand
 from .commands.dependencias_cmd import DependenciasCommand
@@ -38,6 +39,7 @@ def main(argv=None):
         DocsCommand(),
         EmpaquetarCommand(),
         CrearCommand(),
+        AgixCommand(),
         JupyterCommand(),
         InteractiveCommand(),
     ]

--- a/backend/src/cli/commands/agix_cmd.py
+++ b/backend/src/cli/commands/agix_cmd.py
@@ -1,0 +1,30 @@
+import os
+from .base import BaseCommand
+
+from src.ia.analizador_agix import generar_sugerencias
+
+
+class AgixCommand(BaseCommand):
+    """Genera sugerencias para código Cobra usando agix."""
+
+    name = "agix"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(
+            self.name, help="Analiza un archivo Cobra y sugiere mejoras"
+        )
+        parser.add_argument("archivo")
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        archivo = args.archivo
+        if not os.path.exists(archivo):
+            print(f"El archivo '{archivo}' no existe")
+            return 1
+        with open(archivo, "r") as f:
+            codigo = f.read()
+        sugerencias = generar_sugerencias(codigo)
+        for s in sugerencias:
+            print(s)
+        return 0

--- a/backend/src/ia/analizador_agix.py
+++ b/backend/src/ia/analizador_agix.py
@@ -1,0 +1,43 @@
+"""Módulo que analiza código Cobra usando agix y genera sugerencias."""
+
+from agix.reasoning.basic import Reasoner
+from typing import List
+
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+
+
+def generar_sugerencias(codigo: str) -> List[str]:
+    """Genera sugerencias para el ``codigo`` proporcionado.
+
+    El análisis valida el código con el lexer y parser de Cobra y luego usa
+    :class:`agix.reasoning.basic.Reasoner` para elegir la mejor sugerencia
+    de un conjunto predefinido.
+    """
+    # Validar el código utilizando las herramientas de Cobra
+    tokens = Lexer(codigo).tokenizar()
+    Parser(tokens).parsear()
+
+    evaluaciones = []
+    if "imprimir(" not in codigo:
+        evaluaciones.append({
+            "name": "Agregar imprimir para depurar",
+            "accuracy": 0.9,
+            "interpretability": 0.8,
+        })
+    if "var " in codigo:
+        evaluaciones.append({
+            "name": "Usar nombres descriptivos para variables",
+            "accuracy": 0.8,
+            "interpretability": 0.7,
+        })
+    if not evaluaciones:
+        evaluaciones.append({
+            "name": "Código correcto",
+            "accuracy": 0.5,
+            "interpretability": 1.0,
+        })
+
+    razonador = Reasoner()
+    mejor = razonador.select_best_model(evaluaciones)
+    return [mejor["reason"]]

--- a/backend/src/tests/test_cli_agix.py
+++ b/backend/src/tests/test_cli_agix.py
@@ -1,0 +1,13 @@
+from io import StringIO
+from unittest.mock import patch
+
+from src.cli.cli import main
+
+
+def test_cli_agix_generates_suggestion(tmp_path):
+    archivo = tmp_path / "ejemplo.co"
+    archivo.write_text("var x = 5")
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["agix", str(archivo)])
+    salida = out.getvalue().strip()
+    assert "Modelo seleccionado" in salida


### PR DESCRIPTION
## Summary
- add new analyser using agix to generate suggestions
- expose new `agix` command in CLI
- test the new command

## Testing
- `pytest backend/src/tests/test_cli_agix.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68598ec3b2fc8327913db79259a64f69