### PR TITLE
Add real-case notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Cobra es un lenguaje de programación diseñado en español, enfocado en la crea
 - [Especificación técnica](docs/especificacion_tecnica.md)
 - [Cheatsheet](docs/cheatsheet.tex) – compílalo a PDF con LaTeX
 - [Casos de uso reales](docs/casos_reales.md)
-- Notebooks de ejemplo
+- Notebooks de ejemplo y casos reales
 - [Historial de cambios](CHANGELOG.md)
 
 ## Ejemplos
@@ -38,11 +38,11 @@ Proyectos de demostracion disponibles en [cobra-ejemplos](https://github.com/tuu
 Este repositorio incluye ejemplos básicos en la carpeta `examples/`, por
 ejemplo `examples/funciones_principales.co` que muestra condicionales, bucles y
 definición de funciones en Cobra.
+Para ejemplos interactivos revisa los cuadernos en `notebooks/casos_reales/`.
 
 ## Notebooks de ejemplo
 
-En la carpeta `notebooks/` se incluye el cuaderno `ejemplo_basico.ipynb` con un
-ejemplo básico de uso de Cobra. Para abrirlo ejecuta:
+En la carpeta `notebooks/` se incluye el cuaderno `ejemplo_basico.ipynb` con un ejemplo básico de uso de Cobra. Además, los cuadernos de `notebooks/casos_reales/` muestran cómo ejecutar los ejemplos avanzados. Para abrirlo ejecuta:
 
 ```bash
 cobra jupyter

--- a/docs/casos_reales.md
+++ b/docs/casos_reales.md
@@ -3,6 +3,7 @@
 Esta sección muestra ejemplos prácticos de cómo emplear la CLI de Cobra en distintos contextos.
 
 Los scripts completos de estos ejemplos se encuentran en la carpeta `casos_reales/` del repositorio.
+Se incluyen cuadernos interactivos en `notebooks/casos_reales/` que muestran paso a paso la compilación y ejecución de cada ejemplo.
 ## Bioinformática
 Un pequeño programa puede leer un archivo FASTA y contar el porcentaje de GC:
 
@@ -17,6 +18,8 @@ Ejecuta el script con:
 ```bash
 cobra ejecutar bioinfo.co
 ```
+También puedes ejecutar el cuaderno `notebooks/casos_reales/bioinformatica.ipynb` para verlo paso a paso.
+
 
 Dependencia recomendada: `biopython`.
 
@@ -35,6 +38,8 @@ Para ejecutar:
 ```bash
 cobra ejecutar ia.co
 ```
+También puedes ejecutar el cuaderno `notebooks/casos_reales/inteligencia_artificial.ipynb` para una versión interactiva.
+
 
 Necesitarás `scikit-learn` y opcionalmente `analizador_agix`.
 
@@ -53,5 +58,7 @@ Ejecuta el programa así:
 ```bash
 cobra ejecutar analisis.co
 ```
+Puedes revisar el cuaderno interactivo `notebooks/casos_reales/analisis_datos.ipynb` para seguirlo paso a paso.
+
 
 Instala las dependencias `pandas` y `matplotlib` antes de correrlo.

--- a/notebooks/casos_reales/analisis_datos.ipynb
+++ b/notebooks/casos_reales/analisis_datos.ipynb
@@ -1,0 +1,57 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "15e0f99f",
+   "metadata": {},
+   "source": [
+    "## Análisis de Datos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c43b3cc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat ../../casos_reales/analisis_datos/estadisticas.cob"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd7da4b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "df = pd.DataFrame({'valor':[1,2,3]})\n",
+    "df.to_csv('datos.csv', index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c14fa28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!PYTHONPATH='..:../backend/src:../backend' python ../../scripts/compile.py ../../casos_reales/analisis_datos/estadisticas.cob"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4164d7d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!PYTHONPATH='..:../backend/src:../backend' python estadisticas.py"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/casos_reales/bioinformatica.ipynb
+++ b/notebooks/casos_reales/bioinformatica.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4c231d62",
+   "metadata": {},
+   "source": [
+    "## Bioinformática"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "113e7ccb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat ../../casos_reales/bioinformatica/ejemplo_gc.cob"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "400959bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('secuencia.fasta','w') as f: f.write('>seq\n",
+    "GATTACA')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a1ec8af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!PYTHONPATH='..:../backend/src:../backend' python ../../scripts/compile.py ../../casos_reales/bioinformatica/ejemplo_gc.cob"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9656f1c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!PYTHONPATH='..:../backend/src:../backend' python ejemplo_gc.py"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/casos_reales/inteligencia_artificial.ipynb
+++ b/notebooks/casos_reales/inteligencia_artificial.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "abd91434",
+   "metadata": {},
+   "source": [
+    "## Inteligencia Artificial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98b1333b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat ../../casos_reales/inteligencia_artificial/modelo_ia.cob"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b0d6a89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "import pickle\n",
+    "model = LogisticRegression().fit([[0,0],[1,1]],[0,1])\n",
+    "pickle.dump(model, open('modelo.pkl','wb'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3459075f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!PYTHONPATH='..:../backend/src:../backend' python ../../scripts/compile.py ../../casos_reales/inteligencia_artificial/modelo_ia.cob"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2ff4716",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!PYTHONPATH='..:../backend/src:../backend' python modelo_ia.py"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add notebooks for real-case scenarios
- link new notebooks from docs and README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_6866a60ee1f48327be1c0283f3ca3b26