### PR TITLE
Fix CLI imports to absolute paths

### DIFF
--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -3,33 +3,32 @@ import logging
 import os
 import sys
 
-from .i18n import _, setup_gettext, format_traceback
-from .utils import messages
-
-from .commands.compile_cmd import CompileCommand
-from .commands.docs_cmd import DocsCommand
-from .commands.execute_cmd import ExecuteCommand
-from .commands.interactive_cmd import InteractiveCommand
-from .commands.jupyter_cmd import JupyterCommand
-from .commands.flet_cmd import FletCommand
-from .commands.agix_cmd import AgixCommand
-from .plugin import descubrir_plugins
-from .commands.plugins_cmd import PluginsCommand
-from .commands.modules_cmd import ModulesCommand
-from .commands.dependencias_cmd import DependenciasCommand
-from .commands.empaquetar_cmd import EmpaquetarCommand
-from .commands.package_cmd import PaqueteCommand
-from .commands.crear_cmd import CrearCommand
-from .commands.init_cmd import InitCommand
-from .commands.container_cmd import ContainerCommand
-from .commands.benchmarks_cmd import BenchmarksCommand
-from .commands.benchmarks2_cmd import BenchmarksV2Command
-from .commands.bench_transpilers_cmd import BenchTranspilersCommand
-from .commands.benchthreads_cmd import BenchThreadsCommand
-from .commands.bench_cmd import BenchCommand
-from .commands.profile_cmd import ProfileCommand
-from .commands.cache_cmd import CacheCommand
-from .commands.verify_cmd import VerifyCommand
+from src.cli.commands.agix_cmd import AgixCommand
+from src.cli.commands.bench_cmd import BenchCommand
+from src.cli.commands.bench_transpilers_cmd import BenchTranspilersCommand
+from src.cli.commands.benchmarks2_cmd import BenchmarksV2Command
+from src.cli.commands.benchmarks_cmd import BenchmarksCommand
+from src.cli.commands.benchthreads_cmd import BenchThreadsCommand
+from src.cli.commands.cache_cmd import CacheCommand
+from src.cli.commands.compile_cmd import CompileCommand
+from src.cli.commands.container_cmd import ContainerCommand
+from src.cli.commands.crear_cmd import CrearCommand
+from src.cli.commands.dependencias_cmd import DependenciasCommand
+from src.cli.commands.docs_cmd import DocsCommand
+from src.cli.commands.empaquetar_cmd import EmpaquetarCommand
+from src.cli.commands.execute_cmd import ExecuteCommand
+from src.cli.commands.flet_cmd import FletCommand
+from src.cli.commands.init_cmd import InitCommand
+from src.cli.commands.interactive_cmd import InteractiveCommand
+from src.cli.commands.jupyter_cmd import JupyterCommand
+from src.cli.commands.modules_cmd import ModulesCommand
+from src.cli.commands.package_cmd import PaqueteCommand
+from src.cli.commands.plugins_cmd import PluginsCommand
+from src.cli.commands.profile_cmd import ProfileCommand
+from src.cli.commands.verify_cmd import VerifyCommand
+from src.cli.i18n import _, format_traceback, setup_gettext
+from src.cli.plugin import descubrir_plugins
+from src.cli.utils import messages
 
 # La configuración de logging solo debe activarse cuando la CLI se ejecuta
 # directamente para evitar modificar la configuración global al importar este

--- a/backend/src/cli/cobrahub_client.py
+++ b/backend/src/cli/cobrahub_client.py
@@ -1,8 +1,9 @@
 import os
+
 import requests
 
-from .i18n import _
-from .utils.messages import mostrar_info, mostrar_error
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 COBRAHUB_URL = os.environ.get("COBRAHUB_URL", "https://cobrahub.example.com/api")
 

--- a/backend/src/cli/commands/agix_cmd.py
+++ b/backend/src/cli/commands/agix_cmd.py
@@ -1,9 +1,10 @@
 import os
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
 
 from ia.analizador_agix import generar_sugerencias
+
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class AgixCommand(BaseCommand):

--- a/backend/src/cli/commands/bench_cmd.py
+++ b/backend/src/cli/commands/bench_cmd.py
@@ -1,19 +1,18 @@
+import cProfile
 import json
 import os
 import re
+import resource
 import shutil
 import subprocess
 import sys
 import tempfile
 import time
-import cProfile
 from pathlib import Path
 
