### PR TITLE
Add basic WebAssembly backend

### DIFF
--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -25,6 +25,7 @@ from src.cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
 from src.cobra.transpilers.transpiler.to_php import TranspiladorPHP
 from src.cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
 from src.cobra.transpilers.transpiler.to_latex import TranspiladorLatex
+from src.cobra.transpilers.transpiler.to_wasm import TranspiladorWasm
 
 TRANSPILERS = {
     "python": TranspiladorPython,
@@ -43,6 +44,7 @@ TRANSPILERS = {
     "php": TranspiladorPHP,
     "matlab": TranspiladorMatlab,
     "latex": TranspiladorLatex,
+    "wasm": TranspiladorWasm,
 }
 
 
@@ -50,7 +52,7 @@ class CompileCommand(BaseCommand):
     """Transpila un archivo Cobra a distintos lenguajes.
 
     Soporta Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Ruby,
-    PHP, Java y ahora también COBOL, Fortran, Pascal, Matlab y LaTeX.
+    PHP, Java y ahora también COBOL, Fortran, Pascal, Matlab, LaTeX y WebAssembly.
     """
 
     name = "compilar"
@@ -77,9 +79,33 @@ class CompileCommand(BaseCommand):
                 "php",
                 "matlab",
                 "latex",
+                "wasm",
             ],
             default="python",
             help=_("Tipo de código generado"),
