### PR TITLE
Agregar helper asincrono para limitar tiempo

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -362,6 +362,11 @@ varias tareas sin perder legibilidad:
   obtener el primer resultado, igual que `Promise.race`.
 - `esperar_timeout` cubre `asyncio.wait_for` garantizando que la corrutina se
   cancela limpiamente si se supera el límite.
+- `limitar_tiempo` proporciona un contexto asíncrono que aprovecha
+  `asyncio.timeout` en Python 3.11+ y replica su comportamiento en versiones
+  anteriores cancelando la tarea actual cuando el bloque supera el límite
+  configurado, permitiendo definir un mensaje personalizado para el
+  `TimeoutError` resultante.
 - `crear_tarea` centraliza la creación de tareas para evitar fugas de corrutinas
   al integrar Cobra con bibliotecas Python.
 - `proteger_tarea` reutiliza `asyncio.shield` para aislar corrutinas de

--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -203,6 +203,7 @@ from corelibs.asincrono import (
     recolectar_resultados,
     carrera,
     primero_exitoso,
+    limitar_tiempo,
     esperar_timeout,
     reintentar_async,
     crear_tarea,
@@ -402,6 +403,7 @@ __all__ = [
     "recolectar_resultados",
     "carrera",
     "primero_exitoso",
+    "limitar_tiempo",
     "esperar_timeout",
     "reintentar_async",
     "crear_tarea",
@@ -618,4 +620,11 @@ limitar.__doc__ = (
     " prefieren una API en español al clamping ``min``/``max`` habitual,"
     " garantizando la propagación de ``NaN`` y validando que el mínimo no exceda"
     " al máximo."
+)
+
+limitar_tiempo.__doc__ = (
+    "Reexporta :func:`pcobra.corelibs.asincrono.limitar_tiempo`. Ofrece un"
+    " contexto asíncrono que utiliza ``asyncio.timeout`` cuando está disponible y"
+    " recrea su semántica en versiones anteriores cancelando la tarea en curso"
+    " para disparar un ``asyncio.TimeoutError`` opcionalmente personalizado."
 )

--- a/src/pcobra/standard_library/asincrono.py
+++ b/src/pcobra/standard_library/asincrono.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from typing import (
     Any,
     AsyncContextManager,
+    AsyncIterator,
     Awaitable,
     Callable,
     Coroutine,
@@ -17,11 +19,18 @@ from pcobra.corelibs import (
     proteger_tarea as _proteger_tarea,
     ejecutar_en_hilo as _ejecutar_en_hilo,
     reintentar_async as _reintentar_async,
+    limitar_tiempo as _limitar_tiempo,
 )
 
 T = TypeVar("T")
 
-__all__ = ["grupo_tareas", "proteger_tarea", "ejecutar_en_hilo", "reintentar_async"]
+__all__ = [
+    "grupo_tareas",
+    "limitar_tiempo",
+    "proteger_tarea",
+    "ejecutar_en_hilo",
+    "reintentar_async",
+]
 
 
 def grupo_tareas() -> AsyncContextManager[Any]:
@@ -35,6 +44,16 @@ def grupo_tareas() -> AsyncContextManager[Any]:
     """
 
     return _grupo_tareas()
+
+
+@asynccontextmanager
+async def limitar_tiempo(
+    segundos: float | None, *, mensaje: str | None = None
+) -> AsyncIterator[None]:
+    """Limita la ejecución del bloque actual a ``segundos`` como máximo."""
+
+    async with _limitar_tiempo(segundos, mensaje=mensaje):
+        yield
 
 
 def proteger_tarea(awaitable: Awaitable[T] | Coroutine[Any, Any, T]):

--- a/tests/unit/test_standard_library_async.py
+++ b/tests/unit/test_standard_library_async.py
@@ -1,0 +1,11 @@
+import asyncio
+
+import pytest
+
+from pcobra.standard_library import asincrono as std_asincrono
+
+
+@pytest.mark.asyncio
+async def test_limitar_tiempo_disponible_en_standard_library():
+    async with std_asincrono.limitar_tiempo(0.05):
+        await asyncio.sleep(0)


### PR DESCRIPTION
## Summary
- añade el administrador asincrono `limitar_tiempo` con compatibilidad hacia atrás
- expone la utilidad en la biblioteca estándar y documenta su uso
- amplía las pruebas de corelibs y añade un test de humo para la biblioteca estándar

## Testing
- pytest -o addopts="" tests/unit/test_corelibs_async.py tests/unit/test_standard_library_async.py


------
https://chatgpt.com/codex/tasks/task_e_68d2d3a022748327964529430231954f