### PR TITLE
feat(transpiler): ampliar soporte de Go y Java

### DIFF
--- a/src/cobra/transpilers/transpiler/go_nodes/asignacion.py
+++ b/src/cobra/transpilers/transpiler/go_nodes/asignacion.py
@@ -1,0 +1,6 @@
+def visit_asignacion(self, nodo):
+    nombre = getattr(nodo, "identificador", nodo.variable)
+    op = ":=" if hasattr(nodo, "variable") else "="
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"{nombre} {op} {valor}")
+

--- a/src/cobra/transpilers/transpiler/go_nodes/bucle_mientras.py
+++ b/src/cobra/transpilers/transpiler/go_nodes/bucle_mientras.py
@@ -1,0 +1,9 @@
+def visit_bucle_mientras(self, nodo):
+    condicion = self.obtener_valor(nodo.condicion)
+    self.agregar_linea(f"for {condicion} {{")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+

--- a/src/cobra/transpilers/transpiler/go_nodes/clase.py
+++ b/src/cobra/transpilers/transpiler/go_nodes/clase.py
@@ -1,0 +1,7 @@
+def visit_clase(self, nodo):
+    metodos = getattr(nodo, "metodos", getattr(nodo, "cuerpo", []))
+    self.agregar_linea(f"type {nodo.nombre} struct {{}}")
+    for metodo in metodos:
+        setattr(metodo, "nombre_clase", nodo.nombre)
+        metodo.aceptar(self)
+

--- a/src/cobra/transpilers/transpiler/go_nodes/condicional.py
+++ b/src/cobra/transpilers/transpiler/go_nodes/condicional.py
@@ -1,0 +1,17 @@
+def visit_condicional(self, nodo):
+    cuerpo_si = getattr(nodo, "cuerpo_si", getattr(nodo, "bloque_si", []))
+    cuerpo_sino = getattr(nodo, "cuerpo_sino", getattr(nodo, "bloque_sino", []))
+    condicion = self.obtener_valor(nodo.condicion)
+    self.agregar_linea(f"if {condicion} {{")
+    self.indent += 1
+    for inst in cuerpo_si:
+        inst.aceptar(self)
+    self.indent -= 1
+    if cuerpo_sino:
+        self.agregar_linea("} else {")
+        self.indent += 1
+        for inst in cuerpo_sino:
+            inst.aceptar(self)
+        self.indent -= 1
+    self.agregar_linea("}")
+

--- a/src/cobra/transpilers/transpiler/go_nodes/continuar.py
+++ b/src/cobra/transpilers/transpiler/go_nodes/continuar.py
@@ -1,0 +1,3 @@
+def visit_continuar(self, nodo):
+    self.agregar_linea("continue")
+

--- a/src/cobra/transpilers/transpiler/go_nodes/for_.py
+++ b/src/cobra/transpilers/transpiler/go_nodes/for_.py
@@ -1,0 +1,9 @@
+def visit_for(self, nodo):
+    iterable = self.obtener_valor(nodo.iterable)
+    self.agregar_linea(f"for _, {nodo.variable} := range {iterable} {{")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+

--- a/src/cobra/transpilers/transpiler/go_nodes/funcion.py
+++ b/src/cobra/transpilers/transpiler/go_nodes/funcion.py
@@ -1,0 +1,9 @@
+def visit_funcion(self, nodo):
+    params = ", ".join(nodo.parametros)
+    self.agregar_linea(f"func {nodo.nombre}({params}) {{")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+

--- a/src/cobra/transpilers/transpiler/go_nodes/imprimir.py
+++ b/src/cobra/transpilers/transpiler/go_nodes/imprimir.py
@@ -1,0 +1,4 @@
+def visit_imprimir(self, nodo):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"fmt.Println({valor})")
+

--- a/src/cobra/transpilers/transpiler/go_nodes/instancia.py
+++ b/src/cobra/transpilers/transpiler/go_nodes/instancia.py
@@ -1,0 +1,3 @@
+def visit_instancia(self, nodo):
+    self.agregar_linea(self.obtener_valor(nodo))
+

--- a/src/cobra/transpilers/transpiler/go_nodes/llamada_funcion.py
+++ b/src/cobra/transpilers/transpiler/go_nodes/llamada_funcion.py
@@ -1,0 +1,4 @@
+def visit_llamada_funcion(self, nodo):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"{nodo.nombre}({args})")
+

