### PR TITLE
Enable safe mode by default with CLI override

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -200,10 +200,11 @@ Herencia múltiple en clases.
 
 ## 9. Modo seguro
 
-- Añade `--seguro` para evitar operaciones peligrosas como `leer_archivo` o `hilo`.
+El modo seguro se encuentra activado por defecto y evita operaciones peligrosas
+como `leer_archivo` o `hilo`. Para desactivarlo:
 
 ```bash
-cobra ejecutar programa.co --seguro
+cobra ejecutar programa.co --no-seguro
 ```
 
 ## 10. Próximos pasos

--- a/README.md
+++ b/README.md
@@ -922,9 +922,10 @@ archivo con la nueva clase y llamar a `register_subparser` y `run`.
 Para un tutorial completo de creación de plugins revisa
 [`frontend/docs/plugins.rst`](frontend/docs/plugins.rst).
 
-## Modo seguro (--seguro)
+## Modo seguro
 
-Tanto el intérprete como la CLI aceptan la opción `--seguro`, que ejecuta el código bajo restricciones adicionales. Al activarla se valida el AST y se prohíben primitivas como `leer_archivo`, `escribir_archivo`, `obtener_url`, `hilo`, `leer`, `escribir`, `existe`, `eliminar` y `enviar_post`. El validador `ValidadorProhibirReflexion` también bloquea llamadas a `eval`, `exec` y otras funciones de reflexión, además de impedir el acceso a atributos internos. Asimismo, las instrucciones `import` solo están permitidas para módulos instalados o incluidos en `IMPORT_WHITELIST`. Si el programa intenta utilizar estas funciones o importar otros archivos se lanzará `PrimitivaPeligrosaError`.
+El intérprete y la CLI ejecutan el código en modo seguro de forma predeterminada. Este modo valida el AST y prohíbe primitivas como `leer_archivo`, `escribir_archivo`, `obtener_url`, `hilo`, `leer`, `escribir`, `existe`, `eliminar` y `enviar_post`. El validador `ValidadorProhibirReflexion` también bloquea llamadas a `eval`, `exec` y otras funciones de reflexión, además de impedir el acceso a atributos internos. Asimismo, las instrucciones `import` solo están permitidas para módulos instalados o incluidos en `IMPORT_WHITELIST`. Si el programa intenta utilizar estas funciones o importar otros archivos se lanzará `PrimitivaPeligrosaError`.
+Si se desea desactivar esta protección, la CLI ofrece la opción `--no-seguro`.
 La validación se realiza mediante una cadena de validadores configurada por la
 función `construir_cadena`, lo que facilita añadir nuevas comprobaciones en el
 futuro.

--- a/README_en.md
+++ b/README_en.md
@@ -517,7 +517,7 @@ Generating code for these functions creates `asyncio.create_task` calls in Pytho
 
 Once the package is installed, the `cobra` tool offers several subcommands. The README in Spanish contains a complete list of commands and examples.
 
-The CLI also includes a safe mode (`--seguro`), a sandbox option (`--sandbox`), support for multiple languages via `--lang` and the ability to generate documentation, packages and executables. See the Spanish README for detailed examples.
+The CLI runs in safe mode by default. Use `--no-seguro` to disable it. A sandbox option (`--sandbox`), support for multiple languages via `--lang` and the ability to generate documentation, packages and executables are also available. See the Spanish README for detailed examples.
 
 ## Tests and development
 

--- a/frontend/docs/cli.rst
+++ b/frontend/docs/cli.rst
@@ -41,13 +41,13 @@ Opciones principales:
 - ``archivo``: ruta del código ``.co``.
 - ``--formatear``: aplica ``black`` antes de procesar el archivo.
 - ``--depurar``: muestra información de depuración.
-- ``--seguro``: activa el :doc:`modo seguro <modo_seguro>`.
+- ``--no-seguro``: desactiva el :doc:`modo seguro <modo_seguro>`.
 
 Ejemplo:
 
 .. code-block:: bash
 
-   cobra ejecutar programa.co --seguro --depurar
+   cobra ejecutar programa.co --no-seguro --depurar
 
 Subcomando ``interactive``
 -------------------------

--- a/frontend/docs/modo_seguro.rst
+++ b/frontend/docs/modo_seguro.rst
@@ -1,8 +1,8 @@
 Modo seguro
 ===========
 
