### PR TITLE
docs: add install_dev script and usage instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,9 @@ PYTHONPATH=$PWD/src python -c "from src.core.main import main; main()"
 ## Ejecutar Pruebas
 
 Las pruebas unitarias se ubican en `src/tests/unit` y las de integración en
-`src/tests/integration`. Antes de ejecutarlas, establece `PYTHONPATH=$PWD/src`
-o instala el paquete en modo editable (`pip install -e .`). Para ejecutarlas
+`src/tests/integration`. Antes de ejecutarlas, establece `PYTHONPATH=$PWD/src`,
+instala el paquete en modo editable (`pip install -e .`) y ejecuta
+`./scripts/install_dev.sh` para instalar las dependencias. Para ejecutarlas
 todas utiliza:
 
 ```bash

--- a/README_en.md
+++ b/README_en.md
@@ -93,13 +93,13 @@ source .venv/bin/activate  # Unix
 .\.venv\Scripts\activate  # Windows
 ```
 
-4. Install the development dependencies (pytest, `python-dotenv`, `tomli`, `hypothesis`, etc.):
+4. Install the project dependencies using the provided script:
 
 ```bash
-pip install -r requirements-dev.txt
+./scripts/install_dev.sh
 ```
 
-   These libraries are needed for running the tests and other development tasks. Runtime dependencies are installed when installing the package.
+   This will install both runtime and development requirements needed for running the tests.
 
 5. Install the package in editable mode to use the CLI and obtain the dependencies declared in ``pyproject.toml``:
 
@@ -481,7 +481,7 @@ The CLI also includes a safe mode (`--seguro`), a sandbox option (`--sandbox`), 
 
 ## Tests and development
 
-Tests are located in the `src/tests/` folder and use pytest. You can run all tests with:
+Tests are located in the `src/tests/` folder and use pytest. First install the dependencies with `./scripts/install_dev.sh` and then run all tests with:
 
 ```bash
 PYTHONPATH=$PWD pytest

--- a/scripts/install_dev.sh
+++ b/scripts/install_dev.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+pip install -r requirements.txt -r requirements-dev.txt
+


### PR DESCRIPTION
## Summary
- add `scripts/install_dev.sh` for installing project requirements
- mention this script in English and Spanish docs

## Testing
- `./scripts/install_dev.sh`
- `PYTHONPATH=$PWD pytest` *(fails: 5 failed, 5 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6885ecb9fe148327b323bc01265896a2