### PR TITLE
Valida nombres de paquetes en usar_loader

### DIFF
--- a/src/tests/unit/test_usar_loader_validation.py
+++ b/src/tests/unit/test_usar_loader_validation.py
@@ -1,0 +1,10 @@
+import pytest
+
+from cobra import usar_loader
+
+
+@pytest.mark.parametrize("nombre", ["-malicious", "requests==2.0", "../etc/passwd"])
+def test_obtener_modulo_rechaza_nombres_invalidos(nombre):
+    with pytest.raises(ValueError):
+        usar_loader.obtener_modulo(nombre)
+


### PR DESCRIPTION
## Summary
- valida y sanea nombres de paquetes antes de usarlos
- comprueba de nuevo el nombre antes de instalar con pip
- añade pruebas que rechazan nombres malformados

## Testing
- `ruff check src/cobra/usar_loader.py src/tests/unit/test_usar_loader_validation.py`
- `pytest src/tests/unit/test_usar_loader_validation.py src/tests/unit/test_usar.py -o addopts="--cov=src/cobra/usar_loader.py --cov-report=term-missing --cov-report=xml --cov-fail-under=0"`

------
https://chatgpt.com/codex/tasks/task_e_689f529b57348327a25c1828e3e0e0dc