--- a/src/cobra/transpilers/transpiler/go_nodes/llamada_metodo.py
+++ b/src/cobra/transpilers/transpiler/go_nodes/llamada_metodo.py
@@ -1,0 +1,5 @@
+def visit_llamada_metodo(self, nodo):
+    obj = self.obtener_valor(nodo.objeto)
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"{obj}.{nodo.nombre_metodo}({args})")
+

--- a/src/cobra/transpilers/transpiler/go_nodes/metodo.py
+++ b/src/cobra/transpilers/transpiler/go_nodes/metodo.py
@@ -1,0 +1,11 @@
+def visit_metodo(self, nodo):
+    params = ", ".join(nodo.parametros)
+    clase = getattr(nodo, "nombre_clase", "")
+    receptor = f"(self *{clase}) " if clase else ""
+    self.agregar_linea(f"func {receptor}{nodo.nombre}({params}) {{")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+

--- a/src/cobra/transpilers/transpiler/go_nodes/retorno.py
+++ b/src/cobra/transpilers/transpiler/go_nodes/retorno.py
@@ -1,0 +1,7 @@
+def visit_retorno(self, nodo):
+    if getattr(nodo, "expresion", None) is not None:
+        valor = self.obtener_valor(nodo.expresion)
+        self.agregar_linea(f"return {valor}")
+    else:
+        self.agregar_linea("return")
+

--- a/src/cobra/transpilers/transpiler/go_nodes/romper.py
+++ b/src/cobra/transpilers/transpiler/go_nodes/romper.py
@@ -1,0 +1,3 @@
+def visit_romper(self, nodo):
+    self.agregar_linea("break")
+

--- a/src/cobra/transpilers/transpiler/java_nodes/asignacion.py
+++ b/src/cobra/transpilers/transpiler/java_nodes/asignacion.py
@@ -1,0 +1,5 @@
+def visit_asignacion(self, nodo):
+    nombre = getattr(nodo, "identificador", nodo.variable)
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"var {nombre} = {valor};")
+

--- a/src/cobra/transpilers/transpiler/java_nodes/bucle_mientras.py
+++ b/src/cobra/transpilers/transpiler/java_nodes/bucle_mientras.py
@@ -1,0 +1,9 @@
+def visit_bucle_mientras(self, nodo):
+    condicion = self.obtener_valor(nodo.condicion)
+    self.agregar_linea(f"while ({condicion}) {{")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+

--- a/src/cobra/transpilers/transpiler/java_nodes/clase.py
+++ b/src/cobra/transpilers/transpiler/java_nodes/clase.py
@@ -1,0 +1,9 @@
+def visit_clase(self, nodo):
+    metodos = getattr(nodo, "metodos", getattr(nodo, "cuerpo", []))
+    self.agregar_linea(f"class {nodo.nombre} {{")
+    self.indent += 1
+    for metodo in metodos:
+        metodo.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+

--- a/src/cobra/transpilers/transpiler/java_nodes/condicional.py
+++ b/src/cobra/transpilers/transpiler/java_nodes/condicional.py
@@ -1,0 +1,17 @@
+def visit_condicional(self, nodo):
+    cuerpo_si = getattr(nodo, "cuerpo_si", getattr(nodo, "bloque_si", []))
+    cuerpo_sino = getattr(nodo, "cuerpo_sino", getattr(nodo, "bloque_sino", []))
+    condicion = self.obtener_valor(nodo.condicion)
+    self.agregar_linea(f"if ({condicion}) {{")
+    self.indent += 1
+    for inst in cuerpo_si:
+        inst.aceptar(self)
+    self.indent -= 1
+    if cuerpo_sino:
+        self.agregar_linea("} else {")
+        self.indent += 1
+        for inst in cuerpo_sino:
+            inst.aceptar(self)
+        self.indent -= 1
+    self.agregar_linea("}")
+

--- a/src/cobra/transpilers/transpiler/java_nodes/continuar.py
+++ b/src/cobra/transpilers/transpiler/java_nodes/continuar.py
@@ -1,0 +1,3 @@
+def visit_continuar(self, nodo):
+    self.agregar_linea("continue;")
+

