### PR TITLE
Agregar pruebas unitarias para el lexer

### DIFF
--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent / "pCobra"))
+from cobra.core.lexer import InvalidTokenError, Lexer, TipoToken
+
+
+
+def test_lexer_aritmetica_simple() -> None:
+    codigo = "1 + 2"
+    lexer = Lexer(codigo)
+    tokens = lexer.tokenizar()
+    tipos = [token.tipo for token in tokens]
+    assert tipos == [
+        TipoToken.ENTERO,
+        TipoToken.SUMA,
+        TipoToken.ENTERO,
+        TipoToken.EOF,
+    ]
+
+
+def test_lexer_token_invalido() -> None:
+    with pytest.raises(InvalidTokenError):
+        lexer = Lexer("$")
+        lexer.tokenizar()


### PR DESCRIPTION
## Resumen
- Añadir pruebas de aritmética simple para el lexer
- Validar que un símbolo inválido genere `InvalidTokenError`

## Pruebas
- `pytest tests/test_lexer.py -q --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68b19e37cdd88327bf5b2bba48aa46e1