### PR TITLE
Soporta build CLI en Windows

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -21,7 +21,7 @@ jobs:
           - os: ubuntu-latest
             shell: bash
           - os: windows-latest
-            shell: pwsh
+            shell: bash
           # mac: build both arm64 (Apple Silicon) and x86_64 (Intel)
           - os: macos-latest
             shell: bash
@@ -32,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -65,10 +67,11 @@ jobs:
         env:
           PYINSTALLER_ARCH: ${{ matrix.mac_arch || '' }}
         run: |
-          # Your script can read $PYINSTALLER_ARCH on macOS to pass --target-arch
-          # e.g., pyinstaller --onefile yourapp.py ${PYINSTALLER_ARCH:+--target-arch $PYINSTALLER_ARCH}
-          chmod +x scripts/build_cli.sh 2>/dev/null || true
-          ./scripts/build_cli.sh
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            bash scripts/build_cli.sh
+          else
+            ./scripts/build_cli.sh
+          fi
 
       - name: List dist
         if: always()

--- a/scripts/build_cli.ps1
+++ b/scripts/build_cli.ps1
@@ -1,0 +1,37 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repoRoot = Resolve-Path "$PSScriptRoot/.."
+Set-Location $repoRoot
+
+if (-not $env:SOURCE_DATE_EPOCH) { $env:SOURCE_DATE_EPOCH = "0" }
+
+$versionLine = Select-String '^version = ' -Path pyproject.toml | Select-Object -First 1
+$VERSION = ($versionLine -split '"')[1]
+$COMMIT = (git rev-parse --short HEAD).Trim()
+$env:COBRA_CLI_VERSION = $VERSION
+$env:COBRA_CLI_COMMIT = $COMMIT
+Write-Host "Construyendo Cobra CLI v$env:COBRA_CLI_VERSION (commit $env:COBRA_CLI_COMMIT)"
+
+pip install --no-cache-dir -r requirements.txt
+
+pyinstaller --onefile --clean --strip cobra-cli.spec
+
+$artifactName = "cobra-cli"
+if ($IsWindows) { $artifactName += ".exe" }
+$artifact = Join-Path "dist" $artifactName
+$HASH1 = (Get-FileHash $artifact -Algorithm SHA256).Hash.ToLower()
+Write-Host "Primer hash: $HASH1"
+
+Remove-Item -Recurse -Force build, dist
+pyinstaller --onefile --clean --strip cobra-cli.spec
+$HASH2 = (Get-FileHash $artifact -Algorithm SHA256).Hash.ToLower()
+Write-Host "Segundo hash: $HASH2"
+
+if ($HASH1 -ne $HASH2) {
+    Write-Error "Error: los hashes no coinciden"
+    exit 1
+}
+
+Write-Host "Hash verificado: $HASH1"


### PR DESCRIPTION
## Resumen
- Añadido script PowerShell `build_cli.ps1` equivalente al script de construcción del CLI.
- Condicionado el paso de construcción en GitHub Actions para usar Bash en Windows.
- `checkout` ahora usa `fetch-depth: 0` para disponer de todo el historial.

## Pruebas
- `pytest -q` *(falla: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_68a4c1b434d48327b76c74c022fc09b3