### PR TITLE
Add basic transpilers for Go, R and Julia

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/to_go.py
+++ b/backend/src/cobra/transpilers/transpiler/to_go.py
@@ -1,0 +1,98 @@
+"""Transpilador sencillo de Cobra a Go."""
+
+from src.core.ast_nodes import (
+    NodoValor,
+    NodoIdentificador,
+    NodoLlamadaFuncion,
+    NodoAsignacion,
+    NodoFuncion,
+    NodoImprimir,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoAtributo,
+)
+from src.cobra.lexico.lexer import TipoToken
+from src.core.visitor import NodeVisitor
+from src.core.optimizations import optimize_constants, remove_dead_code
+from src.cobra.macro import expandir_macros
+
+
+def visit_asignacion(self, nodo: NodoAsignacion):
+    nombre = getattr(nodo, "identificador", nodo.variable)
+    op = ":=" if hasattr(nodo, "variable") else "="
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"{nombre} {op} {valor}")
+
+
+def visit_funcion(self, nodo: NodoFuncion):
+    params = ", ".join(nodo.parametros)
+    self.agregar_linea(f"func {nodo.nombre}({params}) {{")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+
+
+def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"{nodo.nombre}({args})")
+
+
+def visit_imprimir(self, nodo: NodoImprimir):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"fmt.Println({valor})")
+
+
+go_nodes = {
+    "asignacion": visit_asignacion,
+    "funcion": visit_funcion,
+    "llamada_funcion": visit_llamada_funcion,
+    "imprimir": visit_imprimir,
+}
+
+
+class TranspiladorGo(NodeVisitor):
+    def __init__(self):
+        self.codigo = []
+        self.indent = 0
+
+    def agregar_linea(self, linea: str) -> None:
+        self.codigo.append("    " * self.indent + linea)
+
+    def obtener_valor(self, nodo):
+        if isinstance(nodo, NodoValor):
+            return str(nodo.valor)
+        elif isinstance(nodo, NodoIdentificador):
+            return nodo.nombre
+        elif isinstance(nodo, NodoAtributo):
+            return f"{self.obtener_valor(nodo.objeto)}.{nodo.nombre}"
+        elif isinstance(nodo, NodoLlamadaFuncion):
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"{nodo.nombre}({args})"
+        elif isinstance(nodo, NodoOperacionBinaria):
+            izq = self.obtener_valor(nodo.izquierda)
+            der = self.obtener_valor(nodo.derecha)
+            op_map = {TipoToken.AND: "&&", TipoToken.OR: "||"}
+            op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
+            return f"{izq} {op} {der}"
+        elif isinstance(nodo, NodoOperacionUnaria):
+            val = self.obtener_valor(nodo.operando)
+            op = "!" if nodo.operador.tipo == TipoToken.NOT else nodo.operador.valor
+            return f"{op}{val}" if op != "!" else f"!{val}"
+        else:
+            return str(getattr(nodo, "valor", nodo))
+
+    def transpilar(self, nodos):
+        nodos = expandir_macros(nodos)
+        nodos = remove_dead_code(optimize_constants(nodos))
+        for nodo in nodos:
+            metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
+            if metodo:
+                metodo(nodo)
+        return "\n".join(self.codigo)
+
+
+# Asignar visitantes
+for nombre, funcion in go_nodes.items():
+    setattr(TranspiladorGo, f"visit_{nombre}", funcion)

--- a/backend/src/cobra/transpilers/transpiler/to_julia.py
+++ b/backend/src/cobra/transpilers/transpiler/to_julia.py
@@ -1,0 +1,96 @@
+"""Transpilador simple de Cobra a Julia."""
+
+from src.core.ast_nodes import (
+    NodoValor,
+    NodoIdentificador,
+    NodoLlamadaFuncion,
+    NodoAsignacion,
+    NodoFuncion,
+    NodoImprimir,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoAtributo,
+)
+from src.cobra.lexico.lexer import TipoToken
+from src.core.visitor import NodeVisitor
+from src.core.optimizations import optimize_constants, remove_dead_code
+from src.cobra.macro import expandir_macros
+
+
+def visit_asignacion(self, nodo: NodoAsignacion):
+    nombre = getattr(nodo, "identificador", nodo.variable)
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"{nombre} = {valor}")
+
+
+def visit_funcion(self, nodo: NodoFuncion):
+    params = ", ".join(nodo.parametros)
+    self.agregar_linea(f"function {nodo.nombre}({params})")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("end")
+
+
+def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"{nodo.nombre}({args})")
+
+
+def visit_imprimir(self, nodo: NodoImprimir):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"println({valor})")
+
+
+julia_nodes = {
+    "asignacion": visit_asignacion,
+    "funcion": visit_funcion,
+    "llamada_funcion": visit_llamada_funcion,
+    "imprimir": visit_imprimir,
+}
+
+
+class TranspiladorJulia(NodeVisitor):
+    def __init__(self):
+        self.codigo = []
+        self.indent = 0
+
+    def agregar_linea(self, linea: str) -> None:
+        self.codigo.append("    " * self.indent + linea)
+
+    def obtener_valor(self, nodo):
+        if isinstance(nodo, NodoValor):
+            return str(nodo.valor)
+        elif isinstance(nodo, NodoIdentificador):
+            return nodo.nombre
+        elif isinstance(nodo, NodoAtributo):
+            return f"{self.obtener_valor(nodo.objeto)}.{nodo.nombre}"
+        elif isinstance(nodo, NodoLlamadaFuncion):
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"{nodo.nombre}({args})"
+        elif isinstance(nodo, NodoOperacionBinaria):
+            izq = self.obtener_valor(nodo.izquierda)
+            der = self.obtener_valor(nodo.derecha)
+            op_map = {TipoToken.AND: "&&", TipoToken.OR: "||"}
+            op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
+            return f"{izq} {op} {der}"
+        elif isinstance(nodo, NodoOperacionUnaria):
+            val = self.obtener_valor(nodo.operando)
+            op = "!" if nodo.operador.tipo == TipoToken.NOT else nodo.operador.valor
+            return f"{op}{val}" if op != "!" else f"!{val}"
+        else:
+            return str(getattr(nodo, "valor", nodo))
+
+    def transpilar(self, nodos):
+        nodos = expandir_macros(nodos)
+        nodos = remove_dead_code(optimize_constants(nodos))
+        for nodo in nodos:
+            metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
+            if metodo:
+                metodo(nodo)
+        return "\n".join(self.codigo)
+
+
+for nombre, funcion in julia_nodes.items():
+    setattr(TranspiladorJulia, f"visit_{nombre}", funcion)

