### PR TITLE
feat(cli): incluir registro detallado en plugin

### DIFF
--- a/backend/src/cli/plugin.py
+++ b/backend/src/cli/plugin.py
@@ -11,7 +11,11 @@ from importlib import import_module
 from importlib.metadata import entry_points
 
 from .commands.base import BaseCommand
-from .plugin_registry import registrar_plugin, obtener_registro
+from .plugin_registry import (
+    registrar_plugin,
+    obtener_registro,
+    obtener_registro_detallado,
+)
 
 
 class PluginInterface(ABC):


### PR DESCRIPTION
## Summary
- permite importar `obtener_registro_detallado` en los comandos de la CLI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src.core')*

------
https://chatgpt.com/codex/tasks/task_e_686ea5a0db6083278f4c5cac6fa6a1de