### PR TITLE
Añade puntuación al comentario de cadena de suministro en workflows

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -35,7 +35,7 @@ jobs:
             mac_arch: x86_64
 
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro.
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro.
         with:
           fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro.
         with:
           fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -147,7 +147,7 @@ jobs:
   benchmarks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro.
         with:
           fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro.
         with:
           fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/pcobra-cli:latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro.
         with:
           fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro.
         with:
           fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   publish-artifacts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro.
         with:
           fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro.
         with:
           fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5


### PR DESCRIPTION
## Summary
- añade un punto final al comentario que fija actions/checkout para la seguridad de la cadena de suministro en todos los workflows afectados

## Testing
- yamllint -d '{extends: relaxed, rules: {line-length: disable, empty-lines: disable}}' .github/workflows/build-binaries.yml .github/workflows/build-exe.yml .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/docker.yml .github/workflows/pages.yml .github/workflows/release.yml .github/workflows/test.yml

------
https://chatgpt.com/codex/tasks/task_e_68c916cc95788327bce0add8aa38e724