### PR TITLE
Quote extra packages in install action and add workflow tests

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -16,6 +16,6 @@ runs:
         pip install -e .
         # pip install -e .[dev] también es válido para extras de desarrollo
         if [ -n "${{ inputs.extra }}" ]; then
-          pip install ${{ inputs.extra }}
+          pip install "${{ inputs.extra }}"
         fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,14 @@ jobs:
         uses: ./.github/actions/install
         with:
           extra: "sphinx sphinx-rtd-theme pytest-cov codecov pyright"
+      - name: Verify extra packages
+        shell: bash
+        run: |
+          python - <<'PY'
+          import importlib
+          for pkg in ["sphinx", "pyright"]:
+              importlib.import_module(pkg.replace('-', '_'))
+          PY
       - name: Seguridad de dependencias
         shell: bash
         run: |
@@ -134,6 +142,14 @@ jobs:
         uses: ./.github/actions/install
         with:
           extra: "sphinx sphinx-rtd-theme pytest-cov codecov pyright"
+      - name: Verify extra packages
+        shell: bash
+        run: |
+          python - <<'PY'
+          import importlib
+          for pkg in ["sphinx", "pyright"]:
+              importlib.import_module(pkg.replace('-', '_'))
+          PY
       - name: Compare benchmarks
         run: |
           python scripts/benchmarks/compare_releases.py \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,14 @@ jobs:
           choco install -y --no-progress mingw golang ruby rust openjdk
       - name: Install dependencies
         uses: ./.github/actions/install
+        with:
+          extra: "flask requests"
+      - name: Verify extra packages
+        shell: bash
+        run: |
+          python - <<'PY'
+          import flask, requests
+          PY
       - name: Scan for secrets
         uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
         env:


### PR DESCRIPTION
## Summary
- Quote extra packages in install action to handle space-separated lists
- Test workflows to ensure install action works with multiple packages

## Testing
- `pytest -q` *(fails: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68aa8bddc738832797c5c595dd9834d8