### PR TITLE
Actualizar referencias a generate_code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Actualización mayor del lenguaje Cobra y de las herramientas de desarrollo.
 - Documentación reorganizada con nuevos ejemplos.
 - Integración de procesos de lanzamiento automatizados a través de GitHub Actions.
+- Los transpiladores exponen el método `generate_code` y permiten guardar el resultado con `save_file`.
 
 ## v5.6.3 - 2025-07-02
 - Cambios pendientes.

--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -137,7 +137,7 @@ from cobra.parser.parser import Parser
 codigo = "imprimir('hola')"
 parser = Parser(codigo)
 arbol = parser.parsear()
-print(TranspiladorPython().transpilar(arbol))
+print(TranspiladorPython().generate_code(arbol))
 ```
 
 ### Características aún no soportadas

--- a/README.md
+++ b/README.md
@@ -323,9 +323,9 @@ parser = Parser(tokens)
 arbol = parser.parsear()
 print(arbol)
 
-# Transpilación a Python
+# Generación de código en Python
 transpiler = TranspiladorPython()
-codigo_python = transpiler.transpilar(arbol)
+codigo_python = transpiler.generate_code(arbol)
 print(codigo_python)
 ````
 
@@ -348,7 +348,7 @@ para var i en rango(2) :
 '''
 ````
 
-Al transpilar a Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. En Rust se produce código equivalente con `println!`, `while` y `for`. En C++ se obtienen construcciones con `std::cout`, `while` y `for`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust o `holobit({ ... })` en C++. En Go se genera `fmt.Println`, en R se usa `print` y en Julia `println`; en Java se usa `System.out.println`, en COBOL `DISPLAY`, en Fortran `print *` y en Pascal `writeln`, en Ruby `puts`, en PHP `echo`, en Matlab `disp` y en LaTeX `\texttt{}`.
+Al generar código para Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. En Rust se produce código equivalente con `println!`, `while` y `for`. En C++ se obtienen construcciones con `std::cout`, `while` y `for`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust o `holobit({ ... })` en C++. En Go se genera `fmt.Println`, en R se usa `print` y en Julia `println`; en Java se usa `System.out.println`, en COBOL `DISPLAY`, en Fortran `print *` y en Pascal `writeln`, en Ruby `puts`, en PHP `echo`, en Matlab `disp` y en LaTeX `\texttt{}`.
 
 ## Integración con holobit-sdk
 
@@ -425,7 +425,7 @@ codigo = "imprimir('hola')"
 parser = Parser(codigo)
 arbol = parser.parsear()
 transpiler = TranspiladorPython()
-resultado = transpiler.transpilar(arbol)
+resultado = transpiler.generate_code(arbol)
 print(resultado)
 ```
 
@@ -440,13 +440,19 @@ from cobra.transpilers.transpiler.to_php import TranspiladorPHP
 from cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
 from cobra.transpilers.transpiler.to_latex import TranspiladorLatex
 
