### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   bump-version:
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -31,6 +33,8 @@ jobs:
 
   build-and-publish:
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/Alphonsus411/pCobra/security/code-scanning/7](https://github.com/Alphonsus411/pCobra/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimal permissions required for each job. For the `bump-version` job, write permissions to `contents` are needed to commit and push changes. For the `build-and-publish` job, read permissions to `contents` are sufficient, as it primarily involves reading files and publishing to PyPI.

The `permissions` block will be added at the job level to ensure each job has the least privileges required for its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
