### PR TITLE
Limit CI workflow to master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,9 @@ permissions:
 
 on:
   push:
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- limit CI workflow to trigger on `master` for pushes and pull requests

## Testing
- `./actionlint -ignore 'context "secrets"' .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b268c1ec4483278c8cea3c9aa15d1a