### PR TITLE
Soporte para agix 1.4

### DIFF
--- a/src/pcobra/ia/analizador_agix.py
+++ b/src/pcobra/ia/analizador_agix.py
@@ -12,6 +12,19 @@ try:
     sys.modules.setdefault("src", types.ModuleType("src"))
     sys.modules["src.agix"] = agix
 
+    # Nuevas dependencias internas en agix>=1.4 requieren mapear otros
+    # submódulos con el prefijo ``src.agix`` para mantener compatibilidad.
+    # Estos ``imports`` pueden fallar si el paquete cambia en versiones
+    # futuras, por lo que se ignoran las excepciones.
+    try:  # pragma: no cover - solo se ejecuta si existen los módulos
+        import agix.memory as _agix_memory
+        import agix.memory.experiential as _agix_memory_experiential
+
+        sys.modules["src.agix.memory"] = _agix_memory
+        sys.modules["src.agix.memory.experiential"] = _agix_memory_experiential
+    except Exception:  # pragma: no cover - alias opcionales
+        pass
+
     from agix.emotion.emotion_simulator import PADState
     # Alias similar para los módulos de simulación emocional.
     sys.modules["src.agix.emotion.emotion_simulator"] = agix.emotion.emotion_simulator

--- a/tests/integration/test_agix_reasoner.py
+++ b/tests/integration/test_agix_reasoner.py
@@ -1,3 +1,30 @@
+"""Pruebas de integración para ``agix`` y el razonador básico.
+
+agix>=1.4 importa internamente módulos bajo el prefijo ``src.agix``. Para
+que las pruebas puedan ejecutarse sin modificar la librería original se
+registran alias equivalentes antes de importar :class:`Reasoner`.
+"""
+
+import importlib
+import sys
+import types
+
+import agix
+
+sys.modules.setdefault("src", types.ModuleType("src"))
+sys.modules["src.agix"] = agix
+
+try:  # pragma: no cover - depende de submódulos opcionales
+    sys.modules["src.agix.memory"] = importlib.import_module("agix.memory")
+    sys.modules["src.agix.memory.experiential"] = importlib.import_module(
+        "agix.memory.experiential"
+    )
+    sys.modules["src.agix.emotion.emotion_simulator"] = importlib.import_module(
+        "agix.emotion.emotion_simulator"
+    )
+except Exception:  # pragma: no cover
+    pass
+
 from agix.reasoning.basic import Reasoner
 
 


### PR DESCRIPTION
## Resumen
- Ajuste de `analizador_agix` para compatibilidad con agix 1.4 mapeando módulos `src.agix.*`
- Actualización de pruebas de integración para preparar alias de agix antes de importar `Reasoner`

## Testing
- `pytest -o addopts="" tests/integration/test_agix_reasoner.py tests/unit/test_cli_agix.py tests/unit/test_cli_agix_missing_dep.py`
- `pytest -o addopts="" tests/unit/test_analizador_agix.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf04961ddc8327af0c35b84a70280a