### PR TITLE
Add basic LLVM backend

### DIFF
--- a/src/cobra/cli/commands/compile_cmd.py
+++ b/src/cobra/cli/commands/compile_cmd.py
@@ -18,6 +18,7 @@ from cobra.transpilers.transpiler.to_kotlin import TranspiladorKotlin
 from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 from cobra.transpilers.transpiler.to_julia import TranspiladorJulia
 from cobra.transpilers.transpiler.to_latex import TranspiladorLatex
+from cobra.transpilers.transpiler.to_llvm import TranspiladorLLVM
 from cobra.transpilers.transpiler.to_matlab import TranspiladorMatlab
 from cobra.transpilers.transpiler.to_mojo import TranspiladorMojo
 from cobra.transpilers.transpiler.to_pascal import TranspiladorPascal
@@ -72,6 +73,7 @@ TRANSPILERS = {
     "matlab": TranspiladorMatlab,
     "mojo": TranspiladorMojo,
     "latex": TranspiladorLatex,
+    "llvm": TranspiladorLLVM,
     "wasm": TranspiladorWasm,
 }
 
@@ -96,7 +98,10 @@ LANG_CHOICES = sorted(TRANSPILERS.keys())
 
 def validate_file(filepath: str) -> bool:
     """Valida que el archivo sea accesible y cumpla con los límites establecidos."""
-    path = validar_archivo_existente(filepath)
+    try:
+        path = validar_archivo_existente(filepath)
+    except FileNotFoundError:
+        raise ValueError(f"'{filepath}' no es un archivo válido")
     if not os.access(path, os.R_OK):
         raise ValueError(f"No hay permisos de lectura para '{filepath}'")
     if os.path.getsize(path) > MAX_FILE_SIZE:

--- a/src/cobra/transpilers/transpiler/to_llvm.py
+++ b/src/cobra/transpilers/transpiler/to_llvm.py
@@ -1,0 +1,27 @@
+"""Transpilador que genera LLVM IR a partir del AST de Cobra."""
+
+from __future__ import annotations
+
+from typing import List
+
+from compiler.llvm_backend import generar_ir_funcion
+
+from core import ast_nodes
+
+
+class TranspiladorLLVM:
+    """Transpilador muy básico para LLVM.
+
+    Solo maneja funciones sin parámetros cuyo cuerpo es una única expresión
+    soportada por :mod:`compiler.llvm_backend`.
+    """
+
+    def generate_code(self, ast: List[ast_nodes.NodoAST]) -> str:
+        ir_funcs: List[str] = []
+        for nodo in ast:
+            if isinstance(nodo, ast_nodes.NodoFuncion) and not nodo.parametros:
+                if nodo.cuerpo:
+                    expr = getattr(nodo.cuerpo[0], "expresion", None)
+                    if expr is not None:
+                        ir_funcs.append(generar_ir_funcion(nodo.nombre, expr))
+        return "\n\n".join(ir_funcs)

--- a/src/compiler/__init__.py
+++ b/src/compiler/__init__.py
@@ -1,0 +1,2 @@
+"""Módulo de compiladores para pCobra."""
+

--- a/src/compiler/llvm_backend.py
+++ b/src/compiler/llvm_backend.py
@@ -1,0 +1,64 @@
+"""Generación sencilla de IR para LLVM."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple, Union
+
+Expr = Union[int, Tuple[str, "Expr", "Expr"]]
+
+
+@dataclass
+class LLVMBackend:
+    """Backend minimalista que genera fragmentos de LLVM IR.
+
+    Solo se soportan expresiones con enteros y sumas binarias.
+    """
+
+    counter: int = 0
+    instrucciones: List[str] = field(default_factory=list)
+
+    def _temp(self) -> str:
+        """Devuelve el nombre de un registro temporal nuevo."""
+        self.counter += 1
+        return f"%t{self.counter}"
+
+    def emitir(self, linea: str) -> None:
+        self.instrucciones.append(linea)
+
+    def generar_expresion(self, expr: Expr) -> str:
+        """Genera IR para ``expr`` y devuelve el registro con el resultado."""
+        if isinstance(expr, int):
+            temp = self._temp()
+            self.emitir(f"{temp} = add i32 0, {expr}")
+            return temp
+        if isinstance(expr, tuple) and len(expr) == 3 and expr[0] == "add":
+            izquierda = self.generar_expresion(expr[1])
+            derecha = self.generar_expresion(expr[2])
+            temp = self._temp()
+            self.emitir(f"{temp} = add i32 {izquierda}, {derecha}")
+            return temp
+        raise NotImplementedError("Expresión no soportada")
+
+    def generar_funcion(self, nombre: str, expr: Expr) -> str:
+        """Crea una función que evalúa ``expr`` y retorna el resultado."""
+        self.instrucciones.clear()
+        resultado = self.generar_expresion(expr)
+        cuerpo = "\n  ".join(self.instrucciones)
+        return (
+            f"define i32 @{nombre}() {{\n  {cuerpo}\n  ret i32 {resultado}\n}}"
+        )
+
+
+def generar_ir_expresion(expr: Expr) -> str:
+    """Devuelve el código LLVM IR para una expresión simple."""
+    backend = LLVMBackend()
+    backend.generar_expresion(expr)
+    return "\n".join(backend.instrucciones)
+
+
+def generar_ir_funcion(nombre: str, expr: Expr) -> str:
+    """Devuelve el IR de una función sin parámetros que retorna ``expr``."""
+    backend = LLVMBackend()
+    return backend.generar_funcion(nombre, expr)
+


### PR DESCRIPTION
## Summary
- add minimal LLVM IR generator and backend module
- integrate LLVM backend into compile command
- expose LLVM transpiler for simple functions

## Testing
- `PYTHONPATH=src pytest src/tests/unit/test_compile_cmd_errors.py -q -c /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_689cc04f9afc8327b20ebdf174f0293d