### PR TITLE
Add unicode identifier tests

### DIFF
--- a/tests/unit/test_unicode_identifiers_extra.py
+++ b/tests/unit/test_unicode_identifiers_extra.py
@@ -1,0 +1,29 @@
+from src.cobra.lexico.lexer import Lexer, TipoToken
+
+
+def test_unicode_identifiers_extra():
+    codigo = """var ma\u00f1ana = 1
+var se\u00f1al = 2
+var \u03bbambda = 3
+var \u00e1rbol = 4"""
+    lexer = Lexer(codigo)
+    tokens = lexer.analizar_token()
+    assert [(t.tipo, t.valor) for t in tokens] == [
+        (TipoToken.VAR, 'var'),
+        (TipoToken.IDENTIFICADOR, 'ma\u00f1ana'),
+        (TipoToken.ASIGNAR, '='),
+        (TipoToken.ENTERO, 1),
+        (TipoToken.VAR, 'var'),
+        (TipoToken.IDENTIFICADOR, 'se\u00f1al'),
+        (TipoToken.ASIGNAR, '='),
+        (TipoToken.ENTERO, 2),
+        (TipoToken.VAR, 'var'),
+        (TipoToken.IDENTIFICADOR, '\u03bbambda'),
+        (TipoToken.ASIGNAR, '='),
+        (TipoToken.ENTERO, 3),
+        (TipoToken.VAR, 'var'),
+        (TipoToken.IDENTIFICADOR, '\u00e1rbol'),
+        (TipoToken.ASIGNAR, '='),
+        (TipoToken.ENTERO, 4),
+        (TipoToken.EOF, None),
+    ]


### PR DESCRIPTION
## Summary
- add tests for extra Unicode identifiers

## Testing
- `PYTHONPATH=backend/src pytest -q tests/unit/test_unicode_identifiers.py tests/unit/test_unicode_identifiers_extra.py`

------
https://chatgpt.com/codex/tasks/task_e_68675ae3d5048327a953f116738eb21b