### PR TITLE
Add pcobra config loader

### DIFF
--- a/backend/src/core/pcobra_config.py
+++ b/backend/src/core/pcobra_config.py
@@ -1,0 +1,30 @@
+import os
+import tomli
+
+PCOBRA_CONFIG_PATH = os.environ.get(
+    "PCOBRA_CONFIG",
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "pcobra.toml")
+    ),
+)
+
+_cache = {}
+
+
+def cargar_configuracion(ruta: str | None = None) -> dict:
+    """Carga y devuelve la configuración en formato TOML.
+
+    Si ``ruta`` es ``None`` se usa la ruta por defecto definida en
+    ``PCOBRA_CONFIG_PATH``. Los resultados se almacenan en una caché
+    interna para evitar lecturas repetidas.
+    """
+    path = ruta or PCOBRA_CONFIG_PATH
+
+    if path not in _cache:
+        if os.path.exists(path):
+            with open(path, "rb") as f:
+                data = tomli.load(f)
+        else:
+            data = {}
+        _cache[path] = data
+    return _cache[path]

--- a/backend/src/tests/test_pcobra_config.py
+++ b/backend/src/tests/test_pcobra_config.py
@@ -1,0 +1,44 @@
+import importlib
+import sys
+
+
+def _reload_module():
+    if 'src.core.pcobra_config' in sys.modules:
+        importlib.reload(sys.modules['src.core.pcobra_config'])
+    return sys.modules.get('src.core.pcobra_config')
+
+
+def test_cargar_configuracion_python_js(tmp_path, monkeypatch):
+    mod = tmp_path / "m.co"
+    py_out = tmp_path / "m.py"
+    js_out = tmp_path / "m.js"
+
+    config = f"\n['{mod}']\npython = '{py_out}'\njs = '{js_out}'\n"
+    cfg_file = tmp_path / "pcobra.toml"
+    cfg_file.write_text(config)
+
+    monkeypatch.setenv('PCOBRA_CONFIG', str(cfg_file))
+    _reload_module()
+    from src.core.pcobra_config import cargar_configuracion
+
+    data = cargar_configuracion()
+    ruta = str(mod)
+    assert data[ruta]['python'] == str(py_out)
+    assert data[ruta]['js'] == str(js_out)
+
+
+def test_cargar_configuracion_cache(tmp_path, monkeypatch):
+    cfg_file = tmp_path / 'pcobra.toml'
+    cfg_file.write_text("")
+    monkeypatch.setenv('PCOBRA_CONFIG', str(cfg_file))
+    _reload_module()
+    from src.core.pcobra_config import cargar_configuracion, _cache
+
+    cargar_configuracion()
+    before = dict(_cache)
+
+    cfg_file.write_text("['x']\npython='a.py'\n")
+    data = cargar_configuracion()
+
+    assert _cache == before
+    assert data == before[str(cfg_file)]


### PR DESCRIPTION
## Summary
- implement `cargar_configuracion` for reading `pcobra.toml`
- add caching mechanism similar to other modules
- create tests to verify configuration reading and caching

## Testing
- `pytest backend/src/tests/test_pcobra_config.py -q`
- `flake8 backend/src/core/pcobra_config.py backend/src/tests/test_pcobra_config.py`

------
https://chatgpt.com/codex/tasks/task_e_685d78ba1bac8327918ffbde8898a750