### PR TITLE
Unifica mensajes CLI y tests de errores

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,11 @@ Una vez instalado el paquete, la herramienta `cobra` ofrece varios subcomandos:
 # Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab o LaTeX
 cobra compilar programa.co --tipo python
 
+# Ejemplo de mensaje de error al compilar un archivo inexistente
+cobra compilar noexiste.co
+# Salida:
+# Error: El archivo 'noexiste.co' no existe
+
 # Ejecutar directamente un script Cobra
 cobra ejecutar programa.co --depurar --formatear
 

--- a/backend/src/cli/commands/agix_cmd.py
+++ b/backend/src/cli/commands/agix_cmd.py
@@ -1,5 +1,6 @@
 import os
 from .base import BaseCommand
+from ..utils.messages import mostrar_error, mostrar_info
 
 from src.ia.analizador_agix import generar_sugerencias
 
@@ -20,11 +21,11 @@ class AgixCommand(BaseCommand):
     def run(self, args):
         archivo = args.archivo
         if not os.path.exists(archivo):
-            print(f"El archivo '{archivo}' no existe")
+            mostrar_error(f"El archivo '{archivo}' no existe")
             return 1
         with open(archivo, "r") as f:
             codigo = f.read()
         sugerencias = generar_sugerencias(codigo)
         for s in sugerencias:
-            print(s)
+            mostrar_info(str(s))
         return 0

--- a/backend/src/cli/commands/crear_cmd.py
+++ b/backend/src/cli/commands/crear_cmd.py
@@ -1,5 +1,6 @@
 import os
 from .base import BaseCommand
+from ..utils.messages import mostrar_error, mostrar_info
 
 
 class CrearCommand(BaseCommand):
@@ -28,7 +29,7 @@ class CrearCommand(BaseCommand):
         elif accion == "proyecto":
             return self._crear_proyecto(args.ruta)
         else:
-            print("Acción no reconocida")
+            mostrar_error("Acción no reconocida")
             return 1
 
     @staticmethod
@@ -38,13 +39,13 @@ class CrearCommand(BaseCommand):
         os.makedirs(os.path.dirname(ruta) or ".", exist_ok=True)
         with open(ruta, "w", encoding="utf-8"):
             pass
-        print(f"Archivo creado: {ruta}")
+        mostrar_info(f"Archivo creado: {ruta}")
         return 0
 
     @staticmethod
     def _crear_carpeta(ruta):
         os.makedirs(ruta, exist_ok=True)
-        print(f"Carpeta creada: {ruta}")
+        mostrar_info(f"Carpeta creada: {ruta}")
         return 0
 
     @staticmethod
@@ -53,5 +54,5 @@ class CrearCommand(BaseCommand):
         main = os.path.join(ruta, "main.co")
         with open(main, "w", encoding="utf-8"):
             pass
-        print(f"Proyecto Cobra creado en {ruta}")
+        mostrar_info(f"Proyecto Cobra creado en {ruta}")
         return 0

--- a/backend/src/cli/commands/dependencias_cmd.py
+++ b/backend/src/cli/commands/dependencias_cmd.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from .base import BaseCommand
+from ..utils.messages import mostrar_error, mostrar_info
 
 
 class DependenciasCommand(BaseCommand):
@@ -25,7 +26,7 @@ class DependenciasCommand(BaseCommand):
         elif accion == "instalar":
             return self._instalar_dependencias()
         else:
-            print("Acci\u00f3n de dependencias no reconocida")
+            mostrar_error("Acci\u00f3n de dependencias no reconocida")
             return 1
 
     @staticmethod
@@ -38,15 +39,15 @@ class DependenciasCommand(BaseCommand):
     def _listar_dependencias(cls):
         archivo = cls._ruta_requirements()
         if not os.path.exists(archivo):
-            print("No se encontr\u00f3 requirements.txt")
+            mostrar_error("No se encontr\u00f3 requirements.txt")
             return 1
         with open(archivo, "r") as f:
             deps = [l.strip() for l in f if l.strip() and not l.startswith("#")]
         if not deps:
