### PR TITLE
Añade pruebas adicionales de errores y transpiladores

### DIFF
--- a/backend/src/tests/test_lexer_errors_extra.py
+++ b/backend/src/tests/test_lexer_errors_extra.py
@@ -1,0 +1,23 @@
+import pytest
+from src.cobra.lexico.lexer import Lexer, LexerError
+
+
+def test_unclosed_string():
+    codigo = "'hola"
+    lexer = Lexer(codigo)
+    with pytest.raises(LexerError):
+        lexer.tokenizar()
+
+
+def test_multiple_decimal_points():
+    codigo = "123.45.67"
+    lexer = Lexer(codigo)
+    with pytest.raises(LexerError):
+        lexer.tokenizar()
+
+
+def test_invalid_symbol():
+    codigo = "var x = €"
+    lexer = Lexer(codigo)
+    with pytest.raises(LexerError):
+        lexer.tokenizar()

--- a/backend/src/tests/test_parser_errors_extra.py
+++ b/backend/src/tests/test_parser_errors_extra.py
@@ -1,0 +1,26 @@
+import pytest
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+
+
+def parse(code: str):
+    tokens = Lexer(code).analizar_token()
+    return Parser(tokens)
+
+
+def test_decorator_without_function():
+    codigo = "@d var x = 1"
+    with pytest.raises(SyntaxError):
+        parse(codigo).parsear()
+
+
+def test_desde_without_import():
+    codigo = "desde 'm' x"
+    with pytest.raises(SyntaxError):
+        parse(codigo).parsear()
+
+
+def test_unclosed_macro():
+    codigo = "macro m { var x = 1 "
+    with pytest.raises(SyntaxError):
+        parse(codigo).parsear()

--- a/backend/src/tests/test_transpiler_operations_extra.py
+++ b/backend/src/tests/test_transpiler_operations_extra.py
@@ -1,0 +1,25 @@
+from src.cobra.lexico.lexer import Token, TipoToken
+from src.core.ast_nodes import (
+    NodoAsignacion,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoIdentificador,
+)
+from src.cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
+from src.cobra.transpilers.transpiler.to_rust import TranspiladorRust
+
+
+def test_operacion_binaria_matlab():
+    expr = NodoOperacionBinaria(
+        NodoIdentificador("a"),
+        Token(TipoToken.SUMA, "+"),
+        NodoIdentificador("b"),
+    )
+    codigo = TranspiladorMatlab().transpilar([NodoAsignacion("x", expr)])
+    assert codigo == "x = a + b;"
+
+
+def test_operacion_unaria_rust():
+    expr = NodoOperacionUnaria(Token(TipoToken.NOT, "!"), NodoIdentificador("cond"))
+    codigo = TranspiladorRust().transpilar([NodoAsignacion("y", expr)])
+    assert codigo == "let y = !cond;"


### PR DESCRIPTION
## Summary
- cubre errores léxicos raros como cadenas sin cerrar y símbolos desconocidos
- valida errores de sintaxis poco comunes en el parser
- comprueba operaciones binarias y unarias en los transpiladores de MATLAB y Rust

## Testing
- `PYTHONPATH=backend/src pytest --maxfail=1 --cov=backend/src` *(falla: NameError en interpreter)*

------
https://chatgpt.com/codex/tasks/task_e_685ce77526fc832787f7c988136dcd3a