### PR TITLE
Add env example file and usage instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Variables de entorno para ejecutar Cobra
+# Copia este archivo a `.env` y ajusta los valores según tu entorno.
+
+# Idioma de la interfaz
+COBRA_LANG=es
+
+# URL del servicio CobraHub
+COBRAHUB_URL=https://cobrahub.example.com/api
+
+# Archivos de configuración
+COBRA_MODULE_MAP=./cobra.mod
+PCOBRA_TOML=./pcobra.toml
+COBRA_CONFIG=./cobra.toml
+PCOBRA_CONFIG=./pcobra.toml
+
+# Ruta para almacenar el estado de Qualia
+QUALIA_STATE_PATH=backend/src/core/qualia_state.json
+
+# Directorio de caché del AST
+COBRA_AST_CACHE=./cache
+
+# Parser alternativo (usar "lark" para habilitarlo)
+COBRA_PARSER=

--- a/README.md
+++ b/README.md
@@ -110,7 +110,15 @@ pip install -r requirements.txt
 pip install -e .
 ````
 
-6. Ejecuta un programa de prueba para verificar la instalación:
+6. Copia el archivo ``.env.example`` a ``.env`` y personaliza las rutas o claves
+   de ser necesario:
+
+````bash
+cp .env.example .env
+# Edita .env con tu editor favorito
+````
+
+7. Ejecuta un programa de prueba para verificar la instalación:
 
 ````bash
 echo "imprimir('Hola Cobra')" > hola.co


### PR DESCRIPTION
## Summary
- add `.env.example` with common variables
- explain in the README how to copy it to `.env`

## Testing
- `PYTHONPATH=$PWD/backend/src pytest tests/unit/test_qualia_bridge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68747e394aa48327b88086ee4e7ed1d9