### PR TITLE
Agregar límite de nodos en imports y documentar

### DIFF
--- a/backend/src/core/interpreter.py
+++ b/backend/src/core/interpreter.py
@@ -554,6 +554,10 @@ class InterpretadorCobra:
         lexer = Lexer(codigo)
         tokens = lexer.analizar_token()
         ast = Parser(tokens).parsear()
+        total = self._contar_nodos(ast)
+        max_nodos = limite_nodos()
+        if total > max_nodos:
+            raise RuntimeError(f"El AST excede el límite de {max_nodos} nodos")
         for subnodo in ast:
             self._validar(subnodo)
             resultado = self.ejecutar_nodo(subnodo)

--- a/frontend/docs/modo_seguro.rst
+++ b/frontend/docs/modo_seguro.rst
@@ -76,3 +76,5 @@ Si el árbol de sintaxis supera ``limite_nodos`` el intérprete aborta. Los otro
 parámetros establecen el máximo de memoria en megabytes y el tiempo de CPU en
 segundos usando ``limitar_memoria_mb`` y ``limitar_cpu_segundos`` de
 ``src.core.resource_limits``.
+Esta verificación del número de nodos también se aplica al cargar módulos con
+``import``.


### PR DESCRIPTION
## Summary
- abort interpretation if imported module AST exceeds `limite_nodos`
- clarify doc that the node limit also applies when importing modules

## Testing
- `pytest tests/unit/test_ast_limit.py -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_6867beb545f48327b7345291bcaec675