### PR TITLE
Add backend path setup for pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+# Agrega el directorio backend/src para simplificar los imports en las pruebas
+ROOT = Path(__file__).resolve().parents[1]
+backend_src = ROOT / "backend" / "src"
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if backend_src.exists() and str(backend_src) not in sys.path:
+    sys.path.insert(0, str(backend_src))
+
+# Carga el paquete backend para registrar sus submódulos en "src"
+try:  # nosec B001
+    import backend  # noqa: F401
+except Exception:
+    pass


### PR DESCRIPTION
## Summary
- ensure tests can import backend modules without manual path manipulation
- add `tests/conftest.py` which injects `backend/src` and the repository root into `sys.path`
- load `backend` package so its submodules are available under the `src` namespace

## Testing
- `pytest --collect-only`
- `pytest -k test_analizador_agix.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68768bc98fb08327afb4653674f701ac