### PR TITLE
Manejar ausencia del paquete agix

### DIFF
--- a/backend/src/ia/analizador_agix.py
+++ b/backend/src/ia/analizador_agix.py
@@ -1,6 +1,9 @@
 """Módulo que analiza código Cobra usando agix y genera sugerencias."""
 
-from agix.reasoning.basic import Reasoner
+try:
+    from agix.reasoning.basic import Reasoner
+except ImportError:  # pragma: no cover - depende de agix instalado
+    Reasoner = None
 from typing import List
 
 from src.cobra.lexico.lexer import Lexer
@@ -14,6 +17,10 @@ def generar_sugerencias(codigo: str) -> List[str]:
     :class:`agix.reasoning.basic.Reasoner` para elegir la mejor sugerencia
     de un conjunto predefinido.
     """
+    if Reasoner is None:
+        print("Instala el paquete agix")
+        raise SystemExit(1)
+
     # Validar el código utilizando las herramientas de Cobra
     tokens = Lexer(codigo).tokenizar()
     Parser(tokens).parsear()

--- a/backend/src/tests/test_cli_agix_missing_dep.py
+++ b/backend/src/tests/test_cli_agix_missing_dep.py
@@ -1,0 +1,25 @@
+from io import StringIO
+from unittest.mock import patch
+import sys
+
+import pytest
+
+
+def test_cli_agix_sin_agix(tmp_path):
+    archivo = tmp_path / "ejemplo.co"
+    archivo.write_text("var x = 5")
+    for mod in ["src.cli.cli", "src.cli.commands.agix_cmd", "src.ia.analizador_agix"]:
+        sys.modules.pop(mod, None)
+    real_import = __import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "agix.reasoning.basic":
+            raise ImportError
+        return real_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        from src.cli.cli import main
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            with pytest.raises(SystemExit):
+                main(["agix", str(archivo)])
+        assert "Instala el paquete agix" in out.getvalue()


### PR DESCRIPTION
## Summary
- soportar ausencia de `agix` al importar `analizador_agix`
- informar que se debe instalar el paquete agix al ejecutar `agix`
- cubrir con prueba el caso sin la dependencia

## Testing
- `pytest backend/src/tests/test_cli_agix.py backend/src/tests/test_cli_agix_missing_dep.py -q`
- `pytest backend/src/tests/test_cli_agix.py backend/src/tests/test_cli_agix_missing_dep.py backend/src/tests/test_cli_docs.py backend/src/tests/test_cli_empaquetar.py backend/src/tests/test_cli_jupyter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9d4714108327b58a206375c4512a