### PR TITLE
Add VSCode snippets for Cobra language

### DIFF
--- a/frontend/vscode/README.md
+++ b/frontend/vscode/README.md
@@ -16,3 +16,35 @@ npm install
 3. En la nueva ventana, ejecuta el comando **Iniciar Cobra LSP** desde la paleta (`Ctrl+Shift+P`).
 
 El servidor de lenguaje se ejecutará mediante `python -m lsp.server` y proporcionará autocompletado y errores en vivo para archivos Cobra.
+
+## Snippets incluidos
+
+La extensión registra fragmentos de código (snippets) para acelerar la escritura.
+
+- **func** &rarr; definición de función
+
+```cobra
+func nombre(parametros):
+    
+fin
+```
+
+- **si** &rarr; bloque condicional `si`/`sino`
+
+```cobra
+si condicion:
+    
+sino:
+    
+fin
+```
+
+- **para** &rarr; bucle `para`
+
+```cobra
+para item en iterable:
+    
+fin
+```
+
+Al escribir los prefijos anteriores y pulsar `Tab`, VS Code mostrará las plantillas correspondientes.

--- a/frontend/vscode/package.json
+++ b/frontend/vscode/package.json
@@ -24,6 +24,12 @@
                 "extensions": [".co"],
                 "aliases": ["Cobra"]
             }
+        ],
+        "snippets": [
+            {
+                "language": "cobra",
+                "path": "./snippets/cobra.json"
+            }
         ]
     }
     ,

--- a/frontend/vscode/snippets/cobra.json
+++ b/frontend/vscode/snippets/cobra.json
@@ -1,0 +1,31 @@
+{
+    "funcion": {
+        "prefix": "func",
+        "body": [
+            "func ${1:nombre}(${2:parametros}):",
+            "    ${0}",
+            "fin"
+        ],
+        "description": "Definición de función"
+    },
+    "condicional si/sino": {
+        "prefix": "si",
+        "body": [
+            "si ${1:condicion}:",
+            "    ${2}",
+            "sino:",
+            "    ${0}",
+            "fin"
+        ],
+        "description": "Bloque condicional si/sino"
+    },
+    "bucle para": {
+        "prefix": "para",
+        "body": [
+            "para ${1:item} en ${2:iterable}:",
+            "    ${0}",
+            "fin"
+        ],
+        "description": "Bucle para"
+    }
+}


### PR DESCRIPTION
## Summary
- provide VSCode snippets for Cobra functions, loops and conditionals
- register the snippets in the extension manifest
- document usage examples in the extension README

## Testing
- `pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6860f413a45c8327a2d14e51a0e437ed