### PR TITLE
Usar contenedor para sandbox C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Cobra es un lenguaje de programación diseñado en español, enfocado en la crea
 - [Cheatsheet](docs/cheatsheet.tex) – compílalo a PDF con LaTeX
 - [Casos de uso reales](docs/casos_reales.md)
 - [Limitaciones del sandbox de Node](docs/limitaciones_node_sandbox.md)
+- [Limitaciones del sandbox de C++](docs/limitaciones_cpp_sandbox.md)
 - Notebooks de ejemplo y casos reales
 - [Historial de cambios](CHANGELOG.md)
 

--- a/docs/limitaciones_cpp_sandbox.md
+++ b/docs/limitaciones_cpp_sandbox.md
@@ -1,0 +1,3 @@
+# Limitaciones del sandbox de C++
+
+`compilar_en_sandbox_cpp` ejecuta el código dentro del contenedor Docker `cobra-cpp-sandbox`. Si la imagen no está disponible o Docker no está instalado se rechaza la operación con un error indicando que el contenedor de C++ no puede usarse.

--- a/src/core/sandbox.py
+++ b/src/core/sandbox.py
@@ -88,32 +88,15 @@ process.stdout.write(output);
 
 
 def compilar_en_sandbox_cpp(codigo: str) -> str:
-    """Compila y ejecuta código C++ de forma segura."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        src = Path(tmpdir) / "main.cpp"
-        src.write_text(codigo)
-        exe = Path(tmpdir) / "a.out"
-        try:
-            subprocess.run(
-                [
-                    "g++",
-                    "-std=c++17",
-                    str(src),
-                    "-o",
-                    str(exe),
-                ],
-                check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )  # nosec B603
-            proc = subprocess.run(
-                [str(exe)], capture_output=True, text=True, check=True
-            )  # nosec B603
-            return proc.stdout
-        except subprocess.CalledProcessError as exc:
-            if exc.stderr:
-                return exc.stderr.decode() if isinstance(exc.stderr, bytes) else exc.stderr
-            return str(exc)
+    """Compila y ejecuta código C++ de forma segura utilizando Docker.
+
+    Si el contenedor ``cobra-cpp-sandbox`` no está disponible o Docker no está
+    instalado se lanza ``RuntimeError`` con un mensaje descriptivo.
+    """
+    try:
+        return ejecutar_en_contenedor(codigo, "cpp")
+    except RuntimeError as exc:
+        raise RuntimeError(f"Contenedor de C++ no disponible: {exc}") from exc
 
 
 def ejecutar_en_contenedor(codigo: str, backend: str) -> str:

--- a/src/tests/unit/test_security_sandbox.py
+++ b/src/tests/unit/test_security_sandbox.py
@@ -24,9 +24,9 @@ def test_js_timeout_invalido():
 
 
 @pytest.mark.timeout(5)
-def test_compilar_cpp_sin_compilador():
-    with patch("subprocess.run", side_effect=FileNotFoundError):
-        with pytest.raises(FileNotFoundError):
+def test_compilar_cpp_sin_contenedor():
+    with patch("core.sandbox.ejecutar_en_contenedor", side_effect=RuntimeError("docker")):
+        with pytest.raises(RuntimeError, match="Contenedor.*C\+\+"):
             compilar_en_sandbox_cpp("int main() { return 0; }")
 
 


### PR DESCRIPTION
## Summary
- ejecutar sandbox de C++ con `ejecutar_en_contenedor`
- anotar en la documentación la nueva limitación
- actualizar la prueba de seguridad

## Testing
- `pytest src/tests/unit/test_security_sandbox.py::test_compilar_cpp_sin_contenedor -q`
- `pytest src/tests/unit/test_security_sandbox.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68862ff859e48327b20049f7a8148ed5