### PR TITLE
Restringe PATH en sandbox JS

### DIFF
--- a/docs/limitaciones_node_sandbox.md
+++ b/docs/limitaciones_node_sandbox.md
@@ -6,7 +6,9 @@ memoria `--max-old-space-size=128` para deshabilitar las capacidades de red
 incluidas por defecto y restringir el consumo de memoria. El código se ejecuta
 mediante `vm2` en un contexto vacío donde únicamente se expone un objeto
 `console`. De esta forma no se tiene acceso a funciones internas de Node ni a
-módulos del sistema.
+módulos del sistema. Además, la ejecución se realiza con un entorno de
+variables reducido donde `PATH` apunta exclusivamente a `/usr/bin` o al
+directorio que contiene el ejecutable de Node.
 
 Es imprescindible mantener `vm2` actualizado; antes de cada ejecución se
 verifica que la versión instalada sea al menos `3.9.19` para mitigar


### PR DESCRIPTION
## Resumen
- Limita el entorno de `ejecutar_en_sandbox_js` a un `PATH` mínimo que solo apunta al directorio de Node o `/usr/bin`.
- Documenta la restricción del `PATH` en la sandbox de Node.

## Testing
- `ruff check src/core/sandbox.py`
- `PYTHONPATH=src pytest src/tests/unit/test_sandbox_js.py src/tests/unit/test_security_sandbox.py --cov-fail-under=0` *(falla: vm2 no disponible y ausencia de mensaje truncado)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f250455c83278efeaae9fe27e59f