### PR TITLE
Update docs with new transpilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,10 @@ from cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
 from cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
 from cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
 from cobra.transpilers.transpiler.to_php import TranspiladorPHP
+from cobra.transpilers.transpiler.to_perl import TranspiladorPerl
+from cobra.transpilers.transpiler.to_visualbasic import TranspiladorVisualBasic
+from cobra.transpilers.transpiler.to_kotlin import TranspiladorKotlin
+from cobra.transpilers.transpiler.to_swift import TranspiladorSwift
 from cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
 from cobra.transpilers.transpiler.to_mojo import TranspiladorMojo
 from cobra.transpilers.transpiler.to_latex import TranspiladorLatex
@@ -534,6 +538,10 @@ codigo_fortran = TranspiladorFortran().generate_code(arbol)
 codigo_pascal = TranspiladorPascal().generate_code(arbol)
 codigo_ruby = TranspiladorRuby().generate_code(arbol)
 codigo_php = TranspiladorPHP().generate_code(arbol)
+codigo_perl = TranspiladorPerl().generate_code(arbol)
+codigo_visualbasic = TranspiladorVisualBasic().generate_code(arbol)
+codigo_kotlin = TranspiladorKotlin().generate_code(arbol)
+codigo_swift = TranspiladorSwift().generate_code(arbol)
 codigo_matlab = TranspiladorMatlab().generate_code(arbol)
 codigo_mojo = TranspiladorMojo().generate_code(arbol)
 codigo_latex = TranspiladorLatex().generate_code(arbol)
@@ -968,7 +976,7 @@ Este proyecto está bajo la [Licencia MIT](LICENSE).
 
 ### Notas
 
-- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, VisualBasic y PHP.
+- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX.
 - **Ejemplos de Código y Nuevas Estructuras**: Incluye ejemplos con el uso de estructuras avanzadas como clases y diccionarios en el lenguaje Cobra.
 
 Si deseas agregar o modificar algo, házmelo saber.

--- a/README_en.md
+++ b/README_en.md
@@ -4,7 +4,7 @@
 
 Version 9.1.0
 
-Cobra is a programming language designed in Spanish, aimed at creating tools, simulations and analyses in fields such as biology, computing and astrophysics. This project includes a lexer, parser and transpilers to Python, JavaScript, assembly, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo and LaTeX, allowing greater versatility when running and deploying Cobra code.
+Cobra is a programming language designed in Spanish, aimed at creating tools, simulations and analyses in fields such as biology, computing and astrophysics. This project includes a lexer, parser and transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo and LaTeX, allowing greater versatility when running and deploying Cobra code.
 
 ## Table of Contents
 
@@ -194,7 +194,7 @@ The project is organized into the following folders and modules:
 # Main Features
 
 - Lexer and Parser: Implementation of a lexer to tokenize the source code and a parser to build an abstract syntax tree (AST).
-- Transpilers to Python, JavaScript, assembly, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo and LaTeX: Cobra can convert code to these languages, facilitating integration with external applications.
+- Transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo and LaTeX: Cobra can convert code to these languages, facilitating integration with external applications.
 - Support for advanced structures: declaration of variables, functions, classes, lists and dictionaries, as well as loops and conditionals.
 - Native modules with I/O functions, math utilities and data structures ready to use from Cobra.
 - Runtime package installation via the `usar` instruction.
