### PR TITLE
Implement plugin registry and listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,13 @@ entry_points={
 Tras instalar el paquete con `pip install -e .`, Cobra detectará automáticamente
 el nuevo comando.
 
+Cada plugin se registra junto con su número de versión en un registro interno.
+Puedes ver la lista de plugins disponibles ejecutando:
+
+```bash
+cobra plugins
+```
+
 ### Ejemplo de plugin
 
 ```python

--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -11,6 +11,7 @@ from .commands.jupyter_cmd import JupyterCommand
 from .commands.flet_cmd import FletCommand
 from .commands.agix_cmd import AgixCommand
 from .plugin_loader import descubrir_plugins
+from .commands.plugins_cmd import PluginsCommand
 from .commands.modules_cmd import ModulesCommand
 from .commands.dependencias_cmd import DependenciasCommand
 from .commands.empaquetar_cmd import EmpaquetarCommand
@@ -47,6 +48,7 @@ def main(argv=None):
         AgixCommand(),
         JupyterCommand(),
         FletCommand(),
+        PluginsCommand(),
         InteractiveCommand(),
     ]
     comandos.extend(descubrir_plugins())

--- a/backend/src/cli/commands/plugins_cmd.py
+++ b/backend/src/cli/commands/plugins_cmd.py
@@ -1,0 +1,23 @@
+from .base import BaseCommand
+from ..plugin_registry import obtener_registro
+
+
+class PluginsCommand(BaseCommand):
+    """Muestra los plugins instalados."""
+
+    name = "plugins"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help="Lista plugins instalados")
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        registro = obtener_registro()
+        if not registro:
+            print("No hay plugins instalados")
+        else:
+            for nombre, version in registro.items():
+                print(f"{nombre} {version}")
+        return 0
+

--- a/backend/src/cli/plugin_loader.py
+++ b/backend/src/cli/plugin_loader.py
@@ -3,6 +3,7 @@ from importlib.metadata import entry_points
 
 from .commands.base import BaseCommand
 from .plugin_interface import PluginInterface
+from .plugin_registry import registrar_plugin
 
 
 class PluginCommand(BaseCommand, PluginInterface):
@@ -25,7 +26,9 @@ def descubrir_plugins():
                     f"El plugin {ep.name} no implementa PluginInterface"
                 )
                 continue
-            plugins.append(plugin_cls())
+            instancia = plugin_cls()
+            registrar_plugin(instancia.name, getattr(instancia, "version", "0"))
+            plugins.append(instancia)
         except Exception as exc:
             logging.error(f"Error cargando plugin {ep.name}: {exc}")
     return plugins

--- a/backend/src/cli/plugin_registry.py
+++ b/backend/src/cli/plugin_registry.py
@@ -1,0 +1,18 @@
+"""Registro en memoria de plugins y versiones."""
+
+_registry = {}
+
+
+def registrar_plugin(nombre: str, version: str) -> None:
+    """Registra un plugin con su versión."""
+    _registry[nombre] = version
+
+
+def obtener_registro():
+    """Devuelve una copia del registro de plugins."""
+    return dict(_registry)
+
+
+def limpiar_registro() -> None:
+    """Limpia el registro de plugins (principalmente para pruebas)."""
+    _registry.clear()

--- a/backend/src/tests/test_cli_plugins_cmd.py
+++ b/backend/src/tests/test_cli_plugins_cmd.py
@@ -1,0 +1,30 @@
+from io import StringIO
+from unittest.mock import patch
+import importlib.metadata
+
+from src.cli.cli import main
+from src.cli.plugin_loader import PluginCommand
+
+
+class DummyPlugin(PluginCommand):
+    name = "dummy"
+    version = "2.0"
+
+    def register_subparser(self, subparsers):
+        pass
+
+    def run(self, args):
+        pass
+
+
+def test_cli_plugins_muestra_registro():
+    ep = importlib.metadata.EntryPoint(
+        name="dummy",
+        value="src.tests.test_cli_plugins_cmd:DummyPlugin",
+        group="cobra.plugins",
+    )
+    with patch("src.cli.plugin_loader.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            main(["plugins"])
+    assert out.getvalue().strip() == "dummy 2.0"
+

--- a/backend/src/tests/test_plugin_loader.py
+++ b/backend/src/tests/test_plugin_loader.py
@@ -2,9 +2,11 @@ import importlib.metadata
 from unittest.mock import patch
 
 from src.cli.plugin_loader import descubrir_plugins, PluginCommand
+from src.cli.plugin_registry import obtener_registro, limpiar_registro
 
 class DummyPlugin(PluginCommand):
     name = "dummy"
+    version = "1.0"
     def register_subparser(self, subparsers):
         pass
     def run(self, args):
@@ -17,6 +19,8 @@ def test_descubrir_plugins_carga_plugins():
         group="cobra.plugins",
     )
     with patch("src.cli.plugin_loader.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+        limpiar_registro()
         plugins = descubrir_plugins()
     assert len(plugins) == 1
     assert isinstance(plugins[0], DummyPlugin)
+    assert obtener_registro() == {"dummy": "1.0"}

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -136,3 +136,13 @@ Ejemplo:
 .. code-block:: bash
 
    cobra gui
+
+Subcomando ``plugins``
+---------------------
+Muestra los plugins instalados y sus versiones registrados mediante ``entry_points``.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra plugins

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -21,6 +21,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    optimizaciones
    benchmarking
    modulos_nativos
+   plugins
    ejemplos
    ejemplos_avanzados
    referencia

--- a/frontend/docs/plugins.rst
+++ b/frontend/docs/plugins.rst
@@ -1,0 +1,13 @@
+Sistema de plugins
+==================
+
+La CLI de Cobra se puede extender instalando paquetes externos que expongan
+un "entry point" en el grupo ``cobra.plugins``. Durante el arranque la
+aplicación busca dichos entry points e instancia cada plugin.
+
+Al cargarse, la información de nombre y versión se almacena en un registro
+interno accesible desde ``src.cli.plugin_registry``. Para consultar qué
+plugins están disponibles se proporciona el subcomando ``plugins``::
+
+   cobra plugins
+


### PR DESCRIPTION
## Summary
- add `plugin_registry` module and register plugins when discovered
- implement `plugins` CLI subcommand
- document plugin registry usage in README and docs
- provide tests for plugin registry and CLI command

## Testing
- `pytest backend/src/tests/test_plugin_loader.py::test_descubrir_plugins_carga_plugins -q`
- `pytest backend/src/tests/test_cli_plugins_cmd.py::test_cli_plugins_muestra_registro -q`
- `pytest -q` *(fails: SystemExit in agix and NameError in interpreter objects)*

------
https://chatgpt.com/codex/tasks/task_e_685d051dd65c8327afc7a44d2d887157