### PR TITLE
Add tabular data helpers to standard library

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -573,3 +573,29 @@ imprimir(muestra)
 Cada paso mantiene el orden de entrada y devuelve nuevas listas, de modo que puedes reutilizar la variable original más adelante. `mezclar` acepta un parámetro `semilla` para producir barajados reproducibles en pruebas o demostraciones.
 
 Las funciones están disponibles tanto al ejecutar Cobra directamente como al transpirar a Python o JavaScript: la semántica se conserva gracias a las implementaciones equivalentes en `core/nativos/coleccion.js`.
+
+## 24. Procesamiento de datos tabulares
+
+El módulo `standard_library.datos` añade una capa ligera sobre `pandas` que permite trabajar con tablas desde Cobra sin exponerse a los detalles internos del `DataFrame`. Las funciones devuelven listas de diccionarios o diccionarios de listas, estructuras fáciles de manipular desde Cobra o al transpirar a Python.
+
+- `leer_csv` y `leer_json` cargan archivos en disco y devuelven registros con valores `None` cuando la fuente contiene datos perdidos.
+- `describir` calcula estadísticas básicas (`count`, `mean`, `std`, percentiles) para cada columna.
+- `seleccionar_columnas` y `filtrar` permiten aislar subconjuntos antes de seguir procesando los datos.
+- `agrupar_y_resumir` aplica agregaciones (`sum`, `mean`, funciones personalizadas) agrupando por columnas clave.
+- `a_listas` y `de_listas` convierten entre lista de registros y diccionario de columnas, facilitando la interoperabilidad con librerías externas.
+
+```cobra
+usar pandas
+
+ventas = pandas.leer_csv('ventas.csv')
+ventas_limpias = pandas.filtrar(ventas, lambda fila: fila['monto'] != None)
+resumen = pandas.agrupar_y_resumir(
+    ventas_limpias,
+    por=['region'],
+    agregaciones={'monto': 'sum'}
+)
+columnas = pandas.a_listas(resumen)
+imprimir(columnas['region'])
+```
+
+> **Diferencias entre backends:** las funciones de lectura y estadística solo están disponibles cuando el objetivo de ejecución es Python, ya que dependen de `pandas`. En JavaScript puedes seguir usando `seleccionar_columnas`, `filtrar`, `a_listas` y `de_listas`, pero las operaciones avanzadas dispararán un error explicando la limitación.

--- a/docs/casos_reales.md
+++ b/docs/casos_reales.md
@@ -55,12 +55,22 @@ imprimir sugerencias[0]
 ```
 
 ## Análisis de Datos
-Con `pandas` y `matplotlib` puedes procesar CSV y generar gráficos:
+
+El módulo `pandas` de la biblioteca estándar facilita leer archivos CSV/JSON y obtener resúmenes estadísticos sin perder la sencillez de Cobra. El siguiente programa carga ventas, filtra los registros incompletos y agrupa por mes para graficar posteriormente con `matplotlib`:
 
 ```cobra
 usar pandas, matplotlib
-datos = pandas.leer_csv("datos.csv")
-figura = datos.graficar(x="fecha", y="valor")
+
+ventas = pandas.leer_csv("ventas.csv")
+limpias = pandas.filtrar(ventas, lambda fila: fila['monto'] != None)
+mensuales = pandas.agrupar_y_resumir(
+    limpias,
+    por=['mes'],
+    agregaciones={'monto': 'sum'}
+)
+
+columnas = pandas.a_listas(mensuales)
+figura = matplotlib.linea(x=columnas['mes'], y=columnas['monto_sum'])
 matplotlib.guardar(figura, "salida.png")
 ```
 
@@ -71,8 +81,7 @@ cobra ejecutar analisis.co
 ```
 Puedes revisar el cuaderno interactivo `notebooks/casos_reales/analisis_datos.ipynb` para seguirlo paso a paso.
 
