### PR TITLE
Enforce whitelist presence in usar_loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,9 @@ registrado en el entorno bajo el mismo nombre para su uso posterior.
 Para restringir qué dependencias pueden instalarse se emplea la variable
 `USAR_WHITELIST` definida en `backend/src/cobra/usar_loader.py`. Basta con
 añadir o quitar nombres de paquetes en dicho conjunto para modificar la lista
-autorizada.
+autorizada. Si la lista se deja vacía la función `obtener_modulo` lanzará
+`PermissionError`, por lo que es necesario poblarla antes de permitir
+instalaciones dinámicas.
 
 ## Archivo de mapeo de módulos
 

--- a/backend/src/cobra/usar_loader.py
+++ b/backend/src/cobra/usar_loader.py
@@ -12,7 +12,11 @@ def obtener_modulo(nombre: str):
     """Importa y devuelve un módulo. Si no está instalado intenta
     instalarlo usando pip y lo importa nuevamente.
     """
-    if USAR_WHITELIST and nombre not in USAR_WHITELIST:
+    if not USAR_WHITELIST:
+        raise PermissionError(
+            "USAR_WHITELIST vacía: es necesario listar los paquetes permitidos"
+        )
+    if nombre not in USAR_WHITELIST:
         raise PermissionError(f"Paquete '{nombre}' no permitido")
 
     try:

--- a/frontend/docs/modo_seguro.rst
+++ b/frontend/docs/modo_seguro.rst
@@ -14,7 +14,9 @@ También se valida la
 instrucción ``import`` para permitir únicamente los módulos instalados o los
 especificados en ``IMPORT_WHITELIST``. La instrucción ``usar`` está limitada a
 los paquetes listados en ``USAR_WHITELIST`` ubicado en
-``backend/src/cobra/usar_loader.py``.
+``backend/src/cobra/usar_loader.py``. Si esta lista se encuentra vacía, la
+función ``obtener_modulo`` provocará un ``PermissionError`` y no se podrán
+instalar dependencias nuevas.
 
 La cadena comienza con ``ValidadorAuditoria`` que registra mediante
 ``logging.warning`` cada primitiva utilizada. Esta auditoría puede
@@ -51,7 +53,9 @@ Configuraciones avanzadas
 Las listas ``IMPORT_WHITELIST`` y ``USAR_WHITELIST`` determinan qué módulos y
 paquetes pueden cargarse cuando el modo seguro está activo. Puedes editarlas en
 ``backend/src/cobra/import_loader.py`` y ``backend/src/cobra/usar_loader.py``
-respectivamente para afinar las restricciones.
+respectivamente para afinar las restricciones. Recuerda que si
+``USAR_WHITELIST`` está vacía no se permitirá la instalación de paquetes
+adicionales.
 
 También es posible definir validadores adicionales creando un módulo con la
 variable ``VALIDADORES_EXTRA`` y pasándolo mediante la opción

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -3,7 +3,9 @@ from unittest.mock import patch
 import sys
 
 # Evitar dependencias externas durante la importación de los módulos de pruebas
-sys.modules.setdefault('yaml', ModuleType('yaml'))
+fake_yaml = ModuleType('yaml')
+fake_yaml.safe_load = lambda *_args, **_kwargs: {}
+sys.modules.setdefault('yaml', fake_yaml)
 
 import pytest
 
@@ -25,8 +27,10 @@ def test_obtener_modulo_instala_si_no_existe():
 
 
 def test_obtener_modulo_desde_corelibs_sin_pip():
+    usar_loader.USAR_WHITELIST.add('texto')
     with patch.object(usar_loader.subprocess, 'run') as mock_run:
         mod = usar_loader.obtener_modulo('texto')
+    usar_loader.USAR_WHITELIST.remove('texto')
     mock_run.assert_not_called()
     assert mod.mayusculas('hola') == 'HOLA'
 

--- a/tests/unit/test_usar_loader_stdlib.py
+++ b/tests/unit/test_usar_loader_stdlib.py
@@ -12,7 +12,9 @@ import standard_library.fecha as fecha
 
 
 def test_obtener_modulo_standard_library(monkeypatch):
+    usar_loader.USAR_WHITELIST.add("fecha")
     mod = usar_loader.obtener_modulo("fecha")
+    usar_loader.USAR_WHITELIST.remove("fecha")
     assert isinstance(mod, types.ModuleType)
     assert hasattr(mod, "formatear")
     assert mod.formatear(datetime(2020, 1, 1)) == fecha.formatear(datetime(2020, 1, 1))


### PR DESCRIPTION
## Summary
- prevent installing modules when `USAR_WHITELIST` is empty
- adapt `test_usar.py` and `test_usar_loader_stdlib.py` for the stricter checks
- explain whitelist requirement in README and modo_seguro docs

## Testing
- `PYTHONPATH=backend:backend/src:. pytest tests/unit/test_usar.py::test_obtener_modulo_instala_si_no_existe tests/unit/test_usar.py::test_obtener_modulo_desde_corelibs_sin_pip tests/unit/test_usar.py::test_obtener_modulo_rechaza_paquete_fuera_de_lista tests/unit/test_usar_loader_stdlib.py::test_obtener_modulo_standard_library -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ee99a6088327ae6e36bc0f6e5a64