### PR TITLE
Reemplazar transpilar por generate_code en CLI y pruebas

### DIFF
--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -109,7 +109,7 @@ class CompileCommand(BaseCommand):
     def _ejecutar_transpilador(self, parametros):
         lang, ast = parametros
         transp = TRANSPILERS[lang]()
-        return lang, transp.__class__.__name__, transp.transpilar(ast)
+        return lang, transp.__class__.__name__, transp.generate_code(ast)
 
     def run(self, args):
         archivo = args.archivo
@@ -161,7 +161,7 @@ class CompileCommand(BaseCommand):
                 if transpilador not in TRANSPILERS:
                     raise ValueError(_("Transpilador no soportado."))
                 transp = TRANSPILERS[transpilador]()
-                resultado = transp.transpilar(ast)
+                resultado = transp.generate_code(ast)
                 mostrar_info(
                     _("Código generado ({name}):").format(
                         name=transp.__class__.__name__

--- a/tests/fuzz/test_fuzz_parser.py
+++ b/tests/fuzz/test_fuzz_parser.py
@@ -39,7 +39,7 @@ def programas(draw):
 def test_fuzz_parser(programa: str):
     tokens = Lexer(programa).analizar_token()
     ast = Parser(tokens).parsear()
-    codigo_py = TranspiladorPython().transpilar(ast)
+    codigo_py = TranspiladorPython().generate_code(ast)
     # Eliminar importaciones globales que RestrictedPython no permite
     codigo_py = "\n".join(
         linea for linea in codigo_py.splitlines() if not linea.startswith("from ")

--- a/tests/integration/test_cross_backend_output.py
+++ b/tests/integration/test_cross_backend_output.py
@@ -102,7 +102,7 @@ def test_cross_backend_output(tmp_path):
         diferencias = {}
         for lang in TRANSPILERS:
             try:
-                codigo = TRANSPILERS[lang]().transpilar(ast)
+                codigo = TRANSPILERS[lang]().generate_code(ast)
             except NotImplementedError as e:
                 diferencias[lang] = f"Error: {e}"
                 continue

--- a/tests/integration/test_transpiladores.py
+++ b/tests/integration/test_transpiladores.py
@@ -5,5 +5,5 @@ from backend.src.cobra.transpilers.transpiler.to_python import TranspiladorPytho
 
 def test_transpilador_python_generacion():
     ast = [NodoImprimir(NodoValor("'hola'"))]
-    codigo = TranspiladorPython().transpilar(ast)
+    codigo = TranspiladorPython().generate_code(ast)
     assert "print('hola')" in codigo

--- a/tests/unit/test_async.py
+++ b/tests/unit/test_async.py
@@ -41,7 +41,7 @@ def test_transpiler_python_async_exec():
         NodoFuncion('saluda', [], [NodoImprimir(NodoValor('1'))], asincronica=True),
         NodoFuncion('principal', [], [NodoEsperar(NodoLlamadaFuncion('saluda', []))], asincronica=True),
     ]
-    code = TranspiladorPython().transpilar(ast)
+    code = TranspiladorPython().generate_code(ast)
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     patcher = patch('sys.stdout', new=StringIO())
@@ -59,7 +59,7 @@ def test_transpiler_js_async_exec(tmp_path):
         NodoFuncion('saluda', [], [NodoImprimir(NodoValor(1))], asincronica=True),
         NodoFuncion('principal', [], [NodoEsperar(NodoLlamadaFuncion('saluda', []))], asincronica=True),
     ]
-    code = TranspiladorJavaScript().transpilar(ast)
+    code = TranspiladorJavaScript().generate_code(ast)
     code = "\n".join(l for l in code.splitlines() if not l.startswith('import'))
     code += "\nprincipal();"
     archivo = tmp_path / 'async.js'

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -102,8 +102,8 @@ def test_transpile_texto():
         NodoLlamadaFuncion('invertir', [NodoValor("'abc'")]),
         NodoLlamadaFuncion('concatenar', [NodoValor("'a'"), NodoValor("'b'")]),
     ]
-    py = TranspiladorPython().transpilar(ast)
-    js = TranspiladorJavaScript().transpilar(ast)
+    py = TranspiladorPython().generate_code(ast)
+    js = TranspiladorJavaScript().generate_code(ast)
     py_exp = (
         IMPORTS_PY
         + "mayusculas('hola')\n"
@@ -129,8 +129,8 @@ def test_transpile_numero():
         NodoLlamadaFuncion('factorial', [NodoValor(3)]),
         NodoLlamadaFuncion('promedio', [NodoValor('[1,2]')]),
     ]
-    py = TranspiladorPython().transpilar(ast)
-    js = TranspiladorJavaScript().transpilar(ast)
+    py = TranspiladorPython().generate_code(ast)
+    js = TranspiladorJavaScript().generate_code(ast)
     py_exp = (
         IMPORTS_PY
         + "es_par(2)\n"
@@ -156,8 +156,8 @@ def test_transpile_archivo():
         NodoLlamadaFuncion('existe', [NodoValor("'f.txt'")]),
         NodoLlamadaFuncion('eliminar', [NodoValor("'f.txt'")]),
     ]
-    py = TranspiladorPython().transpilar(ast)
-    js = TranspiladorJavaScript().transpilar(ast)
+    py = TranspiladorPython().generate_code(ast)
+    js = TranspiladorJavaScript().generate_code(ast)
     py_exp = (
         IMPORTS_PY
         + "leer('f.txt')\n"
@@ -182,8 +182,8 @@ def test_transpile_tiempo():
         NodoLlamadaFuncion('formatear', [NodoValor('fecha'), NodoValor("'%Y'")]),
         NodoLlamadaFuncion('dormir', [NodoValor(1)]),
     ]
-    py = TranspiladorPython().transpilar(ast)
-    js = TranspiladorJavaScript().transpilar(ast)
+    py = TranspiladorPython().generate_code(ast)
+    js = TranspiladorJavaScript().generate_code(ast)
     py_exp = (
         IMPORTS_PY
         + "ahora()\n"
@@ -207,8 +207,8 @@ def test_transpile_coleccion():
         NodoLlamadaFuncion('minimo', [NodoValor('[1,2]')]),
         NodoLlamadaFuncion('sin_duplicados', [NodoValor('[1,1]')]),
     ]
-    py = TranspiladorPython().transpilar(ast)
-    js = TranspiladorJavaScript().transpilar(ast)
+    py = TranspiladorPython().generate_code(ast)
+    js = TranspiladorJavaScript().generate_code(ast)
     py_exp = (
         IMPORTS_PY
         + "ordenar([3,1])\n"
@@ -233,8 +233,8 @@ def test_transpile_seguridad():
         NodoLlamadaFuncion('hash_sha256', [NodoValor("'a'")]),
         NodoLlamadaFuncion('generar_uuid', []),
     ]
-    py = TranspiladorPython().transpilar(ast)
-    js = TranspiladorJavaScript().transpilar(ast)
+    py = TranspiladorPython().generate_code(ast)
+    js = TranspiladorJavaScript().generate_code(ast)
     py_exp = (
         IMPORTS_PY
         + "hash_md5('a')\n"
@@ -256,8 +256,8 @@ def test_transpile_red():
         NodoLlamadaFuncion('obtener_url', [NodoValor("'http://x'")]),
         NodoLlamadaFuncion('enviar_post', [NodoValor("'http://x'"), NodoValor('{"a":1}')]),
     ]
-    py = TranspiladorPython().transpilar(ast)
-    js = TranspiladorJavaScript().transpilar(ast)
+    py = TranspiladorPython().generate_code(ast)
+    js = TranspiladorJavaScript().generate_code(ast)
     py_exp = (
         IMPORTS_PY
         + "obtener_url('http://x')\n"
@@ -279,8 +279,8 @@ def test_transpile_sistema():
         NodoLlamadaFuncion('obtener_env', [NodoValor("'PATH'")]),
         NodoLlamadaFuncion('listar_dir', [NodoValor("'.'")]),
     ]
-    py = TranspiladorPython().transpilar(ast)
-    js = TranspiladorJavaScript().transpilar(ast)
+    py = TranspiladorPython().generate_code(ast)
+    js = TranspiladorJavaScript().generate_code(ast)
     py_exp = (
         IMPORTS_PY
         + "obtener_os()\n"

--- a/tests/unit/test_ctypes_bridge.py
+++ b/tests/unit/test_ctypes_bridge.py
@@ -41,7 +41,7 @@ def test_ctypes_bridge_executes_function(tmp_path):
         ),
         NodoImprimir(NodoLlamadaFuncion("triple", [NodoValor(4)])),
     ]
-    code = TranspiladorPython().transpilar(ast)
+    code = TranspiladorPython().generate_code(ast)
     with patch("sys.stdout", new_callable=StringIO) as out:
         exec(code, {})
     assert out.getvalue().strip() == "12"

--- a/tests/unit/test_decoradores_yield.py
+++ b/tests/unit/test_decoradores_yield.py
@@ -12,7 +12,7 @@ from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 def test_transpilar_funcion_con_decorador():
     decorador = NodoDecorador(NodoIdentificador("decor"))
     func = NodoFuncion("saluda", [], [NodoImprimir(NodoValor("'hola'"))], [decorador])
