### PR TITLE
feat: add generic translation for multiple transpilers

### DIFF
--- a/docs/genericos.md
+++ b/docs/genericos.md
@@ -12,14 +12,20 @@ clase Caja<T>:
     fin
 ```
 
-Al transpilar a Python y Rust los parámetros se conservan:
+Al transpilar a Python, Rust o C++ los parámetros se convierten en las
+construcciones genéricas propias de cada lenguaje. En lenguajes sin soporte
+de genéricos, como JavaScript, los parámetros de tipo se omiten y se utilizan
+tipos dinámicos.
 
 ```python
-from typing import TypeVar
+from typing import TypeVar, Generic
 T = TypeVar('T')
 
-def identidad[T](x):
+def identidad(x: T) -> T:
     return x
+
+class Caja(Generic[T]):
+    pass
 ```
 
 ```rust
@@ -28,4 +34,19 @@ fn identidad<T>(x: T) {
 
 struct Caja<T> {}
 impl<T> Caja<T> {}
+```
+
+```cpp
+template <typename T>
+void identidad(T x) {}
+
+template <typename T>
+class Caja {};
+```
+
+```javascript
+// Los parámetros genéricos se ignoran por la naturaleza dinámica de JS
+function identidad(x) {
+    return x;
+}
 ```

--- a/src/cobra/transpilers/transpiler/cpp_nodes/clase.py
+++ b/src/cobra/transpilers/transpiler/cpp_nodes/clase.py
@@ -2,6 +2,9 @@ def visit_clase(self, nodo):
     bases = getattr(nodo, 'bases', [])
     base = f" : public {bases[0]}" if bases else ""
     extra = f" // bases: {', '.join(bases)}" if len(bases) > 1 else ""
+    if getattr(nodo, "type_params", []):
+        genericos = ", ".join(f"typename {t}" for t in nodo.type_params)
+        self.agregar_linea(f"template <{genericos}>")
     self.agregar_linea(f"class {nodo.nombre}{base}{extra} {{")
     self.indent += 1
     for metodo in getattr(nodo, 'metodos', []):

--- a/src/cobra/transpilers/transpiler/cpp_nodes/funcion.py
+++ b/src/cobra/transpilers/transpiler/cpp_nodes/funcion.py
@@ -1,4 +1,7 @@
 def visit_funcion(self, nodo):
+    if getattr(nodo, "type_params", []):
+        genericos = ", ".join(f"typename {t}" for t in nodo.type_params)
+        self.agregar_linea(f"template <{genericos}>")
     parametros = ", ".join(f"auto {p}" for p in nodo.parametros)
     self.agregar_linea(f"void {nodo.nombre}({parametros}) {{")
     self.indent += 1

--- a/src/cobra/transpilers/transpiler/js_nodes/clase.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/clase.py
@@ -6,6 +6,10 @@ def visit_clase(self, nodo):
     bases = getattr(nodo, "bases", [])
     base = f" extends {bases[0]}" if bases else ""
     extra = f" /* bases: {', '.join(bases)} */" if len(bases) > 1 else ""
+    if getattr(nodo, "type_params", []):
+        self.agregar_linea(
+            f"// Generics {', '.join(nodo.type_params)} no soportados en JavaScript"
+        )
     self.agregar_linea(f"class {nodo.nombre}{base} {{{extra}")
     if self.usa_indentacion:
         self.indentacion += 1

--- a/src/cobra/transpilers/transpiler/js_nodes/funcion.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/funcion.py
@@ -4,6 +4,10 @@ def visit_funcion(self, nodo):
     cuerpo = nodo.cuerpo
     if self.usa_indentacion is None:
         self.usa_indentacion = any(hasattr(ins, "variable") for ins in cuerpo)
+    if getattr(nodo, "type_params", []):
+        self.agregar_linea(
+            f"// Generics {', '.join(nodo.type_params)} no soportados en JavaScript"
+        )
     palabra = "async function" if getattr(nodo, "asincronica", False) else "function"
     self.agregar_linea(f"{palabra} {nodo.nombre}({parametros}) {{")
     if self.usa_indentacion:

--- a/src/cobra/transpilers/transpiler/python_nodes/clase.py
+++ b/src/cobra/transpilers/transpiler/python_nodes/clase.py
@@ -2,11 +2,14 @@ def visit_clase(self, nodo):
     for decorador in getattr(nodo, "decoradores", []):
         decorador.aceptar(self)
     metodos = getattr(nodo, "metodos", getattr(nodo, "cuerpo", []))
-    bases = f"({', '.join(nodo.bases)})" if getattr(nodo, 'bases', []) else ""
-    genericos = (
-        f"[{', '.join(nodo.type_params)}]" if getattr(nodo, "type_params", []) else ""
-    )
-    self.codigo += f"{self.obtener_indentacion()}class {nodo.nombre}{genericos}{bases}:\n"
+    bases_lista = list(getattr(nodo, "bases", []))
+    if getattr(nodo, "type_params", []):
+        self.usa_typing = True
+        for tp in nodo.type_params:
+            self.codigo += f"{self.obtener_indentacion()}{tp} = TypeVar('{tp}')\n"
+        bases_lista.insert(0, f"Generic[{', '.join(nodo.type_params)}]")
+    bases = f"({', '.join(bases_lista)})" if bases_lista else ""
+    self.codigo += f"{self.obtener_indentacion()}class {nodo.nombre}{bases}:\n"
     self.nivel_indentacion += 1
     for metodo in metodos:
         metodo.aceptar(self)

--- a/src/cobra/transpilers/transpiler/python_nodes/funcion.py
+++ b/src/cobra/transpilers/transpiler/python_nodes/funcion.py
@@ -6,12 +6,11 @@ def visit_funcion(self, nodo):
     prefijo = "async def" if asincrona else "def"
     if asincrona:
         self.usa_asyncio = True
-    genericos = (
-        f"[{', '.join(nodo.type_params)}]" if getattr(nodo, "type_params", []) else ""
-    )
-    self.codigo += (
-        f"{self.obtener_indentacion()}{prefijo} {nodo.nombre}{genericos}({parametros}):\n"
-    )
+    if getattr(nodo, "type_params", []):
+        self.usa_typing = True
+        for tp in nodo.type_params:
+            self.codigo += f"{self.obtener_indentacion()}{tp} = TypeVar('{tp}')\n"
+    self.codigo += f"{self.obtener_indentacion()}{prefijo} {nodo.nombre}({parametros}):\n"
     self.nivel_indentacion += 1
     for instruccion in nodo.cuerpo:
         instruccion.aceptar(self)

--- a/src/cobra/transpilers/transpiler/to_cpp.py
+++ b/src/cobra/transpilers/transpiler/to_cpp.py
@@ -1,4 +1,7 @@
-"""Transpilador que genera código C++ a partir de Cobra."""
+"""Transpilador que genera código C++ a partir de Cobra.
+
+Los parámetros de tipo de Cobra se traducen a plantillas ``template`` propias
+de C++."""
 
 from core.ast_nodes import (
     NodoLista,

--- a/src/cobra/transpilers/transpiler/to_js.py
+++ b/src/cobra/transpilers/transpiler/to_js.py
@@ -1,4 +1,7 @@
-"""Transpilador que genera código JavaScript a partir de Cobra."""
+"""Transpilador que genera código JavaScript a partir de Cobra.
+
+Los parámetros de tipo se omiten porque JavaScript no soporta genéricos de
+forma nativa, por lo que se recurre a tipos dinámicos."""
 
 from core.ast_nodes import (
     NodoLista,

--- a/src/cobra/transpilers/transpiler/to_python.py
+++ b/src/cobra/transpilers/transpiler/to_python.py
@@ -153,6 +153,7 @@ class TranspiladorPython(BaseTranspiler):
         # Incluir los modulos nativos al inicio del codigo generado
         self.codigo = get_standard_imports("python")
         self.usa_asyncio = False
+        self.usa_typing = False
         self.nivel_indentacion = 0
 
     def generate_code(self, ast):
@@ -190,6 +191,8 @@ class TranspiladorPython(BaseTranspiler):
                 codigo = self.codigo.rstrip("\n")
         else:
             codigo = self.codigo
+        if self.usa_typing:
+            codigo = "from typing import TypeVar, Generic\n" + codigo
         if self.usa_asyncio:
             codigo = "import asyncio\n" + codigo
         return codigo

--- a/src/cobra/transpilers/transpiler/to_rust.py
+++ b/src/cobra/transpilers/transpiler/to_rust.py
@@ -1,4 +1,6 @@
-"""Transpilador que genera código Rust a partir de Cobra."""
+"""Transpilador que genera código Rust a partir de Cobra.
+
+Los parámetros de tipo de Cobra se convierten en genéricos idiomáticos de Rust."""
 
 from core.ast_nodes import (
     NodoLista,

--- a/src/tests/unit/test_to_python.py
+++ b/src/tests/unit/test_to_python.py
@@ -236,7 +236,13 @@ def test_imports_python_por_defecto():
 def test_transpilador_funcion_generica():
     func = NodoFuncion("identidad", ["x"], [NodoPasar()], type_params=["T"])
     codigo = TranspiladorPython().generate_code([func])
-    esperado = IMPORTS + "def identidad[T](x):\n    pass\n"
+    esperado = (
+        "from typing import TypeVar, Generic\n"
+        + IMPORTS
+        + "T = TypeVar('T')\n"
+        + "def identidad(x):\n"
+        + "    pass\n"
+    )
     assert codigo == esperado
 
 
@@ -245,8 +251,10 @@ def test_transpilador_clase_generica():
     clase = NodoClase("Caja", [metodo], type_params=["T"])
     codigo = TranspiladorPython().generate_code([clase])
     esperado = (
-        IMPORTS
-        + "class Caja[T]:\n"
+        "from typing import TypeVar, Generic\n"
+        + IMPORTS
+        + "T = TypeVar('T')\n"
+        + "class Caja(Generic[T]):\n"
         + "    def identidad(self, x):\n"
         + "        pass\n"
     )


### PR DESCRIPTION
## Summary
- Emit TypeVar declarations and Generic bases for Python transpilation
- Add template generation for C++ functions and classes
- Warn about missing generic support in JavaScript targets and update docs

## Testing
- `pytest src/tests/unit/test_to_python.py::test_transpilador_funcion_generica src/tests/unit/test_to_python.py::test_transpilador_clase_generica src/tests/unit/test_to_rust.py::test_transpilador_funcion_generica_rust src/tests/unit/test_to_rust.py::test_transpilador_clase_generica_rust src/tests/unit/test_to_cpp.py::test_transpilador_funcion src/tests/unit/test_to_js.py::test_transpilador_funcion -q > /tmp/pytest.log 2>&1 && tail -n 2 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_6892d352922c83279fcd62855467b01b