### PR TITLE
feat: añadir coincidencia de patrones

### DIFF
--- a/cobra.toml
+++ b/cobra.toml
@@ -22,3 +22,8 @@ modulos_prohibidos = ["os", "sys", "socket"]
 [rendimiento]
 # Tiempo máximo permitido para la transpilación de un archivo (en segundos)
 tiempo_max_transpilacion_seg = 300
+
+[analisis]
+# Validaciones opcionales para expresiones "coincidir"
+coincidir_exhaustivo = false
+patrones_inaccesibles = false

--- a/docs/gramatica.ebnf
+++ b/docs/gramatica.ebnf
@@ -44,7 +44,8 @@ llamada: IDENTIFICADOR "(" argumentos? ")"
 cuerpo: statement*
 parametros: IDENTIFICADOR ("," IDENTIFICADOR)*
 argumentos: expr ("," expr)*
-?expr: valor (operador valor)*
+?expr: coincidencia
+     | valor (operador valor)*
 ?valor: CADENA
       | ENTERO
       | FLOTANTE
@@ -65,3 +66,5 @@ FLOTANTE: /[0-9]+\.[0-9]+/
 IDENTIFICADOR: /[^\W\d][\w]*/
 
 %ignore /\s+/
+coincidencia: ("coincidir"|"match") expr ":" brazo_coincidencia+ ("sino" "=>" expr)? "fin"
+brazo_coincidencia: "cuando" patron ("si" expr)? "=>" expr

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -396,6 +396,21 @@ enum Color:
 fin
 ```
 
+La expresión `coincidir` permite desempaquetar enums y otras estructuras de
+forma declarativa. Cada brazo se inicia con `cuando` y utiliza `=>` para
+indicar el resultado.
+
+```cobra
+var descripcion = coincidir color:
+    cuando Color.ROJO => "caliente"
+    cuando Color.AZUL => "frío"
+    sino => "neutro"
+fin
+```
+
+Si se omite `sino`, Cobra puede verificar opcionalmente que todos los miembros
+de un `enum` estén cubiertos antes de la transpilación.
+
 ## 29. Entrada y salida de datos tabulares
 ```cobra
 import standard_library.datos as datos


### PR DESCRIPTION
## Resumen
- corrige la integración del parser para `coincidir` y evita que los brazos de atributo se queden sin devolver
- ajusta los transpiladores y validadores para tratar correctamente los nuevos nodos y detectar casos por defecto inaccesibles
- documenta la nueva sintaxis y expone los flags de configuración relacionados

## Pruebas
- PYTHONPATH=src/cobra-lenguaje/src PYTEST_ADDOPTS=--no-cov pytest src/cobra-lenguaje/src/tests/unit/test_parser_coincidir.py -k coincidir -q
- PYTHONPATH=src/cobra-lenguaje/src PYTEST_ADDOPTS=--no-cov pytest src/cobra-lenguaje/src/tests/unit/test_to_python.py -k coincidir -q
- PYTHONPATH=src/cobra-lenguaje/src PYTEST_ADDOPTS=--no-cov pytest src/cobra-lenguaje/src/tests/unit/test_to_rust.py -k coincidir -q
- PYTHONPATH=src/cobra-lenguaje/src PYTEST_ADDOPTS=--no-cov pytest src/cobra-lenguaje/src/tests/unit/test_to_js.py -k coincidir -q
- PYTHONPATH=src/cobra-lenguaje/src PYTEST_ADDOPTS=--no-cov pytest src/cobra-lenguaje/src/tests/unit/test_to_cpp.py -k coincidir -q
- PYTHONPATH=src/cobra-lenguaje/src PYTEST_ADDOPTS=--no-cov pytest src/cobra-lenguaje/src/tests/unit/test_semantic_coincidir.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d03440fd088327a2a56ef407ab6355