### PR TITLE
Usa importaciones absolutas en validadores semánticos

### DIFF
--- a/src/core/semantic_validators/__init__.py
+++ b/src/core/semantic_validators/__init__.py
@@ -1,13 +1,13 @@
 """Cadena de validadores semánticos para el modo seguro de Cobra."""
 
-from .primitiva_peligrosa import (
+from core.semantic_validators.primitiva_peligrosa import (
     PrimitivaPeligrosaError,
     ValidadorPrimitivaPeligrosa,
 )
-from .auditoria import ValidadorAuditoria
-from .import_seguro import ValidadorImportSeguro
-from .fs_access import ValidadorSistemaArchivos
-from .reflexion_segura import ValidadorProhibirReflexion
+from core.semantic_validators.auditoria import ValidadorAuditoria
+from core.semantic_validators.import_seguro import ValidadorImportSeguro
+from core.semantic_validators.fs_access import ValidadorSistemaArchivos
+from core.semantic_validators.reflexion_segura import ValidadorProhibirReflexion
 from core.cobra_config import auditoria_activa
 
 # Instancia por defecto reutilizable de la cadena de validación

--- a/src/core/semantic_validators/auditoria.py
+++ b/src/core/semantic_validators/auditoria.py
@@ -1,6 +1,6 @@
 import logging
 
-from .base import ValidadorBase
+from core.semantic_validators.base import ValidadorBase
 from core.ast_nodes import (
     NodoLlamadaFuncion,
     NodoLlamadaMetodo,

--- a/src/core/semantic_validators/fs_access.py
+++ b/src/core/semantic_validators/fs_access.py
@@ -1,6 +1,6 @@
-from .base import ValidadorBase
+from core.semantic_validators.base import ValidadorBase
 from core.ast_nodes import NodoLlamadaFuncion, NodoLlamadaMetodo
-from .primitiva_peligrosa import PrimitivaPeligrosaError
+from core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
 
 
 class ValidadorSistemaArchivos(ValidadorBase):

--- a/src/core/semantic_validators/import_seguro.py
+++ b/src/core/semantic_validators/import_seguro.py
@@ -1,7 +1,7 @@
 import os
-from .base import ValidadorBase
+from core.semantic_validators.base import ValidadorBase
 from core.ast_nodes import NodoImport
-from .primitiva_peligrosa import PrimitivaPeligrosaError
+from core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
 
 
 class ValidadorImportSeguro(ValidadorBase):

--- a/src/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/core/semantic_validators/primitiva_peligrosa.py
@@ -1,4 +1,4 @@
-from .base import ValidadorBase
+from core.semantic_validators.base import ValidadorBase
 from core.ast_nodes import NodoLlamadaFuncion, NodoHilo, NodoLlamadaMetodo
 
 

--- a/src/core/semantic_validators/reflexion_segura.py
+++ b/src/core/semantic_validators/reflexion_segura.py
@@ -1,6 +1,6 @@
-from .base import ValidadorBase
+from core.semantic_validators.base import ValidadorBase
 from core.ast_nodes import NodoLlamadaFuncion, NodoLlamadaMetodo, NodoAtributo
-from .primitiva_peligrosa import PrimitivaPeligrosaError
+from core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
 
 
 class ValidadorProhibirReflexion(ValidadorBase):


### PR DESCRIPTION
## Summary
- Reemplaza los imports relativos por rutas absolutas en la cadena de validadores semánticos
- Ajusta las referencias entre validadores para usar `core.semantic_validators`

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68afb1ba5fa08327bf9110131ba85566