### PR TITLE
refactor: usar rutas pcobra

### DIFF
--- a/src/pcobra/core/ast_cache.py
+++ b/src/pcobra/core/ast_cache.py
@@ -94,13 +94,13 @@ def _get_node_classes():
 def _get_enum_classes():
     global _ENUM_CLASSES
     if _ENUM_CLASSES is None:
-        from cobra.core.lexer import TipoToken
+        from pcobra.cobra.core.lexer import TipoToken
         _ENUM_CLASSES = {"TipoToken": TipoToken}
     return _ENUM_CLASSES
 
 
 def _serialize(obj):
-    from cobra.core.lexer import Token
+    from pcobra.cobra.core.lexer import Token
 
     if is_dataclass(obj):
         data = {"__class__": obj.__class__.__name__}
@@ -125,7 +125,7 @@ def _serialize(obj):
 
 
 def _deserialize(data):
-    from cobra.core.lexer import Token, TipoToken
+    from pcobra.cobra.core.lexer import Token, TipoToken
 
     if isinstance(data, list):
         return [_deserialize(i) for i in data]
@@ -177,7 +177,7 @@ def obtener_tokens(codigo: str):
         with open(ruta, "r", encoding="utf-8") as f:
             return _deserialize(json.load(f))
 
-    from cobra.core import Lexer
+    from pcobra.cobra.core import Lexer
 
     tokens = Lexer(codigo).tokenizar()
     with open(ruta, "w", encoding="utf-8") as f:
@@ -196,7 +196,7 @@ def obtener_ast(codigo: str):
             return _deserialize(json.load(f))
 
     tokens = obtener_tokens(codigo)
-    from cobra.core import Parser
+    from pcobra.cobra.core import Parser
 
     ast = Parser(tokens).parsear()
 
@@ -224,7 +224,7 @@ def obtener_tokens_fragmento(codigo: str):
         with open(ruta, "r", encoding="utf-8") as f:
             return _deserialize(json.load(f))
 
-    from cobra.core import Lexer
+    from pcobra.cobra.core import Lexer
 
     tokens = Lexer(codigo).tokenizar()
     with open(ruta, "w", encoding="utf-8") as f:
@@ -240,7 +240,7 @@ def obtener_ast_fragmento(codigo: str):
             return _deserialize(json.load(f))
 
     tokens = obtener_tokens_fragmento(codigo)
-    from cobra.core import Parser
+    from pcobra.cobra.core import Parser
 
     ast = Parser(tokens).parsear()
     with open(ruta, "w", encoding="utf-8") as f:

--- a/src/pcobra/core/ast_nodes.py
+++ b/src/pcobra/core/ast_nodes.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - solo para verificación estática
-    from cobra.core.lexer import Token, TipoToken
+    from pcobra.cobra.core.lexer import Token, TipoToken
 
 
 @dataclass
@@ -25,7 +25,7 @@ class NodoAsignacion(NodoAST):
     """Representa la asignación de una expresión a una variable."""
 
     def __post_init__(self):
-        from cobra.core.lexer import Token
+        from pcobra.cobra.core.lexer import Token
 
         if isinstance(self.variable, Token):
             nombre = self.variable.valor
@@ -260,7 +260,7 @@ class NodoIdentificador(NodoAST):
     """Uso de una variable o identificador."""
 
     def __post_init__(self):
-        from cobra.core.lexer import Token
+        from pcobra.cobra.core.lexer import Token
 
         if isinstance(self.nombre, Token):
             self.nombre = self.nombre.valor
@@ -285,7 +285,7 @@ class NodoIdentificador(NodoAST):
         if isinstance(valor, NodoValor):
             return valor.valor
 
