### PR TITLE
Fix memory search loop and add boundary test

### DIFF
--- a/backend/src/core/memoria/estrategia_memoria.py
+++ b/backend/src/core/memoria/estrategia_memoria.py
@@ -23,7 +23,7 @@ class EstrategiaMemoria:
         :param tam: Tamaño del bloque a asignar.
         :return: Índice del bloque asignado o -1 si no se pudo asignar.
         """
-        for i in range(len(self.memoria) - tam):
+        for i in range(len(self.memoria) - tam + 1):
             # Verifica si todos los bloques en el rango son None
             if all(block is None for block in self.memoria[i:i + tam]):
                 # Asignar el bloque

--- a/backend/src/tests/test_gestor_memoria.py
+++ b/backend/src/tests/test_gestor_memoria.py
@@ -15,6 +15,19 @@ def test_asignacion_y_liberacion():
                estrategia.memoria[index:index + 10]), "Error: La memoria no se liberó correctamente"
 
 
+def test_asignacion_espacio_justo_al_final():
+    estrategia = EstrategiaMemoria(10, 0.0)
+    tam = 5
+
+    # Ocupamos toda la memoria excepto los últimos 'tam' bloques
+    estrategia.memoria[:-tam] = [True] * (len(estrategia.memoria) - tam)
+
+    # Intentar asignar un bloque que encaja exactamente al final
+    index = estrategia.asignar(tam)
+
+    assert index == len(estrategia.memoria) - tam
+
+
 def test_gestor_memoria_genetico():
     gestor = GestorMemoriaGenetico(poblacion_tam=10)
 


### PR DESCRIPTION
## Summary
- allow memory allocation check to include last index
- test allocating a block when exactly one block fits at the end

## Testing
- `pytest -q backend/src/tests/test_gestor_memoria.py::test_asignacion_espacio_justo_al_final`
- `pytest -q` *(fails: 46 failed, 143 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685a7f68f78c8327b68453a1ec585441