### PR TITLE
feat: soporte inverso básico para Matlab y Pascal

### DIFF
--- a/src/cobra/transpilers/reverse/from_matlab.py
+++ b/src/cobra/transpilers/reverse/from_matlab.py
@@ -1,31 +1,104 @@
 # -*- coding: utf-8 -*-
-"""Transpilador inverso desde Matlab a Cobra (no soportado)."""
+"""Transpilador inverso desde Matlab a Cobra usando Lark."""
+
+from __future__ import annotations
+
 from typing import Any, List
+
+from lark import Lark, Transformer
+
 from cobra.transpilers.reverse.base import BaseReverseTranspiler
+from core.ast_nodes import (
+    NodoAsignacion,
+    NodoCondicional,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoPara,
+    NodoValor,
+    NodoIdentificador,
+)
+
+
+MATLAB_GRAMMAR = r"""
+start: (function_def | statement)+
+
+function_def: "function" NAME "=" NAME "(" NAME ")" statements "end"
+
+statements: statement*
+
+?statement: assignment
+          | if_statement
+          | for_loop
+
+assignment: NAME "=" expr
+
+if_statement: "if" expr statements ("else" statements)? "end"
+
+for_loop: "for" NAME "=" expr ":" expr statements "end"
+
+?expr: NUMBER        -> number
+     | NAME          -> var
+
+NAME: /[a-zA-Z_][a-zA-Z0-9_]*/
+NUMBER: /\d+/
+
+%import common.WS
+%ignore WS
+%ignore ";"
+"""
+
+
+class _MatlabTransformer(Transformer):
+    """Convierte el árbol de Lark en nodos AST de Cobra."""
+
+    def start(self, items: List[Any]) -> List[Any]:  # type: ignore[override]
+        return items
+
+    def statements(self, items: List[Any]) -> List[Any]:  # type: ignore[override]
+        return items
+
+    def number(self, items: List[Any]) -> NodoValor:  # type: ignore[override]
+        return NodoValor(int(items[0]))
+
+    def var(self, items: List[Any]) -> NodoIdentificador:  # type: ignore[override]
+        return NodoIdentificador(str(items[0]))
+
+    def assignment(self, items: List[Any]) -> NodoAsignacion:  # type: ignore[override]
+        nombre = str(items[0])
+        expresion = items[1]
+        return NodoAsignacion(nombre, expresion)
+
+    def if_statement(self, items: List[Any]) -> NodoCondicional:  # type: ignore[override]
+        condicion = items[0]
+        bloque_si = items[1]
+        bloque_sino = items[2] if len(items) > 2 else []
+        return NodoCondicional(condicion, bloque_si, bloque_sino)
+
+    def for_loop(self, items: List[Any]) -> NodoPara:  # type: ignore[override]
+        variable = str(items[0])
+        inicio = items[1]
+        fin = items[2]
+        cuerpo = items[3]
+        iterable = NodoLlamadaFuncion("range", [inicio, fin])
+        return NodoPara(variable, iterable, cuerpo)
+
+    def function_def(self, items: List[Any]) -> NodoFuncion:  # type: ignore[override]
+        _, nombre, parametro, cuerpo = items
+        return NodoFuncion(str(nombre), [str(parametro)], cuerpo)
+
 
 class ReverseFromMatlab(BaseReverseTranspiler):
-    """Transpilador inverso de Matlab a Cobra.
-    
-    Esta clase representa un transpilador que convertiría código Matlab
-    a AST de Cobra, pero actualmente no está implementado.
-    """
-    
+    """Transpilador inverso de Matlab a Cobra."""
+
     def __init__(self) -> None:
-        """Inicializa el transpilador."""
         super().__init__()
+        self.parser = Lark(MATLAB_GRAMMAR, parser="lalr")
+        self.transformer = _MatlabTransformer()
 
     def generate_ast(self, code: str) -> List[Any]:
