### PR TITLE
Add auditing validator configurable via cobra.toml

### DIFF
--- a/backend/src/core/cobra_config.py
+++ b/backend/src/core/cobra_config.py
@@ -1,0 +1,31 @@
+import os
+import tomli
+
+COBRA_CONFIG_PATH = os.environ.get(
+    "COBRA_CONFIG",
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "cobra.toml")
+    ),
+)
+
+_cache = {}
+
+
+def cargar_configuracion(ruta: str | None = None) -> dict:
+    """Carga la configuraci\u00f3n general en formato TOML."""
+    path = ruta or COBRA_CONFIG_PATH
+
+    if path not in _cache:
+        if os.path.exists(path):
+            with open(path, "rb") as f:
+                data = tomli.load(f)
+        else:
+            data = {}
+        _cache[path] = data
+    return _cache[path]
+
+
+def auditoria_activa(config: dict | None = None) -> bool:
+    """Devuelve si la auditor\u00eda debe activarse seg\u00fan la configuraci\u00f3n."""
+    cfg = config or cargar_configuracion()
+    return cfg.get("auditoria", {}).get("activa", False)

--- a/backend/src/core/semantic_validators/__init__.py
+++ b/backend/src/core/semantic_validators/__init__.py
@@ -4,9 +4,11 @@ from .primitiva_peligrosa import (
     PrimitivaPeligrosaError,
     ValidadorPrimitivaPeligrosa,
 )
+from .auditoria import ValidadorAuditoria
 from .import_seguro import ValidadorImportSeguro
 from .fs_access import ValidadorSistemaArchivos
 from .reflexion_segura import ValidadorProhibirReflexion
+from src.core.cobra_config import auditoria_activa
 
 # Instancia por defecto reutilizable de la cadena de validación
 _CADENA_DEFECTO = None
@@ -23,8 +25,13 @@ def construir_cadena(extra_validators=None):
     if extra_validators is None and _CADENA_DEFECTO is not None:
         return _CADENA_DEFECTO
 
-    primero = ValidadorPrimitivaPeligrosa()
-    actual = primero.set_siguiente(ValidadorImportSeguro())
+    if auditoria_activa():
+        primero = ValidadorAuditoria()
+        actual = primero.set_siguiente(ValidadorPrimitivaPeligrosa())
+    else:
+        primero = ValidadorPrimitivaPeligrosa()
+        actual = primero
+    actual = actual.set_siguiente(ValidadorImportSeguro())
     actual = actual.set_siguiente(ValidadorSistemaArchivos())
     actual = actual.set_siguiente(ValidadorProhibirReflexion())
 
@@ -40,6 +47,7 @@ def construir_cadena(extra_validators=None):
 __all__ = [
     "PrimitivaPeligrosaError",
     "ValidadorPrimitivaPeligrosa",
+    "ValidadorAuditoria",
     "ValidadorImportSeguro",
     "ValidadorSistemaArchivos",
     "ValidadorProhibirReflexion",

--- a/backend/src/core/semantic_validators/auditoria.py
+++ b/backend/src/core/semantic_validators/auditoria.py
@@ -1,0 +1,43 @@
+import logging
+
+from .base import ValidadorBase
+from src.core.ast_nodes import (
+    NodoLlamadaFuncion,
+    NodoLlamadaMetodo,
+    NodoHilo,
+    NodoImport,
+    NodoUsar,
+    NodoImportDesde,
+)
+
+
+class ValidadorAuditoria(ValidadorBase):
+    """Validador que registra las primitivas utilizadas."""
+
+    def _log(self, mensaje: str) -> None:
+        logging.warning(mensaje)
+
+    def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
+        self._log(f"Llamada a funcion: {nodo.nombre}")
+        self.generic_visit(nodo)
+
+    def visit_llamada_metodo(self, nodo: NodoLlamadaMetodo):
+        self._log(f"Llamada a metodo: {nodo.nombre_metodo}")
+        self.generic_visit(nodo)
+
+    def visit_hilo(self, nodo: NodoHilo):
+        self._log(f"Ejecucion de hilo: {nodo.llamada.nombre}")
+        nodo.llamada.aceptar(self)
+        self.delegar(nodo)
+
+    def visit_import(self, nodo: NodoImport):
+        self._log(f"Import de modulo: {nodo.ruta}")
+        self.generic_visit(nodo)
+
+    def visit_usar(self, nodo: NodoUsar):
+        self._log(f"Usar modulo: {nodo.modulo}")
+        self.generic_visit(nodo)
+
+    def visit_import_desde(self, nodo: NodoImportDesde):
+        self._log(f"Importar desde: {nodo.modulo}")
+        self.generic_visit(nodo)

--- a/cobra.toml
+++ b/cobra.toml
@@ -1,0 +1,2 @@
+[auditoria]
+activa = true

--- a/frontend/docs/modo_seguro.rst
+++ b/frontend/docs/modo_seguro.rst
@@ -16,6 +16,15 @@ especificados en ``IMPORT_WHITELIST``. La instrucción ``usar`` está limitada a
 los paquetes listados en ``USAR_WHITELIST`` ubicado en
 ``backend/src/cobra/usar_loader.py``.
 
+La cadena comienza con ``ValidadorAuditoria`` que registra mediante
+``logging.warning`` cada primitiva utilizada. Esta auditoría puede
+habilitarse o deshabilitarse editando ``cobra.toml``:
+
+.. code-block:: toml
+
+   [auditoria]
+   activa = true
+
 Si se intenta utilizar alguna de estas operaciones se lanzará
 ``PrimitivaPeligrosaError`` antes de ejecutar el código.
 


### PR DESCRIPTION
## Summary
- add `ValidadorAuditoria` logging every primitive call
- add configuration loader `cobra_config.py`
- insert `ValidadorAuditoria` into validator chain based on config
- document the new validator in `modo_seguro.rst`
- provide sample configuration file `cobra.toml`

## Testing
- `pip install -r requirements.txt`
- `pytest tests/unit/test_safe_mode.py::test_codigo_seguro_se_ejecuta_en_modo_seguro -q`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865269eea688327888d4a1cf315e49e