### PR TITLE
Agregar transpiladores inversos con tree-sitter

### DIFF
--- a/backend/src/cli/commands/transpilar_inverso_cmd.py
+++ b/backend/src/cli/commands/transpilar_inverso_cmd.py
@@ -1,6 +1,30 @@
 import os
 
-from cobra.transpilers.reverse import ReverseFromPython
+from cobra.transpilers.reverse import (
+    ReverseFromPython,
+    ReverseFromC,
+    ReverseFromCPP,
+    ReverseFromJS,
+    ReverseFromJava,
+    ReverseFromGo,
+    ReverseFromJulia,
+    ReverseFromPHP,
+    ReverseFromPerl,
+    ReverseFromR,
+    ReverseFromRuby,
+    ReverseFromRust,
+    ReverseFromSwift,
+    ReverseFromKotlin,
+    ReverseFromFortran,
+    ReverseFromASM,
+    ReverseFromCOBOL,
+    ReverseFromLatex,
+    ReverseFromMatlab,
+    ReverseFromMojo,
+    ReverseFromPascal,
+    ReverseFromVisualBasic,
+    ReverseFromWasm,
+)
 from src.cli.commands.base import BaseCommand
 from src.cli.commands.compile_cmd import TRANSPILERS, LANG_CHOICES
 from src.cli.i18n import _
@@ -8,6 +32,28 @@ from src.cli.utils.messages import mostrar_error, mostrar_info
 
 REVERSE_TRANSPILERS = {
     "python": ReverseFromPython,
+    "c": ReverseFromC,
+    "cpp": ReverseFromCPP,
+    "js": ReverseFromJS,
+    "java": ReverseFromJava,
+    "go": ReverseFromGo,
+    "julia": ReverseFromJulia,
+    "php": ReverseFromPHP,
+    "perl": ReverseFromPerl,
+    "r": ReverseFromR,
+    "ruby": ReverseFromRuby,
+    "rust": ReverseFromRust,
+    "swift": ReverseFromSwift,
+    "kotlin": ReverseFromKotlin,
+    "fortran": ReverseFromFortran,
+    "asm": ReverseFromASM,
+    "cobol": ReverseFromCOBOL,
+    "latex": ReverseFromLatex,
+    "matlab": ReverseFromMatlab,
+    "mojo": ReverseFromMojo,
+    "pascal": ReverseFromPascal,
+    "visualbasic": ReverseFromVisualBasic,
+    "wasm": ReverseFromWasm,
 }
 
 ORIGIN_CHOICES = sorted(REVERSE_TRANSPILERS.keys())

--- a/backend/src/cobra/transpilers/reverse/__init__.py
+++ b/backend/src/cobra/transpilers/reverse/__init__.py
@@ -2,5 +2,52 @@
 
 from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
 from src.cobra.transpilers.reverse.from_python import ReverseFromPython
+from src.cobra.transpilers.reverse.from_c import ReverseFromC
+from src.cobra.transpilers.reverse.from_cpp import ReverseFromCPP
+from src.cobra.transpilers.reverse.from_js import ReverseFromJS
+from src.cobra.transpilers.reverse.from_java import ReverseFromJava
+from src.cobra.transpilers.reverse.from_go import ReverseFromGo
+from src.cobra.transpilers.reverse.from_julia import ReverseFromJulia
+from src.cobra.transpilers.reverse.from_php import ReverseFromPHP
+from src.cobra.transpilers.reverse.from_perl import ReverseFromPerl
+from src.cobra.transpilers.reverse.from_r import ReverseFromR
+from src.cobra.transpilers.reverse.from_ruby import ReverseFromRuby
+from src.cobra.transpilers.reverse.from_rust import ReverseFromRust
+from src.cobra.transpilers.reverse.from_swift import ReverseFromSwift
+from src.cobra.transpilers.reverse.from_kotlin import ReverseFromKotlin
+from src.cobra.transpilers.reverse.from_fortran import ReverseFromFortran
+from src.cobra.transpilers.reverse.from_asm import ReverseFromASM
+from src.cobra.transpilers.reverse.from_cobol import ReverseFromCOBOL
+from src.cobra.transpilers.reverse.from_latex import ReverseFromLatex
+from src.cobra.transpilers.reverse.from_matlab import ReverseFromMatlab
+from src.cobra.transpilers.reverse.from_mojo import ReverseFromMojo
+from src.cobra.transpilers.reverse.from_pascal import ReverseFromPascal
+from src.cobra.transpilers.reverse.from_visualbasic import ReverseFromVisualBasic
+from src.cobra.transpilers.reverse.from_wasm import ReverseFromWasm
 
