### PR TITLE
Limita CPU en sandbox Docker

### DIFF
--- a/src/core/sandbox.py
+++ b/src/core/sandbox.py
@@ -235,7 +235,7 @@ def ejecutar_en_contenedor(
     usuario ``nobody`` (``--user 65534:65534``), con el sistema de archivos en
     modo solo lectura (``--read-only`` y ``--tmpfs /tmp``) y sin capacidades
     adicionales (``--cap-drop=ALL``). Además, se aplican límites de recursos
-    mediante ``--pids-limit`` y ``--memory`` para evitar abusos del sistema.
+    mediante ``--pids-limit``, ``--memory`` y ``--cpus`` para evitar abusos del sistema.
     """
 
     imagenes = {
@@ -257,6 +257,7 @@ def ejecutar_en_contenedor(
                 "--network=none",
                 "--pids-limit=128",
                 "--memory=256m",
+                "--cpus=1",
                 "--user", "65534:65534",
                 "--read-only",
                 "--tmpfs", "/tmp",


### PR DESCRIPTION
## Resumen
- Limita la ejecución de contenedores sandbox a un solo CPU con `--cpus=1`.
- Documenta el nuevo límite de CPU en la función `ejecutar_en_contenedor`.

## Testing
- `pytest src/tests/unit/test_security_sandbox.py` *(falla: RuntimeError: vm2 no disponible; cobertura < 85%)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ebfcf308832797c4025fe7dafb7e