### PR TITLE
chore: pin actions checkout

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -32,7 +32,7 @@ jobs:
             mac_arch: x86_64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # Fijado a commit para seguridad de la cadena de suministro
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # Fijado a commit para seguridad de la cadena de suministro
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # Fijado a commit para seguridad de la cadena de suministro
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v5
@@ -111,7 +111,7 @@ jobs:
   benchmarks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # Fijado a commit para seguridad de la cadena de suministro
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # Fijado a commit para seguridad de la cadena de suministro
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/pcobra-cli:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # Fijado a commit para seguridad de la cadena de suministro
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # Fijado a commit para seguridad de la cadena de suministro
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   publish-artifacts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # Fijado a commit para seguridad de la cadena de suministro
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # Fijado a commit para seguridad de la cadena de suministro
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'


### PR DESCRIPTION
## Summary
- pin `actions/checkout` to commit SHA across workflows
- document pinning reason for supply chain security

## Testing
- `pytest -q` *(fails: No module named 'cobra'; plugin coverage missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f957e8bc8327a58fc1c162cd9e7d