-    codigo = TranspiladorPython().transpilar([func])
+    codigo = TranspiladorPython().generate_code([func])
     esperado = (
         "from src.core.nativos import *\n"
         "@decor\n"
@@ -23,7 +23,7 @@ def test_transpilar_funcion_con_decorador():
 
 def test_transpilar_funcion_con_yield():
     func = NodoFuncion("generador", [], [NodoYield(NodoValor(1))])
-    codigo = TranspiladorPython().transpilar([func])
+    codigo = TranspiladorPython().generate_code([func])
     esperado = (
         "from src.core.nativos import *\n"
         "def generador():\n    yield 1\n"

--- a/tests/unit/test_hilos.py
+++ b/tests/unit/test_hilos.py
@@ -36,13 +36,13 @@ def test_interpreter_hilo():
 
 def test_transpiler_python_hilo():
     ast = [NodoHilo(NodoLlamadaFuncion('tarea', []))]
-    code = TranspiladorPython().transpilar(ast)
+    code = TranspiladorPython().generate_code(ast)
     assert 'asyncio.create_task(tarea())' in code
 
 
 def test_transpiler_js_hilo():
     ast = [NodoHilo(NodoLlamadaFuncion('tarea', []))]
-    code = TranspiladorJavaScript().transpilar(ast)
+    code = TranspiladorJavaScript().generate_code(ast)
     assert 'Promise.resolve().then(() => tarea());' in code
 
 
@@ -84,7 +84,7 @@ def test_transpiled_python_hilos_exec():
         NodoHilo(NodoLlamadaFuncion('tarea', [NodoValor(1)])),
         NodoHilo(NodoLlamadaFuncion('tarea', [NodoValor(2)])),
     ]
-    code = TranspiladorPython().transpilar(ast)
+    code = TranspiladorPython().generate_code(ast)
     code = code.replace('def tarea(', 'async def tarea(')
     code = code.replace('asyncio.create_task', 'loop.create_task')
     loop = asyncio.new_event_loop()
@@ -105,7 +105,7 @@ def test_transpiled_js_hilos_exec(tmp_path):
         NodoHilo(NodoLlamadaFuncion('tarea', [])),
         NodoHilo(NodoLlamadaFuncion('tarea', [])),
     ]
-    code = TranspiladorJavaScript().transpilar(ast)
+    code = TranspiladorJavaScript().generate_code(ast)
     code = "\n".join(l for l in code.splitlines() if not l.startswith('import'))
     archivo = tmp_path / 'script.js'
     archivo.write_text(code)

--- a/tests/unit/test_import.py
+++ b/tests/unit/test_import.py
@@ -41,7 +41,7 @@ def test_import_transpiler(tmp_path):
     tokens = Lexer(codigo).analizar_token()
     ast = Parser(tokens).parsear()
 
-    py_code = TranspiladorPython().transpilar(ast)
+    py_code = TranspiladorPython().generate_code(ast)
     expected = (
         "from src.core.nativos import *\nvalor = 3\nprint(valor)\n"
     )

--- a/tests/unit/test_imports_alias_clase.py
+++ b/tests/unit/test_imports_alias_clase.py
@@ -30,7 +30,7 @@ def crear_ast():
 
 def test_transpilador_python_imports_alias_clase():
     ast = crear_ast()
