### PR TITLE
chore: simplify rust backend Dockerfile

### DIFF
--- a/docker/backends/rust.Dockerfile
+++ b/docker/backends/rust.Dockerfile
@@ -7,15 +7,10 @@ ENV RUSTFLAGS="-C target-cpu=native"
 # Directorio de trabajo
 WORKDIR /work
 
-# Instalar herramientas necesarias para bindings y compilaciones nativas
+# Instalar herramientas mínimas para compilación con rustc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential \
-        clang \
-        python3-dev \
-        libffi-dev \
-        pkg-config \
-        cbindgen \
     && rm -rf /var/lib/apt/lists/*
 
 # Copiar script de compilación


### PR DESCRIPTION
## Summary
- remove unnecessary packages from rust backend Dockerfile, keeping only build-essential

## Testing
- `echo 'fn main() { println!("Hola desde Rust!"); }' | docker/scripts/compile_rust.sh`
- `docker build -f docker/backends/rust.Dockerfile -t rust-compiler docker` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689c84ffea2c8327a2e92187d411c2e5