### PR TITLE
Handle missing jupyter executable

### DIFF
--- a/backend/src/cli/commands/jupyter_cmd.py
+++ b/backend/src/cli/commands/jupyter_cmd.py
@@ -22,6 +22,12 @@ class JupyterCommand(BaseCommand):
                 "--KernelManager.default_kernel_name=cobra",
             ], check=True)
             return 0
+        except FileNotFoundError:
+            print(
+                "No se encontró el ejecutable 'jupyter'. "
+                "Instala Jupyter para utilizar esta función."
+            )
+            return 1
         except subprocess.CalledProcessError as e:
             print(f"Error lanzando Jupyter: {e}")
             return 1


### PR DESCRIPTION
## Summary
- ensure jupyter command tells user to install Jupyter when executable missing

## Testing
- `pytest backend/src/tests/test_cli_jupyter.py -q`
- `pytest -q` *(fails: 46 failed, 144 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685a9b5ffe988327879584cccf4e6e6d