### PR TITLE
Use config-path for Gitleaks in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,10 @@ jobs:
           safety check --full-report
       - name: Scan for secrets
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        with:
+          config-path: gitleaks.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: gitleaks.toml
       - name: Run linters
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,9 +56,10 @@ jobs:
           python -c "import flask, requests"
       - name: Scan for secrets
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        with:
+          config-path: gitleaks.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: gitleaks.toml
       - name: Run linters
         if: runner.os != 'Windows'
         shell: bash


### PR DESCRIPTION
## Summary
- replace `env.GITLEAKS_CONFIG` with `with.config-path` for Gitleaks action in CI and test workflows

## Testing
- `gitleaks detect --source . --config gitleaks.toml`
- `pytest` *(fails: unrecognized arguments: --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4668c2b08327a9d61d3286185718