### PR TITLE
Añade alias para agix y maneja ImportError en analizador

### DIFF
--- a/src/pcobra/ia/analizador_agix.py
+++ b/src/pcobra/ia/analizador_agix.py
@@ -1,9 +1,25 @@
 """Módulo que analiza código Cobra usando agix y genera sugerencias."""
 
+import sys
+import types
+
 try:
+    import agix
+
+    # El paquete ``agix`` está pensado para importarse como ``src.agix`` en
+    # algunos entornos. Registramos este alias para mantener compatibilidad
+    # sin modificar la librería original.
+    sys.modules.setdefault("src", types.ModuleType("src"))
+    sys.modules["src.agix"] = agix
+
+    from agix.emotion.emotion_simulator import PADState
+    # Alias similar para los módulos de simulación emocional.
+    sys.modules["src.agix.emotion.emotion_simulator"] = agix.emotion.emotion_simulator
+
     from agix.reasoning.basic import Reasoner
 except ImportError:  # pragma: no cover - depende de agix instalado
     Reasoner = None
+    PADState = None
 from typing import List
 
 from pcobra.cobra.core import Lexer, Parser


### PR DESCRIPTION
## Summary
- Registra `agix` y su simulador emocional bajo el prefijo `src` en `sys.modules`
- Importa `PADState` y expone el módulo de emociones con alias
- Maneja ausencia de `agix` dejando `Reasoner` en `None` e incluye comentarios explicativos

## Testing
- `pytest` *(falló: FileNotFoundError: [Errno 2] No such file or directory: '/workspace/pCobra/core...' y otros módulos faltantes)*

------
https://chatgpt.com/codex/tasks/task_e_68bc93bb408883279d1b62e8c5b4bf73