### PR TITLE
Check spec in cargar_extension

### DIFF
--- a/backend/src/core/pybind_bridge.py
+++ b/backend/src/core/pybind_bridge.py
@@ -47,6 +47,8 @@ def cargar_extension(ruta: str) -> ModuleType:
         nombre = os.path.splitext(os.path.basename(path))[0]
         loader = importlib.machinery.ExtensionFileLoader(nombre, path)
         spec = importlib.util.spec_from_loader(loader.name, loader)
+        if spec is None:
+            raise ImportError(f"No se pudo obtener un spec para {path}")
         module = importlib.util.module_from_spec(spec)
         loader.exec_module(module)
         _cache[path] = module

--- a/tests/unit/test_pybind_bridge_invalid_loader.py
+++ b/tests/unit/test_pybind_bridge_invalid_loader.py
@@ -1,0 +1,30 @@
+import sys
+from types import ModuleType
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
+
+fake_pybind11 = ModuleType('pybind11')
+fake_helpers = ModuleType('pybind11.setup_helpers')
+fake_helpers.Pybind11Extension = object
+fake_helpers.build_ext = object
+sys.modules.setdefault('pybind11', fake_pybind11)
+sys.modules.setdefault('pybind11.setup_helpers', fake_helpers)
+fake_setuptools = ModuleType('setuptools')
+fake_setuptools.Distribution = object
+sys.modules.setdefault('setuptools', fake_setuptools)
+
+from src.core.pybind_bridge import cargar_extension
+
+
+def test_cargar_extension_loader_invalido(tmp_path):
+    ruta = tmp_path / "x.so"
+    ruta.touch()
+    with patch("importlib.util.spec_from_loader", return_value=None):
+        with pytest.raises(ImportError, match="No se pudo obtener un spec"):
+            cargar_extension(str(ruta))
+


### PR DESCRIPTION
## Summary
- handle missing spec in `cargar_extension`
- test invalid loader handling for `cargar_extension`

## Testing
- `pytest tests/unit/test_pybind_bridge_invalid_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f907a70e08327a6a104656ba45516