### PR TITLE
Add autocomplete test for list-based choices

### DIFF
--- a/src/tests/unit/test_cli_autocomplete_list.py
+++ b/src/tests/unit/test_cli_autocomplete_list.py
@@ -1,0 +1,19 @@
+import pytest
+from argcomplete.completers import FilesCompleter
+
+from cobra.cli.cli import CliApplication
+from cobra.cli.utils.argument_parser import CustomArgumentParser
+
+
+def test_configure_autocomplete_with_list_choices():
+    app = CliApplication()
+    parser = CustomArgumentParser(prog="cobra")
+    parser.add_argument("archivo", choices=["uno", "dos"])
+
+    try:
+        app._configure_autocomplete(parser)
+    except Exception as exc:  # pragma: no cover
+        pytest.fail(f"_configure_autocomplete raised {exc}")
+
+    action = next(a for a in parser._actions if a.dest == "archivo")
+    assert isinstance(getattr(action, "completer", None), FilesCompleter)


### PR DESCRIPTION
## Summary
- add unit test ensuring `_configure_autocomplete` handles list `choices` and assigns file completer

## Testing
- `pytest src/tests/unit/test_cli_autocomplete_list.py` *(fails: Required test coverage of 85% not reached)*
- `pytest --no-cov src/tests/unit/test_cli_autocomplete_list.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6c0e7e8b48327b2a8b025bf1d4c31