### PR TITLE
Add profile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@ cobra paquete instalar demo.cobra
 cobra docs
 # Crear un ejecutable independiente
 cobra empaquetar --output dist
+# Perfilar un programa y guardar los resultados
+cobra profile programa.co --output salida.prof
 # Iniciar el iddle gráfico (requiere Flet)
 cobra gui
 ```

--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -23,6 +23,7 @@ from .commands.crear_cmd import CrearCommand
 from .commands.init_cmd import InitCommand
 from .commands.container_cmd import ContainerCommand
 from .commands.benchmarks_cmd import BenchmarksCommand
+from .commands.profile_cmd import ProfileCommand
 
 # La configuración de logging solo debe activarse cuando la CLI se ejecuta
 # directamente para evitar modificar la configuración global al importar este
@@ -61,6 +62,7 @@ def main(argv=None):
         FletCommand(),
         ContainerCommand(),
         BenchmarksCommand(),
+        ProfileCommand(),
         PluginsCommand(),
         InteractiveCommand(),
     ]

--- a/backend/src/cli/commands/profile_cmd.py
+++ b/backend/src/cli/commands/profile_cmd.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Comando para perfilar la ejecución de programas Cobra."""
+
+import cProfile
+import io
+import logging
+import os
+import pstats
+
+from .base import BaseCommand
+from .execute_cmd import ExecuteCommand
+from ..i18n import _
+from ..utils.messages import mostrar_error, mostrar_info
+from src.cobra.transpilers import module_map
+from src.core.sandbox import validar_dependencias
+from src.core.interpreter import InterpretadorCobra
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from src.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
+
+
+class ProfileCommand(BaseCommand):
+    """Ejecuta un script Cobra con cProfile."""
+
+    name = "profile"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help=_("Perfila un programa"))
+        parser.add_argument("archivo")
+        parser.add_argument(
+            "--output",
+            "-o",
+            help=_("Archivo .prof para guardar los resultados"),
+        )
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        archivo = args.archivo
+        output = getattr(args, "output", None)
+        depurar = getattr(args, "depurar", False)
+        formatear = getattr(args, "formatear", False)
+        seguro = getattr(args, "seguro", False)
+        extra_validators = getattr(args, "validadores_extra", None)
+
+        if not os.path.exists(archivo):
+            mostrar_error(f"El archivo '{archivo}' no existe")
+            return 1
+
+        try:
+            validar_dependencias("python", module_map.get_toml_map())
+        except (ValueError, FileNotFoundError) as dep_err:
+            mostrar_error(f"Error de dependencias: {dep_err}")
+            return 1
+        if formatear:
+            ExecuteCommand._formatear_codigo(archivo)  # type: ignore[attr-defined]
+        if depurar:
+            logging.getLogger().setLevel(logging.DEBUG)
+        else:
+            logging.getLogger().setLevel(logging.ERROR)
+
+        with open(archivo, "r") as f:
+            codigo = f.read()
+
+        tokens = Lexer(codigo).tokenizar()
+        ast = Parser(tokens).parsear()
+        if seguro:
+            try:
+                validador = construir_cadena(
+                    InterpretadorCobra._cargar_validadores(extra_validators)
+                    if isinstance(extra_validators, str)
+                    else extra_validators
+                )
+                for nodo in ast:
+                    nodo.aceptar(validador)
+            except PrimitivaPeligrosaError as pe:
+                logging.error(f"Primitiva peligrosa: {pe}")
+                mostrar_error(str(pe))
+                return 1
+
+        profiler = cProfile.Profile()
+        try:
+            profiler.enable()
+            InterpretadorCobra(
+                safe_mode=seguro, extra_validators=extra_validators
+            ).ejecutar_ast(ast)
+            profiler.disable()
+            if output:
+                profiler.dump_stats(output)
+                mostrar_info(
+                    _("Resultados de perfil guardados en {file}").format(file=output)
+                )
+            else:
+                s = io.StringIO()
+                stats = pstats.Stats(profiler, stream=s).sort_stats("cumulative")
+                stats.print_stats(10)
+                print(s.getvalue())
+            return 0
+        except Exception as e:
+            logging.error(f"Error ejecutando el script: {e}")
+            mostrar_error(f"Error ejecutando el script: {e}")
+            return 1

--- a/backend/src/tests/test_cli_profile.py
+++ b/backend/src/tests/test_cli_profile.py
@@ -1,0 +1,24 @@
+from io import StringIO
+from src.cli.cli import main
+from src.cobra.transpilers import module_map
+
+
+def test_cli_profile_creates_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: {})
+    archivo = tmp_path / "prog.co"
+    archivo.write_text("imprimir(1)")
+    salida = tmp_path / "out.prof"
+    main(["profile", str(archivo), "--output", str(salida)])
+    assert salida.exists()
+
+
+def test_cli_profile_shows_stats(tmp_path, monkeypatch):
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: {})
+    archivo = tmp_path / "prog2.co"
+    archivo.write_text("imprimir(2)")
+    with StringIO() as buf:
+        from unittest.mock import patch
+        with patch("sys.stdout", buf):
+            main(["profile", str(archivo)])
+        data = buf.getvalue()
+    assert "ncalls" in data and "tottime" in data

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -201,3 +201,15 @@ Ejemplo:
 .. code-block:: bash
 
    cobra benchmarks --output resultados.json
+
+Subcomando ``profile``
+----------------------
+Ejecuta un archivo Cobra bajo ``cProfile``. Muestra en pantalla las
+estadísticas básicas o las guarda en un archivo ``.prof`` mediante
+``--output``.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra profile programa.co --output perfil.prof


### PR DESCRIPTION
## Summary
- add `profile` CLI command for running scripts under cProfile
- document profiling command in README and CLI docs
- include basic tests for the new command

## Testing
- `pytest backend/src/tests/test_cli_profile.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685ec242cfd483279022f104f085e02d