### PR TITLE
Implement global and nonlocal for CPP transpiler

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/to_cpp.py
+++ b/backend/src/cobra/transpilers/transpiler/to_cpp.py
@@ -49,11 +49,13 @@ def visit_del(self, nodo):
 
 
 def visit_global(self, nodo):
-    pass
+    nombres = ", ".join(nodo.nombres)
+    self.agregar_linea(f"// global {nombres}")
 
 
 def visit_nolocal(self, nodo):
-    pass
+    nombres = ", ".join(nodo.nombres)
+    self.agregar_linea(f"// nonlocal {nombres}")
 
 
 def visit_with(self, nodo):
@@ -146,6 +148,7 @@ TranspiladorCPP.visit_assert = visit_assert
 TranspiladorCPP.visit_del = visit_del
 TranspiladorCPP.visit_global = visit_global
 TranspiladorCPP.visit_nolocal = visit_nolocal
+TranspiladorCPP.visit_no_local = visit_nolocal
 TranspiladorCPP.visit_with = visit_with
 TranspiladorCPP.visit_import_desde = visit_import_desde
 TranspiladorCPP.visit_switch = _visit_switch

--- a/tests/unit/test_to_cpp.py
+++ b/tests/unit/test_to_cpp.py
@@ -13,6 +13,8 @@ from core.ast_nodes import (
     NodoClase,
     NodoYield,
     NodoValor,
+    NodoGlobal,
+    NodoNoLocal,
 )
 
 
@@ -116,3 +118,17 @@ def test_transpilador_switch():
         "}"
     )
     assert resultado == esperado
+
+
+def test_transpilador_global():
+    ast = [NodoGlobal(["a", "b"])]
+    t = TranspiladorCPP()
+    resultado = t.generate_code(ast)
+    assert resultado == "// global a, b"
+
+
+def test_transpilador_nolocal():
+    ast = [NodoNoLocal(["x"])]
+    t = TranspiladorCPP()
+    resultado = t.generate_code(ast)
+    assert resultado == "// nonlocal x"

--- a/tests/unit/test_transpiladores_incompletos.py
+++ b/tests/unit/test_transpiladores_incompletos.py
@@ -18,7 +18,7 @@ class NodoDesconocido(NodoAST):
 
 def test_transpiladores_cpp_rust_global_vacio():
     ast = [NodoGlobal(["x"])]
-    assert TranspiladorCPP().generate_code(ast) == ""
+    assert TranspiladorCPP().generate_code(ast) == "// global x"
     assert TranspiladorRust().generate_code(ast) == ""
 
 


### PR DESCRIPTION
## Summary
- add C++ comment generation for `global` and `nonlocal`
- register alias `visit_no_local`
- test new behavior in `test_to_cpp.py`
- adjust `test_transpiladores_incompletos` expectation

## Testing
- `pytest tests/unit/test_to_cpp.py::test_transpilador_global -q`
- `pytest tests/unit/test_to_cpp.py::test_transpilador_nolocal -q`
- `pytest tests/unit/test_transpiladores_incompletos.py::test_transpiladores_cpp_rust_global_vacio -q`
- `pytest tests/unit/test_transpiladores_incompletos.py tests/unit/test_to_cpp.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68804b2da6348327a9601df1a0667e0f