### PR TITLE
docs: explicar benchmarks en CI y etiquetar rendimiento

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,6 @@
 feature/*: feature
 bugfix/*: bug
 doc/*: documentation
+perf/*:
+  - performance
+  - "priority: low"

--- a/README.md
+++ b/README.md
@@ -304,6 +304,16 @@ El archivo [bench_results.json](bench_results.json) se guarda en el directorio
 actual y puede analizarse con el cuaderno
 [notebooks/benchmarks_resultados.ipynb](notebooks/benchmarks_resultados.ipynb).
 
+Para ver la evolución entre versiones ejecuta:
+
+```bash
+python scripts/benchmarks/compare_releases.py --output benchmarks_compare.json
+```
+
+Los resultados históricos se publican como archivos `benchmarks.json` en la
+[sección de Releases](https://github.com/Alphonsus411/pCobra/releases), donde
+puedes consultar las métricas de cada versión.
+
 Para comparar el rendimiento de los hilos ejecuta `cobra benchthreads`:
 
 ```bash

--- a/frontend/docs/benchmarking.rst
+++ b/frontend/docs/benchmarking.rst
@@ -84,6 +84,21 @@ También puedes ejecutar el script manualmente:
      - 0.05
      - 0
 
+Benchmarks en CI
+----------------
+
+En la integración continua los benchmarks se generan mediante el
+script ``scripts/benchmarks/run_benchmarks.py``. Cada ejecución guarda
+los resultados en ``benchmarks.json`` y el flujo de release publica este
+archivo como artefacto de la versión.
+
+El trabajo ``benchmarks`` de ``ci.yml`` ejecuta
+``scripts/benchmarks/compare_releases.py`` para volver a correr las
+pruebas y comparar los números actuales con los de la última release.
+La comparación se guarda en ``benchmarks_compare.json`` y se adjunta al
+job como artefacto junto con un resumen en la bitácora del flujo.
+
+
 Pruebas de mutación
 -------------------
 


### PR DESCRIPTION
## Summary
- documentar cómo se generan y comparan artefactos de benchmarks en CI
- agregar ejemplo en README con referencia a resultados históricos
- etiquetar ramas `perf/*` con `performance` y prioridad baja

## Testing
- `make lint` (falló: W292, E741 y más)
- `make typecheck` (falló: missing return type annotations)
- `PYTHONPATH=$PWD/src pytest -q` (falló: ModuleNotFoundError para `cli.cli`)
- `make secrets` (falló: gitleaks no instalado)


------
https://chatgpt.com/codex/tasks/task_e_689844b9a66883279ad1167f8f1254d0