### PR TITLE
Add benchmarking guide and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,18 @@ El proyecto se organiza en las siguientes carpetas y módulos:
 - Decoradores de rendimiento: la biblioteca ``smooth-criminal`` ofrece
   funciones como ``optimizar`` y ``perfilar`` para mejorar y medir la
   ejecución de código Python desde Cobra.
+- Benchmarking: ejemplos completos de medición de rendimiento están
+  disponibles en `frontend/docs/benchmarking.rst`.
 - Ejemplos de Código y Documentación: Ejemplos prácticos que ilustran el uso del lexer, parser y transpiladores.
 - Ejemplos Avanzados: Revisa `frontend/docs/ejemplos_avanzados.rst` para conocer casos con clases, hilos y manejo de errores.
 - Identificadores en Unicode: Puedes nombrar variables y funciones utilizando
   caracteres como `á`, `ñ` o `Ω` para una mayor flexibilidad.
 
 # Uso
+
+Para conocer las opciones avanzadas del modo seguro revisa
+`frontend/docs/modo_seguro.rst`. Los ejemplos de medición de rendimiento
+están disponibles en `frontend/docs/benchmarking.rst`.
 
 Para ejecutar pruebas unitarias, utiliza pytest:
 

--- a/frontend/docs/benchmarking.rst
+++ b/frontend/docs/benchmarking.rst
@@ -1,0 +1,54 @@
+Benchmarking y medición de rendimiento
+======================================
+
+Esta guía explica cómo obtener métricas de ejecución en programas Cobra.
+El módulo ``src.core.performance`` se basa en la librería ``smooth-criminal``
+y expone los ayudantes ``optimizar`` y ``perfilar`` para decorar funciones o
+medir su comportamiento.
+
+Uso de ``perfilar``
+-------------------
+
+El siguiente ejemplo ejecuta una función varias veces y devuelve estadísticas
+de tiempo:
+
+.. code-block:: python
+
+    from src.core.performance import perfilar
+
+    def sumar(a, b):
+        return a + b
+
+    datos = perfilar(sumar, args=(1, 2), repeticiones=10)
+    print(datos)
+
+Optimización con ``optimizar``
+------------------------------
+
+Si deseas aplicar automáticamente optimizaciones de ``smooth-criminal`` usa
+``optimizar`` como decorador:
+
+.. code-block:: python
+
+    from src.core.performance import optimizar
+
+    @optimizar(workers=2)
+    def proceso():
+        # código intensivo en CPU
+        pass
+
+Otras herramientas
+------------------
+
+Además de ``smooth-criminal`` puedes emplear la biblioteca estándar
+``timeit`` para microbenchmarks rápidos:
+
+.. code-block:: python
+
+    import timeit
+
+    tiempo = timeit.timeit("x = 1 + 1", number=100000)
+    print(tiempo)
+
+Para más información sobre configuraciones seguras consulta
+:doc:`modo_seguro`.

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -19,6 +19,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    avances
    proximos_pasos
    optimizaciones
+   benchmarking
    modulos_nativos
    ejemplos
    ejemplos_avanzados

--- a/frontend/docs/modo_seguro.rst
+++ b/frontend/docs/modo_seguro.rst
@@ -29,3 +29,18 @@ Se puede ampliar la cadena de validación pasando la opción
 .. code-block:: bash
 
    cobra ejecutar programa.co --seguro --validadores-extra mis_validadores.py
+
+Configuraciones avanzadas
+-------------------------
+
+Las listas ``IMPORT_WHITELIST`` y ``USAR_WHITELIST`` determinan qué módulos y
+paquetes pueden cargarse cuando el modo seguro está activo. Puedes editarlas en
+``backend/src/cobra/import_loader.py`` y ``backend/src/cobra/usar_loader.py``
+respectivamente para afinar las restricciones.
+
+También es posible definir validadores adicionales creando un módulo con la
+variable ``VALIDADORES_EXTRA`` y pasándolo mediante la opción
+``--validadores-extra``.
+
+Para evaluar el impacto de estas comprobaciones en el rendimiento revisa
+:doc:`benchmarking`.


### PR DESCRIPTION
## Summary
- document benchmarking with `smooth-criminal`
- describe advanced safe mode configuration and cross-link to benchmarking
- reference benchmarking docs in README
- add benchmarking page to Sphinx toctree

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685cf958e38083279b5c28db1b287ec0