### PR TITLE
Agregar pruebas de ejecucion restringida

### DIFF
--- a/tests/unit/test_restricted_exec.py
+++ b/tests/unit/test_restricted_exec.py
@@ -1,0 +1,21 @@
+import pytest
+from src.core.sandbox import ejecutar_en_sandbox
+
+
+@pytest.mark.timeout(5)
+def test_eval_bloqueado():
+    with pytest.raises(Exception):
+        ejecutar_en_sandbox("eval('2+2')")
+
+
+@pytest.mark.timeout(5)
+def test_import_os_system_bloqueado():
+    with pytest.raises(Exception):
+        ejecutar_en_sandbox("__import__('os').system('echo hola')")
+
+
+@pytest.mark.timeout(5)
+def test_import_os_statement_bloqueado():
+    codigo = "import os\nos.system('echo hola')"
+    with pytest.raises(Exception):
+        ejecutar_en_sandbox(codigo)


### PR DESCRIPTION
## Resumen
- añadir `tests/unit/test_restricted_exec.py` con casos que verifican que la sandbox rechaza llamadas peligrosas

## Testing
- `PYTHONPATH=$PWD pytest tests/unit/test_restricted_exec.py -q`
- `make lint` *(falla: múltiples errores de flake8)*

------
https://chatgpt.com/codex/tasks/task_e_686f8c9f34c883279c2031ed1300ee50