### PR TITLE
Agregar utilidades numéricas y documentarlas

### DIFF
--- a/docs/cheatsheet.tex
+++ b/docs/cheatsheet.tex
@@ -68,6 +68,15 @@ no / ! & Negación lógica\\
 \section*{Números}
 \begin{tabular}{ll}
 \textbf{Función} & \textbf{Descripción}\\\hline
+\texttt{absoluto(valor)} & Valor absoluto equivalente a \texttt{abs}.\\
+\texttt{redondear(valor, decimales)} & Redondeo con semántica de banca y decimales opcionales.\\
+\texttt{redondear\_arriba(valor)} & Entero inmediato superior usando \texttt{math.ceil}.\\
+\texttt{redondear\_abajo(valor)} & Entero inferior más cercano mediante \texttt{math.floor}.\\
+\texttt{potencia(base, exponente)} & Potencia compatible con enteros y flotantes.\\
+\texttt{dividir\_entero(dividendo, divisor)} & Cociente entero con la regla de piso de Python.\\
+\texttt{resto\_division(dividendo, divisor)} & Residuo que comparte el signo del divisor.\\
+\texttt{limitar(valor, minimo, maximo)} & Acota valores al intervalo cerrado provisto.\\
+\texttt{signo(valor)} & Devuelve -1, 0 o 1 según la dirección del número.\\
 \texttt{mcd(a, b, ...)} & Máximo común divisor como \texttt{math.gcd}.\\
 \texttt{mcm(a, b, ...)} & Mínimo común múltiplo equivalente a \texttt{math.lcm}.\\
 \texttt{es\_cercano(a, b, tol\_rel, tol\_abs)} & Compara con tolerancias opcionales.\\

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -414,3 +414,33 @@ print(f"{nombre} lleva {anios} años programando y hoy experimenta con {lenguaje
 ```
 
 En pantalla se muestran las opciones formateadas por `rich` y se reaprovecha el estilo de colores de Cobra. Cada pregunta valida automáticamente el tipo de entrada y guía a la persona usuaria con mensajes descriptivos.
+
+## 30. Atajos numéricos de la biblioteca estándar
+
+Las utilidades numéricas ofrecen envoltorios con nombres en español para cálculos frecuentes sin sacrificar precisión.
+
+```python
+from standard_library import (
+    absoluto,
+    redondear,
+    redondear_arriba,
+    redondear_abajo,
+    potencia,
+    dividir_entero,
+    resto_division,
+    limitar,
+    signo,
+)
+
+print(absoluto(-8))               # 8
+print(redondear(2.5))             # 2 → redondeo al par más cercano
+print(redondear_arriba(-1.2))     # -1
+print(redondear_abajo(1.8))       # 1
+print(potencia(9, 0.5))           # 3.0
+print(dividir_entero(-7, 2))      # -4
+print(resto_division(-7, 2))      # 1
+print(limitar(1.5, 0.0, 1.0))     # 1.0
+print(signo(-3))                  # -1
+```
+
+`limitar` acota un valor a un intervalo cerrado, mientras que `signo` devuelve `-1`, `0` o `1` según la dirección del número recibido. Los redondeos delegan en las implementaciones de Python para conservar la semántica de banca y permitir especificar la cantidad de decimales deseada.


### PR DESCRIPTION
## Resumen
- documentar las nuevas funciones numéricas de la biblioteca estándar en la guía básica
- añadir las mismas utilidades a la hoja de referencia para consulta rápida

## Pruebas
- `pytest --no-cov src/tests/unit/test_numeros.py`


------
https://chatgpt.com/codex/tasks/task_e_68cf805510088327b9c04c6d6ff02999