### PR TITLE
Usar json.dumps y repr en LarkParser

### DIFF
--- a/src/cobra/parser/lark_parser.py
+++ b/src/cobra/parser/lark_parser.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
+import json
 from lark import Lark, ParseError
 from cobra.lexico.lexer import Token, TipoToken
 
@@ -43,11 +44,11 @@ class LarkParser:
         parts = []
         for t in self.tokens:
             if t.tipo == TipoToken.CADENA:
-                parts.append(f'"{t.valor}"')
+                parts.append(json.dumps(t.valor))
             elif t.tipo == TipoToken.EOF:
                 continue
             else:
-                parts.append(str(t.valor))
+                parts.append(repr(t.valor))
         return " ".join(parts)
 
     def parsear(self) -> Optional[object]:

--- a/src/tests/unit/test_lark_parser_tokens.py
+++ b/src/tests/unit/test_lark_parser_tokens.py
@@ -1,0 +1,18 @@
+import json
+from cobra.lexico.lexer import Token, TipoToken
+from cobra.parser.lark_parser import LarkParser
+
+
+def test_tokens_to_source_cadenas_comillas_y_salto_linea():
+    """Verifica que las cadenas se escapen con json.dumps y otros tokens con repr."""
+    cadena_valor = 'hola "cobra"\nfin'
+    otro_valor = 'linea1\nlinea2'
+    tokens = [
+        Token(TipoToken.CADENA, cadena_valor),
+        Token(TipoToken.IDENTIFICADOR, otro_valor),
+        Token(TipoToken.EOF, None),
+    ]
+    parser = LarkParser(tokens)
+    esperado = f"{json.dumps(cadena_valor)} {repr(otro_valor)}"
+    assert parser._tokens_to_source() == esperado
+


### PR DESCRIPTION
## Resumen
- Reemplazo de concatenación manual por `json.dumps` en tokens de cadena.
- Representación de otros tokens mediante `repr` para asegurar escape de caracteres especiales.
- Prueba unitaria que valida el manejo de comillas y saltos de línea en `_tokens_to_source`.

## Pruebas
- `pytest src/tests/unit/test_lark_parser_tokens.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f98ab3ed08327b31f4b400c4f74ea