### PR TITLE
fix: actualizar módulos permitidos en SafeUnpickler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v10.0.9 - 2025-07-29
+- Ajuste en `SafeUnpickler` para aceptar los módulos `core.ast_nodes` y `cobra.core.ast_nodes`.
+
 ## v10.0.8 - 2025-07-28
 - Actualización de dependencias a versiones estables recientes (numpy, scipy, requests, PyYAML, entre otras).
 

--- a/src/core/ast_cache.py
+++ b/src/core/ast_cache.py
@@ -13,7 +13,8 @@ class SafeUnpickler(pickle.Unpickler):
 
     # Módulos de los que se permitirá cargar clases
     ALLOWED_MODULES = {
-        "src.core.ast_nodes",
+        "core.ast_nodes",
+        "cobra.core.ast_nodes",
         "cobra.core.lexer",
         "builtins",
     }


### PR DESCRIPTION
## Resumen
- Permitir la lectura de pickles generados con `core.ast_nodes` y `cobra.core.ast_nodes` en la caché de AST
- Documentar el cambio en el `CHANGELOG`

## Pruebas
- `PYTHONPATH=src pytest -q src/tests/unit/test_ast_cache.py src/tests/unit/test_token_cache.py --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_689f068c9fdc83279ce49333f1d225f0