### PR TITLE
Improve docs for AST cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ pip install -r requirements.txt
 pip install -e .
 ````
 
+6. Ejecuta un programa de prueba para verificar la instalación:
+
+````bash
+echo "imprimir('Hola Cobra')" > hola.co
+cobra ejecutar hola.co
+````
+
 ### Instalación con pipx
 
 [pipx](https://pypa.github.io/pipx/) es una herramienta para instalar y ejecutar aplicaciones de Python de forma aislada y requiere Python 3.6 o superior. Para instalar Cobra con pipx ejecuta:

--- a/frontend/docs/cache.rst
+++ b/frontend/docs/cache.rst
@@ -4,6 +4,11 @@ Manejo de la cach\u00e9 del AST
 La compilaci\u00f3n de archivos Cobra genera árboles de sintaxis abstracta
 (AST) que se guardan para acelerar futuras ejecuciones.
 
+.. note::
+   La cach\u00e9 usa un **checksum** del c\u00f3digo (SHA256) para nombrar los
+   archivos. Puedes modificar la ruta predeterminada con la variable de
+   entorno ``COBRA_AST_CACHE``.
+
 Nombre de los archivos
 ----------------------
 
@@ -15,7 +20,7 @@ Variable de entorno ``COBRA_AST_CACHE``
 ---------------------------------------
 
 Por defecto la cach\u00e9 se coloca en ``cache`` dentro de la ra\u00edz del
-proyecto. Puedes cambiar esta ubicaci\u00f3n defininedo la variable de
+proyecto. Puedes cambiar esta ubicaci\u00f3n definiendo la variable de
 entorno ``COBRA_AST_CACHE`` antes de ejecutar la compilaci\u00f3n.
 
 Limpiar la cach\u00e9


### PR DESCRIPTION
## Summary
- document that the cache uses a SHA256 checksum and is configurable via `COBRA_AST_CACHE`
- fix a typo in `cache.rst`
- add a short example in the installation section of README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686a8bafa494832788b981deb41e0028