### PR TITLE
Restringe rutas de IO a directorio autorizado y agrega pruebas

### DIFF
--- a/src/core/nativos/io.py
+++ b/src/core/nativos/io.py
@@ -1,18 +1,37 @@
 import os
 import urllib.parse
+from pathlib import Path
 
 import requests
 
 
+def _resolver_ruta(ruta: str) -> Path:
+    """Resuelve ``ruta`` dentro de un directorio permitido."""
+    base = Path(os.environ.get("COBRA_IO_BASE_DIR") or Path.cwd()).resolve()
+    p = Path(ruta)
+    if p.is_absolute():
+        raise ValueError("Ruta absoluta no permitida")
+    if ".." in p.parts:
+        raise ValueError("La ruta no puede contener '..'")
+    destino = (base / p).resolve()
+    try:
+        destino.relative_to(base)
+    except ValueError as exc:
+        raise ValueError("Ruta fuera del directorio permitido") from exc
+    return destino
+
+
 def leer_archivo(ruta):
     """Devuelve el contenido de un archivo de texto."""
-    with open(ruta, "r", encoding="utf-8") as f:
+    ruta_segura = _resolver_ruta(ruta)
+    with open(ruta_segura, "r", encoding="utf-8") as f:
         return f.read()
 
 
 def escribir_archivo(ruta, datos):
     """Escribe datos en un archivo de texto."""
-    with open(ruta, "w", encoding="utf-8") as f:
+    ruta_segura = _resolver_ruta(ruta)
+    with open(ruta_segura, "w", encoding="utf-8") as f:
         f.write(datos)
 
 

--- a/src/tests/unit/test_nativos_io.py
+++ b/src/tests/unit/test_nativos_io.py
@@ -61,3 +61,21 @@ def test_obtener_url_redireccion_fuera_whitelist(monkeypatch):
     with patch('requests.get', return_value=mock_resp):
         with pytest.raises(ValueError):
             io.obtener_url('https://example.com', permitir_redirecciones=True)
+
+
+@pytest.mark.parametrize("func", [io.leer_archivo, lambda p: io.escribir_archivo(p, "dato")])
+def test_io_restringe_rutas_absolutas(monkeypatch, tmp_path, func):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    archivo = tmp_path / "interno.txt"
+    archivo.write_text("contenido", encoding="utf-8")
+    with pytest.raises(ValueError):
+        func(str(archivo.resolve()))
+
+
+@pytest.mark.parametrize("func", [io.leer_archivo, lambda p: io.escribir_archivo(p, "dato")])
+def test_io_restringe_rutas_fuera_base(monkeypatch, tmp_path, func):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    externo = tmp_path.parent / "externo.txt"
+    externo.write_text("afuera", encoding="utf-8")
+    with pytest.raises(ValueError):
+        func("../externo.txt")


### PR DESCRIPTION
## Summary
- valida rutas de `leer_archivo` y `escribir_archivo` para que permanezcan dentro de un directorio permitido
- agrega pruebas que aseguran el rechazo de rutas absolutas o fuera de la base

## Testing
- `pytest src/tests/unit/test_nativos_io.py -vv -o addopts="" -p no:cov`


------
https://chatgpt.com/codex/tasks/task_e_689f22f1ed4083278c69cc43f005660d