### PR TITLE
Add query for codegen exception handling

### DIFF
--- a/.github/codeql/custom/codeql-config.yml
+++ b/.github/codeql/custom/codeql-config.yml
@@ -4,3 +4,4 @@ paths:
   - frontend
 queries:
   - uses: custom/*.ql
+  - uses: custom/missing-codegen-exception.ql

--- a/.github/codeql/custom/missing-codegen-exception.ql
+++ b/.github/codeql/custom/missing-codegen-exception.ql
@@ -1,0 +1,15 @@
+import python
+
+/**
+ * Reporta métodos "generate_code" en los transpiladores que no contienen
+ * sentencias try/except para manejar excepciones durante la generación de código.
+ */
+from Method m, File f
+where
+  m.getName() = "generate_code" and
+  m.getFile() = f and
+  f.getRelativePath().regexp("^backend/src/cobra/transpilers/transpiler/") and
+  not exists(TryStmt t |
+    t.getEnclosingCallable() = m
+  )
+select m, "Falta manejo de excepciones durante la generación de código"


### PR DESCRIPTION
## Summary
- add `missing-codegen-exception.ql` query to detect `generate_code` methods without `try` blocks
- reference new query in CodeQL config

## Testing
- `pytest -q` *(fails: 57 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6868cba2a5a083278ebc7be933be7661