### PR TITLE
docs: actualizar notas de la versión 10.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 Versión 10.0.9
 
+- Ajustes en `SafeUnpickler` para admitir `core.ast_nodes` y `cobra.core.ast_nodes`.
+- `corelibs.sistema.ejecutar` ahora requiere una lista blanca mediante `permitidos` o `COBRA_EJECUTAR_PERMITIDOS`.
+- Caché incremental en formato JSON para AST y tokens.
+
 [English version available here](README_en.md)
 
 pCobra es un lenguaje de programación escrito en español y pensado para la creación de herramientas, simulaciones y análisis en disciplinas como biología, computación y astrofísica. El proyecto integra un lexer, parser y un sistema de transpilación capaz de generar código en Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly, facilitando su despliegue en distintos entornos.
@@ -1105,7 +1109,7 @@ Este proyecto sigue el esquema [SemVer](https://semver.org/lang/es/). Los numero
 
 ## Historial de Cambios
 
-- Versión 10.0.9: ajustes en `SafeUnpickler` y restricciones en `corelibs.sistema.ejecutar`.
+ - Versión 10.0.9: ajustes en `SafeUnpickler`, restricciones en `corelibs.sistema.ejecutar` y caché incremental en formato JSON para AST y tokens.
 
 ## Publicar una nueva versión
 

--- a/README_en.md
+++ b/README_en.md
@@ -4,8 +4,9 @@
 
 Version 10.0.9
 
+- Tweaks in `SafeUnpickler` to support `core.ast_nodes` and `cobra.core.ast_nodes`.
 - `corelibs.sistema.ejecutar` now runs only whitelisted executables provided via the `permitidos` argument or the `COBRA_EJECUTAR_PERMITIDOS` environment variable.
-- Added an incremental JSON cache to speed up repeated compilations.
+- Added an incremental JSON cache for AST and tokens to speed up repeated compilations.
 
 Cobra is a programming language designed in Spanish, aimed at creating tools, simulations and analyses in fields such as biology, computing and astrophysics. This project includes a lexer, parser and transpilers to Python, JavaScript, assembly, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C and WebAssembly, allowing greater versatility when running and deploying Cobra code.
 


### PR DESCRIPTION
## Resumen
- Añadir detalles de la versión 10.0.9 en español.
- Incluir la nota de SafeUnpickler en la versión inglesa.

## Testing
- `pytest` *(falla: FileNotFoundError en tests de holobit y otros módulos)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fdd50b7c83278f73e68b98e83978