### PR TITLE
feat: publicar entradas en blog mediante script y make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ GRAMMAR_COV?=30
 help:
 	@echo "Comandos disponibles:"
 	@echo "  make install         Instala el entorno en modo desarrollo"
-        @echo "  make run             Ejecuta Cobra usando dotenv"
-        @echo "  make test            Ejecuta tests con pytest y coverage"
-        @echo "  make coverage        Ejecuta coverage y genera reporte HTML"
-        @echo "  make lint            Ejecuta linters: ruff, mypy, bandit"
+	@echo "  make run             Ejecuta Cobra usando dotenv"
+	@echo "  make test            Ejecuta tests con pytest y coverage"
+	@echo "  make coverage        Ejecuta coverage y genera reporte HTML"
+	@echo "  make lint            Ejecuta linters: ruff, mypy, bandit"
 	@echo "  make format          Formatea con black + isort"
 	@echo "  make typecheck       Verifica tipos con mypy + pyright"
 	@echo "  make docker          Construye todos los contenedores"
@@ -25,6 +25,7 @@ help:
 	@echo "  make clean           Limpia archivos temporales"
 	@echo "  make secrets         Busca secretos con gitleaks"
 	@echo "  make check           Linter + Tests + Typecheck (pre-commit/release)"
+	@echo "  make publicar-blog FILE=archivo.md  Publica una entrada en el blog"
 
 install:
 	$(PYTHON) -m venv $(VENV)
@@ -36,12 +37,12 @@ run:
 	$(PYTHON) -m dotenv -f .env run -- $(PYTHON) -m src.main
 
 test:
-        $(PYTHON) scripts/grammar_coverage.py --threshold=$(GRAMMAR_COV)
-        pytest --cov=$(SRC) $(TESTS) --cov-report=term-missing --cov-fail-under=90
+	$(PYTHON) scripts/grammar_coverage.py --threshold=$(GRAMMAR_COV)
+	pytest --cov=$(SRC) $(TESTS) --cov-report=term-missing --cov-fail-under=90
 
 coverage:
-        coverage run -m pytest
-        coverage html
+	coverage run -m pytest
+	coverage html
 
 lint:
 	ruff check $(SRC)
@@ -72,10 +73,12 @@ docker:
 docs:
 	$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
+publicar-blog:
+	bash scripts/publicar_blog.sh $(FILE)
 clean:
 	find . -type d -name "__pycache__" -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
 	rm -rf .pytest_cache .mypy_cache .coverage htmlcov \
 	       $(BUILDDIR) .venv dist build bench_results.json
 
-.PHONY: help install run test coverage lint format typecheck secrets docker docs clean check
+.PHONY: help install run test coverage lint format typecheck secrets docker docs publicar-blog clean check

--- a/docs/comunidad.md
+++ b/docs/comunidad.md
@@ -22,3 +22,23 @@ Este proyecto cuenta con un servidor en Discord donde los usuarios pueden comuni
 ## Difusión
 En esta sección se listarán los enlaces a hilos de Reddit, Dev.to y GitHub Discussions relacionados con el proyecto.
 
+## Publicar entradas en el blog
+
+El proyecto incluye un script para subir contenido Markdown al blog oficial.
+
+### Variables de entorno
+- `BLOG_API_URL`: URL del endpoint al que se enviará el contenido.
+- `BLOG_API_TOKEN`: token de autenticación para el servicio.
+
+### Ejecución
+Define las variables anteriores y ejecuta:
+
+```bash
+scripts/publicar_blog.sh ruta/al/archivo.md
+```
+
+También puede ejecutarse mediante Make:
+
+```bash
+make publicar-blog FILE=ruta/al/archivo.md
+```

--- a/scripts/publicar_blog.sh
+++ b/scripts/publicar_blog.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILE=${1:-}
+
+if [[ -z "$FILE" ]]; then
+    echo "Uso: $0 <ruta_markdown>" >&2
+    exit 1
+fi
+
+if [[ ! -f "$FILE" ]]; then
+    echo "No se encontró el archivo: $FILE" >&2
+    exit 1
+fi
+
+BLOG_API_URL=${BLOG_API_URL:-}
+BLOG_API_TOKEN=${BLOG_API_TOKEN:-}
+
+if [[ -z "$BLOG_API_URL" || -z "$BLOG_API_TOKEN" ]]; then
+    echo "Debes definir las variables de entorno BLOG_API_URL y BLOG_API_TOKEN" >&2
+    exit 1
+fi
+
+curl -H "Authorization: Bearer $BLOG_API_TOKEN" \
+     -H "Content-Type: text/markdown" \
+     --data-binary "@$FILE" \
+     "$BLOG_API_URL"


### PR DESCRIPTION
## Resumen
- agregar script `publicar_blog.sh` para subir archivos Markdown al blog usando `curl`
- documentar uso del script y variables de entorno en `docs/comunidad.md`
- añadir objetivo `publicar-blog` al `Makefile` para facilitar su ejecución

## Testing
- `make lint` *(falla: Found 863 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689def749b40832796aea029f83bda14