### PR TITLE
Add integration test for transpiler semantics

### DIFF
--- a/tests/integration/test_transpile_semantics.py
+++ b/tests/integration/test_transpile_semantics.py
@@ -1,0 +1,105 @@
+import sys
+from pathlib import Path
+from io import StringIO
+from unittest.mock import patch
+import subprocess
+import shutil
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import backend  # noqa: F401
+from backend.src.core.interpreter import InterpretadorCobra
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from backend.src.cli.commands.compile_cmd import TRANSPILERS
+from backend.src.core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
+
+
+def obtener_salida_interprete(archivo: Path) -> str:
+    codigo = archivo.read_text()
+    tokens = Lexer(codigo).analizar_token()
+    ast = Parser(tokens).parsear()
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        InterpretadorCobra().ejecutar_ast(ast)
+    return out.getvalue()
+
+
+def ejecutar_codigo(lang: str, codigo: str, tmp_path: Path) -> str:
+    if lang == "python":
+        return ejecutar_en_sandbox(codigo)
+    if lang == "js":
+        return ejecutar_en_sandbox_js(codigo)
+    if lang == "ruby":
+        if not shutil.which("ruby"):
+            pytest.skip("ruby no disponible")
+        proc = subprocess.run(["ruby", "-"], input=codigo, text=True,
+                               capture_output=True, check=True)
+        return proc.stdout
+    if lang == "c":
+        comp = shutil.which("gcc")
+        if not comp:
+            pytest.skip("gcc no disponible")
+        src = tmp_path / "prog.c"
+        src.write_text(codigo)
+        exe = tmp_path / "prog"
+        subprocess.run([comp, str(src), "-o", str(exe)], check=True)
+        proc = subprocess.run([str(exe)], capture_output=True, text=True,
+                              check=True)
+        return proc.stdout
+    if lang == "cpp":
+        comp = shutil.which("g++")
+        if not comp:
+            pytest.skip("g++ no disponible")
+        src = tmp_path / "prog.cpp"
+        src.write_text(codigo)
+        exe = tmp_path / "prog"
+        subprocess.run([comp, str(src), "-o", str(exe)], check=True)
+        proc = subprocess.run([str(exe)], capture_output=True, text=True,
+                              check=True)
+        return proc.stdout
+    if lang == "go":
+        comp = shutil.which("go")
+        if not comp:
+            pytest.skip("go no disponible")
+        src = tmp_path / "prog.go"
+        src.write_text(codigo)
+        proc = subprocess.run([comp, "run", str(src)], capture_output=True,
+                              text=True, check=True)
+        return proc.stdout
+    if lang == "rust":
+        comp = shutil.which("rustc")
+        if not comp:
+            pytest.skip("rustc no disponible")
+        src = tmp_path / "prog.rs"
+        src.write_text(codigo)
+        exe = tmp_path / "prog"
+        subprocess.run([comp, str(src), "-o", str(exe)], check=True)
+        proc = subprocess.run([str(exe)], capture_output=True, text=True,
+                              check=True)
+        return proc.stdout
+    if lang == "java":
+        comp = shutil.which("javac")
+        if not comp:
+            pytest.skip("javac no disponible")
+        src = tmp_path / "Main.java"
+        src.write_text(codigo)
+        subprocess.run([comp, str(src)], cwd=tmp_path, check=True)
+        proc = subprocess.run(["java", "-cp", str(tmp_path), "Main"],
+                              capture_output=True, text=True, check=True)
+        return proc.stdout
+    pytest.skip(f"ejecuci\u00f3n no soportada para {lang}")
+
+
+@pytest.mark.parametrize("lang", ["python", "rust", "go"])
+def test_transpile_semantics(tmp_path, lang):
+    src = Path("tests/data/ejemplo.co")
+    esperado = obtener_salida_interprete(src)
+
+    tokens = Lexer(src.read_text()).analizar_token()
+    ast = Parser(tokens).parsear()
+    codigo = TRANSPILERS[lang]().generate_code(ast)
+
+    salida = ejecutar_codigo(lang, codigo, tmp_path)
+    assert salida == esperado


### PR DESCRIPTION
## Summary
- add `tests/integration/test_transpile_semantics.py` to check transpiled code execution

## Testing
- `pytest tests/integration/test_transpile_semantics.py -q` *(fails: SyntaxError for Python code, NotImplementedError for Rust, subprocess.CalledProcessError for Go)*

------
https://chatgpt.com/codex/tasks/task_e_686e911092a08327b198b033c4034808