### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -1,4 +1,6 @@
 name: Build Executables
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/Alphonsus411/pCobra/security/code-scanning/8](https://github.com/Alphonsus411/pCobra/security/code-scanning/8)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/build-exe.yml`. This block can be added at the top level (applies to all jobs) or at the job level (applies only to the specific job). Since the workflow only checks out code, installs dependencies, builds, and uploads artifacts, the minimal required permission is `contents: read`. If you later add steps that require additional permissions (e.g., publishing a release), you can expand the permissions as needed. The best way to fix this is to add the following block after the `name:` line and before the `on:` block:

```yaml
permissions:
  contents: read
```

No imports or additional definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
