### PR TITLE
Fix Java transpiler output

### DIFF
--- a/pCobra/tests/unit/test_to_java.py
+++ b/pCobra/tests/unit/test_to_java.py
@@ -6,14 +6,29 @@ def test_transpilador_asignacion_java():
     ast = [NodoAsignacion("x", 10)]
     t = TranspiladorJava()
     resultado = t.generate_code(ast)
-    assert resultado == "var x = 10;"
+    esperado = (
+        "public class Main {\n"
+        "    public static void main(String[] args) {\n"
+        "        var x = 10;\n"
+        "    }\n"
+        "}"
+    )
+    assert resultado == esperado
 
 
 def test_transpilador_funcion_java():
     ast = [NodoFuncion("miFuncion", ["a", "b"], [NodoAsignacion("x", "a + b")])]
     t = TranspiladorJava()
     resultado = t.generate_code(ast)
-    esperado = "static void miFuncion(a, b) {\n    var x = a + b;\n}"
+    esperado = (
+        "public class Main {\n"
+        "    static void miFuncion(a, b) {\n"
+        "        var x = a + b;\n"
+        "    }\n"
+        "    public static void main(String[] args) {\n"
+        "    }\n"
+        "}"
+    )
     assert resultado == esperado
 
 
@@ -21,11 +36,25 @@ def test_transpilador_llamada_funcion_java():
     ast = [NodoLlamadaFuncion("miFuncion", ["a", "b"])]
     t = TranspiladorJava()
     resultado = t.generate_code(ast)
-    assert resultado == "miFuncion(a, b);"
+    esperado = (
+        "public class Main {\n"
+        "    public static void main(String[] args) {\n"
+        "        miFuncion(a, b);\n"
+        "    }\n"
+        "}"
+    )
+    assert resultado == esperado
 
 
 def test_transpilador_imprimir_java():
     ast = [NodoImprimir(NodoValor("x"))]
     t = TranspiladorJava()
     resultado = t.generate_code(ast)
-    assert resultado == "System.out.println(x);"
+    esperado = (
+        "public class Main {\n"
+        "    public static void main(String[] args) {\n"
+        "        System.out.println(\"x\");\n"
+        "    }\n"
+        "}"
+    )
+    assert resultado == esperado


### PR DESCRIPTION
## Summary
- Ensure Java transpiler wraps code in a `Main` class with a `main` method
- Quote string, boolean and null literals during Java generation
- Adjust unit tests to match new Java output

## Testing
- `PYTHONPATH=pCobra pytest pCobra/tests/unit/test_to_java.py -vv` *(fails: Required test coverage of 85% not reached. Total coverage: 9.54%)*
- `PYTHONPATH=src/cobra-lenguaje/src python - <<'PY' ...` *(generates Main.java and runs javac/java)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f5a076f48327a27f99d296cc41b4