### PR TITLE
Integrate CLI entrypoint with CliApplication and add subprocess tests

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -1,28 +1,21 @@
-import argparse
-import contextlib
-import io
 import logging
 import sys
 from typing import List, Optional
-
-from . import cobra as cobra_pkg
-from . import core as core_pkg
-from . import compiler as compiler_pkg
-
-# Registrar alias de paquetes para compatibilidad con imports absolutos
-sys.modules.setdefault("cobra", cobra_pkg)
-sys.modules.setdefault("core", core_pkg)
-sys.modules.setdefault("compiler", compiler_pkg)
-
-import re
 
 try:
     from dotenv import load_dotenv
 except ModuleNotFoundError:  # pragma: no cover - rama dependiente del entorno
     load_dotenv = None
-from .cobra.cli.commands.compile_cmd import CompileCommand, LANG_CHOICES
-from .cobra.cli.commands.execute_cmd import ExecuteCommand
-from .cobra.cli.utils import messages
+
+from . import cobra as cobra_pkg
+from . import compiler as compiler_pkg
+from . import core as core_pkg
+from .cobra.cli.cli import CliApplication
+
+# Registrar alias de paquetes para compatibilidad con imports absolutos
+sys.modules.setdefault("cobra", cobra_pkg)
+sys.modules.setdefault("core", core_pkg)
+sys.modules.setdefault("compiler", compiler_pkg)
 
 logger = logging.getLogger(__name__)
 
@@ -46,101 +39,11 @@ def configurar_entorno() -> None:
         logger.warning("El archivo .env no se cargó")
 
 
-cobra = argparse.ArgumentParser(prog="cobra")
-subparsers = cobra.add_subparsers(dest="comando")
-
-ejecutar_parser = subparsers.add_parser(
-    "ejecutar", help="Ejecuta un programa Cobra"
-)
-ejecutar_parser.add_argument(
-    "archivo", help="Ruta al archivo a ejecutar"
-)
-ejecutar_parser.add_argument(
-    "--sandbox", action="store_true", help="Ejecuta el código en una sandbox"
-)
-ejecutar_parser.add_argument(
-    "--contenedor",
-    choices=["python", "js", "cpp", "rust"],
-    help="Ejecuta el código en un contenedor Docker",
-)
-
-transpilar_parser = subparsers.add_parser(
-    "transpilar", help="Transpila código Cobra"
-)
-transpilar_parser.add_argument(
-    "archivo", help="Ruta al archivo a transpilar"
-)
-transpilar_parser.add_argument(
-    "--a", "--lenguaje",
-    dest="lenguaje",
-    choices=LANG_CHOICES,
-    default="python",
-    help="Lenguaje de salida",
-)
-transpilar_parser.add_argument(
-    "--backend",
-    dest="backend",
-    choices=LANG_CHOICES,
-    default=None,
-    help="Alias de --lenguaje para integraciones",
-)
-transpilar_parser.add_argument(
-    "--o", "--salida",
-    dest="salida",
-    help="Archivo donde guardar el código generado",
-)
-
-def mostrar_ayuda(_: argparse.Namespace) -> int:
-    """Imprime la ayuda general del programa."""
-    cobra.print_help()
-    return 0
-
-
-ayuda_parser = subparsers.add_parser("ayuda", help="Muestra esta ayuda y sale")
-ayuda_parser.set_defaults(func=mostrar_ayuda)
-
-
 def main(argumentos: Optional[List[str]] = None) -> int:
     """Punto de entrada principal para la ejecución del CLI."""
     configurar_entorno()
-    args = cobra.parse_args(argumentos)
-    if args.comando is None:
-        cobra.print_help()
-        return 0
-    if args.comando == "ejecutar":
-        comando = ExecuteCommand()
-        try:
-            return comando.run(args)
-        except Exception as exc:  # pragma: no cover - captura errores imprevistos
-            logger.error("Error al ejecutar: %s", exc)
-            return 1
-    if args.comando == "transpilar":
-        comando = CompileCommand()
-        compile_args = argparse.Namespace(
-            archivo=args.archivo,
-            tipo=args.lenguaje,
-            backend=getattr(args, "backend", None),
-            tipos=None,
-        )
-        if args.salida:
-            messages.disable_colors()
-            buffer = io.StringIO()
-            with contextlib.redirect_stdout(buffer):
-                resultado = comando.run(compile_args)
-            output = buffer.getvalue()
-            output = re.sub(r"\x1b\[[0-9;]*m", "", output)
-            lineas = [l for l in output.splitlines() if not l.startswith("Código generado")]
-            output = "\n".join(lineas)
-            if output and not output.endswith("\n"):
-                output += "\n"
-            with open(args.salida, "w", encoding="utf-8") as f:
-                f.write(output)
-            return resultado
-        return comando.run(compile_args)
-    if args.comando == "ayuda":
-        return args.func(args)
-    cobra.print_help()
-    return 1
+    aplicacion = CliApplication()
+    return aplicacion.run(argumentos)
 
 
 if __name__ == "__main__":

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -28,6 +28,7 @@ from cobra.cli.commands.execute_cmd import ExecuteCommand
 from cobra.cli.commands.flet_cmd import FletCommand
 from cobra.cli.commands.init_cmd import InitCommand
 from cobra.cli.commands.interactive_cmd import InteractiveCommand
