### PR TITLE
Agregar puente pybind11 y documentar uso

### DIFF
--- a/backend/src/core/nativos/__init__.py
+++ b/backend/src/core/nativos/__init__.py
@@ -8,6 +8,11 @@ from ..ctypes_bridge import (
     obtener_funcion,
     cargar_funcion,
 )
+from ..pybind_bridge import (
+    compilar_extension,
+    cargar_extension,
+    compilar_y_cargar,
+)
 
 __all__ = [
     "leer_archivo",
@@ -21,4 +26,7 @@ __all__ = [
     "cargar_biblioteca",
     "obtener_funcion",
     "cargar_funcion",
+    "compilar_extension",
+    "cargar_extension",
+    "compilar_y_cargar",
 ]

--- a/backend/src/core/pybind_bridge.py
+++ b/backend/src/core/pybind_bridge.py
@@ -1,0 +1,60 @@
+"""Utilidades para compilar y cargar extensiones C++ con ``pybind11``."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import os
+import tempfile
+from types import ModuleType
+from typing import Dict, Iterable, Optional
+
+from pybind11.setup_helpers import Pybind11Extension, build_ext
+from setuptools import Distribution
+
+
+_cache: Dict[str, ModuleType] = {}
+
+
+def compilar_extension(nombre: str, codigo: str, directorio: str | None = None,
+                       extra_cflags: Optional[Iterable[str]] = None) -> str:
+    """Compila ``codigo`` como una extensi\u00f3n Python usando ``pybind11``.
+
+    Se devuelve la ruta absoluta del archivo generado (.so, .pyd, etc.).
+    """
+    if directorio is None:
+        directorio = tempfile.mkdtemp()
+    cpp = os.path.join(directorio, f"{nombre}.cpp")
+    with open(cpp, "w", encoding="utf-8") as fh:
+        fh.write(codigo)
+
+    ext = Pybind11Extension(nombre, [cpp],
+                             extra_compile_args=list(extra_cflags or []))
+    dist = Distribution({"name": nombre, "ext_modules": [ext]})
+    cmd = build_ext(dist)
+    cmd.build_lib = directorio
+    cmd.build_temp = os.path.join(directorio, "temp")
+    cmd.finalize_options()
+    cmd.run()
+
+    return os.path.join(directorio, cmd.get_ext_filename(nombre))
+
+
+def cargar_extension(ruta: str) -> ModuleType:
+    """Carga la extensi\u00f3n ubicada en ``ruta`` y la almacena en cach\u00e9."""
+    path = os.path.abspath(ruta)
+    if path not in _cache:
+        nombre = os.path.splitext(os.path.basename(path))[0]
+        loader = importlib.machinery.ExtensionFileLoader(nombre, path)
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
+        _cache[path] = module
+    return _cache[path]
+
+
+def compilar_y_cargar(nombre: str, codigo: str, directorio: str | None = None,
+                      extra_cflags: Optional[Iterable[str]] = None) -> ModuleType:
+    """Compila ``codigo`` y devuelve el m\u00f3dulo resultante."""
+    path = compilar_extension(nombre, codigo, directorio, extra_cflags)
+    return cargar_extension(path)

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -20,3 +20,30 @@ Se añade el archivo ``pcobra.toml`` para definir el mapeo de módulos en format
    python = "modulo.py"
    js = "modulo.js"
 
+Compilación de extensiones C++ con PyBind11
+------------------------------------------
+El nuevo módulo ``pybind_bridge`` permite compilar código C++ usando
+``pybind11`` y cargarlo como extensión de Python. El flujo habitual
+consiste en llamar a ``compilar_y_cargar`` con el nombre del módulo y
+el código fuente:
+
+.. code-block:: python
+
+   from cobra.core.nativos import compilar_y_cargar
+
+   cpp = """
+   #include <pybind11/pybind11.h>
+
+   int duplicar(int x) { return x * 2; }
+
+   PYBIND11_MODULE(mi_mod, m) {
+       m.def("duplicar", &duplicar);
+   }
+   """
+
+   mod = compilar_y_cargar("mi_mod", cpp)
+   print(mod.duplicar(5))
+
+Las funciones ``compilar_extension`` y ``cargar_extension`` están
+disponibles si se requiere mayor control sobre el proceso.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ smooth-criminal
 RestrictedPython==8.0
 flake8==7.3.0
 mypy==1.16.1
+pybind11==2.13.6


### PR DESCRIPTION
## Resumen
- compilar y cargar extensiones C++ con pybind11
- exponer utilidades en `nativos`
- registrar la dependencia en `requirements.txt`
- documentar el flujo de compilación en la guía de avances

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(falla: 80 failed, 261 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685e592411b08327b157e78c3e161616