-
-Instala las dependencias `pandas` y `matplotlib` antes de correrlo.
+> **Requisitos:** instala `pandas` y `matplotlib`. Si transpiras a JavaScript, las funciones de lectura y estadística (`leer_csv`, `leer_json`, `describir`, `agrupar_y_resumir`) no estarán disponibles y deberás preparar los datos manualmente.
 
 ## Aplicación web
 Un servicio mínimo con Flask puede generarse y ejecutarse con Cobra:

--- a/docs/matriz_transpiladores.md
+++ b/docs/matriz_transpiladores.md
@@ -57,3 +57,7 @@
 > **Nota:** además de aparecer como destino en la tabla, Hololang ahora puede
 > emplearse como lenguaje de origen gracias al adaptador de IR a AST incluido
 > en los transpiladores principales.
+
+> **Compatibilidad de la biblioteca de datos:** las funciones de `standard_library.datos` que dependen de `pandas` solo están
+> disponibles al generar código Python. Al apuntar a JavaScript recibirás un error orientativo indicando cómo recrear la
+> funcionalidad de forma manual.

--- a/docs/standard_library/datos.md
+++ b/docs/standard_library/datos.md
@@ -1,0 +1,20 @@
+# standard_library.datos
+
+El módulo `standard_library.datos` encapsula operaciones comunes sobre datos tabulares usando `pandas` y `numpy`. Todas las funciones devuelven estructuras simples (`list` de `dict` o `dict` de listas) para que puedan consumirse fácilmente desde Cobra o por librerías externas.
+
+## Funciones disponibles (backend Python)
+
+- **`leer_csv(ruta, *, separador=",", encoding="utf-8", limite_filas=None)`**: lee un archivo CSV y devuelve una lista de registros. Los valores ausentes se normalizan como `None`.
+- **`leer_json(ruta, *, orient=None, lineas=False)`**: carga un archivo JSON (incluido JSON Lines) y lo expone como lista de diccionarios.
+- **`describir(datos)`**: calcula estadísticas básicas por columna y devuelve un diccionario de métricas.
+- **`seleccionar_columnas(datos, columnas)`**: extrae columnas específicas y reporta si alguna falta.
+- **`filtrar(datos, condicion)`**: aplica una función por fila y conserva solo los registros que devuelvan `True`.
+- **`agrupar_y_resumir(datos, por, agregaciones)`**: agrupa por columnas y aplica agregaciones compatibles con `DataFrame.agg`.
+- **`a_listas(datos)`**: transforma la tabla a un diccionario columna → lista.
+- **`de_listas(columnas)`**: genera una lista de diccionarios a partir de un mapeo de columnas.
+
+## Backend JavaScript
+
+En el objetivo JavaScript se ofrece una implementación parcial que mantiene las transformaciones puramente estructurales (`seleccionar_columnas`, `filtrar`, `a_listas`, `de_listas`). Las funciones que dependen de `pandas` (`leer_csv`, `leer_json`, `describir`, `agrupar_y_resumir`) lanzan un error explicando la limitación para evitar resultados inconsistentes.
+
+> **Sugerencia:** si necesitas procesar archivos directamente en JavaScript, realiza la lectura con utilidades propias del entorno (por ejemplo `fetch` o `fs`) y entrega los datos a Cobra usando `de_listas` o listas de diccionarios.

