### PR TITLE
Documentar uso de -- para argumentos posicionales y añadir prueba

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,11 @@ Al generar código para estas funciones, se crean llamadas `asyncio.create_task`
 ## Guía rápida de la CLI
 
 La herramienta `cobra` se invoca con `cobra [subcomando] [archivo] [opciones]`.
+Cuando un argumento posicional comienza con `-`, precede la lista de opciones con `--` para que se trate como un valor literal.
+
+```bash
+cobra ejecutar -- -archivo.co
+```
 Para obtener ayuda puedes ejecutar:
 
 ```bash

--- a/src/tests/unit/test_cli_double_dash.py
+++ b/src/tests/unit/test_cli_double_dash.py
@@ -1,0 +1,15 @@
+from unittest.mock import patch
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from cobra.cli.cli import main
+
+
+def test_cli_accepts_positional_argument_with_leading_dash():
+    with patch("cobra.cli.cli.messages.mostrar_logo"), \
+         patch("cobra.cli.commands.execute_cmd.ExecuteCommand.run", return_value=0) as mock_run:
+        result = main(["ejecutar", "--", "-archivo.co"])
+    assert result == 0
+    args_passed = mock_run.call_args[0][0]
+    assert args_passed.archivo == "-archivo.co"


### PR DESCRIPTION
## Resumen
- Documentar en README cómo usar `--` para pasar argumentos posicionales que comienzan con `-`
- Agregar prueba unitaria que valida el manejo de `--` en la CLI

## Pruebas
- `pytest src/tests/unit/test_cli_double_dash.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68af07a2c9088327845439ea8c688cdb