### PR TITLE
Normalize tests imports

### DIFF
--- a/tests/fuzz/test_fuzz_parser.py
+++ b/tests/fuzz/test_fuzz_parser.py
@@ -2,14 +2,16 @@ from pathlib import Path
 import sys
 
 # Asegura que los módulos del proyecto sean importables
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "backend"))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend" / "src"))
+sys.path.insert(0, str(ROOT))
 
 from hypothesis import given, strategies as st
 
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.core.sandbox import ejecutar_en_sandbox
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from core.sandbox import ejecutar_en_sandbox
 
 
 # Estrategias para construir identificadores y valores simples

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -2,7 +2,7 @@ import pytest
 from io import StringIO
 from unittest.mock import patch
 import backend  # ensure backend aliases are initialized
-from src.cli.cli import main
+from cli.cli import main
 
 
 def test_cli_help():

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -21,7 +21,7 @@ def _spawn(args, extra_env=None):
     if extra_env:
         env.update(extra_env)
     return pexpect.spawn(
-        f"{sys.executable} -m src.cli.cli {args}", env=env, encoding="utf-8"
+        f"{sys.executable} -m cli.cli {args}", env=env, encoding="utf-8"
     )
 
 

--- a/tests/integration/test_cross_backend_output.py
+++ b/tests/integration/test_cross_backend_output.py
@@ -1,17 +1,19 @@
 import sys
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
 from io import StringIO
 from unittest.mock import patch
 import subprocess
 import shutil
 
 import backend
-from backend.src.core.interpreter import InterpretadorCobra
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from backend.src.cli.commands.compile_cmd import TRANSPILERS
-from backend.src.core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
+from core.interpreter import InterpretadorCobra
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from cli.commands.compile_cmd import TRANSPILERS
+from core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
 import pytest
 
 

--- a/tests/integration/test_docs_generation.py
+++ b/tests/integration/test_docs_generation.py
@@ -7,9 +7,11 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
 import backend  # noqa: F401
-from src.cli.cli import main
+from cli.cli import main
 
 
 def test_docs_generation():

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -6,15 +6,17 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import backend  # noqa: F401
-from src.cli.cli import main
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from backend.src.core.interpreter import InterpretadorCobra
-from backend.src.core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
-import backend.src.cobra.transpilers.module_map as module_map
+from cli.cli import main
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.interpreter import InterpretadorCobra
+from core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
+import cobra.transpilers.module_map as module_map
 
 RUNNERS = {"python": ejecutar_en_sandbox, "js": ejecutar_en_sandbox_js}
 

--- a/tests/integration/test_execute_container.py
+++ b/tests/integration/test_execute_container.py
@@ -1,8 +1,10 @@
 import sys
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
 import backend
-from src.cli.cli import main
+from cli.cli import main
 from io import StringIO
 from unittest.mock import patch
 
@@ -11,11 +13,11 @@ def test_execute_en_contenedor(tmp_path, monkeypatch):
     script = tmp_path / "prog.co"
     script.write_text("imprimir('hola')")
 
-    import backend.src.cobra.transpilers.module_map as module_map
+    import cobra.transpilers.module_map as module_map
     monkeypatch.setattr(module_map, "get_toml_map", lambda: {})
     monkeypatch.setattr(module_map, "_toml_cache", {}, raising=False)
 
-    with patch("src.cli.commands.execute_cmd.ejecutar_en_contenedor", return_value="hola") as mock_run, \
+    with patch("cli.commands.execute_cmd.ejecutar_en_contenedor", return_value="hola") as mock_run, \
          patch("sys.stdout", new_callable=StringIO) as out:
         ret = main(["ejecutar", str(script), "--contenedor=python"])
 

