### PR TITLE
refactor: usar imports absolutos en módulo semántico

### DIFF
--- a/src/cobra/semantico/__init__.py
+++ b/src/cobra/semantico/__init__.py
@@ -11,8 +11,8 @@ Clases exportadas:
 Funciones exportadas:
     - validar_mod: Valida la estructura de un módulo Cobra
 """
-from .analizador import AnalizadorSemantico
-from .mod_validator import validar_mod
-from .tabla import Ambito, Simbolo
+from cobra.semantico.analizador import AnalizadorSemantico
+from cobra.semantico.mod_validator import validar_mod
+from cobra.semantico.tabla import Ambito, Simbolo
 
-__all__ = ["Simbolo", "Ambito", "AnalizadorSemantico", "validar_mod"]
+__all__ = ["Ambito", "AnalizadorSemantico", "Simbolo", "validar_mod"]


### PR DESCRIPTION
## Resumen
- Reemplazados imports relativos por absolutos en `cobra.semantico`.
- Ajustado `__all__` para exponer símbolos correctos y ordenados.

## Pruebas
- `ruff check src/cobra/semantico/__init__.py`
- `pytest --no-cov src/tests/unit/test_semantico.py src/tests/unit/test_mod_validator.py`


------
https://chatgpt.com/codex/tasks/task_e_68b05b568c448327ac9bd912525dd218