### PR TITLE
Add parser error handling tests

### DIFF
--- a/backend/src/cobra/parser/parser.py
+++ b/backend/src/cobra/parser/parser.py
@@ -686,6 +686,8 @@ class ClassicParser:
 
     def declaracion_global(self):
         self.comer(TipoToken.GLOBAL)
+        if self.token_actual().tipo != TipoToken.IDENTIFICADOR:
+            raise SyntaxError("Se esperaba al menos un identificador después de 'global'")
         nombres = []
         while self.token_actual().tipo == TipoToken.IDENTIFICADOR:
             nombres.append(self.token_actual().valor)

--- a/tests/unit/test_parser_del_global.py
+++ b/tests/unit/test_parser_del_global.py
@@ -78,3 +78,18 @@ def test_transpilar_with():
     codigo = TranspiladorPython().generate_code([nodo])
     esperado = IMPORTS + "with recurso as r:\n    pass\n"
     assert codigo == esperado
+
+
+def test_parser_del_sin_expresion():
+    with pytest.raises(SyntaxError):
+        Parser(Lexer("eliminar").analizar_token()).parsear()
+
+
+def test_parser_global_sin_identificadores():
+    with pytest.raises(SyntaxError):
+        Parser(Lexer("global").analizar_token()).parsear()
+
+
+def test_parser_con_sin_fin():
+    with pytest.raises(SyntaxError):
+        Parser(Lexer("con x:").analizar_token()).parsear()


### PR DESCRIPTION
## Summary
- raise syntax error when `global` lacks identifiers
- test parsing errors for `eliminar`, `global`, and `con` blocks

## Testing
- `pytest -q tests/unit/test_parser_del_global.py`
- `pytest -q tests/unit/test_parser_del_global.py::test_parser_del_sin_expresion tests/unit/test_parser_del_global.py::test_parser_global_sin_identificadores tests/unit/test_parser_del_global.py::test_parser_con_sin_fin`

------
https://chatgpt.com/codex/tasks/task_e_686932ea4d988327b89861f4d35d4357