### PR TITLE
Fix stack overflow when evaluating variables stored as nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## v10.0.6 - 2025-07-26
 - Actualización de documentación y archivos de configuración.
 
+## v10.0.7 - 2025-07-27
+- Corregido un desbordamiento de pila al resolver variables que almacenaban
+  nodos en operaciones como ``x + y``.
+
 ## v10.0.0 - 2025-08-15
 - Incremento de versión principal a 10.0.0.
 - Actualización de documentación y ejemplos.

--- a/src/core/ast_nodes.py
+++ b/src/core/ast_nodes.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 
-from cobra.lexico.lexer import Token
+from cobra.lexico.lexer import Token, TipoToken
 
 
 @dataclass
@@ -201,9 +201,26 @@ class NodoIdentificador(NodoAST):
         return f"NodoIdentificador({self.nombre})"
 
     def evaluar(self, contexto):
-        if self.nombre in contexto:
-            return contexto[self.nombre]
-        raise NameError(f"Identificador no definido: '{self.nombre}'")
+        if self.nombre not in contexto:
+            raise NameError(f"Identificador no definido: '{self.nombre}'")
+
+        valor = contexto[self.nombre]
+
+        while isinstance(valor, NodoIdentificador):
+            if valor.nombre not in contexto:
+                raise NameError(f"Identificador no definido: '{valor.nombre}'")
+            valor = contexto[valor.nombre]
+
+        if isinstance(valor, NodoValor):
+            return valor.valor
+        if isinstance(valor, Token) and valor.tipo in {
+            TipoToken.ENTERO,
+            TipoToken.FLOTANTE,
+            TipoToken.CADENA,
+            TipoToken.BOOLEANO,
+        }:
+            return valor.valor
+        return valor
 
 
 @dataclass

--- a/src/core/interpreter.py
+++ b/src/core/interpreter.py
@@ -46,6 +46,7 @@ from core.ast_nodes import (
     NodoNoLocal,
     NodoWith,
     NodoImportDesde,
+    NodoAST,
 )
 from cobra.parser.parser import Parser
 from core.memoria.gestor_memoria import GestorMemoriaGenetico
@@ -137,7 +138,27 @@ class InterpretadorCobra:
         """Busca una variable en la pila de contextos."""
         for contexto in reversed(self.contextos):
             if nombre in contexto:
-                return contexto[nombre]
+                valor = contexto[nombre]
+                # Resuelve nodos simples a valores primitivos
+                while isinstance(
+                    valor,
+                    (
+                        NodoValor,
+                        NodoIdentificador,
+                        NodoAsignacion,
+                        NodoInstancia,
+                        NodoAtributo,
+                        NodoOperacionBinaria,
+                        NodoOperacionUnaria,
+                        NodoEsperar,
+                        NodoLlamadaFuncion,
+                        NodoLlamadaMetodo,
+                        NodoHolobit,
+                        Token,
+                    ),
+                ):
+                    valor = self.evaluar_expresion(valor)
+                return valor
         return None
 
     # -- Gestión de memoria -------------------------------------------------

--- a/src/tests/unit/test_interpreter.py
+++ b/src/tests/unit/test_interpreter.py
@@ -130,3 +130,30 @@ def test_asignacion_y_operacion_aritmetica():
     resultado = inter.ejecutar_nodo(NodoAsignacion("suma", suma_expr))
     assert resultado == 5
     assert inter.variables["suma"] == 5
+
+
+def test_resolver_variables_con_nodos():
+    """Las variables almacenadas como nodos se resuelven a primitivos."""
+    inter = InterpretadorCobra()
+
+    inter.variables["x"] = NodoValor(4)
+    inter.variables["y"] = NodoIdentificador("x")
+
+    valor = inter.evaluar_expresion(NodoIdentificador("y"))
+    assert valor == 4
+
+
+def test_operacion_con_valores_nodo():
+    """Operaciones aritméticas funcionan aunque las variables guarden nodos."""
+    inter = InterpretadorCobra()
+
+    inter.variables["x"] = NodoValor(2)
+    inter.variables["y"] = NodoValor(3)
+
+    expr = NodoOperacionBinaria(
+        NodoIdentificador("x"),
+        Token(TipoToken.SUMA, "+"),
+        NodoIdentificador("y"),
+    )
+
+    assert inter.evaluar_expresion(expr) == 5


### PR DESCRIPTION
## Summary
- resolve variable nodes to primitives within `obtener_variable`
- ensure `NodoIdentificador.evaluar` resolves nested identifiers
- test variable resolution with node values
- document stack overflow fix in changelog

## Testing
- `pytest -q src/tests/unit/test_interpreter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688760e86a488327853125831a88d3d4