### PR TITLE
Fix holobit path in unit test

### DIFF
--- a/src/tests/unit/test_holobit_generation.py
+++ b/src/tests/unit/test_holobit_generation.py
@@ -5,7 +5,10 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
-holobit_path = ROOT / "src/core/holobits/holobit.py"
+# ``ROOT`` apunta al directorio ``src`` dentro del repositorio. Construimos la
+# ruta al módulo ``holobit`` de forma relativa a este directorio para evitar
+# errores de carga por rutas inexistentes.
+holobit_path = ROOT / "core" / "holobits" / "holobit.py"
 spec = importlib.util.spec_from_file_location("holobit", holobit_path)
 holobit_module = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = holobit_module


### PR DESCRIPTION
## Summary
- fix path to `holobit.py` so the module loads during tests

## Testing
- `pytest src/tests/unit/test_holobit_generation.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6883ac30394c8327ad08a7031446f84c