### PR TITLE
Handle missing submodules

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,7 @@
 """Paquete principal de Cobra."""
 
 import importlib
+import importlib.util
 import logging
 
 logger = logging.getLogger(__name__)
@@ -8,6 +9,9 @@ logger = logging.getLogger(__name__)
 _submodules = ["cli", "cobra", "core", "ia", "jupyter_kernel", "gui", "lsp"]
 
 for pkg in _submodules:
+    if importlib.util.find_spec(f".{pkg}", __name__) is None:
+        logger.warning("Subm\u00f3dulo %s no encontrado, se omite su importaci\u00f3n", pkg)
+        continue
     try:
         module = importlib.import_module(f".{pkg}", __name__)
         globals()[pkg] = module


### PR DESCRIPTION
## Summary
- prevent import errors by skipping missing submodules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ipykernel')*

------
https://chatgpt.com/codex/tasks/task_e_6885dc3eeb088327b9a518f33d363d34