### PR TITLE
Add benchmarks subcommand

### DIFF
--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -22,6 +22,7 @@ from .commands.package_cmd import PaqueteCommand
 from .commands.crear_cmd import CrearCommand
 from .commands.init_cmd import InitCommand
 from .commands.container_cmd import ContainerCommand
+from .commands.benchmarks_cmd import BenchmarksCommand
 
 # La configuración de logging solo debe activarse cuando la CLI se ejecuta
 # directamente para evitar modificar la configuración global al importar este
@@ -59,6 +60,7 @@ def main(argv=None):
         JupyterCommand(),
         FletCommand(),
         ContainerCommand(),
+        BenchmarksCommand(),
         PluginsCommand(),
         InteractiveCommand(),
     ]

--- a/backend/src/cli/commands/benchmarks_cmd.py
+++ b/backend/src/cli/commands/benchmarks_cmd.py
@@ -1,0 +1,134 @@
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import resource
+
+from .base import BaseCommand
+from ..i18n import _
+from ..utils.messages import mostrar_error, mostrar_info
+
+CODE = """
+var x = 0
+mientras x <= 1000 :
+    x = x + 1
+fin
+imprimir(x)
+"""
+
+BACKENDS = {
+    "python": {
+        "ext": "py",
+        "run": ["python", "{file}"]
+    },
+    "js": {
+        "ext": "js",
+        "run": ["node", "{file}"]
+    },
+    "cpp": {
+        "ext": "cpp",
+        "compile": ["g++", "{file}", "-O2", "-o", "{tmp}/prog_cpp"],
+        "run": ["{tmp}/prog_cpp"]
+    },
+    "go": {
+        "ext": "go",
+        "run": ["go", "run", "{file}"]
+    },
+    "ruby": {
+        "ext": "rb",
+        "run": ["ruby", "{file}"]
+    },
+    "rust": {
+        "ext": "rs",
+        "compile": ["rustc", "{file}", "-O", "-o", "{tmp}/prog_rs"],
+        "run": ["{tmp}/prog_rs"]
+    }
+}
+
+
+def run_and_measure(cmd: list[str], env: dict[str, str] | None = None) -> tuple[float, int]:
+    """Ejecuta *cmd* y devuelve (tiempo_en_segundos, memoria_en_kb)."""
+    start_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    start_time = time.perf_counter()
+    subprocess.run(cmd, env=env, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+    elapsed = time.perf_counter() - start_time
+    end_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    mem_kb = max(0, end_usage.ru_maxrss - start_usage.ru_maxrss)
+    return elapsed, mem_kb
+
+
+class BenchmarksCommand(BaseCommand):
+    """Compara el rendimiento de distintos backends."""
+
+    name = "benchmarks"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help=_("Ejecuta benchmarks"))
+        parser.add_argument(
+            "--output",
+            "-o",
+            help=_("Archivo donde guardar el JSON con resultados"),
+        )
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
+        env["PCOBRA_TOML"] = str(Path(tempfile.mkstemp(suffix=".toml")[1]))
+
+        results = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            co_file = Path(tmpdir) / "program.co"
+            co_file.write_text(CODE)
+            for backend, cfg in BACKENDS.items():
+                run_cmd = cfg["run"]
+                src_file = Path(tmpdir) / f"program.{cfg['ext']}"
+                transp_cmd = [
+                    sys.executable,
+                    "-m",
+                    "src.cli.cli",
+                    "compilar",
+                    str(co_file),
+                    "--tipo",
+                    backend,
+                ]
+                try:
+                    out = subprocess.check_output(transp_cmd, env=env, text=True)
+                except subprocess.CalledProcessError:
+                    continue
+                out = re.sub(r"\x1b\[[0-9;]*m", "", out)
+                lines = [l for l in out.splitlines() if not l.startswith("DEBUG:") and not l.startswith("INFO:")]
+                if lines and lines[0].startswith("Código generado"):
+                    lines = lines[1:]
+                out = "\n".join(lines)
+                src_file.write_text(out)
+                if "compile" in cfg:
+                    compile_cmd = [arg.format(file=src_file, tmp=tmpdir) for arg in cfg["compile"]]
+                    try:
+                        subprocess.check_call(compile_cmd)
+                    except Exception:
+                        continue
+                cmd = [arg.format(file=src_file, tmp=tmpdir) for arg in run_cmd]
+                if not shutil.which(cmd[0]) and not os.path.exists(cmd[0]):
+                    continue
+                elapsed, mem = run_and_measure(cmd, env)
+                results.append({"backend": backend, "time": round(elapsed, 4), "memory_kb": mem})
+
+        data = json.dumps(results, indent=2)
+        if args.output:
+            try:
+                Path(args.output).write_text(data)
+                mostrar_info(_("Resultados guardados en {file}").format(file=args.output))
+            except Exception as err:
+                mostrar_error(_("No se pudo escribir el archivo: {err}").format(err=err))
+                return 1
+        else:
+            print(data)
+        return 0

--- a/frontend/docs/benchmarking.rst
+++ b/frontend/docs/benchmarking.rst
@@ -56,7 +56,8 @@ Para más información sobre configuraciones seguras consulta
 Resultados recientes
 --------------------
 
-Los siguientes datos se obtuvieron ejecutando ``scripts/benchmarks/run_benchmarks.py``.
+Los benchmarks pueden ejecutarse con ``cobra benchmarks``. El siguiente
+resumen se obtuvo con ``scripts/benchmarks/run_benchmarks.py``.
 
 .. list-table:: Tiempos y memoria aproximados
    :header-rows: 1

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -189,3 +189,15 @@ Ejemplo:
 .. code-block:: bash
 
    cobra init mi_app
+
+Subcomando ``benchmarks``
+-----------------------
+Compara el rendimiento de los distintos backends y muestra un resumen
+en formato JSON. Opcionalmente puede guardarse en un archivo mediante
+``--output``.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra benchmarks --output resultados.json


### PR DESCRIPTION
## Summary
- add BenchmarksCommand to CLI
- document new subcommand
- update benchmarking guide

## Testing
- `make lint` *(fails: flake8 E501 etc.)*
- `pytest -q` *(fails: 73 failed, 301 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685ec0c66bac83279369910917a7d187