### PR TITLE
Actualiza guía de contribución y plantillas

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,3 +20,5 @@ Una descripción clara de lo que esperabas que sucediera.
 
 **Contexto adicional**
 Agrega cualquier otro contexto o capturas de pantalla sobre el problema.
+
+Si tienes dudas, coméntalas en nuestro [canal de comunidad](https://discord.gg/placeholder).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -21,3 +21,5 @@ Explica otras soluciones o características que hayas pensado.
 **Contexto adicional**
 
 Agrega cualquier información adicional.
+
+Si tienes dudas, coméntalas en nuestro [canal de comunidad](https://discord.gg/placeholder).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,5 @@ Por favor explica brevemente los cambios realizados y la motivación detrás de 
 - [ ] He ejecutado `make lint` y `make typecheck`
 - [ ] Se añadieron pruebas o documentación cuando fue necesario
 - [ ] Se vincularon los issues relevantes con `#numero`
+
+Consulta la [guía de contribución](../CONTRIBUTING.md) y si surge alguna duda visita nuestro [canal de comunidad](https://discord.gg/placeholder).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,13 @@ pytest
 Para generar un reporte de cobertura:
 
 ```bash
-pytest --cov=backend/src
+pytest --cov
+```
+
+Además de las pruebas, ejecuta las verificaciones de estilo con:
+
+```bash
+make lint
 ```
 
 ## Pull Requests
@@ -42,3 +48,7 @@ pytest --cov=backend/src
 6. **Revisión**: una vez abierto el PR, espera la revisión de los mantenedores y realiza los cambios solicitados.
 
 ¡Agradecemos todas las contribuciones!
+
+## Contacto
+
+Si tienes dudas o necesitas ayuda, únete a nuestro canal comunitario en [Discord](https://discord.gg/placeholder).


### PR DESCRIPTION
## Summary
- incluye comandos de cobertura y lint en la sección de pruebas
- agrega sección de contacto en `CONTRIBUTING.md`
- añade invitación al canal comunitario en las plantillas de issues
- referencia la guía de contribución y el canal en la plantilla de PR

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `make lint` *(fails: E501 line too long, E741 ambiguous variable name)*

------
https://chatgpt.com/codex/tasks/task_e_6866ca65ae848327ad7cdf64ef8ddeb3