### PR TITLE
Add ASM transpiler and CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Versión 1.0
 
-Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python y JavaScript, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
+Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript y ensamblador, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
 ## Tabla de Contenidos
 
@@ -91,7 +91,7 @@ El proyecto se organiza en las siguientes carpetas y módulos:
 # Características Principales
 
 - Lexer y Parser: Implementación de un lexer para la tokenización del código fuente y un parser para la construcción de un árbol de sintaxis abstracta (AST).
-- Transpiladores a Python y JavaScript: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
+- Transpiladores a Python, JavaScript y ensamblador: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
 - Soporte de Estructuras Avanzadas: Permite la declaración de variables, funciones, clases, listas y diccionarios, así como el uso de bucles y condicionales.
 - Módulos nativos con funciones de E/S, utilidades matemáticas y estructuras de datos para usar directamente desde Cobra.
 - Instalación de paquetes en tiempo de ejecución mediante la instrucción `usar`.
@@ -160,7 +160,7 @@ para var i en rango(2) :
 '''
 ````
 
-Al transpilar a Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. El tipo `holobit` se transfiere a la llamada `holobit([...])` en Python o `new Holobit([...])` en JavaScript.
+Al transpilar a Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python o `new Holobit([...])` en JavaScript.
 
 ## Integración con holobit-sdk
 
@@ -218,7 +218,7 @@ editar `cobra.mod` y volver a ejecutar las pruebas.
 ## Invocar el transpilador
 
 La carpeta [`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler)
-contiene la implementación de los transpiladores a Python y JavaScript. Una vez
+contiene la implementación de los transpiladores a Python, JavaScript y ensamblador. Una vez
 instaladas las dependencias, puedes llamar al transpilador desde tu propio
 script de la siguiente manera:
 
@@ -258,7 +258,7 @@ Al transpilarlas, se generan llamadas `asyncio.create_task` en Python y `Promise
 Una vez instalado el paquete, la herramienta `cobra` ofrece varios subcomandos:
 
 ```bash
-# Compilar un archivo a Python o JavaScript
+# Compilar un archivo a Python, JavaScript o ensamblador
 cobra compilar programa.co --tipo python
 
 # Ejecutar directamente un script Cobra
@@ -310,6 +310,7 @@ de error.
 
 ````bash
 cobra compilar programa.co --tipo=python
+cobra compilar programa.co --tipo=asm
 echo $?  # 0 al compilar sin problemas
 
 cobra ejecutar inexistente.co
@@ -401,7 +402,7 @@ Este proyecto está bajo la [Licencia MIT](LICENSE).
 
 ### Notas
 
-- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python y JavaScript.
+- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript y ensamblador.
 - **Ejemplos de Código y Nuevas Estructuras**: Incluye ejemplos con el uso de estructuras avanzadas como clases y diccionarios en el lenguaje Cobra.
 
 Si deseas agregar o modificar algo, házmelo saber.

--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -7,6 +7,7 @@ from src.cobra.parser.parser import Parser
 from src.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.transpiler.to_asm import TranspiladorASM
 
 
 class CompileCommand(BaseCommand):
@@ -17,7 +18,12 @@ class CompileCommand(BaseCommand):
     def register_subparser(self, subparsers):
         parser = subparsers.add_parser(self.name, help="Transpila un archivo")
         parser.add_argument("archivo")
-        parser.add_argument("--tipo", choices=["python", "js"], default="python")
+        parser.add_argument(
+            "--tipo",
+            choices=["python", "js", "asm"],
+            default="python",
+            help="Tipo de código generado",
+        )
         parser.set_defaults(cmd=self)
         return parser
 
@@ -42,6 +48,8 @@ class CompileCommand(BaseCommand):
                     transp = TranspiladorPython()
                 elif transpilador == "js":
                     transp = TranspiladorJavaScript()
+                elif transpilador == "asm":
+                    transp = TranspiladorASM()
                 else:
                     raise ValueError("Transpilador no soportado.")
 

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/asignacion.py
@@ -1,0 +1,10 @@
+from src.core.ast_nodes import NodoAtributo
+
+def visit_asignacion(self, nodo):
+    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
+    if isinstance(nombre_raw, NodoAtributo):
+        nombre = self.obtener_valor(nombre_raw)
+    else:
+        nombre = nombre_raw
+    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
+    self.agregar_linea(f"SET {nombre}, {self.obtener_valor(valor)}")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/atributo.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/atributo.py
@@ -1,0 +1,2 @@
+def visit_atributo(self, nodo):
+    self.agregar_linea(f"ATTR {self.obtener_valor(nodo.objeto)}.{nodo.nombre}")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/bucle_mientras.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/bucle_mientras.py
@@ -1,0 +1,8 @@
+def visit_bucle_mientras(self, nodo):
+    condicion = self.obtener_valor(nodo.condicion)
+    self.agregar_linea(f"WHILE {condicion}")
+    self.indent += 1
+    for ins in nodo.cuerpo:
+        ins.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("END")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/clase.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/clase.py
@@ -1,0 +1,7 @@
+def visit_clase(self, nodo):
+    self.agregar_linea(f"CLASS {nodo.nombre}")
+    self.indent += 1
+    for m in nodo.metodos:
+        m.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("ENDCLASS")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/condicional.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/condicional.py
@@ -1,0 +1,16 @@
+def visit_condicional(self, nodo):
+    bloque_si = getattr(nodo, "bloque_si", getattr(nodo, "cuerpo_si", []))
+    bloque_sino = getattr(nodo, "bloque_sino", getattr(nodo, "cuerpo_sino", []))
+    condicion = self.obtener_valor(nodo.condicion)
+    self.agregar_linea(f"IF {condicion}")
+    self.indent += 1
+    for ins in bloque_si:
+        ins.aceptar(self)
+    self.indent -= 1
+    if bloque_sino:
+        self.agregar_linea("ELSE")
+        self.indent += 1
+        for ins in bloque_sino:
+            ins.aceptar(self)
+        self.indent -= 1
+    self.agregar_linea("END")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/diccionario.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/diccionario.py
@@ -1,0 +1,5 @@
+def visit_diccionario(self, nodo):
+    pares = ", ".join(
+        f"{self.obtener_valor(k)}:{self.obtener_valor(v)}" for k, v in nodo.elementos
+    )
+    self.agregar_linea(f"{{{pares}}}")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/for_.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/for_.py
@@ -1,0 +1,8 @@
+def visit_for(self, nodo):
+    iterable = self.obtener_valor(nodo.iterable)
+    self.agregar_linea(f"FOR {nodo.variable} IN {iterable}")
+    self.indent += 1
+    for ins in nodo.cuerpo:
+        ins.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("END")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/funcion.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/funcion.py
@@ -1,0 +1,8 @@
+def visit_funcion(self, nodo):
+    parametros = " ".join(nodo.parametros)
+    self.agregar_linea(f"FUNC {nodo.nombre} {parametros}")
+    self.indent += 1
+    for ins in nodo.cuerpo:
+        ins.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("ENDFUNC")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/hilo.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/hilo.py
@@ -1,0 +1,3 @@
+def visit_hilo(self, nodo):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.llamada.argumentos)
+    self.agregar_linea(f"THREAD {nodo.llamada.nombre} {args}")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/holobit.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/holobit.py
@@ -1,0 +1,6 @@
+def visit_holobit(self, nodo):
+    valores = ", ".join(str(v) for v in nodo.valores)
+    if nodo.nombre:
+        self.agregar_linea(f"HOLOBIT {nodo.nombre} [{valores}]")
+    else:
+        self.agregar_linea(f"HOLOBIT [{valores}]")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/identificador.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/identificador.py
@@ -1,0 +1,2 @@
+def visit_identificador(self, nodo):
+    self.agregar_linea(nodo.nombre)

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/importar.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/importar.py
@@ -1,0 +1,11 @@
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+
+
+def visit_import(self, nodo):
+    with open(nodo.ruta, "r", encoding="utf-8") as f:
+        codigo = f.read()
+    tokens = Lexer(codigo).tokenizar()
+    ast = Parser(tokens).parsear()
+    for sub in ast:
+        sub.aceptar(self)

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/imprimir.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/imprimir.py
@@ -1,0 +1,3 @@
+def visit_imprimir(self, nodo):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"PRINT {valor}")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/instancia.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/instancia.py
@@ -1,0 +1,3 @@
+def visit_instancia(self, nodo):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"NEW {nodo.nombre_clase} {args}")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/lista.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/lista.py
@@ -1,0 +1,3 @@
+def visit_lista(self, nodo):
+    elems = ", ".join(self.obtener_valor(e) for e in nodo.elementos)
+    self.agregar_linea(f"[{elems}]")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/llamada_funcion.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/llamada_funcion.py
@@ -1,0 +1,3 @@
+def visit_llamada_funcion(self, nodo):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"CALL {nodo.nombre} {args}")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/llamada_metodo.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/llamada_metodo.py
@@ -1,0 +1,4 @@
+def visit_llamada_metodo(self, nodo):
+    obj = self.obtener_valor(nodo.objeto)
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"CALL {obj}.{nodo.nombre_metodo} {args}")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/metodo.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/metodo.py
@@ -1,0 +1,8 @@
+def visit_metodo(self, nodo):
+    params = " ".join(nodo.parametros)
+    self.agregar_linea(f"METHOD {nodo.nombre} {params}")
+    self.indent += 1
+    for ins in nodo.cuerpo:
+        ins.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("ENDMETHOD")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/operacion_binaria.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/operacion_binaria.py
@@ -1,0 +1,2 @@
+def visit_operacion_binaria(self, nodo):
+    self.agregar_linea(self.obtener_valor(nodo))

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/operacion_unaria.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/operacion_unaria.py
@@ -1,0 +1,2 @@
+def visit_operacion_unaria(self, nodo):
+    self.agregar_linea(self.obtener_valor(nodo))

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/para.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/para.py
@@ -1,0 +1,8 @@
+def visit_para(self, nodo):
+    iterable = self.obtener_valor(nodo.iterable)
+    self.agregar_linea(f"PARA {nodo.variable} EN {iterable}")
+    self.indent += 1
+    for ins in nodo.cuerpo:
+        ins.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("FINPARA")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/retorno.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/retorno.py
@@ -1,0 +1,3 @@
+def visit_retorno(self, nodo):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"RETURN {valor}")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/throw.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/throw.py
@@ -1,0 +1,3 @@
+def visit_throw(self, nodo):
+    val = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"THROW {val}")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/try_catch.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/try_catch.py
@@ -1,0 +1,14 @@
+def visit_try_catch(self, nodo):
+    self.agregar_linea("TRY")
+    self.indent += 1
+    for ins in nodo.bloque_try:
+        ins.aceptar(self)
+    self.indent -= 1
+    if nodo.bloque_catch:
+        nombre = nodo.nombre_excepcion or ""
+        self.agregar_linea(f"CATCH {nombre}")
+        self.indent += 1
+        for ins in nodo.bloque_catch:
+            ins.aceptar(self)
+        self.indent -= 1
+    self.agregar_linea("ENDTRY")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/usar.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/usar.py
@@ -1,0 +1,2 @@
+def visit_usar(self, nodo):
+    self.agregar_linea(f"USAR {nodo.modulo}")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/valor.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/valor.py
@@ -1,0 +1,2 @@
+def visit_valor(self, nodo):
+    self.agregar_linea(self.obtener_valor(nodo))

--- a/backend/src/cobra/transpilers/transpiler/to_asm.py
+++ b/backend/src/cobra/transpilers/transpiler/to_asm.py
@@ -1,0 +1,139 @@
+"""Transpilador que genera código ensamblador simple desde Cobra."""
+
+from src.core.ast_nodes import (
+    NodoAsignacion,
+    NodoCondicional,
+    NodoBucleMientras,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoHolobit,
+    NodoFor,
+    NodoLista,
+    NodoDiccionario,
+    NodoClase,
+    NodoMetodo,
+    NodoValor,
+    NodoRetorno,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoIdentificador,
+    NodoInstancia,
+    NodoLlamadaMetodo,
+    NodoAtributo,
+    NodoHilo,
+    NodoTryCatch,
+    NodoThrow,
+    NodoImport,
+    NodoImprimir,
+    NodoPara,
+    NodoUsar,
+)
+from src.cobra.lexico.lexer import TipoToken, Lexer
+from src.cobra.parser.parser import Parser
+from src.core.visitor import NodeVisitor
+from src.core.optimizations import optimize_constants, remove_dead_code
+
+from .asm_nodes.asignacion import visit_asignacion as _visit_asignacion
+from .asm_nodes.condicional import visit_condicional as _visit_condicional
+from .asm_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
+from .asm_nodes.funcion import visit_funcion as _visit_funcion
+from .asm_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from .asm_nodes.llamada_metodo import visit_llamada_metodo as _visit_llamada_metodo
+from .asm_nodes.hilo import visit_hilo as _visit_hilo
+from .asm_nodes.imprimir import visit_imprimir as _visit_imprimir
+from .asm_nodes.retorno import visit_retorno as _visit_retorno
+from .asm_nodes.holobit import visit_holobit as _visit_holobit
+from .asm_nodes.for_ import visit_for as _visit_for
+from .asm_nodes.para import visit_para as _visit_para
+from .asm_nodes.lista import visit_lista as _visit_lista
+from .asm_nodes.diccionario import visit_diccionario as _visit_diccionario
+from .asm_nodes.clase import visit_clase as _visit_clase
+from .asm_nodes.metodo import visit_metodo as _visit_metodo
+from .asm_nodes.try_catch import visit_try_catch as _visit_try_catch
+from .asm_nodes.throw import visit_throw as _visit_throw
+from .asm_nodes.importar import visit_import as _visit_import
+from .asm_nodes.instancia import visit_instancia as _visit_instancia
+from .asm_nodes.atributo import visit_atributo as _visit_atributo
+from .asm_nodes.operacion_binaria import visit_operacion_binaria as _visit_operacion_binaria
+from .asm_nodes.operacion_unaria import visit_operacion_unaria as _visit_operacion_unaria
+from .asm_nodes.valor import visit_valor as _visit_valor
+from .asm_nodes.identificador import visit_identificador as _visit_identificador
+from .asm_nodes.usar import visit_usar as _visit_usar
+
+
+class TranspiladorASM(NodeVisitor):
+    """Transpila el AST de Cobra a instrucciones de ensamblador simplificado."""
+
+    def __init__(self):
+        self.codigo = []
+        self.indent = 0
+
+    def agregar_linea(self, linea: str) -> None:
+        self.codigo.append("    " * self.indent + linea)
+
+    def obtener_valor(self, nodo):
+        if isinstance(nodo, NodoValor):
+            return str(nodo.valor)
+        elif isinstance(nodo, NodoAtributo):
+            obj = self.obtener_valor(nodo.objeto)
+            return f"{obj}.{nodo.nombre}"
+        elif isinstance(nodo, NodoInstancia):
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"NEW {nodo.nombre_clase}({args})"
+        elif isinstance(nodo, NodoIdentificador):
+            return nodo.nombre
+        elif isinstance(nodo, NodoOperacionBinaria):
+            izq = self.obtener_valor(nodo.izquierda)
+            der = self.obtener_valor(nodo.derecha)
+            op_map = {TipoToken.AND: "AND", TipoToken.OR: "OR"}
+            op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
+            return f"{izq} {op} {der}"
+        elif isinstance(nodo, NodoOperacionUnaria):
+            val = self.obtener_valor(nodo.operando)
+            op = "NOT" if nodo.operador.tipo == TipoToken.NOT else nodo.operador.valor
+            return f"{op} {val}" if op == "NOT" else f"{op}{val}"
+        elif isinstance(nodo, NodoLista):
+            elems = ", ".join(self.obtener_valor(e) for e in nodo.elementos)
+            return f"[{elems}]"
+        elif isinstance(nodo, NodoDiccionario):
+            pares = ", ".join(
+                f"{self.obtener_valor(k)}:{self.obtener_valor(v)}" for k, v in nodo.elementos
+            )
+            return f"{{{pares}}}"
+        else:
+            return str(getattr(nodo, "valor", nodo))
+
+    def transpilar(self, nodos):
+        nodos = remove_dead_code(optimize_constants(nodos))
+        for nodo in nodos:
+            nodo.aceptar(self)
+        return "\n".join(self.codigo)
+
+
+# Asignar los visitantes externos a la clase
+TranspiladorASM.visit_asignacion = _visit_asignacion
+TranspiladorASM.visit_condicional = _visit_condicional
+TranspiladorASM.visit_bucle_mientras = _visit_bucle_mientras
+TranspiladorASM.visit_funcion = _visit_funcion
+TranspiladorASM.visit_llamada_funcion = _visit_llamada_funcion
+TranspiladorASM.visit_llamada_metodo = _visit_llamada_metodo
+TranspiladorASM.visit_hilo = _visit_hilo
+TranspiladorASM.visit_imprimir = _visit_imprimir
+TranspiladorASM.visit_retorno = _visit_retorno
+TranspiladorASM.visit_holobit = _visit_holobit
+TranspiladorASM.visit_for = _visit_for
+TranspiladorASM.visit_para = _visit_para
+TranspiladorASM.visit_lista = _visit_lista
+TranspiladorASM.visit_diccionario = _visit_diccionario
+TranspiladorASM.visit_clase = _visit_clase
+TranspiladorASM.visit_metodo = _visit_metodo
+TranspiladorASM.visit_try_catch = _visit_try_catch
+TranspiladorASM.visit_throw = _visit_throw
+TranspiladorASM.visit_import = _visit_import
+TranspiladorASM.visit_instancia = _visit_instancia
+TranspiladorASM.visit_atributo = _visit_atributo
+TranspiladorASM.visit_operacion_binaria = _visit_operacion_binaria
+TranspiladorASM.visit_operacion_unaria = _visit_operacion_unaria
+TranspiladorASM.visit_valor = _visit_valor
+TranspiladorASM.visit_identificador = _visit_identificador
+TranspiladorASM.visit_usar = _visit_usar

--- a/backend/src/tests/test_to_asm.py
+++ b/backend/src/tests/test_to_asm.py
@@ -1,0 +1,60 @@
+from src.cobra.transpilers.transpiler.to_asm import TranspiladorASM
+from src.core.ast_nodes import (
+    NodoAsignacion,
+    NodoCondicional,
+    NodoBucleMientras,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoHolobit,
+)
+
+
+def test_transpilador_asignacion():
+    ast = [NodoAsignacion("x", 10)]
+    t = TranspiladorASM()
+    resultado = t.transpilar(ast)
+    assert resultado == "SET x, 10"
+
+
+def test_transpilador_condicional():
+    ast = [
+        NodoCondicional(
+            "x > 5",
+            [NodoAsignacion("y", 2)],
+            [NodoAsignacion("y", 3)],
+        )
+    ]
+    t = TranspiladorASM()
+    resultado = t.transpilar(ast)
+    expected = "IF x > 5\n    SET y, 2\nELSE\n    SET y, 3\nEND"
+    assert resultado == expected
+
+
+def test_transpilador_mientras():
+    ast = [NodoBucleMientras("x > 0", [NodoAsignacion("x", "x - 1")])]
+    t = TranspiladorASM()
+    resultado = t.transpilar(ast)
+    expected = "WHILE x > 0\n    SET x, x - 1\nEND"
+    assert resultado == expected
+
+
+def test_transpilador_funcion():
+    ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
+    t = TranspiladorASM()
+    resultado = t.transpilar(ast)
+    expected = "FUNC miFuncion a b\n    SET x, a + b\nENDFUNC"
+    assert resultado == expected
+
+
+def test_transpilador_llamada_funcion():
+    ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
+    t = TranspiladorASM()
+    resultado = t.transpilar(ast)
+    assert resultado == "CALL miFuncion a, b"
+
+
+def test_transpilador_holobit():
+    ast = [NodoHolobit("miHolobit", [0.8, -0.5, 1.2])]
+    t = TranspiladorASM()
+    resultado = t.transpilar(ast)
+    assert resultado == "HOLOBIT miHolobit [0.8, -0.5, 1.2]"

--- a/frontend/docs/api/src.core.transpiler.rst
+++ b/frontend/docs/api/src.core.transpiler.rst
@@ -29,6 +29,14 @@ src.core.transpiler.to\_python module
    :undoc-members:
    :show-inheritance:
 
+src.core.transpiler.to\_asm module
+----------------------------------
+
+.. automodule:: src.core.transpiler.to_asm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/frontend/docs/arquitectura.rst
+++ b/frontend/docs/arquitectura.rst
@@ -12,7 +12,7 @@ compilar a otros lenguajes y gestionar módulos instalados.
 Core
 ----
 Contiene el corazón del lenguaje: lexer, parser, intérprete y
-transpiladores a Python y JavaScript. Estos elementos trabajan en
+transpiladores a Python, JavaScript y ensamblador. Estos elementos trabajan en
 conjunto para analizar el código fuente y transformarlo en otras
 representaciones o ejecutarlo de forma directa.
 Las clases que componen el AST se definen en ``src.core.ast_nodes`` para facilitar su reutilización.
@@ -20,9 +20,9 @@ El recorrido de estos nodos puede realizarse mediante la clase ``NodeVisitor``
 ubicada en ``src.core.visitor``, que despacha automáticamente al método
 ``visit_<Clase>`` correspondiente.
 Para mantener el código modular, la lógica específica de cada nodo del AST se
-almacena en paquetes independientes. Los transpiladores a Python y JavaScript
+almacena en paquetes independientes. Los transpiladores a Python, JavaScript y ensamblador
 importan estas funciones desde ``src.core.transpiler.python_nodes`` y
-``src.core.transpiler.js_nodes`` respectivamente, delegando la operación de
+``src.core.transpiler.js_nodes`` (o ``asm_nodes``) respectivamente, delegando la operación de
 ``visit_<nodo>`` a dichas funciones.
 
 Módulos nativos

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -5,5 +5,5 @@ Avances del lenguaje Cobra
 - **Lexer y Parser funcionales**: El sistema lexico y sintactico esta completamente implementado y es capaz de procesar asignaciones de variables, funciones, condicionales, bucles y operaciones de holobits.
 - **Holobits**: Tipo de dato especial para trabajar con informacion multidimensional, con soporte para operaciones como proyecciones, transformaciones y visualizacion.
 - **Gestión de memoria automatizada**: Cobra incluye un sistema de manejo de memoria optimizado que se ajusta automáticamente utilizando algoritmos genéticos.
-- **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python y JavaScript.
+- **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript y ensamblador.
 - **Pruebas unitarias**: Se han creado pruebas para validar el correcto funcionamiento del lexer y el parser.

--- a/frontend/docs/caracteristicas.rst
+++ b/frontend/docs/caracteristicas.rst
@@ -4,7 +4,7 @@ Caracteristicas principales de Cobra
 - **Sintaxis en espanol**: Todas las palabras clave y estructuras del lenguaje estan en español, para facilitar su uso por hablantes nativos.
 - **Gestion de memoria automatica**: Cobra incorpora un sistema de manejo de memoria basado en algoritmos genéticos que optimiza el uso de los recursos durante la ejecución.
 - **Soporte para holobits**: Un tipo de dato multidimensional que permite trabajar con datos de alta complejidad.
-- **Transpiler a Python y JavaScript**: Los programas escritos en Cobra pueden ser transpilados a Python o JavaScript, lo que permite su ejecucion en una variedad de plataformas.
+- **Transpiler a Python, JavaScript y ensamblador**: Los programas escritos en Cobra pueden ser transpilados a estos lenguajes, lo que permite su ejecucion en una variedad de plataformas.
 - **Nombres Unicode**: Los identificadores aceptan caracteres como `á`, `ñ` o `Ω`.
 
 **Ejemplo basico**

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -33,7 +33,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
 Introducción
 --------------------
 
-Cobra fue creado con la idea de facilitar la programacion en español, optimizando la gestion de memoria y anadiendo soporte para trabajar con datos de alta complejidad como los holobits. Ademas, ofrece soporte para transpilar a Python y JavaScript, permitiendo su ejecucion en multiples plataformas.
+Cobra fue creado con la idea de facilitar la programacion en español, optimizando la gestion de memoria y anadiendo soporte para trabajar con datos de alta complejidad como los holobits. Ademas, ofrece soporte para transpilar a Python, JavaScript y ensamblador, permitiendo su ejecucion en multiples plataformas.
 
 
 

--- a/frontend/docs/optimizaciones.rst
+++ b/frontend/docs/optimizaciones.rst
@@ -11,4 +11,4 @@ Eliminación de código muerto
 ----------------------------
 ``remove_dead_code`` elimina instrucciones que nunca se ejecutarán. Por ejemplo, todo lo que aparezca después de ``return`` dentro de una función se descarta y, si un condicional tiene una condición constante, solo se conserva la rama correspondiente.
 
-Estas optimizaciones se aplican automáticamente antes de ejecutar el intérprete y en los transpiladores a Python y JavaScript.
+Estas optimizaciones se aplican automáticamente antes de ejecutar el intérprete y en los transpiladores a Python, JavaScript y ensamblador.

--- a/frontend/docs/referencia.rst
+++ b/frontend/docs/referencia.rst
@@ -29,6 +29,7 @@ El comando ``cobra`` cuenta con varias subopciones:
 .. code-block:: bash
 
    cobra compilar archivo.co --tipo python
+   cobra compilar archivo.co --tipo asm
    cobra ejecutar archivo.co --depurar
    cobra modulos listar
    cobra docs

--- a/frontend/docs/sintaxis.rst
+++ b/frontend/docs/sintaxis.rst
@@ -87,9 +87,9 @@ Es posible ejecutar funciones de forma concurrente:
 
    hilo trabajo()
 
-**Transpilación a Python y JavaScript**
+**Transpilación a Python, JavaScript y ensamblador**
 
-- `imprimir` se transpila a `print` en Python y a `console.log` en JavaScript.
-- Los bucles `mientras` y `para` se convierten en `while` y `for` respectivamente.
+- `imprimir` se transpila a `print` en Python, `console.log` en JavaScript y `PRINT` en ensamblador.
+- Los bucles `mientras` y `para` se convierten en `while` y `for` en los lenguajes de alto nivel, mientras que en ensamblador generan instrucciones `WHILE` y `FOR`.
 - La construcción `holobit` se traduce a `holobit([...])` en Python o `new Holobit([...])` en JavaScript.
 


### PR DESCRIPTION
## Summary
- implement `TranspiladorASM` for generating pseudo assembly code
- add asm node visitors
- support `--tipo asm` in CLI
- document new option in README and docs
- test assembly code generation

## Testing
- `pytest -q backend/src/tests/test_to_asm.py`
- `pytest -q` *(full test suite)*

------
https://chatgpt.com/codex/tasks/task_e_685aa2c66c4883279b9cb05334c6528b