### PR TITLE
refactor: reutilizar workflow de binarios

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
     tags: [ 'v*.*.*' ]
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,48 +1,12 @@
 name: Release Binaries
 permissions:
-  contents: read
+  contents: write
 
 on:
   push:
     tags: ['v*.*.*']
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements.txt
-            requirements-dev.txt
-      - name: Install dependencies
-        uses: ./.github/actions/install
-        with:
-          extra: "pyinstaller"
-      - name: Build executable
-        run: cobra empaquetar --output dist --add-data all-bytes.dat:all-bytes.dat
-      - name: Upload executable
-        uses: actions/upload-artifact@v4
-        with:
-          name: cobra-${{ matrix.os }}
-          path: dist/*
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: dist/**/cobra*
+  release-binaries:
+    uses: ./.github/workflows/build-binaries.yml
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,43 +48,23 @@ jobs:
           docker build -t "$DOCKERHUB_USERNAME/cobra:${{ github.ref_name }}" .
           docker push "$DOCKERHUB_USERNAME/cobra:${{ github.ref_name }}"
 
-  build-executables:
+  build-binaries:
     needs: publish-artifacts
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements.txt
-            requirements-dev.txt
-      - name: Install dependencies
-        uses: ./.github/actions/install
-        with:
-          extra: "pyinstaller"
-      - name: Build executable
-        run: cobra empaquetar --output dist
-      - name: Upload executable
-        uses: actions/upload-artifact@v4
-        with:
-          name: cobra-${{ matrix.os }}
-          path: dist/*
+    uses: ./.github/workflows/build-binaries.yml
+    secrets: inherit
 
   release:
-    needs: build-executables
+    needs: [publish-artifacts, build-binaries]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
         with:
           path: dist
+          merge-multiple: true
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.ref_name }}
           files: |
             dist/**/cobra*
       - name: Notify Slack


### PR DESCRIPTION
## Summary
- expose build-binaries workflow via `workflow_call`
- release workflow reuses binary build and merges artifacts
- release-binaries workflow delegates to build-binaries

## Testing
- `pytest` *(fails: No module named 'core'; unrecognized arguments --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*
- `pip install -r requirements-dev.txt` *(cancelled: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_68a571fa34f08327915ab171005f41f1