### PR TITLE
feat(cli): add config loader

### DIFF
--- a/src/cobra/cli/utils/__init__.py
+++ b/src/cobra/cli/utils/__init__.py
@@ -1,7 +1,5 @@
 """Utilidades varias para la CLI de Cobra."""
 
-__all__ = ["messages", "semver"]
+from . import config
 
-
-def config():
-    return None
+__all__ = ["messages", "semver", "config"]

--- a/src/cobra/cli/utils/config.py
+++ b/src/cobra/cli/utils/config.py
@@ -1,0 +1,54 @@
+"""Funciones para cargar la configuración de la CLI de Cobra."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict
+
+try:  # Python >= 3.11
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
+
+DEFAULTS = {
+    "language": "es",
+    "default_command": "interactive",
+    "log_format": "%(asctime)s - %(levelname)s - %(message)s",
+    "program_name": "cobra",
+}
+
+
+def load_config() -> Dict[str, str]:
+    """Carga la configuración para la CLI.
+
+    Se busca un archivo ``cobra-cli.toml`` en el directorio actual y se
+    permiten sobrescribir valores mediante variables de entorno.
+
+    Returns:
+        Dict[str, str]: Configuración con las claves ``language``,
+        ``default_command``, ``log_format`` y ``program_name``.
+    """
+
+    config = DEFAULTS.copy()
+    cfg_path = Path("cobra-cli.toml")
+    if cfg_path.exists():
+        try:
+            with cfg_path.open("rb") as f:
+                data = tomllib.load(f)
+            if isinstance(data, dict):
+                for key in DEFAULTS:
+                    if key in data:
+                        config[key] = data[key]
+        except (OSError, tomllib.TOMLDecodeError):  # pragma: no cover
+            pass
+
+    config["language"] = os.environ.get("COBRA_LANG", config["language"])
+    config["default_command"] = os.environ.get(
+        "COBRA_DEFAULT_COMMAND", config["default_command"]
+    )
+    config["log_format"] = os.environ.get("COBRA_LOG_FORMAT", config["log_format"])
+    config["program_name"] = os.environ.get(
+        "COBRA_PROGRAM_NAME", config["program_name"]
+    )
+    return config


### PR DESCRIPTION
## Summary
- add utility to load CLI configuration from `cobra-cli.toml` or environment variables
- expose config module in `cobra.cli.utils`

## Testing
- `PYTHONPATH=src .venv/bin/python -m pytest -c /dev/null src/tests/unit/test_cli_menu.py -q` *(fails: 'list' object has no attribute 'values')*

------
https://chatgpt.com/codex/tasks/task_e_68a60beb8ca88327bc60563dc2115ce7