### PR TITLE
chore: simplify CLI package imports

### DIFF
--- a/src/pcobra/__init__.py
+++ b/src/pcobra/__init__.py
@@ -7,7 +7,8 @@ import sys as _sys
 
 logger = logging.getLogger(__name__)
 
-_submodules = ["cli", "cobra", "core", "ia", "jupyter_kernel", "gui", "lsp", "compiler"]
+# Cargar primero los paquetes base para evitar errores de dependencias cruzadas
+_submodules = ["cobra", "core", "cli", "ia", "jupyter_kernel", "gui", "lsp", "compiler"]
 
 for pkg in _submodules:
     if importlib.util.find_spec(f".{pkg}", __name__) is None:

--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -5,11 +5,20 @@ import logging
 import sys
 from typing import List, Optional
 
+from . import cobra as cobra_pkg
+from . import core as core_pkg
+from . import compiler as compiler_pkg
+
+# Registrar alias de paquetes para compatibilidad con imports absolutos
+sys.modules.setdefault("cobra", cobra_pkg)
+sys.modules.setdefault("core", core_pkg)
+sys.modules.setdefault("compiler", compiler_pkg)
+
+import re
 from dotenv import load_dotenv
 from .cobra.cli.commands.compile_cmd import CompileCommand, LANG_CHOICES
 from .cobra.cli.commands.execute_cmd import ExecuteCommand
 from .cobra.cli.utils import messages
-import re
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- ensure CLI registers internal packages as absolute aliases
- import core modules before CLI to avoid missing dependency warnings

## Testing
- `PYTHONPATH=src python -m pcobra.cli ayuda`
- `PYTHONPATH=src pytest tests/test_cli.py tests/test_ejemplos_io.py -q` *(fails: Required test coverage of 85% not reached. Total coverage: 2.60%)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fab7acb0832796e30c99aa0388cd