### PR TITLE
Remove obsolete rel keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,6 @@ describen todos los tokens disponibles:
 | DOSPUNTOS | Símbolo ":" |
 | VAR | Palabra clave "var" |
 | FUNC | Palabra clave "func" o "definir" |
-| REL | Palabra clave "rel" |
 | SI | Palabra clave "si" |
 | SINO | Palabra clave "sino" |
 | MIENTRAS | Palabra clave "mientras" |

--- a/README_en.md
+++ b/README_en.md
@@ -304,7 +304,6 @@ The lexer converts code into tokens according to the regular expressions defined
 | DOSPUNTOS | Symbol ":" |
 | VAR | Keyword "var" |
 | FUNC | Keyword "func" or "definir" |
-| REL | Keyword "rel" |
 | SI | Keyword "si" |
 | SINO | Keyword "sino" |
 | MIENTRAS | Keyword "mientras" |

--- a/SPEC_COBRA.md
+++ b/SPEC_COBRA.md
@@ -66,7 +66,7 @@ Cada regla define construcciones del lenguaje: por ejemplo `asignacion` utiliza 
 
 ## Tokens y palabras reservadas
 El lexer de `src/cobra/lexico/lexer.py` define todos los tokens. Las principales palabras clave son:
-- `var`, `variable`, `func`, `metodo`, `atributo`, `rel`
+- `var`, `variable`, `func`, `metodo`, `atributo`
 - `si`, `sino`, `mientras`, `para`, `import`, `usar`, `macro`, `hilo`, `asincronico`
 - `switch`, `case`, `clase`, `in`, `holobit`, `proyectar`, `transformar`, `graficar`
 - `try`/`intentar`, `catch`/`capturar`, `throw`/`lanzar`

--- a/frontend/docs/referencia.rst
+++ b/frontend/docs/referencia.rst
@@ -7,7 +7,6 @@ Palabras clave
 --------------
 - ``var``: declara variables.
 - ``func``: define funciones.
-- ``rel``: crea funciones relativas a un contexto temporal.
 - ``si`` / ``sino``: condicionales.
 - ``mientras`` / ``para``: bucles de control.
 - ``import``: carga otros archivos Cobra.

--- a/frontend/docs/sintaxis.rst
+++ b/frontend/docs/sintaxis.rst
@@ -20,14 +20,7 @@ func sumar(a, b) :
 
 Al igual que con las variables, el nombre de la función no puede coincidir con palabras reservadas.
 
-**3. Funciones relativas (rel)**
-
-Las funciones relativas se utilizan en contextos temporales específicos:
-
-rel calculo_temporal(x) :
-    return x * 2
-
-**4. Condicionales**
+**3. Condicionales**
 
 Para condicionales, se usan `si` y `sino` :
 
@@ -36,7 +29,7 @@ si x > 10 :
 sino :
     imprimir("x es menor o igual a 10")
 
-**5. Bucles**
+**4. Bucles**
 
 Cobra soporta los bucles `mientras` y `para` :
 
@@ -47,14 +40,14 @@ mientras x < 5 :
 para var i en rango(5) :
     imprimir(i)
 
-**6. Holobits**
+**5. Holobits**
 
 Los holobits permiten trabajar con datos multidimensionales:
 
 var h = holobit([0.8, -0.5, 1.2])
 imprimir(h)
 
-**7. Importación de módulos**
+**6. Importación de módulos**
 
 Puedes dividir tu código en varios archivos y cargarlos con ``import``:
 
@@ -63,7 +56,7 @@ Puedes dividir tu código en varios archivos y cargarlos con ``import``:
    import 'utilidades.co'
    imprimir(variable_definida_en_utilidades)
 
-**8. Manejo de excepciones**
+**7. Manejo de excepciones**
 
 Para capturar errores se utiliza la estructura ``try`` / ``catch``. Puedes
 lanzar excepciones con ``throw``:
@@ -75,7 +68,7 @@ lanzar excepciones con ``throw``:
    catch e:
        imprimir(e)
 
-**9. Concurrencia con hilos**
+**8. Concurrencia con hilos**
 
 Es posible ejecutar funciones de forma concurrente:
 

--- a/frontend/vscode/syntaxes/cobra.tmLanguage.json
+++ b/frontend/vscode/syntaxes/cobra.tmLanguage.json
@@ -20,7 +20,7 @@
       "patterns": [
         {
           "name": "keyword.control.cobra",
-          "match": "\\b(var|variable|func|definir|metodo|atributo|rel|si|sino|mientras|para|import|usar|macro|hilo|asincronico|switch|segun|case|caso|clase|in|holobit|proyectar|transformar|graficar|try|catch|throw|intentar|capturar|lanzar|imprimir|yield|esperar|romper|continuar|pasar|afirmar|eliminar|global|nolocal|lambda|con|finalmente|desde|como|retorno|fin)\\b"
+            "match": "\\b(var|variable|func|definir|metodo|atributo|si|sino|mientras|para|import|usar|macro|hilo|asincronico|switch|segun|case|caso|clase|in|holobit|proyectar|transformar|graficar|try|catch|throw|intentar|capturar|lanzar|imprimir|yield|esperar|romper|continuar|pasar|afirmar|eliminar|global|nolocal|lambda|con|finalmente|desde|como|retorno|fin)\\b"
         }
       ]
     },

--- a/src/cobra/lexico/lexer.py
+++ b/src/cobra/lexico/lexer.py
@@ -40,7 +40,6 @@ class TipoToken(Enum):
     FUNC = "FUNC"
     METODO = "METODO"
     ATRIBUTO = "ATRIBUTO"
-    REL = "REL"
     SI = "SI"
     SINO = "SINO"
     MIENTRAS = "MIENTRAS"
@@ -185,7 +184,6 @@ class Lexer:
             (TipoToken.FUNC, re.compile(r"\b(func|definir)\b")),
             (TipoToken.METODO, re.compile(r"\bmetodo\b")),
             (TipoToken.ATRIBUTO, re.compile(r"\batributo\b")),
-            (TipoToken.REL, re.compile(r"\brel\b")),
             (TipoToken.SI, re.compile(r"\bsi\b")),
             (TipoToken.SINO, re.compile(r"\bsino\b")),
             (TipoToken.MIENTRAS, re.compile(r"\bmientras\b")),

--- a/src/cobra/parser/utils.py
+++ b/src/cobra/parser/utils.py
@@ -8,7 +8,6 @@ UMBRAL_COINCIDENCIA = 0.8
 PALABRAS_RESERVADAS = frozenset({
     "var",
     "func",
-    "rel",
     "si",
     "sino",
     "mientras",


### PR DESCRIPTION
## Summary
- drop unused `rel` token from lexer and reserved word list
- clean up docs and VS Code grammar referencing `rel`

## Testing
- `PYTHONPATH=$PWD/src pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_6892319221248327bb24c1e5adff4dc0