### PR TITLE
Add IEEE-754 helpers for numeric utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Ampliación de `corelibs.texto` y nuevas utilidades en `standard_library.texto` con soporte Unicode y pruebas asociadas.
 - Validadores `es_*` alineados con `str.is*` disponibles tanto en `pcobra.corelibs.texto` como en `standard_library.texto`, con equivalentes nativos para JavaScript.
 - `standard_library.datos` incorpora lectura y escritura de archivos Parquet y Feather detectando automáticamente los motores opcionales requeridos.
+- `corelibs.numero` añade `es_finito`, `es_infinito`, `es_nan` y `copiar_signo`, reexportados en la biblioteca estándar y con equivalentes nativos que respetan IEEE-754.
 
 ## v10.0.9 - 2025-08-17
 - Ajuste en `SafeUnpickler` para aceptar los módulos `core.ast_nodes` y `cobra.core.ast_nodes`.

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -192,6 +192,16 @@ aleatorios reproducibles y analizar datos sin abandonar Cobra.
    print(core.clamp(5, 0, 3))
    print(core.mediana(medidas))
    print(core.desviacion_estandar(medidas, muestral=True))
+   print(core.es_finito(42.0))
+   print(core.es_infinito(float("inf")))
+   print(core.es_nan(float("nan")))
+   print(core.copiar_signo(2.0, -0.0))
+
+Las utilidades ``es_finito``, ``es_infinito`` y ``es_nan`` permiten validar los
+resultados de cálculos con números de punto flotante antes de continuar con el
+flujo del programa. ``copiar_signo`` resulta útil al normalizar magnitudes y
+preservar el signo de ceros, infinitos o ``NaN`` para mantener la compatibilidad
+con otros entornos IEEE-754.
 
 .. list-table:: Equivalencias con bibliotecas numéricas
    :header-rows: 1
@@ -229,6 +239,22 @@ aleatorios reproducibles y analizar datos sin abandonar Cobra.
      - ``min(max(x, a), b)``
      - ``numpy.clip(x, a, b)``
      - ``Math.min(Math.max(x, a), b)``
+   * - ``es_finito(x)``
+     - ``math.isfinite(x)``
+     - ``numpy.isfinite(x)``
+     - ``Number.isFinite(x)``
+   * - ``es_infinito(x)``
+     - ``math.isinf(x)``
+     - ``numpy.isinf(x)``
+     - ``!Number.isFinite(x) && !Number.isNaN(x)``
+   * - ``es_nan(x)``
+     - ``math.isnan(x)``
+     - ``numpy.isnan(x)``
+     - ``Number.isNaN(x)``
+   * - ``copiar_signo(a, b)``
+     - ``math.copysign(a, b)``
+     - ``numpy.copysign(a, b)``
+     - ``Math.abs(a) * (Number.isNaN(b) ? 1 : Math.sign(b) || 1)``
    * - ``aleatorio(a, b)``
      - ``random.uniform(a, b)``
      - ``numpy.random.uniform(a, b)``

--- a/src/pcobra/core/nativos/numero.js
+++ b/src/pcobra/core/nativos/numero.js
@@ -12,6 +12,26 @@ export function redondear(valor, ndigitos = null) {
 }
 
 
+function _aNumero(nombre, valor) {
+    if (typeof valor === "number") {
+        return valor;
+    }
+    if (typeof valor === "boolean") {
+        return valor ? 1 : 0;
+    }
+    if (valor != null) {
+        const primitivo = valor.valueOf?.();
+        if (typeof primitivo === "number") {
+            return primitivo;
+        }
+    }
+    throw new TypeError(`${nombre} solo acepta números reales`);
+}
+
+function _esSignoNegativo(valor) {
+    return valor < 0 || (valor === 0 && Object.is(valor, -0));
+}
+
 export function piso(valor) {
     return Math.floor(valor);
 }
@@ -53,6 +73,29 @@ export function clamp(valor, minimo, maximo) {
         throw new Error("El mínimo no puede ser mayor que el máximo");
     }
     return Math.min(Math.max(valor, minimo), maximo);
