### PR TITLE
Handle missing UI tool in profile command

### DIFF
--- a/backend/src/cli/commands/profile_cmd.py
+++ b/backend/src/cli/commands/profile_cmd.py
@@ -6,6 +6,7 @@ import io
 import logging
 import os
 import pstats
+import shutil
 import subprocess
 import tempfile
 
@@ -103,6 +104,13 @@ class ProfileCommand(BaseCommand):
             profiler.disable()
             stats_file = output
             if ui:
+                if shutil.which(ui) is None:
+                    msg = _(
+                        "Herramienta {tool} no encontrada. "
+                        "Instálala con 'pip install {tool}'"
+                    ).format(tool=ui)
+                    mostrar_error(msg)
+                    return 1
                 if not stats_file:
                     tmp = tempfile.NamedTemporaryFile(suffix=".prof", delete=False)
                     stats_file = tmp.name

--- a/tests/unit/test_cli_profile.py
+++ b/tests/unit/test_cli_profile.py
@@ -62,3 +62,23 @@ def test_cli_profile_analysis_flag(tmp_path, monkeypatch):
             main(["profile", str(archivo), "--analysis"])
         data = buf.getvalue()
     assert "Lexer profile" in data and "Parser profile" in data
+
+
+def test_cli_profile_invalid_ui(tmp_path, monkeypatch):
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: {})
+    monkeypatch.setattr(backend_map, "get_toml_map", lambda: {})
+    monkeypatch.setattr(module_map, "_toml_cache", {}, raising=False)
+    monkeypatch.setattr(backend_map, "_toml_cache", {}, raising=False)
+    for name in dir(backend_nodes):
+        if name.startswith("Nodo"):
+            obj = getattr(backend_nodes, name)
+            monkeypatch.setattr(src_nodes, name, obj, raising=False)
+            monkeypatch.setattr(interpreter_mod, name, obj, raising=False)
+    archivo = tmp_path / "prog4.co"
+    archivo.write_text("imprimir(4)")
+    with StringIO() as buf:
+        from unittest.mock import patch
+        with patch("sys.stdout", buf):
+            main(["profile", str(archivo), "--ui", "fake_tool"])
+        data = buf.getvalue()
+    assert "fake_tool" in data and "no encontrada" in data


### PR DESCRIPTION
## Summary
- prevent subprocess call if `--ui` tool doesn't exist
- add regression test for invalid `--ui` argument

## Testing
- `pytest tests/unit/test_cli_profile.py::test_cli_profile_invalid_ui -q`

------
https://chatgpt.com/codex/tasks/task_e_687f130070c083279899ebf0a1690228