### PR TITLE
Add lexer error subclass checks

### DIFF
--- a/backend/src/tests/test_lexer_errors_extra.py
+++ b/backend/src/tests/test_lexer_errors_extra.py
@@ -1,12 +1,19 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer, LexerError
+from src.cobra.lexico.lexer import (
+    Lexer,
+    LexerError,
+    InvalidTokenError,
+    UnclosedStringError,
+)
 
 
 def test_unclosed_string():
     codigo = "'hola"
     lexer = Lexer(codigo)
-    with pytest.raises(LexerError):
+    with pytest.raises(LexerError) as exc:
         lexer.tokenizar()
+    assert isinstance(exc.value, UnclosedStringError)
+    assert "Cadena sin cerrar en linea 1, columna 1" in str(exc.value)
 
 
 def test_multiple_decimal_points():
@@ -19,5 +26,7 @@ def test_multiple_decimal_points():
 def test_invalid_symbol():
     codigo = "var x = €"
     lexer = Lexer(codigo)
-    with pytest.raises(LexerError):
+    with pytest.raises(LexerError) as exc:
         lexer.tokenizar()
+    assert isinstance(exc.value, InvalidTokenError)
+    assert "Token no reconocido: '€' en linea 1, columna 9" in str(exc.value)


### PR DESCRIPTION
## Summary
- update tests to validate `InvalidTokenError` and `UnclosedStringError`
- keep original `LexerError` assertions while checking subclasses

## Testing
- `pytest backend/src/tests/test_lexer_errors.py backend/src/tests/test_lexer_errors_extra.py::test_unclosed_string backend/src/tests/test_lexer_errors_extra.py::test_invalid_symbol -q`

------
https://chatgpt.com/codex/tasks/task_e_685fabb8d7c88327b0f446cd852acf9d