### PR TITLE
Add pivot helpers and mutation utility for datos module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   Swift, con opciones para ignorar mayúsculas o normalizar Unicode; se
   reexportan en la biblioteca estándar y cuentan con versiones nativas para JavaScript.
 - `corelibs.logica` añade `condicional`, un selector de ramas inspirado en ``when`` (Kotlin) y `case_when` (R) con evaluación perezosa; se reexporta en la biblioteca estándar junto con ejemplos y pruebas actualizadas.
+- `standard_library.datos` incorpora los helpers `pivotar_ancho`, `pivotar_largo` y `mutar_columna` para transformar registros y calcular columnas derivadas.
 
 ## v10.0.9 - 2025-08-17
 - Ajuste en `SafeUnpickler` para aceptar los módulos `core.ast_nodes` y `cobra.core.ast_nodes`.

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -18,6 +18,9 @@ from standard_library.datos import (
     describir,
     filtrar,
     desplegar_tabla,
+    mutar_columna,
+    pivotar_ancho,
+    pivotar_largo,
     leer_csv,
     leer_excel,
     leer_feather,
@@ -167,6 +170,9 @@ __all__: list[str] = [
     "describir",
     "seleccionar_columnas",
     "filtrar",
+    "mutar_columna",
+    "pivotar_ancho",
+    "pivotar_largo",
     "desplegar_tabla",
     "agrupar_y_resumir",
     "a_listas",
@@ -198,6 +204,9 @@ leer_feather: Callable[..., list[dict[str, Any]]]
 describir: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, Any]]
 seleccionar_columnas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Sequence[str]], list[dict[str, Any]]]
 filtrar: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Callable[[dict[str, Any]], bool]], list[dict[str, Any]]]
+mutar_columna: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], str, Callable[[dict[str, Any]], Any]], list[dict[str, Any]]]
+pivotar_ancho: Callable[..., list[dict[str, Any]]]
+pivotar_largo: Callable[..., list[dict[str, Any]]]
 desplegar_tabla: Callable[..., list[dict[str, Any]]]
 agrupar_y_resumir: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Sequence[str], Mapping[str, Any]], list[dict[str, Any]]]
 a_listas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, list[Any]]]


### PR DESCRIPTION
## Summary
- add `pivotar_ancho`, `pivotar_largo` and `mutar_columna` helpers in `standard_library.datos` and export them from the package
- extend documentation and changelog to explain the new data helpers
- exercise the new behaviour with focused unit tests for reshaping and column mutation

## Testing
- pytest tests/unit/test_standard_library_datos.py --cov=pcobra.standard_library.datos --cov-fail-under=0

------
https://chatgpt.com/codex/tasks/task_e_68cd7d8b9fe08327854bd32f00f828a8