### PR TITLE
Actualizar documentación CLI y arquitectura

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,14 +371,16 @@ pytest --cov=backend/src --cov-report=term-missing --cov-fail-under=80
 
 ## Generar documentación
 
+Para obtener la documentación HTML puedes usar `cobra docs` o
+`make html` desde la raíz del proyecto. El subcomando `docs` ejecuta
+`sphinx-apidoc` y luego compila el HTML en `frontend/build/html`.
+
 Puedes compilar la documentación de dos maneras:
 
-1. **Con la CLI de Cobra**. Ejecuta `cobra docs`. Este subcomando
-   invoca `sphinx-apidoc` para generar automáticamente la API y luego
-   usa Sphinx para crear el HTML en `frontend/build/html`.
+1. **Con la CLI de Cobra**. Ejecuta `cobra docs`.
 
-2. **Con Make**. Desde la raíz del proyecto, ejecuta `make html` para
-   compilar los archivos ubicados en `frontend/docs`.
+2. **Con Make**. Ejecuta `make html` para compilar los archivos ubicados en
+   `frontend/docs`.
 
 3. **Con pdoc**. Para generar documentación de la API con [pdoc](https://pdoc.dev),
    ejecuta `python scripts/generar_pdoc.py`. El resultado se guardará en

--- a/frontend/docs/arquitectura.rst
+++ b/frontend/docs/arquitectura.rst
@@ -51,6 +51,11 @@ optimizar el rendimiento y evitar fugas de memoria.
    Interprete -> ModulosNativos;
    Transpiladores -> {Python JS Asm Rust Cpp Go R Julia Java COBOL Fortran Pascal Ruby PHP Matlab LaTeX};
    }
+ 
+Interacción de los módulos
+-------------------------
+El flujo típico comienza con el ``Lexer`` que lee el código fuente y produce tokens. Estos tokens son consumidos por el ``Parser`` para construir el AST. A partir de este árbol el ``Intérprete`` ejecuta cada nodo o, alternativamente, los transpiladores lo recorren para generar código en otros lenguajes. Cuando se activa el modo seguro se aplica una cadena de validadores (ver :doc:`modo_seguro`) antes de ejecutar o transpilar, bloqueando operaciones peligrosas.
+
 
 Reporte de errores léxicos
 --------------------------

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -1,8 +1,138 @@
-Arquitectura de la CLI
-======================
+CLI de Cobra
+===========
 
-La herramienta ``cobra`` permite ejecutar programas y transpilar el codigo a otros lenguajes. Internamente sigue el flujo que se muestra a continuacion:
+La herramienta ``cobra`` se maneja mediante subcomandos que facilitan
+la ejecución y transpilación de programas. A continuación se resumen
+las opciones más importantes y un ejemplo de uso para cada una.
 
-.. graphviz:: uml/flow_diagram.gv
-   :caption: Flujo de la CLI
+Subcomando ``compilar``
+----------------------
+Transpila un archivo Cobra a otro lenguaje.
 
+Opciones principales:
+
+- ``archivo``: ruta del script ``.co``.
+- ``--tipo``: lenguaje de salida (``python``, ``js``, ``asm``, ``rust``,
+  ``cpp``, ``go``, ``ruby``, ``r``, ``julia``, ``java``, ``cobol``,
+  ``fortran``, ``pascal``, ``php``, ``matlab``, ``latex``).
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra compilar hola.co --tipo python
+
+Subcomando ``ejecutar``
+----------------------
+Ejecuta directamente un script Cobra.
+
+Opciones principales:
+
+- ``archivo``: ruta del código ``.co``.
+- ``--formatear``: aplica ``black`` antes de procesar el archivo.
+- ``--depurar``: muestra información de depuración.
+- ``--seguro``: activa el :doc:`modo seguro <modo_seguro>`.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra ejecutar programa.co --seguro --depurar
+
+Subcomando ``interactive``
+-------------------------
+Abre el intérprete interactivo. Es el modo por defecto si no se
+especifica un subcomando.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra
+
+Subcomando ``modulos``
+---------------------
+Gestiona módulos instalados.
+
+Acciones disponibles:
+
+- ``listar`` muestra los módulos instalados.
+- ``instalar <ruta>`` copia un archivo ``.co`` al directorio de módulos.
+- ``remover <nombre>`` elimina un módulo instalado.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra modulos instalar extra/modulo.co
+
+Subcomando ``dependencias``
+--------------------------
+Permite listar o instalar las dependencias definidas en
+``requirements.txt``.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra dependencias instalar
+
+Subcomando ``docs``
+-------------------
+Genera la documentación HTML del proyecto.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra docs
+
+Subcomando ``empaquetar``
+------------------------
+Crea un ejecutable independiente usando ``PyInstaller``.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra empaquetar --output dist
+
+Subcomando ``crear``
+-------------------
+Genera archivos o proyectos básicos.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra crear proyecto mi_app
+
+Subcomando ``agix``
+------------------
+Analiza un archivo y sugiere mejoras utilizando ``agix``.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra agix ejemplo.co
+
+Subcomando ``jupyter``
+---------------------
+Instala el kernel Cobra y abre ``Jupyter Notebook``.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra jupyter
+
+Subcomando ``gui``
+-----------------
+Inicia la interfaz gráfica basada en ``Flet``.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra gui

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -14,6 +14,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
 
    caracteristicas
    arquitectura
+   cli
    sintaxis
    avances
    proximos_pasos
@@ -26,7 +27,6 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    modo_seguro
    empaquetar
    primeros_pasos
-   cli
    como_contribuir
    qualia
    jupyter


### PR DESCRIPTION
## Summary
- expand CLI usage documentation with subcommands and examples
- deepen architecture docs with module interaction and safe mode link
- rearrange toctree to highlight the CLI page
- clarify in README how to generate the docs

## Testing
- `pytest -q` *(fails: 33 errors during collection)*
- `make html` *(fails: Makefile missing separator error)*

------
https://chatgpt.com/codex/tasks/task_e_685cec3d40f88327bd335339f51d59d1