### PR TITLE
refactor: usar importaciones absolutas en core

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -10,10 +10,10 @@ de implementaciones manuales.
 """
 
 from core.ast_nodes import *
-from .ast_nodes import NodoListaComprehension, NodoDiccionarioComprehension, NodoEnum
-from .visitor import NodeVisitor
-from .performance import optimizar, perfilar, smart_perfilar, optimizar_bucle
-from .resource_limits import limitar_memoria_mb, limitar_cpu_segundos
+from core.ast_nodes import NodoListaComprehension, NodoDiccionarioComprehension, NodoEnum
+from core.visitor import NodeVisitor
+from core.performance import optimizar, perfilar, smart_perfilar, optimizar_bucle
+from core.resource_limits import limitar_memoria_mb, limitar_cpu_segundos
 
 __all__ = [
     "NodoAST",


### PR DESCRIPTION
## Summary
- usar importaciones absolutas en el módulo core

## Testing
- `python - <<'PY'
import sys
sys.path.insert(0, 'src')
import core
print(len(core.__all__))
print(core.__all__[:10])
PY`
- `PYTHONPATH=src pytest` *(falla: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68af4283223c8327bd9a007865a56e66