### PR TITLE
Mejora parser con sugerencias de palabras clave

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,16 @@ python ejemplo.py
 
 Si no proporcionas un subcomando se abrirá el modo interactivo.
 
+### Uso interactivo
+
+Al ejecutar `cobra` sin argumentos aparecerá un REPL. Si escribes una palabra
+clave con un error tipográfico se mostrará una sugerencia automática. Ejemplo:
+
+```bash
+cobra> imprmir 1
+SyntaxError: Token inesperado. ¿Quiso decir 'imprimir'?
+```
+
 ## Uso desde la CLI
 
 Una vez instalado el paquete, la herramienta `cobra` ofrece varios subcomandos:

--- a/src/cobra/parser/parser.py
+++ b/src/cobra/parser/parser.py
@@ -4,6 +4,7 @@ import logging
 import json
 import os
 from cobra.lexico.lexer import TipoToken, Token
+from .utils import PALABRAS_RESERVADAS, sugerir_palabra_clave
 
 from core.ast_nodes import (
     NodoAsignacion,
@@ -48,57 +49,6 @@ from core.ast_nodes import (
 from core import NodoYield
 
 
-# Palabras reservadas que no pueden usarse como identificadores
-PALABRAS_RESERVADAS = {
-    "var",
-    "func",
-    "rel",
-    "si",
-    "sino",
-    "mientras",
-    "para",
-    "import",
-    "try",
-    "catch",
-    "throw",
-    "hilo",
-    "retorno",
-    "fin",
-    "in",
-    "holobit",
-    "imprimir",
-    "proyectar",
-    "transformar",
-    "graficar",
-    "usar",
-    "macro",
-    "clase",
-    "metodo",
-    "atributo",
-    "decorador",
-    "yield",
-    "romper",
-    "continuar",
-    "pasar",
-    "afirmar",
-    "eliminar",
-    "global",
-    "nolocal",
-    "lambda",
-    "asincronico",
-    "esperar",
-    "con",
-    "finalmente",
-    "desde",
-    "como",
-    "switch",
-    "case",
-    "segun",
-    "caso",
-    "intentar",
-    "capturar",
-    "lanzar",
-}
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -263,6 +213,13 @@ class ClassicParser:
             handler = self._factories.get(token.tipo)
             if handler:
                 return handler()
+
+            if token.tipo == TipoToken.IDENTIFICADOR:
+                sugerencia = sugerir_palabra_clave(token.valor)
+                if sugerencia:
+                    raise SyntaxError(
+                        f"Token inesperado. ¿Quiso decir '{sugerencia}'?"
+                    )
 
             # Posibles expresiones o asignaciones/invocaciones
             if token.tipo == TipoToken.ATRIBUTO:

--- a/src/cobra/parser/utils.py
+++ b/src/cobra/parser/utils.py
@@ -1,0 +1,60 @@
+from difflib import get_close_matches
+
+# Lista de palabras reservadas del lenguaje que no pueden usarse como identificadores
+PALABRAS_RESERVADAS = {
+    "var",
+    "func",
+    "rel",
+    "si",
+    "sino",
+    "mientras",
+    "para",
+    "import",
+    "try",
+    "catch",
+    "throw",
+    "hilo",
+    "retorno",
+    "fin",
+    "in",
+    "holobit",
+    "imprimir",
+    "proyectar",
+    "transformar",
+    "graficar",
+    "usar",
+    "macro",
+    "clase",
+    "metodo",
+    "atributo",
+    "decorador",
+    "yield",
+    "romper",
+    "continuar",
+    "pasar",
+    "afirmar",
+    "eliminar",
+    "global",
+    "nolocal",
+    "lambda",
+    "asincronico",
+    "esperar",
+    "con",
+    "finalmente",
+    "desde",
+    "como",
+    "switch",
+    "case",
+    "segun",
+    "caso",
+    "intentar",
+    "capturar",
+    "lanzar",
+}
+
+
+def sugerir_palabra_clave(palabra: str) -> str | None:
+    """Devuelve la palabra clave más parecida si existe una coincidencia."""
+    coincidencias = get_close_matches(palabra, PALABRAS_RESERVADAS, n=1, cutoff=0.8)
+    return coincidencias[0] if coincidencias else None
+

--- a/src/jupyter_kernel/__init__.py
+++ b/src/jupyter_kernel/__init__.py
@@ -8,7 +8,8 @@ import contextlib
 from importlib.metadata import PackageNotFoundError, version
 from ipykernel.kernelbase import Kernel
 from cobra.lexico.lexer import Lexer
-from cobra.parser.parser import Parser, PALABRAS_RESERVADAS
+from cobra.parser.parser import Parser
+from cobra.parser.utils import PALABRAS_RESERVADAS
 from core.interpreter import InterpretadorCobra
 from core.qualia_bridge import get_suggestions
 

--- a/src/tests/unit/test_parser_sugerencias.py
+++ b/src/tests/unit/test_parser_sugerencias.py
@@ -1,0 +1,12 @@
+import pytest
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+
+
+def test_sugerencia_palabra_clave():
+    codigo = "imprmir 1"
+    tokens = Lexer(codigo).analizar_token()
+    parser = Parser(tokens)
+    with pytest.raises(SyntaxError, match="¿Quiso decir 'imprimir'?"):
+        parser.parsear()
+


### PR DESCRIPTION
## Summary
- añadir util `sugerir_palabra_clave` con las palabras reservadas
- usar dicha utilidad en `Parser.declaracion`
- ajustar `jupyter_kernel` al nuevo módulo
- documentar la nueva característica de ayuda interactiva
- crear prueba unitaria de la sugerencia

## Testing
- `pytest -q` *(fails: test_auditoria_registra_primitiva, test_bench_profile_creates_json, test_bench_transpilers_generates_results, test_bench_transpilers_profile_creates_file, test_benchmarks2_without_resource)*

------
https://chatgpt.com/codex/tasks/task_e_688758dd81648327a99f164159349cba