### PR TITLE
Add parser tests

### DIFF
--- a/backend/src/tests/test_parser_condicional_anidado.py
+++ b/backend/src/tests/test_parser_condicional_anidado.py
@@ -1,0 +1,21 @@
+import pytest
+from backend.src.cobra.lexico.lexer import Lexer
+from backend.src.cobra.parser.parser import Parser
+from backend.src.core.ast_nodes import NodoCondicional
+
+
+def test_parser_condicional_si_en_sino():
+    codigo = '''
+    si x > 0:
+        imprimir(x)
+    sino:
+        si x < 0:
+            imprimir(x)
+        fin
+    fin
+    '''
+    tokens = Lexer(codigo).analizar_token()
+    ast = Parser(tokens).parsear()
+
+    assert isinstance(ast[0], NodoCondicional)
+    assert isinstance(ast[0].bloque_sino[0], NodoCondicional)

--- a/backend/src/tests/test_parser_errors_extra.py
+++ b/backend/src/tests/test_parser_errors_extra.py
@@ -1,6 +1,6 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
+from backend.src.cobra.lexico.lexer import Lexer
+from backend.src.cobra.parser.parser import Parser
 
 
 def parse(code: str):
@@ -22,5 +22,21 @@ def test_desde_without_import():
 
 def test_unclosed_macro():
     codigo = "macro m { var x = 1 "
+    with pytest.raises(SyntaxError):
+        parse(codigo).parsear()
+
+def test_condicional_sino_sin_fin():
+    codigo = """
+    si x > 0:
+        imprimir(x)
+    sino:
+        imprimir(x)
+    """
+    with pytest.raises(SyntaxError):
+        parse(codigo).parsear()
+
+
+def test_macro_llaves_desbalanceadas():
+    codigo = "macro m { var x = 1 }}"
     with pytest.raises(SyntaxError):
         parse(codigo).parsear()


### PR DESCRIPTION
## Summary
- add nested conditional parser test
- add tests for parser errors on missing `fin` and macro with unbalanced braces

## Testing
- `PYTHONPATH=. pytest backend/src/tests/test_parser_condicional_anidado.py::test_parser_condicional_si_en_sino -q`
- `PYTHONPATH=. pytest backend/src/tests/test_parser_errors_extra.py::test_condicional_sino_sin_fin -q`
- `PYTHONPATH=. pytest backend/src/tests/test_parser_errors_extra.py::test_macro_llaves_desbalanceadas -q`


------
https://chatgpt.com/codex/tasks/task_e_685fbf1ddb00832788761773b8da3bf6