### PR TITLE
feat: add basic wasm reverse transpiler

### DIFF
--- a/docs/limitaciones_wasm_reverse.md
+++ b/docs/limitaciones_wasm_reverse.md
@@ -1,0 +1,8 @@
+# Limitaciones del transpílador inverso desde WASM
+
+El soporte actual para convertir código WebAssembly a Cobra es **experimental**.
+Solo se reconocen funciones que contengan asignaciones simples de constantes a
+variables locales mediante instrucciones `i32.const` seguidas de `local.set`.
+
+No se procesan estructuras de control, llamadas a funciones ni otros tipos de
+instrucciones. Esta funcionalidad se ampliará en el futuro.

--- a/src/cobra/transpilers/reverse/from_visualbasic_stub.py
+++ b/src/cobra/transpilers/reverse/from_visualbasic_stub.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde VisualBasic a Cobra (no soportado)."""
+from typing import List, Any
+from cobra.transpilers.reverse.base import BaseReverseTranspiler
+
+
+class ReverseFromVisualBasicStub(BaseReverseTranspiler):
+    """Transpilador inverso de VisualBasic a Cobra.
+
+    Esta clase actualmente no está implementada ya que no hay un parser
+    disponible para código VisualBasic.
+    """
+
+    def __init__(self) -> None:
+        """Inicializa el transpilador."""
+        super().__init__()
+
+    def generate_ast(self, code: str) -> List[Any]:
+        """Genera el AST Cobra desde código VisualBasic.
+
+        Args:
+            code: Código fuente en VisualBasic
+
+        Returns:
+            List[Any]: Lista de nodos AST de Cobra
+
+        Raises:
+            NotImplementedError: Esta funcionalidad no está implementada actualmente
+        """
+        raise NotImplementedError(
+            "La transpilación desde VisualBasic no está implementada. "
+            "Se requiere un parser compatible para procesar código VisualBasic."
+        )

--- a/src/cobra/transpilers/reverse/from_wasm.py
+++ b/src/cobra/transpilers/reverse/from_wasm.py
@@ -1,33 +1,82 @@
 # -*- coding: utf-8 -*-
-"""Transpilador inverso desde VisualBasic a Cobra (no soportado)."""
-from typing import List, Any
+"""Transpilador inverso desde WebAssembly (WASM) a Cobra."""
+
+from __future__ import annotations
+
+from typing import Any, List, Union
+
 from cobra.transpilers.reverse.base import BaseReverseTranspiler
+from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoIdentificador, NodoValor
+
+try:
+    from wabt import Wabt  # type: ignore
+    from sexpdata import loads, Symbol  # type: ignore
+except Exception as exc:  # pragma: no cover - dependencias opcionales
+    raise ImportError(
+        "Se requieren las dependencias 'wabt' y 'sexpdata' para ReverseFromWasm"
+    ) from exc
 
 
-class ReverseFromVisualBasic(BaseReverseTranspiler):
-    """Transpilador inverso de VisualBasic a Cobra.
+class ReverseFromWasm(BaseReverseTranspiler):
+    """Convierte código WASM en nodos del AST de Cobra.
 
-    Esta clase actualmente no está implementada ya que no hay un parser
-    disponible para código VisualBasic.
+    Este transpilador utiliza `wabt` para decodificar módulos WASM y `sexpdata`
+    para procesar la representación en texto (WAT). Actualmente solo soporta
+    asignaciones simples de constantes a variables locales.
     """
 
     def __init__(self) -> None:
-        """Inicializa el transpilador."""
         super().__init__()
+        self._wabt = Wabt()
 
-    def generate_ast(self, code: str) -> List[Any]:
-        """Genera el AST Cobra desde código VisualBasic.
+    def _to_wat(self, code: Union[str, bytes]) -> str:
+        """Obtiene la representación WAT del código WASM."""
+        if isinstance(code, bytes):
+            return self._wabt.wasm_to_wat(code)
+        return code
 
-        Args:
-            code: Código fuente en VisualBasic
+    def generate_ast(self, code: Union[str, bytes]) -> List[Any]:
+        """Genera el AST Cobra desde código WASM o WAT."""
+        wat = self._to_wat(code)
+        sexp = loads(wat)
 
-        Returns:
-            List[Any]: Lista de nodos AST de Cobra
+        ast: List[Any] = []
+        for elem in sexp:
+            if isinstance(elem, list) and elem and elem[0] == Symbol("func"):
+                nombre = "anon"
+                idx = 1
+                if len(elem) > 1 and isinstance(elem[1], Symbol) and str(elem[1]).startswith("$"):
+                    nombre = str(elem[1])[1:]
+                    idx = 2
+                cuerpo = self._parse_instructions(elem[idx:])
+                ast.append(NodoFuncion(nombre, [], cuerpo))
+        self.ast = ast
+        return ast
 
-        Raises:
-            NotImplementedError: Esta funcionalidad no está implementada actualmente
-        """
-        raise NotImplementedError(
-            "La transpilación desde VisualBasic no está implementada. "
-            "Se requiere un parser compatible para procesar código VisualBasic."
-        )
+    def _parse_instructions(self, instr: List[Any]) -> List[Any]:
+        """Convierte una lista de instrucciones WAT en nodos Cobra."""
+        resultado: List[Any] = []
+        i = 0
+        while i < len(instr):
+            actual = instr[i]
+            siguiente = instr[i + 1] if i + 1 < len(instr) else None
+            if (
+                isinstance(actual, list)
+                and actual and actual[0] == Symbol("i32.const")
+                and isinstance(siguiente, list)
+                and siguiente and siguiente[0] == Symbol("local.set")
+            ):
+                valor = actual[1]
+                destino = siguiente[1]
+                if isinstance(destino, Symbol):
+                    nombre = str(destino)[1:] if str(destino).startswith("$") else str(destino)
+                    resultado.append(
+                        NodoAsignacion(
+                            NodoIdentificador(nombre),
+                            NodoValor(valor),
+                        )
+                    )
+                    i += 2
+                    continue
+            i += 1
+        return resultado


### PR DESCRIPTION
## Summary
- implement basic ReverseFromWasm using wabt and sexpdata
- keep Visual Basic stub separate
- document current WASM reverse transpiler limitations

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_6891fa0661988327862444e86d94f474