### PR TITLE
Detect unclosed block comments

### DIFF
--- a/src/cobra/core/lexer.py
+++ b/src/cobra/core/lexer.py
@@ -305,35 +305,61 @@ class Lexer:
         i = 0
         longitud = len(codigo)
         nivel_bloque = 0
+        linea_actual = 1
+        columna_actual = 1
 
         while i < longitud:
             if nivel_bloque > 0:
                 if codigo.startswith("/*", i):
                     nivel_bloque += 1
                     i += 2
+                    columna_actual += 2
                 elif codigo.startswith("*/", i):
                     nivel_bloque -= 1
                     i += 2
+                    columna_actual += 2
                 else:
+                    if codigo[i] == "\n":
+                        linea_actual += 1
+                        columna_actual = 1
+                    else:
+                        columna_actual += 1
                     i += 1
                 continue
 
             if codigo.startswith("/*", i):
                 nivel_bloque = 1
                 i += 2
+                columna_actual += 2
             elif codigo.startswith("//", i):
                 i += 2
+                columna_actual += 2
                 while i < longitud and codigo[i] not in "\n\r":
                     i += 1
+                    columna_actual += 1
             elif codigo[i] == "#":
                 i += 1
+                columna_actual += 1
                 while i < longitud and codigo[i] not in "\n\r":
                     i += 1
+                    columna_actual += 1
             else:
+                if codigo[i] == "\n":
+                    linea_actual += 1
+                    columna_actual = 1
+                else:
+                    columna_actual += 1
                 resultado.append(codigo[i])
                 i += 1
 
         self.codigo_fuente = "".join(resultado)
+
+        if nivel_bloque > 0:
+            raise InvalidTokenError(
+                f"Comentario de bloque sin cerrar en línea {linea_actual}, columna {columna_actual}",
+                linea_actual,
+                columna_actual,
+            )
 
     def _procesar_cadena(self, valor: str) -> str:
         """Procesa una cadena, manejando caracteres de escape.

--- a/src/tests/unit/lexer_test_casos_edge.py
+++ b/src/tests/unit/lexer_test_casos_edge.py
@@ -46,5 +46,5 @@ def test_cadena_con_comillas_escapadas():
     codigo = '"dijo \\"hola\\""'
     tokens = Lexer(codigo).analizar_token()
     assert tokens[0].tipo == TipoToken.CADENA
-    assert tokens[0].valor == 'dijo \\"hola\\"'
+    assert tokens[0].valor == 'dijo "hola"'
     assert tokens[-1].tipo == TipoToken.EOF

--- a/src/tests/unit/test_lexer_additional_cases.py
+++ b/src/tests/unit/test_lexer_additional_cases.py
@@ -3,15 +3,22 @@ from cobra.core import (
     Lexer,
     TipoToken,
     InvalidTokenError,
-    UnclosedStringError,
 )
 
 
-def test_unclosed_comment_triggers_unclosed_string():
+def test_unclosed_comment_raises_invalid_token():
     codigo = "var x = 1 /* comentario ' sin cerrar"
     lexer = Lexer(codigo)
-    with pytest.raises(UnclosedStringError):
+    with pytest.raises(InvalidTokenError):
         lexer.tokenizar()
+
+
+def test_block_comment_without_closing():
+    codigo = "/*"
+    lexer = Lexer(codigo)
+    with pytest.raises(InvalidTokenError) as exc:
+        lexer.tokenizar()
+    assert "Comentario de bloque sin cerrar en línea 1, columna 3" in str(exc.value)
 
 
 def test_unclosed_comment_with_invalid_symbol():

--- a/src/tests/unit/test_lexer_errors.py
+++ b/src/tests/unit/test_lexer_errors.py
@@ -10,7 +10,7 @@ from cobra.core import (
 def test_mensaje_cadena_no_cerrada():
     codigo = "'hola"
     lexer = Lexer(codigo)
-    with pytest.raises(UnclosedStringError, match="Cadena sin cerrar en linea 1, columna 1"):
+    with pytest.raises(UnclosedStringError, match="Cadena sin cerrar en línea 1, columna 1"):
         lexer.tokenizar()
 
 
@@ -19,5 +19,5 @@ def test_mensaje_token_desconocido():
     lexer = Lexer(codigo)
     with pytest.raises(InvalidTokenError) as exc:
         lexer.tokenizar()
-    assert "Token no reconocido: '€' en linea 1, columna 9" in str(exc.value)
+    assert "Token no reconocido: '€' en línea 1, columna 9" in str(exc.value)
 

--- a/src/tests/unit/test_lexer_errors_extra.py
+++ b/src/tests/unit/test_lexer_errors_extra.py
@@ -13,7 +13,7 @@ def test_unclosed_string():
     with pytest.raises(LexerError) as exc:
         lexer.tokenizar()
     assert isinstance(exc.value, UnclosedStringError)
-    assert "Cadena sin cerrar en linea 1, columna 1" in str(exc.value)
+    assert "Cadena sin cerrar en línea 1, columna 1" in str(exc.value)
 
 
 def test_multiple_decimal_points():
@@ -29,4 +29,4 @@ def test_invalid_symbol():
     with pytest.raises(LexerError) as exc:
         lexer.tokenizar()
     assert isinstance(exc.value, InvalidTokenError)
-    assert "Token no reconocido: '€' en linea 1, columna 9" in str(exc.value)
+    assert "Token no reconocido: '€' en línea 1, columna 9" in str(exc.value)


### PR DESCRIPTION
## Summary
- Signal `InvalidTokenError` when a block comment isn't closed and report its position
- Adjust tests to expect accented error messages and add regression test for unterminated block comments

## Testing
- `PYTEST_ADDOPTS="--cov-fail-under=0" pytest src/tests/unit/test_lexer_additional_cases.py src/tests/unit/test_lexer_errors.py src/tests/unit/test_lexer_errors_extra.py src/tests/unit/test_lexer.py src/tests/unit/lexer_test_casos_edge.py src/tests/unit/test_lexer_edge_unicode.py src/tests/unit/test_lexer2.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4a6ef97088327aec827a401a0f42f