### PR TITLE
Actualiza timeout en obtener_url

### DIFF
--- a/backend/src/core/nativos/io.py
+++ b/backend/src/core/nativos/io.py
@@ -18,5 +18,5 @@ def obtener_url(url):
     url_baja = url.lower()
     if not (url_baja.startswith("http://") or url_baja.startswith("https://")):
         raise ValueError("Esquema de URL no soportado")
-    with urllib.request.urlopen(url) as resp:
+    with urllib.request.urlopen(url, timeout=5) as resp:
         return resp.read().decode("utf-8")


### PR DESCRIPTION
## Summary
- agrega timeout de 5 segundos a `urllib.request.urlopen` en `obtener_url`
- se ejecutan pruebas unitarias de `tests/unit/test_nativos_io.py`

## Testing
- `pytest tests/unit/test_nativos_io.py::test_obtener_url_rechaza_esquema_no_http -q`
- `pytest tests/unit/test_nativos_io.py::test_obtener_url_rechaza_otro_esquema -q`
- `pytest tests/unit/test_nativos_io.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687efe44d6608327ad0afd728e2c6eaa