+        )
+        parser.add_argument(
+            "--backend",
+            choices=[
+                "python",
+                "js",
+                "asm",
+                "rust",
+                "cpp",
+                "go",
+                "ruby",
+                "r",
+                "julia",
+                "java",
+                "cobol",
+                "fortran",
+                "pascal",
+                "php",
+                "matlab",
+                "latex",
+                "wasm",
+            ],
+            help=_("Alias de --tipo"),
         )
         parser.add_argument(
             "--tipos",
@@ -95,6 +121,8 @@ class CompileCommand(BaseCommand):
 
     def run(self, args):
         archivo = args.archivo
+        if getattr(args, "backend", None):
+            args.tipo = args.backend
         if not os.path.exists(archivo):
             mostrar_error(f"El archivo '{archivo}' no existe")
             return 1

--- a/backend/src/cobra/transpilers/transpiler/to_wasm.py
+++ b/backend/src/cobra/transpilers/transpiler/to_wasm.py
@@ -1,0 +1,65 @@
+"""Transpilador muy básico que genera código WebAssembly en formato WAT."""
+
+from src.core.ast_nodes import (
+    NodoAsignacion,
+    NodoFuncion,
+    NodoOperacionBinaria,
+    NodoValor,
+    NodoIdentificador,
+)
+from src.cobra.lexico.lexer import TipoToken
+from src.core.visitor import NodeVisitor
+from src.core.optimizations import optimize_constants, remove_dead_code
+from src.cobra.macro import expandir_macros
+
+
+class TranspiladorWasm(NodeVisitor):
+    """Transpila el AST de Cobra a WebAssembly (WAT) de forma sencilla."""
+
+    def __init__(self):
+        self.codigo = []
+        self.indent = 0
+
+    def agregar_linea(self, linea: str) -> None:
+        self.codigo.append("    " * self.indent + linea)
+
+    def obtener_valor(self, nodo):
+        if isinstance(nodo, NodoValor) or isinstance(nodo, int):
+            valor = nodo.valor if hasattr(nodo, "valor") else nodo
+            return f"(i32.const {valor})"
+        elif isinstance(nodo, NodoIdentificador):
+            return f"(local.get ${nodo.nombre})"
+        elif isinstance(nodo, NodoOperacionBinaria):
+            izq = self.obtener_valor(nodo.izquierda)
+            der = self.obtener_valor(nodo.derecha)
+            op_map = {
+                TipoToken.SUMA: "i32.add",
+                TipoToken.RESTA: "i32.sub",
+                TipoToken.MULT: "i32.mul",
+                TipoToken.DIV: "i32.div_s",
+            }
+            op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
+            return f"({op} {izq} {der})"
+        else:
+            return str(getattr(nodo, "valor", nodo))
+
+    def visit_asignacion(self, nodo: NodoAsignacion):
+        nombre = getattr(nodo, "identificador", nodo.variable)
+        valor = self.obtener_valor(nodo.expresion)
+        self.agregar_linea(f"(local.set ${nombre} {valor})")
+
+    def visit_funcion(self, nodo: NodoFuncion):
+        params = " ".join(f"(param ${p} i32)" for p in nodo.parametros)
+        self.agregar_linea(f"(func ${nodo.nombre} {params}")
+        self.indent += 1
+        for inst in nodo.cuerpo:
+            inst.aceptar(self)
+        self.indent -= 1
+        self.agregar_linea(")")
+
+    def transpilar(self, nodos):
+        nodos = expandir_macros(nodos)
+        nodos = remove_dead_code(optimize_constants(nodos))
+        for nodo in nodos:
+            nodo.aceptar(self)
+        return "\n".join(self.codigo)

--- a/backend/src/tests/test_to_wasm.py
+++ b/backend/src/tests/test_to_wasm.py
@@ -1,0 +1,32 @@
+from src.cobra.transpilers.transpiler.to_wasm import TranspiladorWasm
+from src.core.ast_nodes import (
+    NodoAsignacion,
+    NodoFuncion,
+    NodoOperacionBinaria,
+    NodoIdentificador,
+    NodoValor,
+)
+from src.cobra.lexico.lexer import Token, TipoToken
+
+
+def test_transpilador_asignacion_wasm():
+    ast = [NodoAsignacion("x", 10)]
+    t = TranspiladorWasm()
+    resultado = t.transpilar(ast)
+    assert resultado == "(local.set $x (i32.const 10))"
+
+
+def test_transpilador_funcion_wasm():
+    expr = NodoOperacionBinaria(
+        NodoIdentificador("a"),
+        Token(TipoToken.SUMA, "+"),
+        NodoIdentificador("b"),
+    )
+    ast = [NodoFuncion("sumar", ["a", "b"], [NodoAsignacion("x", expr)])]
+    t = TranspiladorWasm()
+    resultado = t.transpilar(ast)
+    esperado = (
+        "(func $sumar (param $a i32) (param $b i32)\n"
+        "    (local.set $x (i32.add (local.get $a) (local.get $b)))\n)"
+    )
+    assert resultado == esperado

--- a/frontend/docs/backends.rst
+++ b/frontend/docs/backends.rst
@@ -1,0 +1,15 @@
+Soporte de backends
+===================
+
+Cobra permite generar código para varios lenguajes a través del subcomando
+``compilar``. A partir de esta versión se incluye un backend experimental para
+WebAssembly.
+
+Para obtener el código en formato WAT basta ejecutar:
+
+.. code-block:: bash
+
+   cobra compilar programa.co --backend wasm
+
+El resultado puede compilarse posteriormente con herramientas como
+``wat2wasm`` para obtener un módulo ejecutable.

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -14,7 +14,7 @@ Opciones principales:
 - ``archivo``: ruta del script ``.co``.
 - ``--tipo``: lenguaje de salida (``python``, ``js``, ``asm``, ``rust``,
   ``cpp``, ``go``, ``ruby``, ``r``, ``julia``, ``java``, ``cobol``,
-  ``fortran``, ``pascal``, ``php``, ``matlab``, ``latex``).
+  ``fortran``, ``pascal``, ``php``, ``matlab``, ``latex``, ``wasm``).
 
 Ejemplo:
 

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -15,6 +15,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    caracteristicas
    arquitectura
    cli
+   backends
    sintaxis
    avances
    proximos_pasos


### PR DESCRIPTION
## Summary
- add a simple WebAssembly transpiler
- enable `--backend wasm` option in CompileCommand
- document wasm backend usage
- list wasm backend in CLI docs and index
- test WebAssembly transpiler

## Testing
- `pytest backend/src/tests/test_to_wasm.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685e4f56a93c8327a94ef9ba79e97fe7