### PR TITLE
Add tests for incomplete transpilers

### DIFF
--- a/tests/unit/test_transpiladores_incompletos.py
+++ b/tests/unit/test_transpiladores_incompletos.py
@@ -1,0 +1,38 @@
+import pytest
+
+from src.cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
+from src.cobra.transpilers.transpiler.to_rust import TranspiladorRust
+from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from src.cobra.transpilers.base import BaseTranspiler
+from src.core.ast_nodes import NodoAST, NodoGlobal
+
+
+class NodoInvalido(NodoAST):
+    def aceptar(self, visitante):
+        raise AttributeError("Nodo invalido")
+
+
+class NodoDesconocido(NodoAST):
+    pass
+
+
+def test_transpiladores_cpp_rust_global_vacio():
+    ast = [NodoGlobal(["x"])]
+    assert TranspiladorCPP().generate_code(ast) == ""
+    assert TranspiladorRust().generate_code(ast) == ""
+
+
+def test_transpilador_js_nodo_invalido_attribute_error():
+    with pytest.raises(AttributeError):
+        TranspiladorJavaScript().generate_code([NodoInvalido()])
+
+
+def test_generic_visit_lanza_not_implemented_error():
+    class DummyTranspiler(BaseTranspiler):
+        def generate_code(self, ast):
+            for nodo in ast:
+                nodo.aceptar(self)
+            return ""
+
+    with pytest.raises(NotImplementedError):
+        DummyTranspiler().generate_code([NodoDesconocido()])


### PR DESCRIPTION
## Summary
- create `test_transpiladores_incompletos.py` verifying partial transpilation
- check that JS transpiler raises `AttributeError` for a dummy node
- ensure unknown nodes trigger `NotImplementedError` through `generic_visit`

## Testing
- `PYTHONPATH=/workspace/pCobra:/workspace/pCobra/backend/src pytest tests/unit/test_transpiladores_incompletos.py -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6869377ed8e48327b551767d752496b3