### PR TITLE
Agregar documento de caché

### DIFF
--- a/frontend/docs/cache.rst
+++ b/frontend/docs/cache.rst
@@ -1,0 +1,31 @@
+Manejo de la cach\u00e9 del AST
+=============================
+
+La compilaci\u00f3n de archivos Cobra genera árboles de sintaxis abstracta
+(AST) que se guardan para acelerar futuras ejecuciones.
+
+Nombre de los archivos
+----------------------
+
+Cada archivo del directorio de cach\u00e9 recibe por nombre el SHA256
+calculado a partir del c\u00f3digo fuente original y se almacena con
+extensi\u00f3n ``.ast``.
+
+Variable de entorno ``COBRA_AST_CACHE``
+---------------------------------------
+
+Por defecto la cach\u00e9 se coloca en ``cache`` dentro de la ra\u00edz del
+proyecto. Puedes cambiar esta ubicaci\u00f3n defininedo la variable de
+entorno ``COBRA_AST_CACHE`` antes de ejecutar la compilaci\u00f3n.
+
+Limpiar la cach\u00e9
+------------------
+
+Para eliminar todos los archivos ``.ast`` existe el subcomando:
+
+.. code-block:: bash
+
+   cobra cache
+
+que borra los ficheros generados e informa por pantalla que la cach\u00e9 ha
+sido limpiada.

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -37,6 +37,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    paquetes
    cobrahub
    cobra_lock
+   cache
    instalacion_pypi
    primeros_pasos
    como_contribuir


### PR DESCRIPTION
## Summary
- documentar cómo funciona la caché de AST
- enlazar la nueva guía en la página principal

## Testing
- `pytest -q` *(fails: 58 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6868f0ea1a908327b4ab2d3c0a4854bb