### PR TITLE
Add MutPy mutation script

### DIFF
--- a/frontend/docs/benchmarking.rst
+++ b/frontend/docs/benchmarking.rst
@@ -83,3 +83,22 @@ También puedes ejecutar el script manualmente:
    * - rust
      - 0.04
      - 0
+
+Pruebas de mutación
+-------------------
+
+Para evaluar la efectividad de las pruebas se incluye un script que ejecuta
+`MutPy` sobre el código fuente. Primero instala la dependencia opcional:
+
+.. code-block:: bash
+
+   pip install .[mutation]
+
+Luego lanza el análisis:
+
+.. code-block:: bash
+
+   python scripts/run_mutation.py
+
+Se recomienda alcanzar un porcentaje de detección de mutantes de al
+menos 70 %.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dependencies = [
 Documentation = "https://github.com/Alphonsus411/pCobra#readme"
 Source = "https://github.com/Alphonsus411/pCobra"
 
+[project.optional-dependencies]
+mutation = ["mutpy>=0.6.1"]
+
 [tool.setuptools]
 package-dir = {"" = "backend/src"}
 

--- a/scripts/run_mutation.py
+++ b/scripts/run_mutation.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Ejecuta pruebas de mutación con MutPy sobre backend/src."""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+
+def _ensure_py312_compat() -> None:
+    """Define importlib.find_loader para MutPy en Python 3.12."""
+    if not hasattr(importlib, "find_loader"):
+        from importlib.machinery import PathFinder
+
+        def find_loader(name: str, path: list[str] | None = None):
+            spec = PathFinder.find_spec(name, path)
+            return spec.loader if spec else None
+
+        importlib.find_loader = find_loader  # type: ignore[attr-defined]
+
+
+def main() -> None:
+    _ensure_py312_compat()
+    repo = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo))
+    sys.path.insert(0, str(repo / "backend" / "src"))
+    os.environ["PYTHONPATH"] = f"{repo}:{repo / 'backend' / 'src'}"
+
+    args = [
+        "--target",
+        "src",
+        "--unit-test",
+        "tests.unit",
+        "--runner",
+        "pytest",
+        "--percentage",
+        "5",
+        "--path",
+        str(repo / "backend" / "src"),
+    ]
+    sys.argv = ["mut.py"] + args
+    import mutpy.commandline as commandline
+
+    commandline.main(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setup(
         'smooth-criminal',
         # Agrega más requisitos según sea necesario
     ],
+    extras_require={
+        'mutation': ['mutpy>=0.6.1'],
+    },
     tests_require=[
         'pytest-cov',
     ],


### PR DESCRIPTION
## Summary
- include MutPy as optional dependency
- create helper script to run mutation tests
- document how to execute mutation analysis

## Testing
- `pytest -q` *(fails: 55 errors during collection)*
- `python scripts/run_mutation.py` *(fails to import tests)*

------
https://chatgpt.com/codex/tasks/task_e_6867b215642c83279baf6c55197dd254