### PR TITLE
Add collection scanning utilities and list wrappers

### DIFF
--- a/docs/cheatsheet.tex
+++ b/docs/cheatsheet.tex
@@ -33,6 +33,10 @@ excepto & Captura de excepción\\
 \texttt{mezclar(lista, semilla)} & Copia barajada con semilla opcional para pruebas.\\
 \texttt{zip\_listas(a, b, ...)} & Crea tuplas alineadas hasta la lista más corta.\\
 \texttt{tomar(lista, n)} & Obtiene los primeros \texttt{n} elementos sin mutar.\\
+\texttt{tomar\_mientras(lista, funcion)} & Prefijo mientras la condición sea cierta; inspirado en Kotlin \texttt{takeWhile} y Ruby \texttt{Enumerable\#take\_while}.\\
+\texttt{descartar\_mientras(lista, funcion)} & Omite el prefijo que cumple la condición, como \texttt{dropWhile} de Kotlin y Ruby \texttt{Enumerable\#drop\_while}.\\
+\texttt{scanear(lista, funcion, inicial)} & Acumulaciones parciales al estilo Kotlin \texttt{scan}/\texttt{runningFold} y Ruby \texttt{Enumerable\#inject}.\\
+\texttt{pares\_consecutivos(lista)} & Pares deslizantes, similar a Kotlin \texttt{zipWithNext} y Ruby \texttt{each\_cons(2)}.\\
 \texttt{mapear\_seguro(lista, funcion)} & Devuelve resultados y excepciones por elemento.\\
 \texttt{ventanas(lista, tam, paso)} & Genera ventanas deslizantes; usa \texttt{incluir\_incompletas}.\\
 \texttt{chunk(lista, tam)} & Construye bloques consecutivos del mismo tamaño.\\

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -82,6 +82,10 @@ from corelibs.coleccion import (
     mezclar,
     zip_listas,
     tomar,
+    tomar_mientras,
+    descartar_mientras,
+    scanear,
+    pares_consecutivos,
 )
 from corelibs.seguridad import hash_sha256, generar_uuid
 from corelibs.red import (
@@ -187,6 +191,10 @@ __all__ = [
     "mezclar",
     "zip_listas",
     "tomar",
+    "tomar_mientras",
+    "descartar_mientras",
+    "scanear",
+    "pares_consecutivos",
     "hash_sha256",
     "generar_uuid",
     "obtener_url",

--- a/src/pcobra/corelibs/coleccion.py
+++ b/src/pcobra/corelibs/coleccion.py
@@ -204,3 +204,69 @@ def tomar(lista: Iterable[T] | Sequence[T], cantidad: int) -> List[T]:
         raise ValueError("cantidad debe ser positiva")
     elementos = _asegurar_iterable(lista)
     return elementos[:cantidad]
+
+
+def tomar_mientras(
+    lista: Iterable[T] | Sequence[T], funcion: Callable[[T], bool]
+) -> List[T]:
+    """Recoge elementos mientras ``funcion`` devuelva ``True``."""
+
+    elementos = _asegurar_iterable(lista)
+    fn = _asegurar_callable(funcion)
+    resultado: List[T] = []
+    for elemento in elementos:
+        if not fn(elemento):
+            break
+        resultado.append(elemento)
+    return resultado
+
+
+def descartar_mientras(
+    lista: Iterable[T] | Sequence[T], funcion: Callable[[T], bool]
+) -> List[T]:
+    """Descarta elementos iniciales mientras ``funcion`` sea ``True``."""
+
+    elementos = _asegurar_iterable(lista)
+    fn = _asegurar_callable(funcion)
+    resultado: List[T] = []
+    descartando = True
+    for elemento in elementos:
+        if descartando and fn(elemento):
+            continue
+        descartando = False
+        resultado.append(elemento)
+    return resultado
+
+
+def scanear(
+    lista: Iterable[T] | Sequence[T],
+    funcion: Callable[[U, T], U],
+    inicial: U | object = _SIN_VALOR,
+) -> List[U]:
+    """Genera acumulaciones parciales de izquierda a derecha."""
+
+    elementos = iter(_asegurar_iterable(lista))
+    fn = _asegurar_callable(funcion)
+    resultado: List[U] = []
+
+    if inicial is _SIN_VALOR:
+        try:
+            acumulado = next(elementos)  # type: ignore[assignment]
+        except StopIteration:
+            return []
+        resultado.append(acumulado)  # type: ignore[arg-type]
+    else:
+        acumulado = inicial
+        resultado.append(acumulado)
+
+    for elemento in elementos:
+        acumulado = fn(acumulado, elemento)
+        resultado.append(acumulado)
+    return resultado
+
+
+def pares_consecutivos(lista: Iterable[T] | Sequence[T]) -> List[Tuple[T, T]]:
+    """Devuelve pares ``(anterior, actual)`` consecutivos."""
+
+    elementos = _asegurar_iterable(lista)
+    return list(zip(elementos, elementos[1:]))

--- a/src/pcobra/standard_library/lista.py
+++ b/src/pcobra/standard_library/lista.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 from typing import Any, Callable, Iterable, List, Sequence, Tuple
 
-from corelibs.coleccion import tomar as tomar_core
+from corelibs.coleccion import (
+    tomar as tomar_core,
+    tomar_mientras as tomar_mientras_core,
+    descartar_mientras as descartar_mientras_core,
+    scanear as scanear_core,
+    pares_consecutivos as pares_consecutivos_core,
+)
+
+_SIN_INICIAL = object()
 
 
 def cabeza(lista):
@@ -109,4 +117,42 @@ def chunk(
             break
         resultado.append(bloque)
     return resultado
+
+
+def tomar_mientras(
+    lista: Iterable[Any] | Sequence[Any], funcion: Callable[[Any], bool]
+) -> List[Any]:
+    """Obtiene los elementos iniciales que cumplen ``funcion``."""
+
+    elementos = _asegurar_lista(lista)
+    return tomar_mientras_core(elementos, funcion)
+
+
+def descartar_mientras(
+    lista: Iterable[Any] | Sequence[Any], funcion: Callable[[Any], bool]
+) -> List[Any]:
+    """Elimina elementos iniciales mientras ``funcion`` devuelva ``True``."""
+
+    elementos = _asegurar_lista(lista)
+    return descartar_mientras_core(elementos, funcion)
+
+
+def scanear(
+    lista: Iterable[Any] | Sequence[Any],
+    funcion: Callable[[Any, Any], Any],
+    inicial: Any | object = _SIN_INICIAL,
+) -> List[Any]:
+    """Devuelve las acumulaciones parciales de ``funcion``."""
+
+    elementos = _asegurar_lista(lista)
+    if inicial is _SIN_INICIAL:
+        return scanear_core(elementos, funcion)
+    return scanear_core(elementos, funcion, inicial)
+
+
+def pares_consecutivos(lista: Iterable[Any] | Sequence[Any]) -> List[Tuple[Any, Any]]:
+    """Construye pares consecutivos ``(anterior, actual)``."""
+
+    elementos = _asegurar_lista(lista)
+    return pares_consecutivos_core(elementos)
 

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -263,6 +263,17 @@ def test_coleccion_funcs():
     assert core.zip_listas() == []
     assert core.tomar(datos, 2) == [3, 1]
     assert core.tomar(datos, 0) == []
+    assert core.tomar_mientras([5, 4, 3, 0, 1], lambda x: x > 0) == [5, 4, 3]
+    assert core.tomar_mientras([], lambda _: True) == []
+    assert core.descartar_mientras([0, 0, 1, 2], lambda x: x == 0) == [1, 2]
+    assert core.descartar_mientras([], lambda _: False) == []
+    assert core.scanear([1, 2, 3], operator.add) == [1, 3, 6]
+    assert core.scanear([1, 2, 3], operator.mul, 1) == [1, 1, 2, 6]
+    assert core.scanear([], operator.add) == []
+    assert core.scanear([], operator.add, 5) == [5]
+    assert core.pares_consecutivos([1, 2, 3]) == [(1, 2), (2, 3)]
+    assert core.pares_consecutivos([]) == []
+    assert core.pares_consecutivos([1]) == []
     assert core.mapear([], lambda x: x) == []
 
 
@@ -285,6 +296,33 @@ def test_coleccion_validaciones():
         core.tomar([1], -1)
     with pytest.raises(TypeError):
         core.tomar([1], 1.5)
+    with pytest.raises(TypeError):
+        core.tomar_mientras(123, lambda x: x)
+    with pytest.raises(TypeError):
+        core.tomar_mientras([1], None)
+    with pytest.raises(TypeError):
+        core.descartar_mientras(123, lambda x: x)
+    with pytest.raises(TypeError):
+        core.descartar_mientras([1], "no callable")
+    with pytest.raises(TypeError):
+        core.scanear([1, 2], "no callable")
+
+
+def test_coleccion_excepciones():
+    def explota(valor):
+        raise RuntimeError("boom")
+
+    def explota_scan(acumulado, valor):  # pragma: no cover - auxilia en prueba
+        raise RuntimeError("scan")
+
+    with pytest.raises(RuntimeError):
+        core.tomar_mientras([1, 2, 3], explota)
+
+    with pytest.raises(RuntimeError):
+        core.descartar_mientras([0, 1, 2], explota)
+
+    with pytest.raises(RuntimeError):
+        core.scanear([1, 2, 3], explota_scan)
 
 
 def test_seguridad_funcs():

--- a/tests/unit/test_lista.py
+++ b/tests/unit/test_lista.py
@@ -27,6 +27,23 @@ def test_lista():
     ]
     assert lista.chunk([1, 2, 3, 4, 5], 2) == [[1, 2], [3, 4], [5]]
     assert lista.chunk([1, 2, 3, 4, 5], 2, incluir_incompleto=False) == [[1, 2], [3, 4]]
+    assert lista.tomar_mientras((3, 2, 1, 0), lambda x: x > 0) == [3, 2, 1]
+    assert lista.descartar_mientras([0, 0, 1, 2], lambda x: x == 0) == [1, 2]
+    assert lista.scanear([1, 2, 3], lambda acc, x: acc + x) == [1, 3, 6]
+    assert lista.scanear([1, 2, 3], lambda acc, x: acc + x, 0) == [0, 1, 3, 6]
+    assert lista.scanear([], lambda acc, x: acc + x, 5) == [5]
+    assert lista.pares_consecutivos(["a", "b", "c"]) == [("a", "b"), ("b", "c")]
+    with pytest.raises(TypeError):
+        lista.tomar_mientras(123, lambda x: x)
+    with pytest.raises(TypeError):
+        lista.descartar_mientras(123, lambda x: x)
+    with pytest.raises(TypeError):
+        lista.scanear([1, 2], "no callable")
+    def reventar(acc, x):  # pragma: no cover - auxiliar para excepciones
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        lista.scanear([1, 2], reventar)
     with pytest.raises(ValueError):
         lista.ventanas(datos, 0)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Resumen
- incorpora en `corelibs.coleccion` las funciones `tomar_mientras`, `descartar_mientras`, `scanear` y `pares_consecutivos` con validaciones coherentes
- expone las utilidades recién creadas a través de `pcobra.corelibs` y añade envoltorios específicos para listas en la biblioteca estándar
- amplía la documentación y las pruebas unitarias para cubrir secuencias vacías, propagación de excepciones y acumulaciones progresivas

## Pruebas
- `PYTEST_ADDOPTS='' pytest -o addopts='' tests/unit/test_corelibs.py tests/unit/test_lista.py`


------
https://chatgpt.com/codex/tasks/task_e_68cbbc60434c832784754ab99be4fcc5