### PR TITLE
Evitar importación de resource en modo interactivo

### DIFF
--- a/src/cobra/cli/commands/interactive_cmd.py
+++ b/src/cobra/cli/commands/interactive_cmd.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import re
-import resource
 import traceback
 from typing import Optional, Any, NoReturn
 from argparse import ArgumentParser
@@ -15,6 +14,7 @@ from cobra.core import Lexer, LexerError
 from cobra.core import Parser, ParserError
 from cobra.transpilers import module_map
 from core.interpreter import InterpretadorCobra
+from core.resource_limits import limitar_memoria_mb
 from core.qualia_bridge import get_suggestions
 from core.sandbox import (
     ejecutar_en_contenedor,
@@ -162,12 +162,9 @@ class InteractiveCommand(BaseCommand):
                 return 1
 
             try:
-                resource.setrlimit(
-                    resource.RLIMIT_AS,
-                    (memory_limit * 1024 * 1024,) * 2
-                )
-            except OSError as e:
-                mostrar_error(f"Error al establecer límites de recursos: {e}")
+                limitar_memoria_mb(memory_limit)
+            except RuntimeError as e:
+                mostrar_error(f"Error al establecer límite de memoria: {e}")
                 return 1
 
             # Validar dependencias


### PR DESCRIPTION
## Resumen
- Reemplazo de `resource` por `limitar_memoria_mb` en `InteractiveCommand` para compatibilidad multiplataforma.
- Manejo explícito de `RuntimeError` al establecer el límite de memoria.

## Testing
- `PYTHONPATH=src python - <<'PY' ...` (importación en Unix)
- `PYTHONPATH=src python - <<'PY' ...` (importación sin módulo `resource` para simular Windows)
- `PYTHONPATH=src pytest -q --override-ini="addopts=" src/tests/unit/test_resource_limits.py` *(falla: ValueError: not allowed to raise maximum limit)*

------
https://chatgpt.com/codex/tasks/task_e_68a6efcab7f483279437743ead7968dc