### PR TITLE
Remove unused transpiler imports

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/__init__.py
+++ b/backend/src/cobra/transpilers/transpiler/__init__.py
@@ -1,5 +1,3 @@
 """Herramientas para convertir el AST de Cobra a otros lenguajes."""
 
-# Exportar transpiladores básicos
-from src.cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
-from src.cobra.transpilers.transpiler.to_php import TranspiladorPHP
+# Este módulo define herramientas de transpilación a diferentes lenguajes.


### PR DESCRIPTION
## Summary
- remove unused TranspiladorRuby and TranspiladorPHP imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'corelibs', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687fbcc1acc483278d411895b8d39835