### PR TITLE
Agregar ejemplos y guía de publicación VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Cobra es un lenguaje de programación diseñado en español, enfocado en la crea
 ## Ejemplos
 
 Proyectos de demostracion disponibles en [cobra-ejemplos](https://github.com/tuusuario/cobra-ejemplos).
+Este repositorio incluye ejemplos básicos en la carpeta `examples/`, por
+ejemplo `examples/funciones_principales.co` que muestra condicionales, bucles y
+definición de funciones en Cobra.
 
 ## Notebooks de ejemplo
 

--- a/examples/funciones_principales.co
+++ b/examples/funciones_principales.co
@@ -1,0 +1,11 @@
+func saludar(nombre):
+    imprimir "Hola, " + nombre
+fin
+
+para numero en rango(3):
+    si numero % 2 == 0:
+        imprimir numero, "es par"
+    sino:
+        imprimir numero, "es impar"
+    fin
+fin

--- a/frontend/vscode/README.md
+++ b/frontend/vscode/README.md
@@ -68,3 +68,21 @@ Sigue estos pasos para comprobar que el servidor LSP ofrece sugerencias de Cobra
 2. Crea o abre un archivo con la extensión `.co`.
 3. Al escribir prefijos como `func`, `si` o `cabeza` deberás ver en VS Code las
    sugerencias proporcionadas por el servidor.
+
+## Empaquetar y publicar
+
+Instala `vsce` una vez de forma global y genera el archivo `.vsix` con:
+
+```bash
+npm install -g vsce
+vsce package
+```
+
+Esto creará un paquete instalable localmente. Para publicarlo en el Marketplace
+asegúrate de actualizar `package.json` (autor, repositorio y versión) y ejecuta:
+
+```bash
+vsce publish
+```
+
+Debes iniciar sesión previamente con `vsce login <publisher>`.

--- a/frontend/vscode/package.json
+++ b/frontend/vscode/package.json
@@ -2,7 +2,12 @@
     "name": "cobra-vscode-extension",
     "displayName": "Cobra Support",
     "description": "Extensión básica para editar archivos Cobra",
-    "version": "0.0.1",
+    "version": "1.0.0",
+    "author": "Adolfo González Hernández",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Alphonsus411/pCobra"
+    },
     "engines": {
         "vscode": "^1.80.0"
     },


### PR DESCRIPTION
## Summary
- añadir archivo `funciones_principales.co` con ejemplos básicos
- explicar la carpeta `examples/` en el README principal
- incluir sección para empaquetar con `vsce` en la extensión
- actualizar metadatos de `package.json`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68668b0612448327974e88bf4fafd4fa