### PR TITLE
Ajusta manejo de errores en configurar_entorno y añade prueba

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -26,13 +26,15 @@ logger = logging.getLogger(__name__)
 def configurar_entorno() -> None:
     """Carga variables de entorno desde un archivo .env si está presente."""
     try:
-        if not load_dotenv():
-            logger.warning("El archivo .env no se cargó")
-    except Exception as exc:  # pragma: no cover - manejo básico de errores
-        logger.critical(
-            "Error inesperado al cargar variables de entorno: %s", str(exc)
-        )
+        cargado = load_dotenv()
+    except OSError as exc:
+        logger.error("No se pudo acceder al archivo .env: %s", exc)
+        return
+    except Exception as exc:  # pragma: no cover - registro y propagación
+        logger.exception("Error inesperado al cargar variables de entorno")
         raise
+    if not cargado:
+        logger.warning("El archivo .env no se cargó")
 
 
 cobra = argparse.ArgumentParser(prog="cobra")

--- a/tests/unit/test_cli_configurar_entorno.py
+++ b/tests/unit/test_cli_configurar_entorno.py
@@ -1,0 +1,71 @@
+import logging
+import sys
+import types
+
+
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda _stream: {}
+
+
+class _YamlError(Exception):
+    """Excepción ficticia para simular errores de PyYAML."""
+
+
+yaml_stub.YAMLError = _YamlError
+sys.modules.setdefault("yaml", yaml_stub)
+
+restricted_stub = types.ModuleType("RestrictedPython")
+restricted_stub.compile_restricted = lambda source, filename, mode: compile(
+    source, filename, mode
+)
+restricted_stub.safe_builtins = {}
+
+restricted_eval_stub = types.ModuleType("RestrictedPython.Eval")
+restricted_eval_stub.default_guarded_getitem = lambda *args, **kwargs: None
+restricted_eval_stub.default_guarded_getattr = lambda *args, **kwargs: None
+
+restricted_guards_stub = types.ModuleType("RestrictedPython.Guards")
+restricted_guards_stub.guarded_iter_unpack_sequence = lambda *args, **kwargs: None
+restricted_guards_stub.guarded_unpack_sequence = lambda *args, **kwargs: None
+
+
+class _DummyPrintCollector:
+    def __call__(self):
+        return ""
+
+
+restricted_print_stub = types.ModuleType("RestrictedPython.PrintCollector")
+restricted_print_stub.PrintCollector = _DummyPrintCollector
+
+sys.modules.setdefault("RestrictedPython", restricted_stub)
+sys.modules.setdefault("RestrictedPython.Eval", restricted_eval_stub)
+sys.modules.setdefault("RestrictedPython.Guards", restricted_guards_stub)
+sys.modules.setdefault("RestrictedPython.PrintCollector", restricted_print_stub)
+
+jsonschema_stub = types.ModuleType("jsonschema")
+
+
+class _JsonSchemaValidationError(Exception):
+    """Excepción ficticia de jsonschema."""
+
+
+jsonschema_stub.ValidationError = _JsonSchemaValidationError
+jsonschema_stub.validate = lambda *args, **kwargs: None
+sys.modules.setdefault("jsonschema", jsonschema_stub)
+
+from pcobra.cli import configurar_entorno
+
+
+def test_configurar_entorno_permiso_denegado(monkeypatch, caplog):
+    """Debe registrar un error y continuar cuando .env no se puede leer."""
+
+    def _raise_permission_error():
+        raise PermissionError("sin permiso")
+
+    monkeypatch.setattr("pcobra.cli.load_dotenv", _raise_permission_error)
+
+    caplog.set_level(logging.ERROR, logger="pcobra.cli")
+
+    configurar_entorno()
+
+    assert "No se pudo acceder al archivo .env" in caplog.text


### PR DESCRIPTION
## Summary
- registra errores de acceso al archivo .env capturando específicamente OSError en configurar_entorno
- asegura que errores inesperados se registren con el contexto adecuado y se propaguen
- agrega una prueba unitaria que simula un PermissionError y verifica el registro del mensaje

## Testing
- pytest --cov-fail-under=0 tests/unit/test_cli_configurar_entorno.py

------
https://chatgpt.com/codex/tasks/task_e_68c911d594d88327a28b7c4552444bf4