### PR TITLE
Add shared semantics helpers for transpilers

### DIFF
--- a/backend/src/cobra/transpilers/semantica.py
+++ b/backend/src/cobra/transpilers/semantica.py
@@ -1,0 +1,51 @@
+from backend.src.core.ast_nodes import NodoAtributo
+
+
+def datos_asignacion(transpilador, nodo):
+    """Obtiene el nombre y el valor de una asignación.
+
+    Devuelve una tupla ``(nombre, valor, es_atributo)`` donde ``nombre`` y
+    ``valor`` ya están procesados mediante ``transpilador.obtener_valor``.
+    ``es_atributo`` indica si el identificador era un atributo del AST.
+    """
+    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
+    valor_nodo = getattr(nodo, "expresion", getattr(nodo, "valor", None))
+    es_atributo = isinstance(nombre_raw, NodoAtributo)
+    if es_atributo:
+        nombre = transpilador.obtener_valor(nombre_raw)
+    else:
+        nombre = nombre_raw
+    valor = transpilador.obtener_valor(valor_nodo)
+    return nombre, valor, es_atributo
+
+
+def _inc_indent(transpilador):
+    if hasattr(transpilador, "usa_indentacion"):
+        if transpilador.usa_indentacion:
+            transpilador.indentacion += 1
+    elif hasattr(transpilador, "indentacion"):
+        transpilador.indentacion += 1
+    elif hasattr(transpilador, "indent"):
+        transpilador.indent += 1
+    elif hasattr(transpilador, "nivel_indentacion"):
+        transpilador.nivel_indentacion += 1
+
+
+def _dec_indent(transpilador):
+    if hasattr(transpilador, "usa_indentacion"):
+        if transpilador.usa_indentacion:
+            transpilador.indentacion -= 1
+    elif hasattr(transpilador, "indentacion"):
+        transpilador.indentacion -= 1
+    elif hasattr(transpilador, "indent"):
+        transpilador.indent -= 1
+    elif hasattr(transpilador, "nivel_indentacion"):
+        transpilador.nivel_indentacion -= 1
+
+
+def procesar_bloque(transpilador, cuerpo):
+    """Ejecuta el cuerpo de un bloque aumentando la indentación de forma genérica."""
+    _inc_indent(transpilador)
+    for instruccion in cuerpo:
+        instruccion.aceptar(transpilador)
+    _dec_indent(transpilador)

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/asignacion.py
@@ -1,10 +1,5 @@
-from backend.src.core.ast_nodes import NodoAtributo
+from ...semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
-    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
-    if isinstance(nombre_raw, NodoAtributo):
-        nombre = self.obtener_valor(nombre_raw)
-    else:
-        nombre = nombre_raw
-    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
-    self.agregar_linea(f"SET {nombre}, {self.obtener_valor(valor)}")
+    nombre, valor, _ = datos_asignacion(self, nodo)
+    self.agregar_linea(f"SET {nombre}, {valor}")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/bucle_mientras.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/bucle_mientras.py
@@ -1,8 +1,7 @@
+from ...semantica import procesar_bloque
+
 def visit_bucle_mientras(self, nodo):
     condicion = self.obtener_valor(nodo.condicion)
     self.agregar_linea(f"WHILE {condicion}")
-    self.indent += 1
-    for ins in nodo.cuerpo:
-        ins.aceptar(self)
-    self.indent -= 1
+    procesar_bloque(self, nodo.cuerpo)
     self.agregar_linea("END")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/for_.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/for_.py
@@ -1,8 +1,7 @@
+from ...semantica import procesar_bloque
+
 def visit_for(self, nodo):
     iterable = self.obtener_valor(nodo.iterable)
     self.agregar_linea(f"FOR {nodo.variable} IN {iterable}")
-    self.indent += 1
-    for ins in nodo.cuerpo:
-        ins.aceptar(self)
-    self.indent -= 1
+    procesar_bloque(self, nodo.cuerpo)
     self.agregar_linea("END")

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/para.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/para.py
@@ -1,8 +1,7 @@
+from ...semantica import procesar_bloque
+
 def visit_para(self, nodo):
     iterable = self.obtener_valor(nodo.iterable)
     self.agregar_linea(f"PARA {nodo.variable} EN {iterable}")
-    self.indent += 1
-    for ins in nodo.cuerpo:
-        ins.aceptar(self)
-    self.indent -= 1
+    procesar_bloque(self, nodo.cuerpo)
     self.agregar_linea("FINPARA")

