### PR TITLE
Add Option node and Rust transpilation

### DIFF
--- a/backend/src/cobra/parser/parser.py
+++ b/backend/src/cobra/parser/parser.py
@@ -38,6 +38,7 @@ from backend.src.core.ast_nodes import (
     NodoWith,
     NodoImportDesde,
     NodoEsperar,
+    NodoOption,
     NodoSwitch,
     NodoCase,
 )
@@ -926,11 +927,21 @@ class Parser:
             cuerpo = self.expresion()
             return NodoLambda(parametros, cuerpo)
         elif token.tipo == TipoToken.IDENTIFICADOR:
-            siguiente_token = self.token_siguiente()
-            if siguiente_token and siguiente_token.tipo == TipoToken.LPAREN:
-                return self.llamada_funcion()
-            self.comer(TipoToken.IDENTIFICADOR)
-            return NodoIdentificador(token.valor)
+            if token.valor == "Some":
+                self.comer(TipoToken.IDENTIFICADOR)
+                self.comer(TipoToken.LPAREN)
+                valor = self.expresion()
+                self.comer(TipoToken.RPAREN)
+                return NodoOption(valor)
+            elif token.valor == "None":
+                self.comer(TipoToken.IDENTIFICADOR)
+                return NodoOption(None)
+            else:
+                siguiente_token = self.token_siguiente()
+                if siguiente_token and siguiente_token.tipo == TipoToken.LPAREN:
+                    return self.llamada_funcion()
+                self.comer(TipoToken.IDENTIFICADOR)
+                return NodoIdentificador(token.valor)
         elif token.tipo == TipoToken.HOLOBIT:
             # Permitir el uso de 'holobit' dentro de expresiones
             return self.declaracion_holobit()

--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/option.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/option.py
@@ -1,0 +1,6 @@
+from typing import Any
+
+
+def visit_option(self, nodo: Any) -> None:
+    valor = self.obtener_valor(nodo)
+    self.agregar_linea(f"{valor};")

--- a/backend/src/cobra/transpilers/transpiler/to_rust.py
+++ b/backend/src/cobra/transpilers/transpiler/to_rust.py
@@ -1,6 +1,6 @@
 """Transpilador que genera código Rust a partir de Cobra."""
 
-from backend.src.core.ast_nodes import (
+from src.core.ast_nodes import (
     NodoLista,
     NodoDiccionario,
     NodoValor,
@@ -18,6 +18,7 @@ from backend.src.core.ast_nodes import (
     NodoLambda,
     NodoWith,
     NodoImportDesde,
+    NodoOption,
     NodoSwitch,
     NodoCase,
 )
@@ -41,6 +42,7 @@ from .rust_nodes.pasar import visit_pasar as _visit_pasar
 from .rust_nodes.switch import visit_switch as _visit_switch
 from .rust_nodes.try_catch import visit_try_catch as _visit_try_catch
 from .rust_nodes.throw import visit_throw as _visit_throw
+from .rust_nodes.option import visit_option as _visit_option
 
 def visit_assert(self, nodo):
     cond = self.obtener_valor(nodo.condicion)
@@ -105,6 +107,10 @@ class TranspiladorRust(NodeVisitor):
                 params = ", ".join(f"{p}: impl std::any::Any" for p in nodo.parametros)
                 cuerpo = self.obtener_valor(nodo.cuerpo)
                 return f"|{', '.join(nodo.parametros)}| {{ {cuerpo} }}"
+            case NodoOption():
+                if nodo.valor is None:
+                    return "None"
+                return f"Some({self.obtener_valor(nodo.valor)})"
             case NodoLista():
                 elems = ", ".join(self.obtener_valor(e) for e in nodo.elementos)
                 return f"vec![{elems}]"
@@ -146,3 +152,4 @@ TranspiladorRust.visit_import_desde = visit_import_desde
 TranspiladorRust.visit_switch = _visit_switch
 TranspiladorRust.visit_try_catch = _visit_try_catch
 TranspiladorRust.visit_throw = _visit_throw
+TranspiladorRust.visit_option = _visit_option

--- a/backend/src/core/ast_nodes.py
+++ b/backend/src/core/ast_nodes.py
@@ -252,6 +252,18 @@ class NodoEsperar(NodoAST):
 
 
 @dataclass
+class NodoOption(NodoAST):
+    valor: Any | None = None
+
+    """Representa un valor opcional, equivalente a ``Some`` o ``None``."""
+
+    def __repr__(self):
+        return (
+            "NodoOption(None)" if self.valor is None else f"NodoOption({self.valor})"
+        )
+
+
+@dataclass
 class NodoRomper(NodoAST):
     """Sentencia para romper un bucle."""
 
@@ -433,6 +445,7 @@ __all__ = [
     'NodoRetorno',
     'NodoYield',
     'NodoEsperar',
+    'NodoOption',
     'NodoRomper',
     'NodoContinuar',
     'NodoPasar',

--- a/backend/src/tests/test_to_rust.py
+++ b/backend/src/tests/test_to_rust.py
@@ -13,6 +13,7 @@ from src.core.ast_nodes import (
     NodoTryCatch,
     NodoThrow,
     NodoIdentificador,
+    NodoOption,
     NodoSwitch,
     NodoCase,
 )
@@ -142,3 +143,46 @@ def test_try_catch_result():
         "};"
     )
     assert resultado == esperado
+
+
+def test_option_some_none():
+    ast = [
+        NodoAsignacion("a", NodoOption(NodoValor(5))),
+        NodoAsignacion("b", NodoOption(None)),
+    ]
+    t = TranspiladorRust()
+    resultado = t.transpilar(ast)
+    esperado = "let a = Some(5);\nlet b = None;"
+    assert resultado == esperado
+
+
+def test_option_match():
+    ast = [
+        NodoAsignacion("opt", NodoOption(NodoValor(1))),
+        NodoSwitch(
+            NodoIdentificador("opt"),
+            [
+                NodoCase(
+                    NodoOption(NodoIdentificador("v")),
+                    [NodoAsignacion("y", NodoIdentificador("v"))],
+                ),
+                NodoCase(NodoOption(None), [NodoAsignacion("y", NodoValor(0))]),
+            ],
+            [],
+        ),
+    ]
+    t = TranspiladorRust()
+    resultado = t.transpilar(ast)
+    esperado = (
+        "let opt = Some(1);\n"
+        "match opt {\n"
+        "    Some(v) => {\n"
+        "        let y = v;\n"
+        "    },\n"
+        "    None => {\n"
+        "        let y = 0;\n"
+        "    },\n"
+        "}"
+    )
+    assert resultado == esperado
+


### PR DESCRIPTION
## Summary
- add `NodoOption` to AST
- parse `Some(...)` and `None` constructs
- implement Rust code generation for Option
- support Option visitor in the Rust transpiler
- test Option handling in Rust transpilation

## Testing
- `pytest backend/src/tests/test_to_rust.py::test_option_some_none backend/src/tests/test_to_rust.py::test_option_match -q`

------
https://chatgpt.com/codex/tasks/task_e_686032480208832794baf9354a562bad