### PR TITLE
Add VSCode LSP command

### DIFF
--- a/frontend/vscode/README.md
+++ b/frontend/vscode/README.md
@@ -1,3 +1,18 @@
 # Extensión Cobra para VS Code
 
 Este directorio contiene una plantilla mínima de extensión que habilita el resaltado básico para archivos `.co`.
+
+## Instalación de dependencias
+
+```bash
+cd frontend/vscode
+npm install
+```
+
+## Ejecución de la extensión
+
+1. Abre VS Code y carga este directorio como espacio de trabajo.
+2. Pulsa `F5` para iniciar un "Extension Development Host".
+3. En la nueva ventana, ejecuta el comando **Iniciar Cobra LSP** desde la paleta (`Ctrl+Shift+P`).
+
+El servidor de lenguaje se ejecutará mediante `python -m lsp.server` y proporcionará autocompletado y errores en vivo para archivos Cobra.

--- a/frontend/vscode/extension.js
+++ b/frontend/vscode/extension.js
@@ -1,7 +1,38 @@
+const vscode = require('vscode');
+const cp = require('child_process');
+const { LanguageClient } = require('vscode-languageclient/node');
+
+let client;
+
 function activate(context) {
     console.log('Extensión Cobra activada');
+
+    const disposable = vscode.commands.registerCommand('cobra.startLSP', () => {
+        if (client) {
+            vscode.window.showInformationMessage('El servidor ya está en ejecución.');
+            return;
+        }
+
+        const serverOptions = () => {
+            const process = cp.spawn('python', ['-m', 'lsp.server']);
+            return { process };
+        };
+
+        const clientOptions = {
+            documentSelector: [{ scheme: 'file', language: 'cobra' }],
+        };
+
+        client = new LanguageClient('cobra-lsp', 'Cobra LSP', serverOptions, clientOptions);
+        context.subscriptions.push(client.start());
+    });
+
+    context.subscriptions.push(disposable);
 }
 
-function deactivate() {}
+function deactivate() {
+    if (client) {
+        return client.stop();
+    }
+}
 
 module.exports = { activate, deactivate };

--- a/frontend/vscode/package.json
+++ b/frontend/vscode/package.json
@@ -7,10 +7,17 @@
         "vscode": "^1.80.0"
     },
     "activationEvents": [
+        "onCommand:cobra.startLSP",
         "onLanguage:cobra"
     ],
     "main": "./extension.js",
     "contributes": {
+        "commands": [
+            {
+                "command": "cobra.startLSP",
+                "title": "Iniciar Cobra LSP"
+            }
+        ],
         "languages": [
             {
                 "id": "cobra",
@@ -18,5 +25,9 @@
                 "aliases": ["Cobra"]
             }
         ]
+    }
+    ,
+    "dependencies": {
+        "vscode-languageclient": "^9.0.1"
     }
 }


### PR DESCRIPTION
## Summary
- connect VS Code to the Python LSP server with `vscode-languageclient`
- declare the command and activation event in `package.json`
- document how to install dependencies and run the extension

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6860ef6d3c788327af173727bffab9b5