### PR TITLE
Añade utilidades tabulares avanzadas

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -669,6 +669,10 @@ El módulo `standard_library.datos` añade una capa ligera sobre `pandas` que pe
 - `describir` calcula estadísticas básicas (`count`, `mean`, `std`, percentiles) para cada columna.
 - `seleccionar_columnas` y `filtrar` permiten aislar subconjuntos antes de seguir procesando los datos.
 - `agrupar_y_resumir` aplica agregaciones (`sum`, `mean`, funciones personalizadas) agrupando por columnas clave.
+- `ordenar_tabla` admite ordenar por varias columnas controlando el sentido ascendente o descendente de cada una.
+- `combinar_tablas` replica los `join` de pandas y R para cruzar datasets con claves compartidas o diferenciadas.
+- `rellenar_nulos` rellena valores perdidos por columna antes de analizar la información.
+- `pivotar_tabla` reorganiza los datos en formato ancho calculando métricas múltiples de manera declarativa.
 - `a_listas` y `de_listas` convierten entre lista de registros y diccionario de columnas, facilitando la interoperabilidad con librerías externas.
 
 ```cobra
@@ -680,6 +684,16 @@ resumen = pandas.agrupar_y_resumir(
     ventas_limpias,
     por=['region'],
     agregaciones={'monto': 'sum'}
+)
+ventas_ordenadas = pandas.ordenar_tabla(ventas_limpias, por=['region', 'mes'], ascendente=[True, False])
+ventas_con_clientes = pandas.combinar_tablas(clientes, ventas_limpias, claves=('cliente_id', 'cliente'), tipo='left')
+ventas_completas = pandas.rellenar_nulos(ventas_con_clientes, {'monto': 0})
+resumen_ancho = pandas.pivotar_tabla(
+    ventas_completas,
+    index='region',
+    columnas='mes',
+    valores='monto',
+    agregacion='sum'
 )
 columnas = pandas.a_listas(resumen)
 imprimir(columnas['region'])

--- a/docs/cheatsheet.tex
+++ b/docs/cheatsheet.tex
@@ -80,4 +80,13 @@ excepto & Captura de excepción\\
 \texttt{rellenar\_ceros(cad, ancho)} & Antepone ceros respetando signos como \texttt{str.zfill}.\\
 \texttt{minusculas\_casefold(cad)} & Convierte a minúsculas Unicode agresivas (casefold).\\
 \end{tabular}
+
+\section*{Datos tabulares}
+\begin{tabular}{ll}
+\textbf{Función} & \textbf{Descripción}\\\hline
+\texttt{ordenar\_tabla(datos, por, ascendente)} & Ordena múltiples columnas al estilo pandas/R manteniendo listas de registros.\\
+\texttt{combinar\_tablas(izq, der, claves, tipo)} & Realiza joins internos/externos validando claves antes de cruzar la información.\\
+\texttt{rellenar\_nulos(datos, valores)} & Sustituye valores perdidos por columna siguiendo reglas declarativas.\\
+\texttt{pivotar\_tabla(datos, index, columnas, valores, agregacion)} & Reorganiza métricas a formato ancho con agregaciones múltiples.\\
+\end{tabular}
 \end{document}


### PR DESCRIPTION
## Resumen
- incorporar funciones de ordenamiento, combinación, rellenado de nulos y pivoteo en `standard_library.datos`, inspiradas en pandas y R
- ampliar la batería de pruebas unitarias con fixtures y casos para joins, ordenamientos, rellenos y pivotajes
- documentar las nuevas capacidades en el manual y la chuleta de Cobra

## Pruebas
- `PYTEST_ADDOPTS="--cov-fail-under=0" pytest tests/unit/test_standard_library_datos.py`


------
https://chatgpt.com/codex/tasks/task_e_68cbb2aaeac48327a1272ebca83ce6b2