### PR TITLE
Add tests for Go, R and Julia transpilers

### DIFF
--- a/backend/src/tests/test_cli_commands_extra.py
+++ b/backend/src/tests/test_cli_commands_extra.py
@@ -43,6 +43,27 @@ from src.cli.commands import modules_cmd
                 "auto x = 5;",
             ],
         ),
+        (
+            "go",
+            [
+                "Código generado (TranspiladorGo):",
+                "x := 5",
+            ],
+        ),
+        (
+            "r",
+            [
+                "Código generado (TranspiladorR):",
+                "x <- 5",
+            ],
+        ),
+        (
+            "julia",
+            [
+                "Código generado (TranspiladorJulia):",
+                "x = 5",
+            ],
+        ),
     ],
 )
 def test_cli_compilar_generates_output(tmp_path, tipo, esperado):

--- a/backend/src/tests/test_to_go.py
+++ b/backend/src/tests/test_to_go.py
@@ -1,0 +1,31 @@
+from src.cobra.transpilers.transpiler.to_go import TranspiladorGo
+from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+
+
+def test_transpilador_asignacion_go():
+    ast = [NodoAsignacion("x", 10)]
+    t = TranspiladorGo()
+    resultado = t.transpilar(ast)
+    assert resultado == "x := 10"
+
+
+def test_transpilador_funcion_go():
+    ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
+    t = TranspiladorGo()
+    resultado = t.transpilar(ast)
+    esperado = "func miFuncion(a, b) {\n    x := a + b\n}"
+    assert resultado == esperado
+
+
+def test_transpilador_llamada_funcion_go():
+    ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
+    t = TranspiladorGo()
+    resultado = t.transpilar(ast)
+    assert resultado == "miFuncion(a, b)"
+
+
+def test_transpilador_imprimir_go():
+    ast = [NodoImprimir(NodoValor("x"))]
+    t = TranspiladorGo()
+    resultado = t.transpilar(ast)
+    assert resultado == "fmt.Println(x)"

--- a/backend/src/tests/test_to_julia.py
+++ b/backend/src/tests/test_to_julia.py
@@ -1,0 +1,31 @@
+from src.cobra.transpilers.transpiler.to_julia import TranspiladorJulia
+from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+
+
+def test_transpilador_asignacion_julia():
+    ast = [NodoAsignacion("x", 10)]
+    t = TranspiladorJulia()
+    resultado = t.transpilar(ast)
+    assert resultado == "x = 10"
+
+
+def test_transpilador_funcion_julia():
+    ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
+    t = TranspiladorJulia()
+    resultado = t.transpilar(ast)
+    esperado = "function miFuncion(a, b)\n    x = a + b\nend"
+    assert resultado == esperado
+
+
+def test_transpilador_llamada_funcion_julia():
+    ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
+    t = TranspiladorJulia()
+    resultado = t.transpilar(ast)
+    assert resultado == "miFuncion(a, b)"
+
+
+def test_transpilador_imprimir_julia():
+    ast = [NodoImprimir(NodoValor("x"))]
+    t = TranspiladorJulia()
+    resultado = t.transpilar(ast)
+    assert resultado == "println(x)"

--- a/backend/src/tests/test_to_r.py
+++ b/backend/src/tests/test_to_r.py
@@ -1,0 +1,31 @@
+from src.cobra.transpilers.transpiler.to_r import TranspiladorR
+from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+
+
+def test_transpilador_asignacion_r():
+    ast = [NodoAsignacion("x", 10)]
+    t = TranspiladorR()
+    resultado = t.transpilar(ast)
+    assert resultado == "x <- 10"
+
+
+def test_transpilador_funcion_r():
+    ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
+    t = TranspiladorR()
+    resultado = t.transpilar(ast)
+    esperado = "miFuncion <- function(a, b) {\n    x <- a + b\n}"
+    assert resultado == esperado
+
+
+def test_transpilador_llamada_funcion_r():
+    ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
+    t = TranspiladorR()
+    resultado = t.transpilar(ast)
+    assert resultado == "miFuncion(a, b)"
+
+
+def test_transpilador_imprimir_r():
+    ast = [NodoImprimir(NodoValor("x"))]
+    t = TranspiladorR()
+    resultado = t.transpilar(ast)
+    assert resultado == "print(x)"


### PR DESCRIPTION
## Summary
- add unit tests for TranspiladorGo, TranspiladorR and TranspiladorJulia
- extend CLI compile tests to cover Go, R and Julia outputs

## Testing
- `pytest -k "test_to_go or test_to_r or test_to_julia or test_cli_compilar_generates_output" -vv` *(fails: PluggyTeardownRaisedWarning)*

------
https://chatgpt.com/codex/tasks/task_e_685bee46e5b8832795936d043069a54f