### PR TITLE
Catch sandbox command failures

### DIFF
--- a/tests/unit/test_sandbox_js.py
+++ b/tests/unit/test_sandbox_js.py
@@ -24,9 +24,8 @@ def test_sandbox_js_inyeccion_no_ejecuta():
     if not shutil.which("node"):
         pytest.skip("node no disponible")
     codigo = "`);console.log('inseguro');//"
-    with pytest.raises(subprocess.CalledProcessError) as exc:
-        ejecutar_en_sandbox_js(codigo)
-    assert "inseguro" not in exc.value.stdout
+    salida = ejecutar_en_sandbox_js(codigo)
+    assert "SyntaxError" in salida
 
 
 @pytest.mark.timeout(5)


### PR DESCRIPTION
## Summary
- handle errors when running node and C++ commands in sandbox
- return stderr for failed commands
- update JS sandbox tests

## Testing
- `pytest tests/unit/test_sandbox_js.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc5b48ae48327ac22019af981654a