### PR TITLE
Add container execution option

### DIFF
--- a/frontend/docs/contenedores.rst
+++ b/frontend/docs/contenedores.rst
@@ -9,3 +9,13 @@ Para generar la imagen ejecuta:
    cobra contenedor --tag cobra
 
 Esto ejecuta internamente ``docker build`` y produce una imagen lista para usar.
+
+Ejecutar programas en contenedores
+----------------------------------
+
+Tras construir las imágenes es posible lanzar un script directamente en un
+contenedor temporal usando ``--contenedor``:
+
+.. code-block:: bash
+
+   cobra ejecutar hola.cob --contenedor=python

--- a/tests/integration/test_execute_container.py
+++ b/tests/integration/test_execute_container.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import backend
+from src.cli.cli import main
+from io import StringIO
+from unittest.mock import patch
+
+
+def test_execute_en_contenedor(tmp_path, monkeypatch):
+    script = tmp_path / "prog.cob"
+    script.write_text("imprimir('hola')")
+
+    import backend.src.cobra.transpilers.module_map as module_map
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: {})
+    monkeypatch.setattr(module_map, "_toml_cache", {}, raising=False)
+
+    with patch("src.cli.commands.execute_cmd.ejecutar_en_contenedor", return_value="hola") as mock_run, \
+         patch("sys.stdout", new_callable=StringIO) as out:
+        ret = main(["ejecutar", str(script), "--contenedor=python"])
+
+    assert ret == 0
+    mock_run.assert_called_once_with("imprimir('hola')", "python")
+    assert "hola" in out.getvalue()


### PR DESCRIPTION
## Summary
- add `--contenedor` option to `ejecutar`
- run code inside a temporary container using sandbox
- document usage examples
- add integration test for container execution

## Testing
- `pytest tests/integration/test_execute_container.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ba20840c83279605587f3bfd97ae