### PR TITLE
Refuerzo de sandbox Docker con usuario nobody y FS de solo lectura

### DIFF
--- a/docs/limitaciones_cpp_sandbox.md
+++ b/docs/limitaciones_cpp_sandbox.md
@@ -1,3 +1,15 @@
 # Limitaciones del sandbox de C++
 
-`compilar_en_sandbox_cpp` ejecuta el código dentro del contenedor Docker `cobra-cpp-sandbox`. Si la imagen no está disponible o Docker no está instalado se rechaza la operación con un error indicando que el contenedor de C++ no puede usarse.
+`compilar_en_sandbox_cpp` ejecuta el código dentro del contenedor Docker
+`cobra-cpp-sandbox`. El contenedor se lanza con restricciones estrictas de
+seguridad:
+
+* Se ejecuta como el usuario `nobody` (`--user 65534:65534`).
+* El sistema de archivos es de solo lectura (`--read-only`) y solo se permite
+  un directorio temporal (`--tmpfs /tmp`).
+* No se conceden capacidades adicionales (`--cap-drop=ALL`).
+* No hay acceso a la red (`--network=none`) y se limitan procesos y memoria
+  (`--pids-limit` y `--memory`).
+
+Si la imagen no está disponible o Docker no está instalado se rechaza la
+operación con un error indicando que el contenedor de C++ no puede usarse.

--- a/src/core/sandbox.py
+++ b/src/core/sandbox.py
@@ -154,9 +154,11 @@ def ejecutar_en_contenedor(
     previamente. ``timeout`` define el límite de tiempo en segundos para la
     ejecución del contenedor.
 
-    El contenedor se lanza sin acceso a la red (``--network=none``) y con
-    límites de recursos básicos mediante ``--pids-limit`` y ``--memory`` para
-    evitar abusos del sistema.
+    El contenedor se lanza sin acceso a la red (``--network=none``), como el
+    usuario ``nobody`` (``--user 65534:65534``), con el sistema de archivos en
+    modo solo lectura (``--read-only`` y ``--tmpfs /tmp``) y sin capacidades
+    adicionales (``--cap-drop=ALL``). Además, se aplican límites de recursos
+    mediante ``--pids-limit`` y ``--memory`` para evitar abusos del sistema.
     """
 
     imagenes = {
@@ -178,6 +180,10 @@ def ejecutar_en_contenedor(
                 "--network=none",
                 "--pids-limit=128",
                 "--memory=256m",
+                "--user", "65534:65534",
+                "--read-only",
+                "--tmpfs", "/tmp",
+                "--cap-drop=ALL",
                 "-i",
                 imagenes[backend],
             ],

--- a/src/tests/unit/test_cli_sandbox_docker.py
+++ b/src/tests/unit/test_cli_sandbox_docker.py
@@ -13,7 +13,20 @@ def test_cli_sandbox_docker_invoca_docker(monkeypatch):
         mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="4\n", stderr="")
         main(["interactive", "--sandbox-docker", "python"])
         mock_run.assert_called_once_with(
-            ["docker", "run", "--rm", "-i", "cobra-python-sandbox"],
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--network=none",
+                "--pids-limit=128",
+                "--memory=256m",
+                "--user", "65534:65534",
+                "--read-only",
+                "--tmpfs", "/tmp",
+                "--cap-drop=ALL",
+                "-i",
+                "cobra-python-sandbox",
+            ],
             input="print(2+2)", text=True, capture_output=True, check=True,
         )
 


### PR DESCRIPTION
## Resumen
- Ejecutar contenedores como usuario `nobody` y sin capacidades
- Montar los contenedores en modo solo lectura con tmpfs temporal
- Actualizar documentación y pruebas para reflejar las nuevas restricciones

## Pruebas
- `PYTHONPATH=.:src:backend/src pytest src/tests/unit/test_security_sandbox.py -q --cov-fail-under=0`
- `PYTHONPATH=.:src:backend/src pytest src/tests/unit/test_cli_sandbox_docker.py -q` *(falla: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_689ee92b5e108327a6da1acd5d2d6007