### PR TITLE
Add linting tools and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install sphinx sphinx-rtd-theme pytest-cov codecov
+      - name: Run linters
+        run: |
+          flake8 backend/src
+          mypy backend/src
       - name: Run tests
         run: pytest --cov=backend/src --cov-report=xml \
           --cov-report=term-missing --cov-fail-under=80

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,9 @@ help:
         @$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 coverage:
-	pytest backend/src/tests --cov=backend/src 
-	  --cov-report=term-missing --cov-fail-under=80
+        pytest backend/src/tests --cov=backend/src
+          --cov-report=term-missing --cov-fail-under=80
+
+lint:
+	flake8 backend/src
+	mypy backend/src

--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
 - Las ramas que comiencen con `feature/`, `bugfix/` o `doc/` recibirán etiquetas
   automáticas al abrir un pull request.
 - Realiza tus cambios y haz commit (`git commit -m 'Añadir nueva característica'`).
+- Ejecuta `make lint` para verificar el código con *flake8* y *mypy*.
 - Envía un pull request.
 
 ## Desarrollo de plugins

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+python_version = 3.11
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ holobit-sdk
 flet
 smooth-criminal
 RestrictedPython==8.0
+flake8==7.3.0
+mypy==1.16.1


### PR DESCRIPTION
## Summary
- enable flake8 and mypy checks
- add lint target for Makefile
- update CI workflow to run flake8 and mypy
- document linting requirement
- provide mypy configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `flake8 backend/src` *(fails with style errors)*
- `mypy backend/src` *(fails with typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d17a434288327a069765830e9d981