### PR TITLE
Ajusta búsquedas de texto y normaliza tabla de traducción

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -664,11 +664,13 @@ El módulo `pcobra.corelibs.texto` se amplió con herramientas inspiradas en `st
 - `quitar_prefijo`, `quitar_sufijo`, `prefijo_comun` y `sufijo_comun` replican `str.removeprefix`/`str.removesuffix` de Python, `strings.TrimPrefix`/`TrimSuffix` de Go y añaden equivalentes a `commonPrefixWith`/`commonSuffixWith` de Kotlin o `String.commonPrefix`/`String.commonSuffix` de Swift con opciones para ignorar mayúsculas y normalizar Unicode.
 - `a_snake` y `a_camel` generan identificadores normalizados como lo hacen extensiones de Kotlin, las rutinas `lowerCamelCase` de Swift o utilidades de JavaScript (por ejemplo `lodash.snakeCase`/`camelCase`), mientras que `quitar_envoltura` reproduce `removeSurrounding` de Kotlin junto con los patrones `hasPrefix`/`hasSuffix` de Swift y `String.prototype.slice` en JS.
 - `dividir_lineas` respeta combinaciones `\r\n` como `str.splitlines`, `contar_subcadena` acepta intervalos opcionales al estilo `str.count`, `centrar_texto` centra con relleno como `str.center` y `rellenar_ceros` añade ceros como `str.zfill`.
+- `encontrar` y `encontrar_derecha` replican `str.find`/`str.rfind` aceptando un ``por_defecto`` opcional, mientras que `indice` e `indice_derecha` imitan `str.index`/`str.rindex` con la posibilidad de devolver valores alternativos cuando no hay coincidencias.
 - `indentar_texto` y `desindentar_texto` replican `textwrap.indent`/`dedent` para aplicar o eliminar sangrías comunes sin perder líneas en blanco relevantes.
 - `envolver_texto` ajusta párrafos con sangrías iniciales y posteriores, y `acortar_texto` resume frases al estilo de `textwrap.shorten` añadiendo un marcador configurable.
 - `minusculas_casefold` aplica minúsculas intensivas (`casefold`) que homogeneizan mayúsculas, ß alemana o símbolos con diacríticos.
 - `intercambiar_mayusculas` alterna mayúsculas y minúsculas en toda la cadena, ideal para depurar textos que mezclan casos.
 - `expandir_tabulaciones` convierte tabuladores en espacios con un ancho configurable para unificar indentaciones mixtas.
+- `formatear` simplifica interpolaciones al estilo de `str.format`, `formatear_mapa` acepta mapeos como `str.format_map` y el dúo `tabla_traduccion`/`traducir` construye y aplica tablas compatibles con `str.maketrans`/`str.translate` en ambos backends.
 - Las comprobaciones `es_alfabetico`, `es_alfa_numerico`, `es_decimal`, `es_numerico`, `es_identificador`, `es_imprimible`, `es_ascii`, `es_mayusculas`, `es_minusculas`, `es_titulo`, `es_digito` y `es_espacio` replican directamente los métodos `str.is*` de Python.
 
 En la biblioteca estándar (`standard_library.texto`) se añadieron utilidades de mayor nivel como `quitar_acentos`, `normalizar_espacios`, `es_palindromo` y `es_anagrama`, además de accesos directos a los validadores `es_*`. Estas funciones combinan las primitivas anteriores para resolver tareas frecuentes como limpiar entrada de usuarios, validar palíndromos independientemente de acentos o comparar cadenas ignorando espacios.
@@ -697,6 +699,11 @@ imprimir(texto.sufijo_comun("astronomía", "economía"))      # 'onomía'
 imprimir(core.a_snake("MiValorHTTP"))                     # 'mi_valor_http'
 imprimir(texto.a_camel("hola-mundo cobra", inicial_mayuscula=True))  # 'HolaMundoCobra'
 imprimir(core.quitar_envoltura("«mañana»", "«", "»"))    # 'mañana'
+imprimir(core.encontrar_texto("banana", "na"))           # 2
+imprimir(core.indice_texto("banana", "zz", por_defecto=-1))  # -1
+tabla = core.tabla_traduccion_texto("áé", "ae", "í")
+imprimir(core.traducir_texto("áéí", tabla))              # 'ae'
+imprimir(core.formatear_texto("{} {}", "hola", "cobra"))  # 'hola cobra'
 ```
 
 Estas herramientas están disponibles al transpirar tanto a Python como a JavaScript y respetan los casos borde como cadenas vacías o entradas Unicode combinadas.

