### PR TITLE
Refuerza validación de rutas de import

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,7 +769,7 @@ Para un tutorial completo de creación de plugins revisa
 
 ## Modo seguro
 
-El intérprete y la CLI ejecutan el código en modo seguro de forma predeterminada. Este modo valida el AST y prohíbe primitivas como `leer_archivo`, `escribir_archivo`, `obtener_url`, `hilo`, `leer`, `escribir`, `existe`, `eliminar` y `enviar_post`. El validador `ValidadorProhibirReflexion` también bloquea llamadas a `eval`, `exec` y otras funciones de reflexión, además de impedir el acceso a atributos internos. Asimismo, las instrucciones `import` solo están permitidas para módulos instalados o incluidos en `IMPORT_WHITELIST`. Si el programa intenta utilizar estas funciones o importar otros archivos se lanzará `PrimitivaPeligrosaError`.
+El intérprete y la CLI ejecutan el código en modo seguro de forma predeterminada. Este modo valida el AST y prohíbe primitivas como `leer_archivo`, `escribir_archivo`, `obtener_url`, `hilo`, `leer`, `escribir`, `existe`, `eliminar` y `enviar_post`. El validador `ValidadorProhibirReflexion` también bloquea llamadas a `eval`, `exec` y otras funciones de reflexión, además de impedir el acceso a atributos internos. Asimismo, las instrucciones `import` solo están permitidas para módulos instalados o incluidos en `IMPORT_WHITELIST`. Antes de cargar el código las rutas se normalizan con `os.path.realpath` y se comparan con `os.path.commonpath`, por lo que un enlace simbólico o un directorio como `modules_fake` no pueden evadir el filtro. Si el programa intenta utilizar estas funciones o importar otros archivos se lanzará `PrimitivaPeligrosaError`.
 La validación se realiza mediante una cadena de validadores configurada por la
 función `construir_cadena`, lo que facilita añadir nuevas comprobaciones en el
 futuro.

--- a/docs/frontend/modo_seguro.rst
+++ b/docs/frontend/modo_seguro.rst
@@ -12,7 +12,10 @@ El validador ``ValidadorProhibirReflexion`` impide utilizar ``eval``, ``exec`` y
 otras funciones de reflexión o acceder a atributos internos como ``__dict__``.
 También se valida la
 instrucción ``import`` para permitir únicamente los módulos instalados o los
-especificados en ``IMPORT_WHITELIST``. La instrucción ``usar`` está limitada a
+especificados en ``IMPORT_WHITELIST``. Antes de ejecutar el módulo la ruta se
+normaliza con ``os.path.realpath`` y se compara con ``os.path.commonpath`` para
+evitar evasiones mediante prefijos como ``modules_fake`` o enlaces simbólicos.
+La instrucción ``usar`` está limitada a
 los paquetes listados en ``USAR_WHITELIST`` ubicado en
 ``src/pcobra/cobra/usar_loader.py``. Si esta lista se encuentra vacía, la
 función ``obtener_modulo`` provocará un ``PermissionError`` y no se podrán

--- a/src/pcobra/core/semantic_validators/import_seguro.py
+++ b/src/pcobra/core/semantic_validators/import_seguro.py
@@ -8,10 +8,9 @@ class ValidadorImportSeguro(ValidadorBase):
     """Valida que las instrucciones import sean seguras."""
 
     def visit_import(self, nodo: NodoImport):
-        from core.interpreter import MODULES_PATH, IMPORT_WHITELIST
+        from core.interpreter import _ruta_import_permitida
 
-        ruta = os.path.abspath(nodo.ruta)
-        if not ruta.startswith(MODULES_PATH) and ruta not in IMPORT_WHITELIST:
+        if not _ruta_import_permitida(nodo.ruta):
             raise PrimitivaPeligrosaError(
                 f"Importación de módulo no permitida: {nodo.ruta}"
             )

