### PR TITLE
Add notebook dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ Source = "https://github.com/Alphonsus411/pCobra"
 
 [project.optional-dependencies]
 mutation = ["mutpy>=0.6.1"]
+notebooks = [
+    "papermill>=2.6.0",
+    "nbconvert>=7.16.6",
+]
 
 [tool.setuptools]
 package-dir = {"" = "backend/src"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,5 @@ lark==1.1.9
 psutil==7.0.0
 tomli>=2.0
 sphinxcontrib-plantuml==0.30
+papermill==2.6.0
+nbconvert==7.16.6


### PR DESCRIPTION
## Summary
- include papermill and nbconvert in dev requirements
- define optional dependency group `notebooks`

## Testing
- `pytest tests/integration/test_notebooks_execution.py -vv` *(fails: papermill.exceptions.PapermillExecutionError)*

------
https://chatgpt.com/codex/tasks/task_e_687261e00a8c8327a9532aa7fd1d165f