### PR TITLE
feat: agregar prompt_toolkit y Pygments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     "packaging",
     "pybind11>=2.13.6",
     "RestrictedPython>=8.0",
+    "prompt_toolkit",
+    "Pygments",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ holobit-sdk==1.0.8
 smooth-criminal==0.4.0
 
 argcomplete
+
+prompt_toolkit
+Pygments


### PR DESCRIPTION
## Resumen
- agrega prompt_toolkit y Pygments a las dependencias del proyecto

## Testing
- `pip install -r requirements.txt`
- `pytest` *(falla: unrecognized arguments: --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_6898b66cfc208327b4ea5ef4aeb4c0de