### PR TITLE
Add reverse transpiler tests

### DIFF
--- a/backend/src/cobra/transpilers/reverse/from_python.py
+++ b/backend/src/cobra/transpilers/reverse/from_python.py
@@ -57,6 +57,13 @@ class ReverseFromPython(BaseReverseTranspiler):
         self.ast = [self.visit(stmt) for stmt in tree.body]
         return self.ast
 
+    # Ajustar el dispatch para nodos de ``ast`` escritos en CamelCase
+    def visit(self, node):  # type: ignore[override]
+        metodo = getattr(self, f"visit_{node.__class__.__name__}", None)
+        if metodo is None:
+            return self.generic_visit(node)
+        return metodo(node)
+
     # Utilizamos los métodos visit_ heredados de NodeVisitor
     def generic_visit(self, node):
         raise NotImplementedError(f"Nodo de Python no soportado: {node.__class__.__name__}")

--- a/tests/integration/test_reverse_transpile_chain.py
+++ b/tests/integration/test_reverse_transpile_chain.py
@@ -1,0 +1,10 @@
+from cobra.transpilers.reverse.from_python import ReverseFromPython
+from cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
+
+
+def test_python_to_cobra_to_cpp():
+    codigo = "x = 1\nprint(x)"
+    ast = ReverseFromPython().generate_ast(codigo)
+    cpp_code = TranspiladorCPP().generate_code(ast)
+    esperado = "auto x = 1;\nprint(x);"
+    assert cpp_code == esperado

--- a/tests/unit/test_reverse_ast.py
+++ b/tests/unit/test_reverse_ast.py
@@ -1,0 +1,29 @@
+from cobra.transpilers.reverse.from_python import ReverseFromPython
+from core.ast_nodes import (
+    NodoAsignacion,
+    NodoLlamadaFuncion,
+    NodoValor,
+    NodoIdentificador,
+)
+
+
+def test_reverse_from_python_assignment():
+    codigo = "x = 42"
+    ast = ReverseFromPython().generate_ast(codigo)
+    assert len(ast) == 1
+    nodo = ast[0]
+    assert isinstance(nodo, NodoAsignacion)
+    assert nodo.variable == "x"
+    assert isinstance(nodo.expresion, NodoValor)
+    assert nodo.expresion.valor == 42
+
+
+def test_reverse_from_python_print():
+    codigo = "x = 1\nprint(x)"
+    ast = ReverseFromPython().generate_ast(codigo)
+    assert len(ast) == 2
+    llamada = ast[1]
+    assert isinstance(llamada, NodoLlamadaFuncion)
+    assert llamada.nombre == "print"
+    assert isinstance(llamada.argumentos[0], NodoIdentificador)
+    assert llamada.argumentos[0].nombre == "x"


### PR DESCRIPTION
## Summary
- fix Python reverse transpiler to dispatch camel case ast nodes
- add unit tests for Python reverse transpiler AST generation
- add integration test chaining Python -> Cobra -> C++ transpilers

## Testing
- `pytest tests/unit/test_reverse_ast.py tests/integration/test_reverse_transpile_chain.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688123e008488327bcc066280837b84f