### PR TITLE
Fix CobraHub symlink handling

### DIFF
--- a/src/cobra/cli/cobrahub_client.py
+++ b/src/cobra/cli/cobrahub_client.py
@@ -51,7 +51,13 @@ def descargar_modulo(nombre: str, destino: str) -> bool:
         mostrar_error(_("Ruta de destino inválida"))
         return False
     destino_abs = os.path.abspath(destino)
-    if not destino_abs.startswith(os.path.abspath(os.getcwd()) + os.sep):
+    cwd = os.path.abspath(os.getcwd()) + os.sep
+    if not destino_abs.startswith(cwd):
+        mostrar_error(_("Ruta de destino inválida"))
+        return False
+    # Evitar escribir en enlaces simbólicos o fuera del directorio actual
+    real_destino = os.path.realpath(destino_abs)
+    if os.path.islink(destino_abs) or not real_destino.startswith(cwd):
         mostrar_error(_("Ruta de destino inválida"))
         return False
     if not _validar_url():

--- a/src/tests/unit/test_cli_cobrahub.py
+++ b/src/tests/unit/test_cli_cobrahub.py
@@ -151,3 +151,18 @@ def test_descargar_modulo_permission_error(tmp_path, monkeypatch):
     assert not ok
     err.assert_called_once()
     mock_get.assert_called_once()
+
+
+@pytest.mark.timeout(5)
+def test_descargar_modulo_symlink(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    destino_real = tmp_path / "real.co"
+    destino_real.write_text("")
+    enlace = tmp_path / "link.co"
+    enlace.symlink_to(destino_real)
+    with patch("cobra.cli.cobrahub_client.mostrar_error") as err, \
+            patch("cli.cobrahub_client.requests.get") as mock_get:
+        ok = cobrahub_client.descargar_modulo("m.co", str(enlace))
+    assert not ok
+    err.assert_called_once()
+    mock_get.assert_not_called()


### PR DESCRIPTION
## Summary
- avoid writing modules to symlinks or outside cwd
- test failure when saving to a symlink

## Testing
- `pytest src/tests/unit/test_cli_cobrahub.py::test_descargar_modulo_symlink -vv`
- `make lint` *(fails: line breaks, E501, etc.)*
- `make typecheck` *(fails: mypy.ini parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_68861c24665c8327be438c2978ac3c63