### PR TITLE
Actualizar rutas a src en configuración y tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-source = backend/src
+source = src
 branch = True
 
 [report]

--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ COBRA_CONFIG=./cobra.toml
 PCOBRA_CONFIG=./pcobra.toml
 
 # Ruta para almacenar el estado de Qualia
-QUALIA_STATE_PATH=backend/src/core/qualia_state.json
+QUALIA_STATE_PATH=src/core/qualia_state.json
 
 # Directorio de caché del AST
 COBRA_AST_CACHE=./cache

--- a/.github/codeql/custom/missing-codegen-exception.ql
+++ b/.github/codeql/custom/missing-codegen-exception.ql
@@ -8,7 +8,7 @@ from Method m, File f
 where
   m.getName() = "generate_code" and
   m.getFile() = f and
-  f.getRelativePath().regexp("^backend/src/cobra/transpilers/transpiler/") and
+  f.getRelativePath().regexp("^src/cobra/transpilers/transpiler/") and
   not exists(TryStmt t |
     t.getEnclosingCallable() = m
   )

--- a/.github/codeql/custom/unsafe-eval-exec.ql
+++ b/.github/codeql/custom/unsafe-eval-exec.ql
@@ -10,6 +10,6 @@ where
     c.getTarget().hasQualifiedName("builtins", "exec")
   ) and
   f = c.getFile() and
-  f.getRelativePath().regexp("^backend/src/") and
-  not f.getRelativePath().regexp("^backend/src/core/sandbox.py$")
+  f.getRelativePath().regexp("^src/") and
+  not f.getRelativePath().regexp("^src/core/sandbox.py$")
 select c, "Uso potencialmente inseguro de eval/exec"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
       - name: Run linters
         run: make lint
       - name: Run flake8
-        run: flake8 backend/src src
+        run: flake8 src
       - name: Run type checks
         run: make typecheck
       - name: Run tests
-        run: pytest --cov=backend/src --cov-report=xml \
+        run: pytest --cov=src --cov-report=xml \
           --cov-report=term-missing --cov-fail-under=95
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,14 +29,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run linters
         run: |
-          isort --check backend/src src
-          black --check backend/src src
-          flake8 backend/src
-          mypy backend/src
-          bandit -r src backend/src
+          isort --check src
+          black --check src
+          flake8 src
+          mypy src
+          bandit -r src
       - name: Run tests
         run: |
-          pytest --cov=backend/src --cov-report=xml --cov-fail-under=95
+          pytest --cov=src --cov-report=xml --cov-fail-under=95
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-report

--- a/Makefile
+++ b/Makefile
@@ -20,24 +20,24 @@ help:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 coverage:
-	pytest backend/src/tests --cov=backend/src
-	--cov-report=term-missing --cov-fail-under=95
+        pytest tests --cov=src \
+        --cov-report=term-missing --cov-fail-under=95
 
 lint:
-	flake8 backend/src
-	mypy backend/src
-	bandit -r src backend/src
-	flake8 src/ tests/
+        flake8 src
+        mypy src
+        bandit -r src
+        flake8 src/ tests/
 
 format:
-	isort backend/src src
-	black backend/src src
-	black src/ tests/
+        isort src
+        black src
+        black src/ tests/
 
 typecheck:
-		mypy backend/src
-		@if command -v pyright >/dev/null 2>&1; then \
-		pyright backend/src; \
+                mypy src
+                @if command -v pyright >/dev/null 2>&1; then \
+                pyright src; \
 	fi
 
 benchmarks:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
 python_version = 3.11
 ignore_missing_imports = True
-files = backend/src
-exclude = ^(frontend/build/|frontend/docs/|venv/|backend/src/tests/)
+files = src
+exclude = ^(frontend/build/|frontend/docs/|venv/|src/tests/)

--- a/notebooks/casos_reales/analisis_datos.ipynb
+++ b/notebooks/casos_reales/analisis_datos.ipynb
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!PYTHONPATH='..:../backend/src:../backend' python ../../scripts/compile.py ../../casos_reales/analisis_datos/estadisticas.co"
+    "!PYTHONPATH='..:../src:../backend' python ../../scripts/compile.py ../../casos_reales/analisis_datos/estadisticas.co"
    ]
   },
   {
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!PYTHONPATH='..:../backend/src:../backend' python estadisticas.py"
+    "!PYTHONPATH='..:../src:../backend' python estadisticas.py"
    ]
   }
  ],

--- a/notebooks/casos_reales/bioinformatica.ipynb
+++ b/notebooks/casos_reales/bioinformatica.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!PYTHONPATH='..:../backend/src:../backend' python ../../scripts/compile.py ../../casos_reales/bioinformatica/ejemplo_gc.co"
+    "!PYTHONPATH='..:../src:../backend' python ../../scripts/compile.py ../../casos_reales/bioinformatica/ejemplo_gc.co"
    ]
   },
   {
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!PYTHONPATH='..:../backend/src:../backend' python ejemplo_gc.py"
+    "!PYTHONPATH='..:../src:../backend' python ejemplo_gc.py"
    ]
   }
  ],

