### PR TITLE
Handle Sphinx errors when generating docs

### DIFF
--- a/src/cobra/cli/commands/docs_cmd.py
+++ b/src/cobra/cli/commands/docs_cmd.py
@@ -70,6 +70,14 @@ class DocsCommand(BaseCommand):
             ["sphinx-apidoc", "-o", str(api), str(codigo)],
             ["sphinx-build", "-b", "html", str(source), str(build)]
         ]:
-            resultado = subprocess.run(cmd, capture_output=True, text=True)
-            if resultado.returncode != 0:
-                raise RuntimeError(f"Error ejecutando {cmd[0]}: {resultado.stderr}")
+            try:
+                subprocess.run(
+                    cmd,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(
+                    f"Error ejecutando {cmd[0]}: {e.stderr}"
+                ) from e

--- a/src/tests/unit/test_cli_docs.py
+++ b/src/tests/unit/test_cli_docs.py
@@ -18,14 +18,14 @@ def test_cli_docs_invokes_sphinx():
                 "-o",
                 str(api),
                 str(codigo),
-            ], check=True),
+            ], check=True, capture_output=True, text=True),
             call([
                 "sphinx-build",
                 "-b",
                 "html",
                 str(source),
                 str(build),
-            ], check=True),
+            ], check=True, capture_output=True, text=True),
         ])
 
 
@@ -34,4 +34,5 @@ def test_cli_docs_sin_sphinx():
             patch("sys.stdout", new_callable=StringIO) as out:
         main(["docs"])
     assert "Sphinx no está instalado" in out.getvalue()
+
 


### PR DESCRIPTION
## Summary
- Improve `docs` command to run Sphinx with `check=True` and capture output
- Surface Sphinx stderr when generation fails
- Update tests for new subprocess invocation

## Testing
- `PYTHONPATH=src:. pytest src/tests/unit/test_cli_docs.py::test_cli_docs_invokes_sphinx src/tests/unit/test_cli_docs.py::test_cli_docs_sin_sphinx src/tests/integration/test_docs_generation.py::test_docs_generation -q` *(fails: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_68abcfddd14483279cf1f86a6000db76