### PR TITLE
Añade pcobra.toml y documenta formato 2.0

### DIFF
--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -8,3 +8,14 @@ Avances del lenguaje Cobra
 - **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX.
 - **Pruebas unitarias**: Se han creado pruebas para validar el correcto funcionamiento del lexer y el parser.
 - **Versión 1.4**: Actualización de la documentación y configuración del proyecto.
+
+Versión 2.0
+-----------
+Se añade el archivo ``pcobra.toml`` para definir el mapeo de módulos en formato TOML. Su estructura es la siguiente:
+
+.. code-block:: toml
+
+   ["modulo.co"]
+   python = "modulo.py"
+   js = "modulo.js"
+

--- a/pcobra.toml
+++ b/pcobra.toml
@@ -1,0 +1,9 @@
+# Mapeo de módulos Cobra a archivos transpilados
+# La clave es la ruta usada en la instrucción `import`.
+# Cada entrada puede especificar rutas para los archivos generados en Python o JavaScript.
+# Por ejemplo:
+["modulo.co"]
+python = "modulo.py"
+js = "modulo.js"
+
+# Actualmente no existen módulos transpilados a registrar.


### PR DESCRIPTION
## Summary
- crea `pcobra.toml` con esquema de mapeo para módulos
- documenta el nuevo formato en `avances.rst` como novedad de la versión 2.0

## Testing
- `pytest backend/src/tests --cov=backend/src --cov-report=term-missing` *(fallan muchas pruebas)*

------
https://chatgpt.com/codex/tasks/task_e_685d774153e48327a4f38932715ca05c