### PR TITLE
Pruebas para utilidades de rendimiento basadas en agix

### DIFF
--- a/tests/integration/test_agix_reasoner.py
+++ b/tests/integration/test_agix_reasoner.py
@@ -1,0 +1,12 @@
+from agix.reasoning.basic import Reasoner
+
+
+def test_agix_reasoner_selects_best_model():
+    evaluations = [
+        {"name": "A", "accuracy": 0.8, "interpretability": 0.9},
+        {"name": "B", "accuracy": 0.85, "interpretability": 0.7},
+        {"name": "C", "accuracy": 0.85, "interpretability": 0.8},
+    ]
+    result = Reasoner().select_best_model(evaluations)
+    assert result["name"] == "C"
+    assert "Modelo seleccionado" in result["reason"]

--- a/tests/unit/test_performance.py
+++ b/tests/unit/test_performance.py
@@ -5,11 +5,65 @@ from unittest.mock import patch
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
-from core.performance import smart_perfilar, optimizar_bucle
+from core.performance import (
+    optimizar,
+    perfilar,
+    smart_perfilar,
+    optimizar_bucle,
+)
 
 
 def _dummy(x=0):
     return x + 1
+
+
+def test_optimizar_decorator_invoca_auto_boost():
+    def fake_auto_boost(*, workers=4, fallback=None):
+        def decorator(func):
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return wrapper
+
+        return decorator
+
+    with patch("core.performance.auto_boost", side_effect=fake_auto_boost) as ab:
+        @optimizar(workers=2)
+        def foo(x):
+            return x + 1
+
+        assert foo(1) == 2
+        ab.assert_called_once_with(workers=2, fallback=None)
+
+
+def test_optimizar_directo_invoca_auto_boost():
+    def fake_auto_boost(*, workers=4, fallback=None):
+        def decorator(func):
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return wrapper
+
+        return decorator
+
+    with patch("core.performance.auto_boost", side_effect=fake_auto_boost) as ab:
+        def bar(x):
+            return x + 2
+
+        wrapped = optimizar(bar, workers=3)
+        assert wrapped(1) == 3
+        ab.assert_called_once_with(workers=3, fallback=None)
+
+
+def test_perfilar_invoca_profile_it():
+    def suma(x, y):
+        return x + y
+
+    with patch("core.performance.profile_it", return_value={"mean": 1}) as pf:
+        datos = perfilar(suma, args=(1, 2), repeticiones=3, paralelo=True)
+
+    pf.assert_called_once_with(suma, args=(1, 2), kwargs={}, repeat=3, parallel=True)
+    assert datos == {"mean": 1}
 
 
 def test_smart_perfilar_invoca_smart_profile():


### PR DESCRIPTION
## Resumen
- Añadir pruebas unitarias que verifican `optimizar` y `perfilar`
- Incluir prueba de integración con `agix.reasoning.basic.Reasoner`

## Testing
- `pytest --no-cov tests/unit/test_performance.py tests/integration/test_agix_reasoner.py tests/unit/test_analizador_agix.py`


------
https://chatgpt.com/codex/tasks/task_e_68becc3806b0832789fd18b2e65ef806