### PR TITLE
Añadir helpers asincrónicos protegidos y su documentación

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -280,6 +280,12 @@ varias tareas sin perder legibilidad:
   cancela limpiamente si se supera el límite.
 - `crear_tarea` centraliza la creación de tareas para evitar fugas de corrutinas
   al integrar Cobra con bibliotecas Python.
+- `proteger_tarea` reutiliza `asyncio.shield` para aislar corrutinas de
+  cancelaciones externas, muy en la línea de `Promise.resolve` cuando se quiere
+  preservar el trabajo en curso.
+- `ejecutar_en_hilo` usa `asyncio.to_thread` (o `run_in_executor` en versiones
+  antiguas) para llevar funciones síncronas a un flujo asincrónico, igual que
+  `Promise.resolve` permite esperar valores que no son promesas.
 - `grupo_tareas` replica `asyncio.TaskGroup`, cancelando las tareas hermanas
   cuando una falla y manteniendo compatibilidad con Python 3.10.
 
@@ -317,7 +323,9 @@ async def procesar_datos():
 ```
 
 Este manejador también está disponible como `standard_library.grupo_tareas` para
-los programas escritos íntegramente en Cobra.
+los programas escritos íntegramente en Cobra, junto con `standard_library.proteger_tarea`
+y `standard_library.ejecutar_en_hilo` para integrarse con el resto de utilidades
+asíncronas.
 
 La combinación de estas utilidades facilita alternar entre estilos típicos de
 Python y de JavaScript sin perder características de ninguno: se conservan las

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -113,6 +113,13 @@ través de ``asyncio.Semaphore`` para respetar un ``limite`` máximo de tareas y
 decidir, mediante ``return_exceptions``, si los errores cancelan el resto o se
 registran junto a sus posiciones originales.
 
+Además se incluyen ``proteger_tarea``, que envuelve ``asyncio.shield`` para
+evitar que una cancelación externa interrumpa el trabajo en curso (muy similar a
+como ``Promise.resolve`` preserva un valor ya en proceso), y
+``ejecutar_en_hilo``, que delega en ``asyncio.to_thread`` o
+``run_in_executor`` para llevar funciones bloqueantes a un flujo asincrónico sin
+romper la semántica de ``await``.
+
 Decoradores
 -----------
 

--- a/docs/frontend/ejemplos.rst
+++ b/docs/frontend/ejemplos.rst
@@ -30,6 +30,29 @@ Excepciones y hilos
    catch e:
        imprimir(e)
 
+Concurrencia asíncrona segura
+-----------------------------
+
+Las utilidades de ``standard_library.asincrono`` ayudan a mezclar corrutinas de
+``asyncio`` con código bloqueante sin perder control sobre las cancelaciones.
+
+.. code-block:: python
+
+   import asyncio
+   import standard_library as stlib
+
+   async def main():
+       trabajo = asyncio.create_task(asyncio.sleep(0.05, result="ok"))
+       protegido = stlib.proteger_tarea(trabajo)
+       protegido.cancel()  # la cancelación no afecta a la tarea original
+       resultado = await trabajo
+       print("terminó:", resultado)
+
+       valor = await stlib.ejecutar_en_hilo(lambda: sum(range(10_000)))
+       print("cálculo paralelo:", valor)
+
+   asyncio.run(main())
+
 Transpilación con Hololang
 --------------------------
 Los archivos disponibles en ``examples/hololang`` muestran cómo convertir

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -168,6 +168,8 @@ from corelibs.asincrono import (
     reintentar_async,
     crear_tarea,
     mapear_concurrencia,
+    proteger_tarea,
+    ejecutar_en_hilo,
     grupo_tareas as _grupo_tareas_impl,
 )
 
@@ -348,6 +350,8 @@ __all__ = [
     "reintentar_async",
     "crear_tarea",
     "mapear_concurrencia",
+    "proteger_tarea",
+    "ejecutar_en_hilo",
     "grupo_tareas",
 ]
 

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -8,7 +8,9 @@ documentación en español para facilitar su consulta.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable, Mapping, Sequence
+import asyncio
+
+from typing import Any, Awaitable, Callable, Coroutine, Iterable, Mapping, Sequence, TypeVar
 
 from standard_library.archivo import leer, escribir, adjuntar, existe
 from standard_library.datos import (
@@ -107,7 +109,7 @@ from standard_library.numero import (
     envolver_modular,
 )
 from standard_library.util import es_nulo, es_vacio, rel, repetir
-from standard_library.asincrono import grupo_tareas
+from standard_library.asincrono import grupo_tareas, proteger_tarea, ejecutar_en_hilo
 
 __all__: list[str] = [
     "leer",
@@ -204,6 +206,8 @@ __all__: list[str] = [
     "iniciar_gui",
     "iniciar_gui_idle",
     "grupo_tareas",
+    "proteger_tarea",
+    "ejecutar_en_hilo",
 ]
 
 
@@ -237,3 +241,7 @@ limpiar_consola: Callable[..., None]
 imprimir_aviso: Callable[..., None]
 iniciar_gui: Callable[..., None]
 iniciar_gui_idle: Callable[..., None]
+
+T_co = TypeVar("T_co")
+proteger_tarea: Callable[[Awaitable[T_co] | Coroutine[Any, Any, T_co]], asyncio.Future[T_co]]
+ejecutar_en_hilo: Callable[..., Awaitable[Any]]

--- a/tests/integration/test_standard_library_async.py
+++ b/tests/integration/test_standard_library_async.py
@@ -1,0 +1,79 @@
+import asyncio
+import time
+
+import pytest
+
+import standard_library as stlib
+
+
+@pytest.mark.asyncio
+async def test_proteger_tarea_desacopla_cancelaciones():
+    finalizado = asyncio.Event()
+    cancelaciones: list[str] = []
+
+    async def trabajo():
+        try:
+            await asyncio.sleep(0.01)
+            return "listo"
+        except asyncio.CancelledError:
+            cancelaciones.append("cancelada")
+            raise
+        finally:
+            finalizado.set()
+
+    original = asyncio.create_task(trabajo())
+    protegido = stlib.proteger_tarea(original)
+
+    protegido.cancel()
+    await asyncio.sleep(0)
+
+    assert not original.cancelled()
+
+    resultado = await original
+    await finalizado.wait()
+
+    assert resultado == "listo"
+    assert not cancelaciones
+
+
+def _trabajo_bloqueante(marcas: list[str], demora: float) -> str:
+    marcas.append("inicio")
+    time.sleep(demora)
+    marcas.append("fin")
+    return "hecho"
+
+
+@pytest.mark.asyncio
+async def test_ejecutar_en_hilo_permite_proteger_resultados():
+    marcas: list[str] = []
+    tarea = asyncio.create_task(stlib.ejecutar_en_hilo(_trabajo_bloqueante, marcas, 0.02))
+    envoltura = stlib.proteger_tarea(tarea)
+
+    envoltura.cancel()
+    await asyncio.sleep(0)
+
+    assert not tarea.cancelled()
+
+    resultado = await tarea
+
+    assert resultado == "hecho"
+    assert marcas == ["inicio", "fin"]
+
+
+@pytest.mark.asyncio
+async def test_ejecutar_en_hilo_sigue_trabajando_si_se_cancela():
+    marcas: list[str] = []
+    tarea = asyncio.create_task(stlib.ejecutar_en_hilo(_trabajo_bloqueante, marcas, 0.02))
+
+    await asyncio.sleep(0)
+    tarea.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await tarea
+
+    for _ in range(20):
+        if marcas == ["inicio", "fin"]:
+            break
+        await asyncio.sleep(0.01)
+
+    assert marcas == ["inicio", "fin"]


### PR DESCRIPTION
## Resumen
- implementé en `pcobra.corelibs.asincrono` los helpers `proteger_tarea` y `ejecutar_en_hilo`, integrando `asyncio.shield` y `asyncio.to_thread` con retrocompatibilidad
- expuse ambas utilidades en la biblioteca estándar y actualicé la documentación de Cobra y la guía de frontend para explicar sus usos
- reforcé las pruebas unitarias de asincronía y añadí un conjunto de pruebas de integración que validan el comportamiento frente a cancelaciones

## Pruebas
- `pytest --no-cov tests/unit/test_corelibs_async.py tests/integration/test_standard_library_async.py`


------
https://chatgpt.com/codex/tasks/task_e_68ceb352bb2883278797c4ae2cee4d93