### PR TITLE
Bump version to 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Historial de Cambios
 
+## v2.1 - 2025-07-15
+- Actualización del paquete a la versión 2.1.
+- Nuevos comandos `init` y `package`.
+- Incorporación del puente ctypes y del helper de importación de transpiladores.
+- Documentación y kernel actualizados.
+
 ## v2.0 - 2025-07-01
 - Actualización de la versión del paquete a 2.0.
 - Documentación y archivos de configuración actualizados a la versión 2.0.

--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -1,6 +1,6 @@
 # Manual del Lenguaje Cobra
 
-Versión 2.0
+Versión 2.1
 
 Este manual presenta en español los conceptos básicos para programar en Cobra. Se organiza en tareas que puedes seguir paso a paso.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![codecov](https://codecov.io/gh/Alphonsus411/pCobra/branch/main/graph/badge.svg)](https://codecov.io/gh/Alphonsus411/pCobra)
 
 
-Versión 2.0
+Versión 2.1
 
 Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
@@ -531,7 +531,7 @@ class HolaCommand(PluginCommand):
 ```
 ## Historial de Cambios
 
-- Versión 2.0: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
+- Versión 2.1: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
 
 # Licencia
 

--- a/backend/src/jupyter_kernel/__init__.py
+++ b/backend/src/jupyter_kernel/__init__.py
@@ -16,9 +16,9 @@ def install(user=True):
 
 class CobraKernel(Kernel):
     implementation = "Cobra"
-    implementation_version = "2.0"
+    implementation_version = "2.1"
     language = "cobra"
-    language_version = "2.0"
+    language_version = "2.1"
     language_info = {
         "name": "cobra",
         "mimetype": "text/plain",

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -7,10 +7,10 @@ Avances del lenguaje Cobra
 - **Gestión de memoria automatizada**: Cobra incluye un sistema de manejo de memoria optimizado que se ajusta automáticamente utilizando algoritmos genéticos.
 - **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX.
 - **Pruebas unitarias**: Se han creado pruebas para validar el correcto funcionamiento del lexer y el parser.
-- **Versión 2.0**: Actualización de la documentación y configuración del proyecto.
-- **Versión 2.0**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
+- **Versión 2.1**: Actualización de la documentación y configuración del proyecto.
+- **Versión 2.1**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
 
-Versión 2.0
+Versión 2.1
 -----------
 Se añade el archivo ``pcobra.toml`` para definir el mapeo de módulos en formato TOML. Su estructura es la siguiente:
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cobra-lenguaje',
-    version='2.0',
+    version='2.1',
     author='Adolfo González Hernández',
     author_email='adolfogonzal@gmail.com',
     description='Un lenguaje de programación en español para simulaciones y más.',


### PR DESCRIPTION
## Summary
- update package version to 2.1 in setup.py
- refresh docs for version 2.1
- bump kernel implementation and language versions
- add 2.1 entry to changelog

## Testing
- `pytest backend/src/tests -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685e3efb7fd883279f9238a1fdfc662e