### PR TITLE
Add Spanish help alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,7 @@ Para obtener ayuda puedes ejecutar:
 
 ```bash
 cobra --help
+cobra --ayuda
 ```
 
 Para personalizar el comportamiento de la herramienta consulta la [configuración de la CLI](docs/config_cli.md).
@@ -871,6 +872,7 @@ $ cobra --help
  \____\___/  |_.__/ \___|_|   \____|_____|___|
 usage: cobra [-h] [--formatear] ...
 ```
+El mismo resultado se obtiene con `cobra --ayuda`.
 
 Si deseas desactivar los colores usa `--no-color`:
 
@@ -891,7 +893,7 @@ El subcomando `docs` ejecuta `sphinx-apidoc` para generar la documentación de l
 El subcomando `gui` abre el iddle integrado y requiere tener instalado Flet.
 
 
-Si no se pasa un subcomando se abrirá el modo interactivo. Usa `cobra --help` para más detalles.
+Si no se pasa un subcomando se abrirá el modo interactivo. Usa `cobra --help` o `cobra --ayuda` para más detalles.
 
 ## Conversión desde otros lenguajes a Cobra
 
@@ -1056,7 +1058,7 @@ Puedes definir el idioma estableciendo la variable de entorno `COBRA_LANG`
 o pasando el argumento `--lang` al ejecutar `cobra`.
 
 ```bash
-COBRA_LANG=en cobra --help
+COBRA_LANG=en cobra --ayuda
 cobra --lang en compilar archivo.co
 ```
 

--- a/src/cobra/cli/cli.py
+++ b/src/cobra/cli/cli.py
@@ -165,6 +165,8 @@ class CliApplication:
             version=f"%(prog)s {CLI_VERSION} (commit {CLI_COMMIT})",
             help=_("Show version information and exit"),
         )
+        parser.add_argument("--ayuda", action="help",
+                          help=_("Muestra esta ayuda y termina"))
         parser.add_argument("--format", action="store_true",
                           help=_("Format file before processing"))
         parser.add_argument("--debug", action="store_true",

--- a/src/tests/integration/test_cli_ayuda.py
+++ b/src/tests/integration/test_cli_ayuda.py
@@ -4,13 +4,19 @@ from pathlib import Path
 
 
 def test_cobra_ayuda_equivalente_help():
-    cli_path = Path(__file__).resolve().parents[2] / "cli.py"
+    cli_dir = Path(__file__).resolve().parents[2]
     result_help = subprocess.run(
-        [sys.executable, str(cli_path), "--help"], capture_output=True, text=True
+        [sys.executable, "-m", "cobra.cli.cli", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=str(cli_dir),
     )
     assert result_help.returncode == 0
     result_ayuda = subprocess.run(
-        [sys.executable, str(cli_path), "ayuda"], capture_output=True, text=True
+        [sys.executable, "-m", "cobra.cli.cli", "--ayuda"],
+        capture_output=True,
+        text=True,
+        cwd=str(cli_dir),
     )
     assert result_ayuda.returncode == 0
     assert result_help.stdout == result_ayuda.stdout


### PR DESCRIPTION
## Summary
- add `--ayuda` help option to CLI
- document Spanish help alias in README examples
- test that `--ayuda` matches `--help`

## Testing
- `pytest -q` *(fails: No module named 'jsonschema'; No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68aefb1cdae8832786afcc4562cecabc