### PR TITLE
chore: establece fetch-depth 0 en checkout de workflows

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -18,6 +18,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,8 @@ jobs:
       IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/pcobra-cli:latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'


### PR DESCRIPTION
## Summary
- establece `fetch-depth: 0` en los pasos `actions/checkout` de los flujos `test`, `docker`, `pages`, `release` y `build-exe`

## Testing
- `yamllint .github/workflows/test.yml .github/workflows/docker.yml .github/workflows/pages.yml .github/workflows/release.yml .github/workflows/build-exe.yml`
- `python - <<'PY'
import yaml, pathlib
files = [
    '.github/workflows/test.yml',
    '.github/workflows/docker.yml',
    '.github/workflows/pages.yml',
    '.github/workflows/release.yml',
    '.github/workflows/build-exe.yml'
]
for f in files:
    with open(f) as fp:
        yaml.safe_load(fp)
    print(f'{f}: OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ade30ca4a88327a47476fa08dfc186