### PR TITLE
Documentar decorador @registro en guías

### DIFF
--- a/docs/especificacion_tecnica.md
+++ b/docs/especificacion_tecnica.md
@@ -58,6 +58,11 @@ clase Mezcla(Base1, Base2):
     fin
 ```
 
+Cuando una clase está precedida por `@registro`, Cobra genera automáticamente
+los métodos `__init__/constructor`, `__repr__/toString` y `__eq__/equals`
+utilizando los campos declarados en el cuerpo como atributos de instancia. Los
+valores asignados se convierten en parámetros opcionales en el constructor.
+
 ## Control de flujo
 
 Cobra cuenta con condicionales `si`, `sino` y bucles `para` y `mientras`.

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -187,6 +187,24 @@ el objeto funciona como iterable en los distintos backends. Si declaras dos
 métodos que colisionan tras la traducción (por ejemplo, `inicializar` y
 `__init__`), Cobra mostrará una advertencia durante el parseo.
 
+### Decorador `@registro`
+
+Para clases que solo almacenan datos puedes utilizar `@registro`. Cobra genera
+automáticamente los métodos especiales de inicialización, representación y
+comparación en cada backend de destino.
+
+```cobra
+@registro
+clase Persona:
+    var nombre = ""
+    var edad = 0
+fin
+```
+
+El constructor acepta los campos declarados (utilizando los valores asignados
+como parámetros opcionales), `toString`/`__repr__` devuelve una cadena con los
+atributos y `equals`/`__eq__` compara instancia a instancia.
+
 ## 12. Herencia múltiple
 ```cobra
 clase Volador:


### PR DESCRIPTION
## Summary
- document the new @registro decorator workflow in the basic guide
- describe the autogenerated methods in the technical specification

## Testing
- pytest src/cobra-lenguaje/src/tests/unit/test_parser_decorador.py src/cobra-lenguaje/src/tests/unit/test_to_python.py *(fails: coverage threshold 85% unmet in legacy code)*
- PYTEST_ADDOPTS="--no-cov" pytest src/cobra-lenguaje/src/tests/unit/test_parser_decorador.py src/cobra-lenguaje/src/tests/unit/test_to_python.py

------
https://chatgpt.com/codex/tasks/task_e_68cf8f1832f48327a7a078f2d78c7ff6