### PR TITLE
Agregar pyright al CI y documentación

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install sphinx sphinx-rtd-theme pytest-cov codecov
+          pip install pyright
       - name: Run linters
         run: |
           flake8 backend/src
           mypy backend/src
           bandit -r backend/src
+          pyright backend/src
       - name: Run type checks
         run: make typecheck
       - name: Run tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ Gracias por tu interés en mejorar Cobra. A continuación se describen las pauta
 - El codigo debe formatearse con `black` y respetar 88 caracteres por linea.
 - Ejecuta `make lint` para comprobar `flake8`, `mypy` y `bandit`.
 - Usa `make typecheck` para la verificacion de tipos.
+- Para analisis estatico con `pyright`, instala el paquete y ejecuta
+  `pyright backend/src` (o `make typecheck`).
 
 ## Pull Requests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ RestrictedPython==8.0
 flake8==7.3.0
 mypy==1.16.1
 bandit==1.8.5
+pyright
 pybind11==2.13.6
 python-lsp-server==1.11.0
 packaging==24.0


### PR DESCRIPTION
## Resumen
- ejecutar pyright en el flujo de CI
- instalar pyright como dependencia
- actualizar la guía de contribución para explicar cómo usar pyright

## Testing
- `python -m flake8 backend/src` *(falla: múltiples errores de estilo)*
- `python -m bandit -r backend/src`
- `pyright backend/src` *(falla: 220 errores de tipo)*
- `pytest backend/src/tests/test_cli.py::test_cli_interactive -vv --maxfail=1` *(falla: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_685ed087fa808327a99af5553fc2b39b