### PR TITLE
Añadir soporte a python-dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ pip install -e .
 ````
 
 6. Copia el archivo ``.env.example`` a ``.env`` y personaliza las rutas o claves
-   de ser necesario:
+   de ser necesario. Estas variables se cargarán automáticamente al iniciar
+   Cobra gracias a ``python-dotenv``:
 
 ````bash
 cp .env.example .env

--- a/backend/src/core/main.py
+++ b/backend/src/core/main.py
@@ -1,5 +1,10 @@
 """Punto de entrada mínimo para ejecutar un saludo de prueba."""
 
+from dotenv import load_dotenv
+
+# Carga variables de entorno desde un archivo .env si existe
+load_dotenv()
+
 
 def main():
     """Imprime un mensaje de bienvenida."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ notebooks = [
     "papermill>=2.6.0",
     "nbconvert>=7.16.6",
 ]
+dev = ["python-dotenv"]
 
 [tool.setuptools]
 package-dir = {"" = "backend/src"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ psutil==7.0.0
 sphinxcontrib-plantuml==0.30
 black==25.1.0
 isort==6.0.1
+python-dotenv

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,8 @@
+from dotenv import load_dotenv
+
+# Carga las variables de entorno antes de importar otros módulos
+load_dotenv()
+
 from src.core.main import main
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Resumen
- instalar python-dotenv en el entorno
- declarar la dependencia en `requirements.txt` y en la sección `[project.optional-dependencies]` de `pyproject.toml`
- cargar variables de entorno con `load_dotenv()` en los puntos de entrada
- documentar en `README.md` el uso del archivo `.env`

## Testing
- `pytest tests/unit/test_core_main.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6875d84679a083278feba21f9d3cefd6