### PR TITLE
Fix test paths to core modules

### DIFF
--- a/tests/unit/test_holobit_generation.py
+++ b/tests/unit/test_holobit_generation.py
@@ -5,10 +5,10 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
-# ``ROOT`` apunta al directorio ``src`` dentro del repositorio. Construimos la
-# ruta al módulo ``holobit`` de forma relativa a este directorio para evitar
-# errores de carga por rutas inexistentes.
-holobit_path = ROOT / "core" / "holobits" / "holobit.py"
+# ``ROOT`` apunta al directorio raíz del repositorio. Construimos la ruta al
+# módulo ``holobit`` de forma relativa a este directorio para evitar errores de
+# carga por rutas inexistentes.
+holobit_path = ROOT / "src" / "pcobra" / "core" / "holobits" / "holobit.py"
 spec = importlib.util.spec_from_file_location("holobit", holobit_path)
 holobit_module = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = holobit_module

--- a/tests/unit/test_sandbox_js.py
+++ b/tests/unit/test_sandbox_js.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
-sandbox_path = ROOT / "core" / "sandbox.py"
+sandbox_path = ROOT / "src" / "pcobra" / "core" / "sandbox.py"
 spec = importlib.util.spec_from_file_location("sandbox", sandbox_path)
 sandbox = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(sandbox)

--- a/tests/unit/test_security_sandbox.py
+++ b/tests/unit/test_security_sandbox.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
-sandbox_path = ROOT / "core" / "sandbox.py"
+sandbox_path = ROOT / "src" / "pcobra" / "core" / "sandbox.py"
 spec = importlib.util.spec_from_file_location("sandbox", sandbox_path)
 sandbox = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(sandbox)


### PR DESCRIPTION
## Summary
- update sandbox tests to import `src/pcobra/core/sandbox.py`
- adjust holobit generation test to load core holobit module from `src/pcobra`

## Testing
- `PYTHONPATH=$PWD/src pytest tests/unit/test_security_sandbox.py tests/unit/test_sandbox_js.py tests/unit/test_holobit_generation.py` *(fails: RuntimeError: vm2 no disponible; FAIL Required test coverage of 85% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3a71507c83278bb5a2f06e0d1af3