### PR TITLE
Fix parser declaration fallback for parenthesized expressions

### DIFF
--- a/src/pcobra/cobra/core/parser.py
+++ b/src/pcobra/cobra/core/parser.py
@@ -369,6 +369,7 @@ class ClassicParser:
                 # Permite iniciar declaraciones/expresiones con literales booleanos.
                 TipoToken.BOOLEANO,
                 TipoToken.LAMBDA,
+                TipoToken.LPAREN,
             ]:
                 siguiente = self.token_siguiente()
                 if siguiente and siguiente.tipo == TipoToken.LPAREN:
@@ -377,7 +378,8 @@ class ClassicParser:
                     return self.declaracion_asignacion()
                 return self.expresion()
 
-            raise ParserError(f"Token inesperado: {token.tipo}")
+            # Fallback: cualquier expresión válida puede ser una declaración en REPL.
+            return self.expresion()
 
         except Exception as e:
             logger.error(f"Error en la declaración: {e}")


### PR DESCRIPTION
## Resumen
- Permite que `parse_declaracion` acepte expresiones que empiezan con `LPAREN`.
- Añade `TipoToken.LPAREN` a los tokens iniciales válidos para expresiones/declaraciones.
- Cambia el cierre de `parse_declaracion` para usar fallback a `self.expresion()` en lugar de error directo de token inesperado.

## Impacto
- En REPL, ahora `(1 + 2)` se parsea como expresión válida en lugar de fallar con `Token inesperado: LPAREN`.
- No se modifica el lexer ni la lógica estructural existente (`si`, asignaciones, handlers/factories).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2599726d88327a8dfed91baa7d766)