### PR TITLE
Pin argcomplete==3.6.2 in dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,5 +13,5 @@ pyright
 python-lsp-server
 ipykernel
 sphinxcontrib-plantuml==0.30
-argcomplete
+argcomplete==3.6.2
 chardet==5.2.0


### PR DESCRIPTION
## Summary
- pin argcomplete to 3.6.2 for dev dependencies

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'tree_sitter')*


------
https://chatgpt.com/codex/tasks/task_e_68bc24d8873c83279088e9e8f3fe0db1