### PR TITLE
Restringir acceso HTTP y redirecciones en utilidades de red

### DIFF
--- a/frontend/docs/modulos_nativos.rst
+++ b/frontend/docs/modulos_nativos.rst
@@ -9,7 +9,7 @@ E/S de archivos y red
 ---------------------
 - ``leer_archivo(ruta)`` lee el contenido de un archivo de texto.
 - ``escribir_archivo(ruta, datos)`` guarda datos en un archivo.
-- ``obtener_url(url)`` devuelve el texto obtenido desde una URL.
+- ``obtener_url(url)`` devuelve el texto obtenido desde una URL ``https://``.
 
 Utilidades matematicas
 ----------------------
@@ -62,10 +62,12 @@ Operaciones numericas
 
 Red
 ---
-- ``obtener_url(url)`` recupera el contenido de una URL.
-- ``enviar_post(url, datos)`` envia datos por ``POST``.
+- ``obtener_url(url, permitir_redirecciones=False)`` recupera el contenido de una URL ``https://``.
+- ``enviar_post(url, datos, permitir_redirecciones=False)`` envia datos por ``POST`` a una URL ``https://``.
+  Las peticiones no siguen redirecciones a menos que se habilite ``permitir_redirecciones=True``.
   Los destinos se validan opcionalmente con la lista de hosts definida en
-  la variable de entorno ``COBRA_HOST_WHITELIST``.
+  la variable de entorno ``COBRA_HOST_WHITELIST``. Si se permiten redirecciones,
+  el host final tras la redirección también debe pertenecer a la lista blanca.
 
 .. code-block:: cobra
 

--- a/src/corelibs/red.py
+++ b/src/corelibs/red.py
@@ -6,33 +6,49 @@ import urllib.parse
 import requests
 
 
-def obtener_url(url: str) -> str:
-    """Devuelve el contenido de una URL como texto."""
+def _validar_host(url: str, hosts: set[str]) -> None:
+    host = urllib.parse.urlparse(url).hostname
+    if host not in hosts:
+        raise ValueError("Host no permitido")
+
+
+def obtener_url(url: str, permitir_redirecciones: bool = False) -> str:
+    """Devuelve el contenido de una URL ``https://`` como texto.
+
+    Las redirecciones están deshabilitadas por defecto. Si se permiten,
+    se valida que el destino final continúe dentro de la lista blanca de hosts.
+    """
     url_baja = url.lower()
-    if not (url_baja.startswith("http://") or url_baja.startswith("https://")):
+    if not url_baja.startswith("https://"):
         raise ValueError("Esquema de URL no soportado")
     allowed = os.environ.get("COBRA_HOST_WHITELIST")
-    if allowed:
-        hosts = {h.strip() for h in allowed.split(',') if h.strip()}
-        host = urllib.parse.urlparse(url).hostname
-        if host not in hosts:
-            raise ValueError("Host no permitido")
-    resp = requests.get(url, timeout=5)
+    hosts = {h.strip() for h in allowed.split(',') if h.strip()} if allowed else set()
+    if hosts:
+        _validar_host(url, hosts)
+    resp = requests.get(url, timeout=5, allow_redirects=permitir_redirecciones)
     resp.raise_for_status()
+    if permitir_redirecciones and hosts:
+        _validar_host(resp.url, hosts)
     return resp.text
 
 
-def enviar_post(url: str, datos: dict) -> str:
-    """Envía datos por POST y retorna la respuesta."""
+def enviar_post(url: str, datos: dict, permitir_redirecciones: bool = False) -> str:
+    """Envía datos por ``POST`` a una URL ``https://`` y retorna la respuesta.
+
+    Las redirecciones están deshabilitadas por defecto. Si se permiten,
+    se valida que el destino final continúe dentro de la lista blanca de hosts.
+    """
     url_baja = url.lower()
-    if not (url_baja.startswith("http://") or url_baja.startswith("https://")):
+    if not url_baja.startswith("https://"):
         raise ValueError("Esquema de URL no soportado")
     allowed = os.environ.get("COBRA_HOST_WHITELIST")
-    if allowed:
-        hosts = {h.strip() for h in allowed.split(',') if h.strip()}
-        host = urllib.parse.urlparse(url).hostname
-        if host not in hosts:
-            raise ValueError("Host no permitido")
-    resp = requests.post(url, data=datos, timeout=5)
+    hosts = {h.strip() for h in allowed.split(',') if h.strip()} if allowed else set()
+    if hosts:
+        _validar_host(url, hosts)
+    resp = requests.post(
+        url, data=datos, timeout=5, allow_redirects=permitir_redirecciones
+    )
     resp.raise_for_status()
+    if permitir_redirecciones and hosts:
+        _validar_host(resp.url, hosts)
     return resp.text


### PR DESCRIPTION
## Resumen
- Aceptar únicamente URLs `https://` en las funciones de red.
- Deshabilitar redirecciones por defecto y validar el host final si se permiten.
- Documentar el nuevo comportamiento de `obtener_url` y `enviar_post`.

## Pruebas
- `pytest src/tests/unit/test_corelibs.py::test_core_red_funcs src/tests/unit/test_corelibs.py::test_red_obtener_url_rechaza_esquema_no_http src/tests/unit/test_corelibs.py::test_red_obtener_url_rechaza_otro_esquema src/tests/unit/test_corelibs.py::test_red_enviar_post_rechaza_esquema_no_http src/tests/unit/test_corelibs.py::test_red_enviar_post_rechaza_otro_esquema src/tests/unit/test_corelibs.py::test_red_host_whitelist_permite src/tests/unit/test_corelibs.py::test_red_host_whitelist_rechaza src/tests/unit/test_corelibs.py::test_red_obtener_url_redireccion_fuera_whitelist src/tests/unit/test_corelibs.py::test_red_enviar_post_redireccion_fuera_whitelist src/tests/unit/test_corelibs.py::test_transpile_red src/tests/unit/test_nativos_io.py::test_obtener_url_rechaza_esquema_no_http src/tests/unit/test_nativos_io.py::test_obtener_url_rechaza_otro_esquema src/tests/unit/test_nativos_io.py::test_obtener_url_host_whitelist src/tests/unit/test_nativos_io.py::test_obtener_url_host_no_permitido src/tests/unit/test_nativos_io.py::test_obtener_url_redireccion_fuera_whitelist -q` (errores de importación)
- `python -m py_compile src/corelibs/red.py src/core/nativos/io.py src/tests/unit/test_corelibs.py src/tests/unit/test_nativos_io.py`

------
https://chatgpt.com/codex/tasks/task_e_689eeb7a1510832786e6a2933d311b09