### PR TITLE
Add Markdown and JSON helpers to interfaz

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -782,6 +782,10 @@ El módulo `standard_library.interfaz` incorpora una capa de presentación const
 
 - `mostrar_tabla` acepta listas de diccionarios o secuencias y genera automáticamente los encabezados. Puedes personalizar el título y aplicar estilos Rich a cada columna.
 - `mostrar_panel` dibuja recuadros con bordes y soporta títulos, estilos y expansión.
+- `mostrar_markdown` procesa texto con formato y respeta tablas, listas y
+  resaltado inline.
+- `mostrar_json` ordena y colorea diccionarios o listas para inspeccionarlos
+  rápidamente desde la terminal.
 - `barra_progreso` expone un *context manager* que devuelve el objeto :class:`Progress` y el identificador de la tarea, lo que permite actualizar la barra con `advance` o `update`.
 - `imprimir_aviso` y `limpiar_consola` unifican la presentación de mensajes informativos, de advertencia o de error.
 - `iniciar_gui` e `iniciar_gui_idle` sirven como atajos seguros para lanzar las aplicaciones Flet oficiales del proyecto.
@@ -795,6 +799,13 @@ var participantes = [
 ]
 
 ui.mostrar_tabla(participantes, titulo="Referentes")
+ui.mostrar_markdown("""\
+## Resumen
+
+- Se cargaron los datos de participantes.
+- Los totales están listos para exportar.
+""")
+ui.mostrar_json({"total": longitud(participantes), "estado": "ok"})
 ui.imprimir_aviso("Datos cargados", nivel="exito")
 
 con ui.barra_progreso(descripcion="Procesando", total=3) como (progreso, tarea):

