### PR TITLE
Verificar cleanup del intérprete en CLI

### DIFF
--- a/src/cobra/cli/cli.py
+++ b/src/cobra/cli/cli.py
@@ -134,7 +134,7 @@ class CliApplication:
             self.cleanup()
 
     def cleanup(self) -> None:
-        if self.interpreter:
+        if self.interpreter and hasattr(self.interpreter, "cleanup"):
             self.interpreter.cleanup()
         logging.shutdown()
 


### PR DESCRIPTION
## Resumen
- Evitar fallos al limpiar recursos del intérprete usando `hasattr` antes de llamar a `cleanup` en la aplicación CLI.

## Testing
- `pytest -q` *(falla: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_68a47245dea48327960dfb32b834435f