### PR TITLE
Update docs for plugin registry versioning

### DIFF
--- a/frontend/docs/plugin_sdk.rst
+++ b/frontend/docs/plugin_sdk.rst
@@ -76,3 +76,18 @@ Al instanciarse, cada plugin registra su nombre y versión en el
 
 Si actualizas el paquete con una nueva versión, el registro se actualiza de
 forma automática cuando Cobra vuelve a cargar el plugin.
+
+Registro y versionado de plugins
+--------------------------------
+
+Puedes inspeccionar los plugins cargados y sus versiones mediante el
+registro interno. Importa la función ``obtener_registro`` y
+muestra su contenido:
+
+.. code-block:: python
+
+   from src.cli.plugin import obtener_registro
+
+   for nombre, version in obtener_registro().items():
+       print(nombre, version)
+


### PR DESCRIPTION
## Summary
- document how to query plugin registry

## Testing
- `pytest tests/unit/test_plugin_loader.py tests/unit/test_cli_plugins_cmd.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a95bb9460832795a467d03cf55e00