### PR TITLE
Implementación de generate_code en transpiladores

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/to_asm.py
+++ b/backend/src/cobra/transpilers/transpiler/to_asm.py
@@ -31,6 +31,7 @@ from backend.src.core.ast_nodes import (
 from backend.src.cobra.lexico.lexer import TipoToken, Lexer
 from backend.src.cobra.parser.parser import Parser
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
@@ -65,12 +66,16 @@ from .asm_nodes.continuar import visit_continuar as _visit_continuar
 from .asm_nodes.pasar import visit_pasar as _visit_pasar
 
 
-class TranspiladorASM(NodeVisitor):
+class TranspiladorASM(BaseTranspiler):
     """Transpila el AST de Cobra a instrucciones de ensamblador simplificado."""
 
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_c.py
+++ b/backend/src/cobra/transpilers/transpiler/to_c.py
@@ -12,6 +12,7 @@ from backend.src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
@@ -81,12 +82,16 @@ c_nodes = {
 }
 
 
-class TranspiladorC(NodeVisitor):
+class TranspiladorC(BaseTranspiler):
     """Transpila el AST de Cobra a un C muy básico."""
 
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_cobol.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cobol.py
@@ -13,6 +13,7 @@ from backend.src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
@@ -30,12 +31,16 @@ cobol_nodes = {
 }
 
 
-class TranspiladorCOBOL(NodeVisitor):
+class TranspiladorCOBOL(BaseTranspiler):
     """Transpila el AST de Cobra a un COBOL muy simplificado."""
 
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_cpp.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cpp.py
@@ -19,6 +19,7 @@ from backend.src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
@@ -63,12 +64,16 @@ def visit_import_desde(self, nodo):
     self.agregar_linea(f"// from {nodo.modulo} import {nodo.nombre}{alias}")
 
 
-class TranspiladorCPP(NodeVisitor):
+class TranspiladorCPP(BaseTranspiler):
     """Transpila el AST de Cobra a código C++ sencillo."""
 
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_fortran.py
+++ b/backend/src/cobra/transpilers/transpiler/to_fortran.py
@@ -13,6 +13,7 @@ from backend.src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
@@ -29,10 +30,14 @@ fortran_nodes = {
 }
 
 
-class TranspiladorFortran(NodeVisitor):
+class TranspiladorFortran(BaseTranspiler):
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_go.py
+++ b/backend/src/cobra/transpilers/transpiler/to_go.py
@@ -13,6 +13,7 @@ from backend.src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
@@ -52,10 +53,14 @@ go_nodes = {
 }
 
 
-class TranspiladorGo(NodeVisitor):
+class TranspiladorGo(BaseTranspiler):
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_java.py
+++ b/backend/src/cobra/transpilers/transpiler/to_java.py
@@ -13,6 +13,7 @@ from backend.src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
@@ -51,10 +52,14 @@ java_nodes = {
 }
 
 
-class TranspiladorJava(NodeVisitor):
+class TranspiladorJava(BaseTranspiler):
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_js.py
+++ b/backend/src/cobra/transpilers/transpiler/to_js.py
@@ -23,6 +23,7 @@ from backend.src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 from ..import_helper import get_standard_imports
@@ -94,12 +95,16 @@ def visit_import_desde(self, nodo):
     self.agregar_linea(f"import {{ {nodo.nombre}{alias} }} from '{modulo}';")
 
 
-class TranspiladorJavaScript(NodeVisitor):
+class TranspiladorJavaScript(BaseTranspiler):
     def __init__(self):
         # Incluir importaciones de modulos nativos
         self.codigo = get_standard_imports("js")
         self.indentacion = 0
         self.usa_indentacion = None
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea):
         if self.usa_indentacion:
@@ -208,4 +213,3 @@ TranspiladorJavaScript.visit_with = visit_with
 TranspiladorJavaScript.visit_import_desde = visit_import_desde
 
     # Métodos de transpilación para tipos de nodos básicos
-

--- a/backend/src/cobra/transpilers/transpiler/to_julia.py
+++ b/backend/src/cobra/transpilers/transpiler/to_julia.py
@@ -13,6 +13,7 @@ from backend.src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
@@ -51,10 +52,14 @@ julia_nodes = {
 }
 
 
-class TranspiladorJulia(NodeVisitor):
+class TranspiladorJulia(BaseTranspiler):
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_latex.py
+++ b/backend/src/cobra/transpilers/transpiler/to_latex.py
@@ -10,6 +10,7 @@ from backend.src.core.ast_nodes import (
     NodoAtributo,
 )
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
@@ -26,10 +27,14 @@ latex_nodes = {
 }
 
 
-class TranspiladorLatex(NodeVisitor):
+class TranspiladorLatex(BaseTranspiler):
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_matlab.py
+++ b/backend/src/cobra/transpilers/transpiler/to_matlab.py
@@ -13,6 +13,7 @@ from backend.src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
@@ -29,10 +30,14 @@ matlab_nodes = {
 }
 
 
-class TranspiladorMatlab(NodeVisitor):
+class TranspiladorMatlab(BaseTranspiler):
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_pascal.py
+++ b/backend/src/cobra/transpilers/transpiler/to_pascal.py
@@ -13,6 +13,7 @@ from backend.src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
@@ -29,10 +30,14 @@ pascal_nodes = {
 }
 
 
