### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,4 +1,7 @@
 name: Label PRs by branch
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request:
     types: [opened, reopened, synchronize]


### PR DESCRIPTION
Potential fix for [https://github.com/Alphonsus411/pCobra/security/code-scanning/15](https://github.com/Alphonsus411/pCobra/security/code-scanning/15)

To fix the issue, add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the functionality of the `actions/labeler` action, the workflow likely needs `contents: read` to access repository files and `pull-requests: write` to label pull requests. The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`label`) to limit its scope.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
