### PR TITLE
Manejar ImportError por submódulos y relanzar excepciones

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -15,5 +15,8 @@ for pkg in _submodules:
     try:
         module = importlib.import_module(f".{pkg}", __name__)
         globals()[pkg] = module
-    except Exception as e:  # nosec B110
+    except ImportError as e:
         logger.warning("No se pudo importar %s: %s", pkg, e)
+    except Exception as e:  # nosec B110
+        logger.error("Error al importar %s", pkg, exc_info=True)
+        raise


### PR DESCRIPTION
## Summary
- Manejo específico de `ImportError` al cargar submódulos en `src/__init__.py`
- Registro y relanzamiento de excepciones inesperadas durante las importaciones

## Testing
- `pytest` *(errores: AttributeError y ModuleNotFoundError en múltiples pruebas)*

------
https://chatgpt.com/codex/tasks/task_e_689ef8d9ba4483279f121a36eb175be0