### PR TITLE
Pin actions versions in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4 (08eba0b27e820071cde6df949e0beb9ba4906955)
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5 (a26af69be951a213d495a4c3e4e4022e16d87065)
         with:
           python-version: "3.11"
       - run: pip install black


### PR DESCRIPTION
## Summary
- pin the checkout and setup-python actions in the lint workflow to specific commits and document their versions for traceability

## Testing
- actionlint .github/workflows/lint.yml

------
https://chatgpt.com/codex/tasks/task_e_68c91cafbb448327a511d61db6f37709