### PR TITLE
Add Cobra package command and docs

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -76,7 +76,13 @@ import 'modulo.co'
 imprimir(saludo)
 ```
 
-## 5. Macros
+## 5. Paquetes Cobra
+
+- Agrupa varios módulos en un archivo con manifest ``cobra.pkg``.
+- Crea un paquete con ``cobra paquete crear carpeta paquete.cobra``.
+- Instálalo posteriormente con ``cobra paquete instalar paquete.cobra``.
+
+## 6. Macros
 
 Permiten reutilizar fragmentos de código mediante la directiva `macro`.
 
@@ -84,7 +90,7 @@ Permiten reutilizar fragmentos de código mediante la directiva `macro`.
 macro saluda { imprimir(1) }
 saluda()
 ```
-## 6. Concurrencia
+## 7. Concurrencia
 
 - Ejecuta funciones en paralelo con la palabra clave `hilo`.
 
@@ -97,7 +103,7 @@ hilo tarea()
 imprimir('principal')
 ```
 
-## 7. Transpilación y ejecución
+## 8. Transpilación y ejecución
 
 - Compila a Python, JavaScript, ensamblador, Rust o C++ con `cobra compilar archivo.co --tipo python`.
 - Ejecuta directamente con `cobra ejecutar archivo.co`.
@@ -126,7 +132,7 @@ print(TranspiladorPython().transpilar(arbol))
 
 Herencia múltiple en clases.
 
-## 8. Modo seguro
+## 9. Modo seguro
 
 - Añade `--seguro` para evitar operaciones peligrosas como `leer_archivo` o `hilo`.
 
@@ -134,11 +140,11 @@ Herencia múltiple en clases.
 cobra ejecutar programa.co --seguro
 ```
 
-## 9. Próximos pasos
+## 10. Próximos pasos
 
 Revisa la documentación en `frontend/docs` para profundizar en la arquitectura, validadores y más ejemplos.
 
-## 10. Novedades
+## 11. Novedades
 
 Se añadieron nuevas construcciones al lenguaje:
 
@@ -151,14 +157,14 @@ Se añadieron nuevas construcciones al lenguaje:
 - Importaciones `desde` ... `como` para alias de módulos.
 - Nueva estructura `switch` con múltiples `case`.
 
-## 11. Uso de Qualia
+## 12. Uso de Qualia
 
 Qualia registra cada ejecución y genera sugerencias para mejorar tu código.
 El estado se guarda en `qualia_state.json`. Puedes obtener las sugerencias
 ejecutando `sugerencias` en el modo interactivo o escribiendo `%sugerencias`
 en el kernel de Jupyter.
 
-## 12. Bibliotecas compartidas con ctypes
+## 13. Bibliotecas compartidas con ctypes
 
 Puedes cargar funciones escritas en C mediante ``cargar_funcion``. Solo
 compila una biblioteca compartida y proporciona la ruta y el nombre de la

--- a/README.md
+++ b/README.md
@@ -315,6 +315,9 @@ cobra ejecutar programa.co --depurar --formatear
 cobra modulos listar
 cobra modulos instalar ruta/al/modulo.co
 cobra modulos remover modulo.co
+# Crear e instalar paquetes Cobra
+cobra paquete crear src demo.cobra
+cobra paquete instalar demo.cobra
 # Generar documentación HTML y API
 cobra docs
 # Crear un ejecutable independiente

--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -17,6 +17,7 @@ from .commands.plugins_cmd import PluginsCommand
 from .commands.modules_cmd import ModulesCommand
 from .commands.dependencias_cmd import DependenciasCommand
 from .commands.empaquetar_cmd import EmpaquetarCommand
+from .commands.package_cmd import PaqueteCommand
 from .commands.crear_cmd import CrearCommand
 from .commands.init_cmd import InitCommand
 
@@ -49,6 +50,7 @@ def main(argv=None):
         DependenciasCommand(),
         DocsCommand(),
         EmpaquetarCommand(),
+        PaqueteCommand(),
         CrearCommand(),
         InitCommand(),
         AgixCommand(),

