### PR TITLE
docs: elimina guía de contribución duplicada

### DIFF
--- a/docs/contribucion.md
+++ b/docs/contribucion.md
@@ -1,4 +1,0 @@
-# Guía de Contribución
-
-Esta guía se ha movido a [../CONTRIBUTING.md](../CONTRIBUTING.md).
-Consulta ese archivo para instrucciones actualizadas sobre cómo colaborar, abrir issues y enviar pull requests.


### PR DESCRIPTION
## Summary
- remove redundant docs/contribucion.md that redirected to CONTRIBUTING.md

## Testing
- `PYTHONPATH=$PWD/src:$PWD pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68a1b5b79c6883278db47a30b10b63c1