### PR TITLE
Documentar transpiladores y ejemplos Hello World

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -7,7 +7,7 @@ Este manual presenta en español los conceptos básicos para programar en Cobra.
 ## 1. Preparación del entorno
 
 1. Clona el repositorio y entra en el directorio `pCobra`.
-2. Crea y activa un entorno virtual.
+2. Crea y activa un entorno virtual de **Python 3.8 o superior**.
 3. Instala las dependencias con `pip install -r requirements-dev.txt`.
    Aseg\u00farate tambi\u00e9n de tener disponible la herramienta `cbindgen`:
 
@@ -20,7 +20,7 @@ Este manual presenta en español los conceptos básicos para programar en Cobra.
 
 ### Instalación con pipx
 
-Puedes instalar Cobra utilizando [pipx](https://pypa.github.io/pipx/), una herramienta que permite ejecutar aplicaciones de Python aisladas y requiere Python 3.6 o superior.
+Puedes instalar Cobra utilizando [pipx](https://pypa.github.io/pipx/), una herramienta que permite ejecutar aplicaciones de Python aisladas y requiere Python 3.8 o superior.
 
 ```bash
 pipx install cobra-lenguaje
@@ -164,6 +164,34 @@ Convierte programas entre distintos lenguajes usando la CLI:
   ```bash
   cobra transpilar-inverso reporte.cob --origen=cobol --destino=python
   ```
+
+### Transpiladores disponibles
+
+La carpeta [`examples/hello_world`](examples/hello_world) incluye ejemplos de "Hello World" para cada generador:
+
+- **ASM** – [hola.asm](examples/hello_world/asm/hola.asm)
+- **C** – [hola.c](examples/hello_world/c/hola.c)
+- **COBOL** – [hola.cob](examples/hello_world/cobol/hola.cob)
+- **C++** – [hola.cpp](examples/hello_world/cpp/hola.cpp)
+- **Fortran** – [hola.f90](examples/hello_world/fortran/hola.f90)
+- **Go** – [hola.go](examples/hello_world/go/hola.go)
+- **Java** – [Hola.java](examples/hello_world/java/Hola.java)
+- **JavaScript** – [hola.js](examples/hello_world/javascript/hola.js)
+- **Julia** – [hola.jl](examples/hello_world/julia/hola.jl)
+- **Kotlin** – [hola.kt](examples/hello_world/kotlin/hola.kt)
+- **LaTeX** – [hola.tex](examples/hello_world/latex/hola.tex)
+- **Matlab** – [hola.m](examples/hello_world/matlab/hola.m)
+- **Mojo** – [hola.mojo](examples/hello_world/mojo/hola.mojo)
+- **Pascal** – [hola.pas](examples/hello_world/pascal/hola.pas)
+- **Perl** – [hola.pl](examples/hello_world/perl/hola.pl)
+- **PHP** – [hola.php](examples/hello_world/php/hola.php)
+- **Python** – [hola.py](examples/hello_world/python/hola.py)
+- **R** – [hola.r](examples/hello_world/r/hola.r)
+- **Ruby** – [hola.rb](examples/hello_world/ruby/hola.rb)
+- **Rust** – [hola.rs](examples/hello_world/rust/hola.rs)
+- **Swift** – [hola.swift](examples/hello_world/swift/hola.swift)
+- **Visual Basic** – [Hola.vb](examples/hello_world/visualbasic/Hola.vb)
+- **WebAssembly** – [hola.wat](examples/hello_world/wasm/hola.wat)
 
 ### Características aún no soportadas
 

--- a/docs/especificacion_tecnica.md
+++ b/docs/especificacion_tecnica.md
@@ -63,21 +63,21 @@ fin
 
 ## Módulos
 
-Los archivos pueden importarse usando `importar`.
+Los archivos pueden importarse usando `import`.
 
 ```cobra
-importar utilidades
+import utilidades
 ```
 
 ## Manejo de errores
 
-El bloque `intentar` ... `excepto` captura excepciones.
+El bloque `intentar` ... `capturar` captura excepciones y puede incluir `finalmente`.
 
 ```cobra
 intentar:
     ejecutar_algo()
-excepto ErrorComoE:
-    imprimir e
+capturar e:
+    imprimir(e)
 fin
 ```
 
@@ -104,13 +104,13 @@ Las lambdas son funciones anónimas de una sola expresión.
 doble = lambda x: x * 2
 ```
 
-## Bloque `with`
+## Gestión de contextos
 
-El bloque `with` gestiona contextos y cierra recursos automáticamente.
+El bloque `con` gestiona contextos y cierra recursos automáticamente.
 
 ```cobra
-with archivo("datos.txt") as f:
-    imprimir f.leer()
+con archivo("datos.txt") como f:
+    imprimir(f.leer())
 fin
 ```
 

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -16,16 +16,36 @@ También puedes transpilar el programa a otros lenguajes usando la opción `--to
 cobra archivo.co --to python
 ```
 
-Los ejemplos de **Hello World** generados para cada transpilador se encuentran en la carpeta [`examples/hello_world`](../examples/hello_world) y en las siguientes rutas específicas:
+Los ejemplos de **Hello World** se encuentran en la carpeta [`examples/hello_world`](../examples/hello_world) con un subdirectorio por lenguaje. Algunos de ellos son:
 
-- [Hello World en Python](../examples/hello_world/python)
-- [Hello World en JavaScript](../examples/hello_world/javascript)
-- [Hello World en C](../examples/hello_world/c)
+- [ASM](../examples/hello_world/asm)
+- [C](../examples/hello_world/c)
+- [COBOL](../examples/hello_world/cobol)
+- [C++](../examples/hello_world/cpp)
+- [Fortran](../examples/hello_world/fortran)
+- [Go](../examples/hello_world/go)
+- [Java](../examples/hello_world/java)
+- [JavaScript](../examples/hello_world/javascript)
+- [Julia](../examples/hello_world/julia)
+- [Kotlin](../examples/hello_world/kotlin)
+- [LaTeX](../examples/hello_world/latex)
+- [Matlab](../examples/hello_world/matlab)
+- [Mojo](../examples/hello_world/mojo)
+- [Pascal](../examples/hello_world/pascal)
+- [Perl](../examples/hello_world/perl)
+- [PHP](../examples/hello_world/php)
+- [Python](../examples/hello_world/python)
+- [R](../examples/hello_world/r)
+- [Ruby](../examples/hello_world/ruby)
+- [Rust](../examples/hello_world/rust)
+- [Swift](../examples/hello_world/swift)
+- [Visual Basic](../examples/hello_world/visualbasic)
+- [WebAssembly](../examples/hello_world/wasm)
 
 
 ## 1. Hola mundo
 ```cobra
-imprimir "Hola mundo"
+imprimir("Hola mundo")
 ```
 
 ## 2. Variables y operaciones
@@ -123,16 +143,16 @@ imprimir atributo p nombre
 
 ## 15. Importar módulos
 ```cobra
-importar fecha
-imprimir fecha.hoy()
+import fecha
+imprimir(fecha.hoy())
 ```
 
 ## 16. Manejo de errores
 ```cobra
 intentar:
     abrir("no_existe.txt")
-excepto ErrorComoE:
-    imprimir "fallo"
+capturar ErrorComoE:
+    imprimir("fallo")
 fin
 ```
 

--- a/examples/hello_world/asm/hola.asm
+++ b/examples/hello_world/asm/hola.asm
@@ -1,0 +1,13 @@
+section .data
+    msg db "Hola Mundo", 10
+    len equ $ - msg
+section .text
+    global _start
+_start:
+    mov edx, len
+    mov ecx, msg
+    mov ebx, 1
+    mov eax, 4
+    int 0x80
+    mov eax, 1
+    int 0x80

--- a/examples/hello_world/c/hola.c
+++ b/examples/hello_world/c/hola.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hola Mundo\n");
+    return 0;
+}

--- a/examples/hello_world/cobol/hola.cob
+++ b/examples/hello_world/cobol/hola.cob
@@ -1,0 +1,5 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. HOLA.
+       PROCEDURE DIVISION.
+           DISPLAY "Hola Mundo".
+           STOP RUN.

--- a/examples/hello_world/cpp/hola.cpp
+++ b/examples/hello_world/cpp/hola.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hola Mundo" << std::endl;
+    return 0;
+}

