### PR TITLE
Limpia variables de entorno Node en sandbox

### DIFF
--- a/src/core/sandbox.py
+++ b/src/core/sandbox.py
@@ -93,12 +93,17 @@ def ejecutar_en_sandbox_js(codigo: str, timeout: int = 5) -> str:
     import json
     import os
 
+    env = os.environ.copy()
+    env.pop("NODE_OPTIONS", None)
+    env.pop("NODE_PATH", None)
+
     try:
         version = subprocess.run(
             ["node", "-e", "console.log(require('vm2/package.json').version)"],
             capture_output=True,
             text=True,
             check=True,
+            env=env,
         )
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
         raise RuntimeError("vm2 no disponible") from exc
@@ -150,6 +155,7 @@ process.stdout.write(output);
             check=True,
             cwd=base_dir,
             timeout=timeout,
+            env=env,
         )  # nosec B603
         return proc.stdout
     except subprocess.CalledProcessError as exc:

--- a/src/tests/unit/test_sandbox_js.py
+++ b/src/tests/unit/test_sandbox_js.py
@@ -61,3 +61,18 @@ def test_sandbox_js_sin_comandos_externos():
     codigo = "require('child_process').exec('echo hola')"
     salida = ejecutar_en_sandbox_js(codigo)
     assert "Cannot find module" in salida
+
+
+@pytest.mark.timeout(5)
+def test_sandbox_js_ignora_node_options(monkeypatch):
+    if not shutil.which("node"):
+        pytest.skip("node no disponible")
+    try:
+        subprocess.run(["node", "-e", "require('vm2')"], check=True, capture_output=True)
+    except subprocess.CalledProcessError:
+        pytest.skip("vm2 no disponible")
+    monkeypatch.setenv("NODE_OPTIONS", "--eval \"process.stdout.write('pwned')\"")
+    salida = ejecutar_en_sandbox_js("console.log('hola')")
+    assert salida.strip() == "hola"
+    assert "pwned" not in salida
+


### PR DESCRIPTION
## Resumen
- Limpia NODE_OPTIONS y NODE_PATH al ejecutar sandbox de JS, aislando el entorno de Node.
- Añade prueba para garantizar que NODE_OPTIONS maliciosos no se apliquen.

## Pruebas
- `pytest src/tests/unit/test_sandbox_js.py::test_sandbox_js_ignora_node_options -vv --no-cov` *(omitido: vm2 no disponible)*

------
https://chatgpt.com/codex/tasks/task_e_689f04bf60a48327b9817f2670d75e54