### PR TITLE
Add install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ Para instalar el proyecto, sigue estos pasos:
 cd pCobra
 ````
 
+Si prefieres automatizar el proceso, ejecuta:
+
+```bash
+./install.sh            # instala desde PyPI
+./install.sh --dev      # instala en modo editable
+```
+
+
 3. Crea un entorno virtual y actívalo:
 
 ````bash

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+VENV=".venv"
+OS="$(uname)"
+
+echo "Detectando sistema operativo: $OS"
+
+if [ ! -d "$VENV" ]; then
+    echo "Creando entorno virtual en $VENV"
+    python3 -m venv "$VENV"
+fi
+
+# Activar entorno dependiendo del SO
+case "$OS" in
+    *MINGW*|*MSYS*|*CYGWIN*|*Windows*)
+        source "$VENV/Scripts/activate"
+        ;;
+    *)
+        source "$VENV/bin/activate"
+        ;;
+esac
+
+if [ "$1" = "--dev" ]; then
+    echo "Instalando pCobra en modo editable"
+    pip install -e .
+else
+    echo "Instalando cobra-lenguaje desde PyPI"
+    pip install cobra-lenguaje
+fi
+
+echo "Instalación finalizada. Entorno activado en $VENV"
+


### PR DESCRIPTION
## Summary
- add install.sh script for creating a virtualenv and installing Cobra
- document how to use the script in README

## Testing
- `pip install pytest pytest-cov pytest-timeout`
- `pip install -e .`
- `PYTHONPATH=$PWD pytest` *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6877d15b17548327a6b261d3f2bf5f5c