### PR TITLE
Add transpile & sandbox test

### DIFF
--- a/tests/unit/test_transpile_python.py
+++ b/tests/unit/test_transpile_python.py
@@ -1,0 +1,21 @@
+import py_compile
+from src.core.ast_nodes import NodoImprimir, NodoValor
+from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.core.sandbox import ejecutar_en_sandbox
+
+
+def test_transpile_python_and_execute(tmp_path):
+    transpiler = TranspiladorPython()
+    transpiler.codigo = ""  # Evitar importaciones que bloquea la sandbox
+    ast = [NodoImprimir(NodoValor("'hola'"))]
+
+    codigo = transpiler.generate_code(ast)
+
+    archivo = tmp_path / "script.py"
+    archivo.write_text(codigo)
+
+    py_compile.compile(str(archivo), doraise=True)
+
+    salida = ejecutar_en_sandbox(archivo.read_text())
+    assert salida.strip() == "hola"
+


### PR DESCRIPTION
## Summary
- add unit test to transpile a simple AST to Python
- compile generated code with `py_compile`
- execute resulting code in sandbox and verify output

## Testing
- `PYTHONPATH=".:backend/src" pytest -q tests/unit/test_transpile_python.py`

------
https://chatgpt.com/codex/tasks/task_e_686e6b126dbc832791ebb3ba61b94a6b