### PR TITLE
Actualiza comandos de seguridad

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           black --check backend/src
           flake8 backend/src
           mypy backend/src
-          bandit -r backend/src
+          bandit -r src backend/src
           pyright --project pyrightconfig.json
       - name: Run type checks
         run: make typecheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           flake8 backend/src
           mypy backend/src
+          bandit -r src backend/src
       - name: Run tests
         run: |
           pytest --cov=backend/src --cov-report=xml --cov-fail-under=95

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ coverage:
 lint:
 	flake8 backend/src
 	mypy backend/src
-	bandit -r backend/src
+	bandit -r src backend/src
 
 typecheck:
 		mypy backend/src

--- a/README.md
+++ b/README.md
@@ -765,7 +765,7 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
   (formateo con `black`, longitud máxima de línea 88 y uso de `flake8`, `mypy`
   y `bandit`).
 - Realiza tus cambios y haz commit (`git commit -m 'Añadir nueva característica'`).
-- Ejecuta `make lint` para verificar el código con *flake8*, *mypy* y *bandit*.
+- Ejecuta `make lint` para verificar el código con *flake8*, *mypy* y *bandit*. `bandit` analizará los directorios `src` y `backend/src`.
 - Ejecuta `make typecheck` para la verificación estática con *mypy* (y
   opcionalmente *pyright* si está instalado).
 - El CI de GitHub Actions ejecuta automáticamente estas herramientas en cada pull request.
@@ -811,8 +811,8 @@ Para ejecutar los linters puedes usar el comando de Make:
 make lint
 ```
 
-Esto ejecutará `flake8` y `mypy` sobre `backend/src`. Si prefieres lanzarlos de manera
-individual utiliza:
+Esto ejecutará `flake8` y `mypy` sobre `backend/src`, y `bandit` revisará los directorios `src` y `backend/src`. Si prefieres lanzar las herramientas de
+manera individual utiliza:
 
 ```bash
 flake8 backend/src


### PR DESCRIPTION
## Summary
- actualiza `Makefile` para que bandit revise `src` y `backend/src`
- cambia los workflows de GitHub Actions con el nuevo comando de bandit
- aclara en el `README` que `make lint` revisa ambos directorios

## Testing
- `make lint` *(falla: flake8 encontró múltiples errores)*
- `pytest -k ""` *(falla: 70 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68750a5106588327bd936b6f5a6a4613