### PR TITLE
fix: usar imports absolutos en core

### DIFF
--- a/src/cobra/core/__init__.py
+++ b/src/cobra/core/__init__.py
@@ -6,7 +6,7 @@ AST se realiza de forma explícita en los módulos que lo necesitan para
 evitar dependencias circulares durante la inicialización del paquete.
 """
 
-from .lexer import (
+from cobra.core.lexer import (
     Lexer,
     Token,
     TipoToken,

--- a/src/cobra/core/parser.py
+++ b/src/cobra/core/parser.py
@@ -5,7 +5,7 @@ import json
 import os
 from typing import Any
 from cobra.core import TipoToken, Token
-from .utils import PALABRAS_RESERVADAS, sugerir_palabra_clave
+from cobra.core.utils import PALABRAS_RESERVADAS, sugerir_palabra_clave
 
 from core.ast_nodes import (
     NodoAsignacion,


### PR DESCRIPTION
## Summary
- utilizar importación absoluta para `cobra.core.lexer`
- utilizar importación absoluta para `cobra.core.utils` en el parser

## Testing
- `PYTHONPATH=src python - <<'PY'\nimport cobra.core\nfrom cobra.core import Lexer, Parser\nfrom cobra.core.parser import PALABRAS_RESERVADAS, sugerir_palabra_clave\nprint('Lexer:', Lexer.__name__)\nprint('PALABRAS_RESERVADAS sample:', list(PALABRAS_RESERVADAS)[:3])\nprint('sugerir_palabra_clave callable:', callable(sugerir_palabra_clave))\nPY`
- `PYTHONPATH=src:. pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68b05056c2408327b3ed2d56f0110246