### PR TITLE
ci: enviar correo tras publicación

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,4 +86,19 @@ jobs:
           SLACK_MESSAGE: |
             Release ${{ github.ref_name }} ${{ job.status }}
             https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+      - name: Send release email
+        if: always()
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server: ${{ secrets.SMTP_SERVER }}
+          port: ${{ secrets.SMTP_PORT }}
+          username: ${{ secrets.SMTP_USERNAME }}
+          password: ${{ secrets.SMTP_PASSWORD }}
+          subject: "Release ${{ github.ref_name }}"
+          to: "devs@example.com"
+          from: "Cobra CI <${{ secrets.SMTP_USERNAME }}>"
+          body: |
+            Se ha publicado la versión ${{ github.ref_name }}.
+            https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+        # Validar este flujo de correo en un entorno controlado antes de producción.
 


### PR DESCRIPTION
## Summary
- enviar correo de liberación mediante `dawidd6/action-send-mail@v3`
- referencias a credenciales SMTP vía secretos

## Testing
- `pytest` *(falló: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_689b7070c2748327ae8a99735e086490