### PR TITLE
Add basic Java transpiler

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/to_java.py
+++ b/backend/src/cobra/transpilers/transpiler/to_java.py
@@ -1,0 +1,102 @@
+"""Transpilador sencillo de Cobra a Java."""
+
+from src.core.ast_nodes import (
+    NodoValor,
+    NodoIdentificador,
+    NodoLlamadaFuncion,
+    NodoAsignacion,
+    NodoFuncion,
+    NodoImprimir,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoAtributo,
+)
+from src.cobra.lexico.lexer import TipoToken
+from src.core.visitor import NodeVisitor
+from src.core.optimizations import optimize_constants, remove_dead_code
+from src.cobra.macro import expandir_macros
+
+
+def visit_asignacion(self, nodo: NodoAsignacion):
+    nombre = getattr(nodo, "identificador", nodo.variable)
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"var {nombre} = {valor};")
+
+
+def visit_funcion(self, nodo: NodoFuncion):
+    params = ", ".join(nodo.parametros)
+    self.agregar_linea(f"static void {nodo.nombre}({params}) {{")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+
+
+def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"{nodo.nombre}({args});")
+
+
+def visit_imprimir(self, nodo: NodoImprimir):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"System.out.println({valor});")
+
+
+java_nodes = {
+    "asignacion": visit_asignacion,
+    "funcion": visit_funcion,
+    "llamada_funcion": visit_llamada_funcion,
+    "imprimir": visit_imprimir,
+}
+
+
+class TranspiladorJava(NodeVisitor):
+    def __init__(self):
+        self.codigo = []
+        self.indent = 0
+
+    def agregar_linea(self, linea: str) -> None:
+        self.codigo.append("    " * self.indent + linea)
+
+    def obtener_valor(self, nodo):
+        if isinstance(nodo, NodoValor):
+            return str(nodo.valor)
+        elif isinstance(nodo, NodoIdentificador):
+            return nodo.nombre
+        elif isinstance(nodo, NodoAtributo):
+            return f"{self.obtener_valor(nodo.objeto)}.{nodo.nombre}"
+        elif isinstance(nodo, NodoLlamadaFuncion):
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"{nodo.nombre}({args})"
+        elif isinstance(nodo, NodoOperacionBinaria):
+            izq = self.obtener_valor(nodo.izquierda)
+            der = self.obtener_valor(nodo.derecha)
+            op_map = {TipoToken.AND: "&&", TipoToken.OR: "||"}
+            op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
+            return f"{izq} {op} {der}"
+        elif isinstance(nodo, NodoOperacionUnaria):
+            val = self.obtener_valor(nodo.operando)
+            op = "!" if nodo.operador.tipo == TipoToken.NOT else nodo.operador.valor
+            return f"{op}{val}" if op != "!" else f"!{val}"
+        else:
+            return str(getattr(nodo, "valor", nodo))
+
+    def transpilar(self, nodos):
+        nodos = expandir_macros(nodos)
+        nodos = remove_dead_code(optimize_constants(nodos))
+        for nodo in nodos:
+            if hasattr(nodo, "aceptar"):
+                nodo.aceptar(self)
+            else:
+                metodo = getattr(
+                    self, f"visit_{nodo.__class__.__name__[4:].lower()}", None
+                )
+                if metodo:
+                    metodo(nodo)
+        return "\n".join(self.codigo)
+
+
+# Asignar visitantes
+for nombre, funcion in java_nodes.items():
+    setattr(TranspiladorJava, f"visit_{nombre}", funcion)

--- a/backend/src/tests/test_to_java.py
+++ b/backend/src/tests/test_to_java.py
@@ -1,0 +1,31 @@
+from src.cobra.transpilers.transpiler.to_java import TranspiladorJava
+from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+
+
+def test_transpilador_asignacion_java():
+    ast = [NodoAsignacion("x", 10)]
+    t = TranspiladorJava()
+    resultado = t.transpilar(ast)
+    assert resultado == "var x = 10;"
+
+
+def test_transpilador_funcion_java():
+    ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
+    t = TranspiladorJava()
+    resultado = t.transpilar(ast)
+    esperado = "static void miFuncion(a, b) {\n    var x = a + b;\n}"
+    assert resultado == esperado
+
+
+def test_transpilador_llamada_funcion_java():
+    ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
+    t = TranspiladorJava()
+    resultado = t.transpilar(ast)
+    assert resultado == "miFuncion(a, b);"
+
+
+def test_transpilador_imprimir_java():
+    ast = [NodoImprimir(NodoValor("x"))]
+    t = TranspiladorJava()
+    resultado = t.transpilar(ast)
+    assert resultado == "System.out.println(x);"


### PR DESCRIPTION
## Summary
- implement `TranspiladorJava` following the simple `TranspiladorGo` style
- add unit tests for Java transpiler

## Testing
- `pytest backend/src/tests/test_to_java.py -q`
- `pytest -q` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685bf284aafc8327809aaab7511683c3