### PR TITLE
Remove insecure compile fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,11 @@ evita acciones potencialmente peligrosas como leer archivos o importar módulos
 externos. Para activar esta opción utiliza `--sandbox` en los subcomandos
 `ejecutar` e `interactive`.
 
+El código se compila con `compile_restricted` y luego se ejecuta mediante
+`exec`. Si la compilación falla se propaga la excepción sin intentar una
+compilación normal. Mantén el entorno de ejecución lo más pequeño posible
+para reducir riesgos.
+
 # Pruebas
 
 Las pruebas están ubicadas en la carpeta tests/ y utilizan pytest para la ejecución. Antes de correrlas añade el proyecto al `PYTHONPATH` o instala el paquete en modo editable (`pip install -e .`). Así pytest podrá encontrar los módulos correctamente.

--- a/backend/src/core/sandbox.py
+++ b/backend/src/core/sandbox.py
@@ -18,14 +18,19 @@ def ejecutar_en_sandbox(codigo: str) -> str:
     """Ejecuta una cadena de código Python de forma segura.
 
     Devuelve la salida producida por ``print`` o lanza una excepción si
-    se intenta realizar una operación prohibida.
+    se intenta realizar una operación prohibida. El código se compila
+    usando :func:`compile_restricted` y posteriormente se ejecuta con
+    ``exec``. Mantener el diccionario ``env`` tan reducido como sea
+    posible ayuda a minimizar la superficie de ataque.
     """
     try:
         byte_code = compile_restricted(codigo, "<string>", "exec")
-    except SyntaxError:
-        byte_code = compile(codigo, "<string>", "exec")
+    except SyntaxError as se:  # pragma: no cover - comportamiento simple
+        raise SyntaxError(f"compile_restricted falló: {se}") from se
+
     env = {
         "__builtins__": safe_builtins,
+        "__name__": "sandbox",
         "_print_": PrintCollector,
         "_getattr_": getattr,
         "_getitem_": default_guarded_getitem,

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -19,3 +19,10 @@ def test_operacion_bloqueada_import():
     codigo = "import os\nos.listdir('.')"
     with pytest.raises(Exception):
         ejecutar_en_sandbox(codigo)
+
+
+@pytest.mark.timeout(5)
+def test_error_sintaxis():
+    """Si compile_restricted falla se debe propagar SyntaxError."""
+    with pytest.raises(SyntaxError):
+        ejecutar_en_sandbox("for")


### PR DESCRIPTION
## Summary
- disable fallback to builtin `compile` in sandbox
- warn about risk in README and docstring
- limit sandbox execution environment slightly
- test SyntaxError is raised when compilation fails

## Testing
- `pytest tests/unit/test_sandbox.py tests/unit/test_sandbox_restrictions.py tests/unit/test_restricted_exec.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687ca957d20883278c255b04c43bf812