### PR TITLE
feat(cli): validar archivo inexistente antes de ejecutar comandos

### DIFF
--- a/src/cobra/cli/cli.py
+++ b/src/cobra/cli/cli.py
@@ -220,7 +220,7 @@ class CliApplication:
         if isinstance(exc, ValueError):
             messages.mostrar_error(_("Value error: {}").format(str(exc)))
         elif isinstance(exc, FileNotFoundError):
-            messages.mostrar_error(_("File not found: {}").format(str(exc)))
+            messages.mostrar_error(str(exc))
         else:
             messages.mostrar_error(_("An unexpected error occurred"))
 

--- a/src/cobra/cli/commands/agix_cmd.py
+++ b/src/cobra/cli/commands/agix_cmd.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, NoReturn
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.utils.validators import validar_archivo_existente
 from ia.analizador_agix import generar_sugerencias
 
 class AgixCommand(BaseCommand):
@@ -61,13 +62,7 @@ class AgixCommand(BaseCommand):
             mostrar_error(_("El peso de interpretabilidad debe ser positivo"))
             return 1
 
-        archivo = Path(args.archivo)
-
-        try:
-            self._validar_archivo(archivo)
-        except ValueError as e:
-            mostrar_error(str(e))
-            return 1
+        archivo = validar_archivo_existente(args.archivo)
 
         try:
             codigo = self._leer_archivo(archivo)
@@ -87,20 +82,6 @@ class AgixCommand(BaseCommand):
         except Exception as e:
             mostrar_error(_("Error al generar sugerencias: {error}").format(error=str(e)))
             return 1
-
-    def _validar_archivo(self, archivo: Path) -> None:
-        """Valida que el archivo exista y sea accesible.
-
-        Args:
-            archivo: Ruta al archivo a validar
-
-        Raises:
-            ValueError: Si el archivo no existe o no es accesible
-        """
-        if not archivo.exists():
-            raise ValueError(_("El archivo '{archivo}' no existe").format(archivo=archivo))
-        if not archivo.is_file():
-            raise ValueError(_("La ruta '{archivo}' no es un archivo").format(archivo=archivo))
 
     def _leer_archivo(self, archivo: Path) -> str:
         """Lee el contenido del archivo.

--- a/src/cobra/cli/commands/compile_cmd.py
+++ b/src/cobra/cli/commands/compile_cmd.py
@@ -39,6 +39,7 @@ from core.semantic_validators import (
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.utils.validators import validar_archivo_existente
 from cobra.core import ParserError
 from core.cobra_config import tiempo_max_transpilacion
 
@@ -95,11 +96,10 @@ LANG_CHOICES = sorted(TRANSPILERS.keys())
 
 def validate_file(filepath: str) -> bool:
     """Valida que el archivo sea accesible y cumpla con los límites establecidos."""
-    if not os.path.isfile(filepath):
-        raise ValueError(f"'{filepath}' no es un archivo válido")
-    if not os.access(filepath, os.R_OK):
+    path = validar_archivo_existente(filepath)
+    if not os.access(path, os.R_OK):
         raise ValueError(f"No hay permisos de lectura para '{filepath}'")
-    if os.path.getsize(filepath) > MAX_FILE_SIZE:
+    if os.path.getsize(path) > MAX_FILE_SIZE:
         raise ValueError(f"El archivo excede el tamaño máximo permitido ({MAX_FILE_SIZE} bytes)")
     return True
 

--- a/src/cobra/cli/commands/execute_cmd.py
+++ b/src/cobra/cli/commands/execute_cmd.py
@@ -9,6 +9,7 @@ from argcomplete.completers import FilesCompleter
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.utils.validators import validar_archivo_existente
 from cobra.core import Lexer, LexerError
 from cobra.core import Parser, ParserError
 from cobra.transpilers import module_map
@@ -56,9 +57,7 @@ class ExecuteCommand(BaseCommand):
         Raises:
             ValueError: Si el archivo no existe o excede el tamaño máximo
         """
-        ruta = Path(archivo)
-        if not ruta.exists():
-            raise FileNotFoundError(f"El archivo '{archivo}' no existe")
+        ruta = validar_archivo_existente(archivo)
         if ruta.stat().st_size > self.MAX_FILE_SIZE:
             raise ValueError(f"El archivo excede el tamaño máximo permitido ({self.MAX_FILE_SIZE} bytes)")
 
