### PR TITLE
Añade consulta CodeQL para detectar eval/exec inseguros

### DIFF
--- a/.github/codeql/custom/codeql-config.yml
+++ b/.github/codeql/custom/codeql-config.yml
@@ -5,3 +5,4 @@ paths:
 queries:
   - uses: custom/*.ql
   - uses: custom/missing-codegen-exception.ql
+  - uses: custom/unsafe-eval-exec.ql

--- a/.github/codeql/custom/unsafe-eval-exec.ql
+++ b/.github/codeql/custom/unsafe-eval-exec.ql
@@ -1,0 +1,15 @@
+import python
+
+/**
+ * Reporta el uso de 'eval' o 'exec' fuera del sandbox.
+ */
+from Call c, File f
+where
+  (
+    c.getTarget().hasQualifiedName("builtins", "eval") or
+    c.getTarget().hasQualifiedName("builtins", "exec")
+  ) and
+  f = c.getFile() and
+  f.getRelativePath().regexp("^backend/src/") and
+  not f.getRelativePath().regexp("^backend/src/core/sandbox.py$")
+select c, "Uso potencialmente inseguro de eval/exec"

--- a/README.md
+++ b/README.md
@@ -717,6 +717,7 @@ transpiladores:
   `__post_init__`.
 - **missing-codegen-exception.ql** detecta métodos `generate_code` sin
   manejo de excepciones.
+- **unsafe-eval-exec.ql** avisa cuando se usa `eval` o `exec` fuera del sandbox.
 
 Para ejecutar el análisis de CodeQL de forma local puedes usar la CLI:
 
@@ -767,6 +768,9 @@ lista de paquetes instalados en busca de vulnerabilidades conocidas. Si se
 detecta alguna, la acción devolverá un reporte detallado y el trabajo fallará.
 Consulta el log del paso "Seguridad de dependencias" para ver los paquetes
 afectados y las recomendaciones de actualización.
+
+El repositorio también ejecuta CodeQL con reglas personalizadas para detectar
+patrones de código riesgosos, como el uso de `eval` o `exec` fuera del sandbox.
 
 ## Comunidad
 


### PR DESCRIPTION
## Resumen
- crea `unsafe-eval-exec.ql` para detectar usos de `eval` o `exec` fuera del sandbox
- registra la nueva regla en la configuracion de CodeQL
- actualiza la documentacion con la politica de seguridad

## Testing
- `make lint` *(falla: flake8 reporta multiples errores de estilo)*
- `pytest -q` *(falla por dependencias faltantes como RestrictedPython y tomli)*

------
https://chatgpt.com/codex/tasks/task_e_68708f487ea083279d95cfb93012e7f0