### PR TITLE
docs: proponer azúcar sintáctica

### DIFF
--- a/docs/proposals/sintaxis_azucarada.md
+++ b/docs/proposals/sintaxis_azucarada.md
@@ -1,0 +1,42 @@
+# Propuesta de azúcar sintáctica para Cobra
+
+## Antecedentes
+
+La gramática actual utiliza delimitadores como `:` y `fin` para cerrar bloques y repite palabras clave completas en varias construcciones. Esto puede resultar verboso, especialmente en definiciones de funciones, estructuras de control y condicionales.
+
+## Azúcar sintáctica sugerida
+
+### Bloques con llaves
+En lugar de `func nombre(): ... fin`, permitir `func nombre() { ... }`.
+
+```cobra
+func saludar() {
+    imprimir("hola")
+}
+```
+
+### Funciones de expresión
+Permitir abreviatura de funciones que retornan una única expresión.
+
+```cobra
+func doble(x) => x * 2
+```
+
+### Condicionales encadenados
+Simplificar `si/si no` repetitivos con `sino si`.
+
+```cobra
+si x > 10 {
+    imprimir("alto")
+} sino si x > 5 {
+    imprimir("medio")
+} sino {
+    imprimir("bajo")
+}
+```
+
+## Implicaciones
+
+- **Parser**: la gramática debe aceptar llaves y la forma abreviada `=>` en las reglas de `funcion`, `bucle_para` y `condicional`. También se requerirán reglas para `sino si`.
+- **AST** (`src/core/ast_nodes.py`): se pueden reutilizar nodos existentes como `NodoFuncion` y `NodoCondicional`, pero será necesario detectar variantes abreviadas y posiblemente añadir banderas para distinguir cuerpos con llaves y funciones de expresión.
+

--- a/issues/13_sintaxis_azucarada.md
+++ b/issues/13_sintaxis_azucarada.md
@@ -1,0 +1,20 @@
+---
+name: Solicitud de mejora
+about: Simplificar sintaxis mediante azúcar
+title: "[Diseño] Azúcar sintáctica para bloques y funciones"
+labels: [design, low priority]
+assignees: ''
+---
+
+**Resumen**
+
+Explorar la introducción de azúcar sintáctica que reduzca la verbosidad del lenguaje.
+
+**Detalles**
+
+Las ideas iniciales y ejemplos se encuentran en `docs/proposals/sintaxis_azucarada.md`.
+
+**Contexto adicional**
+
+La implementación impactaría al parser y a `src/core/ast_nodes.py`.
+


### PR DESCRIPTION
## Resumen
- Documenta propuesta de azúcar sintáctica para simplificar bloques, funciones y condicionales
- Registra un issue asociado con etiquetas de diseño y baja prioridad

## Testing
- `pytest -q` *(falla: module 'importlib' has no attribute 'ModuleType'; faltan dependencias como 'jsonschema' y 'tree_sitter')*


------
https://chatgpt.com/codex/tasks/task_e_689b82578f9c8327a685a1dd8a02e605