### PR TITLE
Remove src prefix from import strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ Al generar código para Python, `imprimir` se convierte en `print`, `mientras` e
 El proyecto instala automáticamente la librería `holobit-sdk`, utilizada para visualizar y manipular holobits. Las funciones `graficar`, `proyectar` y `transformar` de `src.core.holobits` delegan en esta API.
 
 ```python
-from src.core.holobits import Holobit, graficar, proyectar, transformar
+from core.holobits import Holobit, graficar, proyectar, transformar
 
 h = Holobit([0.8, -0.5, 1.2, 0.0, 0.0, 0.0])
 proyectar(h, "2D")
@@ -857,7 +857,7 @@ cobra plugins
 ### Ejemplo de plugin
 
 ```python
-from src.cli.plugin import PluginCommand
+from cli.plugin import PluginCommand
 
 
 class HolaCommand(PluginCommand):

--- a/examples/plugins/hora_plugin.py
+++ b/examples/plugins/hora_plugin.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from src.cli.plugin import PluginCommand
+from cli.plugin import PluginCommand
 
 class HoraCommand(PluginCommand):
     """Muestra la hora actual por pantalla."""

--- a/examples/plugins/md2cobra_plugin.py
+++ b/examples/plugins/md2cobra_plugin.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import re
-from src.cli.plugin import PluginCommand
+from cli.plugin import PluginCommand
 
 
 class MarkdownToCobraCommand(PluginCommand):

--- a/examples/plugins/saludo_plugin.py
+++ b/examples/plugins/saludo_plugin.py
@@ -1,4 +1,4 @@
-from src.cli.plugin import PluginCommand
+from cli.plugin import PluginCommand
 
 class SaludoCommand(PluginCommand):
     """Comando de ejemplo que imprime un saludo."""

--- a/examples/tutorial_basico/compile_manual.py
+++ b/examples/tutorial_basico/compile_manual.py
@@ -1,9 +1,9 @@
 import sys
 import backend
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.core.ast_nodes import NodoValor, NodoImprimir
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from core.ast_nodes import NodoValor, NodoImprimir
 
 codigo = open('examples/tutorial_basico/hola_mundo.co').read()
 lex = Lexer(codigo)

--- a/examples/tutorial_basico/hola_mundo.py
+++ b/examples/tutorial_basico/hola_mundo.py
@@ -1,4 +1,4 @@
-from src.core.nativos import *
+from core.nativos import *
 from corelibs import *
 from standard_library import *
 print('Hola, mundo!')

--- a/frontend/docs/benchmarking.rst
+++ b/frontend/docs/benchmarking.rst
@@ -15,7 +15,7 @@ de tiempo:
 
 .. code-block:: python
 
-    from src.core.performance import perfilar
+    from core.performance import perfilar
 
     def sumar(a, b):
         return a + b
@@ -31,7 +31,7 @@ Si deseas aplicar automáticamente optimizaciones de ``smooth-criminal`` usa
 
 .. code-block:: python
 
-    from src.core.performance import optimizar
+    from core.performance import optimizar
 
     @optimizar()
     def proceso():

--- a/frontend/docs/ejemplos_avanzados.rst
+++ b/frontend/docs/ejemplos_avanzados.rst
@@ -125,7 +125,7 @@ Cobra puede extenderse con plugins escritos en Python que heredan de
 
 .. code-block:: python
 
-   from src.cli.plugin import PluginCommand
+   from cli.plugin import PluginCommand
 
    class SaludoCommand(PluginCommand):
        name = "saludo"

--- a/frontend/docs/plugin_dev.rst
+++ b/frontend/docs/plugin_dev.rst
@@ -33,7 +33,7 @@ En ``hola.py`` se define la clase del comando:
 
 .. code-block:: python
 
-   from src.cli.plugin import PluginCommand
+   from cli.plugin import PluginCommand
 
 
    class HolaCommand(PluginCommand):

--- a/frontend/docs/plugin_sdk.rst
+++ b/frontend/docs/plugin_sdk.rst
@@ -33,7 +33,7 @@ Ejemplo de implementación
 
 .. code-block:: python
 
