### PR TITLE
Implement Qualia CLI command

### DIFF
--- a/backend/src/cli/cli.py
+++ b/backend/src/cli/cli.py
@@ -25,6 +25,7 @@ from src.cli.commands.modules_cmd import ModulesCommand
 from src.cli.commands.package_cmd import PaqueteCommand
 from src.cli.commands.plugins_cmd import PluginsCommand
 from src.cli.commands.profile_cmd import ProfileCommand
+from src.cli.commands.qualia_cmd import QualiaCommand
 from src.cli.commands.transpilar_inverso_cmd import TranspilarInversoCommand
 from src.cli.commands.verify_cmd import VerifyCommand
 from src.cli.i18n import _, format_traceback, setup_gettext
@@ -89,6 +90,7 @@ def main(argv=None):
         BenchTranspilersCommand(),
         BenchThreadsCommand(),
         ProfileCommand(),
+        QualiaCommand(),
         CacheCommand(),
         TranspilarInversoCommand(),
         VerifyCommand(),

--- a/backend/src/cli/commands/qualia_cmd.py
+++ b/backend/src/cli/commands/qualia_cmd.py
@@ -1,0 +1,42 @@
+import json
+import os
+
+from src.cli.commands.base import BaseCommand
+from src.cli.i18n import _
+from src.cli.utils.messages import mostrar_error, mostrar_info
+from core import qualia_bridge
+
+
+class QualiaCommand(BaseCommand):
+    """Gestiona el estado del sistema Qualia."""
+
+    name = "qualia"
+
+    def register_subparser(self, subparsers):
+        """Registra los argumentos del subcomando."""
+        parser = subparsers.add_parser(
+            self.name, help=_("Administra el estado de Qualia")
+        )
+        sub = parser.add_subparsers(dest="accion")
+        sub.add_parser("mostrar", help=_("Muestra la base de conocimiento"))
+        sub.add_parser("reiniciar", help=_("Elimina el estado guardado"))
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args):
+        """Ejecuta la lógica del comando."""
+        accion = args.accion
+        if accion == "mostrar":
+            data = qualia_bridge.QUALIA.knowledge.as_dict()
+            print(json.dumps(data, ensure_ascii=False, indent=2))
+            return 0
+        if accion == "reiniciar":
+            state = qualia_bridge.STATE_FILE
+            if os.path.exists(state):
+                os.remove(state)
+                mostrar_info(_("Estado de Qualia eliminado"))
+            else:
+                mostrar_info(_("No existe estado de Qualia"))
+            return 0
+        mostrar_error(_("Acción no reconocida"))
+        return 1

--- a/tests/unit/test_cli_qualia_cmd.py
+++ b/tests/unit/test_cli_qualia_cmd.py
@@ -1,0 +1,36 @@
+import importlib
+import json
+from io import StringIO
+from unittest.mock import patch
+
+
+def _capture_json(output: str) -> dict:
+    start = output.find("{")
+    end = output.rfind("}") + 1
+    return json.loads(output[start:end])
+
+
+def test_cli_qualia_mostrar(tmp_path, monkeypatch):
+    state = tmp_path / "state.json"
+    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
+    from core import qualia_bridge
+    qb = importlib.reload(qualia_bridge)
+    qb.register_execution("imprimir(1)")
+    from cli.cli import main
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["qualia", "mostrar"])
+    data = _capture_json(out.getvalue())
+    assert data["node_counts"].get("NodoImprimir")
+
+
+def test_cli_qualia_reiniciar(tmp_path, monkeypatch):
+    state = tmp_path / "state.json"
+    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
+    from core import qualia_bridge
+    importlib.reload(qualia_bridge)
+    state.write_text("{}")
+    from cli.cli import main
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["qualia", "reiniciar"])
+    assert not state.exists()
+    assert "Estado de Qualia eliminado" in out.getvalue()


### PR DESCRIPTION
## Summary
- add a new QualiaCommand with `mostrar` and `reiniciar` actions
- register the command in the CLI
- add unit tests for the new command

## Testing
- `pytest -q tests/unit/test_cli_qualia_cmd.py`

------
https://chatgpt.com/codex/tasks/task_e_6881c6f93df88327913c9cee86d72dc7