### PR TITLE
Add loop control nodes

### DIFF
--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -74,6 +74,8 @@ class TipoToken:
     HILO = 'HILO'
     DECORADOR = 'DECORADOR'
     YIELD = 'YIELD'
+    ROMPER = 'ROMPER'
+    CONTINUAR = 'CONTINUAR'
 
 
 class Token:
@@ -130,6 +132,8 @@ class Lexer:
             (TipoToken.THROW, r'\bthrow\b'),
             (TipoToken.IMPRIMIR, r'\bimprimir\b'),  # Reconoce 'imprimir'
             (TipoToken.YIELD, r'\byield\b'),
+            (TipoToken.ROMPER, r'\bromper\b'),
+            (TipoToken.CONTINUAR, r'\bcontinuar\b'),
             (TipoToken.FLOTANTE, r'\d+\.\d+'),
             (TipoToken.ENTERO, r'\d+'),
             (TipoToken.CADENA, r"'[^']*'|\"[^\"]*\""),

--- a/backend/src/cobra/macro/__init__.py
+++ b/backend/src/cobra/macro/__init__.py
@@ -1,6 +1,6 @@
 macros = {}
 
-from backend.src.core.ast_nodes import NodoMacro, NodoLlamadaFuncion
+from src.core.ast_nodes import NodoMacro, NodoLlamadaFuncion
 
 def registrar_macro(nodo: NodoMacro):
     """Registra una macro a partir de su nodo."""

--- a/backend/src/cobra/parser/parser.py
+++ b/backend/src/cobra/parser/parser.py
@@ -24,6 +24,8 @@ from src.core.ast_nodes import (
     NodoDecorador,
     NodoTryCatch,
     NodoThrow,
+    NodoRomper,
+    NodoContinuar,
     NodoImport,
     NodoUsar,
     NodoMacro,
@@ -56,6 +58,8 @@ PALABRAS_RESERVADAS = {
     "clase",
     "decorador",
     "yield",
+    "romper",
+    "continuar",
 }
 
 
@@ -85,6 +89,8 @@ class Parser:
             TipoToken.TRY: self.declaracion_try_catch,
             TipoToken.THROW: self.declaracion_throw,
             TipoToken.YIELD: self.declaracion_yield,
+            TipoToken.ROMPER: self.declaracion_romper,
+            TipoToken.CONTINUAR: self.declaracion_continuar,
             TipoToken.MACRO: self.declaracion_macro,
             TipoToken.CLASE: self.declaracion_clase,
         }
@@ -516,6 +522,16 @@ class Parser:
         """Parsea una expresión 'yield' dentro de una función generadora."""
         self.comer(TipoToken.YIELD)
         return NodoYield(self.expresion())
+
+    def declaracion_romper(self):
+        """Parsea la sentencia 'romper' para salir de un bucle."""
+        self.comer(TipoToken.ROMPER)
+        return NodoRomper()
+
+    def declaracion_continuar(self):
+        """Parsea la sentencia 'continuar' para la siguiente iteración."""
+        self.comer(TipoToken.CONTINUAR)
+        return NodoContinuar()
 
     def declaracion_macro(self):
         """Parsea la definición de una macro simple."""

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/continuar.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/continuar.py
@@ -1,0 +1,2 @@
+def visit_continuar(self, nodo):
+    self.agregar_linea("CONTINUE")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/romper.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/romper.py
@@ -1,0 +1,2 @@
+def visit_romper(self, nodo):
+    self.agregar_linea("BREAK")

--- a/backend/src/cobra/transpilers/transpiler/cpp_nodes/continuar.py
+++ b/backend/src/cobra/transpilers/transpiler/cpp_nodes/continuar.py
@@ -1,0 +1,2 @@
+def visit_continuar(self, nodo):
+    self.agregar_linea("continue;")

--- a/backend/src/cobra/transpilers/transpiler/cpp_nodes/romper.py
+++ b/backend/src/cobra/transpilers/transpiler/cpp_nodes/romper.py
@@ -1,0 +1,2 @@
+def visit_romper(self, nodo):
+    self.agregar_linea("break;")

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/continuar.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/continuar.py
@@ -1,0 +1,2 @@
+def visit_continuar(self, nodo):
+    self.agregar_linea("continue;")

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/romper.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/romper.py
@@ -1,0 +1,2 @@
+def visit_romper(self, nodo):
+    self.agregar_linea("break;")

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/continuar.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/continuar.py
@@ -1,0 +1,2 @@
+def visit_continuar(self, nodo):
+    self.codigo += f"{self.obtener_indentacion()}continue\n"

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/romper.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/romper.py
@@ -1,0 +1,2 @@
+def visit_romper(self, nodo):
+    self.codigo += f"{self.obtener_indentacion()}break\n"

