### PR TITLE
Reforzar heurísticas de rutas para SQLitePlus

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,17 +947,25 @@ A partir de la migración a **SQLitePlus**, la caché incremental de AST y token
 se almacena en una base de datos `SQLite` cifrada en lugar de archivos sueltos.
 La ruta por defecto es `~/.cobra/sqliteplus/core.db`, que se crea
 automáticamente al primer acceso. Para inicializar la conexión es obligatoria la
-variable de entorno `SQLITE_DB_KEY`, cuyo valor actúa como clave de cifrado (o
-como pista para la ruta en despliegues sin cifrado).
+variable de entorno `SQLITE_DB_KEY`, cuyo valor actúa como clave de cifrado.
+Si necesitas una ubicación distinta configura `COBRA_DB_PATH`; cuando se
+proporciona, el valor de `SQLITE_DB_KEY` se mantiene como clave incluso si
+contiene `/` u otros separadores.
 
 ```bash
 export SQLITE_DB_KEY="clave-local"          # Obligatorio para abrir la base
 export COBRA_DB_PATH="$HOME/.cobra/sqliteplus/core.db"  # Opcional; usa el
                                                         # valor por defecto
+# Para despliegues sin cifrado puedes usar un prefijo explícito:
+export SQLITE_DB_KEY="path:/var/cache/pcobra/core.db"
 ```
 
 Si necesitas ubicar la base de datos en otro sitio, ajusta `COBRA_DB_PATH` a la
-ubicación deseada antes de ejecutar `cobra`. La antigua variable
+ubicación deseada antes de ejecutar `cobra`. Como compatibilidad adicional, un
+valor de `SQLITE_DB_KEY` que empiece por `path:` o `file:` se interpreta como
+ruta explícita y desactiva el cifrado; en cualquier otro caso el valor se trata
+como clave aunque contenga separadores y se emitirá una advertencia si parece
+una ruta. La antigua variable
 `COBRA_AST_CACHE` continúa disponible únicamente como alias de compatibilidad:
 si la defines, el sistema derivará automáticamente una ruta `cache.db` en ese
 directorio y mostrará una advertencia de depreciación.

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,0 +1,56 @@
+import pytest
+
+from pcobra.core import database
+
+
+@pytest.fixture(autouse=True)
+def _reset_database_state(monkeypatch):
+    """Limpia variables de entorno y estado compartido antes de cada prueba."""
+
+    monkeypatch.delenv(database.SQLITE_DB_KEY_ENV, raising=False)
+    monkeypatch.delenv(database.COBRA_DB_PATH_ENV, raising=False)
+    database._SQLITEPLUS_INSTANCE = None  # type: ignore[attr-defined]
+    database._TABLES_READY = False  # type: ignore[attr-defined]
+    yield
+    database._SQLITEPLUS_INSTANCE = None  # type: ignore[attr-defined]
+    database._TABLES_READY = False  # type: ignore[attr-defined]
+
+
+def test_resolve_paths_keeps_cipher_key_with_slash(monkeypatch, tmp_path):
+    """Una clave que contiene `/` debe conservarse intacta."""
+
+    monkeypatch.setattr(database, "DEFAULT_DB_PATH", tmp_path / "core.db")
+    base64_key = "Zm9vL2Jhcg=="  # 'foo/bar'
+    monkeypatch.setenv(database.SQLITE_DB_KEY_ENV, base64_key)
+
+    db_path, cipher_key = database._resolve_paths()
+
+    assert db_path == tmp_path / "core.db"
+    assert cipher_key == base64_key
+
+
+def test_resolve_paths_warns_when_key_looks_like_path(monkeypatch, tmp_path):
+    """Si la clave parece una ruta se avisa pero se mantiene como clave."""
+
+    monkeypatch.setattr(database, "DEFAULT_DB_PATH", tmp_path / "core.db")
+    monkeypatch.setenv(database.SQLITE_DB_KEY_ENV, "/var/lib/pcobra/core.db")
+
+    with pytest.warns(RuntimeWarning, match="parece una ruta"):
+        db_path, cipher_key = database._resolve_paths()
+
+    assert db_path == tmp_path / "core.db"
+    assert cipher_key == "/var/lib/pcobra/core.db"
+
+
+def test_resolve_paths_accepts_explicit_path_prefix(monkeypatch, tmp_path):
+    """El prefijo `path:` debe permitir desactivar el cifrado explícitamente."""
+
+    explicit_path = tmp_path / "sqlite" / "core.db"
+    monkeypatch.setattr(database, "DEFAULT_DB_PATH", tmp_path / "ignored.db")
+    monkeypatch.setenv(database.SQLITE_DB_KEY_ENV, f"path:{explicit_path}")
+
+    db_path, cipher_key = database._resolve_paths()
+
+    assert db_path == explicit_path
+    assert cipher_key is None
+    assert explicit_path.parent.exists()


### PR DESCRIPTION
## Summary
- asegurar que la resolución de rutas mantenga la clave de cifrado incluso cuando contiene separadores y permitir rutas explícitas mediante prefijos
- añadir detecciones de cadenas base64 y advertencias para valores ambiguos al decidir la ruta de la base de datos
- actualizar la documentación y crear pruebas unitarias que cubren los nuevos escenarios

## Testing
- pytest --override-ini="addopts=" tests/unit/test_database.py

------
https://chatgpt.com/codex/tasks/task_e_68d97c281ff8832790f79e979712f0f0