### PR TITLE
Corrige rutas de AST en transpilers

### DIFF
--- a/src/cobra/core/ast_nodes.py
+++ b/src/cobra/core/ast_nodes.py
@@ -1,0 +1,1 @@
+from core.ast_nodes import *  # noqa: F401,F403

--- a/src/cobra/transpilers/reverse/from_asm.py
+++ b/src/cobra/transpilers/reverse/from_asm.py
@@ -7,7 +7,7 @@ import re
 from typing import Any, List
 
 from cobra.transpilers.reverse.base import BaseReverseTranspiler
-from core.ast_nodes import NodoAsignacion, NodoIdentificador, NodoValor
+from cobra.core.ast_nodes import NodoAsignacion, NodoIdentificador, NodoValor
 
 
 def _parse_expression(text: str) -> Any:

--- a/src/cobra/transpilers/reverse/from_c.py
+++ b/src/cobra/transpilers/reverse/from_c.py
@@ -24,7 +24,7 @@ Nota:
 
 from typing import Any, List, Optional
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoBloque,
     NodoDeclaracion,
     NodoExpresion,

--- a/src/cobra/transpilers/reverse/from_cobol.py
+++ b/src/cobra/transpilers/reverse/from_cobol.py
@@ -7,7 +7,7 @@ import re
 from typing import Any, List
 
 from cobra.transpilers.reverse.base import BaseReverseTranspiler
-from core.ast_nodes import NodoAsignacion, NodoIdentificador, NodoValor
+from cobra.core.ast_nodes import NodoAsignacion, NodoIdentificador, NodoValor
 
 
 def _parse_expression(text: str) -> Any:

--- a/src/cobra/transpilers/reverse/from_cpp.py
+++ b/src/cobra/transpilers/reverse/from_cpp.py
@@ -3,7 +3,7 @@
 
 from typing import Any, List
 
-import core.ast_nodes
+import cobra.core.ast_nodes
 from .tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
 
 
@@ -20,7 +20,7 @@ class ReverseFromCPP(TreeSitterReverseTranspiler):
     LANGUAGE = "cpp"
     # ------------------------------------------------------------------
     # Clases y namespaces
-    def visit_class_definition(self, node: Any) -> core.ast_nodes.NodoClase:
+    def visit_class_definition(self, node: Any) -> cobra.core.ast_nodes.NodoClase:
         """Procesa una definición de clase C++."""
         nombre_n = node.child_by_field_name("name")
         body_n = node.child_by_field_name("body")
@@ -32,21 +32,21 @@ class ReverseFromCPP(TreeSitterReverseTranspiler):
                 if child.is_named:
                     miembros.append(self.visit(child))
 
-        return core.ast_nodes.NodoClase(nombre, miembros)
+        return cobra.core.ast_nodes.NodoClase(nombre, miembros)
 
     # Alias para el nodo de tree-sitter `class_specifier`
-    def visit_class_specifier(self, node: Any) -> core.ast_nodes.NodoClase:
+    def visit_class_specifier(self, node: Any) -> cobra.core.ast_nodes.NodoClase:
         return self.visit_class_definition(node)
 
-    def visit_field_declaration(self, node: Any) -> core.ast_nodes.NodoAsignacion:
+    def visit_field_declaration(self, node: Any) -> cobra.core.ast_nodes.NodoAsignacion:
         """Convierte una declaración de campo en una asignación simple."""
         declarator = node.child_by_field_name("declarator")
         nombre = TreeSitterNode(declarator).get_text() if declarator else ""
-        return core.ast_nodes.NodoAsignacion(
-            nombre, core.ast_nodes.NodoValor(None)
+        return cobra.core.ast_nodes.NodoAsignacion(
+            nombre, cobra.core.ast_nodes.NodoValor(None)
         )
 
-    def visit_function_definition(self, node: Any) -> core.ast_nodes.NodoMetodo:
+    def visit_function_definition(self, node: Any) -> cobra.core.ast_nodes.NodoMetodo:
         """Procesa una definición de método dentro de una clase."""
         if node.parent and node.parent.type == "field_declaration_list":
             nombre_n = node.child_by_field_name("name")
@@ -66,11 +66,11 @@ class ReverseFromCPP(TreeSitterReverseTranspiler):
                 if c.is_named
             ] if body_n else []
 
