### PR TITLE
Añadir pruebas para límites de recursos sin soporte y configurar CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,12 @@ jobs:
         run: |
           if [ -d tests ]; then
             pytest tests src/tests --cov=src --cov-report=xml \
-              --cov-report=term-missing --cov-fail-under=95
+              --cov-report=term-missing --cov-fail-under=95 -m "not windows"
+            pytest tests src/tests -m windows
           else
             pytest src/tests --cov=src --cov-report=xml \
-              --cov-report=term-missing --cov-fail-under=95
+              --cov-report=term-missing --cov-fail-under=95 -m "not windows"
+            pytest src/tests -m windows
           fi
       - name: Run LLVM examples
         shell: bash

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ markers =
     integration: pruebas de integración
     fuzz: pruebas de mutación/fuzzing
     performance: pruebas de rendimiento
+    windows: pruebas específicas de Windows
 
 # Rutas de tests por defecto
 testpaths =

--- a/src/tests/core/test_resource_limits.py
+++ b/src/tests/core/test_resource_limits.py
@@ -1,0 +1,47 @@
+import logging
+import sys
+import types
+
+import pytest
+
+from core import resource_limits
+
+
+@pytest.mark.windows
+def test_limitar_memoria_sin_resource_y_psutil_sin_rlimit(monkeypatch, caplog):
+    monkeypatch.delitem(sys.modules, "resource", raising=False)
+    monkeypatch.setattr(resource_limits, "IS_WINDOWS", True)
+    fake_psutil = types.SimpleNamespace(
+        Process=lambda: types.SimpleNamespace(),
+        RLIMIT_AS=0,
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+    with caplog.at_level(logging.WARNING):
+        resource_limits.limitar_memoria_mb(1)
+    assert any(
+        "psutil.Process no soporta 'rlimit'" in record.message for record in caplog.records
+    )
+    assert any(
+        "No se pudo establecer el límite de memoria en Windows" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.windows
+def test_limitar_cpu_sin_resource_y_psutil_sin_rlimit(monkeypatch, caplog):
+    monkeypatch.delitem(sys.modules, "resource", raising=False)
+    monkeypatch.setattr(resource_limits, "IS_WINDOWS", True)
+    fake_psutil = types.SimpleNamespace(
+        Process=lambda: types.SimpleNamespace(),
+        RLIMIT_CPU=0,
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+    with caplog.at_level(logging.WARNING):
+        resource_limits.limitar_cpu_segundos(1)
+    assert any(
+        "psutil.Process no soporta 'rlimit'" in record.message for record in caplog.records
+    )
+    assert any(
+        "No se pudo establecer el límite de CPU en Windows" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Resumen
- Añade pruebas que simulan ausencia del módulo `resource` y un `psutil.Process` sin `rlimit`, verificando advertencias sin excepciones.
- Crea prueba equivalente para la limitación de CPU.
- Configura CI y `pytest.ini` para ejecutar tests marcados como `windows`.

## Pruebas
- `pytest -o addopts='' -p no:cov -m windows src/tests/core/test_resource_limits.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7608973dc83278f4d3606b2c34ac8