### PR TITLE
Add language status documentation

### DIFF
--- a/docs/lenguajes.rst
+++ b/docs/lenguajes.rst
@@ -1,0 +1,49 @@
+Estado de los lenguajes soportados
+=================================
+
+En la actualidad Cobra puede generar código para múltiples lenguajes. A
+continuación se lista cada backend y su estado de soporte. Para más
+detalles consulta :doc:`../frontend/docs/backends` y la sección
+*Características Principales* del `README.md <../README.md>`_.
+
+.. list-table:: Estado de los backends
+   :header-rows: 1
+
+   * - Lenguaje
+     - Estado
+   * - Python
+     - Estable
+   * - JavaScript
+     - Estable
+   * - Ensamblador
+     - Cobertura básica
+   * - C
+     - Experimental
+   * - C++
+     - Experimental
+   * - Rust
+     - Parcial
+   * - WebAssembly
+     - Experimental
+   * - Go
+     - Parcial
+   * - R
+     - Parcial
+   * - Julia
+     - Parcial
+   * - Java
+     - Parcial
+   * - COBOL
+     - Parcial
+   * - Fortran
+     - Parcial
+   * - Pascal
+     - Parcial
+   * - Ruby
+     - Parcial
+   * - PHP
+     - Parcial
+   * - Matlab
+     - Parcial
+   * - LaTeX
+     - Parcial

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -17,6 +17,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    design_patterns
    cli
    backends
+   ../../docs/lenguajes
    sintaxis
    avances
    proximos_pasos


### PR DESCRIPTION
## Summary
- document available languages and stability in a new page
- link the new page from the docs index

## Testing
- `pytest -q` *(fails: 59 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68694f2c74888327b950aeec9c114dff