--- a/examples/hello_world/fortran/hola.f90
+++ b/examples/hello_world/fortran/hola.f90
@@ -1,0 +1,3 @@
+program hola
+    print *, "Hola Mundo"
+end program hola

--- a/examples/hello_world/go/hola.go
+++ b/examples/hello_world/go/hola.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hola Mundo")
+}

--- a/examples/hello_world/java/Hola.java
+++ b/examples/hello_world/java/Hola.java
@@ -1,0 +1,5 @@
+public class Hola {
+    public static void main(String[] args) {
+        System.out.println("Hola Mundo");
+    }
+}

--- a/examples/hello_world/javascript/hola.js
+++ b/examples/hello_world/javascript/hola.js
@@ -1,0 +1,1 @@
+console.log("Hola Mundo");

--- a/examples/hello_world/julia/hola.jl
+++ b/examples/hello_world/julia/hola.jl
@@ -1,0 +1,1 @@
+println("Hola Mundo")

--- a/examples/hello_world/kotlin/hola.kt
+++ b/examples/hello_world/kotlin/hola.kt
@@ -1,0 +1,3 @@
+fun main() {
+    println("Hola Mundo")
+}

--- a/examples/hello_world/latex/hola.tex
+++ b/examples/hello_world/latex/hola.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+Hola Mundo
+\end{document}

