### PR TITLE
Validación de esquemas en obtener_url

### DIFF
--- a/backend/src/core/nativos/io.py
+++ b/backend/src/core/nativos/io.py
@@ -15,7 +15,8 @@ def escribir_archivo(ruta, datos):
 
 def obtener_url(url):
     """Devuelve el contenido de una URL como texto."""
-    if not (url.startswith("http://") or url.startswith("https://")):
+    url_baja = url.lower()
+    if not (url_baja.startswith("http://") or url_baja.startswith("https://")):
         raise ValueError("Esquema de URL no soportado")
     with urllib.request.urlopen(url) as resp:
         return resp.read().decode("utf-8")

--- a/tests/unit/test_nativos_io.py
+++ b/tests/unit/test_nativos_io.py
@@ -27,3 +27,10 @@ def test_obtener_url_rechaza_esquema_no_http():
         with pytest.raises(ValueError):
             io.obtener_url('ftp://ejemplo.com')
         mock_urlopen.assert_not_called()
+
+
+def test_obtener_url_rechaza_otro_esquema():
+    with patch('urllib.request.urlopen') as mock_urlopen:
+        with pytest.raises(ValueError):
+            io.obtener_url('file:///tmp/archivo.txt')
+        mock_urlopen.assert_not_called()


### PR DESCRIPTION
## Summary
- mejorar validación de `obtener_url` usando prefijo en minúsculas
- añadir prueba unitaria para otro esquema no permitido

## Testing
- `pytest -q tests/unit/test_nativos_io.py`

------
https://chatgpt.com/codex/tasks/task_e_687cb82bae988327b08a7173b86bc4b7