### PR TITLE
Fix cobra entrypoint

### DIFF
--- a/backend/src/src/__init__.py
+++ b/backend/src/src/__init__.py
@@ -1,0 +1,8 @@
+import importlib, sys
+
+for pkg in ['cli', 'cobra', 'core', 'ia', 'jupyter_kernel', 'tests']:
+    try:
+        module = importlib.import_module(pkg)
+        sys.modules[__name__ + '.' + pkg] = module
+    except Exception:
+        pass

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'cobra=cli.cli:main',
+            'cobra=src.cli.cli:main',
         ],
         'cobra.plugins': [
             # Se registrarán plugins externos aquí


### PR DESCRIPTION
## Summary
- change CLI entrypoint to `src.cli.cli:main`
- add shim package so `src` imports resolve correctly

## Testing
- `pip install -e .`
- `cobra --help | head`

------
https://chatgpt.com/codex/tasks/task_e_685a716a40d48327be0ae957afe70585