### PR TITLE
Bump version to 10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v10.0.0 - 2025-08-15
+- Incremento de versión principal a 10.0.0.
+- Actualización de documentación y ejemplos.
+
 ## v9.1.0 - 2025-07-20
 - Incremento de versión menor a 9.1.0.
 - Actualización de documentación y ejemplos.

--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -1,6 +1,6 @@
 # Manual del Lenguaje Cobra
 
-Versión 9.1.0
+Versión 10.0.0
 
 Este manual presenta en español los conceptos básicos para programar en Cobra. Se organiza en tareas que puedes seguir paso a paso.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Versión estable](https://img.shields.io/github/v/release/Alphonsus411/pCobra?label=stable)](https://github.com/Alphonsus411/pCobra/releases/latest)
 
 
-Versión 9.1.0
+Versión 10.0.0
 
 [English version available here](README_en.md)
 Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
@@ -1027,7 +1027,7 @@ Este proyecto sigue el esquema [SemVer](https://semver.org/lang/es/). Los numero
 
 ## Historial de Cambios
 
-- Versión 9.1.0: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
+- Versión 10.0.0: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
 
 ## Publicar una nueva versión
 
@@ -1036,8 +1036,8 @@ Al crear y subir una etiqueta `vX.Y.Z` se ejecuta el workflow [`release.yml`](.g
 El workflow [`Deploy Docs`](.github/workflows/pages.yml) generará la documentación cuando haya un push en `main` o al etiquetar una nueva versión.
 
 ```bash
-git tag v9.1.0
-git push origin v9.1.0
+git tag v10.0.0
+git push origin v10.0.0
 ```
 
 Para más información consulta el [CHANGELOG](CHANGELOG.md) y la [configuración de GitHub Actions](.github/workflows).

--- a/README_en.md
+++ b/README_en.md
@@ -2,7 +2,7 @@
 [![Codecov](https://codecov.io/gh/Alphonsus411/pCobra/branch/master/graph/badge.svg)](https://codecov.io/gh/Alphonsus411/pCobra)
 [![Stable release](https://img.shields.io/github/v/release/Alphonsus411/pCobra?label=stable)](https://github.com/Alphonsus411/pCobra/releases/latest)
 
-Version 9.1.0
+Version 10.0.0
 
 Cobra is a programming language designed in Spanish, aimed at creating tools, simulations and analyses in fields such as biology, computing and astrophysics. This project includes a lexer, parser and transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo and LaTeX, allowing greater versatility when running and deploying Cobra code.
 

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -1,7 +1,7 @@
 Manual de Cobra
 ===============
 
-Versión 9.1.0
+Versión 10.0.0
 
 Este documento resume la sintaxis y los elementos fundamentales del lenguaje
 Cobra. Incluye ejemplos de uso idiomático, limitaciones de los backends y

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ sys.path.insert(0, ROOT_DIR)
 project = 'Proyecto Cobra'
 copyright = '2024, Adolfo González Hernández'
 author = 'Adolfo González Hernández'
-release = '9.1.0'
+release = '10.0.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -8,10 +8,10 @@ Avances del lenguaje Cobra
 - **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX.
 - **Pruebas unitarias**: Se han creado pruebas para validar el correcto funcionamiento del lexer y el parser.
 
- - **Versión 9.1.0**: Actualización de la documentación y configuración del proyecto.
- - **Versión 9.1.0**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
+ - **Versión 10.0.0**: Actualización de la documentación y configuración del proyecto.
+ - **Versión 10.0.0**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
 
-Versión 9.1.0
+Versión 10.0.0
 -----------
 Se añade el archivo ``pcobra.toml`` para definir el mapeo de módulos en formato TOML. Su estructura es la siguiente:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cobra-lenguaje"
-version = "9.1.0"
+version = "10.0.0"
 description = "Un lenguaje de programación en español para simulaciones y más."
 authors = [ {name = "Adolfo González Hernández", email = "adolfogonzal@gmail.com"} ]
 readme = "README.md"

--- a/src/jupyter_kernel/__init__.py
+++ b/src/jupyter_kernel/__init__.py
@@ -18,7 +18,7 @@ def _get_version() -> str:
     try:
         return version("cobra-lenguaje")
     except PackageNotFoundError:
-        return "9.1.0"
+        return "10.0.0"
 
 
 __version__ = _get_version()

--- a/tests/unit/test_cli_plugins_cmd.py
+++ b/tests/unit/test_cli_plugins_cmd.py
@@ -10,7 +10,7 @@ from cli.plugin_registry import limpiar_registro
 
 class DummyPlugin(PluginCommand):
     name = "dummy"
-    version = "9.1.0"
+    version = "10.0.0"
 
     def register_subparser(self, subparsers):
         pass
@@ -43,7 +43,7 @@ def test_cli_plugins_muestra_registro():
     with patch("cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["plugins"])
-    assert "dummy 9.1.0" in out.getvalue().strip()
+    assert "dummy 10.0.0" in out.getvalue().strip()
 
 
 def test_cli_plugin_ejemplo_hola():


### PR DESCRIPTION
## Summary
- bump library version to 10.0.0
- update docs with the new version
- add changelog entry
- update tests referencing the version

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tomli')*
- `bandit -r . -q`

------
https://chatgpt.com/codex/tasks/task_e_688347e410f48327af97b05d08ebe8d3