### PR TITLE
Add custom validator support

### DIFF
--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -29,6 +29,10 @@ def main(argv=None):
     parser.add_argument("--formatear", action="store_true", help="Formatea el archivo antes de procesarlo")
     parser.add_argument("--depurar", action="store_true", help="Muestra mensajes de depuración")
     parser.add_argument("--seguro", action="store_true", help="Ejecuta en modo seguro")
+    parser.add_argument(
+        "--validadores-extra",
+        help="Ruta a módulo con validadores personalizados",
+    )
 
     subparsers = parser.add_subparsers(dest="comando")
 

--- a/backend/src/cli/commands/execute_cmd.py
+++ b/backend/src/cli/commands/execute_cmd.py
@@ -24,6 +24,7 @@ class ExecuteCommand(BaseCommand):
         depurar = getattr(args, "depurar", False)
         formatear = getattr(args, "formatear", False)
         seguro = getattr(args, "seguro", False)
+        extra_validators = getattr(args, "validadores_extra", None)
 
         if not os.path.exists(archivo):
             print(f"El archivo '{archivo}' no existe")
@@ -41,7 +42,11 @@ class ExecuteCommand(BaseCommand):
         ast = Parser(tokens).parsear()
         if seguro:
             try:
-                validador = construir_cadena()
+                validador = construir_cadena(
+                    InterpretadorCobra._cargar_validadores(extra_validators)
+                    if isinstance(extra_validators, str)
+                    else extra_validators
+                )
                 for nodo in ast:
                     nodo.aceptar(validador)
             except PrimitivaPeligrosaError as pe:
@@ -49,7 +54,10 @@ class ExecuteCommand(BaseCommand):
                 print(f"Error: {pe}")
                 return 1
         try:
-            InterpretadorCobra(safe_mode=seguro).ejecutar_ast(ast)
+            InterpretadorCobra(
+                safe_mode=seguro,
+                extra_validators=extra_validators,
+            ).ejecutar_ast(ast)
             return 0
         except Exception as e:
             logging.error(f"Error ejecutando el script: {e}")

--- a/backend/src/cli/commands/interactive_cmd.py
+++ b/backend/src/cli/commands/interactive_cmd.py
@@ -20,8 +20,19 @@ class InteractiveCommand(BaseCommand):
 
     def run(self, args):
         seguro = getattr(args, "seguro", False)
-        interpretador = InterpretadorCobra(safe_mode=seguro)
-        validador = construir_cadena() if seguro else None
+        extra_validators = getattr(args, "validadores_extra", None)
+        interpretador = InterpretadorCobra(
+            safe_mode=seguro, extra_validators=extra_validators
+        )
+        validador = (
+            construir_cadena(
+                InterpretadorCobra._cargar_validadores(extra_validators)
+                if isinstance(extra_validators, str)
+                else extra_validators
+            )
+            if seguro
+            else None
+        )
 
         while True:
             try:

--- a/backend/src/tests/test_cli_commands_extra.py
+++ b/backend/src/tests/test_cli_commands_extra.py
@@ -145,6 +145,20 @@ def test_cli_ejecutar_flag_seguro(tmp_path):
 
 
 @pytest.mark.timeout(5)
+def test_cli_validadores_extra(tmp_path):
+    archivo = tmp_path / "p.co"
+    archivo.write_text("imprimir(1)")
+    ruta = tmp_path / "vals.py"
+    ruta.write_text("VALIDADORES_EXTRA = []\n")
+    with patch("src.cli.commands.execute_cmd.InterpretadorCobra") as mock_interp:
+        main(["--seguro", f"--validadores-extra={ruta}", "ejecutar", str(archivo)])
+        mock_interp.assert_called_once_with(
+            safe_mode=True, extra_validators=str(ruta)
+        )
+        mock_interp.return_value.ejecutar_ast.assert_called_once()
+
+
+@pytest.mark.timeout(5)
 def test_cli_modulos_comandos(tmp_path, monkeypatch):
     mods_dir = tmp_path / "mods"
     mods_dir.mkdir()

