### PR TITLE
chore: eliminar variable sin usar en dependencias_cmd

### DIFF
--- a/src/cobra/cli/commands/dependencias_cmd.py
+++ b/src/cobra/cli/commands/dependencias_cmd.py
@@ -268,7 +268,7 @@ class DependenciasCommand(BaseCommand):
                     mostrar_error(_("No se encontró pip en el entorno virtual"))
                     return 1
 
-                result = subprocess.run(
+                subprocess.run(
                     [pip_path, "install", "-r", tmp_path],
                     check=True,
                     capture_output=True,


### PR DESCRIPTION
## Summary
- evita almacenar el resultado de `subprocess.run` en el comando de dependencias

## Testing
- `pytest src/tests/unit/test_cli_dependencias.py -q` *(falla: ModuleNotFoundError: No module named 'cli.commands')*
- `PYTHONPATH=src python - <<'PY'
import sys, importlib.util, pytest
spec = importlib.util.spec_from_file_location('cli', 'src/cobra/cli/__init__.py', submodule_search_locations=['src/cobra/cli'])
module = importlib.util.module_from_spec(spec)
sys.modules['cli'] = module
spec.loader.exec_module(module)
raise SystemExit(pytest.main(['src/tests/unit/test_cli_dependencias.py', '-q']))
PY` *(falla: IndexError: list index out of range)*

------
https://chatgpt.com/codex/tasks/task_e_68ac94c049d883279377200d15037163