### PR TITLE
Fix constant-folder import and add dead-code tests

### DIFF
--- a/backend/src/core/optimizations/constant_folder.py
+++ b/backend/src/core/optimizations/constant_folder.py
@@ -16,7 +16,7 @@ from ..ast_nodes import (
     NodoMetodo,
     NodoRetorno,
 )
-from backend.src.cobra.lexico.lexer import TipoToken, Token
+from src.cobra.lexico.lexer import TipoToken, Token
 
 
 class _ConstantFolder(NodeVisitor):

--- a/backend/src/tests/test_dead_code_integration.py
+++ b/backend/src/tests/test_dead_code_integration.py
@@ -1,0 +1,51 @@
+from src.core.interpreter import InterpretadorCobra
+from src.core.ast_nodes import (
+    NodoFuncion,
+    NodoRetorno,
+    NodoAsignacion,
+    NodoValor,
+    NodoBucleMientras,
+    NodoRomper,
+    NodoCondicional,
+    NodoLlamadaFuncion,
+)
+
+
+def test_ejecucion_sin_instrucciones_post_return():
+    ast = [
+        NodoFuncion(
+            "f",
+            [],
+            [NodoRetorno(NodoValor(1)), NodoAsignacion("x", NodoValor(2))],
+        ),
+        NodoLlamadaFuncion("f", []),
+    ]
+    interpreter = InterpretadorCobra()
+    interpreter.ejecutar_ast(ast)
+    assert "x" not in interpreter.variables
+
+
+def test_ejecucion_sin_instrucciones_post_break():
+    ast = [
+        NodoBucleMientras(
+            NodoValor(True),
+            [NodoRomper(), NodoAsignacion("x", NodoValor(1))],
+        )
+    ]
+    interpreter = InterpretadorCobra()
+    interpreter.ejecutar_ast(ast)
+    assert "x" not in interpreter.variables
+
+
+def test_condicional_constante():
+    ast = [
+        NodoCondicional(
+            NodoValor(False),
+            [NodoAsignacion("x", NodoValor(1))],
+            [NodoAsignacion("y", NodoValor(2))],
+        )
+    ]
+    interpreter = InterpretadorCobra()
+    interpreter.ejecutar_ast(ast)
+    assert "x" not in interpreter.variables
+    assert interpreter.variables.get("y") == 2


### PR DESCRIPTION
## Summary
- import tokens using the `src` package so constant folding works consistently
- test interpreter pipeline removes unreachable instructions

## Testing
- `pytest backend/src/tests/test_dead_code_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6860201928c88327869143ab72d051dc