### PR TITLE
docs: actualiza requerimiento de Python a 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Mejoras de empaquetado que simplifican la distribución.
 - Integración de notebooks de ejemplo en el paquete.
 - Otros ajustes menores.
-- Requisito mínimo de Python actualizado a la versión 3.8.
+- Requisito mínimo de Python actualizado a la versión 3.9.
 
 ## v8.0.0 - 2025-07-07
 - Incremento de versión principal a 8.0.0.

--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -7,7 +7,7 @@ Este manual presenta en español los conceptos básicos para programar en Cobra.
 ## 1. Preparación del entorno
 
 1. Clona el repositorio y entra en el directorio `pCobra`.
-2. Crea y activa un entorno virtual de **Python 3.8 o superior**.
+2. Crea y activa un entorno virtual de **Python 3.9 o superior**.
 3. Instala las dependencias con `pip install -r requirements-dev.txt`.
    Aseg\u00farate tambi\u00e9n de tener disponible la herramienta `cbindgen`:
 
@@ -20,7 +20,7 @@ Este manual presenta en español los conceptos básicos para programar en Cobra.
 
 ### Instalación con pipx
 
-Puedes instalar Cobra utilizando [pipx](https://pypa.github.io/pipx/), una herramienta que permite ejecutar aplicaciones de Python aisladas y requiere Python 3.8 o superior.
+Puedes instalar Cobra utilizando [pipx](https://pypa.github.io/pipx/), una herramienta que permite ejecutar aplicaciones de Python aisladas y requiere Python 3.9 o superior.
 
 ```bash
 pipx install cobra-lenguaje

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ PYTHONPATH=$PWD/src python -c "from src.core.main import main; main()"
 
 ### Instalación con pipx
 
-[pipx](https://pypa.github.io/pipx/) es una herramienta para instalar y ejecutar aplicaciones de Python de forma aislada y requiere Python 3.6 o superior. Para instalar Cobra con pipx ejecuta:
+[pipx](https://pypa.github.io/pipx/) es una herramienta para instalar y ejecutar aplicaciones de Python de forma aislada y requiere Python 3.9 o superior. Para instalar Cobra con pipx ejecuta:
 
 ```bash
 pipx install cobra-lenguaje

--- a/README_en.md
+++ b/README_en.md
@@ -151,7 +151,7 @@ PYTHONPATH=$PWD/src python -c "from src.core.main import main; main()"
 
 ### Installation with pipx
 
-[pipx](https://pypa.github.io/pipx/) is a tool to install and run Python applications in isolation and requires Python 3.6 or higher. To install Cobra with pipx run:
+[pipx](https://pypa.github.io/pipx/) is a tool to install and run Python applications in isolation and requires Python 3.9 or higher. To install Cobra with pipx run:
 
 ```bash
 pipx install cobra-lenguaje


### PR DESCRIPTION
## Summary
- indica Python 3.9 como versión mínima en el manual y la documentación
- actualiza changelog para reflejar el nuevo requisito

## Testing
- `PYTHONPATH=$PWD/src:$PWD pytest` (errores: ModuleNotFoundError: No module named 'cli.cli')

------
https://chatgpt.com/codex/tasks/task_e_68a186f716108327b95096625f348a9f