### PR TITLE
Ajusta cobertura mínima al 95%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,4 +2,4 @@ coverage:
   status:
     project:
       default:
-        target: 85%
+        target: 95%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: make typecheck
       - name: Run tests
         run: pytest --cov=backend/src --cov-report=xml \
-          --cov-report=term-missing --cov-fail-under=85
+          --cov-report=term-missing --cov-fail-under=95
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           pip install -e .
       - name: Run tests
         run: |
-          pytest --cov=backend/src --cov-report=xml --cov-fail-under=85
+          pytest --cov=backend/src --cov-report=xml --cov-fail-under=95
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-report

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ help:
 
 coverage:
 	pytest backend/src/tests --cov=backend/src
-	--cov-report=term-missing --cov-fail-under=85
+	--cov-report=term-missing --cov-fail-under=95
 
 lint:
 	flake8 backend/src

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Para ejecutar pruebas unitarias, utiliza pytest:
 
 ````bash
 PYTHONPATH=$PWD pytest backend/src/tests --cov=backend/src --cov-report=term-missing \
-  --cov-fail-under=85
+  --cov-fail-under=95
 ````
 
 También puedes ejecutar suites específicas ubicadas en `backend/src/tests`:
@@ -603,7 +603,7 @@ Las pruebas están ubicadas en la carpeta tests/ y utilizan pytest para la ejecu
 
 ````bash
 PYTHONPATH=$PWD pytest backend/src/tests --cov=backend/src --cov-report=term-missing \
-  --cov-fail-under=85
+  --cov-fail-under=95
 ````
 
 Algunas pruebas generan código en distintos lenguajes (por ejemplo C++, JavaScript o Go) y verifican que la sintaxis sea correcta. Para que estas pruebas se ejecuten con éxito es necesario contar con los compiladores o intérpretes correspondientes instalados en el sistema, como Node, gcc/g++, Go, etc. Puedes ejecutar todo el conjunto con:
@@ -662,7 +662,7 @@ con los archivos `.po` de traducción y envía un pull request.
 Para obtener un reporte de cobertura en la terminal ejecuta:
 
 ````bash
-pytest --cov=backend/src --cov-report=term-missing --cov-fail-under=85
+pytest --cov=backend/src --cov-report=term-missing --cov-fail-under=95
 ````
 
 ## Caché del AST


### PR DESCRIPTION
## Summary
- incrementa el umbral de cobertura a 95% en CI y tareas locales
- actualiza los ejemplos de README
- ajusta configuración de Codecov

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$PWD pytest --maxfail=1 --disable-warnings -q` *(falla: SyntaxError en tests/unit/test_to_python.py)*

------
https://chatgpt.com/codex/tasks/task_e_68707916ae6c832796523886d65b9824