### PR TITLE
Check COBRAHUB_URL scheme

### DIFF
--- a/backend/src/cli/cobrahub_client.py
+++ b/backend/src/cli/cobrahub_client.py
@@ -7,8 +7,18 @@ from .utils.messages import mostrar_info, mostrar_error
 COBRAHUB_URL = os.environ.get("COBRAHUB_URL", "https://cobrahub.example.com/api")
 
 
+def _validar_url() -> bool:
+    """Verifica que la URL de CobraHub sea segura."""
+    if not COBRAHUB_URL.startswith("https://"):
+        mostrar_error(_("COBRAHUB_URL debe empezar con https://"))
+        return False
+    return True
+
+
 def publicar_modulo(ruta: str) -> bool:
     """Publica un archivo .co en CobraHub."""
+    if not _validar_url():
+        return False
     if not os.path.exists(ruta):
         mostrar_error(_("No se encontró el módulo {path}").format(path=ruta))
         return False
@@ -29,6 +39,8 @@ def publicar_modulo(ruta: str) -> bool:
 
 def descargar_modulo(nombre: str, destino: str) -> bool:
     """Descarga un módulo de CobraHub y lo guarda en destino."""
+    if not _validar_url():
+        return False
     try:
         response = requests.get(
             f"{COBRAHUB_URL}/modulos/{nombre}",

--- a/tests/unit/test_cli_cobrahub.py
+++ b/tests/unit/test_cli_cobrahub.py
@@ -4,6 +4,7 @@ import pytest
 
 from src.cli.cli import main
 from src.cli.commands import modules_cmd
+from src.cli import cobrahub_client
 
 
 @pytest.mark.timeout(5)
@@ -41,3 +42,30 @@ def test_cli_modulos_buscar(tmp_path, monkeypatch):
     assert archivo.read_bytes() == b"data"
     assert f"Módulo descargado en {archivo}" in out.getvalue().strip()
     mock_get.assert_called_once()
+
+
+@pytest.mark.timeout(5)
+def test_publicar_modulo_url_insegura(tmp_path, monkeypatch):
+    mod = tmp_path / "m.co"
+    mod.write_text("var x = 1")
+    monkeypatch.setattr(cobrahub_client, "COBRAHUB_URL", "http://inseguro/api")
+    with patch("src.cli.cobrahub_client.mostrar_error") as err, \
+            patch("src.cli.cobrahub_client.requests.post") as mock_post:
+        ok = cobrahub_client.publicar_modulo(str(mod))
+    assert not ok
+    err.assert_called_once()
+    assert "https://" in err.call_args[0][0]
+    mock_post.assert_not_called()
+
+
+@pytest.mark.timeout(5)
+def test_descargar_modulo_url_insegura(tmp_path, monkeypatch):
+    destino = tmp_path / "out.co"
+    monkeypatch.setattr(cobrahub_client, "COBRAHUB_URL", "http://inseguro/api")
+    with patch("src.cli.cobrahub_client.mostrar_error") as err, \
+            patch("src.cli.cobrahub_client.requests.get") as mock_get:
+        ok = cobrahub_client.descargar_modulo("m.co", str(destino))
+    assert not ok
+    err.assert_called_once()
+    assert "https://" in err.call_args[0][0]
+    mock_get.assert_not_called()


### PR DESCRIPTION
## Summary
- validate COBRAHUB_URL uses HTTPS
- test publishing/downloading abort on invalid URL

## Testing
- `pip install -q PyYAML==6.0.1 tomli hypothesis`
- `pip install -q -r requirements.txt`
- `pip install -q RestrictedPython==8.0`
- `pytest tests/unit/test_cli_cobrahub.py::test_publicar_modulo_url_insegura -q` *(fails: ModuleNotFoundError: No module named 'backend.src.core')*


------
https://chatgpt.com/codex/tasks/task_e_6867f99346d88327bce18389bf5e011d