### PR TITLE
Añadir async/await y export/import para JavaScript

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/js_nodes/exportar.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/exportar.py
@@ -1,0 +1,6 @@
+from src.core.ast_nodes import NodoExport
+
+
+def visit_export(self, nodo: NodoExport):
+    """Genera una sentencia de exportación."""
+    self.agregar_linea(f"export {{ {nodo.nombre} }};")

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/importar.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/importar.py
@@ -1,16 +1,6 @@
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from ...import_helper import load_mapped_module
+from ...module_map import get_mapped_path
 
 def visit_import(self, nodo):
-    """Carga y transpila el módulo indicado usando el mapeo."""
-    codigo, ruta = load_mapped_module(nodo.ruta, "js")
-
-    if ruta.endswith(".co"):
-        lexer = Lexer(codigo)
-        tokens = lexer.analizar_token()
-        ast = Parser(tokens).parsear()
-        for subnodo in ast:
-            subnodo.aceptar(self)
-    else:
-        self.codigo.extend(codigo.splitlines())
+    """Genera una importación ES module."""
+    ruta = get_mapped_path(nodo.ruta, "js")
+    self.agregar_linea(f"import '{ruta}';")

--- a/backend/src/cobra/transpilers/transpiler/to_js.py
+++ b/backend/src/cobra/transpilers/transpiler/to_js.py
@@ -17,6 +17,8 @@ from src.core.ast_nodes import (
     NodoLambda,
     NodoWith,
     NodoImportDesde,
+    NodoImport,
+    NodoExport,
     NodoEsperar,
 )
 from src.cobra.lexico.lexer import TipoToken
@@ -24,6 +26,7 @@ from src.core.visitor import NodeVisitor
 from src.core.optimizations import optimize_constants, remove_dead_code
 from src.cobra.macro import expandir_macros
 from ..import_helper import get_standard_imports
+from ..module_map import get_mapped_path
 
 from .js_nodes.asignacion import visit_asignacion as _visit_asignacion
 from .js_nodes.condicional import visit_condicional as _visit_condicional
@@ -58,6 +61,7 @@ from .js_nodes.romper import visit_romper as _visit_romper
 from .js_nodes.continuar import visit_continuar as _visit_continuar
 from .js_nodes.pasar import visit_pasar as _visit_pasar
 from .js_nodes.switch import visit_switch as _visit_switch
+from .js_nodes.exportar import visit_export as _visit_export
 
 def visit_assert(self, nodo):
     cond = self.obtener_valor(nodo.condicion)
@@ -86,7 +90,8 @@ def visit_with(self, nodo):
 
 def visit_import_desde(self, nodo):
     alias = f" as {nodo.alias}" if nodo.alias else ""
-    self.agregar_linea(f"import {{ {nodo.nombre}{alias} }} from '{nodo.modulo}';")
+    modulo = get_mapped_path(nodo.modulo, "js")
+    self.agregar_linea(f"import {{ {nodo.nombre}{alias} }} from '{modulo}';")
 
 
 class TranspiladorJavaScript(NodeVisitor):
@@ -194,6 +199,7 @@ TranspiladorJavaScript.visit_continuar = _visit_continuar
 TranspiladorJavaScript.visit_pasar = _visit_pasar
 TranspiladorJavaScript.visit_esperar = _visit_esperar
 TranspiladorJavaScript.visit_switch = _visit_switch
+TranspiladorJavaScript.visit_export = _visit_export
 TranspiladorJavaScript.visit_assert = visit_assert
 TranspiladorJavaScript.visit_del = visit_del
 TranspiladorJavaScript.visit_global = visit_global

--- a/backend/src/core/ast_nodes.py
+++ b/backend/src/core/ast_nodes.py
@@ -351,6 +351,16 @@ class NodoImportDesde(NodoAST):
 
 
 @dataclass
+class NodoExport(NodoAST):
+    nombre: str
+
+    """Indica que un identificador debe exportarse en el módulo generado."""
+
+    def __repr__(self):
+        return f"NodoExport(nombre={self.nombre})"
+
+
+@dataclass
 class NodoPara(NodoAST):
     variable: Any
     iterable: Any
@@ -435,6 +445,7 @@ __all__ = [
     'NodoThrow',
     'NodoTryCatch',
     'NodoImportDesde',
+    'NodoExport',
     'NodoImport',
     'NodoUsar',
     'NodoPara',


### PR DESCRIPTION
## Resumen
- se añade el nodo `NodoExport`
- se crea `js_nodes/exportar.py`
- se actualiza `to_js.py` para manejar importaciones ES Modules y exportaciones
- `js_nodes/importar` genera sentencias `import`
- se corrige `test_to_js.py` y se incluyen pruebas de async/await y export/import

## Testing
- `pytest -q src/tests/test_to_js.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685e8306551c83279a6b73c7512def1c