### PR TITLE
Refactor AST cache to use database storage

### DIFF
--- a/src/pcobra/cobra/cli/commands/cache_cmd.py
+++ b/src/pcobra/cobra/cli/commands/cache_cmd.py
@@ -1,58 +1,61 @@
 from typing import Any
-from argparse import ArgumentParser
+import sqlite3
+
 from core.ast_cache import limpiar_cache
+from pcobra.core.database import DatabaseDependencyError, DatabaseKeyError
 
 from cobra.cli.commands.base import BaseCommand
 from cobra.cli.i18n import _
 from cobra.cli.utils.argument_parser import CustomArgumentParser
 from cobra.cli.utils.messages import mostrar_info, mostrar_error
 
+
 class CacheCommand(BaseCommand):
-    """Limpia la caché del AST.
-    
-    Este comando elimina todos los archivos temporales generados durante
-    el análisis sintáctico de archivos Cobra.
-    
-    Raises:
-        OSError: Si hay problemas de permisos o E/S al acceder al sistema de archivos
-    """
-    
+    """Limpia la caché del AST basada en la base de datos."""
+
     name: str = "cache"
-    
+
     def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
-        """Registra los argumentos del subcomando.
-        
-        Args:
-            subparsers: Objeto para registrar el subcomando
-            
-        Returns:
-            CustomArgumentParser: El parser configurado para el subcomando
-        """
+        """Registra los argumentos del subcomando."""
+
         parser = subparsers.add_parser(
             self.name, help=_("Elimina los archivos de la caché de AST")
+        )
+        parser.add_argument(
+            "--vacuum",
+            action="store_true",
+            help=_(
+                "Recompacta la base de datos SQLite después de limpiar la caché"
+            ),
         )
         parser.set_defaults(cmd=self)
         return parser
 
     def run(self, args: Any) -> int:
-        """Ejecuta la lógica del comando.
-        
-        Args:
-            args: Argumentos parseados del comando
-            
-        Returns:
-            int: 0 si la operación fue exitosa, 1 en caso de error
-            
-        Raises:
-            OSError: Si hay problemas al acceder al sistema de archivos
-        """
+        """Ejecuta la lógica del comando."""
+
         try:
-            limpiar_cache()
+            limpiar_cache(vacuum=getattr(args, "vacuum", False))
             mostrar_info(_("Caché limpiada exitosamente"))
             return 0
-        except PermissionError:
-            mostrar_error(_("Error de permisos al limpiar la caché"))
+        except DatabaseKeyError:
+            mostrar_error(
+                _(
+                    "No se configuró la clave 'SQLITE_DB_KEY' necesaria para acceder a la caché"
+                )
+            )
             return 1
-        except OSError as e:
-            mostrar_error(_("Error al limpiar la caché: {error}").format(error=str(e)))
+        except DatabaseDependencyError as exc:
+            mostrar_error(
+                _("No fue posible inicializar la base de datos de caché: {error}").format(
+                    error=str(exc)
+                )
+            )
+            return 1
+        except sqlite3.Error as exc:
+            mostrar_error(
+                _("Fallo de conexión con la base de datos de caché: {error}").format(
+                    error=str(exc)
+                )
+            )
             return 1

--- a/src/pcobra/core/ast_cache.py
+++ b/src/pcobra/core/ast_cache.py
@@ -1,16 +1,20 @@
-import os
+"""Capa de compatibilidad para la caché incremental basada en SQLite."""
+
+from __future__ import annotations
+
 import hashlib
 import json
-from dataclasses import is_dataclass, fields
+import logging
+import os
+import warnings
+from dataclasses import fields, is_dataclass
 from enum import Enum
+from pathlib import Path
+from typing import Any, Callable
 
-# Las importaciones de ``Lexer`` y ``Parser`` se realizan de forma
-# perezosa dentro de las funciones para evitar dependencias circulares
-# cuando estos módulos utilizan a su vez la caché incremental.
+from pcobra.core import database
 
