### PR TITLE
feat: enforce hashed pip installs

### DIFF
--- a/pcobra.toml
+++ b/pcobra.toml
@@ -11,3 +11,11 @@ js = "modulo.js"
 # python = "ciencia/genetica.py"
 # js = "ciencia/genetica.js"
 
+# Configuración opcional para la directiva `usar`.
+# La lista `permitidos` acepta elementos en los formatos:
+#   "nombre"                      # solo nombre
+#   "nombre==version"             # nombre y versión exacta
+#   "nombre==version --hash=sha256:<hash>"  # con hash de integridad
+#[usar]
+#permitidos = []
+


### PR DESCRIPTION
## Summary
- allow whitelist entries with versions or hashes
- require hashed package installs and log installed spec
- document `usar` whitelist format in `pcobra.toml`

## Testing
- `python -m py_compile src/cobra/usar_loader.py`
- `pytest` *(fails: unrecognized arguments --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68abbe643cc883279f2e90fa15323791