### PR TITLE
Usar sandbox seguro en kernel Jupyter

### DIFF
--- a/frontend/docs/entorno_desarrollo.rst
+++ b/frontend/docs/entorno_desarrollo.rst
@@ -40,7 +40,13 @@ probarlo ejecuta:
    export COBRA_JUPYTER_PYTHON=1
    cobra jupyter notebooks/ide_demo.ipynb
 
-El kernel transpilará cada celda a Python antes de ejecutarla.
+El kernel transpilará cada celda a Python y la ejecutará en una *sandbox* con
+límites de tiempo y memoria.
+
+.. warning::
+
+   Activar este modo implica ejecutar código Python, lo que puede ser inseguro.
+   El kernel mostrará una advertencia al iniciarse.
 
 Pruebas de integración
 ----------------------

--- a/frontend/docs/jupyter.rst
+++ b/frontend/docs/jupyter.rst
@@ -42,8 +42,13 @@ Modo Python
 
 Si estableces la variable de entorno ``COBRA_JUPYTER_PYTHON`` el kernel transpilará
 las celdas a Python mediante ``cobra.transpilers.transpiler.to_python`` y ejecutará
-el resultado en un subproceso ``python``. La salida estándar y los errores se
-mostrarán en la celda correspondiente.
+el resultado dentro de una *sandbox* con límites de tiempo y memoria. La salida
+estándar y los errores se mostrarán en la celda correspondiente.
+
+.. warning::
+
+   Ejecutar código Python puede ser inseguro. El kernel mostrará una advertencia
+   explícita cuando este modo esté activo.
 
 Para activarlo:
 
@@ -53,4 +58,4 @@ Para activarlo:
    cobra jupyter
 
 Este modo es útil para depurar la traducción a Python o comparar el comportamiento
-del intérprete con el backend de Python.
+del intérprete con el backend de Python, pero debe usarse con precaución.

--- a/src/tests/integration/test_kernel_transpiler.py
+++ b/src/tests/integration/test_kernel_transpiler.py
@@ -1,18 +1,56 @@
 import subprocess
-from io import StringIO
+import sys
 import sys
 import types
 
-from jupyter_kernel import CobraKernel
+import core.sandbox as sandbox
 
 
-def fake_run(cmd, input=None, capture_output=True, text=True):
-    return subprocess.CompletedProcess(cmd, 0, stdout="hola\n", stderr="")
+def fake_sandbox(code, timeout=5, memoria_mb=None):
+    return "hola\n"
 
 
 def test_kernel_transpiler_mode(monkeypatch):
     monkeypatch.setenv("COBRA_JUPYTER_PYTHON", "1")
     outputs = []
+
+    core_mod = types.ModuleType("cobra.core")
+    class DummyLexer:
+        def __init__(self, code):
+            pass
+        def tokenizar(self):
+            return []
+    class DummyParser:
+        def __init__(self, tokens):
+            pass
+        def parsear(self):
+            return []
+    core_mod.Lexer = DummyLexer
+    core_mod.Parser = DummyParser
+    core_mod.utils = types.SimpleNamespace(PALABRAS_RESERVADAS=[])
+    cobra_pkg = types.ModuleType("cobra")
+    cobra_pkg.core = core_mod
+    sys.modules["cobra"] = cobra_pkg
+    sys.modules["cobra.core"] = core_mod
+    sys.modules["cobra.core.utils"] = core_mod.utils
+
+    interp_mod = types.ModuleType("core.interpreter")
+    class FakeInterpreter:
+        def __init__(self):
+            self.variables = {}
+        def ejecutar_ast(self, ast):
+            return None
+    interp_mod.InterpretadorCobra = FakeInterpreter
+    qualia_mod = types.ModuleType("core.qualia_bridge")
+    qualia_mod.get_suggestions = lambda: []
+    core_pkg = types.ModuleType("core")
+    core_pkg.interpreter = interp_mod
+    core_pkg.qualia_bridge = qualia_mod
+    sys.modules["core"] = core_pkg
+    sys.modules["core.interpreter"] = interp_mod
+    sys.modules["core.qualia_bridge"] = qualia_mod
+
+    from jupyter_kernel import CobraKernel
 
     class DummyKernel(CobraKernel):
         def __init__(self):