-# La caché se almacena en formato JSON para evitar la ejecución de código
-# arbitrario asociada al uso de ``pickle``.
-
+logger = logging.getLogger(__name__)
 
 AST_NODE_CLASS_NAMES = [
     "NodoAST",
@@ -76,45 +80,67 @@ AST_NODE_CLASS_NAMES = [
     "NodoExpresion",
 ]
 
+_NODE_CLASSES: dict[str, type] | None = None
+_ENUM_CLASSES: dict[str, type] | None = None
+_ALIAS_CONFIGURED = False
+_NULL_JSON = json.dumps(None)
+_FULL_TOKENS_KEY = "full_tokens"
+_FRAGMENT_TOKENS_KEY = "fragment_tokens"
+_FRAGMENT_AST_KEY = "fragment_ast"
 
-# -- Serialización -----------------------------------------------------------
 
-_NODE_CLASSES = None
-_ENUM_CLASSES = None
+def _is_token_like(obj: Any) -> bool:
+    try:
+        from pcobra.cobra.core.lexer import Token
+    except ModuleNotFoundError:  # pragma: no cover - entornos acotados
+        Token = None  # type: ignore
+
+    if Token is not None and isinstance(obj, Token):
+        return True
+
+    if obj.__class__.__name__ != "Token":
+        return False
+    return all(hasattr(obj, attr) for attr in ("tipo", "valor", "linea", "columna"))
 
 
-def _get_node_classes():
+def _serialize_token(obj: Any) -> dict[str, Any]:
+    tipo = getattr(obj, "tipo", None)
+    tipo_valor = getattr(tipo, "value", tipo)
+    return {
+        "__token__": True,
+        "tipo": tipo_valor,
+        "valor": getattr(obj, "valor", None),
+        "linea": getattr(obj, "linea", None),
+        "columna": getattr(obj, "columna", None),
+    }
+
+
+def _get_node_classes() -> dict[str, type]:
     global _NODE_CLASSES
     if _NODE_CLASSES is None:
         from core import ast_nodes as _ast_nodes
+
         _NODE_CLASSES = {name: getattr(_ast_nodes, name) for name in AST_NODE_CLASS_NAMES}
     return _NODE_CLASSES
 
 
-def _get_enum_classes():
+def _get_enum_classes() -> dict[str, type]:
     global _ENUM_CLASSES
     if _ENUM_CLASSES is None:
         from pcobra.cobra.core.lexer import TipoToken
+
         _ENUM_CLASSES = {"TipoToken": TipoToken}
     return _ENUM_CLASSES
 
 
-def _serialize(obj):
-    from pcobra.cobra.core.lexer import Token
-
+def _serialize(obj: Any) -> Any:
     if is_dataclass(obj):
-        data = {"__class__": obj.__class__.__name__}
+        data: dict[str, Any] = {"__class__": obj.__class__.__name__}
         for f in fields(obj):
             data[f.name] = _serialize(getattr(obj, f.name))
         return data
-    if isinstance(obj, Token):
-        return {
-            "__token__": True,
-            "tipo": obj.tipo.value,
-            "valor": obj.valor,
-            "linea": obj.linea,
-            "columna": obj.columna,
-        }
+    if _is_token_like(obj):
+        return _serialize_token(obj)
     if isinstance(obj, Enum):
         return {"__enum__": obj.__class__.__name__, "value": obj.value}
     if isinstance(obj, list):
@@ -124,7 +150,7 @@ def _serialize(obj):
     return obj
 
 
-def _deserialize(data):
+def _deserialize(data: Any) -> Any:
     from pcobra.cobra.core.lexer import Token, TipoToken
 
     if isinstance(data, list):
@@ -148,117 +174,232 @@ def _deserialize(data):
     return data
 
 
-# Directorio donde se almacenará el cache de AST. Puede modificarse con la
-# variable de entorno `COBRA_AST_CACHE`.
-CACHE_DIR = os.environ.get(
-    "COBRA_AST_CACHE",
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "cache")),
-)
+def _ensure_alias_configured() -> None:
+    global _ALIAS_CONFIGURED
+    if _ALIAS_CONFIGURED:
+        return
+
+    alias = os.environ.get("COBRA_AST_CACHE")
+    if not alias:
+        _ALIAS_CONFIGURED = True
+        return
+
+    db_path_env = database.COBRA_DB_PATH_ENV
+    key_env = database.SQLITE_DB_KEY_ENV
+    existing_path = os.environ.get(db_path_env)
+    if existing_path:
+        os.environ.setdefault(key_env, existing_path)
+        warnings.warn(
+            "El uso de 'COBRA_AST_CACHE' está obsoleto; utilice 'COBRA_DB_PATH' en su lugar.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        _ALIAS_CONFIGURED = True
+        return
+
+    target = Path(alias).expanduser()
+    if target.suffix.lower() == ".db":
+        db_path = target
+    elif target.is_dir() or not target.suffix:
+        db_path = target / "cache.db"
+    else:
+        db_path = target.with_suffix(".db")
+
+    os.environ[db_path_env] = str(db_path)
+    os.environ.setdefault(key_env, str(db_path))
+    logger.debug("Alias 'COBRA_AST_CACHE' redirigido a %s", db_path)
+    _ALIAS_CONFIGURED = True
 
 
-def _ruta_cache(codigo: str) -> str:
-    """Devuelve la ruta del archivo de cache para un código determinado."""
-    checksum = hashlib.sha256(codigo.encode("utf-8")).hexdigest()
-    return os.path.join(CACHE_DIR, f"{checksum}.ast")
+def _checksum(source: str) -> str:
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()
 
 
-def _ruta_tokens(codigo: str) -> str:
-    """Ruta del archivo cache que almacena los tokens."""
-    checksum = hashlib.sha256(codigo.encode("utf-8")).hexdigest()
-    return os.path.join(CACHE_DIR, f"{checksum}.tok")
+def _encode_payload(obj: Any) -> str:
+    return json.dumps(_serialize(obj), ensure_ascii=False)
+
+
+def _decode_payload(serialized: str) -> Any:
+    return _deserialize(json.loads(serialized))
+
+
+def _with_connection(action: Callable[[Any], Any]) -> Any:
+    _ensure_alias_configured()
+    with database.get_connection() as conn:
+        return action(conn)
+
+
+def _load_ast(hash_key: str) -> Any | None:
+    def _query(conn):
+        cursor = conn.cursor()
+        cursor.execute("SELECT ast_json FROM ast_cache WHERE hash = ?", (hash_key,))
+        row = cursor.fetchone()
+        return row[0] if row else None
+
+    serialized = _with_connection(_query)
+    if not serialized or serialized == _NULL_JSON:
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Cache AST sin datos para hash %s", hash_key)
+        return None
+
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("Cache AST encontrada para hash %s", hash_key)
+    return _decode_payload(serialized)
+
+
+def _store_ast(hash_key: str, source: str, ast_obj: Any) -> None:
+    payload = _encode_payload(ast_obj)
+
+    def _insert(conn):
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO ast_cache(hash, source, ast_json)
+            VALUES (?, ?, ?)
+            ON CONFLICT(hash) DO UPDATE
+            SET source = excluded.source,
+                ast_json = excluded.ast_json,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (hash_key, source, payload),
+        )
+        conn.commit()
+
+    _with_connection(_insert)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("AST almacenado para hash %s", hash_key)
+
+
+def _load_fragment(hash_key: str, fragment_name: str) -> Any | None:
+    def _query(conn):
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT content FROM ast_fragments WHERE hash = ? AND fragment_name = ?",
+            (hash_key, fragment_name),
+        )
+        row = cursor.fetchone()
+        return row[0] if row else None
+
+    serialized = _with_connection(_query)
+    if serialized is None:
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Cache de fragmento '%s' ausente para hash %s", fragment_name, hash_key
+            )
+        return None
+
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            "Cache de fragmento '%s' recuperada para hash %s", fragment_name, hash_key
+        )
+    return _decode_payload(serialized)
+
+
+def _store_fragment(hash_key: str, source: str, fragment_name: str, payload_obj: Any) -> None:
+    payload = _encode_payload(payload_obj)
+
+    def _insert(conn):
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT OR IGNORE INTO ast_cache(hash, source, ast_json)
+            VALUES (?, ?, ?)
+            """,
+            (hash_key, source, _NULL_JSON),
+        )
+        cursor.execute(
+            "UPDATE ast_cache SET source = ? WHERE hash = ?",
+            (source, hash_key),
+        )
+        cursor.execute(
+            """
+            INSERT OR REPLACE INTO ast_fragments(hash, fragment_name, content)
+            VALUES (?, ?, ?)
+            """,
+            (hash_key, fragment_name, payload),
+        )
+        conn.commit()
+
+    _with_connection(_insert)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            "Fragmento '%s' almacenado para hash %s", fragment_name, hash_key
+        )
 
 
 def obtener_tokens(codigo: str):
-    """Obtiene la lista de tokens reutilizando la versión en caché si existe."""
-    os.makedirs(CACHE_DIR, exist_ok=True)
-    ruta = _ruta_tokens(codigo)
+    """Obtiene los tokens reutilizando la caché persistida si existe."""
 
-    if os.path.exists(ruta):
-        with open(ruta, "r", encoding="utf-8") as f:
-            return _deserialize(json.load(f))
+    hash_key = _checksum(codigo)
+    tokens = _load_fragment(hash_key, _FULL_TOKENS_KEY)
+    if tokens is not None:
+        return tokens
 
     from pcobra.cobra.core import Lexer
 
     tokens = Lexer(codigo).tokenizar()
-    with open(ruta, "w", encoding="utf-8") as f:
-        json.dump(_serialize(tokens), f)
-
+    _store_fragment(hash_key, codigo, _FULL_TOKENS_KEY, tokens)
     return tokens
 
 
 def obtener_ast(codigo: str):
-    """Obtiene el AST del codigo reutilizando una version en cache si existe."""
-    os.makedirs(CACHE_DIR, exist_ok=True)
-    ruta = _ruta_cache(codigo)
+    """Obtiene el AST reutilizando la caché persistida si existe."""
 
-    if os.path.exists(ruta):
-        with open(ruta, "r", encoding="utf-8") as f:
-            return _deserialize(json.load(f))
+    hash_key = _checksum(codigo)
+    ast = _load_ast(hash_key)
+    if ast is not None:
+        return ast
 
     tokens = obtener_tokens(codigo)
     from pcobra.cobra.core import Parser
 
     ast = Parser(tokens).parsear()
-
-    with open(ruta, "w", encoding="utf-8") as f:
-        json.dump(_serialize(ast), f)
-
+    _store_ast(hash_key, codigo, ast)
     return ast
 
 
-# -- Almacenamiento por secciones -------------------------------------------
-
-
-def _ruta_fragmento(codigo: str, ext: str) -> str:
-    """Devuelve la ruta del archivo de caché para un fragmento."""
-    checksum = hashlib.sha256(codigo.encode("utf-8")).hexdigest()
-    frag_dir = os.path.join(CACHE_DIR, "fragmentos")
-    os.makedirs(frag_dir, exist_ok=True)
-    return os.path.join(frag_dir, f"{checksum}.{ext}")
-
-
 def obtener_tokens_fragmento(codigo: str):
-    """Devuelve los tokens de un fragmento, reutilizando la caché si existe."""
-    ruta = _ruta_fragmento(codigo, "tok")
-    if os.path.exists(ruta):
-        with open(ruta, "r", encoding="utf-8") as f:
-            return _deserialize(json.load(f))
+    """Obtiene los tokens de un fragmento reutilizando la caché si existe."""
+
+    hash_key = _checksum(codigo)
+    tokens = _load_fragment(hash_key, _FRAGMENT_TOKENS_KEY)
+    if tokens is not None:
+        return tokens
 
     from pcobra.cobra.core import Lexer
 
     tokens = Lexer(codigo).tokenizar()
-    with open(ruta, "w", encoding="utf-8") as f:
-        json.dump(_serialize(tokens), f)
+    _store_fragment(hash_key, codigo, _FRAGMENT_TOKENS_KEY, tokens)
     return tokens
 
 
 def obtener_ast_fragmento(codigo: str):
     """Obtiene el AST de un fragmento reutilizando la caché si existe."""
-    ruta = _ruta_fragmento(codigo, "ast")
-    if os.path.exists(ruta):
-        with open(ruta, "r", encoding="utf-8") as f:
-            return _deserialize(json.load(f))
+
+    hash_key = _checksum(codigo)
+    ast = _load_fragment(hash_key, _FRAGMENT_AST_KEY)
+    if ast is not None:
+        return ast
 
     tokens = obtener_tokens_fragmento(codigo)
     from pcobra.cobra.core import Parser
 
     ast = Parser(tokens).parsear()
-    with open(ruta, "w", encoding="utf-8") as f:
-        json.dump(_serialize(ast), f)
+    _store_fragment(hash_key, codigo, _FRAGMENT_AST_KEY, ast)
     return ast
 
 
-def limpiar_cache():
-    """Elimina todos los archivos de cache generados."""
-    if not os.path.isdir(CACHE_DIR):
-        return
-    for nombre in os.listdir(CACHE_DIR):
-        ruta = os.path.join(CACHE_DIR, nombre)
-        if os.path.isfile(ruta) and (
-            nombre.endswith(".ast") or nombre.endswith(".tok")
-        ):
-            os.remove(ruta)
-        elif os.path.isdir(ruta) and nombre == "fragmentos":
-            for archivo in os.listdir(ruta):
-                os.remove(os.path.join(ruta, archivo))
-            os.rmdir(ruta)
+def limpiar_cache(*, vacuum: bool = False) -> None:
+    """Elimina todas las entradas de la caché persistida."""
+
+    def _wipe(conn):
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM ast_fragments")
+        cursor.execute("DELETE FROM ast_cache")
+        conn.commit()
+        if vacuum:
+            conn.execute("VACUUM")
+
+    _with_connection(_wipe)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("Caché de AST limpiada (vacuum=%s)", vacuum)

--- a/tests/unit/test_ast_cache.py
+++ b/tests/unit/test_ast_cache.py
@@ -1,17 +1,58 @@
-import os
+import importlib
+import sqlite3
+import sys
+
 import pytest
-from cobra.core import Parser
+from pcobra.cobra.core import Lexer, Parser
+import pcobra.core.database as core_database
+
+
+def _reload_ast_cache(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("COBRA_AST_CACHE", str(cache_dir))
+    monkeypatch.delenv("SQLITE_DB_KEY", raising=False)
+    monkeypatch.delenv("COBRA_DB_PATH", raising=False)
+    database_module = importlib.reload(core_database)
+
+    class SQLitePlusStub:
+        def __init__(self, db_path: str, cipher_key: str | None = None):
+            self._db_path = db_path
+
+        def get_connection(self):
+            conn = sqlite3.connect(self._db_path)
+            conn.execute("PRAGMA foreign_keys = ON")
+            return conn
+
+    monkeypatch.setattr(
+        database_module,
+        "_load_sqliteplus_class",
+        lambda: SQLitePlusStub,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        database_module, "_SQLITEPLUS_CLASS", SQLitePlusStub, raising=False
+    )
+    monkeypatch.setattr(
+        database_module, "_SQLITEPLUS_INSTANCE", None, raising=False
+    )
+
+    sys.modules.pop("core.ast_cache", None)
+    module = importlib.import_module("core.ast_cache")
+    return module, cache_dir
+
+
+def _db_path(cache_dir):
+    return cache_dir / "cache.db"
+
+
+def _count_rows(db_path, table):
+    with sqlite3.connect(db_path) as conn:
+        cursor = conn.execute(f"SELECT COUNT(*) FROM {table}")
+        return cursor.fetchone()[0]
 
 
 def test_obtener_ast_reutiliza(monkeypatch, tmp_path):
-    # Redirigir el directorio de cache a una carpeta temporal
-    cache_dir = tmp_path / "cache"
-    monkeypatch.setenv("COBRA_AST_CACHE", str(cache_dir))
-
-    import importlib, sys
-    if 'core.ast_cache' in sys.modules:
-        importlib.reload(sys.modules['core.ast_cache'])
-    from core.ast_cache import obtener_ast
+    ast_cache, cache_dir = _reload_ast_cache(monkeypatch, tmp_path)
 
     llamadas = {"count": 0}
 
@@ -22,28 +63,89 @@ def test_obtener_ast_reutiliza(monkeypatch, tmp_path):
     monkeypatch.setattr(Parser, "parsear", fake_parsear)
 
     codigo = "var x = 1"
-    obtener_ast(codigo)
-    obtener_ast(codigo)
+    ast_cache.obtener_ast(codigo)
+    ast_cache.obtener_ast(codigo)
 
     assert llamadas["count"] == 1
-    # Se creó un único archivo en la caché
-    archivos = list(cache_dir.glob("*.ast"))
-    assert len(archivos) == 1
+    assert _count_rows(_db_path(cache_dir), "ast_cache") == 1
 
 
 @pytest.mark.timeout(5)
 def test_limpiar_cache(monkeypatch, tmp_path):
-    cache_dir = tmp_path / "cache"
-    monkeypatch.setenv("COBRA_AST_CACHE", str(cache_dir))
+    ast_cache, cache_dir = _reload_ast_cache(monkeypatch, tmp_path)
     codigo = "var y = 2"
 
-    import importlib, sys
-    if 'core.ast_cache' in sys.modules:
-        importlib.reload(sys.modules['core.ast_cache'])
-    from core.ast_cache import obtener_ast, limpiar_cache
+    monkeypatch.setattr(Parser, "parsear", lambda self: [])
+    ast_cache.obtener_ast(codigo)
+    assert _count_rows(_db_path(cache_dir), "ast_cache") > 0
 
-    obtener_ast(codigo)
-    assert list(cache_dir.glob("*.ast"))
+    ast_cache.limpiar_cache(vacuum=True)
+    assert _count_rows(_db_path(cache_dir), "ast_cache") == 0
+    assert _count_rows(_db_path(cache_dir), "ast_fragments") == 0
 
-    limpiar_cache()
-    assert list(cache_dir.glob("*.ast")) == []
+
+def test_obtener_tokens_reutiliza(monkeypatch, tmp_path):
+    ast_cache, cache_dir = _reload_ast_cache(monkeypatch, tmp_path)
+
+    llamadas = {"count": 0}
+
+    def fake_tokenizar(self):
+        llamadas["count"] += 1
+        return []
+
+    monkeypatch.setattr(Lexer, "tokenizar", fake_tokenizar)
+
+    codigo = "var z = 3"
+    ast_cache.obtener_tokens(codigo)
+    ast_cache.obtener_tokens(codigo)
+
+    assert llamadas["count"] == 1
+    assert _count_rows(_db_path(cache_dir), "ast_fragments") == 1
+
+
+def test_obtener_ast_reutiliza_tokens(monkeypatch, tmp_path):
+    ast_cache, cache_dir = _reload_ast_cache(monkeypatch, tmp_path)
+
+    token_calls = {"count": 0}
+    parse_calls = {"count": 0}
+
+    def fake_tokenizar(self):
+        token_calls["count"] += 1
+        return []
+
+    def fake_parsear(self):
+        parse_calls["count"] += 1
+        return []
+
+    monkeypatch.setattr(Lexer, "tokenizar", fake_tokenizar)
+    monkeypatch.setattr(Parser, "parsear", fake_parsear)
+
+    codigo = "var a = 5"
+    ast_cache.obtener_ast(codigo)
+
+    with sqlite3.connect(_db_path(cache_dir)) as conn:
+        conn.execute("UPDATE ast_cache SET ast_json = 'null'")
+        conn.commit()
+
+    ast_cache.obtener_ast(codigo)
+
+    assert token_calls["count"] == 1
+    assert parse_calls["count"] == 2
+
+
+def test_cache_fragmentos(monkeypatch, tmp_path):
+    ast_cache, cache_dir = _reload_ast_cache(monkeypatch, tmp_path)
+
+    llamadas = {"count": 0}
+
+    def fake_tokenizar(self, *a, **k):
+        llamadas["count"] += 1
+        return []
+
+    monkeypatch.setattr(Lexer, "_tokenizar_base", fake_tokenizar, raising=False)
+
+    codigo = "imprimir(1)\n"
+    ast_cache.obtener_tokens_fragmento(codigo)
+    ast_cache.obtener_tokens_fragmento(codigo)
+    assert llamadas["count"] == 1
+    assert _count_rows(_db_path(cache_dir), "ast_fragments") >= 1


### PR DESCRIPTION
## Summary
- rewrite the AST cache to persist tokens and ASTs in the SQLite-based adapter with JSON serialization, alias handling, and optional logging
- add a vacuum option and database error reporting to the cache CLI command
- refresh unit tests to exercise the new database-backed cache and security checks

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts= tests/unit/test_ast_cache.py tests/unit/test_token_cache.py tests/unit/test_ast_cache_security.py

------
https://chatgpt.com/codex/tasks/task_e_68d91ca72adc8327a4a48648bae53665