### PR TITLE
Ampliar imports y pruebas de transpiladores

### DIFF
--- a/backend/src/cobra/transpilers/import_helper.py
+++ b/backend/src/cobra/transpilers/import_helper.py
@@ -8,12 +8,20 @@ from .module_map import get_mapped_path
 
 # Mapeo de importaciones estándar por lenguaje
 STANDARD_IMPORTS = {
-    "python": "from src.core.nativos import *\n",
+    "python": "from src.core.nativos import *\nfrom corelibs import *\n",
     "js": [
         "import * as io from './nativos/io.js';",
-        "import * as net from './nativos/io.js';",
+        "import * as net from './nativos/red.js';",
         "import * as matematicas from './nativos/matematicas.js';",
         "import { Pila, Cola } from './nativos/estructuras.js';",
+        "import * as archivo from './nativos/archivo.js';",
+        "import * as coleccion from './nativos/coleccion.js';",
+        "import * as numero from './nativos/numero.js';",
+        "import * as red from './nativos/red.js';",
+        "import * as seguridad from './nativos/seguridad.js';",
+        "import * as sistema from './nativos/sistema.js';",
+        "import * as texto from './nativos/texto.js';",
+        "import * as tiempo from './nativos/tiempo.js';",
     ],
 }
 

--- a/backend/src/tests/test_to_js.py
+++ b/backend/src/tests/test_to_js.py
@@ -1,5 +1,6 @@
 import pytest
 from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from src.cobra.transpilers.import_helper import get_standard_imports
 from src.core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
@@ -21,12 +22,7 @@ from src.core.ast_nodes import (
     NodoExport,
 )
 
-IMPORTS = (
-    "import * as io from './nativos/io.js';\n"
-    "import * as net from './nativos/io.js';\n"
-    "import * as matematicas from './nativos/matematicas.js';\n"
-    "import { Pila, Cola } from './nativos/estructuras.js';\n"
-)
+IMPORTS = "".join(f"{line}\n" for line in get_standard_imports("js"))
 
 
 def test_transpilador_asignacion():
@@ -169,4 +165,10 @@ def test_decoradores_en_clase_y_metodo_js():
         "C.prototype.run = dec(C.prototype.run);\n"
         "C = dec(C);"
     )
+    assert resultado == esperado
+
+
+def test_imports_js_por_defecto():
+    resultado = TranspiladorJavaScript().transpilar([])
+    esperado = "\n".join(get_standard_imports("js"))
     assert resultado == esperado

--- a/backend/src/tests/test_to_js3.py
+++ b/backend/src/tests/test_to_js3.py
@@ -1,4 +1,5 @@
 from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from src.cobra.transpilers.import_helper import get_standard_imports
 
 
 # Definición de nodos para las pruebas
@@ -159,12 +160,10 @@ def test_transpilar_clase_multibase():
     nodo = NodoClase("Hija", [metodo], ["Base1", "Base2"])
     transpiler = TranspiladorJavaScript()
     result = transpiler.transpilar([nodo])
