### PR TITLE
Handle symlinked module destination

### DIFF
--- a/src/cobra/cli/commands/modules_cmd.py
+++ b/src/cobra/cli/commands/modules_cmd.py
@@ -122,6 +122,11 @@ class ModulesCommand(BaseCommand):
             mostrar_error(_("Ruta de módulo inválida"))
             return 1
         destino = os.path.join(MODULES_PATH, os.path.basename(ruta))
+        if os.path.exists(destino) and os.path.islink(destino):
+            mostrar_error(
+                _("El destino {dest} es un enlace simbólico").format(dest=destino)
+            )
+            return 1
         shutil.copy(ruta, destino)
         mostrar_info(_("Módulo instalado en {dest}").format(dest=destino))
         version = ModulesCommand._obtener_version(ruta)

--- a/src/tests/unit/test_instalar_modulo_destino_symlink.py
+++ b/src/tests/unit/test_instalar_modulo_destino_symlink.py
@@ -1,0 +1,27 @@
+import yaml
+from unittest.mock import patch
+import pytest
+
+from cli.commands import modules_cmd
+
+
+@pytest.mark.timeout(5)
+def test_instalar_modulo_destino_symlink(tmp_path, monkeypatch):
+    mods_dir = tmp_path / "mods"
+    mods_dir.mkdir()
+    monkeypatch.setattr(modules_cmd, "MODULES_PATH", str(mods_dir))
+    mod_file = tmp_path / "cobra.mod"
+    mod_file.write_text("lock: {}\n")
+    monkeypatch.setattr(modules_cmd, "MODULE_MAP_PATH", str(mod_file))
+    monkeypatch.setattr(modules_cmd, "LOCK_FILE", str(mod_file))
+
+    modulo = tmp_path / "m.co"
+    modulo.write_text("var x = 1")
+
+    dest = mods_dir / modulo.name
+    dest.symlink_to(modulo)
+
+    with patch("cli.commands.modules_cmd.mostrar_error") as err:
+        ret = modules_cmd.ModulesCommand._instalar_modulo(str(modulo))
+    assert ret == 1
+    err.assert_called_once()


### PR DESCRIPTION
## Summary
- detect if destination already exists as a symlink before copying a module
- test install fails when destination is a symlink

## Testing
- `pytest src/tests/unit/test_instalar_modulo_destino_symlink.py::test_instalar_modulo_destino_symlink -q`

------
https://chatgpt.com/codex/tasks/task_e_68861f7791f483278710d13a912bb7fc