### PR TITLE
chore: add workflow to build cli binaries

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,54 @@
+name: Build CLI Binaries
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*.*.*']
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install --no-cache-dir -r requirements.txt
+      - name: Build CLI
+        shell: bash
+        run: bash scripts/build_cli.sh
+      - name: Upload executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: cobra-cli-${{ matrix.os }}
+          path: dist/*
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Generate checksums
+        run: |
+          cd dist
+          for file in *; do
+            sha256sum "$file" > "$file.sha256"
+          done
+      - name: Release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*


### PR DESCRIPTION
## Summary
- add workflow to build CLI binaries on ubuntu, windows and macOS
- upload artifacts and release assets with checksums on tagged releases

## Testing
- `pytest -q` *(fails: No module named 'cobra')*
- `pip install -e .` *(fails: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_689abece9dc0832780f2197d1138377d