### PR TITLE
Add stable version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Proyecto Cobra
 [![Coverage](https://img.shields.io/badge/coverage-71%25-brightgreen)](https://codecov.io/gh/Alphonsus411/pCobra)
+[![Versión estable](https://img.shields.io/github/v/release/Alphonsus411/pCobra?label=stable)](https://github.com/Alphonsus411/pCobra/releases/latest)
 
 
 Versión 6.0.0


### PR DESCRIPTION
## Summary
- add a badge linking to the latest release

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686682bfc4248327ba0c39495f2cf949