### PR TITLE
Actualizar workflow de release con validaciones

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,22 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body_path: CHANGELOG.md
+      - name: Verificar etiqueta de publicación
+        run: |
+          if [[ "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "La referencia ${GITHUB_REF} es válida"
+          else
+            echo "Referencia de tag no válida: ${GITHUB_REF}" >&2
+            exit 1
+          fi
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: twine upload --skip-existing dist/*
+      - name: Verificar instalación desde PyPI
+        run: |
+          python -m venv env
+          source env/bin/activate
+          pip install cobra-lenguaje
+          cobra --version


### PR DESCRIPTION
## Summary
- verificar que la referencia de GitHub cumple el patrón `refs/tags/vX.Y.Z` antes de subir a PyPI
- crear un entorno virtual temporal e instalar el paquete desde PyPI para comprobar su disponibilidad

## Testing
- `pytest -q` *(falla: 31 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68650689ab248327822aee53751f2060