### PR TITLE
Agregar decoradores y async en nodos; soporte Result en Rust

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/js_nodes/clase.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/clase.py
@@ -22,3 +22,12 @@ def visit_clase(self, nodo):
     if self.usa_indentacion:
         self.indentacion -= 1
     self.agregar_linea("}")
+    for metodo in metodos:
+        for decorador in reversed(getattr(metodo, "decoradores", [])):
+            expr = self.obtener_valor(decorador.expresion)
+            self.agregar_linea(
+                f"{nodo.nombre}.prototype.{metodo.nombre} = {expr}({nodo.nombre}.prototype.{metodo.nombre});"
+            )
+    for decorador in reversed(getattr(nodo, "decoradores", [])):
+        expr = self.obtener_valor(decorador.expresion)
+        self.agregar_linea(f"{nodo.nombre} = {expr}({nodo.nombre});")

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/clase.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/clase.py
@@ -1,4 +1,6 @@
 def visit_clase(self, nodo):
+    for decorador in getattr(nodo, "decoradores", []):
+        decorador.aceptar(self)
     metodos = getattr(nodo, "metodos", getattr(nodo, "cuerpo", []))
     bases = f"({', '.join(nodo.bases)})" if getattr(nodo, 'bases', []) else ""
     self.codigo += f"{self.obtener_indentacion()}class {nodo.nombre}{bases}:\n"

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/metodo.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/metodo.py
@@ -1,4 +1,6 @@
 def visit_metodo(self, nodo):
+    for decorador in getattr(nodo, "decoradores", []):
+        decorador.aceptar(self)
     parametros = ", ".join(nodo.parametros)
     asincrona = getattr(nodo, "asincronica", False)
     prefijo = "async def" if asincrona else "def"

--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/throw.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/throw.py
@@ -1,0 +1,6 @@
+from typing import Any
+
+
+def visit_throw(self, nodo: Any) -> None:
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"return Err({valor}.into());")

--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/try_catch.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/try_catch.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+
+def visit_try_catch(self, nodo: Any) -> None:
+    self.agregar_linea("let resultado: Result<(), Box<dyn std::error::Error>> = (|| {")
+    self.indent += 1
+    for inst in nodo.bloque_try:
+        inst.aceptar(self)
+    self.agregar_linea("Ok(())")
+    self.indent -= 1
+    self.agregar_linea("})();")
+    self.agregar_linea("match resultado {")
+    self.indent += 1
+    self.agregar_linea("Ok(_) => (),")
+    self.agregar_linea("Err(e) => {")
+    self.indent += 1
+    if nodo.nombre_excepcion:
+        self.agregar_linea(f"let {nodo.nombre_excepcion} = e;")
+    for inst in nodo.bloque_catch:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("},")
+    self.indent -= 1
+    self.agregar_linea("};")

