### PR TITLE
Añade classifiers de licencia y versiones de Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,20 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cobra-lenguaje"
-version = "10.0.6"
+version = "10.0.7a0"
 description = "Un lenguaje de programación en español para simulaciones y más."
 authors = [ {name = "Adolfo González Hernández", email = "adolfogonzal@gmail.com"} ]
 readme = "README.md"
 requires-python = ">=3.9"
 license = { file = "LICENSE" }
 keywords = ["cobra", "lenguaje", "cli"]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
 
 dependencies = [
     "numpy>=1.22.0",


### PR DESCRIPTION
## Resumen
- Agrega la sección `classifiers` al `[project]` con información de licencia MIT y compatibilidad con Python 3.9–3.11.
- Actualiza el `version` a `10.0.7a0` para preparar una pre-release.

## Pruebas
- `PYTHONPATH=src pytest -q` (falla: ModuleType ausente e imports).
- `python -m build` (exitoso).
- `twine upload --repository testpypi dist/* -u __token__ -p pypi-FAKE_TOKEN` (falla: HTTP 403).


------
https://chatgpt.com/codex/tasks/task_e_689a1fe774b88327bd37f8338b73d240