### PR TITLE
Add interpolation and modular wrap helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Validadores `es_*` alineados con `str.is*` disponibles tanto en `pcobra.corelibs.texto` como en `standard_library.texto`, con equivalentes nativos para JavaScript.
 - `standard_library.datos` incorpora lectura y escritura de archivos Parquet y Feather detectando automáticamente los motores opcionales requeridos.
 - `corelibs.numero` añade `es_finito`, `es_infinito`, `es_nan` y `copiar_signo`, reexportados en la biblioteca estándar y con equivalentes nativos que respetan IEEE-754.
+- `corelibs.numero` suma `interpolar` (lerp saturado al estilo de Rust/Kotlin) y `envolver_modular` (residuo euclidiano compatible con `rem_euclid`/`mod`), expuestos también desde `standard_library.numero` y documentados con nuevos ejemplos.
 - `corelibs.asincrono` incorpora `grupo_tareas`, un administrador compatible con
   versiones anteriores que replica la semántica de `asyncio.TaskGroup` y se
   expone también desde la biblioteca estándar.

--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -636,6 +636,18 @@ imprimir(texto.sufijo_comun("astronomía", "economía"))      # 'onomía'
 
 Estas herramientas están disponibles al transpirar tanto a Python como a JavaScript y respetan los casos borde como cadenas vacías o entradas Unicode combinadas.
 
+`pcobra.corelibs.numero` también ganó atajos inspirados en `f32::lerp`/`f64::lerp` de Rust y en `kotlin.math.lerp`/`mod`. `interpolar` acota el factor al intervalo `[0, 1]` para evitar extrapolaciones accidentales y devolver siempre el extremo correcto cuando el coeficiente se sale del rango, mientras que `envolver_modular` aplica un residuo euclidiano compatible con `rem_euclid` y el operador `mod` de Kotlin incluso si los valores son negativos.
+
+```cobra
+import pcobra.corelibs as core
+import standard_library.numero as numero
+
+imprimir(core.interpolar(10.0, 20.0, 1.5))   # 20.0: factor fuera de rango saturado
+imprimir(numero.interpolar(-5.0, 5.0, 0.25))  # 0.0: idéntica API en la biblioteca estándar
+imprimir(core.envolver_modular(-3, 5))        # 2: envoltura positiva como en Rust
+imprimir(numero.envolver_modular(7.5, -5.0))  # -2.5: respeta el signo del divisor
+```
+
 ## 23. Operaciones con colecciones
 
 El módulo `pcobra.corelibs.coleccion` ahora ofrece funciones pensadas para transformar y analizar listas sin perder el orden de los elementos ni sacrificar seguridad de tipos. Las más destacadas son:

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -354,6 +354,22 @@ usar en Cobra. Entre las más destacadas se encuentran:
    print(texto.sufijo_comun("astronomía", "economía"))
    print(texto.es_palindromo("Sé verlas al revés"))
 
+Asimismo, :mod:`pcobra.corelibs.numero` incorpora ``interpolar`` y
+``envolver_modular`` inspiradas en ``f32::lerp`` de Rust y en
+``kotlin.math.lerp``/``mod``. La primera acota el factor a ``[0, 1]`` para
+evitar extrapolaciones involuntarias y la segunda devuelve residuos euclidianos
+con el mismo signo que el divisor incluso si se usan valores negativos.
+
+.. code-block:: python
+
+   import pcobra.corelibs as core
+   import standard_library.numero as numero
+
+   print(core.interpolar(10.0, 20.0, 1.5))    # 20.0
+   print(numero.interpolar(-5.0, 5.0, 0.25))  # 0.0
+   print(core.envolver_modular(-3, 5))         # 2
+   print(numero.envolver_modular(7.5, -5.0))   # -2.5
+
 Transpilación y ejecución
 -------------------------
 

--- a/src/pcobra/core/nativos/numero.js
+++ b/src/pcobra/core/nativos/numero.js
@@ -75,6 +75,58 @@ export function clamp(valor, minimo, maximo) {
     return Math.min(Math.max(valor, minimo), maximo);
 }
 