--- a/src/pcobra/core/nativos/datos.js
+++ b/src/pcobra/core/nativos/datos.js
@@ -1,0 +1,113 @@
+function asegurarTabla(tabla) {
+    if (!Array.isArray(tabla)) {
+        throw new TypeError('Se esperaba una lista de registros (array de objetos).');
+    }
+    return tabla.map((fila) => {
+        if (fila == null || typeof fila !== 'object' || Array.isArray(fila)) {
+            throw new TypeError('Cada fila debe ser un objeto con pares clave-valor.');
+        }
+        return { ...fila };
+    });
+}
+
+function normalizarColumnas(columnas) {
+    if (columnas == null || typeof columnas !== 'object' || Array.isArray(columnas)) {
+        throw new TypeError('Se esperaba un objeto columna -> valores.');
+    }
+    return columnas;
+}
+
+function errorNoDisponible(funcion) {
+    return new Error(
+        `${funcion} solo está disponible en el backend de Python con pandas. ` +
+            'En JavaScript debes preparar los datos manualmente o trabajar con estructuras básicas.',
+    );
+}
+
+export function leer_csv() {
+    throw errorNoDisponible('leer_csv');
+}
+
+export function leer_json() {
+    throw errorNoDisponible('leer_json');
+}
+
+export function describir() {
+    throw errorNoDisponible('describir');
+}
+
+export function agrupar_y_resumir() {
+    throw errorNoDisponible('agrupar_y_resumir');
+}
+
+export function seleccionar_columnas(tabla, columnas) {
+    const datos = asegurarTabla(tabla);
+    if (!Array.isArray(columnas)) {
+        throw new TypeError('columnas debe ser una lista.');
+    }
+    columnas.forEach((columna) => {
+        if (typeof columna !== 'string') {
+            throw new TypeError('Cada nombre de columna debe ser una cadena.');
+        }
+    });
+    return datos.map((fila) => {
+        const resultado = {};
+        columnas.forEach((columna) => {
+            if (!(columna in fila)) {
+                throw new Error(`La columna ${columna} no existe en al menos una fila.`);
+            }
+            resultado[columna] = fila[columna];
+        });
+        return resultado;
+    });
+}
+
+export function filtrar(tabla, condicion) {
+    const datos = asegurarTabla(tabla);
+    if (typeof condicion !== 'function') {
+        throw new TypeError('condicion debe ser una función.');
+    }
+    return datos.filter((fila) => {
+        const resultado = condicion({ ...fila });
+        return Boolean(resultado);
+    });
+}
+
+export function a_listas(tabla) {
+    const datos = asegurarTabla(tabla);
+    const columnas = {};
+    datos.forEach((fila) => {
+        Object.keys(fila).forEach((columna) => {
+            if (!columnas[columna]) {
+                columnas[columna] = [];
+            }
+            columnas[columna].push(fila[columna]);
+        });
+    });
+    return columnas;
+}
+
+export function de_listas(columnas) {
+    const entradas = Object.entries(normalizarColumnas(columnas));
+    if (entradas.length === 0) {
+        return [];
+    }
+    const longitud = entradas[0][1].length;
+    entradas.forEach(([nombre, valores]) => {
+        if (!Array.isArray(valores)) {
+            throw new TypeError(`Los valores de la columna ${nombre} deben ser una lista.`);
+        }
+        if (valores.length !== longitud) {
+            throw new Error('Todas las columnas deben tener la misma longitud.');
+        }
+    });
+    const filas = [];
+    for (let i = 0; i < longitud; i += 1) {
+        const fila = {};
+        entradas.forEach(([nombre, valores]) => {
+            fila[nombre] = valores[i];
+        });
+        filas.push(fila);
+    }
+    return filas;
+}

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -1,28 +1,46 @@
-"""Biblioteca estándar complementaria para Cobra."""
+"""Biblioteca estándar complementaria para Cobra.
+
+Este paquete expone utilidades enfocadas en manipular colecciones, texto,
+fechas y ahora datos tabulares mediante envoltorios amigables. Cada función
+re-exportada incluye anotaciones de tipo para favorecer el autocompletado y la
+documentación en español para facilitar su consulta.
+"""
 
 from __future__ import annotations
 
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
 from standard_library.archivo import leer, escribir, adjuntar, existe
