### PR TITLE
Corrige comandos de transpilación en la documentación

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ La cadena de herramientas de Cobra se articula alrededor de Hololang, un lenguaj
 2. Ese AST se normaliza y se transforma en representaciones Hololang que capturan estructuras de control, módulos y tipos.
 3. Los transpiladores consumen el IR Hololang para generar código en los distintos backends soportados.
 
-Hololang actúa como contrato estable entre el front-end y los generadores de código, permitiendo incorporar nuevos destinos sin modificar el parser original. Gracias a esta capa intermedia, Cobra ofrece un generador de ensamblador que produce instrucciones simbólicas optimizadas para depuración y diagnóstico de rendimiento. El comando `cobra transpila` puede emitir directamente los ficheros Hololang o derivarlos a `asm` para obtener la salida en ensamblador.
+Hololang actúa como contrato estable entre el front-end y los generadores de código, permitiendo incorporar nuevos destinos sin modificar el parser original. Gracias a esta capa intermedia, Cobra ofrece un generador de ensamblador que produce instrucciones simbólicas optimizadas para depuración y diagnóstico de rendimiento. El comando `cobra transpilar` puede emitir directamente los ficheros Hololang o derivarlos a `asm` para obtener la salida en ensamblador.
 
 ## Instalación
 
@@ -152,7 +152,7 @@ cobra archivo.co --no-seguro
 ### Ejemplo de transpilación
 
 ```bash
-cobra transpila hola.co --dest python
+cobra transpilar hola.co --lenguaje python
 ```
 
 Esto generará `hola.py`. Para conocer otros destinos y opciones, consulta la [documentación detallada](docs/) o revisa [docs/frontend](docs/frontend).

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -87,7 +87,7 @@ Cobra's toolchain revolves around Hololang, an intermediate language that captur
 2. That AST is normalized and lowered into Hololang representations that encode control structures, modules and types.
 3. The transpilers consume the Hololang IR to generate code for each supported backend.
 
-Hololang acts as a stable contract between the front-end and the code generators, enabling new targets without touching the original parser. Thanks to this intermediate layer Cobra ships an assembler generator that emits symbolic instructions focused on debugging and performance diagnostics. The `cobra transpila` command can output Hololang files directly or route them to the `asm` backend to obtain assembly listings.
+Hololang acts as a stable contract between the front-end and the code generators, enabling new targets without touching the original parser. Thanks to this intermediate layer Cobra ships an assembler generator that emits symbolic instructions focused on debugging and performance diagnostics. The `cobra transpilar` command can output Hololang files directly or route them to the `asm` backend to obtain assembly listings.
 
 ## Installation
 

--- a/docs/blog_minilenguaje.md
+++ b/docs/blog_minilenguaje.md
@@ -9,7 +9,7 @@ imprimir("Hola mundo")
 ```
 Para transpilar este código a Python ejecuta:
 ```bash
-cobra archivo.co --to python
+cobra archivo.co --lenguaje python
 ```
 
 ## Referencias

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -32,10 +32,10 @@ Para ejecutar un archivo Cobra desde la línea de comandos:
 cobra archivo.co
 ```
 
-También puedes transpilar el programa a otros lenguajes usando la opción `--to`:
+También puedes transpilar el programa a otros lenguajes usando la opción `--lenguaje` (o su alias `--backend`):
 
 ```bash
-cobra archivo.co --to python
+cobra archivo.co --lenguaje python
 ```
 
 ### Ejecución en GitHub Codespaces


### PR DESCRIPTION
## Summary
- actualiza el README en español e inglés para referenciar el subcomando `cobra transpilar`
- corrige las banderas de la CLI en la guía básica y la entrada del blog del minilenguaje

## Testing
- no tests were run (documentación)


------
https://chatgpt.com/codex/tasks/task_e_68d49a5f6f3c8327aa36b7924b733482