### PR TITLE
Fix imports location for PEP8

### DIFF
--- a/backend/src/cobra/macro/__init__.py
+++ b/backend/src/cobra/macro/__init__.py
@@ -1,6 +1,7 @@
-macros = {}
-
 from core.ast_nodes import NodoMacro, NodoLlamadaFuncion
+
+
+macros = {}
 
 def registrar_macro(nodo: NodoMacro):
     """Registra una macro a partir de su nodo."""

--- a/backend/src/cobra/parser/parser.py
+++ b/backend/src/cobra/parser/parser.py
@@ -2,6 +2,7 @@
 
 import logging
 import json
+import os
 from cobra.lexico.lexer import TipoToken, Token
 
 from core.ast_nodes import (
@@ -45,6 +46,7 @@ from core.ast_nodes import (
 )
 
 from core import NodoYield
+
 
 # Palabras reservadas que no pueden usarse como identificadores
 PALABRAS_RESERVADAS = {
@@ -1145,7 +1147,6 @@ class ClassicParser:
 # Permitir seleccionar un parser alternativo basado en Lark mediante la variable
 # de entorno ``COBRA_PARSER``. Si su valor es ``"lark"`` se cargará
 # ``LarkParser`` en lugar del parser clásico.
-import os
 
 if os.getenv("COBRA_PARSER") == "lark":
     from src.cobra.parser.lark_parser import LarkParser


### PR DESCRIPTION
## Summary
- move `import os` to the top of `parser.py`
- place macro imports before the `macros` definition
- keep two blank lines after each import block

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and SyntaxError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_687fba1782508327919aabd374bbcc35