### PR TITLE
Add runFile command in VS Code extension

### DIFF
--- a/frontend/vscode/README.md
+++ b/frontend/vscode/README.md
@@ -14,6 +14,7 @@ npm install
 1. Abre VS Code y carga este directorio como espacio de trabajo.
 2. Pulsa `F5` para iniciar un "Extension Development Host".
 3. En la nueva ventana, ejecuta el comando **Iniciar Cobra LSP** desde la paleta (`Ctrl+Shift+P`).
+4. Para ejecutar el archivo Cobra actualmente abierto, presiona `Ctrl+R` o ejecuta el comando **Ejecutar archivo Cobra**.
 
 El servidor de lenguaje se ejecutará mediante `python -m lsp.server` y proporcionará autocompletado y errores en vivo para archivos Cobra.
 
@@ -48,6 +49,10 @@ fin
 ```
 
 Al escribir los prefijos anteriores y pulsar `Tab`, VS Code mostrará las plantillas correspondientes.
+
+## Ejecutar scripts Cobra
+
+Con la extensión activa puedes ejecutar rápidamente el archivo abierto con `Ctrl+R`. Esto lanzará `cobra ejecutar <archivo>` y mostrará la salida en el panel **Cobra**.
 
 ## Gramática de resaltado
 

--- a/frontend/vscode/extension.js
+++ b/frontend/vscode/extension.js
@@ -27,6 +27,28 @@ function activate(context) {
     });
 
     context.subscriptions.push(disposable);
+
+    const runFileDisposable = vscode.commands.registerCommand('cobra.runFile', () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            vscode.window.showErrorMessage('No hay un editor activo.');
+            return;
+        }
+
+        const filePath = editor.document.fileName;
+
+        const output = vscode.window.createOutputChannel('Cobra');
+        output.clear();
+        output.show(true);
+
+        const proc = cp.spawn('cobra', ['ejecutar', filePath]);
+
+        proc.stdout.on('data', data => output.append(data.toString()));
+        proc.stderr.on('data', data => output.append(data.toString()));
+        proc.on('error', err => output.append(`Error: ${err.message}\n`));
+    });
+
+    context.subscriptions.push(runFileDisposable);
 }
 
 function deactivate() {

--- a/frontend/vscode/package.json
+++ b/frontend/vscode/package.json
@@ -16,6 +16,10 @@
             {
                 "command": "cobra.startLSP",
                 "title": "Iniciar Cobra LSP"
+            },
+            {
+                "command": "cobra.runFile",
+                "title": "Ejecutar archivo Cobra"
             }
         ],
         "languages": [
@@ -38,7 +42,12 @@
                 "language": "cobra",
                 "path": "./snippets/cobra.json"
             }
-        ]
+        ],
+        "keybindings": [{
+            "command": "cobra.runFile",
+            "key": "ctrl+r",
+            "when": "editorTextFocus && editorLangId == cobra"
+        }]
     }
     ,
     "dependencies": {


### PR DESCRIPTION
## Summary
- implement new `cobra.runFile` command to execute the active Cobra file
- expose command in `package.json` and add `Ctrl+R` keybinding
- document the new shortcut in VS Code extension README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686686ed3d108327be9e1658369e2b51