### PR TITLE
feat: ampliar utilidades numericas

### DIFF
--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -161,6 +161,77 @@ Factorial recursivo::
 
    imprimir(factorial(5))
 
+Operaciones numéricas con ``corelibs.numero``
+--------------------------------------------
+
+La biblioteca estándar también incluye utilidades numéricas inspiradas en
+``math`` y ``statistics`` de Python. Permiten normalizar valores, generar
+aleatorios reproducibles y analizar datos sin abandonar Cobra.
+
+.. code-block:: python
+
+   import pcobra.corelibs as core
+
+   medidas = [1.2, 1.8, 2.0, 2.5]
+   print(core.absoluto(-3))
+   print(core.redondear(3.14159, 3))
+   print(core.clamp(5, 0, 3))
+   print(core.mediana(medidas))
+   print(core.desviacion_estandar(medidas, muestral=True))
+
+.. list-table:: Equivalencias con bibliotecas numéricas
+   :header-rows: 1
+   :widths: 20 25 25 30
+
+   * - Cobra
+     - Python ``math``/``statistics``
+     - ``numpy``
+     - JavaScript ``Math``
+   * - ``absoluto(x)``
+     - ``math.fabs(x)``
+     - ``numpy.abs(x)``
+     - ``Math.abs(x)``
+   * - ``redondear(x, n)``
+     - ``round(x, n)``
+     - ``numpy.round(x, n)``
+     - ``Math.round(x * 10**n) / 10**n``
+   * - ``piso(x)``
+     - ``math.floor(x)``
+     - ``numpy.floor(x)``
+     - ``Math.floor(x)``
+   * - ``techo(x)``
+     - ``math.ceil(x)``
+     - ``numpy.ceil(x)``
+     - ``Math.ceil(x)``
+   * - ``raiz(x, n)``
+     - ``math.pow(x, 1/n)``
+     - ``numpy.power(x, 1/n)``
+     - ``Math.pow(x, 1/n)``
+   * - ``potencia(a, b)``
+     - ``math.pow(a, b)``
+     - ``numpy.power(a, b)``
+     - ``Math.pow(a, b)``
+   * - ``clamp(x, a, b)``
+     - ``min(max(x, a), b)``
+     - ``numpy.clip(x, a, b)``
+     - ``Math.min(Math.max(x, a), b)``
+   * - ``aleatorio(a, b)``
+     - ``random.uniform(a, b)``
+     - ``numpy.random.uniform(a, b)``
+     - ``Math.random() * (b - a) + a``
+   * - ``mediana(datos)``
+     - ``statistics.median(datos)``
+     - ``numpy.median(datos)``
+     - «Sin equivalente directo; ordenar y promediar»
+   * - ``moda(datos)``
+     - ``statistics.mode(datos)``
+     - ``numpy.unique(datos, return_counts=True)``
+     - «Sin equivalente directo; contar frecuencias»
+   * - ``desviacion_estandar(datos)``
+     - ``statistics.pstdev(datos)``
+     - ``numpy.std(datos)``
+     - «Sin equivalente directo; implementar manualmente»
+
 Transpilación y ejecución
 -------------------------
 

