### PR TITLE
docs: añadir blog de minilenguaje

### DIFF
--- a/docs/blog_minilenguaje.md
+++ b/docs/blog_minilenguaje.md
@@ -1,0 +1,17 @@
+# Minilenguaje
+
+## Introducción
+En esta entrada se presenta un vistazo rápido al minilenguaje de Cobra.
+
+## Ejemplo rápido
+```cobra
+imprimir("Hola mundo")
+```
+Para transpilar este código a Python ejecuta:
+```bash
+cobra archivo.co --to python
+```
+
+## Referencias
+- [Guía básica](guia_basica.md)
+- [Repositorio oficial](https://github.com/Alphonsus411/pCobra)


### PR DESCRIPTION
## Resumen
- Documentación del minilenguaje con ejemplo rápido y enlaces de referencia

## Testing
- `pytest` *(errores: ModuleNotFoundError: No module named 'cli.cli'; AttributeError: module 'importlib' has no attribute 'ModuleType')*

------
https://chatgpt.com/codex/tasks/task_e_689de083944883278a04d72193fddc52