### PR TITLE
Integrar CobraHub a la CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Cobra es un lenguaje de programación diseñado en español, enfocado en la crea
 - Ejemplo de Uso
 - Pruebas
 - Generar documentación
+- [CobraHub](frontend/docs/cobrahub.rst)
 - Hitos y Roadmap
 - Contribuciones
 - Licencia

--- a/backend/src/cli/cobrahub_client.py
+++ b/backend/src/cli/cobrahub_client.py
@@ -1,0 +1,44 @@
+import os
+import requests
+
+from .i18n import _
+from .utils.messages import mostrar_info, mostrar_error
+
+COBRAHUB_URL = os.environ.get("COBRAHUB_URL", "https://cobrahub.example.com/api")
+
+
+def publicar_modulo(ruta: str) -> bool:
+    """Publica un archivo .co en CobraHub."""
+    if not os.path.exists(ruta):
+        mostrar_error(_("No se encontró el módulo {path}").format(path=ruta))
+        return False
+    try:
+        with open(ruta, "rb") as f:
+            response = requests.post(
+                f"{COBRAHUB_URL}/modulos",
+                files={"file": f},
+                timeout=5,
+            )
+        response.raise_for_status()
+        mostrar_info(_("Módulo publicado correctamente"))
+        return True
+    except requests.RequestException as exc:
+        mostrar_error(_("Error publicando módulo: {err}").format(err=exc))
+        return False
+
+
+def descargar_modulo(nombre: str, destino: str) -> bool:
+    """Descarga un módulo de CobraHub y lo guarda en destino."""
+    try:
+        response = requests.get(
+            f"{COBRAHUB_URL}/modulos/{nombre}",
+            timeout=5,
+        )
+        response.raise_for_status()
+        with open(destino, "wb") as f:
+            f.write(response.content)
+        mostrar_info(_("Módulo descargado en {dest}").format(dest=destino))
+        return True
+    except requests.RequestException as exc:
+        mostrar_error(_("Error descargando módulo: {err}").format(err=exc))
+        return False

--- a/backend/src/cli/commands/modules_cmd.py
+++ b/backend/src/cli/commands/modules_cmd.py
@@ -3,6 +3,7 @@ import shutil
 from .base import BaseCommand
 from ..i18n import _
 from ..utils.messages import mostrar_error, mostrar_info
+from ..cobrahub_client import publicar_modulo, descargar_modulo
 
 MODULES_PATH = os.path.join(os.path.dirname(__file__), "..", "modules")
 os.makedirs(MODULES_PATH, exist_ok=True)
@@ -21,6 +22,10 @@ class ModulesCommand(BaseCommand):
         inst.add_argument("ruta")
         rem = mod_sub.add_parser("remover", help=_("Elimina un módulo"))
         rem.add_argument("nombre")
+        pub = mod_sub.add_parser("publicar", help=_("Publica un módulo en CobraHub"))
+        pub.add_argument("ruta")
+        bus = mod_sub.add_parser("buscar", help=_("Descarga un módulo desde CobraHub"))
+        bus.add_argument("nombre")
         parser.set_defaults(cmd=self)
         return parser
 
@@ -32,6 +37,11 @@ class ModulesCommand(BaseCommand):
             return self._instalar_modulo(args.ruta)
         elif accion == "remover":
             return self._remover_modulo(args.nombre)
+        elif accion == "publicar":
+            return 0 if publicar_modulo(args.ruta) else 1
+        elif accion == "buscar":
+            destino = os.path.join(MODULES_PATH, args.nombre)
+            return 0 if descargar_modulo(args.nombre, destino) else 1
         else:
             mostrar_error(_("Acción de módulos no reconocida"))
             return 1

--- a/backend/src/tests/test_cli_cobrahub.py
+++ b/backend/src/tests/test_cli_cobrahub.py
@@ -1,0 +1,39 @@
+from io import StringIO
+from unittest.mock import patch, MagicMock
+import pytest
+
+from src.cli.cli import main
+from src.cli.commands import modules_cmd
+
+
+@pytest.mark.timeout(5)
+def test_cli_modulos_publicar(tmp_path):
+    archivo = tmp_path / "m.co"
+    archivo.write_text("var x = 1")
+    with patch("src.cli.cobrahub_client.requests.post") as mock_post, \
+            patch("sys.stdout", new_callable=StringIO) as out:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_resp
+        main(["modulos", "publicar", str(archivo)])
+    assert "Módulo publicado correctamente" in out.getvalue().strip()
+    mock_post.assert_called_once()
+
+
+@pytest.mark.timeout(5)
+def test_cli_modulos_buscar(tmp_path, monkeypatch):
+    mods_dir = tmp_path / "mods"
+    mods_dir.mkdir()
+    monkeypatch.setattr(modules_cmd, "MODULES_PATH", str(mods_dir))
+    with patch("src.cli.cobrahub_client.requests.get") as mock_get, \
+            patch("sys.stdout", new_callable=StringIO) as out:
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.content = b"data"
+        mock_get.return_value = response
+        main(["modulos", "buscar", "remote.co"])
+    archivo = mods_dir / "remote.co"
+    assert archivo.exists()
+    assert archivo.read_bytes() == b"data"
+    assert f"Módulo descargado en {archivo}" in out.getvalue().strip()
+    mock_get.assert_called_once()

--- a/frontend/docs/cobrahub.rst
+++ b/frontend/docs/cobrahub.rst
@@ -1,0 +1,30 @@
+CobraHub
+========
+
+CobraHub es un repositorio centralizado donde se pueden compartir módulos Cobra.
+La CLI integra dos acciones para interactuar con este servicio: ``publicar`` y
+``buscar`` dentro del subcomando ``modulos``.
+
+Publicar un módulo
+------------------
+
+Para subir un archivo ``.co`` a CobraHub ejecuta:
+
+.. code-block:: bash
+
+   cobra modulos publicar ruta/al/modulo.co
+
+Si la operación es exitosa se mostrará un mensaje indicando que el módulo fue
+publicado correctamente.
+
+Buscar un módulo
+----------------
+
+Los módulos disponibles pueden descargarse con:
+
+.. code-block:: bash
+
+   cobra modulos buscar nombre.co
+
+El archivo se guardará en el directorio de módulos configurado. Puedes cambiar
+la URL del servicio estableciendo la variable de entorno ``COBRAHUB_URL``.

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -29,6 +29,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    modo_seguro
    empaquetar
    paquetes
+   cobrahub
    primeros_pasos
    como_contribuir
    qualia

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ PyYAML==6.0.1
 agix==0.8.3
 holobit-sdk
 flet
+requests
 smooth-criminal
 RestrictedPython==8.0
 flake8==7.3.0


### PR DESCRIPTION
## Summary
- add CobraHub client with publish and download helpers
- extend `modulos` command to handle `publicar` and `buscar`
- document CobraHub workflow
- link documentation from README
- include `requests` in requirements
- test CLI integration simulating HTTP responses

## Testing
- `pytest backend/src/tests/test_cli_cobrahub.py::test_cli_modulos_publicar -q`
- `pytest backend/src/tests/test_cli_cobrahub.py::test_cli_modulos_buscar -q`


------
https://chatgpt.com/codex/tasks/task_e_685e4da939788327b7eef73b4ac7c6e1