### PR TITLE
Agregar pruebas de sandbox para exec y subprocess

### DIFF
--- a/tests/unit/test_restricted_exec.py
+++ b/tests/unit/test_restricted_exec.py
@@ -19,3 +19,17 @@ def test_import_os_statement_bloqueado():
     codigo = "import os\nos.system('echo hola')"
     with pytest.raises(Exception):
         ejecutar_en_sandbox(codigo)
+
+
+@pytest.mark.timeout(5)
+def test_exec_bloqueado():
+    """Verifica que la función exec está bloqueada en la sandbox."""
+    with pytest.raises(Exception):
+        ejecutar_en_sandbox("exec('print(1)')")
+
+
+@pytest.mark.timeout(5)
+def test_subprocess_bloqueado():
+    """Asegura que no se pueda invocar subprocess dentro de la sandbox."""
+    with pytest.raises(Exception):
+        ejecutar_en_sandbox("__import__('subprocess').run(['echo', 'hola'])")


### PR DESCRIPTION
## Summary
- ampliar `tests/unit/test_restricted_exec.py` con pruebas adicionales
  - `test_exec_bloqueado` verifica que el uso de `exec` está prohibido
  - `test_subprocess_bloqueado` asegura que `subprocess.run` no se puede invocar
- se ejecutó `pytest` pero la suite completa requiere dependencias faltantes
  - solo el archivo nuevo se ejecutó con éxito

## Testing
- `PYTHONPATH=$PWD pytest tests/unit/test_restricted_exec.py -q`
- `PYTHONPATH=$PWD pytest -q` *(falla: 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872a9a564948327860c65b23a7faed8