### PR TITLE
docs: explica revision de logs de CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,20 @@ Además de las pruebas, ejecuta las verificaciones de estilo con:
 ```bash
 make lint
 ```
+## Revisar logs de GitHub Actions
+
+Cuando una tarea falla en CI dirígete a la pestaña *Actions* del repositorio y abre el flujo asociado a tu commit. Cada trabajo muestra los pasos ejecutados y permite desplegar los registros completos. Utiliza la barra de búsqueda para filtrar por palabras clave como `pytest` o `lint`. Desde **View raw logs** puedes descargar el archivo para analizarlo con mayor detalle.
+
+Para reproducir los errores comunes ejecuta localmente:
+
+```bash
+pytest -vv
+make lint
+make typecheck
+make secrets     # analiza con gitleaks
+safety check --full-report
+```
+
 
 ## Pull Requests
 

--- a/docs/contribucion.md
+++ b/docs/contribucion.md
@@ -37,6 +37,20 @@ Además de las pruebas, ejecuta las verificaciones de estilo con:
 ```bash
 make lint
 ```
+## Revisar logs de GitHub Actions
+
+Cuando una tarea falla en CI dirígete a la pestaña *Actions* del repositorio y abre el flujo asociado a tu commit. Cada trabajo muestra los pasos ejecutados y permite desplegar los registros completos. Utiliza la barra de búsqueda para filtrar por palabras clave como `pytest` o `lint`. Desde **View raw logs** puedes descargar el archivo para analizarlo con mayor detalle.
+
+Para reproducir los errores comunes ejecuta localmente:
+
+```bash
+pytest -vv
+make lint
+make typecheck
+make secrets     # analiza con gitleaks
+safety check --full-report
+```
+
 
 ## Pull Requests
 


### PR DESCRIPTION
## Summary
- explica donde consultar logs de GitHub Actions
- muestra comandos locales para reproducir errores de CI

## Testing
- `make lint` *(fails: blank line at end of file, E501 line too long)*
- `pytest -q` *(fails: SyntaxError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68777173bcb483279e82dd8a58a76e36