### PR TITLE
Add new corelibs modules

### DIFF
--- a/backend/corelibs/__init__.py
+++ b/backend/corelibs/__init__.py
@@ -1,0 +1,41 @@
+"""Colección de utilidades estándar para Cobra."""
+
+from .texto import mayusculas, minusculas, invertir, concatenar
+from .numero import es_par, es_primo, factorial, promedio
+from .archivo import leer, escribir, existe, eliminar
+from .tiempo import ahora, formatear, dormir
+from .coleccion import ordenar, maximo, minimo, sin_duplicados
+from .seguridad import hash_md5, hash_sha256, generar_uuid
+from .red import obtener_url, enviar_post
+from .sistema import obtener_os, ejecutar, obtener_env, listar_dir
+
+__all__ = [
+    "mayusculas",
+    "minusculas",
+    "invertir",
+    "concatenar",
+    "es_par",
+    "es_primo",
+    "factorial",
+    "promedio",
+    "leer",
+    "escribir",
+    "existe",
+    "eliminar",
+    "ahora",
+    "formatear",
+    "dormir",
+    "ordenar",
+    "maximo",
+    "minimo",
+    "sin_duplicados",
+    "hash_md5",
+    "hash_sha256",
+    "generar_uuid",
+    "obtener_url",
+    "enviar_post",
+    "obtener_os",
+    "ejecutar",
+    "obtener_env",
+    "listar_dir",
+]

