### PR TITLE
fix: remove duplicate argparse import

### DIFF
--- a/src/cobra/cli/cli.py
+++ b/src/cobra/cli/cli.py
@@ -6,17 +6,11 @@ from os import environ
 from pathlib import Path
 from typing import List, Dict, Optional, Type, Any, ContextManager
 from contextlib import contextmanager
-import argparse
 
 from cobra.cli.utils.argument_parser import CustomArgumentParser
 
 import argcomplete
 from argcomplete.completers import FilesCompleter, DirectoriesCompleter
-
-# Importaciones con TYPE_CHECKING para evitar dependencias circulares
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from cobra.cli.commands.interactive_cmd import InteractiveCommand
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.commands.bench_cmd import BenchCommand


### PR DESCRIPTION
## Summary
- remove duplicate `import argparse` in CLI
- drop unused TYPE_CHECKING block

## Testing
- `isort --check-only src/cobra/cli/cli.py` (fails: Imports are incorrectly sorted and/or formatted)
- `black --check src/cobra/cli/cli.py` (fails: 1 file would be reformatted)
- `ruff check src/cobra/cli/cli.py --select F401`

------
https://chatgpt.com/codex/tasks/task_e_68a482a6004083279c963d6a7c892450