### PR TITLE
Add yield node support

### DIFF
--- a/backend/src/cobra/parser/parser.py
+++ b/backend/src/cobra/parser/parser.py
@@ -55,6 +55,7 @@ PALABRAS_RESERVADAS = {
     "macro",
     "clase",
     "decorador",
+    "yield",
 }
 
 
@@ -83,6 +84,7 @@ class Parser:
             TipoToken.HILO: self.declaracion_hilo,
             TipoToken.TRY: self.declaracion_try_catch,
             TipoToken.THROW: self.declaracion_throw,
+            TipoToken.YIELD: self.declaracion_yield,
             TipoToken.MACRO: self.declaracion_macro,
             TipoToken.CLASE: self.declaracion_clase,
         }
@@ -509,6 +511,11 @@ class Parser:
         """Parsea una declaración 'throw'."""
         self.comer(TipoToken.THROW)
         return NodoThrow(self.expresion())
+
+    def declaracion_yield(self):
+        """Parsea una expresión 'yield' dentro de una función generadora."""
+        self.comer(TipoToken.YIELD)
+        return NodoYield(self.expresion())
 
     def declaracion_macro(self):
         """Parsea la definición de una macro simple."""

--- a/backend/src/cobra/transpilers/transpiler/cpp_nodes/yield_.py
+++ b/backend/src/cobra/transpilers/transpiler/cpp_nodes/yield_.py
@@ -1,0 +1,3 @@
+def visit_yield(self, nodo):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"co_yield {valor};")

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/yield_.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/yield_.py
@@ -1,0 +1,3 @@
+def visit_yield(self, nodo):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"yield {valor};")

--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/yield_.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/yield_.py
@@ -1,0 +1,3 @@
+def visit_yield(self, nodo):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"yield {valor};")

--- a/backend/src/cobra/transpilers/transpiler/to_cpp.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cpp.py
@@ -23,6 +23,7 @@ from .cpp_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_f
 from .cpp_nodes.holobit import visit_holobit as _visit_holobit
 from .cpp_nodes.clase import visit_clase as _visit_clase
 from .cpp_nodes.metodo import visit_metodo as _visit_metodo
+from .cpp_nodes.yield_ import visit_yield as _visit_yield
 
 
 class TranspiladorCPP(NodeVisitor):
@@ -84,3 +85,4 @@ TranspiladorCPP.visit_llamada_funcion = _visit_llamada_funcion
 TranspiladorCPP.visit_holobit = _visit_holobit
 TranspiladorCPP.visit_clase = _visit_clase
 TranspiladorCPP.visit_metodo = _visit_metodo
+TranspiladorCPP.visit_yield = _visit_yield

--- a/backend/src/cobra/transpilers/transpiler/to_js.py
+++ b/backend/src/cobra/transpilers/transpiler/to_js.py
@@ -42,6 +42,7 @@ from .js_nodes.valor import visit_valor as _visit_valor
 from .js_nodes.identificador import visit_identificador as _visit_identificador
 from .js_nodes.para import visit_para as _visit_para
 from .js_nodes.decorador import visit_decorador as _visit_decorador
+from .js_nodes.yield_ import visit_yield as _visit_yield
 
 
 class TranspiladorJavaScript(NodeVisitor):
@@ -138,6 +139,7 @@ TranspiladorJavaScript.visit_valor = _visit_valor
 TranspiladorJavaScript.visit_identificador = _visit_identificador
 TranspiladorJavaScript.visit_para = _visit_para
 TranspiladorJavaScript.visit_decorador = _visit_decorador
+TranspiladorJavaScript.visit_yield = _visit_yield
 
     # Métodos de transpilación para tipos de nodos básicos
 

--- a/backend/src/cobra/transpilers/transpiler/to_rust.py
+++ b/backend/src/cobra/transpilers/transpiler/to_rust.py
@@ -23,6 +23,7 @@ from .rust_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_
 from .rust_nodes.holobit import visit_holobit as _visit_holobit
 from .rust_nodes.clase import visit_clase as _visit_clase
 from .rust_nodes.metodo import visit_metodo as _visit_metodo
+from .rust_nodes.yield_ import visit_yield as _visit_yield
 
 
 class TranspiladorRust(NodeVisitor):
@@ -84,3 +85,4 @@ TranspiladorRust.visit_llamada_funcion = _visit_llamada_funcion
 TranspiladorRust.visit_holobit = _visit_holobit
 TranspiladorRust.visit_clase = _visit_clase
 TranspiladorRust.visit_metodo = _visit_metodo
+TranspiladorRust.visit_yield = _visit_yield

--- a/backend/src/tests/test_generadores.py
+++ b/backend/src/tests/test_generadores.py
@@ -1,0 +1,12 @@
+from src.core.ast_nodes import NodoFuncion, NodoYield, NodoValor
+from src.core.ast_nodes import NodoLlamadaFuncion
+from src.core.interpreter import InterpretadorCobra
+
+
+def test_interpretador_generador_simple():
+    inter = InterpretadorCobra()
+    funcion = NodoFuncion("gen", [], [NodoYield(NodoValor(1)), NodoYield(NodoValor(2))])
+    inter.ejecutar_funcion(funcion)
+    gen = inter.ejecutar_llamada_funcion(NodoLlamadaFuncion("gen", []))
+    assert next(gen) == 1
+    assert next(gen) == 2

--- a/backend/src/tests/test_to_cpp.py
+++ b/backend/src/tests/test_to_cpp.py
@@ -72,3 +72,11 @@ def test_transpilador_clase():
         "};"
     )
     assert resultado == esperado
+
+
+def test_transpilador_yield():
+    ast = [NodoFuncion("generador", [], [NodoYield(NodoValor(1))])]
+    t = TranspiladorCPP()
+    resultado = t.transpilar(ast)
+    esperado = "void generador() {\n    co_yield 1;\n}"
+    assert resultado == esperado

--- a/backend/src/tests/test_to_js.py
+++ b/backend/src/tests/test_to_js.py
@@ -48,3 +48,11 @@ def test_transpilador_holobit():
     resultado = transpilador.transpilar(ast)
     expected = "let miHolobit = new Holobit([0.8, -0.5, 1.2]);"
     assert resultado == expected
+
+
+def test_transpilador_yield():
+    ast = [NodoFuncion("generador", [], [NodoYield(NodoValor(1))])]
+    t = TranspiladorJavaScript()
+    resultado = t.transpilar(ast)
+    esperado = "function generador() {\n    yield 1;\n}"
+    assert resultado == esperado

--- a/backend/src/tests/test_to_rust.py
+++ b/backend/src/tests/test_to_rust.py
@@ -73,3 +73,11 @@ def test_transpilador_clase():
         "}"
     )
     assert resultado == esperado
+
+
+def test_transpilador_yield():
+    ast = [NodoFuncion("generador", [], [NodoYield(NodoValor(1))])]
+    t = TranspiladorRust()
+    resultado = t.transpilar(ast)
+    esperado = "fn generador() {\n    yield 1;\n}"
+    assert resultado == esperado


### PR DESCRIPTION
## Summary
- add `yield` reserved word to parser
- implement parsing rule for `yield`
- translate `NodoYield` in JavaScript, Rust and C++ transpilers
- support generator behavior in interpreter
- add generator test and language transpiler tests

## Testing
- `pytest backend/src/tests/test_generadores.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'holobit_sdk')*

------
https://chatgpt.com/codex/tasks/task_e_685bc4c6aedc83279c4361be0731b3d4