### PR TITLE
Actualizar lógica de búsqueda en usar_loader

### DIFF
--- a/backend/src/cobra/usar_loader.py
+++ b/backend/src/cobra/usar_loader.py
@@ -22,8 +22,16 @@ def obtener_modulo(nombre: str):
     try:
         return importlib.import_module(nombre)
     except ModuleNotFoundError:
-        # Verificar si el módulo existe dentro de ``backend/corelibs``
-        corelibs = Path(__file__).resolve().parents[2] / "corelibs"
+        # Verificar si el módulo existe dentro de ``corelibs``
+        base = Path(__file__).resolve()
+        corelibs = None
+        for parent in base.parents:
+            candidate = parent / "corelibs"
+            if candidate.exists():
+                corelibs = candidate
+                break
+        if corelibs is None:
+            corelibs = Path()
         mod_path = corelibs / f"{nombre}.py"
         pkg_path = corelibs / nombre / "__init__.py"
         if mod_path.exists() or pkg_path.exists():
@@ -35,7 +43,14 @@ def obtener_modulo(nombre: str):
             return modulo
 
         # Buscar también en ``standard_library``
-        stdlib = Path(__file__).resolve().parents[2].parent / "standard_library"
+        stdlib = None
+        for parent in base.parents:
+            candidate = parent / "standard_library"
+            if candidate.exists():
+                stdlib = candidate
+                break
+        if stdlib is None:
+            stdlib = Path()
         mod_path = stdlib / f"{nombre}.py"
         pkg_path = stdlib / nombre / "__init__.py"
         if mod_path.exists() or pkg_path.exists():

--- a/tests/unit/test_usar_loader_site_packages.py
+++ b/tests/unit/test_usar_loader_site_packages.py
@@ -1,0 +1,49 @@
+import importlib
+import types
+import sys
+from pathlib import Path
+from datetime import datetime
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_obtener_modulo_en_site_packages(tmp_path, monkeypatch):
+    site = tmp_path / "site-packages"
+    cobra_dir = site / "cobra"
+    corelibs_dir = site / "corelibs"
+    stdlib_dir = site / "standard_library"
+    cobra_dir.mkdir(parents=True)
+    corelibs_dir.mkdir()
+    stdlib_dir.mkdir()
+
+    # Copiar archivos necesarios
+    (cobra_dir / "__init__.py").write_text("")
+    usar_loader_src = ROOT / "backend" / "src" / "cobra" / "usar_loader.py"
+    (cobra_dir / "usar_loader.py").write_text(usar_loader_src.read_text())
+
+    (corelibs_dir / "__init__.py").write_text("")
+    texto_src = ROOT / "backend" / "corelibs" / "texto.py"
+    (corelibs_dir / "texto.py").write_text(texto_src.read_text())
+
+    (stdlib_dir / "__init__.py").write_text("")
+    fecha_src = ROOT / "standard_library" / "fecha.py"
+    (stdlib_dir / "fecha.py").write_text(fecha_src.read_text())
+
+    monkeypatch.syspath_prepend(str(site))
+    for key in list(sys.modules):
+        if key == "cobra" or key.startswith("cobra."):
+            del sys.modules[key]
+
+    usar_loader = importlib.import_module("cobra.usar_loader")
+
+    usar_loader.USAR_WHITELIST.update({"texto", "fecha"})
+    try:
+        mod_texto = usar_loader.obtener_modulo("texto")
+        mod_fecha = usar_loader.obtener_modulo("fecha")
+    finally:
+        usar_loader.USAR_WHITELIST.clear()
+
+    assert isinstance(mod_texto, types.ModuleType)
+    assert mod_texto.mayusculas("hola") == "HOLA"
+    assert isinstance(mod_fecha, types.ModuleType)
+    assert mod_fecha.formatear(datetime(2020, 1, 1)) == "2020-01-01"


### PR DESCRIPTION
## Resumen
- mejorar `usar_loader` para encontrar `corelibs` y `standard_library` subiendo en la jerarquía de carpetas
- agregar prueba que simula un entorno `site-packages` para verificar la carga correcta de módulos

## Testing
- `pytest -q tests/unit/test_usar_loader_stdlib.py tests/unit/test_usar.py tests/unit/test_usar_loader_site_packages.py`

------
https://chatgpt.com/codex/tasks/task_e_687b20a83f0083278f9da3748dc52b1e