### PR TITLE
docs: fix example links to default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ El objetivo de pCobra es brindar a la comunidad hispanohablante una alternativa 
 
 ## Ejemplos
 
-Proyectos de demostracion disponibles en [cobra-ejemplos](https://github.com/Alphonsus411/pCobra/tree/work/examples).
+Proyectos de demostración disponibles en el [repositorio de ejemplos](https://github.com/Alphonsus411/pCobra/tree/HEAD/examples).
 Este repositorio incluye ejemplos básicos en la carpeta `examples/`, por
 ejemplo `examples/funciones_principales.co` que muestra condicionales, bucles y
 definición de funciones en Cobra.

--- a/README_en.md
+++ b/README_en.md
@@ -40,7 +40,7 @@ Cobra is a programming language designed in Spanish, aimed at creating tools, si
 
 ## Examples
 
-Demo projects are available in [cobra-ejemplos](https://github.com/Alphonsus411/pCobra/tree/work/examples). This repository includes basic examples in the `examples/` folder, for instance `examples/funciones_principales.co` which shows conditionals, loops and function definitions in Cobra. For interactive examples check the notebooks in `notebooks/casos_reales/`.
+Demo projects are available in the [example repository](https://github.com/Alphonsus411/pCobra/tree/HEAD/examples). This repository includes basic examples in the `examples/` folder, for instance `examples/funciones_principales.co` which shows conditionals, loops and function definitions in Cobra. For interactive examples check the notebooks in `notebooks/casos_reales/`.
 
 ### Advanced examples
 


### PR DESCRIPTION
## Summary
- update examples link in README and README_en to track default branch

## Testing
- `curl -L -o /dev/null -w '%{http_code}\n' https://github.com/Alphonsus411/pCobra/tree/HEAD/examples`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend.corelibs')*

------
https://chatgpt.com/codex/tasks/task_e_68b56a61f5148327ab69a0f4029ed160