-import resource
-
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_info
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_info
 
 CODE = """
 var x = 0

--- a/backend/src/cli/commands/bench_transpilers_cmd.py
+++ b/backend/src/cli/commands/bench_transpilers_cmd.py
@@ -1,14 +1,14 @@
-import json
 import cProfile
+import json
 from pathlib import Path
 from timeit import timeit
 
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
-from .compile_cmd import TRANSPILERS
 from core.ast_cache import obtener_ast
 
+from src.cli.commands.base import BaseCommand
+from src.cli.commands.compile_cmd import TRANSPILERS
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 PROGRAM_DIR = (
     Path(__file__).resolve().parents[4] / "scripts" / "benchmarks" / "programs"

--- a/backend/src/cli/commands/benchmarks2_cmd.py
+++ b/backend/src/cli/commands/benchmarks2_cmd.py
@@ -18,9 +18,9 @@ except ImportError:  # pragma: no cover - Windows
 else:
     psutil = None  # type: ignore
 
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 CODE = """
 var x = 0

--- a/backend/src/cli/commands/benchmarks_cmd.py
+++ b/backend/src/cli/commands/benchmarks_cmd.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import resource
 import shutil
 import subprocess
 import sys
@@ -8,11 +9,9 @@ import tempfile
 import time
 from pathlib import Path
 
-import resource
-
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 CODE = """
 var x = 0

--- a/backend/src/cli/commands/benchthreads_cmd.py
+++ b/backend/src/cli/commands/benchthreads_cmd.py
@@ -1,20 +1,20 @@
 import json
 import os
+import resource
 import subprocess
 import sys
 import tempfile
 import time
-import resource
 from pathlib import Path
 
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
-from jupyter_kernel import CobraKernel
-from core.interpreter import InterpretadorCobra
 from cobra.lexico.lexer import Lexer
 from cobra.parser.parser import Parser
+from core.interpreter import InterpretadorCobra
+from jupyter_kernel import CobraKernel
 
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 SEQUENTIAL_CODE = """
 funcion tarea(n):

--- a/backend/src/cli/commands/cache_cmd.py
+++ b/backend/src/cli/commands/cache_cmd.py
@@ -1,7 +1,8 @@
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_info
 from core.ast_cache import limpiar_cache
+
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_info
 
 
 class CacheCommand(BaseCommand):

--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -1,37 +1,38 @@
 import logging
-import os
 import multiprocessing
+import os
 from importlib import import_module
 from importlib.metadata import entry_points
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
-from cobra.transpilers import module_map
-from core.sandbox import validar_dependencias
 
+from cobra.transpilers import module_map
+from cobra.transpilers.transpiler.to_asm import TranspiladorASM
+from cobra.transpilers.transpiler.to_c import TranspiladorC
+from cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
+from cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
+from cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
+from cobra.transpilers.transpiler.to_go import TranspiladorGo
+from cobra.transpilers.transpiler.to_java import TranspiladorJava
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.transpiler.to_julia import TranspiladorJulia
+from cobra.transpilers.transpiler.to_latex import TranspiladorLatex
+from cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
+from cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
+from cobra.transpilers.transpiler.to_php import TranspiladorPHP
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_r import TranspiladorR
+from cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
+from cobra.transpilers.transpiler.to_rust import TranspiladorRust
+from cobra.transpilers.transpiler.to_wasm import TranspiladorWasm
 from core.ast_cache import obtener_ast
+from core.sandbox import validar_dependencias
 from core.semantic_validators import (
     PrimitivaPeligrosaError,
     construir_cadena,
 )
-from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
-from cobra.transpilers.transpiler.to_python import TranspiladorPython
-from cobra.transpilers.transpiler.to_asm import TranspiladorASM
-from cobra.transpilers.transpiler.to_rust import TranspiladorRust
-from cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
-from cobra.transpilers.transpiler.to_c import TranspiladorC
-from cobra.transpilers.transpiler.to_go import TranspiladorGo
-from cobra.transpilers.transpiler.to_r import TranspiladorR
-from cobra.transpilers.transpiler.to_julia import TranspiladorJulia
-from cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
-from cobra.transpilers.transpiler.to_java import TranspiladorJava
-from cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
-from cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
-from cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
-from cobra.transpilers.transpiler.to_php import TranspiladorPHP
-from cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
-from cobra.transpilers.transpiler.to_latex import TranspiladorLatex
-from cobra.transpilers.transpiler.to_wasm import TranspiladorWasm
+
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 # Mapa que asocia el nombre de cada lenguaje con la clase de su
 # transpilador. Sirve como una fábrica sencilla: a partir de una clave

