### PR TITLE
Fix whitelist logic in ejecutar

### DIFF
--- a/src/corelibs/sistema.py
+++ b/src/corelibs/sistema.py
@@ -25,7 +25,11 @@ def ejecutar(comando: list[str], permitidos: Iterable[str] | None = None) -> str
     cuando esté disponible o lanzando un ``RuntimeError`` con
     información detallada.
     """
-    if permitidos is not None and comando and comando[0] not in permitidos:
+    if (
+        permitidos is not None
+        and comando
+        and os.path.basename(comando[0]) not in permitidos
+    ):
         raise ValueError(f"Comando no permitido: {comando[0]}")
     args = comando
     try:

--- a/src/tests/unit/test_corelibs_sistema.py
+++ b/src/tests/unit/test_corelibs_sistema.py
@@ -26,3 +26,10 @@ def test_ejecutar_error(monkeypatch):
     monkeypatch.setattr(core.sistema.subprocess, "run", raise_err2)
     with pytest.raises(RuntimeError):
         core.ejecutar(["bad"])
+
+
+def test_ejecutar_permitido_con_ruta(monkeypatch):
+    proc = MagicMock()
+    proc.stdout = "ok"
+    monkeypatch.setattr(core.sistema.subprocess, "run", lambda *a, **k: proc)
+    assert core.ejecutar(["/bin/echo", "ok"], permitidos=["echo"]) == "ok"


### PR DESCRIPTION
## Summary
- update command whitelist to use basename
- test command whitelist with full path

## Testing
- `python check.py` *(fails: flake8, mypy, bandit, pytest, pyright)*
- `pytest -q` *(fails: ModuleNotFoundError: RestrictedPython)*

------
https://chatgpt.com/codex/tasks/task_e_68863fe2cb3483279308e5f729a2e4da