### PR TITLE
Soporte para transpiladores externos en CLI

### DIFF
--- a/examples/plugins/demo_transpiler.py
+++ b/examples/plugins/demo_transpiler.py
@@ -1,8 +1,0 @@
-from typing import List
-
-
-class DemoTranspiler:
-    """Transpilador de ejemplo que genera codigo ficticio."""
-
-    def transpilar(self, ast: List[object]) -> str:
-        return "# codigo generado por DemoTranspiler"

--- a/examples/plugins/demo_transpiler.py
+++ b/examples/plugins/demo_transpiler.py
@@ -1,0 +1,8 @@
+from typing import List
+
+
+class DemoTranspiler:
+    """Transpilador de ejemplo que genera codigo ficticio."""
+
+    def transpilar(self, ast: List[object]) -> str:
+        return "# codigo generado por DemoTranspiler"

--- a/examples/plugins/setup.py
+++ b/examples/plugins/setup.py
@@ -1,13 +1,16 @@
 from setuptools import setup
 
 setup(
-    name='ejemplo-plugin-cobra',
-    version='1.0',
-    py_modules=['saludo_plugin', 'md2cobra_plugin'],
+    name="ejemplo-plugin-cobra",
+    version="1.0",
+    py_modules=["saludo_plugin", "md2cobra_plugin", "demo_transpiler"],
     entry_points={
-        'cobra.plugins': [
-            'saludo = saludo_plugin:SaludoCommand',
-            'md2cobra = md2cobra_plugin:MarkdownToCobraCommand',
+        "cobra.plugins": [
+            "saludo = saludo_plugin:SaludoCommand",
+            "md2cobra = md2cobra_plugin:MarkdownToCobraCommand",
+        ],
+        "cobra.transpilers": [
+            "demo = demo_transpiler:DemoTranspiler",
         ],
     },
 )

--- a/examples/plugins/setup.py
+++ b/examples/plugins/setup.py
@@ -1,16 +1,16 @@
 from setuptools import setup
 
 setup(
-    name="ejemplo-plugin-cobra",
-    version="1.0",
-    py_modules=["saludo_plugin", "md2cobra_plugin", "demo_transpiler"],
+    name='ejemplo-plugin-cobra',
+    version='1.0',
+    py_modules=['saludo_plugin', 'md2cobra_plugin', 'transpiler_demo'],
     entry_points={
-        "cobra.plugins": [
-            "saludo = saludo_plugin:SaludoCommand",
-            "md2cobra = md2cobra_plugin:MarkdownToCobraCommand",
+        'cobra.plugins': [
+            'saludo = saludo_plugin:SaludoCommand',
+            'md2cobra = md2cobra_plugin:MarkdownToCobraCommand',
         ],
-        "cobra.transpilers": [
-            "demo = demo_transpiler:DemoTranspiler",
+        'cobra.transpilers': [
+            'demo = transpiler_demo:TranspiladorDemo',
         ],
     },
 )

--- a/examples/plugins/transpiler_demo.py
+++ b/examples/plugins/transpiler_demo.py
@@ -1,0 +1,7 @@
+"""Transpilador de ejemplo para Cobra."""
+
+class TranspiladorDemo:
+    """Transpilador muy simple que genera un mensaje fijo."""
+
+    def transpilar(self, nodos):
+        return "# Código generado por TranspiladorDemo"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,6 @@ cobra = "src.cli.cli:main"
 
 [project.entry-points."cobra.plugins"]
 # Se registrarán plugins externos aquí
+
+[project.entry-points."cobra.transpilers"]
+# Se registrarán transpiladores externos aquí


### PR DESCRIPTION
## Summary
- detectar transpiladores adicionales mediante `entry_points`
- incluir grupo `cobra.transpilers` en `pyproject.toml`
- ejemplo de plugin con un transpilador de prueba

## Testing
- `make lint` *(falla: E501 y otros errores)*
- `make typecheck` *(falla: 171 errores de mypy)*
- `pytest -q` *(falla: 57 errores durante collection)*

------
https://chatgpt.com/codex/tasks/task_e_6867c87ad550832794a75f4d334ce354