### PR TITLE
Add benchmarks results notebook

### DIFF
--- a/notebooks/benchmarks_resultados.ipynb
+++ b/notebooks/benchmarks_resultados.ipynb
@@ -1,0 +1,72 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "titulo",
+      "metadata": {},
+      "source": [
+        "## Resultados de Benchmarks"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "instrucciones",
+      "metadata": {},
+      "source": [
+        "Genera los datos ejecutando:\n",
+        "\n",
+        "```bash\n",
+        "python scripts/benchmarks/compare_backends.py --output bench_results.json\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cargar",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import json\n",
+        "import pandas as pd\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "with open('bench_results.json') as f:\n",
+        "    data = json.load(f)\n",
+        "df = pd.DataFrame(data)\n",
+        "df"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "graficas",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "df.plot(kind='bar', x='backend', y='time', legend=False, title='Tiempo por backend')\n",
+        "plt.ylabel('segundos')\n",
+        "plt.show()\n",
+        "\n",
+        "df.plot(kind='bar', x='backend', y='memory_kb', legend=False, title='Memoria por backend')\n",
+        "plt.ylabel('KB')\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ejecucion",
+      "metadata": {},
+      "source": [
+        "Para abrir este cuaderno ejecuta:\n",
+        "\n",
+        "```bash\n",
+        "cobra jupyter\n",
+        "```\n"
+      ]
+    }
+  ],
+  "metadata": {},
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `benchmarks_resultados.ipynb` showing how to visualize benchmark data

## Testing
- `pytest -q` *(fails: 53 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68668fd97c8c83279f0db9dfbadf87c6