### PR TITLE
Fix md5 usage with usedforsecurity flag

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -21,7 +21,14 @@ if str(path) not in sys.path:
 src_mod = importlib.import_module('src')
 sys.modules[__name__ + '.src'] = src_mod
 # Propagar submódulos principales
-for sub in ['cli', 'cobra', 'core', 'ia', 'jupyter_kernel', 'tests']:
-    name = __name__ + '.src.' + sub
-    if 'src.' + sub in sys.modules:
-        sys.modules[name] = sys.modules['src.' + sub]
+for sub in ['cli', 'cobra', 'core', 'corelibs', 'ia', 'jupyter_kernel', 'tests']:
+    full = f'src.{sub}'
+    if full in sys.modules:
+        mod = sys.modules[full]
+    else:
+        try:
+            mod = importlib.import_module(full)
+        except ModuleNotFoundError:
+            continue
+    sys.modules[f'{__name__}.{sub}'] = mod
+    sys.modules[f'{__name__}.src.{sub}'] = mod

--- a/src/corelibs/seguridad.py
+++ b/src/corelibs/seguridad.py
@@ -18,7 +18,7 @@ def hash_md5(texto: str) -> str:
         DeprecationWarning,
         stacklevel=2,
     )
-    return hashlib.md5(texto.encode("utf-8")).hexdigest()
+    return hashlib.md5(texto.encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
 def hash_sha256(texto: str) -> str:


### PR DESCRIPTION
## Summary
- disable security risk warning in `hash_md5`
- expose `corelibs` through the `backend` shim to allow tests importing `backend.corelibs`

## Testing
- `pytest tests/unit/test_corelibs.py::test_seguridad_funcs -q`
- `pytest tests/unit/test_corelibs.py::test_transpile_seguridad -q`
- `bandit -r src/corelibs/seguridad.py`

------
https://chatgpt.com/codex/tasks/task_e_68833f744a0c8327baf4ec89330d804c