### PR TITLE
refactor: evitar uso de _SubParsersAction

### DIFF
--- a/examples/plugins/saludo_plugin.py
+++ b/examples/plugins/saludo_plugin.py
@@ -1,4 +1,4 @@
-from argparse import _SubParsersAction
+from argparse import ArgumentParser
 from typing import Any
 from cobra.cli.plugin import PluginCommand
 
@@ -9,7 +9,7 @@ class SaludoCommand(PluginCommand):
     author = "Equipo Cobra"
     description = "Comando de saludo de ejemplo"
     
-    def register_subparser(self, subparsers: _SubParsersAction) -> None:
+    def register_subparser(self, subparsers: Any) -> None:
         parser = subparsers.add_parser(self.name, help="Muestra un saludo")
         parser.set_defaults(cmd=self)
         

--- a/src/cobra/cli/cli.py
+++ b/src/cobra/cli/cli.py
@@ -6,7 +6,7 @@ from os import environ
 from pathlib import Path
 from typing import List, Dict, Optional, Type, Any, ContextManager
 from contextlib import contextmanager
-from argparse import _SubParsersAction
+import argparse
 
 from cobra.cli.utils.argument_parser import CustomArgumentParser
 
@@ -94,7 +94,7 @@ class CommandRegistry:
             logging.error(f"Error creating command {command_class.__name__}: {e}")
             raise
 
-    def register_base_commands(self, subparsers: _SubParsersAction) -> Dict[str, BaseCommand]:
+    def register_base_commands(self, subparsers: Any) -> Dict[str, BaseCommand]:
         base_commands = []
         for cmd_class in AppConfig.BASE_COMMAND_CLASSES:
             try:
@@ -192,8 +192,9 @@ class CliApplication:
         dir_args = {"directorio", "carpeta"}
 
         for action in parser._actions:
-            if isinstance(action, argparse._SubParsersAction):
-                for sub in action.choices.values():
+            choices = getattr(action, "choices", None)
+            if choices:
+                for sub in choices.values():
                     self._configure_autocomplete(sub)
             elif action.dest in file_args:
                 action.completer = FilesCompleter()

--- a/src/cobra/cli/commands/agix_cmd.py
+++ b/src/cobra/cli/commands/agix_cmd.py
@@ -1,8 +1,9 @@
-from argparse import _SubParsersAction
+from argparse import ArgumentParser
 from pathlib import Path
 from typing import Any, Optional, NoReturn
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 from cobra.cli.utils.validators import validar_archivo_existente
 from ia.analizador_agix import generar_sugerencias
@@ -11,7 +12,7 @@ class AgixCommand(BaseCommand):
     """Genera sugerencias para código Cobra usando agix."""
     name = "agix"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> Any:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
 
         Args:

--- a/src/cobra/cli/commands/base.py
+++ b/src/cobra/cli/commands/base.py
@@ -1,4 +1,4 @@
-from argparse import _SubParsersAction  # TODO: evitar uso de _SubParsersAction
+from argparse import ArgumentParser
 from typing import Any
 
 from cobra.cli.utils.argument_parser import CustomArgumentParser
@@ -18,7 +18,7 @@ class BaseCommand:
         if not self.name:
             raise ValueError("El nombre del comando no puede estar vacío")
     
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando en el parser.
         
         Args:

--- a/src/cobra/cli/commands/bench_cmd.py
+++ b/src/cobra/cli/commands/bench_cmd.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from argparse import _SubParsersAction
+from argparse import ArgumentParser
 from pathlib import Path
 
 from cobra.cli.commands.base import BaseCommand
@@ -119,7 +119,7 @@ class BenchCommand(BaseCommand):
 
     name = "bench"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
 
         Args:

--- a/src/cobra/cli/commands/bench_transpilers_cmd.py
+++ b/src/cobra/cli/commands/bench_transpilers_cmd.py
@@ -1,7 +1,7 @@
 import cProfile
 import contextlib
 import json
-from argparse import _SubParsersAction
+from argparse import ArgumentParser
 from pathlib import Path
 from timeit import timeit
 from typing import Any, Dict, List
@@ -41,7 +41,7 @@ class BenchTranspilersCommand(BaseCommand):
 
     name = "benchtranspilers"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:

--- a/src/cobra/cli/commands/benchmarks2_cmd.py
+++ b/src/cobra/cli/commands/benchmarks2_cmd.py
@@ -7,7 +7,7 @@ import time
 import psutil
 import json
 from typing import Dict, Any, Optional
-from argparse import _SubParsersAction
+from argparse import ArgumentParser
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
@@ -36,7 +36,7 @@ class Benchmarks2Command(BaseCommand):
         self._formato: Optional[str] = None
         self._proceso = psutil.Process()
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:

--- a/src/cobra/cli/commands/benchmarks_cmd.py
+++ b/src/cobra/cli/commands/benchmarks_cmd.py
@@ -1,4 +1,4 @@
-from argparse import _SubParsersAction
+from argparse import ArgumentParser
 from typing import Any
 
 from cobra.cli.commands.base import BaseCommand
