### PR TITLE
feat: usar JSON seguro en caché de AST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   `COBRA_EJECUTAR_PERMITIDOS`. Invocarlo sin esta configuración produce
   `ValueError` y la lista de la variable de entorno se fija al importar
   el módulo, evitando modificaciones en tiempo de ejecución.
+- Reemplazo del uso de `pickle` por serialización JSON segura en la caché
+  de AST y tokens.
 
 ## v10.0.8 - Pendiente de liberación
 - Nota: versión en desarrollo, sin cambios liberados.

--- a/src/tests/unit/test_ast_cache_security.py
+++ b/src/tests/unit/test_ast_cache_security.py
@@ -1,7 +1,7 @@
 import importlib
 import os
-import pickle
 import sys
+import json
 
 import pytest
 
@@ -15,8 +15,8 @@ def _prepare_cache(monkeypatch, tmp_path):
 
 
 def _escribir_malicioso(ruta):
-    with open(ruta, "wb") as f:
-        f.write(pickle.dumps(eval))
+    with open(ruta, "w", encoding="utf-8") as f:
+        f.write("{malformed json]")
 
 
 def test_carga_ast_malicioso(monkeypatch, tmp_path):
@@ -28,7 +28,7 @@ def test_carga_ast_malicioso(monkeypatch, tmp_path):
     os.makedirs(os.path.dirname(ruta), exist_ok=True)
     _escribir_malicioso(ruta)
 
-    with pytest.raises(pickle.UnpicklingError):
+    with pytest.raises(json.JSONDecodeError):
         obtener_ast(codigo)
 
 
@@ -41,6 +41,6 @@ def test_carga_tokens_maliciosos(monkeypatch, tmp_path):
     os.makedirs(os.path.dirname(ruta), exist_ok=True)
     _escribir_malicioso(ruta)
 
-    with pytest.raises(pickle.UnpicklingError):
+    with pytest.raises(json.JSONDecodeError):
         obtener_tokens(codigo)
 


### PR DESCRIPTION
## Resumen
- Reemplazo de `pickle` y `SafeUnpickler` por serialización JSON segura para nodos del AST y tokens.
- Implementación de funciones explícitas de (de)serialización y actualización de pruebas de seguridad.
- Documentación actualizada en el CHANGELOG.

## Testing
- `pytest src/tests/unit/test_ast_cache.py src/tests/unit/test_ast_cache_security.py src/tests/unit/test_token_cache.py -q --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68a35e0f066c83279442aaea4eccd926