### PR TITLE
Add tests and docs for holobit scaling & moving

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ Al generar código para Python, `imprimir` se convierte en `print`, `mientras` e
 
 ## Integración con holobit-sdk
 
-El proyecto instala automáticamente la librería `holobit-sdk`, utilizada para visualizar y manipular holobits. Las funciones `graficar`, `proyectar`, `transformar`, `escalar` y `mover` de `src.core.holobits` delegan en esta API.
+El proyecto instala automáticamente la librería `holobit-sdk`, utilizada para visualizar y manipular holobits. Las funciones `graficar`, `proyectar`, `transformar`, `escalar` y `mover` de `src.core.holobits` delegan en esta API. Desde la versión ``1.0.8`` del SDK se incluyen las operaciones ``escalar`` y ``mover``; en versiones anteriores Cobra calcula estos efectos manualmente.
 
 ```python
 from core.holobits import Holobit, graficar, proyectar, transformar, escalar, mover

--- a/frontend/docs/caracteristicas.rst
+++ b/frontend/docs/caracteristicas.rst
@@ -22,6 +22,8 @@ imprimir(rotado)
 # Escalar y trasladar
 escalar(x, 2)
 mover(x, 1, 0, -1)
+# ``escalar`` y ``mover`` requieren ``holobit-sdk`` >= 1.0.8; si no está
+# disponible se calcula internamente.
 
 # Graficar el holobit
 graficar(x)

--- a/frontend/docs/referencia.rst
+++ b/frontend/docs/referencia.rst
@@ -24,6 +24,8 @@ Funciones integradas
 - ``graficar(h)``: visualiza el holobit en pantalla.
 - ``escalar(h, factor)``: multiplica las coordenadas por ``factor``.
 - ``mover(h, x, y, z)``: traslada el holobit en el espacio.
+  Estas funciones están disponibles en ``holobit-sdk`` desde la versión ``1.0.8``;
+  en versiones anteriores Cobra realiza el cálculo de forma interna.
 
 Uso de la CLI
 -------------

--- a/src/core/holobits/transformacion.py
+++ b/src/core/holobits/transformacion.py
@@ -1,4 +1,8 @@
-"""Transformaciones de ``Holobit`` a través de ``holobit-sdk``."""
+"""Transformaciones de ``Holobit`` a través de ``holobit-sdk``.
+
+Si la versión instalada del SDK no dispone de las operaciones
+``escalar`` o ``mover`` se aplican cálculos locales equivalentes.
+"""
 
 from .holobit import Holobit
 from holobit_sdk.core.holobit import Holobit as SDKHolobit

--- a/tests/unit/test_holobit_transformacion_extra.py
+++ b/tests/unit/test_holobit_transformacion_extra.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 from core.holobits import Holobit, escalar, mover
 
 
@@ -22,3 +23,37 @@ def test_mover_usa_sdk(monkeypatch):
     h = Holobit([1, 2, 3])
     mover(h, 0.5, -1.0, 2.0)
     assert args == {'x': 0.5, 'y': -1.0, 'z': 2.0}
+
+
+def test_escalar_fallback(monkeypatch):
+    class DummyQuark:
+        def __init__(self, pos):
+            self.posicion = np.array(pos, dtype=float)
+
+    class DummyHolobit:
+        def __init__(self):
+            self.quarks = [DummyQuark([1, 0, 0])]
+            self.antiquarks = [DummyQuark([-1, 0, 0])]
+
+    dummy = DummyHolobit()
+    monkeypatch.setattr('core.holobits.transformacion._to_sdk_holobit', lambda hb: dummy)
+    escalar(Holobit([1, 2, 3]), 3)
+    assert np.allclose(dummy.quarks[0].posicion, [3, 0, 0])
+    assert np.allclose(dummy.antiquarks[0].posicion, [-3, 0, 0])
+
+
+def test_mover_fallback(monkeypatch):
+    class DummyQuark:
+        def __init__(self, pos):
+            self.posicion = np.array(pos, dtype=float)
+
+    class DummyHolobit:
+        def __init__(self):
+            self.quarks = [DummyQuark([0, 1, 0])]
+            self.antiquarks = []
+
+    dummy = DummyHolobit()
+    monkeypatch.setattr('core.holobits.transformacion._to_sdk_holobit', lambda hb: dummy)
+    mover(Holobit([1, 2, 3]), -1, 2, 1)
+    assert np.allclose(dummy.quarks[0].posicion, [-1, 3, 1])
+


### PR DESCRIPTION
## Summary
- clarify transformacion wrapper docstring
- document SDK version requirement for `escalar` and `mover`
- note requirement in frontend docs
- show example usage in `caracteristicas` doc
- add fallback tests for `escalar` and `mover`

## Testing
- `PYTHONPATH=src pytest -q tests/unit/test_holobit_transformacion_extra.py`
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'tomli')*

------
https://chatgpt.com/codex/tasks/task_e_68832956cc88832783fec148b17728d0