### PR TITLE
Añadir utilidades de codificación y decodificación de texto

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -738,7 +738,22 @@ El módulo `pcobra.corelibs.texto` se amplió con herramientas inspiradas en `st
 - `formatear` simplifica interpolaciones al estilo de `str.format`, `formatear_mapa` acepta mapeos como `str.format_map` y el dúo `tabla_traduccion`/`traducir` construye y aplica tablas compatibles con `str.maketrans`/`str.translate` en ambos backends.
 - Las comprobaciones `es_alfabetico`, `es_alfa_numerico`, `es_decimal`, `es_numerico`, `es_identificador`, `es_imprimible`, `es_ascii`, `es_mayusculas`, `es_minusculas`, `es_titulo`, `es_digito` y `es_espacio` replican directamente los métodos `str.is*` de Python.
 
-En la biblioteca estándar (`standard_library.texto`) se añadieron utilidades de mayor nivel como `quitar_acentos`, `normalizar_espacios`, `es_palindromo` y `es_anagrama`, además de accesos directos a los validadores `es_*`. Estas funciones combinan las primitivas anteriores para resolver tareas frecuentes como limpiar entrada de usuarios, validar palíndromos independientemente de acentos o comparar cadenas ignorando espacios.
+En la biblioteca estándar (`standard_library.texto`) se añadieron utilidades de mayor nivel como `quitar_acentos`, `normalizar_espacios`, `es_palindromo` y `es_anagrama`, además de accesos directos a los validadores `es_*`. Se suman también `codificar` y `decodificar`, que validan tipos y nombres de encoding antes de operar y permiten seleccionar políticas de errores (`strict`, `ignore`, `replace`, etc.) para decidir cómo tratar símbolos problemáticos.
+
+```cobra
+import standard_library.texto as texto
+
+intentar:
+    texto.codificar("Señal", encoding="ascii")
+capturar error:
+    imprimir(error)
+fin
+
+var datos = texto.codificar("hola€", encoding="ascii", errores="ignore")
+imprimir(texto.decodificar(datos, encoding="ascii"))  # 'hola'
+```
+
+Estas funciones combinan las primitivas anteriores para resolver tareas frecuentes como limpiar entrada de usuarios, validar palíndromos independientemente de acentos o comparar cadenas ignorando espacios.
 
 ```cobra
 import pcobra.corelibs as core

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -468,6 +468,15 @@ imprimir(limpio)  # 'hola mundo'
 
 imprimir(texto.quitar_acentos("Canción"))  # 'Cancion'
 imprimir(texto.es_palindromo("Sé verlas al revés"))  # True
+
+intentar:
+    texto.codificar("Señal", encoding="ascii")
+capturar error:
+    imprimir("falló la codificación:", error)
+fin
+
+var datos = texto.codificar("hola€", encoding="ascii", errores="ignore")
+imprimir(texto.decodificar(datos, encoding="ascii"))  # 'hola'
 ```
 
 Este fragmento muestra cómo combinar las utilidades de `corelibs.texto` con los atajos de `standard_library.texto` para trabajar con Unicode sin perder legibilidad.

--- a/docs/standard_library/texto.md
+++ b/docs/standard_library/texto.md
@@ -36,6 +36,36 @@ assert es_anagrama("Roma", "amor") is True
 assert es_anagrama("cosa", "caso ", ignorar_espacios=False) is False
 ```
 
