### PR TITLE
Actualizar manejo de imprimir y pruebas

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -42,6 +42,7 @@ pip install cobra-lenguaje
 ```cobra
 var mensaje = 'Hola Mundo'
 imprimir(mensaje)
+imprimir(valor_inexistente)  # Variable no definida
 ```
 
 Ejemplo con decoradores y `yield`:

--- a/src/cobra/parser/parser.py
+++ b/src/cobra/parser/parser.py
@@ -622,8 +622,6 @@ class ClassicParser:
 
         # Procesa el contenido que será impreso (podría ser una expresión)
         expresion = self.expresion()
-        if isinstance(expresion, NodoIdentificador):
-            expresion = NodoValor(expresion.nombre)
 
         # Consume ')'
         if self.token_actual().tipo != TipoToken.RPAREN:

--- a/src/core/interpreter.py
+++ b/src/core/interpreter.py
@@ -245,17 +245,8 @@ class InterpretadorCobra:
             return self.ejecutar_llamada_metodo(nodo)
         elif isinstance(nodo, NodoImprimir):
             valor = self.evaluar_expresion(nodo.expresion)
-            if isinstance(valor, str):
-                if (valor.startswith('"') and valor.endswith('"')) or (
-                    valor.startswith("'") and valor.endswith("'")
-                ):
-                    print(valor.strip('"').strip("'"))
-                else:
-                    obtenido = self.obtener_variable(valor)
-                    if obtenido is not None:
-                        print(obtenido)
-                    else:
-                        print(f"Variable '{valor}' no definida")
+            if valor is None and isinstance(nodo.expresion, NodoIdentificador):
+                print(f"Variable '{nodo.expresion.nombre}' no definida")
             else:
                 print(valor)
         elif isinstance(nodo, NodoImport):

--- a/src/tests/unit/test_interpreter.py
+++ b/src/tests/unit/test_interpreter.py
@@ -4,7 +4,14 @@ from unittest.mock import patch
 
 from core.interpreter import InterpretadorCobra
 from cobra.lexico.lexer import Token, TipoToken
-from core.ast_nodes import NodoAsignacion, NodoValor, NodoLlamadaFuncion, NodoFuncion
+from core.ast_nodes import (
+    NodoAsignacion,
+    NodoValor,
+    NodoLlamadaFuncion,
+    NodoFuncion,
+    NodoImprimir,
+    NodoIdentificador,
+)
 def test_interpretador_asignacion_y_llamada_funcion():
 
     # Crea una instancia del intérprete
@@ -79,3 +86,28 @@ def test_preservacion_de_variables_globales():
     inter.ejecutar_llamada_funcion(NodoLlamadaFuncion("modificar", []))
 
     assert inter.variables["a"] == 5
+
+
+def test_imprimir_cadena_literal():
+    inter = InterpretadorCobra()
+    nodo = NodoImprimir(NodoValor("Hola"))
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        inter.ejecutar_nodo(nodo)
+    assert out.getvalue().strip() == "Hola"
+
+
+def test_imprimir_identificador_existente():
+    inter = InterpretadorCobra()
+    inter.ejecutar_nodo(NodoAsignacion("x", NodoValor(3)))
+    nodo = NodoImprimir(NodoIdentificador("x"))
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        inter.ejecutar_nodo(nodo)
+    assert out.getvalue().strip() == "3"
+
+
+def test_imprimir_identificador_no_definido():
+    inter = InterpretadorCobra()
+    nodo = NodoImprimir(NodoIdentificador("y"))
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        inter.ejecutar_nodo(nodo)
+    assert out.getvalue().strip() == "Variable 'y' no definida"

--- a/src/tests/unit/test_parser5.py
+++ b/src/tests/unit/test_parser5.py
@@ -1,7 +1,7 @@
 import pytest
 from cobra.lexico.lexer import Lexer
 from cobra.parser.parser import Parser
-from core.ast_nodes import NodoPara, NodoImprimir, NodoFuncion
+from core.ast_nodes import NodoPara, NodoImprimir, NodoFuncion, NodoIdentificador
 
 def test_declaracion_para():
     """Prueba una declaración de bucle 'para'."""
@@ -21,7 +21,8 @@ def test_declaracion_para():
     assert nodo_para.iterable.valor == "range(0, 10)"  # O ajusta según cómo se represente el iterable
     assert len(nodo_para.cuerpo) == 1
     assert isinstance(nodo_para.cuerpo[0], NodoImprimir)
-    assert nodo_para.cuerpo[0].expresion.valor == "i"
+    assert isinstance(nodo_para.cuerpo[0].expresion, NodoIdentificador)
+    assert nodo_para.cuerpo[0].expresion.nombre == "i"
 
 
 def test_declaracion_imprimir():
@@ -66,4 +67,5 @@ def test_funcion_y_para():
 
     nodo_imprimir = nodo_para.cuerpo[0]
     assert isinstance(nodo_imprimir, NodoImprimir)
-    assert nodo_imprimir.expresion.valor == "i"
+    assert isinstance(nodo_imprimir.expresion, NodoIdentificador)
+    assert nodo_imprimir.expresion.nombre == "i"


### PR DESCRIPTION
## Resumen
- la función `declaracion_imprimir` ya no convierte identificadores a valores
- el intérprete imprime directamente la expresión y avisa si el identificador no existe
- nuevas pruebas para `imprimir` con cadenas e identificadores
- ejemplo actualizado en la documentación

## Testing
- `pytest src/tests/unit/test_parser5.py::test_declaracion_imprimir src/tests/unit/test_parser5.py::test_funcion_y_para src/tests/unit/test_interpreter.py::test_imprimir_cadena_literal src/tests/unit/test_interpreter.py::test_imprimir_identificador_existente src/tests/unit/test_interpreter.py::test_imprimir_identificador_no_definido -q`

------
https://chatgpt.com/codex/tasks/task_e_68866a0d20e083279741380c8cbae770