### PR TITLE
ci: agregar ejecución semanal de CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,8 @@ name: CodeQL
 on:
   push:
   pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- programa CodeQL semanal en GitHub Actions

## Testing
- `pytest` (errores: ModuleNotFoundError: No module named 'cli.cli')

------
https://chatgpt.com/codex/tasks/task_e_68a5f95ca0388327a8a67a919fb284a4