### PR TITLE
Add 'pasar' statement support

### DIFF
--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -76,6 +76,7 @@ class TipoToken:
     YIELD = 'YIELD'
     ROMPER = 'ROMPER'
     CONTINUAR = 'CONTINUAR'
+    PASAR = 'PASAR'
 
 
 class Token:
@@ -134,6 +135,7 @@ class Lexer:
             (TipoToken.YIELD, r'\byield\b'),
             (TipoToken.ROMPER, r'\bromper\b'),
             (TipoToken.CONTINUAR, r'\bcontinuar\b'),
+            (TipoToken.PASAR, r'\bpasar\b'),
             (TipoToken.FLOTANTE, r'\d+\.\d+'),
             (TipoToken.ENTERO, r'\d+'),
             (TipoToken.CADENA, r"'[^']*'|\"[^\"]*\""),

--- a/backend/src/cobra/parser/parser.py
+++ b/backend/src/cobra/parser/parser.py
@@ -26,6 +26,7 @@ from src.core.ast_nodes import (
     NodoThrow,
     NodoRomper,
     NodoContinuar,
+    NodoPasar,
     NodoImport,
     NodoUsar,
     NodoMacro,
@@ -60,6 +61,7 @@ PALABRAS_RESERVADAS = {
     "yield",
     "romper",
     "continuar",
+    "pasar",
 }
 
 
@@ -91,6 +93,7 @@ class Parser:
             TipoToken.YIELD: self.declaracion_yield,
             TipoToken.ROMPER: self.declaracion_romper,
             TipoToken.CONTINUAR: self.declaracion_continuar,
+            TipoToken.PASAR: self.declaracion_pasar,
             TipoToken.MACRO: self.declaracion_macro,
             TipoToken.CLASE: self.declaracion_clase,
         }
@@ -532,6 +535,11 @@ class Parser:
         """Parsea la sentencia 'continuar' para la siguiente iteración."""
         self.comer(TipoToken.CONTINUAR)
         return NodoContinuar()
+
+    def declaracion_pasar(self):
+        """Parsea la sentencia 'pasar' que no realiza ninguna acción."""
+        self.comer(TipoToken.PASAR)
+        return NodoPasar()
 
     def declaracion_macro(self):
         """Parsea la definición de una macro simple."""

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/pasar.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/pasar.py
@@ -1,0 +1,3 @@
+def visit_pasar(self, nodo):
+    self.agregar_linea("NOP")
+

--- a/backend/src/cobra/transpilers/transpiler/cpp_nodes/pasar.py
+++ b/backend/src/cobra/transpilers/transpiler/cpp_nodes/pasar.py
@@ -1,0 +1,3 @@
+def visit_pasar(self, nodo):
+    self.agregar_linea(";")
+

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/pasar.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/pasar.py
@@ -1,0 +1,3 @@
+def visit_pasar(self, nodo):
+    self.agregar_linea(";")
+

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/pasar.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/pasar.py
@@ -1,0 +1,3 @@
+def visit_pasar(self, nodo):
+    self.codigo += f"{self.obtener_indentacion()}pass\n"
+

--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/pasar.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/pasar.py
@@ -1,0 +1,3 @@
+def visit_pasar(self, nodo):
+    self.agregar_linea(";")
+

--- a/backend/src/cobra/transpilers/transpiler/to_asm.py
+++ b/backend/src/cobra/transpilers/transpiler/to_asm.py
@@ -62,6 +62,7 @@ from .asm_nodes.identificador import visit_identificador as _visit_identificador
 from .asm_nodes.usar import visit_usar as _visit_usar
 from .asm_nodes.romper import visit_romper as _visit_romper
 from .asm_nodes.continuar import visit_continuar as _visit_continuar
+from .asm_nodes.pasar import visit_pasar as _visit_pasar
 
 
 class TranspiladorASM(NodeVisitor):
@@ -143,3 +144,4 @@ TranspiladorASM.visit_identificador = _visit_identificador
 TranspiladorASM.visit_usar = _visit_usar
 TranspiladorASM.visit_romper = _visit_romper
 TranspiladorASM.visit_continuar = _visit_continuar
+TranspiladorASM.visit_pasar = _visit_pasar

--- a/backend/src/cobra/transpilers/transpiler/to_cpp.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cpp.py
@@ -26,6 +26,7 @@ from .cpp_nodes.metodo import visit_metodo as _visit_metodo
 from .cpp_nodes.yield_ import visit_yield as _visit_yield
 from .cpp_nodes.romper import visit_romper as _visit_romper
 from .cpp_nodes.continuar import visit_continuar as _visit_continuar
+from .cpp_nodes.pasar import visit_pasar as _visit_pasar
 
 
 class TranspiladorCPP(NodeVisitor):
@@ -90,3 +91,4 @@ TranspiladorCPP.visit_metodo = _visit_metodo
 TranspiladorCPP.visit_yield = _visit_yield
 TranspiladorCPP.visit_romper = _visit_romper
 TranspiladorCPP.visit_continuar = _visit_continuar
+TranspiladorCPP.visit_pasar = _visit_pasar

--- a/backend/src/cobra/transpilers/transpiler/to_js.py
+++ b/backend/src/cobra/transpilers/transpiler/to_js.py
@@ -45,6 +45,7 @@ from .js_nodes.decorador import visit_decorador as _visit_decorador
 from .js_nodes.yield_ import visit_yield as _visit_yield
 from .js_nodes.romper import visit_romper as _visit_romper
 from .js_nodes.continuar import visit_continuar as _visit_continuar
