### PR TITLE
Extend Qualia with knowledge tracking

### DIFF
--- a/backend/src/core/interpreter.py
+++ b/backend/src/core/interpreter.py
@@ -216,7 +216,7 @@ class InterpretadorCobra:
         ast = remove_dead_code(
             inline_functions(eliminate_common_subexpressions(optimize_constants(ast)))
         )
-        register_execution(str(ast))
+        register_execution(ast)
         AnalizadorSemantico().analizar(ast)
         for nodo in ast:
             self._validar(nodo)

--- a/backend/src/core/qualia_bridge.py
+++ b/backend/src/core/qualia_bridge.py
@@ -1,6 +1,10 @@
 import json
 import os
-from typing import List
+from typing import List, Union
+
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.qualia_knowledge import QualiaKnowledge
 
 
 STATE_FILE = os.environ.get(
@@ -14,6 +18,7 @@ class QualiaSpirit:
 
     def __init__(self) -> None:
         self.history: List[str] = []
+        self.knowledge = QualiaKnowledge()
 
     def register(self, code: str) -> None:
         """Guarda el ``code`` ejecutado en la historia."""
@@ -39,6 +44,7 @@ def load_state() -> QualiaSpirit:
             data = json.load(fh)
         spirit = QualiaSpirit()
         spirit.history = data.get("history", [])
+        spirit.knowledge = QualiaKnowledge.from_dict(data.get("knowledge", {}))
         return spirit
     return QualiaSpirit()
 
@@ -46,15 +52,32 @@ def load_state() -> QualiaSpirit:
 def save_state(spirit: QualiaSpirit) -> None:
     """Guarda el estado de ``spirit`` en ``STATE_FILE``."""
     with open(STATE_FILE, "w", encoding="utf-8") as fh:
-        json.dump({"history": spirit.history}, fh, ensure_ascii=False, indent=2)
+        json.dump(
+            {
+                "history": spirit.history,
+                "knowledge": spirit.knowledge.as_dict(),
+            },
+            fh,
+            ensure_ascii=False,
+            indent=2,
+        )
 
 
 QUALIA = load_state()
 
 
-def register_execution(code: str) -> None:
-    """Registra una ejecuci\u00f3n y persiste el estado."""
+def register_execution(execution: Union[str, list]) -> None:
+    """Registra una ejecución y persiste el estado actualizando el conocimiento."""
+    if isinstance(execution, str):
+        tokens = Lexer(execution).analizar_token()
+        ast = Parser(tokens).parsear()
+        code = execution
+    else:
+        ast = execution
+        code = str(execution)
+
     QUALIA.register(code)
+    QUALIA.knowledge.update_from_ast(ast)
     save_state(QUALIA)
 
 

--- a/backend/src/core/qualia_knowledge.py
+++ b/backend/src/core/qualia_knowledge.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from core.ast_nodes import NodoAST
+
+
+@dataclass
+class QualiaKnowledge:
+    """Almacena estadísticas simples sobre el AST ejecutado."""
+
+    node_counts: Dict[str, int] = field(default_factory=dict)
+    patterns: List[str] = field(default_factory=list)
+
+    def update_from_ast(self, ast: List[NodoAST]) -> None:
+        for nodo in ast:
+            self._procesar(nodo)
+
+    def _procesar(self, nodo: NodoAST) -> None:
+        tipo = type(nodo).__name__
+        self.node_counts[tipo] = self.node_counts.get(tipo, 0) + 1
+        # Patrones sencillos
+        if tipo == "NodoTryCatch" and "try_catch" not in self.patterns:
+            self.patterns.append("try_catch")
+        if tipo == "NodoLambda" and "lambda" not in self.patterns:
+            self.patterns.append("lambda")
+        if tipo == "NodoBucleMientras" and "bucle_mientras" not in self.patterns:
+            self.patterns.append("bucle_mientras")
+        for valor in nodo.__dict__.values():
+            self._revisar_valor(valor)
+
+    def _revisar_valor(self, valor: Any) -> None:
+        if isinstance(valor, list):
+            for elemento in valor:
+                if hasattr(elemento, "__dict__"):
+                    self._procesar(elemento)
+        elif hasattr(valor, "__dict__"):
+            self._procesar(valor)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"node_counts": self.node_counts, "patterns": self.patterns}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "QualiaKnowledge":
+        qk = cls()
+        qk.node_counts = data.get("node_counts", {})
+        qk.patterns = data.get("patterns", [])
+        return qk

--- a/tests/unit/test_qualia_bridge.py
+++ b/tests/unit/test_qualia_bridge.py
@@ -22,3 +22,13 @@ def test_qualia_generates_suggestions(tmp_path, monkeypatch):
     sugs = qb.get_suggestions()
     assert any("imprimir" in s for s in sugs)
 
+
+def test_knowledge_persistence(tmp_path, monkeypatch):
+    state = tmp_path / "state.json"
+    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
+    qb = importlib.reload(qualia_bridge)
+    qb.register_execution("imprimir(1)")
+    data = json.loads(state.read_text())
+    assert "knowledge" in data
+    assert data["knowledge"]["node_counts"].get("NodoImprimir")
+


### PR DESCRIPTION
## Summary
- introduce `QualiaKnowledge` dataclass to track AST node usage and patterns
- persist Qualia knowledge to `qualia_state.json`
- load saved knowledge when creating `QualiaSpirit`
- analyse code/AST in `register_execution`
- hook interpreter to update Qualia with executed AST
- add regression test for knowledge persistence

## Testing
- `pytest -q tests/unit/test_qualia_bridge.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tomli', 'hypothesis', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6881ba3d69bc8327a8bdf149cea2e17c