### PR TITLE
ci: trigger labeler on pull_request_target

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -3,7 +3,7 @@ permissions:
   contents: read
   pull-requests: write
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 jobs:
   label:


### PR DESCRIPTION
## Summary
- use `pull_request_target` event so PRs from forks can be labeled

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68a4b2cc33b48327bc29322d1ab56f00