+}
+
+export function es_finito(valor) {
+    const numero = _aNumero("es_finito", valor);
+    return Number.isFinite(numero);
+}
+
+export function es_infinito(valor) {
+    const numero = _aNumero("es_infinito", valor);
+    return numero === Infinity || numero === -Infinity;
+}
+
+export function es_nan(valor) {
+    const numero = _aNumero("es_nan", valor);
+    return Number.isNaN(numero);
+}
+
+export function copiar_signo(magnitud, signo) {
+    const magnitudNumero = _aNumero("copiar_signo", magnitud);
+    const signoNumero = _aNumero("copiar_signo", signo);
+    const negativo = _esSignoNegativo(signoNumero);
+    const magnitudAbsoluta = Math.abs(magnitudNumero);
+    return negativo ? -magnitudAbsoluta : magnitudAbsoluta;
 }
 
 

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -71,6 +71,7 @@ from corelibs.numero import (
     absoluto,
     aleatorio,
     clamp,
+    copiar_signo,
     contar_bits,
     desviacion_estandar,
     entero_a_base,
@@ -78,6 +79,9 @@ from corelibs.numero import (
     entero_desde_base,
     entero_desde_bytes,
     es_cercano,
+    es_finito,
+    es_infinito,
+    es_nan,
     es_par,
     es_primo,
     factorial,
@@ -212,6 +216,7 @@ __all__ = [
     "absoluto",
     "aleatorio",
     "clamp",
+    "copiar_signo",
     "contar_bits",
     "desviacion_estandar",
     "entero_a_base",
@@ -219,6 +224,9 @@ __all__ = [
     "entero_desde_base",
     "entero_desde_bytes",
     "es_cercano",
+    "es_finito",
+    "es_infinito",
+    "es_nan",
     "es_par",
     "es_primo",
     "factorial",
@@ -415,4 +423,26 @@ mapear_concurrencia.__doc__ = (
     " un patrón equivalente a los *worker pools* de Go, y documenta el"
     " parámetro ``limite`` junto con la opción ``return_exceptions`` para"
     " decidir si se propagan o coleccionan los errores."
+)
+
+es_finito.__doc__ = (
+    "Reexporta :func:`math.isfinite`. Indica si un número es finito tras validar"
+    " que el argumento represente un real y evita confundir ``NaN`` o infinitos"
+    " con valores válidos."
+)
+
+es_infinito.__doc__ = (
+    "Reexporta :func:`math.isinf`. Resulta útil para detectar desbordamientos"
+    " positivos o negativos antes de continuar con cálculos numéricos."
+)
+
+es_nan.__doc__ = (
+    "Reexporta :func:`math.isnan`. Permite identificar ``NaN`` conforme a IEEE-754"
+    " manteniendo comprobaciones de tipo explícitas."
+)
+
+copiar_signo.__doc__ = (
+    "Reexporta :func:`math.copysign`. Replica la semántica IEEE-754 conservando"
+    " ceros con signo e infinitos al combinar magnitudes y signos provenientes de"
+    " diferentes cálculos."
 )

--- a/src/pcobra/corelibs/numero.py
+++ b/src/pcobra/corelibs/numero.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 import random
+from typing import Any
 from statistics import StatisticsError, median, mode, pstdev, stdev
 
 _ALFABETO_DEFECTO = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -68,6 +69,49 @@ def es_cercano(
     """
 
     return math.isclose(a, b, rel_tol=tolerancia_relativa, abs_tol=tolerancia_absoluta)
+
+
+def _a_float(valor: Any, nombre: str) -> float:
+    """Coacciona ``valor`` a ``float`` validando que represente un número real."""
+
+    if isinstance(valor, bool):
+        valor = int(valor)
+    if isinstance(valor, (int, float)):
+        return float(valor)
+    if isinstance(valor, (str, bytes, bytearray, memoryview)):
+        raise TypeError(f"{nombre} solo acepta números reales")
+    if hasattr(valor, "__float__"):
+        try:
+            return float(valor)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(f"{nombre} solo acepta números reales") from exc
+    raise TypeError(f"{nombre} solo acepta números reales")
+
+
+def es_finito(valor) -> bool:
+    """Indica si ``valor`` representa un número finito."""
+
+    return math.isfinite(_a_float(valor, "es_finito"))
+
+
+def es_infinito(valor) -> bool:
+    """Indica si ``valor`` es positivo o negativo infinito."""
+
+    return math.isinf(_a_float(valor, "es_infinito"))
+
+
+def es_nan(valor) -> bool:
+    """Indica si ``valor`` es ``NaN`` siguiendo la semántica IEEE-754."""
+
+    return math.isnan(_a_float(valor, "es_nan"))
+
+
+def copiar_signo(magnitud, signo):
+    """Devuelve ``magnitud`` con el signo de ``signo`` conservando ``NaN`` y ceros con signo."""
+
+    magnitud_float = _a_float(magnitud, "copiar_signo")
+    signo_float = _a_float(signo, "copiar_signo")
+    return math.copysign(magnitud_float, signo_float)
 
 
 def producto(valores, inicio=1):

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -86,6 +86,7 @@ from standard_library.texto import (
     envolver_texto,
     acortar_texto,
 )
+from standard_library.numero import es_finito, es_infinito, es_nan, copiar_signo
 from standard_library.util import es_nulo, es_vacio, rel, repetir
 
 __all__: list[str] = [
@@ -116,6 +117,10 @@ __all__: list[str] = [
     "xor_multiple",
     "todas",
     "alguna",
+    "es_finito",
+    "es_infinito",
+    "es_nan",
+    "copiar_signo",
     "es_nulo",
     "es_vacio",
     "rel",

--- a/src/pcobra/standard_library/numero.py
+++ b/src/pcobra/standard_library/numero.py
@@ -1,0 +1,35 @@
+"""Atajos numéricos de la biblioteca estándar."""
+
+from __future__ import annotations
+
+from typing import SupportsFloat
+
+from pcobra.corelibs import numero as _numero
+
+RealLike = SupportsFloat | int | float
+
+__all__ = ["es_finito", "es_infinito", "es_nan", "copiar_signo"]
+
+
+def es_finito(valor: RealLike) -> bool:
+    """Retorna ``True`` si ``valor`` es finito evitando `NaN` e infinitos."""
+
+    return _numero.es_finito(valor)
+
+
+def es_infinito(valor: RealLike) -> bool:
+    """Retorna ``True`` si ``valor`` representa ``+∞`` o ``-∞``."""
+
+    return _numero.es_infinito(valor)
+
+
+def es_nan(valor: RealLike) -> bool:
+    """Retorna ``True`` cuando ``valor`` es ``NaN`` conforme a IEEE-754."""
+
+    return _numero.es_nan(valor)
+
+
+def copiar_signo(magnitud: RealLike, signo: RealLike) -> float:
+    """Devuelve ``magnitud`` con el signo de ``signo`` manteniendo ceros con signo."""
+
+    return _numero.copiar_signo(magnitud, signo)

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -1,3 +1,4 @@
+import math
 import operator
 import os
 import random
@@ -137,6 +138,30 @@ def test_texto_funcs():
 
 
 def test_numero_funcs():
+    assert core.es_finito(42) is True
+    assert core.es_finito(0.0) is True
+    assert core.es_finito(float("inf")) is False
+    assert core.es_finito(float("nan")) is False
+    assert core.es_infinito(float("inf")) is True
+    assert core.es_infinito(float("-inf")) is True
+    assert core.es_infinito(3.14) is False
+    assert core.es_nan(float("nan")) is True
+    assert core.es_nan(1.0) is False
+    with pytest.raises(TypeError):
+        core.es_finito("0")
+    with pytest.raises(TypeError):
+        core.es_infinito(b"1")
+    with pytest.raises(TypeError):
+        core.es_nan(object())
+    assert core.copiar_signo(3.0, -2.0) == pytest.approx(-3.0)
+    assert core.copiar_signo(-2.5, 7.0) == pytest.approx(2.5)
+    cero_negativo = core.copiar_signo(0.0, -0.0)
+    assert math.copysign(1.0, cero_negativo) == -1.0
+    nan_resultado = core.copiar_signo(float("nan"), -1.0)
+    assert math.isnan(nan_resultado)
+    with pytest.raises(TypeError):
+        core.copiar_signo("1", 1)
+
     assert core.absoluto(-5) == 5
     assert core.absoluto(-5.2) == pytest.approx(5.2)
     assert core.redondear(3.14159, 2) == pytest.approx(3.14)

--- a/tests/unit/test_standard_library_numero.py
+++ b/tests/unit/test_standard_library_numero.py
@@ -1,0 +1,62 @@
+from importlib import util
+from pathlib import Path
+import math
+import sys
+from types import ModuleType
+
+import pytest
+
+
+def _cargar_numero():
+    ruta = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "pcobra"
+        / "standard_library"
+        / "numero.py"
+    )
+    spec = util.spec_from_file_location("standard_library.numero", ruta)
+    modulo = util.module_from_spec(spec)
+    if "standard_library" not in sys.modules:
+        paquete = ModuleType("standard_library")
+        paquete.__path__ = [str(ruta.parent)]
+        sys.modules["standard_library"] = paquete
+    sys.modules["standard_library.numero"] = modulo
+    assert spec.loader is not None
+    spec.loader.exec_module(modulo)
+    return modulo
+
+
+numero = _cargar_numero()
+
+
+def test_es_finito_infinito_nan():
+    assert numero.es_finito(10)
+    assert not numero.es_finito(float("inf"))
+    assert not numero.es_finito(float("nan"))
+    assert numero.es_infinito(float("-inf"))
+    assert not numero.es_infinito(0.0)
+    assert numero.es_nan(float("nan"))
+    assert not numero.es_nan(1.0)
+
+
+def test_copiar_signo():
+    assert numero.copiar_signo(5.0, -2.0) == pytest.approx(-5.0)
+    resultado = numero.copiar_signo(0.0, -0.0)
+    assert math.copysign(1.0, resultado) == -1.0
+    nan = numero.copiar_signo(float("nan"), -1.0)
+    assert math.isnan(nan)
+
+
+@pytest.mark.parametrize(
+    "funcion, argumentos",
+    [
+        (numero.es_finito, ("1",)),
+        (numero.es_infinito, (object(),)),
+        (numero.es_nan, (b"0",)),
+        (numero.copiar_signo, ("1", 1)),
+    ],
+)
+def test_validaciones(funcion, argumentos):
+    with pytest.raises(TypeError):
+        funcion(*argumentos)


### PR DESCRIPTION
## Summary
- add IEEE-754 aware helpers es_finito, es_infinito, es_nan and copiar_signo to core numeric utilities and re-export them through the aggregated API
- mirror the helpers in the standard library package, provide native JavaScript counterparts and extend documentation plus changelog entries
- expand unit tests for corelibs and standard library to cover NaN, infinity and copy-sign edge cases

## Testing
- `pytest -o addopts='' tests/unit/test_corelibs.py tests/unit/test_standard_library_numero.py`


------
https://chatgpt.com/codex/tasks/task_e_68cd2ac8c3a083279bb37a9d6c569726