### PR TITLE
docs: actualizar formato de caché incremental

### DIFF
--- a/docs/cache_incremental.md
+++ b/docs/cache_incremental.md
@@ -5,6 +5,10 @@ Se ha incorporado un sistema de almacenamiento por fragmentos en
 por separado mediante un *checksum*, permitiendo reutilizar los
 fragmentos que no cambian entre ejecuciones.
 
+Desde la versión 10.0.9, la caché de AST y tokens se almacena en
+formato JSON en lugar de `pickle`, lo que reduce la superficie de
+ataque al eliminar la deserialización insegura de datos.
+
 El directorio utilizado para la caché puede modificarse mediante la
 variable de entorno `COBRA_AST_CACHE`.
 


### PR DESCRIPTION
## Summary
- aclarar que la caché incremental ahora se guarda en JSON

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'backend.corelibs')*

------
https://chatgpt.com/codex/tasks/task_e_68b5866872388327af41c6839e9b624a