### PR TITLE
Reemplazo imports con rutas absolutas

### DIFF
--- a/backend/src/cli/commands/agix_cmd.py
+++ b/backend/src/cli/commands/agix_cmd.py
@@ -3,7 +3,7 @@ from .base import BaseCommand
 from ..i18n import _
 from ..utils.messages import mostrar_error, mostrar_info
 
-from backend.src.ia.analizador_agix import generar_sugerencias
+from ia.analizador_agix import generar_sugerencias
 
 
 class AgixCommand(BaseCommand):

--- a/backend/src/cli/commands/bench_transpilers_cmd.py
+++ b/backend/src/cli/commands/bench_transpilers_cmd.py
@@ -7,7 +7,7 @@ from .base import BaseCommand
 from ..i18n import _
 from ..utils.messages import mostrar_error, mostrar_info
 from .compile_cmd import TRANSPILERS
-from backend.src.core.ast_cache import obtener_ast
+from core.ast_cache import obtener_ast
 
 
 PROGRAM_DIR = Path(__file__).resolve().parents[4] / "scripts" / "benchmarks" / "programs"

--- a/backend/src/cli/commands/benchmarks2_cmd.py
+++ b/backend/src/cli/commands/benchmarks2_cmd.py
@@ -137,7 +137,7 @@ class BenchmarksV2Command(BaseCommand):
             # Ejecución en sandbox
             runner = Path(tmpdir) / "run_sandbox.py"
             runner.write_text(
-                "from src.core.sandbox import ejecutar_en_sandbox\n"
+                "from core.sandbox import ejecutar_en_sandbox\n"
                 "import pathlib, sys\n"
                 "codigo = pathlib.Path(sys.argv[1]).read_text()\n"
                 "ejecutar_en_sandbox(codigo)\n"

--- a/backend/src/cli/commands/benchthreads_cmd.py
+++ b/backend/src/cli/commands/benchthreads_cmd.py
@@ -10,10 +10,10 @@ from pathlib import Path
 from .base import BaseCommand
 from ..i18n import _
 from ..utils.messages import mostrar_error, mostrar_info
-from backend.src.jupyter_kernel import CobraKernel
-from backend.src.core.interpreter import InterpretadorCobra
-from backend.src.cobra.lexico.lexer import Lexer
-from backend.src.cobra.parser.parser import Parser
+from jupyter_kernel import CobraKernel
+from core.interpreter import InterpretadorCobra
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
 
 
 SEQUENTIAL_CODE = """

--- a/backend/src/cli/commands/cache_cmd.py
+++ b/backend/src/cli/commands/cache_cmd.py
@@ -2,7 +2,7 @@ import os
 from .base import BaseCommand
 from ..i18n import _
 from ..utils.messages import mostrar_info
-from backend.src.core.ast_cache import limpiar_cache
+from core.ast_cache import limpiar_cache
 
 
 class CacheCommand(BaseCommand):

--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -6,32 +6,32 @@ from importlib.metadata import entry_points
 from .base import BaseCommand
 from ..i18n import _
 from ..utils.messages import mostrar_error, mostrar_info
-from backend.src.cobra.transpilers import module_map
-from backend.src.core.sandbox import validar_dependencias
+from cobra.transpilers import module_map
+from core.sandbox import validar_dependencias
 
-from backend.src.core.ast_cache import obtener_ast
-from backend.src.core.semantic_validators import (
+from core.ast_cache import obtener_ast
+from core.semantic_validators import (
     PrimitivaPeligrosaError,
     construir_cadena,
 )
-from backend.src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from backend.src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from backend.src.cobra.transpilers.transpiler.to_asm import TranspiladorASM
-from backend.src.cobra.transpilers.transpiler.to_rust import TranspiladorRust
-from backend.src.cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
-from backend.src.cobra.transpilers.transpiler.to_c import TranspiladorC
-from backend.src.cobra.transpilers.transpiler.to_go import TranspiladorGo
-from backend.src.cobra.transpilers.transpiler.to_r import TranspiladorR
-from backend.src.cobra.transpilers.transpiler.to_julia import TranspiladorJulia
-from backend.src.cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
-from backend.src.cobra.transpilers.transpiler.to_java import TranspiladorJava
-from backend.src.cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
-from backend.src.cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
-from backend.src.cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
-from backend.src.cobra.transpilers.transpiler.to_php import TranspiladorPHP
-from backend.src.cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
-from backend.src.cobra.transpilers.transpiler.to_latex import TranspiladorLatex
-from backend.src.cobra.transpilers.transpiler.to_wasm import TranspiladorWasm
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_asm import TranspiladorASM
+from cobra.transpilers.transpiler.to_rust import TranspiladorRust
+from cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
+from cobra.transpilers.transpiler.to_c import TranspiladorC
+from cobra.transpilers.transpiler.to_go import TranspiladorGo
+from cobra.transpilers.transpiler.to_r import TranspiladorR
+from cobra.transpilers.transpiler.to_julia import TranspiladorJulia
+from cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
+from cobra.transpilers.transpiler.to_java import TranspiladorJava
+from cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
+from cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
+from cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
+from cobra.transpilers.transpiler.to_php import TranspiladorPHP
+from cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
+from cobra.transpilers.transpiler.to_latex import TranspiladorLatex
+from cobra.transpilers.transpiler.to_wasm import TranspiladorWasm
 
 # Mapa que asocia el nombre de cada lenguaje con la clase de su
 # transpilador. Sirve como una fábrica sencilla: a partir de una clave

--- a/backend/src/cli/commands/execute_cmd.py
+++ b/backend/src/cli/commands/execute_cmd.py
@@ -3,17 +3,17 @@ import os
 from .base import BaseCommand
 from ..i18n import _
 from ..utils.messages import mostrar_error, mostrar_info
-from backend.src.core.sandbox import (
+from core.sandbox import (
     ejecutar_en_sandbox,
     ejecutar_en_contenedor,
     validar_dependencias,
 )
-from backend.src.cobra.transpilers import module_map
+from cobra.transpilers import module_map
 
-from backend.src.core.interpreter import InterpretadorCobra
-from src.cobra.lexico.lexer import Lexer
-from backend.src.cobra.parser.parser import Parser
-from backend.src.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
+from core.interpreter import InterpretadorCobra
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 
 
 class ExecuteCommand(BaseCommand):

--- a/backend/src/cli/commands/flet_cmd.py
+++ b/backend/src/cli/commands/flet_cmd.py
@@ -18,7 +18,7 @@ class FletCommand(BaseCommand):
     def run(self, args):
         try:
             import flet
-            from src.gui.idle import main
+            from gui.idle import main
         except ModuleNotFoundError:
             mostrar_error(_("Flet no está instalado. Ejecuta 'pip install flet'."))
             return 1

--- a/backend/src/cli/commands/interactive_cmd.py
+++ b/backend/src/cli/commands/interactive_cmd.py
@@ -2,18 +2,18 @@ import logging
 from .base import BaseCommand
 from ..i18n import _
 from ..utils.messages import mostrar_error, mostrar_info
-from backend.src.core.sandbox import (
+from core.sandbox import (
     ejecutar_en_sandbox,
     ejecutar_en_contenedor,
     validar_dependencias,
 )
-from backend.src.cobra.transpilers import module_map
+from cobra.transpilers import module_map
 
-from backend.src.core.interpreter import InterpretadorCobra
-from backend.src.core.qualia_bridge import get_suggestions
-from src.cobra.lexico.lexer import Lexer
-from backend.src.cobra.parser.parser import Parser
-from backend.src.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
+from core.interpreter import InterpretadorCobra
+from core.qualia_bridge import get_suggestions
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 
 
 class InteractiveCommand(BaseCommand):

--- a/backend/src/cli/commands/profile_cmd.py
+++ b/backend/src/cli/commands/profile_cmd.py
@@ -13,12 +13,12 @@ from .base import BaseCommand
 from .execute_cmd import ExecuteCommand
 from ..i18n import _
 from ..utils.messages import mostrar_error, mostrar_info
-from backend.src.cobra.transpilers import module_map
-from backend.src.core.sandbox import validar_dependencias
-from backend.src.core.interpreter import InterpretadorCobra
-from src.cobra.lexico.lexer import Lexer
-from backend.src.cobra.parser.parser import Parser
-from backend.src.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
+from cobra.transpilers import module_map
+from core.sandbox import validar_dependencias
+from core.interpreter import InterpretadorCobra
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 
 
 class ProfileCommand(BaseCommand):

--- a/backend/src/cli/commands/verify_cmd.py
+++ b/backend/src/cli/commands/verify_cmd.py
@@ -6,11 +6,11 @@ from unittest.mock import patch
 from .base import BaseCommand
 from ..i18n import _
 from ..utils.messages import mostrar_error, mostrar_info
-from backend.src.cli.commands.compile_cmd import TRANSPILERS
-from backend.src.core.interpreter import InterpretadorCobra
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from backend.src.core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
+from cli.commands.compile_cmd import TRANSPILERS
+from core.interpreter import InterpretadorCobra
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
 
 
 class VerifyCommand(BaseCommand):

--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -309,7 +309,7 @@ class Lexer:
         """Convierte el código en tokens con soporte opcional de caché
         incremental y perfilado."""
         if incremental:
-            from src.core.ast_cache import obtener_tokens_fragmento
+            from core.ast_cache import obtener_tokens_fragmento
             self.tokens = []
             for linea in self.codigo_fuente.splitlines(keepends=True):
                 self.tokens.extend(obtener_tokens_fragmento(linea)[:-1])

--- a/backend/src/cobra/macro/__init__.py
+++ b/backend/src/cobra/macro/__init__.py
@@ -1,6 +1,6 @@
 macros = {}
 
-from src.core.ast_nodes import NodoMacro, NodoLlamadaFuncion
+from core.ast_nodes import NodoMacro, NodoLlamadaFuncion
 
 def registrar_macro(nodo: NodoMacro):
     """Registra una macro a partir de su nodo."""

--- a/backend/src/cobra/parser/lark_parser.py
+++ b/backend/src/cobra/parser/lark_parser.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import List
 
 from lark import Lark
-from src.cobra.lexico.lexer import Token, TipoToken
+from cobra.lexico.lexer import Token, TipoToken
 
 
 class LarkParser:

--- a/backend/src/cobra/parser/parser.py
+++ b/backend/src/cobra/parser/parser.py
@@ -2,9 +2,9 @@
 
 import logging
 import json
-from src.cobra.lexico.lexer import TipoToken, Token
+from cobra.lexico.lexer import TipoToken, Token
 
-from src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoAsignacion,
     NodoHolobit,
     NodoCondicional,
@@ -44,7 +44,7 @@ from src.core.ast_nodes import (
     NodoCase,
 )
 
-from src.core import NodoYield
+from core import NodoYield
 
 # Palabras reservadas que no pueden usarse como identificadores
 PALABRAS_RESERVADAS = {
@@ -177,7 +177,7 @@ class ClassicParser:
     def parsear(self, *, incremental: bool = False, profile: bool = False):
         """Parsea tokens con soporte de caché incremental y perfilado."""
         if incremental:
-            from src.core.ast_cache import obtener_ast_fragmento
+            from core.ast_cache import obtener_ast_fragmento
             codigo = "\n".join(
                 token.valor if token.valor is not None else ""
                 for token in self.tokens

--- a/backend/src/cobra/semantico/analizador.py
+++ b/backend/src/cobra/semantico/analizador.py
@@ -1,7 +1,7 @@
 from typing import List
 
-from backend.src.core.visitor import NodeVisitor
-from backend.src.core.ast_nodes import (
+from core.visitor import NodeVisitor
+from core.ast_nodes import (
     NodoAsignacion,
     NodoFuncion,
     NodoClase,

--- a/backend/src/cobra/semantico/mod_validator.py
+++ b/backend/src/cobra/semantico/mod_validator.py
@@ -17,8 +17,8 @@ import yaml
 from typing import Dict, Any
 from jsonschema import validate, ValidationError
 
-from src.cli.utils.semver import es_version_valida
-from src.cobra.transpilers import module_map
+from cli.utils.semver import es_version_valida
+from cobra.transpilers import module_map
 
 SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "cobra_mod_schema.yaml")
 with open(SCHEMA_PATH, "r", encoding="utf-8") as f:

--- a/backend/src/cobra/transpilers/base.py
+++ b/backend/src/cobra/transpilers/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from backend.src.core.visitor import NodeVisitor
+from core.visitor import NodeVisitor
 
 
 class BaseTranspiler(NodeVisitor, ABC):

--- a/backend/src/cobra/transpilers/import_helper.py
+++ b/backend/src/cobra/transpilers/import_helper.py
@@ -9,7 +9,7 @@ from .module_map import get_mapped_path
 # Mapeo de importaciones estándar por lenguaje
 STANDARD_IMPORTS = {
     "python": (
-        "from src.core.nativos import *\n" "from corelibs import *\n" "from standard_library import *\n"
+        "from core.nativos import *\n" "from corelibs import *\n" "from standard_library import *\n"
     ),
     "js": [
         "import * as io from './nativos/io.js';",

--- a/backend/src/cobra/transpilers/semantica.py
+++ b/backend/src/cobra/transpilers/semantica.py
@@ -1,4 +1,4 @@
-from backend.src.core.ast_nodes import NodoAtributo
+from core.ast_nodes import NodoAtributo
 
 
 def datos_asignacion(transpilador, nodo):

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/importar.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/importar.py
@@ -1,5 +1,5 @@
-from backend.src.cobra.lexico.lexer import Lexer
-from backend.src.cobra.parser.parser import Parser
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
 
 
 def visit_import(self, nodo):

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/elemento.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/elemento.py
@@ -1,4 +1,4 @@
-from backend.src.core.ast_nodes import NodoLista, NodoDiccionario
+from core.ast_nodes import NodoLista, NodoDiccionario
 def visit_elemento(self, elemento):
 
     """Transpila un elemento o estructura."""

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/exportar.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/exportar.py
@@ -1,4 +1,4 @@
-from backend.src.core.ast_nodes import NodoExport
+from core.ast_nodes import NodoExport
 
 
 def visit_export(self, nodo: NodoExport):

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/importar.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/importar.py
@@ -1,5 +1,5 @@
-from backend.src.cobra.lexico.lexer import Lexer
-from backend.src.cobra.parser.parser import Parser
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
 from ...import_helper import load_mapped_module
 
 

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/usar.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/usar.py
@@ -1,4 +1,4 @@
-from backend.src.cobra.usar_loader import obtener_modulo
+from cobra.usar_loader import obtener_modulo
 
 
 def visit_usar(self, nodo):
@@ -6,6 +6,6 @@ def visit_usar(self, nodo):
 
     ind = self.obtener_indentacion()
     self.codigo += (
-        f"{ind}from src.cobra.usar_loader import obtener_modulo\n"
+        f"{ind}from cobra.usar_loader import obtener_modulo\n"
         f"{ind}{nodo.modulo} = obtener_modulo('{nodo.modulo}')\n"
     )

--- a/backend/src/cobra/transpilers/transpiler/to_asm.py
+++ b/backend/src/cobra/transpilers/transpiler/to_asm.py
@@ -1,6 +1,6 @@
 """Transpilador que genera código ensamblador simple desde Cobra."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoBucleMientras,
@@ -28,12 +28,12 @@ from backend.src.core.ast_nodes import (
     NodoPara,
     NodoUsar,
 )
-from backend.src.cobra.lexico.lexer import TipoToken, Lexer
-from backend.src.cobra.parser.parser import Parser
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken, Lexer
+from cobra.parser.parser import Parser
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 from .asm_nodes.asignacion import visit_asignacion as _visit_asignacion
 from .asm_nodes.condicional import visit_condicional as _visit_condicional

--- a/backend/src/cobra/transpilers/transpiler/to_c.py
+++ b/backend/src/cobra/transpilers/transpiler/to_c.py
@@ -1,6 +1,6 @@
 """Transpilador básico de Cobra a C."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoLista,
     NodoDiccionario,
     NodoValor,
@@ -10,11 +10,11 @@ from backend.src.core.ast_nodes import (
     NodoAtributo,
     NodoInstancia,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 
 def visit_asignacion(self, nodo):

--- a/backend/src/cobra/transpilers/transpiler/to_cobol.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cobol.py
@@ -1,6 +1,6 @@
 """Transpilador que genera código COBOL a partir de Cobra."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,
@@ -11,11 +11,11 @@ from backend.src.core.ast_nodes import (
     NodoOperacionUnaria,
     NodoAtributo,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 from .cobol_nodes.asignacion import visit_asignacion as _visit_asignacion
 from .cobol_nodes.funcion import visit_funcion as _visit_funcion

--- a/backend/src/cobra/transpilers/transpiler/to_cpp.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cpp.py
@@ -1,6 +1,6 @@
 """Transpilador que genera código C++ a partir de Cobra."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoLista,
     NodoDiccionario,
     NodoValor,
@@ -17,11 +17,11 @@ from backend.src.core.ast_nodes import (
     NodoWith,
     NodoImportDesde,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 from .cpp_nodes.asignacion import visit_asignacion as _visit_asignacion
 from .cpp_nodes.condicional import visit_condicional as _visit_condicional

--- a/backend/src/cobra/transpilers/transpiler/to_fortran.py
+++ b/backend/src/cobra/transpilers/transpiler/to_fortran.py
@@ -1,6 +1,6 @@
 """Transpilador sencillo de Cobra a Fortran."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,
@@ -11,11 +11,11 @@ from backend.src.core.ast_nodes import (
     NodoOperacionUnaria,
     NodoAtributo,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 from .fortran_nodes.asignacion import visit_asignacion as _visit_asignacion
 from .fortran_nodes.funcion import visit_funcion as _visit_funcion

--- a/backend/src/cobra/transpilers/transpiler/to_go.py
+++ b/backend/src/cobra/transpilers/transpiler/to_go.py
@@ -1,6 +1,6 @@
 """Transpilador sencillo de Cobra a Go."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,
@@ -11,11 +11,11 @@ from backend.src.core.ast_nodes import (
     NodoOperacionUnaria,
     NodoAtributo,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 
 def visit_asignacion(self, nodo: NodoAsignacion):

--- a/backend/src/cobra/transpilers/transpiler/to_java.py
+++ b/backend/src/cobra/transpilers/transpiler/to_java.py
@@ -1,6 +1,6 @@
 """Transpilador sencillo de Cobra a Java."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,
@@ -11,11 +11,11 @@ from backend.src.core.ast_nodes import (
     NodoOperacionUnaria,
     NodoAtributo,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 
 def visit_asignacion(self, nodo: NodoAsignacion):

--- a/backend/src/cobra/transpilers/transpiler/to_js.py
+++ b/backend/src/cobra/transpilers/transpiler/to_js.py
@@ -1,6 +1,6 @@
 """Transpilador que genera código JavaScript a partir de Cobra."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoLista,
     NodoDiccionario,
     NodoValor,
@@ -21,11 +21,11 @@ from backend.src.core.ast_nodes import (
     NodoExport,
     NodoEsperar,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 from ..import_helper import get_standard_imports
 from ..module_map import get_mapped_path
 

--- a/backend/src/cobra/transpilers/transpiler/to_julia.py
+++ b/backend/src/cobra/transpilers/transpiler/to_julia.py
@@ -1,6 +1,6 @@
 """Transpilador simple de Cobra a Julia."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,
@@ -11,11 +11,11 @@ from backend.src.core.ast_nodes import (
     NodoOperacionUnaria,
     NodoAtributo,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 
 def visit_asignacion(self, nodo: NodoAsignacion):

--- a/backend/src/cobra/transpilers/transpiler/to_latex.py
+++ b/backend/src/cobra/transpilers/transpiler/to_latex.py
@@ -1,6 +1,6 @@
 """Transpilador simple de Cobra a LaTeX."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,
@@ -9,10 +9,10 @@ from backend.src.core.ast_nodes import (
     NodoImprimir,
     NodoAtributo,
 )
-from backend.src.core.visitor import NodeVisitor
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 from .latex_nodes.asignacion import visit_asignacion as _visit_asignacion
 from .latex_nodes.funcion import visit_funcion as _visit_funcion

--- a/backend/src/cobra/transpilers/transpiler/to_matlab.py
+++ b/backend/src/cobra/transpilers/transpiler/to_matlab.py
@@ -1,6 +1,6 @@
 """Transpilador simple de Cobra a MATLAB."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,
@@ -11,11 +11,11 @@ from backend.src.core.ast_nodes import (
     NodoOperacionUnaria,
     NodoAtributo,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 from .matlab_nodes.asignacion import visit_asignacion as _visit_asignacion
 from .matlab_nodes.funcion import visit_funcion as _visit_funcion

--- a/backend/src/cobra/transpilers/transpiler/to_pascal.py
+++ b/backend/src/cobra/transpilers/transpiler/to_pascal.py
@@ -1,6 +1,6 @@
 """Transpilador que genera código Pascal a partir de Cobra."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,
@@ -11,11 +11,11 @@ from backend.src.core.ast_nodes import (
     NodoOperacionUnaria,
     NodoAtributo,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 from .pascal_nodes.asignacion import visit_asignacion as _visit_asignacion
 from .pascal_nodes.funcion import visit_funcion as _visit_funcion

--- a/backend/src/cobra/transpilers/transpiler/to_php.py
+++ b/backend/src/cobra/transpilers/transpiler/to_php.py
@@ -1,6 +1,6 @@
 """Transpilador simple de Cobra a PHP."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,
@@ -11,11 +11,11 @@ from backend.src.core.ast_nodes import (
     NodoOperacionUnaria,
     NodoAtributo,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 
 def visit_asignacion(self, nodo: NodoAsignacion):

--- a/backend/src/cobra/transpilers/transpiler/to_python.py
+++ b/backend/src/cobra/transpilers/transpiler/to_python.py
@@ -1,6 +1,6 @@
 """Transpilador que convierte código Cobra en código Python."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoAsignacion, NodoCondicional, NodoBucleMientras, NodoFuncion,
     NodoLlamadaFuncion, NodoHolobit, NodoFor, NodoLista, NodoDiccionario,
     NodoClase,
@@ -28,12 +28,12 @@ from backend.src.core.ast_nodes import (
     NodoImportDesde,
     NodoEsperar
 )
-from backend.src.cobra.parser.parser import Parser
-from backend.src.cobra.lexico.lexer import TipoToken, Lexer
-from backend.src.core.visitor import NodeVisitor
+from cobra.parser.parser import Parser
+from cobra.lexico.lexer import TipoToken, Lexer
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 from ..import_helper import get_standard_imports
 
 from .python_nodes.asignacion import visit_asignacion as _visit_asignacion
@@ -162,7 +162,7 @@ class TranspiladorPython(BaseTranspiler):
 
 
     def obtener_valor(self, nodo):
-        from backend.src.cobra.parser.parser import (
+        from cobra.parser.parser import (
             NodoOperacionBinaria,
             NodoOperacionUnaria,
             NodoIdentificador,

--- a/backend/src/cobra/transpilers/transpiler/to_r.py
+++ b/backend/src/cobra/transpilers/transpiler/to_r.py
@@ -1,6 +1,6 @@
 """Transpilador básico de Cobra a R."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,
@@ -11,11 +11,11 @@ from backend.src.core.ast_nodes import (
     NodoOperacionUnaria,
     NodoAtributo,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 
 def visit_asignacion(self, nodo: NodoAsignacion):

--- a/backend/src/cobra/transpilers/transpiler/to_ruby.py
+++ b/backend/src/cobra/transpilers/transpiler/to_ruby.py
@@ -1,6 +1,6 @@
 """Transpilador simple de Cobra a Ruby."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,
@@ -11,11 +11,11 @@ from backend.src.core.ast_nodes import (
     NodoOperacionUnaria,
     NodoAtributo,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 
 def visit_asignacion(self, nodo: NodoAsignacion):

--- a/backend/src/cobra/transpilers/transpiler/to_rust.py
+++ b/backend/src/cobra/transpilers/transpiler/to_rust.py
@@ -1,6 +1,6 @@
 """Transpilador que genera código Rust a partir de Cobra."""
 
-from src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoLista,
     NodoDiccionario,
     NodoValor,
@@ -22,11 +22,11 @@ from src.core.ast_nodes import (
     NodoSwitch,
     NodoCase,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 from .rust_nodes.asignacion import visit_asignacion as _visit_asignacion
 from .rust_nodes.condicional import visit_condicional as _visit_condicional

--- a/backend/src/cobra/transpilers/transpiler/to_wasm.py
+++ b/backend/src/cobra/transpilers/transpiler/to_wasm.py
@@ -1,17 +1,17 @@
 """Transpilador muy básico que genera código WebAssembly en formato WAT."""
 
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoAsignacion,
     NodoFuncion,
     NodoOperacionBinaria,
     NodoValor,
     NodoIdentificador,
 )
-from backend.src.cobra.lexico.lexer import TipoToken
-from backend.src.core.visitor import NodeVisitor
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
 from ..base import BaseTranspiler
-from backend.src.core.optimizations import optimize_constants, remove_dead_code, inline_functions
-from backend.src.cobra.macro import expandir_macros
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
 
 
 class TranspiladorWasm(BaseTranspiler):

--- a/backend/src/core/ast_cache.py
+++ b/backend/src/core/ast_cache.py
@@ -55,7 +55,7 @@ def obtener_tokens(codigo: str):
         with open(ruta, "rb") as f:
             return SafeUnpickler(f).load()
 
-    from src.cobra.lexico.lexer import Lexer
+    from cobra.lexico.lexer import Lexer
     tokens = Lexer(codigo).tokenizar()
     with open(ruta, "wb") as f:
         pickle.dump(tokens, f)
@@ -75,7 +75,7 @@ def obtener_ast(codigo: str):
             return SafeUnpickler(f).load()
 
     tokens = obtener_tokens(codigo)
-    from src.cobra.parser.parser import Parser
+    from cobra.parser.parser import Parser
     ast = Parser(tokens).parsear()
 
     with open(ruta, "wb") as f:
@@ -103,7 +103,7 @@ def obtener_tokens_fragmento(codigo: str):
         with open(ruta, "rb") as f:
             return SafeUnpickler(f).load()
 
-    from src.cobra.lexico.lexer import Lexer
+    from cobra.lexico.lexer import Lexer
     tokens = Lexer(codigo).tokenizar()
     with open(ruta, "wb") as f:
         pickle.dump(tokens, f)
@@ -118,7 +118,7 @@ def obtener_ast_fragmento(codigo: str):
             return SafeUnpickler(f).load()
 
     tokens = obtener_tokens_fragmento(codigo)
-    from src.cobra.parser.parser import Parser
+    from cobra.parser.parser import Parser
     ast = Parser(tokens).parsear()
     with open(ruta, "wb") as f:
         pickle.dump(ast, f)

--- a/backend/src/core/ast_nodes.py
+++ b/backend/src/core/ast_nodes.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 
-from backend.src.cobra.lexico.lexer import Token
+from cobra.lexico.lexer import Token
 
 @dataclass
 class NodoAST:

--- a/backend/src/core/interpreter.py
+++ b/backend/src/core/interpreter.py
@@ -2,21 +2,21 @@
 
 import os
 
-from src.cobra.lexico.lexer import Token, TipoToken, Lexer
-from src.core.optimizations import (
+from cobra.lexico.lexer import Token, TipoToken, Lexer
+from core.optimizations import (
     optimize_constants,
     remove_dead_code,
     inline_functions,
     eliminate_common_subexpressions,
 )
-from src.core.type_utils import (
+from core.type_utils import (
     verificar_sumables,
     verificar_numeros,
     verificar_comparables,
     verificar_booleanos,
     verificar_booleano,
 )
-from src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoBucleMientras,
@@ -41,20 +41,20 @@ from src.core.ast_nodes import (
     NodoImport,
     NodoUsar, NodoAssert, NodoDel, NodoGlobal, NodoNoLocal, NodoWith, NodoImportDesde,
 )
-from src.cobra.parser.parser import Parser
-from src.core.memoria.gestor_memoria import GestorMemoriaGenetico
-from src.core.semantic_validators import (
+from cobra.parser.parser import Parser
+from core.memoria.gestor_memoria import GestorMemoriaGenetico
+from core.semantic_validators import (
     construir_cadena,
     PrimitivaPeligrosaError,
 )
-from src.cobra.semantico import AnalizadorSemantico
-from src.core.qualia_bridge import register_execution
-from src.core.cobra_config import (
+from cobra.semantico import AnalizadorSemantico
+from core.qualia_bridge import register_execution
+from core.cobra_config import (
     limite_nodos,
     limite_memoria_mb,
     limite_cpu_segundos,
 )
-from src.core.resource_limits import (
+from core.resource_limits import (
     limitar_memoria_mb as _lim_mem,
     limitar_cpu_segundos as _lim_cpu,
 )
@@ -592,7 +592,7 @@ class InterpretadorCobra:
 
     def ejecutar_usar(self, nodo):
         """Importa un módulo de Python instalándolo si es necesario."""
-        from src.cobra.usar_loader import obtener_modulo
+        from cobra.usar_loader import obtener_modulo
 
         try:
             modulo = obtener_modulo(nodo.modulo)

--- a/backend/src/core/optimizations/constant_folder.py
+++ b/backend/src/core/optimizations/constant_folder.py
@@ -16,7 +16,7 @@ from ..ast_nodes import (
     NodoMetodo,
     NodoRetorno,
 )
-from src.cobra.lexico.lexer import TipoToken, Token
+from cobra.lexico.lexer import TipoToken, Token
 
 
 class _ConstantFolder(NodeVisitor):

--- a/backend/src/core/semantic_validator.py
+++ b/backend/src/core/semantic_validator.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """Módulo de compatibilidad para el antiguo validador semántico."""
 
-from backend.src.core.semantic_validators import (
+from core.semantic_validators import (
     PrimitivaPeligrosaError,
     ValidadorPrimitivaPeligrosa,
     construir_cadena,

--- a/backend/src/core/semantic_validators/__init__.py
+++ b/backend/src/core/semantic_validators/__init__.py
@@ -8,7 +8,7 @@ from .auditoria import ValidadorAuditoria
 from .import_seguro import ValidadorImportSeguro
 from .fs_access import ValidadorSistemaArchivos
 from .reflexion_segura import ValidadorProhibirReflexion
-from src.core.cobra_config import auditoria_activa
+from core.cobra_config import auditoria_activa
 
 # Instancia por defecto reutilizable de la cadena de validación
 _CADENA_DEFECTO = None

--- a/backend/src/core/semantic_validators/auditoria.py
+++ b/backend/src/core/semantic_validators/auditoria.py
@@ -1,7 +1,7 @@
 import logging
 
 from .base import ValidadorBase
-from src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoLlamadaFuncion,
     NodoLlamadaMetodo,
     NodoHilo,

--- a/backend/src/core/semantic_validators/base.py
+++ b/backend/src/core/semantic_validators/base.py
@@ -1,4 +1,4 @@
-from src.core.visitor import NodeVisitor
+from core.visitor import NodeVisitor
 
 class ValidadorBase(NodeVisitor):
     """Validador base para componer una cadena de validadores."""

--- a/backend/src/core/semantic_validators/fs_access.py
+++ b/backend/src/core/semantic_validators/fs_access.py
@@ -1,5 +1,5 @@
 from .base import ValidadorBase
-from src.core.ast_nodes import NodoLlamadaFuncion, NodoLlamadaMetodo
+from core.ast_nodes import NodoLlamadaFuncion, NodoLlamadaMetodo
 from .primitiva_peligrosa import PrimitivaPeligrosaError
 
 

--- a/backend/src/core/semantic_validators/import_seguro.py
+++ b/backend/src/core/semantic_validators/import_seguro.py
@@ -1,6 +1,6 @@
 import os
 from .base import ValidadorBase
-from src.core.ast_nodes import NodoImport
+from core.ast_nodes import NodoImport
 from .primitiva_peligrosa import PrimitivaPeligrosaError
 
 
@@ -8,7 +8,7 @@ class ValidadorImportSeguro(ValidadorBase):
     """Valida que las instrucciones import sean seguras."""
 
     def visit_import(self, nodo: NodoImport):
-        from src.core.interpreter import MODULES_PATH, IMPORT_WHITELIST
+        from core.interpreter import MODULES_PATH, IMPORT_WHITELIST
 
         ruta = os.path.abspath(nodo.ruta)
         if not ruta.startswith(MODULES_PATH) and ruta not in IMPORT_WHITELIST:

--- a/backend/src/core/semantic_validators/primitiva_peligrosa.py
+++ b/backend/src/core/semantic_validators/primitiva_peligrosa.py
@@ -1,5 +1,5 @@
 from .base import ValidadorBase
-from src.core.ast_nodes import NodoLlamadaFuncion, NodoHilo, NodoLlamadaMetodo
+from core.ast_nodes import NodoLlamadaFuncion, NodoHilo, NodoLlamadaMetodo
 
 
 class PrimitivaPeligrosaError(Exception):

--- a/backend/src/core/semantic_validators/reflexion_segura.py
+++ b/backend/src/core/semantic_validators/reflexion_segura.py
@@ -1,5 +1,5 @@
 from .base import ValidadorBase
-from src.core.ast_nodes import NodoLlamadaFuncion, NodoLlamadaMetodo, NodoAtributo
+from core.ast_nodes import NodoLlamadaFuncion, NodoLlamadaMetodo, NodoAtributo
 from .primitiva_peligrosa import PrimitivaPeligrosaError
 
 

--- a/backend/src/gui/app.py
+++ b/backend/src/gui/app.py
@@ -2,9 +2,9 @@ import io
 import sys
 import flet as ft
 
-from backend.src.cobra.lexico.lexer import Lexer
-from backend.src.cobra.parser.parser import Parser
-from backend.src.core.interpreter import InterpretadorCobra
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.interpreter import InterpretadorCobra
 
 
 def _ejecutar_codigo(codigo: str) -> str:

--- a/backend/src/gui/idle.py
+++ b/backend/src/gui/idle.py
@@ -2,9 +2,9 @@ import io
 import sys
 import flet as ft
 
-from backend.src.cobra.lexico.lexer import Lexer
-from backend.src.cobra.parser.parser import Parser
-from backend.src.core.interpreter import InterpretadorCobra
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.interpreter import InterpretadorCobra
 
 
 def _ejecutar_codigo(codigo: str) -> str:

--- a/backend/src/ia/analizador_agix.py
+++ b/backend/src/ia/analizador_agix.py
@@ -6,8 +6,8 @@ except ImportError:  # pragma: no cover - depende de agix instalado
     Reasoner = None
 from typing import List
 
-from backend.src.cobra.lexico.lexer import Lexer
-from backend.src.cobra.parser.parser import Parser
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
 
 
 def generar_sugerencias(codigo: str) -> List[str]:

--- a/backend/src/jupyter_kernel/__init__.py
+++ b/backend/src/jupyter_kernel/__init__.py
@@ -3,10 +3,10 @@ import io
 import contextlib
 from importlib.metadata import PackageNotFoundError, version
 from ipykernel.kernelbase import Kernel
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser, PALABRAS_RESERVADAS
-from src.core.interpreter import InterpretadorCobra
-from src.core.qualia_bridge import get_suggestions
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser, PALABRAS_RESERVADAS
+from core.interpreter import InterpretadorCobra
+from core.qualia_bridge import get_suggestions
 
 
 def _get_version() -> str:

--- a/backend/src/lsp/cobra_plugin.py
+++ b/backend/src/lsp/cobra_plugin.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import re
 from pylsp import hookimpl, lsp
 from standard_library import __all__ as STD_FUNCS
-from src.cobra.lexico.lexer import Lexer, LexerError
-from src.cobra.parser.parser import Parser
-from src.cli.commands.execute_cmd import ExecuteCommand
+from cobra.lexico.lexer import Lexer, LexerError
+from cobra.parser.parser import Parser
+from cli.commands.execute_cmd import ExecuteCommand
 
 # Palabras reservadas más comunes de Cobra
 KEYWORDS = [


### PR DESCRIPTION
## Summary
- remove `src.` prefix from backend imports

## Testing
- `pytest -q` *(fails: 155 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6873d3fdab608327955cef61f555e12c