### PR TITLE
Add decorator parsing and JS transpilation

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/js_nodes/decorador.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/decorador.py
@@ -1,0 +1,4 @@
+# Este nodo no genera salida directa; se maneja en visit_funcion
+
+def visit_decorador(self, nodo):
+    pass

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/funcion.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/funcion.py
@@ -12,3 +12,6 @@ def visit_funcion(self, nodo):
     if self.usa_indentacion:
         self.indentacion -= 1
     self.agregar_linea("}")
+    for decorador in reversed(getattr(nodo, "decoradores", [])):
+        expr = self.obtener_valor(decorador.expresion)
+        self.agregar_linea(f"{nodo.nombre} = {expr}({nodo.nombre});")

--- a/backend/src/cobra/transpilers/transpiler/to_js.py
+++ b/backend/src/cobra/transpilers/transpiler/to_js.py
@@ -41,6 +41,7 @@ from .js_nodes.operacion_unaria import visit_operacion_unaria as _visit_operacio
 from .js_nodes.valor import visit_valor as _visit_valor
 from .js_nodes.identificador import visit_identificador as _visit_identificador
 from .js_nodes.para import visit_para as _visit_para
+from .js_nodes.decorador import visit_decorador as _visit_decorador
 
 
 class TranspiladorJavaScript(NodeVisitor):
@@ -136,6 +137,7 @@ TranspiladorJavaScript.visit_operacion_unaria = _visit_operacion_unaria
 TranspiladorJavaScript.visit_valor = _visit_valor
 TranspiladorJavaScript.visit_identificador = _visit_identificador
 TranspiladorJavaScript.visit_para = _visit_para
+TranspiladorJavaScript.visit_decorador = _visit_decorador
 
     # Métodos de transpilación para tipos de nodos básicos
 

--- a/backend/src/tests/test_parser_decorador.py
+++ b/backend/src/tests/test_parser_decorador.py
@@ -1,0 +1,17 @@
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from src.core.ast_nodes import NodoFuncion, NodoDecorador, NodoIdentificador
+
+
+def test_parser_funcion_con_decorador():
+    codigo = """@decor\nfunc saludo():\n    fin"""
+    tokens = Lexer(codigo).analizar_token()
+    ast = Parser(tokens).parsear()
+    assert len(ast) == 1
+    nodo = ast[0]
+    assert isinstance(nodo, NodoFuncion)
+    assert len(nodo.decoradores) == 1
+    decor = nodo.decoradores[0]
+    assert isinstance(decor, NodoDecorador)
+    assert isinstance(decor.expresion, NodoIdentificador)
+    assert decor.expresion.nombre == "decor"

--- a/frontend/docs/sintaxis.rst
+++ b/frontend/docs/sintaxis.rst
@@ -87,6 +87,17 @@ Es posible ejecutar funciones de forma concurrente:
 
    hilo trabajo()
 
+**10. Decoradores de funciones**
+
+Puedes anteponer `@` a una función para modificar su comportamiento con un decorador:
+
+.. code-block:: cobra
+
+   @temporizador
+   func saluda():
+       imprimir('hola')
+   fin
+
 **Transpilación a Python, JavaScript, ensamblador y Rust**
 
 - `imprimir` se transpila a `print` en Python, `console.log` en JavaScript, `PRINT` en ensamblador y `println!` en Rust.


### PR DESCRIPTION
## Summary
- enable `DECORADOR` token and mark `decorador` as reserved word
- parse decorators before function definitions and create `NodoDecorador`
- transpile decorators in JS by wrapping functions
- document decorator syntax
- add parser test for decorators

## Testing
- `PYTHONPATH=. pytest backend/src/tests/test_decoradores_yield.py backend/src/tests/test_parser_decorador.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc06f841c832799bb57e4a99ead62