### PR TITLE
Fix Node imports in sistema.js

### DIFF
--- a/pCobra/core/nativos/sistema.js
+++ b/pCobra/core/nativos/sistema.js
@@ -1,10 +1,6 @@
-import os
-
-import 'child_process'
-import 'fs'
-import 'os'
-import child_process
-import fs
+import os from 'os';
+import child_process from 'child_process';
+import fs from 'fs';
 
 export function obtener_os() {
     return os.platform();


### PR DESCRIPTION
## Summary
- replace Python-style imports with ES module syntax in `sistema.js`

## Testing
- `node main.js` (manual run after transpile)
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_68b3eeb62da88327ac61f27232b6c280