### PR TITLE
Add Java CLI compile test

### DIFF
--- a/backend/src/tests/test_cli_commands_extra.py
+++ b/backend/src/tests/test_cli_commands_extra.py
@@ -64,6 +64,13 @@ from src.cli.commands import modules_cmd
                 "x = 5",
             ],
         ),
+        (
+            "java",
+            [
+                "Código generado (TranspiladorJava):",
+                "var x = 5;",
+            ],
+        ),
     ],
 )
 def test_cli_compilar_generates_output(tmp_path, tipo, esperado):


### PR DESCRIPTION
## Summary
- extend CLI compile tests for Java output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'smooth_criminal')*

------
https://chatgpt.com/codex/tasks/task_e_685bf8dce9a883279c24953839717446