### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Alphonsus411/pCobra/security/code-scanning/5](https://github.com/Alphonsus411/pCobra/security/code-scanning/5)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, the `contents: read` permission is sufficient, as the workflow primarily reads repository contents and uploads coverage reports.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `build` job to limit permissions specifically for that job. In this case, adding it at the root level is recommended for simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
