### PR TITLE
Separa índices de tokens en lexer y añade pruebas

### DIFF
--- a/src/cobra/core/lexer.py
+++ b/src/cobra/core/lexer.py
@@ -194,8 +194,9 @@ class Lexer:
 
         self.codigo_fuente = codigo_fuente
         # Índice dentro del código fuente durante la tokenización
+        # (se mantiene independiente del índice de tokens)
         self.posicion_codigo = 0
-        # Índice del token actual al consumir la lista de tokens
+        # Índice del token actual al consumir la lista de tokens generados
         self.indice_token = 0
         self.linea = 1
         self.columna = 1
@@ -411,6 +412,10 @@ class Lexer:
     def _tokenizar_base(self) -> List[Token]:
         """Implementación base del proceso de tokenización.
 
+        Utiliza ``self.posicion_codigo`` para recorrer el código fuente y
+        mantiene ``self.indice_token`` como puntero independiente al consumir
+        la lista de tokens generada.
+
         Returns:
             Lista de tokens encontrados
 
@@ -418,7 +423,7 @@ class Lexer:
             RuntimeError: Si se excede el límite de iteraciones
         """
         self._limpiar_comentarios()
-        self.posicion_codigo = 0
+        self.posicion_codigo = 0  # reinicia índice sobre el código fuente
         self.linea = 1
         self.columna = 1
         self.tokens = []
@@ -538,8 +543,12 @@ class Lexer:
     def guardar_estado(self) -> EstadoLexer:
         """Guarda el estado actual del lexer.
 
+        El estado guarda el ``indice_token`` junto con la línea y columna
+        actuales, permitiendo regresar a esta posición más adelante.
+
         Returns:
-            EstadoLexer con el índice de token actual
+            EstadoLexer con la información necesaria para restaurar
+            el estado del lexer
         """
         return EstadoLexer(self.indice_token, self.linea, self.columna)
 

--- a/src/tests/test_lexer_indices.py
+++ b/src/tests/test_lexer_indices.py
@@ -1,0 +1,37 @@
+from cobra.core.lexer import Lexer, TipoToken
+
+
+def test_peek_and_state_after_tokenizar():
+    codigo = "var x = 5"
+    lexer = Lexer(codigo)
+
+    # tokenizar genera la lista de tokens y reinicia el índice
+    tokens = lexer.tokenizar()
+    assert tokens[0].tipo == TipoToken.VAR
+
+    # peek no debe consumir el primer token
+    primer_peek = lexer.peek()
+    assert primer_peek is not None
+    assert primer_peek.tipo == TipoToken.VAR
+
+    # siguiente_token devuelve el mismo token observado por peek
+    primer_token = lexer.siguiente_token()
+    assert primer_token == primer_peek
+
+    # el siguiente token debe ser el identificador "x"
+    segundo_token = lexer.siguiente_token()
+    assert segundo_token.tipo == TipoToken.IDENTIFICADOR
+
+    # retroceder permite volver a leer el identificador
+    lexer.retroceder()
+    assert lexer.siguiente_token() == segundo_token
+
+    # guardar y restaurar estado alrededor del operador de asignación
+    estado = lexer.guardar_estado()
+    tercer_token = lexer.siguiente_token()
+    assert tercer_token.tipo == TipoToken.ASIGNAR
+    lexer.restaurar_estado(estado)
+    assert lexer.siguiente_token() == tercer_token
+
+    # aún deben quedar tokens por leer (el número 5 y EOF)
+    assert lexer.hay_mas_tokens()


### PR DESCRIPTION
## Resumen
- Documentación y comentarios aclarando la separación entre `posicion_codigo` e `indice_token` en el lexer.
- Prueba unitaria que verifica `peek`, gestión de estado y retroceso tras `tokenizar()`.

## Testing
- `PYTHONPATH=src python -m pytest src/tests/test_lexer_indices.py -q --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68a4a255b23c83279ec6d23c4b7f1c36