### PR TITLE
Update CLI docs with parallel compile example

### DIFF
--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -15,12 +15,19 @@ Opciones principales:
 - ``--tipo``: lenguaje de salida (``python``, ``js``, ``asm``, ``rust``,
   ``cpp``, ``go``, ``ruby``, ``r``, ``julia``, ``java``, ``cobol``,
   ``fortran``, ``pascal``, ``php``, ``matlab``, ``latex``, ``wasm``).
+- ``--tipos``: lista de lenguajes separados por comas para transpilación paralela.
 
 Ejemplo:
 
 .. code-block:: bash
 
    cobra compilar hola.co --tipo python
+
+Otro ejemplo generando varios lenguajes a la vez:
+
+.. code-block:: bash
+
+   cobra compilar hola.co --tipos=python,js,c
 
 Subcomando ``ejecutar``
 ----------------------


### PR DESCRIPTION
## Summary
- document `--tipos` option and show parallel example

## Testing
- `pytest tests/unit/test_cli_compile_parallel.py tests/unit/test_compile_stress.py -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_686a8e4ab1a08327b56474949de149fa