### PR TITLE
Soporte unicode en eliminación de comentarios

### DIFF
--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -134,9 +134,24 @@ class Lexer:
 
     def tokenizar(self):
         # Elimina comentarios de una línea y bloques de comentarios
-        codigo_sin_bloques = re.sub(r'/\*.*?\*/', '', self.codigo_fuente, flags=re.DOTALL)
-        codigo_sin_doble = re.sub(r'//.*?$', '', codigo_sin_bloques, flags=re.MULTILINE)
-        codigo_limpio = re.sub(r'#.*?$', '', codigo_sin_doble, flags=re.MULTILINE)
+        codigo_sin_bloques = re.sub(
+            r'/\*.*?\*/',
+            '',
+            self.codigo_fuente,
+            flags=re.DOTALL | re.UNICODE,
+        )
+        codigo_sin_doble = re.sub(
+            r'//.*?$',
+            '',
+            codigo_sin_bloques,
+            flags=re.MULTILINE | re.UNICODE,
+        )
+        codigo_limpio = re.sub(
+            r'#.*?$',
+            '',
+            codigo_sin_doble,
+            flags=re.MULTILINE | re.UNICODE,
+        )
 
         self.codigo_fuente = codigo_limpio
         self.posicion = 0


### PR DESCRIPTION
## Summary
- maneja comentarios con `re.UNICODE` en el lexer
- ejecuta pruebas de lexer con comentarios

## Testing
- `PYTHONPATH=backend/src pytest tests/unit/test_lexer.py::test_lexer_con_comentarios -q`
- `PYTHONPATH=backend/src pytest tests/unit/test_lexer2.py::test_lexer_comentarios_ignorados -q`


------
https://chatgpt.com/codex/tasks/task_e_68677131ce2c83279ffbb145af811e16