### PR TITLE
feat(cli): mostrar version y commit

### DIFF
--- a/scripts/build_cli.sh
+++ b/scripts/build_cli.sh
@@ -6,6 +6,13 @@ cd "$REPO_ROOT"
 
 export SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-0}"
 
+# Obtain version and current git commit to embed in the binary
+VERSION=$(grep -m1 '^version = ' pyproject.toml | cut -d'"' -f2)
+COMMIT=$(git rev-parse --short HEAD)
+export COBRA_CLI_VERSION="$VERSION"
+export COBRA_CLI_COMMIT="$COMMIT"
+echo "Construyendo Cobra CLI v$COBRA_CLI_VERSION (commit $COBRA_CLI_COMMIT)"
+
 pip install --no-cache-dir -r requirements.txt
 
 pyinstaller --onefile --clean --strip cobra-cli.spec

--- a/src/cobra/cli/cli.py
+++ b/src/cobra/cli/cli.py
@@ -46,6 +46,10 @@ from cobra.cli.i18n import _, format_traceback, setup_gettext
 from cobra.cli.plugin import descubrir_plugins
 from cobra.cli.utils import messages, config
 
+# Metadata injected at build time
+CLI_VERSION = environ.get("COBRA_CLI_VERSION", "dev")
+CLI_COMMIT = environ.get("COBRA_CLI_COMMIT", "unknown")
+
 
 class LogLevel(Enum):
     DEBUG = logging.DEBUG
@@ -148,6 +152,12 @@ class CliApplication:
         )
 
     def _configure_cli_options(self, parser: CustomArgumentParser) -> None:
+        parser.add_argument(
+            "--version",
+            action="version",
+            version=f"%(prog)s {CLI_VERSION} (commit {CLI_COMMIT})",
+            help=_("Show version information and exit"),
+        )
         parser.add_argument("--format", action="store_true",
                           help=_("Format file before processing"))
         parser.add_argument("--debug", action="store_true",


### PR DESCRIPTION
## Resumen
- Expone metadatos de versión y commit en `build_cli.sh`
- Agrega opción `--version` al CLI mostrando esos metadatos

## Pruebas
- `PYTHONPATH=src pytest -k cli -q` *(falla: AttributeError: module 'importlib' has no attribute 'ModuleType')*
- `./scripts/build_cli.sh` *(falla: PyYAML requires cython_sources)*

------
https://chatgpt.com/codex/tasks/task_e_689ac639b10c8327a0132669bbe9fb3f