### PR TITLE
fix(lsp): usar import absoluto para cobra_plugin

### DIFF
--- a/src/lsp/server.py
+++ b/src/lsp/server.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from pylsp.python_lsp import PythonLSPServer, start_io_lang_server
 
-from . import cobra_plugin
+from lsp import cobra_plugin
 
 
 class CobraLSPServer(PythonLSPServer):


### PR DESCRIPTION
## Summary
- Use absolute import for cobra_plugin in LSP server

## Testing
- `pytest -q` *(falla: ModuleNotFoundError: No module named 'yaml')*
- `pytest src/lsp -q` *(falla: Coverage failure: total of 0 is less than fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68b1127754e48327bd543a0aafc5489f