### PR TITLE
Add snake/camel casing helpers and docs

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -621,6 +621,7 @@ El módulo `pcobra.corelibs.texto` se amplió con herramientas inspiradas en `st
 - `rellenar_izquierda` y `rellenar_derecha` para completar cadenas con cualquier patrón.
 - `normalizar_unicode` que acepta las formas `NFC`, `NFD`, `NFKC` y `NFKD` para trabajar con Unicode de forma predecible.
 - `quitar_prefijo`, `quitar_sufijo`, `prefijo_comun` y `sufijo_comun` replican `str.removeprefix`/`str.removesuffix` de Python, `strings.TrimPrefix`/`TrimSuffix` de Go y añaden equivalentes a `commonPrefixWith`/`commonSuffixWith` de Kotlin o `String.commonPrefix`/`String.commonSuffix` de Swift con opciones para ignorar mayúsculas y normalizar Unicode.
+- `a_snake` y `a_camel` generan identificadores normalizados como lo hacen extensiones de Kotlin, las rutinas `lowerCamelCase` de Swift o utilidades de JavaScript (por ejemplo `lodash.snakeCase`/`camelCase`), mientras que `quitar_envoltura` reproduce `removeSurrounding` de Kotlin junto con los patrones `hasPrefix`/`hasSuffix` de Swift y `String.prototype.slice` en JS.
 - `dividir_lineas` respeta combinaciones `\r\n` como `str.splitlines`, `contar_subcadena` acepta intervalos opcionales al estilo `str.count`, `centrar_texto` centra con relleno como `str.center` y `rellenar_ceros` añade ceros como `str.zfill`.
 - `indentar_texto` y `desindentar_texto` replican `textwrap.indent`/`dedent` para aplicar o eliminar sangrías comunes sin perder líneas en blanco relevantes.
 - `envolver_texto` ajusta párrafos con sangrías iniciales y posteriores, y `acortar_texto` resume frases al estilo de `textwrap.shorten` añadiendo un marcador configurable.
@@ -652,6 +653,9 @@ imprimir(texto.envolver_texto("Cobra facilita scripts portables", 18, como_texto
 imprimir(core.particionar_texto("ruta/archivo.ext", "/"))  # ('ruta', '/', 'archivo.ext')
 imprimir(texto.particionar_derecha("archivo.tar.gz", "."))  # ('archivo.tar', '.', 'gz')
 imprimir(texto.sufijo_comun("astronomía", "economía"))      # 'onomía'
+imprimir(core.a_snake("MiValorHTTP"))                     # 'mi_valor_http'
+imprimir(texto.a_camel("hola-mundo cobra", inicial_mayuscula=True))  # 'HolaMundoCobra'
+imprimir(core.quitar_envoltura("«mañana»", "«", "»"))    # 'mañana'
 ```
 
 Estas herramientas están disponibles al transpirar tanto a Python como a JavaScript y respetan los casos borde como cadenas vacías o entradas Unicode combinadas.

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -334,6 +334,12 @@ usar en Cobra. Entre las más destacadas se encuentran:
   ``commonPrefixWith``/``commonSuffixWith`` de Kotlin o
   ``String.commonPrefix``/``String.commonSuffix`` de Swift. Ambas admiten
   ignorar mayúsculas y normalizar Unicode antes de comparar.
+* ``a_snake`` y ``a_camel`` producen identificadores inspirados en
+  extensiones de Kotlin, las rutinas ``lowerCamelCase`` de Swift y
+  utilidades de JavaScript como ``lodash.snakeCase``/``camelCase``; a su
+  vez ``quitar_envoltura`` reproduce ``removeSurrounding`` de Kotlin y el
+  recorte con ``hasPrefix``/``hasSuffix`` de Swift o ``String.prototype.slice``
+  en JavaScript.
 * ``normalizar_unicode`` acepta las formas ``NFC``, ``NFD``, ``NFKC`` y
   ``NFKD`` para unificar representaciones.
 * ``indentar_texto``/``desindentar_texto``, ``envolver_texto`` y
@@ -353,6 +359,9 @@ usar en Cobra. Entre las más destacadas se encuentran:
    print(core.prefijo_comun("Canción", "cancio\u0301n", ignorar_mayusculas=True, normalizar="NFC"))
    print(texto.sufijo_comun("astronomía", "economía"))
    print(texto.es_palindromo("Sé verlas al revés"))
