### PR TITLE
Add Black lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install black
+      - run: black --check .


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Black in check mode on pushes and pull requests

## Testing
- `black --check .` *(fails: would reformat 416 files)*

------
https://chatgpt.com/codex/tasks/task_e_68b276f3e9608327996891e035b5085e