### PR TITLE
Usar imports absolutos en core

### DIFF
--- a/src/core/memoria/gestor_memoria.py
+++ b/src/core/memoria/gestor_memoria.py
@@ -2,7 +2,7 @@
 
 import random
 
-from .estrategia_memoria import EstrategiaMemoria
+from core.memoria.estrategia_memoria import EstrategiaMemoria
 
 
 class GestorMemoriaGenetico:

--- a/src/core/nativos/__init__.py
+++ b/src/core/nativos/__init__.py
@@ -1,8 +1,8 @@
 """Colección de primitivas nativas disponibles para los programas Cobra."""
 
-from .io import leer_archivo, escribir_archivo, obtener_url
-from .matematicas import sumar, promedio, potencia
-from .estructuras import Pila, Cola
+from core.nativos.io import leer_archivo, escribir_archivo, obtener_url
+from core.nativos.matematicas import sumar, promedio, potencia
+from core.nativos.estructuras import Pila, Cola
 from ..ctypes_bridge import (
     cargar_biblioteca,
     obtener_funcion,

--- a/src/core/rust_bridge.py
+++ b/src/core/rust_bridge.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 from typing import Iterable, Any
 
-from .ctypes_bridge import cargar_biblioteca, obtener_funcion
+from core.ctypes_bridge import cargar_biblioteca, obtener_funcion
 
 
 def compilar_crate(ruta: str, release: bool = True, timeout: int = 300) -> str:


### PR DESCRIPTION
## Summary
- Ajustar las importaciones internas de `core.nativos` para usar rutas absolutas
- Cambiar `ctypes_bridge` a ruta absoluta en `rust_bridge`
- Actualizar `gestor_memoria` para importar `estrategia_memoria` con ruta completa

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68afd204d2488327af4f20304d0fdeb2