### PR TITLE
Restringir red y recursos en ejecución de contenedores

### DIFF
--- a/src/core/sandbox.py
+++ b/src/core/sandbox.py
@@ -119,6 +119,10 @@ def ejecutar_en_contenedor(
     backend utiliza una imagen específica que debe estar construida
     previamente. ``timeout`` define el límite de tiempo en segundos para la
     ejecución del contenedor.
+
+    El contenedor se lanza sin acceso a la red (``--network=none``) y con
+    límites de recursos básicos mediante ``--pids-limit`` y ``--memory`` para
+    evitar abusos del sistema.
     """
 
     imagenes = {
@@ -133,7 +137,16 @@ def ejecutar_en_contenedor(
 
     try:
         proc = subprocess.run(
-            ["docker", "run", "--rm", "-i", imagenes[backend]],
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--network=none",
+                "--pids-limit=128",
+                "--memory=256m",
+                "-i",
+                imagenes[backend],
+            ],
             input=codigo,
             text=True,
             capture_output=True,


### PR DESCRIPTION
## Resumen
- Deshabilita la red en los contenedores de sandbox mediante `--network=none`.
- Limita procesos y memoria con `--pids-limit` y `--memory` al invocar `docker run`.
- Documenta las nuevas restricciones en `ejecutar_en_contenedor`.

## Pruebas
- `pytest src/tests/unit/test_security_sandbox.py --no-cov -q`
- Ejecución manual de `ejecutar_en_contenedor` para cada backend (Docker no disponible en el entorno).

------
https://chatgpt.com/codex/tasks/task_e_689ee4691e048327a8a1a0c8cba6df35