### PR TITLE
fix: add no-install-recommends for latex

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           extra: "sphinx sphinx-rtd-theme"
       - name: Install LaTeX packages
-        run: sudo apt-get update && sudo apt-get install -y texlive-latex-recommended texlive-latex-extra latexmk
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive-latex-recommended texlive-latex-extra latexmk
       - name: Build docs
         run: sphinx-build -b html frontend/docs frontend/build/html
       - name: Build root docs


### PR DESCRIPTION
## Summary
- avoid installing recommended packages when setting up TeX for docs deployment

## Testing
- `sphinx-build -b html frontend/docs frontend/build/html`
- `sphinx-build -b html docs docs/_build`
- `make -C docs/_build/latex all-pdf` *(fails: File `tgtermes.sty` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac919c79088327a07ce4a468e502e5