### PR TITLE
build: add tree-sitter dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,7 +902,7 @@ Actualmente es posible convertir a Cobra código escrito en ensamblador, C, C++,
 
 ### Instalación de gramáticas
 
-Varios transpiladores inversos están basados en [tree-sitter](https://tree-sitter.github.io/tree-sitter/). Para que funcionen es necesario disponer de los paquetes `tree-sitter` y `tree-sitter-languages`. Instálalos con:
+Varios transpiladores inversos están basados en [tree-sitter](https://tree-sitter.github.io/tree-sitter/). Cobra ya incluye la dependencia `tree-sitter`, por lo que solo necesitas instalar `tree-sitter-languages`:
 
 ```bash
 pip install tree-sitter-languages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "flet==0.28.3",
     "packaging==25.0",
     "pybind11==3.0.0",
+    "tree-sitter==0.25.1",
     "RestrictedPython==8.0",
     "prompt_toolkit==3.0.51",
     "Pygments==2.19.2",


### PR DESCRIPTION
## Summary
- add tree-sitter runtime dependency in pyproject
- clarify tree-sitter installation instructions

## Testing
- `make lint` (fails: Found 882 errors)
- `PYTHONPATH=$PWD/src:$PWD pytest` (fails: ModuleNotFoundError: No module named 'cli.cli')

------
https://chatgpt.com/codex/tasks/task_e_68a457218e188327a2f8fe331b1f1f41