### PR TITLE
Fix expected string concatenation in unit tests

### DIFF
--- a/src/tests/unit/test_decoradores_yield.py
+++ b/src/tests/unit/test_decoradores_yield.py
@@ -16,19 +16,12 @@ def test_transpilar_funcion_con_decorador():
     decorador = NodoDecorador(NodoIdentificador("decor"))
     func = NodoFuncion("saluda", [], [NodoImprimir(NodoValor("'hola'"))], [decorador])
     codigo = TranspiladorPython().generate_code([func])
-    esperado = (
-        IMPORTS
-        "@decor\n"
-        "def saluda():\n    print('hola')\n"
-    )
+    esperado = IMPORTS + "@decor\n" + "def saluda():\n    print('hola')\n"
     assert codigo == esperado
 
 
 def test_transpilar_funcion_con_yield():
     func = NodoFuncion("generador", [], [NodoYield(NodoValor(1))])
     codigo = TranspiladorPython().generate_code([func])
-    esperado = (
-        IMPORTS
-        "def generador():\n    yield 1\n"
-    )
+    esperado = IMPORTS + "def generador():\n    yield 1\n"
     assert codigo == esperado

--- a/src/tests/unit/test_imports_alias_clase.py
+++ b/src/tests/unit/test_imports_alias_clase.py
@@ -38,12 +38,12 @@ def test_transpilador_python_imports_alias_clase():
         "import asyncio\n"
         + IMPORTS_PY
         + "from package.module import decorador as dec\n"
-        "from package2.module2 import Base as B\n"
-        "@dec\n"
-        "class C(B):\n"
-        "    @dec\n"
-        "    async def run(self):\n"
-        "        await accion()\n"
+        + "from package2.module2 import Base as B\n"
+        + "@dec\n"
+        + "class C(B):\n"
+        + "    @dec\n"
+        + "    async def run(self):\n"
+        + "        await accion()\n"
     )
     assert resultado == esperado
 
@@ -61,13 +61,13 @@ def test_transpilador_js_imports_alias_clase():
     resultado = TranspiladorJavaScript().generate_code(ast)
     esperado = IMPORTS + (
         "import { decorador as dec } from 'package.module';\n"
-        "import { Base as B } from 'package2.module2';\n"
-        "class C extends B {\n"
-        "async run(self) {\n"
-        "await accion();\n"
-        "}\n"
-        "}\n"
-        "C.prototype.run = dec(C.prototype.run);\n"
-        "C = dec(C);"
+        + "import { Base as B } from 'package2.module2';\n"
+        + "class C extends B {\n"
+        + "async run(self) {\n"
+        + "await accion();\n"
+        + "}\n"
+        + "}\n"
+        + "C.prototype.run = dec(C.prototype.run);\n"
+        + "C = dec(C);"
     )
     assert resultado == esperado

--- a/src/tests/unit/test_inlining_transpilers.py
+++ b/src/tests/unit/test_inlining_transpilers.py
@@ -23,9 +23,9 @@ def test_inline_js_transpiler():
     codigo = TranspiladorJavaScript().generate_code(_ast_inline())
     esperado = (
         "import * as io from './nativos/io.js';\n"
-        "import * as net from './nativos/io.js';\n"
-        "import * as matematicas from './nativos/matematicas.js';\n"
-        "import { Pila, Cola } from './nativos/estructuras.js';\n"
-        "let x = 1;"
+        + "import * as net from './nativos/io.js';\n"
+        + "import * as matematicas from './nativos/matematicas.js';\n"
+        + "import { Pila, Cola } from './nativos/estructuras.js';\n"
+        + "let x = 1;"
     )
     assert codigo == esperado