--- a/backend/src/cli/commands/package_cmd.py
+++ b/backend/src/cli/commands/package_cmd.py
@@ -1,0 +1,75 @@
+import os
+import zipfile
+from .base import BaseCommand
+from ..i18n import _
+from ..utils.messages import mostrar_error, mostrar_info
+from . import modules_cmd
+
+
+class PaqueteCommand(BaseCommand):
+    """Crea e instala paquetes Cobra."""
+
+    name = "paquete"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help=_("Gestiona paquetes Cobra"))
+        sub = parser.add_subparsers(dest="accion")
+
+        crear = sub.add_parser("crear", help=_("Crea un paquete"))
+        crear.add_argument("fuente", help=_("Carpeta con archivos .co"))
+        crear.add_argument("paquete", help=_("Archivo de paquete"))
+        crear.add_argument("--nombre", default="paquete", help=_("Nombre"))
+        crear.add_argument("--version", default="0.1", help=_("Version"))
+
+        inst = sub.add_parser("instalar", help=_("Instala un paquete"))
+        inst.add_argument("paquete", help=_("Archivo de paquete"))
+
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        accion = args.accion
+        if accion == "crear":
+            return self._crear(args.fuente, args.paquete, args.nombre, args.version)
+        elif accion == "instalar":
+            return self._instalar(args.paquete)
+        else:
+            mostrar_error(_("Accion de paquete no reconocida"))
+            return 1
+
+    @staticmethod
+    def _crear(src, pkg, nombre, version):
+        if not os.path.isdir(src):
+            mostrar_error(_("Directorio invalido"))
+            return 1
+        mods = [f for f in os.listdir(src) if f.endswith(".co")]
+        if not mods:
+            mostrar_error(_("No se encontraron modulos"))
+            return 1
+        contenido = (
+            f"[paquete]\nnombre = \"{nombre}\"\nversion = \"{version}\"\n\n"
+            f"[modulos]\narchivos = [{', '.join(f'\"{m}\"' for m in mods)}]\n"
+        )
+        with zipfile.ZipFile(pkg, "w") as zf:
+            for m in mods:
+                zf.write(os.path.join(src, m), arcname=m)
+            zf.writestr("cobra.pkg", contenido)
+        mostrar_info(_("Paquete creado en {dest}").format(dest=pkg))
+        return 0
+
+    @staticmethod
+    def _instalar(pkg):
+        if not os.path.exists(pkg):
+            mostrar_error(_("Paquete no encontrado"))
+            return 1
+        os.makedirs(modules_cmd.MODULES_PATH, exist_ok=True)
+        with zipfile.ZipFile(pkg) as zf:
+            for name in zf.namelist():
+                if name.endswith(".co"):
+                    dest = os.path.join(modules_cmd.MODULES_PATH, os.path.basename(name))
+                    with zf.open(name) as src, open(dest, "wb") as out:
+                        out.write(src.read())
+        mostrar_info(
+            _("Paquete instalado en {dest}").format(dest=modules_cmd.MODULES_PATH)
+        )
+        return 0

--- a/backend/src/tests/test_cli_paquete.py
+++ b/backend/src/tests/test_cli_paquete.py
@@ -1,0 +1,30 @@
+from io import StringIO
+import zipfile
+import tomllib
+from unittest.mock import patch
+
+from src.cli.cli import main
+from src.cli.commands import modules_cmd, package_cmd
+
+
+def test_paquete_crear_instalar(tmp_path, monkeypatch):
+    src = tmp_path / "src"
+    src.mkdir()
+    modulo = src / "m.co"
+    modulo.write_text("var x = 1")
+    pkg = tmp_path / "demo.cobra"
+
+    with patch("sys.stdout", new_callable=StringIO):
+        main(["paquete", "crear", str(src), str(pkg), "--nombre=demo", "--version=0.1"])
+
+    assert pkg.exists()
+    with zipfile.ZipFile(pkg) as zf:
+        data = tomllib.loads(zf.read("cobra.pkg").decode("utf-8"))
+    assert data["paquete"]["nombre"] == "demo"
+    mods_dir = tmp_path / "mods"
+    monkeypatch.setattr(modules_cmd, "MODULES_PATH", str(mods_dir))
+
+    with patch("sys.stdout", new_callable=StringIO):
+        main(["paquete", "instalar", str(pkg)])
+
+    assert (mods_dir / "m.co").exists()

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -97,6 +97,17 @@ Ejemplo:
 
    cobra empaquetar --output dist
 
+Subcomando ``paquete``
+----------------------
+Permite crear e instalar paquetes Cobra.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra paquete crear src demo.cobra
+   cobra paquete instalar demo.cobra
+
 Subcomando ``crear``
 -------------------
 Genera archivos o proyectos básicos.

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -28,6 +28,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    validador
    modo_seguro
    empaquetar
+   paquetes
    primeros_pasos
    como_contribuir
    qualia

--- a/frontend/docs/paquetes.rst
+++ b/frontend/docs/paquetes.rst
@@ -1,0 +1,36 @@
+Paquetes Cobra
+==============
+
+Un paquete Cobra es un archivo comprimido que agrupa varios módulos ``.co`` y un
+manifest llamado ``cobra.pkg``. Este manifest utiliza sintaxis TOML para
+especificar los metadatos del paquete.
+
+Estructura de ``cobra.pkg``
+---------------------------
+
+.. code-block:: toml
+
+   [paquete]
+   nombre = "demo"
+   version = "0.1"
+
+   [modulos]
+   archivos = ["main.co", "util.co"]
+
+Creación e instalación
+----------------------
+
+Para crear un paquete desde una carpeta que contenga archivos ``.co`` ejecuta:
+
+.. code-block:: bash
+
+   cobra paquete crear src demo.cobra --nombre=demo --version=0.1
+
+El archivo resultante ``demo.cobra`` puede instalarse en el directorio de
+módulos predeterminado con:
+
+.. code-block:: bash
+
+   cobra paquete instalar demo.cobra
+
+Los módulos incluidos estarán disponibles para ser importados con ``import``.


### PR DESCRIPTION
## Summary
- document cobra packages and manifest
- add `PaqueteCommand` for creating and installing packages
- register new command in CLI
- update CLI docs and index
- update README and MANUAL_COBRA with package instructions
- test package creation and installation

## Testing
- `pip install -r requirements.txt`
- `pytest backend/src/tests/test_cli_paquete.py -q`
- `pytest -q` *(fails: 83 failed, 252 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685e3be1de4c83279864aa3261a4d6a9