+    imports = "".join(f"{line}\n" for line in get_standard_imports("js"))
     expected = (
-        "import * as io from './nativos/io.js';\n"
-        "import * as net from './nativos/io.js';\n"
-        "import * as matematicas from './nativos/matematicas.js';\n"
-        "import { Pila, Cola } from './nativos/estructuras.js';\n"
-        "class Hija extends Base1 { /* bases: Base1, Base2 */\n"
+        imports
+        + "class Hija extends Base1 { /* bases: Base1, Base2 */\n"
         "m(p) {\n"
         "x = p;\n"
         "}\n"

--- a/backend/src/tests/test_to_js4.py
+++ b/backend/src/tests/test_to_js4.py
@@ -1,4 +1,5 @@
 from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from src.cobra.transpilers.import_helper import get_standard_imports
 
 
 # Nodos simulados para pruebas
@@ -159,12 +160,10 @@ def test_transpilar_clase_multibase():
     nodo = NodoClase("Hija", [metodo], ["Base1", "Base2"])
     transpiler = TranspiladorJavaScript()
     result = transpiler.transpilar([nodo])
+    imports = "".join(f"{line}\n" for line in get_standard_imports("js"))
     expected = (
-        "import * as io from './nativos/io.js';\n"
-        "import * as net from './nativos/io.js';\n"
-        "import * as matematicas from './nativos/matematicas.js';\n"
-        "import { Pila, Cola } from './nativos/estructuras.js';\n"
-        "class Hija extends Base1 { /* bases: Base1, Base2 */\n"
+        imports
+        + "class Hija extends Base1 { /* bases: Base1, Base2 */\n"
         "m(p) {\n"
         "x = p;\n"
         "}\n"

--- a/backend/src/tests/test_to_python.py
+++ b/backend/src/tests/test_to_python.py
@@ -22,7 +22,7 @@ def test_transpilador_asignacion():
     ast = [NodoAsignacion("x", NodoValor(10))]
     transpilador = TranspiladorPython()
     resultado = transpilador.transpilar(ast)
-    esperado = "from src.core.nativos import *\nx = 10\n"
+    esperado = IMPORTS + "x = 10\n"
     assert resultado == esperado
 
 
@@ -37,7 +37,7 @@ def test_transpilador_condicional():
     transpilador = TranspiladorPython()
     resultado = transpilador.transpilar(ast)
     esperado = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "if x > 5:\n    y = 2\nelse:\n    y = 3\n"
     )
     assert resultado == esperado
@@ -52,7 +52,7 @@ def test_transpilador_mientras():
     transpilador = TranspiladorPython()
     resultado = transpilador.transpilar(ast)
     esperado = (
-        "from src.core.nativos import *\nwhile x > 0:\n    x = x - 1\n"
+        IMPORTS + "while x > 0:\n    x = x - 1\n"
     )
     assert resultado == esperado
 
@@ -68,7 +68,7 @@ def test_transpilador_funcion():
     transpilador = TranspiladorPython()
     resultado = transpilador.transpilar(ast)
     esperado = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "def miFuncion(a, b):\n    x = a + b\n"
     )
     assert resultado == esperado
@@ -78,7 +78,7 @@ def test_transpilador_llamada_funcion():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     transpilador = TranspiladorPython()
     resultado = transpilador.transpilar(ast)
-    esperado = "from src.core.nativos import *\nmiFuncion(a, b)\n"
+    esperado = IMPORTS + "miFuncion(a, b)\n"
     assert resultado == esperado
 
 
@@ -87,7 +87,7 @@ def test_transpilador_holobit():
     transpilador = TranspiladorPython()
     resultado = transpilador.transpilar(ast)
     esperado = (
-        "from src.core.nativos import *\nmiHolobit = holobit([0.8, -0.5, 1.2])\n"
+        IMPORTS + "miHolobit = holobit([0.8, -0.5, 1.2])\n"
     )
     assert resultado == esperado
 
@@ -106,7 +106,7 @@ def test_transpilador_switch():
     t = TranspiladorPython()
     resultado = t.transpilar(ast)
     esperado = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "match x:\n"
         "    case 1:\n"
         "        y = 1\n"
@@ -129,7 +129,7 @@ def test_transpilador_decoradores_anidados():
     )
     codigo = TranspiladorPython().transpilar([func])
     esperado = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "@d1\n"
         "@d2\n"
         "def saluda():\n    print('hola')\n"
@@ -148,7 +148,7 @@ def test_transpilador_corutina_await():
     codigo = TranspiladorPython().transpilar([f1, f2])
     esperado = (
         "import asyncio\n"
-        "from src.core.nativos import *\n"
+        IMPORTS
         "async def saluda():\n    print(1)\n"
         "async def principal():\n    await saluda()\n"
     )
