### PR TITLE
Add decorator utilities for retries and synchronization

### DIFF
--- a/docs/standard_library/decoradores.md
+++ b/docs/standard_library/decoradores.md
@@ -62,3 +62,92 @@ from pcobra.standard_library.decoradores import temporizar
 def renderizar():
     ...
 ```
+
+## `depreciado`
+
+Emite una advertencia de `DeprecationWarning` cada vez que se ejecuta la
+función decorada. Es útil para guiar a quienes consumen el código hacia nuevas
+alternativas sin romper la compatibilidad inmediata.
+
+Cuando [Rich](https://rich.readthedocs.io/) está disponible se aprovecha para
+enviar un aviso con formato en la consola. También puedes pasar tu propia
+instancia de `Console` mediante el parámetro `consola`.
+
+```python
+from pcobra.standard_library.decoradores import depreciado
+
+@depreciado(mensaje="Usa `procesar_datos_v2`")
+def procesar_datos():
+    ...
+```
+
+## `sincronizar`
+
+Garantiza que una función se ejecute con exclusión mutua utilizando
+`threading.Lock`. Resulta práctico para proteger secciones críticas cuando el
+estado compartido se manipula desde múltiples hilos.
+
+Puedes suministrar un candado propio (por ejemplo, un `threading.RLock`) con el
+parámetro `candado` para coordinar varias funciones que deban compartir el mismo
+lock.
+
+```python
+from threading import Lock
+from pcobra.standard_library.decoradores import sincronizar
+
+candado = Lock()
+
+@sincronizar(candado=candado)
+def actualizar_cache():
+    ...
+```
+
+## `reintentar`
+
+Reintenta la ejecución de una función sincrónica cuando se producen excepciones
+controladas. Aplica un *backoff* exponencial configurable, con soporte de
+`jitter` para repartir la carga en sistemas distribuidos.
+
+Parámetros principales:
+
+- **`intentos`** (`int`): número máximo de intentos. Debe ser mayor o igual a 1.
+- **`excepciones`** (`type[BaseException] | Sequence[type[BaseException]]`):
+  tipos que activan un nuevo intento.
+- **`retardo_inicial`** (`float`): espera antes del primer reintento.
+- **`factor_backoff`** (`float`): factor multiplicador entre esperas.
+- **`max_retardo`** (`float | None`): límite superior opcional a la espera.
+- **`jitter`** (`Callable[[float], float] | tuple[float, float] | float | bool | None`):
+  controla la aleatoriedad aplicada a la espera.
+- **`consola`** (`rich.console.Console | None`): instancia opcional para emitir
+  mensajes estilizados cuando Rich está instalado.
+
+```python
+from pcobra.standard_library.decoradores import reintentar
+
+@reintentar(intentos=5, excepciones=(TimeoutError,), retardo_inicial=0.2)
+def consultar_servicio():
+    ...
+```
+
+> **Nota:** la compatibilidad con Rich es opcional. Si no está instalado, los
+> mensajes se envían mediante `print`.
+
+## `reintentar_async`
+
+Versión asíncrona de `reintentar` que delega en
+`pcobra.corelibs.reintentar_async`. Mantiene la misma firma y comportamiento
+general, aplicando la lógica de reintentos sobre corrutinas.
+
+```python
+from pcobra.standard_library.decoradores import reintentar_async
+
+@reintentar_async(intentos=4, excepciones=(OSError,))
+async def descargar_archivo():
+    ...
+```
+
+> **Dependencias opcionales:**
+>
+> - [Rich](https://rich.readthedocs.io/) para mensajes con estilo.
+> - `pcobra.corelibs` ya provee `reintentar_async`, por lo que no es necesario
+>   instalar nada adicional para los reintentos asíncronos más allá de Cobra.

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -138,7 +138,15 @@ from standard_library.numero import (
 )
 from standard_library.util import es_nulo, es_vacio, rel, repetir
 from standard_library.asincrono import grupo_tareas, proteger_tarea, ejecutar_en_hilo
-from standard_library.decoradores import memoizar, dataclase, temporizar
+from standard_library.decoradores import (
+    dataclase,
+    depreciado,
+    memoizar,
+    reintentar,
+    reintentar_async,
+    sincronizar,
+    temporizar,
+)
 
 __all__: list[str] = [
     "leer",
@@ -253,6 +261,10 @@ __all__: list[str] = [
     "memoizar",
     "dataclase",
     "temporizar",
+    "depreciado",
+    "sincronizar",
+    "reintentar",
+    "reintentar_async",
 ]
 
 
@@ -301,3 +313,7 @@ ejecutar_en_hilo: Callable[..., Awaitable[Any]]
 memoizar: Callable[..., Callable[..., Any]]
 temporizar: Callable[..., Callable[..., Any]]
 dataclase: Callable[..., Any]
+depreciado: Callable[..., Callable[..., Any]]
+sincronizar: Callable[..., Callable[..., Any]]
+reintentar: Callable[..., Callable[..., Any]]
+reintentar_async: Callable[..., Callable[..., Any]]

--- a/src/pcobra/standard_library/decoradores.py
+++ b/src/pcobra/standard_library/decoradores.py
@@ -8,11 +8,16 @@ legibilidad al trabajar junto a Cobra.
 from __future__ import annotations
 
 import inspect
+import random
+import threading
 import time
+import warnings
 from dataclasses import dataclass as _dataclass
 from functools import lru_cache as _lru_cache, wraps
 import importlib.util
-from typing import Any, Callable, Optional, ParamSpec, TypeVar, overload
+from typing import Any, Awaitable, Callable, Optional, ParamSpec, Sequence, TypeVar, overload
+
+from pcobra.corelibs import reintentar_async as _reintentar_async
 
 _rich_spec = importlib.util.find_spec("rich.console")
 if _rich_spec is not None:
@@ -24,6 +29,88 @@ else:  # pragma: no cover - ``rich`` es opcional.
 P = ParamSpec("P")
 R = TypeVar("R")
 T = TypeVar("T")
+
+
+def _validar_parametros_reintento(
+    *,
+    intentos: int,
+    retardo_inicial: float,
+    factor_backoff: float,
+    max_retardo: float | None,
+) -> None:
+    if intentos < 1:
+        raise ValueError("intentos debe ser un entero positivo")
+    if retardo_inicial < 0:
+        raise ValueError("retardo_inicial no puede ser negativo")
+    if factor_backoff <= 0:
+        raise ValueError("factor_backoff debe ser mayor que cero")
+    if max_retardo is not None and max_retardo < 0:
+        raise ValueError("max_retardo no puede ser negativo")
+
+
+def _normalizar_excepciones(
+    excepciones: type[BaseException] | Sequence[type[BaseException]],
+) -> tuple[type[BaseException], ...]:
+    if isinstance(excepciones, type):
+        tipos = (excepciones,)
+    else:
+        tipos = tuple(excepciones)
+
+    if not tipos:
+        raise ValueError("excepciones no puede estar vacío")
+
+    for tipo in tipos:
+        if not isinstance(tipo, type) or not issubclass(tipo, BaseException):
+            raise TypeError("Cada entrada de excepciones debe ser una excepción")
+
+    return tipos
+
+
+def _crear_calculadora_espera(
+    *,
+    retardo_inicial: float,
+    factor_backoff: float,
+    max_retardo: float | None,
+    jitter: Callable[[float], float]
+    | tuple[float, float]
+    | float
+    | bool
+    | None,
+) -> Callable[[int], float]:
+    def _aplicar_jitter(valor: float) -> float:
+        if jitter is None:
+            return valor
+        if callable(jitter):
+            ajustado = jitter(valor)
+        elif isinstance(jitter, bool):
+            if not jitter:
+                return valor
+            ajustado = random.uniform(0.0, valor)
+        elif isinstance(jitter, tuple):
+            if len(jitter) != 2:
+                raise ValueError("jitter como tupla debe tener dos elementos")
+            minimo, maximo = float(jitter[0]), float(jitter[1])
+            if minimo > maximo:
+                minimo, maximo = maximo, minimo
+            ajustado = random.uniform(minimo, maximo)
+        else:
+            amplitud = float(jitter)
+            minimo = valor - amplitud
+            maximo = valor + amplitud
+            if minimo > maximo:
+                minimo, maximo = maximo, minimo
+            ajustado = random.uniform(minimo, maximo)
+        return max(0.0, float(ajustado))
+
+    def _calcular(intento: int) -> float:
+        espera = retardo_inicial * (factor_backoff ** (intento - 1))
+        if max_retardo is not None:
+            espera = min(espera, max_retardo)
+        if espera <= 0:
+            return 0.0
+        return _aplicar_jitter(espera)
+
+    return _calcular
 
 
 @overload
@@ -51,6 +138,328 @@ def memoizar(
 
     def decorador(objetivo: Callable[P, R]) -> Callable[P, R]:
         return _lru_cache(maxsize=maxsize, typed=typed)(objetivo)
+
+    if funcion is not None:
+        return decorador(funcion)
+    return decorador
+
+
+@overload
+def depreciado(
+    funcion: Callable[P, R],
+    /,
+    *,
+    mensaje: str | None = ...,
+    categoria: type[Warning] = ...,
+    consola: Console | None = ...,
+    estilizar: bool = ...,
+) -> Callable[P, R]:
+    ...
+
+
+@overload
+def depreciado(
+    *,
+    mensaje: str | None = ...,
+    categoria: type[Warning] = ...,
+    consola: Console | None = ...,
+    estilizar: bool = ...,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    ...
+
+
+def depreciado(
+    funcion: Callable[P, R] | None = None,
+    /,
+    *,
+    mensaje: str | None = None,
+    categoria: type[Warning] = DeprecationWarning,
+    consola: Console | None = None,
+    estilizar: bool = True,
+) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
+    """Marca ``funcion`` como obsoleta emitiendo una advertencia al usarla."""
+
+    def decorador(objetivo: Callable[P, R]) -> Callable[P, R]:
+        nombre = getattr(objetivo, "__qualname__", repr(objetivo))
+        texto = mensaje or f"{nombre} está en desuso y puede eliminarse en futuras versiones."
+        console = consola
+        if console is None and estilizar and Console is not None:
+            console = Console()
+
+        if inspect.iscoroutinefunction(objetivo):
+
+            @wraps(objetivo)
+            async def wrapper_async(*args: P.args, **kwargs: P.kwargs) -> R:
+                warnings.warn(texto, category=categoria, stacklevel=2)
+                if estilizar and console is not None:
+                    console.print(texto, style="bold yellow")
+                return await objetivo(*args, **kwargs)
+
+            return wrapper_async
+
+        @wraps(objetivo)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            warnings.warn(texto, category=categoria, stacklevel=2)
+            if estilizar and console is not None:
+                console.print(texto, style="bold yellow")
+            return objetivo(*args, **kwargs)
+
+        return wrapper
+
+    if funcion is not None:
+        return decorador(funcion)
+    return decorador
+
+
+@overload
+def sincronizar(
+    funcion: Callable[P, R],
+    /,
+    *,
+    candado: threading.Lock | threading.RLock | None = ...,
+) -> Callable[P, R]:
+    ...
+
+
+@overload
+def sincronizar(
+    *,
+    candado: threading.Lock | threading.RLock | None = ...,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    ...
+
+
+def sincronizar(
+    funcion: Callable[P, R] | None = None,
+    /,
+    *,
+    candado: threading.Lock | threading.RLock | None = None,
+) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
+    """Protege ``funcion`` con un ``threading.Lock`` para evitar concurrencia."""
+
+    def decorador(objetivo: Callable[P, R]) -> Callable[P, R]:
+        if inspect.iscoroutinefunction(objetivo):
+            raise TypeError(
+                "sincronizar solo admite funciones síncronas; para corrutinas usa asyncio.Lock"
+            )
+
+        bloqueo = candado or threading.Lock()
+
+        @wraps(objetivo)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            with bloqueo:
+                return objetivo(*args, **kwargs)
+
+        return wrapper
+
+    if funcion is not None:
+        return decorador(funcion)
+    return decorador
+
+
+@overload
+def reintentar(
+    funcion: Callable[P, R],
+    /,
+    *,
+    intentos: int = ...,
+    excepciones: type[BaseException] | Sequence[type[BaseException]] = ...,
+    retardo_inicial: float = ...,
+    factor_backoff: float = ...,
+    max_retardo: float | None = ...,
+    jitter: Callable[[float], float] | tuple[float, float] | float | bool | None = ...,
+    etiqueta: str | None = ...,
+    consola: Console | None = ...,
+    estilizar: bool = ...,
+) -> Callable[P, R]:
+    ...
+
+
+@overload
+def reintentar(
+    *,
+    intentos: int = ...,
+    excepciones: type[BaseException] | Sequence[type[BaseException]] = ...,
+    retardo_inicial: float = ...,
+    factor_backoff: float = ...,
+    max_retardo: float | None = ...,
+    jitter: Callable[[float], float] | tuple[float, float] | float | bool | None = ...,
+    etiqueta: str | None = ...,
+    consola: Console | None = ...,
+    estilizar: bool = ...,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    ...
+
+
+def reintentar(
+    funcion: Callable[P, R] | None = None,
+    /,
+    *,
+    intentos: int = 3,
+    excepciones: type[BaseException] | Sequence[type[BaseException]] = (Exception,),
+    retardo_inicial: float = 0.1,
+    factor_backoff: float = 2.0,
+    max_retardo: float | None = None,
+    jitter: Callable[[float], float] | tuple[float, float] | float | bool | None = None,
+    etiqueta: str | None = None,
+    consola: Console | None = None,
+    estilizar: bool = True,
+) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
+    """Reintenta ``funcion`` al fallar con *backoff* exponencial configurable."""
+
+    _validar_parametros_reintento(
+        intentos=intentos,
+        retardo_inicial=retardo_inicial,
+        factor_backoff=factor_backoff,
+        max_retardo=max_retardo,
+    )
+    tipos_controlados = _normalizar_excepciones(excepciones)
+    calcular_espera = _crear_calculadora_espera(
+        retardo_inicial=retardo_inicial,
+        factor_backoff=factor_backoff,
+        max_retardo=max_retardo,
+        jitter=jitter,
+    )
+
+    def decorador(objetivo: Callable[P, R]) -> Callable[P, R]:
+        if inspect.iscoroutinefunction(objetivo):
+            raise TypeError(
+                "reintentar solo admite funciones síncronas; usa reintentar_async para corrutinas"
+            )
+
+        nombre = etiqueta or getattr(objetivo, "__qualname__", repr(objetivo))
+        console = consola
+        if console is None and estilizar and Console is not None:
+            console = Console()
+
+        def _emitir(intento_siguiente: int) -> None:
+            mensaje = f"[reintentar:{nombre}] reintento {intento_siguiente}/{intentos}"
+            if estilizar:
+                if console is not None:
+                    console.print(mensaje, style="bold yellow")
+                else:
+                    print(mensaje)
+
+        @wraps(objetivo)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            ultimo_error: BaseException | None = None
+            for numero_intento in range(1, intentos + 1):
+                try:
+                    return objetivo(*args, **kwargs)
+                except tipos_controlados as exc:
+                    ultimo_error = exc
+                if numero_intento == intentos:
+                    assert ultimo_error is not None
+                    raise ultimo_error
+                espera = calcular_espera(numero_intento)
+                _emitir(numero_intento + 1)
+                if espera > 0:
+                    time.sleep(espera)
+            assert ultimo_error is not None  # pragma: no cover - sanidad
+            raise ultimo_error
+
+        return wrapper
+
+    if funcion is not None:
+        return decorador(funcion)
+    return decorador
+
+
+@overload
+def reintentar_async(
+    funcion: Callable[P, Awaitable[R]],
+    /,
+    *,
+    intentos: int = ...,
+    excepciones: type[BaseException] | Sequence[type[BaseException]] = ...,
+    retardo_inicial: float = ...,
+    factor_backoff: float = ...,
+    max_retardo: float | None = ...,
+    jitter: Callable[[float], float] | tuple[float, float] | float | bool | None = ...,
+    etiqueta: str | None = ...,
+    consola: Console | None = ...,
+    estilizar: bool = ...,
+) -> Callable[P, Awaitable[R]]:
+    ...
+
+
+@overload
+def reintentar_async(
+    *,
+    intentos: int = ...,
+    excepciones: type[BaseException] | Sequence[type[BaseException]] = ...,
+    retardo_inicial: float = ...,
+    factor_backoff: float = ...,
+    max_retardo: float | None = ...,
+    jitter: Callable[[float], float] | tuple[float, float] | float | bool | None = ...,
+    etiqueta: str | None = ...,
+    consola: Console | None = ...,
+    estilizar: bool = ...,
+) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
+    ...
+
+
+def reintentar_async(
+    funcion: Callable[P, Awaitable[R]] | None = None,
+    /,
+    *,
+    intentos: int = 3,
+    excepciones: type[BaseException] | Sequence[type[BaseException]] = (Exception,),
+    retardo_inicial: float = 0.1,
+    factor_backoff: float = 2.0,
+    max_retardo: float | None = None,
+    jitter: Callable[[float], float] | tuple[float, float] | float | bool | None = None,
+    etiqueta: str | None = None,
+    consola: Console | None = None,
+    estilizar: bool = True,
+) -> Callable[P, Awaitable[R]] | Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
+    """Equivalente asíncrono de :func:`reintentar` basado en ``corelibs``."""
+
+    _validar_parametros_reintento(
+        intentos=intentos,
+        retardo_inicial=retardo_inicial,
+        factor_backoff=factor_backoff,
+        max_retardo=max_retardo,
+    )
+    tipos_controlados = _normalizar_excepciones(excepciones)
+
+    def decorador(objetivo: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+        if not inspect.iscoroutinefunction(objetivo):
+            raise TypeError(
+                "reintentar_async requiere una corrutina; usa reintentar para funciones síncronas"
+            )
+
+        nombre = etiqueta or getattr(objetivo, "__qualname__", repr(objetivo))
+        console = consola
+        if console is None and estilizar and Console is not None:
+            console = Console()
+
+        @wraps(objetivo)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            contador = 0
+
+            async def _invocar() -> R:
+                nonlocal contador
+                contador += 1
+                if estilizar and contador > 1:
+                    mensaje = f"[reintentar:{nombre}] reintento {contador}/{intentos}"
+                    if console is not None:
+                        console.print(mensaje, style="bold yellow")
+                    else:
+                        print(mensaje)
+                return await objetivo(*args, **kwargs)
+
+            return await _reintentar_async(
+                _invocar,
+                intentos=intentos,
+                excepciones=tipos_controlados,
+                retardo_inicial=retardo_inicial,
+                factor_backoff=factor_backoff,
+                max_retardo=max_retardo,
+                jitter=jitter,
+            )
+
+        return wrapper
 
     if funcion is not None:
         return decorador(funcion)
@@ -147,4 +556,12 @@ def temporizar(
     return decorador
 
 
-__all__ = ["memoizar", "dataclase", "temporizar"]
+__all__ = [
+    "memoizar",
+    "dataclase",
+    "temporizar",
+    "depreciado",
+    "sincronizar",
+    "reintentar",
+    "reintentar_async",
+]

--- a/tests/unit/test_standard_library_decoradores.py
+++ b/tests/unit/test_standard_library_decoradores.py
@@ -1,28 +1,60 @@
 import dataclasses
+import importlib.machinery
 import importlib.util
 from pathlib import Path
 import sys
+import threading
+import time
 import types
+from typing import Any, Awaitable, Callable
 
 import pytest
 
 MODULO = Path(__file__).resolve().parents[2] / "src" / "pcobra" / "standard_library" / "decoradores.py"
 ESPEC = importlib.util.spec_from_file_location("standard_library.decoradores", MODULO)
 assert ESPEC is not None and ESPEC.loader is not None
-decoradores = importlib.util.module_from_spec(ESPEC)
-sys.modules.setdefault(ESPEC.name, decoradores)
-ESPEC.loader.exec_module(decoradores)
 
 pcobra_pkg = sys.modules.setdefault("pcobra", types.ModuleType("pcobra"))
+corelibs_pkg = sys.modules.setdefault("pcobra.corelibs", types.ModuleType("pcobra.corelibs"))
 standard_library_pkg = sys.modules.setdefault(
     "pcobra.standard_library", types.ModuleType("pcobra.standard_library")
 )
+
+rich_pkg = sys.modules.setdefault("rich", types.ModuleType("rich"))
+rich_console_pkg = sys.modules.setdefault("rich.console", types.ModuleType("rich.console"))
+
+
+class _ConsoleStub:
+    def print(self, *_: Any, **__: Any) -> None:
+        pass
+
+
+setattr(rich_console_pkg, "Console", _ConsoleStub)
+setattr(rich_pkg, "console", rich_console_pkg)
+rich_pkg.__spec__ = importlib.machinery.ModuleSpec("rich", loader=None)
+rich_console_pkg.__spec__ = importlib.machinery.ModuleSpec("rich.console", loader=None)
+
+
+async def _corelibs_stub(*args: Any, **kwargs: Any) -> Any:
+    raise RuntimeError("reintentar_async no configurado en stub")
+
+
+setattr(corelibs_pkg, "reintentar_async", _corelibs_stub)
+setattr(pcobra_pkg, "corelibs", corelibs_pkg)
 setattr(pcobra_pkg, "standard_library", standard_library_pkg)
+
+decoradores = importlib.util.module_from_spec(ESPEC)
+sys.modules.setdefault(ESPEC.name, decoradores)
+ESPEC.loader.exec_module(decoradores)
 sys.modules["pcobra.standard_library.decoradores"] = decoradores
 
 memoizar = decoradores.memoizar
 dataclase = decoradores.dataclase
 temporizar = decoradores.temporizar
+depreciado = decoradores.depreciado
+sincronizar = decoradores.sincronizar
+reintentar = decoradores.reintentar
+reintentar_async = decoradores.reintentar_async
 
 
 def test_memoizar_cachea_resultados():
@@ -52,9 +84,11 @@ def test_dataclase_crea_dataclass():
 class ConsolaFalsa:
     def __init__(self) -> None:
         self.mensajes: list[str] = []
+        self.estilos: list[str | None] = []
 
-    def print(self, mensaje: str) -> None:
+    def print(self, mensaje: str, *, style: str | None = None) -> None:
         self.mensajes.append(mensaje)
+        self.estilos.append(style)
 
 
 def test_temporizar_reporta_duracion(monkeypatch: pytest.MonkeyPatch):
@@ -72,3 +106,123 @@ def test_temporizar_reporta_duracion(monkeypatch: pytest.MonkeyPatch):
 
     assert tarea() == "ok"
     assert consola.mensajes == ["[prueba] 2.50 s"]
+    assert consola.estilos == [None]
+
+
+def test_depreciado_emite_advertencia(monkeypatch: pytest.MonkeyPatch):
+    consola = ConsolaFalsa()
+
+    @depreciado(mensaje="Usa `nuevo`", consola=consola)
+    def funcion_obsoleta() -> str:
+        return "hecho"
+
+    with pytest.warns(DeprecationWarning) as advertencias:
+        assert funcion_obsoleta() == "hecho"
+
+    assert advertencias[0].message.args[0] == "Usa `nuevo`"
+    assert consola.mensajes == ["Usa `nuevo`"]
+    assert consola.estilos == ["bold yellow"]
+
+
+def test_sincronizar_evita_concurrencia():
+    errores: list[str] = []
+    en_ejecucion = threading.Event()
+
+    @sincronizar()
+    def seccion_critica() -> None:
+        if en_ejecucion.is_set():
+            errores.append("concurrencia")
+        en_ejecucion.set()
+        time.sleep(0.01)
+        en_ejecucion.clear()
+
+    hilos = [threading.Thread(target=seccion_critica) for _ in range(2)]
+    for hilo in hilos:
+        hilo.start()
+    for hilo in hilos:
+        hilo.join()
+
+    assert errores == []
+
+
+def test_reintentar_aplica_reintentos(monkeypatch: pytest.MonkeyPatch):
+    consola = ConsolaFalsa()
+    esperas: list[float] = []
+
+    def sleep_falso(segundos: float) -> None:
+        esperas.append(segundos)
+
+    monkeypatch.setattr(decoradores.time, "sleep", sleep_falso)
+
+    contador = {"llamadas": 0}
+
+    @reintentar(
+        intentos=3,
+        excepciones=(ValueError,),
+        retardo_inicial=0.5,
+        factor_backoff=2,
+        consola=consola,
+    )
+    def fragil() -> str:
+        contador["llamadas"] += 1
+        if contador["llamadas"] < 3:
+            raise ValueError("fallo")
+        return "ok"
+
+    assert fragil() == "ok"
+    assert contador["llamadas"] == 3
+    assert esperas == [0.5, 1.0]
+    assert len(consola.mensajes) == 2
+    assert consola.mensajes[0].endswith("reintento 2/3")
+    assert consola.mensajes[1].endswith("reintento 3/3")
+    assert consola.mensajes[0].startswith("[reintentar:")
+    assert consola.estilos == ["bold yellow", "bold yellow"]
+
+
+@pytest.mark.asyncio
+async def test_reintentar_async_envuelve_corelibs(monkeypatch: pytest.MonkeyPatch):
+    consola = ConsolaFalsa()
+    llamadas = {"contador": 0}
+
+    async def reintentar_falso(
+        funcion: Callable[[], Awaitable[str]],
+        *,
+        intentos: int,
+        excepciones: tuple[type[BaseException], ...],
+        retardo_inicial: float,
+        factor_backoff: float,
+        max_retardo: float | None,
+        jitter: Any,
+    ) -> str:
+        assert intentos == 3
+        assert excepciones == (RuntimeError,)
+        assert retardo_inicial == 0.1
+        assert factor_backoff == 2.0
+        assert max_retardo is None
+        assert jitter is None
+        ultimo_error: BaseException | None = None
+        for numero in range(1, intentos + 1):
+            try:
+                return await funcion()
+            except excepciones as exc:  # type: ignore[misc]
+                ultimo_error = exc
+                if numero == intentos:
+                    raise
+        assert ultimo_error is not None
+        raise ultimo_error
+
+    monkeypatch.setattr(decoradores, "_reintentar_async", reintentar_falso)
+
+    @reintentar_async(intentos=3, excepciones=(RuntimeError,), consola=consola, etiqueta="tarea")
+    async def fragil() -> str:
+        llamadas["contador"] += 1
+        if llamadas["contador"] < 2:
+            raise RuntimeError("fallo")
+        return "listo"
+
+    assert await fragil() == "listo"
+    assert llamadas["contador"] == 2
+    assert len(consola.mensajes) == 1
+    assert consola.mensajes[0].endswith("reintento 2/3")
+    assert consola.mensajes[0].startswith("[reintentar:")
+    assert consola.estilos == ["bold yellow"]


### PR DESCRIPTION
## Summary
- implement new standard library decorators for deprecation notices, locking and retry logic
- expose the new decorators and integrate optional Rich messaging support
- extend documentation and unit tests with coverage for warnings, locking and retry flows

## Testing
- pytest --override-ini addopts='' tests/unit/test_standard_library_decoradores.py

------
https://chatgpt.com/codex/tasks/task_e_68d193b25b68832781419e0b2d0a04dc