--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/continuar.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/continuar.py
@@ -1,0 +1,2 @@
+def visit_continuar(self, nodo):
+    self.agregar_linea("continue;")

--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/romper.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/romper.py
@@ -1,0 +1,2 @@
+def visit_romper(self, nodo):
+    self.agregar_linea("break;")

--- a/backend/src/cobra/transpilers/transpiler/to_asm.py
+++ b/backend/src/cobra/transpilers/transpiler/to_asm.py
@@ -60,6 +60,8 @@ from .asm_nodes.operacion_unaria import visit_operacion_unaria as _visit_operaci
 from .asm_nodes.valor import visit_valor as _visit_valor
 from .asm_nodes.identificador import visit_identificador as _visit_identificador
 from .asm_nodes.usar import visit_usar as _visit_usar
+from .asm_nodes.romper import visit_romper as _visit_romper
+from .asm_nodes.continuar import visit_continuar as _visit_continuar
 
 
 class TranspiladorASM(NodeVisitor):
@@ -139,3 +141,5 @@ TranspiladorASM.visit_operacion_unaria = _visit_operacion_unaria
 TranspiladorASM.visit_valor = _visit_valor
 TranspiladorASM.visit_identificador = _visit_identificador
 TranspiladorASM.visit_usar = _visit_usar
+TranspiladorASM.visit_romper = _visit_romper
+TranspiladorASM.visit_continuar = _visit_continuar

--- a/backend/src/cobra/transpilers/transpiler/to_cpp.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cpp.py
@@ -24,6 +24,8 @@ from .cpp_nodes.holobit import visit_holobit as _visit_holobit
 from .cpp_nodes.clase import visit_clase as _visit_clase
 from .cpp_nodes.metodo import visit_metodo as _visit_metodo
 from .cpp_nodes.yield_ import visit_yield as _visit_yield
+from .cpp_nodes.romper import visit_romper as _visit_romper
+from .cpp_nodes.continuar import visit_continuar as _visit_continuar
 
 
 class TranspiladorCPP(NodeVisitor):
@@ -86,3 +88,5 @@ TranspiladorCPP.visit_holobit = _visit_holobit
 TranspiladorCPP.visit_clase = _visit_clase
 TranspiladorCPP.visit_metodo = _visit_metodo
 TranspiladorCPP.visit_yield = _visit_yield
+TranspiladorCPP.visit_romper = _visit_romper
+TranspiladorCPP.visit_continuar = _visit_continuar

--- a/backend/src/cobra/transpilers/transpiler/to_js.py
+++ b/backend/src/cobra/transpilers/transpiler/to_js.py
@@ -43,6 +43,8 @@ from .js_nodes.identificador import visit_identificador as _visit_identificador
 from .js_nodes.para import visit_para as _visit_para
 from .js_nodes.decorador import visit_decorador as _visit_decorador
 from .js_nodes.yield_ import visit_yield as _visit_yield
+from .js_nodes.romper import visit_romper as _visit_romper
+from .js_nodes.continuar import visit_continuar as _visit_continuar
 
 
 class TranspiladorJavaScript(NodeVisitor):
@@ -140,6 +142,8 @@ TranspiladorJavaScript.visit_identificador = _visit_identificador
 TranspiladorJavaScript.visit_para = _visit_para
 TranspiladorJavaScript.visit_decorador = _visit_decorador
 TranspiladorJavaScript.visit_yield = _visit_yield
+TranspiladorJavaScript.visit_romper = _visit_romper
+TranspiladorJavaScript.visit_continuar = _visit_continuar
 
     # Métodos de transpilación para tipos de nodos básicos
 

--- a/backend/src/cobra/transpilers/transpiler/to_python.py
+++ b/backend/src/cobra/transpilers/transpiler/to_python.py
@@ -53,6 +53,8 @@ from .python_nodes.identificador import visit_identificador as _visit_identifica
 from .python_nodes.para import visit_para as _visit_para
 from .python_nodes.decorador import visit_decorador as _visit_decorador
 from .python_nodes.yield_ import visit_yield as _visit_yield
+from .python_nodes.romper import visit_romper as _visit_romper
+from .python_nodes.continuar import visit_continuar as _visit_continuar
 
 
 class TranspiladorPython(NodeVisitor):
@@ -174,4 +176,6 @@ TranspiladorPython.visit_identificador = _visit_identificador
 TranspiladorPython.visit_para = _visit_para
 TranspiladorPython.visit_decorador = _visit_decorador
 TranspiladorPython.visit_yield = _visit_yield
+TranspiladorPython.visit_romper = _visit_romper
+TranspiladorPython.visit_continuar = _visit_continuar
 

