### PR TITLE
Add NodeVisitor generic_visit test

### DIFF
--- a/tests/unit/test_node_visitor.py
+++ b/tests/unit/test_node_visitor.py
@@ -1,0 +1,15 @@
+import pytest
+
+from src.core.visitor import NodeVisitor
+from src.core.ast_nodes import NodoAST
+
+class MiNodo(NodoAST):
+    pass
+
+class MiVisitor(NodeVisitor):
+    pass
+
+def test_generic_visit_se_ejecuta_para_nodo_desconocido():
+    visitante = MiVisitor()
+    with pytest.raises(NotImplementedError):
+        visitante.visit(MiNodo())


### PR DESCRIPTION
## Summary
- add minimal NodeVisitor subclass test
- ensure `generic_visit` raises `NotImplementedError` when visiting an unknown node

## Testing
- `PYTHONPATH=backend/src python -m pytest tests/unit/test_node_visitor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68693b5efc2c832780c344e9f69590f0