### PR TITLE
Manejo de rutas en validar_dependencias

### DIFF
--- a/src/core/sandbox.py
+++ b/src/core/sandbox.py
@@ -247,7 +247,11 @@ def validar_dependencias(backend: str, mod_info: dict) -> None:
         if not ruta:
             continue
         abs_path = os.path.realpath(ruta)
-        if os.path.commonpath([base, abs_path]) != base:
+        try:
+            comun = os.path.commonpath([base, abs_path])
+        except ValueError:
+            raise ValueError(f"Ruta no permitida: {ruta}") from None
+        if comun != base:
             raise ValueError(f"Ruta no permitida: {ruta}")
         if not os.path.exists(abs_path):
             raise FileNotFoundError(f"Dependencia no encontrada: {ruta}")

--- a/src/tests/unit/test_sandbox_commonpath.py
+++ b/src/tests/unit/test_sandbox_commonpath.py
@@ -1,0 +1,13 @@
+import os
+import pytest
+from core.sandbox import validar_dependencias
+
+
+def test_validar_dependencias_unidades_distintas(monkeypatch):
+    def fake_commonpath(paths):
+        raise ValueError("rutas en distintas unidades")
+
+    monkeypatch.setattr(os.path, "commonpath", fake_commonpath)
+    mod_info = {"mod": {"python": "D:\\mod.py"}}
+    with pytest.raises(ValueError, match="Ruta no permitida"):
+        validar_dependencias("python", mod_info)


### PR DESCRIPTION
## Resumen
- Manejo amigable de `ValueError` en `validar_dependencias` cuando `os.path.commonpath` falla por rutas en unidades distintas.
- Prueba unitaria que simula unidades diferentes y verifica la excepción controlada.

## Testing
- `pytest src/tests/unit/test_sandbox_commonpath.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_689f1f0b72048327b2b42dd68afd72cd