@@ -86,7 +85,7 @@ class ExecuteCommand(BaseCommand):
         """
         try:
             self._validar_archivo(args.archivo)
-        except (FileNotFoundError, ValueError) as e:
+        except ValueError as e:
             mostrar_error(str(e))
             return 1
 

--- a/src/cobra/cli/commands/jupyter_cmd.py
+++ b/src/cobra/cli/commands/jupyter_cmd.py
@@ -8,6 +8,7 @@ from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
 from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error
+from cobra.cli.utils.validators import validar_archivo_existente
 
 
 class JupyterCommand(BaseCommand):
@@ -51,9 +52,8 @@ class JupyterCommand(BaseCommand):
             return 1
 
         # Validar ruta del notebook si se proporciona
-        if args.notebook and not args.notebook.exists():
-            mostrar_error(_("El archivo '{path}' no existe").format(path=args.notebook))
-            return 1
+        if args.notebook:
+            validar_archivo_existente(args.notebook)
 
         try:
             # Instalar el kernel de Cobra

--- a/src/cobra/cli/commands/profile_cmd.py
+++ b/src/cobra/cli/commands/profile_cmd.py
@@ -24,6 +24,7 @@ from cobra.cli.commands.execute_cmd import ExecuteCommand
 from cobra.cli.i18n import _
 from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.utils.validators import validar_archivo_existente
 
 
 class ProfileCommand(BaseCommand):
@@ -93,9 +94,7 @@ class ProfileCommand(BaseCommand):
         extra_validators: Optional[str] = self._obtener_argumento(args, "validadores_extra")
         analysis: bool = self._obtener_argumento(args, "analysis", False)
 
-        if not Path(archivo).exists():
-            mostrar_error(f"El archivo '{archivo}' no existe")
-            return 1
+        validar_archivo_existente(archivo)
 
         if output and not self._validar_directorio_salida(output):
             mostrar_error(f"No se puede escribir en el directorio de salida para '{output}'")

--- a/src/cobra/cli/commands/transpilar_inverso_cmd.py
+++ b/src/cobra/cli/commands/transpilar_inverso_cmd.py
@@ -13,6 +13,7 @@ from cobra.cli.commands.compile_cmd import TRANSPILERS
 from cobra.cli.i18n import _
 from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.utils.validators import validar_archivo_existente
 
 # Configuración del logging
 logger = logging.getLogger(__name__)
@@ -117,8 +118,6 @@ class TranspilarInversoCommand(BaseCommand):
         Returns:
             Optional[str]: Mensaje de error si hay problemas, None si todo está bien
         """
-        if not os.path.exists(archivo):
-            return f"El archivo '{archivo}' no existe"
         if not os.path.isfile(archivo):
             return f"'{archivo}' no es un archivo regular"
         if not os.access(archivo, os.R_OK):
@@ -187,6 +186,8 @@ class TranspilarInversoCommand(BaseCommand):
 
             logger.debug(f"Iniciando validación del archivo {args.archivo}")
 
+            validar_archivo_existente(args.archivo)
+
             # Validar archivo
             if error := self._validar_archivo(args.archivo, origen):
                 raise CommandError(error)
@@ -230,6 +231,8 @@ class TranspilarInversoCommand(BaseCommand):
             mostrar_error(f"Error de codificación al leer '{args.archivo}'")
             return 1
         except OSError as exc:
+            if isinstance(exc, FileNotFoundError):
+                raise
             logger.error(f"Error de E/S: {exc}", exc_info=True)
             mostrar_error(f"Error al leer el archivo: {exc}")
             return 1

--- a/src/cobra/cli/commands/verify_cmd.py
+++ b/src/cobra/cli/commands/verify_cmd.py
@@ -16,6 +16,7 @@ from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
 from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
