### PR TITLE
chore: reference license file in package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Un lenguaje de programación en español para simulaciones y más
 authors = [ {name = "Adolfo González Hernández", email = "adolfogonzal@gmail.com"} ]
 readme = "README.md"
 requires-python = ">=3.9"
-license = { text = "MIT" }
+license = { file = "LICENSE" }
 keywords = ["cobra", "lenguaje", "cli"]
 
 dependencies = [


### PR DESCRIPTION
## Summary
- point project metadata to LICENSE file

## Testing
- `python -m build`
- `pip show cobra-lenguaje`
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_689a1ce6fca88327a1b37a5f4377edb1