--- a/backend/src/cobra/transpilers/transpiler/to_rust.py
+++ b/backend/src/cobra/transpilers/transpiler/to_rust.py
@@ -24,6 +24,8 @@ from .rust_nodes.holobit import visit_holobit as _visit_holobit
 from .rust_nodes.clase import visit_clase as _visit_clase
 from .rust_nodes.metodo import visit_metodo as _visit_metodo
 from .rust_nodes.yield_ import visit_yield as _visit_yield
+from .rust_nodes.romper import visit_romper as _visit_romper
+from .rust_nodes.continuar import visit_continuar as _visit_continuar
 
 
 class TranspiladorRust(NodeVisitor):
@@ -86,3 +88,5 @@ TranspiladorRust.visit_holobit = _visit_holobit
 TranspiladorRust.visit_clase = _visit_clase
 TranspiladorRust.visit_metodo = _visit_metodo
 TranspiladorRust.visit_yield = _visit_yield
+TranspiladorRust.visit_romper = _visit_romper
+TranspiladorRust.visit_continuar = _visit_continuar

--- a/backend/src/core/__init__.py
+++ b/backend/src/core/__init__.py
@@ -34,6 +34,8 @@ __all__ = [
     'NodoTryCatch',
     'NodoImport',
     'NodoUsar',
+    'NodoRomper',
+    'NodoContinuar',
     'NodoPara',
     'NodoImprimir',
     'NodeVisitor',

--- a/backend/src/core/ast_nodes.py
+++ b/backend/src/core/ast_nodes.py
@@ -240,6 +240,22 @@ class NodoYield(NodoAST):
 
 
 @dataclass
+class NodoRomper(NodoAST):
+    """Sentencia para romper un bucle."""
+
+    def __repr__(self):
+        return "NodoRomper()"
+
+
+@dataclass
+class NodoContinuar(NodoAST):
+    """Sentencia para continuar con la siguiente iteración de un bucle."""
+
+    def __repr__(self):
+        return "NodoContinuar()"
+
+
+@dataclass
 class NodoThrow(NodoAST):
     expresion: Any
 
@@ -331,6 +347,8 @@ __all__ = [
     'NodoHilo',
     'NodoRetorno',
     'NodoYield',
+    'NodoRomper',
+    'NodoContinuar',
     'NodoThrow',
     'NodoTryCatch',
     'NodoImport',

--- a/backend/src/tests/test_romper_continuar.py
+++ b/backend/src/tests/test_romper_continuar.py
@@ -1,0 +1,51 @@
+import pytest
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from src.core.ast_nodes import (
+    NodoBucleMientras,
+    NodoPara,
+    NodoRomper,
+    NodoContinuar,
+    NodoValor,
+)
+from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+
+
+def test_parser_romper_continuar():
+    codigo = """
+    mientras x > 5:
+        romper
+    fin
+    para i in lista:
+        continuar
+    fin
+    """
+    tokens = Lexer(codigo).tokenizar()
+    ast = Parser(tokens).parsear()
+    assert isinstance(ast[0], NodoBucleMientras)
+    assert isinstance(ast[0].cuerpo[0], NodoRomper)
+    assert isinstance(ast[1], NodoPara)
+    assert isinstance(ast[1].cuerpo[0], NodoContinuar)
+
+
+def test_transpilar_romper_python():
+    nodo = NodoBucleMientras("i < 3", [NodoRomper()])
+    t = TranspiladorPython()
+    resultado = t.transpilar([nodo])
+    esperado = "from src.core.nativos import *\nwhile i < 3:\n    break\n"
+    assert resultado == esperado
+
+
+def test_transpilar_continuar_js():
+    nodo = NodoPara("x", NodoValor("datos"), [NodoContinuar()])
+    t = TranspiladorJavaScript()
+    resultado = t.transpilar([nodo])
+    esperado = (
+        "import * as io from './nativos/io.js';\n"
+        "import * as net from './nativos/io.js';\n"
+        "import * as matematicas from './nativos/matematicas.js';\n"
+        "import { Pila, Cola } from './nativos/estructuras.js';\n"
+        "for (let x of datos) {\ncontinue;\n}"
+    )
+    assert resultado == esperado


### PR DESCRIPTION
## Summary
- add new tokens `ROMPER` and `CONTINUAR`
- implement new AST nodes `NodoRomper` and `NodoContinuar`
- parse new keywords in the parser
- transpile loop control statements for all targets
- add regression tests for break/continue

## Testing
- `pytest backend/src/tests/test_romper_continuar.py -q`
- `pytest -q` *(interrupted after completion)*

------
https://chatgpt.com/codex/tasks/task_e_685bc81ae49c83279f1d682f2ff9b5c7