--- a/docs/standard_library/interfaz.md
+++ b/docs/standard_library/interfaz.md
@@ -9,6 +9,13 @@ El módulo ofrece utilidades listas para usar con [`rich`](https://rich.readthed
   [`rich.syntax.Syntax`](https://rich.readthedocs.io/en/stable/syntax.html) y lo
   imprime en la consola indicada. Devuelve el objeto `Syntax` para posteriores
   personalizaciones.
+- **`mostrar_markdown(contenido, **opciones)`**: interpreta cadenas Markdown con
+  `rich.markdown.Markdown`, incluyendo tablas, listas y resaltado inline. Admite
+  pasar argumentos extras compatibles con `Markdown`.
+- **`mostrar_json(datos, indent=2, sort_keys=True)`**: serializa diccionarios o
+  listas con `rich.json.JSON`. Si recibe una cadena se asume que ya contiene
+  JSON válido. Cuando el objeto no puede convertirse automáticamente se
+  utiliza `rich.pretty.Pretty` para mostrar su representación.
 - **`mostrar_arbol(nodos, titulo=None)`**: convierte diccionarios o listas
   anidadas en un árbol visual basado en `rich.tree.Tree`, ideal para mostrar
   estructuras de carpetas o relaciones jerárquicas.
@@ -29,6 +36,8 @@ El módulo ofrece utilidades listas para usar con [`rich`](https://rich.readthed
 ```python
 from standard_library.interfaz import (
     barra_progreso,
+    mostrar_json,
+    mostrar_markdown,
     mostrar_arbol,
     mostrar_codigo,
     mostrar_tabla,
@@ -41,6 +50,13 @@ filas = [
 
 mostrar_tabla(filas, titulo="Referentes")
 mostrar_codigo("print('hola cobra')", "python")
+mostrar_markdown("""\
+# Informe
+
+- Uso de Markdown desde Cobra
+- Integración con Rich
+""")
+mostrar_json({"lenguaje": "Cobra", "version": "10.0.9"})
 mostrar_arbol(
     [
         ("src", ["cobra.co", ("modulos", ["texto.co", "interfaz.co"])])],

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -31,6 +31,8 @@ from standard_library.interfaz import (
     iniciar_gui,
     iniciar_gui_idle,
     limpiar_consola,
+    mostrar_markdown,
+    mostrar_json,
     mostrar_panel,
     mostrar_tabla,
 )
@@ -115,6 +117,8 @@ __all__: list[str] = [
     "escribir_excel",
     "mostrar_tabla",
     "mostrar_panel",
+    "mostrar_markdown",
+    "mostrar_json",
     "barra_progreso",
     "limpiar_consola",
     "imprimir_aviso",
@@ -137,6 +141,8 @@ de_listas: Callable[[Mapping[str, Sequence[Any]]], list[dict[str, Any]]]
 escribir_excel: Callable[..., None]
 mostrar_tabla: Callable[..., Any]
 mostrar_panel: Callable[..., Any]
+mostrar_markdown: Callable[..., Any]
+mostrar_json: Callable[..., Any]
 barra_progreso: Callable[..., Any]
 limpiar_consola: Callable[..., None]
 imprimir_aviso: Callable[..., None]

--- a/src/pcobra/standard_library/interfaz.py
+++ b/src/pcobra/standard_library/interfaz.py
@@ -53,6 +53,56 @@ def mostrar_codigo(
     return resaltado
 
 
+def mostrar_markdown(
+    contenido: str,
+    *,
+    console: Console | None = None,
+    **markdown_kwargs: Any,
+) -> Any:
+    """Renderiza texto Markdown con Rich y lo envía a la consola indicada."""
+
+    try:
+        from rich.markdown import Markdown
+    except ModuleNotFoundError as exc:  # pragma: no cover - depende de la instalación de Rich
+        raise RuntimeError("Rich no está instalado. Ejecuta 'pip install rich'.") from exc
+
+    render = Markdown(contenido, **markdown_kwargs)
+
+    console_obj = _obtener_console(console)
+    console_obj.print(render)
+    return render
+
+
+def mostrar_json(
+    datos: Any,
+    *,
+    console: Console | None = None,
+    indent: int | None = 2,
+    sort_keys: bool = True,
+) -> Any:
+    """Muestra datos JSON o estructuras Python con formato legible."""
+
+    try:
+        from rich.json import JSON
+        from rich.pretty import Pretty
+    except ModuleNotFoundError as exc:  # pragma: no cover - depende de la instalación de Rich
+        raise RuntimeError("Rich no está instalado. Ejecuta 'pip install rich'.") from exc
+
+    console_obj = _obtener_console(console)
+
+    render: Any
+    if isinstance(datos, str):
+        render = JSON(datos, indent=indent)
+    else:
+        try:
+            render = JSON.from_data(datos, indent=indent, sort_keys=sort_keys)
+        except (TypeError, ValueError):
+            render = Pretty(datos)
+
+    console_obj.print(render)
+    return render
+
+
 def _agregar_a_arbol(arbol: Any, contenido: Any) -> None:
     if isinstance(contenido, Mapping):
         for clave, valor in contenido.items():
@@ -300,6 +350,8 @@ def iniciar_gui_idle(*, destino: GuiTarget | None = None, **kwargs: Any) -> None
 
 __all__ = [
     "mostrar_codigo",  # Resalta fragmentos de código en la consola.
+    "mostrar_markdown",  # Renderiza texto Markdown enriquecido.
+    "mostrar_json",  # Formatea estructuras o cadenas JSON.
     "mostrar_arbol",  # Renderiza estructuras jerárquicas con Rich Tree.
     "preguntar_confirmacion",  # Pregunta sí/no utilizando ``rich.prompt``.
     "mostrar_tabla",  # Construye tablas a partir de mapeos o secuencias.


### PR DESCRIPTION
## Summary
- add new helpers to render Markdown and JSON with Rich following the existing console pattern
- re-export the helpers in the standard library facade and document their usage in the CLI manual and interface guide
- extend interfaz unit tests with coverage for the new helpers and additional branches

## Testing
- `pytest -o addopts="--cov=pcobra.standard_library.interfaz --cov-report=term-missing --cov-report=xml --cov-fail-under=85" tests/unit/test_standard_library_interfaz.py`


------
https://chatgpt.com/codex/tasks/task_e_68cc207a1b948327a0d836f682b2211e