### PR TITLE
Add cross-platform executable build workflow

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -1,0 +1,31 @@
+name: Build Executables
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+          pip install pyinstaller
+      - name: Build executable
+        run: cobra empaquetar --output dist
+      - name: Upload executable
+        uses: actions/upload-artifact@v3
+        with:
+          name: cobra-${{ matrix.os }}
+          path: dist/*

--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ cobra contenedor --tag cobra
 
 Esto ejecutará internamente ``docker build`` y generará una imagen llamada `cobra` en tu sistema Docker.
 
+## Descarga de binarios
+
+Para cada lanzamiento se generan ejecutables para Linux, Windows y macOS mediante
+GitHub Actions. Puedes encontrarlos en la pestaña
+[Releases](https://github.com/Alphonsus411/pCobra/releases) del repositorio.
+Solo descarga el archivo correspondiente a tu sistema operativo desde la versión
+más reciente y ejecútalo directamente.
+
 # Estructura del Proyecto
 
 El proyecto se organiza en las siguientes carpetas y módulos:


### PR DESCRIPTION
## Summary
- build executables for Linux, Windows and macOS with PyInstaller
- add instructions in README on downloading binaries from Releases

## Testing
- `pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68610100aa488327a8efa5d027574589