### PR TITLE
Actualiza documentación y kernel a versión 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Historial de Cambios
 
+## v1.4 - 2025-06-26
+- Publicación en PyPI con metadata completa.
+- Soporte de instalación mediante pipx.
+- Inicio de la internacionalización en la CLI y documentación.
+
 ## v1.3 - 2024-06-01
 - Versión inicial migrada al changelog.

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ class HolaCommand(PluginCommand):
 ```
 ## Historial de Cambios
 
-- Versión 1.3: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
+- Versión 1.4: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
 
 # Licencia
 

--- a/backend/src/jupyter_kernel/__init__.py
+++ b/backend/src/jupyter_kernel/__init__.py
@@ -16,9 +16,9 @@ def install(user=True):
 
 class CobraKernel(Kernel):
     implementation = "Cobra"
-    implementation_version = "1.3"
+    implementation_version = "1.4"
     language = "cobra"
-    language_version = "1.3"
+    language_version = "1.4"
     language_info = {
         "name": "cobra",
         "mimetype": "text/plain",

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -7,4 +7,4 @@ Avances del lenguaje Cobra
 - **Gestión de memoria automatizada**: Cobra incluye un sistema de manejo de memoria optimizado que se ajusta automáticamente utilizando algoritmos genéticos.
 - **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX.
 - **Pruebas unitarias**: Se han creado pruebas para validar el correcto funcionamiento del lexer y el parser.
-- **Versión 1.3**: Actualización de la documentación y configuración del proyecto.
+- **Versión 1.4**: Actualización de la documentación y configuración del proyecto.

--- a/frontend/docs/conf.py
+++ b/frontend/docs/conf.py
@@ -27,7 +27,7 @@ sys.path.insert(0, ROOT_DIR)
 project = 'Proyecto Cobra'
 copyright = '2024, Adolfo González Hernández'
 author = 'Adolfo González Hernández'
-release = '0.9'
+release = '1.4'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
## Summary
- actualiza referencias de "Versión 1.3" a "Versión 1.4"
- actualiza variables de versión en el kernel de Jupyter
- establece `release = '1.4'` en la configuración de la documentación
- añade sección v1.4 al `CHANGELOG`

## Testing
- `pytest -q` *(fallan varias pruebas)*

------
https://chatgpt.com/codex/tasks/task_e_685d3b8988d4832794c6c61907afe093