### PR TITLE
Registra fallos de importación

### DIFF
--- a/backend/src/src/__init__.py
+++ b/backend/src/src/__init__.py
@@ -1,8 +1,12 @@
-import importlib, sys
+import importlib
+import logging
+import sys
+
+logging.basicConfig(level=logging.INFO)
 
 for pkg in ["cli", "cobra", "core", "ia", "jupyter_kernel", "tests"]:
     try:
         module = importlib.import_module(pkg)
         sys.modules[__name__ + "." + pkg] = module
-    except Exception:
-        pass  # nosec B110
+    except Exception as e:  # nosec B110
+        logging.warning("No se pudo importar %s: %s", pkg, e)


### PR DESCRIPTION
## Summary
- muestra advertencias en `backend/src/src/__init__.py` cuando un paquete no se puede importar

## Testing
- `pytest -q` *(falla: 76 errors)*
- `PYTHONPATH=backend/src python - <<'PY'
import logging, io
log_stream = io.StringIO()
logging.basicConfig(level=logging.INFO, stream=log_stream)
import backend.src.src
print(log_stream.getvalue())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6881db20b258832780a9ea66a737754f