### PR TITLE
Filtra NODE_PATH en sandbox de Node

### DIFF
--- a/docs/limitaciones_node_sandbox.md
+++ b/docs/limitaciones_node_sandbox.md
@@ -8,7 +8,11 @@ mediante `vm2` en un contexto vacío donde únicamente se expone un objeto
 `console`. De esta forma no se tiene acceso a funciones internas de Node ni a
 módulos del sistema. Además, la ejecución se realiza con un entorno de
 variables reducido donde `PATH` apunta exclusivamente a `/usr/bin` o al
-directorio que contiene el ejecutable de Node.
+directorio que contiene el ejecutable de Node. Antes de ejecutar el código se
+limpia cualquier variable sensible proporcionada por el usuario, como
+`NODE_OPTIONS`, `NODE_PATH`, `PATH` personalizado o entradas que comiencen por
+`LD_`, para impedir que se carguen módulos maliciosos o se altere la resolución
+de dependencias.
 
 Es imprescindible mantener `vm2` actualizado; antes de cada ejecución se
 verifica que la versión instalada sea al menos `3.9.19` para mitigar

--- a/src/pcobra/core/sandbox.py
+++ b/src/pcobra/core/sandbox.py
@@ -120,6 +120,7 @@ def ejecutar_en_sandbox_js(
         claves_sensibles = {
             "PATH",
             "NODE_OPTIONS",
+            "NODE_PATH",
             "LD_PRELOAD",
             "LD_LIBRARY_PATH",
         }

--- a/tests/unit/test_sandbox_js.py
+++ b/tests/unit/test_sandbox_js.py
@@ -119,6 +119,7 @@ def test_sandbox_js_env_vars_permitidas(monkeypatch):
         "NODE_OPTIONS": "--eval \"process.stdout.write('pwned')\"",
         "PATH": "/tmp",
         "API_KEY": "secreta",
+        "NODE_PATH": "/tmp/node_modules",
     }
 
     salida = ejecutar_en_sandbox_js("console.log('hola')", env_vars=env_vars)
@@ -126,6 +127,7 @@ def test_sandbox_js_env_vars_permitidas(monkeypatch):
     assert "pwned" not in salida
     assert capturadas.get("API_KEY") == "secreta"
     assert capturadas.get("NODE_OPTIONS") is None
+    assert capturadas.get("NODE_PATH") is None
     assert capturadas.get("PATH") != "/tmp"
 
 


### PR DESCRIPTION
## Summary
- añade `NODE_PATH` a las variables descartadas por la sandbox de Node
- documenta la limpieza de variables sensibles en la guía de limitaciones
- extiende la prueba de entorno permitido para comprobar que `NODE_PATH` se filtra

## Testing
- pytest tests/unit/test_sandbox_js.py *(falla porque la instalación de `vm2` no está disponible en el entorno de pruebas y la cobertura mínima configurada no se alcanza)*

------
https://chatgpt.com/codex/tasks/task_e_68c93d895b3c8327845a9747e9fe49e3