### PR TITLE
Add v1.2 roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,14 @@ El proyecto avanza en versiones incrementales. A continuacion se listan las tare
 - Implementar optimizaciones del AST para mayor rendimiento.
 - Anadir pruebas de concurrencia para mejorar la estabilidad.
 
+### v1.2
+
+- Cache de AST con checksum
+- Transpilación multi-lenguaje en paralelo
+- Ejemplos de benchmarking y configuración segura
+- Interfaz base para plugins
+- Registro y versionado de plugins
+
 
 # Contribuciones
 
@@ -440,7 +448,7 @@ Tras instalar el paquete con `pip install -e .`, Cobra detectará automáticamen
 el nuevo comando.
 ## Historial de Cambios
 
-- Versión 1.2: actualización de documentación y archivos de configuración.
+- Versión 1.2: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.2 del roadmap.
 
 # Licencia
 


### PR DESCRIPTION
## Summary
- document plans for version 1.2 in README
- reference v1.2 roadmap in change log

## Testing
- `pytest -q` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685cf85b3e8c8327846a3d5d50d35fdf