### PR TITLE
Elimina la palabra clave 'class' en el lexer

### DIFF
--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -33,7 +33,6 @@ class TipoToken:
     LISTA = 'LISTA'
     RBRACE = 'RBRACE'
     DEF = 'DEF'
-    CLASS = 'CLASS'
     IN = 'IN'
     LBRACE = 'LBRACE'
     FOR = 'FOR'
@@ -150,7 +149,6 @@ class Lexer:
             (TipoToken.SWITCH, r'\b(switch|segun)\b'),
             (TipoToken.CASE, r'\b(case|caso)\b'),
             (TipoToken.CLASE, r'\bclase\b'),
-            (TipoToken.CLASS, r'\bclass\b'),
             (TipoToken.IN, r'\bin\b'),  # Define el token 'in'
             (TipoToken.HOLOBIT, r'\bholobit\b'),
             (TipoToken.PROYECTAR, r'\bproyectar\b'),

--- a/backend/src/tests/test_lexer.py
+++ b/backend/src/tests/test_lexer.py
@@ -90,3 +90,29 @@ def test_lexer_error_posicion():
     assert err.linea == 1
     assert err.columna == 9
 
+
+def test_keyword_clase_recognized():
+    codigo = "clase Persona:"
+    lexer = Lexer(codigo)
+    tokens = lexer.analizar_token()
+
+    assert [(t.tipo, t.valor) for t in tokens] == [
+        (TipoToken.CLASE, "clase"),
+        (TipoToken.IDENTIFICADOR, "Persona"),
+        (TipoToken.DOSPUNTOS, ":"),
+        (TipoToken.EOF, None),
+    ]
+
+
+def test_class_not_keyword_anymore():
+    codigo = "class Persona:"
+    lexer = Lexer(codigo)
+    tokens = lexer.analizar_token()
+
+    assert [(t.tipo, t.valor) for t in tokens] == [
+        (TipoToken.IDENTIFICADOR, "class"),
+        (TipoToken.IDENTIFICADOR, "Persona"),
+        (TipoToken.DOSPUNTOS, ":"),
+        (TipoToken.EOF, None),
+    ]
+


### PR DESCRIPTION
## Resumen
- quita `CLASS` de `TipoToken`
- elimina el patrón de tokenización de `class`
- añade pruebas de que `clase` se reconoce como palabra clave y `class` no

## Testing
- `pytest backend/src/tests/test_lexer.py::test_keyword_clase_recognized -q`
- `pytest backend/src/tests/test_lexer.py::test_class_not_keyword_anymore -q`
- `pytest backend/src/tests/test_lexer.py -q`
- `pytest backend/src/tests/test_nuevos_tokens.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685fa49eb72483278a051cc6dce73bd3