### PR TITLE
Actualizar docs y pruebas para subcomando profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ cobra docs
 cobra empaquetar --output dist
 # Perfilar un programa y guardar los resultados
 cobra profile programa.co --output salida.prof
+# O mostrar el perfil directamente en pantalla
+cobra profile programa.co
 # Iniciar el iddle gráfico (requiere Flet)
 cobra gui
 ```

--- a/backend/src/tests/test_cli_profile.py
+++ b/backend/src/tests/test_cli_profile.py
@@ -1,10 +1,22 @@
 from io import StringIO
 from src.cli.cli import main
 from src.cobra.transpilers import module_map
+import backend.src.cobra.transpilers.module_map as backend_map
+import src.core.ast_nodes as src_nodes
+import backend.src.core.ast_nodes as backend_nodes
+import src.core.interpreter as interpreter_mod
 
 
 def test_cli_profile_creates_file(tmp_path, monkeypatch):
     monkeypatch.setattr(module_map, "get_toml_map", lambda: {})
+    monkeypatch.setattr(backend_map, "get_toml_map", lambda: {})
+    monkeypatch.setattr(module_map, "_toml_cache", {}, raising=False)
+    monkeypatch.setattr(backend_map, "_toml_cache", {}, raising=False)
+    for name in dir(backend_nodes):
+        if name.startswith("Nodo"):
+            obj = getattr(backend_nodes, name)
+            monkeypatch.setattr(src_nodes, name, obj, raising=False)
+            monkeypatch.setattr(interpreter_mod, name, obj, raising=False)
     archivo = tmp_path / "prog.co"
     archivo.write_text("imprimir(1)")
     salida = tmp_path / "out.prof"
@@ -14,6 +26,14 @@ def test_cli_profile_creates_file(tmp_path, monkeypatch):
 
 def test_cli_profile_shows_stats(tmp_path, monkeypatch):
     monkeypatch.setattr(module_map, "get_toml_map", lambda: {})
+    monkeypatch.setattr(backend_map, "get_toml_map", lambda: {})
+    monkeypatch.setattr(module_map, "_toml_cache", {}, raising=False)
+    monkeypatch.setattr(backend_map, "_toml_cache", {}, raising=False)
+    for name in dir(backend_nodes):
+        if name.startswith("Nodo"):
+            obj = getattr(backend_nodes, name)
+            monkeypatch.setattr(src_nodes, name, obj, raising=False)
+            monkeypatch.setattr(interpreter_mod, name, obj, raising=False)
     archivo = tmp_path / "prog2.co"
     archivo.write_text("imprimir(2)")
     with StringIO() as buf:

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -213,3 +213,9 @@ Ejemplo:
 .. code-block:: bash
 
    cobra profile programa.co --output perfil.prof
+
+Si se omite ``--output`` las estadísticas se muestran por consola:
+
+.. code-block:: bash
+
+   cobra profile programa.co


### PR DESCRIPTION
## Resumen
- documentar el subcomando `profile` en la guía CLI y el README
- añadir ejemplo sin `--output`
- ampliar las pruebas de `profile` para evitar dependencias de `pcobra.toml`

## Testing
- `PYTHONPATH=backend/src pytest backend/src/tests/test_cli_profile.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68602a34a4ec8327be226f258012d4be