### PR TITLE
Fix import paths to package modules

### DIFF
--- a/src/cobra/cli/cobrahub_client.py
+++ b/src/cobra/cli/cobrahub_client.py
@@ -2,8 +2,8 @@ import os
 
 import requests
 
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 COBRAHUB_URL = os.environ.get("COBRAHUB_URL", "https://cobrahub.example.com/api")
 

--- a/src/cobra/cli/commands/agix_cmd.py
+++ b/src/cobra/cli/commands/agix_cmd.py
@@ -2,9 +2,9 @@ import os
 
 from ia.analizador_agix import generar_sugerencias
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class AgixCommand(BaseCommand):

--- a/src/cobra/cli/commands/bench_cmd.py
+++ b/src/cobra/cli/commands/bench_cmd.py
@@ -19,9 +19,9 @@ import tempfile
 import time
 from pathlib import Path
 
-from src.cobra.cli.commands.base import BaseCommand
-from src.cobra.cli.i18n import _
-from src.cobra.cli.utils.messages import mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_info
 
 CODE = """
 var x = 0
@@ -119,7 +119,7 @@ class BenchCommand(BaseCommand):
             co_file = Path(tmpdir) / "program.co"
             co_file.write_text(CODE)
 
-            cobra_cmd = [sys.executable, "-m", "src.cli.cli", "ejecutar", str(co_file)]
+            cobra_cmd = [sys.executable, "-m", "cobra.cli.cli", "ejecutar", str(co_file)]
             elapsed, mem = run_and_measure(cobra_cmd, env)
             results.append(
                 {"backend": "cobra", "time": round(elapsed, 4), "memory_kb": mem}
@@ -131,7 +131,7 @@ class BenchCommand(BaseCommand):
                 transp_cmd = [
                     sys.executable,
                     "-m",
-                    "src.cli.cli",
+                    "cobra.cli.cli",
                     "compilar",
                     str(co_file),
                     "--tipo",

--- a/src/cobra/cli/commands/bench_transpilers_cmd.py
+++ b/src/cobra/cli/commands/bench_transpilers_cmd.py
@@ -5,10 +5,10 @@ from timeit import timeit
 
 from core.ast_cache import obtener_ast
 
-from src.cli.commands.base import BaseCommand
-from src.cli.commands.compile_cmd import TRANSPILERS
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.commands.compile_cmd import TRANSPILERS
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 PROGRAM_DIR = (
     Path(__file__).resolve().parents[4] / "scripts" / "benchmarks" / "programs"

--- a/src/cobra/cli/commands/benchmarks2_cmd.py
+++ b/src/cobra/cli/commands/benchmarks2_cmd.py
@@ -18,9 +18,9 @@ except ImportError:  # pragma: no cover - Windows
 else:
     psutil = None  # type: ignore
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 CODE = """
 var x = 0
@@ -114,7 +114,7 @@ class BenchmarksV2Command(BaseCommand):
             co_file.write_text(CODE)
 
             # Modo nativo Cobra
