### PR TITLE
Centralizar límites de recursos en comandos

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -3,6 +3,10 @@
 Al importar :mod:`src.core` se exponen todas las clases que componen el
 árbol de sintaxis abstracta junto con el visitante base ``NodeVisitor``.
 Esto simplifica el uso de la biblioteca desde otros módulos.
+
+Las funciones para limitar recursos ``limitar_memoria_mb`` y
+``limitar_cpu_segundos`` también se exponen aquí y deben usarse en lugar
+de implementaciones manuales.
 """
 
 from core.ast_nodes import *

--- a/src/core/resource_limits.py
+++ b/src/core/resource_limits.py
@@ -1,4 +1,7 @@
-"""Utilidades para limitar memoria y tiempo de CPU."""
+"""Utilidades centralizadas para limitar memoria y tiempo de CPU.
+
+Todos los comandos deben emplear estas funciones en lugar de
+implementaciones manuales para gestionar los límites de recursos."""
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Resumen
- Reemplazado el mecanismo manual de tiempo en `execute` por `limitar_cpu_segundos`.
- Documentado que los límites de recursos deben pasar por `core.resource_limits`.

## Testing
- `python -m py_compile src/cobra/cli/commands/execute_cmd.py src/core/__init__.py src/core/resource_limits.py`
- `PYTHONPATH=src pytest` *(falla: ModuleNotFoundError: No module named 'cli.commands')*


------
https://chatgpt.com/codex/tasks/task_e_68a7091c6a0c832785d416543f88f08f