### PR TITLE
Documentar benchtranspilers

### DIFF
--- a/frontend/docs/benchmarking.rst
+++ b/frontend/docs/benchmarking.rst
@@ -102,3 +102,21 @@ Luego lanza el análisis:
 
 Se recomienda alcanzar un porcentaje de detección de mutantes de al
 menos 70 %.
+
+Benchmark de transpiladores
+---------------------------
+
+Para medir la velocidad de cada transpilador puedes ejecutar ``cobra
+benchtranspilers``. Este comando genera programas pequeños, medianos y
+grandes y calcula el tiempo que tarda cada transpilador en producir el
+código de salida.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra benchtranspilers --output transpilers.json
+
+El archivo resultante es una lista de objetos con las claves
+``size`` (tamaño del programa), ``lang`` (lenguaje de salida) y
+``time`` (segundos de ejecución).

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -202,6 +202,18 @@ Ejemplo:
 
    cobra benchmarks --output resultados.json
 
+Subcomando ``benchtranspilers``
+------------------------------
+Mide la velocidad de los distintos transpiladores generando programas de
+tamaño pequeño, mediano y grande. Los tiempos se muestran en formato
+JSON y opcionalmente pueden guardarse con ``--output``.
+
+Ejemplo:
+
+.. code-block:: bash
+
+   cobra benchtranspilers --output transpilers.json
+
 Subcomando ``profile``
 ----------------------
 Ejecuta un archivo Cobra bajo ``cProfile``. Muestra en pantalla las


### PR DESCRIPTION
## Summary
- documentar el benchmark de transpiladores
- agregar subcomando `benchtranspilers` en la ayuda de CLI
- compilar la documentación con Sphinx

## Testing
- `make html`

------
https://chatgpt.com/codex/tasks/task_e_6868e5d971e48327a3ff53b469b87706