### PR TITLE
Add test dependencies to dev extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,7 @@ posible para reducir riesgos.
 # Pruebas
 
 Las pruebas están ubicadas en la carpeta tests/ y utilizan pytest para la ejecución. Antes de correrlas añade el proyecto al `PYTHONPATH` o instala el paquete en modo editable (`pip install -e .`). Así pytest podrá encontrar los módulos correctamente.
+También puedes instalar las dependencias de desarrollo con `pip install .[dev]` para contar con todas las herramientas necesarias.
 
 ````bash
 PYTHONPATH=$PWD pytest src/tests --cov=src --cov-report=term-missing \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,11 @@ dev = [
     "python-dotenv",
     "python-lsp-server",
     "hypothesis",
+    "ipykernel>=6.29.5",
+    "tree-sitter-languages>=1.10.2",
+    "pytest",
+    "pytest-cov",
+    "pytest-timeout",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- install test packages such as ipykernel and tree-sitter-languages in dev extras
- mention `pip install .[dev]` in README for running tests

## Testing
- `pytest tests/unit/test_archivo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883128d74188327b82420ae6ed9e83d