### PR TITLE
feat: enable basic Ruby transpilation

### DIFF
--- a/pCobra/cobra/transpilers/transpiler/to_ruby.py
+++ b/pCobra/cobra/transpilers/transpiler/to_ruby.py
@@ -10,11 +10,10 @@ from cobra.core.ast_nodes import (
     NodoOperacionBinaria,
     NodoOperacionUnaria,
     NodoAtributo,
+    NodoRetorno,
 )
 from cobra.core import TipoToken
-from core.visitor import NodeVisitor
 from cobra.transpilers.common.utils import BaseTranspiler
-from core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from cobra.macro import expandir_macros
 
 
@@ -44,11 +43,17 @@ def visit_imprimir(self, nodo: NodoImprimir):
     self.agregar_linea(f"puts {valor}")
 
 
+def visit_retorno(self, nodo: NodoRetorno):
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"return {valor}")
+
+
 ruby_nodes = {
     "asignacion": visit_asignacion,
     "funcion": visit_funcion,
     "llamada_funcion": visit_llamada_funcion,
     "imprimir": visit_imprimir,
+    "retorno": visit_retorno,
 }
 
 
@@ -89,7 +94,6 @@ class TranspiladorRuby(BaseTranspiler):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
         for nodo in nodos:
             nombre = self._camel_to_snake(nodo.__class__.__name__)
             metodo = getattr(self, f"visit_{nombre}", None)

--- a/pCobra/tests/unit/test_to_ruby.py
+++ b/pCobra/tests/unit/test_to_ruby.py
@@ -1,5 +1,12 @@
 from cobra.transpilers.transpiler.to_ruby import TranspiladorRuby
-from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+from core.ast_nodes import (
+    NodoAsignacion,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoImprimir,
+    NodoValor,
+    NodoRetorno,
+)
 
 
 def test_transpilador_asignacion_ruby():
@@ -29,3 +36,10 @@ def test_transpilador_imprimir_ruby():
     t = TranspiladorRuby()
     resultado = t.generate_code(ast)
     assert resultado == "puts x"
+
+
+def test_transpilador_retorno_ruby():
+    ast = [NodoRetorno(NodoValor(5))]
+    t = TranspiladorRuby()
+    resultado = t.generate_code(ast)
+    assert resultado == "return 5"


### PR DESCRIPTION
## Summary
- soporte de retornos y eliminación de optimizaciones que eliminaban código en el transpilador Ruby
- nueva prueba unitaria para el transpilador Ruby

## Testing
- `pytest -q pCobra/tests/unit/test_to_ruby.py -p no:cov --override-ini addopts=""`
- `PYTHONPATH=src/cobra-lenguaje/src python -m pCobra.cli transpilar --a ruby examples/main.cobra --o main.rb`
- `ruby main.rb`


------
https://chatgpt.com/codex/tasks/task_e_68b4202c5f0c83279fcdb8d063a74aa7