### PR TITLE
Add Sphinx config for docs and update pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,9 +20,11 @@ jobs:
           pip install sphinx sphinx-rtd-theme
       - name: Build docs
         run: sphinx-build -b html frontend/docs frontend/build/html
+      - name: Build root docs
+        run: sphinx-build -b html docs docs/_build
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: frontend/build/html
+          publish_dir: docs/_build
           publish_branch: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 *.log
 frontend/vscode/node_modules/
 
+# Build directory for Sphinx documentation
+docs/_build/
+
 # Coverage reports
 .coverage
 htmlcov/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,63 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+
+# Setup paths so Sphinx can find the backend package
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+BACKEND_SRC = os.path.join(ROOT_DIR, 'backend', 'src')
+sys.path.insert(0, BACKEND_SRC)
+sys.path.insert(0, ROOT_DIR)
+
+project = 'Proyecto Cobra'
+copyright = '2024, Adolfo González Hernández'
+author = 'Adolfo González Hernández'
+release = '2.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.todo',
+    'sphinx.ext.graphviz',
+    'sphinxcontrib.plantuml',
+]
+
+# Evita errores si los paquetes no están instalados
+autodoc_mock_imports = ['src', 'tests']
+
+# Habilitar la generación automática de autosummary
+autosummary_generate = True
+
+# The master toctree document.
+master_doc = 'MANUAL_COBRA'
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+language = 'es'
+
+# Configuración de catálogos gettext
+locale_dirs = ['locale/']
+gettext_compact = False
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_static_path = ['_static']
+html_theme = 'sphinx_rtd_theme'
+html_css_files = ['custom.css']
+
+# Configuración de PlantUML
+plantuml = 'plantuml'
+plantuml_output_format = 'png'


### PR DESCRIPTION
## Summary
- add `docs/conf.py` to build docs with Sphinx
- ignore generated build directory
- run `sphinx-build` for `docs` in Pages workflow and deploy its HTML output

## Testing
- `sphinx-build -b html docs docs/_build`
- `sphinx-build -b html frontend/docs frontend/build/html`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68694b8f2a708327913063f40a95e7d5