### PR TITLE
Verificar ejecutable de Docker en la sandbox

### DIFF
--- a/tests/unit/test_security_sandbox.py
+++ b/tests/unit/test_security_sandbox.py
@@ -65,8 +65,13 @@ def test_js_detecta_reemplazo_binario(monkeypatch, tmp_path):
         ejecutar_en_sandbox_js("console.log('hola')")
 
 
-def test_contenedor_trunca_salida(monkeypatch):
+def test_contenedor_trunca_salida(monkeypatch, tmp_path):
     datos = b"A" * (sandbox.MAX_CONTAINER_OUTPUT_BYTES + 100)
+
+    fake_docker = tmp_path / "docker"
+    fake_docker.write_text("#!/bin/sh\nexit 0\n")
+    fake_docker.chmod(0o755)
+    monkeypatch.setattr(sandbox.shutil, "which", lambda *_: str(fake_docker))
 
     class FakeStdout:
         def __init__(self, data: bytes) -> None:


### PR DESCRIPTION
## Summary
- Resolved the Docker executable path via `shutil.which`, verified its inode before and after launching the container, and enforced a minimal PATH when invoking Docker.
- Improved runtime errors when Docker is unavailable and ensured the sandbox process stops if the binary changes.
- Updated the unit test to provide a fake Docker binary so output truncation continues to be validated under the new checks.

## Testing
- pytest -o addopts= tests/unit/test_security_sandbox.py -k contenedor *(fails: missing dependency `RestrictedPython`)*

------
https://chatgpt.com/codex/tasks/task_e_68c94129df6c8327ae9a2e22451e97ba