### PR TITLE
Add Binder configuration and playground notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Proyecto Cobra
 [![Codecov](https://codecov.io/gh/Alphonsus411/pCobra/branch/master/graph/badge.svg)](https://codecov.io/gh/Alphonsus411/pCobra)
 [![Versión estable](https://img.shields.io/github/v/release/Alphonsus411/pCobra?label=stable)](https://github.com/Alphonsus411/pCobra/releases/latest)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Alphonsus411/pCobra/HEAD?labpath=notebooks/playground.ipynb)
 
 
 Versión 10.0.6

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+pip install -e .

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,2 @@
+jupyterlab
+-e .

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -23,6 +23,13 @@ cobra archivo.co --to python
 3. El archivo `.replit` ya define el comando de ejecución `python -m cobra examples/replit/main.cobra`.
 4. Presiona **Run** para ejecutar el ejemplo inicial ubicado en `examples/replit/main.cobra`.
 
+### Ejecución en Binder
+
+1. Haz clic en el badge de Binder del README o visita [este enlace](https://mybinder.org/v2/gh/Alphonsus411/pCobra/HEAD?labpath=notebooks/playground.ipynb).
+2. Espera a que se construya el entorno; puede tardar unos minutos.
+3. Cuando se abra JupyterLab, abre el cuaderno `notebooks/playground.ipynb` si no se abrió automáticamente.
+4. Ejecuta las celdas una a una para transpilar el programa de Cobra a Python y ver el resultado.
+
 Los ejemplos de **Hello World** se encuentran en la carpeta [`examples/hello_world`](../examples/hello_world) con un subdirectorio por lenguaje. En esa misma carpeta hay un `README.md` que muestra cómo transpilar cada archivo `.co` a su lenguaje destino y contiene los resultados pre-generados. Algunos de ellos son:
 
 - [ASM](../examples/hello_world/asm)

--- a/notebooks/playground.ipynb
+++ b/notebooks/playground.ipynb
@@ -1,0 +1,57 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8e3a074c",
+   "metadata": {},
+   "source": [
+    "## Playground de Cobra\n",
+    "Este cuaderno muestra cómo transpilar un programa de Cobra a Python y ejecutarlo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5187733",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile hola.cobra\n",
+    "imprimir(\"Hola desde Cobra\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6829df4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cobra transpilar hola.cobra --destino=python -o hola.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9a6af22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat hola.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23d2e2ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python hola.py"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add binder environment with Jupyter
- showcase transpilation in new playground notebook
- document how to launch notebook via Binder and add README badge

## Testing
- `pip install .`
- `pytest -q` *(fails: module 'importlib' has no attribute 'ModuleType'; No module named 'ipykernel'; ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_6899e30455748327a0b1f6e1678df0a9