### PR TITLE
Agregar desplegar_tabla y pruebas asociadas

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -717,6 +717,7 @@ El módulo `standard_library.datos` añade una capa ligera sobre `pandas` que pe
 - `ordenar_tabla` admite ordenar por varias columnas controlando el sentido ascendente o descendente de cada una.
 - `combinar_tablas` replica los `join` de pandas y R para cruzar datasets con claves compartidas o diferenciadas.
 - `rellenar_nulos` rellena valores perdidos por columna antes de analizar la información.
+- `desplegar_tabla` transforma los datos a formato largo, equivalente a `pivot_longer` de R o `pandas.melt`.
 - `pivotar_tabla` reorganiza los datos en formato ancho calculando métricas múltiples de manera declarativa.
 - `a_listas` y `de_listas` convierten entre lista de registros y diccionario de columnas, facilitando la interoperabilidad con librerías externas.
 
@@ -739,6 +740,13 @@ resumen_ancho = pandas.pivotar_tabla(
     columnas='mes',
     valores='monto',
     agregacion='sum'
+)
+resumen_largo = pandas.desplegar_tabla(
+    ventas_completas,
+    identificadores=['region', 'mes'],
+    valores=['monto'],
+    var_name='metrica',
+    value_name='valor'
 )
 columnas = pandas.a_listas(resumen)
 imprimir(columnas['region'])

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -17,6 +17,7 @@ from standard_library.datos import (
     de_listas,
     describir,
     filtrar,
+    desplegar_tabla,
     leer_csv,
     leer_excel,
     leer_json,
@@ -107,6 +108,7 @@ __all__: list[str] = [
     "describir",
     "seleccionar_columnas",
     "filtrar",
+    "desplegar_tabla",
     "agrupar_y_resumir",
     "a_listas",
     "de_listas",
@@ -128,6 +130,7 @@ leer_excel: Callable[..., list[dict[str, Any]]]
 describir: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, Any]]
 seleccionar_columnas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Sequence[str]], list[dict[str, Any]]]
 filtrar: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Callable[[dict[str, Any]], bool]], list[dict[str, Any]]]
+desplegar_tabla: Callable[..., list[dict[str, Any]]]
 agrupar_y_resumir: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Sequence[str], Mapping[str, Any]], list[dict[str, Any]]]
 a_listas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, list[Any]]]
 de_listas: Callable[[Mapping[str, Sequence[Any]]], list[dict[str, Any]]]

--- a/tests/unit/test_standard_library_datos.py
+++ b/tests/unit/test_standard_library_datos.py
@@ -12,6 +12,7 @@ from pcobra.standard_library.datos import (
     combinar_tablas,
     de_listas,
     describir,
+    desplegar_tabla,
     escribir_excel,
     filtrar,
     leer_csv,
@@ -200,6 +201,43 @@ def test_rellenar_nulos_por_columna(tabla_pedidos):
     assert any(fila["monto"] == 0.0 for fila in rellenos)
     # Las columnas no reemplazadas conservan sus valores originales.
     assert rellenos[0]["unidades"] == 5
+
+
+def test_desplegar_tabla_con_varias_columnas(tabla_metricas):
+    desplegada = desplegar_tabla(
+        tabla_metricas,
+        identificadores=["region", "mes"],
+        valores=["monto", "descuento"],
+        var_name="metrica",
+        value_name="valor",
+    )
+    assert len(desplegada) == len(tabla_metricas) * 2
+    assert desplegada[0] == {
+        "region": "norte",
+        "mes": "enero",
+        "metrica": "monto",
+        "valor": 100,
+    }
+    registro_descuento = next(
+        fila
+        for fila in desplegada
+        if fila["region"] == "norte" and fila["mes"] == "febrero" and fila["metrica"] == "descuento"
+    )
+    assert registro_descuento["valor"] is None
+
+
+def test_desplegar_tabla_sin_especificar_valores():
+    datos = [
+        {"id": 1, "col_a": 10, "col_b": None},
+        {"id": 2, "col_a": 20, "col_b": 30},
+    ]
+    desplegada = desplegar_tabla(datos, identificadores="id")
+    assert desplegada == [
+        {"id": 1, "variable": "col_a", "value": 10},
+        {"id": 2, "variable": "col_a", "value": 20},
+        {"id": 1, "variable": "col_b", "value": None},
+        {"id": 2, "variable": "col_b", "value": 30},
+    ]
 
 
 def test_pivotar_tabla_multiple_metricas(tabla_metricas):


### PR DESCRIPTION
## Resumen
- agregar `desplegar_tabla` como envoltorio de `pandas.melt` con saneamiento y parámetros opcionales
- exponer la nueva utilidad desde `pcobra.standard_library` y documentar su uso en el manual
- añadir pruebas unitarias que validan el despliegue con múltiples columnas y valores nulos

## Pruebas
- `pytest tests/unit/test_standard_library_datos.py` *(falla la verificación de cobertura global exigida por la configuración del proyecto)*
- `pytest` *(se detiene por dependencias de integración que requieren paquetes adicionales; tras instalar varias dependencias, el entorno sigue reportando que "requests" no es un paquete durante la recolección)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe9f38ea48327acd3e4520d09d3f2