+## `codificar(texto: str, encoding: str = "utf-8", errores: str = "strict") -> bytes`
+Genera bytes a partir de una cadena validando tanto la codificación como la política de errores. Úsalo cuando necesites producir archivos en distintos formatos o preparar mensajes para sockets.
+
+```python
+from standard_library.texto import codificar
+
+try:
+    codificar("Señal", "ascii")
+except UnicodeEncodeError as exc:
+    print(exc)  # no se pudo codificar el texto usando 'ascii': ordinal not in range(128)
+
+assert codificar("Señal", "latin-1") == b"Se\xf1al"
+assert codificar("hola€", "ascii", errores="ignore") == b"hola"
+```
+
+## `decodificar(datos: bytes | bytearray | memoryview, encoding: str = "utf-8", errores: str = "strict") -> str`
+Convierte datos binarios en texto asegurándose de que el `encoding` exista y permitiendo elegir la estrategia de recuperación ante bytes inválidos.
+
+```python
+from standard_library.texto import decodificar
+
+try:
+    decodificar(b"hola\xff", "utf-8")
+except UnicodeDecodeError as exc:
+    print(exc)  # no se pudo decodificar los datos usando 'utf-8': invalid start byte
+
+assert decodificar(b"Se\xf1al", "latin-1") == "Señal"
+assert decodificar(b"hola\xff", "utf-8", errores="ignore") == "hola"
+```
+
 ## Búsquedas con `encontrar`/`indice`
 `encontrar` y `encontrar_derecha` replican la semántica de `str.find`/`str.rfind` devolviendo `-1` cuando no hallan la subcadena, o bien el valor indicado en `por_defecto`. Las variantes `indice` e `indice_derecha` siguen a `str.index`/`str.rindex` y permiten retornar un valor alternativo en lugar de lanzar un error. Los índices que se devuelven son base cero, en sintonía con Python y JavaScript.
 

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -10,6 +10,8 @@ from corelibs.texto import (
     intercambiar_mayusculas,
     invertir,
     concatenar,
+    codificar as _texto_codificar,
+    decodificar as _texto_decodificar,
     quitar_espacios,
     dividir,
     dividir_derecha,
@@ -63,7 +65,7 @@ from corelibs.texto import (
     es_espacio,
     rellenar_izquierda,
     rellenar_derecha,
-    normalizar_unicode,
+normalizar_unicode,
 )
 
 encontrar_texto = _texto_encontrar
@@ -77,6 +79,8 @@ tabla_traduccion_texto = _texto_tabla_traduccion
 tabla_traduccion = _texto_tabla_traduccion
 traducir_texto = _texto_traducir
 traducir = _texto_traducir
+codificar_texto = _texto_codificar
+decodificar_texto = _texto_decodificar
 from corelibs.logica import (
     es_verdadero,
     es_falso,

--- a/src/pcobra/corelibs/texto.py
+++ b/src/pcobra/corelibs/texto.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import codecs
 from collections.abc import Iterable, Mapping
 import operator
 import re
@@ -101,6 +102,84 @@ def concatenar(*cadenas: str) -> str:
     """Concatena las cadenas proporcionadas sin separador adicional."""
 
     return "".join(cadenas)
+
+
+def codificar(texto: str, encoding: str = "utf-8", errores: str = "strict") -> bytes:
+    """Codifica ``texto`` empleando la codificación y política de errores indicadas."""
+
+    if not isinstance(texto, str):
+        raise TypeError("texto debe ser una cadena")
+    if not isinstance(encoding, str):
+        raise TypeError("encoding debe ser una cadena")
+    if not isinstance(errores, str):
+        raise TypeError("errores debe ser una cadena")
+
+    try:
+        codecs.lookup(encoding)
+    except LookupError as exc:
+        raise LookupError(f"el encoding '{encoding}' no está disponible") from exc
+
+    try:
+        codecs.lookup_error(errores)
+    except LookupError as exc:
+        raise LookupError(
+            f"la política de errores '{errores}' no está registrada"
+        ) from exc
+
+    try:
+        return codecs.encode(texto, encoding, errores)
+    except UnicodeEncodeError as exc:
+        raise UnicodeEncodeError(
+            exc.encoding,
+            exc.object,
+            exc.start,
+            exc.end,
+            f"no se pudo codificar el texto usando '{encoding}': {exc.reason}",
+        ) from None
+
+
+def decodificar(
+    datos: bytes | bytearray | memoryview,
+    encoding: str = "utf-8",
+    errores: str = "strict",
+) -> str:
+    """Decodifica ``datos`` según la codificación y política de errores solicitadas."""
+
+    if not isinstance(datos, (bytes, bytearray, memoryview)):
+        raise TypeError("datos debe ser un objeto de bytes")
+    if not isinstance(encoding, str):
+        raise TypeError("encoding debe ser una cadena")
+    if not isinstance(errores, str):
+        raise TypeError("errores debe ser una cadena")
+
+    try:
+        codecs.lookup(encoding)
+    except LookupError as exc:
+        raise LookupError(f"el encoding '{encoding}' no está disponible") from exc
+
+    try:
+        codecs.lookup_error(errores)
+    except LookupError as exc:
+        raise LookupError(
+            f"la política de errores '{errores}' no está registrada"
+        ) from exc
+
+    buffer: bytes | bytearray
+    if isinstance(datos, memoryview):
+        buffer = datos.tobytes()
+    else:
+        buffer = datos
+
+    try:
+        return bytes(buffer).decode(encoding, errores)
+    except UnicodeDecodeError as exc:
+        raise UnicodeDecodeError(
+            exc.encoding,
+            exc.object,
+            exc.start,
+            exc.end,
+            f"no se pudo decodificar los datos usando '{encoding}': {exc.reason}",
+        ) from None
 
 
 def quitar_espacios(

--- a/src/pcobra/standard_library/texto.py
+++ b/src/pcobra/standard_library/texto.py
@@ -44,6 +44,8 @@ from pcobra.corelibs import (
     minusculas_casefold as _minusculas_casefold,
     normalizar_unicode,
     expandir_tabulaciones as _expandir_tabulaciones,
+    codificar_texto as _codificar_texto,
+    decodificar_texto as _decodificar_texto,
     prefijo_comun as _prefijo_comun,
     quitar_espacios,
     quitar_prefijo as _quitar_prefijo,
@@ -82,6 +84,8 @@ __all__ = [
     "normalizar_espacios",
     "es_palindromo",
     "es_anagrama",
+    "codificar",
+    "decodificar",
     "es_alfabetico",
     "es_alfa_numerico",
     "es_decimal",
@@ -353,6 +357,22 @@ def es_anagrama(texto: str, otro: str, *, ignorar_espacios: bool = True) -> bool
         return normalizar_unicode("".join(sorted(resultado)), "NFC")
 
     return preparar(texto) == preparar(otro)
+
+
+def codificar(texto: str, encoding: str = "utf-8", errores: str = "strict") -> bytes:
+    """Convierte texto en bytes validando explícitamente la codificación y la política."""
+
+    return _codificar_texto(texto, encoding=encoding, errores=errores)
+
+
+def decodificar(
+    datos: bytes | bytearray | memoryview,
+    encoding: str = "utf-8",
+    errores: str = "strict",
+) -> str:
+    """Interpreta datos binarios como texto controlando codificación y errores."""
+
+    return _decodificar_texto(datos, encoding=encoding, errores=errores)
 
 
 def a_snake(texto: str) -> str:

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -202,6 +202,18 @@ def test_texto_funcs():
     assert core.particionar_derecha("uno-dos-tres", "-") == ("uno-dos", "-", "tres")
     assert core.particionar_derecha("sin", "-") == ("", "", "sin")
     assert core.particionar_derecha("mañana", "a") == ("mañan", "a", "")
+    assert core.codificar_texto("Señal", "latin-1") == b"Se\xf1al"
+    with pytest.raises(UnicodeEncodeError):
+        core.codificar_texto("€", "ascii")
+    assert core.codificar_texto("hola€", "ascii", errores="ignore") == b"hola"
+    assert core.decodificar_texto(b"Se\xf1al", "latin-1") == "Señal"
+    with pytest.raises(UnicodeDecodeError):
+        core.decodificar_texto(b"\xff", "utf-8")
+    assert core.decodificar_texto(b"hola\xff", "utf-8", errores="ignore") == "hola"
+    with pytest.raises(TypeError):
+        core.codificar_texto(123)  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        core.decodificar_texto("texto")  # type: ignore[arg-type]
 
 
 def test_numero_funcs():

--- a/tests/unit/test_standard_library_texto.py
+++ b/tests/unit/test_standard_library_texto.py
@@ -108,6 +108,17 @@ def test_prefijos_y_sufijos():
     assert texto.quitar_sufijo("archivo.log", ".gz") == "archivo.log"
 
 
+def test_codificar_decodificar_control_errores():
+    assert texto.codificar("Señal", "latin-1") == b"Se\xf1al"
+    with pytest.raises(UnicodeEncodeError):
+        texto.codificar("€", "ascii")
+    assert texto.codificar("hola€", "ascii", errores="ignore") == b"hola"
+    assert texto.decodificar(b"Se\xf1al", "latin-1") == "Señal"
+    with pytest.raises(UnicodeDecodeError):
+        texto.decodificar(b"\xff", "utf-8")
+    assert texto.decodificar(b"hola\xff", "utf-8", errores="ignore") == "hola"
+
+
 def test_prefijo_y_sufijo_comun():
     assert texto.prefijo_comun("mañana", "Mañanita", ignorar_mayusculas=True) == "mañan"
     assert texto.prefijo_comun(


### PR DESCRIPTION
## Summary
- agregar a `pcobra.corelibs.texto` las funciones `codificar` y `decodificar` con validaciones de tipos, elección de encoding y mensajes claros
- reexportar las utilidades en `pcobra.corelibs` y `standard_library.texto`, documentándolas en la guía y el manual con ejemplos de control de errores
- extender las pruebas de núcleo y biblioteca estándar para cubrir rutas de éxito, fallos de codificación/decodificación y políticas de errores permisivas

## Testing
- pytest tests/unit/test_corelibs.py tests/unit/test_standard_library_texto.py *(falla: el entorno carece de soporte para async y de los recursos necesarios para las pruebas de transpilación ajenas al cambio)*

------
https://chatgpt.com/codex/tasks/task_e_68d2255ea8608327b7dd46664390f6c6