### PR TITLE
Update documentation to new src layout and PyInstaller usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,42 +25,42 @@ Para agilizar la organización del proyecto, categoriza cada tarea utilizando la
 - Ejecuta `make secrets` para buscar credenciales expuestas con *gitleaks*.
 - Usa `make typecheck` para la verificacion de tipos.
 - Para analisis estatico con `pyright`, instala el paquete y ejecuta
-  `pyright backend/src` (o `make typecheck`).
+  `pyright src` (o `make typecheck`).
 - Cualquier cambio en el lenguaje debe seguir lo descrito en
   [SPEC_COBRA.md](SPEC_COBRA.md).
 
 ## PYTHONPATH y PyCharm
 
 Para que las importaciones `from src...` funcionen durante el desarrollo,
-define el directorio `backend/src` en la variable `PYTHONPATH` o instala el
+define el directorio `src` en la variable `PYTHONPATH` o instala el
 paquete en modo editable con `pip install -e .`:
 
 ```bash
-export PYTHONPATH=$PWD/backend/src
+export PYTHONPATH=$PWD/src
 ```
 
-En PyCharm marca `backend/src` como *Sources Root* para que resuelva las rutas
+En PyCharm marca `src` como *Sources Root* para que resuelva las rutas
 correctamente. Un ejemplo rápido de ejecución sería:
 
 ```bash
-PYTHONPATH=$PWD/backend/src python -c "from src.core.main import main; main()"
+PYTHONPATH=$PWD/src python -c "from src.core.main import main; main()"
 ```
 
 ## Ejecutar Pruebas
 
 Las pruebas unitarias se ubican en `tests/unit` y las de integración en
-`tests/integration`. Antes de ejecutarlas, establece `PYTHONPATH=$PWD/backend/src`
+`tests/integration`. Antes de ejecutarlas, establece `PYTHONPATH=$PWD/src`
 o instala el paquete en modo editable (`pip install -e .`). Para ejecutarlas
 todas utiliza:
 
 ```bash
-PYTHONPATH=$PWD/backend/src pytest
+PYTHONPATH=$PWD/src pytest
 ```
 
 Para generar un reporte de cobertura:
 
 ```bash
-PYTHONPATH=$PWD/backend/src pytest --cov
+PYTHONPATH=$PWD/src pytest --cov
 ```
 
 Además de las pruebas, ejecuta las verificaciones de estilo con:

--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -127,7 +127,7 @@ cobra compilar ejemplo.co --tipo python
 ```
 
 Si prefieres usar las clases del proyecto, llama al módulo
-[`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler)
+[`src/cobra/transpilers/transpiler`](src/cobra/transpilers/transpiler)
 de la siguiente forma:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -144,22 +144,22 @@ cobra ejecutar hola.co
 ### PYTHONPATH y PyCharm
 
 Para que las importaciones `from src...` funcionen desde la consola y PyCharm,
-agrega el directorio `backend/src` al `PYTHONPATH` o instala el paquete en modo
+agrega el directorio `src` al `PYTHONPATH` o instala el paquete en modo
 editable con `pip install -e .`:
 
 ```bash
-export PYTHONPATH=$PWD/backend/src
+export PYTHONPATH=$PWD/src
 # o bien
 pip install -e .
 ```
 
-En PyCharm marca la carpeta `backend/src` como *Sources Root* para que las
+En PyCharm marca la carpeta `src` como *Sources Root* para que las
 importaciones se resuelvan correctamente.
 
 Puedes verificar la configuración ejecutando en la consola:
 
 ```bash
-PYTHONPATH=$PWD/backend/src python -c "from src.core.main import main; main()"
+PYTHONPATH=$PWD/src python -c "from src.core.main import main; main()"
 ```
 
 ### Instalación con pipx
