### PR TITLE
feat: enable LLVM transpiler example

### DIFF
--- a/examples/main.cobra
+++ b/examples/main.cobra
@@ -1,5 +1,3 @@
-func principal():
-    imprimir "Hola desde Codespaces"
+func main():
+    retorno 2 + 2
 fin
-
-principal()


### PR DESCRIPTION
## Summary
- simplify `examples/main.cobra` to an LLVM-friendly arithmetic function
- convert AST nodes to backend expressions in the LLVM transpiler

## Testing
- `python -m pCobra.cli transpilar --a llvm examples/main.cobra --o main.ll`
- `python - <<'PY'
import subprocess
res = subprocess.run(["lli", "main.ll"])
print("returncode:", res.returncode)
PY`
- `llc main.ll -filetype=obj -o main.o`
- `clang main.o -o main_bin`
- `python - <<'PY'
import subprocess
res = subprocess.run(["./main_bin"])
print("returncode:", res.returncode)
PY`
- `PYTHONPATH=. python scripts/test_llvm_examples.py`


------
https://chatgpt.com/codex/tasks/task_e_68b40568fea08327af582a1f164cc0dd