### PR TITLE
Add VS Code grammar for Cobra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 *.egg-info/
 /dist/
 *.log
+frontend/vscode/node_modules/
 
 # Coverage reports
 .coverage

--- a/frontend/vscode/README.md
+++ b/frontend/vscode/README.md
@@ -48,3 +48,9 @@ fin
 ```
 
 Al escribir los prefijos anteriores y pulsar `Tab`, VS Code mostrará las plantillas correspondientes.
+
+## Gramática de resaltado
+
+La extensión incluye una gramática TextMate (`syntaxes/cobra.tmLanguage.json`) que define palabras clave, cadenas, números y comentarios de Cobra. Existe además un archivo `language-configuration.json` con las reglas de comentarios y parejas de llaves.
+
+Para ajustar los colores, puedes editar tu `settings.json` y usar `editor.tokenColorCustomizations` con reglas `textMateRules` que apliquen al scope `source.cobra`.

--- a/frontend/vscode/language-configuration.json
+++ b/frontend/vscode/language-configuration.json
@@ -1,0 +1,25 @@
+{
+  "comments": {
+    "lineComment": "#",
+    "blockComment": ["/*", "*/"]
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] },
+    { "open": "'", "close": "'", "notIn": ["string"] }
+  ],
+  "surroundingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"" },
+    { "open": "'", "close": "'" }
+  ]
+}

--- a/frontend/vscode/package.json
+++ b/frontend/vscode/package.json
@@ -22,7 +22,15 @@
             {
                 "id": "cobra",
                 "extensions": [".co"],
-                "aliases": ["Cobra"]
+                "aliases": ["Cobra"],
+                "configuration": "./language-configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "cobra",
+                "scopeName": "source.cobra",
+                "path": "./syntaxes/cobra.tmLanguage.json"
             }
         ],
         "snippets": [

--- a/frontend/vscode/syntaxes/cobra.tmLanguage.json
+++ b/frontend/vscode/syntaxes/cobra.tmLanguage.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vscode/master/extensions/theme-defaults/syntaxes/textmate.tmLanguage.schema.json",
+  "name": "Cobra",
+  "scopeName": "source.cobra",
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#keywords" },
+    { "include": "#strings" },
+    { "include": "#numbers" },
+    { "include": "#brackets" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        { "name": "comment.line.double-slash.cobra", "match": "//.*$" },
+        { "name": "comment.line.number-sign.cobra", "match": "#.*$" }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.cobra",
+          "match": "\\b(var|variable|func|definir|metodo|atributo|rel|si|sino|mientras|para|import|usar|macro|hilo|asincronico|switch|segun|case|caso|clase|in|holobit|proyectar|transformar|graficar|try|catch|throw|intentar|capturar|lanzar|imprimir|yield|esperar|romper|continuar|pasar|afirmar|eliminar|global|nolocal|lambda|con|finalmente|desde|como|retorno|fin)\\b"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        { "name": "string.quoted.double.cobra", "begin": "\"", "end": "\"" },
+        { "name": "string.quoted.single.cobra", "begin": "'", "end": "'" }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        { "name": "constant.numeric.cobra", "match": "\\b\\d+\\.\\d+\\b" },
+        { "name": "constant.numeric.cobra", "match": "\\b\\d+\\b" },
+        { "name": "constant.language.boolean.cobra", "match": "\\b(verdadero|falso)\\b" }
+      ]
+    },
+    "brackets": {
+      "patterns": [
+        { "name": "punctuation.section.braces.begin.cobra", "match": "\\{" },
+        { "name": "punctuation.section.braces.end.cobra", "match": "\\}" },
+        { "name": "punctuation.section.parens.begin.cobra", "match": "\\(" },
+        { "name": "punctuation.section.parens.end.cobra", "match": "\\)" },
+        { "name": "punctuation.section.brackets.begin.cobra", "match": "\\[" },
+        { "name": "punctuation.section.brackets.end.cobra", "match": "\\]" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `.tmLanguage` grammar for Cobra language
- register the grammar and language configuration in `package.json`
- define comment and bracket rules in a new `language-configuration.json`
- document how to tweak highlighting in the extension README
- ignore `frontend/vscode/node_modules`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68668523d83c8327a29342f5f9198e90