### PR TITLE
Restrict pybind_bridge load paths

### DIFF
--- a/src/tests/unit/test_pybind_bridge_invalid_loader.py
+++ b/src/tests/unit/test_pybind_bridge_invalid_loader.py
@@ -18,13 +18,15 @@ fake_setuptools = ModuleType('setuptools')
 fake_setuptools.Distribution = object
 sys.modules.setdefault('setuptools', fake_setuptools)
 
-from src.core.pybind_bridge import cargar_extension
 
-
-def test_cargar_extension_loader_invalido(tmp_path):
+def test_cargar_extension_loader_invalido(tmp_path, monkeypatch):
     ruta = tmp_path / "x.so"
     ruta.touch()
+    monkeypatch.setenv("COBRA_ALLOWED_EXT_PATHS", str(tmp_path))
+    import importlib
+    import src.core.pybind_bridge as bridge
+    importlib.reload(bridge)
     with patch("importlib.util.spec_from_loader", return_value=None):
         with pytest.raises(ImportError, match="No se pudo obtener un spec"):
-            cargar_extension(str(ruta))
+            bridge.cargar_extension(str(ruta))
 

--- a/src/tests/unit/test_pybind_bridge_paths.py
+++ b/src/tests/unit/test_pybind_bridge_paths.py
@@ -1,0 +1,45 @@
+import sys
+from types import ModuleType
+from pathlib import Path
+import importlib
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "backend" / "src"))
+
+fake_pybind11 = ModuleType('pybind11')
+fake_helpers = ModuleType('pybind11.setup_helpers')
+fake_helpers.Pybind11Extension = object
+fake_helpers.build_ext = object
+sys.modules.setdefault('pybind11', fake_pybind11)
+sys.modules.setdefault('pybind11.setup_helpers', fake_helpers)
+fake_setuptools = ModuleType('setuptools')
+fake_setuptools.Distribution = object
+sys.modules.setdefault('setuptools', fake_setuptools)
+
+
+def test_cargar_extension_invalid_path(tmp_path, monkeypatch):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    monkeypatch.setenv("COBRA_ALLOWED_EXT_PATHS", str(allowed))
+    import src.core.pybind_bridge as bridge
+    importlib.reload(bridge)
+    invalid = tmp_path / "other" / "x.so"
+    invalid.parent.mkdir()
+    invalid.touch()
+    with pytest.raises(ValueError):
+        bridge.cargar_extension(str(invalid))
+
+
+def test_cargar_extension_invalid_parent(tmp_path, monkeypatch):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    monkeypatch.setenv("COBRA_ALLOWED_EXT_PATHS", str(allowed))
+    import src.core.pybind_bridge as bridge
+    importlib.reload(bridge)
+    outside = allowed.parent / "x.so"
+    outside.touch()
+    with pytest.raises(ValueError):
+        bridge.cargar_extension(str(outside))
+


### PR DESCRIPTION
## Summary
- add allowed path checks for `pybind_bridge` modules
- ensure invalid paths raise `ValueError`
- adjust loader test and add new path tests

## Testing
- `pytest src/tests/unit/test_pybind_bridge_invalid_loader.py src/tests/unit/test_pybind_bridge_paths.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ea3a92948327b6c2e97d8cf93652