### PR TITLE
Filtra variables de entorno inseguras en sandbox JS

### DIFF
--- a/src/core/sandbox.py
+++ b/src/core/sandbox.py
@@ -110,7 +110,13 @@ def ejecutar_en_sandbox_js(
     env_path = os.path.dirname(node_dir) if node_dir else "/usr/bin"
     env = {"PATH": env_path}
     if env_vars:
-        env.update(env_vars)
+        claves_sensibles = {"PATH", "NODE_OPTIONS"}
+        filtradas = {
+            k: v
+            for k, v in env_vars.items()
+            if k.isalnum() and k not in claves_sensibles
+        }
+        env.update(filtradas)
 
     try:
         version = subprocess.run(

--- a/src/tests/unit/test_sandbox_js.py
+++ b/src/tests/unit/test_sandbox_js.py
@@ -79,6 +79,25 @@ def test_sandbox_js_ignora_node_options(monkeypatch):
 
 
 @pytest.mark.timeout(5)
+def test_sandbox_js_filtra_env_vars(monkeypatch):
+    if not shutil.which("node"):
+        pytest.skip("node no disponible")
+    try:
+        subprocess.run(["node", "-e", "require('vm2')"], check=True, capture_output=True)
+    except subprocess.CalledProcessError:
+        pytest.skip("vm2 no disponible")
+    env_vars = {
+        "NODE_OPTIONS": "--eval \"process.stdout.write('pwned')\"",
+        "PATH": "/tmp",
+        "SAFE": "1",
+        "MAL-ENV": "bad",
+    }
+    salida = ejecutar_en_sandbox_js("console.log('hola')", env_vars=env_vars)
+    assert salida.strip() == "hola"
+    assert "pwned" not in salida
+
+
+@pytest.mark.timeout(5)
 def test_sandbox_js_trunca_salida_grande():
     if not shutil.which("node"):
         pytest.skip("node no disponible")


### PR DESCRIPTION
## Resumen
- Filtra claves sensibles y no alfanuméricas antes de propagar `env_vars` en la sandbox JS.
- Añade prueba que verifica el filtrado de `NODE_OPTIONS` y `PATH` al ejecutar código JS aislado.

## Testing
- `pytest src/tests/unit/test_sandbox_js.py::test_sandbox_js_filtra_env_vars --no-cov -q`
- `pytest src/tests/unit/test_sandbox_js.py --no-cov -q` *(falla: `test_sandbox_js_trunca_stderr_grande_no_bloquea`, `test_sandbox_js_elimina_archivo_inexistente`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab56599a6c83278a010bcf25b20f85