--- a/backend/src/cobra/transpilers/transpiler/cobol_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/cobol_nodes/asignacion.py
@@ -1,10 +1,5 @@
-from backend.src.core.ast_nodes import NodoAtributo
+from ...semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
-    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
-    if isinstance(nombre_raw, NodoAtributo):
-        nombre = self.obtener_valor(nombre_raw)
-    else:
-        nombre = nombre_raw
-    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
-    self.agregar_linea(f"MOVE {self.obtener_valor(valor)} TO {nombre}")
+    nombre, valor, _ = datos_asignacion(self, nodo)
+    self.agregar_linea(f"MOVE {valor} TO {nombre}")

--- a/backend/src/cobra/transpilers/transpiler/cpp_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/cpp_nodes/asignacion.py
@@ -1,11 +1,8 @@
-from backend.src.core.ast_nodes import NodoAtributo
+from ...semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
-    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
-    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
-    if isinstance(nombre_raw, NodoAtributo):
-        nombre = self.obtener_valor(nombre_raw)
-        self.agregar_linea(f"{nombre} = {self.obtener_valor(valor)};")
+    nombre, valor, es_attr = datos_asignacion(self, nodo)
+    if es_attr:
+        self.agregar_linea(f"{nombre} = {valor};")
     else:
-        nombre = nombre_raw
-        self.agregar_linea(f"auto {nombre} = {self.obtener_valor(valor)};")
+        self.agregar_linea(f"auto {nombre} = {valor};")

--- a/backend/src/cobra/transpilers/transpiler/cpp_nodes/bucle_mientras.py
+++ b/backend/src/cobra/transpilers/transpiler/cpp_nodes/bucle_mientras.py
@@ -1,9 +1,8 @@
+from ...semantica import procesar_bloque
+
 def visit_bucle_mientras(self, nodo):
     cuerpo = nodo.cuerpo
     condicion = self.obtener_valor(nodo.condicion)
     self.agregar_linea(f"while ({condicion}) {{")
-    self.indent += 1
-    for instr in cuerpo:
-        instr.aceptar(self)
-    self.indent -= 1
+    procesar_bloque(self, cuerpo)
     self.agregar_linea("}")

--- a/backend/src/cobra/transpilers/transpiler/fortran_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/fortran_nodes/asignacion.py
@@ -1,10 +1,5 @@
-from backend.src.core.ast_nodes import NodoAtributo
+from ...semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
-    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
-    if isinstance(nombre_raw, NodoAtributo):
-        nombre = self.obtener_valor(nombre_raw)
-    else:
-        nombre = nombre_raw
-    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
-    self.agregar_linea(f"{nombre} = {self.obtener_valor(valor)}")
+    nombre, valor, _ = datos_asignacion(self, nodo)
+    self.agregar_linea(f"{nombre} = {valor}")

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/asignacion.py
@@ -1,19 +1,12 @@
-from backend.src.core.ast_nodes import NodoAtributo
+from ...semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     """Transpila una asignación en JavaScript."""
     if self.usa_indentacion is None:
         self.usa_indentacion = hasattr(nodo, "variable") or hasattr(nodo, "identificador")
-    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
-    if isinstance(nombre_raw, NodoAtributo):
-        nombre = self.obtener_valor(nombre_raw)
+    nombre, valor, es_attr = datos_asignacion(self, nodo)
+    if es_attr:
         prefijo = ""
     else:
-        nombre = nombre_raw
-        if hasattr(nodo, "variable") and not getattr(nodo, "inferencia", False):
-            prefijo = "let "
-        else:
-            prefijo = ""
-    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
-    valor = self.obtener_valor(valor)
+        prefijo = "let " if hasattr(nodo, "variable") and not getattr(nodo, "inferencia", False) else ""
     self.agregar_linea(f"{prefijo}{nombre} = {valor};")

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/bucle_mientras.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/bucle_mientras.py
@@ -1,3 +1,5 @@
+from ...semantica import procesar_bloque
+
 def visit_bucle_mientras(self, nodo):
     """Transpila un bucle 'while' en JavaScript, permitiendo anidación."""
     cuerpo = nodo.cuerpo
@@ -5,10 +7,5 @@ def visit_bucle_mientras(self, nodo):
         self.usa_indentacion = any(hasattr(ins, "variable") for ins in cuerpo)
     condicion = self.obtener_valor(nodo.condicion)
     self.agregar_linea(f"while ({condicion}) {{")
