### PR TITLE
Integra iddle de Cobra con Flet

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,12 +272,12 @@ cobra modulos remover modulo.co
 cobra docs
 # Crear un ejecutable independiente
 cobra empaquetar --output dist
-# Iniciar la interfaz gráfica (requiere Flet)
+# Iniciar el iddle gráfico (requiere Flet)
 cobra gui
 ```
 
 El subcomando `docs` ejecuta `sphinx-apidoc` para generar la documentación de la API antes de compilar el HTML.
-El subcomando `gui` abre la interfaz gráfica y requiere tener instalado Flet.
+El subcomando `gui` abre el iddle integrado y requiere tener instalado Flet.
 
 
 Si no se pasa un subcomando se abrirá el modo interactivo. Usa `cobra --help` para más detalles.

--- a/backend/src/cli/commands/flet_cmd.py
+++ b/backend/src/cli/commands/flet_cmd.py
@@ -2,7 +2,7 @@ from .base import BaseCommand
 
 
 class FletCommand(BaseCommand):
-    """Inicia la interfaz gráfica utilizando Flet."""
+    """Inicia el entorno IDLE basado en Flet."""
 
     name = "gui"
 
@@ -16,7 +16,7 @@ class FletCommand(BaseCommand):
     def run(self, args):
         try:
             import flet
-            from src.gui.app import main
+            from src.gui.idle import main
         except ModuleNotFoundError:
             print("Flet no está instalado. Ejecuta 'pip install flet'.")
             return 1

--- a/backend/src/gui/idle.py
+++ b/backend/src/gui/idle.py
@@ -1,0 +1,59 @@
+import io
+import sys
+import flet as ft
+
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from src.core.interpreter import InterpretadorCobra
+
+
+def _ejecutar_codigo(codigo: str) -> str:
+    """Ejecuta código Cobra y captura la salida impresa."""
+    buffer = io.StringIO()
+    stdout = sys.stdout
+    sys.stdout = buffer
+    try:
+        tokens = Lexer(codigo).tokenizar()
+        ast = Parser(tokens).parsear()
+        InterpretadorCobra().ejecutar_ast(ast)
+    finally:
+        sys.stdout = stdout
+    return buffer.getvalue()
+
+
+def _mostrar_tokens(codigo: str) -> str:
+    tokens = Lexer(codigo).tokenizar()
+    return "\n".join(str(t) for t in tokens)
+
+
+def _mostrar_ast(codigo: str) -> str:
+    tokens = Lexer(codigo).tokenizar()
+    ast = Parser(tokens).parsear()
+    return str(ast)
+
+
+def main(page: ft.Page):
+    """Función principal para el entorno IDLE."""
+
+    entrada = ft.TextField(multiline=True, expand=True)
+    salida = ft.Text(value="", selectable=True)
+
+    def ejecutar_handler(e):
+        salida.value = _ejecutar_codigo(entrada.value)
+        page.update()
+
+    def tokens_handler(e):
+        salida.value = _mostrar_tokens(entrada.value)
+        page.update()
+
+    def ast_handler(e):
+        salida.value = _mostrar_ast(entrada.value)
+        page.update()
+
+    page.add(
+        entrada,
+        ft.ElevatedButton("Ejecutar", on_click=ejecutar_handler),
+        ft.ElevatedButton("Tokens", on_click=tokens_handler),
+        ft.ElevatedButton("AST", on_click=ast_handler),
+        salida,
+    )


### PR DESCRIPTION
## Summary
- crea un fichero `idle.py` que implementa un iddle minimal usando Flet
- ajusta el subcomando `gui` para lanzar el nuevo iddle
- actualiza el README para reflejar el cambio

## Testing
- `pytest backend/src/tests/test_cli_gui.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685be4792bd08327b3ac4c3f29d2a3ae