### PR TITLE
Añadir utilidades asincrónicas y pruebas de concurrencia

### DIFF
--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -100,12 +100,18 @@ su resultado con ``esperar``.
    esperar principal()
 
 El módulo :mod:`pcobra.corelibs.asincrono` ofrece varios atajos que reproducen
-patrones habituales tanto de ``asyncio`` como de las *promises* en JavaScript.
-``recolectar`` equivale a ``asyncio.gather``/``Promise.all``,
-``iterar_completadas`` se inspira en ``asyncio.as_completed`` y permite
-procesar resultados a medida que van llegando, mientras que
-``recolectar_resultados`` devuelve una estructura similar a ``Promise.allSettled``
-con los estados finales (cumplida, rechazada o cancelada) de cada corrutina.
+patrones habituales tanto de ``asyncio`` como de las *promises* en JavaScript y
+las rutinas concurrentes en Go. ``recolectar`` equivale a
+``asyncio.gather``/``Promise.all``, ``primero_exitoso`` se comporta como
+``Promise.any`` al devolver el primer resultado sin excepciones y
+``iterar_completadas`` se inspira en ``asyncio.as_completed`` para procesar
+respuestas a medida que van llegando. ``recolectar_resultados`` devuelve una
+estructura similar a ``Promise.allSettled`` con los estados finales (cumplida,
+rechazada o cancelada) de cada corrutina, mientras que
+``mapear_concurrencia`` implementa un patrón de *worker pool* estilo Go a
+través de ``asyncio.Semaphore`` para respetar un ``limite`` máximo de tareas y
+decidir, mediante ``return_exceptions``, si los errores cancelan el resto o se
+registran junto a sus posiciones originales.
 
 Decoradores
 -----------

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -125,8 +125,10 @@ from corelibs.asincrono import (
     iterar_completadas,
     recolectar_resultados,
     carrera,
+    primero_exitoso,
     esperar_timeout,
     crear_tarea,
+    mapear_concurrencia,
 )
 
 __all__ = [
@@ -248,8 +250,10 @@ __all__ = [
     "iterar_completadas",
     "recolectar_resultados",
     "carrera",
+    "primero_exitoso",
     "esperar_timeout",
     "crear_tarea",
+    "mapear_concurrencia",
 ]
 
 quitar_prefijo.__doc__ = (
@@ -344,4 +348,19 @@ carrera.__doc__ = (
     "Reexporta :func:`pcobra.corelibs.asincrono.carrera`. Expone un comportamiento"
     " semejante a ``Promise.race`` empleando :func:`asyncio.wait` para devolver"
     " el primer resultado disponible."
+)
+
+primero_exitoso.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.asincrono.primero_exitoso`. Funciona como"
+    " ``Promise.any`` al devolver el primer resultado sin excepciones y agrupa"
+    " los fallos restantes en una ``ExceptionGroup`` si ninguna corrutina"
+    " completa con éxito."
+)
+
+mapear_concurrencia.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.asincrono.mapear_concurrencia`. Permite"
+    " limitar el número de corrutinas simultáneas con ``asyncio.Semaphore``,"
+    " un patrón equivalente a los *worker pools* de Go, y documenta el"
+    " parámetro ``limite`` junto con la opción ``return_exceptions`` para"
+    " decidir si se propagan o coleccionan los errores."
 )


### PR DESCRIPTION
## Summary
- incorporar `primero_exitoso` y `mapear_concurrencia` en `corelibs.asincrono`, gestionando cancelaciones y límites de simultaneidad
- reexportar las nuevas utilidades y documentar su relación con Promise.any y los worker pools de Go
- ampliar la guía y las pruebas unitarias para cubrir casos de éxito, error y control de concurrencia

## Testing
- PYTEST_ADDOPTS="--no-cov" pytest tests/unit/test_corelibs_async.py

------
https://chatgpt.com/codex/tasks/task_e_68cbf30a1d4c8327b7632988adbd83f4