### PR TITLE
Fix COBOL transpiler output and handle returns

### DIFF
--- a/pCobra/cobra/transpilers/transpiler/cobol_nodes/retorno.py
+++ b/pCobra/cobra/transpilers/transpiler/cobol_nodes/retorno.py
@@ -1,0 +1,8 @@
+"""Nodo COBOL para manejar sentencias de retorno."""
+
+
+def visit_retorno(self, nodo):
+    """Muestra el valor de retorno usando DISPLAY."""
+    valor = self.obtener_valor(getattr(nodo, "expresion", None))
+    self.agregar_linea(f"DISPLAY {valor}")
+

--- a/pCobra/tests/unit/test_to_cobol.py
+++ b/pCobra/tests/unit/test_to_cobol.py
@@ -1,19 +1,42 @@
 from cobra.transpilers.transpiler.to_cobol import TranspiladorCOBOL
-from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+from core.ast_nodes import (
+    NodoAsignacion,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoImprimir,
+    NodoValor,
+    NodoRetorno,
+)
+
+
+HEADER = (
+    "IDENTIFICATION DIVISION.\n"
+    "PROGRAM-ID. MAIN.\n"
+    "PROCEDURE DIVISION.\n"
+)
 
 
 def test_transpilador_asignacion_cobol():
     ast = [NodoAsignacion("X", 10)]
     t = TranspiladorCOBOL()
     resultado = t.generate_code(ast)
-    assert resultado == "MOVE 10 TO X"
+    esperado = HEADER + "    MOVE 10 TO X\n    STOP RUN."
+    assert resultado == esperado
 
 
 def test_transpilador_funcion_cobol():
-    ast = [NodoFuncion("MIFUNCION", ["A", "B"], [NodoAsignacion("X", "A + B")])]
+    ast = [
+        NodoFuncion("MIFUNCION", ["A", "B"], [NodoAsignacion("X", "A + B")])
+    ]
     t = TranspiladorCOBOL()
     resultado = t.generate_code(ast)
-    esperado = "MIFUNCION SECTION.\n    MOVE A + B TO X\nEXIT SECTION."
+    esperado = (
+        HEADER
+        + "    MIFUNCION SECTION.\n"
+        + "        MOVE A + B TO X\n"
+        + "    EXIT SECTION.\n"
+        + "    STOP RUN."
+    )
     assert resultado == esperado
 
 
@@ -21,11 +44,28 @@ def test_transpilador_llamada_funcion_cobol():
     ast = [NodoLlamadaFuncion("MIFUNCION", ["A", "B"])]
     t = TranspiladorCOBOL()
     resultado = t.generate_code(ast)
-    assert resultado == "CALL 'MIFUNCION' USING A B"
+    esperado = HEADER + "    CALL 'MIFUNCION' USING A B\n    STOP RUN."
+    assert resultado == esperado
 
 
 def test_transpilador_imprimir_cobol():
     ast = [NodoImprimir(NodoValor("X"))]
     t = TranspiladorCOBOL()
     resultado = t.generate_code(ast)
-    assert resultado == "DISPLAY X"
+    esperado = HEADER + "    DISPLAY X\n    STOP RUN."
+    assert resultado == esperado
+
+
+def test_transpilador_retorno_cobol():
+    ast = [NodoFuncion("main", [], [NodoRetorno(NodoValor(1))])]
+    t = TranspiladorCOBOL()
+    resultado = t.generate_code(ast)
+    esperado = (
+        HEADER
+        + "    main SECTION.\n"
+        + "        DISPLAY 1\n"
+        + "    EXIT SECTION.\n"
+        + "    STOP RUN."
+    )
+    assert resultado == esperado
+


### PR DESCRIPTION
## Summary
- Ensure COBOL transpiler emits program structure and optimizes constants
- Add COBOL node to transpile return statements as DISPLAY
- Expand unit tests for COBOL transpilation

## Testing
- `python -m pytest pCobra/tests/unit/test_to_cobol.py -q -c /dev/null`
- `PYTHONPATH=pCobra python -m pCobra.cli transpilar --a cobol examples/main.cobra --o main.cob`
- `cobc -x -free main.cob && ./main`


------
https://chatgpt.com/codex/tasks/task_e_68b44076b2b88327ac380e4a9cf769cc