### PR TITLE
Añadir prueba de saludo para main

### DIFF
--- a/tests/unit/test_core_main.py
+++ b/tests/unit/test_core_main.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+from io import StringIO
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
+
+from core.main import main
+
+
+def test_main_saludo(capsys=None):
+    """Verifica que se imprima el saludo correcto."""
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main()
+    assert out.getvalue().strip() == "¡Hola desde Cobra!"


### PR DESCRIPTION
## Summary
- añadir test `test_core_main.py` que verifica la salida de `main()`

## Testing
- `pytest tests/unit/test_core_main.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6874f857f148832789dfd5480c988b59