### PR TITLE
Add safety dependency check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
           pip install -e .
           pip install sphinx sphinx-rtd-theme pytest-cov codecov
           pip install pyright
+      - name: Seguridad de dependencias
+        run: |
+          pip install safety
+          safety check --full-report
       - name: Run linters
         run: |
           black --check backend/src


### PR DESCRIPTION
## Summary
- add a step in `.github/workflows/ci.yml` to run `safety check`

## Testing
- `pytest -q` *(fails: 57 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6868b7c89be48327b0fd2f0be186f762