+from standard_library.datos import (
+    agrupar_y_resumir,
+    a_listas,
+    de_listas,
+    describir,
+    filtrar,
+    leer_csv,
+    leer_json,
+    seleccionar_columnas,
+)
 from standard_library.fecha import hoy, formatear, sumar_dias
 from standard_library.lista import (
     cabeza,
+    chunk,
     cola,
-    longitud,
     combinar,
+    longitud,
     mapear_seguro,
     ventanas,
-    chunk,
 )
 from standard_library.logica import conjuncion, disyuncion, negacion
-from standard_library.util import es_nulo, es_vacio, rel, repetir
 from standard_library.texto import (
-    quitar_acentos,
-    normalizar_espacios,
-    es_palindromo,
     es_anagrama,
+    es_palindromo,
+    normalizar_espacios,
+    quitar_acentos,
 )
+from standard_library.util import es_nulo, es_vacio, rel, repetir
 
-__all__ = [
+__all__: list[str] = [
     "leer",
     "escribir",
     "adjuntar",
@@ -48,4 +66,23 @@ __all__ = [
     "normalizar_espacios",
     "es_palindromo",
     "es_anagrama",
+    "leer_csv",
+    "leer_json",
+    "describir",
+    "seleccionar_columnas",
+    "filtrar",
+    "agrupar_y_resumir",
+    "a_listas",
+    "de_listas",
 ]
+
+
+# Se exponen las firmas para mejorar el autocompletado en editores compatibles.
+leer_csv: Callable[..., list[dict[str, Any]]]
+leer_json: Callable[..., list[dict[str, Any]]]
+describir: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, Any]]
+seleccionar_columnas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Sequence[str]], list[dict[str, Any]]]
+filtrar: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Callable[[dict[str, Any]], bool]], list[dict[str, Any]]]
+agrupar_y_resumir: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Sequence[str], Mapping[str, Any]], list[dict[str, Any]]]
+a_listas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, list[Any]]]
+de_listas: Callable[[Mapping[str, Sequence[Any]]], list[dict[str, Any]]]

