### PR TITLE
docs: make heavy deps optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ pip install -e .
 
    Opcionalmente puedes ejecutar ``pip install -e .[dev]`` para instalar los
    extras de desarrollo.
+   Para añadir capacidades específicas puedes instalar extras desde PyPI:
+
+   ```bash
+   pip install cobra-lenguaje[ml]        # dependencias de aprendizaje automático
+   pip install cobra-lenguaje[big-data]  # soporte para procesamiento distribuido
+   ```
 
 6. Copia el archivo ``.env.example`` a ``.env`` y personaliza las rutas o claves
    de ser necesario. Estas variables se cargarán automáticamente al iniciar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,6 @@ dependencies = [
     "scipy>=1.5.4",
     "matplotlib>=3.2.2",
     "pandas>=1.1.3",
-    "tensorflow>=2.5.0",
-    "dask>=0.19.0",
-    "DEAP>=1.3.1",
     "agix>=0.2.0",
     "holobit-sdk>=1.0.0; python_version >= '3.10'",
     "smooth-criminal>=0.1.0",
@@ -49,6 +46,11 @@ Documentation = "https://github.com/Alphonsus411/pCobra#readme"
 Source = "https://github.com/Alphonsus411/pCobra"
 
 [project.optional-dependencies]
+ml = [
+    "tensorflow>=2.5.0",
+    "DEAP>=1.3.1",
+]
+big-data = ["dask>=0.19.0"]
 mutation = ["mutpy>=0.6.1"]
 notebooks = [
     "papermill>=2.6.0",


### PR DESCRIPTION
## Summary
- mark TensorFlow, DEAP and Dask as optional extras
- document installation of optional ML and big-data extras

## Testing
- `pytest -q -c /dev/null` *(fails: ModuleNotFoundError: No module named 'hypothesis')*
- `ruff check pyproject.toml`


------
https://chatgpt.com/codex/tasks/task_e_689a2f76448c83278a2d4bc4d4dbef0a