-codigo_cobol = TranspiladorCOBOL().transpilar(arbol)
-codigo_fortran = TranspiladorFortran().transpilar(arbol)
-codigo_pascal = TranspiladorPascal().transpilar(arbol)
-codigo_ruby = TranspiladorRuby().transpilar(arbol)
-codigo_php = TranspiladorPHP().transpilar(arbol)
-codigo_matlab = TranspiladorMatlab().transpilar(arbol)
-codigo_latex = TranspiladorLatex().transpilar(arbol)
+codigo_cobol = TranspiladorCOBOL().generate_code(arbol)
+codigo_fortran = TranspiladorFortran().generate_code(arbol)
+codigo_pascal = TranspiladorPascal().generate_code(arbol)
+codigo_ruby = TranspiladorRuby().generate_code(arbol)
+codigo_php = TranspiladorPHP().generate_code(arbol)
+codigo_matlab = TranspiladorMatlab().generate_code(arbol)
+codigo_latex = TranspiladorLatex().generate_code(arbol)
+```
+
+Tras obtener el código con ``generate_code`` puedes guardarlo usando ``save_file``:
+
+```python
+transpiler.save_file("salida.py")
 ```
 
 Requiere tener instalado el paquete en modo editable y todas las dependencias
@@ -466,7 +472,7 @@ hilo tarea()
 imprimir('principal')
 ````
 
-Al transpilarlas, se generan llamadas `asyncio.create_task` en Python y `Promise.resolve().then` en JavaScript.
+Al generar código para estas funciones, se crean llamadas `asyncio.create_task` en Python y `Promise.resolve().then` en JavaScript.
 
 ## Uso desde la CLI
 

--- a/frontend/docs/arquitectura.rst
+++ b/frontend/docs/arquitectura.rst
@@ -65,7 +65,7 @@ optimizar el rendimiento y evitar fugas de memoria.
  
 Interacción de los módulos
 -------------------------
-El flujo típico comienza con el ``Lexer`` que lee el código fuente y produce tokens. Estos tokens son consumidos por el ``Parser`` para construir el AST. A partir de este árbol el ``Intérprete`` ejecuta cada nodo o, alternativamente, los transpiladores lo recorren para generar código en otros lenguajes. Cuando se activa el modo seguro se aplica una cadena de validadores (ver :doc:`modo_seguro`) antes de ejecutar o transpilar, bloqueando operaciones peligrosas.
+El flujo típico comienza con el ``Lexer`` que lee el código fuente y produce tokens. Estos tokens son consumidos por el ``Parser`` para construir el AST. A partir de este árbol el ``Intérprete`` ejecuta cada nodo o, alternativamente, los transpiladores lo recorren para generar código en otros lenguajes. Cuando se activa el modo seguro se aplica una cadena de validadores (ver :doc:`modo_seguro`) antes de ejecutar o generar código, bloqueando operaciones peligrosas.
 
 
 Patrones de diseño

--- a/frontend/docs/design_patterns.rst
+++ b/frontend/docs/design_patterns.rst
@@ -67,12 +67,12 @@ agregan al diccionario al iniciar el comando.
        TRANSPILERS[ep.name] = cls
 
 Cuando se solicita un lenguaje, se instancia la clase correspondiente y se
-llama a ``transpilar`` sobre el AST:
+llama a ``generate_code`` sobre el AST:
 
 .. code-block:: python
 
    transp = TRANSPILERS[lang]()
-   codigo = transp.transpilar(ast)
+   codigo = transp.generate_code(ast)
 
 Cada transpilador hereda de ``NodeVisitor`` e inyecta las funciones de
 visita desde módulos específicos. Por ejemplo, en el backend de Go se

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -50,7 +50,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
 Introducción
 --------------------
 
-Cobra fue creado con la idea de facilitar la programacion en español, optimizando la gestion de memoria y anadiendo soporte para trabajar con datos de alta complejidad como los holobits. Ademas, ofrece soporte para transpilar a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX, permitiendo su ejecucion en multiples plataformas.
+Cobra fue creado con la idea de facilitar la programacion en español, optimizando la gestion de memoria y anadiendo soporte para trabajar con datos de alta complejidad como los holobits. Ademas, ofrece soporte para generar código en Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX, permitiendo su ejecucion en multiples plataformas.
 
 
 

--- a/frontend/docs/modulos_nativos.rst
+++ b/frontend/docs/modulos_nativos.rst
@@ -113,6 +113,6 @@ Tiempo
 
    dormir(1)
 
-Estas funciones se importan automaticamente al transpilar tanto a Python
-como a JavaScript, por lo que pueden utilizarse directamente en el
+Estas funciones se importan automaticamente al generar código para Python
+y JavaScript, por lo que pueden utilizarse directamente en el
 codigo Cobra.


### PR DESCRIPTION
## Summary
- reemplaza menciones de `transpilar` por `generate_code`
- explica la generación y guardado de código con `save_file`
- ajusta notas de la versión v6.0.0

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_6868adce37f883279f171b75c97f159a