### PR TITLE
Support escaped sequences in string tokens

### DIFF
--- a/src/cobra/lexico/lexer.py
+++ b/src/cobra/lexico/lexer.py
@@ -205,7 +205,10 @@ class Lexer:
             (TipoToken.COMO, r"\bcomo\b"),
             (TipoToken.FLOTANTE, r"\d+\.\d+"),
             (TipoToken.ENTERO, r"\d+"),
-            (TipoToken.CADENA, r"'[^']*'|\"[^\"]*\""),
+            (
+                TipoToken.CADENA,
+                r"'(?:\\.|[^'])*'|\"(?:\\.|[^\"])*\"",
+            ),
             (TipoToken.BOOLEANO, r"\b(verdadero|falso)\b"),
             (TipoToken.ASIGNAR_INFERENCIA, r":="),
             (TipoToken.DOSPUNTOS, r":"),

--- a/src/tests/unit/lexer_test_casos_edge.py
+++ b/src/tests/unit/lexer_test_casos_edge.py
@@ -33,3 +33,19 @@ def test_literal_extremo():
     assert tokens[0].tipo == TipoToken.ENTERO
     assert tokens[0].valor == 999999999999999999
     assert tokens[-1].tipo == TipoToken.EOF
+
+
+def test_cadena_con_escape():
+    codigo = r"'hola\\nmundo'"
+    tokens = Lexer(codigo).analizar_token()
+    assert tokens[0].tipo == TipoToken.CADENA
+    assert tokens[0].valor == "hola\\nmundo"
+    assert tokens[-1].tipo == TipoToken.EOF
+
+
+def test_cadena_con_comillas_escapadas():
+    codigo = '"dijo \\"hola\\""'
+    tokens = Lexer(codigo).analizar_token()
+    assert tokens[0].tipo == TipoToken.CADENA
+    assert tokens[0].valor == 'dijo \\"hola\\"'
+    assert tokens[-1].tipo == TipoToken.EOF


### PR DESCRIPTION
## Summary
- update lexer regex for string tokens to accept escaped sequences
- add lexer edge tests covering escaped sequences

## Testing
- `make lint` *(fails: F401/E501 etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'tomli', 'tree_sitter_languages', 'cli')*

------
https://chatgpt.com/codex/tasks/task_e_6884bceed7c08327b2b3631c61d038b6