### PR TITLE
Add Visual Basic transpiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Versión 9.1.0
 
 [English version available here](README_en.md)
-Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, Matlab y LaTeX, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
+Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab y LaTeX, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
 
 ## Tabla de Contenidos
@@ -227,7 +227,7 @@ El proyecto se organiza en las siguientes carpetas y módulos:
 # Características Principales
 
 - Lexer y Parser: Implementación de un lexer para la tokenización del código fuente y un parser para la construcción de un árbol de sintaxis abstracta (AST).
-- Transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, Matlab y LaTeX: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
+- Transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab y LaTeX: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
 - Soporte de Estructuras Avanzadas: Permite la declaración de variables, funciones, clases, listas y diccionarios, así como el uso de bucles y condicionales.
 - Módulos nativos con funciones de E/S, utilidades matemáticas y estructuras de datos para usar directamente desde Cobra.
 - Instalación de paquetes en tiempo de ejecución mediante la instrucción `usar`.
@@ -436,7 +436,7 @@ para var i en rango(2) :
 '''
 ````
 
-Al generar código para Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. En Rust se produce código equivalente con `println!`, `while` y `for`. En C++ se obtienen construcciones con `std::cout`, `while` y `for`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust o `holobit({ ... })` en C++. En Go se genera `fmt.Println`, en Kotlin `println`, en Swift `print`, en R se usa `print` y en Julia `println`; en Java se usa `System.out.println`, en COBOL `DISPLAY`, en Fortran `print *` y en Pascal `writeln`, en Ruby `puts`, en PHP `echo`, en Matlab `disp` y en LaTeX `\texttt{}`.
+Al generar código para Python, `imprimir` se convierte en `print`, `mientras` en `while` y `para` en `for`. En JavaScript estos elementos se transforman en `console.log`, `while` y `for...of` respectivamente. Para el modo ensamblador se generan instrucciones `PRINT`, `WHILE` y `FOR`. En Rust se produce código equivalente con `println!`, `while` y `for`. En C++ se obtienen construcciones con `std::cout`, `while` y `for`. El tipo `holobit` se traduce a la llamada `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust o `holobit({ ... })` en C++. En Go se genera `fmt.Println`, en Kotlin `println`, en Swift `print`, en R se usa `print` y en Julia `println`; en Java se usa `System.out.println`, en COBOL `DISPLAY`, en Fortran `print *` y en Pascal `writeln`, en VisualBasic `Console.WriteLine`, en Ruby `puts`, en PHP `echo`, en Matlab `disp` y en LaTeX `\texttt{}`.
 
 ## Integración con holobit-sdk
 
@@ -501,7 +501,7 @@ editar `cobra.mod` y volver a ejecutar las pruebas.
 ## Invocar el transpilador
 
 La carpeta [`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler)
-contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, Matlab y LaTeX. Una vez
+contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab y LaTeX. Una vez
 instaladas las dependencias, puedes llamar al transpilador desde tu propio
 script de la siguiente manera:
 
@@ -567,7 +567,7 @@ Al generar código para estas funciones, se crean llamadas `asyncio.create_task`
 Una vez instalado el paquete, la herramienta `cobra` ofrece varios subcomandos:
 
 ```bash
-# Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, Matlab o LaTeX
+# Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab o LaTeX
 cobra compilar programa.co --tipo python
 
 # Ejemplo de mensaje de error al compilar un archivo inexistente
@@ -966,7 +966,7 @@ Este proyecto está bajo la [Licencia MIT](LICENSE).
 
 ### Notas
 
-- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal y PHP.
+- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, VisualBasic y PHP.
 - **Ejemplos de Código y Nuevas Estructuras**: Incluye ejemplos con el uso de estructuras avanzadas como clases y diccionarios en el lenguaje Cobra.
 
 Si deseas agregar o modificar algo, házmelo saber.

--- a/README_en.md
+++ b/README_en.md
@@ -4,7 +4,7 @@
 
 Version 9.1.0
 
-Cobra is a programming language designed in Spanish, aimed at creating tools, simulations and analyses in fields such as biology, computing and astrophysics. This project includes a lexer, parser and transpilers to Python, JavaScript, assembly, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, Matlab and LaTeX, allowing greater versatility when running and deploying Cobra code.
+Cobra is a programming language designed in Spanish, aimed at creating tools, simulations and analyses in fields such as biology, computing and astrophysics. This project includes a lexer, parser and transpilers to Python, JavaScript, assembly, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab and LaTeX, allowing greater versatility when running and deploying Cobra code.
 
 ## Table of Contents
 
@@ -194,7 +194,7 @@ The project is organized into the following folders and modules:
 # Main Features
 
 - Lexer and Parser: Implementation of a lexer to tokenize the source code and a parser to build an abstract syntax tree (AST).
-- Transpilers to Python, JavaScript, assembly, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, Matlab and LaTeX: Cobra can convert code to these languages, facilitating integration with external applications.
+- Transpilers to Python, JavaScript, assembly, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab and LaTeX: Cobra can convert code to these languages, facilitating integration with external applications.
 - Support for advanced structures: declaration of variables, functions, classes, lists and dictionaries, as well as loops and conditionals.
 - Native modules with I/O functions, math utilities and data structures ready to use from Cobra.
 - Runtime package installation via the `usar` instruction.
@@ -372,7 +372,7 @@ If an entry is not found, the transpiler will load the file indicated in the `im
 
 ## Calling the transpiler
 
-The folder [`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler) contains the implementation of the transpilers to Python, JavaScript, assembly, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, Matlab and LaTeX. Once the dependencies are installed you can call the transpiler from your own script like this:
+The folder [`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler) contains the implementation of the transpilers to Python, JavaScript, assembly, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab and LaTeX. Once the dependencies are installed you can call the transpiler from your own script like this:
 
 ```python
 from cobra.transpilers.transpiler.to_python import TranspiladorPython

--- a/backend/src/cli/commands/compile_cmd.py
+++ b/backend/src/cli/commands/compile_cmd.py
@@ -20,6 +20,7 @@ from cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
 from cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
 from cobra.transpilers.transpiler.to_php import TranspiladorPHP
 from cobra.transpilers.transpiler.to_perl import TranspiladorPerl
+from cobra.transpilers.transpiler.to_visualbasic import TranspiladorVisualBasic
 from cobra.transpilers.transpiler.to_python import TranspiladorPython
 from cobra.transpilers.transpiler.to_r import TranspiladorR
 from cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
@@ -61,6 +62,7 @@ TRANSPILERS = {
     "pascal": TranspiladorPascal,
     "php": TranspiladorPHP,
     "perl": TranspiladorPerl,
+    "visualbasic": TranspiladorVisualBasic,
     "matlab": TranspiladorMatlab,
     "latex": TranspiladorLatex,
     "wasm": TranspiladorWasm,
@@ -88,7 +90,7 @@ class CompileCommand(BaseCommand):
 
     Soporta Python, JavaScript, ensamblador, Rust, C++, C, Go, Kotlin, Swift,
     R, Julia, Ruby, PHP, Java y ahora también COBOL, Fortran, Pascal,
-    Matlab, LaTeX y WebAssembly.
+    VisualBasic, Matlab, LaTeX y WebAssembly.
     """
 
     name = "compilar"

--- a/backend/src/cobra/transpilers/import_helper.py
+++ b/backend/src/cobra/transpilers/import_helper.py
@@ -29,6 +29,7 @@ STANDARD_IMPORTS = {
     ],
     "swift": [],
     "perl": [],
+    "visualbasic": [],
 }
 
 

--- a/backend/src/cobra/transpilers/transpiler/to_visualbasic.py
+++ b/backend/src/cobra/transpilers/transpiler/to_visualbasic.py
@@ -1,0 +1,108 @@
+"""Transpilador simple de Cobra a Visual Basic."""
+
+from core.ast_nodes import (
+    NodoValor,
+    NodoIdentificador,
+    NodoLlamadaFuncion,
+    NodoAsignacion,
+    NodoFuncion,
+    NodoImprimir,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoAtributo,
+)
+from cobra.lexico.lexer import TipoToken
+from core.visitor import NodeVisitor
+from src.cobra.transpilers.base import BaseTranspiler
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
+
+
+def visit_asignacion(self, nodo: NodoAsignacion):
+    nombre_raw = getattr(nodo, "identificador", getattr(nodo, "variable", None))
+    if isinstance(nombre_raw, NodoAtributo):
+        nombre = self.obtener_valor(nombre_raw)
+    else:
+        nombre = nombre_raw
+    valor = getattr(nodo, "expresion", getattr(nodo, "valor", None))
+    self.agregar_linea(f"Dim {nombre} = {self.obtener_valor(valor)}")
+
+
+def visit_funcion(self, nodo: NodoFuncion):
+    params = ", ".join(nodo.parametros)
+    self.agregar_linea(f"Sub {nodo.nombre}({params})")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("End Sub")
+
+
+def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"{nodo.nombre}({args})")
+
+
+def visit_imprimir(self, nodo: NodoImprimir):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"Console.WriteLine({valor})")
+
+
+vb_nodes = {
+    "asignacion": visit_asignacion,
+    "funcion": visit_funcion,
+    "llamada_funcion": visit_llamada_funcion,
+    "imprimir": visit_imprimir,
+}
+
+
+class TranspiladorVisualBasic(BaseTranspiler):
+    """Transpila el AST de Cobra a un Visual Basic muy básico."""
+
+    def __init__(self):
+        self.codigo = []
+        self.indent = 0
+
+    def generate_code(self, ast):
+        self.codigo = self.transpilar(ast)
+        return self.codigo
+
+    def agregar_linea(self, linea: str) -> None:
+        self.codigo.append("    " * self.indent + linea)
+
+    def obtener_valor(self, nodo):
+        if isinstance(nodo, NodoValor):
+            return str(nodo.valor)
+        elif isinstance(nodo, NodoIdentificador):
+            return nodo.nombre
+        elif isinstance(nodo, NodoAtributo):
+            return f"{self.obtener_valor(nodo.objeto)}.{nodo.nombre}"
+        elif isinstance(nodo, NodoLlamadaFuncion):
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"{nodo.nombre}({args})"
+        elif isinstance(nodo, NodoOperacionBinaria):
+            izq = self.obtener_valor(nodo.izquierda)
+            der = self.obtener_valor(nodo.derecha)
+            op_map = {TipoToken.AND: "And", TipoToken.OR: "Or"}
+            op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
+            return f"{izq} {op} {der}"
+        elif isinstance(nodo, NodoOperacionUnaria):
+            val = self.obtener_valor(nodo.operando)
+            op = "Not" if nodo.operador.tipo == TipoToken.NOT else nodo.operador.valor
+            return f"{op} {val}" if op == "Not" else f"{op}{val}"
+        else:
+            return str(getattr(nodo, "valor", nodo))
+
+    def transpilar(self, nodos):
+        nodos = expandir_macros(nodos)
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
+        for nodo in nodos:
+            nombre = self._camel_to_snake(nodo.__class__.__name__)
+            metodo = getattr(self, f"visit_{nombre}", None)
+            if metodo:
+                metodo(nodo)
+        return "\n".join(self.codigo)
+
+
+for nombre, funcion in vb_nodes.items():
+    setattr(TranspiladorVisualBasic, f"visit_{nombre}", funcion)

--- a/docs/arquitectura_parser_transpiladores.md
+++ b/docs/arquitectura_parser_transpiladores.md
@@ -11,7 +11,7 @@ Se encarga de leer el texto fuente y convertirlo en una secuencia de *tokens*. C
 Consume los tokens generados por el lexer y construye el \u00c1rbol de Sintaxis Abstracta (**AST**). El parser valida la estructura del programa y crea los nodos que representar\u00e1n instrucciones, expresiones y declaraciones.
 
 ### `transpilers`
-Una vez disponible el AST, los transpiladores recorren cada nodo mediante el patr\u00f3n *Visitor* para generar c\u00f3digo en otros lenguajes. Cobra incluye transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, Matlab y LaTeX.
+Una vez disponible el AST, los transpiladores recorren cada nodo mediante el patr\u00f3n *Visitor* para generar c\u00f3digo en otros lenguajes. Cobra incluye transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab y LaTeX.
 
 ## Interacci\u00f3n general
 El proceso habitual comienza con el lexer, sigue con el parser y finaliza en el int\u00e9rprete o en alguno de los transpiladores. La siguiente gr\u00e1fica resume dicho flujo.

--- a/docs/estructura_ast.md
+++ b/docs/estructura_ast.md
@@ -71,6 +71,7 @@ Transpiladores --> Java
 Transpiladores --> COBOL
 Transpiladores --> Fortran
 Transpiladores --> Pascal
+Transpiladores --> VisualBasic
 Transpiladores --> Ruby
 Transpiladores --> PHP
 Transpiladores --> Perl

--- a/docs/lenguajes.rst
+++ b/docs/lenguajes.rst
@@ -39,6 +39,8 @@ detalles consulta :doc:`../frontend/docs/backends` y la sección
      - Parcial
    * - Pascal
      - Parcial
+   * - VisualBasic
+     - Parcial
    * - Ruby
      - Parcial
    * - PHP

--- a/docs/lenguajes_soportados.rst
+++ b/docs/lenguajes_soportados.rst
@@ -39,6 +39,8 @@ detalles consulta :doc:`../frontend/docs/backends` y la sección
      - Parcial
    * - Pascal
      - Parcial
+   * - VisualBasic
+     - Parcial
    * - Ruby
      - Parcial
    * - PHP

--- a/tests/unit/test_to_visualbasic.py
+++ b/tests/unit/test_to_visualbasic.py
@@ -1,0 +1,38 @@
+from cobra.transpilers.transpiler.to_visualbasic import TranspiladorVisualBasic
+from core.ast_nodes import (
+    NodoAsignacion,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoImprimir,
+    NodoValor,
+    NodoIdentificador,
+)
+
+
+def test_transpilador_asignacion_vb():
+    ast = [NodoAsignacion("x", 10)]
+    t = TranspiladorVisualBasic()
+    resultado = t.generate_code(ast)
+    assert resultado == "Dim x = 10"
+
+
+def test_transpilador_funcion_vb():
+    ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", NodoIdentificador("a"))])]
+    t = TranspiladorVisualBasic()
+    resultado = t.generate_code(ast)
+    esperado = "Sub miFuncion(a, b)\n    Dim x = a\nEnd Sub"
+    assert resultado == esperado
+
+
+def test_transpilador_llamada_funcion_vb():
+    ast = [NodoLlamadaFuncion("miFuncion", [NodoIdentificador("x"), NodoValor(3)])]
+    t = TranspiladorVisualBasic()
+    resultado = t.generate_code(ast)
+    assert resultado == "miFuncion(x, 3)"
+
+
+def test_transpilador_imprimir_vb():
+    ast = [NodoImprimir(NodoIdentificador("x"))]
+    t = TranspiladorVisualBasic()
+    resultado = t.generate_code(ast)
+    assert resultado == "Console.WriteLine(x)"


### PR DESCRIPTION
## Summary
- implement Visual Basic transpiler with minimal visitors
- register the new transpiler in CLI compile command
- document Visual Basic support
- support standard imports
- add unit tests for the Visual Basic transpiler

## Testing
- `pytest -q tests/unit/test_to_visualbasic.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tomli')*

------
https://chatgpt.com/codex/tasks/task_e_6880cbb20d148327a010057d5055dd19