### PR TITLE
Add enum declaration support

### DIFF
--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -206,3 +206,10 @@ imprimir factorial(5)
 ## 26. Comando verify
 El subcomando `cobra verificar` (`cobra verify`) comprueba que un programa
 genere la misma salida en distintos lenguajes.
+
+## 27. Enumeraciones
+```cobra
+enum Color:
+    ROJO, VERDE, AZUL
+fin
+```

--- a/src/cobra/lexico/lexer.py
+++ b/src/cobra/lexico/lexer.py
@@ -37,6 +37,7 @@ class TipoToken(Enum):
     DIVIDIR = "DIVIDIR"
     MULTIPLICAR = "MULTIPLICAR"
     CLASE = "CLASE"
+    ENUM = "ENUM"
     DICCIONARIO = "DICCIONARIO"
     LISTA = "LISTA"
     RBRACE = "RBRACE"
@@ -215,6 +216,7 @@ class Lexer:
             (TipoToken.SWITCH, re.compile(r"\b(switch|segun)\b")),
             (TipoToken.CASE, re.compile(r"\b(case|caso)\b")),
             (TipoToken.CLASE, re.compile(r"\bclase\b")),
+            (TipoToken.ENUM, re.compile(r"\benum\b")),
             (TipoToken.IN, re.compile(r"\bin\b")),
             (TipoToken.HOLOBIT, re.compile(r"\bholobit\b")),
             (TipoToken.PROYECTAR, re.compile(r"\bproyectar\b")),

--- a/src/cobra/parser/parser.py
+++ b/src/cobra/parser/parser.py
@@ -14,6 +14,7 @@ from core.ast_nodes import (
     NodoBucleMientras,
     NodoFuncion,
     NodoClase,
+    NodoEnum,
     NodoMetodo,
     NodoAtributo,
     NodoLlamadaFuncion,
@@ -99,6 +100,7 @@ class ClassicParser:
             TipoToken.PASAR: self.declaracion_pasar,
             TipoToken.MACRO: self.declaracion_macro,
             TipoToken.CLASE: self.declaracion_clase,
+            TipoToken.ENUM: self.declaracion_enum,
             TipoToken.AFIRMAR: self.declaracion_afirmar,
             TipoToken.ELIMINAR: self.declaracion_eliminar,
             TipoToken.GLOBAL: self.declaracion_global,
@@ -1117,6 +1119,33 @@ class ClassicParser:
         return NodoMetodo(
             nombre, parametros, cuerpo, asincronica=asincronica, type_params=type_params
         )
+
+    def declaracion_enum(self):
+        """Parsea la declaración de un enum."""
+        self.comer(TipoToken.ENUM)
+        if self.token_actual().tipo != TipoToken.IDENTIFICADOR:
+            raise ParserError("Se esperaba un nombre de enum")
+        nombre = self.token_actual().valor
+        self.comer(TipoToken.IDENTIFICADOR)
+
+        if self.token_actual().tipo != TipoToken.DOSPUNTOS:
+            raise ParserError("Se esperaba ':' después del nombre del enum")
+        self.comer(TipoToken.DOSPUNTOS)
+
+        miembros: list[str] = []
+        while self.token_actual().tipo != TipoToken.FIN:
+            if self.token_actual().tipo != TipoToken.IDENTIFICADOR:
+                raise ParserError("Se esperaba un identificador de miembro")
+            miembros.append(self.token_actual().valor)
+            self.comer(TipoToken.IDENTIFICADOR)
+            if self.token_actual().tipo == TipoToken.COMA:
+                self.comer(TipoToken.COMA)
+            elif self.token_actual().tipo == TipoToken.FIN:
+                break
+        if self.token_actual().tipo != TipoToken.FIN:
+            raise ParserError("Se esperaba 'fin' para cerrar el enum")
+        self.comer(TipoToken.FIN)
+        return NodoEnum(nombre, miembros)
 
     def declaracion_clase(self):
         """Parsea la declaración de una clase."""

--- a/src/cobra/parser/utils.py
+++ b/src/cobra/parser/utils.py
@@ -57,6 +57,7 @@ PALABRAS_RESERVADAS = frozenset(
         "capturar",
         "lanzar",
         "option",
+        "enum",
     }
 )
 

--- a/src/cobra/transpilers/transpiler/js_nodes/enum.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/enum.py
@@ -1,0 +1,4 @@
+def visit_enum(self, nodo):
+    """Genera un objeto que representa un ``enum``."""
+    miembros = ", ".join(f"{m}: {i}" for i, m in enumerate(nodo.miembros))
+    self.agregar_linea(f"const {nodo.nombre} = {{{miembros}}};")

--- a/src/cobra/transpilers/transpiler/python_nodes/enum.py
+++ b/src/cobra/transpilers/transpiler/python_nodes/enum.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+def visit_enum(self, nodo):
+    """Genera la definición de un ``enum`` sencillo."""
+    self.codigo += f"{self.obtener_indentacion()}class {nodo.nombre}:\n"
+    self.nivel_indentacion += 1
+    for idx, miembro in enumerate(nodo.miembros):
+        self.codigo += f"{self.obtener_indentacion()}{miembro} = {idx}\n"
+    self.nivel_indentacion -= 1

