### PR TITLE
Refactor ejecutar without shell

### DIFF
--- a/backend/corelibs/sistema.py
+++ b/backend/corelibs/sistema.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import shlex
 import subprocess
 
 
@@ -12,9 +13,9 @@ def obtener_os() -> str:
 
 def ejecutar(comando: str) -> str:
     """Ejecuta un comando y devuelve su salida."""
+    args = shlex.split(comando)
     resultado = subprocess.run(
-        comando,
-        shell=True,
+        args,
         check=True,
         text=True,
         stdout=subprocess.PIPE,

--- a/backend/src/core/nativos/sistema.js
+++ b/backend/src/core/nativos/sistema.js
@@ -7,7 +7,12 @@ export function obtener_os() {
 }
 
 export function ejecutar(cmd) {
-    return child_process.execSync(cmd, { encoding: 'utf-8' });
+    const args = cmd.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
+    const program = args.shift();
+    const proc = child_process.spawnSync(program, args, { encoding: 'utf-8' });
+    if (proc.error) throw proc.error;
+    if (proc.status !== 0) throw new Error(proc.stderr);
+    return proc.stdout;
 }
 
 export function obtener_env(nombre) {

--- a/frontend/docs/modulos_nativos.rst
+++ b/frontend/docs/modulos_nativos.rst
@@ -82,7 +82,8 @@ Seguridad
 Sistema
 -------
 - ``obtener_os()`` retorna el sistema operativo.
-- ``ejecutar(cmd)`` ejecuta un comando en la consola.
+- ``ejecutar(cmd)`` ejecuta un comando en la consola. La cadena se divide
+  en argumentos como en ``shlex.split`` y se ejecuta sin pasar por un shell.
 - ``obtener_env(nombre)`` lee variables de entorno.
 - ``listar_dir(ruta)`` lista los archivos de un directorio.
 


### PR DESCRIPTION
## Summary
- avoid shell=True in backend corelibs `ejecutar`
- use `spawnSync` for JS `ejecutar`
- document new `ejecutar` behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: yaml, tomli, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_6867e53c2b748327a665821b6ba5dd5d