### PR TITLE
Add Hololang transpiler and unit tests

### DIFF
--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -16,6 +16,7 @@ from cobra.transpilers.transpiler.to_go import TranspiladorGo
 from cobra.transpilers.transpiler.to_java import TranspiladorJava
 from cobra.transpilers.transpiler.to_kotlin import TranspiladorKotlin
 from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+from cobra.transpilers.transpiler.to_hololang import TranspiladorHololang
 from cobra.transpilers.transpiler.to_julia import TranspiladorJulia
 from cobra.transpilers.transpiler.to_latex import TranspiladorLatex
 from cobra.transpilers.transpiler.to_llvm import TranspiladorLLVM
@@ -53,6 +54,7 @@ MAX_LANGUAGES = 10
 TRANSPILERS = {
     "python": TranspiladorPython,
     "js": TranspiladorJavaScript,
+    "hololang": TranspiladorHololang,
     "asm": TranspiladorASM,
     "rust": TranspiladorRust,
     "cpp": TranspiladorCPP,

--- a/src/pcobra/cobra/transpilers/common/utils.py
+++ b/src/pcobra/cobra/transpilers/common/utils.py
@@ -54,6 +54,10 @@ STANDARD_IMPORTS = {
         "import * as texto from './nativos/texto.js';",
         "import * as tiempo from './nativos/tiempo.js';",
     ],
+    "hololang": [
+        "use holo.core::*;",
+        "use holo.bits::*;",
+    ],
     "swift": [],
     "perl": [],
     "visualbasic": [],

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/__init__.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/__init__.py
@@ -1,0 +1,3 @@
+"""Nodos específicos para el transpilador de Hololang."""
+
+__all__ = []

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/asignacion.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/asignacion.py
@@ -1,0 +1,20 @@
+"""Visitadores de asignación para Hololang."""
+
+from cobra.transpilers.semantica import datos_asignacion
+
+
+def visit_asignacion(self, nodo):
+    """Transpila una instrucción de asignación a Hololang."""
+    nombre, valor, es_atributo = datos_asignacion(self, nodo)
+    tipo = getattr(nodo, "tipo", None)
+    if es_atributo:
+        declaracion = f"{nombre} = {valor};"
+    else:
+        prefijo = "let "
+        if getattr(nodo, "inferencia", False):
+            prefijo = ""
+        if tipo:
+            declaracion = f"{prefijo}{nombre}: {tipo} = {valor};"
+        else:
+            declaracion = f"{prefijo}{nombre} = {valor};"
+    self.agregar_linea(declaracion)

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/atributo.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/atributo.py
@@ -1,0 +1,6 @@
+"""Acceso a atributos en Hololang."""
+
+
+def visit_atributo(self, nodo):
+    """Transpila el acceso a un atributo como sentencia autónoma."""
+    self.agregar_linea(f"{self.obtener_valor(nodo)};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/bucle_mientras.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/bucle_mientras.py
@@ -1,0 +1,11 @@
+"""Nodo de bucle 'mientras' para Hololang."""
+
+from cobra.transpilers.semantica import procesar_bloque
+
+
+def visit_bucle_mientras(self, nodo):
+    """Transpila un bucle mientras a Hololang."""
+    condicion = self.obtener_valor(nodo.condicion)
+    self.agregar_linea(f"while ({condicion}) {{")
+    procesar_bloque(self, nodo.cuerpo)
+    self.agregar_linea("}")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/clase.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/clase.py
@@ -1,0 +1,12 @@
+"""Clases para Hololang."""
+
+from cobra.transpilers.semantica import procesar_bloque
+
+
+def visit_clase(self, nodo):
+    """Transpila la definición de una clase."""
+    genericos = f"<{', '.join(nodo.type_params)}>" if getattr(nodo, "type_params", []) else ""
+    bases = f" : {', '.join(nodo.bases)}" if getattr(nodo, "bases", []) else ""
+    self.agregar_linea(f"class {nodo.nombre}{genericos}{bases} {{")
+    procesar_bloque(self, nodo.metodos)
+    self.agregar_linea("}")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/condicional.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/condicional.py
@@ -1,0 +1,16 @@
+"""Nodo condicional para Hololang."""
+
+from cobra.transpilers.semantica import procesar_bloque
+
+
+def visit_condicional(self, nodo):
+    """Transpila una estructura condicional a Hololang."""
+    cuerpo_si = getattr(nodo, "bloque_si", getattr(nodo, "cuerpo_si", []))
+    cuerpo_sino = getattr(nodo, "bloque_sino", getattr(nodo, "cuerpo_sino", []))
+    condicion = self.obtener_valor(nodo.condicion)
+    self.agregar_linea(f"if ({condicion}) {{")
+    procesar_bloque(self, cuerpo_si)
+    if cuerpo_sino:
+        self.agregar_linea("} else {")
+        procesar_bloque(self, cuerpo_sino)
+    self.agregar_linea("}")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/continuar.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/continuar.py
@@ -1,0 +1,6 @@
+"""Sentencias ``continue`` en Hololang."""
+
+
+def visit_continuar(self, nodo):
+    """Transpila un ``continue``."""
+    self.agregar_linea("continue;")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/decorador.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/decorador.py
@@ -1,0 +1,7 @@
+"""Decoradores en Hololang."""
+
+
+def visit_decorador(self, nodo):
+    """Transpila un decorador antes de funciones o métodos."""
+    expresion = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"@{expresion}")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/diccionario.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/diccionario.py
@@ -1,0 +1,6 @@
+"""Diccionarios en Hololang."""
+
+
+def visit_diccionario(self, nodo):
+    """Transpila un literal de diccionario como instrucción."""
+    self.agregar_linea(f"{self.obtener_valor(nodo)};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/enum.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/enum.py
@@ -1,0 +1,11 @@
+"""Enumeraciones en Hololang."""
+
+
+def visit_enum(self, nodo):
+    """Transpila la definición de un enum."""
+    self.agregar_linea(f"enum {nodo.nombre} {{")
+    self.indentacion += 1
+    for miembro in nodo.miembros:
+        self.agregar_linea(f"{miembro},")
+    self.indentacion -= 1
+    self.agregar_linea("}")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/esperar.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/esperar.py
@@ -1,0 +1,8 @@
+"""Expresiones ``await`` en Hololang."""
+
+
+def visit_esperar(self, nodo):
+    """Transpila la espera de una operación asíncrona."""
+    self.requiere_async = True
+    expresion = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"await {expresion};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/for_.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/for_.py
@@ -1,0 +1,12 @@
+"""Bucle 'para' para Hololang."""
+
+from cobra.transpilers.semantica import procesar_bloque
+
+
+def visit_for(self, nodo):
+    """Transpila un bucle ``for`` a Hololang."""
+    variable = self.obtener_valor(nodo.variable)
+    iterable = self.obtener_valor(nodo.iterable)
+    self.agregar_linea(f"for ({variable} in {iterable}) {{")
+    procesar_bloque(self, nodo.cuerpo)
+    self.agregar_linea("}")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/funcion.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/funcion.py
@@ -1,0 +1,16 @@
+"""Funciones de Hololang."""
+
+from cobra.transpilers.semantica import procesar_bloque
+
+
+def visit_funcion(self, nodo):
+    """Transpila una función Cobra a Hololang."""
+    for decorador in getattr(nodo, "decoradores", []) or []:
+        expresion = self.obtener_valor(decorador.expresion)
+        self.agregar_linea(f"@{expresion}")
+    genericos = f"<{', '.join(nodo.type_params)}>" if getattr(nodo, "type_params", []) else ""
+    parametros = ", ".join(nodo.parametros)
+    prefijo = "async " if getattr(nodo, "asincronica", False) else ""
+    self.agregar_linea(f"{prefijo}fn {nodo.nombre}{genericos}({parametros}) {{")
+    procesar_bloque(self, nodo.cuerpo)
+    self.agregar_linea("}")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/graficar.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/graficar.py
@@ -1,0 +1,7 @@
+"""Visualización de holobits en Hololang."""
+
+
+def visit_graficar(self, nodo):
+    """Transpila la llamada ``graficar``."""
+    hb = self.obtener_valor(nodo.holobit)
+    self.agregar_linea(f"render({hb});")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/hilo.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/hilo.py
@@ -1,0 +1,7 @@
+"""Creación de hilos en Hololang."""
+
+
+def visit_hilo(self, nodo):
+    """Transpila la creación de un hilo."""
+    llamada = self.obtener_valor(nodo.llamada)
+    self.agregar_linea(f"spawn {llamada};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/holobit.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/holobit.py
@@ -1,0 +1,11 @@
+"""Soporte de holobits para Hololang."""
+
+
+def visit_holobit(self, nodo):
+    """Genera la creación de un holobit."""
+    valores = ", ".join(self.obtener_valor(v) for v in nodo.valores)
+    expresion = f"Holobit::new([{valores}])"
+    if getattr(nodo, "nombre", None):
+        self.agregar_linea(f"let {nodo.nombre} = {expresion};")
+    else:
+        self.agregar_linea(f"{expresion};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/identificador.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/identificador.py
@@ -1,0 +1,6 @@
+"""Identificadores en Hololang."""
+
+
+def visit_identificador(self, nodo):
+    """Transpila un identificador como sentencia autónoma."""
+    self.agregar_linea(f"{nodo.nombre};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/importar.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/importar.py
@@ -1,0 +1,19 @@
+"""Gestión de importaciones para Hololang."""
+
+from cobra.core import Lexer, Parser
+from cobra.transpilers.common.utils import load_mapped_module
+
+
+def visit_import(self, nodo):
+    """Transpila una instrucción ``import`` evaluando mapeos específicos."""
+    codigo, ruta = load_mapped_module(nodo.ruta, "hololang")
+    if ruta.endswith(".co"):
+        lexer = Lexer(codigo)
+        tokens = lexer.analizar_token()
+        ast = Parser(tokens).parsear()
+        for subnodo in ast:
+            subnodo.aceptar(self)
+    else:
+        for linea in codigo.splitlines():
+            if linea.strip():
+                self.agregar_linea(linea.rstrip())

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/imprimir.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/imprimir.py
@@ -1,0 +1,7 @@
+"""Impresión en Hololang."""
+
+
+def visit_imprimir(self, nodo):
+    """Transpila la instrucción ``imprimir``."""
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"print({valor});")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/instancia.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/instancia.py
@@ -1,0 +1,6 @@
+"""Instanciación de objetos en Hololang."""
+
+
+def visit_instancia(self, nodo):
+    """Transpila la creación de una instancia como sentencia."""
+    self.agregar_linea(f"{self.obtener_valor(nodo)};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/lista.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/lista.py
@@ -1,0 +1,6 @@
+"""Listas en Hololang."""
+
+
+def visit_lista(self, nodo):
+    """Transpila un literal de lista como instrucción independiente."""
+    self.agregar_linea(f"{self.obtener_valor(nodo)};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/llamada_funcion.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/llamada_funcion.py
@@ -1,0 +1,7 @@
+"""Llamadas a función en Hololang."""
+
+
+def visit_llamada_funcion(self, nodo):
+    """Transpila la llamada a una función."""
+    args = ", ".join(self.obtener_valor(arg) for arg in nodo.argumentos)
+    self.agregar_linea(f"{nodo.nombre}({args});")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/llamada_metodo.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/llamada_metodo.py
@@ -1,0 +1,8 @@
+"""Llamadas a métodos en Hololang."""
+
+
+def visit_llamada_metodo(self, nodo):
+    """Transpila la invocación de un método."""
+    args = ", ".join(self.obtener_valor(arg) for arg in nodo.argumentos)
+    objeto = self.obtener_valor(nodo.objeto)
+    self.agregar_linea(f"{objeto}.{nodo.nombre_metodo}({args});")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/metodo.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/metodo.py
@@ -1,0 +1,13 @@
+"""Métodos de clase en Hololang."""
+
+from cobra.transpilers.semantica import procesar_bloque
+
+
+def visit_metodo(self, nodo):
+    """Transpila un método perteneciente a una clase."""
+    genericos = f"<{', '.join(nodo.type_params)}>" if getattr(nodo, "type_params", []) else ""
+    parametros = ", ".join(nodo.parametros)
+    prefijo = "async " if getattr(nodo, "asincronica", False) else ""
+    self.agregar_linea(f"{prefijo}fn {nodo.nombre}{genericos}({parametros}) {{")
+    procesar_bloque(self, nodo.cuerpo)
+    self.agregar_linea("}")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/operacion_binaria.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/operacion_binaria.py
@@ -1,0 +1,6 @@
+"""Operaciones binarias para Hololang."""
+
+
+def visit_operacion_binaria(self, nodo):
+    """Transpila una operación binaria suelta."""
+    self.agregar_linea(f"{self.obtener_valor(nodo)};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/operacion_unaria.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/operacion_unaria.py
@@ -1,0 +1,6 @@
+"""Operaciones unarias en Hololang."""
+
+
+def visit_operacion_unaria(self, nodo):
+    """Transpila una operación unaria como sentencia."""
+    self.agregar_linea(f"{self.obtener_valor(nodo)};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/option.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/option.py
@@ -1,0 +1,7 @@
+"""Opciones en Hololang."""
+
+
+def visit_option(self, nodo):
+    """Transpila un valor opcional."""
+    valor = self.obtener_valor(nodo)
+    self.agregar_linea(f"{valor};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/para.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/para.py
@@ -1,0 +1,12 @@
+"""Bucle ``para`` específico para Hololang."""
+
+from cobra.transpilers.semantica import procesar_bloque
+
+
+def visit_para(self, nodo):
+    """Transpila un ``para`` (foreach) a Hololang."""
+    variable = self.obtener_valor(nodo.variable)
+    iterable = self.obtener_valor(nodo.iterable)
+    self.agregar_linea(f"foreach ({variable} in {iterable}) {{")
+    procesar_bloque(self, nodo.cuerpo)
+    self.agregar_linea("}")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/pasar.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/pasar.py
@@ -1,0 +1,6 @@
+"""Sentencia ``pasar`` para Hololang."""
+
+
+def visit_pasar(self, nodo):
+    """Transpila una operación nula."""
+    self.agregar_linea("// pass")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/proyectar.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/proyectar.py
@@ -1,0 +1,8 @@
+"""Operación de proyección para Hololang."""
+
+
+def visit_proyectar(self, nodo):
+    """Transpila la llamada a ``proyectar`` sobre un holobit."""
+    hb = self.obtener_valor(nodo.holobit)
+    modo = self.obtener_valor(nodo.modo)
+    self.agregar_linea(f"project({hb}, {modo});")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/retorno.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/retorno.py
@@ -1,0 +1,10 @@
+"""Declaraciones de retorno en Hololang."""
+
+
+def visit_retorno(self, nodo):
+    """Transpila un ``retorno``."""
+    if nodo.expresion is None:
+        self.agregar_linea("return;")
+    else:
+        valor = self.obtener_valor(nodo.expresion)
+        self.agregar_linea(f"return {valor};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/romper.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/romper.py
@@ -1,0 +1,6 @@
+"""Sentencias ``break`` en Hololang."""
+
+
+def visit_romper(self, nodo):
+    """Transpila un ``break``."""
+    self.agregar_linea("break;")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/switch.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/switch.py
@@ -1,0 +1,25 @@
+"""Estructura ``match`` para Hololang."""
+
+
+def visit_switch(self, nodo):
+    """Transpila una estructura de patrones estilo ``match``."""
+    expresion = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"match {expresion} {{")
+    self.indentacion += 1
+    for caso in nodo.casos:
+        valor = self.obtener_valor(caso.valor)
+        self.agregar_linea(f"{valor} => {{")
+        self.indentacion += 1
+        for instruccion in caso.cuerpo:
+            instruccion.aceptar(self)
+        self.indentacion -= 1
+        self.agregar_linea("},")
+    if getattr(nodo, "por_defecto", []):
+        self.agregar_linea("_ => {")
+        self.indentacion += 1
+        for instruccion in nodo.por_defecto:
+            instruccion.aceptar(self)
+        self.indentacion -= 1
+        self.agregar_linea("},")
+    self.indentacion -= 1
+    self.agregar_linea("};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/throw.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/throw.py
@@ -1,0 +1,7 @@
+"""Lanzamiento de excepciones para Hololang."""
+
+
+def visit_throw(self, nodo):
+    """Transpila ``throw``."""
+    expr = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"throw {expr};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/transformar.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/transformar.py
@@ -1,0 +1,12 @@
+"""Transformaciones de holobits para Hololang."""
+
+
+def visit_transformar(self, nodo):
+    """Transpila la instrucción ``transformar``."""
+    hb = self.obtener_valor(nodo.holobit)
+    operacion = self.obtener_valor(nodo.operacion)
+    parametros = ", ".join(self.obtener_valor(p) for p in nodo.parametros)
+    if parametros:
+        self.agregar_linea(f"transform({hb}, {operacion}, {parametros});")
+    else:
+        self.agregar_linea(f"transform({hb}, {operacion});")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/try_catch.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/try_catch.py
@@ -1,0 +1,17 @@
+"""Bloques try-catch en Hololang."""
+
+from cobra.transpilers.semantica import procesar_bloque
+
+
+def visit_try_catch(self, nodo):
+    """Transpila un bloque try/catch/finally."""
+    self.agregar_linea("try {")
+    procesar_bloque(self, nodo.bloque_try)
+    if getattr(nodo, "bloque_catch", []):
+        nombre = nodo.nombre_excepcion or "error"
+        self.agregar_linea(f"}} catch ({nombre}) {{")
+        procesar_bloque(self, nodo.bloque_catch)
+    if getattr(nodo, "bloque_finally", []):
+        self.agregar_linea("} finally {")
+        procesar_bloque(self, nodo.bloque_finally)
+    self.agregar_linea("}")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/usar.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/usar.py
@@ -1,0 +1,6 @@
+"""Instrucción ``usar`` para Hololang."""
+
+
+def visit_usar(self, nodo):
+    """Transpila la instrucción ``usar`` a una directiva ``use`` de Hololang."""
+    self.agregar_linea(f"use {nodo.modulo};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/valor.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/valor.py
@@ -1,0 +1,6 @@
+"""Valores literales en Hololang."""
+
+
+def visit_valor(self, nodo):
+    """Escribe un valor literal como sentencia independiente."""
+    self.agregar_linea(f"{self.obtener_valor(nodo)};")

--- a/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/yield_.py
+++ b/src/pcobra/cobra/transpilers/transpiler/hololang_nodes/yield_.py
@@ -1,0 +1,7 @@
+"""Soporte de ``yield`` en Hololang."""
+
+
+def visit_yield(self, nodo):
+    """Transpila la expresión ``yield``."""
+    valor = self.obtener_valor(nodo.expresion)
+    self.agregar_linea(f"yield {valor};")

--- a/src/pcobra/cobra/transpilers/transpiler/to_hololang.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_hololang.py
@@ -1,0 +1,403 @@
+"""Transpilador que convierte código Cobra a Hololang."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from cobra.core.ast_nodes import (
+    NodoAsignacion,
+    NodoCondicional,
+    NodoBucleMientras,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoHolobit,
+    NodoFor,
+    NodoLista,
+    NodoDiccionario,
+    NodoListaComprehension,
+    NodoDiccionarioComprehension,
+    NodoListaTipo,
+    NodoDiccionarioTipo,
+    NodoClase,
+    NodoEnum,
+    NodoInterface,
+    NodoMetodo,
+    NodoValor,
+    NodoRetorno,
+    NodoOperacionBinaria,
+    NodoOperacionUnaria,
+    NodoIdentificador,
+    NodoInstancia,
+    NodoLlamadaMetodo,
+    NodoAtributo,
+    NodoHilo,
+    NodoTryCatch,
+    NodoThrow,
+    NodoImport,
+    NodoImprimir,
+    NodoProyectar,
+    NodoTransformar,
+    NodoGraficar,
+    NodoAssert,
+    NodoDel,
+    NodoGlobal,
+    NodoNoLocal,
+    NodoLambda,
+    NodoWith,
+    NodoImportDesde,
+    NodoEsperar,
+    NodoOption,
+    NodoPattern,
+    NodoGuard,
+    NodoPara,
+)
+from cobra.core import TipoToken
+from cobra.transpilers.common.utils import BaseTranspiler, get_standard_imports
+from core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from cobra.macro import expandir_macros
+
+from cobra.transpilers.transpiler.hololang_nodes.asignacion import (
+    visit_asignacion as _visit_asignacion,
+)
+from cobra.transpilers.transpiler.hololang_nodes.condicional import (
+    visit_condicional as _visit_condicional,
+)
+from cobra.transpilers.transpiler.hololang_nodes.bucle_mientras import (
+    visit_bucle_mientras as _visit_bucle_mientras,
+)
+from cobra.transpilers.transpiler.hololang_nodes.for_ import visit_for as _visit_for
+from cobra.transpilers.transpiler.hololang_nodes.funcion import (
+    visit_funcion as _visit_funcion,
+)
+from cobra.transpilers.transpiler.hololang_nodes.llamada_funcion import (
+    visit_llamada_funcion as _visit_llamada_funcion,
+)
+from cobra.transpilers.transpiler.hololang_nodes.llamada_metodo import (
+    visit_llamada_metodo as _visit_llamada_metodo,
+)
+from cobra.transpilers.transpiler.hololang_nodes.imprimir import (
+    visit_imprimir as _visit_imprimir,
+)
+from cobra.transpilers.transpiler.hololang_nodes.retorno import (
+    visit_retorno as _visit_retorno,
+)
+from cobra.transpilers.transpiler.hololang_nodes.holobit import (
+    visit_holobit as _visit_holobit,
+)
+from cobra.transpilers.transpiler.hololang_nodes.lista import visit_lista as _visit_lista
+from cobra.transpilers.transpiler.hololang_nodes.diccionario import (
+    visit_diccionario as _visit_diccionario,
+)
+from cobra.transpilers.transpiler.hololang_nodes.clase import visit_clase as _visit_clase
+from cobra.transpilers.transpiler.hololang_nodes.metodo import (
+    visit_metodo as _visit_metodo,
+)
+from cobra.transpilers.transpiler.hololang_nodes.try_catch import (
+    visit_try_catch as _visit_try_catch,
+)
+from cobra.transpilers.transpiler.hololang_nodes.throw import visit_throw as _visit_throw
+from cobra.transpilers.transpiler.hololang_nodes.importar import (
+    visit_import as _visit_import,
+)
+from cobra.transpilers.transpiler.hololang_nodes.usar import visit_usar as _visit_usar
+from cobra.transpilers.transpiler.hololang_nodes.hilo import visit_hilo as _visit_hilo
+from cobra.transpilers.transpiler.hololang_nodes.instancia import (
+    visit_instancia as _visit_instancia,
+)
+from cobra.transpilers.transpiler.hololang_nodes.atributo import (
+    visit_atributo as _visit_atributo,
+)
+from cobra.transpilers.transpiler.hololang_nodes.proyectar import (
+    visit_proyectar as _visit_proyectar,
+)
+from cobra.transpilers.transpiler.hololang_nodes.transformar import (
+    visit_transformar as _visit_transformar,
+)
+from cobra.transpilers.transpiler.hololang_nodes.graficar import (
+    visit_graficar as _visit_graficar,
+)
+from cobra.transpilers.transpiler.hololang_nodes.operacion_binaria import (
+    visit_operacion_binaria as _visit_operacion_binaria,
+)
+from cobra.transpilers.transpiler.hololang_nodes.operacion_unaria import (
+    visit_operacion_unaria as _visit_operacion_unaria,
+)
+from cobra.transpilers.transpiler.hololang_nodes.valor import visit_valor as _visit_valor
+from cobra.transpilers.transpiler.hololang_nodes.identificador import (
+    visit_identificador as _visit_identificador,
+)
+from cobra.transpilers.transpiler.hololang_nodes.para import visit_para as _visit_para
+from cobra.transpilers.transpiler.hololang_nodes.decorador import (
+    visit_decorador as _visit_decorador,
+)
+from cobra.transpilers.transpiler.hololang_nodes.yield_ import (
+    visit_yield as _visit_yield,
+)
+from cobra.transpilers.transpiler.hololang_nodes.esperar import (
+    visit_esperar as _visit_esperar,
+)
+from cobra.transpilers.transpiler.hololang_nodes.romper import (
+    visit_romper as _visit_romper,
+)
+from cobra.transpilers.transpiler.hololang_nodes.continuar import (
+    visit_continuar as _visit_continuar,
+)
+from cobra.transpilers.transpiler.hololang_nodes.pasar import visit_pasar as _visit_pasar
+from cobra.transpilers.transpiler.hololang_nodes.switch import (
+    visit_switch as _visit_switch,
+)
+from cobra.transpilers.transpiler.hololang_nodes.option import (
+    visit_option as _visit_option,
+)
+from cobra.transpilers.transpiler.hololang_nodes.enum import visit_enum as _visit_enum
+
+
+ASYNC_IMPORT = "use holo.async::*;"
+
+
+def _extraer_lineas(imports: str | Iterable[str]) -> list[str]:
+    if isinstance(imports, str):
+        return [line for line in imports.splitlines() if line]
+    return list(imports)
+
+
+class TranspiladorHololang(BaseTranspiler):
+    """Genera código Hololang a partir de un AST de Cobra."""
+
+    def __init__(self):
+        self.codigo: list[str] = []
+        self.indentacion = 0
+        self.requiere_async = False
+
+    def _reiniciar_codigo(self) -> None:
+        base_imports = get_standard_imports("hololang")
+        self.codigo = _extraer_lineas(base_imports)
+        self.indentacion = 0
+        self.requiere_async = False
+
+    def generate_code(self, ast):
+        self._reiniciar_codigo()
+        codigo = self.transpilar(ast)
+        return codigo
+
+    def agregar_linea(self, linea: str) -> None:
+        self.codigo.append("    " * self.indentacion + linea)
+
+    def obtener_indentacion(self) -> str:
+        return "    " * self.indentacion
+
+    def transpilar(self, nodos):
+        nodos = expandir_macros(nodos)
+        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
+        for nodo in nodos:
+            nodo.aceptar(self)
+        if self.requiere_async and ASYNC_IMPORT not in self.codigo:
+            self.codigo.insert(0, ASYNC_IMPORT)
+        texto = "\n".join(self.codigo)
+        if texto and not texto.endswith("\n"):
+            texto += "\n"
+        return texto
+
+    def obtener_valor(self, nodo):  # noqa: C901 - requiere múltiples casos
+        if isinstance(nodo, NodoValor):
+            valor = nodo.valor
+            if isinstance(valor, bool):
+                return "true" if valor else "false"
+            if valor is None:
+                return "null"
+            if isinstance(valor, str):
+                return valor
+            return str(valor)
+        if isinstance(nodo, NodoAtributo):
+            obj = self.obtener_valor(nodo.objeto)
+            return f"{obj}.{nodo.nombre}"
+        if isinstance(nodo, NodoInstancia):
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"new {nodo.nombre_clase}({args})"
+        if isinstance(nodo, NodoIdentificador):
+            return nodo.nombre
+        if isinstance(nodo, NodoLlamadaFuncion):
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"{nodo.nombre}({args})"
+        if isinstance(nodo, NodoLlamadaMetodo):
+            obj = self.obtener_valor(nodo.objeto)
+            args = ", ".join(self.obtener_valor(a) for a in nodo.argumentos)
+            return f"{obj}.{nodo.nombre_metodo}({args})"
+        if isinstance(nodo, NodoOperacionBinaria):
+            izq = self.obtener_valor(nodo.izquierda)
+            der = self.obtener_valor(nodo.derecha)
+            op_map = {TipoToken.AND: "&&", TipoToken.OR: "||"}
+            op = op_map.get(nodo.operador.tipo, nodo.operador.valor)
+            return f"{izq} {op} {der}"
+        if isinstance(nodo, NodoOperacionUnaria):
+            val = self.obtener_valor(nodo.operando)
+            if nodo.operador.tipo == TipoToken.NOT:
+                return f"!{val}"
+            return f"{nodo.operador.valor}{val}"
+        if isinstance(nodo, NodoEsperar):
+            self.requiere_async = True
+            val = self.obtener_valor(nodo.expresion)
+            return f"await {val}"
+        if isinstance(nodo, NodoLambda):
+            params = ", ".join(nodo.parametros)
+            cuerpo = self.obtener_valor(nodo.cuerpo)
+            return f"|{params}| -> {cuerpo}"
+        if isinstance(nodo, NodoOption):
+            if nodo.valor is None:
+                return "Option::None"
+            return f"Option::Some({self.obtener_valor(nodo.valor)})"
+        if isinstance(nodo, NodoPattern):
+            if isinstance(nodo.valor, list):
+                elems = ", ".join(self.obtener_valor(v) for v in nodo.valor)
+                return f"({elems})"
+            if nodo.valor == "_":
+                return "_"
+            return self.obtener_valor(nodo.valor)
+        if isinstance(nodo, NodoGuard):
+            patron = self.obtener_valor(nodo.patron)
+            condicion = self.obtener_valor(nodo.condicion)
+            return f"{patron} if {condicion}"
+        if isinstance(nodo, NodoLista):
+            elems = ", ".join(self.obtener_valor(e) for e in nodo.elementos)
+            return f"[{elems}]"
+        if isinstance(nodo, NodoDiccionario):
+            pares = ", ".join(
+                f"{self.obtener_valor(k)}: {self.obtener_valor(v)}" for k, v in nodo.elementos
+            )
+            return f"{{{pares}}}"
+        if isinstance(nodo, NodoListaTipo):
+            elems = ", ".join(self.obtener_valor(e) for e in nodo.elementos)
+            return f"[{elems}]"
+        if isinstance(nodo, NodoDiccionarioTipo):
+            pares = ", ".join(
+                f"{self.obtener_valor(k)}: {self.obtener_valor(v)}" for k, v in nodo.elementos
+            )
+            return f"{{{pares}}}"
+        if isinstance(nodo, NodoListaComprehension):
+            expresion = self.obtener_valor(nodo.expresion)
+            iterable = self.obtener_valor(nodo.iterable)
+            condicion = (
+                f" if {self.obtener_valor(nodo.condicion)}" if nodo.condicion else ""
+            )
+            return f"[{expresion} for {nodo.variable} in {iterable}{condicion}]"
+        if isinstance(nodo, NodoDiccionarioComprehension):
+            clave = self.obtener_valor(nodo.clave)
+            valor = self.obtener_valor(nodo.valor)
+            iterable = self.obtener_valor(nodo.iterable)
+            condicion = (
+                f" if {self.obtener_valor(nodo.condicion)}" if nodo.condicion else ""
+            )
+            return f"{{{clave}: {valor} for {nodo.variable} in {iterable}{condicion}}}"
+        if isinstance(nodo, NodoHolobit):
+            valores = ", ".join(self.obtener_valor(v) for v in nodo.valores)
+            return f"Holobit::new([{valores}])"
+        return str(getattr(nodo, "valor", nodo))
+
+    # Implementaciones particulares no cubiertas por nodos externos
+    def visit_interface(self, nodo: NodoInterface):
+        self.agregar_linea(f"trait {nodo.nombre} {{")
+        self.indentacion += 1
+        for metodo in nodo.metodos:
+            params = ", ".join(metodo.parametros)
+            self.agregar_linea(f"fn {metodo.nombre}({params});")
+        self.indentacion -= 1
+        self.agregar_linea("}")
+
+    def visit_assert(self, nodo: NodoAssert):
+        condicion = self.obtener_valor(nodo.condicion)
+        mensaje = f", {self.obtener_valor(nodo.mensaje)}" if getattr(nodo, "mensaje", None) else ""
+        self.agregar_linea(f"assert {condicion}{mensaje};")
+
+    def visit_del(self, nodo: NodoDel):
+        objetivo = self.obtener_valor(nodo.objetivo)
+        self.agregar_linea(f"drop {objetivo};")
+
+    def visit_global(self, nodo: NodoGlobal):
+        nombres = ", ".join(nodo.nombres)
+        self.agregar_linea(f"// global {nombres}")
+
+    def visit_nolocal(self, nodo: NodoNoLocal):
+        nombres = ", ".join(nodo.nombres)
+        self.agregar_linea(f"// nonlocal {nombres}")
+
+    visit_no_local = visit_nolocal
+
+    def visit_with(self, nodo: NodoWith):
+        contexto = self.obtener_valor(nodo.contexto)
+        alias = f" as {nodo.alias}" if nodo.alias else ""
+        self.agregar_linea(f"with ({contexto}{alias}) {{")
+        self.indentacion += 1
+        for instruccion in nodo.cuerpo:
+            instruccion.aceptar(self)
+        self.indentacion -= 1
+        self.agregar_linea("}")
+
+    def visit_import_desde(self, nodo: NodoImportDesde):
+        alias = f" as {nodo.alias}" if nodo.alias else ""
+        self.agregar_linea(f"use {nodo.modulo}::{nodo.nombre}{alias};")
+
+    def visit_lista_tipo(self, nodo: NodoListaTipo):
+        elementos = ", ".join(self.obtener_valor(e) for e in nodo.elementos)
+        self.agregar_linea(
+            f"let {nodo.nombre}: list<{nodo.tipo}> = [{elementos}];"
+        )
+
+    def visit_diccionario_tipo(self, nodo: NodoDiccionarioTipo):
+        pares = ", ".join(
+            f"{self.obtener_valor(k)}: {self.obtener_valor(v)}" for k, v in nodo.elementos
+        )
+        self.agregar_linea(
+            "let {nombre}: map<{tk}, {tv}> = {{{pares}}};".format(
+                nombre=nodo.nombre,
+                tk=nodo.tipo_clave,
+                tv=nodo.tipo_valor,
+                pares=pares,
+            )
+        )
+
+    def visit_lista_comprehension(self, nodo: NodoListaComprehension):
+        self.agregar_linea(f"{self.obtener_valor(nodo)};")
+
+    def visit_diccionario_comprehension(self, nodo: NodoDiccionarioComprehension):
+        self.agregar_linea(f"{self.obtener_valor(nodo)};")
+
+
+# Asignar los visitantes externos a la clase
+TranspiladorHololang.visit_asignacion = _visit_asignacion
+TranspiladorHololang.visit_condicional = _visit_condicional
+TranspiladorHololang.visit_bucle_mientras = _visit_bucle_mientras
+TranspiladorHololang.visit_for = _visit_for
+TranspiladorHololang.visit_funcion = _visit_funcion
+TranspiladorHololang.visit_llamada_funcion = _visit_llamada_funcion
+TranspiladorHololang.visit_llamada_metodo = _visit_llamada_metodo
+TranspiladorHololang.visit_imprimir = _visit_imprimir
+TranspiladorHololang.visit_retorno = _visit_retorno
+TranspiladorHololang.visit_holobit = _visit_holobit
+TranspiladorHololang.visit_lista = _visit_lista
+TranspiladorHololang.visit_diccionario = _visit_diccionario
+TranspiladorHololang.visit_clase = _visit_clase
+TranspiladorHololang.visit_metodo = _visit_metodo
+TranspiladorHololang.visit_try_catch = _visit_try_catch
+TranspiladorHololang.visit_throw = _visit_throw
+TranspiladorHololang.visit_import = _visit_import
+TranspiladorHololang.visit_usar = _visit_usar
+TranspiladorHololang.visit_hilo = _visit_hilo
+TranspiladorHololang.visit_instancia = _visit_instancia
+TranspiladorHololang.visit_atributo = _visit_atributo
+TranspiladorHololang.visit_proyectar = _visit_proyectar
+TranspiladorHololang.visit_transformar = _visit_transformar
+TranspiladorHololang.visit_graficar = _visit_graficar
+TranspiladorHololang.visit_operacion_binaria = _visit_operacion_binaria
+TranspiladorHololang.visit_operacion_unaria = _visit_operacion_unaria
+TranspiladorHololang.visit_valor = _visit_valor
+TranspiladorHololang.visit_identificador = _visit_identificador
+TranspiladorHololang.visit_para = _visit_para
+TranspiladorHololang.visit_decorador = _visit_decorador
+TranspiladorHololang.visit_yield = _visit_yield
+TranspiladorHololang.visit_esperar = _visit_esperar
+TranspiladorHololang.visit_romper = _visit_romper
+TranspiladorHololang.visit_continuar = _visit_continuar
+TranspiladorHololang.visit_pasar = _visit_pasar
+TranspiladorHololang.visit_switch = _visit_switch
+TranspiladorHololang.visit_option = _visit_option
+TranspiladorHololang.visit_enum = _visit_enum

--- a/tests/unit/test_to_hololang.py
+++ b/tests/unit/test_to_hololang.py
@@ -1,0 +1,115 @@
+"""Pruebas unitarias para el transpilador de Hololang."""
+
+from cobra.core.ast_nodes import (
+    NodoAsignacion,
+    NodoCondicional,
+    NodoBucleMientras,
+    NodoFuncion,
+    NodoLlamadaFuncion,
+    NodoHolobit,
+    NodoValor,
+    NodoRetorno,
+    NodoIdentificador,
+    NodoEsperar,
+)
+from cobra.transpilers.import_helper import get_standard_imports
+from cobra.transpilers.transpiler.to_hololang import TranspiladorHololang
+
+IMPORTS = "".join(f"{line}\n" for line in get_standard_imports("hololang"))
+
+
+def test_transpilador_hololang_asignacion():
+    ast = [NodoAsignacion("x", NodoValor(10))]
+    transpiler = TranspiladorHololang()
+    resultado = transpiler.generate_code(ast)
+    esperado = IMPORTS + "let x = 10;\n"
+    assert resultado == esperado
+
+
+def test_transpilador_hololang_condicional():
+    ast = [
+        NodoCondicional(
+            "x > 5",
+            [NodoAsignacion("y", NodoValor(2))],
+            [NodoAsignacion("y", NodoValor(3))],
+        )
+    ]
+    transpiler = TranspiladorHololang()
+    resultado = transpiler.generate_code(ast)
+    esperado = (
+        IMPORTS
+        + "if (x > 5) {\n"
+        + "    let y = 2;\n"
+        + "} else {\n"
+        + "    let y = 3;\n"
+        + "}\n"
+    )
+    assert resultado == esperado
+
+
+def test_transpilador_hololang_mientras():
+    ast = [NodoBucleMientras("x > 0", [NodoAsignacion("x", "x - 1")])]
+    transpiler = TranspiladorHololang()
+    resultado = transpiler.generate_code(ast)
+    esperado = IMPORTS + "while (x > 0) {\n    let x = x - 1;\n}\n"
+    assert resultado == esperado
+
+
+def test_transpilador_hololang_funcion():
+    ast = [
+        NodoFuncion(
+            "sumar",
+            ["a", "b"],
+            [
+                NodoAsignacion("resultado", "a + b"),
+                NodoRetorno(NodoIdentificador("resultado")),
+            ],
+        )
+    ]
+    transpiler = TranspiladorHololang()
+    resultado = transpiler.generate_code(ast)
+    esperado = (
+        IMPORTS
+        + "fn sumar(a, b) {\n"
+        + "    let resultado = a + b;\n"
+        + "    return resultado;\n"
+        + "}\n"
+    )
+    assert resultado == esperado
+
+
+def test_transpilador_hololang_llamada_funcion():
+    ast = [NodoLlamadaFuncion("sumar", [1, 2])]
+    transpiler = TranspiladorHololang()
+    resultado = transpiler.generate_code(ast)
+    esperado = IMPORTS + "sumar(1, 2);\n"
+    assert resultado == esperado
+
+
+def test_transpilador_hololang_holobit():
+    ast = [NodoHolobit("miHolobit", [0.8, -0.5, 1.2])]
+    transpiler = TranspiladorHololang()
+    resultado = transpiler.generate_code(ast)
+    esperado = IMPORTS + "let miHolobit = Holobit::new([0.8, -0.5, 1.2]);\n"
+    assert resultado == esperado
+
+
+def test_transpilador_hololang_async_inserta_import():
+    ast = [
+        NodoFuncion(
+            "principal",
+            [],
+            [NodoEsperar(NodoLlamadaFuncion("trabajo", []))],
+            asincronica=True,
+        )
+    ]
+    transpiler = TranspiladorHololang()
+    resultado = transpiler.generate_code(ast)
+    esperado = (
+        "use holo.async::*;\n"
+        + IMPORTS
+        + "async fn principal() {\n"
+        + "    await trabajo();\n"
+        + "}\n"
+    )
+    assert resultado == esperado


### PR DESCRIPTION
## Summary
- add a Hololang transpiler that wires dedicated visitors and manages async imports
- register Hololang defaults in the transpiler registry and provide base imports
- cover Hololang generation for basic constructs and holobits with unit tests

## Testing
- pytest tests/unit/test_to_hololang.py --override-ini="addopts="

------
https://chatgpt.com/codex/tasks/task_e_68c97d0811048327b8293c6586c48e9c