### PR TITLE
Add basic Kotlin transpiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Versión 9.1.0
 
 [English version available here](README_en.md)
-Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
+Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
 
 ## Tabla de Contenidos
@@ -436,7 +436,7 @@ para var i en rango(2) :
 '''
 ````
 
-Al generar código para Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. En Rust se produce código equivalente con `println!`, `while` y `for`. En C++ se obtienen construcciones con `std::cout`, `while` y `for`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust o `holobit({ ... })` en C++. En Go se genera `fmt.Println`, en R se usa `print` y en Julia `println`; en Java se usa `System.out.println`, en COBOL `DISPLAY`, en Fortran `print *` y en Pascal `writeln`, en Ruby `puts`, en PHP `echo`, en Matlab `disp` y en LaTeX `\texttt{}`.
+Al generar código para Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. En Rust se produce código equivalente con `println!`, `while` y `for`. En C++ se obtienen construcciones con `std::cout`, `while` y `for`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust o `holobit({ ... })` en C++. En Go se genera `fmt.Println`, en Kotlin `println`, en R se usa `print` y en Julia `println`; en Java se usa `System.out.println`, en COBOL `DISPLAY`, en Fortran `print *` y en Pascal `writeln`, en Ruby `puts`, en PHP `echo`, en Matlab `disp` y en LaTeX `\texttt{}`.
 
 ## Integración con holobit-sdk
 
@@ -501,7 +501,7 @@ editar `cobra.mod` y volver a ejecutar las pruebas.
 ## Invocar el transpilador
 
 La carpeta [`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler)
-contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX. Una vez
+contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX. Una vez
 instaladas las dependencias, puedes llamar al transpilador desde tu propio
 script de la siguiente manera:
 
@@ -567,7 +567,7 @@ Al generar código para estas funciones, se crean llamadas `asyncio.create_task`
 Una vez instalado el paquete, la herramienta `cobra` ofrece varios subcomandos:
 
 ```bash
-# Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab o LaTeX
+# Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab o LaTeX
 cobra compilar programa.co --tipo python
 
 # Ejemplo de mensaje de error al compilar un archivo inexistente
@@ -966,7 +966,7 @@ Este proyecto está bajo la [Licencia MIT](LICENSE).
 
 ### Notas
 
-- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal y PHP.
+- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, R, Julia, Java, COBOL, Fortran, Pascal y PHP.
 - **Ejemplos de Código y Nuevas Estructuras**: Incluye ejemplos con el uso de estructuras avanzadas como clases y diccionarios en el lenguaje Cobra.
 
 Si deseas agregar o modificar algo, házmelo saber.

--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -12,6 +12,7 @@ from cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
 from cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
 from cobra.transpilers.transpiler.to_go import TranspiladorGo
 from cobra.transpilers.transpiler.to_java import TranspiladorJava
+from cobra.transpilers.transpiler.to_kotlin import TranspiladorKotlin
 from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 from cobra.transpilers.transpiler.to_julia import TranspiladorJulia
 from cobra.transpilers.transpiler.to_latex import TranspiladorLatex
@@ -47,6 +48,7 @@ TRANSPILERS = {
     "cpp": TranspiladorCPP,
     "c": TranspiladorC,
     "go": TranspiladorGo,
+    "kotlin": TranspiladorKotlin,
     "ruby": TranspiladorRuby,
     "r": TranspiladorR,
     "julia": TranspiladorJulia,

--- a/backend/src/cobra/transpilers/transpiler/to_kotlin.py
+++ b/backend/src/cobra/transpilers/transpiler/to_kotlin.py
@@ -1,0 +1,102 @@
+"""Transpilador sencillo de Cobra a Kotlin."""
+
+from core.ast_nodes import (
+    NodoValor,
+    NodoIdentificador,
+    NodoLlamadaFuncion,
+    NodoAsignacion,
+    NodoFuncion,
+    NodoImprimir,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoAtributo,
+)
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
+from src.cobra.transpilers.base import BaseTranspiler
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
+
+
+def visit_asignacion(self, nodo: NodoAsignacion):
+    nombre = getattr(nodo, "identificador", nodo.variable)
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"var {nombre} = {valor}")
+
+
+def visit_funcion(self, nodo: NodoFuncion):
+    params = ", ".join(nodo.parametros)
+    self.agregar_linea(f"fun {nodo.nombre}({params}) {{")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+
+
+def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"{nodo.nombre}({args})")
+
+
+def visit_imprimir(self, nodo: NodoImprimir):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"println({valor})")
+
+
+kotlin_nodes = {
+    "asignacion": visit_asignacion,
+    "funcion": visit_funcion,
+    "llamada_funcion": visit_llamada_funcion,
+    "imprimir": visit_imprimir,
+}
+
+
+class TranspiladorKotlin(BaseTranspiler):
+    def __init__(self):
+        self.codigo = []
+        self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
+
+    def agregar_linea(self, linea: str) -> None:
+        self.codigo.append("    " * self.indent + linea)
+
+    def obtener_valor(self, nodo):
+        if isinstance(nodo, NodoValor):
+            return str(nodo.valor)
+        elif isinstance(nodo, NodoIdentificador):
+            return nodo.nombre
+        elif isinstance(nodo, NodoAtributo):
+            return f"{self.obtener_valor(nodo.objeto)}.{nodo.nombre}"
+        elif isinstance(nodo, NodoLlamadaFuncion):
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"{nodo.nombre}({args})"
+        elif isinstance(nodo, NodoOperacionBinaria):
+            izq = self.obtener_valor(nodo.izquierda)
+            der = self.obtener_valor(nodo.derecha)
+            op_map = {TipoToken.AND: "&&", TipoToken.OR: "||"}
+            op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
+            return f"{izq} {op} {der}"
+        elif isinstance(nodo, NodoOperacionUnaria):
+            val = self.obtener_valor(nodo.operando)
+            op = "!" if nodo.operador.tipo == TipoToken.NOT else nodo.operador.valor
+            return f"{op}{val}" if op != "!" else f"!{val}"
+        else:
+            return str(getattr(nodo, "valor", nodo))
+
+    def transpilar(self, nodos):
+        nodos = expandir_macros(nodos)
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
+        for nodo in nodos:
+            nombre = self._camel_to_snake(nodo.__class__.__name__)
+            metodo = getattr(self, f"visit_{nombre}", None)
+            if metodo:
+                metodo(nodo)
+        return "\n".join(self.codigo)
+
+
+for nombre, funcion in kotlin_nodes.items():
+    setattr(TranspiladorKotlin, f"visit_{nombre}", funcion)

--- a/docs/arquitectura_parser_transpiladores.md
+++ b/docs/arquitectura_parser_transpiladores.md
@@ -11,7 +11,7 @@ Se encarga de leer el texto fuente y convertirlo en una secuencia de *tokens*. C
 Consume los tokens generados por el lexer y construye el \u00c1rbol de Sintaxis Abstracta (**AST**). El parser valida la estructura del programa y crea los nodos que representar\u00e1n instrucciones, expresiones y declaraciones.
 
 ### `transpilers`
-Una vez disponible el AST, los transpiladores recorren cada nodo mediante el patr\u00f3n *Visitor* para generar c\u00f3digo en otros lenguajes. Cobra incluye transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX.
+Una vez disponible el AST, los transpiladores recorren cada nodo mediante el patr\u00f3n *Visitor* para generar c\u00f3digo en otros lenguajes. Cobra incluye transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Matlab y LaTeX.
 
 ## Interacci\u00f3n general
 El proceso habitual comienza con el lexer, sigue con el parser y finaliza en el int\u00e9rprete o en alguno de los transpiladores. La siguiente gr\u00e1fica resume dicho flujo.

--- a/tests/unit/test_to_kotlin.py
+++ b/tests/unit/test_to_kotlin.py
@@ -1,0 +1,31 @@
+from cobra.transpilers.transpiler.to_kotlin import TranspiladorKotlin
+from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+
+
+def test_transpilador_asignacion_kotlin():
+    ast = [NodoAsignacion("x", 10)]
+    t = TranspiladorKotlin()
+    resultado = t.generate_code(ast)
+    assert resultado == "var x = 10"
+
+
+def test_transpilador_funcion_kotlin():
+    ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
+    t = TranspiladorKotlin()
+    resultado = t.generate_code(ast)
+    esperado = "fun miFuncion(a, b) {\n    var x = a + b\n}"
+    assert resultado == esperado
+
+
+def test_transpilador_llamada_funcion_kotlin():
+    ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
+    t = TranspiladorKotlin()
+    resultado = t.generate_code(ast)
+    assert resultado == "miFuncion(a, b)"
+
+
+def test_transpilador_imprimir_kotlin():
+    ast = [NodoImprimir(NodoValor("x"))]
+    t = TranspiladorKotlin()
+    resultado = t.generate_code(ast)
+    assert resultado == "println(x)"


### PR DESCRIPTION
## Summary
- add `TranspiladorKotlin` for assignments, function definitions, calls and prints
- integrate new transpiler in compile command
- document Kotlin support
- include unit tests for `to_kotlin` transpiler

## Testing
- `pytest tests/unit/test_to_kotlin.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880639f1bc083278eaeda67e2c05443