### PR TITLE
Add Docker container CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ pipx install cobra-lenguaje
 
 ## Construir la imagen Docker
 
-Puedes crear la imagen utilizando el script `docker/scripts/build.sh`:
+Puedes crear la imagen utilizando el script `docker/scripts/build.sh` o el subcomando de la CLI:
 
 ````bash
-./docker/scripts/build.sh
+cobra contenedor --tag cobra
 ````
 
-Esto generará una imagen llamada `cobra` en tu sistema Docker.
+Esto ejecutará internamente ``docker build`` y generará una imagen llamada `cobra` en tu sistema Docker.
 
 # Estructura del Proyecto
 

--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -20,6 +20,7 @@ from .commands.empaquetar_cmd import EmpaquetarCommand
 from .commands.package_cmd import PaqueteCommand
 from .commands.crear_cmd import CrearCommand
 from .commands.init_cmd import InitCommand
+from .commands.container_cmd import ContainerCommand
 
 # La configuración de logging solo debe activarse cuando la CLI se ejecuta
 # directamente para evitar modificar la configuración global al importar este
@@ -56,6 +57,7 @@ def main(argv=None):
         AgixCommand(),
         JupyterCommand(),
         FletCommand(),
+        ContainerCommand(),
         PluginsCommand(),
         InteractiveCommand(),
     ]

--- a/backend/src/cli/commands/container_cmd.py
+++ b/backend/src/cli/commands/container_cmd.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+from .base import BaseCommand
+from ..i18n import _
+from ..utils.messages import mostrar_error, mostrar_info
+
+
+class ContainerCommand(BaseCommand):
+    """Construye la imagen Docker del proyecto."""
+
+    name = "contenedor"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help=_("Construye la imagen Docker"))
+        parser.add_argument("--tag", default="cobra", help=_("Nombre de la imagen"))
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        raiz = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+        try:
+            subprocess.run([
+                "docker",
+                "build",
+                "-t",
+                args.tag,
+                raiz,
+            ], check=True)
+            mostrar_info(_("Imagen Docker creada"))
+            return 0
+        except FileNotFoundError:
+            mostrar_error(_("Docker no está instalado. Ejecuta 'apt install docker' u otra configuración."))
+            return 1
+        except subprocess.CalledProcessError as e:
+            mostrar_error(_("Error construyendo la imagen Docker: {err}").format(err=e))
+            return 1

--- a/backend/src/tests/test_cli_container.py
+++ b/backend/src/tests/test_cli_container.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from io import StringIO
+from unittest.mock import patch, call
+
+from src.cli.cli import main
+
+
+def test_cli_contenedor_invoca_docker():
+    with patch("subprocess.run") as mock_run:
+        main(["contenedor"])
+        raiz = Path(__file__).resolve().parents[3]
+        mock_run.assert_called_once_with([
+            "docker",
+            "build",
+            "-t",
+            "cobra",
+            str(raiz),
+        ], check=True)
+
+
+def test_cli_contenedor_sin_docker():
+    with patch("subprocess.run", side_effect=FileNotFoundError), \
+            patch("sys.stdout", new_callable=StringIO) as out:
+        main(["contenedor"])
+    assert "Docker no está instalado" in out.getvalue()

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -158,6 +158,16 @@ Ejemplo:
 
    cobra plugins
 
+Subcomando ``contenedor``
+------------------------
+Construye la imagen Docker del proyecto.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra contenedor --tag cobra
+
 Subcomando ``init``
 ------------------
 Inicializa un proyecto básico.

--- a/frontend/docs/contenedores.rst
+++ b/frontend/docs/contenedores.rst
@@ -1,0 +1,11 @@
+Construcción de contenedores
+============================
+
+El proyecto incluye un ``Dockerfile`` para crear una imagen que empaqueta todas las dependencias de Cobra.
+Para generar la imagen ejecuta:
+
+.. code-block:: bash
+
+   cobra contenedor --tag cobra
+
+Esto ejecuta internamente ``docker build`` y produce una imagen lista para usar.

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -29,6 +29,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    validador
    modo_seguro
    empaquetar
+   contenedores
    paquetes
    cobrahub
    primeros_pasos


### PR DESCRIPTION
## Summary
- add `ContainerCommand` to build Docker images via `docker build`
- register new command in CLI
- document it in the CLI docs and new `contenedores.rst`
- briefly mention container option in README
- add unit tests for the container command

## Testing
- `pytest backend/src/tests/test_cli_container.py backend/src/tests/test_cli_empaquetar.py backend/src/tests/test_cli_docs.py backend/src/tests/test_cli_jupyter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685e5101e9988327bbeef7b3e96130dc