### PR TITLE
Add tests for ruby and php CLI compile options

### DIFF
--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -24,8 +24,8 @@ from src.cobra.transpilers.transpiler.to_php import TranspiladorPHP
 class CompileCommand(BaseCommand):
     """Transpila un archivo Cobra a distintos lenguajes.
 
-    Soporta Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia,
-    Java y ahora también COBOL, Fortran y Pascal.
+    Soporta Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Ruby,
+    PHP, Java y ahora también COBOL, Fortran y Pascal.
     """
 
     name = "compilar"

--- a/backend/src/tests/test_cli_commands_extra.py
+++ b/backend/src/tests/test_cli_commands_extra.py
@@ -78,6 +78,20 @@ from src.cli.commands import modules_cmd
                 "x = 5",
             ],
         ),
+        (
+            "ruby",
+            [
+                "Código generado (TranspiladorRuby):",
+                "x = 5",
+            ],
+        ),
+        (
+            "php",
+            [
+                "Código generado (TranspiladorPHP):",
+                "$x = 5;",
+            ],
+        ),
     ],
 )
 def test_cli_compilar_generates_output(tmp_path, tipo, esperado):


### PR DESCRIPTION
## Summary
- document Ruby and PHP support in compile command
- test CLI compile command with Ruby and PHP targets

## Testing
- `pytest backend/src/tests/test_cli_commands_extra.py::test_cli_compilar_generates_output -q`

------
https://chatgpt.com/codex/tasks/task_e_685c24a8a27c83278e7d7e9942afe0b0