### PR TITLE
Expose signo and limitar numeric helpers

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -672,6 +672,22 @@ imprimir(core.envolver_modular(-3, 5))        # 2: envoltura positiva como en Ru
 imprimir(numero.envolver_modular(7.5, -5.0))  # -2.5: respeta el signo del divisor
 ```
 
+`signo` y `limitar` complementan estos atajos cuando necesitas clasificar o
+acotar magnitudes con semántica de IEEE-754. `signo` devuelve `-1`, `0` o `1`
+para enteros y preserva ceros con signo o `NaN` al trabajar con flotantes,
+mientras que `limitar` valida que el mínimo no supere al máximo y propaga `NaN`
+si los extremos no son válidos.
+
+```cobra
+import pcobra.corelibs as core
+import standard_library.numero as numero
+
+imprimir(core.signo(-3))                 # -1: enteros devuelven -1/0/1
+imprimir(numero.signo(-0.0))             # -0.0: conserva ceros con signo
+imprimir(core.limitar(120, 0, 100))      # 100: satura el valor al máximo
+imprimir(numero.limitar(float("nan"), 0.0, 1.0))  # NaN propagado
+```
+
 Para cálculos combinatorios o sumas delicadas en precisión cuentas con nuevos
 accesos directos. `raiz_entera` aprovecha `math.isqrt` para trabajar con enteros
 gigantes, `combinaciones` y `permutaciones` delegan en `math.comb`/`math.perm`

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -203,6 +203,22 @@ flujo del programa. ``copiar_signo`` resulta útil al normalizar magnitudes y
 preservar el signo de ceros, infinitos o ``NaN`` para mantener la compatibilidad
 con otros entornos IEEE-754.
 
+``signo`` y ``limitar`` completan estas herramientas cuando necesitas clasificar
+o acotar valores reales. ``signo`` devuelve ``-1``, ``0`` o ``1`` para enteros y
+mantiene ceros con signo o ``NaN`` cuando trabajas con flotantes, mientras que
+``limitar`` valida el rango ``[minimo, maximo]`` y también propaga ``NaN`` si
+algún extremo no es un número válido.
+
+.. code-block:: python
+
+   import pcobra.corelibs as core
+   import standard_library.numero as numero
+
+   print(core.signo(-3))                 # -1: enteros devuelven -1/0/1
+   print(numero.signo(-0.0))             # -0.0: conserva ceros con signo
+   print(core.limitar(120, 0, 100))      # 100: satura el valor al máximo
+   print(numero.limitar(float("nan"), 0.0, 1.0))  # NaN propagado
+
 Para cálculos combinatorios y sumas sensibles a errores de redondeo dispones
 de atajos adicionales. ``raiz_entera`` delega en ``math.isqrt`` para obtener la
 raíz cuadrada entera de valores gigantes sin perder precisión, ``combinaciones``
@@ -257,7 +273,7 @@ de significancia en sumas largas.
      - ``math.pow(a, b)``
      - ``numpy.power(a, b)``
      - ``Math.pow(a, b)``
-   * - ``clamp(x, a, b)``
+   * - ``limitar(x, a, b)`` / ``clamp(x, a, b)``
      - ``min(max(x, a), b)``
      - ``numpy.clip(x, a, b)``
      - ``Math.min(Math.max(x, a), b)``

--- a/docs/SPEC_COBRA.md
+++ b/docs/SPEC_COBRA.md
@@ -150,3 +150,18 @@ El intérprete define la excepción `ExcepcionCobra`. Al ejecutar un `throw` se 
 
 ## Ejemplos mínimos
 Los ejemplos de `frontend/sintaxis.rst` muestran el uso básico del lenguaje: declaraciones con `var`, funciones `func`, condicionales `si`/`sino`, bucles `mientras` y `para`, holobits, importaciones, manejo de excepciones con `try`/`catch`, hilos y decoradores con `@`.
+
+## Biblioteca estándar
+
+El paquete `standard_library.numero` reexporta los atajos numéricos de
+`pcobra.corelibs` con nombres idiomáticos en español. Entre ellos destacan
+`signo`, que devuelve `-1`, `0` o `1` y preserva ceros con signo o `NaN` cuando
+se trabaja con flotantes, y `limitar`, que valida que `minimo` no supere a
+`maximo` y propaga `NaN` si alguno de los extremos no es un número válido.
+
+```cobra
+import standard_library.numero as numero
+
+var direccion = numero.signo(-0.0)        # -0.0 conserva el signo del cero
+var brillo = numero.limitar(1.5, 0.0, 1.0)  # 1.0: el valor queda dentro del rango
+```

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -83,6 +83,7 @@ from corelibs.numero import (
     absoluto,
     aleatorio,
     clamp,
+    limitar,
     copiar_signo,
     combinaciones,
     contar_bits,
@@ -112,6 +113,7 @@ from corelibs.numero import (
     promedio,
     raiz,
     raiz_entera,
+    signo,
     rotar_bits_derecha,
     rotar_bits_izquierda,
     suma_precisa,
@@ -263,8 +265,10 @@ __all__ = [
     "absoluto",
     "aleatorio",
     "clamp",
+    "limitar",
     "copiar_signo",
     "combinaciones",
+    "signo",
     "interpolar",
     "envolver_modular",
     "contar_bits",
@@ -523,6 +527,12 @@ es_nan.__doc__ = (
     " manteniendo comprobaciones de tipo explícitas."
 )
 
+signo.__doc__ = (
+    "Equivalente a ``math.copysign`` combinado con ``math.sign`` de Kotlin o"
+    " ``numpy.sign``. Devuelve ``-1``, ``0`` o ``1`` para enteros y preserva ceros"
+    " con signo o ``NaN`` cuando se trabaja con flotantes."
+)
+
 copiar_signo.__doc__ = (
     "Reexporta :func:`math.copysign`. Replica la semántica IEEE-754 conservando"
     " ceros con signo e infinitos al combinar magnitudes y signos provenientes de"
@@ -541,4 +551,11 @@ envolver_modular.__doc__ = (
     " ``mod`` de Kotlin, retornando siempre un valor con el mismo signo que el"
     " divisor y proporcionando envoltura modular estable incluso con valores"
     " negativos."
+)
+
+limitar.__doc__ = (
+    "Alias descriptivo de :func:`pcobra.corelibs.numero.limitar` para quienes"
+    " prefieren una API en español al clamping ``min``/``max`` habitual,"
+    " garantizando la propagación de ``NaN`` y validando que el mínimo no exceda"
+    " al máximo."
 )

--- a/src/pcobra/corelibs/numero.py
+++ b/src/pcobra/corelibs/numero.py
@@ -114,6 +114,27 @@ def copiar_signo(magnitud, signo):
     return math.copysign(magnitud_float, signo_float)
 
 
+def signo(valor):
+    """Obtiene el signo de ``valor`` preservando enteros y ceros con signo."""
+
+    if isinstance(valor, bool):
+        valor = int(valor)
+
+    if isinstance(valor, int):
+        if valor > 0:
+            return 1
+        if valor < 0:
+            return -1
+        return 0
+
+    numero = _a_float(valor, "signo")
+    if math.isnan(numero):
+        return math.nan
+    if numero == 0.0:
+        return math.copysign(0.0, numero)
+    return math.copysign(1.0, numero)
+
+
 def producto(valores, inicio=1):
     """Obtiene el producto acumulado de ``valores`` iniciando en ``inicio``.
 
@@ -413,12 +434,54 @@ def potencia(base, exponente):
     return math.pow(base, exponente)
 
 
+def limitar(valor, minimo, maximo):
+    """Restringe ``valor`` al rango ``[minimo, maximo]`` propagando ``NaN``."""
+
+    if isinstance(valor, bool):
+        valor = int(valor)
+    if isinstance(minimo, bool):
+        minimo = int(minimo)
+    if isinstance(maximo, bool):
+        maximo = int(maximo)
+
+    origen_entero = all(isinstance(argumento, int) for argumento in (valor, minimo, maximo))
+    valor_es_int = isinstance(valor, int)
+    if origen_entero:
+        if minimo > maximo:
+            raise ValueError("El mínimo no puede ser mayor que el máximo")
+        if valor < minimo:
+            return minimo
+        if valor > maximo:
+            return maximo
+        return valor
+
+    valor_float = _a_float(valor, "limitar")
+    minimo_float = _a_float(minimo, "limitar")
+    maximo_float = _a_float(maximo, "limitar")
+
+    if math.isnan(minimo_float) or math.isnan(maximo_float):
+        return math.nan
+    if minimo_float > maximo_float:
+        raise ValueError("El mínimo no puede ser mayor que el máximo")
+    if math.isnan(valor_float):
+        return math.nan
+
+    if valor_float < minimo_float:
+        resultado = minimo_float
+    elif valor_float > maximo_float:
+        resultado = maximo_float
+    else:
+        resultado = valor_float
+
+    if valor_es_int and math.isfinite(resultado) and resultado.is_integer():
+        return int(resultado)
+    return resultado
+
+
 def clamp(valor, minimo, maximo):
     """Restringe ``valor`` al rango ``[minimo, maximo]``."""
 
-    if minimo > maximo:
-        raise ValueError("El mínimo no puede ser mayor que el máximo")
-    return max(min(valor, maximo), minimo)
+    return limitar(valor, minimo, maximo)
 
 
 def interpolar(inicio, fin, factor):

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -101,6 +101,8 @@ from standard_library.numero import (
     es_infinito,
     es_nan,
     copiar_signo,
+    signo,
+    limitar,
     interpolar,
     envolver_modular,
 )
@@ -138,6 +140,8 @@ __all__: list[str] = [
     "alguna",
     "es_finito",
     "es_infinito",
+    "signo",
+    "limitar",
     "es_nan",
     "copiar_signo",
     "interpolar",

--- a/src/pcobra/standard_library/numero.py
+++ b/src/pcobra/standard_library/numero.py
@@ -13,6 +13,8 @@ __all__ = [
     "es_infinito",
     "es_nan",
     "copiar_signo",
+    "signo",
+    "limitar",
     "raiz_entera",
     "combinaciones",
     "permutaciones",
@@ -44,6 +46,18 @@ def copiar_signo(magnitud: RealLike, signo: RealLike) -> float:
     """Devuelve ``magnitud`` con el signo de ``signo`` manteniendo ceros con signo."""
 
     return _numero.copiar_signo(magnitud, signo)
+
+
+def signo(valor: RealLike) -> float | int:
+    """Calcula el signo de ``valor`` devolviendo ``-1``, ``0`` o ``1`` y propagando ``NaN``."""
+
+    return _numero.signo(valor)
+
+
+def limitar(valor: RealLike, minimo: RealLike, maximo: RealLike) -> float | int:
+    """Restringe ``valor`` al intervalo ``[minimo, maximo]`` validando los límites."""
+
+    return _numero.limitar(valor, minimo, maximo)
 
 
 def raiz_entera(valor: RealLike) -> int:

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -185,6 +185,24 @@ def test_numero_funcs():
     with pytest.raises(TypeError):
         core.copiar_signo("1", 1)
 
+    assert core.signo(-5) == -1
+    assert core.signo(0) == 0
+    assert core.signo(2.5) == pytest.approx(1.0)
+    assert math.copysign(1.0, core.signo(-0.0)) == -1.0
+    assert math.isnan(core.signo(float("nan")))
+    with pytest.raises(TypeError):
+        core.signo("1")
+
+    assert core.limitar(5, 0, 10) == 5
+    assert core.limitar(-5, -3, 3) == -3
+    assert core.limitar(2.5, 0.0, 1.0) == pytest.approx(1.0)
+    assert math.isnan(core.limitar(float("nan"), 0.0, 1.0))
+    assert math.isnan(core.limitar(1.0, float("nan"), 2.0))
+    with pytest.raises(ValueError):
+        core.limitar(0, 2, 1)
+    with pytest.raises(TypeError):
+        core.limitar(0, 1, "2")
+
     assert core.absoluto(-5) == 5
     assert core.absoluto(-5.2) == pytest.approx(5.2)
     assert core.redondear(3.14159, 2) == pytest.approx(3.14)

--- a/tests/unit/test_standard_library_numero.py
+++ b/tests/unit/test_standard_library_numero.py
@@ -51,6 +51,22 @@ def test_copiar_signo():
     assert math.isnan(nan)
 
 
+def test_signo_y_limitar():
+    assert numero.signo(-5) == -1
+    assert numero.signo(0) == 0
+    assert numero.signo(3.5) == pytest.approx(1.0)
+    assert math.copysign(1.0, numero.signo(-0.0)) == -1.0
+    assert math.isnan(numero.signo(float("nan")))
+
+    assert numero.limitar(5, 0, 10) == 5
+    assert numero.limitar(-5, -3, 3) == -3
+    assert numero.limitar(2.5, 0.0, 1.0) == pytest.approx(1.0)
+    assert math.isnan(numero.limitar(1.0, float("nan"), 5.0))
+    assert math.isnan(numero.limitar(float("nan"), 0.0, 1.0))
+    with pytest.raises(ValueError):
+        numero.limitar(0, 2, 1)
+
+
 def test_interpolar_y_envolver_modular():
     assert numero.interpolar(0.0, 10.0, 0.5) == pytest.approx(5.0)
     assert numero.interpolar(-5.0, 5.0, 3.0) == pytest.approx(5.0)
@@ -90,6 +106,8 @@ def test_suma_precisa_precision():
         (numero.es_infinito, (object(),)),
         (numero.es_nan, (b"0",)),
         (numero.copiar_signo, ("1", 1)),
+        (numero.signo, (object(),)),
+        (numero.limitar, (1, "0", 2)),
         (numero.interpolar, (0, 1, "factor")),
         (numero.envolver_modular, (1, "0")),
         (numero.raiz_entera, ("9",)),


### PR DESCRIPTION
## Summary
- add `signo` and `limitar` helpers to the numeric core library and route `clamp` through the new implementation that propagates NaN
- re-export the helpers from the standard library and document their behaviour in both manuals and the SPEC
- extend unit coverage for integers and floats in the corelibs and standard library number tests

## Testing
- pytest --override-ini addopts='' -k 'not reintentar_async and not grupo_tareas' tests/unit/test_standard_library_numero.py tests/unit/test_corelibs.py

------
https://chatgpt.com/codex/tasks/task_e_68ce9f4a8e588327b93853708bf0b286