### PR TITLE
docs: ampliar información de Hololang en changelog y guías

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v10.1.0 - 2025-08-24
+- Integración completa de Hololang como lenguaje intermedio oficial del compilador.
+- Reestructuración de la cadena de transpilación para emitir Hololang antes de despachar a cada backend.
+- Incorporación del generador de ensamblador basado en el IR de Hololang y documentación asociada.
+
 ## v10.0.10 - Pendiente de liberación
 - Actualización de la dependencia `agix` a la versión 1.6.0.
 - Mejora de rendimiento y compatibilidad derivada de esta actualización.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ El objetivo de pCobra es brindar a la comunidad hispanohablante una alternativa 
 ## Tabla de Contenidos
 
 - Descripción del Proyecto
+- Arquitectura centrada en Hololang
 - Instalación
 - Cómo usar la CLI
 - Descargas
@@ -101,6 +102,16 @@ Puedes experimentar con Cobra directamente en tu navegador:
 Cobra está diseñado para facilitar la programación en español, permitiendo que los desarrolladores utilicen un lenguaje más accesible. A través de su lexer, parser y transpiladores, Cobra puede analizar, ejecutar y convertir código a otros lenguajes, brindando soporte para variables, funciones, estructuras de control y estructuras de datos como listas, diccionarios y clases.
 Para un tutorial paso a paso consulta el [Manual de Cobra](docs/MANUAL_COBRA.rst).
 La especificación completa del lenguaje se encuentra en [SPEC_COBRA.md](docs/SPEC_COBRA.md).
+
+## Arquitectura centrada en Hololang
+
+La cadena de herramientas de Cobra se articula alrededor de Hololang, un lenguaje intermedio diseñado para describir los programas de forma explícita y portable. El flujo principal funciona de la siguiente manera:
+
+1. El front-end analiza el código fuente y construye el AST de Cobra.
+2. Ese AST se normaliza y se transforma en representaciones Hololang que capturan estructuras de control, módulos y tipos.
+3. Los transpiladores consumen el IR Hololang para generar código en los distintos backends soportados.
+
+Hololang actúa como contrato estable entre el front-end y los generadores de código, permitiendo incorporar nuevos destinos sin modificar el parser original. Gracias a esta capa intermedia, Cobra ofrece un generador de ensamblador que produce instrucciones simbólicas optimizadas para depuración y diagnóstico de rendimiento. El comando `cobra transpila` puede emitir directamente los ficheros Hololang o derivarlos a `asm` para obtener la salida en ensamblador.
 
 ## Instalación
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -13,6 +13,7 @@ Cobra is a programming language designed in Spanish, aimed at creating tools, si
 ## Table of Contents
 
 - Project Description
+- Hololang-centric architecture
 - Installation
 - Project Structure
 - Supported tools and scripts
@@ -77,6 +78,16 @@ You can experiment with Cobra directly in your browser:
 ## Project Description
 
 Cobra is designed to make programming in Spanish easier, allowing developers to use a more accessible language. Through its lexer, parser and transpilers, Cobra can analyze, execute and convert code to other languages, providing support for variables, functions, control structures and data structures such as lists, dictionaries and classes. For a step-by-step tutorial check the [Cobra Manual](MANUAL_COBRA.rst). The full language specification is available in [SPEC_COBRA.md](SPEC_COBRA.md).
+
+## Hololang-centric architecture
+
+Cobra's toolchain revolves around Hololang, an intermediate language that captures the program semantics in a portable format. The main flow works as follows:
+
+1. The front-end parses the source code and builds the Cobra AST.
+2. That AST is normalized and lowered into Hololang representations that encode control structures, modules and types.
+3. The transpilers consume the Hololang IR to generate code for each supported backend.
+
+Hololang acts as a stable contract between the front-end and the code generators, enabling new targets without touching the original parser. Thanks to this intermediate layer Cobra ships an assembler generator that emits symbolic instructions focused on debugging and performance diagnostics. The `cobra transpila` command can output Hololang files directly or route them to the `asm` backend to obtain assembly listings.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- document the Hololang integration release with its main features in the changelog
- describe the Hololang-centric architecture and its assembly backend in the Spanish README
- mirror the architecture section in the English documentation README to keep both languages aligned

## Testing
- no tests were run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68ca73fbf4a883278c2bb8315fc67880