### PR TITLE
Add docs generation integration test

### DIFF
--- a/tests/integration/test_docs_generation.py
+++ b/tests/integration/test_docs_generation.py
@@ -1,0 +1,27 @@
+import sys
+import shutil
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+import backend  # noqa: F401
+from src.cli.cli import main
+
+
+def test_docs_generation():
+    if not shutil.which("sphinx-build") or not shutil.which("sphinx-apidoc"):
+        pytest.skip("Sphinx no disponible")
+
+    build_dir = Path("frontend/build/html")
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        ret = main(["docs"])
+
+    assert ret == 0
+    assert (build_dir / "index.html").is_file()
+    assert "Documentación generada" in out.getvalue()


### PR DESCRIPTION
## Summary
- add integration test for documentation build using CLI

## Testing
- `pytest tests/integration/test_docs_generation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686f386325cc83278d39282ae2ac12a0