### PR TITLE
Bump version to 5.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v5.6.3 - 2025-07-02
+- Cambios pendientes.
+
 ## v5.6.1 - 2025-07-02
 - Cambios pendientes.
 

--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -1,6 +1,6 @@
 # Manual del Lenguaje Cobra
 
-Versión 5.6.2
+Versión 5.6.3
 
 Este manual presenta en español los conceptos básicos para programar en Cobra. Se organiza en tareas que puedes seguir paso a paso.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-71%25-brightgreen)](https://codecov.io/gh/Alphonsus411/pCobra)
 
 
-Versión 5.6.2
+Versión 5.6.3
 
 Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
@@ -688,7 +688,7 @@ Este proyecto sigue el esquema [SemVer](https://semver.org/lang/es/). Los numero
 
 ## Historial de Cambios
 
- - Versión 5.6.2: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
+ - Versión 5.6.3: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
 
 # Licencia
 

--- a/backend/src/jupyter_kernel/__init__.py
+++ b/backend/src/jupyter_kernel/__init__.py
@@ -16,9 +16,9 @@ def install(user=True):
 
 class CobraKernel(Kernel):
     implementation = "Cobra"
-    implementation_version = "5.6.2"
+    implementation_version = "5.6.3"
     language = "cobra"
-    language_version = "5.6.2"
+    language_version = "5.6.3"
     language_info = {
         "name": "cobra",
         "mimetype": "text/plain",

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -7,10 +7,10 @@ Avances del lenguaje Cobra
 - **Gestión de memoria automatizada**: Cobra incluye un sistema de manejo de memoria optimizado que se ajusta automáticamente utilizando algoritmos genéticos.
 - **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX.
 - **Pruebas unitarias**: Se han creado pruebas para validar el correcto funcionamiento del lexer y el parser.
- - **Versión 5.6.2**: Actualización de la documentación y configuración del proyecto.
- - **Versión 5.6.2**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
+ - **Versión 5.6.3**: Actualización de la documentación y configuración del proyecto.
+ - **Versión 5.6.3**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
 
-Versión 5.6.2
+Versión 5.6.3
 -----------
 Se añade el archivo ``pcobra.toml`` para definir el mapeo de módulos en formato TOML. Su estructura es la siguiente:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cobra-lenguaje"
-version = "5.6.2"
+version = "5.6.3"
 description = "Un lenguaje de programación en español para simulaciones y más."
 authors = [ {name = "Adolfo González Hernández", email = "adolfogonzal@gmail.com"} ]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cobra-lenguaje',
-    version='5.6.2',
+    version='5.6.3',
     author='Adolfo González Hernández',
     author_email='adolfogonzal@gmail.com',
     description='Un lenguaje de programación en español para simulaciones y más.',

--- a/tests/unit/test_cli_plugins_cmd.py
+++ b/tests/unit/test_cli_plugins_cmd.py
@@ -8,7 +8,7 @@ from src.cli.plugin import PluginCommand
 
 class DummyPlugin(PluginCommand):
     name = "dummy"
-    version = "5.6.2"
+    version = "5.6.3"
 
     def register_subparser(self, subparsers):
         pass
@@ -38,7 +38,7 @@ def test_cli_plugins_muestra_registro():
     with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["plugins"])
-    assert "dummy 5.6.2.2" in out.getvalue().strip()
+    assert "dummy 5.6.3" in out.getvalue().strip()
 
 
 def test_cli_plugin_ejemplo_hola():


### PR DESCRIPTION
## Summary
- bump package version to 5.6.3
- update kernel version strings
- refresh documentation with new version
- adjust CLI plugin test with new version
- prepend 5.6.3 entry in changelog

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q tomli`
- `PYTHONPATH="backend:." pytest -q` *(fails: SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6865538e201c8327b97f65ba8f196ffb