### PR TITLE
Usar sesión real y reforzar tests de CobraHub

### DIFF
--- a/src/pcobra/cobra/cli/cobrahub_client.py
+++ b/src/pcobra/cobra/cli/cobrahub_client.py
@@ -125,6 +125,7 @@ class CobraHubClient:
             return sha256.hexdigest()
         except Exception as e:
             logger.error(f"Error calculando checksum: {e}")
+            mostrar_error(_("Error calculando checksum: {err}").format(err=str(e)))
             return None
 
     def _verificar_tamaño_archivo(self, ruta: str) -> bool:

--- a/src/pcobra/cobra/cli/commands/modules_cmd.py
+++ b/src/pcobra/cobra/cli/commands/modules_cmd.py
@@ -6,24 +6,6 @@ from argparse import ArgumentParser
 from pathlib import Path
 from filelock import FileLock
 import yaml
-import requests
-
-
-class _PatchedSession:
-    """Sesión proxy que delega en requests y ajusta la respuesta para pruebas."""
-
-    def get(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - simple delegación
-        resp = requests.get(*args, **kwargs)
-        resp.headers = {}
-        content = getattr(resp, "content", b"")
-        resp.iter_content = lambda chunk_size: [content]
-        resp.__enter__ = lambda *a, **k: resp
-        resp.__exit__ = lambda *a, **k: False
-        return resp
-
-    def post(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - simple delegación
-        return requests.post(*args, **kwargs)
-
 from cobra.semantico import mod_validator
 from cobra.transpilers.module_map import MODULE_MAP_PATH
 from cobra.cli.cobrahub_client import CobraHubClient
@@ -38,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 # Cliente de CobraHub
 client = CobraHubClient()
-client.session = _PatchedSession()
 
 # Constantes
 MODULES_PATH = Path(os.path.dirname(__file__)) / ".." / "modules"

--- a/tests/unit/test_cli_cobrahub.py
+++ b/tests/unit/test_cli_cobrahub.py
@@ -2,6 +2,7 @@ from io import StringIO
 from unittest.mock import patch, MagicMock
 import sys
 from types import ModuleType
+import hashlib
 import pytest
 import requests
 
@@ -13,12 +14,51 @@ from cobra.cli.commands import modules_cmd  # noqa: E402
 from cobra.cli import cobrahub_client  # noqa: E402
 
 
+class _PatchedSession:
+    """Sesión mínima que redirige a ``requests`` real para los tests."""
+
+    def get(self, *args, **kwargs):
+        resp = cobrahub_client.requests.get(*args, **kwargs)
+
+        if "headers" not in getattr(resp, "__dict__", {}):
+            resp.headers = {}
+
+        iter_content_attr = getattr(resp, "iter_content", None)
+        if isinstance(iter_content_attr, MagicMock) or iter_content_attr is None:
+            content = getattr(resp, "content", b"")
+            resp.iter_content = lambda chunk_size: [content]
+
+        if isinstance(getattr(resp, "__enter__", None), MagicMock):
+            resp.__enter__ = lambda *a, **k: resp
+        if isinstance(getattr(resp, "__exit__", None), MagicMock) or not hasattr(resp, "__exit__"):
+            resp.__exit__ = lambda *a, **k: False
+
+        return resp
+
+    def post(self, *args, **kwargs):
+        return cobrahub_client.requests.post(*args, **kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _use_patched_session(monkeypatch):
+    """Fuerza que los clientes usen la sesión parcheada durante las pruebas."""
+
+    session = _PatchedSession()
+    monkeypatch.setattr(modules_cmd.client, "session", session)
+
+    def _factory(self):
+        return _PatchedSession()
+
+    monkeypatch.setattr(cobrahub_client.CobraHubClient, "_configurar_sesion", _factory)
+    return session
+
+
 @pytest.mark.timeout(5)
 def test_cli_modulos_publicar(tmp_path):
     archivo = tmp_path / "m.co"
     archivo.write_text("var x = 1")
     args = type("obj", (), {"accion": "publicar", "ruta": str(archivo)})
-    with patch("cli.cobrahub_client.requests.post") as mock_post, \
+    with patch("cobra.cli.cobrahub_client.requests.post") as mock_post, \
             patch("sys.stdout", new_callable=StringIO) as out:
         mock_resp = MagicMock()
         mock_resp.raise_for_status.return_value = None
@@ -40,7 +80,7 @@ def test_cli_modulos_buscar(tmp_path, monkeypatch):
     monkeypatch.setattr(modules_cmd, "MODULE_MAP_PATH", str(mod_file))
     monkeypatch.setattr(modules_cmd, "LOCK_FILE", str(mod_file))
     args = type("obj", (), {"accion": "buscar", "nombre": "remote.co"})
-    with patch("cli.cobrahub_client.requests.get") as mock_get, \
+    with patch("cobra.cli.cobrahub_client.requests.get") as mock_get, \
             patch("sys.stdout", new_callable=StringIO) as out:
         response = MagicMock()
         response.raise_for_status.return_value = None
@@ -61,7 +101,7 @@ def test_publicar_modulo_url_insegura(tmp_path, monkeypatch):
     mod.write_text("var x = 1")
     monkeypatch.setattr(cobrahub_client, "COBRAHUB_URL", "http://inseguro/api")
     with patch("cobra.cli.cobrahub_client.mostrar_error") as err, \
-            patch("cli.cobrahub_client.requests.post") as mock_post:
+            patch("cobra.cli.cobrahub_client.requests.post") as mock_post:
         ok = cobrahub_client.publicar_modulo(str(mod))
     assert not ok
     err.assert_called_once()
@@ -75,7 +115,7 @@ def test_descargar_modulo_url_insegura(tmp_path, monkeypatch):
     destino = "out.co"
     monkeypatch.setattr(cobrahub_client, "COBRAHUB_URL", "http://inseguro/api")
     with patch("cobra.cli.cobrahub_client.mostrar_error") as err, \
-            patch("cli.cobrahub_client.requests.get") as mock_get:
+            patch("cobra.cli.cobrahub_client.requests.get") as mock_get:
         ok = cobrahub_client.descargar_modulo("m.co", destino)
     assert not ok
     err.assert_called_once()
@@ -87,7 +127,7 @@ def test_descargar_modulo_url_insegura(tmp_path, monkeypatch):
 def test_descargar_modulo_ruta_invalida_absoluta(tmp_path):
     destino = tmp_path / "m.co"
     with patch("cobra.cli.cobrahub_client.mostrar_error") as err, \
-            patch("cli.cobrahub_client.requests.get") as mock_get:
+            patch("cobra.cli.cobrahub_client.requests.get") as mock_get:
         ok = cobrahub_client.descargar_modulo("m.co", str(destino))
     assert not ok
     err.assert_called_once()
@@ -99,7 +139,7 @@ def test_descargar_modulo_ruta_invalida_traversal(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     destino = "../salir.co"
     with patch("cobra.cli.cobrahub_client.mostrar_error") as err, \
-            patch("cli.cobrahub_client.requests.get") as mock_get:
+            patch("cobra.cli.cobrahub_client.requests.get") as mock_get:
         ok = cobrahub_client.descargar_modulo("m.co", destino)
     assert not ok
     err.assert_called_once()
@@ -111,7 +151,7 @@ def test_descargar_modulo_ruta_invalida_parent(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     destino = "../"
     with patch("cobra.cli.cobrahub_client.mostrar_error") as err, \
-            patch("cli.cobrahub_client.requests.get") as mock_get:
+            patch("cobra.cli.cobrahub_client.requests.get") as mock_get:
         ok = cobrahub_client.descargar_modulo("m.co", destino)
     assert not ok
     err.assert_called_once()
@@ -122,7 +162,7 @@ def test_descargar_modulo_ruta_invalida_parent(tmp_path, monkeypatch):
 def test_descargar_modulo_ruta_invalida_tmp_espacios():
     destino = "/tmp/proyecto falso"
     with patch("cobra.cli.cobrahub_client.mostrar_error") as err, \
-            patch("cli.cobrahub_client.requests.get") as mock_get:
+            patch("cobra.cli.cobrahub_client.requests.get") as mock_get:
         ok = cobrahub_client.descargar_modulo("m.co", destino)
     assert not ok
     err.assert_called_once()
@@ -134,7 +174,7 @@ def test_descargar_modulo_ruta_valida(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     destino = "mods/m.co"
     (tmp_path / "mods").mkdir()
-    with patch("cli.cobrahub_client.requests.get") as mock_get:
+    with patch("cobra.cli.cobrahub_client.requests.get") as mock_get:
         resp = MagicMock()
         resp.raise_for_status.return_value = None
         resp.content = b"x"
@@ -148,11 +188,71 @@ def test_descargar_modulo_ruta_valida(tmp_path, monkeypatch):
 
 
 @pytest.mark.timeout(5)
+def test_descargar_modulo_streaming_con_checksum(tmp_path, monkeypatch):
+    """Las descargas grandes deben usar streaming y validar encabezados."""
+
+    monkeypatch.chdir(tmp_path)
+    destino = "mods/m.co"
+    (tmp_path / "mods").mkdir()
+
+    client = cobrahub_client.CobraHubClient()
+
+    chunks = [b"a" * client.CHUNK_SIZE, b"b" * 128]
+    sha = hashlib.sha256()
+    for chunk in chunks:
+        sha.update(chunk)
+    checksum = sha.hexdigest()
+
+    class _StreamingResponse:
+        def __init__(self):
+            self.iter_calls = []
+            self.closed = False
+            self.headers = MagicMock()
+            self.headers.get.return_value = checksum
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.closed = True
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size):
+            self.iter_calls.append(chunk_size)
+            for part in chunks:
+                yield part
+
+        def close(self):
+            self.closed = True
+
+        @property
+        def content(self):  # pragma: no cover - asegura que no se use ``content``
+            raise AssertionError("La descarga debe procesarse en streaming")
+
+    response = _StreamingResponse()
+    client.session.get = MagicMock(return_value=response)
+
+    ok = client.descargar_modulo("m.co", destino)
+
+    assert ok
+    archivo = tmp_path / destino
+    assert archivo.read_bytes() == b"".join(chunks)
+    client.session.get.assert_called_once()
+    assert client.session.get.call_args.kwargs["stream"] is True
+    assert response.iter_calls == [client.CHUNK_SIZE]
+    response.headers.get.assert_called_once_with("X-Content-Checksum")
+    assert response.closed is True
+
+
+@pytest.mark.timeout(5)
 def test_publicar_modulo_permission_error(tmp_path):
     archivo = tmp_path / "m.co"
     archivo.write_text("var x = 1")
     with patch("cobra.cli.cobrahub_client.mostrar_error") as err, \
-            patch("cli.cobrahub_client.requests.post") as mock_post, \
+            patch("cobra.cli.cobrahub_client.requests.post") as mock_post, \
             patch("builtins.open", side_effect=PermissionError):
         ok = cobrahub_client.publicar_modulo(str(archivo))
     assert not ok
@@ -185,7 +285,7 @@ def test_descargar_modulo_permission_error(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     destino = "out.co"
     with patch("cobra.cli.cobrahub_client.mostrar_error") as err, \
-            patch("cli.cobrahub_client.requests.get") as mock_get, \
+            patch("cobra.cli.cobrahub_client.requests.get") as mock_get, \
             patch("builtins.open", side_effect=PermissionError):
         resp = MagicMock()
         resp.raise_for_status.return_value = None
@@ -205,7 +305,7 @@ def test_descargar_modulo_symlink(tmp_path, monkeypatch):
     enlace = tmp_path / "link.co"
     enlace.symlink_to(destino_real)
     with patch("cobra.cli.cobrahub_client.mostrar_error") as err, \
-            patch("cli.cobrahub_client.requests.get") as mock_get:
+            patch("cobra.cli.cobrahub_client.requests.get") as mock_get:
         ok = cobrahub_client.descargar_modulo("m.co", str(enlace))
     assert not ok
     err.assert_called_once()
@@ -219,7 +319,7 @@ def test_publicar_modulo_host_no_permitido(tmp_path, monkeypatch):
     monkeypatch.setenv("COBRA_HOST_WHITELIST", "cobrahub.example.com")
     monkeypatch.setattr(cobrahub_client, "COBRAHUB_URL", "https://otro.com/api")
     with patch("cobra.cli.cobrahub_client.mostrar_error") as err, \
-            patch("cli.cobrahub_client.requests.post") as mock_post:
+            patch("cobra.cli.cobrahub_client.requests.post") as mock_post:
         ok = cobrahub_client.publicar_modulo(str(archivo))
     assert not ok
     err.assert_called_once()
@@ -234,7 +334,7 @@ def test_descargar_modulo_host_no_permitido(tmp_path, monkeypatch):
     monkeypatch.setenv("COBRA_HOST_WHITELIST", "cobrahub.example.com")
     monkeypatch.setattr(cobrahub_client, "COBRAHUB_URL", "https://otro.com/api")
     with patch("cobra.cli.cobrahub_client.mostrar_error") as err, \
-            patch("cli.cobrahub_client.requests.get") as mock_get:
+            patch("cobra.cli.cobrahub_client.requests.get") as mock_get:
         ok = cobrahub_client.descargar_modulo("m.co", destino)
     assert not ok
     err.assert_called_once()


### PR DESCRIPTION
## Resumen
- Eliminar el uso de `_PatchedSession` en `modules_cmd` para que la CLI use la `requests.Session` real del cliente.
- Mostrar un mensaje de error al fallar el cálculo del checksum durante la publicación de módulos.
- Reubicar la sesión parcheada dentro de los tests, actualizar los mocks y añadir una prueba de streaming con checksum para descargas grandes.

## Pruebas
- `pytest --override-ini addopts="" tests/unit/test_cli_cobrahub.py::test_cli_modulos_buscar -q`
- `pytest --override-ini addopts="" tests/unit/test_cli_cobrahub.py::test_descargar_modulo_ruta_valida -q`
- `pytest --override-ini addopts="" tests/unit/test_cli_cobrahub.py::test_descargar_modulo_streaming_con_checksum -q`
- `pytest --override-ini addopts="" tests/unit/test_cobrahub_retry.py -q`
- `pytest --override-ini addopts="" tests/unit/test_cobrahub_close.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c875a077d48327ab9dee395e9cf9eb