### PR TITLE
Update Qualia docs

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -174,9 +174,25 @@ Se añadieron nuevas construcciones al lenguaje:
 ## 12. Uso de Qualia
 
 Qualia registra cada ejecución y genera sugerencias para mejorar tu código.
-El estado se guarda en `qualia_state.json`. Puedes obtener las sugerencias
-ejecutando `sugerencias` en el modo interactivo o escribiendo `%sugerencias`
-en el kernel de Jupyter.
+El estado se guarda en `qualia_state.json` para conservar la información entre
+sesiones.
+
+Cada vez que ejecutes o transpilas un programa se actualiza la base de
+conocimiento. Puedes consultarla con:
+
+```bash
+cobra qualia mostrar
+```
+
+Si deseas empezar de cero ejecuta:
+
+```bash
+cobra qualia reiniciar
+```
+
+En el modo interactivo escribe `sugerencias` para obtener las recomendaciones
+actuales o bien `%sugerencias` en Jupyter. Las propuestas se vuelven más
+detalladas a medida que Qualia aprende de tu código.
 
 ## 13. Bibliotecas compartidas con ctypes
 

--- a/frontend/docs/qualia.rst
+++ b/frontend/docs/qualia.rst
@@ -1,11 +1,35 @@
 Sistema Qualia
 ==============
 
-Qualia Spirit almacena un historial de las ejecuciones realizadas con Cobra.
-Con esa información genera sugerencias sencillas para mejorar el código.
-El estado se persiste en ``qualia_state.json`` para que las recomendaciones
-estén disponibles entre sesiones.
+Qualia Spirit registra un historial de todo el codigo ejecutado y analiza el AST resultante. Con esa informacion construye una *base de conocimiento* que contiene:
+
+- ``node_counts``: cu\u00e1ntas veces aparece cada tipo de nodo.
+- ``patterns``: peque\u00f1os patrones detectados (``lambda``, ``try_catch``, etc.).
+- ``variable_names``: nombres de variables y su frecuencia.
+- ``modules_used``: m\u00f3dulos importados durante las ejecuciones.
+
+Todo el estado se guarda en ``qualia_state.json`` para que las recomendaciones se mantengan entre sesiones.
+
+Generaci\u00f3n de sugerencias
+---------------------------
+
+A partir de la informaci\u00f3n recolectada, Cobra ofrece sugerencias para
+mejorar tus programas. Por ejemplo, si detecta variables con nombres muy
+cortos indicar\u00e1 que uses descripciones m\u00e1s claras. Si usas ``pandas`` sin
+``matplotlib`` te sugerir\u00e1 incorporar esta \u00faltima para graficar.
+
+Uso del subcomando ``qualia``
+-----------------------------
+
+Puedes inspeccionar o reiniciar el estado con el subcomando ``qualia``:
+
+.. code-block:: bash
+
+   cobra qualia mostrar
+   cobra qualia reiniciar
+
+El primer comando imprime la base de conocimiento en formato JSON. El segundo
+elimina ``qualia_state.json`` y comienza desde cero.
 
 Para ver las sugerencias en el modo interactivo escribe ``sugerencias``.
 En Jupyter puedes ejecutar una celda con ``%sugerencias``.
-


### PR DESCRIPTION
## Summary
- document the expanded Qualia knowledge base and subcommand
- add examples to the manual showing how Qualia learns over time

## Testing
- `pytest tests/unit/test_qualia_bridge.py -q`
- `make html`

------
https://chatgpt.com/codex/tasks/task_e_6881ca98ce8c8327aceb783ada3a65ac