### PR TITLE
Mostrar ayuda cuando se pasa un comando inválido

### DIFF
--- a/src/cobra/cli/cli.py
+++ b/src/cobra/cli/cli.py
@@ -281,7 +281,8 @@ class CliApplication:
         if command == "menu":
             return self.run_menu()
         if not command:
-            messages.mostrar_error(_("Invalid command"))
+            self.parser.print_help()
+            messages.mostrar_error(_("Comando inválido. Use --help para ver opciones."))
             return 1
             
         try:


### PR DESCRIPTION
## Resumen
- Mostrar ayuda del parser si no se detecta un comando
- Mensaje de error más claro indicando cómo obtener ayuda

## Testing
- `pytest -q` (falla: ModuleNotFoundError: No module named 'jsonschema')

------
https://chatgpt.com/codex/tasks/task_e_68a6dc735e048327845185455dc63ab0