### PR TITLE
docs: añadir guía de Hololang y ejemplos de transpilación

### DIFF
--- a/docs/frontend/caracteristicas.rst
+++ b/docs/frontend/caracteristicas.rst
@@ -4,6 +4,7 @@ Caracteristicas principales de Cobra
 - **Sintaxis en espanol**: Todas las palabras clave y estructuras del lenguaje estan en español, para facilitar su uso por hablantes nativos.
 - **Gestion de memoria automatica**: Cobra incorpora un sistema de manejo de memoria basado en algoritmos genéticos que optimiza el uso de los recursos durante la ejecución.
 - **Soporte para holobits**: Un tipo de dato multidimensional que permite trabajar con datos de alta complejidad.
+- **Interoperabilidad con Hololang**: El transpilador genera un IR intermedio expresado en Hololang, lo que permite convertir proyectos Cobra a múltiples lenguajes e importar código Hololang mediante la cadena ``transpilar-inverso``.
 - **Transpiler a Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly**: Los programas escritos en Cobra pueden ser transpilados a estos lenguajes, lo que permite su ejecucion en una variedad de plataformas.
 - **Nombres Unicode**: Los identificadores aceptan caracteres como `á`, `ñ` o `Ω`.
 

--- a/docs/frontend/ejemplos.rst
+++ b/docs/frontend/ejemplos.rst
@@ -29,3 +29,17 @@ Excepciones y hilos
        hilo tarea()
    catch e:
        imprimir(e)
+
+Transpilación con Hololang
+--------------------------
+Los archivos disponibles en ``examples/hololang`` muestran cómo convertir
+programas Cobra a Hololang y viceversa, además de generar salidas en Python o
+ensamblador.  Ejecuta, por ejemplo:
+
+.. code-block:: bash
+
+   cobra compilar examples/hololang/saludo.co --backend hololang
+   cobra transpilar-inverso examples/hololang/saludo.holo --origen hololang --destino python
+
+El primer comando imprime la versión Hololang del programa ``saludo.co`` y el
+segundo parte desde Hololang para reconstruir el código Python equivalente.

--- a/docs/frontend/hololang.rst
+++ b/docs/frontend/hololang.rst
@@ -1,0 +1,100 @@
+Hololang: sintaxis e interoperabilidad
+======================================
+
+Hololang es el lenguaje intermedio utilizado por Cobra para describir programas
+orientados a holobits con un estilo declarativo inspirado en Rust.  Su IR
+funciona como un punto de encuentro entre el AST de Cobra y los backends que
+emiten código para otros lenguajes o para ensamblador simbólico.  En esta guía
+se resume la sintaxis disponible, cómo integrarla con Cobra y cómo aprovecharla
+para generar artefactos adicionales.
+
+Sintaxis básica de Hololang
+---------------------------
+
+Todo archivo Hololang comienza importando los módulos estándar generados por el
+transpilador:
+
+.. code-block:: hololang
+
+   use holo.core::*;
+   use holo.bits::*;
+
+A partir de ahí se pueden declarar variables, funciones y holobits utilizando la
+siguiente gramática:
+
+* Declaraciones: ``let`` crea variables inmutables y admite anotaciones de tipo
+  opcionales.
+* Funciones: ``fn`` define rutinas con parámetros separados por comas.
+* Bloques: se delimitan con llaves ``{`` y ``}``.
+* Impresión: ``print(expr);`` envía datos a la salida estándar.
+* Holobits: ``holobit([1.0, -0.5, 0.8]);`` construye estructuras multidimensionales.
+
+Ejemplo completo generado a partir de un programa Cobra:
+
+.. code-block:: hololang
+
+   use holo.core::*;
+   use holo.bits::*;
+
+   let saludo = "Hola desde Hololang";
+
+   fn principal() {
+       let espectro = holobit([0.8, -0.5, 1.2]);
+       print(saludo);
+       print("Norma:" + norma(espectro));
+   }
+
+   fn norma(holo) {
+       return magnitud(holo);
+   }
+
+Interoperar con Cobra
+---------------------
+
+La CLI de Cobra expone comandos para convertir código entre ambos lenguajes:
+
+* **De Cobra a Hololang:**
+
+  .. code-block:: bash
+
+     cobra compilar examples/hololang/saludo.co --backend hololang
+
+  El comando anterior muestra por pantalla el Hololang equivalente y puede
+  guardarse con ``--salida``.
+
+* **De Hololang a Cobra y otros backends:**
+
+  .. code-block:: bash
+
+     cobra transpilar-inverso examples/hololang/saludo.holo \
+         --origen hololang \
+         --destino python
+
+  ``transpilar-inverso`` analiza el código Hololang, lo convierte al AST de
+  Cobra y, a continuación, vuelve a emitirlo con el transpilador seleccionado.
+  Si deseas reconstruir una versión canónica en Hololang basta con indicar
+  ``--destino hololang``.
+
+Generación de ensamblador desde Hololang
+----------------------------------------
+
+Una vez que dispones del código Hololang, puedes obtener ensamblador simbólico
+empleando la misma cadena de transpilación inversa:
+
+.. code-block:: bash
+
+   cobra transpilar-inverso examples/hololang/saludo.holo \
+       --origen hololang \
+       --destino asm
+
+El transpilador ``asm`` consume el IR de Hololang y produce instrucciones
+legibles que describen asignaciones, saltos condicionales y bucles.  Esto es
+útil para auditar optimizaciones o para integrarse con herramientas de nivel
+inferior.
+
+Recursos adicionales
+--------------------
+
+* Consulta :doc:`sintaxis` para repasar el lenguaje original de Cobra.
+* En ``examples/hololang`` encontrarás archivos listos para realizar las
+  conversiones mostradas en esta página.

