### PR TITLE
docs: documentar actualización de agix 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v10.0.10 - Pendiente de liberación
+- Actualización de la dependencia `agix` a la versión 1.6.0.
+- Mejora de rendimiento y compatibilidad derivada de esta actualización.
+
 ## v10.0.9 - 2025-08-17
 - Ajuste en `SafeUnpickler` para aceptar los módulos `core.ast_nodes` y `cobra.core.ast_nodes`.
 - `corelibs.sistema.ejecutar` ahora exige una lista blanca de comandos


### PR DESCRIPTION
## Resumen
- registra en el changelog la actualización de la dependencia agix a la versión 1.6.0
- anota las mejoras de rendimiento y compatibilidad aportadas por la nueva versión

## Pruebas
- `python scripts/grammar_coverage.py --threshold=30`
- `pytest --cov=src/pcobra tests --cov-report=term-missing --cov-fail-under=90` *(falla: ModuleNotFoundError: No module named 'RestrictedPython')*

------
https://chatgpt.com/codex/tasks/task_e_68c7e01029608327aba8ea834f49be8f