### PR TITLE
Use capsys fixture for agix CLI tests

### DIFF
--- a/tests/unit/test_cli_agix.py
+++ b/tests/unit/test_cli_agix.py
@@ -1,12 +1,11 @@
 from argparse import Namespace
-from io import StringIO
 from unittest.mock import MagicMock, patch
 
 from cobra.cli.cli import main
 from cobra.cli.commands.agix_cmd import AgixCommand
 
 
-def test_cli_agix_generates_suggestion(tmp_path):
+def test_cli_agix_generates_suggestion(tmp_path, capsys):
     archivo = tmp_path / "ejemplo.co"
     archivo.write_text("var x = 5")
     cmd = AgixCommand()
@@ -21,13 +20,12 @@ def test_cli_agix_generates_suggestion(tmp_path):
     instancia = MagicMock()
     instancia.select_best_model.return_value = {"reason": "Usar nombres descriptivos"}
     with patch("ia.analizador_agix.Reasoner", return_value=instancia):
-        with patch("sys.stdout", new_callable=StringIO) as out:
-            cmd.run(args)
-    salida = out.getvalue().strip()
+        cmd.run(args)
+    salida = capsys.readouterr().out.strip()
     assert "Usar nombres descriptivos" in salida
 
 
-def test_cli_agix_pad_values(tmp_path):
+def test_cli_agix_pad_values(tmp_path, capsys):
     archivo = tmp_path / "ejemplo.co"
     archivo.write_text("var x = 5")
     instancia = MagicMock()
@@ -39,20 +37,19 @@ def test_cli_agix_pad_values(tmp_path):
                     "cobra.cli.cli.AppConfig.BASE_COMMAND_CLASSES",
                     new=[AgixCommand],
                 ):
-                    with patch("sys.stdout", new_callable=StringIO) as out:
-                        main(
-                            [
-                                "agix",
-                                str(archivo),
-                                "--placer",
-                                "0.1",
-                                "--activacion",
-                                "0.2",
-                                "--dominancia",
-                                "-0.3",
-                            ]
-                        )
-    salida = out.getvalue().strip()
+                    main(
+                        [
+                            "agix",
+                            str(archivo),
+                            "--placer",
+                            "0.1",
+                            "--activacion",
+                            "0.2",
+                            "--dominancia",
+                            "-0.3",
+                        ]
+                    )
+    salida = capsys.readouterr().out.strip()
     assert "Usar nombres descriptivos" in salida
     pad_mock.assert_called_once_with(0.1, 0.2, -0.3)
     instancia.modular_por_emocion.assert_called_once_with(pad_mock.return_value)

--- a/tests/unit/test_cli_agix_missing_dep.py
+++ b/tests/unit/test_cli_agix_missing_dep.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from cobra.cli.commands.agix_cmd import AgixCommand
 
 
-def test_cli_agix_sin_agix(tmp_path):
+def test_cli_agix_sin_agix(tmp_path, capsys):
     archivo = tmp_path / "ejemplo.co"
     archivo.write_text("var x = 5")
     cmd = AgixCommand()
@@ -17,8 +17,7 @@ def test_cli_agix_sin_agix(tmp_path):
         dominancia=None,
     )
     with patch("ia.analizador_agix.Reasoner", None):
-        with patch("cobra.cli.commands.agix_cmd.mostrar_error") as err_mock:
-            exit_code = cmd.run(args)
-    err_mock.assert_called_once()
+        exit_code = cmd.run(args)
+    salida = capsys.readouterr().out
     assert exit_code == 1
-    assert "Instala el paquete agix" in err_mock.call_args[0][0]
+    assert "Instala el paquete agix" in salida


### PR DESCRIPTION
## Summary
- Refactor agix CLI tests to capture stdout via `capsys` instead of patching `sys.stdout`
- Update agix missing dependency test to assert output using `capsys`

## Testing
- `pytest -o addopts='' tests/unit/test_cli_agix.py tests/unit/test_cli_agix_missing_dep.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7d2220af48327b84203f164b0b1a3