### PR TITLE
Implement AST cache system

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,19 @@ Para obtener un reporte de cobertura en la terminal ejecuta:
 pytest --cov=backend/src --cov-report=term-missing --cov-fail-under=80
 ````
 
+## Caché del AST
+
+Cobra guarda los árboles de sintaxis en la carpeta `cache` situada en la
+raíz del proyecto. Cada archivo se nombra con el SHA256 del código y tiene
+extensión `.ast`. Puedes cambiar la ubicación definiendo la variable de
+entorno `COBRA_AST_CACHE` antes de ejecutar la compilación.
+
+Para limpiar la caché elimina los archivos de dicho directorio:
+
+```bash
+rm cache/*.ast
+```
+
 ## Generar documentación
 
 Para obtener la documentación HTML puedes usar `cobra docs` o

--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -2,8 +2,7 @@ import logging
 import os
 from .base import BaseCommand
 
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
+from src.core.ast_cache import obtener_ast
 from src.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
@@ -71,8 +70,7 @@ class CompileCommand(BaseCommand):
         with open(archivo, "r") as f:
             codigo = f.read()
             try:
-                tokens = Lexer(codigo).tokenizar()
-                ast = Parser(tokens).parsear()
+                ast = obtener_ast(codigo)
 
                 validador = construir_cadena()
                 for nodo in ast:

--- a/backend/src/core/ast_cache.py
+++ b/backend/src/core/ast_cache.py
@@ -1,0 +1,46 @@
+import os
+import hashlib
+import pickle
+
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+
+# Directorio donde se almacenará el cache de AST. Puede modificarse con la
+# variable de entorno `COBRA_AST_CACHE`.
+CACHE_DIR = os.environ.get(
+    "COBRA_AST_CACHE",
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "cache")),
+)
+
+
+def _ruta_cache(codigo: str) -> str:
+    """Devuelve la ruta del archivo de cache para un codigo determinado."""
+    checksum = hashlib.sha256(codigo.encode("utf-8")).hexdigest()
+    return os.path.join(CACHE_DIR, f"{checksum}.ast")
+
+
+def obtener_ast(codigo: str):
+    """Obtiene el AST del codigo reutilizando una version en cache si existe."""
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    ruta = _ruta_cache(codigo)
+
+    if os.path.exists(ruta):
+        with open(ruta, "rb") as f:
+            return pickle.load(f)
+
+    tokens = Lexer(codigo).tokenizar()
+    ast = Parser(tokens).parsear()
+
+    with open(ruta, "wb") as f:
+        pickle.dump(ast, f)
+
+    return ast
+
+
+def limpiar_cache():
+    """Elimina todos los archivos de cache generados."""
+    if not os.path.isdir(CACHE_DIR):
+        return
+    for nombre in os.listdir(CACHE_DIR):
+        if nombre.endswith(".ast"):
+            os.remove(os.path.join(CACHE_DIR, nombre))

--- a/backend/src/tests/test_ast_cache.py
+++ b/backend/src/tests/test_ast_cache.py
@@ -1,0 +1,49 @@
+import os
+import pytest
+from src.cobra.parser.parser import Parser
+
+
+def test_obtener_ast_reutiliza(monkeypatch, tmp_path):
+    # Redirigir el directorio de cache a una carpeta temporal
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("COBRA_AST_CACHE", str(cache_dir))
+
+    import importlib, sys
+    if 'src.core.ast_cache' in sys.modules:
+        importlib.reload(sys.modules['src.core.ast_cache'])
+    from src.core.ast_cache import obtener_ast
+
+    llamadas = {"count": 0}
+
+    def fake_parsear(self):
+        llamadas["count"] += 1
+        return []
+
+    monkeypatch.setattr(Parser, "parsear", fake_parsear)
+
+    codigo = "var x = 1"
+    obtener_ast(codigo)
+    obtener_ast(codigo)
+
+    assert llamadas["count"] == 1
+    # Se creó un único archivo en la caché
+    archivos = list(cache_dir.glob("*.ast"))
+    assert len(archivos) == 1
+
+
+@pytest.mark.timeout(5)
+def test_limpiar_cache(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("COBRA_AST_CACHE", str(cache_dir))
+    codigo = "var y = 2"
+
+    import importlib, sys
+    if 'src.core.ast_cache' in sys.modules:
+        importlib.reload(sys.modules['src.core.ast_cache'])
+    from src.core.ast_cache import obtener_ast, limpiar_cache
+
+    obtener_ast(codigo)
+    assert list(cache_dir.glob("*.ast"))
+
+    limpiar_cache()
+    assert list(cache_dir.glob("*.ast")) == []


### PR DESCRIPTION
## Summary
- implement `ast_cache.py` module with SHA256-based caching
- adjust `compile_cmd` to reuse cached AST
- describe cache usage in README
- add unit tests for the cache

## Testing
- `pytest backend/src/tests/test_ast_cache.py backend/src/tests/test_cli.py::test_cli_interactive backend/src/tests/test_cli.py::test_cli_transpilador -q`

------
https://chatgpt.com/codex/tasks/task_e_685cfb0e93188327bbb0ceb3aab17730