### PR TITLE
Add module version lock support

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Ejemplo de formato:
 
 ```yaml
 modulo.co:
+  version: "1.0.0"
   python: modulo.py
   js: modulo.js
 ```

--- a/backend/src/tests/test_cli_commands_extra.py
+++ b/backend/src/tests/test_cli_commands_extra.py
@@ -1,6 +1,7 @@
 import pytest
 from io import StringIO
 from unittest.mock import patch
+import yaml
 
 from src.cli.cli import main
 from src.cli.commands import modules_cmd
@@ -175,6 +176,12 @@ def test_cli_modulos_comandos(tmp_path, monkeypatch):
     mods_dir = tmp_path / "mods"
     mods_dir.mkdir()
     monkeypatch.setattr(modules_cmd, "MODULES_PATH", str(mods_dir))
+    lock_file = tmp_path / "cobra.lock"
+    monkeypatch.setattr(modules_cmd, "LOCK_FILE", str(lock_file))
+    mod_file = tmp_path / "cobra.mod"
+    mod_mapping = {"m.co": {"version": "0.1.0"}}
+    mod_file.write_text(yaml.safe_dump(mod_mapping))
+    monkeypatch.setattr(modules_cmd, "MODULE_MAP_PATH", str(mod_file))
 
     modulo = tmp_path / "m.co"
     modulo.write_text("var d = 1")
@@ -188,6 +195,8 @@ def test_cli_modulos_comandos(tmp_path, monkeypatch):
     destino = mods_dir / modulo.name
     assert destino.exists()
     assert f"Módulo instalado en {destino}" in out.getvalue().strip()
+    data = yaml.safe_load(lock_file.read_text())
+    assert data[modulo.name]["version"] == "0.1.0"
 
     with patch("sys.stdout", new_callable=StringIO) as out:
         main(["modulos", "listar"])

--- a/cobra.mod
+++ b/cobra.mod
@@ -3,6 +3,7 @@
 # Cada entrada puede especificar rutas para los archivos generados en Python o JavaScript.
 # Por ejemplo:
 #   modulo.co:
+#     version: "1.0.0"
 #     python: modulo.py
 #     js: modulo.js
 # Actualmente no existen módulos transpilados a registrar.

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -57,8 +57,18 @@ Gestiona módulos instalados.
 Acciones disponibles:
 
 - ``listar`` muestra los módulos instalados.
+
 - ``instalar <ruta>`` copia un archivo ``.co`` al directorio de módulos.
 - ``remover <nombre>`` elimina un módulo instalado.
+
+Al instalar un módulo se actualiza ``cobra.lock`` con la versión declarada
+en ``cobra.mod``. Este archivo admite un campo ``version`` por entrada:
+
+.. code-block:: yaml
+
+   modulo.co:
+     version: "1.0.0"
+     python: modulo.py
 
 Ejemplo:
 


### PR DESCRIPTION
## Summary
- extend `cobra.mod` format with per-module `version`
- update `modules` CLI command to maintain `cobra.lock`
- document lock file and versioned modules in CLI docs
- adjust tests for new lock behavior

## Testing
- `pytest backend/src/tests/test_cli_commands_extra.py::test_cli_modulos_comandos -q`
- `pytest backend/src/tests/test_module_map.py backend/src/tests/test_pcobra_module_map.py -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_685e8e20c4ec8327b028c157460a3ff8