### PR TITLE
Añadir configuracion Pyright y actualizar CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           flake8 backend/src
           mypy backend/src
           bandit -r backend/src
-          pyright backend/src
+          pyright --project pyrightconfig.json
       - name: Run type checks
         run: make typecheck
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -608,6 +608,17 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
   issues y preparar pull requests.
 - Para proponer nuevas extensiones consulta [frontend/docs/rfc_plugins.rst](frontend/docs/rfc_plugins.rst).
 
+## Desarrollo
+
+Para verificar el tipado de forma local ejecuta:
+
+```bash
+mypy backend/src
+pyright --project pyrightconfig.json
+```
+
+`mypy` utiliza la configuración de `mypy.ini` y `pyright` toma las rutas de `pyrightconfig.json`.
+
 ## Desarrollo de plugins
 
 La CLI puede ampliarse mediante plugins externos. Para crear uno, define una

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": ["backend/src"],
+  "exclude": [
+    "frontend/build",
+    "frontend/docs",
+    "venv",
+    "backend/src/tests"
+  ],
+  "pythonVersion": "3.11",
+  "reportMissingImports": false
+}


### PR DESCRIPTION
## Resumen
- incorporar `pyrightconfig.json` con las rutas y exclusiones de `mypy.ini`
- usar dicho archivo en la acción de CI
- documentar la ejecución local de `mypy` y `pyright`

## Testing
- `pyright --project pyrightconfig.json` *(falla por módulos faltantes)*
- `mypy backend/src` *(falla con varios errores de tipado)*

------
https://chatgpt.com/codex/tasks/task_e_6860cad056c88327bbe19de74463c420