### PR TITLE
Add spec and extra data options

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -23,7 +23,7 @@ jobs:
           pip install -e .
           pip install pyinstaller
       - name: Build executable
-        run: cobra empaquetar --output dist
+        run: cobra empaquetar --output dist --add-data all-bytes.dat:all-bytes.dat
       - name: Upload executable
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -22,7 +22,7 @@ jobs:
           pip install -e .
           pip install pyinstaller
       - name: Build executable
-        run: cobra empaquetar --output dist
+        run: cobra empaquetar --output dist --add-data all-bytes.dat:all-bytes.dat
       - name: Upload executable
         uses: actions/upload-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -154,12 +154,20 @@ Solo descarga el archivo correspondiente a tu sistema operativo desde la versió
 más reciente y ejecútalo directamente.
 
 Si prefieres generar el ejecutable manualmente ejecuta desde la raíz del
-repositorio:
+repositorio en tu sistema (Windows, macOS o Linux):
 
 ```bash
+pip install pyinstaller
 cobra empaquetar --output dist
 ```
-El nombre del binario puede ajustarse con la opción `--name`.
+El nombre del binario puede ajustarse con la opción `--name`. También puedes
+usar un archivo `.spec` propio o agregar datos adicionales mediante
+``--spec`` y ``--add-data``:
+
+```bash
+cobra empaquetar --spec build/cobra.spec \
+  --add-data "all-bytes.dat;all-bytes.dat" --output dist
+```
 
 # Estructura del Proyecto
 

--- a/backend/src/cli/commands/empaquetar_cmd.py
+++ b/backend/src/cli/commands/empaquetar_cmd.py
@@ -25,6 +25,17 @@ class EmpaquetarCommand(BaseCommand):
             default="cobra",
             help=_("Nombre del ejecutable resultante"),
         )
+        parser.add_argument(
+            "--spec",
+            help=_("Ruta al archivo .spec a utilizar"),
+        )
+        parser.add_argument(
+            "--add-data",
+            action="append",
+            default=[],
+            metavar="RUTA;DEST",
+            help=_("Datos adicionales a incluir en formato 'src;dest'"),
+        )
         parser.set_defaults(cmd=self)
         return parser
 
@@ -35,19 +46,18 @@ class EmpaquetarCommand(BaseCommand):
         cli_path = os.path.join(raiz, "backend", "src", "cli", "cli.py")
         output = args.output
         nombre = args.name
+        spec = getattr(args, "spec", None)
+        datos = getattr(args, "add_data", [])
         try:
-            subprocess.run(
-                [
-                    "pyinstaller",
-                    "--onefile",
-                    "-n",
-                    nombre,
-                    cli_path,
-                    "--distpath",
-                    output,
-                ],
-                check=True,
-            )
+            cmd = ["pyinstaller"]
+            if spec:
+                cmd.append(spec)
+            else:
+                cmd.extend(["--onefile", "-n", nombre, cli_path])
+            for d in datos:
+                cmd.extend(["--add-data", d])
+            cmd.extend(["--distpath", output])
+            subprocess.run(cmd, check=True)
             mostrar_info(
                 _("Ejecutable generado en {path}").format(
                     path=os.path.join(output, nombre)

--- a/frontend/docs/empaquetar.rst
+++ b/frontend/docs/empaquetar.rst
@@ -16,6 +16,14 @@ El nombre del ejecutable puede cambiarse con ``--name``. Por ejemplo:
 
    cobra empaquetar --name pcobra --output dist
 
+También puedes pasar un archivo ``.spec`` personalizado o incluir archivos
+adicionales en el paquete utilizando ``--spec`` y ``--add-data``:
+
+.. code-block:: bash
+
+   cobra empaquetar --spec build/cobra.spec \
+       --add-data "all-bytes.dat;all-bytes.dat" --output dist
+
 Esto creará un archivo ``cobra`` (o ``cobra.exe`` en Windows) en el directorio
 ``dist``. Se necesita tener ``pyinstaller`` instalado previamente. Puedes
 instalarlo con ``pip install pyinstaller``.
@@ -26,3 +34,13 @@ Requisitos de plataforma
 PyInstaller está disponible para Windows, macOS y Linux. El ejecutable sólo
 funciona en el mismo sistema operativo donde se creó. Si deseas distribuir para
 varias plataformas, debes empaquetar el proyecto en cada una de ellas.
+
+Los pasos para generar el binario son idénticos en los tres sistemas operativos:
+
+.. code-block:: bash
+
+   pip install pyinstaller
+   cobra empaquetar --output dist
+
+En caso de necesitar archivos adicionales o un ``.spec`` propio, utiliza las
+opciones ``--add-data`` y ``--spec`` mostradas anteriormente.

--- a/tests/unit/test_cli_empaquetar.py
+++ b/tests/unit/test_cli_empaquetar.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from io import StringIO
-from unittest.mock import patch, call
+from unittest.mock import patch
 
 from src.cli.cli import main
 
@@ -29,3 +29,47 @@ def test_cli_empaquetar_sin_pyinstaller(tmp_path):
             patch("sys.stdout", new_callable=StringIO) as out:
         main(["empaquetar", f"--output={tmp_path}", "--name", "pcobra"])
     assert "PyInstaller no está instalado" in out.getvalue()
+
+
+def test_cli_empaquetar_con_spec(tmp_path):
+    with patch("subprocess.run") as mock_run:
+        main(["empaquetar", f"--output={tmp_path}", "--spec", "cobra.spec"])
+        mock_run.assert_called_once_with(
+            [
+                "pyinstaller",
+                "cobra.spec",
+                "--distpath",
+                str(tmp_path),
+            ],
+            check=True,
+        )
+
+
+def test_cli_empaquetar_con_datos(tmp_path):
+    with patch("subprocess.run") as mock_run:
+        main([
+            "empaquetar",
+            f"--output={tmp_path}",
+            "--add-data",
+            "foo;bar",
+            "--add-data",
+            "spam;eggs",
+        ])
+        raiz = Path(__file__).resolve().parents[3]
+        cli_path = raiz / "backend" / "src" / "cli" / "cli.py"
+        mock_run.assert_called_once_with(
+            [
+                "pyinstaller",
+                "--onefile",
+                "-n",
+                "cobra",
+                str(cli_path),
+                "--add-data",
+                "foo;bar",
+                "--add-data",
+                "spam;eggs",
+                "--distpath",
+                str(tmp_path),
+            ],
+            check=True,
+        )


### PR DESCRIPTION
## Summary
- allow --spec and --add-data in empaquetar command
- document packaging options in README and empaquetar.rst
- update build-exe and release-binaries workflows with --add-data
- add unit tests for new empaquetar arguments

## Testing
- `pip install -r requirements.txt` *(partial output shown)*
- `pytest tests/unit/test_cli_empaquetar.py -q` *(fails: ModuleNotFoundError: No module named 'src')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686a5b826ce083279ce68e7637c279cf