### PR TITLE
Add Cobra hello world example and document examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,35 @@
+# Ejemplos
+
+Este directorio reúne distintos ejemplos de uso de Cobra y material relacionado.
+
+## Subcarpetas
+
+- **avanzados/**: ejercicios que profundizan en control de flujo, funciones y clases. Para ejecutar uno:
+  ```bash
+  cobra ejecutar examples/avanzados/<tema>/<archivo>.co
+  ```
+- **hello_world/**: demostraciones "Hola Mundo" en varios lenguajes. El ejemplo en Cobra se ejecuta con:
+  ```bash
+  cobra ejecutar examples/hello_world/cobra/hola.co
+  ```
+- **plugins/**: plugins de muestra instalables en modo editable. Para probarlos:
+  ```bash
+  cd examples/plugins
+  pip install -e .
+  cobra plugins
+  ```
+- **tutorial_basico/**: guía básica con un hola mundo y utilidades de compilación manual. El programa principal se corre con:
+  ```bash
+  cobra ejecutar examples/tutorial_basico/hola_mundo.co
+  ```
+
+## Archivos individuales
+
+- `clase_metodo_atributo.co`
+- `funciones_principales.co`
+- `patrones.co`
+
+Cada uno puede ejecutarse con:
+```bash
+cobra ejecutar examples/<archivo>.co
+```

--- a/examples/hello_world/cobra/hola.co
+++ b/examples/hello_world/cobra/hola.co
@@ -1,0 +1,2 @@
+# Programa de ejemplo que imprime un saludo en pantalla
+imprimir('Hola, mundo!') // Esta línea muestra el texto en la consola

--- a/src/tests/data/expected_examples/hello_world/cobra/hola.txt
+++ b/src/tests/data/expected_examples/hello_world/cobra/hola.txt
@@ -1,0 +1,1 @@
+Hola, mundo!


### PR DESCRIPTION
## Summary
- Add `examples/hello_world/cobra` with a Cobra "Hola Mundo" example
- Document `examples` folder explaining how to run each section
- Provide expected CLI output for the new example

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68995be041148327aa117e155b646a7f