### PR TITLE
chore: configurar cache de npm en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
       - name: Install system packages (Linux)
         if: runner.os == 'Linux'
         shell: bash
@@ -121,6 +122,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
       - name: Install system packages
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary
- agrega `cache-dependency-path` para caché de npm en la configuración CI

## Testing
- `pytest -q` *(falla: No module named 'cobra')*

------
https://chatgpt.com/codex/tasks/task_e_68a5c39bed508327b948a801a49ccda2