### PR TITLE
Add Docker build script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ pip install -r requirements.txt
 pip install -e .
 ````
 
+## Construir la imagen Docker
+
+Puedes crear la imagen utilizando el script `docker/scripts/build.sh`:
+
+````bash
+./docker/scripts/build.sh
+````
+
+Esto generará una imagen llamada `cobra` en tu sistema Docker.
+
 # Estructura del Proyecto
 
 El proyecto se organiza en las siguientes carpetas y módulos:

--- a/docker/scripts/build.sh
+++ b/docker/scripts/build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build -t cobra .


### PR DESCRIPTION
## Summary
- add simple Docker build script
- document how to use it in README

## Testing
- `pytest -q` *(fails: KeyboardInterrupt; partial result shows 66 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685a82709b108327b2ab98b363af1196