--- a/tests/unit/test_import_path_security.py
+++ b/tests/unit/test_import_path_security.py
@@ -1,0 +1,115 @@
+import os
+import builtins
+
+import pytest
+
+from core.ast_nodes import NodoImport
+from core.interpreter import InterpretadorCobra, _ruta_import_permitida
+from core.semantic_validators.import_seguro import ValidadorImportSeguro
+from core.semantic_validators.primitiva_peligrosa import PrimitivaPeligrosaError
+
+
+def _configurar_imports(monkeypatch, modules_dir, whitelist=None):
+    import core.interpreter as interpreter_mod
+
+    lista = set() if whitelist is None else set(whitelist)
+    monkeypatch.setattr(interpreter_mod, "MODULES_PATH", str(modules_dir))
+    monkeypatch.setattr(interpreter_mod, "IMPORT_WHITELIST", lista)
+
+
+def test_ruta_permitida_dentro_de_modules(tmp_path, monkeypatch):
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    archivo = modules_dir / "seguro.co"
+    archivo.write_text("var seguro = 1")
+
+    _configurar_imports(monkeypatch, modules_dir)
+
+    assert _ruta_import_permitida(str(archivo))
+
+
+def test_ruta_permitida_por_lista_blanca(tmp_path, monkeypatch):
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    archivo = tmp_path / "externo.co"
+    archivo.write_text("var externo = 1")
+
+    _configurar_imports(monkeypatch, modules_dir, {str(archivo)})
+
+    assert _ruta_import_permitida(str(archivo))
+
+
+def test_interpreter_bloquea_prefijo_modules_fake(tmp_path, monkeypatch):
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    ruta_evasion = tmp_path / "modules_fake" / "malicioso.co"
+    ruta_evasion.parent.mkdir()
+    ruta_evasion.write_text("var trampa = 1")
+
+    _configurar_imports(monkeypatch, modules_dir)
+
+    original_open = builtins.open
+
+    def _abrir_no_permitido(path, *args, **kwargs):
+        try:
+            if os.path.realpath(path) == os.path.realpath(ruta_evasion):
+                raise AssertionError("open() no debe ejecutarse para rutas bloqueadas")
+        except TypeError:
+            pass
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", _abrir_no_permitido)
+
+    interp = InterpretadorCobra()
+
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_import(NodoImport(str(ruta_evasion)))
+
+
+def test_interpreter_bloquea_symlink_fuera_de_modules(tmp_path, monkeypatch):
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    directorio_fuera = tmp_path / "fuera"
+    directorio_fuera.mkdir()
+    archivo_real = directorio_fuera / "malicioso.co"
+    archivo_real.write_text("var x = 0")
+    enlace = modules_dir / "atajo.co"
+    os.symlink(archivo_real, enlace)
+
+    _configurar_imports(monkeypatch, modules_dir)
+
+    original_open = builtins.open
+
+    def _abrir_no_permitido(path, *args, **kwargs):
+        try:
+            if os.path.realpath(path) == os.path.realpath(archivo_real):
+                raise AssertionError("open() no debe ejecutarse para rutas bloqueadas")
+        except TypeError:
+            pass
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", _abrir_no_permitido)
+
+    interp = InterpretadorCobra()
+
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_import(NodoImport(str(enlace)))
+
+
+def test_validador_detecta_symlink(tmp_path, monkeypatch):
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    directorio_fuera = tmp_path / "trampa"
+    directorio_fuera.mkdir()
+    archivo_real = directorio_fuera / "malicioso.co"
+    archivo_real.write_text("var x = 1")
+    enlace = modules_dir / "atajo.co"
+    os.symlink(archivo_real, enlace)
+
+    _configurar_imports(monkeypatch, modules_dir)
+
+    nodo = NodoImport(str(enlace))
+    validator = ValidadorImportSeguro()
+
+    with pytest.raises(PrimitivaPeligrosaError):
+        nodo.aceptar(validator)


### PR DESCRIPTION
## Resumen
- añadir el helper `_ruta_import_permitida` para normalizar rutas con `realpath` y reutilizarlo en el intérprete y el validador `import_seguro`
- bloquear intentos de evasión mediante prefijos como `modules_fake` o enlaces simbólicos antes de ejecutar el módulo
- documentar el nuevo comportamiento y crear pruebas unitarias que ejercitan rutas válidas, rutas en lista blanca y casos maliciosos

## Pruebas
- `pytest --no-cov tests/unit/test_import_path_security.py -vv`
- `pytest --no-cov tests/unit/test_import_seguro_validator.py tests/unit/test_safe_mode_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_68ca8cb457748327bf94767c1183039a