### PR TITLE
Verifica esquema tras redirecciones en obtener_url

### DIFF
--- a/src/pcobra/core/nativos/io.py
+++ b/src/pcobra/core/nativos/io.py
@@ -59,7 +59,8 @@ def obtener_url(url, permitir_redirecciones: bool = False):
     Es obligatorio definir la variable de entorno ``COBRA_HOST_WHITELIST`` con
     la lista de hosts permitidos separados por comas. Las redirecciones están
     deshabilitadas por defecto. Si se permiten, se valida que el destino final
-    continúe dentro de la lista blanca de hosts.
+    continúe dentro de la lista blanca de hosts y que el esquema se mantenga en
+    ``https``.
     """
     url_baja = url.lower()
     if not url_baja.startswith("https://"):
@@ -76,6 +77,8 @@ def obtener_url(url, permitir_redirecciones: bool = False):
     )
     try:
         resp.raise_for_status()
+        if permitir_redirecciones and not resp.url.lower().startswith("https://"):
+            raise ValueError("Esquema de URL no soportado")
         _validar_host(resp.url, hosts)
         return _leer_respuesta(resp)
     finally:

--- a/tests/unit/test_nativos_io.py
+++ b/tests/unit/test_nativos_io.py
@@ -90,6 +90,15 @@ def test_obtener_url_redireccion_fuera_whitelist(monkeypatch):
             io.obtener_url('https://example.com', permitir_redirecciones=True)
 
 
+def test_obtener_url_redireccion_http(monkeypatch):
+    monkeypatch.setenv("COBRA_HOST_WHITELIST", "example.com")
+    mock_resp = MagicMock(text="ok", url="http://example.com")
+    mock_resp.raise_for_status.return_value = None
+    with patch('requests.get', return_value=mock_resp):
+        with pytest.raises(ValueError):
+            io.obtener_url('https://example.com', permitir_redirecciones=True)
+
+
 def test_obtener_url_respuesta_muy_grande(monkeypatch):
     monkeypatch.setenv("COBRA_HOST_WHITELIST", "example.com")
     grande = MagicMock(url="https://example.com", encoding="utf-8")


### PR DESCRIPTION
## Summary
- valida que las redirecciones de `obtener_url` mantengan el esquema HTTPS en el módulo nativo
- documenta el comportamiento en el docstring
- agrega una prueba unitaria que cubre redirecciones hacia HTTP

## Testing
- `pytest --no-cov tests/unit/test_nativos_io.py`


------
https://chatgpt.com/codex/tasks/task_e_68c8f8f8e8008327b8f2da04da1394ee