### PR TITLE
Incluir esquema de cobra.mod y validación con jsonschema

### DIFF
--- a/backend/src/cobra/semantico/cobra_mod_schema.yaml
+++ b/backend/src/cobra/semantico/cobra_mod_schema.yaml
@@ -1,0 +1,21 @@
+type: object
+patternProperties:
+  ".*\\.co$":
+    type: object
+    required:
+      - version
+    properties:
+      version:
+        type: string
+        pattern: '^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:[-+].*)?$'
+      python:
+        type: string
+      js:
+        type: string
+    anyOf:
+      - required: [python]
+      - required: [js]
+properties:
+  lock:
+    type: object
+additionalProperties: false

--- a/backend/src/cobra/semantico/mod_validator.py
+++ b/backend/src/cobra/semantico/mod_validator.py
@@ -15,9 +15,14 @@ import os
 import tomllib
 import yaml
 from typing import Dict, Any
+from jsonschema import validate, ValidationError
 
 from src.cli.utils.semver import es_version_valida
 from src.cobra.transpilers import module_map
+
+SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "cobra_mod_schema.yaml")
+with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+    SCHEMA = yaml.safe_load(f)
 
 
 def cargar_mod(path: str | None = None) -> Dict[str, Any]:
@@ -43,6 +48,11 @@ def validar_mod(path: str | None = None) -> None:
     Lanza ``ValueError`` si se detecta algún problema.
     """
     datos = cargar_mod(path)
+    try:
+        validate(instance=datos, schema=SCHEMA)
+    except ValidationError as e:
+        raise ValueError(f"Archivo cobra.mod inválido: {e.message}") from None
+
     errores: list[str] = []
 
     archivos_py: set[str] = set()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ codecov==2.1.13
 # Ejecución de la CLI y kernel de Jupyter
 ipykernel==6.29.5
 PyYAML==6.0.1
+jsonschema==4.22.0
 agix==0.8.3
 holobit-sdk
 flet

--- a/tests/unit/test_cli_commands_extra.py
+++ b/tests/unit/test_cli_commands_extra.py
@@ -177,7 +177,9 @@ def test_cli_modulos_comandos(tmp_path, monkeypatch):
     mods_dir.mkdir()
     monkeypatch.setattr(modules_cmd, "MODULES_PATH", str(mods_dir))
     mod_file = tmp_path / "cobra.mod"
-    mod_mapping = {"m.co": {"version": "0.1.0"}, "lock": {}}
+    py_out = tmp_path / "m.py"
+    py_out.write_text("d = 1\n")
+    mod_mapping = {"m.co": {"version": "0.1.0", "python": str(py_out)}, "lock": {}}
     mod_file.write_text(yaml.safe_dump(mod_mapping))
     monkeypatch.setattr(modules_cmd, "MODULE_MAP_PATH", str(mod_file))
     monkeypatch.setattr(modules_cmd, "LOCK_FILE", str(mod_file))
@@ -219,7 +221,9 @@ def test_cli_modulo_version_invalida(tmp_path, monkeypatch):
     mods_dir.mkdir()
     monkeypatch.setattr(modules_cmd, "MODULES_PATH", str(mods_dir))
     mod_file = tmp_path / "cobra.mod"
-    mod_mapping = {"bad.co": {"version": "abc"}, "lock": {}}
+    bad_py = tmp_path / "bad.py"
+    bad_py.write_text("d = 1\n")
+    mod_mapping = {"bad.co": {"version": "abc", "python": str(bad_py)}, "lock": {}}
     mod_file.write_text(yaml.safe_dump(mod_mapping))
     monkeypatch.setattr(modules_cmd, "MODULE_MAP_PATH", str(mod_file))
     monkeypatch.setattr(modules_cmd, "LOCK_FILE", str(mod_file))

--- a/tests/unit/test_mod_validator.py
+++ b/tests/unit/test_mod_validator.py
@@ -10,7 +10,7 @@ def _write_yaml(path, data):
 
 def test_validador_archivo_faltante(tmp_path):
     mod = tmp_path / "m.co"
-    data = {str(mod): {"python": str(tmp_path / "m.py")}}
+    data = {str(mod): {"version": "0.1.0", "python": str(tmp_path / "m.py")}}
     _write_yaml(tmp_path / "cobra.mod", data)
     with pytest.raises(ValueError):
         validar_mod(str(tmp_path / "cobra.mod"))
@@ -30,8 +30,8 @@ def test_validador_duplicados(tmp_path):
     py = tmp_path / "dup.py"
     py.write_text("x = 1")
     data = {
-        str(tmp_path / "a.co"): {"python": str(py)},
-        str(tmp_path / "b.co"): {"python": str(py)},
+        str(tmp_path / "a.co"): {"version": "0.1.0", "python": str(py)},
+        str(tmp_path / "b.co"): {"version": "0.1.0", "python": str(py)},
     }
     _write_yaml(tmp_path / "cobra.mod", data)
     with pytest.raises(ValueError):

--- a/tests/unit/test_module_map.py
+++ b/tests/unit/test_module_map.py
@@ -14,7 +14,7 @@ def test_transpilador_mapeo_python(tmp_path, monkeypatch):
     py_out = tmp_path / "m.py"
     py_out.write_text("x = 1\n")
 
-    mapping = {str(mod): {"python": str(py_out)}}
+    mapping = {str(mod): {"version": "0.1.0", "python": str(py_out)}}
     mapfile = tmp_path / "cobra.mod"
     mapfile.write_text(yaml.safe_dump(mapping))
 
@@ -36,7 +36,7 @@ def test_transpilador_mapeo_js(tmp_path, monkeypatch):
     js_out = tmp_path / "m.js"
     js_out.write_text("let x = 2;\n")
 
-    mapping = {str(mod): {"js": str(js_out)}}
+    mapping = {str(mod): {"version": "0.1.0", "js": str(js_out)}}
     mapfile = tmp_path / "cobra.mod"
     mapfile.write_text(yaml.safe_dump(mapping))
 


### PR DESCRIPTION
## Summary
- add jsonschema dependency
- create `cobra_mod_schema.yaml`
- load the schema in `mod_validator` and validate using jsonschema
- update unit tests for the new requirements

## Testing
- `PYTHONPATH=$PWD:$PWD/backend:$PWD/backend/src:$PWD/src pytest -q` *(fails: ModuleNotFoundError: No module named 'tomli')*

------
https://chatgpt.com/codex/tasks/task_e_68654c32874c83278b52be401b71a18b