--- a/src/tests/unit/test_integracion_transpiladores.py
+++ b/src/tests/unit/test_integracion_transpiladores.py
@@ -24,11 +24,11 @@ def test_integracion_js():
     resultado = TranspiladorJavaScript().generate_code(ast)
     esperado = (
         "import * as io from './nativos/io.js';\n"
-        "import * as net from './nativos/io.js';\n"
-        "import * as matematicas from './nativos/matematicas.js';\n"
-        "import { Pila, Cola } from './nativos/estructuras.js';\n"
-        "let x = 10;\n"
-        "console.log(x);"
+        + "import * as net from './nativos/io.js';\n"
+        + "import * as matematicas from './nativos/matematicas.js';\n"
+        + "import { Pila, Cola } from './nativos/estructuras.js';\n"
+        + "let x = 10;\n"
+        + "console.log(x);"
     )
     assert resultado == esperado
 
@@ -40,8 +40,8 @@ def test_integracion_condicional_python():
     resultado = TranspiladorPython().generate_code(ast)
     esperado = (
         IMPORTS
-        "x = 10\n"
-        "if x > 5:\n"
-        "    print(x)\n"
+        + "x = 10\n"
+        + "if x > 5:\n"
+        + "    print(x)\n"
     )
     assert resultado == esperado

--- a/src/tests/unit/test_module_map.py
+++ b/src/tests/unit/test_module_map.py
@@ -53,10 +53,10 @@ def test_transpilador_mapeo_js(tmp_path, monkeypatch):
     resultado = TranspiladorJavaScript().generate_code(ast)
     esperado = (
         "import * as io from './nativos/io.js';\n"
-        "import * as net from './nativos/io.js';\n"
-        "import * as matematicas from './nativos/matematicas.js';\n"
-        "import { Pila, Cola } from './nativos/estructuras.js';\n"
-        "let x = 2;\n"
-        "console.log(x);"
+        + "import * as net from './nativos/io.js';\n"
+        + "import * as matematicas from './nativos/matematicas.js';\n"
+        + "import { Pila, Cola } from './nativos/estructuras.js';\n"
+        + "let x = 2;\n"
+        + "console.log(x);"
     )
     assert resultado == esperado

--- a/src/tests/unit/test_pasar.py
+++ b/src/tests/unit/test_pasar.py
@@ -34,10 +34,10 @@ def test_transpilar_pasar_js():
     resultado = t.generate_code([nodo])
     esperado = (
         "import * as io from './nativos/io.js';\n"
-        "import * as net from './nativos/io.js';\n"
-        "import * as matematicas from './nativos/matematicas.js';\n"
-        "import { Pila, Cola } from './nativos/estructuras.js';\n"
-        ";"
+        + "import * as net from './nativos/io.js';\n"
+        + "import * as matematicas from './nativos/matematicas.js';\n"
+        + "import { Pila, Cola } from './nativos/estructuras.js';\n"
+        + ";"
     )
     assert resultado == esperado
 

--- a/src/tests/unit/test_pcobra_module_map.py
+++ b/src/tests/unit/test_pcobra_module_map.py
@@ -64,11 +64,11 @@ def test_pcobra_mapeo_js(tmp_path, monkeypatch):
     resultado = TranspiladorJavaScript().generate_code(ast)
     esperado = (
         "import * as io from './nativos/io.js';\n"
-        "import * as net from './nativos/io.js';\n"
-        "import * as matematicas from './nativos/matematicas.js';\n"
-        "import { Pila, Cola } from './nativos/estructuras.js';\n"
-        "let x = 2;\n"
-        "console.log(x);"
+        + "import * as net from './nativos/io.js';\n"
+        + "import * as matematicas from './nativos/matematicas.js';\n"
+        + "import { Pila, Cola } from './nativos/estructuras.js';\n"
+        + "let x = 2;\n"
+        + "console.log(x);"
     )
     assert resultado == esperado
 

