### PR TITLE
Add lint steps to tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -e .
+      - name: Run linters
+        run: |
+          flake8 backend/src
+          mypy backend/src
       - name: Run tests
         run: |
           pytest --cov=backend/src --cov-report=xml --cov-fail-under=95

--- a/README.md
+++ b/README.md
@@ -784,6 +784,20 @@ pyright --project pyrightconfig.json
 
 `mypy` utiliza la configuración de `mypy.ini` y `pyright` toma las rutas de `pyrightconfig.json`.
 
+Para ejecutar los linters puedes usar el comando de Make:
+
+```bash
+make lint
+```
+
+Esto ejecutará `flake8` y `mypy` sobre `backend/src`. Si prefieres lanzarlos de manera
+individual utiliza:
+
+```bash
+flake8 backend/src
+mypy backend/src
+```
+
 ## Desarrollo de plugins
 
 La CLI puede ampliarse mediante plugins externos. Desde esta versión todo el SDK


### PR DESCRIPTION
## Summary
- add flake8 and mypy runs in the test workflow
- document how to run the linters locally

## Testing
- `pytest -q` *(fails: 153 errors during collection)*
- `make lint` *(fails: flake8 reported many style errors)*
- `mypy backend/src` *(fails: many typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68707ebf3f60832796d48ed89a14c844