### PR TITLE
Soporte de límites de recursos multiplataforma

### DIFF
--- a/src/core/resource_limits.py
+++ b/src/core/resource_limits.py
@@ -5,14 +5,23 @@ implementaciones manuales para gestionar los límites de recursos."""
 from __future__ import annotations
 
 import logging
+import os
+import sys
 
 
 logger = logging.getLogger(__name__)
+IS_WINDOWS = os.name == "nt" or sys.platform.startswith("win")
 
 
 def limitar_memoria_mb(mb: int) -> None:
     """Restringe la memoria máxima del proceso actual."""
     bytes_ = mb * 1024 * 1024
+    if IS_WINDOWS:
+        if not _limitar_memoria_psutil(bytes_):
+            logger.warning(
+                "No se pudo establecer el límite de memoria en Windows; el ajuste se omitirá.",
+            )
+        return
     try:
         import resource
     except ImportError as exc:
@@ -34,29 +43,44 @@ def limitar_memoria_mb(mb: int) -> None:
         _limitar_memoria_psutil(bytes_)
 
 
-def _limitar_memoria_psutil(bytes_: int) -> None:
+def _limitar_memoria_psutil(bytes_: int) -> bool:
     try:
         import psutil  # type: ignore
     except ImportError as exc:
-        # Falta 'psutil'; no hay forma de establecer el límite.
-        logger.error(
-            "El módulo 'psutil' no está disponible para limitar la memoria.",
-            exc_info=exc,
-        )
-        raise RuntimeError("No se pudo establecer el límite de memoria") from exc
+        mensaje = "El módulo 'psutil' no está disponible para limitar la memoria."
+        if IS_WINDOWS:
+            logger.warning(mensaje, exc_info=exc)
+            return False
+        logger.error(mensaje, exc_info=exc)
+        raise RuntimeError("No se pudo establecer el límite de memoria en esta plataforma") from exc
+    proc = psutil.Process()
+    if not hasattr(proc, "rlimit"):
+        mensaje = "psutil.Process no soporta 'rlimit'; no se aplicará el límite de memoria."
+        if IS_WINDOWS:
+            logger.warning(mensaje)
+            return False
+        logger.error(mensaje)
+        raise RuntimeError("No se pudo establecer el límite de memoria en esta plataforma")
     try:
-        psutil.Process().rlimit(psutil.RLIMIT_AS, (bytes_, bytes_))
+        proc.rlimit(psutil.RLIMIT_AS, (bytes_, bytes_))
+        return True
     except (OSError, ValueError) as exc:
-        # Error de configuración en 'psutil'.
-        logger.error(
-            "Error configurando el límite de memoria con 'psutil'.",
-            exc_info=exc,
-        )
-        raise RuntimeError("No se pudo establecer el límite de memoria") from exc
+        mensaje = "Error configurando el límite de memoria con 'psutil'."
+        if IS_WINDOWS:
+            logger.warning(mensaje, exc_info=exc)
+            return False
+        logger.error(mensaje, exc_info=exc)
+        raise RuntimeError("No se pudo establecer el límite de memoria en esta plataforma") from exc
 
 
 def limitar_cpu_segundos(segundos: int) -> None:
     """Limita el tiempo de CPU en segundos para este proceso."""
+    if IS_WINDOWS:
+        if not _limitar_cpu_psutil(segundos):
+            logger.warning(
+                "No se pudo establecer el límite de CPU en Windows; el ajuste se omitirá."
+            )
+        return
     try:
         import resource
     except ImportError as exc:
@@ -78,22 +102,31 @@ def limitar_cpu_segundos(segundos: int) -> None:
         _limitar_cpu_psutil(segundos)
 
 
-def _limitar_cpu_psutil(segundos: int) -> None:
+def _limitar_cpu_psutil(segundos: int) -> bool:
     try:
         import psutil  # type: ignore
     except ImportError as exc:
-        # Falta 'psutil'; no hay forma de establecer el límite.
-        logger.error(
-            "El módulo 'psutil' no está disponible para limitar la CPU.",
-            exc_info=exc,
-        )
-        raise RuntimeError("No se pudo establecer el límite de CPU") from exc
+        mensaje = "El módulo 'psutil' no está disponible para limitar la CPU."
+        if IS_WINDOWS:
+            logger.warning(mensaje, exc_info=exc)
+            return False
+        logger.error(mensaje, exc_info=exc)
+        raise RuntimeError("No se pudo establecer el límite de CPU en esta plataforma") from exc
+    proc = psutil.Process()
+    if not hasattr(proc, "rlimit"):
+        mensaje = "psutil.Process no soporta 'rlimit'; no se aplicará el límite de CPU."
+        if IS_WINDOWS:
+            logger.warning(mensaje)
+            return False
+        logger.error(mensaje)
+        raise RuntimeError("No se pudo establecer el límite de CPU en esta plataforma")
     try:
-        psutil.Process().rlimit(psutil.RLIMIT_CPU, (segundos, segundos))
+        proc.rlimit(psutil.RLIMIT_CPU, (segundos, segundos))
+        return True
     except (OSError, ValueError) as exc:
-        # Error de configuración en 'psutil'.
-        logger.error(
-            "Error configurando el límite de CPU con 'psutil'.",
-            exc_info=exc,
-        )
-        raise RuntimeError("No se pudo establecer el límite de CPU") from exc
+        mensaje = "Error configurando el límite de CPU con 'psutil'."
+        if IS_WINDOWS:
+            logger.warning(mensaje, exc_info=exc)
+            return False
+        logger.error(mensaje, exc_info=exc)
+        raise RuntimeError("No se pudo establecer el límite de CPU en esta plataforma") from exc


### PR DESCRIPTION
## Resumen
- Detectar Windows y usar `psutil` como alternativa, omitiendo el límite si no es soportado
- Validar disponibilidad de `rlimit` en `psutil.Process` antes de aplicar límites

## Testing
- `pytest -q` *(errores: ModuleNotFoundError: No module named 'cli.cli')*
- `cd src/cobra-lenguaje && pytest -q` *(errores: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68a74cbbad948327b022bad740431021