### PR TITLE
chore: actualizar Dependabot a main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "master"
+    target-branch: "main"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "master"
+    target-branch: "main"
 


### PR DESCRIPTION
## Resumen
- apuntar Dependabot a la rama `main`

## Pruebas
- `pytest` *(falla: ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_68ada6d4372c8327869d7cedf3b13762