### PR TITLE
Add tomli dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ pip install -r requirements.txt
    - `PyYAML` utilizado al leer `cobra.mod`.
    - `cbindgen` para generar encabezados de crates Rust
      (instalable con `cargo install cbindgen`).
+   - `tomli` necesario para Python anterior a la versión 3.11.
 
 5. Instala el paquete de forma editable para usar la CLI:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "agix==0.8.3",
     "holobit-sdk",
     "smooth-criminal",
+    "tomli",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ packaging==24.0
 snakeviz==2.2.2
 lark==1.1.9
 psutil==7.0.0
+tomli>=2.0


### PR DESCRIPTION
## Summary
- add `tomli>=2.0` to requirements
- include `tomli` in project dependencies
- document `tomli` for Python < 3.11

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867deb93b488327b595e174d7865bf9