### PR TITLE
docs: aclarar configuracion de logging externa

### DIFF
--- a/src/cobra/core/lexer.py
+++ b/src/cobra/core/lexer.py
@@ -1,12 +1,15 @@
-"""Analizador léxico para el lenguaje Cobra."""
+"""Analizador léxico para el lenguaje Cobra.
+
+Este módulo no configura el sistema de *logging*. El consumidor debe
+configurar el *logging* externamente y, una vez hecho, los mensajes se
+enviarán a través del ``logger`` local.
+"""
 
 import logging
 import re
 from enum import Enum
 from typing import Dict, List, Optional, Pattern, Tuple, Union, cast
 
-# Configuración de logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- remover uso de `logging.basicConfig` en el lexer
- documentar que el `logging` debe configurarse externamente

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'cli.cli')*
- `python - <<'PY'\nimport logging\nlogging.basicConfig(level=logging.INFO)\nfrom src.cobra.core import lexer\nlexer.logger.info('mensaje de prueba')\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68a4a968d7648327bd00df0cb617523c