### PR TITLE
feat: optimizar compilación C++ y Rust

### DIFF
--- a/docker/scripts/compile_cpp.sh
+++ b/docker/scripts/compile_cpp.sh
@@ -5,7 +5,10 @@ echo "🛠️  Recibiendo código C++ desde stdin..."
 cat > main.cpp
 
 echo "🔧 Compilando con g++..."
-g++ -std=c++17 -O2 -Wall -o main main.cpp
+# -O3  : maximiza las optimizaciones
+# -flto: realiza optimización en tiempo de enlace
+# -s   : elimina símbolos para reducir el tamaño del binario
+g++ -std=c++17 -O3 -flto -s -Wall -o main main.cpp
 
 echo "🚀 Ejecutando programa compilado..."
 ./main

--- a/docker/scripts/compile_rust.sh
+++ b/docker/scripts/compile_rust.sh
@@ -5,7 +5,10 @@ echo "🦀 Recibiendo código Rust desde stdin..."
 cat > main.rs
 
 echo "🔧 Compilando con rustc..."
-rustc main.rs -O -o main
+# -C opt-level=3   : maximiza las optimizaciones
+# -C lto           : habilita Link Time Optimization
+# -C strip=symbols : remueve símbolos para reducir el tamaño final
+rustc -C opt-level=3 -C lto -C strip=symbols main.rs -o main
 
 echo "🚀 Ejecutando..."
 ./main


### PR DESCRIPTION
## Summary
- añade optimizaciones O3, LTO y strip en compile_cpp.sh
- usa rustc con opt-level=3, LTO y eliminación de símbolos

## Testing
- `g++ -std=c++17 -O0 -o /tmp/baseline_cpp /tmp/test.cpp`: 16496 bytes
- `g++ -std=c++17 -O3 -flto -s -Wall -o /tmp/optimized_cpp /tmp/test.cpp`: 14472 bytes
- `rustc /tmp/test.rs -o /tmp/baseline_rust`: 3690096 bytes
- `rustc -C opt-level=3 -C lto -C strip=symbols /tmp/test.rs -o /tmp/optimized_rust`: 328352 bytes
- `cat /tmp/test.cpp | sh docker/scripts/compile_cpp.sh`
- `cat /tmp/test.rs | sh docker/scripts/compile_rust.sh`
- `python check.py` (falló: ruff, mypy, bandit, pytest)


------
https://chatgpt.com/codex/tasks/task_e_689c8ed008ec83279dfa67130ab50db1