@@ -166,7 +166,7 @@ def test_transpilador_clase_compleja():
     codigo = TranspiladorPython().transpilar([clase])
     esperado = (
         "import asyncio\n"
-        "from src.core.nativos import *\n"
+        IMPORTS
         "class Hija(Base1, Base2):\n"
         "    async def run(self):\n"
         "        await tarea()\n"
@@ -182,7 +182,7 @@ def test_decoradores_en_clase_y_metodo():
     codigo = TranspiladorPython().transpilar([clase])
     esperado = (
         "import asyncio\n"
-        "from src.core.nativos import *\n"
+        IMPORTS
         "@dec\n"
         "class C:\n"
         "    @dec\n"
@@ -190,3 +190,8 @@ def test_decoradores_en_clase_y_metodo():
         "        pass\n"
     )
     assert codigo == esperado
+
+
+def test_imports_python_por_defecto():
+    codigo = TranspiladorPython().transpilar([])
+    assert codigo == IMPORTS

--- a/backend/src/tests/test_to_python2.py
+++ b/backend/src/tests/test_to_python2.py
@@ -1,4 +1,7 @@
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 from src.core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
@@ -14,7 +17,7 @@ def test_transpilar_asignacion():
     nodo = NodoAsignacion("variable", NodoValor("10"))
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    esperado = "from src.core.nativos import *\nvariable = 10\n"
+    esperado = IMPORTS + "variable = 10\n"
     assert result == esperado, "Error en la transpilaci\u00f3n de asignaci\u00f3n"
 
 
@@ -27,7 +30,7 @@ def test_transpilar_condicional():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "if x > 5:\n    y = 10\nelse:\n    y = 0\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de condicional"
@@ -38,7 +41,7 @@ def test_transpilar_mientras():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\nwhile i < 10:\n    i = i + 1\n"
+        IMPORTS + "while i < 10:\n    i = i + 1\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de bucle mientras"
 
@@ -48,7 +51,7 @@ def test_transpilar_funcion():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "def sumar(a, b):\n    resultado = a + b\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de funci\u00f3n"
@@ -58,7 +61,7 @@ def test_transpilar_llamada_funcion():
     nodo = NodoLlamadaFuncion("sumar", ["5", "3"])
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    esperado = "from src.core.nativos import *\nsumar(5, 3)\n"
+    esperado = IMPORTS + "sumar(5, 3)\n"
     assert result == esperado, "Error en la transpilaci\u00f3n de llamada a funci\u00f3n"
 
 
@@ -66,5 +69,5 @@ def test_transpilar_holobit():
     nodo = NodoHolobit("miHolobit", [1, 2, 3])
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    esperado = "from src.core.nativos import *\nmiHolobit = holobit([1, 2, 3])\n"
+    esperado = IMPORTS + "miHolobit = holobit([1, 2, 3])\n"
     assert result == esperado, "Error en la transpilaci\u00f3n de Holobit"

--- a/backend/src/tests/test_to_python3.py
+++ b/backend/src/tests/test_to_python3.py
@@ -1,4 +1,7 @@
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 from src.core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
@@ -20,7 +23,7 @@ def test_transpilar_asignacion():
     nodo = NodoAsignacion("variable", NodoValor("10"))
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    esperado = "from src.core.nativos import *\nvariable = 10\n"
+    esperado = IMPORTS + "variable = 10\n"
     assert result == esperado, "Error en la transpilaci\u00f3n de asignaci\u00f3n"
 
 
@@ -33,7 +36,7 @@ def test_transpilar_condicional():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "if x > 5:\n    y = 10\nelse:\n    y = 0\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de condicional"
@@ -44,7 +47,7 @@ def test_transpilar_mientras():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\nwhile i < 10:\n    i = i + 1\n"
+        IMPORTS + "while i < 10:\n    i = i + 1\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de bucle mientras"
 
@@ -58,7 +61,7 @@ def test_transpilar_funcion():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "def sumar(a, b):\n    resultado = a + b\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de funci\u00f3n"
@@ -68,7 +71,7 @@ def test_transpilar_llamada_funcion():
     nodo = NodoLlamadaFuncion("sumar", ["5", "3"])
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    esperado = "from src.core.nativos import *\nsumar(5, 3)\n"
+    esperado = IMPORTS + "sumar(5, 3)\n"
     assert result == esperado, "Error en la transpilaci\u00f3n de llamada a funci\u00f3n"
 
 
@@ -76,7 +79,7 @@ def test_transpilar_holobit():
     nodo = NodoHolobit("miHolobit", [1, 2, 3])
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    esperado = "from src.core.nativos import *\nmiHolobit = holobit([1, 2, 3])\n"
+    esperado = IMPORTS + "miHolobit = holobit([1, 2, 3])\n"
     assert result == esperado, "Error en la transpilaci\u00f3n de Holobit"
 
 
@@ -85,7 +88,7 @@ def test_transpilar_for():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\nfor i in lista:\n    suma = suma + i\n"
+        IMPORTS + "for i in lista:\n    suma = suma + i\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de bucle for"
 
@@ -94,7 +97,7 @@ def test_transpilar_lista():
     nodo = NodoLista([NodoValor("1"), NodoValor("2"), NodoValor("3")])
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    expected = "from src.core.nativos import *\n[1, 2, 3]\n"
+    expected = IMPORTS + "[1, 2, 3]\n"
     assert result == expected, "Error en la transpilaci\u00f3n de lista"
 
 
@@ -106,7 +109,7 @@ def test_transpilar_diccionario():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\n{clave1: valor1, clave2: valor2}\n"
+        IMPORTS + "{clave1: valor1, clave2: valor2}\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de diccionario"
 
@@ -117,7 +120,7 @@ def test_transpilar_clase():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "class MiClase:\n    def miMetodo(param):\n        x = param + 1\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de clase"
@@ -129,7 +132,7 @@ def test_transpilar_clase_multibase():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "class Hija(Base1, Base2):\n    def m(self):\n        return 1\n"
     )
     assert result == expected, "Error en herencia múltiple"
