### PR TITLE
feat: añadir límite de tiempo de transpilación

### DIFF
--- a/cobra.toml
+++ b/cobra.toml
@@ -18,3 +18,7 @@ limite_cpu_segundos = 10
 
 # Módulos bloqueados explícitamente (por seguridad)
 modulos_prohibidos = ["os", "sys", "socket"]
+
+[rendimiento]
+# Tiempo máximo permitido para la transpilación de un archivo (en segundos)
+tiempo_max_transpilacion_seg = 300

--- a/src/cobra/cli/commands/bench_cmd.py
+++ b/src/cobra/cli/commands/bench_cmd.py
@@ -25,10 +25,11 @@ from pathlib import Path
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
+from core.cobra_config import tiempo_max_transpilacion
 
 # Constantes
 ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
-SUBPROCESS_TIMEOUT = 30  # segundos
+SUBPROCESS_TIMEOUT = tiempo_max_transpilacion()
 
 CODE = """
 var x = 0

--- a/src/cobra/cli/commands/benchthreads_cmd.py
+++ b/src/cobra/cli/commands/benchthreads_cmd.py
@@ -27,9 +27,10 @@ from jupyter_kernel import CobraKernel
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
+from core.cobra_config import tiempo_max_transpilacion
 
 # Constantes de configuración
-PROCESS_TIMEOUT = 30  # segundos
+PROCESS_TIMEOUT = tiempo_max_transpilacion()
 MAX_RETRIES = 3
 
 # Mover códigos de prueba a archivos separados

--- a/src/cobra/cli/commands/compile_cmd.py
+++ b/src/cobra/cli/commands/compile_cmd.py
@@ -38,11 +38,12 @@ from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 from cobra.core import ParserError
+from core.cobra_config import tiempo_max_transpilacion
 
 # Constantes de configuración
 MAX_PROCESSES = 4
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
-PROCESS_TIMEOUT = 300  # 5 minutos
+PROCESS_TIMEOUT = tiempo_max_transpilacion()
 MAX_LANGUAGES = 10
 
 TRANSPILERS = {

--- a/src/core/cobra_config.py
+++ b/src/core/cobra_config.py
@@ -46,3 +46,11 @@ def limite_cpu_segundos(config: dict | None = None) -> int | None:
     """Tiempo máximo de CPU en segundos o ``None``."""
     cfg = config or cargar_configuracion()
     return cfg.get("seguridad", {}).get("limite_cpu_segundos")
+
+
+def tiempo_max_transpilacion(config: dict | None = None) -> float:
+    """Tiempo máximo permitido para la transpilación."""
+    cfg = config or cargar_configuracion()
+    return float(
+        cfg.get("rendimiento", {}).get("tiempo_max_transpilacion_seg", 1.0)
+    )


### PR DESCRIPTION
## Resumen
- Agrega sección de rendimiento en `cobra.toml` con límite de transpilación
- Expone función `tiempo_max_transpilacion` en `cobra_config`
- Usa el nuevo límite en comandos de compilación y benchmarks

## Testing
- `PYTHONPATH=src pytest src/tests/unit/test_run_transpiler_pool.py src/tests/unit/test_compile_cmd_errors.py --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_68989145ff2c8327bc7e52dcafb57142