### PR TITLE
Mejora de manejo de excepciones en plegado de constantes

### DIFF
--- a/src/core/optimizations/constant_folder.py
+++ b/src/core/optimizations/constant_folder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, List
 
 from ..visitor import NodeVisitor
@@ -44,7 +45,8 @@ class _ConstantFolder(NodeVisitor):
                     nodo.izquierda.valor, nodo.operador, nodo.derecha.valor
                 )
                 return NodoValor(resultado)
-            except Exception:
+            except (TypeError, ZeroDivisionError, ValueError) as exc:
+                logging.debug("No se pudo plegar constante binaria: %s", exc)
                 return nodo
         return nodo
 
@@ -54,7 +56,8 @@ class _ConstantFolder(NodeVisitor):
             try:
                 resultado = self._evaluar_unaria(nodo.operador, nodo.operando.valor)
                 return NodoValor(resultado)
-            except Exception:
+            except (TypeError, ValueError) as exc:
+                logging.debug("No se pudo plegar constante unaria: %s", exc)
                 return nodo
         return nodo
 


### PR DESCRIPTION
## Resumen
- Registro de fallos en plegado de constantes para operaciones binarias y unarias
- Manejo explícito de `TypeError`, `ZeroDivisionError` y `ValueError`

## Pruebas
- `pytest` *(falla: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_689c1536f73c8327b676a3b4d4d06f37