### PR TITLE
chore: use pull_request_target for PR labeling

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,9 +1,10 @@
+---
 name: Label PRs by branch
 permissions:
   contents: read
-  pull-requests: write
-on:
-  pull_request:
+  pull-requests: "write"
+'on':
+  pull_request_target:
     types: [opened, reopened, synchronize]
 jobs:
   label:


### PR DESCRIPTION
## Summary
- safeguard PR labeler workflow using `pull_request_target`
- add YAML document start and quote reserved keys

## Testing
- `yamllint .github/workflows/pr-labeler.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68a5a377dc288327bf199a7889d78f27