### PR TITLE
Verifica binario de Node en sandbox

### DIFF
--- a/tests/unit/test_security_sandbox.py
+++ b/tests/unit/test_security_sandbox.py
@@ -1,5 +1,6 @@
 import importlib.util
 import shutil
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -33,3 +34,31 @@ def test_compilar_cpp_sin_contenedor():
 def test_contenedor_backend_invalido():
     with pytest.raises(ValueError):
         ejecutar_en_contenedor("print(1)", "malicioso")
+
+
+@pytest.mark.timeout(5)
+def test_js_detecta_reemplazo_binario(monkeypatch, tmp_path):
+    fake_node = tmp_path / "node"
+    fake_node.write_text("#!/bin/sh\nexit 0\n")
+    fake_node.chmod(0o755)
+
+    monkeypatch.setattr(shutil, "which", lambda _: str(fake_node))
+    monkeypatch.setattr(
+        sandbox.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 0, stdout="3.9.19"),
+    )
+
+    original_popen = sandbox.subprocess.Popen
+
+    def fake_popen(cmd, *a, **k):
+        proc = original_popen(cmd, *a, **k)
+        fake_node.unlink()
+        fake_node.write_text("#!/bin/sh\nexit 0\n")
+        fake_node.chmod(0o755)
+        return proc
+
+    monkeypatch.setattr(sandbox.subprocess, "Popen", fake_popen)
+
+    with pytest.raises(sandbox.SecurityError):
+        ejecutar_en_sandbox_js("console.log('hola')")


### PR DESCRIPTION
## Resumen
- Usa la ruta completa de `node` y verifica su inode antes y después de ejecutar
- Lanza `SecurityError` si el binario de `node` cambia durante la ejecución
- Añade prueba unitaria que simula el reemplazo del binario

## Testing
- `pytest --no-cov tests/unit/test_security_sandbox.py::test_js_detecta_reemplazo_binario -q`
- `pytest --no-cov tests/unit/test_sandbox_js.py::test_sandbox_js_template_string -q` *(falla: RuntimeError: vm2 no disponible)*


------
https://chatgpt.com/codex/tasks/task_e_68c7fdf3ca608327b2c9b3f373b77507