### PR TITLE
feat: añadir utilidades de interfaz basadas en Rich

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -672,3 +672,33 @@ imprimir(columnas['region'])
 ```
 
 > **Diferencias entre backends:** las funciones de lectura y estadística solo están disponibles cuando el objetivo de ejecución es Python, ya que dependen de `pandas`. En JavaScript puedes seguir usando `seleccionar_columnas`, `filtrar`, `a_listas` y `de_listas`, pero las operaciones avanzadas dispararán un error explicando la limitación.
+
+## 25. Interfaces de consola enriquecidas
+
+El módulo `standard_library.interfaz` incorpora una capa de presentación construida sobre [`rich`](https://rich.readthedocs.io/) para crear paneles, tablas y barras de progreso sin tener que manipular manualmente códigos ANSI. Estas utilidades están pensadas para scripts de línea de comandos escritos en Cobra o en Python y mantienen el mismo API en ambos contextos.
+
+- `mostrar_tabla` acepta listas de diccionarios o secuencias y genera automáticamente los encabezados. Puedes personalizar el título y aplicar estilos Rich a cada columna.
+- `mostrar_panel` dibuja recuadros con bordes y soporta títulos, estilos y expansión.
+- `barra_progreso` expone un *context manager* que devuelve el objeto :class:`Progress` y el identificador de la tarea, lo que permite actualizar la barra con `advance` o `update`.
+- `imprimir_aviso` y `limpiar_consola` unifican la presentación de mensajes informativos, de advertencia o de error.
+- `iniciar_gui` e `iniciar_gui_idle` sirven como atajos seguros para lanzar las aplicaciones Flet oficiales del proyecto.
+
+```cobra
+usar standard_library.interfaz como ui
+
+var participantes = [
+    {"Nombre": "Ada", "Rol": "Pionera"},
+    {"Nombre": "Hedy", "Rol": "Educadora"},
+]
+
+ui.mostrar_tabla(participantes, titulo="Referentes")
+ui.imprimir_aviso("Datos cargados", nivel="exito")
+
+con ui.barra_progreso(descripcion="Procesando", total=3) como (progreso, tarea):
+    para var _ in rango(0, 3):
+        progreso.advance(tarea)
+```
+
+![Tabla generada con `mostrar_tabla`](frontend/_static/interfaz_tabla.svg)
+
+> Consejo: si necesitas usar estas utilidades desde un entorno que no tiene `rich` instalado, captura la excepción `RuntimeError` que lanzan y muestra un mensaje alternativo.

--- a/docs/frontend/_static/interfaz_tabla.svg
+++ b/docs/frontend/_static/interfaz_tabla.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 460 160" role="img" aria-labelledby="titulo descripcion">
+  <title id="titulo">Vista previa de mostrar_tabla</title>
+  <desc id="descripcion">Tabla ficticia renderizada en la consola utilizando Rich.</desc>
+  <rect x="1" y="1" width="458" height="158" rx="8" ry="8" fill="#0f172a" stroke="#38bdf8" stroke-width="2" />
+  <text x="230" y="32" font-family="'Fira Code', 'Courier New', monospace" font-size="18" fill="#38bdf8" text-anchor="middle">Referentes</text>
+  <line x1="20" y1="50" x2="440" y2="50" stroke="#38bdf8" stroke-width="1.5" />
+  <text x="60" y="78" font-family="'Fira Code', 'Courier New', monospace" font-size="15" fill="#e2e8f0">Nombre</text>
+  <text x="280" y="78" font-family="'Fira Code', 'Courier New', monospace" font-size="15" fill="#e2e8f0">Rol</text>
+  <line x1="20" y1="90" x2="440" y2="90" stroke="#38bdf8" stroke-width="1" stroke-dasharray="4 4" />
+  <text x="60" y="114" font-family="'Fira Code', 'Courier New', monospace" font-size="15" fill="#f8fafc">Ada</text>
+  <text x="280" y="114" font-family="'Fira Code', 'Courier New', monospace" font-size="15" fill="#f8fafc">Pionera</text>
+  <text x="60" y="140" font-family="'Fira Code', 'Courier New', monospace" font-size="15" fill="#f8fafc">Hedy</text>
+  <text x="280" y="140" font-family="'Fira Code', 'Courier New', monospace" font-size="15" fill="#f8fafc">Educadora</text>
+</svg>

--- a/docs/frontend/ejemplos.rst
+++ b/docs/frontend/ejemplos.rst
@@ -43,3 +43,27 @@ ensamblador.  Ejecuta, por ejemplo:
 
 El primer comando imprime la versión Hololang del programa ``saludo.co`` y el
 segundo parte desde Hololang para reconstruir el código Python equivalente.
+
+
+Interfaces de consola enriquecidas
+----------------------------------
+
+Las utilidades de ``standard_library.interfaz`` permiten componer tablas,
+paneles y barras de progreso directamente desde Cobra o desde scripts Python.
+
+.. code-block:: cobra
+
+   usar standard_library.interfaz como ui
+
+   var datos = [
+       {"Nombre": "Ada", "Rol": "Pionera"},
+       {"Nombre": "Grace", "Rol": "Arquitecta"},
+   ]
+
+   ui.mostrar_tabla(datos, titulo="Personas clave")
+   ui.imprimir_aviso("Tabla generada", nivel="exito")
+
+.. figure:: _static/interfaz_tabla.svg
+   :alt: Captura de una tabla renderizada con Rich
+
+   Vista previa producida por ``mostrar_tabla`` en la consola.

--- a/docs/standard_library/interfaz.md
+++ b/docs/standard_library/interfaz.md
@@ -1,0 +1,31 @@
+# `standard_library.interfaz`
+
+El módulo ofrece utilidades listas para usar con [`rich`](https://rich.readthedocs.io/):
+
+- **`mostrar_tabla(filas, columnas=None, titulo=None, estilos=None)`**: construye una
+  tabla a partir de listas de diccionarios o secuencias y la imprime usando la consola
+  indicada. Devuelve el objeto `Table` para ajustes adicionales.
+- **`mostrar_panel(contenido, titulo=None, estilo="bold cyan")`**: crea un panel con
+  bordes y permite definir el estilo interior y el color del borde.
+- **`barra_progreso(descripcion="Progreso", total=None)`**: context manager que
+  devuelve el `Progress` de Rich y el identificador de la tarea.
+- **`limpiar_consola(console=None)`**: invoca `Console.clear()` sobre la consola
+  objetivo.
+- **`imprimir_aviso(mensaje, nivel="info")`**: imprime mensajes consistentes con un
+  icono y estilo según el nivel.
+- **`iniciar_gui`** e **`iniciar_gui_idle`**: lanzan las aplicaciones Flet
+  distribuidas con Cobra, validando previamente que la dependencia esté disponible.
+
+```python
+from standard_library.interfaz import mostrar_tabla, barra_progreso
+
+filas = [
+    {"Nombre": "Ada", "Rol": "Pionera"},
+    {"Nombre": "Hedy", "Rol": "Educadora"},
+]
+
+mostrar_tabla(filas, titulo="Referentes")
+with barra_progreso(total=3, descripcion="Cargando") as (progreso, tarea):
+    for _ in range(3):
+        progreso.advance(tarea)
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,9 @@ Este directorio reúne distintos ejemplos de uso de Cobra y material relacionado
   cobra ejecutar examples/tutorial_basico/hola_mundo.co
   ```
 
+- **main.py**: script Python que muestra cómo usar `standard_library.interfaz` para
+  imprimir tablas y barras de progreso enriquecidas en la consola.
+
 ## Archivos individuales
 
 - `clase_metodo_atributo.co`

--- a/examples/main.py
+++ b/examples/main.py
@@ -5,7 +5,17 @@ from standard_library import *
 
 
 def principal():
-    print("Hola desde Codespaces")
+    referentes = [
+        {"Nombre": "Ada", "Rol": "Pionera"},
+        {"Nombre": "Grace", "Rol": "Arquitecta"},
+    ]
+
+    mostrar_tabla(referentes, titulo="Referentes Cobra")
+    imprimir_aviso("Tabla generada", nivel="exito")
+
+    with barra_progreso(total=3, descripcion="Preparando demo") as (progreso, tarea):
+        for _ in range(3):
+            progreso.advance(tarea)
 
 
 principal()

--- a/notebooks/ejemplo_basico.ipynb
+++ b/notebooks/ejemplo_basico.ipynb
@@ -51,6 +51,33 @@
     "cobra jupyter\n",
     "```\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interfaz de consola con Rich\n",
