### PR TITLE
Add MENORQUE token support

### DIFF
--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -65,6 +65,7 @@ class TipoToken:
     MULT = 'MULT'
     DIV = 'DIV'
     MAYORQUE = 'MAYORQUE'
+    MENORQUE = 'MENORQUE'
     MAYORIGUAL = 'MAYORIGUAL'
     MENORIGUAL = 'MENORIGUAL'
     IGUAL = 'IGUAL'
@@ -192,6 +193,7 @@ class Lexer:
             (TipoToken.MULT, r'\*'),
             (TipoToken.DIV, r'/'),
             (TipoToken.MAYORQUE, r'>'),
+            (TipoToken.MENORQUE, r'<'),
             (TipoToken.LPAREN, r'\('),
             (TipoToken.RPAREN, r'\)'),
             (TipoToken.LBRACE, r'\{'),

--- a/backend/src/cobra/parser/parser.py
+++ b/backend/src/cobra/parser/parser.py
@@ -853,6 +853,7 @@ class Parser:
         while self.token_actual().tipo in [
             TipoToken.MAYORQUE,
             TipoToken.MAYORIGUAL,
+            TipoToken.MENORQUE,
             TipoToken.MENORIGUAL,
         ]:
             operador = self.token_actual()

--- a/backend/src/core/interpreter.py
+++ b/backend/src/core/interpreter.py
@@ -294,6 +294,8 @@ class InterpretadorCobra:
                 return izquierda % derecha
             elif tipo == TipoToken.MAYORQUE:
                 return izquierda > derecha
+            elif tipo == TipoToken.MENORQUE:
+                return izquierda < derecha
             elif tipo == TipoToken.MAYORIGUAL:
                 return izquierda >= derecha
             elif tipo == TipoToken.MENORIGUAL:

--- a/backend/src/core/optimizations/constant_folder.py
+++ b/backend/src/core/optimizations/constant_folder.py
@@ -95,6 +95,8 @@ class _ConstantFolder(NodeVisitor):
             return izq % der
         if token.tipo == TipoToken.MAYORQUE:
             return izq > der
+        if token.tipo == TipoToken.MENORQUE:
+            return izq < der
         if token.tipo == TipoToken.MAYORIGUAL:
             return izq >= der
         if token.tipo == TipoToken.MENORIGUAL:

--- a/backend/src/tests/test_operadores.py
+++ b/backend/src/tests/test_operadores.py
@@ -1,7 +1,7 @@
 import pytest
 from src.cobra.lexico.lexer import Lexer, Token, TipoToken
 from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoOperacionBinaria, NodoOperacionUnaria
+from backend.src.core.ast_nodes import NodoOperacionBinaria, NodoOperacionUnaria
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 from src.core.interpreter import InterpretadorCobra
@@ -21,6 +21,18 @@ def test_lexer_nuevos_operadores():
         TipoToken.MENORIGUAL, TipoToken.ENTERO,
         TipoToken.MOD, TipoToken.ENTERO,
     ]
+
+
+def test_menorque_operador():
+    lexer = Lexer("1 < 2")
+    tokens = lexer.tokenizar()
+    tipos = [t.tipo for t in tokens[:-1]]
+    assert tipos == [TipoToken.ENTERO, TipoToken.MENORQUE, TipoToken.ENTERO]
+
+    parser = Parser(tokens)
+    ast = parser.parsear()[0]
+    assert isinstance(ast, NodoOperacionBinaria)
+    assert ast.operador.tipo == TipoToken.MENORQUE
 
 
 def test_parser_precedencia_operadores():


### PR DESCRIPTION
## Summary
- recognize `<` operator with new `TipoToken.MENORQUE`
- allow parsing of `<` in comparison expressions
- evaluate `<` in interpreter and constant folding
- test lexer and parser behavior for `<`

## Testing
- `PYTHONPATH=. pytest backend/src/tests/test_operadores.py::test_lexer_nuevos_operadores -q`
- `PYTHONPATH=. pytest backend/src/tests/test_operadores.py::test_menorque_operador -q`

------
https://chatgpt.com/codex/tasks/task_e_685fb2d319a48327931d2a8a6a247605