### PR TITLE
Refactorizar persistencia de qualia usando base de datos

### DIFF
--- a/src/pcobra/core/qualia_bridge.py
+++ b/src/pcobra/core/qualia_bridge.py
@@ -1,9 +1,11 @@
 import json
+import logging
 import os
 from pathlib import Path
-from typing import List, Union
+from typing import Any, List, Union
 
 from pcobra.cobra.core import Lexer, Parser
+from core import database
 from core.qualia_knowledge import QualiaKnowledge
 
 
@@ -30,7 +32,10 @@ def _resolve_state_file() -> str:
     return path
 
 
-STATE_FILE = _resolve_state_file()
+LEGACY_STATE_FILE = _resolve_state_file()
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class QualiaSpirit:
@@ -65,48 +70,107 @@ class QualiaSpirit:
             and self.knowledge.modules_used.get("matplotlib", 0) == 0
         ):
             sugerencias.append(
-                "Si usas pandas, podr\u00edas utilizar matplotlib para graficar."
+                "Si usas pandas, podrías utilizar matplotlib para graficar."
             )
 
         if not sugerencias:
-            sugerencias.append("\u00a1Sigue as\u00ed!")
+            sugerencias.append("¡Sigue así!")
 
         return sugerencias
 
 
-def load_state() -> QualiaSpirit:
-    """Carga el estado del ``QualiaSpirit`` desde ``STATE_FILE``."""
-    if os.path.exists(STATE_FILE):
-        with open(STATE_FILE, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-        spirit = QualiaSpirit()
-        spirit.history = data.get("history", [])
-        spirit.knowledge = QualiaKnowledge.from_dict(data.get("knowledge", {}))
+def _payload_to_dict(payload: Any) -> dict[str, Any] | None:
+    """Convierte el ``payload`` obtenido de la base de datos en un diccionario."""
+
+    if payload is None:
+        return None
+    if isinstance(payload, memoryview):  # pragma: no cover - ruta dependiente de sqlite
+        payload = payload.tobytes()
+    if isinstance(payload, (bytes, bytearray)):
+        payload = payload.decode("utf-8")
+    if isinstance(payload, str):
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError as exc:  # pragma: no cover - corrupción inesperada
+            LOGGER.warning("No se pudo decodificar el estado guardado: %s", exc)
+            return None
+    LOGGER.warning("Tipo de payload inesperado: %s", type(payload).__name__)
+    return None
+
+
+def _build_spirit(data: dict[str, Any] | None) -> QualiaSpirit:
+    spirit = QualiaSpirit()
+    if not data:
         return spirit
-    return QualiaSpirit()
+    spirit.history = list(data.get("history", []))
+    spirit.knowledge = QualiaKnowledge.from_dict(data.get("knowledge", {}))
+    return spirit
+
+
+def _migrate_legacy_state(cursor, conn) -> dict[str, Any] | None:
+    """Migra el estado almacenado en el archivo JSON heredado."""
+
+    if not os.path.exists(LEGACY_STATE_FILE):
+        return None
+
+    if os.path.islink(LEGACY_STATE_FILE) or Path(LEGACY_STATE_FILE).is_symlink():
+        raise ValueError("QUALIA_STATE_PATH se convirtió en un enlace simbólico")
+
+    with open(LEGACY_STATE_FILE, "r", encoding="utf-8") as fh:
+        legacy_data = json.load(fh)
+
+    payload = json.dumps(legacy_data, ensure_ascii=False)
+    cursor.execute(
+        "INSERT OR REPLACE INTO qualia_state(id, payload) VALUES (1, ?)",
+        (payload,),
+    )
+    conn.commit()
+
+    try:
+        os.remove(LEGACY_STATE_FILE)
+    except OSError as exc:  # pragma: no cover - casos poco comunes
+        LOGGER.warning(
+            "No se pudo eliminar el archivo de estado heredado %s: %s",
+            LEGACY_STATE_FILE,
+            exc,
+        )
+    else:
+        LOGGER.info("Migrado el estado de qualia desde %s", LEGACY_STATE_FILE)
+
+    return legacy_data
+
+
+def load_state() -> QualiaSpirit:
+    """Carga el estado del ``QualiaSpirit`` desde la base de datos."""
+
+    with database.get_connection() as conn:
+        cursor = conn.cursor()
+        data = _migrate_legacy_state(cursor, conn)
+        if data is None:
+            cursor.execute("SELECT payload FROM qualia_state WHERE id = 1")
+            row = cursor.fetchone()
+            data = _payload_to_dict(row[0]) if row else None
+    return _build_spirit(data)
 
 
 def save_state(spirit: QualiaSpirit) -> None:
-    """Guarda el estado de ``spirit`` en ``STATE_FILE``."""
-    os.makedirs(os.path.dirname(STATE_FILE), mode=0o700, exist_ok=True)
+    """Guarda el estado de ``spirit`` en la base de datos."""
 
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
-    fd = os.open(STATE_FILE, flags, 0o600)
-    if os.path.islink(STATE_FILE) or Path(STATE_FILE).is_symlink():
-        os.close(fd)
-        raise ValueError("QUALIA_STATE_PATH se convirti\u00f3 en un enlace simb\u00f3lico")
+    payload = json.dumps(
+        {
+            "history": spirit.history,
+            "knowledge": spirit.knowledge.as_dict(),
+        },
+        ensure_ascii=False,
+    )
 
-    os.fchmod(fd, 0o600)
-    with os.fdopen(fd, "w", encoding="utf-8") as fh:
-        json.dump(
-            {
-                "history": spirit.history,
-                "knowledge": spirit.knowledge.as_dict(),
-            },
-            fh,
-            ensure_ascii=False,
-            indent=2,
+    with database.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT OR REPLACE INTO qualia_state(id, payload) VALUES (1, ?)",
+            (payload,),
         )
+        conn.commit()
 
 
 QUALIA = load_state()

--- a/tests/unit/test_qualia_bridge.py
+++ b/tests/unit/test_qualia_bridge.py
@@ -1,84 +1,173 @@
 import importlib
 import json
-import os
+import sqlite3
+import sys
+from pathlib import Path
+
 import pytest
-from core import qualia_bridge
+
+MODULE_ALIASES = (
+    "core.qualia_bridge",
+    "pcobra.core.qualia_bridge",
+)
+DATABASE_ALIASES = (
+    "core.database",
+    "pcobra.core.database",
+)
+
+
+def _configure_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    db_path = tmp_path / "core.db"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("SQLITE_DB_KEY", str(db_path))
+    monkeypatch.setenv("COBRA_DB_PATH", str(db_path))
+    monkeypatch.delenv("QUALIA_STATE_PATH", raising=False)
+    return home
+
+
+def _clear_modules() -> None:
+    for name in MODULE_ALIASES + DATABASE_ALIASES:
+        sys.modules.pop(name, None)
+
+
+def _reload_qualia(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    home = _configure_env(tmp_path, monkeypatch)
+    _clear_modules()
+    db_module = importlib.import_module("pcobra.core.database")
+    _install_sqlite_stub(db_module, monkeypatch)
+    sys.modules.setdefault("core.database", db_module)
+    module = importlib.import_module("core.qualia_bridge")
+    module = importlib.reload(module)
+    _install_parser_stub(module, monkeypatch)
+    return module, home
+
+
+def _install_sqlite_stub(db_module, monkeypatch: pytest.MonkeyPatch) -> None:
+    class StubSQLitePlus:
+        def __init__(self, db_path: str, cipher_key: str | None = None) -> None:
+            self._db_path = db_path
+
+        def get_connection(self):
+            conn = sqlite3.connect(self._db_path)
+            conn.row_factory = sqlite3.Row
+            return conn
+
+    monkeypatch.setattr(db_module, "_SQLITEPLUS_CLASS", None, raising=False)
+    monkeypatch.setattr(db_module, "_SQLITEPLUS_INSTANCE", None, raising=False)
+    monkeypatch.setattr(db_module, "_TABLES_READY", False, raising=False)
+    monkeypatch.setattr(db_module, "_load_sqliteplus_class", lambda: StubSQLitePlus)
+
+
+def _install_parser_stub(module, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _make_node(name: str, **attrs):
+        cls = type(name, (), {})
+        obj = cls()
+        for key, value in attrs.items():
+            setattr(obj, key, value)
+        return obj
+
+    class StubLexer:
+        def __init__(self, source: str) -> None:
+            self._source = source
+
+        def analizar_token(self):
+            return self._source
+
+    class StubParser:
+        def __init__(self, tokens: str) -> None:
+            self._source = tokens
+
+        def parsear(self):
+            nodes = []
+            text = self._source
+            if "imprimir" in text:
+                nodes.append(_make_node("NodoImprimir"))
+            if "var " in text:
+                try:
+                    nombre = text.split("var ", 1)[1].split("=", 1)[0].strip()
+                except IndexError:  # pragma: no cover - entradas malformadas
+                    nombre = "x"
+                nodes.append(_make_node("NodoAsignacion", nombre=nombre))
+            if "usar" in text and "pandas" in text:
+                nodes.append(_make_node("NodoUsar", modulo="pandas"))
+            return nodes
+
+    monkeypatch.setattr(module, "Lexer", StubLexer)
+    monkeypatch.setattr(module, "Parser", StubParser)
 
 
 def test_qualia_state_persistence(tmp_path, monkeypatch):
-    state = tmp_path / ".cobra" / "state.json"
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
-    qb = importlib.reload(qualia_bridge)
-    qb.register_execution("var x = 1")
-    assert state.exists()
-    qb2 = importlib.reload(qualia_bridge)
-    assert "var x = 1" in qb2.QUALIA.history
+    module, _ = _reload_qualia(tmp_path, monkeypatch)
+    module.register_execution("var x = 1")
+
+    with module.database.get_connection() as conn:
+        row = conn.execute("SELECT payload FROM qualia_state WHERE id = 1").fetchone()
+    assert row is not None
+    payload = json.loads(row[0])
+    assert "var x = 1" in payload["history"]
+
+    module, _ = _reload_qualia(tmp_path, monkeypatch)
+    assert "var x = 1" in module.QUALIA.history
 
 
 def test_qualia_generates_suggestions(tmp_path, monkeypatch):
-    state = tmp_path / ".cobra" / "state.json"
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
-    qb = importlib.reload(qualia_bridge)
-    qb.register_execution("var x = 1")
-    sugs = qb.get_suggestions()
+    module, _ = _reload_qualia(tmp_path, monkeypatch)
+    module.register_execution("var x = 1")
+    sugs = module.get_suggestions()
     assert any("imprimir" in s for s in sugs)
 
 
 def test_knowledge_persistence(tmp_path, monkeypatch):
-    state = tmp_path / ".cobra" / "state.json"
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
-    qb = importlib.reload(qualia_bridge)
-    qb.register_execution("imprimir(1)")
-    data = json.loads(state.read_text())
-    assert "knowledge" in data
+    module, _ = _reload_qualia(tmp_path, monkeypatch)
+    module.register_execution("imprimir(1)")
+
+    with module.database.get_connection() as conn:
+        row = conn.execute("SELECT payload FROM qualia_state WHERE id = 1").fetchone()
+    data = json.loads(row[0])
     assert data["knowledge"]["node_counts"].get("NodoImprimir")
 
 
 def test_sugerir_funciones_por_asignaciones(tmp_path, monkeypatch):
-    state = tmp_path / ".cobra" / "state.json"
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
-    qb = importlib.reload(qualia_bridge)
+    module, _ = _reload_qualia(tmp_path, monkeypatch)
     for i in range(5):
-        qb.register_execution(f"var v{i} = {i}")
-    sugs = qb.get_suggestions()
+        module.register_execution(f"var v{i} = {i}")
+    sugs = module.get_suggestions()
     assert any("funciones" in s for s in sugs)
     assert any("nombres descriptivos" in s for s in sugs)
 
 
 def test_sugerencia_pandas_matplotlib(tmp_path, monkeypatch):
-    state = tmp_path / ".cobra" / "state.json"
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
-    qb = importlib.reload(qualia_bridge)
-    qb.register_execution('usar "pandas"')
-    sugs = qb.get_suggestions()
+    module, _ = _reload_qualia(tmp_path, monkeypatch)
+    module.register_execution('usar "pandas"')
+    sugs = module.get_suggestions()
     assert any("matplotlib" in s for s in sugs)
 
 
 def test_qualia_rejects_outside_home(tmp_path, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path))
+    home = _configure_env(tmp_path, monkeypatch)
     monkeypatch.setenv("QUALIA_STATE_PATH", "/etc/passwd")
+    _clear_modules()
     with pytest.raises(ValueError):
-        importlib.reload(qualia_bridge)
+        importlib.import_module("core.qualia_bridge")
+    monkeypatch.delenv("QUALIA_STATE_PATH", raising=False)
+    assert not (home / "qualia_state.json").exists()
 
 
 def test_qualia_rejects_traversal(tmp_path, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _configure_env(tmp_path, monkeypatch)
     evil = tmp_path / ".." / "mal.json"
     monkeypatch.setenv("QUALIA_STATE_PATH", str(evil))
+    _clear_modules()
     with pytest.raises(ValueError):
-        importlib.reload(qualia_bridge)
+        importlib.import_module("core.qualia_bridge")
 
 
 def test_qualia_rejects_symlink(tmp_path, monkeypatch):
-    """El path no debe ser un enlace simbólico que apunte fuera de ~/.cobra."""
-    home = tmp_path
+    home = _configure_env(tmp_path, monkeypatch)
     cobra_dir = home / ".cobra"
-    cobra_dir.mkdir()
+    cobra_dir.mkdir(exist_ok=True)
 
     target = home / "outside.json"
     target.write_text("{}")
@@ -86,55 +175,57 @@ def test_qualia_rejects_symlink(tmp_path, monkeypatch):
     link = cobra_dir / "state.json"
     link.symlink_to(target)
 
-    monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("QUALIA_STATE_PATH", str(link))
-
+    _clear_modules()
     with pytest.raises(ValueError):
-        importlib.reload(qualia_bridge)
+        importlib.import_module("core.qualia_bridge")
 
 
-def test_state_file_permissions(tmp_path, monkeypatch):
-    state = tmp_path / ".cobra" / "state.json"
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
-    qb = importlib.reload(qualia_bridge)
-    qb.register_execution("var x = 1")
-    if os.name == "posix":
-        assert state.exists()
-        mode = state.stat().st_mode & 0o777
-        assert mode == 0o600
+def test_migrates_legacy_state(tmp_path, monkeypatch, caplog):
+    home = _configure_env(tmp_path, monkeypatch)
+    legacy_file = home / ".cobra" / "qualia_state.json"
+    legacy_file.parent.mkdir(parents=True, exist_ok=True)
+    legacy_payload = {
+        "history": ["print('hola')"],
+        "knowledge": {"node_counts": {"NodoImprimir": 1}},
+    }
+    legacy_file.write_text(json.dumps(legacy_payload, ensure_ascii=False), encoding="utf-8")
+
+    caplog.set_level("INFO")
+    module, _ = _reload_qualia(tmp_path, monkeypatch)
+
+    assert not legacy_file.exists()
+    assert "Migrado el estado de qualia" in caplog.text
+
+    with module.database.get_connection() as conn:
+        row = conn.execute("SELECT payload FROM qualia_state WHERE id = 1").fetchone()
+    assert row is not None
+    data = json.loads(row[0])
+    assert data["history"] == legacy_payload["history"]
+
+    module = importlib.reload(module)
+    assert module.QUALIA.history == legacy_payload["history"]
 
 
-def test_state_dir_permissions(tmp_path, monkeypatch):
-    state = tmp_path / ".cobra" / "state.json"
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
-    qb = importlib.reload(qualia_bridge)
-    qb.register_execution("var x = 1")
-    dir_path = state.parent
-    # Elimina el directorio para probar la creación con permisos
-    for child in dir_path.glob("*"):
-        if child.is_file() or child.is_symlink():
-            child.unlink()
-    dir_path.rmdir()
-    qb.save_state(qb.QUALIA)
-    if os.name == "posix":
-        mode = dir_path.stat().st_mode & 0o777
-        assert mode == 0o700
+def test_load_state_recovers_existing_data(tmp_path, monkeypatch):
+    module, _ = _reload_qualia(tmp_path, monkeypatch)
+    payload = {
+        "history": ["persisted()"],
+        "knowledge": {
+            "node_counts": {"NodoAsignacion": 3},
+            "patterns": ["lambda"],
+            "variable_names": {"abc": 2},
+            "modules_used": {"pandas": 1},
+        },
+    }
+    with module.database.get_connection() as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO qualia_state(id, payload) VALUES (1, ?)",
+            (json.dumps(payload, ensure_ascii=False),),
+        )
+        conn.commit()
 
-
-def test_symlink_created_after_resolve(tmp_path, monkeypatch):
-    home = tmp_path
-    state = home / ".cobra" / "state.json"
-    monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
-    qb = importlib.reload(qualia_bridge)
-
-    state.parent.mkdir(parents=True, exist_ok=True)
-    target = home / "outside.json"
-    target.write_text("{}")
-    state.symlink_to(target)
-
-    with pytest.raises(OSError):
-        qb.save_state(qb.QUALIA)
-
+    module, _ = _reload_qualia(tmp_path, monkeypatch)
+    assert module.QUALIA.history == ["persisted()"]
+    assert module.QUALIA.knowledge.node_counts["NodoAsignacion"] == 3
+    assert "lambda" in module.QUALIA.knowledge.patterns


### PR DESCRIPTION
## Summary
- persist the Qualia state in the qualia_state table with explicit SELECT/INSERT logic and migrate any legacy JSON file once
- log migration events while keeping QualiaSpirit reconstruction consistent with the previous behaviour
- add unit tests with database and parser stubs to cover migration, persistence, and state recovery scenarios

## Testing
- pytest -o addopts= tests/unit/test_qualia_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68d925896d54832793b3e26c8f20a90e