### PR TITLE
Add ctypes bridge and example

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -158,3 +158,14 @@ El estado se guarda en `qualia_state.json`. Puedes obtener las sugerencias
 ejecutando `sugerencias` en el modo interactivo o escribiendo `%sugerencias`
 en el kernel de Jupyter.
 
+## 12. Bibliotecas compartidas con ctypes
+
+Puedes cargar funciones escritas en C mediante ``cargar_funcion``. Solo
+compila una biblioteca compartida y proporciona la ruta y el nombre de la
+función:
+
+```cobra
+var triple = cargar_funcion('libtriple.so', 'triple')
+imprimir(triple(3))
+```
+

--- a/backend/src/core/ctypes_bridge.py
+++ b/backend/src/core/ctypes_bridge.py
@@ -1,0 +1,41 @@
+"""Puente sencillo para cargar bibliotecas C usando ``ctypes``."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+from typing import Any, Iterable
+
+
+_cache: dict[str, ctypes.CDLL] = {}
+
+
+def cargar_biblioteca(ruta: str) -> ctypes.CDLL:
+    """Carga la biblioteca compartida ubicada en ``ruta``.
+
+    La biblioteca se almacena en una caché interna para evitar cargarse
+    varias veces. Se devuelve el objeto :class:`ctypes.CDLL` asociado.
+    """
+    path = os.path.abspath(ruta)
+    if path not in _cache:
+        _cache[path] = ctypes.CDLL(path)
+    return _cache[path]
+
+
+def obtener_funcion(lib: ctypes.CDLL, nombre: str,
+                    restype: ctypes._CData | None = ctypes.c_int,
+                    argtypes: Iterable[ctypes._CData] | None = None) -> Any:
+    """Devuelve una función de ``lib`` configurando tipos opcionales."""
+    fn = getattr(lib, nombre)
+    fn.restype = restype
+    if argtypes is not None:
+        fn.argtypes = list(argtypes)
+    return fn
+
+
+def cargar_funcion(ruta: str, nombre: str,
+                   restype: ctypes._CData | None = ctypes.c_int,
+                   argtypes: Iterable[ctypes._CData] | None = None) -> Any:
+    """Carga ``ruta`` y devuelve la función indicada."""
+    lib = cargar_biblioteca(ruta)
+    return obtener_funcion(lib, nombre, restype, argtypes)

--- a/backend/src/core/nativos/__init__.py
+++ b/backend/src/core/nativos/__init__.py
@@ -3,6 +3,11 @@
 from .io import leer_archivo, escribir_archivo, obtener_url
 from .matematicas import sumar, promedio, potencia
 from .estructuras import Pila, Cola
+from ..ctypes_bridge import (
+    cargar_biblioteca,
+    obtener_funcion,
+    cargar_funcion,
+)
 
 __all__ = [
     "leer_archivo",
@@ -13,4 +18,7 @@ __all__ = [
     "potencia",
     "Pila",
     "Cola",
+    "cargar_biblioteca",
+    "obtener_funcion",
+    "cargar_funcion",
 ]

--- a/backend/src/tests/test_ctypes_bridge.py
+++ b/backend/src/tests/test_ctypes_bridge.py
@@ -1,0 +1,47 @@
+import subprocess
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.core.ast_nodes import (
+    NodoAsignacion,
+    NodoValor,
+    NodoLlamadaFuncion,
+    NodoImprimir,
+)
+
+
+def _compilar_lib(dir_: Path) -> Path:
+    src = dir_ / "lib.c"
+    src.write_text("int triple(int x){return x*3;}")
+    lib = dir_ / "libtriple.so"
+    subprocess.run([
+        "gcc",
+        "-shared",
+        "-fPIC",
+        str(src),
+        "-o",
+        str(lib),
+    ], check=True)
+    return lib
+
+
+@pytest.mark.timeout(5)
+def test_ctypes_bridge_executes_function(tmp_path):
+    lib = _compilar_lib(tmp_path)
+    ast = [
+        NodoAsignacion(
+            "triple",
+            NodoLlamadaFuncion(
+                "cargar_funcion",
+                [NodoValor(f"'{lib}'"), NodoValor("'triple'")],
+            ),
+        ),
+        NodoImprimir(NodoLlamadaFuncion("triple", [NodoValor(4)])),
+    ]
+    code = TranspiladorPython().transpilar(ast)
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        exec(code, {})
+    assert out.getvalue().strip() == "12"

--- a/frontend/docs/ejemplos_avanzados.rst
+++ b/frontend/docs/ejemplos_avanzados.rst
@@ -66,3 +66,10 @@ Manejo de errores
    catch e:
        imprimir("Error:" + e)
    fin
+
+Bibliotecas C con ctypes
+------------------------
+.. code-block:: cobra
+
+   var triple = cargar_funcion('libtriple.so', 'triple')
+   imprimir(triple(5))


### PR DESCRIPTION
## Summary
- add `ctypes_bridge` utilities to load C libraries
- expose them through the nativos package
- document how to use `cargar_funcion` in manual and advanced docs
- test calling a C function from Cobra via the Python transpiler

## Testing
- `flake8 backend/src/core/ctypes_bridge.py backend/src/core/nativos/__init__.py backend/src/tests/test_ctypes_bridge.py`
- `pytest backend/src/tests/test_ctypes_bridge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685e38ebd4e88327934c27e413495435