### PR TITLE
Añadir comprobaciones booleanas reutilizables

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -657,6 +657,7 @@ Las funciones están disponibles tanto al ejecutar Cobra directamente como al tr
 
 `pcobra.corelibs.logica` reúne operadores booleanos con validaciones explícitas de tipo. Las versiones de `standard_library.logica` reutilizan la misma implementación para ofrecer una API homogénea en cualquier backend.
 
+- `es_verdadero` y `es_falso` encapsulan `bool()` y ``not`` emulando `operator.truth` y `operator.not_`, respectivamente, pero con comprobaciones de tipo estrictas.
 - `conjuncion`, `disyuncion` y `negacion` cubren las puertas clásicas.
 - `xor`, `nand`, `nor`, `implica` y `equivale` facilitan construir tablas de verdad completas.
 - `xor_multiple` acepta un número arbitrario de argumentos y exige al menos dos valores.

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -33,6 +33,8 @@ from corelibs.texto import (
     normalizar_unicode,
 )
 from corelibs.logica import (
+    es_verdadero,
+    es_falso,
     conjuncion,
     disyuncion,
     negacion,
@@ -154,6 +156,8 @@ __all__ = [
     "rellenar_izquierda",
     "rellenar_derecha",
     "normalizar_unicode",
+    "es_verdadero",
+    "es_falso",
     "conjuncion",
     "disyuncion",
     "negacion",

--- a/src/pcobra/corelibs/logica.py
+++ b/src/pcobra/corelibs/logica.py
@@ -21,6 +21,18 @@ def _asegurar_booleano(valor: bool, nombre: str = "valor") -> bool:
     raise TypeError(f"{nombre} debe ser un booleano, se recibió {type(valor).__name__}")
 
 
+def es_verdadero(valor: bool) -> bool:
+    """Valida que *valor* sea booleano y retorna ``bool(valor)``."""
+
+    return bool(_asegurar_booleano(valor))
+
+
+def es_falso(valor: bool) -> bool:
+    """Valida que *valor* sea booleano y retorna ``bool(not valor)``."""
+
+    return bool(not _asegurar_booleano(valor))
+
+
 def conjuncion(a: bool, b: bool) -> bool:
     """Devuelve ``True`` cuando *a* y *b* son verdaderos."""
 
@@ -147,6 +159,8 @@ def paridad(valores: Iterable[bool]) -> bool:
 
 
 __all__ = [
+    "es_verdadero",
+    "es_falso",
     "conjuncion",
     "disyuncion",
     "negacion",

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -41,6 +41,8 @@ from standard_library.lista import (
     ventanas,
 )
 from standard_library.logica import (
+    es_verdadero,
+    es_falso,
     conjuncion,
     disyuncion,
     negacion,
@@ -76,6 +78,8 @@ __all__: list[str] = [
     "mapear_seguro",
     "ventanas",
     "chunk",
+    "es_verdadero",
+    "es_falso",
     "conjuncion",
     "disyuncion",
     "negacion",

--- a/src/pcobra/standard_library/logica.py
+++ b/src/pcobra/standard_library/logica.py
@@ -6,6 +6,38 @@ from typing import Iterable
 
 from pcobra.corelibs import logica as _logica
 
+__all__ = [
+    "es_verdadero",
+    "es_falso",
+    "conjuncion",
+    "disyuncion",
+    "negacion",
+    "xor",
+    "nand",
+    "nor",
+    "implica",
+    "equivale",
+    "xor_multiple",
+    "todas",
+    "alguna",
+    "ninguna",
+    "solo_uno",
+    "conteo_verdaderos",
+    "paridad",
+]
+
+
+def es_verdadero(valor: bool) -> bool:
+    """Replica ``operator.truth`` validando que el argumento sea booleano."""
+
+    return _logica.es_verdadero(valor)
+
+
+def es_falso(valor: bool) -> bool:
+    """Replica ``operator.not_`` validando que el argumento sea booleano."""
+
+    return _logica.es_falso(valor)
+
 
 def conjuncion(a: bool, b: bool) -> bool:
     """Retorna ``True`` si ambos argumentos son verdaderos."""

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -198,6 +198,15 @@ def test_logica_funcs():
 
     assert core.xor_multiple(True, False, True) is False
     assert core.xor_multiple(False, False, False) is False
+    assert core.es_verdadero(True) is True
+    assert core.es_verdadero(False) is False
+    assert core.es_falso(True) is False
+    assert core.es_falso(False) is True
+    for valor in (1, "False", None):
+        with pytest.raises(TypeError):
+            core.es_verdadero(valor)
+        with pytest.raises(TypeError):
+            core.es_falso(valor)
     assert core.xor_multiple(True, True, True, False) is True
 
     assert core.todas([True, True, True]) is True

--- a/tests/unit/test_standard_library_logica.py
+++ b/tests/unit/test_standard_library_logica.py
@@ -1,0 +1,38 @@
+from importlib import util
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+
+def _cargar_logica():
+    ruta = Path(__file__).resolve().parents[2] / "src" / "pcobra" / "standard_library" / "logica.py"
+    spec = util.spec_from_file_location("standard_library.logica", ruta)
+    modulo = util.module_from_spec(spec)
+    if "standard_library" not in sys.modules:
+        paquete = ModuleType("standard_library")
+        paquete.__path__ = [str(ruta.parent)]
+        sys.modules["standard_library"] = paquete
+    sys.modules["standard_library.logica"] = modulo
+    assert spec.loader is not None
+    spec.loader.exec_module(modulo)
+    return modulo
+
+
+logica = _cargar_logica()
+
+
+def test_es_verdadero_y_es_falso():
+    assert logica.es_verdadero(True) is True
+    assert logica.es_verdadero(False) is False
+    assert logica.es_falso(True) is False
+    assert logica.es_falso(False) is True
+
+
+def test_es_verdadero_es_falso_tipos_invalidos():
+    for valor in (1, "False", None):
+        with pytest.raises(TypeError):
+            logica.es_verdadero(valor)
+        with pytest.raises(TypeError):
+            logica.es_falso(valor)


### PR DESCRIPTION
## Summary
- incorpora `es_verdadero` y `es_falso` en `pcobra.corelibs.logica` con sus respectivos wrappers públicos y documentación
- actualiza la biblioteca estándar y el manual para reflejar las nuevas funciones booleanas
- añade pruebas unitarias que validan los nuevos ayudantes y los errores de tipo asociados

## Testing
- pytest --override-ini="addopts=" tests/unit/test_corelibs.py tests/unit/test_standard_library_logica.py

------
https://chatgpt.com/codex/tasks/task_e_68cbda9880ac83279b30f2071b05cd78