### PR TITLE
Mejoras en subcomando jupyter y kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ de clases. Cada tema cuenta con su propia carpeta:
 En la carpeta `notebooks/` se incluye el cuaderno `ejemplo_basico.ipynb` con un ejemplo básico de uso de Cobra. Además, los cuadernos de `notebooks/casos_reales/` muestran cómo ejecutar los ejemplos avanzados. Para abrirlo ejecuta:
 
 ```bash
-cobra jupyter
+cobra jupyter --notebook notebooks/ejemplo_basico.ipynb
 ```
-Luego selecciona el archivo desde la interfaz web de Jupyter.
+Si omites el argumento ``--notebook`` se abrirá Jupyter Notebook de manera convencional y podrás escoger el archivo desde la interfaz web.
  
 
 

--- a/backend/src/cli/commands/jupyter_cmd.py
+++ b/backend/src/cli/commands/jupyter_cmd.py
@@ -12,17 +12,24 @@ class JupyterCommand(BaseCommand):
 
     def register_subparser(self, subparsers):
         parser = subparsers.add_parser(self.name, help=_("Inicia Jupyter Notebook"))
+        parser.add_argument(
+            "--notebook",
+            help=_("Ruta del cuaderno a abrir"),
+        )
         parser.set_defaults(cmd=self)
         return parser
 
     def run(self, args):
         try:
             subprocess.run([sys.executable, "-m", "cobra.jupyter_kernel", "install"], check=True)
-            subprocess.run([
+            cmd = [
                 "jupyter",
                 "notebook",
                 "--KernelManager.default_kernel_name=cobra",
-            ], check=True)
+            ]
+            if args.notebook:
+                cmd.append(args.notebook)
+            subprocess.run(cmd, check=True)
             return 0
         except FileNotFoundError:
             mostrar_error(

--- a/backend/src/jupyter_kernel/__init__.py
+++ b/backend/src/jupyter_kernel/__init__.py
@@ -1,6 +1,7 @@
 import sys
 import io
 import contextlib
+from importlib.metadata import PackageNotFoundError, version
 from ipykernel.kernelbase import Kernel
 from src.cobra.lexico.lexer import Lexer
 from src.cobra.parser.parser import Parser, PALABRAS_RESERVADAS
@@ -8,17 +9,28 @@ from src.core.interpreter import InterpretadorCobra
 from src.core.qualia_bridge import get_suggestions
 
 
+def _get_version() -> str:
+    """Obtiene la versión instalada del paquete."""
+    try:
+        return version("cobra-lenguaje")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+__version__ = _get_version()
+
+
 def install(user=True):
     """Instala el kernel de Cobra para Jupyter."""
-    from ipykernel.kernelspec import install as ipy_install
-    return ipy_install(user=user, kernel_name="cobra", display_name="Cobra")
+    from jupyter_client.kernelspec import install as jupyter_install
+    return jupyter_install(user=user, kernel_name="cobra", display_name="Cobra")
 
 
 class CobraKernel(Kernel):
     implementation = "Cobra"
-    implementation_version = "7.0.0"
+    implementation_version = __version__
     language = "cobra"
-    language_version = "7.0.0"
+    language_version = __version__
     language_info = {
         "name": "cobra",
         "mimetype": "text/plain",

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -144,11 +144,13 @@ Subcomando ``jupyter``
 ---------------------
 Instala el kernel Cobra y abre ``Jupyter Notebook``.
 
+Opcionalmente se puede indicar un cuaderno concreto con ``--notebook``.
+
 Ejemplo:
 
 .. code-block:: bash
 
-   cobra jupyter
+   cobra jupyter --notebook ruta/al/cuaderno.ipynb
 
 Subcomando ``gui``
 -----------------

--- a/tests/unit/test_cli_jupyter.py
+++ b/tests/unit/test_cli_jupyter.py
@@ -14,3 +14,17 @@ def test_cli_jupyter_installs_kernel():
                 "--KernelManager.default_kernel_name=cobra",
             ], check=True),
         ])
+
+
+def test_cli_jupyter_opens_specific_notebook():
+    with patch("subprocess.run") as mock_run:
+        main(["jupyter", "--notebook=demo.ipynb"])
+        mock_run.assert_has_calls([
+            call([sys.executable, "-m", "cobra.jupyter_kernel", "install"], check=True),
+            call([
+                "jupyter",
+                "notebook",
+                "--KernelManager.default_kernel_name=cobra",
+                "demo.ipynb",
+            ], check=True),
+        ])


### PR DESCRIPTION
## Summary
- dinamizar versión del kernel y usar `jupyter_client` para la instalación
- permitir indicar notebook en la CLI
- documentar la opción en README y docs/cli.rst
- añadir prueba para abrir un notebook concreto

## Testing
- `PYTHONPATH=$PWD:$PWD/backend:$PWD/backend/src pytest tests/unit/test_cli_jupyter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a7433eee08327b073bb90e8a9fae5