### PR TITLE
feat: actualiza ayudas de performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ El proyecto soporta oficialmente:
 - Instalación de paquetes en tiempo de ejecución mediante la instrucción `usar`.
 - Manejo de Errores: El sistema captura y reporta errores de sintaxis, facilitando la depuración.
 - Visualización y Depuración: Salida detallada de tokens, AST y errores de sintaxis para un desarrollo más sencillo.
-- Decoradores de rendimiento: la biblioteca ``agix`` ofrece
+- Decoradores de rendimiento: la biblioteca ``smooth-criminal`` ofrece
   funciones como ``optimizar`` y ``perfilar`` para mejorar y medir la
   ejecución de código Python desde Cobra.
 - Benchmarking: ejemplos completos de medición de rendimiento están

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -297,7 +297,7 @@ The project officially supports:
 - Runtime package installation via the `usar` instruction.
 - Error handling: the system captures and reports syntax errors, easing debugging.
 - Visualization and debugging: detailed output of tokens, AST and syntax errors for simpler development.
-- Performance decorators: the ``agix`` library provides helpers like ``optimizar`` and ``perfilar`` to improve and measure Python code executed from Cobra.
+- Performance decorators: the ``smooth-criminal`` library provides helpers like ``optimizar`` and ``perfilar`` to improve and measure Python code executed from Cobra.
 - Benchmarking: full performance measurement examples are available in `frontend/benchmarking.rst`.
 - Code and documentation examples: practical examples illustrating the lexer, parser and transpilers.
 - Advanced examples: see `frontend/ejemplos_avanzados.rst` to learn about classes, threads and error handling.

--- a/docs/frontend/benchmarking.rst
+++ b/docs/frontend/benchmarking.rst
@@ -3,7 +3,7 @@ Benchmarking y medición de rendimiento
 
 Esta guía explica cómo obtener métricas de ejecución en programas Cobra.
 Desde la versión 9.0 se incluye una pequeña suite de benchmarking basada en el
-módulo ``src.core.performance`` y la librería ``agix``. Dicho módulo
+módulo ``src.core.performance`` y la librería ``smooth-criminal``. Dicho módulo
 expone los ayudantes ``optimizar``, ``perfilar``, ``smart_perfilar`` y ``optimizar_bucle`` para decorar funciones o medir
 su comportamiento.
 
@@ -26,7 +26,7 @@ de tiempo:
 Optimización con ``optimizar``
 ------------------------------
 
-Si deseas aplicar automáticamente optimizaciones de ``agix`` usa
+Si deseas aplicar automáticamente optimizaciones de ``smooth-criminal`` usa
 ``optimizar`` como decorador:
 
 .. code-block:: python
@@ -41,7 +41,7 @@ Si deseas aplicar automáticamente optimizaciones de ``agix`` usa
 Otras herramientas
 ------------------
 
-Además de ``agix`` puedes emplear la biblioteca estándar
+Además de ``smooth-criminal`` puedes emplear la biblioteca estándar
 ``timeit`` para microbenchmarks rápidos:
 
 .. code-block:: python

--- a/docs/frontend/optimizaciones.rst
+++ b/docs/frontend/optimizaciones.rst
@@ -21,6 +21,6 @@ Eliminación de subexpresiones comunes
 
 Estas optimizaciones se aplican automáticamente antes de ejecutar el intérprete y en los transpiladores a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly.
 
-Decoradores de rendimiento (``agix``)
--------------------------------------
-Se incorporó la biblioteca ``agix`` al núcleo para facilitar la optimización de funciones de usuario. Desde ``src.core`` se exponen los ayudantes ``optimizar``, ``perfilar``, ``smart_perfilar`` y ``optimizar_bucle`` que utilizan dicha librería para aplicar decoradores como ``auto_boost`` y obtener métricas de ejecución.
+Decoradores de rendimiento (``Smooth Criminal``)
+------------------------------------------------
+Se incorporó la biblioteca ``smooth-criminal`` al núcleo para facilitar la optimización de funciones de usuario. Desde ``src.core`` se exponen los ayudantes ``optimizar``, ``perfilar``, ``smart_perfilar`` y ``optimizar_bucle`` que utilizan dicha librería para aplicar decoradores como ``bad``, ``bad_and_dangerous`` o ``jam`` y obtener métricas de ejecución.

--- a/src/pcobra/core/performance.py
+++ b/src/pcobra/core/performance.py
@@ -3,13 +3,13 @@
 from typing import Callable, Any
 try:
     from smooth_criminal.core import (
-        auto_boost,
+        bad,
         profile_it,
-        smart_profile,
-        optimize_loop,
+        bad_and_dangerous,
+        jam,
     )
 except Exception:  # pragma: no cover - fallback when library is missing
-    def auto_boost(*, workers=4, fallback=None):
+    def bad(*, workers=4, fallback=None):
         def decorator(func):
             return func
 
@@ -18,10 +18,14 @@ except Exception:  # pragma: no cover - fallback when library is missing
     def profile_it(func, *, args=None, kwargs=None, repeat=1, parallel=False):
         return {}
 
-    def smart_profile(func, *, args=None, kwargs=None, repeat=1, parallel=False):
-        return profile_it(func, args=args, kwargs=kwargs, repeat=repeat, parallel=parallel)
+    def bad_and_dangerous(
+        func, *, args=None, kwargs=None, repeat=1, parallel=False
+    ):
+        return profile_it(
+            func, args=args, kwargs=kwargs, repeat=repeat, parallel=parallel
+        )
 
-    def optimize_loop(*, loops=1, fallback=None):
+    def jam(*, loops=1, fallback=None):
         def decorator(func):
             return func
 
