### PR TITLE
Fix pip install with sys.executable

### DIFF
--- a/backend/src/cobra/usar_loader.py
+++ b/backend/src/cobra/usar_loader.py
@@ -63,7 +63,7 @@ def obtener_modulo(nombre: str):
 
         print(f"Paquete '{nombre}' no encontrado. Instalando...")
         try:
-            subprocess.run(["pip", "install", nombre], check=True)
+            subprocess.run([sys.executable, "-m", "pip", "install", nombre], check=True)
         except subprocess.CalledProcessError as exc:
             raise RuntimeError(f"Fallo al instalar '{nombre}': {exc}") from exc
         try:

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -22,7 +22,7 @@ def test_obtener_modulo_instala_si_no_existe():
         mock_run.return_value.returncode = 0
         mod = usar_loader.obtener_modulo('demo')
     usar_loader.USAR_WHITELIST.remove('demo')
-    mock_run.assert_called_once_with(['pip', 'install', 'demo'], check=True)
+    mock_run.assert_called_once_with([sys.executable, '-m', 'pip', 'install', 'demo'], check=True)
     assert mod is mock_mod
 
 


### PR DESCRIPTION
## Summary
- use `sys.executable -m pip` when installing modules with `usar`
- update unit test accordingly

## Testing
- `pytest tests/unit/test_usar.py tests/unit/test_usar_loader_stdlib.py tests/unit/test_usar_loader_site_packages.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f526158508327bbd5231e338137c4