### PR TITLE
docs: document interactive REPL history

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,8 +666,22 @@ Si no proporcionas un subcomando se abrirá el modo interactivo.
 
 ### Uso interactivo
 
-Al ejecutar `cobra` sin argumentos aparecerá un REPL. Si escribes una palabra
-clave con un error tipográfico se mostrará una sugerencia automática. Ejemplo:
+Al ejecutar `cobra` sin argumentos, o explícitamente con `cobra interactive`,
+se inicia un REPL construido con
+[prompt_toolkit](https://python-prompt-toolkit.readthedocs.io/). Este REPL
+ofrece resaltado de sintaxis mediante Pygments y mantiene un historial
+persistente entre sesiones.
+
+El historial se guarda en el archivo `~/.cobra_history`. Para consultarlo o
+reiniciarlo puedes ejecutar:
+
+```bash
+cat ~/.cobra_history   # muestra el historial
+rm ~/.cobra_history    # borra el historial
+```
+
+Si escribes una palabra clave con un error tipográfico se mostrará una
+sugerencia automática. Ejemplo:
 
 ```bash
 cobra> imprmir 1


### PR DESCRIPTION
## Summary
- document that `cobra interactive` uses `prompt_toolkit` with syntax highlighting and persistent history
- explain how to view or remove the `~/.cobra_history` file

## Testing
- `python check.py` *(fails: ruff, mypy, pytest, pyright; bandit missing)*

------
https://chatgpt.com/codex/tasks/task_e_6898d4ad4ee48327a666506897a2c09f