### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     paths: ['**.py', 'src/tests/**', '.github/workflows/test.yml']
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Alphonsus411/pCobra/security/code-scanning/21](https://github.com/Alphonsus411/pCobra/security/code-scanning/21)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the following permissions are necessary:
- `contents: read` for accessing the repository's files.
- `security-events: write` for the `Scan for secrets` step, which uses the `GITHUB_TOKEN` to report findings.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
