### PR TITLE
test: parametrizar snippets cobra

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 # Añade el directorio ``src`` al ``PYTHONPATH`` para simplificar los imports en las pruebas
 ROOT = Path(__file__).resolve().parents[1]
 src_path = ROOT / "src"
@@ -15,3 +17,21 @@ try:  # nosec B001
     import backend  # noqa: F401
 except Exception:
     pass
+
+
+@pytest.fixture
+def codigo_imprimir() -> str:
+    """Snippet Cobra que imprime el valor de una variable."""
+    return "x = 1\nimprimir(x)"
+
+
+@pytest.fixture
+def codigo_bucle_simple() -> str:
+    """Snippet Cobra con un bucle ``mientras`` que imprime valores."""
+    return (
+        "x = 0\n"
+        "mientras x < 2:\n"
+        "    imprimir(x)\n"
+        "    x = x + 1\n"
+        "fin"
+    )

--- a/src/tests/integration/test_runtime_go.py
+++ b/src/tests/integration/test_runtime_go.py
@@ -17,9 +17,12 @@ from cobra.transpilers.transpiler.to_go import TranspiladorGo  # noqa: E402
 
 
 @pytest.mark.skipif(shutil.which("go") is None, reason="requiere Go")
-def test_runtime_go_imprimir():
-    """Transpila y ejecuta un snippet Cobra sencillo en Go."""
-    codigo_cobra = "x = 1\nimprimir(x)"
+@pytest.mark.parametrize(
+    "codigo_cobra_fixture", ["codigo_imprimir", "codigo_bucle_simple"]
+)
+def test_runtime_go_ejecucion(request, codigo_cobra_fixture):
+    """Transpila y ejecuta snippets Cobra básicos en Go."""
+    codigo_cobra = request.getfixturevalue(codigo_cobra_fixture)
     lexer = Lexer(codigo_cobra)
     tokens = lexer.analizar_token()
     parser = Parser(tokens)

--- a/src/tests/integration/test_runtime_ruby.py
+++ b/src/tests/integration/test_runtime_ruby.py
@@ -17,9 +17,10 @@ from cobra.transpilers.transpiler.to_ruby import TranspiladorRuby  # noqa: E402
 
 
 @pytest.mark.skipif(shutil.which("ruby") is None, reason="requiere Ruby")
-def test_runtime_ruby_imprimir():
-    """Transpila y ejecuta un snippet Cobra sencillo en Ruby."""
-    codigo_cobra = "x = 1\nimprimir(x)"
+@pytest.mark.parametrize("codigo_cobra_fixture", ["codigo_imprimir"])
+def test_runtime_ruby_ejecucion(request, codigo_cobra_fixture):
+    """Transpila y ejecuta snippets Cobra básicos en Ruby."""
+    codigo_cobra = request.getfixturevalue(codigo_cobra_fixture)
     lexer = Lexer(codigo_cobra)
     tokens = lexer.analizar_token()
     parser = Parser(tokens)


### PR DESCRIPTION
## Summary
- add fixtures with print and loop Cobra snippets
- reuse fixtures in runtime tests to reduce duplication

## Testing
- `pytest src/tests/integration/test_runtime_python.py src/tests/integration/test_runtime_js.py src/tests/integration/test_runtime_ruby.py src/tests/integration/test_runtime_go.py src/tests/integration/test_runtime_rust.py > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68985d3d7f088327873507dd4ba3d7ef