### PR TITLE
docs: document Windows resource limit caveats

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -281,3 +281,18 @@ captura al importar el módulo, por lo que modificar la variable de
 entorno después no surte efecto. Invocar la función sin esta
 configuración producirá un ``ValueError``.
 
+## 16. Limitaciones de recursos en Windows
+
+En sistemas Windows los límites de memoria y de CPU pueden no aplicarse
+correctamente. Si Cobra no logra establecer las restricciones solicitadas
+mostrará advertencias como:
+
+```
+No se pudo establecer el límite de memoria en Windows; el ajuste se omitirá.
+No se pudo establecer el límite de CPU en Windows; el ajuste se omitirá.
+```
+
+Para garantizar estos límites se recomienda ejecutar Cobra dentro de un
+contenedor como Docker o bajo WSL2, donde sí es posible aplicar las
+restricciones de recursos.
+

--- a/README_en.md
+++ b/README_en.md
@@ -312,6 +312,20 @@ python -m tests.suite_core          # Lexer, parser and interpreter tests
 python -m tests.suite_transpiladores  # Transpiler tests
 ```
 
+### Resource limits on Windows
+
+On Windows the operating system may ignore the requested memory and CPU
+limits. Cobra will warn when this happens, for example:
+
+```
+No se pudo establecer el límite de memoria en Windows; el ajuste se omitirá.
+No se pudo establecer el límite de CPU en Windows; el ajuste se omitirá.
+```
+
+To enforce these restrictions consider running Cobra inside a Linux
+container, such as Docker or WSL2, where resource limits are fully
+supported.
+
 ## Tokens and lexical rules
 
 The lexer converts code into tokens according to the regular expressions defined in `lexer.py`. The following table describes all available tokens:

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -196,6 +196,19 @@ Recomendaciones de estilo
 * Prefiere expresiones claras antes que construcciones complejas y evita macros
   innecesarias.
 
+Limitaciones de recursos en Windows
+-----------------------------------
+
+En sistemas Windows, las funciones que intentan limitar la memoria o el tiempo
+de CPU pueden no aplicarse. Cobra mostrará advertencias como::
+
+   No se pudo establecer el límite de memoria en Windows; el ajuste se omitirá.
+   No se pudo establecer el límite de CPU en Windows; el ajuste se omitirá.
+
+Para asegurar estos límites, ejecuta Cobra dentro de un contenedor (por
+ejemplo, Docker o WSL2) donde las restricciones de recursos sí se pueden
+aplicar.
+
 Recursos adicionales
 --------------------
 

--- a/docs/limitaciones_cpp_sandbox.md
+++ b/docs/limitaciones_cpp_sandbox.md
@@ -13,3 +13,16 @@ seguridad:
 
 Si la imagen no está disponible o Docker no está instalado se rechaza la
 operación con un error indicando que el contenedor de C++ no puede usarse.
+
+## Limitaciones en Windows
+
+En Windows los límites de memoria y CPU del contenedor pueden no aplicarse.
+Cuando esto sucede se registran advertencias como:
+
+```
+No se pudo establecer el límite de memoria en Windows; el ajuste se omitirá.
+No se pudo establecer el límite de CPU en Windows; el ajuste se omitirá.
+```
+
+Para aplicar correctamente estas restricciones utiliza un entorno basado en
+Linux, como WSL2 o Docker Desktop con un contenedor Linux.


### PR DESCRIPTION
## Summary
- document that CPU/memory limits may not apply on Windows
- include sample warning messages and container workarounds
- update manual and English README with Windows resource limit notes

## Testing
- `PYTHONPATH=$PWD pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68a76529ef848327b40da7f75b516297