### PR TITLE
Agregar soporte para escritura de CSV y JSON en la biblioteca estándar

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -860,6 +860,7 @@ assert estado == "advertencia"
 El módulo `standard_library.datos` añade una capa ligera sobre `pandas` que permite trabajar con tablas desde Cobra sin exponerse a los detalles internos del `DataFrame`. Las funciones devuelven listas de diccionarios o diccionarios de listas, estructuras fáciles de manipular desde Cobra o al transpirar a Python.
 
 - `leer_csv` y `leer_json` cargan archivos en disco y devuelven registros con valores `None` cuando la fuente contiene datos perdidos.
+- `escribir_csv` y `escribir_json` guardan tablas saneadas controlando el separador, la codificación, el modo *append* y la generación de JSON Lines.
 - `leer_parquet` y `escribir_parquet` manipulan archivos en formato columnar detectando automáticamente si hay motores como `pyarrow` o `fastparquet` disponibles.
 - `leer_feather` y `escribir_feather` intercambian datos con otras herramientas que usan el formato Feather siempre que `pyarrow` esté instalado.
 - `describir` calcula estadísticas básicas (`count`, `mean`, `std`, percentiles) para cada columna.
@@ -925,6 +926,29 @@ ventas_limpias_largo = pandas.pivotar_largo(
 columnas = pandas.a_listas(resumen)
 imprimir(columnas['region'])
 ```
+
+```cobra
+# Exportar los resultados saneados a disco
+pandas.escribir_csv(
+    ventas_limpias,
+    'salida/reportes/ventas.csv',
+    separador=';',
+    aniadir=True,
+)
+pandas.escribir_json(
+    ventas_limpias,
+    'salida/reportes/ventas.json',
+    indent=2,
+)
+pandas.escribir_json(
+    ventas_limpias,
+    'salida/reportes/ventas.jsonl',
+    lineas=True,
+    aniadir=True,
+)
+```
+
+> Las funciones de escritura crean las carpetas necesarias, evitan duplicar encabezados al anexar CSV y permiten generar archivos JSON convencionales o en formato JSON Lines sin introducir valores `NaN`.
 
 > **Diferencias entre backends:** las funciones de lectura y estadística solo están disponibles cuando el objetivo de ejecución es Python, ya que dependen de `pandas`. En JavaScript puedes seguir usando `seleccionar_columnas`, `filtrar`, `a_listas` y `de_listas`, pero las operaciones avanzadas dispararán un error explicando la limitación.
 

--- a/docs/SPEC_COBRA.md
+++ b/docs/SPEC_COBRA.md
@@ -170,3 +170,16 @@ import standard_library.numero as numero
 var direccion = numero.signo(-0.0)        # -0.0 conserva el signo del cero
 var brillo = numero.limitar(1.5, 0.0, 1.0)  # 1.0: el valor queda dentro del rango
 ```
+
+El módulo `standard_library.datos` usa `pandas` para trabajar con tablas desde Cobra y expone utilidades de lectura y escritura
+que devuelven listas de diccionarios. Las funciones `leer_csv`/`leer_json` normalizan valores perdidos como `None`, mientras que
+`escribir_csv` y `escribir_json` permiten controlar el separador, la codificación, anexar información y producir archivos en JSON
+Lines sin duplicar encabezados.
+
+```cobra
+import standard_library.datos as datos
+
+var registros = datos.leer_csv('datos/ventas.csv')
+datos.escribir_csv(registros, 'salida/ventas.csv', separador=';')
+datos.escribir_json(registros, 'salida/ventas.jsonl', lineas=True, aniadir=True)
+```

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -332,6 +332,30 @@ enum Color:
 fin
 ```
 
+## 29. Entrada y salida de datos tabulares
+```cobra
+import standard_library.datos as datos
+
+var ventas = datos.leer_csv('datos/ventas.csv', separador=';')
+var ventas_limpias = datos.filtrar(ventas, lambda fila: fila['monto'] != None)
+
+datos.escribir_csv(
+    ventas_limpias,
+    'salida/ventas_filtradas.csv',
+    separador=';',
+)
+
+datos.escribir_json(
+    ventas_limpias,
+    'salida/ventas.jsonl',
+    lineas=True,
+    aniadir=True,
+)
+```
+
+Las funciones de `standard_library.datos` crean directorios intermedios cuando es necesario, limpian los valores especiales de `NaN`
+antes de serializar y permiten anexar nuevos registros sin reescribir archivos completos.
+
 ### Ejemplo: limpiar texto y detectar palíndromos
 
 ```cobra

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -28,8 +28,10 @@ from standard_library.datos import (
     leer_feather,
     leer_json,
     leer_parquet,
+    escribir_csv,
     escribir_excel,
     escribir_feather,
+    escribir_json,
     escribir_parquet,
     seleccionar_columnas,
 )
@@ -191,6 +193,8 @@ __all__: list[str] = [
     "agrupar_y_resumir",
     "a_listas",
     "de_listas",
+    "escribir_csv",
+    "escribir_json",
     "escribir_excel",
     "escribir_parquet",
     "escribir_feather",
@@ -227,6 +231,8 @@ desplegar_tabla: Callable[..., list[dict[str, Any]]]
 agrupar_y_resumir: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Sequence[str], Mapping[str, Any]], list[dict[str, Any]]]
 a_listas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, list[Any]]]
 de_listas: Callable[[Mapping[str, Sequence[Any]]], list[dict[str, Any]]]
