### PR TITLE
Actualizar documentación de validadores

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Para un tutorial completo de creación de plugins revisa
 
 ## Modo seguro (--seguro)
 
-Tanto el intérprete como la CLI aceptan la opción `--seguro`, que ejecuta el código bajo restricciones adicionales. Al activarla se valida el AST y se prohíben primitivas como `leer_archivo`, `escribir_archivo`, `obtener_url` y `hilo`. Asimismo, las instrucciones `import` solo están permitidas para módulos instalados o incluidos en `IMPORT_WHITELIST`. Si el programa intenta utilizar estas funciones o importar otros archivos se lanzará `PrimitivaPeligrosaError`.
+Tanto el intérprete como la CLI aceptan la opción `--seguro`, que ejecuta el código bajo restricciones adicionales. Al activarla se valida el AST y se prohíben primitivas como `leer_archivo`, `escribir_archivo`, `obtener_url`, `hilo`, `leer`, `escribir`, `existe`, `eliminar` y `enviar_post`. El validador `ValidadorProhibirReflexion` también bloquea llamadas a `eval`, `exec` y otras funciones de reflexión, además de impedir el acceso a atributos internos. Asimismo, las instrucciones `import` solo están permitidas para módulos instalados o incluidos en `IMPORT_WHITELIST`. Si el programa intenta utilizar estas funciones o importar otros archivos se lanzará `PrimitivaPeligrosaError`.
 La validación se realiza mediante una cadena de validadores configurada por la
 función `construir_cadena`, lo que facilita añadir nuevas comprobaciones en el
 futuro.

--- a/frontend/docs/modo_seguro.rst
+++ b/frontend/docs/modo_seguro.rst
@@ -4,9 +4,12 @@ Modo seguro
 La herramienta ``cobra`` permite ejecutar programas en modo seguro mediante la
 opción ``--seguro``. Al activarse se construye una cadena de validadores que
 analiza el AST y bloquea primitivas peligrosas como ``leer_archivo``,
-``escribir_archivo``, ``obtener_url`` y ``hilo``. A partir de esta versión
-también se restringen las funciones de archivo ``leer``, ``escribir``,
-``existe`` y ``eliminar``, además de ``enviar_post`` para operaciones de red.
+``escribir_archivo``, ``obtener_url`` y ``hilo``.
+A partir de esta versión también se restringen las funciones ``leer``,
+``escribir``, ``existe`` y ``eliminar``, además de ``enviar_post`` para
+operaciones de red.
+El validador ``ValidadorProhibirReflexion`` impide utilizar ``eval``, ``exec`` y
+otras funciones de reflexión o acceder a atributos internos como ``__dict__``.
 También se valida la
 instrucción ``import`` para permitir únicamente los módulos instalados o los
 especificados en ``IMPORT_WHITELIST``. La instrucción ``usar`` está limitada a

--- a/frontend/docs/validador.rst
+++ b/frontend/docs/validador.rst
@@ -14,6 +14,15 @@ Las primitivas actualmente marcadas como peligrosas son:
 - ``escribir_archivo``
 - ``obtener_url``
 - ``hilo``
+- ``leer``
+- ``escribir``
+- ``existe``
+- ``eliminar``
+- ``enviar_post``
+
+Reflexión e introspección
+-------------------------
+Además de las primitivas anteriores, la cadena incluye el ``ValidadorProhibirReflexion``. Este validador bloquea llamadas a ``eval``, ``exec``, ``getattr``, ``setattr`` y ``hasattr``, así como el acceso a ``globals()`` , ``locals()`` o ``vars()`` y a atributos como ``__dict__`` o ``__class__``.
 
 Si se detecta el uso de alguna de estas primitivas, se lanza la excepcion
 ``PrimitivaPeligrosaError`` antes de que el codigo sea interpretado o transpilado.


### PR DESCRIPTION
## Resumen
- ampliar listado de primitivas en `validador.rst`
- mencionar bloqueo de reflexión y validador usado
- sincronizar información en `modo_seguro.rst` y `README.md`

## Testing
- `pytest tests/unit/test_reflexion_validator.py` *(falla: ModuleNotFoundError)*
- `make html` *(falla: sphinx-build not found)*

------
https://chatgpt.com/codex/tasks/task_e_686523e967888327afefe26f77d53fcc