### PR TITLE
fix: enable C transpiler output

### DIFF
--- a/pCobra/tests/unit/test_to_c.py
+++ b/pCobra/tests/unit/test_to_c.py
@@ -5,6 +5,7 @@ from core.ast_nodes import (
     NodoBucleMientras,
     NodoFuncion,
     NodoLlamadaFuncion,
+    NodoRetorno,
 )
 
 
@@ -42,6 +43,14 @@ def test_transpilador_funcion_c():
     t = TranspiladorC()
     resultado = t.generate_code(ast)
     esperado = "void miFuncion(int a, int b) {\n    int x = a + b;\n}"
+    assert resultado == esperado
+
+
+def test_transpilador_retorno_c():
+    ast = [NodoFuncion("main", [], [NodoRetorno("2 + 2")])]
+    t = TranspiladorC()
+    resultado = t.generate_code(ast)
+    esperado = "int main() {\n    return 2 + 2;\n}"
     assert resultado == esperado
 
 


### PR DESCRIPTION
## Summary
- allow C transpiler to preserve functions and emit returns
- add regression test for C return statements

## Testing
- `pytest pCobra/tests/unit/test_to_c.py --cov=pCobra/cobra/transpilers/transpiler/to_c.py --cov-report=term-missing --cov-report=xml --cov-fail-under=0`
- `python -m pCobra.cli transpilar --a c examples/main.cobra`
- `gcc main.c -o main && ./main`


------
https://chatgpt.com/codex/tasks/task_e_68b439ee9c208327b6e4b07f0b0fdb81