-            cmd = [sys.executable, "-m", "src.cli.cli", "ejecutar", str(co_file)]
+            cmd = [sys.executable, "-m", "cobra.cli.cli", "ejecutar", str(co_file)]
             elapsed, mem = run_and_measure(cmd, env)
             results.append(
                 {"modo": "cobra", "time": round(elapsed, 4), "memory_kb": mem}
@@ -125,7 +125,7 @@ class BenchmarksV2Command(BaseCommand):
             transp_cmd = [
                 sys.executable,
                 "-m",
-                "src.cli.cli",
+                "cobra.cli.cli",
                 "compilar",
                 str(co_file),
                 "--tipo",
@@ -151,7 +151,7 @@ class BenchmarksV2Command(BaseCommand):
             transp_cmd = [
                 sys.executable,
                 "-m",
-                "src.cli.cli",
+                "cobra.cli.cli",
                 "compilar",
                 str(co_file),
                 "--tipo",

--- a/src/cobra/cli/commands/benchmarks_cmd.py
+++ b/src/cobra/cli/commands/benchmarks_cmd.py
@@ -18,9 +18,9 @@ import tempfile
 import time
 from pathlib import Path
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 CODE = """
 var x = 0
@@ -126,7 +126,7 @@ class BenchmarksCommand(BaseCommand):
                 transp_cmd = [
                     sys.executable,
                     "-m",
-                    "src.cli.cli",
+                    "cobra.cli.cli",
                     "compilar",
                     str(co_file),
                     "--tipo",

--- a/src/cobra/cli/commands/benchthreads_cmd.py
+++ b/src/cobra/cli/commands/benchthreads_cmd.py
@@ -21,9 +21,9 @@ from cobra.parser.parser import Parser
 from core.interpreter import InterpretadorCobra
 from jupyter_kernel import CobraKernel
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 SEQUENTIAL_CODE = """
 funcion tarea(n):
@@ -112,7 +112,7 @@ class BenchThreadsCommand(BaseCommand):
         with tempfile.NamedTemporaryFile("w", suffix=".co", delete=False) as tmp:
             tmp.write(code)
             tmp.flush()
-            cmd = [sys.executable, "-m", "src.cli.cli", "ejecutar", tmp.name]
+            cmd = [sys.executable, "-m", "cobra.cli.cli", "ejecutar", tmp.name]
             subprocess.run(
                 cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
             )

--- a/src/cobra/cli/commands/cache_cmd.py
+++ b/src/cobra/cli/commands/cache_cmd.py
@@ -1,8 +1,8 @@
 from core.ast_cache import limpiar_cache
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_info
 
 
 class CacheCommand(BaseCommand):

--- a/src/cobra/cli/commands/compile_cmd.py
+++ b/src/cobra/cli/commands/compile_cmd.py
@@ -35,9 +35,9 @@ from core.semantic_validators import (
     construir_cadena,
 )
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 # Mapa que asocia el nombre de cada lenguaje con la clase de su
 # transpilador. Sirve como una fábrica sencilla: a partir de una clave

--- a/src/cobra/cli/commands/container_cmd.py
+++ b/src/cobra/cli/commands/container_cmd.py
@@ -1,9 +1,9 @@
 import os
 import subprocess
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class ContainerCommand(BaseCommand):

--- a/src/cobra/cli/commands/crear_cmd.py
+++ b/src/cobra/cli/commands/crear_cmd.py
@@ -1,8 +1,8 @@
 import os
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class CrearCommand(BaseCommand):

--- a/src/cobra/cli/commands/dependencias_cmd.py
+++ b/src/cobra/cli/commands/dependencias_cmd.py
@@ -6,9 +6,9 @@ try:
 except ModuleNotFoundError:  # pragma: no cover
     import tomli as tomllib
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class DependenciasCommand(BaseCommand):

--- a/src/cobra/cli/commands/docs_cmd.py
+++ b/src/cobra/cli/commands/docs_cmd.py
@@ -1,9 +1,9 @@
 import os
 import subprocess
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class DocsCommand(BaseCommand):

--- a/src/cobra/cli/commands/empaquetar_cmd.py
+++ b/src/cobra/cli/commands/empaquetar_cmd.py
@@ -1,9 +1,9 @@
 import os
 import subprocess
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class EmpaquetarCommand(BaseCommand):

--- a/src/cobra/cli/commands/execute_cmd.py
+++ b/src/cobra/cli/commands/execute_cmd.py
@@ -12,9 +12,9 @@ from core.sandbox import (
 )
 from core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class ExecuteCommand(BaseCommand):

--- a/src/cobra/cli/commands/flet_cmd.py
+++ b/src/cobra/cli/commands/flet_cmd.py
@@ -1,6 +1,6 @@
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error
 
 
 class FletCommand(BaseCommand):

--- a/src/cobra/cli/commands/init_cmd.py
+++ b/src/cobra/cli/commands/init_cmd.py
@@ -1,8 +1,8 @@
 import os
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_info
 
 
 class InitCommand(BaseCommand):

--- a/src/cobra/cli/commands/interactive_cmd.py
+++ b/src/cobra/cli/commands/interactive_cmd.py
@@ -12,9 +12,9 @@ from core.sandbox import (
 )
 from core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class InteractiveCommand(BaseCommand):

--- a/src/cobra/cli/commands/jupyter_cmd.py
+++ b/src/cobra/cli/commands/jupyter_cmd.py
@@ -1,9 +1,9 @@
 import subprocess
 import sys
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error
 
 
 class JupyterCommand(BaseCommand):

--- a/src/cobra/cli/commands/modules_cmd.py
+++ b/src/cobra/cli/commands/modules_cmd.py
@@ -5,11 +5,11 @@ import yaml
 from cobra.semantico import mod_validator
 from cobra.transpilers.module_map import MODULE_MAP_PATH
 
-from src.cli.cobrahub_client import descargar_modulo, publicar_modulo
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
-from src.cli.utils.semver import es_nueva_version, es_version_valida
+from cobra.cli.cobrahub_client import descargar_modulo, publicar_modulo
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.utils.semver import es_nueva_version, es_version_valida
 
 MODULES_PATH = os.path.join(os.path.dirname(__file__), "..", "modules")
 os.makedirs(MODULES_PATH, exist_ok=True)

--- a/src/cobra/cli/commands/package_cmd.py
+++ b/src/cobra/cli/commands/package_cmd.py
@@ -1,10 +1,10 @@
 import os
 import zipfile
 
-from src.cli.commands import modules_cmd
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands import modules_cmd
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class PaqueteCommand(BaseCommand):

--- a/src/cobra/cli/commands/plugins_cmd.py
+++ b/src/cobra/cli/commands/plugins_cmd.py
@@ -1,7 +1,7 @@
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.plugin_registry import obtener_registro_detallado
-from src.cli.utils.messages import mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.plugin_registry import obtener_registro_detallado
+from cobra.cli.utils.messages import mostrar_info
 
 
 class PluginsCommand(BaseCommand):

--- a/src/cobra/cli/commands/profile_cmd.py
+++ b/src/cobra/cli/commands/profile_cmd.py
@@ -17,10 +17,10 @@ from core.interpreter import InterpretadorCobra
 from core.sandbox import validar_dependencias
 from core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 
-from src.cli.commands.base import BaseCommand
-from src.cli.commands.execute_cmd import ExecuteCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.commands.execute_cmd import ExecuteCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class ProfileCommand(BaseCommand):

--- a/src/cobra/cli/commands/qualia_cmd.py
+++ b/src/cobra/cli/commands/qualia_cmd.py
@@ -1,9 +1,9 @@
 import json
 import os
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 from core import qualia_bridge
 
 

--- a/src/cobra/cli/commands/transpilar_inverso_cmd.py
+++ b/src/cobra/cli/commands/transpilar_inverso_cmd.py
@@ -25,10 +25,10 @@ from cobra.transpilers.reverse import (
     ReverseFromVisualBasic,
     ReverseFromWasm,
 )
-from src.cli.commands.base import BaseCommand
-from src.cli.commands.compile_cmd import TRANSPILERS, LANG_CHOICES
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.commands.compile_cmd import TRANSPILERS, LANG_CHOICES
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 REVERSE_TRANSPILERS = {
     "python": ReverseFromPython,

--- a/src/cobra/cli/commands/verify_cmd.py
+++ b/src/cobra/cli/commands/verify_cmd.py
@@ -9,9 +9,9 @@ from cobra.parser.parser import Parser
 from core.interpreter import InterpretadorCobra
 from core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
 
-from src.cli.commands.base import BaseCommand
-from src.cli.i18n import _
-from src.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.i18n import _
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 
 class VerifyCommand(BaseCommand):

--- a/src/cobra/cli/plugin.py
+++ b/src/cobra/cli/plugin.py
@@ -10,8 +10,8 @@ from abc import ABC, abstractmethod
 from importlib import import_module
 from importlib.metadata import entry_points
 
-from src.cli.commands.base import BaseCommand
-from src.cli.plugin_registry import (
+from cobra.cli.commands.base import BaseCommand
+from cobra.cli.plugin_registry import (
     obtener_registro,
     obtener_registro_detallado,
     registrar_plugin,

--- a/src/cobra/cli/plugin_interface.py
+++ b/src/cobra/cli/plugin_interface.py
@@ -1,9 +1,9 @@
 """M\xf3dulo interno deprecado.
 
 Este archivo se mantiene por compatibilidad pero las clases y funciones
-relacionadas con plugins se encuentran ahora en ``src.cli.plugin``.
+relacionadas con plugins se encuentran ahora en ``cobra.cli.plugin``.
 """
 
-from src.cli.plugin import PluginInterface
+from cobra.cli.plugin import PluginInterface
 
 __all__ = ["PluginInterface"]

--- a/src/cobra/cli/plugin_loader.py
+++ b/src/cobra/cli/plugin_loader.py
@@ -1,10 +1,10 @@
 """M\xf3dulo interno deprecado.
 
 Las utilidades de carga y las clases para plugins ahora residen en
-``src.cli.plugin``.
+``cobra.cli.plugin``.
 """
 
-from src.cli.plugin import PluginCommand, cargar_plugin_seguro, descubrir_plugins
+from cobra.cli.plugin import PluginCommand, cargar_plugin_seguro, descubrir_plugins
 
 __all__ = [
     "PluginCommand",

--- a/src/cobra/cli/utils/messages.py
+++ b/src/cobra/cli/utils/messages.py
@@ -1,6 +1,6 @@
 import logging
 
-from src.cli.i18n import _
+from cobra.cli.i18n import _
 
 RED = "\033[91m"
 GREEN = "\033[92m"

--- a/src/cobra/parser/parser.py
+++ b/src/cobra/parser/parser.py
@@ -1149,7 +1149,7 @@ class ClassicParser:
 # ``LarkParser`` en lugar del parser clásico.
 
 if os.getenv("COBRA_PARSER") == "lark":
-    from src.cobra.parser.lark_parser import LarkParser
+    from cobra.parser.lark_parser import LarkParser
 
     Parser = LarkParser
 else:

--- a/src/cobra/semantico/__init__.py
+++ b/src/cobra/semantico/__init__.py
@@ -1,7 +1,7 @@
 """Utilidades para el análisis semántico y la validación de módulos Cobra."""
 
-from src.cobra.semantico.analizador import AnalizadorSemantico
-from src.cobra.semantico.mod_validator import validar_mod
-from src.cobra.semantico.tabla import Ambito, Simbolo
+from cobra.semantico.analizador import AnalizadorSemantico
+from cobra.semantico.mod_validator import validar_mod
+from cobra.semantico.tabla import Ambito, Simbolo
 
 __all__ = ["Simbolo", "Ambito", "AnalizadorSemantico", "validar_mod"]

--- a/src/cobra/semantico/analizador.py
+++ b/src/cobra/semantico/analizador.py
@@ -11,7 +11,7 @@ from core.ast_nodes import (
 )
 from core.visitor import NodeVisitor
 
-from src.cobra.semantico.tabla import Ambito
+from cobra.semantico.tabla import Ambito
 
 
 class AnalizadorSemantico(NodeVisitor):

--- a/src/cobra/transpilers/__init__.py
+++ b/src/cobra/transpilers/__init__.py
@@ -1,6 +1,6 @@
 """Facilita el acceso a los distintos transpiladores de Cobra."""
 
-from src.cobra.transpilers.base import BaseTranspiler
-from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.reverse.base import BaseReverseTranspiler
 
 __all__ = ["BaseTranspiler", "BaseReverseTranspiler"]

--- a/src/cobra/transpilers/import_helper.py
+++ b/src/cobra/transpilers/import_helper.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List, Tuple, Union
 
-from src.cobra.transpilers.module_map import get_mapped_path
+from cobra.transpilers.module_map import get_mapped_path
 
 # Mapeo de importaciones estándar por lenguaje
 STANDARD_IMPORTS = {

--- a/src/cobra/transpilers/reverse/__init__.py
+++ b/src/cobra/transpilers/reverse/__init__.py
@@ -1,29 +1,29 @@
 """Componentes para convertir código de otros lenguajes a Cobra."""
 
-from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
-from src.cobra.transpilers.reverse.from_python import ReverseFromPython
-from src.cobra.transpilers.reverse.from_c import ReverseFromC
-from src.cobra.transpilers.reverse.from_cpp import ReverseFromCPP
-from src.cobra.transpilers.reverse.from_js import ReverseFromJS
-from src.cobra.transpilers.reverse.from_java import ReverseFromJava
-from src.cobra.transpilers.reverse.from_go import ReverseFromGo
-from src.cobra.transpilers.reverse.from_julia import ReverseFromJulia
-from src.cobra.transpilers.reverse.from_php import ReverseFromPHP
-from src.cobra.transpilers.reverse.from_perl import ReverseFromPerl
-from src.cobra.transpilers.reverse.from_r import ReverseFromR
-from src.cobra.transpilers.reverse.from_ruby import ReverseFromRuby
-from src.cobra.transpilers.reverse.from_rust import ReverseFromRust
-from src.cobra.transpilers.reverse.from_swift import ReverseFromSwift
-from src.cobra.transpilers.reverse.from_kotlin import ReverseFromKotlin
-from src.cobra.transpilers.reverse.from_fortran import ReverseFromFortran
-from src.cobra.transpilers.reverse.from_asm import ReverseFromASM
-from src.cobra.transpilers.reverse.from_cobol import ReverseFromCOBOL
-from src.cobra.transpilers.reverse.from_latex import ReverseFromLatex
-from src.cobra.transpilers.reverse.from_matlab import ReverseFromMatlab
-from src.cobra.transpilers.reverse.from_mojo import ReverseFromMojo
-from src.cobra.transpilers.reverse.from_pascal import ReverseFromPascal
-from src.cobra.transpilers.reverse.from_visualbasic import ReverseFromVisualBasic
-from src.cobra.transpilers.reverse.from_wasm import ReverseFromWasm
+from cobra.transpilers.reverse.base import BaseReverseTranspiler
+from cobra.transpilers.reverse.from_python import ReverseFromPython
+from cobra.transpilers.reverse.from_c import ReverseFromC
+from cobra.transpilers.reverse.from_cpp import ReverseFromCPP
+from cobra.transpilers.reverse.from_js import ReverseFromJS
+from cobra.transpilers.reverse.from_java import ReverseFromJava
+from cobra.transpilers.reverse.from_go import ReverseFromGo
+from cobra.transpilers.reverse.from_julia import ReverseFromJulia
+from cobra.transpilers.reverse.from_php import ReverseFromPHP
+from cobra.transpilers.reverse.from_perl import ReverseFromPerl
+from cobra.transpilers.reverse.from_r import ReverseFromR
+from cobra.transpilers.reverse.from_ruby import ReverseFromRuby
+from cobra.transpilers.reverse.from_rust import ReverseFromRust
+from cobra.transpilers.reverse.from_swift import ReverseFromSwift
+from cobra.transpilers.reverse.from_kotlin import ReverseFromKotlin
+from cobra.transpilers.reverse.from_fortran import ReverseFromFortran
+from cobra.transpilers.reverse.from_asm import ReverseFromASM
+from cobra.transpilers.reverse.from_cobol import ReverseFromCOBOL
+from cobra.transpilers.reverse.from_latex import ReverseFromLatex
+from cobra.transpilers.reverse.from_matlab import ReverseFromMatlab
+from cobra.transpilers.reverse.from_mojo import ReverseFromMojo
+from cobra.transpilers.reverse.from_pascal import ReverseFromPascal
+from cobra.transpilers.reverse.from_visualbasic import ReverseFromVisualBasic
+from cobra.transpilers.reverse.from_wasm import ReverseFromWasm
 
 __all__ = [
     "BaseReverseTranspiler",

--- a/src/cobra/transpilers/reverse/from_asm.py
+++ b/src/cobra/transpilers/reverse/from_asm.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Transpilador inverso desde ensamblador a Cobra (no soportado)."""
 
-from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+from cobra.transpilers.reverse.base import BaseReverseTranspiler
 
 
 class ReverseFromASM(BaseReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_cobol.py
+++ b/src/cobra/transpilers/reverse/from_cobol.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Transpilador inverso desde COBOL a Cobra (no soportado)."""
 
-from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+from cobra.transpilers.reverse.base import BaseReverseTranspiler
 
 
 class ReverseFromCOBOL(BaseReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_latex.py
+++ b/src/cobra/transpilers/reverse/from_latex.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Transpilador inverso desde LaTeX a Cobra (no soportado)."""
 
-from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+from cobra.transpilers.reverse.base import BaseReverseTranspiler
 
 
 class ReverseFromLatex(BaseReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_matlab.py
+++ b/src/cobra/transpilers/reverse/from_matlab.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Transpilador inverso desde Matlab a Cobra (no soportado)."""
 
-from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+from cobra.transpilers.reverse.base import BaseReverseTranspiler
 
 
 class ReverseFromMatlab(BaseReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_mojo.py
+++ b/src/cobra/transpilers/reverse/from_mojo.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Transpilador inverso desde Mojo a Cobra (no soportado)."""
 
-from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+from cobra.transpilers.reverse.base import BaseReverseTranspiler
 
 
 class ReverseFromMojo(BaseReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_pascal.py
+++ b/src/cobra/transpilers/reverse/from_pascal.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Transpilador inverso desde Pascal a Cobra (no soportado)."""
 
-from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+from cobra.transpilers.reverse.base import BaseReverseTranspiler
 
 
 class ReverseFromPascal(BaseReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_python.py
+++ b/src/cobra/transpilers/reverse/from_python.py
@@ -23,7 +23,7 @@ from core.ast_nodes import (
     NodoContinuar,
 )
 from cobra.lexico.lexer import Token, TipoToken
-from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+from cobra.transpilers.reverse.base import BaseReverseTranspiler
 
 
 _OP_BINARIA = {

--- a/src/cobra/transpilers/reverse/from_visualbasic.py
+++ b/src/cobra/transpilers/reverse/from_visualbasic.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Transpilador inverso desde VisualBasic a Cobra (no soportado)."""
 
-from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+from cobra.transpilers.reverse.base import BaseReverseTranspiler
 
 
 class ReverseFromVisualBasic(BaseReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_wasm.py
+++ b/src/cobra/transpilers/reverse/from_wasm.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Transpilador inverso desde WebAssembly a Cobra (no soportado)."""
 
-from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+from cobra.transpilers.reverse.base import BaseReverseTranspiler
 
 
 class ReverseFromWasm(BaseReverseTranspiler):

--- a/src/cobra/transpilers/reverse/tree_sitter_base.py
+++ b/src/cobra/transpilers/reverse/tree_sitter_base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from tree_sitter_languages import get_parser
 
-from src.cobra.transpilers.reverse.base import BaseReverseTranspiler
+from cobra.transpilers.reverse.base import BaseReverseTranspiler
 from core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,

--- a/src/cobra/transpilers/transpiler/asm_nodes/asignacion.py
+++ b/src/cobra/transpilers/transpiler/asm_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import datos_asignacion
+from cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, _ = datos_asignacion(self, nodo)

--- a/src/cobra/transpilers/transpiler/asm_nodes/bucle_mientras.py
+++ b/src/cobra/transpilers/transpiler/asm_nodes/bucle_mientras.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import procesar_bloque
+from cobra.transpilers.semantica import procesar_bloque
 
 def visit_bucle_mientras(self, nodo):
     condicion = self.obtener_valor(nodo.condicion)

--- a/src/cobra/transpilers/transpiler/asm_nodes/for_.py
+++ b/src/cobra/transpilers/transpiler/asm_nodes/for_.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import procesar_bloque
+from cobra.transpilers.semantica import procesar_bloque
 
 def visit_for(self, nodo):
     iterable = self.obtener_valor(nodo.iterable)

--- a/src/cobra/transpilers/transpiler/asm_nodes/para.py
+++ b/src/cobra/transpilers/transpiler/asm_nodes/para.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import procesar_bloque
+from cobra.transpilers.semantica import procesar_bloque
 
 def visit_para(self, nodo):
     iterable = self.obtener_valor(nodo.iterable)

--- a/src/cobra/transpilers/transpiler/cobol_nodes/asignacion.py
+++ b/src/cobra/transpilers/transpiler/cobol_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import datos_asignacion
+from cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, _ = datos_asignacion(self, nodo)

--- a/src/cobra/transpilers/transpiler/cpp_nodes/asignacion.py
+++ b/src/cobra/transpilers/transpiler/cpp_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import datos_asignacion
+from cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, es_attr = datos_asignacion(self, nodo)

--- a/src/cobra/transpilers/transpiler/cpp_nodes/bucle_mientras.py
+++ b/src/cobra/transpilers/transpiler/cpp_nodes/bucle_mientras.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import procesar_bloque
+from cobra.transpilers.semantica import procesar_bloque
 
 def visit_bucle_mientras(self, nodo):
     cuerpo = nodo.cuerpo

--- a/src/cobra/transpilers/transpiler/fortran_nodes/asignacion.py
+++ b/src/cobra/transpilers/transpiler/fortran_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import datos_asignacion
+from cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, _ = datos_asignacion(self, nodo)

--- a/src/cobra/transpilers/transpiler/js_nodes/asignacion.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import datos_asignacion
+from cobra.transpilers.semantica import datos_asignacion
 
 
 def visit_asignacion(self, nodo):

--- a/src/cobra/transpilers/transpiler/js_nodes/bucle_mientras.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/bucle_mientras.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import procesar_bloque
+from cobra.transpilers.semantica import procesar_bloque
 
 def visit_bucle_mientras(self, nodo):
     """Transpila un bucle 'while' en JavaScript, permitiendo anidación."""

--- a/src/cobra/transpilers/transpiler/js_nodes/for_.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/for_.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import procesar_bloque
+from cobra.transpilers.semantica import procesar_bloque
 
 def visit_for(self, nodo):
     """Transpila un bucle 'for...of' en JavaScript, permitiendo anidación."""

--- a/src/cobra/transpilers/transpiler/js_nodes/importar.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/importar.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.module_map import get_mapped_path
+from cobra.transpilers.module_map import get_mapped_path
 
 def visit_import(self, nodo):
     """Genera una importación ES module."""

--- a/src/cobra/transpilers/transpiler/js_nodes/para.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/para.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import procesar_bloque
+from cobra.transpilers.semantica import procesar_bloque
 
 def visit_para(self, nodo):
     cuerpo = nodo.cuerpo

--- a/src/cobra/transpilers/transpiler/latex_nodes/asignacion.py
+++ b/src/cobra/transpilers/transpiler/latex_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import datos_asignacion
+from cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, _ = datos_asignacion(self, nodo)

--- a/src/cobra/transpilers/transpiler/matlab_nodes/asignacion.py
+++ b/src/cobra/transpilers/transpiler/matlab_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import datos_asignacion
+from cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, _ = datos_asignacion(self, nodo)

--- a/src/cobra/transpilers/transpiler/pascal_nodes/asignacion.py
+++ b/src/cobra/transpilers/transpiler/pascal_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import datos_asignacion
+from cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, _ = datos_asignacion(self, nodo)

--- a/src/cobra/transpilers/transpiler/python_nodes/asignacion.py
+++ b/src/cobra/transpilers/transpiler/python_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import datos_asignacion
+from cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, _ = datos_asignacion(self, nodo)

--- a/src/cobra/transpilers/transpiler/python_nodes/bucle_mientras.py
+++ b/src/cobra/transpilers/transpiler/python_nodes/bucle_mientras.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import procesar_bloque
+from cobra.transpilers.semantica import procesar_bloque
 
 def visit_bucle_mientras(self, nodo):
     condicion = self.obtener_valor(nodo.condicion)

--- a/src/cobra/transpilers/transpiler/python_nodes/for_.py
+++ b/src/cobra/transpilers/transpiler/python_nodes/for_.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import procesar_bloque
+from cobra.transpilers.semantica import procesar_bloque
 
 def visit_for(self, nodo):
     iterable = self.obtener_valor(nodo.iterable)

--- a/src/cobra/transpilers/transpiler/python_nodes/importar.py
+++ b/src/cobra/transpilers/transpiler/python_nodes/importar.py
@@ -1,6 +1,6 @@
 from cobra.lexico.lexer import Lexer
 from cobra.parser.parser import Parser
-from src.cobra.transpilers.import_helper import load_mapped_module
+from cobra.transpilers.import_helper import load_mapped_module
 
 
 def visit_import(self, nodo):

--- a/src/cobra/transpilers/transpiler/python_nodes/para.py
+++ b/src/cobra/transpilers/transpiler/python_nodes/para.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import procesar_bloque
+from cobra.transpilers.semantica import procesar_bloque
 
 def visit_para(self, nodo):
     iterable = self.obtener_valor(nodo.iterable)

--- a/src/cobra/transpilers/transpiler/rust_nodes/asignacion.py
+++ b/src/cobra/transpilers/transpiler/rust_nodes/asignacion.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import datos_asignacion
+from cobra.transpilers.semantica import datos_asignacion
 
 def visit_asignacion(self, nodo):
     nombre, valor, es_attr = datos_asignacion(self, nodo)

--- a/src/cobra/transpilers/transpiler/rust_nodes/bucle_mientras.py
+++ b/src/cobra/transpilers/transpiler/rust_nodes/bucle_mientras.py
@@ -1,4 +1,4 @@
-from src.cobra.transpilers.semantica import procesar_bloque
+from cobra.transpilers.semantica import procesar_bloque
 
 def visit_bucle_mientras(self, nodo):
     cuerpo = nodo.cuerpo

--- a/src/cobra/transpilers/transpiler/to_asm.py
+++ b/src/cobra/transpilers/transpiler/to_asm.py
@@ -31,43 +31,43 @@ from core.ast_nodes import (
 from cobra.lexico.lexer import TipoToken, Lexer
 from cobra.parser.parser import Parser
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from src.cobra.transpilers.transpiler.asm_nodes.asignacion import visit_asignacion as _visit_asignacion
-from src.cobra.transpilers.transpiler.asm_nodes.condicional import visit_condicional as _visit_condicional
-from src.cobra.transpilers.transpiler.asm_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
-from src.cobra.transpilers.transpiler.asm_nodes.funcion import visit_funcion as _visit_funcion
-from src.cobra.transpilers.transpiler.asm_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
-from src.cobra.transpilers.transpiler.asm_nodes.llamada_metodo import visit_llamada_metodo as _visit_llamada_metodo
-from src.cobra.transpilers.transpiler.asm_nodes.hilo import visit_hilo as _visit_hilo
-from src.cobra.transpilers.transpiler.asm_nodes.imprimir import visit_imprimir as _visit_imprimir
-from src.cobra.transpilers.transpiler.asm_nodes.retorno import visit_retorno as _visit_retorno
-from src.cobra.transpilers.transpiler.asm_nodes.holobit import visit_holobit as _visit_holobit
-from src.cobra.transpilers.transpiler.asm_nodes.for_ import visit_for as _visit_for
-from src.cobra.transpilers.transpiler.asm_nodes.para import visit_para as _visit_para
-from src.cobra.transpilers.transpiler.asm_nodes.lista import visit_lista as _visit_lista
-from src.cobra.transpilers.transpiler.asm_nodes.diccionario import visit_diccionario as _visit_diccionario
-from src.cobra.transpilers.transpiler.asm_nodes.clase import visit_clase as _visit_clase
-from src.cobra.transpilers.transpiler.asm_nodes.metodo import visit_metodo as _visit_metodo
-from src.cobra.transpilers.transpiler.asm_nodes.try_catch import visit_try_catch as _visit_try_catch
-from src.cobra.transpilers.transpiler.asm_nodes.throw import visit_throw as _visit_throw
-from src.cobra.transpilers.transpiler.asm_nodes.importar import visit_import as _visit_import
-from src.cobra.transpilers.transpiler.asm_nodes.instancia import visit_instancia as _visit_instancia
-from src.cobra.transpilers.transpiler.asm_nodes.atributo import visit_atributo as _visit_atributo
-from src.cobra.transpilers.transpiler.asm_nodes.operacion_binaria import (
+from cobra.transpilers.transpiler.asm_nodes.asignacion import visit_asignacion as _visit_asignacion
+from cobra.transpilers.transpiler.asm_nodes.condicional import visit_condicional as _visit_condicional
+from cobra.transpilers.transpiler.asm_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
+from cobra.transpilers.transpiler.asm_nodes.funcion import visit_funcion as _visit_funcion
+from cobra.transpilers.transpiler.asm_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from cobra.transpilers.transpiler.asm_nodes.llamada_metodo import visit_llamada_metodo as _visit_llamada_metodo
+from cobra.transpilers.transpiler.asm_nodes.hilo import visit_hilo as _visit_hilo
+from cobra.transpilers.transpiler.asm_nodes.imprimir import visit_imprimir as _visit_imprimir
+from cobra.transpilers.transpiler.asm_nodes.retorno import visit_retorno as _visit_retorno
+from cobra.transpilers.transpiler.asm_nodes.holobit import visit_holobit as _visit_holobit
+from cobra.transpilers.transpiler.asm_nodes.for_ import visit_for as _visit_for
+from cobra.transpilers.transpiler.asm_nodes.para import visit_para as _visit_para
+from cobra.transpilers.transpiler.asm_nodes.lista import visit_lista as _visit_lista
+from cobra.transpilers.transpiler.asm_nodes.diccionario import visit_diccionario as _visit_diccionario
+from cobra.transpilers.transpiler.asm_nodes.clase import visit_clase as _visit_clase
+from cobra.transpilers.transpiler.asm_nodes.metodo import visit_metodo as _visit_metodo
+from cobra.transpilers.transpiler.asm_nodes.try_catch import visit_try_catch as _visit_try_catch
+from cobra.transpilers.transpiler.asm_nodes.throw import visit_throw as _visit_throw
+from cobra.transpilers.transpiler.asm_nodes.importar import visit_import as _visit_import
+from cobra.transpilers.transpiler.asm_nodes.instancia import visit_instancia as _visit_instancia
+from cobra.transpilers.transpiler.asm_nodes.atributo import visit_atributo as _visit_atributo
+from cobra.transpilers.transpiler.asm_nodes.operacion_binaria import (
     visit_operacion_binaria as _visit_operacion_binaria,
 )
-from src.cobra.transpilers.transpiler.asm_nodes.operacion_unaria import (
+from cobra.transpilers.transpiler.asm_nodes.operacion_unaria import (
     visit_operacion_unaria as _visit_operacion_unaria,
 )
-from src.cobra.transpilers.transpiler.asm_nodes.valor import visit_valor as _visit_valor
-from src.cobra.transpilers.transpiler.asm_nodes.identificador import visit_identificador as _visit_identificador
-from src.cobra.transpilers.transpiler.asm_nodes.usar import visit_usar as _visit_usar
-from src.cobra.transpilers.transpiler.asm_nodes.romper import visit_romper as _visit_romper
-from src.cobra.transpilers.transpiler.asm_nodes.continuar import visit_continuar as _visit_continuar
-from src.cobra.transpilers.transpiler.asm_nodes.pasar import visit_pasar as _visit_pasar
+from cobra.transpilers.transpiler.asm_nodes.valor import visit_valor as _visit_valor
+from cobra.transpilers.transpiler.asm_nodes.identificador import visit_identificador as _visit_identificador
+from cobra.transpilers.transpiler.asm_nodes.usar import visit_usar as _visit_usar
+from cobra.transpilers.transpiler.asm_nodes.romper import visit_romper as _visit_romper
+from cobra.transpilers.transpiler.asm_nodes.continuar import visit_continuar as _visit_continuar
+from cobra.transpilers.transpiler.asm_nodes.pasar import visit_pasar as _visit_pasar
 
 
 class TranspiladorASM(BaseTranspiler):

--- a/src/cobra/transpilers/transpiler/to_c.py
+++ b/src/cobra/transpilers/transpiler/to_c.py
@@ -12,7 +12,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_cobol.py
+++ b/src/cobra/transpilers/transpiler/to_cobol.py
@@ -13,14 +13,14 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from src.cobra.transpilers.transpiler.cobol_nodes.asignacion import visit_asignacion as _visit_asignacion
-from src.cobra.transpilers.transpiler.cobol_nodes.funcion import visit_funcion as _visit_funcion
-from src.cobra.transpilers.transpiler.cobol_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
-from src.cobra.transpilers.transpiler.cobol_nodes.imprimir import visit_imprimir as _visit_imprimir
+from cobra.transpilers.transpiler.cobol_nodes.asignacion import visit_asignacion as _visit_asignacion
+from cobra.transpilers.transpiler.cobol_nodes.funcion import visit_funcion as _visit_funcion
+from cobra.transpilers.transpiler.cobol_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from cobra.transpilers.transpiler.cobol_nodes.imprimir import visit_imprimir as _visit_imprimir
 
 
 cobol_nodes = {

--- a/src/cobra/transpilers/transpiler/to_cpp.py
+++ b/src/cobra/transpilers/transpiler/to_cpp.py
@@ -19,23 +19,23 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from src.cobra.transpilers.transpiler.cpp_nodes.asignacion import visit_asignacion as _visit_asignacion
-from src.cobra.transpilers.transpiler.cpp_nodes.condicional import visit_condicional as _visit_condicional
-from src.cobra.transpilers.transpiler.cpp_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
-from src.cobra.transpilers.transpiler.cpp_nodes.funcion import visit_funcion as _visit_funcion
-from src.cobra.transpilers.transpiler.cpp_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
-from src.cobra.transpilers.transpiler.cpp_nodes.holobit import visit_holobit as _visit_holobit
-from src.cobra.transpilers.transpiler.cpp_nodes.clase import visit_clase as _visit_clase
-from src.cobra.transpilers.transpiler.cpp_nodes.metodo import visit_metodo as _visit_metodo
-from src.cobra.transpilers.transpiler.cpp_nodes.yield_ import visit_yield as _visit_yield
-from src.cobra.transpilers.transpiler.cpp_nodes.romper import visit_romper as _visit_romper
-from src.cobra.transpilers.transpiler.cpp_nodes.continuar import visit_continuar as _visit_continuar
-from src.cobra.transpilers.transpiler.cpp_nodes.pasar import visit_pasar as _visit_pasar
-from src.cobra.transpilers.transpiler.cpp_nodes.switch import visit_switch as _visit_switch
+from cobra.transpilers.transpiler.cpp_nodes.asignacion import visit_asignacion as _visit_asignacion
+from cobra.transpilers.transpiler.cpp_nodes.condicional import visit_condicional as _visit_condicional
+from cobra.transpilers.transpiler.cpp_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
+from cobra.transpilers.transpiler.cpp_nodes.funcion import visit_funcion as _visit_funcion
+from cobra.transpilers.transpiler.cpp_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from cobra.transpilers.transpiler.cpp_nodes.holobit import visit_holobit as _visit_holobit
+from cobra.transpilers.transpiler.cpp_nodes.clase import visit_clase as _visit_clase
+from cobra.transpilers.transpiler.cpp_nodes.metodo import visit_metodo as _visit_metodo
+from cobra.transpilers.transpiler.cpp_nodes.yield_ import visit_yield as _visit_yield
+from cobra.transpilers.transpiler.cpp_nodes.romper import visit_romper as _visit_romper
+from cobra.transpilers.transpiler.cpp_nodes.continuar import visit_continuar as _visit_continuar
+from cobra.transpilers.transpiler.cpp_nodes.pasar import visit_pasar as _visit_pasar
+from cobra.transpilers.transpiler.cpp_nodes.switch import visit_switch as _visit_switch
 
 
 def visit_assert(self, nodo):

--- a/src/cobra/transpilers/transpiler/to_fortran.py
+++ b/src/cobra/transpilers/transpiler/to_fortran.py
@@ -13,16 +13,16 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from src.cobra.transpilers.transpiler.fortran_nodes.asignacion import visit_asignacion as _visit_asignacion
-from src.cobra.transpilers.transpiler.fortran_nodes.funcion import visit_funcion as _visit_funcion
-from src.cobra.transpilers.transpiler.fortran_nodes.llamada_funcion import (
+from cobra.transpilers.transpiler.fortran_nodes.asignacion import visit_asignacion as _visit_asignacion
+from cobra.transpilers.transpiler.fortran_nodes.funcion import visit_funcion as _visit_funcion
+from cobra.transpilers.transpiler.fortran_nodes.llamada_funcion import (
     visit_llamada_funcion as _visit_llamada_funcion,
 )
-from src.cobra.transpilers.transpiler.fortran_nodes.imprimir import visit_imprimir as _visit_imprimir
+from cobra.transpilers.transpiler.fortran_nodes.imprimir import visit_imprimir as _visit_imprimir
 
 fortran_nodes = {
     "asignacion": _visit_asignacion,

--- a/src/cobra/transpilers/transpiler/to_go.py
+++ b/src/cobra/transpilers/transpiler/to_go.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_java.py
+++ b/src/cobra/transpilers/transpiler/to_java.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_js.py
+++ b/src/cobra/transpilers/transpiler/to_js.py
@@ -23,48 +23,48 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
-from src.cobra.transpilers.import_helper import get_standard_imports
-from src.cobra.transpilers.module_map import get_mapped_path
+from cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.module_map import get_mapped_path
 
-from src.cobra.transpilers.transpiler.js_nodes.asignacion import visit_asignacion as _visit_asignacion
-from src.cobra.transpilers.transpiler.js_nodes.condicional import visit_condicional as _visit_condicional
-from src.cobra.transpilers.transpiler.js_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
-from src.cobra.transpilers.transpiler.js_nodes.funcion import visit_funcion as _visit_funcion
-from src.cobra.transpilers.transpiler.js_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
-from src.cobra.transpilers.transpiler.js_nodes.hilo import visit_hilo as _visit_hilo
-from src.cobra.transpilers.transpiler.js_nodes.llamada_metodo import visit_llamada_metodo as _visit_llamada_metodo
-from src.cobra.transpilers.transpiler.js_nodes.imprimir import visit_imprimir as _visit_imprimir
-from src.cobra.transpilers.transpiler.js_nodes.retorno import visit_retorno as _visit_retorno
-from src.cobra.transpilers.transpiler.js_nodes.holobit import visit_holobit as _visit_holobit
-from src.cobra.transpilers.transpiler.js_nodes.for_ import visit_for as _visit_for
-from src.cobra.transpilers.transpiler.js_nodes.lista import visit_lista as _visit_lista
-from src.cobra.transpilers.transpiler.js_nodes.diccionario import visit_diccionario as _visit_diccionario
-from src.cobra.transpilers.transpiler.js_nodes.elemento import visit_elemento as _visit_elemento
-from src.cobra.transpilers.transpiler.js_nodes.clase import visit_clase as _visit_clase
-from src.cobra.transpilers.transpiler.js_nodes.metodo import visit_metodo as _visit_metodo
-from src.cobra.transpilers.transpiler.js_nodes.try_catch import visit_try_catch as _visit_try_catch
-from src.cobra.transpilers.transpiler.js_nodes.throw import visit_throw as _visit_throw
-from src.cobra.transpilers.transpiler.js_nodes.importar import visit_import as _visit_import
-from src.cobra.transpilers.transpiler.js_nodes.instancia import visit_instancia as _visit_instancia
-from src.cobra.transpilers.transpiler.js_nodes.atributo import visit_atributo as _visit_atributo
-from src.cobra.transpilers.transpiler.js_nodes.operacion_binaria import (
+from cobra.transpilers.transpiler.js_nodes.asignacion import visit_asignacion as _visit_asignacion
+from cobra.transpilers.transpiler.js_nodes.condicional import visit_condicional as _visit_condicional
+from cobra.transpilers.transpiler.js_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
+from cobra.transpilers.transpiler.js_nodes.funcion import visit_funcion as _visit_funcion
+from cobra.transpilers.transpiler.js_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from cobra.transpilers.transpiler.js_nodes.hilo import visit_hilo as _visit_hilo
+from cobra.transpilers.transpiler.js_nodes.llamada_metodo import visit_llamada_metodo as _visit_llamada_metodo
+from cobra.transpilers.transpiler.js_nodes.imprimir import visit_imprimir as _visit_imprimir
+from cobra.transpilers.transpiler.js_nodes.retorno import visit_retorno as _visit_retorno
+from cobra.transpilers.transpiler.js_nodes.holobit import visit_holobit as _visit_holobit
+from cobra.transpilers.transpiler.js_nodes.for_ import visit_for as _visit_for
+from cobra.transpilers.transpiler.js_nodes.lista import visit_lista as _visit_lista
+from cobra.transpilers.transpiler.js_nodes.diccionario import visit_diccionario as _visit_diccionario
+from cobra.transpilers.transpiler.js_nodes.elemento import visit_elemento as _visit_elemento
+from cobra.transpilers.transpiler.js_nodes.clase import visit_clase as _visit_clase
+from cobra.transpilers.transpiler.js_nodes.metodo import visit_metodo as _visit_metodo
+from cobra.transpilers.transpiler.js_nodes.try_catch import visit_try_catch as _visit_try_catch
+from cobra.transpilers.transpiler.js_nodes.throw import visit_throw as _visit_throw
+from cobra.transpilers.transpiler.js_nodes.importar import visit_import as _visit_import
+from cobra.transpilers.transpiler.js_nodes.instancia import visit_instancia as _visit_instancia
+from cobra.transpilers.transpiler.js_nodes.atributo import visit_atributo as _visit_atributo
+from cobra.transpilers.transpiler.js_nodes.operacion_binaria import (
     visit_operacion_binaria as _visit_operacion_binaria,
 )
-from src.cobra.transpilers.transpiler.js_nodes.operacion_unaria import visit_operacion_unaria as _visit_operacion_unaria
-from src.cobra.transpilers.transpiler.js_nodes.valor import visit_valor as _visit_valor
-from src.cobra.transpilers.transpiler.js_nodes.identificador import visit_identificador as _visit_identificador
-from src.cobra.transpilers.transpiler.js_nodes.para import visit_para as _visit_para
-from src.cobra.transpilers.transpiler.js_nodes.decorador import visit_decorador as _visit_decorador
-from src.cobra.transpilers.transpiler.js_nodes.yield_ import visit_yield as _visit_yield
-from src.cobra.transpilers.transpiler.js_nodes.esperar import visit_esperar as _visit_esperar
-from src.cobra.transpilers.transpiler.js_nodes.romper import visit_romper as _visit_romper
-from src.cobra.transpilers.transpiler.js_nodes.continuar import visit_continuar as _visit_continuar
-from src.cobra.transpilers.transpiler.js_nodes.pasar import visit_pasar as _visit_pasar
-from src.cobra.transpilers.transpiler.js_nodes.switch import visit_switch as _visit_switch
-from src.cobra.transpilers.transpiler.js_nodes.exportar import visit_export as _visit_export
+from cobra.transpilers.transpiler.js_nodes.operacion_unaria import visit_operacion_unaria as _visit_operacion_unaria
+from cobra.transpilers.transpiler.js_nodes.valor import visit_valor as _visit_valor
+from cobra.transpilers.transpiler.js_nodes.identificador import visit_identificador as _visit_identificador
+from cobra.transpilers.transpiler.js_nodes.para import visit_para as _visit_para
+from cobra.transpilers.transpiler.js_nodes.decorador import visit_decorador as _visit_decorador
+from cobra.transpilers.transpiler.js_nodes.yield_ import visit_yield as _visit_yield
+from cobra.transpilers.transpiler.js_nodes.esperar import visit_esperar as _visit_esperar
+from cobra.transpilers.transpiler.js_nodes.romper import visit_romper as _visit_romper
+from cobra.transpilers.transpiler.js_nodes.continuar import visit_continuar as _visit_continuar
+from cobra.transpilers.transpiler.js_nodes.pasar import visit_pasar as _visit_pasar
+from cobra.transpilers.transpiler.js_nodes.switch import visit_switch as _visit_switch
+from cobra.transpilers.transpiler.js_nodes.exportar import visit_export as _visit_export
 
 
 def visit_assert(self, nodo):

--- a/src/cobra/transpilers/transpiler/to_julia.py
+++ b/src/cobra/transpilers/transpiler/to_julia.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_kotlin.py
+++ b/src/cobra/transpilers/transpiler/to_kotlin.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_latex.py
+++ b/src/cobra/transpilers/transpiler/to_latex.py
@@ -10,14 +10,14 @@ from core.ast_nodes import (
     NodoAtributo,
 )
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from src.cobra.transpilers.transpiler.latex_nodes.asignacion import visit_asignacion as _visit_asignacion
-from src.cobra.transpilers.transpiler.latex_nodes.funcion import visit_funcion as _visit_funcion
-from src.cobra.transpilers.transpiler.latex_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
-from src.cobra.transpilers.transpiler.latex_nodes.imprimir import visit_imprimir as _visit_imprimir
+from cobra.transpilers.transpiler.latex_nodes.asignacion import visit_asignacion as _visit_asignacion
+from cobra.transpilers.transpiler.latex_nodes.funcion import visit_funcion as _visit_funcion
+from cobra.transpilers.transpiler.latex_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from cobra.transpilers.transpiler.latex_nodes.imprimir import visit_imprimir as _visit_imprimir
 
 latex_nodes = {
     "asignacion": _visit_asignacion,

--- a/src/cobra/transpilers/transpiler/to_matlab.py
+++ b/src/cobra/transpilers/transpiler/to_matlab.py
@@ -13,16 +13,16 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from src.cobra.transpilers.transpiler.matlab_nodes.asignacion import visit_asignacion as _visit_asignacion
-from src.cobra.transpilers.transpiler.matlab_nodes.funcion import visit_funcion as _visit_funcion
-from src.cobra.transpilers.transpiler.matlab_nodes.llamada_funcion import (
+from cobra.transpilers.transpiler.matlab_nodes.asignacion import visit_asignacion as _visit_asignacion
+from cobra.transpilers.transpiler.matlab_nodes.funcion import visit_funcion as _visit_funcion
+from cobra.transpilers.transpiler.matlab_nodes.llamada_funcion import (
     visit_llamada_funcion as _visit_llamada_funcion,
 )
-from src.cobra.transpilers.transpiler.matlab_nodes.imprimir import visit_imprimir as _visit_imprimir
+from cobra.transpilers.transpiler.matlab_nodes.imprimir import visit_imprimir as _visit_imprimir
 
 matlab_nodes = {
     "asignacion": _visit_asignacion,

--- a/src/cobra/transpilers/transpiler/to_mojo.py
+++ b/src/cobra/transpilers/transpiler/to_mojo.py
@@ -12,7 +12,7 @@ from core.ast_nodes import (
     NodoAtributo,
 )
 from cobra.lexico.lexer import TipoToken
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_pascal.py
+++ b/src/cobra/transpilers/transpiler/to_pascal.py
@@ -13,16 +13,16 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from src.cobra.transpilers.transpiler.pascal_nodes.asignacion import visit_asignacion as _visit_asignacion
-from src.cobra.transpilers.transpiler.pascal_nodes.funcion import visit_funcion as _visit_funcion
-from src.cobra.transpilers.transpiler.pascal_nodes.llamada_funcion import (
+from cobra.transpilers.transpiler.pascal_nodes.asignacion import visit_asignacion as _visit_asignacion
+from cobra.transpilers.transpiler.pascal_nodes.funcion import visit_funcion as _visit_funcion
+from cobra.transpilers.transpiler.pascal_nodes.llamada_funcion import (
     visit_llamada_funcion as _visit_llamada_funcion,
 )
-from src.cobra.transpilers.transpiler.pascal_nodes.imprimir import visit_imprimir as _visit_imprimir
+from cobra.transpilers.transpiler.pascal_nodes.imprimir import visit_imprimir as _visit_imprimir
 
 pascal_nodes = {
     "asignacion": _visit_asignacion,

--- a/src/cobra/transpilers/transpiler/to_perl.py
+++ b/src/cobra/transpilers/transpiler/to_perl.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_php.py
+++ b/src/cobra/transpilers/transpiler/to_php.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_python.py
+++ b/src/cobra/transpilers/transpiler/to_python.py
@@ -38,50 +38,50 @@ from core.ast_nodes import (
 from cobra.parser.parser import Parser
 from cobra.lexico.lexer import TipoToken, Lexer
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
-from src.cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.import_helper import get_standard_imports
 
-from src.cobra.transpilers.transpiler.python_nodes.asignacion import visit_asignacion as _visit_asignacion
-from src.cobra.transpilers.transpiler.python_nodes.condicional import visit_condicional as _visit_condicional
-from src.cobra.transpilers.transpiler.python_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
-from src.cobra.transpilers.transpiler.python_nodes.for_ import visit_for as _visit_for
-from src.cobra.transpilers.transpiler.python_nodes.funcion import visit_funcion as _visit_funcion
-from src.cobra.transpilers.transpiler.python_nodes.llamada_funcion import (
+from cobra.transpilers.transpiler.python_nodes.asignacion import visit_asignacion as _visit_asignacion
+from cobra.transpilers.transpiler.python_nodes.condicional import visit_condicional as _visit_condicional
+from cobra.transpilers.transpiler.python_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
+from cobra.transpilers.transpiler.python_nodes.for_ import visit_for as _visit_for
+from cobra.transpilers.transpiler.python_nodes.funcion import visit_funcion as _visit_funcion
+from cobra.transpilers.transpiler.python_nodes.llamada_funcion import (
     visit_llamada_funcion as _visit_llamada_funcion,
 )
-from src.cobra.transpilers.transpiler.python_nodes.llamada_metodo import visit_llamada_metodo as _visit_llamada_metodo
-from src.cobra.transpilers.transpiler.python_nodes.imprimir import visit_imprimir as _visit_imprimir
-from src.cobra.transpilers.transpiler.python_nodes.retorno import visit_retorno as _visit_retorno
-from src.cobra.transpilers.transpiler.python_nodes.holobit import visit_holobit as _visit_holobit
-from src.cobra.transpilers.transpiler.python_nodes.lista import visit_lista as _visit_lista
-from src.cobra.transpilers.transpiler.python_nodes.diccionario import visit_diccionario as _visit_diccionario
-from src.cobra.transpilers.transpiler.python_nodes.clase import visit_clase as _visit_clase
-from src.cobra.transpilers.transpiler.python_nodes.metodo import visit_metodo as _visit_metodo
-from src.cobra.transpilers.transpiler.python_nodes.try_catch import visit_try_catch as _visit_try_catch
-from src.cobra.transpilers.transpiler.python_nodes.throw import visit_throw as _visit_throw
-from src.cobra.transpilers.transpiler.python_nodes.importar import visit_import as _visit_import
-from src.cobra.transpilers.transpiler.python_nodes.usar import visit_usar as _visit_usar
-from src.cobra.transpilers.transpiler.python_nodes.hilo import visit_hilo as _visit_hilo
-from src.cobra.transpilers.transpiler.python_nodes.instancia import visit_instancia as _visit_instancia
-from src.cobra.transpilers.transpiler.python_nodes.atributo import visit_atributo as _visit_atributo
-from src.cobra.transpilers.transpiler.python_nodes.operacion_binaria import (
+from cobra.transpilers.transpiler.python_nodes.llamada_metodo import visit_llamada_metodo as _visit_llamada_metodo
+from cobra.transpilers.transpiler.python_nodes.imprimir import visit_imprimir as _visit_imprimir
+from cobra.transpilers.transpiler.python_nodes.retorno import visit_retorno as _visit_retorno
+from cobra.transpilers.transpiler.python_nodes.holobit import visit_holobit as _visit_holobit
+from cobra.transpilers.transpiler.python_nodes.lista import visit_lista as _visit_lista
+from cobra.transpilers.transpiler.python_nodes.diccionario import visit_diccionario as _visit_diccionario
+from cobra.transpilers.transpiler.python_nodes.clase import visit_clase as _visit_clase
+from cobra.transpilers.transpiler.python_nodes.metodo import visit_metodo as _visit_metodo
+from cobra.transpilers.transpiler.python_nodes.try_catch import visit_try_catch as _visit_try_catch
+from cobra.transpilers.transpiler.python_nodes.throw import visit_throw as _visit_throw
+from cobra.transpilers.transpiler.python_nodes.importar import visit_import as _visit_import
+from cobra.transpilers.transpiler.python_nodes.usar import visit_usar as _visit_usar
+from cobra.transpilers.transpiler.python_nodes.hilo import visit_hilo as _visit_hilo
+from cobra.transpilers.transpiler.python_nodes.instancia import visit_instancia as _visit_instancia
+from cobra.transpilers.transpiler.python_nodes.atributo import visit_atributo as _visit_atributo
+from cobra.transpilers.transpiler.python_nodes.operacion_binaria import (
     visit_operacion_binaria as _visit_operacion_binaria,
 )
-from src.cobra.transpilers.transpiler.python_nodes.operacion_unaria import (
+from cobra.transpilers.transpiler.python_nodes.operacion_unaria import (
     visit_operacion_unaria as _visit_operacion_unaria,
 )
-from src.cobra.transpilers.transpiler.python_nodes.valor import visit_valor as _visit_valor
-from src.cobra.transpilers.transpiler.python_nodes.identificador import visit_identificador as _visit_identificador
-from src.cobra.transpilers.transpiler.python_nodes.para import visit_para as _visit_para
-from src.cobra.transpilers.transpiler.python_nodes.decorador import visit_decorador as _visit_decorador
-from src.cobra.transpilers.transpiler.python_nodes.yield_ import visit_yield as _visit_yield
-from src.cobra.transpilers.transpiler.python_nodes.esperar import visit_esperar as _visit_esperar
-from src.cobra.transpilers.transpiler.python_nodes.romper import visit_romper as _visit_romper
-from src.cobra.transpilers.transpiler.python_nodes.continuar import visit_continuar as _visit_continuar
-from src.cobra.transpilers.transpiler.python_nodes.pasar import visit_pasar as _visit_pasar
-from src.cobra.transpilers.transpiler.python_nodes.switch import visit_switch as _visit_switch
+from cobra.transpilers.transpiler.python_nodes.valor import visit_valor as _visit_valor
+from cobra.transpilers.transpiler.python_nodes.identificador import visit_identificador as _visit_identificador
+from cobra.transpilers.transpiler.python_nodes.para import visit_para as _visit_para
+from cobra.transpilers.transpiler.python_nodes.decorador import visit_decorador as _visit_decorador
+from cobra.transpilers.transpiler.python_nodes.yield_ import visit_yield as _visit_yield
+from cobra.transpilers.transpiler.python_nodes.esperar import visit_esperar as _visit_esperar
+from cobra.transpilers.transpiler.python_nodes.romper import visit_romper as _visit_romper
+from cobra.transpilers.transpiler.python_nodes.continuar import visit_continuar as _visit_continuar
+from cobra.transpilers.transpiler.python_nodes.pasar import visit_pasar as _visit_pasar
+from cobra.transpilers.transpiler.python_nodes.switch import visit_switch as _visit_switch
 
 
 def visit_assert(self, nodo):
@@ -142,7 +142,7 @@ class TranspiladorPython(BaseTranspiler):
         if (
             nodos
             and all(
-                n.__class__.__module__.startswith("src.cobra.parser.parser")
+            n.__class__.__module__.startswith("cobra.parser.parser")
                 for n in nodos
             )
             and not any(self._contiene_nodo_valor(n) for n in nodos)

--- a/src/cobra/transpilers/transpiler/to_r.py
+++ b/src/cobra/transpilers/transpiler/to_r.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_ruby.py
+++ b/src/cobra/transpilers/transpiler/to_ruby.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_rust.py
+++ b/src/cobra/transpilers/transpiler/to_rust.py
@@ -24,26 +24,26 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-from src.cobra.transpilers.transpiler.rust_nodes.asignacion import visit_asignacion as _visit_asignacion
-from src.cobra.transpilers.transpiler.rust_nodes.condicional import visit_condicional as _visit_condicional
-from src.cobra.transpilers.transpiler.rust_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
-from src.cobra.transpilers.transpiler.rust_nodes.funcion import visit_funcion as _visit_funcion
-from src.cobra.transpilers.transpiler.rust_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
-from src.cobra.transpilers.transpiler.rust_nodes.holobit import visit_holobit as _visit_holobit
-from src.cobra.transpilers.transpiler.rust_nodes.clase import visit_clase as _visit_clase
-from src.cobra.transpilers.transpiler.rust_nodes.metodo import visit_metodo as _visit_metodo
-from src.cobra.transpilers.transpiler.rust_nodes.yield_ import visit_yield as _visit_yield
-from src.cobra.transpilers.transpiler.rust_nodes.romper import visit_romper as _visit_romper
-from src.cobra.transpilers.transpiler.rust_nodes.continuar import visit_continuar as _visit_continuar
-from src.cobra.transpilers.transpiler.rust_nodes.pasar import visit_pasar as _visit_pasar
-from src.cobra.transpilers.transpiler.rust_nodes.switch import visit_switch as _visit_switch
-from src.cobra.transpilers.transpiler.rust_nodes.try_catch import visit_try_catch as _visit_try_catch
-from src.cobra.transpilers.transpiler.rust_nodes.throw import visit_throw as _visit_throw
-from src.cobra.transpilers.transpiler.rust_nodes.option import visit_option as _visit_option
+from cobra.transpilers.transpiler.rust_nodes.asignacion import visit_asignacion as _visit_asignacion
+from cobra.transpilers.transpiler.rust_nodes.condicional import visit_condicional as _visit_condicional
+from cobra.transpilers.transpiler.rust_nodes.bucle_mientras import visit_bucle_mientras as _visit_bucle_mientras
+from cobra.transpilers.transpiler.rust_nodes.funcion import visit_funcion as _visit_funcion
+from cobra.transpilers.transpiler.rust_nodes.llamada_funcion import visit_llamada_funcion as _visit_llamada_funcion
+from cobra.transpilers.transpiler.rust_nodes.holobit import visit_holobit as _visit_holobit
+from cobra.transpilers.transpiler.rust_nodes.clase import visit_clase as _visit_clase
+from cobra.transpilers.transpiler.rust_nodes.metodo import visit_metodo as _visit_metodo
+from cobra.transpilers.transpiler.rust_nodes.yield_ import visit_yield as _visit_yield
+from cobra.transpilers.transpiler.rust_nodes.romper import visit_romper as _visit_romper
+from cobra.transpilers.transpiler.rust_nodes.continuar import visit_continuar as _visit_continuar
+from cobra.transpilers.transpiler.rust_nodes.pasar import visit_pasar as _visit_pasar
+from cobra.transpilers.transpiler.rust_nodes.switch import visit_switch as _visit_switch
+from cobra.transpilers.transpiler.rust_nodes.try_catch import visit_try_catch as _visit_try_catch
+from cobra.transpilers.transpiler.rust_nodes.throw import visit_throw as _visit_throw
+from cobra.transpilers.transpiler.rust_nodes.option import visit_option as _visit_option
 
 
 def visit_assert(self, nodo):

--- a/src/cobra/transpilers/transpiler/to_swift.py
+++ b/src/cobra/transpilers/transpiler/to_swift.py
@@ -12,7 +12,7 @@ from core.ast_nodes import (
     NodoAtributo,
 )
 from cobra.lexico.lexer import TipoToken
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_visualbasic.py
+++ b/src/cobra/transpilers/transpiler/to_visualbasic.py
@@ -13,7 +13,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_wasm.py
+++ b/src/cobra/transpilers/transpiler/to_wasm.py
@@ -9,7 +9,7 @@ from core.ast_nodes import (
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
-from src.cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/core/ast_cache.py
+++ b/src/core/ast_cache.py
@@ -14,7 +14,7 @@ class SafeUnpickler(pickle.Unpickler):
     # Módulos de los que se permitirá cargar clases
     ALLOWED_MODULES = {
         "src.core.ast_nodes",
-        "src.cobra.lexico.lexer",
+        "cobra.lexico.lexer",
         "builtins",
     }
 

--- a/src/tests/unit/test_cli_interactive_cmd.py
+++ b/src/tests/unit/test_cli_interactive_cmd.py
@@ -27,8 +27,6 @@ sys.modules.setdefault("tree_sitter_languages", tsl_mod)
 
 import cli
 import cli.commands
-sys.modules.setdefault("src.cli", cli)
-sys.modules.setdefault("src.cli.commands", cli.commands)
 
 from cli.commands.interactive_cmd import InteractiveCommand
 

--- a/src/tests/unit/test_cli_transpilar_inverso_cmd.py
+++ b/src/tests/unit/test_cli_transpilar_inverso_cmd.py
@@ -22,8 +22,6 @@ def test_transpilar_inverso_ok(tmp_path):
     args = ["--no-color", "transpilar-inverso", str(archivo), "--origen=python", "--destino=python"]
     with patch("cli.commands.transpilar_inverso_cmd.REVERSE_TRANSPILERS", {"python": FakeReverse}), \
          patch("cli.commands.transpilar_inverso_cmd.TRANSPILERS", {"python": FakeTranspiler}), \
-         patch("src.cli.commands.transpilar_inverso_cmd.REVERSE_TRANSPILERS", {"python": FakeReverse}), \
-         patch("src.cli.commands.transpilar_inverso_cmd.TRANSPILERS", {"python": FakeTranspiler}), \
          patch("sys.stdout", new_callable=StringIO) as out:
         main(args)
     lineas = [l for l in out.getvalue().splitlines() if "Código transpilado" in l]

--- a/src/tests/unit/test_descubrir_plugins_invalid.py
+++ b/src/tests/unit/test_descubrir_plugins_invalid.py
@@ -9,9 +9,6 @@ import cobra.cli.plugin_registry as cobra_reg
 sys.modules.setdefault("cli", cobra_cli)
 sys.modules.setdefault("cli.commands", cobra_cmds)
 sys.modules.setdefault("cli.plugin_registry", cobra_reg)
-sys.modules.setdefault("src.cli", cobra_cli)
-sys.modules.setdefault("src.cli.commands", cobra_cmds)
-sys.modules.setdefault("src.cli.plugin_registry", cobra_reg)
 
 from cli.plugin import descubrir_plugins
 from cli.plugin_registry import obtener_registro, limpiar_registro

--- a/src/tests/unit/test_usar.py
+++ b/src/tests/unit/test_usar.py
@@ -50,7 +50,7 @@ def test_interpreter_usar_registra_modulo(monkeypatch):
         return mod
     monkeypatch.setattr(usar_loader, 'obtener_modulo', fake)
     import sys
-    sys.modules['src.cobra.usar_loader'] = usar_loader
+    sys.modules['cobra.usar_loader'] = usar_loader
     interp = InterpretadorCobra()
     interp.ejecutar_nodo(NodoUsar('math'))
     assert interp.variables['math'] is mod


### PR DESCRIPTION
## Summary
- update imports from `src.cobra` and `src.cli` to package paths
- adjust CLI modules to use `cobra.cli`
- fix tests referencing old module paths

## Testing
- `PYTHONPATH=src pytest -q` *(fails: DID NOT ...)

------
https://chatgpt.com/codex/tasks/task_e_6885e74689948327b1638bb01f94cb4d