--- a/src/cobra/transpilers/transpiler/java_nodes/for_.py
+++ b/src/cobra/transpilers/transpiler/java_nodes/for_.py
@@ -1,0 +1,9 @@
+def visit_for(self, nodo):
+    iterable = self.obtener_valor(nodo.iterable)
+    self.agregar_linea(f"for (var {nodo.variable} : {iterable}) {{")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+

--- a/src/cobra/transpilers/transpiler/java_nodes/funcion.py
+++ b/src/cobra/transpilers/transpiler/java_nodes/funcion.py
@@ -1,0 +1,9 @@
+def visit_funcion(self, nodo):
+    params = ", ".join(nodo.parametros)
+    self.agregar_linea(f"static void {nodo.nombre}({params}) {{")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+

--- a/src/cobra/transpilers/transpiler/java_nodes/imprimir.py
+++ b/src/cobra/transpilers/transpiler/java_nodes/imprimir.py
@@ -1,0 +1,4 @@
+def visit_imprimir(self, nodo):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"System.out.println({valor});")
+

--- a/src/cobra/transpilers/transpiler/java_nodes/instancia.py
+++ b/src/cobra/transpilers/transpiler/java_nodes/instancia.py
@@ -1,0 +1,3 @@
+def visit_instancia(self, nodo):
+    self.agregar_linea(self.obtener_valor(nodo) + ";")
+

--- a/src/cobra/transpilers/transpiler/java_nodes/llamada_funcion.py
+++ b/src/cobra/transpilers/transpiler/java_nodes/llamada_funcion.py
@@ -1,0 +1,4 @@
+def visit_llamada_funcion(self, nodo):
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"{nodo.nombre}({args});")
+

--- a/src/cobra/transpilers/transpiler/java_nodes/llamada_metodo.py
+++ b/src/cobra/transpilers/transpiler/java_nodes/llamada_metodo.py
@@ -1,0 +1,5 @@
+def visit_llamada_metodo(self, nodo):
+    obj = self.obtener_valor(nodo.objeto)
+    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+    self.agregar_linea(f"{obj}.{nodo.nombre_metodo}({args});")
+

--- a/src/cobra/transpilers/transpiler/java_nodes/metodo.py
+++ b/src/cobra/transpilers/transpiler/java_nodes/metodo.py
@@ -1,0 +1,9 @@
+def visit_metodo(self, nodo):
+    params = ", ".join(nodo.parametros)
+    self.agregar_linea(f"void {nodo.nombre}({params}) {{")
+    self.indent += 1
+    for inst in nodo.cuerpo:
+        inst.aceptar(self)
+    self.indent -= 1
+    self.agregar_linea("}")
+

--- a/src/cobra/transpilers/transpiler/java_nodes/retorno.py
+++ b/src/cobra/transpilers/transpiler/java_nodes/retorno.py
@@ -1,0 +1,7 @@
+def visit_retorno(self, nodo):
+    if getattr(nodo, "expresion", None) is not None:
+        valor = self.obtener_valor(nodo.expresion)
+        self.agregar_linea(f"return {valor};")
+    else:
+        self.agregar_linea("return;")
+

--- a/src/cobra/transpilers/transpiler/java_nodes/romper.py
+++ b/src/cobra/transpilers/transpiler/java_nodes/romper.py
@@ -1,0 +1,3 @@
+def visit_romper(self, nodo):
+    self.agregar_linea("break;")
+

--- a/src/cobra/transpilers/transpiler/to_go.py
+++ b/src/cobra/transpilers/transpiler/to_go.py
@@ -10,46 +10,64 @@ from core.ast_nodes import (
     NodoOperacionBinaria,
     NodoOperacionUnaria,
     NodoAtributo,
+    NodoLlamadaMetodo,
+    NodoInstancia,
 )
 from cobra.lexico.lexer import TipoToken
-from core.visitor import NodeVisitor
 from cobra.transpilers.base import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
