### PR TITLE
Ensure src package is included in setuptools discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["src"]
+include = ["src", "cobra*", "core*"]
 
 [project.scripts]
 cobra = "cobra.cli.cli:main"


### PR DESCRIPTION
## Summary
- Include `src` and related patterns in setuptools package discovery

## Testing
- `pip install -e .`
- `python - <<'PY'
import src
print(src.__file__)
PY`
- `cobra --help | head -n 20` *(fails: ImportError: cannot import name 'NodoAsignacion' from partially initialized module 'core.ast_nodes')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_689f5e300414832786939986894ae02c