### PR TITLE
Use PowerShell for Windows binary builds

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -22,7 +22,7 @@ jobs:
           - os: ubuntu-latest
             shell: bash
           - os: windows-latest
-            shell: bash
+            shell: pwsh
           # mac: build both arm64 (Apple Silicon) and x86_64 (Intel)
           - os: macos-latest
             shell: bash
@@ -67,12 +67,7 @@ jobs:
         shell: ${{ matrix.shell }}
         env:
           PYINSTALLER_ARCH: ${{ matrix.mac_arch || '' }}
-        run: |
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            bash scripts/build_cli.sh
-          else
-            ./scripts/build_cli.sh
-          fi
+        run: ${{ runner.os == 'Windows' && './scripts/build_cli.ps1' || './scripts/build_cli.sh' }}
 
       - name: List dist
         if: always()


### PR DESCRIPTION
## Summary
- Use PowerShell `build_cli.ps1` for Windows binary builds
- Run Windows matrix jobs with PowerShell shell

## Testing
- `pytest -q` *(fails: No module named 'cobra'; unrecognized arguments: --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68a592b0a4248327af2ea19f8bcdc868