### PR TITLE
Fix long lines and enforce flake8 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run linters
         run: make lint
+      - name: Run flake8
+        run: flake8 backend/src src
       - name: Run type checks
         run: make typecheck
       - name: Run tests

--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,2 +1,1 @@
 """Inicializa el paquete del backend y expone módulos principales."""
-

--- a/backend/src/cli/__init__.py
+++ b/backend/src/cli/__init__.py
@@ -1,2 +1,1 @@
 """Herramientas y utilidades para la línea de comandos de Cobra."""
-

--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -39,14 +39,29 @@ from .commands.verify_cmd import VerifyCommand
 def main(argv=None):
     """Punto de entrada principal de la CLI."""
     setup_gettext()
-    logging.basicConfig(level=logging.DEBUG,
-                        format="%(asctime)s - %(levelname)s - %(message)s")
+    logging.basicConfig(
+        level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
     parser = argparse.ArgumentParser(prog="cobra", description=_("CLI para Cobra"))
-    parser.add_argument("--formatear", action="store_true", help=_("Formatea el archivo antes de procesarlo"))
-    parser.add_argument("--depurar", action="store_true", help=_("Muestra mensajes de depuración"))
-    parser.add_argument("--seguro", action="store_true", help=_("Ejecuta en modo seguro"))
-    parser.add_argument("--lang", default=os.environ.get("COBRA_LANG", "es"), help=_("Código de idioma para la interfaz"))
-    parser.add_argument("--no-color", action="store_true", help=_("Desactiva colores en la salida"))
+    parser.add_argument(
+        "--formatear",
+        action="store_true",
+        help=_("Formatea el archivo antes de procesarlo"),
+    )
+    parser.add_argument(
+        "--depurar", action="store_true", help=_("Muestra mensajes de depuración")
+    )
+    parser.add_argument(
+        "--seguro", action="store_true", help=_("Ejecuta en modo seguro")
+    )
+    parser.add_argument(
+        "--lang",
+        default=os.environ.get("COBRA_LANG", "es"),
+        help=_("Código de idioma para la interfaz"),
+    )
+    parser.add_argument(
+        "--no-color", action="store_true", help=_("Desactiva colores en la salida")
+    )
     parser.add_argument(
         "--validadores-extra",
         help="Ruta a módulo con validadores personalizados",

--- a/backend/src/cli/commands/bench_transpilers_cmd.py
+++ b/backend/src/cli/commands/bench_transpilers_cmd.py
@@ -10,7 +10,9 @@ from .compile_cmd import TRANSPILERS
 from core.ast_cache import obtener_ast
 
 
-PROGRAM_DIR = Path(__file__).resolve().parents[4] / "scripts" / "benchmarks" / "programs"
+PROGRAM_DIR = (
+    Path(__file__).resolve().parents[4] / "scripts" / "benchmarks" / "programs"
+)
 
 
 class BenchTranspilersCommand(BaseCommand):
@@ -76,9 +78,13 @@ class BenchTranspilersCommand(BaseCommand):
         if args.output:
             try:
                 Path(args.output).write_text(data)
-                mostrar_info(_("Resultados guardados en {file}").format(file=args.output))
+                mostrar_info(
+                    _("Resultados guardados en {file}").format(file=args.output)
+                )
             except Exception as err:  # pragma: no cover - error inesperado de E/S
-                mostrar_error(_("No se pudo escribir el archivo: {err}").format(err=err))
+                mostrar_error(
+                    _("No se pudo escribir el archivo: {err}").format(err=err)
+                )
                 return 1
         else:
             print(data)

--- a/backend/src/cli/commands/benchthreads_cmd.py
+++ b/backend/src/cli/commands/benchthreads_cmd.py
@@ -79,7 +79,9 @@ class BenchThreadsCommand(BaseCommand):
             tmp.write(code)
             tmp.flush()
             cmd = [sys.executable, "-m", "src.cli.cli", "ejecutar", tmp.name]
-            subprocess.run(cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run(
+                cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
         os.unlink(tmp.name)
 
     def _run_kernel(self, code: str) -> None:
@@ -101,23 +103,47 @@ class BenchThreadsCommand(BaseCommand):
         results = []
 
         elapsed, cpu, io = _measure(self._run_sequential)
-        results.append({"modo": "secuencial", "time": round(elapsed, 4), "cpu": round(cpu, 4), "io": io})
+        results.append(
+            {
+                "modo": "secuencial",
+                "time": round(elapsed, 4),
+                "cpu": round(cpu, 4),
+                "io": io,
+            }
+        )
 
         elapsed, cpu, io = _measure(lambda: self._run_cli(THREAD_CODE, env))
-        results.append({"modo": "cli_hilos", "time": round(elapsed, 4), "cpu": round(cpu, 4), "io": io})
+        results.append(
+            {
+                "modo": "cli_hilos",
+                "time": round(elapsed, 4),
+                "cpu": round(cpu, 4),
+                "io": io,
+            }
+        )
 
         elapsed, cpu, io = _measure(lambda: self._run_kernel(THREAD_CODE))
-        results.append({"modo": "kernel_hilos", "time": round(elapsed, 4), "cpu": round(cpu, 4), "io": io})
+        results.append(
+            {
+                "modo": "kernel_hilos",
+                "time": round(elapsed, 4),
+                "cpu": round(cpu, 4),
+                "io": io,
+            }
+        )
 
         data = json.dumps(results, indent=2)
         if args.output:
             try:
                 Path(args.output).write_text(data)
-                mostrar_info(_("Resultados guardados en {file}").format(file=args.output))
+                mostrar_info(
+                    _("Resultados guardados en {file}").format(file=args.output)
+                )
             except Exception as err:
-                mostrar_error(_("No se pudo escribir el archivo: {err}").format(err=err))
+                mostrar_error(
+                    _("No se pudo escribir el archivo: {err}").format(err=err)
+                )
                 return 1
         else:
             print(data)
         return 0
-

--- a/backend/src/cli/commands/package_cmd.py
+++ b/backend/src/cli/commands/package_cmd.py
@@ -50,7 +50,7 @@ class PaqueteCommand(BaseCommand):
             return 1
         mod_list = ", ".join(f'"{m}"' for m in mods)
         contenido = (
-            f"[paquete]\nnombre = \"{nombre}\"\nversion = \"{version}\"\n\n"
+            f'[paquete]\nnombre = "{nombre}"\nversion = "{version}"\n\n'
             f"[modulos]\narchivos = [{mod_list}]\n"
         )
         with zipfile.ZipFile(pkg, "w") as zf:
@@ -69,7 +69,9 @@ class PaqueteCommand(BaseCommand):
         with zipfile.ZipFile(pkg) as zf:
             for name in zf.namelist():
                 if name.endswith(".co"):
-                    dest = os.path.join(modules_cmd.MODULES_PATH, os.path.basename(name))
+                    dest = os.path.join(
+                        modules_cmd.MODULES_PATH, os.path.basename(name)
+                    )
                     with zf.open(name) as src, open(dest, "wb") as out:
                         out.write(src.read())
         mostrar_info(

--- a/backend/src/cli/commands/plugins_cmd.py
+++ b/backend/src/cli/commands/plugins_cmd.py
@@ -45,4 +45,3 @@ class PluginsCommand(BaseCommand):
             else:
                 mostrar_info(f"{nombre} {version}")
         return 0
-

--- a/backend/src/cli/utils/__init__.py
+++ b/backend/src/cli/utils/__init__.py
@@ -1,4 +1,3 @@
 """Utilidades varias para la CLI de Cobra."""
 
 __all__ = ["messages", "semver"]
-

--- a/backend/src/cobra/__init__.py
+++ b/backend/src/cobra/__init__.py
@@ -9,4 +9,3 @@ try:
 except Exception:
     # Permitir que el paquete se importe incluso si ipykernel no está disponible
     pass
-

--- a/backend/src/cobra/lexico/__init__.py
+++ b/backend/src/cobra/lexico/__init__.py
@@ -1,2 +1,1 @@
 """Módulo de inicialización para el analizador léxico de Cobra."""
-

--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -280,12 +280,18 @@ class Lexer:
             if not matched:
                 error_token = self.codigo_fuente[self.posicion]
                 logging.error(
-                    f"Error: Token no reconocido en posición {self.posicion}: '{error_token}'"
+                    (
+                        "Error: Token no reconocido en posición "
+                        f"{self.posicion}: '{error_token}'"
+                    )
                 )
                 if error_token in {"'", '"'}:
                     mensaje = f"Cadena sin cerrar en linea {linea}, columna {columna}"
                     raise UnclosedStringError(mensaje, linea, columna)
-                mensaje = f"Token no reconocido: '{error_token}' en linea {linea}, columna {columna}"
+                mensaje = (
+                    "Token no reconocido: "
+                    f"'{error_token}' en linea {linea}, columna {columna}"
+                )
                 raise InvalidTokenError(mensaje, linea, columna)
 
             if self.posicion == prev_pos:

--- a/backend/src/cobra/parser/__init__.py
+++ b/backend/src/cobra/parser/__init__.py
@@ -1,2 +1,1 @@
 """Submódulos relacionados con el análisis sintáctico del lenguaje Cobra."""
-

--- a/backend/src/cobra/transpilers/base.py
+++ b/backend/src/cobra/transpilers/base.py
@@ -15,6 +15,10 @@ class BaseTranspiler(NodeVisitor, ABC):
 
     def save_file(self, path):
         """Guarda el código generado en la ruta dada."""
-        contenido = "\n".join(self.codigo) if isinstance(self.codigo, list) else str(self.codigo)
+        contenido = (
+            "\n".join(self.codigo)
+            if isinstance(self.codigo, list)
+            else str(self.codigo)
+        )
         with open(path, "w", encoding="utf-8") as archivo:
             archivo.write(contenido)

--- a/backend/src/cobra/transpilers/import_helper.py
+++ b/backend/src/cobra/transpilers/import_helper.py
@@ -9,7 +9,9 @@ from .module_map import get_mapped_path
 # Mapeo de importaciones estándar por lenguaje
 STANDARD_IMPORTS = {
     "python": (
-        "from core.nativos import *\n" "from corelibs import *\n" "from standard_library import *\n"
+        "from core.nativos import *\n"
+        "from corelibs import *\n"
+        "from standard_library import *\n"
     ),
     "js": [
         "import * as io from './nativos/io.js';",

--- a/backend/src/cobra/transpilers/transpiler/__init__.py
+++ b/backend/src/cobra/transpilers/transpiler/__init__.py
@@ -3,4 +3,3 @@
 # Exportar transpiladores básicos
 from .to_ruby import TranspiladorRuby
 from .to_php import TranspiladorPHP
-

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/pasar.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/pasar.py
@@ -1,3 +1,2 @@
 def visit_pasar(self, nodo):
     self.agregar_linea("NOP")
-

--- a/backend/src/cobra/transpilers/transpiler/cpp_nodes/pasar.py
+++ b/backend/src/cobra/transpilers/transpiler/cpp_nodes/pasar.py
@@ -1,3 +1,2 @@
 def visit_pasar(self, nodo):
     self.agregar_linea(";")
-

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/asignacion.py
@@ -1,12 +1,19 @@
 from ...semantica import datos_asignacion
 
+
 def visit_asignacion(self, nodo):
     """Transpila una asignación en JavaScript."""
     if self.usa_indentacion is None:
-        self.usa_indentacion = hasattr(nodo, "variable") or hasattr(nodo, "identificador")
+        self.usa_indentacion = hasattr(nodo, "variable") or hasattr(
+            nodo, "identificador"
+        )
     nombre, valor, es_attr = datos_asignacion(self, nodo)
     if es_attr:
         prefijo = ""
     else:
-        prefijo = "let " if hasattr(nodo, "variable") and not getattr(nodo, "inferencia", False) else ""
+        prefijo = (
+            "let "
+            if hasattr(nodo, "variable") and not getattr(nodo, "inferencia", False)
+            else ""
+        )
     self.agregar_linea(f"{prefijo}{nombre} = {valor};")

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/clase.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/clase.py
@@ -3,18 +3,18 @@ def visit_clase(self, nodo):
     metodos = getattr(nodo, "cuerpo", getattr(nodo, "metodos", []))
     if self.usa_indentacion is None:
         self.usa_indentacion = any(hasattr(m, "variable") for m in metodos)
-    bases = getattr(nodo, 'bases', [])
+    bases = getattr(nodo, "bases", [])
     base = f" extends {bases[0]}" if bases else ""
     extra = f" /* bases: {', '.join(bases)} */" if len(bases) > 1 else ""
     self.agregar_linea(f"class {nodo.nombre}{base} {{{extra}")
     if self.usa_indentacion:
         self.indentacion += 1
     for metodo in metodos:
-        if hasattr(metodo, 'aceptar'):
+        if hasattr(metodo, "aceptar"):
             metodo.aceptar(self)
         else:
             nombre = metodo.__class__.__name__
-            if nombre.startswith('Nodo'):
+            if nombre.startswith("Nodo"):
                 nombre = nombre[4:]
             visit = getattr(self, f"visit_{nombre.lower()}", None)
             if visit:
@@ -26,7 +26,10 @@ def visit_clase(self, nodo):
         for decorador in reversed(getattr(metodo, "decoradores", [])):
             expr = self.obtener_valor(decorador.expresion)
             self.agregar_linea(
-                f"{nodo.nombre}.prototype.{metodo.nombre} = {expr}({nodo.nombre}.prototype.{metodo.nombre});"
+                (
+                    f"{nodo.nombre}.prototype.{metodo.nombre} = "
+                    f"{expr}({nodo.nombre}.prototype.{metodo.nombre});"
+                )
             )
     for decorador in reversed(getattr(nodo, "decoradores", [])):
         expr = self.obtener_valor(decorador.expresion)

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/pasar.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/pasar.py
@@ -1,3 +1,2 @@
 def visit_pasar(self, nodo):
     self.agregar_linea(";")
-

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/hilo.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/hilo.py
@@ -1,4 +1,7 @@
 def visit_hilo(self, nodo):
     self.usa_asyncio = True
     args = ", ".join(self.obtener_valor(a) for a in nodo.llamada.argumentos)
-    self.codigo += f"{self.obtener_indentacion()}asyncio.create_task({nodo.llamada.nombre}({args}))\n"
+    self.codigo += (
+        f"{self.obtener_indentacion()}asyncio.create_task("
+        f"{nodo.llamada.nombre}({args}))\n"
+    )

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/pasar.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/pasar.py
@@ -1,3 +1,2 @@
 def visit_pasar(self, nodo):
     self.codigo += f"{self.obtener_indentacion()}pass\n"
-

--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/pasar.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/pasar.py
@@ -1,3 +1,2 @@
 def visit_pasar(self, nodo):
     self.agregar_linea(";")
-

--- a/backend/src/cobra/transpilers/transpiler/to_asm.py
+++ b/backend/src/cobra/transpilers/transpiler/to_asm.py
@@ -56,8 +56,12 @@ from .asm_nodes.throw import visit_throw as _visit_throw
 from .asm_nodes.importar import visit_import as _visit_import
 from .asm_nodes.instancia import visit_instancia as _visit_instancia
 from .asm_nodes.atributo import visit_atributo as _visit_atributo
-from .asm_nodes.operacion_binaria import visit_operacion_binaria as _visit_operacion_binaria
-from .asm_nodes.operacion_unaria import visit_operacion_unaria as _visit_operacion_unaria
+from .asm_nodes.operacion_binaria import (
+    visit_operacion_binaria as _visit_operacion_binaria,
+)
+from .asm_nodes.operacion_unaria import (
+    visit_operacion_unaria as _visit_operacion_unaria,
+)
 from .asm_nodes.valor import visit_valor as _visit_valor
 from .asm_nodes.identificador import visit_identificador as _visit_identificador
 from .asm_nodes.usar import visit_usar as _visit_usar
@@ -106,7 +110,8 @@ class TranspiladorASM(BaseTranspiler):
             return f"[{elems}]"
         elif isinstance(nodo, NodoDiccionario):
             pares = ", ".join(
-                f"{self.obtener_valor(k)}:{self.obtener_valor(v)}" for k, v in nodo.elementos
+                f"{self.obtener_valor(k)}:{self.obtener_valor(v)}"
+                for k, v in nodo.elementos
             )
             return f"{{{pares}}}"
         else:

--- a/backend/src/cobra/transpilers/transpiler/to_c.py
+++ b/backend/src/cobra/transpilers/transpiler/to_c.py
@@ -122,7 +122,8 @@ class TranspiladorC(BaseTranspiler):
             return f"{{{elems}}}"
         elif isinstance(nodo, NodoDiccionario):
             pares = ", ".join(
-                f"{{{self.obtener_valor(k)}, {self.obtener_valor(v)}}}" for k, v in nodo.elementos
+                f"{{{self.obtener_valor(k)}, {self.obtener_valor(v)}}}"
+                for k, v in nodo.elementos
             )
             return f"{{{pares}}}"
         else:
@@ -135,7 +136,9 @@ class TranspiladorC(BaseTranspiler):
             if hasattr(nodo, "aceptar"):
                 nodo.aceptar(self)
             else:
-                metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
+                metodo = getattr(
+                    self, f"visit_{nodo.__class__.__name__[4:].lower()}", None
+                )
                 if metodo:
                     metodo(nodo)
         return "\n".join(self.codigo)

--- a/backend/src/cobra/transpilers/transpiler/to_cpp.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cpp.py
@@ -37,19 +37,24 @@ from .cpp_nodes.continuar import visit_continuar as _visit_continuar
 from .cpp_nodes.pasar import visit_pasar as _visit_pasar
 from .cpp_nodes.switch import visit_switch as _visit_switch
 
+
 def visit_assert(self, nodo):
     cond = self.obtener_valor(nodo.condicion)
     self.agregar_linea(f"assert({cond});")
+
 
 def visit_del(self, nodo):
     nombre = self.obtener_valor(nodo.objetivo)
     self.agregar_linea(f"/* del {nombre} */")
 
+
 def visit_global(self, nodo):
     pass
 
+
 def visit_nolocal(self, nodo):
     pass
+
 
 def visit_with(self, nodo):
     self.agregar_linea("{")
@@ -58,6 +63,7 @@ def visit_with(self, nodo):
         inst.aceptar(self)
     self.indent -= 1
     self.agregar_linea("}")
+
 
 def visit_import_desde(self, nodo):
     alias = f" {nodo.alias}" if nodo.alias else ""
@@ -108,7 +114,8 @@ class TranspiladorCPP(BaseTranspiler):
             return f"std::vector{{{elems}}}"
         elif isinstance(nodo, NodoDiccionario):
             pares = ", ".join(
-                f"{{{self.obtener_valor(k)}, {self.obtener_valor(v)}}}" for k, v in nodo.elementos
+                f"{{{self.obtener_valor(k)}, {self.obtener_valor(v)}}}"
+                for k, v in nodo.elementos
             )
             return f"std::map{{{pares}}}"
         else:

--- a/backend/src/cobra/transpilers/transpiler/to_fortran.py
+++ b/backend/src/cobra/transpilers/transpiler/to_fortran.py
@@ -19,7 +19,9 @@ from cobra.macro import expandir_macros
 
 from .fortran_nodes.asignacion import visit_asignacion as _visit_asignacion
 from .fortran_nodes.funcion import visit_funcion as _visit_funcion
-from .fortran_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from .fortran_nodes.llamada_funcion import (
+    visit_llamada_funcion as _visit_llamada_funcion,
+)
 from .fortran_nodes.imprimir import visit_imprimir as _visit_imprimir
 
 fortran_nodes = {
@@ -72,7 +74,9 @@ class TranspiladorFortran(BaseTranspiler):
             if hasattr(nodo, "aceptar"):
                 nodo.aceptar(self)
             else:
-                metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
+                metodo = getattr(
+                    self, f"visit_{nodo.__class__.__name__[4:].lower()}", None
+                )
                 if metodo:
                     metodo(nodo)
         return "\n".join(self.codigo)

--- a/backend/src/cobra/transpilers/transpiler/to_js.py
+++ b/backend/src/cobra/transpilers/transpiler/to_js.py
@@ -50,7 +50,9 @@ from .js_nodes.throw import visit_throw as _visit_throw
 from .js_nodes.importar import visit_import as _visit_import
 from .js_nodes.instancia import visit_instancia as _visit_instancia
 from .js_nodes.atributo import visit_atributo as _visit_atributo
-from .js_nodes.operacion_binaria import visit_operacion_binaria as _visit_operacion_binaria
+from .js_nodes.operacion_binaria import (
+    visit_operacion_binaria as _visit_operacion_binaria,
+)
 from .js_nodes.operacion_unaria import visit_operacion_unaria as _visit_operacion_unaria
 from .js_nodes.valor import visit_valor as _visit_valor
 from .js_nodes.identificador import visit_identificador as _visit_identificador
@@ -64,19 +66,24 @@ from .js_nodes.pasar import visit_pasar as _visit_pasar
 from .js_nodes.switch import visit_switch as _visit_switch
 from .js_nodes.exportar import visit_export as _visit_export
 
+
 def visit_assert(self, nodo):
     cond = self.obtener_valor(nodo.condicion)
     self.agregar_linea(f"console.assert({cond});")
+
 
 def visit_del(self, nodo):
     nombre = self.obtener_valor(nodo.objetivo)
     self.agregar_linea(f"delete {nombre};")
 
+
 def visit_global(self, nodo):
     pass
 
+
 def visit_nolocal(self, nodo):
     pass
+
 
 def visit_with(self, nodo):
     ctx = self.obtener_valor(nodo.contexto)
@@ -88,6 +95,7 @@ def visit_with(self, nodo):
     if self.usa_indentacion:
         self.indentacion -= 1
     self.agregar_linea("}")
+
 
 def visit_import_desde(self, nodo):
     alias = f" as {nodo.alias}" if nodo.alias else ""
@@ -131,7 +139,11 @@ class TranspiladorJavaScript(BaseTranspiler):
             return f"{izq} {nodo.operador.valor} {der}"
         elif isinstance(nodo, NodoOperacionUnaria):
             val = self.obtener_valor(nodo.operando)
-            return f"!{val}" if nodo.operador.tipo == TipoToken.NOT else f"{nodo.operador.valor}{val}"
+            return (
+                f"!{val}"
+                if nodo.operador.tipo == TipoToken.NOT
+                else f"{nodo.operador.valor}{val}"
+            )
         elif isinstance(nodo, NodoEsperar):
             val = self.obtener_valor(nodo.expresion)
             return f"await {val}"
@@ -148,7 +160,7 @@ class TranspiladorJavaScript(BaseTranspiler):
             else:
                 self.visit_diccionario(nodo)
             self.codigo = original
-            return ''.join(temp)
+            return "".join(temp)
         else:
             return str(nodo)
 
@@ -156,11 +168,11 @@ class TranspiladorJavaScript(BaseTranspiler):
         ast_raiz = expandir_macros(ast_raiz)
         ast_raiz = remove_dead_code(inline_functions(optimize_constants(ast_raiz)))
         for nodo in ast_raiz:
-            if hasattr(nodo, 'aceptar'):
+            if hasattr(nodo, "aceptar"):
                 nodo.aceptar(self)
             else:
                 nombre = nodo.__class__.__name__
-                if nombre.startswith('Nodo'):
+                if nombre.startswith("Nodo"):
                     nombre = nombre[4:]
                 metodo = getattr(self, f"visit_{nombre.lower()}", None)
                 if metodo:
@@ -212,4 +224,4 @@ TranspiladorJavaScript.visit_nolocal = visit_nolocal
 TranspiladorJavaScript.visit_with = visit_with
 TranspiladorJavaScript.visit_import_desde = visit_import_desde
 
-    # Métodos de transpilación para tipos de nodos básicos
+# Métodos de transpilación para tipos de nodos básicos

--- a/backend/src/cobra/transpilers/transpiler/to_latex.py
+++ b/backend/src/cobra/transpilers/transpiler/to_latex.py
@@ -59,7 +59,9 @@ class TranspiladorLatex(BaseTranspiler):
             if hasattr(nodo, "aceptar"):
                 nodo.aceptar(self)
             else:
-                metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
+                metodo = getattr(
+                    self, f"visit_{nodo.__class__.__name__[4:].lower()}", None
+                )
                 if metodo:
                     metodo(nodo)
         return "\n".join(self.codigo)

--- a/backend/src/cobra/transpilers/transpiler/to_matlab.py
+++ b/backend/src/cobra/transpilers/transpiler/to_matlab.py
@@ -19,7 +19,9 @@ from cobra.macro import expandir_macros
 
 from .matlab_nodes.asignacion import visit_asignacion as _visit_asignacion
 from .matlab_nodes.funcion import visit_funcion as _visit_funcion
-from .matlab_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from .matlab_nodes.llamada_funcion import (
+    visit_llamada_funcion as _visit_llamada_funcion,
+)
 from .matlab_nodes.imprimir import visit_imprimir as _visit_imprimir
 
 matlab_nodes = {
@@ -72,7 +74,9 @@ class TranspiladorMatlab(BaseTranspiler):
             if hasattr(nodo, "aceptar"):
                 nodo.aceptar(self)
             else:
-                metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
+                metodo = getattr(
+                    self, f"visit_{nodo.__class__.__name__[4:].lower()}", None
+                )
                 if metodo:
                     metodo(nodo)
         return "\n".join(self.codigo)

--- a/backend/src/cobra/transpilers/transpiler/to_pascal.py
+++ b/backend/src/cobra/transpilers/transpiler/to_pascal.py
@@ -19,7 +19,9 @@ from cobra.macro import expandir_macros
 
 from .pascal_nodes.asignacion import visit_asignacion as _visit_asignacion
 from .pascal_nodes.funcion import visit_funcion as _visit_funcion
-from .pascal_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from .pascal_nodes.llamada_funcion import (
+    visit_llamada_funcion as _visit_llamada_funcion,
+)
 from .pascal_nodes.imprimir import visit_imprimir as _visit_imprimir
 
 pascal_nodes = {
@@ -55,7 +57,7 @@ class TranspiladorPascal(BaseTranspiler):
         elif isinstance(nodo, NodoOperacionBinaria):
             izq = self.obtener_valor(nodo.izquierda)
             der = self.obtener_valor(nodo.derecha)
-            op_map = {TipoToken.AND: 'and', TipoToken.OR: 'or'}
+            op_map = {TipoToken.AND: "and", TipoToken.OR: "or"}
             op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
             return f"{izq} {op} {der}"
         elif isinstance(nodo, NodoOperacionUnaria):
@@ -73,7 +75,9 @@ class TranspiladorPascal(BaseTranspiler):
             if hasattr(nodo, "aceptar"):
                 nodo.aceptar(self)
             else:
-                metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
+                metodo = getattr(
+                    self, f"visit_{nodo.__class__.__name__[4:].lower()}", None
+                )
                 if metodo:
                     metodo(nodo)
         return "\n".join(self.codigo)

--- a/backend/src/cobra/transpilers/transpiler/to_php.py
+++ b/backend/src/cobra/transpilers/transpiler/to_php.py
@@ -83,13 +83,13 @@ class TranspiladorPHP(BaseTranspiler):
         elif isinstance(nodo, NodoOperacionBinaria):
             izq = self.obtener_valor(nodo.izquierda)
             der = self.obtener_valor(nodo.derecha)
-            op_map = {TipoToken.AND: '&&', TipoToken.OR: '||'}
+            op_map = {TipoToken.AND: "&&", TipoToken.OR: "||"}
             op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
             return f"{izq} {op} {der}"
         elif isinstance(nodo, NodoOperacionUnaria):
             val = self.obtener_valor(nodo.operando)
-            op = '!' if nodo.operador.tipo == TipoToken.NOT else nodo.operador.valor
-            return f"{op}{val}" if op != '!' else f"!{val}"
+            op = "!" if nodo.operador.tipo == TipoToken.NOT else nodo.operador.valor
+            return f"{op}{val}" if op != "!" else f"!{val}"
         else:
             return str(getattr(nodo, "valor", nodo))
 
@@ -100,7 +100,9 @@ class TranspiladorPHP(BaseTranspiler):
             if hasattr(nodo, "aceptar"):
                 nodo.aceptar(self)
             else:
-                metodo = getattr(self, f"visit_{nodo.__class__.__name__[4:].lower()}", None)
+                metodo = getattr(
+                    self, f"visit_{nodo.__class__.__name__[4:].lower()}", None
+                )
                 if metodo:
                     metodo(nodo)
         return "\n".join(self.codigo)

--- a/backend/src/cobra/transpilers/transpiler/to_python.py
+++ b/backend/src/cobra/transpilers/transpiler/to_python.py
@@ -1,8 +1,15 @@
 """Transpilador que convierte código Cobra en código Python."""
 
 from core.ast_nodes import (
-    NodoAsignacion, NodoCondicional, NodoBucleMientras, NodoFuncion,
-    NodoLlamadaFuncion, NodoHolobit, NodoFor, NodoLista, NodoDiccionario,
+    NodoAsignacion,
+    NodoCondicional,
+    NodoBucleMientras,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoHolobit,
+    NodoFor,
+    NodoLista,
+    NodoDiccionario,
     NodoClase,
     NodoMetodo,
     NodoValor,
@@ -26,7 +33,7 @@ from core.ast_nodes import (
     NodoLambda,
     NodoWith,
     NodoImportDesde,
-    NodoEsperar
+    NodoEsperar,
 )
 from cobra.parser.parser import Parser
 from cobra.lexico.lexer import TipoToken, Lexer
@@ -41,7 +48,9 @@ from .python_nodes.condicional import visit_condicional as _visit_condicional
 from .python_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
 from .python_nodes.for_ import visit_for as _visit_for
 from .python_nodes.funcion import visit_funcion as _visit_funcion
-from .python_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from .python_nodes.llamada_funcion import (
+    visit_llamada_funcion as _visit_llamada_funcion,
+)
 from .python_nodes.llamada_metodo import visit_llamada_metodo as _visit_llamada_metodo
 from .python_nodes.imprimir import visit_imprimir as _visit_imprimir
 from .python_nodes.retorno import visit_retorno as _visit_retorno
@@ -57,8 +66,12 @@ from .python_nodes.usar import visit_usar as _visit_usar
 from .python_nodes.hilo import visit_hilo as _visit_hilo
 from .python_nodes.instancia import visit_instancia as _visit_instancia
 from .python_nodes.atributo import visit_atributo as _visit_atributo
-from .python_nodes.operacion_binaria import visit_operacion_binaria as _visit_operacion_binaria
-from .python_nodes.operacion_unaria import visit_operacion_unaria as _visit_operacion_unaria
+from .python_nodes.operacion_binaria import (
+    visit_operacion_binaria as _visit_operacion_binaria,
+)
+from .python_nodes.operacion_unaria import (
+    visit_operacion_unaria as _visit_operacion_unaria,
+)
 from .python_nodes.valor import visit_valor as _visit_valor
 from .python_nodes.identificador import visit_identificador as _visit_identificador
 from .python_nodes.para import visit_para as _visit_para
@@ -70,22 +83,27 @@ from .python_nodes.continuar import visit_continuar as _visit_continuar
 from .python_nodes.pasar import visit_pasar as _visit_pasar
 from .python_nodes.switch import visit_switch as _visit_switch
 
+
 def visit_assert(self, nodo):
     expr = self.obtener_valor(nodo.condicion)
     msg = f", {self.obtener_valor(nodo.mensaje)}" if nodo.mensaje else ""
     self.codigo += f"{self.obtener_indentacion()}assert {expr}{msg}\n"
 
+
 def visit_del(self, nodo):
     objetivo = self.obtener_valor(nodo.objetivo)
     self.codigo += f"{self.obtener_indentacion()}del {objetivo}\n"
+
 
 def visit_global(self, nodo):
     nombres = ", ".join(nodo.nombres)
     self.codigo += f"{self.obtener_indentacion()}global {nombres}\n"
 
+
 def visit_nolocal(self, nodo):
     nombres = ", ".join(nodo.nombres)
     self.codigo += f"{self.obtener_indentacion()}nonlocal {nombres}\n"
+
 
 def visit_with(self, nodo):
     ctx = self.obtener_valor(nodo.contexto)
@@ -95,6 +113,7 @@ def visit_with(self, nodo):
     for inst in nodo.cuerpo:
         inst.aceptar(self)
     self.nivel_indentacion -= 1
+
 
 def visit_import_desde(self, nodo):
     alias = f" as {nodo.alias}" if nodo.alias else ""
@@ -120,12 +139,16 @@ class TranspiladorPython(BaseTranspiler):
         nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             nodo.aceptar(self)
-        if nodos and all(
-            n.__class__.__module__.startswith("src.cobra.parser.parser") for n in nodos
-        ) and not any(self._contiene_nodo_valor(n) for n in nodos):
-            solo_llamadas = all(
-                hasattr(n, "argumentos") and not hasattr(n, "parametros")
+        if (
+            nodos
+            and all(
+                n.__class__.__module__.startswith("src.cobra.parser.parser")
                 for n in nodos
+            )
+            and not any(self._contiene_nodo_valor(n) for n in nodos)
+        ):
+            solo_llamadas = all(
+                hasattr(n, "argumentos") and not hasattr(n, "parametros") for n in nodos
             )
             if solo_llamadas:
                 solo_numeros = all(
@@ -151,15 +174,15 @@ class TranspiladorPython(BaseTranspiler):
                 for elem in atributo:
                     if isinstance(elem, (list, tuple)):
                         for sub in elem:
-                            if hasattr(sub, "__dict__") and self._contiene_nodo_valor(sub):
+                            if hasattr(sub, "__dict__") and self._contiene_nodo_valor(
+                                sub
+                            ):
                                 return True
                     elif hasattr(elem, "__dict__") and self._contiene_nodo_valor(elem):
                         return True
             elif hasattr(atributo, "__dict__") and self._contiene_nodo_valor(atributo):
                 return True
         return False
-
-
 
     def obtener_valor(self, nodo):
         from cobra.parser.parser import (

--- a/backend/src/cobra/transpilers/transpiler/to_rust.py
+++ b/backend/src/cobra/transpilers/transpiler/to_rust.py
@@ -45,19 +45,24 @@ from .rust_nodes.try_catch import visit_try_catch as _visit_try_catch
 from .rust_nodes.throw import visit_throw as _visit_throw
 from .rust_nodes.option import visit_option as _visit_option
 
+
 def visit_assert(self, nodo):
     cond = self.obtener_valor(nodo.condicion)
     self.agregar_linea(f"assert!({cond});")
+
 
 def visit_del(self, nodo):
     nombre = self.obtener_valor(nodo.objetivo)
     self.agregar_linea(f"// del {nombre}")
 
+
 def visit_global(self, nodo):
     pass
 
+
 def visit_nolocal(self, nodo):
     pass
+
 
 def visit_with(self, nodo):
     self.agregar_linea("{")
@@ -66,6 +71,7 @@ def visit_with(self, nodo):
         inst.aceptar(self)
     self.indent -= 1
     self.agregar_linea("}")
+
 
 def visit_import_desde(self, nodo):
     alias = f" as {nodo.alias}" if nodo.alias else ""
@@ -121,7 +127,8 @@ class TranspiladorRust(BaseTranspiler):
                 return f"vec![{elems}]"
             case NodoDiccionario():
                 pares = ", ".join(
-                    f"({self.obtener_valor(k)}, {self.obtener_valor(v)})" for k, v in nodo.elementos
+                    f"({self.obtener_valor(k)}, {self.obtener_valor(v)})"
+                    for k, v in nodo.elementos
                 )
                 return f"std::collections::HashMap::from([{pares}])"
             case _:

--- a/backend/src/core/ast_cache.py
+++ b/backend/src/core/ast_cache.py
@@ -20,11 +20,10 @@ class SafeUnpickler(pickle.Unpickler):
 
     def find_class(self, module: str, name: str):
         if module not in self.ALLOWED_MODULES:
-            raise pickle.UnpicklingError(
-                f"Importación no permitida: {module}.{name}"
-            )
+            raise pickle.UnpicklingError(f"Importación no permitida: {module}.{name}")
         __import__(module)
         return getattr(sys.modules[module], name)
+
 
 # Directorio donde se almacenará el cache de AST. Puede modificarse con la
 # variable de entorno `COBRA_AST_CACHE`.
@@ -56,6 +55,7 @@ def obtener_tokens(codigo: str):
             return SafeUnpickler(f).load()
 
     from cobra.lexico.lexer import Lexer
+
     tokens = Lexer(codigo).tokenizar()
     with open(ruta, "wb") as f:
         pickle.dump(tokens, f)
@@ -76,6 +76,7 @@ def obtener_ast(codigo: str):
 
     tokens = obtener_tokens(codigo)
     from cobra.parser.parser import Parser
+
     ast = Parser(tokens).parsear()
 
     with open(ruta, "wb") as f:
@@ -87,6 +88,7 @@ def obtener_ast(codigo: str):
 
 
 # -- Almacenamiento por secciones -------------------------------------------
+
 
 def _ruta_fragmento(codigo: str, ext: str) -> str:
     """Devuelve la ruta del archivo de caché para un fragmento."""
@@ -104,6 +106,7 @@ def obtener_tokens_fragmento(codigo: str):
             return SafeUnpickler(f).load()
 
     from cobra.lexico.lexer import Lexer
+
     tokens = Lexer(codigo).tokenizar()
     with open(ruta, "wb") as f:
         pickle.dump(tokens, f)
@@ -119,6 +122,7 @@ def obtener_ast_fragmento(codigo: str):
 
     tokens = obtener_tokens_fragmento(codigo)
     from cobra.parser.parser import Parser
+
     ast = Parser(tokens).parsear()
     with open(ruta, "wb") as f:
         pickle.dump(ast, f)
@@ -131,7 +135,9 @@ def limpiar_cache():
         return
     for nombre in os.listdir(CACHE_DIR):
         ruta = os.path.join(CACHE_DIR, nombre)
-        if os.path.isfile(ruta) and (nombre.endswith(".ast") or nombre.endswith(".tok")):
+        if os.path.isfile(ruta) and (
+            nombre.endswith(".ast") or nombre.endswith(".tok")
+        ):
             os.remove(ruta)
         elif os.path.isdir(ruta) and nombre == "fragmentos":
             for archivo in os.listdir(ruta):

--- a/backend/src/core/ast_nodes.py
+++ b/backend/src/core/ast_nodes.py
@@ -5,6 +5,7 @@ from typing import Any, List, Optional
 
 from cobra.lexico.lexer import Token
 
+
 @dataclass
 class NodoAST:
     """Clase base para todos los nodos del AST."""
@@ -259,9 +260,7 @@ class NodoOption(NodoAST):
     """Representa un valor opcional, equivalente a ``Some`` o ``None``."""
 
     def __repr__(self):
-        return (
-            "NodoOption(None)" if self.valor is None else f"NodoOption({self.valor})"
-        )
+        return "NodoOption(None)" if self.valor is None else f"NodoOption({self.valor})"
 
 
 @dataclass
@@ -383,7 +382,10 @@ class NodoPara(NodoAST):
 
     def __repr__(self):
         return (
-            f"NodoPara(variable={self.variable}, iterable={self.iterable}, cuerpo={self.cuerpo})"
+            "NodoPara("
+            f"variable={self.variable}, "
+            f"iterable={self.iterable}, "
+            f"cuerpo={self.cuerpo})"
         )
 
 
@@ -422,49 +424,49 @@ class NodoSwitch(NodoAST):
 
 
 __all__ = [
-    'NodoAST',
-    'NodoAsignacion',
-    'NodoHolobit',
-    'NodoCondicional',
-    'NodoBucleMientras',
-    'NodoFor',
-    'NodoLista',
-    'NodoDiccionario',
-    'NodoDecorador',
-    'NodoFuncion',
-    'NodoClase',
-    'NodoMetodo',
-    'NodoInstancia',
-    'NodoAtributo',
-    'NodoLlamadaMetodo',
-    'NodoOperacionBinaria',
-    'NodoOperacionUnaria',
-    'NodoValor',
-    'NodoIdentificador',
-    'NodoLlamadaFuncion',
-    'NodoHilo',
-    'NodoRetorno',
-    'NodoYield',
-    'NodoEsperar',
-    'NodoOption',
-    'NodoRomper',
-    'NodoContinuar',
-    'NodoPasar',
-    'NodoAssert',
-    'NodoDel',
-    'NodoGlobal',
-    'NodoNoLocal',
-    'NodoLambda',
-    'NodoWith',
-    'NodoThrow',
-    'NodoTryCatch',
-    'NodoImportDesde',
-    'NodoExport',
-    'NodoImport',
-    'NodoUsar',
-    'NodoPara',
-    'NodoImprimir',
-    'NodoMacro',
-    'NodoCase',
-    'NodoSwitch',
+    "NodoAST",
+    "NodoAsignacion",
+    "NodoHolobit",
+    "NodoCondicional",
+    "NodoBucleMientras",
+    "NodoFor",
+    "NodoLista",
+    "NodoDiccionario",
+    "NodoDecorador",
+    "NodoFuncion",
+    "NodoClase",
+    "NodoMetodo",
+    "NodoInstancia",
+    "NodoAtributo",
+    "NodoLlamadaMetodo",
+    "NodoOperacionBinaria",
+    "NodoOperacionUnaria",
+    "NodoValor",
+    "NodoIdentificador",
+    "NodoLlamadaFuncion",
+    "NodoHilo",
+    "NodoRetorno",
+    "NodoYield",
+    "NodoEsperar",
+    "NodoOption",
+    "NodoRomper",
+    "NodoContinuar",
+    "NodoPasar",
+    "NodoAssert",
+    "NodoDel",
+    "NodoGlobal",
+    "NodoNoLocal",
+    "NodoLambda",
+    "NodoWith",
+    "NodoThrow",
+    "NodoTryCatch",
+    "NodoImportDesde",
+    "NodoExport",
+    "NodoImport",
+    "NodoUsar",
+    "NodoPara",
+    "NodoImprimir",
+    "NodoMacro",
+    "NodoCase",
+    "NodoSwitch",
 ]

--- a/backend/src/core/interpreter.py
+++ b/backend/src/core/interpreter.py
@@ -39,7 +39,13 @@ from core.ast_nodes import (
     NodoTryCatch,
     NodoThrow,
     NodoImport,
-    NodoUsar, NodoAssert, NodoDel, NodoGlobal, NodoNoLocal, NodoWith, NodoImportDesde,
+    NodoUsar,
+    NodoAssert,
+    NodoDel,
+    NodoGlobal,
+    NodoNoLocal,
+    NodoWith,
+    NodoImportDesde,
 )
 from cobra.parser.parser import Parser
 from core.memoria.gestor_memoria import GestorMemoriaGenetico
@@ -163,12 +169,12 @@ class InterpretadorCobra:
             return True
         if isinstance(nodo, Token):
             return False
-        for valor in getattr(nodo, '__dict__', {}).values():
+        for valor in getattr(nodo, "__dict__", {}).values():
             if isinstance(valor, list):
                 for elem in valor:
-                    if hasattr(elem, '__dict__') and self._contiene_yield(elem):
+                    if hasattr(elem, "__dict__") and self._contiene_yield(elem):
                         return True
-            elif hasattr(valor, '__dict__') and self._contiene_yield(valor):
+            elif hasattr(valor, "__dict__") and self._contiene_yield(valor):
                 return True
         return False
 
@@ -183,12 +189,12 @@ class InterpretadorCobra:
                 continue
             visitados.add(id(nodo))
             total += 1
-            for val in getattr(nodo, '__dict__', {}).values():
+            for val in getattr(nodo, "__dict__", {}).values():
                 if isinstance(val, list):
                     for elem in val:
-                        if hasattr(elem, '__dict__'):
+                        if hasattr(elem, "__dict__"):
                             pila.append(elem)
-                elif hasattr(val, '__dict__'):
+                elif hasattr(val, "__dict__"):
                     pila.append(val)
         return total
 
@@ -208,9 +214,7 @@ class InterpretadorCobra:
             _lim_cpu(cpu)
 
         ast = remove_dead_code(
-            inline_functions(
-                eliminate_common_subexpressions(optimize_constants(ast))
-            )
+            inline_functions(eliminate_common_subexpressions(optimize_constants(ast)))
         )
         register_execution(str(ast))
         AnalizadorSemantico().analizar(ast)
@@ -242,7 +246,7 @@ class InterpretadorCobra:
         elif isinstance(nodo, NodoImprimir):
             valor = self.evaluar_expresion(nodo.expresion)
             if isinstance(valor, str):
-                if (valor.startswith("\"") and valor.endswith("\"")) or (
+                if (valor.startswith('"') and valor.endswith('"')) or (
                     valor.startswith("'") and valor.endswith("'")
                 ):
                     print(valor.strip('"').strip("'"))
@@ -265,7 +269,11 @@ class InterpretadorCobra:
         elif isinstance(nodo, NodoAssert):
             condicion = self.evaluar_expresion(nodo.condicion)
             if not condicion:
-                mensaje = self.evaluar_expresion(nodo.mensaje) if nodo.mensaje else "Assertion failed"
+                mensaje = (
+                    self.evaluar_expresion(nodo.mensaje)
+                    if nodo.mensaje
+                    else "Assertion failed"
+                )
                 raise AssertionError(mensaje)
         elif isinstance(nodo, NodoDel):
             nombre = self.evaluar_expresion(nodo.objetivo)
@@ -359,38 +367,38 @@ class InterpretadorCobra:
                 verificar_sumables(izquierda, derecha)
                 return izquierda + derecha
             elif tipo == TipoToken.RESTA:
-                verificar_numeros(izquierda, derecha, '-')
+                verificar_numeros(izquierda, derecha, "-")
                 return izquierda - derecha
             elif tipo == TipoToken.MULT:
-                verificar_numeros(izquierda, derecha, '*')
+                verificar_numeros(izquierda, derecha, "*")
                 return izquierda * derecha
             elif tipo == TipoToken.DIV:
-                verificar_numeros(izquierda, derecha, '/')
+                verificar_numeros(izquierda, derecha, "/")
                 return izquierda / derecha
             elif tipo == TipoToken.MOD:
-                verificar_numeros(izquierda, derecha, '%')
+                verificar_numeros(izquierda, derecha, "%")
                 return izquierda % derecha
             elif tipo == TipoToken.MAYORQUE:
-                verificar_comparables(izquierda, derecha, '>')
+                verificar_comparables(izquierda, derecha, ">")
                 return izquierda > derecha
             elif tipo == TipoToken.MENORQUE:
-                verificar_comparables(izquierda, derecha, '<')
+                verificar_comparables(izquierda, derecha, "<")
                 return izquierda < derecha
             elif tipo == TipoToken.MAYORIGUAL:
-                verificar_comparables(izquierda, derecha, '>=')
+                verificar_comparables(izquierda, derecha, ">=")
                 return izquierda >= derecha
             elif tipo == TipoToken.MENORIGUAL:
-                verificar_comparables(izquierda, derecha, '<=')
+                verificar_comparables(izquierda, derecha, "<=")
                 return izquierda <= derecha
             elif tipo == TipoToken.IGUAL:
                 return izquierda == derecha
             elif tipo == TipoToken.DIFERENTE:
                 return izquierda != derecha
             elif tipo == TipoToken.AND:
-                verificar_booleanos(izquierda, derecha, '&&')
+                verificar_booleanos(izquierda, derecha, "&&")
                 return izquierda and derecha
             elif tipo == TipoToken.OR:
-                verificar_booleanos(izquierda, derecha, '||')
+                verificar_booleanos(izquierda, derecha, "||")
                 return izquierda or derecha
             else:
                 raise ValueError(f"Operador no soportado: {tipo}")
@@ -398,7 +406,7 @@ class InterpretadorCobra:
             valor = self.evaluar_expresion(expresion.operando)
             tipo = expresion.operador.tipo
             if tipo == TipoToken.NOT:
-                verificar_booleano(valor, '!')
+                verificar_booleano(valor, "!")
                 return not valor
             else:
                 raise ValueError(f"Operador unario no soportado: {tipo}")
@@ -479,7 +487,9 @@ class InterpretadorCobra:
                 print(f"Error: se esperaban {len(funcion.parametros)} argumentos")
                 return None
 
-            contiene_yield = any(self._contiene_yield(instr) for instr in funcion.cuerpo)
+            contiene_yield = any(
+                self._contiene_yield(instr) for instr in funcion.cuerpo
+            )
 
             def preparar_contexto():
                 self.contextos.append({})
@@ -497,6 +507,7 @@ class InterpretadorCobra:
                 self.contextos.pop()
 
             if contiene_yield:
+
                 def generador():
                     preparar_contexto()
                     try:

--- a/backend/src/core/memoria/__init__.py
+++ b/backend/src/core/memoria/__init__.py
@@ -1,2 +1,1 @@
 """Submódulo con las estrategias y gestores de memoria utilizados por Cobra."""
-

--- a/backend/src/core/optimizations/common_subexpr.py
+++ b/backend/src/core/optimizations/common_subexpr.py
@@ -85,7 +85,9 @@ class _CommonSubexprEliminator(NodeVisitor):
         nodo.derecha = self.visit(nodo.derecha)
         key = _expr_key(nodo)
         if self.counts.get(key, 0) > 1:
-            return self._replace(key, NodoOperacionBinaria(nodo.izquierda, nodo.operador, nodo.derecha))
+            return self._replace(
+                key, NodoOperacionBinaria(nodo.izquierda, nodo.operador, nodo.derecha)
+            )
         return nodo
 
     def visit_operacion_unaria(self, nodo: NodoOperacionUnaria):
@@ -118,7 +120,11 @@ class _CommonSubexprEliminator(NodeVisitor):
     def generic_visit(self, nodo: Any):
         for attr, value in list(getattr(nodo, "__dict__", {}).items()):
             if isinstance(value, list):
-                setattr(nodo, attr, [self.visit(v) if hasattr(v, "aceptar") else v for v in value])
+                setattr(
+                    nodo,
+                    attr,
+                    [self.visit(v) if hasattr(v, "aceptar") else v for v in value],
+                )
             elif hasattr(value, "aceptar"):
                 setattr(nodo, attr, self.visit(value))
         return nodo

--- a/backend/src/core/optimizations/constant_folder.py
+++ b/backend/src/core/optimizations/constant_folder.py
@@ -29,16 +29,20 @@ class _ConstantFolder(NodeVisitor):
         nombres de atributo.
         """
 
-        attr = 'expresion' if hasattr(nodo, 'expresion') else 'valor'
+        attr = "expresion" if hasattr(nodo, "expresion") else "valor"
         setattr(nodo, attr, self.visit(getattr(nodo, attr)))
         return nodo
 
     def visit_operacion_binaria(self, nodo: NodoOperacionBinaria):
         nodo.izquierda = self.visit(nodo.izquierda)
         nodo.derecha = self.visit(nodo.derecha)
-        if isinstance(nodo.izquierda, NodoValor) and isinstance(nodo.derecha, NodoValor):
+        if isinstance(nodo.izquierda, NodoValor) and isinstance(
+            nodo.derecha, NodoValor
+        ):
             try:
-                resultado = self._evaluar(nodo.izquierda.valor, nodo.operador, nodo.derecha.valor)
+                resultado = self._evaluar(
+                    nodo.izquierda.valor, nodo.operador, nodo.derecha.valor
+                )
                 return NodoValor(resultado)
             except Exception:
                 return nodo

--- a/backend/src/core/optimizations/dead_code.py
+++ b/backend/src/core/optimizations/dead_code.py
@@ -22,7 +22,9 @@ class _DeadCodeRemover(NodeVisitor):
     def visit_condicional(self, nodo: NodoCondicional):
         nodo.condicion = self.visit(nodo.condicion)
         nodo.bloque_si = self._limpiar_bloque([self.visit(n) for n in nodo.bloque_si])
-        nodo.bloque_sino = self._limpiar_bloque([self.visit(n) for n in nodo.bloque_sino])
+        nodo.bloque_sino = self._limpiar_bloque(
+            [self.visit(n) for n in nodo.bloque_sino]
+        )
         if isinstance(nodo.condicion, NodoValor):
             return nodo.bloque_si if nodo.condicion.valor else nodo.bloque_sino
         return nodo
@@ -33,7 +35,11 @@ class _DeadCodeRemover(NodeVisitor):
         if isinstance(nodo.condicion, NodoValor):
             if nodo.condicion.valor is False:
                 return []
-            if nodo.condicion.valor is True and nodo.cuerpo and self._es_salida(nodo.cuerpo[-1]):
+            if (
+                nodo.condicion.valor is True
+                and nodo.cuerpo
+                and self._es_salida(nodo.cuerpo[-1])
+            ):
                 cuerpo = nodo.cuerpo
                 if isinstance(cuerpo[-1], (NodoRomper, NodoContinuar)):
                     cuerpo = cuerpo[:-1]

--- a/backend/src/core/semantic_validators/primitiva_peligrosa.py
+++ b/backend/src/core/semantic_validators/primitiva_peligrosa.py
@@ -4,6 +4,7 @@ from core.ast_nodes import NodoLlamadaFuncion, NodoHilo, NodoLlamadaMetodo
 
 class PrimitivaPeligrosaError(Exception):
     """Se lanza cuando se utiliza una primitiva peligrosa."""
+
     pass
 
 
@@ -26,12 +27,16 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
 
     def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
         if nodo.nombre in self.PRIMITIVAS_PELIGROSAS:
-            raise PrimitivaPeligrosaError(f"Uso de primitiva peligrosa: '{nodo.nombre}'")
+            raise PrimitivaPeligrosaError(
+                f"Uso de primitiva peligrosa: '{nodo.nombre}'"
+            )
         self.generic_visit(nodo)
 
     def visit_hilo(self, nodo: NodoHilo):
         if nodo.llamada.nombre in self.PRIMITIVAS_PELIGROSAS:
-            raise PrimitivaPeligrosaError(f"Uso de primitiva peligrosa: '{nodo.llamada.nombre}'")
+            raise PrimitivaPeligrosaError(
+                f"Uso de primitiva peligrosa: '{nodo.llamada.nombre}'"
+            )
         nodo.llamada.aceptar(self)
 
     def visit_llamada_metodo(self, nodo: NodoLlamadaMetodo):

--- a/backend/src/core/type_utils.py
+++ b/backend/src/core/type_utils.py
@@ -18,7 +18,9 @@ def verificar_sumables(a: Any, b: Any) -> None:
 def verificar_numeros(a: Any, b: Any, operador: str) -> None:
     """Valida que ambos operandos sean num\xc3\xa9ricos."""
     if not isinstance(a, (int, float)) or not isinstance(b, (int, float)):
-        raise TypeError(f"Operaci\xc3\xb3n '{operador}' requiere operandos num\xc3\xa9ricos")
+        raise TypeError(
+            f"Operaci\xc3\xb3n '{operador}' requiere operandos num\xc3\xa9ricos"
+        )
 
 
 def verificar_comparables(a: Any, b: Any, operador: str) -> None:
@@ -27,19 +29,20 @@ def verificar_comparables(a: Any, b: Any, operador: str) -> None:
         return
     if type(a) is type(b):
         return
-    raise TypeError(
-        f"Operaci\xc3\xb3n '{operador}' requiere operandos comparables"
-    )
+    raise TypeError(f"Operaci\xc3\xb3n '{operador}' requiere operandos comparables")
 
 
 def verificar_booleanos(a: Any, b: Any, operador: str) -> None:
     """Valida que ambos operandos sean booleanos."""
     if not isinstance(a, bool) or not isinstance(b, bool):
-        raise TypeError(f"Operaci\xc3\xb3n l\xc3\xb3gica '{operador}' requiere booleanos")
+        raise TypeError(
+            f"Operaci\xc3\xb3n l\xc3\xb3gica '{operador}' requiere booleanos"
+        )
 
 
 def verificar_booleano(a: Any, operador: str) -> None:
     """Valida que el operando sea booleano."""
     if not isinstance(a, bool):
-        raise TypeError(f"Operaci\xc3\xb3n l\xc3\xb3gica '{operador}' requiere booleano")
-
+        raise TypeError(
+            f"Operaci\xc3\xb3n l\xc3\xb3gica '{operador}' requiere booleano"
+        )

--- a/backend/src/gui/__init__.py
+++ b/backend/src/gui/__init__.py
@@ -1,2 +1,1 @@
 """Componentes de la interfaz gráfica de Cobra."""
-

--- a/backend/src/ia/__init__.py
+++ b/backend/src/ia/__init__.py
@@ -1,2 +1,1 @@
 """Herramientas experimentales de inteligencia artificial aplicadas a Cobra."""
-


### PR DESCRIPTION
## Summary
- wrap long Python lines to respect 88 char limit
- remove extra blank lines at EOF
- add explicit flake8 step to CI workflow

## Testing
- `pytest -k ''` *(fails: 72 errors during collection)*
- `flake8 backend/src src`

------
https://chatgpt.com/codex/tasks/task_e_687cc077c970832793faff269213341c