### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,10 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Alphonsus411/pCobra/security/code-scanning/19](https://github.com/Alphonsus411/pCobra/security/code-scanning/19)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the workflow's steps, the `contents: read` permission is sufficient for most actions, while the `pages: write` permission is required for deploying to GitHub Pages. These permissions will be explicitly set to ensure the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
