### PR TITLE
Add helpers to split and join tabular columns

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -866,6 +866,12 @@ El módulo `standard_library.datos` añade una capa ligera sobre `pandas` que pe
 - `describir` calcula estadísticas básicas (`count`, `mean`, `std`, percentiles) para cada columna.
 - `seleccionar_columnas` y `filtrar` permiten aislar subconjuntos antes de seguir procesando los datos.
 - `mutar_columna` crea o actualiza campos calculados evaluando una función por registro.
+- `separar_columna` divide un campo compuesto en varias columnas al estilo de
+  `tidyr::separate` en R o `DataFrames.jl.separatecols`, conservando o descartando
+  filas con valores faltantes según tus necesidades.
+- `unir_columnas` concatena columnas en una sola cadena con control sobre
+  delimitadores y nulos, similar a `tidyr::unite` o a las transformaciones
+  `ByRow` de DataFrames.jl.
 - `agrupar_y_resumir` aplica agregaciones (`sum`, `mean`, funciones personalizadas) agrupando por columnas clave.
 - `ordenar_tabla` admite ordenar por varias columnas controlando el sentido ascendente o descendente de cada una.
 - `combinar_tablas` replica los `join` de pandas y R para cruzar datasets con claves compartidas o diferenciadas.
@@ -892,6 +898,21 @@ ventas_con_bonus = pandas.mutar_columna(
     lambda fila: fila['monto'] * 1.05 if fila['monto'] is not None else None,
 )
 ventas_ordenadas = pandas.ordenar_tabla(ventas_limpias, por=['region', 'mes'], ascendente=[True, False])
