### PR TITLE
Add SnakeViz option for profiling

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -180,3 +180,19 @@ var triple = cargar_funcion('libtriple.so', 'triple')
 imprimir(triple(3))
 ```
 
+## 14. Perfilado de programas
+
+Para analizar el rendimiento de un script utiliza `cobra profile`. Puedes guardar
+el resultado en un archivo `.prof` y abrirlo con herramientas como `snakeviz`:
+
+```bash
+cobra profile ejemplo.co --output ejemplo.prof --ui snakeviz
+```
+
+Si no indicas `--ui`, se mostrará un resumen en la consola. Instala `snakeviz`
+con:
+
+```bash
+pip install snakeviz
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ pyright
 pybind11==2.13.6
 python-lsp-server==1.11.0
 packaging==24.0
+snakeviz==2.2.2


### PR DESCRIPTION
## Summary
- extend `cobra profile` command with `--ui` option to open profile result in tools like SnakeViz
- record profiling results and open chosen UI when requested
- add optional `snakeviz` dependency
- document profiling usage in MANUAL_COBRA.md

## Testing
- `flake8 backend/src/cli/commands/profile_cmd.py`
- `pytest -q` *(fails: 73 failed, 309 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685ed1efc2a883278e05454574080826