### PR TITLE
feat: agregar soporte de proyeccion y transformacion

### DIFF
--- a/src/cobra/parser/parser.py
+++ b/src/cobra/parser/parser.py
@@ -22,6 +22,9 @@ from core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoImprimir,
+    NodoProyectar,
+    NodoTransformar,
+    NodoGraficar,
     NodoRetorno,
     NodoPara,
     NodoDecorador,
@@ -69,6 +72,9 @@ class ClassicParser:
             TipoToken.VAR: self.declaracion_asignacion,
             TipoToken.VARIABLE: self.declaracion_asignacion,
             TipoToken.HOLOBIT: self.declaracion_holobit,
+            TipoToken.PROYECTAR: self.declaracion_proyectar,
+            TipoToken.TRANSFORMAR: self.declaracion_transformar,
+            TipoToken.GRAFICAR: self.declaracion_graficar,
             TipoToken.SI: self.declaracion_condicional,
             TipoToken.PARA: self.declaracion_para,
             TipoToken.MIENTRAS: self.declaracion_mientras,
@@ -681,6 +687,48 @@ class ClassicParser:
             expresion = self.expresion()
 
         return NodoImprimir(expresion)
+
+    def declaracion_proyectar(self):
+        """Parsea una declaración ``proyectar``."""
+        self.comer(TipoToken.PROYECTAR)
+        self.comer(TipoToken.LPAREN)
+        hb = self.expresion()
+        if self.token_actual().tipo != TipoToken.COMA:
+            raise ParserError("Se esperaba ',' después del holobit en 'proyectar'")
+        self.comer(TipoToken.COMA)
+        modo = self.expresion()
+        if self.token_actual().tipo != TipoToken.RPAREN:
+            raise ParserError("Se esperaba ')' al final de 'proyectar'")
+        self.comer(TipoToken.RPAREN)
+        return NodoProyectar(hb, modo)
+
+    def declaracion_transformar(self):
+        """Parsea una declaración ``transformar``."""
+        self.comer(TipoToken.TRANSFORMAR)
+        self.comer(TipoToken.LPAREN)
+        hb = self.expresion()
+        if self.token_actual().tipo != TipoToken.COMA:
+            raise ParserError("Se esperaba ',' después del holobit en 'transformar'")
+        self.comer(TipoToken.COMA)
+        operacion = self.expresion()
+        parametros = []
+        while self.token_actual().tipo == TipoToken.COMA:
+            self.comer(TipoToken.COMA)
+            parametros.append(self.expresion())
+        if self.token_actual().tipo != TipoToken.RPAREN:
+            raise ParserError("Se esperaba ')' al final de 'transformar'")
+        self.comer(TipoToken.RPAREN)
+        return NodoTransformar(hb, operacion, parametros)
+
+    def declaracion_graficar(self):
+        """Parsea una declaración ``graficar``."""
+        self.comer(TipoToken.GRAFICAR)
+        self.comer(TipoToken.LPAREN)
+        hb = self.expresion()
+        if self.token_actual().tipo != TipoToken.RPAREN:
+            raise ParserError("Se esperaba ')' al final de 'graficar'")
+        self.comer(TipoToken.RPAREN)
+        return NodoGraficar(hb)
 
     def declaracion_import(self):
         """Parsea una declaración de importación de módulo."""

--- a/src/cobra/transpilers/reverse/from_python.py
+++ b/src/cobra/transpilers/reverse/from_python.py
@@ -17,6 +17,9 @@ from core.ast_nodes import (
     NodoFuncion,
     NodoLlamadaFuncion,
     NodoLlamadaMetodo,
+    NodoProyectar,
+    NodoTransformar,
+    NodoGraficar,
     NodoRetorno,
     NodoValor,
     NodoIdentificador,
@@ -181,7 +184,20 @@ class ReverseFromPython(BaseReverseTranspiler):
             )
         
         if isinstance(node.func, ast.Name):
-            return NodoLlamadaFuncion(node.func.id, args)
+            nombre = node.func.id
+            if nombre == "proyectar":
+                hb = args[0] if args else NodoValor(None)
+                modo = args[1] if len(args) > 1 else NodoValor(None)
+                return NodoProyectar(hb, modo)
+            if nombre == "transformar":
+                hb = args[0] if args else NodoValor(None)
+                oper = args[1] if len(args) > 1 else NodoValor(None)
+                params = args[2:] if len(args) > 2 else []
+                return NodoTransformar(hb, oper, params)
+            if nombre == "graficar":
+                hb = args[0] if args else NodoValor(None)
+                return NodoGraficar(hb)
+            return NodoLlamadaFuncion(nombre, args)
         
         raise NotImplementedError(f"Tipo de llamada no soportado: {type(node.func).__name__}")
 

