### PR TITLE
docs: actualización agix 1.4.0 y modulación emocional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   el módulo, evitando modificaciones en tiempo de ejecución.
 - Reemplazo del uso de `pickle` por serialización JSON segura en la caché
   de AST y tokens.
+- Actualización a Agix 1.4.0.
 
 ## v10.0.8 - Pendiente de liberación
 - Integración de la biblioteca **holobit** para la creación y manipulación de holobits.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Versión 10.0.9
 - Ajustes en `SafeUnpickler` para admitir `core.ast_nodes` y `cobra.core.ast_nodes`.
 - `corelibs.sistema.ejecutar` ahora requiere una lista blanca mediante `permitidos` o `COBRA_EJECUTAR_PERMITIDOS`.
 - Caché incremental en formato JSON para AST y tokens.
+- Actualización a Agix 1.4.0.
 
 [English version available here](docs/README.en.md)
 
@@ -1113,7 +1114,7 @@ Este proyecto sigue el esquema [SemVer](https://semver.org/lang/es/). Los numero
 
 ## Historial de Cambios
 
- - Versión 10.0.9: ajustes en `SafeUnpickler`, restricciones en `corelibs.sistema.ejecutar` y caché incremental en formato JSON para AST y tokens.
+ - Versión 10.0.9: ajustes en `SafeUnpickler`, restricciones en `corelibs.sistema.ejecutar`, caché incremental en formato JSON para AST y tokens, y actualización a Agix 1.4.0.
 
 ## Publicar una nueva versión
 

--- a/docs/casos_reales.md
+++ b/docs/casos_reales.md
@@ -43,6 +43,17 @@ También puedes ejecutar el cuaderno `notebooks/casos_reales/inteligencia_artifi
 
 Necesitarás `scikit-learn` y opcionalmente `analizador_agix`.
 
+El plugin `analizador_agix` soporta modulación emocional mediante los
+parámetros `placer`, `activacion` y `dominancia`, cada uno en el rango
+de `-1` a `1`.
+
+```cobra
+usar analizador_agix
+codigo = "imprimir \"hola\""
+sugerencias = analizador_agix.generar_sugerencias(codigo, placer=0.5, activacion=0.3, dominancia=-0.2)
+imprimir sugerencias[0]
+```
+
 ## Análisis de Datos
 Con `pandas` y `matplotlib` puedes procesar CSV y generar gráficos:
 

--- a/docs/frontend/cli.rst
+++ b/docs/frontend/cli.rst
@@ -162,11 +162,24 @@ Analiza un archivo y sugiere mejoras utilizando ``agix``.  A partir de la
 versión ``1.0.0`` la selección de la mejor recomendación se realiza con la
 clase ``Reasoner`` de ``agix.reasoning.basic``.
 
+Opcionalmente se pueden modular las recomendaciones emocionalmente
+mediante los siguientes flags, cuyos valores aceptan el rango ``-1`` a ``1``:
+
+* ``--placer``: regula el grado de placer percibido.
+* ``--activacion``: ajusta el nivel de activación.
+* ``--dominancia``: indica el control o dominancia.
+
 Ejemplo:
 
 .. code-block:: bash
 
    cobra agix ejemplo.co
+
+Ejemplo con modulación emocional:
+
+.. code-block:: bash
+
+   cobra agix ejemplo.co --placer 0.5 --activacion 0.2 --dominancia -0.1
 
 Subcomando ``jupyter``
 ---------------------


### PR DESCRIPTION
## Resumen
- Documentación del subcomando `agix` con flags emocionales y ejemplo.
- `analizador_agix` ahora muestra cómo modular emociones en casos reales.
- README y changelog actualizados con la referencia a Agix 1.4.0.

## Pruebas
- `pytest` *(falla: ModuleNotFoundError: No module named 'tree_sitter_languages')*

------
https://chatgpt.com/codex/tasks/task_e_68bd347462848327af4d17cd6ee1872e