### PR TITLE
docs: añade ejemplo hola_mundo

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,10 @@ Este directorio reúne distintos ejemplos de uso de Cobra y material relacionado
   ```bash
   cobra ejecutar examples/hello_world/cobra/hola.co
   ```
+- **[hola_mundo](hola_mundo/)**: ejemplo mínimo para transpilar a Python.
+  ```bash
+  cobra examples/hola_mundo/hola.co --to python
+  ```
 - **plugins/**: plugins de muestra instalables en modo editable. Para probarlos:
   ```bash
   cd examples/plugins

--- a/examples/hola_mundo/README.md
+++ b/examples/hola_mundo/README.md
@@ -1,0 +1,7 @@
+# Hola Mundo
+
+Transpila este ejemplo a Python con:
+
+```bash
+cobra hola.co --to python
+```

--- a/examples/hola_mundo/hola.co
+++ b/examples/hola_mundo/hola.co
@@ -1,0 +1,1 @@
+imprimir("Hola mundo")


### PR DESCRIPTION
## Summary
- add simple hola_mundo example that transpiles to Python
- link hola_mundo example from examples/README

## Testing
- `PYTHONPATH=src pytest` *(fails: module 'importlib' has no attribute 'ModuleType'; No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_689decec5d5c8327ae334834d0eb431c