### PR TITLE
Restringir rutas en lectura/escritura de archivo

### DIFF
--- a/src/pcobra/corelibs/archivo.py
+++ b/src/pcobra/corelibs/archivo.py
@@ -1,17 +1,58 @@
 """Funciones de manejo de archivos de texto."""
 
 import os
+from pathlib import Path
+from typing import Union
+
+PathLike = Union[str, os.PathLike[str]]
 
 
-def leer(ruta: str) -> str:
-    """Devuelve el contenido de un archivo."""
-    with open(ruta, "r", encoding="utf-8") as f:
+def _resolver_ruta(ruta: PathLike) -> Path:
+    """Normaliza ``ruta`` dentro de un directorio permitido.
+
+    Se utiliza ``COBRA_IO_BASE_DIR`` como directorio base si está definido;
+    en caso contrario se emplea el directorio de trabajo actual. Si la ruta
+    resultante se sale de este directorio controlado, se genera un
+    ``ValueError``.
+    """
+
+    base = Path(os.environ.get("COBRA_IO_BASE_DIR") or Path.cwd()).resolve()
+    objetivo = Path(ruta)
+    if objetivo.is_absolute():
+        raise ValueError("Las rutas absolutas no están permitidas")
+    if ".." in objetivo.parts:
+        raise ValueError("La ruta no puede contener '..'")
+    destino = (base / objetivo).resolve()
+    try:
+        destino.relative_to(base)
+    except ValueError as exc:
+        raise ValueError("La ruta queda fuera del directorio permitido") from exc
+    return destino
+
+
+def leer(ruta: PathLike) -> str:
+    """Devuelve el contenido de un archivo dentro del directorio permitido.
+
+    La ruta debe permanecer dentro de ``COBRA_IO_BASE_DIR`` (si existe) o del
+    directorio de trabajo actual. Se lanza ``ValueError`` si la ruta no es
+    válida.
+    """
+
+    ruta_segura = _resolver_ruta(ruta)
+    with ruta_segura.open("r", encoding="utf-8") as f:
         return f.read()
 
 
-def escribir(ruta: str, datos: str) -> None:
-    """Escribe *datos* en el archivo indicado."""
-    with open(ruta, "w", encoding="utf-8") as f:
+def escribir(ruta: PathLike, datos: str) -> None:
+    """Escribe ``datos`` en un archivo dentro del directorio permitido.
+
+    La ruta debe permanecer dentro de ``COBRA_IO_BASE_DIR`` (si existe) o del
+    directorio de trabajo actual. Se lanza ``ValueError`` si la ruta no es
+    válida.
+    """
+
+    ruta_segura = _resolver_ruta(ruta)
+    with ruta_segura.open("w", encoding="utf-8") as f:
         f.write(datos)
 
 

--- a/src/pcobra/standard_library/archivo.py
+++ b/src/pcobra/standard_library/archivo.py
@@ -3,27 +3,69 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
+from typing import Union
+
+PathLike = Union[str, os.PathLike[str]]
 
 
-def leer(ruta: str) -> str:
-    """Devuelve el contenido de un archivo."""
-    with open(ruta, "r", encoding="utf-8") as f:
+def _resolver_ruta(ruta: PathLike) -> Path:
+    """Normaliza ``ruta`` asegurando que permanezca en un directorio seguro."""
+
+    base = Path(os.environ.get("COBRA_IO_BASE_DIR") or Path.cwd()).resolve()
+    objetivo = Path(ruta)
+    if objetivo.is_absolute():
+        raise ValueError("Las rutas absolutas no están permitidas")
+    if ".." in objetivo.parts:
+        raise ValueError("La ruta no puede contener '..'")
+    destino = (base / objetivo).resolve()
+    try:
+        destino.relative_to(base)
+    except ValueError as exc:
+        raise ValueError("La ruta queda fuera del directorio permitido") from exc
+    return destino
+
+
+def leer(ruta: PathLike) -> str:
+    """Devuelve el contenido de un archivo dentro del directorio permitido.
+
+    La ruta debe permanecer dentro de ``COBRA_IO_BASE_DIR`` (si existe) o del
+    directorio de trabajo actual. Se lanza ``ValueError`` si la ruta no es
+    válida.
+    """
+
+    ruta_segura = _resolver_ruta(ruta)
+    with ruta_segura.open("r", encoding="utf-8") as f:
         return f.read()
 
 