@@ -140,7 +143,7 @@ def test_transpilar_metodo():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "def miMetodo(a, b):\n    resultado = a + b\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de m\u00e9todo"

--- a/backend/src/tests/test_to_python4.py
+++ b/backend/src/tests/test_to_python4.py
@@ -1,13 +1,16 @@
 import pytest
 from src.core.ast_nodes import NodoAsignacion, NodoCondicional, NodoBucleMientras, NodoFuncion, NodoLlamadaFuncion, NodoHolobit, NodoFor, NodoLista, NodoDiccionario, NodoClase, NodoMetodo, NodoValor, NodoRetorno
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 
 
 def test_transpilar_asignacion():
     nodo = NodoAsignacion("variable", NodoValor("10"))
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    expected = "from src.core.nativos import *\nvariable = 10\n"
+    expected = IMPORTS + "variable = 10\n"
     assert result == expected, "Error en la transpilación de asignación"
 
 
@@ -16,7 +19,7 @@ def test_transpilar_condicional():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "if x > 5:\n    y = 10\nelse:\n    y = 0\n"
     )
     assert result == expected, "Error en la transpilación de condicional"
@@ -26,7 +29,7 @@ def test_transpilar_mientras():
     nodo = NodoBucleMientras("i < 10", [NodoAsignacion("i", NodoValor("i + 1"))])
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    expected = "from src.core.nativos import *\nwhile i < 10:\n    i = i + 1\n"
+    expected = IMPORTS + "while i < 10:\n    i = i + 1\n"
     assert result == expected, "Error en la transpilación de bucle mientras"
 
 
@@ -35,7 +38,7 @@ def test_transpilar_funcion():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "def sumar(a, b):\n    resultado = a + b\n"
     )
     assert result == expected, "Error en la transpilación de función"
@@ -45,7 +48,7 @@ def test_transpilar_llamada_funcion():
     nodo = NodoLlamadaFuncion("sumar", ["5", "3"])
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    expected = "from src.core.nativos import *\nsumar(5, 3)\n"
+    expected = IMPORTS + "sumar(5, 3)\n"
     assert result == expected, "Error en la transpilación de llamada a función"
 
 
@@ -53,7 +56,7 @@ def test_transpilar_holobit():
     nodo = NodoHolobit([NodoValor(1), NodoValor(2), NodoValor(3)])
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    expected = "from src.core.nativos import *\nholobit([1, 2, 3])\n"
+    expected = IMPORTS + "holobit([1, 2, 3])\n"
     assert result == expected, "Error en la transpilación de holobit"
 
 
@@ -62,7 +65,7 @@ def test_transpilar_for():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\nfor i in lista:\n    suma = suma + i\n"
+        IMPORTS + "for i in lista:\n    suma = suma + i\n"
     )
     assert result == expected, "Error en la transpilación de bucle for"
 
