### PR TITLE
Configure devcontainer with sample transpile task

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "pCobra Codespace",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "postCreateCommand": "pip install -r requirements-dev.txt && pip install -e .",
+  "postAttachCommand": "cobra compile examples/main.cobra",
+  "customizations": {
+    "vscode": {
+      "openFiles": ["examples/main.cobra"],
+      "tasks": {
+        "version": "2.0.0",
+        "tasks": [
+          {
+            "label": "Transpilar ejemplo",
+            "type": "shell",
+            "command": "cobra compile examples/main.cobra",
+            "problemMatcher": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -16,6 +16,13 @@ También puedes transpilar el programa a otros lenguajes usando la opción `--to
 cobra archivo.co --to python
 ```
 
+### Ejecución en GitHub Codespaces
+
+1. En la página del repositorio en GitHub pulsa **Code** y luego la pestaña **Codespaces**.
+2. Selecciona **Create codespace on main** para lanzar un entorno basado en el contenedor de desarrollo.
+3. Durante el arranque se instalarán las dependencias de `requirements-dev.txt` y se configurará la CLI de Cobra.
+4. El archivo `examples/main.cobra` se abrirá automáticamente y se transpilará gracias a la tarea `Transpilar ejemplo`.
+
 ### Ejecución en Replit
 
 1. Abre [Replit](https://replit.com/) e importa este repositorio desde GitHub.

--- a/examples/main.cobra
+++ b/examples/main.cobra
@@ -1,0 +1,5 @@
+func principal():
+    imprimir "Hola desde Codespaces"
+fin
+
+principal()


### PR DESCRIPTION
## Summary
- add `.devcontainer` with Python base image and setup scripts
- open and transpile `examples/main.cobra` automatically in Codespaces
- document Codespaces usage in `docs/guia_basica.md`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_6899eaeabe7c8327a0b6e99d63f0d1b2