### PR TITLE
Add function inliner and enhance dead code optimizer

### DIFF
--- a/backend/src/core/interpreter.py
+++ b/backend/src/core/interpreter.py
@@ -3,7 +3,7 @@
 import os
 
 from src.cobra.lexico.lexer import Token, TipoToken, Lexer
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
@@ -145,7 +145,7 @@ class InterpretadorCobra:
         return False
 
     def ejecutar_ast(self, ast):
-        ast = remove_dead_code(optimize_constants(ast))
+        ast = remove_dead_code(inline_functions(optimize_constants(ast)))
         register_execution(str(ast))
         for nodo in ast:
             self._validar(nodo)

--- a/backend/src/core/optimizations/__init__.py
+++ b/backend/src/core/optimizations/__init__.py
@@ -2,5 +2,6 @@
 
 from .constant_folder import optimize_constants
 from .dead_code import remove_dead_code
+from .inliner import inline_functions
 
-__all__ = ["optimize_constants", "remove_dead_code"]
+__all__ = ["optimize_constants", "remove_dead_code", "inline_functions"]

--- a/backend/src/core/optimizations/dead_code.py
+++ b/backend/src/core/optimizations/dead_code.py
@@ -11,6 +11,8 @@ from ..ast_nodes import (
     NodoMetodo,
     NodoRetorno,
     NodoThrow,
+    NodoRomper,
+    NodoContinuar,
     NodoValor,
 )
 from ..visitor import NodeVisitor
@@ -49,11 +51,21 @@ class _DeadCodeRemover(NodeVisitor):
         return nodo
 
     # Helpers --------------------------------------------------------------
+    def _es_salida(self, nodo: Any) -> bool:
+        if isinstance(nodo, (NodoRetorno, NodoThrow, NodoRomper, NodoContinuar)):
+            return True
+        if isinstance(nodo, NodoCondicional):
+            if nodo.bloque_si and nodo.bloque_sino:
+                return self._es_salida(nodo.bloque_si[-1]) and self._es_salida(
+                    nodo.bloque_sino[-1]
+                )
+        return False
+
     def _limpiar_bloque(self, nodos: List[Any]):
         limpios = []
         for n in nodos:
             limpios.append(n)
-            if isinstance(n, (NodoRetorno, NodoThrow)):
+            if self._es_salida(n):
                 break
         return limpios
 

--- a/backend/src/core/optimizations/inliner.py
+++ b/backend/src/core/optimizations/inliner.py
@@ -1,0 +1,64 @@
+"""Optimizacion para integrar funciones pequeñas en su punto de uso."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from ..ast_nodes import NodoFuncion, NodoRetorno, NodoLlamadaFuncion
+from ..visitor import NodeVisitor
+
+
+class _FunctionInliner(NodeVisitor):
+    """Recolecta funciones simples y reemplaza sus llamadas."""
+
+    def __init__(self):
+        self.funciones: dict[str, Any] = {}
+
+    def visit_funcion(self, nodo: NodoFuncion):
+        # Solo se consideran funciones sin parámetros y con un único return
+        if (
+            len(nodo.parametros) == 0
+            and len(nodo.cuerpo) == 1
+            and isinstance(nodo.cuerpo[0], NodoRetorno)
+        ):
+            self.funciones[nodo.nombre] = self.visit(nodo.cuerpo[0].expresion)
+            return None  # se elimina la definición
+        nodo.cuerpo = [self.visit(n) for n in nodo.cuerpo]
+        return nodo
+
+    def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
+        if nodo.nombre in self.funciones and not nodo.argumentos:
+            return self.funciones[nodo.nombre]
+        return nodo
+
+    def generic_visit(self, nodo: Any):
+        for attr, value in list(getattr(nodo, "__dict__", {}).items()):
+            if isinstance(value, list):
+                nuevos = []
+                for v in value:
+                    res = self.visit(v)
+                    if res is None:
+                        continue
+                    elif isinstance(res, list):
+                        nuevos.extend(res)
+                    else:
+                        nuevos.append(res)
+                setattr(nodo, attr, nuevos)
+            elif hasattr(value, "aceptar"):
+                setattr(nodo, attr, self.visit(value))
+        return nodo
+
+
+def inline_functions(ast: List[Any]):
+    """Aplica inlining a funciones simples en la lista de nodos."""
+    inliner = _FunctionInliner()
+    resultado = []
+    for nodo in ast:
+        res = inliner.visit(nodo)
+        if res is None:
+            continue
+        if isinstance(res, list):
+            resultado.extend(res)
+        else:
+            resultado.append(res)
+    return resultado


### PR DESCRIPTION
## Summary
- add a simple function inliner optimization
- improve dead code removal to detect more useless blocks
- expose new optimization helpers
- apply inlining in interpreter
- test new optimizations

## Testing
- `pytest backend/src/tests/test_optimizations.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7b01878c83279583c36ac80e5913