### PR TITLE
Compatibilidad con Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "10.0.6"
 description = "Un lenguaje de programación en español para simulaciones y más."
 authors = [ {name = "Adolfo González Hernández", email = "adolfogonzal@gmail.com"} ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "MIT" }
 keywords = ["cobra", "lenguaje", "cli"]
 


### PR DESCRIPTION
## Summary
- Ajusta `requires-python` a `>=3.9`
- Reescribe `obtener_valor` sin `match/case` para compatibilidad con Python 3.9

## Testing
- `apt-get install -y python3.9 python3.9-venv` *(falló: Unable to locate package)*
- `curl https://www.python.org/ftp/python/3.9.19/Python-3.9.19.tgz` *(falló: 403)*
- `PYTHONPATH=src python -m pytest -q --override-ini addopts=""` *(119 errors: ModuleNotFoundError: No module named 'coverage')*

------
https://chatgpt.com/codex/tasks/task_e_689a18167ef883278ca1645ec9bec472