--- a/backend/src/tests/test_custom_validators.py
+++ b/backend/src/tests/test_custom_validators.py
@@ -1,0 +1,31 @@
+import pytest
+from src.core.interpreter import InterpretadorCobra
+from src.core.semantic_validators.base import ValidadorBase
+from src.core.ast_nodes import NodoValor
+
+class DummyError(Exception):
+    pass
+
+class DummyValidator(ValidadorBase):
+    def visit_valor(self, nodo):
+        raise DummyError('validado')
+
+def test_interpreter_extra_validators_list():
+    interp = InterpretadorCobra(safe_mode=True, extra_validators=[DummyValidator()])
+    with pytest.raises(DummyError):
+        interp.ejecutar_ast([NodoValor(1)])
+
+
+def test_interpreter_extra_validators_file(tmp_path):
+    mod = tmp_path / 'vals.py'
+    mod.write_text(
+        'from src.core.semantic_validators.base import ValidadorBase\n'
+        'class V(ValidadorBase):\n'
+        '    def visit_valor(self, nodo):\n'
+        '        raise Exception("file")\n'
+        'VALIDADORES_EXTRA = [V()]\n'
+    )
+    interp = InterpretadorCobra(safe_mode=True, extra_validators=str(mod))
+    with pytest.raises(Exception):
+        interp.ejecutar_ast([NodoValor(2)])
+

--- a/frontend/docs/modo_seguro.rst
+++ b/frontend/docs/modo_seguro.rst
@@ -19,3 +19,13 @@ Ejemplo de uso
 .. code-block:: bash
 
    cobra ejecutar programa.co --seguro
+
+Validadores personalizados
+-------------------------
+Se puede ampliar la cadena de validación pasando la opción
+``--validadores-extra`` con la ruta a un módulo que defina la lista
+``VALIDADORES_EXTRA``. Cada elemento debe ser una instancia de un validador.
+
+.. code-block:: bash
+
+   cobra ejecutar programa.co --seguro --validadores-extra mis_validadores.py

--- a/frontend/docs/validador.rst
+++ b/frontend/docs/validador.rst
@@ -36,6 +36,30 @@ otros validadores pasando una lista a esta función.
 
    cadena = construir_cadena([MiValidador()])
 
+Registro automático de validadores
+---------------------------------
+Los validadores también pueden cargarse de forma automática desde un módulo
+externo mediante la opción ``--validadores-extra`` de la CLI. El módulo debe
+definir una lista ``VALIDADORES_EXTRA`` con las instancias a añadir.
+
+.. code-block:: python
+
+   # archivo validadores.py
+   from src.core.semantic_validators.base import ValidadorBase
+
+   class Demo(ValidadorBase):
+       def visit_valor(self, nodo):
+           self.generic_visit(nodo)
+           self.delegar(nodo)
+
+   VALIDADORES_EXTRA = [Demo()]
+
+Posteriormente se indica la ruta al ejecutar Cobra:
+
+.. code-block:: bash
+
+   cobra ejecutar prog.co --seguro --validadores-extra validadores.py
+
 Ejemplo de deteccion
 --------------------
 


### PR DESCRIPTION
## Summary
- extend InterpretadorCobra to accept extra validators from list or file
- add `--validadores-extra` CLI option and pass custom validators to commands
- document how to register validators in `modo_seguro.rst` and `validador.rst`
- test interpreter and CLI loading of custom validators

## Testing
- `pytest backend/src/tests/test_custom_validators.py::test_interpreter_extra_validators_list -q`
- `pytest backend/src/tests/test_custom_validators.py::test_interpreter_extra_validators_file -q`
- `pytest backend/src/tests/test_cli_commands_extra.py::test_cli_validadores_extra -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'holobit_sdk')*

------
https://chatgpt.com/codex/tasks/task_e_685cf09eb5dc8327b46d33516791c0f6