### PR TITLE
Add logical aggregate helpers

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -633,6 +633,10 @@ Las funciones están disponibles tanto al ejecutar Cobra directamente como al tr
 - `xor`, `nand`, `nor`, `implica` y `equivale` facilitan construir tablas de verdad completas.
 - `xor_multiple` acepta un número arbitrario de argumentos y exige al menos dos valores.
 - `todas` y `alguna` validan colecciones de booleanos antes de aplicar `all`/`any`.
+- `ninguna` retorna `True` únicamente cuando todos los elementos son falsos, como el agregador ``none`` de Cobra.
+- `solo_uno` verifica si exactamente un elemento es verdadero, equivalente a ``one?`` y lanza `ValueError` si no recibe argumentos.
+- `conteo_verdaderos` devuelve el total de verdaderos (similar a ``count``) y permite reutilizar el resultado para otras comprobaciones.
+- `paridad` informa si el número de verdaderos es par; internamente reutiliza `conteo_verdaderos` y equivale a calcular ``count(valores) % 2 == 0``.
 
 Los parámetros no booleanos producen un `TypeError` descriptivo, lo cual ayuda a detectar errores lógicos tempranamente. Además, la versión en JavaScript (`core/nativos/logica.js`) replica la semántica para mantener el comportamiento al transpirar.
 
@@ -646,6 +650,10 @@ imprimir(logica_alto_nivel.xor_multiple(True, False, False))  # True
 
 var sensores = [True, True, False]
 imprimir(logica_alto_nivel.alguna(sensores))      # True
