### PR TITLE
Usar multiprocessing para limitar ejecución y pruebas de timeout

### DIFF
--- a/src/tests/unit/test_cli_execute_timeout.py
+++ b/src/tests/unit/test_cli_execute_timeout.py
@@ -1,0 +1,25 @@
+import time
+import cobra.cli.commands.execute_cmd as execute_cmd
+import pytest
+
+
+def _bucle_infinito():
+    while True:
+        time.sleep(0.1)
+
+
+def _ejecutar_timeout(monkeypatch, os_name):
+    monkeypatch.setattr(execute_cmd.os, "name", os_name)
+    cmd = execute_cmd.ExecuteCommand()
+    cmd.EXECUTION_TIMEOUT = 1
+    with pytest.raises(TimeoutError):
+        cmd._limitar_recursos(_bucle_infinito)
+
+
+def test_timeout_unix(monkeypatch):
+    _ejecutar_timeout(monkeypatch, "posix")
+
+
+def test_timeout_windows(monkeypatch):
+    _ejecutar_timeout(monkeypatch, "nt")
+


### PR DESCRIPTION
## Resumen
- Ejecutar scripts en proceso hijo en Windows y terminarlo al exceder el tiempo límite.
- Mantener `signal.SIGALRM` para Unix.
- Añadir pruebas que simulan Windows y Unix verificando timeout en un bucle infinito.

## Pruebas
- `pytest -q` *(falla: No module named 'cobra', ...)*
- `pytest src/tests/unit/test_cli_execute_timeout.py -q --override-ini="addopts="`

------
https://chatgpt.com/codex/tasks/task_e_689f0002fd648327b79922811d990e47