### PR TITLE
ci: enable npm cache for Node setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
       - name: Install system packages (Linux)
         if: runner.os == 'Linux'
         shell: bash
@@ -119,6 +120,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
       - name: Install system packages
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary
- cache npm dependencies in CI workflow

## Testing
- `yamllint .github/workflows/ci.yml` *(warnings: missing document start, truthy value should be one of [false, true])*

------
https://chatgpt.com/codex/tasks/task_e_68a59c0120b88327a601aed671f85c6c