### PR TITLE
Update language lists with C and WebAssembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Versión 10.0.6
 
 [English version available here](README_en.md)
-Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
+Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
 
 
 ## Tabla de Contenidos
@@ -268,7 +268,7 @@ El proyecto se organiza en las siguientes carpetas y módulos:
 # Características Principales
 
 - Lexer y Parser: Implementación de un lexer para la tokenización del código fuente y un parser para la construcción de un árbol de sintaxis abstracta (AST).
-- Transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
+- Transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly: Cobra puede convertir el código en estos lenguajes, facilitando su integración con aplicaciones externas.
 - Soporte de Estructuras Avanzadas: Permite la declaración de variables, funciones, clases, listas y diccionarios, así como el uso de bucles y condicionales.
 - Módulos nativos con funciones de E/S, utilidades matemáticas y estructuras de datos para usar directamente desde Cobra.
 - Instalación de paquetes en tiempo de ejecución mediante la instrucción `usar`.
@@ -544,7 +544,7 @@ editar `cobra.mod` y volver a ejecutar las pruebas.
 ## Invocar el transpilador
 
 La carpeta [`src/cobra/transpilers/transpiler`](src/cobra/transpilers/transpiler)
-contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX. Una vez
+contiene la implementación de los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly. Una vez
 instaladas las dependencias, puedes llamar al transpilador desde tu propio
 script de la siguiente manera:
 
@@ -638,7 +638,7 @@ Si no proporcionas un subcomando se abrirá el modo interactivo.
 Una vez instalado el paquete, la herramienta `cobra` ofrece varios subcomandos:
 
 ```bash
-# Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo o LaTeX
+# Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C o WebAssembly
 cobra compilar programa.co --tipo python
 
 # Transpilar inverso de Python a JavaScript
@@ -1053,7 +1053,7 @@ Este proyecto está bajo la [Licencia MIT](LICENSE).
 
 ### Notas
 
-- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX.
+- **Documentación y Ejemplos Actualizados**: El README ha sido actualizado para reflejar las capacidades de transpilación y la compatibilidad con Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly.
 - **Ejemplos de Código y Nuevas Estructuras**: Incluye ejemplos con el uso de estructuras avanzadas como clases y diccionarios en el lenguaje Cobra.
 
 Si deseas agregar o modificar algo, házmelo saber.

--- a/README_en.md
+++ b/README_en.md
@@ -4,7 +4,7 @@
 
 Version 10.0.6
 
-Cobra is a programming language designed in Spanish, aimed at creating tools, simulations and analyses in fields such as biology, computing and astrophysics. This project includes a lexer, parser and transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo and LaTeX, allowing greater versatility when running and deploying Cobra code.
+Cobra is a programming language designed in Spanish, aimed at creating tools, simulations and analyses in fields such as biology, computing and astrophysics. This project includes a lexer, parser and transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C and WebAssembly, allowing greater versatility when running and deploying Cobra code.
 
 ## Table of Contents
 
@@ -228,7 +228,7 @@ The project is organized into the following folders and modules:
 # Main Features
 
 - Lexer and Parser: Implementation of a lexer to tokenize the source code and a parser to build an abstract syntax tree (AST).
-- Transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo and LaTeX: Cobra can convert code to these languages, facilitating integration with external applications.
+- Transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C and WebAssembly: Cobra can convert code to these languages, facilitating integration with external applications.
 - Support for advanced structures: declaration of variables, functions, classes, lists and dictionaries, as well as loops and conditionals.
 - Native modules with I/O functions, math utilities and data structures ready to use from Cobra.
 - Runtime package installation via the `usar` instruction.
@@ -406,7 +406,7 @@ If an entry is not found, the transpiler will load the file indicated in the `im
 
 ## Calling the transpiler
 
-The folder [`src/cobra/transpilers/transpiler`](src/cobra/transpilers/transpiler) contains the implementation of the transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo and LaTeX. Once the dependencies are installed you can call the transpiler from your own script like this:
+The folder [`src/cobra/transpilers/transpiler`](src/cobra/transpilers/transpiler) contains the implementation of the transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C and WebAssembly. Once the dependencies are installed you can call the transpiler from your own script like this:
 
 ```python
 from cobra.transpilers.transpiler.to_python import TranspiladorPython

--- a/docs/arquitectura_parser_transpiladores.md
+++ b/docs/arquitectura_parser_transpiladores.md
@@ -11,7 +11,7 @@ Se encarga de leer el texto fuente y convertirlo en una secuencia de *tokens*. C
 Consume los tokens generados por el lexer y construye el \u00c1rbol de Sintaxis Abstracta (**AST**). El parser valida la estructura del programa y crea los nodos que representar\u00e1n instrucciones, expresiones y declaraciones.
 
 ### `transpilers`
-Una vez disponible el AST, los transpiladores recorren cada nodo mediante el patr\u00f3n *Visitor* para generar c\u00f3digo en otros lenguajes. Cobra incluye transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX.
+Una vez disponible el AST, los transpiladores recorren cada nodo mediante el patr\u00f3n *Visitor* para generar c\u00f3digo en otros lenguajes. Cobra incluye transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly.
 
 ## Interacci\u00f3n general
 El proceso habitual comienza con el lexer, sigue con el parser y finaliza en el int\u00e9rprete o en alguno de los transpiladores. La siguiente gr\u00e1fica resume dicho flujo.

--- a/docs/estructura_ast.md
+++ b/docs/estructura_ast.md
@@ -80,5 +80,7 @@ Transpiladores --> Perl
 Transpiladores --> Matlab
 Transpiladores --> Mojo
 Transpiladores --> LaTeX
+Transpiladores --> C
+Transpiladores --> WebAssembly
 @enduml
 ```

