### PR TITLE
Mejora comando plugins y documentación

### DIFF
--- a/backend/src/cli/commands/plugins_cmd.py
+++ b/backend/src/cli/commands/plugins_cmd.py
@@ -1,6 +1,6 @@
 from .base import BaseCommand
 from ..i18n import _
-from ..plugin_registry import obtener_registro
+from ..plugin_registry import obtener_registro_detallado
 from ..utils.messages import mostrar_info
 
 
@@ -15,11 +15,16 @@ class PluginsCommand(BaseCommand):
         return parser
 
     def run(self, args):
-        registro = obtener_registro()
+        registro = obtener_registro_detallado()
         if not registro:
             mostrar_info(_("No hay plugins instalados"))
         else:
-            for nombre, version in registro.items():
-                mostrar_info(f"{nombre} {version}")
+            for nombre, datos in registro.items():
+                version = datos.get("version", "")
+                descripcion = datos.get("description", "")
+                if descripcion:
+                    mostrar_info(f"{nombre} {version} - {descripcion}")
+                else:
+                    mostrar_info(f"{nombre} {version}")
         return 0
 

--- a/backend/src/cli/plugin.py
+++ b/backend/src/cli/plugin.py
@@ -96,7 +96,8 @@ def cargar_plugin_seguro(ruta: str):
         return None
 
     version = getattr(instancia, "version", "0")
-    registrar_plugin(instancia.name, version)
+    description = getattr(instancia, "description", "")
+    registrar_plugin(instancia.name, version, description)
     return instancia
 
 
@@ -107,4 +108,5 @@ __all__ = [
     "cargar_plugin_seguro",
     "registrar_plugin",
     "obtener_registro",
+    "obtener_registro_detallado",
 ]

--- a/backend/src/cli/plugin_registry.py
+++ b/backend/src/cli/plugin_registry.py
@@ -1,16 +1,21 @@
-"""Registro en memoria de plugins y versiones."""
+"""Registro en memoria de plugins y metadatos."""
 
 _registry = {}
 
 
-def registrar_plugin(nombre: str, version: str) -> None:
-    """Registra un plugin con su versión."""
-    _registry[nombre] = version
+def registrar_plugin(nombre: str, version: str, description: str = "") -> None:
+    """Registra un plugin con su versión y descripción."""
+    _registry[nombre] = {"version": version, "description": description}
 
 
 def obtener_registro():
-    """Devuelve una copia del registro de plugins."""
-    return dict(_registry)
+    """Devuelve un diccionario nombre -> versión."""
+    return {k: v["version"] for k, v in _registry.items()}
+
+
+def obtener_registro_detallado():
+    """Devuelve una copia completa del registro de plugins."""
+    return {k: v.copy() for k, v in _registry.items()}
 
 
 def limpiar_registro() -> None:

--- a/frontend/docs/plugins.rst
+++ b/frontend/docs/plugins.rst
@@ -12,6 +12,10 @@ plugins están disponibles se proporciona el subcomando ``plugins``::
 
    cobra plugins
 
+.. code-block:: text
+
+   saludo 1.0 - Comando de saludo de ejemplo
+
 Guía paso a paso
 ----------------
 


### PR DESCRIPTION
## Summary
- registrar descripción y versión de cada plugin
- mostrar descripción en `cobra plugins` si está disponible
- ampliar la información en la documentación de plugins

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_686a994508c083278a89bebd627fc311