### PR TITLE
Add twine check step and document tagging process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install build twine
           python -m build
+          twine check dist/*
           twine upload dist/*
       - name: Build and push Docker image
         env:

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ GitHub Actions. Puedes encontrarlos en la pestaña
 Solo descarga el archivo correspondiente a tu sistema operativo desde la versión
 más reciente y ejecútalo directamente.
 
+Crear un tag `vX.Y.Z` en GitHub desencadena la publicación automática del
+paquete en PyPI y la actualización de la imagen Docker.
+
 Si prefieres generar el ejecutable manualmente ejecuta desde la raíz del
 repositorio en tu sistema (Windows, macOS o Linux):
 


### PR DESCRIPTION
## Summary
- verify artifacts with `twine check dist/*` in the release workflow
- note in README that pushing a tag `vX.Y.Z` triggers automatic publishing

## Testing
- `pytest -q` *(fails: 60 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ce44523a48327aa7d155fdb9eac2b