@@ -214,11 +214,35 @@ cobra empaquetar --spec build/cobra.spec \
   --add-data "all-bytes.dat;all-bytes.dat" --output dist
 ```
 
+## Crear un ejecutable con PyInstaller
+
+Para compilar Cobra de forma independiente primero crea y activa un entorno virtual:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # En Windows usa .\\.venv\\Scripts\\activate
+```
+
+Instala la distribución publicada y PyInstaller:
+
+```bash
+pip install cobra-lenguaje
+pip install pyinstaller
+```
+
+Luego genera el binario con:
+
+```bash
+pyinstaller --onefile -m src.main -n cobra
+```
+
+El ejecutable aparecerá en el directorio `dist/`.
+
 # Estructura del Proyecto
 
 El proyecto se organiza en las siguientes carpetas y módulos:
 
-- `backend/src/`: Contiene la lógica Python del proyecto.
+- `src/`: Contiene la lógica Python del proyecto.
 - `frontend/docs/` y `frontend/build/`: Carpetas donde se genera y aloja la documentación. El archivo `frontend/docs/arquitectura.rst` describe la estructura interna del lenguaje. Consulta `docs/arquitectura_parser_transpiladores.md` para un resumen de la relación entre lexer, parser y transpiladores.
 - `tests/`: Incluye pruebas unitarias para asegurar el correcto funcionamiento del código.
 - `README.md`: Documentación del proyecto.
@@ -290,11 +314,11 @@ están disponibles en `frontend/docs/benchmarking.rst`.
 Para ejecutar pruebas unitarias, utiliza pytest:
 
 ````bash
-PYTHONPATH=$PWD pytest backend/src/tests --cov=backend/src --cov-report=term-missing \
+PYTHONPATH=$PWD pytest src/tests --cov=src --cov-report=term-missing \
   --cov-fail-under=95
 ````
 
-También puedes ejecutar suites específicas ubicadas en `backend/src/tests`:
+También puedes ejecutar suites específicas ubicadas en `src/tests`:
 
 ````bash
 python -m tests.suite_cli           # Solo pruebas de la CLI
@@ -475,7 +499,7 @@ paquete no está disponible, Cobra ejecutará `pip install paquete` para
 instalarlo y luego lo cargará en tiempo de ejecución. El módulo queda
 registrado en el entorno bajo el mismo nombre para su uso posterior.
 Para restringir qué dependencias pueden instalarse se emplea la variable
-`USAR_WHITELIST` definida en `backend/src/cobra/usar_loader.py`. Basta con
+`USAR_WHITELIST` definida en `src/cobra/usar_loader.py`. Basta con
 añadir o quitar nombres de paquetes en dicho conjunto para modificar la lista
 autorizada. Si la lista se deja vacía la función `obtener_modulo` lanzará
 `PermissionError`, por lo que es necesario poblarla antes de permitir
@@ -502,7 +526,7 @@ editar `cobra.mod` y volver a ejecutar las pruebas.
 
 ## Invocar el transpilador
 
