### PR TITLE
ci: valida entradas de changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         run: make lint
       - name: Run type checks
         run: make typecheck  # Ejecuta mypy con la configuración del proyecto y pyright
+      - name: Validate changelog
+        run: python scripts/check_changelog.py
       - name: Run tests
         run: |
           if [ -d tests ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Validate changelog
+        run: python scripts/check_changelog.py
       - name: Build package and upload to PyPI
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,19 @@ safety check --full-report
 
 ¡Agradecemos todas las contribuciones!
 
+## Actualizar CHANGELOG
+
+Cada release debe incluir una entrada en `CHANGELOG.md` con el formato:
+
+```
+## vX.Y.Z - YYYY-MM-DD
+- Descripción breve de los cambios.
+```
+
+Asegúrate de reemplazar cualquier marcador provisional como `Cambios pendientes.`
+por una lista clara de mejoras o correcciones. Ejecuta `python scripts/check_changelog.py`
+para validar que la última versión esté documentada antes de fusionar la rama.
+
 ## Mensajes de Commit
 
 Seguimos la convención [Conventional Commits](https://www.conventionalcommits.org/es/v1.0.0/), que define un formato estructurado para los mensajes. Cada commit debe comenzar con un **tipo**, un alcance opcional y una breve descripción en presente.

--- a/scripts/check_changelog.py
+++ b/scripts/check_changelog.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Verifica que CHANGELOG.md contenga la entrada de version actual."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
+
+CHANGELOG = Path("CHANGELOG.md")
+PYPROJECT = Path("pyproject.toml")
+
+
+def current_version() -> str:
+    """Obtiene la version numerica definida en pyproject.toml."""
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    raw_version: str = data.get("project", {}).get("version", "")
+    match = re.match(r"\d+\.\d+\.\d+", raw_version)
+    if not match:
+        raise ValueError("version invalida en pyproject.toml")
+    return match.group(0)
+
+
+def main() -> None:
+    version = current_version()
+    pattern = re.compile(
+        rf"^## v{re.escape(version)} - (\d{{4}}-\d{{2}}-\d{{2}})\n((?:- .+\n)+)",
+        re.MULTILINE,
+    )
+    text = CHANGELOG.read_text(encoding="utf-8")
+    match = pattern.search(text)
+    if not match:
+        sys.exit(f"Entrada para v{version} no encontrada o con formato invalido")
+    entries = [line.strip() for line in match.group(2).strip().splitlines()]
+    if "Cambios pendientes." in entries:
+        sys.exit("La entrada del changelog contiene un marcador pendiente")
+    print(f"Changelog verificado para v{version}: {match.group(1)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Summary
- documenta como agregar nuevas entradas en `CHANGELOG.md`
- agrega script que valida la entrada de la versión actual
- ejecuta la validación en CI y al publicar releases

### Testing
- `python scripts/check_changelog.py`
- `make lint` *(falla: Makefile:17: missing separator)*
- `pytest` *(falla: unrecognized arguments --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_689d68d96ec88327b84168edf6964fe1