### PR TITLE
Add LSP server and VS Code skeleton

### DIFF
--- a/backend/src/lsp/__init__.py
+++ b/backend/src/lsp/__init__.py
@@ -1,0 +1,1 @@
+"""Servidor LSP sencillo basado en python-lsp-server."""

--- a/backend/src/lsp/server.py
+++ b/backend/src/lsp/server.py
@@ -1,0 +1,13 @@
+"""Módulo para iniciar un servidor LSP mínimo."""
+
+import sys
+from pylsp import lsp, start_io_lang_server
+
+
+def main() -> None:
+    """Arranca el servidor de lenguaje utilizando la implementación por defecto"""
+    start_io_lang_server(lsp, sys.stdin.buffer, sys.stdout.buffer)
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/docs/entorno_desarrollo.rst
+++ b/frontend/docs/entorno_desarrollo.rst
@@ -1,0 +1,27 @@
+Entorno de desarrollo
+=====================
+
+Esta guía explica cómo preparar el entorno para trabajar con la extensión
+experimental de VS Code y el servidor LSP.
+
+Instalación de dependencias
+---------------------------
+
+1. Instala las dependencias de Python:
+
+   .. code-block:: bash
+
+      pip install -r requirements.txt
+
+2. Para utilizar el servidor LSP ejecuta:
+
+   .. code-block:: bash
+
+      python -m lsp.server
+
+Directorio de la extensión de VS Code
+-------------------------------------
+
+Dentro de ``frontend/vscode`` encontrarás una plantilla mínima para la
+extensión de Cobra. Puedes abrir dicho directorio en VS Code y modificarla
+según tus necesidades.

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -34,6 +34,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    cobrahub
    primeros_pasos
    como_contribuir
+   entorno_desarrollo
    qualia
    jupyter
    api/modules

--- a/frontend/vscode/README.md
+++ b/frontend/vscode/README.md
@@ -1,0 +1,3 @@
+# Extensión Cobra para VS Code
+
+Este directorio contiene una plantilla mínima de extensión que habilita el resaltado básico para archivos `.co`.

--- a/frontend/vscode/extension.js
+++ b/frontend/vscode/extension.js
@@ -1,0 +1,7 @@
+function activate(context) {
+    console.log('Extensión Cobra activada');
+}
+
+function deactivate() {}
+
+module.exports = { activate, deactivate };

--- a/frontend/vscode/package.json
+++ b/frontend/vscode/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "cobra-vscode-extension",
+    "displayName": "Cobra Support",
+    "description": "Extensión básica para editar archivos Cobra",
+    "version": "0.0.1",
+    "engines": {
+        "vscode": "^1.80.0"
+    },
+    "activationEvents": [
+        "onLanguage:cobra"
+    ],
+    "main": "./extension.js",
+    "contributes": {
+        "languages": [
+            {
+                "id": "cobra",
+                "extensions": [".co"],
+                "aliases": ["Cobra"]
+            }
+        ]
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ RestrictedPython==8.0
 flake8==7.3.0
 mypy==1.16.1
 pybind11==2.13.6
+python-lsp-server==1.11.0


### PR DESCRIPTION
## Summary
- create minimal VS Code extension in `frontend/vscode`
- implement simple language server using `python-lsp-server`
- document how to install and run the dev environment
- update docs index and requirements

## Testing
- `pip install python-lsp-server==1.11.0`
- `pytest -q` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685e90b498048327a315115cdb048115