### PR TITLE
Add PHP transpiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Versión 1.0
 
-Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran y Pascal, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
+Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal y PHP, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
 ## Tabla de Contenidos
 
@@ -91,7 +91,7 @@ El proyecto se organiza en las siguientes carpetas y módulos:
 # Características Principales
 
 - Lexer y Parser: Implementación de un lexer para la tokenización del código fuente y un parser para la construcción de un árbol de sintaxis abstracta (AST).
-- Transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran y Pascal: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
+- Transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal y PHP: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
 - Soporte de Estructuras Avanzadas: Permite la declaración de variables, funciones, clases, listas y diccionarios, así como el uso de bucles y condicionales.
 - Módulos nativos con funciones de E/S, utilidades matemáticas y estructuras de datos para usar directamente desde Cobra.
 - Instalación de paquetes en tiempo de ejecución mediante la instrucción `usar`.
@@ -163,7 +163,7 @@ para var i en rango(2) :
 '''
 ````
 
-Al transpilar a Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. En Rust se produce código equivalente con `println!`, `while` y `for`. En C++ se obtienen construcciones con `std::cout`, `while` y `for`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust o `holobit({ ... })` en C++. En Go se genera `fmt.Println`, en R se usa `print` y en Julia `println`; en Java se usa `System.out.println`, en COBOL `DISPLAY`, en Fortran `print *` y en Pascal `writeln`.
+Al transpilar a Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. En Rust se produce código equivalente con `println!`, `while` y `for`. En C++ se obtienen construcciones con `std::cout`, `while` y `for`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust o `holobit({ ... })` en C++. En Go se genera `fmt.Println`, en R se usa `print` y en Julia `println`; en Java se usa `System.out.println`, en COBOL `DISPLAY`, en Fortran `print *` y en Pascal `writeln` y en PHP `echo`.
 
 ## Integración con holobit-sdk
 
@@ -221,7 +221,7 @@ editar `cobra.mod` y volver a ejecutar las pruebas.
 ## Invocar el transpilador
 
 La carpeta [`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler)
-contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran y Pascal. Una vez
+contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal y PHP. Una vez
 instaladas las dependencias, puedes llamar al transpilador desde tu propio
 script de la siguiente manera:
 
@@ -244,11 +244,13 @@ from cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
 from cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
 from cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
 from cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
+from cobra.transpilers.transpiler.to_php import TranspiladorPHP
 
 codigo_cobol = TranspiladorCOBOL().transpilar(arbol)
 codigo_fortran = TranspiladorFortran().transpilar(arbol)
 codigo_pascal = TranspiladorPascal().transpilar(arbol)
 codigo_ruby = TranspiladorRuby().transpilar(arbol)
+codigo_php = TranspiladorPHP().transpilar(arbol)
 ```
 
 Requiere tener instalado el paquete en modo editable y todas las dependencias
@@ -275,7 +277,7 @@ Al transpilarlas, se generan llamadas `asyncio.create_task` en Python y `Promise
 Una vez instalado el paquete, la herramienta `cobra` ofrece varios subcomandos:
 
 ```bash
-# Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran o Pascal
+# Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal o PHP
 cobra compilar programa.co --tipo python
 
 # Ejecutar directamente un script Cobra
@@ -431,7 +433,7 @@ Este proyecto está bajo la [Licencia MIT](LICENSE).
 
 ### Notas
 
-- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran y Pascal.
+- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal y PHP.
 - **Ejemplos de Código y Nuevas Estructuras**: Incluye ejemplos con el uso de estructuras avanzadas como clases y diccionarios en el lenguaje Cobra.
 
 Si deseas agregar o modificar algo, házmelo saber.

--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -18,6 +18,7 @@ from src.cobra.transpilers.transpiler.to_java import TranspiladorJava
 from src.cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
 from src.cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
 from src.cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
+from src.cobra.transpilers.transpiler.to_php import TranspiladorPHP
 
 
 class CompileCommand(BaseCommand):
@@ -48,6 +49,7 @@ class CompileCommand(BaseCommand):
                 "cobol",
                 "fortran",
                 "pascal",
+                "php",
             ],
             default="python",
             help="Tipo de código generado",
@@ -98,6 +100,8 @@ class CompileCommand(BaseCommand):
                     transp = TranspiladorFortran()
                 elif transpilador == "pascal":
                     transp = TranspiladorPascal()
+                elif transpilador == "php":
+                    transp = TranspiladorPHP()
                 else:
                     raise ValueError("Transpilador no soportado.")
 

--- a/backend/src/cobra/transpilers/transpiler/__init__.py
+++ b/backend/src/cobra/transpilers/transpiler/__init__.py
@@ -2,4 +2,5 @@
 
 # Exportar transpiladores básicos
 from .to_ruby import TranspiladorRuby
+from .to_php import TranspiladorPHP
 

--- a/backend/src/cobra/transpilers/transpiler/to_php.py
+++ b/backend/src/cobra/transpilers/transpiler/to_php.py
@@ -1,0 +1,105 @@
+"""Transpilador simple de Cobra a PHP."""
+
+from src.core.ast_nodes import (
+    NodoValor,
+    NodoIdentificador,
+    NodoLlamadaFuncion,
+    NodoAsignacion,
+    NodoFuncion,
+    NodoImprimir,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoAtributo,
+)
+from src.cobra.lexico.lexer import TipoToken
+from src.core.visitor import NodeVisitor
+from src.core.optimizations import optimize_constants, remove_dead_code
+from src.cobra.macro import expandir_macros
+
+
+def visit_asignacion(self, nodo: NodoAsignacion):
+    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
+    if isinstance(nombre_raw, NodoAtributo):
+        nombre = self.obtener_valor(nombre_raw)
+    else:
+        nombre = f"${nombre_raw}"
+    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
+    self.agregar_linea(f"{nombre} = {self.obtener_valor(valor)};")
+
+
+def visit_funcion(self, nodo: NodoFuncion):
+    params = ", ".join(f"${p}" for p in nodo.parametros)
+    self.agregar_linea(f"function {nodo.nombre}({params}) {{")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+
+
+def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"{nodo.nombre}({args});")
+
+
+def visit_imprimir(self, nodo: NodoImprimir):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"echo {valor};")
+
+
+php_nodes = {
+    "asignacion": visit_asignacion,
+    "funcion": visit_funcion,
+    "llamada_funcion": visit_llamada_funcion,
+    "imprimir": visit_imprimir,
+}
+
+
+class TranspiladorPHP(NodeVisitor):
+    """Transpila el AST de Cobra a un PHP muy básico."""
+
+    def __init__(self):
+        self.codigo = []
+        self.indent = 0
+
+    def agregar_linea(self, linea: str) -> None:
+        self.codigo.append("    " * self.indent + linea)
+
+    def obtener_valor(self, nodo):
+        if isinstance(nodo, NodoValor):
+            return str(nodo.valor)
+        elif isinstance(nodo, NodoIdentificador):
+            return f"${nodo.nombre}"
+        elif isinstance(nodo, NodoAtributo):
+            return f"{self.obtener_valor(nodo.objeto)}->{nodo.nombre}"
+        elif isinstance(nodo, NodoLlamadaFuncion):
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"{nodo.nombre}({args})"
+        elif isinstance(nodo, NodoOperacionBinaria):
+            izq = self.obtener_valor(nodo.izquierda)
+            der = self.obtener_valor(nodo.derecha)
+            op_map = {TipoToken.AND: '&&', TipoToken.OR: '||'}
+            op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
+            return f"{izq} {op} {der}"
+        elif isinstance(nodo, NodoOperacionUnaria):
+            val = self.obtener_valor(nodo.operando)
+            op = '!' if nodo.operador.tipo == TipoToken.NOT else nodo.operador.valor
+            return f"{op}{val}" if op != '!' else f"!{val}"
+        else:
+            return str(getattr(nodo, "valor", nodo))
+
+    def transpilar(self, nodos):
+        nodos = expandir_macros(nodos)
+        nodos = remove_dead_code(optimize_constants(nodos))
+        for nodo in nodos:
+            if hasattr(nodo, "aceptar"):
+                nodo.aceptar(self)
+            else:
+                metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
+                if metodo:
+                    metodo(nodo)
+        return "\n".join(self.codigo)
+
+
+for nombre, funcion in php_nodes.items():
+    setattr(TranspiladorPHP, f"visit_{nombre}", funcion)

--- a/backend/src/tests/test_to_php.py
+++ b/backend/src/tests/test_to_php.py
@@ -1,0 +1,39 @@
+from src.cobra.transpilers.transpiler.to_php import TranspiladorPHP
+from src.core.ast_nodes import (
+    NodoAsignacion,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoImprimir,
+    NodoValor,
+    NodoIdentificador,
+)
+
+
+def test_transpilador_asignacion_php():
+    ast = [NodoAsignacion("x", 10)]
+    t = TranspiladorPHP()
+    resultado = t.transpilar(ast)
+    assert resultado == "$x = 10;"
+
+
+def test_transpilador_funcion_php():
+    ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", NodoIdentificador("a"))])]
+    t = TranspiladorPHP()
+    resultado = t.transpilar(ast)
+    esperado = "function miFuncion($a, $b) {\n    $x = $a;\n}"
+    assert resultado == esperado
+
+
+def test_transpilador_llamada_funcion_php():
+    ast = [NodoLlamadaFuncion("miFuncion", [NodoIdentificador("x"), NodoValor(3)])]
+    t = TranspiladorPHP()
+    resultado = t.transpilar(ast)
+    assert resultado == "miFuncion($x, 3);"
+
+
+def test_transpilador_imprimir_php():
+    ast = [NodoImprimir(NodoIdentificador("x"))]
+    t = TranspiladorPHP()
+    resultado = t.transpilar(ast)
+    assert resultado == "echo $x;"
+


### PR DESCRIPTION
## Summary
- implement `TranspiladorPHP` for converting Cobra AST to PHP
- add CLI integration for the new transpiler
- document PHP support in README
- export PHP transpiler in the package
- include tests covering assignments, functions, calls and printing

## Testing
- `pytest backend/src/tests/test_to_php.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685c21f930848327a637f07534d73fdc