### PR TITLE
Ajustar validación de dependencias al elegir backend

### DIFF
--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -165,13 +165,15 @@ class CompileCommand(BaseCommand):
             return 1
 
         mod_info = module_map.get_toml_map()
+        transpilador_objetivo = getattr(args, "backend", None) or args.tipo
+
         try:
             if getattr(args, "tipos", None):
                 langs = [t.strip() for t in args.tipos.split(",") if t.strip()]
                 for lang in langs:
                     validar_dependencias(lang, mod_info)
             else:
-                validar_dependencias(args.tipo, mod_info)
+                validar_dependencias(transpilador_objetivo, mod_info)
         except (ValueError, FileNotFoundError) as dep_err:
             mostrar_error(f"Error de dependencias: {dep_err}")
             return 1
@@ -204,7 +206,7 @@ class CompileCommand(BaseCommand):
                     mostrar_error(_("Tiempo de ejecución excedido"))
                     return 1
             else:
-                transpilador = args.tipo if not getattr(args, "backend", None) else args.backend
+                transpilador = transpilador_objetivo
                 if transpilador not in TRANSPILERS:
                     raise ValueError(_("Transpilador no soportado."))
                 transp = TRANSPILERS[transpilador]()

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -198,7 +198,11 @@ class InteractiveCommand(BaseCommand):
             # Validar dependencias
             validar_dependencias("python", module_map.get_toml_map())
         except (ValueError, FileNotFoundError) as err:
-            mostrar_error(_("Error de inicialización: {err}").format(err=err))
+            mostrar_error(
+                _("Error de dependencias durante la inicialización: {err}").format(
+                    err=err
+                )
+            )
             return 1
 
         # Configurar modo seguro y validadores


### PR DESCRIPTION
## Summary
- reutilizar un backend efectivo común en el comando `compilar` antes de validar dependencias y al crear el transpilador seleccionado
- armonizar el mensaje de error inicial del modo interactivo para reportar fallos de dependencias de forma consistente

## Testing
- `PYTEST_ADDOPTS="--cov-fail-under=0" pytest tests/unit/test_validar_dependencias.py`


------
https://chatgpt.com/codex/tasks/task_e_68ca6bd413988327b65860a2b7214cb9