### PR TITLE
docs: documentar herencia múltiple

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -74,10 +74,31 @@ juan.nombre = 'Juan'
 juan.saludar()
 ```
 
-**Limitaciones actuales**
+**Herencia múltiple**
 
-- No existe herencia múltiple.
-- La herencia es simple y no hay interfaces.
+Cobra permite que una clase herede de varias bases listándolas entre paréntesis.
+El intérprete resuelve los métodos de izquierda a derecha según el orden de las bases.
+
+```cobra
+clase Volador:
+    func volar():
+        imprimir('vuelo')
+    fin
+fin
+
+clase Nadador:
+    func nadar():
+        imprimir('nado')
+    fin
+fin
+
+clase Pato(Volador, Nadador):
+    fin
+
+var p = Pato()
+p.volar()
+p.nadar()
+```
 
 ## 4. Control de flujo
 

--- a/docs/especificacion_tecnica.md
+++ b/docs/especificacion_tecnica.md
@@ -51,6 +51,13 @@ clase Persona:
 fin
 ```
 
+Las clases pueden heredar de varias bases listándolas entre paréntesis. La búsqueda de métodos se realiza de izquierda a derecha.
+
+```cobra
+clase Mezcla(Base1, Base2):
+    fin
+```
+
 ## Control de flujo
 
 Cobra cuenta con condicionales `si`, `sino` y bucles `para` y `mientras`.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -15,5 +15,22 @@ clase Documento(Printable):
 fin
 ```
 
+Una clase puede implementar varias interfaces a la vez o combinarlas con herencia de clases.
+
+```cobra
+interface Comprimible:
+    func comprimir()
+fin
+
+clase Archivo(Printable, Comprimible):
+    func mostrar():
+        imprimir("archivo")
+    fin
+    func comprimir():
+        imprimir("zip")
+    fin
+fin
+```
+
 En los transpilers a Python, JavaScript, C++ y Rust se generan las construcciones equivalentes
 (`class` abstracta, clase vacía, `struct` con métodos virtuales y `trait`).


### PR DESCRIPTION
## Summary
- describe sintaxis y ejemplo de herencia múltiple en el manual de Cobra
- detalla la búsqueda de métodos con varias bases en la especificación técnica
- muestra cómo combinar varias interfaces en una misma clase

## Testing
- `pytest` *(falla: FileNotFoundError y errores en pruebas de integración)*

------
https://chatgpt.com/codex/tasks/task_e_68b89e68b7b88327affd8c0433c8126a