### PR TITLE
Añadir documentación del Plugin SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,8 @@ A partir de esta versión, la API se genera de forma automática antes de
 cada compilación para mantener la documentación actualizada.
 Para aprender a desarrollar plugins revisa
 [`frontend/docs/plugin_dev.rst`](frontend/docs/plugin_dev.rst).
+Para conocer en detalle la interfaz disponible consulta
+[`frontend/docs/plugin_sdk.rst`](frontend/docs/plugin_sdk.rst).
 ## Hitos y Roadmap
 
 El proyecto avanza en versiones incrementales. A continuacion se listan las tareas previstas para las proximas entregas.

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -24,6 +24,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    modulos_nativos
    plugins
    plugin_dev
+   plugin_sdk
    rfc_plugins
    ejemplos
    ejemplos_avanzados

--- a/frontend/docs/plugin_sdk.rst
+++ b/frontend/docs/plugin_sdk.rst
@@ -1,0 +1,78 @@
+API de PluginInterface
+======================
+
+La clase ``PluginInterface`` define la interfaz mínima que deben implementar los
+plugins externos de la CLI. Cada plugin expone metadatos de identificación y dos
+métodos esenciales para registrar el subcomando y ejecutar la lógica
+correspondiente.
+
+Atributos
+---------
+
+``name``
+    Nombre del subcomando.
+``version``
+    Versión del plugin.
+``author``
+    Autor o mantenedor.
+``description``
+    Descripción breve que aparece en ``cobra plugins``.
+
+Métodos
+-------
+
+``register_subparser(subparsers)``
+    Recibe el objeto ``argparse`` y debe añadir el subcomando junto con sus
+    opciones.
+
+``run(args)``
+    Ejecuta la funcionalidad principal del plugin.
+
+Ejemplo de implementación
+-------------------------
+
+.. code-block:: python
+
+   from src.cli.plugin_loader import PluginCommand
+
+
+   class HolaCommand(PluginCommand):
+       name = "hola"
+       version = "1.0"
+       author = "Tu Nombre"
+       description = "Muestra un saludo"
+
+       def register_subparser(self, subparsers):
+           parser = subparsers.add_parser(self.name, help=self.description)
+           parser.set_defaults(cmd=self)
+
+       def run(self, args):
+           print("¡Hola desde un plugin!")
+
+Registro a través de ``entry_points``
+------------------------------------
+
+Para que Cobra cargue el plugin se declara un ``entry_point`` en ``setup.py``:
+
+.. code-block:: python
+
+   entry_points={
+       'cobra.plugins': [
+           'hola = mi_plugin.hola:HolaCommand',
+       ],
+   }
+
+Gestión de versiones
+--------------------
+
+Al instanciarse, cada plugin registra su nombre y versión en
+``plugin_registry``. Puedes consultarlo con:
+
+.. code-block:: python
+
+   from src.cli.plugin_registry import obtener_registro
+
+   print(obtener_registro())  # {'hola': '1.0'}
+
+Si actualizas el paquete con una nueva versión, el registro se actualiza de
+forma automática cuando Cobra vuelve a cargar el plugin.

--- a/frontend/docs/plugins.rst
+++ b/frontend/docs/plugins.rst
@@ -60,3 +60,6 @@ A continuación se muestra cómo crear un plugin sencillo utilizando
 Con estos pasos se crea un plugin funcional que se integra de forma automática
 con el sistema de comandos de Cobra.
 
+Para una descripción completa de la interfaz disponible consulta
+:doc:`plugin_sdk`.
+


### PR DESCRIPTION
## Summary
- crear `plugin_sdk.rst` con la API de `PluginInterface`
- enlazar el nuevo documento desde `README.md` y `plugins.rst`
- incluirlo en el índice de la documentación

## Testing
- `make lint` *(fails: line length and other issues)*
- `make typecheck` *(fails: mypy errors)*
- `pytest -q backend/src/tests/test_plugin_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_685ed3b16b148327bf55c299e0561538