-            print("No hay dependencias listadas")
+            mostrar_info("No hay dependencias listadas")
         else:
             for dep in deps:
-                print(dep)
+                mostrar_info(dep)
         return 0
 
     @classmethod
@@ -54,8 +55,8 @@ class DependenciasCommand(BaseCommand):
         archivo = cls._ruta_requirements()
         try:
             subprocess.run(["pip", "install", "-r", archivo], check=True)
-            print("Dependencias instaladas")
+            mostrar_info("Dependencias instaladas")
             return 0
         except subprocess.CalledProcessError as e:
-            print(f"Error instalando dependencias: {e}")
+            mostrar_error(f"Error instalando dependencias: {e}")
             return 1

--- a/backend/src/cli/commands/docs_cmd.py
+++ b/backend/src/cli/commands/docs_cmd.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from .base import BaseCommand
+from ..utils.messages import mostrar_error, mostrar_info
 
 
 class DocsCommand(BaseCommand):
@@ -27,11 +28,11 @@ class DocsCommand(BaseCommand):
         try:
             subprocess.run(["sphinx-apidoc", "-o", api, codigo], check=True)
             subprocess.run(["sphinx-build", "-b", "html", source, build], check=True)
-            print(f"Documentación generada en {build}")
+            mostrar_info(f"Documentación generada en {build}")
             return 0
         except FileNotFoundError:
-            print("Sphinx no está instalado. Ejecuta 'pip install sphinx'.")
+            mostrar_error("Sphinx no está instalado. Ejecuta 'pip install sphinx'.")
             return 1
         except subprocess.CalledProcessError as e:
-            print(f"Error generando la documentación: {e}")
+            mostrar_error(f"Error generando la documentación: {e}")
             return 1

--- a/backend/src/cli/commands/empaquetar_cmd.py
+++ b/backend/src/cli/commands/empaquetar_cmd.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 
 from .base import BaseCommand
+from ..utils.messages import mostrar_error, mostrar_info
 
 
 class EmpaquetarCommand(BaseCommand):
@@ -40,13 +41,13 @@ class EmpaquetarCommand(BaseCommand):
                 ],
                 check=True,
             )
-            print(f"Ejecutable generado en {os.path.join(output, 'cobra')}")
+            mostrar_info(f"Ejecutable generado en {os.path.join(output, 'cobra')}")
             return 0
         except FileNotFoundError:
