### PR TITLE
Add common subexpression optimization

### DIFF
--- a/backend/src/core/interpreter.py
+++ b/backend/src/core/interpreter.py
@@ -3,7 +3,12 @@
 import os
 
 from src.cobra.lexico.lexer import Token, TipoToken, Lexer
-from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from src.core.optimizations import (
+    optimize_constants,
+    remove_dead_code,
+    inline_functions,
+    eliminate_common_subexpressions,
+)
 from src.core.type_utils import (
     verificar_sumables,
     verificar_numeros,
@@ -195,7 +200,11 @@ class InterpretadorCobra:
         if cpu:
             _lim_cpu(cpu)
 
-        ast = remove_dead_code(inline_functions(optimize_constants(ast)))
+        ast = remove_dead_code(
+            inline_functions(
+                eliminate_common_subexpressions(optimize_constants(ast))
+            )
+        )
         register_execution(str(ast))
         AnalizadorSemantico().analizar(ast)
         for nodo in ast:

--- a/backend/src/core/optimizations/__init__.py
+++ b/backend/src/core/optimizations/__init__.py
@@ -3,5 +3,11 @@
 from .constant_folder import optimize_constants
 from .dead_code import remove_dead_code
 from .inliner import inline_functions
+from .common_subexpr import eliminate_common_subexpressions
 
-__all__ = ["optimize_constants", "remove_dead_code", "inline_functions"]
+__all__ = [
+    "optimize_constants",
+    "remove_dead_code",
+    "inline_functions",
+    "eliminate_common_subexpressions",
+]

--- a/backend/src/core/optimizations/common_subexpr.py
+++ b/backend/src/core/optimizations/common_subexpr.py
@@ -1,0 +1,143 @@
+"""Eliminación de subexpresiones comunes para Cobra."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from ..visitor import NodeVisitor
+from ..ast_nodes import (
+    NodoAsignacion,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoIdentificador,
+    NodoValor,
+    NodoFuncion,
+    NodoMetodo,
+)
+
+
+def _expr_key(expr: Any):
+    if isinstance(expr, NodoOperacionBinaria):
+        return (
+            "bin",
+            expr.operador.tipo,
+            _expr_key(expr.izquierda),
+            _expr_key(expr.derecha),
+        )
+    if isinstance(expr, NodoOperacionUnaria):
+        return ("un", expr.operador.tipo, _expr_key(expr.operando))
+    if isinstance(expr, NodoIdentificador):
+        return ("id", expr.nombre)
+    if isinstance(expr, NodoValor):
+        return ("val", expr.valor)
+    return expr.__class__.__name__
+
+
+class _ExprCounter(NodeVisitor):
+    def __init__(self) -> None:
+        self.counts: dict[Any, int] = {}
+
+    def visit_operacion_binaria(self, nodo: NodoOperacionBinaria):
+        key = _expr_key(nodo)
+        self.counts[key] = self.counts.get(key, 0) + 1
+        self.visit(nodo.izquierda)
+        self.visit(nodo.derecha)
+
+    def visit_operacion_unaria(self, nodo: NodoOperacionUnaria):
+        key = _expr_key(nodo)
+        self.counts[key] = self.counts.get(key, 0) + 1
+        self.visit(nodo.operando)
+
+    def generic_visit(self, nodo: Any):
+        for attr, value in list(getattr(nodo, "__dict__", {}).items()):
+            if isinstance(value, list):
+                for v in value:
+                    if hasattr(v, "aceptar"):
+                        self.visit(v)
+            elif hasattr(value, "aceptar"):
+                self.visit(value)
+
+
+class _CommonSubexprEliminator(NodeVisitor):
+    def __init__(self, counts: dict[Any, int]):
+        self.counts = counts
+        self.maps: list[dict[Any, str]] = [{}]
+        self.assigns: list[list[Any]] = [[]]
+
+    # Helpers --------------------------------------------------------------
+    def _current_map(self) -> dict[Any, str]:
+        return self.maps[-1]
+
+    def _current_assigns(self) -> list[Any]:
+        return self.assigns[-1]
+
+    def _replace(self, key: Any, expr: Any):
+        cur = self._current_map()
+        if key not in cur:
+            nombre = f"_cse{len(cur)}"
+            cur[key] = nombre
+            self._current_assigns().append(NodoAsignacion(nombre, expr))
+        return NodoIdentificador(cur[key])
+
+    # Visit methods --------------------------------------------------------
+    def visit_operacion_binaria(self, nodo: NodoOperacionBinaria):
+        nodo.izquierda = self.visit(nodo.izquierda)
+        nodo.derecha = self.visit(nodo.derecha)
+        key = _expr_key(nodo)
+        if self.counts.get(key, 0) > 1:
+            return self._replace(key, NodoOperacionBinaria(nodo.izquierda, nodo.operador, nodo.derecha))
+        return nodo
+
+    def visit_operacion_unaria(self, nodo: NodoOperacionUnaria):
+        nodo.operando = self.visit(nodo.operando)
+        key = _expr_key(nodo)
+        if self.counts.get(key, 0) > 1:
+            return self._replace(key, NodoOperacionUnaria(nodo.operador, nodo.operando))
+        return nodo
+
+    def visit_funcion(self, nodo: NodoFuncion):
+        self.maps.append({})
+        self.assigns.append([])
+        nodo.cuerpo = [self.visit(n) for n in nodo.cuerpo]
+        assigns = self.assigns.pop()
+        self.maps.pop()
+        if assigns:
+            nodo.cuerpo = assigns + nodo.cuerpo
+        return nodo
+
+    def visit_metodo(self, nodo: NodoMetodo):
+        self.maps.append({})
+        self.assigns.append([])
+        nodo.cuerpo = [self.visit(n) for n in nodo.cuerpo]
+        assigns = self.assigns.pop()
+        self.maps.pop()
+        if assigns:
+            nodo.cuerpo = assigns + nodo.cuerpo
+        return nodo
+
+    def generic_visit(self, nodo: Any):
+        for attr, value in list(getattr(nodo, "__dict__", {}).items()):
+            if isinstance(value, list):
+                setattr(nodo, attr, [self.visit(v) if hasattr(v, "aceptar") else v for v in value])
+            elif hasattr(value, "aceptar"):
+                setattr(nodo, attr, self.visit(value))
+        return nodo
+
+
+def eliminate_common_subexpressions(ast: List[Any]):
+    """Reemplaza subexpresiones repetidas por variables temporales."""
+    counter = _ExprCounter()
+    for nodo in ast:
+        counter.visit(nodo)
+    eliminator = _CommonSubexprEliminator(counter.counts)
+    resultado = []
+    for nodo in ast:
+        res = eliminator.visit(nodo)
+        if isinstance(res, list):
+            resultado.extend(res)
+        else:
+            resultado.append(res)
+    asignaciones = eliminator.assigns.pop()
+    if asignaciones:
+        resultado = asignaciones + resultado
+    return resultado

--- a/frontend/docs/optimizaciones.rst
+++ b/frontend/docs/optimizaciones.rst
@@ -1,7 +1,7 @@
 Optimizaciones del AST
 ======================
 
-El proyecto incluye un conjunto de visitantes que mejoran el \ *performance\* del c\ódigo generado o ejecutado. Actualmente existen tres optimizaciones sencillas:
+El proyecto incluye un conjunto de visitantes que mejoran el \ *performance\* del código generado o ejecutado. Actualmente existen cuatro optimizaciones sencillas:
 
 Plegado de constantes
 ---------------------
@@ -14,6 +14,10 @@ Eliminación de código muerto
 Integración de funciones simples
 --------------------------------
 ``inline_functions`` identifica funciones sin parámetros y con un único ``return`` para sustituir sus llamadas por el valor retornado, eliminando además la definición original cuando es posible.
+
+Eliminación de subexpresiones comunes
+------------------------------------
+``eliminate_common_subexpressions`` detecta expresiones idénticas que se repiten dentro de una misma función o en el nivel global. Dichas expresiones se calculan una única vez asignándose a una variable temporal y las repeticiones se reemplazan por el identificador generado.
 
 Estas optimizaciones se aplican automáticamente antes de ejecutar el intérprete y en los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX.
 


### PR DESCRIPTION
## Summary
- implement `eliminate_common_subexpressions` optimization pass
- expose the new pass in the optimizations package
- apply the pass in the interpreter pipeline
- document the optimization
- test the reduction of duplicated expressions

## Testing
- `python -m pytest tests/unit/test_optimizations.py::test_eliminate_common_subexpressions_global tests/unit/test_optimizations.py::test_eliminate_common_subexpressions_in_function -q`

------
https://chatgpt.com/codex/tasks/task_e_686a77e6766083279fe10e4a6559404a