### PR TITLE
Update package metadata for PyPI release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 include LICENSE
 include cobra.mod
+include README.md
+include CHANGELOG.md
+include MANUAL_COBRA.md

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cobra-lenguaje',
-    version='1.3',
+    version='1.4',
     author='Adolfo González Hernández',
     author_email='adolfogonzal@gmail.com',
     description='Un lenguaje de programación en español para simulaciones y más.',
@@ -13,6 +13,11 @@ setup(
     packages=find_packages(where='backend/src', include=['*']),
     package_dir={'': 'backend/src'},
     include_package_data=True,
+    keywords=['cobra', 'lenguaje', 'cli'],
+    project_urls={
+        'Documentation': 'https://github.com/Alphonsus411/pCobra#readme',
+        'Source': 'https://github.com/Alphonsus411/pCobra',
+    },
     install_requires=[
         'pytest>=7.0',  # Requerimientos según requirements.txt
         'numpy>=1.22.0',
@@ -42,8 +47,10 @@ setup(
 
     classifiers=[
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.11',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
+        'Natural Language :: Spanish',
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
## Summary
- bump version to 1.4
- add project URLs and keywords
- extend classifiers
- include additional files in MANIFEST

## Testing
- `pytest backend/src/tests/test_cli.py::test_cli_transpilador -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685d26c491908327876df60eb0b35f3b