### PR TITLE
refactor: centralizar utilidades de transpiladores

### DIFF
--- a/src/cobra/transpilers/__init__.py
+++ b/src/cobra/transpilers/__init__.py
@@ -1,10 +1,6 @@
 """Facilita el acceso a los distintos transpiladores de Cobra."""
 
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from cobra.transpilers.reverse.base import BaseReverseTranspiler
 
 __all__ = ["BaseTranspiler", "BaseReverseTranspiler"]
-
-
-def exceptions():
-    return None

--- a/src/cobra/transpilers/base.py
+++ b/src/cobra/transpilers/base.py
@@ -1,24 +1,8 @@
-from abc import ABC, abstractmethod
-from core.visitor import NodeVisitor
+"""Compatibilidad retrocompatible para :mod:`cobra.transpilers`.
 
+El contenido real se encuentra en ``cobra.transpilers.common.utils``.
+"""
 
-class BaseTranspiler(NodeVisitor, ABC):
-    """Clase base para los transpiladores de Cobra."""
+from cobra.transpilers.common.utils import BaseTranspiler, save_file
 
-    def __init__(self):
-        self.codigo = []
-
-    @abstractmethod
-    def generate_code(self, ast):
-        """Genera el código a partir del AST proporcionado."""
-        raise NotImplementedError
-
-    def save_file(self, path):
-        """Guarda el código generado en la ruta dada."""
-        contenido = (
-            "\n".join(self.codigo)
-            if isinstance(self.codigo, list)
-            else str(self.codigo)
-        )
-        with open(path, "w", encoding="utf-8") as archivo:
-            archivo.write(contenido)
+__all__ = ["BaseTranspiler", "save_file"]

--- a/src/cobra/transpilers/common/__init__.py
+++ b/src/cobra/transpilers/common/__init__.py
@@ -1,0 +1,17 @@
+"""Módulo con utilidades compartidas por los transpiladores."""
+
+from .utils import (
+    BaseTranspiler,
+    get_standard_imports,
+    load_mapped_module,
+    save_file,
+    STANDARD_IMPORTS,
+)
+
+__all__ = [
+    "BaseTranspiler",
+    "get_standard_imports",
+    "load_mapped_module",
+    "save_file",
+    "STANDARD_IMPORTS",
+]

--- a/src/cobra/transpilers/common/utils.py
+++ b/src/cobra/transpilers/common/utils.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+"""Utilidades comunes para los transpiladores de Cobra."""
+
+from abc import ABC, abstractmethod
+from typing import List, Tuple, Union
+
+from core.visitor import NodeVisitor
+from cobra.transpilers.module_map import get_mapped_path
+
+# ---------------------------------------------------------------------------
+# Clases base
+# ---------------------------------------------------------------------------
+
+
+class BaseTranspiler(NodeVisitor, ABC):
+    """Clase base para los transpiladores que generan código."""
+
+    def __init__(self) -> None:
+        self.codigo: Union[str, List[str]] = []
+
+    @abstractmethod
+    def generate_code(self, ast):
+        """Genera el código a partir del AST proporcionado."""
+        raise NotImplementedError
+
+    def save_file(self, path: str) -> None:
+        """Guarda el código generado en la ruta dada."""
+        save_file(self.codigo, path)
+
+
+# ---------------------------------------------------------------------------
+# Funciones de utilidad
+# ---------------------------------------------------------------------------
+
+
+STANDARD_IMPORTS = {
+    "python": (
+        "from core.nativos import *\n"
+        "from corelibs import *\n"
+        "from standard_library import *\n"
+    ),
+    "js": [
+        "import * as io from './nativos/io.js';",
+        "import * as net from './nativos/red.js';",
+        "import * as matematicas from './nativos/matematicas.js';",
+        "import { Pila, Cola } from './nativos/estructuras.js';",
+        "import * as archivo from './nativos/archivo.js';",
+        "import * as coleccion from './nativos/coleccion.js';",
+        "import * as numero from './nativos/numero.js';",
+        "import * as red from './nativos/red.js';",
+        "import * as seguridad from './nativos/seguridad.js';",
+        "import * as sistema from './nativos/sistema.js';",
+        "import * as texto from './nativos/texto.js';",
+        "import * as tiempo from './nativos/tiempo.js';",
+    ],
+    "swift": [],
+    "perl": [],
+    "visualbasic": [],
+}
+
+
+def save_file(content: Union[str, List[str]], path: str) -> None:
+    """Guarda *content* en la ruta *path*."""
+    texto = "\n".join(content) if isinstance(content, list) else str(content)
+    with open(path, "w", encoding="utf-8") as archivo:
+        archivo.write(texto)
+
+
+def get_standard_imports(language: str) -> Union[str, List[str]]:
+    """Devuelve las importaciones por defecto para *language*."""
+    imports = STANDARD_IMPORTS.get(language, [])
+    if isinstance(imports, list):
+        return list(imports)
+    return imports
+
+
+def load_mapped_module(path: str, language: str) -> Tuple[str, str]:
+    """Carga el módulo indicado respetando el mapeo configurado."""
+    ruta = get_mapped_path(path, language)
+    with open(ruta, "r", encoding="utf-8") as f:
+        contenido = f.read()
+    return contenido, ruta
+
+
+__all__ = [
+    "BaseTranspiler",
+    "save_file",
+    "get_standard_imports",
+    "load_mapped_module",
+    "STANDARD_IMPORTS",
+]

