### PR TITLE
Clarifica extensiones de paquetes Cobra

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -92,6 +92,7 @@ imprimir(saludo)
 - Agrupa varios módulos en un archivo con manifest ``cobra.pkg``.
 - Crea un paquete con ``cobra paquete crear carpeta paquete.cobra``.
 - Instálalo posteriormente con ``cobra paquete instalar paquete.cobra``.
+- Los archivos ``.cobra`` corresponden a paquetes completos, mientras que los scripts usan la extensión ``.co``.
 
 ## 6. Macros
 

--- a/README.md
+++ b/README.md
@@ -503,6 +503,8 @@ cobra profile programa.co
 cobra gui
 ```
 
+Los archivos con extensión ``.cobra`` representan paquetes completos, mientras que los scripts individuales se guardan como ``.co``.
+
 El subcomando `docs` ejecuta `sphinx-apidoc` para generar la documentación de la API antes de compilar el HTML.
 El subcomando `gui` abre el iddle integrado y requiere tener instalado Flet.
 


### PR DESCRIPTION
## Summary
- indica que los archivos `.cobra` son paquetes y los scripts usan `.co` en MANUAL_COBRA
- añade la misma aclaración en README

## Testing
- `make lint` *(fails: flake8 not found)*
- `make typecheck` *(fails: mypy errors)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6868063a27208327aa2cfff60d7085ef