### PR TITLE
Organiza dependencias de desarrollo en pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,17 +20,14 @@ dependencies = [
     "tensorflow>=2.6.0",
     "dask>=2021.09.0",
     "DEAP>=1.3.1",
-    "ipykernel>=6.29.5",
-  "agix==0.8.3",
-  "holobit-sdk",
-  "smooth-criminal",
-  "tomli>=2.0",
-  "PyYAML>=6.0",
-  "jsonschema>=4.24.0",
-  "python-dotenv",
-  "python-lsp-server",
-  "pexpect",
-  "hypothesis",
+    "agix==0.8.3",
+    "holobit-sdk",
+    "smooth-criminal",
+    "tomli>=2.0",
+    "PyYAML>=6.0",
+    "jsonschema>=4.24.0",
+    "python-dotenv",
+    "pexpect",
 ]
 
 [project.urls]
@@ -42,8 +39,13 @@ mutation = ["mutpy>=0.6.1"]
 notebooks = [
     "papermill>=2.6.0",
     "nbconvert>=7.16.6",
+    "ipykernel>=6.29.5",
 ]
-dev = ["python-dotenv"]
+dev = [
+    "python-dotenv",
+    "python-lsp-server",
+    "hypothesis",
+]
 
 [tool.setuptools]
 package-dir = {"" = "backend/src"}


### PR DESCRIPTION
## Summary
- reubicar dependencias de desarrollo en el extra `dev`
- mover `ipykernel` al extra `notebooks`
- comprobar scripts instalables y generación del paquete

## Testing
- `python -m build`
- `pip install .`
- `pcobra`

------
https://chatgpt.com/codex/tasks/task_e_6877cc0315408327ae4a026628ddeed1