### PR TITLE
Add PyInstaller test script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,16 @@ pyinstaller --onefile -m src.main -n cobra
 
 El ejecutable aparecerá en el directorio `dist/`.
 
+Para realizar una prueba rápida puedes ejecutar el script
+`scripts/test_pyinstaller.sh`. Este script crea un entorno virtual temporal,
+instala `cobra-lenguaje` desde el repositorio (o desde PyPI si se ejecuta fuera
+de él) y ejecuta PyInstaller sobre `src/cli/cli.py`. El binario resultante se
+guardará por defecto en `dist/`.
+
+```bash
+scripts/test_pyinstaller.sh
+```
+
 # Estructura del Proyecto
 
 El proyecto se organiza en las siguientes carpetas y módulos:

--- a/scripts/test_pyinstaller.sh
+++ b/scripts/test_pyinstaller.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+OUTPUT_DIR="${OUTPUT_DIR:-dist}"
+TMP_ENV="$(mktemp -d)"
+trap 'deactivate 2>/dev/null || true; rm -rf "$TMP_ENV"' EXIT
+
+python3 -m venv "$TMP_ENV/venv"
+source "$TMP_ENV/venv/bin/activate"
+
+if [ -f pyproject.toml ]; then
+    pip install .
+else
+    pip install cobra-lenguaje
+fi
+pip install pyinstaller
+
+pyinstaller --distpath "$OUTPUT_DIR" --onefile src/cli/cli.py
+
+echo "Binario generado en $OUTPUT_DIR"

--- a/tests/integration/test_pyinstaller_script.py
+++ b/tests/integration/test_pyinstaller_script.py
@@ -1,0 +1,22 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_pyinstaller_script(tmp_path):
+    if not shutil.which("pyinstaller"):
+        pytest.skip("pyinstaller no disponible")
+
+    script = ROOT / "scripts" / "test_pyinstaller.sh"
+    out_dir = tmp_path / "dist"
+    env = os.environ.copy()
+    env["OUTPUT_DIR"] = str(out_dir)
+    result = subprocess.run(["bash", str(script)], cwd=ROOT, env=env)
+    assert result.returncode == 0
+    assert any(out_dir.iterdir())
+


### PR DESCRIPTION
## Summary
- add `scripts/test_pyinstaller.sh` to build a PyInstaller binary in a temp venv
- document usage of the script in `README.md`
- add optional integration test to run the script when PyInstaller is available

## Testing
- `pytest tests/integration/test_pyinstaller_script.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68830d4136a08327b582a3d081e29bca