### PR TITLE
Arreglo imports de Lexer en comandos CLI

### DIFF
--- a/backend/src/cli/commands/execute_cmd.py
+++ b/backend/src/cli/commands/execute_cmd.py
@@ -11,7 +11,7 @@ from backend.src.core.sandbox import (
 from backend.src.cobra.transpilers import module_map
 
 from backend.src.core.interpreter import InterpretadorCobra
-from backend.src.cobra.lexico.lexer import Lexer
+from src.cobra.lexico.lexer import Lexer
 from backend.src.cobra.parser.parser import Parser
 from backend.src.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 

--- a/backend/src/cli/commands/interactive_cmd.py
+++ b/backend/src/cli/commands/interactive_cmd.py
@@ -11,7 +11,7 @@ from backend.src.cobra.transpilers import module_map
 
 from backend.src.core.interpreter import InterpretadorCobra
 from backend.src.core.qualia_bridge import get_suggestions
-from backend.src.cobra.lexico.lexer import Lexer
+from src.cobra.lexico.lexer import Lexer
 from backend.src.cobra.parser.parser import Parser
 from backend.src.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 

--- a/backend/src/cli/commands/profile_cmd.py
+++ b/backend/src/cli/commands/profile_cmd.py
@@ -16,7 +16,7 @@ from ..utils.messages import mostrar_error, mostrar_info
 from backend.src.cobra.transpilers import module_map
 from backend.src.core.sandbox import validar_dependencias
 from backend.src.core.interpreter import InterpretadorCobra
-from backend.src.cobra.lexico.lexer import Lexer
+from src.cobra.lexico.lexer import Lexer
 from backend.src.cobra.parser.parser import Parser
 from backend.src.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 


### PR DESCRIPTION
## Resumen
- corrige la ruta de `Lexer` en los comandos `execute`, `interactive` y `profile`
- se ejecutó `grep` para confirmar la ausencia de la importación antigua
- se lanzó `pytest tests/unit/test_cli_run_examples.py` para verificar `cobra ejecutar`

## Testing
- `grep -R "backend.src.cobra.lexico.lexer" -n backend/src/cli/commands`
- `pytest tests/unit/test_cli_run_examples.py` *(fallan por dependencias ausentes)*

------
https://chatgpt.com/codex/tasks/task_e_68710aba0a8483278715298011d30572