@@ -31,17 +35,17 @@ except Exception:  # pragma: no cover - fallback when library is missing
 def optimizar(
     func: Callable | None = None, *, workers: int = 4, fallback: Callable | None = None
 ) -> Callable:
-    """Devuelve una versión optimizada de ``func`` usando ``auto_boost``.
+    """Devuelve una versión optimizada de ``func`` usando ``bad``.
 
     Puede usarse como decorador o llamando ``optimizar(func)`` directamente.
     """
     if func is None:
 
         def decorator(f: Callable) -> Callable:
-            return auto_boost(workers=workers, fallback=fallback)(f)
+            return bad(workers=workers, fallback=fallback)(f)
 
         return decorator
-    return auto_boost(workers=workers, fallback=fallback)(func)
+    return bad(workers=workers, fallback=fallback)(func)
 
 
 def perfilar(
@@ -68,12 +72,17 @@ def smart_perfilar(
     repeticiones: int = 5,
     paralelo: bool = False
 ) -> dict[str, Any]:
-    """Versión inteligente de :func:`perfilar` usando ``smart_profile``."""
+    """Perfila ``func`` usando ``bad_and_dangerous`` o ``profile_it``."""
     args = args or ()
     kwargs = kwargs or {}
-    return smart_profile(
-        func, args=args, kwargs=kwargs, repeat=repeticiones, parallel=paralelo
-    )
+    try:
+        return bad_and_dangerous(
+            func, args=args, kwargs=kwargs, repeat=repeticiones, parallel=paralelo
+        )
+    except Exception:
+        return profile_it(
+            func, args=args, kwargs=kwargs, repeat=repeticiones, parallel=paralelo
+        )
 
 
 def optimizar_bucle(
@@ -82,11 +91,11 @@ def optimizar_bucle(
     loops: int = 1,
     fallback: Callable | None = None,
 ) -> Callable:
-    """Optimiza bucles dentro de ``func`` usando ``optimize_loop``."""
+    """Optimiza bucles dentro de ``func`` usando ``jam``."""
     if func is None:
 
         def decorator(f: Callable) -> Callable:
-            return optimize_loop(loops=loops, fallback=fallback)(f)
+            return jam(loops=loops, fallback=fallback)(f)
 
         return decorator
-    return optimize_loop(loops=loops, fallback=fallback)(func)
+    return jam(loops=loops, fallback=fallback)(func)

--- a/tests/unit/test_performance.py
+++ b/tests/unit/test_performance.py
@@ -17,8 +17,8 @@ def _dummy(x=0):
     return x + 1
 
 
-def test_optimizar_decorator_invoca_auto_boost():
-    def fake_auto_boost(*, workers=4, fallback=None):
+def test_optimizar_decorator_invoca_bad():
+    def fake_bad(*, workers=4, fallback=None):
         def decorator(func):
             def wrapper(*args, **kwargs):
                 return func(*args, **kwargs)
@@ -27,7 +27,7 @@ def test_optimizar_decorator_invoca_auto_boost():
 
         return decorator
 
-    with patch("core.performance.auto_boost", side_effect=fake_auto_boost) as ab:
+    with patch("core.performance.bad", side_effect=fake_bad) as ab:
         @optimizar(workers=2)
         def foo(x):
             return x + 1
@@ -36,8 +36,8 @@ def test_optimizar_decorator_invoca_auto_boost():
         ab.assert_called_once_with(workers=2, fallback=None)
 
 
-def test_optimizar_directo_invoca_auto_boost():
-    def fake_auto_boost(*, workers=4, fallback=None):
+def test_optimizar_directo_invoca_bad():
+    def fake_bad(*, workers=4, fallback=None):
         def decorator(func):
             def wrapper(*args, **kwargs):
                 return func(*args, **kwargs)
@@ -46,7 +46,7 @@ def test_optimizar_directo_invoca_auto_boost():
 
         return decorator
 
-    with patch("core.performance.auto_boost", side_effect=fake_auto_boost) as ab:
+    with patch("core.performance.bad", side_effect=fake_bad) as ab:
         def bar(x):
             return x + 2
 
@@ -66,22 +66,24 @@ def test_perfilar_invoca_profile_it():
     assert datos == {"mean": 1}
 
 
-def test_smart_perfilar_invoca_smart_profile():
-    with patch("core.performance.smart_profile", create=True, return_value={"mean": 1}) as sp:
+def test_smart_perfilar_invoca_bad_and_dangerous():
+    with patch(
+        "core.performance.bad_and_dangerous", create=True, return_value={"mean": 1}
+    ) as sp:
         result = smart_perfilar(_dummy, args=(1,))
     sp.assert_called_once()
     assert result == {"mean": 1}
 
 
 def test_optimizar_bucle_decorator():
-    def fake_optimize_loop(loops=1, fallback=None):
+    def fake_jam(loops=1, fallback=None):
         def decorator(func):
             def wrapper(*args, **kwargs):
                 return func(*args, **kwargs)
             return wrapper
         return decorator
 
-    with patch("core.performance.optimize_loop", create=True, side_effect=fake_optimize_loop) as op:
+    with patch("core.performance.jam", create=True, side_effect=fake_jam) as op:
         @optimizar_bucle(loops=2)
         def foo():
             return "ok"


### PR DESCRIPTION
## Resumen
- usa las nuevas utilidades `bad`, `bad_and_dangerous` y `jam` de Smooth Criminal
- reescribe `smart_perfilar` y `optimizar_bucle` con las API actualizadas
- documenta los nuevos decoradores de rendimiento

## Testing
- `pytest` *(falla: módulos faltantes `hypothesis` y `yaml`)*
- `pytest tests/unit/test_performance.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68bedbbfabd483278118c25e7e7b6945