### PR TITLE
docs: actualizar ruta de ast_cache

### DIFF
--- a/docs/cache_incremental.md
+++ b/docs/cache_incremental.md
@@ -1,7 +1,7 @@
 # Caché incremental de tokens y AST
 
 Se ha incorporado un sistema de almacenamiento por fragmentos en
-`src/core/ast_cache.py`. Cada línea del código puede guardarse
+`src/pcobra/core/ast_cache.py`. Cada línea del código puede guardarse
 por separado mediante un *checksum*, permitiendo reutilizar los
 fragmentos que no cambian entre ejecuciones.
 


### PR DESCRIPTION
## Summary
- reemplaza ruta de `ast_cache.py` en la documentación

## Testing
- `pre-commit run --files docs/cache_incremental.md` *(falló: .pre-commit-config.yaml is not a file)*
- `pytest` *(falló: No module named 'hypothesis'; No module named 'tree_sitter')*


------
https://chatgpt.com/codex/tasks/task_e_68b74b2fcfc88327be0c274b2cd72d5c