### PR TITLE
Consolidar archivos de dependencias en la raíz

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,9 @@ El proyecto se organiza en las siguientes carpetas y módulos:
 - `frontend/docs/`: Carpeta donde se genera y aloja la documentación. El archivo `frontend/docs/arquitectura.rst` describe la estructura interna del lenguaje. Consulta `docs/arquitectura_parser_transpiladores.md` para un resumen de la relación entre lexer, parser y transpiladores.
 - `pCobra/tests/`: Incluye pruebas unitarias para asegurar el correcto funcionamiento del código.
 - `README.md`: Documentación del proyecto.
-- `requirements.txt`: Archivo que lista las dependencias del proyecto.
-- `pyproject.toml`: También define dependencias en las secciones
-  ``project.dependencies`` y ``project.optional-dependencies``.
+- `requirements.txt`: Archivo en la raíz que lista las dependencias del proyecto.
+- `pyproject.toml`: Define dependencias en las secciones ``project.dependencies`` y ``project.optional-dependencies``. Estos
+  archivos en la raíz son la única fuente de dependencias.
 
 # Características Principales
 

--- a/README_en.md
+++ b/README_en.md
@@ -249,8 +249,9 @@ The project is organized into the following folders and modules:
 - `frontend/docs/` and `frontend/build/`: Folders where the documentation is generated and stored. The file `frontend/docs/arquitectura.rst` describes the internal structure of the language.
 - `src/tests/`: Unit tests to ensure correct behaviour of the code.
 - `README.md`: Project documentation.
-- `requirements.txt`: Lists the project dependencies.
-- `pyproject.toml`: Also defines dependencies in the ``project.dependencies`` and ``project.optional-dependencies`` sections.
+- `requirements.txt`: File in the repository root that lists the project dependencies.
+- `pyproject.toml`: Defines dependencies in the ``project.dependencies`` and ``project.optional-dependencies`` sections. These
+  root-level files are the single source of dependencies.
 
 # Main Features
 


### PR DESCRIPTION
## Resumen
- Referencia a `requirements.txt` y `pyproject.toml` únicamente en la raíz del repositorio.
- Limpieza de duplicados en `src/cobra-lenguaje` y actualización de documentación.

## Testing
- `pytest -q` *(falla: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68b54757b70c8327b0986385cc0f96a0