-
-def visit_asignacion(self, nodo: NodoAsignacion):
-    nombre = getattr(nodo, "identificador", nodo.variable)
-    op = ":=" if hasattr(nodo, "variable") else "="
-    valor = self.obtener_valor(nodo.expresion)
-    self.agregar_linea(f"{nombre} {op} {valor}")
-
-
-def visit_funcion(self, nodo: NodoFuncion):
-    params = ", ".join(nodo.parametros)
-    self.agregar_linea(f"func {nodo.nombre}({params}) {{")
-    self.indent += 1
-    for inst in nodo.cuerpo:
-        inst.aceptar(self)
-    self.indent -= 1
-    self.agregar_linea("}")
-
-
-def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
-    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
-    self.agregar_linea(f"{nodo.nombre}({args})")
-
-
-def visit_imprimir(self, nodo: NodoImprimir):
-    valor = self.obtener_valor(nodo.expresion)
-    self.agregar_linea(f"fmt.Println({valor})")
-
+from cobra.transpilers.transpiler.go_nodes.asignacion import (
+    visit_asignacion as _visit_asignacion,
+)
+from cobra.transpilers.transpiler.go_nodes.funcion import (
+    visit_funcion as _visit_funcion,
+)
+from cobra.transpilers.transpiler.go_nodes.llamada_funcion import (
+    visit_llamada_funcion as _visit_llamada_funcion,
+)
+from cobra.transpilers.transpiler.go_nodes.imprimir import (
+    visit_imprimir as _visit_imprimir,
+)
+from cobra.transpilers.transpiler.go_nodes.condicional import (
+    visit_condicional as _visit_condicional,
+)
+from cobra.transpilers.transpiler.go_nodes.bucle_mientras import (
+    visit_bucle_mientras as _visit_bucle_mientras,
+)
+from cobra.transpilers.transpiler.go_nodes.for_ import visit_for as _visit_for
+from cobra.transpilers.transpiler.go_nodes.clase import visit_clase as _visit_clase
+from cobra.transpilers.transpiler.go_nodes.metodo import visit_metodo as _visit_metodo
+from cobra.transpilers.transpiler.go_nodes.retorno import (
+    visit_retorno as _visit_retorno,
+)
+from cobra.transpilers.transpiler.go_nodes.romper import visit_romper as _visit_romper
+from cobra.transpilers.transpiler.go_nodes.continuar import (
+    visit_continuar as _visit_continuar,
+)
+from cobra.transpilers.transpiler.go_nodes.llamada_metodo import (
+    visit_llamada_metodo as _visit_llamada_metodo,
+)
+from cobra.transpilers.transpiler.go_nodes.instancia import (
+    visit_instancia as _visit_instancia,
+)
 
 go_nodes = {
-    "asignacion": visit_asignacion,
-    "funcion": visit_funcion,
-    "llamada_funcion": visit_llamada_funcion,
-    "imprimir": visit_imprimir,
+    "asignacion": _visit_asignacion,
+    "funcion": _visit_funcion,
+    "llamada_funcion": _visit_llamada_funcion,
+    "imprimir": _visit_imprimir,
+    "condicional": _visit_condicional,
+    "bucle_mientras": _visit_bucle_mientras,
+    "for": _visit_for,
+    "clase": _visit_clase,
+    "metodo": _visit_metodo,
+    "retorno": _visit_retorno,
+    "romper": _visit_romper,
+    "continuar": _visit_continuar,
+    "llamada_metodo": _visit_llamada_metodo,
+    "instancia": _visit_instancia,
 }
 
 
@@ -75,6 +93,13 @@ class TranspiladorGo(BaseTranspiler):
         elif isinstance(nodo, NodoLlamadaFuncion):
             args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
             return f"{nodo.nombre}({args})"
+        elif isinstance(nodo, NodoLlamadaMetodo):
+            obj = self.obtener_valor(nodo.objeto)
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"{obj}.{nodo.nombre_metodo}({args})"
+        elif isinstance(nodo, NodoInstancia):
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"&{nodo.nombre_clase}{{{args}}}"
         elif isinstance(nodo, NodoOperacionBinaria):
             izq = self.obtener_valor(nodo.izquierda)
             der = self.obtener_valor(nodo.derecha)
@@ -101,3 +126,4 @@ class TranspiladorGo(BaseTranspiler):
 # Asignar visitantes
 for nombre, funcion in go_nodes.items():
     setattr(TranspiladorGo, f"visit_{nombre}", funcion)
+


### PR DESCRIPTION
## Summary
- Add visitor modules for Go and Java to handle conditionals, loops, classes and more
- Register new node handlers in TranspiladorGo and TranspiladorJava
- Extend value resolution for method calls and class instantiation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.commands')*

------
https://chatgpt.com/codex/tasks/task_e_6897767e97ac8327b2310cd484f4226d