### PR TITLE
Actualizar umbral de cobertura a 85

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: make typecheck
       - name: Run tests
         run: pytest --cov=backend/src --cov-report=xml \
-          --cov-report=term-missing --cov-fail-under=80
+          --cov-report=term-missing --cov-fail-under=85
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           pip install -e .
       - name: Run tests
         run: |
-          pytest --cov=backend/src --cov-report=xml
+          pytest --cov=backend/src --cov-report=xml --cov-fail-under=85
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-report

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ help:
 
 coverage:
 	pytest backend/src/tests --cov=backend/src
-	--cov-report=term-missing --cov-fail-under=80
+	--cov-report=term-missing --cov-fail-under=85
 
 lint:
 	flake8 backend/src

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Para ejecutar pruebas unitarias, utiliza pytest:
 
 ````bash
 pytest backend/src/tests --cov=backend/src --cov-report=term-missing \
-  --cov-fail-under=80
+  --cov-fail-under=85
 ````
 
 También puedes ejecutar suites específicas ubicadas en `backend/src/tests`:
@@ -549,7 +549,7 @@ Las pruebas están ubicadas en la carpeta tests/ y utilizan pytest para la ejecu
 
 ````bash
 pytest backend/src/tests --cov=backend/src --cov-report=term-missing \
-  --cov-fail-under=80
+  --cov-fail-under=85
 ````
 
 Algunas pruebas generan código en distintos lenguajes (por ejemplo C++, JavaScript o Go) y verifican que la sintaxis sea correcta. Para que estas pruebas se ejecuten con éxito es necesario contar con los compiladores o intérpretes correspondientes instalados en el sistema, como Node, gcc/g++, Go, etc. Puedes ejecutar todo el conjunto con:
@@ -608,7 +608,7 @@ con los archivos `.po` de traducción y envía un pull request.
 Para obtener un reporte de cobertura en la terminal ejecuta:
 
 ````bash
-pytest --cov=backend/src --cov-report=term-missing --cov-fail-under=80
+pytest --cov=backend/src --cov-report=term-missing --cov-fail-under=85
 ````
 
 ## Caché del AST


### PR DESCRIPTION
## Summary
- ajusta el workflow de CI para exigir cobertura mínima de 85%
- actualiza la regla `coverage` en el `Makefile`
- actualiza las instrucciones de `README` con el nuevo umbral
- añade la verificación de cobertura en el workflow `test.yml`

## Testing
- `pytest --maxfail=1 -q` *(falla: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_686923ead51c8327b3e3955e20803ad3