### PR TITLE
feat(reverse): add js and java tree-sitter transpilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,15 @@ cobra transpilar-inverso script.py --origen=python --destino=cobra
 El proceso intenta mapear instrucciones básicas, pero características muy específicas pueden requerir ajustes manuales.
 Actualmente la cobertura varía según el lenguaje y puede que ciertas construcciones no estén implementadas.
 
+### Dependencias de tree-sitter
+
+Varios transpiladores inversos están basados en
+[tree-sitter](https://tree-sitter.github.io/tree-sitter/). Para que funcionen es
+necesario disponer de los paquetes `tree-sitter` y
+`tree-sitter-languages`, incluidos en `requirements.txt`. Asegúrate de que estas
+dependencias estén instaladas antes de transpilar código desde lenguajes como
+JavaScript o Java.
+
 ### Diseño extensible de la CLI
 
 La CLI está organizada en clases dentro de `src/cli/commands`. Cada subcomando

--- a/src/cobra/transpilers/reverse/from_java.py
+++ b/src/cobra/transpilers/reverse/from_java.py
@@ -1,24 +1,130 @@
 # -*- coding: utf-8 -*-
 """Transpilador inverso desde Java a Cobra usando tree-sitter."""
-from typing import Any, List
+from typing import List
 
+from tree_sitter import Node
+
+from cobra.lexico.lexer import Token, TipoToken
 from core.ast_nodes import (
     NodoClase,
-    NodoFuncion,
+    NodoMetodo,
+    NodoBucleMientras,
+    NodoOperacionBinaria,
     NodoIdentificador,
-    NodoMetodo
+    NodoRetorno,
+    NodoValor,
+    NodoCondicional,
 )
-from .tree_sitter_base import TreeSitterReverseTranspiler
+
+from .tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
 
 
 class ReverseFromJava(TreeSitterReverseTranspiler):
-    """Transpilador inverso de Java a Cobra usando tree-sitter.
-    
-    Este transpilador convierte código fuente Java en nodos AST de Cobra,
-    manteniendo la semántica del código original.
-    
-    Attributes:
-        LANGUAGE (str): Identificador del lenguaje para tree-sitter
-    """
-    
+    """Transpilador inverso de Java a Cobra usando tree-sitter."""
+
     LANGUAGE: str = "java"
+
+    OPERADORES = {
+        "+": Token(TipoToken.SUMA, "+"),
+        "-": Token(TipoToken.RESTA, "-"),
+        "*": Token(TipoToken.MULT, "*"),
+        "/": Token(TipoToken.DIV, "/"),
+        "==": Token(TipoToken.IGUAL, "=="),
+        "!=": Token(TipoToken.DIFERENTE, "!="),
+        "<": Token(TipoToken.MENORQUE, "<"),
+        ">": Token(TipoToken.MAYORQUE, ">"),
+        "<=": Token(TipoToken.MENORIGUAL, "<="),
+        ">=": Token(TipoToken.MAYORIGUAL, ">="),
+    }
+
+    # ------------------------------------------------------------------
+    def visit_class_declaration(self, node: Node) -> NodoClase:
+        """Convierte una declaración de clase."""
+        nombre_n = node.child_by_field_name("name")
+        body_n = node.child_by_field_name("body")
+        nombre = TreeSitterNode(nombre_n).get_text() if nombre_n else ""
+        metodos = [
+            self.visit(c)
+            for c in body_n.children
+            if c.is_named
+        ] if body_n else []
+        return NodoClase(nombre, metodos)
+
+    def visit_method_declaration(self, node: Node) -> NodoMetodo:
+        """Convierte una declaración de método."""
+        nombre_n = node.child_by_field_name("name")
+        params_n = node.child_by_field_name("parameters")
+        body_n = node.child_by_field_name("body")
+
+        nombre = TreeSitterNode(nombre_n).get_text() if nombre_n else ""
+        params = [
+            TreeSitterNode(c).get_text()
+            for c in params_n.children
+            if c.type == "identifier"
+        ] if params_n else []
+
+        cuerpo = [
+            self.visit(c)
+            for c in body_n.children
+            if c.is_named
+        ] if body_n else []
+        return NodoMetodo(nombre, params, cuerpo)
+
+    # ------------------------------------------------------------------
+    # Bucles
+    def visit_while_statement(self, node: Node) -> NodoBucleMientras:
+        """Convierte un bucle while."""
+        cond = self.visit(node.child_by_field_name("condition"))
+        body_n = node.child_by_field_name("body")
+        cuerpo = [
+            self.visit(c)
+            for c in body_n.children
+            if c.is_named
+        ] if body_n else []
+        return NodoBucleMientras(cond, cuerpo)
+
+    def visit_for_statement(self, node: Node) -> NodoBucleMientras:
+        """Convierte un bucle for en un mientras simplificado."""
+        cond = self.visit(node.child_by_field_name("condition"))
+        body_n = node.child_by_field_name("body")
+        cuerpo = [
+            self.visit(c)
+            for c in body_n.children
+            if c.is_named
+        ] if body_n else []
+        return NodoBucleMientras(cond, cuerpo)
+
+    # ------------------------------------------------------------------
+    # Expresiones
+    def visit_binary_expression(self, node: Node) -> NodoOperacionBinaria:
+        """Convierte una expresión binaria."""
+        izquierda = self.visit(node.child_by_field_name("left"))
+        derecha = self.visit(node.child_by_field_name("right"))
+        operador_txt = TreeSitterNode(node.children[1]).get_text()
+        token = self.OPERADORES.get(operador_txt, Token(TipoToken.DIFERENTE, operador_txt))
+        return NodoOperacionBinaria(izquierda, token, derecha)
+
+    def visit_condition(self, node: Node):
+        """Procesa un nodo condición envolviendo una expresión."""
+        expr = next((c for c in node.children if c.is_named), None)
+        return self.visit(expr) if expr else None
+
+    def visit_parenthesized_expression(self, node: Node):
+        """Elimina paréntesis de la expresión contenida."""
+        expr = next((c for c in node.children if c.is_named), None)
+        return self.visit(expr) if expr else None
+
+    def visit_identifier(self, node: Node) -> NodoIdentificador:  # type: ignore[override]
+        return super().visit_identifier(node)
+
+    def visit_number(self, node: Node) -> NodoValor:  # type: ignore[override]
+        return super().visit_number(node)
+
+    def visit_string(self, node: Node) -> NodoValor:  # type: ignore[override]
+        return super().visit_string(node)
+
+    def visit_return_statement(self, node: Node) -> NodoRetorno:  # type: ignore[override]
+        return super().visit_return_statement(node)
+
+    def visit_if_statement(self, node: Node) -> NodoCondicional:  # type: ignore[override]
+        return super().visit_if_statement(node)

--- a/src/cobra/transpilers/reverse/from_js.py
+++ b/src/cobra/transpilers/reverse/from_js.py
@@ -9,25 +9,150 @@ Ejemplos:
     >>> transpiler = ReverseFromJS()
     >>> ast = transpiler.generate_ast("function main() { return 0; }")
 """
-from typing import Any, List
+from typing import List
 
+from tree_sitter import Node
+
+from cobra.lexico.lexer import Token, TipoToken
 from core.ast_nodes import (
-    NodoBloque,
+    NodoClase,
     NodoFuncion,
+    NodoMetodo,
+    NodoBucleMientras,
+    NodoOperacionBinaria,
     NodoIdentificador,
     NodoRetorno,
-    NodoValor
+    NodoValor,
 )
-from .tree_sitter_base import TreeSitterReverseTranspiler
+
+from .tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
+
 
 class ReverseFromJS(TreeSitterReverseTranspiler):
-    """Transpilador inverso de JavaScript a Cobra usando tree-sitter.
-    
-    Este transpilador convierte código fuente JavaScript en nodos AST de Cobra,
-    manteniendo la semántica del código original.
-    
-    Attributes:
-        LANGUAGE (str): Identificador del lenguaje para tree-sitter
-    """
-    
+    """Transpilador inverso de JavaScript a Cobra usando tree-sitter."""
+
     LANGUAGE = "javascript"
+
+    OPERADORES = {
+        "+": Token(TipoToken.SUMA, "+"),
+        "-": Token(TipoToken.RESTA, "-"),
+        "*": Token(TipoToken.MULT, "*"),
+        "/": Token(TipoToken.DIV, "/"),
+        "==": Token(TipoToken.IGUAL, "=="),
+        "!=": Token(TipoToken.DIFERENTE, "!="),
+        "<": Token(TipoToken.MENORQUE, "<"),
+        ">": Token(TipoToken.MAYORQUE, ">"),
+        "<=": Token(TipoToken.MENORIGUAL, "<="),
+        ">=": Token(TipoToken.MAYORIGUAL, ">="),
+    }
+
+    # ------------------------------------------------------------------
+    # Definiciones
+    def visit_function_declaration(self, node: Node) -> NodoFuncion:
+        """Convierte una declaración de función."""
+        nombre_n = node.child_by_field_name("name")
+        params_n = node.child_by_field_name("parameters")
+        body_n = node.child_by_field_name("body")
+
+        nombre = TreeSitterNode(nombre_n).get_text() if nombre_n else ""
+        params = [
+            TreeSitterNode(c).get_text()
+            for c in params_n.children
+            if c.type == "identifier"
+        ] if params_n else []
+
+        cuerpo = [
+            self.visit(c)
+            for c in body_n.children
+            if c.is_named
+        ] if body_n else []
+
+        return NodoFuncion(nombre, params, cuerpo)
+
+    def visit_class_declaration(self, node: Node) -> NodoClase:
+        """Convierte una declaración de clase."""
+        nombre_n = node.child_by_field_name("name")
+        body_n = node.child_by_field_name("body")
+
+        nombre = TreeSitterNode(nombre_n).get_text() if nombre_n else ""
+        metodos = [
+            self.visit(c)
+            for c in body_n.children
+            if c.is_named
+        ] if body_n else []
+
+        return NodoClase(nombre, metodos)
+
+    def visit_method_definition(self, node: Node) -> NodoMetodo:
+        """Convierte una definición de método."""
+        nombre_n = node.child_by_field_name("name")
+        params_n = node.child_by_field_name("parameters")
+        body_n = node.child_by_field_name("body")
+
+        nombre = TreeSitterNode(nombre_n).get_text() if nombre_n else ""
+        params = [
+            TreeSitterNode(c).get_text()
+            for c in params_n.children
+            if c.type == "identifier"
+        ] if params_n else []
+
+        cuerpo = [
+            self.visit(c)
+            for c in body_n.children
+            if c.is_named
+        ] if body_n else []
+
+        return NodoMetodo(nombre, params, cuerpo)
+
+    # ------------------------------------------------------------------
+    # Bucles
+    def visit_while_statement(self, node: Node) -> NodoBucleMientras:
+        """Convierte un bucle while."""
+        cond = self.visit(node.child_by_field_name("condition"))
+        body_n = node.child_by_field_name("body")
+        cuerpo = [
+            self.visit(c)
+            for c in body_n.children
+            if c.is_named
+        ] if body_n else []
+        return NodoBucleMientras(cond, cuerpo)
+
+    def visit_for_statement(self, node: Node) -> NodoBucleMientras:
+        """Convierte un bucle for en un mientras simplificado."""
+        cond = self.visit(node.child_by_field_name("condition"))
+        body_n = node.child_by_field_name("body")
+        cuerpo = [
+            self.visit(c)
+            for c in body_n.children
+            if c.is_named
+        ] if body_n else []
+        return NodoBucleMientras(cond, cuerpo)
+
+    # ------------------------------------------------------------------
+    # Expresiones
+    def visit_binary_expression(self, node: Node) -> NodoOperacionBinaria:
+        """Convierte una expresión binaria."""
+        izquierda = self.visit(node.children[0])
+        derecha = self.visit(node.children[2])
+        operador_txt = TreeSitterNode(node.children[1]).get_text()
+        token = self.OPERADORES.get(operador_txt, Token(TipoToken.DIFERENTE, operador_txt))
+        return NodoOperacionBinaria(izquierda, token, derecha)
+
+    def visit_parenthesized_expression(self, node: Node) -> NodoValor:
+        """Elimina paréntesis de una expresión."""
+        expr = next((c for c in node.children if c.is_named), None)
+        return self.visit(expr) if expr else NodoValor(None)
+
+    def visit_return_statement(self, node: Node) -> NodoRetorno:  # type: ignore[override]
+        """Convierte un return de JavaScript."""
+        expr = next((c for c in node.children if c.is_named), None)
+        return NodoRetorno(self.visit(expr) if expr else NodoValor(None))
+
+    def visit_identifier(self, node: Node) -> NodoIdentificador:  # type: ignore[override]
+        return super().visit_identifier(node)
+
+    def visit_number(self, node: Node) -> NodoValor:  # type: ignore[override]
+        return super().visit_number(node)
+
+    def visit_string(self, node: Node) -> NodoValor:  # type: ignore[override]
+        return super().visit_string(node)

--- a/src/cobra/transpilers/reverse/tree_sitter_base.py
+++ b/src/cobra/transpilers/reverse/tree_sitter_base.py
@@ -5,7 +5,13 @@ from typing import Any, List, Optional, Union
 import logging
 from dataclasses import dataclass
 from tree_sitter import Node, Tree
-from tree_sitter_languages import get_parser, TreeSitterError
+from tree_sitter_languages import get_parser
+try:  # Compatibilidad con versiones antiguas
+    from tree_sitter_languages import TreeSitterLanguageError as TreeSitterError  # type: ignore
+except Exception:  # pragma: no cover - dependencia opcional
+    class TreeSitterError(Exception):
+        """Excepción genérica para errores de tree-sitter."""
+        pass
 
 from cobra.transpilers.reverse.base import BaseReverseTranspiler
 from core.ast_nodes import (
@@ -55,7 +61,7 @@ class TreeSitterReverseTranspiler(BaseReverseTranspiler):
             raise ValueError("LANGUAGE debe definirse en la subclase")
         try:
             self.parser = get_parser(self.LANGUAGE)
-        except TreeSitterError as exc:
+        except Exception as exc:
             raise NotImplementedError(
                 f"No hay gramática tree-sitter para {self.LANGUAGE}"
             ) from exc

--- a/src/tests/integration/reverse/test_from_java.py
+++ b/src/tests/integration/reverse/test_from_java.py
@@ -1,0 +1,30 @@
+import pytest
+
+from cobra.transpilers.reverse.from_java import ReverseFromJava
+from core.ast_nodes import (
+    NodoClase,
+    NodoMetodo,
+    NodoBucleMientras,
+    NodoCondicional,
+    NodoOperacionBinaria,
+)
+
+
+def test_reverse_from_java_constructs():
+    code = """
+    class Main {
+        int test(int a, int b) {
+            while (a < b) { a = b; }
+            if (a > b) { return a; } else { return b; }
+        }
+    }
+    """
+    transpiler = ReverseFromJava()
+    ast_nodes = transpiler.generate_ast(code)
+
+    clase = next(n for n in ast_nodes if isinstance(n, NodoClase))
+    metodo = next(m for m in clase.metodos if isinstance(m, NodoMetodo))
+
+    assert any(isinstance(n, NodoBucleMientras) for n in metodo.cuerpo)
+    cond = next(n for n in metodo.cuerpo if isinstance(n, NodoCondicional))
+    assert isinstance(cond.condicion, NodoOperacionBinaria)

--- a/src/tests/integration/reverse/test_from_js.py
+++ b/src/tests/integration/reverse/test_from_js.py
@@ -1,0 +1,27 @@
+import pytest
+
+from cobra.transpilers.reverse.from_js import ReverseFromJS
+from core.ast_nodes import (
+    NodoFuncion,
+    NodoClase,
+    NodoBucleMientras,
+    NodoOperacionBinaria,
+)
+
+
+def test_reverse_from_js_constructs():
+    code = """
+    function add(a, b) { return a + b; }
+    class Greeter { greet() { return a; } }
+    while (a < b) { a = b; }
+    for (; a < b;) { a = b; }
+    """
+    transpiler = ReverseFromJS()
+    ast_nodes = transpiler.generate_ast(code)
+
+    assert any(isinstance(n, NodoFuncion) for n in ast_nodes)
+    assert any(isinstance(n, NodoClase) for n in ast_nodes)
+    loops = [n for n in ast_nodes if isinstance(n, NodoBucleMientras)]
+    assert len(loops) == 2
+    func = next(n for n in ast_nodes if isinstance(n, NodoFuncion))
+    assert isinstance(func.cuerpo[0].expresion, NodoOperacionBinaria)


### PR DESCRIPTION
## Summary
- implement tree-sitter reverse transpilers for JavaScript and Java
- document tree-sitter dependency requirements
- add integration tests for JavaScript and Java reverse transpilers

## Testing
- `pytest src/tests/integration/reverse/test_from_js.py src/tests/integration/reverse/test_from_java.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6890e2aae7888327ab63aa945cbb3591