### PR TITLE
Add runtime tests for Go, Rust, and Ruby

### DIFF
--- a/src/tests/integration/test_runtime_go.py
+++ b/src/tests/integration/test_runtime_go.py
@@ -1,0 +1,40 @@
+import shutil
+
+import pytest
+import cobra.core as cobra_core
+import core.ast_nodes as core_ast_nodes
+
+from tests.utils.runtime import run_code
+
+# Expone todos los nodos al paquete "cobra.core" y ajusta __all__
+node_names = [name for name in dir(core_ast_nodes) if name.startswith("Nodo")]
+core_ast_nodes.__all__ = node_names
+for name in node_names:
+    setattr(cobra_core, name, getattr(core_ast_nodes, name))
+
+from cobra.core import Lexer, Parser  # noqa: E402
+from cobra.transpilers.transpiler.to_go import TranspiladorGo  # noqa: E402
+
+
+@pytest.mark.skipif(shutil.which("go") is None, reason="requiere Go")
+def test_runtime_go_imprimir():
+    """Transpila y ejecuta un snippet Cobra sencillo en Go."""
+    codigo_cobra = "x = 1\nimprimir(x)"
+    lexer = Lexer(codigo_cobra)
+    tokens = lexer.analizar_token()
+    parser = Parser(tokens)
+    ast = parser.parsear()
+    snippet_go = TranspiladorGo().generate_code(ast)
+
+    codigo_go = (
+        "package main\n"
+        "import \"fmt\"\n"
+        "func main() {\n"
+        f"{snippet_go}\n"
+        "}\n"
+    )
+
+    salida = run_code("go", codigo_go)
+
+    assert "1" in salida
+

--- a/src/tests/integration/test_runtime_ruby.py
+++ b/src/tests/integration/test_runtime_ruby.py
@@ -1,0 +1,32 @@
+import shutil
+
+import pytest
+import cobra.core as cobra_core
+import core.ast_nodes as core_ast_nodes
+
+from tests.utils.runtime import run_code
+
+# Expone todos los nodos al paquete "cobra.core" y ajusta __all__
+node_names = [name for name in dir(core_ast_nodes) if name.startswith("Nodo")]
+core_ast_nodes.__all__ = node_names
+for name in node_names:
+    setattr(cobra_core, name, getattr(core_ast_nodes, name))
+
+from cobra.core import Lexer, Parser  # noqa: E402
+from cobra.transpilers.transpiler.to_ruby import TranspiladorRuby  # noqa: E402
+
+
+@pytest.mark.skipif(shutil.which("ruby") is None, reason="requiere Ruby")
+def test_runtime_ruby_imprimir():
+    """Transpila y ejecuta un snippet Cobra sencillo en Ruby."""
+    codigo_cobra = "x = 1\nimprimir(x)"
+    lexer = Lexer(codigo_cobra)
+    tokens = lexer.analizar_token()
+    parser = Parser(tokens)
+    ast = parser.parsear()
+    codigo_ruby = TranspiladorRuby().generate_code(ast)
+
+    salida = run_code("ruby", codigo_ruby)
+
+    assert "1" in salida
+

--- a/src/tests/integration/test_runtime_rust.py
+++ b/src/tests/integration/test_runtime_rust.py
@@ -1,0 +1,39 @@
+import shutil
+
+import pytest
+import cobra.core as cobra_core
+import core.ast_nodes as core_ast_nodes
+
+from tests.utils.runtime import run_code
+
+# Expone todos los nodos al paquete "cobra.core" y ajusta __all__
+node_names = [name for name in dir(core_ast_nodes) if name.startswith("Nodo")]
+core_ast_nodes.__all__ = node_names
+for name in node_names:
+    setattr(cobra_core, name, getattr(core_ast_nodes, name))
+
+from cobra.core import Lexer, Parser  # noqa: E402
+from cobra.transpilers.transpiler.to_rust import TranspiladorRust  # noqa: E402
+
+
+@pytest.mark.skipif(shutil.which("rustc") is None, reason="requiere rustc")
+def test_runtime_rust_imprimir():
+    """Transpila y ejecuta un snippet Cobra sencillo en Rust."""
+    codigo_cobra = "x = 1"
+    lexer = Lexer(codigo_cobra)
+    tokens = lexer.analizar_token()
+    parser = Parser(tokens)
+    ast = parser.parsear()
+    snippet_rust = TranspiladorRust().generate_code(ast)
+
+    codigo_rust = (
+        "fn main() {\n"
+        f"{snippet_rust}\n"
+        "println!(\"{}\", x);\n"
+        "}\n"
+    )
+
+    salida = run_code("rust", codigo_rust)
+
+    assert "1" in salida
+


### PR DESCRIPTION
## Summary
- extend `run_code` utility to execute Go, Rust, and Ruby snippets
- add integration tests transpiling Cobra to Go, Rust, and Ruby and running them with native runtimes

## Testing
- `ruff check src/tests/utils/runtime.py src/tests/integration/test_runtime_go.py src/tests/integration/test_runtime_rust.py src/tests/integration/test_runtime_ruby.py`
- `pytest src/tests/integration/test_runtime_python.py src/tests/integration/test_runtime_js.py src/tests/integration/test_runtime_go.py src/tests/integration/test_runtime_rust.py src/tests/integration/test_runtime_ruby.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898546f7a948327afe44b335c2f9195