### PR TITLE
Añadir documentación de plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,8 @@ Puedes compilar la documentación de dos maneras:
 
 A partir de esta versión, la API se genera de forma automática antes de
 cada compilación para mantener la documentación actualizada.
+Para aprender a desarrollar plugins revisa
+[`frontend/docs/plugin_dev.rst`](frontend/docs/plugin_dev.rst).
 ## Hitos y Roadmap
 
 El proyecto avanza en versiones incrementales. A continuacion se listan las tareas previstas para las proximas entregas.

--- a/examples/plugins/saludo_plugin.py
+++ b/examples/plugins/saludo_plugin.py
@@ -1,0 +1,14 @@
+from src.cli.plugin_loader import PluginCommand
+
+class SaludoCommand(PluginCommand):
+    """Comando de ejemplo que imprime un saludo."""
+
+    name = "saludo"
+    version = "1.0"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help="Muestra un saludo")
+        parser.set_defaults(cmd=self)
+
+    def run(self, args):
+        print("¡Hola desde el plugin de ejemplo!")

--- a/examples/plugins/setup.py
+++ b/examples/plugins/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    name='ejemplo-plugin-cobra',
+    version='1.0',
+    py_modules=['saludo_plugin'],
+    entry_points={
+        'cobra.plugins': [
+            'saludo = saludo_plugin:SaludoCommand',
+        ],
+    },
+)

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -23,6 +23,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    benchmarking
    modulos_nativos
    plugins
+   plugin_dev
    ejemplos
    ejemplos_avanzados
    referencia

--- a/frontend/docs/plugin_dev.rst
+++ b/frontend/docs/plugin_dev.rst
@@ -1,0 +1,67 @@
+Desarrollo de plugins
+=====================
+
+Un plugin permite añadir nuevos subcomandos a la CLI de Cobra mediante
+paquetes externos. Cada plugin se implementa como una clase que hereda de
+``PluginCommand``.
+
+Estructura básica
+-----------------
+
+.. code-block:: text
+
+   mi_plugin/
+       setup.py
+       mi_plugin/
+           __init__.py
+           hola.py
+
+En ``hola.py`` se define la clase del comando:
+
+.. code-block:: python
+
+   from src.cli.plugin_loader import PluginCommand
+
+
+   class HolaCommand(PluginCommand):
+       name = "hola"
+       version = "1.0"
+
+       def register_subparser(self, subparsers):
+           parser = subparsers.add_parser(self.name, help="Muestra un saludo")
+           parser.set_defaults(cmd=self)
+
+       def run(self, args):
+           print("¡Hola desde un plugin!")
+
+Registro con ``entry_points``
+-----------------------------
+
+Para que Cobra descubra el plugin se declara un ``entry_point`` en
+``setup.py``:
+
+.. code-block:: python
+
+   from setuptools import setup
+
+   setup(
+       name="mi-plugin",
+       version="1.0",
+       py_modules=["mi_plugin.hola"],
+       entry_points={
+           'cobra.plugins': [
+               'hola = mi_plugin.hola:HolaCommand',
+           ],
+       },
+   )
+
+Uso
+---
+
+Instala el paquete en modo editable y ejecuta el comando:
+
+.. code-block:: bash
+
+   pip install -e .
+   cobra plugins
+   cobra hola


### PR DESCRIPTION
## Summary
- documentar desarrollo de plugins
- enlazar plugin_dev.rst en la documentación y README
- agregar ejemplo básico de plugin

## Testing
- `make lint` *(fails: flake8 issues in repository)*
- `pytest -q` *(fails: 19 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685e9ddaac3c83279a8e9bc1a443e9b0