### PR TITLE
docs: reemplazar smooth-criminal por agix

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ El proyecto soporta oficialmente:
 - Instalación de paquetes en tiempo de ejecución mediante la instrucción `usar`.
 - Manejo de Errores: El sistema captura y reporta errores de sintaxis, facilitando la depuración.
 - Visualización y Depuración: Salida detallada de tokens, AST y errores de sintaxis para un desarrollo más sencillo.
-- Decoradores de rendimiento: la biblioteca ``smooth-criminal`` ofrece
+- Decoradores de rendimiento: la biblioteca ``agix`` ofrece
   funciones como ``optimizar`` y ``perfilar`` para mejorar y medir la
   ejecución de código Python desde Cobra.
 - Benchmarking: ejemplos completos de medición de rendimiento están

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -297,7 +297,7 @@ The project officially supports:
 - Runtime package installation via the `usar` instruction.
 - Error handling: the system captures and reports syntax errors, easing debugging.
 - Visualization and debugging: detailed output of tokens, AST and syntax errors for simpler development.
-- Performance decorators: the ``smooth-criminal`` library offers functions such as ``optimizar`` and ``perfilar`` to improve and measure Python code executed from Cobra.
+- Performance decorators: the ``agix`` library provides helpers like ``optimizar`` and ``perfilar`` to improve and measure Python code executed from Cobra.
 - Benchmarking: full performance measurement examples are available in `frontend/benchmarking.rst`.
 - Code and documentation examples: practical examples illustrating the lexer, parser and transpilers.
 - Advanced examples: see `frontend/ejemplos_avanzados.rst` to learn about classes, threads and error handling.

--- a/docs/frontend/benchmarking.rst
+++ b/docs/frontend/benchmarking.rst
@@ -3,8 +3,8 @@ Benchmarking y medición de rendimiento
 
 Esta guía explica cómo obtener métricas de ejecución en programas Cobra.
 Desde la versión 9.0 se incluye una pequeña suite de benchmarking basada en el
-módulo ``src.core.performance`` y la librería ``smooth-criminal``. Dicho módulo
-expone los ayudantes ``optimizar`` y ``perfilar`` para decorar funciones o medir
+módulo ``src.core.performance`` y la librería ``agix``. Dicho módulo
+expone los ayudantes ``optimizar``, ``perfilar``, ``smart_perfilar`` y ``optimizar_bucle`` para decorar funciones o medir
 su comportamiento.
 
 Uso de ``perfilar``
@@ -26,7 +26,7 @@ de tiempo:
 Optimización con ``optimizar``
 ------------------------------
 
-Si deseas aplicar automáticamente optimizaciones de ``smooth-criminal`` usa
+Si deseas aplicar automáticamente optimizaciones de ``agix`` usa
 ``optimizar`` como decorador:
 
 .. code-block:: python
@@ -41,7 +41,7 @@ Si deseas aplicar automáticamente optimizaciones de ``smooth-criminal`` usa
 Otras herramientas
 ------------------
 
-Además de ``smooth-criminal`` puedes emplear la biblioteca estándar
+Además de ``agix`` puedes emplear la biblioteca estándar
 ``timeit`` para microbenchmarks rápidos:
 
 .. code-block:: python

--- a/docs/frontend/optimizaciones.rst
+++ b/docs/frontend/optimizaciones.rst
@@ -21,6 +21,6 @@ Eliminación de subexpresiones comunes
 
 Estas optimizaciones se aplican automáticamente antes de ejecutar el intérprete y en los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly.
 
-Decoradores de rendimiento (``smooth-criminal``)
-------------------------------------------------
-Se incorporó la biblioteca ``smooth-criminal`` al núcleo para facilitar la optimización de funciones de usuario. Desde ``src.core`` se exponen los ayudantes ``optimizar`` y ``perfilar`` que utilizan dicha librería para aplicar decoradores como ``auto_boost`` y obtener métricas de ejecución.
+Decoradores de rendimiento (``agix``)
+-------------------------------------
+Se incorporó la biblioteca ``agix`` al núcleo para facilitar la optimización de funciones de usuario. Desde ``src.core`` se exponen los ayudantes ``optimizar``, ``perfilar``, ``smart_perfilar`` y ``optimizar_bucle`` que utilizan dicha librería para aplicar decoradores como ``auto_boost`` y obtener métricas de ejecución.


### PR DESCRIPTION
## Summary
- rename smooth-criminal references to agix in README
- update benchmarking and optimizations docs to mention agix helpers

## Testing
- `make docs` *(fails: Makefile:37: *** missing separator. Stop.)*
- `sphinx-build -M html docs/frontend docs/build`

------
https://chatgpt.com/codex/tasks/task_e_68be94d6990c8327ba5bc0e09e146a6d