### PR TITLE
Add UML docs

### DIFF
--- a/frontend/docs/arquitectura.rst
+++ b/frontend/docs/arquitectura.rst
@@ -57,3 +57,10 @@ Reporte de errores léxicos
 El lexer genera tokens mientras mantiene un conteo de línea y columna.
 Si encuentra un símbolo no reconocido detiene el proceso y lanza
 ``LexerError`` indicando la posición exacta del problema.
+
+Diagrama de clases principal
+----------------------------
+
+.. graphviz:: uml/class_diagram.gv
+   :caption: Estructura basica del nucleo
+

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -1,0 +1,8 @@
+Arquitectura de la CLI
+======================
+
+La herramienta ``cobra`` permite ejecutar programas y transpilar el codigo a otros lenguajes. Internamente sigue el flujo que se muestra a continuacion:
+
+.. graphviz:: uml/flow_diagram.gv
+   :caption: Flujo de la CLI
+

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -26,6 +26,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    modo_seguro
    empaquetar
    primeros_pasos
+   cli
    como_contribuir
    qualia
    jupyter

--- a/frontend/docs/uml/class_diagram.gv
+++ b/frontend/docs/uml/class_diagram.gv
@@ -1,0 +1,13 @@
+digraph classes {
+    node [shape=record, fontname="Helvetica"];
+    Lexer [label="{Lexer|+tokenize()}"];
+    Parser [label="{Parser|+parse()}"];
+    AST [label="{AST|+Node classes}"];
+    Interpreter [label="{Interpreter|+execute()}"];
+    Transpilers [label="{Transpilers|+to_python()|+to_js()|...}"];
+
+    Lexer -> Parser;
+    Parser -> AST;
+    AST -> Interpreter;
+    AST -> Transpilers;
+}

--- a/frontend/docs/uml/flow_diagram.gv
+++ b/frontend/docs/uml/flow_diagram.gv
@@ -1,0 +1,4 @@
+digraph flow {
+    rankdir=LR;
+    Lexer -> Parser -> AST -> Transpilers;
+}


### PR DESCRIPTION
## Summary
- add UML dot files to `frontend/docs/uml`
- document CLI flow
- reference diagrams from documentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685ceaad48a08327af84f39fe2b9682c