### PR TITLE
Add docs for new native modules

### DIFF
--- a/frontend/docs/api/src.core.nativos.archivo.rst
+++ b/frontend/docs/api/src.core.nativos.archivo.rst
@@ -1,0 +1,7 @@
+src.core.nativos.archivo module
+-------------------------------
+
+.. automodule:: src.core.nativos.archivo
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.nativos.coleccion.rst
+++ b/frontend/docs/api/src.core.nativos.coleccion.rst
@@ -1,0 +1,7 @@
+src.core.nativos.coleccion module
+---------------------------------
+
+.. automodule:: src.core.nativos.coleccion
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.nativos.numero.rst
+++ b/frontend/docs/api/src.core.nativos.numero.rst
@@ -1,0 +1,7 @@
+src.core.nativos.numero module
+------------------------------
+
+.. automodule:: src.core.nativos.numero
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.nativos.red.rst
+++ b/frontend/docs/api/src.core.nativos.red.rst
@@ -1,0 +1,7 @@
+src.core.nativos.red module
+---------------------------
+
+.. automodule:: src.core.nativos.red
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.nativos.rst
+++ b/frontend/docs/api/src.core.nativos.rst
@@ -4,6 +4,18 @@ src.core.nativos package
 Submodules
 ----------
 
+.. toctree::
+   :maxdepth: 4
+
+   src.core.nativos.archivo
+   src.core.nativos.coleccion
+   src.core.nativos.numero
+   src.core.nativos.red
+   src.core.nativos.seguridad
+   src.core.nativos.sistema
+   src.core.nativos.texto
+   src.core.nativos.tiempo
+
 src.core.nativos.estructuras module
 -----------------------------------
 
@@ -24,6 +36,70 @@ src.core.nativos.matematicas module
 -----------------------------------
 
 .. automodule:: src.core.nativos.matematicas
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.nativos.archivo module
+-------------------------------
+
+.. automodule:: src.core.nativos.archivo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.nativos.coleccion module
+---------------------------------
+
+.. automodule:: src.core.nativos.coleccion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.nativos.numero module
+------------------------------
+
+.. automodule:: src.core.nativos.numero
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.nativos.red module
+---------------------------
+
+.. automodule:: src.core.nativos.red
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.nativos.seguridad module
+---------------------------------
+
+.. automodule:: src.core.nativos.seguridad
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.nativos.sistema module
+-------------------------------
+
+.. automodule:: src.core.nativos.sistema
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.nativos.texto module
+-----------------------------
+
+.. automodule:: src.core.nativos.texto
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+src.core.nativos.tiempo module
+------------------------------
+
+.. automodule:: src.core.nativos.tiempo
    :members:
    :undoc-members:
    :show-inheritance:

--- a/frontend/docs/api/src.core.nativos.seguridad.rst
+++ b/frontend/docs/api/src.core.nativos.seguridad.rst
@@ -1,0 +1,7 @@
+src.core.nativos.seguridad module
+---------------------------------
+
+.. automodule:: src.core.nativos.seguridad
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.nativos.sistema.rst
+++ b/frontend/docs/api/src.core.nativos.sistema.rst
@@ -1,0 +1,7 @@
+src.core.nativos.sistema module
+-------------------------------
+
+.. automodule:: src.core.nativos.sistema
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.nativos.texto.rst
+++ b/frontend/docs/api/src.core.nativos.texto.rst
@@ -1,0 +1,7 @@
+src.core.nativos.texto module
+-----------------------------
+
+.. automodule:: src.core.nativos.texto
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/api/src.core.nativos.tiempo.rst
+++ b/frontend/docs/api/src.core.nativos.tiempo.rst
@@ -1,0 +1,7 @@
+src.core.nativos.tiempo module
+------------------------------
+
+.. automodule:: src.core.nativos.tiempo
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/frontend/docs/modulos_nativos.rst
+++ b/frontend/docs/modulos_nativos.rst
@@ -22,6 +22,95 @@ Estructuras de datos
 - ``Pila`` con los metodos ``apilar`` y ``desapilar``.
 - ``Cola`` con los metodos ``encolar`` y ``desencolar``.
 
+Manejo de archivos
+------------------
+- ``leer(ruta)`` devuelve el contenido de un archivo.
+- ``escribir(ruta, datos)`` guarda datos de texto.
+- ``existe(ruta)`` comprueba si el archivo existe.
+- ``eliminar(ruta)`` borra el archivo indicado.
+
+.. code-block:: cobra
+
+   si not existe("datos.txt"):
+       escribir("datos.txt", "hola")
+   imprimir(leer("datos.txt"))
+
+Colecciones
+-----------
+- ``ordenar(lista)`` retorna la lista ordenada.
+- ``maximo(lista)`` devuelve el mayor valor.
+- ``minimo(lista)`` devuelve el menor valor.
+- ``sin_duplicados(lista)`` elimina elementos repetidos.
+
+.. code-block:: cobra
+
+   var numeros = [3, 1, 2, 1]
+   imprimir(ordenar(numeros))
+   imprimir(sin_duplicados(numeros))
+
+Operaciones numericas
+---------------------
+- ``es_par(n)`` indica si ``n`` es par.
+- ``es_primo(n)`` verifica si ``n`` es primo.
+- ``factorial(n)`` calcula el factorial de ``n``.
+- ``promedio(lista)`` promedia una lista de numeros.
+
+.. code-block:: cobra
+
+   imprimir(es_primo(7))
+   imprimir(factorial(5))
+
+Red
+---
+- ``obtener_url(url)`` recupera el contenido de una URL.
+- ``enviar_post(url, datos)`` envia datos por ``POST``.
+
+.. code-block:: cobra
+
+   var html = obtener_url("https://ejemplo.com")
+
+Seguridad
+---------
+- ``hash_md5(texto)`` devuelve el hash MD5 de ``texto``.
+- ``hash_sha256(texto)`` devuelve el hash SHA-256.
+- ``generar_uuid()`` crea un identificador unico.
+
+.. code-block:: cobra
+
+   var id = generar_uuid()
+
+Sistema
+-------
+- ``obtener_os()`` retorna el sistema operativo.
+- ``ejecutar(cmd)`` ejecuta un comando en la consola.
+- ``obtener_env(nombre)`` lee variables de entorno.
+- ``listar_dir(ruta)`` lista los archivos de un directorio.
+
+.. code-block:: cobra
+
+   imprimir(obtener_os())
+
+Texto
+-----
+- ``mayusculas(texto)`` convierte a mayusculas.
+- ``minusculas(texto)`` convierte a minusculas.
+- ``invertir(texto)`` invierte el texto.
+- ``concatenar(...cadenas)`` une varias cadenas.
+
+.. code-block:: cobra
+
+   imprimir(mayusculas("cobra"))
+
+Tiempo
+------
+- ``ahora()`` devuelve la fecha y hora actual.
+- ``formatear(fecha, formato)`` formatea una fecha.
+- ``dormir(segundos)`` pausa la ejecucion.
+
+.. code-block:: cobra
+
+   dormir(1)
+
 Estas funciones se importan automaticamente al transpilar tanto a Python
 como a JavaScript, por lo que pueden utilizarse directamente en el
 codigo Cobra.


### PR DESCRIPTION
## Summary
- document new core libraries in `modulos_nativos.rst`
- add autodoc pages for each native module
- list the new modules in `src.core.nativos.rst`

## Testing
- `pytest -q` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6862b8d2eb8c8327a069da9d1a485d8b