@@ -372,7 +372,7 @@ If an entry is not found, the transpiler will load the file indicated in the `im
 
 ## Calling the transpiler
 
-The folder [`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler) contains the implementation of the transpilers to Python, JavaScript, assembly, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo and LaTeX. Once the dependencies are installed you can call the transpiler from your own script like this:
+The folder [`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler) contains the implementation of the transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo and LaTeX. Once the dependencies are installed you can call the transpiler from your own script like this:
 
 ```python
 from cobra.transpilers.transpiler.to_python import TranspiladorPython
@@ -394,6 +394,10 @@ from cobra.transpilers.transpiler.to_fortran import TranspiladorFortran
 from cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
 from cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
 from cobra.transpilers.transpiler.to_php import TranspiladorPHP
+from cobra.transpilers.transpiler.to_perl import TranspiladorPerl
+from cobra.transpilers.transpiler.to_visualbasic import TranspiladorVisualBasic
+from cobra.transpilers.transpiler.to_kotlin import TranspiladorKotlin
+from cobra.transpilers.transpiler.to_swift import TranspiladorSwift
 from cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
 from cobra.transpilers.transpiler.to_mojo import TranspiladorMojo
 from cobra.transpilers.transpiler.to_latex import TranspiladorLatex
@@ -403,6 +407,10 @@ codigo_fortran = TranspiladorFortran().generate_code(arbol)
 codigo_pascal = TranspiladorPascal().generate_code(arbol)
 codigo_ruby = TranspiladorRuby().generate_code(arbol)
 codigo_php = TranspiladorPHP().generate_code(arbol)
+codigo_perl = TranspiladorPerl().generate_code(arbol)
+codigo_visualbasic = TranspiladorVisualBasic().generate_code(arbol)
+codigo_kotlin = TranspiladorKotlin().generate_code(arbol)
+codigo_swift = TranspiladorSwift().generate_code(arbol)
 codigo_matlab = TranspiladorMatlab().generate_code(arbol)
 codigo_mojo = TranspiladorMojo().generate_code(arbol)
 codigo_latex = TranspiladorLatex().generate_code(arbol)

--- a/docs/estructura_ast.md
+++ b/docs/estructura_ast.md
@@ -65,6 +65,8 @@ Transpiladores --> ASM
 Transpiladores --> Rust
 Transpiladores --> "C++"
 Transpiladores --> Go
+Transpiladores --> Kotlin
+Transpiladores --> Swift
 Transpiladores --> R
 Transpiladores --> Julia
 Transpiladores --> Java

--- a/docs/lenguajes.rst
+++ b/docs/lenguajes.rst
@@ -27,6 +27,10 @@ detalles consulta :doc:`../frontend/docs/backends` y la sección
      - Experimental
    * - Go
      - Parcial
+   * - Kotlin
+     - Parcial
+   * - Swift
+     - Parcial
    * - R
      - Parcial
    * - Julia

--- a/docs/lenguajes_soportados.rst
+++ b/docs/lenguajes_soportados.rst
@@ -27,6 +27,10 @@ detalles consulta :doc:`../frontend/docs/backends` y la sección
      - Experimental
    * - Go
      - Parcial
+   * - Kotlin
+     - Parcial
+   * - Swift
+     - Parcial
    * - R
      - Parcial
    * - Julia

--- a/frontend/docs/arquitectura.rst
+++ b/frontend/docs/arquitectura.rst
@@ -15,7 +15,7 @@ Command (ver :ref:`patron_command`).
 Core
 ----
 Contiene el corazón del lenguaje: lexer, parser, intérprete y
-transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, Matlab y LaTeX. Estos elementos trabajan en
+transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX. Estos elementos trabajan en
 conjunto para analizar el código fuente y transformarlo en otras
 representaciones o ejecutarlo de forma directa.
 Las clases que componen el AST se definen en ``src.core.ast_nodes`` para facilitar su reutilización.
@@ -62,7 +62,7 @@ optimizar el rendimiento y evitar fugas de memoria.
        CLI -> Lexer;
    Interprete -> Memoria;
    Interprete -> ModulosNativos;
-   Transpiladores -> {Python JS Asm Rust Cpp Go R Julia Java COBOL Fortran Pascal Ruby PHP Matlab LaTeX};
+   Transpiladores -> {Python JS Asm Rust Cpp Go Kotlin Swift R Julia Java COBOL Fortran Pascal Ruby PHP Perl VisualBasic Matlab Mojo LaTeX};
    }
  
 Interacción de los módulos

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -5,7 +5,7 @@ Avances del lenguaje Cobra
 - **Lexer y Parser funcionales**: El sistema lexico y sintactico esta completamente implementado y es capaz de procesar asignaciones de variables, funciones, condicionales, bucles y operaciones de holobits.
 - **Holobits**: Tipo de dato especial para trabajar con informacion multidimensional, con soporte para operaciones como proyecciones, transformaciones y visualizacion.
 - **Gestión de memoria automatizada**: Cobra incluye un sistema de manejo de memoria optimizado que se ajusta automáticamente utilizando algoritmos genéticos.
-- **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, Matlab y LaTeX.
+- **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX.
 - **Pruebas unitarias**: Se han creado pruebas para validar el correcto funcionamiento del lexer y el parser.
 
  - **Versión 9.1.0**: Actualización de la documentación y configuración del proyecto.

--- a/frontend/docs/caracteristicas.rst
+++ b/frontend/docs/caracteristicas.rst
@@ -4,7 +4,7 @@ Caracteristicas principales de Cobra
 - **Sintaxis en espanol**: Todas las palabras clave y estructuras del lenguaje estan en español, para facilitar su uso por hablantes nativos.
 - **Gestion de memoria automatica**: Cobra incorpora un sistema de manejo de memoria basado en algoritmos genéticos que optimiza el uso de los recursos durante la ejecución.
 - **Soporte para holobits**: Un tipo de dato multidimensional que permite trabajar con datos de alta complejidad.
-- **Transpiler a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, Matlab y LaTeX**: Los programas escritos en Cobra pueden ser transpilados a estos lenguajes, lo que permite su ejecucion en una variedad de plataformas.
+- **Transpiler a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX**: Los programas escritos en Cobra pueden ser transpilados a estos lenguajes, lo que permite su ejecucion en una variedad de plataformas.
 - **Nombres Unicode**: Los identificadores aceptan caracteres como `á`, `ñ` o `Ω`.
 
 **Ejemplo basico**

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -56,7 +56,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
 Introducción
 --------------------
 
