### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,10 @@
 name: Release
 
+permissions:
+  contents: read
+  packages: write
+  actions: write
+
 on:
   push:
     tags: ['v*']


### PR DESCRIPTION
Potential fix for [https://github.com/Alphonsus411/pCobra/security/code-scanning/23](https://github.com/Alphonsus411/pCobra/security/code-scanning/23)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow (e.g., uploading to PyPI, pushing Docker images, creating GitHub releases), the following permissions are required:
- `contents: read` for accessing repository contents.
- `packages: write` for uploading packages to PyPI.
- `actions: write` for managing workflow artifacts.
- `pull-requests: write` for interacting with pull requests (if applicable).

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
