### PR TITLE
Update CLI packaging path

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ pip install pyinstaller
 Luego genera el binario con:
 
 ```bash
-pyinstaller --onefile src/main_init.py -n cobra
+pyinstaller --onefile src/cli/cli.py -n cobra
 ```
 
 El ejecutable aparecerá en el directorio `dist/`.
@@ -241,7 +241,7 @@ El ejecutable aparecerá en el directorio `dist/`.
 Para realizar una prueba rápida puedes ejecutar el script
 `scripts/test_pyinstaller.sh`. Este script crea un entorno virtual temporal,
 instala `cobra-lenguaje` desde el repositorio (o desde PyPI si se ejecuta fuera
-de él) y ejecuta PyInstaller sobre `src/main_init.py` o el script `cobra-init`.
+de él) y ejecuta PyInstaller sobre `src/cli/cli.py` o el script `cobra-init`.
 El binario resultante se
 guardará por defecto en `dist/`.
 

--- a/README_en.md
+++ b/README_en.md
@@ -199,7 +199,7 @@ pip install pyinstaller
 Generate the binary with:
 
 ```bash
-pyinstaller --onefile src/main_init.py -n cobra
+pyinstaller --onefile src/cli/cli.py -n cobra
 ```
 
 You can also execute the new ``cobra-init`` script which loads the same

--- a/frontend/docs/empaquetar.rst
+++ b/frontend/docs/empaquetar.rst
@@ -3,8 +3,8 @@ Empaquetar la CLI
 
 Este proyecto puede distribuirse como un ejecutable independiente usando
 `PyInstaller <https://pyinstaller.org>`_. Internamente PyInstaller se
-ejecutar\u00e1 sobre ``src/main_init.py``. De forma manual podr\u00edas ejecutar
-``pyinstaller --onefile src/main_init.py -n cobra``.
+ejecutar\u00e1 sobre ``src/cli/cli.py``. De forma manual podr\u00edas ejecutar
+``pyinstaller --onefile src/cli/cli.py -n cobra``.
 
 Para generar el ejecutable ejecuta:
 

--- a/scripts/test_pyinstaller.sh
+++ b/scripts/test_pyinstaller.sh
@@ -15,6 +15,6 @@ else
 fi
 pip install pyinstaller
 
-pyinstaller --distpath "$OUTPUT_DIR" --onefile src/main_init.py
+pyinstaller --distpath "$OUTPUT_DIR" --onefile src/cli/cli.py
 
 echo "Binario generado en $OUTPUT_DIR"

--- a/src/cli/commands/empaquetar_cmd.py
+++ b/src/cli/commands/empaquetar_cmd.py
@@ -45,7 +45,7 @@ class EmpaquetarCommand(BaseCommand):
         raiz = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
         )
-        cli_path = os.path.join(raiz, "src", "main_init.py")
+        cli_path = os.path.join(raiz, "src", "cli", "cli.py")
         output = args.output
         nombre = args.name
         spec = getattr(args, "spec", None)


### PR DESCRIPTION
## Summary
- point empaquetar command to `src/cli/cli.py`
- adjust test script to use new path
- document new PyInstaller target

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `bandit -r src`

------
https://chatgpt.com/codex/tasks/task_e_688341d318488327a045ac89472afc34