### PR TITLE
Add extended text helpers

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -537,6 +537,9 @@ El módulo `pcobra.corelibs.texto` se amplió con herramientas inspiradas en `st
 - `reemplazar`, `empieza_con`, `termina_con` e `incluye` para búsquedas y sustituciones expresivas.
 - `rellenar_izquierda` y `rellenar_derecha` para completar cadenas con cualquier patrón.
 - `normalizar_unicode` que acepta las formas `NFC`, `NFD`, `NFKC` y `NFKD` para trabajar con Unicode de forma predecible.
+- `quitar_prefijo` y `quitar_sufijo` replican `str.removeprefix`/`str.removesuffix` de Python, `strings.TrimPrefix`/`TrimSuffix` de Go y los patrones `startsWith`/`endsWith` + `slice` en JavaScript.
+- `dividir_lineas` respeta combinaciones `\r\n` como `str.splitlines`, `contar_subcadena` acepta intervalos opcionales al estilo `str.count`, `centrar_texto` centra con relleno como `str.center` y `rellenar_ceros` añade ceros como `str.zfill`.
+- `minusculas_casefold` aplica minúsculas intensivas (`casefold`) que homogeneizan mayúsculas, ß alemana o símbolos con diacríticos.
 
 En la biblioteca estándar (`standard_library.texto`) se añadieron utilidades de mayor nivel como `quitar_acentos`, `normalizar_espacios`, `es_palindromo` y `es_anagrama`. Estas funciones combinan las primitivas anteriores para resolver tareas frecuentes como limpiar entrada de usuarios, validar palíndromos independientemente de acentos o comparar cadenas ignorando espacios.
 
@@ -548,6 +551,9 @@ imprimir(core.titulo("guía de cobra"))          # 'Guía De Cobra'
 imprimir(core.dividir("uno   dos\ttres"))       # ['uno', 'dos', 'tres']
 imprimir(texto.quitar_acentos("Canción"))       # 'Cancion'
 imprimir(texto.es_palindromo("Sé verlas al revés"))  # True
+imprimir(core.quitar_prefijo("🧪Prueba", "🧪"))      # 'Prueba'
+imprimir(core.centrar_texto("cobra", 9, "*"))        # '**cobra**'
+imprimir(core.minusculas_casefold("Straße"))         # 'strasse'
 ```
 
 Estas herramientas están disponibles al transpirar tanto a Python como a JavaScript y respetan los casos borde como cadenas vacías o entradas Unicode combinadas.

--- a/docs/cheatsheet.tex
+++ b/docs/cheatsheet.tex
@@ -55,4 +55,16 @@ excepto & Captura de excepción\\
 \end{tabular}
 
 \textit{Todas las funciones validan que las entradas sean booleanas y lanzan \texttt{TypeError} si se proporciona otro tipo.}