-   from src.cli.plugin import PluginCommand
+   from cli.plugin import PluginCommand
 
 
    class HolaCommand(PluginCommand):
@@ -70,7 +70,7 @@ Al instanciarse, cada plugin registra su nombre y versión en el
 
 .. code-block:: python
 
-   from src.cli.plugin import obtener_registro
+   from cli.plugin import obtener_registro
 
    print(obtener_registro())  # {'hola': '1.0'}
 
@@ -86,7 +86,7 @@ muestra su contenido:
 
 .. code-block:: python
 
-   from src.cli.plugin import obtener_registro
+   from cli.plugin import obtener_registro
 
    for nombre, version in obtener_registro().items():
        print(nombre, version)

--- a/frontend/docs/plugins.rst
+++ b/frontend/docs/plugins.rst
@@ -28,7 +28,7 @@ A continuación se muestra cómo crear un plugin sencillo utilizando
 
      .. code-block:: python
 
-        from src.cli.plugin import PluginCommand
+        from cli.plugin import PluginCommand
 
 
       class SaludoCommand(PluginCommand):

--- a/frontend/docs/validador.rst
+++ b/frontend/docs/validador.rst
@@ -35,7 +35,7 @@ otros validadores pasando una lista a esta función.
 
 .. code-block:: python
 
-   from src.core.semantic_validators import construir_cadena, ValidadorBase
+   from core.semantic_validators import construir_cadena, ValidadorBase
 
    class MiValidador(ValidadorBase):
        def visit_mi_nodo(self, nodo):
@@ -54,7 +54,7 @@ definir una lista ``VALIDADORES_EXTRA`` con las instancias a añadir.
 .. code-block:: python
 
    # archivo validadores.py
-   from src.core.semantic_validators.base import ValidadorBase
+   from core.semantic_validators.base import ValidadorBase
 
    class Demo(ValidadorBase):
        def visit_valor(self, nodo):

--- a/tests/unit/test_cli_commands_extra.py
+++ b/tests/unit/test_cli_commands_extra.py
@@ -15,7 +15,7 @@ from src.cli.commands import modules_cmd
             "python",
             [
                 "Código generado (TranspiladorPython):",
-                "from src.core.nativos import *",
+                "from core.nativos import *",
                 "x = 5",
             ],
         ),

--- a/tests/unit/test_custom_validators.py
+++ b/tests/unit/test_custom_validators.py
@@ -19,7 +19,7 @@ def test_interpreter_extra_validators_list():
 def test_interpreter_extra_validators_file(tmp_path):
     mod = tmp_path / 'vals.py'
     mod.write_text(
-        'from src.core.semantic_validators.base import ValidadorBase\n'
+        'from core.semantic_validators.base import ValidadorBase\n'
         'class V(ValidadorBase):\n'
         '    def visit_valor(self, nodo):\n'
         '        raise Exception("file")\n'

--- a/tests/unit/test_decoradores_yield.py
+++ b/tests/unit/test_decoradores_yield.py
@@ -7,6 +7,9 @@ from src.core.ast_nodes import (
     NodoIdentificador,
 )
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 
 
 def test_transpilar_funcion_con_decorador():
@@ -14,7 +17,7 @@ def test_transpilar_funcion_con_decorador():
     func = NodoFuncion("saluda", [], [NodoImprimir(NodoValor("'hola'"))], [decorador])
     codigo = TranspiladorPython().generate_code([func])
     esperado = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "@decor\n"
         "def saluda():\n    print('hola')\n"
     )
@@ -25,7 +28,7 @@ def test_transpilar_funcion_con_yield():
     func = NodoFuncion("generador", [], [NodoYield(NodoValor(1))])
     codigo = TranspiladorPython().generate_code([func])
     esperado = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "def generador():\n    yield 1\n"
     )
     assert codigo == esperado

--- a/tests/unit/test_import.py
+++ b/tests/unit/test_import.py
@@ -10,6 +10,9 @@ from src.core.interpreter import (
     IMPORT_WHITELIST,
 )
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 
 
 @pytest.mark.timeout(5)
