### PR TITLE
Update docs for dev requirements

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -12,8 +12,9 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
         pip install -e .
+        # pip install -e .[dev] también es válido para extras de desarrollo
         if [ -n "${{ inputs.extra }}" ]; then
           pip install ${{ inputs.extra }}
         fi

--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -8,13 +8,15 @@ Este manual presenta en español los conceptos básicos para programar en Cobra.
 
 1. Clona el repositorio y entra en el directorio `pCobra`.
 2. Crea y activa un entorno virtual.
-3. Instala las dependencias con `pip install -r requirements.txt`.
+3. Instala las dependencias con `pip install -r requirements-dev.txt`.
    Aseg\u00farate tambi\u00e9n de tener disponible la herramienta `cbindgen`:
 
    ```bash
    cargo install cbindgen
    ```
 4. Instala la herramienta de forma editable con `pip install -e .`.
+
+   Puedes usar ``pip install -e .[dev]`` para incluir los extras de desarrollo.
 
 ### Instalación con pipx
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ source .venv/bin/activate  # Para Unix
    `hypothesis`, etc.):
 
 ````bash
-pip install -r requirements.txt
+pip install -r requirements-dev.txt
 ````
 
    Estas bibliotecas permiten ejecutar las pruebas y otras tareas de desarrollo.
@@ -125,6 +125,9 @@ pip install -r requirements.txt
 ````bash
 pip install -e .
 ````
+
+   Opcionalmente puedes ejecutar ``pip install -e .[dev]`` para instalar los
+   extras de desarrollo.
 
 6. Copia el archivo ``.env.example`` a ``.env`` y personaliza las rutas o claves
    de ser necesario. Estas variables se cargarán automáticamente al iniciar

--- a/README_en.md
+++ b/README_en.md
@@ -96,7 +96,7 @@ source .venv/bin/activate  # Unix
 4. Install the development dependencies (pytest, `python-dotenv`, `tomli`, `hypothesis`, etc.):
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements-dev.txt
 ```
 
    These libraries are needed for running the tests and other development tasks. Runtime dependencies are installed when installing the package.
@@ -106,6 +106,8 @@ pip install -r requirements.txt
 ```bash
 pip install -e .
 ```
+
+Optionally, you may run ``pip install -e .[dev]`` to include the development extras.
 
 6. Copy ``.env.example`` to ``.env`` and customize the paths or keys if necessary. These variables will be loaded automatically thanks to ``python-dotenv``:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,8 +25,8 @@ RUN apt-get update && \
 
 # Instalar dependencias de Python
 RUN pip install --upgrade pip setuptools wheel && \
-    pip install -r requirements.txt && \
-    pip install -e .
+    pip install -r requirements-dev.txt && \
+    pip install -e .  # pip install -e .[dev] también es válido para extras de desarrollo
 
 # Comando por defecto: ejecutar los tests
 CMD ["pytest"]

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -15,8 +15,11 @@ Preparación del entorno
 
 1. Clona el repositorio y entra en ``pCobra``.
 2. Crea y activa un entorno virtual.
-3. Instala las dependencias con ``pip install -r requirements.txt``.
+3. Instala las dependencias con ``pip install -r requirements-dev.txt``.
 4. Instala Cobra en modo editable con ``pip install -e .``.
+
+   También puedes ejecutar ``pip install -e .[dev]`` para incluir los extras de
+   desarrollo.
 
 Sintaxis básica
 ---------------

--- a/frontend/docs/entorno_desarrollo.rst
+++ b/frontend/docs/entorno_desarrollo.rst
@@ -11,7 +11,9 @@ Instalación de dependencias
 
    .. code-block:: bash
 
-      pip install -r requirements.txt
+      pip install -r requirements-dev.txt
+
+   También puedes ejecutar ``pip install -e .[dev]`` para instalar los extras de desarrollo junto con Cobra.
 
 2. Para utilizar el servidor LSP ejecuta:
 

--- a/frontend/docs/primeros_pasos.rst
+++ b/frontend/docs/primeros_pasos.rst
@@ -25,8 +25,10 @@ Instalación
 
 .. code-block:: bash
 
-   pip install -r requirements.txt
+   pip install -r requirements-dev.txt
    pip install -e .
+
+   # También puedes usar ``pip install -e .[dev]`` para instalar los extras de desarrollo
 
 Uso básico
 ----------


### PR DESCRIPTION
## Summary
- use `requirements-dev.txt` when installing dependencies
- mention `pip install -e .[dev]` as an alternative

## Testing
- `make test` *(fails: No module named 'src.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68850b88d5b083279ad672dec4345dc3