### PR TITLE
Add rich prompt helpers to standard library interface

### DIFF
--- a/docs/frontend/cobrahub.rst
+++ b/docs/frontend/cobrahub.rst
@@ -28,3 +28,20 @@ Los módulos disponibles pueden descargarse con:
 
 El archivo se guardará en el directorio de módulos configurado. Puedes cambiar
 la URL del servicio estableciendo la variable de entorno ``COBRAHUB_URL``.
+
+Diálogo asistido desde la terminal
+---------------------------------
+
+Cuando la CLI requiere más contexto (por ejemplo, credenciales o etiquetas del
+módulo) utiliza las utilidades de ``standard_library.interfaz`` para guiar el
+proceso. En pantalla verás algo similar a lo siguiente:
+
+.. code-block:: text
+
+   ¿Nombre para publicar en CobraHub? [demo_modulo]:
+   ¿Elige la visibilidad? (privado/público) [público]: público
+   ¿Cuántas etiquetas vas a registrar? 3
+
+Los campos se validan automáticamente y se muestran las opciones disponibles en
+colores, lo que facilita publicar en CobraHub desde entornos como Codespaces o
+Replit sin necesidad de interfaces gráficas adicionales.

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -375,3 +375,27 @@ imprimir(texto.es_palindromo("Sé verlas al revés"))  # True
 Este fragmento muestra cómo combinar las utilidades de `corelibs.texto` con los atajos de `standard_library.texto` para trabajar con Unicode sin perder legibilidad.
 
 La misma tanda de utilidades incorporó `intercambiar_mayusculas` y `expandir_tabulaciones` para alternar casos y homogeneizar indentaciones mezcladas, además de `es_titulo` y `es_digito` que validan títulos con acentos y dígitos Unicode sin complicaciones.
+
+### Ejemplo: recopilar datos con la interfaz enriquecida
+
+Las nuevas utilidades de `standard_library.interfaz` permiten construir pequeños asistentes de consola sin manejar directamente las API de `rich`. El siguiente fragmento muestra una conversación típica en la terminal:
+
+```python
+from standard_library import (
+    preguntar_texto,
+    preguntar_opcion,
+    preguntar_entero,
+)
+
+nombre = preguntar_texto("¿Cómo te llamas?", por_defecto="Ada")
+lenguaje = preguntar_opcion(
+    "¿Qué lenguaje prefieres?",
+    ["Cobra", "Python", "Rust"],
+    por_defecto="Cobra",
+)
+anios = preguntar_entero("¿Cuántos años llevas programando?", minimo=0)
+
+print(f"{nombre} lleva {anios} años programando y hoy experimenta con {lenguaje}.")
+```
+
+En pantalla se muestran las opciones formateadas por `rich` y se reaprovecha el estilo de colores de Cobra. Cada pregunta valida automáticamente el tipo de entrada y guía a la persona usuaria con mensajes descriptivos.

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -5,6 +5,20 @@ fechas y datos tabulares mediante envoltorios amigables. Cada función
 re-exportada incluye anotaciones de tipo para favorecer el autocompletado y la
 documentación en español, con notas sobre compatibilidad funcional con
 ecosistemas como R o Julia cuando aplica.
+
+Ejemplos rápidos::
+
+    from standard_library import (
+        preguntar_texto,
+        preguntar_opcion,
+        preguntar_entero,
+    )
+
+    nombre = preguntar_texto("¿Cómo te llamas?", por_defecto="Ada")
+    color = preguntar_opcion("Color favorito", ["azul", "verde", "rojo"], por_defecto="azul")
+    edad = preguntar_entero("Edad", minimo=0)
+
+    print(f"{nombre} prefiere el {color} y tiene {edad} años")
 """
 
 from __future__ import annotations
@@ -51,6 +65,10 @@ from standard_library.interfaz import (
     mostrar_json,
     mostrar_panel,
     mostrar_tabla,
+    preguntar_confirmacion,
+    preguntar_entero,
+    preguntar_opcion,
+    preguntar_texto,
 )
 from standard_library.lista import (
     cabeza,
@@ -204,6 +222,10 @@ __all__: list[str] = [
     "escribir_parquet",
     "escribir_feather",
     "mostrar_tabla",
+    "preguntar_confirmacion",
+    "preguntar_texto",
+    "preguntar_opcion",
+    "preguntar_entero",
     "mostrar_columnas",
     "mostrar_panel",
     "mostrar_markdown",


### PR DESCRIPTION
## Summary
- add preguntar_texto, preguntar_opcion and preguntar_entero helpers built on rich prompts
- expose the helpers via the standard_library package and document quick usage examples
- extend the user guides with console walkthroughs and add unit tests that simulate interactive input

## Testing
- pytest -o addopts= tests/unit/test_standard_library_interfaz.py

------
https://chatgpt.com/codex/tasks/task_e_68ceece446f0832793e35ac3109866f0