--- a/src/tests/unit/test_romper_continuar.py
+++ b/src/tests/unit/test_romper_continuar.py
@@ -46,9 +46,9 @@ def test_transpilar_continuar_js():
     resultado = t.generate_code([nodo])
     esperado = (
         "import * as io from './nativos/io.js';\n"
-        "import * as net from './nativos/io.js';\n"
-        "import * as matematicas from './nativos/matematicas.js';\n"
-        "import { Pila, Cola } from './nativos/estructuras.js';\n"
-        "for (let x of datos) {\ncontinue;\n}"
+        + "import * as net from './nativos/io.js';\n"
+        + "import * as matematicas from './nativos/matematicas.js';\n"
+        + "import { Pila, Cola } from './nativos/estructuras.js';\n"
+        + "for (let x of datos) {\ncontinue;\n}"
     )
     assert resultado == esperado

--- a/src/tests/unit/test_to_cpp.py
+++ b/src/tests/unit/test_to_cpp.py
@@ -75,10 +75,10 @@ def test_transpilador_clase():
     resultado = t.generate_code(ast)
     esperado = (
         "class Persona {\n"
-        "    auto saludar(auto self) {\n"
-        "        auto x = 1;\n"
-        "    }\n"
-        "};"
+        + "    auto saludar(auto self) {\n"
+        + "        auto x = 1;\n"
+        + "    }\n"
+        + "};"
     )
     assert resultado == esperado
 
@@ -106,16 +106,16 @@ def test_transpilador_switch():
     resultado = t.generate_code(ast)
     esperado = (
         "switch (x) {\n"
-        "    case 1:\n"
-        "        auto y = 1;\n"
-        "        break;\n"
-        "    case 2:\n"
-        "        auto y = 2;\n"
-        "        break;\n"
-        "    default:\n"
-        "        auto y = 0;\n"
-        "        break;\n"
-        "}"
+        + "    case 1:\n"
+        + "        auto y = 1;\n"
+        + "        break;\n"
+        + "    case 2:\n"
+        + "        auto y = 2;\n"
+        + "        break;\n"
+        + "    default:\n"
+        + "        auto y = 0;\n"
+        + "        break;\n"
+        + "}"
     )
     assert resultado == esperado
 

--- a/src/tests/unit/test_to_fortran.py
+++ b/src/tests/unit/test_to_fortran.py
@@ -63,7 +63,7 @@ def test_fortran_atributo_y_operaciones():
     resultado = t.generate_code(ast)
     esperado = (
         "obj%campo = 5\n"
-        "a = 1 + 2\n"
-        "b = .NOT. c"
+        + "a = 1 + 2\n"
+        + "b = .NOT. c"
     )
     assert resultado == esperado

--- a/src/tests/unit/test_to_js.py
+++ b/src/tests/unit/test_to_js.py
@@ -101,16 +101,16 @@ def test_transpilador_switch():
     esperado = (
         IMPORTS
         + "switch (x) {\n"
-        "    case 1:\n"
-        "        let y = 1;\n"
-        "        break;\n"
-        "    case 2:\n"
-        "        let y = 2;\n"
-        "        break;\n"
-        "    default:\n"
-        "        let y = 0;\n"
-        "        break;\n"
-        "}"
+        + "    case 1:\n"
+        + "        let y = 1;\n"
+        + "        break;\n"
+        + "    case 2:\n"
+        + "        let y = 2;\n"
+        + "        break;\n"
+        + "    default:\n"
+        + "        let y = 0;\n"
+        + "        break;\n"
+        + "}"
     )
     assert resultado == esperado
 
@@ -128,8 +128,8 @@ def test_async_function_and_await():
     resultado = t.generate_code(ast)
     esperado = IMPORTS + (
         "async function principal() {\n"
-        "await saluda();\n"
-        "}"
+        + "await saluda();\n"
+        + "}"
     )
     assert resultado == esperado
 
@@ -144,9 +144,9 @@ def test_export_import():
     resultado = t.generate_code(ast)
     esperado = IMPORTS + (
         "import { saluda } from './mod.js';\n"
-        "function saluda() {\n"
-        "}\n"
-        "export { saluda };"
+        + "function saluda() {\n"
+        + "}\n"
+        + "export { saluda };"
     )
     assert resultado == esperado
 
