### PR TITLE
docs: añadir sección de clases y objetos

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -55,7 +55,31 @@ func generador():
 fin
 ```
 
-## 3. Control de flujo
+## 3. Clases y objetos
+
+- Define una clase con `clase Nombre:` y finaliza con `fin`.
+- Las clases pueden declarar atributos y métodos.
+
+```cobra
+clase Persona:
+    var nombre = ''
+
+    func saludar():
+        imprimir('Hola ' + nombre)
+    fin
+fin
+
+var juan = Persona()
+juan.nombre = 'Juan'
+juan.saludar()
+```
+
+**Limitaciones actuales**
+
+- No existe herencia múltiple.
+- La herencia es simple y no hay interfaces.
+
+## 4. Control de flujo
 
 - Condicionales con `si`, `sino` y `fin` opcional.
 - Bucles `mientras` y `para`.
@@ -81,7 +105,7 @@ switch opcion:
 fin
 ```
 
-## 4. Trabajar con módulos
+## 5. Trabajar con módulos
 
 - Usa `import` para cargar archivos `.co` o módulos nativos.
 - Los módulos nativos ofrecen funciones de E/S y estructuras de datos.
@@ -91,14 +115,14 @@ import 'modulo.co'
 imprimir(saludo)
 ```
 
-## 5. Paquetes Cobra
+## 6. Paquetes Cobra
 
 - Agrupa varios módulos en un archivo con manifest ``cobra.pkg``.
 - Crea un paquete con ``cobra paquete crear carpeta paquete.cobra``.
 - Instálalo posteriormente con ``cobra paquete instalar paquete.cobra``.
 - Los archivos ``.cobra`` corresponden a paquetes completos, mientras que los scripts usan la extensión ``.co``.
 
-## 6. Macros
+## 7. Macros
 
 Permiten reutilizar fragmentos de código mediante la directiva `macro`.
 
@@ -106,7 +130,7 @@ Permiten reutilizar fragmentos de código mediante la directiva `macro`.
 macro saluda { imprimir(1) }
 saluda()
 ```
-## 7. Concurrencia
+## 8. Concurrencia
 
 - Ejecuta funciones en paralelo con la palabra clave `hilo`.
 
@@ -119,7 +143,7 @@ hilo tarea()
 imprimir('principal')
 ```
 
-## 8. Transpilación y ejecución
+## 9. Transpilación y ejecución
 
 - Compila a Python, JavaScript, ensamblador, Rust o C++ con `cobra compilar archivo.co --tipo python`.
 - Ejecuta directamente con `cobra ejecutar archivo.co`.
@@ -198,7 +222,7 @@ La carpeta [`examples/hello_world`](examples/hello_world) incluye ejemplos de "H
 
 Herencia múltiple en clases.
 
-## 9. Modo seguro
+## 10. Modo seguro
 
 El modo seguro se encuentra activado por defecto y evita operaciones peligrosas
 como `leer_archivo` o `hilo`. Para desactivarlo:
@@ -207,12 +231,12 @@ como `leer_archivo` o `hilo`. Para desactivarlo:
 cobra ejecutar programa.co --no-seguro
 ```
 
-## 10. Próximos pasos
+## 11. Próximos pasos
 
 Revisa la documentación en `frontend/docs` para profundizar en la arquitectura, validadores y más ejemplos.
 También puedes consultar ejemplos prácticos en la carpeta `casos_reales/` ubicada en la raíz del repositorio.
 
-## 11. Novedades
+## 12. Novedades
 
 Se añadieron nuevas construcciones al lenguaje:
 
@@ -226,7 +250,7 @@ Se añadieron nuevas construcciones al lenguaje:
 - Importaciones `desde` ... `como` para alias de módulos.
 - Nueva estructura `switch` con múltiples `case`.
 
-## 12. Uso de Qualia
+## 13. Uso de Qualia
 
 Qualia registra cada ejecución y genera sugerencias para mejorar tu código.
 El estado se guarda en `qualia_state.json` para conservar la información entre
@@ -249,7 +273,7 @@ En el modo interactivo escribe `sugerencias` para obtener las recomendaciones
 actuales o bien `%sugerencias` en Jupyter. Las propuestas se vuelven más
 detalladas a medida que Qualia aprende de tu código.
 
-## 13. Bibliotecas compartidas con ctypes
+## 14. Bibliotecas compartidas con ctypes
 
 Puedes cargar funciones escritas en C mediante ``cargar_funcion``. Solo
 compila una biblioteca compartida y proporciona la ruta y el nombre de la
@@ -260,7 +284,7 @@ var triple = cargar_funcion('libtriple.so', 'triple')
 imprimir(triple(3))
 ```
 
-## 14. Perfilado de programas
+## 15. Perfilado de programas
 
 Para analizar el rendimiento de un script utiliza `cobra profile`. Puedes guardar
 el resultado en un archivo `.prof` y abrirlo con herramientas como `snakeviz`:
@@ -271,7 +295,7 @@ cobra profile ejemplo.co --output ejemplo.prof --ui snakeviz
 
 Si no indicas `--ui`, se mostrará un resumen en la consola. `snakeviz` se instala junto con las dependencias de desarrollo.
 
-## 15. Funciones del sistema
+## 16. Funciones del sistema
 
 La biblioteca estándar expone `corelibs.sistema.ejecutar` para lanzar
 procesos del sistema. Por motivos de seguridad es **obligatorio**
@@ -282,7 +306,7 @@ captura al importar el módulo, por lo que modificar la variable de
 entorno después no surte efecto. Invocar la función sin esta
 configuración producirá un ``ValueError``.
 
-## 16. Limitaciones de recursos en Windows
+## 17. Limitaciones de recursos en Windows
 
 En sistemas Windows los límites de memoria y de CPU pueden no aplicarse
 correctamente. Si Cobra no logra establecer las restricciones solicitadas


### PR DESCRIPTION
## Summary
- documentar sintaxis `clase Nombre:` con atributos y métodos
- listar limitaciones actuales como la ausencia de herencia múltiple

## Testing
- `pytest` *(errores: ModuleNotFoundError: No module named 'jsonschema', cli.cli, cli.commands)*

------
https://chatgpt.com/codex/tasks/task_e_68b330d13dc08327981c552bba79fef1