### PR TITLE
Add actionlint workflow validation

### DIFF
--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -1,0 +1,25 @@
+name: Validar workflows
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  actionlint:
+    name: Ejecutar actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout del repositorio
+        uses: actions/checkout@v4
+
+      - name: Instalar actionlint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash \
+            | bash -s -- -b ./bin
+
+      - name: Analizar workflows
+        run: ./bin/actionlint -color

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -1,4 +1,6 @@
 name: Validar workflows
+permissions:
+  contents: read
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -787,6 +787,13 @@ editable junto con las dependencias de desarrollo:**
 pip install -e .[dev]
 ```
 
+Además, cada cambio en los workflows de GitHub Actions se valida con
+[`actionlint`](https://github.com/rhysd/actionlint) mediante el workflow
+[Validar workflows](.github/workflows/validate-workflows.yml). Este proceso se
+ejecuta automáticamente en los eventos `push` y `pull_request` cuando se
+modifican archivos dentro de `.github/workflows/`, evitando que se integren
+definiciones inválidas en la canalización de CI.
+
 Esta instrucción añade el proyecto al `PYTHONPATH` e instala todas las
 dependencias listadas en `requirements-dev.txt`, las cuales están incluidas en
 el extra `dev` de `pyproject.toml`. Sin estas bibliotecas las pruebas fallarán


### PR DESCRIPTION
## Summary
- add a dedicated workflow to run actionlint against GitHub Actions definitions
- document the automatic validation in the testing section of the README

## Testing
- not run (not needed for documentation/workflow update)


------
https://chatgpt.com/codex/tasks/task_e_68c91e6983b483278b4e1a720cc0a2db