### PR TITLE
feat: install extras from space-delimited string

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -16,8 +16,6 @@ runs:
         pip install -e .
         # pip install -e .[dev] también es válido para extras de desarrollo
         if [ -n "${{ inputs.extra }}" ]; then
-          while IFS=$'\n' read -r pkg; do
-            pip install "$pkg"
-          done <<< "${{ inputs.extra }}"
+          pip install ${{ inputs.extra }}
         fi
 


### PR DESCRIPTION
## Summary
- simplify extra dependency handling in GitHub Action by accepting space-separated strings

## Testing
- `pytest -q` *(fails: No se pudo importar core, unrecognized arguments --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68ad77765114832789f69285578cd010