### PR TITLE
Add smart performance wrappers

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -7,7 +7,7 @@ Esto simplifica el uso de la biblioteca desde otros módulos.
 
 from .ast_nodes import *
 from .visitor import NodeVisitor
-from .performance import optimizar, perfilar
+from .performance import optimizar, perfilar, smart_perfilar, optimizar_bucle
 from .resource_limits import limitar_memoria_mb, limitar_cpu_segundos
 
 __all__ = [
@@ -51,6 +51,8 @@ __all__ = [
     "NodeVisitor",
     "optimizar",
     "perfilar",
+    "smart_perfilar",
+    "optimizar_bucle",
     "limitar_memoria_mb",
     "limitar_cpu_segundos",
 ]

--- a/src/core/performance.py
+++ b/src/core/performance.py
@@ -2,7 +2,12 @@
 
 from typing import Callable, Any
 try:
-    from smooth_criminal.core import auto_boost, profile_it
+    from smooth_criminal.core import (
+        auto_boost,
+        profile_it,
+        smart_profile,
+        optimize_loop,
+    )
 except Exception:  # pragma: no cover - fallback when library is missing
     def auto_boost(*, workers=4, fallback=None):
         def decorator(func):
@@ -12,6 +17,15 @@ except Exception:  # pragma: no cover - fallback when library is missing
 
     def profile_it(func, *, args=None, kwargs=None, repeat=1, parallel=False):
         return {}
+
+    def smart_profile(func, *, args=None, kwargs=None, repeat=1, parallel=False):
+        return profile_it(func, args=args, kwargs=kwargs, repeat=repeat, parallel=parallel)
+
+    def optimize_loop(*, loops=1, fallback=None):
+        def decorator(func):
+            return func
+
+        return decorator
 
 
 def optimizar(
@@ -44,3 +58,35 @@ def perfilar(
     return profile_it(
         func, args=args, kwargs=kwargs, repeat=repeticiones, parallel=paralelo
     )
+
+
+def smart_perfilar(
+    func: Callable,
+    *,
+    args: tuple | None = None,
+    kwargs: dict | None = None,
+    repeticiones: int = 5,
+    paralelo: bool = False
+) -> dict[str, Any]:
+    """Versión inteligente de :func:`perfilar` usando ``smart_profile``."""
+    args = args or ()
+    kwargs = kwargs or {}
+    return smart_profile(
+        func, args=args, kwargs=kwargs, repeat=repeticiones, parallel=paralelo
+    )
+
+
+def optimizar_bucle(
+    func: Callable | None = None,
+    *,
+    loops: int = 1,
+    fallback: Callable | None = None,
+) -> Callable:
+    """Optimiza bucles dentro de ``func`` usando ``optimize_loop``."""
+    if func is None:
+
+        def decorator(f: Callable) -> Callable:
+            return optimize_loop(loops=loops, fallback=fallback)(f)
+
+        return decorator
+    return optimize_loop(loops=loops, fallback=fallback)(func)

--- a/tests/unit/test_performance.py
+++ b/tests/unit/test_performance.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
+
+from src.core.performance import smart_perfilar, optimizar_bucle
+
+
+def _dummy(x=0):
+    return x + 1
+
+
+def test_smart_perfilar_invoca_smart_profile():
+    with patch("src.core.performance.smart_profile", create=True, return_value={"mean": 1}) as sp:
+        result = smart_perfilar(_dummy, args=(1,))
+    sp.assert_called_once()
+    assert result == {"mean": 1}
+
+
+def test_optimizar_bucle_decorator():
+    def fake_optimize_loop(loops=1, fallback=None):
+        def decorator(func):
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+            return wrapper
+        return decorator
+
+    with patch("src.core.performance.optimize_loop", create=True, side_effect=fake_optimize_loop) as op:
+        @optimizar_bucle(loops=2)
+        def foo():
+            return "ok"
+
+        assert foo() == "ok"
+        op.assert_called_once_with(loops=2, fallback=None)


### PR DESCRIPTION
## Summary
- wrap new `smart_profile` and `optimize_loop` utilities
- expose `smart_perfilar` and `optimizar_bucle` from core
- test the new wrappers

## Testing
- `PYTHONPATH=. pytest tests/unit/test_performance.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68832b23f11c83278987155f1a3800cf