### PR TITLE
Fix encoding in CLI commands

### DIFF
--- a/backend/src/cli/commands/agix_cmd.py
+++ b/backend/src/cli/commands/agix_cmd.py
@@ -24,7 +24,7 @@ class AgixCommand(BaseCommand):
         if not os.path.exists(archivo):
             mostrar_error(f"El archivo '{archivo}' no existe")
             return 1
-        with open(archivo, "r") as f:
+        with open(archivo, "r", encoding="utf-8") as f:
             codigo = f.read()
         sugerencias = generar_sugerencias(codigo)
         for s in sugerencias:

--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -143,7 +143,7 @@ class CompileCommand(BaseCommand):
             mostrar_error(f"Error de dependencias: {dep_err}")
             return 1
 
-        with open(archivo, "r") as f:
+        with open(archivo, "r", encoding="utf-8") as f:
             codigo = f.read()
         try:
             ast = obtener_ast(codigo)

--- a/backend/src/cli/commands/dependencias_cmd.py
+++ b/backend/src/cli/commands/dependencias_cmd.py
@@ -42,7 +42,7 @@ class DependenciasCommand(BaseCommand):
         if not os.path.exists(archivo):
             mostrar_error(_("No se encontró requirements.txt"))
             return 1
-        with open(archivo, "r") as f:
+        with open(archivo, "r", encoding="utf-8") as f:
             deps = [l.strip() for l in f if l.strip() and not l.startswith("#")]
         if not deps:
             mostrar_info(_("No hay dependencias listadas"))

--- a/backend/src/cli/commands/execute_cmd.py
+++ b/backend/src/cli/commands/execute_cmd.py
@@ -52,7 +52,7 @@ class ExecuteCommand(BaseCommand):
         else:
             logging.getLogger().setLevel(logging.ERROR)
 
-        with open(archivo, "r") as f:
+        with open(archivo, "r", encoding="utf-8") as f:
             codigo = f.read()
 
         if sandbox:

--- a/backend/src/cli/commands/profile_cmd.py
+++ b/backend/src/cli/commands/profile_cmd.py
@@ -66,7 +66,7 @@ class ProfileCommand(BaseCommand):
         else:
             logging.getLogger().setLevel(logging.ERROR)
 
-        with open(archivo, "r") as f:
+        with open(archivo, "r", encoding="utf-8") as f:
             codigo = f.read()
 
         tokens = Lexer(codigo).tokenizar()


### PR DESCRIPTION
## Summary
- add utf-8 encoding when reading files in CLI commands
- update compile, agix, dependencias, execute and profile commands

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68675d9666e08327a5c042055895f751