### PR TITLE
Prevent recursive assignment evaluation

### DIFF
--- a/src/core/ast_nodes.py
+++ b/src/core/ast_nodes.py
@@ -191,6 +191,10 @@ class NodoIdentificador(NodoAST):
     """Uso de una variable o identificador."""
 
     def __post_init__(self):
+        if isinstance(self.nombre, Token):
+            self.nombre = self.nombre.valor
+        elif isinstance(self.nombre, NodoIdentificador):
+            self.nombre = self.nombre.nombre
         self.valor = self.nombre
 
     def __repr__(self):

--- a/src/tests/unit/test_interpreter.py
+++ b/src/tests/unit/test_interpreter.py
@@ -11,6 +11,7 @@ from core.ast_nodes import (
     NodoFuncion,
     NodoImprimir,
     NodoIdentificador,
+    NodoOperacionBinaria,
 )
 def test_interpretador_asignacion_y_llamada_funcion():
 
@@ -111,3 +112,21 @@ def test_imprimir_identificador_no_definido():
     with patch("sys.stdout", new_callable=StringIO) as out:
         inter.ejecutar_nodo(nodo)
     assert out.getvalue().strip() == "Variable 'y' no definida"
+
+
+def test_asignacion_y_operacion_aritmetica():
+    """Asignar variables y realizar una suma sin recursión infinita."""
+    inter = InterpretadorCobra()
+
+    inter.ejecutar_nodo(NodoAsignacion("x", NodoValor(2)))
+    inter.ejecutar_nodo(NodoAsignacion("y", NodoValor(3)))
+
+    suma_expr = NodoOperacionBinaria(
+        NodoIdentificador("x"),
+        Token(TipoToken.SUMA, "+"),
+        NodoIdentificador("y"),
+    )
+
+    resultado = inter.ejecutar_nodo(NodoAsignacion("suma", suma_expr))
+    assert resultado == 5
+    assert inter.variables["suma"] == 5


### PR DESCRIPTION
## Summary
- avoid recursive evaluation in `ejecutar_asignacion`
- return value from assignments
- normalize identifier names to avoid recursion
- add a regression test for arithmetic assignment

## Testing
- `pytest src/tests/unit/test_interpreter.py::test_asignacion_y_operacion_aritmetica -q`
- `pytest -q` *(fails: FileNotFoundError in bench command tests)*

------
https://chatgpt.com/codex/tasks/task_e_688749f1eddc8327a1c9722f6a9c2ef4