### PR TITLE
Mejorar manejo de errores léxicos

### DIFF
--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -13,6 +13,18 @@ class LexerError(Exception):
         self.columna = columna
 
 
+class InvalidTokenError(LexerError):
+    """Excepción para símbolos no reconocidos."""
+
+    pass
+
+
+class UnclosedStringError(LexerError):
+    """Excepción para cadenas sin cerrar."""
+
+    pass
+
+
 class TipoToken:
     DIVIDIR = 'DIVIDIR'
     MULTIPLICAR = 'MULTIPLICAR'
@@ -238,7 +250,13 @@ class Lexer:
                 logging.error(
                     f"Error: Token no reconocido en posición {self.posicion}: '{error_token}'"
                 )
-                raise LexerError(f"Token no reconocido: '{error_token}'", linea, columna)
+                if error_token in {"'", '"'}:
+                    mensaje = f"Cadena sin cerrar en linea {linea}, columna {columna}"
+                    raise UnclosedStringError(mensaje, linea, columna)
+                mensaje = (
+                    f"Token no reconocido: '{error_token}' en linea {linea}, columna {columna}"
+                )
+                raise InvalidTokenError(mensaje, linea, columna)
 
             if self.posicion == prev_pos:
                 same_pos_count += 1

--- a/backend/src/tests/test_lexer_errors.py
+++ b/backend/src/tests/test_lexer_errors.py
@@ -1,0 +1,23 @@
+import pytest
+from src.cobra.lexico.lexer import (
+    Lexer,
+    LexerError,
+    InvalidTokenError,
+    UnclosedStringError,
+)
+
+
+def test_mensaje_cadena_no_cerrada():
+    codigo = "'hola"
+    lexer = Lexer(codigo)
+    with pytest.raises(UnclosedStringError, match="Cadena sin cerrar en linea 1, columna 1"):
+        lexer.tokenizar()
+
+
+def test_mensaje_token_desconocido():
+    codigo = "var x = €"
+    lexer = Lexer(codigo)
+    with pytest.raises(InvalidTokenError) as exc:
+        lexer.tokenizar()
+    assert "Token no reconocido: '€' en linea 1, columna 9" in str(exc.value)
+


### PR DESCRIPTION
## Summary
- agrega excepciones `InvalidTokenError` y `UnclosedStringError`
- incluye la línea y columna en los mensajes de error del lexer
- añade pruebas para verificar las cadenas sin cerrar y símbolos no reconocidos

## Testing
- `pytest backend/src/tests/test_lexer.py backend/src/tests/test_lexer2.py backend/src/tests/test_lexer_errors_extra.py backend/src/tests/test_lexer_errors.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685e75801c0883279756bd533d24ff36