### PR TITLE
Fix CLI imports

### DIFF
--- a/src/cobra/cli/cli.py
+++ b/src/cobra/cli/cli.py
@@ -32,7 +32,6 @@ from cobra.cli.commands.verify_cmd import VerifyCommand
 from cobra.cli.i18n import _, format_traceback, setup_gettext
 from cobra.cli.plugin import descubrir_plugins
 from cobra.cli.utils import messages
-from cobra.cli.commands import *
 
 
 class ConfigConstants:


### PR DESCRIPTION
## Summary
- drop unused star import from CLI

## Testing
- `pytest src/tests/unit/test_cli.py::test_cli_interactive` *(fails: ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_6885b64ebedc8327bcb8d4ef350b9866