### PR TITLE
feat(gui): add transpiler selection UI

### DIFF
--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -7,6 +7,7 @@ import flet as ft
 from cobra.lexico.lexer import Lexer
 from cobra.parser.parser import Parser
 from core.interpreter import InterpretadorCobra
+from cobra.cli.commands.compile_cmd import TRANSPILERS
 
 
 def _ejecutar_codigo(codigo: str) -> str:
@@ -23,18 +24,34 @@ def _ejecutar_codigo(codigo: str) -> str:
     return buffer.getvalue()
 
 
+def _transpilar_codigo(codigo: str, lang: str) -> str:
+    """Transpila código Cobra al lenguaje especificado."""
+    tokens = Lexer(codigo).tokenizar()
+    ast = Parser(tokens).parsear()
+    transp = TRANSPILERS[lang]()
+    return transp.generate_code(ast)
+
+
 def main(page: ft.Page):
     """Función principal para Flet."""
 
     entrada = ft.TextField(multiline=True, expand=True)
     salida = ft.Text(value="", selectable=True)
+    lenguajes = sorted(TRANSPILERS.keys())
+    selector = ft.Dropdown(options=[ft.dropdown.Option(lang) for lang in lenguajes])
+    activar = ft.Switch(label="Transpilar")
 
     def ejecutar_handler(e):
-        salida.value = _ejecutar_codigo(entrada.value)
+        if activar.value and selector.value in TRANSPILERS:
+            salida.value = _transpilar_codigo(entrada.value, selector.value)
+        else:
+            salida.value = _ejecutar_codigo(entrada.value)
         page.update()
 
     page.add(
         entrada,
+        selector,
+        activar,
         ft.ElevatedButton("Ejecutar", on_click=ejecutar_handler),
         salida,
     )

--- a/src/gui/idle.py
+++ b/src/gui/idle.py
@@ -7,6 +7,7 @@ import flet as ft
 from cobra.lexico.lexer import Lexer
 from cobra.parser.parser import Parser
 from core.interpreter import InterpretadorCobra
+from cobra.cli.commands.compile_cmd import TRANSPILERS
 
 
 def _ejecutar_codigo(codigo: str) -> str:
@@ -34,14 +35,28 @@ def _mostrar_ast(codigo: str) -> str:
     return str(ast)
 
 
+def _transpilar_codigo(codigo: str, lang: str) -> str:
+    """Transpila código Cobra al lenguaje especificado."""
+    tokens = Lexer(codigo).tokenizar()
+    ast = Parser(tokens).parsear()
+    transp = TRANSPILERS[lang]()
+    return transp.generate_code(ast)
+
+
 def main(page: ft.Page):
     """Función principal para el entorno IDLE."""
 
     entrada = ft.TextField(multiline=True, expand=True)
     salida = ft.Text(value="", selectable=True)
+    lenguajes = sorted(TRANSPILERS.keys())
+    selector = ft.Dropdown(options=[ft.dropdown.Option(lang) for lang in lenguajes])
+    activar = ft.Switch(label="Transpilar")
 
     def ejecutar_handler(e):
-        salida.value = _ejecutar_codigo(entrada.value)
+        if activar.value and selector.value in TRANSPILERS:
+            salida.value = _transpilar_codigo(entrada.value, selector.value)
+        else:
+            salida.value = _ejecutar_codigo(entrada.value)
         page.update()
 
     def tokens_handler(e):
@@ -54,6 +69,8 @@ def main(page: ft.Page):
 
     page.add(
         entrada,
+        selector,
+        activar,
         ft.ElevatedButton("Ejecutar", on_click=ejecutar_handler),
         ft.ElevatedButton("Tokens", on_click=tokens_handler),
         ft.ElevatedButton("AST", on_click=ast_handler),

--- a/src/tests/unit/test_gui_menu.py
+++ b/src/tests/unit/test_gui_menu.py
@@ -1,0 +1,104 @@
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _fake_flet():
+    class TextField:
+        def __init__(self, **kwargs):
+            self.value = ""
+
+    class Text:
+        def __init__(self, value="", **kwargs):
+            self.value = value
+
+    class Dropdown:
+        def __init__(self, options=None, **kwargs):
+            self.options = options or []
+            self.value = None
+
+    class Switch:
+        def __init__(self, **kwargs):
+            self.value = False
+
+    class ElevatedButton:
+        def __init__(self, text, on_click=None):
+            self.text = text
+            self.on_click = on_click
+
+    class Page:
+        def __init__(self):
+            self.controls = []
+
+        def add(self, *args):
+            self.controls.extend(args)
+
+        def update(self):
+            pass
+
+    return SimpleNamespace(
+        TextField=TextField,
+        Text=Text,
+        Dropdown=Dropdown,
+        Switch=Switch,
+        ElevatedButton=ElevatedButton,
+        Page=Page,
+        dropdown=SimpleNamespace(Option=lambda v: v),
+    )
+
+
+def _prepare_module(monkeypatch, module_name):
+    fake_ft = _fake_flet()
+    dummy_compile = SimpleNamespace(TRANSPILERS={"py": object()})
+    monkeypatch.setitem(sys.modules, "flet", fake_ft)
+    monkeypatch.setitem(sys.modules, "cobra.cli.commands.compile_cmd", dummy_compile)
+    module = importlib.import_module(module_name)
+    importlib.reload(module)
+    return module, fake_ft
+
+
+def _prepare_transpiler(monkeypatch, module):
+    inst = MagicMock()
+    cls = MagicMock(return_value=inst)
+    monkeypatch.setattr(module, "TRANSPILERS", {"py": cls})
+    lexer_inst = MagicMock()
+    parser_inst = MagicMock()
+    lexer_inst.tokenizar.return_value = "TOK"
+    parser_inst.parsear.return_value = "AST"
+    monkeypatch.setattr(module, "Lexer", MagicMock(return_value=lexer_inst))
+    monkeypatch.setattr(module, "Parser", MagicMock(return_value=parser_inst))
+    return cls, inst
+
+
+def _run_handler(ft, page, text):
+    entrada = next(c for c in page.controls if isinstance(c, ft.TextField))
+    selector = next(c for c in page.controls if isinstance(c, ft.Dropdown))
+    switch = next(c for c in page.controls if isinstance(c, ft.Switch))
+    boton = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Ejecutar"
+    )
+    entrada.value = text
+    selector.value = "py"
+    switch.value = True
+    boton.on_click(None)
+
+
+def test_app_transpiler_invocado(monkeypatch):
+    module, ft = _prepare_module(monkeypatch, "gui.app")
+    _, inst = _prepare_transpiler(monkeypatch, module)
+    page = ft.Page()
+    module.main(page)
+    _run_handler(ft, page, "print(1)")
+    inst.generate_code.assert_called_once_with("AST")
+
+
+def test_idle_transpiler_invocado(monkeypatch):
+    module, ft = _prepare_module(monkeypatch, "gui.idle")
+    _, inst = _prepare_transpiler(monkeypatch, module)
+    page = ft.Page()
+    module.main(page)
+    _run_handler(ft, page, "print(1)")
+    inst.generate_code.assert_called_once_with("AST")


### PR DESCRIPTION
## Summary
- add language dropdown and transpile switch to GUI and IDLE
- invoke selected transpiler when enabled
- cover GUI menu with Flet mocks

## Testing
- `flake8 src/gui/app.py src/gui/idle.py src/tests/unit/test_gui_menu.py`
- `pytest src/tests/unit/test_gui_menu.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68915ec257148327989d36539ad20775