### PR TITLE
Add extra transpiler tests

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,8 @@
+import importlib, sys
+try:
+    core = importlib.import_module('backend.src.core')
+    sys.modules.setdefault('src.core', core)
+    if hasattr(core, 'ast_nodes'):
+        sys.modules.setdefault('src.core.ast_nodes', core.ast_nodes)
+except Exception:
+    pass

--- a/tests/unit/test_to_fortran.py
+++ b/tests/unit/test_to_fortran.py
@@ -1,10 +1,15 @@
 from src.cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
+from backend.src.cobra.lexico.lexer import TipoToken, Token
 from src.core.ast_nodes import (
     NodoAsignacion,
     NodoFuncion,
     NodoLlamadaFuncion,
     NodoImprimir,
     NodoValor,
+    NodoIdentificador,
+    NodoAtributo,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
 )
 
 
@@ -35,3 +40,30 @@ def test_transpilador_imprimir_fortran():
     t = TranspiladorFortran()
     resultado = t.generate_code(ast)
     assert resultado == "print *, x"
+
+
+def test_fortran_atributo_y_operaciones():
+    ast = [
+        NodoAsignacion(
+            NodoAtributo(NodoIdentificador("obj"), "campo"),
+            NodoValor(5),
+        ),
+        NodoAsignacion(
+            "a",
+            NodoOperacionBinaria(
+                NodoValor(1), Token(TipoToken.SUMA, "+"), NodoValor(2)
+            ),
+        ),
+        NodoAsignacion(
+            "b",
+            NodoOperacionUnaria(Token(TipoToken.NOT, ".NOT."), NodoIdentificador("c")),
+        ),
+    ]
+    t = TranspiladorFortran()
+    resultado = t.generate_code(ast)
+    esperado = (
+        "obj%campo = 5\n"
+        "a = 1 + 2\n"
+        "b = .NOT. c"
+    )
+    assert resultado == esperado

--- a/tests/unit/test_to_pascal.py
+++ b/tests/unit/test_to_pascal.py
@@ -1,5 +1,16 @@
+from backend.src.cobra.lexico.lexer import TipoToken, Token
 from src.cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
-from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+from src.core.ast_nodes import (
+    NodoAsignacion,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoImprimir,
+    NodoValor,
+    NodoIdentificador,
+    NodoAtributo,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+)
 
 
 def test_transpilador_asignacion_pascal():
@@ -29,3 +40,30 @@ def test_transpilador_imprimir_pascal():
     t = TranspiladorPascal()
     resultado = t.generate_code(ast)
     assert resultado == "writeln(x);"
+
+
+def test_pascal_atributo_y_operaciones():
+    ast = [
+        NodoAsignacion(
+            NodoAtributo(NodoIdentificador("obj"), "campo"),
+            NodoValor(5),
+        ),
+        NodoAsignacion(
+            "a",
+            NodoOperacionBinaria(
+                NodoValor(1), Token(TipoToken.SUMA, "+"), NodoValor(2)
+            ),
+        ),
+        NodoAsignacion(
+            "b",
+            NodoOperacionUnaria(Token(TipoToken.NOT, "not"), NodoIdentificador("c")),
+        ),
+    ]
+    t = TranspiladorPascal()
+    resultado = t.generate_code(ast)
+    esperado = (
+        "obj.campo := 5;\n"
+        "a := 1 + 2;\n"
+        "b := not c;"
+    )
+    assert resultado == esperado

--- a/tests/unit/test_to_php.py
+++ b/tests/unit/test_to_php.py
@@ -1,4 +1,5 @@
 from src.cobra.transpilers.transpiler.to_php import TranspiladorPHP
