### PR TITLE
Add pcobra CLI entrypoint

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include CHANGELOG.md
 include MANUAL_COBRA.md
 recursive-include notebooks *
 recursive-include frontend/docs *
+include pcobra.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ where = ["backend/src"]
 
 [project.scripts]
 cobra = "src.cli.cli:main"
+pcobra = "src.main:main"
 
 [project.entry-points."cobra.plugins"]
 # Se registrarán plugins externos aquí

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,4 @@
+from src.core.main import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expose `pcobra` script for running Cobra from CLI
- include `pcobra.toml` in package data

## Testing
- `pip install -e . --no-deps`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_687487e2a06483278f51a84f07cb0f5a