### PR TITLE
ci: ejecutar etiquetado en contexto del PR

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -3,7 +3,7 @@ permissions:
   contents: read
   pull-requests: write
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
 jobs:
   label:


### PR DESCRIPTION
## Summary
- Cambiar el flujo de etiquetado de PRs para ejecutarse en contexto del `pull_request`

## Testing
- `pytest -q` (errores: ModuleNotFoundError: No module named 'cli.cli')

------
https://chatgpt.com/codex/tasks/task_e_68a56d705ebc83278d182119ef031a94