--- a/backend/src/cli/commands/container_cmd.py
+++ b/backend/src/cli/commands/container_cmd.py
@@ -1,8 +1,9 @@
 import os
 import subprocess
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
+
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class ContainerCommand(BaseCommand):

--- a/backend/src/cli/commands/crear_cmd.py
+++ b/backend/src/cli/commands/crear_cmd.py
@@ -1,7 +1,8 @@
 import os
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
+
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class CrearCommand(BaseCommand):

--- a/backend/src/cli/commands/dependencias_cmd.py
+++ b/backend/src/cli/commands/dependencias_cmd.py
@@ -2,9 +2,10 @@ import os
 import subprocess
 import tempfile
 import tomllib
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
+
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class DependenciasCommand(BaseCommand):

--- a/backend/src/cli/commands/docs_cmd.py
+++ b/backend/src/cli/commands/docs_cmd.py
@@ -1,8 +1,9 @@
 import os
 import subprocess
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
+
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class DocsCommand(BaseCommand):
@@ -31,15 +32,11 @@ class DocsCommand(BaseCommand):
         try:
             subprocess.run(["sphinx-apidoc", "-o", api, codigo], check=True)
             subprocess.run(["sphinx-build", "-b", "html", source, build], check=True)
-            mostrar_info(
-                _("Documentación generada en {path}").format(path=build)
-            )
+            mostrar_info(_("Documentación generada en {path}").format(path=build))
             return 0
         except FileNotFoundError:
             mostrar_error(_("Sphinx no está instalado. Ejecuta 'pip install sphinx'."))
             return 1
         except subprocess.CalledProcessError as e:
-            mostrar_error(
-                _("Error generando la documentación: {err}").format(err=e)
-            )
+            mostrar_error(_("Error generando la documentación: {err}").format(err=e))
             return 1

--- a/backend/src/cli/commands/empaquetar_cmd.py
+++ b/backend/src/cli/commands/empaquetar_cmd.py
@@ -1,9 +1,9 @@
 import os
 import subprocess
 
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class EmpaquetarCommand(BaseCommand):
@@ -68,9 +68,7 @@ class EmpaquetarCommand(BaseCommand):
             return 0
         except FileNotFoundError:
             mostrar_error(
-                _(
-                    "PyInstaller no está instalado. Ejecuta 'pip install pyinstaller'."
-                )
+                _("PyInstaller no está instalado. Ejecuta 'pip install pyinstaller'.")
             )
             return 1
         except subprocess.CalledProcessError as e:

--- a/backend/src/cli/commands/execute_cmd.py
+++ b/backend/src/cli/commands/execute_cmd.py
@@ -1,19 +1,20 @@
 import logging
 import os
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
-from core.sandbox import (
-    ejecutar_en_sandbox,
-    ejecutar_en_contenedor,
-    validar_dependencias,
-)
-from cobra.transpilers import module_map
 
-from core.interpreter import InterpretadorCobra
 from cobra.lexico.lexer import Lexer
 from cobra.parser.parser import Parser
+from cobra.transpilers import module_map
+from core.interpreter import InterpretadorCobra
+from core.sandbox import (
+    ejecutar_en_contenedor,
+    ejecutar_en_sandbox,
+    validar_dependencias,
+)
 from core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
+
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class ExecuteCommand(BaseCommand):

--- a/backend/src/cli/commands/flet_cmd.py
+++ b/backend/src/cli/commands/flet_cmd.py
@@ -1,6 +1,6 @@
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error
 
 
 class FletCommand(BaseCommand):
@@ -10,9 +10,7 @@ class FletCommand(BaseCommand):
 
     def register_subparser(self, subparsers):
         """Registra los argumentos del subcomando."""
-        parser = subparsers.add_parser(
-            self.name, help=_("Inicia la interfaz gráfica")
-        )
+        parser = subparsers.add_parser(self.name, help=_("Inicia la interfaz gráfica"))
         parser.set_defaults(cmd=self)
         return parser
 

--- a/backend/src/cli/commands/init_cmd.py
+++ b/backend/src/cli/commands/init_cmd.py
@@ -1,8 +1,8 @@
 import os
 
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_info
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_info
 
 
 class InitCommand(BaseCommand):
