### PR TITLE
feat(cli): custom argument parser with localized errors

### DIFF
--- a/src/cobra/cli/cli.py
+++ b/src/cobra/cli/cli.py
@@ -8,6 +8,8 @@ from typing import List, Dict, Optional, Type, Any, ContextManager
 from contextlib import contextmanager
 from argparse import _SubParsersAction
 
+from cobra.cli.utils.argument_parser import CustomArgumentParser
+
 import argcomplete
 from argcomplete.completers import FilesCompleter, DirectoriesCompleter
 
@@ -116,7 +118,7 @@ class CommandRegistry:
 
 class CliApplication:
     def __init__(self) -> None:
-        self.parser: Optional[argparse.ArgumentParser] = None
+        self.parser: Optional[CustomArgumentParser] = None
         self.interpreter: Optional[InterpretadorCobra] = None
         self.command_registry: Optional[CommandRegistry] = None
 
@@ -145,7 +147,7 @@ class CliApplication:
             format=AppConfig.LOG_FORMAT
         )
 
-    def _configure_cli_options(self, parser: argparse.ArgumentParser) -> None:
+    def _configure_cli_options(self, parser: CustomArgumentParser) -> None:
         parser.add_argument("--format", action="store_true",
                           help=_("Format file before processing"))
         parser.add_argument("--debug", action="store_true",
@@ -161,7 +163,7 @@ class CliApplication:
                           help=_("Path to custom validators module"),
                           type=Path)
 
