### PR TITLE
Ensure qualia state directory permissions

### DIFF
--- a/src/core/qualia_bridge.py
+++ b/src/core/qualia_bridge.py
@@ -89,7 +89,7 @@ def load_state() -> QualiaSpirit:
 
 def save_state(spirit: QualiaSpirit) -> None:
     """Guarda el estado de ``spirit`` en ``STATE_FILE``."""
-    os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
+    os.makedirs(os.path.dirname(STATE_FILE), mode=0o700, exist_ok=True)
     with open(STATE_FILE, "w", encoding="utf-8") as fh:
         json.dump(
             {

--- a/src/tests/unit/test_qualia_bridge.py
+++ b/src/tests/unit/test_qualia_bridge.py
@@ -104,3 +104,21 @@ def test_state_file_permissions(tmp_path, monkeypatch):
         mode = state.stat().st_mode & 0o777
         assert mode == 0o600
 
+
+def test_state_dir_permissions(tmp_path, monkeypatch):
+    state = tmp_path / ".cobra" / "state.json"
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
+    qb = importlib.reload(qualia_bridge)
+    qb.register_execution("var x = 1")
+    dir_path = state.parent
+    # Elimina el directorio para probar la creación con permisos
+    for child in dir_path.glob("*"):
+        if child.is_file() or child.is_symlink():
+            child.unlink()
+    dir_path.rmdir()
+    qb.save_state(qb.QUALIA)
+    if os.name == "posix":
+        mode = dir_path.stat().st_mode & 0o777
+        assert mode == 0o700
+


### PR DESCRIPTION
## Summary
- create qualia state directory with `0o700` permissions
- test directory permission creation

## Testing
- `pytest src/tests/unit/test_qualia_bridge.py::test_state_file_permissions src/tests/unit/test_qualia_bridge.py::test_state_dir_permissions -q`

------
https://chatgpt.com/codex/tasks/task_e_68863c76e4f483279c09ed22192f404f