### PR TITLE
refactor: eliminar helpers obsoletos

### DIFF
--- a/docs/frontend/benchmarking.rst
+++ b/docs/frontend/benchmarking.rst
@@ -4,7 +4,7 @@ Benchmarking y medición de rendimiento
 Esta guía explica cómo obtener métricas de ejecución en programas Cobra.
 Desde la versión 9.0 se incluye una pequeña suite de benchmarking basada en el
 módulo ``src.core.performance`` y la librería ``smooth-criminal``. Dicho módulo
-expone los ayudantes ``optimizar``, ``perfilar``, ``smart_perfilar`` y ``optimizar_bucle`` para decorar funciones o medir
+expone los ayudantes ``optimizar`` y ``perfilar`` para decorar funciones o medir
 su comportamiento.
 
 Uso de ``perfilar``

--- a/docs/frontend/optimizaciones.rst
+++ b/docs/frontend/optimizaciones.rst
@@ -23,4 +23,4 @@ Estas optimizaciones se aplican automáticamente antes de ejecutar el intérpret
 
 Decoradores de rendimiento (``Smooth Criminal``)
 ------------------------------------------------
-Se incorporó la biblioteca ``smooth-criminal`` al núcleo para facilitar la optimización de funciones de usuario. Desde ``src.core`` se exponen los ayudantes ``optimizar``, ``perfilar``, ``smart_perfilar`` y ``optimizar_bucle`` que utilizan dicha librería para aplicar decoradores como ``bad``, ``bad_and_dangerous`` o ``jam`` y obtener métricas de ejecución.
+Se incorporó la biblioteca ``smooth-criminal`` al núcleo para facilitar la optimización de funciones de usuario. Desde ``src.core`` se exponen los ayudantes ``optimizar`` y ``perfilar`` que utilizan dicha librería para aplicar decoradores como ``bad``, ``bad_and_dangerous`` o ``jam`` y obtener métricas de ejecución.

--- a/src/pcobra/core/__init__.py
+++ b/src/pcobra/core/__init__.py
@@ -12,7 +12,7 @@ de implementaciones manuales.
 from .ast_nodes import *
 from .ast_nodes import NodoListaComprehension, NodoDiccionarioComprehension, NodoEnum
 from .visitor import NodeVisitor
-from .performance import optimizar, perfilar, smart_perfilar, optimizar_bucle
+from .performance import optimizar, perfilar
 from .resource_limits import limitar_memoria_mb, limitar_cpu_segundos
 
 __all__ = [
@@ -59,8 +59,6 @@ __all__ = [
     "NodeVisitor",
     "optimizar",
     "perfilar",
-    "smart_perfilar",
-    "optimizar_bucle",
     "limitar_memoria_mb",
     "limitar_cpu_segundos",
 ]

--- a/tests/unit/test_performance.py
+++ b/tests/unit/test_performance.py
@@ -8,13 +8,7 @@ sys.path.insert(0, str(ROOT))
 from core.performance import (
     optimizar,
     perfilar,
-    smart_perfilar,
-    optimizar_bucle,
 )
-
-
-def _dummy(x=0):
-    return x + 1
 
 
 def test_optimizar_decorator_invoca_bad():
@@ -64,29 +58,3 @@ def test_perfilar_invoca_profile_it():
 
     pf.assert_called_once_with(suma, args=(1, 2), kwargs={}, repeat=3, parallel=True)
     assert datos == {"mean": 1}
-
-
-def test_smart_perfilar_invoca_bad_and_dangerous():
-    with patch(
-        "core.performance.bad_and_dangerous", create=True, return_value={"mean": 1}
-    ) as sp:
-        result = smart_perfilar(_dummy, args=(1,))
-    sp.assert_called_once()
-    assert result == {"mean": 1}
-
-
-def test_optimizar_bucle_decorator():
-    def fake_jam(loops=1, fallback=None):
-        def decorator(func):
-            def wrapper(*args, **kwargs):
-                return func(*args, **kwargs)
-            return wrapper
-        return decorator
-
-    with patch("core.performance.jam", create=True, side_effect=fake_jam) as op:
-        @optimizar_bucle(loops=2)
-        def foo():
-            return "ok"
-
-        assert foo() == "ok"
-        op.assert_called_once_with(loops=2, fallback=None)


### PR DESCRIPTION
## Summary
- deja de exponer `smart_perfilar` y `optimizar_bucle`
- elimina pruebas y referencias de los helpers obsoletos

## Testing
- `pytest -q` *(falla: ModuleNotFoundError: No module named 'src.agix', No module named 'filelock')*

------
https://chatgpt.com/codex/tasks/task_e_68befbf596848327939c00f96b350a53