### PR TITLE
Gestionar índices de código y tokens en lexer

### DIFF
--- a/src/tests/unit/test_lexer_token_index.py
+++ b/src/tests/unit/test_lexer_token_index.py
@@ -1,0 +1,34 @@
+from cobra.core import Lexer, TipoToken
+
+
+def test_peek_and_navigation_after_tokenizar():
+    codigo = "var x = 1"
+    lexer = Lexer(codigo)
+    lexer.tokenizar()
+
+    # peek debe mostrar el primer token sin consumirlo
+    primer = lexer.peek()
+    assert primer.tipo == TipoToken.VAR
+    assert lexer.hay_mas_tokens()
+
+    # consumir y navegar por los tokens
+    assert lexer.siguiente_token().tipo == TipoToken.VAR
+    assert lexer.siguiente_token().tipo == TipoToken.IDENTIFICADOR
+
+    # retroceder y volver a leer el identificador
+    lexer.retroceder()
+    assert lexer.peek().tipo == TipoToken.IDENTIFICADOR
+
+    # guardar y restaurar estado
+    estado = lexer.guardar_estado()
+    assert lexer.siguiente_token().tipo == TipoToken.IDENTIFICADOR
+    lexer.restaurar_estado(estado)
+    assert lexer.siguiente_token().tipo == TipoToken.IDENTIFICADOR
+
+    # consumir el resto de tokens hasta EOF
+    ultimo = None
+    while lexer.hay_mas_tokens():
+        ultimo = lexer.siguiente_token()
+    assert ultimo is not None and ultimo.tipo == TipoToken.EOF
+    assert not lexer.hay_mas_tokens()
+    assert lexer.siguiente_token() is None


### PR DESCRIPTION
## Resumen
- Añadido `indice_token` para manejar la posición de lectura de tokens y `posicion_codigo` para recorrer el código fuente sin conflictos.
- Actualizados los métodos de navegación (`guardar_estado`, `restaurar_estado`, `siguiente_token`, `retroceder`, `hay_mas_tokens`) para usar el nuevo índice de tokens.
- Incorporadas pruebas unitarias que verifican el correcto funcionamiento de `peek` y la navegación tras `tokenizar`.

## Pruebas
- `pytest src/tests/unit/test_lexer_token_index.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a48e0cfd648327aca060a09c2f8ec9