### PR TITLE
Refuerza validaciones de red y añade pruebas

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -15,6 +15,7 @@ import logging
 import sys
 from pathlib import Path
 from typing import Dict, Optional
+from types import ModuleType
 
 # Configuración del logging
 logger = logging.getLogger(__name__)
@@ -46,7 +47,7 @@ def validate_path(path: Path) -> bool:
         logger.error(f"Error validando path {path}: {e}")
         return False
 
-def import_module_safe(module_name: str) -> Optional[importlib.ModuleType]:
+def import_module_safe(module_name: str) -> Optional[ModuleType]:
     """
     Importa un módulo de forma segura manejando las excepciones.
     

--- a/src/corelibs/red.py
+++ b/src/corelibs/red.py
@@ -22,12 +22,17 @@ def obtener_url(url: str, permitir_redirecciones: bool = False) -> str:
     if not url_baja.startswith("https://"):
         raise ValueError("Esquema de URL no soportado")
     allowed = os.environ.get("COBRA_HOST_WHITELIST")
-    hosts = {h.strip() for h in allowed.split(',') if h.strip()} if allowed else set()
-    if hosts:
-        _validar_host(url, hosts)
+    if not allowed:
+        raise ValueError("COBRA_HOST_WHITELIST no establecido")
+    hosts = {h.strip() for h in allowed.split(',') if h.strip()}
+    if not hosts:
+        raise ValueError("COBRA_HOST_WHITELIST vacío")
+    _validar_host(url, hosts)
     resp = requests.get(url, timeout=5, allow_redirects=permitir_redirecciones)
     resp.raise_for_status()
-    if permitir_redirecciones and hosts:
+    if permitir_redirecciones:
+        if not resp.url.lower().startswith("https://"):
+            raise ValueError("Esquema de URL no soportado")
         _validar_host(resp.url, hosts)
     return resp.text
 
@@ -42,13 +47,18 @@ def enviar_post(url: str, datos: dict, permitir_redirecciones: bool = False) -> 
     if not url_baja.startswith("https://"):
         raise ValueError("Esquema de URL no soportado")
     allowed = os.environ.get("COBRA_HOST_WHITELIST")
-    hosts = {h.strip() for h in allowed.split(',') if h.strip()} if allowed else set()
-    if hosts:
-        _validar_host(url, hosts)
+    if not allowed:
+        raise ValueError("COBRA_HOST_WHITELIST no establecido")
+    hosts = {h.strip() for h in allowed.split(',') if h.strip()}
+    if not hosts:
+        raise ValueError("COBRA_HOST_WHITELIST vacío")
+    _validar_host(url, hosts)
     resp = requests.post(
         url, data=datos, timeout=5, allow_redirects=permitir_redirecciones
     )
     resp.raise_for_status()
-    if permitir_redirecciones and hosts:
+    if permitir_redirecciones:
+        if not resp.url.lower().startswith("https://"):
+            raise ValueError("Esquema de URL no soportado")
         _validar_host(resp.url, hosts)
     return resp.text

--- a/src/tests/unit/test_corelibs.py
+++ b/src/tests/unit/test_corelibs.py
@@ -76,6 +76,7 @@ def test_seguridad_funcs():
 
 
 def test_red_funcs(monkeypatch):
+    monkeypatch.setenv("COBRA_HOST_WHITELIST", "x")
     mock_resp = MagicMock()
     mock_resp.text = "ok"
     mock_resp.raise_for_status.return_value = None

--- a/src/tests/unit/test_red.py
+++ b/src/tests/unit/test_red.py
@@ -1,0 +1,29 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import backend.corelibs as core
+
+
+def test_obtener_url_sin_whitelist(monkeypatch):
+    monkeypatch.delenv("COBRA_HOST_WHITELIST", raising=False)
+    with patch("backend.corelibs.red.requests.get") as mock_get:
+        with pytest.raises(ValueError):
+            core.obtener_url("https://example.com")
+        mock_get.assert_not_called()
+
+
+def test_obtener_url_redireccion_http(monkeypatch):
+    monkeypatch.setenv("COBRA_HOST_WHITELIST", "example.com")
+    mock_resp = MagicMock(text="ok", url="http://example.com")
+    mock_resp.raise_for_status.return_value = None
+    with patch("backend.corelibs.red.requests.get", return_value=mock_resp):
+        with pytest.raises(ValueError):
+            core.obtener_url("https://example.com", permitir_redirecciones=True)
+
+
+def test_obtener_url_redireccion_fuera_whitelist(monkeypatch):
+    monkeypatch.setenv("COBRA_HOST_WHITELIST", "example.com")
+    mock_resp = MagicMock(text="ok", url="https://otro.com")
+    mock_resp.raise_for_status.return_value = None
+    with patch("backend.corelibs.red.requests.get", return_value=mock_resp):
+        with pytest.raises(ValueError):
+            core.obtener_url("https://example.com", permitir_redirecciones=True)


### PR DESCRIPTION
## Resumen
- Exige definir `COBRA_HOST_WHITELIST` y valida esquema HTTPS tras redirecciones
- Ajusta carga de módulos en `backend` para evitar errores de importación
- Cubre casos de lista blanca ausente y redirecciones inseguras en pruebas unitarias

## Testing
- `pytest src/tests/unit/test_red.py -q --cov=src/corelibs/red.py --cov-report=term-missing --cov-report=xml --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_689f157c7e08832781244ffa1e736346