### PR TITLE
feat(cli): add verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,8 +878,12 @@ Si deseas desactivar los colores usa `--no-color`:
 cobra --no-color ejecutar programa.co
 ```
 
-Para mostrar mensajes de depuración añade la opción `--debug`. Por defecto el
-nivel de registro es `INFO`.
+Para aumentar el nivel de detalle de los mensajes añade `-v` o `--verbose`.
+Por defecto el nivel de registro es `INFO`; con `-v` o más se cambia a `DEBUG`:
+
+```bash
+cobra -v ejecutar programa.co
+```
 
 Los archivos con extensión ``.cobra`` representan paquetes completos, mientras que los scripts individuales se guardan como ``.co``.
 

--- a/src/cobra/cli/cli.py
+++ b/src/cobra/cli/cli.py
@@ -169,6 +169,8 @@ class CliApplication:
                           help=_("Format file before processing"))
         parser.add_argument("--debug", action="store_true",
                           help=_("Show debug messages"))
+        parser.add_argument("-v", "--verbose", action="count", default=0,
+                          help=_("Incrementa el nivel de detalle"))
         parser.add_argument(
             "--no-safe",
             "--no-seguro",
@@ -312,8 +314,8 @@ class CliApplication:
 
             try:
                 args = self._parse_arguments(argv)
-                if args.debug:
-                    logging.getLogger().setLevel(logging.DEBUG)
+                log_level = logging.DEBUG if args.verbose > 0 or args.debug else logging.INFO
+                logging.getLogger().setLevel(log_level)
                 setup_gettext(args.lang)
                 messages.disable_colors(args.no_color)
                 messages.mostrar_logo()


### PR DESCRIPTION
## Summary
- add -v/--verbose flag to CLI
- configure logging level from verbosity
- document verbose flag in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68aebf2c8ae083278e9a68e372c3127a