+export function interpolar(inicio, fin, factor) {
+    const inicioNumero = _aNumero("interpolar", inicio);
+    const finNumero = _aNumero("interpolar", fin);
+    const factorNumero = _aNumero("interpolar", factor);
+
+    if (
+        Number.isNaN(inicioNumero)
+        || Number.isNaN(finNumero)
+        || Number.isNaN(factorNumero)
+    ) {
+        return Number.NaN;
+    }
+
+    if (!Number.isFinite(factorNumero)) {
+        return factorNumero > 0 ? finNumero : inicioNumero;
+    }
+    if (factorNumero <= 0) {
+        return inicioNumero;
+    }
+    if (factorNumero >= 1) {
+        return finNumero;
+    }
+
+    return inicioNumero + (finNumero - inicioNumero) * factorNumero;
+}
+
+export function envolver_modular(valor, modulo) {
+    const divisor = _aNumero("envolver_modular", modulo);
+    if (divisor === 0) {
+        throw new Error("El módulo no puede ser cero");
+    }
+    const numero = _aNumero("envolver_modular", valor);
+    let resto = numero % divisor;
+
+    if (
+        (resto > 0 && divisor > 0)
+        || (resto < 0 && divisor < 0)
+    ) {
+        return resto;
+    }
+
+    if (resto === 0) {
+        return divisor < 0 || Object.is(divisor, -0) ? -0 : 0;
+    }
+
+    resto += divisor;
+    if (resto === 0) {
+        return divisor < 0 || Object.is(divisor, -0) ? -0 : 0;
+    }
+    return resto;
+}
+
 export function es_finito(valor) {
     const numero = _aNumero("es_finito", valor);
     return Number.isFinite(numero);

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -82,6 +82,7 @@ from corelibs.numero import (
     entero_a_bytes,
     entero_desde_base,
     entero_desde_bytes,
+    envolver_modular,
     es_cercano,
     es_finito,
     es_infinito,
@@ -94,6 +95,7 @@ from corelibs.numero import (
     mcm,
     mediana,
     moda,
+    interpolar,
     piso,
     potencia,
     producto,
@@ -237,6 +239,8 @@ __all__ = [
     "aleatorio",
     "clamp",
     "copiar_signo",
+    "interpolar",
+    "envolver_modular",
     "contar_bits",
     "desviacion_estandar",
     "entero_a_base",
@@ -466,4 +470,18 @@ copiar_signo.__doc__ = (
     "Reexporta :func:`math.copysign`. Replica la semántica IEEE-754 conservando"
     " ceros con signo e infinitos al combinar magnitudes y signos provenientes de"
     " diferentes cálculos."
+)
+
+interpolar.__doc__ = (
+    "Interpola valores con la misma saturación que ``f32::lerp`` en Rust y"
+    " documenta el paralelismo con ``kotlin.math.lerp``: el factor se acota al"
+    " rango ``[0, 1]`` para evitar extrapolaciones y manejar factores fuera de"
+    " rango igual que hacen dichas bibliotecas estándar."
+)
+
+envolver_modular.__doc__ = (
+    "Calcula el residuo euclidiano como ``rem_euclid`` en Rust o el operador"
+    " ``mod`` de Kotlin, retornando siempre un valor con el mismo signo que el"
+    " divisor y proporcionando envoltura modular estable incluso con valores"
+    " negativos."
 )

--- a/src/pcobra/corelibs/numero.py
+++ b/src/pcobra/corelibs/numero.py
@@ -407,6 +407,54 @@ def clamp(valor, minimo, maximo):
     return max(min(valor, maximo), minimo)
 
 
+def interpolar(inicio, fin, factor):
+    """Interpola linealmente de ``inicio`` a ``fin`` como ``lerp`` en Rust/Kotlin."""
+
+    inicio_float = _a_float(inicio, "interpolar")
+    fin_float = _a_float(fin, "interpolar")
+    factor_float = _a_float(factor, "interpolar")
+
+    if math.isnan(inicio_float) or math.isnan(fin_float) or math.isnan(factor_float):
+        return math.nan
+
+    if math.isinf(factor_float):
+        factor_normalizado = 1.0 if factor_float > 0 else 0.0
+    else:
+        factor_normalizado = max(0.0, min(1.0, factor_float))
+
+    if factor_normalizado <= 0.0:
+        return inicio_float
+    if factor_normalizado >= 1.0:
+        return fin_float
+
+    return inicio_float + (fin_float - inicio_float) * factor_normalizado
+
+
+def envolver_modular(valor, modulo):
+    """Calcula el residuo euclidiano, igual que ``rem_euclid`` o ``mod``."""
+
+    if modulo == 0:
+        raise ZeroDivisionError("El módulo no puede ser cero")
+
+    if isinstance(valor, bool):
+        valor = int(valor)
+    if isinstance(modulo, bool):
+        modulo = int(modulo)
+
+    if isinstance(valor, int) and isinstance(modulo, int):
+        return valor % modulo
+
+    valor_float = _a_float(valor, "envolver_modular")
+    modulo_float = _a_float(modulo, "envolver_modular")
+    if modulo_float == 0.0:
+        raise ZeroDivisionError("El módulo no puede ser cero")
+
+    resultado = valor_float % modulo_float
+    if resultado == 0.0:
+        return math.copysign(0.0, modulo_float)
+    return resultado
+
+
 def aleatorio(inicio: float = 0.0, fin: float = 1.0, semilla: int | None = None) -> float:
     """Genera un número aleatorio uniforme entre ``inicio`` y ``fin``."""
 

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -88,7 +88,14 @@ from standard_library.texto import (
     envolver_texto,
     acortar_texto,
 )
-from standard_library.numero import es_finito, es_infinito, es_nan, copiar_signo
+from standard_library.numero import (
+    es_finito,
+    es_infinito,
+    es_nan,
+    copiar_signo,
+    interpolar,
+    envolver_modular,
+)
 from standard_library.util import es_nulo, es_vacio, rel, repetir
 from standard_library.asincrono import grupo_tareas
 
@@ -124,6 +131,8 @@ __all__: list[str] = [
     "es_infinito",
     "es_nan",
     "copiar_signo",
+    "interpolar",
+    "envolver_modular",
     "es_nulo",
     "es_vacio",
     "rel",

--- a/src/pcobra/standard_library/numero.py
+++ b/src/pcobra/standard_library/numero.py
@@ -8,7 +8,14 @@ from pcobra.corelibs import numero as _numero
 
 RealLike = SupportsFloat | int | float
 
-__all__ = ["es_finito", "es_infinito", "es_nan", "copiar_signo"]
+__all__ = [
+    "es_finito",
+    "es_infinito",
+    "es_nan",
+    "copiar_signo",
+    "interpolar",
+    "envolver_modular",
+]
 
 
 def es_finito(valor: RealLike) -> bool:
@@ -33,3 +40,15 @@ def copiar_signo(magnitud: RealLike, signo: RealLike) -> float:
     """Devuelve ``magnitud`` con el signo de ``signo`` manteniendo ceros con signo."""
 
     return _numero.copiar_signo(magnitud, signo)
+
+
+def interpolar(inicio: RealLike, fin: RealLike, factor: RealLike) -> float:
+    """Interpola linealmente siguiendo ``lerp`` de Rust/Kotlin."""
+
+    return _numero.interpolar(inicio, fin, factor)
+
+
+def envolver_modular(valor: RealLike, modulo: RealLike) -> float | int:
+    """Aplica una envoltura modular como ``rem_euclid``/``mod``."""
+
+    return _numero.envolver_modular(valor, modulo)

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -193,6 +193,14 @@ def test_numero_funcs():
     assert core.raiz(-8, 3) == pytest.approx(-2.0)
     assert core.potencia(2, 3) == pytest.approx(8.0)
     assert core.clamp(5, 0, 3) == 3
+    assert core.interpolar(0.0, 10.0, 0.25) == pytest.approx(2.5)
+    assert core.interpolar(-5, 5, -1.0) == pytest.approx(-5.0)
+    assert core.interpolar(-5, 5, 2.0) == pytest.approx(5.0)
+    assert core.envolver_modular(7, 5) == 2
+    assert core.envolver_modular(-2, 5) == 3
+    assert core.envolver_modular(7.5, -5.0) == pytest.approx(-2.5)
+    with pytest.raises(ZeroDivisionError):
+        core.envolver_modular(1, 0)
     assert 1 <= core.aleatorio(1, 2, semilla=42) <= 2
     assert core.mediana([1, 2, 3, 4]) == 2.5
     assert core.moda([1, 1, 2, 2, 2]) == 2

--- a/tests/unit/test_standard_library_numero.py
+++ b/tests/unit/test_standard_library_numero.py
@@ -48,6 +48,16 @@ def test_copiar_signo():
     assert math.isnan(nan)
 
 
+def test_interpolar_y_envolver_modular():
+    assert numero.interpolar(0.0, 10.0, 0.5) == pytest.approx(5.0)
+    assert numero.interpolar(-5.0, 5.0, 3.0) == pytest.approx(5.0)
+    assert numero.envolver_modular(7, 5) == 2
+    assert numero.envolver_modular(-2, 5) == 3
+    assert numero.envolver_modular(7.5, -5.0) == pytest.approx(-2.5)
+    with pytest.raises(ZeroDivisionError):
+        numero.envolver_modular(1, 0)
+
+
 @pytest.mark.parametrize(
     "funcion, argumentos",
     [
@@ -55,6 +65,8 @@ def test_copiar_signo():
         (numero.es_infinito, (object(),)),
         (numero.es_nan, (b"0",)),
         (numero.copiar_signo, ("1", 1)),
+        (numero.interpolar, (0, 1, "factor")),
+        (numero.envolver_modular, (1, "0")),
     ],
 )
 def test_validaciones(funcion, argumentos):


### PR DESCRIPTION
## Summary
- implement `interpolar` and `envolver_modular` in the numeric core library mirroring Rust/Kotlin lerp and Euclidean remainder semantics, and document their export
- expose the helpers in the standard library and JavaScript runtime together with manual and changelog updates
- extend unit coverage in the core and standard library to exercise out-of-range interpolation factors and modular wrapping of negative values

## Testing
- pytest --override-ini addopts="" tests/unit/test_corelibs.py::test_numero_funcs tests/unit/test_standard_library_numero.py

------
https://chatgpt.com/codex/tasks/task_e_68cd6e2849d08327a7c05a7a05e06a8d