### PR TITLE
Handle Rust return statements and preserve functions

### DIFF
--- a/pCobra/cobra/transpilers/transpiler/rust_nodes/funcion.py
+++ b/pCobra/cobra/transpilers/transpiler/rust_nodes/funcion.py
@@ -1,11 +1,35 @@
+from cobra.core.ast_nodes import NodoRetorno, NodoValor
+
+
+def _inferir_tipo(expr):
+    if isinstance(expr, NodoValor):
+        if isinstance(expr.valor, bool):
+            return "bool"
+        if isinstance(expr.valor, int):
+            return "i32"
+        if isinstance(expr.valor, float):
+            return "f64"
+    return ""
+
+
 def visit_funcion(self, nodo):
     parametros = ", ".join(nodo.parametros)
     genericos = (
         f"<{', '.join(nodo.type_params)}>" if getattr(nodo, "type_params", []) else ""
     )
-    self.agregar_linea(f"fn {nodo.nombre}{genericos}({parametros}) {{")
+    retorno = ""
+    for inst in nodo.cuerpo:
+        if isinstance(inst, NodoRetorno):
+            tipo = _inferir_tipo(inst.expresion)
+            if tipo and nodo.nombre != "main":
+                retorno = f" -> {tipo}"
+            break
+    self.agregar_linea(f"fn {nodo.nombre}{genericos}({parametros}){retorno} {{")
+    prev = getattr(self, "current_function", None)
+    self.current_function = nodo.nombre
     self.indent += 1
     for instruccion in nodo.cuerpo:
         instruccion.aceptar(self)
     self.indent -= 1
     self.agregar_linea("}")
+    self.current_function = prev

--- a/pCobra/cobra/transpilers/transpiler/rust_nodes/retorno.py
+++ b/pCobra/cobra/transpilers/transpiler/rust_nodes/retorno.py
@@ -1,0 +1,6 @@
+def visit_retorno(self, nodo):
+    valor = self.obtener_valor(nodo.expresion)
+    if getattr(self, "current_function", "") == "main":
+        self.agregar_linea(f"std::process::exit({valor});")
+    else:
+        self.agregar_linea(f"return {valor};")

--- a/pCobra/cobra/transpilers/transpiler/to_rust.py
+++ b/pCobra/cobra/transpilers/transpiler/to_rust.py
@@ -41,6 +41,7 @@ from cobra.transpilers.transpiler.rust_nodes.llamada_funcion import visit_llamad
 from cobra.transpilers.transpiler.rust_nodes.holobit import visit_holobit as _visit_holobit
 from cobra.transpilers.transpiler.rust_nodes.clase import visit_clase as _visit_clase
 from cobra.transpilers.transpiler.rust_nodes.metodo import visit_metodo as _visit_metodo
+from cobra.transpilers.transpiler.rust_nodes.retorno import visit_retorno as _visit_retorno
 from cobra.transpilers.transpiler.rust_nodes.yield_ import visit_yield as _visit_yield
 from cobra.transpilers.transpiler.rust_nodes.romper import visit_romper as _visit_romper
 from cobra.transpilers.transpiler.rust_nodes.continuar import visit_continuar as _visit_continuar
@@ -167,7 +168,7 @@ class TranspiladorRust(BaseTranspiler):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
+        nodos = optimize_constants(nodos)
         for nodo in nodos:
             nodo.aceptar(self)
         return "\n".join(self.codigo)
@@ -182,6 +183,7 @@ TranspiladorRust.visit_llamada_funcion = _visit_llamada_funcion
 TranspiladorRust.visit_holobit = _visit_holobit
 TranspiladorRust.visit_clase = _visit_clase
 TranspiladorRust.visit_metodo = _visit_metodo
+TranspiladorRust.visit_retorno = _visit_retorno
 TranspiladorRust.visit_interface = visit_interface
 TranspiladorRust.visit_yield = _visit_yield
 TranspiladorRust.visit_romper = _visit_romper


### PR DESCRIPTION
## Summary
- Emit `std::process::exit` for `main` returns and `return` for other functions in Rust transpiler
- Infer simple return types in Rust function visitor and skip aggressive dead code removal
- Register Rust return visitor

## Testing
- `PYTHONPATH=pCobra python -m pCobra transpilar --a rust examples/main.cobra`
- `PYTHONPATH=pCobra python -m pCobra transpilar --a rust examples/main.cobra --o main.rs`
- `rustc main.rs && ./main; echo EXIT:$?`
- `PYTHONPATH=. pytest tests/unit/test_transpile_rust_go.py::test_transpile_and_compile_rust_go -q` *(fails: Coverage failure: total of 1 is less than fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68b41be93e188327a33a6eaa98e28815