### PR TITLE
Update entrypoints and remove obsolete script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,8 @@ include-package-data = true
 where = ["src"]
 
 [project.scripts]
-cobra = "src.cli.cli:main"
+cobra = "cobra.cli.cli:main"
 pcobra = "src.main:main"
-cobra-init = "src.main_init:main"
 
 [project.entry-points."cobra.plugins"]
 # Se registrarán plugins externos aquí


### PR DESCRIPTION
## Summary
- simplify entrypoints
- remove unused `cobra-init` script definition

## Testing
- `pytest src/tests/unit/test_archivo.py::test_archivo -q`

------
https://chatgpt.com/codex/tasks/task_e_6885dfd3e40c8327b74f69a42e0630b7