### PR TITLE
Incluye notebooks y docs en el paquete

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,5 @@ include cobra.mod
 include README.md
 include CHANGELOG.md
 include MANUAL_COBRA.md
+recursive-include notebooks *
+recursive-include frontend/docs *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ notebooks = [
 
 [tool.setuptools]
 package-dir = {"" = "backend/src"}
+include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["backend/src"]


### PR DESCRIPTION
## Summary
- añade los directorios `notebooks` y `frontend/docs` al `MANIFEST.in`
- configura `include-package-data=true` en `pyproject.toml`
- se validó que el paquete construido contiene los nuevos recursos

## Testing
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_6873495f98248327b8482ed05a83e6c8