### PR TITLE
Integración con holobit-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,19 @@ para var i en rango(2) :
 
 Al transpilar a Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. El tipo `holobit` se transfiere a la llamada `holobit([...])` en Python o `new Holobit([...])` en JavaScript.
 
+## Integración con holobit-sdk
+
+El proyecto instala automáticamente la librería `holobit-sdk`, utilizada para visualizar y manipular holobits. Las funciones `graficar`, `proyectar` y `transformar` de `src.core.holobits` delegan en esta API.
+
+```python
+from src.core.holobits import Holobit, graficar, proyectar, transformar
+
+h = Holobit([0.8, -0.5, 1.2, 0.0, 0.0, 0.0])
+proyectar(h, "2D")
+graficar(h)
+transformar(h, "rotar", "z", 90)
+```
+
 ## Ejemplo de carga de módulos
 
 Puedes dividir el código en varios archivos y cargarlos con `import`:

--- a/backend/src/core/holobits/graficar.py
+++ b/backend/src/core/holobits/graficar.py
@@ -1,11 +1,23 @@
-"""Funciones de ejemplo para graficar objetos ``Holobit``."""
+"""Funciones para graficar objetos ``Holobit`` utilizando ``holobit-sdk``."""
 
 from .holobit import Holobit
+from holobit_sdk.visualization.projector import proyectar_holograma
+from holobit_sdk.core.quark import Quark
+from holobit_sdk.core.holobit import Holobit as SDKHolobit
+
+
+def _to_sdk_holobit(hb: Holobit) -> SDKHolobit:
+    """Convierte un :class:`Holobit` local a uno del SDK."""
+    valores = list(hb.valores) + [0.0] * (6 - len(hb.valores))
+    quarks = [Quark(v, 0, 0) for v in valores[:6]]
+    antiquarks = [Quark(-q.posicion[0], -q.posicion[1], -q.posicion[2]) for q in quarks]
+    return SDKHolobit(quarks, antiquarks)
 
 
 def graficar(hb: Holobit):
-    """Funcion placeholder para graficar un Holobit."""
+    """Grafica un ``Holobit`` delegando en ``holobit-sdk``."""
     if not isinstance(hb, Holobit):
         raise TypeError("graficar espera una instancia de Holobit")
-    # Comportamiento simulado
-    return f"Graficando {hb}"
+    sdk_hb = _to_sdk_holobit(hb)
+    proyectar_holograma(sdk_hb)
+    return None

--- a/backend/src/core/holobits/proyection.py
+++ b/backend/src/core/holobits/proyection.py
@@ -1,10 +1,18 @@
-"""Operaciones para proyectar holobits en diferentes modos."""
+"""Operaciones para proyectar holobits usando ``holobit-sdk``."""
 
 from .holobit import Holobit
+from holobit_sdk.visualization.projector import proyectar_holograma
+from holobit_sdk.core.quark import Quark
+from holobit_sdk.core.holobit import Holobit as SDKHolobit
+
+from .graficar import _to_sdk_holobit
 
 
 def proyectar(hb: Holobit, modo: str):
-    """Funcion placeholder para proyectar un Holobit."""
+    """Proyecta un ``Holobit`` mediante ``holobit-sdk``."""
     if not isinstance(hb, Holobit):
         raise TypeError("proyectar espera una instancia de Holobit")
-    return f"Proyectando {hb} en {modo}"
+    sdk_hb = _to_sdk_holobit(hb)
+    # El SDK no distingue modos actualmente; se grafica el resultado
+    proyectar_holograma(sdk_hb)
+    return None

--- a/backend/src/core/holobits/transformacion.py
+++ b/backend/src/core/holobits/transformacion.py
@@ -1,10 +1,19 @@
-"""Ejemplos de transformaciones aplicables a un ``Holobit``."""
+"""Transformaciones de ``Holobit`` a través de ``holobit-sdk``."""
 
 from .holobit import Holobit
+from holobit_sdk.core.holobit import Holobit as SDKHolobit
+
+from .graficar import _to_sdk_holobit
 
 
 def transformar(hb: Holobit, operacion: str, *parametros):
-    """Funcion placeholder para transformar un Holobit."""
+    """Aplica transformaciones utilizando ``holobit-sdk``."""
     if not isinstance(hb, Holobit):
         raise TypeError("transformar espera una instancia de Holobit")
-    return f"Transformar {hb} con {operacion} {parametros}"
+    sdk_hb = _to_sdk_holobit(hb)
+    if operacion == "rotar" and len(parametros) >= 2:
+        eje, angulo = parametros[0], float(parametros[1])
+        sdk_hb.rotar(eje, angulo)
+    else:
+        raise ValueError(f"Operacion no soportada: {operacion}")
+    return None

--- a/backend/src/tests/test_holobit_sdk_integration.py
+++ b/backend/src/tests/test_holobit_sdk_integration.py
@@ -1,0 +1,37 @@
+import pytest
+from src.core.holobits import Holobit, graficar, proyectar, transformar
+
+
+def test_graficar_usa_sdk(monkeypatch):
+    llamadas = {}
+    def fake(hb):
+        llamadas['hb'] = hb
+    import importlib
+    gmod = importlib.import_module('src.core.holobits.graficar')
+    monkeypatch.setattr(gmod, 'proyectar_holograma', fake)
+    h = Holobit([1, 2, 3, 4, 5, 6])
+    graficar(h)
+    assert 'hb' in llamadas
+
+
+def test_proyectar_usa_sdk(monkeypatch):
+    llamadas = {}
+    def fake(hb):
+        llamadas['hb'] = hb
+    import importlib
+    pmod = importlib.import_module('src.core.holobits.proyection')
+    monkeypatch.setattr(pmod, 'proyectar_holograma', fake)
+    h = Holobit([1, 2, 3, 4, 5, 6])
+    proyectar(h, '2D')
+    assert 'hb' in llamadas
+
+
+def test_transformar_usa_sdk(monkeypatch):
+    args = {}
+    def fake_rotar(self, eje, angulo):
+        args['eje'] = eje
+        args['angulo'] = angulo
+    monkeypatch.setattr('holobit_sdk.core.holobit.Holobit.rotar', fake_rotar)
+    h = Holobit([1, 2, 3, 4, 5, 6])
+    transformar(h, 'rotar', 'z', 45)
+    assert args == {'eje': 'z', 'angulo': 45.0}


### PR DESCRIPTION
## Summary
- integrate holobit-sdk for holobit actions
- document how to use holobit-sdk
- add tests to ensure the SDK is invoked

## Testing
- `pytest backend/src/tests/test_holobit_sdk_integration.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4362cf24832791d801bf8d88eb2d