### PR TITLE
Add eval and exec unit test

### DIFF
--- a/tests/unit/test_codeql_eval_exec.py
+++ b/tests/unit/test_codeql_eval_exec.py
@@ -1,0 +1,14 @@
+# Funciones para probar presencia de eval y exec
+
+
+def insecure_eval(data):
+    return eval(data)
+
+
+def insecure_exec(code):
+    exec(code)
+
+
+def test_insecure_eval_exec():
+    assert insecure_eval("1 + 1") == 2
+    assert insecure_exec("a = 5") is None


### PR DESCRIPTION
## Summary
- add simple eval and exec utilities
- call them in a new test so they appear in the analysis tree

## Testing
- `pytest tests/unit/test_codeql_eval_exec.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872b07ccde883279135008bf2192e23