### PR TITLE
Add import helper for transpilers

### DIFF
--- a/backend/src/cobra/transpilers/import_helper.py
+++ b/backend/src/cobra/transpilers/import_helper.py
@@ -1,0 +1,54 @@
+"""Utilidades para gestionar importaciones en los transpiladores."""
+
+from __future__ import annotations
+
+from typing import List, Tuple, Union
+
+from .module_map import get_mapped_path
+
+# Mapeo de importaciones estándar por lenguaje
+STANDARD_IMPORTS = {
+    "python": "from src.core.nativos import *\n",
+    "js": [
+        "import * as io from './nativos/io.js';",
+        "import * as net from './nativos/io.js';",
+        "import * as matematicas from './nativos/matematicas.js';",
+        "import { Pila, Cola } from './nativos/estructuras.js';",
+    ],
+}
+
+
+def get_standard_imports(language: str) -> Union[str, List[str]]:
+    """Devuelve las importaciones por defecto para *language*.
+
+    Parameters
+    ----------
+    language: str
+        Identificador del backend (``python``, ``js``...).
+    """
+    imports = STANDARD_IMPORTS.get(language, [])
+    if isinstance(imports, list):
+        return list(imports)
+    return imports
+
+
+def load_mapped_module(path: str, language: str) -> Tuple[str, str]:
+    """Carga el módulo indicado respetando el mapeo configurado.
+
+    Parameters
+    ----------
+    path: str
+        Ruta declarada en la instrucción ``import``.
+    language: str
+        Lenguaje de destino para el cual se busca el archivo.
+
+    Returns
+    -------
+    Tuple[str, str]
+        Una tupla ``(contenido, ruta)`` con el código del módulo y la ruta
+        real utilizada.
+    """
+    ruta = get_mapped_path(path, language)
+    with open(ruta, "r", encoding="utf-8") as f:
+        contenido = f.read()
+    return contenido, ruta

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/importar.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/importar.py
@@ -1,16 +1,10 @@
 from src.cobra.lexico.lexer import Lexer
 from src.cobra.parser.parser import Parser
-from ...module_map import get_mapped_path
+from ...import_helper import load_mapped_module
 
 def visit_import(self, nodo):
     """Carga y transpila el módulo indicado usando el mapeo."""
-    ruta = get_mapped_path(nodo.ruta, "js")
-
-    try:
-        with open(ruta, "r", encoding="utf-8") as f:
-            codigo = f.read()
-    except FileNotFoundError:
-        raise FileNotFoundError(f"Módulo no encontrado: {ruta}")
+    codigo, ruta = load_mapped_module(nodo.ruta, "js")
 
     if ruta.endswith(".co"):
         lexer = Lexer(codigo)

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/importar.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/importar.py
@@ -1,17 +1,11 @@
 from src.cobra.lexico.lexer import Lexer
 from src.cobra.parser.parser import Parser
-from ...module_map import get_mapped_path
+from ...import_helper import load_mapped_module
 
 
 def visit_import(self, nodo):
     """Transpila una declaración de importación consultando el mapeo."""
-    ruta = get_mapped_path(nodo.ruta, "python")
-
-    try:
-        with open(ruta, "r", encoding="utf-8") as f:
-            codigo = f.read()
-    except FileNotFoundError:
-        raise FileNotFoundError(f"Módulo no encontrado: {ruta}")
+    codigo, ruta = load_mapped_module(nodo.ruta, "python")
 
     if ruta.endswith(".co"):
         lexer = Lexer(codigo)

--- a/backend/src/cobra/transpilers/transpiler/to_js.py
+++ b/backend/src/cobra/transpilers/transpiler/to_js.py
@@ -23,6 +23,7 @@ from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
 from src.core.optimizations import optimize_constants, remove_dead_code
 from src.cobra.macro import expandir_macros
+from ..import_helper import get_standard_imports
 
 from .js_nodes.asignacion import visit_asignacion as _visit_asignacion
 from .js_nodes.condicional import visit_condicional as _visit_condicional
@@ -91,12 +92,7 @@ def visit_import_desde(self, nodo):
 class TranspiladorJavaScript(NodeVisitor):
     def __init__(self):
         # Incluir importaciones de modulos nativos
-        self.codigo = [
-            "import * as io from './nativos/io.js';",
-            "import * as net from './nativos/io.js';",
-            "import * as matematicas from './nativos/matematicas.js';",
-            "import { Pila, Cola } from './nativos/estructuras.js';",
-        ]
+        self.codigo = get_standard_imports("js")
         self.indentacion = 0
         self.usa_indentacion = None
 

--- a/backend/src/cobra/transpilers/transpiler/to_python.py
+++ b/backend/src/cobra/transpilers/transpiler/to_python.py
@@ -25,13 +25,15 @@ from src.core.ast_nodes import (
     NodoNoLocal,
     NodoLambda,
     NodoWith,
-    NodoImportDesde
+    NodoImportDesde,
+    NodoEsperar
 )
 from src.cobra.parser.parser import Parser
 from src.cobra.lexico.lexer import TipoToken, Lexer
 from src.core.visitor import NodeVisitor
 from src.core.optimizations import optimize_constants, remove_dead_code
 from src.cobra.macro import expandir_macros
+from ..import_helper import get_standard_imports
 
 from .python_nodes.asignacion import visit_asignacion as _visit_asignacion
 from .python_nodes.condicional import visit_condicional as _visit_condicional
@@ -101,7 +103,7 @@ def visit_import_desde(self, nodo):
 class TranspiladorPython(NodeVisitor):
     def __init__(self):
         # Incluir los modulos nativos al inicio del codigo generado
-        self.codigo = "from src.core.nativos import *\n"
+        self.codigo = get_standard_imports("python")
         self.usa_asyncio = False
         self.nivel_indentacion = 0
 

--- a/frontend/docs/arquitectura.rst
+++ b/frontend/docs/arquitectura.rst
@@ -30,6 +30,14 @@ Módulos nativos
 Bibliotecas básicas que amplían la funcionalidad de Cobra con
 operaciones de E/S, utilidades matemáticas y estructuras de datos.
 
+Helper de importaciones
+-----------------------
+El módulo ``src.cobra.transpilers.import_helper`` centraliza la gestión de
+las importaciones. Ofrece una función para obtener las importaciones estándar
+de cada lenguaje y otra que carga archivos según el ``module_map``
+configurado. Los transpiladores utilizan este helper tanto al inicializar su
+código como al resolver los ``import`` presentes en los programas.
+
 Sistema de memoria
 ------------------
 Gestiona de forma automática los recursos durante la ejecución para


### PR DESCRIPTION
## Summary
- introduce `import_helper` with standard imports and mapped module loader
- use helper in Python and JavaScript transpilers
- update import nodes to rely on `load_mapped_module`
- document helper in architecture guide

## Testing
- `flake8 backend/src` *(fails: line length, unused imports, etc.)*
- `mypy backend/src` *(fails: numerous missing attributes)*
- `pytest backend/src/tests/test_to_python2.py::test_transpilar_llamada_funcion -q`
- `pytest -q` *(fails: 83 failed, 250 passed, 1 skipped, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_685e3599f6dc8327bc5fea44d11d93dd