### PR TITLE
docs: actualizar enlace a ejemplos de Cobra

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Cobra es un lenguaje de programación diseñado en español, enfocado en la crea
 
 ## Ejemplos
 
-Proyectos de demostracion disponibles en [cobra-ejemplos](https://github.com/tuusuario/cobra-ejemplos).
+Proyectos de demostracion disponibles en [cobra-ejemplos](https://github.com/Alphonsus411/pCobra/tree/master/examples).
 Este repositorio incluye ejemplos básicos en la carpeta `examples/`, por
 ejemplo `examples/funciones_principales.co` que muestra condicionales, bucles y
 definición de funciones en Cobra.

--- a/README_en.md
+++ b/README_en.md
@@ -40,7 +40,7 @@ Cobra is a programming language designed in Spanish, aimed at creating tools, si
 
 ## Examples
 
-Demo projects are available in [cobra-ejemplos](https://github.com/tuusario/cobra-ejemplos). This repository includes basic examples in the `examples/` folder, for instance `examples/funciones_principales.co` which shows conditionals, loops and function definitions in Cobra. For interactive examples check the notebooks in `notebooks/casos_reales/`.
+Demo projects are available in [cobra-ejemplos](https://github.com/Alphonsus411/pCobra/tree/master/examples). This repository includes basic examples in the `examples/` folder, for instance `examples/funciones_principales.co` which shows conditionals, loops and function definitions in Cobra. For interactive examples check the notebooks in `notebooks/casos_reales/`.
 
 ### Advanced examples
 

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -65,4 +65,4 @@ Cobra fue creado con la idea de facilitar la programacion en español, optimizan
 Repositorio de Ejemplos
 ----------------------
 
-Los proyectos de demostracion se encuentran en `cobra-ejemplos <https://github.com/tuusuario/cobra-ejemplos>`_.
+Los proyectos de demostracion se encuentran en `cobra-ejemplos <https://github.com/Alphonsus411/pCobra/tree/master/examples>`_.


### PR DESCRIPTION
## Summary
- corrige enlaces en README y docs para apuntar a los ejemplos oficiales

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68a1896762f08327889e177c127787d1