### PR TITLE
Add md2cobra plugin example

### DIFF
--- a/backend/src/tests/test_md2cobra_plugin.py
+++ b/backend/src/tests/test_md2cobra_plugin.py
@@ -1,0 +1,42 @@
+import importlib.metadata
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+import sys
+
+from src.cli.cli import main
+
+# Añadimos la carpeta de plugins de ejemplo al path para importar el plugin
+ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_DIR = ROOT / "examples" / "plugins"
+sys.path.insert(0, str(PLUGIN_DIR))
+
+
+def test_md2cobra_plugin_generates_file(tmp_path):
+    md = tmp_path / "ejemplo.md"
+    md.write_text(
+        """
+Texto normal
+```cobra
+var x = 1
+```
+Mas texto
+````cobra
+var y = 2
+````
+""",
+        encoding="utf-8",
+    )
+    salida = tmp_path / "salida.co"
+    ep = importlib.metadata.EntryPoint(
+        name="md2cobra",
+        value="md2cobra_plugin:MarkdownToCobraCommand",
+        group="cobra.plugins",
+    )
+    with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+        main(["md2cobra", "--input", str(md), "--output", str(salida)])
+
+    assert salida.exists()
+    contenido = salida.read_text(encoding="utf-8").strip()
+    assert "var x = 1" in contenido
+    assert "var y = 2" in contenido

--- a/examples/plugins/md2cobra_plugin.py
+++ b/examples/plugins/md2cobra_plugin.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import re
+from src.cli.plugin import PluginCommand
+
+
+class MarkdownToCobraCommand(PluginCommand):
+    """Extrae bloques de codigo ``cobra`` desde un Markdown."""
+
+    name = "md2cobra"
+    version = "1.0"
+    description = "Convierte Markdown a script Cobra"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help=self.description)
+        parser.add_argument("--input", required=True, help="Archivo Markdown")
+        parser.add_argument("--output", required=True, help="Archivo .co de salida")
+        parser.set_defaults(cmd=self)
+
+    def run(self, args):
+        input_path = Path(args.input)
+        output_path = Path(args.output)
+        texto = input_path.read_text(encoding="utf-8")
+
+        bloques = []
+        dentro = False
+        actual = []
+        for linea in texto.splitlines():
+            if not dentro and re.match(r"`{3,}cobra", linea):
+                dentro = True
+                actual = []
+                continue
+            if dentro and re.match(r"`{3,}$", linea):
+                bloques.append("\n".join(actual))
+                dentro = False
+                continue
+            if dentro:
+                actual.append(linea)
+        salida = "\n\n".join(bloques)
+        output_path.write_text(salida, encoding="utf-8")

--- a/examples/plugins/setup.py
+++ b/examples/plugins/setup.py
@@ -3,10 +3,11 @@ from setuptools import setup
 setup(
     name='ejemplo-plugin-cobra',
     version='1.0',
-    py_modules=['saludo_plugin'],
+    py_modules=['saludo_plugin', 'md2cobra_plugin'],
     entry_points={
         'cobra.plugins': [
             'saludo = saludo_plugin:SaludoCommand',
+            'md2cobra = md2cobra_plugin:MarkdownToCobraCommand',
         ],
     },
 )

--- a/frontend/docs/plugins.rst
+++ b/frontend/docs/plugins.rst
@@ -64,3 +64,16 @@ con el sistema de comandos de Cobra.
 Para una descripción completa de la interfaz disponible consulta
 :doc:`plugin_sdk`.
 
+Ejemplo: convertir Markdown a Cobra
+-----------------------------------
+
+Dentro de ``examples/plugins`` se incluye el plugin ``md2cobra`` que extrae
+los bloques de código iniciados con `````cobra```` de un archivo Markdown y los
+guarda en un script ``.co``. Para instalarlo y utilizarlo ejecuta::
+
+   pip install -e examples/plugins
+
+Una vez instalado, el subcomando queda disponible::
+
+   cobra md2cobra --input notas.md --output resultado.co
+


### PR DESCRIPTION
## Summary
- add MarkdownToCobraCommand example plugin
- register plugin in example setup
- document installation and usage
- unit test ensuring plugin works

## Testing
- `pytest backend/src/tests/test_md2cobra_plugin.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6860d7bef30c832785e0afc2bcaee16e