### PR TITLE
Validación estricta de hosts en obtener_url

### DIFF
--- a/src/corelibs/red.py
+++ b/src/corelibs/red.py
@@ -30,10 +30,9 @@ def obtener_url(url: str, permitir_redirecciones: bool = False) -> str:
     _validar_host(url, hosts)
     resp = requests.get(url, timeout=5, allow_redirects=permitir_redirecciones)
     resp.raise_for_status()
-    if permitir_redirecciones:
-        if not resp.url.lower().startswith("https://"):
-            raise ValueError("Esquema de URL no soportado")
-        _validar_host(resp.url, hosts)
+    if permitir_redirecciones and not resp.url.lower().startswith("https://"):
+        raise ValueError("Esquema de URL no soportado")
+    _validar_host(resp.url, hosts)
     return resp.text
 
 
@@ -57,8 +56,7 @@ def enviar_post(url: str, datos: dict, permitir_redirecciones: bool = False) -> 
         url, data=datos, timeout=5, allow_redirects=permitir_redirecciones
     )
     resp.raise_for_status()
-    if permitir_redirecciones:
-        if not resp.url.lower().startswith("https://"):
-            raise ValueError("Esquema de URL no soportado")
-        _validar_host(resp.url, hosts)
+    if permitir_redirecciones and not resp.url.lower().startswith("https://"):
+        raise ValueError("Esquema de URL no soportado")
+    _validar_host(resp.url, hosts)
     return resp.text

--- a/src/tests/unit/test_corelibs.py
+++ b/src/tests/unit/test_corelibs.py
@@ -77,8 +77,7 @@ def test_seguridad_funcs():
 
 def test_red_funcs(monkeypatch):
     monkeypatch.setenv("COBRA_HOST_WHITELIST", "x")
-    mock_resp = MagicMock()
-    mock_resp.text = "ok"
+    mock_resp = MagicMock(text="ok", url="https://x")
     mock_resp.raise_for_status.return_value = None
     with patch(
         "backend.corelibs.red.requests.get", return_value=mock_resp
@@ -93,28 +92,32 @@ def test_red_funcs(monkeypatch):
         )
 
 
-def test_red_obtener_url_rechaza_esquema_no_http():
+def test_red_obtener_url_rechaza_esquema_no_http(monkeypatch):
+    monkeypatch.setenv("COBRA_HOST_WHITELIST", "example.com")
     with patch("backend.corelibs.red.requests.get") as mock_get:
         with pytest.raises(ValueError):
             core.obtener_url("ftp://ejemplo.com")
         mock_get.assert_not_called()
 
 
-def test_red_obtener_url_rechaza_otro_esquema():
+def test_red_obtener_url_rechaza_otro_esquema(monkeypatch):
+    monkeypatch.setenv("COBRA_HOST_WHITELIST", "example.com")
     with patch("backend.corelibs.red.requests.get") as mock_get:
         with pytest.raises(ValueError):
             core.obtener_url("file:///tmp/archivo.txt")
         mock_get.assert_not_called()
 
 
-def test_red_enviar_post_rechaza_esquema_no_http():
+def test_red_enviar_post_rechaza_esquema_no_http(monkeypatch):
+    monkeypatch.setenv("COBRA_HOST_WHITELIST", "example.com")
     with patch("backend.corelibs.red.requests.post") as mock_post:
         with pytest.raises(ValueError):
             core.enviar_post("ftp://ejemplo.com", {"a": 1})
         mock_post.assert_not_called()
 
 
-def test_red_enviar_post_rechaza_otro_esquema():
+def test_red_enviar_post_rechaza_otro_esquema(monkeypatch):
+    monkeypatch.setenv("COBRA_HOST_WHITELIST", "example.com")
     with patch("backend.corelibs.red.requests.post") as mock_post:
         with pytest.raises(ValueError):
             core.enviar_post("file:///tmp/archivo.txt", {"a": 1})
@@ -123,7 +126,7 @@ def test_red_enviar_post_rechaza_otro_esquema():
 
 def test_red_host_whitelist_permite(monkeypatch):
     monkeypatch.setenv("COBRA_HOST_WHITELIST", "example.com")
-    mock_resp = MagicMock(text="ok")
+    mock_resp = MagicMock(text="ok", url="https://example.com")
     mock_resp.raise_for_status.return_value = None
     with patch("backend.corelibs.red.requests.get", return_value=mock_resp) as mock_get:
         assert core.obtener_url("https://example.com") == "ok"

--- a/src/tests/unit/test_red.py
+++ b/src/tests/unit/test_red.py
@@ -11,6 +11,14 @@ def test_obtener_url_sin_whitelist(monkeypatch):
         mock_get.assert_not_called()
 
 
+def test_obtener_url_whitelist_vacia(monkeypatch):
+    monkeypatch.setenv("COBRA_HOST_WHITELIST", "")
+    with patch("backend.corelibs.red.requests.get") as mock_get:
+        with pytest.raises(ValueError):
+            core.obtener_url("https://example.com")
+        mock_get.assert_not_called()
+
+
 def test_obtener_url_redireccion_http(monkeypatch):
     monkeypatch.setenv("COBRA_HOST_WHITELIST", "example.com")
     mock_resp = MagicMock(text="ok", url="http://example.com")


### PR DESCRIPTION
## Resumen
- Exigir que `COBRA_HOST_WHITELIST` esté definida y contenga hosts válidos.
- Validar siempre el host de la respuesta, incluso sin redirecciones.
- Documentar la necesidad de la variable de entorno y ampliar pruebas para cubrir errores por lista blanca ausente o vacía.

## Pruebas
- `pytest --no-cov src/tests/unit/test_nativos_io.py src/tests/unit/test_red.py -q`
- `pytest src/tests/unit/test_corelibs.py` *(falla: ImportError: cannot import name 'NodoListaComprehension')*


------
https://chatgpt.com/codex/tasks/task_e_689f30aa74c88327afc124184200fd27