### PR TITLE
Add COBOL transpiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Versión 1.0
 
-Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia y Java, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
+Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java y COBOL, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
 ## Tabla de Contenidos
 
@@ -91,7 +91,7 @@ El proyecto se organiza en las siguientes carpetas y módulos:
 # Características Principales
 
 - Lexer y Parser: Implementación de un lexer para la tokenización del código fuente y un parser para la construcción de un árbol de sintaxis abstracta (AST).
-- Transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia y Java: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
+- Transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java y COBOL: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
 - Soporte de Estructuras Avanzadas: Permite la declaración de variables, funciones, clases, listas y diccionarios, así como el uso de bucles y condicionales.
 - Módulos nativos con funciones de E/S, utilidades matemáticas y estructuras de datos para usar directamente desde Cobra.
 - Instalación de paquetes en tiempo de ejecución mediante la instrucción `usar`.
@@ -163,7 +163,7 @@ para var i en rango(2) :
 '''
 ````
 
-Al transpilar a Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. En Rust se produce código equivalente con `println!`, `while` y `for`. En C++ se obtienen construcciones con `std::cout`, `while` y `for`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust o `holobit({ ... })` en C++. En Go se genera `fmt.Println`, en R se usa `print` y en Julia `println`; en Java se usa `System.out.println`.
+Al transpilar a Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. En Rust se produce código equivalente con `println!`, `while` y `for`. En C++ se obtienen construcciones con `std::cout`, `while` y `for`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust o `holobit({ ... })` en C++. En Go se genera `fmt.Println`, en R se usa `print` y en Julia `println`; en Java se usa `System.out.println` y en COBOL `DISPLAY`.
 
 ## Integración con holobit-sdk
 
@@ -221,7 +221,7 @@ editar `cobra.mod` y volver a ejecutar las pruebas.
 ## Invocar el transpilador
 
 La carpeta [`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler)
-contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia y Java. Una vez
+contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java y COBOL. Una vez
 instaladas las dependencias, puedes llamar al transpilador desde tu propio
 script de la siguiente manera:
 
@@ -261,7 +261,7 @@ Al transpilarlas, se generan llamadas `asyncio.create_task` en Python y `Promise
 Una vez instalado el paquete, la herramienta `cobra` ofrece varios subcomandos:
 
 ```bash
-# Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia o Java
+# Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java o COBOL
 cobra compilar programa.co --tipo python
 
 # Ejecutar directamente un script Cobra
@@ -322,6 +322,7 @@ cobra compilar programa.co --tipo=go
 cobra compilar programa.co --tipo=r
 cobra compilar programa.co --tipo=julia
 cobra compilar programa.co --tipo=java
+cobra compilar programa.co --tipo=cobol
 echo $?  # 0 al compilar sin problemas
 
 cobra ejecutar inexistente.co
@@ -413,7 +414,7 @@ Este proyecto está bajo la [Licencia MIT](LICENSE).
 
 ### Notas
 
-- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia y Java.
+- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java y COBOL.
 - **Ejemplos de Código y Nuevas Estructuras**: Incluye ejemplos con el uso de estructuras avanzadas como clases y diccionarios en el lenguaje Cobra.
 
 Si deseas agregar o modificar algo, házmelo saber.

--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -14,6 +14,7 @@ from src.cobra.transpilers.transpiler.to_go import TranspiladorGo
 from src.cobra.transpilers.transpiler.to_r import TranspiladorR
 from src.cobra.transpilers.transpiler.to_julia import TranspiladorJulia
 from src.cobra.transpilers.transpiler.to_java import TranspiladorJava
+from src.cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
 
 
 class CompileCommand(BaseCommand):
@@ -26,7 +27,7 @@ class CompileCommand(BaseCommand):
         parser.add_argument("archivo")
         parser.add_argument(
             "--tipo",
-            choices=["python", "js", "asm", "rust", "cpp", "go", "r", "julia", "java"],
+            choices=["python", "js", "asm", "rust", "cpp", "go", "r", "julia", "java", "cobol"],
             default="python",
             help="Tipo de código generado",
         )
@@ -68,6 +69,8 @@ class CompileCommand(BaseCommand):
                     transp = TranspiladorR()
                 elif transpilador == "julia":
                     transp = TranspiladorJulia()
+                elif transpilador == "cobol":
+                    transp = TranspiladorCOBOL()
                 else:
                     raise ValueError("Transpilador no soportado.")
 

--- a/backend/src/cobra/transpilers/transpiler/cobol_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/cobol_nodes/asignacion.py
@@ -1,0 +1,10 @@
+from src.core.ast_nodes import NodoAtributo
+
+def visit_asignacion(self, nodo):
+    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
+    if isinstance(nombre_raw, NodoAtributo):
+        nombre = self.obtener_valor(nombre_raw)
+    else:
+        nombre = nombre_raw
+    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
+    self.agregar_linea(f"MOVE {self.obtener_valor(valor)} TO {nombre}")

--- a/backend/src/cobra/transpilers/transpiler/cobol_nodes/funcion.py
+++ b/backend/src/cobra/transpilers/transpiler/cobol_nodes/funcion.py
@@ -1,0 +1,8 @@
+
+def visit_funcion(self, nodo):
+    self.agregar_linea(f"{nodo.nombre} SECTION.")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("EXIT SECTION.")

--- a/backend/src/cobra/transpilers/transpiler/cobol_nodes/imprimir.py
+++ b/backend/src/cobra/transpilers/transpiler/cobol_nodes/imprimir.py
@@ -1,0 +1,4 @@
+
+def visit_imprimir(self, nodo):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"DISPLAY {valor}")

--- a/backend/src/cobra/transpilers/transpiler/cobol_nodes/llamada_funcion.py
+++ b/backend/src/cobra/transpilers/transpiler/cobol_nodes/llamada_funcion.py
@@ -1,0 +1,7 @@
+
+def visit_llamada_funcion(self, nodo):
+    args = " ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    if args:
+        self.agregar_linea(f"CALL '{nodo.nombre}' USING {args}")
+    else:
+        self.agregar_linea(f"CALL '{nodo.nombre}'")

--- a/backend/src/cobra/transpilers/transpiler/to_cobol.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cobol.py
@@ -1,0 +1,77 @@
+"""Transpilador que genera código COBOL a partir de Cobra."""
+
+from src.core.ast_nodes import (
+    NodoValor,
+    NodoIdentificador,
+    NodoLlamadaFuncion,
+    NodoAsignacion,
+    NodoFuncion,
+    NodoImprimir,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoAtributo,
+)
+from src.cobra.lexico.lexer import TipoToken
+from src.core.visitor import NodeVisitor
+from src.core.optimizations import optimize_constants, remove_dead_code
+from src.cobra.macro import expandir_macros
+
+from .cobol_nodes.asignacion import visit_asignacion as _visit_asignacion
+from .cobol_nodes.funcion import visit_funcion as _visit_funcion
+from .cobol_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from .cobol_nodes.imprimir import visit_imprimir as _visit_imprimir
+
+
+cobol_nodes = {
+    "asignacion": _visit_asignacion,
+    "funcion": _visit_funcion,
+    "llamada_funcion": _visit_llamada_funcion,
+    "imprimir": _visit_imprimir,
+}
+
+
+class TranspiladorCOBOL(NodeVisitor):
+    """Transpila el AST de Cobra a un COBOL muy simplificado."""
+
+    def __init__(self):
+        self.codigo = []
+        self.indent = 0
+
+    def agregar_linea(self, linea: str) -> None:
+        self.codigo.append("    " * self.indent + linea)
+
+    def obtener_valor(self, nodo):
+        if isinstance(nodo, NodoValor):
+            return str(nodo.valor)
+        elif isinstance(nodo, NodoIdentificador):
+            return nodo.nombre
+        elif isinstance(nodo, NodoAtributo):
+            return f"{self.obtener_valor(nodo.objeto)}-{nodo.nombre}"
+        elif isinstance(nodo, NodoLlamadaFuncion):
+            args = " ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            if args:
+                return f"CALL '{nodo.nombre}' USING {args}"
+            return f"CALL '{nodo.nombre}'"
+        elif isinstance(nodo, NodoOperacionBinaria):
+            izq = self.obtener_valor(nodo.izquierda)
+            der = self.obtener_valor(nodo.derecha)
+            op_map = {TipoToken.AND: "AND", TipoToken.OR: "OR"}
+            op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
+            return f"{izq} {op} {der}"
+        elif isinstance(nodo, NodoOperacionUnaria):
+            val = self.obtener_valor(nodo.operando)
+            op = "NOT" if nodo.operador.tipo == TipoToken.NOT else nodo.operador.valor
+            return f"{op} {val}" if op == "NOT" else f"{op}{val}"
+        else:
+            return str(getattr(nodo, "valor", nodo))
+
+    def transpilar(self, nodos):
+        nodos = expandir_macros(nodos)
+        nodos = remove_dead_code(optimize_constants(nodos))
+        for nodo in nodos:
+            nodo.aceptar(self)
+        return "\n".join(self.codigo)
+
+
+for nombre, funcion in cobol_nodes.items():
+    setattr(TranspiladorCOBOL, f"visit_{nombre}", funcion)

--- a/backend/src/tests/test_to_cobol.py
+++ b/backend/src/tests/test_to_cobol.py
@@ -1,0 +1,31 @@
+from src.cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
+from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+
+
+def test_transpilador_asignacion_cobol():
+    ast = [NodoAsignacion("X", 10)]
+    t = TranspiladorCOBOL()
+    resultado = t.transpilar(ast)
+    assert resultado == "MOVE 10 TO X"
+
+
+def test_transpilador_funcion_cobol():
+    ast = [NodoFuncion("MIFUNCION", ["A", "B"], [NodoAsignacion("X", "A + B")])]
+    t = TranspiladorCOBOL()
+    resultado = t.transpilar(ast)
+    esperado = "MIFUNCION SECTION.\n    MOVE A + B TO X\nEXIT SECTION."
+    assert resultado == esperado
+
+
+def test_transpilador_llamada_funcion_cobol():
+    ast = [NodoLlamadaFuncion("MIFUNCION", ["A", "B"])]
+    t = TranspiladorCOBOL()
+    resultado = t.transpilar(ast)
+    assert resultado == "CALL 'MIFUNCION' USING A B"
+
+
+def test_transpilador_imprimir_cobol():
+    ast = [NodoImprimir(NodoValor("X"))]
+    t = TranspiladorCOBOL()
+    resultado = t.transpilar(ast)
+    assert resultado == "DISPLAY X"


### PR DESCRIPTION
## Summary
- implement a simple COBOL transpiler and node visitors
- enable COBOL compilation option in compile command
- test COBOL transpiler
- document COBOL support in README

## Testing
- `pytest backend/src/tests/test_to_cobol.py -q`
- `pytest -q` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685c04b87d008327acd542f104820b37