### PR TITLE
chore: cache docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,8 +22,19 @@ jobs:
           cache-dependency-path: |
             requirements.txt
             requirements-dev.txt
+      - uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-docker-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-docker-
       - name: Build Docker image
-        run: docker build --target final -t pcobra-cli .
+        run: |
+          docker build --target final \
+            --cache-from type=local,src=/tmp/.buildx-cache \
+            --cache-to type=local,dest=/tmp/.buildx-cache-new \
+            -t pcobra-cli .
+      - name: Move Docker cache
+        run: mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       - name: Smoke test
         run: docker run --rm pcobra-cli --version
       - name: Check image size


### PR DESCRIPTION
## Summary
- cache Docker build in GitHub workflow

## Testing
- `python3 check.py` *(fails: ruff falló; mypy falló; bandit no encontrado; pytest falló; pyright not executed)*

------
https://chatgpt.com/codex/tasks/task_e_68a553d172848327983e919016d605f7