### PR TITLE
feat: usar ParserError personalizado

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ clave con un error tipográfico se mostrará una sugerencia automática. Ejemplo
 
 ```bash
 cobra> imprmir 1
-SyntaxError: Token inesperado. ¿Quiso decir 'imprimir'?
+ParserError: Token inesperado. ¿Quiso decir 'imprimir'?
 ```
 
 ## Uso desde la CLI

--- a/frontend/docs/sintaxis.rst
+++ b/frontend/docs/sintaxis.rst
@@ -9,7 +9,7 @@ var nombre = "Cobra"
 var numero = 10
 var año = 1  # Identificadores Unicode permitidos
 
-Los nombres de variables no pueden ser palabras reservadas como ``si`` o ``mientras``. Usarlas como identificador generará un ``SyntaxError``.
+Los nombres de variables no pueden ser palabras reservadas como ``si`` o ``mientras``. Usarlas como identificador generará un ``ParserError``.
 
 **2. Funciones**
 

--- a/src/cobra/cli/commands/compile_cmd.py
+++ b/src/cobra/cli/commands/compile_cmd.py
@@ -37,6 +37,7 @@ from core.semantic_validators import (
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.parser.parser import ParserError
 
 # Constantes de configuración
 MAX_PROCESSES = 4
@@ -210,7 +211,7 @@ class CompileCommand(BaseCommand):
             logging.error("Primitiva peligrosa: %s", pe)
             mostrar_error(str(pe))
             return 1
-        except SyntaxError as se:
+        except ParserError as se:
             logging.error("Error de sintaxis durante la transpilación: %s", se)
             mostrar_error(f"Error durante la transpilación: {se}")
             return 1

--- a/src/cobra/cli/commands/interactive_cmd.py
+++ b/src/cobra/cli/commands/interactive_cmd.py
@@ -6,7 +6,7 @@ from typing import Optional, Any, NoReturn
 from argparse import _SubParsersAction, ArgumentParser
 
 from cobra.lexico.lexer import Lexer, LexerError
-from cobra.parser.parser import Parser
+from cobra.parser.parser import Parser, ParserError
 from cobra.transpilers import module_map
 from core.interpreter import InterpretadorCobra
 from core.qualia_bridge import get_suggestions
@@ -19,13 +19,6 @@ from core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
-
-
-class ParserError(Exception):
-    """Excepción lanzada cuando ocurre un error durante el parsing."""
-    pass
-
-
 class InteractiveCommand(BaseCommand):
     """Modo interactivo del lenguaje Cobra.
     

--- a/src/lsp/cobra_plugin.py
+++ b/src/lsp/cobra_plugin.py
@@ -6,7 +6,7 @@ import re
 from pylsp import hookimpl, lsp
 from standard_library import __all__ as STD_FUNCS
 from cobra.lexico.lexer import Lexer, LexerError
-from cobra.parser.parser import Parser
+from cobra.parser.parser import Parser, ParserError
 from cli.commands.execute_cmd import ExecuteCommand
 
 # Palabras reservadas más comunes de Cobra
@@ -135,7 +135,7 @@ def pylsp_diagnostics(config, workspace, document, **_args):
                 "severity": lsp.DiagnosticSeverity.Error,
             }
         )
-    except SyntaxError as exc:
+    except ParserError as exc:
         token = parser.token_actual() if parser is not None else None
         line = getattr(token, "linea", 1) - 1 if token else 0
         col = getattr(token, "columna", 1) - 1 if token else 0

--- a/src/tests/unit/parser_error_handling.py
+++ b/src/tests/unit/parser_error_handling.py
@@ -1,6 +1,6 @@
 import pytest
 from cobra.lexico.lexer import Lexer
-from cobra.parser.parser import Parser
+from cobra.parser.parser import Parser, ParserError
 
 
 def parse_code(code: str) -> Parser:
@@ -10,17 +10,17 @@ def parse_code(code: str) -> Parser:
 
 def test_para_sin_dospuntos():
     codigo = "para i in range(0,5) imprimir(i)"
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         parse_code(codigo).parsear()
 
 
 def test_mientras_parentesis_sin_cerrar():
     codigo = "mientras (x < 3"
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         parse_code(codigo).parsear()
 
 
 def test_intentar_sin_capturar():
     codigo = "intentar: lanzar 1 fin"
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         parse_code(codigo).parsear()

--- a/src/tests/unit/parser_recursion_types.py
+++ b/src/tests/unit/parser_recursion_types.py
@@ -1,6 +1,6 @@
 import pytest
 from cobra.lexico.lexer import Lexer
-from cobra.parser.parser import Parser
+from cobra.parser.parser import Parser, ParserError
 from core.ast_nodes import NodoFuncion, NodoAsignacion
 
 
@@ -35,5 +35,5 @@ def test_error_lista_no_soportada():
     tokens = Lexer(codigo).analizar_token()
     parser = Parser(tokens)
 
-    with pytest.raises(SyntaxError, match="LBRACKET"):
+    with pytest.raises(ParserError, match="LBRACKET"):
         parser.parsear()

--- a/src/tests/unit/test_error_handling.py
+++ b/src/tests/unit/test_error_handling.py
@@ -1,6 +1,6 @@
 import pytest
 from cobra.lexico.lexer import Lexer
-from cobra.parser.parser import Parser
+from cobra.parser.parser import Parser, ParserError
 
 
 def parsear_codigo(codigo: str):
@@ -10,11 +10,11 @@ def parsear_codigo(codigo: str):
 
 def test_asignacion_sin_identificador():
     codigo = "var = 5"
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         parsear_codigo(codigo).parsear()
 
 
 def test_condicional_sin_dospuntos():
     codigo = "si x > 0 imprimir(x) fin"
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         parsear_codigo(codigo).parsear()

--- a/src/tests/unit/test_parser4.py
+++ b/src/tests/unit/test_parser4.py
@@ -2,8 +2,7 @@ import pytest
 
 from cobra.lexico.lexer import Token, TipoToken
 from core.ast_nodes import NodoAsignacion, NodoCondicional, NodoFuncion, NodoRetorno, NodoBucleMientras, NodoValor
-from cobra.parser.parser import Parser
-from cobra.parser.parser import Parser
+from cobra.parser.parser import Parser, ParserError
 
 
 def test_parser_asignacion():
@@ -159,7 +158,7 @@ def test_parser_errores():
     ]
     parser = Parser(tokens)
 
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         parser.parsear()
 
 

--- a/src/tests/unit/test_parser_del_global.py
+++ b/src/tests/unit/test_parser_del_global.py
@@ -10,7 +10,7 @@ sys.modules.setdefault("backend.src.core.visitor", _vis)
 sys.modules.setdefault("backend.src.core", sys.modules.get("core"))
 
 from cobra.lexico.lexer import Lexer
-from cobra.parser.parser import Parser
+from cobra.parser.parser import Parser, ParserError
 from core.ast_nodes import (
     NodoDel,
     NodoGlobal,
@@ -80,15 +80,15 @@ def test_transpilar_with():
 
 
 def test_parser_del_sin_expresion():
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         Parser(Lexer("eliminar").analizar_token()).parsear()
 
 
 def test_parser_global_sin_identificadores():
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         Parser(Lexer("global").analizar_token()).parsear()
 
 
 def test_parser_con_sin_fin():
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         Parser(Lexer("con x:").analizar_token()).parsear()

--- a/src/tests/unit/test_parser_error_reporting.py
+++ b/src/tests/unit/test_parser_error_reporting.py
@@ -1,6 +1,6 @@
 import pytest
 from cobra.lexico.lexer import Token, TipoToken
-from cobra.parser.parser import Parser
+from cobra.parser.parser import Parser, ParserError
 
 
 def test_error_en_declaracion_para():
@@ -13,7 +13,7 @@ def test_error_en_declaracion_para():
         Token(TipoToken.EOF, None),
     ]
     parser = Parser(tokens)
-    with pytest.raises(SyntaxError) as excinfo:
+    with pytest.raises(ParserError) as excinfo:
         parser.parsear()
     mensaje = str(excinfo.value)
     assert "Se esperaba ':' después del iterable en 'para'" in mensaje
@@ -34,7 +34,7 @@ def test_error_en_declaracion_condicional():
         Token(TipoToken.EOF, None),
     ]
     parser = Parser(tokens)
-    with pytest.raises(SyntaxError) as excinfo:
+    with pytest.raises(ParserError) as excinfo:
         parser.parsear()
     mensaje = str(excinfo.value)
     assert "Se esperaba ':' después de la condición del 'si'" in mensaje
@@ -51,7 +51,7 @@ def test_error_en_declaracion_mientras():
         Token(TipoToken.EOF, None),
     ]
     parser = Parser(tokens)
-    with pytest.raises(SyntaxError) as excinfo:
+    with pytest.raises(ParserError) as excinfo:
         parser.parsear()
     mensaje = str(excinfo.value)
     assert "Se esperaba 'fin' para cerrar el bucle 'mientras'" in mensaje

--- a/src/tests/unit/test_parser_errors_extra.py
+++ b/src/tests/unit/test_parser_errors_extra.py
@@ -1,6 +1,6 @@
 import pytest
 from cobra.lexico.lexer import Lexer
-from cobra.parser.parser import Parser
+from cobra.parser.parser import Parser, ParserError
 
 
 def parse(code: str):
@@ -10,19 +10,19 @@ def parse(code: str):
 
 def test_decorator_without_function():
     codigo = "@d var x = 1"
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         parse(codigo).parsear()
 
 
 def test_desde_without_import():
     codigo = "desde 'm' x"
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         parse(codigo).parsear()
 
 
 def test_unclosed_macro():
     codigo = "macro m { var x = 1 "
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         parse(codigo).parsear()
 
 def test_condicional_sino_sin_fin():
@@ -32,11 +32,11 @@ def test_condicional_sino_sin_fin():
     sino:
         imprimir(x)
     """
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         parse(codigo).parsear()
 
 
 def test_macro_llaves_desbalanceadas():
     codigo = "macro m { var x = 1 }}"
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         parse(codigo).parsear()

--- a/src/tests/unit/test_parser_holobit.py
+++ b/src/tests/unit/test_parser_holobit.py
@@ -1,5 +1,5 @@
 from cobra.lexico.lexer import Token, TipoToken
-from cobra.parser.parser import Parser
+from cobra.parser.parser import Parser, ParserError
 from core.ast_nodes import NodoHolobit
 import pytest
 
@@ -43,6 +43,6 @@ def test_parser_holobit_invalido():
     ]
 
     parser = Parser(tokens)
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ParserError):
         parser.parsear()
 

