### PR TITLE
Arregla generación de código Fortran

### DIFF
--- a/pCobra/cobra/transpilers/semantica.py
+++ b/pCobra/cobra/transpilers/semantica.py
@@ -1,4 +1,4 @@
-from cobra.core.ast_nodes import NodoAtributo
+from core.ast_nodes import NodoAtributo
 
 
 def datos_asignacion(transpilador, nodo):

--- a/pCobra/cobra/transpilers/transpiler/fortran_nodes/funcion.py
+++ b/pCobra/cobra/transpilers/transpiler/fortran_nodes/funcion.py
@@ -1,9 +1,32 @@
+from core.ast_nodes import NodoRetorno
+
 
 def visit_funcion(self, nodo):
+    """Genera una función, subrutina o programa principal en Fortran."""
     params = ", ".join(nodo.parametros)
-    self.agregar_linea(f"subroutine {nodo.nombre}({params})")
-    self.indent += 1
-    for inst in nodo.cuerpo:
-        inst.aceptar(self)
-    self.indent -= 1
-    self.agregar_linea("end subroutine")
+    tiene_retorno = any(isinstance(inst, NodoRetorno) for inst in nodo.cuerpo)
+    if nodo.nombre == "main":
+        self.agregar_linea("program main")
+        self.indent += 1
+        self.in_main = True
+        for inst in nodo.cuerpo:
+            inst.aceptar(self)
+        self.in_main = False
+        self.indent -= 1
+        self.agregar_linea("end program main")
+    elif tiene_retorno:
+        self.agregar_linea(f"function {nodo.nombre}({params}) result(r)")
+        self.indent += 1
+        self.current_result = "r"
+        for inst in nodo.cuerpo:
+            inst.aceptar(self)
+        self.current_result = None
+        self.indent -= 1
+        self.agregar_linea("end function")
+    else:
+        self.agregar_linea(f"subroutine {nodo.nombre}({params})")
+        self.indent += 1
+        for inst in nodo.cuerpo:
+            inst.aceptar(self)
+        self.indent -= 1
+        self.agregar_linea("end subroutine")

--- a/pCobra/cobra/transpilers/transpiler/fortran_nodes/retorno.py
+++ b/pCobra/cobra/transpilers/transpiler/fortran_nodes/retorno.py
@@ -1,0 +1,13 @@
+def visit_retorno(self, nodo):
+    """Maneja la instrucción de retorno en Fortran."""
+    if getattr(self, "in_main", False):
+        if getattr(nodo, "expresion", None) is not None:
+            valor = self.obtener_valor(nodo.expresion)
+            self.agregar_linea(f"print *, {valor}")
+    elif getattr(self, "current_result", None):
+        if getattr(nodo, "expresion", None) is not None:
+            valor = self.obtener_valor(nodo.expresion)
+            self.agregar_linea(f"{self.current_result} = {valor}")
+        self.agregar_linea("return")
+    else:
+        self.agregar_linea("return")

--- a/pCobra/tests/unit/test_to_fortran.py
+++ b/pCobra/tests/unit/test_to_fortran.py
@@ -10,6 +10,7 @@ from core.ast_nodes import (
     NodoAtributo,
     NodoOperacionBinaria,
     NodoOperacionUnaria,
+    NodoRetorno,
 )
 
 
@@ -25,6 +26,26 @@ def test_transpilador_funcion_fortran():
     t = TranspiladorFortran()
     resultado = t.generate_code(ast)
     esperado = "subroutine miFuncion(a, b)\n    x = a + b\nend subroutine"
+    assert resultado == esperado
+
+
+def test_transpilador_program_main_fortran():
+    ast = [
+        NodoFuncion(
+            "main",
+            [],
+            [
+                NodoRetorno(
+                    NodoOperacionBinaria(
+                        NodoValor(2), Token(TipoToken.SUMA, "+"), NodoValor(2)
+                    )
+                )
+            ],
+        )
+    ]
+    t = TranspiladorFortran()
+    resultado = t.generate_code(ast)
+    esperado = "program main\n    print *, 2 + 2\nend program main"
     assert resultado == esperado
 
 


### PR DESCRIPTION
## Summary
- Maneja `main` como programa principal y soporta `return` en el transpilador Fortran
- Ajusta utilidades semánticas y referencias de AST para evitar nodos vacíos
- Añade prueba unitaria para la generación de programas Fortran

## Testing
- `pytest -q -o addopts='' pCobra/tests/unit/test_to_fortran.py`
- `python -m pCobra.cli transpilar --a fortran examples/main.cobra --o main.f90`
- `gfortran main.f90 -o main`
- `./main`


------
https://chatgpt.com/codex/tasks/task_e_68b48547c150832783ba793318af4437