### PR TITLE
Expandir documentación de plugins y test

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,8 @@ hereda de `BaseCommand` y define su nombre, los argumentos que acepta y la acci�
 a ejecutar. En `src/cli/cli.py` se instancian automáticamente y se registran en
 `argparse`, por lo que para añadir un nuevo comando solo es necesario crear un
 archivo con la nueva clase y llamar a `register_subparser` y `run`.
+Para un tutorial completo de creación de plugins revisa
+[`frontend/docs/plugins.rst`](frontend/docs/plugins.rst).
 
 ## Modo seguro (--seguro)
 

--- a/backend/src/tests/test_cli_plugins_cmd.py
+++ b/backend/src/tests/test_cli_plugins_cmd.py
@@ -17,6 +17,18 @@ class DummyPlugin(PluginCommand):
         pass
 
 
+class HolaPlugin(PluginCommand):
+    name = "hola"
+    version = "1.0"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help="Muestra un saludo")
+        parser.set_defaults(cmd=self)
+
+    def run(self, args):
+        print("¡Hola desde un plugin!")
+
+
 def test_cli_plugins_muestra_registro():
     ep = importlib.metadata.EntryPoint(
         name="dummy",
@@ -27,4 +39,16 @@ def test_cli_plugins_muestra_registro():
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["plugins"])
     assert "dummy 2.3" in out.getvalue().strip()
+
+
+def test_cli_plugin_ejemplo_hola():
+    ep = importlib.metadata.EntryPoint(
+        name="hola",
+        value="src.tests.test_cli_plugins_cmd:HolaPlugin",
+        group="cobra.plugins",
+    )
+    with patch("src.cli.plugin_loader.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            main(["hola"])
+    assert "¡Hola desde un plugin!" in out.getvalue().strip()
 

--- a/frontend/docs/plugins.rst
+++ b/frontend/docs/plugins.rst
@@ -11,3 +11,52 @@ plugins están disponibles se proporciona el subcomando ``plugins``::
 
    cobra plugins
 
+Guía paso a paso
+----------------
+
+A continuación se muestra cómo crear un plugin sencillo utilizando
+``PluginCommand``.
+
+1. **Crea un módulo Python** donde se implementará el plugin. Por ejemplo,
+   ``mi_paquete/mi_plugin.py``.
+2. **Importa** ``PluginCommand`` e implementa una clase que herede de ella:
+
+   .. code-block:: python
+
+      from src.cli.plugin_loader import PluginCommand
+
+
+      class SaludoCommand(PluginCommand):
+          name = "saludo"
+          version = "1.0"
+
+          def register_subparser(self, subparsers):
+              parser = subparsers.add_parser(self.name, help="Muestra un saludo")
+              parser.set_defaults(cmd=self)
+
+          def run(self, args):
+              print("¡Hola desde un plugin!")
+
+3. **Declara el entry point** en tu ``setup.py`` para que Cobra lo descubra:
+
+   .. code-block:: python
+
+      entry_points={
+          'cobra.plugins': [
+              'saludo = mi_paquete.mi_plugin:SaludoCommand',
+          ],
+      }
+
+4. **Instala el paquete** en modo editable con ``pip install -e .`` para que
+   el comando quede disponible.
+5. **Comprueba la instalación** ejecutando ``cobra plugins``. Deberías ver el
+   nombre y la versión registrados.
+6. **Utiliza tu plugin** directamente desde la CLI:
+
+   .. code-block:: bash
+
+      cobra saludo
+
+Con estos pasos se crea un plugin funcional que se integra de forma automática
+con el sistema de comandos de Cobra.
+


### PR DESCRIPTION
## Resumen
- ampliar `frontend/docs/plugins.rst` con un tutorial paso a paso para crear un plugin
- añadir referencia a este tutorial en la sección de CLI del `README.md`
- extender `test_cli_plugins_cmd.py` con un ejemplo de plugin funcional

## Testing
- `pytest backend/src/tests/test_cli_plugins_cmd.py -q`
- `pytest backend/src/tests/test_plugin_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685e8c0065c8832785a428e11ce1cd6a