### PR TITLE
Add docs clarifying src alias modules

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,3 +1,15 @@
+"""Inicializa el paquete ``backend`` para desarrollo.
+
+Este archivo se ejecuta al importar ``backend`` directamente desde el
+repositorio. Su principal objetivo es exponer los módulos ubicados en
+``backend/src`` bajo el alias ``src`` para mantener compatibilidad con
+código legado y ejemplos que aún realizan ``import src.*``.
+
+Se añade ``backend/src`` al ``sys.path`` y se propagan algunos
+submódulos a ``sys.modules`` para que puedan ser localizados mediante
+``import src...`` sin necesidad de instalar el paquete.
+"""
+
 import importlib
 import sys
 from pathlib import Path

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,3 +1,12 @@
+"""Habilita la resolución del paquete ``src`` durante el desarrollo.
+
+Python carga este módulo automáticamente al iniciar si se encuentra en
+``sys.path``. Al ejecutarse, importa ``backend.src`` y registra sus
+submódulos en ``sys.modules`` bajo el nombre ``src``. Esto permite que
+los imports del estilo ``from src.modulo import ...`` funcionen sin
+haber instalado previamente el paquete.
+"""
+
 import importlib
 import sys
 


### PR DESCRIPTION
## Summary
- document purpose of `backend/__init__.py`
- document purpose of `sitecustomize.py`

## Testing
- `pytest tests/unit/test_import.py::test_import_basico -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_6873d6462508832792ab853368dfd899