### PR TITLE
Add Pascal transpiler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Versión 1.0
 
-Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL y Fortran, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
+Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran y Pascal, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
 ## Tabla de Contenidos
 
@@ -91,7 +91,7 @@ El proyecto se organiza en las siguientes carpetas y módulos:
 # Características Principales
 
 - Lexer y Parser: Implementación de un lexer para la tokenización del código fuente y un parser para la construcción de un árbol de sintaxis abstracta (AST).
-- Transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL y Fortran: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
+- Transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran y Pascal: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
 - Soporte de Estructuras Avanzadas: Permite la declaración de variables, funciones, clases, listas y diccionarios, así como el uso de bucles y condicionales.
 - Módulos nativos con funciones de E/S, utilidades matemáticas y estructuras de datos para usar directamente desde Cobra.
 - Instalación de paquetes en tiempo de ejecución mediante la instrucción `usar`.
@@ -163,7 +163,7 @@ para var i en rango(2) :
 '''
 ````
 
-Al transpilar a Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. En Rust se produce código equivalente con `println!`, `while` y `for`. En C++ se obtienen construcciones con `std::cout`, `while` y `for`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust o `holobit({ ... })` en C++. En Go se genera `fmt.Println`, en R se usa `print` y en Julia `println`; en Java se usa `System.out.println`, en COBOL `DISPLAY` y en Fortran `print *`.
+Al transpilar a Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. En Rust se produce código equivalente con `println!`, `while` y `for`. En C++ se obtienen construcciones con `std::cout`, `while` y `for`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust o `holobit({ ... })` en C++. En Go se genera `fmt.Println`, en R se usa `print` y en Julia `println`; en Java se usa `System.out.println`, en COBOL `DISPLAY`, en Fortran `print *` y en Pascal `writeln`.
 
 ## Integración con holobit-sdk
 
@@ -221,7 +221,7 @@ editar `cobra.mod` y volver a ejecutar las pruebas.
 ## Invocar el transpilador
 
 La carpeta [`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler)
-contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL y Fortran. Una vez
+contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran y Pascal. Una vez
 instaladas las dependencias, puedes llamar al transpilador desde tu propio
 script de la siguiente manera:
 
@@ -261,7 +261,7 @@ Al transpilarlas, se generan llamadas `asyncio.create_task` en Python y `Promise
 Una vez instalado el paquete, la herramienta `cobra` ofrece varios subcomandos:
 
 ```bash
-# Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL o Fortran
+# Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran o Pascal
 cobra compilar programa.co --tipo python
 
 # Ejecutar directamente un script Cobra
@@ -414,7 +414,7 @@ Este proyecto está bajo la [Licencia MIT](LICENSE).
 
 ### Notas
 
-- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL y Fortran.
+- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran y Pascal.
 - **Ejemplos de Código y Nuevas Estructuras**: Incluye ejemplos con el uso de estructuras avanzadas como clases y diccionarios en el lenguaje Cobra.
 
 Si deseas agregar o modificar algo, házmelo saber.

--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -16,6 +16,7 @@ from src.cobra.transpilers.transpiler.to_julia import TranspiladorJulia
 from src.cobra.transpilers.transpiler.to_java import TranspiladorJava
 from src.cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
 from src.cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
+from src.cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
 
 
 class CompileCommand(BaseCommand):
@@ -28,7 +29,7 @@ class CompileCommand(BaseCommand):
         parser.add_argument("archivo")
         parser.add_argument(
             "--tipo",
-            choices=["python", "js", "asm", "rust", "cpp", "go", "r", "julia", "java", "cobol", "fortran"],
+            choices=["python", "js", "asm", "rust", "cpp", "go", "r", "julia", "java", "cobol", "fortran", "pascal"],
             default="python",
             help="Tipo de código generado",
         )
@@ -74,6 +75,8 @@ class CompileCommand(BaseCommand):
                     transp = TranspiladorCOBOL()
                 elif transpilador == "fortran":
                     transp = TranspiladorFortran()
+                elif transpilador == "pascal":
+                    transp = TranspiladorPascal()
                 else:
                     raise ValueError("Transpilador no soportado.")
 

--- a/backend/src/cobra/transpilers/transpiler/pascal_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/pascal_nodes/asignacion.py
@@ -1,0 +1,10 @@
+from src.core.ast_nodes import NodoAtributo
+
+def visit_asignacion(self, nodo):
+    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
+    if isinstance(nombre_raw, NodoAtributo):
+        nombre = self.obtener_valor(nombre_raw)
+    else:
+        nombre = nombre_raw
+    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
+    self.agregar_linea(f"{nombre} := {self.obtener_valor(valor)};")

--- a/backend/src/cobra/transpilers/transpiler/pascal_nodes/funcion.py
+++ b/backend/src/cobra/transpilers/transpiler/pascal_nodes/funcion.py
@@ -1,0 +1,10 @@
+
+def visit_funcion(self, nodo):
+    params = ", ".join(nodo.parametros)
+    self.agregar_linea(f"procedure {nodo.nombre}({params});")
+    self.agregar_linea("begin")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("end;")

--- a/backend/src/cobra/transpilers/transpiler/pascal_nodes/imprimir.py
+++ b/backend/src/cobra/transpilers/transpiler/pascal_nodes/imprimir.py
@@ -1,0 +1,4 @@
+
+def visit_imprimir(self, nodo):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"writeln({valor});")

--- a/backend/src/cobra/transpilers/transpiler/pascal_nodes/llamada_funcion.py
+++ b/backend/src/cobra/transpilers/transpiler/pascal_nodes/llamada_funcion.py
@@ -1,0 +1,4 @@
+
+def visit_llamada_funcion(self, nodo):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"{nodo.nombre}({args});")

--- a/backend/src/cobra/transpilers/transpiler/to_pascal.py
+++ b/backend/src/cobra/transpilers/transpiler/to_pascal.py
@@ -1,0 +1,78 @@
+"""Transpilador que genera código Pascal a partir de Cobra."""
+
+from src.core.ast_nodes import (
+    NodoValor,
+    NodoIdentificador,
+    NodoLlamadaFuncion,
+    NodoAsignacion,
+    NodoFuncion,
+    NodoImprimir,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoAtributo,
+)
+from src.cobra.lexico.lexer import TipoToken
+from src.core.visitor import NodeVisitor
+from src.core.optimizations import optimize_constants, remove_dead_code
+from src.cobra.macro import expandir_macros
+
+from .pascal_nodes.asignacion import visit_asignacion as _visit_asignacion
+from .pascal_nodes.funcion import visit_funcion as _visit_funcion
+from .pascal_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from .pascal_nodes.imprimir import visit_imprimir as _visit_imprimir
+
+pascal_nodes = {
+    "asignacion": _visit_asignacion,
+    "funcion": _visit_funcion,
+    "llamada_funcion": _visit_llamada_funcion,
+    "imprimir": _visit_imprimir,
+}
+
+
+class TranspiladorPascal(NodeVisitor):
+    def __init__(self):
+        self.codigo = []
+        self.indent = 0
+
+    def agregar_linea(self, linea: str) -> None:
+        self.codigo.append("    " * self.indent + linea)
+
+    def obtener_valor(self, nodo):
+        if isinstance(nodo, NodoValor):
+            return str(nodo.valor)
+        elif isinstance(nodo, NodoIdentificador):
+            return nodo.nombre
+        elif isinstance(nodo, NodoAtributo):
+            return f"{self.obtener_valor(nodo.objeto)}.{nodo.nombre}"
+        elif isinstance(nodo, NodoLlamadaFuncion):
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"{nodo.nombre}({args})"
+        elif isinstance(nodo, NodoOperacionBinaria):
+            izq = self.obtener_valor(nodo.izquierda)
+            der = self.obtener_valor(nodo.derecha)
+            op_map = {TipoToken.AND: 'and', TipoToken.OR: 'or'}
+            op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
+            return f"{izq} {op} {der}"
+        elif isinstance(nodo, NodoOperacionUnaria):
+            val = self.obtener_valor(nodo.operando)
+            if nodo.operador.tipo == TipoToken.NOT:
+                return f"not {val}"
+            return f"{nodo.operador.valor}{val}"
+        else:
+            return str(getattr(nodo, "valor", nodo))
+
+    def transpilar(self, nodos):
+        nodos = expandir_macros(nodos)
+        nodos = remove_dead_code(optimize_constants(nodos))
+        for nodo in nodos:
+            if hasattr(nodo, "aceptar"):
+                nodo.aceptar(self)
+            else:
+                metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
+                if metodo:
+                    metodo(nodo)
+        return "\n".join(self.codigo)
+
+
+for nombre, funcion in pascal_nodes.items():
+    setattr(TranspiladorPascal, f"visit_{nombre}", funcion)

--- a/backend/src/tests/test_to_pascal.py
+++ b/backend/src/tests/test_to_pascal.py
@@ -1,0 +1,31 @@
+from src.cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
+from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+
+
+def test_transpilador_asignacion_pascal():
+    ast = [NodoAsignacion("x", 10)]
+    t = TranspiladorPascal()
+    resultado = t.transpilar(ast)
+    assert resultado == "x := 10;"
+
+
+def test_transpilador_funcion_pascal():
+    ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
+    t = TranspiladorPascal()
+    resultado = t.transpilar(ast)
+    esperado = "procedure miFuncion(a, b);\nbegin\n    x := a + b;\nend;"
+    assert resultado == esperado
+
+
+def test_transpilador_llamada_funcion_pascal():
+    ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
+    t = TranspiladorPascal()
+    resultado = t.transpilar(ast)
+    assert resultado == "miFuncion(a, b);"
+
+
+def test_transpilador_imprimir_pascal():
+    ast = [NodoImprimir(NodoValor("x"))]
+    t = TranspiladorPascal()
+    resultado = t.transpilar(ast)
+    assert resultado == "writeln(x);"


### PR DESCRIPTION
## Summary
- implement basic Pascal transpiler and node visitors
- register Pascal in CLI compile command
- add tests for Pascal transpiler
- update README to mention Pascal support

## Testing
- `pytest backend/src/tests/test_to_pascal.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0eec683883278dcc06aa9f57e18d