### PR TITLE
Usar imports absolutos en optimizaciones

### DIFF
--- a/src/core/optimizations/__init__.py
+++ b/src/core/optimizations/__init__.py
@@ -1,9 +1,9 @@
 """Herramientas de optimizacion para el AST de Cobra."""
 
-from .constant_folder import optimize_constants
-from .dead_code import remove_dead_code
-from .inliner import inline_functions
-from .common_subexpr import eliminate_common_subexpressions
+from core.optimizations.constant_folder import optimize_constants
+from core.optimizations.dead_code import remove_dead_code
+from core.optimizations.inliner import inline_functions
+from core.optimizations.common_subexpr import eliminate_common_subexpressions
 
 __all__ = [
     "optimize_constants",

--- a/src/core/optimizations/common_subexpr.py
+++ b/src/core/optimizations/common_subexpr.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Any, List
 
-from ..visitor import NodeVisitor
-from ..ast_nodes import (
+from core.visitor import NodeVisitor
+from core.ast_nodes import (
     NodoAsignacion,
     NodoOperacionBinaria,
     NodoOperacionUnaria,

--- a/src/core/optimizations/constant_folder.py
+++ b/src/core/optimizations/constant_folder.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any, List
 
-from ..visitor import NodeVisitor
-from ..ast_nodes import (
+from core.visitor import NodeVisitor
+from core.ast_nodes import (
     NodoAsignacion,
     NodoOperacionBinaria,
     NodoOperacionUnaria,

--- a/src/core/optimizations/dead_code.py
+++ b/src/core/optimizations/dead_code.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, List
 
-from ..ast_nodes import (
+from core.ast_nodes import (
     NodoCondicional,
     NodoBucleMientras,
     NodoFuncion,
@@ -15,7 +15,7 @@ from ..ast_nodes import (
     NodoContinuar,
     NodoValor,
 )
-from ..visitor import NodeVisitor
+from core.visitor import NodeVisitor
 
 
 class _DeadCodeRemover(NodeVisitor):

--- a/src/core/optimizations/inliner.py
+++ b/src/core/optimizations/inliner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, List, Tuple
 import copy
 
-from ..ast_nodes import (
+from core.ast_nodes import (
     NodoFuncion,
     NodoRetorno,
     NodoLlamadaFuncion,
@@ -21,7 +21,7 @@ from ..ast_nodes import (
     NodoNoLocal,
     NodoIdentificador,
 )
-from ..visitor import NodeVisitor
+from core.visitor import NodeVisitor
 
 
 class _FunctionInliner(NodeVisitor):


### PR DESCRIPTION
## Resumen
- Actualizar __init__ de optimizations a imports absolutos.
- Reemplazar imports relativos por core.visitor y core.ast_nodes.

## Testing
- `pytest` *(falló: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68afc64b755c8327add30c5db8fe9226