### PR TITLE
Añadir alias españoles para métodos especiales

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -77,21 +77,33 @@ juan.saludar()
 **Alias de métodos especiales**
 
 Para mejorar la legibilidad, Cobra reconoce varios alias en castellano que se
-transpilan a los métodos especiales habituales del ecosistema Python:
+transpilan a los métodos especiales habituales del ecosistema Python. Los alias
+nuevos (`texto`, `llamar`, `obtener_item`, `poner_item`, `borrar_item`,
+`entrar_async`, `salir_async`) amplían la cobertura de protocolos comunes.
 
-- `inicializar` &rarr; `__init__`
-- `representar` &rarr; `__repr__`
-- `iterar` &rarr; `__iter__`
-- `longitud` &rarr; `__len__`
-- `contener` &rarr; `__contains__`
-- `comparar` &rarr; `__eq__`
-- `ordenar` &rarr; `__lt__`
-- `entrar` &rarr; `__enter__`
-- `salir` &rarr; `__exit__`
+- **Alias síncronos** (válidos tanto para funciones como para métodos):
+  - `inicializar` &rarr; `__init__`
+  - `representar` &rarr; `__repr__`
+  - `iterar` &rarr; `__iter__`
+  - `longitud` &rarr; `__len__`
+  - `contener` &rarr; `__contains__`
+  - `comparar` &rarr; `__eq__`
+  - `ordenar` &rarr; `__lt__`
+  - `texto` &rarr; `__str__`
+  - `llamar` &rarr; `__call__`
+  - `obtener_item` &rarr; `__getitem__`
+  - `poner_item` &rarr; `__setitem__`
+  - `borrar_item` &rarr; `__delitem__`
+  - `entrar` &rarr; `__enter__`
+  - `salir` &rarr; `__exit__`
+- **Alias asincrónicos** (úsalos junto con la palabra clave `asincronico` para
+  declarar context managers asíncronos):
+  - `entrar_async` &rarr; `__aenter__`
+  - `salir_async` &rarr; `__aexit__`
 
 El parser registra una advertencia cuando dos declaraciones de la clase generan
-el mismo nombre especial (por ejemplo, `inicializar` y `__init__`) para evitar
-errores silenciosos.
+el mismo nombre especial (por ejemplo, `inicializar` y `__init__` o
+`entrar_async` y `__aenter__`) para evitar errores silenciosos.
 
 **Herencia múltiple**
 

--- a/src/pcobra/cobra/core/parser.py
+++ b/src/pcobra/cobra/core/parser.py
@@ -739,10 +739,10 @@ class ClassicParser:
             )
         if nombre_token.tipo != TipoToken.IDENTIFICADOR:
             raise ParserError("Se esperaba un nombre para la función después de 'func'")
-        nombre = nombre_token.valor
+        nombre_original = nombre_token.valor
         self.comer(TipoToken.IDENTIFICADOR)
 
-        nombre = ALIAS_METODOS_ESPECIALES.get(nombre, nombre)
+        nombre = ALIAS_METODOS_ESPECIALES.get(nombre_original, nombre_original)
 
         # Parámetros de tipo genéricos opcionales
         type_params = self.lista_parametros_tipo()
@@ -791,7 +791,12 @@ class ClassicParser:
 
         logger.debug(f"Función '{nombre}' parseada con cuerpo: {cuerpo}")
         return NodoFuncion(
-            nombre, parametros, cuerpo, asincronica=asincronica, type_params=type_params
+            nombre,
+            parametros,
+            cuerpo,
+            asincronica=asincronica,
+            type_params=type_params,
+            nombre_original=nombre_original,
         )
 
     def declaracion_imprimir(self):

--- a/src/pcobra/cobra/core/utils.py
+++ b/src/pcobra/cobra/core/utils.py
@@ -10,8 +10,15 @@ ALIAS_METODOS_ESPECIALES = {
     "contener": "__contains__",
     "comparar": "__eq__",
     "ordenar": "__lt__",
+    "texto": "__str__",
+    "llamar": "__call__",
+    "obtener_item": "__getitem__",
+    "poner_item": "__setitem__",
+    "borrar_item": "__delitem__",
     "entrar": "__enter__",
     "salir": "__exit__",
+    "entrar_async": "__aenter__",
+    "salir_async": "__aexit__",
 }
 
 # Umbral de similitud para las coincidencias

--- a/src/pcobra/core/ast_nodes.py
+++ b/src/pcobra/core/ast_nodes.py
@@ -159,6 +159,7 @@ class NodoFuncion(NodoAST):
     decoradores: List[Any] = field(default_factory=list)
     asincronica: bool = False
     type_params: List[str] = field(default_factory=list)
