### PR TITLE
Add parallel multi-language compile

### DIFF
--- a/backend/src/tests/test_cli_commands_extra.py
+++ b/backend/src/tests/test_cli_commands_extra.py
@@ -118,6 +118,17 @@ def test_cli_compilar_generates_output(tmp_path, tipo, esperado):
 
 
 @pytest.mark.timeout(5)
+def test_cli_compilar_varios_tipos(tmp_path):
+    archivo = tmp_path / "c.co"
+    archivo.write_text("var x = 5")
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["compilar", str(archivo), "--tipos=python,js"])
+    output = out.getvalue().strip().splitlines()
+    assert output[0].startswith("Código generado (TranspiladorPython) para python:")
+    assert any(line.startswith("Código generado (TranspiladorJavaScript) para js:") for line in output)
+
+
+@pytest.mark.timeout(5)
 def test_cli_compilar_archivo_inexistente(tmp_path):
     archivo = tmp_path / "no.co"
     with patch("sys.stdout", new_callable=StringIO) as out:

--- a/backend/src/tests/test_cli_compile_parallel.py
+++ b/backend/src/tests/test_cli_compile_parallel.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+from io import StringIO
+from unittest.mock import patch
+
+from src.cli.cli import main
+
+
+def _fake_transpile(self, ast):
+    import time
+    time.sleep(0.1)
+    return str(os.getpid())
+
+
+@pytest.mark.timeout(5)
+def test_cli_compilar_varios_tipos_en_paralelo(tmp_path):
+    archivo = tmp_path / "c.co"
+    archivo.write_text("var x = 5")
+    with patch("src.cobra.transpilers.transpiler.to_python.TranspiladorPython.transpilar", _fake_transpile), \
+         patch("src.cobra.transpilers.transpiler.to_js.TranspiladorJavaScript.transpilar", _fake_transpile), \
+         patch("sys.stdout", new_callable=StringIO) as out:
+        main(["compilar", str(archivo), "--tipos=python,js"])
+    lineas = out.getvalue().strip().splitlines()
+    assert lineas[0].startswith("Código generado (TranspiladorPython) para python:")
+    assert lineas[2].startswith("Código generado (TranspiladorJavaScript) para js:")
+    pid1 = lineas[1]
+    pid2 = lineas[3]
+    assert pid1 != pid2


### PR DESCRIPTION
## Summary
- expand `compile_cmd` with new `--tipos` option to compile to several languages
- run transpilers in parallel using `multiprocessing.Pool`
- show generated code grouped per language
- add tests for new option and parallel execution

## Testing
- `pytest backend/src/tests/test_cli_commands_extra.py::test_cli_compilar_varios_tipos -q`
- `pytest backend/src/tests/test_cli_compile_parallel.py::test_cli_compilar_varios_tipos_en_paralelo -q`
- `pytest -q` *(fails: 77 failed, 240 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685cff13bd988327ba1c07276d2ac34f