### PR TITLE
Actualización de bump_version.py y archivos de versión

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v5.6.1 - 2025-07-02
+- Cambios pendientes.
+
 ## v5.6 - 2025-06-29 - actualizacion de version
 - Paquete actualizado a la versión 5.6.
 - Documentación y kernel reflejan la nueva versión.

--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -1,6 +1,6 @@
 # Manual del Lenguaje Cobra
 
-Versión 5.6
+Versión 5.6.1
 
 Este manual presenta en español los conceptos básicos para programar en Cobra. Se organiza en tareas que puedes seguir paso a paso.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-71%25-brightgreen)](https://codecov.io/gh/Alphonsus411/pCobra)
 
 
-Versión 5.6.0
+Versión 5.6.1
 
 Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
@@ -671,7 +671,7 @@ Este proyecto sigue el esquema [SemVer](https://semver.org/lang/es/). Los numero
 
 ## Historial de Cambios
 
- - Versión 5.6.0: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
+ - Versión 5.6.1: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
 
 # Licencia
 

--- a/backend/src/jupyter_kernel/__init__.py
+++ b/backend/src/jupyter_kernel/__init__.py
@@ -16,9 +16,9 @@ def install(user=True):
 
 class CobraKernel(Kernel):
     implementation = "Cobra"
-    implementation_version = "5.6"
+    implementation_version = "5.6.1"
     language = "cobra"
-    language_version = "5.6"
+    language_version = "5.6.1"
     language_info = {
         "name": "cobra",
         "mimetype": "text/plain",

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -7,10 +7,10 @@ Avances del lenguaje Cobra
 - **Gestión de memoria automatizada**: Cobra incluye un sistema de manejo de memoria optimizado que se ajusta automáticamente utilizando algoritmos genéticos.
 - **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX.
 - **Pruebas unitarias**: Se han creado pruebas para validar el correcto funcionamiento del lexer y el parser.
- - **Versión 5.6**: Actualización de la documentación y configuración del proyecto.
- - **Versión 5.6**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
+ - **Versión 5.6.1**: Actualización de la documentación y configuración del proyecto.
+ - **Versión 5.6.1**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
 
-Versión 5.6
+Versión 5.6.1
 -----------
 Se añade el archivo ``pcobra.toml`` para definir el mapeo de módulos en formato TOML. Su estructura es la siguiente:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cobra-lenguaje"
-version = "5.6.0"
+version = "5.6.1"
 description = "Un lenguaje de programación en español para simulaciones y más."
 authors = [ {name = "Adolfo González Hernández", email = "adolfogonzal@gmail.com"} ]
 readme = "README.md"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,34 +1,84 @@
 #!/usr/bin/env python3
 import re
+import tomllib
 from datetime import date
 from pathlib import Path
 
-SETUP_PATH = Path('setup.py')
-CHANGELOG_PATH = Path('CHANGELOG.md')
+SETUP_PATH = Path("setup.py")
+PYPROJECT_PATH = Path("pyproject.toml")
+CHANGELOG_PATH = Path("CHANGELOG.md")
 
-VERSION_RE = re.compile(r"version='(\d+\.\d+\.\d+)'")
+# Archivos en los que se actualizará la versión
+FILES_TO_UPDATE = [
+    SETUP_PATH,
+    PYPROJECT_PATH,
+    Path("README.md"),
+    Path("MANUAL_COBRA.md"),
+    Path("backend/src/jupyter_kernel/__init__.py"),
+    Path("frontend/docs/avances.rst"),
+    Path("tests/unit/test_cli_plugins_cmd.py"),
+]
+
+VERSION_RE = re.compile(r"version=['\"](\d+\.\d+\.\d+)['\"]")
 
 
-def read_version():
+def read_version() -> str:
+    """Obtiene la versión actual del proyecto."""
+    if PYPROJECT_PATH.exists():
+        data = tomllib.loads(PYPROJECT_PATH.read_text())
+        project = data.get("project", {})
+        if "version" in project:
+            return str(project["version"])
+
     content = SETUP_PATH.read_text()
     match = VERSION_RE.search(content)
     if not match:
-        raise ValueError('Versión no encontrada en setup.py')
+        raise ValueError("Versión no encontrada")
     return match.group(1)
 
 
-def bump(version: str) -> str:
-    parts = version.split('.')
-    if len(parts) < 3:
-        parts.append('0')
-    parts[-1] = str(int(parts[-1]) + 1)
-    return '.'.join(parts)
+def bump(version: str, part: str = "patch") -> str:
+    """Incrementa la versión según la parte indicada."""
+    parts = [int(p) for p in version.split(".")]
+    while len(parts) < 3:
+        parts.append(0)
+
+    if part == "major":
+        parts[0] += 1
+        parts[1] = 0
+        parts[2] = 0
+    elif part == "minor":
+        parts[1] += 1
+        parts[2] = 0
+    else:
+        parts[2] += 1
+
+    return "{}".format(".".join(str(p) for p in parts))
 
 
-def update_setup(new_version: str):
-    content = SETUP_PATH.read_text()
-    new_content = VERSION_RE.sub(f"version='{new_version}'", content)
-    SETUP_PATH.write_text(new_content)
+def update_files(current: str, new_version: str) -> None:
+    """Reemplaza la versión en todos los archivos listados."""
+    short_current = ".".join(current.split(".")[:2])
+    short_new = ".".join(new_version.split(".")[:2])
+
+    for path in FILES_TO_UPDATE:
+        if not path.exists():
+            continue
+        text = path.read_text()
+        text = text.replace(current, new_version)
+        text = re.sub(rf"\b{re.escape(short_current)}\b", short_new, text)
+        if short_current == short_new:
+            text = re.sub(rf"Versión {re.escape(short_current)}(?![\.\d])", f"Versión {new_version}", text)
+        else:
+            text = re.sub(rf"Versión {re.escape(short_current)}", f"Versión {short_new}", text)
+        text = re.sub(
+            rf"(implementation_version\s*=\s*\"|language_version\s*=\s*\"){re.escape(short_current)}(\")",
+            rf"\g<1>{new_version}\g<2>",
+            text,
+        )
+        text = re.sub(rf"version\s*=\s*\"{re.escape(short_current)}\"", f'version = "{new_version}"', text)
+        text = text.replace(f"dummy {short_current}", f"dummy {new_version}")
+        path.write_text(text)
 
 
 def update_changelog(new_version: str):
@@ -42,7 +92,7 @@ def update_changelog(new_version: str):
 def main():
     current = read_version()
     new = bump(current)
-    update_setup(new)
+    update_files(current, new)
     update_changelog(new)
     print(new)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cobra-lenguaje',
-    version='5.6.0',
+    version='5.6.1',
     author='Adolfo González Hernández',
     author_email='adolfogonzal@gmail.com',
     description='Un lenguaje de programación en español para simulaciones y más.',

--- a/tests/unit/test_cli_plugins_cmd.py
+++ b/tests/unit/test_cli_plugins_cmd.py
@@ -8,7 +8,7 @@ from src.cli.plugin import PluginCommand
 
 class DummyPlugin(PluginCommand):
     name = "dummy"
-    version = "5.6"
+    version = "5.6.1"
 
     def register_subparser(self, subparsers):
         pass
@@ -38,7 +38,7 @@ def test_cli_plugins_muestra_registro():
     with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["plugins"])
-    assert "dummy 5.6" in out.getvalue().strip()
+    assert "dummy 5.6.1" in out.getvalue().strip()
 
 
 def test_cli_plugin_ejemplo_hola():


### PR DESCRIPTION
## Summary
- leer la versión desde `pyproject.toml` o `setup.py`
- incrementar el número de versión y actualizarlo en toda la base de código
- registrar la nueva versión al inicio de `CHANGELOG.md`

## Testing
- `python scripts/bump_version.py`
- `pytest -q` *(fallan varias pruebas por falta de dependencias o configuración)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff769a1883278689313319b6afec