### PR TITLE
chore: bump version to 10.0.9

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -1,6 +1,6 @@
 # Manual del Lenguaje Cobra
 
-Versión 10.0.6
+Versión 10.0.9
 
 Este manual presenta en español los conceptos básicos para programar en Cobra. Se organiza en tareas que puedes seguir paso a paso.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Alphonsus411/pCobra/HEAD?labpath=notebooks/playground.ipynb)
 
 
-Versión 10.0.6
+Versión 10.0.9
 
 [English version available here](README_en.md)
 Cobra es un lenguaje de programación diseñado en español, enfocado en la creación de herramientas, simulaciones y análisis en áreas como biología, computación y astrofísica. Este proyecto incluye un lexer, parser y transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly, lo que permite una mayor versatilidad en la ejecución y despliegue del código escrito en Cobra.
@@ -329,9 +329,9 @@ Los ejecutables precompilados para Cobra se publican en la sección de [Releases
 
 | Versión | Plataforma | Enlace |
 | --- | --- | --- |
-| 10.0.6 | Linux x86_64 | [cobra-linux](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.6/cobra-linux) |
-| 10.0.6 | Windows x86_64 | [cobra.exe](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.6/cobra.exe) |
-| 10.0.6 | macOS arm64 | [cobra-macos](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.6/cobra-macos) |
+| 10.0.9 | Linux x86_64 | [cobra-linux](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.9/cobra-linux) |
+| 10.0.9 | Windows x86_64 | [cobra.exe](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.9/cobra.exe) |
+| 10.0.9 | macOS arm64 | [cobra-macos](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.9/cobra-macos) |
 
 Para comprobar la integridad del archivo descargado calcula su hash SHA256 y compáralo con el publicado:
 
@@ -1270,7 +1270,7 @@ Este proyecto sigue el esquema [SemVer](https://semver.org/lang/es/). Los numero
 
 ## Historial de Cambios
 
-- Versión 10.0.6: actualización de documentación y archivos de configuración. Ver tareas en la sección v1.3 del roadmap.
+- Versión 10.0.9: ajustes en `SafeUnpickler` y restricciones en `corelibs.sistema.ejecutar`.
 
 ## Publicar una nueva versión
 
@@ -1281,8 +1281,8 @@ El workflow [`Deploy Docs`](.github/workflows/pages.yml) generará la documentac
 Consulta la [guía de lanzamiento](docs/release.md) para más detalles sobre el etiquetado, secretos y el flujo de la pipeline.
 
 ```bash
-git tag v10.0.6
-git push origin v10.0.6
+git tag v10.0.9
+git push origin v10.0.9
 ```
 
 Para más información consulta el [CHANGELOG](CHANGELOG.md) y la [configuración de GitHub Actions](.github/workflows).

--- a/README_en.md
+++ b/README_en.md
@@ -2,7 +2,7 @@
 [![Codecov](https://codecov.io/gh/Alphonsus411/pCobra/branch/master/graph/badge.svg)](https://codecov.io/gh/Alphonsus411/pCobra)
 [![Stable release](https://img.shields.io/github/v/release/Alphonsus411/pCobra?label=stable)](https://github.com/Alphonsus411/pCobra/releases/latest)
 
-Version 10.0.6
+Version 10.0.9
 
 Cobra is a programming language designed in Spanish, aimed at creating tools, simulations and analyses in fields such as biology, computing and astrophysics. This project includes a lexer, parser and transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C and WebAssembly, allowing greater versatility when running and deploying Cobra code.
 

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -1,7 +1,7 @@
 Manual de Cobra
 ===============
 
-Versión 10.0.6
+Versión 10.0.9
 
 Este documento resume la sintaxis y los elementos fundamentales del lenguaje
 Cobra. Incluye ejemplos de uso idiomático, limitaciones de los backends y

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ sys.path.insert(0, str(ROOT_DIR))
 project = 'Proyecto Cobra'
 copyright = f'{datetime.now().year}, Adolfo González Hernández'
 author = 'Adolfo González Hernández'
-release = '10.0.6'
+release = '10.0.9'
 
 # -- General configuration ---------------------------------------------------
 extensions = [

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -8,9 +8,9 @@ Puedes obtener binarios precompilados desde la sección de [Releases](https://gi
 
 | Versión | Plataforma | Enlace |
 | --- | --- | --- |
-| 10.0.6 | Linux x86_64 | [cobra-linux](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.6/cobra-linux) |
-| 10.0.6 | Windows x86_64 | [cobra.exe](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.6/cobra.exe) |
-| 10.0.6 | macOS arm64 | [cobra-macos](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.6/cobra-macos) |
+| 10.0.9 | Linux x86_64 | [cobra-linux](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.9/cobra-linux) |
+| 10.0.9 | Windows x86_64 | [cobra.exe](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.9/cobra.exe) |
+| 10.0.9 | macOS arm64 | [cobra-macos](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.9/cobra-macos) |
 
 Para verificar la integridad del archivo descargado calcula su hash SHA256 y compáralo con el valor publicado:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cobra-lenguaje"
-version = "10.0.7a0"
+version = "10.0.9"
 description = "Un lenguaje de programación en español para simulaciones y más."
 authors = [ {name = "Adolfo González Hernández", email = "adolfogonzal@gmail.com"} ]
 readme = "README.md"

--- a/src/jupyter_kernel/__init__.py
+++ b/src/jupyter_kernel/__init__.py
@@ -19,7 +19,7 @@ def _get_version() -> str:
     try:
         return version("cobra-lenguaje")
     except PackageNotFoundError:
-        return "10.0.6"
+        return "10.0.9"
 
 
 __version__ = _get_version()

--- a/src/tests/unit/test_cli_plugins_cmd.py
+++ b/src/tests/unit/test_cli_plugins_cmd.py
@@ -10,7 +10,7 @@ from cli.plugin_registry import limpiar_registro
 
 class DummyPlugin(PluginCommand):
     name = "dummy"
-    version = "10.0.6"
+    version = "10.0.9"
 
     def register_subparser(self, subparsers):
         pass
@@ -43,7 +43,7 @@ def test_cli_plugins_muestra_registro():
     with patch("cli.plugin.entry_points", return_value=importlib.metadata.EntryPoints((ep,))):
         with patch("sys.stdout", new_callable=StringIO) as out:
             main(["plugins"])
-    assert "dummy 10.0.6" in out.getvalue().strip()
+    assert "dummy 10.0.9" in out.getvalue().strip()
 
 
 def test_cli_plugin_ejemplo_hola():


### PR DESCRIPTION
## Summary
- update documentation headers and download links to version 10.0.9
- synchronize project version in pyproject and auxiliary files

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68a184c41e288327942de05db01d4d55