### PR TITLE
ci: update Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   pages: write
+  id-token: write
 
 jobs:
   deploy:
@@ -38,9 +39,7 @@ jobs:
         run: make -C docs/_build/latex all-pdf
       - name: Copy PDF to build dir
         run: cp docs/_build/latex/proyectocobra.pdf docs/_build/
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - uses: actions/upload-pages-artifact@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/_build
-          publish_branch: gh-pages
+          path: docs/_build
+      - uses: actions/deploy-pages@v2


### PR DESCRIPTION
## Summary
- migrate Pages workflow to `upload-pages-artifact` and `deploy-pages`
- add `id-token` permission for GitHub Pages

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68a56039e97883279b2717891a71b3d1