### PR TITLE
Añadir sistema Qualia

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -142,3 +142,11 @@ Se añadieron nuevas construcciones al lenguaje:
 - `finalmente` dentro de `try` para ejecutar código final.
 - Importaciones `desde` ... `como` para alias de módulos.
 - Nueva estructura `switch` con múltiples `case`.
+
+## 11. Uso de Qualia
+
+Qualia registra cada ejecución y genera sugerencias para mejorar tu código.
+El estado se guarda en `qualia_state.json`. Puedes obtener las sugerencias
+ejecutando `sugerencias` en el modo interactivo o escribiendo `%sugerencias`
+en el kernel de Jupyter.
+

--- a/backend/src/cli/commands/interactive_cmd.py
+++ b/backend/src/cli/commands/interactive_cmd.py
@@ -2,6 +2,7 @@ import logging
 from .base import BaseCommand
 
 from src.core.interpreter import InterpretadorCobra
+from src.core.qualia_bridge import get_suggestions
 from src.cobra.lexico.lexer import Lexer
 from src.cobra.parser.parser import Parser
 from src.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
@@ -32,6 +33,10 @@ class InteractiveCommand(BaseCommand):
                     print("Tokens generados:")
                     for token in tokens:
                         print(token)
+                    continue
+                elif linea == "sugerencias":
+                    for s in get_suggestions():
+                        print(s)
                     continue
                 elif linea == "ast":
                     tokens = Lexer(linea).tokenizar()

--- a/backend/src/core/interpreter.py
+++ b/backend/src/core/interpreter.py
@@ -34,6 +34,7 @@ from src.core.semantic_validators import (
     construir_cadena,
     PrimitivaPeligrosaError,
 )