-__all__ = ["BaseReverseTranspiler", "ReverseFromPython"]
+__all__ = [
+    "BaseReverseTranspiler",
+    "ReverseFromPython",
+    "ReverseFromC",
+    "ReverseFromCPP",
+    "ReverseFromJS",
+    "ReverseFromJava",
+    "ReverseFromGo",
+    "ReverseFromJulia",
+    "ReverseFromPHP",
+    "ReverseFromPerl",
+    "ReverseFromR",
+    "ReverseFromRuby",
+    "ReverseFromRust",
+    "ReverseFromSwift",
+    "ReverseFromKotlin",
+    "ReverseFromFortran",
+    "ReverseFromASM",
+    "ReverseFromCOBOL",
+    "ReverseFromLatex",
+    "ReverseFromMatlab",
+    "ReverseFromMojo",
+    "ReverseFromPascal",
+    "ReverseFromVisualBasic",
+    "ReverseFromWasm",
+]

--- a/backend/src/cobra/transpilers/reverse/from_asm.py
+++ b/backend/src/cobra/transpilers/reverse/from_asm.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde ensamblador a Cobra (no soportado)."""
+
+from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+
+
+class ReverseFromASM(BaseReverseTranspiler):
+    """Placeholder sin implementación por falta de gramática."""
+
+    def generate_ast(self, code: str):
+        raise NotImplementedError("No hay parser para ensamblador")

--- a/backend/src/cobra/transpilers/reverse/from_c.py
+++ b/backend/src/cobra/transpilers/reverse/from_c.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde C a Cobra usando tree-sitter."""
+
+from .tree_sitter_base import TreeSitterReverseTranspiler
+
+
+class ReverseFromC(TreeSitterReverseTranspiler):
+    LANGUAGE = "c"

--- a/backend/src/cobra/transpilers/reverse/from_cobol.py
+++ b/backend/src/cobra/transpilers/reverse/from_cobol.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde COBOL a Cobra (no soportado)."""
+
+from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+
+
+class ReverseFromCOBOL(BaseReverseTranspiler):
+    def generate_ast(self, code: str):
+        raise NotImplementedError("No hay parser para COBOL")

--- a/backend/src/cobra/transpilers/reverse/from_cpp.py
+++ b/backend/src/cobra/transpilers/reverse/from_cpp.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde C++ a Cobra usando tree-sitter."""
+
+from .tree_sitter_base import TreeSitterReverseTranspiler
+
+
+class ReverseFromCPP(TreeSitterReverseTranspiler):
+    LANGUAGE = "cpp"

--- a/backend/src/cobra/transpilers/reverse/from_fortran.py
+++ b/backend/src/cobra/transpilers/reverse/from_fortran.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde Fortran a Cobra usando tree-sitter."""
+
+from .tree_sitter_base import TreeSitterReverseTranspiler
+
+
+class ReverseFromFortran(TreeSitterReverseTranspiler):
+    LANGUAGE = "fortran"

--- a/backend/src/cobra/transpilers/reverse/from_go.py
+++ b/backend/src/cobra/transpilers/reverse/from_go.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde Go a Cobra usando tree-sitter."""
+
+from .tree_sitter_base import TreeSitterReverseTranspiler
+
+
+class ReverseFromGo(TreeSitterReverseTranspiler):
+    LANGUAGE = "go"

--- a/backend/src/cobra/transpilers/reverse/from_java.py
+++ b/backend/src/cobra/transpilers/reverse/from_java.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde Java a Cobra usando tree-sitter."""
+
+from .tree_sitter_base import TreeSitterReverseTranspiler
+
+
+class ReverseFromJava(TreeSitterReverseTranspiler):
+    LANGUAGE = "java"

--- a/backend/src/cobra/transpilers/reverse/from_js.py
+++ b/backend/src/cobra/transpilers/reverse/from_js.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde JavaScript a Cobra usando tree-sitter."""
+
+from .tree_sitter_base import TreeSitterReverseTranspiler
+
+
+class ReverseFromJS(TreeSitterReverseTranspiler):
+    LANGUAGE = "javascript"

--- a/backend/src/cobra/transpilers/reverse/from_julia.py
+++ b/backend/src/cobra/transpilers/reverse/from_julia.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde Julia a Cobra usando tree-sitter."""
+
+from .tree_sitter_base import TreeSitterReverseTranspiler
+
+
+class ReverseFromJulia(TreeSitterReverseTranspiler):
+    LANGUAGE = "julia"

--- a/backend/src/cobra/transpilers/reverse/from_kotlin.py
+++ b/backend/src/cobra/transpilers/reverse/from_kotlin.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde Kotlin a Cobra usando tree-sitter."""
+
+from .tree_sitter_base import TreeSitterReverseTranspiler
+
+
+class ReverseFromKotlin(TreeSitterReverseTranspiler):
+    LANGUAGE = "kotlin"

