### PR TITLE
Evitar dependencias de tree_sitter al importar transpilers

### DIFF
--- a/src/cobra/transpilers/__init__.py
+++ b/src/cobra/transpilers/__init__.py
@@ -1,6 +1,20 @@
 """Facilita el acceso a los distintos transpiladores de Cobra."""
 
+from typing import TYPE_CHECKING, Any
+
 from cobra.transpilers.common.utils import BaseTranspiler
-from cobra.transpilers.reverse.base import BaseReverseTranspiler
+
+if TYPE_CHECKING:  # pragma: no cover - solo para análisis estático
+    from cobra.transpilers.reverse.base import BaseReverseTranspiler
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - importación diferida
+    if name == "BaseReverseTranspiler":
+        from cobra.transpilers.reverse.base import BaseReverseTranspiler
+
+        return BaseReverseTranspiler
+    raise AttributeError(name)
+
 
 __all__ = ["BaseTranspiler", "BaseReverseTranspiler"]
+

--- a/src/cobra/transpilers/reverse/__init__.py
+++ b/src/cobra/transpilers/reverse/__init__.py
@@ -7,7 +7,16 @@ no impedir el uso de los demás.
 from typing import List, Type
 
 from cobra.transpilers.reverse.base import BaseReverseTranspiler
-from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler
+try:  # pragma: no cover - dependencia opcional
+    from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler
+except ModuleNotFoundError as exc:  # pragma: no cover - sin tree_sitter
+    class TreeSitterReverseTranspiler(BaseReverseTranspiler):  # type: ignore
+        """Stub cuando tree-sitter no está disponible."""
+
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401
+            raise ModuleNotFoundError(
+                "tree_sitter es necesario para los transpiladores inversos"
+            ) from exc
 
 # Lista de módulos a intentar importar
 _MODULOS = [

--- a/src/tests/unit/test_transpilers_import_no_tree_sitter.py
+++ b/src/tests/unit/test_transpilers_import_no_tree_sitter.py
@@ -1,0 +1,24 @@
+import builtins
+import sys
+
+
+def test_import_cobra_transpilers_without_tree_sitter(monkeypatch):
+    """Importar cobra.transpilers no requiere tree_sitter."""
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("tree_sitter"):
+            raise ModuleNotFoundError
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    sys.modules.pop("cobra.transpilers", None)
+    sys.modules.pop("cobra.transpilers.reverse", None)
+
+    import cobra.transpilers as tr
+
+    assert hasattr(tr, "BaseTranspiler")
+    assert tr.BaseReverseTranspiler.__name__ == "BaseReverseTranspiler"
+


### PR DESCRIPTION
## Resumen
- Evitar que `cobra.transpilers` cargue `tree_sitter` cuando no es necesario mediante importación diferida.
- Controlar la importación de `TreeSitterReverseTranspiler` con un `try/except` que provee un stub informativo.
- Añadir prueba para asegurar que `import cobra.transpilers` funciona sin `tree_sitter`.

## Testing
- `pytest src/tests/unit/test_transpilers_import_no_tree_sitter.py -q --no-cov`
- `pytest src/tests/unit/test_module_map.py -q --no-cov` *(falla: ImportError: cannot import name 'NodoOperacionBinaria')*


------
https://chatgpt.com/codex/tasks/task_e_68a4593db5bc83279f696d023045553f