### PR TITLE
Add parser error handling tests

### DIFF
--- a/tests/unit/parser_error_handling.py
+++ b/tests/unit/parser_error_handling.py
@@ -1,0 +1,26 @@
+import pytest
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+
+
+def parse_code(code: str) -> Parser:
+    tokens = Lexer(code).analizar_token()
+    return Parser(tokens)
+
+
+def test_para_sin_dospuntos():
+    codigo = "para i in range(0,5) imprimir(i)"
+    with pytest.raises(SyntaxError):
+        parse_code(codigo).parsear()
+
+
+def test_mientras_parentesis_sin_cerrar():
+    codigo = "mientras (x < 3"
+    with pytest.raises(SyntaxError):
+        parse_code(codigo).parsear()
+
+
+def test_intentar_sin_capturar():
+    codigo = "intentar: lanzar 1 fin"
+    with pytest.raises(SyntaxError):
+        parse_code(codigo).parsear()


### PR DESCRIPTION
## Summary
- cover invalid syntax cases in new unit tests

## Testing
- `PYTHONPATH=.:backend/src pytest tests/unit/parser_error_handling.py -q` *(fails: DID NOT RAISE <class 'SyntaxError'>)*

------
https://chatgpt.com/codex/tasks/task_e_686e36f8a6648327a1f729b9f8c5e2a2