### PR TITLE
Agrega validacion de dependencias y sandbox extendido

### DIFF
--- a/backend/src/cli/commands/execute_cmd.py
+++ b/backend/src/cli/commands/execute_cmd.py
@@ -3,7 +3,8 @@ import os
 from .base import BaseCommand
 from ..i18n import _
 from ..utils.messages import mostrar_error, mostrar_info
-from src.core.sandbox import ejecutar_en_sandbox
+from src.core.sandbox import ejecutar_en_sandbox, validar_dependencias
+from src.cobra.transpilers import module_map
 
 from src.core.interpreter import InterpretadorCobra
 from src.cobra.lexico.lexer import Lexer
@@ -37,6 +38,12 @@ class ExecuteCommand(BaseCommand):
 
         if not os.path.exists(archivo):
             mostrar_error(f"El archivo '{archivo}' no existe")
+            return 1
+
+        try:
+            validar_dependencias("python", module_map.get_toml_map())
+        except (ValueError, FileNotFoundError) as dep_err:
+            mostrar_error(f"Error de dependencias: {dep_err}")
             return 1
         if formatear:
             self._formatear_codigo(archivo)

--- a/backend/src/cli/commands/interactive_cmd.py
+++ b/backend/src/cli/commands/interactive_cmd.py
@@ -2,7 +2,8 @@ import logging
 from .base import BaseCommand
 from ..i18n import _
 from ..utils.messages import mostrar_error, mostrar_info
-from src.core.sandbox import ejecutar_en_sandbox
+from src.core.sandbox import ejecutar_en_sandbox, validar_dependencias
+from src.cobra.transpilers import module_map
 
 from src.core.interpreter import InterpretadorCobra
 from src.core.qualia_bridge import get_suggestions
@@ -30,6 +31,12 @@ class InteractiveCommand(BaseCommand):
         seguro = getattr(args, "seguro", False)
         extra_validators = getattr(args, "validadores_extra", None)
         sandbox = getattr(args, "sandbox", False)
+
+        try:
+            validar_dependencias("python", module_map.get_toml_map())
+        except (ValueError, FileNotFoundError) as dep_err:
+            mostrar_error(f"Error de dependencias: {dep_err}")
+            return 1
         interpretador = InterpretadorCobra(
             safe_mode=seguro, extra_validators=extra_validators
         )

--- a/backend/src/tests/test_validar_dependencias.py
+++ b/backend/src/tests/test_validar_dependencias.py
@@ -1,0 +1,66 @@
+from io import StringIO
+from unittest.mock import patch
+import pytest
+
+from src.cli.cli import main
+from src.cobra.transpilers import module_map
+
+
+@pytest.mark.timeout(5)
+def test_compilar_dependencia_invalida_python(tmp_path, monkeypatch):
+    mod = tmp_path / "m.co"
+    mod.write_text("var x = 1")
+    prog = tmp_path / "p.co"
+    prog.write_text(f"import '{mod}'\nimprimir(x)")
+    mapping = {str(mod): {"python": str(tmp_path / 'no.py')}}
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: mapping)
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["compilar", str(prog)])
+    assert "dependencia" in out.getvalue().lower()
+
+
+@pytest.mark.timeout(5)
+def test_compilar_dependencia_invalida_js(tmp_path, monkeypatch):
+    mod = tmp_path / "m.co"
+    mod.write_text("var x = 1")
+    prog = tmp_path / "p.co"
+    prog.write_text(f"import '{mod}'\nimprimir(x)")
+    mapping = {str(mod): {"js": str(tmp_path / 'no.js')}}
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: mapping)
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["compilar", str(prog), "--tipo=js"])
+    assert "dependencia" in out.getvalue().lower()
+
+
+@pytest.mark.timeout(5)
+def test_compilar_dependencia_invalida_cpp(tmp_path, monkeypatch):
+    mod = tmp_path / "m.co"
+    mod.write_text("var x = 1")
+    prog = tmp_path / "p.co"
+    prog.write_text(f"import '{mod}'\nimprimir(x)")
+    mapping = {str(mod): {"cpp": str(tmp_path / 'no.cpp')}}
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: mapping)
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["compilar", str(prog), "--tipo=cpp"])
+    assert "dependencia" in out.getvalue().lower()
+
+
+@pytest.mark.timeout(5)
+def test_ejecutar_dependencia_invalida(tmp_path, monkeypatch):
+    prog = tmp_path / "p.co"
+    prog.write_text("imprimir(1)")
+    mapping = {"x": {"python": str(tmp_path / 'no.py')}}
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: mapping)
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["ejecutar", str(prog)])
+    assert "dependencia" in out.getvalue().lower()
+
+
+@pytest.mark.timeout(5)
+def test_interactive_dependencia_invalida(monkeypatch):
+    mapping = {"x": {"python": "/no/dep.py"}}
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: mapping)
+    with patch("builtins.input", return_value="salir()"), \
+         patch("sys.stdout", new_callable=StringIO) as out:
+        main(["interactive"])
+    assert "dependencia" in out.getvalue().lower()


### PR DESCRIPTION
## Summary
- implement JS and C++ sandbox helpers
- add `validar_dependencias` to sandbox utilities
- integrate dependency checks in compile, execute and interactive commands
- provide tests for invalid dependencies across backends

## Testing
- `pytest backend/src/tests/test_validar_dependencias.py -q`
- `pytest -q` *(fails: 28 failed, 74 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685d7bcbcb808327b5ecf37d6ddef55d