### PR TITLE
Añadir utilidades de interfaz con Rich

### DIFF
--- a/docs/standard_library/interfaz.md
+++ b/docs/standard_library/interfaz.md
@@ -5,6 +5,16 @@ El módulo ofrece utilidades listas para usar con [`rich`](https://rich.readthed
 - **`mostrar_tabla(filas, columnas=None, titulo=None, estilos=None)`**: construye una
   tabla a partir de listas de diccionarios o secuencias y la imprime usando la consola
   indicada. Devuelve el objeto `Table` para ajustes adicionales.
+- **`mostrar_codigo(codigo, lenguaje)`**: resalta código fuente usando
+  [`rich.syntax.Syntax`](https://rich.readthedocs.io/en/stable/syntax.html) y lo
+  imprime en la consola indicada. Devuelve el objeto `Syntax` para posteriores
+  personalizaciones.
+- **`mostrar_arbol(nodos, titulo=None)`**: convierte diccionarios o listas
+  anidadas en un árbol visual basado en `rich.tree.Tree`, ideal para mostrar
+  estructuras de carpetas o relaciones jerárquicas.
+- **`preguntar_confirmacion(mensaje, por_defecto=True)`**: solicita una respuesta
+  afirmativa o negativa mediante `rich.prompt.Confirm`, respetando el valor por
+  defecto especificado.
 - **`mostrar_panel(contenido, titulo=None, estilo="bold cyan")`**: crea un panel con
   bordes y permite definir el estilo interior y el color del borde.
 - **`barra_progreso(descripcion="Progreso", total=None)`**: context manager que
@@ -17,7 +27,12 @@ El módulo ofrece utilidades listas para usar con [`rich`](https://rich.readthed
   distribuidas con Cobra, validando previamente que la dependencia esté disponible.
 
 ```python
-from standard_library.interfaz import mostrar_tabla, barra_progreso
+from standard_library.interfaz import (
+    barra_progreso,
+    mostrar_arbol,
+    mostrar_codigo,
+    mostrar_tabla,
+)
 
 filas = [
     {"Nombre": "Ada", "Rol": "Pionera"},
@@ -25,6 +40,12 @@ filas = [
 ]
 
 mostrar_tabla(filas, titulo="Referentes")
+mostrar_codigo("print('hola cobra')", "python")
+mostrar_arbol(
+    [
+        ("src", ["cobra.co", ("modulos", ["texto.co", "interfaz.co"])])],
+    titulo="Proyecto",
+)
 with barra_progreso(total=3, descripcion="Cargando") as (progreso, tarea):
     for _ in range(3):
         progreso.advance(tarea)

--- a/tests/unit/test_standard_library_interfaz.py
+++ b/tests/unit/test_standard_library_interfaz.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import importlib.util
 import sys
 from pathlib import Path
@@ -8,7 +9,9 @@ from unittest.mock import Mock
 
 import pytest
 from rich.console import Console
+from rich.syntax import Syntax
 from rich.table import Table
+from rich.tree import Tree
 
 
 def _cargar_interfaz() -> ModuleType:
@@ -29,6 +32,82 @@ iniciar_gui_idle = interfaz.iniciar_gui_idle
 limpiar_consola = interfaz.limpiar_consola
 mostrar_panel = interfaz.mostrar_panel
 mostrar_tabla = interfaz.mostrar_tabla
+mostrar_codigo = interfaz.mostrar_codigo
+mostrar_arbol = interfaz.mostrar_arbol
+preguntar_confirmacion = interfaz.preguntar_confirmacion
+
+
+def test_mostrar_codigo_resalta_codigo_en_console_mock():
+    console = Mock(spec=Console)
+
+    resaltado = mostrar_codigo("print('hola')", "python", console=console)
+
+    console.print.assert_called_once()
+    render = console.print.call_args.args[0]
+    assert isinstance(render, Syntax)
+    assert render.code == "print('hola')"
+    assert getattr(render.lexer, "name", "").lower() == "python"
+    assert resaltado is render
+
+
+def test_mostrar_codigo_sin_rich_syntax_lanza_error(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "rich.syntax":
+            raise ModuleNotFoundError("simulado")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(RuntimeError):
+        mostrar_codigo("print('hola')", "python")
+
+
+def test_mostrar_arbol_construye_ramas_en_orden():
+    console = Mock(spec=Console)
+    estructura = [
+        ("src", ["app.py", ("utils", ["helpers.py"])]),
+        ("tests", ["test_app.py"]),
+    ]
+
+    arbol = mostrar_arbol(estructura, titulo="Proyecto", console=console)
+
+    console.print.assert_called_once_with(arbol)
+    assert isinstance(arbol, Tree)
+    assert arbol.label == "Proyecto"
+    assert [rama.label for rama in arbol.children] == ["src", "tests"]
+    src = arbol.children[0]
+    assert [hijo.label for hijo in src.children] == ["app.py", "utils"]
+    utils = src.children[1]
+    assert [hoja.label for hoja in utils.children] == ["helpers.py"]
+
+
+def test_preguntar_confirmacion_usa_valor_por_defecto(monkeypatch):
+    console = Mock(spec=Console)
+
+    class DummyConfirm:
+        last_call = None
+
+        @classmethod
+        def ask(cls, mensaje, default=None, console=None):
+            cls.last_call = (mensaje, default, console)
+            return default
+
+    prompt_mod = ModuleType("rich.prompt")
+    prompt_mod.Confirm = DummyConfirm
+    monkeypatch.setitem(sys.modules, "rich.prompt", prompt_mod)
+
+    respuesta = preguntar_confirmacion("¿Continuar?", console=console)
+
+    assert respuesta is True
+    assert DummyConfirm.last_call == ("¿Continuar?", True, console)
+
+    respuesta_no = preguntar_confirmacion(
+        "¿Continuar?", por_defecto=False, console=console
+    )
+    assert respuesta_no is False
+    assert DummyConfirm.last_call == ("¿Continuar?", False, console)
 
 
 def test_mostrar_tabla_emplea_console_mock():


### PR DESCRIPTION
## Summary
- agregar helpers `mostrar_codigo`, `mostrar_arbol` y `preguntar_confirmacion` con gestión de dependencias opcionales
- ampliar las pruebas unitarias para validar el uso de `Console` y los valores por defecto simulando las clases de Rich
- documentar las nuevas utilidades de la interfaz en la guía correspondiente

## Testing
- pytest --override-ini addopts= tests/unit/test_standard_library_interfaz.py


------
https://chatgpt.com/codex/tasks/task_e_68cbb9436ae88327999d2c1599c9702e