### PR TITLE
Fix Kotlin transpiler to preserve main return

### DIFF
--- a/pCobra/tests/unit/test_to_kotlin.py
+++ b/pCobra/tests/unit/test_to_kotlin.py
@@ -1,5 +1,12 @@
 from cobra.transpilers.transpiler.to_kotlin import TranspiladorKotlin
-from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoLlamadaFuncion, NodoImprimir, NodoValor
+from core.ast_nodes import (
+    NodoAsignacion,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoImprimir,
+    NodoValor,
+    NodoRetorno,
+)
 
 
 def test_transpilador_asignacion_kotlin():
@@ -29,3 +36,11 @@ def test_transpilador_imprimir_kotlin():
     t = TranspiladorKotlin()
     resultado = t.generate_code(ast)
     assert resultado == "println(x)"
+
+
+def test_transpilador_main_retorno_kotlin():
+    ast = [NodoFuncion("main", [], [NodoRetorno(NodoValor(5))])]
+    t = TranspiladorKotlin()
+    resultado = t.generate_code(ast)
+    esperado = "fun main() {\n    println(5)\n}"
+    assert resultado == esperado


### PR DESCRIPTION
## Summary
- Handle return statements in Kotlin transpiler and track current function
- Preserve functions during transpilation and add regression test

## Testing
- `PYTHONPATH=pCobra python -m pCobra.cli transpilar --a kotlin examples/main.cobra --o Main.kt`
- `kotlinc Main.kt -include-runtime -d Main.jar`
- `java -jar Main.jar`
- `pytest pCobra/tests/unit/test_to_kotlin.py --override-ini="addopts=" -q`

------
https://chatgpt.com/codex/tasks/task_e_68b47f1b0c50832786fb2daedab1d7cc