### PR TITLE
Add test helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,16 @@ dependencias listadas en `requirements-dev.txt`, las cuales están incluidas en
 el extra `dev` de `pyproject.toml`. Sin estas bibliotecas las pruebas fallarán
 debido a módulos no encontrados.
 
+Si prefieres ejecutar las pruebas directamente desde el repositorio sin
+instalar el paquete, utiliza el script `scripts/test.sh`:
+
+```bash
+./scripts/test.sh
+```
+
+Este comando exporta `PYTHONPATH=$PWD` e invoca `pytest` con los argumentos
+definidos en `pytest.ini`.
+
 ````bash
 PYTHONPATH=$PWD pytest src/tests --cov=src --cov-report=term-missing \
   --cov-fail-under=95

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+# Añade la raíz del proyecto a PYTHONPATH para importar módulos sin instalar
+export PYTHONPATH="$PWD"
+
+pytest "$@"


### PR DESCRIPTION
## Summary
- provide `scripts/test.sh` to run pytest with repo in `PYTHONPATH`
- document the new script in the README

## Testing
- `bash scripts/test.sh src/tests/unit/test_to_python2.py::test_transpilar_asignacion -vv`

------
https://chatgpt.com/codex/tasks/task_e_6886035896c88327accee37bad378e07