### PR TITLE
Actualizar enlaces que referían a master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Proyecto Cobra
-[![Codecov](https://codecov.io/gh/Alphonsus411/pCobra/branch/master/graph/badge.svg)](https://codecov.io/gh/Alphonsus411/pCobra)
+[![Codecov](https://codecov.io/gh/Alphonsus411/pCobra/branch/work/graph/badge.svg)](https://codecov.io/gh/Alphonsus411/pCobra)
 [![Versión estable](https://img.shields.io/github/v/release/Alphonsus411/pCobra?label=stable)](https://github.com/Alphonsus411/pCobra/releases/latest)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Alphonsus411/pCobra/HEAD?labpath=notebooks/playground.ipynb)
 
@@ -49,7 +49,7 @@ Cobra es un lenguaje de programación diseñado en español, enfocado en la crea
 
 ## Ejemplos
 
-Proyectos de demostracion disponibles en [cobra-ejemplos](https://github.com/Alphonsus411/pCobra/tree/master/examples).
+Proyectos de demostracion disponibles en [cobra-ejemplos](https://github.com/Alphonsus411/pCobra/tree/work/examples).
 Este repositorio incluye ejemplos básicos en la carpeta `examples/`, por
 ejemplo `examples/funciones_principales.co` que muestra condicionales, bucles y
 definición de funciones en Cobra.
@@ -1161,7 +1161,7 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
 
 Este repositorio cuenta con [Dependabot](.github/dependabot.yml) para mantener
 actualizadas las dependencias de Python y las acciones de GitHub. Cada semana se
-crean PR automáticos contra la rama `master` con las versiones más recientes.
+crean PR automáticos contra la rama `work` con las versiones más recientes.
 
 Además, en el flujo de CI se incluye un paso de **safety check** que revisa la
 lista de paquetes instalados en busca de vulnerabilidades conocidas. Si se

--- a/README_en.md
+++ b/README_en.md
@@ -1,5 +1,5 @@
 # Cobra Project
-[![Codecov](https://codecov.io/gh/Alphonsus411/pCobra/branch/master/graph/badge.svg)](https://codecov.io/gh/Alphonsus411/pCobra)
+[![Codecov](https://codecov.io/gh/Alphonsus411/pCobra/branch/work/graph/badge.svg)](https://codecov.io/gh/Alphonsus411/pCobra)
 [![Stable release](https://img.shields.io/github/v/release/Alphonsus411/pCobra?label=stable)](https://github.com/Alphonsus411/pCobra/releases/latest)
 
 Version 10.0.9
@@ -40,7 +40,7 @@ Cobra is a programming language designed in Spanish, aimed at creating tools, si
 
 ## Examples
 
-Demo projects are available in [cobra-ejemplos](https://github.com/Alphonsus411/pCobra/tree/master/examples). This repository includes basic examples in the `examples/` folder, for instance `examples/funciones_principales.co` which shows conditionals, loops and function definitions in Cobra. For interactive examples check the notebooks in `notebooks/casos_reales/`.
+Demo projects are available in [cobra-ejemplos](https://github.com/Alphonsus411/pCobra/tree/work/examples). This repository includes basic examples in the `examples/` folder, for instance `examples/funciones_principales.co` which shows conditionals, loops and function definitions in Cobra. For interactive examples check the notebooks in `notebooks/casos_reales/`.
 
 ### Advanced examples
 

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -41,7 +41,7 @@ cobra archivo.co --to python
 ### Ejecución en GitHub Codespaces
 
 1. En la página del repositorio en GitHub pulsa **Code** y luego la pestaña **Codespaces**.
-2. Selecciona **Create codespace on master** (o la rama por defecto del repositorio) para lanzar un entorno basado en el contenedor de desarrollo.
+2. Selecciona **Create codespace on work** (o la rama por defecto del repositorio) para lanzar un entorno basado en el contenedor de desarrollo.
 3. Durante el arranque se instalarán las dependencias de `requirements-dev.txt` y se configurará la CLI de Cobra.
 4. El archivo `examples/main.cobra` se abrirá automáticamente y se transpilará gracias a la tarea `Transpilar ejemplo`.
 

--- a/frontend/docs/index.rst
+++ b/frontend/docs/index.rst
@@ -65,4 +65,4 @@ Cobra fue creado con la idea de facilitar la programacion en español, optimizan
 Repositorio de Ejemplos
 ----------------------
 
-Los proyectos de demostracion se encuentran en `cobra-ejemplos <https://github.com/Alphonsus411/pCobra/tree/master/examples>`_.
+Los proyectos de demostracion se encuentran en `cobra-ejemplos <https://github.com/Alphonsus411/pCobra/tree/work/examples>`_.

--- a/frontend/vscode/syntaxes/cobra.tmLanguage.json
+++ b/frontend/vscode/syntaxes/cobra.tmLanguage.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vscode/master/extensions/theme-defaults/syntaxes/textmate.tmLanguage.schema.json",
+  "$schema": "https://raw.githubusercontent.com/microsoft/vscode/main/extensions/theme-defaults/syntaxes/textmate.tmLanguage.schema.json",
   "name": "Cobra",
   "scopeName": "source.cobra",
   "patterns": [


### PR DESCRIPTION
## Resumen
- Actualizar enlaces a ejemplos y badge de cobertura para usar la rama `work`
- Ajustar instrucciones de Codespaces y Dependabot a la rama principal
- Corregir URL de esquema en la extensión de VS Code

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68a1d37ccb508327ae55115ee56855f1