### PR TITLE
Añadir pruebas de transpilación basadas en ejemplos

### DIFF
--- a/pCobra/tests/data/expected_examples/hola.py
+++ b/pCobra/tests/data/expected_examples/hola.py
@@ -1,0 +1,4 @@
+from core.nativos import *
+from corelibs import *
+from standard_library import *
+print(Hola Cobra)

--- a/pCobra/tests/data/expected_examples/suma.py
+++ b/pCobra/tests/data/expected_examples/suma.py
@@ -1,0 +1,7 @@
+from core.nativos import *
+from corelibs import *
+from standard_library import *
+def sumar(a, b):
+    c = (NodoIdentificador(a) + NodoIdentificador(b))
+    print(c)
+sumar(2, 3)


### PR DESCRIPTION
## Resumen
- Agrega archivos de referencia `hola.py` y `suma.py` con el código Python generado desde los ejemplos Cobra.
- Extiende `test_ejemplos_io` con una prueba que transpila cada ejemplo y compara el resultado con los archivos de referencia.

## Pruebas
- `pytest tests/test_ejemplos_io.py -q --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68b498b1fca88327b424ef3efb98a7f5