### PR TITLE
Add cobra logo header and no-color option

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,24 @@ cobra profile programa.co
 cobra gui
 ```
 
+Al iniciar la CLI se muestra una cabecera con el logo de Cobra:
+
+```bash
+$ cobra --help
+  ____        _               ____ _     ___
+ / ___|___   | |__   ___ _ __/ ___| |   |_ _|
+| |   / _ \  | '_ \ / _ \ '__| |   | |    | |
+| |__| (_) | | |_) |  __/ |  | |___| |___ | |
+ \____\___/  |_.__/ \___|_|   \____|_____|___|
+usage: cobra [-h] [--formatear] ...
+```
+
+Si deseas desactivar los colores usa `--no-color`:
+
+```bash
+cobra --no-color ejecutar programa.co
+```
+
 Los archivos con extensión ``.cobra`` representan paquetes completos, mientras que los scripts individuales se guardan como ``.co``.
 
 El subcomando `docs` ejecuta `sphinx-apidoc` para generar la documentación de la API antes de compilar el HTML.

--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -44,6 +44,7 @@ def main(argv=None):
     parser.add_argument("--depurar", action="store_true", help=_("Muestra mensajes de depuración"))
     parser.add_argument("--seguro", action="store_true", help=_("Ejecuta en modo seguro"))
     parser.add_argument("--lang", default=os.environ.get("COBRA_LANG", "es"), help=_("Código de idioma para la interfaz"))
+    parser.add_argument("--no-color", action="store_true", help=_("Desactiva colores en la salida"))
     parser.add_argument(
         "--validadores-extra",
         help="Ruta a módulo con validadores personalizados",
@@ -91,6 +92,8 @@ def main(argv=None):
 
     args = parser.parse_args(argv)
     setup_gettext(args.lang)
+    messages.disable_colors(args.no_color)
+    messages.mostrar_logo()
     command = getattr(args, "cmd", command_map["interactive"])
     try:
         resultado = command.run(args)

--- a/backend/src/cli/utils/messages.py
+++ b/backend/src/cli/utils/messages.py
@@ -7,17 +7,47 @@ GREEN = "\033[92m"
 YELLOW = "\033[93m"
 RESET = "\033[0m"
 
+# Flag global para habilitar o desactivar los colores.
+USE_COLOR = True
+
+# Logo ASCII mostrado al iniciar la CLI.
+COBRA_LOGO = r"""
+  ____        _               ____ _     ___ 
+ / ___|___   | |__   ___ _ __/ ___| |   |_ _|
+| |   / _ \  | '_ \ / _ \ '__| |   | |    | | 
+| |__| (_) | | |_) |  __/ |  | |___| |___ | | 
+ \____\___/  |_.__/ \___|_|   \____|_____|___|
+"""
+
+
+def disable_colors(disable: bool = True) -> None:
+    """Activa o desactiva la salida de colores."""
+    global USE_COLOR
+    USE_COLOR = not disable
+
+
+def mostrar_logo() -> None:
+    """Muestra el logo de Cobra en verde."""
+    color = GREEN if USE_COLOR else ""
+    reset = RESET if USE_COLOR else ""
+    print(f"{color}{COBRA_LOGO}{reset}")
+
 
 def _mostrar(msg: str, nivel: str = "info") -> None:
     """Imprime el mensaje con color y registra el log correspondiente."""
     texto = _(msg)
-    color = GREEN if nivel == "info" else YELLOW if nivel == "warning" else RED
+    if USE_COLOR:
+        color = GREEN if nivel == "info" else YELLOW if nivel == "warning" else RED
+        reset = RESET
+    else:
+        color = ""
+        reset = ""
     prefijos = {
         "warning": _("Advertencia"),
         "error": _("Error"),
     }
     prefijo = f"{prefijos[nivel]}: " if nivel in prefijos else ""
-    print(f"{color}{prefijo}{texto}{RESET}")
+    print(f"{color}{prefijo}{texto}{reset}")
     getattr(logging, nivel)(texto)
 
 

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -5,6 +5,9 @@ La herramienta ``cobra`` se maneja mediante subcomandos que facilitan
 la ejecución y transpilación de programas. A continuación se resumen
 las opciones más importantes y un ejemplo de uso para cada una.
 
+Al iniciarse, la CLI muestra una cabecera con el logo de Cobra. Si se
+prefiere desactivar los colores puede usarse la opción ``--no-color``.
+
 Subcomando ``compilar``
 ----------------------
 Transpila un archivo Cobra a otro lenguaje.


### PR DESCRIPTION
## Summary
- show Cobra logo at startup and allow disabling colors
- add `--no-color` global option for the CLI
- update `messages` module with logo helpers
- document the new behaviour in `README.md` and CLI docs

## Testing
- `pytest --cov=backend/src --cov-report=term-missing --cov-fail-under=85` *(fails: 61 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686d42b285dc8327bbcfd91c1d3dea6b