### PR TITLE
feat: add max regression threshold for benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           extra: "sphinx sphinx-rtd-theme pytest-cov codecov pyright"
       - name: Compare benchmarks
-        run: python scripts/benchmarks/compare_releases.py --output benchmarks_compare.json
+        run: python scripts/benchmarks/compare_releases.py --output benchmarks_compare.json --max-regression 10
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- allow setting maximum allowed benchmark regression
- fail CI if regression exceeds configured threshold

## Testing
- `python scripts/benchmarks/compare_releases.py --help`
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_689846cf2664832793cffef7b9c41174