### PR TITLE
Fix file descriptor leak in benchmark commands

### DIFF
--- a/backend/src/cli/commands/bench_cmd.py
+++ b/backend/src/cli/commands/bench_cmd.py
@@ -68,7 +68,9 @@ class BenchCommand(BaseCommand):
     def _run_benchmarks(self) -> list[dict[str, object]]:
         env = os.environ.copy()
         env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
-        env["PCOBRA_TOML"] = str(Path(tempfile.mkstemp(suffix=".toml")[1]))
+        fd, tmp_path = tempfile.mkstemp(suffix=".toml")
+        os.close(fd)
+        env["PCOBRA_TOML"] = str(Path(tmp_path))
 
         results = []
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/backend/src/cli/commands/benchmarks2_cmd.py
+++ b/backend/src/cli/commands/benchmarks2_cmd.py
@@ -103,7 +103,9 @@ class BenchmarksV2Command(BaseCommand):
         """Ejecuta la lógica del comando."""
         env = os.environ.copy()
         env["PYTHONPATH"] = str(Path(__file__).resolve().parents[3])
-        env["PCOBRA_TOML"] = str(Path(tempfile.mkstemp(suffix=".toml")[1]))
+        fd, tmp_path = tempfile.mkstemp(suffix=".toml")
+        os.close(fd)
+        env["PCOBRA_TOML"] = str(Path(tmp_path))
         env.pop("PYTEST_CURRENT_TEST", None)
 
         results = []

--- a/backend/src/cli/commands/benchmarks_cmd.py
+++ b/backend/src/cli/commands/benchmarks_cmd.py
@@ -74,7 +74,9 @@ class BenchmarksCommand(BaseCommand):
         """Ejecuta la lógica del comando."""
         env = os.environ.copy()
         env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
-        env["PCOBRA_TOML"] = str(Path(tempfile.mkstemp(suffix=".toml")[1]))
+        fd, tmp_path = tempfile.mkstemp(suffix=".toml")
+        os.close(fd)
+        env["PCOBRA_TOML"] = str(Path(tmp_path))
 
         results = []
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/backend/src/cli/commands/benchthreads_cmd.py
+++ b/backend/src/cli/commands/benchthreads_cmd.py
@@ -98,7 +98,9 @@ class BenchThreadsCommand(BaseCommand):
         """Ejecuta la lógica del comando."""
         env = os.environ.copy()
         env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
-        env["PCOBRA_TOML"] = str(Path(tempfile.mkstemp(suffix=".toml")[1]))
+        fd, tmp_path = tempfile.mkstemp(suffix=".toml")
+        os.close(fd)
+        env["PCOBRA_TOML"] = str(Path(tmp_path))
 
         results = []
 

--- a/scripts/benchmarks/compare_backends.py
+++ b/scripts/benchmarks/compare_backends.py
@@ -60,7 +60,9 @@ def main() -> None:
 
     env = os.environ.copy()
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "backend")
-    env["PCOBRA_TOML"] = str(Path(tempfile.mkstemp(suffix=".toml")[1]))
+    fd, tmp_path = tempfile.mkstemp(suffix=".toml")
+    os.close(fd)
+    env["PCOBRA_TOML"] = str(Path(tmp_path))
 
     results = []
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/scripts/benchmarks/run_benchmarks.py
+++ b/scripts/benchmarks/run_benchmarks.py
@@ -64,7 +64,9 @@ def run_and_measure(cmd: list[str], env: dict[str, str] | None = None) -> tuple[
 def main() -> None:
     env = os.environ.copy()
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "backend")
-    env["PCOBRA_TOML"] = str(Path(tempfile.mkstemp(suffix=".toml")[1]))
+    fd, tmp_path = tempfile.mkstemp(suffix=".toml")
+    os.close(fd)
+    env["PCOBRA_TOML"] = str(Path(tmp_path))
 
     results = []
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- close file descriptors after calling `tempfile.mkstemp`
- keep only the generated path for the `PCOBRA_TOML` env var

## Testing
- `pytest -vv tests/unit/test_bench_cmd.py::test_bench_profile_creates_json -s` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6881e042bbec8327b9106f7c6174d1ea