@@ -160,12 +160,12 @@ def test_decoradores_en_clase_y_metodo_js():
     resultado = t.generate_code([clase])
     esperado = IMPORTS + (
         "class C {\n"
-        "async run(a) {\n"
-        ";\n"
-        "}\n"
-        "}\n"
-        "C.prototype.run = dec(C.prototype.run);\n"
-        "C = dec(C);"
+        + "async run(a) {\n"
+        + ";\n"
+        + "}\n"
+        + "}\n"
+        + "C.prototype.run = dec(C.prototype.run);\n"
+        + "C = dec(C);"
     )
     assert resultado == esperado
 

--- a/src/tests/unit/test_to_js3.py
+++ b/src/tests/unit/test_to_js3.py
@@ -164,10 +164,10 @@ def test_transpilar_clase_multibase():
     expected = (
         imports
         + "class Hija extends Base1 { /* bases: Base1, Base2 */\n"
-        "m(p) {\n"
-        "x = p;\n"
-        "}\n"
-        "}"
+        + "m(p) {\n"
+        + "x = p;\n"
+        + "}\n"
+        + "}"
     )
     assert result == expected, "Error en herencia múltiple"
 

--- a/src/tests/unit/test_to_js4.py
+++ b/src/tests/unit/test_to_js4.py
@@ -164,10 +164,10 @@ def test_transpilar_clase_multibase():
     expected = (
         imports
         + "class Hija extends Base1 { /* bases: Base1, Base2 */\n"
-        "m(p) {\n"
-        "x = p;\n"
-        "}\n"
-        "}"
+        + "m(p) {\n"
+        + "x = p;\n"
+        + "}\n"
+        + "}"
     )
     assert result == expected, "Error en herencia múltiple"
 

--- a/src/tests/unit/test_to_pascal.py
+++ b/src/tests/unit/test_to_pascal.py
@@ -63,7 +63,7 @@ def test_pascal_atributo_y_operaciones():
     resultado = t.generate_code(ast)
     esperado = (
         "obj.campo := 5;\n"
-        "a := 1 + 2;\n"
-        "b := not c;"
+        + "a := 1 + 2;\n"
+        + "b := not c;"
     )
     assert resultado == esperado

--- a/src/tests/unit/test_to_php.py
+++ b/src/tests/unit/test_to_php.py
@@ -63,8 +63,8 @@ def test_php_atributo_y_operaciones():
     resultado = t.generate_code(ast)
     esperado = (
         "$obj->campo = 5;\n"
-        "$a = 1 + 2;\n"
-        "$b = !$c;"
+        + "$a = 1 + 2;\n"
+        + "$b = !$c;"
     )
     assert resultado == esperado
 

--- a/src/tests/unit/test_to_python.py
+++ b/src/tests/unit/test_to_python.py
@@ -38,7 +38,7 @@ def test_transpilador_condicional():
     resultado = transpilador.generate_code(ast)
     esperado = (
         IMPORTS
-        "if x > 5:\n    y = 2\nelse:\n    y = 3\n"
+        + "if x > 5:\n    y = 2\nelse:\n    y = 3\n"
     )
     assert resultado == esperado
 
@@ -69,7 +69,7 @@ def test_transpilador_funcion():
     resultado = transpilador.generate_code(ast)
     esperado = (
         IMPORTS
-        "def miFuncion(a, b):\n    x = a + b\n"
+        + "def miFuncion(a, b):\n    x = a + b\n"
     )
     assert resultado == esperado
 
@@ -107,13 +107,13 @@ def test_transpilador_switch():
     resultado = t.generate_code(ast)
     esperado = (
         IMPORTS
-        "match x:\n"
-        "    case 1:\n"
-        "        y = 1\n"
-        "    case 2:\n"
-        "        y = 2\n"
-        "    case _:\n"
-        "        y = 0\n"
+        + "match x:\n"
+        + "    case 1:\n"
+        + "        y = 1\n"
+        + "    case 2:\n"
+        + "        y = 2\n"
+        + "    case _:\n"
+        + "        y = 0\n"
     )
     assert resultado == esperado
 
