### PR TITLE
feat(cli): add ejecutar subcommand

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from dotenv import load_dotenv
 from cobra.cli.cli import main as cobra_cli_main
+from cobra.cli.commands.execute_cmd import ExecuteCommand
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,22 @@ def configurar_entorno() -> None:
 
 cobra = argparse.ArgumentParser(prog="cobra")
 subparsers = cobra.add_subparsers(dest="comando")
-subparsers.add_parser("ejecutar", help="Ejecuta un programa Cobra")
+
+ejecutar_parser = subparsers.add_parser(
+    "ejecutar", help="Ejecuta un programa Cobra"
+)
+ejecutar_parser.add_argument(
+    "archivo", help="Ruta al archivo a ejecutar"
+)
+ejecutar_parser.add_argument(
+    "--sandbox", action="store_true", help="Ejecuta el código en una sandbox"
+)
+ejecutar_parser.add_argument(
+    "--contenedor",
+    choices=["python", "js", "cpp", "rust"],
+    help="Ejecuta el código en un contenedor Docker",
+)
+
 subparsers.add_parser("transpilar", help="Transpila código Cobra")
 subparsers.add_parser("ayuda", help="Muestra esta ayuda y sale")
 
@@ -36,7 +52,12 @@ def main(argumentos: Optional[List[str]] = None) -> int:
         cobra.print_help()
         return 0
     if args.comando == "ejecutar":
-        return cobra_cli_main(["execute", *extra])
+        comando = ExecuteCommand()
+        try:
+            return comando.run(args)
+        except Exception as exc:  # pragma: no cover - captura errores imprevistos
+            logger.error("Error al ejecutar: %s", exc)
+            return 1
     if args.comando == "transpilar":
         return cobra_cli_main(["compile", *extra])
     cobra.print_help()


### PR DESCRIPTION
## Summary
- add `ejecutar` subcommand to main CLI with sandbox and container options
- reuse `ExecuteCommand.run` for file execution

## Testing
- `pytest -q src/tests/unit/test_cli_execute_missing_file.py --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_68ae6e2fb8508327b231d7fd86325d3d