### PR TITLE
Añadir test de campos faltantes y mensaje de versión en mod_validator

### DIFF
--- a/tests/unit/test_mod_validator.py
+++ b/tests/unit/test_mod_validator.py
@@ -16,13 +16,22 @@ def test_validador_archivo_faltante(tmp_path):
         validar_mod(str(tmp_path / "cobra.mod"))
 
 
+def test_validador_campos_faltantes(tmp_path):
+    """Debe fallar si falta la clave python y js en una entrada."""
+    mod = tmp_path / "x.co"
+    data = {str(mod): {"version": "0.1.0"}}
+    _write_yaml(tmp_path / "cobra.mod", data)
+    with pytest.raises(ValueError):
+        validar_mod(str(tmp_path / "cobra.mod"))
+
+
 def test_validador_version_incorrecta(tmp_path):
     py = tmp_path / "m.py"
     py.write_text("x = 1")
     mod = tmp_path / "m.co"
     data = {str(mod): {"version": "bad", "python": str(py)}}
     _write_yaml(tmp_path / "cobra.mod", data)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"Versión inválida para {mod}: bad"):
         validar_mod(str(tmp_path / "cobra.mod"))
 
 


### PR DESCRIPTION
## Summary
- amplío `test_validador_version_incorrecta` comprobando el mensaje de error
- añado `test_validador_campos_faltantes` para verificar ausencia de `python` y `js`

## Testing
- `pytest -q` *(falla: ModuleNotFoundError durante la recogida de pruebas)*

------
https://chatgpt.com/codex/tasks/task_e_68654fb69af883279894acaf25d3d357