### PR TITLE
Fix package install symlink check

### DIFF
--- a/src/cobra/cli/commands/package_cmd.py
+++ b/src/cobra/cli/commands/package_cmd.py
@@ -73,6 +73,11 @@ class PaqueteCommand(BaseCommand):
                     dest = os.path.join(
                         modules_cmd.MODULES_PATH, os.path.basename(name)
                     )
+                    if os.path.exists(dest) and os.path.islink(dest):
+                        mostrar_error(
+                            _("El destino {dest} es un enlace simbólico").format(dest=dest)
+                        )
+                        return 1
                     with zf.open(name) as src, open(dest, "wb") as out:
                         out.write(src.read())
         mostrar_info(

--- a/src/tests/unit/test_cli_paquete_symlink.py
+++ b/src/tests/unit/test_cli_paquete_symlink.py
@@ -1,0 +1,28 @@
+import zipfile
+from unittest.mock import patch
+import pytest
+
+from cli.commands import modules_cmd, package_cmd
+
+
+@pytest.mark.timeout(5)
+def test_instalar_paquete_destino_symlink(tmp_path, monkeypatch):
+    # Preparar un paquete con un módulo
+    src = tmp_path / "src"
+    src.mkdir()
+    modulo = src / "m.co"
+    modulo.write_text("var x = 1")
+    pkg = tmp_path / "demo.cobra"
+    with zipfile.ZipFile(pkg, "w") as zf:
+        zf.write(modulo, arcname=modulo.name)
+    # Destino dentro de MODULES_PATH es un symlink
+    mods_dir = tmp_path / "mods"
+    mods_dir.mkdir()
+    monkeypatch.setattr(modules_cmd, "MODULES_PATH", str(mods_dir))
+    monkeypatch.setattr(package_cmd.modules_cmd, "MODULES_PATH", str(mods_dir))
+    dest = mods_dir / modulo.name
+    dest.symlink_to(modulo)
+    with patch("cli.commands.package_cmd.mostrar_error") as err:
+        ret = package_cmd.PaqueteCommand._instalar(str(pkg))
+    assert ret == 1
+    err.assert_called_once()


### PR DESCRIPTION
## Summary
- detect symlink targets when installing packages
- add regression test for symlink destination rejection

## Testing
- `pytest src/tests/unit/test_cli_paquete_symlink.py::test_instalar_paquete_destino_symlink -q`

------
https://chatgpt.com/codex/tasks/task_e_688623368fb88327bd5079c8e322237d