### PR TITLE
Modificar validación de AST según flag --seguro

### DIFF
--- a/backend/src/cli/commands/execute_cmd.py
+++ b/backend/src/cli/commands/execute_cmd.py
@@ -39,14 +39,15 @@ class ExecuteCommand(BaseCommand):
             codigo = f.read()
         tokens = Lexer(codigo).tokenizar()
         ast = Parser(tokens).parsear()
-        try:
-            validador = construir_cadena()
-            for nodo in ast:
-                nodo.aceptar(validador)
-        except PrimitivaPeligrosaError as pe:
-            logging.error(f"Primitiva peligrosa: {pe}")
-            print(f"Error: {pe}")
-            return 1
+        if seguro:
+            try:
+                validador = construir_cadena()
+                for nodo in ast:
+                    nodo.aceptar(validador)
+            except PrimitivaPeligrosaError as pe:
+                logging.error(f"Primitiva peligrosa: {pe}")
+                print(f"Error: {pe}")
+                return 1
         try:
             InterpretadorCobra(safe_mode=seguro).ejecutar_ast(ast)
             return 0


### PR DESCRIPTION
## Resumen
- en `execute_cmd.py` sólo crear y usar el validador en modo seguro

## Testing
- `pytest backend/src/tests/test_cli_commands_extra.py::test_cli_ejecutar_flag_seguro -q`
- `pytest -q` *(fallan varias pruebas)*

------
https://chatgpt.com/codex/tasks/task_e_685a988d269c8327afb23c71eaf7c0cf