--- a/src/pcobra/core/nativos/numero.js
+++ b/src/pcobra/core/nativos/numero.js
@@ -1,3 +1,120 @@
+export function absoluto(n) {
+    return Math.abs(n);
+}
+
+
+export function redondear(valor, ndigitos = null) {
+    if (ndigitos === null || ndigitos === undefined) {
+        return Math.round(valor);
+    }
+    const factor = Math.pow(10, ndigitos);
+    return Math.round(valor * factor) / factor;
+}
+
+
+export function piso(valor) {
+    return Math.floor(valor);
+}
+
+
+export function techo(valor) {
+    return Math.ceil(valor);
+}
+
+
+export function raiz(valor, indice = 2) {
+    const indiceFloat = Number(indice);
+    if (indiceFloat === 0) {
+        throw new Error("El índice de la raíz no puede ser cero");
+    }
+    if (valor < 0) {
+        if (Number.isInteger(indiceFloat)) {
+            if (Math.abs(indiceFloat) % 2 === 0) {
+                throw new Error("No se puede calcular la raíz par de un número negativo");
+            }
+        } else {
+            throw new Error(
+                "No se puede calcular la raíz de índice fraccionario de un número negativo",
+            );
+        }
+    }
+    const magnitud = Math.pow(Math.abs(valor), 1 / indiceFloat);
+    return valor < 0 ? -magnitud : magnitud;
+}
+
+
+export function potencia(base, exponente) {
+    return Math.pow(base, exponente);
+}
+
+
+export function clamp(valor, minimo, maximo) {
+    if (minimo > maximo) {
+        throw new Error("El mínimo no puede ser mayor que el máximo");
+    }
+    return Math.min(Math.max(valor, minimo), maximo);
+}
+
+
+export function aleatorio(inicio = 0, fin = 1) {
+    if (inicio > fin) {
+        throw new Error("El inicio no puede ser mayor que el fin");
+    }
+    return Math.random() * (fin - inicio) + inicio;
+}
+
+
+export function mediana(lista) {
+    if (!lista || lista.length === 0) {
+        throw new Error("No se puede calcular la mediana de una secuencia vacía");
+    }
+    const ordenada = [...lista].sort((a, b) => a - b);
+    const mitad = Math.floor(ordenada.length / 2);
+    if (ordenada.length % 2 === 0) {
+        return (ordenada[mitad - 1] + ordenada[mitad]) / 2;
+    }
+    return ordenada[mitad];
+}
+
+
+export function moda(lista) {
+    if (!lista || lista.length === 0) {
+        throw new Error("No se puede calcular la moda de una secuencia vacía");
+    }
+    const frecuencias = new Map();
+    let maxConteo = 0;
+    let modaActual = lista[0];
+    for (const valor of lista) {
+        const conteo = (frecuencias.get(valor) ?? 0) + 1;
+        frecuencias.set(valor, conteo);
+        if (conteo > maxConteo) {
+            maxConteo = conteo;
+            modaActual = valor;
+        }
+    }
+    return modaActual;
+}
+
+
+export function desviacion_estandar(lista, muestral = false) {
+    if (!lista || lista.length === 0) {
+        throw new Error(
+            "No se puede calcular la desviación estándar de una secuencia vacía",
+        );
+    }
+    if (muestral && lista.length < 2) {
+        throw new Error("La desviación estándar muestral requiere al menos dos valores");
+    }
+    const promedio = lista.reduce((acc, val) => acc + val, 0) / lista.length;
+    const sumaCuadrados = lista.reduce(
+        (acc, val) => acc + Math.pow(val - promedio, 2),
+        0,
+    );
+    const divisor = muestral && lista.length > 1 ? lista.length - 1 : lista.length;
+    return Math.sqrt(sumaCuadrados / divisor);
+}
+
+
 export function es_par(n) {
     return n % 2 === 0;
 }

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -18,7 +18,23 @@ from corelibs.texto import (
     rellenar_derecha,
     normalizar_unicode,
 )
