### PR TITLE
Handle Python subprocess failures in Jupyter kernel

### DIFF
--- a/src/jupyter_kernel/__init__.py
+++ b/src/jupyter_kernel/__init__.py
@@ -87,6 +87,10 @@ class CobraKernel(Kernel):
                     )
                     output = proc.stdout
                     error = proc.stderr
+                    if proc.returncode != 0 and not error:
+                        error = (
+                            f"Error al ejecutar código Python (código de retorno {proc.returncode})"
+                        )
                     result = None
                 else:
                     result = self.interpreter.ejecutar_ast(ast)

--- a/src/tests/unit/test_kernel_python_error.py
+++ b/src/tests/unit/test_kernel_python_error.py
@@ -1,0 +1,58 @@
+import subprocess
+import sys
+import types
+
+
+def fake_run(cmd, input=None, capture_output=True, text=True):
+    return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+
+
+def test_kernel_reports_generic_error(monkeypatch):
+    monkeypatch.setenv("COBRA_JUPYTER_PYTHON", "1")
+    outputs = []
+
+    # Crea un módulo "cli" mínimo requerido por cobra.semantico
+    cli_mod = types.ModuleType("cli")
+    utils_mod = types.ModuleType("cli.utils")
+    semver_mod = types.ModuleType("cli.utils.semver")
+    semver_mod.es_version_valida = lambda v: True
+    utils_mod.semver = semver_mod
+    cli_mod.utils = utils_mod
+    sys.modules.setdefault("cli", cli_mod)
+    sys.modules.setdefault("cli.utils", utils_mod)
+    sys.modules.setdefault("cli.utils.semver", semver_mod)
+
+    ts_mod = types.ModuleType("tree_sitter_languages")
+    ts_mod.get_parser = lambda lang: types.SimpleNamespace(parse=lambda b: types.SimpleNamespace(root_node=types.SimpleNamespace(children=[], is_named=False)))
+    sys.modules.setdefault("tree_sitter_languages", ts_mod)
+
+    from jupyter_kernel import CobraKernel
+
+    class DummyKernel(CobraKernel):
+        def __init__(self):
+            super().__init__()
+            self.iopub_socket = None
+            self.session = None
+
+        def send_response(self, stream, msg_or_type, content, **kwargs):
+            outputs.append((msg_or_type, content))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    setup_mod = types.ModuleType("pybind11.setup_helpers")
+    setup_mod.Pybind11Extension = object
+    setup_mod.build_ext = object
+    sys.modules["pybind11.setup_helpers"] = setup_mod
+    mod = types.ModuleType("pybind11")
+    mod.setup_helpers = setup_mod
+    sys.modules["pybind11"] = mod
+    sys.modules.setdefault("corelibs", types.ModuleType("corelibs"))
+
+    kernel = DummyKernel()
+    kernel.do_execute("imprimir('hola')", False)
+
+    assert any(
+        msg_type == "stream"
+        and content.get("name") == "stderr"
+        and "código de retorno" in content.get("text", "")
+        for msg_type, content in outputs
+    )


### PR DESCRIPTION
## Summary
- check the Python subprocess return code in `jupyter_kernel`
- emit a generic error message when the process fails
- test the new behavior in unit tests

## Testing
- `pytest src/tests/unit/test_kernel_python_error.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6885cc198ee8832780c68e07b1b9a3bc