### PR TITLE
Add black check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           pip install pyright
       - name: Run linters
         run: |
+          black --check backend/src
           flake8 backend/src
           mypy backend/src
           bandit -r backend/src


### PR DESCRIPTION
## Summary
- run `black --check` alongside other lint commands

## Testing
- `black --check backend/src` *(fails: 195 files would be reformatted)*
- `flake8 backend/src` *(fails with E501 errors)*
- `mypy backend/src` *(fails with typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fd5d433188327b7795af9ad9be5e7