@@ -11,7 +11,7 @@ class BenchmarksCommand(BaseCommand):
     
     name = "benchmarks"
     
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:

--- a/src/cobra/cli/commands/cache_cmd.py
+++ b/src/cobra/cli/commands/cache_cmd.py
@@ -1,5 +1,5 @@
 from typing import Any
-from argparse import _SubParsersAction  # TODO: Usar API pública
+from argparse import ArgumentParser
 from core.ast_cache import limpiar_cache
 
 from cobra.cli.commands.base import BaseCommand
@@ -19,7 +19,7 @@ class CacheCommand(BaseCommand):
     
     name: str = "cache"
     
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:

--- a/src/cobra/cli/commands/container_cmd.py
+++ b/src/cobra/cli/commands/container_cmd.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 from pathlib import Path
 from typing import Any
-from argparse import _SubParsersAction
+from argparse import ArgumentParser
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
@@ -20,7 +20,7 @@ class ContainerCommand(BaseCommand):
     """Construye la imagen Docker del proyecto."""
     name = "contenedor"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando."""
         parser = subparsers.add_parser(self.name, help=_("Construye la imagen Docker"))
         parser.add_argument(

--- a/src/cobra/cli/commands/crear_cmd.py
+++ b/src/cobra/cli/commands/crear_cmd.py
@@ -1,4 +1,4 @@
-from argparse import _SubParsersAction  # TODO: Reemplazar _SubParsersAction
+from argparse import ArgumentParser
 from pathlib import Path
 from typing import Any
 
@@ -13,7 +13,7 @@ class CrearCommand(BaseCommand):
     
     name = "crear"
     
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:

--- a/src/cobra/cli/commands/dependencias_cmd.py
+++ b/src/cobra/cli/commands/dependencias_cmd.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 import tempfile
 import venv
-from argparse import _SubParsersAction
+from argparse import ArgumentParser
 from pathlib import Path
 from typing import List, Optional, Any
 
@@ -34,7 +34,7 @@ class DependenciasCommand(BaseCommand):
 
     name = "dependencias"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:

--- a/src/cobra/cli/commands/docs_cmd.py
+++ b/src/cobra/cli/commands/docs_cmd.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import subprocess
 from typing import Any, Optional
-from argparse import _SubParsersAction
+from argparse import ArgumentParser
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
@@ -12,7 +12,7 @@ class DocsCommand(BaseCommand):
     """Genera la documentación HTML del proyecto."""
     name = "docs"
     
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando."""
         parser = subparsers.add_parser(
             self.name, help=_("Genera la documentación del proyecto")

--- a/src/cobra/cli/commands/flet_cmd.py
+++ b/src/cobra/cli/commands/flet_cmd.py
@@ -1,4 +1,5 @@
-from argparse import _SubParsersAction  # TODO: Reemplazar _SubParsersAction
+from argparse import ArgumentParser
+from typing import Any
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
@@ -13,7 +14,7 @@ class FletCommand(BaseCommand):
         """Inicializa el comando."""
         super().__init__()
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:

--- a/src/cobra/cli/commands/init_cmd.py
+++ b/src/cobra/cli/commands/init_cmd.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from argparse import _SubParsersAction  # TODO: Reemplazar _SubParsersAction
+from argparse import ArgumentParser
 from typing import Any
 
 from cobra.cli.commands.base import BaseCommand
@@ -13,7 +13,7 @@ class InitCommand(BaseCommand):
     
     name = "init"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:

--- a/src/cobra/cli/commands/interactive_cmd.py
+++ b/src/cobra/cli/commands/interactive_cmd.py
@@ -4,7 +4,7 @@ import re
 import resource
 import traceback
 from typing import Optional, Any, NoReturn
-from argparse import _SubParsersAction
+from argparse import ArgumentParser
 from types import TracebackType
 
 from prompt_toolkit import PromptSession
@@ -57,7 +57,7 @@ class InteractiveCommand(BaseCommand):
             format='%(asctime)s - %(levelname)s - %(message)s'
         )
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
 
         Args:

--- a/src/cobra/cli/commands/jupyter_cmd.py
+++ b/src/cobra/cli/commands/jupyter_cmd.py
@@ -1,6 +1,6 @@
 import subprocess
 import sys
-from argparse import _SubParsersAction  # TODO: Evitar uso de _SubParsersAction
+from argparse import ArgumentParser
 from pathlib import Path
 from typing import Any
 
@@ -15,7 +15,7 @@ class JupyterCommand(BaseCommand):
     """Lanza Jupyter Notebook con el kernel Cobra instalado."""
     name = "jupyter"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
 
         Args:

--- a/src/cobra/cli/commands/modules_cmd.py
+++ b/src/cobra/cli/commands/modules_cmd.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import logging
 from typing import Any, Dict, Optional
-from argparse import _SubParsersAction
+from argparse import ArgumentParser
 from pathlib import Path
 from filelock import FileLock
 import yaml
