### PR TITLE
Captura de interrupciones en modo interactivo

### DIFF
--- a/src/cobra/cli/commands/interactive_cmd.py
+++ b/src/cobra/cli/commands/interactive_cmd.py
@@ -125,6 +125,9 @@ class InteractiveCommand(BaseCommand):
                         mostrar_error(str(pe))
                         continue
                     interpretador.ejecutar_ast(ast)
+            except (KeyboardInterrupt, EOFError):
+                mostrar_info("Saliendo...")
+                break
             except SyntaxError as se:
                 logging.error(f"Error de sintaxis: {se}")
                 mostrar_error(f"Error procesando la entrada: {se}")


### PR DESCRIPTION
## Summary
- manejar `KeyboardInterrupt` y `EOFError` en `InteractiveCommand`
- crear pruebas que simulan dichas interrupciones

## Testing
- `PYTHONPATH=$PWD/src:$PWD/src/cobra pytest -k "interactive_keyboard_interrupt or interactive_eof_error" src/tests/unit/test_cli_interactive_cmd.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d8da9a248327b9de6e5d744387be