### PR TITLE
Add pcobra.toml module mapping loader

### DIFF
--- a/backend/src/cobra/transpilers/module_map.py
+++ b/backend/src/cobra/transpilers/module_map.py
@@ -1,5 +1,6 @@
 import os
 import yaml
+import tomllib
 
 MODULE_MAP_PATH = os.environ.get(
     'COBRA_MODULE_MAP',
@@ -8,7 +9,15 @@ MODULE_MAP_PATH = os.environ.get(
     ),
 )
 
+PCOBRA_TOML_PATH = os.environ.get(
+    'PCOBRA_TOML',
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'pcobra.toml')
+    ),
+)
+
 _cache = None
+_toml_cache = None
 
 def get_map():
     global _cache
@@ -20,3 +29,24 @@ def get_map():
             data = {}
         _cache = data
     return _cache
+
+
+def get_toml_map():
+    global _toml_cache
+    if _toml_cache is None:
+        if os.path.exists(PCOBRA_TOML_PATH):
+            with open(PCOBRA_TOML_PATH, 'rb') as f:
+                data = tomllib.load(f) or {}
+        else:
+            data = {}
+        _toml_cache = data
+    return _toml_cache
+
+
+def get_mapped_path(module: str, backend: str) -> str:
+    """Return the path for *module* mapped for the given *backend*.
+
+    If no mapping exists, the original module path is returned.
+    """
+    mapa = get_toml_map()
+    return mapa.get(module, {}).get(backend, module)

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/importar.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/importar.py
@@ -1,11 +1,10 @@
 from src.cobra.lexico.lexer import Lexer
 from src.cobra.parser.parser import Parser
-from ...module_map import get_map
+from ...module_map import get_mapped_path
 
 def visit_import(self, nodo):
     """Carga y transpila el módulo indicado usando el mapeo."""
-    mapa = get_map()
-    ruta = mapa.get(nodo.ruta, {}).get("js", nodo.ruta)
+    ruta = get_mapped_path(nodo.ruta, "js")
 
     try:
         with open(ruta, "r", encoding="utf-8") as f:

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/importar.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/importar.py
@@ -1,12 +1,11 @@
 from src.cobra.lexico.lexer import Lexer
 from src.cobra.parser.parser import Parser
-from ...module_map import get_map
+from ...module_map import get_mapped_path
 
 
 def visit_import(self, nodo):
     """Transpila una declaración de importación consultando el mapeo."""
-    mapa = get_map()
-    ruta = mapa.get(nodo.ruta, {}).get("python", nodo.ruta)
+    ruta = get_mapped_path(nodo.ruta, "python")
 
     try:
         with open(ruta, "r", encoding="utf-8") as f:

--- a/backend/src/tests/test_pcobra_module_map.py
+++ b/backend/src/tests/test_pcobra_module_map.py
@@ -1,0 +1,68 @@
+import tomllib
+
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from src.cobra.transpilers import module_map
+
+
+def _write_toml(path, data):
+    content = ""
+    for mod, mapping in data.items():
+        content += f"['{mod}']\n"
+        for key, value in mapping.items():
+            content += f"{key} = '{value}'\n"
+    path.write_text(content)
+
+
+def test_pcobra_mapeo_python(tmp_path, monkeypatch):
+    mod = tmp_path / "m.co"
+    mod.write_text("var x = 1")
+    py_out = tmp_path / "m.py"
+    py_out.write_text("x = 1\n")
+
+    mapping = {str(mod): {"python": str(py_out)}}
+    toml_file = tmp_path / "pcobra.toml"
+    _write_toml(toml_file, mapping)
+
+    monkeypatch.setenv("PCOBRA_TOML", str(toml_file))
+    module_map._toml_cache = None
+
+    codigo = f"import '{mod}'\nimprimir(x)"
+    tokens = Lexer(codigo).analizar_token()
+    ast = Parser(tokens).parsear()
+
+    resultado = TranspiladorPython().transpilar(ast)
+    esperado = f"from src.core.nativos import *\n{py_out.read_text()}print(x)\n"
+    assert resultado == esperado
+
+
+def test_pcobra_mapeo_js(tmp_path, monkeypatch):
+    mod = tmp_path / "m.co"
+    mod.write_text("var x = 2")
+    js_out = tmp_path / "m.js"
+    js_out.write_text("let x = 2;\n")
+
+    mapping = {str(mod): {"js": str(js_out)}}
+    toml_file = tmp_path / "pcobra.toml"
+    _write_toml(toml_file, mapping)
+
+    monkeypatch.setenv("PCOBRA_TOML", str(toml_file))
+    module_map._toml_cache = None
+
+    codigo = f"import '{mod}'\nimprimir(x)"
+    tokens = Lexer(codigo).analizar_token()
+    ast = Parser(tokens).parsear()
+
+    resultado = TranspiladorJavaScript().transpilar(ast)
+    esperado = (
+        "import * as io from './nativos/io.js';\n"
+        "import * as net from './nativos/io.js';\n"
+        "import * as matematicas from './nativos/matematicas.js';\n"
+        "import { Pila, Cola } from './nativos/estructuras.js';\n"
+        "let x = 2;\n"
+        "console.log(x);"
+    )
+    assert resultado == esperado
+


### PR DESCRIPTION
## Summary
- extend `module_map` with TOML loader and helper to select per-backend paths
- update Python and JS `importar` nodes to use the new loader
- add tests validating mapping resolution via `pcobra.toml`

## Testing
- `pytest backend/src/tests/test_pcobra_module_map.py -q`
- `pytest backend/src/tests/test_module_map.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685d7a0b72348327a6a7a596ab6dd931