### PR TITLE
fix: use absolute import for CLI config

### DIFF
--- a/src/cobra/cli/utils/__init__.py
+++ b/src/cobra/cli/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utilidades varias para la CLI de Cobra."""
 
-from . import config
+from cobra.cli.utils import config
 
 __all__ = ["messages", "semver", "config"]


### PR DESCRIPTION
## Summary
- use absolute import for config in CLI utils

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68b0588702a88327968e362f6c4fc922