### PR TITLE
Handle missing default CLI command

### DIFF
--- a/src/cobra/cli/cli.py
+++ b/src/cobra/cli/cli.py
@@ -114,6 +114,13 @@ class CommandRegistry:
                 logging.error(f"Failed to register subparser for {command.name}: {e}")
                 del self.commands[command.name]
 
+        if AppConfig.DEFAULT_COMMAND not in self.commands:
+            fallback = "interactive" if "interactive" in self.commands else next(iter(self.commands), None)
+            logging.warning(
+                "Default command '%s' not found. Falling back to '%s'", AppConfig.DEFAULT_COMMAND, fallback
+            )
+            AppConfig.DEFAULT_COMMAND = fallback
+
         return self.commands
 
     def get_default_command(self) -> Optional[BaseCommand]:


### PR DESCRIPTION
## Summary
- warn and fall back to a safe command when configured default is missing
- test default command fallback behavior

## Testing
- `PYTHONPATH=src pytest src/tests/unit/test_command_registry_interactive.py::test_register_base_commands_uses_fallback_for_missing_default --cov-fail-under=0 -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6deda3b8c83278ba9473c80ba0986