### PR TITLE
feat: limit memory usage in JS sandbox

### DIFF
--- a/src/core/sandbox.py
+++ b/src/core/sandbox.py
@@ -91,6 +91,7 @@ def ejecutar_en_sandbox_js(
     codigo: str,
     timeout: int = 5,
     env_vars: dict[str, str] | None = None,
+    memoria_mb: int | None = 128,
 ) -> str:
     """Ejecuta código JavaScript de forma aislada usando Node.
 
@@ -100,7 +101,9 @@ def ejecutar_en_sandbox_js(
     comprueba que la versión instalada sea al menos ``3.9.19``. La sandbox
     se ejecuta con un entorno minimizado cuyo ``PATH`` apunta únicamente a
     ``/usr/bin`` o al directorio que contiene el ejecutable de Node; se pueden
-    añadir variables específicas mediante ``env_vars``.
+    añadir variables específicas mediante ``env_vars``. ``memoria_mb`` limita
+    la memoria disponible para la ejecución de Node estableciendo
+    ``--max-old-space-size``.
     """
     import json
     import os
@@ -169,13 +172,12 @@ process.stdout.write(output);
         import select
         import time
 
+        args = ["node", "--no-experimental-fetch"]
+        if memoria_mb is not None:
+            args.append(f"--max-old-space-size={memoria_mb}")
+        args.append(tmp_path)
         with subprocess.Popen(
-            [
-                "node",
-                "--no-experimental-fetch",
-                "--max-old-space-size=128",
-                tmp_path,
-            ],
+            args,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             cwd=base_dir,

--- a/src/tests/unit/test_sandbox_js.py
+++ b/src/tests/unit/test_sandbox_js.py
@@ -127,6 +127,19 @@ def test_sandbox_js_trunca_stderr_grande_no_bloquea():
 
 
 @pytest.mark.timeout(5)
+def test_sandbox_js_limita_memoria():
+    if not shutil.which("node"):
+        pytest.skip("node no disponible")
+    try:
+        subprocess.run(["node", "-e", "require('vm2')"], check=True, capture_output=True)
+    except subprocess.CalledProcessError:
+        pytest.skip("vm2 no disponible")
+    codigo = "const a=[]; while(true) a.push(new Array(1e6).fill('x'));"
+    salida = ejecutar_en_sandbox_js(codigo, memoria_mb=16)
+    assert "heap out of memory" in salida.lower()
+
+
+@pytest.mark.timeout(5)
 def test_sandbox_js_elimina_archivo_inexistente(monkeypatch):
     if not shutil.which("node"):
         pytest.skip("node no disponible")


### PR DESCRIPTION
## Summary
- allow customizing Node's memory via `--max-old-space-size`
- add sandbox test verifying memory limit

## Testing
- `pytest src/tests/unit/test_sandbox_js.py::test_sandbox_js_limita_memoria --no-cov -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac9ac915b4832780f0d1bfdd687ba4