### PR TITLE
Fix thread as daemon

### DIFF
--- a/src/core/interpreter.py
+++ b/src/core/interpreter.py
@@ -629,6 +629,8 @@ class InterpretadorCobra:
         def destino():
             self.ejecutar_llamada_funcion(nodo.llamada)
 
-        hilo = threading.Thread(target=destino)
+        # El hilo se marca como daemon para evitar que bloquee el cierre del
+        # intérprete si queda en ejecución al finalizar el programa.
+        hilo = threading.Thread(target=destino, daemon=True)
         hilo.start()
         return hilo

--- a/src/tests/unit/test_hilos.py
+++ b/src/tests/unit/test_hilos.py
@@ -30,6 +30,7 @@ def test_interpreter_hilo():
     interp.ejecutar_funcion(funcion)
     with patch('sys.stdout', new_callable=StringIO) as out:
         hilo = interp.ejecutar_hilo(NodoHilo(NodoLlamadaFuncion('marca', [])))
+        assert hilo.daemon
         hilo.join()
         assert out.getvalue().strip() == 'ok'
 

--- a/src/tests/unit/test_interpreter_hilo.py
+++ b/src/tests/unit/test_interpreter_hilo.py
@@ -1,0 +1,34 @@
+import sys
+import types
+from io import StringIO
+from unittest.mock import patch
+
+# Crear modulos ficticios para dependencias opcionales
+cli_mod = types.ModuleType("cli")
+utils_mod = types.ModuleType("cli.utils")
+semver_mod = types.ModuleType("cli.utils.semver")
+semver_mod.es_version_valida = lambda v: True
+utils_mod.semver = semver_mod
+cli_mod.utils = utils_mod
+sys.modules.setdefault("cli", cli_mod)
+sys.modules.setdefault("cli.utils", utils_mod)
+sys.modules.setdefault("cli.utils.semver", semver_mod)
+
+# En caso de que tree_sitter_languages no esté instalado
+if "tree_sitter_languages" not in sys.modules:
+    tsl_mod = types.ModuleType("tree_sitter_languages")
+    tsl_mod.get_parser = lambda lang: None
+    sys.modules["tree_sitter_languages"] = tsl_mod
+
+from core.ast_nodes import NodoHilo, NodoLlamadaFuncion, NodoValor, NodoFuncion
+from core.interpreter import InterpretadorCobra
+
+
+def test_hilo_es_daemon():
+    interp = InterpretadorCobra()
+    funcion = NodoFuncion('marca', [], [NodoLlamadaFuncion('imprimir', [NodoValor('ok')])])
+    interp.ejecutar_funcion(funcion)
+    with patch('sys.stdout', new_callable=StringIO):
+        hilo = interp.ejecutar_hilo(NodoHilo(NodoLlamadaFuncion('marca', [])))
+        assert hilo.daemon
+        hilo.join()


### PR DESCRIPTION
## Summary
- ensure threads launched by `InterpretadorCobra` run as daemons
- document daemon behaviour in interpreter
- verify daemon attribute in thread tests
- provide isolated test to avoid heavy dependencies

## Testing
- `pytest src/tests/unit/test_interpreter_hilo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6885d45affa0832798de109948d0895c