@@ -130,9 +130,9 @@ def test_transpilador_decoradores_anidados():
     codigo = TranspiladorPython().generate_code([func])
     esperado = (
         IMPORTS
-        "@d1\n"
-        "@d2\n"
-        "def saluda():\n    print('hola')\n"
+        + "@d1\n"
+        + "@d2\n"
+        + "def saluda():\n    print('hola')\n"
     )
     assert codigo == esperado
 
@@ -148,9 +148,9 @@ def test_transpilador_corutina_await():
     codigo = TranspiladorPython().generate_code([f1, f2])
     esperado = (
         "import asyncio\n"
-        IMPORTS
-        "async def saluda():\n    print(1)\n"
-        "async def principal():\n    await saluda()\n"
+        + IMPORTS
+        + "async def saluda():\n    print(1)\n"
+        + "async def principal():\n    await saluda()\n"
     )
     assert codigo == esperado
 
@@ -166,10 +166,10 @@ def test_transpilador_clase_compleja():
     codigo = TranspiladorPython().generate_code([clase])
     esperado = (
         "import asyncio\n"
-        IMPORTS
-        "class Hija(Base1, Base2):\n"
-        "    async def run(self):\n"
-        "        await tarea()\n"
+        + IMPORTS
+        + "class Hija(Base1, Base2):\n"
+        + "    async def run(self):\n"
+        + "        await tarea()\n"
     )
     assert codigo == esperado
 
@@ -182,12 +182,12 @@ def test_decoradores_en_clase_y_metodo():
     codigo = TranspiladorPython().generate_code([clase])
     esperado = (
         "import asyncio\n"
-        IMPORTS
-        "@dec\n"
-        "class C:\n"
-        "    @dec\n"
-        "    async def run(self):\n"
-        "        pass\n"
+        + IMPORTS
+        + "@dec\n"
+        + "class C:\n"
+        + "    @dec\n"
+        + "    async def run(self):\n"
+        + "        pass\n"
     )
     assert codigo == esperado
 

--- a/src/tests/unit/test_to_python2.py
+++ b/src/tests/unit/test_to_python2.py
@@ -31,7 +31,7 @@ def test_transpilar_condicional():
     result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
-        "if x > 5:\n    y = 10\nelse:\n    y = 0\n"
+        + "if x > 5:\n    y = 10\nelse:\n    y = 0\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de condicional"
 
@@ -52,7 +52,7 @@ def test_transpilar_funcion():
     result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
-        "def sumar(a, b):\n    resultado = a + b\n"
+        + "def sumar(a, b):\n    resultado = a + b\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de funci\u00f3n"
 

--- a/src/tests/unit/test_to_python3.py
+++ b/src/tests/unit/test_to_python3.py
@@ -37,7 +37,7 @@ def test_transpilar_condicional():
     result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
-        "if x > 5:\n    y = 10\nelse:\n    y = 0\n"
+        + "if x > 5:\n    y = 10\nelse:\n    y = 0\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de condicional"
 
@@ -62,7 +62,7 @@ def test_transpilar_funcion():
     result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
-        "def sumar(a, b):\n    resultado = a + b\n"
+        + "def sumar(a, b):\n    resultado = a + b\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de funci\u00f3n"
 
@@ -121,7 +121,7 @@ def test_transpilar_clase():
     result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
-        "class MiClase:\n    def miMetodo(param):\n        x = param + 1\n"
+        + "class MiClase:\n    def miMetodo(param):\n        x = param + 1\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de clase"
 
@@ -133,7 +133,7 @@ def test_transpilar_clase_multibase():
     result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
