### PR TITLE
Add validator and CLI interactive tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ pytest backend/src/tests --cov=backend/src --cov-report=term-missing \
   --cov-fail-under=80
 ````
 
+También puedes ejecutar suites específicas ubicadas en `backend/src/tests`:
+
+````bash
+python -m tests.suite_cli           # Solo pruebas de la CLI
+python -m tests.suite_core          # Pruebas de lexer, parser e intérprete
+python -m tests.suite_transpiladores  # Pruebas de los transpiladores
+````
+
 
 # Ejemplo de Uso
 

--- a/backend/src/tests/suite_cli.py
+++ b/backend/src/tests/suite_cli.py
@@ -1,0 +1,12 @@
+import pathlib
+import pytest
+import sys
+
+
+def main():
+    root = pathlib.Path(__file__).parent
+    sys.exit(pytest.main([str(root), '-k', 'cli']))
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/src/tests/suite_core.py
+++ b/backend/src/tests/suite_core.py
@@ -1,0 +1,12 @@
+import pathlib
+import pytest
+import sys
+
+
+def main():
+    root = pathlib.Path(__file__).parent
+    sys.exit(pytest.main([str(root), '-k', 'not cli']))
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/src/tests/suite_transpiladores.py
+++ b/backend/src/tests/suite_transpiladores.py
@@ -1,0 +1,12 @@
+import pathlib
+import pytest
+import sys
+
+
+def main():
+    root = pathlib.Path(__file__).parent
+    sys.exit(pytest.main([str(root), '-k', 'to_']))
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/src/tests/test_cli_interactive_cmd.py
+++ b/backend/src/tests/test_cli_interactive_cmd.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace, ModuleType
+from unittest.mock import patch
+import sys
+
+# Crear un módulo falso para evitar que la importación de sandbox
+# requiera RestrictedPython durante las pruebas.
+fake_rp = ModuleType("RestrictedPython")
+fake_rp.compile_restricted = lambda *a, **k: None
+fake_rp.safe_builtins = {}
+sys.modules.setdefault("RestrictedPython", fake_rp)
+eval_mod = ModuleType("Eval")
+eval_mod.default_guarded_getitem = lambda seq, key: seq[key]
+sys.modules.setdefault("RestrictedPython.Eval", eval_mod)
+guards_mod = ModuleType("Guards")
+guards_mod.guarded_iter_unpack_sequence = lambda *a, **k: iter([])
+guards_mod.guarded_unpack_sequence = lambda *a, **k: []
+sys.modules.setdefault("RestrictedPython.Guards", guards_mod)
+pc_mod = ModuleType("PrintCollector")
+pc_mod.PrintCollector = list
+sys.modules.setdefault("RestrictedPython.PrintCollector", pc_mod)
+sys.modules.setdefault("yaml", ModuleType("yaml"))
+
+from src.cli.commands.interactive_cmd import InteractiveCommand
+
+
+def _args():
+    return SimpleNamespace(seguro=False, validadores_extra=None, sandbox=False, sandbox_docker=None)
+
+
+def test_interactive_exit():
+    cmd = InteractiveCommand()
+    with patch('builtins.input', side_effect=['salir']), \
+         patch('src.cli.commands.interactive_cmd.InterpretadorCobra') as mock_interp, \
+         patch('src.cli.commands.interactive_cmd.validar_dependencias'):
+        ret = cmd.run(_args())
+    assert ret == 0
+    mock_interp.assert_called_once_with(safe_mode=False, extra_validators=None)
+
+
+def test_interactive_tokens():
+    cmd = InteractiveCommand()
+    with patch('builtins.input', side_effect=['tokens', 'salir']), \
+         patch('src.cli.commands.interactive_cmd.mostrar_info') as mock_info, \
+         patch('src.cli.commands.interactive_cmd.validar_dependencias'):
+        cmd.run(_args())
+    mock_info.assert_any_call('Tokens generados:')
+
+
+def test_interactive_ast():
+    cmd = InteractiveCommand()
+    with patch('builtins.input', side_effect=['ast', 'salir']), \
+         patch('src.cli.commands.interactive_cmd.mostrar_info') as mock_info, \
+         patch('src.cli.commands.interactive_cmd.validar_dependencias'):
+        cmd.run(_args())
+    mock_info.assert_any_call('AST generado:')

