### PR TITLE
Soporte de clases en parser y transpiladores

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/cpp_nodes/clase.py
+++ b/backend/src/cobra/transpilers/transpiler/cpp_nodes/clase.py
@@ -1,0 +1,10 @@
+def visit_clase(self, nodo):
+    bases = getattr(nodo, 'bases', [])
+    base = f" : public {bases[0]}" if bases else ""
+    extra = f" // bases: {', '.join(bases)}" if len(bases) > 1 else ""
+    self.agregar_linea(f"class {nodo.nombre}{base}{extra} {{")
+    self.indent += 1
+    for metodo in getattr(nodo, 'metodos', []):
+        metodo.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("};")

--- a/backend/src/cobra/transpilers/transpiler/cpp_nodes/metodo.py
+++ b/backend/src/cobra/transpilers/transpiler/cpp_nodes/metodo.py
@@ -1,0 +1,8 @@
+def visit_metodo(self, nodo):
+    parametros = ", ".join(f"auto {p}" for p in nodo.parametros)
+    self.agregar_linea(f"auto {nodo.nombre}({parametros}) {{")
+    self.indent += 1
+    for instruccion in nodo.cuerpo:
+        instruccion.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")

--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/clase.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/clase.py
@@ -1,0 +1,11 @@
+def visit_clase(self, nodo):
+    bases = getattr(nodo, 'bases', [])
+    extra = f" // bases: {', '.join(bases)}" if bases else ""
+    self.agregar_linea(f"struct {nodo.nombre} {{}}{extra}")
+    self.agregar_linea("")
+    self.agregar_linea(f"impl {nodo.nombre} {{")
+    self.indent += 1
+    for metodo in getattr(nodo, 'metodos', []):
+        metodo.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")

--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/metodo.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/metodo.py
@@ -1,0 +1,8 @@
+def visit_metodo(self, nodo):
+    parametros = ", ".join(nodo.parametros)
+    self.agregar_linea(f"fn {nodo.nombre}({parametros}) {{")
+    self.indent += 1
+    for instruccion in nodo.cuerpo:
+        instruccion.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")

--- a/backend/src/cobra/transpilers/transpiler/to_cpp.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cpp.py
@@ -21,6 +21,8 @@ from .cpp_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mient
 from .cpp_nodes.funcion import visit_funcion as _visit_funcion
 from .cpp_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
 from .cpp_nodes.holobit import visit_holobit as _visit_holobit
+from .cpp_nodes.clase import visit_clase as _visit_clase
+from .cpp_nodes.metodo import visit_metodo as _visit_metodo
 
 
 class TranspiladorCPP(NodeVisitor):
@@ -80,3 +82,5 @@ TranspiladorCPP.visit_bucle_mientras = _visit_bucle_mientras
 TranspiladorCPP.visit_funcion = _visit_funcion
 TranspiladorCPP.visit_llamada_funcion = _visit_llamada_funcion
 TranspiladorCPP.visit_holobit = _visit_holobit
+TranspiladorCPP.visit_clase = _visit_clase
+TranspiladorCPP.visit_metodo = _visit_metodo

--- a/backend/src/cobra/transpilers/transpiler/to_rust.py
+++ b/backend/src/cobra/transpilers/transpiler/to_rust.py
@@ -21,6 +21,8 @@ from .rust_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mien
 from .rust_nodes.funcion import visit_funcion as _visit_funcion
 from .rust_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
 from .rust_nodes.holobit import visit_holobit as _visit_holobit
+from .rust_nodes.clase import visit_clase as _visit_clase
+from .rust_nodes.metodo import visit_metodo as _visit_metodo
 
 
 class TranspiladorRust(NodeVisitor):
@@ -80,3 +82,5 @@ TranspiladorRust.visit_bucle_mientras = _visit_bucle_mientras
 TranspiladorRust.visit_funcion = _visit_funcion
 TranspiladorRust.visit_llamada_funcion = _visit_llamada_funcion
 TranspiladorRust.visit_holobit = _visit_holobit
+TranspiladorRust.visit_clase = _visit_clase
+TranspiladorRust.visit_metodo = _visit_metodo

--- a/backend/src/tests/test_parser_clase.py
+++ b/backend/src/tests/test_parser_clase.py
@@ -1,0 +1,22 @@
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from src.core.ast_nodes import NodoClase, NodoMetodo
+
+
+def test_parser_declaracion_clase():
+    codigo = """
+    clase Persona:
+        func saludar(self):
+            fin
+    fin
+    """
+    tokens = Lexer(codigo).analizar_token()
+    ast = Parser(tokens).parsear()
+    assert len(ast) == 1
+    clase = ast[0]
+    assert isinstance(clase, NodoClase)
+    assert clase.nombre == "Persona"
+    assert len(clase.metodos) == 1
+    metodo = clase.metodos[0]
+    assert isinstance(metodo, NodoMetodo)
+    assert metodo.nombre == "saludar"

--- a/backend/src/tests/test_to_cpp.py
+++ b/backend/src/tests/test_to_cpp.py
@@ -58,3 +58,17 @@ def test_transpilador_holobit():
     t = TranspiladorCPP()
     resultado = t.transpilar(ast)
     assert resultado == "auto miHolobit = holobit({ 0.8, -0.5, 1.2 });"
+
+def test_transpilador_clase():
+    metodo = NodoMetodo("saludar", ["self"], [NodoAsignacion("x", 1)])
+    ast = [NodoClase("Persona", [metodo])]
+    t = TranspiladorCPP()
+    resultado = t.transpilar(ast)
+    esperado = (
+        "class Persona {\n"
+        "    auto saludar(auto self) {\n"
+        "        auto x = 1;\n"
+        "    }\n"
+        "};"
+    )
+    assert resultado == esperado

--- a/backend/src/tests/test_to_rust.py
+++ b/backend/src/tests/test_to_rust.py
@@ -58,3 +58,18 @@ def test_transpilador_holobit():
     t = TranspiladorRust()
     resultado = t.transpilar(ast)
     assert resultado == "let miHolobit = holobit(vec![0.8, -0.5, 1.2]);"
+
+def test_transpilador_clase():
+    metodo = NodoMetodo("saludar", ["self"], [NodoAsignacion("x", 1)])
+    ast = [NodoClase("Persona", [metodo])]
+    t = TranspiladorRust()
+    resultado = t.transpilar(ast)
+    esperado = (
+        "struct Persona {}\n\n"
+        "impl Persona {\n"
+        "    fn saludar(self) {\n"
+        "        let x = 1;\n"
+        "    }\n"
+        "}"
+    )
+    assert resultado == esperado


### PR DESCRIPTION
## Summary
- agregar "clase" a las palabras reservadas
- implementar `declaracion_clase` y `declaracion_metodo`
- soportar `NodoClase` en transpiladores C++ y Rust
- pruebas de parser y transpiladores para clases

## Testing
- `pytest backend/src/tests/test_parser_clase.py::test_parser_declaracion_clase -q`
- `pytest -q` *(falla: ModuleNotFoundError y NotImplementedError)*


------
https://chatgpt.com/codex/tasks/task_e_685bbb5be49483279683e6f067fa9aaf