### PR TITLE
docs: ampliar gramatica

### DIFF
--- a/docs/especificacion_tecnica.md
+++ b/docs/especificacion_tecnica.md
@@ -85,3 +85,64 @@ fin
 
 Cobra evalúa expresiones de izquierda a derecha. Los parámetros se pasan por valor. El ámbito de las variables es estático, determinado por la indentación.
 
+## Decoradores
+
+Los decoradores se indican con `@` y permiten modificar funciones antes de su ejecución.
+
+```cobra
+@medir_tiempo
+func tarea():
+    imprimir "hola"
+fin
+```
+
+## Funciones lambda
+
+Las lambdas son funciones anónimas de una sola expresión.
+
+```cobra
+doble = lambda x: x * 2
+```
+
+## Bloque `with`
+
+El bloque `with` gestiona contextos y cierra recursos automáticamente.
+
+```cobra
+with archivo("datos.txt") as f:
+    imprimir f.leer()
+fin
+```
+
+## Asincronía
+
+Las funciones pueden marcarse como `asincronico` y utilizar `esperar` para suspender su ejecución hasta que otra operación termine.
+
+```cobra
+asincronico func descargar():
+    datos = esperar solicitar()
+    retornar datos
+fin
+```
+
+## Option
+
+La construcción `option` declara valores opcionales que pueden o no contener un dato.
+
+```cobra
+option resultado = obtener()
+```
+
+## Switch ampliado
+
+`switch` admite múltiples valores por caso y un bloque `default` opcional.
+
+```cobra
+switch x:
+    case 1, 2:
+        imprimir "uno o dos"
+    default:
+        imprimir "otro"
+fin
+```
+

--- a/docs/gramatica.ebnf
+++ b/docs/gramatica.ebnf
@@ -2,6 +2,7 @@
 
 ?statement: asignacion
           | funcion
+          | funcion_asincronica
           | clase
           | bucle_mientras
           | bucle_para
@@ -15,10 +16,14 @@
           | llamada
           | switch
           | try_catch
+          | with_stmt
+          | option
           | expr
 
 asignacion: ("var"|"variable")? IDENTIFICADOR "=" expr
-funcion: "func" IDENTIFICADOR "(" parametros? ")" ":" cuerpo "fin"
+decorador: "@" IDENTIFICADOR
+funcion: decorador* "func" IDENTIFICADOR "(" parametros? ")" ":" cuerpo "fin"
+funcion_asincronica: decorador* "asincronico" "func" IDENTIFICADOR "(" parametros? ")" ":" cuerpo "fin"
 clase: "clase" IDENTIFICADOR ":" cuerpo "fin"
 bucle_mientras: "mientras" expr ":" cuerpo "fin"
 bucle_para: "para" IDENTIFICADOR "in" expr ":" cuerpo "fin"
@@ -29,9 +34,11 @@ macro: "macro" IDENTIFICADOR "{" statement* "}"
 impresion: "imprimir" "(" argumentos? ")"
 retorno: "retorno" expr
 hilo: "hilo" llamada
-switch: "switch" expr ":" case+ "fin"
-case: ("case" expr ":" cuerpo)+
+switch: "switch" expr ":" case+ ("default" ":" cuerpo)? "fin"
+case: "case" expr ("," expr)* ":" cuerpo
 try_catch: ("try"|"intentar") ":" cuerpo ("catch"|"capturar") IDENTIFICADOR ":" cuerpo "fin"
+with_stmt: "with" expr ("as" IDENTIFICADOR)? ":" cuerpo "fin"
+option: "option" IDENTIFICADOR "=" expr
 llamada: IDENTIFICADOR "(" argumentos? ")"
 cuerpo: statement*
 parametros: IDENTIFICADOR ("," IDENTIFICADOR)*
@@ -43,7 +50,10 @@ argumentos: expr ("," expr)*
       | IDENTIFICADOR
       | llamada
       | holobit
+      | lambda
+      | "esperar" valor
 holobit: "holobit" "(" "[" [expr ("," expr)*] "]" ")"
+lambda: "lambda" parametros? ":" expr
 operador: "+"|"-"|"*"|"/"|">="|"<="|">"|"<"|"=="|"!="|"&&"|"||"
 
 CADENA: /"[^"\n]*"|'[^'\n]*'/


### PR DESCRIPTION
## Summary
- expand grammar with decorators, lambdas, with blocks, async/await, option, and extended switch/case
- document new grammar rules in technical specification

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68922bf3749883279ea12f1c11932bc8