### PR TITLE
feat: agrega chardet a dependencias

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "matplotlib==3.10.5",
     "pandas==2.3.1",
     "agix==1.3.0",
+    "chardet==5.2.0",
     "holobit-sdk==1.0.8; python_version >= '3.10'",
     "smooth-criminal==0.4.0",
     "tomli==2.2.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ python-lsp-server
 ipykernel
 sphinxcontrib-plantuml==0.30
 argcomplete
+chardet==5.2.0


### PR DESCRIPTION
## Resumen
- incluye chardet 5.2.0 en las dependencias del proyecto
- añade chardet 5.2.0 al entorno de desarrollo

## Pruebas
- `pip install -e .[dev]`
- `pip install filelock`
- `pip install lark-parser`
- `pytest` *(falla: FileNotFoundError y otros)*

------
https://chatgpt.com/codex/tasks/task_e_68bc13207b388327abb34b4a2c4576b9