### PR TITLE
Refactor plugin utilities

### DIFF
--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -13,7 +13,7 @@ from .commands.interactive_cmd import InteractiveCommand
 from .commands.jupyter_cmd import JupyterCommand
 from .commands.flet_cmd import FletCommand
 from .commands.agix_cmd import AgixCommand
-from .plugin_loader import descubrir_plugins
+from .plugin import descubrir_plugins
 from .commands.plugins_cmd import PluginsCommand
 from .commands.modules_cmd import ModulesCommand
 from .commands.dependencias_cmd import DependenciasCommand

--- a/backend/src/cli/plugin.py
+++ b/backend/src/cli/plugin.py
@@ -1,0 +1,110 @@
+"""Utilidades para la carga y registro de plugins de la CLI.
+
+Este m\xf3dulo combina las clases y funciones que antes estaban en
+``plugin_interface`` y ``plugin_loader``. Se mantiene aqu\xed para unificar la
+API p\fablica relacionada con plugins.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from importlib import import_module
+from importlib.metadata import entry_points
+
+from .commands.base import BaseCommand
+from .plugin_registry import registrar_plugin, obtener_registro
+
+
+class PluginInterface(ABC):
+    """Interfaz base para plugins de la CLI."""
+
+    #: Nombre del plugin o subcomando
+    name: str = ""
+
+    #: Versi\xf3n del plugin
+    version: str = "0.1"
+
+    #: Autor del plugin
+    author: str = ""
+
+    #: Breve descripci\xf3n del plugin
+    description: str = ""
+
+    @abstractmethod
+    def register_subparser(self, subparsers):
+        """Registra los argumentos del subcomando en el parser."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def run(self, args):
+        """Ejecuta la l\xf3gica del plugin."""
+        raise NotImplementedError
+
+
+class PluginCommand(BaseCommand, PluginInterface):
+    """Clase base para implementar comandos externos mediante plugins."""
+
+
+def descubrir_plugins():
+    """Descubre e instancia los plugins registrados bajo ``cobra.plugins``."""
+    plugins = []
+    try:
+        eps = entry_points(group="cobra.plugins")
+    except TypeError:  # Compatibilidad con versiones antiguas
+        eps = entry_points().get("cobra.plugins", [])
+
+    for ep in eps:
+        instancia = cargar_plugin_seguro(ep.value)
+        if instancia is not None:
+            plugins.append(instancia)
+    return plugins
+
+
+def cargar_plugin_seguro(ruta: str):
+    """Carga de forma segura un plugin a partir de ``modulo:Clase``."""
+    try:
+        module_name, class_name = ruta.split(":", 1)
+    except ValueError:
+        logging.error(f"Ruta de plugin inv\xe1lida: {ruta}")
+        return None
+
+    try:
+        module = import_module(module_name)
+    except Exception as exc:
+        logging.error(f"Error importando m\xf3dulo {module_name}: {exc}")
+        return None
+
+    try:
+        plugin_cls = getattr(module, class_name)
+    except AttributeError:
+        logging.error(f"No se encontr\xf3 la clase {class_name} en {module_name}")
+        return None
+
+    if not issubclass(plugin_cls, PluginInterface):
+        logging.warning(
+            f"El plugin {ruta} no implementa PluginInterface"
+        )
+        return None
+
+    try:
+        instancia = plugin_cls()
+    except Exception as exc:
+        logging.error(f"Error instanciando plugin {ruta}: {exc}")
+        return None
+
+    if not getattr(instancia, "name", ""):
+        logging.warning(f"Plugin {ruta} no define atributo name")
+        return None
+
+    version = getattr(instancia, "version", "0")
+    registrar_plugin(instancia.name, version)
+    return instancia
+
+
+__all__ = [
+    "PluginInterface",
+    "PluginCommand",
+    "descubrir_plugins",
+    "cargar_plugin_seguro",
+    "registrar_plugin",
+    "obtener_registro",
+]

--- a/backend/src/cli/plugin_interface.py
+++ b/backend/src/cli/plugin_interface.py
@@ -1,30 +1,9 @@
-from abc import ABC, abstractmethod
+"""M\xf3dulo interno deprecado.
 
-class PluginInterface(ABC):
-    """Interfaz base que define el comportamiento de un plugin de la CLI.
+Este archivo se mantiene por compatibilidad pero las clases y funciones
+relacionadas con plugins se encuentran ahora en ``src.cli.plugin``.
+"""
 
-    Los plugins deben declarar nombre, versión, autor y una breve
-    descripción para que la CLI pueda mostrarlos correctamente.
-    """
+from .plugin import PluginInterface
 
-    #: Nombre del plugin o subcomando
-    name: str = ""
-
-    #: Versión del plugin
-    version: str = "0.1"
-
-    #: Autor del plugin
-    author: str = ""
-
-    #: Breve descripción del plugin
-    description: str = ""
-
-    @abstractmethod
-    def register_subparser(self, subparsers):
-        """Registra los argumentos del subcomando en el parser."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def run(self, args):
-        """Ejecuta la lógica del plugin."""
-        raise NotImplementedError
+__all__ = ["PluginInterface"]

--- a/backend/src/cli/plugin_loader.py
+++ b/backend/src/cli/plugin_loader.py
@@ -1,67 +1,13 @@
-import logging
-from importlib import import_module
-from importlib.metadata import entry_points
+"""M\xf3dulo interno deprecado.
 
