### PR TITLE
Agregar tests de seguridad sandbox

### DIFF
--- a/src/tests/unit/test_security_sandbox.py
+++ b/src/tests/unit/test_security_sandbox.py
@@ -1,0 +1,35 @@
+import shutil
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from core.sandbox import (
+    ejecutar_en_sandbox_js,
+    compilar_en_sandbox_cpp,
+    ejecutar_en_contenedor,
+)
+
+
+@pytest.mark.timeout(5)
+def test_js_timeout_invalido():
+    if not shutil.which("node"):
+        pytest.skip("node no disponible")
+    salida = ejecutar_en_sandbox_js("console.log('hola')", timeout=-1)
+    assert "agotado" in salida
+
+
+@pytest.mark.timeout(5)
+def test_compilar_cpp_sin_compilador():
+    with patch("subprocess.run", side_effect=FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
+            compilar_en_sandbox_cpp("int main() { return 0; }")
+
+
+def test_contenedor_backend_invalido():
+    with pytest.raises(ValueError):
+        ejecutar_en_contenedor("print(1)", "malicioso")


### PR DESCRIPTION
## Resumen
- añadir pruebas de seguridad para las funciones de sandbox

## Testing
- `pytest src/tests/unit/test_security_sandbox.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688609af7eb08327a1908e5903cc2218