### PR TITLE
docs: add new languages and CLI examples

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -143,6 +143,28 @@ arbol = parser.parsear()
 print(TranspiladorPython().generate_code(arbol))
 ```
 
+### Guías rápidas de transpilación entre lenguajes
+
+Convierte programas entre distintos lenguajes usando la CLI:
+
+- **De Cobra a C**
+
+  ```bash
+  cobra compilar hola.co --tipo c
+  ```
+
+- **De Python a JavaScript**
+
+  ```bash
+  cobra transpilar-inverso ejemplo.py --origen=python --destino=js
+  ```
+
+- **De COBOL a Python**
+
+  ```bash
+  cobra transpilar-inverso reporte.cob --origen=cobol --destino=python
+  ```
+
 ### Características aún no soportadas
 
 Herencia múltiple en clases.

--- a/README.md
+++ b/README.md
@@ -744,17 +744,19 @@ convertirlo al AST de Cobra y luego generarlo en cualquier backend soportado.
 cobra transpilar-inverso script.py --origen=python --destino=cobra
 ```
 
-El proceso intenta mapear instrucciones básicas, pero características muy específicas pueden requerir ajustes manuales.
-Actualmente la cobertura varía según el lenguaje y puede que ciertas construcciones no estén implementadas.
+El proceso intenta mapear instrucciones básicas, pero características muy específicas pueden requerir ajustes manuales. Actualmente la cobertura varía según el lenguaje y puede que ciertas construcciones no estén implementadas.
 
-### Dependencias de tree-sitter
+Actualmente es posible convertir a Cobra código escrito en ensamblador, C, C++, COBOL, Fortran, Go, Java, JavaScript, Julia, Kotlin, LaTeX, Matlab, Mojo, Pascal, Perl, PHP, Python, R, Ruby, Rust, Swift, VisualBasic y WebAssembly.
 
