### PR TITLE
feat: soporte inverso básico para Fortran con tree-sitter

### DIFF
--- a/docs/lenguajes.rst
+++ b/docs/lenguajes.rst
@@ -77,7 +77,7 @@ Los siguientes lenguajes pueden convertirse a Cobra:
    * - COBOL
      - Experimental
    * - Fortran
-     - Experimental
+     - Experimental (tree-sitter)
    * - Go
      - Experimental
    * - Java

--- a/docs/lenguajes_soportados.rst
+++ b/docs/lenguajes_soportados.rst
@@ -77,7 +77,7 @@ Los siguientes lenguajes pueden convertirse a Cobra:
    * - COBOL
      - Experimental
    * - Fortran
-     - Experimental
+     - Experimental (tree-sitter)
    * - Go
      - Experimental
    * - Java

--- a/src/cobra/transpilers/reverse/from_fortran.py
+++ b/src/cobra/transpilers/reverse/from_fortran.py
@@ -6,11 +6,15 @@ utilizando el parser tree-sitter.
 """
 
 from typing import Any, List
-from .tree_sitter_base import TreeSitterReverseTranspiler
+
+from .tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
 from core.ast_nodes import (
+    NodoAsignacion,
     NodoFuncion,
+    NodoIdentificador,
     NodoModulo,
-    NodoDeclaracion
+    NodoValor,
+    NodoDeclaracion,
 )
 
 class ReverseFromFortran(TreeSitterReverseTranspiler):
@@ -23,16 +27,75 @@ class ReverseFromFortran(TreeSitterReverseTranspiler):
     LANGUAGE = "fortran"
 
     def visit_program(self, node: Any) -> NodoModulo:
-        """Procesa un programa Fortran."""
-        # Implementación aquí
-        pass
+        """Procesa un ``program`` de Fortran."""
+        # El primer hijo es ``program_statement`` con el nombre
+        stmt = node.children[0] if node.children else None
+        nombre = ""
+        if stmt:
+            for c in stmt.children:
+                if c.type == "name":
+                    nombre = TreeSitterNode(c).get_text()
+                    break
+
+        # El cuerpo está compuesto por los nodos intermedios
+        cuerpo = [
+            self.visit(c)
+            for c in node.children[1:-1]
+            if c.is_named
+        ]
+
+        modulo = NodoModulo()
+        modulo.nombre = nombre
+        modulo.cuerpo = cuerpo
+        return modulo
 
     def visit_subroutine(self, node: Any) -> NodoFuncion:
-        """Procesa una subrutina Fortran."""
-        # Implementación aquí
-        pass
+        """Procesa una ``subroutine`` de Fortran."""
+        stmt = node.children[0] if node.children else None
+        nombre_n = stmt.child_by_field_name("name") if stmt else None
+        params_n = stmt.child_by_field_name("parameters") if stmt else None
 
-    def visit_declaration(self, node: Any) -> NodoDeclaracion:
-        """Procesa una declaración de variable."""
-        # Implementación aquí
-        pass
+        nombre = TreeSitterNode(nombre_n).get_text() if nombre_n else ""
+        parametros = [
+            TreeSitterNode(c).get_text()
+            for c in (params_n.children if params_n else [])
+            if c.is_named
+        ]
+
+        cuerpo = [
+            self.visit(c)
+            for c in node.children[1:-1]
+            if c.is_named
+        ]
+
+        return NodoFuncion(nombre, parametros, cuerpo)
+
+    def visit_variable_declaration(self, node: Any) -> NodoDeclaracion:
+        """Procesa una declaración simple de variable."""
+        tipo = TreeSitterNode(node.children[0]).get_text() if node.children else ""
+        nombre = (
+            TreeSitterNode(node.children[-1]).get_text() if len(node.children) > 2 else ""
+        )
+
+        decl = NodoDeclaracion()
+        decl.nombre = nombre
+        decl.tipo = tipo
+        return decl
+
+    # Alias para cumplir con la API solicitada
+    visit_declaration = visit_variable_declaration
+
+    # Nodos básicos ---------------------------------------------------
+    def visit_assignment_statement(self, node: Any) -> NodoAsignacion:
+        """Convierte una asignación ``a = b``."""
+        left = self.visit(node.child_by_field_name("left"))
+        right = self.visit(node.child_by_field_name("right"))
+        return NodoAsignacion(left, right)
+
+    def visit_number_literal(self, node: Any) -> NodoValor:
+        """Convierte un literal numérico."""
+        return self.visit_number(node)
+
+    def visit_identifier(self, node: Any) -> NodoIdentificador:
+        """Alias explícito para identificadores."""
+        return super().visit_identifier(node)

--- a/src/tests/integration/reverse/test_from_fortran.py
+++ b/src/tests/integration/reverse/test_from_fortran.py
@@ -1,0 +1,47 @@
+"""Pruebas para el transpilador inverso de Fortran."""
+
+from cobra.transpilers.reverse.from_fortran import ReverseFromFortran
+from core.ast_nodes import (
+    NodoAsignacion,
+    NodoDeclaracion,
+    NodoFuncion,
+    NodoIdentificador,
+    NodoModulo,
+    NodoValor,
+)
+
+
+def test_reverse_from_fortran_program():
+    code = "program hola\ninteger :: a\na = 5\nend program hola\n"
+    ast = ReverseFromFortran().generate_ast(code)
+    assert len(ast) == 1
+    modulo = ast[0]
+    assert isinstance(modulo, NodoModulo)
+    assert modulo.nombre == "hola"
+    assert len(modulo.cuerpo) == 2
+
+    decl = modulo.cuerpo[0]
+    assert isinstance(decl, NodoDeclaracion)
+    assert decl.nombre == "a"
+    assert decl.tipo == "integer"
+
+    asign = modulo.cuerpo[1]
+    assert isinstance(asign, NodoAsignacion)
+    assert isinstance(asign.variable, NodoIdentificador)
+    assert asign.variable.nombre == "a"
+    assert isinstance(asign.expresion, NodoValor)
+    assert asign.expresion.valor == 5
+
+
+def test_reverse_from_fortran_subroutine():
+    code = "subroutine foo(x)\ninteger :: x\nend subroutine foo\n"
+    ast = ReverseFromFortran().generate_ast(code)
+    assert len(ast) == 1
+    func = ast[0]
+    assert isinstance(func, NodoFuncion)
+    assert func.nombre == "foo"
+    assert func.parametros == ["x"]
+    assert len(func.cuerpo) == 1
+    decl = func.cuerpo[0]
+    assert isinstance(decl, NodoDeclaracion)
+    assert decl.nombre == "x"


### PR DESCRIPTION
## Resumen
- Añadido transpilador inverso para Fortran usando tree-sitter.
- Se documentó Fortran como lenguaje de entrada experimental.
- Se incluyeron pruebas de conversión desde Fortran al AST de Cobra.

## Pruebas
- `pytest src/tests/integration/reverse/test_from_fortran.py`


------
https://chatgpt.com/codex/tasks/task_e_68937d5ae81083279bdd3d325c0786c1