### PR TITLE
Update test instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,16 +23,17 @@ Gracias por tu interés en mejorar Cobra. A continuación se describen las pauta
 ## Ejecutar Pruebas
 
 Las pruebas unitarias se ubican en `tests/unit` y las de integración en
-`tests/integration`. Para ejecutarlas todas utiliza:
+`tests/integration`. Antes de ejecutarlas, establece `PYTHONPATH=$PWD` o instala
+el paquete en modo editable (`pip install -e .`). Para ejecutarlas todas utiliza:
 
 ```bash
-pytest
+PYTHONPATH=$PWD pytest
 ```
 
 Para generar un reporte de cobertura:
 
 ```bash
-pytest --cov
+PYTHONPATH=$PWD pytest --cov
 ```
 
 Además de las pruebas, ejecuta las verificaciones de estilo con:

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ están disponibles en `frontend/docs/benchmarking.rst`.
 Para ejecutar pruebas unitarias, utiliza pytest:
 
 ````bash
-pytest backend/src/tests --cov=backend/src --cov-report=term-missing \
+PYTHONPATH=$PWD pytest backend/src/tests --cov=backend/src --cov-report=term-missing \
   --cov-fail-under=85
 ````
 
@@ -599,17 +599,17 @@ externos. Para activar esta opción utiliza `--sandbox` en los subcomandos
 
 # Pruebas
 
-Las pruebas están ubicadas en la carpeta tests/ y utilizan pytest para la ejecución. Puedes añadir más pruebas para cubrir nuevos casos de uso y asegurar la estabilidad del código.
+Las pruebas están ubicadas en la carpeta tests/ y utilizan pytest para la ejecución. Antes de correrlas añade el proyecto al `PYTHONPATH` o instala el paquete en modo editable (`pip install -e .`). Así pytest podrá encontrar los módulos correctamente.
 
 ````bash
-pytest backend/src/tests --cov=backend/src --cov-report=term-missing \
+PYTHONPATH=$PWD pytest backend/src/tests --cov=backend/src --cov-report=term-missing \
   --cov-fail-under=85
 ````
 
 Algunas pruebas generan código en distintos lenguajes (por ejemplo C++, JavaScript o Go) y verifican que la sintaxis sea correcta. Para que estas pruebas se ejecuten con éxito es necesario contar con los compiladores o intérpretes correspondientes instalados en el sistema, como Node, gcc/g++, Go, etc. Puedes ejecutar todo el conjunto con:
 
 ```bash
-pytest
+PYTHONPATH=$PWD pytest
 ```
 
 Se han incluido pruebas que verifican los códigos de salida de la CLI. Los


### PR DESCRIPTION
## Summary
- mention setting `PYTHONPATH` or installing editable package before running tests
- update example commands in README and CONTRIBUTING

## Testing
- `PYTHONPATH=$PWD pytest -q` *(fails: 64 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686fbf6d95288327ad7ddced5dbbc63d