### PR TITLE
Añadir decoradores en biblioteca estándar

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -1019,3 +1019,39 @@ con ui.barra_progreso(descripcion="Procesando", total=3) como (progreso, tarea):
 ![Tabla generada con `mostrar_tabla`](frontend/_static/interfaz_tabla.svg)
 
 > Consejo: si necesitas usar estas utilidades desde un entorno que no tiene `rich` instalado, captura la excepción `RuntimeError` que lanzan y muestra un mensaje alternativo.
+
+## 26. Anotaciones y decoradores
+
+Los decoradores permiten añadir comportamiento a funciones y clases. Además de los
+existentes en Python, Cobra expone atajos en español dentro de
+`standard_library.decoradores`:
+
+- `@memoizar` cachea resultados mediante `functools.lru_cache`, ideal para
+  funciones puras o costosas.
+- `@dataclase` crea clases de datos con el mismo API que
+  `dataclasses.dataclass`, manteniendo anotaciones y comparadores útiles para
+  estructurar registros.
+- `@temporizar` mide el tiempo de cada invocación con `time.perf_counter`. Si
+  [`rich`](https://rich.readthedocs.io) está instalado, envía el resultado a una
+  consola enriquecida; en caso contrario utiliza `print` estándar.
+
+```python
+from pcobra.standard_library.decoradores import dataclase, memoizar, temporizar
+
+@dataclase
+class Punto:
+    x: float
+    y: float
+
+@memoizar(maxsize=None)
+def distancia(x, y):
+    return (x ** 2 + y ** 2) ** 0.5
+
+@temporizar(etiqueta="calculo")
+def hipotenusa(punto):
+    return distancia(punto.x, punto.y)
+```
+
+> Consejo: `temporizar` admite un parámetro `consola` para reutilizar una
+> instancia de `rich.console.Console` durante pruebas o integrar el registro con
+> tu sistema de logging.

--- a/docs/standard_library/decoradores.md
+++ b/docs/standard_library/decoradores.md
@@ -1,0 +1,64 @@
+# standard_library.decoradores
+
+El módulo `standard_library.decoradores` ofrece atajos en español para patrones
+comunes al definir funciones y clases en Python. Facilita alternar entre Cobra y
+Python sin perder expresividad ni documentación.
+
+## `memoizar`
+
+Envoltorio de :func:`functools.lru_cache`. Permite memorizar el resultado de una
+función según sus argumentos.
+
+### Parámetros
+- **`maxsize`** (`int | None`, opcional): cantidad máxima de entradas a
+  conservar. Usa `None` para un caché ilimitado. Valor predeterminado: `128`.
+- **`typed`** (`bool`, opcional): cuando es `True`, considera tipos distintos
+  como claves diferentes (`1` y `1.0`).
+
+### Uso básico
+```python
+from pcobra.standard_library.decoradores import memoizar
+
+@memoizar(maxsize=None)
+def fibonacci(n):
+    if n < 2:
+        return n
+    return fibonacci(n - 1) + fibonacci(n - 2)
+```
+
+## `dataclase`
+
+Alias directo de :func:`dataclasses.dataclass` que mantiene todos los
+argumentos originales.
+
+```python
+from pcobra.standard_library.decoradores import dataclase
+
+@dataclase
+class Punto:
+    x: float
+    y: float
+```
+
+## `temporizar`
+
+Mide el tiempo de ejecución de una función usando `time.perf_counter` y reporta
+el resultado con [Rich](https://rich.readthedocs.io/en/stable/) si está
+instalado.
+
+### Parámetros
+- **`etiqueta`** (`str`, opcional): texto mostrado al reportar la duración. Por
+  defecto usa `func.__qualname__`.
+- **`precision`** (`int`, opcional): cantidad de decimales. Valor por defecto: 4.
+- **`consola`** (`rich.console.Console`, opcional): instancia personalizada para
+  imprimir. Si es `None`, se crea una temporal cuando Rich está disponible y en
+  caso contrario se usa `print`.
+
+### Ejemplo
+```python
+from pcobra.standard_library.decoradores import temporizar
+
+@temporizar(etiqueta="render")
+def renderizar():
+    ...
+```

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -133,6 +133,7 @@ from standard_library.numero import (
 )
 from standard_library.util import es_nulo, es_vacio, rel, repetir
 from standard_library.asincrono import grupo_tareas, proteger_tarea, ejecutar_en_hilo
+from standard_library.decoradores import memoizar, dataclase, temporizar
 
 __all__: list[str] = [
     "leer",
@@ -239,6 +240,9 @@ __all__: list[str] = [
     "grupo_tareas",
     "proteger_tarea",
     "ejecutar_en_hilo",
+    "memoizar",
+    "dataclase",
+    "temporizar",
 ]
 
 
@@ -278,3 +282,7 @@ iniciar_gui_idle: Callable[..., None]
 T_co = TypeVar("T_co")
 proteger_tarea: Callable[[Awaitable[T_co] | Coroutine[Any, Any, T_co]], asyncio.Future[T_co]]
 ejecutar_en_hilo: Callable[..., Awaitable[Any]]
+
+memoizar: Callable[..., Callable[..., Any]]
+temporizar: Callable[..., Callable[..., Any]]
+dataclase: Callable[..., Any]

--- a/src/pcobra/standard_library/decoradores.py
+++ b/src/pcobra/standard_library/decoradores.py
@@ -1,0 +1,150 @@
+"""Decoradores utilitarios expuestos por :mod:`standard_library`.
+
+Este módulo proporciona atajos en español para decorar funciones y clases
+utilizando patrones comunes en Python, con un enfoque en mantener la
+legibilidad al trabajar junto a Cobra.
+"""
+
+from __future__ import annotations
+
+import inspect
+import time
+from dataclasses import dataclass as _dataclass
+from functools import lru_cache as _lru_cache, wraps
+import importlib.util
+from typing import Any, Callable, Optional, ParamSpec, TypeVar, overload
+
+_rich_spec = importlib.util.find_spec("rich.console")
+if _rich_spec is not None:
+    from rich.console import Console  # type: ignore[assignment]
+else:  # pragma: no cover - ``rich`` es opcional.
+    Console = None  # type: ignore[assignment]
+
+
+P = ParamSpec("P")
+R = TypeVar("R")
+T = TypeVar("T")
+
+
+@overload
+def memoizar(funcion: Callable[P, R], /, *, maxsize: Optional[int] = ..., typed: bool = ...) -> Callable[P, R]:
+    ...
+
+
+@overload
+def memoizar(*, maxsize: Optional[int] = ..., typed: bool = ...) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    ...
+
+
+def memoizar(
+    funcion: Callable[P, R] | None = None,
+    /,
+    *,
+    maxsize: Optional[int] = 128,
+    typed: bool = False,
+) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
+    """Cachea resultados de una función basada en sus argumentos.
+
+    Es un envoltorio directo sobre :func:`functools.lru_cache` con un nombre en
+    español para facilitar su descubrimiento desde Cobra.
+    """
+
+    def decorador(objetivo: Callable[P, R]) -> Callable[P, R]:
+        return _lru_cache(maxsize=maxsize, typed=typed)(objetivo)
+
+    if funcion is not None:
+        return decorador(funcion)
+    return decorador
+
+
+@overload
+def dataclase(_cls: type[T], /, **opciones: Any) -> type[T]:
+    ...
+
+
+@overload
+def dataclase(**opciones: Any) -> Callable[[type[T]], type[T]]:
+    ...
+
+
+def dataclase(_cls: type[T] | None = None, /, **opciones: Any) -> type[T] | Callable[[type[T]], type[T]]:
+    """Alias en español para :func:`dataclasses.dataclass`.
+
+    Todos los argumentos originales están disponibles a través de ``opciones``.
+    """
+
+    def decorador(clase: type[T]) -> type[T]:
+        return _dataclass(**opciones)(clase)
+
+    if _cls is not None:
+        return decorador(_cls)
+    return decorador
+
+
+@overload
+def temporizar(funcion: Callable[P, R], /, *, etiqueta: str | None = ..., precision: int = ..., consola: Console | None = ...) -> Callable[P, R]:
+    ...
+
+
+@overload
+def temporizar(*, etiqueta: str | None = ..., precision: int = ..., consola: Console | None = ...) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    ...
+
+
+def temporizar(
+    funcion: Callable[P, R] | None = None,
+    /,
+    *,
+    etiqueta: str | None = None,
+    precision: int = 4,
+    consola: Console | None = None,
+) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
+    """Mide y reporta la duración de cada invocación de ``funcion``.
+
+    Por defecto imprime el resultado usando :class:`rich.console.Console` si está
+    disponible. Cuando ``rich`` no puede importarse, se utiliza ``print``.
+    """
+
+    console = consola
+    if console is None and Console is not None:
+        console = Console()
+
+    def decorador(objetivo: Callable[P, R]) -> Callable[P, R]:
+        nombre = etiqueta or getattr(objetivo, "__qualname__", repr(objetivo))
+
+        if inspect.iscoroutinefunction(objetivo):
+
+            @wraps(objetivo)
+            async def wrapper_async(*args: P.args, **kwargs: P.kwargs) -> R:
+                inicio = time.perf_counter()
+                resultado = await objetivo(*args, **kwargs)
+                duracion = time.perf_counter() - inicio
+                mensaje = f"[{nombre}] {duracion:.{precision}f} s"
+                if console is not None:
+                    console.print(mensaje)
+                else:
+                    print(mensaje)
+                return resultado
+
+            return wrapper_async
+
+        @wraps(objetivo)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            inicio = time.perf_counter()
+            resultado = objetivo(*args, **kwargs)
+            duracion = time.perf_counter() - inicio
+            mensaje = f"[{nombre}] {duracion:.{precision}f} s"
+            if console is not None:
+                console.print(mensaje)
+            else:
+                print(mensaje)
+            return resultado
+
+        return wrapper
+
+    if funcion is not None:
+        return decorador(funcion)
+    return decorador
+
+
+__all__ = ["memoizar", "dataclase", "temporizar"]

--- a/tests/unit/test_standard_library_decoradores.py
+++ b/tests/unit/test_standard_library_decoradores.py
@@ -1,0 +1,74 @@
+import dataclasses
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+MODULO = Path(__file__).resolve().parents[2] / "src" / "pcobra" / "standard_library" / "decoradores.py"
+ESPEC = importlib.util.spec_from_file_location("standard_library.decoradores", MODULO)
+assert ESPEC is not None and ESPEC.loader is not None
+decoradores = importlib.util.module_from_spec(ESPEC)
+sys.modules.setdefault(ESPEC.name, decoradores)
+ESPEC.loader.exec_module(decoradores)
+
+pcobra_pkg = sys.modules.setdefault("pcobra", types.ModuleType("pcobra"))
+standard_library_pkg = sys.modules.setdefault(
+    "pcobra.standard_library", types.ModuleType("pcobra.standard_library")
+)
+setattr(pcobra_pkg, "standard_library", standard_library_pkg)
+sys.modules["pcobra.standard_library.decoradores"] = decoradores
+
+memoizar = decoradores.memoizar
+dataclase = decoradores.dataclase
+temporizar = decoradores.temporizar
+
+
+def test_memoizar_cachea_resultados():
+    contador = {"llamadas": 0}
+
+    @memoizar(maxsize=None)
+    def sumar(x: int, y: int) -> int:
+        contador["llamadas"] += 1
+        return x + y
+
+    assert sumar(1, 2) == 3
+    assert sumar(1, 2) == 3
+    assert sumar(2, 3) == 5
+    assert contador["llamadas"] == 2
+
+
+def test_dataclase_crea_dataclass():
+    @dataclase(order=True)
+    class Punto:
+        x: int
+        y: int
+
+    assert dataclasses.is_dataclass(Punto)
+    assert Punto(1, 2) < Punto(2, 3)
+
+
+class ConsolaFalsa:
+    def __init__(self) -> None:
+        self.mensajes: list[str] = []
+
+    def print(self, mensaje: str) -> None:
+        self.mensajes.append(mensaje)
+
+
+def test_temporizar_reporta_duracion(monkeypatch: pytest.MonkeyPatch):
+    consola = ConsolaFalsa()
+    tiempos = iter([1.0, 3.5])
+
+    def perf_counter_falso() -> float:
+        return next(tiempos)
+
+    monkeypatch.setattr(decoradores.time, "perf_counter", perf_counter_falso)
+
+    @temporizar(etiqueta="prueba", consola=consola, precision=2)
+    def tarea() -> str:
+        return "ok"
+
+    assert tarea() == "ok"
+    assert consola.mensajes == ["[prueba] 2.50 s"]


### PR DESCRIPTION
## Summary
- crear el módulo `standard_library.decoradores` con los atajos `memoizar`, `dataclase` y `temporizar`
- exponer los nuevos decoradores en `standard_library.__init__` y documentarlos en los manuales
- añadir pruebas unitarias para comprobar la memoización y el reporte de tiempos

## Testing
- `pytest --cov-fail-under=0 --cov=pcobra.standard_library.decoradores tests/unit/test_standard_library_decoradores.py`


------
https://chatgpt.com/codex/tasks/task_e_68cef0092fcc8327a5c630c150f9b206