### PR TITLE
Allow manual execution of release binaries workflow

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -3,6 +3,7 @@ permissions:
   contents: write
 
 on:
+  workflow_dispatch:
   push:
     tags: ['v*.*.*']
 


### PR DESCRIPTION
## Summary
- allow manual workflow dispatch for release-binaries

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68a5d8770c7c832780c172315f856656