### PR TITLE
Añade pruebas parametrizadas para transpiladores

### DIFF
--- a/src/tests/data/transpiler_outputs.csv
+++ b/src/tests/data/transpiler_outputs.csv
@@ -1,0 +1,2 @@
+archivo,lenguaje,salida
+factorial_recursivo.co,python,120\\n

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -1,0 +1,25 @@
+import csv
+from pathlib import Path
+
+import pytest
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+CSV_FILE = DATA_DIR / "transpiler_outputs.csv"
+
+
+def _cargar_casos():
+    casos = {}
+    with CSV_FILE.open(newline="", encoding="utf-8") as f:
+        lector = csv.DictReader(f)
+        for fila in lector:
+            archivo = DATA_DIR / fila["archivo"]
+            salida = fila["salida"].encode("utf-8").decode("unicode_escape")
+            salida = salida.replace("\\n", "\n")
+            casos.setdefault(archivo, {})[fila["lenguaje"]] = salida
+    return list(casos.items())
+
+
+@pytest.fixture(params=_cargar_casos())
+def transpiler_case(request):
+    """Devuelve (archivo, salidas_esperadas) por cada entrada del CSV."""
+    return request.param


### PR DESCRIPTION
## Resumen
- Agrega dataset `transpiler_outputs.csv` con salidas esperadas
- Implementa fixture que lee el CSV y parametriza los casos
- Amplía test de cross backend para generar y ejecutar código en cada lenguaje disponible

## Pruebas
- `pytest src/tests/integration/test_cross_backend_output.py::test_cross_backend_output -q`

------
https://chatgpt.com/codex/tasks/task_e_689863314f94832780967349505b3da8