### PR TITLE
feat: soporte básico para clases y namespaces de C++

### DIFF
--- a/src/cobra/transpilers/reverse/from_cpp.py
+++ b/src/cobra/transpilers/reverse/from_cpp.py
@@ -4,7 +4,7 @@
 from typing import Any, List
 
 import core.ast_nodes
-from .tree_sitter_base import TreeSitterReverseTranspiler
+from .tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
 
 
 class ReverseFromCPP(TreeSitterReverseTranspiler):
@@ -18,13 +18,67 @@ class ReverseFromCPP(TreeSitterReverseTranspiler):
     """
     
     LANGUAGE = "cpp"
-    
+    # ------------------------------------------------------------------
+    # Clases y namespaces
     def visit_class_definition(self, node: Any) -> core.ast_nodes.NodoClase:
         """Procesa una definición de clase C++."""
-        # TODO: Implementar
-        raise NotImplementedError
-        
+        nombre_n = node.child_by_field_name("name")
+        body_n = node.child_by_field_name("body")
+        nombre = TreeSitterNode(nombre_n).get_text() if nombre_n else ""
+
+        miembros: List[Any] = []
+        if body_n:
+            for child in body_n.children:
+                if child.is_named:
+                    miembros.append(self.visit(child))
+
+        return core.ast_nodes.NodoClase(nombre, miembros)
+
+    # Alias para el nodo de tree-sitter `class_specifier`
+    def visit_class_specifier(self, node: Any) -> core.ast_nodes.NodoClase:
+        return self.visit_class_definition(node)
+
+    def visit_field_declaration(self, node: Any) -> core.ast_nodes.NodoAsignacion:
+        """Convierte una declaración de campo en una asignación simple."""
+        declarator = node.child_by_field_name("declarator")
+        nombre = TreeSitterNode(declarator).get_text() if declarator else ""
+        return core.ast_nodes.NodoAsignacion(
+            nombre, core.ast_nodes.NodoValor(None)
+        )
+
+    def visit_function_definition(self, node: Any) -> core.ast_nodes.NodoMetodo:
+        """Procesa una definición de método dentro de una clase."""
+        if node.parent and node.parent.type == "field_declaration_list":
+            nombre_n = node.child_by_field_name("name")
+            params_n = node.child_by_field_name("parameters")
+            body_n = node.child_by_field_name("body")
+
+            nombre = TreeSitterNode(nombre_n).get_text() if nombre_n else ""
+            params = [
+                TreeSitterNode(c).get_text()
+                for c in params_n.children
+                if c.type == "identifier"
+            ] if params_n else []
+
+            cuerpo = [
+                self.visit(c)
+                for c in body_n.children
+                if c.is_named
+            ] if body_n else []
+
+            return core.ast_nodes.NodoMetodo(nombre, params, cuerpo)
+
+        return super().visit_function_definition(node)
+
     def visit_namespace_definition(self, node: Any) -> core.ast_nodes.NodoBloque:
         """Procesa una definición de namespace."""
-        # TODO: Implementar
-        raise NotImplementedError
+        body_n = node.child_by_field_name("body")
+        sentencias: List[Any] = []
+        if body_n:
+            for child in body_n.children:
+                if child.is_named:
+                    sentencias.append(self.visit(child))
+
+        bloque = core.ast_nodes.NodoBloque()
+        bloque.sentencias = sentencias
+        return bloque

--- a/src/tests/integration/reverse/test_from_cpp.py
+++ b/src/tests/integration/reverse/test_from_cpp.py
@@ -1,0 +1,26 @@
+import pytest
+
+from cobra.transpilers.reverse.from_cpp import ReverseFromCPP
+from core.ast_nodes import NodoClase, NodoMetodo, NodoAsignacion, NodoBloque
+
+
+def test_reverse_from_cpp_class_members():
+    code = """
+    class Persona { int edad; void saludar() {} };
+    """
+    transpiler = ReverseFromCPP()
+    ast_nodes = transpiler.generate_ast(code)
+    clase = next(n for n in ast_nodes if isinstance(n, NodoClase))
+    assert any(isinstance(m, NodoAsignacion) for m in clase.metodos)
+    assert any(isinstance(m, NodoMetodo) for m in clase.metodos)
+
+
+def test_reverse_from_cpp_namespace():
+    code = """
+    namespace N { class A {}; }
+    """
+    transpiler = ReverseFromCPP()
+    ast_nodes = transpiler.generate_ast(code)
+    bloque = next(n for n in ast_nodes if isinstance(n, NodoBloque))
+    assert any(isinstance(n, NodoClase) for n in getattr(bloque, 'sentencias', []))
+


### PR DESCRIPTION
## Resumen
- Convierte definiciones de clases C++ en `NodoClase` con métodos y campos
- Traduce namespaces a bloques anidados de Cobra
- Agrega pruebas de integración para clases y namespaces sencillos

## Pruebas
- `pytest src/tests/integration/reverse/test_from_cpp.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689189b5a5708327a44211bba9c56109