### PR TITLE
docs: add release guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1250,6 +1250,8 @@ Al crear y subir una etiqueta `vX.Y.Z` se ejecuta el workflow [`release.yml`](.g
 
 El workflow [`Deploy Docs`](.github/workflows/pages.yml) generará la documentación cuando haya un push en `main` o al etiquetar una nueva versión.
 
+Consulta la [guía de lanzamiento](docs/release.md) para más detalles sobre el etiquetado, secretos y el flujo de la pipeline.
+
 ```bash
 git tag v10.0.6
 git push origin v10.0.6

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,38 @@
+# Guía de Lanzamiento
+
+## Etiquetar una versión
+
+1. Asegúrate de que `main` contenga los cambios que deseas publicar.
+2. Crea una etiqueta semántica y súbela al repositorio:
+
+```bash
+ git tag vX.Y.Z
+ git push origin vX.Y.Z
+```
+
+ También puedes subir todas las etiquetas existentes con:
+
+```bash
+ git push --tags
+```
+
+## Secretos requeridos
+
+Los workflows de publicación utilizan los siguientes secretos configurados en el repositorio:
+
+- `PYPI_USERNAME` y `PYPI_PASSWORD`: credenciales para subir el paquete a PyPI.
+- `DOCKERHUB_USERNAME` y `DOCKERHUB_TOKEN`: acceso para publicar la imagen en Docker Hub.
+- `SLACK_WEBHOOK_URL`: webhook para notificaciones en Slack.
+- Credenciales SMTP (`SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_HOST`, `SMTP_PORT`): envío de correos electrónicos.
+
+## Flujo de la pipeline
+
+Al crear una etiqueta `vX.Y.Z` se ejecuta el workflow [`release.yml`](../.github/workflows/release.yml) que:
+
+1. Construye y publica el paquete en PyPI.
+2. Genera los ejecutables y los adjunta a GitHub Releases.
+3. Construye y sube la imagen Docker.
+4. Publica la documentación.
+5. Envía notificaciones a Slack y correo electrónico si corresponde.
+
+Consulta el [archivo del workflow](../.github/workflows/release.yml) para más detalles.


### PR DESCRIPTION
## Summary
- add release guide covering version tagging, required secrets, and pipeline flow
- link README to release guide for quick reference

## Testing
- `make lint` (failed: missing separator in Makefile)
- `ruff check src` (865 errors)
- `mypy src` (816 errors)
- `bandit -r src` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_689b733f2ae88327b8a22b02822b21fc