### PR TITLE
Prevent symlink race when saving Qualia state

### DIFF
--- a/src/tests/unit/test_qualia_bridge.py
+++ b/src/tests/unit/test_qualia_bridge.py
@@ -122,3 +122,19 @@ def test_state_dir_permissions(tmp_path, monkeypatch):
         mode = dir_path.stat().st_mode & 0o777
         assert mode == 0o700
 
+
+def test_symlink_created_after_resolve(tmp_path, monkeypatch):
+    home = tmp_path
+    state = home / ".cobra" / "state.json"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
+    qb = importlib.reload(qualia_bridge)
+
+    state.parent.mkdir(parents=True, exist_ok=True)
+    target = home / "outside.json"
+    target.write_text("{}")
+    state.symlink_to(target)
+
+    with pytest.raises(OSError):
+        qb.save_state(qb.QUALIA)
+


### PR DESCRIPTION
## Summary
- open Qualia state file with `os.open(..., O_NOFOLLOW)` and re-check for symlinks
- apply strict `0o600` permissions via `os.fchmod`
- add test ensuring symlink created after `_resolve_state_file` causes `save_state` to fail

## Testing
- `ruff check src/core/qualia_bridge.py src/tests/unit/test_qualia_bridge.py`
- `pytest src/tests/unit/test_qualia_bridge.py --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2973696c88327b118b0404c4dc3e1