### PR TITLE
ci: usa acciones Docker y análisis con Trivy

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/pcobra-cli:latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -27,27 +29,43 @@ jobs:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-docker-${{ github.sha }}
           restore-keys: ${{ runner.os }}-docker-
-      - name: Build Docker image
-        run: |
-          docker build --target final \
-            --cache-from type=local,src=/tmp/.buildx-cache \
-            --cache-to type=local,dest=/tmp/.buildx-cache-new \
-            -t pcobra-cli .
+      - name: Login to Docker registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: final
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          tags: ${{ env.IMAGE_NAME }}
+          push: true
       - name: Move Docker cache
         run: mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       - name: Smoke test
-        run: docker run --rm pcobra-cli --version
+        run: docker run --rm $IMAGE_NAME --version
       - name: Check image size
         run: |
-          size=$(docker image inspect pcobra-cli --format '{{.Size}}')
+          size=$(docker image inspect $IMAGE_NAME --format '{{.Size}}')
           echo "Image size: $size bytes"
           max_size=$((50 * 1024 * 1024))
           if [ "$size" -ge "$max_size" ]; then
             echo "Image is too large" >&2
             exit 1
           fi
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.32.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}
+          format: table
+          exit-code: 1
+          vuln-type: 'os,library'
+          ignore-unfixed: true
       - name: Save image
-        run: docker save pcobra-cli -o pcobra-cli.tar
+        run: docker save $IMAGE_NAME -o pcobra-cli.tar
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Resumen
- Se configura `docker/login-action` con credenciales de DockerHub
- Se reemplaza el build manual por `docker/build-push-action` con `push: true`
- Se añade escaneo de vulnerabilidades mediante `aquasecurity/trivy-action`

## Testing
- `pytest -q` *(falla: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_68a5a12ed9408327892bf66cbe7517ed