### PR TITLE
Add Hololang backend option and CLI tests

### DIFF
--- a/docs/frontend/cli.rst
+++ b/docs/frontend/cli.rst
@@ -15,9 +15,11 @@ Transpila un archivo Cobra a otro lenguaje.
 Opciones principales:
 
 - ``archivo``: ruta del script ``.co``.
-- ``--tipo``: lenguaje de salida (``python``, ``js``, ``asm``, ``rust``,
-  ``cpp``, ``go``, ``ruby``, ``r``, ``julia``, ``java``, ``cobol``,
+- ``--tipo``: lenguaje de salida (``python``, ``js``, ``hololang``, ``asm``,
+  ``rust``, ``cpp``, ``go``, ``ruby``, ``r``, ``julia``, ``java``, ``cobol``,
   ``fortran``, ``pascal``, ``php``, ``matlab``, ``latex``, ``wasm``).
+- ``--backend``: alias de ``--tipo`` útil para integraciones automatizadas.
+  Admite los mismos lenguajes disponibles, incluido ``hololang``.
 - ``--tipos``: lista de lenguajes separados por comas para transpilación paralela.
 
 Ejemplo:

--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -69,6 +69,13 @@ transpilar_parser.add_argument(
     help="Lenguaje de salida",
 )
 transpilar_parser.add_argument(
+    "--backend",
+    dest="backend",
+    choices=LANG_CHOICES,
+    default=None,
+    help="Alias de --lenguaje para integraciones",
+)
+transpilar_parser.add_argument(
     "--o", "--salida",
     dest="salida",
     help="Archivo donde guardar el código generado",
@@ -101,7 +108,10 @@ def main(argumentos: Optional[List[str]] = None) -> int:
     if args.comando == "transpilar":
         comando = CompileCommand()
         compile_args = argparse.Namespace(
-            archivo=args.archivo, tipo=args.lenguaje, backend=None, tipos=None
+            archivo=args.archivo,
+            tipo=args.lenguaje,
+            backend=getattr(args, "backend", None),
+            tipos=None,
         )
         if args.salida:
             messages.disable_colors()

--- a/src/pcobra/cobra/cli/__init__.py
+++ b/src/pcobra/cobra/cli/__init__.py
@@ -7,6 +7,7 @@ de línea de comandos del lenguaje Cobra, incluyendo:
 - Procesamiento de argumentos
 - Gestión de comandos
 - Utilidades de CLI
+- Selección de *backends* como ``hololang`` mediante la opción ``--backend``
 
 Para más información, consulte la documentación completa.
 """

--- a/src/pcobra/cobra/transpilers/reverse/__init__.py
+++ b/src/pcobra/cobra/transpilers/reverse/__init__.py
@@ -43,6 +43,7 @@ _MODULOS = [
     "cobra.transpilers.reverse.from_pascal",
     "cobra.transpilers.reverse.from_visualbasic",
     "cobra.transpilers.reverse.from_wasm",
+    "pcobra.cobra.reverse",
 ]
 
 # Importaciones seguras -------------------------------------------------

--- a/tests/integration/test_cli_hololang.py
+++ b/tests/integration/test_cli_hololang.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import os
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import pcobra  # noqa: F401 - asegura el registro de paquetes
+import cobra.cli.i18n as cli_i18n
+from cobra.cli.cli import main
+from cobra.cli.utils import messages
+from cobra.transpilers import module_map
+import core.ast_cache as ast_cache
+from pcobra.cobra.core import Lexer as CobraLexer, Parser as CobraParser
+from cobra.cli.commands import compile_cmd as compile_module
+
+
+
+def _run_cli(arguments: list[str]) -> tuple[int, str]:
+    with messages.color_disabled():
+        with patch("sys.stdout", new_callable=StringIO) as stdout:
+            exit_code = main(arguments)
+    return exit_code, stdout.getvalue()
+
+
+@pytest.mark.timeout(5)
+def test_cli_compilar_backend_hololang(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    locale_dir = tmp_path / "locale"
+    locale_dir.mkdir()
+    monkeypatch.setattr(cli_i18n, "LOCALE_DIR", locale_dir)
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: {})
+    monkeypatch.setenv("COBRA_TOML", str(tmp_path / "missing.toml"))
+    monkeypatch.setenv("COBRA_AST_CACHE", str(tmp_path / "cache"))
+
+    def _parse(code: str):
+        tokens = CobraLexer(code).tokenizar()
+        return CobraParser(tokens).parsear()
+
+    monkeypatch.setattr(ast_cache, "obtener_ast", _parse)
+    monkeypatch.setattr(compile_module, "obtener_ast", _parse)
+
+    archivo = tmp_path / "saludo.co"
+    archivo.write_text('imprimir("hola")\n', encoding="utf-8")
+
+    exit_code, salida = _run_cli(["compilar", str(archivo), "--backend", "hololang"])
+
+    assert exit_code == 0
+    assert "Código generado" in salida
+    assert "print(hola);" in salida
+
+
+@pytest.mark.timeout(5)
+def test_cli_transpilar_inverso_desde_hololang(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    locale_dir = tmp_path / "locale"
+    locale_dir.mkdir()
+    monkeypatch.setattr(cli_i18n, "LOCALE_DIR", locale_dir)
+    monkeypatch.setattr(module_map, "get_toml_map", lambda: {})
+    monkeypatch.setenv("COBRA_TOML", str(tmp_path / "missing.toml"))
+    monkeypatch.setenv("COBRA_AST_CACHE", str(tmp_path / "cache"))
+
+    def _parse(code: str):
+        tokens = CobraLexer(code).tokenizar()
+        return CobraParser(tokens).parsear()
+
+    monkeypatch.setattr(ast_cache, "obtener_ast", _parse)
+    monkeypatch.setattr(compile_module, "obtener_ast", _parse)
+
+    archivo = tmp_path / "saludo.holo"
+    archivo.write_text('let saludo = "hola";\nprint(saludo);\n', encoding="utf-8")
+
+    exit_code, salida = _run_cli(
+        [
+            "transpilar-inverso",
+            str(archivo),
+            "--origen",
+            "hololang",
+            "--destino",
+            "python",
+        ]
+    )
+
+    assert exit_code == 0
+    assert "Código transpilado" in salida
+    assert "saludo = hola" in salida
+    assert "print(saludo)" in salida


### PR DESCRIPTION
## Summary
- allow the legacy `cobra transpilar` command to accept the `--backend` flag and forward it to the compiler
- document the new Hololang backend option in the CLI package docstring and user guide
- register the Hololang reverse transpiler module and add integration tests for Hololang forward and reverse CLI flows

## Testing
- `pytest --override-ini addopts="" -p no:cov tests/integration/test_cli_hololang.py`


------
https://chatgpt.com/codex/tasks/task_e_68ca601b0ac083279989b3e710afd160