### PR TITLE
feat: añadir orden_total y despacho por tipo

### DIFF
--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -1258,9 +1258,19 @@ existentes en Python, Cobra expone atajos en español dentro de
 - `@temporizar` mide el tiempo de cada invocación con `time.perf_counter`. Si
   [`rich`](https://rich.readthedocs.io) está instalado, envía el resultado a una
   consola enriquecida; en caso contrario utiliza `print` estándar.
+- `@orden_total` (envoltorio de `functools.total_ordering`) completa los
+  operadores de comparación a partir de `__eq__` y uno adicional.
+- `@despachar_por_tipo` expone el despacho por tipo de `functools.singledispatch`
+  con métodos `registrar` y `despachar` en español.
 
 ```python
-from pcobra.standard_library.decoradores import dataclase, memoizar, temporizar
+from pcobra.standard_library.decoradores import (
+    dataclase,
+    memoizar,
+    temporizar,
+    orden_total,
+    despachar_por_tipo,
+)
 
 @dataclase
 class Punto:
@@ -1274,6 +1284,30 @@ def distancia(x, y):
 @temporizar(etiqueta="calculo")
 def hipotenusa(punto):
     return distancia(punto.x, punto.y)
+
+
+@orden_total()
+@dataclase
+class Version:
+    mayor: int
+    menor: int
+
+    def __lt__(self, otro: "Version") -> bool:
+        return (self.mayor, self.menor) < (otro.mayor, otro.menor)
+
+
+@despachar_por_tipo
+def describir(valor):
+    return f"Valor genérico: {valor!r}"
+
+
+@describir.registrar(Version)
+def _(valor: Version) -> str:
+    return f"Version {valor.mayor}.{valor.menor}"
+
+
+assert Version(1, 2) < Version(2, 0)
+assert describir(Version(1, 0)) == "Version 1.0"
 ```
 
 > Consejo: `temporizar` admite un parámetro `consola` para reutilizar una

--- a/docs/standard_library/decoradores.md
+++ b/docs/standard_library/decoradores.md
@@ -40,6 +40,32 @@ class Punto:
     y: float
 ```
 
+## `orden_total`
+
+Permite definir comparaciones completas en clases de datos usando
+:func:`functools.total_ordering`. Acepta tanto ``@orden_total`` como
+``@orden_total()`` y valida que se aplique sobre una clase.
+
+```python
+from pcobra.standard_library.decoradores import dataclase, orden_total
+
+@orden_total
+@dataclase
+class Punto:
+    x: int
+    y: int
+
+    def __lt__(self, otro: "Punto") -> bool:
+        return (self.x, self.y) < (otro.x, otro.y)
+
+    def __eq__(self, otro: object) -> bool:
+        if not isinstance(otro, Punto):
+            return NotImplemented
+        return (self.x, self.y) == (otro.x, otro.y)
+
+assert Punto(0, 1) <= Punto(0, 1) < Punto(1, 0)
+```
+
 ## `temporizar`
 
 Mide el tiempo de ejecución de una función usando `time.perf_counter` y reporta
@@ -151,3 +177,28 @@ async def descargar_archivo():
 > - [Rich](https://rich.readthedocs.io/) para mensajes con estilo.
 > - `pcobra.corelibs` ya provee `reintentar_async`, por lo que no es necesario
 >   instalar nada adicional para los reintentos asíncronos más allá de Cobra.
+
+## `despachar_por_tipo`
+
+Equivalente en español de :func:`functools.singledispatch`. Construye una
+función despachadora que selecciona la implementación adecuada según el tipo del
+primer argumento posicional. Añade atajos en español:
+
+- ``registrar``: versión localizada de ``register`` con validación de tipos.
+- ``despachar``: equivalente localizado de ``dispatch``.
+- ``registros``: acceso de solo lectura al mapeo de implementaciones.
+
+```python
+from pcobra.standard_library.decoradores import despachar_por_tipo
+
+@despachar_por_tipo()
+def describir(valor):
+    return f"Valor genérico: {valor!r}"
+
+@describir.registrar(int)
+def _(valor: int) -> str:
+    return f"Entero: {valor}"
+
+assert describir(5) == "Entero: 5"
+assert describir(5.0).startswith("Valor genérico")
+```

--- a/src/pcobra/standard_library/__init__.py
+++ b/src/pcobra/standard_library/__init__.py
@@ -144,7 +144,9 @@ from standard_library.asincrono import grupo_tareas, proteger_tarea, ejecutar_en
 from standard_library.decoradores import (
     dataclase,
     depreciado,
+    despachar_por_tipo,
     memoizar,
+    orden_total,
     reintentar,
     reintentar_async,
     sincronizar,
@@ -271,6 +273,8 @@ __all__: list[str] = [
     "sincronizar",
     "reintentar",
     "reintentar_async",
+    "orden_total",
+    "despachar_por_tipo",
 ]
 
 
@@ -325,3 +329,5 @@ depreciado: Callable[..., Callable[..., Any]]
 sincronizar: Callable[..., Callable[..., Any]]
 reintentar: Callable[..., Callable[..., Any]]
 reintentar_async: Callable[..., Callable[..., Any]]
+orden_total: Callable[..., type[Any]]
+despachar_por_tipo: Callable[..., Callable[..., Any]]


### PR DESCRIPTION
## Summary
- incorpora los nuevos ayudantes `orden_total` y `despachar_por_tipo` en el módulo de decoradores, validando objetivos y añadiendo alias en español
- reexporta los decoradores desde `standard_library` y amplía la documentación con ejemplos de uso en la guía y en la referencia
- extiende la batería de pruebas unitarias para cubrir la semántica de orden total y el registro/despacho por tipo

## Testing
- PYTEST_ADDOPTS="--cov=pcobra --cov-report=term-missing --cov-report=xml --cov-fail-under=0" pytest tests/unit/test_standard_library_decoradores.py

------
https://chatgpt.com/codex/tasks/task_e_68d3ba7d62988327879e3dd7e3105f5f