### PR TITLE
Usar lru_cache para configuraciones y prueba concurrente

### DIFF
--- a/src/core/cobra_config.py
+++ b/src/core/cobra_config.py
@@ -1,4 +1,5 @@
 import os
+from functools import lru_cache
 try:
     import tomllib as tomli  # Python >= 3.11
 except ModuleNotFoundError:  # pragma: no cover - para entornos sin tomllib
@@ -8,21 +9,15 @@ DEFAULT_CONFIG_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "cobra.toml")
 )
 
-_cache = {}
-
-
+@lru_cache(maxsize=None)
 def cargar_configuracion(ruta: str | None = None) -> dict:
     """Carga la configuraci\u00f3n general en formato TOML."""
     path = ruta or os.environ.get("COBRA_CONFIG", DEFAULT_CONFIG_PATH)
 
-    if path not in _cache:
-        if os.path.exists(path):
-            with open(path, "rb") as f:
-                data = tomli.load(f)
-        else:
-            data = {}
-        _cache[path] = data
-    return _cache[path]
+    if os.path.exists(path):
+        with open(path, "rb") as f:
+            return tomli.load(f)
+    return {}
 
 
 def auditoria_activa(config: dict | None = None) -> bool:

--- a/src/tests/unit/test_ast_limit.py
+++ b/src/tests/unit/test_ast_limit.py
@@ -1,14 +1,14 @@
 import pytest
 from core.interpreter import InterpretadorCobra
 from core.ast_nodes import NodoImprimir, NodoValor
-from core.cobra_config import _cache
+from core.cobra_config import cargar_configuracion
 
 
 def test_limite_nodos(monkeypatch, tmp_path):
     cfg = tmp_path / "cfg.toml"
     cfg.write_text("[seguridad]\nlimite_nodos = 1\n")
     monkeypatch.setenv("COBRA_CONFIG", str(cfg))
-    _cache.clear()
+    cargar_configuracion.cache_clear()
     interp = InterpretadorCobra()
     ast = [NodoImprimir(NodoValor(1)), NodoImprimir(NodoValor(2))]
     with pytest.raises(RuntimeError):

--- a/src/tests/unit/test_cobra_config_concurrent.py
+++ b/src/tests/unit/test_cobra_config_concurrent.py
@@ -1,0 +1,32 @@
+import threading
+import time
+import core.cobra_config as cobra_config
+from core.cobra_config import cargar_configuracion
+
+
+def test_cargar_configuracion_concurrente(tmp_path, monkeypatch):
+    cfg = tmp_path / "cfg.toml"
+    cfg.write_text("valor = 1\n")
+    cargar_configuracion.cache_clear()
+
+    original_load = cobra_config.tomli.load
+
+    def slow_load(f):
+        time.sleep(0.05)
+        return original_load(f)
+
+    monkeypatch.setattr(cobra_config.tomli, "load", slow_load)
+
+    resultados: list[dict | None] = [None] * 10
+
+    def worker(i: int) -> None:
+        resultados[i] = cargar_configuracion(str(cfg))
+
+    hilos = [threading.Thread(target=worker, args=(i,)) for i in range(len(resultados))]
+    for h in hilos:
+        h.start()
+    for h in hilos:
+        h.join()
+
+    assert all(r == resultados[0] for r in resultados)
+    assert cargar_configuracion.cache_info().currsize == 1


### PR DESCRIPTION
## Resumen
- Reemplazo del diccionario global por `functools.lru_cache` en `cargar_configuracion`
- Limpieza de caché en pruebas de límite de nodos
- Nueva prueba que verifica accesos concurrentes a la configuración

## Pruebas
- `pytest src/tests/unit/test_cobra_config_concurrent.py --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=0 -q`
- `pytest src/tests/unit/test_ast_limit.py src/tests/unit/test_cobra_config_concurrent.py -q` *(falla: ModuleNotFoundError: No module named 'jsonschema')*


------
https://chatgpt.com/codex/tasks/task_e_689ed778c00483278443a1d07f11a02b