### PR TITLE
refactor: use absolute import for common utils

### DIFF
--- a/src/cobra/transpilers/common/__init__.py
+++ b/src/cobra/transpilers/common/__init__.py
@@ -1,6 +1,6 @@
 """Módulo con utilidades compartidas por los transpiladores."""
 
-from .utils import (
+from cobra.transpilers.common.utils import (
     BaseTranspiler,
     get_standard_imports,
     load_mapped_module,


### PR DESCRIPTION
## Summary
- use absolute path for `common.utils` imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68b08bb165888327861667cb7bc3906e