### PR TITLE
Add IDE demo notebook and kernel transpiler test

### DIFF
--- a/frontend/docs/entorno_desarrollo.rst
+++ b/frontend/docs/entorno_desarrollo.rst
@@ -25,3 +25,24 @@ Directorio de la extensión de VS Code
 Dentro de ``frontend/vscode`` encontrarás una plantilla mínima para la
 extensión de Cobra. Puedes abrir dicho directorio en VS Code y modificarla
 según tus necesidades.
+
+Ejemplo de kernel transpiler
+----------------------------
+
+Se incluye el cuaderno ``notebooks/ide_demo.ipynb`` que muestra cómo
+utilizar el kernel con la variable ``COBRA_JUPYTER_PYTHON`` activada. Para
+probarlo ejecuta:
+
+.. code-block:: bash
+
+   export COBRA_JUPYTER_PYTHON=1
+   cobra jupyter notebooks/ide_demo.ipynb
+
+El kernel transpilará cada celda a Python antes de ejecutarla.
+
+Pruebas de integración
+----------------------
+
+En ``tests/integration`` encontrarás ``test_kernel_transpiler.py``. Este
+script ejecuta el kernel en modo transpiler y comprueba que la salida es la
+esperada.

--- a/notebooks/ide_demo.ipynb
+++ b/notebooks/ide_demo.ipynb
@@ -1,0 +1,46 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0391cfc0",
+   "metadata": {},
+   "source": [
+    "## Demo de kernel en modo transpiler\n",
+    "Este cuaderno se ejecuta con `COBRA_JUPYTER_PYTHON=1` para que el kernel transpile a Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87aa7482",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = 2\n",
+    "imprimir(x * 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ca0c610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "func suma(a, b):\n",
+    "    retornar a + b\n",
+    "fin\n",
+    "imprimir(suma(5, 7))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Cobra",
+   "language": "cobra",
+   "name": "cobra"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/integration/test_kernel_transpiler.py
+++ b/tests/integration/test_kernel_transpiler.py
@@ -1,0 +1,37 @@
+import subprocess
+from io import StringIO
+import sys
+import types
+
+from jupyter_kernel import CobraKernel
+
+
+def fake_run(cmd, input=None, capture_output=True, text=True):
+    return subprocess.CompletedProcess(cmd, 0, stdout="hola\n", stderr="")
+
+
+def test_kernel_transpiler_mode(monkeypatch):
+    monkeypatch.setenv("COBRA_JUPYTER_PYTHON", "1")
+    outputs = []
+
+    class DummyKernel(CobraKernel):
+        def __init__(self):
+            super().__init__()
+            self.iopub_socket = None
+            self.session = None
+
+        def send_response(self, stream, msg_or_type, content, **kwargs):
+            outputs.append((msg_or_type, content))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    setup_mod = types.ModuleType("pybind11.setup_helpers")
+    setup_mod.Pybind11Extension = object
+    setup_mod.build_ext = object
+    sys.modules["pybind11.setup_helpers"] = setup_mod
+    mod = types.ModuleType("pybind11")
+    mod.setup_helpers = setup_mod
+    sys.modules["pybind11"] = mod
+    sys.modules.setdefault("corelibs", types.ModuleType("corelibs"))
+    kernel = DummyKernel()
+    kernel.do_execute("imprimir('hola')", False)
+    assert ("stream", {"name": "stdout", "text": "hola\n"}) in outputs


### PR DESCRIPTION
## Summary
- include ide_demo.ipynb showing transpiler kernel usage
- test Jupyter kernel in transpiler mode
- document new notebook and tests in entorno_desarrollo.rst

## Testing
- `pytest -q tests/integration/test_kernel_transpiler.py`

------
https://chatgpt.com/codex/tasks/task_e_687924420c2c8327b1533daefbf6d6f1