+   print(core.a_snake("MiValorHTTP"))
+   print(texto.a_camel("hola-mundo cobra", inicial_mayuscula=True))
+   print(core.quitar_envoltura("«mañana»", "«", "»"))
 
 Asimismo, :mod:`pcobra.corelibs.numero` incorpora ``interpolar`` y
 ``envolver_modular`` inspiradas en ``f32::lerp`` de Rust y en

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -25,6 +25,9 @@ from corelibs.texto import (
     incluye,
     quitar_prefijo,
     quitar_sufijo,
+    a_snake,
+    a_camel,
+    quitar_envoltura,
     prefijo_comun,
     sufijo_comun,
     particionar as particionar_texto,
@@ -202,6 +205,9 @@ __all__ = [
     "incluye",
     "quitar_prefijo",
     "quitar_sufijo",
+    "a_snake",
+    "a_camel",
+    "quitar_envoltura",
     "prefijo_comun",
     "sufijo_comun",
     "particionar_texto",
@@ -343,6 +349,25 @@ quitar_sufijo.__doc__ = (
     "Reexporta :func:`pcobra.corelibs.texto.quitar_sufijo`. Se inspira en ``str.removesuffix`` "
     "de Python, ``strings.TrimSuffix`` del paquete estándar de Go y en el uso de"
     " ``String.prototype.endsWith`` junto a ``slice`` en JavaScript."
+)
+
+a_snake.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.texto.a_snake`. Convierte identificadores al estilo"
+    " ``snake_case`` como hacen utilidades de JavaScript (por ejemplo, ``lodash.snakeCase``)"
+    " y extensiones populares de Kotlin para homogeneizar nombres."
+)
+
+a_camel.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.texto.a_camel`. Genera ``camelCase``/``PascalCase``"
+    " emulando los transformadores presentes en Swift (``lowerCamelCase``) y en"
+    " bibliotecas de JavaScript."
+)
+
+quitar_envoltura.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.texto.quitar_envoltura`. Reproduce ``removeSurrounding``"
+    " de Kotlin y puede replicarse en Swift combinando ``hasPrefix``/``hasSuffix`` con"
+    " ``dropFirst``/``dropLast``, o en JavaScript mediante ``startsWith``/``endsWith`` y"
+    " ``slice``."
 )
 
 dividir_lineas.__doc__ = (

--- a/src/pcobra/standard_library/texto.py
+++ b/src/pcobra/standard_library/texto.py
@@ -36,6 +36,9 @@ from pcobra.corelibs import (
     quitar_espacios,
     quitar_prefijo as _quitar_prefijo,
     quitar_sufijo as _quitar_sufijo,
+    a_snake as _a_snake,
+    a_camel as _a_camel,
+    quitar_envoltura as _quitar_envoltura,
     particionar_derecha as _particionar_derecha,
     particionar_texto as _particionar,
     rellenar_ceros as _rellenar_ceros,
@@ -81,6 +84,9 @@ __all__ = [
     "es_espacio",
     "quitar_prefijo",
     "quitar_sufijo",
+    "a_snake",
+    "a_camel",
+    "quitar_envoltura",
     "prefijo_comun",
     "sufijo_comun",
     "dividir_lineas",
@@ -155,6 +161,24 @@ def es_anagrama(texto: str, otro: str, *, ignorar_espacios: bool = True) -> bool
         return normalizar_unicode("".join(sorted(resultado)), "NFC")
 
     return preparar(texto) == preparar(otro)
+
+
+def a_snake(texto: str) -> str:
+    """Convierte ``texto`` en ``snake_case`` Unicode estable.
+
+    English: Convert ``texto`` into Unicode-aware ``snake_case`` inspired by JS helpers.
+    """
+
+    return _a_snake(texto)
+
+
+def a_camel(texto: str, *, inicial_mayuscula: bool = False) -> str:
+    """Construye ``camelCase`` o ``PascalCase`` al estilo de Swift y JavaScript.
+
+    English: Produce ``camelCase``/``PascalCase`` identifiers similar to Swift and JS tools.
+    """
+
+    return _a_camel(texto, inicial_mayuscula=inicial_mayuscula)
 
 
 def intercambiar_mayusculas(texto: str) -> str:
@@ -352,6 +376,15 @@ def sufijo_comun(
         ignorar_mayusculas=ignorar_mayusculas,
         normalizar=normalizar,
     )
+
+
+def quitar_envoltura(texto: str, prefijo: str, sufijo: str) -> str:
+    """Quita envolturas coincidentes como ``removeSurrounding`` de Kotlin.
+
+    English: Remove matching wrappers mirroring Kotlin, Swift slicing and JS idioms.
+    """
+
+    return _quitar_envoltura(texto, prefijo, sufijo)
 
 
 def dividir_lineas(texto: str, conservar_delimitadores: bool = False) -> list[str]:

--- a/tests/unit/test_standard_library_texto.py
+++ b/tests/unit/test_standard_library_texto.py
@@ -42,6 +42,21 @@ def test_es_anagrama():
     assert texto.es_anagrama("cosa", "caso ", ignorar_espacios=False) is False
 
 
+def test_a_snake_y_a_camel():
+    assert texto.a_snake("HolaMundo") == "hola_mundo"
+    assert texto.a_snake("mañana-tarde Noche") == "mañana_tarde_noche"
+    assert texto.a_snake("JSONDataLoader") == "json_data_loader"
+    assert texto.a_camel("hola mundo") == "holaMundo"
+    assert texto.a_camel("mañana_tarde noche", inicial_mayuscula=True) == "MañanaTardeNoche"
+    assert texto.a_camel("datos-JSON_parser") == "datosJsonParser"
+
+
+def test_quitar_envoltura_normaliza():
+    assert texto.quitar_envoltura("«mañana»", "«", "»") == "mañana"
+    assert texto.quitar_envoltura("cancio\u0301n", "can", "ón") == "ci"
+    assert texto.quitar_envoltura("⚡dato⚡", "", "⚡") == "⚡dato"
+
+
 def test_prefijos_y_sufijos():
     assert texto.quitar_prefijo("🧪Prueba", "🧪") == "Prueba"
     assert texto.quitar_prefijo("demo", "x") == "demo"


### PR DESCRIPTION
## Summary
- add Unicode-aware tokenization plus snake/camel casing and wrapper removal helpers to `corelibs.texto`
- expose the new helpers from `standard_library.texto` with bilingual docstrings and document their Kotlin/Swift/JS inspiration
- extend manuals and unit tests with examples covering accents and mixed separators

## Testing
- pytest -o addopts="" tests/unit/test_standard_library_texto.py

------
https://chatgpt.com/codex/tasks/task_e_68ce2979ae6c83279e2b8770d2add0a0