### PR TITLE
Usar importaciones absolutas en corelibs

### DIFF
--- a/src/corelibs/__init__.py
+++ b/src/corelibs/__init__.py
@@ -1,13 +1,13 @@
 """Colección de utilidades estándar para Cobra."""
 
-from .texto import mayusculas, minusculas, invertir, concatenar
-from .numero import es_par, es_primo, factorial, promedio
-from .archivo import leer, escribir, existe, eliminar
-from .tiempo import ahora, formatear, dormir
-from .coleccion import ordenar, maximo, minimo, sin_duplicados
-from .seguridad import hash_sha256, generar_uuid
-from .red import obtener_url, enviar_post
-from .sistema import obtener_os, ejecutar, obtener_env, listar_dir
+from corelibs.texto import mayusculas, minusculas, invertir, concatenar
+from corelibs.numero import es_par, es_primo, factorial, promedio
+from corelibs.archivo import leer, escribir, existe, eliminar
+from corelibs.tiempo import ahora, formatear, dormir
+from corelibs.coleccion import ordenar, maximo, minimo, sin_duplicados
+from corelibs.seguridad import hash_sha256, generar_uuid
+from corelibs.red import obtener_url, enviar_post
+from corelibs.sistema import obtener_os, ejecutar, obtener_env, listar_dir
 
 __all__ = [
     "mayusculas",


### PR DESCRIPTION
## Resumen
- Reemplazados los imports relativos en `corelibs` por imports absolutos usando el prefijo del paquete.

## Pruebas
- `ruff check src/corelibs/__init__.py`
- `pytest` (falla: ModuleNotFoundError: No module named 'yaml')

------
https://chatgpt.com/codex/tasks/task_e_68b011c3688083279085e6a2a82a0656