### PR TITLE
refactor: validar ruta destino y ampliar pruebas

### DIFF
--- a/src/cobra/cli/cobrahub_client.py
+++ b/src/cobra/cli/cobrahub_client.py
@@ -87,7 +87,9 @@ class CobraHubClient:
             ruta_abs = ruta.resolve()
             dir_trabajo = Path.cwd().resolve()
 
-            if not str(ruta_abs).startswith(str(dir_trabajo)):
+            try:
+                ruta_abs.relative_to(dir_trabajo)
+            except ValueError:
                 mostrar_error(_("Ruta fuera del directorio de trabajo"))
                 return None
 

--- a/src/tests/unit/test_cli_cobrahub.py
+++ b/src/tests/unit/test_cli_cobrahub.py
@@ -106,6 +106,29 @@ def test_descargar_modulo_ruta_invalida_traversal(tmp_path, monkeypatch):
 
 
 @pytest.mark.timeout(5)
+def test_descargar_modulo_ruta_invalida_parent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    destino = "../"
+    with patch("cobra.cli.cobrahub_client.mostrar_error") as err, \
+            patch("cli.cobrahub_client.requests.get") as mock_get:
+        ok = cobrahub_client.descargar_modulo("m.co", destino)
+    assert not ok
+    err.assert_called_once()
+    mock_get.assert_not_called()
+
+
+@pytest.mark.timeout(5)
+def test_descargar_modulo_ruta_invalida_tmp_espacios():
+    destino = "/tmp/proyecto falso"
+    with patch("cobra.cli.cobrahub_client.mostrar_error") as err, \
+            patch("cli.cobrahub_client.requests.get") as mock_get:
+        ok = cobrahub_client.descargar_modulo("m.co", destino)
+    assert not ok
+    err.assert_called_once()
+    mock_get.assert_not_called()
+
+
+@pytest.mark.timeout(5)
 def test_descargar_modulo_ruta_valida(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     destino = "mods/m.co"


### PR DESCRIPTION
## Resumen
- valida rutas de descarga con `Path.relative_to` para asegurar que están bajo el directorio de trabajo
- añade pruebas negativas para rutas `../` y `/tmp/proyecto falso`

## Pruebas
- `python - <<'PY'
import cobra.cli as cobra_cli
import cobra.cli.commands as cobra_cli_commands
import cobra.cli.cobrahub_client as ch
import sys

def descargar_modulo(nombre, destino):
    return ch.CobraHubClient().descargar_modulo(nombre, destino)

def publicar_modulo(ruta):
    return ch.CobraHubClient().publicar_modulo(ruta)

ch.descargar_modulo = descargar_modulo
ch.publicar_modulo = publicar_modulo

sys.modules['cli'] = cobra_cli
sys.modules['cli.commands'] = cobra_cli_commands
sys.modules['cli.cobrahub_client'] = ch

import pytest
pytest.main(["-c","/dev/null","src/tests/unit/test_cli_cobrahub.py::test_descargar_modulo_ruta_invalida_parent","src/tests/unit/test_cli_cobrahub.py::test_descargar_modulo_ruta_invalida_tmp_espacios","-q"])
PY`

------
https://chatgpt.com/codex/tasks/task_e_689f10282ed88327b745eed61dc03315