### PR TITLE
Compatibilidad tomli

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 import re
 import sys
-import tomllib
+try:
+    import tomllib  # Python >= 3.11
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
 from datetime import date
 from pathlib import Path
 

--- a/src/cli/commands/dependencias_cmd.py
+++ b/src/cli/commands/dependencias_cmd.py
@@ -1,7 +1,10 @@
 import os
 import subprocess
 import tempfile
-import tomllib
+try:
+    import tomllib  # Python >= 3.11
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
 
 from src.cli.commands.base import BaseCommand
 from src.cli.i18n import _

--- a/src/cobra/semantico/mod_validator.py
+++ b/src/cobra/semantico/mod_validator.py
@@ -12,7 +12,10 @@ comprobaciones incluyen:
 from __future__ import annotations
 
 import os
-import tomllib
+try:
+    import tomllib  # Python >= 3.11
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
 import yaml
 from typing import Dict, Any
 from jsonschema import validate, ValidationError

--- a/src/cobra/transpilers/module_map.py
+++ b/src/cobra/transpilers/module_map.py
@@ -1,6 +1,9 @@
 import os
 import yaml
-import tomllib
+try:
+    import tomllib  # Python >= 3.11
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
 
 MODULE_MAP_PATH = os.environ.get(
     'COBRA_MODULE_MAP',

--- a/src/tests/unit/test_cli_paquete.py
+++ b/src/tests/unit/test_cli_paquete.py
@@ -1,6 +1,9 @@
 from io import StringIO
 import zipfile
-import tomllib
+try:
+    import tomllib  # Python >= 3.11
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
 from unittest.mock import patch
 
 from cli.cli import main

--- a/src/tests/unit/test_pcobra_module_map.py
+++ b/src/tests/unit/test_pcobra_module_map.py
@@ -1,4 +1,7 @@
-import tomllib
+try:
+    import tomllib  # Python >= 3.11
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
 
 from cobra.lexico.lexer import Lexer
 from cobra.parser.parser import Parser


### PR DESCRIPTION
## Summary
- usa tomli como alternativa cuando no se encuentra tomllib
- actualiza las pruebas que importaban tomllib

## Testing
- `pytest -q` *(falla: No module named 'tree_sitter_languages')*

------
https://chatgpt.com/codex/tasks/task_e_68837716e20083279b29132e024609bc