### PR TITLE
Refina recursión de autocompletado en CLI

### DIFF
--- a/src/cobra/cli/cli.py
+++ b/src/cobra/cli/cli.py
@@ -192,10 +192,12 @@ class CliApplication:
 
         for action in parser._actions:
             choices = getattr(action, "choices", None)
-            if choices:
-                for sub in choices.values():
-                    self._configure_autocomplete(sub)
-            elif action.dest in file_args:
+            if isinstance(choices, dict) or isinstance(action, argparse._SubParsersAction):
+                if isinstance(choices, dict):
+                    for sub in choices.values():
+                        self._configure_autocomplete(sub)
+                continue
+            if action.dest in file_args:
                 action.completer = FilesCompleter()
             elif action.dest in dir_args:
                 action.completer = DirectoriesCompleter()


### PR DESCRIPTION
## Summary
- Ajusta `_configure_autocomplete` para verificar el tipo de `choices` y evitar recursión innecesaria.

## Testing
- `PYTHONPATH=src PYTEST_ADDOPTS="--cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=0" pytest src/tests/unit/test_cli.py::test_cli_interactive -q` *(falla: No module named 'cli.cli')*
- `PYTHONPATH=src PYTEST_ADDOPTS="--cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=0" pytest src/tests/unit/test_cli.py::test_cli_transpilador -q` *(falla: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_68a6be61eeec832797278b4fa1ef70ef