### PR TITLE
docs: explica pruebas de rendimiento y configuracion

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,6 +850,21 @@ pytest --cov=src src/tests/
 
 El reporte se guarda como `coverage.xml` y se utiliza en el CI.
 
+### Pruebas de rendimiento
+
+El archivo `cobra.toml` incluye una sección `[rendimiento]` con el parámetro
+`tiempo_max_transpilacion_seg`, que define en segundos el tiempo máximo
+permitido para transpilar un archivo.
+
+Para ejecutar únicamente las pruebas de rendimiento utiliza:
+
+```bash
+pytest -m performance
+```
+
+Si tu entorno es más lento o más rápido, ajusta el valor de
+`tiempo_max_transpilacion_seg` en `cobra.toml` según tus necesidades.
+
 Se han incluido pruebas que verifican los códigos de salida de la CLI. Los
 subcomandos devuelven `0` al finalizar correctamente y un valor distinto en caso
 de error.


### PR DESCRIPTION
## Summary
- documenta el uso de `[rendimiento].tiempo_max_transpilacion_seg` en `cobra.toml`
- agrega instrucciones para ejecutar las pruebas de rendimiento con `pytest -m performance`

## Testing
- `pytest -m performance` *(falla: AttributeError: module 'importlib' has no attribute 'ModuleType')*

------
https://chatgpt.com/codex/tasks/task_e_689898864e4c8327bf203e7e1c7eef7b