### PR TITLE
Integrar lockfile dentro de cobra.mod

### DIFF
--- a/backend/src/tests/test_cli_cobrahub.py
+++ b/backend/src/tests/test_cli_cobrahub.py
@@ -25,6 +25,10 @@ def test_cli_modulos_buscar(tmp_path, monkeypatch):
     mods_dir = tmp_path / "mods"
     mods_dir.mkdir()
     monkeypatch.setattr(modules_cmd, "MODULES_PATH", str(mods_dir))
+    mod_file = tmp_path / "cobra.mod"
+    mod_file.write_text("lock: {}\n")
+    monkeypatch.setattr(modules_cmd, "MODULE_MAP_PATH", str(mod_file))
+    monkeypatch.setattr(modules_cmd, "LOCK_FILE", str(mod_file))
     with patch("src.cli.cobrahub_client.requests.get") as mock_get, \
             patch("sys.stdout", new_callable=StringIO) as out:
         response = MagicMock()

--- a/cobra.mod
+++ b/cobra.mod
@@ -7,4 +7,4 @@
 #     python: modulo.py
 #     js: modulo.js
 # Actualmente no existen módulos transpilados a registrar.
-{}
+lock: {}


### PR DESCRIPTION
## Summary
- embed module lock info into `cobra.mod`
- update CLI module command to manage the new lock section
- adjust tests expecting lock handling
- isolate CobraHub test from global lock file

## Testing
- `pytest backend/src/tests/test_cli_commands_extra.py::test_cli_modulos_comandos backend/src/tests/test_cli_commands_extra.py::test_cli_modulo_version_invalida backend/src/tests/test_cli_cobrahub.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685ecec1b6ec8327a57e55b8226c294e