--- a/src/tests/unit/test_parser_sugerencias.py
+++ b/src/tests/unit/test_parser_sugerencias.py
@@ -1,12 +1,12 @@
 import pytest
 from cobra.lexico.lexer import Lexer
-from cobra.parser.parser import Parser
+from cobra.parser.parser import Parser, ParserError
 
 
 def test_sugerencia_palabra_clave():
     codigo = "imprmir 1"
     tokens = Lexer(codigo).analizar_token()
     parser = Parser(tokens)
-    with pytest.raises(SyntaxError, match="¿Quiso decir 'imprimir'?"):
+    with pytest.raises(ParserError, match="¿Quiso decir 'imprimir'?"):
         parser.parsear()
 

--- a/src/tests/unit/test_reserved_identifiers.py
+++ b/src/tests/unit/test_reserved_identifiers.py
@@ -1,13 +1,13 @@
 import pytest
 from cobra.lexico.lexer import Lexer
-from cobra.parser.parser import Parser
+from cobra.parser.parser import Parser, ParserError
 
 
 def test_variable_nombre_reservado():
     codigo = "var si = 1"
     tokens = Lexer(codigo).analizar_token()
     parser = Parser(tokens)
-    with pytest.raises(SyntaxError, match="palabra reservada"):
+    with pytest.raises(ParserError, match="palabra reservada"):
         parser.parsear()
 
 
@@ -18,7 +18,7 @@ def test_funcion_nombre_reservado():
     """
     tokens = Lexer(codigo).analizar_token()
     parser = Parser(tokens)
-    with pytest.raises(SyntaxError, match="palabra reservada"):
+    with pytest.raises(ParserError, match="palabra reservada"):
         parser.parsear()
 
 
@@ -29,5 +29,5 @@ def test_parametro_nombre_reservado():
     """
     tokens = Lexer(codigo).analizar_token()
     parser = Parser(tokens)
-    with pytest.raises(SyntaxError, match="palabra reservada"):
+    with pytest.raises(ParserError, match="palabra reservada"):
         parser.parsear()


### PR DESCRIPTION
## Summary
- reemplaza `SyntaxError` por `ParserError` en el parser
- ajusta CLI, LSP, documentación y pruebas para la nueva excepción

## Testing
- `pytest` *(falla: ModuleNotFoundError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_688f9e8e2b5c8327a9331d1d7f04c846