### PR TITLE
Actualiza tests para usar src directamente

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,8 @@
+# Paquete `backend`
+
+Este directorio no contiene código funcional del proyecto, sino un alias de
+conveniencia para desarrolladores. Al importar `backend` se añade
+`src/` al `sys.path` y se exponen sus submódulos principales bajo
+`backend.*`. Esto permite ejecutar los tests y ejemplos sin instalar el
+paquete.
+

--- a/src/tests/unit/lexer_test_casos_edge.py
+++ b/src/tests/unit/lexer_test_casos_edge.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import pytest
 from cobra.lexico.lexer import (

--- a/src/tests/unit/test_archivo.py
+++ b/src/tests/unit/test_archivo.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import standard_library.archivo as archivo
 

--- a/src/tests/unit/test_cli_cache_cmd.py
+++ b/src/tests/unit/test_cli_cache_cmd.py
@@ -14,11 +14,8 @@ def test_cli_cache_limpiar(monkeypatch, tmp_path):
     cache_dir.mkdir()
     (cache_dir / "x.ast").write_text("dato")
     monkeypatch.setenv("COBRA_AST_CACHE", str(cache_dir))
-    backend_src = PROJECT_ROOT / "backend" / "src"
-    for path in (PROJECT_ROOT, backend_src):
-        if str(path) not in sys.path:
-            sys.path.insert(0, str(path))
-    import backend  # ensure path hooks are set
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
 
     from cli.commands.cache_cmd import CacheCommand
 

--- a/src/tests/unit/test_cli_docs.py
+++ b/src/tests/unit/test_cli_docs.py
@@ -11,7 +11,7 @@ def test_cli_docs_invokes_sphinx():
         source = raiz / "frontend" / "docs"
         build = raiz / "frontend" / "build" / "html"
         api = raiz / "frontend" / "docs" / "api"
-        codigo = raiz / "backend" / "src"
+        codigo = raiz / "src"
         mock_run.assert_has_calls([
             call([
                 "sphinx-apidoc",

--- a/src/tests/unit/test_cli_empaquetar.py
+++ b/src/tests/unit/test_cli_empaquetar.py
@@ -9,7 +9,7 @@ def test_cli_empaquetar_invoca_pyinstaller(tmp_path):
     with patch("subprocess.run") as mock_run:
         main(["empaquetar", f"--output={tmp_path}", "--name", "pcobra"])
         raiz = Path(__file__).resolve().parents[3]
-        cli_path = raiz / "backend" / "src" / "cli" / "cli.py"
+        cli_path = raiz / "src" / "cli" / "cli.py"
         mock_run.assert_called_once_with(
             [
                 "pyinstaller",
@@ -56,7 +56,7 @@ def test_cli_empaquetar_con_datos(tmp_path):
             "spam;eggs",
         ])
         raiz = Path(__file__).resolve().parents[3]
-        cli_path = raiz / "backend" / "src" / "cli" / "cli.py"
+        cli_path = raiz / "src" / "cli" / "cli.py"
         mock_run.assert_called_once_with(
             [
                 "pyinstaller",

--- a/src/tests/unit/test_cli_plugins.py
+++ b/src/tests/unit/test_cli_plugins.py
@@ -10,7 +10,6 @@ from cli.plugin_registry import limpiar_registro
 # Añadimos la carpeta de plugins de ejemplo al path para poder importar el plugin
 ROOT = Path(__file__).resolve().parents[2]
 PLUGIN_DIR = ROOT / "examples" / "plugins"
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(PLUGIN_DIR))
 

--- a/src/tests/unit/test_cli_run_examples.py
+++ b/src/tests/unit/test_cli_run_examples.py
@@ -13,7 +13,7 @@ EXAMPLE_FILES = sorted(EXAMPLES_DIR.rglob("*.co"))
 
 def _run_cli(args, toml_path):
     env = os.environ.copy()
-    pythonpath = [str(ROOT), str(ROOT / "backend" / "src")]
+    pythonpath = [str(ROOT)]
     if env.get("PYTHONPATH"):
         pythonpath.append(env["PYTHONPATH"])
     env["PYTHONPATH"] = os.pathsep.join(pythonpath)

--- a/src/tests/unit/test_cli_secure_validators.py
+++ b/src/tests/unit/test_cli_secure_validators.py
@@ -9,7 +9,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 def _run_cli(args):
     env = os.environ.copy()
-    pythonpath = [str(ROOT), str(ROOT / "backend" / "src")]
+    pythonpath = [str(ROOT)]
     if env.get("PYTHONPATH"):
         pythonpath.append(env["PYTHONPATH"])
     env["PYTHONPATH"] = os.pathsep.join(pythonpath)

--- a/src/tests/unit/test_core_main.py
+++ b/src/tests/unit/test_core_main.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 from core.main import main
 

--- a/src/tests/unit/test_fecha.py
+++ b/src/tests/unit/test_fecha.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import standard_library.fecha as fecha
 

--- a/src/tests/unit/test_lista.py
+++ b/src/tests/unit/test_lista.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import standard_library.lista as lista
 

--- a/src/tests/unit/test_logica.py
+++ b/src/tests/unit/test_logica.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import standard_library.logica as logica
 

--- a/src/tests/unit/test_lsp_server.py
+++ b/src/tests/unit/test_lsp_server.py
@@ -5,7 +5,6 @@ import types
 from unittest.mock import Mock, patch
 
 ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 sys.path.insert(0, str(ROOT))
 
 # Evita dependencias pesadas al importar el módulo

--- a/src/tests/unit/test_md2cobra_plugin.py
+++ b/src/tests/unit/test_md2cobra_plugin.py
@@ -9,7 +9,6 @@ from cli.cli import main
 # Añadimos la carpeta de plugins de ejemplo al path para importar el plugin
 ROOT = Path(__file__).resolve().parents[3]
 PLUGIN_DIR = ROOT / "examples" / "plugins"
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(PLUGIN_DIR))
 

--- a/src/tests/unit/test_nativos_io.py
+++ b/src/tests/unit/test_nativos_io.py
@@ -6,7 +6,6 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / 'backend' / 'src'))
 
 # Evita dependencias externas requeridas al importar src.core.nativos
 fake_pybind11 = ModuleType('pybind11')

--- a/src/tests/unit/test_parser_del_global.py
+++ b/src/tests/unit/test_parser_del_global.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 sys.path.insert(0, str(ROOT))
 import core.visitor as _vis
 sys.modules.setdefault("backend.src.core.visitor", _vis)

--- a/src/tests/unit/test_performance.py
+++ b/src/tests/unit/test_performance.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 from src.core.performance import smart_perfilar, optimizar_bucle
 

--- a/src/tests/unit/test_plugin_loader.py
+++ b/src/tests/unit/test_plugin_loader.py
@@ -16,7 +16,6 @@ from cli.plugin_registry import obtener_registro, limpiar_registro
 # el plugin md2cobra durante las pruebas.
 ROOT = Path(__file__).resolve().parents[2]
 PLUGIN_DIR = ROOT / "examples" / "plugins"
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(PLUGIN_DIR))
 sys.modules.setdefault("src.tests.test_plugin_loader", sys.modules[__name__])

--- a/src/tests/unit/test_pybind_bridge_invalid_loader.py
+++ b/src/tests/unit/test_pybind_bridge_invalid_loader.py
@@ -6,7 +6,6 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 fake_pybind11 = ModuleType('pybind11')
 fake_helpers = ModuleType('pybind11.setup_helpers')

--- a/src/tests/unit/test_pybind_bridge_paths.py
+++ b/src/tests/unit/test_pybind_bridge_paths.py
@@ -6,7 +6,6 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 fake_pybind11 = ModuleType('pybind11')
 fake_helpers = ModuleType('pybind11.setup_helpers')

--- a/src/tests/unit/test_sandbox_js.py
+++ b/src/tests/unit/test_sandbox_js.py
@@ -6,7 +6,6 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 from core.sandbox import ejecutar_en_sandbox_js
 

--- a/src/tests/unit/test_sandbox_restrictions.py
+++ b/src/tests/unit/test_sandbox_restrictions.py
@@ -1,5 +1,5 @@
 import pytest
-from backend.src.core.sandbox import ejecutar_en_sandbox
+from src.core.sandbox import ejecutar_en_sandbox
 
 
 @pytest.mark.timeout(5)

--- a/src/tests/unit/test_usar_loader_site_packages.py
+++ b/src/tests/unit/test_usar_loader_site_packages.py
@@ -18,11 +18,11 @@ def test_obtener_modulo_en_site_packages(tmp_path, monkeypatch):
 
     # Copiar archivos necesarios
     (cobra_dir / "__init__.py").write_text("")
-    usar_loader_src = ROOT / "backend" / "src" / "cobra" / "usar_loader.py"
+    usar_loader_src = ROOT / "src" / "cobra" / "usar_loader.py"
     (cobra_dir / "usar_loader.py").write_text(usar_loader_src.read_text())
 
     (corelibs_dir / "__init__.py").write_text("")
-    texto_src = ROOT / "backend" / "corelibs" / "texto.py"
+    texto_src = ROOT / "src" / "corelibs" / "texto.py"
     (corelibs_dir / "texto.py").write_text(texto_src.read_text())
 
     (stdlib_dir / "__init__.py").write_text("")

--- a/src/tests/unit/test_usar_loader_stdlib.py
+++ b/src/tests/unit/test_usar_loader_stdlib.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 sys.path.insert(0, str(ROOT))
 
 from cobra import usar_loader

--- a/src/tests/unit/test_util.py
+++ b/src/tests/unit/test_util.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT / "backend" / "src"))
 
 import standard_library.util as util
 


### PR DESCRIPTION
## Summary
- remove extra `backend/src` path manipulations in tests
- use files from `src/` in loader test
- document the `backend` alias purpose

## Testing
- `pytest -q` *(fails: Failed: DID NOT RAISE <class 'RuntimeError'>)*

------
https://chatgpt.com/codex/tasks/task_e_6885f8a7bc74832790a0c04d600d16b9