### PR TITLE
Normaliza comparación de rutas en el módulo sistema

### DIFF
--- a/src/pcobra/corelibs/sistema.py
+++ b/src/pcobra/corelibs/sistema.py
@@ -32,7 +32,10 @@ def ejecutar(
     directamente a ``subprocess.run`` sin crear un shell. Se lanza
     ``ValueError`` si la lista está vacía. ``permitidos`` define una lista
     blanca de rutas absolutas de ejecutables autorizados; este parámetro es
-    obligatorio. Si se invoca la función
+    obligatorio. Las rutas suministradas deben estar normalizadas previamente
+    con ``os.path.normpath`` y ``os.path.normcase`` para asegurar
+    comparaciones coherentes en plataformas con distinta sensibilidad a las
+    mayúsculas. Si se invoca la función
     sin una lista se utilizará la capturada desde
     ``COBRA_EJECUTAR_PERMITIDOS`` al importar el módulo, siempre que no
     esté vacía. Los cambios posteriores en la variable de entorno no
@@ -70,8 +73,11 @@ def ejecutar(
         if exe_resuelto is None:
             raise ValueError(f"Comando no permitido: {exe}")
         exe_real = os.path.realpath(exe_resuelto)
-        permitidos_reales = {os.path.realpath(p) for p in permitidos}
-        if exe_real not in permitidos_reales:
+        exe_normalizado = os.path.normcase(os.path.normpath(exe_real))
+        permitidos_reales = {
+            os.path.normcase(os.path.normpath(os.path.realpath(p))) for p in permitidos
+        }
+        if exe_normalizado not in permitidos_reales:
             raise ValueError(f"Comando no permitido: {exe_real}")
         inode = os.stat(exe_real).st_ino
     args = comando

--- a/tests/unit/test_corelibs_sistema.py
+++ b/tests/unit/test_corelibs_sistema.py
@@ -1,10 +1,16 @@
+import os
 import subprocess
 import importlib
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 import pcobra.corelibs as core
+import pcobra.corelibs.sistema as core_sistema
+
+
+CASE_INSENSITIVE_OS = os.path.normcase("Aa") == os.path.normcase("aa")
 
 
 def test_ejecutar_exitoso(monkeypatch):
@@ -15,9 +21,9 @@ def test_ejecutar_exitoso(monkeypatch):
         assert k["timeout"] == 1
         return proc
 
-    monkeypatch.setattr(core.sistema.subprocess, "run", fake_run)
-    monkeypatch.setattr(core.sistema.shutil, "which", lambda x: f"/usr/bin/{x}")
-    permitido = core.sistema.os.path.realpath("/usr/bin/echo")
+    monkeypatch.setattr(core_sistema.subprocess, "run", fake_run)
+    monkeypatch.setattr(core_sistema.shutil, "which", lambda x: f"/usr/bin/{x}")
+    permitido = core_sistema.os.path.realpath("/usr/bin/echo")
     assert core.ejecutar(["echo", "ok"], permitidos=[permitido], timeout=1) == "ok"
 
 
@@ -25,17 +31,20 @@ def test_ejecutar_error(monkeypatch):
     def raise_err(*a, **k):
         raise subprocess.CalledProcessError(1, a[0], stderr="fallo")
 
-    monkeypatch.setattr(core.sistema.subprocess, "run", raise_err)
-    monkeypatch.setattr(core.sistema.shutil, "which", lambda x: f"/usr/bin/{x}")
-    permitido = core.sistema.os.path.realpath("/usr/bin/bad")
+    monkeypatch.setattr(core_sistema.subprocess, "run", raise_err)
+    monkeypatch.setattr(core_sistema.shutil, "which", lambda x: f"/usr/bin/{x}")
+    monkeypatch.setattr(
+        core_sistema.os, "stat", lambda _path: SimpleNamespace(st_ino=1)
+    )
+    permitido = core_sistema.os.path.realpath("/usr/bin/bad")
     assert core.ejecutar(["bad"], permitidos=[permitido], timeout=1) == "fallo"
 
     def raise_err2(*a, **k):
         raise subprocess.CalledProcessError(1, a[0])
 
-    monkeypatch.setattr(core.sistema.subprocess, "run", raise_err2)
-    monkeypatch.setattr(core.sistema.shutil, "which", lambda x: f"/usr/bin/{x}")
-    permitido = core.sistema.os.path.realpath("/usr/bin/bad")
+    monkeypatch.setattr(core_sistema.subprocess, "run", raise_err2)
+    monkeypatch.setattr(core_sistema.shutil, "which", lambda x: f"/usr/bin/{x}")
+    permitido = core_sistema.os.path.realpath("/usr/bin/bad")
     with pytest.raises(RuntimeError):
         core.ejecutar(["bad"], permitidos=[permitido], timeout=1)
 
@@ -43,34 +52,34 @@ def test_ejecutar_error(monkeypatch):
 def test_ejecutar_permitido_con_ruta(monkeypatch):
     proc = MagicMock()
     proc.stdout = "ok"
-    monkeypatch.setattr(core.sistema.subprocess, "run", lambda *a, **k: proc)
-    permitido = core.sistema.os.path.realpath("/bin/echo")
+    monkeypatch.setattr(core_sistema.subprocess, "run", lambda *a, **k: proc)
+    permitido = core_sistema.os.path.realpath("/bin/echo")
     assert core.ejecutar(["/bin/echo", "ok"], permitidos=[permitido], timeout=1) == "ok"
 
 
 def test_ejecutar_sin_lista_blanca(monkeypatch):
     proc = MagicMock()
     proc.stdout = "ok"
-    monkeypatch.setattr(core.sistema.subprocess, "run", lambda *a, **k: proc)
-    monkeypatch.setattr(core.sistema.shutil, "which", lambda x: f"/usr/bin/{x}")
-    monkeypatch.delenv(core.sistema.WHITELIST_ENV, raising=False)
+    monkeypatch.setattr(core_sistema.subprocess, "run", lambda *a, **k: proc)
+    monkeypatch.setattr(core_sistema.shutil, "which", lambda x: f"/usr/bin/{x}")
+    monkeypatch.delenv(core_sistema.WHITELIST_ENV, raising=False)
     with pytest.raises(ValueError):
         core.ejecutar(["echo", "ok"], timeout=1)
 
 
 def test_ejecutar_env_ignora_cambios(monkeypatch):
     permitido = "/usr/bin/echo"
-    monkeypatch.setenv(core.sistema.WHITELIST_ENV, permitido)
-    importlib.reload(core.sistema)
+    monkeypatch.setenv(core_sistema.WHITELIST_ENV, permitido)
+    importlib.reload(core_sistema)
 
-    monkeypatch.setenv(core.sistema.WHITELIST_ENV, "/usr/bin/false")
+    monkeypatch.setenv(core_sistema.WHITELIST_ENV, "/usr/bin/false")
     proc = MagicMock()
     proc.stdout = "ok"
-    monkeypatch.setattr(core.sistema.subprocess, "run", lambda *a, **k: proc)
-    monkeypatch.setattr(core.sistema.shutil, "which", lambda x: f"/usr/bin/{x}")
-    assert core.sistema.ejecutar(["echo", "ok"], timeout=1) == "ok"
+    monkeypatch.setattr(core_sistema.subprocess, "run", lambda *a, **k: proc)
+    monkeypatch.setattr(core_sistema.shutil, "which", lambda x: f"/usr/bin/{x}")
+    assert core_sistema.ejecutar(["echo", "ok"], timeout=1) == "ok"
     with pytest.raises(ValueError):
-        core.sistema.ejecutar(["false"], timeout=1)
+        core_sistema.ejecutar(["false"], timeout=1)
 
 
 def test_ejecutar_comando_vacio():
@@ -82,8 +91,30 @@ def test_ejecutar_timeout_expira(monkeypatch):
     def raise_timeout(*a, **k):
         raise subprocess.TimeoutExpired(a[0], k.get("timeout"))
 
-    monkeypatch.setattr(core.sistema.subprocess, "run", raise_timeout)
-    monkeypatch.setattr(core.sistema.shutil, "which", lambda x: f"/usr/bin/{x}")
-    permitido = core.sistema.os.path.realpath("/usr/bin/echo")
+    monkeypatch.setattr(core_sistema.subprocess, "run", raise_timeout)
+    monkeypatch.setattr(core_sistema.shutil, "which", lambda x: f"/usr/bin/{x}")
+    permitido = core_sistema.os.path.realpath("/usr/bin/echo")
     with pytest.raises(RuntimeError, match="Tiempo de espera agotado"):
         core.ejecutar(["echo", "ok"], permitidos=[permitido], timeout=1)
+
+
+@pytest.mark.skipif(
+    not CASE_INSENSITIVE_OS,
+    reason="Requiere sistema de archivos insensible a mayúsculas",
+)
+def test_ejecutar_compara_rutas_normalizadas_en_os_insensible(monkeypatch, tmp_path):
+    proc = MagicMock()
+    proc.stdout = "ok"
+    monkeypatch.setattr(core_sistema.subprocess, "run", lambda *a, **k: proc)
+
+    carpeta = tmp_path / "Binario"
+    carpeta.mkdir()
+    ejecutable = carpeta / "MiEjecutable"
+    ejecutable.write_text("echo")
+
+    permitido = core_sistema.os.path.normcase(
+        core_sistema.os.path.normpath(str(ejecutable))
+    )
+    comando = [str(ejecutable).upper()]
+
+    assert core.ejecutar(comando, permitidos=[permitido], timeout=1) == "ok"


### PR DESCRIPTION
## Summary
- normaliza las rutas permitidas y el ejecutable con `normpath` y `normcase` antes de compararlos
- documenta en `ejecutar` que la lista blanca debe recibirse con rutas normalizadas
- actualiza las pruebas de `corelibs.sistema`, incluido un caso que verifica la equivalencia en sistemas insensibles a mayúsculas

## Testing
- `PYTEST_ADDOPTS="--cov-fail-under=0" pytest tests/unit/test_corelibs_sistema.py`


------
https://chatgpt.com/codex/tasks/task_e_68c87042d2688327bda5d3688cf96dfc