### PR TITLE
Actualizar documentación sobre importación de plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,9 +621,10 @@ pyright --project pyrightconfig.json
 
 ## Desarrollo de plugins
 
-La CLI puede ampliarse mediante plugins externos. Para crear uno, define una
-clase que herede de `PluginCommand` e incluye una entrada en el grupo
-`cobra.plugins` de tu `setup.py`:
+La CLI puede ampliarse mediante plugins externos. Desde esta versión todo el SDK
+de plugins se encuentra en ``src.cli.plugin``. Para crear uno, define una clase
+que herede de ``PluginCommand`` e incluye una entrada en el grupo
+``cobra.plugins`` de tu ``setup.py``:
 
 ```python
 entry_points={
@@ -646,7 +647,7 @@ cobra plugins
 ### Ejemplo de plugin
 
 ```python
-from src.cli.plugin_loader import PluginCommand
+from src.cli.plugin import PluginCommand
 
 
 class HolaCommand(PluginCommand):

--- a/frontend/docs/plugin_dev.rst
+++ b/frontend/docs/plugin_dev.rst
@@ -2,10 +2,11 @@ Desarrollo de plugins
 =====================
 
 Un plugin permite ampliar la CLI de Cobra con nuevos subcomandos
-distribuidos como paquetes externos. Cada plugin se implementa como una
-clase que hereda de ``PluginCommand``. Esta clase define varios
-metadatos (``name``, ``version``, ``author`` y ``description``) que se
-mostrarán al ejecutar ``cobra plugins``.
+distribuidos como paquetes externos. Todas las utilidades del SDK se
+encuentran en ``src.cli.plugin``. Cada plugin se implementa como una
+clase que hereda de ``PluginCommand``. Esta clase define varios metadatos
+(``name``, ``version``, ``author`` y ``description``) que se mostrarán al
+ejecutar ``cobra plugins``.
 
 Estructura básica
 -----------------
@@ -22,7 +23,7 @@ En ``hola.py`` se define la clase del comando:
 
 .. code-block:: python
 
-   from src.cli.plugin_loader import PluginCommand
+   from src.cli.plugin import PluginCommand
 
 
    class HolaCommand(PluginCommand):

--- a/frontend/docs/plugin_sdk.rst
+++ b/frontend/docs/plugin_sdk.rst
@@ -2,9 +2,9 @@ API de PluginInterface
 ======================
 
 La clase ``PluginInterface`` define la interfaz mínima que deben implementar los
-plugins externos de la CLI. Cada plugin expone metadatos de identificación y dos
-métodos esenciales para registrar el subcomando y ejecutar la lógica
-correspondiente.
+plugins externos de la CLI. Todas las utilidades del SDK se encuentran ahora en
+``src.cli.plugin``. Cada plugin expone metadatos de identificación y dos métodos
+esenciales para registrar el subcomando y ejecutar la lógica correspondiente.
 
 Atributos
 ---------
@@ -33,7 +33,7 @@ Ejemplo de implementación
 
 .. code-block:: python
 
-   from src.cli.plugin_loader import PluginCommand
+   from src.cli.plugin import PluginCommand
 
 
    class HolaCommand(PluginCommand):
@@ -65,12 +65,12 @@ Para que Cobra cargue el plugin se declara un ``entry_point`` en ``setup.py``:
 Gestión de versiones
 --------------------
 
-Al instanciarse, cada plugin registra su nombre y versión en
-``plugin_registry``. Puedes consultarlo con:
+Al instanciarse, cada plugin registra su nombre y versión en el
+``plugin_registry`` del módulo ``src.cli.plugin``. Puedes consultarlo con:
 
 .. code-block:: python
 
-   from src.cli.plugin_registry import obtener_registro
+   from src.cli.plugin import obtener_registro
 
    print(obtener_registro())  # {'hola': '1.0'}
 

--- a/frontend/docs/plugins.rst
+++ b/frontend/docs/plugins.rst
@@ -3,10 +3,11 @@ Sistema de plugins
 
 La CLI de Cobra se puede extender instalando paquetes externos que expongan
 un "entry point" en el grupo ``cobra.plugins``. Durante el arranque la
-aplicación busca dichos entry points e instancia cada plugin.
+aplicación busca dichos entry points e instancia cada plugin. Todas las
+utilidades necesarias se importan desde ``src.cli.plugin``.
 
 Al cargarse, la información de nombre y versión se almacena en un registro
-interno accesible desde ``src.cli.plugin_registry``. Para consultar qué
+interno accesible desde ``src.cli.plugin``. Para consultar qué
 plugins están disponibles se proporciona el subcomando ``plugins``::
 
    cobra plugins
@@ -21,9 +22,9 @@ A continuación se muestra cómo crear un plugin sencillo utilizando
    ``mi_paquete/mi_plugin.py``.
 2. **Importa** ``PluginCommand`` e implementa una clase que herede de ella:
 
-   .. code-block:: python
+     .. code-block:: python
 
-      from src.cli.plugin_loader import PluginCommand
+        from src.cli.plugin import PluginCommand
 
 
       class SaludoCommand(PluginCommand):


### PR DESCRIPTION
## Summary
- actualizar README con nueva ruta de importación `src.cli.plugin`
- adaptar sección de desarrollo de plugins y docs referentes al SDK
- explicar nueva ubicación del SDK en `src.cli.plugin`

## Testing
- `make lint` *(fails: flake8 not found)*
- `make typecheck` *(fails with mypy errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860d5e0e2f48327a0346feb95375c95