### PR TITLE
Manejar error de archivo inexistente en comando ejecutar

### DIFF
--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -55,8 +55,18 @@ class ExecuteCommand(BaseCommand):
 
         Raises:
             ValueError: Si el archivo no existe o excede el tamaño máximo
+                permitido. Los errores de archivo inexistente se convierten
+                en ValueError con un mensaje amigable para la CLI.
         """
-        ruta = validar_archivo_existente(archivo)
+        try:
+            ruta = validar_archivo_existente(archivo)
+        except FileNotFoundError as exc:
+            raise ValueError(
+                _(
+                    "No se encontró el archivo '{path}'. "
+                    "Verifica la ruta e inténtalo de nuevo."
+                ).format(path=archivo)
+            ) from exc
         if ruta.stat().st_size > self.MAX_FILE_SIZE:
             raise ValueError(f"El archivo excede el tamaño máximo permitido ({self.MAX_FILE_SIZE} bytes)")
 

--- a/tests/unit/test_cli_execute_missing_file.py
+++ b/tests/unit/test_cli_execute_missing_file.py
@@ -1,13 +1,16 @@
-import pytest
 from argparse import Namespace
 
 from cobra.cli.commands.execute_cmd import ExecuteCommand
+from cobra.cli.utils.messages import color_disabled
 
 
-def test_cli_ejecutar_archivo_inexistente(tmp_path):
+def test_cli_ejecutar_archivo_inexistente(tmp_path, capsys):
     archivo = tmp_path / "no.co"
     cmd = ExecuteCommand()
     args = Namespace(archivo=str(archivo), sandbox=False, contenedor=None)
-    with pytest.raises(FileNotFoundError) as exc:
-        cmd.run(args)
-    assert f"El archivo '{archivo}' no existe" in str(exc.value)
+    with color_disabled():
+        codigo_salida = cmd.run(args)
+    assert codigo_salida == 1
+    salida = capsys.readouterr().out
+    assert "No se encontró el archivo" in salida
+    assert str(archivo) in salida


### PR DESCRIPTION
## Summary
- convierte el FileNotFoundError de la validación de archivos del comando `ejecutar` en un ValueError con un mensaje más amigable para la CLI
- actualiza la documentación interna del validador para reflejar la conversión
- ajusta la prueba unitaria para comprobar el mensaje mostrado y el código de salida cuando el archivo no existe

## Testing
- pytest tests/unit/test_cli_execute_missing_file.py --cov-fail-under=0

------
https://chatgpt.com/codex/tasks/task_e_68ca76158c1c8327b6fcd991f37aa527