-            return core.ast_nodes.NodoMetodo(nombre, params, cuerpo)
+            return cobra.core.ast_nodes.NodoMetodo(nombre, params, cuerpo)
 
         return super().visit_function_definition(node)
 
-    def visit_namespace_definition(self, node: Any) -> core.ast_nodes.NodoBloque:
+    def visit_namespace_definition(self, node: Any) -> cobra.core.ast_nodes.NodoBloque:
         """Procesa una definición de namespace."""
         body_n = node.child_by_field_name("body")
         sentencias: List[Any] = []
@@ -79,11 +79,11 @@ class ReverseFromCPP(TreeSitterReverseTranspiler):
                 if child.is_named:
                     sentencias.append(self.visit(child))
 
-        bloque = core.ast_nodes.NodoBloque()
+        bloque = cobra.core.ast_nodes.NodoBloque()
         bloque.sentencias = sentencias
         return bloque
 
-    def visit_simple_declaration(self, node: Any) -> core.ast_nodes.NodoAsignacion:
+    def visit_simple_declaration(self, node: Any) -> cobra.core.ast_nodes.NodoAsignacion:
         declarator = node.child_by_field_name("declarator")
         valor_n = node.child_by_field_name("value")
         nombre_n = declarator
@@ -91,34 +91,34 @@ class ReverseFromCPP(TreeSitterReverseTranspiler):
             nombre_n = declarator.child_by_field_name("declarator")
             valor_n = declarator.child_by_field_name("value")
         nombre = TreeSitterNode(nombre_n).get_text() if nombre_n else ""
-        valor = self.visit(valor_n) if valor_n else core.ast_nodes.NodoValor(None)
-        return core.ast_nodes.NodoAsignacion(nombre, valor)
+        valor = self.visit(valor_n) if valor_n else cobra.core.ast_nodes.NodoValor(None)
+        return cobra.core.ast_nodes.NodoAsignacion(nombre, valor)
 
-    def visit_switch_statement(self, node: Any) -> core.ast_nodes.NodoSwitch:
+    def visit_switch_statement(self, node: Any) -> cobra.core.ast_nodes.NodoSwitch:
         cond_n = node.child_by_field_name("condition")
         body_n = node.child_by_field_name("body")
-        expr = self.visit(cond_n) if cond_n else core.ast_nodes.NodoValor(None)
-        casos: List[core.ast_nodes.NodoCase] = []
+        expr = self.visit(cond_n) if cond_n else cobra.core.ast_nodes.NodoValor(None)
+        casos: List[cobra.core.ast_nodes.NodoCase] = []
         por_defecto: List[Any] = []
         if body_n:
             for child in body_n.children:
                 if child.type == "case_statement":
                     val_n = child.child_by_field_name("value")
-                    val = self.visit(val_n) if val_n else core.ast_nodes.NodoValor(None)
-                    if not isinstance(val, core.ast_nodes.NodoPattern):
-                        val = core.ast_nodes.NodoPattern(val)
+                    val = self.visit(val_n) if val_n else cobra.core.ast_nodes.NodoValor(None)
+                    if not isinstance(val, cobra.core.ast_nodes.NodoPattern):
+                        val = cobra.core.ast_nodes.NodoPattern(val)
                     cuerpo = [
                         self.visit(c)
                         for c in child.children
                         if c.is_named and c is not val_n
                     ]
-                    casos.append(core.ast_nodes.NodoCase(val, cuerpo))
+                    casos.append(cobra.core.ast_nodes.NodoCase(val, cuerpo))
                 elif child.type == "default_statement":
                     por_defecto = [self.visit(c) for c in child.children if c.is_named]
-        return core.ast_nodes.NodoSwitch(expr, casos, por_defecto)
+        return cobra.core.ast_nodes.NodoSwitch(expr, casos, por_defecto)
 
     def visit_identifier(self, node: Any) -> Any:  # type: ignore[override]
         text = TreeSitterNode(node).get_text()
         if text in {"nullptr", "NULL", "std::nullopt"}:
