### PR TITLE
Ajusta logging de InteractiveCommand para evitar eco y ruido

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -120,6 +120,15 @@ class InteractiveCommand(BaseCommand):
         self.interpretador = interpretador
         self._allow_insecure_fallback = False
         self.logger = logging.getLogger(__name__)
+        if self.logger.handlers:
+            # Evita salida duplicada en consola del REPL cuando este logger ya
+            # tiene un handler propio.
+            self.logger.propagate = False
+        else:
+            # Sin handler local, dejamos que el root gestione el logging
+            # técnico pero evitando ruido innecesario por defecto.
+            self.logger.propagate = True
+            self.logger.setLevel(logging.INFO)
         self._estado_repl = self._crear_estado_repl()
         self._debug_mode = False
 
@@ -654,7 +663,11 @@ class InteractiveCommand(BaseCommand):
         mensaje_usuario = f"{categoria}: {error}"
 
         # Log técnico único (sin duplicar salida en consola del usuario).
-        self.logger.debug("Error en REPL: %s", mensaje_usuario, exc_info=True)
+        self.logger.debug(
+            "Error en REPL: %s",
+            mensaje_usuario,
+            exc_info=self._debug_mode,
+        )
 
         if self._debug_mode:
             traza = traceback.format_exc()


### PR DESCRIPTION
### Motivation
- Evitar que los mensajes técnicos del REPL se dupliquen en la consola raíz (eco) y reducir el ruido de logging fuera de modo depuración.

### Description
- En `src/pcobra/cobra/cli/commands/interactive_cmd.py` la inicialización de `self.logger` ahora desactiva `propagate` (`self.logger.propagate = False`) únicamente cuando ese logger ya tiene handlers propios, y en caso contrario mantiene la propagación al root y ajusta el nivel con `self.logger.setLevel(logging.INFO)` para reducir ruido.
- En `_log_error` se cambia `exc_info=True` por `exc_info=self._debug_mode` para que las trazas técnicas completas solo se incluyan en modo debug, y se mantiene `mostrar_error(..., registrar_log=False)` para no reinyectar los errores al logger root.

### Testing
- Se ejecutó la verificación de sintaxis con `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py` y completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da03c1d7e08327871f280720604e27)