### PR TITLE
docs: enlazar matriz de transpiladores

### DIFF
--- a/docs/lenguajes_soportados.rst
+++ b/docs/lenguajes_soportados.rst
@@ -128,3 +128,17 @@ Este paquete incluye gramáticas para los lenguajes listados y puede instalarse 
 
 Para conocer el alcance y las limitaciones del soporte de LaTeX consulte :doc:`soporte_latex`.
 
+
+Comparativa de características
+------------------------------
+
+La cobertura de características por lenguaje se resume en la matriz de transpiladores:
+
+.. include:: matriz_transpiladores.md
+
+Diferencias identificadas
+-------------------------
+
+- Go y Java no soportan condicionales ni bucles. Se recomienda implementar estas
+  estructuras; véase el `issue #11 <../issues/11_soporte_condicionales_bucles_go_java.md>`_.
+

--- a/frontend/docs/backends.rst
+++ b/frontend/docs/backends.rst
@@ -49,3 +49,16 @@ Además un bloque ``switch`` de Cobra se traduce utilizando ``match``::
            let y = 0;
        },
    }
+
+Matriz de características
+-------------------------
+
+Para un resumen completo de la cobertura por lenguaje, revisa la `matriz de transpiladores <../../docs/matriz_transpiladores.md>`_:
+
+.. include:: ../../docs/matriz_transpiladores.md
+
+Diferencias identificadas
+-------------------------
+
+- Go y Java no soportan condicionales ni bucles. Consulta el `issue #11 <../../issues/11_soporte_condicionales_bucles_go_java.md>`_ para seguimiento y contribuciones.
+

--- a/issues/11_soporte_condicionales_bucles_go_java.md
+++ b/issues/11_soporte_condicionales_bucles_go_java.md
@@ -1,0 +1,15 @@
+# Falta de condicionales y bucles en Go y Java
+
+Los backends de Go y Java no implementan estructuras de control básicas como
+condicionales (`if`) ni bucles (`for`, `bucle_mientras`). Esto limita la
+capacidad de generar código útil en estos lenguajes.
+
+## Tareas recomendadas
+
+- [ ] Agregar soporte para sentencias `if`.
+- [ ] Implementar bucles `for` y `while`.
+- [ ] Añadir pruebas que cubran estas estructuras.
+
+## Referencias
+
+- Matriz de características: [docs/matriz_transpiladores.md](../docs/matriz_transpiladores.md)


### PR DESCRIPTION
## Summary
- enlaza la matriz de transpiladores desde la documentación de lenguajes soportados y backends
- documenta brechas en Go y Java y referencia un issue de seguimiento

## Testing
- `PYTHONPATH=$PWD pytest` *(falla: No module named 'cli.cli')*

Labels: transpiler, medium priority

------
https://chatgpt.com/codex/tasks/task_e_68977afa456483279e3a7996bde78943