### PR TITLE
Mejora sugerencias de QualiaSpirit

### DIFF
--- a/backend/src/core/qualia_bridge.py
+++ b/backend/src/core/qualia_bridge.py
@@ -25,15 +25,32 @@ class QualiaSpirit:
         self.history.append(code)
 
     def suggestions(self) -> List[str]:
-        """Devuelve una lista de sugerencias basadas en el historial."""
+        """Devuelve una lista de sugerencias basadas en el historial y el conocimiento."""
         joined = "\n".join(self.history)
         sugerencias: List[str] = []
+
         if "imprimir" not in joined:
             sugerencias.append("Agrega \"imprimir\" para depurar.")
-        if any("var " in linea for linea in self.history):
+
+        if any(len(nombre) <= 2 for nombre in self.knowledge.variable_names):
             sugerencias.append("Usa nombres descriptivos para variables.")
+
+        if self.knowledge.node_counts.get("NodoAsignacion", 0) >= 5:
+            sugerencias.append(
+                "Considera agrupar asignaciones repetidas en funciones."
+            )
+
+        if (
+            self.knowledge.modules_used.get("pandas", 0) >= 1
+            and self.knowledge.modules_used.get("matplotlib", 0) == 0
+        ):
+            sugerencias.append(
+                "Si usas pandas, podr\u00edas utilizar matplotlib para graficar."
+            )
+
         if not sugerencias:
             sugerencias.append("\u00a1Sigue as\u00ed!")
+
         return sugerencias
 
 

--- a/tests/unit/test_qualia_bridge.py
+++ b/tests/unit/test_qualia_bridge.py
@@ -32,3 +32,23 @@ def test_knowledge_persistence(tmp_path, monkeypatch):
     assert "knowledge" in data
     assert data["knowledge"]["node_counts"].get("NodoImprimir")
 
+
+def test_sugerir_funciones_por_asignaciones(tmp_path, monkeypatch):
+    state = tmp_path / "state.json"
+    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
+    qb = importlib.reload(qualia_bridge)
+    for i in range(5):
+        qb.register_execution(f"var v{i} = {i}")
+    sugs = qb.get_suggestions()
+    assert any("funciones" in s for s in sugs)
+    assert any("nombres descriptivos" in s for s in sugs)
+
+
+def test_sugerencia_pandas_matplotlib(tmp_path, monkeypatch):
+    state = tmp_path / "state.json"
+    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
+    qb = importlib.reload(qualia_bridge)
+    qb.register_execution('usar "pandas"')
+    sugs = qb.get_suggestions()
+    assert any("matplotlib" in s for s in sugs)
+


### PR DESCRIPTION
## Summary
- expand `QualiaKnowledge` to guardar nombres de variables y módulos usados
- analizar conocimiento en `QualiaSpirit.suggestions`
- añadir sugerencias contextuales sobre `pandas` y asignaciones repetidas
- actualizar tests para cubrir nuevas reglas

## Testing
- `PYTHONPATH=./backend/src pytest tests/unit/test_qualia_bridge.py::test_qualia_state_persistence -q`
- `PYTHONPATH=./backend/src pytest tests/unit/test_qualia_bridge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881c3a30aec83279f4bbe3b41b18ae5