### PR TITLE
test: add CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+
+
+def test_cli_ayuda() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "pCobra.cli", "ayuda"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    salida = result.stdout.lower()
+    assert "cobra" in salida or "uso" in salida or "usage" in salida
+
+
+def test_cli_transpilar_help() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "pCobra.cli", "transpilar", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    salida = result.stdout.lower()
+    assert "transpilar" in salida or "uso" in salida or "usage" in salida
+


### PR DESCRIPTION
## Summary
- add tests for `pCobra.cli` to verify `ayuda` and `transpilar --help` commands

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.commands')*
- `pytest tests/test_cli.py -q` *(fails: Required test coverage of 85% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cd23519c8327b6e7f1c0bdfa471e