### PR TITLE
Deprecate insecure hash_md5

### DIFF
--- a/backend/corelibs/seguridad.py
+++ b/backend/corelibs/seguridad.py
@@ -2,11 +2,22 @@
 
 import hashlib
 import uuid
+import warnings
 
 
 # MD5 es inseguro para hashing criptográfico y se incluye sólo por compatibilidad
 def hash_md5(texto: str) -> str:
-    """Devuelve el hash MD5 de *texto*."""
+    """Devuelve el hash MD5 de *texto*.
+
+    .. warning:: Este algoritmo está obsoleto y no debe usarse para propósitos
+       de seguridad. Se mantiene únicamente por compatibilidad. Utiliza
+       :func:`hash_sha256` para un hashing seguro.
+    """
+    warnings.warn(
+        "hash_md5 está en desuso; utiliza hash_sha256 para hashing seguro",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return hashlib.md5(texto.encode("utf-8")).hexdigest()
 
 

--- a/frontend/docs/modulos_nativos.rst
+++ b/frontend/docs/modulos_nativos.rst
@@ -72,7 +72,8 @@ Red
 Seguridad
 ---------
 - ``hash_md5(texto)`` devuelve el hash MD5 de ``texto``.
-  .. warning:: MD5 es un algoritmo obsoleto para hashing seguro; se recomienda usar ``hash_sha256``.
+  .. warning:: Esta función está en desuso y no debe emplearse para seguridad.
+     MD5 es un algoritmo obsoleto; se recomienda usar ``hash_sha256``.
 - ``hash_sha256(texto)`` devuelve el hash SHA-256.
 - ``generar_uuid()`` crea un identificador unico.
 


### PR DESCRIPTION
## Summary
- improve docs for `hash_md5` and issue a deprecation warning
- clarify deprecation in native modules docs

## Testing
- `PYTHONPATH=$PWD:$PWD/backend pytest tests/unit/test_corelibs.py::test_seguridad_funcs -q`

------
https://chatgpt.com/codex/tasks/task_e_687f0f0699248327977687c03d588586