### PR TITLE
ci: instala intérpretes extra y documenta dependencias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc g++ golang-go ruby-full
+          sudo apt-get install -y gcc g++ golang-go ruby-full rustc default-jdk
       - name: Install dependencies
         uses: ./.github/actions/install
         with:
@@ -39,8 +39,14 @@ jobs:
       - name: Run type checks
         run: make typecheck  # Ejecuta mypy con la configuración del proyecto y pyright
       - name: Run tests
-        run: pytest --cov=src --cov-report=xml \
-          --cov-report=term-missing --cov-fail-under=95
+        run: |
+          if [ -d tests ]; then
+            pytest tests src/tests --cov=src --cov-report=xml \
+              --cov-report=term-missing --cov-fail-under=95
+          else
+            pytest src/tests --cov=src --cov-report=xml \
+              --cov-report=term-missing --cov-fail-under=95
+          fi
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -63,7 +69,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc g++ golang-go ruby-full
+          sudo apt-get install -y gcc g++ golang-go ruby-full rustc default-jdk
       - name: Install dependencies
         uses: ./.github/actions/install
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc g++ golang-go ruby-full
+          sudo apt-get install -y gcc g++ golang-go ruby-full rustc default-jdk
       - name: Install dependencies
         uses: ./.github/actions/install
       - name: Scan for secrets
@@ -40,7 +40,11 @@ jobs:
           bandit -r src
       - name: Run tests
         run: |
-          pytest --cov=src --cov-report=xml --cov-fail-under=95
+          if [ -d tests ]; then
+            pytest tests src/tests --cov=src --cov-report=xml --cov-fail-under=95
+          else
+            pytest src/tests --cov=src --cov-report=xml --cov-fail-under=95
+          fi
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-report

--- a/README.md
+++ b/README.md
@@ -827,7 +827,16 @@ PYTHONPATH=$PWD pytest src/tests --cov=src --cov-report=term-missing \
   --cov-fail-under=95
 ````
 
-Algunas pruebas generan código en distintos lenguajes (por ejemplo C++, JavaScript o Go) y verifican que la sintaxis sea correcta. Para que estas pruebas se ejecuten con éxito es necesario contar con los compiladores o intérpretes correspondientes instalados en el sistema, como Node, gcc/g++, Go, etc. Puedes ejecutar todo el conjunto con:
+ Algunas pruebas generan código en distintos lenguajes (por ejemplo C++, JavaScript o Go) y verifican que la sintaxis sea correcta. Para que estas pruebas se ejecuten con éxito es necesario contar con los compiladores o intérpretes correspondientes instalados en el sistema. En particular se requiere:
+
+- Node.js
+- gcc y g++
+- Go (`golang-go`)
+- Ruby (`ruby`)
+- Rust (`rustc`)
+- Java (`default-jdk`)
+
+Con estas herramientas disponibles puedes ejecutar todo el conjunto con:
 
 ```bash
 PYTHONPATH=$PWD pytest


### PR DESCRIPTION
## Resumen
- instala Node.js, Go, Ruby, Rust y Java en los flujos de CI
- ejecuta pytest considerando una posible carpeta `tests`
- documenta en el README los intérpretes externos requeridos

## Testing
- `PYTHONPATH=$PWD pytest src/tests/unit/test_cli_imports_alias.py -q` (falla: cannot import name 'NodoInterface')

------
https://chatgpt.com/codex/tasks/task_e_689856ed929c83279a9e26ad2f6d2a6b