### PR TITLE
Implement whitelist for usar

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ La sentencia `usar "paquete"` intenta importar un módulo de Python. Si el
 paquete no está disponible, Cobra ejecutará `pip install paquete` para
 instalarlo y luego lo cargará en tiempo de ejecución. El módulo queda
 registrado en el entorno bajo el mismo nombre para su uso posterior.
+Para restringir qué dependencias pueden instalarse se emplea la variable
+`USAR_WHITELIST` definida en `backend/src/cobra/usar_loader.py`. Basta con
+añadir o quitar nombres de paquetes en dicho conjunto para modificar la lista
+autorizada.
 
 ## Archivo de mapeo de módulos
 

--- a/backend/src/cobra/usar_loader.py
+++ b/backend/src/cobra/usar_loader.py
@@ -1,11 +1,17 @@
 import importlib
 import subprocess
 
+# Lista blanca de paquetes que se pueden instalar con ``usar``.
+USAR_WHITELIST: set[str] = set()
+
 
 def obtener_modulo(nombre: str):
     """Importa y devuelve un módulo. Si no está instalado intenta
     instalarlo usando pip y lo importa nuevamente.
     """
+    if USAR_WHITELIST and nombre not in USAR_WHITELIST:
+        raise PermissionError(f"Paquete '{nombre}' no permitido")
+
     try:
         return importlib.import_module(nombre)
     except ModuleNotFoundError:

--- a/backend/src/tests/test_usar.py
+++ b/backend/src/tests/test_usar.py
@@ -10,12 +10,22 @@ from src.cobra import usar_loader
 
 def test_obtener_modulo_instala_si_no_existe():
     mock_mod = ModuleType('demo')
+    usar_loader.USAR_WHITELIST.add('demo')
     with patch.object(usar_loader.importlib, 'import_module', side_effect=[ModuleNotFoundError(), mock_mod]) as mock_import, \
          patch.object(usar_loader.subprocess, 'run') as mock_run:
         mock_run.return_value.returncode = 0
         mod = usar_loader.obtener_modulo('demo')
+    usar_loader.USAR_WHITELIST.remove('demo')
     mock_run.assert_called_once_with(['pip', 'install', 'demo'], check=True)
     assert mod is mock_mod
+
+
+def test_obtener_modulo_rechaza_paquete_fuera_de_lista():
+    usar_loader.USAR_WHITELIST.clear()
+    usar_loader.USAR_WHITELIST.add('ok')
+    with pytest.raises(PermissionError):
+        usar_loader.obtener_modulo('malo')
+    usar_loader.USAR_WHITELIST.clear()
 
 
 @pytest.mark.timeout(5)

--- a/frontend/docs/modo_seguro.rst
+++ b/frontend/docs/modo_seguro.rst
@@ -6,7 +6,9 @@ opción ``--seguro``. Al activarse se construye una cadena de validadores que
 analiza el AST y bloquea primitivas peligrosas como ``leer_archivo``,
 ``escribir_archivo``, ``obtener_url`` y ``hilo``. También se valida la
 instrucción ``import`` para permitir únicamente los módulos instalados o los
-especificados en ``IMPORT_WHITELIST``.
+especificados en ``IMPORT_WHITELIST``. La instrucción ``usar`` está limitada a
+los paquetes listados en ``USAR_WHITELIST`` ubicado en
+``backend/src/cobra/usar_loader.py``.
 
 Si se intenta utilizar alguna de estas operaciones se lanzará
 ``PrimitivaPeligrosaError`` antes de ejecutar el código.


### PR DESCRIPTION
## Summary
- restrict package installation with `USAR_WHITELIST`
- mention editing whitelist in README and docs
- enforce whitelist in `obtener_modulo`
- test whitelist behaviour

## Testing
- `pytest backend/src/tests/test_usar.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685cedede3dc8327a816cfdb7d6cb2ff