### PR TITLE
docs: agregar ADR de nuevas features

### DIFF
--- a/docs/ADR/000-nuevas_features.md
+++ b/docs/ADR/000-nuevas_features.md
@@ -1,0 +1,12 @@
+# ADR 000: Nuevas features
+
+## Contexto
+El equipo ha realizado sesiones de _brainstorming_ documentadas en [propuestas de azúcar sintáctica](../proposals/sintaxis_azucarada.md), [nuevos tipos](../proposals/tipos_nuevos.md) y [librerías candidatas](../proposals/librerias_candidatas.md). Estas ideas exploran mejoras para el lenguaje y su ecosistema, como simplificar la gramática, ampliar el sistema de tipos y evaluar dependencias externas.
+
+## Decisión
+Se consolida la información de los documentos anteriores para formar la base de una hoja de ruta de nuevas features. Cada propuesta se implementará de manera incremental, priorizando la estabilidad y la coherencia del lenguaje.
+
+## Consecuencias
+- Se crearán tareas específicas para cada feature.
+- La documentación y las pruebas deberán actualizarse conforme se desarrollen las mejoras.
+- El alcance del proyecto aumenta, por lo que será necesario revisar dependencias y mantener la cohesión del diseño.


### PR DESCRIPTION
## Summary
- Añade `docs/ADR/000-nuevas_features.md` que consolida ideas de nuevas funcionalidades referenciando documentos de brainstorming.

## Testing
- `python check.py` *(falló: ruff, mypy, pytest, pyright)*

## Labels
- design
- low priority


------
https://chatgpt.com/codex/tasks/task_e_689b85a011a483278099c1d63489c2b1