-A partir de Cobra 9.0 la herramienta ``cobra`` permite ejecutar programas en
-modo seguro mediante la opción ``--seguro``. Al activarse se construye una
+A partir de Cobra 9.0 la herramienta ``cobra`` ejecuta los programas en
+modo seguro de forma predeterminada. Este modo construye una
 cadena de validadores que analiza el AST y bloquea primitivas peligrosas como
 ``leer_archivo``, ``escribir_archivo``, ``obtener_url`` y ``hilo``.
 A partir de esta versión también se restringen las funciones ``leer``,
@@ -28,14 +28,15 @@ habilitarse o deshabilitarse editando ``cobra.toml``:
    activa = true
 
 Si se intenta utilizar alguna de estas operaciones se lanzará
-``PrimitivaPeligrosaError`` antes de ejecutar el código.
+``PrimitivaPeligrosaError`` antes de ejecutar el código. Para desactivar
+estas restricciones puede utilizarse la opción ``--no-seguro``.
 
 Ejemplo de uso
 --------------
 
 .. code-block:: bash
 
-   cobra ejecutar hola.co --seguro
+   cobra ejecutar hola.co
 
 Validadores personalizados
 -------------------------
@@ -45,7 +46,7 @@ Se puede ampliar la cadena de validación pasando la opción
 
 .. code-block:: bash
 
-   cobra ejecutar programa.co --seguro --validadores-extra mis_validadores.py
+   cobra ejecutar programa.co --validadores-extra mis_validadores.py
 
 Configuraciones avanzadas
 -------------------------

--- a/frontend/docs/referencia.rst
+++ b/frontend/docs/referencia.rst
@@ -41,8 +41,9 @@ El comando ``cobra`` cuenta con varias subopciones:
    cobra docs
    cobra empaquetar --output dist
 
-La opción ``--seguro`` puede añadirse a ``ejecutar`` o al modo interactivo para
-bloquear primitivas peligrosas e importaciones no permitidas.
+El modo seguro está habilitado por defecto. Si se desea permitir primitivas
+peligrosas e importaciones no permitidas, puede desactivarse con ``--no-seguro``
+en ``ejecutar`` o en el modo interactivo.
 
 El subcomando ``docs`` genera la documentación del proyecto en ``frontend/build/html``.
 ``empaquetar`` crea un ejecutable independiente usando PyInstaller.

--- a/frontend/docs/validador.rst
+++ b/frontend/docs/validador.rst
@@ -63,11 +63,11 @@ definir una lista ``VALIDADORES_EXTRA`` con las instancias a añadir.
 
    VALIDADORES_EXTRA = [Demo()]
 
-Posteriormente se indica la ruta al ejecutar Cobra:
+Posteriormente se indica la ruta al ejecutar Cobra (el modo seguro está activo por defecto):
 
 .. code-block:: bash
 
-   cobra ejecutar prog.co --seguro --validadores-extra validadores.py
+   cobra ejecutar prog.co --validadores-extra validadores.py
 
 Ejemplo de deteccion
 --------------------

--- a/src/cobra/cli/cli.py
+++ b/src/cobra/cli/cli.py
@@ -169,8 +169,14 @@ class CliApplication:
                           help=_("Format file before processing"))
         parser.add_argument("--debug", action="store_true",
                           help=_("Show debug messages"))
-        parser.add_argument("--safe", action="store_true",
-                          help=_("Run in safe mode"))
+        parser.add_argument(
+            "--no-safe",
+            "--no-seguro",
+            dest="seguro",
+            action="store_false",
+            help=_("Run without safe mode"),
+        )
+        parser.set_defaults(seguro=True)
         parser.add_argument("--lang",
                           default=environ.get("COBRA_LANG", AppConfig.DEFAULT_LANGUAGE),
                           help=_("Interface language code"))

--- a/src/cobra/cli/commands/execute_cmd.py
+++ b/src/cobra/cli/commands/execute_cmd.py
@@ -85,7 +85,7 @@ class ExecuteCommand(BaseCommand):
 
         depurar = getattr(args, "depurar", False)
         formatear = getattr(args, "formatear", False)
-        seguro = getattr(args, "seguro", False)
+        seguro = getattr(args, "seguro", True)
         extra_validators = getattr(args, "validadores_extra", None)
         sandbox = getattr(args, "sandbox", False)
         contenedor = getattr(args, "contenedor", None)

