### PR TITLE
Add corelibs check in usar_loader

### DIFF
--- a/backend/src/cobra/usar_loader.py
+++ b/backend/src/cobra/usar_loader.py
@@ -1,5 +1,8 @@
 import importlib
+import importlib.util
 import subprocess
+from pathlib import Path
+import sys
 
 # Lista blanca de paquetes que se pueden instalar con ``usar``.
 USAR_WHITELIST: set[str] = set()
@@ -15,6 +18,18 @@ def obtener_modulo(nombre: str):
     try:
         return importlib.import_module(nombre)
     except ModuleNotFoundError:
+        # Verificar si el módulo existe dentro de ``backend/corelibs``
+        corelibs = Path(__file__).resolve().parents[2] / "corelibs"
+        mod_path = corelibs / f"{nombre}.py"
+        pkg_path = corelibs / nombre / "__init__.py"
+        if mod_path.exists() or pkg_path.exists():
+            ruta = mod_path if mod_path.exists() else pkg_path
+            spec = importlib.util.spec_from_file_location(nombre, ruta)
+            modulo = importlib.util.module_from_spec(spec)
+            sys.modules[nombre] = modulo
+            spec.loader.exec_module(modulo)
+            return modulo
+
         print(f"Paquete '{nombre}' no encontrado. Instalando...")
         try:
             subprocess.run(["pip", "install", nombre], check=True)


### PR DESCRIPTION
## Summary
- load modules from `backend/corelibs` before falling back to pip in `usar_loader`
- ensure tests don't require external deps
- add test to verify `usar` loads from corelibs without running pip

## Testing
- `pytest backend/src/tests/test_usar.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6862aa47722c8327b34733361bd61bc7