### PR TITLE
Add unicode comments test

### DIFF
--- a/tests/unit/test_unicode_comments.py
+++ b/tests/unit/test_unicode_comments.py
@@ -1,0 +1,24 @@
+from src.cobra.lexico.lexer import Lexer, TipoToken
+
+
+def test_unicode_comments_removed():
+    codigo = """
+    # пример
+    var x = 1
+    // مثال
+    imprimir(x)
+    /* مثال */
+    """
+    tokens = Lexer(codigo).analizar_token()
+
+    assert [(t.tipo, t.valor) for t in tokens] == [
+        (TipoToken.VAR, "var"),
+        (TipoToken.IDENTIFICADOR, "x"),
+        (TipoToken.ASIGNAR, "="),
+        (TipoToken.ENTERO, 1),
+        (TipoToken.IMPRIMIR, "imprimir"),
+        (TipoToken.LPAREN, "("),
+        (TipoToken.IDENTIFICADOR, "x"),
+        (TipoToken.RPAREN, ")"),
+        (TipoToken.EOF, None),
+    ]


### PR DESCRIPTION
## Summary
- add unit test covering unicode comments in lexer

## Testing
- `PYTHONPATH=backend pytest tests/unit/test_unicode_comments.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68676da94a88832787ec79242e140ffb