### PR TITLE
Add reverse transpiler base

### DIFF
--- a/backend/src/cobra/transpilers/__init__.py
+++ b/backend/src/cobra/transpilers/__init__.py
@@ -1,5 +1,6 @@
 """Facilita el acceso a los distintos transpiladores de Cobra."""
 
 from src.cobra.transpilers.base import BaseTranspiler
+from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
 
-__all__ = ["BaseTranspiler"]
+__all__ = ["BaseTranspiler", "BaseReverseTranspiler"]

--- a/backend/src/cobra/transpilers/reverse/__init__.py
+++ b/backend/src/cobra/transpilers/reverse/__init__.py
@@ -1,0 +1,5 @@
+"""Componentes para convertir código de otros lenguajes a Cobra."""
+
+from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+
+__all__ = ["BaseReverseTranspiler"]

--- a/backend/src/cobra/transpilers/reverse/base.py
+++ b/backend/src/cobra/transpilers/reverse/base.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+from core.visitor import NodeVisitor
+
+
+class BaseReverseTranspiler(NodeVisitor, ABC):
+    """Clase base para transpiladores inversos que generan el AST de Cobra."""
+
+    def __init__(self):
+        self.ast = []
+
+    @abstractmethod
+    def generate_ast(self, code: str):
+        """Devuelve el AST Cobra equivalente al código fuente dado."""
+        raise NotImplementedError
+
+    def load_file(self, path: str):
+        """Carga un archivo y genera su AST correspondiente."""
+        with open(path, "r", encoding="utf-8") as archivo:
+            contenido = archivo.read()
+        return self.generate_ast(contenido)


### PR DESCRIPTION
## Summary
- add base class for reverse transpilers
- expose new interface via `cobra.transpilers`

## Testing
- `pytest -q` *(fails: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688113ec465483278b85452f04f7cbfb