### PR TITLE
Add MD5 security notes

### DIFF
--- a/backend/corelibs/seguridad.py
+++ b/backend/corelibs/seguridad.py
@@ -4,6 +4,7 @@ import hashlib
 import uuid
 
 
+# MD5 es inseguro para hashing criptográfico y se incluye sólo por compatibilidad
 def hash_md5(texto: str) -> str:
     """Devuelve el hash MD5 de *texto*."""
     return hashlib.md5(texto.encode("utf-8")).hexdigest()

--- a/frontend/docs/modulos_nativos.rst
+++ b/frontend/docs/modulos_nativos.rst
@@ -72,6 +72,7 @@ Red
 Seguridad
 ---------
 - ``hash_md5(texto)`` devuelve el hash MD5 de ``texto``.
+  .. warning:: MD5 es un algoritmo obsoleto para hashing seguro; se recomienda usar ``hash_sha256``.
 - ``hash_sha256(texto)`` devuelve el hash SHA-256.
 - ``generar_uuid()`` crea un identificador unico.
 


### PR DESCRIPTION
## Summary
- warn in code that MD5 is insecure for cryptographic hashing
- mention the MD5 deprecation in native modules documentation

## Testing
- `pytest -q` *(fails: 57 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6868006bf8a08327ab2aaaf3f6882ebc