### PR TITLE
Manejo robusto de LarkParser ante dependencias o gramática faltantes

### DIFF
--- a/src/cobra/parser/lark_parser.py
+++ b/src/cobra/parser/lark_parser.py
@@ -3,41 +3,49 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
 import json
-from lark import Lark, ParseError
+try:
+    from lark import Lark, ParseError
+except ImportError as exc:  # pragma: no cover - dependencia externa
+    raise ImportError(
+        "No se pudo importar 'lark'. Instálalo ejecutando 'pip install lark-parser'."
+    ) from exc
 from cobra.lexico.lexer import Token, TipoToken
+
 
 class LarkParser:
     """Parser basado en Lark que carga la gramática EBNF."""
-    
+
     def __init__(self, tokens: List[Token]) -> None:
         """
         Inicializa el parser con una lista de tokens.
-        
+
         Args:
             tokens: Lista de tokens a parsear
-            
+
         Raises:
             FileNotFoundError: Si no se encuentra el archivo de gramática
             ValueError: Si la gramática está vacía o es inválida
         """
         self.tokens = tokens
         grammar_path = Path(__file__).resolve().parents[3] / "docs" / "gramatica.ebnf"
-        
-        if not grammar_path.exists():
-            raise FileNotFoundError(f"No se encuentra el archivo de gramática: {grammar_path}")
-            
-        with open(grammar_path, "r", encoding="utf-8") as f:
-            grammar = f.read()
-            
+
+        try:
+            with open(grammar_path, "r", encoding="utf-8") as f:
+                grammar = f.read()
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                f"No se encuentra el archivo de gramática: {grammar_path}"
+            ) from exc
+
         if not grammar.strip():
             raise ValueError("El archivo de gramática está vacío")
-            
+
         self._lark = Lark(grammar, start="start")
 
     def _tokens_to_source(self) -> str:
         """
         Convierte la lista de tokens a una cadena de texto.
-        
+
         Returns:
             str: Cadena de texto representando los tokens
         """
@@ -54,10 +62,10 @@ class LarkParser:
     def parsear(self) -> Optional[object]:
         """
         Realiza el parsing de los tokens.
-        
+
         Returns:
             Optional[object]: Árbol de parsing resultante o None si hay error
-            
+
         Raises:
             ParseError: Si ocurre un error durante el parsing
         """

--- a/src/tests/unit/test_lark_parser_missing_grammar.py
+++ b/src/tests/unit/test_lark_parser_missing_grammar.py
@@ -1,0 +1,15 @@
+import pytest
+from cobra.parser.lark_parser import LarkParser
+
+
+def test_missing_grammar_file(monkeypatch):
+    """Verifica que se emita un mensaje claro si falta la gramática."""
+
+    def fake_open(*args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr("builtins.open", fake_open)
+
+    mensaje = "No se encuentra el archivo de gramática"
+    with pytest.raises(FileNotFoundError, match=mensaje):
+        LarkParser([])


### PR DESCRIPTION
## Resumen
- Manejo explícito de `ImportError` para `lark` con instrucción de instalación.
- Lectura de la gramática envuelta en `try/except` para entregar un mensaje claro ante archivos ausentes.
- Prueba unitaria que simula la ausencia de la gramática y verifica el mensaje.

## Testing
- `flake8 src/cobra/parser/lark_parser.py src/tests/unit/test_lark_parser_missing_grammar.py`
- `pytest --no-cov src/tests/unit/test_lark_parser_tokens.py src/tests/unit/test_lark_parser_missing_grammar.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f9c0bdb008327a5e50c3a1f3f0771