### PR TITLE
Add reference to SPEC_COBRA in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ Gracias por tu interés en mejorar Cobra. A continuación se describen las pauta
 - Usa `make typecheck` para la verificacion de tipos.
 - Para analisis estatico con `pyright`, instala el paquete y ejecuta
   `pyright backend/src` (o `make typecheck`).
+- Cualquier cambio en el lenguaje debe seguir lo descrito en
+  [SPEC_COBRA.md](SPEC_COBRA.md).
 
 ## Ejecutar Pruebas
 


### PR DESCRIPTION
## Summary
- clarify language changes in **CONTRIBUTING.md** to follow `SPEC_COBRA.md`

## Testing
- `make lint` *(fails: E501 line too long and other errors)*
- `pytest` *(fails: 59 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686a30beb780832797f2bc97e2be8283