### PR TITLE
docs: reemplaza cobra-lenguaje por pcobra

### DIFF
--- a/MANUAL_COBRA.md
+++ b/MANUAL_COBRA.md
@@ -23,13 +23,13 @@ Este manual presenta en español los conceptos básicos para programar en Cobra.
 Puedes instalar Cobra utilizando [pipx](https://pypa.github.io/pipx/), una herramienta que permite ejecutar aplicaciones de Python aisladas y requiere Python 3.9 o superior.
 
 ```bash
-pipx install cobra-lenguaje
+pipx install pcobra
 ```
 
 También puedes instalar Cobra directamente desde PyPI con
 
 ```bash
-pip install cobra-lenguaje
+pip install pcobra
 ```
 
 ## 2. Estructura básica de un programa

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ source .venv/bin/activate  # En Windows usa .\\.venv\\Scripts\\activate
 Instala la distribución publicada y PyInstaller:
 
 ```bash
-pip install cobra-lenguaje
+pip install pcobra
 pip install pyinstaller
 ```
 
@@ -193,7 +193,7 @@ El ejecutable aparecerá en el directorio `dist/`.
 
 Para realizar una prueba rápida puedes ejecutar el script
 `scripts/test_pyinstaller.sh`. Este script crea un entorno virtual temporal,
-instala `cobra-lenguaje` desde el repositorio (o desde PyPI si se ejecuta fuera
+instala `pcobra` desde el repositorio (o desde PyPI si se ejecuta fuera
 de él) y ejecuta PyInstaller sobre `pCobra/cli/cli.py` o el script `cobra-init`.
 El binario resultante se
 guardará por defecto en `dist/`.

--- a/README_en.md
+++ b/README_en.md
@@ -154,13 +154,13 @@ PYTHONPATH=$PWD/src python -c "from src.core.main import main; main()"
 [pipx](https://pypa.github.io/pipx/) is a tool to install and run Python applications in isolation and requires Python 3.9 or higher. To install Cobra with pipx run:
 
 ```bash
-pipx install cobra-lenguaje
+pipx install pcobra
 ```
 
 If you prefer to install Cobra directly from PyPI without using `pipx`, run:
 
 ```bash
-pip install cobra-lenguaje
+pip install pcobra
 ```
 
 ## Build the Docker image
@@ -222,7 +222,7 @@ source .venv/bin/activate  # On Windows use .\\.venv\\Scripts\\activate
 Install the published package and PyInstaller:
 
 ```bash
-pip install cobra-lenguaje
+pip install pcobra
 pip install pyinstaller
 ```
 

--- a/frontend/docs/instalacion_pypi.rst
+++ b/frontend/docs/instalacion_pypi.rst
@@ -1,7 +1,7 @@
 Instalación desde PyPI
 ======================
 
-Sigue los pasos siguientes para instalar ``cobra-lenguaje`` en un
+Sigue los pasos siguientes para instalar ``pcobra`` en un
 entorno nuevo y ejecutar un ejemplo básico.
 
 1. **Crea y activa un entorno virtual**:
@@ -15,7 +15,7 @@ entorno nuevo y ejecutar un ejemplo básico.
 
    .. code-block:: bash
 
-      pip install cobra-lenguaje
+      pip install pcobra
 
 3. **Verifica que la instalación funciona** ejecutando la CLI:
 

--- a/install.sh
+++ b/install.sh
@@ -48,8 +48,8 @@ if [ "$1" = "--dev" ]; then
     echo "📦 Instalando pCobra en modo editable (desarrollo)..."
     pip install -e .
 else
-    echo "📦 Instalando cobra-lenguaje desde PyPI..."
-    pip install cobra-lenguaje
+    echo "📦 Instalando pcobra desde PyPI..."
+    pip install pcobra
 fi
 
 echo "✅ Instalación finalizada. Usa 'source $ACTIVATE' para activarlo manualmente."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "cobra-lenguaje"
+name = "pcobra"
 version = "10.0.9"
 description = "Un lenguaje de programación en español para simulaciones y más."
 authors = [ {name = "Adolfo González Hernández", email = "adolfogonzal@gmail.com"} ]

--- a/scripts/test_pyinstaller.sh
+++ b/scripts/test_pyinstaller.sh
@@ -11,7 +11,7 @@ source "$TMP_ENV/venv/bin/activate"
 if [ -f pyproject.toml ]; then
     pip install .
 else
-    pip install cobra-lenguaje
+    pip install pcobra
 fi
 pip install pyinstaller
 

--- a/src/pcobra/jupyter_kernel/__init__.py
+++ b/src/pcobra/jupyter_kernel/__init__.py
@@ -16,7 +16,7 @@ from core.sandbox import ejecutar_en_sandbox
 def _get_version() -> str:
     """Obtiene la versión instalada del paquete."""
     try:
-        return version("cobra-lenguaje")
+        return version("pcobra")
     except PackageNotFoundError:
         return "10.0.9"
 


### PR DESCRIPTION
## Resumen
- actualiza instrucciones de instalación en README y manuales para usar el paquete `pcobra`
- ajusta scripts de instalación y PyInstaller al nuevo nombre
- renombra el proyecto en `pyproject.toml` y actualiza el kernel de Jupyter

## Pruebas
- `sphinx-build -b html frontend/docs frontend/build` (falla: El directorio backend no existe)
- `pytest` (falla: ModuleNotFoundError: No module named 'chardet')

------
https://chatgpt.com/codex/tasks/task_e_68b680c8dfb883279d668d6571b6d564