### PR TITLE
feat: generar ensamblador compatible con nasm

### DIFF
--- a/pCobra/cobra/transpilers/transpiler/asm_nodes/funcion.py
+++ b/pCobra/cobra/transpilers/transpiler/asm_nodes/funcion.py
@@ -1,8 +1,12 @@
 def visit_funcion(self, nodo):
-    parametros = " ".join(nodo.parametros)
-    self.agregar_linea(f"FUNC {nodo.nombre} {parametros}")
-    self.indent += 1
+    previo = self.current
+    previa_indent = self.indent
+    cuerpo: list[str] = []
+    self.current = cuerpo
+    self.indent = 1
     for ins in nodo.cuerpo:
         ins.aceptar(self)
-    self.indent -= 1
-    self.agregar_linea("ENDFUNC")
+    self.current = previo
+    self.indent = previa_indent
+    cuerpo_code = "\n".join(cuerpo)
+    self.functions.append(f"{nodo.nombre}:\n{cuerpo_code}\n    ret")

--- a/pCobra/cobra/transpilers/transpiler/asm_nodes/imprimir.py
+++ b/pCobra/cobra/transpilers/transpiler/asm_nodes/imprimir.py
@@ -1,3 +1,15 @@
+from cobra.core.ast_nodes import NodoValor
+
+
 def visit_imprimir(self, nodo):
-    valor = self.obtener_valor(nodo.expresion)
-    self.agregar_linea(f"PRINT {valor}")
+    texto = (
+        nodo.expresion.valor
+        if isinstance(nodo.expresion, NodoValor)
+        else self.obtener_valor(nodo.expresion)
+    )
+    etiqueta = self.nueva_cadena(str(texto))
+    self.agregar_linea("mov rax, 1")
+    self.agregar_linea("mov rdi, 1")
+    self.agregar_linea(f"mov rsi, {etiqueta}")
+    self.agregar_linea(f"mov rdx, {etiqueta}_len")
+    self.agregar_linea("syscall")

--- a/pCobra/cobra/transpilers/transpiler/asm_nodes/llamada_funcion.py
+++ b/pCobra/cobra/transpilers/transpiler/asm_nodes/llamada_funcion.py
@@ -1,3 +1,3 @@
 def visit_llamada_funcion(self, nodo):
-    args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
-    self.agregar_linea(f"CALL {nodo.nombre} {args}")
+    # Por ahora se ignoran los argumentos y se realiza una llamada directa
+    self.agregar_linea(f"call {nodo.nombre}")


### PR DESCRIPTION
## Summary
- generar secciones `.data` y `.text` con salida para NASM
- imprimir cadenas mediante syscalls y llamar funciones con `call`

## Testing
- `python -m pCobra.cli transpilar --a asm examples/main.cobra --o main.asm`
- `nasm -f elf64 main.asm -o main.o`
- `ld -o main main.o`
- `./main`
- `pytest` *(fails: ModuleNotFoundError: No module named 'cli.cli')*


------
https://chatgpt.com/codex/tasks/task_e_68b402bf29248327a36f598b39d1d590