### PR TITLE
Manejo robusto de errores en sistema.ejecutar

### DIFF
--- a/backend/corelibs/__init__.py
+++ b/backend/corelibs/__init__.py
@@ -1,13 +1,13 @@
 """Colección de utilidades estándar para Cobra."""
 
-from corelibs.texto import mayusculas, minusculas, invertir, concatenar
-from corelibs.numero import es_par, es_primo, factorial, promedio
-from corelibs.archivo import leer, escribir, existe, eliminar
-from corelibs.tiempo import ahora, formatear, dormir
-from corelibs.coleccion import ordenar, maximo, minimo, sin_duplicados
-from corelibs.seguridad import hash_md5, hash_sha256, generar_uuid
-from corelibs.red import obtener_url, enviar_post
-from corelibs.sistema import obtener_os, ejecutar, obtener_env, listar_dir
+from .texto import mayusculas, minusculas, invertir, concatenar
+from .numero import es_par, es_primo, factorial, promedio
+from .archivo import leer, escribir, existe, eliminar
+from .tiempo import ahora, formatear, dormir
+from .coleccion import ordenar, maximo, minimo, sin_duplicados
+from .seguridad import hash_md5, hash_sha256, generar_uuid
+from .red import obtener_url, enviar_post
+from .sistema import obtener_os, ejecutar, obtener_env, listar_dir
 
 __all__ = [
     "mayusculas",

--- a/backend/corelibs/sistema.py
+++ b/backend/corelibs/sistema.py
@@ -12,16 +12,26 @@ def obtener_os() -> str:
 
 
 def ejecutar(comando: str) -> str:
-    """Ejecuta un comando y devuelve su salida."""
+    """Ejecuta un comando y devuelve su salida.
+
+    Si el comando finaliza con un código de error se captura la excepción
+    ``subprocess.CalledProcessError`` devolviendo ``stderr`` cuando esté
+    disponible o lanzando un ``RuntimeError`` con información detallada.
+    """
     args = shlex.split(comando)
-    resultado = subprocess.run(
-        args,
-        check=True,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    return resultado.stdout
+    try:
+        resultado = subprocess.run(
+            args,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return resultado.stdout
+    except subprocess.CalledProcessError as exc:
+        if exc.stderr:
+            return exc.stderr
+        raise RuntimeError(f"Error al ejecutar '{comando}': {exc}") from exc
 
 
 def obtener_env(nombre: str) -> str | None:

--- a/tests/unit/test_corelibs_sistema.py
+++ b/tests/unit/test_corelibs_sistema.py
@@ -1,0 +1,27 @@
+import subprocess
+from unittest.mock import MagicMock
+import pytest
+
+import backend.corelibs as core
+
+
+def test_ejecutar_exitoso(monkeypatch):
+    proc = MagicMock()
+    proc.stdout = 'ok'
+    monkeypatch.setattr(core.sistema.subprocess, 'run', lambda *a, **k: proc)
+    assert core.ejecutar('echo ok') == 'ok'
+
+
+def test_ejecutar_error(monkeypatch):
+    def raise_err(*a, **k):
+        raise subprocess.CalledProcessError(1, a[0], stderr='fallo')
+
+    monkeypatch.setattr(core.sistema.subprocess, 'run', raise_err)
+    assert core.ejecutar('bad') == 'fallo'
+
+    def raise_err2(*a, **k):
+        raise subprocess.CalledProcessError(1, a[0])
+
+    monkeypatch.setattr(core.sistema.subprocess, 'run', raise_err2)
+    with pytest.raises(RuntimeError):
+        core.ejecutar('bad')


### PR DESCRIPTION
## Summary
- handle `subprocess.run` errors in `backend/corelibs/sistema.py`
- use relative imports in `backend/corelibs/__init__.py`
- add unit tests for the new behaviour

## Testing
- `pytest tests/unit/test_corelibs_sistema.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881e7fc3ab48327a4e1125756dbbf7e