### PR TITLE
feat: añadir subcomando de ayuda al CLI

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -61,14 +61,21 @@ transpilar_parser.add_argument(
     help="Archivo donde guardar el código generado",
 )
 
-subparsers.add_parser("ayuda", help="Muestra esta ayuda y sale")
+def mostrar_ayuda(_: argparse.Namespace) -> int:
+    """Imprime la ayuda general del programa."""
+    cobra.print_help()
+    return 0
+
+
+ayuda_parser = subparsers.add_parser("ayuda", help="Muestra esta ayuda y sale")
+ayuda_parser.set_defaults(func=mostrar_ayuda)
 
 
 def main(argumentos: Optional[List[str]] = None) -> int:
     """Punto de entrada principal para la ejecución del CLI."""
     configurar_entorno()
     args = cobra.parse_args(argumentos)
-    if args.comando == "ayuda" or args.comando is None:
+    if args.comando is None:
         cobra.print_help()
         return 0
     if args.comando == "ejecutar":
@@ -91,6 +98,8 @@ def main(argumentos: Optional[List[str]] = None) -> int:
                 f.write(buffer.getvalue())
             return resultado
         return comando.run(compile_args)
+    if args.comando == "ayuda":
+        return args.func(args)
     cobra.print_help()
     return 1
 

--- a/src/tests/integration/test_cli_ayuda.py
+++ b/src/tests/integration/test_cli_ayuda.py
@@ -1,0 +1,16 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cobra_ayuda_equivalente_help():
+    cli_path = Path(__file__).resolve().parents[2] / "cli.py"
+    result_help = subprocess.run(
+        [sys.executable, str(cli_path), "--help"], capture_output=True, text=True
+    )
+    assert result_help.returncode == 0
+    result_ayuda = subprocess.run(
+        [sys.executable, str(cli_path), "ayuda"], capture_output=True, text=True
+    )
+    assert result_ayuda.returncode == 0
+    assert result_help.stdout == result_ayuda.stdout


### PR DESCRIPTION
## Resumen
- Agregar función `mostrar_ayuda` y subcomando `ayuda` para imprimir la ayuda general
- Probar que `cobra ayuda` y `cobra --help` producen la misma salida

## Pruebas
- `ruff check src/cli.py src/tests/integration/test_cli_ayuda.py`
- `pytest` *(falla: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68ae83e64ce883278410888120820086