### PR TITLE
Evitar dependencia de coverage al cargar pcobra.toml

### DIFF
--- a/src/cobra/transpilers/module_map.py
+++ b/src/cobra/transpilers/module_map.py
@@ -4,7 +4,10 @@ import yaml
 from typing import Dict, Any
 import logging
 
-from coverage.tomlconfig import tomllib
+try:
+    import tomllib  # Python ≥3.11
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
 
 logger = logging.getLogger(__name__)
 

--- a/src/tests/unit/test_module_map_no_coverage.py
+++ b/src/tests/unit/test_module_map_no_coverage.py
@@ -1,0 +1,24 @@
+import builtins
+import importlib
+
+
+def test_get_toml_map_without_coverage(monkeypatch, tmp_path):
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("coverage"):
+            raise ModuleNotFoundError
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    import cobra.transpilers.module_map as module_map
+    importlib.reload(module_map)
+
+    toml_file = tmp_path / "pcobra.toml"
+    toml_file.write_text("")
+    monkeypatch.setenv("PCOBRA_TOML", str(toml_file))
+
+    module_map._toml_cache = None
+    assert module_map.get_toml_map() == {}
+


### PR DESCRIPTION
## Resumen
- Reemplazo de `coverage.tomlconfig` por importación directa de `tomllib` con respaldo a `tomli`
- Añadida prueba para ejecutar `get_toml_map` en ausencia de `coverage`

## Testing
- `pytest src/tests/unit/test_module_map_no_coverage.py -q -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_68a46857e5f083279f208ba5ff220005