### PR TITLE
Actualizar versión a 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v6.0.0 - 2025-07-03
+- Cambios pendientes.
+
 ## v5.6.3 - 2025-07-02
 - Cambios pendientes.
 

--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -1,6 +1,6 @@
 # Manual del Lenguaje Cobra
 
-Versión 5.6.3
+Versión 6.0.0
 
 Este manual presenta en español los conceptos básicos para programar en Cobra. Se organiza en tareas que puedes seguir paso a paso.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-71%25-brightgreen)](https://codecov.io/gh/Alphonsus411/pCobra)
 
 
-Versión 5.6.3
+Versión 6.0.0
 
 Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
@@ -688,7 +688,7 @@ Este proyecto sigue el esquema [SemVer](https://semver.org/lang/es/). Los numero
 
 ## Historial de Cambios
 
- - Versión 5.6.3: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
+ - Versión 6.0.0: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
 
 # Licencia
 

--- a/backend/src/jupyter_kernel/__init__.py
+++ b/backend/src/jupyter_kernel/__init__.py
@@ -16,9 +16,9 @@ def install(user=True):
 
 class CobraKernel(Kernel):
     implementation = "Cobra"
-    implementation_version = "5.6.3"
+    implementation_version = "6.0.0"
     language = "cobra"
-    language_version = "5.6.3"
+    language_version = "6.0.0"
     language_info = {
         "name": "cobra",
         "mimetype": "text/plain",

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -7,10 +7,10 @@ Avances del lenguaje Cobra
 - **Gestión de memoria automatizada**: Cobra incluye un sistema de manejo de memoria optimizado que se ajusta automáticamente utilizando algoritmos genéticos.
 - **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX.
 - **Pruebas unitarias**: Se han creado pruebas para validar el correcto funcionamiento del lexer y el parser.
- - **Versión 5.6.3**: Actualización de la documentación y configuración del proyecto.
- - **Versión 5.6.3**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
+ - **Versión 6.0.0**: Actualización de la documentación y configuración del proyecto.
+ - **Versión 6.0.0**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
 
-Versión 5.6.3
+Versión 6.0.0
 -----------
 Se añade el archivo ``pcobra.toml`` para definir el mapeo de módulos en formato TOML. Su estructura es la siguiente:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cobra-lenguaje"
-version = "5.6.3"
+version = "6.0.0"
 description = "Un lenguaje de programación en español para simulaciones y más."
 authors = [ {name = "Adolfo González Hernández", email = "adolfogonzal@gmail.com"} ]
 readme = "README.md"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import re
+import sys
 import tomllib
 from datetime import date
 from pathlib import Path
@@ -90,8 +91,9 @@ def update_changelog(new_version: str):
 
 
 def main():
+    part = sys.argv[1] if len(sys.argv) > 1 else "patch"
     current = read_version()
-    new = bump(current)
+    new = bump(current, part)
     update_files(current, new)
     update_changelog(new)
     print(new)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cobra-lenguaje',
-    version='5.6.3',
+    version='6.0.0',
     author='Adolfo González Hernández',
     author_email='adolfogonzal@gmail.com',
     description='Un lenguaje de programación en español para simulaciones y más.',

--- a/tests/unit/test_cli_plugins_cmd.py
+++ b/tests/unit/test_cli_plugins_cmd.py
@@ -8,7 +8,7 @@ from src.cli.plugin import PluginCommand
 
 class DummyPlugin(PluginCommand):
     name = "dummy"
-    version = "5.6.3"
+    version = "6.0.0"
 
     def register_subparser(self, subparsers):
         pass
@@ -38,7 +38,7 @@ def test_cli_plugins_muestra_registro():
     with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["plugins"])
-    assert "dummy 5.6.3" in out.getvalue().strip()
+    assert "dummy 6.0.0" in out.getvalue().strip()
 
 
 def test_cli_plugin_ejemplo_hola():


### PR DESCRIPTION
## Resumen
- actualizar script `bump_version.py` para aceptar argumentos y ejecutar `python scripts/bump_version.py major`
- subir la versión del proyecto a **6.0.0** en `pyproject.toml`, `setup.py`, `README.md`, `MANUAL_COBRA.md`, pruebas y más
- añadir entrada correspondiente en `CHANGELOG.md`
- crear etiqueta `v6.0.0`

## Testing
- `pytest -q` *(falla: ModuleNotFoundError: No module named 'yaml' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686679d0b1fc83279736aa498728f6fb