### PR TITLE
Add match support in Rust transpiler

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/switch.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/switch.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+
+def visit_switch(self, nodo: Any) -> None:
+    expr = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"match {expr} {{")
+    self.indent += 1
+    for caso in nodo.casos:
+        val = self.obtener_valor(caso.valor)
+        self.agregar_linea(f"{val} => {{")
+        self.indent += 1
+        for inst in caso.cuerpo:
+            inst.aceptar(self)
+        self.indent -= 1
+        self.agregar_linea("},")
+    if nodo.por_defecto:
+        self.agregar_linea("_ => {")
+        self.indent += 1
+        for inst in nodo.por_defecto:
+            inst.aceptar(self)
+        self.indent -= 1
+        self.agregar_linea("},")
+    self.indent -= 1
+    self.agregar_linea("}")

--- a/backend/src/tests/test_to_rust.py
+++ b/backend/src/tests/test_to_rust.py
@@ -6,6 +6,12 @@ from src.core.ast_nodes import (
     NodoFuncion,
     NodoLlamadaFuncion,
     NodoHolobit,
+    NodoClase,
+    NodoMetodo,
+    NodoYield,
+    NodoValor,
+    NodoSwitch,
+    NodoCase,
 )
 
 
@@ -80,4 +86,33 @@ def test_transpilador_yield():
     t = TranspiladorRust()
     resultado = t.transpilar(ast)
     esperado = "fn generador() {\n    yield 1;\n}"
+    assert resultado == esperado
+
+
+def test_transpilador_switch():
+    ast = [
+        NodoSwitch(
+            "x",
+            [
+                NodoCase(NodoValor(1), [NodoAsignacion("y", NodoValor(1))]),
+                NodoCase(NodoValor(2), [NodoAsignacion("y", NodoValor(2))]),
+            ],
+            [NodoAsignacion("y", NodoValor(0))],
+        )
+    ]
+    t = TranspiladorRust()
+    resultado = t.transpilar(ast)
+    esperado = (
+        "match x {\n"
+        "    1 => {\n"
+        "        let y = 1;\n"
+        "    },\n"
+        "    2 => {\n"
+        "        let y = 2;\n"
+        "    },\n"
+        "    _ => {\n"
+        "        let y = 0;\n"
+        "    },\n"
+        "}"
+    )
     assert resultado == esperado

--- a/frontend/docs/backends.rst
+++ b/frontend/docs/backends.rst
@@ -13,3 +13,35 @@ Para obtener el código en formato WAT basta ejecutar:
 
 El resultado puede compilarse posteriormente con herramientas como
 ``wat2wasm`` para obtener un módulo ejecutable.
+
+Ejemplo de generación de código Rust::
+
+   cobra compilar programa.co --backend rust
+
+produce:
+
+.. code-block:: rust
+
+   struct Persona {}
+
+   impl Persona {
+       fn saludar(self) {
+           let x = 1;
+       }
+   }
+
+Además un bloque ``switch`` de Cobra se traduce utilizando ``match``::
+
+.. code-block:: rust
+
+   match x {
+       1 => {
+           let y = 1;
+       },
+       2 => {
+           let y = 2;
+       },
+       _ => {
+           let y = 0;
+       },
+   }


### PR DESCRIPTION
## Summary
- generate idiomatic `match` statements for `switch` nodes in the Rust transpiler
- rewrite `obtener_valor` using Python `match` for clarity
- document Rust backend output in `backends.rst`
- extend tests to cover Rust `switch` generation

## Testing
- `pytest -q backend/src/tests/test_to_rust.py`
- `pytest -q` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685e86de57548327acb5a39e1ceafa39