### PR TITLE
Add verify command

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,8 @@ cobra empaquetar --output dist
 cobra profile programa.co --output salida.prof
 # O mostrar el perfil directamente en pantalla
 cobra profile programa.co
+# Verificar la salida en Python y JavaScript
+cobra verificar ejemplo.co --lenguajes=python,js
 # Iniciar el iddle gráfico (requiere Flet)
 cobra gui
 ```

--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -28,6 +28,7 @@ from .commands.bench_transpilers_cmd import BenchTranspilersCommand
 from .commands.bench_cmd import BenchCommand
 from .commands.profile_cmd import ProfileCommand
 from .commands.cache_cmd import CacheCommand
+from .commands.verify_cmd import VerifyCommand
 
 # La configuración de logging solo debe activarse cuando la CLI se ejecuta
 # directamente para evitar modificar la configuración global al importar este
@@ -72,6 +73,7 @@ def main(argv=None):
         BenchTranspilersCommand(),
         ProfileCommand(),
         CacheCommand(),
+        VerifyCommand(),
         PluginsCommand(),
         InteractiveCommand(),
     ]

--- a/backend/src/cli/commands/verify_cmd.py
+++ b/backend/src/cli/commands/verify_cmd.py
@@ -1,0 +1,84 @@
+import os
+import logging
+from io import StringIO
+from unittest.mock import patch
+
+from .base import BaseCommand
+from ..i18n import _
+from ..utils.messages import mostrar_error, mostrar_info
+from backend.src.cli.commands.compile_cmd import TRANSPILERS
+from backend.src.core.interpreter import InterpretadorCobra
+from src.cobra.lexico.lexer import Lexer
+from src.cobra.parser.parser import Parser
+from backend.src.core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
+
+
+class VerifyCommand(BaseCommand):
+    """Verifica que la salida sea la misma en distintos lenguajes."""
+
+    name = "verificar"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(
+            self.name,
+            help=_("Comprueba la salida en varios lenguajes"),
+        )
+        parser.add_argument("archivo")
+        parser.add_argument(
+            "--lenguajes",
+            "-l",
+            required=True,
+            help=_("Lista de lenguajes separados por comas"),
+        )
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        archivo = args.archivo
+        lenguajes = [l.strip() for l in args.lenguajes.split(",") if l.strip()]
+        if not os.path.exists(archivo):
+            mostrar_error(f"El archivo '{archivo}' no existe")
+            return 1
+
+        with open(archivo, "r", encoding="utf-8") as f:
+            codigo = f.read()
+
+        tokens = Lexer(codigo).tokenizar()
+        ast = Parser(tokens).parsear()
+
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            InterpretadorCobra().ejecutar_ast(ast)
+        esperado = out.getvalue()
+
+        diferencias = {}
+        for lang in lenguajes:
+            if lang not in ("python", "js"):
+                mostrar_error(f"Lenguaje no soportado: {lang}")
+                return 1
+            transpiler = TRANSPILERS[lang]()
+            try:
+                codigo_gen = transpiler.generate_code(ast)
+            except Exception as e:  # pylint: disable=broad-except
+                logging.error("Error generando código para %s: %s", lang, e)
+                diferencias[lang] = f"Error: {e}"
+                continue
+            try:
+                if lang == "python":
+                    salida = ejecutar_en_sandbox(codigo_gen)
+                else:
+                    salida = ejecutar_en_sandbox_js(codigo_gen)
+            except Exception as e:  # pylint: disable=broad-except
+                logging.error("Error ejecutando código para %s: %s", lang, e)
+                diferencias[lang] = f"Error: {e}"
+                continue
+            if salida != esperado:
+                diferencias[lang] = salida
+
+        if diferencias:
+            mostrar_error("Se encontraron diferencias:")
+            for lang, salida in diferencias.items():
+                mostrar_error(f"{lang}: {salida.strip()}")
+            return 1
+
+        mostrar_info("Todas las salidas coinciden")
+        return 0

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -81,6 +81,9 @@ Transpilación y ejecución
 
 El comando ``cobra compilar`` genera código para múltiples lenguajes. También
 puede ejecutarse un archivo directamente con ``cobra ejecutar``.
+El subcomando ``cobra verificar`` permite comparar la salida de un programa
+transpilado a distintos lenguajes (actualmente Python y JavaScript) y avisa si
+alguna difiere.
 
 Limitaciones de los backends
 ----------------------------


### PR DESCRIPTION
## Summary
- add `verify_cmd.py` implementing verification of program output across Python and JavaScript
- register the new command in the CLI
- document the command in MANUAL_COBRA and README

## Testing
- `python -m py_compile backend/src/cli/commands/verify_cmd.py`
- `PYTHONPATH=$PWD pytest -k verify -q` *(fails: ModuleNotFoundError: hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68722d33d19883279aa854b74e345844