@@ -23,7 +61,7 @@ def test_kernel_transpiler_mode(monkeypatch):
         def send_response(self, stream, msg_or_type, content, **kwargs):
             outputs.append((msg_or_type, content))
 
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(sandbox, "ejecutar_en_sandbox", fake_sandbox)
     setup_mod = types.ModuleType("pybind11.setup_helpers")
     setup_mod.Pybind11Extension = object
     setup_mod.build_ext = object
@@ -35,3 +73,9 @@ def test_kernel_transpiler_mode(monkeypatch):
     kernel = DummyKernel()
     kernel.do_execute("imprimir('hola')", False)
     assert ("stream", {"name": "stdout", "text": "hola\n"}) in outputs
+    assert any(
+        msg_type == "stream"
+        and content.get("name") == "stderr"
+        and "Advertencia" in content.get("text", "")
+        for msg_type, content in outputs
+    )

--- a/src/tests/unit/test_kernel_python_error.py
+++ b/src/tests/unit/test_kernel_python_error.py
@@ -1,10 +1,11 @@
-import subprocess
 import sys
 import types
 
+import core.sandbox as sandbox
 
-def fake_run(cmd, input=None, capture_output=True, text=True, timeout=None):
-    return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+
+def fake_sandbox(code, timeout=5, memoria_mb=None):
+    raise RuntimeError("fallo genérico")
 
 
 def test_kernel_reports_generic_error(monkeypatch):
@@ -37,6 +38,42 @@ def test_kernel_reports_generic_error(monkeypatch):
         "cobra.transpilers.transpiler.to_python", transp_mod
     )
 
+    core_mod = types.ModuleType("cobra.core")
+    class DummyLexer:
+        def __init__(self, code):
+            pass
+        def tokenizar(self):
+            return []
+    class DummyParser:
+        def __init__(self, tokens):
+            pass
+        def parsear(self):
+            return []
+    core_mod.Lexer = DummyLexer
+    core_mod.Parser = DummyParser
+    core_mod.utils = types.SimpleNamespace(PALABRAS_RESERVADAS=[])
+    cobra_pkg = types.ModuleType("cobra")
+    cobra_pkg.core = core_mod
+    sys.modules["cobra"] = cobra_pkg
+    sys.modules["cobra.core"] = core_mod
+    sys.modules["cobra.core.utils"] = core_mod.utils
+
+    interp_mod = types.ModuleType("core.interpreter")
+    class FakeInterpreter:
+        def __init__(self):
+            self.variables = {}
+        def ejecutar_ast(self, ast):
+            return None
+    interp_mod.InterpretadorCobra = FakeInterpreter
+    qualia_mod = types.ModuleType("core.qualia_bridge")
+    qualia_mod.get_suggestions = lambda: []
+    core_pkg = types.ModuleType("core")
+    core_pkg.interpreter = interp_mod
+    core_pkg.qualia_bridge = qualia_mod
+    sys.modules["core"] = core_pkg
+    sys.modules["core.interpreter"] = interp_mod
+    sys.modules["core.qualia_bridge"] = qualia_mod
+
     from jupyter_kernel import CobraKernel
 
     class DummyKernel(CobraKernel):
@@ -48,7 +85,7 @@ def test_kernel_reports_generic_error(monkeypatch):
         def send_response(self, stream, msg_or_type, content, **kwargs):
             outputs.append((msg_or_type, content))
 
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(sandbox, "ejecutar_en_sandbox", fake_sandbox)
     setup_mod = types.ModuleType("pybind11.setup_helpers")
     setup_mod.Pybind11Extension = object
     setup_mod.build_ext = object
@@ -64,6 +101,7 @@ def test_kernel_reports_generic_error(monkeypatch):
     assert any(
         msg_type == "stream"
         and content.get("name") == "stderr"
-        and "código de retorno" in content.get("text", "")
+        and "Error al ejecutar código Python" in content.get("text", "")
         for msg_type, content in outputs
     )
+


### PR DESCRIPTION
## Resumen
- Ejecutar celdas Python del kernel Jupyter en `core.sandbox.ejecutar_en_sandbox` con límites de tiempo y memoria
- Mostrar advertencia de seguridad al activar `COBRA_JUPYTER_PYTHON`
- Actualizar documentación y pruebas para reflejar el nuevo modo seguro

## Testing
- `pytest src/tests/integration/test_kernel_transpiler.py src/tests/unit/test_kernel_python_error.py src/tests/unit/test_kernel_python_timeout.py -q` *(falla: cannot import name 'TipoToken')*


------
https://chatgpt.com/codex/tasks/task_e_68a4465d89488327b9425a66cd92d8c7