-            return core.ast_nodes.NodoOption(None)
+            return cobra.core.ast_nodes.NodoOption(None)
         return super().visit_identifier(node)

--- a/src/cobra/transpilers/reverse/from_fortran.py
+++ b/src/cobra/transpilers/reverse/from_fortran.py
@@ -8,7 +8,7 @@ utilizando el parser tree-sitter.
 from typing import Any, List
 
 from .tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoAsignacion,
     NodoFuncion,
     NodoIdentificador,

--- a/src/cobra/transpilers/reverse/from_java.py
+++ b/src/cobra/transpilers/reverse/from_java.py
@@ -5,7 +5,7 @@ from typing import List
 from tree_sitter import Node
 
 from cobra.core import Token, TipoToken
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoClase,
     NodoMetodo,
     NodoBucleMientras,

--- a/src/cobra/transpilers/reverse/from_js.py
+++ b/src/cobra/transpilers/reverse/from_js.py
@@ -14,7 +14,7 @@ from typing import Any, List
 from tree_sitter import Node
 
 from cobra.core import Token, TipoToken
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoClase,
     NodoFuncion,
     NodoMetodo,

--- a/src/cobra/transpilers/reverse/from_kotlin.py
+++ b/src/cobra/transpilers/reverse/from_kotlin.py
@@ -13,7 +13,7 @@ Nota:
     Requiere que el parser tree-sitter para Kotlin esté instalado y configurado.
 """
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoBloque,
     NodoDeclaracion,
     NodoExpresion,

--- a/src/cobra/transpilers/reverse/from_matlab.py
+++ b/src/cobra/transpilers/reverse/from_matlab.py
@@ -8,7 +8,7 @@ from typing import Any, List
 from lark import Lark, Transformer
 
 from cobra.transpilers.reverse.base import BaseReverseTranspiler
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoFuncion,

--- a/src/cobra/transpilers/reverse/from_mojo.py
+++ b/src/cobra/transpilers/reverse/from_mojo.py
@@ -7,7 +7,7 @@ import re
 from typing import Any, List
 
 from cobra.transpilers.reverse.base import BaseReverseTranspiler
-from core.ast_nodes import NodoAsignacion, NodoIdentificador, NodoValor
+from cobra.core.ast_nodes import NodoAsignacion, NodoIdentificador, NodoValor
 
 
 def _parse_expression(text: str) -> Any:

--- a/src/cobra/transpilers/reverse/from_pascal.py
+++ b/src/cobra/transpilers/reverse/from_pascal.py
@@ -8,7 +8,7 @@ from typing import Any, List
 from lark import Lark, Transformer
 
 from cobra.transpilers.reverse.base import BaseReverseTranspiler
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoFuncion,

--- a/src/cobra/transpilers/reverse/from_perl.py
+++ b/src/cobra/transpilers/reverse/from_perl.py
@@ -2,7 +2,7 @@
 """Transpilador inverso desde Perl a Cobra usando tree-sitter."""
 from typing import Any, List
 
-from core.ast_nodes import NodoAsignacion, NodoIdentificador, NodoValor
+from cobra.core.ast_nodes import NodoAsignacion, NodoIdentificador, NodoValor
 from .tree_sitter_base import TreeSitterNode, TreeSitterReverseTranspiler
 
 class ReverseFromPerl(TreeSitterReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_python.py
+++ b/src/cobra/transpilers/reverse/from_python.py
@@ -9,7 +9,7 @@ permitiendo la traducción de programas Python al lenguaje Cobra.
 import ast
 from typing import Any, List, Optional, Union
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoAST,
     NodoAsignacion,
     NodoBucleMientras,

--- a/src/cobra/transpilers/reverse/from_rust.py
+++ b/src/cobra/transpilers/reverse/from_rust.py
@@ -11,7 +11,7 @@ Ejemplos:
 """
 from typing import Any, List
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoBloque,
     NodoFuncion,
     NodoIdentificador,

--- a/src/cobra/transpilers/reverse/from_swift.py
+++ b/src/cobra/transpilers/reverse/from_swift.py
@@ -12,7 +12,7 @@ Ejemplos:
 import re
 from typing import Any, List
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoAsignacion,
     NodoFuncion,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/reverse/from_visualbasic.py