-            print(
+            mostrar_error(
                 "PyInstaller no está instalado. Ejecuta 'pip install pyinstaller'."
             )
             return 1
         except subprocess.CalledProcessError as e:
-            print(f"Error empaquetando la CLI: {e}")
+            mostrar_error(f"Error empaquetando la CLI: {e}")
             return 1

--- a/backend/src/cli/commands/execute_cmd.py
+++ b/backend/src/cli/commands/execute_cmd.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from .base import BaseCommand
+from ..utils.messages import mostrar_error, mostrar_info
 from src.core.sandbox import ejecutar_en_sandbox
 
 from src.core.interpreter import InterpretadorCobra
@@ -34,7 +35,7 @@ class ExecuteCommand(BaseCommand):
         sandbox = getattr(args, "sandbox", False)
 
         if not os.path.exists(archivo):
-            print(f"El archivo '{archivo}' no existe")
+            mostrar_error(f"El archivo '{archivo}' no existe")
             return 1
         if formatear:
             self._formatear_codigo(archivo)
@@ -52,7 +53,7 @@ class ExecuteCommand(BaseCommand):
                 return 0
             except Exception as e:
                 logging.error(f"Error ejecutando en sandbox: {e}")
-                print(f"Error ejecutando en sandbox: {e}")
+                mostrar_error(f"Error ejecutando en sandbox: {e}")
                 return 1
 
         tokens = Lexer(codigo).tokenizar()
@@ -68,7 +69,7 @@ class ExecuteCommand(BaseCommand):
                     nodo.aceptar(validador)
             except PrimitivaPeligrosaError as pe:
                 logging.error(f"Primitiva peligrosa: {pe}")
-                print(f"Error: {pe}")
+                mostrar_error(str(pe))
                 return 1
         try:
             InterpretadorCobra(
@@ -78,7 +79,7 @@ class ExecuteCommand(BaseCommand):
             return 0
         except Exception as e:
             logging.error(f"Error ejecutando el script: {e}")
-            print(f"Error ejecutando el script: {e}")
+            mostrar_error(f"Error ejecutando el script: {e}")
             return 1
 
     @staticmethod
@@ -91,7 +92,7 @@ class ExecuteCommand(BaseCommand):
                 archivo,
             ], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except FileNotFoundError:
-            print(
+            mostrar_error(
                 "Herramienta de formateo no encontrada. "
                 "Asegúrate de tener 'black' instalado."
             )

--- a/backend/src/cli/commands/flet_cmd.py
+++ b/backend/src/cli/commands/flet_cmd.py
@@ -1,4 +1,5 @@
 from .base import BaseCommand
+from ..utils.messages import mostrar_error
 
 
 class FletCommand(BaseCommand):
@@ -18,7 +19,7 @@ class FletCommand(BaseCommand):
             import flet
             from src.gui.idle import main
         except ModuleNotFoundError:
-            print("Flet no está instalado. Ejecuta 'pip install flet'.")
+            mostrar_error("Flet no está instalado. Ejecuta 'pip install flet'.")
             return 1
         flet.app(target=main)
         return 0

--- a/backend/src/cli/commands/interactive_cmd.py
+++ b/backend/src/cli/commands/interactive_cmd.py
@@ -1,5 +1,6 @@
 import logging
 from .base import BaseCommand
+from ..utils.messages import mostrar_error, mostrar_info
 from src.core.sandbox import ejecutar_en_sandbox
 
 from src.core.interpreter import InterpretadorCobra
@@ -48,13 +49,13 @@ class InteractiveCommand(BaseCommand):
                     break
                 elif linea == "tokens":
                     tokens = Lexer(linea).tokenizar()
-                    print("Tokens generados:")
+                    mostrar_info("Tokens generados:")
                     for token in tokens:
-                        print(token)
+                        mostrar_info(str(token))
                     continue
                 elif linea == "sugerencias":
                     for s in get_suggestions():
-                        print(s)
+                        mostrar_info(str(s))
                     continue
                 elif linea == "ast":
                     tokens = Lexer(linea).tokenizar()
@@ -67,18 +68,18 @@ class InteractiveCommand(BaseCommand):
                         logging.error(f"Primitiva peligrosa: {pe}")
                         print(f"Error: {pe}")
                         continue
-                    print("AST generado:")
-                    print(ast)
+                    mostrar_info("AST generado:")
+                    mostrar_info(str(ast))
                     continue
                 elif linea:
                     if sandbox:
                         try:
                             salida = ejecutar_en_sandbox(linea)
                             if salida:
-                                print(salida)
+                                mostrar_info(str(salida))
                         except Exception as e:
                             logging.error(f"Error en sandbox: {e}")
-                            print(f"Error en sandbox: {e}")
+                            mostrar_error(f"Error en sandbox: {e}")
                         continue
 
                     tokens = Lexer(linea).tokenizar()
@@ -91,16 +92,16 @@ class InteractiveCommand(BaseCommand):
                                 nodo.aceptar(validador)
                     except PrimitivaPeligrosaError as pe:
                         logging.error(f"Primitiva peligrosa: {pe}")
-                        print(f"Error: {pe}")
+                        mostrar_error(str(pe))
                         continue
                     interpretador.ejecutar_ast(ast)
             except SyntaxError as se:
                 logging.error(f"Error de sintaxis: {se}")
-                print(f"Error procesando la entrada: {se}")
+                mostrar_error(f"Error procesando la entrada: {se}")
             except RuntimeError as re:
                 logging.error(f"Error crítico: {re}")
-                print(f"Error crítico: {re}")
+                mostrar_error(f"Error crítico: {re}")
             except Exception as e:
                 logging.error(f"Error general procesando la entrada: {e}")
-                print(f"Error procesando la entrada: {e}")
+                mostrar_error(f"Error procesando la entrada: {e}")
         return 0

--- a/backend/src/cli/commands/jupyter_cmd.py
+++ b/backend/src/cli/commands/jupyter_cmd.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 from .base import BaseCommand
+from ..utils.messages import mostrar_error
 
 
 class JupyterCommand(BaseCommand):
@@ -23,11 +24,11 @@ class JupyterCommand(BaseCommand):
             ], check=True)
             return 0
         except FileNotFoundError:
