### PR TITLE
Use tomllib when available

### DIFF
--- a/src/core/cobra_config.py
+++ b/src/core/cobra_config.py
@@ -1,5 +1,8 @@
 import os
-import tomli
+try:
+    import tomllib as tomli  # Python >= 3.11
+except ModuleNotFoundError:  # pragma: no cover - para entornos sin tomllib
+    import tomli
 
 COBRA_CONFIG_PATH = os.environ.get(
     "COBRA_CONFIG",

--- a/src/core/pcobra_config.py
+++ b/src/core/pcobra_config.py
@@ -1,5 +1,8 @@
 import os
-import tomli
+try:
+    import tomllib as tomli  # Python >= 3.11
+except ModuleNotFoundError:  # pragma: no cover - para entornos sin tomllib
+    import tomli
 
 PCOBRA_CONFIG_PATH = os.environ.get(
     "PCOBRA_CONFIG",


### PR DESCRIPTION
## Summary
- add fallback import to `tomllib` for config helpers
- ensure compatibility with both `tomllib` and `tomli`

## Testing
- `pytest -q` *(fails: ImportError: No module named 'core.ast_nodes.NodoAsignacion')*
- `pip install -q tomli`
- `pytest -q` *(fails: ImportError: No module named 'core.ast_nodes.NodoAsignacion')*

------
https://chatgpt.com/codex/tasks/task_e_6885ddee72a0832799a9032330802664