### PR TITLE
Implement escalar and mover operations for holobits

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,15 +476,17 @@ Al generar código para Python, `imprimir` se convierte en `print`, `mientras` e
 
 ## Integración con holobit-sdk
 
-El proyecto instala automáticamente la librería `holobit-sdk`, utilizada para visualizar y manipular holobits. Las funciones `graficar`, `proyectar` y `transformar` de `src.core.holobits` delegan en esta API.
+El proyecto instala automáticamente la librería `holobit-sdk`, utilizada para visualizar y manipular holobits. Las funciones `graficar`, `proyectar`, `transformar`, `escalar` y `mover` de `src.core.holobits` delegan en esta API.
 
 ```python
-from core.holobits import Holobit, graficar, proyectar, transformar
+from core.holobits import Holobit, graficar, proyectar, transformar, escalar, mover
 
 h = Holobit([0.8, -0.5, 1.2, 0.0, 0.0, 0.0])
 proyectar(h, "2D")
 graficar(h)
 transformar(h, "rotar", "z", 90)
+escalar(h, 2.0)
+mover(h, 1.0, 0.0, -1.0)
 ```
 
 ## Ejemplo de carga de módulos

--- a/frontend/docs/caracteristicas.rst
+++ b/frontend/docs/caracteristicas.rst
@@ -19,6 +19,10 @@ imprimir(proyeccion)
 var rotado = transformar(x, 'rotar', 45)
 imprimir(rotado)
 
+# Escalar y trasladar
+escalar(x, 2)
+mover(x, 1, 0, -1)
+
 # Graficar el holobit
 graficar(x)
 

--- a/frontend/docs/referencia.rst
+++ b/frontend/docs/referencia.rst
@@ -22,6 +22,8 @@ Funciones integradas
 - ``proyectar(h, modo)``: proyecta un holobit en ``modo`` (por ejemplo ``'2D'``).
 - ``transformar(h, accion, valor)``: aplica una transformación sobre un holobit.
 - ``graficar(h)``: visualiza el holobit en pantalla.
+- ``escalar(h, factor)``: multiplica las coordenadas por ``factor``.
+- ``mover(h, x, y, z)``: traslada el holobit en el espacio.
 
 Uso de la CLI
 -------------

--- a/src/core/holobits/__init__.py
+++ b/src/core/holobits/__init__.py
@@ -3,6 +3,13 @@
 from .holobit import Holobit
 from .graficar import graficar
 from .proyection import proyectar
-from .transformacion import transformar
+from .transformacion import transformar, escalar, mover
 
-__all__ = ["Holobit", "graficar", "proyectar", "transformar"]
+__all__ = [
+    "Holobit",
+    "graficar",
+    "proyectar",
+    "transformar",
+    "escalar",
+    "mover",
+]

--- a/src/core/holobits/transformacion.py
+++ b/src/core/holobits/transformacion.py
@@ -2,6 +2,7 @@
 
 from .holobit import Holobit
 from holobit_sdk.core.holobit import Holobit as SDKHolobit
+import numpy as np
 
 from .graficar import _to_sdk_holobit
 
@@ -16,4 +17,31 @@ def transformar(hb: Holobit, operacion: str, *parametros):
         sdk_hb.rotar(eje, angulo)
     else:
         raise ValueError(f"Operacion no soportada: {operacion}")
+    return None
+
+
+def escalar(hb: Holobit, factor: float):
+    """Escala un ``Holobit`` usando ``holobit-sdk``."""
+    if not isinstance(hb, Holobit):
+        raise TypeError("escalar espera una instancia de Holobit")
+    sdk_hb = _to_sdk_holobit(hb)
+    if hasattr(sdk_hb, "escalar"):
+        sdk_hb.escalar(float(factor))
+    else:
+        for q in sdk_hb.quarks + sdk_hb.antiquarks:
+            q.posicion *= float(factor)
+    return None
+
+
+def mover(hb: Holobit, x: float, y: float, z: float):
+    """Traslada un ``Holobit`` utilizando ``holobit-sdk``."""
+    if not isinstance(hb, Holobit):
+        raise TypeError("mover espera una instancia de Holobit")
+    sdk_hb = _to_sdk_holobit(hb)
+    if hasattr(sdk_hb, "mover"):
+        sdk_hb.mover(float(x), float(y), float(z))
+    else:
+        delta = np.array([float(x), float(y), float(z)])
+        for q in sdk_hb.quarks + sdk_hb.antiquarks:
+            q.posicion += delta
     return None

--- a/tests/unit/test_holobit_transformacion_extra.py
+++ b/tests/unit/test_holobit_transformacion_extra.py
@@ -1,0 +1,24 @@
+import pytest
+from core.holobits import Holobit, escalar, mover
+
+
+def test_escalar_usa_sdk(monkeypatch):
+    args = {}
+    def fake_escalar(self, factor):
+        args['factor'] = factor
+    monkeypatch.setattr('holobit_sdk.core.holobit.Holobit.escalar', fake_escalar, raising=False)
+    h = Holobit([1, 2, 3])
+    escalar(h, 2)
+    assert args == {'factor': 2.0}
+
+
+def test_mover_usa_sdk(monkeypatch):
+    args = {}
+    def fake_mover(self, x, y, z):
+        args['x'] = x
+        args['y'] = y
+        args['z'] = z
+    monkeypatch.setattr('holobit_sdk.core.holobit.Holobit.mover', fake_mover, raising=False)
+    h = Holobit([1, 2, 3])
+    mover(h, 0.5, -1.0, 2.0)
+    assert args == {'x': 0.5, 'y': -1.0, 'z': 2.0}


### PR DESCRIPTION
## Summary
- extend holobit transformations with `escalar` and `mover`
- expose new functions from `core.holobits`
- document new operations in README and docs
- add unit tests covering the new SDK calls

## Testing
- `pytest -q tests/unit/test_holobit_transformacion_extra.py`

------
https://chatgpt.com/codex/tasks/task_e_6883267938788327a6e258a387f2818f