--- a/backend/src/tests/test_fs_access_validator.py
+++ b/backend/src/tests/test_fs_access_validator.py
@@ -1,0 +1,18 @@
+import pytest
+from src.core.semantic_validators.fs_access import ValidadorSistemaArchivos
+from src.core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
+from src.core.ast_nodes import NodoLlamadaFuncion, NodoLlamadaMetodo
+
+
+def test_fs_access_funcion_prohibida():
+    validator = ValidadorSistemaArchivos()
+    nodo = NodoLlamadaFuncion("cargar_funcion", [])
+    with pytest.raises(PrimitivaPeligrosaError):
+        nodo.aceptar(validator)
+
+
+def test_fs_access_metodo_prohibido():
+    validator = ValidadorSistemaArchivos()
+    nodo = NodoLlamadaMetodo("m", "cargar_biblioteca", [])
+    with pytest.raises(PrimitivaPeligrosaError):
+        nodo.aceptar(validator)

--- a/backend/src/tests/test_import_seguro_validator.py
+++ b/backend/src/tests/test_import_seguro_validator.py
@@ -1,0 +1,14 @@
+import pytest
+from types import SimpleNamespace
+from src.core.semantic_validators.import_seguro import ValidadorImportSeguro
+from src.core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
+from src.core.ast_nodes import NodoImport
+
+
+def test_import_seguro_fuera_de_ruta(tmp_path, monkeypatch):
+    validator = ValidadorImportSeguro()
+    nodo = NodoImport(str(tmp_path / "m.co"))
+    monkeypatch.setattr('src.core.interpreter.MODULES_PATH', str(tmp_path / 'mods'))
+    monkeypatch.setattr('src.core.interpreter.IMPORT_WHITELIST', set())
+    with pytest.raises(PrimitivaPeligrosaError):
+        nodo.aceptar(validator)

--- a/backend/src/tests/test_nodo_macro.py
+++ b/backend/src/tests/test_nodo_macro.py
@@ -1,0 +1,7 @@
+from src.core.ast_nodes import NodoMacro
+
+
+def test_nodo_macro_repr():
+    nodo = NodoMacro('m', [1, 2])
+    assert 'nombre=m' in repr(nodo)
+    assert 'cuerpo=[1, 2]' in repr(nodo)

--- a/backend/src/tests/test_reflexion_validator.py
+++ b/backend/src/tests/test_reflexion_validator.py
@@ -1,0 +1,18 @@
+import pytest
+from src.core.semantic_validators.reflexion_segura import ValidadorProhibirReflexion
+from src.core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
+from src.core.ast_nodes import NodoLlamadaFuncion, NodoAtributo, NodoIdentificador
+
+
+def test_reflexion_funcion_prohibida():
+    validator = ValidadorProhibirReflexion()
+    nodo = NodoLlamadaFuncion("eval", [])
+    with pytest.raises(PrimitivaPeligrosaError):
+        nodo.aceptar(validator)
+
+
+def test_reflexion_atributo_prohibido():
+    validator = ValidadorProhibirReflexion()
+    nodo = NodoAtributo(NodoIdentificador("obj"), "__dict__")
+    with pytest.raises(PrimitivaPeligrosaError):
+        nodo.aceptar(validator)


### PR DESCRIPTION
## Summary
- add missing semantic validator tests
- add CLI interactive command tests and patch sandbox imports
- add NodoMacro test
- introduce basic pytest suites for cli, core and transpilers
- document running suites in README

## Testing
- `pytest backend/src/tests/test_fs_access_validator.py backend/src/tests/test_reflexion_validator.py backend/src/tests/test_import_seguro_validator.py backend/src/tests/test_nodo_macro.py backend/src/tests/test_cli_interactive_cmd.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685e931f4e108327988756bf82478404