### PR TITLE
Galería sin binarios en documentación

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ docs/cheatsheet.pdf
 bench_results.json
 all-bytes.dat
 venv/
+frontend/docs/galeria/*.png
+frontend/docs/galeria/*.gif

--- a/frontend/docs/galeria/README.rst
+++ b/frontend/docs/galeria/README.rst
@@ -1,0 +1,1 @@
+En este directorio puedes añadir capturas de pantalla o GIFs que muestren la ejecución de los notebooks. Para mantener ligero el repositorio, estas imágenes no se incluyen en el control de versiones.

--- a/frontend/docs/jupyter.rst
+++ b/frontend/docs/jupyter.rst
@@ -12,3 +12,27 @@ Una vez instalado puedes lanzar el cuaderno con:
 .. code-block:: bash
 
    cobra jupyter
+
+También puedes abrir un cuaderno concreto con:
+
+.. code-block:: bash
+
+   cobra jupyter --notebook ruta/al/cuaderno.ipynb
+
+Dispones de varios cuadernos de ejemplo en la carpeta ``notebooks``:
+
+* `Ejemplo básico <../../notebooks/ejemplo_basico.ipynb>`_
+* `Benchmarks <../../notebooks/benchmarks_resultados.ipynb>`_
+* `Casos reales: Bioinformática <../../notebooks/casos_reales/bioinformatica.ipynb>`_
+* `Casos reales: IA <../../notebooks/casos_reales/inteligencia_artificial.ipynb>`_
+* `Casos reales: Análisis de datos <../../notebooks/casos_reales/analisis_datos.ipynb>`_
+
+.. note::
+
+   Puedes añadir tus propias capturas de pantalla en ``frontend/docs/galeria``.
+
+Puedes probarlos en línea con este badge de Binder:
+
+.. raw:: html
+
+   <a href="https://mybinder.org/v2/gh/tuusuario/pCobra/HEAD?filepath=notebooks/ejemplo_basico.ipynb"><img src="https://mybinder.org/badge_logo.svg" alt="Binder"></a>


### PR DESCRIPTION
## Summary
- eliminar la captura binaria y documentar que puede añadirse manualmente
- ignorar imágenes de la galería en .gitignore
- actualizar la documentación de Jupyter con una nota sobre la galería

## Testing
- `pytest tests` *(falla: 72 errores durante la recolección)*

------
https://chatgpt.com/codex/tasks/task_e_6877e0f8d4448327a5bcd90538443e08