+
+\section*{Texto}
+\begin{tabular}{ll}
+\textbf{Función} & \textbf{Descripción}\\\hline
+\texttt{quitar\_prefijo(cad, prefijo)} & Elimina el prefijo si existe, como \texttt{str.removeprefix}.\\
+\texttt{quitar\_sufijo(cad, sufijo)} & Recorta el sufijo coincidente, inspirado en \texttt{str.removesuffix}.\\
+\texttt{dividir\_lineas(cad, conservar)} & Divide por saltos de línea opcionalmente manteniéndolos.\\
+\texttt{contar\_subcadena(cad, sub, ini, fin)} & Cuenta apariciones sin solapamiento en el intervalo dado.\\
+\texttt{centrar\_texto(cad, ancho, relleno)} & Centra la cadena rellenando con un carácter.\\
+\texttt{rellenar\_ceros(cad, ancho)} & Antepone ceros respetando signos como \texttt{str.zfill}.\\
+\texttt{minusculas\_casefold(cad)} & Convierte a minúsculas Unicode agresivas (casefold).\\
+\end{tabular}
 \end{document}

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -9,11 +9,18 @@ from corelibs.texto import (
     concatenar,
     quitar_espacios,
     dividir,
+    dividir_lineas,
     unir,
     reemplazar,
     empieza_con,
     termina_con,
     incluye,
+    quitar_prefijo,
+    quitar_sufijo,
+    contar_subcadena,
+    centrar_texto,
+    rellenar_ceros,
+    minusculas_casefold,
     rellenar_izquierda,
     rellenar_derecha,
     normalizar_unicode,
@@ -92,11 +99,18 @@ __all__ = [
     "concatenar",
     "quitar_espacios",
     "dividir",
+    "dividir_lineas",
     "unir",
     "reemplazar",
     "empieza_con",
     "termina_con",
     "incluye",
+    "quitar_prefijo",
+    "quitar_sufijo",
+    "contar_subcadena",
+    "centrar_texto",
+    "rellenar_ceros",
+    "minusculas_casefold",
     "rellenar_izquierda",
     "rellenar_derecha",
     "normalizar_unicode",
@@ -161,3 +175,46 @@ __all__ = [
     "obtener_env",
     "listar_dir",
 ]
+
+quitar_prefijo.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.texto.quitar_prefijo`. Equivale a ``str.removeprefix`` "
+    "en Python, ``strings.TrimPrefix`` en Go y puede reproducirse en JavaScript"
+    " combinando ``String.prototype.startsWith`` con ``slice``."
+)
+
+quitar_sufijo.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.texto.quitar_sufijo`. Se inspira en ``str.removesuffix`` "
+    "de Python, ``strings.TrimSuffix`` del paquete estándar de Go y en el uso de"
+    " ``String.prototype.endsWith`` junto a ``slice`` en JavaScript."
+)
+
+dividir_lineas.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.texto.dividir_lineas`. Ofrece la misma semántica"
+    " que ``str.splitlines`` de Python, comparable a recorrer líneas con ``bufio.Scanner``"
+    " en Go o dividir por expresiones ``/\r?\n/`` en JavaScript."
+)
+
+contar_subcadena.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.texto.contar_subcadena`. Equivale a usar"
+    " ``str.count`` en Python, ``strings.Count`` en Go o dividir cadenas en JavaScript"
+    " para cuantificar apariciones."
+)
+
+centrar_texto.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.texto.centrar_texto`. Refleja ``str.center`` de"
+    " Python, puede replicarse en Go combinando ``strings.Repeat`` y operaciones de"
+    " concatenación y en JavaScript mediante ``padStart`` y ``padEnd``."
+)
+
+rellenar_ceros.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.texto.rellenar_ceros`. Es análogo a ``str.zfill``"
+    " de Python, a ``fmt.Sprintf(\"%0*d\", ancho, valor)`` en Go y a ``padStart``"
+    " con ceros en JavaScript."
+)
+
+minusculas_casefold.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.texto.minusculas_casefold`. Sigue las reglas"
+    " de ``str.casefold`` en Python, puede lograrse en Go con ``cases.Fold`` del"
+    " paquete ``x/text`` y en JavaScript mediante normalización previa y"
+    " ``toLocaleLowerCase``."
+)

--- a/src/pcobra/corelibs/texto.py
+++ b/src/pcobra/corelibs/texto.py
@@ -132,6 +132,22 @@ def incluye(texto: str, subcadena: str) -> bool:
     return subcadena in texto
 
 
+def quitar_prefijo(texto: str, prefijo: str) -> str:
+    """Emula ``str.removeprefix`` de Python, ``strings.TrimPrefix`` de Go y el patrón ``startsWith``/``slice`` de JavaScript."""
+
+    if prefijo and texto.startswith(prefijo):
+        return texto[len(prefijo) :]
+    return texto
+
+
+def quitar_sufijo(texto: str, sufijo: str) -> str:
+    """Replica ``str.removesuffix`` de Python, ``strings.TrimSuffix`` en Go y el recorte con ``endsWith``/``slice`` en JavaScript."""
+
+    if sufijo and texto.endswith(sufijo):
+        return texto[: -len(sufijo)]
+    return texto
+
+
 def rellenar_izquierda(texto: str, ancho: int, relleno: str = " ") -> str:
     """Rellena ``texto`` por la izquierda hasta alcanzar ``ancho`` caracteres."""
 
@@ -171,3 +187,44 @@ def normalizar_unicode(texto: str, forma: str = "NFC") -> str:
     if forma not in formas_permitidas:
         raise ValueError(f"forma debe ser una de {sorted(formas_permitidas)}")
     return unicodedata.normalize(forma, texto)
+
+
+def dividir_lineas(texto: str, conservar_delimitadores: bool = False) -> list[str]:
+    """Hace eco de ``str.splitlines`` (Python), ``bufio.Scanner`` (Go) y ``String.prototype.split`` (JS)."""
+
+    return texto.splitlines(keepends=conservar_delimitadores)
+
+
+def contar_subcadena(
+    texto: str,
+    subcadena: str,
+    inicio: int | None = None,
+    fin: int | None = None,
+) -> int:
+    """Imita ``str.count`` (Python), ``strings.Count`` (Go) y ``String.prototype.split`` para conteos en JS."""
+
+    if inicio is None and fin is None:
+        return texto.count(subcadena)
+    if inicio is None:
+        return texto.count(subcadena, 0, fin)
+    if fin is None:
+        return texto.count(subcadena, inicio)
+    return texto.count(subcadena, inicio, fin)
+
+
+def centrar_texto(texto: str, ancho: int, relleno: str = " ") -> str:
+    """Se alinea con ``str.center`` (Python), ``strings.Repeat`` en Go y ``padStart``/``padEnd`` en JS."""
+
+    return texto.center(ancho, relleno)
+
+
+def rellenar_ceros(texto: str, ancho: int) -> str:
+    """Equivale a ``str.zfill`` (Python), ``fmt.Sprintf`` en Go y ``padStart`` con ``'0'`` en JS."""
+
+    return texto.zfill(ancho)
+
+
+def minusculas_casefold(texto: str) -> str:
+    """Aplica ``str.casefold`` (Python), ``cases.Fold`` del paquete ``x/text`` en Go y ``toLocaleLowerCase`` estricto en JS."""
+
+    return texto.casefold()

--- a/src/pcobra/standard_library/texto.py
+++ b/src/pcobra/standard_library/texto.py
@@ -1,18 +1,47 @@
-"""Funciones de texto de alto nivel basadas en ``pcobra.corelibs.texto``."""
+"""Funciones de texto de alto nivel basadas en ``pcobra.corelibs.texto``.
+
+Ejemplo rápido::
+
+    import standard_library.texto as texto
+
+    texto.quitar_prefijo("🧪Prueba", "🧪")  # -> "Prueba"
+    texto.centrar_texto("cobra", 10, "-")    # -> "---cobra--"
+    texto.dividir_lineas("uno\r\ndos\n", conservar_delimitadores=True)
+    # -> ["uno\r\n", "dos\n"]
+"""
 
 from __future__ import annotations
 
 import unicodedata
 from pcobra.corelibs import (
+    centrar_texto as _centrar_texto,
+    contar_subcadena as _contar_subcadena,
     dividir,
+    dividir_lineas as _dividir_lineas,
     invertir,
     minusculas,
+    minusculas_casefold as _minusculas_casefold,
     normalizar_unicode,
     quitar_espacios,
+    quitar_prefijo as _quitar_prefijo,
+    quitar_sufijo as _quitar_sufijo,
+    rellenar_ceros as _rellenar_ceros,
     unir,
 )
 
-__all__ = ["quitar_acentos", "normalizar_espacios", "es_palindromo", "es_anagrama"]
+__all__ = [
+    "quitar_acentos",
+    "normalizar_espacios",
+    "es_palindromo",
+    "es_anagrama",
+    "quitar_prefijo",
+    "quitar_sufijo",
+    "dividir_lineas",
+    "contar_subcadena",
+    "centrar_texto",
+    "rellenar_ceros",
+    "minusculas_casefold",
+]
 
 
 def quitar_acentos(texto: str) -> str:
@@ -66,3 +95,75 @@ def es_anagrama(texto: str, otro: str, *, ignorar_espacios: bool = True) -> bool
         return normalizar_unicode("".join(sorted(resultado)), "NFC")
 
     return preparar(texto) == preparar(otro)
+
+
+def quitar_prefijo(texto: str, prefijo: str) -> str:
+    """Elimina ``prefijo`` cuando ``texto`` lo contiene al inicio.
+
+    Ejemplo::
+
+        quitar_prefijo("foobar", "foo")  # -> "bar"
+    """
+
+    return _quitar_prefijo(texto, prefijo)
+
+
+def quitar_sufijo(texto: str, sufijo: str) -> str:
+    """Recorta ``sufijo`` si ``texto`` termina con él.
+
+    Ejemplo::
+
+        quitar_sufijo("archivo.tmp", ".tmp")  # -> "archivo"
+    """
+
+    return _quitar_sufijo(texto, sufijo)
+
+
+def dividir_lineas(texto: str, conservar_delimitadores: bool = False) -> list[str]:
+    """Divide ``texto`` por saltos de línea sin perder combinaciones ``\r\n``.
+
+    Args:
+        texto: Contenido multilinea a segmentar.
+        conservar_delimitadores: Cuando es ``True`` preserva los separadores.
+    """
+
+    return _dividir_lineas(texto, conservar_delimitadores)
+
+
+def contar_subcadena(
+    texto: str,
+    subcadena: str,
+    inicio: int | None = None,
+    fin: int | None = None,
+) -> int:
+    """Cuenta apariciones de ``subcadena`` respetando ``inicio`` y ``fin``.
+
+    Ejemplo::
+
+        contar_subcadena("banana", "na")  # -> 2
+    """
+
+    return _contar_subcadena(texto, subcadena, inicio, fin)
+
+
+def centrar_texto(texto: str, ancho: int, relleno: str = " ") -> str:
+    """Centra ``texto`` a ``ancho`` caracteres usando ``relleno``.
+
+    Ejemplo::
+
+        centrar_texto("cobra", 9, "*")  # -> "**cobra**"
+    """
+
+    return _centrar_texto(texto, ancho, relleno)
+
+
+def rellenar_ceros(texto: str, ancho: int) -> str:
+    """Completa ``texto`` con ceros a la izquierda preservando signos."""
+
+    return _rellenar_ceros(texto, ancho)
+
+
+def minusculas_casefold(texto: str) -> str:
+    """Devuelve ``texto`` en minúsculas intensivas según Unicode (casefold)."""
+
+    return _minusculas_casefold(texto)

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -47,6 +47,25 @@ def test_texto_funcs():
     assert core.empieza_con("cobral", ("co", "za")) is True
     assert core.termina_con("cobral", ("co", "al")) is True
     assert core.incluye("hola", "ol") is True
+    assert core.quitar_prefijo("prefijo", "pre") == "fijo"
+    assert core.quitar_prefijo("prefijo", "prE") == "prefijo"
+    assert core.quitar_sufijo("archivo.tmp", ".tmp") == "archivo"
+    assert core.quitar_sufijo("archivo.tmp", ".tm") == "archivo.tmp"
+    assert core.dividir_lineas("uno\r\ndos\n") == ["uno", "dos"]
+    assert core.dividir_lineas("uno\r\ndos\n", conservar_delimitadores=True) == [
+        "uno\r\n",
+        "dos\n",
+    ]
+    assert core.dividir_lineas("") == []
+    assert core.contar_subcadena("banana", "na") == 2
+    assert core.contar_subcadena("banana", "na", 0, 3) == 0
+    assert core.centrar_texto("cobra", 9, "*") == "**cobra**"
+    with pytest.raises(TypeError):
+        core.centrar_texto("cobra", 10, "--")
+    assert core.rellenar_ceros("7", 3) == "007"
+    assert core.rellenar_ceros("-5", 4) == "-005"
+    assert core.rellenar_ceros("猫", 3) == "00猫"
+    assert core.minusculas_casefold("Straße") == "strasse"
     assert core.rellenar_izquierda("7", 3, "0") == "007"
     assert core.rellenar_derecha("7", 3, "0") == "700"
     with pytest.raises(ValueError):

--- a/tests/unit/test_standard_library_texto.py
+++ b/tests/unit/test_standard_library_texto.py
@@ -1,3 +1,5 @@
+import pytest
+
 import standard_library.texto as texto
 
 
@@ -22,3 +24,31 @@ def test_es_anagrama():
     assert texto.es_anagrama("Roma", "amor") is True
     assert texto.es_anagrama("cosa", "caso") is True
     assert texto.es_anagrama("cosa", "caso ", ignorar_espacios=False) is False
+
+
+def test_prefijos_y_sufijos():
+    assert texto.quitar_prefijo("🧪Prueba", "🧪") == "Prueba"
+    assert texto.quitar_prefijo("demo", "x") == "demo"
+    assert texto.quitar_sufijo("archivo.log", ".log") == "archivo"
+    assert texto.quitar_sufijo("archivo.log", ".gz") == "archivo.log"
+
+
+def test_dividir_lineas_y_contar():
+    contenido = "uno\r\ndos\n"
+    assert texto.dividir_lineas(contenido) == ["uno", "dos"]
+    assert texto.dividir_lineas(contenido, conservar_delimitadores=True) == [
+        "uno\r\n",
+        "dos\n",
+    ]
+    assert texto.contar_subcadena("bananana", "na") == 3
+    assert texto.contar_subcadena("bananana", "na", 2) == 3
+    assert texto.contar_subcadena("bananana", "na", 0, 5) == 1
+
+
+def test_centrar_rellenar_y_casefold():
+    assert texto.centrar_texto("cobra", 9, "*") == "**cobra**"
+    with pytest.raises(TypeError):
+        texto.centrar_texto("cobra", 10, "--")
+    assert texto.rellenar_ceros("-5", 4) == "-005"
+    assert texto.rellenar_ceros("猫", 3) == "00猫"
+    assert texto.minusculas_casefold("Straße") == "strasse"


### PR DESCRIPTION
## Summary
- expand `pcobra.corelibs.texto` with helpers that mirror Python, Go and JavaScript string operations
- reexport the helpers in `pcobra.corelibs` and expose friendly wrappers in `standard_library.texto`
- cover the new behaviours with unit tests and update documentation references

## Testing
- PYTEST_ADDOPTS=--no-cov pytest tests/unit/test_corelibs.py tests/unit/test_standard_library_texto.py

------
https://chatgpt.com/codex/tasks/task_e_68cbaad57f5883278f87c83696fb1757