### PR TITLE
Agrega instrucciones de instalación via PyPI

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -24,6 +24,12 @@ Puedes instalar Cobra utilizando [pipx](https://pypa.github.io/pipx/), una herra
 pipx install cobra-lenguaje
 ```
 
+También puedes instalar Cobra directamente desde PyPI con
+
+```bash
+pip install cobra-lenguaje
+```
+
 ## 2. Estructura básica de un programa
 
 - Declara variables con `var`.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ pip install -e .
 pipx install cobra-lenguaje
 ```
 
+Si prefieres instalar Cobra directamente desde PyPI sin usar
+`pipx`, ejecuta:
+
+```bash
+pip install cobra-lenguaje
+```
+
 ## Construir la imagen Docker
 
 Puedes crear la imagen utilizando el script `docker/scripts/build.sh` o el subcomando de la CLI:

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -36,6 +36,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    paquetes
    cobrahub
    cobra_lock
+   instalacion_pypi
    primeros_pasos
    como_contribuir
    entorno_desarrollo

--- a/frontend/docs/instalacion_pypi.rst
+++ b/frontend/docs/instalacion_pypi.rst
@@ -1,0 +1,12 @@
+Instalación desde PyPI
+======================
+
+Además de utilizar ``pipx``, puedes instalar Cobra directamente desde
+`PyPI <https://pypi.org/project/cobra-lenguaje/>`_. Simplemente ejecuta:
+
+.. code-block:: bash
+
+   pip install cobra-lenguaje
+
+Esta alternativa te permitirá usar la CLI ``cobra`` en cualquier
+entorno donde tengas ``pip`` disponible.


### PR DESCRIPTION
## Summary
- documentar la instalación con `pip install cobra-lenguaje`
- repetir el aviso en el manual
- añadir referencia en la documentación y archivo dedicado

## Testing
- `pytest -q` *(falla por errores de importación durante la recolección)*

------
https://chatgpt.com/codex/tasks/task_e_6860ff9c51588327b9568938ce4d2de3