### PR TITLE
Add COBOL, Fortran and Pascal compile options

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,18 @@ resultado = transpiler.transpilar(arbol)
 print(resultado)
 ```
 
+Para otros lenguajes puedes invocar los nuevos transpiladores así:
+
+```python
+from cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
+from cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
+from cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
+
+codigo_cobol = TranspiladorCOBOL().transpilar(arbol)
+codigo_fortran = TranspiladorFortran().transpilar(arbol)
+codigo_pascal = TranspiladorPascal().transpilar(arbol)
+```
+
 Requiere tener instalado el paquete en modo editable y todas las dependencias
 de `requirements.txt`. Si necesitas generar archivos a partir de módulos Cobra,
 consulta el mapeo definido en `cobra.mod`.
@@ -323,6 +335,8 @@ cobra compilar programa.co --tipo=r
 cobra compilar programa.co --tipo=julia
 cobra compilar programa.co --tipo=java
 cobra compilar programa.co --tipo=cobol
+cobra compilar programa.co --tipo=fortran
+cobra compilar programa.co --tipo=pascal
 echo $?  # 0 al compilar sin problemas
 
 cobra ejecutar inexistente.co

--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -20,7 +20,11 @@ from src.cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
 
 
 class CompileCommand(BaseCommand):
-    """Transpila un archivo Cobra."""
+    """Transpila un archivo Cobra a distintos lenguajes.
+
+    Soporta Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia,
+    Java y ahora también COBOL, Fortran y Pascal.
+    """
 
     name = "compilar"
 
@@ -29,7 +33,20 @@ class CompileCommand(BaseCommand):
         parser.add_argument("archivo")
         parser.add_argument(
             "--tipo",
-            choices=["python", "js", "asm", "rust", "cpp", "go", "r", "julia", "java", "cobol", "fortran", "pascal"],
+            choices=[
+                "python",
+                "js",
+                "asm",
+                "rust",
+                "cpp",
+                "go",
+                "r",
+                "julia",
+                "java",
+                "cobol",
+                "fortran",
+                "pascal",
+            ],
             default="python",
             help="Tipo de código generado",
         )


### PR DESCRIPTION
## Summary
- document new transpiladores cobol, fortran y pascal
- add usage examples for them in README
- update compile command to show the new options in help text

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: NameError: NodoEsperar is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685c16ba353c8327a5dcd9f50aca64e9