### PR TITLE
refactor: remove smooth-criminal from whitelist

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -62,7 +62,6 @@ def cargar_lista_blanca():
         "requests",
         "matplotlib",
         "holobit-sdk",
-        "smooth-criminal",
         "agix",
     ]
 


### PR DESCRIPTION
## Summary
- remove `smooth-criminal` from default USAR package list
- ensure `agix` stays in whitelist

## Testing
- `PYTHONPATH=src python -m pcobra.cobra.usar_loader`
- `PYTHONPATH=src python - <<'PY'\nimport pcobra.cobra.usar_loader as u\nprint('agix' in u.USAR_WHITELIST)\nprint('smooth-criminal' in u.USAR_WHITELIST)\nmod=u.obtener_modulo('agix')\nprint('agix version', getattr(mod,'__version__', 'sin version'))\nPY`
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'RestrictedPython', 'tree_sitter')*


------
https://chatgpt.com/codex/tasks/task_e_68be5d5c3ba88327a7993f8a7a688177