--- a/docs/frontend/index.rst
+++ b/docs/frontend/index.rst
@@ -21,6 +21,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    ../../docs/lenguajes_soportados
    ../../docs/lenguajes
    sintaxis
+   hololang
    avances
    proximos_pasos
    optimizaciones
@@ -57,7 +58,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
 Introducción
 --------------------
 
-Cobra fue creado con la idea de facilitar la programacion en español, optimizando la gestion de memoria y anadiendo soporte para trabajar con datos de alta complejidad como los holobits. Ademas, ofrece soporte para generar código en Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly, permitiendo su ejecucion en multiples plataformas.
+Cobra fue creado con la idea de facilitar la programacion en español, optimizando la gestion de memoria y anadiendo soporte para trabajar con datos de alta complejidad como los holobits. Su cadena de compilación incorpora Hololang como lenguaje intermedio para coordinar la transpilación hacia distintos backends. Ademas, ofrece soporte para generar código en Python, JavaScript, ensamblador, Rust, C++, Go, Kotlin, Swift, R, Julia, Java, COBOL, Fortran, Pascal, Ruby, PHP, Perl, VisualBasic, Matlab, Mojo, LaTeX, C y WebAssembly, permitiendo su ejecucion en multiples plataformas.
 
 
 

--- a/examples/hololang/README.md
+++ b/examples/hololang/README.md
@@ -1,0 +1,50 @@
+# Hololang y transpilación cruzada
+
+Este directorio reúne fragmentos mínimos que ilustran el flujo de trabajo entre
+Cobra y Hololang.  Los comandos están pensados para ejecutarse desde la raíz del
+repositorio.
+
+## Archivos
+
+- `saludo.co`: versión en Cobra del ejemplo básico con holobits.
+- `saludo.holo`: contraparte Hololang generada por el transpilador.
+
+## De Cobra a Hololang
+
+```bash
+cobra compilar examples/hololang/saludo.co --backend hololang --salida saludo.holo
+```
+
+El parámetro `--salida` guarda la traducción en un archivo.  Si lo omites, la
+salida se muestra por consola.
+
+## Hololang de vuelta a Cobra
+
+```bash
+cobra transpilar-inverso examples/hololang/saludo.holo --origen hololang --destino hololang
+```
+
+El comando `transpilar-inverso` parsea el código Hololang, lo convierte al AST
+de Cobra y lo reemite con el transpilador seleccionado.  Aunque en este ejemplo
+se vuelve a generar Hololang, el paso intermedio valida que la estructura del
+programa sea compatible con Cobra.
+
+Para inspeccionar cómo se vería el mismo programa si el destino fuera Python
+puedes ejecutar:
+
+```bash
+cobra transpilar-inverso examples/hololang/saludo.holo --origen hololang --destino python
+```
+
+## Hololang a otros lenguajes
+
+Desde los mismos archivos puedes emitir ensamblador simbólico u otros backends
+soportados:
+
+```bash
+cobra transpilar-inverso examples/hololang/saludo.holo --origen hololang --destino asm
+cobra transpilar-inverso examples/hololang/saludo.holo --origen hololang --destino rust
+```
+
+El primer comando produce instrucciones de bajo nivel basadas en el IR de
+Hololang, mientras que el segundo genera una implementación equivalente en Rust.

--- a/examples/hololang/saludo.co
+++ b/examples/hololang/saludo.co
@@ -1,0 +1,11 @@
+var saludo = "Hola desde Cobra"
+
+func principal() :
+    var espectro = holobit([0.8, -0.5, 1.2])
+    imprimir(saludo)
+    imprimir("Norma: " + norma(espectro))
+fin
+
+func norma(holo) :
+    return magnitud(holo)
+fin

--- a/examples/hololang/saludo.holo
+++ b/examples/hololang/saludo.holo
@@ -1,0 +1,14 @@
+use holo.core::*;
+use holo.bits::*;
+
+let saludo = "Hola desde Hololang";
+
+fn principal() {
+    let espectro = holobit([0.8, -0.5, 1.2]);
+    print(saludo);
+    print("Norma: " + norma(espectro));
+}
+
+fn norma(holo) {
+    return magnitud(holo);
+}


### PR DESCRIPTION
## Resumen
- agregar la página `hololang.rst` con sintaxis básica, interoperabilidad con Cobra y guía para generar ensamblador
- enlazar Hololang desde el índice, características y ejemplos de la documentación
- incorporar ejemplos en `examples/hololang/` que demuestran la transpilación Cobra↔Hololang y Hololang hacia otros lenguajes

## Pruebas
- no se ejecutaron pruebas; solo se actualizaron documentos y archivos de ejemplo

------
https://chatgpt.com/codex/tasks/task_e_68ca654469fc832784809c8a0aec5959