### PR TITLE
Add plugin discovery regression test

### DIFF
--- a/src/tests/fake_plugins.py
+++ b/src/tests/fake_plugins.py
@@ -1,0 +1,32 @@
+from cli.plugin import PluginCommand
+
+
+class GoodPlugin(PluginCommand):
+    name = "good"
+    version = "1.0"
+    description = "good plugin"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help=self.description)
+        parser.set_defaults(cmd=self)
+
+    def run(self, args):
+        pass
+
+
+class NotPlugin:
+    """Class that does not implement PluginInterface"""
+    pass
+
+
+class BadInitPlugin(PluginCommand):
+    name = "badinit"
+
+    def __init__(self):
+        raise RuntimeError("boom")
+
+    def register_subparser(self, subparsers):
+        pass
+
+    def run(self, args):
+        pass

--- a/src/tests/unit/test_descubrir_plugins_invalid.py
+++ b/src/tests/unit/test_descubrir_plugins_invalid.py
@@ -1,0 +1,48 @@
+import sys
+from unittest.mock import patch
+import importlib.metadata
+
+# Ensure CLI modules are importable
+import cobra.cli as cobra_cli
+import cobra.cli.commands as cobra_cmds
+import cobra.cli.plugin_registry as cobra_reg
+sys.modules.setdefault("cli", cobra_cli)
+sys.modules.setdefault("cli.commands", cobra_cmds)
+sys.modules.setdefault("cli.plugin_registry", cobra_reg)
+sys.modules.setdefault("src.cli", cobra_cli)
+sys.modules.setdefault("src.cli.commands", cobra_cmds)
+sys.modules.setdefault("src.cli.plugin_registry", cobra_reg)
+
+from cli.plugin import descubrir_plugins
+from cli.plugin_registry import obtener_registro, limpiar_registro
+from tests.fake_plugins import GoodPlugin, NotPlugin, BadInitPlugin
+
+
+def test_descubrir_plugins_varios_invalidos(caplog):
+    ep_good = importlib.metadata.EntryPoint(
+        name="good",
+        value="tests.fake_plugins:GoodPlugin",
+        group="cobra.plugins",
+    )
+    ep_bad = importlib.metadata.EntryPoint(
+        name="bad",
+        value="tests.fake_plugins:NotPlugin",
+        group="cobra.plugins",
+    )
+    ep_crash = importlib.metadata.EntryPoint(
+        name="crash",
+        value="tests.fake_plugins:BadInitPlugin",
+        group="cobra.plugins",
+    )
+    eps = importlib.metadata.EntryPoints((ep_good, ep_bad, ep_crash))
+    with patch("cli.plugin.entry_points", return_value=eps):
+        limpiar_registro()
+        with caplog.at_level("WARNING"):
+            plugins = descubrir_plugins()
+    # Only the valid plugin should be returned
+    assert [p.__class__ for p in plugins] == [GoodPlugin]
+    # Registry only contains the valid plugin
+    assert obtener_registro() == {"good": "1.0"}
+    # Errors for the invalid plugins should have been logged
+    assert any("no implementa PluginInterface" in r.message for r in caplog.records)
+    assert any("Error instanciando plugin" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- add fake plugins for discovery tests
- ensure invalid plugins don't register and only valid plugins are returned

## Testing
- `PYTHONPATH=src:src/cobra pytest src/tests/unit/test_descubrir_plugins_invalid.py::test_descubrir_plugins_varios_invalidos -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e1cb18a8832794ce8b953f4c1ec9