--- a/src/pcobra/standard_library/datos.py
+++ b/src/pcobra/standard_library/datos.py
@@ -1,0 +1,226 @@
+"""Funciones utilitarias para trabajar con datos tabulares.
+
+Todas las funciones usan internamente :mod:`pandas` y :mod:`numpy`, pero
+devuelven estructuras de datos sencillas (listas y diccionarios) que pueden ser
+consumidas directamente desde Cobra sin depender de objetos complejos.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence
+
+import numpy as np
+import pandas as pd
+
+Registro = dict[str, Any]
+Tabla = list[Registro]
+
+
+def _a_dataframe(datos: Iterable[Registro] | Mapping[str, Sequence[Any]] | pd.DataFrame) -> pd.DataFrame:
+    """Convierte ``datos`` a un ``DataFrame`` de ``pandas``.
+
+    Se aceptan ``DataFrame`` ya construidos, listas de registros (diccionarios
+    por fila) o diccionarios de listas (columnas).
+    """
+
+    if isinstance(datos, pd.DataFrame):
+        return datos.copy()
+    if isinstance(datos, Mapping):
+        return pd.DataFrame(datos)
+    if isinstance(datos, Iterable):
+        return pd.DataFrame(list(datos))
+    raise TypeError("Formato de datos no soportado. Usa registros o columnas.")
+
+
+def _sanear_valor(valor: Any) -> Any:
+    """Reemplaza valores especiales de ``numpy`` por ``None`` y normaliza tipos."""
+
+    if valor is None:
+        return None
+    if isinstance(valor, (float, np.floating)) and np.isnan(valor):
+        return None
+    if isinstance(valor, (np.floating, np.integer)):
+        escalar = valor.item()
+        if isinstance(escalar, float) and np.isnan(escalar):
+            return None
+        return escalar
+    if isinstance(valor, pd.Timestamp):
+        return valor.isoformat()
+    if isinstance(valor, pd.Timedelta):
+        return valor.isoformat() if hasattr(valor, "isoformat") else str(valor)
+    if isinstance(valor, np.ndarray):  # pragma: no cover - casos raros
+        return valor.tolist()
+    return valor
+
+
+def _sanear_registros(registros: list[MutableMapping[str, Any]]) -> Tabla:
+    """Limpia los registros reemplazando valores no serializables."""
+
+    resultado: Tabla = []
+    for registro in registros:
+        limpio: Registro = {clave: _sanear_valor(valor) for clave, valor in registro.items()}
+        resultado.append(limpio)
+    return resultado
+
+
+def leer_csv(
+    ruta: str | Path,
+    *,
+    separador: str = ",",
+    encoding: str = "utf-8",
+    limite_filas: int | None = None,
+) -> Tabla:
+    """Lee un archivo CSV y devuelve una tabla como lista de diccionarios.
+
+    Parameters
+    ----------
+    ruta:
+        Ruta al archivo CSV. Puede ser relativa o absoluta.
+    separador:
+        Separador de columnas utilizado en el archivo. Por defecto ``,``.
+    encoding:
+        Codificación del archivo. Por defecto ``utf-8``.
+    limite_filas:
+        Si se especifica, solo se leen las primeras ``limite_filas`` filas.
+    """
+
+    try:
+        df = pd.read_csv(Path(ruta), sep=separador, encoding=encoding, nrows=limite_filas)
+    except (FileNotFoundError, pd.errors.ParserError, UnicodeDecodeError) as exc:
+        raise ValueError(f"No fue posible leer el CSV: {exc}") from exc
+    return _sanear_registros(df.to_dict(orient="records"))
+
+
+def leer_json(ruta: str | Path, *, orient: str | None = None, lineas: bool = False) -> Tabla:
+    """Lee un archivo JSON con estructura tabular.
+
+    Parameters
+    ----------
+    ruta:
+        Ruta al archivo JSON.
+    orient:
+        Orientación utilizada por :func:`pandas.read_json`. Si es ``None`` se
+        intenta inferir automáticamente.
+    lineas:
+        Indica si el archivo está en formato JSON Lines.
+    """
+
+    try:
+        df = pd.read_json(Path(ruta), orient=orient, lines=lineas)
+    except (ValueError, FileNotFoundError) as exc:
+        raise ValueError(f"No fue posible leer el JSON: {exc}") from exc
+    return _sanear_registros(df.to_dict(orient="records"))
+
+
+def describir(datos: Iterable[Registro] | Mapping[str, Sequence[Any]] | pd.DataFrame) -> Registro:
+    """Genera estadísticas descriptivas para cada columna de ``datos``.
+
+    El resultado es un diccionario donde cada columna contiene sus métricas
+    básicas (conteo, media, desviación, percentiles, etc.).
+    """
+
+    df = _a_dataframe(datos)
+    descripcion = df.describe(include="all").fillna(np.nan)
+    return {columna: {indice: _sanear_valor(valor) for indice, valor in serie.items()} for columna, serie in descripcion.to_dict().items()}
+
+
+def seleccionar_columnas(
+    datos: Iterable[Registro] | Mapping[str, Sequence[Any]] | pd.DataFrame,
+    columnas: Sequence[str],
+) -> Tabla:
+    """Devuelve una nueva tabla solo con ``columnas``.
+
+    Lanza ``KeyError`` si alguna de las columnas no existe.
+    """
+
+    df = _a_dataframe(datos)
+    faltantes = [col for col in columnas if col not in df.columns]
+    if faltantes:
+        raise KeyError(f"Columnas inexistentes: {', '.join(faltantes)}")
+    return _sanear_registros(df.loc[:, list(columnas)].to_dict(orient="records"))
+
+
+def filtrar(
+    datos: Iterable[Registro] | Mapping[str, Sequence[Any]] | pd.DataFrame,
+    condicion: Callable[[Registro], bool],
+) -> Tabla:
+    """Aplica ``condicion`` fila por fila y devuelve solo las filas que cumplen.
+
+    La función ``condicion`` recibe un diccionario por fila y debe devolver un
+    booleano.
+    """
+
+    df = _a_dataframe(datos)
+
+    def _evaluar(fila: pd.Series) -> bool:
+        try:
+            return bool(condicion(fila.to_dict()))
+        except Exception as exc:  # pragma: no cover - defensivo
+            raise ValueError(f"Error al evaluar la condición de filtrado: {exc}") from exc
+
+    mascara = df.apply(_evaluar, axis=1)
+    return _sanear_registros(df.loc[mascara].to_dict(orient="records"))
+
+
+def agrupar_y_resumir(
+    datos: Iterable[Registro] | Mapping[str, Sequence[Any]] | pd.DataFrame,
+    por: Sequence[str],
+    agregaciones: Mapping[str, str | Sequence[str] | Callable[[pd.Series], Any]],
+) -> Tabla:
+    """Agrupa ``datos`` por las columnas ``por`` y aplica ``agregaciones``.
+
+    Las agregaciones admiten cadenas reconocidas por :meth:`DataFrame.agg`,
+    listas de cadenas o funciones personalizadas.
+    """
+
+    df = _a_dataframe(datos)
+    faltantes = [col for col in por if col not in df.columns]
+    if faltantes:
+        raise KeyError(f"Columnas inexistentes para agrupar: {', '.join(faltantes)}")
+    agrupado = df.groupby(list(por), dropna=False).agg(agregaciones).reset_index()
+    # Aplanar columnas con múltiples niveles
+    if isinstance(agrupado.columns, pd.MultiIndex):
+        columnas = [
+            "_".join([str(nivel) for nivel in columna if str(nivel) != ""]).strip("_")
+            for columna in agrupado.columns.values
+        ]
+        agrupado.columns = columnas
+    else:
+        renombres: dict[str, str] = {}
+        for columna, operacion in agregaciones.items():
+            if columna in por or columna not in agrupado.columns:
+                continue
+            if isinstance(operacion, str):
+                sufijo = operacion
+            elif callable(operacion):
+                sufijo = getattr(operacion, "__name__", "func")
+                sufijo = sufijo.replace("<", "").replace(">", "") or "func"
+            else:
+                sufijo = "custom"
+            renombres[columna] = f"{columna}_{sufijo}"
+        if renombres:
+            agrupado = agrupado.rename(columns=renombres)
+    return _sanear_registros(agrupado.to_dict(orient="records"))
+
+
+def a_listas(datos: Iterable[Registro] | Mapping[str, Sequence[Any]] | pd.DataFrame) -> dict[str, list[Any]]:
+    """Convierte ``datos`` a un diccionario ``columna -> lista``."""
+
+    df = _a_dataframe(datos)
+    columnas = df.to_dict(orient="list")
+    return {col: [_sanear_valor(valor) for valor in valores] for col, valores in columnas.items()}
+
+
+def de_listas(columnas: Mapping[str, Sequence[Any]]) -> Tabla:
+    """Construye una tabla a partir de un diccionario de listas.
+
+    Todas las listas deben tener la misma longitud.
+    """
+
+    try:
+        df = pd.DataFrame(columnas)
+    except ValueError as exc:
+        raise ValueError(f"No fue posible construir la tabla: {exc}") from exc
+    return _sanear_registros(df.to_dict(orient="records"))
+

--- a/tests/unit/test_standard_library_datos.py
+++ b/tests/unit/test_standard_library_datos.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from pcobra.standard_library import datos as datos_mod
+from pcobra.standard_library.datos import (
+    agrupar_y_resumir,
+    a_listas,
+    de_listas,
+    describir,
+    filtrar,
+    leer_csv,
+    leer_json,
+    seleccionar_columnas,
+)
+
+
+def _tabla_base() -> list[dict[str, object]]:
+    return [
+        {"categoria": "A", "valor": 10, "etiqueta": "foo"},
+        {"categoria": "A", "valor": 5, "etiqueta": "bar"},
+        {"categoria": "B", "valor": 3, "etiqueta": "baz"},
+    ]
+
+
+def test_a_listas_y_de_listas_bidireccional():
+    tabla = _tabla_base()
+    columnas = a_listas(tabla)
+    reconstruido = de_listas(columnas)
+    assert reconstruido == tabla
+
+
+def test_de_listas_columnas_inconsistentes():
+    with pytest.raises(ValueError):
+        de_listas({"a": [1, 2], "b": [3]})
+
+
+def test_seleccionar_columnas_y_filtrar():
+    tabla = _tabla_base()
+    seleccion = seleccionar_columnas(tabla, ["categoria", "valor"])
+    assert all(set(fila.keys()) == {"categoria", "valor"} for fila in seleccion)
+    filtrado = filtrar(seleccion, lambda fila: fila["valor"] > 5)
+    assert filtrado == [{"categoria": "A", "valor": 10}]
+
+
+def test_filtrar_condicion_erronea():
+    tabla = _tabla_base()
+
+    def condicion(_fila: dict[str, object]) -> bool:
+        raise RuntimeError("fallo")
+
+    with pytest.raises(ValueError):
+        filtrar(tabla, condicion)
+
+
+def test_seleccionar_columnas_inexistentes():
+    with pytest.raises(KeyError):
+        seleccionar_columnas(_tabla_base(), ["id"])
+
+
+def test_agrupar_y_resumir():
+    tabla = _tabla_base()
+    resultado = agrupar_y_resumir(tabla, por=["categoria"], agregaciones={"valor": "sum"})
+    esperado = [
+        {"categoria": "A", "valor_sum": 15},
+        {"categoria": "B", "valor_sum": 3},
+    ]
+    assert resultado == esperado
+
+
+def test_describir_contiene_metricas():
+    df = pd.DataFrame(_tabla_base())
+    resumen = describir(df)
+    assert "valor" in resumen
+    assert "mean" in resumen["valor"]
+    assert resumen["valor"]["mean"] == pytest.approx(6.0)
+
+
+def test_leer_csv_y_json(tmp_path: Path):
+    csv_path = tmp_path / "datos.csv"
+    csv_path.write_text("categoria,valor\nA,10\nB,\n", encoding="utf-8")
+    datos_csv = leer_csv(csv_path)
+    assert datos_csv == [{"categoria": "A", "valor": 10}, {"categoria": "B", "valor": None}]
+
+    json_path = tmp_path / "datos.json"
+    json_path.write_text('[{"categoria": "C", "valor": 7}]', encoding="utf-8")
+    datos_json = leer_json(json_path)
+    assert datos_json == [{"categoria": "C", "valor": 7}]
+
+
+def test_leer_csv_error(tmp_path: Path):
+    csv_path = tmp_path / "datos.csv"
+    csv_path.write_text('valor\n"1', encoding="utf-8")
+    with pytest.raises(ValueError):
+        leer_csv(csv_path)
+
+
+def test_desde_modulo_publico():
+    # Asegura que las re-exportaciones incluyan anotaciones y funciones activas.
+    assert hasattr(datos_mod, "leer_csv")
+    assert callable(datos_mod.leer_csv)


### PR DESCRIPTION
## Resumen
- incorporar el módulo `standard_library.datos` con utilidades para leer CSV/JSON, describir, filtrar y agrupar datos en estructuras amigables
- exponer las nuevas funciones en `standard_library.__init__`, documentar los flujos de trabajo y añadir equivalentes/parciales en la capa JavaScript
- crear pruebas unitarias que cubren conversiones bidireccionales, agregaciones y manejo de errores

## Pruebas
- PYTEST_ADDOPTS="--no-cov" pytest tests/unit/test_standard_library_datos.py

------
https://chatgpt.com/codex/tasks/task_e_68cb11a440948327935144192d019b62