### PR TITLE
Actualiza imports en transpilers

### DIFF
--- a/backend/src/cobra/transpilers/__init__.py
+++ b/backend/src/cobra/transpilers/__init__.py
@@ -1,5 +1,5 @@
 """Facilita el acceso a los distintos transpiladores de Cobra."""
 
-from .base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 
 __all__ = ["BaseTranspiler"]

--- a/backend/src/cobra/transpilers/import_helper.py
+++ b/backend/src/cobra/transpilers/import_helper.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List, Tuple, Union
 
-from .module_map import get_mapped_path
+from src.cobra.transpilers.module_map import get_mapped_path
 
 # Mapeo de importaciones estándar por lenguaje
 STANDARD_IMPORTS = {

--- a/backend/src/cobra/transpilers/transpiler/__init__.py
+++ b/backend/src/cobra/transpilers/transpiler/__init__.py
@@ -1,5 +1,5 @@
 """Herramientas para convertir el AST de Cobra a otros lenguajes."""
 
 # Exportar transpiladores básicos
-from .to_ruby import TranspiladorRuby
-from .to_php import TranspiladorPHP
+from src.cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
+from src.cobra.transpilers.transpiler.to_php import TranspiladorPHP

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from ...semantica import datos_asignacion
+from src.cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, _ = datos_asignacion(self, nodo)

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/bucle_mientras.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/bucle_mientras.py
@@ -1,4 +1,4 @@
-from ...semantica import procesar_bloque
+from src.cobra.transpilers.semantica import procesar_bloque
 
 def visit_bucle_mientras(self, nodo):
     condicion = self.obtener_valor(nodo.condicion)

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/for_.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/for_.py
@@ -1,4 +1,4 @@
-from ...semantica import procesar_bloque
+from src.cobra.transpilers.semantica import procesar_bloque
 
 def visit_for(self, nodo):
     iterable = self.obtener_valor(nodo.iterable)

--- a/backend/src/cobra/transpilers/transpiler/asm_nodes/para.py
+++ b/backend/src/cobra/transpilers/transpiler/asm_nodes/para.py
@@ -1,4 +1,4 @@
-from ...semantica import procesar_bloque
+from src.cobra.transpilers.semantica import procesar_bloque
 
 def visit_para(self, nodo):
     iterable = self.obtener_valor(nodo.iterable)

--- a/backend/src/cobra/transpilers/transpiler/cobol_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/cobol_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from ...semantica import datos_asignacion
+from src.cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, _ = datos_asignacion(self, nodo)

--- a/backend/src/cobra/transpilers/transpiler/cpp_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/cpp_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from ...semantica import datos_asignacion
+from src.cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, es_attr = datos_asignacion(self, nodo)

--- a/backend/src/cobra/transpilers/transpiler/cpp_nodes/bucle_mientras.py
+++ b/backend/src/cobra/transpilers/transpiler/cpp_nodes/bucle_mientras.py
@@ -1,4 +1,4 @@
-from ...semantica import procesar_bloque
+from src.cobra.transpilers.semantica import procesar_bloque
 
 def visit_bucle_mientras(self, nodo):
     cuerpo = nodo.cuerpo

--- a/backend/src/cobra/transpilers/transpiler/fortran_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/fortran_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from ...semantica import datos_asignacion
+from src.cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, _ = datos_asignacion(self, nodo)

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from ...semantica import datos_asignacion
+from src.cobra.transpilers.semantica import datos_asignacion
 
 
 def visit_asignacion(self, nodo):

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/bucle_mientras.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/bucle_mientras.py
@@ -1,4 +1,4 @@
-from ...semantica import procesar_bloque
+from src.cobra.transpilers.semantica import procesar_bloque
 
 def visit_bucle_mientras(self, nodo):
     """Transpila un bucle 'while' en JavaScript, permitiendo anidación."""

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/for_.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/for_.py
@@ -1,4 +1,4 @@
-from ...semantica import procesar_bloque
+from src.cobra.transpilers.semantica import procesar_bloque
 
 def visit_for(self, nodo):
     """Transpila un bucle 'for...of' en JavaScript, permitiendo anidación."""

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/importar.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/importar.py
@@ -1,4 +1,4 @@
-from ...module_map import get_mapped_path
+from src.cobra.transpilers.module_map import get_mapped_path
 
 def visit_import(self, nodo):
     """Genera una importación ES module."""

--- a/backend/src/cobra/transpilers/transpiler/js_nodes/para.py
+++ b/backend/src/cobra/transpilers/transpiler/js_nodes/para.py
@@ -1,4 +1,4 @@
-from ...semantica import procesar_bloque
+from src.cobra.transpilers.semantica import procesar_bloque
 
 def visit_para(self, nodo):
     cuerpo = nodo.cuerpo

--- a/backend/src/cobra/transpilers/transpiler/latex_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/latex_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from ...semantica import datos_asignacion
+from src.cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, _ = datos_asignacion(self, nodo)

--- a/backend/src/cobra/transpilers/transpiler/matlab_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/matlab_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from ...semantica import datos_asignacion
+from src.cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, _ = datos_asignacion(self, nodo)

--- a/backend/src/cobra/transpilers/transpiler/pascal_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/pascal_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from ...semantica import datos_asignacion
+from src.cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, _ = datos_asignacion(self, nodo)

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from ...semantica import datos_asignacion
+from src.cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, _ = datos_asignacion(self, nodo)

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/bucle_mientras.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/bucle_mientras.py
@@ -1,4 +1,4 @@
-from ...semantica import procesar_bloque
+from src.cobra.transpilers.semantica import procesar_bloque
 
 def visit_bucle_mientras(self, nodo):
     condicion = self.obtener_valor(nodo.condicion)

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/for_.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/for_.py
@@ -1,4 +1,4 @@
-from ...semantica import procesar_bloque
+from src.cobra.transpilers.semantica import procesar_bloque
 
 def visit_for(self, nodo):
     iterable = self.obtener_valor(nodo.iterable)

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/importar.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/importar.py
@@ -1,6 +1,6 @@
 from cobra.lexico.lexer import Lexer
 from cobra.parser.parser import Parser
-from ...import_helper import load_mapped_module
+from src.cobra.transpilers.import_helper import load_mapped_module
 
 
 def visit_import(self, nodo):

--- a/backend/src/cobra/transpilers/transpiler/python_nodes/para.py
+++ b/backend/src/cobra/transpilers/transpiler/python_nodes/para.py
@@ -1,4 +1,4 @@
-from ...semantica import procesar_bloque
+from src.cobra.transpilers.semantica import procesar_bloque
 
 def visit_para(self, nodo):
     iterable = self.obtener_valor(nodo.iterable)

--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/asignacion.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from ...semantica import datos_asignacion
+from src.cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, es_attr = datos_asignacion(self, nodo)

--- a/backend/src/cobra/transpilers/transpiler/rust_nodes/bucle_mientras.py
+++ b/backend/src/cobra/transpilers/transpiler/rust_nodes/bucle_mientras.py
@@ -1,4 +1,4 @@
-from ...semantica import procesar_bloque
+from src.cobra.transpilers.semantica import procesar_bloque
 
 def visit_bucle_mientras(self, nodo):
     cuerpo = nodo.cuerpo

--- a/backend/src/cobra/transpilers/transpiler/to_asm.py
+++ b/backend/src/cobra/transpilers/transpiler/to_asm.py
@@ -31,43 +31,43 @@ from core.ast_nodes import (
 from cobra.lexico.lexer import TipoToken, Lexer
 from cobra.parser.parser import Parser
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from .asm_nodes.asignacion import visit_asignacion as _visit_asignacion
-from .asm_nodes.condicional import visit_condicional as _visit_condicional
-from .asm_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
-from .asm_nodes.funcion import visit_funcion as _visit_funcion
-from .asm_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
-from .asm_nodes.llamada_metodo import visit_llamada_metodo as _visit_llamada_metodo
-from .asm_nodes.hilo import visit_hilo as _visit_hilo
-from .asm_nodes.imprimir import visit_imprimir as _visit_imprimir
-from .asm_nodes.retorno import visit_retorno as _visit_retorno
-from .asm_nodes.holobit import visit_holobit as _visit_holobit
-from .asm_nodes.for_ import visit_for as _visit_for
-from .asm_nodes.para import visit_para as _visit_para
-from .asm_nodes.lista import visit_lista as _visit_lista
-from .asm_nodes.diccionario import visit_diccionario as _visit_diccionario
-from .asm_nodes.clase import visit_clase as _visit_clase
-from .asm_nodes.metodo import visit_metodo as _visit_metodo
-from .asm_nodes.try_catch import visit_try_catch as _visit_try_catch
-from .asm_nodes.throw import visit_throw as _visit_throw
-from .asm_nodes.importar import visit_import as _visit_import
-from .asm_nodes.instancia import visit_instancia as _visit_instancia
-from .asm_nodes.atributo import visit_atributo as _visit_atributo
-from .asm_nodes.operacion_binaria import (
+from src.cobra.transpilers.transpiler.asm_nodes.asignacion import visit_asignacion as _visit_asignacion
+from src.cobra.transpilers.transpiler.asm_nodes.condicional import visit_condicional as _visit_condicional
+from src.cobra.transpilers.transpiler.asm_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
+from src.cobra.transpilers.transpiler.asm_nodes.funcion import visit_funcion as _visit_funcion
+from src.cobra.transpilers.transpiler.asm_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from src.cobra.transpilers.transpiler.asm_nodes.llamada_metodo import visit_llamada_metodo as _visit_llamada_metodo
+from src.cobra.transpilers.transpiler.asm_nodes.hilo import visit_hilo as _visit_hilo
+from src.cobra.transpilers.transpiler.asm_nodes.imprimir import visit_imprimir as _visit_imprimir
+from src.cobra.transpilers.transpiler.asm_nodes.retorno import visit_retorno as _visit_retorno
+from src.cobra.transpilers.transpiler.asm_nodes.holobit import visit_holobit as _visit_holobit
+from src.cobra.transpilers.transpiler.asm_nodes.for_ import visit_for as _visit_for
+from src.cobra.transpilers.transpiler.asm_nodes.para import visit_para as _visit_para
+from src.cobra.transpilers.transpiler.asm_nodes.lista import visit_lista as _visit_lista
+from src.cobra.transpilers.transpiler.asm_nodes.diccionario import visit_diccionario as _visit_diccionario
+from src.cobra.transpilers.transpiler.asm_nodes.clase import visit_clase as _visit_clase
+from src.cobra.transpilers.transpiler.asm_nodes.metodo import visit_metodo as _visit_metodo
+from src.cobra.transpilers.transpiler.asm_nodes.try_catch import visit_try_catch as _visit_try_catch
+from src.cobra.transpilers.transpiler.asm_nodes.throw import visit_throw as _visit_throw
+from src.cobra.transpilers.transpiler.asm_nodes.importar import visit_import as _visit_import
+from src.cobra.transpilers.transpiler.asm_nodes.instancia import visit_instancia as _visit_instancia
+from src.cobra.transpilers.transpiler.asm_nodes.atributo import visit_atributo as _visit_atributo
+from src.cobra.transpilers.transpiler.asm_nodes.operacion_binaria import (
     visit_operacion_binaria as _visit_operacion_binaria,
 )
-from .asm_nodes.operacion_unaria import (
+from src.cobra.transpilers.transpiler.asm_nodes.operacion_unaria import (
     visit_operacion_unaria as _visit_operacion_unaria,
 )
-from .asm_nodes.valor import visit_valor as _visit_valor
-from .asm_nodes.identificador import visit_identificador as _visit_identificador
-from .asm_nodes.usar import visit_usar as _visit_usar
-from .asm_nodes.romper import visit_romper as _visit_romper
-from .asm_nodes.continuar import visit_continuar as _visit_continuar
-from .asm_nodes.pasar import visit_pasar as _visit_pasar
+from src.cobra.transpilers.transpiler.asm_nodes.valor import visit_valor as _visit_valor
+from src.cobra.transpilers.transpiler.asm_nodes.identificador import visit_identificador as _visit_identificador
+from src.cobra.transpilers.transpiler.asm_nodes.usar import visit_usar as _visit_usar
+from src.cobra.transpilers.transpiler.asm_nodes.romper import visit_romper as _visit_romper
+from src.cobra.transpilers.transpiler.asm_nodes.continuar import visit_continuar as _visit_continuar
+from src.cobra.transpilers.transpiler.asm_nodes.pasar import visit_pasar as _visit_pasar
 
 
 class TranspiladorASM(BaseTranspiler):

--- a/backend/src/cobra/transpilers/transpiler/to_c.py
+++ b/backend/src/cobra/transpilers/transpiler/to_c.py
@@ -12,7 +12,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/backend/src/cobra/transpilers/transpiler/to_cobol.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cobol.py
@@ -13,14 +13,14 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from .cobol_nodes.asignacion import visit_asignacion as _visit_asignacion
-from .cobol_nodes.funcion import visit_funcion as _visit_funcion
-from .cobol_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
-from .cobol_nodes.imprimir import visit_imprimir as _visit_imprimir
+from src.cobra.transpilers.transpiler.cobol_nodes.asignacion import visit_asignacion as _visit_asignacion
+from src.cobra.transpilers.transpiler.cobol_nodes.funcion import visit_funcion as _visit_funcion
+from src.cobra.transpilers.transpiler.cobol_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from src.cobra.transpilers.transpiler.cobol_nodes.imprimir import visit_imprimir as _visit_imprimir
 
 
 cobol_nodes = {

--- a/backend/src/cobra/transpilers/transpiler/to_cpp.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cpp.py
@@ -19,23 +19,23 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from .cpp_nodes.asignacion import visit_asignacion as _visit_asignacion
-from .cpp_nodes.condicional import visit_condicional as _visit_condicional
-from .cpp_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
-from .cpp_nodes.funcion import visit_funcion as _visit_funcion
-from .cpp_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
-from .cpp_nodes.holobit import visit_holobit as _visit_holobit
-from .cpp_nodes.clase import visit_clase as _visit_clase
-from .cpp_nodes.metodo import visit_metodo as _visit_metodo
-from .cpp_nodes.yield_ import visit_yield as _visit_yield
-from .cpp_nodes.romper import visit_romper as _visit_romper
-from .cpp_nodes.continuar import visit_continuar as _visit_continuar
-from .cpp_nodes.pasar import visit_pasar as _visit_pasar
-from .cpp_nodes.switch import visit_switch as _visit_switch
+from src.cobra.transpilers.transpiler.cpp_nodes.asignacion import visit_asignacion as _visit_asignacion
+from src.cobra.transpilers.transpiler.cpp_nodes.condicional import visit_condicional as _visit_condicional
+from src.cobra.transpilers.transpiler.cpp_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
+from src.cobra.transpilers.transpiler.cpp_nodes.funcion import visit_funcion as _visit_funcion
+from src.cobra.transpilers.transpiler.cpp_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from src.cobra.transpilers.transpiler.cpp_nodes.holobit import visit_holobit as _visit_holobit
+from src.cobra.transpilers.transpiler.cpp_nodes.clase import visit_clase as _visit_clase
+from src.cobra.transpilers.transpiler.cpp_nodes.metodo import visit_metodo as _visit_metodo
+from src.cobra.transpilers.transpiler.cpp_nodes.yield_ import visit_yield as _visit_yield
+from src.cobra.transpilers.transpiler.cpp_nodes.romper import visit_romper as _visit_romper
+from src.cobra.transpilers.transpiler.cpp_nodes.continuar import visit_continuar as _visit_continuar
+from src.cobra.transpilers.transpiler.cpp_nodes.pasar import visit_pasar as _visit_pasar
+from src.cobra.transpilers.transpiler.cpp_nodes.switch import visit_switch as _visit_switch
 
 
 def visit_assert(self, nodo):

--- a/backend/src/cobra/transpilers/transpiler/to_fortran.py
+++ b/backend/src/cobra/transpilers/transpiler/to_fortran.py
@@ -13,16 +13,16 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from .fortran_nodes.asignacion import visit_asignacion as _visit_asignacion
-from .fortran_nodes.funcion import visit_funcion as _visit_funcion
-from .fortran_nodes.llamada_funcion import (
+from src.cobra.transpilers.transpiler.fortran_nodes.asignacion import visit_asignacion as _visit_asignacion
+from src.cobra.transpilers.transpiler.fortran_nodes.funcion import visit_funcion as _visit_funcion
+from src.cobra.transpilers.transpiler.fortran_nodes.llamada_funcion import (
     visit_llamada_funcion as _visit_llamada_funcion,
 )
-from .fortran_nodes.imprimir import visit_imprimir as _visit_imprimir
+from src.cobra.transpilers.transpiler.fortran_nodes.imprimir import visit_imprimir as _visit_imprimir
 
 fortran_nodes = {
     "asignacion": _visit_asignacion,

--- a/backend/src/cobra/transpilers/transpiler/to_go.py
+++ b/backend/src/cobra/transpilers/transpiler/to_go.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/backend/src/cobra/transpilers/transpiler/to_java.py
+++ b/backend/src/cobra/transpilers/transpiler/to_java.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/backend/src/cobra/transpilers/transpiler/to_js.py
+++ b/backend/src/cobra/transpilers/transpiler/to_js.py
@@ -23,48 +23,48 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
-from ..import_helper import get_standard_imports
-from ..module_map import get_mapped_path
+from src.cobra.transpilers.import_helper import get_standard_imports
+from src.cobra.transpilers.module_map import get_mapped_path
 
-from .js_nodes.asignacion import visit_asignacion as _visit_asignacion
-from .js_nodes.condicional import visit_condicional as _visit_condicional
-from .js_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
-from .js_nodes.funcion import visit_funcion as _visit_funcion
-from .js_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
-from .js_nodes.hilo import visit_hilo as _visit_hilo
-from .js_nodes.llamada_metodo import visit_llamada_metodo as _visit_llamada_metodo
-from .js_nodes.imprimir import visit_imprimir as _visit_imprimir
-from .js_nodes.retorno import visit_retorno as _visit_retorno
-from .js_nodes.holobit import visit_holobit as _visit_holobit
-from .js_nodes.for_ import visit_for as _visit_for
-from .js_nodes.lista import visit_lista as _visit_lista
-from .js_nodes.diccionario import visit_diccionario as _visit_diccionario
-from .js_nodes.elemento import visit_elemento as _visit_elemento
-from .js_nodes.clase import visit_clase as _visit_clase
-from .js_nodes.metodo import visit_metodo as _visit_metodo
-from .js_nodes.try_catch import visit_try_catch as _visit_try_catch
-from .js_nodes.throw import visit_throw as _visit_throw
-from .js_nodes.importar import visit_import as _visit_import
-from .js_nodes.instancia import visit_instancia as _visit_instancia
-from .js_nodes.atributo import visit_atributo as _visit_atributo
-from .js_nodes.operacion_binaria import (
+from src.cobra.transpilers.transpiler.js_nodes.asignacion import visit_asignacion as _visit_asignacion
+from src.cobra.transpilers.transpiler.js_nodes.condicional import visit_condicional as _visit_condicional
+from src.cobra.transpilers.transpiler.js_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
+from src.cobra.transpilers.transpiler.js_nodes.funcion import visit_funcion as _visit_funcion
+from src.cobra.transpilers.transpiler.js_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from src.cobra.transpilers.transpiler.js_nodes.hilo import visit_hilo as _visit_hilo
+from src.cobra.transpilers.transpiler.js_nodes.llamada_metodo import visit_llamada_metodo as _visit_llamada_metodo
+from src.cobra.transpilers.transpiler.js_nodes.imprimir import visit_imprimir as _visit_imprimir
+from src.cobra.transpilers.transpiler.js_nodes.retorno import visit_retorno as _visit_retorno
+from src.cobra.transpilers.transpiler.js_nodes.holobit import visit_holobit as _visit_holobit
+from src.cobra.transpilers.transpiler.js_nodes.for_ import visit_for as _visit_for
+from src.cobra.transpilers.transpiler.js_nodes.lista import visit_lista as _visit_lista
+from src.cobra.transpilers.transpiler.js_nodes.diccionario import visit_diccionario as _visit_diccionario
+from src.cobra.transpilers.transpiler.js_nodes.elemento import visit_elemento as _visit_elemento
+from src.cobra.transpilers.transpiler.js_nodes.clase import visit_clase as _visit_clase
+from src.cobra.transpilers.transpiler.js_nodes.metodo import visit_metodo as _visit_metodo
+from src.cobra.transpilers.transpiler.js_nodes.try_catch import visit_try_catch as _visit_try_catch
+from src.cobra.transpilers.transpiler.js_nodes.throw import visit_throw as _visit_throw
+from src.cobra.transpilers.transpiler.js_nodes.importar import visit_import as _visit_import
+from src.cobra.transpilers.transpiler.js_nodes.instancia import visit_instancia as _visit_instancia
+from src.cobra.transpilers.transpiler.js_nodes.atributo import visit_atributo as _visit_atributo
+from src.cobra.transpilers.transpiler.js_nodes.operacion_binaria import (
     visit_operacion_binaria as _visit_operacion_binaria,
 )
-from .js_nodes.operacion_unaria import visit_operacion_unaria as _visit_operacion_unaria
-from .js_nodes.valor import visit_valor as _visit_valor
-from .js_nodes.identificador import visit_identificador as _visit_identificador
-from .js_nodes.para import visit_para as _visit_para
-from .js_nodes.decorador import visit_decorador as _visit_decorador
-from .js_nodes.yield_ import visit_yield as _visit_yield
-from .js_nodes.esperar import visit_esperar as _visit_esperar
-from .js_nodes.romper import visit_romper as _visit_romper
-from .js_nodes.continuar import visit_continuar as _visit_continuar
-from .js_nodes.pasar import visit_pasar as _visit_pasar
-from .js_nodes.switch import visit_switch as _visit_switch
-from .js_nodes.exportar import visit_export as _visit_export
+from src.cobra.transpilers.transpiler.js_nodes.operacion_unaria import visit_operacion_unaria as _visit_operacion_unaria
+from src.cobra.transpilers.transpiler.js_nodes.valor import visit_valor as _visit_valor
+from src.cobra.transpilers.transpiler.js_nodes.identificador import visit_identificador as _visit_identificador
+from src.cobra.transpilers.transpiler.js_nodes.para import visit_para as _visit_para
+from src.cobra.transpilers.transpiler.js_nodes.decorador import visit_decorador as _visit_decorador
+from src.cobra.transpilers.transpiler.js_nodes.yield_ import visit_yield as _visit_yield
+from src.cobra.transpilers.transpiler.js_nodes.esperar import visit_esperar as _visit_esperar
+from src.cobra.transpilers.transpiler.js_nodes.romper import visit_romper as _visit_romper
+from src.cobra.transpilers.transpiler.js_nodes.continuar import visit_continuar as _visit_continuar
+from src.cobra.transpilers.transpiler.js_nodes.pasar import visit_pasar as _visit_pasar
+from src.cobra.transpilers.transpiler.js_nodes.switch import visit_switch as _visit_switch
+from src.cobra.transpilers.transpiler.js_nodes.exportar import visit_export as _visit_export
 
 
 def visit_assert(self, nodo):

--- a/backend/src/cobra/transpilers/transpiler/to_julia.py
+++ b/backend/src/cobra/transpilers/transpiler/to_julia.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/backend/src/cobra/transpilers/transpiler/to_latex.py
+++ b/backend/src/cobra/transpilers/transpiler/to_latex.py
@@ -10,14 +10,14 @@ from core.ast_nodes import (
     NodoAtributo,
 )
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from .latex_nodes.asignacion import visit_asignacion as _visit_asignacion
-from .latex_nodes.funcion import visit_funcion as _visit_funcion
-from .latex_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
-from .latex_nodes.imprimir import visit_imprimir as _visit_imprimir
+from src.cobra.transpilers.transpiler.latex_nodes.asignacion import visit_asignacion as _visit_asignacion
+from src.cobra.transpilers.transpiler.latex_nodes.funcion import visit_funcion as _visit_funcion
+from src.cobra.transpilers.transpiler.latex_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from src.cobra.transpilers.transpiler.latex_nodes.imprimir import visit_imprimir as _visit_imprimir
 
 latex_nodes = {
     "asignacion": _visit_asignacion,

--- a/backend/src/cobra/transpilers/transpiler/to_matlab.py
+++ b/backend/src/cobra/transpilers/transpiler/to_matlab.py
@@ -13,16 +13,16 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from .matlab_nodes.asignacion import visit_asignacion as _visit_asignacion
-from .matlab_nodes.funcion import visit_funcion as _visit_funcion
-from .matlab_nodes.llamada_funcion import (
+from src.cobra.transpilers.transpiler.matlab_nodes.asignacion import visit_asignacion as _visit_asignacion
+from src.cobra.transpilers.transpiler.matlab_nodes.funcion import visit_funcion as _visit_funcion
+from src.cobra.transpilers.transpiler.matlab_nodes.llamada_funcion import (
     visit_llamada_funcion as _visit_llamada_funcion,
 )
-from .matlab_nodes.imprimir import visit_imprimir as _visit_imprimir
+from src.cobra.transpilers.transpiler.matlab_nodes.imprimir import visit_imprimir as _visit_imprimir
 
 matlab_nodes = {
     "asignacion": _visit_asignacion,

--- a/backend/src/cobra/transpilers/transpiler/to_pascal.py
+++ b/backend/src/cobra/transpilers/transpiler/to_pascal.py
@@ -13,16 +13,16 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from .pascal_nodes.asignacion import visit_asignacion as _visit_asignacion
-from .pascal_nodes.funcion import visit_funcion as _visit_funcion
-from .pascal_nodes.llamada_funcion import (
+from src.cobra.transpilers.transpiler.pascal_nodes.asignacion import visit_asignacion as _visit_asignacion
+from src.cobra.transpilers.transpiler.pascal_nodes.funcion import visit_funcion as _visit_funcion
+from src.cobra.transpilers.transpiler.pascal_nodes.llamada_funcion import (
     visit_llamada_funcion as _visit_llamada_funcion,
 )
-from .pascal_nodes.imprimir import visit_imprimir as _visit_imprimir
+from src.cobra.transpilers.transpiler.pascal_nodes.imprimir import visit_imprimir as _visit_imprimir
 
 pascal_nodes = {
     "asignacion": _visit_asignacion,

--- a/backend/src/cobra/transpilers/transpiler/to_php.py
+++ b/backend/src/cobra/transpilers/transpiler/to_php.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/backend/src/cobra/transpilers/transpiler/to_python.py
+++ b/backend/src/cobra/transpilers/transpiler/to_python.py
@@ -38,50 +38,50 @@ from core.ast_nodes import (
 from cobra.parser.parser import Parser
 from cobra.lexico.lexer import TipoToken, Lexer
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
-from ..import_helper import get_standard_imports
+from src.cobra.transpilers.import_helper import get_standard_imports
 
-from .python_nodes.asignacion import visit_asignacion as _visit_asignacion
-from .python_nodes.condicional import visit_condicional as _visit_condicional
-from .python_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
-from .python_nodes.for_ import visit_for as _visit_for
-from .python_nodes.funcion import visit_funcion as _visit_funcion
-from .python_nodes.llamada_funcion import (
+from src.cobra.transpilers.transpiler.python_nodes.asignacion import visit_asignacion as _visit_asignacion
+from src.cobra.transpilers.transpiler.python_nodes.condicional import visit_condicional as _visit_condicional
+from src.cobra.transpilers.transpiler.python_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
+from src.cobra.transpilers.transpiler.python_nodes.for_ import visit_for as _visit_for
+from src.cobra.transpilers.transpiler.python_nodes.funcion import visit_funcion as _visit_funcion
+from src.cobra.transpilers.transpiler.python_nodes.llamada_funcion import (
     visit_llamada_funcion as _visit_llamada_funcion,
 )
-from .python_nodes.llamada_metodo import visit_llamada_metodo as _visit_llamada_metodo
-from .python_nodes.imprimir import visit_imprimir as _visit_imprimir
-from .python_nodes.retorno import visit_retorno as _visit_retorno
-from .python_nodes.holobit import visit_holobit as _visit_holobit
-from .python_nodes.lista import visit_lista as _visit_lista
-from .python_nodes.diccionario import visit_diccionario as _visit_diccionario
-from .python_nodes.clase import visit_clase as _visit_clase
-from .python_nodes.metodo import visit_metodo as _visit_metodo
-from .python_nodes.try_catch import visit_try_catch as _visit_try_catch
-from .python_nodes.throw import visit_throw as _visit_throw
-from .python_nodes.importar import visit_import as _visit_import
-from .python_nodes.usar import visit_usar as _visit_usar
-from .python_nodes.hilo import visit_hilo as _visit_hilo
-from .python_nodes.instancia import visit_instancia as _visit_instancia
-from .python_nodes.atributo import visit_atributo as _visit_atributo
-from .python_nodes.operacion_binaria import (
+from src.cobra.transpilers.transpiler.python_nodes.llamada_metodo import visit_llamada_metodo as _visit_llamada_metodo
+from src.cobra.transpilers.transpiler.python_nodes.imprimir import visit_imprimir as _visit_imprimir
+from src.cobra.transpilers.transpiler.python_nodes.retorno import visit_retorno as _visit_retorno
+from src.cobra.transpilers.transpiler.python_nodes.holobit import visit_holobit as _visit_holobit
+from src.cobra.transpilers.transpiler.python_nodes.lista import visit_lista as _visit_lista
+from src.cobra.transpilers.transpiler.python_nodes.diccionario import visit_diccionario as _visit_diccionario
+from src.cobra.transpilers.transpiler.python_nodes.clase import visit_clase as _visit_clase
+from src.cobra.transpilers.transpiler.python_nodes.metodo import visit_metodo as _visit_metodo
+from src.cobra.transpilers.transpiler.python_nodes.try_catch import visit_try_catch as _visit_try_catch
+from src.cobra.transpilers.transpiler.python_nodes.throw import visit_throw as _visit_throw
+from src.cobra.transpilers.transpiler.python_nodes.importar import visit_import as _visit_import
+from src.cobra.transpilers.transpiler.python_nodes.usar import visit_usar as _visit_usar
+from src.cobra.transpilers.transpiler.python_nodes.hilo import visit_hilo as _visit_hilo
+from src.cobra.transpilers.transpiler.python_nodes.instancia import visit_instancia as _visit_instancia
+from src.cobra.transpilers.transpiler.python_nodes.atributo import visit_atributo as _visit_atributo
+from src.cobra.transpilers.transpiler.python_nodes.operacion_binaria import (
     visit_operacion_binaria as _visit_operacion_binaria,
 )
-from .python_nodes.operacion_unaria import (
+from src.cobra.transpilers.transpiler.python_nodes.operacion_unaria import (
     visit_operacion_unaria as _visit_operacion_unaria,
 )
-from .python_nodes.valor import visit_valor as _visit_valor
-from .python_nodes.identificador import visit_identificador as _visit_identificador
-from .python_nodes.para import visit_para as _visit_para
-from .python_nodes.decorador import visit_decorador as _visit_decorador
-from .python_nodes.yield_ import visit_yield as _visit_yield
-from .python_nodes.esperar import visit_esperar as _visit_esperar
-from .python_nodes.romper import visit_romper as _visit_romper
-from .python_nodes.continuar import visit_continuar as _visit_continuar
-from .python_nodes.pasar import visit_pasar as _visit_pasar
-from .python_nodes.switch import visit_switch as _visit_switch
+from src.cobra.transpilers.transpiler.python_nodes.valor import visit_valor as _visit_valor
+from src.cobra.transpilers.transpiler.python_nodes.identificador import visit_identificador as _visit_identificador
+from src.cobra.transpilers.transpiler.python_nodes.para import visit_para as _visit_para
+from src.cobra.transpilers.transpiler.python_nodes.decorador import visit_decorador as _visit_decorador
+from src.cobra.transpilers.transpiler.python_nodes.yield_ import visit_yield as _visit_yield
+from src.cobra.transpilers.transpiler.python_nodes.esperar import visit_esperar as _visit_esperar
+from src.cobra.transpilers.transpiler.python_nodes.romper import visit_romper as _visit_romper
+from src.cobra.transpilers.transpiler.python_nodes.continuar import visit_continuar as _visit_continuar
+from src.cobra.transpilers.transpiler.python_nodes.pasar import visit_pasar as _visit_pasar
+from src.cobra.transpilers.transpiler.python_nodes.switch import visit_switch as _visit_switch
 
 
 def visit_assert(self, nodo):

--- a/backend/src/cobra/transpilers/transpiler/to_r.py
+++ b/backend/src/cobra/transpilers/transpiler/to_r.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/backend/src/cobra/transpilers/transpiler/to_ruby.py
+++ b/backend/src/cobra/transpilers/transpiler/to_ruby.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/backend/src/cobra/transpilers/transpiler/to_rust.py
+++ b/backend/src/cobra/transpilers/transpiler/to_rust.py
@@ -24,26 +24,26 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from .rust_nodes.asignacion import visit_asignacion as _visit_asignacion
-from .rust_nodes.condicional import visit_condicional as _visit_condicional
-from .rust_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
-from .rust_nodes.funcion import visit_funcion as _visit_funcion
-from .rust_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
-from .rust_nodes.holobit import visit_holobit as _visit_holobit
-from .rust_nodes.clase import visit_clase as _visit_clase
-from .rust_nodes.metodo import visit_metodo as _visit_metodo
-from .rust_nodes.yield_ import visit_yield as _visit_yield
-from .rust_nodes.romper import visit_romper as _visit_romper
-from .rust_nodes.continuar import visit_continuar as _visit_continuar
-from .rust_nodes.pasar import visit_pasar as _visit_pasar
-from .rust_nodes.switch import visit_switch as _visit_switch
-from .rust_nodes.try_catch import visit_try_catch as _visit_try_catch
-from .rust_nodes.throw import visit_throw as _visit_throw
-from .rust_nodes.option import visit_option as _visit_option
+from src.cobra.transpilers.transpiler.rust_nodes.asignacion import visit_asignacion as _visit_asignacion
+from src.cobra.transpilers.transpiler.rust_nodes.condicional import visit_condicional as _visit_condicional
+from src.cobra.transpilers.transpiler.rust_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
+from src.cobra.transpilers.transpiler.rust_nodes.funcion import visit_funcion as _visit_funcion
+from src.cobra.transpilers.transpiler.rust_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from src.cobra.transpilers.transpiler.rust_nodes.holobit import visit_holobit as _visit_holobit
+from src.cobra.transpilers.transpiler.rust_nodes.clase import visit_clase as _visit_clase
+from src.cobra.transpilers.transpiler.rust_nodes.metodo import visit_metodo as _visit_metodo
+from src.cobra.transpilers.transpiler.rust_nodes.yield_ import visit_yield as _visit_yield
+from src.cobra.transpilers.transpiler.rust_nodes.romper import visit_romper as _visit_romper
+from src.cobra.transpilers.transpiler.rust_nodes.continuar import visit_continuar as _visit_continuar
+from src.cobra.transpilers.transpiler.rust_nodes.pasar import visit_pasar as _visit_pasar
+from src.cobra.transpilers.transpiler.rust_nodes.switch import visit_switch as _visit_switch
+from src.cobra.transpilers.transpiler.rust_nodes.try_catch import visit_try_catch as _visit_try_catch
+from src.cobra.transpilers.transpiler.rust_nodes.throw import visit_throw as _visit_throw
+from src.cobra.transpilers.transpiler.rust_nodes.option import visit_option as _visit_option
 
 
 def visit_assert(self, nodo):

--- a/backend/src/cobra/transpilers/transpiler/to_wasm.py
+++ b/backend/src/cobra/transpilers/transpiler/to_wasm.py
@@ -9,7 +9,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from ..base import BaseTranspiler
+from src.cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 


### PR DESCRIPTION
## Summary
- replace relative imports in `backend/src/cobra/transpilers` with absolute paths

## Testing
- `make format` *(fails: Cannot parse some tests for Python 3.11)*
- `make lint` *(fails: flake8 errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_687e42336888832782dd417b68bd30a6