### PR TITLE
Add coverage flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
           pip install -r requirements.txt
           pip install sphinx sphinx-rtd-theme pytest-cov codecov
       - name: Run tests
-        run: pytest --cov=backend/src --cov-report=xml
+        run: pytest --cov=backend/src --cov-report=xml \
+          --cov-report=term-missing --cov-fail-under=80
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,8 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+        @$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+coverage:
+	pytest backend/src/tests --cov=backend/src 
+	  --cov-report=term-missing --cov-fail-under=80

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ El proyecto se organiza en las siguientes carpetas y módulos:
 Para ejecutar pruebas unitarias, utiliza pytest:
 
 ````bash
-pytest backend/src/tests
+pytest backend/src/tests --cov=backend/src --cov-report=term-missing \
+  --cov-fail-under=80
 ````
 
 
@@ -325,7 +326,8 @@ futuro.
 Las pruebas están ubicadas en la carpeta tests/ y utilizan pytest para la ejecución. Puedes añadir más pruebas para cubrir nuevos casos de uso y asegurar la estabilidad del código.
 
 ````bash
-pytest backend/src/tests
+pytest backend/src/tests --cov=backend/src --cov-report=term-missing \
+  --cov-fail-under=80
 ````
 
 Se han incluido pruebas que verifican los códigos de salida de la CLI. Los
@@ -364,7 +366,7 @@ echo $?  # 1
 Para obtener un reporte de cobertura en la terminal ejecuta:
 
 ````bash
-pytest --cov=backend/src --cov-report=term-missing
+pytest --cov=backend/src --cov-report=term-missing --cov-fail-under=80
 ````
 
 ## Generar documentación


### PR DESCRIPTION
## Summary
- enforce coverage threshold in CI
- document coverage options in README
- add `coverage` Makefile target for convenience

## Testing
- `pytest backend/src/tests --cov=backend/src --cov-report=term-missing --cov-fail-under=80` *(fails: ModuleNotFoundError: No module named 'holobit_sdk')*

------
https://chatgpt.com/codex/tasks/task_e_685ce569b50c832786605eaaef682543