### PR TITLE
Add Qualia reset helper and CLI tests

### DIFF
--- a/tests/unit/test_cli_qualia_cmd.py
+++ b/tests/unit/test_cli_qualia_cmd.py
@@ -10,22 +10,30 @@ def _capture_json(output: str) -> dict:
     return json.loads(output[start:end])
 
 
-def test_cli_qualia_mostrar(tmp_path, monkeypatch):
+def test_cli_qualia_mostrar(tmp_path, monkeypatch, base_datos_temporal):
+    _ = base_datos_temporal
     state = tmp_path / ".cobra" / "state.json"
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
     state.parent.mkdir(parents=True, exist_ok=True)
     from core import qualia_bridge
     qb = importlib.reload(qualia_bridge)
-    qb.register_execution("imprimir(1)")
+    spirit = qb.QualiaSpirit()
+    spirit.history.append("imprimir(1)")
+    spirit.knowledge.node_counts["NodoImprimir"] = 1
+    qb.save_state(spirit)
+    qb.QUALIA = spirit
     from cobra.cli.cli import main
-    with patch("sys.stdout", new_callable=StringIO) as out:
+    with patch("sys.stdout", new_callable=StringIO) as out, patch(
+        "cobra.cli.cli.setup_gettext", return_value=lambda s: s
+    ):
         main(["qualia", "mostrar"])
     data = _capture_json(out.getvalue())
     assert data["node_counts"].get("NodoImprimir")
 
 
-def test_cli_qualia_reiniciar(tmp_path, monkeypatch):
+def test_cli_qualia_reiniciar(tmp_path, monkeypatch, base_datos_temporal):
+    _ = base_datos_temporal
     state = tmp_path / ".cobra" / "state.json"
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("QUALIA_STATE_PATH", str(state))
@@ -34,7 +42,9 @@ def test_cli_qualia_reiniciar(tmp_path, monkeypatch):
     state.parent.mkdir(parents=True, exist_ok=True)
     state.write_text("{}")
     from cobra.cli.cli import main
-    with patch("sys.stdout", new_callable=StringIO) as out:
+    with patch("sys.stdout", new_callable=StringIO) as out, patch(
+        "cobra.cli.cli.setup_gettext", return_value=lambda s: s
+    ):
         main(["qualia", "reiniciar"])
     assert not state.exists()
     assert "Estado de Qualia eliminado" in out.getvalue()

--- a/tests/unit/test_qualia_cmd.py
+++ b/tests/unit/test_qualia_cmd.py
@@ -1,0 +1,43 @@
+import importlib
+from io import StringIO
+from unittest.mock import patch
+
+
+def test_reiniciar_limpiar_estado(base_datos_temporal, tmp_path, monkeypatch):
+    _ = base_datos_temporal
+    home = tmp_path / "home"
+    home.mkdir()
+    legacy_path = home / ".cobra" / "qualia_state.json"
+    legacy_path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("QUALIA_STATE_PATH", str(legacy_path))
+
+    from core import qualia_bridge as qb
+
+    qb = importlib.reload(qb)
+
+    spirit = qb.QualiaSpirit()
+    spirit.history.append("imprimir(1)")
+    qb.save_state(spirit)
+
+    with qb.database.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM qualia_state")
+        assert cursor.fetchone()[0] == 1
+
+    from cobra.cli.cli import main
+
+    with patch("sys.stdout", new_callable=StringIO) as out, patch(
+        "cobra.cli.cli.setup_gettext", return_value=lambda s: s
+    ):
+        exit_code = main(["qualia", "reiniciar"])
+
+    assert exit_code == 0
+
+    with qb.database.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM qualia_state")
+        assert cursor.fetchone()[0] == 0
+
+    salida = out.getvalue()
+    assert "Qualia" in salida


### PR DESCRIPTION
## Summary
- add a reset_state helper in qualia_bridge to clear the database row and legacy file
- update the qualia reiniciar CLI command to use the helper and surface errors
- add unit coverage ensuring the command resets state without raising AttributeError

## Testing
- pytest -o addopts="" tests/unit/test_qualia_cmd.py tests/unit/test_cli_qualia_cmd.py

------
https://chatgpt.com/codex/tasks/task_e_68d979cdaebc83278e2f0de85283dfef