-Cobra fue creado con la idea de facilitar la programacion en español, optimizando la gestion de memoria y anadiendo soporte para trabajar con datos de alta complejidad como los holobits. Ademas, ofrece soporte para generar código en Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, Matlab y LaTeX, permitiendo su ejecucion en multiples plataformas.
+Cobra fue creado con la idea de facilitar la programacion en español, optimizando la gestion de memoria y anadiendo soporte para trabajar con datos de alta complejidad como los holobits. Ademas, ofrece soporte para generar código en Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX, permitiendo su ejecucion en multiples plataformas.
 
 
 

--- a/frontend/docs/optimizaciones.rst
+++ b/frontend/docs/optimizaciones.rst
@@ -19,7 +19,7 @@ Eliminación de subexpresiones comunes
 ------------------------------------
 ``eliminate_common_subexpressions`` detecta expresiones idénticas que se repiten dentro de una misma función o en el nivel global. Dichas expresiones se calculan una única vez asignándose a una variable temporal y las repeticiones se reemplazan por el identificador generado.
 
-Estas optimizaciones se aplican automáticamente antes de ejecutar el intérprete y en los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, Matlab y LaTeX.
+Estas optimizaciones se aplican automáticamente antes de ejecutar el intérprete y en los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX.
 
 Decoradores de rendimiento (``smooth-criminal``)
 ------------------------------------------------

--- a/frontend/docs/sintaxis.rst
+++ b/frontend/docs/sintaxis.rst
@@ -98,9 +98,9 @@ Puedes anteponer `@` a una función para modificar su comportamiento con un deco
        imprimir('hola')
    fin
 
-**Transpilación a Python, JavaScript, ensamblador, Rust, C++, Go, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, Matlab y LaTeX**
+**Transpilación a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX**
 
-- `imprimir` se transpila a `print` en Python, `console.log` en JavaScript, `PRINT` en ensamblador, `println!` en Rust, `std::cout` en C++, `fmt.Println` en Go, `print` en R, `println` en Julia, `System.out.println` en Java, `DISPLAY` en COBOL, `print *` en Fortran, `writeln` en Pascal, `puts` en Ruby, `echo` en PHP, `disp` en Matlab y `\texttt{}` en LaTeX.
+- `imprimir` se transpila a `print` en Python, `console.log` en JavaScript, `PRINT` en ensamblador, `println!` en Rust, `std::cout` en C++, `fmt.Println` en Go, `println` en Kotlin, `print` en Swift, `print` en R, `println` en Julia, `System.out.println` en Java, `DISPLAY` en COBOL, `print *` en Fortran, `writeln` en Pascal, `Console.WriteLine` en VisualBasic, `puts` en Ruby, `echo` en PHP, `print` en Perl, `disp` en Matlab, `print` en Mojo y `	exttt{}` en LaTeX.
 - Los bucles `mientras` y `para` se convierten en `while` y `for` en los lenguajes de alto nivel, mientras que en ensamblador generan instrucciones `WHILE` y `FOR`.
 - La construcción `holobit` se traduce a `holobit([...])` en Python, `new Holobit([...])` en JavaScript, `holobit(vec![...])` en Rust y `holobit({...})` en C++, mientras que en Ruby utiliza `Holobit.new([...])` y en PHP `new Holobit([...])`.
 

--- a/frontend/docs/uml/arquitectura_general.puml
+++ b/frontend/docs/uml/arquitectura_general.puml
@@ -8,14 +8,19 @@ Transpiladores --> ASM
 Transpiladores --> Rust
 Transpiladores --> "C++"
 Transpiladores --> Go
+Transpiladores --> Kotlin
+Transpiladores --> Swift
 Transpiladores --> R
 Transpiladores --> Julia
 Transpiladores --> Java
 Transpiladores --> COBOL
 Transpiladores --> Fortran
 Transpiladores --> Pascal
+Transpiladores --> Perl
+Transpiladores --> VisualBasic
 Transpiladores --> Ruby
 Transpiladores --> PHP
+Transpiladores --> Mojo
 Transpiladores --> Matlab
 Transpiladores --> LaTeX
 @enduml


### PR DESCRIPTION
## Summary
- document Kotlin, Swift, Perl, Visual Basic and Mojo in every list of transpilers
- show how to invoke the new transpilers in README examples

## Testing
- `pytest tests/unit/test_to_kotlin.py tests/unit/test_to_swift.py tests/unit/test_to_perl.py tests/unit/test_to_visualbasic.py tests/unit/test_to_mojo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d839ef74832786a94465cbda529f