### PR TITLE
Exigir lista blanca en sistema.ejecutar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v10.0.9 - 2025-07-29
 - Ajuste en `SafeUnpickler` para aceptar los módulos `core.ast_nodes` y `cobra.core.ast_nodes`.
+- `corelibs.sistema.ejecutar` ahora exige una lista blanca de comandos
+  mediante el parámetro `permitidos` o la variable de entorno
+  `COBRA_EJECUTAR_PERMITIDOS`. Invocarlo sin esta configuración produce
+  `ValueError`.
 
 ## v10.0.8 - 2025-07-28
 - Actualización de dependencias a versiones estables recientes (numpy, scipy, requests, PyYAML, entre otras).

--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -274,3 +274,12 @@ con:
 pip install snakeviz
 ```
 
+## 15. Funciones del sistema
+
+La biblioteca estándar expone `corelibs.sistema.ejecutar` para lanzar
+procesos del sistema. Por motivos de seguridad es **obligatorio**
+proporcionar una lista blanca de ejecutables permitidos mediante el
+parámetro ``permitidos`` o definiendo la variable de entorno
+``COBRA_EJECUTAR_PERMITIDOS`` separada por ``os.pathsep``. Invocar la
+función sin esta configuración producirá un ``ValueError``.
+


### PR DESCRIPTION
## Resumen
- Obliga a proporcionar una lista blanca de comandos al invocar `corelibs.sistema.ejecutar`, con opción a cargarla desde la variable de entorno `COBRA_EJECUTAR_PERMITIDOS`.
- Documenta en el manual y en el changelog la necesidad de definir comandos permitidos.
- Añade pruebas unitarias que comprueban el uso correcto de la lista blanca y el error cuando falta.

## Pruebas
- `pytest -c /dev/null src/tests/unit/test_corelibs_sistema.py`

------
https://chatgpt.com/codex/tasks/task_e_689f1c5358c883278b06bc175ac0f47d