--- a/backend/src/cobra/transpilers/reverse/from_latex.py
+++ b/backend/src/cobra/transpilers/reverse/from_latex.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde LaTeX a Cobra (no soportado)."""
+
+from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+
+
+class ReverseFromLatex(BaseReverseTranspiler):
+    def generate_ast(self, code: str):
+        raise NotImplementedError("No hay parser para LaTeX")

--- a/backend/src/cobra/transpilers/reverse/from_matlab.py
+++ b/backend/src/cobra/transpilers/reverse/from_matlab.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde Matlab a Cobra (no soportado)."""
+
+from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+
+
+class ReverseFromMatlab(BaseReverseTranspiler):
+    def generate_ast(self, code: str):
+        raise NotImplementedError("No hay parser para Matlab")

--- a/backend/src/cobra/transpilers/reverse/from_mojo.py
+++ b/backend/src/cobra/transpilers/reverse/from_mojo.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde Mojo a Cobra (no soportado)."""
+
+from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+
+
+class ReverseFromMojo(BaseReverseTranspiler):
+    def generate_ast(self, code: str):
+        raise NotImplementedError("No hay parser para Mojo")

--- a/backend/src/cobra/transpilers/reverse/from_pascal.py
+++ b/backend/src/cobra/transpilers/reverse/from_pascal.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde Pascal a Cobra (no soportado)."""
+
+from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+
+
+class ReverseFromPascal(BaseReverseTranspiler):
+    def generate_ast(self, code: str):
+        raise NotImplementedError("No hay parser para Pascal")

--- a/backend/src/cobra/transpilers/reverse/from_perl.py
+++ b/backend/src/cobra/transpilers/reverse/from_perl.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde Perl a Cobra usando tree-sitter."""
+
+from .tree_sitter_base import TreeSitterReverseTranspiler
+
+
+class ReverseFromPerl(TreeSitterReverseTranspiler):
+    LANGUAGE = "perl"

--- a/backend/src/cobra/transpilers/reverse/from_php.py
+++ b/backend/src/cobra/transpilers/reverse/from_php.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde PHP a Cobra usando tree-sitter."""
+
+from .tree_sitter_base import TreeSitterReverseTranspiler
+
+
+class ReverseFromPHP(TreeSitterReverseTranspiler):
+    LANGUAGE = "php"

--- a/backend/src/cobra/transpilers/reverse/from_r.py
+++ b/backend/src/cobra/transpilers/reverse/from_r.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde R a Cobra usando tree-sitter."""
+
+from .tree_sitter_base import TreeSitterReverseTranspiler
+
+
+class ReverseFromR(TreeSitterReverseTranspiler):
+    LANGUAGE = "r"

--- a/backend/src/cobra/transpilers/reverse/from_ruby.py
+++ b/backend/src/cobra/transpilers/reverse/from_ruby.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde Ruby a Cobra usando tree-sitter."""
+
+from .tree_sitter_base import TreeSitterReverseTranspiler
+
+
+class ReverseFromRuby(TreeSitterReverseTranspiler):
+    LANGUAGE = "ruby"

--- a/backend/src/cobra/transpilers/reverse/from_rust.py
+++ b/backend/src/cobra/transpilers/reverse/from_rust.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde Rust a Cobra usando tree-sitter."""
+
+from .tree_sitter_base import TreeSitterReverseTranspiler
+
+
+class ReverseFromRust(TreeSitterReverseTranspiler):
+    LANGUAGE = "rust"

--- a/backend/src/cobra/transpilers/reverse/from_swift.py
+++ b/backend/src/cobra/transpilers/reverse/from_swift.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde Swift a Cobra usando tree-sitter."""
+
+from .tree_sitter_base import TreeSitterReverseTranspiler
+
+
+class ReverseFromSwift(TreeSitterReverseTranspiler):
+    LANGUAGE = "swift"

--- a/backend/src/cobra/transpilers/reverse/from_visualbasic.py
+++ b/backend/src/cobra/transpilers/reverse/from_visualbasic.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde VisualBasic a Cobra (no soportado)."""
+
+from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+
+
+class ReverseFromVisualBasic(BaseReverseTranspiler):
+    def generate_ast(self, code: str):
+        raise NotImplementedError("No hay parser para VisualBasic")

--- a/backend/src/cobra/transpilers/reverse/from_wasm.py
+++ b/backend/src/cobra/transpilers/reverse/from_wasm.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde WebAssembly a Cobra (no soportado)."""
+
+from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+
+
+class ReverseFromWasm(BaseReverseTranspiler):
+    def generate_ast(self, code: str):
+        raise NotImplementedError("No hay parser para WebAssembly")

