### PR TITLE
Add cobra.mod validation

### DIFF
--- a/backend/src/cli/commands/modules_cmd.py
+++ b/backend/src/cli/commands/modules_cmd.py
@@ -7,6 +7,7 @@ from ..utils.messages import mostrar_error, mostrar_info
 from ..utils.semver import es_version_valida, es_nueva_version
 from ..cobrahub_client import publicar_modulo, descargar_modulo
 from ...cobra.transpilers.module_map import MODULE_MAP_PATH
+from ...cobra.semantico import mod_validator
 
 MODULES_PATH = os.path.join(os.path.dirname(__file__), "..", "modules")
 os.makedirs(MODULES_PATH, exist_ok=True)
@@ -90,6 +91,11 @@ class ModulesCommand(BaseCommand):
 
     @staticmethod
     def _listar_modulos():
+        try:
+            mod_validator.validar_mod(MODULE_MAP_PATH)
+        except ValueError as e:
+            mostrar_error(str(e))
+            return 1
         mods = [f for f in os.listdir(MODULES_PATH) if f.endswith(".co")]
         if not mods:
             mostrar_info(_("No hay módulos instalados"))
@@ -100,6 +106,11 @@ class ModulesCommand(BaseCommand):
 
     @staticmethod
     def _instalar_modulo(ruta):
+        try:
+            mod_validator.validar_mod(MODULE_MAP_PATH)
+        except ValueError as e:
+            mostrar_error(str(e))
+            return 1
         if not os.path.exists(ruta):
             mostrar_error(_("No se encontró el módulo {path}").format(path=ruta))
             return 1

--- a/backend/src/cobra/semantico/__init__.py
+++ b/backend/src/cobra/semantico/__init__.py
@@ -1,4 +1,5 @@
 from .tabla import Simbolo, Ambito
 from .analizador import AnalizadorSemantico
+from .mod_validator import validar_mod
 
-__all__ = ["Simbolo", "Ambito", "AnalizadorSemantico"]
+__all__ = ["Simbolo", "Ambito", "AnalizadorSemantico", "validar_mod"]

--- a/backend/src/cobra/semantico/mod_validator.py
+++ b/backend/src/cobra/semantico/mod_validator.py
@@ -1,0 +1,70 @@
+"""Validación de archivos cobra.mod.
+
+Este módulo proporciona utilidades para leer un archivo ``cobra.mod``
+(tanto en formato YAML como TOML) y verificar su integridad. Las
+comprobaciones incluyen:
+
+- Existencia de los archivos declarados en las claves ``python`` y ``js``.
+- Validez de las versiones indicadas utilizando el formato semver.
+- Detección de nombres de módulos o archivos duplicados.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+import yaml
+from typing import Dict, Any
+
+from src.cli.utils.semver import es_version_valida
+from src.cobra.transpilers import module_map
+
+
+def cargar_mod(path: str | None = None) -> Dict[str, Any]:
+    """Carga y devuelve el contenido de ``cobra.mod``.
+
+    Se intenta primero interpretar el archivo como TOML. Si falla se usa YAML.
+    Si el archivo no existe se devuelve un diccionario vacío.
+    """
+    path = path or module_map.MODULE_MAP_PATH
+    if not os.path.exists(path):
+        return {}
+    with open(path, "rb") as f:
+        data = f.read()
+    try:
+        return tomllib.loads(data.decode("utf-8"))
+    except Exception:
+        return yaml.safe_load(data) or {}
+
+
+def validar_mod(path: str | None = None) -> None:
+    """Valida el contenido de ``cobra.mod``.
+
+    Lanza ``ValueError`` si se detecta algún problema.
+    """
+    datos = cargar_mod(path)
+    errores: list[str] = []
+
+    archivos_py: set[str] = set()
+    archivos_js: set[str] = set()
+
+    for modulo, info in datos.items():
+        if modulo == "lock":
+            continue
+        if not isinstance(info, dict):
+            errores.append(f"Entrada inválida para {modulo}")
+            continue
+        version = info.get("version")
+        if version and not es_version_valida(str(version)):
+            errores.append(f"Versión inválida para {modulo}: {version}")
+        for clave in ("python", "js"):
+            ruta = info.get(clave)
+            if ruta:
+                if not os.path.exists(ruta):
+                    errores.append(f"No existe el archivo {ruta} para {modulo}")
+                registro = archivos_py if clave == "python" else archivos_js
+                if ruta in registro:
+                    errores.append(f"Archivo duplicado: {ruta}")
+                registro.add(ruta)
+    if errores:
+        raise ValueError("; ".join(errores))

--- a/backend/src/tests/test_mod_validator.py
+++ b/backend/src/tests/test_mod_validator.py
@@ -1,0 +1,38 @@
+import yaml
+import pytest
+
+from src.cobra.semantico.mod_validator import validar_mod
+
+
+def _write_yaml(path, data):
+    path.write_text(yaml.safe_dump(data))
+
+
+def test_validador_archivo_faltante(tmp_path):
+    mod = tmp_path / "m.co"
+    data = {str(mod): {"python": str(tmp_path / "m.py")}}
+    _write_yaml(tmp_path / "cobra.mod", data)
+    with pytest.raises(ValueError):
+        validar_mod(str(tmp_path / "cobra.mod"))
+
+
+def test_validador_version_incorrecta(tmp_path):
+    py = tmp_path / "m.py"
+    py.write_text("x = 1")
+    mod = tmp_path / "m.co"
+    data = {str(mod): {"version": "bad", "python": str(py)}}
+    _write_yaml(tmp_path / "cobra.mod", data)
+    with pytest.raises(ValueError):
+        validar_mod(str(tmp_path / "cobra.mod"))
+
+
+def test_validador_duplicados(tmp_path):
+    py = tmp_path / "dup.py"
+    py.write_text("x = 1")
+    data = {
+        str(tmp_path / "a.co"): {"python": str(py)},
+        str(tmp_path / "b.co"): {"python": str(py)},
+    }
+    _write_yaml(tmp_path / "cobra.mod", data)
+    with pytest.raises(ValueError):
+        validar_mod(str(tmp_path / "cobra.mod"))


### PR DESCRIPTION
## Summary
- add a validator for `cobra.mod` files to check file paths, semver and duplicates
- expose validator in semantico package
- run validator when listing or installing modules
- test validator behaviour

## Testing
- `pytest backend/src/tests/test_mod_validator.py -q`
- `pytest -q` *(fails: 21 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6860c753b1d883279a88d840c7dc1fff