### PR TITLE
Replace urllib with requests

### DIFF
--- a/frontend/docs/modulos_nativos.rst
+++ b/frontend/docs/modulos_nativos.rst
@@ -64,6 +64,8 @@ Red
 ---
 - ``obtener_url(url)`` recupera el contenido de una URL.
 - ``enviar_post(url, datos)`` envia datos por ``POST``.
+  Los destinos se validan opcionalmente con la lista de hosts definida en
+  la variable de entorno ``COBRA_HOST_WHITELIST``.
 
 .. code-block:: cobra
 

--- a/src/core/nativos/io.py
+++ b/src/core/nativos/io.py
@@ -1,4 +1,7 @@
-import urllib.request
+import os
+import urllib.parse
+
+import requests
 
 
 def leer_archivo(ruta):
@@ -18,5 +21,12 @@ def obtener_url(url):
     url_baja = url.lower()
     if not (url_baja.startswith("http://") or url_baja.startswith("https://")):
         raise ValueError("Esquema de URL no soportado")
-    with urllib.request.urlopen(url, timeout=5) as resp:
-        return resp.read().decode("utf-8")
+    allowed = os.environ.get("COBRA_HOST_WHITELIST")
+    if allowed:
+        hosts = {h.strip() for h in allowed.split(',') if h.strip()}
+        host = urllib.parse.urlparse(url).hostname
+        if host not in hosts:
+            raise ValueError("Host no permitido")
+    resp = requests.get(url, timeout=5)
+    resp.raise_for_status()
+    return resp.text

--- a/src/tests/unit/test_nativos_io.py
+++ b/src/tests/unit/test_nativos_io.py
@@ -1,7 +1,7 @@
 import sys
 from types import ModuleType
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -23,14 +23,31 @@ import src.core.nativos.io as io
 
 
 def test_obtener_url_rechaza_esquema_no_http():
-    with patch('urllib.request.urlopen') as mock_urlopen:
+    with patch('requests.get') as mock_get:
         with pytest.raises(ValueError):
             io.obtener_url('ftp://ejemplo.com')
-        mock_urlopen.assert_not_called()
+        mock_get.assert_not_called()
 
 
 def test_obtener_url_rechaza_otro_esquema():
-    with patch('urllib.request.urlopen') as mock_urlopen:
+    with patch('requests.get') as mock_get:
         with pytest.raises(ValueError):
             io.obtener_url('file:///tmp/archivo.txt')
-        mock_urlopen.assert_not_called()
+        mock_get.assert_not_called()
+
+
+def test_obtener_url_host_whitelist(monkeypatch):
+    monkeypatch.setenv("COBRA_HOST_WHITELIST", "example.com")
+    mock_resp = MagicMock()
+    mock_resp.text = "ok"
+    mock_resp.raise_for_status.return_value = None
+    with patch('requests.get', return_value=mock_resp):
+        assert io.obtener_url('http://example.com') == 'ok'
+
+
+def test_obtener_url_host_no_permitido(monkeypatch):
+    monkeypatch.setenv("COBRA_HOST_WHITELIST", "example.com")
+    with patch('requests.get') as mock_get:
+        with pytest.raises(ValueError):
+            io.obtener_url('http://otro.com')
+        mock_get.assert_not_called()


### PR DESCRIPTION
## Summary
- switch network helpers to `requests`
- validate URL host using `COBRA_HOST_WHITELIST`
- document host whitelist in native modules docs
- update unit tests for `requests` and host validation

## Testing
- `pytest -k "corelibs or nativos_io" -q` *(fails: ModuleNotFoundError: No module named 'cli')*
- `pytest src/tests/unit/test_corelibs.py::test_red_funcs -q`
- `pytest src/tests/unit/test_nativos_io.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6884decac4b4832782c89471a781049b