### PR TITLE
ci: run llvm examples only on linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
             pytest src/tests -m windows
           fi
       - name: Run LLVM examples
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           PYTHONPATH=src python scripts/test_llvm_examples.py


### PR DESCRIPTION
## Summary
- run LLVM example tests only on Linux runners

## Testing
- `pytest -q` *(fails: Error al importar el módulo: No module named 'cobra')*

------
https://chatgpt.com/codex/tasks/task_e_68a9c3d62678832787aa16b0216dc8fe