### PR TITLE
Arregla validación de rutas de estado en Qualia

### DIFF
--- a/src/core/qualia_bridge.py
+++ b/src/core/qualia_bridge.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 from typing import List, Union
 
 from cobra.lexico.lexer import Lexer
@@ -15,8 +16,14 @@ DEFAULT_STATE_FILE = os.path.join(
 def _resolve_state_file() -> str:
     """Devuelve la ruta de estado validada y normalizada."""
     raw_path = os.environ.get("QUALIA_STATE_PATH", DEFAULT_STATE_FILE)
-    path = os.path.abspath(raw_path)
-    base = os.path.abspath(os.path.join(os.path.expanduser("~"), ".cobra"))
+    abspath = os.path.abspath(raw_path)
+
+    # Rechazar explícitamente rutas que sean enlaces simbólicos
+    if os.path.islink(abspath) or Path(abspath).is_symlink():
+        raise ValueError("QUALIA_STATE_PATH no debe ser un enlace simbólico")
+
+    path = os.path.realpath(abspath)
+    base = os.path.realpath(os.path.join(os.path.expanduser("~"), ".cobra"))
 
     if os.path.commonpath([path, base]) != base:
         raise ValueError("QUALIA_STATE_PATH debe ubicarse dentro de ~/.cobra")

--- a/src/tests/unit/test_qualia_bridge.py
+++ b/src/tests/unit/test_qualia_bridge.py
@@ -74,6 +74,25 @@ def test_qualia_rejects_traversal(tmp_path, monkeypatch):
         importlib.reload(qualia_bridge)
 
 
+def test_qualia_rejects_symlink(tmp_path, monkeypatch):
+    """El path no debe ser un enlace simbólico que apunte fuera de ~/.cobra."""
+    home = tmp_path
+    cobra_dir = home / ".cobra"
+    cobra_dir.mkdir()
+
+    target = home / "outside.json"
+    target.write_text("{}")
+
+    link = cobra_dir / "state.json"
+    link.symlink_to(target)
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("QUALIA_STATE_PATH", str(link))
+
+    with pytest.raises(ValueError):
+        importlib.reload(qualia_bridge)
+
+
 def test_state_file_permissions(tmp_path, monkeypatch):
     state = tmp_path / ".cobra" / "state.json"
     monkeypatch.setenv("HOME", str(tmp_path))


### PR DESCRIPTION
## Summary
- usa `os.path.realpath` y rechaza enlaces simbólicos al resolver `QUALIA_STATE_PATH`
- añade test que verifica que se rechazan symlinks fuera de `~/.cobra`

## Testing
- `PYTHONPATH=$PWD pytest src/tests/unit/test_qualia_bridge.py::test_qualia_rejects_symlink -q`

------
https://chatgpt.com/codex/tasks/task_e_688635bf7030832798e5b59fb313ebaa