### PR TITLE
Add Go, R and Julia options

### DIFF
--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -10,6 +10,9 @@ from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 from src.cobra.transpilers.transpiler.to_asm import TranspiladorASM
 from src.cobra.transpilers.transpiler.to_rust import TranspiladorRust
 from src.cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
+from src.cobra.transpilers.transpiler.to_go import TranspiladorGo
+from src.cobra.transpilers.transpiler.to_r import TranspiladorR
+from src.cobra.transpilers.transpiler.to_julia import TranspiladorJulia
 
 
 class CompileCommand(BaseCommand):
@@ -22,7 +25,7 @@ class CompileCommand(BaseCommand):
         parser.add_argument("archivo")
         parser.add_argument(
             "--tipo",
-            choices=["python", "js", "asm", "rust", "cpp"],
+            choices=["python", "js", "asm", "rust", "cpp", "go", "r", "julia"],
             default="python",
             help="Tipo de código generado",
         )
@@ -56,6 +59,12 @@ class CompileCommand(BaseCommand):
                     transp = TranspiladorRust()
                 elif transpilador == "cpp":
                     transp = TranspiladorCPP()
+                elif transpilador == "go":
+                    transp = TranspiladorGo()
+                elif transpilador == "r":
+                    transp = TranspiladorR()
+                elif transpilador == "julia":
+                    transp = TranspiladorJulia()
                 else:
                     raise ValueError("Transpilador no soportado.")
 


### PR DESCRIPTION
## Summary
- allow `go`, `r` and `julia` as values for `--tipo`
- import the new transpilers
- route compile command to use the chosen transpiler

## Testing
- `pytest backend/src/tests/test_cli_commands_extra.py::test_cli_compilar_generates_output -q`
- `pytest backend/src/tests -q` *(fails: NameError: NodoEsperar is not defined and others)*

------
https://chatgpt.com/codex/tasks/task_e_685bea5eeec88327bd346afae6b8e4d7