### PR TITLE
feat: soporte de unicode y comentarios anidados en lexer

### DIFF
--- a/src/tests/unit/test_lexer_edge_unicode.py
+++ b/src/tests/unit/test_lexer_edge_unicode.py
@@ -1,0 +1,51 @@
+import pytest
+from cobra.lexico.lexer import Lexer, TipoToken
+
+
+def test_identificadores_unicode():
+    codigo = "var á = 1\nvar βeta = 2"
+    tokens = Lexer(codigo).analizar_token()
+    assert [(t.tipo, t.valor) for t in tokens] == [
+        (TipoToken.VAR, 'var'),
+        (TipoToken.IDENTIFICADOR, 'á'),
+        (TipoToken.ASIGNAR, '='),
+        (TipoToken.ENTERO, 1),
+        (TipoToken.VAR, 'var'),
+        (TipoToken.IDENTIFICADOR, 'βeta'),
+        (TipoToken.ASIGNAR, '='),
+        (TipoToken.ENTERO, 2),
+        (TipoToken.EOF, None),
+    ]
+
+
+def test_cadenas_escape_mixtas():
+    codigo = 'var texto = "Linea1\\r\\nLinea2\\tTab"'
+    tokens = Lexer(codigo).analizar_token()
+    assert [(t.tipo, t.valor) for t in tokens] == [
+        (TipoToken.VAR, 'var'),
+        (TipoToken.IDENTIFICADOR, 'texto'),
+        (TipoToken.ASIGNAR, '='),
+        (TipoToken.CADENA, "Linea1\r\nLinea2\tTab"),
+        (TipoToken.EOF, None),
+    ]
+
+
+def test_comentarios_anidados_y_linea_en_bloque():
+    codigo = """
+    var x = 1 /* comentario externo
+                 /* comentario interno */
+                 // comentario de linea dentro
+               */ var y = 2
+    """
+    tokens = Lexer(codigo).analizar_token()
+    assert [(t.tipo, t.valor) for t in tokens] == [
+        (TipoToken.VAR, 'var'),
+        (TipoToken.IDENTIFICADOR, 'x'),
+        (TipoToken.ASIGNAR, '='),
+        (TipoToken.ENTERO, 1),
+        (TipoToken.VAR, 'var'),
+        (TipoToken.IDENTIFICADOR, 'y'),
+        (TipoToken.ASIGNAR, '='),
+        (TipoToken.ENTERO, 2),
+        (TipoToken.EOF, None),
+    ]


### PR DESCRIPTION
## Summary
- permitir identificadores Unicode explícitos
- manejar comentarios de bloque anidados y `//` dentro de `/* */`
- añadir pruebas de lexer para unicode, escapes de cadena y comentarios complejos

## Testing
- `PYTHONPATH=src pytest -q src/tests/unit/test_lexer_edge_unicode.py`

------
https://chatgpt.com/codex/tasks/task_e_68974706e3688327b8c9da69fff486a7