### PR TITLE
Add CodeQL query for AST nodes

### DIFF
--- a/.github/codeql/custom/ast-no-type-validation.ql
+++ b/.github/codeql/custom/ast-no-type-validation.ql
@@ -1,0 +1,27 @@
+import python
+
+/**
+ * Reporta clases que representan nodos de AST cuyo nombre
+ * empieza por "Nodo" y cuyo método __post_init__ no contiene
+ * validación de tipos mediante llamadas a `isinstance` ni
+ * sentencias `assert`.
+ */
+from Class c
+where
+  c.getName().regexp("^Nodo") and
+  not exists(Method m |
+    m.getDeclaringType() = c and
+    m.getName() = "__post_init__" and
+    (
+      // Búsqueda de llamada a builtin isinstance
+      exists(FunctionCall fc |
+        fc.getEnclosingCallable() = m and
+        fc.getTarget().hasQualifiedName("isinstance")
+      ) or
+      // Búsqueda de sentencia assert
+      exists(AssertStmt ast |
+        ast.getEnclosingCallable() = m
+      )
+    )
+  )
+select c, "El nodo del AST carece de validación de tipos"

--- a/.github/codeql/custom/qlpack.yml
+++ b/.github/codeql/custom/qlpack.yml
@@ -1,0 +1,4 @@
+name: custom-queries
+version: 0.0.1
+dependencies:
+  codeql/python-all: '*'


### PR DESCRIPTION
## Summary
- add custom CodeQL query `ast-no-type-validation.ql`
- include a qlpack for custom queries

## Testing
- `codeql pack install .github/codeql/custom` *(fails: Could not create access credentials)*

------
https://chatgpt.com/codex/tasks/task_e_6868c9f60cb483279b3750ae4d2d6e51