### PR TITLE
feat: añade autocompletado con argcomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,32 @@ ParserError: Token inesperado. ¿Quiso decir 'imprimir'?
 
 Una vez instalado el paquete, la herramienta `cobra` ofrece varios subcomandos:
 
+### Autocompletado
+
+La CLI soporta autocompletado de argumentos mediante
+[argcomplete](https://kislyuk.github.io/argcomplete/). Para habilitarlo en tu
+terminal ejecuta uno de los siguientes comandos según tu *shell*:
+
+- **bash**:
+
+  ```bash
+  eval "$(register-python-argcomplete cobra)"
+  ```
+
+- **zsh**:
+
+  ```bash
+  autoload -U bashcompinit
+  bashcompinit
+  eval "$(register-python-argcomplete cobra)"
+  ```
+
+- **fish**:
+
+  ```bash
+  register-python-argcomplete --shell fish cobra | source
+  ```
+
 ```bash
 # Compilar un archivo a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C o WebAssembly
 cobra compilar programa.co --tipo python

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ pyright
 python-lsp-server
 ipykernel
 sphinxcontrib-plantuml==0.30
+argcomplete

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ flet
 holobit-sdk==1.0.8
 smooth-criminal==0.4.0
 
+argcomplete

--- a/src/cobra/cli/commands/compile_cmd.py
+++ b/src/cobra/cli/commands/compile_cmd.py
@@ -4,6 +4,8 @@ import os
 from importlib import import_module
 from importlib.metadata import entry_points
 
+from argcomplete.completers import FilesCompleter
+
 from cobra.transpilers import module_map
 from cobra.transpilers.transpiler.to_asm import TranspiladorASM
 from cobra.transpilers.transpiler.to_c import TranspiladorC
@@ -120,7 +122,7 @@ class CompileCommand(BaseCommand):
     def register_subparser(self, subparsers):
         """Registra los argumentos del subcomando."""
         parser = subparsers.add_parser(self.name, help=_("Transpila un archivo"))
-        parser.add_argument("archivo")
+        parser.add_argument("archivo").completer = FilesCompleter()
         parser.add_argument(
             "--tipo",
             choices=LANG_CHOICES,

--- a/src/cobra/cli/commands/execute_cmd.py
+++ b/src/cobra/cli/commands/execute_cmd.py
@@ -4,6 +4,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
+from argcomplete.completers import FilesCompleter
+
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
@@ -31,7 +33,7 @@ class ExecuteCommand(BaseCommand):
     def register_subparser(self, subparsers):
         """Registra los argumentos del subcomando."""
         parser = subparsers.add_parser(self.name, help=_("Ejecuta un script Cobra"))
-        parser.add_argument("archivo", help=_("Ruta al archivo a ejecutar"))
+        parser.add_argument("archivo", help=_("Ruta al archivo a ejecutar")).completer = FilesCompleter()
         parser.add_argument(
             "--sandbox",
             action="store_true",


### PR DESCRIPTION
## Summary
- integra la librería argcomplete en los requisitos
- activa autocompletado global para la CLI y añade completadores de archivos
- documenta cómo habilitar autocompletado en bash, zsh y fish

## Testing
- `pytest` *(falla: No module named 'cobra', error de argumentos de pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68989cf4f23483279ef224309eb59960