### PR TITLE
Split Verify extra packages for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           extra: "sphinx sphinx-rtd-theme pytest-cov codecov pyright"
       - name: Verify extra packages
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           python - <<'PY'
@@ -60,6 +61,11 @@ jobs:
           for pkg in ["sphinx", "pyright"]:
               importlib.import_module(pkg.replace('-', '_'))
           PY
+      - name: Verify extra packages (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          python -c "import importlib; [importlib.import_module(pkg.replace('-', '_')) for pkg in ['sphinx','pyright']]"
       - name: Seguridad de dependencias
         shell: bash
         run: |
@@ -144,6 +150,7 @@ jobs:
         with:
           extra: "sphinx sphinx-rtd-theme pytest-cov codecov pyright"
       - name: Verify extra packages
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           python - <<'PY'
@@ -151,6 +158,11 @@ jobs:
           for pkg in ["sphinx", "pyright"]:
               importlib.import_module(pkg.replace('-', '_'))
           PY
+      - name: Verify extra packages (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          python -c "import importlib; [importlib.import_module(pkg.replace('-', '_')) for pkg in ['sphinx','pyright']]"
       - name: Compare benchmarks
         run: |
           python scripts/benchmarks/compare_releases.py \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,11 +43,17 @@ jobs:
         with:
           extra: "flask requests"
       - name: Verify extra packages
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           python - <<'PY'
           import flask, requests
           PY
+      - name: Verify extra packages (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          python -c "import flask, requests"
       - name: Scan for secrets
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:


### PR DESCRIPTION
## Summary
- split "Verify extra packages" into bash and pwsh variants in test workflow
- do the same split in CI workflow for build and benchmarks jobs

## Testing
- `pre-commit run --files .github/workflows/test.yml .github/workflows/ci.yml` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68aac5d7c54c8327b3506b439eab3f13