### PR TITLE
Add localized traceback formatting and improved CLI logging

### DIFF
--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -3,7 +3,8 @@ import logging
 import os
 import sys
 
-from .i18n import _, setup_gettext
+from .i18n import _, setup_gettext, format_traceback
+from .utils import messages
 
 from .commands.compile_cmd import CompileCommand
 from .commands.docs_cmd import DocsCommand
@@ -79,7 +80,13 @@ def main(argv=None):
     args = parser.parse_args(argv)
     setup_gettext(args.lang)
     command = getattr(args, "cmd", command_map["interactive"])
-    resultado = command.run(args)
+    try:
+        resultado = command.run(args)
+    except Exception as exc:  # pragma: no cover - trazas manejadas
+        logging.exception("Unhandled exception")
+        messages.mostrar_error("Ocurri\u00f3 un error inesperado")
+        print(format_traceback(exc, args.lang))
+        return 1
     return 0 if resultado is None else resultado
 
 

--- a/backend/src/cli/i18n.py
+++ b/backend/src/cli/i18n.py
@@ -1,5 +1,20 @@
 import gettext
 import os
+import traceback
+
+# Traducciones mínimas para mensajes del traceback.
+_TRACEBACK_TRANSLATIONS = {
+    "es": {
+        "header": "Rastreo (llamadas más recientes al final):",
+        "file": "Archivo",
+        "line": "línea",
+    },
+    "en": {
+        "header": "Traceback (most recent call last):",
+        "file": "File",
+        "line": "line",
+    },
+}
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 LOCALE_DIR = os.path.join(ROOT_DIR, 'frontend', 'docs', 'locale')
@@ -16,3 +31,23 @@ def setup_gettext(lang: str | None = None):
     global _
     _ = translation.gettext
     return _
+
+
+def format_traceback(exc: BaseException, lang: str | None = None) -> str:
+    """Devuelve el traceback formateado en el idioma indicado."""
+    selected = lang or os.environ.get("COBRA_LANG", "es")
+    tr = _TRACEBACK_TRANSLATIONS.get(selected, _TRACEBACK_TRANSLATIONS["es"])
+
+    lines = traceback.format_exception(type(exc), exc, exc.__traceback__)
+    out: list[str] = []
+    for line in lines:
+        if line.startswith("Traceback (most recent call last):"):
+            out.append(tr["header"] + "\n")
+            continue
+        if line.strip().startswith("File "):
+            line = line.replace("File", tr["file"]).replace("line", tr["line"])
+        out.append(line)
+    return "".join(out)
+
+
+__all__ = ["_", "setup_gettext", "format_traceback"]

--- a/backend/src/cli/utils/messages.py
+++ b/backend/src/cli/utils/messages.py
@@ -1,15 +1,42 @@
+import logging
+
 from ..i18n import _
 
 RED = "\033[91m"
 GREEN = "\033[92m"
+YELLOW = "\033[93m"
 RESET = "\033[0m"
 
 
-def mostrar_error(msg):
+def _mostrar(msg: str, nivel: str = "info") -> None:
+    """Imprime el mensaje con color y registra el log correspondiente."""
+    texto = _(msg)
+    color = GREEN if nivel == "info" else YELLOW if nivel == "warning" else RED
+    prefijos = {
+        "warning": _("Advertencia"),
+        "error": _("Error"),
+    }
+    prefijo = f"{prefijos[nivel]}: " if nivel in prefijos else ""
+    print(f"{color}{prefijo}{texto}{RESET}")
+    getattr(logging, nivel)(texto)
+
+
+def mostrar_info(msg: str) -> None:
+    """Muestra un mensaje informativo en verde."""
+    _mostrar(msg, "info")
+
+
+def mostrar_advertencia(msg: str) -> None:
+    """Muestra un mensaje de advertencia en amarillo."""
+    _mostrar(msg, "warning")
+
+
+def mostrar_error(msg: str) -> None:
     """Muestra un mensaje de error en rojo."""
-    print(f"{RED}{_('Error')}: {_(msg)}{RESET}")
+    _mostrar(msg, "error")
 
 
-def mostrar_info(msg):
-    """Muestra un mensaje informativo en verde por stdout."""
-    print(f"{GREEN}{_(msg)}{RESET}")
+# Aliases para mantener compatibilidad con versiones anteriores.
+info = mostrar_info
+warning = mostrar_advertencia
+error = mostrar_error


### PR DESCRIPTION
## Summary
- implement minimal translation system and new `format_traceback`
- update CLI messages utilities with log levels
- show translated tracebacks and better error handling in `cli.py`

## Testing
- `pytest backend/src/tests/test_cli_error_messages.py::test_error_msg_compile_missing backend/src/tests/test_cli_exit_codes.py::test_exit_code_compile_missing -q`

------
https://chatgpt.com/codex/tasks/task_e_685e5dfbfa84832780f51b4f42c9d967