### PR TITLE
chore: streamline pages workflow LaTeX install

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,8 +41,6 @@ jobs:
         run: make -C docs/_build/latex all-pdf
       - name: Copy PDF to build dir
         run: cp docs/_build/latex/proyectocobra.pdf docs/_build/
-      - name: Install LaTeX packages for deploy
-        run: sudo apt-get update && sudo apt-get install -y texlive-latex-recommended texlive-latex-extra latexmk
       - uses: actions/configure-pages@v2
       - uses: actions/upload-pages-artifact@v2
         with:


### PR DESCRIPTION
## Summary
- remove duplicate LaTeX package install step from Pages workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68a9ea0921588327b172256603cf0ff3