### PR TITLE
docs: especificar version Python

### DIFF
--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -14,7 +14,7 @@ Preparación del entorno
 ----------------------
 
 1. Clona el repositorio y entra en ``pCobra``.
-2. Crea y activa un entorno virtual.
+2. Crea y activa un entorno virtual de **Python 3.9 o superior**.
 3. Instala las dependencias con ``pip install -r requirements-dev.txt``.
 4. Instala Cobra en modo editable con ``pip install -e .``.
 


### PR DESCRIPTION
## Summary
- Detalla que el entorno virtual debe usar Python 3.9 o superior en la guía de instalación

## Testing
- `pytest` *(falló: ModuleNotFoundError: No module named 'backend.corelibs')*


------
https://chatgpt.com/codex/tasks/task_e_68b5784556248327ad16f6b1a4acd282