### PR TITLE
Add formatting tools with CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
           safety check --full-report
       - name: Run linters
         run: |
-          black --check backend/src
+          isort --check backend/src src
+          black --check backend/src src
           flake8 backend/src
           mypy backend/src
           bandit -r src backend/src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,8 @@ jobs:
           pip install -e .
       - name: Run linters
         run: |
+          isort --check backend/src src
+          black --check backend/src src
           flake8 backend/src
           mypy backend/src
           bandit -r src backend/src

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ lint:
 	mypy backend/src
 	bandit -r src backend/src
 
+format:
+	isort backend/src src
+	black backend/src src
+
 typecheck:
 		mypy backend/src
 		@if command -v pyright >/dev/null 2>&1; then \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,12 @@ pcobra = "src.main:main"
 
 [project.entry-points."cobra.transpilers"]
 # Se registrarán transpiladores externos aquí
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.isort]
+profile = "black"
+line_length = 88
+known_first_party = ["backend", "src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,5 @@ snakeviz==2.2.2
 lark==1.1.9
 psutil==7.0.0
 sphinxcontrib-plantuml==0.30
+black==25.1.0
+isort==6.0.1


### PR DESCRIPTION
## Summary
- include `black` and `isort` in `requirements.txt`
- configure `black` and `isort` in `pyproject.toml`
- add a `format` target in the `Makefile`
- run `isort --check` and `black --check` in CI workflows

## Testing
- `isort --check backend/src src` *(fails: imports not sorted)*
- `black --check backend/src src` *(fails: code not formatted)*

------
https://chatgpt.com/codex/tasks/task_e_6875290d8ff88327be75164a3a101c88