### PR TITLE
Add host whitelist to CobraHub client

### DIFF
--- a/src/cobra/cli/cobrahub_client.py
+++ b/src/cobra/cli/cobrahub_client.py
@@ -1,4 +1,5 @@
 import os
+import urllib.parse
 
 import requests
 
@@ -13,6 +14,13 @@ def _validar_url() -> bool:
     if not COBRAHUB_URL.startswith("https://"):
         mostrar_error(_("COBRAHUB_URL debe empezar con https://"))
         return False
+    allowed = os.environ.get("COBRA_HOST_WHITELIST")
+    if allowed:
+        hosts = {h.strip() for h in allowed.split(',') if h.strip()}
+        host = urllib.parse.urlparse(COBRAHUB_URL).hostname
+        if host not in hosts:
+            mostrar_error(_("Host de COBRAHUB_URL no permitido"))
+            return False
     return True
 
 


### PR DESCRIPTION
## Summary
- verify COBRAHUB_URL host using COBRA_HOST_WHITELIST
- reject CobraHub operations when host isn't allowed
- test host whitelist in CobraHub client

## Testing
- `pytest src/tests/unit/test_cli_cobrahub.py::test_publicar_modulo_host_no_permitido src/tests/unit/test_cli_cobrahub.py::test_descargar_modulo_host_no_permitido -q`

------
https://chatgpt.com/codex/tasks/task_e_688650d8aebc832796eab8f37329109b