@@ -27,7 +27,5 @@ class InitCommand(BaseCommand):
         if not os.path.exists(main):
             with open(main, "w", encoding="utf-8"):
                 pass
-        mostrar_info(
-            _("Proyecto Cobra inicializado en {path}").format(path=ruta)
-        )
+        mostrar_info(_("Proyecto Cobra inicializado en {path}").format(path=ruta))
         return 0

--- a/backend/src/cli/commands/interactive_cmd.py
+++ b/backend/src/cli/commands/interactive_cmd.py
@@ -1,19 +1,20 @@
 import logging
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
-from core.sandbox import (
-    ejecutar_en_sandbox,
-    ejecutar_en_contenedor,
-    validar_dependencias,
-)
-from cobra.transpilers import module_map
 
-from core.interpreter import InterpretadorCobra
-from core.qualia_bridge import get_suggestions
 from cobra.lexico.lexer import Lexer
 from cobra.parser.parser import Parser
+from cobra.transpilers import module_map
+from core.interpreter import InterpretadorCobra
+from core.qualia_bridge import get_suggestions
+from core.sandbox import (
+    ejecutar_en_contenedor,
+    ejecutar_en_sandbox,
+    validar_dependencias,
+)
 from core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
+
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class InteractiveCommand(BaseCommand):

--- a/backend/src/cli/commands/jupyter_cmd.py
+++ b/backend/src/cli/commands/jupyter_cmd.py
@@ -1,8 +1,9 @@
 import subprocess
 import sys
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error
+
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error
 
 
 class JupyterCommand(BaseCommand):

--- a/backend/src/cli/commands/modules_cmd.py
+++ b/backend/src/cli/commands/modules_cmd.py
@@ -1,13 +1,15 @@
 import os
 import shutil
+
 import yaml
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
-from ..utils.semver import es_version_valida, es_nueva_version
-from ..cobrahub_client import publicar_modulo, descargar_modulo
-from cobra.transpilers.module_map import MODULE_MAP_PATH
 from cobra.semantico import mod_validator
+from cobra.transpilers.module_map import MODULE_MAP_PATH
+
+from src.cli.cobrahub_client import descargar_modulo, publicar_modulo
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
+from src.cli.utils.semver import es_nueva_version, es_version_valida
 
 MODULES_PATH = os.path.join(os.path.dirname(__file__), "..", "modules")
 os.makedirs(MODULES_PATH, exist_ok=True)

--- a/backend/src/cli/commands/package_cmd.py
+++ b/backend/src/cli/commands/package_cmd.py
@@ -1,9 +1,10 @@
 import os
 import zipfile
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
-from . import modules_cmd
+
+from src.cli.commands import modules_cmd
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class PaqueteCommand(BaseCommand):

--- a/backend/src/cli/commands/plugins_cmd.py
+++ b/backend/src/cli/commands/plugins_cmd.py
@@ -1,7 +1,7 @@
-from .base import BaseCommand
-from ..i18n import _
-from ..plugin_registry import obtener_registro_detallado
-from ..utils.messages import mostrar_info
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.plugin_registry import obtener_registro_detallado
+from src.cli.utils.messages import mostrar_info
 
 
 class PluginsCommand(BaseCommand):
@@ -33,8 +33,7 @@ class PluginsCommand(BaseCommand):
             registro = {
                 n: d
                 for n, d in registro.items()
-                if texto in n.lower()
-                or texto in d.get("description", "").lower()
+                if texto in n.lower() or texto in d.get("description", "").lower()
             }
 
         for nombre, datos in registro.items():

--- a/backend/src/cli/commands/profile_cmd.py
+++ b/backend/src/cli/commands/profile_cmd.py
@@ -9,16 +9,17 @@ import pstats
 import subprocess
 import tempfile
 
-from .base import BaseCommand
-from .execute_cmd import ExecuteCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
-from cobra.transpilers import module_map
-from core.sandbox import validar_dependencias
-from core.interpreter import InterpretadorCobra
 from cobra.lexico.lexer import Lexer
 from cobra.parser.parser import Parser
+from cobra.transpilers import module_map
+from core.interpreter import InterpretadorCobra
+from core.sandbox import validar_dependencias
 from core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
+
+from src.cli.commands.base import BaseCommand
+from src.cli.commands.execute_cmd import ExecuteCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class ProfileCommand(BaseCommand):

