### PR TITLE
Add CLI plugin test

### DIFF
--- a/tests/unit/test_cli_plugins.py
+++ b/tests/unit/test_cli_plugins.py
@@ -1,0 +1,26 @@
+import importlib.metadata
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+import sys
+
+from src.cli.cli import main
+from src.cli.plugin_registry import limpiar_registro
+
+# Añadimos la carpeta de plugins de ejemplo al path para poder importar el plugin
+ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = ROOT / "examples" / "plugins"
+sys.path.insert(0, str(PLUGIN_DIR))
+
+
+def test_cli_saludo_plugin():
+    ep = importlib.metadata.EntryPoint(
+        name="saludo",
+        value="saludo_plugin:SaludoCommand",
+        group="cobra.plugins",
+    )
+    limpiar_registro()
+    with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            main(["saludo"])
+    assert "¡Hola desde el plugin de ejemplo!" in out.getvalue()


### PR DESCRIPTION
## Summary
- test CLI integration with example `saludo` plugin

## Testing
- `PYTHONPATH=$PWD:$PWD/backend/src pytest tests/unit/test_cli_plugins.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686eb3cbf534832785bda4aea15669eb