### PR TITLE
Add install and test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,12 @@ lint:
 	flake8 backend/src
 	mypy backend/src
 	bandit -r src backend/src
+	flake8 src/ tests/
 
 format:
 	isort backend/src src
 	black backend/src src
+	black src/ tests/
 
 typecheck:
 		mypy backend/src
@@ -39,7 +41,13 @@ typecheck:
 	fi
 
 benchmarks:
-                python scripts/benchmarks/run_benchmarks.py > bench_results.json
+	python scripts/benchmarks/run_benchmarks.py > bench_results.json
 
 secrets:
 	gitleaks detect --source . --redact
+
+install:
+	pip install -e .[dev]
+
+test:
+	pytest --cov=src tests/


### PR DESCRIPTION
## Summary
- add Makefile rules for `install` and `test`
- augment `format` and `lint` targets

## Testing
- `make install` *(fails: `WARNING: cobra-lenguaje 9.0.0 does not provide the extra 'dev'`)*
- `make test` *(fails: `error: unrecognized arguments: --cov=src`)*
- `make format` *(fails: cannot format some files)*
- `make lint` *(fails: flake8 not found)*
- `make coverage` *(fails: pytest error unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6875c30994cc83278a862d027e0a7643