### PR TITLE
docs: actualiza enlaces de Codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Proyecto Cobra
-[![Codecov](https://codecov.io/gh/Alphonsus411/pCobra/branch/work/graph/badge.svg)](https://codecov.io/gh/Alphonsus411/pCobra)
+[![Codecov](https://codecov.io/gh/Alphonsus411/pCobra/branch/work/graph/badge.svg)](https://codecov.io/gh/Alphonsus411/pCobra/branch/work)
 [![Versión estable](https://img.shields.io/github/v/release/Alphonsus411/pCobra?label=stable)](https://github.com/Alphonsus411/pCobra/releases/latest)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Alphonsus411/pCobra/HEAD?labpath=notebooks/playground.ipynb)
 

--- a/README_en.md
+++ b/README_en.md
@@ -1,5 +1,5 @@
 # Cobra Project
-[![Codecov](https://codecov.io/gh/Alphonsus411/pCobra/branch/work/graph/badge.svg)](https://codecov.io/gh/Alphonsus411/pCobra)
+[![Codecov](https://codecov.io/gh/Alphonsus411/pCobra/branch/work/graph/badge.svg)](https://codecov.io/gh/Alphonsus411/pCobra/branch/work)
 [![Stable release](https://img.shields.io/github/v/release/Alphonsus411/pCobra?label=stable)](https://github.com/Alphonsus411/pCobra/releases/latest)
 
 Version 10.0.9


### PR DESCRIPTION
## Summary
- actualiza las insignias de Codecov en los README

## Testing
- `curl -I https://codecov.io/gh/Alphonsus411/pCobra/branch/work/graph/badge.svg` *(403 Forbidden)*
- `pytest` *(errores: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68a1e1f64fb0832787ce1cd60a7a5386