--- a/backend/corelibs/archivo.py
+++ b/backend/corelibs/archivo.py
@@ -1,0 +1,26 @@
+"""Funciones de manejo de archivos de texto."""
+
+import os
+
+
+def leer(ruta: str) -> str:
+    """Devuelve el contenido de un archivo."""
+    with open(ruta, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def escribir(ruta: str, datos: str) -> None:
+    """Escribe *datos* en el archivo indicado."""
+    with open(ruta, "w", encoding="utf-8") as f:
+        f.write(datos)
+
+
+def existe(ruta: str) -> bool:
+    """Indica si el archivo *ruta* existe."""
+    return os.path.exists(ruta)
+
+
+def eliminar(ruta: str) -> None:
+    """Elimina el archivo si existe."""
+    if os.path.exists(ruta):
+        os.remove(ruta)

--- a/backend/corelibs/coleccion.py
+++ b/backend/corelibs/coleccion.py
@@ -1,0 +1,21 @@
+"""Funciones para trabajar con colecciones."""
+
+
+def ordenar(lista):
+    """Devuelve una copia ordenada de *lista*."""
+    return sorted(lista)
+
+
+def maximo(lista):
+    """Devuelve el valor máximo de *lista*."""
+    return max(lista)
+
+
+def minimo(lista):
+    """Devuelve el valor mínimo de *lista*."""
+    return min(lista)
+
+
+def sin_duplicados(lista):
+    """Retorna una lista sin elementos duplicados manteniendo el orden."""
+    return list(dict.fromkeys(lista))

--- a/backend/corelibs/numero.py
+++ b/backend/corelibs/numero.py
@@ -1,0 +1,29 @@
+"""Operaciones numéricas comunes."""
+
+
+def es_par(n: int) -> bool:
+    """Retorna ``True`` si *n* es par."""
+    return n % 2 == 0
+
+
+def es_primo(n: int) -> bool:
+    """Determina si *n* es un número primo."""
+    if n <= 1:
+        return False
+    for i in range(2, int(n ** 0.5) + 1):
+        if n % i == 0:
+            return False
+    return True
+
+
+def factorial(n: int) -> int:
+    """Calcula el factorial de *n*."""
+    resultado = 1
+    for i in range(1, n + 1):
+        resultado *= i
+    return resultado
+
+
+def promedio(valores) -> float:
+    """Calcula el promedio de una secuencia de valores."""
+    return sum(valores) / len(valores) if valores else 0.0

--- a/backend/corelibs/red.py
+++ b/backend/corelibs/red.py
@@ -1,0 +1,17 @@
+"""Funciones para realizar peticiones de red básicas."""
+
+import urllib.parse
+import urllib.request
+
+
+def obtener_url(url: str) -> str:
+    """Devuelve el contenido de una URL como texto."""
+    with urllib.request.urlopen(url) as resp:
+        return resp.read().decode("utf-8")
+
+
+def enviar_post(url: str, datos: dict) -> str:
+    """Envía datos por POST y retorna la respuesta."""
+    encoded = urllib.parse.urlencode(datos).encode()
+    with urllib.request.urlopen(url, encoded) as resp:
+        return resp.read().decode("utf-8")

--- a/backend/corelibs/seguridad.py
+++ b/backend/corelibs/seguridad.py
@@ -1,0 +1,19 @@
+"""Operaciones sencillas de seguridad y hashing."""
+
+import hashlib
+import uuid
+
+
+def hash_md5(texto: str) -> str:
+    """Devuelve el hash MD5 de *texto*."""
+    return hashlib.md5(texto.encode("utf-8")).hexdigest()
+
+
+def hash_sha256(texto: str) -> str:
+    """Devuelve el hash SHA-256 de *texto*."""
+    return hashlib.sha256(texto.encode("utf-8")).hexdigest()
+
+
+def generar_uuid() -> str:
+    """Genera un identificador único."""
+    return str(uuid.uuid4())

--- a/backend/corelibs/sistema.py
+++ b/backend/corelibs/sistema.py
@@ -1,0 +1,33 @@
+"""Funciones relacionadas con el sistema operativo."""
+
+import os
+import platform
+import subprocess
+
+
+def obtener_os() -> str:
+    """Retorna el nombre del sistema operativo."""
+    return platform.system()
+
+
+def ejecutar(comando: str) -> str:
+    """Ejecuta un comando y devuelve su salida."""
+    resultado = subprocess.run(
+        comando,
+        shell=True,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return resultado.stdout
+
+
+def obtener_env(nombre: str) -> str | None:
+    """Devuelve el valor de una variable de entorno."""
+    return os.getenv(nombre)
+
+
+def listar_dir(ruta: str) -> list[str]:
+    """Lista los archivos de un directorio."""
+    return os.listdir(ruta)

--- a/backend/corelibs/texto.py
+++ b/backend/corelibs/texto.py
@@ -1,0 +1,21 @@
+"""Funciones utilitarias para manipular cadenas de texto."""
+
+
+def mayusculas(texto: str) -> str:
+    """Devuelve *texto* en mayúsculas."""
+    return texto.upper()
+
+
+def minusculas(texto: str) -> str:
+    """Devuelve *texto* en minúsculas."""
+    return texto.lower()
+
+
+def invertir(texto: str) -> str:
+    """Invierte el contenido de *texto*."""
+    return texto[::-1]
+
+
+def concatenar(*cadenas: str) -> str:
+    """Concatena las cadenas proporcionadas."""
+    return "".join(cadenas)

--- a/backend/corelibs/tiempo.py
+++ b/backend/corelibs/tiempo.py
@@ -1,0 +1,19 @@
+"""Utilidades relacionadas con el tiempo."""
+
+import time
+from datetime import datetime
+
+
+def ahora() -> datetime:
+    """Devuelve la fecha y hora actual."""
+    return datetime.now()
+
+
+def formatear(fecha: datetime, formato: str = "%Y-%m-%d %H:%M:%S") -> str:
+    """Convierte *fecha* a texto según *formato*."""
+    return fecha.strftime(formato)
+
+
+def dormir(segundos: float) -> None:
+    """Detiene la ejecución durante *segundos*."""
+    time.sleep(segundos)

--- a/backend/src/core/nativos/archivo.js
+++ b/backend/src/core/nativos/archivo.js
@@ -1,0 +1,17 @@
+import fs from 'fs';
+
+export function leer(ruta) {
+    return fs.readFileSync(ruta, 'utf-8');
+}
+
+export function escribir(ruta, datos) {
+    fs.writeFileSync(ruta, datos);
+}
+
+export function existe(ruta) {
+    return fs.existsSync(ruta);
+}
+
+export function eliminar(ruta) {
+    if (fs.existsSync(ruta)) fs.unlinkSync(ruta);
+}

--- a/backend/src/core/nativos/coleccion.js
+++ b/backend/src/core/nativos/coleccion.js
@@ -1,0 +1,15 @@
+export function ordenar(lista) {
+    return [...lista].sort();
+}
+
+export function maximo(lista) {
+    return Math.max(...lista);
+}
+
+export function minimo(lista) {
+    return Math.min(...lista);
+}
+
+export function sin_duplicados(lista) {
+    return Array.from(new Set(lista));
+}

--- a/backend/src/core/nativos/numero.js
+++ b/backend/src/core/nativos/numero.js
@@ -1,0 +1,25 @@
+export function es_par(n) {
+    return n % 2 === 0;
+}
+
+export function es_primo(n) {
+    if (n <= 1) return false;
+    for (let i = 2; i <= Math.sqrt(n); i++) {
+        if (n % i === 0) return false;
+    }
+    return true;
+}
+
+export function factorial(n) {
+    let r = 1;
+    for (let i = 1; i <= n; i++) {
+        r *= i;
+    }
+    return r;
+}
+
+export function promedio(lista) {
+    if (lista.length === 0) return 0;
+    const total = lista.reduce((a, b) => a + b, 0);
+    return total / lista.length;
+}

--- a/backend/src/core/nativos/red.js
+++ b/backend/src/core/nativos/red.js
@@ -1,0 +1,16 @@
+import fetch from 'node-fetch';
+import * as querystring from 'querystring';
+
+export async function obtener_url(url) {
+    const res = await fetch(url);
+    return await res.text();
+}
+
+export async function enviar_post(url, datos) {
+    const res = await fetch(url, {
+        method: 'POST',
+        body: querystring.stringify(datos),
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+    });
+    return await res.text();
+}

--- a/backend/src/core/nativos/seguridad.js
+++ b/backend/src/core/nativos/seguridad.js
@@ -1,0 +1,14 @@
+import crypto from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
+
+export function hash_md5(texto) {
+    return crypto.createHash('md5').update(texto).digest('hex');
+}
+
+export function hash_sha256(texto) {
+    return crypto.createHash('sha256').update(texto).digest('hex');
+}
+
+export function generar_uuid() {
+    return uuidv4();
+}

--- a/backend/src/core/nativos/sistema.js
+++ b/backend/src/core/nativos/sistema.js
@@ -1,0 +1,19 @@
+import os from 'os';
+import fs from 'fs';
+import child_process from 'child_process';
+
+export function obtener_os() {
+    return os.platform();
+}
+
+export function ejecutar(cmd) {
+    return child_process.execSync(cmd, { encoding: 'utf-8' });
+}
+
+export function obtener_env(nombre) {
+    return process.env[nombre];
+}
+
+export function listar_dir(ruta) {
+    return fs.readdirSync(ruta);
+}

--- a/backend/src/core/nativos/texto.js
+++ b/backend/src/core/nativos/texto.js
@@ -1,0 +1,15 @@
+export function mayusculas(texto) {
+    return texto.toUpperCase();
+}
+
+export function minusculas(texto) {
+    return texto.toLowerCase();
+}
+
+export function invertir(texto) {
+    return texto.split('').reverse().join('');
+}
+
+export function concatenar(...cadenas) {
+    return cadenas.join('');
+}

--- a/backend/src/core/nativos/tiempo.js
+++ b/backend/src/core/nativos/tiempo.js
@@ -1,0 +1,12 @@
+export function ahora() {
+    return Date.now();
+}
+
+export function formatear(fecha, formato) {
+    const d = new Date(fecha);
+    return d.toISOString();
+}
+
+export function dormir(ms) {
+    return new Promise(res => setTimeout(res, ms));
+}


### PR DESCRIPTION
## Summary
- implement new python "corelibs" with text, numeric, file, time, collection, security, network and system utilities
- add JavaScript counterparts for parity with transpiled JS
- expose the new functions via backend/corelibs/__init__

## Testing
- `pytest backend/src/tests/test_to_python.py::test_transpilador_asignacion -q`

------
https://chatgpt.com/codex/tasks/task_e_6862a2c692148327a51b289d2afce102