-La carpeta [`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler)
+La carpeta [`src/cobra/transpilers/transpiler`](src/cobra/transpilers/transpiler)
 contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX. Una vez
 instaladas las dependencias, puedes llamar al transpilador desde tu propio
 script de la siguiente manera:
@@ -672,7 +696,7 @@ Actualmente la cobertura varía según el lenguaje y puede que ciertas construcc
 
 ### Diseño extensible de la CLI
 
-La CLI está organizada en clases dentro de `backend/src/cli/commands`. Cada subcomando
+La CLI está organizada en clases dentro de `src/cli/commands`. Cada subcomando
 hereda de `BaseCommand` y define su nombre, los argumentos que acepta y la acción
 a ejecutar. En `src/cli/cli.py` se instancian automáticamente y se registran en
 `argparse`, por lo que para añadir un nuevo comando solo es necesario crear un
@@ -706,7 +730,7 @@ posible para reducir riesgos.
 Las pruebas están ubicadas en la carpeta tests/ y utilizan pytest para la ejecución. Antes de correrlas añade el proyecto al `PYTHONPATH` o instala el paquete en modo editable (`pip install -e .`). Así pytest podrá encontrar los módulos correctamente.
 
 ````bash
-PYTHONPATH=$PWD pytest backend/src/tests --cov=backend/src --cov-report=term-missing \
+PYTHONPATH=$PWD pytest src/tests --cov=src --cov-report=term-missing \
   --cov-fail-under=95
 ````
 
@@ -719,7 +743,7 @@ PYTHONPATH=$PWD pytest
 En la integración continua se emplea:
 
 ```bash
-pytest --cov=backend/src tests/
+pytest --cov=src tests/
 ```
 
 El reporte se guarda como `coverage.xml` y se utiliza en el CI.
@@ -774,7 +798,7 @@ con los archivos `.po` de traducción y envía un pull request.
 Para obtener un reporte de cobertura en la terminal ejecuta:
 
 ````bash
-pytest --cov=backend/src --cov-report=term-missing --cov-fail-under=95
+pytest --cov=src --cov-report=term-missing --cov-fail-under=95
 ````
 
 ## Caché del AST
@@ -860,7 +884,7 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
   (formateo con `black`, longitud máxima de línea 88 y uso de `flake8`, `mypy`
   y `bandit`).
 - Realiza tus cambios y haz commit (`git commit -m 'Añadir nueva característica'`).
-- Ejecuta `make lint` para verificar el código con *flake8*, *mypy* y *bandit*. `bandit` analizará los directorios `src` y `backend/src`.
+- Ejecuta `make lint` para verificar el código con *flake8*, *mypy* y *bandit*. `bandit` analizará el directorio `src`.
 - Ejecuta `make typecheck` para la verificación estática con *mypy* (y
   opcionalmente *pyright* si está instalado).
 - Ejecuta `make secrets` para buscar credenciales expuestas usando *gitleaks*.
@@ -897,7 +921,7 @@ También contamos con un canal de **Telegram** y una cuenta de **Twitter** donde
 Para verificar el tipado de forma local ejecuta:
 
 ```bash
-mypy backend/src
+mypy src
 pyright --project pyrightconfig.json
 ```
 
@@ -911,12 +935,12 @@ make secrets
 ```
 El segundo comando ejecuta *gitleaks* para detectar posibles secretos en el repositorio.
 
-Esto ejecutará `flake8` y `mypy` sobre `backend/src`, y `bandit` revisará los directorios `src` y `backend/src`. Si prefieres lanzar las herramientas de
+Esto ejecutará `flake8` y `mypy` sobre `src`, y `bandit` revisará el directorio `src`. Si prefieres lanzar las herramientas de
 manera individual utiliza:
 
 ```bash
-flake8 backend/src
-mypy backend/src
+flake8 src
+mypy src
 ```
 
 ## Desarrollo de plugins

--- a/README_en.md
+++ b/README_en.md
@@ -122,19 +122,19 @@ cobra ejecutar hola.co
 
 ### PYTHONPATH and PyCharm
 
-For the imports `from src...` to work from the console and PyCharm, add the directory `backend/src` to `PYTHONPATH` or install the package in editable mode with `pip install -e .`:
+For the imports `from src...` to work from the console and PyCharm, add the directory `src` to `PYTHONPATH` or install the package in editable mode with `pip install -e .`:
 
 ```bash
-export PYTHONPATH=$PWD/backend/src
+export PYTHONPATH=$PWD/src
 # or
 pip install -e .
 ```
 
-In PyCharm mark the folder `backend/src` as *Sources Root* so that the imports resolve correctly.
+In PyCharm mark the folder `src` as *Sources Root* so that the imports resolve correctly.
 You can verify the configuration by running in the console:
 
 ```bash
-PYTHONPATH=$PWD/backend/src python -c "from src.core.main import main; main()"
+PYTHONPATH=$PWD/src python -c "from src.core.main import main; main()"
 ```
 
 ### Installation with pipx
@@ -180,11 +180,35 @@ cobra empaquetar --spec build/cobra.spec \
   --add-data "all-bytes.dat;all-bytes.dat" --output dist
 ```
 
+## Build an executable with PyInstaller
+
+If you want to compile Cobra manually follow these steps:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows use .\\.venv\\Scripts\\activate
+```
+
+Install the published package and PyInstaller:
+
+```bash
+pip install cobra-lenguaje
+pip install pyinstaller
+```
+
+Generate the binary with:
+
+```bash
+pyinstaller --onefile -m src.main -n cobra
+```
+
+The executable will be placed inside the `dist/` directory.
+
 # Project Structure
 
 The project is organized into the following folders and modules:
 
-- `backend/src/`: Contains the Python logic of the project.
+- `src/`: Contains the Python logic of the project.
 - `frontend/docs/` and `frontend/build/`: Folders where the documentation is generated and stored. The file `frontend/docs/arquitectura.rst` describes the internal structure of the language.
 - `tests/`: Unit tests to ensure correct behaviour of the code.
 - `README.md`: Project documentation.
@@ -239,11 +263,11 @@ For advanced options of safe mode see `frontend/docs/modo_seguro.rst`. Performan
 To run unit tests use pytest:
 
 ```bash
-PYTHONPATH=$PWD pytest backend/src/tests --cov=backend/src --cov-report=term-missing \
+PYTHONPATH=$PWD pytest src/tests --cov=src --cov-report=term-missing \
   --cov-fail-under=95
 ```
 
-You can also run specific suites located in `backend/src/tests`:
+You can also run specific suites located in `src/tests`:
 
 ```bash
 python -m tests.suite_cli           # CLI tests only
@@ -353,7 +377,7 @@ When running `programa.co`, `modulo.co` is processed first and then `Hola desde 
 
 ## `usar` statement for dynamic dependencies
 
-The statement `usar "paquete"` tries to import a Python module. If the package is not available, Cobra will run `pip install paquete` to install it and then load it at runtime. The module is registered in the environment under the same name for later use. To restrict which dependencies can be installed use the variable `USAR_WHITELIST` defined in `backend/src/cobra/usar_loader.py`.
+The statement `usar "paquete"` tries to import a Python module. If the package is not available, Cobra will run `pip install paquete` to install it and then load it at runtime. The module is registered in the environment under the same name for later use. To restrict which dependencies can be installed use the variable `USAR_WHITELIST` defined in `src/cobra/usar_loader.py`.
 
 ## Module mapping file
 
@@ -372,7 +396,7 @@ If an entry is not found, the transpiler will load the file indicated in the `im
 
 ## Calling the transpiler
 
-The folder [`backend/src/cobra/transpilers/transpiler`](backend/src/cobra/transpilers/transpiler) contains the implementation of the transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo and LaTeX. Once the dependencies are installed you can call the transpiler from your own script like this:
+The folder [`src/cobra/transpilers/transpiler`](src/cobra/transpilers/transpiler) contains the implementation of the transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo and LaTeX. Once the dependencies are installed you can call the transpiler from your own script like this:
 
 ```python
 from cobra.transpilers.transpiler.to_python import TranspiladorPython

--- a/SPEC_COBRA.md
+++ b/SPEC_COBRA.md
@@ -65,7 +65,7 @@ IDENTIFICADOR: /[^\W\d_][\w]*/
 Cada regla define construcciones del lenguaje: por ejemplo `asignacion` utiliza `var` para crear variables, `funcion` agrupa parámetros y un cuerpo, y `try_catch` permite atrapar errores con `try` o `intentar` y `catch` o `capturar`.
 
 ## Tokens y palabras reservadas
-El lexer de `backend/src/cobra/lexico/lexer.py` define todos los tokens. Las principales palabras clave son:
+El lexer de `src/cobra/lexico/lexer.py` define todos los tokens. Las principales palabras clave son:
 - `var`, `variable`, `func`, `metodo`, `atributo`, `rel`
 - `si`, `sino`, `mientras`, `para`, `import`, `usar`, `macro`, `hilo`, `asincronico`
 - `switch`, `case`, `clase`, `in`, `holobit`, `proyectar`, `transformar`, `graficar`

--- a/docs/cache_incremental.md
+++ b/docs/cache_incremental.md
@@ -1,7 +1,7 @@
 # Caché incremental de tokens y AST
 
 Se ha incorporado un sistema de almacenamiento por fragmentos en
-`backend/src/core/ast_cache.py`. Cada línea del código puede guardarse
+`src/core/ast_cache.py`. Cada línea del código puede guardarse
 por separado mediante un *checksum*, permitiendo reutilizar los
 fragmentos que no cambian entre ejecuciones.
 

--- a/examples/tutorial_basico/README.md
+++ b/examples/tutorial_basico/README.md
@@ -12,11 +12,11 @@ Este directorio contiene un ejemplo mínimo de un programa escrito en Cobra y su
 
 1. Ejecutar la transpilación:
    ```bash
-   PYTHONPATH=..:../backend/src python compile_manual.py > hola_mundo.py
+   PYTHONPATH=..:../src python compile_manual.py > hola_mundo.py
    ```
    El script `compile_manual.py` usa los módulos de Cobra para convertir el archivo `hola_mundo.co` en Python.
 2. Ejecutar el script generado:
    ```bash
-   PYTHONPATH=..:../backend/src:../backend python hola_mundo.py > hola_mundo.out
+   PYTHONPATH=..:../src:../backend python hola_mundo.py > hola_mundo.out
    ```
 3. Revisar `hola_mundo.out` para ver el texto `Hola, mundo!`.

--- a/frontend/docs/benchmarking.rst
+++ b/frontend/docs/benchmarking.rst
@@ -15,7 +15,7 @@ de tiempo:
 
 .. code-block:: python
 
-    from core.performance import perfilar
+    from src.core.performance import perfilar
 
     def sumar(a, b):
         return a + b
@@ -31,7 +31,7 @@ Si deseas aplicar automáticamente optimizaciones de ``smooth-criminal`` usa
 
 .. code-block:: python
 
-    from core.performance import optimizar
+    from src.core.performance import optimizar
 
     @optimizar()
     def proceso():

--- a/frontend/docs/modo_seguro.rst
+++ b/frontend/docs/modo_seguro.rst
@@ -14,7 +14,7 @@ También se valida la
 instrucción ``import`` para permitir únicamente los módulos instalados o los
 especificados en ``IMPORT_WHITELIST``. La instrucción ``usar`` está limitada a
 los paquetes listados en ``USAR_WHITELIST`` ubicado en
-``backend/src/cobra/usar_loader.py``. Si esta lista se encuentra vacía, la
+``src/cobra/usar_loader.py``. Si esta lista se encuentra vacía, la
 función ``obtener_modulo`` provocará un ``PermissionError`` y no se podrán
 instalar dependencias nuevas.
 
@@ -52,7 +52,7 @@ Configuraciones avanzadas
 
 Las listas ``IMPORT_WHITELIST`` y ``USAR_WHITELIST`` determinan qué módulos y
 paquetes pueden cargarse cuando el modo seguro está activo. Puedes editarlas en
-``backend/src/cobra/import_loader.py`` y ``backend/src/cobra/usar_loader.py``
+``src/cobra/import_loader.py`` y ``src/cobra/usar_loader.py``
 respectivamente para afinar las restricciones. Recuerda que si
 ``USAR_WHITELIST`` está vacía no se permitirá la instalación de paquetes
 adicionales.

--- a/frontend/docs/validador.rst
+++ b/frontend/docs/validador.rst
@@ -35,7 +35,7 @@ otros validadores pasando una lista a esta función.
 
 .. code-block:: python
 
-   from core.semantic_validators import construir_cadena, ValidadorBase
+   from src.core.semantic_validators import construir_cadena, ValidadorBase
 
    class MiValidador(ValidadorBase):
        def visit_mi_nodo(self, nodo):
@@ -54,7 +54,7 @@ definir una lista ``VALIDADORES_EXTRA`` con las instancias a añadir.
 .. code-block:: python
 
    # archivo validadores.py
-   from core.semantic_validators.base import ValidadorBase
+   from src.core.semantic_validators.base import ValidadorBase
 
    class Demo(ValidadorBase):
        def visit_valor(self, nodo):


### PR DESCRIPTION
## Summary
- mention that Python code lives in `src/`
- update docs to reference `src/` paths
- add section on creating a virtual env, installing `cobra-lenguaje` and building an executable with PyInstaller

## Testing
- `pytest -k 'nonexistent_test_pattern'` *(fails: 178 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6883059629608327b551e9a8dfadff5b