### PR TITLE
docs: agrega ejemplo de transpilación en CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ El intérprete se ejecuta en modo seguro por defecto. Si deseas desactivarlo uti
 cobra archivo.co --no-seguro
 ```
 
+### Ejemplo de transpilación
+
+```bash
+cobra transpila hola.co --dest python
+```
+
+Esto generará `hola.py`. Para conocer otros destinos y opciones, consulta la [documentación detallada](docs/) o revisa [frontend/docs](frontend/docs).
+
 ## Descarga de binarios
 
 Para cada lanzamiento se generan ejecutables para Linux, Windows y macOS mediante


### PR DESCRIPTION
## Summary
- añade sección de ejemplo de transpilación en la guía de CLI

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'cli.commands')*

------
https://chatgpt.com/codex/tasks/task_e_68b2fb75b8488327a036087ea1e06591