### PR TITLE
Add package init for cli utils

### DIFF
--- a/backend/src/cli/utils/__init__.py
+++ b/backend/src/cli/utils/__init__.py
@@ -1,0 +1,4 @@
+"""Utilidades varias para la CLI de Cobra."""
+
+__all__ = ["messages", "semver"]
+


### PR DESCRIPTION
## Summary
- declare `cli.utils` as a package so imports like `from cli.utils.semver` work

## Testing
- `flake8 backend/src | head` *(fails: line too long, ambiguous variable name, etc.)*
- `mypy backend/src | tail -n 20` *(fails: found 23 errors)*
- `pytest -q` *(fails: 69 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6873e76c1a408327ab639b8b40c37ba6