--- a/src/cobra/transpilers/import_helper.py
+++ b/src/cobra/transpilers/import_helper.py
@@ -1,69 +1,9 @@
-"""Utilidades para gestionar importaciones en los transpiladores."""
+"""Compatibilidad retrocompatible para utilidades de importación."""
 
-from __future__ import annotations
+from cobra.transpilers.common.utils import (
+    STANDARD_IMPORTS,
+    get_standard_imports,
+    load_mapped_module,
+)
 
-from typing import List, Tuple, Union
-
-from cobra.transpilers.module_map import get_mapped_path
-
-# Mapeo de importaciones estándar por lenguaje
-STANDARD_IMPORTS = {
-    "python": (
-        "from core.nativos import *\n"
-        "from corelibs import *\n"
-        "from standard_library import *\n"
-    ),
-    "js": [
-        "import * as io from './nativos/io.js';",
-        "import * as net from './nativos/red.js';",
-        "import * as matematicas from './nativos/matematicas.js';",
-        "import { Pila, Cola } from './nativos/estructuras.js';",
-        "import * as archivo from './nativos/archivo.js';",
-        "import * as coleccion from './nativos/coleccion.js';",
-        "import * as numero from './nativos/numero.js';",
-        "import * as red from './nativos/red.js';",
-        "import * as seguridad from './nativos/seguridad.js';",
-        "import * as sistema from './nativos/sistema.js';",
-        "import * as texto from './nativos/texto.js';",
-        "import * as tiempo from './nativos/tiempo.js';",
-    ],
-    "swift": [],
-    "perl": [],
-    "visualbasic": [],
-}
-
-
-def get_standard_imports(language: str) -> Union[str, List[str]]:
-    """Devuelve las importaciones por defecto para *language*.
-
-    Parameters
-    ----------
-    language: str
-        Identificador del backend (``python``, ``js``...).
-    """
-    imports = STANDARD_IMPORTS.get(language, [])
-    if isinstance(imports, list):
-        return list(imports)
-    return imports
-
-
-def load_mapped_module(path: str, language: str) -> Tuple[str, str]:
-    """Carga el módulo indicado respetando el mapeo configurado.
-
-    Parameters
-    ----------
-    path: str
-        Ruta declarada en la instrucción ``import``.
-    language: str
-        Lenguaje de destino para el cual se busca el archivo.
-
-    Returns
-    -------
-    Tuple[str, str]
-        Una tupla ``(contenido, ruta)`` con el código del módulo y la ruta
-        real utilizada.
-    """
-    ruta = get_mapped_path(path, language)
-    with open(ruta, "r", encoding="utf-8") as f:
-        contenido = f.read()
-    return contenido, ruta
+__all__ = ["STANDARD_IMPORTS", "get_standard_imports", "load_mapped_module"]

--- a/src/cobra/transpilers/transpiler/python_nodes/importar.py
+++ b/src/cobra/transpilers/transpiler/python_nodes/importar.py
@@ -1,6 +1,6 @@
 from cobra.core import Lexer
 from cobra.core import Parser
-from cobra.transpilers.import_helper import load_mapped_module
+from cobra.transpilers.common.utils import load_mapped_module
 
 
 def visit_import(self, nodo):

