### PR TITLE
Agregar pruebas de manejo de errores del mapa de módulos

### DIFF
--- a/src/cobra/transpilers/module_map.py
+++ b/src/cobra/transpilers/module_map.py
@@ -46,12 +46,16 @@ def get_toml_map():
     """Devuelve la configuración del archivo ``pcobra.toml``."""
     global _toml_cache
     if _toml_cache is None:
-        if os.path.exists(PCOBRA_TOML_PATH):
-            with open(PCOBRA_TOML_PATH, 'rb') as f:
-                data = tomllib.load(f) or {}
-        else:
-            data = {}
-        _toml_cache = data
+        try:
+            if os.path.exists(PCOBRA_TOML_PATH):
+                with open(PCOBRA_TOML_PATH, 'rb') as f:
+                    data = tomllib.load(f) or {}
+            else:
+                data = {}
+            _toml_cache = data
+        except (tomllib.TOMLDecodeError, OSError) as e:
+            logger.error(f"Error al cargar pcobra.toml: {e}")
+            _toml_cache = {}
     return _toml_cache
 
 

--- a/src/tests/unit/test_module_map_errors.py
+++ b/src/tests/unit/test_module_map_errors.py
@@ -1,0 +1,70 @@
+import builtins
+import logging
+
+
+from cobra.transpilers import module_map
+
+
+def test_get_map_missing_file_returns_empty_and_logs_error(monkeypatch, caplog):
+    module_map._cache = None
+    monkeypatch.setattr(module_map, "MODULE_MAP_PATH", "missing.mod")
+    monkeypatch.setattr(module_map.os.path, "exists", lambda path: True)
+
+    def fake_open(*args, **kwargs):
+        raise FileNotFoundError("missing")
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    with caplog.at_level(logging.ERROR):
+        result = module_map.get_map()
+
+    assert result == {}
+    assert "Error al cargar el archivo de mapeo" in caplog.text
+
+
+def test_get_map_corrupt_yaml_returns_empty_and_logs_error(tmp_path, monkeypatch, caplog):
+    module_map._cache = None
+    bad_file = tmp_path / "cobra.mod"
+    bad_file.write_text("foo: [1, 2")
+    monkeypatch.setattr(module_map, "MODULE_MAP_PATH", str(bad_file))
+
+    with caplog.at_level(logging.ERROR):
+        result = module_map.get_map()
+
+    assert result == {}
+    assert "Error al cargar el archivo de mapeo" in caplog.text
+
+
+def test_get_toml_map_missing_file_returns_empty_and_logs_error(monkeypatch, caplog):
+    module_map._toml_cache = None
+    monkeypatch.setattr(module_map, "PCOBRA_TOML_PATH", "missing.toml")
+    monkeypatch.setattr(module_map.os.path, "exists", lambda path: True)
+
+    def fake_open(*args, **kwargs):
+        raise FileNotFoundError("missing")
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    with caplog.at_level(logging.ERROR):
+        result = module_map.get_toml_map()
+
+    assert result == {}
+    assert "Error al cargar pcobra.toml" in caplog.text
+
+
+def test_get_toml_map_invalid_file_returns_empty_and_logs_error(tmp_path, monkeypatch, caplog):
+    module_map._toml_cache = None
+    bad_toml = tmp_path / "pcobra.toml"
+    bad_toml.write_text("invalid = ]")
+    monkeypatch.setattr(module_map, "PCOBRA_TOML_PATH", str(bad_toml))
+
+    with caplog.at_level(logging.ERROR):
+        result = module_map.get_toml_map()
+
+    assert result == {}
+    assert "Error al cargar pcobra.toml" in caplog.text
+
+
+def test_get_mapped_path_returns_original_when_no_mapping(monkeypatch):
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: {})
+    assert module_map.get_mapped_path("m", "python") == "m"


### PR DESCRIPTION
## Resumen
- Manejar errores al cargar `pcobra.toml` registrando un mensaje y devolviendo un mapa vacío.
- Añadir pruebas que simulan `cobra.mod` ausente o corrupto y `pcobra.toml` ausente o inválido.
- Verificar que `get_mapped_path` devuelve el módulo original cuando no hay mapeo.

## Pruebas
- `PYTHONPATH=src pytest src/tests/unit/test_module_map_errors.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_6898872ecbcc83278be19b4db0f33e05