### PR TITLE
Configurar historial del REPL

### DIFF
--- a/src/cobra/cli/commands/interactive_cmd.py
+++ b/src/cobra/cli/commands/interactive_cmd.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import resource
 import traceback
@@ -189,9 +190,11 @@ class InteractiveCommand(BaseCommand):
         # Obtener modos de ejecución
         sandbox = getattr(args, "sandbox", False)
         sandbox_docker = getattr(args, "sandbox_docker", None)
+        history_path = os.path.expanduser("~/.cobra_history")
+        os.makedirs(os.path.dirname(history_path), exist_ok=True)
         session = PromptSession(
             lexer=PygmentsLexer(CobraLexer),
-            history=FileHistory('~/.cobra_history'),
+            history=FileHistory(history_path),
         )
 
         with self:  # Usar context manager para recursos

--- a/src/tests/unit/test_cli_interactive_cmd.py
+++ b/src/tests/unit/test_cli_interactive_cmd.py
@@ -101,3 +101,17 @@ def test_interactive_session_persistence():
         cmd.run(_args())
     salida = mock_stdout.getvalue().strip().split('\n')
     assert salida[-1] == '5'
+
+
+def test_interactive_history_setup(tmp_path):
+    cmd = InteractiveCommand(MagicMock())
+    fake_path = tmp_path / '.cobra_history'
+    with patch('cobra.cli.commands.interactive_cmd.os.path.expanduser', return_value=str(fake_path)) as mock_expanduser, \
+         patch('cobra.cli.commands.interactive_cmd.os.makedirs') as mock_makedirs, \
+         patch('cobra.cli.commands.interactive_cmd.FileHistory') as mock_history, \
+         patch('prompt_toolkit.shortcuts.prompt.PromptSession.prompt', side_effect=['salir']), \
+         patch('cobra.cli.commands.interactive_cmd.validar_dependencias'):
+        cmd.run(_args())
+    mock_expanduser.assert_called_once_with('~/.cobra_history')
+    mock_makedirs.assert_called_once_with(str(tmp_path), exist_ok=True)
+    mock_history.assert_called_once_with(str(fake_path))


### PR DESCRIPTION
## Resumen
- Asegura que el REPL use un archivo de historial en `~/.cobra_history` y crea el directorio si es necesario
- Añade prueba unitaria para comprobar que el historial se configura correctamente

## Pruebas
- `pytest` *(falló: module 'importlib' has no attribute 'ModuleType')*
- `pytest src/tests/unit/test_cli_interactive_cmd.py -q --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_6898ce786aa0832783d78067cdc357eb