### PR TITLE
Add CONTRIBUTING guidelines and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Informe de bug
+about: Reporta un problema para que podamos corregirlo
+title: "[Bug]"
+labels: bug
+assignees: ''
+---
+
+**Describe el bug**
+Una descripción clara y concisa de lo que sucede.
+
+**Para reproducir**
+Pasos para reproducir el comportamiento:
+1. Ir a '...'
+2. Ejecutar '...'
+3. Ver el error
+
+**Comportamiento esperado**
+Una descripción clara de lo que esperabas que sucediera.
+
+**Contexto adicional**
+Agrega cualquier otro contexto o capturas de pantalla sobre el problema.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Solicitud de mejora
+about: Sugiere una nueva función o mejora
+title: "[Mejora]"
+labels: enhancement
+assignees: ''
+---
+
+**¿Tu solicitud está relacionada con un problema? Por favor descríbelo.**
+
+Una descripción clara del problema o necesidad.
+
+**Describe la solución que te gustaría**
+
+Una descripción clara de lo que quieres que suceda.
+
+**Alternativas consideradas**
+
+Explica otras soluciones o características que hayas pensado.
+
+**Contexto adicional**
+
+Agrega cualquier información adicional.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Descripción
+
+Por favor explica brevemente los cambios realizados y la motivación detrás de ellos.
+
+## Checklist
+- [ ] El código compila y las pruebas pasan
+- [ ] He ejecutado `make lint` y `make typecheck`
+- [ ] Se añadieron pruebas o documentación cuando fue necesario
+- [ ] Se vincularon los issues relevantes con `#numero`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Guía de Contribución
+
+Gracias por tu interés en mejorar Cobra. A continuación se describen las pautas para participar en el proyecto.
+
+## Reportar Issues
+
+1. **Busca duplicados**: antes de abrir un issue verifica si alguien más ya ha reportado el mismo problema o solicitado la misma característica.
+2. **Título claro**: usa un título descriptivo. Si es un error, añade un prefijo `[Bug]`.
+3. **Información útil**: indica la versión de Cobra, sistema operativo y pasos detallados para reproducir el problema. Incluye el comportamiento esperado y lo que realmente ocurre.
+4. **Etiquetas recomendadas**: usa `bug` para reportes de errores, `enhancement` para mejoras y `question` para dudas. Si se trata de documentación, utiliza `documentation`.
+
+## Pull Requests
+
+1. **Fork y rama**: haz un fork y crea una rama a partir de `main` con el prefijo adecuado (`feature/`, `bugfix/` o `doc/`). Esto permite que las acciones de GitHub etiqueten tu PR automáticamente.
+2. **Sincroniza con `main`**: antes de abrir el PR, actualiza tu rama para incorporar los últimos cambios.
+3. **Pruebas y estilo**: ejecuta `make lint` y `make typecheck` para asegurarte de que el código pasa las verificaciones. Añade o ajusta pruebas cuando sea necesario.
+4. **Descripción**: indica el propósito del cambio y referencia issues relacionados usando `#numero`.
+5. **Revisión**: una vez abierto el PR, espera la revisión de los mantenedores y realiza los cambios solicitados.
+
+¡Agradecemos todas las contribuciones!

--- a/README.md
+++ b/README.md
@@ -506,6 +506,8 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
   opcionalmente *pyright* si está instalado).
 - El CI de GitHub Actions ejecuta automáticamente estas herramientas en cada pull request.
 - Envía un pull request.
+- Consulta [CONTRIBUTING.md](CONTRIBUTING.md) para más detalles sobre cómo abrir
+  issues y preparar pull requests.
 
 ## Desarrollo de plugins
 


### PR DESCRIPTION
## Summary
- add CONTRIBUTING.md with instructions on issues and PRs
- mention CONTRIBUTING in README
- add issue and PR templates under `.github`

## Testing
- `pip install -r requirements.txt`
- `make lint` *(fails: E501, E741, etc.)*
- `make typecheck` *(fails: 158 errors in 13 files)*
- `pytest -q` *(fails: 72 failed, 299 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685ea0c8ecbc83279f56f1aaa9f4facd