+++ b/src/cobra/transpilers/reverse/from_visualbasic.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import re
 from typing import Any, List
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoAsignacion,
     NodoFuncion,
     NodoIdentificador,

--- a/src/cobra/transpilers/reverse/from_wasm.py
+++ b/src/cobra/transpilers/reverse/from_wasm.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Any, List, Union
 
 from cobra.transpilers.reverse.base import BaseReverseTranspiler
-from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoIdentificador, NodoValor
+from cobra.core.ast_nodes import NodoAsignacion, NodoFuncion, NodoIdentificador, NodoValor
 
 try:
     from wabt import Wabt  # type: ignore

--- a/src/cobra/transpilers/reverse/tree_sitter_base.py
+++ b/src/cobra/transpilers/reverse/tree_sitter_base.py
@@ -14,7 +14,7 @@ except Exception:  # pragma: no cover - dependencia opcional
         pass
 
 from cobra.transpilers.reverse.base import BaseReverseTranspiler
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoFuncion,

--- a/src/cobra/transpilers/semantica.py
+++ b/src/cobra/transpilers/semantica.py
@@ -1,4 +1,4 @@
-from core.ast_nodes import NodoAtributo
+from cobra.core.ast_nodes import NodoAtributo
 
 
 def datos_asignacion(transpilador, nodo):

--- a/src/cobra/transpilers/transpiler/js_nodes/elemento.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/elemento.py
@@ -1,4 +1,4 @@
-from core.ast_nodes import NodoLista, NodoDiccionario
+from cobra.core.ast_nodes import NodoLista, NodoDiccionario
 def visit_elemento(self, elemento):
 
     """Transpila un elemento o estructura."""

--- a/src/cobra/transpilers/transpiler/js_nodes/exportar.py
+++ b/src/cobra/transpilers/transpiler/js_nodes/exportar.py
@@ -1,4 +1,4 @@
-from core.ast_nodes import NodoExport
+from cobra.core.ast_nodes import NodoExport
 
 
 def visit_export(self, nodo: NodoExport):

--- a/src/cobra/transpilers/transpiler/to_asm.py
+++ b/src/cobra/transpilers/transpiler/to_asm.py
@@ -1,6 +1,6 @@
 """Transpilador que genera código ensamblador simple desde Cobra."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoBucleMientras,

--- a/src/cobra/transpilers/transpiler/to_c.py
+++ b/src/cobra/transpilers/transpiler/to_c.py
@@ -1,6 +1,6 @@
 """Transpilador básico de Cobra a C."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoLista,
     NodoDiccionario,
     NodoValor,

--- a/src/cobra/transpilers/transpiler/to_cobol.py
+++ b/src/cobra/transpilers/transpiler/to_cobol.py
@@ -1,6 +1,6 @@
 """Transpilador que genera código COBOL a partir de Cobra."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_cpp.py
+++ b/src/cobra/transpilers/transpiler/to_cpp.py
@@ -3,7 +3,7 @@
 Los parámetros de tipo de Cobra se traducen a plantillas ``template`` propias
 de C++."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoLista,
     NodoDiccionario,
     NodoListaTipo,

--- a/src/cobra/transpilers/transpiler/to_fortran.py
+++ b/src/cobra/transpilers/transpiler/to_fortran.py
@@ -1,6 +1,6 @@
 """Transpilador sencillo de Cobra a Fortran."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_go.py
+++ b/src/cobra/transpilers/transpiler/to_go.py
@@ -1,6 +1,6 @@
 """Transpilador sencillo de Cobra a Go."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_java.py
+++ b/src/cobra/transpilers/transpiler/to_java.py
@@ -1,6 +1,6 @@
 """Transpilador sencillo de Cobra a Java."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_js.py
+++ b/src/cobra/transpilers/transpiler/to_js.py
@@ -3,7 +3,7 @@
 Los parámetros de tipo se omiten porque JavaScript no soporta genéricos de
 forma nativa, por lo que se recurre a tipos dinámicos."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoLista,
     NodoDiccionario,
     NodoListaTipo,

