### PR TITLE
feat(cli): add interactive command to registry

### DIFF
--- a/src/cobra/cli/cli.py
+++ b/src/cobra/cli/cli.py
@@ -27,6 +27,7 @@ from cobra.cli.commands.empaquetar_cmd import EmpaquetarCommand
 from cobra.cli.commands.execute_cmd import ExecuteCommand
 from cobra.cli.commands.flet_cmd import FletCommand
 from cobra.cli.commands.init_cmd import InitCommand
+from cobra.cli.commands.interactive_cmd import InteractiveCommand
 from core.interpreter import InterpretadorCobra
 from cobra.cli.commands.jupyter_cmd import JupyterCommand
 from cobra.cli.commands.modules_cmd import ModulesCommand
@@ -65,7 +66,7 @@ class AppConfig:
     LOG_FORMAT = config_data.get("log_format", "%(asctime)s - %(levelname)s - %(message)s")
     PROGRAM_NAME = config_data.get("program_name", "cobra")
     BASE_COMMAND_CLASSES: List[Type[BaseCommand]] = [
-        CompileCommand, ExecuteCommand, ModulesCommand,
+        InteractiveCommand, CompileCommand, ExecuteCommand, ModulesCommand,
         DependenciasCommand, DocsCommand, EmpaquetarCommand,
         PaqueteCommand, CrearCommand, InitCommand,
         JupyterCommand, FletCommand, ContainerCommand,

--- a/src/tests/unit/test_command_registry_interactive.py
+++ b/src/tests/unit/test_command_registry_interactive.py
@@ -1,0 +1,25 @@
+import argparse
+from unittest.mock import MagicMock, patch
+
+from cobra.cli.cli import CommandRegistry
+from cobra.cli.commands.interactive_cmd import InteractiveCommand
+
+
+def test_register_base_commands_includes_interactive():
+    registry = CommandRegistry(MagicMock())
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    with patch('cobra.cli.cli.descubrir_plugins', return_value=[]):
+        commands = registry.register_base_commands(subparsers)
+    assert 'interactive' in commands
+    assert isinstance(commands['interactive'], InteractiveCommand)
+
+
+def test_get_default_command_returns_interactive():
+    registry = CommandRegistry(MagicMock())
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    with patch('cobra.cli.cli.descubrir_plugins', return_value=[]):
+        registry.register_base_commands(subparsers)
+    default_cmd = registry.get_default_command()
+    assert isinstance(default_cmd, InteractiveCommand)


### PR DESCRIPTION
## Summary
- allow CLI to import InteractiveCommand and include it in base commands
- add tests ensuring CommandRegistry registers InteractiveCommand and returns it as default

## Testing
- `pytest src/tests/unit/test_command_registry_interactive.py` *(fails: Coverage failure: total of 22 is less than fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d89d3fec8327a1f0e8b161a54e44