### PR TITLE
feat: añadir job de release en build-exe

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -27,9 +27,21 @@ jobs:
         with:
           extra: "pyinstaller"
       - name: Build executable
-        run: cobra empaquetar --output dist --add-data all-bytes.dat:all-bytes.dat
+        run: |
+          cobra empaquetar --output dist --add-data all-bytes.dat:all-bytes.dat
       - name: Upload executable
         uses: actions/upload-artifact@v4
         with:
           name: cobra-${{ matrix.os }}
           path: dist/*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/**


### PR DESCRIPTION
## Summary
- add release job after build to publish artifacts
- restructure build step to multiline command

## Testing
- `yamllint .github/workflows/build-exe.yml` *(warnings: missing document start, truthy value)*
- `pytest -q` *(fails: No module named 'cobra')*

------
https://chatgpt.com/codex/tasks/task_e_68a4c4f66a98832795fffd2c7d1dc2ed