@@ -12,6 +12,7 @@ from cobra.transpilers.module_map import MODULE_MAP_PATH
 from cobra.cli.cobrahub_client import descargar_modulo, publicar_modulo
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
+from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
 from cobra.cli.utils.semver import es_nueva_version, es_version_valida
 
@@ -32,7 +33,7 @@ class ModulesCommand(BaseCommand):
 
     name = "modulos"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> _SubParsersAction:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
 
         Args:

--- a/src/cobra/cli/commands/package_cmd.py
+++ b/src/cobra/cli/commands/package_cmd.py
@@ -1,8 +1,8 @@
 import logging
 import zipfile
-from argparse import _SubParsersAction, Namespace  # TODO: Evitar uso de API privada
+from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import List
+from typing import List, Any
 
 from cobra.cli.commands import modules_cmd
 from cobra.cli.commands.base import BaseCommand
@@ -19,7 +19,7 @@ class PaqueteCommand(BaseCommand):
     """Crea e instala paquetes Cobra."""
     name = "paquete"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:

--- a/src/cobra/cli/commands/profile_cmd.py
+++ b/src/cobra/cli/commands/profile_cmd.py
@@ -9,9 +9,9 @@ import pstats
 import shutil
 import subprocess
 import tempfile
-from argparse import _SubParsersAction, Namespace
+from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Any
 
 from cobra.core import Lexer
 from cobra.core import Parser
@@ -53,7 +53,7 @@ class ProfileCommand(BaseCommand):
         mostrar_error(msg)
         return 1
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando."""
         parser = subparsers.add_parser(self.name, help=_("Perfila un programa"))
         parser.add_argument("archivo")

--- a/src/cobra/cli/commands/qualia_cmd.py
+++ b/src/cobra/cli/commands/qualia_cmd.py
@@ -1,5 +1,5 @@
 import json
-from argparse import _SubParsersAction  # TODO: Reemplazar _SubParsersAction
+from argparse import ArgumentParser
 from pathlib import Path
 from typing import Any, Union
 
@@ -19,7 +19,7 @@ class QualiaCommand(BaseCommand):
     ACCION_MOSTRAR = "mostrar"
     ACCION_REINICIAR = "reiniciar"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:

--- a/src/cobra/cli/commands/transpilar_inverso_cmd.py
+++ b/src/cobra/cli/commands/transpilar_inverso_cmd.py
@@ -1,8 +1,8 @@
 import os
 import logging
 import inspect
-from typing import Optional, Dict, Type
-from argparse import _SubParsersAction, Namespace
+from typing import Optional, Dict, Type, Any
+from argparse import ArgumentParser, Namespace
 from contextlib import contextmanager
 from chardet import detect
 from jsonschema import ValidationError
@@ -75,7 +75,7 @@ class TranspilarInversoCommand(BaseCommand):
 
     name: str = "transpilar-inverso"
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando en el parser.
         
         Args:

--- a/src/cobra/cli/commands/verify_cmd.py
+++ b/src/cobra/cli/commands/verify_cmd.py
@@ -5,7 +5,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
-from argparse import _SubParsersAction
+from argparse import ArgumentParser
 
 from cobra.cli.commands.compile_cmd import TRANSPILERS
 from cobra.core import Lexer
@@ -34,7 +34,7 @@ class VerifyCommand(BaseCommand):
         self._interprete = InterpretadorCobra()
         self._logger = logging.getLogger(__name__)
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> CustomArgumentParser:
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
         
         Args:

--- a/src/cobra/cli/plugin.py
+++ b/src/cobra/cli/plugin.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from importlib import import_module
 from importlib.metadata import entry_points
 from typing import List, Optional, Any
-from argparse import _SubParsersAction
+from argparse import ArgumentParser
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.plugin_registry import (
@@ -41,7 +41,7 @@ class PluginInterface(ABC):
     description: str = DEFAULT_DESCRIPTION
 
     @abstractmethod
-    def register_subparser(self, subparsers: _SubParsersAction) -> None:
+    def register_subparser(self, subparsers: Any) -> None:
         """Registra los argumentos del subcomando en el parser.
         
         Args:
@@ -65,7 +65,7 @@ class PluginInterface(ABC):
 class PluginCommand(BaseCommand, PluginInterface):
     """Clase base para implementar comandos externos mediante plugins."""
 
-    def register_subparser(self, subparsers: _SubParsersAction) -> None:
+    def register_subparser(self, subparsers: Any) -> None:
         """Implementación por defecto del registro de subparser."""
         super().register_subparser(subparsers)
 


### PR DESCRIPTION
## Resumen
- Reemplazadas las importaciones de `_SubParsersAction` por el alias público `ArgumentParser` en todos los comandos de la CLI.
- Las funciones `register_subparser` ahora aceptan un subparser tipado como `Any` y ya no dependen de la clase interna.
- Ajustes en el núcleo de la CLI y ejemplo de plugin para remover dependencias de `_SubParsersAction` y usar verificaciones alternativas.

## Testing
- `pytest -q` *(falla: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_689ebd0be90883278e1c7a447a3cc09e