### PR TITLE
Add module path validation and tests

### DIFF
--- a/src/cobra/cli/commands/modules_cmd.py
+++ b/src/cobra/cli/commands/modules_cmd.py
@@ -118,6 +118,9 @@ class ModulesCommand(BaseCommand):
         if not os.path.exists(ruta):
             mostrar_error(_("No se encontró el módulo {path}").format(path=ruta))
             return 1
+        if os.path.islink(ruta) or not os.path.isfile(ruta) or os.path.splitext(ruta)[1] != ".co":
+            mostrar_error(_("Ruta de módulo inválida"))
+            return 1
         destino = os.path.join(MODULES_PATH, os.path.basename(ruta))
         shutil.copy(ruta, destino)
         mostrar_info(_("Módulo instalado en {dest}").format(dest=destino))

--- a/src/tests/integration/test_cli.py
+++ b/src/tests/integration/test_cli.py
@@ -3,6 +3,7 @@ from io import StringIO
 from unittest.mock import patch
 import backend  # ensure backend aliases are initialized
 from cli.cli import main
+from cli.commands import modules_cmd
 
 
 def test_cli_help():
@@ -11,3 +12,56 @@ def test_cli_help():
             main(["--help"])
         assert exc.value.code == 0
     assert "uso" in out.getvalue().lower() or "usage" in out.getvalue().lower()
+
+
+@pytest.mark.timeout(5)
+def test_modulos_instalar_ruta_no_archivo(tmp_path, monkeypatch):
+    mods_dir = tmp_path / "mods"
+    mods_dir.mkdir()
+    monkeypatch.setattr(modules_cmd, "MODULES_PATH", str(mods_dir))
+    mod_file = tmp_path / "cobra.mod"
+    mod_file.write_text("lock: {}\n")
+    monkeypatch.setattr(modules_cmd, "MODULE_MAP_PATH", str(mod_file))
+    monkeypatch.setattr(modules_cmd, "LOCK_FILE", str(mod_file))
+
+    ruta = tmp_path / "dir"
+    ruta.mkdir()
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["modulos", "instalar", str(ruta)])
+    assert "inv\u00e1lida" in out.getvalue().lower()
+
+
+@pytest.mark.timeout(5)
+def test_modulos_instalar_extension_invalida(tmp_path, monkeypatch):
+    mods_dir = tmp_path / "mods"
+    mods_dir.mkdir()
+    monkeypatch.setattr(modules_cmd, "MODULES_PATH", str(mods_dir))
+    mod_file = tmp_path / "cobra.mod"
+    mod_file.write_text("lock: {}\n")
+    monkeypatch.setattr(modules_cmd, "MODULE_MAP_PATH", str(mod_file))
+    monkeypatch.setattr(modules_cmd, "LOCK_FILE", str(mod_file))
+
+    archivo = tmp_path / "m.txt"
+    archivo.write_text("x = 1")
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["modulos", "instalar", str(archivo)])
+    assert "inv\u00e1lida" in out.getvalue().lower()
+
+
+@pytest.mark.timeout(5)
+def test_modulos_instalar_enlace_simbolico(tmp_path, monkeypatch):
+    mods_dir = tmp_path / "mods"
+    mods_dir.mkdir()
+    monkeypatch.setattr(modules_cmd, "MODULES_PATH", str(mods_dir))
+    mod_file = tmp_path / "cobra.mod"
+    mod_file.write_text("lock: {}\n")
+    monkeypatch.setattr(modules_cmd, "MODULE_MAP_PATH", str(mod_file))
+    monkeypatch.setattr(modules_cmd, "LOCK_FILE", str(mod_file))
+
+    real_file = tmp_path / "m.co"
+    real_file.write_text("var x = 1")
+    link = tmp_path / "link.co"
+    link.symlink_to(real_file)
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        main(["modulos", "instalar", str(link)])
+    assert "inv\u00e1lida" in out.getvalue().lower()


### PR DESCRIPTION
## Summary
- validate module file path in `ModulesCommand._instalar_modulo`
- add integration tests for invalid module paths

## Testing
- `PYTHONPATH=src:$PYTHONPATH pytest -q src/tests/integration/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6884d1dbd1ec8327a420ee9d7108cb59