### PR TITLE
Add secure CLI validator tests

### DIFF
--- a/tests/unit/test_cli_secure_validators.py
+++ b/tests/unit/test_cli_secure_validators.py
@@ -1,29 +1,39 @@
 import sys
-from io import StringIO
-from unittest.mock import patch
+import os
+import subprocess
+from pathlib import Path
 import pytest
 
-from src.cli.cli import main
+ROOT = Path(__file__).resolve().parents[2]
 
 
-def _run_sys_exit(args):
-    with patch("sys.stdout", new_callable=StringIO):
-        with pytest.raises(SystemExit) as exc:
-            sys.exit(main(args))
-    return exc.value.code
+def _run_cli(args):
+    env = os.environ.copy()
+    pythonpath = [str(ROOT), str(ROOT / "backend" / "src")]
+    if env.get("PYTHONPATH"):
+        pythonpath.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath)
+    proc = subprocess.run(
+        [sys.executable, "-m", "src.cli.cli", *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    return proc.returncode
 
 
 @pytest.mark.timeout(5)
-def test_cli_seguro_archivos_prohibidos(tmp_path):
+@pytest.mark.parametrize(
+    "contenido",
+    [
+        "cargar_extension('x.so')",
+        "eval('1')",
+        "exec('1')",
+        "import 'os'",
+    ],
+)
+def test_cli_seguro_primitivas_prohibidas(tmp_path, contenido):
     archivo = tmp_path / "a.co"
-    archivo.write_text("cargar_extension('x.so')")
-    code = _run_sys_exit(["--seguro", "ejecutar", str(archivo)])
-    assert code != 0
-
-
-@pytest.mark.timeout(5)
-def test_cli_seguro_reflexion_prohibida(tmp_path):
-    archivo = tmp_path / "b.co"
-    archivo.write_text("eval('1')")
-    code = _run_sys_exit(["--seguro", "ejecutar", str(archivo)])
+    archivo.write_text(contenido)
+    code = _run_cli(["--seguro", "ejecutar", str(archivo)])
     assert code != 0


### PR DESCRIPTION
## Summary
- expand secure CLI tests to check `exec('1')` and attempting `import os`
- run CLI through subprocess to avoid import issues

## Testing
- `pytest tests/unit/test_cli_secure_validators.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68652cbf5a488327bf986a99e4f6a8bd