-def escribir(ruta: str, datos: str) -> None:
-    """Sobrescribe el archivo indicado con ``datos``."""
-    with open(ruta, "w", encoding="utf-8") as f:
+def escribir(ruta: PathLike, datos: str) -> None:
+    """Sobrescribe el archivo indicado con ``datos`` dentro del directorio permitido.
+
+    La ruta debe permanecer dentro de ``COBRA_IO_BASE_DIR`` (si existe) o del
+    directorio de trabajo actual. Se lanza ``ValueError`` si la ruta no es
+    válida.
+    """
+
+    ruta_segura = _resolver_ruta(ruta)
+    with ruta_segura.open("w", encoding="utf-8") as f:
         f.write(datos)
 
 
-def adjuntar(ruta: str, datos: str) -> None:
-    """Agrega ``datos`` al final del archivo."""
-    with open(ruta, "a", encoding="utf-8") as f:
+def adjuntar(ruta: PathLike, datos: str) -> None:
+    """Agrega ``datos`` al final de un archivo dentro del directorio permitido."""
+
+    ruta_segura = _resolver_ruta(ruta)
+    with ruta_segura.open("a", encoding="utf-8") as f:
         f.write(datos)
 
 
-def existe(ruta: str) -> bool:
-    """Indica si el archivo existe."""
-    return os.path.isfile(ruta)
+def existe(ruta: PathLike) -> bool:
+    """Indica si el archivo existe dentro del directorio permitido."""
+
+    try:
+        ruta_segura = _resolver_ruta(ruta)
+    except ValueError:
+        return False
+    return ruta_segura.is_file()
 

--- a/tests/unit/test_archivo.py
+++ b/tests/unit/test_archivo.py
@@ -2,18 +2,38 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
 import standard_library.archivo as archivo
 
 
-def test_archivo(tmp_path):
-    ruta = tmp_path / "f.txt"
-    archivo.escribir(ruta, "hola")
-    assert archivo.existe(ruta)
-    archivo.adjuntar(ruta, " mundo")
-    assert archivo.leer(ruta) == "hola mundo"
-    os.remove(ruta)
-    assert not archivo.existe(ruta)
+def test_archivo(tmp_path, monkeypatch):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    nombre = "f.txt"
+    archivo.escribir(nombre, "hola")
+    assert archivo.existe(nombre)
+    archivo.adjuntar(nombre, " mundo")
+    assert archivo.leer(nombre) == "hola mundo"
+    os.remove(tmp_path / nombre)
+    assert not archivo.existe(nombre)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [archivo.leer, lambda ruta: archivo.escribir(ruta, "dato")],
+)
+@pytest.mark.parametrize(
+    "ruta",
+    [
+        lambda base: str((base / "absoluta.txt").resolve()),
+        lambda _base: "../escape.txt",
+    ],
+)
+def test_archivo_rechaza_rutas_invalidas(monkeypatch, tmp_path, func, ruta):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    with pytest.raises(ValueError):
+        func(ruta(tmp_path))
 


### PR DESCRIPTION
## Summary
- agrega el ayudante `_resolver_ruta` y actualiza `leer`/`escribir` para validar rutas dentro del directorio permitido en los módulos de archivo de corelibs y de la biblioteca estándar
- ajusta los docstrings para documentar la restricción y reutiliza el ayudante en operaciones de escritura/lectura (incluyendo `adjuntar` y `existe` en la biblioteca estándar)
- fortalece las pruebas unitarias configurando `COBRA_IO_BASE_DIR` y verificando que rutas absolutas o con ``..`` disparen `ValueError`

## Testing
- PYTEST_ADDOPTS="--no-cov" pytest tests/unit/test_corelibs.py tests/unit/test_archivo.py

------
https://chatgpt.com/codex/tasks/task_e_68c90beba1c883278548f2ee7805ea07