### PR TITLE
feat: soportar decoradores en clases

### DIFF
--- a/src/cobra/parser/parser.py
+++ b/src/cobra/parser/parser.py
@@ -204,20 +204,14 @@ class ClassicParser:
                 self.token_actual().tipo = TipoToken.FUNC
                 token = self.token_actual()
 
-            # Decoradores antes de funciones
+            # Decoradores antes de cualquier bloque o definición
             if token.tipo == TipoToken.DECORADOR:
                 decoradores = []
                 while self.token_actual().tipo == TipoToken.DECORADOR:
                     decoradores.append(self.declaracion_decorador())
-                asincronica = False
-                if self.token_actual().tipo == TipoToken.ASINCRONICO:
-                    self.comer(TipoToken.ASINCRONICO)
-                    asincronica = True
-                if self.token_actual().tipo != TipoToken.FUNC:
-                    raise ParserError("Un decorador debe preceder a una función")
-                funcion = self.declaracion_funcion(asincronica)
-                funcion.decoradores = decoradores + funcion.decoradores
-                return funcion
+                nodo = self.declaracion()
+                nodo.decoradores = decoradores + getattr(nodo, "decoradores", [])
+                return nodo
 
             if token.tipo == TipoToken.ASINCRONICO:
                 return self.declaracion_asincronico()
@@ -815,7 +809,7 @@ class ClassicParser:
         return NodoDiccionarioTipo(nombre, clave_tipo, valor_tipo, elementos)
 
     def declaracion_decorador(self):
-        """Parsea una línea de decorador previa a una función."""
+        """Parsea una línea de decorador previa a funciones o clases."""
         self.comer(TipoToken.DECORADOR)
         expresion = self.expresion()
         return NodoDecorador(expresion)

--- a/src/cobra/transpilers/transpiler/js_nodes/clase.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/clase.py
@@ -1,5 +1,5 @@
 def visit_clase(self, nodo):
-    """Transpila una clase en JavaScript, admitiendo métodos y clases anidados."""
+    """Transpila una clase en JavaScript aplicando sus decoradores."""
     metodos = getattr(nodo, "cuerpo", getattr(nodo, "metodos", []))
     if self.usa_indentacion is None:
         self.usa_indentacion = any(hasattr(m, "variable") for m in metodos)

--- a/src/cobra/transpilers/transpiler/python_nodes/clase.py
+++ b/src/cobra/transpilers/transpiler/python_nodes/clase.py
@@ -1,4 +1,5 @@
 def visit_clase(self, nodo):
+    """Genera la definición de una clase aplicando sus decoradores."""
     for decorador in getattr(nodo, "decoradores", []):
         decorador.aceptar(self)
     metodos = getattr(nodo, "metodos", getattr(nodo, "cuerpo", []))

--- a/src/tests/unit/test_parser_decorador.py
+++ b/src/tests/unit/test_parser_decorador.py
@@ -1,6 +1,6 @@
 from cobra.lexico.lexer import Lexer
 from cobra.parser.parser import Parser
-from core.ast_nodes import NodoFuncion, NodoDecorador, NodoIdentificador
+from core.ast_nodes import NodoFuncion, NodoClase, NodoDecorador, NodoIdentificador
 
 
 def test_parser_funcion_con_decorador():
@@ -10,6 +10,20 @@ def test_parser_funcion_con_decorador():
     assert len(ast) == 1
     nodo = ast[0]
     assert isinstance(nodo, NodoFuncion)
+    assert len(nodo.decoradores) == 1
+    decor = nodo.decoradores[0]
+    assert isinstance(decor, NodoDecorador)
+    assert isinstance(decor.expresion, NodoIdentificador)
+    assert decor.expresion.nombre == "decor"
+
+
+def test_parser_clase_con_decorador():
+    codigo = """@decor\nclase C:\n    pasar\nfin"""
+    tokens = Lexer(codigo).analizar_token()
+    ast = Parser(tokens).parsear()
+    assert len(ast) == 1
+    nodo = ast[0]
+    assert isinstance(nodo, NodoClase)
     assert len(nodo.decoradores) == 1
     decor = nodo.decoradores[0]
     assert isinstance(decor, NodoDecorador)

--- a/src/tests/unit/test_to_js.py
+++ b/src/tests/unit/test_to_js.py
@@ -23,6 +23,8 @@ from core.ast_nodes import (
     NodoImportDesde,
     NodoExport,
 )
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
 
 IMPORTS = "".join(f"{line}\n" for line in get_standard_imports("js"))
 
@@ -181,6 +183,21 @@ def test_decoradores_en_clase_y_metodo_js():
         + "}\n"
         + "}\n"
         + "C.prototype.run = dec(C.prototype.run);\n"
+        + "C = dec(C);"
+    )
+    assert resultado == esperado
+
+
+def test_clase_con_decorador_desde_parser_js():
+    codigo = """@dec\nclase C:\n    pasar\nfin"""
+    tokens = Lexer(codigo).analizar_token()
+    ast = Parser(tokens).parsear()
+    t = TranspiladorJavaScript()
+    resultado = t.generate_code(ast)
+    esperado = IMPORTS + (
+        "class C {\n"
+        + ";\n"
+        + "}\n"
         + "C = dec(C);"
     )
     assert resultado == esperado

--- a/src/tests/unit/test_to_python.py
+++ b/src/tests/unit/test_to_python.py
@@ -17,6 +17,8 @@ from core.ast_nodes import (
 from core.ast_nodes import NodoSwitch, NodoCase, NodoPattern, NodoGuard
 from cobra.transpilers.transpiler.to_python import TranspiladorPython
 from cobra.transpilers.import_helper import get_standard_imports
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
 
 IMPORTS = get_standard_imports("python")
 
@@ -225,6 +227,15 @@ def test_decoradores_en_clase_y_metodo():
         + "    async def run(self):\n"
         + "        pass\n"
     )
+    assert codigo == esperado
+
+
+def test_clase_con_decorador_desde_parser():
+    codigo_fuente = """@dec\nclase C:\n    pasar\nfin"""
+    tokens = Lexer(codigo_fuente).analizar_token()
+    ast = Parser(tokens).parsear()
+    codigo = TranspiladorPython().generate_code(ast)
+    esperado = IMPORTS + "@dec\nclass C:\n    pass\n"
     assert codigo == esperado
 
 


### PR DESCRIPTION
## Resumen
- Permitir decoradores delante de clases y otros bloques
- Aplicar decoradores de clase en los transpiladores de Python y JS
- Probar la transpilación de clases decoradas

## Testing
- `pytest src/tests/unit/test_parser_decorador.py::test_parser_clase_con_decorador src/tests/unit/test_to_python.py::test_clase_con_decorador_desde_parser src/tests/unit/test_to_js.py::test_clase_con_decorador_desde_parser_js`
- `pytest` *(falla: ModuleNotFoundError: No module named 'cli.commands')*


------
https://chatgpt.com/codex/tasks/task_e_6892dbde9c9c8327b458ea4da96f4631