+from cobra.cli.commands.agix_cmd import AgixCommand
 from core.interpreter import InterpretadorCobra
 from cobra.cli.commands.jupyter_cmd import JupyterCommand
 from cobra.cli.commands.modules_cmd import ModulesCommand
@@ -74,7 +75,7 @@ class AppConfig:
         BenchTranspilersCommand, BenchThreadsCommand,
         ProfileCommand, QualiaCommand, CacheCommand,
         TranspilarInversoCommand, VerifyCommand,
-        PluginsCommand
+        PluginsCommand, AgixCommand
     ]
 
 

--- a/tests/unit/test_cli_entrypoint_subprocess.py
+++ b/tests/unit/test_cli_entrypoint_subprocess.py
@@ -1,0 +1,395 @@
+"""Pruebas de extremo a extremo para el punto de entrada de ``cobra``.
+
+Estas pruebas ejecutan comandos reales de la CLI en un subproceso para
+verificar que la aplicación principal cargue todos los subcomandos
+registrados y que pueda funcionar en un entorno sin las dependencias
+opcionales instaladas. Para evitar instalar paquetes pesados se crean
+"stubs" temporales que satisfacen las importaciones requeridas por la
+CLI completa.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_stub(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dedent(content).lstrip(), encoding="utf-8")
+
+
+def _create_stub_environment(tmp_path: Path) -> dict[str, str]:
+    stubs_dir = tmp_path / "stubs"
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    requirements = """\
+    numpy==1.0.0
+    cobra-lib==0.0.1
+    """
+    (project_root / "requirements.txt").write_text(dedent(requirements).strip(), encoding="utf-8")
+
+    pyproject = """\
+    [project]
+    dependencies = [
+        "pandas==1.0.0",
+        "matplotlib==1.0.0",
+    ]
+    """
+    (project_root / "pyproject.toml").write_text(dedent(pyproject).strip(), encoding="utf-8")
+
+    _write_stub(
+        stubs_dir / "yaml.py",
+        """
+        class YAMLError(Exception):
+            pass
+
+        def safe_load(_stream):
+            return {}
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "jsonschema.py",
+        """
+        class ValidationError(Exception):
+            pass
+
+        def validate(*_args, **_kwargs):
+            return None
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "RestrictedPython/__init__.py",
+        """
+        def compile_restricted(source, filename, mode):
+            return compile(source, filename, mode)
+
+        safe_builtins = {}
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "RestrictedPython/Eval/__init__.py",
+        """
+        def default_guarded_getitem(*_args, **_kwargs):
+            return None
+
+        def default_guarded_getattr(*_args, **_kwargs):
+            return None
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "RestrictedPython/Guards/__init__.py",
+        """
+        def guarded_iter_unpack_sequence(*_args, **_kwargs):
+            return None
+
+        def guarded_unpack_sequence(*_args, **_kwargs):
+            return None
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "RestrictedPython/PrintCollector/__init__.py",
+        """
+        class PrintCollector:
+            def __call__(self):
+                return ""
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "argcomplete/__init__.py",
+        """
+        def autocomplete(_parser, **_kwargs):
+            return None
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "argcomplete/completers.py",
+        """
+        class FilesCompleter:
+            def __call__(self, *_args, **_kwargs):
+                return []
+
+        class DirectoriesCompleter(FilesCompleter):
+            pass
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "prompt_toolkit/__init__.py",
+        """
+        class PromptSession:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def prompt(self, *_args, **_kwargs):
+                return ""
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "prompt_toolkit/lexers.py",
+        """
+        class PygmentsLexer:
+            def __init__(self, *_args, **_kwargs):
+                pass
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "prompt_toolkit/history.py",
+        """
+        class FileHistory:
+            def __init__(self, *_args, **_kwargs):
+                pass
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "prompt_toolkit/output/__init__.py",
+        """
+        class DummyOutput:
+            def __init__(self, *_args, **_kwargs):
+                pass
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "prompt_toolkit/output/win32.py",
+        """
+        class NoConsoleScreenBufferError(Exception):
+            pass
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "filelock.py",
+        """
+        class FileLock:
+            def __init__(self, *_args, **_kwargs):
+                self._locked = False
+
+            def __enter__(self):
+                self._locked = True
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self._locked = False
+                return False
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "chardet.py",
+        """
+        def detect(_data):
+            return {"encoding": "utf-8"}
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "jupyter_kernel.py",
+        """
+        class CobraKernel:
+            pass
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "pcobra_core_database_stub.py",
+        """
+        from contextlib import contextmanager
+
+
+        class DatabaseDependencyError(RuntimeError):
+            pass
+
+
+        class DatabaseKeyError(RuntimeError):
+            pass
+
+
+        @contextmanager
+        def get_connection():
+            class _DummyConnection:
+                def cursor(self):
+                    return self
+
+                def execute(self, *_args, **_kwargs):
+                    return None
+
+                def fetchone(self):
+                    return None
+
+                def commit(self):
+                    return None
+
+                def close(self):
+                    return None
+
+            yield _DummyConnection()
+
+
+        def store_ast(*_args, **_kwargs):
+            return None
+
+
+        def load_ast(*_args, **_kwargs):
+            return None
+
+
+        def clear_cache():
+            return None
+
+
+        def save_qualia_state(*_args, **_kwargs):
+            return None
+
+
+        __all__ = [
+            "DatabaseDependencyError",
+            "DatabaseKeyError",
+            "get_connection",
+            "store_ast",
+            "load_ast",
+            "clear_cache",
+            "save_qualia_state",
+        ]
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "pcobra_cobra_cli_i18n_stub.py",
+        """
+        import traceback
+
+
+        def _(text):
+            return text
+
+
+        def setup_gettext(_lang=None):
+            return _
+
+
+        def format_traceback(exc, _lang=None):
+            return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+
+
+        __all__ = ["_", "setup_gettext", "format_traceback"]
+        """,
+    )
+
+    _write_stub(
+        stubs_dir / "sitecustomize.py",
+        """
+        import importlib.util
+        import os
+        import sys
+        from pathlib import Path
+
+        CODE_ROOT = Path(os.environ.get("PCOBRA_CODE_ROOT", Path.cwd()))
+        PROJECT_ROOT = Path(os.environ.get("PCOBRA_PROJECT_ROOT", CODE_ROOT))
+        SRC_PATH = CODE_ROOT / "src"
+        if str(SRC_PATH) not in sys.path:
+            sys.path.insert(0, str(SRC_PATH))
+
+        def _load_stub(name: str, relative: str):
+            stub_path = Path(__file__).with_name(relative)
+            spec = importlib.util.spec_from_file_location(name, stub_path)
+            if spec and spec.loader:
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[name] = module
+                spec.loader.exec_module(module)
+                return module
+            return None
+
+        database_stub = _load_stub("pcobra.core.database", "pcobra_core_database_stub.py")
+        if database_stub is not None:
+            try:
+                import pcobra.core  # type: ignore
+
+                setattr(pcobra.core, "database", database_stub)
+            except Exception:
+                pass
+
+        i18n_stub = _load_stub("pcobra.cobra.cli.i18n", "pcobra_cobra_cli_i18n_stub.py")
+        if i18n_stub is not None:
+            sys.modules["cobra.cli.i18n"] = i18n_stub
+
+        try:
+            from cobra.cli.commands import dependencias_cmd
+
+            def _project_root(cls):
+                return PROJECT_ROOT
+
+            dependencias_cmd.DependenciasCommand._get_project_root = classmethod(_project_root)
+        except Exception:
+            pass
+        """,
+    )
+
+    env = os.environ.copy()
+    original_path = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [str(stubs_dir), str(REPO_ROOT / "src"), original_path])
+    )
+    env["PCOBRA_CODE_ROOT"] = str(REPO_ROOT)
+    env["PCOBRA_PROJECT_ROOT"] = str(project_root)
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    env.pop("PYTEST_CURRENT_TEST", None)
+    return env
+
+
+def _run_cli(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, "-m", "pcobra.cli", *args]
+    try:
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:  # pragma: no cover - diagnóstico
+        raise AssertionError(
+            "El comando {} se bloqueó tras 30 s.\nstdout acumulado: {!r}\nstderr acumulado: {!r}".format(
+                " ".join(cmd), exc.stdout, exc.stderr
+            )
+        ) from exc
+
+
+@pytest.mark.timeout(30)
+def test_cli_dependencias_listar(tmp_path: Path) -> None:
+    env = _create_stub_environment(tmp_path)
+    result = _run_cli(["dependencias", "listar"], env)
+    assert result.returncode == 0, result.stderr
+    stdout = result.stdout
+    assert "numpy==1.0.0" in stdout
+    assert "pandas==1.0.0" in stdout
+
+
+@pytest.mark.timeout(30)
+def test_cli_agix_help(tmp_path: Path) -> None:
+    env = _create_stub_environment(tmp_path)
+    result = _run_cli(["agix", "--help"], env)
+    assert result.returncode == 0, result.stderr
+    stdout = result.stdout
+    assert stdout.startswith("usage: cobra agix")
+    assert "--peso-precision" in stdout


### PR DESCRIPTION
## Summary
- delegate the legacy `pcobra.cli` entrypoint to `CliApplication` to avoid duplicated argparse logic
- register the Agix command in the CLI command registry so it is exposed by the main entrypoint
- add subprocess-based tests that stub optional dependencies and exercise `cobra dependencias listar` and `cobra agix --help`

## Testing
- PYTEST_ADDOPTS= pytest --no-cov tests/unit/test_cli_entrypoint_subprocess.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d95a06664c832797c5ce1c7ff304d6