### PR TITLE
Aclarar fallback de `ClassicParser.declaracion` hacia `self.expresion()`

### DIFF
--- a/src/pcobra/cobra/core/parser.py
+++ b/src/pcobra/cobra/core/parser.py
@@ -380,7 +380,9 @@ class ClassicParser:
                     return self.declaracion_asignacion()
                 return self.expresion()
 
-            # Fallback: cualquier expresión válida puede ser una declaración en REPL.
+            # Fallback: ante un token no reconocido como declaración estructural
+            # o fábrica registrada, se intenta parsear como expresión en lugar
+            # de lanzar un ParserError inmediato.
             return self.expresion()
 
         except Exception as e:


### PR DESCRIPTION
### Motivation
- Evitar que el parser arroje un `ParserError` inmediato en la rama final de `ClassicParser.declaracion` y dejar explícito que, fuera de las ramas estructurales y de `self._factories`, se debe intentar parsear una expresión con `self.expresion()`.

### Description
- Se actualizó el comentario y la clarificación en el bloque fallback al final de `ClassicParser.declaracion` en `src/pcobra/cobra/core/parser.py` para documentar que se retorna `self.expresion()` en lugar de fallar, sin cambiar las ramas previas ni el mapeo `self._factories`.

### Testing
- Ejecuté `python -m pytest -q` y la ejecución falló en la fase de recolección por un error preexistente en `tests/unit/test_interpreter_identifier_comparisons.py` (`DummyInterpreter` no tiene `ejecutar_asignacion`), por lo que no se observaron fallos nuevos relacionados con este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d27f5513d88327826f9e455822dbff)