### PR TITLE
Fix CLI parser import and defer CobraHub dependencies

### DIFF
--- a/src/pcobra/cobra/cli/cobrahub_client.py
+++ b/src/pcobra/cobra/cli/cobrahub_client.py
@@ -4,15 +4,14 @@ import os
 import re
 import urllib.parse
 from pathlib import Path
-from typing import Optional, Tuple, Dict
+from typing import Optional, Tuple, Dict, TYPE_CHECKING
 from urllib.parse import urlparse
-
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3 import Retry
 
 from cobra.cli.i18n import _
 from cobra.cli.utils.messages import mostrar_error, mostrar_info
+
+if TYPE_CHECKING:  # pragma: no cover - solo para tipado
+    import requests
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +42,16 @@ class CobraHubClient:
             raise ValueError(_("URL de CobraHub demasiado larga"))
         return url
 
-    def _configurar_sesion(self) -> requests.Session:
+    def _configurar_sesion(self) -> "requests.Session":
         """Configura una sesión HTTP con reintentos y timeouts."""
+        try:
+            import requests
+            from requests.adapters import HTTPAdapter
+            from urllib3 import Retry
+        except ModuleNotFoundError as exc:  # pragma: no cover - error de entorno
+            raise RuntimeError(
+                _("El comando requiere el paquete 'requests'. Instálalo para continuar.")) from exc
+
         session = requests.Session()
         retry_strategy = Retry(
             total=self.MAX_RETRIES,

--- a/src/pcobra/cobra/cli/commands/modules_cmd.py
+++ b/src/pcobra/cobra/cli/commands/modules_cmd.py
@@ -18,8 +18,16 @@ from cobra.cli.utils.semver import es_nueva_version, es_version_valida
 # Configuración de logging
 logger = logging.getLogger(__name__)
 
-# Cliente de CobraHub
-client = CobraHubClient()
+# Cliente de CobraHub (inicializado bajo demanda)
+_client: Optional[CobraHubClient] = None
+
+
+def _get_client() -> CobraHubClient:
+    """Obtiene una instancia única del cliente de CobraHub."""
+    global _client
+    if _client is None:
+        _client = CobraHubClient()
+    return _client
 
 # Constantes
 MODULES_PATH = Path(os.path.dirname(__file__)) / ".." / "modules"
@@ -79,7 +87,7 @@ class ModulesCommand(BaseCommand):
             "listar": self._listar_modulos,
             "instalar": lambda: self._instalar_modulo(args.ruta),
             "remover": lambda: self._remover_modulo(args.nombre),
-            "publicar": lambda: 0 if client.publicar_modulo(args.ruta) else 1,
+            "publicar": lambda: 0 if _get_client().publicar_modulo(args.ruta) else 1,
             "buscar": lambda: self._buscar_modulo(args.nombre)
         }
 
@@ -349,7 +357,7 @@ class ModulesCommand(BaseCommand):
 
         try:
             destino = str(Path(MODULES_PATH) / nombre)
-            ok = client.descargar_modulo(nombre, destino)
+            ok = _get_client().descargar_modulo(nombre, destino)
             if ok:
                 ModulesCommand._actualizar_lock(nombre, None)
             return 0 if ok else 1

--- a/src/pcobra/cobra/cli/utils/argument_parser.py
+++ b/src/pcobra/cobra/cli/utils/argument_parser.py
@@ -3,6 +3,8 @@ from argparse import ArgumentParser
 from cobra.cli.i18n import _
 from cobra.cli.utils import messages
 
+__all__ = ["CustomArgumentParser"]
+
 
 class CustomArgumentParser(ArgumentParser):
     """ArgumentParser personalizado que usa mostrar_error y muestra la ayuda."""


### PR DESCRIPTION
## Summary
- export `CustomArgumentParser` and keep the CLI using the stdlib `ArgumentParser`
- defer optional CobraHub dependencies until runtime and add a clear error when `requests` is missing
- lazily create the CobraHub client inside the modules command to avoid eager imports during CLI startup

## Testing
- python -m compileall src/pcobra/cobra/cli/utils/argument_parser.py
- pytest --no-cov tests/unit/test_custom_argument_parser.py tests/unit/test_cli_default_command.py

------
https://chatgpt.com/codex/tasks/task_e_68d8f9a1727883279451b4db71cdc5fc