--- a/frontend/docs/arquitectura.rst
+++ b/frontend/docs/arquitectura.rst
@@ -15,7 +15,7 @@ Command (ver :ref:`patron_command`).
 Core
 ----
 Contiene el corazón del lenguaje: lexer, parser, intérprete y
-transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX. Estos elementos trabajan en
+transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly. Estos elementos trabajan en
 conjunto para analizar el código fuente y transformarlo en otras
 representaciones o ejecutarlo de forma directa.
 Las clases que componen el AST se definen en ``src.core.ast_nodes`` para facilitar su reutilización.

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -5,7 +5,7 @@ Avances del lenguaje Cobra
 - **Lexer y Parser funcionales**: El sistema lexico y sintactico esta completamente implementado y es capaz de procesar asignaciones de variables, funciones, condicionales, bucles y operaciones de holobits.
 - **Holobits**: Tipo de dato especial para trabajar con informacion multidimensional, con soporte para operaciones como proyecciones, transformaciones y visualizacion.
 - **Gestión de memoria automatizada**: Cobra incluye un sistema de manejo de memoria optimizado que se ajusta automáticamente utilizando algoritmos genéticos.
-- **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX.
+- **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly.
 - **Pruebas unitarias**: Se han creado pruebas para validar el correcto funcionamiento del lexer y el parser.
 
  - **Versión 10.0.6**: Actualización de la documentación y configuración del proyecto.

--- a/frontend/docs/caracteristicas.rst
+++ b/frontend/docs/caracteristicas.rst
@@ -4,7 +4,7 @@ Caracteristicas principales de Cobra
 - **Sintaxis en espanol**: Todas las palabras clave y estructuras del lenguaje estan en español, para facilitar su uso por hablantes nativos.
 - **Gestion de memoria automatica**: Cobra incorpora un sistema de manejo de memoria basado en algoritmos genéticos que optimiza el uso de los recursos durante la ejecución.
 - **Soporte para holobits**: Un tipo de dato multidimensional que permite trabajar con datos de alta complejidad.
-- **Transpiler a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX**: Los programas escritos en Cobra pueden ser transpilados a estos lenguajes, lo que permite su ejecucion en una variedad de plataformas.
+- **Transpiler a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly**: Los programas escritos en Cobra pueden ser transpilados a estos lenguajes, lo que permite su ejecucion en una variedad de plataformas.
 - **Nombres Unicode**: Los identificadores aceptan caracteres como `á`, `ñ` o `Ω`.
 
 **Ejemplo basico**

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -56,7 +56,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
 Introducción
 --------------------
 
-Cobra fue creado con la idea de facilitar la programacion en español, optimizando la gestion de memoria y anadiendo soporte para trabajar con datos de alta complejidad como los holobits. Ademas, ofrece soporte para generar código en Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX, permitiendo su ejecucion en multiples plataformas.
+Cobra fue creado con la idea de facilitar la programacion en español, optimizando la gestion de memoria y anadiendo soporte para trabajar con datos de alta complejidad como los holobits. Ademas, ofrece soporte para generar código en Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly, permitiendo su ejecucion en multiples plataformas.
 
 
 

--- a/frontend/docs/optimizaciones.rst
+++ b/frontend/docs/optimizaciones.rst
@@ -19,7 +19,7 @@ Eliminación de subexpresiones comunes
 ------------------------------------
 ``eliminate_common_subexpressions`` detecta expresiones idénticas que se repiten dentro de una misma función o en el nivel global. Dichas expresiones se calculan una única vez asignándose a una variable temporal y las repeticiones se reemplazan por el identificador generado.
 
-Estas optimizaciones se aplican automáticamente antes de ejecutar el intérprete y en los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX.
+Estas optimizaciones se aplican automáticamente antes de ejecutar el intérprete y en los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly.
 
 Decoradores de rendimiento (``smooth-criminal``)
 ------------------------------------------------

--- a/frontend/docs/sintaxis.rst
+++ b/frontend/docs/sintaxis.rst
@@ -98,7 +98,7 @@ Puedes anteponer `@` a una función para modificar su comportamiento con un deco
        imprimir('hola')
    fin
 
-**Transpilación a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo y LaTeX**
+**Transpilación a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly**
 
 - `imprimir` se transpila a `print` en Python, `console.log` en JavaScript, `PRINT` en ensamblador, `println!` en Rust, `std::cout` en C++, `fmt.Println` en Go, `println` en Kotlin, `print` en Swift, `print` en R, `println` en Julia, `System.out.println` en Java, `DISPLAY` en COBOL, `print *` en Fortran, `writeln` en Pascal, `Console.WriteLine` en VisualBasic, `puts` en Ruby, `echo` en PHP, `print` en Perl, `disp` en Matlab, `print` en Mojo y `	exttt{}` en LaTeX.
 - Los bucles `mientras` y `para` se convierten en `while` y `for` en los lenguajes de alto nivel, mientras que en ensamblador generan instrucciones `WHILE` y `FOR`.


### PR DESCRIPTION
## Summary
- document support for C and WebAssembly across README files
- update docs mentioning supported languages
- extend AST diagram with new languages

## Testing
- `pytest -q` *(fails: No se pudo importar cli: No module named 'src.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68851300a2cc83279a18e236f800d1af