### PR TITLE
Add Replit setup with example and docs

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,1 @@
+run = "python -m cobra examples/replit/main.cobra"

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -16,6 +16,13 @@ También puedes transpilar el programa a otros lenguajes usando la opción `--to
 cobra archivo.co --to python
 ```
 
+### Ejecución en Replit
+
+1. Abre [Replit](https://replit.com/) e importa este repositorio desde GitHub.
+2. Al cargarse el entorno, se instalarán las dependencias indicadas en `requirements.txt` gracias al archivo `replit.nix`.
+3. El archivo `.replit` ya define el comando de ejecución `python -m cobra examples/replit/main.cobra`.
+4. Presiona **Run** para ejecutar el ejemplo inicial ubicado en `examples/replit/main.cobra`.
+
 Los ejemplos de **Hello World** se encuentran en la carpeta [`examples/hello_world`](../examples/hello_world) con un subdirectorio por lenguaje. En esa misma carpeta hay un `README.md` que muestra cómo transpilar cada archivo `.co` a su lenguaje destino y contiene los resultados pre-generados. Algunos de ellos son:
 
 - [ASM](../examples/hello_world/asm)

--- a/examples/replit/main.cobra
+++ b/examples/replit/main.cobra
@@ -1,0 +1,1 @@
+imprimir("Hola desde Replit")

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,9 @@
+{ pkgs }: {
+  deps = [
+    pkgs.python311Full
+    pkgs.python311Packages.pip
+  ];
+  shellHook = ''
+    pip install -r requirements.txt
+  '';
+}


### PR DESCRIPTION
## Summary
- configure Replit run command and environment
- add sample Cobra file for Replit
- document how to use Replit in basic guide

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_6899775b61cc8327b423c3282c739e9d