### PR TITLE
Agregar resolución de clases base y búsqueda en herencia

### DIFF
--- a/tests/unit/test_interpreter_herencia.py
+++ b/tests/unit/test_interpreter_herencia.py
@@ -1,0 +1,31 @@
+from core.interpreter import InterpretadorCobra
+from core.ast_nodes import (
+    NodoClase,
+    NodoMetodo,
+    NodoRetorno,
+    NodoValor,
+    NodoInstancia,
+    NodoAsignacion,
+    NodoLlamadaMetodo,
+    NodoIdentificador,
+)
+
+
+def test_metodo_definido_en_base_se_ejecuta_desde_subclase():
+    inter = InterpretadorCobra()
+
+    metodo_base = NodoMetodo("saludo", ["self"], [NodoRetorno(NodoValor("hola"))])
+    clase_base = NodoClase("Base", [metodo_base])
+    inter.ejecutar_clase(clase_base)
+
+    clase_derivada = NodoClase("Derivada", [], bases=["Base"])
+    inter.ejecutar_clase(clase_derivada)
+
+    inter.ejecutar_nodo(NodoAsignacion("obj", NodoInstancia("Derivada")))
+
+    resultado = inter.evaluar_expresion(
+        NodoLlamadaMetodo(NodoIdentificador("obj"), "saludo", [])
+    )
+
+    assert resultado == "hola"
+


### PR DESCRIPTION
## Resumen
- Resolver y almacenar clases base al registrar una clase
- Incluir clases base en instancias y buscar métodos heredados
- Añadir prueba para ejecución de métodos heredados desde subclases

## Pruebas
- `PYTEST_ADDOPTS="" pytest tests/unit/test_interpreter_herencia.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b833cb4b8083278f8cf5615ca39008