### PR TITLE
Validar comandos vacíos en ejecutar de corelibs

### DIFF
--- a/src/corelibs/sistema.py
+++ b/src/corelibs/sistema.py
@@ -28,9 +28,9 @@ def ejecutar(
 ) -> str:
     """Ejecuta un comando y devuelve su salida.
 
-    ``comando`` debe ser una lista de argumentos que se pasa
-    directamente a ``subprocess.run`` sin crear un shell. ``permitidos``
-    define una lista blanca de rutas absolutas de ejecutables
+    ``comando`` debe ser una lista no vacía de argumentos que se pasa
+    directamente a ``subprocess.run`` sin crear un shell. Se lanza
+    ``ValueError`` si la lista está vacía. ``permitidos`` define una lista blanca de rutas absolutas de ejecutables
     autorizados; este parámetro es obligatorio. Si se invoca la función
     sin una lista se utilizará la capturada desde
     ``COBRA_EJECUTAR_PERMITIDOS`` al importar el módulo, siempre que no
@@ -47,6 +47,9 @@ def ejecutar(
     cuando esté disponible o lanzando un ``RuntimeError`` con
     información detallada.
     """
+    if not comando:
+        raise ValueError("Comando vacío")
+
     if permitidos is None:
         if PERMITIDOS_FIJOS:
             permitidos = PERMITIDOS_FIJOS

--- a/src/tests/unit/test_corelibs_sistema.py
+++ b/src/tests/unit/test_corelibs_sistema.py
@@ -73,6 +73,11 @@ def test_ejecutar_env_ignora_cambios(monkeypatch):
         core.sistema.ejecutar(["false"], timeout=1)
 
 
+def test_ejecutar_comando_vacio():
+    with pytest.raises(ValueError, match="Comando vacío"):
+        core.ejecutar([], permitidos=[], timeout=1)
+
+
 def test_ejecutar_timeout_expira(monkeypatch):
     def raise_timeout(*a, **k):
         raise subprocess.TimeoutExpired(a[0], k.get("timeout"))


### PR DESCRIPTION
## Resumen
- Evita ejecutar comandos vacíos en `corelibs.sistema.ejecutar`
- Documenta la necesidad de proporcionar una lista de argumentos no vacía
- Agrega prueba unitaria para la validación de comandos vacíos

## Testing
- `pytest src/tests/unit/test_corelibs_sistema.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a4abcbbcd4832798215b7867c2f2e5