### PR TITLE
feat: comparar benchmarks entre releases

### DIFF
--- a/scripts/benchmarks/compare_releases.py
+++ b/scripts/benchmarks/compare_releases.py
@@ -1,0 +1,88 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.request import urlopen
+
+API_URL = "https://api.github.com/repos/Alphonsus411/pCobra/releases/latest"
+
+
+def ejecutar_benchmarks() -> list[dict]:
+    """Ejecuta los benchmarks de la versión actual y devuelve la lista de resultados."""
+    root = Path(__file__).resolve().parents[2]
+    script = Path(__file__).resolve().parent / "run_benchmarks.py"
+
+    backend_src = root / "backend" / "src"
+    src_dir = root / "src"
+    cleanup = False
+    if not backend_src.exists() and src_dir.exists():
+        try:
+            backend_src.symlink_to(src_dir, target_is_directory=True)
+            cleanup = True
+        except OSError:
+            pass
+
+    try:
+        cmd = [sys.executable, str(script)]
+        out = subprocess.check_output(cmd, text=True, cwd=root)
+    except subprocess.CalledProcessError as err:
+        raise RuntimeError("Fallo al ejecutar run_benchmarks.py") from err
+    finally:
+        if cleanup and backend_src.exists():
+            backend_src.unlink()
+    return json.loads(out)
+
+
+def descargar_benchmarks_release() -> list[dict]:
+    """Descarga el archivo benchmarks.json de la última release."""
+    try:
+        with urlopen(API_URL) as resp:
+            release = json.load(resp)
+    except HTTPError as err:
+        raise RuntimeError("No se pudo obtener la información de la última release") from err
+    for asset in release.get("assets", []):
+        if asset.get("name") == "benchmarks.json":
+            url = asset.get("browser_download_url")
+            with urlopen(url) as resp:
+                return json.load(resp)
+    raise RuntimeError("No se encontró benchmarks.json en la última release")
+
+
+def comparar(actuales: list[dict], previos: list[dict]) -> list[dict]:
+    """Compara los resultados actuales con los de la release anterior."""
+    backends = {d["backend"] for d in actuales} | {d["backend"] for d in previos}
+    resumen: list[dict] = []
+    for backend in sorted(backends):
+        cur = next((d for d in actuales if d["backend"] == backend), None)
+        prev = next((d for d in previos if d["backend"] == backend), None)
+        entry = {
+            "backend": backend,
+            "current_time": cur["time"] if cur else None,
+            "previous_time": prev["time"] if prev else None,
+            "diff_time": (cur["time"] - prev["time"]) if cur and prev else None,
+            "current_memory_kb": cur["memory_kb"] if cur else None,
+            "previous_memory_kb": prev["memory_kb"] if prev else None,
+            "diff_memory_kb": (cur["memory_kb"] - prev["memory_kb"]) if cur and prev else None,
+        }
+        resumen.append(entry)
+    return resumen
+
+
+def main() -> None:
+    actuales = ejecutar_benchmarks()
+    previos = descargar_benchmarks_release()
+    resumen = comparar(actuales, previos)
+    out_path = Path(__file__).resolve().parents[2] / "benchmarks_compare.json"
+    out_path.write_text(json.dumps(resumen, indent=2))
+    for r in resumen:
+        dt = r["diff_time"]
+        dm = r["diff_memory_kb"]
+        dt_str = f"{dt:+.4f}s" if dt is not None else "N/A"
+        dm_str = f"{dm:+d}kB" if dm is not None else "N/A"
+        print(f"{r['backend']}: tiempo {dt_str}, memoria {dm_str}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Resumen
- Agrega `compare_releases.py` para ejecutar benchmarks actuales, descargar resultados de la última release y generar un informe comparativo.

## Testing
- `python scripts/benchmarks/compare_releases.py` *(falló: No se pudo obtener la información de la última release)*


------
https://chatgpt.com/codex/tasks/task_e_689833960300832791fe2272fe49c172