### PR TITLE
Add checks for rust tooling

### DIFF
--- a/src/core/rust_bridge.py
+++ b/src/core/rust_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Iterable, Any
@@ -18,6 +19,16 @@ def compilar_crate(ruta: str, release: bool = True) -> str:
     compilar\u00e1 en modo debug.
     """
     path = Path(ruta).resolve()
+
+    if shutil.which("cbindgen") is None:
+        raise RuntimeError(
+            "La herramienta 'cbindgen' no est\xc3\xa1 instalada o no se encuentra en PATH"
+        )
+
+    if shutil.which("cargo") is None:
+        raise RuntimeError(
+            "La herramienta 'cargo' no est\xc3\xa1 instalada o no se encuentra en PATH"
+        )
 
     subprocess.run([
         "cbindgen",

--- a/src/tests/unit/test_rust_bridge.py
+++ b/src/tests/unit/test_rust_bridge.py
@@ -1,0 +1,25 @@
+import pytest
+from unittest.mock import patch
+from pathlib import Path
+
+import core.rust_bridge as rust_bridge
+
+
+def test_compilar_crate_sin_cbindgen(tmp_path):
+    def fake_which(cmd):
+        return None if cmd == "cbindgen" else "/usr/bin/" + cmd
+    with patch("shutil.which", side_effect=fake_which), patch("subprocess.run") as run:
+        with pytest.raises(RuntimeError):
+            rust_bridge.compilar_crate(str(tmp_path))
+        run.assert_not_called()
+
+
+def test_compilar_crate_sin_cargo(tmp_path):
+    def fake_which(cmd):
+        if cmd == "cbindgen":
+            return "/usr/bin/cbindgen"
+        return None
+    with patch("shutil.which", side_effect=fake_which), patch("subprocess.run") as run:
+        with pytest.raises(RuntimeError):
+            rust_bridge.compilar_crate(str(tmp_path))
+        run.assert_not_called()


### PR DESCRIPTION
## Summary
- ensure `cbindgen` and `cargo` are available before building rust crates
- add unit tests simulating missing tools

## Testing
- `pytest src/tests/unit/test_rust_bridge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6884fb064f688327ad5a20f745de0e68