### PR TITLE
Add support for external transpilers

### DIFF
--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -1,6 +1,8 @@
 import logging
 import os
 import multiprocessing
+from importlib import import_module
+from importlib.metadata import entry_points
 from .base import BaseCommand
 from ..i18n import _
 from ..utils.messages import mostrar_error, mostrar_info
@@ -49,6 +51,22 @@ TRANSPILERS = {
     "wasm": TranspiladorWasm,
 }
 
+# Detectar transpiladores externos registrados via entry points
+try:
+    eps = entry_points(group="cobra.transpilers")
+except TypeError:  # Compatibilidad con versiones antiguas
+    eps = entry_points().get("cobra.transpilers", [])
+
+for ep in eps:
+    try:
+        module_name, class_name = ep.value.split(":", 1)
+        cls = getattr(import_module(module_name), class_name)
+        TRANSPILERS[ep.name] = cls
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.error("Error cargando transpilador %s: %s", ep.name, exc)
+
+LANG_CHOICES = sorted(TRANSPILERS.keys())
+
 
 class CompileCommand(BaseCommand):
     """Transpila un archivo Cobra a distintos lenguajes.
@@ -64,51 +82,13 @@ class CompileCommand(BaseCommand):
         parser.add_argument("archivo")
         parser.add_argument(
             "--tipo",
-            choices=[
-                "python",
-                "js",
-                "asm",
-                "rust",
-                "cpp",
-                "c",
-                "go",
-                "ruby",
-                "r",
-                "julia",
-                "java",
-                "cobol",
-                "fortran",
-                "pascal",
-                "php",
-                "matlab",
-                "latex",
-                "wasm",
-            ],
+            choices=LANG_CHOICES,
             default="python",
             help=_("Tipo de código generado"),
         )
         parser.add_argument(
             "--backend",
-            choices=[
-                "python",
-                "js",
-                "asm",
-                "rust",
-                "cpp",
-                "c",
-                "go",
-                "ruby",
-                "r",
-                "julia",
-                "java",
-                "cobol",
-                "fortran",
-                "pascal",
-                "php",
-                "matlab",
-                "latex",
-                "wasm",
-            ],
+            choices=LANG_CHOICES,
             help=_("Alias de --tipo"),
         )
         parser.add_argument(

--- a/examples/plugins/setup.py
+++ b/examples/plugins/setup.py
@@ -3,11 +3,14 @@ from setuptools import setup
 setup(
     name='ejemplo-plugin-cobra',
     version='1.0',
-    py_modules=['saludo_plugin', 'md2cobra_plugin'],
+    py_modules=['saludo_plugin', 'md2cobra_plugin', 'transpiler_demo'],
     entry_points={
         'cobra.plugins': [
             'saludo = saludo_plugin:SaludoCommand',
             'md2cobra = md2cobra_plugin:MarkdownToCobraCommand',
+        ],
+        'cobra.transpilers': [
+            'demo = transpiler_demo:TranspiladorDemo',
         ],
     },
 )

--- a/examples/plugins/transpiler_demo.py
+++ b/examples/plugins/transpiler_demo.py
@@ -1,0 +1,7 @@
+"""Transpilador de ejemplo para Cobra."""
+
+class TranspiladorDemo:
+    """Transpilador muy simple que genera un mensaje fijo."""
+
+    def transpilar(self, nodos):
+        return "# Código generado por TranspiladorDemo"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,6 @@ cobra = "src.cli.cli:main"
 
 [project.entry-points."cobra.plugins"]
 # Se registrarán plugins externos aquí
+
+[project.entry-points."cobra.transpilers"]
+# Se registrarán transpiladores externos aquí


### PR DESCRIPTION
## Summary
- define the `cobra.transpilers` entry-point group
- auto-discover external transpilers in `compile_cmd.py`
- use discovered names as CLI choices
- example plugin registering a dummy transpiler

## Testing
- `python -m py_compile backend/src/cli/commands/compile_cmd.py examples/plugins/transpiler_demo.py examples/plugins/setup.py`
- `pytest -q` *(fails: 57 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6867c87a8c6c8327b9cd24d2cc395cb1