--- a/backend/src/cobra/transpilers/reverse/tree_sitter_base.py
+++ b/backend/src/cobra/transpilers/reverse/tree_sitter_base.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""Transpiladores inversos basados en tree-sitter."""
+
+from __future__ import annotations
+
+from tree_sitter_languages import get_parser
+
+from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+from core.ast_nodes import (
+    NodoAsignacion,
+    NodoCondicional,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoRetorno,
+    NodoIdentificador,
+    NodoValor,
+)
+
+
+class TreeSitterReverseTranspiler(BaseReverseTranspiler):
+    """Convierte código de varios lenguajes a nodos Cobra usando tree-sitter."""
+
+    LANGUAGE: str = ""
+
+    def __init__(self):
+        super().__init__()
+        if not self.LANGUAGE:
+            raise ValueError("LANGUAGE debe definirse en la subclase")
+        try:
+            self.parser = get_parser(self.LANGUAGE)
+        except Exception as exc:  # pylint: disable=broad-except
+            raise NotImplementedError(
+                f"No hay gramática tree-sitter para {self.LANGUAGE}"
+            ) from exc
+
+    def generate_ast(self, code: str):
+        tree = self.parser.parse(code.encode("utf-8"))
+        self.ast = [self.visit(child) for child in tree.root_node.children if child.is_named]
+        return self.ast
+
+    # Visitas genéricas -------------------------------------------------
+    def visit(self, node):  # type: ignore[override]
+        method = getattr(self, f"visit_{node.type}", None)
+        if method is None:
+            return self.generic_visit(node)
+        return method(node)
+
+    def generic_visit(self, node):
+        raise NotImplementedError(f"Nodo no soportado: {node.type}")
+
+    # Nodos simples -----------------------------------------------------
+    def visit_identifier(self, node):
+        return NodoIdentificador(node.text.decode())
+
+    def visit_number(self, node):
+        texto = node.text.decode()
+        try:
+            valor = int(texto)
+        except ValueError:
+            try:
+                valor = float(texto)
+            except ValueError:
+                valor = texto
+        return NodoValor(valor)
+
+    def visit_string(self, node):
+        texto = node.text.decode().strip('"\'')
+        return NodoValor(texto)
+
+    # Expresiones -------------------------------------------------------
+    def visit_call_expression(self, node):
+        nombre = node.child_by_field_name("function")
+        args = node.child_by_field_name("arguments")
+        nombre_txt = nombre.text.decode() if nombre else ""
+        argumentos = []
+        if args:
+            for child in args.children:
+                if child.is_named:
+                    argumentos.append(self.visit(child))
+        return NodoLlamadaFuncion(nombre_txt, argumentos)
+
+    # Sentencias -------------------------------------------------------
+    def visit_assignment_expression(self, node):
+        izquierdo = self.visit(node.child_by_field_name("left"))
+        derecho = self.visit(node.child_by_field_name("right"))
+        return NodoAsignacion(izquierdo, derecho)
+
+    def visit_expression_statement(self, node):
+        expr = node.child_by_field_name("expression") or node.children[0]
+        return self.visit(expr)
+
+    def visit_return_statement(self, node):
+        valor = node.child_by_field_name("argument")
+        return NodoRetorno(self.visit(valor) if valor else NodoValor(None))
+
+    def visit_if_statement(self, node):
+        cond = self.visit(node.child_by_field_name("condition"))
+        conseq = node.child_by_field_name("consequence")
+        alt = node.child_by_field_name("alternative")
+        bloque_si = [self.visit(c) for c in conseq.children if c.is_named] if conseq else []
+        bloque_sino = [self.visit(c) for c in alt.children if c.is_named] if alt else []
+        return NodoCondicional(cond, bloque_si, bloque_sino)
+
+    def visit_function_definition(self, node):
+        nombre_n = node.child_by_field_name("name")
+        params_n = node.child_by_field_name("parameters")
+        body_n = node.child_by_field_name("body")
+        nombre = nombre_n.text.decode() if nombre_n else ""
+        params = [c.text.decode() for c in params_n.children if c.type == "identifier"] if params_n else []
+        cuerpo = [self.visit(c) for c in body_n.children if c.is_named] if body_n else []
+        return NodoFuncion(nombre, params, cuerpo)

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,5 @@ pexpect
 hypothesis
 holobit-sdk
 ipykernel
+tree-sitter==0.25.0
+tree-sitter-languages==1.10.2


### PR DESCRIPTION
## Summary
- incorporar `TreeSitterReverseTranspiler` para facilitar el parsing
- añadir módulos `from_*` en `cobra/transpilers/reverse/`
- ampliar `__all__` con los nuevos transpiladores
- extender CLI para reconocer nuevos orígenes
- incluir dependencias de `tree-sitter` en `requirements.txt`

## Testing
- `python -m pip install -r requirements.txt` *(fails: huge output truncated)*
- `pytest -q` *(fails: 8 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68811fd211188327a0cdc2cd50d6cc87