### PR TITLE
Agregar soporte Parquet y Feather en standard_library.datos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Actualización de `holobit-sdk` a la versión 1.0.9 y ajuste de `graficar`/`proyectar` al nuevo API.
 - Ampliación de `corelibs.texto` y nuevas utilidades en `standard_library.texto` con soporte Unicode y pruebas asociadas.
 - Validadores `es_*` alineados con `str.is*` disponibles tanto en `pcobra.corelibs.texto` como en `standard_library.texto`, con equivalentes nativos para JavaScript.
+- `standard_library.datos` incorpora lectura y escritura de archivos Parquet y Feather detectando automáticamente los motores opcionales requeridos.
 
 ## v10.0.9 - 2025-08-17
 - Ajuste en `SafeUnpickler` para aceptar los módulos `core.ast_nodes` y `cobra.core.ast_nodes`.

--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -738,6 +738,8 @@ assert si_no(True, lambda: "omitido") is None  # La función no se ejecuta
 El módulo `standard_library.datos` añade una capa ligera sobre `pandas` que permite trabajar con tablas desde Cobra sin exponerse a los detalles internos del `DataFrame`. Las funciones devuelven listas de diccionarios o diccionarios de listas, estructuras fáciles de manipular desde Cobra o al transpirar a Python.
 
 - `leer_csv` y `leer_json` cargan archivos en disco y devuelven registros con valores `None` cuando la fuente contiene datos perdidos.
+- `leer_parquet` y `escribir_parquet` manipulan archivos en formato columnar detectando automáticamente si hay motores como `pyarrow` o `fastparquet` disponibles.
+- `leer_feather` y `escribir_feather` intercambian datos con otras herramientas que usan el formato Feather siempre que `pyarrow` esté instalado.
 - `describir` calcula estadísticas básicas (`count`, `mean`, `std`, percentiles) para cada columna.
 - `seleccionar_columnas` y `filtrar` permiten aislar subconjuntos antes de seguir procesando los datos.
 - `agrupar_y_resumir` aplica agregaciones (`sum`, `mean`, funciones personalizadas) agrupando por columnas clave.

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -20,8 +20,12 @@ from standard_library.datos import (
     desplegar_tabla,
     leer_csv,
     leer_excel,
+    leer_feather,
     leer_json,
+    leer_parquet,
     escribir_excel,
+    escribir_feather,
+    escribir_parquet,
     seleccionar_columnas,
 )
 from standard_library.fecha import hoy, formatear, sumar_dias
@@ -137,6 +141,8 @@ __all__: list[str] = [
     "leer_csv",
     "leer_json",
     "leer_excel",
+    "leer_parquet",
+    "leer_feather",
     "describir",
     "seleccionar_columnas",
     "filtrar",
@@ -145,6 +151,8 @@ __all__: list[str] = [
     "a_listas",
     "de_listas",
     "escribir_excel",
+    "escribir_parquet",
+    "escribir_feather",
     "mostrar_tabla",
     "mostrar_columnas",
     "mostrar_panel",
@@ -163,6 +171,8 @@ __all__: list[str] = [
 leer_csv: Callable[..., list[dict[str, Any]]]
 leer_json: Callable[..., list[dict[str, Any]]]
 leer_excel: Callable[..., list[dict[str, Any]]]
+leer_parquet: Callable[..., list[dict[str, Any]]]
+leer_feather: Callable[..., list[dict[str, Any]]]
 describir: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, Any]]
 seleccionar_columnas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Sequence[str]], list[dict[str, Any]]]
 filtrar: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Callable[[dict[str, Any]], bool]], list[dict[str, Any]]]
@@ -171,6 +181,8 @@ agrupar_y_resumir: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[An
 a_listas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, list[Any]]]
 de_listas: Callable[[Mapping[str, Sequence[Any]]], list[dict[str, Any]]]
 escribir_excel: Callable[..., None]
+escribir_parquet: Callable[..., None]
+escribir_feather: Callable[..., None]
 mostrar_tabla: Callable[..., Any]
 mostrar_columnas: Callable[..., Any]
 mostrar_panel: Callable[..., Any]


### PR DESCRIPTION
## Resumen
- añadir utilidades `leer_*` y `escribir_*` para Parquet y Feather con detección de motores opcionales y mensajes de error claros en `standard_library.datos`
- exponer las nuevas funciones desde `pcobra.standard_library` y documentar los nuevos formatos en el manual
- ampliar la batería de pruebas para cubrir Parquet y Feather utilizando archivos temporales e importaciones condicionales, además de registrar el cambio en el changelog

## Pruebas
- pytest -p no:cov -o addopts='' tests/unit/test_standard_library_datos.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1e2bbfc88327af8dfe573cd052c8