### PR TITLE
refactor: validar rutas de dependencias con realpath

### DIFF
--- a/src/core/sandbox.py
+++ b/src/core/sandbox.py
@@ -137,13 +137,13 @@ def validar_dependencias(backend: str, mod_info: dict) -> None:
     """Verifica que las rutas de *mod_info* para *backend* existan y sean seguras."""
     if not mod_info:
         return
-    base = os.getcwd()
+    base = os.path.realpath(os.getcwd())
     for mod, data in mod_info.items():
         ruta = data.get(backend)
         if not ruta:
             continue
-        abs_path = os.path.abspath(ruta)
-        if not abs_path.startswith(base):
+        abs_path = os.path.realpath(ruta)
+        if os.path.commonpath([base, abs_path]) != base:
             raise ValueError(f"Ruta no permitida: {ruta}")
         if not os.path.exists(abs_path):
             raise FileNotFoundError(f"Dependencia no encontrada: {ruta}")


### PR DESCRIPTION
## Summary
- valida rutas de dependencias resolviendo enlaces simbólicos
- verifica la pertenencia al directorio base con `os.path.commonpath`

## Testing
- `pytest` *(errores: module 'importlib' has no attribute 'ModuleType'; ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_689e159d92c48327a4635b0e89fba625