### PR TITLE
Remove duplicate RETORNO token

### DIFF
--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -234,7 +234,6 @@ class Lexer:
             (TipoToken.LBRACKET, r"\["),
             (TipoToken.RBRACKET, r"\]"),
             (TipoToken.COMA, r","),
-            (TipoToken.RETORNO, r"\bretorno\b"),
             (TipoToken.DECORADOR, r"@"),
             (None, r"\s+"),  # Ignorar espacios en blanco
         ]


### PR DESCRIPTION
## Summary
- remove repeated token specification for `RETORNO` in lexer
- keep remaining specification order the same

## Testing
- `pytest tests/unit/test_lexer.py tests/unit/test_lexer_basics.py tests/unit/test_lexer_additional_cases.py tests/unit/lexer_test_casos_edge.py tests/unit/test_nuevos_tokens.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881e4f2ec248327812f2d2370942379