### PR TITLE
Add init command

### DIFF
--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -18,6 +18,7 @@ from .commands.modules_cmd import ModulesCommand
 from .commands.dependencias_cmd import DependenciasCommand
 from .commands.empaquetar_cmd import EmpaquetarCommand
 from .commands.crear_cmd import CrearCommand
+from .commands.init_cmd import InitCommand
 
 # La configuración de logging solo debe activarse cuando la CLI se ejecuta
 # directamente para evitar modificar la configuración global al importar este
@@ -49,6 +50,7 @@ def main(argv=None):
         DocsCommand(),
         EmpaquetarCommand(),
         CrearCommand(),
+        InitCommand(),
         AgixCommand(),
         JupyterCommand(),
         FletCommand(),

--- a/backend/src/cli/commands/init_cmd.py
+++ b/backend/src/cli/commands/init_cmd.py
@@ -1,0 +1,31 @@
+import os
+
+from .base import BaseCommand
+from ..i18n import _
+from ..utils.messages import mostrar_info
+
+
+class InitCommand(BaseCommand):
+    """Inicializa un proyecto Cobra básico."""
+
+    name = "init"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(
+            self.name, help=_("Inicializa un proyecto Cobra")
+        )
+        parser.add_argument("ruta")
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        ruta = args.ruta
+        os.makedirs(ruta, exist_ok=True)
+        main = os.path.join(ruta, "main.co")
+        if not os.path.exists(main):
+            with open(main, "w", encoding="utf-8"):
+                pass
+        mostrar_info(
+            _("Proyecto Cobra inicializado en {path}").format(path=ruta)
+        )
+        return 0

--- a/backend/src/tests/test_cli_init.py
+++ b/backend/src/tests/test_cli_init.py
@@ -1,0 +1,12 @@
+from io import StringIO
+from unittest.mock import patch
+
+from src.cli.cli import main
+
+
+def test_cli_init_creates_project(tmp_path):
+    ruta = tmp_path / "proy"
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["init", str(ruta)])
+    assert (ruta / "main.co").exists()
+    assert "Proyecto Cobra inicializado" in out.getvalue()

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -146,3 +146,13 @@ Ejemplo:
 .. code-block:: bash
 
    cobra plugins
+
+Subcomando ``init``
+------------------
+Inicializa un proyecto básico.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra init mi_app


### PR DESCRIPTION
## Summary
- implement InitCommand to create minimal Cobra project
- register command in CLI
- document new init subcommand
- add tests for init command

## Testing
- `pytest backend/src/tests/test_cli_init.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'holobit_sdk' ... 28 failed, 75 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685e2a22aa8083278138037334ad61b0