### PR TITLE
Agrega pruebas básicas para ClassicParser

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent / "pCobra"))
+from cobra.core.lexer import Lexer
+from cobra.core.parser import ClassicParser, ParserError
+from core.ast_nodes import NodoAsignacion
+
+
+
+def test_parser_asignacion_simple() -> None:
+    codigo = "var x = 5"
+    tokens = Lexer(codigo).tokenizar()
+    parser = ClassicParser(tokens)
+    ast = parser.parsear()
+    nodo = ast[0]
+    assert isinstance(nodo, NodoAsignacion)
+    assert nodo.identificador == "x"
+    assert nodo.valor.valor == 5
+
+
+def test_parser_error_sintaxis() -> None:
+    codigo = "mientras 1"
+    tokens = Lexer(codigo).tokenizar()
+    parser = ClassicParser(tokens)
+    with pytest.raises(ParserError):
+        parser.parsear()
+    assert parser.errores


### PR DESCRIPTION
## Resumen
- Añade test_parser_asignacion_simple para validar asignaciones con ClassicParser
- Añade test_parser_error_sintaxis para registrar errores de sintaxis

## Testing
- `python -m pytest -o addopts="" tests/test_lexer.py tests/test_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1a681c9b48327940bb8c40a286bc0