-Varios transpiladores inversos están basados en
-[tree-sitter](https://tree-sitter.github.io/tree-sitter/). Para que funcionen es
-necesario disponer de los paquetes `tree-sitter` y
-`tree-sitter-languages`, incluidos en `requirements.txt`. Asegúrate de que estas
-dependencias estén instaladas antes de transpilar código desde lenguajes como
-JavaScript o Java.
+### Instalación de gramáticas
+
+Varios transpiladores inversos están basados en [tree-sitter](https://tree-sitter.github.io/tree-sitter/). Para que funcionen es necesario disponer de los paquetes `tree-sitter` y `tree-sitter-languages`. Instálalos con:
+
+```bash
+pip install tree-sitter-languages
+```
+
+Estas gramáticas también están listadas en `requirements.txt`, pero puedes instalarlas manualmente si deseas solo esta característica.
 
 ### Diseño extensible de la CLI
 

--- a/docs/lenguajes.rst
+++ b/docs/lenguajes.rst
@@ -68,12 +68,61 @@ Los siguientes lenguajes pueden convertirse a Cobra:
 
    * - Lenguaje
      - Estado
-   * - VisualBasic
-     - Experimental
-   * - Mojo
-     - Experimental
    * - Ensamblador
+     - Experimental
+   * - C
+     - Experimental
+   * - C++
      - Experimental
    * - COBOL
      - Experimental
+   * - Fortran
+     - Experimental
+   * - Go
+     - Experimental
+   * - Java
+     - Experimental
+   * - JavaScript
+     - Experimental
+   * - Julia
+     - Experimental
+   * - Kotlin
+     - Experimental
+   * - LaTeX
+     - Experimental
+   * - Matlab
+     - Experimental
+   * - Mojo
+     - Experimental
+   * - Pascal
+     - Experimental
+   * - Perl
+     - Experimental
+   * - PHP
+     - Experimental
+   * - Python
+     - Experimental
+   * - R
+     - Experimental
+   * - Ruby
+     - Experimental
+   * - Rust
+     - Experimental
+   * - Swift
+     - Experimental
+   * - VisualBasic
+     - Experimental
+   * - WebAssembly
+     - Experimental
+
+Instalación de gramáticas
+-------------------------
+
+Para habilitar estos transpiladores inversos es necesario instalar las gramáticas de `tree-sitter`:
+
+.. code-block:: bash
+
+   pip install tree-sitter-languages
+
+Este paquete incluye gramáticas para los lenguajes listados y puede instalarse junto con las dependencias del proyecto.
 

--- a/docs/lenguajes_soportados.rst
+++ b/docs/lenguajes_soportados.rst
@@ -68,12 +68,61 @@ Los siguientes lenguajes pueden convertirse a Cobra:
 
    * - Lenguaje
      - Estado
-   * - VisualBasic
-     - Experimental
-   * - Mojo
-     - Experimental
    * - Ensamblador
+     - Experimental
+   * - C
+     - Experimental
+   * - C++
      - Experimental
    * - COBOL
      - Experimental
+   * - Fortran
+     - Experimental
+   * - Go
+     - Experimental
+   * - Java
+     - Experimental
+   * - JavaScript
+     - Experimental
+   * - Julia
+     - Experimental
+   * - Kotlin
+     - Experimental
+   * - LaTeX
+     - Experimental
+   * - Matlab
+     - Experimental
+   * - Mojo
+     - Experimental
+   * - Pascal
+     - Experimental
+   * - Perl
+     - Experimental
+   * - PHP
+     - Experimental
+   * - Python
+     - Experimental
+   * - R
+     - Experimental
+   * - Ruby
+     - Experimental
+   * - Rust
+     - Experimental
+   * - Swift
+     - Experimental
+   * - VisualBasic
+     - Experimental
+   * - WebAssembly
+     - Experimental
+
+Instalación de gramáticas
+-------------------------
+
+Para habilitar estos transpiladores inversos es necesario instalar las gramáticas de `tree-sitter`:
+
+.. code-block:: bash
+
+   pip install tree-sitter-languages
+
+Este paquete incluye gramáticas para los lenguajes listados y puede instalarse junto con las dependencias del proyecto.
 

--- a/frontend/docs/avances.rst
+++ b/frontend/docs/avances.rst
@@ -7,6 +7,8 @@ Avances del lenguaje Cobra
 - **Gestión de memoria automatizada**: Cobra incluye un sistema de manejo de memoria optimizado que se ajusta automáticamente utilizando algoritmos genéticos.
 - **Transpilacion a otros lenguajes**: Se ha implementado un transpilador que convierte el codigo Cobra a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly.
 - **Pruebas unitarias**: Se han creado pruebas para validar el correcto funcionamiento del lexer y el parser.
+- **Menú interactivo en la CLI**: ``cobra menu`` guía paso a paso la transpilación entre lenguajes.
+- **Aplicación Flet**: ``cobra gui`` abre una interfaz gráfica ligera para escribir y ejecutar programas.
 
  - **Versión 10.0.6**: Actualización de la documentación y configuración del proyecto.
  - **Versión 10.0.6**: Se incorpora ``pcobra.toml`` para definir el mapeo de módulos.
@@ -62,4 +64,26 @@ función a exponer:
    # Suponiendo un crate en ``./mi_crate`` con la función `triple`
    triple = compilar_y_cargar_crate("mi_crate", "triple")
    print(triple(3))
+
+Menú interactivo y aplicación Flet
+----------------------------------
+
+Ejemplo del asistente de consola:
+
+.. code-block:: text
+
+   $ cobra menu
+   Lenguajes destino disponibles: python, js, c...
+   Lenguajes de origen disponibles: python, js, c...
+   ¿Desea transpilar? (s/n): s
+   ¿Transpilar desde Cobra a otro lenguaje? (s/n): n
+   Ruta al archivo origen: ejemplo.py
+   Lenguaje origen: python
+   Lenguaje destino: js
+
+Para abrir la interfaz gráfica ejecuta:
+
+.. code-block:: bash
+
+   cobra gui
 

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -60,6 +60,22 @@ Ejemplo:
 
    cobra
 
+Subcomando ``menu``
+-------------------
+Muestra un asistente en consola para guiar la transpilación entre lenguajes.
+
+Ejemplo:
+
+.. code-block:: text
+
+   $ cobra menu
+   Lenguajes destino disponibles: python, js, c...
+   Lenguajes de origen disponibles: python, js, c...
+   ¿Desea transpilar? (s/n): s
+   ¿Transpilar desde Cobra a otro lenguaje? (s/n): s
+   Ruta al archivo Cobra: hola.co
+   Lenguaje destino: python
+
 Subcomando ``modulos``
 ---------------------
 Gestiona módulos instalados.
@@ -173,6 +189,10 @@ Ejemplo:
 .. code-block:: bash
 
    cobra gui
+
+Al ejecutarlo se abre una ventana con un editor de texto y botones para
+ejecutar o limpiar el código. Es una forma rápida de probar programas
+sin usar la terminal.
 
 Subcomando ``plugins``
 ---------------------


### PR DESCRIPTION
## Summary
- document reverse transpiler languages and grammar installation
- add CLI menu and Flet GUI examples
- include quick transpilation guides in manual

## Testing
- `pip install pytest-cov`
- `PYTHONPATH=$PWD/src pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_689172c51ed88327a8aad6b13111a21b