--- a/docs/standard_library/texto.md
+++ b/docs/standard_library/texto.md
@@ -36,4 +36,35 @@ assert es_anagrama("Roma", "amor") is True
 assert es_anagrama("cosa", "caso ", ignorar_espacios=False) is False
 ```
 
+## Búsquedas con `encontrar`/`indice`
+`encontrar` y `encontrar_derecha` replican la semántica de `str.find`/`str.rfind` devolviendo `-1` cuando no hallan la subcadena, o bien el valor indicado en `por_defecto`. Las variantes `indice` e `indice_derecha` siguen a `str.index`/`str.rindex` y permiten retornar un valor alternativo en lugar de lanzar un error. Los índices que se devuelven son base cero, en sintonía con Python y JavaScript.
+
+```python
+from standard_library.texto import encontrar, indice
+
+assert encontrar("banana", "na") == 2
+assert encontrar("banana", "zz", por_defecto=None) is None
+assert indice("banana", "zz", por_defecto=-1) == -1
+```
+
+## Formateo con `formatear` y `formatear_mapa`
+`formatear` ofrece interpolación posicional inspirada en `str.format`, mientras que `formatear_mapa` acepta diccionarios o `Mapping` para resolver marcadores con nombre, igual que `str.format_map`.
+
+```python
+from standard_library.texto import formatear, formatear_mapa
+
+assert formatear("{} {}", "hola", "cobra") == "hola cobra"
+assert formatear_mapa("Hola {nombre}", {"nombre": "Cobra"}) == "Hola Cobra"
+```
+
+## Traducciones con `tabla_traduccion` y `traducir`
+`tabla_traduccion` construye tablas compatibles con `str.maketrans`, ya sea a partir de mapeos o de cadenas de origen/destino y caracteres a eliminar. `traducir` aplica la tabla resultante emulando `str.translate` tanto en Python como en JavaScript.
+
+```python
+from standard_library.texto import tabla_traduccion, traducir
+
+tabla = tabla_traduccion("áé", "ae", "í")
+assert traducir("áéí", tabla) == "ae"
+```
+
 Todas estas funciones respetan Unicode y aprovechan los normalizadores base disponibles en Cobra y en los lenguajes de destino.

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -13,12 +13,20 @@ from corelibs.texto import (
     quitar_espacios,
     dividir,
     dividir_derecha,
+    encontrar as _texto_encontrar,
+    encontrar_derecha as _texto_encontrar_derecha,
     subcadena_antes,
     subcadena_despues,
     subcadena_antes_ultima,
     subcadena_despues_ultima,
+    indice as _texto_indice,
+    indice_derecha as _texto_indice_derecha,
     dividir_lineas,
     unir,
+    formatear as _texto_formatear,
+    formatear_mapa as _texto_formatear_mapa,
+    tabla_traduccion as _texto_tabla_traduccion,
+    traducir as _texto_traducir,
     reemplazar,
     empieza_con,
     termina_con,
@@ -57,6 +65,18 @@ from corelibs.texto import (
     rellenar_derecha,
     normalizar_unicode,
 )
+
+encontrar_texto = _texto_encontrar
+encontrar_derecha_texto = _texto_encontrar_derecha
+indice_texto = _texto_indice
+indice_derecha_texto = _texto_indice_derecha
+formatear_texto = _texto_formatear
+formatear_texto_mapa = _texto_formatear_mapa
+formatear_mapa = _texto_formatear_mapa
+tabla_traduccion_texto = _texto_tabla_traduccion
+tabla_traduccion = _texto_tabla_traduccion
+traducir_texto = _texto_traducir
+traducir = _texto_traducir
 from corelibs.logica import (
     es_verdadero,
     es_falso,
@@ -201,12 +221,28 @@ __all__ = [
     "quitar_espacios",
     "dividir",
     "dividir_derecha",
+    "encontrar",
+    "encontrar_texto",
+    "encontrar_derecha",
+    "encontrar_derecha_texto",
     "subcadena_antes",
     "subcadena_despues",
     "subcadena_antes_ultima",
     "subcadena_despues_ultima",
+    "indice",
+    "indice_texto",
+    "indice_derecha",
+    "indice_derecha_texto",
     "dividir_lineas",
     "unir",
+    "formatear",
+    "formatear_mapa",
+    "tabla_traduccion",
+    "traducir",
+    "formatear_texto",
+    "formatear_texto_mapa",
+    "tabla_traduccion_texto",
+    "traducir_texto",
     "reemplazar",
     "empieza_con",
     "termina_con",

--- a/src/pcobra/standard_library/texto.py
+++ b/src/pcobra/standard_library/texto.py
@@ -13,9 +13,21 @@ Ejemplo rápido::
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, TypeVar, overload
 
 import unicodedata
+
+from pcobra.corelibs.texto import (
+    encontrar as _encontrar_texto,
+    encontrar_derecha as _encontrar_derecha_texto,
+    indice as _indice_texto,
+    indice_derecha as _indice_derecha_texto,
+    formatear as _formatear_texto,
+    formatear_mapa as _formatear_mapa_texto,
+    tabla_traduccion as _tabla_traduccion_texto,
+    traducir as _traducir_texto,
+)
 from pcobra.corelibs import (
     centrar_texto as _centrar_texto,
     contar_subcadena as _contar_subcadena,
@@ -91,10 +103,14 @@ __all__ = [
     "sufijo_comun",
     "dividir_lineas",
     "dividir_derecha",
+    "encontrar",
+    "encontrar_derecha",
     "subcadena_antes",
     "subcadena_despues",
     "subcadena_antes_ultima",
     "subcadena_despues_ultima",
+    "indice",
+    "indice_derecha",
     "contar_subcadena",
     "centrar_texto",
     "rellenar_ceros",
@@ -107,6 +123,10 @@ __all__ = [
     "desindentar_texto",
     "envolver_texto",
     "acortar_texto",
+    "formatear",
+    "formatear_mapa",
+    "tabla_traduccion",
+    "traducir",
 ]
 
 
@@ -127,6 +147,178 @@ def normalizar_espacios(texto: str) -> str:
 
     partes = dividir(texto)
     return unir(" ", partes) if partes else ""
+
+
+@overload
+def encontrar(
+    texto: str,
+    subcadena: str,
+    inicio: int = 0,
+    fin: int | None = None,
+) -> int:
+    ...
+
+
+@overload
+def encontrar(
+    texto: str,
+    subcadena: str,
+    inicio: int = 0,
+    fin: int | None = None,
+    *,
+    por_defecto: _T,
+) -> int | _T:
+    ...
+
+
+def encontrar(
+    texto: str,
+    subcadena: str,
+    inicio: int = 0,
+    fin: int | None = None,
+    *,
+    por_defecto: Any = _SIN_VALOR,
+) -> Any:
+    """Replica ``corelibs.texto.encontrar`` manteniendo la semántica de ``str.find``."""
+
+    if por_defecto is _SIN_VALOR:
+        return _encontrar_texto(texto, subcadena, inicio, fin)
+    return _encontrar_texto(
+        texto,
+        subcadena,
+        inicio,
+        fin,
+        por_defecto=por_defecto,
+    )
+
+
+@overload
+def encontrar_derecha(
+    texto: str,
+    subcadena: str,
+    inicio: int = 0,
+    fin: int | None = None,
+) -> int:
+    ...
+
+
+@overload
+def encontrar_derecha(
+    texto: str,
+    subcadena: str,
+    inicio: int = 0,
+    fin: int | None = None,
+    *,
+    por_defecto: _T,
+) -> int | _T:
+    ...
+
+
+def encontrar_derecha(
+    texto: str,
+    subcadena: str,
+    inicio: int = 0,
+    fin: int | None = None,
+    *,
+    por_defecto: Any = _SIN_VALOR,
+) -> Any:
+    """Equivalente a ``str.rfind`` con ``por_defecto`` opcional."""
+
+    if por_defecto is _SIN_VALOR:
+        return _encontrar_derecha_texto(texto, subcadena, inicio, fin)
+    return _encontrar_derecha_texto(
+        texto,
+        subcadena,
+        inicio,
+        fin,
+        por_defecto=por_defecto,
+    )
+
+
+@overload
+def indice(
+    texto: str,
+    subcadena: str,
+    inicio: int = 0,
+    fin: int | None = None,
+) -> int:
+    ...
+
+
+@overload
+def indice(
+    texto: str,
+    subcadena: str,
+    inicio: int = 0,
+    fin: int | None = None,
+    *,
+    por_defecto: _T,
+) -> int | _T:
+    ...
+
+
+def indice(
+    texto: str,
+    subcadena: str,
+    inicio: int = 0,
+    fin: int | None = None,
+    *,
+    por_defecto: Any = _SIN_VALOR,
+) -> Any:
+    """Devuelve la primera posición como ``str.index`` o usa ``por_defecto``."""
+
+    if por_defecto is _SIN_VALOR:
+        return _indice_texto(texto, subcadena, inicio, fin)
+    return _indice_texto(
+        texto,
+        subcadena,
+        inicio,
+        fin,
+        por_defecto=por_defecto,
+    )
+
+
+@overload
+def indice_derecha(
+    texto: str,
+    subcadena: str,
+    inicio: int = 0,
+    fin: int | None = None,
+) -> int:
+    ...
+
+
+@overload
+def indice_derecha(
+    texto: str,
+    subcadena: str,
+    inicio: int = 0,
+    fin: int | None = None,
+    *,
+    por_defecto: _T,
+) -> int | _T:
+    ...
+
+
+def indice_derecha(
+    texto: str,
+    subcadena: str,
+    inicio: int = 0,
+    fin: int | None = None,
+    *,
+    por_defecto: Any = _SIN_VALOR,
+) -> Any:
+    """Emula ``str.rindex`` devolviendo ``por_defecto`` si se indica."""
+
+    if por_defecto is _SIN_VALOR:
+        return _indice_derecha_texto(texto, subcadena, inicio, fin)
+    return _indice_derecha_texto(
+        texto,
+        subcadena,
+        inicio,
+        fin,
+        por_defecto=por_defecto,
+    )
 
 
 def es_palindromo(
@@ -568,3 +760,27 @@ def particionar_derecha(texto: str, separador: str) -> tuple[str, str, str]:
     """Particiona ``texto`` tomando la última coincidencia de ``separador``."""
 
     return _particionar_derecha(texto, separador)
+
+
+def formatear(formato: str, *args: Any, **kwargs: Any) -> str:
+    """Atajo de alto nivel para ``corelibs.texto.formatear``."""
+
+    return _formatear_texto(formato, *args, **kwargs)
+
+
+def formatear_mapa(formato: str, valores: Mapping[str, Any]) -> str:
+    """Versión directa de ``str.format_map`` a través del núcleo de Cobra."""
+
+    return _formatear_mapa_texto(formato, valores)
+
+
+def tabla_traduccion(*argumentos: Any) -> dict[int, str | None]:
+    """Construye tablas compatibles con ``traducir`` y ``str.translate``."""
+
+    return _tabla_traduccion_texto(*argumentos)
+
+
+def traducir(texto: str, tabla: Mapping[int, str | None]) -> str:
+    """Aplica la tabla producida por ``tabla_traduccion`` sobre ``texto``."""
+
+    return _traducir_texto(texto, tabla)

--- a/tests/unit/test_standard_library_texto.py
+++ b/tests/unit/test_standard_library_texto.py
@@ -1,3 +1,4 @@
+import importlib.machinery as _machinery
 import sys
 from types import ModuleType
 
@@ -15,6 +16,49 @@ try:  # pragma: no cover - entorno de CI sin dependencias opcionales
     import pandas  # noqa: F401
 except ModuleNotFoundError:  # pragma: no cover - fallback para ejecutar pruebas sin pandas
     sys.modules.setdefault("pandas", ModuleType("pandas"))
+
+try:  # pragma: no cover - simplifica las pruebas cuando rich no está instalado
+    import rich  # noqa: F401
+except ModuleNotFoundError:
+    rich_mod = ModuleType("rich")
+    rich_mod.__spec__ = _machinery.ModuleSpec("rich", loader=None)
+    sys.modules.setdefault("rich", rich_mod)
+    columnas_mod = ModuleType("columns")
+    columnas_mod.__spec__ = _machinery.ModuleSpec("rich.columns", loader=None)
+    columnas_mod.Columns = type("Columns", (), {})
+    sys.modules.setdefault("rich.columns", columnas_mod)
+    console_mod = ModuleType("console")
+    console_mod.__spec__ = _machinery.ModuleSpec("rich.console", loader=None)
+    console_mod.Console = type("Console", (), {})
+    console_mod.Group = type("Group", (), {})
+    console_mod.RenderableType = object
+    sys.modules.setdefault("rich.console", console_mod)
+    tabla_mod = ModuleType("table")
+    tabla_mod.__spec__ = _machinery.ModuleSpec("rich.table", loader=None)
+    tabla_mod.Table = type("Table", (), {})
+    sys.modules.setdefault("rich.table", tabla_mod)
+    texto_mod = ModuleType("text")
+    texto_mod.__spec__ = _machinery.ModuleSpec("rich.text", loader=None)
+    texto_mod.Text = type("Text", (), {})
+    sys.modules.setdefault("rich.text", texto_mod)
+    panel_mod = ModuleType("panel")
+    panel_mod.__spec__ = _machinery.ModuleSpec("rich.panel", loader=None)
+    panel_mod.Panel = type("Panel", (), {})
+    sys.modules.setdefault("rich.panel", panel_mod)
+    progress_mod = ModuleType("progress")
+    progress_mod.__spec__ = _machinery.ModuleSpec("rich.progress", loader=None)
+    progress_mod.BarColumn = type("BarColumn", (), {})
+    progress_mod.Progress = type("Progress", (), {})
+    progress_mod.SpinnerColumn = type("SpinnerColumn", (), {})
+    progress_mod.TaskID = int
+    progress_mod.TextColumn = type("TextColumn", (), {})
+    progress_mod.TimeElapsedColumn = type("TimeElapsedColumn", (), {})
+    progress_mod.TimeRemainingColumn = type("TimeRemainingColumn", (), {})
+    sys.modules.setdefault("rich.progress", progress_mod)
+    padding_mod = ModuleType("padding")
+    padding_mod.__spec__ = _machinery.ModuleSpec("rich.padding", loader=None)
+    padding_mod.Padding = type("Padding", (), {})
+    sys.modules.setdefault("rich.padding", padding_mod)
 
 import standard_library.texto as texto
 
@@ -163,6 +207,22 @@ def test_subcadenas():
     assert texto.subcadena_despues("abc", "") == "abc"
     assert texto.subcadena_antes_ultima("abc", "") == "abc"
     assert texto.subcadena_despues_ultima("abc", "") == ""
+
+
+def test_busquedas_formato_y_traduccion():
+    assert texto.encontrar("banana", "na") == 2
+    assert texto.encontrar("banana", "zz") == -1
+    assert texto.encontrar("banana", "zz", por_defecto=None) is None
+    assert texto.encontrar_derecha("banana", "na") == 4
+    assert texto.indice("banana", "na") == 2
+    with pytest.raises(ValueError):
+        texto.indice("banana", "zz")
+    assert texto.indice_derecha("banana", "na") == 4
+    assert texto.indice_derecha("banana", "zz", por_defecto="nada") == "nada"
+    assert texto.formatear("{} {}", "hola", "cobra") == "hola cobra"
+    assert texto.formatear_mapa("Hola {nombre}", {"nombre": "Cobra"}) == "Hola Cobra"
+    tabla = texto.tabla_traduccion("áé", "ae", "í")
+    assert texto.traducir("áéí", tabla) == "ae"
 
 
 def test_dividir_y_particionar():


### PR DESCRIPTION
## Resumen
- Corrige la API de búsqueda de `corelibs.texto` y de la biblioteca estándar para que sigan los índices base cero de `str.find`/`str.index`.
- Normaliza la tabla devuelta por `tabla_traduccion` a valores de cadena y reexpone los envoltorios directos en `pcobra.corelibs`.
- Actualiza documentación y pruebas para reflejar el comportamiento real y la salida del transpilador JavaScript.

## Pruebas
- `PYTHONPATH=src pytest -o addopts='' tests/unit/test_corelibs.py::test_texto_funcs -q`
- `PYTHONPATH=src pytest -o addopts='' tests/unit/test_corelibs.py::test_transpile_texto_busquedas -q`
- `PYTHONPATH=src python - <<'PY' ... tests/unit/test_standard_library_texto.py::test_busquedas_formato_y_traduccion -q`
- `PYTHONPATH=src python - <<'PY' ... tests/unit/test_standard_library_texto.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d0a62697e88327ba36d89bea23c93f