### PR TITLE
Añade script main para invocar la CLI

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,12 @@
+from pCobra.cli import main as cli_main
+
+
+def main() -> int:
+    """Envoltorio para la función principal de la CLI de Cobra."""
+    return cli_main()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/pCobra/__init__.py
+++ b/pCobra/__init__.py
@@ -1,0 +1,1 @@
+"""Alias de paquete para acceder a la CLI como pCobra."""

--- a/pCobra/cli.py
+++ b/pCobra/cli.py
@@ -1,0 +1,9 @@
+"""Accesos a la interfaz de línea de comandos.
+
+Este módulo actúa como un puente hacia ``src.cli`` para poder
+importar ``main`` desde ``pCobra.cli``.
+"""
+
+from src.cli import main
+
+__all__ = ["main"]


### PR DESCRIPTION
## Resumen
- Crea `main.py` para ejecutar la función principal de la CLI.
- Expone la CLI como paquete `pCobra` para facilitar el import.

## Testing
- `python main.py`
- `pytest` *(fallos: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68b121b0fb5c832793748417e2fc844f