+    nombre_original: Optional[str] = None
 
     """Declaración de una función definida por el usuario."""
 

--- a/tests/unit/test_metodo_atributo.py
+++ b/tests/unit/test_metodo_atributo.py
@@ -1,6 +1,13 @@
 from cobra.core import Lexer
 from cobra.core import Parser
-from core.ast_nodes import NodoClase, NodoMetodo, NodoAsignacion, NodoAtributo, NodoImprimir
+from pcobra.core.ast_nodes import (
+    NodoClase,
+    NodoMetodo,
+    NodoFuncion,
+    NodoAsignacion,
+    NodoAtributo,
+    NodoImprimir,
+)
 
 
 def test_parser_metodo_keyword():
@@ -36,6 +43,39 @@ def test_parser_metodo_alias_especial():
     assert parser.advertencias == []
 
 
+def test_parser_metodo_alias_texto():
+    codigo = """
+    clase Persona:
+        metodo texto(self):
+            pasar
+        fin
+    fin
+    """
+    parser = Parser(Lexer(codigo).analizar_token())
+    clase = parser.parsear()[0]
+    metodo = clase.metodos[0]
+    assert metodo.nombre == "__str__"
+    assert metodo.nombre_original == "texto"
+    assert parser.advertencias == []
+
+
+def test_parser_metodo_alias_async():
+    codigo = """
+    clase Gestor:
+        asincronico metodo entrar_async(self):
+            pasar
+        fin
+    fin
+    """
+    parser = Parser(Lexer(codigo).analizar_token())
+    clase = parser.parsear()[0]
+    metodo = clase.metodos[0]
+    assert metodo.nombre == "__aenter__"
+    assert metodo.nombre_original == "entrar_async"
+    assert metodo.asincronica is True
+    assert parser.advertencias == []
+
+
 def test_parser_atributo_asignacion():
     codigo = "atributo obj nombre = 1"
     ast = Parser(Lexer(codigo).analizar_token()).parsear()
@@ -54,3 +94,18 @@ def test_parser_atributo_expresion():
     attr = imp.expresion
     assert isinstance(attr, NodoAtributo)
     assert attr.nombre == "nombre"
+
+
+def test_parser_funcion_alias_especial():
+    codigo = """
+    func texto():
+        pasar
+    fin
+    """
+    parser = Parser(Lexer(codigo).analizar_token())
+    ast = parser.parsear()
+    funcion = ast[0]
+    assert isinstance(funcion, NodoFuncion)
+    assert funcion.nombre == "__str__"
+    assert funcion.nombre_original == "texto"
+    assert parser.advertencias == []

--- a/tests/unit/test_parser_clase.py
+++ b/tests/unit/test_parser_clase.py
@@ -1,6 +1,6 @@
 from cobra.core import Lexer
 from cobra.core import Parser
-from core.ast_nodes import NodoClase, NodoMetodo
+from pcobra.core.ast_nodes import NodoClase, NodoMetodo
 
 
 def test_parser_declaracion_clase():
@@ -45,3 +45,29 @@ def test_parser_clase_alias_choque_nombres():
     mensaje = parser.advertencias[0]
     assert "Choque de nombres" in mensaje
     assert "inicializar" in mensaje and "__init__" in mensaje
+
+
+def test_parser_clase_alias_async_choque_nombres():
+    codigo = """
+    clase Gestor:
+        asincronico metodo entrar_async(self):
+            pasar
+        fin
+        asincronico metodo __aenter__(self):
+            pasar
+        fin
+    fin
+    """
+    tokens = Lexer(codigo).analizar_token()
+    parser = Parser(tokens)
+    ast = parser.parsear()
+    clase = ast[0]
+    assert isinstance(clase, NodoClase)
+    metodos = [n for n in clase.metodos if isinstance(n, NodoMetodo)]
+    assert len(metodos) == 2
+    nombres = [metodo.nombre for metodo in metodos]
+    assert nombres == ["__aenter__", "__aenter__"]
+    assert len(parser.advertencias) == 1
+    mensaje = parser.advertencias[0]
+    assert "Choque de nombres" in mensaje
+    assert "entrar_async" in mensaje and "__aenter__" in mensaje


### PR DESCRIPTION
## Summary
- add Spanish aliases for additional Python special methods, including async context manager hooks
- store the original declared name on function nodes so alias usage is preserved
- expand unit tests and documentation to cover the new aliases and collision warnings

## Testing
- pytest -o addopts="" tests/unit/test_metodo_atributo.py tests/unit/test_parser_clase.py

------
https://chatgpt.com/codex/tasks/task_e_68d1f7ed71ac832788c59c6623ebb479