### PR TITLE
Add docker sandbox execution

### DIFF
--- a/backend/src/tests/test_cli_sandbox_docker.py
+++ b/backend/src/tests/test_cli_sandbox_docker.py
@@ -1,0 +1,28 @@
+from io import StringIO
+from unittest.mock import patch
+import subprocess
+
+from src.cli.cli import main
+from src.cobra.transpilers import module_map
+
+
+def test_cli_sandbox_docker_invoca_docker(monkeypatch):
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: {})
+    with patch("builtins.input", side_effect=["print(2+2)", "salir()"]), \
+         patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="4\n", stderr="")
+        main(["interactive", "--sandbox-docker", "python"])
+        mock_run.assert_called_once_with(
+            ["docker", "run", "--rm", "-i", "cobra-python-sandbox"],
+            input="print(2+2)", text=True, capture_output=True, check=True,
+        )
+
+
+def test_cli_sandbox_docker_sin_docker(monkeypatch):
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: {})
+    with patch("builtins.input", side_effect=["print(1)", "salir()"]), \
+         patch("subprocess.run", side_effect=FileNotFoundError), \
+         patch("sys.stdout", new_callable=StringIO) as out:
+        main(["interactive", "--sandbox-docker", "python"])
+    assert "Docker no está instalado" in out.getvalue()
+

--- a/docker/backends/cpp.Dockerfile
+++ b/docker/backends/cpp.Dockerfile
@@ -1,0 +1,5 @@
+FROM gcc:12-slim
+WORKDIR /work
+COPY compile_cpp.sh /usr/local/bin/compile_cpp.sh
+RUN chmod +x /usr/local/bin/compile_cpp.sh
+CMD ["/usr/local/bin/compile_cpp.sh"]

--- a/docker/backends/js.Dockerfile
+++ b/docker/backends/js.Dockerfile
@@ -1,0 +1,2 @@
+FROM node:20-slim
+CMD ["node", "-"]

--- a/docker/backends/python.Dockerfile
+++ b/docker/backends/python.Dockerfile
@@ -1,0 +1,2 @@
+FROM python:3.11-slim
+CMD ["python", "-u", "-"]

--- a/docker/backends/rust.Dockerfile
+++ b/docker/backends/rust.Dockerfile
@@ -1,0 +1,5 @@
+FROM rust:1.72-slim
+WORKDIR /work
+COPY compile_rust.sh /usr/local/bin/compile_rust.sh
+RUN chmod +x /usr/local/bin/compile_rust.sh
+CMD ["/usr/local/bin/compile_rust.sh"]

--- a/docker/scripts/compile_cpp.sh
+++ b/docker/scripts/compile_cpp.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cat > main.cpp
+g++ -std=c++17 main.cpp -o main && ./main

--- a/docker/scripts/compile_rust.sh
+++ b/docker/scripts/compile_rust.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cat > main.rs
+rustc main.rs -O -o main && ./main


### PR DESCRIPTION
## Summary
- run sandbox code inside Docker containers
- allow interactive CLI to run with `--sandbox-docker`
- add Dockerfiles for Python, JS, C++, Rust backends
- provide build scripts for C++ and Rust containers
- test CLI docker sandbox behaviour

## Testing
- `pytest backend/src/tests/test_cli_sandbox_docker.py -q`
- `pytest backend/src/tests/test_cli_container.py -q`
- `pytest backend/src/tests/test_sandbox.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'holobit_sdk')*

------
https://chatgpt.com/codex/tasks/task_e_685e5bff4a408327856c0bb6e41b5639