### PR TITLE
Set secure permissions on qualia state

### DIFF
--- a/src/core/qualia_bridge.py
+++ b/src/core/qualia_bridge.py
@@ -93,6 +93,7 @@ def save_state(spirit: QualiaSpirit) -> None:
             ensure_ascii=False,
             indent=2,
         )
+    os.chmod(STATE_FILE, 0o600)
 
 
 QUALIA = load_state()

--- a/src/tests/unit/test_qualia_bridge.py
+++ b/src/tests/unit/test_qualia_bridge.py
@@ -73,3 +73,15 @@ def test_qualia_rejects_traversal(tmp_path, monkeypatch):
     with pytest.raises(ValueError):
         importlib.reload(qualia_bridge)
 
+
+def test_state_file_permissions(tmp_path, monkeypatch):
+    state = tmp_path / ".cobra" / "state.json"
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
+    qb = importlib.reload(qualia_bridge)
+    qb.register_execution("var x = 1")
+    if os.name == "posix":
+        assert state.exists()
+        mode = state.stat().st_mode & 0o777
+        assert mode == 0o600
+


### PR DESCRIPTION
## Summary
- restrict file permissions when saving Qualia state
- test permissions of saved state file on POSIX systems

## Testing
- `pytest -q src/tests/unit/test_qualia_bridge.py::test_state_file_permissions`
- `pytest -q src/tests/unit/test_qualia_bridge.py`

------
https://chatgpt.com/codex/tasks/task_e_6884f61418b08327815cc6fd5183bf08