### PR TITLE
Fix DOSPUNTOS constant spelling

### DIFF
--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -36,7 +36,7 @@ class TipoToken:
     IN = 'IN'
     LBRACE = 'LBRACE'
     FOR = 'FOR'
-    DOSPUNTOS = 'DOS PUNTOS'
+    DOSPUNTOS = 'DOSPUNTOS'
     VAR = 'VAR'
     FUNC = 'FUNC'
     REL = 'REL'


### PR DESCRIPTION
## Summary
- correct `DOSPUNTOS` token string in lexer
- verified parser and lexer tests

## Testing
- `PYTHONPATH=. pytest backend/src/tests/test_lexer.py backend/src/tests/test_lexer2.py backend/src/tests/test_lexer_errors.py backend/src/tests/test_lexer_errors_extra.py backend/src/tests/test_parser.py backend/src/tests/test_parser2.py backend/src/tests/test_parser3.py backend/src/tests/test_parser4.py backend/src/tests/test_parser5.py backend/src/tests/test_parser_clase.py backend/src/tests/test_parser_decorador.py backend/src/tests/test_parser_errors_extra.py backend/src/tests/test_parser_factories.py backend/src/tests/test_parser_holobit.py backend/src/tests/test_parser_nuevos.py backend/src/tests/test_parser_switch.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa894b5e883279f5b4353e2581b2e