### PR TITLE
docs: agregar informe de cobertura

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,33 @@
+# Informe de cobertura
+
+Este informe recoge los resultados de `coverage run -m pytest` y `coverage report`.
+
+## Resumen
+
+- Cobertura total: 19 % (por debajo del objetivo del 85 %).
+- Durante la recolección de pruebas se produjeron 60 errores de importación, lo que limita la cobertura actual.
+
+## Módulos con cobertura inferior al 85 %
+
+A continuación se listan algunos de los módulos con menor cobertura detectados:
+
+| Módulo | Cobertura |
+| --- | --- |
+| `src/cobra/cli/cli.py` | 14 % |
+| `src/cobra/cli/cobrahub_client.py` | 0 % |
+| `src/cobra/core/parser.py` | 5 % |
+| `src/cobra/transpilers/feature_inspector.py` | 0 % |
+| `src/cobra/transpilers/reverse/from_c.py` | 3 % |
+| `src/cobra/transpilers/transpiler/to_python.py` | 33 % |
+| `src/core/ast_nodes.py` | 82 % |
+| `src/core/interpreter.py` | 7 % |
+| `src/gui/app.py` | 0 % |
+
+Estos resultados indican que gran parte del código aún carece de cobertura de pruebas suficiente.
+
+## Áreas que requieren atención
+
+- Mejorar la cobertura de los comandos de la CLI.
+- Añadir pruebas para los distintos transpiladores y el intérprete central.
+- Resolver los errores de importación que impiden ejecutar las pruebas.
+


### PR DESCRIPTION
## Summary
- documentar resultados de `coverage run -m pytest`
- listar módulos con cobertura por debajo del 85%

## Testing
- `coverage run -m pytest`
- `coverage report`


------
https://chatgpt.com/codex/tasks/task_e_68988a5b8b7883278a1cae523d249ff2