### PR TITLE
Add Rust bridge and document cbindgen

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -9,6 +9,11 @@ Este manual presenta en español los conceptos básicos para programar en Cobra.
 1. Clona el repositorio y entra en el directorio `pCobra`.
 2. Crea y activa un entorno virtual.
 3. Instala las dependencias con `pip install -r requirements.txt`.
+   Aseg\u00farate tambi\u00e9n de tener disponible la herramienta `cbindgen`:
+
+   ```bash
+   cargo install cbindgen
+   ```
 4. Instala la herramienta de forma editable con `pip install -e .`.
 
 ### Instalación con pipx

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ pip install -r requirements.txt
    - `pytest` y complementos para las pruebas automatizadas.
    - `ipykernel` para el kernel de Jupyter.
    - `PyYAML` utilizado al leer `cobra.mod`.
+   - `cbindgen` para generar encabezados de crates Rust
+     (instalable con `cargo install cbindgen`).
 
 5. Instala el paquete de forma editable para usar la CLI:
 

--- a/backend/src/core/nativos/__init__.py
+++ b/backend/src/core/nativos/__init__.py
@@ -13,6 +13,11 @@ from ..pybind_bridge import (
     cargar_extension,
     compilar_y_cargar,
 )
+from ..rust_bridge import (
+    compilar_crate,
+    cargar_crate,
+    compilar_y_cargar_crate,
+)
 
 __all__ = [
     "leer_archivo",
@@ -29,4 +34,7 @@ __all__ = [
     "compilar_extension",
     "cargar_extension",
     "compilar_y_cargar",
+    "compilar_crate",
+    "cargar_crate",
+    "compilar_y_cargar_crate",
 ]

--- a/backend/src/core/rust_bridge.py
+++ b/backend/src/core/rust_bridge.py
@@ -1,0 +1,60 @@
+"""Utilidades para compilar y cargar bibliotecas Rust."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Iterable, Any
+
+from .ctypes_bridge import cargar_biblioteca, obtener_funcion
+
+
+def compilar_crate(ruta: str, release: bool = True) -> str:
+    """Compila el crate Rust ubicado en ``ruta`` y devuelve la ruta de la
+    biblioteca generada.
+
+    Se ejecuta ``cbindgen`` para generar los encabezados C y ``cargo`` para
+    construir la biblioteca como ``cdylib``. Si ``release`` es ``False`` se
+    compilar\u00e1 en modo debug.
+    """
+    path = Path(ruta).resolve()
+
+    subprocess.run([
+        "cbindgen",
+        str(path),
+        "-o",
+        str(path / "bindings.h"),
+    ], check=True)
+
+    cmd = [
+        "cargo",
+        "build",
+        "--manifest-path",
+        str(path / "Cargo.toml"),
+    ]
+    if release:
+        cmd.append("--release")
+    subprocess.run(cmd, check=True)
+
+    target = path / "target" / ("release" if release else "debug")
+    base = f"lib{path.name}"
+    for ext in (".so", ".dylib", ".dll"):
+        lib = target / f"{base}{ext}"
+        if lib.exists():
+            return str(lib)
+    raise FileNotFoundError("Biblioteca generada no encontrada")
+
+
+def cargar_crate(ruta: str, release: bool = True) -> Any:
+    """Compila y carga el crate localizado en ``ruta``."""
+    lib_path = compilar_crate(ruta, release)
+    return cargar_biblioteca(lib_path)
+
+
+def compilar_y_cargar_crate(ruta: str, nombre: str, *,
+                            release: bool = True,
+                            restype: Any | None = None,
+                            argtypes: Iterable[Any] | None = None) -> Any:
+    """Compila ``ruta`` y devuelve la funci\u00f3n ``nombre`` lista para usar."""
+    lib = cargar_crate(ruta, release)
+    return obtener_funcion(lib, nombre, restype, argtypes)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /app
 
 COPY . /app
 
-RUN pip install -r requirements.txt
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends cargo && \
+    cargo install cbindgen && \
+    pip install -r requirements.txt
 
 CMD ["pytest"]

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -47,3 +47,18 @@ el código fuente:
 Las funciones ``compilar_extension`` y ``cargar_extension`` están
 disponibles si se requiere mayor control sobre el proceso.
 
+Compilación de bibliotecas Rust
+--------------------------------
+El módulo ``rust_bridge`` permite compilar crates Rust utilizando
+``cbindgen`` y ``cargo`` para generar bibliotecas compatibles con
+``ctypes``. Basta con indicar la ruta del crate y el nombre de la
+función a exponer:
+
+.. code-block:: python
+
+   from cobra.core.nativos import compilar_y_cargar_crate
+
+   # Suponiendo un crate en ``./mi_crate`` con la función `triple`
+   triple = compilar_y_cargar_crate("mi_crate", "triple")
+   print(triple(3))
+


### PR DESCRIPTION
## Summary
- add `rust_bridge.py` with helpers to build and load Rust crates using cbindgen and cargo
- expose new helpers via `src.core.nativos`
- document cbindgen dependency in README and manual
- include Rust compilation example in the docs
- install cbindgen in Dockerfile

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `flake8 backend/src/core/rust_bridge.py backend/src/core/nativos/__init__.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5a9f43588327be4845abd18c52f9