### PR TITLE
Update docs for Ruby and PHP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Versión 1.0
 
-Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal y PHP, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
+Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby y PHP, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
 ## Tabla de Contenidos
 
@@ -91,7 +91,7 @@ El proyecto se organiza en las siguientes carpetas y módulos:
 # Características Principales
 
 - Lexer y Parser: Implementación de un lexer para la tokenización del código fuente y un parser para la construcción de un árbol de sintaxis abstracta (AST).
-- Transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal y PHP: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
+- Transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby y PHP: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
 - Soporte de Estructuras Avanzadas: Permite la declaración de variables, funciones, clases, listas y diccionarios, así como el uso de bucles y condicionales.
 - Módulos nativos con funciones de E/S, utilidades matemáticas y estructuras de datos para usar directamente desde Cobra.
 - Instalación de paquetes en tiempo de ejecución mediante la instrucción `usar`.
@@ -163,7 +163,7 @@ para var i en rango(2) :
 '''
 ````
 
-Al transpilar a Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. En Rust se produce código equivalente con `println!`, `while` y `for`. En C++ se obtienen construcciones con `std::cout`, `while` y `for`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust o `holobit({ ... })` en C++. En Go se genera `fmt.Println`, en R se usa `print` y en Julia `println`; en Java se usa `System.out.println`, en COBOL `DISPLAY`, en Fortran `print *` y en Pascal `writeln` y en PHP `echo`.
+Al transpilar a Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. En Rust se produce código equivalente con `println!`, `while` y `for`. En C++ se obtienen construcciones con `std::cout`, `while` y `for`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust o `holobit({ ... })` en C++. En Go se genera `fmt.Println`, en R se usa `print` y en Julia `println`; en Java se usa `System.out.println`, en COBOL `DISPLAY`, en Fortran `print *` y en Pascal `writeln`, en Ruby `puts` y en PHP `echo`.
 
 ## Integración con holobit-sdk
 
@@ -221,7 +221,7 @@ editar `cobra.mod` y volver a ejecutar las pruebas.
 ## Invocar el transpilador
 
 La carpeta [`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler)
-contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal y PHP. Una vez
+contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby y PHP. Una vez
 instaladas las dependencias, puedes llamar al transpilador desde tu propio
 script de la siguiente manera:
 
@@ -277,7 +277,7 @@ Al transpilarlas, se generan llamadas `asyncio.create_task` en Python y `Promise
 Una vez instalado el paquete, la herramienta `cobra` ofrece varios subcomandos:
 
 ```bash
-# Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal o PHP
+# Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby o PHP
 cobra compilar programa.co --tipo python
 
 # Ejecutar directamente un script Cobra
@@ -342,6 +342,7 @@ cobra compilar programa.co --tipo=java
 cobra compilar programa.co --tipo=cobol
 cobra compilar programa.co --tipo=fortran
 cobra compilar programa.co --tipo=pascal
+cobra compilar programa.co --tipo=php
 echo $?  # 0 al compilar sin problemas
 
 cobra ejecutar inexistente.co

--- a/frontend/docs/arquitectura.rst
+++ b/frontend/docs/arquitectura.rst
@@ -12,7 +12,7 @@ compilar a otros lenguajes y gestionar módulos instalados.
 Core
 ----
 Contiene el corazón del lenguaje: lexer, parser, intérprete y
-transpiladores a Python, JavaScript, ensamblador y Rust. Estos elementos trabajan en
+transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby y PHP. Estos elementos trabajan en
 conjunto para analizar el código fuente y transformarlo en otras
 representaciones o ejecutarlo de forma directa.
 Las clases que componen el AST se definen en ``src.core.ast_nodes`` para facilitar su reutilización.
@@ -20,7 +20,7 @@ El recorrido de estos nodos puede realizarse mediante la clase ``NodeVisitor``
 ubicada en ``src.core.visitor``, que despacha automáticamente al método
 ``visit_<Clase>`` correspondiente.
 Para mantener el código modular, la lógica específica de cada nodo del AST se
-almacena en paquetes independientes. Los transpiladores a Python, JavaScript, ensamblador y Rust
+almacena en paquetes independientes. Los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby y PHP
 importan estas funciones desde ``src.core.transpiler.python_nodes`` y
 ``src.core.transpiler.js_nodes`` (o ``asm_nodes`` o ``rust_nodes``) respectivamente, delegando la operación de
 ``visit_<nodo>`` a dichas funciones.
@@ -49,7 +49,7 @@ optimizar el rendimiento y evitar fugas de memoria.
        CLI -> Lexer;
    Interprete -> Memoria;
    Interprete -> ModulosNativos;
-   Transpiladores -> {Python JS};
+   Transpiladores -> {Python JS Asm Rust Cpp Go R Julia Java COBOL Fortran Pascal Ruby PHP};
    }
 
 Reporte de errores léxicos

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -5,5 +5,5 @@ Avances del lenguaje Cobra
 - **Lexer y Parser funcionales**: El sistema lexico y sintactico esta completamente implementado y es capaz de procesar asignaciones de variables, funciones, condicionales, bucles y operaciones de holobits.
 - **Holobits**: Tipo de dato especial para trabajar con informacion multidimensional, con soporte para operaciones como proyecciones, transformaciones y visualizacion.
 - **Gestión de memoria automatizada**: Cobra incluye un sistema de manejo de memoria optimizado que se ajusta automáticamente utilizando algoritmos genéticos.
-- **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador y Rust.
+- **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby y PHP.
 - **Pruebas unitarias**: Se han creado pruebas para validar el correcto funcionamiento del lexer y el parser.

--- a/frontend/docs/caracteristicas.rst
+++ b/frontend/docs/caracteristicas.rst
@@ -4,7 +4,7 @@ Caracteristicas principales de Cobra
 - **Sintaxis en espanol**: Todas las palabras clave y estructuras del lenguaje estan en español, para facilitar su uso por hablantes nativos.
 - **Gestion de memoria automatica**: Cobra incorpora un sistema de manejo de memoria basado en algoritmos genéticos que optimiza el uso de los recursos durante la ejecución.
 - **Soporte para holobits**: Un tipo de dato multidimensional que permite trabajar con datos de alta complejidad.
-- **Transpiler a Python, JavaScript, ensamblador y Rust**: Los programas escritos en Cobra pueden ser transpilados a estos lenguajes, lo que permite su ejecucion en una variedad de plataformas.
+- **Transpiler a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby y PHP**: Los programas escritos en Cobra pueden ser transpilados a estos lenguajes, lo que permite su ejecucion en una variedad de plataformas.
 - **Nombres Unicode**: Los identificadores aceptan caracteres como `á`, `ñ` o `Ω`.
 
 **Ejemplo basico**

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -34,7 +34,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
 Introducción
 --------------------
 
-Cobra fue creado con la idea de facilitar la programacion en español, optimizando la gestion de memoria y anadiendo soporte para trabajar con datos de alta complejidad como los holobits. Ademas, ofrece soporte para transpilar a Python, JavaScript, ensamblador y Rust, permitiendo su ejecucion en multiples plataformas.
+Cobra fue creado con la idea de facilitar la programacion en español, optimizando la gestion de memoria y anadiendo soporte para trabajar con datos de alta complejidad como los holobits. Ademas, ofrece soporte para transpilar a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby y PHP, permitiendo su ejecucion en multiples plataformas.
 
 
 

--- a/frontend/docs/optimizaciones.rst
+++ b/frontend/docs/optimizaciones.rst
@@ -11,7 +11,7 @@ Eliminación de código muerto
 ----------------------------
 ``remove_dead_code`` elimina instrucciones que nunca se ejecutarán. Por ejemplo, todo lo que aparezca después de ``return`` dentro de una función se descarta y, si un condicional tiene una condición constante, solo se conserva la rama correspondiente.
 
-Estas optimizaciones se aplican automáticamente antes de ejecutar el intérprete y en los transpiladores a Python, JavaScript, ensamblador y Rust.
+Estas optimizaciones se aplican automáticamente antes de ejecutar el intérprete y en los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby y PHP.
 
 Decoradores de rendimiento (``smooth-criminal``)
 ------------------------------------------------

--- a/frontend/docs/referencia.rst
+++ b/frontend/docs/referencia.rst
@@ -31,6 +31,8 @@ El comando ``cobra`` cuenta con varias subopciones:
 
    cobra compilar archivo.co --tipo python
    cobra compilar archivo.co --tipo asm
+   cobra compilar archivo.co --tipo ruby
+   cobra compilar archivo.co --tipo php
    cobra ejecutar archivo.co --depurar
    cobra modulos listar
    cobra docs

--- a/frontend/docs/sintaxis.rst
+++ b/frontend/docs/sintaxis.rst
@@ -98,9 +98,9 @@ Puedes anteponer `@` a una función para modificar su comportamiento con un deco
        imprimir('hola')
    fin
 
-**Transpilación a Python, JavaScript, ensamblador y Rust**
+**Transpilación a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby y PHP**
 
-- `imprimir` se transpila a `print` en Python, `console.log` en JavaScript, `PRINT` en ensamblador y `println!` en Rust.
+- `imprimir` se transpila a `print` en Python, `console.log` en JavaScript, `PRINT` en ensamblador, `println!` en Rust, `std::cout` en C++, `fmt.Println` en Go, `print` en R, `println` en Julia, `System.out.println` en Java, `DISPLAY` en COBOL, `print *` en Fortran, `writeln` en Pascal, `puts` en Ruby y `echo` en PHP.
 - Los bucles `mientras` y `para` se convierten en `while` y `for` en los lenguajes de alto nivel, mientras que en ensamblador generan instrucciones `WHILE` y `FOR`.
-- La construcción `holobit` se traduce a `holobit([...])` en Python, `new Holobit([...])` en JavaScript y `holobit(vec![...])` en Rust.
+- La construcción `holobit` se traduce a `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust y `holobit({...})` en C++, mientras que en Ruby utiliza `Holobit.new([...])` y en PHP `new Holobit([...])`.
 


### PR DESCRIPTION
## Summary
- mention Ruby support throughout docs
- list Ruby and PHP in CLI examples
- update diagrams and lists to include Ruby and PHP

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685c2673bc6c8327ba6d72813fee4db7