### PR TITLE
Eliminar carpeta duplicada src/cobra-lenguaje y conservar pcobra.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include CHANGELOG.md
 include MANUAL_COBRA.md
 include cobra.mod
 include cobra.toml
+include pcobra.toml
 include pyproject.toml
 include Makefile
 include install.sh

--- a/pcobra.toml
+++ b/pcobra.toml
@@ -1,0 +1,13 @@
+# pcobra.toml
+# Mapeo de módulos Cobra transpilados a Python o JavaScript.
+# Este archivo se genera o mantiene manualmente tras usar comandos como `cobra transpilar`.
+
+[modulos."modulo.co"]
+python = "modulo.py"
+js = "modulo.js"
+
+# Puedes añadir más entradas como:
+# [modulos."ciencia/genetica.co"]
+# python = "ciencia/genetica.py"
+# js = "ciencia/genetica.js"
+


### PR DESCRIPTION
## Resumen
- Mueve `pcobra.toml` a la raíz del repositorio y lo incluye en el manifiesto de distribución.
- Elimina la copia duplicada `src/cobra-lenguaje` y limpia referencias obsoletas.

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'yaml' y 'cli.cli')*

------
https://chatgpt.com/codex/tasks/task_e_68b532686f4c8327bde572fce3a655ac