### PR TITLE
Agregar factorial recursivo con import

### DIFF
--- a/examples/avanzados/funciones/README.md
+++ b/examples/avanzados/funciones/README.md
@@ -3,3 +3,18 @@
 Aquí encontrarás ejemplos relacionados con la definición y el uso de funciones en
 Cobra. Se incluirán casos de parámetros, valores de retorno y funciones
 anónimas.
+
+## Ejemplo de factorial recursivo
+
+`factorial_recursivo.co` importa `utilidades.co` con la instrucción:
+
+```cobra
+import "utilidades.co"
+```
+
+Para compilar y ejecutar el programa utiliza:
+
+```bash
+cobra compilar factorial_recursivo.co --tipo python > factorial_recursivo.py
+python factorial_recursivo.py
+```

--- a/examples/avanzados/funciones/factorial_recursivo.co
+++ b/examples/avanzados/funciones/factorial_recursivo.co
@@ -1,0 +1,11 @@
+import "utilidades.co"
+
+func factorial(n):
+    si n <= 1:
+        retorno 1
+    sino:
+        retorno n * factorial(n - 1)
+    fin
+fin
+
+imprimir factorial(5)

--- a/examples/avanzados/funciones/utilidades.co
+++ b/examples/avanzados/funciones/utilidades.co
@@ -1,0 +1,3 @@
+func es_par(n):
+    retorno n % 2 == 0
+fin


### PR DESCRIPTION
## Summary
- add `utilidades.co` with `es_par`
- add `factorial_recursivo.co` demonstrating recursive call and import
- update README in advanced functions section with compile/run instructions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686a06b8427c83278cd4dcb20547e40a