### PR TITLE
Fix PYTHONPATH resolution in bench commands

### DIFF
--- a/src/cobra/cli/commands/bench_cmd.py
+++ b/src/cobra/cli/commands/bench_cmd.py
@@ -109,7 +109,7 @@ class BenchCommand(BaseCommand):
 
     def _run_benchmarks(self) -> list[dict[str, object]]:
         env = os.environ.copy()
-        env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+        env["PYTHONPATH"] = str(Path(__file__).resolve().parents[4])
         fd, tmp_path = tempfile.mkstemp(suffix=".toml")
         os.close(fd)
         env["PCOBRA_TOML"] = str(Path(tmp_path))

--- a/src/cobra/cli/commands/benchmarks2_cmd.py
+++ b/src/cobra/cli/commands/benchmarks2_cmd.py
@@ -102,7 +102,7 @@ class BenchmarksV2Command(BaseCommand):
     def run(self, args):
         """Ejecuta la lógica del comando."""
         env = os.environ.copy()
-        env["PYTHONPATH"] = str(Path(__file__).resolve().parents[3])
+        env["PYTHONPATH"] = str(Path(__file__).resolve().parents[4])
         fd, tmp_path = tempfile.mkstemp(suffix=".toml")
         os.close(fd)
         env["PCOBRA_TOML"] = str(Path(tmp_path))

--- a/src/cobra/cli/commands/benchmarks_cmd.py
+++ b/src/cobra/cli/commands/benchmarks_cmd.py
@@ -111,7 +111,7 @@ class BenchmarksCommand(BaseCommand):
     def run(self, args):
         """Ejecuta la lógica del comando."""
         env = os.environ.copy()
-        env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
+        env["PYTHONPATH"] = str(Path(__file__).resolve().parents[4])
         fd, tmp_path = tempfile.mkstemp(suffix=".toml")
         os.close(fd)
         env["PCOBRA_TOML"] = str(Path(tmp_path))

--- a/src/cobra/cli/commands/benchthreads_cmd.py
+++ b/src/cobra/cli/commands/benchthreads_cmd.py
@@ -131,7 +131,7 @@ class BenchThreadsCommand(BaseCommand):
     def run(self, args):
         """Ejecuta la lógica del comando."""
         env = os.environ.copy()
-        env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+        env["PYTHONPATH"] = str(Path(__file__).resolve().parents[4])
         fd, tmp_path = tempfile.mkstemp(suffix=".toml")
         os.close(fd)
         env["PCOBRA_TOML"] = str(Path(tmp_path))


### PR DESCRIPTION
## Summary
- adjust PYTHONPATH environment to repo root in benchmarking commands

## Testing
- `pytest src/tests/unit/test_bench_cmd.py src/tests/unit/test_benchthreads_cmd.py src/tests/unit/test_benchmarks2_cmd.py src/tests/unit/test_bench_transpilers_cmd.py -q` *(fails: FileNotFoundError, Timeout, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6885e3cf64788327bf52e7e92a563a83