### PR TITLE
Add docs for SaludoCommand example

### DIFF
--- a/frontend/docs/plugins.rst
+++ b/frontend/docs/plugins.rst
@@ -77,3 +77,34 @@ Una vez instalado, el subcomando queda disponible::
 
    cobra md2cobra --input notas.md --output resultado.co
 
+Ejemplo completo
+----------------
+``SaludoCommand`` está disponible en
+``examples/plugins/saludo_plugin.py``. Para instalarlo en modo editable
+ejecuta:
+
+.. code-block:: bash
+
+   cd examples/plugins
+   pip install -e .
+
+Comprueba que queda registrado con:
+
+.. code-block:: bash
+
+   cobra plugins
+
+.. code-block:: text
+
+   saludo 1.0 - Comando de saludo de ejemplo
+
+Finalmente, prueba el comando:
+
+.. code-block:: bash
+
+   cobra saludo
+
+.. code-block:: text
+
+   ¡Hola desde el plugin de ejemplo!
+


### PR DESCRIPTION
## Summary
- expand plugins guide with a full example using `SaludoCommand`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tomli')*

------
https://chatgpt.com/codex/tasks/task_e_68653eff18a08327bb8fdfa3c6525f1f