+    "Puedes aprovechar `standard_library.interfaz` para mostrar tablas y barras de progreso ",
+    "directamente desde un cuaderno cuando ejecutes código Cobra vía Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from standard_library import mostrar_tabla, barra_progreso, imprimir_aviso\n",
+    "referentes = [\n",
+    "    {'Nombre': 'Ada', 'Rol': 'Pionera'},\n",
+    "    {'Nombre': 'Grace', 'Rol': 'Arquitecta'},\n",
+    "]\n\n",
+    "mostrar_tabla(referentes, titulo='Referentes')\n",
+    "imprimir_aviso('Tabla generada', nivel='exito')\n\n",
+    "with barra_progreso(total=3, descripcion='Preparando ejemplos') as (progreso, tarea):\n",
+    "    for _ in range(3):\n",
+    "        progreso.advance(tarea)\n"
+   ]
   }
  ],
  "metadata": {},

--- a/src/pcobra/cobra/transpilers/common/utils.py
+++ b/src/pcobra/cobra/transpilers/common/utils.py
@@ -49,6 +49,7 @@ STANDARD_IMPORTS = {
         "import * as coleccion from './nativos/coleccion.js';",
         "import * as numero from './nativos/numero.js';",
         "import * as logica from './nativos/logica.js';",
+        "import * as interfaz from './nativos/interfaz.js';",
         "import * as red from './nativos/red.js';",
         "import * as seguridad from './nativos/seguridad.js';",
         "import * as sistema from './nativos/sistema.js';",

--- a/src/pcobra/core/nativos/interfaz.js
+++ b/src/pcobra/core/nativos/interfaz.js
@@ -1,0 +1,134 @@
+const NIVEL_A_ESTILO = {
+    info: { icono: 'ℹ', estilo: '' },
+    exito: { icono: '✔', estilo: '' },
+    advertencia: { icono: '⚠', estilo: '' },
+    error: { icono: '✖', estilo: '' },
+};
+
+export function mostrarTabla(filas, opciones = {}) {
+    const { columnas = null, titulo = null } = opciones;
+    if (titulo) {
+        console.log(`\n=== ${titulo} ===`);
+    }
+
+    if (Array.isArray(filas) && columnas && columnas.length > 0) {
+        const formateadas = filas.map((fila) => {
+            if (fila && typeof fila === 'object' && !Array.isArray(fila)) {
+                return columnas.reduce((acc, columna) => {
+                    acc[columna] = fila[columna];
+                    return acc;
+                }, {});
+            }
+            if (Array.isArray(fila)) {
+                return columnas.reduce((acc, columna, indice) => {
+                    acc[columna] = fila[indice];
+                    return acc;
+                }, {});
+            }
+            return { valor: fila };
+        });
+        console.table(formateadas);
+    } else {
+        console.table(filas);
+    }
+
+    if (titulo) {
+        console.log('');
+    }
+}
+
+export function mostrarPanel(contenido, opciones = {}) {
+    const { titulo = null } = opciones;
+    const texto = Array.isArray(contenido) ? contenido.join('\n') : String(contenido);
+    const lineas = texto.split('\n');
+    const ancho = Math.max(...lineas.map((linea) => linea.length), titulo ? titulo.length + 2 : 0);
+    const bordeHorizontal = '─'.repeat(ancho + 2);
+
+    if (titulo) {
+        const tituloCentrado = ` ${titulo} `;
+        const restante = bordeHorizontal.length - tituloCentrado.length;
+        const izquierda = Math.floor(restante / 2);
+        const derecha = restante - izquierda;
+        console.log(`┌${'─'.repeat(izquierda)}${tituloCentrado}${'─'.repeat(derecha)}┐`);
+    } else {
+        console.log(`┌${bordeHorizontal}┐`);
+    }
+
+    for (const linea of lineas) {
+        const padding = ' '.repeat(ancho - linea.length);
+        console.log(`│ ${linea}${padding} │`);
+    }
+    console.log(`└${bordeHorizontal}┘`);
+}
+
+export function limpiarConsola() {
+    console.clear();
+}
+
+export function imprimirAviso(mensaje, opciones = {}) {
+    const { nivel = 'info', icono = null } = opciones;
+    const configuracion = NIVEL_A_ESTILO[nivel] || NIVEL_A_ESTILO.info;
+    const simbolo = icono || configuracion.icono;
+    console.log(`${simbolo} ${mensaje}`);
+}
+
+export function barraProgreso(total = null, opciones = {}) {
+    const { descripcion = 'Progreso', stream = process.stdout } = opciones;
+    let objetivo = typeof total === 'number' ? total : null;
+    let completado = 0;
+    let frame = 0;
+    let finalizado = false;
+    const spinner = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+    const render = () => {
+        if (finalizado) {
+            return;
+        }
+        if (objetivo === null) {
+            const simbolo = spinner[frame % spinner.length];
+            frame += 1;
+            stream.write(`\r${simbolo} ${descripcion} ${completado}`);
+        } else {
+            const porcentaje = objetivo === 0 ? 100 : Math.min(100, Math.round((completado / objetivo) * 100));
+            const bloques = Math.round((porcentaje / 100) * 20);
+            const barra = '█'.repeat(bloques) + '░'.repeat(20 - bloques);
+            stream.write(`\r${descripcion} [${barra}] ${porcentaje}% (${completado}/${objetivo})`);
+        }
+    };
+
+    const limpiarLinea = () => {
+        stream.write('\r');
+    };
+
+    render();
+
+    return {
+        avanzar(cantidad = 1) {
+            completado += cantidad;
+            if (objetivo !== null) {
+                completado = Math.min(completado, objetivo);
+            }
+            render();
+        },
+        actualizar(valor) {
+            completado = valor;
+            render();
+        },
+        completar() {
+            finalizado = true;
+            if (objetivo !== null) {
+                completado = objetivo;
+                render();
+            }
+            stream.write('\n');
+        },
+        reiniciar(nuevoTotal = objetivo) {
+            objetivo = typeof nuevoTotal === 'number' ? nuevoTotal : null;
+            completado = 0;
+            finalizado = false;
+            frame = 0;
+            limpiarLinea();
+            render();
+        },
+    };
+}

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -22,6 +22,15 @@ from standard_library.datos import (
     seleccionar_columnas,
 )
 from standard_library.fecha import hoy, formatear, sumar_dias
+from standard_library.interfaz import (
+    barra_progreso,
+    imprimir_aviso,
+    iniciar_gui,
+    iniciar_gui_idle,
+    limpiar_consola,
+    mostrar_panel,
+    mostrar_tabla,
+)
 from standard_library.lista import (
     cabeza,
     chunk,
@@ -94,6 +103,13 @@ __all__: list[str] = [
     "agrupar_y_resumir",
     "a_listas",
     "de_listas",
+    "mostrar_tabla",
+    "mostrar_panel",
+    "barra_progreso",
+    "limpiar_consola",
+    "imprimir_aviso",
+    "iniciar_gui",
+    "iniciar_gui_idle",
 ]
 
 
@@ -106,3 +122,10 @@ filtrar: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Calla
 agrupar_y_resumir: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Sequence[str], Mapping[str, Any]], list[dict[str, Any]]]
 a_listas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, list[Any]]]
 de_listas: Callable[[Mapping[str, Sequence[Any]]], list[dict[str, Any]]]
