### PR TITLE
Actualizar ejemplos de plugins y pruebas

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,6 +774,22 @@ entry_points={
 Tras instalar el paquete con `pip install -e .`, Cobra detectará automáticamente
 el nuevo comando.
 
+### Instalación de plugins
+
+Para utilizar un plugin publicado solo necesitas instalar su paquete de
+distribución. Por ejemplo:
+
+```bash
+pip install mi-plugin-cobra
+```
+
+Si estás desarrollando un plugin local puedes hacerlo en modo editable desde su
+directorio:
+
+```bash
+pip install -e ./mi_plugin
+```
+
 Cada plugin se registra junto con su número de versión en un registro interno.
 Puedes ver la lista de plugins disponibles ejecutando:
 

--- a/examples/plugins/hora_plugin.py
+++ b/examples/plugins/hora_plugin.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from src.cli.plugin import PluginCommand
+
+class HoraCommand(PluginCommand):
+    """Muestra la hora actual por pantalla."""
+
+    name = "hora"
+    version = "1.0"
+    author = "Equipo Cobra"
+    description = "Imprime la hora actual"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help=self.description)
+        parser.set_defaults(cmd=self)
+
+    def run(self, args):
+        ahora = datetime.now().strftime("%H:%M:%S")
+        print(f"Hora actual: {ahora}")

--- a/examples/plugins/setup.py
+++ b/examples/plugins/setup.py
@@ -3,11 +3,12 @@ from setuptools import setup
 setup(
     name='ejemplo-plugin-cobra',
     version='1.0',
-    py_modules=['saludo_plugin', 'md2cobra_plugin', 'transpiler_demo'],
+    py_modules=['saludo_plugin', 'md2cobra_plugin', 'hora_plugin', 'transpiler_demo'],
     entry_points={
         'cobra.plugins': [
             'saludo = saludo_plugin:SaludoCommand',
             'md2cobra = md2cobra_plugin:MarkdownToCobraCommand',
+            'hora = hora_plugin:HoraCommand',
         ],
         'cobra.transpilers': [
             'demo = transpiler_demo:TranspiladorDemo',

--- a/frontend/docs/plugins.rst
+++ b/frontend/docs/plugins.rst
@@ -108,3 +108,17 @@ Finalmente, prueba el comando:
 
    ¡Hola desde el plugin de ejemplo!
 
+Ejemplo: mostrar la hora actual
+-------------------------------
+``HoraCommand`` se encuentra en ``examples/plugins/hora_plugin.py`` y muestra
+la hora actual. Tras instalar los ejemplos de plugins con ``pip install -e``
+podrás ejecutar:
+
+.. code-block:: bash
+
+   cobra hora
+
+.. code-block:: text
+
+   Hora actual: 12:34:56
+

--- a/tests/unit/test_cli_plugins_cmd.py
+++ b/tests/unit/test_cli_plugins_cmd.py
@@ -1,9 +1,11 @@
 from io import StringIO
 from unittest.mock import patch
 import importlib.metadata
+import sys
 
 from src.cli.cli import main
 from src.cli.plugin import PluginCommand
+from src.cli.plugin_registry import limpiar_registro
 
 
 class DummyPlugin(PluginCommand):
@@ -28,6 +30,8 @@ class HolaPlugin(PluginCommand):
     def run(self, args):
         print("¡Hola desde un plugin!")
 
+sys.modules.setdefault("src.tests.test_cli_plugins_cmd", sys.modules[__name__])
+
 
 def test_cli_plugins_muestra_registro():
     ep = importlib.metadata.EntryPoint(
@@ -35,6 +39,7 @@ def test_cli_plugins_muestra_registro():
         value="src.tests.test_cli_plugins_cmd:DummyPlugin",
         group="cobra.plugins",
     )
+    limpiar_registro()
     with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["plugins"])
@@ -47,8 +52,17 @@ def test_cli_plugin_ejemplo_hola():
         value="src.tests.test_cli_plugins_cmd:HolaPlugin",
         group="cobra.plugins",
     )
+    limpiar_registro()
     with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["hola"])
     assert "¡Hola desde un plugin!" in out.getvalue().strip()
+
+
+def test_cli_plugins_sin_plugins():
+    limpiar_registro()
+    with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints(())):
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            main(["plugins"])
+    assert "No hay plugins instalados" in out.getvalue()
 

--- a/tests/unit/test_plugin_loader.py
+++ b/tests/unit/test_plugin_loader.py
@@ -9,9 +9,10 @@ from src.cli.plugin_registry import obtener_registro, limpiar_registro
 
 # Añadimos la carpeta de plugins de ejemplo al path para poder importar
 # el plugin md2cobra durante las pruebas.
-ROOT = Path(__file__).resolve().parents[3]
+ROOT = Path(__file__).resolve().parents[2]
 PLUGIN_DIR = ROOT / "examples" / "plugins"
 sys.path.insert(0, str(PLUGIN_DIR))
+sys.modules.setdefault("src.tests.test_plugin_loader", sys.modules[__name__])
 
 class DummyPlugin(PluginCommand):
     name = "dummy"
@@ -47,3 +48,37 @@ def test_descubrir_plugins_md2cobra():
         plugins = descubrir_plugins()
     assert any(p.__class__.__name__ == "MarkdownToCobraCommand" for p in plugins)
     assert obtener_registro() == {"md2cobra": "1.0"}
+
+
+def test_plugin_ruta_invalida():
+    """No se debe cargar un plugin con ruta mal formada."""
+    ep = importlib.metadata.EntryPoint(
+        name="malo",
+        value="invalido",
+        group="cobra.plugins",
+    )
+    with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+        limpiar_registro()
+        plugins = descubrir_plugins()
+    assert plugins == []
+    assert obtener_registro() == {}
+
+
+def test_plugin_sin_atributo_name():
+    class SinNombrePlugin(PluginCommand):
+        version = "1.0"
+        def register_subparser(self, subparsers):
+            pass
+        def run(self, args):
+            pass
+
+    ep = importlib.metadata.EntryPoint(
+        name="noname",
+        value="src.tests.test_plugin_loader:SinNombrePlugin",
+        group="cobra.plugins",
+    )
+    with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+        limpiar_registro()
+        plugins = descubrir_plugins()
+    assert plugins == []
+    assert obtener_registro() == {}


### PR DESCRIPTION
## Resumen
- añadir nuevo plugin `hora` y registrarlo en el `setup.py` de ejemplos
- documentar el ejemplo en `plugins.rst`
- explicar cómo instalar plugins en `README`
- ampliar tests de carga de plugins y comando `plugins`

## Testing
- `PYTHONPATH=backend:. pytest tests/unit/test_plugin_loader.py tests/unit/test_cli_plugins_cmd.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6b0995108327a6c3a75f77d7393a