### PR TITLE
Documentar hackathon y canales de difusión

### DIFF
--- a/.github/ISSUE_TEMPLATE/hackathon_evento.md
+++ b/.github/ISSUE_TEMPLATE/hackathon_evento.md
@@ -1,0 +1,10 @@
+---
+name: Anuncio hackathon
+about: Convocatoria y comentarios para el próximo hackathon
+labels: event
+assignees: ''
+---
+
+Estamos organizando un hackathon para el proyecto Cobra el **15 de julio de 2024** en formato **virtual**. Consulta los detalles en [docs/evento_hackathon.md](../docs/evento_hackathon.md).
+
+Por favor deja tus comentarios y sugerencias sobre la agenda o temas que te gustaría tratar.

--- a/README.md
+++ b/README.md
@@ -664,6 +664,7 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
 
 Únete a nuestro servidor de Discord para recibir anuncios, resolver dudas y colaborar en el desarrollo. Puedes unirte mediante este enlace permanente: [Enlace de invitación](https://discord.gg/placeholder).
 
+También contamos con un canal de **Telegram** y una cuenta de **Twitter** donde difundimos eventos y actualizaciones. Consulta el [evento_hackathon](docs/evento_hackathon.md) para conocer la próxima actividad.
 ## Desarrollo
 
 Para verificar el tipado de forma local ejecuta:

--- a/docs/comunidad.md
+++ b/docs/comunidad.md
@@ -14,3 +14,9 @@ Este proyecto cuenta con un servidor en Discord donde los usuarios pueden comuni
 
 ## Cómo unirse
 Utiliza el siguiente enlace permanente para acceder al servidor: [Invitación a Discord](https://discord.gg/placeholder).
+
+## Difusión de eventos
+- Las convocatorias se anuncian en nuestro nuevo canal de **Telegram**.
+- También publicamos novedades en la cuenta oficial de **Twitter**.
+
+Para más información sobre el próximo hackathon consulta [evento_hackathon.md](evento_hackathon.md).

--- a/docs/evento_hackathon.md
+++ b/docs/evento_hackathon.md
@@ -1,0 +1,19 @@
+# Hackathon Cobra 2024
+
+El evento se celebrará el **15 de julio de 2024** en formato **virtual** utilizando nuestro servidor de Discord. La idea es reunir a la comunidad para trabajar en mejoras del compilador y compartir experiencias.
+
+## Agenda
+1. 10:00 - Bienvenida y presentación
+2. 10:30 - Taller de instalación y entorno
+3. 12:00 - Desarrollo de proyectos en grupos
+4. 16:00 - Puesta en común de resultados
+5. 17:00 - Cierre del hackathon
+
+## Enlaces
+- [Formulario de registro](https://example.com/registro)
+- [Repositorio del proyecto](https://github.com/pCobra/pCobra)
+
+## Requisitos previos
+- Tener instalado **Python 3.10** o superior
+- Clonar el repositorio y ejecutar `pip install -r requirements.txt`
+- Conocimientos básicos de Git y GitHub


### PR DESCRIPTION
## Summary
- add hackathon agenda
- create issue template for event
- mention new Telegram and Twitter channels
- link hackathon details from README

## Testing
- `make lint` *(fails: E501 and other errors)*
- `make typecheck` *(fails: found 168 errors in 15 files)*
- `pytest -q` *(fails: ModuleNotFoundError: RestrictedPython)*

------
https://chatgpt.com/codex/tasks/task_e_6866cd53c1d48327b56aa6dbf66fe33e