### PR TITLE
Handle file permission errors in CobraHub client

### DIFF
--- a/src/cobra/cli/cobrahub_client.py
+++ b/src/cobra/cli/cobrahub_client.py
@@ -33,6 +33,9 @@ def publicar_modulo(ruta: str) -> bool:
         response.raise_for_status()
         mostrar_info(_("Módulo publicado correctamente"))
         return True
+    except (PermissionError, OSError) as exc:
+        mostrar_error(_("Error abriendo módulo: {err}").format(err=exc))
+        return False
     except requests.RequestException as exc:
         mostrar_error(_("Error publicando módulo: {err}").format(err=exc))
         return False
@@ -59,8 +62,12 @@ def descargar_modulo(nombre: str, destino: str) -> bool:
             timeout=5,
         )
         response.raise_for_status()
-        with open(destino_abs, "wb") as f:
-            f.write(response.content)
+        try:
+            with open(destino_abs, "wb") as f:
+                f.write(response.content)
+        except (PermissionError, OSError) as exc:
+            mostrar_error(_("Error guardando módulo: {err}").format(err=exc))
+            return False
         mostrar_info(_("Módulo descargado en {dest}").format(dest=destino_abs))
         return True
     except requests.RequestException as exc:


### PR DESCRIPTION
## Summary
- handle `PermissionError` and `OSError` in `cobrahub_client`
- cover new branches with unit tests

## Testing
- `flake8 src/cobra/cli/cobrahub_client.py src/tests/unit/test_cli_cobrahub.py`
- `pytest src/tests/unit/test_cli_cobrahub.py::test_publicar_modulo_permission_error -q`
- `pytest src/tests/unit/test_cli_cobrahub.py::test_descargar_modulo_permission_error -q`
- `pytest src/tests/unit/test_cli_cobrahub.py -q`
- `pytest -q` *(fails: test_ast_cache, test_ast_limit, test_auditoria_validator, test_bench_cmd)*

------
https://chatgpt.com/codex/tasks/task_e_6885f562bec48327a1bfa384393a3591