### PR TITLE
Add lenguajes_soportados to main docs toc

### DIFF
--- a/docs/lenguajes_soportados.rst
+++ b/docs/lenguajes_soportados.rst
@@ -1,0 +1,49 @@
+Estado de los lenguajes soportados
+=================================
+
+En la actualidad Cobra puede generar código para múltiples lenguajes. A
+continuación se lista cada backend y su estado de soporte. Para más
+detalles consulta :doc:`../frontend/docs/backends` y la sección
+*Características Principales* del `README.md <../README.md>`_.
+
+.. list-table:: Estado de los backends
+   :header-rows: 1
+
+   * - Lenguaje
+     - Estado
+   * - Python
+     - Estable
+   * - JavaScript
+     - Estable
+   * - Ensamblador
+     - Cobertura básica
+   * - C
+     - Experimental
+   * - C++
+     - Experimental
+   * - Rust
+     - Parcial
+   * - WebAssembly
+     - Experimental
+   * - Go
+     - Parcial
+   * - R
+     - Parcial
+   * - Julia
+     - Parcial
+   * - Java
+     - Parcial
+   * - COBOL
+     - Parcial
+   * - Fortran
+     - Parcial
+   * - Pascal
+     - Parcial
+   * - Ruby
+     - Parcial
+   * - PHP
+     - Parcial
+   * - Matlab
+     - Parcial
+   * - LaTeX
+     - Parcial

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -18,6 +18,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    design_patterns
    cli
    backends
+   ../../docs/lenguajes_soportados
    ../../docs/lenguajes
    sintaxis
    avances


### PR DESCRIPTION
## Summary
- include a new languages list in docs
- reference `lenguajes_soportados` in main toctree

## Testing
- `sphinx-build -b html frontend/docs frontend/docs/_build`
- `sphinx-build -b linkcheck frontend/docs frontend/docs/_build_linkcheck` *(fails: pyinstaller.org blocked, GitHub 404)*

------
https://chatgpt.com/codex/tasks/task_e_68695b1faa948327b8520d722d18b4d6