### PR TITLE
Usar rutas absolutas para holobits

### DIFF
--- a/src/core/holobits/__init__.py
+++ b/src/core/holobits/__init__.py
@@ -1,9 +1,9 @@
 """Funciones de manipulación básica de objetos ``Holobit``."""
 
-from .holobit import Holobit
-from .graficar import graficar
-from .proyection import proyectar
-from .transformacion import transformar, escalar, mover
+from core.holobits.holobit import Holobit
+from core.holobits.graficar import graficar
+from core.holobits.proyection import proyectar
+from core.holobits.transformacion import transformar, escalar, mover
 
 __all__ = [
     "Holobit",

--- a/src/core/holobits/graficar.py
+++ b/src/core/holobits/graficar.py
@@ -1,6 +1,6 @@
 """Funciones para graficar objetos ``Holobit`` utilizando ``holobit-sdk``."""
 
-from .holobit import Holobit
+from core.holobits.holobit import Holobit
 from holobit_sdk.visualization.projector import proyectar_holograma
 from holobit_sdk.core.quark import Quark
 from holobit_sdk.core.holobit import Holobit as SDKHolobit

--- a/src/core/holobits/proyection.py
+++ b/src/core/holobits/proyection.py
@@ -1,11 +1,11 @@
 """Operaciones para proyectar holobits usando ``holobit-sdk``."""
 
-from .holobit import Holobit
 from holobit_sdk.visualization.projector import proyectar_holograma
 from holobit_sdk.core.quark import Quark
 from holobit_sdk.core.holobit import Holobit as SDKHolobit
 
-from .graficar import _to_sdk_holobit
+from core.holobits.holobit import Holobit
+from core.holobits.graficar import _to_sdk_holobit
 
 
 def proyectar(hb: Holobit, modo: str):

--- a/src/core/holobits/transformacion.py
+++ b/src/core/holobits/transformacion.py
@@ -4,11 +4,11 @@ Si la versión instalada del SDK no dispone de las operaciones
 ``escalar`` o ``mover`` se aplican cálculos locales equivalentes.
 """
 
-from .holobit import Holobit
 from holobit_sdk.core.holobit import Holobit as SDKHolobit
 import numpy as np
 
-from .graficar import _to_sdk_holobit
+from core.holobits.holobit import Holobit
+from core.holobits.graficar import _to_sdk_holobit
 
 
 def transformar(hb: Holobit, operacion: str, *parametros):


### PR DESCRIPTION
## Resumen
- Actualiza los imports en el paquete `holobits` para utilizar rutas absolutas desde `core.holobits`.
- Ajusta los módulos `graficar`, `proyection` y `transformacion` a la nueva convención de imports.

## Pruebas
- `PYTHONPATH=src:. pytest` *(falla: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68af47956f18832793d7542d23c613ba