### PR TITLE
Limitar entorno de sandbox y aclarar riesgos

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,9 +650,10 @@ externos. Para activar esta opción utiliza `--sandbox` en los subcomandos
 `ejecutar` e `interactive`.
 
 El código se compila con `compile_restricted` y luego se ejecuta mediante
-`exec`. Si la compilación falla se propaga la excepción sin intentar una
-compilación normal. Mantén el entorno de ejecución lo más pequeño posible
-para reducir riesgos.
+`exec`. **No** se recurre a `compile()` cuando la compilación segura falla,
+sino que se propaga la excepción. El uso de `exec` sigue siendo peligroso,
+por lo que se recomienda mantener el entorno de ejecución lo más pequeño
+posible para reducir riesgos.
 
 # Pruebas
 

--- a/backend/src/core/sandbox.py
+++ b/backend/src/core/sandbox.py
@@ -17,11 +17,12 @@ from RestrictedPython.PrintCollector import PrintCollector
 def ejecutar_en_sandbox(codigo: str) -> str:
     """Ejecuta una cadena de código Python de forma segura.
 
-    Devuelve la salida producida por ``print`` o lanza una excepción si
-    se intenta realizar una operación prohibida. El código se compila
-    usando :func:`compile_restricted` y posteriormente se ejecuta con
-    ``exec``. Mantener el diccionario ``env`` tan reducido como sea
-    posible ayuda a minimizar la superficie de ataque.
+    Devuelve la salida producida por ``print`` o lanza ``SyntaxError`` si
+    la compilación segura falla. El código se compila con
+    :func:`compile_restricted` y, de tener éxito, se ejecuta usando
+    ``exec``.  Este paso implica riesgo, por lo que **no** se intenta
+    recompilar con ``compile``. Mantén el diccionario ``env`` lo más
+    reducido posible para minimizar la superficie de ataque.
     """
     try:
         byte_code = compile_restricted(codigo, "<string>", "exec")
@@ -30,7 +31,6 @@ def ejecutar_en_sandbox(codigo: str) -> str:
 
     env = {
         "__builtins__": safe_builtins,
-        "__name__": "sandbox",
         "_print_": PrintCollector,
         "_getattr_": getattr,
         "_getitem_": default_guarded_getitem,


### PR DESCRIPTION
## Summary
- clarificar en README que no se usa `compile()` si `compile_restricted` falla
- documentar el riesgo de `exec` y mantener un entorno mínimo
- reducir el diccionario `env` eliminado `__name__`

## Testing
- `black backend/src/core/sandbox.py`
- `isort backend/src/core/sandbox.py`
- `flake8 backend/src/core/sandbox.py`
- `pytest tests/unit/test_sandbox.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687cb9f5ab0883278b8438ae38176d0d