-    if self.usa_indentacion:
-        self.indentacion += 1
-    for instruccion in cuerpo:
-        instruccion.aceptar(self)
-    if self.usa_indentacion:
-        self.indentacion -= 1
+    procesar_bloque(self, cuerpo)
     self.agregar_linea("}")

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/for_.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/for_.py
@@ -1,3 +1,5 @@
+from ...semantica import procesar_bloque
+
 def visit_for(self, nodo):
     """Transpila un bucle 'for...of' en JavaScript, permitiendo anidación."""
     cuerpo = nodo.cuerpo
@@ -5,10 +7,5 @@ def visit_for(self, nodo):
         self.usa_indentacion = any(hasattr(ins, "variable") for ins in cuerpo)
     iterable = self.obtener_valor(nodo.iterable)
     self.agregar_linea(f"for (let {nodo.variable} of {iterable}) {{")
-    if self.usa_indentacion:
-        self.indentacion += 1
-    for instruccion in cuerpo:
-        instruccion.aceptar(self)
-    if self.usa_indentacion:
-        self.indentacion -= 1
+    procesar_bloque(self, cuerpo)
     self.agregar_linea("}")

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/para.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/para.py
@@ -1,13 +1,10 @@
+from ...semantica import procesar_bloque
+
 def visit_para(self, nodo):
     cuerpo = nodo.cuerpo
     if self.usa_indentacion is None:
         self.usa_indentacion = any(hasattr(ins, "variable") for ins in cuerpo)
     iterable = self.obtener_valor(nodo.iterable)
     self.agregar_linea(f"for (let {nodo.variable} of {iterable}) {{")
-    if self.usa_indentacion:
-        self.indentacion += 1
-    for instruccion in cuerpo:
-        instruccion.aceptar(self)
-    if self.usa_indentacion:
-        self.indentacion -= 1
+    procesar_bloque(self, cuerpo)
     self.agregar_linea("}")

--- a/backend/src/cobra/transpilers/transpiler/latex_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/latex_nodes/asignacion.py
@@ -1,10 +1,5 @@
-from backend.src.core.ast_nodes import NodoAtributo
+from ...semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
-    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
-    if isinstance(nombre_raw, NodoAtributo):
-        nombre = self.obtener_valor(nombre_raw)
-    else:
-        nombre = nombre_raw
-    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
-    self.agregar_linea(f"{nombre} = {self.obtener_valor(valor)}")
+    nombre, valor, _ = datos_asignacion(self, nodo)
+    self.agregar_linea(f"{nombre} = {valor}")

--- a/backend/src/cobra/transpilers/transpiler/matlab_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/matlab_nodes/asignacion.py
@@ -1,10 +1,5 @@
-from backend.src.core.ast_nodes import NodoAtributo
+from ...semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
-    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
-    if isinstance(nombre_raw, NodoAtributo):
-        nombre = self.obtener_valor(nombre_raw)
-    else:
-        nombre = nombre_raw
-    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
-    self.agregar_linea(f"{nombre} = {self.obtener_valor(valor)};")
+    nombre, valor, _ = datos_asignacion(self, nodo)
+    self.agregar_linea(f"{nombre} = {valor};")

--- a/backend/src/cobra/transpilers/transpiler/pascal_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/pascal_nodes/asignacion.py
@@ -1,10 +1,5 @@
-from backend.src.core.ast_nodes import NodoAtributo
+from ...semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
-    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
-    if isinstance(nombre_raw, NodoAtributo):
-        nombre = self.obtener_valor(nombre_raw)
-    else:
-        nombre = nombre_raw
-    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
-    self.agregar_linea(f"{nombre} := {self.obtener_valor(valor)};")
+    nombre, valor, _ = datos_asignacion(self, nodo)
+    self.agregar_linea(f"{nombre} := {valor};")

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/asignacion.py
@@ -1,13 +1,5 @@
-from backend.src.core.ast_nodes import NodoAtributo
+from ...semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
-    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
-    if isinstance(nombre_raw, NodoAtributo):
-        nombre = self.obtener_valor(nombre_raw)
-    else:
-        nombre = nombre_raw
-    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
-    self.codigo += (
-        f"{self.obtener_indentacion()}{nombre} = "
-        f"{self.obtener_valor(valor)}\n"
-    )
+    nombre, valor, _ = datos_asignacion(self, nodo)
+    self.codigo += f"{self.obtener_indentacion()}{nombre} = {valor}\n"

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/bucle_mientras.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/bucle_mientras.py
@@ -1,7 +1,6 @@
+from ...semantica import procesar_bloque
+
 def visit_bucle_mientras(self, nodo):
     condicion = self.obtener_valor(nodo.condicion)
     self.codigo += f"{self.obtener_indentacion()}while {condicion}:\n"
