### PR TITLE
Implement PluginInterface and update plugin system

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,24 @@ entry_points={
 
 Tras instalar el paquete con `pip install -e .`, Cobra detectará automáticamente
 el nuevo comando.
+
+### Ejemplo de plugin
+
+```python
+from src.cli.plugin_loader import PluginCommand
+
+
+class HolaCommand(PluginCommand):
+    name = "hola"
+    version = "1.0"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help="Muestra un saludo")
+        parser.set_defaults(cmd=self)
+
+    def run(self, args):
+        print("¡Hola desde un plugin!")
+```
 ## Historial de Cambios
 
 - Versión 1.2: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.2 del roadmap.

--- a/backend/src/cli/plugin_interface.py
+++ b/backend/src/cli/plugin_interface.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+
+class PluginInterface(ABC):
+    """Interfaz base que define el comportamiento de un plugin de la CLI."""
+
+    #: Nombre del plugin o subcomando
+    name: str = ""
+
+    #: Versión del plugin
+    version: str = "0.1"
+
+    @abstractmethod
+    def register_subparser(self, subparsers):
+        """Registra los argumentos del subcomando en el parser."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def run(self, args):
+        """Ejecuta la lógica del plugin."""
+        raise NotImplementedError

--- a/backend/src/cli/plugin_loader.py
+++ b/backend/src/cli/plugin_loader.py
@@ -2,11 +2,11 @@ import logging
 from importlib.metadata import entry_points
 
 from .commands.base import BaseCommand
+from .plugin_interface import PluginInterface
 
 
-class PluginCommand(BaseCommand):
-    """Clase base para comandos de plugins."""
-    pass
+class PluginCommand(BaseCommand, PluginInterface):
+    """Clase base para implementar comandos externos mediante plugins."""
 
 
 def descubrir_plugins():
@@ -20,8 +20,10 @@ def descubrir_plugins():
     for ep in eps:
         try:
             plugin_cls = ep.load()
-            if not issubclass(plugin_cls, PluginCommand):
-                logging.warning(f"El plugin {ep.name} no es PluginCommand")
+            if not issubclass(plugin_cls, PluginInterface):
+                logging.warning(
+                    f"El plugin {ep.name} no implementa PluginInterface"
+                )
                 continue
             plugins.append(plugin_cls())
         except Exception as exc:


### PR DESCRIPTION
## Summary
- add `PluginInterface` abstract base class
- make `PluginCommand` implement this interface
- validate plugins against `PluginInterface` when loading
- document plugin example in README

## Testing
- `pytest -k plugin_loader -q`
- `pytest -q` *(fails: 77 failed, 240 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685d033568708327a32656981983d5d5