--- a/backend/src/cobra/transpilers/transpiler/to_rust.py
+++ b/backend/src/cobra/transpilers/transpiler/to_rust.py
@@ -9,6 +9,8 @@ from src.core.ast_nodes import (
     NodoIdentificador,
     NodoAtributo,
     NodoInstancia,
+    NodoThrow,
+    NodoTryCatch,
     NodoAssert,
     NodoDel,
     NodoGlobal,
@@ -37,6 +39,8 @@ from .rust_nodes.romper import visit_romper as _visit_romper
 from .rust_nodes.continuar import visit_continuar as _visit_continuar
 from .rust_nodes.pasar import visit_pasar as _visit_pasar
 from .rust_nodes.switch import visit_switch as _visit_switch
+from .rust_nodes.try_catch import visit_try_catch as _visit_try_catch
+from .rust_nodes.throw import visit_throw as _visit_throw
 
 def visit_assert(self, nodo):
     cond = self.obtener_valor(nodo.condicion)
@@ -140,3 +144,5 @@ TranspiladorRust.visit_nolocal = visit_nolocal
 TranspiladorRust.visit_with = visit_with
 TranspiladorRust.visit_import_desde = visit_import_desde
 TranspiladorRust.visit_switch = _visit_switch
+TranspiladorRust.visit_try_catch = _visit_try_catch
+TranspiladorRust.visit_throw = _visit_throw

--- a/backend/src/tests/test_to_js.py
+++ b/backend/src/tests/test_to_js.py
@@ -10,6 +10,11 @@ from src.core.ast_nodes import (
     NodoYield,
     NodoEsperar,
     NodoValor,
+    NodoDecorador,
+    NodoIdentificador,
+    NodoMetodo,
+    NodoClase,
+    NodoPasar,
     NodoSwitch,
     NodoCase,
     NodoImportDesde,
@@ -144,5 +149,24 @@ def test_export_import():
         "function saluda() {\n"
         "}\n"
         "export { saluda };"
+    )
+    assert resultado == esperado
+
+def test_decoradores_en_clase_y_metodo_js():
+    decor = NodoDecorador(NodoIdentificador("dec"))
+    metodo = NodoMetodo("run", ["a"], [NodoPasar()], asincronica=True)
+    metodo.decoradores = [decor]
+    clase = NodoClase("C", [metodo])
+    clase.decoradores = [decor]
+    t = TranspiladorJavaScript()
+    resultado = t.transpilar([clase])
+    esperado = IMPORTS + (
+        "class C {\n"
+        "async run(a) {\n"
+        ";\n"
+        "}\n"
+        "}\n"
+        "C.prototype.run = dec(C.prototype.run);\n"
+        "C = dec(C);"
     )
     assert resultado == esperado

--- a/backend/src/tests/test_to_python.py
+++ b/backend/src/tests/test_to_python.py
@@ -12,6 +12,7 @@ from src.core.ast_nodes import (
     NodoMetodo,
     NodoClase,
     NodoImprimir,
+    NodoPasar,
 )
 from src.core.ast_nodes import NodoSwitch, NodoCase
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
@@ -169,5 +170,23 @@ def test_transpilador_clase_compleja():
         "class Hija(Base1, Base2):\n"
         "    async def run(self):\n"
         "        await tarea()\n"
+    )
+    assert codigo == esperado
+
+def test_decoradores_en_clase_y_metodo():
+    decor = NodoDecorador(NodoIdentificador("dec"))
+    metodo = NodoMetodo("run", ["self"], [NodoPasar()], asincronica=True)
+    metodo.decoradores = [decor]
+    clase = NodoClase("C", [metodo])
+    clase.decoradores = [decor]
+    codigo = TranspiladorPython().transpilar([clase])
+    esperado = (
+        "import asyncio\n"
+        "from src.core.nativos import *\n"
+        "@dec\n"
+        "class C:\n"
+        "    @dec\n"
+        "    async def run(self):\n"
+        "        pass\n"
     )
     assert codigo == esperado

--- a/backend/src/tests/test_to_rust.py
+++ b/backend/src/tests/test_to_rust.py
@@ -10,6 +10,9 @@ from src.core.ast_nodes import (
     NodoMetodo,
     NodoYield,
     NodoValor,
+    NodoTryCatch,
+    NodoThrow,
+    NodoIdentificador,
     NodoSwitch,
     NodoCase,
 )
@@ -114,5 +117,28 @@ def test_transpilador_switch():
         "        let y = 0;\n"
         "    },\n"
         "}"
+    )
+    assert resultado == esperado
+
+def test_try_catch_result():
+    nodo = NodoTryCatch(
+        [NodoThrow(NodoValor("1"))],
+        "e",
+        [NodoAsignacion("y", NodoIdentificador("e"))],
+    )
+    t = TranspiladorRust()
+    resultado = t.transpilar([nodo])
+    esperado = (
+        "let resultado: Result<(), Box<dyn std::error::Error>> = (|| {\n"
+        "    return Err(1.into());\n"
+        "    Ok(())\n"
+        "})();\n"
+        "match resultado {\n"
+        "    Ok(_) => (),\n"
+        "    Err(e) => {\n"
+        "        let e = e;\n"
+        "        let y = e;\n"
+        "    },\n"
+        "};"
     )
     assert resultado == esperado


### PR DESCRIPTION
## Summary
- permitir decoradores en clases y métodos de Python
- aplicar decoradores en clases y métodos de JavaScript
- manejar try/catch y throw en Rust con `Result`
- pruebas para las nuevas características

## Testing
- `pytest backend/src/tests/test_to_python.py::test_decoradores_en_clase_y_metodo backend/src/tests/test_to_js.py::test_decoradores_en_clase_y_metodo_js backend/src/tests/test_to_rust.py::test_try_catch_result -q`
- `pytest -q` *(fails: 21 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685ecbd6105c8327895bffb79c105fbe