### PR TITLE
ci: instala paquetes LaTeX antes de configurar pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,6 +41,8 @@ jobs:
         run: make -C docs/_build/latex all-pdf
       - name: Copy PDF to build dir
         run: cp docs/_build/latex/proyectocobra.pdf docs/_build/
+      - name: Install LaTeX packages for deploy
+        run: sudo apt-get update && sudo apt-get install -y texlive-latex-recommended texlive-latex-extra latexmk
       - uses: actions/configure-pages@v2
       - uses: actions/upload-pages-artifact@v2
         with:


### PR DESCRIPTION
## Summary
- instala paquetes LaTeX justo antes de configurar Pages
- asegura la configuración de Pages antes de subir el artefacto

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68a5f4fa99108327b52b1fc3379e5987