### PR TITLE
Share interpreter across CLI commands

### DIFF
--- a/src/cobra/cli/commands/interactive_cmd.py
+++ b/src/cobra/cli/commands/interactive_cmd.py
@@ -22,10 +22,10 @@ class InteractiveCommand(BaseCommand):
 
     name = "interactive"
 
-    def __init__(self) -> None:
+    def __init__(self, interpretador: InterpretadorCobra) -> None:
         super().__init__()
         # Intérprete reutilizable para mantener estado entre comandos
-        self.interpretador = InterpretadorCobra()
+        self.interpretador = interpretador
 
     def register_subparser(self, subparsers):
         """Registra los argumentos del subcomando."""

--- a/src/tests/integration/test_interactive_persistence.py
+++ b/src/tests/integration/test_interactive_persistence.py
@@ -1,0 +1,39 @@
+import os
+import sys
+from pathlib import Path
+
+import pexpect
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+PATCH_DIR = Path(__file__).parent
+
+
+def _spawn(args="interactive", extra_env=None):
+    env = os.environ.copy()
+    pythonpath = [str(ROOT), str(ROOT / "backend" / "src"), str(PATCH_DIR)]
+    if env.get("PYTHONPATH"):
+        pythonpath.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath)
+    env["PCOBRA_TOML"] = str(PATCH_DIR / "empty.toml")
+    env.pop("PYTEST_CURRENT_TEST", None)
+    if extra_env:
+        env.update(extra_env)
+    return pexpect.spawn(
+        f"{sys.executable} -m cli.cli {args}", env=env, encoding="utf-8"
+    )
+
+
+@pytest.mark.integration
+def test_interactive_persistence():
+    child = _spawn()
+    child.expect("cobra> ")
+    child.sendline("x = 42")
+    child.expect("cobra> ")
+    child.sendline("imprimir(x)")
+    child.expect("42")
+    child.expect("cobra> ")
+    child.sendline("salir")
+    child.expect(pexpect.EOF)
+    child.wait()
+    assert child.exitstatus == 0

--- a/src/tests/unit/test_cli.py
+++ b/src/tests/unit/test_cli.py
@@ -9,7 +9,8 @@ def test_cli_interactive():
     expected_outputs = ["10"]
 
     with patch("builtins.input", side_effect=inputs), \
-            patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            patch("sys.stdout", new_callable=StringIO) as mock_stdout, \
+            patch("cobra.cli.cli.messages.mostrar_logo"):
         from cli.cli import main
         main()
 
@@ -23,7 +24,8 @@ def test_cli_transpilador():
     expected_outputs = ["20"]
 
     with patch("builtins.input", side_effect=inputs), \
-            patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            patch("sys.stdout", new_callable=StringIO) as mock_stdout, \
+            patch("cobra.cli.cli.messages.mostrar_logo"):
         from cli.cli import main
         main()
 


### PR DESCRIPTION
## Summary
- keep a single `InterpretadorCobra` instance in `CliApplication`
- pass the interpreter to `InteractiveCommand`
- adjust unit tests for the new constructor
- add an integration test ensuring interpreter state persists across commands

## Testing
- `pytest src/tests/unit/test_cli_interactive_cmd.py src/tests/unit/test_cli.py src/tests/integration/test_interactive_persistence.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688755882d90832798d254b7634269c5