+from backend.src.cobra.lexico.lexer import TipoToken, Token
 from src.core.ast_nodes import (
     NodoAsignacion,
     NodoFuncion,
@@ -6,6 +7,9 @@ from src.core.ast_nodes import (
     NodoImprimir,
     NodoValor,
     NodoIdentificador,
+    NodoAtributo,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
 )
 
 
@@ -36,4 +40,31 @@ def test_transpilador_imprimir_php():
     t = TranspiladorPHP()
     resultado = t.generate_code(ast)
     assert resultado == "echo $x;"
+
+
+def test_php_atributo_y_operaciones():
+    ast = [
+        NodoAsignacion(
+            NodoAtributo(NodoIdentificador("obj"), "campo"),
+            NodoValor(5),
+        ),
+        NodoAsignacion(
+            "a",
+            NodoOperacionBinaria(
+                NodoValor(1), Token(TipoToken.SUMA, "+"), NodoValor(2)
+            ),
+        ),
+        NodoAsignacion(
+            "b",
+            NodoOperacionUnaria(Token(TipoToken.NOT, "!"), NodoIdentificador("c")),
+        ),
+    ]
+    t = TranspiladorPHP()
+    resultado = t.generate_code(ast)
+    esperado = (
+        "$obj->campo = 5;\n"
+        "$a = 1 + 2;\n"
+        "$b = !$c;"
+    )
+    assert resultado == esperado
 

--- a/tests/unit/test_to_rust.py
+++ b/tests/unit/test_to_rust.py
@@ -13,6 +13,12 @@ from src.core.ast_nodes import (
     NodoTryCatch,
     NodoThrow,
     NodoIdentificador,
+    NodoLista,
+    NodoDiccionario,
+    NodoAssert,
+    NodoDel,
+    NodoWith,
+    NodoImportDesde,
     NodoOption,
     NodoSwitch,
     NodoCase,
@@ -183,6 +189,43 @@ def test_option_match():
         "        let y = 0;\n"
         "    },\n"
         "}"
+    )
+    assert resultado == esperado
+
+
+def test_transpilador_assert_del_with_import():
+    ast = [
+        NodoAssert(NodoValor(True)),
+        NodoDel(NodoIdentificador("x")),
+        NodoWith(None, None, [NodoAsignacion("y", NodoValor(1))]),
+        NodoImportDesde("mod", "func"),
+    ]
+    t = TranspiladorRust()
+    resultado = t.generate_code(ast)
+    esperado = (
+        "assert!(True);\n"
+        "// del x\n"
+        "{\n"
+        "    let y = 1;\n"
+        "}\n"
+        "use mod::func;"
+    )
+    assert resultado == esperado
+
+
+def test_obtener_valor_listas_diccionarios():
+    ast = [
+        NodoAsignacion("a", NodoLista([NodoValor(1), NodoValor(2)])),
+        NodoAsignacion(
+            "b",
+            NodoDiccionario([(NodoValor("x"), NodoValor(1))]),
+        ),
+    ]
+    t = TranspiladorRust()
+    resultado = t.generate_code(ast)
+    esperado = (
+        "let a = vec![1, 2];\n"
+        "let b = std::collections::HashMap::from([(x, 1)]);"
     )
     assert resultado == esperado
 


### PR DESCRIPTION
## Summary
- expand unit tests for Rust transpiler with more node types
- add additional PHP, Fortran and Pascal transpiler tests
- ensure module path compatibility via sitecustomize

## Testing
- `PYTHONPATH=$PWD:$PWD/backend:$PWD/backend/src pytest -q tests/unit/test_to_rust.py tests/unit/test_to_php.py tests/unit/test_to_fortran.py tests/unit/test_to_pascal.py`
- `PYTHONPATH=$PWD:$PWD/backend:$PWD/backend/src pytest --cov=src.cobra.transpilers.transpiler.to_rust --cov=src.cobra.transpilers.transpiler.to_php --cov=src.cobra.transpilers.transpiler.to_fortran --cov=src.cobra.transpilers.transpiler.to_pascal tests/unit/test_to_rust.py tests/unit/test_to_php.py tests/unit/test_to_fortran.py tests/unit/test_to_pascal.py`

------
https://chatgpt.com/codex/tasks/task_e_686ce6196fd88327a5f6a50e95cea405