### PR TITLE
Add Holobit JSON export and tests

### DIFF
--- a/backend/src/core/holobits/holobit.py
+++ b/backend/src/core/holobits/holobit.py
@@ -1,5 +1,7 @@
 """Tipos de datos y operaciones para manipular holobits."""
 
+import json
+
 
 class Holobit:
     """Representa un conjunto de valores numericos para operaciones 3D/2D."""
@@ -17,3 +19,7 @@ class Holobit:
 
     def __getitem__(self, index):
         return self.valores[index]
+
+    def to_json(self):
+        """Convierte los valores del Holobit a una cadena JSON."""
+        return json.dumps(self.valores)

--- a/tests/unit/test_holobit_generation.py
+++ b/tests/unit/test_holobit_generation.py
@@ -1,0 +1,28 @@
+import json
+import importlib.util
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+holobit_path = ROOT / "backend/src/core/holobits/holobit.py"
+spec = importlib.util.spec_from_file_location("holobit", holobit_path)
+holobit_module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = holobit_module
+spec.loader.exec_module(holobit_module)
+Holobit = holobit_module.Holobit
+
+
+def test_holobit_len_and_indexing():
+    datasets = [
+        [],
+        [1],
+        [1, 2, 3],
+        [0.1, -0.2, 3.5, 4.1, 5.0]
+    ]
+    for data in datasets:
+        hb = Holobit(data)
+        assert len(hb) == len(data)
+        for i, value in enumerate(data):
+            assert hb[i] == pytest.approx(float(value))
+        assert json.loads(hb.to_json()) == [float(v) for v in data]


### PR DESCRIPTION
## Summary
- add `to_json` to `Holobit`
- create unit tests for Holobit generation

## Testing
- `pytest tests/unit/test_holobit_generation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6872972391b483278d96465f8c2230ed