### PR TITLE
fix(ci): eliminar referencia a all-bytes.dat

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -28,7 +28,7 @@ jobs:
           extra: "pyinstaller"
       - name: Build executable
         run: |
-          cobra empaquetar --output dist --add-data all-bytes.dat:all-bytes.dat
+          cobra empaquetar --output dist
       - name: Upload executable
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- remove `--add-data` parameter from build-exe workflow to avoid missing `all-bytes.dat`

## Testing
- `pre-commit run --files .github/workflows/build-exe.yml` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a596ad1a208327bc9ab1ba9b771010