### PR TITLE
Expose AST nodes in cobra core and fix generated script

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,11 @@
-from pCobra.cli import main as cli_main
+# Código generado (TranspiladorPython):
+from core.nativos import *
+from corelibs import *
+from standard_library import *
 
 
-def main() -> int:
-    """Envoltorio para la función principal de la CLI de Cobra."""
-    return cli_main()
+def principal():
+    print("Hola desde Codespaces")
 
 
-if __name__ == "__main__":
-    import sys
-
-    sys.exit(main())
+principal()

--- a/pCobra/cobra/core/__init__.py
+++ b/pCobra/cobra/core/__init__.py
@@ -15,6 +15,12 @@ from cobra.core.lexer import (
     UnclosedStringError,
 )
 
+# Reexportar todos los nodos del AST para facilitar el acceso a ellos.
+from . import ast_nodes as _ast_nodes
+
+# Agregar los nodos del AST al espacio de nombres del paquete.
+globals().update({name: getattr(_ast_nodes, name) for name in dir(_ast_nodes) if not name.startswith("_")})
+
 __all__ = [
     "Lexer",
     "Parser",
@@ -24,6 +30,7 @@ __all__ = [
     "UnclosedStringError",
     "Token",
     "TipoToken",
+    *_ast_nodes.__all__,
 ]
 
 


### PR DESCRIPTION
## Summary
- expose all AST nodes in `cobra.core` to avoid import errors
- update generated `main.py` example to valid Python and ensure it prints the greeting

## Testing
- `python main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3ecca7fb48327a269b243d38e3a6a