--- a/backend/src/cli/commands/verify_cmd.py
+++ b/backend/src/cli/commands/verify_cmd.py
@@ -1,16 +1,17 @@
-import os
 import logging
+import os
 from io import StringIO
 from unittest.mock import patch
 
-from .base import BaseCommand
-from ..i18n import _
-from ..utils.messages import mostrar_error, mostrar_info
 from cli.commands.compile_cmd import TRANSPILERS
-from core.interpreter import InterpretadorCobra
 from cobra.lexico.lexer import Lexer
 from cobra.parser.parser import Parser
+from core.interpreter import InterpretadorCobra
 from core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
+
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class VerifyCommand(BaseCommand):

--- a/backend/src/cli/i18n.py
+++ b/backend/src/cli/i18n.py
@@ -16,17 +16,17 @@ _TRACEBACK_TRANSLATIONS = {
     },
 }
 
-ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
-LOCALE_DIR = os.path.join(ROOT_DIR, 'frontend', 'docs', 'locale')
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+LOCALE_DIR = os.path.join(ROOT_DIR, "frontend", "docs", "locale")
 
 _ = gettext.gettext
 
 
 def setup_gettext(lang: str | None = None):
     """Inicializa gettext y devuelve la función de traducción."""
-    selected = lang or os.environ.get('COBRA_LANG', 'es')
+    selected = lang or os.environ.get("COBRA_LANG", "es")
     translation = gettext.translation(
-        'cobra', localedir=LOCALE_DIR, languages=[selected], fallback=True
+        "cobra", localedir=LOCALE_DIR, languages=[selected], fallback=True
     )
     global _
     _ = translation.gettext

--- a/backend/src/cli/plugin.py
+++ b/backend/src/cli/plugin.py
@@ -10,11 +10,11 @@ from abc import ABC, abstractmethod
 from importlib import import_module
 from importlib.metadata import entry_points
 
-from .commands.base import BaseCommand
-from .plugin_registry import (
-    registrar_plugin,
+from src.cli.commands.base import BaseCommand
+from src.cli.plugin_registry import (
     obtener_registro,
     obtener_registro_detallado,
+    registrar_plugin,
 )
 
 
@@ -84,9 +84,7 @@ def cargar_plugin_seguro(ruta: str):
         return None
 
     if not issubclass(plugin_cls, PluginInterface):
-        logging.warning(
-            f"El plugin {ruta} no implementa PluginInterface"
-        )
+        logging.warning(f"El plugin {ruta} no implementa PluginInterface")
         return None
 
     try:

--- a/backend/src/cli/plugin_interface.py
+++ b/backend/src/cli/plugin_interface.py
@@ -4,6 +4,6 @@ Este archivo se mantiene por compatibilidad pero las clases y funciones
 relacionadas con plugins se encuentran ahora en ``src.cli.plugin``.
 """
 
-from .plugin import PluginInterface
+from src.cli.plugin import PluginInterface
 
 __all__ = ["PluginInterface"]

--- a/backend/src/cli/plugin_loader.py
+++ b/backend/src/cli/plugin_loader.py
@@ -4,7 +4,7 @@ Las utilidades de carga y las clases para plugins ahora residen en
 ``src.cli.plugin``.
 """
 
-from .plugin import PluginCommand, descubrir_plugins, cargar_plugin_seguro
+from src.cli.plugin import PluginCommand, cargar_plugin_seguro, descubrir_plugins
 
 __all__ = [
     "PluginCommand",

--- a/backend/src/cli/utils/messages.py
+++ b/backend/src/cli/utils/messages.py
@@ -1,6 +1,6 @@
 import logging
 
-from ..i18n import _
+from src.cli.i18n import _
 
 RED = "\033[91m"
 GREEN = "\033[92m"

--- a/backend/src/cli/utils/semver.py
+++ b/backend/src/cli/utils/semver.py
@@ -1,4 +1,4 @@
-from packaging.version import Version, InvalidVersion
+from packaging.version import InvalidVersion, Version
 
 
 def es_version_valida(version: str) -> bool:


### PR DESCRIPTION
## Summary
- use absolute imports in CLI modules
- run formatting and linting

## Testing
- `make format` *(fails: 119 files reformatted, 7 files failed to reformat)*
- `make lint` *(fails: flake8 reported multiple issues)*

------
https://chatgpt.com/codex/tasks/task_e_687e74debd448327bc0eb42c8e63d158