### PR TITLE
Fix Python glob pattern in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-    paths: ['**.py', 'src/tests/**', '.github/workflows/test.yml']
+    paths: ['**/*.py', 'src/tests/**', '.github/workflows/test.yml']
   pull_request:
-    paths: ['**.py', 'src/tests/**', '.github/workflows/test.yml']
+    paths: ['**/*.py', 'src/tests/**', '.github/workflows/test.yml']
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- use recursive glob for Python files in test workflow

## Testing
- `yamllint .github/workflows/test.yml` *(fails: line length warnings)*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68aca21ac22483278bfd91535b70af92