### PR TITLE
Mejora empaquetado de la CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ GitHub Actions. Puedes encontrarlos en la pestaña
 Solo descarga el archivo correspondiente a tu sistema operativo desde la versión
 más reciente y ejecútalo directamente.
 
+Si prefieres generar el ejecutable manualmente ejecuta desde la raíz del
+repositorio:
+
+```bash
+cobra empaquetar --output dist
+```
+El nombre del binario puede ajustarse con la opción `--name`.
+
 # Estructura del Proyecto
 
 El proyecto se organiza en las siguientes carpetas y módulos:

--- a/backend/src/cli/commands/empaquetar_cmd.py
+++ b/backend/src/cli/commands/empaquetar_cmd.py
@@ -20,6 +20,11 @@ class EmpaquetarCommand(BaseCommand):
             default="dist",
             help=_("Directorio donde colocar el ejecutable generado"),
         )
+        parser.add_argument(
+            "--name",
+            default="cobra",
+            help=_("Nombre del ejecutable resultante"),
+        )
         parser.set_defaults(cmd=self)
         return parser
 
@@ -29,13 +34,14 @@ class EmpaquetarCommand(BaseCommand):
         )
         cli_path = os.path.join(raiz, "backend", "src", "cli", "cli.py")
         output = args.output
+        nombre = args.name
         try:
             subprocess.run(
                 [
                     "pyinstaller",
                     "--onefile",
                     "-n",
-                    "cobra",
+                    nombre,
                     cli_path,
                     "--distpath",
                     output,
@@ -44,7 +50,7 @@ class EmpaquetarCommand(BaseCommand):
             )
             mostrar_info(
                 _("Ejecutable generado en {path}").format(
-                    path=os.path.join(output, 'cobra')
+                    path=os.path.join(output, nombre)
                 )
             )
             return 0

--- a/frontend/docs/empaquetar.rst
+++ b/frontend/docs/empaquetar.rst
@@ -10,6 +10,12 @@ Para generar el ejecutable ejecuta:
 
    cobra empaquetar --output dist
 
+El nombre del ejecutable puede cambiarse con ``--name``. Por ejemplo:
+
+.. code-block:: bash
+
+   cobra empaquetar --name pcobra --output dist
+
 Esto creará un archivo ``cobra`` (o ``cobra.exe`` en Windows) en el directorio
 ``dist``. Se necesita tener ``pyinstaller`` instalado previamente. Puedes
 instalarlo con ``pip install pyinstaller``.

--- a/tests/unit/test_cli_empaquetar.py
+++ b/tests/unit/test_cli_empaquetar.py
@@ -7,7 +7,7 @@ from src.cli.cli import main
 
 def test_cli_empaquetar_invoca_pyinstaller(tmp_path):
     with patch("subprocess.run") as mock_run:
-        main(["empaquetar", f"--output={tmp_path}"])
+        main(["empaquetar", f"--output={tmp_path}", "--name", "pcobra"])
         raiz = Path(__file__).resolve().parents[3]
         cli_path = raiz / "backend" / "src" / "cli" / "cli.py"
         mock_run.assert_called_once_with(
@@ -15,7 +15,7 @@ def test_cli_empaquetar_invoca_pyinstaller(tmp_path):
                 "pyinstaller",
                 "--onefile",
                 "-n",
-                "cobra",
+                "pcobra",
                 str(cli_path),
                 "--distpath",
                 str(tmp_path),
@@ -27,5 +27,5 @@ def test_cli_empaquetar_invoca_pyinstaller(tmp_path):
 def test_cli_empaquetar_sin_pyinstaller(tmp_path):
     with patch("subprocess.run", side_effect=FileNotFoundError), \
             patch("sys.stdout", new_callable=StringIO) as out:
-        main(["empaquetar", f"--output={tmp_path}"])
+        main(["empaquetar", f"--output={tmp_path}", "--name", "pcobra"])
     assert "PyInstaller no está instalado" in out.getvalue()


### PR DESCRIPTION
## Summary
- permite definir nombre del ejecutable con `--name`
- documenta cómo generar el binario manualmente
- ajusta prueba unitaria de empaquetado

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest tests/unit/test_cli_empaquetar.py -q` *(fails: ModuleNotFoundError: No module named 'backend.src.core')*

------
https://chatgpt.com/codex/tasks/task_e_68667ba1580c8327aa5bf71e78ca1a4d