### PR TITLE
Manejo de tokens inválidos en holobit

### DIFF
--- a/backend/src/cobra/parser/parser.py
+++ b/backend/src/cobra/parser/parser.py
@@ -371,8 +371,14 @@ class Parser:
         while self.token_actual().tipo != TipoToken.RBRACKET:
             if self.token_actual().tipo in [TipoToken.FLOTANTE, TipoToken.ENTERO]:
                 valores.append(self.expresion())
-            if self.token_actual().tipo == TipoToken.COMA:
+            elif self.token_actual().tipo == TipoToken.COMA:
                 self.comer(TipoToken.COMA)
+            else:
+                token_invalido = self.token_actual()
+                self.avanzar()
+                raise SyntaxError(
+                    f"Token inesperado en declaracion_holobit: {token_invalido.tipo}"
+                )
         self.comer(TipoToken.RBRACKET)
         self.comer(TipoToken.RPAREN)
         return NodoHolobit(valores=valores)

--- a/backend/src/tests/test_parser_holobit.py
+++ b/backend/src/tests/test_parser_holobit.py
@@ -1,6 +1,7 @@
 from src.cobra.lexico.lexer import Token, TipoToken
 from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoHolobit
+from backend.src.core.ast_nodes import NodoHolobit
+import pytest
 
 
 def test_parser_holobit():
@@ -26,4 +27,22 @@ def test_parser_holobit():
     assert arbol[0].valores[0].valor == 0.8, "El primer valor del holobit debe ser 0.8"
     assert arbol[0].valores[1].valor == -0.5, "El segundo valor del holobit debe ser -0.5"
     assert arbol[0].valores[2].valor == 1.2, "El tercer valor del holobit debe ser 1.2"
+
+
+def test_parser_holobit_invalido():
+    tokens = [
+        Token(TipoToken.HOLOBIT, 'holobit'),
+        Token(TipoToken.LPAREN, '('),
+        Token(TipoToken.LBRACKET, '['),
+        Token(TipoToken.ENTERO, 1),
+        Token(TipoToken.COMA, ','),
+        Token(TipoToken.CADENA, 'error'),  # Token no permitido
+        Token(TipoToken.RBRACKET, ']'),
+        Token(TipoToken.RPAREN, ')'),
+        Token(TipoToken.EOF, None)
+    ]
+
+    parser = Parser(tokens)
+    with pytest.raises(SyntaxError):
+        parser.parsear()
 


### PR DESCRIPTION
## Summary
- detect unexpected tokens inside `declaracion_holobit`
- raise `SyntaxError` and advance token when encountering invalid tokens
- add regression test for malformed holobit
- adjust imports in holobit parser tests

## Testing
- `PYTHONPATH=$PWD:$PWD/backend/src pytest -q backend/src/tests/test_parser_holobit.py`

------
https://chatgpt.com/codex/tasks/task_e_685fbb703e4883278e4c2bb271105bda