### PR TITLE
Handle optional dotenv import and timeout None

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -15,7 +15,11 @@ sys.modules.setdefault("core", core_pkg)
 sys.modules.setdefault("compiler", compiler_pkg)
 
 import re
-from dotenv import load_dotenv
+
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - rama dependiente del entorno
+    load_dotenv = None
 from .cobra.cli.commands.compile_cmd import CompileCommand, LANG_CHOICES
 from .cobra.cli.commands.execute_cmd import ExecuteCommand
 from .cobra.cli.utils import messages
@@ -25,6 +29,11 @@ logger = logging.getLogger(__name__)
 
 def configurar_entorno() -> None:
     """Carga variables de entorno desde un archivo .env si está presente."""
+    if load_dotenv is None:
+        logger.debug(
+            "python-dotenv no está instalado; se omite la carga automática del archivo .env"
+        )
+        return
     try:
         cargado = load_dotenv()
     except OSError as exc:


### PR DESCRIPTION
## Summary
- evitar que la CLI falle cuando python-dotenv no está instalado registrando un mensaje y omitiendo la carga automática
- permitir que ejecutar_en_contenedor acepte timeout=None propagándolo a la sandbox de JS y evitando cálculos con None
- documentar en la función que timeout puede ser None para desactivar el límite

## Testing
- `pytest` *(falla: pytest intenta usar opciones de cobertura --cov sin que el plugin pytest-cov esté disponible en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68d4353759588327865c9e1e3220721c