### PR TITLE
Add threading and compile command stress tests

### DIFF
--- a/tests/unit/test_compile_stress.py
+++ b/tests/unit/test_compile_stress.py
@@ -1,0 +1,47 @@
+import os
+import argparse
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from backend.src.cli.commands.compile_cmd import CompileCommand
+
+
+def _fake_transpile(self, ast):
+    import time
+    time.sleep(0.05)
+    return str(os.getpid())
+
+
+@pytest.mark.timeout(10)
+def test_compile_command_parallel_outputs_unique(tmp_path):
+    archivo = tmp_path / 'c.co'
+    archivo.write_text('var x = 5')
+    args = argparse.Namespace(
+        archivo=str(archivo),
+        tipo='python',
+        backend=None,
+        tipos='python,js,c,cpp',
+    )
+    with patch(
+        'backend.src.cobra.transpilers.transpiler.to_python.TranspiladorPython.transpilar',
+        _fake_transpile,
+    ), patch(
+        'backend.src.cobra.transpilers.transpiler.to_js.TranspiladorJavaScript.transpilar',
+        _fake_transpile,
+    ), patch(
+        'backend.src.cobra.transpilers.transpiler.to_c.TranspiladorC.transpilar',
+        _fake_transpile,
+    ), patch(
+        'backend.src.cobra.transpilers.transpiler.to_cpp.TranspiladorCPP.transpilar',
+        _fake_transpile,
+    ), patch(
+        'backend.src.cobra.transpilers.module_map.get_toml_map',
+        lambda: {},
+    ), patch('sys.stdout', new_callable=StringIO) as out:
+        CompileCommand().run(args)
+
+    lineas = out.getvalue().strip().splitlines()
+    pids = {lineas[1], lineas[3], lineas[5], lineas[7]}
+    assert len(pids) == 4

--- a/tests/unit/test_interpreter_concurrency.py
+++ b/tests/unit/test_interpreter_concurrency.py
@@ -1,0 +1,34 @@
+import pytest
+from src.core.interpreter import InterpretadorCobra
+from src.core.ast_nodes import (
+    NodoAsignacion,
+    NodoValor,
+    NodoFuncion,
+    NodoHilo,
+    NodoLlamadaFuncion,
+    NodoIdentificador,
+)
+
+
+@pytest.mark.timeout(5)
+def test_hilos_preservan_variables_globales_concurrentes():
+    interp = InterpretadorCobra()
+    interp.ejecutar_asignacion(NodoAsignacion('contador', NodoValor(0)))
+    funcion = NodoFuncion(
+        'trabajo',
+        ['n'],
+        [NodoAsignacion('contador', NodoIdentificador('n'))],
+    )
+    interp.ejecutar_funcion(funcion)
+
+    hilos = [
+        interp.ejecutar_hilo(
+            NodoHilo(NodoLlamadaFuncion('trabajo', [NodoValor(i)]))
+        )
+        for i in range(10)
+    ]
+    for h in hilos:
+        h.join()
+
+    assert interp.variables['contador'] == 0
+    assert len(interp.contextos) == 1


### PR DESCRIPTION
## Summary
- add concurrency test for interpreter threads
- add stress test for CompileCommand using multiple parallel languages

## Testing
- `PYTHONPATH=".:backend" pytest tests/unit/test_interpreter_concurrency.py tests/unit/test_compile_stress.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a7cf8a7d08327b6eea200e64f7e11