### PR TITLE
Soporte de patrones y guardias en switch

### DIFF
--- a/docs/gramatica.ebnf
+++ b/docs/gramatica.ebnf
@@ -34,8 +34,9 @@ macro: "macro" IDENTIFICADOR "{" statement* "}"
 impresion: "imprimir" "(" argumentos? ")"
 retorno: "retorno" expr
 hilo: "hilo" llamada
-switch: "switch" expr ":" case+ ("default" ":" cuerpo)? "fin"
-case: "case" expr ("," expr)* ":" cuerpo
+switch: "switch" expr ":" case+ ("sino" ":" cuerpo)? "fin"
+case: "case" patron ("si" expr)? ":" cuerpo
+patron: "_" | IDENTIFICADOR | valor | "(" patron ("," patron)* ")"
 try_catch: ("try"|"intentar") ":" cuerpo ("catch"|"capturar") IDENTIFICADOR ":" cuerpo "fin"
 with_stmt: "with" expr ("as" IDENTIFICADOR)? ":" cuerpo "fin"
 option: "option" IDENTIFICADOR "=" expr
@@ -59,6 +60,6 @@ operador: "+"|"-"|"*"|"/"|">="|"<="|">"|"<"|"=="|"!="|"&&"|"||"
 CADENA: /"[^"\n]*"|'[^'\n]*'/
 ENTERO: /[0-9]+/
 FLOTANTE: /[0-9]+\.[0-9]+/
-IDENTIFICADOR: /[^\W\d_][\w]*/
+IDENTIFICADOR: /[^\W\d][\w]*/
 
 %ignore /\s+/

--- a/examples/patrones.co
+++ b/examples/patrones.co
@@ -1,0 +1,8 @@
+var punto = (1, (2, 3))
+
+switch punto:
+    case (x, (y, _)) si x > y:
+        imprimir(x)
+    sino:
+        imprimir(0)
+fin

--- a/src/cobra/lexico/lexer.py
+++ b/src/cobra/lexico/lexer.py
@@ -231,7 +231,7 @@ class Lexer:
             (TipoToken.DOSPUNTOS, re.compile(r":")),
             (TipoToken.FIN, re.compile(r"\bfin\b")),
             (TipoToken.RETORNO, re.compile(r"\bretorno\b")),
-            (TipoToken.IDENTIFICADOR, re.compile(r"[^\W\d_][\w]*")),
+            (TipoToken.IDENTIFICADOR, re.compile(r"[^\W\d][\w]*")),
             (TipoToken.MAYORIGUAL, re.compile(r">=")),
             (TipoToken.MENORIGUAL, re.compile(r"<=")),
             (TipoToken.IGUAL, re.compile(r"==")),

--- a/src/cobra/transpilers/transpiler/to_python.py
+++ b/src/cobra/transpilers/transpiler/to_python.py
@@ -34,6 +34,8 @@ from core.ast_nodes import (
     NodoWith,
     NodoImportDesde,
     NodoEsperar,
+    NodoPattern,
+    NodoGuard,
 )
 from cobra.parser.parser import Parser
 from cobra.lexico.lexer import TipoToken, Lexer
@@ -225,6 +227,18 @@ class TranspiladorPython(BaseTranspiler):
             params = ", ".join(nodo.parametros)
             cuerpo = self.obtener_valor(nodo.cuerpo)
             return f"lambda {params}: {cuerpo}"
+        elif isinstance(nodo, NodoPattern):
+            if isinstance(nodo.valor, list):
+                elems = ", ".join(self.obtener_valor(p) for p in nodo.valor)
+                return f"({elems})"
+            elif nodo.valor == "_":
+                return "_"
+            else:
+                return self.obtener_valor(nodo.valor)
+        elif isinstance(nodo, NodoGuard):
+            patron = self.obtener_valor(nodo.patron)
+            guardia = self.obtener_valor(nodo.condicion)
+            return f"{patron} if {guardia}"
         else:
             return str(getattr(nodo, "valor", nodo))
 

--- a/src/cobra/transpilers/transpiler/to_rust.py
+++ b/src/cobra/transpilers/transpiler/to_rust.py
@@ -21,6 +21,8 @@ from core.ast_nodes import (
     NodoOption,
     NodoSwitch,
     NodoCase,
+    NodoPattern,
+    NodoGuard,
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
@@ -139,6 +141,16 @@ class TranspiladorRust(BaseTranspiler):
                     for k, v in nodo.elementos
                 )
                 return f"std::collections::HashMap::from([{pares}])"
