### PR TITLE
Fix imports in corelibs and standard library

### DIFF
--- a/backend/corelibs/__init__.py
+++ b/backend/corelibs/__init__.py
@@ -1,13 +1,13 @@
 """Colección de utilidades estándar para Cobra."""
 
-from .texto import mayusculas, minusculas, invertir, concatenar
-from .numero import es_par, es_primo, factorial, promedio
-from .archivo import leer, escribir, existe, eliminar
-from .tiempo import ahora, formatear, dormir
-from .coleccion import ordenar, maximo, minimo, sin_duplicados
-from .seguridad import hash_md5, hash_sha256, generar_uuid
-from .red import obtener_url, enviar_post
-from .sistema import obtener_os, ejecutar, obtener_env, listar_dir
+from corelibs.texto import mayusculas, minusculas, invertir, concatenar
+from corelibs.numero import es_par, es_primo, factorial, promedio
+from corelibs.archivo import leer, escribir, existe, eliminar
+from corelibs.tiempo import ahora, formatear, dormir
+from corelibs.coleccion import ordenar, maximo, minimo, sin_duplicados
+from corelibs.seguridad import hash_md5, hash_sha256, generar_uuid
+from corelibs.red import obtener_url, enviar_post
+from corelibs.sistema import obtener_os, ejecutar, obtener_env, listar_dir
 
 __all__ = [
     "mayusculas",

--- a/standard_library/__init__.py
+++ b/standard_library/__init__.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from .archivo import leer, escribir, adjuntar, existe
-from .fecha import hoy, formatear, sumar_dias
-from .lista import cabeza, cola, longitud, combinar
-from .logica import conjuncion, disyuncion, negacion
-from .util import es_nulo, es_vacio, repetir
+from standard_library.archivo import leer, escribir, adjuntar, existe
+from standard_library.fecha import hoy, formatear, sumar_dias
+from standard_library.lista import cabeza, cola, longitud, combinar
+from standard_library.logica import conjuncion, disyuncion, negacion
+from standard_library.util import es_nulo, es_vacio, repetir
 
 __all__ = [
     "leer",
@@ -27,4 +27,3 @@ __all__ = [
     "es_vacio",
     "repetir",
 ]
-


### PR DESCRIPTION
## Summary
- make corelibs imports absolute
- make standard_library imports absolute

## Testing
- `make format` *(fails: cannot parse some test files for Python 3.11)*

------
https://chatgpt.com/codex/tasks/task_e_687e79668d048327828f898aed9ce27a