### PR TITLE
Add lexer edge case tests

### DIFF
--- a/tests/unit/test_lexer_additional_cases.py
+++ b/tests/unit/test_lexer_additional_cases.py
@@ -1,0 +1,37 @@
+import pytest
+from src.cobra.lexico.lexer import (
+    Lexer,
+    TipoToken,
+    InvalidTokenError,
+    UnclosedStringError,
+)
+
+
+def test_unclosed_comment_triggers_unclosed_string():
+    codigo = "var x = 1 /* comentario ' sin cerrar"
+    lexer = Lexer(codigo)
+    with pytest.raises(UnclosedStringError):
+        lexer.tokenizar()
+
+
+def test_unclosed_comment_with_invalid_symbol():
+    codigo = "var x = 1 /* comentario €"
+    lexer = Lexer(codigo)
+    with pytest.raises(InvalidTokenError):
+        lexer.tokenizar()
+
+
+def test_illegal_symbol_mix():
+    codigo = "var x = 10€$"
+    lexer = Lexer(codigo)
+    with pytest.raises(InvalidTokenError):
+        lexer.tokenizar()
+
+
+def test_extremely_large_integer():
+    numero = 1234567890123456789012345678901234567890
+    codigo = str(numero)
+    tokens = Lexer(codigo).analizar_token()
+    assert tokens[0].tipo == TipoToken.ENTERO
+    assert tokens[0].valor == numero
+    assert tokens[-1].tipo == TipoToken.EOF


### PR DESCRIPTION
## Summary
- add tests for `Lexer.tokenizar` error cases: unclosed comments and invalid symbols
- add test for extremely large integers

## Testing
- `PYTHONPATH=. pytest tests/unit/test_lexer_additional_cases.py -q`
- `pytest -q` *(fails: 152 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686ff1ecc01c8327a943e91239542791