### PR TITLE
Add typecheck step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
           flake8 backend/src
           mypy backend/src
+      - name: Run type checks
+        run: make typecheck
       - name: Run tests
         run: pytest --cov=backend/src --cov-report=xml \
           --cov-report=term-missing --cov-fail-under=80

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Minimal makefile for Sphinx documentation
+	# Minimal makefile for Sphinx documentation
 #
 
 # You can set these variables from the command line, and also
@@ -17,12 +17,18 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-        @$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 coverage:
-        pytest backend/src/tests --cov=backend/src
-          --cov-report=term-missing --cov-fail-under=80
+	pytest backend/src/tests --cov=backend/src
+	--cov-report=term-missing --cov-fail-under=80
 
 lint:
 	flake8 backend/src
 	mypy backend/src
+
+typecheck:
+	mypy backend/src
+	@if command -v pyright >/dev/null 2>&1; then \
+	pyright backend/src; \
+	fi

--- a/README.md
+++ b/README.md
@@ -489,6 +489,8 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
   automáticas al abrir un pull request.
 - Realiza tus cambios y haz commit (`git commit -m 'Añadir nueva característica'`).
 - Ejecuta `make lint` para verificar el código con *flake8* y *mypy*.
+- Ejecuta `make typecheck` para la verificación estática con *mypy* (y
+  opcionalmente *pyright* si está instalado).
 - Envía un pull request.
 
 ## Desarrollo de plugins

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,5 @@
 [mypy]
 python_version = 3.11
 ignore_missing_imports = True
+files = backend/src
+exclude = ^(frontend/build/|frontend/docs/|venv/|backend/src/tests/)


### PR DESCRIPTION
## Summary
- add new typecheck target to run mypy and optional pyright
- update CI workflow to call make typecheck
- list static type check step in README
- extend mypy.ini with backend/src and exclusions

## Testing
- `make typecheck` *(fails: Found 155 errors)*
- `pytest -q` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685e7ef1d0448327894ecb0364bfaddf