### PR TITLE
Add Excel helpers to datos standard library

### DIFF
--- a/docs/standard_library/datos.md
+++ b/docs/standard_library/datos.md
@@ -6,12 +6,43 @@ El módulo `standard_library.datos` encapsula operaciones comunes sobre datos ta
 
 - **`leer_csv(ruta, *, separador=",", encoding="utf-8", limite_filas=None)`**: lee un archivo CSV y devuelve una lista de registros. Los valores ausentes se normalizan como `None`.
 - **`leer_json(ruta, *, orient=None, lineas=False)`**: carga un archivo JSON (incluido JSON Lines) y lo expone como lista de diccionarios.
+- **`leer_excel(ruta, *, hoja=0, encabezado=0, engine=None)`**: abre una hoja de cálculo de Excel (`.xlsx` o `.xls`) y la devuelve como lista de diccionarios. Permite escoger la hoja por nombre/posición, ajustar la fila de encabezados e indicar explícitamente el motor (por ejemplo `openpyxl`).
+- **`escribir_excel(datos, ruta, *, hoja="Hoja1", incluir_indice=False, engine=None)`**: vuelca una tabla en un libro de Excel creando las carpetas intermedias si hacen falta. Se puede elegir la hoja de destino, conservar el índice del `DataFrame` y fijar el motor de escritura (como `openpyxl` o `xlsxwriter`).
 - **`describir(datos)`**: calcula estadísticas básicas por columna y devuelve un diccionario de métricas.
 - **`seleccionar_columnas(datos, columnas)`**: extrae columnas específicas y reporta si alguna falta.
 - **`filtrar(datos, condicion)`**: aplica una función por fila y conserva solo los registros que devuelvan `True`.
 - **`agrupar_y_resumir(datos, por, agregaciones)`**: agrupa por columnas y aplica agregaciones compatibles con `DataFrame.agg`.
 - **`a_listas(datos)`**: transforma la tabla a un diccionario columna → lista.
 - **`de_listas(columnas)`**: genera una lista de diccionarios a partir de un mapeo de columnas.
+
+### Dependencias para trabajar con Excel
+
+Las operaciones con libros de Excel delegan en motores opcionales de `pandas`. Para archivos modernos (`.xlsx`) se recomienda instalar `openpyxl`::
+
+```
+pip install openpyxl
+```
+
+Si prefieres `xlsxwriter` u otro motor compatible, especifica su nombre mediante el argumento `engine`. Cobra detecta internamente los errores de importación y reporta un mensaje claro indicando el motor faltante.
+
+### Ejemplos rápidos
+
+```python
+from pathlib import Path
+from pcobra.standard_library import datos
+
+tabla = [
+    {"categoria": "A", "valor": 10},
+    {"categoria": "B", "valor": 7},
+]
+
+ruta = Path("reportes/ventas.xlsx")
+datos.escribir_excel(tabla, ruta, hoja="Resumen", engine="openpyxl")
+
+registros = datos.leer_excel(ruta, hoja="Resumen", engine="openpyxl")
+```
+
+La variable `registros` contendrá nuevamente una lista de diccionarios con los valores saneados (`None` en lugar de `NaN`, enteros en vez de `numpy.int64`, etc.), lista para continuar el procesamiento dentro de Cobra.
 
 ## Backend JavaScript
 

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -18,7 +18,9 @@ from standard_library.datos import (
     describir,
     filtrar,
     leer_csv,
+    leer_excel,
     leer_json,
+    escribir_excel,
     seleccionar_columnas,
 )
 from standard_library.fecha import hoy, formatear, sumar_dias
@@ -101,12 +103,14 @@ __all__: list[str] = [
     "es_anagrama",
     "leer_csv",
     "leer_json",
+    "leer_excel",
     "describir",
     "seleccionar_columnas",
     "filtrar",
     "agrupar_y_resumir",
     "a_listas",
     "de_listas",
+    "escribir_excel",
     "mostrar_tabla",
     "mostrar_panel",
     "barra_progreso",
@@ -120,12 +124,14 @@ __all__: list[str] = [
 # Se exponen las firmas para mejorar el autocompletado en editores compatibles.
 leer_csv: Callable[..., list[dict[str, Any]]]
 leer_json: Callable[..., list[dict[str, Any]]]
+leer_excel: Callable[..., list[dict[str, Any]]]
 describir: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, Any]]
 seleccionar_columnas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Sequence[str]], list[dict[str, Any]]]
 filtrar: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Callable[[dict[str, Any]], bool]], list[dict[str, Any]]]
 agrupar_y_resumir: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Sequence[str], Mapping[str, Any]], list[dict[str, Any]]]
 a_listas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, list[Any]]]
 de_listas: Callable[[Mapping[str, Sequence[Any]]], list[dict[str, Any]]]
+escribir_excel: Callable[..., None]
 mostrar_tabla: Callable[..., Any]
 mostrar_panel: Callable[..., Any]
 barra_progreso: Callable[..., Any]

--- a/tests/unit/test_standard_library_datos.py
+++ b/tests/unit/test_standard_library_datos.py
@@ -12,8 +12,10 @@ from pcobra.standard_library.datos import (
     combinar_tablas,
     de_listas,
     describir,
+    escribir_excel,
     filtrar,
     leer_csv,
+    leer_excel,
     leer_json,
     ordenar_tabla,
     pivotar_tabla,
@@ -141,6 +143,29 @@ def test_leer_csv_error(tmp_path: Path):
     csv_path.write_text('valor\n"1', encoding="utf-8")
     with pytest.raises(ValueError):
         leer_csv(csv_path)
+
+
+def test_escribir_y_leer_excel(tmp_path: Path):
+    pytest.importorskip("openpyxl")
+    tabla = _tabla_base()
+    ruta = tmp_path / "salida" / "tabla.xlsx"
+    escribir_excel(tabla, ruta, hoja="Datos", engine="openpyxl")
+    assert ruta.exists()
+    leidos = leer_excel(ruta, hoja="Datos", engine="openpyxl")
+    assert leidos == tabla
+
+
+def test_leer_excel_sin_encabezado(tmp_path: Path):
+    pytest.importorskip("openpyxl")
+    ruta = tmp_path / "sin_encabezado.xlsx"
+    pd.DataFrame([[1, "A"], [2, "B"]]).to_excel(
+        ruta,
+        header=False,
+        index=False,
+        engine="openpyxl",
+    )
+    datos = leer_excel(ruta, encabezado=None, engine="openpyxl")
+    assert datos == [{0: 1, 1: "A"}, {0: 2, 1: "B"}]
 
 
 def test_combinar_tablas_inner(tabla_clientes, tabla_pedidos):


### PR DESCRIPTION
## Resumen
- añade `leer_excel` y `escribir_excel` al módulo `standard_library.datos`, con soporte para seleccionar hoja, encabezado y motor
- expone las nuevas funciones desde `pcobra.standard_library` y amplía la documentación con requisitos y ejemplos de Excel
- agrega pruebas unitarias que verifican la lectura/escritura básica de Excel usando `pytest.importorskip`

## Pruebas
- pytest --override-ini addopts='' tests/unit/test_standard_library_datos.py

------
https://chatgpt.com/codex/tasks/task_e_68cbe570e2d883278333d4fb75e88127