### PR TITLE
Add plugin search subcommand

### DIFF
--- a/backend/src/cli/commands/plugins_cmd.py
+++ b/backend/src/cli/commands/plugins_cmd.py
@@ -11,20 +11,36 @@ class PluginsCommand(BaseCommand):
 
     def register_subparser(self, subparsers):
         parser = subparsers.add_parser(self.name, help=_("Lista plugins instalados"))
-        parser.set_defaults(cmd=self)
+        sub = parser.add_subparsers(dest="accion")
+        bus = sub.add_parser(
+            "buscar", help=_("Filtra plugins por nombre o descripción")
+        )
+        bus.add_argument("texto")
+        parser.set_defaults(cmd=self, accion=None)
         return parser
 
     def run(self, args):
         registro = obtener_registro_detallado()
         if not registro:
             mostrar_info(_("No hay plugins instalados"))
-        else:
-            for nombre, datos in registro.items():
-                version = datos.get("version", "")
-                descripcion = datos.get("description", "")
-                if descripcion:
-                    mostrar_info(f"{nombre} {version} - {descripcion}")
-                else:
-                    mostrar_info(f"{nombre} {version}")
+            return 0
+
+        accion = getattr(args, "accion", None)
+        if accion == "buscar":
+            texto = args.texto.lower()
+            registro = {
+                n: d
+                for n, d in registro.items()
+                if texto in n.lower()
+                or texto in d.get("description", "").lower()
+            }
+
+        for nombre, datos in registro.items():
+            version = datos.get("version", "")
+            descripcion = datos.get("description", "")
+            if descripcion:
+                mostrar_info(f"{nombre} {version} - {descripcion}")
+            else:
+                mostrar_info(f"{nombre} {version}")
         return 0
 

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,0 +1,21 @@
+# Ejemplos de plugins
+
+Este directorio contiene plugins de muestra que se pueden instalar en modo editable.
+Para probarlos ejecuta:
+
+```bash
+cd examples/plugins
+pip install -e .
+```
+
+Una vez instalados, puedes listar los plugins disponibles con:
+
+```bash
+cobra plugins
+```
+
+También es posible buscar uno concreto por nombre o descripción:
+
+```bash
+cobra plugins buscar saludo
+```

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -173,11 +173,21 @@ Subcomando ``plugins``
 ---------------------
 Muestra los plugins instalados y sus versiones registrados mediante ``entry_points``.
 
+Acciones disponibles:
+
+- ``buscar <texto>`` filtra por nombre o descripción.
+
 Ejemplo:
 
 .. code-block:: bash
 
    cobra plugins
+
+Otro ejemplo filtrando la lista:
+
+.. code-block:: bash
+
+   cobra plugins buscar saludo
 
 Subcomando ``contenedor``
 ------------------------


### PR DESCRIPTION
## Summary
- support `cobra plugins buscar <texto>` to filter plugins
- document new option in CLI docs
- add README example demonstrating plugin search

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686d109fb36c8327a45984a72e6632e1