### PR TITLE
Manejar ausencia de agix con ImportError

### DIFF
--- a/src/pcobra/ia/analizador_agix.py
+++ b/src/pcobra/ia/analizador_agix.py
@@ -55,8 +55,7 @@ def generar_sugerencias(
     proporcionan, usando valores en el rango ``[-1.0, 1.0]``.
     """
     if Reasoner is None:
-        print("Instala el paquete agix")
-        raise SystemExit(1)
+        raise ImportError("Instala el paquete agix")
 
     # Validar el código utilizando las herramientas de Cobra
     tokens = Lexer(codigo).tokenizar()

--- a/tests/unit/test_analizador_agix.py
+++ b/tests/unit/test_analizador_agix.py
@@ -1,5 +1,6 @@
 import pcobra  # garantiza rutas para submódulos
 from unittest.mock import MagicMock, patch
+import pytest
 
 from ia import analizador_agix
 
@@ -26,3 +27,9 @@ def test_generar_sugerencias_modulacion_emocional():
             )
     pad_mock.assert_called_once_with(0.1, 0.2, -0.3)
     instancia.modular_por_emocion.assert_called_once_with(pad_mock.return_value)
+
+
+def test_generar_sugerencias_sin_agix():
+    with patch.object(analizador_agix, "Reasoner", None):
+        with pytest.raises(ImportError, match="Instala el paquete agix"):
+            analizador_agix.generar_sugerencias("var x = 5")

--- a/tests/unit/test_cli_agix_missing_dep.py
+++ b/tests/unit/test_cli_agix_missing_dep.py
@@ -1,23 +1,24 @@
-from io import StringIO
+from argparse import Namespace
 from unittest.mock import patch
-import sys
 
-import pytest
 from cobra.cli.commands.agix_cmd import AgixCommand
 
 
 def test_cli_agix_sin_agix(tmp_path):
     archivo = tmp_path / "ejemplo.co"
     archivo.write_text("var x = 5")
-    from cobra.cli.cli import main
+    cmd = AgixCommand()
+    args = Namespace(
+        archivo=str(archivo),
+        peso_precision=None,
+        peso_interpretabilidad=None,
+        placer=None,
+        activacion=None,
+        dominancia=None,
+    )
     with patch("ia.analizador_agix.Reasoner", None):
-        with patch("cobra.cli.cli.setup_gettext", return_value=lambda s: s):
-            with patch(
-                "cobra.cli.cli.AppConfig.BASE_COMMAND_CLASSES", new=[AgixCommand]
-            ):
-                with patch("sys.stdout", new_callable=StringIO) as out:
-                    try:
-                        main(["agix", str(archivo)])
-                    except SystemExit:
-                        pass
-                assert "Instala el paquete agix" in out.getvalue()
+        with patch("cobra.cli.commands.agix_cmd.mostrar_error") as err_mock:
+            exit_code = cmd.run(args)
+    err_mock.assert_called_once()
+    assert exit_code == 1
+    assert "Instala el paquete agix" in err_mock.call_args[0][0]


### PR DESCRIPTION
## Resumen
- Lanza `ImportError` cuando `agix` no está instalado en el analizador.
- Ajusta la prueba de CLI para capturar el nuevo mensaje de error.
- Agrega prueba unitaria que verifica la excepción en `generar_sugerencias`.

## Pruebas
- `PYTEST_ADDOPTS="--no-cov" pytest tests/unit/test_cli_agix_missing_dep.py tests/unit/test_analizador_agix.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7cfa351e483279c325d9e0a3097f9