### PR TITLE
Agregar doc de parser y transpiladores

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ cobra empaquetar --spec build/cobra.spec \
 El proyecto se organiza en las siguientes carpetas y módulos:
 
 - `backend/src/`: Contiene la lógica Python del proyecto.
-- `frontend/docs/` y `frontend/build/`: Carpetas donde se genera y aloja la documentación. El archivo `frontend/docs/arquitectura.rst` describe la estructura interna del lenguaje.
+- `frontend/docs/` y `frontend/build/`: Carpetas donde se genera y aloja la documentación. El archivo `frontend/docs/arquitectura.rst` describe la estructura interna del lenguaje. Consulta `docs/arquitectura_parser_transpiladores.md` para un resumen de la relación entre lexer, parser y transpiladores.
 - `tests/`: Incluye pruebas unitarias para asegurar el correcto funcionamiento del código.
 - `README.md`: Documentación del proyecto.
 - `requirements.txt`: Archivo que lista las dependencias del proyecto.

--- a/docs/arquitectura_parser_transpiladores.md
+++ b/docs/arquitectura_parser_transpiladores.md
@@ -1,0 +1,41 @@
+# Arquitectura del Parser y los Transpiladores
+
+Este documento resume la relaci\u00f3n entre los m\u00f3dulos principales del compilador de Cobra y c\u00f3mo cooperan para transformar el c\u00f3digo fuente.
+
+## M\u00f3dulos principales
+
+### `lexer`
+Se encarga de leer el texto fuente y convertirlo en una secuencia de *tokens*. Cada token registra informaci\u00f3n sobre su tipo y su posici\u00f3n en el archivo para que el parser pueda procesarlo correctamente.
+
+### `parser`
+Consume los tokens generados por el lexer y construye el \u00c1rbol de Sintaxis Abstracta (**AST**). El parser valida la estructura del programa y crea los nodos que representar\u00e1n instrucciones, expresiones y declaraciones.
+
+### `transpilers`
+Una vez disponible el AST, los transpiladores recorren cada nodo mediante el patr\u00f3n *Visitor* para generar c\u00f3digo en otros lenguajes. Cobra incluye transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX.
+
+## Interacci\u00f3n general
+El proceso habitual comienza con el lexer, sigue con el parser y finaliza en el int\u00e9rprete o en alguno de los transpiladores. La siguiente gr\u00e1fica resume dicho flujo.
+
+```{graphviz}
+digraph pipeline {
+    rankdir=LR;
+    Lexer -> Parser -> AST;
+    AST -> Interprete;
+    AST -> Transpiladores;
+}
+```
+
+```{uml}
+@startuml
+Lexer --> Parser
+Parser --> AST
+AST --> "Interprete"
+AST --> Transpiladores
+Transpiladores --> Python
+Transpiladores --> JS
+Transpiladores --> ASM
+Transpiladores --> Rust
+@enduml
+```
+
+Para detalles sobre la estructura de nodos consulta [docs/estructura_ast.md](estructura_ast.md).

--- a/frontend/docs/arquitectura.rst
+++ b/frontend/docs/arquitectura.rst
@@ -28,6 +28,8 @@ importan estas funciones desde ``src.core.transpiler.python_nodes`` y
 ``src.core.transpiler.js_nodes`` (o ``asm_nodes`` o ``rust_nodes``) respectivamente, delegando la operación de
 ``visit_<nodo>`` a dichas funciones.
 
+Para una visión esquemática de la interacción entre lexer, parser y transpiladores consulta :doc:`../../docs/arquitectura_parser_transpiladores`.
+
 Módulos nativos
 ---------------
 Bibliotecas básicas que amplían la funcionalidad de Cobra con


### PR DESCRIPTION
## Resumen
- describir los modulos lexer, parser y transpilers
- enlazar el nuevo documento desde la documentación principal y el README

## Testing
- `pytest -q` *(fallan varias pruebas por dependencias y errores de sintaxis)*

------
https://chatgpt.com/codex/tasks/task_e_6878a6aa9ae083278c270b4f9dcef845