### PR TITLE
Usar realpath para validar rutas de bibliotecas

### DIFF
--- a/src/core/ctypes_bridge.py
+++ b/src/core/ctypes_bridge.py
@@ -20,9 +20,9 @@ _ALLOWED_PREFIXES: list[str] = [
 
 
 def _es_ruta_permitida(ruta: str) -> bool:
-    path = os.path.abspath(ruta)
+    path = os.path.realpath(ruta)
     for pref in _ALLOWED_PREFIXES:
-        pref = os.path.abspath(pref)
+        pref = os.path.realpath(pref)
         try:
             if os.path.commonpath([pref, path]) == pref:
                 return True


### PR DESCRIPTION
## Summary
- Usar `os.path.realpath` en `_es_ruta_permitida` para evitar que enlaces simbólicos eludan la lista de rutas permitidas.
- Añadir prueba unitaria que verifica el bloqueo de bibliotecas accedidas mediante symlink fuera de los prefijos autorizados.
- Ajustar pruebas para cargar dependencias opcionales solo si están disponibles.

## Testing
- `ruff check src/tests/unit/test_ctypes_bridge.py src/core/ctypes_bridge.py`
- `pytest src/tests/unit/test_ctypes_bridge.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689edff74a78832790bcf1f27302d431