### PR TITLE
feat: add benchmarks to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,13 @@ jobs:
           python -m build
           twine check dist/*
           twine upload dist/*
+      - name: Run benchmarks
+        run: python scripts/benchmarks/run_benchmarks.py --output benchmarks.json
+      - name: Upload benchmarks
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmarks-${{ github.ref_name }}
+          path: benchmarks.json
       - name: Build and push Docker image
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -69,4 +76,6 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/**/cobra*
+          files: |
+            dist/**/cobra*
+            dist/**/benchmarks.json


### PR DESCRIPTION
## Summary
- run benchmarks after packaging and upload results
- attach benchmark results to release assets

## Testing
- `scripts/test.sh` *(fails: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_689840eba00483278d069f63001ada56