### PR TITLE
Gestionar temporales en compilación pybind

### DIFF
--- a/src/core/pybind_bridge.py
+++ b/src/core/pybind_bridge.py
@@ -6,12 +6,12 @@ import importlib.machinery
 import importlib.util
 import os
 import tempfile
+import shutil
 from types import ModuleType
 from typing import Dict, Iterable, Optional
 
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import Distribution
-
 
 _cache: Dict[str, ModuleType] = {}
 
@@ -37,32 +37,44 @@ def _es_ruta_permitida(ruta: str) -> bool:
     return False
 
 
-def compilar_extension(nombre: str, codigo: str, directorio: str | None = None,
-                       extra_cflags: Optional[Iterable[str]] = None) -> str:
-    """Compila ``codigo`` como una extensi\u00f3n Python usando ``pybind11``.
+def compilar_extension(
+    nombre: str,
+    codigo: str,
+    directorio: str | None = None,
+    extra_cflags: Optional[Iterable[str]] = None,
+    conservar: bool = False,
+) -> str:
+    """Compila ``codigo`` como una extensión Python usando ``pybind11``.
 
     Se devuelve la ruta absoluta del archivo generado (.so, .pyd, etc.).
+    Si ``conservar`` es ``False`` y no se proporciona ``directorio``, el
+    contenido temporal generado será eliminado al finalizar.
     """
+    cleanup = directorio is None
     if directorio is None:
         directorio = tempfile.mkdtemp()
     cpp = os.path.join(directorio, f"{nombre}.cpp")
     with open(cpp, "w", encoding="utf-8") as fh:
         fh.write(codigo)
 
-    ext = Pybind11Extension(nombre, [cpp],
-                             extra_compile_args=list(extra_cflags or []))
+    ext = Pybind11Extension(
+        nombre, [cpp], extra_compile_args=list(extra_cflags or [])
+    )
     dist = Distribution({"name": nombre, "ext_modules": [ext]})
     cmd = build_ext(dist)
     cmd.build_lib = directorio
     cmd.build_temp = os.path.join(directorio, "temp")
     cmd.finalize_options()
-    cmd.run()
-
-    return os.path.join(directorio, cmd.get_ext_filename(nombre))
+    try:
+        cmd.run()
+        return os.path.join(directorio, cmd.get_ext_filename(nombre))
+    finally:
+        if cleanup and not conservar:
+            shutil.rmtree(directorio, ignore_errors=True)
 
 
 def cargar_extension(ruta: str) -> ModuleType:
-    """Carga la extensi\u00f3n ubicada en ``ruta`` y la almacena en cach\u00e9."""
+    """Carga la extensión ubicada en ``ruta`` y la almacena en caché."""
     path = os.path.abspath(ruta)
     if not _es_ruta_permitida(path):
         raise ValueError(f"Ruta no permitida: {ruta}")
@@ -78,8 +90,19 @@ def cargar_extension(ruta: str) -> ModuleType:
     return _cache[path]
 
 
-def compilar_y_cargar(nombre: str, codigo: str, directorio: str | None = None,
-                      extra_cflags: Optional[Iterable[str]] = None) -> ModuleType:
-    """Compila ``codigo`` y devuelve el m\u00f3dulo resultante."""
-    path = compilar_extension(nombre, codigo, directorio, extra_cflags)
-    return cargar_extension(path)
+def compilar_y_cargar(
+    nombre: str,
+    codigo: str,
+    directorio: str | None = None,
+    extra_cflags: Optional[Iterable[str]] = None,
+    conservar: bool = False,
+) -> ModuleType:
+    """Compila ``codigo`` y devuelve el módulo resultante."""
+    propio = directorio is None
+    path = compilar_extension(
+        nombre, codigo, directorio, extra_cflags, conservar=True
+    )
+    mod = cargar_extension(path)
+    if propio and not conservar:
+        shutil.rmtree(os.path.dirname(path), ignore_errors=True)
+    return mod

--- a/src/tests/unit/test_compilar_extension_cleanup.py
+++ b/src/tests/unit/test_compilar_extension_cleanup.py
@@ -1,0 +1,59 @@
+import sys
+from types import ModuleType
+from pathlib import Path
+import importlib
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+fake_pybind11 = ModuleType('pybind11')
+fake_helpers = ModuleType('pybind11.setup_helpers')
+
+
+class DummyExt:
+    def __init__(self, name, sources, extra_compile_args=None):
+        self.name = name
+        self.sources = sources
+
+
+class DummyCmd:
+    def __init__(self, dist):
+        self.build_lib = ''
+        self.build_temp = ''
+        self.ext_modules = dist.ext_modules
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        Path(self.build_lib).mkdir(parents=True, exist_ok=True)
+        (Path(self.build_lib) / f"{self.ext_modules[0].name}.so").touch()
+
+    def get_ext_filename(self, name: str) -> str:
+        return f"{name}.so"
+
+
+fake_helpers.Pybind11Extension = DummyExt
+fake_helpers.build_ext = DummyCmd
+sys.modules.setdefault('pybind11', fake_pybind11)
+sys.modules.setdefault('pybind11.setup_helpers', fake_helpers)
+
+fake_setuptools = ModuleType('setuptools')
+
+
+class DummyDist:
+    def __init__(self, attrs):
+        self.ext_modules = attrs["ext_modules"]
+
+
+fake_setuptools.Distribution = DummyDist
+sys.modules.setdefault('setuptools', fake_setuptools)
+
+
+def test_compilar_extension_elimina_directorio():
+    import core.pybind_bridge as bridge
+    importlib.reload(bridge)
+
+    path = bridge.compilar_extension('mod', 'codigo')
+    assert not Path(path).exists()
+    assert not Path(path).parent.exists()


### PR DESCRIPTION
## Resumen
- Elimina los directorios temporales generados al compilar extensiones con pybind11, con opción para conservarlos.
- Limpia los artefactos tras `compilar_y_cargar` cuando se usan directorios temporales.
- Añade prueba que confirma la eliminación del directorio temporal tras la compilación.

## Pruebas
- `pytest src/tests/unit/test_compilar_extension_cleanup.py src/tests/unit/test_pybind_bridge_invalid_loader.py src/tests/unit/test_pybind_bridge_paths.py --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_689f579e92e08327a85d71029d793315