### PR TITLE
feat: añadir fixtures de carga de programas

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+
+@pytest.fixture
+def ruta_ejemplos() -> Path:
+    """Devuelve el directorio donde se guardan los programas ``.cobra`` de prueba."""
+    base = Path(__file__).resolve().parent
+    local = base / "data"
+    if local.exists():
+        return local
+    # Si los ejemplos están en el paquete principal ``pCobra/tests/data``
+    return base.parent / "pCobra" / "tests" / "data"
+
+
+@pytest.fixture
+def cargar_programa(ruta_ejemplos: Path) -> Callable[[str], str]:
+    """Carga el contenido de un programa ``.cobra`` por nombre."""
+
+    def _cargar(nombre: str) -> str:
+        archivo = ruta_ejemplos / f"{nombre}.cobra"
+        return archivo.read_text(encoding="utf-8")
+
+    return _cargar


### PR DESCRIPTION
## Summary
- añadir fixture `ruta_ejemplos` con la ruta a los programas `.cobra`
- añadir fixture `cargar_programa` para leer programas de prueba

## Testing
- `pytest` *(errores: ModuleNotFoundError: No module named 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68b1e4a155708327ad5c36a78362f146