+from .js_nodes.pasar import visit_pasar as _visit_pasar
 
 
 class TranspiladorJavaScript(NodeVisitor):
@@ -144,6 +145,7 @@ TranspiladorJavaScript.visit_decorador = _visit_decorador
 TranspiladorJavaScript.visit_yield = _visit_yield
 TranspiladorJavaScript.visit_romper = _visit_romper
 TranspiladorJavaScript.visit_continuar = _visit_continuar
+TranspiladorJavaScript.visit_pasar = _visit_pasar
 
     # Métodos de transpilación para tipos de nodos básicos
 

--- a/backend/src/cobra/transpilers/transpiler/to_python.py
+++ b/backend/src/cobra/transpilers/transpiler/to_python.py
@@ -55,6 +55,7 @@ from .python_nodes.decorador import visit_decorador as _visit_decorador
 from .python_nodes.yield_ import visit_yield as _visit_yield
 from .python_nodes.romper import visit_romper as _visit_romper
 from .python_nodes.continuar import visit_continuar as _visit_continuar
+from .python_nodes.pasar import visit_pasar as _visit_pasar
 
 
 class TranspiladorPython(NodeVisitor):
@@ -178,4 +179,5 @@ TranspiladorPython.visit_decorador = _visit_decorador
 TranspiladorPython.visit_yield = _visit_yield
 TranspiladorPython.visit_romper = _visit_romper
 TranspiladorPython.visit_continuar = _visit_continuar
+TranspiladorPython.visit_pasar = _visit_pasar
 

--- a/backend/src/cobra/transpilers/transpiler/to_rust.py
+++ b/backend/src/cobra/transpilers/transpiler/to_rust.py
@@ -26,6 +26,7 @@ from .rust_nodes.metodo import visit_metodo as _visit_metodo
 from .rust_nodes.yield_ import visit_yield as _visit_yield
 from .rust_nodes.romper import visit_romper as _visit_romper
 from .rust_nodes.continuar import visit_continuar as _visit_continuar
+from .rust_nodes.pasar import visit_pasar as _visit_pasar
 
 
 class TranspiladorRust(NodeVisitor):
@@ -90,3 +91,4 @@ TranspiladorRust.visit_metodo = _visit_metodo
 TranspiladorRust.visit_yield = _visit_yield
 TranspiladorRust.visit_romper = _visit_romper
 TranspiladorRust.visit_continuar = _visit_continuar
+TranspiladorRust.visit_pasar = _visit_pasar

--- a/backend/src/core/__init__.py
+++ b/backend/src/core/__init__.py
@@ -36,6 +36,7 @@ __all__ = [
     'NodoUsar',
     'NodoRomper',
     'NodoContinuar',
+    'NodoPasar',
     'NodoPara',
     'NodoImprimir',
     'NodeVisitor',

--- a/backend/src/core/ast_nodes.py
+++ b/backend/src/core/ast_nodes.py
@@ -256,6 +256,14 @@ class NodoContinuar(NodoAST):
 
 
 @dataclass
+class NodoPasar(NodoAST):
+    """Sentencia vacía que no realiza ninguna acción."""
+
+    def __repr__(self):
+        return "NodoPasar()"
+
+
+@dataclass
 class NodoThrow(NodoAST):
     expresion: Any
 
@@ -349,6 +357,7 @@ __all__ = [
     'NodoYield',
     'NodoRomper',
     'NodoContinuar',
+    'NodoPasar',
     'NodoThrow',
     'NodoTryCatch',
     'NodoImport',

--- a/backend/src/tests/test_pasar.py
+++ b/backend/src/tests/test_pasar.py
@@ -1,0 +1,40 @@
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from src.core.ast_nodes import NodoBucleMientras, NodoPasar
+from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+
+
+def test_parser_pasar():
+    codigo = """
+    mientras x > 0:
+        pasar
+    fin
+    """
+    tokens = Lexer(codigo).tokenizar()
+    ast = Parser(tokens).parsear()
+    assert isinstance(ast[0], NodoBucleMientras)
+    assert isinstance(ast[0].cuerpo[0], NodoPasar)
+
+
+def test_transpilar_pasar_python():
+    nodo = NodoPasar()
+    t = TranspiladorPython()
+    resultado = t.transpilar([nodo])
+    esperado = "from src.core.nativos import *\npass\n"
+    assert resultado == esperado
+
+
+def test_transpilar_pasar_js():
+    nodo = NodoPasar()
+    t = TranspiladorJavaScript()
+    resultado = t.transpilar([nodo])
+    esperado = (
+        "import * as io from './nativos/io.js';\n"
+        "import * as net from './nativos/io.js';\n"
+        "import * as matematicas from './nativos/matematicas.js';\n"
+        "import { Pila, Cola } from './nativos/estructuras.js';\n"
+        ";"
+    )
+    assert resultado == esperado
+


### PR DESCRIPTION
## Summary
- add PASAR token to lexer
- define `NodoPasar` in AST and export it
- support `pasar` in parser and reserved words
- output appropriate pass/no-op instructions in all transpilers
- test parsing and transpilation of `pasar`

## Testing
- `pytest backend/src/tests/test_pasar.py backend/src/tests/test_romper_continuar.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685bce82b0bc832789677082622f5e5c