### PR TITLE
feat: add main entrypoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -51,5 +51,11 @@ def ejecutar_cli(argumentos: Optional[List[str]] = None) -> int:
         logger.error("Error en la ejecución del CLI: %s", str(e))
         return 1
 
-if __name__ == "__main__":
+
+def main() -> None:
+    """Punto de entrada principal para la ejecución del CLI."""
     sys.exit(ejecutar_cli())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add public `main()` that delegates to `ejecutar_cli`

## Testing
- `pip install -e .`
- `pcobra --help` *(falla: cannot import name 'NodoInterface')*
- `pytest -q` *(falla: missing modules like `cli.cli`)*

------
https://chatgpt.com/codex/tasks/task_e_689f5fe3566c8327962253e434a52d1f