--- a/src/cobra/cli/commands/interactive_cmd.py
+++ b/src/cobra/cli/commands/interactive_cmd.py
@@ -194,7 +194,7 @@ class InteractiveCommand(BaseCommand):
             return 1
 
         # Configurar modo seguro y validadores
-        seguro = getattr(args, "seguro", False)
+        seguro = getattr(args, "seguro", True)
         extra_validators = getattr(args, "validadores_extra", None)
         validador = None
         if seguro:

--- a/src/cobra/cli/commands/profile_cmd.py
+++ b/src/cobra/cli/commands/profile_cmd.py
@@ -90,7 +90,7 @@ class ProfileCommand(BaseCommand):
         ui: Optional[str] = self._obtener_argumento(args, "ui")
         depurar: bool = self._obtener_argumento(args, "depurar", False)
         formatear: bool = self._obtener_argumento(args, "formatear", False)
-        seguro: bool = self._obtener_argumento(args, "seguro", False)
+        seguro: bool = self._obtener_argumento(args, "seguro", True)
         extra_validators: Optional[str] = self._obtener_argumento(args, "validadores_extra")
         analysis: bool = self._obtener_argumento(args, "analysis", False)
 

--- a/src/core/interpreter.py
+++ b/src/core/interpreter.py
@@ -146,15 +146,16 @@ class InterpretadorCobra:
         exec(byte_code, namespace)
         return namespace.get("VALIDADORES_EXTRA", [])
 
