### PR TITLE
Update workflow trigger for GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
- add tag trigger for docs deployment
- allow running the workflow manually

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68735e2ff19c832788fa61362d2a0e94