### PR TITLE
Add timeout support for JS sandbox

### DIFF
--- a/backend/src/core/sandbox.py
+++ b/backend/src/core/sandbox.py
@@ -42,11 +42,13 @@ def ejecutar_en_sandbox(codigo: str) -> str:
     return env["_print"]()
 
 
-def ejecutar_en_sandbox_js(codigo: str) -> str:
+def ejecutar_en_sandbox_js(codigo: str, timeout: int = 5) -> str:
     """Ejecuta código JavaScript de forma aislada usando Node.
 
     El código se serializa para evitar inyección de comandos cuando se pasa a
     la opción ``-e`` de Node.
+    
+    ``timeout`` especifica el tiempo límite en segundos para la ejecución.
     """
     import json
     import os
@@ -75,8 +77,11 @@ process.stdout.write(output);
             text=True,
             check=True,
             cwd=base_dir,
+            timeout=timeout,
         )  # nosec B603
         return proc.stdout
+    except subprocess.TimeoutExpired:
+        return "Error: tiempo de ejecuci\u00f3n agotado"
     finally:
         os.unlink(tmp_path)
 

--- a/tests/unit/test_sandbox_js.py
+++ b/tests/unit/test_sandbox_js.py
@@ -27,3 +27,12 @@ def test_sandbox_js_inyeccion_no_ejecuta():
     with pytest.raises(subprocess.CalledProcessError) as exc:
         ejecutar_en_sandbox_js(codigo)
     assert "inseguro" not in exc.value.stdout
+
+
+@pytest.mark.timeout(5)
+def test_sandbox_js_timeout():
+    if not shutil.which("node"):
+        pytest.skip("node no disponible")
+    codigo = "while(true){}"
+    salida = ejecutar_en_sandbox_js(codigo, timeout=1)
+    assert "agotado" in salida


### PR DESCRIPTION
## Summary
- allow specifying a timeout when running JavaScript code in sandbox
- handle `TimeoutExpired` and return a user-friendly message
- test that long-running JS code reports a timeout

## Testing
- `pytest tests/unit/test_sandbox_js.py::test_sandbox_js_timeout -q`
- `pytest -q` *(fails: 73 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687f50f3daac8327990c9379cb813302