+            case NodoPattern():
+                if isinstance(nodo.valor, list):
+                    elems = ", ".join(self.obtener_valor(p) for p in nodo.valor)
+                    return f"({elems})"
+                else:
+                    return "_" if nodo.valor == "_" else self.obtener_valor(nodo.valor)
+            case NodoGuard():
+                patron = self.obtener_valor(nodo.patron)
+                guardia = self.obtener_valor(nodo.condicion)
+                return f"{patron} if {guardia}"
             case _:
                 return str(getattr(nodo, "valor", nodo))
 

--- a/src/core/ast_nodes.py
+++ b/src/core/ast_nodes.py
@@ -435,6 +435,17 @@ class NodoMacro(NodoAST):
 
 
 @dataclass
+class NodoPattern(NodoAST):
+    valor: Any
+
+
+@dataclass
+class NodoGuard(NodoAST):
+    patron: NodoPattern
+    condicion: Any
+
+
+@dataclass
 class NodoCase(NodoAST):
     valor: Any
     cuerpo: List[Any]
@@ -491,6 +502,8 @@ __all__ = [
     "NodoPara",
     "NodoImprimir",
     "NodoMacro",
+    "NodoPattern",
+    "NodoGuard",
     "NodoCase",
     "NodoSwitch",
 ]

--- a/src/tests/unit/test_parser_switch.py
+++ b/src/tests/unit/test_parser_switch.py
@@ -1,6 +1,6 @@
 from cobra.lexico.lexer import Lexer
 from cobra.parser.parser import Parser
-from core.ast_nodes import NodoSwitch, NodoCase, NodoImprimir
+from core.ast_nodes import NodoSwitch, NodoCase, NodoImprimir, NodoGuard, NodoPattern
 
 
 def test_parser_switch():
@@ -21,3 +21,24 @@ def test_parser_switch():
     assert isinstance(nodo.casos[0], NodoCase)
     assert len(nodo.por_defecto) == 1
     assert isinstance(nodo.por_defecto[0], NodoImprimir)
+
+
+def test_parser_switch_patrones_guardia():
+    codigo = """
+    switch punto:
+        case (x, (y, _)) si x > y:
+            imprimir(x)
+        sino:
+            imprimir(0)
+    fin
+    """
+    ast = Parser(Lexer(codigo).analizar_token()).parsear()
+    nodo = ast[0]
+    caso = nodo.casos[0]
+    assert isinstance(caso.valor, NodoGuard)
+    patron = caso.valor.patron
+    assert isinstance(patron, NodoPattern)
+    assert isinstance(patron.valor, list) and len(patron.valor) == 2
+    interno = patron.valor[1]
+    assert isinstance(interno.valor, list)
+    assert interno.valor[1].valor == "_"

--- a/src/tests/unit/test_to_rust.py
+++ b/src/tests/unit/test_to_rust.py
@@ -24,6 +24,8 @@ from core.ast_nodes import (
     NodoCase,
     NodoGlobal,
     NodoNoLocal,
+    NodoPattern,
+    NodoGuard,
 )
 
 
@@ -124,6 +126,40 @@ def test_transpilador_switch():
         + "    },\n"
         + "    _ => {\n"
         + "        let y = 0;\n"
+        + "    },\n"
+        + "}"
+    )
+    assert resultado == esperado
+
+def test_transpilador_switch_patron_guardia():
+    patron_interno = NodoPattern([
+        NodoPattern(NodoIdentificador("y")),
+        NodoPattern("_"),
+    ])
+    patron_principal = NodoPattern([
+        NodoPattern(NodoIdentificador("x")),
+        patron_interno,
+    ])
+    caso = NodoCase(
+        NodoGuard(patron_principal, NodoValor("x > y")),
+        [NodoAsignacion("z", NodoValor(1))],
+    )
+    ast = [
+        NodoSwitch(
+            "punto",
+            [caso],
+            [NodoAsignacion("z", NodoValor(0))],
+        )
+    ]
+    t = TranspiladorRust()
+    resultado = t.generate_code(ast)
+    esperado = (
+        "match punto {\n"
+        + "    (x, (y, _)) if x > y => {\n"
+        + "        let z = 1;\n"
+        + "    },\n"
+        + "    _ => {\n"
+        + "        let z = 0;\n"
         + "    },\n"
         + "}"
     )


### PR DESCRIPTION
## Resumen
- Amplía la gramática para patrones, comodines y guardias.
- Crea nodos `NodoPattern` y `NodoGuard` y adapta el parser.
- Actualiza transpilers Python y Rust para manejar patrones.
- Agrega ejemplo y pruebas de patrones anidados con guardias.

## Pruebas
- `pytest src/tests/unit/test_parser_switch.py src/tests/unit/test_to_python.py src/tests/unit/test_to_rust.py`


------
https://chatgpt.com/codex/tasks/task_e_68923a17708c8327843ad7fab8f11989