### PR TITLE
feat: add basic latex reverse transpiler

### DIFF
--- a/docs/lenguajes.rst
+++ b/docs/lenguajes.rst
@@ -126,3 +126,5 @@ Para habilitar estos transpiladores inversos es necesario instalar las gramátic
 
 Este paquete incluye gramáticas para los lenguajes listados y puede instalarse junto con las dependencias del proyecto.
 
+Para conocer el alcance y las limitaciones del soporte de LaTeX consulte :doc:`soporte_latex`.
+

--- a/docs/lenguajes_soportados.rst
+++ b/docs/lenguajes_soportados.rst
@@ -126,3 +126,5 @@ Para habilitar estos transpiladores inversos es necesario instalar las gramátic
 
 Este paquete incluye gramáticas para los lenguajes listados y puede instalarse junto con las dependencias del proyecto.
 
+Para conocer el alcance y las limitaciones del soporte de LaTeX consulte :doc:`soporte_latex`.
+

--- a/docs/soporte_latex.md
+++ b/docs/soporte_latex.md
@@ -1,0 +1,30 @@
+# Soporte LaTeX
+
+El transpilador inverso **ReverseFromLatex** permite convertir fragmentos
+básicos de pseudocódigo escritos en LaTeX al AST de Cobra. El objetivo es
+facilitar prototipos sencillos donde se utilice el entorno `algorithmic` o
+comandos similares.
+
+## Alcance
+
+- Comando `\STATE` con asignaciones y expresiones matemáticas simples.
+- Condicionales `\IF`/`\ELSE`/`\ENDIF`.
+- Bucles `\WHILE`/`\ENDWHILE`.
+- Bucles `\FOR{$i=1 \TO n$}`/`\ENDFOR` con límites numéricos o
+  expresiones aritméticas.
+- Las expresiones se analizan mediante [`sympy`](https://www.sympy.org/),
+  lo que habilita operadores como `+`, `-`, `*`, `/`, `^` y comparaciones.
+
+## Limitaciones
+
+- No se soportan macros personalizadas ni entornos de LaTeX distintos al
+  pseudocódigo mencionado.
+- El formato del bucle `\FOR` debe seguir exactamente la forma
+  `\FOR{$i=1 \TO n$}`. Otras variantes no son reconocidas.
+- No se manejan estructuras adicionales del paquete `algorithmic` como
+  `\REPEAT`, `\UNTIL` o funciones definidas en LaTeX.
+- El análisis ignora todo texto ajeno a los comandos anteriores.
+
+Este soporte es experimental y está destinado a ejemplos mínimos; la
+complejidad completa del lenguaje LaTeX queda fuera del alcance actual.
+

--- a/src/cobra/transpilers/reverse/from_latex.py
+++ b/src/cobra/transpilers/reverse/from_latex.py
@@ -1,31 +1,124 @@
 # -*- coding: utf-8 -*-
-"""Transpilador inverso desde LaTeX a Cobra (no soportado)."""
+"""Transpilador inverso desde LaTeX a Cobra."""
+
+from __future__ import annotations
+
+import re
 from typing import Any, List
+
+from sympy.parsing.latex import parse_latex
+from sympy.printing.pycode import pycode
+
 from cobra.transpilers.reverse.base import BaseReverseTranspiler
+from cobra.transpilers.reverse.from_python import ReverseFromPython
+
 
 class ReverseFromLatex(BaseReverseTranspiler):
-    """Transpilador inverso de LaTeX a Cobra.
-    
-    Esta funcionalidad no está actualmente implementada debido a la complejidad
-    del parsing de LaTeX.
+    r"""Convierte fragmentos básicos de LaTeX en nodos del AST de Cobra.
+
+    Este conversor se enfoca en pseudocódigo escrito mediante comandos
+    como ``\STATE``, ``\IF`` o ``\FOR`` presentes comúnmente en el
+    entorno ``algorithmic``. Las expresiones matemáticas se convierten
+    utilizando :mod:`sympy`.
     """
-    
-    def __init__(self) -> None:
+
+    def __init__(self) -> None:  # pragma: no cover - inicialización trivial
         super().__init__()
-    
+        self.python_transpiler = ReverseFromPython()
+
+    # ------------------------------------------------------------------
+    # Utilidades internas
+    def _latex_expr_to_python(self, expr: str) -> str:
+        """Transforma una expresión LaTeX en su equivalente en Python."""
+
+        expr = expr.strip().strip("$")
+        return pycode(parse_latex(expr))
+
+    def _extract_braces(self, line: str) -> str:
+        """Obtiene el contenido de las llaves ``{}`` de un comando LaTeX."""
+
+        match = re.match(r"\\[A-Za-z]+\{(.*)\}", line)
+        return match.group(1) if match else ""
+
+    def _clean_identifier(self, ident: str) -> str:
+        """Normaliza un identificador LaTeX removiendo escapes."""
+
+        ident = ident.strip().strip("$")
+        return ident.replace("\\", "")
+
+    # ------------------------------------------------------------------
     def generate_ast(self, code: str) -> List[Any]:
-        """Genera el AST Cobra desde código LaTeX.
-        
-        Args:
-            code: Código fuente en LaTeX
-            
-        Returns:
-            List[Any]: Lista de nodos AST de Cobra
-            
-        Raises:
-            NotImplementedError: Esta funcionalidad no está implementada actualmente
-        """
-        raise NotImplementedError(
-            "La conversión desde LaTeX no está implementada debido a la complejidad "
-            "del parsing. Considere usar otro formato de entrada soportado."
-        )
+        """Genera el AST Cobra equivalente al pseudocódigo en LaTeX."""
+
+        python_lines: List[str] = []
+        indent = 0
+
+        for raw_line in code.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("%"):
+                continue
+            if line.startswith("\\begin") or line.startswith("\\end"):
+                continue
+
+            if line.startswith("\\STATE"):
+                content = line[len("\\STATE") :].strip()
+                if content.startswith("{") and content.endswith("}"):
+                    content = content[1:-1].strip()
+                if "=" in content:
+                    izquierda, derecha = content.split("=", 1)
+                    var = self._clean_identifier(izquierda)
+                    expr = self._latex_expr_to_python(derecha)
+                    python_lines.append("    " * indent + f"{var} = {expr}")
+                else:
+                    expr = self._latex_expr_to_python(content)
+                    python_lines.append("    " * indent + expr)
+                continue
+
+            if line.startswith("\\IF"):
+                condicion = self._latex_expr_to_python(self._extract_braces(line))
+                python_lines.append("    " * indent + f"if {condicion}:")
+                indent += 1
+                continue
+
+            if line.startswith("\\ELSE"):
+                indent -= 1
+                python_lines.append("    " * indent + "else:")
+                indent += 1
+                continue
+
+            if line.startswith("\\ENDIF"):
+                indent -= 1
+                continue
+
+            if line.startswith("\\WHILE"):
+                condicion = self._latex_expr_to_python(self._extract_braces(line))
+                python_lines.append("    " * indent + f"while {condicion}:")
+                indent += 1
+                continue
+
+            if line.startswith("\\ENDWHILE"):
+                indent -= 1
+                continue
+
+            if line.startswith("\\FOR"):
+                dentro = self._extract_braces(line).replace("$", "").strip()
+                if "\\TO" not in dentro:
+                    raise NotImplementedError("Formato de FOR no soportado")
+                parte_var, parte_fin = dentro.split("\\TO", 1)
+                var, inicio = parte_var.split("=", 1)
+                var = self._clean_identifier(var)
+                inicio_py = self._latex_expr_to_python(inicio)
+                fin_py = self._latex_expr_to_python(parte_fin)
+                python_lines.append(
+                    "    " * indent + f"for {var} in range({inicio_py}, {fin_py} + 1):"
+                )
+                indent += 1
+                continue
+
+            if line.startswith("\\ENDFOR"):
+                indent -= 1
+                continue
+
+        python_code = "\n".join(python_lines)
+        return self.python_transpiler.generate_ast(python_code)
+

--- a/src/tests/unit/test_reverse_latex.py
+++ b/src/tests/unit/test_reverse_latex.py
@@ -1,0 +1,48 @@
+from cobra.transpilers.reverse.from_latex import ReverseFromLatex
+from core.ast_nodes import (
+    NodoAsignacion,
+    NodoBucleMientras,
+    NodoCondicional,
+    NodoPara,
+)
+
+
+def test_reverse_from_latex_conditional():
+    codigo = r"""
+    \begin{algorithmic}
+    \STATE $x = a + b$
+    \IF{$x > 0$}
+        \STATE $y = x - 1$
+    \ENDIF
+    \end{algorithmic}
+    """
+
+    ast = ReverseFromLatex().generate_ast(codigo)
+    assert len(ast) == 2
+    assert isinstance(ast[0], NodoAsignacion)
+    cond = ast[1]
+    assert isinstance(cond, NodoCondicional)
+    assert isinstance(cond.bloque_si[0], NodoAsignacion)
+
+
+def test_reverse_from_latex_loops():
+    codigo = r"""
+    \begin{algorithmic}
+    \FOR{$i=1 \TO n$}
+        \STATE $s = s + i$
+    \ENDFOR
+    \WHILE{$s > 0$}
+        \STATE $s = s - 1$
+    \ENDWHILE
+    \end{algorithmic}
+    """
+
+    ast = ReverseFromLatex().generate_ast(codigo)
+    assert len(ast) == 2
+    ciclo_for = ast[0]
+    assert isinstance(ciclo_for, NodoPara)
+    assert isinstance(ciclo_for.cuerpo[0], NodoAsignacion)
+    ciclo_while = ast[1]
+    assert isinstance(ciclo_while, NodoBucleMientras)
+    assert isinstance(ciclo_while.cuerpo[0], NodoAsignacion)
+


### PR DESCRIPTION
## Summary
- implement ReverseFromLatex using SymPy and ReverseFromPython
- add minimal LaTeX reverse transpiler tests
- document current LaTeX reverse limitations

## Testing
- `pytest src/tests/unit/test_reverse_latex.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893863b77e88327aae6e8729c709eb2