### PR TITLE
refactor: streamline C++ backend Dockerfile

### DIFF
--- a/docker/backends/cpp.Dockerfile
+++ b/docker/backends/cpp.Dockerfile
@@ -6,11 +6,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Directorio de trabajo
 WORKDIR /work
 
-# Instalar herramientas útiles
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    make cmake gdb \
-    && rm -rf /var/lib/apt/lists/*
-
 # Copiar el script de compilación
 COPY compile_cpp.sh /usr/local/bin/compile_cpp.sh
 RUN chmod +x /usr/local/bin/compile_cpp.sh


### PR DESCRIPTION
## Summary
- simplify C++ backend image by removing unused build tools

## Testing
- `docker build -f docker/backends/cpp.Dockerfile -t pcobra-cpp docker/scripts` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `pytest` *(fails: No se pudo importar core: No module named 'cobra')*
- `printf '#include <iostream>\nint main(){std::cout<<"hola";}' | docker/scripts/compile_cpp.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c87c27c448327b6bdac584797fd35