### PR TITLE
Arreglar import absoluto de LarkParser

### DIFF
--- a/backend/src/cobra/parser/parser.py
+++ b/backend/src/cobra/parser/parser.py
@@ -1148,6 +1148,8 @@ class ClassicParser:
 import os
 
 if os.getenv("COBRA_PARSER") == "lark":
-    from .lark_parser import LarkParser as Parser
+    from src.cobra.parser.lark_parser import LarkParser
+
+    Parser = LarkParser
 else:
     Parser = ClassicParser


### PR DESCRIPTION
## Summary
- usar import absoluto para `LarkParser`

## Testing
- `make format` *(falla: 7 files failed to reformat)*

------
https://chatgpt.com/codex/tasks/task_e_687e3fd09ec883278f7dc3bb400d7a90