### PR TITLE
Add resource limits and AST node check

### DIFF
--- a/backend/src/core/__init__.py
+++ b/backend/src/core/__init__.py
@@ -8,6 +8,7 @@ Esto simplifica el uso de la biblioteca desde otros módulos.
 from .ast_nodes import *
 from .visitor import NodeVisitor
 from .performance import optimizar, perfilar
+from .resource_limits import limitar_memoria_mb, limitar_cpu_segundos
 
 __all__ = [
     "NodoAST",
@@ -50,4 +51,6 @@ __all__ = [
     "NodeVisitor",
     "optimizar",
     "perfilar",
+    "limitar_memoria_mb",
+    "limitar_cpu_segundos",
 ]

--- a/backend/src/core/cobra_config.py
+++ b/backend/src/core/cobra_config.py
@@ -29,3 +29,20 @@ def auditoria_activa(config: dict | None = None) -> bool:
     """Devuelve si la auditor\u00eda debe activarse seg\u00fan la configuraci\u00f3n."""
     cfg = config or cargar_configuracion()
     return cfg.get("auditoria", {}).get("activa", False)
+
+def limite_nodos(config: dict | None = None) -> int:
+    """Devuelve el máximo número de nodos permitido al interpretar."""
+    cfg = config or cargar_configuracion()
+    return int(cfg.get("seguridad", {}).get("limite_nodos", 1000))
+
+
+def limite_memoria_mb(config: dict | None = None) -> int | None:
+    """Cantidad máxima de memoria (en MB) o ``None`` si no se define."""
+    cfg = config or cargar_configuracion()
+    return cfg.get("seguridad", {}).get("limite_memoria_mb")
+
+
+def limite_cpu_segundos(config: dict | None = None) -> int | None:
+    """Tiempo máximo de CPU en segundos o ``None``."""
+    cfg = config or cargar_configuracion()
+    return cfg.get("seguridad", {}).get("limite_cpu_segundos")

--- a/backend/src/core/resource_limits.py
+++ b/backend/src/core/resource_limits.py
@@ -1,0 +1,29 @@
+"""Utilidades para limitar memoria y tiempo de CPU."""
+from __future__ import annotations
+
+
+def limitar_memoria_mb(mb: int) -> None:
+    """Restringe la memoria máxima del proceso actual."""
+    bytes_ = mb * 1024 * 1024
+    try:
+        import resource
+        resource.setrlimit(resource.RLIMIT_AS, (bytes_, bytes_))
+    except Exception:
+        try:
+            import psutil  # type: ignore
+            psutil.Process().rlimit(psutil.RLIMIT_AS, (bytes_, bytes_))
+        except Exception as exc:  # pragma: no cover - fallo improbable
+            raise RuntimeError("No se pudo establecer el límite de memoria") from exc
+
+
+def limitar_cpu_segundos(segundos: int) -> None:
+    """Limita el tiempo de CPU en segundos para este proceso."""
+    try:
+        import resource
+        resource.setrlimit(resource.RLIMIT_CPU, (segundos, segundos))
+    except Exception:
+        try:
+            import psutil  # type: ignore
+            psutil.Process().rlimit(psutil.RLIMIT_CPU, (segundos, segundos))
+        except Exception as exc:  # pragma: no cover
+            raise RuntimeError("No se pudo establecer el límite de CPU") from exc

--- a/cobra.toml
+++ b/cobra.toml
@@ -1,2 +1,7 @@
 [auditoria]
 activa = true
+
+[seguridad]
+limite_nodos = 1000
+limite_memoria_mb = 128
+limite_cpu_segundos = 10

--- a/frontend/docs/modo_seguro.rst
+++ b/frontend/docs/modo_seguro.rst
@@ -59,3 +59,20 @@ variable ``VALIDADORES_EXTRA`` y pasándolo mediante la opción
 
 Para evaluar el impacto de estas comprobaciones en el rendimiento revisa
 :doc:`benchmarking`.
+
+Limitaciones de recursos
+-----------------------
+El modo seguro puede aplicar límites al interpretar un programa. Estos valores se
+definen en ``cobra.toml`` dentro de la sección ``[seguridad]``.
+
+.. code-block:: toml
+
+   [seguridad]
+   limite_nodos = 1000
+   limite_memoria_mb = 128
+   limite_cpu_segundos = 10
+
+Si el árbol de sintaxis supera ``limite_nodos`` el intérprete aborta. Los otros
+parámetros establecen el máximo de memoria en megabytes y el tiempo de CPU en
+segundos usando ``limitar_memoria_mb`` y ``limitar_cpu_segundos`` de
+``src.core.resource_limits``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ python-lsp-server==1.11.0
 packaging==24.0
 snakeviz==2.2.2
 lark==1.1.9
+psutil==7.0.0

--- a/tests/unit/test_ast_limit.py
+++ b/tests/unit/test_ast_limit.py
@@ -1,0 +1,15 @@
+import pytest
+from src.core.interpreter import InterpretadorCobra
+from src.core.ast_nodes import NodoImprimir, NodoValor
+from src.core.cobra_config import _cache
+
+
+def test_limite_nodos(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.toml"
+    cfg.write_text("[seguridad]\nlimite_nodos = 1\n")
+    monkeypatch.setenv("COBRA_CONFIG", str(cfg))
+    _cache.clear()
+    interp = InterpretadorCobra()
+    ast = [NodoImprimir(NodoValor(1)), NodoImprimir(NodoValor(2))]
+    with pytest.raises(RuntimeError):
+        interp.ejecutar_ast(ast)

--- a/tests/unit/test_resource_limits.py
+++ b/tests/unit/test_resource_limits.py
@@ -1,0 +1,18 @@
+import resource
+from src.core.resource_limits import limitar_memoria_mb, limitar_cpu_segundos
+
+
+def test_limitar_memoria():
+    soft, hard = resource.getrlimit(resource.RLIMIT_AS)
+    limitar_memoria_mb(64)
+    new_soft, _ = resource.getrlimit(resource.RLIMIT_AS)
+    assert new_soft == 64 * 1024 * 1024
+    resource.setrlimit(resource.RLIMIT_AS, (soft, hard))
+
+
+def test_limitar_cpu():
+    soft, hard = resource.getrlimit(resource.RLIMIT_CPU)
+    new_val = 1 if soft in (-1, 0) else soft
+    limitar_cpu_segundos(new_val)
+    assert resource.getrlimit(resource.RLIMIT_CPU)[0] == new_val
+    resource.setrlimit(resource.RLIMIT_CPU, (soft, hard))


### PR DESCRIPTION
## Summary
- enforce AST node limit from config when interpreting
- allow CPU and memory limits via `resource` or `psutil`
- expose utilities in `src.core`
- document security options in safe mode docs
- provide unit tests for limits
- update `requirements.txt` with `psutil`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6867bcd5512083278a86d917ee366827