### PR TITLE
ci: establece permisos mínimos por defecto

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,5 +1,8 @@
 name: Build & Release CLI Binaries
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
## Resumen
- Agrega bloque `permissions: contents: read` al inicio del workflow `build-binaries`
- Mantiene permiso explícito de escritura para el job de release

## Testing
- `pytest` *(falló: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68abe9c8bf908327af6302156b54a63c