### PR TITLE
Lazy import of Parser in core package

### DIFF
--- a/src/cobra/core/__init__.py
+++ b/src/cobra/core/__init__.py
@@ -14,7 +14,6 @@ from .lexer import (
     InvalidTokenError,
     UnclosedStringError,
 )
-from .parser import Parser, ParserError
 
 __all__ = [
     "Lexer",
@@ -26,3 +25,17 @@ __all__ = [
     "Token",
     "TipoToken",
 ]
+
+
+def __getattr__(name: str):
+    """Importa dinámicamente el analizador cuando se solicita.
+
+    Esto mantiene una importación perezosa del módulo ``parser`` para
+    evitar dependencias circulares y tiempos de carga innecesarios.
+    """
+    if name in {"Parser", "ParserError"}:
+        from . import parser as _parser
+
+        globals().update({"Parser": _parser.Parser, "ParserError": _parser.ParserError})
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- remove eager parser import
- dynamically load Parser and ParserError via __getattr__

## Testing
- `PYTHONPATH=src pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*
- `PYTHONPATH=src python -m cobra.cli.cli --help` *(fails: ImportError: cannot import name 'descargar_modulo' from 'cobra.cli.cobrahub_client')*

------
https://chatgpt.com/codex/tasks/task_e_689f700bcb74832791292469f6ca799a