### PR TITLE
Add corelibs and standard_library packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,11 +48,11 @@ dev = [
 ]
 
 [tool.setuptools]
-package-dir = {"" = "backend/src"}
+package-dir = {"" = "backend/src", "corelibs" = "backend/corelibs", "standard_library" = "standard_library"}
 include-package-data = true
 
 [tool.setuptools.packages.find]
-where = ["backend/src"]
+where = ["backend/src", "backend/corelibs", "standard_library"]
 
 [project.scripts]
 cobra = "src.cli.cli:main"


### PR DESCRIPTION
## Summary
- add package directories for corelibs and standard_library
- search for packages in these locations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tomli')*


------
https://chatgpt.com/codex/tasks/task_e_687b1b055c7c8327aad3478572fb9518