### PR TITLE
Limitar tamaño de respuestas HTTP

### DIFF
--- a/src/core/nativos/io.py
+++ b/src/core/nativos/io.py
@@ -5,6 +5,18 @@ from pathlib import Path
 import requests
 
 
+_MAX_RESP_SIZE = 1024 * 1024
+
+
+def _leer_respuesta(resp: requests.Response) -> str:
+    datos = bytearray()
+    for chunk in resp.iter_content(chunk_size=8192):
+        datos.extend(chunk)
+        if len(datos) > _MAX_RESP_SIZE:
+            raise ValueError("Respuesta demasiado grande")
+    return datos.decode(resp.encoding or "utf-8", errors="replace")
+
+
 def _resolver_ruta(ruta: str) -> Path:
     """Resuelve ``ruta`` dentro de un directorio permitido."""
     base = Path(os.environ.get("COBRA_IO_BASE_DIR") or Path.cwd()).resolve()
@@ -59,7 +71,12 @@ def obtener_url(url, permitir_redirecciones: bool = False):
     if not hosts:
         raise ValueError("COBRA_HOST_WHITELIST vacío")
     _validar_host(url, hosts)
-    resp = requests.get(url, timeout=5, allow_redirects=permitir_redirecciones)
-    resp.raise_for_status()
-    _validar_host(resp.url, hosts)
-    return resp.text
+    resp = requests.get(
+        url, timeout=5, allow_redirects=permitir_redirecciones, stream=True
+    )
+    try:
+        resp.raise_for_status()
+        _validar_host(resp.url, hosts)
+        return _leer_respuesta(resp)
+    finally:
+        resp.close()

--- a/src/corelibs/red.py
+++ b/src/corelibs/red.py
@@ -6,6 +6,18 @@ import urllib.parse
 import requests
 
 
+_MAX_RESP_SIZE = 1024 * 1024
+
+
+def _leer_respuesta(resp: requests.Response) -> str:
+    datos = bytearray()
+    for chunk in resp.iter_content(chunk_size=8192):
+        datos.extend(chunk)
+        if len(datos) > _MAX_RESP_SIZE:
+            raise ValueError("Respuesta demasiado grande")
+    return datos.decode(resp.encoding or "utf-8", errors="replace")
+
+
 def _validar_host(url: str, hosts: set[str]) -> None:
     host = urllib.parse.urlparse(url).hostname
     if host not in hosts:
@@ -28,12 +40,17 @@ def obtener_url(url: str, permitir_redirecciones: bool = False) -> str:
     if not hosts:
         raise ValueError("COBRA_HOST_WHITELIST vacío")
     _validar_host(url, hosts)
-    resp = requests.get(url, timeout=5, allow_redirects=permitir_redirecciones)
-    resp.raise_for_status()
-    if permitir_redirecciones and not resp.url.lower().startswith("https://"):
-        raise ValueError("Esquema de URL no soportado")
-    _validar_host(resp.url, hosts)
-    return resp.text
+    resp = requests.get(
+        url, timeout=5, allow_redirects=permitir_redirecciones, stream=True
+    )
+    try:
+        resp.raise_for_status()
+        if permitir_redirecciones and not resp.url.lower().startswith("https://"):
+            raise ValueError("Esquema de URL no soportado")
+        _validar_host(resp.url, hosts)
+        return _leer_respuesta(resp)
+    finally:
+        resp.close()
 
 
 def enviar_post(url: str, datos: dict, permitir_redirecciones: bool = False) -> str:
@@ -53,10 +70,17 @@ def enviar_post(url: str, datos: dict, permitir_redirecciones: bool = False) -> 
         raise ValueError("COBRA_HOST_WHITELIST vacío")
     _validar_host(url, hosts)
     resp = requests.post(
-        url, data=datos, timeout=5, allow_redirects=permitir_redirecciones
+        url,
+        data=datos,
+        timeout=5,
+        allow_redirects=permitir_redirecciones,
+        stream=True,
     )
-    resp.raise_for_status()
-    if permitir_redirecciones and not resp.url.lower().startswith("https://"):
-        raise ValueError("Esquema de URL no soportado")
-    _validar_host(resp.url, hosts)
-    return resp.text
+    try:
+        resp.raise_for_status()
+        if permitir_redirecciones and not resp.url.lower().startswith("https://"):
+            raise ValueError("Esquema de URL no soportado")
+        _validar_host(resp.url, hosts)
+        return _leer_respuesta(resp)
+    finally:
+        resp.close()


### PR DESCRIPTION
## Resumen
- Evitar descargas grandes en `obtener_url` de nativos y corelibs
- Limitar respuestas de `enviar_post` a 1 MB
- Añadir pruebas que validan el rechazo de respuestas demasiado grandes

## Testing
- `pytest -o addopts="" src/tests/unit/test_nativos_io.py::test_obtener_url_host_whitelist src/tests/unit/test_nativos_io.py::test_obtener_url_respuesta_muy_grande src/tests/unit/test_corelibs.py::test_red_funcs src/tests/unit/test_corelibs.py::test_red_host_whitelist_permite src/tests/unit/test_corelibs.py::test_red_obtener_url_respuesta_muy_grande src/tests/unit/test_corelibs.py::test_red_enviar_post_respuesta_muy_grande`
- `pytest` *(falla: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68a44ae816148327beeda672d518588b