### PR TITLE
Add new dangerous primitives and adjust test coverage

### DIFF
--- a/backend/src/core/semantic_validators/primitiva_peligrosa.py
+++ b/backend/src/core/semantic_validators/primitiva_peligrosa.py
@@ -20,6 +20,8 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
         "existe",
         "eliminar",
         "enviar_post",
+        "ejecutar",
+        "listar_dir",
     }
 
     def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -1,10 +1,11 @@
+import backend  # garantiza rutas para submódulos
 import pytest
 from io import StringIO
 from unittest.mock import patch
 
-from backend.src.cobra.lexico.lexer import Lexer
-from backend.src.cobra.parser.parser import Parser
-from backend.src.core.interpreter import InterpretadorCobra
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from src.core.interpreter import InterpretadorCobra
 from src.core.ast_nodes import NodoLlamadaFuncion, NodoValor
 from src.core.semantic_validators import PrimitivaPeligrosaError
 
@@ -23,6 +24,8 @@ def generar_ast(codigo: str):
         "escribir('x.txt', 'hola')",
         "existe('x.txt')",
         "enviar_post('u', 'd')",
+        "ejecutar('ls')",
+        "listar_dir('.')",
     ],
 )
 def test_primitivas_rechazadas_en_modo_seguro(codigo):


### PR DESCRIPTION
## Summary
- extend `PRIMITIVAS_PELIGROSAS` with `ejecutar` and `listar_dir`
- broaden safe mode tests to include these primitives
- adjust safe mode tests to rely on `src` modules

## Testing
- `PYTHONPATH=.:backend/src pytest tests/unit/test_safe_mode.py::test_primitivas_rechazadas_en_modo_seguro -q`
- `PYTHONPATH=.:backend/src pytest tests/unit/test_safe_mode.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6867eba625c883279793092091a5c9dc