-    def _configure_autocomplete(self, parser: argparse.ArgumentParser) -> None:
+    def _configure_autocomplete(self, parser: CustomArgumentParser) -> None:
         """Configura autocompletado para argumentos comunes.
 
         Recorre recursivamente todos los subparsers y asigna un completer
@@ -188,8 +190,8 @@ class CliApplication:
             elif action.dest in dir_args:
                 action.completer = DirectoriesCompleter()
 
-    def _build_argument_parser(self) -> argparse.ArgumentParser:
-        parser = argparse.ArgumentParser(
+    def _build_argument_parser(self) -> CustomArgumentParser:
+        parser = CustomArgumentParser(
             prog=AppConfig.PROGRAM_NAME,
             description=_("CLI for Cobra")
         )
@@ -200,7 +202,7 @@ class CliApplication:
         if not self.parser or not self.command_registry:
             raise RuntimeError("Application not properly initialized")
             
-        subparsers = self.parser.add_subparsers(dest="command")
+        subparsers = self.parser.add_subparsers(dest="command", parser_class=CustomArgumentParser)
         self.command_registry.register_base_commands(subparsers)
 
         menu_parser = subparsers.add_parser("menu", help=_("Modo interactivo"))

--- a/src/cobra/cli/commands/base.py
+++ b/src/cobra/cli/commands/base.py
@@ -1,5 +1,7 @@
-from argparse import ArgumentParser, _SubParsersAction  # TODO: evitar uso de _SubParsersAction
+from argparse import _SubParsersAction  # TODO: evitar uso de _SubParsersAction
 from typing import Any
+
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 
 class BaseCommand:
     """Clase base para subcomandos de la CLI."""
@@ -16,14 +18,14 @@ class BaseCommand:
         if not self.name:
             raise ValueError("El nombre del comando no puede estar vacío")
     
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando en el parser.
         
         Args:
             subparsers: Objeto para registrar el subcomando
             
         Returns:
-            ArgumentParser: El parser configurado para el subcomando
+            CustomArgumentParser: El parser configurado para el subcomando
             
         Raises:
             NotImplementedError: Si la subclase no implementa este método

--- a/src/cobra/cli/commands/bench_cmd.py
+++ b/src/cobra/cli/commands/bench_cmd.py
@@ -19,11 +19,12 @@ import subprocess
 import sys
 import tempfile
 import time
-from argparse import ArgumentParser, _SubParsersAction
+from argparse import _SubParsersAction
 from pathlib import Path
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 from core.cobra_config import tiempo_max_transpilacion
 
@@ -118,7 +119,7 @@ class BenchCommand(BaseCommand):
 
     name = "bench"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
 
         Args:

--- a/src/cobra/cli/commands/bench_transpilers_cmd.py
+++ b/src/cobra/cli/commands/bench_transpilers_cmd.py
@@ -1,7 +1,7 @@
 import cProfile
 import contextlib
 import json
-from argparse import _SubParsersAction, ArgumentParser
+from argparse import _SubParsersAction
 from pathlib import Path
 from timeit import timeit
 from typing import Any, Dict, List
@@ -9,6 +9,7 @@ from typing import Any, Dict, List
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.commands.compile_cmd import TRANSPILERS
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 from core.ast_cache import obtener_ast
 
@@ -40,14 +41,14 @@ class BenchTranspilersCommand(BaseCommand):
 
     name = "benchtranspilers"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:
             subparsers: Objeto para registrar subcomandos
             
         Returns:
-            ArgumentParser: Parser configurado para este subcomando
+            CustomArgumentParser: Parser configurado para este subcomando
         """
         parser = subparsers.add_parser(
             self.name, help=_("Evalúa la velocidad de los transpiladores")

--- a/src/cobra/cli/commands/benchmarks2_cmd.py
+++ b/src/cobra/cli/commands/benchmarks2_cmd.py
@@ -7,9 +7,11 @@ import time
 import psutil
 import json
 from typing import Dict, Any, Optional
-from argparse import ArgumentParser, _SubParsersAction
+from argparse import _SubParsersAction
+
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_info, mostrar_error
 
 
@@ -34,14 +36,14 @@ class Benchmarks2Command(BaseCommand):
         self._formato: Optional[str] = None
         self._proceso = psutil.Process()
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:
             subparsers: Objeto para registrar el subcomando
             
         Returns:
-            ArgumentParser: El parser configurado para el subcomando
+            CustomArgumentParser: El parser configurado para el subcomando
             
         Raises:
             ValueError: Si hay error al configurar los argumentos

--- a/src/cobra/cli/commands/benchmarks_cmd.py
+++ b/src/cobra/cli/commands/benchmarks_cmd.py
@@ -1,8 +1,9 @@
-from argparse import _SubParsersAction, ArgumentParser
+from argparse import _SubParsersAction
 from typing import Any
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error
 
 class BenchmarksCommand(BaseCommand):
@@ -10,14 +11,14 @@ class BenchmarksCommand(BaseCommand):
     
     name = "benchmarks"
     
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:
             subparsers: Objeto para registrar el subcomando
             
         Returns:
-            ArgumentParser: El parser configurado para el subcomando
+            CustomArgumentParser: El parser configurado para el subcomando
         """
         parser = subparsers.add_parser(
             self.name, help=_("Ejecuta benchmarks")

--- a/src/cobra/cli/commands/cache_cmd.py
+++ b/src/cobra/cli/commands/cache_cmd.py
@@ -1,8 +1,10 @@
 from typing import Any
-from argparse import ArgumentParser, _SubParsersAction  # TODO: Usar API pública
+from argparse import _SubParsersAction  # TODO: Usar API pública
 from core.ast_cache import limpiar_cache
+
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_info, mostrar_error
 
 class CacheCommand(BaseCommand):
@@ -17,14 +19,14 @@ class CacheCommand(BaseCommand):
     
     name: str = "cache"
     
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:
             subparsers: Objeto para registrar el subcomando
             
         Returns:
-            ArgumentParser: El parser configurado para el subcomando
+            CustomArgumentParser: El parser configurado para el subcomando
         """
         parser = subparsers.add_parser(
             self.name, help=_("Elimina los archivos de la caché de AST")

--- a/src/cobra/cli/commands/container_cmd.py
+++ b/src/cobra/cli/commands/container_cmd.py
@@ -3,10 +3,11 @@ import re
 import subprocess
 from pathlib import Path
 from typing import Any
-from argparse import ArgumentParser, _SubParsersAction
+from argparse import _SubParsersAction
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 def validar_tag(valor: str) -> str:
@@ -19,7 +20,7 @@ class ContainerCommand(BaseCommand):
     """Construye la imagen Docker del proyecto."""
     name = "contenedor"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando."""
         parser = subparsers.add_parser(self.name, help=_("Construye la imagen Docker"))
         parser.add_argument(

--- a/src/cobra/cli/commands/crear_cmd.py
+++ b/src/cobra/cli/commands/crear_cmd.py
@@ -1,8 +1,10 @@
-from argparse import ArgumentParser, _SubParsersAction  # TODO: Reemplazar _SubParsersAction
+from argparse import _SubParsersAction  # TODO: Reemplazar _SubParsersAction
 from pathlib import Path
+from typing import Any
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 
@@ -11,14 +13,14 @@ class CrearCommand(BaseCommand):
     
     name = "crear"
     
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:
             subparsers: Objeto para registrar subcomandos
             
         Returns:
-            ArgumentParser: Parser configurado
+            CustomArgumentParser: Parser configurado
             
         Note:
             Crea subcomandos para crear archivos, carpetas y proyectos
@@ -38,7 +40,7 @@ class CrearCommand(BaseCommand):
         parser.set_defaults(cmd=self)
         return parser
 
-    def run(self, args: ArgumentParser) -> int:
+    def run(self, args: Any) -> int:
         """Ejecuta la lógica del comando.
         
         Args:

--- a/src/cobra/cli/commands/dependencias_cmd.py
+++ b/src/cobra/cli/commands/dependencias_cmd.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 import tempfile
 import venv
-from argparse import _SubParsersAction, ArgumentParser
+from argparse import _SubParsersAction
 from pathlib import Path
 from typing import List, Optional, Any
 
@@ -16,6 +16,7 @@ except ModuleNotFoundError:  # pragma: no cover
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 logger = logging.getLogger(__name__)
@@ -33,14 +34,14 @@ class DependenciasCommand(BaseCommand):
 
     name = "dependencias"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:
             subparsers: Objeto para registrar subcomandos
             
         Returns:
-            ArgumentParser: Parser configurado para este subcomando
+            CustomArgumentParser: Parser configurado para este subcomando
         """
         parser = subparsers.add_parser(
             self.name, help=_("Gestiona las dependencias del proyecto")

--- a/src/cobra/cli/commands/docs_cmd.py
+++ b/src/cobra/cli/commands/docs_cmd.py
@@ -1,16 +1,18 @@
 from pathlib import Path
 import subprocess
 from typing import Any, Optional
-from argparse import _SubParsersAction, ArgumentParser
+from argparse import _SubParsersAction
+
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 class DocsCommand(BaseCommand):
     """Genera la documentación HTML del proyecto."""
     name = "docs"
     
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando."""
         parser = subparsers.add_parser(
             self.name, help=_("Genera la documentación del proyecto")

--- a/src/cobra/cli/commands/empaquetar_cmd.py
+++ b/src/cobra/cli/commands/empaquetar_cmd.py
@@ -3,25 +3,26 @@ import platform
 from pathlib import Path
 import subprocess
 import re
-from typing import List
-from argparse import ArgumentParser, _ArgumentGroup
+from typing import List, Any
+from argparse import _ArgumentGroup
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 class EmpaquetarCommand(BaseCommand):
     """Empaqueta la CLI en un ejecutable."""
     name = "empaquetar"
 
-    def register_subparser(self, subparsers: _ArgumentGroup) -> ArgumentParser:
+    def register_subparser(self, subparsers: _ArgumentGroup) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:
             subparsers: Grupo para registrar subcomandos
             
         Returns:
-            ArgumentParser: El parser configurado para este subcomando
+            CustomArgumentParser: El parser configurado para este subcomando
         """
         parser = subparsers.add_parser(
             self.name, help=_("Crea un ejecutable para la CLI usando PyInstaller")
@@ -92,7 +93,7 @@ class EmpaquetarCommand(BaseCommand):
         except ValueError:
             return False
 
-    def run(self, args: ArgumentParser) -> int:
+    def run(self, args: Any) -> int:
         """Ejecuta la lógica del comando.
         
         Args:

--- a/src/cobra/cli/commands/flet_cmd.py
+++ b/src/cobra/cli/commands/flet_cmd.py
@@ -1,6 +1,8 @@
-from argparse import ArgumentParser, _SubParsersAction  # TODO: Reemplazar _SubParsersAction
+from argparse import _SubParsersAction  # TODO: Reemplazar _SubParsersAction
+
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error
 
 class FletCommand(BaseCommand):
@@ -11,7 +13,7 @@ class FletCommand(BaseCommand):
         """Inicializa el comando."""
         super().__init__()
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:

--- a/src/cobra/cli/commands/init_cmd.py
+++ b/src/cobra/cli/commands/init_cmd.py
@@ -1,10 +1,11 @@
 import os
 from pathlib import Path
-from argparse import ArgumentParser, _SubParsersAction  # TODO: Reemplazar _SubParsersAction
+from argparse import _SubParsersAction  # TODO: Reemplazar _SubParsersAction
 from typing import Any
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_info, mostrar_error
 
 class InitCommand(BaseCommand):
@@ -12,14 +13,14 @@ class InitCommand(BaseCommand):
     
     name = "init"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:
             subparsers: Objeto para registrar subcomandos
             
         Returns:
-            ArgumentParser: El parser configurado para este subcomando
+            CustomArgumentParser: El parser configurado para este subcomando
         """
         parser = subparsers.add_parser(
             self.name, help=_("Inicializa un proyecto Cobra")

--- a/src/cobra/cli/commands/interactive_cmd.py
+++ b/src/cobra/cli/commands/interactive_cmd.py
@@ -3,7 +3,7 @@ import re
 import resource
 import traceback
 from typing import Optional, Any, NoReturn
-from argparse import _SubParsersAction, ArgumentParser
+from argparse import _SubParsersAction
 
 from cobra.core import Lexer, LexerError
 from cobra.core import Parser, ParserError
@@ -18,6 +18,7 @@ from core.sandbox import (
 from core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 class InteractiveCommand(BaseCommand):
     """Modo interactivo del lenguaje Cobra.
@@ -49,7 +50,7 @@ class InteractiveCommand(BaseCommand):
             format='%(asctime)s - %(levelname)s - %(message)s'
         )
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
 
         Args:

--- a/src/cobra/cli/commands/jupyter_cmd.py
+++ b/src/cobra/cli/commands/jupyter_cmd.py
@@ -1,10 +1,12 @@
 import subprocess
 import sys
-from argparse import ArgumentParser, _SubParsersAction  # TODO: Evitar uso de _SubParsersAction
+from argparse import _SubParsersAction  # TODO: Evitar uso de _SubParsersAction
 from pathlib import Path
 from typing import Any
+
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error
 
 
@@ -12,14 +14,14 @@ class JupyterCommand(BaseCommand):
     """Lanza Jupyter Notebook con el kernel Cobra instalado."""
     name = "jupyter"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
 
         Args:
             subparsers: Objeto para registrar el subcomando
 
         Returns:
-            ArgumentParser: El parser configurado para este subcomando
+            CustomArgumentParser: El parser configurado para este subcomando
         """
         parser = subparsers.add_parser(self.name, help=_("Inicia Jupyter Notebook"))
         parser.add_argument(

--- a/src/cobra/cli/commands/package_cmd.py
+++ b/src/cobra/cli/commands/package_cmd.py
@@ -1,12 +1,13 @@
 import logging
 import zipfile
-from argparse import ArgumentParser, _SubParsersAction  # TODO: Evitar uso de API privada
+from argparse import _SubParsersAction, Namespace  # TODO: Evitar uso de API privada
 from pathlib import Path
 from typing import List
 
 from cobra.cli.commands import modules_cmd
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 # Constantes
@@ -18,14 +19,14 @@ class PaqueteCommand(BaseCommand):
     """Crea e instala paquetes Cobra."""
     name = "paquete"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:
             subparsers: Objeto para registrar subcomandos
             
         Returns:
-            ArgumentParser: Parser configurado para este subcomando
+            CustomArgumentParser: Parser configurado para este subcomando
         """
         parser = subparsers.add_parser(self.name, help=_("Gestiona paquetes Cobra"))
         sub = parser.add_subparsers(dest="accion", required=True)
@@ -42,7 +43,7 @@ class PaqueteCommand(BaseCommand):
         parser.set_defaults(cmd=self)
         return parser
 
-    def run(self, args: ArgumentParser) -> int:
+    def run(self, args: Namespace) -> int:
         """Ejecuta la lógica del comando.
         
         Args:

--- a/src/cobra/cli/commands/plugins_cmd.py
+++ b/src/cobra/cli/commands/plugins_cmd.py
@@ -1,9 +1,10 @@
-from argparse import ArgumentParser
 from typing import Dict, Optional
 from dataclasses import dataclass
+
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
 from cobra.cli.plugin_registry import obtener_registro_detallado
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_info, mostrar_error
 
 
@@ -25,14 +26,14 @@ class PluginsCommand(BaseCommand):
     ARG_ACCION = "accion"
     ARG_TEXTO = "texto"
 
-    def register_subparser(self, subparsers) -> ArgumentParser:
+    def register_subparser(self, subparsers) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:
             subparsers: Objeto para registrar subcomandos
             
         Returns:
-            ArgumentParser: El parser configurado para este subcomando
+            CustomArgumentParser: El parser configurado para este subcomando
         """
         parser = subparsers.add_parser(self.name, help=_("Lista plugins instalados"))
         sub = parser.add_subparsers(dest=self.ARG_ACCION)

--- a/src/cobra/cli/commands/profile_cmd.py
+++ b/src/cobra/cli/commands/profile_cmd.py
@@ -9,7 +9,7 @@ import pstats
 import shutil
 import subprocess
 import tempfile
-from argparse import ArgumentParser, _SubParsersAction
+from argparse import _SubParsersAction, Namespace
 from pathlib import Path
 from typing import Optional
 
@@ -22,6 +22,7 @@ from core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.commands.execute_cmd import ExecuteCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 
@@ -38,7 +39,7 @@ class ProfileCommand(BaseCommand):
         except OSError as e:
             self.logger.warning(f"Error al eliminar archivo temporal {archivo}: {e}")
 
-    def _obtener_argumento(self, args: ArgumentParser, nombre: str, default: Optional[any] = None) -> any:
+    def _obtener_argumento(self, args: Namespace, nombre: str, default: Optional[any] = None) -> any:
         """Obtiene un argumento del namespace de argumentos con valor por defecto."""
         return getattr(args, nombre, default)
 
@@ -51,7 +52,7 @@ class ProfileCommand(BaseCommand):
         mostrar_error(msg)
         return 1
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando."""
         parser = subparsers.add_parser(self.name, help=_("Perfila un programa"))
         parser.add_argument("archivo")
@@ -81,7 +82,7 @@ class ProfileCommand(BaseCommand):
         except OSError:
             return False
 
-    def run(self, args: ArgumentParser) -> int:
+    def run(self, args: Namespace) -> int:
         """Ejecuta la lógica del comando."""
         archivo: str = args.archivo
         output: Optional[str] = self._obtener_argumento(args, "output")

--- a/src/cobra/cli/commands/qualia_cmd.py
+++ b/src/cobra/cli/commands/qualia_cmd.py
@@ -1,10 +1,11 @@
 import json
-from argparse import ArgumentParser, _SubParsersAction  # TODO: Reemplazar _SubParsersAction
+from argparse import _SubParsersAction  # TODO: Reemplazar _SubParsersAction
 from pathlib import Path
 from typing import Any, Union
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 from core import qualia_bridge
 
@@ -18,14 +19,14 @@ class QualiaCommand(BaseCommand):
     ACCION_MOSTRAR = "mostrar"
     ACCION_REINICIAR = "reiniciar"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:
             subparsers: Objeto para registrar los subcomandos
             
         Returns:
-            ArgumentParser: El parser configurado para el subcomando
+            CustomArgumentParser: El parser configurado para el subcomando
         """
         parser = subparsers.add_parser(
             self.name, help=_("Administra el estado de Qualia")

--- a/src/cobra/cli/commands/transpilar_inverso_cmd.py
+++ b/src/cobra/cli/commands/transpilar_inverso_cmd.py
@@ -2,7 +2,7 @@ import os
 import logging
 import inspect
 from typing import Optional, Dict, Type
-from argparse import _SubParsersAction, ArgumentParser, Namespace
+from argparse import _SubParsersAction, Namespace
 from contextlib import contextmanager
 from chardet import detect
 from jsonschema import ValidationError
@@ -11,6 +11,7 @@ import cobra.transpilers.reverse as reverse_module
 from cobra.cli.commands.base import BaseCommand, CommandError
 from cobra.cli.commands.compile_cmd import TRANSPILERS
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 # Configuración del logging
@@ -73,14 +74,14 @@ class TranspilarInversoCommand(BaseCommand):
 
     name: str = "transpilar-inverso"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando en el parser.
         
         Args:
             subparsers: Objeto para registrar subcomandos
             
         Returns:
-            ArgumentParser: Parser configurado para el subcomando
+            CustomArgumentParser: Parser configurado para el subcomando
         """
         parser = subparsers.add_parser(
             self.name, help=_("Transpila desde un lenguaje origen a otro destino")

--- a/src/cobra/cli/commands/verify_cmd.py
+++ b/src/cobra/cli/commands/verify_cmd.py
@@ -5,7 +5,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
-from argparse import _SubParsersAction, ArgumentParser
+from argparse import _SubParsersAction
 
 from cobra.cli.commands.compile_cmd import TRANSPILERS
 from cobra.core import Lexer
@@ -14,6 +14,7 @@ from core.interpreter import InterpretadorCobra
 from core.sandbox import ejecutar_en_sandbox, ejecutar_en_sandbox_js
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 
 # Constantes
@@ -32,7 +33,7 @@ class VerifyCommand(BaseCommand):
         self._interprete = InterpretadorCobra()
         self._logger = logging.getLogger(__name__)
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> ArgumentParser:
+    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:

--- a/src/cobra/cli/utils/argument_parser.py
+++ b/src/cobra/cli/utils/argument_parser.py
@@ -1,0 +1,14 @@
+from argparse import ArgumentParser
+
+from cobra.cli.i18n import _
+from cobra.cli.utils import messages
+
+
+class CustomArgumentParser(ArgumentParser):
+    """ArgumentParser personalizado que usa mostrar_error y muestra la ayuda."""
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        """Muestra un mensaje de error localizado y la ayuda."""
+        messages.mostrar_error(_(message))
+        self.print_help()
+        raise SystemExit(2)

--- a/src/tests/unit/test_custom_argument_parser.py
+++ b/src/tests/unit/test_custom_argument_parser.py
@@ -1,0 +1,22 @@
+import pytest
+from io import StringIO
+from unittest.mock import patch
+
+from cobra.cli.utils.argument_parser import CustomArgumentParser
+from cobra.cli.utils import messages
+
+
+def test_custom_argument_parser_error(monkeypatch):
+    captured = {}
+
+    def fake_error(msg: str) -> None:
+        captured['msg'] = msg
+
+    monkeypatch.setattr(messages, 'mostrar_error', fake_error)
+    parser = CustomArgumentParser(prog='cobra')
+    parser.add_argument('--ok')
+    with patch('sys.stdout', new_callable=StringIO) as out, pytest.raises(SystemExit) as exc:
+        parser.parse_args(['--bad'])
+    assert 'unrecognized arguments' in captured['msg']
+    assert 'usage:' in out.getvalue()
+    assert exc.value.code == 2


### PR DESCRIPTION
## Summary
- add CustomArgumentParser using localized error messages
- replace argparse parsers across CLI and subcommands
- test invalid arguments output

## Testing
- `pytest src/tests/unit/test_custom_argument_parser.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_6898a21ee1a0832792fc14e238768f14