### PR TITLE
Add bit rotation helpers for numeric corelibs

### DIFF
--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -234,6 +234,11 @@ Las funciones ``longitud_bits`` y ``contar_bits`` recuperan información del
 entero sin escribir operadores manuales, mientras que ``entero_a_bytes`` y
 ``entero_desde_bytes`` facilitan la conversión a representaciones binarias en
 los órdenes ``big`` y ``little``.
+
+Las utilidades ``rotar_bits_izquierda`` y ``rotar_bits_derecha`` trasladan la
+semántica de ``rotate_left``/``rotate_right`` presente en Go y Rust. Basta
+indicar ``ancho_bits`` para emular palabras de tamaño fijo y conservar el signo
+mediante representación en complemento a dos.
    * - ``mcd(a, b, ...)``
      - ``math.gcd(a, b, ...)``
      - ``numpy.gcd.reduce([a, b, ...])``

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -73,6 +73,8 @@ from corelibs.numero import (
     producto,
     promedio,
     raiz,
+    rotar_bits_derecha,
+    rotar_bits_izquierda,
     redondear,
     techo,
 )
@@ -190,6 +192,8 @@ __all__ = [
     "producto",
     "promedio",
     "raiz",
+    "rotar_bits_derecha",
+    "rotar_bits_izquierda",
     "redondear",
     "techo",
     "leer",

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -134,6 +134,18 @@ def test_numero_funcs():
     assert core.contar_bits(0) == 0
     assert core.contar_bits(255) == 8
     assert core.contar_bits(-3) == 2
+    assert core.rotar_bits_izquierda(0b1011, 1) == 0b0111
+    assert core.rotar_bits_izquierda(0b1011, 5) == 0b0111
+    assert core.rotar_bits_derecha(0b1011, 1) == 0b1101
+    assert core.rotar_bits_derecha(0b1011, 5) == 0b1101
+    assert core.rotar_bits_izquierda(-2, 1, ancho_bits=8) == -3
+    assert core.rotar_bits_derecha(-2, 2, ancho_bits=8) == -65
+    assert core.rotar_bits_izquierda(0x1234, 20, ancho_bits=16) == 0x2341
+    assert core.rotar_bits_derecha(0x1234, 20, ancho_bits=16) == 0x4123
+    assert core.rotar_bits_izquierda(0x80000001, 36, ancho_bits=32) == 0x18
+    assert core.rotar_bits_derecha(0x80000001, 36, ancho_bits=32) == 0x18000000
+    with pytest.raises(ValueError):
+        core.rotar_bits_izquierda(1, 1, ancho_bits=0)
     assert core.entero_a_base(255, 16) == "FF"
     assert core.entero_a_base(-10, 2) == "-1010"
     assert core.entero_desde_base("ff", 16) == 255


### PR DESCRIPTION
## Resumen
- Agregar rotaciones de bits hacia la izquierda y la derecha en `corelibs.numero`, con soporte opcional de `ancho_bits`
- Reexportar las nuevas utilidades desde `pcobra.corelibs` y documentar la equivalencia con `rotate_left`/`rotate_right`
- Cubrir las funciones con pruebas unitarias en distintos anchos de palabra

## Pruebas
- pytest -o addopts= tests/unit/test_corelibs.py

------
https://chatgpt.com/codex/tasks/task_e_68cbcc100c108327b44acc4ccc4813b2