### PR TITLE
Add metodo & atributo syntax support

### DIFF
--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -40,6 +40,8 @@ class TipoToken(Enum):
     DOSPUNTOS = 'DOSPUNTOS'
     VAR = 'VAR'
     FUNC = 'FUNC'
+    METODO = 'METODO'
+    ATRIBUTO = 'ATRIBUTO'
     REL = 'REL'
     SI = 'SI'
     SINO = 'SINO'
@@ -143,6 +145,8 @@ class Lexer:
             (TipoToken.VAR, r'\bvar\b'),
             (TipoToken.VARIABLE, r'\bvariable\b'),
             (TipoToken.FUNC, r'\b(func|definir)\b'),
+            (TipoToken.METODO, r'\bmetodo\b'),
+            (TipoToken.ATRIBUTO, r'\batributo\b'),
             (TipoToken.REL, r'\brel\b'),
             (TipoToken.SI, r'\bsi\b'),
             (TipoToken.SINO, r'\bsino\b'),

--- a/backend/src/tests/test_interpreter_atributo.py
+++ b/backend/src/tests/test_interpreter_atributo.py
@@ -1,0 +1,17 @@
+from io import StringIO
+from unittest.mock import patch
+
+from src.core.interpreter import InterpretadorCobra
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+
+
+def test_interpreter_atributo_lectura_escritura():
+    codigo = """\natributo p nombre = '\"Ana\"'\nimprimir(atributo p nombre)\n"""
+    ast = Parser(Lexer(codigo).analizar_token()).parsear()
+    inter = InterpretadorCobra()
+    inter.variables['p'] = {'__atributos__': {}}
+    with patch('sys.stdout', new_callable=StringIO) as out:
+        for nodo in ast:
+            inter.ejecutar_nodo(nodo)
+    assert out.getvalue().strip() == 'Ana'

--- a/backend/src/tests/test_lexer_metodo_atributo.py
+++ b/backend/src/tests/test_lexer_metodo_atributo.py
@@ -1,0 +1,7 @@
+from src.cobra.lexico.lexer import Lexer, TipoToken
+
+
+def test_lexer_metodo_atributo_tokens():
+    tokens = Lexer("metodo atributo").analizar_token()
+    tipos = [t.tipo for t in tokens if t.tipo != TipoToken.EOF]
+    assert tipos == [TipoToken.METODO, TipoToken.ATRIBUTO]

--- a/backend/src/tests/test_metodo_atributo.py
+++ b/backend/src/tests/test_metodo_atributo.py
@@ -1,0 +1,36 @@
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from src.core.ast_nodes import NodoClase, NodoMetodo, NodoAsignacion, NodoAtributo, NodoImprimir
+
+
+def test_parser_metodo_keyword():
+    codigo = """
+    clase Persona:
+        metodo saludar(self):
+            fin
+    fin
+    """
+    ast = Parser(Lexer(codigo).analizar_token()).parsear()
+    clase = ast[0]
+    assert isinstance(clase, NodoClase)
+    assert clase.metodos[0].nombre == "saludar"
+
+
+def test_parser_atributo_asignacion():
+    codigo = "atributo obj nombre = 1"
+    ast = Parser(Lexer(codigo).analizar_token()).parsear()
+    asign = ast[0]
+    assert isinstance(asign, NodoAsignacion)
+    assert isinstance(asign.variable, NodoAtributo)
+    assert asign.variable.objeto.nombre == "obj"
+    assert asign.variable.nombre == "nombre"
+
+
+def test_parser_atributo_expresion():
+    codigo = "imprimir(atributo obj nombre)"
+    ast = Parser(Lexer(codigo).analizar_token()).parsear()
+    imp = ast[0]
+    assert isinstance(imp, NodoImprimir)
+    attr = imp.expresion
+    assert isinstance(attr, NodoAtributo)
+    assert attr.nombre == "nombre"

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -1,0 +1,18 @@
+# Guía básica de nuevos tokens
+
+El lenguaje ahora reconoce dos palabras clave adicionales:
+
+- `metodo`: puede utilizarse dentro de una `clase` como alternativa a `func` para definir métodos.
+- `atributo`: permite acceder o asignar atributos de objetos.
+
+Ejemplo de uso:
+
+```cobra
+clase Persona:
+    metodo set_nombre(self, nombre):
+        atributo self nombre = nombre
+    metodo saludar(self):
+        imprimir atributo self nombre
+    fin
+fin
+```

--- a/examples/clase_metodo_atributo.co
+++ b/examples/clase_metodo_atributo.co
@@ -1,0 +1,7 @@
+clase Persona:
+    metodo set_nombre(self, nombre):
+        atributo self nombre = nombre
+    metodo saludar(self):
+        imprimir atributo self nombre
+    fin
+fin


### PR DESCRIPTION
## Summary
- add `METODO` and `ATRIBUTO` tokens in lexer
- extend parser to handle `metodo` keyword and attribute operations
- support attribute assignments and lookups at runtime
- document new syntax
- add examples and unit tests

## Testing
- `pytest backend/src/tests/test_lexer_metodo_atributo.py backend/src/tests/test_metodo_atributo.py backend/src/tests/test_interpreter_atributo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6862cc0146948327bad3cc4cd2d79b1e