### PR TITLE
Fix semantico package imports

### DIFF
--- a/backend/src/cobra/semantico/__init__.py
+++ b/backend/src/cobra/semantico/__init__.py
@@ -1,7 +1,7 @@
 """Utilidades para el análisis semántico y la validación de módulos Cobra."""
 
-from .tabla import Simbolo, Ambito
-from .analizador import AnalizadorSemantico
-from .mod_validator import validar_mod
+from src.cobra.semantico.analizador import AnalizadorSemantico
+from src.cobra.semantico.mod_validator import validar_mod
+from src.cobra.semantico.tabla import Ambito, Simbolo
 
 __all__ = ["Simbolo", "Ambito", "AnalizadorSemantico", "validar_mod"]

--- a/backend/src/cobra/semantico/analizador.py
+++ b/backend/src/cobra/semantico/analizador.py
@@ -2,16 +2,16 @@
 
 from typing import List
 
-from core.visitor import NodeVisitor
 from core.ast_nodes import (
     NodoAsignacion,
-    NodoFuncion,
     NodoClase,
-    NodoMetodo,
+    NodoFuncion,
     NodoIdentificador,
+    NodoMetodo,
 )
+from core.visitor import NodeVisitor
 
-from .tabla import Ambito
+from src.cobra.semantico.tabla import Ambito
 
 
 class AnalizadorSemantico(NodeVisitor):


### PR DESCRIPTION
## Summary
- use absolute package imports under `src.cobra.semantico`
- ran `make format`

## Testing
- `make format` *(fails: Cannot parse some test files)*

------
https://chatgpt.com/codex/tasks/task_e_687e3e1e211083278ef2e37ec771a4b6