-    resultado = TranspiladorPython().transpilar(ast)
+    resultado = TranspiladorPython().generate_code(ast)
     esperado = (
         "import asyncio\n"
         "from src.core.nativos import *\n"
@@ -55,7 +55,7 @@ IMPORTS = (
 
 def test_transpilador_js_imports_alias_clase():
     ast = crear_ast()
-    resultado = TranspiladorJavaScript().transpilar(ast)
+    resultado = TranspiladorJavaScript().generate_code(ast)
     esperado = IMPORTS + (
         "import { decorador as dec } from 'package.module';\n"
         "import { Base as B } from 'package2.module2';\n"

--- a/tests/unit/test_inlining_transpilers.py
+++ b/tests/unit/test_inlining_transpilers.py
@@ -12,12 +12,12 @@ def _ast_inline():
 
 
 def test_inline_python_transpiler():
-    codigo = TranspiladorPython().transpilar(_ast_inline())
+    codigo = TranspiladorPython().generate_code(_ast_inline())
     assert codigo == "from src.core.nativos import *\nx = 1\n"
 
 
 def test_inline_js_transpiler():
-    codigo = TranspiladorJavaScript().transpilar(_ast_inline())
+    codigo = TranspiladorJavaScript().generate_code(_ast_inline())
     esperado = (
         "import * as io from './nativos/io.js';\n"
         "import * as net from './nativos/io.js';\n"

--- a/tests/unit/test_integracion_transpiladores.py
+++ b/tests/unit/test_integracion_transpiladores.py
@@ -9,7 +9,7 @@ def test_integracion_python():
     codigo = "var x = 10"
     tokens = Lexer(codigo).analizar_token()
     ast = Parser(tokens).parsear()
-    resultado = TranspiladorPython().transpilar(ast)
+    resultado = TranspiladorPython().generate_code(ast)
     esperado = "from src.core.nativos import *\nx = 10\n"
     assert resultado == esperado
 
@@ -18,7 +18,7 @@ def test_integracion_js():
     codigo = "var x = 10\nimprimir(x)"
     tokens = Lexer(codigo).analizar_token()
     ast = Parser(tokens).parsear()
-    resultado = TranspiladorJavaScript().transpilar(ast)
+    resultado = TranspiladorJavaScript().generate_code(ast)
     esperado = (
         "import * as io from './nativos/io.js';\n"
         "import * as net from './nativos/io.js';\n"
@@ -34,7 +34,7 @@ def test_integracion_condicional_python():
     codigo = "var x = 10\nsi x > 5 :\n    imprimir(x)\nfin"
     tokens = Lexer(codigo).analizar_token()
     ast = Parser(tokens).parsear()
-    resultado = TranspiladorPython().transpilar(ast)
+    resultado = TranspiladorPython().generate_code(ast)
     esperado = (
         "from src.core.nativos import *\n"
         "x = 10\n"

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -8,7 +8,7 @@ def test_macro_python():
     codigo = "macro saludo { imprimir(1) } saludo()"
     tokens = Lexer(codigo).tokenizar()
     ast = Parser(tokens).parsear()
-    resultado = TranspiladorPython().transpilar(ast)
+    resultado = TranspiladorPython().generate_code(ast)
     assert resultado == "from src.core.nativos import *\nprint(1)\n"
 
 
@@ -16,5 +16,5 @@ def test_macro_cpp():
     codigo = "macro inc { var x = 10 } inc()"
     tokens = Lexer(codigo).tokenizar()
     ast = Parser(tokens).parsear()
-    resultado = TranspiladorCPP().transpilar(ast)
+    resultado = TranspiladorCPP().generate_code(ast)
     assert resultado == "auto x = 10;"

--- a/tests/unit/test_module_map.py
+++ b/tests/unit/test_module_map.py
@@ -25,7 +25,7 @@ def test_transpilador_mapeo_python(tmp_path, monkeypatch):
     tokens = Lexer(codigo).analizar_token()
     ast = Parser(tokens).parsear()
 
-    resultado = TranspiladorPython().transpilar(ast)
+    resultado = TranspiladorPython().generate_code(ast)
     esperado = f"from src.core.nativos import *\n{py_out.read_text()}print(x)\n"
     assert resultado == esperado
 
@@ -47,7 +47,7 @@ def test_transpilador_mapeo_js(tmp_path, monkeypatch):
     tokens = Lexer(codigo).analizar_token()
     ast = Parser(tokens).parsear()
 
-    resultado = TranspiladorJavaScript().transpilar(ast)
+    resultado = TranspiladorJavaScript().generate_code(ast)
     esperado = (
         "import * as io from './nativos/io.js';\n"
         "import * as net from './nativos/io.js';\n"

--- a/tests/unit/test_operadores.py
+++ b/tests/unit/test_operadores.py
@@ -96,8 +96,8 @@ def test_transpiladores_operaciones():
     ]
     parser = Parser(tokens)
     expr = parser.parsear()[0]
-    py_code = TranspiladorPython().transpilar([expr])
-    js_code = TranspiladorJavaScript().transpilar([expr])
+    py_code = TranspiladorPython().generate_code([expr])
+    js_code = TranspiladorJavaScript().generate_code([expr])
     assert py_code == "from src.core.nativos import *\nTrue"
     assert js_code == (
         "import * as io from './nativos/io.js';\n"

--- a/tests/unit/test_pasar.py
+++ b/tests/unit/test_pasar.py
@@ -20,7 +20,7 @@ def test_parser_pasar():
 def test_transpilar_pasar_python():
     nodo = NodoPasar()
     t = TranspiladorPython()
-    resultado = t.transpilar([nodo])
+    resultado = t.generate_code([nodo])
     esperado = "from src.core.nativos import *\npass\n"
     assert resultado == esperado
 
@@ -28,7 +28,7 @@ def test_transpilar_pasar_python():
 def test_transpilar_pasar_js():
     nodo = NodoPasar()
     t = TranspiladorJavaScript()
-    resultado = t.transpilar([nodo])
+    resultado = t.generate_code([nodo])
     esperado = (
         "import * as io from './nativos/io.js';\n"
         "import * as net from './nativos/io.js';\n"

--- a/tests/unit/test_pcobra_module_map.py
+++ b/tests/unit/test_pcobra_module_map.py
@@ -33,7 +33,7 @@ def test_pcobra_mapeo_python(tmp_path, monkeypatch):
     tokens = Lexer(codigo).analizar_token()
     ast = Parser(tokens).parsear()
 
-    resultado = TranspiladorPython().transpilar(ast)
+    resultado = TranspiladorPython().generate_code(ast)
     esperado = f"from src.core.nativos import *\n{py_out.read_text()}print(x)\n"
     assert resultado == esperado
 
@@ -55,7 +55,7 @@ def test_pcobra_mapeo_js(tmp_path, monkeypatch):
     tokens = Lexer(codigo).analizar_token()
     ast = Parser(tokens).parsear()
 
-    resultado = TranspiladorJavaScript().transpilar(ast)
+    resultado = TranspiladorJavaScript().generate_code(ast)
     esperado = (
         "import * as io from './nativos/io.js';\n"
         "import * as net from './nativos/io.js';\n"

--- a/tests/unit/test_retornos.py
+++ b/tests/unit/test_retornos.py
@@ -18,9 +18,9 @@ def test_transpiladores_retorno():
     func = NodoFuncion("valor", [], [nodo_ret])
 
     py = TranspiladorPython()
-    codigo_py = py.transpilar([func])
+    codigo_py = py.generate_code([func])
     assert "return 7" in codigo_py
 
     js = TranspiladorJavaScript()
-    codigo_js = js.transpilar([func])
+    codigo_js = js.generate_code([func])
     assert "return 7;" in codigo_js

--- a/tests/unit/test_romper_continuar.py
+++ b/tests/unit/test_romper_continuar.py
@@ -32,7 +32,7 @@ def test_parser_romper_continuar():
 def test_transpilar_romper_python():
     nodo = NodoBucleMientras("i < 3", [NodoRomper()])
     t = TranspiladorPython()
-    resultado = t.transpilar([nodo])
+    resultado = t.generate_code([nodo])
     esperado = "from src.core.nativos import *\nwhile i < 3:\n    break\n"
     assert resultado == esperado
 
@@ -40,7 +40,7 @@ def test_transpilar_romper_python():
 def test_transpilar_continuar_js():
     nodo = NodoPara("x", NodoValor("datos"), [NodoContinuar()])
     t = TranspiladorJavaScript()
-    resultado = t.transpilar([nodo])
+    resultado = t.generate_code([nodo])
     esperado = (
         "import * as io from './nativos/io.js';\n"
         "import * as net from './nativos/io.js';\n"

--- a/tests/unit/test_semantica_transpiladores.py
+++ b/tests/unit/test_semantica_transpiladores.py
@@ -7,9 +7,9 @@ from src.core.ast_nodes import NodoAsignacion, NodoBucleMientras, NodoValor
 def test_asignacion_compartida():
     ast = [NodoAsignacion("x", NodoValor(1))]
     resultados = [
-        TranspiladorPython().transpilar(ast),
-        TranspiladorJavaScript().transpilar(ast),
-        TranspiladorC().transpilar(ast),
+        TranspiladorPython().generate_code(ast),
+        TranspiladorJavaScript().generate_code(ast),
+        TranspiladorC().generate_code(ast),
     ]
     for codigo in resultados:
         assert "x" in codigo
@@ -19,9 +19,9 @@ def test_asignacion_compartida():
 def test_bucle_mientras_compartido():
     ast = [NodoBucleMientras("x > 0", [NodoAsignacion("x", NodoValor("x - 1"))])]
     resultados = [
-        TranspiladorPython().transpilar(ast),
-        TranspiladorJavaScript().transpilar(ast),
-        TranspiladorC().transpilar(ast),
+        TranspiladorPython().generate_code(ast),
+        TranspiladorJavaScript().generate_code(ast),
+        TranspiladorC().generate_code(ast),
     ]
     for codigo in resultados:
         assert "x" in codigo

--- a/tests/unit/test_to_asm.py
+++ b/tests/unit/test_to_asm.py
@@ -12,7 +12,7 @@ from src.core.ast_nodes import (
 def test_transpilador_asignacion():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorASM()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "SET x, 10"
 
 
@@ -25,7 +25,7 @@ def test_transpilador_condicional():
         )
     ]
     t = TranspiladorASM()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     expected = "IF x > 5\n    SET y, 2\nELSE\n    SET y, 3\nEND"
     assert resultado == expected
 
@@ -33,7 +33,7 @@ def test_transpilador_condicional():
 def test_transpilador_mientras():
     ast = [NodoBucleMientras("x > 0", [NodoAsignacion("x", "x - 1")])]
     t = TranspiladorASM()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     expected = "WHILE x > 0\n    SET x, x - 1\nEND"
     assert resultado == expected
 
@@ -41,7 +41,7 @@ def test_transpilador_mientras():
 def test_transpilador_funcion():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     t = TranspiladorASM()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     expected = "FUNC miFuncion a b\n    SET x, a + b\nENDFUNC"
     assert resultado == expected
 
@@ -49,12 +49,12 @@ def test_transpilador_funcion():
 def test_transpilador_llamada_funcion():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     t = TranspiladorASM()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "CALL miFuncion a, b"
 
 
 def test_transpilador_holobit():
     ast = [NodoHolobit("miHolobit", [0.8, -0.5, 1.2])]
     t = TranspiladorASM()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "HOLOBIT miHolobit [0.8, -0.5, 1.2]"

--- a/tests/unit/test_to_c.py
+++ b/tests/unit/test_to_c.py
@@ -11,7 +11,7 @@ from src.core.ast_nodes import (
 def test_transpilador_asignacion_c():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorC()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "int x = 10;"
 
 
@@ -24,7 +24,7 @@ def test_transpilador_condicional_c():
         )
     ]
     t = TranspiladorC()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "if (x > 5) {\n    int y = 2;\n} else {\n    int y = 3;\n}"
     assert resultado == esperado
 
@@ -32,7 +32,7 @@ def test_transpilador_condicional_c():
 def test_transpilador_mientras_c():
     ast = [NodoBucleMientras("x > 0", [NodoAsignacion("x", "x - 1")])]
     t = TranspiladorC()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "while (x > 0) {\n    int x = x - 1;\n}"
     assert resultado == esperado
 
@@ -40,7 +40,7 @@ def test_transpilador_mientras_c():
 def test_transpilador_funcion_c():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     t = TranspiladorC()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "void miFuncion(int a, int b) {\n    int x = a + b;\n}"
     assert resultado == esperado
 
@@ -48,5 +48,5 @@ def test_transpilador_funcion_c():
 def test_transpilador_llamada_funcion_c():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     t = TranspiladorC()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "miFuncion(a, b);"

--- a/tests/unit/test_to_cobol.py
+++ b/tests/unit/test_to_cobol.py
@@ -5,14 +5,14 @@ from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, 
 def test_transpilador_asignacion_cobol():
     ast = [NodoAsignacion("X", 10)]
     t = TranspiladorCOBOL()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "MOVE 10 TO X"
 
 
 def test_transpilador_funcion_cobol():
     ast = [NodoFuncion("MIFUNCION", ["A", "B"], [NodoAsignacion("X", "A + B")])]
     t = TranspiladorCOBOL()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "MIFUNCION SECTION.\n    MOVE A + B TO X\nEXIT SECTION."
     assert resultado == esperado
 
@@ -20,12 +20,12 @@ def test_transpilador_funcion_cobol():
 def test_transpilador_llamada_funcion_cobol():
     ast = [NodoLlamadaFuncion("MIFUNCION", ["A", "B"])]
     t = TranspiladorCOBOL()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "CALL 'MIFUNCION' USING A B"
 
 
 def test_transpilador_imprimir_cobol():
     ast = [NodoImprimir(NodoValor("X"))]
     t = TranspiladorCOBOL()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "DISPLAY X"

--- a/tests/unit/test_to_cpp.py
+++ b/tests/unit/test_to_cpp.py
@@ -19,7 +19,7 @@ from src.core.ast_nodes import (
 def test_transpilador_asignacion():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorCPP()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "auto x = 10;"
 
 
@@ -32,7 +32,7 @@ def test_transpilador_condicional():
         )
     ]
     t = TranspiladorCPP()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "if (x > 5) {\n    auto y = 2;\n} else {\n    auto y = 3;\n}"
     assert resultado == esperado
 
@@ -40,7 +40,7 @@ def test_transpilador_condicional():
 def test_transpilador_mientras():
     ast = [NodoBucleMientras("x > 0", [NodoAsignacion("x", "x - 1")])]
     t = TranspiladorCPP()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "while (x > 0) {\n    auto x = x - 1;\n}"
     assert resultado == esperado
 
@@ -48,7 +48,7 @@ def test_transpilador_mientras():
 def test_transpilador_funcion():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     t = TranspiladorCPP()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "void miFuncion(auto a, auto b) {\n    auto x = a + b;\n}"
     assert resultado == esperado
 
@@ -56,21 +56,21 @@ def test_transpilador_funcion():
 def test_transpilador_llamada_funcion():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     t = TranspiladorCPP()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "miFuncion(a, b);"
 
 
 def test_transpilador_holobit():
     ast = [NodoHolobit("miHolobit", [0.8, -0.5, 1.2])]
     t = TranspiladorCPP()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "auto miHolobit = holobit({ 0.8, -0.5, 1.2 });"
 
 def test_transpilador_clase():
     metodo = NodoMetodo("saludar", ["self"], [NodoAsignacion("x", 1)])
     ast = [NodoClase("Persona", [metodo])]
     t = TranspiladorCPP()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = (
         "class Persona {\n"
         "    auto saludar(auto self) {\n"
@@ -84,7 +84,7 @@ def test_transpilador_clase():
 def test_transpilador_yield():
     ast = [NodoFuncion("generador", [], [NodoYield(NodoValor(1))])]
     t = TranspiladorCPP()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "void generador() {\n    co_yield 1;\n}"
     assert resultado == esperado
 
@@ -101,7 +101,7 @@ def test_transpilador_switch():
         )
     ]
     t = TranspiladorCPP()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = (
         "switch (x) {\n"
         "    case 1:\n"

--- a/tests/unit/test_to_fortran.py
+++ b/tests/unit/test_to_fortran.py
@@ -11,14 +11,14 @@ from src.core.ast_nodes import (
 def test_transpilador_asignacion_fortran():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorFortran()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "x = 10"
 
 
 def test_transpilador_funcion_fortran():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     t = TranspiladorFortran()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "subroutine miFuncion(a, b)\n    x = a + b\nend subroutine"
     assert resultado == esperado
 
@@ -26,12 +26,12 @@ def test_transpilador_funcion_fortran():
 def test_transpilador_llamada_funcion_fortran():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     t = TranspiladorFortran()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "call miFuncion(a, b)"
 
 
 def test_transpilador_imprimir_fortran():
     ast = [NodoImprimir(NodoValor("x"))]
     t = TranspiladorFortran()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "print *, x"

--- a/tests/unit/test_to_go.py
+++ b/tests/unit/test_to_go.py
@@ -5,14 +5,14 @@ from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, 
 def test_transpilador_asignacion_go():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorGo()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "x := 10"
 
 
 def test_transpilador_funcion_go():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     t = TranspiladorGo()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "func miFuncion(a, b) {\n    x := a + b\n}"
     assert resultado == esperado
 
@@ -20,12 +20,12 @@ def test_transpilador_funcion_go():
 def test_transpilador_llamada_funcion_go():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     t = TranspiladorGo()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "miFuncion(a, b)"
 
 
 def test_transpilador_imprimir_go():
     ast = [NodoImprimir(NodoValor("x"))]
     t = TranspiladorGo()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "fmt.Println(x)"

--- a/tests/unit/test_to_java.py
+++ b/tests/unit/test_to_java.py
@@ -5,14 +5,14 @@ from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, 
 def test_transpilador_asignacion_java():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorJava()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "var x = 10;"
 
 
 def test_transpilador_funcion_java():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     t = TranspiladorJava()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "static void miFuncion(a, b) {\n    var x = a + b;\n}"
     assert resultado == esperado
 
@@ -20,12 +20,12 @@ def test_transpilador_funcion_java():
 def test_transpilador_llamada_funcion_java():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     t = TranspiladorJava()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "miFuncion(a, b);"
 
 
 def test_transpilador_imprimir_java():
     ast = [NodoImprimir(NodoValor("x"))]
     t = TranspiladorJava()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "System.out.println(x);"

--- a/tests/unit/test_to_js.py
+++ b/tests/unit/test_to_js.py
@@ -28,14 +28,14 @@ IMPORTS = "".join(f"{line}\n" for line in get_standard_imports("js"))
 def test_transpilador_asignacion():
     ast = [NodoAsignacion("x", 10)]
     transpilador = TranspiladorJavaScript()
-    resultado = transpilador.transpilar(ast)
+    resultado = transpilador.generate_code(ast)
     assert resultado == IMPORTS + "let x = 10;"
 
 
 def test_transpilador_condicional():
     ast = [NodoCondicional("x > 5", [NodoAsignacion("y", 2)], [NodoAsignacion("y", 3)])]
     transpilador = TranspiladorJavaScript()
-    resultado = transpilador.transpilar(ast)
+    resultado = transpilador.generate_code(ast)
     expected = (
         IMPORTS
         + "if (x > 5) {\n    let y = 2;\n} else {\n    let y = 3;\n}"
@@ -46,7 +46,7 @@ def test_transpilador_condicional():
 def test_transpilador_mientras():
     ast = [NodoBucleMientras("x > 0", [NodoAsignacion("x", "x - 1")])]
     transpilador = TranspiladorJavaScript()
-    resultado = transpilador.transpilar(ast)
+    resultado = transpilador.generate_code(ast)
     expected = IMPORTS + "while (x > 0) {\n    let x = x - 1;\n}"
     assert resultado == expected
 
@@ -54,7 +54,7 @@ def test_transpilador_mientras():
 def test_transpilador_funcion():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     transpilador = TranspiladorJavaScript()
-    resultado = transpilador.transpilar(ast)
+    resultado = transpilador.generate_code(ast)
     expected = IMPORTS + "function miFuncion(a, b) {\n    let x = a + b;\n}"
     assert resultado == expected
 
@@ -62,7 +62,7 @@ def test_transpilador_funcion():
 def test_transpilador_llamada_funcion():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     transpilador = TranspiladorJavaScript()
-    resultado = transpilador.transpilar(ast)
+    resultado = transpilador.generate_code(ast)
     expected = IMPORTS + "miFuncion(a, b);"
     assert resultado == expected
 
@@ -70,7 +70,7 @@ def test_transpilador_llamada_funcion():
 def test_transpilador_holobit():
     ast = [NodoHolobit("miHolobit", [0.8, -0.5, 1.2])]
     transpilador = TranspiladorJavaScript()
-    resultado = transpilador.transpilar(ast)
+    resultado = transpilador.generate_code(ast)
     expected = IMPORTS + "let miHolobit = new Holobit([0.8, -0.5, 1.2]);"
     assert resultado == expected
 
@@ -78,7 +78,7 @@ def test_transpilador_holobit():
 def test_transpilador_yield():
     ast = [NodoFuncion("generador", [], [NodoYield(NodoValor(1))])]
     t = TranspiladorJavaScript()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = IMPORTS + "function generador() {\nyield 1;\n}"
     assert resultado == esperado
 
@@ -95,7 +95,7 @@ def test_transpilador_switch():
         )
     ]
     t = TranspiladorJavaScript()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = (
         IMPORTS
         + "switch (x) {\n"
@@ -123,7 +123,7 @@ def test_async_function_and_await():
         )
     ]
     t = TranspiladorJavaScript()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = IMPORTS + (
         "async function principal() {\n"
         "await saluda();\n"
@@ -139,7 +139,7 @@ def test_export_import():
         NodoExport("saluda"),
     ]
     t = TranspiladorJavaScript()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = IMPORTS + (
         "import { saluda } from './mod.js';\n"
         "function saluda() {\n"
@@ -155,7 +155,7 @@ def test_decoradores_en_clase_y_metodo_js():
     clase = NodoClase("C", [metodo])
     clase.decoradores = [decor]
     t = TranspiladorJavaScript()
-    resultado = t.transpilar([clase])
+    resultado = t.generate_code([clase])
     esperado = IMPORTS + (
         "class C {\n"
         "async run(a) {\n"
@@ -169,6 +169,6 @@ def test_decoradores_en_clase_y_metodo_js():
 
 
 def test_imports_js_por_defecto():
-    resultado = TranspiladorJavaScript().transpilar([])
+    resultado = TranspiladorJavaScript().generate_code([])
     esperado = "\n".join(get_standard_imports("js"))
     assert resultado == esperado

--- a/tests/unit/test_to_js2.py
+++ b/tests/unit/test_to_js2.py
@@ -46,14 +46,14 @@ class NodoHolobit:
 def test_transpilar_asignacion():
     nodo = NodoAsignacion("variable", "10")
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     assert result == "variable = 10;", "Error en la transpilación de asignación"
 
 
 def test_transpilar_condicional():
     nodo = NodoCondicional("x > 5", [NodoAsignacion("y", "10")], [NodoAsignacion("y", "0")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "if (x > 5) {\ny = 10;\n}\nelse {\ny = 0;\n}"
     assert result == expected, "Error en la transpilación de condicional"
 
@@ -61,7 +61,7 @@ def test_transpilar_condicional():
 def test_transpilar_mientras():
     nodo = NodoBucleMientras("i < 10", [NodoAsignacion("i", "i + 1")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "while (i < 10) {\ni = i + 1;\n}"
     assert result == expected, "Error en la transpilación de bucle mientras"
 
@@ -69,7 +69,7 @@ def test_transpilar_mientras():
 def test_transpilar_funcion():
     nodo = NodoFuncion("sumar", ["a", "b"], [NodoAsignacion("resultado", "a + b")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "function sumar(a, b) {\nresultado = a + b;\n}"
     assert result == expected, "Error en la transpilación de función"
 
@@ -77,12 +77,12 @@ def test_transpilar_funcion():
 def test_transpilar_llamada_funcion():
     nodo = NodoLlamadaFuncion("sumar", ["5", "3"])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     assert result == "sumar(5, 3);", "Error en la transpilación de llamada a función"
 
 
 def test_transpilar_holobit():
     nodo = NodoHolobit("miHolobit", [1, 2, 3])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     assert result == "let miHolobit = new Holobit([1, 2, 3]);", "Error en la transpilación de Holobit"

--- a/tests/unit/test_to_js3.py
+++ b/tests/unit/test_to_js3.py
@@ -78,14 +78,14 @@ class NodoMetodo:
 def test_transpilar_asignacion():
     nodo = NodoAsignacion("variable", "10")
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     assert result == "variable = 10;", "Error en la transpilación de asignación"
 
 
 def test_transpilar_condicional():
     nodo = NodoCondicional("x > 5", [NodoAsignacion("y", "10")], [NodoAsignacion("y", "0")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "if (x > 5) {\ny = 10;\n}\nelse {\ny = 0;\n}"
     assert result == expected, "Error en la transpilación de condicional"
 
@@ -93,7 +93,7 @@ def test_transpilar_condicional():
 def test_transpilar_mientras():
     nodo = NodoBucleMientras("i < 10", [NodoAsignacion("i", "i + 1")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "while (i < 10) {\ni = i + 1;\n}"
     assert result == expected, "Error en la transpilación de bucle mientras"
 
@@ -101,7 +101,7 @@ def test_transpilar_mientras():
 def test_transpilar_funcion():
     nodo = NodoFuncion("sumar", ["a", "b"], [NodoAsignacion("resultado", "a + b")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "function sumar(a, b) {\nresultado = a + b;\n}"
     assert result == expected, "Error en la transpilación de función"
 
@@ -109,14 +109,14 @@ def test_transpilar_funcion():
 def test_transpilar_llamada_funcion():
     nodo = NodoLlamadaFuncion("sumar", ["5", "3"])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     assert result == "sumar(5, 3);", "Error en la transpilación de llamada a función"
 
 
 def test_transpilar_holobit():
     nodo = NodoHolobit("miHolobit", [1, 2, 3])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     assert result == "let miHolobit = new Holobit([1, 2, 3]);", "Error en la transpilación de Holobit"
 
 
@@ -125,7 +125,7 @@ def test_transpilar_holobit():
 def test_transpilar_for():
     nodo = NodoFor("i", "lista", [NodoAsignacion("suma", "suma + i")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "for (let i of lista) {\nsuma = suma + i;\n}"
     assert result == expected, "Error en la transpilación de bucle for"
 
@@ -133,7 +133,7 @@ def test_transpilar_for():
 def test_transpilar_lista():
     nodo = NodoLista(["1", "2", "3"])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "[1, 2, 3]"
     assert result == expected, "Error en la transpilación de lista"
 
@@ -141,7 +141,7 @@ def test_transpilar_lista():
 def test_transpilar_diccionario():
     nodo = NodoDiccionario([("clave1", "valor1"), ("clave2", "valor2")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "{clave1: valor1, clave2: valor2}"
     assert result == expected, "Error en la transpilación de diccionario"
 
@@ -150,7 +150,7 @@ def test_transpilar_clase():
     metodo = NodoMetodo("miMetodo", ["param"], [NodoAsignacion("x", "param + 1")])
     nodo = NodoClase("MiClase", [metodo])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "class MiClase {\nmiMetodo(param) {\nx = param + 1;\n}\n}"
     assert result == expected, "Error en la transpilación de clase"
 
@@ -159,7 +159,7 @@ def test_transpilar_clase_multibase():
     metodo = NodoMetodo("m", ["p"], [NodoAsignacion("x", "p")])
     nodo = NodoClase("Hija", [metodo], ["Base1", "Base2"])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     imports = "".join(f"{line}\n" for line in get_standard_imports("js"))
     expected = (
         imports
@@ -175,6 +175,6 @@ def test_transpilar_clase_multibase():
 def test_transpilar_metodo():
     nodo = NodoMetodo("miMetodo", ["a", "b"], [NodoAsignacion("resultado", "a + b")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "miMetodo(a, b) {\nresultado = a + b;\n}"
     assert result == expected, "Error en la transpilación de método"

--- a/tests/unit/test_to_js4.py
+++ b/tests/unit/test_to_js4.py
@@ -78,14 +78,14 @@ class NodoMetodo:
 def test_transpilar_asignacion():
     nodo = NodoAsignacion("variable", "10")
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     assert result == "variable = 10;", "Error en la transpilación de asignación"
 
 
 def test_transpilar_condicional():
     nodo = NodoCondicional("x > 5", [NodoAsignacion("y", "10")], [NodoAsignacion("y", "0")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "if (x > 5) {\ny = 10;\n}\nelse {\ny = 0;\n}"
     assert result == expected, "Error en la transpilación de condicional"
 
@@ -93,7 +93,7 @@ def test_transpilar_condicional():
 def test_transpilar_mientras():
     nodo = NodoBucleMientras("i < 10", [NodoAsignacion("i", "i + 1")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "while (i < 10) {\ni = i + 1;\n}"
     assert result == expected, "Error en la transpilación de bucle mientras"
 
@@ -101,7 +101,7 @@ def test_transpilar_mientras():
 def test_transpilar_funcion():
     nodo = NodoFuncion("sumar", ["a", "b"], [NodoAsignacion("resultado", "a + b")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "function sumar(a, b) {\nresultado = a + b;\n}"
     assert result == expected, "Error en la transpilación de función"
 
@@ -109,14 +109,14 @@ def test_transpilar_funcion():
 def test_transpilar_llamada_funcion():
     nodo = NodoLlamadaFuncion("sumar", ["5", "3"])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     assert result == "sumar(5, 3);", "Error en la transpilación de llamada a función"
 
 
 def test_transpilar_holobit():
     nodo = NodoHolobit("miHolobit", [1, 2, 3])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     assert result == "let miHolobit = new Holobit([1, 2, 3]);", "Error en la transpilación de Holobit"
 
 
@@ -125,7 +125,7 @@ def test_transpilar_holobit():
 def test_transpilar_for():
     nodo = NodoFor("i", "lista", [NodoAsignacion("suma", "suma + i")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "for (let i of lista) {\nsuma = suma + i;\n}"
     assert result == expected, "Error en la transpilación de bucle for"
 
@@ -133,7 +133,7 @@ def test_transpilar_for():
 def test_transpilar_lista():
     nodo = NodoLista(["1", "2", "3"])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "[1, 2, 3]"
     assert result == expected, "Error en la transpilación de lista"
 
@@ -141,7 +141,7 @@ def test_transpilar_lista():
 def test_transpilar_diccionario():
     nodo = NodoDiccionario([("clave1", "valor1"), ("clave2", "valor2")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "{clave1: valor1, clave2: valor2}"
     assert result == expected, "Error en la transpilación de diccionario"
 
@@ -150,7 +150,7 @@ def test_transpilar_clase():
     metodo = NodoMetodo("miMetodo", ["param"], [NodoAsignacion("x", "param + 1")])
     nodo = NodoClase("MiClase", [metodo])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "class MiClase {\nmiMetodo(param) {\nx = param + 1;\n}\n}"
     assert result == expected, "Error en la transpilación de clase"
 
@@ -159,7 +159,7 @@ def test_transpilar_clase_multibase():
     metodo = NodoMetodo("m", ["p"], [NodoAsignacion("x", "p")])
     nodo = NodoClase("Hija", [metodo], ["Base1", "Base2"])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     imports = "".join(f"{line}\n" for line in get_standard_imports("js"))
     expected = (
         imports
@@ -175,6 +175,6 @@ def test_transpilar_clase_multibase():
 def test_transpilar_metodo():
     nodo = NodoMetodo("miMetodo", ["a", "b"], [NodoAsignacion("resultado", "a + b")])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = "miMetodo(a, b) {\nresultado = a + b;\n}"
     assert result == expected, "Error en la transpilación de método"

--- a/tests/unit/test_to_js_objects.py
+++ b/tests/unit/test_to_js_objects.py
@@ -5,12 +5,12 @@ from src.core.ast_nodes import NodoInstancia, NodoLlamadaMetodo, NodoIdentificad
 def test_transpilar_instancia():
     nodo = NodoInstancia("Clase")
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     assert result == "new Clase();"
 
 
 def test_transpilar_llamada_metodo():
     nodo = NodoLlamadaMetodo(NodoIdentificador("obj"), "metodo", [NodoValor(1)])
     transpiler = TranspiladorJavaScript()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     assert result == "obj.metodo(1);"

--- a/tests/unit/test_to_julia.py
+++ b/tests/unit/test_to_julia.py
@@ -5,14 +5,14 @@ from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, 
 def test_transpilador_asignacion_julia():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorJulia()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "x = 10"
 
 
 def test_transpilador_funcion_julia():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     t = TranspiladorJulia()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "function miFuncion(a, b)\n    x = a + b\nend"
     assert resultado == esperado
 
@@ -20,12 +20,12 @@ def test_transpilador_funcion_julia():
 def test_transpilador_llamada_funcion_julia():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     t = TranspiladorJulia()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "miFuncion(a, b)"
 
 
 def test_transpilador_imprimir_julia():
     ast = [NodoImprimir(NodoValor("x"))]
     t = TranspiladorJulia()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "println(x)"

--- a/tests/unit/test_to_latex.py
+++ b/tests/unit/test_to_latex.py
@@ -5,14 +5,14 @@ from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, 
 def test_transpilador_asignacion_latex():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorLatex()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "x = 10"
 
 
 def test_transpilador_funcion_latex():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     t = TranspiladorLatex()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "function miFuncion(a, b)\n    x = a + b\nend"
     assert resultado == esperado
 
@@ -20,12 +20,12 @@ def test_transpilador_funcion_latex():
 def test_transpilador_llamada_funcion_latex():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     t = TranspiladorLatex()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "miFuncion(a, b)"
 
 
 def test_transpilador_imprimir_latex():
     ast = [NodoImprimir(NodoValor("x"))]
     t = TranspiladorLatex()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "\\texttt{x}"

--- a/tests/unit/test_to_matlab.py
+++ b/tests/unit/test_to_matlab.py
@@ -5,14 +5,14 @@ from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, 
 def test_transpilador_asignacion_matlab():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorMatlab()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "x = 10;"
 
 
 def test_transpilador_funcion_matlab():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     t = TranspiladorMatlab()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "function miFuncion(a, b)\n    x = a + b;\nend"
     assert resultado == esperado
 
@@ -20,12 +20,12 @@ def test_transpilador_funcion_matlab():
 def test_transpilador_llamada_funcion_matlab():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     t = TranspiladorMatlab()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "miFuncion(a, b);"
 
 
 def test_transpilador_imprimir_matlab():
     ast = [NodoImprimir(NodoValor("x"))]
     t = TranspiladorMatlab()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "disp(x);"

--- a/tests/unit/test_to_pascal.py
+++ b/tests/unit/test_to_pascal.py
@@ -5,14 +5,14 @@ from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, 
 def test_transpilador_asignacion_pascal():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorPascal()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "x := 10;"
 
 
 def test_transpilador_funcion_pascal():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     t = TranspiladorPascal()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "procedure miFuncion(a, b);\nbegin\n    x := a + b;\nend;"
     assert resultado == esperado
 
@@ -20,12 +20,12 @@ def test_transpilador_funcion_pascal():
 def test_transpilador_llamada_funcion_pascal():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     t = TranspiladorPascal()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "miFuncion(a, b);"
 
 
 def test_transpilador_imprimir_pascal():
     ast = [NodoImprimir(NodoValor("x"))]
     t = TranspiladorPascal()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "writeln(x);"

--- a/tests/unit/test_to_php.py
+++ b/tests/unit/test_to_php.py
@@ -12,14 +12,14 @@ from src.core.ast_nodes import (
 def test_transpilador_asignacion_php():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorPHP()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "$x = 10;"
 
 
 def test_transpilador_funcion_php():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", NodoIdentificador("a"))])]
     t = TranspiladorPHP()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "function miFuncion($a, $b) {\n    $x = $a;\n}"
     assert resultado == esperado
 
@@ -27,13 +27,13 @@ def test_transpilador_funcion_php():
 def test_transpilador_llamada_funcion_php():
     ast = [NodoLlamadaFuncion("miFuncion", [NodoIdentificador("x"), NodoValor(3)])]
     t = TranspiladorPHP()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "miFuncion($x, 3);"
 
 
 def test_transpilador_imprimir_php():
     ast = [NodoImprimir(NodoIdentificador("x"))]
     t = TranspiladorPHP()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "echo $x;"
 

--- a/tests/unit/test_to_python.py
+++ b/tests/unit/test_to_python.py
@@ -21,7 +21,7 @@ from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 def test_transpilador_asignacion():
     ast = [NodoAsignacion("x", NodoValor(10))]
     transpilador = TranspiladorPython()
-    resultado = transpilador.transpilar(ast)
+    resultado = transpilador.generate_code(ast)
     esperado = IMPORTS + "x = 10\n"
     assert resultado == esperado
 
@@ -35,7 +35,7 @@ def test_transpilador_condicional():
         )
     ]
     transpilador = TranspiladorPython()
-    resultado = transpilador.transpilar(ast)
+    resultado = transpilador.generate_code(ast)
     esperado = (
         IMPORTS
         "if x > 5:\n    y = 2\nelse:\n    y = 3\n"
@@ -50,7 +50,7 @@ def test_transpilador_mientras():
         )
     ]
     transpilador = TranspiladorPython()
-    resultado = transpilador.transpilar(ast)
+    resultado = transpilador.generate_code(ast)
     esperado = (
         IMPORTS + "while x > 0:\n    x = x - 1\n"
     )
@@ -66,7 +66,7 @@ def test_transpilador_funcion():
         )
     ]
     transpilador = TranspiladorPython()
-    resultado = transpilador.transpilar(ast)
+    resultado = transpilador.generate_code(ast)
     esperado = (
         IMPORTS
         "def miFuncion(a, b):\n    x = a + b\n"
@@ -77,7 +77,7 @@ def test_transpilador_funcion():
 def test_transpilador_llamada_funcion():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     transpilador = TranspiladorPython()
-    resultado = transpilador.transpilar(ast)
+    resultado = transpilador.generate_code(ast)
     esperado = IMPORTS + "miFuncion(a, b)\n"
     assert resultado == esperado
 
@@ -85,7 +85,7 @@ def test_transpilador_llamada_funcion():
 def test_transpilador_holobit():
     ast = [NodoHolobit("miHolobit", [0.8, -0.5, 1.2])]
     transpilador = TranspiladorPython()
-    resultado = transpilador.transpilar(ast)
+    resultado = transpilador.generate_code(ast)
     esperado = (
         IMPORTS + "miHolobit = holobit([0.8, -0.5, 1.2])\n"
     )
@@ -104,7 +104,7 @@ def test_transpilador_switch():
         )
     ]
     t = TranspiladorPython()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = (
         IMPORTS
         "match x:\n"
@@ -127,7 +127,7 @@ def test_transpilador_decoradores_anidados():
         [NodoImprimir(NodoValor("'hola'"))],
         [decor1, decor2],
     )
-    codigo = TranspiladorPython().transpilar([func])
+    codigo = TranspiladorPython().generate_code([func])
     esperado = (
         IMPORTS
         "@d1\n"
@@ -145,7 +145,7 @@ def test_transpilador_corutina_await():
         [NodoEsperar(NodoLlamadaFuncion("saluda", []))],
         asincronica=True,
     )
-    codigo = TranspiladorPython().transpilar([f1, f2])
+    codigo = TranspiladorPython().generate_code([f1, f2])
     esperado = (
         "import asyncio\n"
         IMPORTS
@@ -163,7 +163,7 @@ def test_transpilador_clase_compleja():
         asincronica=True,
     )
     clase = NodoClase("Hija", [metodo], ["Base1", "Base2"])
-    codigo = TranspiladorPython().transpilar([clase])
+    codigo = TranspiladorPython().generate_code([clase])
     esperado = (
         "import asyncio\n"
         IMPORTS
@@ -179,7 +179,7 @@ def test_decoradores_en_clase_y_metodo():
     metodo.decoradores = [decor]
     clase = NodoClase("C", [metodo])
     clase.decoradores = [decor]
-    codigo = TranspiladorPython().transpilar([clase])
+    codigo = TranspiladorPython().generate_code([clase])
     esperado = (
         "import asyncio\n"
         IMPORTS
@@ -193,5 +193,5 @@ def test_decoradores_en_clase_y_metodo():
 
 
 def test_imports_python_por_defecto():
-    codigo = TranspiladorPython().transpilar([])
+    codigo = TranspiladorPython().generate_code([])
     assert codigo == IMPORTS

--- a/tests/unit/test_to_python2.py
+++ b/tests/unit/test_to_python2.py
@@ -16,7 +16,7 @@ from src.core.ast_nodes import (
 def test_transpilar_asignacion():
     nodo = NodoAsignacion("variable", NodoValor("10"))
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     esperado = IMPORTS + "variable = 10\n"
     assert result == esperado, "Error en la transpilaci\u00f3n de asignaci\u00f3n"
 
@@ -28,7 +28,7 @@ def test_transpilar_condicional():
         [NodoAsignacion("y", NodoValor("0"))],
     )
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
         "if x > 5:\n    y = 10\nelse:\n    y = 0\n"
@@ -39,7 +39,7 @@ def test_transpilar_condicional():
 def test_transpilar_mientras():
     nodo = NodoBucleMientras("i < 10", [NodoAsignacion("i", NodoValor("i + 1"))])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS + "while i < 10:\n    i = i + 1\n"
     )
@@ -49,7 +49,7 @@ def test_transpilar_mientras():
 def test_transpilar_funcion():
     nodo = NodoFuncion("sumar", ["a", "b"], [NodoAsignacion("resultado", NodoValor("a + b"))])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
         "def sumar(a, b):\n    resultado = a + b\n"
@@ -60,7 +60,7 @@ def test_transpilar_funcion():
 def test_transpilar_llamada_funcion():
     nodo = NodoLlamadaFuncion("sumar", ["5", "3"])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     esperado = IMPORTS + "sumar(5, 3)\n"
     assert result == esperado, "Error en la transpilaci\u00f3n de llamada a funci\u00f3n"
 
@@ -68,6 +68,6 @@ def test_transpilar_llamada_funcion():
 def test_transpilar_holobit():
     nodo = NodoHolobit("miHolobit", [1, 2, 3])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     esperado = IMPORTS + "miHolobit = holobit([1, 2, 3])\n"
     assert result == esperado, "Error en la transpilaci\u00f3n de Holobit"

--- a/tests/unit/test_to_python3.py
+++ b/tests/unit/test_to_python3.py
@@ -22,7 +22,7 @@ from src.core.ast_nodes import (
 def test_transpilar_asignacion():
     nodo = NodoAsignacion("variable", NodoValor("10"))
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     esperado = IMPORTS + "variable = 10\n"
     assert result == esperado, "Error en la transpilaci\u00f3n de asignaci\u00f3n"
 
@@ -34,7 +34,7 @@ def test_transpilar_condicional():
         [NodoAsignacion("y", NodoValor("0"))],
     )
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
         "if x > 5:\n    y = 10\nelse:\n    y = 0\n"
@@ -45,7 +45,7 @@ def test_transpilar_condicional():
 def test_transpilar_mientras():
     nodo = NodoBucleMientras("i < 10", [NodoAsignacion("i", NodoValor("i + 1"))])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS + "while i < 10:\n    i = i + 1\n"
     )
@@ -59,7 +59,7 @@ def test_transpilar_funcion():
         [NodoAsignacion("resultado", NodoValor("a + b"))],
     )
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
         "def sumar(a, b):\n    resultado = a + b\n"
@@ -70,7 +70,7 @@ def test_transpilar_funcion():
 def test_transpilar_llamada_funcion():
     nodo = NodoLlamadaFuncion("sumar", ["5", "3"])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     esperado = IMPORTS + "sumar(5, 3)\n"
     assert result == esperado, "Error en la transpilaci\u00f3n de llamada a funci\u00f3n"
 
@@ -78,7 +78,7 @@ def test_transpilar_llamada_funcion():
 def test_transpilar_holobit():
     nodo = NodoHolobit("miHolobit", [1, 2, 3])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     esperado = IMPORTS + "miHolobit = holobit([1, 2, 3])\n"
     assert result == esperado, "Error en la transpilaci\u00f3n de Holobit"
 
@@ -86,7 +86,7 @@ def test_transpilar_holobit():
 def test_transpilar_for():
     nodo = NodoFor("i", "lista", [NodoAsignacion("suma", NodoValor("suma + i"))])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS + "for i in lista:\n    suma = suma + i\n"
     )
@@ -96,7 +96,7 @@ def test_transpilar_for():
 def test_transpilar_lista():
     nodo = NodoLista([NodoValor("1"), NodoValor("2"), NodoValor("3")])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = IMPORTS + "[1, 2, 3]\n"
     assert result == expected, "Error en la transpilaci\u00f3n de lista"
 
@@ -107,7 +107,7 @@ def test_transpilar_diccionario():
         (NodoValor("clave2"), NodoValor("valor2"))
     ])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS + "{clave1: valor1, clave2: valor2}\n"
     )
@@ -118,7 +118,7 @@ def test_transpilar_clase():
     metodo = NodoMetodo("miMetodo", ["param"], [NodoAsignacion("x", NodoValor("param + 1"))])
     nodo = NodoClase("MiClase", [metodo])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
         "class MiClase:\n    def miMetodo(param):\n        x = param + 1\n"
@@ -130,7 +130,7 @@ def test_transpilar_clase_multibase():
     metodo = NodoMetodo("m", ["self"], [NodoRetorno(NodoValor(1))])
     nodo = NodoClase("Hija", [metodo], ["Base1", "Base2"])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
         "class Hija(Base1, Base2):\n    def m(self):\n        return 1\n"
@@ -141,7 +141,7 @@ def test_transpilar_clase_multibase():
 def test_transpilar_metodo():
     nodo = NodoMetodo("miMetodo", ["a", "b"], [NodoAsignacion("resultado", NodoValor("a + b"))])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
         "def miMetodo(a, b):\n    resultado = a + b\n"

--- a/tests/unit/test_to_python4.py
+++ b/tests/unit/test_to_python4.py
@@ -9,7 +9,7 @@ IMPORTS = get_standard_imports("python")
 def test_transpilar_asignacion():
     nodo = NodoAsignacion("variable", NodoValor("10"))
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = IMPORTS + "variable = 10\n"
     assert result == expected, "Error en la transpilación de asignación"
 
@@ -17,7 +17,7 @@ def test_transpilar_asignacion():
 def test_transpilar_condicional():
     nodo = NodoCondicional("x > 5", [NodoAsignacion("y", NodoValor("10"))], [NodoAsignacion("y", NodoValor("0"))])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
         "if x > 5:\n    y = 10\nelse:\n    y = 0\n"
@@ -28,7 +28,7 @@ def test_transpilar_condicional():
 def test_transpilar_mientras():
     nodo = NodoBucleMientras("i < 10", [NodoAsignacion("i", NodoValor("i + 1"))])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = IMPORTS + "while i < 10:\n    i = i + 1\n"
     assert result == expected, "Error en la transpilación de bucle mientras"
 
@@ -36,7 +36,7 @@ def test_transpilar_mientras():
 def test_transpilar_funcion():
     nodo = NodoFuncion("sumar", ["a", "b"], [NodoAsignacion("resultado", NodoValor("a + b"))])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
         "def sumar(a, b):\n    resultado = a + b\n"
@@ -47,7 +47,7 @@ def test_transpilar_funcion():
 def test_transpilar_llamada_funcion():
     nodo = NodoLlamadaFuncion("sumar", ["5", "3"])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = IMPORTS + "sumar(5, 3)\n"
     assert result == expected, "Error en la transpilación de llamada a función"
 
@@ -55,7 +55,7 @@ def test_transpilar_llamada_funcion():
 def test_transpilar_holobit():
     nodo = NodoHolobit([NodoValor(1), NodoValor(2), NodoValor(3)])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = IMPORTS + "holobit([1, 2, 3])\n"
     assert result == expected, "Error en la transpilación de holobit"
 
@@ -63,7 +63,7 @@ def test_transpilar_holobit():
 def test_transpilar_for():
     nodo = NodoFor("i", "lista", [NodoAsignacion("suma", NodoValor("suma + i"))])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS + "for i in lista:\n    suma = suma + i\n"
     )
@@ -73,7 +73,7 @@ def test_transpilar_for():
 def test_transpilar_lista():
     nodo = NodoLista([NodoValor("1"), NodoValor("2"), NodoValor("3")])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = IMPORTS + "[1, 2, 3]\n"
     assert result == expected, "Error en la transpilación de lista"
 
@@ -81,7 +81,7 @@ def test_transpilar_lista():
 def test_transpilar_diccionario():
     nodo = NodoDiccionario([(NodoValor("clave1"), NodoValor("valor1")), (NodoValor("clave2"), NodoValor("valor2"))])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS + "{clave1: valor1, clave2: valor2}\n"
     )
@@ -92,7 +92,7 @@ def test_transpilar_clase():
     metodo = NodoMetodo("mi_metodo", ["param"], [NodoAsignacion("x", NodoValor("param + 1"))])
     nodo = NodoClase("MiClase", [metodo])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
         "class MiClase:\n    def mi_metodo(param):\n        x = param + 1\n"
@@ -104,7 +104,7 @@ def test_transpilar_clase_multibase():
     metodo = NodoMetodo("m", ["self"], [NodoRetorno(NodoValor(1))])
     nodo = NodoClase("Hija", [metodo], ["Base1", "Base2"])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
         "class Hija(Base1, Base2):\n    def m(self):\n        return 1\n"
@@ -115,7 +115,7 @@ def test_transpilar_clase_multibase():
 def test_transpilar_metodo():
     nodo = NodoMetodo("mi_metodo", ["a", "b"], [NodoAsignacion("resultado", NodoValor("a + b"))])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
         "def mi_metodo(a, b):\n    resultado = a + b\n"

--- a/tests/unit/test_to_python_extras.py
+++ b/tests/unit/test_to_python_extras.py
@@ -20,7 +20,7 @@ def test_transpilar_try_catch_throw():
         "e",
         [NodoImprimir(NodoIdentificador("e"))],
     )
-    codigo = TranspiladorPython().transpilar([nodo])
+    codigo = TranspiladorPython().generate_code([nodo])
     esperado = (
         IMPORTS
         "try:\n    raise Exception(1)\nexcept Exception as e:\n    print(e)\n"
@@ -32,14 +32,14 @@ def test_transpilar_import(tmp_path):
     mod = tmp_path / "mod.co"
     mod.write_text("var dato = 5")
     nodo = NodoImport(str(mod))
-    codigo = TranspiladorPython().transpilar([nodo])
+    codigo = TranspiladorPython().generate_code([nodo])
     esperado = IMPORTS + "dato = 5\n"
     assert codigo == esperado
 
 
 def test_transpilar_usar():
     nodo = NodoUsar("math")
-    codigo = TranspiladorPython().transpilar([nodo])
+    codigo = TranspiladorPython().generate_code([nodo])
     esperado = (
         IMPORTS
         "from src.cobra.usar_loader import obtener_modulo\n"

--- a/tests/unit/test_to_python_nuevos.py
+++ b/tests/unit/test_to_python_nuevos.py
@@ -6,7 +6,7 @@ from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 
 def test_transpilar_afirmar():
     nodo = NodoAssert(NodoValor("True"))
-    codigo = TranspiladorPython().transpilar([nodo])
+    codigo = TranspiladorPython().generate_code([nodo])
     assert "assert True" in codigo
 
 

--- a/tests/unit/test_to_python_objects.py
+++ b/tests/unit/test_to_python_objects.py
@@ -8,7 +8,7 @@ from src.core.ast_nodes import NodoInstancia, NodoLlamadaMetodo, NodoIdentificad
 def test_transpilar_instancia():
     nodo = NodoInstancia("Clase")
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     esperado = IMPORTS + "Clase()\n"
     assert result == esperado
 
@@ -16,6 +16,6 @@ def test_transpilar_instancia():
 def test_transpilar_llamada_metodo():
     nodo = NodoLlamadaMetodo(NodoIdentificador("obj"), "metodo", [NodoValor(1)])
     transpiler = TranspiladorPython()
-    result = transpiler.transpilar([nodo])
+    result = transpiler.generate_code([nodo])
     esperado = IMPORTS + "obj.metodo(1)\n"
     assert result == esperado

--- a/tests/unit/test_to_r.py
+++ b/tests/unit/test_to_r.py
@@ -5,14 +5,14 @@ from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, 
 def test_transpilador_asignacion_r():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorR()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "x <- 10"
 
 
 def test_transpilador_funcion_r():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     t = TranspiladorR()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "miFuncion <- function(a, b) {\n    x <- a + b\n}"
     assert resultado == esperado
 
@@ -20,12 +20,12 @@ def test_transpilador_funcion_r():
 def test_transpilador_llamada_funcion_r():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     t = TranspiladorR()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "miFuncion(a, b)"
 
 
 def test_transpilador_imprimir_r():
     ast = [NodoImprimir(NodoValor("x"))]
     t = TranspiladorR()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "print(x)"

--- a/tests/unit/test_to_ruby.py
+++ b/tests/unit/test_to_ruby.py
@@ -5,14 +5,14 @@ from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, 
 def test_transpilador_asignacion_ruby():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorRuby()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "x = 10"
 
 
 def test_transpilador_funcion_ruby():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     t = TranspiladorRuby()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "def miFuncion(a, b)\n    x = a + b\nend"
     assert resultado == esperado
 
@@ -20,12 +20,12 @@ def test_transpilador_funcion_ruby():
 def test_transpilador_llamada_funcion_ruby():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     t = TranspiladorRuby()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "miFuncion(a, b)"
 
 
 def test_transpilador_imprimir_ruby():
     ast = [NodoImprimir(NodoValor("x"))]
     t = TranspiladorRuby()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "puts x"

--- a/tests/unit/test_to_rust.py
+++ b/tests/unit/test_to_rust.py
@@ -22,7 +22,7 @@ from src.core.ast_nodes import (
 def test_transpilador_asignacion():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorRust()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "let x = 10;"
 
 
@@ -35,7 +35,7 @@ def test_transpilador_condicional():
         )
     ]
     t = TranspiladorRust()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "if x > 5 {\n    let y = 2;\n} else {\n    let y = 3;\n}"
     assert resultado == esperado
 
@@ -43,7 +43,7 @@ def test_transpilador_condicional():
 def test_transpilador_mientras():
     ast = [NodoBucleMientras("x > 0", [NodoAsignacion("x", "x - 1")])]
     t = TranspiladorRust()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "while x > 0 {\n    let x = x - 1;\n}"
     assert resultado == esperado
 
@@ -51,7 +51,7 @@ def test_transpilador_mientras():
 def test_transpilador_funcion():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     t = TranspiladorRust()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "fn miFuncion(a, b) {\n    let x = a + b;\n}"
     assert resultado == esperado
 
@@ -59,21 +59,21 @@ def test_transpilador_funcion():
 def test_transpilador_llamada_funcion():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     t = TranspiladorRust()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "miFuncion(a, b);"
 
 
 def test_transpilador_holobit():
     ast = [NodoHolobit("miHolobit", [0.8, -0.5, 1.2])]
     t = TranspiladorRust()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "let miHolobit = holobit(vec![0.8, -0.5, 1.2]);"
 
 def test_transpilador_clase():
     metodo = NodoMetodo("saludar", ["self"], [NodoAsignacion("x", 1)])
     ast = [NodoClase("Persona", [metodo])]
     t = TranspiladorRust()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = (
         "struct Persona {}\n\n"
         "impl Persona {\n"
@@ -88,7 +88,7 @@ def test_transpilador_clase():
 def test_transpilador_yield():
     ast = [NodoFuncion("generador", [], [NodoYield(NodoValor(1))])]
     t = TranspiladorRust()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "fn generador() {\n    yield 1;\n}"
     assert resultado == esperado
 
@@ -105,7 +105,7 @@ def test_transpilador_switch():
         )
     ]
     t = TranspiladorRust()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = (
         "match x {\n"
         "    1 => {\n"
@@ -128,7 +128,7 @@ def test_try_catch_result():
         [NodoAsignacion("y", NodoIdentificador("e"))],
     )
     t = TranspiladorRust()
-    resultado = t.transpilar([nodo])
+    resultado = t.generate_code([nodo])
     esperado = (
         "let resultado: Result<(), Box<dyn std::error::Error>> = (|| {\n"
         "    return Err(1.into());\n"
@@ -151,7 +151,7 @@ def test_option_some_none():
         NodoAsignacion("b", NodoOption(None)),
     ]
     t = TranspiladorRust()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = "let a = Some(5);\nlet b = None;"
     assert resultado == esperado
 
@@ -172,7 +172,7 @@ def test_option_match():
         ),
     ]
     t = TranspiladorRust()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = (
         "let opt = Some(1);\n"
         "match opt {\n"

--- a/tests/unit/test_to_wasm.py
+++ b/tests/unit/test_to_wasm.py
@@ -12,7 +12,7 @@ from src.cobra.lexico.lexer import Token, TipoToken
 def test_transpilador_asignacion_wasm():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorWasm()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     assert resultado == "(local.set $x (i32.const 10))"
 
 
@@ -24,7 +24,7 @@ def test_transpilador_funcion_wasm():
     )
     ast = [NodoFuncion("sumar", ["a", "b"], [NodoAsignacion("x", expr)])]
     t = TranspiladorWasm()
-    resultado = t.transpilar(ast)
+    resultado = t.generate_code(ast)
     esperado = (
         "(func $sumar (param $a i32) (param $b i32)\n"
         "    (local.set $x (i32.add (local.get $a) (local.get $b)))\n)"

--- a/tests/unit/test_transpiler_operations_extra.py
+++ b/tests/unit/test_transpiler_operations_extra.py
@@ -15,11 +15,11 @@ def test_operacion_binaria_matlab():
         Token(TipoToken.SUMA, "+"),
         NodoIdentificador("b"),
     )
-    codigo = TranspiladorMatlab().transpilar([NodoAsignacion("x", expr)])
+    codigo = TranspiladorMatlab().generate_code([NodoAsignacion("x", expr)])
     assert codigo == "x = a + b;"
 
 
 def test_operacion_unaria_rust():
     expr = NodoOperacionUnaria(Token(TipoToken.NOT, "!"), NodoIdentificador("cond"))
-    codigo = TranspiladorRust().transpilar([NodoAsignacion("y", expr)])
+    codigo = TranspiladorRust().generate_code([NodoAsignacion("y", expr)])
     assert codigo == "let y = !cond;"

--- a/tests/unit/test_try_catch.py
+++ b/tests/unit/test_try_catch.py
@@ -64,7 +64,7 @@ def test_transpiler_python_try_catch():
         [NodoImprimir(NodoIdentificador("e"))],
     )
     tr = TranspiladorPython()
-    codigo = tr.transpilar([nodo])
+    codigo = tr.generate_code([nodo])
     esperado = "try:\n    raise Exception(1)\nexcept Exception as e:\n    print(e)\n"
     assert codigo == esperado
 
@@ -76,7 +76,7 @@ def test_transpiler_js_try_catch():
         [NodoImprimir(NodoIdentificador("e"))],
     )
     tr = TranspiladorJavaScript()
-    codigo = tr.transpilar([nodo])
+    codigo = tr.generate_code([nodo])
     esperado = "try {\nthrow 1;\n}\ncatch (e) {\nconsole.log(e);\n}"
     assert codigo == esperado
 


### PR DESCRIPTION
## Summary
- actualizar la CLI para usar `generate_code`
- modificar todas las pruebas para llamar a `generate_code` en lugar de `transpilar`

## Testing
- `pip install PyYAML tomli`
- `PYTHONPATH=backend/src:backend pytest -q` *(errored: ModuleNotFoundError: No module named 'backend.src.core')*
- `PYTHONPATH=.:backend:backend/src pytest -q tests/unit/test_to_r.py` *(1 failed, 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68681f38a2d48327b87a4166f87db499