### PR TITLE
feat(corelibs): add settled async helpers

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -237,6 +237,13 @@ varias tareas sin perder legibilidad:
 
 - `recolectar` envuelve `asyncio.gather`, cancela el resto de corrutinas si una
   falla y resulta familiar para quienes hayan usado `Promise.all`.
+- `iterar_completadas` recorre los valores conforme se resuelven las tareas al
+  estilo de `asyncio.as_completed`, algo equivalente a combinar `Promise.race`
+  con iteraciones manuales en JavaScript.
+- `recolectar_resultados` mantiene el orden de las corrutinas originales y
+  devuelve para cada una un diccionario con su estado final, emulando
+  `Promise.allSettled` y aprovechando la semántica de cancelación propia de
+  Python.
 - `carrera` delega en `asyncio.wait(FIRST_COMPLETED)` y cancela el resto tras
   obtener el primer resultado, igual que `Promise.race`.
 - `esperar_timeout` cubre `asyncio.wait_for` garantizando que la corrutina se
@@ -247,11 +254,26 @@ varias tareas sin perder legibilidad:
 Puedes importarlas desde `pcobra.corelibs` directamente:
 
 ```python
-from pcobra.corelibs import carrera, recolectar
+from pcobra.corelibs import (
+    carrera,
+    iterar_completadas,
+    recolectar,
+    recolectar_resultados,
+)
 
 resultado = await carrera(tarea_rapida(), tarea_lenta())
 datos = await recolectar(tarea_a(), tarea_b())
+estados = await recolectar_resultados(tarea_exitosa(), tarea_que_falla())
+
+async for valor in iterar_completadas(tarea_lenta(), tarea_rapida()):
+    print("llegó:", valor)
 ```
+
+La combinación de estas utilidades facilita alternar entre estilos típicos de
+Python y de JavaScript sin perder características de ninguno: se conservan las
+excepciones nativas de `asyncio` (por ejemplo, cancelaciones explícitas) y al
+mismo tiempo se proveen resultados agregados o streams ordenados como los que
+ofrecen las *promises* en navegadores modernos.
 
 ## 11. Transpilación y ejecución
 

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -99,6 +99,14 @@ su resultado con ``esperar``.
 
    esperar principal()
 
+El módulo :mod:`pcobra.corelibs.asincrono` ofrece varios atajos que reproducen
+patrones habituales tanto de ``asyncio`` como de las *promises* en JavaScript.
+``recolectar`` equivale a ``asyncio.gather``/``Promise.all``,
+``iterar_completadas`` se inspira en ``asyncio.as_completed`` y permite
+procesar resultados a medida que van llegando, mientras que
+``recolectar_resultados`` devuelve una estructura similar a ``Promise.allSettled``
+con los estados finales (cumplida, rechazada o cancelada) de cada corrutina.
+
 Decoradores
 -----------
 

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -122,6 +122,8 @@ from corelibs.sistema import (
 )
 from corelibs.asincrono import (
     recolectar,
+    iterar_completadas,
+    recolectar_resultados,
     carrera,
     esperar_timeout,
     crear_tarea,
@@ -243,6 +245,8 @@ __all__ = [
     "obtener_env",
     "listar_dir",
     "recolectar",
+    "iterar_completadas",
+    "recolectar_resultados",
     "carrera",
     "esperar_timeout",
     "crear_tarea",
@@ -321,6 +325,19 @@ recolectar.__doc__ = (
     "Reexporta :func:`pcobra.corelibs.asincrono.recolectar`. Equivale a"
     " coordinar varias corrutinas como haría ``Promise.all`` en JavaScript,"
     " delegando en :func:`asyncio.gather`."
+)
+
+iterar_completadas.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.asincrono.iterar_completadas`. Permite"
+    " observar los resultados conforme cada tarea finaliza, similar a"
+    " combinar ``Promise.race`` con iteraciones sobre ``Promise.all`` en"
+    " JavaScript, aprovechando :func:`asyncio.as_completed`."
+)
+
+recolectar_resultados.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.asincrono.recolectar_resultados`. Su"
+    " interfaz recuerda a ``Promise.allSettled`` al devolver el estado de"
+    " cada corrutina junto al valor o la excepción capturada."
 )
 
 carrera.__doc__ = (


### PR DESCRIPTION
## Summary
- add iterar_completadas and recolectar_resultados helpers built on asyncio utilities
- re-export the new helpers and document their relationship to familiar Promise patterns
- extend async corelibs tests to cover completion order, error propagation, and cancellation handling

## Testing
- pytest --override-ini=addopts="" tests/unit/test_corelibs_async.py

------
https://chatgpt.com/codex/tasks/task_e_68cbf0816d788327b3447a38d2dfc41f