-        "class Hija(Base1, Base2):\n    def m(self):\n        return 1\n"
+        + "class Hija(Base1, Base2):\n    def m(self):\n        return 1\n"
     )
     assert result == expected, "Error en herencia múltiple"
 
@@ -144,6 +144,6 @@ def test_transpilar_metodo():
     result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
-        "def miMetodo(a, b):\n    resultado = a + b\n"
+        + "def miMetodo(a, b):\n    resultado = a + b\n"
     )
     assert result == expected, "Error en la transpilaci\u00f3n de m\u00e9todo"

--- a/src/tests/unit/test_to_python4.py
+++ b/src/tests/unit/test_to_python4.py
@@ -20,7 +20,7 @@ def test_transpilar_condicional():
     result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
-        "if x > 5:\n    y = 10\nelse:\n    y = 0\n"
+        + "if x > 5:\n    y = 10\nelse:\n    y = 0\n"
     )
     assert result == expected, "Error en la transpilación de condicional"
 
@@ -39,7 +39,7 @@ def test_transpilar_funcion():
     result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
-        "def sumar(a, b):\n    resultado = a + b\n"
+        + "def sumar(a, b):\n    resultado = a + b\n"
     )
     assert result == expected, "Error en la transpilación de función"
 
@@ -95,7 +95,7 @@ def test_transpilar_clase():
     result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
-        "class MiClase:\n    def mi_metodo(param):\n        x = param + 1\n"
+        + "class MiClase:\n    def mi_metodo(param):\n        x = param + 1\n"
     )
     assert result == expected, "Error en la transpilación de clase"
 
@@ -107,7 +107,7 @@ def test_transpilar_clase_multibase():
     result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
-        "class Hija(Base1, Base2):\n    def m(self):\n        return 1\n"
+        + "class Hija(Base1, Base2):\n    def m(self):\n        return 1\n"
     )
     assert result == expected, "Error en herencia múltiple"
 
@@ -118,6 +118,6 @@ def test_transpilar_metodo():
     result = transpiler.generate_code([nodo])
     expected = (
         IMPORTS
-        "def mi_metodo(a, b):\n    resultado = a + b\n"
+        + "def mi_metodo(a, b):\n    resultado = a + b\n"
     )
     assert result == expected, "Error en la transpilación de método"

--- a/src/tests/unit/test_to_python_extras.py
+++ b/src/tests/unit/test_to_python_extras.py
@@ -23,7 +23,7 @@ def test_transpilar_try_catch_throw():
     codigo = TranspiladorPython().generate_code([nodo])
     esperado = (
         IMPORTS
-        "try:\n    raise Exception(1)\nexcept Exception as e:\n    print(e)\n"
+        + "try:\n    raise Exception(1)\nexcept Exception as e:\n    print(e)\n"
     )
     assert codigo == esperado
 
@@ -42,7 +42,7 @@ def test_transpilar_usar():
     codigo = TranspiladorPython().generate_code([nodo])
     esperado = (
         IMPORTS
-        "from cobra.usar_loader import obtener_modulo\n"
-        "math = obtener_modulo('math')\n"
+        + "from cobra.usar_loader import obtener_modulo\n"
+        + "math = obtener_modulo('math')\n"
     )
     assert codigo == esperado

--- a/src/tests/unit/test_to_rust.py
+++ b/src/tests/unit/test_to_rust.py
@@ -84,11 +84,11 @@ def test_transpilador_clase():
     resultado = t.generate_code(ast)
     esperado = (
         "struct Persona {}\n\n"
-        "impl Persona {\n"
-        "    fn saludar(self) {\n"
-        "        let x = 1;\n"
-        "    }\n"
-        "}"
+        + "impl Persona {\n"
+        + "    fn saludar(self) {\n"
+        + "        let x = 1;\n"
+        + "    }\n"
+        + "}"
     )
     assert resultado == esperado
 