--- a/src/cobra/transpilers/transpiler/to_julia.py
+++ b/src/cobra/transpilers/transpiler/to_julia.py
@@ -1,6 +1,6 @@
 """Transpilador simple de Cobra a Julia."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_kotlin.py
+++ b/src/cobra/transpilers/transpiler/to_kotlin.py
@@ -1,6 +1,6 @@
 """Transpilador sencillo de Cobra a Kotlin."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_latex.py
+++ b/src/cobra/transpilers/transpiler/to_latex.py
@@ -1,6 +1,6 @@
 """Transpilador simple de Cobra a LaTeX."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_matlab.py
+++ b/src/cobra/transpilers/transpiler/to_matlab.py
@@ -1,6 +1,6 @@
 """Transpilador simple de Cobra a MATLAB."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_mojo.py
+++ b/src/cobra/transpilers/transpiler/to_mojo.py
@@ -1,6 +1,6 @@
 """Transpilador simple de Cobra a Mojo."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_pascal.py
+++ b/src/cobra/transpilers/transpiler/to_pascal.py
@@ -1,6 +1,6 @@
 """Transpilador que genera código Pascal a partir de Cobra."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_perl.py
+++ b/src/cobra/transpilers/transpiler/to_perl.py
@@ -1,6 +1,6 @@
 """Transpilador simple de Cobra a Perl."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_php.py
+++ b/src/cobra/transpilers/transpiler/to_php.py
@@ -1,6 +1,6 @@
 """Transpilador simple de Cobra a PHP."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_python.py
+++ b/src/cobra/transpilers/transpiler/to_python.py
@@ -1,6 +1,6 @@
 """Transpilador que convierte código Cobra en código Python."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoBucleMientras,

--- a/src/cobra/transpilers/transpiler/to_r.py
+++ b/src/cobra/transpilers/transpiler/to_r.py
@@ -1,6 +1,6 @@
 """Transpilador básico de Cobra a R."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_ruby.py
+++ b/src/cobra/transpilers/transpiler/to_ruby.py
@@ -1,6 +1,6 @@
 """Transpilador simple de Cobra a Ruby."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_rust.py
+++ b/src/cobra/transpilers/transpiler/to_rust.py
@@ -2,7 +2,7 @@
 
 Los parámetros de tipo de Cobra se convierten en genéricos idiomáticos de Rust."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoLista,
     NodoDiccionario,
     NodoValor,

--- a/src/cobra/transpilers/transpiler/to_swift.py
+++ b/src/cobra/transpilers/transpiler/to_swift.py
@@ -1,6 +1,6 @@
 """Transpilador sencillo de Cobra a Swift."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_visualbasic.py
+++ b/src/cobra/transpilers/transpiler/to_visualbasic.py
@@ -1,6 +1,6 @@
 """Transpilador simple de Cobra a Visual Basic."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoValor,
     NodoIdentificador,
     NodoLlamadaFuncion,

--- a/src/cobra/transpilers/transpiler/to_wasm.py
+++ b/src/cobra/transpilers/transpiler/to_wasm.py
@@ -1,6 +1,6 @@
 """Transpilador muy básico que genera código WebAssembly en formato WAT."""
 
-from core.ast_nodes import (
+from cobra.core.ast_nodes import (
     NodoAsignacion,
     NodoFuncion,
     NodoOperacionBinaria,


### PR DESCRIPTION
## Resumen
- Reemplaza importaciones desde `core.ast_nodes` por `cobra.core.ast_nodes` en todos los transpilers
- Añade módulo de compatibilidad `cobra.core.ast_nodes`

## Pruebas
- `PYTHONPATH=src python - <<'PY'\nimport cobra.core.lexer\nfrom cobra.transpilers.transpiler.to_wasm import TranspiladorWasm\nfrom cobra.core.ast_nodes import NodoAsignacion, NodoValor\ntranspiler = TranspiladorWasm()\ntranspiler.visit_asignacion(NodoAsignacion('x', NodoValor(1)))\nprint('ok')\nPY`
- `PYTHONPATH=src pytest` (errores: ModuleNotFoundError: No module named 'cli.cli', AttributeError: module 'importlib' has no attribute 'ModuleType')

------
https://chatgpt.com/codex/tasks/task_e_689786a58434832786485756faa6f760