### PR TITLE
Maneja stderr en sandbox JS

### DIFF
--- a/src/core/sandbox.py
+++ b/src/core/sandbox.py
@@ -157,7 +157,7 @@ process.stdout.write(output);
                 tmp_path,
             ],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             cwd=base_dir,
             env=env,
         ) as proc:  # nosec B603
@@ -187,10 +187,12 @@ process.stdout.write(output);
                     break
 
             proc.wait()
-            stderr = proc.stderr.read().decode(errors="ignore") if proc.stderr else ""
-            if proc.returncode and not truncado:
-                return stderr or f"Error: {proc.returncode}"
             resultado = salida.decode(errors="ignore")
+            if proc.returncode and not truncado:
+                resultado = resultado.strip()
+                if resultado:
+                    return f"Error: {resultado}"
+                return f"Error: {proc.returncode}"
             if truncado:
                 resultado += "\n[output truncated]"
             return resultado

--- a/src/tests/unit/test_sandbox_js.py
+++ b/src/tests/unit/test_sandbox_js.py
@@ -90,3 +90,18 @@ def test_sandbox_js_trunca_salida_grande():
     assert len(salida.encode()) <= sandbox.MAX_JS_OUTPUT_BYTES + 100
     assert "truncated" in salida
 
+
+@pytest.mark.timeout(5)
+def test_sandbox_js_trunca_stderr_grande_no_bloquea():
+    if not shutil.which("node"):
+        pytest.skip("node no disponible")
+    try:
+        subprocess.run(["node", "-e", "require('vm2')"], check=True, capture_output=True)
+    except subprocess.CalledProcessError:
+        pytest.skip("vm2 no disponible")
+    codigo = "console.error('e'.repeat(20000))"
+    salida = ejecutar_en_sandbox_js(codigo)
+    assert len(salida.encode()) <= sandbox.MAX_JS_OUTPUT_BYTES + 100
+    assert "truncated" in salida
+    assert not salida.startswith("Error:")
+


### PR DESCRIPTION
## Summary
- Unifica stderr con stdout en `ejecutar_en_sandbox_js` para evitar bloqueos
- Señala errores en la salida combinada utilizando el código de retorno
- Añade prueba que verifica manejo de gran salida por stderr sin bloqueo

## Testing
- `pytest src/tests/unit/test_sandbox_js.py -k "stderr_grande" --override-ini="addopts=" -vv` *(saltado: vm2 no disponible)*

------
https://chatgpt.com/codex/tasks/task_e_68a4012433d0832782a4855a219b9016