### PR TITLE
Create CLI alias packages

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,5 @@
+import importlib
+import sys
+
+module = importlib.import_module("cobra.cli")
+sys.modules[__name__] = module

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -1,0 +1,5 @@
+import importlib
+import sys
+
+module = importlib.import_module("cobra.cli")
+sys.modules[__name__] = module


### PR DESCRIPTION
## Summary
- add `src/cli/__init__.py` re-exporting `cobra.cli`
- add top-level `cli/__init__.py` so `import cli` also works

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'holobit_sdk')*

------
https://chatgpt.com/codex/tasks/task_e_6885d80ecf1c8327989f0987cf61a978