### PR TITLE
Add pyproject and roadmap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -52,6 +53,10 @@ jobs:
         with:
           name: changelog
           path: CHANGELOG.md
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: CHANGELOG.md
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-71%25-brightgreen)](https://codecov.io/gh/Alphonsus411/pCobra)
 
 
-Versión 5.6
+Versión 5.6.0
 
 Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
@@ -586,29 +586,7 @@ Para conocer en detalle la interfaz disponible consulta
 [`frontend/docs/plugin_sdk.rst`](frontend/docs/plugin_sdk.rst).
 ## Hitos y Roadmap
 
-El proyecto avanza en versiones incrementales. A continuacion se listan las tareas previstas para las proximas entregas.
-
-### v0.4
-
-- Consolidar la gestion de dependencias en la CLI.
-- Permitir la creacion de ejecutables para distribucion.
-- Optimizar la validacion del modo seguro.
-- Ampliar la documentacion con ejemplos avanzados.
-
-### v0.5
-
-- Incorporar un sistema de plugins para extender la CLI.
-- Integrar soporte para ejecucion en Jupyter.
-- Implementar optimizaciones del AST para mayor rendimiento.
-- Anadir pruebas de concurrencia para mejorar la estabilidad.
-
-### v1.3
-
-- Cache de AST con checksum
-- Transpilación multi-lenguaje en paralelo
-- Ejemplos de benchmarking y configuración segura
-- Interfaz base para plugins
-- Registro y versionado de plugins
+El proyecto avanza en versiones incrementales. Puedes consultar las tareas planeadas en [ROADMAP.md](ROADMAP.md).
 
 
 # Contribuciones
@@ -687,9 +665,13 @@ class HolaCommand(PluginCommand):
     def run(self, args):
         print("¡Hola desde un plugin!")
 ```
+## Versionado Semántico
+
+Este proyecto sigue el esquema [SemVer](https://semver.org/lang/es/). Los numeros se interpretan como Mayor.Menor.Parche. Cada incremento de version refleja cambios compatibles o rupturas segun esta norma.
+
 ## Historial de Cambios
 
- - Versión 5.6: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
+ - Versión 5.6.0: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
 
 # Licencia
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,22 @@
+# Roadmap
+
+Este documento describe las versiones planeadas y las tareas principales asociadas a cada una. Se sigue el esquema SemVer y los hitos se organizan por versión mayor y menor.
+
+## v0.4
+- Consolidar la gestión de dependencias en la CLI.
+- Permitir la creación de ejecutables para distribución.
+- Optimizar la validación del modo seguro.
+- Ampliar la documentación con ejemplos avanzados.
+
+## v0.5
+- Incorporar un sistema de plugins para extender la CLI.
+- Integrar soporte para ejecución en Jupyter.
+- Implementar optimizaciones del AST para mayor rendimiento.
+- Añadir pruebas de concurrencia para mejorar la estabilidad.
+
+## v1.3
+- Cache de AST con checksum.
+- Transpilación multi-lenguaje en paralelo.
+- Ejemplos de benchmarking y configuración segura.
+- Interfaz base para plugins.
+- Registro y versionado de plugins.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cobra-lenguaje"
+version = "5.6.0"
+description = "Un lenguaje de programación en español para simulaciones y más."
+authors = [ {name = "Adolfo González Hernández", email = "adolfogonzal@gmail.com"} ]
+readme = "README.md"
+requires-python = ">=3.6"
+license = { text = "MIT" }
+keywords = ["cobra", "lenguaje", "cli"]
+
+dependencies = [
+    "pytest>=7.0",
+    "numpy>=1.22.0",
+    "scipy>=1.7.0",
+    "matplotlib>=3.5.0",
+    "pandas>=1.3.0",
+    "tensorflow>=2.6.0",
+    "dask>=2021.09.0",
+    "DEAP>=1.3.1",
+    "ipykernel>=6.0.0",
+    "agix==0.8.3",
+    "holobit-sdk",
+    "smooth-criminal",
+]
+
+[project.urls]
+Documentation = "https://github.com/Alphonsus411/pCobra#readme"
+Source = "https://github.com/Alphonsus411/pCobra"
+
+[tool.setuptools]
+package-dir = {"" = "backend/src"}
+
+[tool.setuptools.packages.find]
+where = ["backend/src"]
+
+[project.scripts]
+cobra = "src.cli.cli:main"
+
+[project.entry-points."cobra.plugins"]
+# Se registrarán plugins externos aquí

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -6,7 +6,7 @@ from pathlib import Path
 SETUP_PATH = Path('setup.py')
 CHANGELOG_PATH = Path('CHANGELOG.md')
 
-VERSION_RE = re.compile(r"version='(\d+\.\d+)'")
+VERSION_RE = re.compile(r"version='(\d+\.\d+\.\d+)'")
 
 
 def read_version():
@@ -19,6 +19,8 @@ def read_version():
 
 def bump(version: str) -> str:
     parts = version.split('.')
+    if len(parts) < 3:
+        parts.append('0')
     parts[-1] = str(int(parts[-1]) + 1)
     return '.'.join(parts)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cobra-lenguaje',
-    version='5.6',
+    version='5.6.0',
     author='Adolfo González Hernández',
     author_email='adolfogonzal@gmail.com',
     description='Un lenguaje de programación en español para simulaciones y más.',


### PR DESCRIPTION
## Summary
- incorporate `pyproject.toml` with metadata and dependencies
- document roadmap in separate file
- mention roadmap and semantic versioning in `README`
- bump version format to `5.6.0` and support SemVer in bump script
- create GitHub release step in workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_6862de28b90083279d4261133798009b