### PR TITLE
Implementa verificación de URL en I/O

### DIFF
--- a/backend/src/core/nativos/io.py
+++ b/backend/src/core/nativos/io.py
@@ -15,5 +15,7 @@ def escribir_archivo(ruta, datos):
 
 def obtener_url(url):
     """Devuelve el contenido de una URL como texto."""
+    if not (url.startswith("http://") or url.startswith("https://")):
+        raise ValueError("Esquema de URL no soportado")
     with urllib.request.urlopen(url) as resp:
         return resp.read().decode("utf-8")

--- a/tests/unit/test_nativos_io.py
+++ b/tests/unit/test_nativos_io.py
@@ -1,0 +1,29 @@
+import sys
+from types import ModuleType
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / 'backend' / 'src'))
+
+# Evita dependencias externas requeridas al importar src.core.nativos
+fake_pybind11 = ModuleType('pybind11')
+fake_helpers = ModuleType('pybind11.setup_helpers')
+fake_helpers.Pybind11Extension = object
+fake_helpers.build_ext = object
+sys.modules.setdefault('pybind11', fake_pybind11)
+sys.modules.setdefault('pybind11.setup_helpers', fake_helpers)
+fake_setuptools = ModuleType('setuptools')
+fake_setuptools.Distribution = object
+sys.modules.setdefault('setuptools', fake_setuptools)
+
+import src.core.nativos.io as io
+
+
+def test_obtener_url_rechaza_esquema_no_http():
+    with patch('urllib.request.urlopen') as mock_urlopen:
+        with pytest.raises(ValueError):
+            io.obtener_url('ftp://ejemplo.com')
+        mock_urlopen.assert_not_called()


### PR DESCRIPTION
## Summary
- valida que `obtener_url` solo acepte esquemas `http` o `https`
- agrega prueba de `obtener_url` para rechazar otros esquemas

## Testing
- `pytest tests/unit/test_nativos_io.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687ca78897e88327bbd6cede19607a3e