### PR TITLE
Documentar lista blanca de comandos y actualizar rutas

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -472,7 +472,7 @@ When running `programa.co`, `modulo.co` is processed first and then `Hola desde 
 
 ## `usar` statement for dynamic dependencies
 
-The statement `usar "paquete"` tries to import a Python module. If the package is not available, Cobra will run `pip install paquete` to install it and then load it at runtime. The module is registered in the environment under the same name for later use. To restrict which dependencies can be installed use the variable `USAR_WHITELIST` defined in `src/cobra/usar_loader.py`.
+The statement `usar "paquete"` tries to import a Python module. If the package is not available, Cobra will run `pip install paquete` to install it and then load it at runtime. The module is registered in the environment under the same name for later use. To restrict which dependencies can be installed use the variable `USAR_WHITELIST` defined in `src/pcobra/cobra/usar_loader.py`.
 
 ## Module mapping file
 
@@ -491,7 +491,7 @@ If an entry is not found, the transpiler will load the file indicated in the `im
 
 ## Calling the transpiler
 
-The folder [`src/cobra/transpilers/transpiler`](src/cobra/transpilers/transpiler) contains the implementation of the transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C and WebAssembly. Once the dependencies are installed you can call the transpiler from your own script like this:
+The folder [`src/pcobra/cobra/transpilers/transpiler`](src/pcobra/cobra/transpilers/transpiler) contains the implementation of the transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C and WebAssembly. Once the dependencies are installed you can call the transpiler from your own script like this:
 
 ```python
 from cobra.transpilers.transpiler.to_python import TranspiladorPython

--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -203,7 +203,7 @@ cobra compilar ejemplo.co --tipo python
 ```
 
 Si prefieres usar las clases del proyecto, llama al módulo
-[`src/cobra/transpilers/transpiler`](src/cobra/transpilers/transpiler)
+[`src/pcobra/cobra/transpilers/transpiler`](src/pcobra/cobra/transpilers/transpiler)
 de la siguiente forma:
 
 ```python

--- a/docs/SPEC_COBRA.md
+++ b/docs/SPEC_COBRA.md
@@ -65,7 +65,7 @@ IDENTIFICADOR: /[^\W\d_][\w]*/
 Cada regla define construcciones del lenguaje: por ejemplo `asignacion` utiliza `var` para crear variables, `funcion` agrupa parámetros y un cuerpo, y `try_catch` permite atrapar errores con `try` o `intentar` y `catch` o `capturar`.
 
 ## Tokens y palabras reservadas
-El lexer de `src/cobra/lexico/lexer.py` define todos los tokens. Las principales palabras clave son:
+El lexer de `src/pcobra/cobra/lexico/lexer.py` define todos los tokens. Las principales palabras clave son:
 - `var`, `variable`, `func`, `metodo`, `atributo`
 - `si`, `sino`, `mientras`, `para`, `import`, `usar`, `macro`, `hilo`, `asincronico`
 - `switch`, `case`, `clase`, `in`, `holobit`, `proyectar`, `transformar`, `graficar`

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -13,12 +13,12 @@ A continuación se listan algunos de los módulos con menor cobertura detectados
 
 | Módulo | Cobertura |
 | --- | --- |
-| `src/cobra/cli/cli.py` | 13 % |
-| `src/cobra/cli/cobrahub_client.py` | 16 % |
-| `src/cobra/core/parser.py` | 9 % |
-| `src/cobra/transpilers/feature_inspector.py` | 0 % |
-| `src/cobra/transpilers/reverse/from_c.py` | 3 % |
-| `src/cobra/transpilers/transpiler/to_python.py` | 33 % |
+| `src/pcobra/cobra/cli/cli.py` | 13 % |
+| `src/pcobra/cobra/cli/cobrahub_client.py` | 16 % |
+| `src/pcobra/cobra/core/parser.py` | 9 % |
+| `src/pcobra/cobra/transpilers/feature_inspector.py` | 0 % |
+| `src/pcobra/cobra/transpilers/reverse/from_c.py` | 3 % |
+| `src/pcobra/cobra/transpilers/transpiler/to_python.py` | 33 % |
 | `src/core/ast_nodes.py` | 81 % |
 | `src/core/interpreter.py` | 6 % |
 | `src/gui/app.py` | 0 % |

--- a/docs/frontend/modo_seguro.rst
+++ b/docs/frontend/modo_seguro.rst
@@ -14,7 +14,7 @@ También se valida la
 instrucción ``import`` para permitir únicamente los módulos instalados o los
 especificados en ``IMPORT_WHITELIST``. La instrucción ``usar`` está limitada a
 los paquetes listados en ``USAR_WHITELIST`` ubicado en
-``src/cobra/usar_loader.py``. Si esta lista se encuentra vacía, la
+``src/pcobra/cobra/usar_loader.py``. Si esta lista se encuentra vacía, la
 función ``obtener_modulo`` provocará un ``PermissionError`` y no se podrán
 instalar dependencias nuevas.
 
@@ -53,10 +53,33 @@ Configuraciones avanzadas
 
 Las listas ``IMPORT_WHITELIST`` y ``USAR_WHITELIST`` determinan qué módulos y
 paquetes pueden cargarse cuando el modo seguro está activo. Puedes editarlas en
-``src/cobra/import_loader.py`` y ``src/cobra/usar_loader.py``
+``src/pcobra/cobra/import_loader.py`` y ``src/pcobra/cobra/usar_loader.py``
 respectivamente para afinar las restricciones. Recuerda que si
 ``USAR_WHITELIST`` está vacía no se permitirá la instalación de paquetes
 adicionales.
+
+La función ``corelibs.sistema.ejecutar`` solo permite lanzar comandos del
+sistema que estén en una lista blanca. Debes pasar las rutas mediante el
+parámetro ``permitidos`` o definir la variable de entorno
+``COBRA_EJECUTAR_PERMITIDOS`` separando las rutas con el delimitador del
+``PATH`` del sistema. Si no se especifica ninguno de los dos mecanismos la
+función lanza ``ValueError``.
+
+Ejemplo para definir la lista de comandos permitidos y ejecutar ``ls``:
+
+.. code-block:: python
+
+   from pcobra.corelibs import sistema
+
+   permitidos = ["/bin/ls", "/usr/bin/echo"]
+   salida = sistema.ejecutar(["ls"], permitidos=permitidos)
+   print(salida)
+
+También puedes establecer la variable de entorno una sola vez:
+
+.. code-block:: bash
+
+   export COBRA_EJECUTAR_PERMITIDOS=/bin/ls:/usr/bin/echo
 
 También es posible definir validadores adicionales creando un módulo con la
 variable ``VALIDADORES_EXTRA`` y pasándolo mediante la opción


### PR DESCRIPTION
## Resumen
- Explica en modo seguro que `corelibs.sistema.ejecutar` exige lista blanca o `COBRA_EJECUTAR_PERMITIDOS`
- Añade ejemplo de comandos permitidos
- Actualiza referencias `src/cobra/...` a `src/pcobra/cobra/...`

## Testing
- `PYTHONPATH=$PWD pytest` *(falla: FileNotFoundError: core/holobits/holobit.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b750c7c3e08327b04b8dfd30c60375