### PR TITLE
Añadir ejemplos LLVM y verificación en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc g++ golang-go ruby-full rustc default-jdk
+          sudo apt-get install -y gcc g++ golang-go ruby-full rustc default-jdk clang llvm
       - name: Install dependencies
         uses: ./.github/actions/install
         with:
@@ -47,6 +47,9 @@ jobs:
             pytest src/tests --cov=src --cov-report=xml \
               --cov-report=term-missing --cov-fail-under=95
           fi
+      - name: Run LLVM examples
+        run: |
+          PYTHONPATH=src python scripts/test_llvm_examples.py
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/examples/llvm/README.md
+++ b/examples/llvm/README.md
@@ -1,0 +1,7 @@
+# Ejemplos LLVM
+
+Programas de muestra para probar la generación de LLVM IR.
+
+Cada archivo `.cobra` define una función `main` con una expresión aritmética simple.
+Estos ejemplos se usan en el CI para verificar que la salida del intérprete y la
+ejecución del binario generado por LLVM coinciden.

--- a/examples/llvm/suma.cobra
+++ b/examples/llvm/suma.cobra
@@ -1,0 +1,3 @@
+func main():
+    retorno 2 + 2
+fin

--- a/scripts/test_llvm_examples.py
+++ b/scripts/test_llvm_examples.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Compila y ejecuta los ejemplos LLVM comparando resultados."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from cobra.core import Lexer, Parser, TipoToken
+from core.ast_nodes import NodoFuncion, NodoValor, NodoOperacionBinaria
+from core.interpreter import InterpretadorCobra
+from compiler.llvm_backend import generar_ir_funcion
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES_DIR = ROOT / "examples" / "llvm"
+
+
+def run_example(path: Path) -> None:
+    code = path.read_text(encoding="utf-8")
+    tokens = Lexer(code).analizar_token()
+    ast = Parser(tokens).parsear()
+
+    interp = InterpretadorCobra()
+    result = None
+    for node in ast:
+        if isinstance(node, NodoFuncion) and node.nombre == "main" and node.cuerpo:
+            instruccion = node.cuerpo[0]
+            expr = getattr(instruccion, "expresion", instruccion)
+            result = interp.evaluar_expresion(expr)
+            break
+    if result is None:
+        raise RuntimeError(f"No se encontró función main en {path}")
+
+    # Convertir el AST a la representación simple que usa el backend LLVM
+    def to_expr(node):
+        if isinstance(node, NodoValor):
+            return int(node.valor)
+        if (
+            isinstance(node, NodoOperacionBinaria)
+            and node.operador.tipo == TipoToken.SUMA
+        ):
+            return ("add", to_expr(node.izquierda), to_expr(node.derecha))
+        raise NotImplementedError("Expresión no soportada para LLVM")
+
+    llvm_ir = generar_ir_funcion("main", to_expr(expr))
+    ll_path = path.with_suffix(".ll")
+    ll_path.write_text(llvm_ir, encoding="utf-8")
+
+    bin_path = path.with_suffix("")
+    subprocess.run(["clang", ll_path, "-o", bin_path], check=True)
+    proc = subprocess.run([bin_path], capture_output=True, text=True)
+    ret = proc.returncode
+
+    if ret != result:
+        raise RuntimeError(f"Resultado distinto en {path.name}: interp={result}, bin={ret}")
+    print(f"{path.name}: OK ({result})")
+
+
+def main() -> None:
+    for cobra_file in sorted(EXAMPLES_DIR.glob("*.cobra")):
+        run_example(cobra_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Resumen
- Agrega carpeta `examples/llvm` con un ejemplo simple de suma.
- Incluye script que compila y compara resultados entre intérprete y binario LLVM.
- Actualiza CI para instalar clang/llvm y ejecutar el nuevo script.

## Pruebas
- `PYTHONPATH=src python scripts/test_llvm_examples.py`
- `PYTHONPATH=src pytest` *(falla: ModuleNotFoundError: No module named 'cli.cli'...)*


------
https://chatgpt.com/codex/tasks/task_e_689ccffc0f448327998309e478bea5c4