### PR TITLE
Agregar resumen de patrones en la documentación

### DIFF
--- a/frontend/docs/arquitectura.rst
+++ b/frontend/docs/arquitectura.rst
@@ -68,6 +68,10 @@ Interacción de los módulos
 El flujo típico comienza con el ``Lexer`` que lee el código fuente y produce tokens. Estos tokens son consumidos por el ``Parser`` para construir el AST. A partir de este árbol el ``Intérprete`` ejecuta cada nodo o, alternativamente, los transpiladores lo recorren para generar código en otros lenguajes. Cuando se activa el modo seguro se aplica una cadena de validadores (ver :doc:`modo_seguro`) antes de ejecutar o transpilar, bloqueando operaciones peligrosas.
 
 
+Patrones de diseño
+------------------
+Cobra implementa diversos patrones para mantener su arquitectura flexible. El AST se recorre con el patrón *Visitor*, los transpiladores se obtienen desde la fábrica ``TRANSPILERS`` y los plugins de la CLI siguen el patrón *Command*. Consulta :doc:`design_patterns` para conocer los detalles.
+
 Reporte de errores léxicos
 --------------------------
 El lexer genera tokens mientras mantiene un conteo de línea y columna.

--- a/frontend/docs/design_patterns.rst
+++ b/frontend/docs/design_patterns.rst
@@ -87,3 +87,14 @@ asignan dinámicamente las funciones ``visit_<nodo>``:
 
 Otros lenguajes como C++ realizan asignaciones equivalentes de forma
 explícita para mantener separada la lógica de cada nodo.
+
+Patr\u00f3n Command
+-----------------
+Los subcomandos que ampl\u00edan la CLI se implementan siguiendo el patr\u00f3n
+*Command*. Cada plugin define una clase derivada de ``PluginCommand`` que
+registra sus argumentos en ``register_subparser`` y ejecuta la l\u00f3gica en
+``run``. Durante el arranque, Cobra localiza estas clases a trav\u00e9s de los
+``entry_points`` del grupo ``cobra.plugins`` y las instancia de manera
+segura. As\u00ed se a\u00f1aden nuevas funcionalidades sin acoplar el n\u00facleo a
+c\u00f3digo espec\u00edfico de cada plugin.
+


### PR DESCRIPTION
## Summary
- documentar el patrón Command en la página de patrones
- añadir un resumen de patrones en `arquitectura.rst` con enlace a la página de patrones

## Testing
- `pip install -r requirements.txt | tail -n 20`
- `pytest -q` *(fallan varias pruebas durante la recolección)*

------
https://chatgpt.com/codex/tasks/task_e_686814261eb483278a3d86a3cb1b310f