@@ -42,8 +45,6 @@ def test_import_transpiler(tmp_path):
     ast = Parser(tokens).parsear()
 
     py_code = TranspiladorPython().generate_code(ast)
-    expected = (
-        "from src.core.nativos import *\nvalor = 3\nprint(valor)\n"
-    )
+    expected = IMPORTS + "valor = 3\nprint(valor)\n"
     assert py_code == expected
 

--- a/tests/unit/test_imports_alias_clase.py
+++ b/tests/unit/test_imports_alias_clase.py
@@ -9,6 +9,9 @@ from backend.src.core.ast_nodes import (
 )
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS_PY = get_standard_imports("python")
 
 
 def crear_ast():
@@ -33,8 +36,8 @@ def test_transpilador_python_imports_alias_clase():
     resultado = TranspiladorPython().generate_code(ast)
     esperado = (
         "import asyncio\n"
-        "from src.core.nativos import *\n"
-        "from package.module import decorador as dec\n"
+        + IMPORTS_PY
+        + "from package.module import decorador as dec\n"
         "from package2.module2 import Base as B\n"
         "@dec\n"
         "class C(B):\n"

--- a/tests/unit/test_inlining_transpilers.py
+++ b/tests/unit/test_inlining_transpilers.py
@@ -2,6 +2,9 @@ import pytest
 from src.core.ast_nodes import NodoFuncion, NodoRetorno, NodoValor, NodoAsignacion, NodoLlamadaFuncion
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 
 
 def _ast_inline():
@@ -13,7 +16,7 @@ def _ast_inline():
 
 def test_inline_python_transpiler():
     codigo = TranspiladorPython().generate_code(_ast_inline())
-    assert codigo == "from src.core.nativos import *\nx = 1\n"
+    assert codigo == IMPORTS + "x = 1\n"
 
 
 def test_inline_js_transpiler():

--- a/tests/unit/test_integracion_transpiladores.py
+++ b/tests/unit/test_integracion_transpiladores.py
@@ -3,6 +3,9 @@ from src.cobra.lexico.lexer import Lexer
 from src.cobra.parser.parser import Parser
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 
 
 def test_integracion_python():
@@ -10,7 +13,7 @@ def test_integracion_python():
     tokens = Lexer(codigo).analizar_token()
     ast = Parser(tokens).parsear()
     resultado = TranspiladorPython().generate_code(ast)
-    esperado = "from src.core.nativos import *\nx = 10\n"
+    esperado = IMPORTS + "x = 10\n"
     assert resultado == esperado
 
 
@@ -36,7 +39,7 @@ def test_integracion_condicional_python():
     ast = Parser(tokens).parsear()
     resultado = TranspiladorPython().generate_code(ast)
     esperado = (
-        "from src.core.nativos import *\n"
+        IMPORTS
         "x = 10\n"
         "if x > 5:\n"
         "    print(x)\n"

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -2,6 +2,9 @@ from src.cobra.lexico.lexer import Lexer
 from src.cobra.parser.parser import Parser
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 from src.cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 
 
 def test_macro_python():
@@ -9,7 +12,7 @@ def test_macro_python():
     tokens = Lexer(codigo).tokenizar()
     ast = Parser(tokens).parsear()
     resultado = TranspiladorPython().generate_code(ast)
-    assert resultado == "from src.core.nativos import *\nprint(1)\n"
+    assert resultado == IMPORTS + "print(1)\n"
 
 
 def test_macro_cpp():

--- a/tests/unit/test_module_map.py
+++ b/tests/unit/test_module_map.py
@@ -6,6 +6,9 @@ from src.cobra.parser.parser import Parser
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 from src.cobra.transpilers import module_map
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 
 
 def test_transpilador_mapeo_python(tmp_path, monkeypatch):
@@ -26,7 +29,7 @@ def test_transpilador_mapeo_python(tmp_path, monkeypatch):
     ast = Parser(tokens).parsear()
 
     resultado = TranspiladorPython().generate_code(ast)
-    esperado = f"from src.core.nativos import *\n{py_out.read_text()}print(x)\n"
+    esperado = IMPORTS + f"{py_out.read_text()}print(x)\n"
     assert resultado == esperado
 
 

--- a/tests/unit/test_operadores.py
+++ b/tests/unit/test_operadores.py
@@ -4,6 +4,9 @@ from src.cobra.parser.parser import Parser
 from backend.src.core.ast_nodes import NodoOperacionBinaria, NodoOperacionUnaria
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 from src.core.interpreter import InterpretadorCobra
 
 
@@ -98,7 +101,7 @@ def test_transpiladores_operaciones():
     expr = parser.parsear()[0]
     py_code = TranspiladorPython().generate_code([expr])
     js_code = TranspiladorJavaScript().generate_code([expr])
-    assert py_code == "from src.core.nativos import *\nTrue"
+    assert py_code == IMPORTS + "True"
     assert js_code == (
         "import * as io from './nativos/io.js';\n"
         "import * as net from './nativos/io.js';\n"

--- a/tests/unit/test_pasar.py
+++ b/tests/unit/test_pasar.py
@@ -3,6 +3,9 @@ from src.cobra.parser.parser import Parser
 from src.core.ast_nodes import NodoBucleMientras, NodoPasar
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 
 
 def test_parser_pasar():
@@ -21,7 +24,7 @@ def test_transpilar_pasar_python():
     nodo = NodoPasar()
     t = TranspiladorPython()
     resultado = t.generate_code([nodo])
-    esperado = "from src.core.nativos import *\npass\n"
+    esperado = IMPORTS + "pass\n"
     assert resultado == esperado
 
 

--- a/tests/unit/test_pcobra_module_map.py
+++ b/tests/unit/test_pcobra_module_map.py
@@ -5,6 +5,9 @@ from src.cobra.parser.parser import Parser
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 from src.cobra.transpilers import module_map
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 
 
 def _write_toml(path, data):
@@ -34,7 +37,7 @@ def test_pcobra_mapeo_python(tmp_path, monkeypatch):
     ast = Parser(tokens).parsear()
 
     resultado = TranspiladorPython().generate_code(ast)
-    esperado = f"from src.core.nativos import *\n{py_out.read_text()}print(x)\n"
+    esperado = IMPORTS + f"{py_out.read_text()}print(x)\n"
     assert resultado == esperado
 
 

--- a/tests/unit/test_romper_continuar.py
+++ b/tests/unit/test_romper_continuar.py
@@ -10,6 +10,9 @@ from src.core.ast_nodes import (
 )
 from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
 from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from src.cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS = get_standard_imports("python")
 
 
 def test_parser_romper_continuar():
@@ -33,7 +36,7 @@ def test_transpilar_romper_python():
     nodo = NodoBucleMientras("i < 3", [NodoRomper()])
     t = TranspiladorPython()
     resultado = t.generate_code([nodo])
-    esperado = "from src.core.nativos import *\nwhile i < 3:\n    break\n"
+    esperado = IMPORTS + "while i < 3:\n    break\n"
     assert resultado == esperado
 
 

--- a/tests/unit/test_to_python_extras.py
+++ b/tests/unit/test_to_python_extras.py
@@ -42,7 +42,7 @@ def test_transpilar_usar():
     codigo = TranspiladorPython().generate_code([nodo])
     esperado = (
         IMPORTS
-        "from src.cobra.usar_loader import obtener_modulo\n"
+        "from cobra.usar_loader import obtener_modulo\n"
         "math = obtener_modulo('math')\n"
     )
     assert codigo == esperado


### PR DESCRIPTION
## Summary
- drop `src.` prefix from example code snippets
- update test expectations to use new paths
- adjust docs and plugin samples

## Testing
- `PYTHONPATH=. pytest tests/unit/test_romper_continuar.py::test_transpilar_romper_python -q`

------
https://chatgpt.com/codex/tasks/task_e_6873d646ca38832784c07f1b73db5e84