### PR TITLE
chore: pin gitleaks action to commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,10 @@ jobs:
           pip install safety
           safety check --full-report
       - name: Scan for secrets
-        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: gitleaks.toml
       - name: Run linters
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,9 +49,10 @@ jobs:
           import flask, requests
           PY
       - name: Scan for secrets
-        uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc # v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: gitleaks.toml
       - name: Run linters
         if: runner.os != 'Windows'
         shell: bash

--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -1,0 +1,9 @@
+title = "pCobra gitleaks config"
+
+[allowlist]
+  description = "Exclude docs and examples from secret scanning"
+  paths = [
+    "docs/",
+    "examples/"
+  ]
+


### PR DESCRIPTION
## Summary
- pin gitleaks action to a specific commit
- add basic gitleaks config and wire into CI

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_68aa9203f7b08327b478d99487bdc4f1