--- a/src/cobra/transpilers/transpiler/to_js.py
+++ b/src/cobra/transpilers/transpiler/to_js.py
@@ -32,6 +32,7 @@ from core.ast_nodes import (
     NodoGraficar,
     NodoOption,
     NodoPattern,
+    NodoEnum,
 )
 from cobra.lexico.lexer import TipoToken
 from core.visitor import NodeVisitor
@@ -82,6 +83,7 @@ from cobra.transpilers.transpiler.js_nodes.switch import visit_switch as _visit_
 from cobra.transpilers.transpiler.js_nodes.exportar import visit_export as _visit_export
 from cobra.transpilers.transpiler.js_nodes.option import visit_option as _visit_option
 from cobra.transpilers.transpiler.js_nodes.pattern import visit_pattern as _visit_pattern
+from cobra.transpilers.transpiler.js_nodes.enum import visit_enum as _visit_enum
 
 
 def visit_assert(self, nodo):
@@ -310,5 +312,6 @@ TranspiladorJavaScript.visit_lista_comprehension = visit_lista_comprehension
 TranspiladorJavaScript.visit_diccionario_comprehension = visit_diccionario_comprehension
 TranspiladorJavaScript.visit_option = _visit_option
 TranspiladorJavaScript.visit_pattern = _visit_pattern
+TranspiladorJavaScript.visit_enum = _visit_enum
 
 # Métodos de transpilación para tipos de nodos básicos

--- a/src/cobra/transpilers/transpiler/to_python.py
+++ b/src/cobra/transpilers/transpiler/to_python.py
@@ -15,6 +15,7 @@ from core.ast_nodes import (
     NodoListaTipo,
     NodoDiccionarioTipo,
     NodoClase,
+    NodoEnum,
     NodoMetodo,
     NodoValor,
     NodoRetorno,
@@ -143,6 +144,9 @@ from cobra.transpilers.transpiler.python_nodes.switch import (
 )
 from cobra.transpilers.transpiler.python_nodes.option import (
     visit_option as _visit_option,
+)
+from cobra.transpilers.transpiler.python_nodes.enum import (
+    visit_enum as _visit_enum,
 )
 
 
@@ -402,6 +406,7 @@ TranspiladorPython.visit_pasar = _visit_pasar
 TranspiladorPython.visit_esperar = _visit_esperar
 TranspiladorPython.visit_switch = _visit_switch
 TranspiladorPython.visit_option = _visit_option
+TranspiladorPython.visit_enum = _visit_enum
 TranspiladorPython.visit_assert = visit_assert
 TranspiladorPython.visit_del = visit_del
 TranspiladorPython.visit_global = visit_global

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "NodoDiccionarioComprehension",
     "NodoFuncion",
     "NodoClase",
+    "NodoEnum",
     "NodoMetodo",
     "NodoInstancia",
     "NodoAtributo",

--- a/src/core/ast_nodes.py
+++ b/src/core/ast_nodes.py
@@ -162,6 +162,14 @@ class NodoClase(NodoAST):
 
 
 @dataclass
+class NodoEnum(NodoAST):
+    nombre: str
+    miembros: List[str]
+
+    """Declaración de un ``enum`` con sus miembros."""
+
+
+@dataclass
 class NodoMetodo(NodoAST):
     nombre: str
     parametros: List[str]

--- a/src/tests/unit/test_enum.py
+++ b/src/tests/unit/test_enum.py
@@ -1,0 +1,38 @@
+import core.visitor as _vis
+import sys
+
+# Compatibilidad para pruebas
+sys.modules.setdefault("backend.src.core.visitor", _vis)
+sys.modules.setdefault("backend.src.core", sys.modules.get("core"))
+
+from cobra.lexico.lexer import Lexer
+from cobra.parser.parser import Parser
+from core.ast_nodes import NodoEnum
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.import_helper import get_standard_imports
+
+IMPORTS_PY = get_standard_imports("python")
+IMPORTS_JS = "".join(f"{line}\n" for line in get_standard_imports("js"))
+
+
+def test_parser_enum():
+    codigo = "enum Color: ROJO, VERDE fin"
+    ast = Parser(Lexer(codigo).analizar_token()).parsear()
+    assert isinstance(ast[0], NodoEnum)
+    assert ast[0].nombre == "Color"
+    assert ast[0].miembros == ["ROJO", "VERDE"]
+
+
+def test_transpilador_python_enum():
+    nodo = NodoEnum("Color", ["ROJO", "VERDE"])
+    codigo = TranspiladorPython().generate_code([nodo])
+    esperado = IMPORTS_PY + "class Color:\n    ROJO = 0\n    VERDE = 1\n"
+    assert codigo == esperado
+
+
+def test_transpilador_js_enum():
+    nodo = NodoEnum("Color", ["ROJO", "VERDE"])
+    codigo = TranspiladorJavaScript().generate_code([nodo])
+    esperado = IMPORTS_JS + "const Color = {ROJO: 0, VERDE: 1};"
+    assert codigo == esperado


### PR DESCRIPTION
## Summary
- add `ENUM` token and lexer rules
- implement `NodoEnum` and parser support
- transpile enums to Python and JavaScript
- document enum syntax and cover with unit tests

## Testing
- `pytest` *(fails: No module named 'cli.cli')*
- `pytest src/tests/unit/test_enum.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893915429708327ba5ce88c22e46c70