### PR TITLE
ci: install openjdk via chocolatey

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          choco install -y --no-progress mingw golang ruby rust temurin17 llvm
+          choco install -y --no-progress mingw golang ruby rust openjdk llvm
       - name: Install dependencies
         uses: ./.github/actions/install
         with:


### PR DESCRIPTION
## Summary
- replace chocolatey jdk package with openjdk and keep --no-progress to avoid timeouts

## Testing
- `pytest -q` *(fails: unrecognized arguments --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bbbdb6d88327a0b47816b2db53a9