### PR TITLE
Validar parámetros contra palabras reservadas

### DIFF
--- a/src/cobra/parser/parser.py
+++ b/src/cobra/parser/parser.py
@@ -1087,11 +1087,14 @@ class ClassicParser:
     def lista_parametros(self):
         """Devuelve la lista de parámetros de una función o lambda."""
         parametros = []
-        while self.token_actual().tipo == TipoToken.IDENTIFICADOR:
+        while (
+            self.token_actual().tipo == TipoToken.IDENTIFICADOR
+            or self.token_actual().valor in PALABRAS_RESERVADAS
+        ):
             nombre_parametro = self.token_actual().valor
-            if nombre_parametro in ["si", "mientras", "func", "fin"]:
+            if nombre_parametro in PALABRAS_RESERVADAS:
                 raise SyntaxError(
-                    f"El nombre del parámetro '{nombre_parametro}' es reservado."
+                    f"El nombre del parámetro '{nombre_parametro}' es una palabra reservada"
                 )
             if nombre_parametro in parametros:
                 raise SyntaxError(

--- a/src/tests/unit/test_reserved_identifiers.py
+++ b/src/tests/unit/test_reserved_identifiers.py
@@ -20,3 +20,14 @@ def test_funcion_nombre_reservado():
     parser = Parser(tokens)
     with pytest.raises(SyntaxError, match="palabra reservada"):
         parser.parsear()
+
+
+def test_parametro_nombre_reservado():
+    codigo = """
+    func foo(para):
+        fin
+    """
+    tokens = Lexer(codigo).analizar_token()
+    parser = Parser(tokens)
+    with pytest.raises(SyntaxError, match="palabra reservada"):
+        parser.parsear()


### PR DESCRIPTION
## Resumen
- Usa `PALABRAS_RESERVADAS` para validar nombres de parámetros y evita duplicados.
- Mejora el mensaje de error cuando el nombre de un parámetro es reservado.
- Añade prueba unitaria que impide declarar parámetros con palabras reservadas.

## Pruebas
- `PYTHONPATH=src pytest src/tests/unit/test_reserved_identifiers.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_688f933fb3a88327b990c0d0466c2c7a