### PR TITLE
Enforce real path whitelist for validators

### DIFF
--- a/src/core/interpreter.py
+++ b/src/core/interpreter.py
@@ -89,12 +89,15 @@ class InterpretadorCobra:
         import ast
 
         ruta_abs = os.path.abspath(ruta)
+        ruta_real = os.path.realpath(ruta_abs)
         allowed_roots = [MODULES_PATH, *IMPORT_WHITELIST]
         if not any(os.path.commonpath([ruta_abs, root]) == root for root in allowed_roots):
             raise ImportError(f"Módulo fuera de la lista blanca: {ruta}")
+        if not any(os.path.commonpath([ruta_real, root]) == root for root in allowed_roots):
+            raise ImportError(f"Módulo fuera de la lista blanca: {ruta}")
 
         try:
-            with open(ruta_abs, "r", encoding="utf-8") as f:
+            with open(ruta_real, "r", encoding="utf-8") as f:
                 source = f.read()
         except FileNotFoundError as e:
             raise FileNotFoundError(
@@ -102,7 +105,7 @@ class InterpretadorCobra:
             ) from e
 
         try:
-            tree = ast.parse(source, filename=ruta_abs)
+            tree = ast.parse(source, filename=ruta_real)
         except SyntaxError as e:
             raise ImportError(f"Error de sintaxis en {ruta}: {e}") from e
 

--- a/src/tests/unit/test_custom_validators.py
+++ b/src/tests/unit/test_custom_validators.py
@@ -61,3 +61,21 @@ def test_validator_import_blocked(tmp_path):
     finally:
         IMPORT_WHITELIST.discard(str(tmp_path))
 
+
+def test_validator_symlink_outside_blocked(tmp_path, tmp_path_factory):
+    outside = tmp_path_factory.mktemp("outside")
+    mod = outside / "vals.py"
+    mod.write_text("VALIDADORES_EXTRA = []")
+
+    inside = tmp_path / "inside"
+    inside.mkdir()
+    link = inside / "vals_link.py"
+    link.symlink_to(mod)
+
+    IMPORT_WHITELIST.add(str(inside))
+    try:
+        with pytest.raises(ImportError):
+            InterpretadorCobra._cargar_validadores(str(link))
+    finally:
+        IMPORT_WHITELIST.discard(str(inside))
+


### PR DESCRIPTION
## Summary
- Resolve symlinks when loading extra validators and validate against whitelist using real path
- Add regression test ensuring symlinked validator outside whitelist is blocked

## Testing
- `pytest src/tests/unit/test_custom_validators.py::test_validator_symlink_outside_blocked -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68adb446546083279ce7a254415f71a6