-            print(
+            mostrar_error(
                 "No se encontró el ejecutable 'jupyter'. "
                 "Instala Jupyter para utilizar esta función."
             )
             return 1
         except subprocess.CalledProcessError as e:
-            print(f"Error lanzando Jupyter: {e}")
+            mostrar_error(f"Error lanzando Jupyter: {e}")
             return 1

--- a/backend/src/cli/commands/modules_cmd.py
+++ b/backend/src/cli/commands/modules_cmd.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from .base import BaseCommand
+from ..utils.messages import mostrar_error, mostrar_info
 
 MODULES_PATH = os.path.join(os.path.dirname(__file__), "..", "modules")
 os.makedirs(MODULES_PATH, exist_ok=True)
@@ -31,27 +32,27 @@ class ModulesCommand(BaseCommand):
         elif accion == "remover":
             return self._remover_modulo(args.nombre)
         else:
-            print("Acción de módulos no reconocida")
+            mostrar_error("Acción de módulos no reconocida")
             return 1
 
     @staticmethod
     def _listar_modulos():
         mods = [f for f in os.listdir(MODULES_PATH) if f.endswith(".co")]
         if not mods:
-            print("No hay módulos instalados")
+            mostrar_info("No hay módulos instalados")
         else:
             for m in mods:
-                print(m)
+                mostrar_info(m)
         return 0
 
     @staticmethod
     def _instalar_modulo(ruta):
         if not os.path.exists(ruta):
-            print(f"No se encontró el módulo {ruta}")
+            mostrar_error(f"No se encontró el módulo {ruta}")
             return 1
         destino = os.path.join(MODULES_PATH, os.path.basename(ruta))
         shutil.copy(ruta, destino)
-        print(f"Módulo instalado en {destino}")
+        mostrar_info(f"Módulo instalado en {destino}")
         return 0
 
     @staticmethod
@@ -59,8 +60,8 @@ class ModulesCommand(BaseCommand):
         archivo = os.path.join(MODULES_PATH, nombre)
         if os.path.exists(archivo):
             os.remove(archivo)
-            print(f"Módulo {nombre} eliminado")
+            mostrar_info(f"Módulo {nombre} eliminado")
             return 0
         else:
-            print(f"El módulo {nombre} no existe")
+            mostrar_error(f"El módulo {nombre} no existe")
             return 1

--- a/backend/src/cli/commands/plugins_cmd.py
+++ b/backend/src/cli/commands/plugins_cmd.py
@@ -1,5 +1,6 @@
 from .base import BaseCommand
 from ..plugin_registry import obtener_registro
+from ..utils.messages import mostrar_info
 
 
 class PluginsCommand(BaseCommand):
@@ -15,9 +16,9 @@ class PluginsCommand(BaseCommand):
     def run(self, args):
         registro = obtener_registro()
         if not registro:
-            print("No hay plugins instalados")
+            mostrar_info("No hay plugins instalados")
         else:
             for nombre, version in registro.items():
-                print(f"{nombre} {version}")
+                mostrar_info(f"{nombre} {version}")
         return 0
 

--- a/backend/src/cli/utils/messages.py
+++ b/backend/src/cli/utils/messages.py
@@ -1,0 +1,13 @@
+RED = "\033[91m"
+GREEN = "\033[92m"
+RESET = "\033[0m"
+
+
+def mostrar_error(msg):
+    """Muestra un mensaje de error en rojo."""
+    print(f"{RED}Error: {msg}{RESET}")
+
+
+def mostrar_info(msg):
+    """Muestra un mensaje informativo en verde por stdout."""
+    print(f"{GREEN}{msg}{RESET}")

--- a/backend/src/tests/test_cli_commands_extra.py
+++ b/backend/src/tests/test_cli_commands_extra.py
@@ -133,7 +133,8 @@ def test_cli_compilar_archivo_inexistente(tmp_path):
     archivo = tmp_path / "no.co"
     with patch("sys.stdout", new_callable=StringIO) as out:
         main(["compilar", str(archivo)])
-    assert f"Error: El archivo '{archivo}' no existe." == out.getvalue().strip()
+    salida = out.getvalue().strip()
+    assert f"El archivo '{archivo}' no existe" in salida
 
 
 @pytest.mark.timeout(5)
@@ -180,26 +181,26 @@ def test_cli_modulos_comandos(tmp_path, monkeypatch):
 
     with patch("sys.stdout", new_callable=StringIO) as out:
         main(["modulos", "listar"])
-    assert out.getvalue().strip() == "No hay módulos instalados"
+    assert "No hay módulos instalados" in out.getvalue().strip()
 
     with patch("sys.stdout", new_callable=StringIO) as out:
         main(["modulos", "instalar", str(modulo)])
     destino = mods_dir / modulo.name
     assert destino.exists()
-    assert f"Módulo instalado en {destino}" == out.getvalue().strip()
+    assert f"Módulo instalado en {destino}" in out.getvalue().strip()
 
     with patch("sys.stdout", new_callable=StringIO) as out:
         main(["modulos", "listar"])
-    assert out.getvalue().strip() == modulo.name
+    assert modulo.name in out.getvalue().strip()
 
     with patch("sys.stdout", new_callable=StringIO) as out:
         main(["modulos", "remover", modulo.name])
     assert not destino.exists()
-    assert f"Módulo {modulo.name} eliminado" == out.getvalue().strip()
+    assert f"Módulo {modulo.name} eliminado" in out.getvalue().strip()
 
     with patch("sys.stdout", new_callable=StringIO) as out:
         main(["modulos", "listar"])
-    assert out.getvalue().strip() == "No hay módulos instalados"
+    assert "No hay módulos instalados" in out.getvalue().strip()
 
 @pytest.mark.timeout(5)
 def test_cli_crear_archivo(tmp_path):
@@ -207,7 +208,7 @@ def test_cli_crear_archivo(tmp_path):
     with patch("sys.stdout", new_callable=StringIO) as out:
         main(["crear", "archivo", str(ruta)])
     assert (tmp_path / "nuevo.co").exists()
-    assert out.getvalue().strip() == f"Archivo creado: {ruta}.co"
+    assert f"Archivo creado: {ruta}.co" in out.getvalue().strip()
 
 
 @pytest.mark.timeout(5)

--- a/backend/src/tests/test_cli_error_messages.py
+++ b/backend/src/tests/test_cli_error_messages.py
@@ -1,0 +1,21 @@
+from io import StringIO
+from unittest.mock import patch
+import pytest
+
+from src.cli.cli import main
+
+
+@pytest.mark.timeout(5)
+def test_error_msg_compile_missing(tmp_path):
+    archivo = tmp_path / "no.co"
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["compilar", str(archivo)])
+    assert "El archivo" in out.getvalue()
+
+
+@pytest.mark.timeout(5)
+def test_error_msg_execute_missing(tmp_path):
+    archivo = tmp_path / "no.co"
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["ejecutar", str(archivo)])
+    assert "El archivo" in out.getvalue()


### PR DESCRIPTION
## Summary
- add `mostrar_error` y `mostrar_info` utilities
- use them across CLI commands
- update tests to check new error messages and add new tests
- document new error output in README

## Testing
- `pytest backend/src/tests/test_cli_error_messages.py -q`
- `pytest backend/src/tests/test_cli_commands_extra.py::test_cli_compilar_archivo_inexistente -q`
- `pytest backend/src/tests/test_cli_commands_extra.py::test_cli_modulos_comandos -q`
- `pytest backend/src/tests/test_cli_docs.py::test_cli_docs_sin_sphinx -q`
- `pytest backend/src/tests/test_cli_commands_extra.py::test_cli_crear_archivo -q`


------
https://chatgpt.com/codex/tasks/task_e_685d1d1770fc8327a7c1974dbb100b13