### PR TITLE
Add end-to-end integration test

### DIFF
--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,0 +1,51 @@
+import sys
+import shutil
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import backend  # noqa: F401
+from src.cli.cli import main
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from backend.src.core.interpreter import InterpretadorCobra
+from backend.src.core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
+import backend.src.cobra.transpilers.module_map as module_map
+
+RUNNERS = {"python": ejecutar_en_sandbox, "js": ejecutar_en_sandbox_js}
+
+
+@pytest.mark.parametrize("lang", RUNNERS.keys())
+def test_end_to_end(tmp_path, lang, monkeypatch):
+    # Copiar archivo de ejemplo a ruta temporal
+    src_file = Path("tests/data/ejemplo.co")
+    tmp_file = tmp_path / src_file.name
+    tmp_file.write_text(src_file.read_text())
+
+    # Obtener salida del intérprete
+    tokens = Lexer(src_file.read_text()).analizar_token()
+    ast = Parser(tokens).parsear()
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        InterpretadorCobra().ejecutar_ast(ast)
+    esperado = out.getvalue()
+
+    # Parchear dependencias
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: {})
+    monkeypatch.setattr(module_map, "_toml_cache", {}, raising=False)
+
+    # Ejecutar CLI y capturar código generado
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        ret = main(["compilar", str(tmp_file), f"--tipo={lang}"])
+    assert ret == 0
+    codigo_generado = "\n".join(out.getvalue().splitlines()[1:])
+
+    # Verificar disponibilidad de ejecutable externo
+    if lang == "js" and not shutil.which("node"):
+        pytest.skip("node no disponible")
+
+    salida = RUNNERS[lang](codigo_generado)
+    assert salida == esperado


### PR DESCRIPTION
## Summary
- add `tests/integration/test_end_to_end.py`
- implement parametrized test compiling a Cobra program to Python/JS, running the generated code in a sandbox and comparing against the interpreter output

## Testing
- `pytest tests/integration/test_end_to_end.py::test_end_to_end[python] -vv`
- `pytest tests/integration/test_end_to_end.py::test_end_to_end[js] -vv` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68694507f8948327a545e272039e03ae