### PR TITLE
Manejar manualmente las redirecciones en el nativo obtener_url

### DIFF
--- a/docs/frontend/modulos_nativos.rst
+++ b/docs/frontend/modulos_nativos.rst
@@ -65,9 +65,10 @@ Red
 - ``obtener_url(url, permitir_redirecciones=False)`` recupera el contenido de una URL ``https://``.
 - ``enviar_post(url, datos, permitir_redirecciones=False)`` envia datos por ``POST`` a una URL ``https://``.
   Las peticiones no siguen redirecciones a menos que se habilite ``permitir_redirecciones=True``.
-  Los destinos se validan opcionalmente con la lista de hosts definida en
-  la variable de entorno ``COBRA_HOST_WHITELIST``. Si se permiten redirecciones,
-  el host final tras la redirección también debe pertenecer a la lista blanca.
+  Cada salto se valida manualmente: primero se comprueba que el esquema siga
+  siendo ``https`` y después que el host aparezca en la lista blanca definida en
+  ``COBRA_HOST_WHITELIST`` antes de realizar la siguiente petición. Esto impide
+  que la función siga redirecciones hacia destinos no autorizados.
 
 .. code-block:: cobra
 

--- a/src/pcobra/core/nativos/io.py
+++ b/src/pcobra/core/nativos/io.py
@@ -5,7 +5,9 @@ from pathlib import Path
 import requests
 
 
+# Mantener estos límites alineados con ``corelibs.red``.
 _MAX_RESP_SIZE = 1024 * 1024
+_MAX_REDIRECTS = 5
 
 
 def _leer_respuesta(resp: requests.Response) -> str:
@@ -47,6 +49,21 @@ def escribir_archivo(ruta, datos):
         f.write(datos)
 
 
+def _validar_esquema(url: str) -> None:
+    if not url.lower().startswith("https://"):
+        raise ValueError("Esquema de URL no soportado")
+
+
+def _obtener_hosts_permitidos() -> set[str]:
+    allowed = os.environ.get("COBRA_HOST_WHITELIST")
+    if not allowed:
+        raise ValueError("COBRA_HOST_WHITELIST no establecido")
+    hosts = {h.strip().lower() for h in allowed.split(',') if h.strip()}
+    if not hosts:
+        raise ValueError("COBRA_HOST_WHITELIST vacío")
+    return hosts
+
+
 def _validar_host(url: str, hosts: set[str]) -> None:
     host = urllib.parse.urlparse(url).hostname
     host_normalizado = host.lower() if host else None
@@ -54,33 +71,53 @@ def _validar_host(url: str, hosts: set[str]) -> None:
         raise ValueError("Host no permitido")
 
 
+def _resolver_redireccion(
+    url_actual: str, destino: str | None, hosts: set[str]
+) -> str:
+    if not destino:
+        raise ValueError("Redirección sin encabezado Location")
+    nueva_url = urllib.parse.urljoin(url_actual, destino)
+    _validar_esquema(nueva_url)
+    _validar_host(nueva_url, hosts)
+    return nueva_url
+
+
 def obtener_url(url, permitir_redirecciones: bool = False):
     """Devuelve el contenido de una URL ``https://`` como texto.
 
-    Es obligatorio definir la variable de entorno ``COBRA_HOST_WHITELIST`` con
-    la lista de hosts permitidos separados por comas. Las redirecciones están
-    deshabilitadas por defecto. Si se permiten, se valida que el destino final
-    continúe dentro de la lista blanca de hosts y que el esquema se mantenga en
-    ``https``.
+    Las redirecciones se siguen manualmente solo si ``permitir_redirecciones``
+    es ``True``. En cada salto se valida primero el esquema (debe permanecer en
+    ``https``) y el host contra ``COBRA_HOST_WHITELIST`` antes de realizar la
+    siguiente petición. Esto replica la política aplicada en ``corelibs.red``
+    para evitar redirecciones abiertas.
     """
-    url_baja = url.lower()
-    if not url_baja.startswith("https://"):
-        raise ValueError("Esquema de URL no soportado")
-    allowed = os.environ.get("COBRA_HOST_WHITELIST")
-    if not allowed:
-        raise ValueError("COBRA_HOST_WHITELIST no establecido")
-    hosts = {h.strip().lower() for h in allowed.split(',') if h.strip()}
-    if not hosts:
-        raise ValueError("COBRA_HOST_WHITELIST vacío")
-    _validar_host(url, hosts)
-    resp = requests.get(
-        url, timeout=5, allow_redirects=permitir_redirecciones, stream=True
-    )
-    try:
-        resp.raise_for_status()
-        if permitir_redirecciones and not resp.url.lower().startswith("https://"):
-            raise ValueError("Esquema de URL no soportado")
-        _validar_host(resp.url, hosts)
-        return _leer_respuesta(resp)
-    finally:
-        resp.close()
+
+    _validar_esquema(url)
+    hosts = _obtener_hosts_permitidos()
+    url_actual = url
+    redirecciones_restantes = _MAX_REDIRECTS
+
+    while True:
+        _validar_host(url_actual, hosts)
+        resp = requests.get(
+            url_actual, timeout=5, allow_redirects=False, stream=True
+        )
+        if permitir_redirecciones and 300 <= resp.status_code < 400:
+            if redirecciones_restantes == 0:
+                resp.close()
+                raise ValueError("Demasiadas redirecciones")
+            destino = resp.headers.get("Location")
+            try:
+                nueva_url = _resolver_redireccion(url_actual, destino, hosts)
+            finally:
+                resp.close()
+            url_actual = nueva_url
+            redirecciones_restantes -= 1
+            continue
+        try:
+            resp.raise_for_status()
+            _validar_esquema(resp.url)
+            _validar_host(resp.url, hosts)
+            return _leer_respuesta(resp)
+        finally:
+            resp.close()


### PR DESCRIPTION
## Summary
- seguir manualmente las redirecciones en `core.nativos.io.obtener_url`, validando esquema y host antes de cada salto y reutilizando los límites seguros
- ampliar las pruebas unitarias de `tests/unit/test_nativos_io.py` para simular redirecciones prohibidas y comprobar que no se realiza la petición final
- documentar en los módulos nativos la política de validación paso a paso para redirecciones

## Testing
- `pytest -o addopts= tests/unit/test_nativos_io.py`


------
https://chatgpt.com/codex/tasks/task_e_68d97225d6b4832791c9f6aa508479be