### PR TITLE
ci: notificar a Slack tras la release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,3 +77,13 @@ jobs:
         with:
           files: |
             dist/**/cobra*
+      - name: Notify Slack
+        if: always()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_COLOR: ${{ job.status == 'success' && 'good' || 'danger' }}
+          SLACK_MESSAGE: |
+            Release ${{ github.ref_name }} ${{ job.status }}
+            https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+


### PR DESCRIPTION
## Summary
- add Slack notification after release

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_689b6aed14dc832790f4dde55ef6a838