### PR TITLE
docs: corrige fechas del changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v10.0.9 - 2025-07-29
+## v10.0.9 - 2025-08-17
 - Ajuste en `SafeUnpickler` para aceptar los módulos `core.ast_nodes` y `cobra.core.ast_nodes`.
 - `corelibs.sistema.ejecutar` ahora exige una lista blanca de comandos
   mediante el parámetro `permitidos` o la variable de entorno
@@ -6,33 +6,31 @@
   `ValueError` y la lista de la variable de entorno se fija al importar
   el módulo, evitando modificaciones en tiempo de ejecución.
 
-## v10.0.8 - 2025-07-28
-- Actualización de dependencias a versiones estables recientes (numpy, scipy, requests, PyYAML, entre otras).
+## v10.0.8 - Pendiente de liberación
+- Nota: versión en desarrollo, sin cambios liberados.
 
-## v10.0.7 - 2025-07-27
-- Corregido un desbordamiento de pila al resolver variables que almacenaban
-  nodos en operaciones como ``x + y``.
+## v10.0.7 - Pendiente de liberación
+- Nota: versión en desarrollo, sin cambios liberados.
 
 ## v10.0.6 - 2025-07-26
 - Actualización de documentación y archivos de configuración.
 
-## v10.0.0 - 2025-08-15
+## v10.0.0 - 2025-07-25
 - Incremento de versión principal a 10.0.0.
 - Actualización de documentación y ejemplos.
 
-## v9.1.0 - 2025-07-20
+## v9.1.0 - 2025-07-16
 - Incremento de versión menor a 9.1.0.
 - Actualización de documentación y ejemplos.
 - Ajustes en el empaquetado y generación de binarios.
 
 ## v9.0.0 - 2025-07-13
-- Cambios pendientes.
 - Mejoras de empaquetado que simplifican la distribución.
 - Integración de notebooks de ejemplo en el paquete.
 - Otros ajustes menores.
 - Requisito mínimo de Python actualizado a la versión 3.9.
 
-## v8.0.0 - 2025-07-07
+## v8.0.0 - 2025-07-08
 - Incremento de versión principal a 8.0.0.
 - Documentación y pruebas actualizadas.
 
@@ -40,72 +38,72 @@
 - Incremento de versión menor a 7.2.0.
 - Documentación y pruebas actualizadas.
 
-## v7.1.0 - 2025-07-05
+## v7.1.0 - 2025-07-06
 - Se actualiza la versión del proyecto y del kernel de Jupyter.
 - Documentación actualizada con nuevas referencias de versión.
 
-## v7.0.0 - 2025-07-04
+## v7.0.0 - 2025-07-06
 - Se incrementa la versión principal del proyecto.
 - Documentación y pruebas adaptadas a la nueva versión.
 
-## v6.0.0 - 2025-07-03
+## v6.0.0 - 2025-07-04
 - Actualización mayor del lenguaje Cobra y de las herramientas de desarrollo.
 - Documentación reorganizada con nuevos ejemplos.
 - Integración de procesos de lanzamiento automatizados a través de GitHub Actions.
 - Los transpiladores exponen el método `generate_code` y permiten guardar el resultado con `save_file`.
 
 ## v5.6.3 - 2025-07-02
-- Cambios pendientes.
+- Ajustes de documentación y versión.
 
-## v5.6.1 - 2025-07-02
-- Cambios pendientes.
+## v5.6.2 - 2025-07-02
+- Actualización de versión a 5.6.2 y ajustes de documentación y pruebas.
 
-## v5.6 - 2025-06-29 - actualizacion de version
+## v5.6 - 2025-06-29
 - Paquete actualizado a la versión 5.6.
 - Documentación y kernel reflejan la nueva versión.
 - Prueba de plugins ajustada a "dummy 5.6".
 
-## v5.5 - 2025-07-07 - actualizacion de version
+## v5.5 - 2025-06-29
 - Paquete actualizado a la versión 5.5.
 - Documentación y kernel reflejan la nueva versión.
 - Prueba de plugins ajustada a "dummy 5.5".
 
-## v5.4 - 2025-07-06 - actualizacion de version
+## v5.4 - 2025-06-29
 - Paquete actualizado a la versión 5.4.
 - Documentación y kernel reflejan la nueva versión.
 - Prueba de plugins ajustada a "dummy 5.4".
 
-## v5.2 - 2025-07-05 - actualizacion de version
+## v5.2 - 2025-06-29
 - Paquete actualizado a la versión 5.2.
 - Documentación y kernel reflejan la nueva versión.
 - Prueba de plugins ajustada a "dummy 5.2".
 
-## v5.1 - 2025-07-04 - actualizacion de version
+## v5.1 - 2025-06-28
 - Paquete actualizado a la versión 5.1.
 - Documentación y kernel reflejan la nueva versión.
 - Prueba de plugins ajustada a "dummy 5.1".
 
-## v5.0 - 2025-07-03 - actualizacion de version
+## v5.0 - 2025-06-28
 - Paquete actualizado a la versión 5.0.
 - Documentación y kernel reflejan la nueva versión.
 - Prueba de plugins ajustada a "dummy 5.0".
 
-## v4.6 - 2025-07-02 - actualizacion de version
+## v4.6 - 2025-06-28
 - Paquete actualizado a la versión 4.6.
 - Documentación y kernel reflejan la nueva versión.
 - Prueba de plugins ajustada a "dummy 4.6".
 
-## v4.5 - 2025-07-01 - actualizacion de version
+## v4.5 - 2025-06-28
 - Paquete actualizado a la versión 4.5.
 - Documentación y kernel reflejan la nueva versión.
 - Prueba de plugins ajustada a "dummy 4.5".
 
-## v4.4 - 2025-06-29 - actualizacion de version
+## v4.4 - 2025-06-28
 - Paquete actualizado a la versión 4.4.
 - Documentación y kernel reflejan la nueva versión.
 - Prueba de plugins ajustada a "dummy 4.4".
 
-## v4.3 - 2025-06-28 - actualizacion de version
+## v4.3 - 2025-06-28
 - Paquete actualizado a la versión 4.3.
 - Documentación y kernel reflejan la nueva versión.
 - Prueba de plugins ajustada a "dummy 4.3".
@@ -120,13 +118,13 @@
 - Documentación y kernel reflejan la nueva versión.
 - Prueba de plugins ajustada a "dummy 2.2".
 
-## v2.1 - 2025-07-15
+## v2.1 - 2025-06-27
 - Actualización del paquete a la versión 2.1.
 - Nuevos comandos `init` y `package`.
 - Incorporación del puente ctypes y del helper de importación de transpiladores.
 - Documentación y kernel actualizados.
 
-## v2.0 - 2025-07-01
+## v2.0 - 2025-06-26
 - Actualización de la versión del paquete a 2.0.
 - Documentación y archivos de configuración actualizados a la versión 2.0.
 - El kernel de Jupyter refleja la nueva versión.


### PR DESCRIPTION
## Summary
- corrige fechas y orden de versiones en `CHANGELOG.md`
- marca versiones pendientes de liberación y documenta cambios reales

## Testing
- `pytest` *(falla: unrecognized arguments --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c4d4ccec8327a9a1f95fe5921ab8