### PR TITLE
Añade validación de esquema en utilidades de red

### DIFF
--- a/src/corelibs/red.py
+++ b/src/corelibs/red.py
@@ -6,12 +6,18 @@ import urllib.request
 
 def obtener_url(url: str) -> str:
     """Devuelve el contenido de una URL como texto."""
+    url_baja = url.lower()
+    if not (url_baja.startswith("http://") or url_baja.startswith("https://")):
+        raise ValueError("Esquema de URL no soportado")
     with urllib.request.urlopen(url, timeout=5) as resp:
         return resp.read().decode("utf-8")
 
 
 def enviar_post(url: str, datos: dict) -> str:
     """Envía datos por POST y retorna la respuesta."""
+    url_baja = url.lower()
+    if not (url_baja.startswith("http://") or url_baja.startswith("https://")):
+        raise ValueError("Esquema de URL no soportado")
     encoded = urllib.parse.urlencode(datos).encode()
     with urllib.request.urlopen(url, encoded, timeout=5) as resp:
         return resp.read().decode("utf-8")

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -3,6 +3,7 @@ import sys
 import os
 from datetime import datetime
 from unittest.mock import MagicMock, patch
+import pytest
 
 sys.modules.setdefault('yaml', ModuleType('yaml'))
 
@@ -80,6 +81,34 @@ def test_red_funcs(monkeypatch):
         mock_urlopen.assert_any_call('http://x', timeout=5)
         mock_urlopen.assert_any_call('http://x', b'a=1', timeout=5)
         assert mock_urlopen.call_count == 2
+
+
+def test_red_obtener_url_rechaza_esquema_no_http():
+    with patch('backend.corelibs.red.urllib.request.urlopen') as mock_urlopen:
+        with pytest.raises(ValueError):
+            core.obtener_url('ftp://ejemplo.com')
+        mock_urlopen.assert_not_called()
+
+
+def test_red_obtener_url_rechaza_otro_esquema():
+    with patch('backend.corelibs.red.urllib.request.urlopen') as mock_urlopen:
+        with pytest.raises(ValueError):
+            core.obtener_url('file:///tmp/archivo.txt')
+        mock_urlopen.assert_not_called()
+
+
+def test_red_enviar_post_rechaza_esquema_no_http():
+    with patch('backend.corelibs.red.urllib.request.urlopen') as mock_urlopen:
+        with pytest.raises(ValueError):
+            core.enviar_post('ftp://ejemplo.com', {'a': 1})
+        mock_urlopen.assert_not_called()
+
+
+def test_red_enviar_post_rechaza_otro_esquema():
+    with patch('backend.corelibs.red.urllib.request.urlopen') as mock_urlopen:
+        with pytest.raises(ValueError):
+            core.enviar_post('file:///tmp/archivo.txt', {'a': 1})
+        mock_urlopen.assert_not_called()
 
 
 def test_sistema_funcs(tmp_path, monkeypatch):


### PR DESCRIPTION
## Resumen
- valida que las funciones `obtener_url` y `enviar_post` solo acepten URLs con `http://` o `https://`
- amplía la batería de pruebas para verificar estos casos

## Testing
- `pytest -q`
- `bandit -r src -q`

------
https://chatgpt.com/codex/tasks/task_e_6883462b2c2c832795090357df5a160e