### PR TITLE
Actualizar instrucciones de cobertura en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,14 @@ Algunas pruebas generan código en distintos lenguajes (por ejemplo C++, JavaScr
 PYTHONPATH=$PWD pytest
 ```
 
+En la integración continua se emplea:
+
+```bash
+pytest --cov=backend/src tests/
+```
+
+El reporte se guarda como `coverage.xml` y se utiliza en el CI.
+
 Se han incluido pruebas que verifican los códigos de salida de la CLI. Los
 subcomandos devuelven `0` al finalizar correctamente y un valor distinto en caso
 de error.


### PR DESCRIPTION
## Summary
- agregar ejemplo de ejecución de pruebas con cobertura en README
- mencionar que coverage.xml se usa en la CI

## Testing
- `PYTHONPATH=$PWD pytest -k "help" tests/unit` *(failing: ImportError while importing test modules)*

------
https://chatgpt.com/codex/tasks/task_e_6874fcbea36c8327b0b10dbc58a601a1