### PR TITLE
Add static analysis steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           flake8 backend/src
           mypy backend/src
+          bandit -r backend/src
       - name: Run type checks
         run: make typecheck
       - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ coverage:
 lint:
 	flake8 backend/src
 	mypy backend/src
+	bandit -r backend/src
 
 typecheck:
 		mypy backend/src

--- a/README.md
+++ b/README.md
@@ -499,9 +499,10 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
 - Las ramas que comiencen con `feature/`, `bugfix/` o `doc/` recibirán etiquetas
   automáticas al abrir un pull request.
 - Realiza tus cambios y haz commit (`git commit -m 'Añadir nueva característica'`).
-- Ejecuta `make lint` para verificar el código con *flake8* y *mypy*.
+- Ejecuta `make lint` para verificar el código con *flake8*, *mypy* y *bandit*.
 - Ejecuta `make typecheck` para la verificación estática con *mypy* (y
   opcionalmente *pyright* si está instalado).
+- El CI de GitHub Actions ejecuta automáticamente estas herramientas en cada pull request.
 - Envía un pull request.
 
 ## Desarrollo de plugins

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,6 @@ smooth-criminal
 RestrictedPython==8.0
 flake8==7.3.0
 mypy==1.16.1
+bandit==1.8.5
 pybind11==2.13.6
 python-lsp-server==1.11.0


### PR DESCRIPTION
## Summary
- check flake8, mypy and bandit in CI
- run bandit in `make lint`
- document linting and CI checks in README
- add bandit to requirements

## Testing
- `make lint` *(fails: E501 line too long)*
- `pytest -q` *(fails: 72 failed, 299 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685e9ae542d88327842ee67ace750ea4