### PR TITLE
Update CONTRIBUTING with doc issue instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,8 @@ Gracias por tu interés en mejorar Cobra. A continuación se describen las pauta
 1. **Busca duplicados**: antes de abrir un issue verifica si alguien más ya ha reportado el mismo problema o solicitado la misma característica.
 2. **Título claro**: usa un título descriptivo. Si es un error, añade un prefijo `[Bug]`.
 3. **Información útil**: indica la versión de Cobra, sistema operativo y pasos detallados para reproducir el problema. Incluye el comportamiento esperado y lo que realmente ocurre.
-4. **Etiquetas recomendadas**: usa `bug` para reportes de errores, `enhancement` para mejoras y `question` para dudas. Si se trata de documentación, utiliza `documentation`.
+4. **Etiquetas recomendadas**: usa `bug` para reportes de errores, `enhancement` para mejoras y `question` para dudas. Las peticiones de mejora de la documentación deben llevar la etiqueta `documentation`.
+5. **Plantilla de documentación**: si abres un issue relacionado con la documentación, selecciona la plantilla **Documentación**.
 
 ## Convenciones de Estilo
 


### PR DESCRIPTION
## Summary
- clarify doc issue labels
- add instructions to use documentation issue template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `make lint` *(fails: flake8: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686a393be8f88327b75691e9a66412a6