### PR TITLE
chore: enforce minimum coverage

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -28,6 +28,7 @@ addopts =
     --cov=src
     --cov-report=term-missing
     --cov-report=xml
+    --cov-fail-under=85
 
 # Ignorar ciertas rutas
 norecursedirs =


### PR DESCRIPTION
## Summary
- set coverage threshold to 85% in pytest configuration

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli'; AttributeError: module 'importlib' has no attribute 'ModuleType')*

------
https://chatgpt.com/codex/tasks/task_e_689866ff461c8327abba07f975bf8a04