### PR TITLE
refactor: endurece unpickling de cache

### DIFF
--- a/src/core/ast_cache.py
+++ b/src/core/ast_cache.py
@@ -7,20 +7,90 @@ import sys
 # perezosa dentro de las funciones para evitar dependencias circulares
 # cuando estos módulos utilizan a su vez la caché incremental.
 
+# TODO: considerar reemplazar ``pickle`` por un formato más seguro como
+# ``json`` o ``msgpack`` para el almacenamiento de la caché.
+
+
+AST_NODE_CLASS_NAMES = [
+    "NodoAST",
+    "NodoAsignacion",
+    "NodoHolobit",
+    "NodoCondicional",
+    "NodoBucleMientras",
+    "NodoFor",
+    "NodoLista",
+    "NodoDiccionario",
+    "NodoListaComprehension",
+    "NodoDiccionarioComprehension",
+    "NodoListaTipo",
+    "NodoDiccionarioTipo",
+    "NodoDecorador",
+    "NodoFuncion",
+    "NodoMetodoAbstracto",
+    "NodoInterface",
+    "NodoClase",
+    "NodoEnum",
+    "NodoMetodo",
+    "NodoInstancia",
+    "NodoAtributo",
+    "NodoLlamadaMetodo",
+    "NodoOperacionBinaria",
+    "NodoOperacionUnaria",
+    "NodoValor",
+    "NodoIdentificador",
+    "NodoLlamadaFuncion",
+    "NodoHilo",
+    "NodoRetorno",
+    "NodoYield",
+    "NodoEsperar",
+    "NodoOption",
+    "NodoRomper",
+    "NodoContinuar",
+    "NodoPasar",
+    "NodoAssert",
+    "NodoDel",
+    "NodoGlobal",
+    "NodoNoLocal",
+    "NodoLambda",
+    "NodoWith",
+    "NodoThrow",
+    "NodoTryCatch",
+    "NodoImport",
+    "NodoUsar",
+    "NodoImportDesde",
+    "NodoExport",
+    "NodoPara",
+    "NodoProyectar",
+    "NodoTransformar",
+    "NodoGraficar",
+    "NodoImprimir",
+    "NodoMacro",
+    "NodoPattern",
+    "NodoGuard",
+    "NodoCase",
+    "NodoSwitch",
+    "NodoBloque",
+    "NodoDeclaracion",
+    "NodoModulo",
+    "NodoExpresion",
+]
+
+TOKEN_CLASS_NAMES = ["Token", "TipoToken"]
+
 
 class SafeUnpickler(pickle.Unpickler):
     """Deserializador seguro que limita los módulos y clases permitidos."""
 
-    # Módulos de los que se permitirá cargar clases
-    ALLOWED_MODULES = {
-        "core.ast_nodes",
-        "cobra.core.ast_nodes",
-        "cobra.core.lexer",
-        "builtins",
+    ALLOWED_CLASSES = {
+        *((m, n) for m in ("core.ast_nodes", "cobra.core.ast_nodes") for n in AST_NODE_CLASS_NAMES),
+        *(("cobra.core.lexer", n) for n in TOKEN_CLASS_NAMES),
     }
 
+    # Módulos permitidos explícitamente
+    ALLOWED_MODULES = {module for module, _ in ALLOWED_CLASSES}
+
     def find_class(self, module: str, name: str):
-        if module not in self.ALLOWED_MODULES:
+        if (module, name) not in self.ALLOWED_CLASSES:
             raise pickle.UnpicklingError(f"Importación no permitida: {module}.{name}")
         __import__(module)
         return getattr(sys.modules[module], name)

--- a/src/tests/unit/test_ast_cache_security.py
+++ b/src/tests/unit/test_ast_cache_security.py
@@ -1,0 +1,46 @@
+import importlib
+import os
+import pickle
+import sys
+
+import pytest
+
+
+def _prepare_cache(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("COBRA_AST_CACHE", str(cache_dir))
+    if "core.ast_cache" in sys.modules:
+        importlib.reload(sys.modules["core.ast_cache"])
+    return cache_dir
+
+
+def _escribir_malicioso(ruta):
+    with open(ruta, "wb") as f:
+        f.write(pickle.dumps(eval))
+
+
+def test_carga_ast_malicioso(monkeypatch, tmp_path):
+    _prepare_cache(monkeypatch, tmp_path)
+    from core.ast_cache import _ruta_cache, obtener_ast
+
+    codigo = "var x = 1"
+    ruta = _ruta_cache(codigo)
+    os.makedirs(os.path.dirname(ruta), exist_ok=True)
+    _escribir_malicioso(ruta)
+
+    with pytest.raises(pickle.UnpicklingError):
+        obtener_ast(codigo)
+
+
+def test_carga_tokens_maliciosos(monkeypatch, tmp_path):
+    _prepare_cache(monkeypatch, tmp_path)
+    from core.ast_cache import _ruta_tokens, obtener_tokens
+
+    codigo = "var x = 1"
+    ruta = _ruta_tokens(codigo)
+    os.makedirs(os.path.dirname(ruta), exist_ok=True)
+    _escribir_malicioso(ruta)
+
+    with pytest.raises(pickle.UnpicklingError):
+        obtener_tokens(codigo)
+


### PR DESCRIPTION
## Summary
- refuerza SafeUnpickler limitando módulos y clases permitidas
- añade tests que detectan archivos de cache maliciosos

## Testing
- `pytest -c /dev/null src/tests/unit/test_ast_cache.py src/tests/unit/test_token_cache.py src/tests/unit/test_ast_cache_security.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f430f3a148327ae2f4c8cd6005cef