--- a/src/cobra/transpilers/transpiler/to_asm.py
+++ b/src/cobra/transpilers/transpiler/to_asm.py
@@ -31,7 +31,7 @@ from cobra.core.ast_nodes import (
 from cobra.core import TipoToken, Lexer
 from cobra.core import Parser
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_c.py
+++ b/src/cobra/transpilers/transpiler/to_c.py
@@ -12,7 +12,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_cobol.py
+++ b/src/cobra/transpilers/transpiler/to_cobol.py
@@ -13,7 +13,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_cpp.py
+++ b/src/cobra/transpilers/transpiler/to_cpp.py
@@ -27,7 +27,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_fortran.py
+++ b/src/cobra/transpilers/transpiler/to_fortran.py
@@ -13,7 +13,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_go.py
+++ b/src/cobra/transpilers/transpiler/to_go.py
@@ -14,7 +14,7 @@ from cobra.core.ast_nodes import (
     NodoInstancia,
 )
 from cobra.core import TipoToken
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_java.py
+++ b/src/cobra/transpilers/transpiler/to_java.py
@@ -14,7 +14,7 @@ from cobra.core.ast_nodes import (
     NodoInstancia,
 )
 from cobra.core import TipoToken
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_js.py
+++ b/src/cobra/transpilers/transpiler/to_js.py
@@ -37,10 +37,10 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
-from cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.common.utils import get_standard_imports
 from cobra.transpilers.module_map import get_mapped_path
 
 from cobra.transpilers.transpiler.js_nodes.asignacion import visit_asignacion as _visit_asignacion

--- a/src/cobra/transpilers/transpiler/to_julia.py
+++ b/src/cobra/transpilers/transpiler/to_julia.py
@@ -13,7 +13,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_kotlin.py
+++ b/src/cobra/transpilers/transpiler/to_kotlin.py
@@ -13,7 +13,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_latex.py
+++ b/src/cobra/transpilers/transpiler/to_latex.py
@@ -10,7 +10,7 @@ from cobra.core.ast_nodes import (
     NodoAtributo,
 )
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_matlab.py
+++ b/src/cobra/transpilers/transpiler/to_matlab.py
@@ -13,7 +13,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_mojo.py
+++ b/src/cobra/transpilers/transpiler/to_mojo.py
@@ -12,7 +12,7 @@ from cobra.core.ast_nodes import (
     NodoAtributo,
 )
 from cobra.core import TipoToken
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_pascal.py
+++ b/src/cobra/transpilers/transpiler/to_pascal.py
@@ -13,7 +13,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_perl.py
+++ b/src/cobra/transpilers/transpiler/to_perl.py
@@ -13,7 +13,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_php.py
+++ b/src/cobra/transpilers/transpiler/to_php.py
@@ -13,7 +13,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_python.py
+++ b/src/cobra/transpilers/transpiler/to_python.py
@@ -50,10 +50,10 @@ from cobra.core.ast_nodes import (
 from cobra.core import Parser
 from cobra.core import TipoToken, Lexer
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
-from cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.common.utils import get_standard_imports
 
 from cobra.transpilers.transpiler.python_nodes.asignacion import (
     visit_asignacion as _visit_asignacion,

--- a/src/cobra/transpilers/transpiler/to_r.py
+++ b/src/cobra/transpilers/transpiler/to_r.py
@@ -13,7 +13,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_ruby.py
+++ b/src/cobra/transpilers/transpiler/to_ruby.py
@@ -13,7 +13,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_rust.py
+++ b/src/cobra/transpilers/transpiler/to_rust.py
@@ -29,7 +29,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_swift.py
+++ b/src/cobra/transpilers/transpiler/to_swift.py
@@ -12,7 +12,7 @@ from cobra.core.ast_nodes import (
     NodoAtributo,
 )
 from cobra.core import TipoToken
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_visualbasic.py
+++ b/src/cobra/transpilers/transpiler/to_visualbasic.py
@@ -13,7 +13,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 

--- a/src/cobra/transpilers/transpiler/to_wasm.py
+++ b/src/cobra/transpilers/transpiler/to_wasm.py
@@ -9,7 +9,7 @@ from cobra.core.ast_nodes import (
 )
 from cobra.core import TipoToken
 from core.visitor import NodeVisitor
-from cobra.transpilers.base import BaseTranspiler
+from cobra.transpilers.common.utils import BaseTranspiler
 from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 


### PR DESCRIPTION
## Resumen
- Añadido módulo `common.utils` con `BaseTranspiler`, `save_file` y helpers de importación.
- Actualizados `base.py`, `import_helper.py` y `__init__.py` para reutilizar las nuevas utilidades.
- Refactorizados todos los transpiladores para importar desde `common.utils`.

## Testing
- `PYTHONPATH=src pytest` *(errores: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_68978911d4848327ad623d50e22da103