### PR TITLE
test: cover new agix arguments

### DIFF
--- a/tests/unit/test_analizador_agix.py
+++ b/tests/unit/test_analizador_agix.py
@@ -14,3 +14,15 @@ def test_generar_sugerencias_variable_descriptiva():
     with patch.object(analizador_agix, "Reasoner", return_value=instancia_falsa):
         sugerencias = analizador_agix.generar_sugerencias("var x = 5")
     assert sugerencias == ["Usar nombres descriptivos para variables"]
+
+
+def test_generar_sugerencias_modulacion_emocional():
+    instancia = MagicMock()
+    instancia.select_best_model.return_value = {"reason": "Usar nombres descriptivos"}
+    with patch.object(analizador_agix, "Reasoner", return_value=instancia):
+        with patch.object(analizador_agix, "PADState") as pad_mock:
+            analizador_agix.generar_sugerencias(
+                "var x = 5", placer=0.1, activacion=0.2, dominancia=-0.3
+            )
+    pad_mock.assert_called_once_with(0.1, 0.2, -0.3)
+    instancia.modular_por_emocion.assert_called_once_with(pad_mock.return_value)

--- a/tests/unit/test_cli_agix_missing_dep.py
+++ b/tests/unit/test_cli_agix_missing_dep.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import sys
 
 import pytest
+from cobra.cli.commands.agix_cmd import AgixCommand
 
 
 def test_cli_agix_sin_agix(tmp_path):
@@ -10,9 +11,13 @@ def test_cli_agix_sin_agix(tmp_path):
     archivo.write_text("var x = 5")
     from cobra.cli.cli import main
     with patch("ia.analizador_agix.Reasoner", None):
-        with patch("sys.stdout", new_callable=StringIO) as out:
-            try:
-                main(["agix", str(archivo)])
-            except SystemExit:
-                pass
-        assert "Instala el paquete agix" in out.getvalue()
+        with patch("cobra.cli.cli.setup_gettext", return_value=lambda s: s):
+            with patch(
+                "cobra.cli.cli.AppConfig.BASE_COMMAND_CLASSES", new=[AgixCommand]
+            ):
+                with patch("sys.stdout", new_callable=StringIO) as out:
+                    try:
+                        main(["agix", str(archivo)])
+                    except SystemExit:
+                        pass
+                assert "Instala el paquete agix" in out.getvalue()

--- a/tests/unit/test_cli_agix_missing_file.py
+++ b/tests/unit/test_cli_agix_missing_file.py
@@ -7,7 +7,14 @@ from cobra.cli.commands.agix_cmd import AgixCommand
 def test_cli_agix_archivo_inexistente(tmp_path):
     archivo = tmp_path / "no.co"
     cmd = AgixCommand()
-    args = Namespace(archivo=str(archivo), peso_precision=None, peso_interpretabilidad=None)
+    args = Namespace(
+        archivo=str(archivo),
+        peso_precision=None,
+        peso_interpretabilidad=None,
+        placer=None,
+        activacion=None,
+        dominancia=None,
+    )
     with pytest.raises(FileNotFoundError) as exc:
         cmd.run(args)
     assert f"El archivo '{archivo}' no existe" in str(exc.value)


### PR DESCRIPTION
## Summary
- adapt Agix CLI tests to new PAD arguments
- ensure Reasoner emotion modulation is invoked
- verify CLI handles missing agix dependency

## Testing
- `pytest tests/unit/test_cli_agix.py tests/unit/test_cli_agix_missing_file.py tests/unit/test_analizador_agix.py tests/unit/test_cli_agix_missing_dep.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68bd35bc92288327ae4d0fee25d16f52