-        """Genera el AST Cobra desde código Matlab.
-        
-        Args:
-            code: Código fuente en Matlab
-            
-        Returns:
-            List[Any]: Lista de nodos AST de Cobra
-            
-        Raises:
-            NotImplementedError: Este transpilador no está implementado actualmente
-        """
-        raise NotImplementedError(
-            "La transpilación desde Matlab no está implementada actualmente"
-        )
+        """Genera el AST Cobra desde código Matlab."""
+
+        tree = self.parser.parse(code)
+        self.ast = self.transformer.transform(tree)  # type: ignore[assignment]
+        return self.ast
+

--- a/src/cobra/transpilers/reverse/from_pascal.py
+++ b/src/cobra/transpilers/reverse/from_pascal.py
@@ -1,28 +1,110 @@
-"""Transpilador inverso desde Pascal a Cobra.
+# -*- coding: utf-8 -*-
+"""Transpilador inverso desde Pascal a Cobra usando Lark."""
 
-Este módulo implementa la conversión de código Pascal a nodos AST de Cobra.
-Actualmente no está soportado.
-"""
-from typing import List, Any
+from __future__ import annotations
+
+from typing import Any, List
+
+from lark import Lark, Transformer
+
 from cobra.transpilers.reverse.base import BaseReverseTranspiler
+from core.ast_nodes import (
+    NodoAsignacion,
+    NodoCondicional,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoPara,
+    NodoValor,
+    NodoIdentificador,
+)
+
+
+PASCAL_GRAMMAR = r"""
+start: function_def
+
+function_def: "function" NAME "(" NAME ":" NAME ")" ":" NAME ";" block ";"
+
+block: "begin" statements "end"
+
+statements: (statement ";")*
+
+?statement: assignment
+          | if_statement
+          | for_loop
+
+assignment: NAME ":=" expr
+
+if_statement: "if" expr "then" block ("else" block)?
+
+for_loop: "for" NAME ":=" expr "to" expr "do" block
+
+?expr: NUMBER        -> number
+     | NAME          -> var
+
+NAME: /[a-zA-Z_][a-zA-Z0-9_]*/
+NUMBER: /\d+/
+
+%import common.WS
+%ignore WS
+"""
+
+
+class _PascalTransformer(Transformer):
+    """Convierte el árbol de Lark en nodos AST de Cobra."""
+
+    def start(self, items: List[Any]) -> List[Any]:  # type: ignore[override]
+        return items
+
+    def statements(self, items: List[Any]) -> List[Any]:  # type: ignore[override]
+        return items
+
+    def block(self, items: List[Any]) -> List[Any]:  # type: ignore[override]
+        return items[0] if items else []
+
+    def number(self, items: List[Any]) -> NodoValor:  # type: ignore[override]
+        return NodoValor(int(items[0]))
+
+    def var(self, items: List[Any]) -> NodoIdentificador:  # type: ignore[override]
+        return NodoIdentificador(str(items[0]))
+
+    def assignment(self, items: List[Any]) -> NodoAsignacion:  # type: ignore[override]
+        nombre = str(items[0])
+        expresion = items[1]
+        return NodoAsignacion(nombre, expresion)
+
+    def if_statement(self, items: List[Any]) -> NodoCondicional:  # type: ignore[override]
+        condicion = items[0]
+        bloque_si = items[1]
+        bloque_sino = items[2] if len(items) > 2 else []
+        return NodoCondicional(condicion, bloque_si, bloque_sino)
+
+    def for_loop(self, items: List[Any]) -> NodoPara:  # type: ignore[override]
+        variable = str(items[0])
+        inicio = items[1]
+        fin = items[2]
+        cuerpo = items[3]
+        iterable = NodoLlamadaFuncion("range", [inicio, fin])
+        return NodoPara(variable, iterable, cuerpo)
+
+    def function_def(self, items: List[Any]) -> NodoFuncion:  # type: ignore[override]
+        nombre = str(items[0])
+        parametro = str(items[1])
+        cuerpo = items[-1]
+        return NodoFuncion(nombre, [parametro], cuerpo)
+
 
 class ReverseFromPascal(BaseReverseTranspiler):
