### PR TITLE
Add BaseTranspiler utility

### DIFF
--- a/backend/src/cobra/transpilers/__init__.py
+++ b/backend/src/cobra/transpilers/__init__.py
@@ -1,0 +1,3 @@
+from .base import BaseTranspiler
+
+__all__ = ["BaseTranspiler"]

--- a/backend/src/cobra/transpilers/base.py
+++ b/backend/src/cobra/transpilers/base.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+from backend.src.core.visitor import NodeVisitor
+
+
+class BaseTranspiler(NodeVisitor, ABC):
+    """Clase base para los transpiladores de Cobra."""
+
+    def __init__(self):
+        self.codigo = []
+
+    @abstractmethod
+    def generate_code(self, ast):
+        """Genera el código a partir del AST proporcionado."""
+        raise NotImplementedError
+
+    def save_file(self, path):
+        """Guarda el código generado en la ruta dada."""
+        contenido = "\n".join(self.codigo) if isinstance(self.codigo, list) else str(self.codigo)
+        with open(path, "w", encoding="utf-8") as archivo:
+            archivo.write(contenido)


### PR DESCRIPTION
## Summary
- add `BaseTranspiler` class for common transpiler features
- expose `BaseTranspiler` in `cobra.transpilers` package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68681726e2bc83278937730c3e791b63