### PR TITLE
Add tests for parser and transpiler features

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/to_python.py
+++ b/backend/src/cobra/transpilers/transpiler/to_python.py
@@ -244,5 +244,6 @@ TranspiladorPython.visit_assert = visit_assert
 TranspiladorPython.visit_del = visit_del
 TranspiladorPython.visit_global = visit_global
 TranspiladorPython.visit_nolocal = visit_nolocal
+TranspiladorPython.visit_no_local = visit_nolocal
 TranspiladorPython.visit_with = visit_with
 TranspiladorPython.visit_import_desde = visit_import_desde

--- a/tests/unit/test_parser_del_global.py
+++ b/tests/unit/test_parser_del_global.py
@@ -1,0 +1,80 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend" / "src"))
+sys.path.insert(0, str(ROOT))
+import src.core.visitor as _vis
+sys.modules.setdefault("backend.src.core.visitor", _vis)
+sys.modules.setdefault("backend.src.core", sys.modules.get("core"))
+
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from src.core.ast_nodes import (
+    NodoDel,
+    NodoGlobal,
+    NodoNoLocal,
+    NodoWith,
+    NodoPasar,
+    NodoIdentificador,
+)
+from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
+
+
+def test_parser_del():
+    ast = Parser(Lexer("eliminar x").analizar_token()).parsear()
+    assert isinstance(ast[0], NodoDel)
+    assert isinstance(ast[0].objetivo, NodoIdentificador)
+    assert ast[0].objetivo.nombre == "x"
+
+
+def test_parser_global():
+    ast = Parser(Lexer("global a, b").analizar_token()).parsear()
+    assert isinstance(ast[0], NodoGlobal)
+    assert ast[0].nombres == ["a", "b"]
+
+
+def test_parser_nolocal():
+    ast = Parser(Lexer("nolocal c").analizar_token()).parsear()
+    assert isinstance(ast[0], NodoNoLocal)
+    assert ast[0].nombres == ["c"]
+
+
+def test_parser_with():
+    code = "con recurso como r: pasar fin"
+    ast = Parser(Lexer(code).analizar_token()).parsear()
+    assert isinstance(ast[0], NodoWith)
+    assert isinstance(ast[0].contexto, NodoIdentificador)
+    assert ast[0].contexto.nombre == "recurso"
+    assert ast[0].alias == "r"
+    assert len(ast[0].cuerpo) == 1 and isinstance(ast[0].cuerpo[0], NodoPasar)
+
+
+def test_transpilar_del():
+    nodo = NodoDel(NodoIdentificador("x"))
+    codigo = TranspiladorPython().generate_code([nodo])
+    assert codigo == IMPORTS + "del x\n"
+
+
+def test_transpilar_global():
+    nodo = NodoGlobal(["a", "b"])
+    codigo = TranspiladorPython().generate_code([nodo])
+    assert codigo == IMPORTS + "global a, b\n"
+
+
+def test_transpilar_nolocal():
+    nodo = NodoNoLocal(["c"])
+    codigo = TranspiladorPython().generate_code([nodo])
+    assert codigo == IMPORTS + "nonlocal c\n"
+
+
+def test_transpilar_with():
+    nodo = NodoWith(NodoIdentificador("recurso"), "r", [NodoPasar()])
+    codigo = TranspiladorPython().generate_code([nodo])
+    esperado = IMPORTS + "with recurso as r:\n    pass\n"
+    assert codigo == esperado


### PR DESCRIPTION
## Summary
- add unit tests covering Parser handling of `eliminar`, `global`, `nolocal` and `con ... fin`
- verify generated Python code for each new node
- alias `visit_no_local` in `TranspiladorPython` so `NodoNoLocal` nodes are supported

## Testing
- `pytest -q tests/unit/test_parser_del_global.py`

------
https://chatgpt.com/codex/tasks/task_e_68692a779b2883278c66b3aa11d7c823