@@ -71,7 +74,7 @@ def test_transpilar_lista():
     nodo = NodoLista([NodoValor("1"), NodoValor("2"), NodoValor("3")])
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    expected = "from src.core.nativos import *\n[1, 2, 3]\n"
+    expected = IMPORTS + "[1, 2, 3]\n"
     assert result == expected, "Error en la transpilación de lista"
 
 
@@ -80,7 +83,7 @@ def test_transpilar_diccionario():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\n{clave1: valor1, clave2: valor2}\n"
+        IMPORTS + "{clave1: valor1, clave2: valor2}\n"
     )
     assert result == expected, "Error en la transpilación de diccionario"
 
@@ -91,7 +94,7 @@ def test_transpilar_clase():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "class MiClase:\n    def mi_metodo(param):\n        x = param + 1\n"
     )
     assert result == expected, "Error en la transpilación de clase"
@@ -103,7 +106,7 @@ def test_transpilar_clase_multibase():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "class Hija(Base1, Base2):\n    def m(self):\n        return 1\n"
     )
     assert result == expected, "Error en herencia múltiple"
@@ -114,7 +117,7 @@ def test_transpilar_metodo():
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
     expected = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "def mi_metodo(a, b):\n    resultado = a + b\n"
     )
     assert result == expected, "Error en la transpilación de método"

--- a/backend/src/tests/test_to_python_extras.py
+++ b/backend/src/tests/test_to_python_extras.py
@@ -9,6 +9,9 @@ from src.core.ast_nodes import (
     NodoUsar,
 )
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 
 
 def test_transpilar_try_catch_throw():
@@ -19,7 +22,7 @@ def test_transpilar_try_catch_throw():
     )
     codigo = TranspiladorPython().transpilar([nodo])
     esperado = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "try:\n    raise Exception(1)\nexcept Exception as e:\n    print(e)\n"
     )
     assert codigo == esperado
@@ -30,7 +33,7 @@ def test_transpilar_import(tmp_path):
     mod.write_text("var dato = 5")
     nodo = NodoImport(str(mod))
     codigo = TranspiladorPython().transpilar([nodo])
-    esperado = "from src.core.nativos import *\ndato = 5\n"
+    esperado = IMPORTS + "dato = 5\n"
     assert codigo == esperado
 
 
@@ -38,7 +41,7 @@ def test_transpilar_usar():
     nodo = NodoUsar("math")
     codigo = TranspiladorPython().transpilar([nodo])
     esperado = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "from src.cobra.usar_loader import obtener_modulo\n"
         "math = obtener_modulo('math')\n"
     )

--- a/backend/src/tests/test_to_python_objects.py
+++ b/backend/src/tests/test_to_python_objects.py
@@ -1,4 +1,7 @@
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 from src.core.ast_nodes import NodoInstancia, NodoLlamadaMetodo, NodoIdentificador, NodoValor
 
 
@@ -6,7 +9,7 @@ def test_transpilar_instancia():
     nodo = NodoInstancia("Clase")
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    esperado = "from src.core.nativos import *\nClase()\n"
+    esperado = IMPORTS + "Clase()\n"
     assert result == esperado
 
 
@@ -14,5 +17,5 @@ def test_transpilar_llamada_metodo():
     nodo = NodoLlamadaMetodo(NodoIdentificador("obj"), "metodo", [NodoValor(1)])
     transpiler = TranspiladorPython()
     result = transpiler.transpilar([nodo])
-    esperado = "from src.core.nativos import *\nobj.metodo(1)\n"
+    esperado = IMPORTS + "obj.metodo(1)\n"
     assert result == esperado


### PR DESCRIPTION
## Summary
- agregar todos los módulos nativos al diccionario `STANDARD_IMPORTS`
- corregir la ruta del módulo de red y añadir utilidades JS
- actualizar pruebas de transpiladores para usar `get_standard_imports`
- añadir comprobaciones de imports por defecto en Python y JS

## Testing
- `python backend/src/tests/suite_transpiladores.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6862acb84f488327927c5362485f063d