### PR TITLE
feat: add benchmarks command

### DIFF
--- a/src/cobra/cli/commands/benchmarks_cmd.py
+++ b/src/cobra/cli/commands/benchmarks_cmd.py
@@ -1,45 +1,100 @@
+"""Comando CLI para ejecutar scripts de benchmarks."""
+
 from argparse import ArgumentParser
+import json
+import subprocess
+import sys
+from pathlib import Path
 from typing import Any
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
 from cobra.cli.utils.argument_parser import CustomArgumentParser
-from cobra.cli.utils.messages import mostrar_error
+from cobra.cli.utils.messages import mostrar_error, mostrar_info
+
 
 class BenchmarksCommand(BaseCommand):
     """Comando para ejecutar benchmarks."""
-    
+
     name = "benchmarks"
-    
+
     def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
         """Registra los argumentos del subcomando.
-        
+
         Args:
             subparsers: Objeto para registrar el subcomando
-            
+
         Returns:
             CustomArgumentParser: El parser configurado para el subcomando
         """
         parser = subparsers.add_parser(
             self.name, help=_("Ejecuta benchmarks")
         )
+        parser.add_argument(
+            "--backend",
+            "-b",
+            help=_("Filtra por backend específico"),
+        )
+        parser.add_argument(
+            "--iteraciones",
+            "-n",
+            type=int,
+            default=1,
+            help=_("Número de veces que se ejecutará el benchmark"),
+        )
         parser.set_defaults(cmd=self)
         return parser
-        
+
     def run(self, args: Any) -> int:
         """Ejecuta la lógica del comando.
-        
+
         Args:
             args: Argumentos parseados del comando
-            
+
         Returns:
             int: Código de salida (0 para éxito, otro valor para error)
         """
         try:
-            # TODO: Implementar lógica de benchmarks aquí
+            script = (
+                Path(__file__).resolve().parents[4]
+                / "scripts"
+                / "benchmarks"
+                / "run_benchmarks.py"
+            )
+            if not script.exists():
+                raise FileNotFoundError(script)
+
+            cmd = [sys.executable, str(script)]
+            results: list[dict[str, Any]] = []
+            for _i in range(max(1, getattr(args, "iteraciones", 1))):
+                out = subprocess.check_output(cmd, text=True)
+                data = json.loads(out)
+                backend = getattr(args, "backend", None)
+                if backend:
+                    data = [d for d in data if d.get("backend") == backend]
+                results.extend(data)
+
+            for res in results:
+                mostrar_info(
+                    _("{backend}: tiempo {time}s, memoria {mem}KB").format(
+                        backend=res.get("backend", "?"),
+                        time=res.get("time", "?"),
+                        mem=res.get("memory_kb", "?"),
+                    )
+                )
             return 0
-        except Exception as e:
+        except FileNotFoundError:
+            mostrar_error(_("No se encontró el script de benchmarks"))
+            return 2
+        except subprocess.CalledProcessError as err:
+            mostrar_error(_("Error al ejecutar el script: {err}").format(err=err))
+            return 3
+        except json.JSONDecodeError:
+            mostrar_error(_("Salida de benchmark inválida"))
+            return 4
+        except Exception as e:  # pragma: no cover - errores inesperados
             mostrar_error(
                 _("Error durante la ejecución: {error}").format(error=str(e))
             )
             return 1
+

--- a/src/tests/unit/test_benchmarks_cmd.py
+++ b/src/tests/unit/test_benchmarks_cmd.py
@@ -1,0 +1,46 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import cobra.cli.commands.benchmarks_cmd as bm
+
+
+@pytest.mark.timeout(10)
+def test_benchmarks_command_runs(monkeypatch):
+    """El comando ejecuta el script y muestra resultados."""
+    fake_out = json.dumps([
+        {"backend": "python", "time": 0.1, "memory_kb": 1}
+    ])
+    called: dict[str, list[str]] = {}
+
+    def fake_check_output(cmd, text=True):  # pragma: no cover - reemplazo
+        called["cmd"] = cmd
+        return fake_out
+
+    mensajes: list[str] = []
+    monkeypatch.setattr(bm.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(bm, "mostrar_info", lambda m: mensajes.append(m))
+
+    rc = bm.BenchmarksCommand().run(SimpleNamespace(backend=None, iteraciones=1))
+
+    assert rc == 0
+    assert "run_benchmarks.py" in called["cmd"][1]
+    assert any("python" in m for m in mensajes)
+
+
+@pytest.mark.timeout(10)
+def test_benchmarks_command_handles_errors(monkeypatch):
+    """Devuelve código adecuado si el script falla."""
+    def fake_check_output(cmd, text=True):  # pragma: no cover - reemplazo
+        raise bm.subprocess.CalledProcessError(1, cmd)
+
+    errores: list[str] = []
+    monkeypatch.setattr(bm.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(bm, "mostrar_error", lambda m: errores.append(m))
+
+    rc = bm.BenchmarksCommand().run(SimpleNamespace(backend=None, iteraciones=1))
+
+    assert rc == 3
+    assert errores
+


### PR DESCRIPTION
## Summary
- run benchmark scripts from CLI
- support backend filtering and multiple iterations
- add unit tests for benchmarks command

## Testing
- `pytest src/tests/unit/test_benchmarks_cmd.py -q --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_689f375bd08c8327b35d80da6b02c302