### PR TITLE
Use Enum for token types

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,15 @@
+import importlib
+import sys
+from pathlib import Path
+
+path = Path(__file__).resolve().parent / 'src'
+if str(path) not in sys.path:
+    sys.path.insert(0, str(path))
+
+src_mod = importlib.import_module('src')
+sys.modules[__name__ + '.src'] = src_mod
+# Propagar submódulos principales
+for sub in ['cli', 'cobra', 'core', 'ia', 'jupyter_kernel', 'tests']:
+    name = __name__ + '.src.' + sub
+    if 'src.' + sub in sys.modules:
+        sys.modules[name] = sys.modules['src.' + sub]

--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+from enum import Enum
 
 
 class LexerError(Exception):
@@ -25,7 +26,7 @@ class UnclosedStringError(LexerError):
     pass
 
 
-class TipoToken:
+class TipoToken(Enum):
     DIVIDIR = 'DIVIDIR'
     MULTIPLICAR = 'MULTIPLICAR'
     CLASE = 'CLASE'


### PR DESCRIPTION
## Summary
- switch `TipoToken` to an `Enum`
- provide `backend/__init__` so imports of `backend.src` work in tests

## Testing
- `pytest backend/src/tests/test_lexer.py -q`
- `pytest backend/src/tests -q` *(fails: ModuleNotFoundError: yaml, requests, holobit_sdk)*

------
https://chatgpt.com/codex/tasks/task_e_685fc262e3248327b67bfdcb6a27d07a