### PR TITLE
Ensure network timeouts in red corelib

### DIFF
--- a/backend/corelibs/red.py
+++ b/backend/corelibs/red.py
@@ -6,12 +6,12 @@ import urllib.request
 
 def obtener_url(url: str) -> str:
     """Devuelve el contenido de una URL como texto."""
-    with urllib.request.urlopen(url) as resp:
+    with urllib.request.urlopen(url, timeout=5) as resp:
         return resp.read().decode("utf-8")
 
 
 def enviar_post(url: str, datos: dict) -> str:
     """Envía datos por POST y retorna la respuesta."""
     encoded = urllib.parse.urlencode(datos).encode()
-    with urllib.request.urlopen(url, encoded) as resp:
+    with urllib.request.urlopen(url, encoded, timeout=5) as resp:
         return resp.read().decode("utf-8")

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -74,9 +74,12 @@ def test_red_funcs(monkeypatch):
     mock_resp.read.return_value = b'ok'
     mock_cm = MagicMock()
     mock_cm.__enter__.return_value = mock_resp
-    with patch('backend.corelibs.red.urllib.request.urlopen', return_value=mock_cm):
+    with patch('backend.corelibs.red.urllib.request.urlopen', return_value=mock_cm) as mock_urlopen:
         assert core.obtener_url('http://x') == 'ok'
         assert core.enviar_post('http://x', {'a': 1}) == 'ok'
+        mock_urlopen.assert_any_call('http://x', timeout=5)
+        mock_urlopen.assert_any_call('http://x', b'a=1', timeout=5)
+        assert mock_urlopen.call_count == 2
 
 
 def test_sistema_funcs(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- apply a 5s timeout when calling `urllib.request.urlopen`
- validate urlopen timeout usage in unit tests

## Testing
- `PYTHONPATH=. pytest tests/unit/test_corelibs.py::test_red_funcs -q`

------
https://chatgpt.com/codex/tasks/task_e_6867f101e1988327b3e70f624d48fc90