### PR TITLE
Add example notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,21 @@ Cobra es un lenguaje de programación diseñado en español, enfocado en la crea
 - [Guía básica](docs/guia_basica.md)
 - [Especificación técnica](docs/especificacion_tecnica.md)
 - [Cheatsheet](docs/cheatsheet.tex) – compílalo a PDF con LaTeX
+- Notebooks de ejemplo
 
 ## Ejemplos
 
 Proyectos de demostracion disponibles en [cobra-ejemplos](https://github.com/tuusuario/cobra-ejemplos).
+
+## Notebooks de ejemplo
+
+En la carpeta `notebooks/` se incluye el cuaderno `ejemplo_basico.ipynb` con un
+ejemplo básico de uso de Cobra. Para abrirlo ejecuta:
+
+```bash
+cobra jupyter
+```
+Luego selecciona el archivo desde la interfaz web de Jupyter.
  
 
 

--- a/notebooks/ejemplo_basico.ipynb
+++ b/notebooks/ejemplo_basico.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3e1b716b",
+   "metadata": {},
+   "source": [
+    "## ¿Qué es Cobra?\n",
+    "Cobra es un lenguaje de programación escrito en español que permite transpilar su código a varios lenguajes como Python, JavaScript o C++."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acdc2c9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat ../examples/tutorial_basico/hola_mundo.cob"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c56966b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!PYTHONPATH='..:../backend/src:../backend' python ../examples/tutorial_basico/compile_manual.py > hola_mundo.py\n",
+    "!cat hola_mundo.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "067b5a70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!PYTHONPATH='..:../backend/src:../backend' python hola_mundo.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06118a26",
+   "metadata": {},
+   "source": [
+    "Para ejecutar este cuaderno puedes iniciar Jupyter con el comando:\n",
+    "\n",
+    "```bash\n",
+    "cobra jupyter\n",
+    "```\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Jupyter notebook with an introductory example
- mention example notebooks in the README

## Testing
- `python -m nbformat --validate notebooks/ejemplo_basico.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_68653a5729f4832792adc66145dcbb22