### PR TITLE
Add Flet GUI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,12 @@ cobra modulos remover modulo.co
 cobra docs
 # Crear un ejecutable independiente
 cobra empaquetar --output dist
+# Iniciar la interfaz gráfica (requiere Flet)
+cobra gui
 ```
 
 El subcomando `docs` ejecuta `sphinx-apidoc` para generar la documentación de la API antes de compilar el HTML.
+El subcomando `gui` abre la interfaz gráfica y requiere tener instalado Flet.
 
 
 Si no se pasa un subcomando se abrirá el modo interactivo. Usa `cobra --help` para más detalles.

--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -8,6 +8,7 @@ from .commands.docs_cmd import DocsCommand
 from .commands.execute_cmd import ExecuteCommand
 from .commands.interactive_cmd import InteractiveCommand
 from .commands.jupyter_cmd import JupyterCommand
+from .commands.flet_cmd import FletCommand
 from .commands.agix_cmd import AgixCommand
 from .plugin_loader import descubrir_plugins
 from .commands.modules_cmd import ModulesCommand
@@ -41,6 +42,7 @@ def main(argv=None):
         CrearCommand(),
         AgixCommand(),
         JupyterCommand(),
+        FletCommand(),
         InteractiveCommand(),
     ]
     comandos.extend(descubrir_plugins())

--- a/backend/src/cli/commands/flet_cmd.py
+++ b/backend/src/cli/commands/flet_cmd.py
@@ -1,0 +1,24 @@
+from .base import BaseCommand
+
+
+class FletCommand(BaseCommand):
+    """Inicia la interfaz gráfica utilizando Flet."""
+
+    name = "gui"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(
+            self.name, help="Inicia la interfaz gráfica"
+        )
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        try:
+            import flet
+            from src.gui.app import main
+        except ModuleNotFoundError:
+            print("Flet no está instalado. Ejecuta 'pip install flet'.")
+            return 1
+        flet.app(target=main)
+        return 0

--- a/backend/src/gui/app.py
+++ b/backend/src/gui/app.py
@@ -1,0 +1,38 @@
+import io
+import sys
+import flet as ft
+
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from src.core.interpreter import InterpretadorCobra
+
+
+def _ejecutar_codigo(codigo: str) -> str:
+    """Ejecuta código Cobra y captura la salida impresa."""
+    buffer = io.StringIO()
+    stdout = sys.stdout
+    sys.stdout = buffer
+    try:
+        tokens = Lexer(codigo).tokenizar()
+        ast = Parser(tokens).parsear()
+        InterpretadorCobra().ejecutar_ast(ast)
+    finally:
+        sys.stdout = stdout
+    return buffer.getvalue()
+
+
+def main(page: ft.Page):
+    """Función principal para Flet."""
+
+    entrada = ft.TextField(multiline=True, expand=True)
+    salida = ft.Text(value="", selectable=True)
+
+    def ejecutar_handler(e):
+        salida.value = _ejecutar_codigo(entrada.value)
+        page.update()
+
+    page.add(
+        entrada,
+        ft.ElevatedButton("Ejecutar", on_click=ejecutar_handler),
+        salida,
+    )

--- a/backend/src/tests/test_cli_gui.py
+++ b/backend/src/tests/test_cli_gui.py
@@ -1,0 +1,18 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from src.cli.cli import main
+
+
+def test_cli_gui_invokes_flet_app():
+    mock_app = MagicMock()
+    fake_flet = SimpleNamespace(
+        app=mock_app,
+        TextField=MagicMock(),
+        Text=MagicMock(),
+        ElevatedButton=MagicMock(),
+        Page=MagicMock(),
+    )
+    with patch.dict('sys.modules', {'flet': fake_flet}):
+        main(['gui'])
+    mock_app.assert_called_once()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ ipykernel==6.29.5
 PyYAML==6.0.1
 agix==0.8.3
 holobit-sdk
+flet


### PR DESCRIPTION
## Summary
- declare flet in requirements
- add Flet GUI launcher with Cobra interpreter
- implement `FletCommand` and register it in CLI
- document `cobra gui` usage
- test that `flet.app` is called by CLI

## Testing
- `pytest backend/src/tests/test_cli_gui.py -q`
- `pytest backend/src/tests -q` *(fails: AttributeError & AssertionError in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_685aaf3c8bd08327aa9762955bdcfe4d