--- a/src/cobra/transpilers/reverse/tree_sitter_base.py
+++ b/src/cobra/transpilers/reverse/tree_sitter_base.py
@@ -19,6 +19,9 @@ from core.ast_nodes import (
     NodoCondicional,
     NodoFuncion,
     NodoLlamadaFuncion,
+    NodoProyectar,
+    NodoTransformar,
+    NodoGraficar,
     NodoRetorno,
     NodoIdentificador,
     NodoValor,
@@ -184,6 +187,19 @@ class TreeSitterReverseTranspiler(BaseReverseTranspiler):
                 for child in args.children
                 if child.is_named
             ]
+
+        if nombre_txt == "proyectar":
+            hb = argumentos[0] if argumentos else NodoValor(None)
+            modo = argumentos[1] if len(argumentos) > 1 else NodoValor(None)
+            return NodoProyectar(hb, modo)
+        if nombre_txt == "transformar":
+            hb = argumentos[0] if argumentos else NodoValor(None)
+            oper = argumentos[1] if len(argumentos) > 1 else NodoValor(None)
+            params = argumentos[2:] if len(argumentos) > 2 else []
+            return NodoTransformar(hb, oper, params)
+        if nombre_txt == "graficar":
+            hb = argumentos[0] if argumentos else NodoValor(None)
+            return NodoGraficar(hb)
 
         return NodoLlamadaFuncion(nombre_txt, argumentos)
 

--- a/src/cobra/transpilers/transpiler/js_nodes/graficar.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/graficar.py
@@ -1,0 +1,3 @@
+def visit_graficar(self, nodo):
+    hb = self.obtener_valor(nodo.holobit)
+    self.agregar_linea(f"graficar({hb});")

--- a/src/cobra/transpilers/transpiler/js_nodes/proyectar.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/proyectar.py
@@ -1,0 +1,4 @@
+def visit_proyectar(self, nodo):
+    hb = self.obtener_valor(nodo.holobit)
+    modo = self.obtener_valor(nodo.modo)
+    self.agregar_linea(f"proyectar({hb}, {modo});")

--- a/src/cobra/transpilers/transpiler/js_nodes/transformar.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/transformar.py
@@ -1,0 +1,6 @@
+def visit_transformar(self, nodo):
+    hb = self.obtener_valor(nodo.holobit)
+    op = self.obtener_valor(nodo.operacion)
+    params = ", ".join(self.obtener_valor(p) for p in nodo.parametros)
+    argumentos = ", ".join(filter(None, [hb, op, params]))
+    self.agregar_linea(f"transformar({argumentos});")

--- a/src/cobra/transpilers/transpiler/python_nodes/graficar.py
+++ b/src/cobra/transpilers/transpiler/python_nodes/graficar.py
@@ -1,0 +1,3 @@
+def visit_graficar(self, nodo):
+    hb = self.obtener_valor(nodo.holobit)
+    self.codigo += f"{self.obtener_indentacion()}graficar({hb})\n"

--- a/src/cobra/transpilers/transpiler/python_nodes/proyectar.py
+++ b/src/cobra/transpilers/transpiler/python_nodes/proyectar.py
@@ -1,0 +1,4 @@
+def visit_proyectar(self, nodo):
+    hb = self.obtener_valor(nodo.holobit)
+    modo = self.obtener_valor(nodo.modo)
+    self.codigo += f"{self.obtener_indentacion()}proyectar({hb}, {modo})\n"

--- a/src/cobra/transpilers/transpiler/python_nodes/transformar.py
+++ b/src/cobra/transpilers/transpiler/python_nodes/transformar.py
@@ -1,0 +1,6 @@
+def visit_transformar(self, nodo):
+    hb = self.obtener_valor(nodo.holobit)
+    op = self.obtener_valor(nodo.operacion)
+    params = ", ".join(self.obtener_valor(p) for p in nodo.parametros)
+    argumentos = f"{hb}, {op}" + (", " + params if params else "")
+    self.codigo += f"{self.obtener_indentacion()}transformar({argumentos})\n"

