### PR TITLE
Añade pruebas de alias de CLI y corrige configuración de imports

### DIFF
--- a/src/pcobra/tests/conftest.py
+++ b/src/pcobra/tests/conftest.py
@@ -3,14 +3,13 @@ from pathlib import Path
 
 import pytest
 
-# Añade el directorio ``src`` al ``PYTHONPATH`` para simplificar los imports en las pruebas
-ROOT = Path(__file__).resolve().parents[1]
-src_path = ROOT / "src"
+# Añade los directorios necesarios al ``PYTHONPATH`` para simplificar los imports
+SRC_ROOT = Path(__file__).resolve().parents[2]
+PCOBRA_PATH = SRC_ROOT / 'pcobra'
 
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-if src_path.exists() and str(src_path) not in sys.path:
-    sys.path.insert(0, str(src_path))
+for path in (SRC_ROOT, PCOBRA_PATH):
+    if path.exists() and str(path) not in sys.path:
+        sys.path.insert(0, str(path))
 
 # Carga opcionalmente el paquete ``backend`` para mantener compatibilidad
 try:  # nosec B001

--- a/src/pcobra/tests/unit/test_cli_imports_alias.py
+++ b/src/pcobra/tests/unit/test_cli_imports_alias.py
@@ -1,0 +1,61 @@
+from types import ModuleType
+import sys
+import importlib
+
+# Crear módulos falsos para evitar dependencias externas
+fake_rp = ModuleType("RestrictedPython")
+fake_rp.compile_restricted = lambda *a, **k: None
+fake_rp.safe_builtins = {}
+sys.modules.setdefault("RestrictedPython", fake_rp)
+
+_eval = ModuleType("Eval")
+_eval.default_guarded_getitem = lambda seq, key: seq[key]
+sys.modules.setdefault("RestrictedPython.Eval", _eval)
+
+_guards = ModuleType("Guards")
+_guards.guarded_iter_unpack_sequence = lambda *a, **k: iter([])
+_guards.guarded_unpack_sequence = lambda *a, **k: []
+sys.modules.setdefault("RestrictedPython.Guards", _guards)
+
+_print = ModuleType("PrintCollector")
+_print.PrintCollector = list
+sys.modules.setdefault("RestrictedPython.PrintCollector", _print)
+
+fake_jsonschema = ModuleType("jsonschema")
+fake_jsonschema.validate = lambda *a, **k: None
+class FakeValidationError(Exception):
+    pass
+fake_jsonschema.ValidationError = FakeValidationError
+sys.modules.setdefault("jsonschema", fake_jsonschema)
+
+tsl_mod = ModuleType("tree_sitter_languages")
+tsl_mod.get_parser = lambda *a, **k: None
+sys.modules.setdefault("tree_sitter_languages", tsl_mod)
+
+pcobra_cli_cli = importlib.import_module("pcobra.cli.cli")
+pcobra_base = importlib.import_module("pcobra.cli.commands.base")
+
+# Alias para que los imports relativos y absolutos apunten al mismo objeto
+sys.modules.setdefault("cli", sys.modules["pcobra.cli"])
+sys.modules.setdefault("cli.cli", pcobra_cli_cli)
+sys.modules.setdefault("cli.commands.base", pcobra_base)
+
+from cli.cli import main as main_cli
+from pcobra.cli.cli import main as main_pcobra
+
+from cli.commands.base import BaseCommand as BaseCommand_cli
+from pcobra.cli.commands.base import BaseCommand as BaseCommand_pcobra
+
+
+def test_cli_alias_module():
+    import cli
+    import pcobra.cli
+    assert cli is pcobra.cli
+
+
+def test_cli_alias_function():
+    assert main_cli is main_pcobra
+
+
+def test_cli_alias_command_class():
+    assert BaseCommand_cli is BaseCommand_pcobra

--- a/src/pcobra/tests/unit/test_cli_module_alias_simple.py
+++ b/src/pcobra/tests/unit/test_cli_module_alias_simple.py
@@ -1,0 +1,26 @@
+import importlib
+import sys
+
+# Import modules from pcobra
+pcobra_cli_pkg = importlib.import_module("pcobra.cli")
+pcobra_init = importlib.import_module("pcobra.cli.commands.init_cmd")
+pcobra_semver = importlib.import_module("pcobra.cli.utils.semver")
+
+# Ensure relative imports map to the same modules
+sys.modules.setdefault("cli", pcobra_cli_pkg)
+sys.modules.setdefault("cli.commands.init_cmd", pcobra_init)
+sys.modules.setdefault("cli.utils.semver", pcobra_semver)
+
+from cli.commands.init_cmd import InitCommand as InitCommand_cli
+from pcobra.cli.commands.init_cmd import InitCommand as InitCommand_pcobra
+
+from cli.utils.semver import es_version_valida as es_version_cli
+from pcobra.cli.utils.semver import es_version_valida as es_version_pcobra
+
+
+def test_init_command_is_same_module():
+    assert InitCommand_cli is InitCommand_pcobra
+
+
+def test_semver_function_is_same_module():
+    assert es_version_cli is es_version_pcobra


### PR DESCRIPTION
## Resumen
- Porta y adapta pruebas `test_cli_imports_alias` y `test_cli_module_alias_simple` desde cobra-lenguaje a pcobra
- Ajusta `conftest.py` para añadir directorios de código al `PYTHONPATH`

## Testing
- `pytest` *(falla: No module named 'chardet')*

------
https://chatgpt.com/codex/tasks/task_e_68b6092479508327a38d75fbe1e4a5da