### PR TITLE
Corrige eliminación de main en transpilador WASM

### DIFF
--- a/pCobra/tests/unit/test_wasm_transpiler.py
+++ b/pCobra/tests/unit/test_wasm_transpiler.py
@@ -1,0 +1,12 @@
+from cobra.core import Lexer, Parser
+from cobra.transpilers.transpiler.to_wasm import TranspiladorWasm
+
+
+def test_transpilar_funcion_simple() -> None:
+    codigo = """func main():\n    retorno 2 + 2\nfin"""
+    tokens = Lexer(codigo).analizar_token()
+    ast = Parser(tokens).parsear()
+    transpiler = TranspiladorWasm()
+    wat = transpiler.generate_code(ast)
+    assert "(func $main" in wat
+    assert "(return" in wat and "4" in wat


### PR DESCRIPTION
## Resumen
- evita que `inline_functions` borre funciones como `main`
- añade soporte de retorno y constantes al WAT generado
- prueba unitaria que verifica la presencia de la función en la salida

## Testing
- `pytest pCobra/tests/unit/test_wasm_transpiler.py::test_transpilar_funcion_simple -q` *(falla cobertura <85%)*
- `wat2wasm main.wat -o main.wasm`
- `wasmtime main.wasm` *(no instalado)*

------
https://chatgpt.com/codex/tasks/task_e_68b48ab059f0832785ddd644058ff6b2