### PR TITLE
chore(ci): add Safety API key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,11 @@ jobs:
           python -c "import importlib; [importlib.import_module(pkg.replace('-', '_')) for pkg in ['sphinx','pyright']]"
       - name: Seguridad de dependencias
         shell: bash
+        env:
+          SAFETY_API_KEY: ${{ secrets.SAFETY_API_KEY }}
         run: |
           pip install safety
-          safety check --full-report
+          safety check --full-report --key $SAFETY_API_KEY
       - name: Scan for secrets
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         with:


### PR DESCRIPTION
## Summary
- pass Safety API key from repo secrets in CI workflow

## Testing
- `yamllint .github/workflows/ci.yml` *(fails: line too long and other warnings)*
- `safety check --full-report --key $SAFETY_API_KEY` *(fails: unable to reach the server)*

------
https://chatgpt.com/codex/tasks/task_e_68ac87c0af988327ab429a674042fd45