### PR TITLE
chore: ampliar target-version de black a Python 3.9-3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ pcobra = "src.main:main"
 
 [tool.black]
 line-length = 88
-target-version = ["py311"]
+target-version = ["py39", "py310", "py311"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Summary
- ampliar la lista `target-version` de black para incluir Python 3.9 y 3.10

## Testing
- `black --check .` *(falla: 384 files would be reformatted)*
- `pytest -q --maxfail=1` *(falla: AttributeError: module 'importlib' has no attribute 'ModuleType')*

------
https://chatgpt.com/codex/tasks/task_e_689a322935048327864b601c7446387b