### PR TITLE
Add decorator support to JS transpiler

### DIFF
--- a/src/cobra/transpilers/transpiler/js_nodes/decorador.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/decorador.py
@@ -1,4 +1,5 @@
 # Este nodo no genera salida directa; se maneja en visit_funcion
 
 def visit_decorador(self, nodo):
-    pass
+    """Devuelve la expresión del decorador para uso posterior."""
+    return self.obtener_valor(nodo.expresion)

--- a/src/tests/unit/test_to_js.py
+++ b/src/tests/unit/test_to_js.py
@@ -85,6 +85,22 @@ def test_transpilador_yield():
     assert resultado == esperado
 
 
+def test_transpilador_decoradores_funcion_js():
+    d1 = NodoDecorador(NodoIdentificador("d1"))
+    d2 = NodoDecorador(NodoIdentificador("d2"))
+    func = NodoFuncion("saluda", [], [NodoPasar()], [d1, d2])
+    t = TranspiladorJavaScript()
+    resultado = t.generate_code([func])
+    esperado = IMPORTS + (
+        "function saluda() {\n"
+        + ";\n"
+        + "}\n"
+        + "saluda = d2(saluda);\n"
+        + "saluda = d1(saluda);"
+    )
+    assert resultado == esperado
+
+
 def test_transpilador_switch():
     ast = [
         NodoSwitch(


### PR DESCRIPTION
## Summary
- implement `visit_decorador` for the JavaScript transpiler
- add unit test ensuring decorated functions are converted correctly

## Testing
- `PYTHONPATH=$PWD pytest src/tests/unit/test_to_js.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886132733bc8327b585abe7d6f4e17e