### PR TITLE
Add lint diagnostics and VS Code command

### DIFF
--- a/frontend/vscode/README.md
+++ b/frontend/vscode/README.md
@@ -16,8 +16,10 @@ npm install
 3. La extensión iniciará automáticamente el servidor LSP. Si lo prefieres puedes usar el comando **Iniciar Cobra LSP**.
 4. Para ejecutar el archivo Cobra actualmente abierto, presiona `Ctrl+R` o ejecuta el comando **Ejecutar archivo Cobra**.
 5. Formatea el documento con `Ctrl+Alt+F` o mediante `Shift+Alt+F`.
+6. Ejecuta el lint con `Ctrl+L` o desde el comando **Lint archivo Cobra**.
 
 El servidor de lenguaje (`python -m lsp.server`) ofrece autocompletado, detección de errores de sintaxis y formateo para archivos Cobra.
+Los avisos de estilo reportados por el lint aparecerán en el panel de problemas de VS Code.
 
 ## Snippets incluidos
 
@@ -27,7 +29,7 @@ La extensión registra fragmentos de código (snippets) para acelerar la escritu
 
 ```cobra
 func nombre(parametros):
-    
+
 fin
 ```
 
@@ -35,9 +37,9 @@ fin
 
 ```cobra
 si condicion:
-    
+
 sino:
-    
+
 fin
 ```
 
@@ -45,7 +47,7 @@ fin
 
 ```cobra
 para item en iterable:
-    
+
 fin
 ```
 

--- a/frontend/vscode/extension.js
+++ b/frontend/vscode/extension.js
@@ -1,72 +1,99 @@
-const vscode = require('vscode');
-const cp = require('child_process');
-const { LanguageClient } = require('vscode-languageclient/node');
+const vscode = require("vscode");
+const cp = require("child_process");
+const { LanguageClient } = require("vscode-languageclient/node");
 
 // Ruta al módulo del servidor LSP. Modifica aquí si cambia el nombre.
-const SERVER_MODULE = 'lsp.server';
+const SERVER_MODULE = "lsp.server";
 
 let client;
 
 function startClient(context) {
-    if (client) {
-        return;
-    }
+  if (client) {
+    return;
+  }
 
-    const serverOptions = () => {
-        const process = cp.spawn('python', ['-m', SERVER_MODULE]);
-        return { process };
-    };
+  const serverOptions = () => {
+    const process = cp.spawn("python", ["-m", SERVER_MODULE]);
+    return { process };
+  };
 
-    const clientOptions = {
-        documentSelector: [{ scheme: 'file', language: 'cobra' }],
-    };
+  const clientOptions = {
+    documentSelector: [{ scheme: "file", language: "cobra" }],
+  };
 
-    client = new LanguageClient('cobra-lsp', 'Cobra LSP', serverOptions, clientOptions);
-    context.subscriptions.push(client.start());
+  client = new LanguageClient(
+    "cobra-lsp",
+    "Cobra LSP",
+    serverOptions,
+    clientOptions,
+  );
+  context.subscriptions.push(client.start());
 }
 
 function activate(context) {
-    console.log('Extensión Cobra activada');
+  console.log("Extensión Cobra activada");
+  startClient(context);
+
+  const disposable = vscode.commands.registerCommand("cobra.startLSP", () => {
     startClient(context);
+  });
+  context.subscriptions.push(disposable);
 
-    const disposable = vscode.commands.registerCommand('cobra.startLSP', () => {
-        startClient(context);
-    });
-    context.subscriptions.push(disposable);
+  const runFileDisposable = vscode.commands.registerCommand(
+    "cobra.runFile",
+    () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) {
+        vscode.window.showErrorMessage("No hay un editor activo.");
+        return;
+      }
 
-    const runFileDisposable = vscode.commands.registerCommand('cobra.runFile', () => {
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showErrorMessage('No hay un editor activo.');
-            return;
-        }
+      const filePath = editor.document.fileName;
 
-        const filePath = editor.document.fileName;
+      const output = vscode.window.createOutputChannel("Cobra");
+      output.clear();
+      output.show(true);
 
-        const output = vscode.window.createOutputChannel('Cobra');
-        output.clear();
-        output.show(true);
+      const proc = cp.spawn("cobra", ["ejecutar", filePath]);
 
-        const proc = cp.spawn('cobra', ['ejecutar', filePath]);
+      proc.stdout.on("data", (data) => output.append(data.toString()));
+      proc.stderr.on("data", (data) => output.append(data.toString()));
+      proc.on("error", (err) => output.append(`Error: ${err.message}\n`));
+    },
+  );
 
-        proc.stdout.on('data', data => output.append(data.toString()));
-        proc.stderr.on('data', data => output.append(data.toString()));
-        proc.on('error', err => output.append(`Error: ${err.message}\n`));
-    });
+  context.subscriptions.push(runFileDisposable);
 
-    context.subscriptions.push(runFileDisposable);
+  const formatDisposable = vscode.commands.registerCommand(
+    "cobra.formatDocument",
+    () => {
+      vscode.commands.executeCommand("editor.action.formatDocument");
+    },
+  );
 
