### PR TITLE
Manejar PromptSession sin consola con DummyOutput

### DIFF
--- a/tests/test_interactive_cmd_no_console.py
+++ b/tests/test_interactive_cmd_no_console.py
@@ -1,0 +1,61 @@
+import argparse
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "pCobra"))
+
+from cobra.cli.commands.interactive_cmd import (
+    InteractiveCommand,
+    NoConsoleScreenBufferError,
+    DummyOutput,
+)
+
+
+class _FakeInterpreter:
+    def ejecutar_ast(self, ast):
+        pass
+
+
+def test_interactive_cmd_without_console(monkeypatch, capsys):
+    cmd = InteractiveCommand(_FakeInterpreter())
+
+    # Evitar efectos secundarios
+    monkeypatch.setattr(
+        "cobra.cli.commands.interactive_cmd.limitar_memoria_mb", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "cobra.cli.commands.interactive_cmd.validar_dependencias", lambda *a, **k: None
+    )
+
+    class DummyPrompt:
+        calls = 0
+        last_output = None
+
+        def __init__(self, *args, **kwargs):
+            DummyPrompt.calls += 1
+            DummyPrompt.last_output = kwargs.get("output")
+            if DummyPrompt.calls == 1:
+                raise NoConsoleScreenBufferError()
+
+        def prompt(self, *args, **kwargs):
+            raise EOFError
+
+    monkeypatch.setattr(
+        "cobra.cli.commands.interactive_cmd.PromptSession", DummyPrompt
+    )
+
+    args = argparse.Namespace(
+        memory_limit=InteractiveCommand.MEMORY_LIMIT_MB,
+        ignore_memory_limit=False,
+        sandbox=False,
+        sandbox_docker=None,
+        seguro=False,
+        validadores_extra=None,
+    )
+
+    result = cmd.run(args)
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "Entorno sin consola compatible" in captured.out
+    assert DummyPrompt.calls == 2
+    assert isinstance(DummyPrompt.last_output, DummyOutput)


### PR DESCRIPTION
## Resumen
- Maneja la ausencia de consola envolviendo la creación de `PromptSession` y usando `DummyOutput` como fallback
- Se emite una advertencia clara cuando no hay consola compatible
- Se añade prueba que simula un entorno sin consola para verificar el mensaje y el uso de `DummyOutput`

## Pruebas
- `pytest tests/test_interactive_cmd_no_console.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b52d5af38c832782e430c5110b224c