### PR TITLE
Add console grouping helper and column display utilities

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -781,11 +781,13 @@ imprimir(columnas['region'])
 El módulo `standard_library.interfaz` incorpora una capa de presentación construida sobre [`rich`](https://rich.readthedocs.io/) para crear paneles, tablas y barras de progreso sin tener que manipular manualmente códigos ANSI. Estas utilidades están pensadas para scripts de línea de comandos escritos en Cobra o en Python y mantienen el mismo API en ambos contextos.
 
 - `mostrar_tabla` acepta listas de diccionarios o secuencias y genera automáticamente los encabezados. Puedes personalizar el título y aplicar estilos Rich a cada columna.
+- `mostrar_columnas` distribuye listas simples en una cuadrícula similar a `console.table` sin necesidad de definir encabezados.
 - `mostrar_panel` dibuja recuadros con bordes y soporta títulos, estilos y expansión.
 - `mostrar_markdown` procesa texto con formato y respeta tablas, listas y
   resaltado inline.
 - `mostrar_json` ordena y colorea diccionarios o listas para inspeccionarlos
   rápidamente desde la terminal.
+- `grupo_consola` funciona como `console.group`, agrupando impresiones bajo un mismo título con sangría opcional.
 - `barra_progreso` expone un *context manager* que devuelve el objeto :class:`Progress` y el identificador de la tarea, lo que permite actualizar la barra con `advance` o `update`.
 - `imprimir_aviso` y `limpiar_consola` unifican la presentación de mensajes informativos, de advertencia o de error.
 - `iniciar_gui` e `iniciar_gui_idle` sirven como atajos seguros para lanzar las aplicaciones Flet oficiales del proyecto.
@@ -807,6 +809,10 @@ ui.mostrar_markdown("""\
 """)
 ui.mostrar_json({"total": longitud(participantes), "estado": "ok"})
 ui.imprimir_aviso("Datos cargados", nivel="exito")
+
+con ui.grupo_consola(titulo="Participantes") como consola:
+    consola.print("Listado breve")
+    ui.mostrar_columnas([p["Nombre"] para p en participantes], numero_columnas=2, console=consola)
 
 con ui.barra_progreso(descripcion="Procesando", total=3) como (progreso, tarea):
     para var _ in rango(0, 3):

--- a/docs/standard_library/interfaz.md
+++ b/docs/standard_library/interfaz.md
@@ -5,6 +5,9 @@ El módulo ofrece utilidades listas para usar con [`rich`](https://rich.readthed
 - **`mostrar_tabla(filas, columnas=None, titulo=None, estilos=None)`**: construye una
   tabla a partir de listas de diccionarios o secuencias y la imprime usando la consola
   indicada. Devuelve el objeto `Table` para ajustes adicionales.
+- **`mostrar_columnas(elementos, numero_columnas=None, titulo=None)`**: reparte una
+  lista de elementos en columnas equilibradas con la ayuda de `rich.columns.Columns`.
+  Ideal para recrear listados tipo `console.table` sin construir tablas completas.
 - **`mostrar_codigo(codigo, lenguaje)`**: resalta código fuente usando
   [`rich.syntax.Syntax`](https://rich.readthedocs.io/en/stable/syntax.html) y lo
   imprime en la consola indicada. Devuelve el objeto `Syntax` para posteriores
@@ -24,6 +27,8 @@ El módulo ofrece utilidades listas para usar con [`rich`](https://rich.readthed
   defecto especificado.
 - **`mostrar_panel(contenido, titulo=None, estilo="bold cyan")`**: crea un panel con
   bordes y permite definir el estilo interior y el color del borde.
+- **`grupo_consola(titulo=None)`**: context manager que agrupa varias impresiones con
+  sangría, emulando el comportamiento de `console.group` del navegador.
 - **`barra_progreso(descripcion="Progreso", total=None)`**: context manager que
   devuelve el `Progress` de Rich y el identificador de la tarea.
 - **`limpiar_consola(console=None)`**: invoca `Console.clear()` sobre la consola
@@ -36,10 +41,12 @@ El módulo ofrece utilidades listas para usar con [`rich`](https://rich.readthed
 ```python
 from standard_library.interfaz import (
     barra_progreso,
+    grupo_consola,
+    mostrar_columnas,
+    mostrar_codigo,
     mostrar_json,
     mostrar_markdown,
     mostrar_arbol,
-    mostrar_codigo,
     mostrar_tabla,
 )
 
@@ -65,4 +72,14 @@ mostrar_arbol(
 with barra_progreso(total=3, descripcion="Cargando") as (progreso, tarea):
     for _ in range(3):
         progreso.advance(tarea)
+
+# Agrupar mensajes para simular console.group/console.table
+with grupo_consola(titulo="Resultados") as consola:
+    consola.print("Resumen general")
+    mostrar_columnas(
+        ["Ada", "Hedy", "Grace", "Radia"],
+        numero_columnas=2,
+        console=consola,
+        titulo="Participantes",
+    )
 ```

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -27,10 +27,12 @@ from standard_library.datos import (
 from standard_library.fecha import hoy, formatear, sumar_dias
 from standard_library.interfaz import (
     barra_progreso,
+    grupo_consola,
     imprimir_aviso,
     iniciar_gui,
     iniciar_gui_idle,
     limpiar_consola,
+    mostrar_columnas,
     mostrar_markdown,
     mostrar_json,
     mostrar_panel,
@@ -116,9 +118,11 @@ __all__: list[str] = [
     "de_listas",
     "escribir_excel",
     "mostrar_tabla",
+    "mostrar_columnas",
     "mostrar_panel",
     "mostrar_markdown",
     "mostrar_json",
+    "grupo_consola",
     "barra_progreso",
     "limpiar_consola",
     "imprimir_aviso",
@@ -140,9 +144,11 @@ a_listas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dic
 de_listas: Callable[[Mapping[str, Sequence[Any]]], list[dict[str, Any]]]
 escribir_excel: Callable[..., None]
 mostrar_tabla: Callable[..., Any]
+mostrar_columnas: Callable[..., Any]
 mostrar_panel: Callable[..., Any]
 mostrar_markdown: Callable[..., Any]
 mostrar_json: Callable[..., Any]
+grupo_consola: Callable[..., Any]
 barra_progreso: Callable[..., Any]
 limpiar_consola: Callable[..., None]
 imprimir_aviso: Callable[..., None]


### PR DESCRIPTION
## Summary
- add a `grupo_consola` context manager that delegates to `Console.group` when available and simulates grouped output otherwise
- expose `mostrar_columnas` to render iterables using `rich.columns.Columns`, wiring both utilities through the standard library exports
- expand unit tests and documentation with examples that mimic `console.group` and `console.table`

## Testing
- pytest -o addopts="" tests/unit/test_standard_library_interfaz.py


------
https://chatgpt.com/codex/tasks/task_e_68cc65e3c8fc8327b2c1da1261d76b84