### PR TITLE
Añadir plugin LSP de autocompletado Cobra

### DIFF
--- a/backend/src/lsp/cobra_plugin.py
+++ b/backend/src/lsp/cobra_plugin.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Plugin de completado para palabras clave y funciones estándar de Cobra."""
+
+import re
+from pylsp import hookimpl, lsp
+from standard_library import __all__ as STD_FUNCS
+
+# Palabras reservadas más comunes de Cobra
+KEYWORDS = [
+    "func",
+    "clase",
+    "metodo",
+    "atributo",
+    "si",
+    "sino",
+    "para",
+    "mientras",
+    "romper",
+    "continuar",
+    "regresar",
+    "importar",
+    "intentar",
+    "excepto",
+    "fin",
+]
+
+# Funciones incluidas en la biblioteca estándar
+BUILTINS = list(STD_FUNCS) + ["imprimir"]
+
+
+@hookimpl
+def pylsp_settings():
+    """Activa el plugin por defecto."""
+    return {"plugins": {"cobra": {"enabled": True}}}
+
+
+@hookimpl
+def pylsp_completions(config, workspace, document, position):
+    """Devuelve sugerencias de autocompletado para Cobra."""
+    line = document.lines[position["line"]]
+    prefix_match = re.search(r"\w*$", line[: position["character"]])
+    prefix = prefix_match.group(0) if prefix_match else ""
+
+    items = []
+    for word in KEYWORDS:
+        if word.startswith(prefix):
+            items.append(
+                {
+                    "label": word,
+                    "kind": lsp.CompletionItemKind.Keyword,
+                    "detail": "Palabra clave Cobra",
+                }
+            )
+    for func in BUILTINS:
+        if func.startswith(prefix):
+            items.append(
+                {
+                    "label": func,
+                    "kind": lsp.CompletionItemKind.Function,
+                    "detail": "Función estándar Cobra",
+                }
+            )
+    return items or None

--- a/backend/src/lsp/server.py
+++ b/backend/src/lsp/server.py
@@ -1,13 +1,24 @@
-"""Módulo para iniciar un servidor LSP mínimo."""
+"""Módulo para iniciar un servidor LSP con soporte para Cobra."""
+
+from __future__ import annotations
 
 import sys
-from pylsp import lsp
-from pylsp.python_lsp import start_io_lang_server
+from pylsp.python_lsp import PythonLSPServer, start_io_lang_server
+
+from . import cobra_plugin
+
+
+class CobraLSPServer(PythonLSPServer):
+    """Servidor LSP que registra el plugin de completado de Cobra."""
+
+    def __init__(self, rx, tx, check_parent_process=False):
+        super().__init__(rx, tx, check_parent_process)
+        self.config.plugin_manager.register(cobra_plugin, name="cobra")
 
 
 def main() -> None:
-    """Arranca el servidor de lenguaje utilizando la implementación por defecto"""
-    start_io_lang_server(lsp, sys.stdin.buffer, sys.stdout.buffer)
+    """Arranca el servidor de lenguaje con el plugin registrado."""
+    start_io_lang_server(sys.stdin.buffer, sys.stdout.buffer, False, CobraLSPServer)
 
 
 if __name__ == "__main__":

--- a/frontend/vscode/README.md
+++ b/frontend/vscode/README.md
@@ -59,3 +59,12 @@ Con la extensión activa puedes ejecutar rápidamente el archivo abierto con `Ct
 La extensión incluye una gramática TextMate (`syntaxes/cobra.tmLanguage.json`) que define palabras clave, cadenas, números y comentarios de Cobra. Existe además un archivo `language-configuration.json` con las reglas de comentarios y parejas de llaves.
 
 Para ajustar los colores, puedes editar tu `settings.json` y usar `editor.tokenColorCustomizations` con reglas `textMateRules` que apliquen al scope `source.cobra`.
+
+## Pruebas manuales
+
+Sigue estos pasos para comprobar que el servidor LSP ofrece sugerencias de Cobra:
+
+1. Inicia la extensión con `F5` y ejecuta el comando **Iniciar Cobra LSP**.
+2. Crea o abre un archivo con la extensión `.co`.
+3. Al escribir prefijos como `func`, `si` o `cabeza` deberás ver en VS Code las
+   sugerencias proporcionadas por el servidor.

--- a/frontend/vscode/extension.js
+++ b/frontend/vscode/extension.js
@@ -2,6 +2,9 @@ const vscode = require('vscode');
 const cp = require('child_process');
 const { LanguageClient } = require('vscode-languageclient/node');
 
+// Ruta al módulo del servidor LSP. Modifica aquí si cambia el nombre.
+const SERVER_MODULE = 'lsp.server';
+
 let client;
 
 function activate(context) {
@@ -14,7 +17,7 @@ function activate(context) {
         }
 
         const serverOptions = () => {
-            const process = cp.spawn('python', ['-m', 'lsp.server']);
+            const process = cp.spawn('python', ['-m', SERVER_MODULE]);
             return { process };
         };
 


### PR DESCRIPTION
## Summary
- registrar un servidor LSP propio con PythonLSPServer
- implementar plugin `cobra_plugin` con sugerencias de palabras clave y funciones estándar
- permitir configurar el módulo del servidor en `extension.js`
- documentar pruebas manuales de autocompletado en VS Code

## Testing
- `make lint` *(fails: flake8 issues)*
- `pytest -q` *(fails: import errors)*
- `make typecheck` *(fails: mypy errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866884fb5bc8327afb277ff413ad64c