### PR TITLE
Configura mypy y ajusta verificación de tipos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run linters
         run: make lint
       - name: Run type checks
-        run: make typecheck
+        run: make typecheck  # Ejecuta mypy con la configuración del proyecto y pyright
       - name: Run tests
         run: pytest --cov=src --cov-report=xml \
           --cov-report=term-missing --cov-fail-under=95

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test:
 
 lint:
 	ruff check $(SRC)
-	mypy $(SRC)
+	mypy $(SRC) --config-file=mypy.ini
 	bandit -r $(SRC)
 
 format:
@@ -48,7 +48,7 @@ format:
 	black $(SRC)
 
 typecheck:
-	mypy $(SRC)
+	mypy $(SRC) --config-file=mypy.ini
 	@command -v pyright >/dev/null 2>&1 && pyright $(SRC) || echo "ℹ️ pyright no está instalado"
 
 secrets:

--- a/check.py
+++ b/check.py
@@ -10,7 +10,7 @@ import shutil
 
 TOOLS = {
     "ruff": ["ruff", "check", "src"],
-    "mypy": ["mypy", "src"],
+    "mypy": ["mypy", "src", "--config-file=mypy.ini"],
     "bandit": ["bandit", "-r", "src"],
     "pytest": ["pytest", "--cov=src", "src/tests", "--cov-report=term-missing", "--cov-fail-under=90"],
     "pyright": ["pyright", "src"],

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,24 +1,16 @@
 [mypy]
 python_version = 3.11
-files = src
 
 # Evita errores por módulos de terceros no tipados
 ignore_missing_imports = True
 
 # Excluye rutas innecesarias o generadas
-exclude = ^(
-    frontend/build/
-    |frontend/docs/
-    |venv/
-    |.venv/
-    |src/tests/
-    |build/
-    |dist/
-)
+exclude = ^(frontend/build/|frontend/docs/|venv/|.venv/|src/tests/|build/|dist/|examples/|notebooks/|casos_reales/)
 
 # Reglas adicionales opcionales
 warn_unused_ignores = True
 warn_redundant_casts = True
 warn_no_return = True
+warn_return_any = True
 strict_optional = True
 disallow_untyped_defs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "pytest-cov",
     "pytest-timeout",
     "ruff",
+    "mypy",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- actualiza `mypy.ini` excluyendo directorios y endureciendo reglas
- añade `mypy` a las dependencias de desarrollo
- usa la configuración de `mypy.ini` en `make typecheck` y en `check.py`
- documenta en CI la ejecución de la verificación de tipos

## Testing
- `make typecheck` *(falla: Found 862 errors in 305 files)*

------
https://chatgpt.com/codex/tasks/task_e_68982abf5c888327b3b865d9cb54278f