### PR TITLE
Agregar manual consolidado y enlaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Cobra es un lenguaje de programación diseñado en español, enfocado en la crea
 - [Comunidad](docs/comunidad.md)
 - Licencia
 - [Manual de Cobra](MANUAL_COBRA.md)
+- [Manual de Cobra en formato reStructuredText](docs/MANUAL_COBRA.rst)
 - [Guía básica](docs/guia_basica.md)
 - [Especificación técnica](docs/especificacion_tecnica.md)
 - [Cheatsheet](docs/cheatsheet.tex) – compílalo a PDF con LaTeX
@@ -55,7 +56,7 @@ Luego selecciona el archivo desde la interfaz web de Jupyter.
 ## Descripción del Proyecto
 
 Cobra está diseñado para facilitar la programación en español, permitiendo que los desarrolladores utilicen un lenguaje más accesible. A través de su lexer, parser y transpiladores, Cobra puede analizar, ejecutar y convertir código a otros lenguajes, brindando soporte para variables, funciones, estructuras de control y estructuras de datos como listas, diccionarios y clases.
-Para un tutorial paso a paso consulta [Manual de Cobra](MANUAL_COBRA.md).
+Para un tutorial paso a paso consulta el [Manual de Cobra](docs/MANUAL_COBRA.rst).
 
 ## Instalación
 

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -1,0 +1,112 @@
+Manual de Cobra
+===============
+
+Este documento resume la sintaxis y los elementos fundamentales del lenguaje
+Cobra. Incluye ejemplos de uso idiomático, limitaciones de los backends y
+recomendaciones de estilo.
+
+.. contents:: Índice
+   :depth: 2
+
+Preparación del entorno
+----------------------
+
+1. Clona el repositorio y entra en ``pCobra``.
+2. Crea y activa un entorno virtual.
+3. Instala las dependencias con ``pip install -r requirements.txt``.
+4. Instala Cobra en modo editable con ``pip install -e .``.
+
+Sintaxis básica
+---------------
+
+* Declaración de variables con ``var``:
+
+  .. code-block:: cobra
+
+     var mensaje = "Hola"
+
+* Funciones con ``func`` y finalización opcional con ``fin``:
+
+  .. code-block:: cobra
+
+     func sumar(a, b):
+         return a + b
+     fin
+
+* Condicionales ``si``/``sino`` y bucles ``mientras``/``para``:
+
+  .. code-block:: cobra
+
+     si x > 0:
+         imprimir(x)
+     sino:
+         imprimir(0)
+
+Tipos y estructuras de datos
+----------------------------
+
+Cobra soporta números, cadenas, listas, diccionarios y conjuntos. Las clases se
+crean con ``clase`` y se instancian como en Python.
+
+.. code-block:: cobra
+
+   clase Persona:
+       func __init__(self, nombre):
+           self.nombre = nombre
+       fin
+
+   var p = Persona("Ada")
+   imprimir(p.nombre)
+
+Módulos y paquetes
+------------------
+
+Los módulos se importan con ``import``. Para agrupar varios módulos puede
+crearse un archivo ``cobra.pkg`` y usar ``cobra paquete crear`` para
+empaquetarlos.
+
+Macros y concurrencia
+---------------------
+
+La directiva ``macro`` permite insertar código reutilizable. Para lanzar tareas
+en paralelo se utiliza ``hilo``.
+
+.. code-block:: cobra
+
+   macro saluda { imprimir("hola") }
+   hilo saluda()
+
+Transpilación y ejecución
+-------------------------
+
+El comando ``cobra compilar`` genera código para múltiples lenguajes. También
+puede ejecutarse un archivo directamente con ``cobra ejecutar``.
+
+Limitaciones de los backends
+----------------------------
+
+* **Python y JavaScript**: implementan la mayoría de características y son los
+  más estables.
+* **C y C++**: se consideran experimentales; no soportan clases ni excepciones
+  complejas.
+* **Rust**: carece de herencia múltiple y requiere anotaciones de tipo
+  explícitas para estructuras complejas.
+* **WebAssembly**: limitado a operaciones numéricas básicas y sin soporte de
+  cadenas.
+* **Otros backends** (Go, R, Julia, etc.): poseen cobertura parcial y pueden
+  carecer de bibliotecas estándar equivalentes.
+
+Recomendaciones de estilo
+-------------------------
+
+* Utiliza indentación de cuatro espacios y nombres en ``snake_case``.
+* Mantén los comentarios en español y procura líneas de menos de 79 caracteres.
+* Prefiere expresiones claras antes que construcciones complejas y evita macros
+  innecesarias.
+
+Recursos adicionales
+--------------------
+
+- :doc:`guia_basica <guia_basica>`
+- :doc:`especificacion_tecnica <especificacion_tecnica>`
+- :doc:`recursos_adicionales <../frontend/docs/recursos_adicionales>`

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -43,6 +43,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    qualia
    jupyter
    recursos_adicionales
+   ../../docs/MANUAL_COBRA
    api/modules
 
 Introducción


### PR DESCRIPTION
## Summary
- crear `docs/MANUAL_COBRA.rst` con sintaxis, tipos, ejemplos y limitaciones de backends
- enlazar el nuevo manual desde `README.md` y `frontend/docs/index.rst`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6867c3f4653483278334d76818c7b069