### PR TITLE
Actualización de versión a 4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## v4.2 - 2025-06-27
-- Paquete actualizado a la versión 4.2.
+## v4.3 - 2025-06-28 - actualizacion de version
+- Paquete actualizado a la versión 4.3.
 - Documentación y kernel reflejan la nueva versión.
-- Prueba de plugins ajustada a "dummy 4.2".
+- Prueba de plugins ajustada a "dummy 4.3".
 
 ## v3.0 - 2025-06-27
 - Paquete actualizado a la versión 3.0.

--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -1,6 +1,6 @@
 # Manual del Lenguaje Cobra
 
-Versión 4.2
+Versión 4.3
 
 Este manual presenta en español los conceptos básicos para programar en Cobra. Se organiza en tareas que puedes seguir paso a paso.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![codecov](https://codecov.io/gh/Alphonsus411/pCobra/branch/main/graph/badge.svg)](https://codecov.io/gh/Alphonsus411/pCobra)
 
 
-Versión 4.2
+Versión 4.3
 
 Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
@@ -564,7 +564,7 @@ class HolaCommand(PluginCommand):
 ```
 ## Historial de Cambios
 
-- Versión 4.2: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
+- Versión 4.3: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
 
 # Licencia
 

--- a/backend/src/jupyter_kernel/__init__.py
+++ b/backend/src/jupyter_kernel/__init__.py
@@ -16,9 +16,9 @@ def install(user=True):
 
 class CobraKernel(Kernel):
     implementation = "Cobra"
-    implementation_version = "4.2"
+    implementation_version = "4.3"
     language = "cobra"
-    language_version = "4.2"
+    language_version = "4.3"
     language_info = {
         "name": "cobra",
         "mimetype": "text/plain",

--- a/backend/src/tests/test_cli_plugins_cmd.py
+++ b/backend/src/tests/test_cli_plugins_cmd.py
@@ -8,7 +8,7 @@ from src.cli.plugin_loader import PluginCommand
 
 class DummyPlugin(PluginCommand):
     name = "dummy"
-    version = "4.2"
+    version = "4.3"
 
     def register_subparser(self, subparsers):
         pass
@@ -38,7 +38,7 @@ def test_cli_plugins_muestra_registro():
     with patch("src.cli.plugin_loader.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["plugins"])
-    assert "dummy 4.2" in out.getvalue().strip()
+    assert "dummy 4.3" in out.getvalue().strip()
 
 
 def test_cli_plugin_ejemplo_hola():

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -7,10 +7,10 @@ Avances del lenguaje Cobra
 - **Gestión de memoria automatizada**: Cobra incluye un sistema de manejo de memoria optimizado que se ajusta automáticamente utilizando algoritmos genéticos.
 - **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX.
 - **Pruebas unitarias**: Se han creado pruebas para validar el correcto funcionamiento del lexer y el parser.
-- **Versión 4.2**: Actualización de la documentación y configuración del proyecto.
-- **Versión 4.2**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
+- **Versión 4.3**: Actualización de la documentación y configuración del proyecto.
+- **Versión 4.3**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
 
-Versión 4.2
+Versión 4.3
 -----------
 Se añade el archivo ``pcobra.toml`` para definir el mapeo de módulos en formato TOML. Su estructura es la siguiente:
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cobra-lenguaje',
-    version='4.2',
+    version='4.3',
     author='Adolfo González Hernández',
     author_email='adolfogonzal@gmail.com',
     description='Un lenguaje de programación en español para simulaciones y más.',


### PR DESCRIPTION
## Resumen
- se reemplazó la referencia de la versión 4.2 por 4.3 en toda la documentación y código
- se actualizó `CHANGELOG.md` con la entrada `v4.3`

## Testing
- `pytest -q` *(falló: 98 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685fafe7a4748327b442e657be3880ab