### PR TITLE
Use pytest.importorskip for resource-dependent tests

### DIFF
--- a/src/tests/unit/test_resource_limits.py
+++ b/src/tests/unit/test_resource_limits.py
@@ -1,4 +1,7 @@
-import resource
+import pytest
+
+resource = pytest.importorskip("resource")
+
 from core.resource_limits import limitar_memoria_mb, limitar_cpu_segundos
 
 


### PR DESCRIPTION
## Summary
- Import `resource` using `pytest.importorskip` in `test_resource_limits.py` to skip tests when the module is unavailable.

## Testing
- `python -m pytest src/tests/unit/test_resource_limits.py -q -p no:cov -o addopts=` *(fails: ValueError: not allowed to raise maximum limit)*

------
https://chatgpt.com/codex/tasks/task_e_68a70525ba3c83278aacc5c9328970fa