### PR TITLE
Add Ruby transpiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,10 +243,12 @@ Para otros lenguajes puedes invocar los nuevos transpiladores así:
 from cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
 from cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
 from cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
+from cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
 
 codigo_cobol = TranspiladorCOBOL().transpilar(arbol)
 codigo_fortran = TranspiladorFortran().transpilar(arbol)
 codigo_pascal = TranspiladorPascal().transpilar(arbol)
+codigo_ruby = TranspiladorRuby().transpilar(arbol)
 ```
 
 Requiere tener instalado el paquete en modo editable y todas las dependencias
@@ -331,6 +333,7 @@ cobra compilar programa.co --tipo=python
 cobra compilar programa.co --tipo=asm
 cobra compilar programa.co --tipo=cpp
 cobra compilar programa.co --tipo=go
+cobra compilar programa.co --tipo=ruby
 cobra compilar programa.co --tipo=r
 cobra compilar programa.co --tipo=julia
 cobra compilar programa.co --tipo=java

--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -13,6 +13,7 @@ from src.cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
 from src.cobra.transpilers.transpiler.to_go import TranspiladorGo
 from src.cobra.transpilers.transpiler.to_r import TranspiladorR
 from src.cobra.transpilers.transpiler.to_julia import TranspiladorJulia
+from src.cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
 from src.cobra.transpilers.transpiler.to_java import TranspiladorJava
 from src.cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
 from src.cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
@@ -40,6 +41,7 @@ class CompileCommand(BaseCommand):
                 "rust",
                 "cpp",
                 "go",
+                "ruby",
                 "r",
                 "julia",
                 "java",
@@ -84,6 +86,8 @@ class CompileCommand(BaseCommand):
                     transp = TranspiladorJava()
                 elif transpilador == "go":
                     transp = TranspiladorGo()
+                elif transpilador == "ruby":
+                    transp = TranspiladorRuby()
                 elif transpilador == "r":
                     transp = TranspiladorR()
                 elif transpilador == "julia":

--- a/backend/src/cobra/transpilers/transpiler/__init__.py
+++ b/backend/src/cobra/transpilers/transpiler/__init__.py
@@ -1,2 +1,5 @@
 """Herramientas para convertir el AST de Cobra a otros lenguajes."""
 
+# Exportar transpiladores básicos
+from .to_ruby import TranspiladorRuby
+

--- a/backend/src/cobra/transpilers/transpiler/to_ruby.py
+++ b/backend/src/cobra/transpilers/transpiler/to_ruby.py
@@ -1,0 +1,97 @@
+"""Transpilador simple de Cobra a Ruby."""
+
+from src.core.ast_nodes import (
+    NodoValor,
+    NodoIdentificador,
+    NodoLlamadaFuncion,
+    NodoAsignacion,
+    NodoFuncion,
+    NodoImprimir,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoAtributo,
+)
+from src.cobra.lexico.lexer import TipoToken
+from src.core.visitor import NodeVisitor
+from src.core.optimizations import optimize_constants, remove_dead_code
+from src.cobra.macro import expandir_macros
+
+
+def visit_asignacion(self, nodo: NodoAsignacion):
+    nombre = getattr(nodo, "identificador", nodo.variable)
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"{nombre} = {valor}")
+
+
+def visit_funcion(self, nodo: NodoFuncion):
+    params = ", ".join(nodo.parametros)
+    self.agregar_linea(f"def {nodo.nombre}({params})")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("end")
+
+
+def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"{nodo.nombre}({args})")
+
+
+def visit_imprimir(self, nodo: NodoImprimir):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"puts {valor}")
+
+
+ruby_nodes = {
+    "asignacion": visit_asignacion,
+    "funcion": visit_funcion,
+    "llamada_funcion": visit_llamada_funcion,
+    "imprimir": visit_imprimir,
+}
+
+
+class TranspiladorRuby(NodeVisitor):
+    def __init__(self):
+        self.codigo = []
+        self.indent = 0
+
+    def agregar_linea(self, linea: str) -> None:
+        self.codigo.append("    " * self.indent + linea)
+
+    def obtener_valor(self, nodo):
+        if isinstance(nodo, NodoValor):
+            return str(nodo.valor)
+        elif isinstance(nodo, NodoIdentificador):
+            return nodo.nombre
+        elif isinstance(nodo, NodoAtributo):
+            return f"{self.obtener_valor(nodo.objeto)}.{nodo.nombre}"
+        elif isinstance(nodo, NodoLlamadaFuncion):
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"{nodo.nombre}({args})"
+        elif isinstance(nodo, NodoOperacionBinaria):
+            izq = self.obtener_valor(nodo.izquierda)
+            der = self.obtener_valor(nodo.derecha)
+            op_map = {TipoToken.AND: "&&", TipoToken.OR: "||"}
+            op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
+            return f"{izq} {op} {der}"
+        elif isinstance(nodo, NodoOperacionUnaria):
+            val = self.obtener_valor(nodo.operando)
+            op = "!" if nodo.operador.tipo == TipoToken.NOT else nodo.operador.valor
+            return f"{op}{val}" if op != "!" else f"!{val}"
+        else:
+            return str(getattr(nodo, "valor", nodo))
+
+    def transpilar(self, nodos):
+        nodos = expandir_macros(nodos)
+        nodos = remove_dead_code(optimize_constants(nodos))
+        for nodo in nodos:
+            nombre = self._camel_to_snake(nodo.__class__.__name__)
+            metodo = getattr(self, f"visit_{nombre}", None)
+            if metodo:
+                metodo(nodo)
+        return "\n".join(self.codigo)
+
+
+for nombre, funcion in ruby_nodes.items():
+    setattr(TranspiladorRuby, f"visit_{nombre}", funcion)

--- a/backend/src/tests/test_to_ruby.py
+++ b/backend/src/tests/test_to_ruby.py
@@ -1,0 +1,31 @@
+from src.cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
+from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+
+
+def test_transpilador_asignacion_ruby():
+    ast = [NodoAsignacion("x", 10)]
+    t = TranspiladorRuby()
+    resultado = t.transpilar(ast)
+    assert resultado == "x = 10"
+
+
+def test_transpilador_funcion_ruby():
+    ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
+    t = TranspiladorRuby()
+    resultado = t.transpilar(ast)
+    esperado = "def miFuncion(a, b)\n    x = a + b\nend"
+    assert resultado == esperado
+
+
+def test_transpilador_llamada_funcion_ruby():
+    ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
+    t = TranspiladorRuby()
+    resultado = t.transpilar(ast)
+    assert resultado == "miFuncion(a, b)"
+
+
+def test_transpilador_imprimir_ruby():
+    ast = [NodoImprimir(NodoValor("x"))]
+    t = TranspiladorRuby()
+    resultado = t.transpilar(ast)
+    assert resultado == "puts x"


### PR DESCRIPTION
## Summary
- implement `TranspiladorRuby` for Ruby code generation
- provide unit tests for Ruby transpiler
- enable Ruby as compilation target in CLI
- expose Ruby transpiler in the API
- document Ruby usage in README

## Testing
- `pytest backend/src/tests/test_to_ruby.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1f0e043483279c9d218b57f8e85c