### PR TITLE
Add TypeError tests for holobit helpers

### DIFF
--- a/tests/unit/test_holobit_sdk_integration.py
+++ b/tests/unit/test_holobit_sdk_integration.py
@@ -14,6 +14,11 @@ def test_graficar_usa_sdk(monkeypatch):
     assert 'hb' in llamadas
 
 
+def test_graficar_rechaza_valor_incorrecto():
+    with pytest.raises(TypeError):
+        graficar(None)
+
+
 def test_proyectar_usa_sdk(monkeypatch):
     llamadas = {}
     def fake(hb):
@@ -24,6 +29,11 @@ def test_proyectar_usa_sdk(monkeypatch):
     h = Holobit([1, 2, 3, 4, 5, 6])
     proyectar(h, '2D')
     assert 'hb' in llamadas
+
+
+def test_proyectar_rechaza_valor_incorrecto():
+    with pytest.raises(TypeError):
+        proyectar(None, '2D')
 
 
 def test_transformar_usa_sdk(monkeypatch):


### PR DESCRIPTION
## Summary
- Add tests confirming `graficar` and `proyectar` raise `TypeError` when called with `None`

## Testing
- `pytest tests/unit/test_holobit_sdk_integration.py` *(fails: Required test coverage of 85% not reached. Total coverage: 2.38%)*
- `pytest tests/unit/test_holobit_sdk_integration.py --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68c7f35e61948327b664a93dc08b575e