### PR TITLE
Pruebas de herencia múltiple en InterpretadorCobra

### DIFF
--- a/tests/unit/test_interpreter_inheritance.py
+++ b/tests/unit/test_interpreter_inheritance.py
@@ -1,0 +1,43 @@
+import pytest
+from core.interpreter import InterpretadorCobra
+from core.ast_nodes import (
+    NodoClase,
+    NodoMetodo,
+    NodoRetorno,
+    NodoValor,
+    NodoInstancia,
+    NodoAsignacion,
+    NodoLlamadaMetodo,
+    NodoIdentificador,
+)
+
+
+def test_metodo_en_segunda_base():
+    inter = InterpretadorCobra()
+    clase_a = NodoClase("A", [])
+    metodo_b = NodoMetodo("saludo", ["self"], [NodoRetorno(NodoValor("desde B"))])
+    clase_b = NodoClase("B", [metodo_b])
+    inter.ejecutar_clase(clase_a)
+    inter.ejecutar_clase(clase_b)
+    clase_c = NodoClase("C", [], bases=["A", "B"])
+    inter.ejecutar_clase(clase_c)
+    inter.ejecutar_nodo(NodoAsignacion("obj", NodoInstancia("C")))
+    resultado = inter.evaluar_expresion(
+        NodoLlamadaMetodo(NodoIdentificador("obj"), "saludo", [])
+    )
+    assert resultado == "desde B"
+
+
+def test_metodo_no_encontrado_en_bases():
+    inter = InterpretadorCobra()
+    clase_a = NodoClase("A", [])
+    clase_b = NodoClase("B", [])
+    inter.ejecutar_clase(clase_a)
+    inter.ejecutar_clase(clase_b)
+    clase_d = NodoClase("D", [], bases=["A", "B"])
+    inter.ejecutar_clase(clase_d)
+    inter.ejecutar_nodo(NodoAsignacion("obj", NodoInstancia("D")))
+    with pytest.raises(ValueError, match="no encontrado"):
+        inter.evaluar_expresion(
+            NodoLlamadaMetodo(NodoIdentificador("obj"), "saludo", [])
+        )


### PR DESCRIPTION
## Resumen
- Añade pruebas unitarias para herencia múltiple que validan la búsqueda de métodos en clases base
- Verifica que se levanta un error si ninguna base define el método

## Pruebas
- `pytest tests/unit/test_interpreter_inheritance.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68b92579fdc48327aa37835264e4c6b4