### PR TITLE
update tests to use installed packages

### DIFF
--- a/src/tests/unit/test_ast_cache.py
+++ b/src/tests/unit/test_ast_cache.py
@@ -9,8 +9,8 @@ def test_obtener_ast_reutiliza(monkeypatch, tmp_path):
     monkeypatch.setenv("COBRA_AST_CACHE", str(cache_dir))
 
     import importlib, sys
-    if 'src.core.ast_cache' in sys.modules:
-        importlib.reload(sys.modules['src.core.ast_cache'])
+    if 'core.ast_cache' in sys.modules:
+        importlib.reload(sys.modules['core.ast_cache'])
     from core.ast_cache import obtener_ast
 
     llamadas = {"count": 0}
@@ -38,8 +38,8 @@ def test_limpiar_cache(monkeypatch, tmp_path):
     codigo = "var y = 2"
 
     import importlib, sys
-    if 'src.core.ast_cache' in sys.modules:
-        importlib.reload(sys.modules['src.core.ast_cache'])
+    if 'core.ast_cache' in sys.modules:
+        importlib.reload(sys.modules['core.ast_cache'])
     from core.ast_cache import obtener_ast, limpiar_cache
 
     obtener_ast(codigo)

--- a/src/tests/unit/test_holobit_sdk_integration.py
+++ b/src/tests/unit/test_holobit_sdk_integration.py
@@ -7,7 +7,7 @@ def test_graficar_usa_sdk(monkeypatch):
     def fake(hb):
         llamadas['hb'] = hb
     import importlib
-    gmod = importlib.import_module('src.core.holobits.graficar')
+    gmod = importlib.import_module('core.holobits.graficar')
     monkeypatch.setattr(gmod, 'proyectar_holograma', fake)
     h = Holobit([1, 2, 3, 4, 5, 6])
     graficar(h)
@@ -19,7 +19,7 @@ def test_proyectar_usa_sdk(monkeypatch):
     def fake(hb):
         llamadas['hb'] = hb
     import importlib
-    pmod = importlib.import_module('src.core.holobits.proyection')
+    pmod = importlib.import_module('core.holobits.proyection')
     monkeypatch.setattr(pmod, 'proyectar_holograma', fake)
     h = Holobit([1, 2, 3, 4, 5, 6])
     proyectar(h, '2D')

--- a/src/tests/unit/test_import_seguro_validator.py
+++ b/src/tests/unit/test_import_seguro_validator.py
@@ -8,7 +8,7 @@ from core.ast_nodes import NodoImport
 def test_import_seguro_fuera_de_ruta(tmp_path, monkeypatch):
     validator = ValidadorImportSeguro()
     nodo = NodoImport(str(tmp_path / "m.co"))
-    monkeypatch.setattr('src.core.interpreter.MODULES_PATH', str(tmp_path / 'mods'))
-    monkeypatch.setattr('src.core.interpreter.IMPORT_WHITELIST', set())
+    monkeypatch.setattr('core.interpreter.MODULES_PATH', str(tmp_path / 'mods'))
+    monkeypatch.setattr('core.interpreter.IMPORT_WHITELIST', set())
     with pytest.raises(PrimitivaPeligrosaError):
         nodo.aceptar(validator)

--- a/src/tests/unit/test_nativos_io.py
+++ b/src/tests/unit/test_nativos_io.py
@@ -7,7 +7,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
-# Evita dependencias externas requeridas al importar src.core.nativos
+# Evita dependencias externas requeridas al importar core.nativos
 fake_pybind11 = ModuleType('pybind11')
 fake_helpers = ModuleType('pybind11.setup_helpers')
 fake_helpers.Pybind11Extension = object
@@ -18,7 +18,7 @@ fake_setuptools = ModuleType('setuptools')
 fake_setuptools.Distribution = object
 sys.modules.setdefault('setuptools', fake_setuptools)
 
-import src.core.nativos.io as io
+import core.nativos.io as io
 
 
 def test_obtener_url_rechaza_esquema_no_http():

--- a/src/tests/unit/test_pcobra_config.py
+++ b/src/tests/unit/test_pcobra_config.py
@@ -3,9 +3,9 @@ import sys
 
 
 def _reload_module():
-    if 'src.core.pcobra_config' in sys.modules:
-        importlib.reload(sys.modules['src.core.pcobra_config'])
-    return sys.modules.get('src.core.pcobra_config')
+    if 'core.pcobra_config' in sys.modules:
+        importlib.reload(sys.modules['core.pcobra_config'])
+    return sys.modules.get('core.pcobra_config')
 
 
 def test_cargar_configuracion_python_js(tmp_path, monkeypatch):

--- a/src/tests/unit/test_performance.py
+++ b/src/tests/unit/test_performance.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
-from src.core.performance import smart_perfilar, optimizar_bucle
+from core.performance import smart_perfilar, optimizar_bucle
 
 
 def _dummy(x=0):
@@ -13,7 +13,7 @@ def _dummy(x=0):
 
 
 def test_smart_perfilar_invoca_smart_profile():
-    with patch("src.core.performance.smart_profile", create=True, return_value={"mean": 1}) as sp:
+    with patch("core.performance.smart_profile", create=True, return_value={"mean": 1}) as sp:
         result = smart_perfilar(_dummy, args=(1,))
     sp.assert_called_once()
     assert result == {"mean": 1}
@@ -27,7 +27,7 @@ def test_optimizar_bucle_decorator():
             return wrapper
         return decorator
 
