### PR TITLE
Implement global/nonlocal in Rust transpiler

### DIFF
--- a/backend/src/cobra/transpilers/transpiler/to_rust.py
+++ b/backend/src/cobra/transpilers/transpiler/to_rust.py
@@ -57,11 +57,19 @@ def visit_del(self, nodo):
 
 
 def visit_global(self, nodo):
-    pass
+    """Marca variables globales en Rust."""
+    nombres = ", ".join(nodo.nombres)
+    # En Rust no existe un equivalente directo a "global" de Python,
+    # por lo que se añade un comentario indicando su presencia.
+    self.agregar_linea(f"// global {nombres}")
 
 
 def visit_nolocal(self, nodo):
-    pass
+    """Marca variables no locales en Rust."""
+    nombres = ", ".join(nodo.nombres)
+    # Rust carece de un concepto equivalente a "nonlocal".
+    # Se inserta un comentario para mantener la información de ámbito.
+    self.agregar_linea(f"// nonlocal {nombres}")
 
 
 def visit_with(self, nodo):
@@ -159,6 +167,7 @@ TranspiladorRust.visit_assert = visit_assert
 TranspiladorRust.visit_del = visit_del
 TranspiladorRust.visit_global = visit_global
 TranspiladorRust.visit_nolocal = visit_nolocal
+TranspiladorRust.visit_no_local = visit_nolocal
 TranspiladorRust.visit_with = visit_with
 TranspiladorRust.visit_import_desde = visit_import_desde
 TranspiladorRust.visit_switch = _visit_switch

--- a/tests/unit/test_to_rust.py
+++ b/tests/unit/test_to_rust.py
@@ -22,6 +22,8 @@ from core.ast_nodes import (
     NodoOption,
     NodoSwitch,
     NodoCase,
+    NodoGlobal,
+    NodoNoLocal,
 )
 
 
@@ -228,4 +230,18 @@ def test_obtener_valor_listas_diccionarios():
         "let b = std::collections::HashMap::from([(x, 1)]);"
     )
     assert resultado == esperado
+
+
+def test_transpilador_global_rust():
+    ast = [NodoGlobal(["a", "b"])]
+    t = TranspiladorRust()
+    resultado = t.generate_code(ast)
+    assert resultado == "// global a, b"
+
+
+def test_transpilador_nolocal_rust():
+    ast = [NodoNoLocal(["x"])]
+    t = TranspiladorRust()
+    resultado = t.generate_code(ast)
+    assert resultado == "// nonlocal x"
 

--- a/tests/unit/test_transpiladores_incompletos.py
+++ b/tests/unit/test_transpiladores_incompletos.py
@@ -19,7 +19,7 @@ class NodoDesconocido(NodoAST):
 def test_transpiladores_cpp_rust_global_vacio():
     ast = [NodoGlobal(["x"])]
     assert TranspiladorCPP().generate_code(ast) == "// global x"
-    assert TranspiladorRust().generate_code(ast) == ""
+    assert TranspiladorRust().generate_code(ast) == "// global x"
 
 
 def test_transpilador_js_nodo_invalido_attribute_error():


### PR DESCRIPTION
## Summary
- handle `global` and `nolocal` in Rust transpiler using comments
- add alias `visit_no_local` for compatibility
- add tests for Rust global/nonlocal support
- update expected output in incomplete transpilers test

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/unit/test_to_rust.py::test_transpilador_global_rust -q`
- `pytest tests/unit/test_to_rust.py::test_transpilador_nolocal_rust -q`
- `pytest tests/unit/test_transpiladores_incompletos.py::test_transpiladores_cpp_rust_global_vacio -q`
- `pytest tests/unit/test_to_rust.py -q`
- `pytest tests/unit/test_transpiladores_incompletos.py -q`
- `pytest tests/unit/test_to_cpp.py::test_transpilador_global -q`
- `pytest tests/unit/test_to_cpp.py::test_transpilador_nolocal -q`


------
https://chatgpt.com/codex/tasks/task_e_68805b868f14832785db41d714e659cc