### PR TITLE
Add run script with env loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,15 @@ los tiempos y uso de CPU.
 
 # Uso
 
+Para ejecutar el proyecto directamente desde el repositorio se incluye el
+script `run.sh`. Este cargará las variables definidas en `.env` si dicho archivo
+existe y luego llamará a `python -m src.main` pasando todos los argumentos
+recibidos. Úsalo de la siguiente forma:
+
+```bash
+./run.sh [opciones]
+```
+
 Para conocer las opciones avanzadas del modo seguro revisa
 `frontend/docs/modo_seguro.rst`. Los ejemplos de medición de rendimiento
 están disponibles en `frontend/docs/benchmarking.rst`.

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Cargar variables de entorno si existe .env
+[ -f .env ] && export $(grep -v '^#' .env | xargs)
+python -m src.main "$@"


### PR DESCRIPTION
## Summary
- add a `run.sh` helper script
- document how to use `run.sh` in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend', 'pexpect', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6875dfe4fb38832780521275a5dd5f23