--- a/examples/hello_world/matlab/hola.m
+++ b/examples/hello_world/matlab/hola.m
@@ -1,0 +1,1 @@
+disp('Hola Mundo')

--- a/examples/hello_world/mojo/hola.mojo
+++ b/examples/hello_world/mojo/hola.mojo
@@ -1,0 +1,2 @@
+fn main():
+    print("Hola Mundo")

--- a/examples/hello_world/pascal/hola.pas
+++ b/examples/hello_world/pascal/hola.pas
@@ -1,0 +1,4 @@
+program Hola;
+begin
+    writeln('Hola Mundo');
+end.

--- a/examples/hello_world/perl/hola.pl
+++ b/examples/hello_world/perl/hola.pl
@@ -1,0 +1,1 @@
+print "Hola Mundo\n";

--- a/examples/hello_world/php/hola.php
+++ b/examples/hello_world/php/hola.php
@@ -1,0 +1,3 @@
+<?php
+echo "Hola Mundo";
+?>

--- a/examples/hello_world/python/hola.py
+++ b/examples/hello_world/python/hola.py
@@ -1,0 +1,1 @@
+print("Hola Mundo")

--- a/examples/hello_world/r/hola.r
+++ b/examples/hello_world/r/hola.r
@@ -1,0 +1,1 @@
+print("Hola Mundo")

--- a/examples/hello_world/ruby/hola.rb
+++ b/examples/hello_world/ruby/hola.rb
@@ -1,0 +1,1 @@
+puts 'Hola Mundo'

--- a/examples/hello_world/rust/hola.rs
+++ b/examples/hello_world/rust/hola.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hola Mundo");
+}

--- a/examples/hello_world/swift/hola.swift
+++ b/examples/hello_world/swift/hola.swift
@@ -1,0 +1,1 @@
+print("Hola Mundo")

--- a/examples/hello_world/visualbasic/Hola.vb
+++ b/examples/hello_world/visualbasic/Hola.vb
@@ -1,0 +1,5 @@
+Module Program
+    Sub Main()
+        Console.WriteLine("Hola Mundo")
+    End Sub
+End Module

--- a/examples/hello_world/wasm/hola.wat
+++ b/examples/hello_world/wasm/hola.wat
@@ -1,0 +1,7 @@
+(module
+  (import "env" "print" (func $print (param i32)))
+  (memory 1)
+  (data (i32.const 0) "Hola Mundo")
+  (func (export "main")
+        (call $print (i32.const 0)))
+)


### PR DESCRIPTION
## Resumen
- Actualiza el manual con requisitos de entorno y lista de transpiladores con enlaces a ejemplos "Hello World".
- Corrige referencias obsoletas en la especificación técnica y la guía básica.
- Añade ejemplos "Hello World" para todos los lenguajes soportados.

## Testing
- `pytest` *(falla: unrecognized arguments --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_6898e089ca10832785ed1a5718ca9216