--- a/tests/integration/test_transpilador_syntax.py
+++ b/tests/integration/test_transpilador_syntax.py
@@ -4,14 +4,16 @@ from pathlib import Path
 from io import StringIO
 from unittest.mock import patch
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import backend
-from src.cli.cli import main
-import backend.src.core.ast_cache as ast_cache
-from src.cobra.lexico.lexer import Lexer as SrcLexer
-import src.cobra.transpilers.module_map as module_map_src
-import backend.src.cobra.transpilers.module_map as module_map_backend
+from cli.cli import main
+import core.ast_cache as ast_cache
+from cobra.lexico.lexer import Lexer as SrcLexer
+import cobra.transpilers.module_map as module_map_src
+import cobra.transpilers.module_map as module_map_backend
 
 # Map languages to file extensions
 LANG_EXT = {

--- a/tests/integration/test_transpiladores.py
+++ b/tests/integration/test_transpiladores.py
@@ -1,6 +1,6 @@
 import backend
-from backend.src.core.ast_nodes import NodoImprimir, NodoValor
-from backend.src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from core.ast_nodes import NodoImprimir, NodoValor
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
 
 
 def test_transpilador_python_generacion():

--- a/tests/integration/test_transpile_semantics.py
+++ b/tests/integration/test_transpile_semantics.py
@@ -7,14 +7,16 @@ import shutil
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import backend  # noqa: F401
-from backend.src.core.interpreter import InterpretadorCobra
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from backend.src.cli.commands.compile_cmd import TRANSPILERS
-from backend.src.core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
+from core.interpreter import InterpretadorCobra
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from cli.commands.compile_cmd import TRANSPILERS
+from core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
 
 
 def obtener_salida_interprete(archivo: Path) -> str:

--- a/tests/integration/test_transpilers_generation.py
+++ b/tests/integration/test_transpilers_generation.py
@@ -7,14 +7,16 @@ import shutil
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import backend  # noqa: F401
-from backend.src.core.interpreter import InterpretadorCobra
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from backend.src.cli.commands.compile_cmd import TRANSPILERS
-from backend.src.core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
+from core.interpreter import InterpretadorCobra
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from cli.commands.compile_cmd import TRANSPILERS
+from core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
 
 from tests.integration.test_transpile_semantics import (
     ejecutar_codigo,

--- a/tests/integration/usercustomize.py
+++ b/tests/integration/usercustomize.py
@@ -8,7 +8,7 @@ if os.environ.get("PEXPECT_TESTING"):
         return CompletedProcess(cmd, 0)
     subprocess.run = fake_run
     try:
-        import backend.src.core.sandbox as sandbox
+        import core.sandbox as sandbox
 
         def fake_sandbox(code: str) -> None:
             print("hola")

--- a/tests/unit/lexer_test_casos_edge.py
+++ b/tests/unit/lexer_test_casos_edge.py
@@ -1,10 +1,12 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import pytest
-from backend.src.cobra.lexico.lexer import (
+from cobra.lexico.lexer import (
     Lexer,
     TipoToken,
     InvalidTokenError,

--- a/tests/unit/parser_error_handling.py
+++ b/tests/unit/parser_error_handling.py
@@ -1,6 +1,6 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
 
 
 def parse_code(code: str) -> Parser:

--- a/tests/unit/parser_recursion_types.py
+++ b/tests/unit/parser_recursion_types.py
@@ -1,7 +1,7 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoFuncion, NodoAsignacion
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoFuncion, NodoAsignacion
 
 
 def test_recursion_mixed_types_ast():

--- a/tests/unit/parser_test_constructs.py
+++ b/tests/unit/parser_test_constructs.py
@@ -1,7 +1,7 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer, Token, TipoToken
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import (
+from cobra.lexico.lexer import Lexer, Token, TipoToken
+from cobra.parser.parser import Parser
+from core.ast_nodes import (
     NodoPara,
     NodoImprimir,
     NodoValor,

--- a/tests/unit/test_archivo.py
+++ b/tests/unit/test_archivo.py
@@ -2,7 +2,9 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import standard_library.archivo as archivo
 

--- a/tests/unit/test_ast_cache.py
+++ b/tests/unit/test_ast_cache.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from src.cobra.parser.parser import Parser
+from cobra.parser.parser import Parser
 
 
 def test_obtener_ast_reutiliza(monkeypatch, tmp_path):
@@ -11,7 +11,7 @@ def test_obtener_ast_reutiliza(monkeypatch, tmp_path):
     import importlib, sys
     if 'src.core.ast_cache' in sys.modules:
         importlib.reload(sys.modules['src.core.ast_cache'])
-    from src.core.ast_cache import obtener_ast
+    from core.ast_cache import obtener_ast
 
     llamadas = {"count": 0}
 
@@ -40,7 +40,7 @@ def test_limpiar_cache(monkeypatch, tmp_path):
     import importlib, sys
     if 'src.core.ast_cache' in sys.modules:
         importlib.reload(sys.modules['src.core.ast_cache'])
-    from src.core.ast_cache import obtener_ast, limpiar_cache
+    from core.ast_cache import obtener_ast, limpiar_cache
 
     obtener_ast(codigo)
     assert list(cache_dir.glob("*.ast"))

--- a/tests/unit/test_ast_limit.py
+++ b/tests/unit/test_ast_limit.py
@@ -1,7 +1,7 @@
 import pytest
-from src.core.interpreter import InterpretadorCobra
-from src.core.ast_nodes import NodoImprimir, NodoValor
-from src.core.cobra_config import _cache
+from core.interpreter import InterpretadorCobra
+from core.ast_nodes import NodoImprimir, NodoValor
+from core.cobra_config import _cache
 
 
 def test_limite_nodos(monkeypatch, tmp_path):

--- a/tests/unit/test_async.py
+++ b/tests/unit/test_async.py
@@ -3,17 +3,17 @@ from unittest.mock import patch
 import asyncio
 import subprocess
 
-from src.cobra.lexico.lexer import Token, TipoToken
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import (
+from cobra.lexico.lexer import Token, TipoToken
+from cobra.parser.parser import Parser
+from core.ast_nodes import (
     NodoFuncion,
     NodoLlamadaFuncion,
     NodoImprimir,
     NodoValor,
     NodoEsperar,
 )
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 
 
 def test_parser_funcion_asincronica():

--- a/tests/unit/test_auditoria_validator.py
+++ b/tests/unit/test_auditoria_validator.py
@@ -1,9 +1,9 @@
 import logging
 import backend  # garantiza rutas para submódulos
 import pytest
-from src.core.interpreter import InterpretadorCobra
-from src.core.ast_nodes import NodoLlamadaFuncion, NodoValor
-from src.core.semantic_validators import PrimitivaPeligrosaError
+from core.interpreter import InterpretadorCobra
+from core.ast_nodes import NodoLlamadaFuncion, NodoValor
+from core.semantic_validators import PrimitivaPeligrosaError
 
 
 def test_auditoria_registra_primitiva(caplog):

--- a/tests/unit/test_bench_cmd.py
+++ b/tests/unit/test_bench_cmd.py
@@ -3,12 +3,12 @@ from pathlib import Path
 
 import pytest
 
-from src.cli.cli import main
+from cli.cli import main
 
 
 @pytest.mark.timeout(10)
 def test_bench_profile_creates_json(tmp_path, monkeypatch):
-    import src.cli.commands.bench_cmd as bc
+    import cli.commands.bench_cmd as bc
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(

--- a/tests/unit/test_bench_transpilers_cmd.py
+++ b/tests/unit/test_bench_transpilers_cmd.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from src.cli.cli import main
+from cli.cli import main
 
 
 class DummyTranspiler:
@@ -14,7 +14,7 @@ class DummyTranspiler:
 
 @pytest.mark.timeout(10)
 def test_bench_transpilers_generates_results(tmp_path, monkeypatch):
-    import src.cli.commands.bench_transpilers_cmd as bt
+    import cli.commands.bench_transpilers_cmd as bt
 
     monkeypatch.setattr(bt, "TRANSPILERS", {"dummy": DummyTranspiler})
     monkeypatch.setattr(bt, "timeit", lambda func, number=1: 0.01)
@@ -32,7 +32,7 @@ def test_bench_transpilers_generates_results(tmp_path, monkeypatch):
 
 @pytest.mark.timeout(10)
 def test_bench_transpilers_profile_creates_file(tmp_path, monkeypatch):
-    import src.cli.commands.bench_transpilers_cmd as bt
+    import cli.commands.bench_transpilers_cmd as bt
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(bt, "TRANSPILERS", {"dummy": DummyTranspiler})

--- a/tests/unit/test_benchmark_execution.py
+++ b/tests/unit/test_benchmark_execution.py
@@ -2,7 +2,7 @@ import time
 
 import pytest
 
-from backend.src.cli.commands import benchmarks_cmd
+from cli.commands import benchmarks_cmd
 
 
 @pytest.mark.timeout(5)

--- a/tests/unit/test_benchmarks2_cmd.py
+++ b/tests/unit/test_benchmarks2_cmd.py
@@ -9,9 +9,9 @@ from pathlib import Path
 import pytest
 import shutil
 
-from src.cli.cli import main
-from src.cobra.transpilers import module_map
-from src.cli.commands import benchmarks_cmd
+from cli.cli import main
+from cobra.transpilers import module_map
+from cli.commands import benchmarks_cmd
 
 
 @pytest.mark.timeout(20)
@@ -30,7 +30,7 @@ def test_benchmarks2_generates_json(tmp_path, monkeypatch):
 @pytest.mark.timeout(20)
 def test_benchmarks2_without_resource(tmp_path, monkeypatch):
     monkeypatch.setattr(module_map, "get_toml_map", lambda: {})
-    import src.cli.commands.benchmarks2_cmd as b2
+    import cli.commands.benchmarks2_cmd as b2
     monkeypatch.setattr(b2, "resource", None)
 
     def fake_run(self, args):

--- a/tests/unit/test_benchthreads_cmd.py
+++ b/tests/unit/test_benchthreads_cmd.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
-from src.cli.cli import main
-from src.cli.commands import benchthreads_cmd
+from cli.cli import main
+from cli.commands import benchthreads_cmd
 import pytest
 
 @pytest.mark.timeout(10)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -10,7 +10,7 @@ def test_cli_interactive():
 
     with patch("builtins.input", side_effect=inputs), \
             patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-        from src.cli.cli import main
+        from cli.cli import main
         main()
 
     output = mock_stdout.getvalue().strip().split("\n")
@@ -24,7 +24,7 @@ def test_cli_transpilador():
 
     with patch("builtins.input", side_effect=inputs), \
             patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-        from src.cli.cli import main
+        from cli.cli import main
         main()
 
     output = mock_stdout.getvalue().strip().split("\n")

--- a/tests/unit/test_cli2.py
+++ b/tests/unit/test_cli2.py
@@ -10,7 +10,7 @@ def test_cli_interactive():
 
     with patch("builtins.input", side_effect=inputs), \
             patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-        from src.cli.cli import main
+        from cli.cli import main
         main()
 
     output = mock_stdout.getvalue().strip().split("\n")
@@ -24,7 +24,7 @@ def test_cli_transpilador():
 
     with patch("builtins.input", side_effect=inputs), \
             patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-        from src.cli.cli import main
+        from cli.cli import main
         main()
 
     output = mock_stdout.getvalue().strip().split("\n")
@@ -38,7 +38,7 @@ def test_cli_with_holobit():
 
     with patch("builtins.input", side_effect=inputs), \
             patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-        from src.cli.cli import main
+        from cli.cli import main
         main()
 
     output = mock_stdout.getvalue().strip().split("\n")

--- a/tests/unit/test_cli_agix.py
+++ b/tests/unit/test_cli_agix.py
@@ -1,7 +1,7 @@
 from io import StringIO
 from unittest.mock import patch
 
-from src.cli.cli import main
+from cli.cli import main
 
 
 def test_cli_agix_generates_suggestion(tmp_path):

--- a/tests/unit/test_cli_agix_missing_dep.py
+++ b/tests/unit/test_cli_agix_missing_dep.py
@@ -8,7 +8,7 @@ import pytest
 def test_cli_agix_sin_agix(tmp_path):
     archivo = tmp_path / "ejemplo.co"
     archivo.write_text("var x = 5")
-    for mod in ["src.cli.cli", "src.cli.commands.agix_cmd", "src.ia.analizador_agix"]:
+    for mod in ["cli.cli", "cli.commands.agix_cmd", "ia.analizador_agix"]:
         sys.modules.pop(mod, None)
     real_import = __import__
 
@@ -18,7 +18,7 @@ def test_cli_agix_sin_agix(tmp_path):
         return real_import(name, globals, locals, fromlist, level)
 
     with patch("builtins.__import__", side_effect=fake_import):
-        from src.cli.cli import main
+        from cli.cli import main
         with patch("sys.stdout", new_callable=StringIO) as out:
             with pytest.raises(SystemExit):
                 main(["agix", str(archivo)])

--- a/tests/unit/test_cli_cache_cmd.py
+++ b/tests/unit/test_cli_cache_cmd.py
@@ -20,7 +20,7 @@ def test_cli_cache_limpiar(monkeypatch, tmp_path):
             sys.path.insert(0, str(path))
     import backend  # ensure path hooks are set
 
-    from src.cli.commands.cache_cmd import CacheCommand
+    from cli.commands.cache_cmd import CacheCommand
 
     with patch("sys.stdout", new_callable=StringIO) as out:
         CacheCommand().run(argparse.Namespace())

--- a/tests/unit/test_cli_cobrahub.py
+++ b/tests/unit/test_cli_cobrahub.py
@@ -2,16 +2,16 @@ from io import StringIO
 from unittest.mock import patch, MagicMock
 import pytest
 
-from src.cli.cli import main
-from src.cli.commands import modules_cmd
-from src.cli import cobrahub_client
+from cli.cli import main
+from cli.commands import modules_cmd
+from cli import cobrahub_client
 
 
 @pytest.mark.timeout(5)
 def test_cli_modulos_publicar(tmp_path):
     archivo = tmp_path / "m.co"
     archivo.write_text("var x = 1")
-    with patch("src.cli.cobrahub_client.requests.post") as mock_post, \
+    with patch("cli.cobrahub_client.requests.post") as mock_post, \
             patch("sys.stdout", new_callable=StringIO) as out:
         mock_resp = MagicMock()
         mock_resp.raise_for_status.return_value = None
@@ -30,7 +30,7 @@ def test_cli_modulos_buscar(tmp_path, monkeypatch):
     mod_file.write_text("lock: {}\n")
     monkeypatch.setattr(modules_cmd, "MODULE_MAP_PATH", str(mod_file))
     monkeypatch.setattr(modules_cmd, "LOCK_FILE", str(mod_file))
-    with patch("src.cli.cobrahub_client.requests.get") as mock_get, \
+    with patch("cli.cobrahub_client.requests.get") as mock_get, \
             patch("sys.stdout", new_callable=StringIO) as out:
         response = MagicMock()
         response.raise_for_status.return_value = None
@@ -49,8 +49,8 @@ def test_publicar_modulo_url_insegura(tmp_path, monkeypatch):
     mod = tmp_path / "m.co"
     mod.write_text("var x = 1")
     monkeypatch.setattr(cobrahub_client, "COBRAHUB_URL", "http://inseguro/api")
-    with patch("src.cli.cobrahub_client.mostrar_error") as err, \
-            patch("src.cli.cobrahub_client.requests.post") as mock_post:
+    with patch("cli.cobrahub_client.mostrar_error") as err, \
+            patch("cli.cobrahub_client.requests.post") as mock_post:
         ok = cobrahub_client.publicar_modulo(str(mod))
     assert not ok
     err.assert_called_once()
@@ -62,8 +62,8 @@ def test_publicar_modulo_url_insegura(tmp_path, monkeypatch):
 def test_descargar_modulo_url_insegura(tmp_path, monkeypatch):
     destino = tmp_path / "out.co"
     monkeypatch.setattr(cobrahub_client, "COBRAHUB_URL", "http://inseguro/api")
-    with patch("src.cli.cobrahub_client.mostrar_error") as err, \
-            patch("src.cli.cobrahub_client.requests.get") as mock_get:
+    with patch("cli.cobrahub_client.mostrar_error") as err, \
+            patch("cli.cobrahub_client.requests.get") as mock_get:
         ok = cobrahub_client.descargar_modulo("m.co", str(destino))
     assert not ok
     err.assert_called_once()

--- a/tests/unit/test_cli_commands_extra.py
+++ b/tests/unit/test_cli_commands_extra.py
@@ -3,8 +3,8 @@ from io import StringIO
 from unittest.mock import patch
 import yaml
 
-from src.cli.cli import main
-from src.cli.commands import modules_cmd
+from cli.cli import main
+from cli.commands import modules_cmd
 
 
 @pytest.mark.timeout(5)
@@ -151,7 +151,7 @@ def test_cli_ejecutar_imprime(tmp_path):
 def test_cli_ejecutar_flag_seguro(tmp_path):
     archivo = tmp_path / "p.co"
     archivo.write_text("imprimir(1)")
-    with patch("src.cli.commands.execute_cmd.InterpretadorCobra") as mock_interp:
+    with patch("cli.commands.execute_cmd.InterpretadorCobra") as mock_interp:
         main(["--seguro", "ejecutar", str(archivo)])
         mock_interp.assert_called_once_with(safe_mode=True)
         mock_interp.return_value.ejecutar_ast.assert_called_once()
@@ -163,7 +163,7 @@ def test_cli_validadores_extra(tmp_path):
     archivo.write_text("imprimir(1)")
     ruta = tmp_path / "vals.py"
     ruta.write_text("VALIDADORES_EXTRA = []\n")
-    with patch("src.cli.commands.execute_cmd.InterpretadorCobra") as mock_interp:
+    with patch("cli.commands.execute_cmd.InterpretadorCobra") as mock_interp:
         main(["--seguro", f"--validadores-extra={ruta}", "ejecutar", str(archivo)])
         mock_interp.assert_called_once_with(
             safe_mode=True, extra_validators=str(ruta)

--- a/tests/unit/test_cli_compile_parallel.py
+++ b/tests/unit/test_cli_compile_parallel.py
@@ -3,7 +3,7 @@ import pytest
 from io import StringIO
 from unittest.mock import patch
 
-from src.cli.cli import main
+from cli.cli import main
 
 
 def _fake_transpile(self, ast):
@@ -16,8 +16,8 @@ def _fake_transpile(self, ast):
 def test_cli_compilar_varios_tipos_en_paralelo(tmp_path):
     archivo = tmp_path / "c.co"
     archivo.write_text("var x = 5")
-    with patch("src.cobra.transpilers.transpiler.to_python.TranspiladorPython.transpilar", _fake_transpile), \
-         patch("src.cobra.transpilers.transpiler.to_js.TranspiladorJavaScript.transpilar", _fake_transpile), \
+    with patch("cobra.transpilers.transpiler.to_python.TranspiladorPython.transpilar", _fake_transpile), \
+         patch("cobra.transpilers.transpiler.to_js.TranspiladorJavaScript.transpilar", _fake_transpile), \
          patch("sys.stdout", new_callable=StringIO) as out:
         main(["compilar", str(archivo), "--tipos=python,js"])
     lineas = out.getvalue().strip().splitlines()

--- a/tests/unit/test_cli_container.py
+++ b/tests/unit/test_cli_container.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from io import StringIO
 from unittest.mock import patch, call
 
-from src.cli.cli import main
+from cli.cli import main
 
 
 def test_cli_contenedor_invoca_docker():

--- a/tests/unit/test_cli_dependencias.py
+++ b/tests/unit/test_cli_dependencias.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from unittest.mock import patch
 import io
 import tempfile
-from src.cli.commands.dependencias_cmd import DependenciasCommand
+from cli.commands.dependencias_cmd import DependenciasCommand
 
 
 def test_cli_dependencias_instalar_invoca_pip(tmp_path):
@@ -20,8 +20,8 @@ def test_cli_dependencias_instalar_invoca_pip(tmp_path):
         created.append(f)
         return f
 
-    with patch("src.cli.commands.dependencias_cmd.DependenciasCommand._ruta_requirements", return_value=str(req_file)) as mock_req, \
-         patch("src.cli.commands.dependencias_cmd.DependenciasCommand._ruta_pyproject", return_value=str(py_file)) as mock_proj, \
+    with patch("cli.commands.dependencias_cmd.DependenciasCommand._ruta_requirements", return_value=str(req_file)) as mock_req, \
+         patch("cli.commands.dependencias_cmd.DependenciasCommand._ruta_pyproject", return_value=str(py_file)) as mock_proj, \
          patch("tempfile.NamedTemporaryFile", side_effect=fake_tmp) as mock_tmp, \
          patch("subprocess.run") as mock_run:
         DependenciasCommand._instalar_dependencias()
@@ -37,8 +37,8 @@ def test_cli_dependencias_listar_muestra_paquetes(tmp_path):
     py_file = tmp_path / "pyproject.toml"
     py_file.write_text("[project]\ndependencies=['paqueteB==2.0']\n")
 
-    with patch("src.cli.commands.dependencias_cmd.DependenciasCommand._ruta_requirements", return_value=str(req_file)) as mock_req, \
-         patch("src.cli.commands.dependencias_cmd.DependenciasCommand._ruta_pyproject", return_value=str(py_file)) as mock_proj, \
+    with patch("cli.commands.dependencias_cmd.DependenciasCommand._ruta_requirements", return_value=str(req_file)) as mock_req, \
+         patch("cli.commands.dependencias_cmd.DependenciasCommand._ruta_pyproject", return_value=str(py_file)) as mock_proj, \
          patch("sys.stdout", new_callable=io.StringIO) as out:
         DependenciasCommand._listar_dependencias()
         salida = out.getvalue().strip().splitlines()

--- a/tests/unit/test_cli_docs.py
+++ b/tests/unit/test_cli_docs.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from unittest.mock import patch, call
 from io import StringIO
-from src.cli.cli import main
+from cli.cli import main
 
 
 def test_cli_docs_invokes_sphinx():

--- a/tests/unit/test_cli_empaquetar.py
+++ b/tests/unit/test_cli_empaquetar.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from io import StringIO
 from unittest.mock import patch
 
-from src.cli.cli import main
+from cli.cli import main
 
 
 def test_cli_empaquetar_invoca_pyinstaller(tmp_path):

--- a/tests/unit/test_cli_error_messages.py
+++ b/tests/unit/test_cli_error_messages.py
@@ -2,7 +2,7 @@ from io import StringIO
 from unittest.mock import patch
 import pytest
 
-from src.cli.cli import main
+from cli.cli import main
 
 
 @pytest.mark.timeout(5)

--- a/tests/unit/test_cli_exit_codes.py
+++ b/tests/unit/test_cli_exit_codes.py
@@ -3,8 +3,8 @@ from io import StringIO
 from unittest.mock import patch
 import pytest
 
-from src.cli.cli import main
-from src.cli.commands import modules_cmd
+from cli.cli import main
+from cli.commands import modules_cmd
 
 
 def _run_sys_exit(args):

--- a/tests/unit/test_cli_gui.py
+++ b/tests/unit/test_cli_gui.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from src.cli.cli import main
+from cli.cli import main
 
 
 def test_cli_gui_invokes_flet_app():

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -1,7 +1,7 @@
 from io import StringIO
 from unittest.mock import patch
 
-from src.cli.cli import main
+from cli.cli import main
 
 
 def test_cli_init_creates_project(tmp_path):

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -20,7 +20,7 @@ pc_mod.PrintCollector = list
 sys.modules.setdefault("RestrictedPython.PrintCollector", pc_mod)
 sys.modules.setdefault("yaml", ModuleType("yaml"))
 
-from src.cli.commands.interactive_cmd import InteractiveCommand
+from cli.commands.interactive_cmd import InteractiveCommand
 
 
 def _args():
@@ -30,8 +30,8 @@ def _args():
 def test_interactive_exit():
     cmd = InteractiveCommand()
     with patch('builtins.input', side_effect=['salir']), \
-         patch('src.cli.commands.interactive_cmd.InterpretadorCobra') as mock_interp, \
-         patch('src.cli.commands.interactive_cmd.validar_dependencias'):
+         patch('cli.commands.interactive_cmd.InterpretadorCobra') as mock_interp, \
+         patch('cli.commands.interactive_cmd.validar_dependencias'):
         ret = cmd.run(_args())
     assert ret == 0
     mock_interp.assert_called_once_with(safe_mode=False, extra_validators=None)
@@ -40,8 +40,8 @@ def test_interactive_exit():
 def test_interactive_tokens():
     cmd = InteractiveCommand()
     with patch('builtins.input', side_effect=['tokens', 'salir']), \
-         patch('src.cli.commands.interactive_cmd.mostrar_info') as mock_info, \
-         patch('src.cli.commands.interactive_cmd.validar_dependencias'):
+         patch('cli.commands.interactive_cmd.mostrar_info') as mock_info, \
+         patch('cli.commands.interactive_cmd.validar_dependencias'):
         cmd.run(_args())
     mock_info.assert_any_call('Tokens generados:')
 
@@ -49,7 +49,7 @@ def test_interactive_tokens():
 def test_interactive_ast():
     cmd = InteractiveCommand()
     with patch('builtins.input', side_effect=['ast', 'salir']), \
-         patch('src.cli.commands.interactive_cmd.mostrar_info') as mock_info, \
-         patch('src.cli.commands.interactive_cmd.validar_dependencias'):
+         patch('cli.commands.interactive_cmd.mostrar_info') as mock_info, \
+         patch('cli.commands.interactive_cmd.validar_dependencias'):
         cmd.run(_args())
     mock_info.assert_any_call('AST generado:')

--- a/tests/unit/test_cli_jupyter.py
+++ b/tests/unit/test_cli_jupyter.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch, call
 import sys
-from src.cli.cli import main
+from cli.cli import main
 
 
 def test_cli_jupyter_installs_kernel():

--- a/tests/unit/test_cli_paquete.py
+++ b/tests/unit/test_cli_paquete.py
@@ -3,8 +3,8 @@ import zipfile
 import tomllib
 from unittest.mock import patch
 
-from src.cli.cli import main
-from src.cli.commands import modules_cmd, package_cmd
+from cli.cli import main
+from cli.commands import modules_cmd, package_cmd
 
 
 def test_paquete_crear_instalar(tmp_path, monkeypatch):

--- a/tests/unit/test_cli_plugins.py
+++ b/tests/unit/test_cli_plugins.py
@@ -4,12 +4,14 @@ from pathlib import Path
 from unittest.mock import patch
 import sys
 
-from src.cli.cli import main
-from src.cli.plugin_registry import limpiar_registro
+from cli.cli import main
+from cli.plugin_registry import limpiar_registro
 
 # Añadimos la carpeta de plugins de ejemplo al path para poder importar el plugin
 ROOT = Path(__file__).resolve().parents[2]
 PLUGIN_DIR = ROOT / "examples" / "plugins"
+sys.path.insert(0, str(ROOT / "backend" / "src"))
+sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(PLUGIN_DIR))
 
 
@@ -20,7 +22,7 @@ def test_cli_saludo_plugin():
         group="cobra.plugins",
     )
     limpiar_registro()
-    with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+    with patch("cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["saludo"])
     assert "¡Hola desde el plugin de ejemplo!" in out.getvalue()

--- a/tests/unit/test_cli_plugins_cmd.py
+++ b/tests/unit/test_cli_plugins_cmd.py
@@ -3,9 +3,9 @@ from unittest.mock import patch
 import importlib.metadata
 import sys
 
-from src.cli.cli import main
-from src.cli.plugin import PluginCommand
-from src.cli.plugin_registry import limpiar_registro
+from cli.cli import main
+from cli.plugin import PluginCommand
+from cli.plugin_registry import limpiar_registro
 
 
 class DummyPlugin(PluginCommand):
@@ -30,17 +30,17 @@ class HolaPlugin(PluginCommand):
     def run(self, args):
         print("¡Hola desde un plugin!")
 
-sys.modules.setdefault("src.tests.test_cli_plugins_cmd", sys.modules[__name__])
+sys.modules.setdefault("tests.test_cli_plugins_cmd", sys.modules[__name__])
 
 
 def test_cli_plugins_muestra_registro():
     ep = importlib.metadata.EntryPoint(
         name="dummy",
-        value="src.tests.test_cli_plugins_cmd:DummyPlugin",
+        value="tests.test_cli_plugins_cmd:DummyPlugin",
         group="cobra.plugins",
     )
     limpiar_registro()
-    with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+    with patch("cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["plugins"])
     assert "dummy 9.0.0" in out.getvalue().strip()
@@ -49,11 +49,11 @@ def test_cli_plugins_muestra_registro():
 def test_cli_plugin_ejemplo_hola():
     ep = importlib.metadata.EntryPoint(
         name="hola",
-        value="src.tests.test_cli_plugins_cmd:HolaPlugin",
+        value="tests.test_cli_plugins_cmd:HolaPlugin",
         group="cobra.plugins",
     )
     limpiar_registro()
-    with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+    with patch("cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["hola"])
     assert "¡Hola desde un plugin!" in out.getvalue().strip()
@@ -61,7 +61,7 @@ def test_cli_plugin_ejemplo_hola():
 
 def test_cli_plugins_sin_plugins():
     limpiar_registro()
-    with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints(())):
+    with patch("cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints(())):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["plugins"])
     assert "No hay plugins instalados" in out.getvalue()

--- a/tests/unit/test_cli_profile.py
+++ b/tests/unit/test_cli_profile.py
@@ -1,10 +1,10 @@
 from io import StringIO
-from src.cli.cli import main
-from src.cobra.transpilers import module_map
-import backend.src.cobra.transpilers.module_map as backend_map
-import src.core.ast_nodes as src_nodes
-import backend.src.core.ast_nodes as backend_nodes
-import src.core.interpreter as interpreter_mod
+from cli.cli import main
+from cobra.transpilers import module_map
+import cobra.transpilers.module_map as backend_map
+import core.ast_nodes as src_nodes
+import core.ast_nodes as backend_nodes
+import core.interpreter as interpreter_mod
 
 
 def test_cli_profile_creates_file(tmp_path, monkeypatch):

--- a/tests/unit/test_cli_run_examples.py
+++ b/tests/unit/test_cli_run_examples.py
@@ -19,7 +19,7 @@ def _run_cli(args, toml_path):
     env["PYTHONPATH"] = os.pathsep.join(pythonpath)
     env["PCOBRA_TOML"] = str(toml_path)
     proc = subprocess.run(
-        [sys.executable, "-m", "src.cli.cli", *args],
+        [sys.executable, "-m", "cli.cli", *args],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         env=env,

--- a/tests/unit/test_cli_sandbox_docker.py
+++ b/tests/unit/test_cli_sandbox_docker.py
@@ -2,8 +2,8 @@ from io import StringIO
 from unittest.mock import patch
 import subprocess
 
-from src.cli.cli import main
-from src.cobra.transpilers import module_map
+from cli.cli import main
+from cobra.transpilers import module_map
 
 
 def test_cli_sandbox_docker_invoca_docker(monkeypatch):

--- a/tests/unit/test_cli_sandbox_mode.py
+++ b/tests/unit/test_cli_sandbox_mode.py
@@ -2,7 +2,7 @@ import io
 from unittest.mock import patch
 import pytest
 
-from src.cli.cli import main
+from cli.cli import main
 
 
 @pytest.mark.timeout(5)
@@ -10,7 +10,7 @@ def test_cli_sandbox_operacion_prohibida(tmp_path):
     archivo = tmp_path / "script.py"
     archivo.write_text("open('f.txt', 'w')")
     salida = io.StringIO()
-    with patch('backend.src.cobra.transpilers.module_map.get_toml_map', return_value={}), \
+    with patch('cobra.transpilers.module_map.get_toml_map', return_value={}), \
          patch('sys.stdout', salida):
         codigo = main(["ejecutar", str(archivo), "--sandbox"])
     out = salida.getvalue()
@@ -22,7 +22,7 @@ def test_cli_sandbox_operacion_prohibida(tmp_path):
 def test_cli_sandbox_operacion_valida(tmp_path):
     archivo = tmp_path / "script.py"
     archivo.write_text("print(2+2)")
-    with patch('backend.src.cobra.transpilers.module_map.get_toml_map', return_value={}), \
+    with patch('cobra.transpilers.module_map.get_toml_map', return_value={}), \
          patch('sys.stdout', new_callable=io.StringIO):
         codigo = main(["ejecutar", str(archivo), "--sandbox"])
     assert codigo == 0

--- a/tests/unit/test_cli_secure_validators.py
+++ b/tests/unit/test_cli_secure_validators.py
@@ -14,7 +14,7 @@ def _run_cli(args):
         pythonpath.append(env["PYTHONPATH"])
     env["PYTHONPATH"] = os.pathsep.join(pythonpath)
     proc = subprocess.run(
-        [sys.executable, "-m", "src.cli.cli", *args],
+        [sys.executable, "-m", "cli.cli", *args],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=env,

--- a/tests/unit/test_compile_stress.py
+++ b/tests/unit/test_compile_stress.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from backend.src.cli.commands.compile_cmd import CompileCommand
+from cli.commands.compile_cmd import CompileCommand
 
 
 def _fake_transpile(self, ast):
@@ -25,19 +25,19 @@ def test_compile_command_parallel_outputs_unique(tmp_path):
         tipos='python,js,c,cpp',
     )
     with patch(
-        'backend.src.cobra.transpilers.transpiler.to_python.TranspiladorPython.transpilar',
+        'cobra.transpilers.transpiler.to_python.TranspiladorPython.transpilar',
         _fake_transpile,
     ), patch(
-        'backend.src.cobra.transpilers.transpiler.to_js.TranspiladorJavaScript.transpilar',
+        'cobra.transpilers.transpiler.to_js.TranspiladorJavaScript.transpilar',
         _fake_transpile,
     ), patch(
-        'backend.src.cobra.transpilers.transpiler.to_c.TranspiladorC.transpilar',
+        'cobra.transpilers.transpiler.to_c.TranspiladorC.transpilar',
         _fake_transpile,
     ), patch(
-        'backend.src.cobra.transpilers.transpiler.to_cpp.TranspiladorCPP.transpilar',
+        'cobra.transpilers.transpiler.to_cpp.TranspiladorCPP.transpilar',
         _fake_transpile,
     ), patch(
-        'backend.src.cobra.transpilers.module_map.get_toml_map',
+        'cobra.transpilers.module_map.get_toml_map',
         lambda: {},
     ), patch('sys.stdout', new_callable=StringIO) as out:
         CompileCommand().run(args)

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -7,10 +7,10 @@ from unittest.mock import MagicMock, patch
 sys.modules.setdefault('yaml', ModuleType('yaml'))
 
 import backend.corelibs as core
-from backend.src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from backend.src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from backend.src.cobra.transpilers.import_helper import get_standard_imports
-from backend.src.core.ast_nodes import NodoLlamadaFuncion, NodoValor
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.import_helper import get_standard_imports
+from core.ast_nodes import NodoLlamadaFuncion, NodoValor
 
 IMPORTS_PY = get_standard_imports("python")
 IMPORTS_JS = "".join(f"{line}\n" for line in get_standard_imports("js"))

--- a/tests/unit/test_ctypes_bridge.py
+++ b/tests/unit/test_ctypes_bridge.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.core.ast_nodes import (
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from core.ast_nodes import (
     NodoAsignacion,
     NodoValor,
     NodoLlamadaFuncion,

--- a/tests/unit/test_custom_validators.py
+++ b/tests/unit/test_custom_validators.py
@@ -1,7 +1,7 @@
 import pytest
-from src.core.interpreter import InterpretadorCobra
-from src.core.semantic_validators.base import ValidadorBase
-from src.core.ast_nodes import NodoValor
+from core.interpreter import InterpretadorCobra
+from core.semantic_validators.base import ValidadorBase
+from core.ast_nodes import NodoValor
 
 class DummyError(Exception):
     pass

--- a/tests/unit/test_dead_code_integration.py
+++ b/tests/unit/test_dead_code_integration.py
@@ -1,5 +1,5 @@
-from src.core.interpreter import InterpretadorCobra
-from src.core.ast_nodes import (
+from core.interpreter import InterpretadorCobra
+from core.ast_nodes import (
     NodoFuncion,
     NodoRetorno,
     NodoAsignacion,

--- a/tests/unit/test_decoradores_yield.py
+++ b/tests/unit/test_decoradores_yield.py
@@ -1,4 +1,4 @@
-from src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoFuncion,
     NodoDecorador,
     NodoYield,
@@ -6,8 +6,8 @@ from src.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
 )
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -1,6 +1,6 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
 
 
 def parsear_codigo(codigo: str):

--- a/tests/unit/test_fecha.py
+++ b/tests/unit/test_fecha.py
@@ -2,7 +2,9 @@ from datetime import datetime
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import standard_library.fecha as fecha
 

--- a/tests/unit/test_fs_access_validator.py
+++ b/tests/unit/test_fs_access_validator.py
@@ -1,7 +1,7 @@
 import pytest
-from src.core.semantic_validators.fs_access import ValidadorSistemaArchivos
-from src.core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
-from src.core.ast_nodes import NodoLlamadaFuncion, NodoLlamadaMetodo
+from core.semantic_validators.fs_access import ValidadorSistemaArchivos
+from core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
+from core.ast_nodes import NodoLlamadaFuncion, NodoLlamadaMetodo
 
 
 def test_fs_access_funcion_prohibida():

--- a/tests/unit/test_generadores.py
+++ b/tests/unit/test_generadores.py
@@ -1,6 +1,6 @@
-from src.core.ast_nodes import NodoFuncion, NodoYield, NodoValor
-from src.core.ast_nodes import NodoLlamadaFuncion
-from src.core.interpreter import InterpretadorCobra
+from core.ast_nodes import NodoFuncion, NodoYield, NodoValor
+from core.ast_nodes import NodoLlamadaFuncion
+from core.interpreter import InterpretadorCobra
 
 
 def test_interpretador_generador_simple():

--- a/tests/unit/test_gestor_memoria.py
+++ b/tests/unit/test_gestor_memoria.py
@@ -1,5 +1,5 @@
-from src.core.memoria.estrategia_memoria import EstrategiaMemoria
-from src.core.memoria.gestor_memoria import GestorMemoriaGenetico
+from core.memoria.estrategia_memoria import EstrategiaMemoria
+from core.memoria.gestor_memoria import GestorMemoriaGenetico
 
 
 def test_asignacion_y_liberacion():

--- a/tests/unit/test_gestor_memoria2.py
+++ b/tests/unit/test_gestor_memoria2.py
@@ -1,5 +1,5 @@
-from src.core.memoria.estrategia_memoria import EstrategiaMemoria
-from src.core.memoria.gestor_memoria import GestorMemoriaGenetico
+from core.memoria.estrategia_memoria import EstrategiaMemoria
+from core.memoria.gestor_memoria import GestorMemoriaGenetico
 
 
 def test_asignacion_y_liberacion_intensiva():

--- a/tests/unit/test_hilos.py
+++ b/tests/unit/test_hilos.py
@@ -3,12 +3,12 @@ from unittest.mock import patch
 import asyncio
 import subprocess
 
-from src.cobra.lexico.lexer import Token, TipoToken
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoHilo, NodoLlamadaFuncion, NodoValor, NodoImprimir, NodoIdentificador, NodoAsignacion, NodoFuncion
-from src.core.interpreter import InterpretadorCobra
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.lexico.lexer import Token, TipoToken
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoHilo, NodoLlamadaFuncion, NodoValor, NodoImprimir, NodoIdentificador, NodoAsignacion, NodoFuncion
+from core.interpreter import InterpretadorCobra
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 
 
 def test_parser_hilo():

--- a/tests/unit/test_holobit_sdk_integration.py
+++ b/tests/unit/test_holobit_sdk_integration.py
@@ -1,5 +1,5 @@
 import pytest
-from src.core.holobits import Holobit, graficar, proyectar, transformar
+from core.holobits import Holobit, graficar, proyectar, transformar
 
 
 def test_graficar_usa_sdk(monkeypatch):

--- a/tests/unit/test_import.py
+++ b/tests/unit/test_import.py
@@ -2,15 +2,15 @@ import pytest
 from io import StringIO
 from unittest.mock import patch
 
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.interpreter import (
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.interpreter import (
     InterpretadorCobra,
     MODULES_PATH,
     IMPORT_WHITELIST,
 )
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 

--- a/tests/unit/test_import_seguro_validator.py
+++ b/tests/unit/test_import_seguro_validator.py
@@ -1,8 +1,8 @@
 import pytest
 from types import SimpleNamespace
-from src.core.semantic_validators.import_seguro import ValidadorImportSeguro
-from src.core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
-from src.core.ast_nodes import NodoImport
+from core.semantic_validators.import_seguro import ValidadorImportSeguro
+from core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
+from core.ast_nodes import NodoImport
 
 
 def test_import_seguro_fuera_de_ruta(tmp_path, monkeypatch):

--- a/tests/unit/test_imports_alias_clase.py
+++ b/tests/unit/test_imports_alias_clase.py
@@ -1,4 +1,4 @@
-from backend.src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoImportDesde,
     NodoDecorador,
     NodoClase,
@@ -7,9 +7,9 @@ from backend.src.core.ast_nodes import (
     NodoLlamadaFuncion,
     NodoIdentificador,
 )
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS_PY = get_standard_imports("python")
 

--- a/tests/unit/test_inlining_transpilers.py
+++ b/tests/unit/test_inlining_transpilers.py
@@ -1,8 +1,8 @@
 import pytest
-from src.core.ast_nodes import NodoFuncion, NodoRetorno, NodoValor, NodoAsignacion, NodoLlamadaFuncion
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.cobra.transpilers.import_helper import get_standard_imports
+from core.ast_nodes import NodoFuncion, NodoRetorno, NodoValor, NodoAsignacion, NodoLlamadaFuncion
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 

--- a/tests/unit/test_integracion_transpiladores.py
+++ b/tests/unit/test_integracion_transpiladores.py
@@ -1,9 +1,9 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -2,9 +2,9 @@ import pytest
 from io import StringIO
 from unittest.mock import patch
 
-from src.core.interpreter import InterpretadorCobra
-from src.cobra.lexico.lexer import Token, TipoToken
-from src.core.ast_nodes import NodoAsignacion, NodoValor, NodoLlamadaFuncion, NodoFuncion
+from core.interpreter import InterpretadorCobra
+from cobra.lexico.lexer import Token, TipoToken
+from core.ast_nodes import NodoAsignacion, NodoValor, NodoLlamadaFuncion, NodoFuncion
 def test_interpretador_asignacion_y_llamada_funcion():
 
     # Crea una instancia del intérprete

--- a/tests/unit/test_interpreter_atributo.py
+++ b/tests/unit/test_interpreter_atributo.py
@@ -1,9 +1,9 @@
 from io import StringIO
 from unittest.mock import patch
 
-from src.core.interpreter import InterpretadorCobra
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
+from core.interpreter import InterpretadorCobra
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
 
 
 def test_interpreter_atributo_lectura_escritura():

--- a/tests/unit/test_interpreter_concurrency.py
+++ b/tests/unit/test_interpreter_concurrency.py
@@ -1,6 +1,6 @@
 import pytest
-from src.core.interpreter import InterpretadorCobra
-from src.core.ast_nodes import (
+from core.interpreter import InterpretadorCobra
+from core.ast_nodes import (
     NodoAsignacion,
     NodoValor,
     NodoFuncion,

--- a/tests/unit/test_interpreter_inferencia.py
+++ b/tests/unit/test_interpreter_inferencia.py
@@ -1,5 +1,5 @@
-from src.core.interpreter import InterpretadorCobra
-from src.core.ast_nodes import NodoAsignacion, NodoValor
+from core.interpreter import InterpretadorCobra
+from core.ast_nodes import NodoAsignacion, NodoValor
 
 
 def test_interpreter_variable_inferencia():

--- a/tests/unit/test_interpreter_memoria.py
+++ b/tests/unit/test_interpreter_memoria.py
@@ -1,6 +1,6 @@
 import pytest
-from src.core.interpreter import InterpretadorCobra
-from src.core.ast_nodes import NodoAsignacion, NodoValor, NodoFuncion, NodoLlamadaFuncion
+from core.interpreter import InterpretadorCobra
+from core.ast_nodes import NodoAsignacion, NodoValor, NodoFuncion, NodoLlamadaFuncion
 
 def test_asignaciones_intensivas_libera_memoria():
     inter = InterpretadorCobra()

--- a/tests/unit/test_interpreter_objects.py
+++ b/tests/unit/test_interpreter_objects.py
@@ -1,5 +1,5 @@
-from src.core.interpreter import InterpretadorCobra
-from src.core.ast_nodes import (
+from core.interpreter import InterpretadorCobra
+from core.ast_nodes import (
     NodoClase,
     NodoMetodo,
     NodoInstancia,

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -1,5 +1,5 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer, TipoToken, LexerError
+from cobra.lexico.lexer import Lexer, TipoToken, LexerError
 
 
 def test_lexer_asignacion_variable():

--- a/tests/unit/test_lexer2.py
+++ b/tests/unit/test_lexer2.py
@@ -1,4 +1,4 @@
-from src.cobra.lexico.lexer import Lexer, TipoToken
+from cobra.lexico.lexer import Lexer, TipoToken
 
 
 def test_lexer_asignacion_variable():

--- a/tests/unit/test_lexer_additional_cases.py
+++ b/tests/unit/test_lexer_additional_cases.py
@@ -1,5 +1,5 @@
 import pytest
-from src.cobra.lexico.lexer import (
+from cobra.lexico.lexer import (
     Lexer,
     TipoToken,
     InvalidTokenError,

--- a/tests/unit/test_lexer_basics.py
+++ b/tests/unit/test_lexer_basics.py
@@ -1,5 +1,5 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer, TipoToken, LexerError
+from cobra.lexico.lexer import Lexer, TipoToken, LexerError
 
 
 def test_simple_assignment_tokens():

--- a/tests/unit/test_lexer_errors.py
+++ b/tests/unit/test_lexer_errors.py
@@ -1,5 +1,5 @@
 import pytest
-from src.cobra.lexico.lexer import (
+from cobra.lexico.lexer import (
     Lexer,
     LexerError,
     InvalidTokenError,

--- a/tests/unit/test_lexer_errors_extra.py
+++ b/tests/unit/test_lexer_errors_extra.py
@@ -1,5 +1,5 @@
 import pytest
-from src.cobra.lexico.lexer import (
+from cobra.lexico.lexer import (
     Lexer,
     LexerError,
     InvalidTokenError,

--- a/tests/unit/test_lexer_metodo_atributo.py
+++ b/tests/unit/test_lexer_metodo_atributo.py
@@ -1,4 +1,4 @@
-from src.cobra.lexico.lexer import Lexer, TipoToken
+from cobra.lexico.lexer import Lexer, TipoToken
 
 
 def test_lexer_metodo_atributo_tokens():

--- a/tests/unit/test_lista.py
+++ b/tests/unit/test_lista.py
@@ -1,7 +1,9 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import standard_library.lista as lista
 

--- a/tests/unit/test_logica.py
+++ b/tests/unit/test_logica.py
@@ -1,7 +1,9 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import standard_library.logica as logica
 

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -1,8 +1,8 @@
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 

--- a/tests/unit/test_md2cobra_plugin.py
+++ b/tests/unit/test_md2cobra_plugin.py
@@ -4,11 +4,13 @@ from pathlib import Path
 from unittest.mock import patch
 import sys
 
-from src.cli.cli import main
+from cli.cli import main
 
 # Añadimos la carpeta de plugins de ejemplo al path para importar el plugin
 ROOT = Path(__file__).resolve().parents[3]
 PLUGIN_DIR = ROOT / "examples" / "plugins"
+sys.path.insert(0, str(ROOT / "backend" / "src"))
+sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(PLUGIN_DIR))
 
 
@@ -33,7 +35,7 @@ var y = 2
         value="md2cobra_plugin:MarkdownToCobraCommand",
         group="cobra.plugins",
     )
-    with patch("src.cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
+    with patch("cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         main(["md2cobra", "--input", str(md), "--output", str(salida)])
 
     assert salida.exists()

--- a/tests/unit/test_metodo_atributo.py
+++ b/tests/unit/test_metodo_atributo.py
@@ -1,6 +1,6 @@
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoClase, NodoMetodo, NodoAsignacion, NodoAtributo, NodoImprimir
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoClase, NodoMetodo, NodoAsignacion, NodoAtributo, NodoImprimir
 
 
 def test_parser_metodo_keyword():

--- a/tests/unit/test_mod_validator.py
+++ b/tests/unit/test_mod_validator.py
@@ -1,7 +1,7 @@
 import yaml
 import pytest
 
-from src.cobra.semantico.mod_validator import validar_mod
+from cobra.semantico.mod_validator import validar_mod
 
 
 def _write_yaml(path, data):

--- a/tests/unit/test_module_map.py
+++ b/tests/unit/test_module_map.py
@@ -1,12 +1,12 @@
 import yaml
 from unittest.mock import patch
 
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.cobra.transpilers import module_map
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers import module_map
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 

--- a/tests/unit/test_node_visitor.py
+++ b/tests/unit/test_node_visitor.py
@@ -1,7 +1,7 @@
 import pytest
 
-from src.core.visitor import NodeVisitor
-from src.core.ast_nodes import NodoAST
+from core.visitor import NodeVisitor
+from core.ast_nodes import NodoAST
 
 class MiNodo(NodoAST):
     pass

--- a/tests/unit/test_nodo_macro.py
+++ b/tests/unit/test_nodo_macro.py
@@ -1,4 +1,4 @@
-from src.core.ast_nodes import NodoMacro
+from core.ast_nodes import NodoMacro
 
 
 def test_nodo_macro_repr():

--- a/tests/unit/test_nuevos_tokens.py
+++ b/tests/unit/test_nuevos_tokens.py
@@ -1,5 +1,5 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer, TipoToken
+from cobra.lexico.lexer import Lexer, TipoToken
 
 
 def test_lexer_palabras_nuevas():

--- a/tests/unit/test_operadores.py
+++ b/tests/unit/test_operadores.py
@@ -1,13 +1,13 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer, Token, TipoToken
-from src.cobra.parser.parser import Parser
-from backend.src.core.ast_nodes import NodoOperacionBinaria, NodoOperacionUnaria
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.lexico.lexer import Lexer, Token, TipoToken
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoOperacionBinaria, NodoOperacionUnaria
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
-from src.core.interpreter import InterpretadorCobra
+from core.interpreter import InterpretadorCobra
 
 
 def test_lexer_nuevos_operadores():

--- a/tests/unit/test_optimizations.py
+++ b/tests/unit/test_optimizations.py
@@ -1,5 +1,5 @@
 import pytest
-from src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoAsignacion,
     NodoOperacionBinaria,
     NodoOperacionUnaria,
@@ -12,8 +12,8 @@ from src.core.ast_nodes import (
     NodoBucleMientras,
     NodoRomper,
 )
-from src.cobra.lexico.lexer import Token, TipoToken
-from src.core.optimizations import (
+from cobra.lexico.lexer import Token, TipoToken
+from core.optimizations import (
     optimize_constants,
     remove_dead_code,
     inline_functions,

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1,7 +1,7 @@
 import pytest
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoAsignacion, NodoHolobit, NodoCondicional
-from src.cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoAsignacion, NodoHolobit, NodoCondicional
+from cobra.lexico.lexer import Lexer
 
 
 @pytest.mark.timeout(5)  # Timeout de 5 segundos para evitar bucles infinitos

--- a/tests/unit/test_parser2.py
+++ b/tests/unit/test_parser2.py
@@ -1,6 +1,6 @@
-from src.cobra.lexico.lexer import Token, TipoToken
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoCondicional, NodoOperacionBinaria, NodoFuncion, NodoLlamadaFuncion, NodoValor, NodoHolobit, NodoAsignacion, NodoBucleMientras
+from cobra.lexico.lexer import Token, TipoToken
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoCondicional, NodoOperacionBinaria, NodoFuncion, NodoLlamadaFuncion, NodoValor, NodoHolobit, NodoAsignacion, NodoBucleMientras
 
 
 def test_parser_asignacion_variable():

--- a/tests/unit/test_parser3.py
+++ b/tests/unit/test_parser3.py
@@ -1,7 +1,7 @@
 import pytest
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoAsignacion, NodoHolobit, NodoCondicional, NodoBucleMientras, NodoFuncion, NodoLlamadaFuncion, NodoValor
-from src.cobra.lexico.lexer import TipoToken, Token
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoAsignacion, NodoHolobit, NodoCondicional, NodoBucleMientras, NodoFuncion, NodoLlamadaFuncion, NodoValor
+from cobra.lexico.lexer import TipoToken, Token
 
 
 def generar_tokens(*args):

--- a/tests/unit/test_parser4.py
+++ b/tests/unit/test_parser4.py
@@ -1,9 +1,9 @@
 import pytest
 
-from src.cobra.lexico.lexer import Token, TipoToken
-from src.core.ast_nodes import NodoAsignacion, NodoCondicional, NodoFuncion, NodoRetorno, NodoBucleMientras, NodoValor
-from src.cobra.parser.parser import Parser
-from src.cobra.parser.parser import Parser
+from cobra.lexico.lexer import Token, TipoToken
+from core.ast_nodes import NodoAsignacion, NodoCondicional, NodoFuncion, NodoRetorno, NodoBucleMientras, NodoValor
+from cobra.parser.parser import Parser
+from cobra.parser.parser import Parser
 
 
 def test_parser_asignacion():

--- a/tests/unit/test_parser5.py
+++ b/tests/unit/test_parser5.py
@@ -1,7 +1,7 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoPara, NodoImprimir, NodoFuncion
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoPara, NodoImprimir, NodoFuncion
 
 def test_declaracion_para():
     """Prueba una declaración de bucle 'para'."""

--- a/tests/unit/test_parser_ast.py
+++ b/tests/unit/test_parser_ast.py
@@ -1,6 +1,6 @@
-from backend.src.cobra.lexico.lexer import Lexer
-from backend.src.cobra.parser.parser import Parser
-from backend.src.core.ast_nodes import NodoAsignacion, NodoValor
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoAsignacion, NodoValor
 
 
 def test_parser_generates_ast_for_assignment():

--- a/tests/unit/test_parser_clase.py
+++ b/tests/unit/test_parser_clase.py
@@ -1,6 +1,6 @@
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoClase, NodoMetodo
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoClase, NodoMetodo
 
 
 def test_parser_declaracion_clase():

--- a/tests/unit/test_parser_condicional_anidado.py
+++ b/tests/unit/test_parser_condicional_anidado.py
@@ -1,7 +1,7 @@
 import pytest
-from backend.src.cobra.lexico.lexer import Lexer
-from backend.src.cobra.parser.parser import Parser
-from backend.src.core.ast_nodes import NodoCondicional
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoCondicional
 
 
 def test_parser_condicional_si_en_sino():

--- a/tests/unit/test_parser_decorador.py
+++ b/tests/unit/test_parser_decorador.py
@@ -1,6 +1,6 @@
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoFuncion, NodoDecorador, NodoIdentificador
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoFuncion, NodoDecorador, NodoIdentificador
 
 
 def test_parser_funcion_con_decorador():

--- a/tests/unit/test_parser_del_global.py
+++ b/tests/unit/test_parser_del_global.py
@@ -6,13 +6,13 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "backend" / "src"))
 sys.path.insert(0, str(ROOT))
-import src.core.visitor as _vis
+import core.visitor as _vis
 sys.modules.setdefault("backend.src.core.visitor", _vis)
 sys.modules.setdefault("backend.src.core", sys.modules.get("core"))
 
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import (
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import (
     NodoDel,
     NodoGlobal,
     NodoNoLocal,
@@ -20,8 +20,8 @@ from src.core.ast_nodes import (
     NodoPasar,
     NodoIdentificador,
 )
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 

--- a/tests/unit/test_parser_errors_extra.py
+++ b/tests/unit/test_parser_errors_extra.py
@@ -1,6 +1,6 @@
 import pytest
-from backend.src.cobra.lexico.lexer import Lexer
-from backend.src.cobra.parser.parser import Parser
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
 
 
 def parse(code: str):

--- a/tests/unit/test_parser_factories.py
+++ b/tests/unit/test_parser_factories.py
@@ -1,7 +1,7 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer, Token, TipoToken
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import (
+from cobra.lexico.lexer import Lexer, Token, TipoToken
+from cobra.parser.parser import Parser
+from core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoFuncion,

--- a/tests/unit/test_parser_holobit.py
+++ b/tests/unit/test_parser_holobit.py
@@ -1,6 +1,6 @@
-from src.cobra.lexico.lexer import Token, TipoToken
-from src.cobra.parser.parser import Parser
-from backend.src.core.ast_nodes import NodoHolobit
+from cobra.lexico.lexer import Token, TipoToken
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoHolobit
 import pytest
 
 

--- a/tests/unit/test_parser_inferencia.py
+++ b/tests/unit/test_parser_inferencia.py
@@ -1,7 +1,7 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoAsignacion, NodoValor
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoAsignacion, NodoValor
 
 
 def test_parser_variable_inferencia():

--- a/tests/unit/test_parser_nuevos.py
+++ b/tests/unit/test_parser_nuevos.py
@@ -1,6 +1,6 @@
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoAssert, NodoDel, NodoGlobal, NodoNoLocal, NodoLambda, NodoWith, NodoTryCatch
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoAssert, NodoDel, NodoGlobal, NodoNoLocal, NodoLambda, NodoWith, NodoTryCatch
 
 
 def test_parser_afirmar():

--- a/tests/unit/test_parser_switch.py
+++ b/tests/unit/test_parser_switch.py
@@ -1,6 +1,6 @@
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoSwitch, NodoCase, NodoImprimir
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoSwitch, NodoCase, NodoImprimir
 
 
 def test_parser_switch():

--- a/tests/unit/test_pasar.py
+++ b/tests/unit/test_pasar.py
@@ -1,9 +1,9 @@
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import NodoBucleMientras, NodoPasar
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoBucleMientras, NodoPasar
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 

--- a/tests/unit/test_pcobra_config.py
+++ b/tests/unit/test_pcobra_config.py
@@ -19,7 +19,7 @@ def test_cargar_configuracion_python_js(tmp_path, monkeypatch):
 
     monkeypatch.setenv('PCOBRA_CONFIG', str(cfg_file))
     _reload_module()
-    from src.core.pcobra_config import cargar_configuracion
+    from core.pcobra_config import cargar_configuracion
 
     data = cargar_configuracion()
     ruta = str(mod)
@@ -32,7 +32,7 @@ def test_cargar_configuracion_cache(tmp_path, monkeypatch):
     cfg_file.write_text("")
     monkeypatch.setenv('PCOBRA_CONFIG', str(cfg_file))
     _reload_module()
-    from src.core.pcobra_config import cargar_configuracion, _cache
+    from core.pcobra_config import cargar_configuracion, _cache
 
     cargar_configuracion()
     before = dict(_cache)

--- a/tests/unit/test_pcobra_module_map.py
+++ b/tests/unit/test_pcobra_module_map.py
@@ -1,11 +1,11 @@
 import tomllib
 
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.cobra.transpilers import module_map
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers import module_map
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 

--- a/tests/unit/test_qualia_bridge.py
+++ b/tests/unit/test_qualia_bridge.py
@@ -1,7 +1,7 @@
 import importlib
 import json
 import os
-from src.core import qualia_bridge
+from core import qualia_bridge
 
 
 def test_qualia_state_persistence(tmp_path, monkeypatch):

--- a/tests/unit/test_reflexion_validator.py
+++ b/tests/unit/test_reflexion_validator.py
@@ -1,7 +1,7 @@
 import pytest
-from src.core.semantic_validators.reflexion_segura import ValidadorProhibirReflexion
-from src.core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
-from src.core.ast_nodes import NodoLlamadaFuncion, NodoAtributo, NodoIdentificador
+from core.semantic_validators.reflexion_segura import ValidadorProhibirReflexion
+from core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
+from core.ast_nodes import NodoLlamadaFuncion, NodoAtributo, NodoIdentificador
 
 
 def test_reflexion_funcion_prohibida():

--- a/tests/unit/test_reserved_identifiers.py
+++ b/tests/unit/test_reserved_identifiers.py
@@ -1,6 +1,6 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
 
 
 def test_variable_nombre_reservado():

--- a/tests/unit/test_resource_limits.py
+++ b/tests/unit/test_resource_limits.py
@@ -1,5 +1,5 @@
 import resource
-from src.core.resource_limits import limitar_memoria_mb, limitar_cpu_segundos
+from core.resource_limits import limitar_memoria_mb, limitar_cpu_segundos
 
 
 def test_limitar_memoria():

--- a/tests/unit/test_restricted_exec.py
+++ b/tests/unit/test_restricted_exec.py
@@ -1,5 +1,5 @@
 import pytest
-from src.core.sandbox import ejecutar_en_sandbox
+from core.sandbox import ejecutar_en_sandbox
 
 
 @pytest.mark.timeout(5)

--- a/tests/unit/test_retornos.py
+++ b/tests/unit/test_retornos.py
@@ -1,10 +1,10 @@
 import pytest
-from src.core.interpreter import InterpretadorCobra
-from src.core.ast_nodes import NodoFuncion, NodoRetorno, NodoValor, NodoLlamadaFuncion
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from core.interpreter import InterpretadorCobra
+from core.ast_nodes import NodoFuncion, NodoRetorno, NodoValor, NodoLlamadaFuncion
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 
 
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
 def test_interpreter_funcion_con_retorno():
     inter = InterpretadorCobra()
     func = NodoFuncion("dame_cinco", [], [NodoRetorno(NodoValor(5))])

--- a/tests/unit/test_romper_continuar.py
+++ b/tests/unit/test_romper_continuar.py
@@ -1,16 +1,16 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.ast_nodes import (
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import (
     NodoBucleMientras,
     NodoPara,
     NodoRomper,
     NodoContinuar,
     NodoValor,
 )
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -3,11 +3,11 @@ import pytest
 from io import StringIO
 from unittest.mock import patch
 
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.interpreter import InterpretadorCobra
-from src.core.ast_nodes import NodoLlamadaFuncion, NodoValor
-from src.core.semantic_validators import PrimitivaPeligrosaError
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.interpreter import InterpretadorCobra
+from core.ast_nodes import NodoLlamadaFuncion, NodoValor
+from core.semantic_validators import PrimitivaPeligrosaError
 
 
 def generar_ast(codigo: str):

--- a/tests/unit/test_safe_mode_imports.py
+++ b/tests/unit/test_safe_mode_imports.py
@@ -1,10 +1,10 @@
 import pytest
 import backend  # garantiza rutas para submódulos
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.interpreter import InterpretadorCobra
-from src.core.ast_nodes import NodoLlamadaFuncion, NodoValor
-from src.core.semantic_validators import PrimitivaPeligrosaError
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.interpreter import InterpretadorCobra
+from core.ast_nodes import NodoLlamadaFuncion, NodoValor
+from core.semantic_validators import PrimitivaPeligrosaError
 
 
 def generar_ast(codigo: str):

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1,5 +1,5 @@
 import pytest
-from src.core.sandbox import ejecutar_en_sandbox
+from core.sandbox import ejecutar_en_sandbox
 
 
 @pytest.mark.timeout(5)

--- a/tests/unit/test_sandbox_js.py
+++ b/tests/unit/test_sandbox_js.py
@@ -4,9 +4,11 @@ import sys
 from pathlib import Path
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
 
-from src.core.sandbox import ejecutar_en_sandbox_js
+from core.sandbox import ejecutar_en_sandbox_js
 
 
 @pytest.mark.timeout(5)

--- a/tests/unit/test_semantic_validator.py
+++ b/tests/unit/test_semantic_validator.py
@@ -1,7 +1,7 @@
 import pytest
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
-from src.core.semantic_validators import (
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.semantic_validators import (
     construir_cadena,
     PrimitivaPeligrosaError,
 )

--- a/tests/unit/test_semantica_transpiladores.py
+++ b/tests/unit/test_semantica_transpiladores.py
@@ -1,7 +1,7 @@
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.cobra.transpilers.transpiler.to_c import TranspiladorC
-from src.core.ast_nodes import NodoAsignacion, NodoBucleMientras, NodoValor
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.transpiler.to_c import TranspiladorC
+from core.ast_nodes import NodoAsignacion, NodoBucleMientras, NodoValor
 
 
 def test_asignacion_compartida():

--- a/tests/unit/test_semantico.py
+++ b/tests/unit/test_semantico.py
@@ -1,7 +1,7 @@
 import pytest
 
-from src.cobra.semantico import AnalizadorSemantico
-from src.core.ast_nodes import (
+from cobra.semantico import AnalizadorSemantico
+from core.ast_nodes import (
     NodoIdentificador,
     NodoAsignacion,
     NodoValor,

--- a/tests/unit/test_to_asm.py
+++ b/tests/unit/test_to_asm.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_asm import TranspiladorASM
-from src.core.ast_nodes import (
+from cobra.transpilers.transpiler.to_asm import TranspiladorASM
+from core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoBucleMientras,

--- a/tests/unit/test_to_c.py
+++ b/tests/unit/test_to_c.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_c import TranspiladorC
-from src.core.ast_nodes import (
+from cobra.transpilers.transpiler.to_c import TranspiladorC
+from core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoBucleMientras,

--- a/tests/unit/test_to_cobol.py
+++ b/tests/unit/test_to_cobol.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
-from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+from cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
+from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
 
 
 def test_transpilador_asignacion_cobol():

--- a/tests/unit/test_to_cpp.py
+++ b/tests/unit/test_to_cpp.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
-from src.core.ast_nodes import (
+from cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
+from core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoBucleMientras,

--- a/tests/unit/test_to_fortran.py
+++ b/tests/unit/test_to_fortran.py
@@ -1,6 +1,6 @@
-from src.cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
-from backend.src.cobra.lexico.lexer import TipoToken, Token
-from src.core.ast_nodes import (
+from cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
+from cobra.lexico.lexer import TipoToken, Token
+from core.ast_nodes import (
     NodoAsignacion,
     NodoFuncion,
     NodoLlamadaFuncion,

--- a/tests/unit/test_to_go.py
+++ b/tests/unit/test_to_go.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_go import TranspiladorGo
-from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+from cobra.transpilers.transpiler.to_go import TranspiladorGo
+from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
 
 
 def test_transpilador_asignacion_go():

--- a/tests/unit/test_to_java.py
+++ b/tests/unit/test_to_java.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_java import TranspiladorJava
-from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+from cobra.transpilers.transpiler.to_java import TranspiladorJava
+from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
 
 
 def test_transpilador_asignacion_java():

--- a/tests/unit/test_to_js.py
+++ b/tests/unit/test_to_js.py
@@ -1,7 +1,7 @@
 import pytest
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.cobra.transpilers.import_helper import get_standard_imports
-from src.core.ast_nodes import (
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.import_helper import get_standard_imports
+from core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoBucleMientras,

--- a/tests/unit/test_to_js2.py
+++ b/tests/unit/test_to_js2.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 
 
 # Definición de clases de nodo simuladas con los atributos necesarios para las pruebas

--- a/tests/unit/test_to_js3.py
+++ b/tests/unit/test_to_js3.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.import_helper import get_standard_imports
 
 
 # Definición de nodos para las pruebas

--- a/tests/unit/test_to_js4.py
+++ b/tests/unit/test_to_js4.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.import_helper import get_standard_imports
 
 
 # Nodos simulados para pruebas

--- a/tests/unit/test_to_js_objects.py
+++ b/tests/unit/test_to_js_objects.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.core.ast_nodes import NodoInstancia, NodoLlamadaMetodo, NodoIdentificador, NodoValor
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from core.ast_nodes import NodoInstancia, NodoLlamadaMetodo, NodoIdentificador, NodoValor
 
 
 def test_transpilar_instancia():

--- a/tests/unit/test_to_julia.py
+++ b/tests/unit/test_to_julia.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_julia import TranspiladorJulia
-from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+from cobra.transpilers.transpiler.to_julia import TranspiladorJulia
+from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
 
 
 def test_transpilador_asignacion_julia():

--- a/tests/unit/test_to_latex.py
+++ b/tests/unit/test_to_latex.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_latex import TranspiladorLatex
-from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+from cobra.transpilers.transpiler.to_latex import TranspiladorLatex
+from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
 
 
 def test_transpilador_asignacion_latex():

--- a/tests/unit/test_to_matlab.py
+++ b/tests/unit/test_to_matlab.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
-from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+from cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
+from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
 
 
 def test_transpilador_asignacion_matlab():

--- a/tests/unit/test_to_pascal.py
+++ b/tests/unit/test_to_pascal.py
@@ -1,6 +1,6 @@
-from backend.src.cobra.lexico.lexer import TipoToken, Token
-from src.cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
-from src.core.ast_nodes import (
+from cobra.lexico.lexer import TipoToken, Token
+from cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
+from core.ast_nodes import (
     NodoAsignacion,
     NodoFuncion,
     NodoLlamadaFuncion,

--- a/tests/unit/test_to_php.py
+++ b/tests/unit/test_to_php.py
@@ -1,6 +1,6 @@
-from src.cobra.transpilers.transpiler.to_php import TranspiladorPHP
-from backend.src.cobra.lexico.lexer import TipoToken, Token
-from src.core.ast_nodes import (
+from cobra.transpilers.transpiler.to_php import TranspiladorPHP
+from cobra.lexico.lexer import TipoToken, Token
+from core.ast_nodes import (
     NodoAsignacion,
     NodoFuncion,
     NodoLlamadaFuncion,

--- a/tests/unit/test_to_python.py
+++ b/tests/unit/test_to_python.py
@@ -1,4 +1,4 @@
-from src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoBucleMientras,
@@ -14,8 +14,8 @@ from src.core.ast_nodes import (
     NodoImprimir,
     NodoPasar,
 )
-from src.core.ast_nodes import NodoSwitch, NodoCase
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from core.ast_nodes import NodoSwitch, NodoCase
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
 
 
 def test_transpilador_asignacion():

--- a/tests/unit/test_to_python2.py
+++ b/tests/unit/test_to_python2.py
@@ -1,8 +1,8 @@
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
-from src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoBucleMientras,

--- a/tests/unit/test_to_python3.py
+++ b/tests/unit/test_to_python3.py
@@ -1,8 +1,8 @@
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
-from src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoBucleMientras,

--- a/tests/unit/test_to_python4.py
+++ b/tests/unit/test_to_python4.py
@@ -1,7 +1,7 @@
 import pytest
-from src.core.ast_nodes import NodoAsignacion, NodoCondicional, NodoBucleMientras, NodoFuncion, NodoLlamadaFuncion, NodoHolobit, NodoFor, NodoLista, NodoDiccionario, NodoClase, NodoMetodo, NodoValor, NodoRetorno
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.import_helper import get_standard_imports
+from core.ast_nodes import NodoAsignacion, NodoCondicional, NodoBucleMientras, NodoFuncion, NodoLlamadaFuncion, NodoHolobit, NodoFor, NodoLista, NodoDiccionario, NodoClase, NodoMetodo, NodoValor, NodoRetorno
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 

--- a/tests/unit/test_to_python_extras.py
+++ b/tests/unit/test_to_python_extras.py
@@ -1,5 +1,5 @@
 import pytest
-from src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoTryCatch,
     NodoThrow,
     NodoImprimir,
@@ -8,8 +8,8 @@ from src.core.ast_nodes import (
     NodoImport,
     NodoUsar,
 )
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
 

--- a/tests/unit/test_to_python_nuevos.py
+++ b/tests/unit/test_to_python_nuevos.py
@@ -1,7 +1,7 @@
-from src.core.ast_nodes import (
+from core.ast_nodes import (
     NodoAssert, NodoDel, NodoGlobal, NodoNoLocal, NodoLambda, NodoValor, NodoWith, NodoPasar
 )
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
 
 
 def test_transpilar_afirmar():

--- a/tests/unit/test_to_python_objects.py
+++ b/tests/unit/test_to_python_objects.py
@@ -1,8 +1,8 @@
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.import_helper import get_standard_imports
 
 IMPORTS = get_standard_imports("python")
-from src.core.ast_nodes import NodoInstancia, NodoLlamadaMetodo, NodoIdentificador, NodoValor
+from core.ast_nodes import NodoInstancia, NodoLlamadaMetodo, NodoIdentificador, NodoValor
 
 
 def test_transpilar_instancia():

--- a/tests/unit/test_to_r.py
+++ b/tests/unit/test_to_r.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_r import TranspiladorR
-from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+from cobra.transpilers.transpiler.to_r import TranspiladorR
+from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
 
 
 def test_transpilador_asignacion_r():

--- a/tests/unit/test_to_ruby.py
+++ b/tests/unit/test_to_ruby.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
-from src.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+from cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
+from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
 
 
 def test_transpilador_asignacion_ruby():

--- a/tests/unit/test_to_rust.py
+++ b/tests/unit/test_to_rust.py
@@ -1,5 +1,5 @@
-from src.cobra.transpilers.transpiler.to_rust import TranspiladorRust
-from src.core.ast_nodes import (
+from cobra.transpilers.transpiler.to_rust import TranspiladorRust
+from core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoBucleMientras,

--- a/tests/unit/test_to_wasm.py
+++ b/tests/unit/test_to_wasm.py
@@ -1,12 +1,12 @@
-from src.cobra.transpilers.transpiler.to_wasm import TranspiladorWasm
-from src.core.ast_nodes import (
+from cobra.transpilers.transpiler.to_wasm import TranspiladorWasm
+from core.ast_nodes import (
     NodoAsignacion,
     NodoFuncion,
     NodoOperacionBinaria,
     NodoIdentificador,
     NodoValor,
 )
-from src.cobra.lexico.lexer import Token, TipoToken
+from cobra.lexico.lexer import Token, TipoToken
 
 
 def test_transpilador_asignacion_wasm():

--- a/tests/unit/test_token_cache.py
+++ b/tests/unit/test_token_cache.py
@@ -2,8 +2,8 @@ import importlib
 import sys
 import hashlib
 import pytest
-from src.cobra.lexico.lexer import Lexer
-from src.cobra.parser.parser import Parser
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
 
 
 def test_obtener_tokens_reutiliza(monkeypatch, tmp_path):
@@ -12,7 +12,7 @@ def test_obtener_tokens_reutiliza(monkeypatch, tmp_path):
 
     if 'src.core.ast_cache' in sys.modules:
         importlib.reload(sys.modules['src.core.ast_cache'])
-    from src.core.ast_cache import obtener_tokens
+    from core.ast_cache import obtener_tokens
 
     llamadas = {"count": 0}
 
@@ -37,7 +37,7 @@ def test_obtener_ast_reutiliza_tokens(monkeypatch, tmp_path):
 
     if 'src.core.ast_cache' in sys.modules:
         importlib.reload(sys.modules['src.core.ast_cache'])
-    from src.core.ast_cache import obtener_ast
+    from core.ast_cache import obtener_ast
 
     token_calls = {"count": 0}
     parse_calls = {"count": 0}
@@ -73,7 +73,7 @@ def test_cache_fragmentos(monkeypatch, tmp_path):
     cache_dir = tmp_path / "cache"
     monkeypatch.setenv("COBRA_AST_CACHE", str(cache_dir))
 
-    from src.core.ast_cache import obtener_tokens_fragmento
+    from core.ast_cache import obtener_tokens_fragmento
 
     llamadas = {"count": 0}
 

--- a/tests/unit/test_transpiladores_incompletos.py
+++ b/tests/unit/test_transpiladores_incompletos.py
@@ -1,10 +1,10 @@
 import pytest
 
-from src.cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
-from src.cobra.transpilers.transpiler.to_rust import TranspiladorRust
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.cobra.transpilers.base import BaseTranspiler
-from src.core.ast_nodes import NodoAST, NodoGlobal
+from cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
+from cobra.transpilers.transpiler.to_rust import TranspiladorRust
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.base import BaseTranspiler
+from core.ast_nodes import NodoAST, NodoGlobal
 
 
 class NodoInvalido(NodoAST):

--- a/tests/unit/test_transpile_python.py
+++ b/tests/unit/test_transpile_python.py
@@ -1,7 +1,7 @@
 import py_compile
-from src.core.ast_nodes import NodoImprimir, NodoValor
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from src.core.sandbox import ejecutar_en_sandbox
+from core.ast_nodes import NodoImprimir, NodoValor
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from core.sandbox import ejecutar_en_sandbox
 
 
 def test_transpile_python_and_execute(tmp_path):

--- a/tests/unit/test_transpile_rust_go.py
+++ b/tests/unit/test_transpile_rust_go.py
@@ -2,9 +2,9 @@ import subprocess
 import shutil
 import pytest
 
-from src.core.ast_nodes import NodoAsignacion, NodoValor
-from src.cobra.transpilers.transpiler.to_rust import TranspiladorRust
-from src.cobra.transpilers.transpiler.to_go import TranspiladorGo
+from core.ast_nodes import NodoAsignacion, NodoValor
+from cobra.transpilers.transpiler.to_rust import TranspiladorRust
+from cobra.transpilers.transpiler.to_go import TranspiladorGo
 
 
 def test_transpile_and_compile_rust_go(tmp_path):

--- a/tests/unit/test_transpiler_operations_extra.py
+++ b/tests/unit/test_transpiler_operations_extra.py
@@ -1,12 +1,12 @@
-from src.cobra.lexico.lexer import Token, TipoToken
-from src.core.ast_nodes import (
+from cobra.lexico.lexer import Token, TipoToken
+from core.ast_nodes import (
     NodoAsignacion,
     NodoOperacionBinaria,
     NodoOperacionUnaria,
     NodoIdentificador,
 )
-from src.cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
-from src.cobra.transpilers.transpiler.to_rust import TranspiladorRust
+from cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
+from cobra.transpilers.transpiler.to_rust import TranspiladorRust
 
 
 def test_operacion_binaria_matlab():

--- a/tests/unit/test_try_catch.py
+++ b/tests/unit/test_try_catch.py
@@ -2,18 +2,18 @@ import pytest
 from io import StringIO
 from unittest.mock import patch
 
-from backend.src.cobra.lexico.lexer import Token, TipoToken, Lexer
-from src.cobra.parser.parser import Parser
-from backend.src.core.ast_nodes import (
+from cobra.lexico.lexer import Token, TipoToken, Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import (
     NodoTryCatch,
     NodoThrow,
     NodoImprimir,
     NodoIdentificador,
     NodoValor,
 )
-from src.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from src.cobra.transpilers.transpiler.to_python import TranspiladorPython
-from backend.src.core.interpreter import InterpretadorCobra
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from core.interpreter import InterpretadorCobra
 
 
 def generar_tokens(*args):
@@ -108,7 +108,7 @@ def test_interpreter_intentar_lanzar_capturar():
     interp.variables["mensaje"] = "hola"
     ast = Parser(Lexer(codigo).analizar_token()).parsear()[0]
 
-    from src.core.ast_nodes import (
+    from core.ast_nodes import (
         NodoTryCatch as STry,
         NodoThrow as SThrow,
         NodoImprimir as SImprimir,

--- a/tests/unit/test_type_checks.py
+++ b/tests/unit/test_type_checks.py
@@ -1,7 +1,7 @@
 import pytest
-from backend.src.core.interpreter import InterpretadorCobra
-from backend.src.cobra.lexico.lexer import Token, TipoToken
-from backend.src.core.ast_nodes import (
+from core.interpreter import InterpretadorCobra
+from cobra.lexico.lexer import Token, TipoToken
+from core.ast_nodes import (
     NodoOperacionBinaria,
     NodoOperacionUnaria,
     NodoValor,

--- a/tests/unit/test_unicode_comments.py
+++ b/tests/unit/test_unicode_comments.py
@@ -1,4 +1,4 @@
-from src.cobra.lexico.lexer import Lexer, TipoToken
+from cobra.lexico.lexer import Lexer, TipoToken
 
 
 def test_unicode_comments_removed():

--- a/tests/unit/test_unicode_identifiers.py
+++ b/tests/unit/test_unicode_identifiers.py
@@ -1,4 +1,4 @@
-from src.cobra.lexico.lexer import Lexer, TipoToken
+from cobra.lexico.lexer import Lexer, TipoToken
 
 
 def test_unicode_identifiers():

--- a/tests/unit/test_unicode_identifiers_extra.py
+++ b/tests/unit/test_unicode_identifiers_extra.py
@@ -1,4 +1,4 @@
-from src.cobra.lexico.lexer import Lexer, TipoToken
+from cobra.lexico.lexer import Lexer, TipoToken
 
 
 def test_unicode_identifiers_extra():

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -9,9 +9,9 @@ sys.modules.setdefault('yaml', fake_yaml)
 
 import pytest
 
-from src.core.interpreter import InterpretadorCobra
-from src.core.ast_nodes import NodoUsar
-from src.cobra import usar_loader
+from core.interpreter import InterpretadorCobra
+from core.ast_nodes import NodoUsar
+from cobra import usar_loader
 
 
 def test_obtener_modulo_instala_si_no_existe():

--- a/tests/unit/test_usar_loader_stdlib.py
+++ b/tests/unit/test_usar_loader_stdlib.py
@@ -7,7 +7,7 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "backend" / "src"))
 sys.path.insert(0, str(ROOT))
 
-from src.cobra import usar_loader
+from cobra import usar_loader
 import standard_library.fecha as fecha
 
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,7 +1,9 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import standard_library.util as util
 

--- a/tests/unit/test_validar_dependencias.py
+++ b/tests/unit/test_validar_dependencias.py
@@ -2,8 +2,8 @@ from io import StringIO
 from unittest.mock import patch
 import pytest
 
-from src.cli.cli import main
-from src.cobra.transpilers import module_map
+from cli.cli import main
+from cobra.transpilers import module_map
 
 
 @pytest.mark.timeout(5)

--- a/tests/unit/test_validator_optimization.py
+++ b/tests/unit/test_validator_optimization.py
@@ -1,7 +1,7 @@
 import importlib
 from unittest.mock import patch
 
-from src.core.semantic_validators import construir_cadena, ValidadorPrimitivaPeligrosa
+from core.semantic_validators import construir_cadena, ValidadorPrimitivaPeligrosa
 
 
 def test_construir_cadena_reutiliza_instancias():
@@ -31,7 +31,7 @@ def test_construir_cadena_sin_reutilizar(monkeypatch):
         original_init(self)
 
     with patch.object(ValidadorPrimitivaPeligrosa, "__init__", cuenta_init):
-        import src.core.semantic_validators as sv
+        import core.semantic_validators as sv
         monkeypatch.setattr(sv, "_CADENA_DEFECTO", None)
         construir_cadena()
         monkeypatch.setattr(sv, "_CADENA_DEFECTO", None)
@@ -41,8 +41,8 @@ def test_construir_cadena_sin_reutilizar(monkeypatch):
 
 
 def test_valida_cada_nodo_una_sola_vez(monkeypatch):
-    from src.core.interpreter import InterpretadorCobra
-    from src.core.ast_nodes import NodoAsignacion, NodoValor
+    from core.interpreter import InterpretadorCobra
+    from core.ast_nodes import NodoAsignacion, NodoValor
 
     interp = InterpretadorCobra(safe_mode=True)
     nodo = NodoAsignacion("x", NodoValor(1))


### PR DESCRIPTION
## Summary
- update tests to use cobra/cli/core modules directly
- keep compatibility by adding backend/src paths
- fix patch paths to new module locations

## Testing
- `pytest -k test_cli_help -q` *(fails: ModuleNotFoundError: No module named 'tomli')*

------
https://chatgpt.com/codex/tasks/task_e_6873dc1c35988327a997027f2d80efc0