-        from cobra.core.lexer import Token, TipoToken
+        from pcobra.cobra.core.lexer import Token, TipoToken
 
         if isinstance(valor, Token) and valor.tipo in {
             TipoToken.ENTERO,

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -3,7 +3,7 @@
 import logging
 import os
 
-from cobra.core import Token, TipoToken, Lexer
+from pcobra.cobra.core import Token, TipoToken, Lexer
 from core.optimizations import (
     optimize_constants,
     remove_dead_code,
@@ -49,13 +49,13 @@ from core.ast_nodes import (
     NodoImportDesde,
     NodoAST,
 )
-from cobra.core import Parser
+from pcobra.cobra.core import Parser
 from core.memoria.gestor_memoria import GestorMemoriaGenetico
 from core.semantic_validators import (
     construir_cadena,
     PrimitivaPeligrosaError,
 )
-from cobra.semantico import AnalizadorSemantico
+from pcobra.cobra.semantico import AnalizadorSemantico
 from core.qualia_bridge import register_execution
 from core.cobra_config import (
     limite_nodos,
@@ -696,7 +696,7 @@ class InterpretadorCobra:
 
     def ejecutar_usar(self, nodo):
         """Importa un módulo de Python instalándolo si es necesario."""
-        from cobra.usar_loader import obtener_modulo
+        from pcobra.cobra.usar_loader import obtener_modulo
 
         try:
             modulo = obtener_modulo(nodo.modulo)

--- a/src/pcobra/core/optimizations/constant_folder.py
+++ b/src/pcobra/core/optimizations/constant_folder.py
@@ -17,7 +17,7 @@ from core.ast_nodes import (
     NodoMetodo,
     NodoRetorno,
 )
-from cobra.core import TipoToken, Token
+from pcobra.cobra.core import TipoToken, Token
 
 
 class _ConstantFolder(NodeVisitor):

--- a/src/pcobra/core/qualia_bridge.py
+++ b/src/pcobra/core/qualia_bridge.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 from typing import List, Union
 
-from cobra.core import Lexer, Parser
+from pcobra.cobra.core import Lexer, Parser
 from core.qualia_knowledge import QualiaKnowledge
 
 

--- a/src/pcobra/core/resource_limits.py
+++ b/src/pcobra/core/resource_limits.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from cobra.cli.i18n import _
+from pcobra.cobra.cli.i18n import _
 
 
 logger = logging.getLogger(__name__)

--- a/src/pcobra/gui/app.py
+++ b/src/pcobra/gui/app.py
@@ -4,10 +4,9 @@ import io
 import sys
 import flet as ft
 
-from cobra.core import Lexer
-from cobra.core import Parser
+from pcobra.cobra.core import Lexer, Parser
 from core.interpreter import InterpretadorCobra
-from cobra.cli.commands.compile_cmd import TRANSPILERS
+from pcobra.cobra.cli.commands.compile_cmd import TRANSPILERS
 
 
 def _ejecutar_codigo(codigo: str) -> str:

--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -4,10 +4,9 @@ import io
 import sys
 import flet as ft
 
-from cobra.core import Lexer
-from cobra.core import Parser
+from pcobra.cobra.core import Lexer, Parser
 from core.interpreter import InterpretadorCobra
-from cobra.cli.commands.compile_cmd import TRANSPILERS
+from pcobra.cobra.cli.commands.compile_cmd import TRANSPILERS
 
 
 def _ejecutar_codigo(codigo: str) -> str:

--- a/src/pcobra/ia/analizador_agix.py
+++ b/src/pcobra/ia/analizador_agix.py
@@ -6,8 +6,7 @@ except ImportError:  # pragma: no cover - depende de agix instalado
     Reasoner = None
 from typing import List
 
-from cobra.core import Lexer
-from cobra.core import Parser
+from pcobra.cobra.core import Lexer, Parser
 
 
 def generar_sugerencias(

--- a/src/pcobra/jupyter_kernel/__init__.py
+++ b/src/pcobra/jupyter_kernel/__init__.py
@@ -6,9 +6,8 @@ import os
 import contextlib
 from importlib.metadata import PackageNotFoundError, version
 from ipykernel.kernelbase import Kernel
-from cobra.core import Lexer
-from cobra.core import Parser
-from cobra.core.utils import PALABRAS_RESERVADAS
+from pcobra.cobra.core import Lexer, Parser
+from pcobra.cobra.core.utils import PALABRAS_RESERVADAS
 from core.interpreter import InterpretadorCobra
 from core.qualia_bridge import get_suggestions
 from core.sandbox import ejecutar_en_sandbox
@@ -76,7 +75,7 @@ class CobraKernel(Kernel):
                 tokens = Lexer(code).tokenizar()
                 ast = Parser(tokens).parsear()
                 if self.use_python:
-                    from cobra.transpilers.transpiler.to_python import (
+                    from pcobra.cobra.transpilers.transpiler.to_python import (
                         TranspiladorPython,
                     )
 

--- a/src/pcobra/lsp/cobra_plugin.py
+++ b/src/pcobra/lsp/cobra_plugin.py
@@ -6,9 +6,9 @@ import logging
 import re
 from pylsp import hookimpl, lsp
 from standard_library import __all__ as STD_FUNCS
-from cobra.core import Lexer, LexerError
-from cobra.core import Parser, ParserError
-from cobra.cli.commands.execute_cmd import ExecuteCommand
+from pcobra.cobra.core import Lexer, LexerError
+from pcobra.cobra.core import Parser, ParserError
+from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
 
 # Palabras reservadas más comunes de Cobra
 KEYWORDS = [

--- a/tests/test_interactive_cmd_no_console.py
+++ b/tests/test_interactive_cmd_no_console.py
@@ -2,9 +2,9 @@ import argparse
 import os
 import sys
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src", "pcobra"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from cobra.cli.commands.interactive_cmd import (
+from pcobra.cobra.cli.commands.interactive_cmd import (
     InteractiveCommand,
     NoConsoleScreenBufferError,
     DummyOutput,
@@ -21,10 +21,12 @@ def test_interactive_cmd_without_console(monkeypatch, capsys):
 
     # Evitar efectos secundarios
     monkeypatch.setattr(
-        "cobra.cli.commands.interactive_cmd.limitar_memoria_mb", lambda *a, **k: None
+        "pcobra.cobra.cli.commands.interactive_cmd.limitar_memoria_mb",
+        lambda *a, **k: None,
     )
     monkeypatch.setattr(
-        "cobra.cli.commands.interactive_cmd.validar_dependencias", lambda *a, **k: None
+        "pcobra.cobra.cli.commands.interactive_cmd.validar_dependencias",
+        lambda *a, **k: None,
     )
 
     class DummyPrompt:
@@ -41,7 +43,7 @@ def test_interactive_cmd_without_console(monkeypatch, capsys):
             raise EOFError
 
     monkeypatch.setattr(
-        "cobra.cli.commands.interactive_cmd.PromptSession", DummyPrompt
+        "pcobra.cobra.cli.commands.interactive_cmd.PromptSession", DummyPrompt
     )
 
     args = argparse.Namespace(

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 import pytest
 
-sys.path.append(str(Path(__file__).resolve().parent.parent / "src" / "pcobra"))
-from cobra.core.lexer import InvalidTokenError, Lexer, TipoToken
+sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
+from pcobra.cobra.core.lexer import InvalidTokenError, Lexer, TipoToken
 
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,10 +3,10 @@ from pathlib import Path
 
 import pytest
 
-sys.path.append(str(Path(__file__).resolve().parent.parent / "src" / "pcobra"))
-from cobra.core.lexer import Lexer
-from cobra.core.parser import ClassicParser, ParserError
-from core.ast_nodes import NodoAsignacion
+sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
+from pcobra.cobra.core.lexer import Lexer
+from pcobra.cobra.core.parser import ClassicParser, ParserError
+from pcobra.core.ast_nodes import NodoAsignacion
 
 
 

--- a/tests/test_transpilers.py
+++ b/tests/test_transpilers.py
@@ -4,17 +4,17 @@ from pathlib import Path
 import pytest
 
 # Añadir la ruta del paquete principal
-sys.path.append(str(Path(__file__).resolve().parent.parent / "src" / "pcobra"))
+sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
 
-from cobra.transpilers.transpiler.to_python import TranspiladorPython
-from core.ast_nodes import (
+from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
+from pcobra.core.ast_nodes import (
     NodoValor,
     NodoAsignacion,
     NodoOperacionBinaria,
     NodoOperacionUnaria,
     NodoIdentificador,
 )
-import cobra.core as cobra_core
+import pcobra.cobra.core as cobra_core
 
 # Registrar nodos adicionales en el módulo ``cobra.core`` para evitar errores de importación
 cobra_core.NodoOperacionBinaria = NodoOperacionBinaria


### PR DESCRIPTION
## Resumen
- Reemplazar importaciones de `cobra` por rutas explícitas de `pcobra` en módulos clave
- Actualizar pruebas para usar las nuevas rutas y limpieza de sys.path

## Testing
- `pytest` *(falla: ModuleNotFoundError en varios módulos opcionales como holobits)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ff496be483279bdfe960c2a5ac4f