### PR TITLE
Agregar carpetas de ejemplos avanzados con README

### DIFF
--- a/examples/avanzados/README.md
+++ b/examples/avanzados/README.md
@@ -1,0 +1,18 @@
+# Ejemplos Avanzados
+
+Este directorio contiene programas que muestran aspectos más complejos de Cobra.
+Cada subcarpeta se centra en un tema específico: control de flujo, funciones y
+clases.
+
+## Compilación y ejecución
+
+Para compilar un archivo Cobra a Python y ejecutarlo, usa la interfaz de
+comandos:
+
+```bash
+cobra compilar archivo.co --tipo python > archivo.py
+python archivo.py
+```
+
+Reemplaza `archivo.co` por el ejemplo que quieras probar. La salida se genera
+en `archivo.py` y luego se ejecuta con Python.

--- a/examples/avanzados/clases/README.md
+++ b/examples/avanzados/clases/README.md
@@ -1,0 +1,5 @@
+# Clases
+
+Este directorio contendrá ejemplos de programación orientada a objetos con
+Cobra. Los archivos mostrarán cómo declarar clases, crear instancias y emplear
+métodos y atributos.

--- a/examples/avanzados/control_flujo/README.md
+++ b/examples/avanzados/control_flujo/README.md
@@ -1,0 +1,5 @@
+# Control de Flujo
+
+En este directorio se ubicarán ejemplos que muestran estructuras de control de
+flujo en Cobra, como condicionales y bucles. Cada archivo `.co` demostrará cómo
+utilizar estas herramientas.

--- a/examples/avanzados/funciones/README.md
+++ b/examples/avanzados/funciones/README.md
@@ -1,0 +1,5 @@
+# Funciones
+
+Aquí encontrarás ejemplos relacionados con la definición y el uso de funciones en
+Cobra. Se incluirán casos de parámetros, valores de retorno y funciones
+anónimas.


### PR DESCRIPTION
## Resumen
- crear `examples/avanzados` y subdirectorios
- añadir README principal y README por cada sección

## Testing
- `pytest -q` *(falla: 9 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a00114d188327bd352af67ccd1d11