### PR TITLE
Optimize lexer regex compilation

### DIFF
--- a/backend/src/cobra/lexico/lexer.py
+++ b/backend/src/cobra/lexico/lexer.py
@@ -238,6 +238,12 @@ class Lexer:
             (None, r"\s+"),  # Ignorar espacios en blanco
         ]
 
+        # Compilar las expresiones regulares una sola vez
+        especificacion_tokens = [
+            (tipo, re.compile(patron, re.UNICODE))
+            for tipo, patron in especificacion_tokens
+        ]
+
         prev_pos = -1
         same_pos_count = 0
         linea = 1
@@ -245,8 +251,7 @@ class Lexer:
 
         while self.posicion < len(self.codigo_fuente):
             matched = False
-            for tipo, patron in especificacion_tokens:
-                regex = re.compile(patron, re.UNICODE)
+            for tipo, regex in especificacion_tokens:
                 coincidencia = regex.match(self.codigo_fuente[self.posicion:])
                 if coincidencia:
                     valor_original = coincidencia.group(0)


### PR DESCRIPTION
## Summary
- compile regex patterns once in `Lexer`
- reuse compiled regex objects for matching

## Testing
- `pytest tests/unit/test_lexer.py tests/unit/test_lexer2.py tests/unit/test_lexer_basics.py tests/unit/test_lexer_errors.py tests/unit/test_lexer_errors_extra.py tests/unit/test_lexer_metodo_atributo.py tests/unit/test_lexer_additional_cases.py tests/unit/lexer_test_casos_edge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881e6a4da7c832780c8ab6c06ca3523