-from corelibs.numero import es_par, es_primo, factorial, promedio
+from corelibs.numero import (
+    absoluto,
+    aleatorio,
+    clamp,
+    desviacion_estandar,
+    es_par,
+    es_primo,
+    factorial,
+    mediana,
+    moda,
+    piso,
+    potencia,
+    promedio,
+    raiz,
+    redondear,
+    techo,
+)
 from corelibs.archivo import leer, escribir, existe, eliminar
 from corelibs.tiempo import ahora, formatear, dormir
 from corelibs.coleccion import (
@@ -58,10 +74,21 @@ __all__ = [
     "rellenar_izquierda",
     "rellenar_derecha",
     "normalizar_unicode",
+    "absoluto",
+    "aleatorio",
+    "clamp",
+    "desviacion_estandar",
     "es_par",
     "es_primo",
     "factorial",
+    "mediana",
+    "moda",
+    "piso",
+    "potencia",
     "promedio",
+    "raiz",
+    "redondear",
+    "techo",
     "leer",
     "escribir",
     "existe",

--- a/src/pcobra/corelibs/numero.py
+++ b/src/pcobra/corelibs/numero.py
@@ -1,5 +1,116 @@
 """Operaciones numéricas comunes."""
 
+from __future__ import annotations
+
+import math
+import random
+from statistics import StatisticsError, median, mode, pstdev, stdev
+
+
+def absoluto(valor):
+    """Devuelve el valor absoluto de ``valor`` preservando el tipo de enteros."""
+
+    resultado = math.fabs(valor)
+    if isinstance(valor, int) and resultado.is_integer():
+        return int(resultado)
+    return resultado
+
+
+def redondear(valor, ndigitos: int | None = None):
+    """Redondea ``valor`` a ``ndigitos`` cifras decimales."""
+
+    if ndigitos is None:
+        return round(valor)
+    return round(valor, ndigitos)
+
+
+def piso(valor):
+    """Equivalente a ``math.floor``."""
+
+    return math.floor(valor)
+
+
+def techo(valor):
+    """Equivalente a ``math.ceil``."""
+
+    return math.ceil(valor)
+
+
+def raiz(valor, indice: float = 2):
+    """Calcula la raíz ``indice``-ésima de ``valor``."""
+
+    indice_float = float(indice)
+    if indice_float == 0:
+        raise ValueError("El índice de la raíz no puede ser cero")
+    if valor < 0:
+        if indice_float.is_integer():
+            if int(indice_float) % 2 == 0:
+                raise ValueError(
+                    "No se puede calcular la raíz par de un número negativo"
+                )
+        else:
+            raise ValueError(
+                "No se puede calcular la raíz de índice fraccionario de un número negativo"
+            )
+    magnitud = math.pow(abs(valor), 1.0 / indice_float)
+    return -magnitud if valor < 0 else magnitud
+
+
+def potencia(base, exponente):
+    """Eleva ``base`` a ``exponente`` utilizando ``math.pow``."""
+
+    return math.pow(base, exponente)
+
+
+def clamp(valor, minimo, maximo):
+    """Restringe ``valor`` al rango ``[minimo, maximo]``."""
+
+    if minimo > maximo:
+        raise ValueError("El mínimo no puede ser mayor que el máximo")
+    return max(min(valor, maximo), minimo)
+
+
+def aleatorio(inicio: float = 0.0, fin: float = 1.0, semilla: int | None = None) -> float:
+    """Genera un número aleatorio uniforme entre ``inicio`` y ``fin``."""
+
+    if inicio > fin:
+        raise ValueError("El inicio no puede ser mayor que el fin")
+    if semilla is not None:
+        generador = random.Random(semilla)
+        return generador.uniform(inicio, fin)
+    return random.uniform(inicio, fin)
+
+
+def mediana(valores) -> float:
+    """Calcula la mediana de ``valores`` usando :mod:`statistics`."""
+
+    if not valores:
+        raise ValueError("No se puede calcular la mediana de una secuencia vacía")
+    return median(valores)
+
+
+def moda(valores):
+    """Calcula la moda de ``valores`` usando :mod:`statistics`."""
+
+    if not valores:
+        raise ValueError("No se puede calcular la moda de una secuencia vacía")
+    try:
+        return mode(valores)
+    except StatisticsError as exc:  # pragma: no cover - comportamiento defensivo
+        raise ValueError(str(exc)) from exc
+
+
+def desviacion_estandar(valores, *, muestral: bool = False) -> float:
+    """Obtiene la desviación estándar de ``valores``."""
+
+    if not valores:
+        raise ValueError("No se puede calcular la desviación estándar de una secuencia vacía")
+    funcion = stdev if muestral else pstdev
+    try:
+        return funcion(valores)
+    except StatisticsError as exc:  # pragma: no cover - comportamiento defensivo
+        raise ValueError(str(exc)) from exc
+
 
 def es_par(n: int) -> bool:
     """Retorna ``True`` si *n* es par."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import ModuleType
 from typing import Callable
 
 import pytest
@@ -20,6 +21,17 @@ try:  # nosec B001
     import pcobra  # noqa: F401
 except Exception:
     pass
+
+if "requests" not in sys.modules:
+    fake_requests = ModuleType("requests")
+    fake_requests.Response = type("Response", (), {})
+
+    def _fail(*_args, **_kwargs):  # pragma: no cover - solo para pruebas
+        raise RuntimeError("requests no disponible en el entorno de pruebas")
+
+    fake_requests.get = _fail
+    fake_requests.post = _fail
+    sys.modules["requests"] = fake_requests
 
 
 @pytest.fixture

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -57,6 +57,24 @@ def test_texto_funcs():
 
 
 def test_numero_funcs():
+    assert core.absoluto(-5) == 5
+    assert core.absoluto(-5.2) == pytest.approx(5.2)
+    assert core.redondear(3.14159, 2) == pytest.approx(3.14)
+    assert core.redondear(3.6) == 4
+    assert core.piso(3.9) == 3
+    assert core.techo(3.1) == 4
+    assert core.raiz(9) == pytest.approx(3.0)
+    assert core.raiz(-8, 3) == pytest.approx(-2.0)
+    assert core.potencia(2, 3) == pytest.approx(8.0)
+    assert core.clamp(5, 0, 3) == 3
+    assert 1 <= core.aleatorio(1, 2, semilla=42) <= 2
+    assert core.mediana([1, 2, 3, 4]) == 2.5
+    assert core.moda([1, 1, 2, 2, 2]) == 2
+    datos = [2, 4, 4, 4, 5, 5, 7, 9]
+    assert core.desviacion_estandar(datos) == pytest.approx(2.0)
+    assert core.desviacion_estandar(datos, muestral=True) == pytest.approx(
+        2.1380899353
+    )
     assert core.es_par(4) is True
     assert core.es_par(5) is False
     assert core.es_primo(7) is True
@@ -406,6 +424,17 @@ def test_transpile_texto():
 
 def test_transpile_numero():
     ast = [
+        NodoLlamadaFuncion("absoluto", [NodoValor(-5)]),
+        NodoLlamadaFuncion("redondear", [NodoValor(3.14159), NodoValor(2)]),
+        NodoLlamadaFuncion("piso", [NodoValor(3.9)]),
+        NodoLlamadaFuncion("techo", [NodoValor(3.1)]),
+        NodoLlamadaFuncion("raiz", [NodoValor(9)]),
+        NodoLlamadaFuncion("potencia", [NodoValor(2), NodoValor(3)]),
+        NodoLlamadaFuncion("clamp", [NodoValor(5), NodoValor(0), NodoValor(3)]),
+        NodoLlamadaFuncion("aleatorio", [NodoValor(1), NodoValor(2)]),
+        NodoLlamadaFuncion("mediana", [NodoValor("[1,2,3]")]),
+        NodoLlamadaFuncion("moda", [NodoValor("[1,1,2]")]),
+        NodoLlamadaFuncion("desviacion_estandar", [NodoValor("[1,2,3]")]),
         NodoLlamadaFuncion("es_par", [NodoValor(2)]),
         NodoLlamadaFuncion("es_primo", [NodoValor(3)]),
         NodoLlamadaFuncion("factorial", [NodoValor(3)]),
@@ -415,6 +444,17 @@ def test_transpile_numero():
     js = TranspiladorJavaScript().generate_code(ast)
     py_exp = (
         IMPORTS_PY
+        + "absoluto(-5)\n"
+        + "redondear(3.14159, 2)\n"
+        + "piso(3.9)\n"
+        + "techo(3.1)\n"
+        + "raiz(9)\n"
+        + "potencia(2, 3)\n"
+        + "clamp(5, 0, 3)\n"
+        + "aleatorio(1, 2)\n"
+        + "mediana([1,2,3])\n"
+        + "moda([1,1,2])\n"
+        + "desviacion_estandar([1,2,3])\n"
         + "es_par(2)\n"
         + "es_primo(3)\n"
         + "factorial(3)\n"
@@ -422,6 +462,17 @@ def test_transpile_numero():
     )
     js_exp = (
         IMPORTS_JS
+        + "absoluto(-5);\n"
+        + "redondear(3.14159, 2);\n"
+        + "piso(3.9);\n"
+        + "techo(3.1);\n"
+        + "raiz(9);\n"
+        + "potencia(2, 3);\n"
+        + "clamp(5, 0, 3);\n"
+        + "aleatorio(1, 2);\n"
+        + "mediana([1,2,3]);\n"
+        + "moda([1,1,2]);\n"
+        + "desviacion_estandar([1,2,3]);\n"
         + "es_par(2);\n"
         + "es_primo(3);\n"
         + "factorial(3);\n"

--- a/tests/unit/test_corelibs_numero_estadistica.py
+++ b/tests/unit/test_corelibs_numero_estadistica.py
@@ -1,0 +1,61 @@
+import sys
+from types import ModuleType
+
+import pytest
+
+fake_requests = ModuleType("requests")
+fake_requests.Response = type("Response", (), {})
+fake_requests.get = lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("requests no disponible"))
+fake_requests.post = lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("requests no disponible"))
+sys.modules.setdefault("requests", fake_requests)
+
+import pcobra.corelibs as core
+
+
+def test_mediana_lista_vacia():
+    with pytest.raises(ValueError):
+        core.mediana([])
+
+
+def test_moda_lista_vacia():
+    with pytest.raises(ValueError):
+        core.moda([])
+
+
+def test_desviacion_estandar_lista_vacia():
+    with pytest.raises(ValueError):
+        core.desviacion_estandar([])
+
+
+def test_desviacion_estandar_muestral_requiere_dos_valores():
+    with pytest.raises(ValueError):
+        core.desviacion_estandar([1.0], muestral=True)
+
+
+def test_raiz_validaciones():
+    with pytest.raises(ValueError):
+        core.raiz(4, 0)
+    with pytest.raises(ValueError):
+        core.raiz(-1, 2)
+    with pytest.raises(ValueError):
+        core.raiz(-8, 2.5)
+
+
+def test_clamp_rango_invalido():
+    with pytest.raises(ValueError):
+        core.clamp(1, 5, 2)
+
+
+def test_aleatorio_intervalo_invalido():
+    with pytest.raises(ValueError):
+        core.aleatorio(5, 1)
+
+
+def test_mediana_negativos_y_precision():
+    assert core.mediana([-5, -1, -3]) == -3
+    assert core.mediana([0.1, 0.2, 0.3, 0.4]) == pytest.approx(0.25)
+
+
+def test_redondear_precision():
+    valor = core.redondear(2 / 3, 3)
+    assert valor == pytest.approx(0.667, rel=1e-6)


### PR DESCRIPTION
## Summary
- añadir funciones numéricas avanzadas en corelibs.numero y exponerlas en el paquete
- implementar equivalentes en el runtime de JavaScript y ampliar las pruebas de corelibs
- documentar nuevos ejemplos en el manual y crear pruebas de estadística dedicadas

## Testing
- PYTEST_ADDOPTS="--cov-fail-under=0" pytest tests/unit/test_corelibs_numero_estadistica.py
- PYTEST_ADDOPTS="--cov-fail-under=0" pytest tests/unit/test_corelibs.py

------
https://chatgpt.com/codex/tasks/task_e_68cb181c631c8327a355e9be213916a3