### PR TITLE
Add OOP class examples

### DIFF
--- a/examples/avanzados/clases/README.md
+++ b/examples/avanzados/clases/README.md
@@ -3,3 +3,20 @@
 Este directorio contendrá ejemplos de programación orientada a objetos con
 Cobra. Los archivos mostrarán cómo declarar clases, crear instancias y emplear
 métodos y atributos.
+
+## Archivos
+
+- `persona.co` define la clase `Persona` con un método `saludar`.
+- `estudiante.co` hereda de `Persona` y añade el método `presentar`.
+- `main.co` crea instancias de `Estudiante` y ejecuta sus métodos.
+
+## Compilación y ejecución
+
+Para compilar cada archivo a Python y ejecutar `main.co` usa:
+
+```bash
+cobra compilar persona.co --tipo python > persona.py
+cobra compilar estudiante.co --tipo python > estudiante.py
+cobra compilar main.co --tipo python > main.py
+python main.py
+```

--- a/examples/avanzados/clases/estudiante.co
+++ b/examples/avanzados/clases/estudiante.co
@@ -1,0 +1,11 @@
+import "persona.co"
+
+clase Estudiante(Persona):
+    metodo __init__(self, nombre, carrera):
+        Persona.__init__(self, nombre)
+        atributo self carrera = carrera
+    metodo presentar(self):
+        self.saludar()
+        imprimir "Estudio " + atributo self carrera
+    fin
+fin

--- a/examples/avanzados/clases/main.co
+++ b/examples/avanzados/clases/main.co
@@ -1,0 +1,7 @@
+import "estudiante.co"
+
+est1 = Estudiante("Ana", "Ingeniería")
+est2 = Estudiante("Luis", "Matemáticas")
+
+est1.presentar()
+est2.presentar()

--- a/examples/avanzados/clases/persona.co
+++ b/examples/avanzados/clases/persona.co
@@ -1,0 +1,7 @@
+clase Persona:
+    metodo __init__(self, nombre):
+        atributo self nombre = nombre
+    metodo saludar(self):
+        imprimir "Hola, soy " + atributo self nombre
+    fin
+fin


### PR DESCRIPTION
## Summary
- add Persona and Estudiante classes with inheritance
- show usage via a main program
- explain how to compile and run these examples

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686a0ead78788327b76d3c5f3d8bbff6