### PR TITLE
Fix FUNC token and add lexer test

### DIFF
--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -134,7 +134,6 @@ class Lexer:
 
         especificacion_tokens = [
             (TipoToken.VAR, r'\bvar\b'),
-            (TipoToken.FUNC, r'\bfunc\b'),
             (TipoToken.FUNC, r'\b(func|definir)\b'),
             (TipoToken.REL, r'\brel\b'),
             (TipoToken.SI, r'\bsi\b'),

--- a/backend/src/tests/test_lexer.py
+++ b/backend/src/tests/test_lexer.py
@@ -116,3 +116,15 @@ def test_class_not_keyword_anymore():
         (TipoToken.EOF, None),
     ]
 
+
+def test_lexer_func_and_definir_tokens():
+    """Verifica que 'func' y 'definir' generan el mismo token FUNC"""
+    codigo = "func definir"
+    tokens = Lexer(codigo).analizar_token()
+
+    assert [(t.tipo, t.valor) for t in tokens] == [
+        (TipoToken.FUNC, "func"),
+        (TipoToken.FUNC, "definir"),
+        (TipoToken.EOF, None),
+    ]
+


### PR DESCRIPTION
## Summary
- unify FUNC token regex so `func` and `definir` are matched together
- add regression test checking `func` and `definir` tokens

## Testing
- `PYTHONPATH=backend:. pytest backend/src/tests/test_lexer.py::test_lexer_func_and_definir_tokens -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa628d7388327a3cdefd44e5245df