### PR TITLE
Add missing module docstrings

### DIFF
--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,0 +1,2 @@
+"""Inicializa el paquete del backend y expone módulos principales."""
+

--- a/backend/src/cli/__init__.py
+++ b/backend/src/cli/__init__.py
@@ -1,0 +1,2 @@
+"""Herramientas y utilidades para la línea de comandos de Cobra."""
+

--- a/backend/src/cobra/lexico/__init__.py
+++ b/backend/src/cobra/lexico/__init__.py
@@ -1,0 +1,2 @@
+"""Módulo de inicialización para el analizador léxico de Cobra."""
+

--- a/backend/src/cobra/parser/__init__.py
+++ b/backend/src/cobra/parser/__init__.py
@@ -1,0 +1,2 @@
+"""Submódulos relacionados con el análisis sintáctico del lenguaje Cobra."""
+

--- a/backend/src/cobra/parser/lark_parser.py
+++ b/backend/src/cobra/parser/lark_parser.py
@@ -1,3 +1,5 @@
+"""Parser alternativo basado en Lark para cargar la gramática EBNF."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/backend/src/cobra/semantico/__init__.py
+++ b/backend/src/cobra/semantico/__init__.py
@@ -1,3 +1,5 @@
+"""Utilidades para el análisis semántico y la validación de módulos Cobra."""
+
 from .tabla import Simbolo, Ambito
 from .analizador import AnalizadorSemantico
 from .mod_validator import validar_mod

--- a/backend/src/cobra/semantico/analizador.py
+++ b/backend/src/cobra/semantico/analizador.py
@@ -1,3 +1,5 @@
+"""Analizador semántico que construye la tabla de símbolos y verifica errores."""
+
 from typing import List
 
 from core.visitor import NodeVisitor

--- a/backend/src/cobra/semantico/tabla.py
+++ b/backend/src/cobra/semantico/tabla.py
@@ -1,3 +1,5 @@
+"""Estructuras de la tabla de símbolos y manejo jerárquico de ámbitos."""
+
 from dataclasses import dataclass
 from typing import Dict, Optional
 

--- a/backend/src/cobra/transpilers/__init__.py
+++ b/backend/src/cobra/transpilers/__init__.py
@@ -1,3 +1,5 @@
+"""Facilita el acceso a los distintos transpiladores de Cobra."""
+
 from .base import BaseTranspiler
 
 __all__ = ["BaseTranspiler"]

--- a/backend/src/gui/__init__.py
+++ b/backend/src/gui/__init__.py
@@ -1,0 +1,2 @@
+"""Componentes de la interfaz gráfica de Cobra."""
+

--- a/backend/src/gui/app.py
+++ b/backend/src/gui/app.py
@@ -1,3 +1,5 @@
+"""Aplicación gráfica básica usando Flet para ejecutar código Cobra."""
+
 import io
 import sys
 import flet as ft

--- a/backend/src/gui/idle.py
+++ b/backend/src/gui/idle.py
@@ -1,3 +1,5 @@
+"""Entorno interactivo para ejecutar código Cobra y explorar tokens y AST."""
+
 import io
 import sys
 import flet as ft

--- a/backend/src/ia/__init__.py
+++ b/backend/src/ia/__init__.py
@@ -1,0 +1,2 @@
+"""Herramientas experimentales de inteligencia artificial aplicadas a Cobra."""
+

--- a/backend/src/jupyter_kernel/__init__.py
+++ b/backend/src/jupyter_kernel/__init__.py
@@ -1,3 +1,5 @@
+"""Kernel de Jupyter que permite ejecutar código Cobra en notebooks."""
+
 import sys
 import io
 import contextlib


### PR DESCRIPTION
## Summary
- add Spanish module docstrings across backend modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tomli')*

------
https://chatgpt.com/codex/tasks/task_e_68753f66320083278a899f07acf08649