--- a/backend/src/cobra/transpilers/transpiler/to_r.py
+++ b/backend/src/cobra/transpilers/transpiler/to_r.py
@@ -1,0 +1,96 @@
+"""Transpilador básico de Cobra a R."""
+
+from src.core.ast_nodes import (
+    NodoValor,
+    NodoIdentificador,
+    NodoLlamadaFuncion,
+    NodoAsignacion,
+    NodoFuncion,
+    NodoImprimir,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoAtributo,
+)
+from src.cobra.lexico.lexer import TipoToken
+from src.core.visitor import NodeVisitor
+from src.core.optimizations import optimize_constants, remove_dead_code
+from src.cobra.macro import expandir_macros
+
+
+def visit_asignacion(self, nodo: NodoAsignacion):
+    nombre = getattr(nodo, "identificador", nodo.variable)
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"{nombre} <- {valor}")
+
+
+def visit_funcion(self, nodo: NodoFuncion):
+    params = ", ".join(nodo.parametros)
+    self.agregar_linea(f"{nodo.nombre} <- function({params}) {{")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+
+
+def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"{nodo.nombre}({args})")
+
+
+def visit_imprimir(self, nodo: NodoImprimir):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"print({valor})")
+
+
+r_nodes = {
+    "asignacion": visit_asignacion,
+    "funcion": visit_funcion,
+    "llamada_funcion": visit_llamada_funcion,
+    "imprimir": visit_imprimir,
+}
+
+
+class TranspiladorR(NodeVisitor):
+    def __init__(self):
+        self.codigo = []
+        self.indent = 0
+
+    def agregar_linea(self, linea: str) -> None:
+        self.codigo.append("    " * self.indent + linea)
+
+    def obtener_valor(self, nodo):
+        if isinstance(nodo, NodoValor):
+            return str(nodo.valor)
+        elif isinstance(nodo, NodoIdentificador):
+            return nodo.nombre
+        elif isinstance(nodo, NodoAtributo):
+            return f"{self.obtener_valor(nodo.objeto)}${nodo.nombre}"
+        elif isinstance(nodo, NodoLlamadaFuncion):
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"{nodo.nombre}({args})"
+        elif isinstance(nodo, NodoOperacionBinaria):
+            izq = self.obtener_valor(nodo.izquierda)
+            der = self.obtener_valor(nodo.derecha)
+            op_map = {TipoToken.AND: "&&", TipoToken.OR: "||"}
+            op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
+            return f"{izq} {op} {der}"
+        elif isinstance(nodo, NodoOperacionUnaria):
+            val = self.obtener_valor(nodo.operando)
+            op = "!" if nodo.operador.tipo == TipoToken.NOT else nodo.operador.valor
+            return f"{op}{val}" if op != "!" else f"!{val}"
+        else:
+            return str(getattr(nodo, "valor", nodo))
+
+    def transpilar(self, nodos):
+        nodos = expandir_macros(nodos)
+        nodos = remove_dead_code(optimize_constants(nodos))
+        for nodo in nodos:
+            metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
+            if metodo:
+                metodo(nodo)
+        return "\n".join(self.codigo)
+
+
+for nombre, funcion in r_nodes.items():
+    setattr(TranspiladorR, f"visit_{nombre}", funcion)


### PR DESCRIPTION
## Summary
- implement minimal Go, R and Julia transpilers
- add helper dictionaries for basic nodes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'smooth_criminal')*

------
https://chatgpt.com/codex/tasks/task_e_685be8fb7d2c83278834ca519a934d79