+from cobra.cli.utils.validators import validar_archivo_existente
 
 # Constantes
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
@@ -111,13 +112,12 @@ class VerifyCommand(BaseCommand):
             FileNotFoundError: Si el archivo no existe
             PermissionError: Si no hay permisos para leer el archivo
         """
+        validar_archivo_existente(file_path)
         self._validate_file(file_path)
-        
+
         try:
             with open(file_path, "r", encoding="utf-8") as f:
                 return f.read()
-        except FileNotFoundError:
-            raise FileNotFoundError(_("El archivo '{}' no existe").format(file_path))
         except PermissionError:
             raise PermissionError(
                 _("No hay permisos para leer el archivo '{}'").format(file_path)
@@ -235,7 +235,7 @@ class VerifyCommand(BaseCommand):
             mostrar_info(_("Todas las salidas coinciden"))
             return 0
             
-        except (ValueError, FileNotFoundError, PermissionError) as e:
+        except (ValueError, PermissionError) as e:
             mostrar_error(str(e))
             return 1
         except Exception as e:

--- a/src/cobra/cli/utils/validators.py
+++ b/src/cobra/cli/utils/validators.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from cobra.cli.i18n import _
+
+
+def validar_archivo_existente(ruta: str | Path) -> Path:
+    """Valida que un archivo exista.
+
+    Args:
+        ruta: Ruta al archivo a comprobar.
+
+    Returns:
+        Path: Objeto Path de la ruta validada.
+
+    Raises:
+        FileNotFoundError: Si el archivo no existe.
+    """
+    path = Path(ruta)
+    if not path.exists() or not path.is_file():
+        raise FileNotFoundError(
+            _("El archivo '{path}' no existe").format(path=path)
+        )
+    return path

--- a/src/tests/unit/test_cli_agix_missing_file.py
+++ b/src/tests/unit/test_cli_agix_missing_file.py
@@ -1,0 +1,13 @@
+import pytest
+from argparse import Namespace
+
+from cobra.cli.commands.agix_cmd import AgixCommand
+
+
+def test_cli_agix_archivo_inexistente(tmp_path):
+    archivo = tmp_path / "no.co"
+    cmd = AgixCommand()
+    args = Namespace(archivo=str(archivo), peso_precision=None, peso_interpretabilidad=None)
+    with pytest.raises(FileNotFoundError) as exc:
+        cmd.run(args)
+    assert f"El archivo '{archivo}' no existe" in str(exc.value)

--- a/src/tests/unit/test_cli_execute_missing_file.py
+++ b/src/tests/unit/test_cli_execute_missing_file.py
@@ -1,0 +1,13 @@
+import pytest
+from argparse import Namespace
+
+from cobra.cli.commands.execute_cmd import ExecuteCommand
+
+
+def test_cli_ejecutar_archivo_inexistente(tmp_path):
+    archivo = tmp_path / "no.co"
+    cmd = ExecuteCommand()
+    args = Namespace(archivo=str(archivo), sandbox=False, contenedor=None)
+    with pytest.raises(FileNotFoundError) as exc:
+        cmd.run(args)
+    assert f"El archivo '{archivo}' no existe" in str(exc.value)

--- a/src/tests/unit/test_cli_jupyter.py
+++ b/src/tests/unit/test_cli_jupyter.py
@@ -1,13 +1,18 @@
 from unittest.mock import patch, call
 import sys
-from cli.cli import main
+from argparse import Namespace
+
+from cobra.cli.commands.jupyter_cmd import JupyterCommand
 
 
 def test_cli_jupyter_installs_kernel():
-    with patch("subprocess.run") as mock_run:
-        main(["jupyter"])
+    cmd = JupyterCommand()
+    with patch.dict("sys.modules", {"jupyter": object()}), patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stderr = ""
+        cmd.run(Namespace(notebook=None))
         mock_run.assert_has_calls([
-            call([sys.executable, "-m", "cobra.jupyter_kernel", "install"], check=True),
+            call([sys.executable, "-m", "cobra.jupyter_kernel", "install"], check=True, capture_output=True, text=True),
             call([
                 "jupyter",
                 "notebook",
@@ -16,15 +21,20 @@ def test_cli_jupyter_installs_kernel():
         ])
 
 
-def test_cli_jupyter_opens_specific_notebook():
-    with patch("subprocess.run") as mock_run:
-        main(["jupyter", "--notebook=demo.ipynb"])
+def test_cli_jupyter_opens_specific_notebook(tmp_path):
+    nb = tmp_path / "demo.ipynb"
+    nb.write_text("\n")
+    cmd = JupyterCommand()
+    with patch.dict("sys.modules", {"jupyter": object()}), patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stderr = ""
+        cmd.run(Namespace(notebook=nb))
         mock_run.assert_has_calls([
-            call([sys.executable, "-m", "cobra.jupyter_kernel", "install"], check=True),
+            call([sys.executable, "-m", "cobra.jupyter_kernel", "install"], check=True, capture_output=True, text=True),
             call([
                 "jupyter",
                 "notebook",
                 "--KernelManager.default_kernel_name=cobra",
-                "demo.ipynb",
+                str(nb),
             ], check=True),
         ])


### PR DESCRIPTION
## Summary
- Añadido utilitario `validar_archivo_existente` para centralizar la verificación de rutas
- Integrados los comandos para usar la nueva validación y propagar `FileNotFoundError`
- El manejador `_handle_execution_error` muestra directamente el mensaje de la excepción
- Pruebas unitarias para comandos que operan sobre archivos inexistentes

## Testing
- `PYTHONPATH=src pytest src/tests/unit/test_cli_execute_missing_file.py src/tests/unit/test_cli_agix_missing_file.py src/tests/unit/test_cli_jupyter.py --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a761d1648327a1b46aebb00f92b4