### PR TITLE
Añadir pruebas básicas de lexer y parser

### DIFF
--- a/backend/src/tests/test_error_handling.py
+++ b/backend/src/tests/test_error_handling.py
@@ -1,0 +1,20 @@
+import pytest
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+
+
+def parsear_codigo(codigo: str):
+    tokens = Lexer(codigo).analizar_token()
+    return Parser(tokens)
+
+
+def test_asignacion_sin_identificador():
+    codigo = "var = 5"
+    with pytest.raises(SyntaxError):
+        parsear_codigo(codigo).parsear()
+
+
+def test_condicional_sin_dospuntos():
+    codigo = "si x > 0 imprimir(x) fin"
+    with pytest.raises(SyntaxError):
+        parsear_codigo(codigo).parsear()

--- a/backend/src/tests/test_lexer_basics.py
+++ b/backend/src/tests/test_lexer_basics.py
@@ -1,0 +1,22 @@
+import pytest
+from src.cobra.lexico.lexer import Lexer, TipoToken, LexerError
+
+
+def test_simple_assignment_tokens():
+    codigo = "var x = 42"
+    tokens = Lexer(codigo).analizar_token()
+    tipos_valores = [(t.tipo, t.valor) for t in tokens]
+    assert tipos_valores == [
+        (TipoToken.VAR, "var"),
+        (TipoToken.IDENTIFICADOR, "x"),
+        (TipoToken.ASIGNAR, "="),
+        (TipoToken.ENTERO, 42),
+        (TipoToken.EOF, None),
+    ]
+
+
+def test_invalid_symbol_raises_error():
+    codigo = "var x = €"
+    lexer = Lexer(codigo)
+    with pytest.raises(LexerError):
+        lexer.analizar_token()

--- a/backend/src/tests/test_parser_ast.py
+++ b/backend/src/tests/test_parser_ast.py
@@ -1,0 +1,15 @@
+from backend.src.cobra.lexico.lexer import Lexer
+from backend.src.cobra.parser.parser import Parser
+from backend.src.core.ast_nodes import NodoAsignacion, NodoValor
+
+
+def test_parser_generates_ast_for_assignment():
+    codigo = "var x = 5"
+    tokens = Lexer(codigo).analizar_token()
+    ast = Parser(tokens).parsear()
+    assert len(ast) == 1
+    nodo = ast[0]
+    assert isinstance(nodo, NodoAsignacion)
+    assert nodo.variable == "x"
+    assert isinstance(nodo.expresion, NodoValor)
+    assert nodo.expresion.valor == 5


### PR DESCRIPTION
## Resumen
- se añaden pruebas nuevas en **backend/src/tests**
- `test_lexer_basics.py` comprueba la tokenización simple y errores del lexer
- `test_parser_ast.py` valida el AST de una asignación sencilla
- `test_error_handling.py` verifica `SyntaxError` en entradas incorrectas

## Testing
- `pytest backend/src/tests/test_lexer_basics.py backend/src/tests/test_parser_ast.py backend/src/tests/test_error_handling.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd37132748327aee9f07a7a71ec80