### PR TITLE
Unifica comportamiento de errores entre CLI y REPL (traza opcional en debug)

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -76,6 +76,12 @@ COBRA_ALLOW_INSECURE_FALLBACK_ENV = "COBRA_ALLOW_INSECURE_FALLBACK"
 COBRA_ALLOW_INSECURE_NON_INTERACTIVE_ENV = "COBRA_ALLOW_INSECURE_NON_INTERACTIVE"
 
 
+class CliErrorYaMostrado(Exception):
+    """Error de CLI cuya salida al usuario ya fue emitida por el comando."""
+
+    error_ya_mostrado = True
+
+
 class LogLevel(Enum):
     DEBUG = logging.DEBUG
     INFO = logging.INFO
@@ -581,14 +587,12 @@ class CliApplication:
         return self._normalizar_flags_sesion(parsed)
 
     def _handle_execution_error(self, exc: Exception, language: str, debug_activo: bool = False) -> int:
-        if isinstance(exc, ValueError):
-            messages.mostrar_error(_("Value error: {}").format(str(exc)))
-        elif isinstance(exc, FileNotFoundError):
-            messages.mostrar_error(str(exc))
-        else:
-            messages.mostrar_error(
-                _("An unexpected error occurred. Use --debug or -v to see the full traceback."),
-            )
+        error_ya_mostrado = isinstance(exc, CliErrorYaMostrado) or bool(
+            getattr(exc, "error_ya_mostrado", False)
+        )
+        if not error_ya_mostrado:
+            mensaje = str(exc).strip() or _("Ha ocurrido un error inesperado.")
+            messages.mostrar_error(mensaje)
 
         logging.exception("Error in execution")
         if debug_activo:

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import re
-import traceback
 from typing import Optional, Any
 from types import TracebackType
 
@@ -43,7 +42,7 @@ from pcobra.core.sandbox import (
 )
 from pcobra.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 from pcobra.cobra.cli.commands.base import BaseCommand
-from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.i18n import _, format_traceback
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import (
     mostrar_advertencia,
@@ -463,16 +462,16 @@ class InteractiveCommand(BaseCommand):
                 else:
                     self.ejecutar_codigo(codigo, validador)
             except Exception as err:  # pragma: no cover - ruta unificada de errores
-                categoria, include_traceback = self._clasificar_error_repl(err)
-                self._log_error(categoria, err, include_traceback=include_traceback)
+                categoria = self._clasificar_error_repl(err)
+                self._log_error(categoria, err)
 
-    def _clasificar_error_repl(self, error: Exception) -> tuple[str, bool]:
+    def _clasificar_error_repl(self, error: Exception) -> str:
         """Clasifica errores del REPL para un reporte único en el loop principal."""
         if isinstance(error, (LexerError, ParserError)):
-            return _("Error de sintaxis"), False
+            return _("Error de sintaxis")
         if isinstance(error, RuntimeError):
-            return _("Error crítico"), False
-        return _("Error general"), True
+            return _("Error crítico")
+        return _("Error general")
 
     def _limpiar_estado_repl(self, estado: dict[str, Any]) -> None:
         estado["buffer_lineas"].clear()
@@ -650,33 +649,25 @@ class InteractiveCommand(BaseCommand):
         if salida:
             mostrar_info(str(salida))
 
-    def _log_error(
-        self, categoria: str, error: Exception, include_traceback: bool = False
-    ) -> None:
+    def _log_error(self, categoria: str, error: Exception) -> None:
         """Registra y muestra un error.
 
         Args:
             categoria: Categoría del error
             error: Excepción ocurrida
-            include_traceback: Si se debe incluir la traza completa del error
         """
         mensaje_usuario = f"{categoria}: {error}"
 
         # Log técnico único (sin duplicar salida en consola del usuario).
-        self.logger.debug(
+        logging.debug(
             "Error en REPL: %s",
             mensaje_usuario,
             exc_info=self._debug_mode,
         )
 
-        if self._debug_mode:
-            traza = traceback.format_exc()
-            if traza and traza.strip() != "NoneType: None":
-                mensaje_usuario = f"{mensaje_usuario}\n{traza}"
-            elif include_traceback:
-                mensaje_usuario = f"{mensaje_usuario}\n{traceback.format_stack()[-1]}"
-
         mostrar_error(mensaje_usuario, registrar_log=False)
+        if self._debug_mode:
+            print(format_traceback(error))
 
     def __enter__(self) -> "InteractiveCommand":
         """Inicializa recursos del REPL.

--- a/tests/unit/test_cli_execution_error_output.py
+++ b/tests/unit/test_cli_execution_error_output.py
@@ -17,10 +17,26 @@ def test_handle_execution_error_normal_hides_traceback_and_keeps_logging_excepti
 
     assert result == 1
     assert mock_error.call_count == 1
-    assert "--debug" in mock_error.call_args[0][0]
+    assert mock_error.call_args[0][0] == "boom"
     mock_logging_exception.assert_called_once_with("Error in execution")
     mock_print.assert_not_called()
     mock_format_traceback.assert_not_called()
+
+
+def test_handle_execution_error_no_duplica_salida_si_ya_fue_mostrada():
+    app = CliApplication()
+    exc = RuntimeError("boom")
+    setattr(exc, "error_ya_mostrado", True)
+
+    with patch("cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
+        "cobra.cli.cli.logging.exception"
+    ) as mock_logging_exception, patch("cobra.cli.cli.print") as mock_print:
+        result = app._handle_execution_error(exc, "es", debug_activo=False)
+
+    assert result == 1
+    mock_error.assert_not_called()
+    mock_logging_exception.assert_called_once_with("Error in execution")
+    mock_print.assert_not_called()
 
 
 def test_handle_execution_error_debug_shows_traceback_and_keeps_logging_exception():


### PR DESCRIPTION
### Motivation
- Evitar mensajes duplicados al usuario cuando un comando ya mostró el error y garantizar una política uniforme entre el CLI principal y el REPL.
- Mostrar la traza completa solo en modo debug para mantener una salida de usuario limpia en modo normal (una única línea `Error: <mensaje>`).

### Description
- Añadido el tipo señalizador `CliErrorYaMostrado` y reconocimiento del atributo `error_ya_mostrado` en `CliApplication._handle_execution_error` para no volver a `mostrar_error` si ya fue emitido por el comando (archivo `src/pcobra/cobra/cli/cli.py`).
- `CliApplication._handle_execution_error` ahora registra el detalle técnico con `logging.exception` y sólo imprime `format_traceback(...)` cuando `debug_activo=True`, mostrando en modo normal únicamente el mensaje de error al usuario.
- Alineado el REPL (`InteractiveCommand`) con la misma política: `format_traceback` se importa y se imprime solo en debug; `_clasificar_error_repl` devuelve solo la categoría textual y `_log_error` realiza un único `mostrar_error(...)` al usuario y un log técnico separado con `logging.debug` (archivo `src/pcobra/cobra/cli/commands/interactive_cmd.py`).
- Actualizadas pruebas para reflejar la nueva política y agregar cobertura del caso `error_ya_mostrado` en `tests/unit/test_cli_execution_error_output.py`.
- Archivos modificados: `src/pcobra/cobra/cli/cli.py`, `src/pcobra/cobra/cli/commands/interactive_cmd.py`, `tests/unit/test_cli_execution_error_output.py`.

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_execution_error_output.py tests/unit/test_interactive_cmd_logging.py` y ambas pruebas unitarias pasaron correctamente: `10 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da04b67e5883279b434344dd9c539a)