### PR TITLE
Handle global and nonlocal in JS transpiler

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/to_js.py
+++ b/backend/src/cobra/transpilers/transpiler/to_js.py
@@ -78,11 +78,13 @@ def visit_del(self, nodo):
 
 
 def visit_global(self, nodo):
-    pass
+    nombres = ", ".join(nodo.nombres)
+    self.agregar_linea(f"// global {nombres}")
 
 
 def visit_nolocal(self, nodo):
-    pass
+    nombres = ", ".join(nodo.nombres)
+    self.agregar_linea(f"// nonlocal {nombres}")
 
 
 def visit_with(self, nodo):
@@ -221,6 +223,7 @@ TranspiladorJavaScript.visit_assert = visit_assert
 TranspiladorJavaScript.visit_del = visit_del
 TranspiladorJavaScript.visit_global = visit_global
 TranspiladorJavaScript.visit_nolocal = visit_nolocal
+TranspiladorJavaScript.visit_no_local = visit_nolocal
 TranspiladorJavaScript.visit_with = visit_with
 TranspiladorJavaScript.visit_import_desde = visit_import_desde
 

--- a/tests/unit/test_to_js.py
+++ b/tests/unit/test_to_js.py
@@ -18,6 +18,8 @@ from core.ast_nodes import (
     NodoPasar,
     NodoSwitch,
     NodoCase,
+    NodoGlobal,
+    NodoNoLocal,
     NodoImportDesde,
     NodoExport,
 )
@@ -172,3 +174,17 @@ def test_imports_js_por_defecto():
     resultado = TranspiladorJavaScript().generate_code([])
     esperado = "\n".join(get_standard_imports("js"))
     assert resultado == esperado
+
+
+def test_transpilador_global_js():
+    ast = [NodoGlobal(["a", "b"])]
+    t = TranspiladorJavaScript()
+    resultado = t.generate_code(ast)
+    assert resultado == IMPORTS + "// global a, b"
+
+
+def test_transpilador_nolocal_js():
+    ast = [NodoNoLocal(["x"])]
+    t = TranspiladorJavaScript()
+    resultado = t.generate_code(ast)
+    assert resultado == IMPORTS + "// nonlocal x"


### PR DESCRIPTION
## Summary
- implement `visit_global` and `visit_nolocal` for JavaScript transpiler
- expose `visit_no_local` alias
- add unit tests for global and nonlocal nodes in JS transpiler

## Testing
- `pytest tests/unit/test_to_js.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68804fa3af6083278961a0d2f3771d77