### PR TITLE
Fix parallel compile timeout handling and add CLI regression tests

### DIFF
--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -115,10 +115,11 @@ def run_transpiler_pool(languages: list, ast, executor) -> list:
     if len(languages) > MAX_LANGUAGES:
         raise ValueError(_("Demasiados lenguajes especificados"))
     with multiprocessing.Pool(processes=min(len(languages), MAX_PROCESSES)) as pool:
+        # ``map_async`` no acepta ``timeout`` como argumento, por lo que el límite
+        # de ejecución se controla exclusivamente mediante ``AsyncResult.get``.
         return pool.map_async(
             executor,
             [(lang, ast) for lang in languages],
-            timeout=PROCESS_TIMEOUT
         ).get(timeout=PROCESS_TIMEOUT)
 
 class CompileCommand(BaseCommand):

--- a/tests/unit/test_cli_compilar_tipos.py
+++ b/tests/unit/test_cli_compilar_tipos.py
@@ -1,0 +1,80 @@
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.timeout(5)
+def test_cli_compilar_con_tipos(tmp_path, monkeypatch):
+    """Ejecuta ``cobra compilar`` con ``--tipos`` sin errores de tipo."""
+
+    from pcobra.cobra.cli import cli as cli_module
+    from pcobra.cobra.cli.commands import compile_cmd as compile_module
+
+    # Evita dependencias externas de localización y banner interactivo.
+    monkeypatch.setattr(cli_module, "setup_gettext", lambda lang=None: (lambda s: s))
+    monkeypatch.setattr(cli_module.messages, "mostrar_logo", lambda: None)
+    monkeypatch.setattr(cli_module.messages, "disable_colors", lambda *args, **kwargs: None)
+
+    monkeypatch.setattr(cli_module.AppConfig, "BASE_COMMAND_CLASSES", [compile_module.CompileCommand])
+
+    class DummyInterpreter:
+        def cleanup(self):
+            pass
+
+    monkeypatch.setattr(cli_module, "InterpretadorCobra", DummyInterpreter)
+
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("COBRA_AST_CACHE", str(cache_dir))
+
+    class DummyNode:
+        def aceptar(self, _visitor):
+            return None
+
+    monkeypatch.setattr(compile_module, "validate_file", lambda _path: True)
+    monkeypatch.setattr(compile_module, "obtener_ast", lambda _codigo: [DummyNode()])
+    monkeypatch.setattr(compile_module, "construir_cadena", lambda: lambda nodo: None)
+    monkeypatch.setattr(compile_module, "validar_dependencias", lambda *a, **k: None)
+
+    class FakePython:
+        def generate_code(self, _ast):
+            return "py"
+
+    class FakeJS:
+        def generate_code(self, _ast):
+            return "js"
+
+    monkeypatch.setattr(compile_module, "TRANSPILERS", {"python": FakePython, "js": FakeJS})
+
+    class DummyPool:
+        def __init__(self, processes=None):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def map_async(self, func, iterable, chunksize=None):
+            class Result:
+                def __init__(self, data):
+                    self._data = data
+
+                def get(self, timeout=None):
+                    return self._data
+
+            return Result([func(item) for item in iterable])
+
+    monkeypatch.setattr(compile_module.multiprocessing, "Pool", DummyPool)
+
+    archivo = tmp_path / "programa.co"
+    archivo.write_text("var x = 5")
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        exit_code = cli_module.main(["compilar", str(archivo), "--tipos=python,js"])
+
+    assert exit_code == 0
+    salida = out.getvalue()
+    assert "Código generado (FakePython) para python:" in salida
+    assert "Código generado (FakeJS) para js:" in salida


### PR DESCRIPTION
## Summary
- remove the unsupported timeout argument from `pool.map_async` and document how the timeout is enforced
- extend the parallel transpiler unit test to assert the timeout usage and cover the timeout error path
- add a CLI-level regression test for `compilar --tipos` that exercises the parallel path without triggering external dependencies

## Testing
- pytest -o addopts="" tests/unit/test_run_transpiler_pool.py tests/unit/test_cli_compilar_tipos.py

------
https://chatgpt.com/codex/tasks/task_e_68ca77f533608327a168ec230930e4ed