### PR TITLE
chore: ajustar workflow de CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,8 +11,11 @@ permissions:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'


### PR DESCRIPTION
## Summary
- define fetch-depth to 0 in CodeQL checkout
- set analyze job timeout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68a4c71525f88327b8dbd6a4da675991