### PR TITLE
Apply inline optimization in transpilers

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/to_asm.py
+++ b/backend/src/cobra/transpilers/transpiler/to_asm.py
@@ -31,7 +31,7 @@ from src.core.ast_nodes import (
 from src.cobra.lexico.lexer import TipoToken, Lexer
 from src.cobra.parser.parser import Parser
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 from .asm_nodes.asignacion import visit_asignacion as _visit_asignacion
@@ -109,7 +109,7 @@ class TranspiladorASM(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             nodo.aceptar(self)
         return "\n".join(self.codigo)

--- a/backend/src/cobra/transpilers/transpiler/to_c.py
+++ b/backend/src/cobra/transpilers/transpiler/to_c.py
@@ -12,7 +12,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 
@@ -125,7 +125,7 @@ class TranspiladorC(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             if hasattr(nodo, "aceptar"):
                 nodo.aceptar(self)

--- a/backend/src/cobra/transpilers/transpiler/to_cobol.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cobol.py
@@ -13,7 +13,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 from .cobol_nodes.asignacion import visit_asignacion as _visit_asignacion
@@ -67,7 +67,7 @@ class TranspiladorCOBOL(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             nodo.aceptar(self)
         return "\n".join(self.codigo)

--- a/backend/src/cobra/transpilers/transpiler/to_cpp.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cpp.py
@@ -19,7 +19,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 from .cpp_nodes.asignacion import visit_asignacion as _visit_asignacion
@@ -111,7 +111,7 @@ class TranspiladorCPP(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             nodo.aceptar(self)
         return "\n".join(self.codigo)

--- a/backend/src/cobra/transpilers/transpiler/to_fortran.py
+++ b/backend/src/cobra/transpilers/transpiler/to_fortran.py
@@ -13,7 +13,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 from .fortran_nodes.asignacion import visit_asignacion as _visit_asignacion
@@ -62,7 +62,7 @@ class TranspiladorFortran(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             if hasattr(nodo, "aceptar"):
                 nodo.aceptar(self)

--- a/backend/src/cobra/transpilers/transpiler/to_go.py
+++ b/backend/src/cobra/transpilers/transpiler/to_go.py
@@ -13,7 +13,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 
@@ -85,7 +85,7 @@ class TranspiladorGo(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
             if metodo:

--- a/backend/src/cobra/transpilers/transpiler/to_java.py
+++ b/backend/src/cobra/transpilers/transpiler/to_java.py
@@ -13,7 +13,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 
@@ -84,7 +84,7 @@ class TranspiladorJava(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             if hasattr(nodo, "aceptar"):
                 nodo.aceptar(self)

--- a/backend/src/cobra/transpilers/transpiler/to_js.py
+++ b/backend/src/cobra/transpilers/transpiler/to_js.py
@@ -23,7 +23,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 from ..import_helper import get_standard_imports
 from ..module_map import get_mapped_path
@@ -149,7 +149,7 @@ class TranspiladorJavaScript(NodeVisitor):
 
     def transpilar(self, ast_raiz):
         ast_raiz = expandir_macros(ast_raiz)
-        ast_raiz = remove_dead_code(optimize_constants(ast_raiz))
+        ast_raiz = remove_dead_code(inline_functions(optimize_constants(ast_raiz)))
         for nodo in ast_raiz:
             if hasattr(nodo, 'aceptar'):
                 nodo.aceptar(self)

--- a/backend/src/cobra/transpilers/transpiler/to_julia.py
+++ b/backend/src/cobra/transpilers/transpiler/to_julia.py
@@ -13,7 +13,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 
@@ -84,7 +84,7 @@ class TranspiladorJulia(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
             if metodo:

--- a/backend/src/cobra/transpilers/transpiler/to_latex.py
+++ b/backend/src/cobra/transpilers/transpiler/to_latex.py
@@ -10,7 +10,7 @@ from src.core.ast_nodes import (
     NodoAtributo,
 )
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 from .latex_nodes.asignacion import visit_asignacion as _visit_asignacion
@@ -49,7 +49,7 @@ class TranspiladorLatex(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             if hasattr(nodo, "aceptar"):
                 nodo.aceptar(self)

--- a/backend/src/cobra/transpilers/transpiler/to_matlab.py
+++ b/backend/src/cobra/transpilers/transpiler/to_matlab.py
@@ -13,7 +13,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 from .matlab_nodes.asignacion import visit_asignacion as _visit_asignacion
@@ -62,7 +62,7 @@ class TranspiladorMatlab(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             if hasattr(nodo, "aceptar"):
                 nodo.aceptar(self)

--- a/backend/src/cobra/transpilers/transpiler/to_pascal.py
+++ b/backend/src/cobra/transpilers/transpiler/to_pascal.py
@@ -13,7 +13,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 from .pascal_nodes.asignacion import visit_asignacion as _visit_asignacion
@@ -63,7 +63,7 @@ class TranspiladorPascal(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             if hasattr(nodo, "aceptar"):
                 nodo.aceptar(self)

--- a/backend/src/cobra/transpilers/transpiler/to_php.py
+++ b/backend/src/cobra/transpilers/transpiler/to_php.py
@@ -13,7 +13,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 
@@ -90,7 +90,7 @@ class TranspiladorPHP(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             if hasattr(nodo, "aceptar"):
                 nodo.aceptar(self)

--- a/backend/src/cobra/transpilers/transpiler/to_python.py
+++ b/backend/src/cobra/transpilers/transpiler/to_python.py
@@ -31,7 +31,7 @@ from src.core.ast_nodes import (
 from src.cobra.parser.parser import Parser
 from src.cobra.lexico.lexer import TipoToken, Lexer
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 from ..import_helper import get_standard_imports
 
@@ -112,7 +112,7 @@ class TranspiladorPython(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             nodo.aceptar(self)
         if nodos and all(

--- a/backend/src/cobra/transpilers/transpiler/to_r.py
+++ b/backend/src/cobra/transpilers/transpiler/to_r.py
@@ -13,7 +13,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 
@@ -84,7 +84,7 @@ class TranspiladorR(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
             if metodo:

--- a/backend/src/cobra/transpilers/transpiler/to_ruby.py
+++ b/backend/src/cobra/transpilers/transpiler/to_ruby.py
@@ -13,7 +13,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 
@@ -84,7 +84,7 @@ class TranspiladorRuby(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             nombre = self._camel_to_snake(nodo.__class__.__name__)
             metodo = getattr(self, f"visit_{nombre}", None)

--- a/backend/src/cobra/transpilers/transpiler/to_rust.py
+++ b/backend/src/cobra/transpilers/transpiler/to_rust.py
@@ -21,7 +21,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 from .rust_nodes.asignacion import visit_asignacion as _visit_asignacion
@@ -114,7 +114,7 @@ class TranspiladorRust(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             nodo.aceptar(self)
         return "\n".join(self.codigo)

--- a/backend/src/cobra/transpilers/transpiler/to_wasm.py
+++ b/backend/src/cobra/transpilers/transpiler/to_wasm.py
@@ -9,7 +9,7 @@ from src.core.ast_nodes import (
 )
 from src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
-from src.core.optimizations import optimize_constants, remove_dead_code
+from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
 
@@ -59,7 +59,7 @@ class TranspiladorWasm(NodeVisitor):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(optimize_constants(nodos))
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             nodo.aceptar(self)
         return "\n".join(self.codigo)

--- a/backend/src/tests/test_inlining_transpilers.py
+++ b/backend/src/tests/test_inlining_transpilers.py
@@ -1,0 +1,28 @@
+import pytest
+from src.core.ast_nodes import NodoFuncion, NodoRetorno, NodoValor, NodoAsignacion, NodoLlamadaFuncion
+from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+
+
+def _ast_inline():
+    return [
+        NodoFuncion("uno", [], [NodoRetorno(NodoValor(1))]),
+        NodoAsignacion("x", NodoLlamadaFuncion("uno", [])),
+    ]
+
+
+def test_inline_python_transpiler():
+    codigo = TranspiladorPython().transpilar(_ast_inline())
+    assert codigo == "from src.core.nativos import *\nx = 1\n"
+
+
+def test_inline_js_transpiler():
+    codigo = TranspiladorJavaScript().transpilar(_ast_inline())
+    esperado = (
+        "import * as io from './nativos/io.js';\n"
+        "import * as net from './nativos/io.js';\n"
+        "import * as matematicas from './nativos/matematicas.js';\n"
+        "import { Pila, Cola } from './nativos/estructuras.js';\n"
+        "let x = 1;"
+    )
+    assert codigo == esperado

--- a/frontend/docs/optimizaciones.rst
+++ b/frontend/docs/optimizaciones.rst
@@ -1,7 +1,7 @@
 Optimizaciones del AST
 ======================
 
-El proyecto incluye un conjunto de visitantes que mejoran el \ *performance\* del c\ódigo generado o ejecutado. Actualmente existen dos optimizaciones sencillas:
+El proyecto incluye un conjunto de visitantes que mejoran el \ *performance\* del c\ódigo generado o ejecutado. Actualmente existen tres optimizaciones sencillas:
 
 Plegado de constantes
 ---------------------
@@ -10,6 +10,10 @@ Plegado de constantes
 Eliminación de código muerto
 ----------------------------
 ``remove_dead_code`` elimina instrucciones que nunca se ejecutarán. Por ejemplo, todo lo que aparezca después de ``return`` dentro de una función se descarta y, si un condicional tiene una condición constante, solo se conserva la rama correspondiente.
+
+Integración de funciones simples
+--------------------------------
+``inline_functions`` identifica funciones sin parámetros y con un único ``return`` para sustituir sus llamadas por el valor retornado, eliminando además la definición original cuando es posible.
 
 Estas optimizaciones se aplican automáticamente antes de ejecutar el intérprete y en los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX.
 


### PR DESCRIPTION
## Summary
- apply `inline_functions` before `remove_dead_code` in every transpiler
- test that Python and JS transpilers inline simple functions
- document the new optimization

## Testing
- `pytest backend/src/tests/test_inlining_transpilers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685eaa322208832789ef44bd99baad17