### PR TITLE
docs: instrucción para activar entorno y verificar CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,25 @@ pip install -e .
    pip install cobra-lenguaje[big-data]  # soporte para procesamiento distribuido
    ```
 
+### Entorno virtual y verificación
+
+Activa un entorno virtual, registra los puntos de entrada de la CLI y comprueba
+que la instalación funciona correctamente:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Unix/macOS
+.\.venv\Scripts\activate   # Windows
+
+pip install -e .
+
+# (Opcional) ejecutar sin instalar el paquete
+export PYTHONPATH=src  # Unix/macOS
+set PYTHONPATH=src     # Windows PowerShell
+
+cobra --version  # debe mostrar la versión sin errores
+```
+
 6. Copia el archivo ``.env.example`` a ``.env`` y personaliza las rutas o claves
    de ser necesario. Estas variables se cargarán automáticamente al iniciar
    Cobra gracias a ``python-dotenv``:


### PR DESCRIPTION
## Summary
- Añade sección de entorno virtual y verificación rápida en README

## Testing
- `pytest` *(falla: No se pudo importar core: No module named 'cobra'; unrecognized arguments --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_689f5f92ed8c8327952318ccda0492e1