+ventas_rotuladas = pandas.unir_columnas(
+    ventas_limpias,
+    ['region', 'mes'],
+    'region_mes',
+    separador='-',
+    eliminar_original=False,
+)
+ventas_con_etiquetas = pandas.separar_columna(
+    ventas_rotuladas,
+    'region_mes',
+    en=['region_tag', 'mes_tag'],
+    separador='-',
+    relleno='desconocido',
+    eliminar_original=False,
+)
 ventas_con_clientes = pandas.combinar_tablas(clientes, ventas_limpias, claves=('cliente_id', 'cliente'), tipo='left')
 ventas_completas = pandas.rellenar_nulos(ventas_con_clientes, {'monto': 0})
 resumen_ancho = pandas.pivotar_tabla(

--- a/docs/notebooks/separar_unir_columnas.ipynb
+++ b/docs/notebooks/separar_unir_columnas.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Separar y unir columnas\n",
+    "\n",
+    "Ejemplo rápido con la biblioteca estándar de Cobra."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pcobra.standard_library import datos\n",
+    "\n",
+    "clientes = [\n",
+    "    {\"cliente\": 1, \"nombre\": \"Ada\", \"zona\": \"Norte\", \"periodo\": \"2024-Q1\"},\n",
+    "    {\"cliente\": 2, \"nombre\": \"Grace\", \"zona\": None, \"periodo\": \"2024-Q2\"},\n",
+    "]\n",
+    "\n",
+    "clientes_unidos = datos.unir_columnas(\n",
+    "    clientes,\n",
+    "    [\"nombre\", \"zona\"],\n",
+    "    \"nombre_zona\",\n",
+    "    separador=\" - \",\n",
+    "    omitir_nulos=False,\n",
+    "    relleno=\"sin zona\",\n",
+    "    eliminar_original=False,\n",
+    ")\n",
+    "\n",
+    "clientes_separados = datos.separar_columna(\n",
+    "    clientes_unidos,\n",
+    "    \"periodo\",\n",
+    "    en=[\"anio\", \"trimestre\"],\n",
+    "    separador=\"-\",\n",
+    "    eliminar_original=False,\n",
+    ")\n",
+    "\n",
+    "clientes_separados\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/standard_library/datos.md
+++ b/docs/standard_library/datos.md
@@ -11,6 +11,14 @@ El módulo `standard_library.datos` encapsula operaciones comunes sobre datos ta
 - **`describir(datos)`**: calcula estadísticas básicas por columna y devuelve un diccionario de métricas.
 - **`seleccionar_columnas(datos, columnas)`**: extrae columnas específicas y reporta si alguna falta.
 - **`filtrar(datos, condicion)`**: aplica una función por fila y conserva solo los registros que devuelvan `True`.
+- **`separar_columna(datos, columna, *, en, separador=" ", maximo_divisiones=None, eliminar_original=True, descartar_nulos=False, relleno=None)`**:
+  divide una columna en varias partes usando `Series.str.split` manteniendo el mismo
+  comportamiento que `tidyr::separate` (R) y `DataFrames.jl.separatecols`, incluyendo
+  opciones para descartar filas con valores incompletos o reemplazarlos con un valor
+  personalizado.
+- **`unir_columnas(datos, columnas, destino, *, separador="_", omitir_nulos=True, relleno="", eliminar_original=True)`**:
+  concatena columnas en un solo campo controlando los nulos como en `tidyr::unite`
+  o en las transformaciones `ByRow` de DataFrames.jl.
 - **`agrupar_y_resumir(datos, por, agregaciones)`**: agrupa por columnas y aplica agregaciones compatibles con `DataFrame.agg`.
 - **`a_listas(datos)`**: transforma la tabla a un diccionario columna → lista.
 - **`de_listas(columnas)`**: genera una lista de diccionarios a partir de un mapeo de columnas.
@@ -40,6 +48,30 @@ ruta = Path("reportes/ventas.xlsx")
 datos.escribir_excel(tabla, ruta, hoja="Resumen", engine="openpyxl")
 
 registros = datos.leer_excel(ruta, hoja="Resumen", engine="openpyxl")
+
+clientes = [
+    {"cliente": 1, "nombre": "Ada", "zona": "Norte"},
+    {"cliente": 2, "nombre": "Grace", "zona": None},
+]
+
+clientes_con_etiqueta = datos.unir_columnas(
+    clientes,
+    ["nombre", "zona"],
+    "etiqueta",
+    separador=" - ",
+    omitir_nulos=False,
+    relleno="sin zona",
+    eliminar_original=False,
+)
+
+clientes_expandido = datos.separar_columna(
+    clientes_con_etiqueta,
+    "etiqueta",
+    en=["nombre_tag", "zona_tag"],
+    separador=" - ",
+    relleno="sin zona",
+    eliminar_original=False,
+)
 ```
 
 La variable `registros` contendrá nuevamente una lista de diccionarios con los valores saneados (`None` en lugar de `NaN`, enteros en vez de `numpy.int64`, etc.), lista para continuar el procesamiento dentro de Cobra.

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -1,9 +1,10 @@
 """Biblioteca estándar complementaria para Cobra.
 
 Este paquete expone utilidades enfocadas en manipular colecciones, texto,
-fechas y ahora datos tabulares mediante envoltorios amigables. Cada función
+fechas y datos tabulares mediante envoltorios amigables. Cada función
 re-exportada incluye anotaciones de tipo para favorecer el autocompletado y la
-documentación en español para facilitar su consulta.
+documentación en español, con notas sobre compatibilidad funcional con
+ecosistemas como R o Julia cuando aplica.
 """
 
 from __future__ import annotations
@@ -23,6 +24,8 @@ from standard_library.datos import (
     mutar_columna,
     pivotar_ancho,
     pivotar_largo,
+    separar_columna,
+    unir_columnas,
     leer_csv,
     leer_excel,
     leer_feather,
@@ -187,6 +190,8 @@ __all__: list[str] = [
     "seleccionar_columnas",
     "filtrar",
     "mutar_columna",
+    "separar_columna",
+    "unir_columnas",
     "pivotar_ancho",
     "pivotar_largo",
     "desplegar_tabla",


### PR DESCRIPTION
## Summary
- implement `separar_columna` y `unir_columnas` en la biblioteca de datos usando `pandas.Series.str.split` y concatenación controlada
- reexportar las nuevas utilidades, documentar compatibilidad con R/Julia y añadir un notebook demostrativo
- ampliar las pruebas unitarias para cubrir delimitadores personalizados y escenarios con valores faltantes

## Testing
- COVERAGE_RCFILE=/tmp/coveragerc pytest tests/unit/test_standard_library_datos.py --cov-fail-under=0

------
https://chatgpt.com/codex/tasks/task_e_68cee7a2276483279ffb6e6d69a2c538