### PR TITLE
Read dependencies from pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ source .venv/bin/activate  # Para Unix
 pip install -r requirements.txt
 ````
 
+   Además del archivo ``requirements.txt`` la CLI consultará
+   ``pyproject.toml`` para incluir las dependencias definidas en
+   las secciones ``project.dependencies`` y
+   ``project.optional-dependencies``.
+
    Esto instalará los paquetes mínimos para ejecutar Cobra:
 
    - `pytest` y complementos para las pruebas automatizadas.
@@ -165,6 +170,8 @@ El proyecto se organiza en las siguientes carpetas y módulos:
 - `tests/`: Incluye pruebas unitarias para asegurar el correcto funcionamiento del código.
 - `README.md`: Documentación del proyecto.
 - `requirements.txt`: Archivo que lista las dependencias del proyecto.
+- `pyproject.toml`: También define dependencias en las secciones
+  ``project.dependencies`` y ``project.optional-dependencies``.
 
 # Características Principales
 

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -81,7 +81,7 @@ Ejemplo:
 Subcomando ``dependencias``
 --------------------------
 Permite listar o instalar las dependencias definidas en
-``requirements.txt``.
+``requirements.txt`` y en ``pyproject.toml``.
 
 Ejemplo:
 

--- a/tests/unit/test_cli_dependencias.py
+++ b/tests/unit/test_cli_dependencias.py
@@ -1,24 +1,48 @@
 from pathlib import Path
 from unittest.mock import patch
-from src.cli.cli import main
+import io
+import tempfile
+from src.cli.commands.dependencias_cmd import DependenciasCommand
 
 
-def test_cli_dependencias_instalar_invoca_pip():
-    with patch("subprocess.run") as mock_run:
-        main(["dependencias", "instalar"])
-        req = Path(__file__).resolve().parents[3] / "requirements.txt"
-        mock_run.assert_called_once_with(["pip", "install", "-r", str(req)], check=True)
-
-
-def test_cli_dependencias_listar_muestra_paquetes(tmp_path, monkeypatch):
+def test_cli_dependencias_instalar_invoca_pip(tmp_path):
     req_file = tmp_path / "requirements.txt"
-    req_file.write_text("paqueteA==1.0\npaqueteB==2.0\n")
-    monkeypatch.setattr(
-        "src.cli.commands.dependencias_cmd.DependenciasCommand._ruta_requirements",
-        lambda: str(req_file),
-    )
+    req_file.write_text("paqueteA==1.0\n")
+    py_file = tmp_path / "pyproject.toml"
+    py_file.write_text("[project]\ndependencies=['paqueteB==2.0']\n")
 
-    with patch("sys.stdout", new_callable=lambda: __import__("io").StringIO()) as out:
-        main(["dependencias", "listar"])
-    salida = out.getvalue().strip().splitlines()
-    assert salida == ["paqueteA==1.0", "paqueteB==2.0"]
+    created = []
+
+    real_ntf = tempfile.NamedTemporaryFile
+
+    def fake_tmp(*a, **k):
+        f = real_ntf(*a, **k)
+        created.append(f)
+        return f
+
+    with patch("src.cli.commands.dependencias_cmd.DependenciasCommand._ruta_requirements", return_value=str(req_file)) as mock_req, \
+         patch("src.cli.commands.dependencias_cmd.DependenciasCommand._ruta_pyproject", return_value=str(py_file)) as mock_proj, \
+         patch("tempfile.NamedTemporaryFile", side_effect=fake_tmp) as mock_tmp, \
+         patch("subprocess.run") as mock_run:
+        DependenciasCommand._instalar_dependencias()
+        tmp_path_generated = created[0].name
+        mock_run.assert_called_once_with(["pip", "install", "-r", tmp_path_generated], check=True)
+        assert mock_req.called
+        assert mock_proj.called
+
+
+def test_cli_dependencias_listar_muestra_paquetes(tmp_path):
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text("paqueteA==1.0\n")
+    py_file = tmp_path / "pyproject.toml"
+    py_file.write_text("[project]\ndependencies=['paqueteB==2.0']\n")
+
+    with patch("src.cli.commands.dependencias_cmd.DependenciasCommand._ruta_requirements", return_value=str(req_file)) as mock_req, \
+         patch("src.cli.commands.dependencias_cmd.DependenciasCommand._ruta_pyproject", return_value=str(py_file)) as mock_proj, \
+         patch("sys.stdout", new_callable=io.StringIO) as out:
+        DependenciasCommand._listar_dependencias()
+        salida = out.getvalue().strip().splitlines()
+        salida = [s.replace("\x1b[92m", "").replace("\x1b[0m", "") for s in salida]
+        assert sorted(salida) == ["paqueteA==1.0", "paqueteB==2.0"]
+        assert mock_req.called
+        assert mock_proj.called


### PR DESCRIPTION
## Summary
- update `DependenciasCommand` to also read dependencies from `pyproject.toml`
- install merged dependencies through a temporary requirements file
- test that requirements and pyproject are consulted
- document the new behaviour in README and CLI docs

## Testing
- `pytest tests/unit/test_cli_dependencias.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a54c1ba7c83279aeaccf477eb3580