+from src.core.qualia_bridge import register_execution
 
 # Ruta de los módulos instalados junto con una lista blanca opcional.
 MODULES_PATH = os.path.abspath(
@@ -128,6 +129,7 @@ class InterpretadorCobra:
 
     def ejecutar_ast(self, ast):
         ast = remove_dead_code(optimize_constants(ast))
+        register_execution(str(ast))
         for nodo in ast:
             self._validar(nodo)
             resultado = self.ejecutar_nodo(nodo)

--- a/backend/src/core/qualia_bridge.py
+++ b/backend/src/core/qualia_bridge.py
@@ -1,0 +1,63 @@
+import json
+import os
+from typing import List
+
+
+STATE_FILE = os.environ.get(
+    "QUALIA_STATE_PATH",
+    os.path.join(os.path.dirname(__file__), "qualia_state.json"),
+)
+
+
+class QualiaSpirit:
+    """Modelo simple para registrar ejecuciones y generar sugerencias."""
+
+    def __init__(self) -> None:
+        self.history: List[str] = []
+
+    def register(self, code: str) -> None:
+        """Guarda el ``code`` ejecutado en la historia."""
+        self.history.append(code)
+
+    def suggestions(self) -> List[str]:
+        """Devuelve una lista de sugerencias basadas en el historial."""
+        joined = "\n".join(self.history)
+        sugerencias: List[str] = []
+        if "imprimir" not in joined:
+            sugerencias.append("Agrega \"imprimir\" para depurar.")
+        if any("var " in linea for linea in self.history):
+            sugerencias.append("Usa nombres descriptivos para variables.")
+        if not sugerencias:
+            sugerencias.append("\u00a1Sigue as\u00ed!")
+        return sugerencias
+
+
+def load_state() -> QualiaSpirit:
+    """Carga el estado del ``QualiaSpirit`` desde ``STATE_FILE``."""
+    if os.path.exists(STATE_FILE):
+        with open(STATE_FILE, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        spirit = QualiaSpirit()
+        spirit.history = data.get("history", [])
+        return spirit
+    return QualiaSpirit()
+
+
+def save_state(spirit: QualiaSpirit) -> None:
+    """Guarda el estado de ``spirit`` en ``STATE_FILE``."""
+    with open(STATE_FILE, "w", encoding="utf-8") as fh:
+        json.dump({"history": spirit.history}, fh, ensure_ascii=False, indent=2)
+
+
+QUALIA = load_state()
+
+
+def register_execution(code: str) -> None:
+    """Registra una ejecuci\u00f3n y persiste el estado."""
+    QUALIA.register(code)
+    save_state(QUALIA)
+
+
+def get_suggestions() -> List[str]:
+    """Obtiene sugerencias actuales del estado cargado."""
+    return QUALIA.suggestions()

--- a/backend/src/jupyter_kernel/__init__.py
+++ b/backend/src/jupyter_kernel/__init__.py
@@ -5,6 +5,7 @@ from ipykernel.kernelbase import Kernel
 from src.cobra.lexico.lexer import Lexer
 from src.cobra.parser.parser import Parser, PALABRAS_RESERVADAS
 from src.core.interpreter import InterpretadorCobra
+from src.core.qualia_bridge import get_suggestions
 
 
 def install(user=True):
@@ -30,6 +31,12 @@ class CobraKernel(Kernel):
         self.interpreter = InterpretadorCobra()
 
     def do_execute(self, code, silent, store_history=True, user_expressions=None, allow_stdin=False):
+        if code.strip() == "%sugerencias":
+            texto = "\n".join(get_suggestions())
+            if not silent:
+                self.send_response(self.iopub_socket, "stream", {"name": "stdout", "text": texto})
+            return {"status": "ok", "execution_count": self.execution_count, "payload": [], "user_expressions": {}}
+
         stdout = io.StringIO()
         try:
             with contextlib.redirect_stdout(stdout):

--- a/backend/src/tests/test_qualia_bridge.py
+++ b/backend/src/tests/test_qualia_bridge.py
@@ -1,0 +1,24 @@
+import importlib
+import json
+import os
+from src.core import qualia_bridge
+
+
+def test_qualia_state_persistence(tmp_path, monkeypatch):
+    state = tmp_path / "state.json"
+    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
+    qb = importlib.reload(qualia_bridge)
+    qb.register_execution("var x = 1")
+    assert state.exists()
+    qb2 = importlib.reload(qualia_bridge)
+    assert "var x = 1" in qb2.QUALIA.history
+
+
+def test_qualia_generates_suggestions(tmp_path, monkeypatch):
+    state = tmp_path / "state.json"
+    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
+    qb = importlib.reload(qualia_bridge)
+    qb.register_execution("var x = 1")
+    sugs = qb.get_suggestions()
+    assert any("imprimir" in s for s in sugs)
+

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -27,6 +27,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    empaquetar
    primeros_pasos
    como_contribuir
+   qualia
    jupyter
    api/modules
 

--- a/frontend/docs/qualia.rst
+++ b/frontend/docs/qualia.rst
@@ -1,0 +1,11 @@
+Sistema Qualia
+==============
+
+Qualia Spirit almacena un historial de las ejecuciones realizadas con Cobra.
+Con esa información genera sugerencias sencillas para mejorar el código.
+El estado se persiste en ``qualia_state.json`` para que las recomendaciones
+estén disponibles entre sesiones.
+
+Para ver las sugerencias en el modo interactivo escribe ``sugerencias``.
+En Jupyter puedes ejecutar una celda con ``%sugerencias``.
+


### PR DESCRIPTION
## Summary
- registrar ejecuciones con `qualia_bridge` y persistir en `qualia_state.json`
- mostrar sugerencias en la CLI interactiva y kernel Jupyter
- documentar el uso de Qualia
- añadir pruebas de persistencia y sugerencias

## Testing
- `pytest backend/src/tests/test_qualia_bridge.py -q`
- `pytest -q` *(fails: 33 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_685c00084700832791638b7050c78b0f