--- a/notebooks/casos_reales/inteligencia_artificial.ipynb
+++ b/notebooks/casos_reales/inteligencia_artificial.ipynb
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!PYTHONPATH='..:../backend/src:../backend' python ../../scripts/compile.py ../../casos_reales/inteligencia_artificial/modelo_ia.co"
+    "!PYTHONPATH='..:../src:../backend' python ../../scripts/compile.py ../../casos_reales/inteligencia_artificial/modelo_ia.co"
    ]
   },
   {
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!PYTHONPATH='..:../backend/src:../backend' python modelo_ia.py"
+    "!PYTHONPATH='..:../src:../backend' python modelo_ia.py"
    ]
   }
  ],

--- a/notebooks/ejemplo_basico.ipynb
+++ b/notebooks/ejemplo_basico.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!PYTHONPATH='..:../backend/src:../backend' python ../examples/tutorial_basico/compile_manual.py > hola_mundo.py\n",
+    "!PYTHONPATH='..:../src:../backend' python ../examples/tutorial_basico/compile_manual.py > hola_mundo.py\n",
     "!cat hola_mundo.py"
    ]
   },
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!PYTHONPATH='..:../backend/src:../backend' python hola_mundo.py"
+    "!PYTHONPATH='..:../src:../backend' python hola_mundo.py"
    ]
   },
   {

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,10 +1,10 @@
 {
-  "include": ["backend/src"],
+  "include": ["src"],
   "exclude": [
     "frontend/build",
     "frontend/docs",
     "venv",
-    "backend/src/tests"
+    "src/tests"
   ],
   "pythonVersion": "3.11",
   "reportMissingImports": false

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -13,7 +13,7 @@ FILES_TO_UPDATE = [
     PYPROJECT_PATH,
     Path("README.md"),
     Path("MANUAL_COBRA.md"),
-    Path("backend/src/jupyter_kernel/__init__.py"),
+    Path("src/jupyter_kernel/__init__.py"),
     Path("frontend/docs/avances.rst"),
     Path("tests/unit/test_cli_plugins_cmd.py"),
 ]

--- a/scripts/generar_pdoc.py
+++ b/scripts/generar_pdoc.py
@@ -8,7 +8,7 @@ def main():
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     subprocess.run([
         'pdoc',
-        'backend/src',
+        'src',
         '--output-dir', str(OUTPUT_DIR)
     ], check=True)
 

--- a/scripts/run_mutation.py
+++ b/scripts/run_mutation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Ejecuta pruebas de mutación con MutPy sobre backend/src."""
+"""Ejecuta pruebas de mutación con MutPy sobre ``src``."""
 from __future__ import annotations
 
 import importlib
@@ -24,8 +24,8 @@ def main() -> None:
     _ensure_py312_compat()
     repo = Path(__file__).resolve().parents[1]
     sys.path.insert(0, str(repo))
-    sys.path.insert(0, str(repo / "backend" / "src"))
-    os.environ["PYTHONPATH"] = f"{repo}:{repo / 'backend' / 'src'}"
+    sys.path.insert(0, str(repo / "src"))
+    os.environ["PYTHONPATH"] = str(repo / 'src')
 
     args = [
         "--target",
@@ -37,7 +37,7 @@ def main() -> None:
         "--percentage",
         "5",
         "--path",
-        str(repo / "backend" / "src"),
+        str(repo / "src"),
     ]
     sys.argv = ["mut.py"] + args
     import mutpy.commandline as commandline

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,16 @@
 import sys
 from pathlib import Path
 
-# Agrega el directorio backend/src para simplificar los imports en las pruebas
+# Añade el directorio ``src`` al ``PYTHONPATH`` para simplificar los imports en las pruebas
 ROOT = Path(__file__).resolve().parents[1]
-backend_src = ROOT / "backend" / "src"
+src_path = ROOT / "src"
 
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
-if backend_src.exists() and str(backend_src) not in sys.path:
-    sys.path.insert(0, str(backend_src))
+if src_path.exists() and str(src_path) not in sys.path:
+    sys.path.insert(0, str(src_path))
 
-# Carga el paquete backend para registrar sus submódulos en "src"
+# Carga opcionalmente el paquete ``backend`` para mantener compatibilidad
 try:  # nosec B001
     import backend  # noqa: F401
 except Exception:

--- a/tests/unit/test_holobit_generation.py
+++ b/tests/unit/test_holobit_generation.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
-holobit_path = ROOT / "backend/src/core/holobits/holobit.py"
+holobit_path = ROOT / "src/core/holobits/holobit.py"
 spec = importlib.util.spec_from_file_location("holobit", holobit_path)
 holobit_module = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = holobit_module


### PR DESCRIPTION
## Resumen
- usar `src` en las rutas de conftest y pruebas
- actualizar workflows y Makefile para usar `src`
- modificar configuración de mypy, pyright y coverage
- corregir referencias en notebooks y scripts

## Testing
- `flake8 src tests` *(falla)*
- `mypy src` *(falla)*
- `pytest -q` *(falla: errors during collection)*
- `bandit -r src`

------
https://chatgpt.com/codex/tasks/task_e_68834368ddec8327a548ffe338d27400