### PR TITLE
Update .gitignore to ignore venv folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docs/cheatsheet.pdf
 \.hypothesis/
 bench_results.json
 all-bytes.dat
+venv/


### PR DESCRIPTION
## Summary
- update `.gitignore` to explicitly ignore `venv/`

## Testing
- `pytest --cov=backend/src tests/` *(fails: 66 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6875394e4d3c8327a467a31d24248ad4