### PR TITLE
Add changelog and bump version automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,35 @@ name: Publish Package
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 
 jobs:
+  bump-version:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Bump version
+        id: bump
+        run: |
+          VERSION=$(python scripts/bump_version.py)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Commit version bump
+        run: |
+          git config user.name 'github-actions'
+          git config user.email 'github-actions@github.com'
+          git commit -am "Bump version to ${VERSION}"
+          git tag -a v${VERSION} -m "v${VERSION}"
+          git push --follow-tags
+
   build-and-publish:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -19,6 +43,11 @@ jobs:
           pip install build twine
       - name: Build package
         run: python -m build
+      - name: Upload changelog
+        uses: actions/upload-artifact@v3
+        with:
+          name: changelog
+          path: CHANGELOG.md
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Historial de Cambios
+
+## v1.3 - 2024-06-01
+- Versión inicial migrada al changelog.

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import re
+from datetime import date
+from pathlib import Path
+
+SETUP_PATH = Path('setup.py')
+CHANGELOG_PATH = Path('CHANGELOG.md')
+
+VERSION_RE = re.compile(r"version='(\d+\.\d+)'")
+
+
+def read_version():
+    content = SETUP_PATH.read_text()
+    match = VERSION_RE.search(content)
+    if not match:
+        raise ValueError('Versión no encontrada en setup.py')
+    return match.group(1)
+
+
+def bump(version: str) -> str:
+    parts = version.split('.')
+    parts[-1] = str(int(parts[-1]) + 1)
+    return '.'.join(parts)
+
+
+def update_setup(new_version: str):
+    content = SETUP_PATH.read_text()
+    new_content = VERSION_RE.sub(f"version='{new_version}'", content)
+    SETUP_PATH.write_text(new_content)
+
+
+def update_changelog(new_version: str):
+    CHANGELOG_PATH.touch(exist_ok=True)
+    existing = CHANGELOG_PATH.read_text()
+    today = date.today().isoformat()
+    entry = f"## v{new_version} - {today}\n- Cambios pendientes.\n\n"
+    CHANGELOG_PATH.write_text(entry + existing)
+
+
+def main():
+    current = read_version()
+    new = bump(current)
+    update_setup(new)
+    update_changelog(new)
+    print(new)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `CHANGELOG.md`
- implement `scripts/bump_version.py` for automatic version increments
- update release workflow to bump version, create tag and upload changelog

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 77 failed, 244 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685d191f7d088327b5a6fc0912ab4b1a