-from .commands.base import BaseCommand
-from .plugin_interface import PluginInterface
-from .plugin_registry import registrar_plugin
+Las utilidades de carga y las clases para plugins ahora residen en
+``src.cli.plugin``.
+"""
 
+from .plugin import PluginCommand, descubrir_plugins, cargar_plugin_seguro
 
-class PluginCommand(BaseCommand, PluginInterface):
-    """Clase base para implementar comandos externos mediante plugins."""
-
-
-def descubrir_plugins():
-    """Descubre e instancia los plugins registrados bajo ``cobra.plugins``."""
-    plugins = []
-    try:
-        eps = entry_points(group="cobra.plugins")
-    except TypeError:  # Compatibilidad con versiones antiguas
-        eps = entry_points().get("cobra.plugins", [])
-
-    for ep in eps:
-        instancia = cargar_plugin_seguro(ep.value)
-        if instancia is not None:
-            plugins.append(instancia)
-    return plugins
-
-
-def cargar_plugin_seguro(ruta: str):
-    """Carga de forma segura un plugin a partir de ``modulo:Clase``."""
-    try:
-        module_name, class_name = ruta.split(":", 1)
-    except ValueError:
-        logging.error(f"Ruta de plugin inválida: {ruta}")
-        return None
-
-    try:
-        module = import_module(module_name)
-    except Exception as exc:
-        logging.error(f"Error importando módulo {module_name}: {exc}")
-        return None
-
-    try:
-        plugin_cls = getattr(module, class_name)
-    except AttributeError:
-        logging.error(f"No se encontró la clase {class_name} en {module_name}")
-        return None
-
-    if not issubclass(plugin_cls, PluginInterface):
-        logging.warning(
-            f"El plugin {ruta} no implementa PluginInterface"
-        )
-        return None
-
-    try:
-        instancia = plugin_cls()
-    except Exception as exc:
-        logging.error(f"Error instanciando plugin {ruta}: {exc}")
-        return None
-
-    if not getattr(instancia, "name", ""):
-        logging.warning(f"Plugin {ruta} no define atributo name")
-        return None
-
-    version = getattr(instancia, "version", "0")
-    registrar_plugin(instancia.name, version)
-    return instancia
+__all__ = [
+    "PluginCommand",
+    "descubrir_plugins",
+    "cargar_plugin_seguro",
+]

--- a/backend/src/tests/test_cli_plugins_cmd.py
+++ b/backend/src/tests/test_cli_plugins_cmd.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import importlib.metadata
 
 from src.cli.cli import main
-from src.cli.plugin_loader import PluginCommand
+from src.cli.plugin import PluginCommand
 
 
 class DummyPlugin(PluginCommand):
@@ -35,7 +35,7 @@ def test_cli_plugins_muestra_registro():
         value="src.tests.test_cli_plugins_cmd:DummyPlugin",
         group="cobra.plugins",
     )
-    with patch("src.cli.plugin_loader.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+    with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["plugins"])
     assert "dummy 5.2" in out.getvalue().strip()
@@ -47,7 +47,7 @@ def test_cli_plugin_ejemplo_hola():
         value="src.tests.test_cli_plugins_cmd:HolaPlugin",
         group="cobra.plugins",
     )
-    with patch("src.cli.plugin_loader.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+    with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["hola"])
     assert "¡Hola desde un plugin!" in out.getvalue().strip()

--- a/backend/src/tests/test_plugin_loader.py
+++ b/backend/src/tests/test_plugin_loader.py
@@ -1,7 +1,7 @@
 import importlib.metadata
 from unittest.mock import patch
 
-from src.cli.plugin_loader import descubrir_plugins, PluginCommand
+from src.cli.plugin import descubrir_plugins, PluginCommand
 from src.cli.plugin_registry import obtener_registro, limpiar_registro
 
 class DummyPlugin(PluginCommand):
@@ -18,7 +18,7 @@ def test_descubrir_plugins_carga_plugins():
         value="src.tests.test_plugin_loader:DummyPlugin",
         group="cobra.plugins",
     )
-    with patch("src.cli.plugin_loader.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+    with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         limpiar_registro()
         plugins = descubrir_plugins()
     assert len(plugins) == 1

--- a/examples/plugins/saludo_plugin.py
+++ b/examples/plugins/saludo_plugin.py
@@ -1,4 +1,4 @@
-from backend.src.cli.plugin_loader import PluginCommand
+from src.cli.plugin import PluginCommand
 
 class SaludoCommand(PluginCommand):
     """Comando de ejemplo que imprime un saludo."""


### PR DESCRIPTION
## Summary
- centralize plugin utilities under `src.cli.plugin`
- deprecate old `plugin_interface` and `plugin_loader` modules
- update CLI to use the new location
- fix tests and example plugin imports

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 154 failed, 263 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6860d2b666f08327bef0aab6c3ed1588