-    """Transpilador inverso de Pascal a Cobra.
-    
-    Esta clase está destinada a implementar la conversión de código Pascal
-    a nodos AST de Cobra. Actualmente no está implementada.
-    """
+    """Transpilador inverso de Pascal a Cobra."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.parser = Lark(PASCAL_GRAMMAR, parser="lalr")
+        self.transformer = _PascalTransformer()
 
     def generate_ast(self, code: str) -> List[Any]:
-        """Genera el AST Cobra desde código Pascal.
-        
-        Args:
-            code: Código fuente en Pascal
-            
-        Returns:
-            Lista de nodos AST de Cobra
-            
-        Raises:
-            NotImplementedError: El transpilador para Pascal no está implementado
-        """
-        raise NotImplementedError("El transpilador para Pascal no está implementado")
+        """Genera el AST Cobra desde código Pascal."""
+
+        tree = self.parser.parse(code)
+        self.ast = self.transformer.transform(tree)  # type: ignore[assignment]
+        return self.ast
+

--- a/src/tests/unit/test_reverse_matlab_pascal.py
+++ b/src/tests/unit/test_reverse_matlab_pascal.py
@@ -1,0 +1,55 @@
+from cobra.transpilers.reverse.from_matlab import ReverseFromMatlab
+from cobra.transpilers.reverse.from_pascal import ReverseFromPascal
+from core.ast_nodes import NodoAsignacion, NodoCondicional, NodoFuncion, NodoPara
+
+
+def test_reverse_from_matlab_basic():
+    codigo = (
+        "function y = foo(x)\n"
+        "y = x\n"
+        "if y\n"
+        " y = y\n"
+        "end\n"
+        "for i = 1:3\n"
+        " y = y\n"
+        "end\n"
+        "end\n"
+    )
+
+    ast = ReverseFromMatlab().generate_ast(codigo)
+    assert len(ast) == 1
+    fn = ast[0]
+    assert isinstance(fn, NodoFuncion)
+    assert fn.nombre == "foo"
+    assert len(fn.cuerpo) == 3
+    assert isinstance(fn.cuerpo[0], NodoAsignacion)
+    assert isinstance(fn.cuerpo[1], NodoCondicional)
+    assert isinstance(fn.cuerpo[2], NodoPara)
+
+
+def test_reverse_from_pascal_basic():
+    codigo = (
+        "function foo(x: integer): integer;\n"
+        "begin\n"
+        "  y := x;\n"
+        "  if y then\n"
+        "  begin\n"
+        "    y := y;\n"
+        "  end;\n"
+        "  for i := 1 to 3 do\n"
+        "  begin\n"
+        "    y := y;\n"
+        "  end;\n"
+        "end;\n"
+    )
+
+    ast = ReverseFromPascal().generate_ast(codigo)
+    assert len(ast) == 1
+    fn = ast[0]
+    assert isinstance(fn, NodoFuncion)
+    assert fn.nombre == "foo"
+    assert len(fn.cuerpo) == 3
+    assert isinstance(fn.cuerpo[0], NodoAsignacion)
+    assert isinstance(fn.cuerpo[1], NodoCondicional)
+    assert isinstance(fn.cuerpo[2], NodoPara)
+


### PR DESCRIPTION
## Resumen
- Implementar transpilers inversos para Matlab y Pascal usando Lark
- Mapear asignaciones, condicionales, bucles `for` y funciones al AST de Cobra
- Agregar pruebas unitarias mínimas para Matlab y Pascal

## Testing
- `PYTHONPATH=src pytest src/tests/unit/test_reverse_matlab_pascal.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68920494502c83279b1bdbae6da244b5