### PR TITLE
Actualiza guía de contribución y RFC de plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,19 @@ Gracias por tu interés en mejorar Cobra. A continuación se describen las pauta
 3. **Información útil**: indica la versión de Cobra, sistema operativo y pasos detallados para reproducir el problema. Incluye el comportamiento esperado y lo que realmente ocurre.
 4. **Etiquetas recomendadas**: usa `bug` para reportes de errores, `enhancement` para mejoras y `question` para dudas. Si se trata de documentación, utiliza `documentation`.
 
+## Convenciones de Estilo
+
+- El codigo debe formatearse con `black` y respetar 88 caracteres por linea.
+- Ejecuta `make lint` para comprobar `flake8`, `mypy` y `bandit`.
+- Usa `make typecheck` para la verificacion de tipos.
+
 ## Pull Requests
 
-1. **Fork y rama**: haz un fork y crea una rama a partir de `main` con el prefijo adecuado (`feature/`, `bugfix/` o `doc/`). Esto permite que las acciones de GitHub etiqueten tu PR automáticamente.
+1. **Fork y rama**: haz un fork y crea una rama a partir de `main` con el prefijo adecuado (`feature/`, `bugfix/` o `doc/`) y una breve descripcion. Esto permite que las acciones de GitHub etiqueten tu PR automáticamente.
 2. **Sincroniza con `main`**: antes de abrir el PR, actualiza tu rama para incorporar los últimos cambios.
 3. **Pruebas y estilo**: ejecuta `make lint` y `make typecheck` para asegurarte de que el código pasa las verificaciones. Añade o ajusta pruebas cuando sea necesario.
 4. **Descripción**: indica el propósito del cambio y referencia issues relacionados usando `#numero`.
-5. **Revisión**: una vez abierto el PR, espera la revisión de los mantenedores y realiza los cambios solicitados.
+5. **Etiquetas de PR**: añade `enhancement`, `bug`, `documentation` u otra etiqueta que describa el cambio.
+6. **Revisión**: una vez abierto el PR, espera la revisión de los mantenedores y realiza los cambios solicitados.
 
 ¡Agradecemos todas las contribuciones!

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Cobra es un lenguaje de programación diseñado en español, enfocado en la crea
 - [CobraHub](frontend/docs/cobrahub.rst)
 - Hitos y Roadmap
 - Contribuciones
+- [Guía de Contribución](CONTRIBUTING.md)
+- [Proponer extensiones](frontend/docs/rfc_plugins.rst)
 - Licencia
 - [Manual de Cobra](MANUAL_COBRA.md)
 
@@ -502,6 +504,9 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
 - Crea una nueva rama (`git checkout -b feature/nueva-caracteristica`).
 - Las ramas que comiencen con `feature/`, `bugfix/` o `doc/` recibirán etiquetas
   automáticas al abrir un pull request.
+- Sigue las convenciones de estilo indicadas en `CONTRIBUTING.md` 
+  (formateo con `black`, longitud máxima de línea 88 y uso de `flake8`, `mypy`
+  y `bandit`).
 - Realiza tus cambios y haz commit (`git commit -m 'Añadir nueva característica'`).
 - Ejecuta `make lint` para verificar el código con *flake8*, *mypy* y *bandit*.
 - Ejecuta `make typecheck` para la verificación estática con *mypy* (y
@@ -510,6 +515,7 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
 - Envía un pull request.
 - Consulta [CONTRIBUTING.md](CONTRIBUTING.md) para más detalles sobre cómo abrir
   issues y preparar pull requests.
+- Para proponer nuevas extensiones consulta [frontend/docs/rfc_plugins.rst](frontend/docs/rfc_plugins.rst).
 
 ## Desarrollo de plugins
 

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -24,6 +24,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    modulos_nativos
    plugins
    plugin_dev
+   rfc_plugins
    ejemplos
    ejemplos_avanzados
    referencia

--- a/frontend/docs/rfc_plugins.rst
+++ b/frontend/docs/rfc_plugins.rst
@@ -1,0 +1,22 @@
+Proceso de propuestas de extensiones
+===================================
+
+Este documento describe el flujo recomendado para sugerir nuevas extensiones
+(*plugins*) para Cobra. Seguir estos pasos permite evaluar de manera ordenada
+las ideas de la comunidad.
+
+1. **Abrir un issue** con la etiqueta ``proposal`` donde se explique brevemente
+   la funcionalidad deseada y su motivación.
+2. **Debate público**: cualquier miembro puede comentar el issue para aportar
+   casos de uso o problemas potenciales.
+3. **Borrador detallado**: si la idea recibe apoyo, prepara un documento con el
+   diseño propuesto. Incluye ejemplos de uso, API prevista y posibles
+   alternativas.
+4. **Revisión**: los mantenedores revisarán el borrador y marcarán el issue
+   como ``accepted`` o ``rejected``. También pueden solicitar ajustes.
+5. **Implementación**: una vez aceptada la propuesta, abre un pull request en
+   una rama ``feature/`` que implemente el plugin siguiendo las guías de
+   contribución.
+
+Seguir este proceso ayuda a mantener la compatibilidad y la calidad del
+ecosistema de plugins de Cobra.


### PR DESCRIPTION
## Summary
- add style guidelines, branch naming and PR labels
- add RFC document for proposing extensions
- link docs from README
- include RFC in docs index

## Testing
- `make lint` *(fails: line too long, unused imports)*
- `make typecheck` *(fails: many mypy errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ec453c248832799ed9cbf6cb4a650