### PR TITLE
Actualizar gestión de memoria en llamadas a función

### DIFF
--- a/backend/src/core/interpreter.py
+++ b/backend/src/core/interpreter.py
@@ -332,7 +332,10 @@ class InterpretadorCobra:
             self.mem_contextos.append({})
 
             for nombre_param, arg in zip(funcion.parametros, nodo.argumentos):
-                self.variables[nombre_param] = self.evaluar_expresion(arg)
+                valor = self.evaluar_expresion(arg)
+                indice = self.solicitar_memoria(1)
+                self.mem_contextos[-1][nombre_param] = (indice, 1)
+                self.variables[nombre_param] = valor
 
             resultado = None
             for instruccion in funcion.cuerpo:


### PR DESCRIPTION
## Resumen
- reservar memoria para los parámetros en `ejecutar_llamada_funcion`
- registrar los índices de memoria de los parámetros para liberarlos al terminar

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fallan 46 tests, 145 pasan)*

------
https://chatgpt.com/codex/tasks/task_e_685a9fc1db688327bd5bb7912ee26440