### PR TITLE
Add tabla_cruzada helper and documentation

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -1060,6 +1060,7 @@ El módulo `standard_library.datos` añade una capa ligera sobre `pandas` que pe
 - `pivotar_ancho` compacta métricas en columnas nuevas al estilo de `pivot_wider`.
 - `pivotar_largo` vuelve a expandir columnas en filas con control sobre nombres y valores nulos.
 - `desplegar_tabla` transforma los datos a formato largo, equivalente a `pivot_longer` de R o `pandas.melt`.
+- `tabla_cruzada` calcula tablas de contingencia a partir de etiquetas por filas y columnas, con agregaciones y normalización opcional.
 - `pivotar_tabla` reorganiza los datos en formato ancho calculando métricas múltiples de manera declarativa.
 - `a_listas` y `de_listas` convierten entre lista de registros y diccionario de columnas, facilitando la interoperabilidad con librerías externas.
 
@@ -1127,6 +1128,23 @@ ventas_limpias_largo = pandas.pivotar_largo(
 )
 columnas = pandas.a_listas(resumen)
 imprimir(columnas['region'])
+```
+
+```cobra
+# Comparar regiones por mes contando registros y calculando proporciones
+conteo_mensual = pandas.tabla_cruzada(
+    ventas_limpias,
+    filas='region',
+    columnas='mes',
+)
+participacion = pandas.tabla_cruzada(
+    ventas_limpias,
+    filas='region',
+    columnas='mes',
+    normalizar='filas',
+)
+imprimir(conteo_mensual)
+imprimir(participacion)
 ```
 
 ```cobra

--- a/docs/standard_library/datos.md
+++ b/docs/standard_library/datos.md
@@ -25,6 +25,10 @@ El módulo `standard_library.datos` encapsula operaciones comunes sobre datos ta
   concatena columnas en un solo campo controlando los nulos como en `tidyr::unite`
   o en las transformaciones `ByRow` de DataFrames.jl.
 - **`agrupar_y_resumir(datos, por, agregaciones)`**: agrupa por columnas y aplica agregaciones compatibles con `DataFrame.agg`.
+- **`tabla_cruzada(datos, filas, columnas, *, valores=None, aggfunc='count', normalizar=None)`**:
+  genera tablas de contingencia a partir de columnas categóricas usando
+  `pandas.crosstab`, permitiendo sumarizar medidas adicionales y obtener
+  proporciones por fila, columna o sobre el total.
 - **`a_listas(datos)`**: transforma la tabla a un diccionario columna → lista.
 - **`de_listas(columnas)`**: genera una lista de diccionarios a partir de un mapeo de columnas.
 

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -42,6 +42,7 @@ from standard_library.datos import (
     mutar_columna,
     pivotar_ancho,
     pivotar_largo,
+    tabla_cruzada,
     resumen_rapido,
     separar_columna,
     unir_columnas,
@@ -232,6 +233,7 @@ __all__: list[str] = [
     "pivotar_ancho",
     "pivotar_largo",
     "desplegar_tabla",
+    "tabla_cruzada",
     "agrupar_y_resumir",
     "a_listas",
     "de_listas",
@@ -286,6 +288,7 @@ mutar_columna: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]],
 pivotar_ancho: Callable[..., list[dict[str, Any]]]
 pivotar_largo: Callable[..., list[dict[str, Any]]]
 desplegar_tabla: Callable[..., list[dict[str, Any]]]
+tabla_cruzada: Callable[..., list[dict[str, Any]]]
 agrupar_y_resumir: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]], Sequence[str], Mapping[str, Any]], list[dict[str, Any]]]
 a_listas: Callable[[Iterable[dict[str, Any]] | Mapping[str, Sequence[Any]]], dict[str, list[Any]]]
 de_listas: Callable[[Mapping[str, Sequence[Any]]], list[dict[str, Any]]]

--- a/tests/unit/test_standard_library_datos.py
+++ b/tests/unit/test_standard_library_datos.py
@@ -34,6 +34,7 @@ from pcobra.standard_library.datos import (
     pivotar_largo,
     ordenar_tabla,
     pivotar_tabla,
+    tabla_cruzada,
     rellenar_nulos,
     resumen_rapido,
     unir_columnas,
@@ -213,6 +214,65 @@ def test_unir_columnas_control_nulos():
     assert unidos_con_relleno[0]["nombre_zona"] == "Ada - Norte"
     assert unidos_con_relleno[1]["nombre_zona"] == "Grace - sin dato"
     assert unidos_con_relleno[2]["nombre_zona"] == "sin dato - sin dato"
+
+
+def test_tabla_cruzada_conteo_simple():
+    datos = [
+        {"region": "norte", "genero": "F"},
+        {"region": "norte", "genero": "M"},
+        {"region": "sur", "genero": "F"},
+    ]
+
+    tabla = tabla_cruzada(datos, "region", "genero")
+
+    assert tabla == [
+        {"region": "norte", "F": 1, "M": 1},
+        {"region": "sur", "F": 1, "M": 0},
+    ]
+
+
+def test_tabla_cruzada_agregacion_personalizada():
+    datos = [
+        {"region": "norte", "mes": "enero", "monto": 100},
+        {"region": "norte", "mes": "enero", "monto": 50},
+        {"region": "norte", "mes": "febrero", "monto": 20},
+        {"region": "sur", "mes": "enero", "monto": 70},
+        {"region": "sur", "mes": "febrero", "monto": 30},
+    ]
+
+    tabla = tabla_cruzada(
+        datos,
+        "region",
+        "mes",
+        valores="monto",
+        aggfunc="sum",
+    )
+
+    assert tabla == [
+        {"region": "norte", "enero": 150, "febrero": 20},
+        {"region": "sur", "enero": 70, "febrero": 30},
+    ]
+
+
+def test_tabla_cruzada_normalizacion_filas_columnas():
+    datos = [
+        {"segmento": "A", "estado": "activo"},
+        {"segmento": "A", "estado": "activo"},
+        {"segmento": "A", "estado": "inactivo"},
+        {"segmento": "B", "estado": "activo"},
+    ]
+
+    por_filas = tabla_cruzada(datos, "segmento", "estado", normalizar="filas")
+    assert por_filas[0]["activo"] == pytest.approx(2 / 3)
+    assert por_filas[0]["inactivo"] == pytest.approx(1 / 3)
+    assert por_filas[1]["activo"] == pytest.approx(1.0)
+    assert por_filas[1]["inactivo"] == pytest.approx(0.0)
+
+    por_columnas = tabla_cruzada(datos, "segmento", "estado", normalizar="columnas")
+    assert por_columnas[0]["activo"] == pytest.approx(2 / 3)
+    assert por_columnas[1]["activo"] == pytest.approx(1 / 3)
+    assert por_columnas[0]["inactivo"] == pytest.approx(1.0)
+    assert por_columnas[1]["inactivo"] == pytest.approx(0.0)
 
 
 def test_mutar_columna_exige_existente():


### PR DESCRIPTION
## Summary
- add `tabla_cruzada` helper on top of `pandas.crosstab` with sanitised output
- expose the new helper in the standard library namespace and document its usage
- extend the manual and unit tests with practical examples, aggregation and normalisation cases

## Testing
- `pytest tests/unit/test_standard_library_datos.py` *(fails: coverage threshold for the full project is enforced and not reached when running the focused suite)*
- `pytest --no-cov tests/unit/test_standard_library_datos.py`


------
https://chatgpt.com/codex/tasks/task_e_68d2ca7accf48327a55700f35952029b