### PR TITLE
Add benchmarking scripts and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 .coverage
 htmlcov/
 coverage.xml
+cache/

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,10 @@ lint:
 	mypy backend/src
 
 typecheck:
-	mypy backend/src
-	@if command -v pyright >/dev/null 2>&1; then \
-	pyright backend/src; \
+		mypy backend/src
+		@if command -v pyright >/dev/null 2>&1; then \
+		pyright backend/src; \
 	fi
+
+benchmarks:
+		python scripts/benchmarks/run_benchmarks.py > bench_results.json

--- a/frontend/docs/benchmarking.rst
+++ b/frontend/docs/benchmarking.rst
@@ -52,3 +52,27 @@ Además de ``smooth-criminal`` puedes emplear la biblioteca estándar
 
 Para más información sobre configuraciones seguras consulta
 :doc:`modo_seguro`.
+
+Resultados recientes
+--------------------
+
+Los siguientes datos se obtuvieron ejecutando ``scripts/benchmarks/run_benchmarks.py``.
+
+.. list-table:: Tiempos y memoria aproximados
+   :header-rows: 1
+
+   * - Backend
+     - Tiempo (s)
+     - Memoria (KB)
+   * - python
+     - 0.6792
+     - 0
+   * - js
+     - 0.071
+     - 0
+   * - go
+     - 0.0149
+     - 0
+   * - ruby
+     - 0.1054
+     - 0

--- a/scripts/benchmarks/run_benchmarks.py
+++ b/scripts/benchmarks/run_benchmarks.py
@@ -1,0 +1,110 @@
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import resource
+
+# Código Cobra para las pruebas de rendimiento
+CODE = """
+var x = 0
+mientras x <= 1000 :
+    x = x + 1
+fin
+imprimir(x)
+"""
+
+# Configuración de cada backend: extensión y comandos de ejecución
+BACKENDS = {
+    "python": {
+        "ext": "py",
+        "run": ["python", "{file}"]
+    },
+    "js": {
+        "ext": "js",
+        "run": ["node", "{file}"]
+    },
+    "cpp": {
+        "ext": "cpp",
+        "compile": ["g++", "{file}", "-O2", "-o", "{tmp}/prog_cpp"],
+        "run": ["{tmp}/prog_cpp"]
+    },
+    "go": {
+        "ext": "go",
+        "run": ["go", "run", "{file}"]
+    },
+    "ruby": {
+        "ext": "rb",
+        "run": ["ruby", "{file}"]
+    },
+    "rust": {
+        "ext": "rs",
+        "compile": ["rustc", "{file}", "-O", "-o", "{tmp}/prog_rs"],
+        "run": ["{tmp}/prog_rs"]
+    }
+}
+
+
+def run_and_measure(cmd: list[str], env: dict[str, str] | None = None) -> tuple[float, int]:
+    """Ejecuta *cmd* y devuelve (tiempo_en_segundos, memoria_en_kb)."""
+    start_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    start_time = time.perf_counter()
+    subprocess.run(cmd, env=env, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+    elapsed = time.perf_counter() - start_time
+    end_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    mem_kb = max(0, end_usage.ru_maxrss - start_usage.ru_maxrss)
+    return elapsed, mem_kb
+
+
+def main() -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "backend" / "src")
+    env["PCOBRA_TOML"] = str(Path(tempfile.mkstemp(suffix=".toml")[1]))
+
+    results = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        co_file = Path(tmpdir) / "program.co"
+        co_file.write_text(CODE)
+        for backend, cfg in BACKENDS.items():
+            run_cmd = cfg["run"]
+            src_file = Path(tmpdir) / f"program.{cfg['ext']}"
+            transp_cmd = [
+                sys.executable,
+                "-m",
+                "src.cli.cli",
+                "compilar",
+                str(co_file),
+                "--tipo",
+                backend,
+            ]
+            try:
+                out = subprocess.check_output(transp_cmd, env=env, text=True)
+            except subprocess.CalledProcessError:
+                continue
+            out = re.sub(r"\x1b\[[0-9;]*m", "", out)
+            lines = [l for l in out.splitlines() if not l.startswith("DEBUG:") and not l.startswith("INFO:")]
+            if lines and lines[0].startswith("Código generado"):
+                lines = lines[1:]
+            out = "\n".join(lines)
+            src_file.write_text(out)
+            if "compile" in cfg:
+                compile_cmd = [arg.format(file=src_file, tmp=tmpdir) for arg in cfg["compile"]]
+                try:
+                    subprocess.check_call(compile_cmd)
+                except Exception:
+                    continue
+            cmd = [arg.format(file=src_file, tmp=tmpdir) for arg in run_cmd]
+            if not shutil.which(cmd[0]) and not os.path.exists(cmd[0]):
+                continue
+            elapsed, mem = run_and_measure(cmd, env)
+            results.append({"backend": backend, "time": round(elapsed, 4), "memory_kb": mem})
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_benchmarks.py` to measure execution time across several backends
- document benchmark results in `frontend/docs/benchmarking.rst`
- create `benchmarks` target in `Makefile`
- ignore cache folder in `.gitignore`

## Testing
- `python scripts/benchmarks/run_benchmarks.py`
- `make benchmarks`

------
https://chatgpt.com/codex/tasks/task_e_685e956a8f0483278302f4ff5d367732