### PR TITLE
Permitir 'imprimir' sin paréntesis

### DIFF
--- a/src/cobra/parser/parser.py
+++ b/src/cobra/parser/parser.py
@@ -618,15 +618,19 @@ class ClassicParser:
     def declaracion_imprimir(self):
         """Parsea una declaración de impresión."""
         self.comer(TipoToken.IMPRIMIR)  # Consume el token 'imprimir'
-        self.comer(TipoToken.LPAREN)  # Consume '('
 
-        # Procesa el contenido que será impreso (podría ser una expresión)
-        expresion = self.expresion()
-
-        # Consume ')'
-        if self.token_actual().tipo != TipoToken.RPAREN:
-            raise SyntaxError("Se esperaba ')' al final de la instrucción 'imprimir'")
-        self.comer(TipoToken.RPAREN)
+        # Si la siguiente parte comienza con paréntesis, se maneja como antes
+        if self.token_actual().tipo == TipoToken.LPAREN:
+            self.comer(TipoToken.LPAREN)
+            expresion = self.expresion()
+            if self.token_actual().tipo != TipoToken.RPAREN:
+                raise SyntaxError(
+                    "Se esperaba ')' al final de la instrucción 'imprimir'"
+                )
+            self.comer(TipoToken.RPAREN)
+        else:
+            # Sin paréntesis, se parsea la expresión directamente
+            expresion = self.expresion()
 
         return NodoImprimir(expresion)
 

--- a/src/tests/unit/test_parser5.py
+++ b/src/tests/unit/test_parser5.py
@@ -40,6 +40,22 @@ def test_declaracion_imprimir():
     assert nodo_imprimir.expresion.valor == "Hola, Cobra!"
 
 
+def test_declaracion_imprimir_sin_parentesis():
+    """Prueba la impresión sin paréntesis."""
+    codigo = """
+    imprimir x
+    """
+    tokens = Lexer(codigo).tokenizar()
+    parser = Parser(tokens)
+    ast = parser.parsear()
+
+    assert len(ast) == 1
+    nodo_imprimir = ast[0]
+    assert isinstance(nodo_imprimir, NodoImprimir)
+    assert isinstance(nodo_imprimir.expresion, NodoIdentificador)
+    assert nodo_imprimir.expresion.nombre == "x"
+
+
 def test_funcion_y_para():
     """Prueba una función que incluye un bucle 'para'."""
     codigo = """


### PR DESCRIPTION
## Summary
- actualizar el parser para aceptar `imprimir` sin paréntesis opcionalmente
- añadir prueba que valida `imprimir x`

## Testing
- `pytest -q src/tests/unit/test_parser5.py::test_declaracion_imprimir_sin_parentesis -vv`


------
https://chatgpt.com/codex/tasks/task_e_68874817bbf48327beec07c64a8f4eca