### PR TITLE
Bump version to 9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v9.0.0 - 2025-07-13
+- Cambios pendientes.
+
 ## v8.0.0 - 2025-07-07
 - Incremento de versión principal a 8.0.0.
 - Documentación y pruebas actualizadas.

--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -1,6 +1,6 @@
 # Manual del Lenguaje Cobra
 
-Versión 8.0.0
+Versión 9.0.0
 
 Este manual presenta en español los conceptos básicos para programar en Cobra. Se organiza en tareas que puedes seguir paso a paso.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Versión estable](https://img.shields.io/github/v/release/Alphonsus411/pCobra?label=stable)](https://github.com/Alphonsus411/pCobra/releases/latest)
 
 
-Versión 8.0.0
+Versión 9.0.0
 
 Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
@@ -870,7 +870,7 @@ Este proyecto sigue el esquema [SemVer](https://semver.org/lang/es/). Los numero
 
 ## Historial de Cambios
 
-- Versión 8.0.0: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
+- Versión 9.0.0: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
 
 # Licencia
 

--- a/backend/src/jupyter_kernel/__init__.py
+++ b/backend/src/jupyter_kernel/__init__.py
@@ -14,7 +14,7 @@ def _get_version() -> str:
     try:
         return version("cobra-lenguaje")
     except PackageNotFoundError:
-        return "8.0.0"
+        return "9.0.0"
 
 
 __version__ = _get_version()

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -8,10 +8,10 @@ Avances del lenguaje Cobra
 - **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX.
 - **Pruebas unitarias**: Se han creado pruebas para validar el correcto funcionamiento del lexer y el parser.
 
- - **Versión 8.0.0**: Actualización de la documentación y configuración del proyecto.
- - **Versión 8.0.0**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
+ - **Versión 9.0.0**: Actualización de la documentación y configuración del proyecto.
+ - **Versión 9.0.0**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
 
-Versión 8.0.0
+Versión 9.0.0
 -----------
 Se añade el archivo ``pcobra.toml`` para definir el mapeo de módulos en formato TOML. Su estructura es la siguiente:
 

--- a/frontend/docs/benchmarking.rst
+++ b/frontend/docs/benchmarking.rst
@@ -2,7 +2,7 @@ Benchmarking y medición de rendimiento
 ======================================
 
 Esta guía explica cómo obtener métricas de ejecución en programas Cobra.
-Desde la versión 8.0 se incluye una pequeña suite de benchmarking basada en el
+Desde la versión 9.0 se incluye una pequeña suite de benchmarking basada en el
 módulo ``src.core.performance`` y la librería ``smooth-criminal``. Dicho módulo
 expone los ayudantes ``optimizar`` y ``perfilar`` para decorar funciones o medir
 su comportamiento.
@@ -60,7 +60,7 @@ Resultados recientes
 Los benchmarks pueden ejecutarse con ``cobra bench``. El siguiente
 resumen se obtuvo con ``scripts/benchmarks/compare_backends.py``.
 
-Las cifras que se muestran a continuación corresponden a Cobra 8.0.
+Las cifras que se muestran a continuación corresponden a Cobra 9.0.
 
 También puedes ejecutar el script manualmente:
 

--- a/frontend/docs/modo_seguro.rst
+++ b/frontend/docs/modo_seguro.rst
@@ -1,7 +1,7 @@
 Modo seguro
 ===========
 
-A partir de Cobra 8.0 la herramienta ``cobra`` permite ejecutar programas en
+A partir de Cobra 9.0 la herramienta ``cobra`` permite ejecutar programas en
 modo seguro mediante la opción ``--seguro``. Al activarse se construye una
 cadena de validadores que analiza el AST y bloquea primitivas peligrosas como
 ``leer_archivo``, ``escribir_archivo``, ``obtener_url`` y ``hilo``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cobra-lenguaje"
-version = "8.0.0"
+version = "9.0.0"
 description = "Un lenguaje de programación en español para simulaciones y más."
 authors = [ {name = "Adolfo González Hernández", email = "adolfogonzal@gmail.com"} ]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cobra-lenguaje',
-    version='8.0.0',
+    version='9.0.0',
     author='Adolfo González Hernández',
     author_email='adolfogonzal@gmail.com',
     description='Un lenguaje de programación en español para simulaciones y más.',

--- a/tests/unit/test_cli_plugins_cmd.py
+++ b/tests/unit/test_cli_plugins_cmd.py
@@ -10,7 +10,7 @@ from src.cli.plugin_registry import limpiar_registro
 
 class DummyPlugin(PluginCommand):
     name = "dummy"
-    version = "8.0.0"
+    version = "9.0.0"
 
     def register_subparser(self, subparsers):
         pass
@@ -43,7 +43,7 @@ def test_cli_plugins_muestra_registro():
     with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["plugins"])
-    assert "dummy 8.0.0" in out.getvalue().strip()
+    assert "dummy 9.0.0" in out.getvalue().strip()
 
 
 def test_cli_plugin_ejemplo_hola():


### PR DESCRIPTION
## Summary
- actualiza la versión principal a 9.0.0 con `bump_version.py`
- ajusta referencias en documentación
- actualiza prueba de plugins

## Testing
- `PYTHONPATH=$PWD pytest tests/unit/test_cli_plugins_cmd.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6873308e24108327aea6e47f04065cdd