### PR TITLE
Implement cross-platform benchmark measurements

### DIFF
--- a/src/cli/commands/bench_cmd.py
+++ b/src/cli/commands/bench_cmd.py
@@ -2,7 +2,16 @@ import cProfile
 import json
 import os
 import re
-import resource
+try:
+    import resource
+except ImportError:  # pragma: no cover - Windows
+    resource = None  # type: ignore
+    try:
+        import psutil  # type: ignore
+    except Exception:
+        psutil = None  # type: ignore
+else:
+    psutil = None  # type: ignore
 import shutil
 import subprocess
 import sys
@@ -36,19 +45,52 @@ BACKENDS = {
 def run_and_measure(
     cmd: list[str], env: dict[str, str] | None = None
 ) -> tuple[float, int]:
-    start_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
-    start_time = time.perf_counter()
-    subprocess.run(
-        cmd,
-        env=env,
-        check=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.STDOUT,
-    )  # nosec B603
-    elapsed = time.perf_counter() - start_time
-    end_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
-    mem_kb = max(0, end_usage.ru_maxrss - start_usage.ru_maxrss)
-    return elapsed, mem_kb
+    if resource is not None:
+        start_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+        start_time = time.perf_counter()
+        subprocess.run(
+            cmd,
+            env=env,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
+        )  # nosec B603
+        elapsed = time.perf_counter() - start_time
+        end_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+        mem_kb = max(0, end_usage.ru_maxrss - start_usage.ru_maxrss)
+        return elapsed, mem_kb
+    else:  # pragma: no cover - resource not available
+        if psutil is not None:
+            start_time = time.perf_counter()
+            proc = psutil.Popen(
+                cmd,
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT,
+            )  # type: ignore
+            max_mem = 0
+            while proc.poll() is None:
+                try:
+                    mem = proc.memory_info().rss  # type: ignore
+                    max_mem = max(max_mem, mem)
+                except Exception:  # pragma: no cover - process ended
+                    break
+                time.sleep(0.05)
+            proc.wait()
+            elapsed = time.perf_counter() - start_time
+            mem_kb = max_mem // 1024
+            return elapsed, mem_kb
+        else:
+            start_time = time.perf_counter()
+            subprocess.run(
+                cmd,
+                env=env,
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT,
+            )  # nosec B603
+            elapsed = time.perf_counter() - start_time
+            return elapsed, 0
 
 
 class BenchCommand(BaseCommand):


### PR DESCRIPTION
## Summary
- allow benchmarks to run with `psutil` when `resource` isn't available
- estimate CPU and IO in `benchthreads` without `resource`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError & SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_688378eb946883279fd01445d0c37bce