### PR TITLE
Add correlation and percentile helpers to datos standard library

### DIFF
--- a/docs/standard_library/datos.md
+++ b/docs/standard_library/datos.md
@@ -9,6 +9,11 @@ El módulo `standard_library.datos` encapsula operaciones comunes sobre datos ta
 - **`leer_excel(ruta, *, hoja=0, encabezado=0, engine=None)`**: abre una hoja de cálculo de Excel (`.xlsx` o `.xls`) y la devuelve como lista de diccionarios. Permite escoger la hoja por nombre/posición, ajustar la fila de encabezados e indicar explícitamente el motor (por ejemplo `openpyxl`).
 - **`escribir_excel(datos, ruta, *, hoja="Hoja1", incluir_indice=False, engine=None)`**: vuelca una tabla en un libro de Excel creando las carpetas intermedias si hacen falta. Se puede elegir la hoja de destino, conservar el índice del `DataFrame` y fijar el motor de escritura (como `openpyxl` o `xlsxwriter`).
 - **`describir(datos)`**: calcula estadísticas básicas por columna y devuelve un diccionario de métricas.
+- **`correlacion_pearson(datos, columnas=None)`**: calcula la matriz de correlaciones de Pearson y la devuelve como diccionario anidado. Las columnas no numéricas pueden indicarse de forma explícita para convertirlas automáticamente.
+- **`correlacion_spearman(datos, columnas=None)`**: igual que la anterior pero empleando coeficientes de Spearman basados en rankings, útil cuando la relación es monótonamente creciente/decreciente.
+- **`matriz_covarianza(datos, columnas=None)`**: obtiene la matriz de covarianzas usando los mismos parámetros de `pandas.DataFrame.cov` y normaliza el resultado a diccionarios sencillos.
+- **`calcular_percentiles(datos, *, columnas=None, percentiles=(0.25, 0.5, 0.75), interpolacion="linear")`**: calcula percentiles y cuartiles de columnas numéricas, regresando etiquetas del estilo `p25`, `p50`, `p75`.
+- **`resumen_rapido(datos)`**: genera una lista con estadísticas clave por columna (tipo de dato, número de nulos, ejemplo de valor y, para columnas numéricas o de fecha, mínimos/máximos y media).
 - **`seleccionar_columnas(datos, columnas)`**: extrae columnas específicas y reporta si alguna falta.
 - **`filtrar(datos, condicion)`**: aplica una función por fila y conserva solo los registros que devuelvan `True`.
 - **`separar_columna(datos, columna, *, en, separador=" ", maximo_divisiones=None, eliminar_original=True, descartar_nulos=False, relleno=None)`**:
@@ -72,9 +77,20 @@ clientes_expandido = datos.separar_columna(
     relleno="sin zona",
     eliminar_original=False,
 )
+
+ventas = [
+    {"ventas": 10, "costos": 15, "unidades": 3},
+    {"ventas": 20, "costos": 30, "unidades": 6},
+    {"ventas": 40, "costos": 60, "unidades": 12},
+]
+metricas = datos.resumen_rapido(ventas)
+correlaciones = datos.correlacion_pearson(ventas)
+cuartiles = datos.calcular_percentiles(ventas, columnas=["ventas", "costos"], percentiles=(0.25, 0.5, 0.75))
 ```
 
 La variable `registros` contendrá nuevamente una lista de diccionarios con los valores saneados (`None` en lugar de `NaN`, enteros en vez de `numpy.int64`, etc.), lista para continuar el procesamiento dentro de Cobra.
+
+Las funciones de correlación y covarianza no requieren dependencias adicionales más allá de `pandas` y `numpy`; Spearman se apoya en las implementaciones internas de `pandas`, por lo que no es necesario instalar `scipy`. Para calcular percentiles con conjuntos de datos grandes se recomiendan tipos numéricos compatibles con `numpy` para evitar conversiones innecesarias.
 
 ## Backend JavaScript
 

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -31,13 +31,18 @@ from standard_library.archivo import leer, escribir, adjuntar, existe
 from standard_library.datos import (
     agrupar_y_resumir,
     a_listas,
+    calcular_percentiles,
+    correlacion_pearson,
+    correlacion_spearman,
     de_listas,
     describir,
     filtrar,
     desplegar_tabla,
+    matriz_covarianza,
     mutar_columna,
     pivotar_ancho,
     pivotar_largo,
+    resumen_rapido,
     separar_columna,
     unir_columnas,
     leer_csv,
@@ -206,6 +211,11 @@ __all__: list[str] = [
     "leer_parquet",
     "leer_feather",
     "describir",
+    "correlacion_pearson",
+    "correlacion_spearman",
+    "matriz_covarianza",
+    "calcular_percentiles",
+    "resumen_rapido",
     "seleccionar_columnas",
     "filtrar",
     "mutar_columna",
@@ -253,6 +263,11 @@ leer_excel: Callable[..., list[dict[str, Any]]]
 leer_parquet: Callable[..., list[dict[str, Any]]]
 leer_feather: Callable[..., list[dict[str, Any]]]
 describir: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, Any]]
+correlacion_pearson: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, dict[str, Any]]]
+correlacion_spearman: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, dict[str, Any]]]
+matriz_covarianza: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, dict[str, Any]]]
+calcular_percentiles: Callable[..., dict[str, dict[str, Any]]]
+resumen_rapido: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], list[dict[str, Any]]]
 seleccionar_columnas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Sequence[str]], list[dict[str, Any]]]
 filtrar: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Callable[[dict[str, Any]], bool]], list[dict[str, Any]]]
 mutar_columna: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], str, Callable[[dict[str, Any]], Any]], list[dict[str, Any]]]


### PR DESCRIPTION
## Summary
- añadir utilidades para correlaciones de Pearson/Spearman, covarianzas, percentiles y resúmenes rápidos en el módulo `datos`
- reexportar las nuevas funciones en `standard_library.__init__`
- documentar las funciones recién agregadas y ampliar las pruebas unitarias con fixtures controladas

## Testing
- `pytest tests/unit/test_standard_library_datos.py` *(falla la comprobación de cobertura global exigida por el proyecto; los tests del módulo pasan)*

------
https://chatgpt.com/codex/tasks/task_e_68d110cc6cbc832792f29e79b8f57314