### PR TITLE
Add Python transpile mode to Jupyter kernel

### DIFF
--- a/frontend/docs/jupyter.rst
+++ b/frontend/docs/jupyter.rst
@@ -35,4 +35,22 @@ Puedes probarlos en línea con este badge de Binder:
 
 .. raw:: html
 
-   <a href="https://mybinder.org/v2/gh/tuusuario/pCobra/HEAD?filepath=notebooks/ejemplo_basico.ipynb"><img src="https://mybinder.org/badge_logo.svg" alt="Binder"></a>
+    <a href="https://mybinder.org/v2/gh/tuusuario/pCobra/HEAD?filepath=notebooks/ejemplo_basico.ipynb"><img src="https://mybinder.org/badge_logo.svg" alt="Binder"></a>
+
+Modo Python
+-----------
+
+Si estableces la variable de entorno ``COBRA_JUPYTER_PYTHON`` el kernel transpilará
+las celdas a Python mediante ``cobra.transpilers.transpiler.to_python`` y ejecutará
+el resultado en un subproceso ``python``. La salida estándar y los errores se
+mostrarán en la celda correspondiente.
+
+Para activarlo:
+
+.. code-block:: bash
+
+   export COBRA_JUPYTER_PYTHON=1
+   cobra jupyter
+
+Este modo es útil para depurar la traducción a Python o comparar el comportamiento
+del intérprete con el backend de Python.


### PR DESCRIPTION
## Summary
- allow running notebook cells by transpiling to Python
- capture subprocess output
- document how to enable this mode

## Testing
- `pytest -k test_cli_jupyter -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6878fbb1002c8327a52a8f33ce32bd15