### PR TITLE
Configuración unificada de Python y tareas CI

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,0 +1,20 @@
+name: Install dependencies
+description: Set up Python dependencies
+inputs:
+  extra:
+    description: Extra packages to install
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Upgrade pip and install base dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -e .
+        if [ -n "${{ inputs.extra }}" ]; then
+          pip install ${{ inputs.extra }}
+        fi
+

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -17,11 +17,9 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -e .
-          pip install pyinstaller
+        uses: ./.github/actions/install
+        with:
+          extra: "pyinstaller"
       - name: Build executable
         run: cobra empaquetar --output dist --add-data all-bytes.dat:all-bytes.dat
       - name: Upload executable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc g++ golang-go ruby-full
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -e .
-          pip install sphinx sphinx-rtd-theme pytest-cov codecov
-          pip install pyright
+        uses: ./.github/actions/install
+        with:
+          extra: "sphinx sphinx-rtd-theme pytest-cov codecov pyright"
       - name: Seguridad de dependencias
         run: |
           pip install safety
@@ -38,13 +35,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run linters
-        run: |
-          isort --check backend/src src
-          black --check backend/src src
-          flake8 backend/src
-          mypy backend/src
-          bandit -r src backend/src
-          pyright --project pyrightconfig.json
+        run: make lint
       - name: Run type checks
         run: make typecheck
       - name: Run tests

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,10 +17,9 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install sphinx sphinx-rtd-theme
+        uses: ./.github/actions/install
+        with:
+          extra: "sphinx sphinx-rtd-theme"
       - name: Build docs
         run: sphinx-build -b html frontend/docs frontend/build/html
       - name: Build root docs

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -16,11 +16,9 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -e .
-          pip install pyinstaller
+        uses: ./.github/actions/install
+        with:
+          extra: "pyinstaller"
       - name: Build executable
         run: cobra empaquetar --output dist --add-data all-bytes.dat:all-bytes.dat
       - name: Upload executable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,9 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -e .
-          pip install pyinstaller
+        uses: ./.github/actions/install
+        with:
+          extra: "pyinstaller"
       - name: Build executable
         run: cobra empaquetar --output dist
       - name: Upload executable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -22,10 +22,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc g++ golang-go ruby-full
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -e .
+        uses: ./.github/actions/install
       - name: Scan for secrets
         uses: gitleaks/gitleaks-action@v2
         env:


### PR DESCRIPTION
## Summary
- unificar version de Python 3.11 en todos los workflows
- crear accion compuesta `install` para instalar dependencias
- usar la nueva accion en CI, tests y releases
- ejecutar `make lint`, `make typecheck` y `pytest`

## Testing
- `make lint` *(falla)*
- `make typecheck` *(falla)*
- `pytest -q` *(falla)*

------
https://chatgpt.com/codex/tasks/task_e_68772e409a648327938d56279c1a5fc2