-    const formatDisposable = vscode.commands.registerCommand('cobra.formatDocument', () => {
-        vscode.commands.executeCommand('editor.action.formatDocument');
-    });
+  context.subscriptions.push(formatDisposable);
 
-    context.subscriptions.push(formatDisposable);
+  const lintDisposable = vscode.commands.registerCommand(
+    "cobra.lintFile",
+    () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) {
+        vscode.window.showErrorMessage("No hay un editor activo.");
+        return;
+      }
+      editor.document.save().then(() => {
+        vscode.window.showInformationMessage("Análisis de lint ejecutado");
+      });
+    },
+  );
+
+  context.subscriptions.push(lintDisposable);
 }
 
 function deactivate() {
-    if (client) {
-        return client.stop();
-    }
+  if (client) {
+    return client.stop();
+  }
 }
 
 module.exports = { activate, deactivate };

--- a/frontend/vscode/package.json
+++ b/frontend/vscode/package.json
@@ -1,69 +1,85 @@
 {
-    "name": "cobra-vscode-extension",
-    "displayName": "Cobra Support",
-    "description": "Extensión básica para editar archivos Cobra",
-    "version": "1.0.0",
-    "author": "Adolfo González Hernández",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Alphonsus411/pCobra"
-    },
-    "engines": {
-        "vscode": "^1.80.0"
-    },
-    "activationEvents": [
-        "onCommand:cobra.startLSP",
-        "onLanguage:cobra"
+  "name": "cobra-vscode-extension",
+  "displayName": "Cobra Support",
+  "description": "Extensión básica para editar archivos Cobra",
+  "version": "1.0.0",
+  "author": "Adolfo González Hernández",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Alphonsus411/pCobra"
+  },
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "activationEvents": [
+    "onCommand:cobra.startLSP",
+    "onCommand:cobra.lintFile",
+    "onLanguage:cobra"
+  ],
+  "main": "./extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "cobra.startLSP",
+        "title": "Iniciar Cobra LSP"
+      },
+      {
+        "command": "cobra.runFile",
+        "title": "Ejecutar archivo Cobra"
+      },
+      {
+        "command": "cobra.formatDocument",
+        "title": "Formatear documento Cobra"
+      },
+      {
+        "command": "cobra.lintFile",
+        "title": "Lint archivo Cobra"
+      }
     ],
-    "main": "./extension.js",
-    "contributes": {
-        "commands": [
-            {
-                "command": "cobra.startLSP",
-                "title": "Iniciar Cobra LSP"
-            },
-            {
-                "command": "cobra.runFile",
-                "title": "Ejecutar archivo Cobra"
-            },
-            {
-                "command": "cobra.formatDocument",
-                "title": "Formatear documento Cobra"
-            }
+    "languages": [
+      {
+        "id": "cobra",
+        "extensions": [
+          ".co"
         ],
-        "languages": [
-            {
-                "id": "cobra",
-                "extensions": [".co"],
-                "aliases": ["Cobra"],
-                "configuration": "./language-configuration.json"
-            }
+        "aliases": [
+          "Cobra"
         ],
-        "grammars": [
-            {
-                "language": "cobra",
-                "scopeName": "source.cobra",
-                "path": "./syntaxes/cobra.tmLanguage.json"
-            }
-        ],
-        "snippets": [
-            {
-                "language": "cobra",
-                "path": "./snippets/cobra.json"
-            }
-        ],
-        "keybindings": [{
-            "command": "cobra.runFile",
-            "key": "ctrl+r",
-            "when": "editorTextFocus && editorLangId == cobra"
-        }, {
-            "command": "cobra.formatDocument",
-            "key": "ctrl+alt+f",
-            "when": "editorTextFocus && editorLangId == cobra"
-        }]
-    }
-    ,
-    "dependencies": {
-        "vscode-languageclient": "^9.0.1"
-    }
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "cobra",
+        "scopeName": "source.cobra",
+        "path": "./syntaxes/cobra.tmLanguage.json"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "cobra",
+        "path": "./snippets/cobra.json"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "cobra.runFile",
+        "key": "ctrl+r",
+        "when": "editorTextFocus && editorLangId == cobra"
+      },
+      {
+        "command": "cobra.formatDocument",
+        "key": "ctrl+alt+f",
+        "when": "editorTextFocus && editorLangId == cobra"
+      },
+      {
+        "command": "cobra.lintFile",
+        "key": "ctrl+l",
+        "when": "editorTextFocus && editorLangId == cobra"
+      }
+    ]
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1"
+  }
 }


### PR DESCRIPTION
## Summary
- extend Cobra LSP plugin to emit style diagnostics (long lines, tabs and trailing spaces)
- register `cobra.lintFile` command in the VS Code extension
- document how to run the lint command

## Testing
- `flake8 backend/src/lsp/cobra_plugin.py`
- `mypy backend/src/lsp/cobra_plugin.py`
- `bandit -r backend/src/lsp/cobra_plugin.py`
- `pytest tests/unit/test_lsp_server.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6878f7a7885883278a8ec57888645659