### PR TITLE
Update docs for reverse transpilation and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Cobra es un lenguaje de programación diseñado en español, enfocado en la crea
 - Uso
 - Tokens y reglas léxicas
 - Ejemplo de Uso
+- Conversión desde otros lenguajes
+- Guía rápida de la CLI
 - Pruebas
 - Generar documentación
 - Análisis con CodeQL
@@ -572,6 +574,24 @@ imprimir('principal')
 
 Al generar código para estas funciones, se crean llamadas `asyncio.create_task` en Python y `Promise.resolve().then` en JavaScript.
 
+## Guía rápida de la CLI
+
+La herramienta `cobra` se invoca con `cobra [subcomando] [archivo] [opciones]`.
+Para obtener ayuda puedes ejecutar:
+
+```bash
+cobra --help
+```
+
+Un uso común es compilar un programa y luego ejecutar el resultado:
+
+```bash
+cobra compilar ejemplo.co --tipo=python > ejemplo.py
+python ejemplo.py
+```
+
+Si no proporcionas un subcomando se abrirá el modo interactivo.
+
 ## Uso desde la CLI
 
 Una vez instalado el paquete, la herramienta `cobra` ofrece varios subcomandos:
@@ -637,6 +657,18 @@ El subcomando `gui` abre el iddle integrado y requiere tener instalado Flet.
 
 
 Si no se pasa un subcomando se abrirá el modo interactivo. Usa `cobra --help` para más detalles.
+
+## Conversión desde otros lenguajes a Cobra
+
+Puedes usar `cobra transpilar-inverso` para leer un archivo en otro lenguaje,
+convertirlo al AST de Cobra y luego generarlo en cualquier backend soportado.
+
+```bash
+cobra transpilar-inverso script.py --origen=python --destino=cobra
+```
+
+El proceso intenta mapear instrucciones básicas, pero características muy específicas pueden requerir ajustes manuales.
+Actualmente la cobertura varía según el lenguaje y puede que ciertas construcciones no estén implementadas.
 
 ### Diseño extensible de la CLI
 

--- a/docs/arquitectura_parser_transpiladores.md
+++ b/docs/arquitectura_parser_transpiladores.md
@@ -39,3 +39,24 @@ Transpiladores --> Rust
 ```
 
 Para detalles sobre la estructura de nodos consulta [docs/estructura_ast.md](estructura_ast.md).
+
+## Flujo de transpilación inversa
+
+Cobra también permite convertir código escrito en otros lenguajes al AST de Cobra
+para luego transpilarlo nuevamente. Este proceso se ejecuta así:
+
+1. Un `ReverseTranspiler` lee el archivo origen y lo analiza con `tree-sitter` u
+   otras bibliotecas específicas.
+2. Se genera un AST con los nodos propios de Cobra.
+3. Dicho AST se entrega a cualquier transpilador convencional para producir
+   código en el lenguaje destino.
+
+El comando `cobra transpilar-inverso` automatiza estos pasos.
+
+```bash
+cobra transpilar-inverso ejemplo.py --origen=python --destino=js
+```
+
+La conversión inversa puede ser parcial y ciertas construcciones avanzadas del
+lenguaje de origen podrían no trasladarse exactamente. Se recomienda revisar el
+resultado antes de usarlo en producción.


### PR DESCRIPTION
## Summary
- describe reverse transpilation flow
- add quick CLI guide and conversion instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_6881a900a2308327a6a818fef30c1391