### PR TITLE
ci: use maintained JDK and disable choco progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          choco install -y mingw golang ruby rust jdk llvm
+          choco install -y --no-progress mingw golang ruby rust temurin17 llvm
       - name: Install dependencies
         uses: ./.github/actions/install
         with:


### PR DESCRIPTION
## Summary
- replace jdk with temurin17 in Windows CI
- add --no-progress flag to chocolatey install

## Testing
- `pytest -q` *(fails: No module named 'cobra')*


------
https://chatgpt.com/codex/tasks/task_e_68a598bd493083279b2311e63922b81e