### PR TITLE
Añadir biblioteca standard_library

### DIFF
--- a/backend/src/cobra/transpilers/import_helper.py
+++ b/backend/src/cobra/transpilers/import_helper.py
@@ -8,7 +8,9 @@ from .module_map import get_mapped_path
 
 # Mapeo de importaciones estándar por lenguaje
 STANDARD_IMPORTS = {
-    "python": "from src.core.nativos import *\nfrom corelibs import *\n",
+    "python": (
+        "from src.core.nativos import *\n" "from corelibs import *\n" "from standard_library import *\n"
+    ),
     "js": [
         "import * as io from './nativos/io.js';",
         "import * as net from './nativos/red.js';",

--- a/backend/src/cobra/usar_loader.py
+++ b/backend/src/cobra/usar_loader.py
@@ -30,6 +30,18 @@ def obtener_modulo(nombre: str):
             spec.loader.exec_module(modulo)
             return modulo
 
+        # Buscar también en ``standard_library``
+        stdlib = Path(__file__).resolve().parents[2].parent / "standard_library"
+        mod_path = stdlib / f"{nombre}.py"
+        pkg_path = stdlib / nombre / "__init__.py"
+        if mod_path.exists() or pkg_path.exists():
+            ruta = mod_path if mod_path.exists() else pkg_path
+            spec = importlib.util.spec_from_file_location(nombre, ruta)
+            modulo = importlib.util.module_from_spec(spec)
+            sys.modules[nombre] = modulo
+            spec.loader.exec_module(modulo)
+            return modulo
+
         print(f"Paquete '{nombre}' no encontrado. Instalando...")
         try:
             subprocess.run(["pip", "install", nombre], check=True)

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -16,3 +16,39 @@ clase Persona:
     fin
 fin
 ```
+
+## API de la biblioteca estándar
+
+La carpeta `standard_library` agrupa utilidades listas para usarse desde Cobra.
+
+### archivo
+
+- `leer(ruta)` - devuelve el contenido de un archivo de texto.
+- `escribir(ruta, datos)` - crea o reemplaza un archivo con el texto dado.
+- `adjuntar(ruta, datos)` - agrega información al final del archivo.
+- `existe(ruta)` - indica si la ruta existe.
+
+### fecha
+
+- `hoy()` - obtiene la fecha y hora actual.
+- `formatear(fecha, formato='%Y-%m-%d')` - formatea una fecha.
+- `sumar_dias(fecha, dias)` - suma días a una fecha dada.
+
+### lista
+
+- `cabeza(lista)` - primer elemento o `None` si está vacía.
+- `cola(lista)` - lista sin el primer elemento.
+- `longitud(lista)` - cantidad de elementos.
+- `combinar(*listas)` - concatena varias listas.
+
+### logica
+
+- `conjuncion(a, b)` - equivalente a `a and b`.
+- `disyuncion(a, b)` - equivalente a `a or b`.
+- `negacion(a)` - equivalente a `not a`.
+
+### util
+
+- `es_nulo(valor)` - retorna `True` si es `None`.
+- `es_vacio(secuencia)` - `True` si la secuencia está vacía.
+- `repetir(cadena, veces)` - repite la cadena.

--- a/standard_library/__init__.py
+++ b/standard_library/__init__.py
@@ -1,0 +1,30 @@
+"""Biblioteca estándar complementaria para Cobra."""
+
+from __future__ import annotations
+
+from .archivo import leer, escribir, adjuntar, existe
+from .fecha import hoy, formatear, sumar_dias
+from .lista import cabeza, cola, longitud, combinar
+from .logica import conjuncion, disyuncion, negacion
+from .util import es_nulo, es_vacio, repetir
+
+__all__ = [
+    "leer",
+    "escribir",
+    "adjuntar",
+    "existe",
+    "hoy",
+    "formatear",
+    "sumar_dias",
+    "cabeza",
+    "cola",
+    "longitud",
+    "combinar",
+    "conjuncion",
+    "disyuncion",
+    "negacion",
+    "es_nulo",
+    "es_vacio",
+    "repetir",
+]
+

--- a/standard_library/archivo.py
+++ b/standard_library/archivo.py
@@ -1,0 +1,29 @@
+"""Funciones básicas para manipular archivos de texto."""
+
+from __future__ import annotations
+
+import os
+
+
+def leer(ruta: str) -> str:
+    """Devuelve el contenido de un archivo."""
+    with open(ruta, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def escribir(ruta: str, datos: str) -> None:
+    """Sobrescribe el archivo indicado con ``datos``."""
+    with open(ruta, "w", encoding="utf-8") as f:
+        f.write(datos)
+
+
+def adjuntar(ruta: str, datos: str) -> None:
+    """Agrega ``datos`` al final del archivo."""
+    with open(ruta, "a", encoding="utf-8") as f:
+        f.write(datos)
+
+
+def existe(ruta: str) -> bool:
+    """Indica si el archivo existe."""
+    return os.path.isfile(ruta)
+

--- a/standard_library/fecha.py
+++ b/standard_library/fecha.py
@@ -1,0 +1,21 @@
+"""Herramientas para trabajar con fechas y tiempos."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+
+def hoy() -> datetime:
+    """Retorna la fecha y hora actual."""
+    return datetime.now()
+
+
+def formatear(fecha: datetime, formato: str = "%Y-%m-%d") -> str:
+    """Convierte ``fecha`` a texto usando ``formato``."""
+    return fecha.strftime(formato)
+
+
+def sumar_dias(fecha: datetime, dias: int) -> datetime:
+    """Devuelve una nueva fecha tras sumar ``dias`` a ``fecha``."""
+    return fecha + timedelta(days=dias)
+

--- a/standard_library/lista.py
+++ b/standard_library/lista.py
@@ -1,0 +1,27 @@
+"""Utilidades para manejar listas."""
+
+from __future__ import annotations
+
+
+def cabeza(lista):
+    """Devuelve el primer elemento de ``lista`` o ``None`` si está vacía."""
+    return lista[0] if lista else None
+
+
+def cola(lista):
+    """Retorna una copia de ``lista`` sin el primer elemento."""
+    return list(lista[1:]) if len(lista) > 1 else []
+
+
+def longitud(lista) -> int:
+    """Número de elementos en ``lista``."""
+    return len(lista)
+
+
+def combinar(*listas):
+    """Concatena varias listas en una nueva."""
+    resultado = []
+    for l in listas:
+        resultado.extend(l)
+    return resultado
+

--- a/standard_library/logica.py
+++ b/standard_library/logica.py
@@ -1,0 +1,19 @@
+"""Operaciones lógicas simples."""
+
+from __future__ import annotations
+
+
+def conjuncion(a: bool, b: bool) -> bool:
+    """Retorna ``True`` si ambos argumentos son verdaderos."""
+    return bool(a and b)
+
+
+def disyuncion(a: bool, b: bool) -> bool:
+    """Retorna ``True`` si al menos uno de los argumentos es verdadero."""
+    return bool(a or b)
+
+
+def negacion(valor: bool) -> bool:
+    """Devuelve el opuesto lógico de ``valor``."""
+    return not valor
+

--- a/standard_library/util.py
+++ b/standard_library/util.py
@@ -1,0 +1,19 @@
+"""Pequeñas funciones de ayuda."""
+
+from __future__ import annotations
+
+
+def es_nulo(valor) -> bool:
+    """Indica si ``valor`` es ``None``."""
+    return valor is None
+
+
+def es_vacio(secuencia) -> bool:
+    """Devuelve ``True`` si la secuencia no contiene elementos."""
+    return len(secuencia) == 0
+
+
+def repetir(cadena: str, veces: int) -> str:
+    """Retorna ``cadena`` repetida ``veces`` veces."""
+    return cadena * veces
+

--- a/tests/unit/test_archivo.py
+++ b/tests/unit/test_archivo.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import standard_library.archivo as archivo
+
+
+def test_archivo(tmp_path):
+    ruta = tmp_path / "f.txt"
+    archivo.escribir(ruta, "hola")
+    assert archivo.existe(ruta)
+    archivo.adjuntar(ruta, " mundo")
+    assert archivo.leer(ruta) == "hola mundo"
+    os.remove(ruta)
+    assert not archivo.existe(ruta)
+

--- a/tests/unit/test_fecha.py
+++ b/tests/unit/test_fecha.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import standard_library.fecha as fecha
+
+
+def test_fecha():
+    ahora = fecha.hoy()
+    assert isinstance(ahora, datetime)
+    form = fecha.formatear(datetime(2020, 1, 1), "%Y")
+    assert form == "2020"
+    futuro = fecha.sumar_dias(datetime(2020, 1, 1), 5)
+    assert futuro == datetime(2020, 1, 6)
+

--- a/tests/unit/test_lista.py
+++ b/tests/unit/test_lista.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import standard_library.lista as lista
+
+
+def test_lista():
+    datos = [1, 2, 3]
+    assert lista.cabeza(datos) == 1
+    assert lista.cola(datos) == [2, 3]
+    assert lista.longitud(datos) == 3
+    assert lista.combinar([1], [2, 3]) == [1, 2, 3]
+

--- a/tests/unit/test_logica.py
+++ b/tests/unit/test_logica.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import standard_library.logica as logica
+
+
+def test_logica():
+    assert logica.conjuncion(True, True) is True
+    assert logica.conjuncion(True, False) is False
+    assert logica.disyuncion(False, True) is True
+    assert logica.disyuncion(False, False) is False
+    assert logica.negacion(True) is False
+

--- a/tests/unit/test_usar_loader_stdlib.py
+++ b/tests/unit/test_usar_loader_stdlib.py
@@ -1,0 +1,19 @@
+import types
+from datetime import datetime
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend" / "src"))
+sys.path.insert(0, str(ROOT))
+
+from src.cobra import usar_loader
+import standard_library.fecha as fecha
+
+
+def test_obtener_modulo_standard_library(monkeypatch):
+    mod = usar_loader.obtener_modulo("fecha")
+    assert isinstance(mod, types.ModuleType)
+    assert hasattr(mod, "formatear")
+    assert mod.formatear(datetime(2020, 1, 1)) == fecha.formatear(datetime(2020, 1, 1))
+

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import standard_library.util as util
+
+
+def test_util():
+    assert util.es_nulo(None) is True
+    assert util.es_nulo(0) is False
+    assert util.es_vacio([]) is True
+    assert util.es_vacio("a") is False
+    assert util.repetir("a", 3) == "aaa"
+


### PR DESCRIPTION
## Summary
- crear carpeta `standard_library` con funciones utilitarias
- ampliar `usar_loader` para buscar modulos en `standard_library`
- importar la libreria desde los transpiladores
- documentar API de la nueva biblioteca
- añadir pruebas unitarias de cada modulo

## Testing
- `pytest tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_6862cf7af5d08327a7511a82fbb1f54f