-    with patch("src.core.performance.optimize_loop", create=True, side_effect=fake_optimize_loop) as op:
+    with patch("core.performance.optimize_loop", create=True, side_effect=fake_optimize_loop) as op:
         @optimizar_bucle(loops=2)
         def foo():
             return "ok"

--- a/src/tests/unit/test_pybind_bridge_invalid_loader.py
+++ b/src/tests/unit/test_pybind_bridge_invalid_loader.py
@@ -23,7 +23,7 @@ def test_cargar_extension_loader_invalido(tmp_path, monkeypatch):
     ruta.touch()
     monkeypatch.setenv("COBRA_ALLOWED_EXT_PATHS", str(tmp_path))
     import importlib
-    import src.core.pybind_bridge as bridge
+    import core.pybind_bridge as bridge
     importlib.reload(bridge)
     with patch("importlib.util.spec_from_loader", return_value=None):
         with pytest.raises(ImportError, match="No se pudo obtener un spec"):

--- a/src/tests/unit/test_pybind_bridge_paths.py
+++ b/src/tests/unit/test_pybind_bridge_paths.py
@@ -22,7 +22,7 @@ def test_cargar_extension_invalid_path(tmp_path, monkeypatch):
     allowed = tmp_path / "allowed"
     allowed.mkdir()
     monkeypatch.setenv("COBRA_ALLOWED_EXT_PATHS", str(allowed))
-    import src.core.pybind_bridge as bridge
+    import core.pybind_bridge as bridge
     importlib.reload(bridge)
     invalid = tmp_path / "other" / "x.so"
     invalid.parent.mkdir()
@@ -35,7 +35,7 @@ def test_cargar_extension_invalid_parent(tmp_path, monkeypatch):
     allowed = tmp_path / "allowed"
     allowed.mkdir()
     monkeypatch.setenv("COBRA_ALLOWED_EXT_PATHS", str(allowed))
-    import src.core.pybind_bridge as bridge
+    import core.pybind_bridge as bridge
     importlib.reload(bridge)
     outside = allowed.parent / "x.so"
     outside.touch()

--- a/src/tests/unit/test_safe_mode_imports.py
+++ b/src/tests/unit/test_safe_mode_imports.py
@@ -23,7 +23,7 @@ AST_COMPLETO = base_ast + EXTRA_NODOS
 
 def test_imports_y_reflexion_en_modo_seguro(tmp_path, monkeypatch):
     import sys
-    mod = sys.modules['src.core.interpreter']
+    mod = sys.modules['core.interpreter']
     monkeypatch.setattr(mod, 'MODULES_PATH', str(tmp_path))
     monkeypatch.setattr(mod, 'IMPORT_WHITELIST', {
         str(tmp_path / 'os'),
@@ -42,7 +42,7 @@ def test_imports_y_reflexion_en_modo_seguro(tmp_path, monkeypatch):
 
 def test_imports_y_reflexion_fuera_modo_seguro(tmp_path, monkeypatch):
     import sys
-    mod = sys.modules['src.core.interpreter']
+    mod = sys.modules['core.interpreter']
     monkeypatch.setattr(mod, 'MODULES_PATH', str(tmp_path))
     monkeypatch.setattr(mod, 'IMPORT_WHITELIST', {
         str(tmp_path / 'os'),

--- a/src/tests/unit/test_sandbox_restrictions.py
+++ b/src/tests/unit/test_sandbox_restrictions.py
@@ -1,5 +1,5 @@
 import pytest
-from src.core.sandbox import ejecutar_en_sandbox
+from core.sandbox import ejecutar_en_sandbox
 
 
 @pytest.mark.timeout(5)

--- a/src/tests/unit/test_token_cache.py
+++ b/src/tests/unit/test_token_cache.py
@@ -10,8 +10,8 @@ def test_obtener_tokens_reutiliza(monkeypatch, tmp_path):
     cache_dir = tmp_path / "cache"
     monkeypatch.setenv("COBRA_AST_CACHE", str(cache_dir))
 
-    if 'src.core.ast_cache' in sys.modules:
-        importlib.reload(sys.modules['src.core.ast_cache'])
+    if 'core.ast_cache' in sys.modules:
+        importlib.reload(sys.modules['core.ast_cache'])
     from core.ast_cache import obtener_tokens
 
     llamadas = {"count": 0}
@@ -35,8 +35,8 @@ def test_obtener_ast_reutiliza_tokens(monkeypatch, tmp_path):
     cache_dir = tmp_path / "cache"
     monkeypatch.setenv("COBRA_AST_CACHE", str(cache_dir))
 
-    if 'src.core.ast_cache' in sys.modules:
-        importlib.reload(sys.modules['src.core.ast_cache'])
+    if 'core.ast_cache' in sys.modules:
+        importlib.reload(sys.modules['core.ast_cache'])
     from core.ast_cache import obtener_ast
 
     token_calls = {"count": 0}


### PR DESCRIPTION
## Summary
- update unit tests to import from installed packages instead of `src` prefix
- ensure comments reflect new imports
- verify tests pass after `pip install -e .[dev]`

## Testing
- `pip install -e .[dev]`
- `pytest src/tests/unit/test_pybind_bridge_invalid_loader.py src/tests/unit/test_pybind_bridge_paths.py src/tests/unit/test_nativos_io.py src/tests/unit/test_sandbox_restrictions.py src/tests/unit/test_performance.py src/tests/unit/test_holobit_sdk_integration.py src/tests/unit/test_ast_cache.py src/tests/unit/test_token_cache.py src/tests/unit/test_pcobra_config.py src/tests/unit/test_import_seguro_validator.py src/tests/unit/test_safe_mode_imports.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688600b5869c8327ba3aac445f184bfe