### PR TITLE
Asegura dependencias para pruebas

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,14 @@ source .venv/bin/activate  # Para Unix
 .\.venv\Scripts\activate  # Para Windows
 ````
 
-4. Instala las dependencias de desarrollo:
+4. Instala las dependencias de desarrollo (pytest, `python-dotenv`, `tomli`,
+   `hypothesis`, etc.):
 
 ````bash
 pip install -r requirements.txt
 ````
 
-   Estas dependencias son únicamente para el entorno de desarrollo.
+   Estas bibliotecas permiten ejecutar las pruebas y otras tareas de desarrollo.
    Las dependencias de ejecución se instalarán al instalar el paquete.
 
 5. Instala el paquete de forma editable para usar la CLI y obtener las

--- a/README_en.md
+++ b/README_en.md
@@ -92,13 +92,13 @@ source .venv/bin/activate  # Unix
 .\.venv\Scripts\activate  # Windows
 ```
 
-4. Install the development dependencies:
+4. Install the development dependencies (pytest, `python-dotenv`, `tomli`, `hypothesis`, etc.):
 
 ```bash
 pip install -r requirements.txt
 ```
 
-   These dependencies are only for the development environment. Runtime dependencies are installed when installing the package.
+   These libraries are needed for running the tests and other development tasks. Runtime dependencies are installed when installing the package.
 
 5. Install the package in editable mode to use the CLI and obtain the dependencies declared in ``pyproject.toml``:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,11 @@ dependencies = [
     "jsonschema>=4.24.0",
     "python-dotenv",
     "pexpect",
+    "requests",
+    "flet",
+    "packaging",
+    "pybind11>=2.13.6",
+    "RestrictedPython>=8.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- agrega dependencias faltantes en `pyproject.toml`
- aclara en la guía de instalación para desarrolladores qué librerías se instalan

## Testing
- `pip install requests flet packaging pybind11 RestrictedPython`
- `pytest -k test_cli_gui -q` *(fallan 72 tests durante la recolección)*

------
https://chatgpt.com/codex/tasks/task_e_687cbe26b9188327b66457b2945afe03