### PR TITLE
Define SecurityError as Exception

### DIFF
--- a/src/core/sandbox.py
+++ b/src/core/sandbox.py
@@ -149,5 +149,5 @@ def validar_dependencias(backend: str, mod_info: dict) -> None:
             raise FileNotFoundError(f"Dependencia no encontrada: {ruta}")
 
 
-class SecurityError:
+class SecurityError(Exception):
     pass


### PR DESCRIPTION
## Summary
- make SecurityError subclass Exception

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_689e1365522c83278362af6915361613