### PR TITLE
Add runtime tests for all transpilers

### DIFF
--- a/tests/integration/test_transpile_semantics.py
+++ b/tests/integration/test_transpile_semantics.py
@@ -92,7 +92,20 @@ def ejecutar_codigo(lang: str, codigo: str, tmp_path: Path) -> str:
     pytest.skip(f"ejecuci\u00f3n no soportada para {lang}")
 
 
-@pytest.mark.parametrize("lang", ["python", "rust", "go"])
+# Lenguajes con soporte de ejecución en los tests
+RUNNABLE_LANGS = [
+    "python",
+    "js",
+    "ruby",
+    "c",
+    "cpp",
+    "go",
+    "rust",
+    "java",
+]
+
+
+@pytest.mark.parametrize("lang", RUNNABLE_LANGS)
 def test_transpile_semantics(tmp_path, lang):
     src = Path("tests/data/ejemplo.co")
     esperado = obtener_salida_interprete(src)

--- a/tests/integration/test_transpilers_generation.py
+++ b/tests/integration/test_transpilers_generation.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+from io import StringIO
+from unittest.mock import patch
+import subprocess
+import shutil
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import backend  # noqa: F401
+from backend.src.core.interpreter import InterpretadorCobra
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from backend.src.cli.commands.compile_cmd import TRANSPILERS
+from backend.src.core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
+
+from tests.integration.test_transpile_semantics import (
+    ejecutar_codigo,
+    obtener_salida_interprete,
+)
+
+
+RUNTIME_LANGS = {
+    "python",
+    "js",
+    "ruby",
+    "c",
+    "cpp",
+    "go",
+    "rust",
+    "java",
+}
+
+
+@pytest.mark.parametrize("lang", sorted(TRANSPILERS.keys()))
+def test_generate_and_syntax(tmp_path, lang):
+    src = Path("tests/data/ejemplo.co")
+    tokens = Lexer(src.read_text()).analizar_token()
+    ast = Parser(tokens).parsear()
+
+    codigo = TRANSPILERS[lang]().generate_code(ast)
+    assert isinstance(codigo, str)
+    assert codigo.strip() != ""
+
+    if lang in RUNTIME_LANGS:
+        esperado = obtener_salida_interprete(src)
+        salida = ejecutar_codigo(lang, codigo, tmp_path)
+        assert salida == esperado


### PR DESCRIPTION
## Summary
- test semantics in more languages
- add generic generation/syntax test for all transpilers

## Testing
- `pytest -q` *(fails: 65 errors during collection)*
- `make lint` *(fails: flake8: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686ffbdbc3c48327a4795f16309884c3