### PR TITLE
Integrar gitleaks y nuevo comando make

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
         run: |
           pip install safety
           safety check --full-report
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run linters
         run: |
           isort --check backend/src src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -e .
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run linters
         run: |
           isort --check backend/src src

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Gracias por tu interés en mejorar Cobra. A continuación se describen las pauta
 
 - El codigo debe formatearse con `black` y respetar 88 caracteres por linea.
 - Ejecuta `make lint` para comprobar `flake8`, `mypy` y `bandit`.
+- Ejecuta `make secrets` para buscar credenciales expuestas con *gitleaks*.
 - Usa `make typecheck` para la verificacion de tipos.
 - Para analisis estatico con `pyright`, instala el paquete y ejecuta
   `pyright backend/src` (o `make typecheck`).
@@ -46,7 +47,7 @@ make lint
 
 1. **Fork y rama**: haz un fork y crea una rama a partir de `main` con el prefijo adecuado (`feature/`, `bugfix/` o `doc/`) y una breve descripcion. Esto permite que las acciones de GitHub etiqueten tu PR automáticamente.
 2. **Sincroniza con `main`**: antes de abrir el PR, actualiza tu rama para incorporar los últimos cambios.
-3. **Pruebas y estilo**: ejecuta `make lint` y `make typecheck` para asegurarte de que el código pasa las verificaciones. Añade o ajusta pruebas cuando sea necesario.
+3. **Pruebas y estilo**: ejecuta `make lint` y `make typecheck` para asegurarte de que el código pasa las verificaciones. Añade o ajusta pruebas cuando sea necesario. Ejecuta además `make secrets` para comprobar que no se subieron credenciales.
 4. **Descripción**: indica el propósito del cambio y referencia issues relacionados usando `#numero`.
 5. **Etiquetas de PR**: añade `enhancement`, `bug`, `documentation` u otra etiqueta que describa el cambio.
 6. **Revisión**: una vez abierto el PR, espera la revisión de los mantenedores y realiza los cambios solicitados.

--- a/Makefile
+++ b/Makefile
@@ -39,4 +39,7 @@ typecheck:
 	fi
 
 benchmarks:
-		python scripts/benchmarks/run_benchmarks.py > bench_results.json
+                python scripts/benchmarks/run_benchmarks.py > bench_results.json
+
+secrets:
+	gitleaks detect --source . --redact

--- a/README.md
+++ b/README.md
@@ -768,6 +768,7 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
 - Ejecuta `make lint` para verificar el código con *flake8*, *mypy* y *bandit*. `bandit` analizará los directorios `src` y `backend/src`.
 - Ejecuta `make typecheck` para la verificación estática con *mypy* (y
   opcionalmente *pyright* si está instalado).
+- Ejecuta `make secrets` para buscar credenciales expuestas usando *gitleaks*.
 - El CI de GitHub Actions ejecuta automáticamente estas herramientas en cada pull request.
 - Envía un pull request.
 - Consulta [CONTRIBUTING.md](CONTRIBUTING.md) para más detalles sobre cómo abrir
@@ -785,6 +786,8 @@ lista de paquetes instalados en busca de vulnerabilidades conocidas. Si se
 detecta alguna, la acción devolverá un reporte detallado y el trabajo fallará.
 Consulta el log del paso "Seguridad de dependencias" para ver los paquetes
 afectados y las recomendaciones de actualización.
+De igual forma, se ejecuta *gitleaks* para asegurarse de que no existan
+credenciales accidentales en el repositorio.
 
 El repositorio también ejecuta CodeQL con reglas personalizadas para detectar
 patrones de código riesgosos, como el uso de `eval` o `exec` fuera del sandbox.
@@ -809,7 +812,9 @@ Para ejecutar los linters puedes usar el comando de Make:
 
 ```bash
 make lint
+make secrets
 ```
+El segundo comando ejecuta *gitleaks* para detectar posibles secretos en el repositorio.
 
 Esto ejecutará `flake8` y `mypy` sobre `backend/src`, y `bandit` revisará los directorios `src` y `backend/src`. Si prefieres lanzar las herramientas de
 manera individual utiliza:


### PR DESCRIPTION
## Summary
- add `gitleaks` secret scanning step to CI workflows
- expose new `make secrets` helper
- document secret scans in CONTRIBUTING and README

## Testing
- `make lint` *(fails: E501 line too long)*
- `pytest -q` *(fails: 67 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68752ec0f0808327a6fa02762139b1e4