### PR TITLE
examples: añadir ejemplo de herencia múltiple

### DIFF
--- a/examples/avanzados/clases/README.md
+++ b/examples/avanzados/clases/README.md
@@ -8,6 +8,7 @@ métodos y atributos.
 
 - `persona.co` define la clase `Persona` con un método `saludar`.
 - `estudiante.co` hereda de `Persona` y añade el método `presentar`.
+- `herencia_multiple.co` muestra cómo una subclase puede heredar de múltiples clases para combinar sus comportamientos.
 - `main.co` crea instancias de `Estudiante` y ejecuta sus métodos.
 
 ## Compilación y ejecución
@@ -19,4 +20,11 @@ cobra compilar persona.co --tipo python > persona.py
 cobra compilar estudiante.co --tipo python > estudiante.py
 cobra compilar main.co --tipo python > main.py
 python main.py
+```
+
+Para probar el ejemplo de herencia múltiple:
+
+```bash
+cobra compilar herencia_multiple.co --tipo python > herencia_multiple.py
+python herencia_multiple.py
 ```

--- a/examples/avanzados/clases/herencia_multiple.co
+++ b/examples/avanzados/clases/herencia_multiple.co
@@ -1,0 +1,21 @@
+clase Volador:
+    metodo volar(self):
+        imprimir "Estoy volando"
+    fin
+fin
+
+clase Nadador:
+    metodo nadar(self):
+        imprimir "Estoy nadando"
+    fin
+fin
+
+clase Pato(Volador, Nadador):
+    metodo desplazar(self):
+        self.volar()
+        self.nadar()
+    fin
+fin
+
+pato = Pato()
+pato.desplazar()


### PR DESCRIPTION
## Summary
- add `herencia_multiple.co` showing a subclass combining `Volador` and `Nadador`
- document the new example in the advanced classes README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b918adf9288327af919a5cbd7ead47