### PR TITLE
Restringir reintentos a solicitudes GET en CobraHubClient

### DIFF
--- a/src/cobra/cli/cobrahub_client.py
+++ b/src/cobra/cli/cobrahub_client.py
@@ -45,7 +45,8 @@ class CobraHubClient:
         retry_strategy = Retry(
             total=self.MAX_RETRIES,
             backoff_factor=0.5,
-            status_forcelist=[500, 502, 503, 504]
+            status_forcelist=[500, 502, 503, 504],
+            allowed_methods=["GET"],
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         session.mount("https://", adapter)

--- a/src/tests/unit/test_cobrahub_retry.py
+++ b/src/tests/unit/test_cobrahub_retry.py
@@ -1,0 +1,25 @@
+import pytest
+import requests
+import urllib3
+
+from cobra.cli.cobrahub_client import CobraHubClient
+
+
+@pytest.mark.timeout(5)
+def test_post_request_is_not_retried(monkeypatch):
+    client = CobraHubClient()
+    counter = {"calls": 0}
+
+    def fake_urlopen(self, method, url, *args, **kwargs):
+        counter["calls"] += 1
+        raise urllib3.exceptions.ProtocolError("boom")
+
+    monkeypatch.setattr(
+        urllib3.connectionpool.HTTPConnectionPool, "urlopen", fake_urlopen
+    )
+
+    with pytest.raises(requests.exceptions.ConnectionError):
+        client.session.post("https://example.com")
+
+    assert counter["calls"] == 1
+


### PR DESCRIPTION
## Resumen
- Limita los reintentos automáticos de CobraHubClient a métodos GET.
- Agrega prueba que asegura que las solicitudes POST fallidas no se reintentan.

## Pruebas
- `PYTHONPATH=src pytest src/tests/unit/test_cobrahub_retry.py -q --override-ini=addopts=`


------
https://chatgpt.com/codex/tasks/task_e_689f3adfcc208327910db7a4bacd8ae3