### PR TITLE
docs: modern plugin packaging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1210,15 +1210,18 @@ mypy src
 
 La CLI puede ampliarse mediante plugins externos. Desde esta versión todo el SDK
 de plugins se encuentra en ``src.cli.plugin``. Para crear uno, define una clase
-que herede de ``PluginCommand`` e incluye una entrada en el grupo
-``cobra.plugins`` de tu ``setup.py``:
+que herede de ``PluginCommand`` y declara el ``entry point`` en la sección
+``[project.entry-points."cobra.plugins"]`` de tu ``pyproject.toml``. También es
+necesario configurar un ``[build-system]`` moderno, como el basado en
+``setuptools``:
 
-```python
-entry_points={
-    'cobra.plugins': [
-        'saludo = mi_paquete.mi_modulo:SaludoCommand',
-    ],
-}
+```toml
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project.entry-points."cobra.plugins"]
+saludo = "mi_paquete.mi_modulo:SaludoCommand"
 ```
 
 Tras instalar el paquete con `pip install -e .`, Cobra detectará automáticamente

--- a/frontend/docs/plugin_dev.rst
+++ b/frontend/docs/plugin_dev.rst
@@ -24,7 +24,7 @@ Estructura básica
 .. code-block:: text
 
    mi_plugin/
-       setup.py
+       pyproject.toml
        mi_plugin/
            __init__.py
            hola.py
@@ -49,26 +49,24 @@ En ``hola.py`` se define la clase del comando:
        def run(self, args):
            print("¡Hola desde un plugin!")
 
-Registro con ``entry_points``
+Registro con ``entry points``
 -----------------------------
 
-Para que Cobra descubra el plugin se declara un ``entry_point`` en
-``setup.py``:
+Para que Cobra descubra el plugin se declara un ``entry point`` en
+``pyproject.toml`` y se configura un ``build-system`` moderno:
 
-.. code-block:: python
+.. code-block:: toml
 
-   from setuptools import setup
+   [build-system]
+   requires = ["setuptools>=61.0"]
+   build-backend = "setuptools.build_meta"
 
-   setup(
-       name="mi-plugin",
-       version="1.0",
-       py_modules=["mi_plugin.hola"],
-       entry_points={
-           'cobra.plugins': [
-               'hola = mi_plugin.hola:HolaCommand',
-           ],
-       },
-   )
+   [project]
+   name = "mi-plugin"
+   version = "1.0"
+
+   [project.entry-points."cobra.plugins"]
+   hola = "mi_plugin.hola:HolaCommand"
 
 Carga dinámica segura
 ---------------------
@@ -91,3 +89,6 @@ para verificar que Cobra detecta tu plugin:
    pip install -e .
    cobra plugins   # muestra los metadatos registrados
    cobra hola      # ejecuta el nuevo subcomando
+
+Para conocer la descripción completa de la interfaz disponible consulta
+:doc:`plugin_sdk`.

--- a/frontend/docs/plugin_sdk.rst
+++ b/frontend/docs/plugin_sdk.rst
@@ -52,15 +52,17 @@ Ejemplo de implementación
 Registro a través de ``entry_points``
 ------------------------------------
 
-Para que Cobra cargue el plugin se declara un ``entry_point`` en ``setup.py``:
+Para que Cobra cargue el plugin se declara un ``entry point`` en
+``pyproject.toml`` y se define un ``build-system`` compatible con PEP 517::
 
-.. code-block:: python
+.. code-block:: toml
 
-   entry_points={
-       'cobra.plugins': [
-           'hola = mi_plugin.hola:HolaCommand',
-       ],
-   }
+   [build-system]
+   requires = ["setuptools>=61.0"]
+   build-backend = "setuptools.build_meta"
+
+   [project.entry-points."cobra.plugins"]
+   hola = "mi_plugin.hola:HolaCommand"
 
 Gestión de versiones
 --------------------
@@ -90,4 +92,7 @@ muestra su contenido:
 
    for nombre, version in obtener_registro().items():
        print(nombre, version)
+
+Para un recorrido paso a paso sobre cómo crear plugins consulta
+:doc:`plugin_dev`.
 

--- a/frontend/docs/plugins.rst
+++ b/frontend/docs/plugins.rst
@@ -6,6 +6,9 @@ un "entry point" en el grupo ``cobra.plugins``. Durante el arranque la
 aplicación busca dichos entry points e instancia cada plugin. Todas las
 utilidades necesarias se importan desde ``src.cli.plugin``.
 
+Para un tutorial detallado sobre cómo desarrollar plugins consulta
+:doc:`plugin_dev`.
+
 Al cargarse, la información de nombre y versión se almacena en un registro
 interno accesible desde ``src.cli.plugin``. Para consultar qué
 plugins están disponibles se proporciona el subcomando ``plugins``::
@@ -42,15 +45,17 @@ A continuación se muestra cómo crear un plugin sencillo utilizando
           def run(self, args):
               print("¡Hola desde un plugin!")
 
-3. **Declara el entry point** en tu ``setup.py`` para que Cobra lo descubra:
+3. **Declara el entry point** en ``pyproject.toml`` y configura un sistema de
+   construcción moderno:
 
-   .. code-block:: python
+   .. code-block:: toml
 
-      entry_points={
-          'cobra.plugins': [
-              'saludo = mi_paquete.mi_plugin:SaludoCommand',
-          ],
-      }
+      [build-system]
+      requires = ["setuptools>=61.0"]
+      build-backend = "setuptools.build_meta"
+
+      [project.entry-points."cobra.plugins"]
+      saludo = "mi_paquete.mi_plugin:SaludoCommand"
 
 4. **Instala el paquete** en modo editable con ``pip install -e .`` para que
    el comando quede disponible.


### PR DESCRIPTION
## Summary
- document plugin entry points using pyproject.toml in README and plugin guides
- describe modern build-system configuration for plugins
- cross-link plugin development documentation for consistency

## Testing
- `pytest` *(fails: No module named 'core'; unrecognized arguments --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68a19f9644b08327ae923e3e173c1352