### PR TITLE
Añadir test para analizador_agix

### DIFF
--- a/tests/unit/test_analizador_agix.py
+++ b/tests/unit/test_analizador_agix.py
@@ -1,0 +1,16 @@
+import backend  # garantiza rutas para submódulos
+from unittest.mock import MagicMock, patch
+
+from ia import analizador_agix
+
+
+
+def test_generar_sugerencias_variable_descriptiva():
+    """Verifica que se retorne la sugerencia adecuada."""
+    instancia_falsa = MagicMock()
+    instancia_falsa.select_best_model.return_value = {
+        "reason": "Usar nombres descriptivos para variables"
+    }
+    with patch.object(analizador_agix, "Reasoner", return_value=instancia_falsa):
+        sugerencias = analizador_agix.generar_sugerencias("var x = 5")
+    assert sugerencias == ["Usar nombres descriptivos para variables"]


### PR DESCRIPTION
## Resumen
- se agrega `tests/unit/test_analizador_agix.py` que verifica las sugerencias generadas

## Testing
- `PYTHONPATH=. pytest tests/unit/test_analizador_agix.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6874cf99a1088327929d8fa9ee9eaa2c