### PR TITLE
Add reverse transpiler CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,9 @@ Una vez instalado el paquete, la herramienta `cobra` ofrece varios subcomandos:
 # Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo o LaTeX
 cobra compilar programa.co --tipo python
 
+# Transpilar inverso de Python a JavaScript
+cobra transpilar-inverso script.py --origen=python --destino=js
+
 # Ejemplo de mensaje de error al compilar un archivo inexistente
 cobra compilar noexiste.co
 # Salida:

--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -25,6 +25,7 @@ from src.cli.commands.modules_cmd import ModulesCommand
 from src.cli.commands.package_cmd import PaqueteCommand
 from src.cli.commands.plugins_cmd import PluginsCommand
 from src.cli.commands.profile_cmd import ProfileCommand
+from src.cli.commands.transpilar_inverso_cmd import TranspilarInversoCommand
 from src.cli.commands.verify_cmd import VerifyCommand
 from src.cli.i18n import _, format_traceback, setup_gettext
 from src.cli.plugin import descubrir_plugins
@@ -89,6 +90,7 @@ def main(argv=None):
         BenchThreadsCommand(),
         ProfileCommand(),
         CacheCommand(),
+        TranspilarInversoCommand(),
         VerifyCommand(),
         PluginsCommand(),
         InteractiveCommand(),

--- a/backend/src/cli/commands/transpilar_inverso_cmd.py
+++ b/backend/src/cli/commands/transpilar_inverso_cmd.py
@@ -1,0 +1,68 @@
+import os
+
+from cobra.transpilers.reverse import ReverseFromPython
+from src.cli.commands.base import BaseCommand
+from src.cli.commands.compile_cmd import TRANSPILERS, LANG_CHOICES
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
+
+REVERSE_TRANSPILERS = {
+    "python": ReverseFromPython,
+}
+
+ORIGIN_CHOICES = sorted(REVERSE_TRANSPILERS.keys())
+
+
+class TranspilarInversoCommand(BaseCommand):
+    """Convierte código desde otro lenguaje a Cobra y luego a otro lenguaje."""
+
+    name = "transpilar-inverso"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(
+            self.name, help=_("Transpila desde un lenguaje origen a otro destino")
+        )
+        parser.add_argument("archivo")
+        parser.add_argument(
+            "--origen",
+            choices=ORIGIN_CHOICES,
+            default="python",
+            help=_("Lenguaje de origen"),
+        )
+        parser.add_argument(
+            "--destino",
+            choices=LANG_CHOICES,
+            default="python",
+            help=_("Lenguaje de destino"),
+        )
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        archivo = args.archivo
+        if not os.path.exists(archivo):
+            mostrar_error(f"El archivo '{archivo}' no existe")
+            return 1
+
+        reverse_cls = REVERSE_TRANSPILERS.get(args.origen)
+        transp_cls = TRANSPILERS.get(args.destino)
+        if reverse_cls is None or transp_cls is None:
+            mostrar_error("Transpilador no soportado")
+            return 1
+
+        try:
+            ast = reverse_cls().load_file(archivo)
+        except Exception as exc:  # pylint: disable=broad-except
+            mostrar_error(f"Error al convertir {args.origen}: {exc}")
+            return 1
+
+        try:
+            codigo = transp_cls().generate_code(ast)
+            mostrar_info(
+                _("Código transpilado ({name}):").format(name=transp_cls.__name__)
+            )
+            print(codigo)
+            return 0
+        except Exception as exc:  # pylint: disable=broad-except
+            mostrar_error(f"Error generando código: {exc}")
+            return 1

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -166,6 +166,10 @@ puede ejecutarse un archivo directamente con ``cobra ejecutar``.
 El subcomando ``cobra verificar`` (``cobra verify`` en la versión en inglés)
 permite comparar la salida de un programa transpilado a distintos lenguajes
 (actualmente Python y JavaScript) y avisa si alguna difiere.
+Adicionalmente puedes convertir código escrito en otros lenguajes a Cobra y
+volver a transpilarlos con ``cobra transpilar-inverso``::
+
+   cobra transpilar-inverso ejemplo.py --origen=python --destino=js
 
 Limitaciones de los backends
 ----------------------------

--- a/tests/unit/test_cli_transpilar_inverso_cmd.py
+++ b/tests/unit/test_cli_transpilar_inverso_cmd.py
@@ -1,0 +1,38 @@
+import argparse
+from io import StringIO
+from unittest.mock import patch
+
+from cli.cli import main
+from cli.utils import messages
+
+
+class FakeReverse:
+    def load_file(self, path):
+        return []
+
+
+class FakeTranspiler:
+    def generate_code(self, ast):
+        return "resultado"
+
+
+def test_transpilar_inverso_ok(tmp_path):
+    archivo = tmp_path / "a.py"
+    archivo.write_text("x = 1")
+    args = ["--no-color", "transpilar-inverso", str(archivo), "--origen=python", "--destino=python"]
+    with patch("cli.commands.transpilar_inverso_cmd.REVERSE_TRANSPILERS", {"python": FakeReverse}), \
+         patch("cli.commands.transpilar_inverso_cmd.TRANSPILERS", {"python": FakeTranspiler}), \
+         patch("src.cli.commands.transpilar_inverso_cmd.REVERSE_TRANSPILERS", {"python": FakeReverse}), \
+         patch("src.cli.commands.transpilar_inverso_cmd.TRANSPILERS", {"python": FakeTranspiler}), \
+         patch("sys.stdout", new_callable=StringIO) as out:
+        main(args)
+    lineas = [l for l in out.getvalue().splitlines() if "Código transpilado" in l]
+    assert lineas[0].startswith("Código transpilado")
+    assert out.getvalue().strip().splitlines()[-1] == "resultado"
+
+
+def test_transpilar_inverso_archivo_inexistente(tmp_path):
+    archivo = tmp_path / "no.py"
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["transpilar-inverso", str(archivo)])
+    assert f"El archivo '{archivo}' no existe" in out.getvalue()


### PR DESCRIPTION
## Summary
- implement `transpilar-inverso` command to convert code between languages
- register the new command in CLI
- document usage in README and manual
- add tests for the command

## Testing
- `pytest tests/unit/test_cli_transpilar_inverso_cmd.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68811c46fb0083278361f0f411cb275c