### PR TITLE
fix: secure extra package installation in install action

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -16,6 +16,8 @@ runs:
         pip install -e .
         # pip install -e .[dev] también es válido para extras de desarrollo
         if [ -n "${{ inputs.extra }}" ]; then
-          pip install ${{ inputs.extra }}
+          # Split extra packages into an array to avoid shell injection and option parsing
+          read -r -a extra_packages <<< "${{ inputs.extra }}"
+          pip install -- "${extra_packages[@]}"
         fi
 


### PR DESCRIPTION
## Summary
- prevent shell injection in extra package installation by splitting inputs into an array and using `pip install --`

## Testing
- `EXTRA="colorama"` installs package
- `EXTRA="colorama tomli"` installs multiple packages
- `EXTRA="colorama && echo HACKED"` fails without running injected command
- `EXTRA="-r requirements.txt"` treated as invalid requirement

------
https://chatgpt.com/codex/tasks/task_e_68ade7d900a48327ab56509bf1dcb452