### PR TITLE
Añadir parser opcional con Lark

### DIFF
--- a/backend/src/cobra/parser/lark_parser.py
+++ b/backend/src/cobra/parser/lark_parser.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from lark import Lark
+from src.cobra.lexico.lexer import Token, TipoToken
+
+
+class LarkParser:
+    """Parser basado en Lark que carga la gramática EBNF."""
+
+    def __init__(self, tokens: List[Token]):
+        grammar_path = Path(__file__).resolve().parents[3] / "docs" / "gramatica.ebnf"
+        with open(grammar_path, "r", encoding="utf-8") as f:
+            grammar = f.read()
+        self._lark = Lark(grammar, start="start")
+        self.tokens = tokens
+
+    def _tokens_to_source(self) -> str:
+        parts = []
+        for t in self.tokens:
+            if t.tipo == TipoToken.CADENA:
+                parts.append(f'"{t.valor}"')
+            elif t.tipo == TipoToken.EOF:
+                continue
+            else:
+                parts.append(str(t.valor))
+        return " ".join(parts)
+
+    def parsear(self):
+        source = self._tokens_to_source()
+        return self._lark.parse(source)

--- a/backend/src/cobra/parser/parser.py
+++ b/backend/src/cobra/parser/parser.py
@@ -44,7 +44,7 @@ from src.core.ast_nodes import (
     NodoCase,
 )
 
-from backend.src.core import NodoYield
+from src.core import NodoYield
 
 # Palabras reservadas que no pueden usarse como identificadores
 PALABRAS_RESERVADAS = {
@@ -103,7 +103,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 
-class Parser:
+class ClassicParser:
     """Convierte una lista de tokens en nodos del AST."""
 
     def __init__(self, tokens):
@@ -772,7 +772,7 @@ class Parser:
             cuerpo_tokens.append(token)
             self.avanzar()
         self.comer(TipoToken.RBRACE)
-        cuerpo_parser = Parser(cuerpo_tokens + [Token(TipoToken.EOF, None)])
+        cuerpo_parser = ClassicParser(cuerpo_tokens + [Token(TipoToken.EOF, None)])
         cuerpo = cuerpo_parser.parsear()
         return NodoMacro(nombre, cuerpo)
 
@@ -1012,3 +1012,13 @@ class Parser:
     def ast_to_json(self, nodo):
         """Exporta el AST a un formato JSON para depuración o visualización."""
         return json.dumps(nodo, default=lambda o: o.__dict__, indent=4)
+
+
+# Permitir seleccionar un parser alternativo basado en Lark mediante la variable
+# de entorno ``COBRA_PARSER``. Si su valor es ``"lark"`` se cargará
+# ``LarkParser`` en lugar del parser clásico.
+import os
+if os.getenv("COBRA_PARSER") == "lark":
+    from .lark_parser import LarkParser as Parser
+else:
+    Parser = ClassicParser

--- a/docs/gramatica.ebnf
+++ b/docs/gramatica.ebnf
@@ -1,0 +1,54 @@
+?start: statement*
+
+?statement: asignacion
+          | funcion
+          | clase
+          | bucle_mientras
+          | bucle_para
+          | condicional
+          | importacion
+          | usar
+          | macro
+          | impresion
+          | retorno
+          | hilo
+          | llamada
+          | switch
+          | try_catch
+          | expr
+
+asignacion: ("var"|"variable")? IDENTIFICADOR "=" expr
+funcion: "func" IDENTIFICADOR "(" parametros? ")" ":" cuerpo "fin"
+clase: "clase" IDENTIFICADOR ":" cuerpo "fin"
+bucle_mientras: "mientras" expr ":" cuerpo "fin"
+bucle_para: "para" IDENTIFICADOR "in" expr ":" cuerpo "fin"
+condicional: "si" expr ":" cuerpo ("sino" ":" cuerpo)? "fin"
+importacion: "import" CADENA
+usar: "usar" CADENA
+macro: "macro" IDENTIFICADOR "{" statement* "}"
+impresion: "imprimir" "(" argumentos? ")"
+retorno: "retorno" expr
+hilo: "hilo" llamada
+switch: "switch" expr ":" case+ "fin"
+case: ("case" expr ":" cuerpo)+
+try_catch: ("try"|"intentar") ":" cuerpo ("catch"|"capturar") IDENTIFICADOR ":" cuerpo "fin"
+llamada: IDENTIFICADOR "(" argumentos? ")"
+cuerpo: statement*
+parametros: IDENTIFICADOR ("," IDENTIFICADOR)*
+argumentos: expr ("," expr)*
+?expr: valor (operador valor)*
+?valor: CADENA
+      | ENTERO
+      | FLOTANTE
+      | IDENTIFICADOR
+      | llamada
+      | holobit
+holobit: "holobit" "(" "[" [expr ("," expr)*] "]" ")"
+operador: "+"|"-"|"*"|"/"|">="|"<="|">"|"<"|"=="|"!="|"&&"|"||"
+
+CADENA: /"[^"\n]*"|'[^'\n]*'/
+ENTERO: /[0-9]+/
+FLOTANTE: /[0-9]+\.[0-9]+/
+IDENTIFICADOR: /[^\W\d_][\w]*/
+
+%ignore /\s+/

--- a/frontend/docs/sintaxis.rst
+++ b/frontend/docs/sintaxis.rst
@@ -104,3 +104,16 @@ Puedes anteponer `@` a una función para modificar su comportamiento con un deco
 - Los bucles `mientras` y `para` se convierten en `while` y `for` en los lenguajes de alto nivel, mientras que en ensamblador generan instrucciones `WHILE` y `FOR`.
 - La construcción `holobit` se traduce a `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust y `holobit({...})` en C++, mientras que en Ruby utiliza `Holobit.new([...])` y en PHP `new Holobit([...])`.
 
+Activar el parser de Lark
+-------------------------
+
+Si deseas utilizar el parser alternativo implementado con ``Lark`` establece la variable
+de entorno ``COBRA_PARSER`` a ``lark`` antes de ejecutar Cobra:
+
+.. code-block:: bash
+
+   export COBRA_PARSER=lark
+   cobra ejecutar programa.co
+
+Si no defines esta variable se seguirá empleando el parser tradicional.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ pybind11==2.13.6
 python-lsp-server==1.11.0
 packaging==24.0
 snakeviz==2.2.2
+lark==1.1.9


### PR DESCRIPTION
## Summary
- document EBNF grammar in `docs/gramatica.ebnf`
- implement `LarkParser` loader
- allow selecting parser via `COBRA_PARSER` environment variable
- document activation instructions
- add `lark` dependency

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q` *(fails: ModuleNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6867a2188c1c8327b205fda582b033c5