### PR TITLE
docs: add system functions section

### DIFF
--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -196,6 +196,16 @@ Recomendaciones de estilo
 * Prefiere expresiones claras antes que construcciones complejas y evita macros
   innecesarias.
 
+Funciones del sistema
+---------------------
+
+La biblioteca estándar expone ``corelibs.sistema.ejecutar`` para lanzar procesos del
+sistema. Por motivos de seguridad es **obligatorio** proporcionar una lista blanca de
+ejecutables permitidos mediante el parámetro ``permitidos`` o definiendo la variable
+de entorno ``COBRA_EJECUTAR_PERMITIDOS`` separada por ``os.pathsep``. La lista se
+captura al importar el módulo, por lo que modificar la variable de entorno después no
+surte efecto. Invocar la función sin esta configuración producirá un ``ValueError``.
+
 Limitaciones de recursos en Windows
 -----------------------------------
 


### PR DESCRIPTION
## Summary
- add documentation on system function whitelist and environment variable to manual

## Testing
- `pytest -q` *(fails: No module named 'dotenv', 'ipykernel', unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68b57f9b614883278c26f5401e541128