### PR TITLE
Corrige ejemplos de importación en documentación

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,31 +449,30 @@ Las expresiones regulares se agrupan en `especificacion_tokens` y se procesan en
 
 Puedes probar el lexer y parser con un código como el siguiente:
 
-````cobra
-codigo = '''
+```python
+from cobra.core import Lexer, Parser
+from cobra.transpilers.transpiler.to_python import TranspiladorPython
+
+codigo = """
 var x = 10
 si x > 5 :
     proyectar(x, "2D")
 sino :
     graficar(x)
-'''
+"""
 
-# Inicializamos el lexer
 lexer = Lexer(codigo)
 tokens = lexer.analizar_token()
 
-# Inicializamos el parser
 parser = Parser(tokens)
 
-# Ejecutar el parser para obtener el AST
 arbol = parser.parsear()
 print(arbol)
 
-# Generación de código en Python
 transpiler = TranspiladorPython()
 codigo_python = transpiler.generate_code(arbol)
 print(codigo_python)
-````
+```
 
 ## Ejemplo de imprimir, holobits y bucles
 

--- a/docs/cache_incremental.md
+++ b/docs/cache_incremental.md
@@ -12,6 +12,10 @@ Para activarlo desde código se puede invocar `Lexer.tokenizar(incremental=True)
 y `ClassicParser.parsear(incremental=True)`, que consultarán la caché de
 fragmentos antes de volver a analizar el texto.
 
+```python
+from cobra.core import Lexer, ClassicParser
+```
+
 Para perfilar estas fases desde la línea de comandos se puede ejecutar:
 
 ```bash


### PR DESCRIPTION
## Resumen
- Actualiza ejemplo de uso en README con importaciones a `cobra.core`
- Menciona importaciones correctas en la guía de caché incremental

## Testing
- `pytest -q` *(errored: module 'importlib' has no attribute 'ModuleType')*
- `PYTHONPATH=src pytest -q` *(errored: module 'importlib' has no attribute 'ModuleType')*

------
https://chatgpt.com/codex/tasks/task_e_689794fd950c8327810b0a9afb7e68f8