### PR TITLE
Add PlantUML diagram to docs

### DIFF
--- a/frontend/docs/arquitectura.rst
+++ b/frontend/docs/arquitectura.rst
@@ -77,3 +77,9 @@ Diagrama de clases principal
 .. graphviz:: uml/class_diagram.gv
    :caption: Estructura basica del nucleo
 
+Diagrama de flujo general
+------------------------
+
+.. uml:: uml/arquitectura_general.puml
+   :caption: Flujo del compilador y transpiladores
+

--- a/frontend/docs/conf.py
+++ b/frontend/docs/conf.py
@@ -38,7 +38,8 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinx.ext.todo',
-    'sphinx.ext.graphviz'
+    'sphinx.ext.graphviz',
+    'sphinxcontrib.plantuml'
               ]
 
 # Evita errores si los paquetes no están instalados
@@ -62,3 +63,7 @@ gettext_compact = False
 html_static_path = ['_static']
 html_theme = 'sphinx_rtd_theme'
 html_css_files = ['custom.css']
+
+# Configuración de PlantUML
+plantuml = 'plantuml'
+plantuml_output_format = 'png'

--- a/frontend/docs/uml/arquitectura_general.puml
+++ b/frontend/docs/uml/arquitectura_general.puml
@@ -1,0 +1,21 @@
+@startuml
+Lexer --> Parser
+Parser --> AST
+AST --> Transpiladores
+Transpiladores --> Python
+Transpiladores --> JS
+Transpiladores --> ASM
+Transpiladores --> Rust
+Transpiladores --> "C++"
+Transpiladores --> Go
+Transpiladores --> R
+Transpiladores --> Julia
+Transpiladores --> Java
+Transpiladores --> COBOL
+Transpiladores --> Fortran
+Transpiladores --> Pascal
+Transpiladores --> Ruby
+Transpiladores --> PHP
+Transpiladores --> Matlab
+Transpiladores --> LaTeX
+@enduml

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ snakeviz==2.2.2
 lark==1.1.9
 psutil==7.0.0
 tomli>=2.0
+sphinxcontrib-plantuml==0.30


### PR DESCRIPTION
## Summary
- include sphinxcontrib-plantuml in requirements
- enable PlantUML extension and configuration
- document general compiler flow with a new diagram

## Testing
- `plantuml frontend/docs/uml/arquitectura_general.puml`
- `make clean html SPHINXOPTS=-E`

------
https://chatgpt.com/codex/tasks/task_e_68680a856d208327bffb058d51d26f62