### PR TITLE
feat: añadir reintentos asincrónicos con backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - `corelibs.asincrono` incorpora `grupo_tareas`, un administrador compatible con
   versiones anteriores que replica la semántica de `asyncio.TaskGroup` y se
   expone también desde la biblioteca estándar.
+- `corelibs.asincrono` suma `reintentar_async`, que aplica reintentos con
+  *backoff* exponencial y *jitter* opcional, reexportado en la biblioteca
+  estándar junto con documentación y pruebas que validan los tiempos de espera.
 - `corelibs.texto` suma `prefijo_comun` y `sufijo_comun`, inspirados en Kotlin y
   Swift, con opciones para ignorar mayúsculas o normalizar Unicode; se
   reexportan en la biblioteca estándar y cuentan con versiones nativas para JavaScript.

--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -198,6 +198,22 @@ imprimir('principal')
 ## 10. Funciones asincrónicas
 
 - Declara funciones asíncronas con `asincronico func`.
+- Usa `pcobra.corelibs.reintentar_async` para encapsular operaciones frágiles con
+  reintentos exponenciales y *jitter* opcional que evita que todos los clientes
+  repitan al mismo tiempo.
+
+```python
+import pcobra.corelibs as core
+
+# Reintenta hasta cuatro veces con esperas 0.2s, 0.4s, 0.8s...
+resultado = await core.reintentar_async(
+    obtener_datos,
+    intentos=4,
+    excepciones=(TimeoutError,),
+    retardo_inicial=0.2,
+    jitter=lambda base: base * 0.75,
+)
+```
 - Usa `esperar` para aguardar su resultado.
 - Las utilidades de red y sistema con sufijo `_async` devuelven tareas que
   deben combinarse con `esperar` (o `await` en los lenguajes generados).

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -152,6 +152,7 @@ from corelibs.asincrono import (
     carrera,
     primero_exitoso,
     esperar_timeout,
+    reintentar_async,
     crear_tarea,
     mapear_concurrencia,
     grupo_tareas as _grupo_tareas_impl,
@@ -318,6 +319,7 @@ __all__ = [
     "carrera",
     "primero_exitoso",
     "esperar_timeout",
+    "reintentar_async",
     "crear_tarea",
     "mapear_concurrencia",
     "grupo_tareas",
@@ -454,6 +456,14 @@ mapear_concurrencia.__doc__ = (
     " un patrón equivalente a los *worker pools* de Go, y documenta el"
     " parámetro ``limite`` junto con la opción ``return_exceptions`` para"
     " decidir si se propagan o coleccionan los errores."
+)
+
+reintentar_async.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.asincrono.reintentar_async`. Implementa"
+    " reintentos con *backoff* exponencial al estilo de utilidades basadas en"
+    " ``Promise`` de JavaScript y de los bucles de reintento con gorutinas en"
+    " Go, permitiendo añadir *jitter* para suavizar la contención entre"
+    " clientes."
 )
 
 es_finito.__doc__ = (

--- a/src/pcobra/standard_library/asincrono.py
+++ b/src/pcobra/standard_library/asincrono.py
@@ -2,11 +2,24 @@
 
 from __future__ import annotations
 
-from typing import Any, AsyncContextManager
+from typing import (
+    Any,
+    AsyncContextManager,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Sequence,
+    TypeVar,
+)
 
-from pcobra.corelibs import grupo_tareas as _grupo_tareas
+from pcobra.corelibs import (
+    grupo_tareas as _grupo_tareas,
+    reintentar_async as _reintentar_async,
+)
 
-__all__ = ["grupo_tareas"]
+T = TypeVar("T")
+
+__all__ = ["grupo_tareas", "reintentar_async"]
 
 
 def grupo_tareas() -> AsyncContextManager[Any]:
@@ -20,3 +33,37 @@ def grupo_tareas() -> AsyncContextManager[Any]:
     """
 
     return _grupo_tareas()
+
+
+async def reintentar_async(
+    funcion: Callable[[], Awaitable[T] | Coroutine[Any, Any, T]],
+    *,
+    intentos: int = 3,
+    excepciones: type[BaseException]
+    | Sequence[type[BaseException]] = (Exception,),
+    retardo_inicial: float = 0.1,
+    factor_backoff: float = 2.0,
+    max_retardo: float | None = None,
+    jitter: Callable[[float], float]
+    | tuple[float, float]
+    | float
+    | bool
+    | None = None,
+) -> T:
+    """Reintenta ``funcion`` aplicando un *backoff* exponencial con *jitter* opcional.
+
+    Envuelve :func:`pcobra.corelibs.reintentar_async` para acercar un patrón
+    equivalente al de ``Promise`` en bibliotecas de JavaScript o los bucles de
+    reintento habituales con gorutinas en Go. Resulta útil cuando se esperan
+    fallos transitorios y se desea espaciar los intentos para aliviar la carga.
+    """
+
+    return await _reintentar_async(
+        funcion,
+        intentos=intentos,
+        excepciones=excepciones,
+        retardo_inicial=retardo_inicial,
+        factor_backoff=factor_backoff,
+        max_retardo=max_retardo,
+        jitter=jitter,
+    )


### PR DESCRIPTION
## Summary
- incorpora `reintentar_async` con backoff exponencial y jitter opcional en `pcobra.corelibs.asincrono`
- reexporta la utilidad en `pcobra.corelibs` y la biblioteca estándar con documentación vinculada
- añade pruebas de reintentos controlados, recomendaciones en el manual y entrada en el changelog

## Testing
- `pytest --override-ini="addopts=" tests/unit/test_corelibs.py`


------
https://chatgpt.com/codex/tasks/task_e_68cdb59ed2a08327bf13e3c30d7362f2