### PR TITLE
chore: split test steps by OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
         shell: bash
         run: python scripts/check_changelog.py
       - name: Run tests
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           if [ -d tests ]; then
@@ -110,6 +111,17 @@ jobs:
               --cov-report=term-missing --cov-fail-under=95 -m "not windows"
             pytest src/tests -m windows
           fi
+      - name: Run tests (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          if (Test-Path tests) {
+            pytest tests src/tests --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=95 -m "not windows"
+            pytest tests src/tests -m windows
+          } else {
+            pytest src/tests --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=95 -m "not windows"
+            pytest src/tests -m windows
+          }
       - name: Run LLVM examples
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,7 @@ jobs:
           ./make.bat lint
           ./make.bat typecheck
       - name: Run tests
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           if [ -d tests ]; then
@@ -82,6 +83,15 @@ jobs:
             pytest src/tests --cov=src --cov-report=xml \
               --cov-fail-under=95
           fi
+      - name: Run tests (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          if (Test-Path tests) {
+            pytest tests src/tests --cov=src --cov-report=xml --cov-fail-under=95
+          } else {
+            pytest src/tests --cov=src --cov-report=xml --cov-fail-under=95
+          }
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5
         with:


### PR DESCRIPTION
## Summary
- run tests separately for Unix and Windows in main CI workflow
- run tests separately for Unix and Windows in test workflow

## Testing
- `pytest -q` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68ac9fb8bd308327bdc1a2a3bf434b73