### PR TITLE
Add filesystem and reflection validators

### DIFF
--- a/backend/src/core/semantic_validators/__init__.py
+++ b/backend/src/core/semantic_validators/__init__.py
@@ -5,6 +5,8 @@ from .primitiva_peligrosa import (
     ValidadorPrimitivaPeligrosa,
 )
 from .import_seguro import ValidadorImportSeguro
+from .fs_access import ValidadorSistemaArchivos
+from .reflexion_segura import ValidadorProhibirReflexion
 
 # Instancia por defecto reutilizable de la cadena de validación
 _CADENA_DEFECTO = None
@@ -23,6 +25,8 @@ def construir_cadena(extra_validators=None):
 
     primero = ValidadorPrimitivaPeligrosa()
     actual = primero.set_siguiente(ValidadorImportSeguro())
+    actual = actual.set_siguiente(ValidadorSistemaArchivos())
+    actual = actual.set_siguiente(ValidadorProhibirReflexion())
 
     if extra_validators:
         for val in extra_validators:
@@ -37,5 +41,7 @@ __all__ = [
     "PrimitivaPeligrosaError",
     "ValidadorPrimitivaPeligrosa",
     "ValidadorImportSeguro",
+    "ValidadorSistemaArchivos",
+    "ValidadorProhibirReflexion",
     "construir_cadena",
 ]

--- a/backend/src/core/semantic_validators/fs_access.py
+++ b/backend/src/core/semantic_validators/fs_access.py
@@ -1,0 +1,33 @@
+from .base import ValidadorBase
+from src.core.ast_nodes import NodoLlamadaFuncion, NodoLlamadaMetodo
+from .primitiva_peligrosa import PrimitivaPeligrosaError
+
+
+class ValidadorSistemaArchivos(ValidadorBase):
+    """Proh\u00edbe funciones que acceden al sistema de archivos."""
+
+    PROHIBIDAS = {
+        "cargar_biblioteca",
+        "obtener_funcion",
+        "cargar_funcion",
+        "compilar_extension",
+        "cargar_extension",
+        "compilar_y_cargar",
+        "compilar_crate",
+        "cargar_crate",
+        "compilar_y_cargar_crate",
+    }
+
+    def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
+        if nodo.nombre in self.PROHIBIDAS:
+            raise PrimitivaPeligrosaError(
+                f"Acceso al sistema de archivos no permitido: {nodo.nombre}"
+            )
+        self.generic_visit(nodo)
+
+    def visit_llamada_metodo(self, nodo: NodoLlamadaMetodo):
+        if nodo.nombre_metodo in self.PROHIBIDAS:
+            raise PrimitivaPeligrosaError(
+                f"Acceso al sistema de archivos no permitido: {nodo.nombre_metodo}"
+            )
+        self.generic_visit(nodo)

--- a/backend/src/core/semantic_validators/reflexion_segura.py
+++ b/backend/src/core/semantic_validators/reflexion_segura.py
@@ -1,0 +1,41 @@
+from .base import ValidadorBase
+from src.core.ast_nodes import NodoLlamadaFuncion, NodoLlamadaMetodo, NodoAtributo
+from .primitiva_peligrosa import PrimitivaPeligrosaError
+
+
+class ValidadorProhibirReflexion(ValidadorBase):
+    """Impide el uso de mecanismos de reflexi\u00f3n e introspecci\u00f3n."""
+
+    FUNCIONES_PROHIBIDAS = {
+        "eval",
+        "exec",
+        "getattr",
+        "setattr",
+        "hasattr",
+        "globals",
+        "locals",
+        "vars",
+    }
+
+    ATRIBUTOS_PROHIBIDOS = {"__dict__", "__class__", "__bases__", "__mro__"}
+
+    def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
+        if nodo.nombre in self.FUNCIONES_PROHIBIDAS:
+            raise PrimitivaPeligrosaError(
+                f"Uso de reflexi\u00f3n no permitido: {nodo.nombre}"
+            )
+        self.generic_visit(nodo)
+
+    def visit_llamada_metodo(self, nodo: NodoLlamadaMetodo):
+        if nodo.nombre_metodo in self.FUNCIONES_PROHIBIDAS:
+            raise PrimitivaPeligrosaError(
+                f"Uso de reflexi\u00f3n no permitido: {nodo.nombre_metodo}"
+            )
+        self.generic_visit(nodo)
+
+    def visit_atributo(self, nodo: NodoAtributo):
+        if nodo.nombre in self.ATRIBUTOS_PROHIBIDOS or nodo.nombre.startswith("__"):
+            raise PrimitivaPeligrosaError(
+                f"Acceso reflexivo no permitido: {nodo.nombre}"
+            )
+        self.generic_visit(nodo)

--- a/backend/src/tests/test_cli_secure_validators.py
+++ b/backend/src/tests/test_cli_secure_validators.py
@@ -1,0 +1,29 @@
+import sys
+from io import StringIO
+from unittest.mock import patch
+import pytest
+
+from src.cli.cli import main
+
+
+def _run_sys_exit(args):
+    with patch("sys.stdout", new_callable=StringIO):
+        with pytest.raises(SystemExit) as exc:
+            sys.exit(main(args))
+    return exc.value.code
+
+
+@pytest.mark.timeout(5)
+def test_cli_seguro_archivos_prohibidos(tmp_path):
+    archivo = tmp_path / "a.co"
+    archivo.write_text("cargar_extension('x.so')")
+    code = _run_sys_exit(["--seguro", "ejecutar", str(archivo)])
+    assert code != 0
+
+
+@pytest.mark.timeout(5)
+def test_cli_seguro_reflexion_prohibida(tmp_path):
+    archivo = tmp_path / "b.co"
+    archivo.write_text("eval('1')")
+    code = _run_sys_exit(["--seguro", "ejecutar", str(archivo)])
+    assert code != 0


### PR DESCRIPTION
## Summary
- add `ValidadorSistemaArchivos` and `ValidadorProhibirReflexion`
- register new validators in `construir_cadena`
- test CLI behavior in safe mode when using forbidden operations

## Testing
- `pytest backend/src/tests/test_cli_secure_validators.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685e7cd4f5688327bec59f7c2692a549