### PR TITLE
Add lexer edge case tests

### DIFF
--- a/tests/unit/lexer_test_casos_edge.py
+++ b/tests/unit/lexer_test_casos_edge.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import pytest
+from backend.src.cobra.lexico.lexer import (
+    Lexer,
+    TipoToken,
+    InvalidTokenError,
+    UnclosedStringError,
+)
+
+
+def test_cadena_sin_cerrar():
+    lexer = Lexer("'hola")
+    with pytest.raises(UnclosedStringError):
+        lexer.tokenizar()
+
+
+def test_caracter_no_valido():
+    codigo = 'var x = \u20AC'
+    lexer = Lexer(codigo)
+    with pytest.raises(InvalidTokenError):
+        lexer.tokenizar()
+
+
+def test_literal_extremo():
+    codigo = '999999999999999999'
+    tokens = Lexer(codigo).analizar_token()
+    assert tokens[0].tipo == TipoToken.ENTERO
+    assert tokens[0].valor == 999999999999999999
+    assert tokens[-1].tipo == TipoToken.EOF


### PR DESCRIPTION
## Summary
- add tests for lexer edge cases

## Testing
- `pytest tests/unit/lexer_test_casos_edge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686def1cbc3483278ad8f4cff855433a