### PR TITLE
docs: actualiza changelog con holobit-sdk 1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v10.0.10 - Pendiente de liberación
 - Actualización de la dependencia `agix` a la versión 1.6.0.
 - Mejora de rendimiento y compatibilidad derivada de esta actualización.
+- Actualización de `holobit-sdk` a la versión 1.0.9 y ajuste de `graficar`/`proyectar` al nuevo API.
 
 ## v10.0.9 - 2025-08-17
 - Ajuste en `SafeUnpickler` para aceptar los módulos `core.ast_nodes` y `cobra.core.ast_nodes`.


### PR DESCRIPTION
## Summary
- añade referencia a holobit-sdk 1.0.9 y ajustes de graficar/proyectar en CHANGELOG

## Testing
- `pytest` *(failed: ModuleNotFoundError: No module named 'pcobra.cli.cli'; no module named 'holobit_sdk'; no module named 'lark')*

------
https://chatgpt.com/codex/tasks/task_e_68c7ead0be888327a9156e95901cf93b