### PR TITLE
Add benchthreads command

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,15 @@ El archivo [bench_results.json](bench_results.json) se guarda en el directorio
 actual y puede analizarse con el cuaderno
 [notebooks/benchmarks_resultados.ipynb](notebooks/benchmarks_resultados.ipynb).
 
+Para comparar el rendimiento de los hilos ejecuta `cobra benchthreads`:
+
+```bash
+cobra benchthreads --output threads.json
+```
+
+El resultado contiene tres entradas (secuencial, cli_hilos y kernel_hilos) con
+los tiempos y uso de CPU.
+
 # Uso
 
 Para conocer las opciones avanzadas del modo seguro revisa

--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -25,6 +25,7 @@ from .commands.container_cmd import ContainerCommand
 from .commands.benchmarks_cmd import BenchmarksCommand
 from .commands.benchmarks2_cmd import BenchmarksV2Command
 from .commands.bench_transpilers_cmd import BenchTranspilersCommand
+from .commands.benchthreads_cmd import BenchThreadsCommand
 from .commands.bench_cmd import BenchCommand
 from .commands.profile_cmd import ProfileCommand
 from .commands.cache_cmd import CacheCommand
@@ -71,6 +72,7 @@ def main(argv=None):
         BenchmarksCommand(),
         BenchmarksV2Command(),
         BenchTranspilersCommand(),
+        BenchThreadsCommand(),
         ProfileCommand(),
         CacheCommand(),
         VerifyCommand(),

--- a/backend/src/cli/commands/benchthreads_cmd.py
+++ b/backend/src/cli/commands/benchthreads_cmd.py
@@ -1,0 +1,121 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import resource
+from pathlib import Path
+
+from .base import BaseCommand
+from ..i18n import _
+from ..utils.messages import mostrar_error, mostrar_info
+from backend.src.jupyter_kernel import CobraKernel
+from backend.src.core.interpreter import InterpretadorCobra
+from backend.src.cobra.lexico.lexer import Lexer
+from backend.src.cobra.parser.parser import Parser
+
+
+SEQUENTIAL_CODE = """
+funcion tarea(n):
+    var x = 0
+    mientras x < n:
+        x = x + 1
+    fin
+fin
+
+tarea(50000)
+tarea(50000)
+"""
+
+THREAD_CODE = """
+funcion tarea(n):
+    var x = 0
+    mientras x < n:
+        x = x + 1
+    fin
+fin
+
+hilo tarea(50000)
+hilo tarea(50000)
+"""
+
+
+def _measure(func):
+    start_usage = resource.getrusage(resource.RUSAGE_SELF)
+    start = time.perf_counter()
+    func()
+    elapsed = time.perf_counter() - start
+    end_usage = resource.getrusage(resource.RUSAGE_SELF)
+    cpu = (end_usage.ru_utime + end_usage.ru_stime) - (
+        start_usage.ru_utime + start_usage.ru_stime
+    )
+    io = (end_usage.ru_inblock + end_usage.ru_oublock) - (
+        start_usage.ru_inblock + start_usage.ru_oublock
+    )
+    return elapsed, cpu, io
+
+
+class BenchThreadsCommand(BaseCommand):
+    """Compara la ejecución secuencial y en hilos."""
+
+    name = "benchthreads"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(
+            self.name, help=_("Benchmark de hilos en CLI y Jupyter")
+        )
+        parser.add_argument(
+            "--output",
+            "-o",
+            help=_("Archivo donde guardar el JSON con resultados"),
+        )
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def _run_cli(self, code: str, env: dict[str, str]) -> None:
+        with tempfile.NamedTemporaryFile("w", suffix=".co", delete=False) as tmp:
+            tmp.write(code)
+            tmp.flush()
+            cmd = [sys.executable, "-m", "src.cli.cli", "ejecutar", tmp.name]
+            subprocess.run(cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        os.unlink(tmp.name)
+
+    def _run_kernel(self, code: str) -> None:
+        kernel = CobraKernel()
+        kernel.do_execute(code, silent=True)
+
+    def _run_sequential(self) -> None:
+        interp = InterpretadorCobra()
+        tokens = Lexer(SEQUENTIAL_CODE).tokenizar()
+        ast = Parser(tokens).parsear()
+        interp.ejecutar_ast(ast)
+
+    def run(self, args):
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+        env["PCOBRA_TOML"] = str(Path(tempfile.mkstemp(suffix=".toml")[1]))
+
+        results = []
+
+        elapsed, cpu, io = _measure(self._run_sequential)
+        results.append({"modo": "secuencial", "time": round(elapsed, 4), "cpu": round(cpu, 4), "io": io})
+
+        elapsed, cpu, io = _measure(lambda: self._run_cli(THREAD_CODE, env))
+        results.append({"modo": "cli_hilos", "time": round(elapsed, 4), "cpu": round(cpu, 4), "io": io})
+
+        elapsed, cpu, io = _measure(lambda: self._run_kernel(THREAD_CODE))
+        results.append({"modo": "kernel_hilos", "time": round(elapsed, 4), "cpu": round(cpu, 4), "io": io})
+
+        data = json.dumps(results, indent=2)
+        if args.output:
+            try:
+                Path(args.output).write_text(data)
+                mostrar_info(_("Resultados guardados en {file}").format(file=args.output))
+            except Exception as err:
+                mostrar_error(_("No se pudo escribir el archivo: {err}").format(err=err))
+                return 1
+        else:
+            print(data)
+        return 0
+

--- a/frontend/docs/benchmarking.rst
+++ b/frontend/docs/benchmarking.rst
@@ -121,3 +121,16 @@ Ejemplo:
 El archivo resultante es una lista de objetos con las claves
 ``size`` (tamaño del programa), ``lang`` (lenguaje de salida) y
 ``time`` (segundos de ejecución).
+
+Benchmark de hilos
+------------------
+
+El comando ``cobra benchthreads`` ejecuta un programa con y sin hilos
+usando tanto la CLI como el kernel de Jupyter. La salida es un JSON con
+los tiempos totales, uso de CPU y operaciones de E/S.
+
+.. code-block:: bash
+
+   cobra benchthreads --output threads.json
+
+

--- a/tests/unit/test_benchthreads_cmd.py
+++ b/tests/unit/test_benchthreads_cmd.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+from src.cli.cli import main
+from src.cli.commands import benchthreads_cmd
+import pytest
+
+@pytest.mark.timeout(10)
+def test_benchthreads_generates_json(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(benchthreads_cmd, "_measure", lambda f: (0.1, 0.05, 1))
+    salida = tmp_path / "threads.json"
+    main(["benchthreads", "--output", str(salida)])
+    data = json.loads(salida.read_text())
+    modos = {d["modo"] for d in data}
+    assert {"secuencial", "cli_hilos", "kernel_hilos"} == modos
+    for d in data:
+        assert isinstance(d["time"], float)
+        assert "cpu" in d and "io" in d
+


### PR DESCRIPTION
## Summary
- benchmark threaded vs sequential execution through CLI and Jupyter
- register new `benchthreads` command
- document benchmark usage in README and docs
- test benchthreads command

## Testing
- `PYTHONPATH=$PWD pytest -q tests/unit/test_benchthreads_cmd.py`

------
https://chatgpt.com/codex/tasks/task_e_6873cf992e9c8327a7d7d9186b6e9553