### PR TITLE
Fija versiones y build determinista para el CLI

### DIFF
--- a/cobra-cli.spec
+++ b/cobra-cli.spec
@@ -1,5 +1,13 @@
 # -*- mode: python ; coding: utf-8 -*-
+import os
+import shutil
 
+# Asegurar compilaciones deterministas
+os.environ["SOURCE_DATE_EPOCH"] = os.getenv("SOURCE_DATE_EPOCH", "0")
+# Limpiar directorios como si se pasara --clean
+for path in ("build", "dist"):
+    if os.path.isdir(path):
+        shutil.rmtree(path)
 
 a = Analysis(
     ['src\\cobra\\cli\\cli.py'],
@@ -25,7 +33,7 @@ exe = EXE(
     name='cobra-cli',
     debug=False,
     bootloader_ignore_signals=False,
-    strip=False,
+    strip=True,
     upx=True,
     upx_exclude=[],
     runtime_tmpdir=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,25 +20,25 @@ classifiers = [
 ]
 
 dependencies = [
-    "numpy>=1.19.3",
-    "scipy>=1.5.4",
-    "matplotlib>=3.2.2",
-    "pandas>=1.1.3",
-    "agix>=0.2.0",
-    "holobit-sdk>=1.0.0; python_version >= '3.10'",
-    "smooth-criminal>=0.1.0",
-    "tomli>=0.2.0",
-    "PyYAML>=5.3.1",
-    "jsonschema>=4.0.1",
-    "python-dotenv>=0.19.0",
-    "pexpect>=4.9.0",
-    "requests>=2.19.0",
-    "flet>=0.1.0",
-    "packaging>=17.0",
-    "pybind11>=2.6.0",
-    "RestrictedPython>=5.1",
-    "prompt_toolkit>=3.0.0",
-    "Pygments>=2.4.0",
+    "numpy==1.19.3",
+    "scipy==1.5.4",
+    "matplotlib==3.2.2",
+    "pandas==1.1.3",
+    "agix==0.2.0",
+    "holobit-sdk==1.0.0; python_version >= '3.10'",
+    "smooth-criminal==0.1.0",
+    "tomli==0.2.0",
+    "PyYAML==5.3.1",
+    "jsonschema==4.0.1",
+    "python-dotenv==0.19.0",
+    "pexpect==4.9.0",
+    "requests==2.19.0",
+    "flet==0.1.0",
+    "packaging==17.0",
+    "pybind11==2.6.0",
+    "RestrictedPython==5.1",
+    "prompt_toolkit==3.0.0",
+    "Pygments==2.4.0",
 ]
 
 [project.urls]
@@ -47,27 +47,27 @@ Source = "https://github.com/Alphonsus411/pCobra"
 
 [project.optional-dependencies]
 ml = [
-    "tensorflow>=2.5.0",
-    "DEAP>=1.3.1",
+    "tensorflow==2.5.0",
+    "DEAP==1.3.1",
 ]
-big-data = ["dask>=0.19.0"]
-mutation = ["mutpy>=0.6.1"]
+big-data = ["dask==0.19.0"]
+mutation = ["mutpy==0.6.1"]
 notebooks = [
-    "papermill>=2.6.0",
-    "nbconvert>=7.16.6",
-    "ipykernel>=6.29.5",
+    "papermill==2.6.0",
+    "nbconvert==7.16.6",
+    "ipykernel==6.29.5",
 ]
 dev = [
-    "python-dotenv",
-    "python-lsp-server",
-    "hypothesis",
-    "ipykernel>=6.29.5",
-    "tree-sitter-languages>=1.10.2",
-    "pytest",
-    "pytest-cov",
-    "pytest-timeout",
-    "ruff",
-    "mypy",
+    "python-dotenv==0.19.0",
+    "python-lsp-server==1.13.0",
+    "hypothesis==6.137.3",
+    "ipykernel==6.29.5",
+    "tree-sitter-languages==1.10.2",
+    "pytest==8.4.1",
+    "pytest-cov==6.2.1",
+    "pytest-timeout==2.4.0",
+    "ruff==0.12.8",
+    "mypy==1.17.1",
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,20 @@
-requests
-PyYAML>=6.0
-jsonschema>=4.24
-RestrictedPython>=8.0
-packaging
-pexpect
-python-dotenv
-psutil
-pybind11
-lark
-tree-sitter
-tree-sitter-languages
-flet
+requests==2.19.0
+PyYAML==6.0
+jsonschema==4.24
+RestrictedPython==8.0
+packaging==17.0
+pexpect==4.9.0
+python-dotenv==0.19.0
+psutil==7.0.0
+pybind11==2.6.0
+lark==1.2.2
+tree-sitter==0.25.1
+tree-sitter-languages==1.10.2
+flet==0.1.0
 holobit-sdk==1.0.8
 smooth-criminal==0.4.0
 
-argcomplete
+argcomplete==3.6.2
 
-prompt_toolkit
-Pygments
+prompt_toolkit==3.0.0
+Pygments==2.4.0

--- a/scripts/build_cli.sh
+++ b/scripts/build_cli.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+export SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-0}"
+
+pip install --no-cache-dir -r requirements.txt
+
+pyinstaller --onefile --clean --strip cobra-cli.spec
+
+HASH1=$(sha256sum dist/cobra-cli | awk '{print $1}')
+echo "Primer hash: $HASH1"
+
+rm -rf build dist
+pyinstaller --onefile --clean --strip cobra-cli.spec
+HASH2=$(sha256sum dist/cobra-cli | awk '{print $1}')
+echo "Segundo hash: $HASH2"
+
+if [ "$HASH1" != "$HASH2" ]; then
+    echo "Error: los hashes no coinciden"
+    exit 1
+fi
+
+echo "Hash verificado: $HASH1"


### PR DESCRIPTION
## Resumen
- Fijadas versiones exactas en `pyproject.toml` y `requirements.txt`.
- `cobra-cli.spec` ahora limpia directorios, fija `SOURCE_DATE_EPOCH` y activa `strip`.
- Nuevo script `scripts/build_cli.sh` que instala deps, compila y verifica hashes.

## Testing
- `pytest` *(falla: unrecognized arguments --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_689aacf0d8a08327a81c2b1db9097f55