--- a/src/cobra/transpilers/transpiler/to_js.py
+++ b/src/cobra/transpilers/transpiler/to_js.py
@@ -20,6 +20,9 @@ from core.ast_nodes import (
     NodoImport,
     NodoExport,
     NodoEsperar,
+    NodoProyectar,
+    NodoTransformar,
+    NodoGraficar,
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
@@ -50,6 +53,9 @@ from cobra.transpilers.transpiler.js_nodes.throw import visit_throw as _visit_th
 from cobra.transpilers.transpiler.js_nodes.importar import visit_import as _visit_import
 from cobra.transpilers.transpiler.js_nodes.instancia import visit_instancia as _visit_instancia
 from cobra.transpilers.transpiler.js_nodes.atributo import visit_atributo as _visit_atributo
+from cobra.transpilers.transpiler.js_nodes.proyectar import visit_proyectar as _visit_proyectar
+from cobra.transpilers.transpiler.js_nodes.transformar import visit_transformar as _visit_transformar
+from cobra.transpilers.transpiler.js_nodes.graficar import visit_graficar as _visit_graficar
 from cobra.transpilers.transpiler.js_nodes.operacion_binaria import (
     visit_operacion_binaria as _visit_operacion_binaria,
 )
@@ -206,6 +212,9 @@ TranspiladorJavaScript.visit_throw = _visit_throw
 TranspiladorJavaScript.visit_import = _visit_import
 TranspiladorJavaScript.visit_instancia = _visit_instancia
 TranspiladorJavaScript.visit_atributo = _visit_atributo
+TranspiladorJavaScript.visit_proyectar = _visit_proyectar
+TranspiladorJavaScript.visit_transformar = _visit_transformar
+TranspiladorJavaScript.visit_graficar = _visit_graficar
 TranspiladorJavaScript.visit_operacion_binaria = _visit_operacion_binaria
 TranspiladorJavaScript.visit_operacion_unaria = _visit_operacion_unaria
 TranspiladorJavaScript.visit_valor = _visit_valor

--- a/src/cobra/transpilers/transpiler/to_python.py
+++ b/src/cobra/transpilers/transpiler/to_python.py
@@ -26,6 +26,9 @@ from core.ast_nodes import (
     NodoThrow,
     NodoImport,
     NodoImprimir,
+    NodoProyectar,
+    NodoTransformar,
+    NodoGraficar,
     NodoAssert,
     NodoDel,
     NodoGlobal,
@@ -68,6 +71,9 @@ from cobra.transpilers.transpiler.python_nodes.usar import visit_usar as _visit_
 from cobra.transpilers.transpiler.python_nodes.hilo import visit_hilo as _visit_hilo
 from cobra.transpilers.transpiler.python_nodes.instancia import visit_instancia as _visit_instancia
 from cobra.transpilers.transpiler.python_nodes.atributo import visit_atributo as _visit_atributo
+from cobra.transpilers.transpiler.python_nodes.proyectar import visit_proyectar as _visit_proyectar
+from cobra.transpilers.transpiler.python_nodes.transformar import visit_transformar as _visit_transformar
+from cobra.transpilers.transpiler.python_nodes.graficar import visit_graficar as _visit_graficar
 from cobra.transpilers.transpiler.python_nodes.operacion_binaria import (
     visit_operacion_binaria as _visit_operacion_binaria,
 )
@@ -265,6 +271,9 @@ TranspiladorPython.visit_usar = _visit_usar
 TranspiladorPython.visit_hilo = _visit_hilo
 TranspiladorPython.visit_instancia = _visit_instancia
 TranspiladorPython.visit_atributo = _visit_atributo
+TranspiladorPython.visit_proyectar = _visit_proyectar
+TranspiladorPython.visit_transformar = _visit_transformar
+TranspiladorPython.visit_graficar = _visit_graficar
 TranspiladorPython.visit_operacion_binaria = _visit_operacion_binaria
 TranspiladorPython.visit_operacion_unaria = _visit_operacion_unaria
 TranspiladorPython.visit_valor = _visit_valor

--- a/src/core/ast_nodes.py
+++ b/src/core/ast_nodes.py
@@ -414,6 +414,30 @@ class NodoPara(NodoAST):
 
 
 @dataclass
+class NodoProyectar(NodoAST):
+    holobit: Any
+    modo: Any
+
+    """Proyección de un ``holobit`` en un modo específico."""
+
+
+@dataclass
+class NodoTransformar(NodoAST):
+    holobit: Any
+    operacion: Any
+    parametros: List[Any] = field(default_factory=list)
+
+    """Transformación aplicada a un ``holobit``."""
+
+
+@dataclass
+class NodoGraficar(NodoAST):
+    holobit: Any
+
+    """Visualización de un ``holobit``."""
+
+
+@dataclass
 class NodoImprimir(NodoAST):
     expresion: Any
 
@@ -500,6 +524,9 @@ __all__ = [
     "NodoImport",
     "NodoUsar",
     "NodoPara",
+    "NodoProyectar",
+    "NodoTransformar",
+    "NodoGraficar",
     "NodoImprimir",
     "NodoMacro",
     "NodoPattern",


### PR DESCRIPTION
## Summary
- agrega nodos AST para `proyectar`, `transformar` y `graficar`
- habilita al parser y a los transpiladores Python/JS para usar estas sentencias
- actualiza los transpiladores inversos para reconstruir dichas instrucciones

## Testing
- `pytest` *(falla: No module named 'cobra'; ModuleType errors)*

------
https://chatgpt.com/codex/tasks/task_e_6892af7652308327a7c06d0a7c227a06