-    self.nivel_indentacion += 1
-    for instruccion in nodo.cuerpo:
-        instruccion.aceptar(self)
-    self.nivel_indentacion -= 1
+    procesar_bloque(self, nodo.cuerpo)

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/for_.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/for_.py
@@ -1,10 +1,8 @@
+from ...semantica import procesar_bloque
+
 def visit_for(self, nodo):
     iterable = self.obtener_valor(nodo.iterable)
     self.codigo += (
-        f"{self.obtener_indentacion()}for {nodo.variable} in "
-        f"{iterable}:\n"
+        f"{self.obtener_indentacion()}for {nodo.variable} in {iterable}:\n"
     )
-    self.nivel_indentacion += 1
-    for instruccion in nodo.cuerpo:
-        instruccion.aceptar(self)
-    self.nivel_indentacion -= 1
+    procesar_bloque(self, nodo.cuerpo)

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/para.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/para.py
@@ -1,9 +1,8 @@
+from ...semantica import procesar_bloque
+
 def visit_para(self, nodo):
     iterable = self.obtener_valor(nodo.iterable)
     self.codigo += (
         f"{self.obtener_indentacion()}for {nodo.variable} in {iterable}:\n"
     )
-    self.nivel_indentacion += 1
-    for instruccion in nodo.cuerpo:
-        instruccion.aceptar(self)
-    self.nivel_indentacion -= 1
+    procesar_bloque(self, nodo.cuerpo)

--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/asignacion.py
@@ -1,11 +1,8 @@
-from src.core.ast_nodes import NodoAtributo
+from ...semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
-    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
-    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
-    if isinstance(nombre_raw, NodoAtributo):
-        nombre = self.obtener_valor(nombre_raw)
-        self.agregar_linea(f"{nombre} = {self.obtener_valor(valor)};")
+    nombre, valor, es_attr = datos_asignacion(self, nodo)
+    if es_attr:
+        self.agregar_linea(f"{nombre} = {valor};")
     else:
-        nombre = nombre_raw
-        self.agregar_linea(f"let {nombre} = {self.obtener_valor(valor)};")
+        self.agregar_linea(f"let {nombre} = {valor};")

--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/bucle_mientras.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/bucle_mientras.py
@@ -1,9 +1,8 @@
+from ...semantica import procesar_bloque
+
 def visit_bucle_mientras(self, nodo):
     cuerpo = nodo.cuerpo
     condicion = self.obtener_valor(nodo.condicion)
     self.agregar_linea(f"while {condicion} {{")
-    self.indent += 1
-    for instr in cuerpo:
-        instr.aceptar(self)
-    self.indent -= 1
+    procesar_bloque(self, cuerpo)
     self.agregar_linea("}")

--- a/tests/unit/test_semantica_transpiladores.py
+++ b/tests/unit/test_semantica_transpiladores.py
@@ -1,0 +1,28 @@
+from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from src.cobra.transpilers.transpiler.to_c import TranspiladorC
+from src.core.ast_nodes import NodoAsignacion, NodoBucleMientras, NodoValor
+
+
+def test_asignacion_compartida():
+    ast = [NodoAsignacion("x", NodoValor(1))]
+    resultados = [
+        TranspiladorPython().transpilar(ast),
+        TranspiladorJavaScript().transpilar(ast),
+        TranspiladorC().transpilar(ast),
+    ]
+    for codigo in resultados:
+        assert "x" in codigo
+        assert "1" in codigo
+
+
+def test_bucle_mientras_compartido():
+    ast = [NodoBucleMientras("x > 0", [NodoAsignacion("x", NodoValor("x - 1"))])]
+    resultados = [
+        TranspiladorPython().transpilar(ast),
+        TranspiladorJavaScript().transpilar(ast),
+        TranspiladorC().transpilar(ast),
+    ]
+    for codigo in resultados:
+        assert "x" in codigo
+        assert "0" in codigo or "x - 1" in codigo


### PR DESCRIPTION
## Summary
- centralize name/value and indentation helpers under `semantica.py`
- refactor node visitors in each transpiler to reuse these helpers
- add regression tests comparing outputs across languages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6867a6e73c848327967759bb8338e088