### PR TITLE
refactor: improve extra pip install

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -16,6 +16,8 @@ runs:
         pip install -e .
         # pip install -e .[dev] también es válido para extras de desarrollo
         if [ -n "${{ inputs.extra }}" ]; then
-          pip install "${{ inputs.extra }}"
+          while IFS=$'\n' read -r pkg; do
+            pip install "$pkg"
+          done <<< "${{ inputs.extra }}"
         fi
 


### PR DESCRIPTION
## Summary
- refine extra dependency installation by looping over lines instead of quoted string

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.commands')*

------
https://chatgpt.com/codex/tasks/task_e_68aa9d46ae0c83279896a77abdbae99d