### PR TITLE
Add C transpiler

### DIFF
--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -14,6 +14,7 @@ from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 from src.cobra.transpilers.transpiler.to_asm import TranspiladorASM
 from src.cobra.transpilers.transpiler.to_rust import TranspiladorRust
 from src.cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
+from src.cobra.transpilers.transpiler.to_c import TranspiladorC
 from src.cobra.transpilers.transpiler.to_go import TranspiladorGo
 from src.cobra.transpilers.transpiler.to_r import TranspiladorR
 from src.cobra.transpilers.transpiler.to_julia import TranspiladorJulia
@@ -33,6 +34,7 @@ TRANSPILERS = {
     "asm": TranspiladorASM,
     "rust": TranspiladorRust,
     "cpp": TranspiladorCPP,
+    "c": TranspiladorC,
     "go": TranspiladorGo,
     "ruby": TranspiladorRuby,
     "r": TranspiladorR,
@@ -51,7 +53,7 @@ TRANSPILERS = {
 class CompileCommand(BaseCommand):
     """Transpila un archivo Cobra a distintos lenguajes.
 
-    Soporta Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Ruby,
+    Soporta Python, JavaScript, ensamblador, Rust, C++, C, Go, R, Julia, Ruby,
     PHP, Java y ahora también COBOL, Fortran, Pascal, Matlab, LaTeX y WebAssembly.
     """
 
@@ -68,6 +70,7 @@ class CompileCommand(BaseCommand):
                 "asm",
                 "rust",
                 "cpp",
+                "c",
                 "go",
                 "ruby",
                 "r",
@@ -92,6 +95,7 @@ class CompileCommand(BaseCommand):
                 "asm",
                 "rust",
                 "cpp",
+                "c",
                 "go",
                 "ruby",
                 "r",

--- a/backend/src/cobra/transpilers/transpiler/to_c.py
+++ b/backend/src/cobra/transpilers/transpiler/to_c.py
@@ -1,0 +1,140 @@
+"""Transpilador básico de Cobra a C."""
+
+from src.core.ast_nodes import (
+    NodoLista,
+    NodoDiccionario,
+    NodoValor,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoIdentificador,
+    NodoAtributo,
+    NodoInstancia,
+)
+from src.cobra.lexico.lexer import TipoToken
+from src.core.visitor import NodeVisitor
+from src.core.optimizations import optimize_constants, remove_dead_code
+from src.cobra.macro import expandir_macros
+
+
+def visit_asignacion(self, nodo):
+    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
+    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
+    if isinstance(nombre_raw, NodoAtributo):
+        nombre = self.obtener_valor(nombre_raw)
+        self.agregar_linea(f"{nombre} = {self.obtener_valor(valor)};")
+    else:
+        nombre = nombre_raw
+        self.agregar_linea(f"int {nombre} = {self.obtener_valor(valor)};")
+
+
+def visit_funcion(self, nodo):
+    params = ", ".join(f"int {p}" for p in nodo.parametros)
+    self.agregar_linea(f"void {nodo.nombre}({params}) {{")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+
+
+def visit_llamada_funcion(self, nodo):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"{nodo.nombre}({args});")
+
+
+def visit_condicional(self, nodo):
+    cuerpo_si = getattr(nodo, "cuerpo_si", getattr(nodo, "bloque_si", []))
+    cuerpo_sino = getattr(nodo, "cuerpo_sino", getattr(nodo, "bloque_sino", []))
+    condicion = self.obtener_valor(nodo.condicion)
+    self.agregar_linea(f"if ({condicion}) {{")
+    self.indent += 1
+    for instr in cuerpo_si:
+        instr.aceptar(self)
+    self.indent -= 1
+    if cuerpo_sino:
+        self.agregar_linea("} else {")
+        self.indent += 1
+        for instr in cuerpo_sino:
+            instr.aceptar(self)
+        self.indent -= 1
+        self.agregar_linea("}")
+    else:
+        self.agregar_linea("}")
+
+
+def visit_bucle_mientras(self, nodo):
+    condicion = self.obtener_valor(nodo.condicion)
+    self.agregar_linea(f"while ({condicion}) {{")
+    self.indent += 1
+    for instr in nodo.cuerpo:
+        instr.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+
+
+c_nodes = {
+    "asignacion": visit_asignacion,
+    "funcion": visit_funcion,
+    "llamada_funcion": visit_llamada_funcion,
+    "condicional": visit_condicional,
+    "bucle_mientras": visit_bucle_mientras,
+}
+
+
+class TranspiladorC(NodeVisitor):
+    """Transpila el AST de Cobra a un C muy básico."""
+
+    def __init__(self):
+        self.codigo = []
+        self.indent = 0
+
+    def agregar_linea(self, linea: str) -> None:
+        self.codigo.append("    " * self.indent + linea)
+
+    def obtener_valor(self, nodo):
+        if isinstance(nodo, NodoValor):
+            return str(nodo.valor)
+        elif isinstance(nodo, NodoAtributo):
+            obj = self.obtener_valor(nodo.objeto)
+            return f"{obj}.{nodo.nombre}"
+        elif isinstance(nodo, NodoInstancia):
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"{nodo.nombre_clase}({args})"
+        elif isinstance(nodo, NodoIdentificador):
+            return nodo.nombre
+        elif isinstance(nodo, NodoOperacionBinaria):
+            izq = self.obtener_valor(nodo.izquierda)
+            der = self.obtener_valor(nodo.derecha)
+            op_map = {TipoToken.AND: "&&", TipoToken.OR: "||"}
+            op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
+            return f"{izq} {op} {der}"
+        elif isinstance(nodo, NodoOperacionUnaria):
+            val = self.obtener_valor(nodo.operando)
+            op = "!" if nodo.operador.tipo == TipoToken.NOT else nodo.operador.valor
+            return f"{op}{val}" if op != "!" else f"!{val}"
+        elif isinstance(nodo, NodoLista):
+            elems = ", ".join(self.obtener_valor(e) for e in nodo.elementos)
+            return f"{{{elems}}}"
+        elif isinstance(nodo, NodoDiccionario):
+            pares = ", ".join(
+                f"{{{self.obtener_valor(k)}, {self.obtener_valor(v)}}}" for k, v in nodo.elementos
+            )
+            return f"{{{pares}}}"
+        else:
+            return str(getattr(nodo, "valor", nodo))
+
+    def transpilar(self, nodos):
+        nodos = expandir_macros(nodos)
+        nodos = remove_dead_code(optimize_constants(nodos))
+        for nodo in nodos:
+            if hasattr(nodo, "aceptar"):
+                nodo.aceptar(self)
+            else:
+                metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
+                if metodo:
+                    metodo(nodo)
+        return "\n".join(self.codigo)
+
+
+for nombre, funcion in c_nodes.items():
+    setattr(TranspiladorC, f"visit_{nombre}", funcion)

--- a/backend/src/tests/test_to_c.py
+++ b/backend/src/tests/test_to_c.py
@@ -1,0 +1,52 @@
+from src.cobra.transpilers.transpiler.to_c import TranspiladorC
+from src.core.ast_nodes import (
+    NodoAsignacion,
+    NodoCondicional,
+    NodoBucleMientras,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+)
+
+
+def test_transpilador_asignacion_c():
+    ast = [NodoAsignacion("x", 10)]
+    t = TranspiladorC()
+    resultado = t.transpilar(ast)
+    assert resultado == "int x = 10;"
+
+
+def test_transpilador_condicional_c():
+    ast = [
+        NodoCondicional(
+            "x > 5",
+            [NodoAsignacion("y", 2)],
+            [NodoAsignacion("y", 3)],
+        )
+    ]
+    t = TranspiladorC()
+    resultado = t.transpilar(ast)
+    esperado = "if (x > 5) {\n    int y = 2;\n} else {\n    int y = 3;\n}"
+    assert resultado == esperado
+
+
+def test_transpilador_mientras_c():
+    ast = [NodoBucleMientras("x > 0", [NodoAsignacion("x", "x - 1")])]
+    t = TranspiladorC()
+    resultado = t.transpilar(ast)
+    esperado = "while (x > 0) {\n    int x = x - 1;\n}"
+    assert resultado == esperado
+
+
+def test_transpilador_funcion_c():
+    ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
+    t = TranspiladorC()
+    resultado = t.transpilar(ast)
+    esperado = "void miFuncion(int a, int b) {\n    int x = a + b;\n}"
+    assert resultado == esperado
+
+
+def test_transpilador_llamada_funcion_c():
+    ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
+    t = TranspiladorC()
+    resultado = t.transpilar(ast)
+    assert resultado == "miFuncion(a, b);"

--- a/frontend/docs/backends.rst
+++ b/frontend/docs/backends.rst
@@ -12,7 +12,11 @@ Para obtener el código en formato WAT basta ejecutar:
    cobra compilar programa.co --backend wasm
 
 El resultado puede compilarse posteriormente con herramientas como
-``wat2wasm`` para obtener un módulo ejecutable.
+   ``wat2wasm`` para obtener un módulo ejecutable.
+
+También se dispone de un backend sencillo para generar código C::
+
+   cobra compilar programa.co --backend c
 
 Ejemplo de generación de código Rust::
 


### PR DESCRIPTION
## Summary
- implement a simple C transpiler
- register new backend in the compile command
- document the new backend in docs
- add tests for the C transpiler

## Testing
- `pytest backend/src/tests/test_to_c.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685e89d809988327899992e24645f36b