### PR TITLE
Include frontend docs in Pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,6 +35,8 @@ jobs:
         run: sphinx-build -b html frontend/docs frontend/build/html
       - name: Build root docs
         run: sphinx-build -b html docs docs/_build
+      - name: Copy frontend docs to build dir
+        run: cp -r frontend/build/html docs/_build/frontend
       - name: Build LaTeX docs
         run: sphinx-build -b latex docs docs/_build/latex
       - name: Build PDF manual


### PR DESCRIPTION
## Summary
- copy frontend HTML docs into `docs/_build/frontend` so Pages artifact includes frontend and root docs

## Testing
- `pytest` *(fails: unrecognized arguments --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fd4b9dac8327a7a584327bfc4dd8