+imprimir(logica_alto_nivel.ninguna(sensores))     # False
+imprimir(logica_alto_nivel.solo_uno(True, False, False))  # True
+imprimir(logica_alto_nivel.conteo_verdaderos(sensores))   # 2
+imprimir(logica_alto_nivel.paridad(sensores))     # False
 
 # Lanzan errores al recibir datos que no son booleanos
 logica.todas([True, 1])  # -> TypeError

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -37,6 +37,10 @@ from corelibs.logica import (
     xor_multiple,
     todas,
     alguna,
+    ninguna,
+    solo_uno,
+    conteo_verdaderos,
+    paridad,
 )
 from corelibs.numero import (
     absoluto,
@@ -131,6 +135,10 @@ __all__ = [
     "xor_multiple",
     "todas",
     "alguna",
+    "ninguna",
+    "solo_uno",
+    "conteo_verdaderos",
+    "paridad",
     "absoluto",
     "aleatorio",
     "clamp",

--- a/src/pcobra/corelibs/logica.py
+++ b/src/pcobra/corelibs/logica.py
@@ -106,6 +106,46 @@ def alguna(valores: Iterable[bool]) -> bool:
     return any(lista)
 
 
+def ninguna(valores: Iterable[bool]) -> bool:
+    """Devuelve ``True`` cuando todos los elementos son ``False``."""
+
+    lista = list(valores)
+    for indice, valor in enumerate(lista):
+        _asegurar_booleano(valor, f"valor_{indice}")
+    return not any(lista)
+
+
+def solo_uno(*valores: bool) -> bool:
+    """Devuelve ``True`` si exactamente uno de los argumentos es verdadero."""
+
+    if not valores:
+        raise ValueError("Se necesita al menos un valor booleano para solo_uno")
+
+    verdaderos = 0
+    for indice, valor in enumerate(valores):
+        if _asegurar_booleano(valor, f"valor_{indice}"):
+            verdaderos += 1
+            if verdaderos > 1:
+                return False
+    return verdaderos == 1
+
+
+def conteo_verdaderos(valores: Iterable[bool]) -> int:
+    """Cuenta la cantidad de elementos verdaderos en *valores*."""
+
+    contador = 0
+    for indice, valor in enumerate(valores):
+        if _asegurar_booleano(valor, f"valor_{indice}"):
+            contador += 1
+    return contador
+
+
+def paridad(valores: Iterable[bool]) -> bool:
+    """Retorna ``True`` si el número de verdaderos en *valores* es par."""
+
+    return conteo_verdaderos(valores) % 2 == 0
+
+
 __all__ = [
     "conjuncion",
     "disyuncion",
@@ -118,4 +158,8 @@ __all__ = [
     "xor_multiple",
     "todas",
     "alguna",
+    "ninguna",
+    "solo_uno",
+    "conteo_verdaderos",
+    "paridad",
 ]

--- a/src/pcobra/standard_library/logica.py
+++ b/src/pcobra/standard_library/logica.py
@@ -72,3 +72,27 @@ def alguna(valores: Iterable[bool]) -> bool:
 
     return _logica.alguna(valores)
 
+
+def ninguna(valores: Iterable[bool]) -> bool:
+    """Devuelve ``True`` cuando ningún elemento es verdadero (equivalente a ``none``)."""
+
+    return _logica.ninguna(valores)
+
+
+def solo_uno(*valores: bool) -> bool:
+    """Retorna ``True`` si exactamente un argumento es verdadero (equivalente a ``one?``)."""
+
+    return _logica.solo_uno(*valores)
+
+
+def conteo_verdaderos(valores: Iterable[bool]) -> int:
+    """Cuenta cuántos elementos son verdaderos (equivalente a ``count``)."""
+
+    return _logica.conteo_verdaderos(valores)
+
+
+def paridad(valores: Iterable[bool]) -> bool:
+    """Informa si la cantidad de verdaderos es par, como usar ``count`` y comprobar ``% 2``."""
+
+    return _logica.paridad(valores)
+

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -138,6 +138,21 @@ def test_logica_funcs():
     assert core.alguna([False, False, True]) is True
     assert core.alguna([False, False, False]) is False
 
+    casos_coleccion = [
+        ([False, False], True, False, 0, True),
+        ([True, False], False, True, 1, False),
+        ([True, True, False], False, False, 2, True),
+        ([True, True, True], False, False, 3, False),
+    ]
+    for valores, ninguna_esperado, solo_uno_esperado, conteo_esperado, paridad_esperada in casos_coleccion:
+        assert core.ninguna(valores) is ninguna_esperado
+        assert core.solo_uno(*valores) is solo_uno_esperado
+        assert core.conteo_verdaderos(valores) == conteo_esperado
+        assert core.paridad(valores) is paridad_esperada
+
+    assert core.solo_uno(True, False, False, False) is True
+    assert core.solo_uno(False, False, False) is False
+
     with pytest.raises(TypeError):
         core.conjuncion(1, True)
     with pytest.raises(TypeError):
@@ -152,6 +167,16 @@ def test_logica_funcs():
         core.todas([True, 1])
     with pytest.raises(TypeError):
         core.alguna([False, None])
+    with pytest.raises(ValueError):
+        core.solo_uno()
+    with pytest.raises(TypeError):
+        core.solo_uno(True, 0)
+    with pytest.raises(TypeError):
+        core.ninguna([True, 1])
+    with pytest.raises(TypeError):
+        core.conteo_verdaderos([False, None])
+    with pytest.raises(TypeError):
+        core.paridad([True, "no bool"])
 
 
 def test_archivo_funcs(tmp_path, monkeypatch):

--- a/tests/unit/test_logica.py
+++ b/tests/unit/test_logica.py
@@ -37,6 +37,21 @@ def test_logica_colecciones():
     assert logica.alguna([False, False, True]) is True
     assert logica.alguna([False, False]) is False
 
+    casos_coleccion = [
+        ([False, False], True, False, 0, True),
+        ([True, False], False, True, 1, False),
+        ([True, True, False], False, False, 2, True),
+        ([True, True, True], False, False, 3, False),
+    ]
+    for valores, ninguna_esperado, solo_uno_esperado, conteo_esperado, paridad_esperada in casos_coleccion:
+        assert logica.ninguna(valores) is ninguna_esperado
+        assert logica.solo_uno(*valores) is solo_uno_esperado
+        assert logica.conteo_verdaderos(valores) == conteo_esperado
+        assert logica.paridad(valores) is paridad_esperada
+
+    assert logica.solo_uno(True, False, False, False) is True
+    assert logica.solo_uno(False, False, False) is False
+
 
 def test_logica_valida_entradas():
     with pytest.raises(TypeError):
@@ -53,4 +68,14 @@ def test_logica_valida_entradas():
         logica.todas([True, 1])
     with pytest.raises(TypeError):
         logica.alguna([False, None])
+    with pytest.raises(ValueError):
+        logica.solo_uno()
+    with pytest.raises(TypeError):
+        logica.solo_uno(True, 0)
+    with pytest.raises(TypeError):
+        logica.ninguna([True, 1])
+    with pytest.raises(TypeError):
+        logica.conteo_verdaderos([False, None])
+    with pytest.raises(TypeError):
+        logica.paridad([True, "no bool"])
 


### PR DESCRIPTION
## Summary
- add logical aggregate helpers (`ninguna`, `solo_uno`, `conteo_verdaderos`, `paridad`) with strict type validation and export them
- expose the helpers through the standard library wrappers and document their relationship with Cobra aggregators
- extend unit tests with truth tables and error checks for the new helpers and update the manual with usage examples

## Testing
- pytest -o addopts='' tests/unit/test_corelibs.py tests/unit/test_logica.py

------
https://chatgpt.com/codex/tasks/task_e_68cbb00fbcac8327a0a01271cee00ddf