### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,4 +1,6 @@
 name: Release Binaries
+permissions:
+  contents: read
 
 on:
   push:
@@ -30,6 +32,8 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/Alphonsus411/pCobra/security/code-scanning/22](https://github.com/Alphonsus411/pCobra/security/code-scanning/22)

To fix the problem, you should add a `permissions` key to the workflow file `.github/workflows/release-binaries.yml`. The best practice is to set the permissions at the workflow level, so all jobs inherit the least privilege required, unless a job needs more. For this workflow, the `build` job only needs `contents: read` to check out code and upload artifacts, while the `release` job needs `contents: write` to create a GitHub release. You can set `contents: read` at the workflow level and override it with `contents: write` for the `release` job. This change should be made at the top of the workflow file, after the `name` and before `on`, and within the `release` job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