-    def __init__(self, safe_mode: bool = False, extra_validators=None):
+    def __init__(self, safe_mode: bool = True, extra_validators=None):
         """Crea un nuevo interpretador.
 
         Parameters
         ----------
         safe_mode: bool, optional
-            Si se activa, valida cada nodo utilizando la cadena devuelta por
-            :func:`construir_cadena` y restringe primitivas como ``import`` o
-            ``hilo``.
+            Indica si el intérprete debe ejecutarse en modo seguro. Está
+            activado por defecto y valida cada nodo utilizando la cadena
+            devuelta por :func:`construir_cadena`, restringiendo primitivas
+            como ``import`` o ``hilo``.
         extra_validators: list | str, optional
             Lista de instancias adicionales o ruta a un módulo que defina
             ``VALIDADORES_EXTRA``.

--- a/src/tests/unit/test_auditoria_validator.py
+++ b/src/tests/unit/test_auditoria_validator.py
@@ -7,7 +7,7 @@ from core.semantic_validators import PrimitivaPeligrosaError
 
 
 def test_auditoria_registra_primitiva(caplog):
-    interp = InterpretadorCobra(safe_mode=True)
+    interp = InterpretadorCobra()
     nodo = NodoLlamadaFuncion("leer_archivo", [NodoValor("x")])
     with caplog.at_level(logging.WARNING):
         with pytest.raises(PrimitivaPeligrosaError):

--- a/src/tests/unit/test_cli_commands_extra.py
+++ b/src/tests/unit/test_cli_commands_extra.py
@@ -148,12 +148,12 @@ def test_cli_ejecutar_imprime(tmp_path):
 
 
 @pytest.mark.timeout(5)
-def test_cli_ejecutar_flag_seguro(tmp_path):
+def test_cli_ejecutar_flag_no_seguro(tmp_path):
     archivo = tmp_path / "p.co"
     archivo.write_text("imprimir(1)")
     with patch("cli.commands.execute_cmd.InterpretadorCobra") as mock_interp:
-        main(["--seguro", "ejecutar", str(archivo)])
-        mock_interp.assert_called_once_with(safe_mode=True)
+        main(["--no-seguro", "ejecutar", str(archivo)])
+        mock_interp.assert_called_once_with(safe_mode=False)
         mock_interp.return_value.ejecutar_ast.assert_called_once()
 
 
@@ -164,7 +164,7 @@ def test_cli_validadores_extra(tmp_path):
     ruta = tmp_path / "vals.py"
     ruta.write_text("VALIDADORES_EXTRA = []\n")
     with patch("cli.commands.execute_cmd.InterpretadorCobra") as mock_interp:
-        main(["--seguro", f"--validadores-extra={ruta}", "ejecutar", str(archivo)])
+        main([f"--validadores-extra={ruta}", "ejecutar", str(archivo)])
         mock_interp.assert_called_once_with(
             safe_mode=True, extra_validators=str(ruta)
         )

--- a/src/tests/unit/test_cli_secure_validators.py
+++ b/src/tests/unit/test_cli_secure_validators.py
@@ -35,5 +35,5 @@ def _run_cli(args):
 def test_cli_seguro_primitivas_prohibidas(tmp_path, contenido):
     archivo = tmp_path / "a.co"
     archivo.write_text(contenido)
-    code = _run_cli(["--seguro", "ejecutar", str(archivo)])
+    code = _run_cli(["ejecutar", str(archivo)])
     assert code != 0

--- a/src/tests/unit/test_custom_validators.py
+++ b/src/tests/unit/test_custom_validators.py
@@ -11,7 +11,7 @@ class DummyValidator(ValidadorBase):
         raise DummyError('validado')
 
 def test_interpreter_extra_validators_list():
-    interp = InterpretadorCobra(safe_mode=True, extra_validators=[DummyValidator()])
+    interp = InterpretadorCobra(extra_validators=[DummyValidator()])
     with pytest.raises(DummyError):
         interp.ejecutar_ast([NodoValor(1)])
 
@@ -26,7 +26,7 @@ def test_interpreter_extra_validators_file(tmp_path):
     )
     IMPORT_WHITELIST.add(str(tmp_path))
     try:
-        interp = InterpretadorCobra(safe_mode=True, extra_validators=str(mod))
+        interp = InterpretadorCobra(extra_validators=str(mod))
         with pytest.raises(Exception):
             interp.ejecutar_ast([NodoValor(2)])
     finally:
@@ -37,7 +37,7 @@ def test_interpreter_rejects_unwhitelisted_validators(tmp_path):
     mod = tmp_path / 'vals.py'
     mod.write_text('VALIDADORES_EXTRA = []')
     with pytest.raises(ImportError):
-        InterpretadorCobra(safe_mode=True, extra_validators=str(mod))
+        InterpretadorCobra(extra_validators=str(mod))
 
 
 def test_validator_open_blocked(tmp_path):

--- a/src/tests/unit/test_safe_mode.py
+++ b/src/tests/unit/test_safe_mode.py
@@ -30,14 +30,14 @@ def generar_ast(codigo: str):
     ],
 )
 def test_primitivas_rechazadas_en_modo_seguro(codigo):
-    interp = InterpretadorCobra(safe_mode=True)
+    interp = InterpretadorCobra()
     ast = generar_ast(codigo)
     with pytest.raises(PrimitivaPeligrosaError):
         interp.ejecutar_ast(ast)
 
 
 def test_codigo_seguro_se_ejecuta_en_modo_seguro():
-    interp = InterpretadorCobra(safe_mode=True)
+    interp = InterpretadorCobra()
     nodo = NodoLlamadaFuncion("imprimir", [NodoValor("hola")])
     with patch("sys.stdout", new_callable=StringIO) as out:
         interp.ejecutar_llamada_funcion(nodo)

--- a/src/tests/unit/test_safe_mode_imports.py
+++ b/src/tests/unit/test_safe_mode_imports.py
@@ -35,7 +35,7 @@ def test_imports_y_reflexion_en_modo_seguro(tmp_path, monkeypatch):
     ruta_sys.write_text('')
     AST_COMPLETO[0].ruta = str(ruta_os)
     AST_COMPLETO[1].ruta = str(ruta_sys)
-    interp = InterpretadorCobra(safe_mode=True)
+    interp = InterpretadorCobra()
     with pytest.raises(PrimitivaPeligrosaError):
         interp.ejecutar_ast(AST_COMPLETO)
 

--- a/src/tests/unit/test_validator_optimization.py
+++ b/src/tests/unit/test_validator_optimization.py
@@ -44,7 +44,7 @@ def test_valida_cada_nodo_una_sola_vez(monkeypatch):
     from core.interpreter import InterpretadorCobra
     from core.ast_nodes import NodoAsignacion, NodoValor
 
-    interp = InterpretadorCobra(safe_mode=True)
+    interp = InterpretadorCobra()
     nodo = NodoAsignacion("x", NodoValor(1))
 
     contador = 0


### PR DESCRIPTION
## Summary
- Default `InterpretadorCobra` to run in safe mode and update docs
- Add `--no-seguro/--no-safe` flag to disable safe mode
- Adjust tests and documentation for new default behavior

## Testing
- `PYTHONPATH=$PWD/src:$PWD pytest -q` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68ac8e253ae0832782bec4ae7e458f66