### PR TITLE
Aclarar soporte de BOOLEANO en ClassicParser.declaracion

### DIFF
--- a/src/pcobra/cobra/core/parser.py
+++ b/src/pcobra/cobra/core/parser.py
@@ -366,6 +366,7 @@ class ClassicParser:
                 TipoToken.ENTERO,
                 TipoToken.FLOTANTE,
                 TipoToken.CADENA,
+                # Permite iniciar declaraciones/expresiones con literales booleanos.
                 TipoToken.BOOLEANO,
                 TipoToken.LAMBDA,
             ]:


### PR DESCRIPTION
### Motivation
- Asegurar y dejar explícito que `ClassicParser.declaracion` acepta literales booleanos como inicio válido de expresiones/declaraciones sin cambiar la lógica del parser ni tocar lexer ni evaluador.

### Description
- Añadí un comentario inline en `src/pcobra/cobra/core/parser.py` junto a `TipoToken.BOOLEANO` dentro del bloque que decide entre llamada, asignación y expresión, confirmando su presencia y manteniendo el mismo flujo (`LPAREN` → llamada, `ASIGNAR` → asignación, fallback → `self.expresion()`).

### Testing
- Se compiló el archivo con `python -m py_compile src/pcobra/cobra/core/parser.py` y la compilación finalizó sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2559a7984832790f4008f54c55be8)