+escribir_csv: Callable[..., None]
+escribir_json: Callable[..., None]
 escribir_excel: Callable[..., None]
 escribir_parquet: Callable[..., None]
 escribir_feather: Callable[..., None]

--- a/tests/unit/test_standard_library_datos.py
+++ b/tests/unit/test_standard_library_datos.py
@@ -13,8 +13,10 @@ from pcobra.standard_library.datos import (
     de_listas,
     describir,
     desplegar_tabla,
+    escribir_csv,
     escribir_excel,
     escribir_feather,
+    escribir_json,
     escribir_parquet,
     filtrar,
     mutar_columna,
@@ -202,6 +204,42 @@ def test_leer_csv_y_json(tmp_path: Path):
     json_path.write_text('[{"categoria": "C", "valor": 7}]', encoding="utf-8")
     datos_json = leer_json(json_path)
     assert datos_json == [{"categoria": "C", "valor": 7}]
+
+
+def test_escribir_csv(tmp_path: Path):
+    tabla = _tabla_base()
+    destino = tmp_path / "reporte" / "datos.csv"
+    escribir_csv(tabla, destino, separador=";", encoding="utf-8")
+    escribir_csv(
+        [{"categoria": "C", "valor": None}],
+        destino,
+        separador=";",
+        encoding="utf-8",
+        aniadir=True,
+    )
+    leidos = leer_csv(destino, separador=";")
+    assert leidos == [
+        {"categoria": "A", "valor": 10, "etiqueta": "foo"},
+        {"categoria": "A", "valor": 5, "etiqueta": "bar"},
+        {"categoria": "B", "valor": 3, "etiqueta": "baz"},
+        {"categoria": "C", "valor": None, "etiqueta": None},
+    ]
+
+
+def test_escribir_json(tmp_path: Path):
+    tabla = _tabla_base()
+    ruta_json = tmp_path / "datos.json"
+    escribir_json(tabla, ruta_json, indent=2)
+    assert leer_json(ruta_json) == tabla
+
+    ruta_jsonl = tmp_path / "datos.jsonl"
+    escribir_json(tabla[:2], ruta_jsonl, lineas=True)
+    escribir_json([{"categoria": "C", "valor": None}], ruta_jsonl, lineas=True, aniadir=True)
+    assert leer_json(ruta_jsonl, lineas=True) == [
+        {"categoria": "A", "valor": 10, "etiqueta": "foo"},
+        {"categoria": "A", "valor": 5, "etiqueta": "bar"},
+        {"categoria": "C", "valor": None, "etiqueta": None},
+    ]
 
 
 def test_leer_csv_error(tmp_path: Path):


### PR DESCRIPTION
## Summary
- añadir las funciones `escribir_csv` y `escribir_json` reutilizando las utilidades internas de conversión y saneamiento
- exponer las nuevas utilidades en `standard_library.__init__` y documentar sus parámetros y errores en la guía y la especificación
- ampliar la guía básica con ejemplos de E/S tabular y añadir pruebas unitarias para la escritura de CSV/JSON

## Testing
- pytest -o addopts="--cov=pcobra --cov-report=term-missing --cov-report=xml --cov-fail-under=0" tests/unit/test_standard_library_datos.py


------
https://chatgpt.com/codex/tasks/task_e_68cee2cb7a8c83278d4eefb97b3409a5