-class TranspiladorPascal(NodeVisitor):
+class TranspiladorPascal(BaseTranspiler):
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_php.py
+++ b/backend/src/cobra/transpilers/transpiler/to_php.py
@@ -13,6 +13,7 @@ from backend.src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from src.cobra.macro import expandir_macros
 
@@ -55,12 +56,16 @@ php_nodes = {
 }
 
 
-class TranspiladorPHP(NodeVisitor):
+class TranspiladorPHP(BaseTranspiler):
     """Transpila el AST de Cobra a un PHP muy básico."""
 
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_python.py
+++ b/backend/src/cobra/transpilers/transpiler/to_python.py
@@ -31,6 +31,7 @@ from backend.src.core.ast_nodes import (
 from backend.src.cobra.parser.parser import Parser
 from backend.src.cobra.lexico.lexer import TipoToken, Lexer
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 from ..import_helper import get_standard_imports
@@ -100,12 +101,16 @@ def visit_import_desde(self, nodo):
     self.codigo += f"from {nodo.modulo} import {nodo.nombre}{alias}\n"
 
 
-class TranspiladorPython(NodeVisitor):
+class TranspiladorPython(BaseTranspiler):
     def __init__(self):
         # Incluir los modulos nativos al inicio del codigo generado
         self.codigo = get_standard_imports("python")
         self.usa_asyncio = False
         self.nivel_indentacion = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def obtener_indentacion(self):
         return "    " * self.nivel_indentacion
@@ -241,4 +246,3 @@ TranspiladorPython.visit_global = visit_global
 TranspiladorPython.visit_nolocal = visit_nolocal
 TranspiladorPython.visit_with = visit_with
 TranspiladorPython.visit_import_desde = visit_import_desde
-

--- a/backend/src/cobra/transpilers/transpiler/to_r.py
+++ b/backend/src/cobra/transpilers/transpiler/to_r.py
@@ -13,6 +13,7 @@ from backend.src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
@@ -51,10 +52,14 @@ r_nodes = {
 }
 
 
-class TranspiladorR(NodeVisitor):
+class TranspiladorR(BaseTranspiler):
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_ruby.py
+++ b/backend/src/cobra/transpilers/transpiler/to_ruby.py
@@ -13,6 +13,7 @@ from backend.src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
@@ -51,10 +52,14 @@ ruby_nodes = {
 }
 
 
-class TranspiladorRuby(NodeVisitor):
+class TranspiladorRuby(BaseTranspiler):
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_rust.py
+++ b/backend/src/cobra/transpilers/transpiler/to_rust.py
@@ -24,6 +24,7 @@ from src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
@@ -71,12 +72,16 @@ def visit_import_desde(self, nodo):
     self.agregar_linea(f"use {nodo.modulo}::{nodo.nombre}{alias};")
 
 
-class TranspiladorRust(NodeVisitor):
+class TranspiladorRust(BaseTranspiler):
     """Transpila el AST de Cobra a código Rust sencillo."""
 
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/backend/src/cobra/transpilers/transpiler/to_wasm.py
+++ b/backend/src/cobra/transpilers/transpiler/to_wasm.py
@@ -9,16 +9,21 @@ from backend.src.core.ast_nodes import (
 )
 from backend.src.cobra.lexico.lexer import TipoToken
 from backend.src.core.visitor import NodeVisitor
+from ..base import BaseTranspiler
 from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from backend.src.cobra.macro import expandir_macros
 
 
-class TranspiladorWasm(NodeVisitor):
+class TranspiladorWasm(BaseTranspiler):
     """Transpila el AST de Cobra a WebAssembly (WAT) de forma sencilla."""
 
     def __init__(self):
         self.codigo = []
         self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
 
     def agregar_linea(self, linea: str) -> None:
         self.codigo.append("    " * self.indent + linea)

--- a/examples/plugins/transpiler_demo.py
+++ b/examples/plugins/transpiler_demo.py
@@ -1,7 +1,14 @@
 """Transpilador de ejemplo para Cobra."""
 
-class TranspiladorDemo:
+from backend.src.cobra.transpilers.base import BaseTranspiler
+
+
+class TranspiladorDemo(BaseTranspiler):
     """Transpilador muy simple que genera un mensaje fijo."""
 
+    def generate_code(self, nodos):
+        self.codigo = "# Código generado por TranspiladorDemo"
+        return self.codigo
+
     def transpilar(self, nodos):
-        return "# Código generado por TranspiladorDemo"
+        return self.generate_code(nodos)

--- a/examples/tutorial_basico/compile_manual.py
+++ b/examples/tutorial_basico/compile_manual.py
@@ -16,5 +16,5 @@ for nodo in ast:
         if isinstance(val, str) and not (val.startswith("'") or val.startswith('"')):
             nodo.expresion.valor = repr(val)
 
-resultado = TranspiladorPython().transpilar(ast)
+resultado = TranspiladorPython().generate_code(ast)
 print(resultado)


### PR DESCRIPTION
## Resumen
- heredar `BaseTranspiler` en todos los transpiladores
- añadir método `generate_code` y mantener `transpilar`
- actualizar ejemplo de plugin y tutorial manual a la nueva API

## Testing
- `pytest -q` *(falla: 57 errors durante collection)*

------
https://chatgpt.com/codex/tasks/task_e_68681ce8991083279540a0bd0108c44b