### PR TITLE
Add type checking for interpreter operations

### DIFF
--- a/backend/src/core/interpreter.py
+++ b/backend/src/core/interpreter.py
@@ -4,6 +4,13 @@ import os
 
 from backend.src.cobra.lexico.lexer import Token, TipoToken, Lexer
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from src.core.type_utils import (
+    verificar_sumables,
+    verificar_numeros,
+    verificar_comparables,
+    verificar_booleanos,
+    verificar_booleano,
+)
 from backend.src.core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
@@ -283,38 +290,50 @@ class InterpretadorCobra:
             derecha = self.evaluar_expresion(expresion.derecha)
             tipo = expresion.operador.tipo
             if tipo == TipoToken.SUMA:
+                verificar_sumables(izquierda, derecha)
                 return izquierda + derecha
             elif tipo == TipoToken.RESTA:
+                verificar_numeros(izquierda, derecha, '-')
                 return izquierda - derecha
             elif tipo == TipoToken.MULT:
+                verificar_numeros(izquierda, derecha, '*')
                 return izquierda * derecha
             elif tipo == TipoToken.DIV:
+                verificar_numeros(izquierda, derecha, '/')
                 return izquierda / derecha
             elif tipo == TipoToken.MOD:
+                verificar_numeros(izquierda, derecha, '%')
                 return izquierda % derecha
             elif tipo == TipoToken.MAYORQUE:
+                verificar_comparables(izquierda, derecha, '>')
                 return izquierda > derecha
             elif tipo == TipoToken.MENORQUE:
+                verificar_comparables(izquierda, derecha, '<')
                 return izquierda < derecha
             elif tipo == TipoToken.MAYORIGUAL:
+                verificar_comparables(izquierda, derecha, '>=')
                 return izquierda >= derecha
             elif tipo == TipoToken.MENORIGUAL:
+                verificar_comparables(izquierda, derecha, '<=')
                 return izquierda <= derecha
             elif tipo == TipoToken.IGUAL:
                 return izquierda == derecha
             elif tipo == TipoToken.DIFERENTE:
                 return izquierda != derecha
             elif tipo == TipoToken.AND:
-                return bool(izquierda) and bool(derecha)
+                verificar_booleanos(izquierda, derecha, '&&')
+                return izquierda and derecha
             elif tipo == TipoToken.OR:
-                return bool(izquierda) or bool(derecha)
+                verificar_booleanos(izquierda, derecha, '||')
+                return izquierda or derecha
             else:
                 raise ValueError(f"Operador no soportado: {tipo}")
         elif isinstance(expresion, NodoOperacionUnaria):
             valor = self.evaluar_expresion(expresion.operando)
             tipo = expresion.operador.tipo
             if tipo == TipoToken.NOT:
-                return not bool(valor)
+                verificar_booleano(valor, '!')
+                return not valor
             else:
                 raise ValueError(f"Operador unario no soportado: {tipo}")
         elif isinstance(expresion, NodoLlamadaMetodo):

--- a/backend/src/core/type_utils.py
+++ b/backend/src/core/type_utils.py
@@ -1,0 +1,45 @@
+# coding: utf-8
+"""Funciones auxiliares para verificacion de tipos en operaciones."""
+
+from typing import Any
+
+
+def verificar_sumables(a: Any, b: Any) -> None:
+    """Asegura que ``a`` y ``b`` se puedan sumar."""
+    if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+        return
+    if isinstance(a, str) and isinstance(b, str):
+        return
+    raise TypeError(
+        f"No se puede sumar valores de tipos {type(a).__name__} y {type(b).__name__}"
+    )
+
+
+def verificar_numeros(a: Any, b: Any, operador: str) -> None:
+    """Valida que ambos operandos sean num\xc3\xa9ricos."""
+    if not isinstance(a, (int, float)) or not isinstance(b, (int, float)):
+        raise TypeError(f"Operaci\xc3\xb3n '{operador}' requiere operandos num\xc3\xa9ricos")
+
+
+def verificar_comparables(a: Any, b: Any, operador: str) -> None:
+    """Valida que los operandos sean comparables."""
+    if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+        return
+    if type(a) is type(b):
+        return
+    raise TypeError(
+        f"Operaci\xc3\xb3n '{operador}' requiere operandos comparables"
+    )
+
+
+def verificar_booleanos(a: Any, b: Any, operador: str) -> None:
+    """Valida que ambos operandos sean booleanos."""
+    if not isinstance(a, bool) or not isinstance(b, bool):
+        raise TypeError(f"Operaci\xc3\xb3n l\xc3\xb3gica '{operador}' requiere booleanos")
+
+
+def verificar_booleano(a: Any, operador: str) -> None:
+    """Valida que el operando sea booleano."""
+    if not isinstance(a, bool):
+        raise TypeError(f"Operaci\xc3\xb3n l\xc3\xb3gica '{operador}' requiere booleano")
+

--- a/backend/src/tests/test_type_checks.py
+++ b/backend/src/tests/test_type_checks.py
@@ -1,0 +1,29 @@
+import pytest
+from backend.src.core.interpreter import InterpretadorCobra
+from backend.src.cobra.lexico.lexer import Token, TipoToken
+from backend.src.core.ast_nodes import (
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoValor,
+)
+
+
+def test_suma_tipos_incompatibles():
+    inter = InterpretadorCobra()
+    expr = NodoOperacionBinaria(NodoValor(1), Token(TipoToken.SUMA, '+'), NodoValor('a'))
+    with pytest.raises(TypeError, match='No se puede sumar'):
+        inter.evaluar_expresion(expr)
+
+
+def test_and_tipos_incompatibles():
+    inter = InterpretadorCobra()
+    expr = NodoOperacionBinaria(NodoValor(1), Token(TipoToken.AND, '&&'), NodoValor(True))
+    with pytest.raises(TypeError, match='requiere booleanos'):
+        inter.evaluar_expresion(expr)
+
+
+def test_not_tipo_incompatible():
+    inter = InterpretadorCobra()
+    expr = NodoOperacionUnaria(Token(TipoToken.NOT, '!'), NodoValor(1))
+    with pytest.raises(TypeError, match='requiere booleano'):
+        inter.evaluar_expresion(expr)


### PR DESCRIPTION
## Summary
- add helper utilities for operand type verification
- enforce checks in the interpreter before arithmetic and logical operations
- raise `TypeError` when mismatched types are used
- cover new behaviour with unit tests

## Testing
- `pytest backend/src/tests/test_type_checks.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685fc6d780c48327a55e6afbb1c757e9