### PR TITLE
Reemplaza imports relativos en transpilers inversos

### DIFF
--- a/src/cobra/transpilers/reverse/from_c.py
+++ b/src/cobra/transpilers/reverse/from_c.py
@@ -34,7 +34,7 @@ from cobra.core.ast_nodes import (
     NodoTipo,
     NodoValor
 )
-from .tree_sitter_base import TreeSitterReverseTranspiler
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler
 
 
 class ReverseFromC(TreeSitterReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_cpp.py
+++ b/src/cobra/transpilers/reverse/from_cpp.py
@@ -4,7 +4,7 @@
 from typing import Any, List
 
 import cobra.core.ast_nodes
-from .tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
 
 
 class ReverseFromCPP(TreeSitterReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_fortran.py
+++ b/src/cobra/transpilers/reverse/from_fortran.py
@@ -7,7 +7,7 @@ utilizando el parser tree-sitter.
 
 from typing import Any, List
 
-from .tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
 from cobra.core.ast_nodes import (
     NodoAsignacion,
     NodoFuncion,

--- a/src/cobra/transpilers/reverse/from_go.py
+++ b/src/cobra/transpilers/reverse/from_go.py
@@ -20,7 +20,7 @@ Nota:
     Requiere que el parser tree-sitter para Go esté instalado y configurado.
 """
 
-from .tree_sitter_base import TreeSitterReverseTranspiler
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler
 
 
 class ReverseFromGo(TreeSitterReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_java.py
+++ b/src/cobra/transpilers/reverse/from_java.py
@@ -16,7 +16,7 @@ from cobra.core.ast_nodes import (
     NodoCondicional,
 )
 
-from .tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
 
 
 class ReverseFromJava(TreeSitterReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_js.py
+++ b/src/cobra/transpilers/reverse/from_js.py
@@ -34,7 +34,7 @@ from cobra.core.ast_nodes import (
     NodoOption,
 )
 
-from .tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
 
 
 class ReverseFromJS(TreeSitterReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_julia.py
+++ b/src/cobra/transpilers/reverse/from_julia.py
@@ -13,7 +13,7 @@ Nota:
     Requiere que el parser tree-sitter para Julia esté instalado y configurado.
 """
 
-from .tree_sitter_base import TreeSitterReverseTranspiler
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler
 
 class ReverseFromJulia(TreeSitterReverseTranspiler):
     """Transpilador inverso de Julia a Cobra usando tree-sitter.

--- a/src/cobra/transpilers/reverse/from_kotlin.py
+++ b/src/cobra/transpilers/reverse/from_kotlin.py
@@ -19,7 +19,7 @@ from cobra.core.ast_nodes import (
     NodoExpresion,
     NodoFuncion
 )
-from .tree_sitter_base import TreeSitterReverseTranspiler
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler
 
 
 class ReverseFromKotlin(TreeSitterReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_perl.py
+++ b/src/cobra/transpilers/reverse/from_perl.py
@@ -3,7 +3,7 @@
 from typing import Any, List
 
 from cobra.core.ast_nodes import NodoAsignacion, NodoIdentificador, NodoValor
-from .tree_sitter_base import TreeSitterNode, TreeSitterReverseTranspiler
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterNode, TreeSitterReverseTranspiler
 
 class ReverseFromPerl(TreeSitterReverseTranspiler):
     """Transpilador inverso de Perl a Cobra usando tree-sitter.

--- a/src/cobra/transpilers/reverse/from_php.py
+++ b/src/cobra/transpilers/reverse/from_php.py
@@ -12,7 +12,7 @@ Ejemplos:
 Nota:
     Requiere que el parser tree-sitter para PHP esté instalado y configurado.
 """
-from .tree_sitter_base import TreeSitterReverseTranspiler
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler
 
 class ReverseFromPHP(TreeSitterReverseTranspiler):
     """Transpilador inverso de PHP a Cobra usando tree-sitter.

--- a/src/cobra/transpilers/reverse/from_r.py
+++ b/src/cobra/transpilers/reverse/from_r.py
@@ -9,7 +9,7 @@ Ejemplos:
     >>> transpiler = ReverseFromR()
     >>> ast = transpiler.generate_ast("x <- 5")
 """
-from .tree_sitter_base import TreeSitterReverseTranspiler
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler
 
 class ReverseFromR(TreeSitterReverseTranspiler):
     """Transpilador inverso de R a Cobra usando tree-sitter.

--- a/src/cobra/transpilers/reverse/from_ruby.py
+++ b/src/cobra/transpilers/reverse/from_ruby.py
@@ -10,7 +10,7 @@ Ejemplos:
     >>> ast = transpiler.generate_ast("def hello; puts 'world'; end")
 """
 from typing import Any, List
-from .tree_sitter_base import TreeSitterReverseTranspiler
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler
 
 
 class ReverseFromRuby(TreeSitterReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_rust.py
+++ b/src/cobra/transpilers/reverse/from_rust.py
@@ -16,7 +16,7 @@ from cobra.core.ast_nodes import (
     NodoFuncion,
     NodoIdentificador,
 )
-from .tree_sitter_base import TreeSitterReverseTranspiler
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler
 
 
 class ReverseFromRust(TreeSitterReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_swift.py
+++ b/src/cobra/transpilers/reverse/from_swift.py
@@ -19,8 +19,8 @@ from cobra.core.ast_nodes import (
     NodoValor,
 )
 
-from .tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
-from .base import BaseReverseTranspiler  # type: ignore
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
+from cobra.transpilers.reverse.base import BaseReverseTranspiler  # type: ignore
 
 
 class ReverseFromSwift(TreeSitterReverseTranspiler):

--- a/src/cobra/transpilers/reverse/from_visualbasic.py
+++ b/src/cobra/transpilers/reverse/from_visualbasic.py
@@ -13,8 +13,8 @@ from cobra.core.ast_nodes import (
     NodoLlamadaFuncion,
     NodoValor,
 )
-from .tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
-from .base import BaseReverseTranspiler  # type: ignore
+from cobra.transpilers.reverse.tree_sitter_base import TreeSitterReverseTranspiler, TreeSitterNode
+from cobra.transpilers.reverse.base import BaseReverseTranspiler  # type: ignore
 
 
 def _parse_expression(texto: str) -> Any:


### PR DESCRIPTION
## Resumen
- Actualiza transpilers inversos para usar importaciones absolutas de `tree_sitter_base` y `BaseReverseTranspiler`.
- Elimina el uso de imports relativos en los archivos `from_*.py`.

## Testing
- `PYTHONPATH=src pytest -q` (falla: No module named 'cli.cli')

------
https://chatgpt.com/codex/tasks/task_e_68b08fb9585c832786e8f376e91549ca