+mostrar_tabla: Callable[..., Any]
+mostrar_panel: Callable[..., Any]
+barra_progreso: Callable[..., Any]
+limpiar_consola: Callable[..., None]
+imprimir_aviso: Callable[..., None]
+iniciar_gui: Callable[..., None]
+iniciar_gui_idle: Callable[..., None]

--- a/src/pcobra/standard_library/interfaz.py
+++ b/src/pcobra/standard_library/interfaz.py
@@ -1,0 +1,234 @@
+"""Utilidades de interfaz basadas en Rich para programas Cobra y scripts Python."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Literal
+
+from rich.console import Console, RenderableType
+from rich.panel import Panel
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TaskID,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+from rich.table import Table
+
+NivelAviso = Literal["info", "exito", "advertencia", "error"]
+FilaTabla = Mapping[str, Any] | Sequence[Any]
+
+
+def _obtener_console(console: Console | None) -> Console:
+    """Devuelve la consola proporcionada o crea una nueva en modo seguro."""
+
+    return console if console is not None else Console()
+
+
+def _es_secuencia(objeto: FilaTabla) -> bool:
+    """Determina si ``objeto`` es una secuencia apta (excluyendo cadenas)."""
+
+    return isinstance(objeto, Sequence) and not isinstance(objeto, (str, bytes, bytearray))
+
+
+def mostrar_tabla(
+    filas: Iterable[FilaTabla],
+    *,
+    columnas: Sequence[str] | None = None,
+    encabezados: Mapping[str, str] | None = None,
+    estilos: Mapping[str, str] | None = None,
+    titulo: str | None = None,
+    console: Console | None = None,
+) -> Table:
+    """Construye y muestra una tabla usando :mod:`rich`.
+
+    Args:
+        filas: Colección de filas representadas como diccionarios o secuencias.
+        columnas: Orden explícito de columnas. Si no se indica se infiere de los datos.
+        encabezados: Etiquetas amigables para los nombres de columna.
+        estilos: Estilos Rich aplicados a cada columna (``"bold green"``, ``"cyan"``, etc.).
+        titulo: Texto a mostrar en la cabecera de la tabla.
+        console: Consola Rich destino. Si se omite se crea una temporal.
+
+    Returns:
+        La instancia de :class:`rich.table.Table` creada, útil para pruebas o
+        personalizaciones adicionales.
+    """
+
+    console_obj = _obtener_console(console)
+    filas_materializadas = list(filas)
+
+    columnas_finales: list[str]
+    if columnas is not None:
+        columnas_finales = [str(col) for col in columnas]
+    else:
+        columnas_finales = []
+        for fila in filas_materializadas:
+            if isinstance(fila, Mapping):
+                for clave in fila.keys():
+                    clave_str = str(clave)
+                    if clave_str not in columnas_finales:
+                        columnas_finales.append(clave_str)
+            elif _es_secuencia(fila):
+                for indice in range(len(fila)):
+                    nombre = f"columna_{indice + 1}"
+                    if nombre not in columnas_finales:
+                        columnas_finales.append(nombre)
+
+    if not columnas_finales:
+        columnas_finales = ["valor"]
+
+    tabla = Table(title=titulo, header_style="bold")
+    for columna in columnas_finales:
+        encabezado = encabezados.get(columna, columna) if encabezados else columna
+        estilo = estilos.get(columna) if estilos else None
+        tabla.add_column(encabezado, style=estilo)
+
+    for fila in filas_materializadas:
+        if isinstance(fila, Mapping):
+            valores = [str(fila.get(col, "")) for col in columnas_finales]
+        elif _es_secuencia(fila):
+            fila_sec = list(fila)
+            valores = [str(valor) for valor in fila_sec]
+            if len(valores) < len(columnas_finales):
+                valores.extend("" for _ in range(len(columnas_finales) - len(valores)))
+            elif len(valores) > len(columnas_finales):
+                valores = valores[: len(columnas_finales)]
+        else:
+            valores = [str(fila)] + [""] * (len(columnas_finales) - 1)
+        tabla.add_row(*valores)
+
+    console_obj.print(tabla)
+    return tabla
+
+
+def mostrar_panel(
+    contenido: RenderableType,
+    *,
+    titulo: str | None = None,
+    estilo: str | None = "bold cyan",
+    borde: str | None = "cyan",
+    expandir: bool = True,
+    console: Console | None = None,
+) -> Panel:
+    """Muestra un panel decorado con Rich y devuelve el render creado."""
+
+    panel = Panel(
+        contenido,
+        title=titulo,
+        border_style=borde,
+        style=estilo,
+        expand=expandir,
+    )
+    console_obj = _obtener_console(console)
+    console_obj.print(panel)
+    return panel
+
+
+@contextmanager
+def barra_progreso(
+    *,
+    descripcion: str = "Progreso",
+    total: float | None = None,
+    console: Console | None = None,
+    transient: bool = True,
+) -> Iterator[tuple[Progress, TaskID]]:
+    """Context manager que crea una barra de progreso lista para usar."""
+
+    console_obj = _obtener_console(console)
+
+    columnas_barra: list[Any] = [
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(bar_width=None),
+    ]
+    if total is not None:
+        columnas_barra.append(TextColumn("{task.completed}/{task.total}"))
+        columnas_barra.append(TimeRemainingColumn())
+    else:
+        columnas_barra.append(TextColumn("{task.completed}"))
+    columnas_barra.append(TimeElapsedColumn())
+
+    progress = Progress(*columnas_barra, console=console_obj, transient=transient)
+    task_id = progress.add_task(descripcion, total=total)
+
+    with progress:
+        yield progress, task_id
+
+
+def limpiar_consola(*, console: Console | None = None) -> None:
+    """Limpia la consola utilizando :func:`rich.console.Console.clear`."""
+
+    console_obj = _obtener_console(console)
+    console_obj.clear()
+
+
+_AVISOS: dict[NivelAviso, tuple[str, str]] = {
+    "info": ("ℹ", "bold blue"),
+    "exito": ("✔", "bold green"),
+    "advertencia": ("⚠", "bold yellow"),
+    "error": ("✖", "bold red"),
+}
+
+
+def imprimir_aviso(
+    mensaje: str,
+    *,
+    nivel: NivelAviso = "info",
+    console: Console | None = None,
+    icono: str | None = None,
+) -> None:
+    """Imprime un mensaje con estilo uniforme para avisos y errores."""
+
+    console_obj = _obtener_console(console)
+    simbolo, estilo = _AVISOS.get(nivel, _AVISOS["info"])
+    simbolo_final = icono if icono is not None else simbolo
+    console_obj.print(f"{simbolo_final} {mensaje}", style=estilo)
+
+
+GuiTarget = Callable[[Any], None]
+
+
+def iniciar_gui(*, destino: GuiTarget | None = None, **kwargs: Any) -> None:
+    """Inicia la aplicación gráfica principal basada en Flet."""
+
+    try:
+        import flet as ft
+    except ModuleNotFoundError as exc:  # pragma: no cover - rama dependiente del entorno
+        raise RuntimeError("Flet no está instalado. Ejecuta 'pip install flet'.") from exc
+
+    target = destino
+    if target is None:
+        from pcobra.gui.app import main as target  # type: ignore[assignment]
+
+    ft.app(target=target, **kwargs)
+
+
+def iniciar_gui_idle(*, destino: GuiTarget | None = None, **kwargs: Any) -> None:
+    """Abre el entorno interactivo (IDLE) de Cobra usando Flet."""
+
+    try:
+        import flet as ft
+    except ModuleNotFoundError as exc:  # pragma: no cover - rama dependiente del entorno
+        raise RuntimeError("Flet no está instalado. Ejecuta 'pip install flet'.") from exc
+
+    target = destino
+    if target is None:
+        from pcobra.gui.idle import main as target  # type: ignore[assignment]
+
+    ft.app(target=target, **kwargs)
+
+
+__all__ = [
+    "mostrar_tabla",
+    "mostrar_panel",
+    "barra_progreso",
+    "limpiar_consola",
+    "imprimir_aviso",
+    "iniciar_gui",
+    "iniciar_gui_idle",
+]

--- a/tests/unit/test_standard_library_interfaz.py
+++ b/tests/unit/test_standard_library_interfaz.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from rich.console import Console
+from rich.table import Table
+
+
+def _cargar_interfaz() -> ModuleType:
+    ruta = Path(__file__).resolve().parents[2] / "src" / "pcobra" / "standard_library" / "interfaz.py"
+    spec = importlib.util.spec_from_file_location("pcobra.standard_library.interfaz", ruta)
+    if spec is None or spec.loader is None:  # pragma: no cover - error al cargar
+        raise RuntimeError("No se pudo preparar el módulo de interfaz")
+    modulo = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(modulo)
+    return modulo
+
+
+interfaz = _cargar_interfaz()
+barra_progreso = interfaz.barra_progreso
+imprimir_aviso = interfaz.imprimir_aviso
+iniciar_gui = interfaz.iniciar_gui
+iniciar_gui_idle = interfaz.iniciar_gui_idle
+limpiar_consola = interfaz.limpiar_consola
+mostrar_panel = interfaz.mostrar_panel
+mostrar_tabla = interfaz.mostrar_tabla
+
+
+def test_mostrar_tabla_emplea_console_mock():
+    console = Mock(spec=Console)
+    filas = [
+        {"nombre": "Ada", "rol": "Pionera"},
+        {"nombre": "Grace", "rol": "Arquitecta"},
+    ]
+
+    tabla = mostrar_tabla(filas, titulo="Referentes", console=console)
+
+    console.print.assert_called_once()
+    renderizable = console.print.call_args[0][0]
+    assert isinstance(renderizable, Table)
+    assert tabla is renderizable
+    assert [col.header for col in tabla.columns] == ["nombre", "rol"]
+
+
+def test_imprimir_aviso_formatea_estilo(monkeypatch):
+    console = Mock(spec=Console)
+    imprimir_aviso("Proceso finalizado", nivel="exito", console=console)
+
+    console.print.assert_called_once()
+    args, kwargs = console.print.call_args
+    assert "✔" in args[0]
+    assert kwargs.get("style") == "bold green"
+
+
+def test_limpiar_consola_invoca_clear():
+    console = Mock(spec=Console)
+    limpiar_consola(console=console)
+    console.clear.assert_called_once()
+
+
+def test_barra_progreso_avanza():
+    console = Console(record=True)
+    with barra_progreso(total=2, descripcion="Carga", console=console, transient=False) as (progreso, tarea):
+        progreso.advance(tarea)
+        progreso.advance(tarea)
+        assert progreso.tasks[0].completed == pytest.approx(2)
+
+
+def test_mostrar_panel_devuelve_render():
+    console = Mock(spec=Console)
+    panel = mostrar_panel("Hola", titulo="Panel", console=console)
+    console.print.assert_called_once_with(panel)
+
+
+def test_iniciar_gui_invoca_flet_app(monkeypatch):
+    fake_app = Mock()
+    fake_flet = SimpleNamespace(app=fake_app)
+    monkeypatch.setitem(sys.modules, "flet", fake_flet)
+
+    def dummy(page):
+        return page
+
+    iniciar_gui(destino=dummy, view="web")
+    fake_app.assert_called_once()
+    assert fake_app.call_args.kwargs["target"] is dummy
+    assert fake_app.call_args.kwargs["view"] == "web"
+
+
+def test_iniciar_gui_idle_usa_objetivo_por_defecto(monkeypatch):
+    fake_app = Mock()
+    fake_flet = SimpleNamespace(app=fake_app)
+    monkeypatch.setitem(sys.modules, "flet", fake_flet)
+
+    def marcador(page):
+        return page
+
+    idle_mod = ModuleType("pcobra.gui.idle")
+    idle_mod.main = marcador
+    monkeypatch.setitem(sys.modules, "pcobra.gui.idle", idle_mod)
+
+    iniciar_gui_idle()
+    fake_app.assert_called_once()
+    assert fake_app.call_args.kwargs["target"] is marcador


### PR DESCRIPTION
## Resumen
- incorporar el nuevo módulo `standard_library.interfaz` con helpers para tablas, paneles, barras de progreso y avisos sobre Rich, además de envoltorios opcionales para las apps Flet
- exponer el módulo desde la biblioteca estándar, sumar la contraparte nativa `core/nativos/interfaz.js` y ajustar las importaciones por defecto del transpiler de JavaScript
- documentar los helpers en el manual, en la guía de frontend y en la documentación de la biblioteca estándar, añadiendo una captura SVG, ejemplos actualizados y una celda de notebook
- ampliar la batería de pruebas con verificaciones sobre Rich mediante `Console` simulado y pruebas de humo para los lanzadores de Flet

## Pruebas
- pytest --override-ini="addopts=" tests/unit/test_standard_library_interfaz.py


------
https://chatgpt.com/codex/tasks/task_e_68cba11ab18883279d0e4d5addc6e0a3