@@ -116,16 +116,16 @@ def test_transpilador_switch():
     resultado = t.generate_code(ast)
     esperado = (
         "match x {\n"
-        "    1 => {\n"
-        "        let y = 1;\n"
-        "    },\n"
-        "    2 => {\n"
-        "        let y = 2;\n"
-        "    },\n"
-        "    _ => {\n"
-        "        let y = 0;\n"
-        "    },\n"
-        "}"
+        + "    1 => {\n"
+        + "        let y = 1;\n"
+        + "    },\n"
+        + "    2 => {\n"
+        + "        let y = 2;\n"
+        + "    },\n"
+        + "    _ => {\n"
+        + "        let y = 0;\n"
+        + "    },\n"
+        + "}"
     )
     assert resultado == esperado
 
@@ -139,16 +139,16 @@ def test_try_catch_result():
     resultado = t.generate_code([nodo])
     esperado = (
         "let resultado: Result<(), Box<dyn std::error::Error>> = (|| {\n"
-        "    return Err(1.into());\n"
-        "    Ok(())\n"
-        "})();\n"
-        "match resultado {\n"
-        "    Ok(_) => (),\n"
-        "    Err(e) => {\n"
-        "        let e = e;\n"
-        "        let y = e;\n"
-        "    },\n"
-        "};"
+        + "    return Err(1.into());\n"
+        + "    Ok(())\n"
+        + "})();\n"
+        + "match resultado {\n"
+        + "    Ok(_) => (),\n"
+        + "    Err(e) => {\n"
+        + "        let e = e;\n"
+        + "        let y = e;\n"
+        + "    },\n"
+        + "};"
     )
     assert resultado == esperado
 
@@ -183,14 +183,14 @@ def test_option_match():
     resultado = t.generate_code(ast)
     esperado = (
         "let opt = Some(1);\n"
-        "match opt {\n"
-        "    Some(v) => {\n"
-        "        let y = v;\n"
-        "    },\n"
-        "    None => {\n"
-        "        let y = 0;\n"
-        "    },\n"
-        "}"
+        + "match opt {\n"
+        + "    Some(v) => {\n"
+        + "        let y = v;\n"
+        + "    },\n"
+        + "    None => {\n"
+        + "        let y = 0;\n"
+        + "    },\n"
+        + "}"
     )
     assert resultado == esperado
 
@@ -206,11 +206,11 @@ def test_transpilador_assert_del_with_import():
     resultado = t.generate_code(ast)
     esperado = (
         "assert!(True);\n"
-        "// del x\n"
-        "{\n"
-        "    let y = 1;\n"
-        "}\n"
-        "use mod::func;"
+        + "// del x\n"
+        + "{\n"
+        + "    let y = 1;\n"
+        + "}\n"
+        + "use mod::func;"
     )
     assert resultado == esperado
 
@@ -227,7 +227,7 @@ def test_obtener_valor_listas_diccionarios():
     resultado = t.generate_code(ast)
     esperado = (
         "let a = vec![1, 2];\n"
-        "let b = std::collections::HashMap::from([(x, 1)]);"
+        + "let b = std::collections::HashMap::from([(x, 1)]);"
     )
     assert resultado == esperado
 

--- a/src/tests/unit/test_to_wasm.py
+++ b/src/tests/unit/test_to_wasm.py
@@ -27,6 +27,6 @@ def test_transpilador_funcion_wasm():
     resultado = t.generate_code(ast)
     esperado = (
         "(func $sumar (param $a i32) (param $b i32)\n"
-        "    (local.set $x (i32.add (local.get $a) (local.get $b)))\n)"
+        + "    (local.set $x (i32.add (local.get $a) (local.get $b)))\n)"
     )
     assert resultado == esperado


### PR DESCRIPTION
## Summary
- replace tuple-like string literals with explicit concatenation in unit tests
- run pytest (fails due to unrelated missing dependencies)

## Testing
- `pytest -q` *(fails: 68 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6883a1cb00ac83279ceeb1df51b28b89