### PR TITLE
Agregar nuevas operaciones lógicas a la biblioteca estándar

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -817,7 +817,7 @@ Las funciones están disponibles tanto al ejecutar Cobra directamente como al tr
 `pcobra.corelibs.logica` reúne operadores booleanos con validaciones explícitas de tipo. Las versiones de `standard_library.logica` reutilizan la misma implementación para ofrecer una API homogénea en cualquier backend.
 
 - `es_verdadero` y `es_falso` encapsulan `bool()` y ``not`` emulando `operator.truth` y `operator.not_`, respectivamente, pero con comprobaciones de tipo estrictas.
-- `conjuncion`, `disyuncion` y `negacion` cubren las puertas clásicas.
+- `conjuncion`, `disyuncion`, `negacion`, `xor`, `implicacion`, `equivalencia` y `nand` cubren las puertas clásicas.
 - `xor`, `nand`, `nor`, `implica` y `equivale` facilitan construir tablas de verdad completas.
 - `xor_multiple` acepta un número arbitrario de argumentos y exige al menos dos valores.
 - `todas` y `alguna` validan colecciones de booleanos antes de aplicar `all`/`any`.

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -249,8 +249,15 @@ fin
 ```
 
 ## 18. Expresiones lógicas
+La biblioteca estándar ofrece puertas lógicas listas para usar. Se pueden combinar para expresar reglas complejas sin escribir expresiones manuales.
+
 ```cobra
-imprimir conjuncion(True, False)
+imprimir conjuncion(True, False)      # False
+imprimir disyuncion(False, False)     # False
+imprimir xor(True, False)             # True cuando solo uno es verdadero
+imprimir implicacion(True, False)     # False porque el antecedente se cumple pero el consecuente no
+imprimir equivalencia(True, True)     # True cuando ambos valores coinciden
+imprimir nand(True, True)             # False, negación de la conjunción
 ```
 
 ## 19. Comprensión de listas


### PR DESCRIPTION
## Resumen
- ampliar `standard_library.logica` con las operaciones xor, implicacion, equivalencia y nand documentando sus tablas de verdad
- exponer los nuevos símbolos desde `standard_library.__init__` y cubrirlos con pruebas unitarias parametrizadas
- actualizar la guía del lenguaje y el manual para reflejar y ejemplificar las nuevas puertas lógicas

## Pruebas
- PYTEST_ADDOPTS="--no-cov" pytest src/cobra-lenguaje/src/tests/unit/test_logica.py

------
https://chatgpt.com/codex/tasks/task_e_68cf8807ce208327a27ee8e567aa1c03