### PR TITLE
Fix C++ transpiler return handling

### DIFF
--- a/pCobra/cobra/transpilers/transpiler/cpp_nodes/funcion.py
+++ b/pCobra/cobra/transpilers/transpiler/cpp_nodes/funcion.py
@@ -1,9 +1,17 @@
+from core.ast_nodes import NodoRetorno
+
+
 def visit_funcion(self, nodo):
     if getattr(nodo, "type_params", []):
         genericos = ", ".join(f"typename {t}" for t in nodo.type_params)
         self.agregar_linea(f"template <{genericos}>")
     parametros = ", ".join(f"auto {p}" for p in nodo.parametros)
-    self.agregar_linea(f"void {nodo.nombre}({parametros}) {{")
+    tiene_retorno = any(isinstance(inst, NodoRetorno) for inst in nodo.cuerpo)
+    if tiene_retorno:
+        tipo = "int" if nodo.nombre == "main" else "auto"
+    else:
+        tipo = "void"
+    self.agregar_linea(f"{tipo} {nodo.nombre}({parametros}) {{")
     self.indent += 1
     for instruccion in nodo.cuerpo:
         instruccion.aceptar(self)

--- a/pCobra/cobra/transpilers/transpiler/cpp_nodes/retorno.py
+++ b/pCobra/cobra/transpilers/transpiler/cpp_nodes/retorno.py
@@ -1,0 +1,6 @@
+def visit_retorno(self, nodo):
+    if getattr(nodo, "expresion", None) is not None:
+        valor = self.obtener_valor(nodo.expresion)
+        self.agregar_linea(f"return {valor};")
+    else:
+        self.agregar_linea("return;")

--- a/pCobra/cobra/transpilers/transpiler/to_cpp.py
+++ b/pCobra/cobra/transpilers/transpiler/to_cpp.py
@@ -46,6 +46,9 @@ from cobra.transpilers.transpiler.cpp_nodes.pasar import visit_pasar as _visit_p
 from cobra.transpilers.transpiler.cpp_nodes.switch import visit_switch as _visit_switch
 from cobra.transpilers.transpiler.cpp_nodes.option import visit_option as _visit_option
 from cobra.transpilers.transpiler.cpp_nodes.pattern import visit_pattern as _visit_pattern
+from cobra.transpilers.transpiler.cpp_nodes.retorno import (
+    visit_retorno as _visit_retorno,
+)
 
 
 def visit_assert(self, nodo):
@@ -180,7 +183,7 @@ class TranspiladorCPP(BaseTranspiler):
 
     def transpilar(self, nodos):
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
+        nodos = remove_dead_code(optimize_constants(nodos))
         for nodo in nodos:
             nodo.aceptar(self)
         return "\n".join(self.codigo)
@@ -212,3 +215,4 @@ TranspiladorCPP.visit_diccionario_tipo = visit_diccionario_tipo
 TranspiladorCPP.visit_interface = visit_interface
 TranspiladorCPP.visit_option = _visit_option
 TranspiladorCPP.visit_pattern = _visit_pattern
+TranspiladorCPP.visit_retorno = _visit_retorno


### PR DESCRIPTION
## Summary
- support return statements in C++ transpiler
- emit proper return type for functions, using `int` for `main`
- skip aggressive inlining that removed top-level functions

## Testing
- `python -m pCobra.cli transpilar --a cpp examples/main.cobra --o main.cpp`
- `g++ main.cpp -o main`
- `./main`
- `pytest pCobra/tests/unit/test_to_cpp.py -q --override-ini=addopts= -p no:cov`


------
https://chatgpt.com/codex/tasks/task_e_68b43392e7488327852aab4e0e285350