### PR TITLE
Add cobra-init entry point and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ pip install pyinstaller
 Luego genera el binario con:
 
 ```bash
-pyinstaller --onefile -m src.main -n cobra
+pyinstaller --onefile src/main_init.py -n cobra
 ```
 
 El ejecutable aparecerá en el directorio `dist/`.
@@ -241,7 +241,8 @@ El ejecutable aparecerá en el directorio `dist/`.
 Para realizar una prueba rápida puedes ejecutar el script
 `scripts/test_pyinstaller.sh`. Este script crea un entorno virtual temporal,
 instala `cobra-lenguaje` desde el repositorio (o desde PyPI si se ejecuta fuera
-de él) y ejecuta PyInstaller sobre `src/cli/cli.py`. El binario resultante se
+de él) y ejecuta PyInstaller sobre `src/main_init.py` o el script `cobra-init`.
+El binario resultante se
 guardará por defecto en `dist/`.
 
 ```bash

--- a/README_en.md
+++ b/README_en.md
@@ -199,7 +199,14 @@ pip install pyinstaller
 Generate the binary with:
 
 ```bash
-pyinstaller --onefile -m src.main -n cobra
+pyinstaller --onefile src/main_init.py -n cobra
+```
+
+You can also execute the new ``cobra-init`` script which loads the same
+entry point automatically.
+
+```bash
+cobra-init
 ```
 
 The executable will be placed inside the `dist/` directory.

--- a/frontend/docs/empaquetar.rst
+++ b/frontend/docs/empaquetar.rst
@@ -2,7 +2,9 @@ Empaquetar la CLI
 =================
 
 Este proyecto puede distribuirse como un ejecutable independiente usando
-`PyInstaller <https://pyinstaller.org>`_.
+`PyInstaller <https://pyinstaller.org>`_. Internamente PyInstaller se
+ejecutar\u00e1 sobre ``src/main_init.py``. De forma manual podr\u00edas ejecutar
+``pyinstaller --onefile src/main_init.py -n cobra``.
 
 Para generar el ejecutable ejecuta:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ where = ["src"]
 [project.scripts]
 cobra = "src.cli.cli:main"
 pcobra = "src.main:main"
+cobra-init = "src.main_init:main"
 
 [project.entry-points."cobra.plugins"]
 # Se registrarán plugins externos aquí

--- a/scripts/test_pyinstaller.sh
+++ b/scripts/test_pyinstaller.sh
@@ -15,6 +15,6 @@ else
 fi
 pip install pyinstaller
 
-pyinstaller --distpath "$OUTPUT_DIR" --onefile src/cli/cli.py
+pyinstaller --distpath "$OUTPUT_DIR" --onefile src/main_init.py
 
 echo "Binario generado en $OUTPUT_DIR"

--- a/src/cli/commands/empaquetar_cmd.py
+++ b/src/cli/commands/empaquetar_cmd.py
@@ -45,7 +45,7 @@ class EmpaquetarCommand(BaseCommand):
         raiz = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
         )
-        cli_path = os.path.join(raiz, "backend", "src", "cli", "cli.py")
+        cli_path = os.path.join(raiz, "src", "main_init.py")
         output = args.output
         nombre = args.name
         spec = getattr(args, "spec", None)

--- a/src/main_init.py
+++ b/src/main_init.py
@@ -1,0 +1,18 @@
+from dotenv import load_dotenv
+
+# Carga variables de entorno desde un archivo .env si existe
+load_dotenv()
+
+from src.cli.cli import main as cli_main
+
+
+def main(argv=None):
+    """Entrada principal que delega en la CLI."""
+    return cli_main(argv)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())
+


### PR DESCRIPTION
## Summary
- implement `src/main_init.py` for initializing Cobra CLI with dotenv
- register `cobra-init` script in project metadata
- update documentation mentioning new entry point for PyInstaller
- use `src/main_init.py` in helper script and `EmpaquetarCommand`

## Testing
- `pytest -q`
- `bandit -r src`

------
https://chatgpt.com/codex/tasks/task_e_68833c0b78a883278877fb5706ce0e91