### PR TITLE
feat: add timeout to rust crate compilation

### DIFF
--- a/src/core/rust_bridge.py
+++ b/src/core/rust_bridge.py
@@ -10,13 +10,14 @@ from typing import Iterable, Any
 from .ctypes_bridge import cargar_biblioteca, obtener_funcion
 
 
-def compilar_crate(ruta: str, release: bool = True) -> str:
+def compilar_crate(ruta: str, release: bool = True, timeout: int = 300) -> str:
     """Compila el crate Rust ubicado en ``ruta`` y devuelve la ruta de la
     biblioteca generada.
 
     Se ejecuta ``cbindgen`` para generar los encabezados C y ``cargo`` para
     construir la biblioteca como ``cdylib``. Si ``release`` es ``False`` se
-    compilar\u00e1 en modo debug.
+    compilar\u00e1 en modo debug. El par\u00e1metro ``timeout`` establece el tiempo
+    m\u00e1ximo en segundos para cada comando externo.
     """
     path = Path(ruta).resolve()
 
@@ -30,12 +31,21 @@ def compilar_crate(ruta: str, release: bool = True) -> str:
             "La herramienta 'cargo' no est\xc3\xa1 instalada o no se encuentra en PATH"
         )
 
-    subprocess.run([
-        "cbindgen",
-        str(path),
-        "-o",
-        str(path / "bindings.h"),
-    ], check=True)
+    try:
+        subprocess.run(
+            [
+                "cbindgen",
+                str(path),
+                "-o",
+                str(path / "bindings.h"),
+            ],
+            check=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            "Tiempo de espera excedido al ejecutar cbindgen"
+        ) from exc
 
     cmd = [
         "cargo",
@@ -45,7 +55,12 @@ def compilar_crate(ruta: str, release: bool = True) -> str:
     ]
     if release:
         cmd.append("--release")
-    subprocess.run(cmd, check=True)
+    try:
+        subprocess.run(cmd, check=True, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            "Tiempo de espera excedido al ejecutar cargo"
+        ) from exc
 
     target = path / "target" / ("release" if release else "debug")
     base = f"lib{path.name}"
@@ -56,16 +71,25 @@ def compilar_crate(ruta: str, release: bool = True) -> str:
     raise FileNotFoundError("Biblioteca generada no encontrada")
 
 
-def cargar_crate(ruta: str, release: bool = True) -> Any:
-    """Compila y carga el crate localizado en ``ruta``."""
-    lib_path = compilar_crate(ruta, release)
+def cargar_crate(ruta: str, release: bool = True, timeout: int = 300) -> Any:
+    """Compila y carga el crate localizado en ``ruta``.
+
+    El par\u00e1metro ``timeout`` establece el tiempo m\u00e1ximo en segundos para
+    cada comando externo.
+    """
+    lib_path = compilar_crate(ruta, release, timeout)
     return cargar_biblioteca(lib_path)
 
 
 def compilar_y_cargar_crate(ruta: str, nombre: str, *,
                             release: bool = True,
+                            timeout: int = 300,
                             restype: Any | None = None,
                             argtypes: Iterable[Any] | None = None) -> Any:
-    """Compila ``ruta`` y devuelve la funci\u00f3n ``nombre`` lista para usar."""
-    lib = cargar_crate(ruta, release)
+    """Compila ``ruta`` y devuelve la funci\u00f3n ``nombre`` lista para usar.
+
+    ``timeout`` establece el tiempo m\u00e1ximo en segundos para cada comando
+    externo.
+    """
+    lib = cargar_crate(ruta, release, timeout)
     return obtener_funcion(lib, nombre, restype, argtypes)


### PR DESCRIPTION
## Summary
- allow specifying a timeout when compiling Rust crates
- propagate timeout to crate loading helpers

## Testing
- `pytest --override-ini addopts= src/tests/unit/test_rust_bridge.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a448e20f4c8327a4c77b9a09383697