### PR TITLE
Add VS Code extension docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Cobra es un lenguaje de programación diseñado en español, enfocado en la crea
 - Contribuciones
 - [Guía de Contribución](CONTRIBUTING.md)
 - [Proponer extensiones](frontend/docs/rfc_plugins.rst)
+- Extensión para VS Code
 - [Comunidad](docs/comunidad.md)
 - Licencia
 - [Manual de Cobra](MANUAL_COBRA.md)
@@ -926,6 +927,10 @@ class HolaCommand(PluginCommand):
     def run(self, args):
         print("¡Hola desde un plugin!")
 ```
+## Extensión para VS Code
+
+La extensión para Visual Studio Code se encuentra en [`frontend/vscode`](frontend/vscode). Instala las dependencias con `npm install`. Desde VS Code puedes pulsar `F5` para probarla o ejecutar `vsce package` para generar el paquete `.vsix`. Consulta [frontend/vscode/README.md](frontend/vscode/README.md) para más detalles.
+
 ## Versionado Semántico
 
 Este proyecto sigue el esquema [SemVer](https://semver.org/lang/es/). Los numeros se interpretan como Mayor.Menor.Parche. Cada incremento de version refleja cambios compatibles o rupturas segun esta norma.

--- a/README_en.md
+++ b/README_en.md
@@ -23,6 +23,7 @@ Cobra is a programming language designed in Spanish, aimed at creating tools, si
 - Contributions
 - [Contribution Guide](CONTRIBUTING.md)
 - [Propose extensions](frontend/docs/rfc_plugins.rst)
+- VS Code extension
 - [Community](docs/comunidad.md)
 - License
 - [Cobra Manual](MANUAL_COBRA.md)
@@ -447,6 +448,10 @@ There are also instructions for running linters (`make lint`), type checking (`m
 ## Contributions and community
 
 Contributions are welcome! Check [CONTRIBUTING.md](CONTRIBUTING.md) for style conventions and pull request guidelines. Join our community via Discord, Telegram or Twitter to get involved.
+## VS Code extension
+
+The extension is located in [`frontend/vscode`](frontend/vscode). Install the dependencies with `npm install`. Press `F5` in VS Code to launch an Extension Development Host or run `vsce package` to create the `.vsix` file. See [frontend/vscode/README.md](frontend/vscode/README.md) for more information.
+
 
 ## License
 


### PR DESCRIPTION
## Summary
- document VS Code extension path and usage in README.md
- mention VS Code extension in English README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tomli')*

------
https://chatgpt.com/codex/tasks/task_e_6878f12bf0d08327a3b79ddb4ed453a4