### PR TITLE
Handle usar errors with logging and re-raise

### DIFF
--- a/src/core/interpreter.py
+++ b/src/core/interpreter.py
@@ -1,5 +1,6 @@
 """Implementación del intérprete del lenguaje Cobra."""
 
+import logging
 import os
 
 from cobra.core import Token, TipoToken, Lexer
@@ -627,7 +628,8 @@ class InterpretadorCobra:
             modulo = obtener_modulo(nodo.modulo)
             self.variables[nodo.modulo] = modulo
         except Exception as exc:
-            print(f"Error al usar el módulo '{nodo.modulo}': {exc}")
+            logging.exception(f"Error al usar el módulo '{nodo.modulo}': {exc}")
+            raise
 
     def ejecutar_holobit(self, nodo):
         """Simula la ejecución de un holobit y devuelve sus valores."""


### PR DESCRIPTION
## Summary
- log importar errores in `ejecutar_usar` and propagate exception
- add logging import

## Testing
- `PYTHONPATH=src pytest` *(fails: ModuleNotFoundError: No module named 'jsonschema', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689c09e1cab48327a592293894a8fb72