### PR TITLE
feat: unificar idioma y probar logs

### DIFF
--- a/src/cobra/cli/commands/interactive_cmd.py
+++ b/src/cobra/cli/commands/interactive_cmd.py
@@ -2,8 +2,7 @@ import logging
 import os
 import re
 import traceback
-from typing import Optional, Any, NoReturn
-from argparse import ArgumentParser
+from typing import Optional, Any
 from types import TracebackType
 
 from prompt_toolkit import PromptSession
@@ -141,10 +140,10 @@ class InteractiveCommand(BaseCommand):
             raise RuntimeError(_("Se excedió la profundidad máxima del AST"))
 
         tokens = Lexer(linea).tokenizar()
-        logging.debug(f"Tokens generados: {tokens}")
+        logging.debug(_("Tokens generados: {tokens}").format(tokens=tokens))
 
         ast = Parser(tokens).parsear()
-        logging.debug(f"AST generado: {ast}")
+        logging.debug(_("AST generado: {ast}").format(ast=ast))
 
         if validador:
             for nodo in ast:
@@ -191,7 +190,7 @@ class InteractiveCommand(BaseCommand):
             # Validar dependencias
             validar_dependencias("python", module_map.get_toml_map())
         except (ValueError, FileNotFoundError) as err:
-            mostrar_error(f"Error de inicialización: {err}")
+            mostrar_error(_("Error de inicialización: {err}").format(err=err))
             return 1
 
         # Configurar modo seguro y validadores
