### PR TITLE
test: agregar pruebas para gui app

### DIFF
--- a/src/tests/unit/test_gui_app.py
+++ b/src/tests/unit/test_gui_app.py
@@ -1,0 +1,37 @@
+"""Pruebas para funciones de la aplicación GUI basadas en Flet."""
+
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def app_module(monkeypatch):
+    """Importa el módulo de la app con Flet y transpiladores simulados."""
+    monkeypatch.setitem(sys.modules, "flet", MagicMock())
+
+    class DummyTranspiler:
+        def generate_code(self, ast):
+            return "codigo"
+
+    dummy_compile = SimpleNamespace(TRANSPILERS={"python": DummyTranspiler})
+    monkeypatch.setitem(sys.modules, "cobra.cli.commands.compile_cmd", dummy_compile)
+
+    module = importlib.import_module("gui.app")
+    importlib.reload(module)
+    return module
+
+
+def test_ejecutar_codigo_captura_salida(app_module):
+    codigo = "imprimir('Hola, mundo!')"
+    salida = app_module._ejecutar_codigo(codigo)
+    assert salida == "Hola, mundo!\n"
+
+
+def test_transpilar_codigo_no_vacio(app_module):
+    codigo = "imprimir('Hola, mundo!')"
+    generado = app_module._transpilar_codigo(codigo, "python")
+    assert generado.strip() != ""


### PR DESCRIPTION
## Summary
- add unit tests for `_ejecutar_codigo` and `_transpilar_codigo` in the GUI app
- mock Flet and transpiler registry to isolate tests

## Testing
- `pytest src/tests/unit/test_gui_app.py -q --no-cov`
- `pytest -q` *(fails: AttributeError: module 'importlib' has no attribute 'ModuleType')*

------
https://chatgpt.com/codex/tasks/task_e_68987581c2ec8327a2aeaf9a06d959ac