### PR TITLE
Añadir prueba de importación de la CLI

### DIFF
--- a/src/tests/integration/test_cli_import.py
+++ b/src/tests/integration/test_cli_import.py
@@ -1,0 +1,20 @@
+import subprocess
+
+from core.cobra_config import tiempo_max_transpilacion
+
+
+def test_cli_import_help():
+    """Verifica que la CLI responde y que `tiempo_max_transpilacion` se importa."""
+    # Llamar a la función para garantizar que el módulo se carga sin errores
+    tiempo_max_transpilacion()
+    try:
+        subprocess.run(
+            ["cobra", "--help"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        print("STDOUT:", exc.stdout)
+        print("STDERR:", exc.stderr)
+        raise


### PR DESCRIPTION
## Summary
- test: ensure `cobra --help` ejecuta sin errores de importación

## Testing
- `pytest src/tests/integration/test_cli_import.py -q -o addopts=` (falla: ImportError: cannot import name 'descargar_modulo')

------
https://chatgpt.com/codex/tasks/task_e_689f799a31408327a4bb9ee17e74b5b7