@@ -350,5 +349,7 @@ class InteractiveCommand(BaseCommand):
             exc_tb: Traceback de la excepción
         """
         if exc_type is not None:
-            logging.error(f"Error al finalizar REPL: {exc_val}")
+            logging.error(
+                _("Error al finalizar REPL: {exc_val}").format(exc_val=exc_val)
+            )
         logging.info(_("Finalizando REPL de Cobra"))

--- a/src/core/resource_limits.py
+++ b/src/core/resource_limits.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from cobra.cli.i18n import _
 
 
 logger = logging.getLogger(__name__)
@@ -18,8 +19,11 @@ def limitar_memoria_mb(mb: int) -> None:
     bytes_ = mb * 1024 * 1024
     if IS_WINDOWS:
         if not _limitar_memoria_psutil(bytes_):
-            logger.warning(
-                "No se pudo establecer el límite de memoria en Windows; el ajuste se omitirá.",
+            logger.error(
+                _(
+                    "No se pudo establecer el límite de memoria en Windows; "
+                    "el ajuste se omitirá."
+                ),
             )
         return
     try:
@@ -27,7 +31,7 @@ def limitar_memoria_mb(mb: int) -> None:
     except ImportError as exc:
         # Falta 'resource', se intenta 'psutil'.
         logger.warning(
-            "El módulo 'resource' no está disponible; se intentará 'psutil'.",
+            _("El módulo 'resource' no está disponible; se intentará 'psutil'."),
             exc_info=exc,
         )
         _limitar_memoria_psutil(bytes_)
@@ -37,7 +41,10 @@ def limitar_memoria_mb(mb: int) -> None:
     except (OSError, ValueError) as exc:
         # Error de configuración en 'resource'.
         logger.warning(
-            "No se pudo configurar el límite de memoria con 'resource'; se intentará 'psutil'.",
+            _(
+                "No se pudo configurar el límite de memoria con 'resource'; "
+                "se intentará 'psutil'."
+            ),
             exc_info=exc,
         )
         _limitar_memoria_psutil(bytes_)
@@ -47,38 +54,49 @@ def _limitar_memoria_psutil(bytes_: int) -> bool:
     try:
         import psutil  # type: ignore
     except ImportError as exc:
-        mensaje = "El módulo 'psutil' no está disponible para limitar la memoria."
+        mensaje = _("El módulo 'psutil' no está disponible para limitar la memoria.")
         if IS_WINDOWS:
             logger.warning(mensaje, exc_info=exc)
             return False
         logger.error(mensaje, exc_info=exc)
-        raise RuntimeError("No se pudo establecer el límite de memoria en esta plataforma") from exc
+        raise RuntimeError(
+            _("No se pudo establecer el límite de memoria en esta plataforma")
+        ) from exc
     proc = psutil.Process()
     if not hasattr(proc, "rlimit"):
-        mensaje = "psutil.Process no soporta 'rlimit'; no se aplicará el límite de memoria."
+        mensaje = _(
+            "psutil.Process no soporta 'rlimit'; no se aplicará el límite de memoria."
+        )
         if IS_WINDOWS:
             logger.warning(mensaje)
             return False
         logger.error(mensaje)
-        raise RuntimeError("No se pudo establecer el límite de memoria en esta plataforma")
+        raise RuntimeError(
+            _("No se pudo establecer el límite de memoria en esta plataforma")
+        )
     try:
         proc.rlimit(psutil.RLIMIT_AS, (bytes_, bytes_))
         return True
     except (OSError, ValueError) as exc:
-        mensaje = "Error configurando el límite de memoria con 'psutil'."
+        mensaje = _("Error configurando el límite de memoria con 'psutil'.")
         if IS_WINDOWS:
             logger.warning(mensaje, exc_info=exc)
             return False
         logger.error(mensaje, exc_info=exc)
-        raise RuntimeError("No se pudo establecer el límite de memoria en esta plataforma") from exc
+        raise RuntimeError(
+            _("No se pudo establecer el límite de memoria en esta plataforma")
+        ) from exc
 
 
 def limitar_cpu_segundos(segundos: int) -> None:
     """Limita el tiempo de CPU en segundos para este proceso."""
     if IS_WINDOWS:
         if not _limitar_cpu_psutil(segundos):
-            logger.warning(
-                "No se pudo establecer el límite de CPU en Windows; el ajuste se omitirá."
+            logger.error(
+                _(
+                    "No se pudo establecer el límite de CPU en Windows; "
+                    "el ajuste se omitirá."
+                )
             )
         return
     try:
@@ -86,7 +104,7 @@ def limitar_cpu_segundos(segundos: int) -> None:
     except ImportError as exc:
         # Falta 'resource', se intenta 'psutil'.
         logger.warning(
-            "El módulo 'resource' no está disponible; se intentará 'psutil'.",
+            _("El módulo 'resource' no está disponible; se intentará 'psutil'."),
             exc_info=exc,
         )
         _limitar_cpu_psutil(segundos)
@@ -96,7 +114,10 @@ def limitar_cpu_segundos(segundos: int) -> None:
     except (OSError, ValueError) as exc:
         # Error de configuración en 'resource'.
         logger.warning(
-            "No se pudo configurar el límite de CPU con 'resource'; se intentará 'psutil'.",
+            _(
+                "No se pudo configurar el límite de CPU con 'resource'; "
+                "se intentará 'psutil'."
+            ),
             exc_info=exc,
         )
         _limitar_cpu_psutil(segundos)
@@ -106,27 +127,35 @@ def _limitar_cpu_psutil(segundos: int) -> bool:
     try:
         import psutil  # type: ignore
     except ImportError as exc:
-        mensaje = "El módulo 'psutil' no está disponible para limitar la CPU."
+        mensaje = _("El módulo 'psutil' no está disponible para limitar la CPU.")
         if IS_WINDOWS:
             logger.warning(mensaje, exc_info=exc)
             return False
         logger.error(mensaje, exc_info=exc)
-        raise RuntimeError("No se pudo establecer el límite de CPU en esta plataforma") from exc
+        raise RuntimeError(
+            _("No se pudo establecer el límite de CPU en esta plataforma")
+        ) from exc
     proc = psutil.Process()
     if not hasattr(proc, "rlimit"):
-        mensaje = "psutil.Process no soporta 'rlimit'; no se aplicará el límite de CPU."
+        mensaje = _(
+            "psutil.Process no soporta 'rlimit'; no se aplicará el límite de CPU."
+        )
         if IS_WINDOWS:
             logger.warning(mensaje)
             return False
         logger.error(mensaje)
-        raise RuntimeError("No se pudo establecer el límite de CPU en esta plataforma")
+        raise RuntimeError(
+            _("No se pudo establecer el límite de CPU en esta plataforma")
+        )
     try:
         proc.rlimit(psutil.RLIMIT_CPU, (segundos, segundos))
         return True
     except (OSError, ValueError) as exc:
-        mensaje = "Error configurando el límite de CPU con 'psutil'."
+        mensaje = _("Error configurando el límite de CPU con 'psutil'.")
         if IS_WINDOWS:
             logger.warning(mensaje, exc_info=exc)
             return False
         logger.error(mensaje, exc_info=exc)
-        raise RuntimeError("No se pudo establecer el límite de CPU en esta plataforma") from exc
+        raise RuntimeError(
+            _("No se pudo establecer el límite de CPU en esta plataforma")
+        ) from exc

--- a/src/tests/unit/test_interactive_cmd_logging.py
+++ b/src/tests/unit/test_interactive_cmd_logging.py
@@ -1,0 +1,27 @@
+import logging
+import types
+
+from cobra.cli.commands.interactive_cmd import InteractiveCommand
+from cobra.cli.i18n import _
+
+
+def test_context_logging(caplog):
+    dummy = types.SimpleNamespace()
+    cmd = InteractiveCommand(dummy)
+    with caplog.at_level(logging.INFO):
+        with cmd:
+            pass
+    messages = [r.message for r in caplog.records]
+    assert _("Iniciando REPL de Cobra") in messages
+    assert _("Finalizando REPL de Cobra") in messages
+
+
+def test_log_error_emits_error(caplog):
+    dummy = types.SimpleNamespace()
+    cmd = InteractiveCommand(dummy)
+    with caplog.at_level(logging.ERROR):
+        cmd._log_error(_("Error de prueba"), RuntimeError("fallo"))
+    record = caplog.records[-1]
+    assert _("Error de prueba") in record.message
+    assert record.levelno == logging.ERROR
+


### PR DESCRIPTION
## Summary
- Aplicar i18n y mejorar niveles de logging en `resource_limits`
- Localizar mensajes y logs en el REPL interactivo
- Añadir pruebas con `caplog` para validar mensajes de logging

## Testing
- `pytest src/tests/unit src/tests/core -q` *(falló: No module named 'yaml')*
- `pytest src/tests/core/test_resource_limits.py::test_limitar_memoria_sin_resource_y_psutil_sin_rlimit -q` *(falló: cobertura < 85%)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ea7da5708327871f276b09a7a91b