### PR TITLE
Agrega manejo de FileNotFoundError en docs_cmd

### DIFF
--- a/backend/src/cli/commands/docs_cmd.py
+++ b/backend/src/cli/commands/docs_cmd.py
@@ -29,6 +29,9 @@ class DocsCommand(BaseCommand):
             subprocess.run(["sphinx-build", "-b", "html", source, build], check=True)
             print(f"Documentación generada en {build}")
             return 0
+        except FileNotFoundError:
+            print("Sphinx no está instalado. Ejecuta 'pip install sphinx'.")
+            return 1
         except subprocess.CalledProcessError as e:
             print(f"Error generando la documentación: {e}")
             return 1

--- a/backend/src/tests/test_cli_docs.py
+++ b/backend/src/tests/test_cli_docs.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from unittest.mock import patch, call
+from io import StringIO
 from src.cli.cli import main
 
 
@@ -26,4 +27,11 @@ def test_cli_docs_invokes_sphinx():
                 str(build),
             ], check=True),
         ])
+
+
+def test_cli_docs_sin_sphinx():
+    with patch("subprocess.run", side_effect=FileNotFoundError), \
+            patch("sys.stdout", new_callable=StringIO) as out:
+        main(["docs"])
+    assert "Sphinx no está instalado" in out.getvalue()
 


### PR DESCRIPTION
## Resumen
- maneja `FileNotFoundError` en `DocsCommand`
- avisa que Sphinx no está instalado y devuelve error
- prueba unitaria para este escenario

## Testing
- `pytest backend/src/tests/test_cli_docs.py -q`
- `pytest -k docs -q`

------
https://chatgpt.com/codex/tasks/task_e_685a999f78e48327b1d1be52a2af75d5