### PR TITLE
tests: cubrir errores runtime en REPL y evitar duplicación de salida en CLI

### DIFF
--- a/tests/unit/test_cli_execution_error_output.py
+++ b/tests/unit/test_cli_execution_error_output.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 from unittest.mock import patch
 
 from cobra.cli.cli import CliApplication
@@ -54,6 +55,34 @@ def test_handle_execution_error_debug_shows_traceback_and_keeps_logging_exceptio
     mock_logging_exception.assert_called_once_with("Error in execution")
     mock_format_traceback.assert_called_once_with(exc, "es")
     mock_print.assert_called_once_with("TRACEBACK")
+
+
+def test_handle_execution_error_con_root_logger_configurado_no_duplica_salida():
+    app = CliApplication()
+    exc = RuntimeError("boom")
+
+    root_logger = logging.getLogger()
+    original_handlers = list(root_logger.handlers)
+    original_level = root_logger.level
+    root_logger.handlers = []
+    root_logger.setLevel(logging.DEBUG)
+    root_logger.addHandler(logging.StreamHandler())
+
+    try:
+        with patch("cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
+            "cobra.cli.cli.logging.exception"
+        ) as mock_logging_exception, patch("cobra.cli.cli.print") as mock_print:
+            result = app._handle_execution_error(exc, "es", debug_activo=False)
+    finally:
+        for handler in list(root_logger.handlers):
+            root_logger.removeHandler(handler)
+        root_logger.handlers = original_handlers
+        root_logger.setLevel(original_level)
+
+    assert result == 1
+    mock_error.assert_called_once_with("boom")
+    mock_logging_exception.assert_called_once_with("Error in execution")
+    mock_print.assert_not_called()
 
 
 def test_run_propaga_debug_activo_hacia_execute_command():

--- a/tests/unit/test_interactive_cmd_logging.py
+++ b/tests/unit/test_interactive_cmd_logging.py
@@ -1,8 +1,10 @@
 import logging
 import types
+from unittest.mock import Mock, patch
 
 from cobra.cli.commands.interactive_cmd import InteractiveCommand
 from cobra.cli.i18n import _
+from pcobra.core.errors import CondicionNoBooleanaError
 
 
 def test_context_logging(caplog):
@@ -27,3 +29,94 @@ def test_log_error_emits_debug_once(caplog):
     assert _("Error de prueba") in record.message
     assert record.levelno == logging.DEBUG
 
+
+def test_run_repl_loop_runtime_error_no_debug_no_imprime_traceback():
+    dummy = types.SimpleNamespace()
+    cmd = InteractiveCommand(dummy)
+    cmd._debug_mode = False
+
+    entradas = iter(["imprimir(1)", "salir"])
+
+    def _leer_linea(_prompt):
+        return next(entradas)
+
+    with patch.object(
+        cmd,
+        "ejecutar_codigo",
+        side_effect=CondicionNoBooleanaError(),
+    ), patch.object(cmd, "_log_error") as mock_log_error:
+        cmd._run_repl_loop(
+            args=types.SimpleNamespace(),
+            validador=None,
+            leer_linea=_leer_linea,
+            sandbox=False,
+            sandbox_docker=None,
+        )
+
+    mock_log_error.assert_called_once()
+
+
+def test_run_repl_loop_runtime_error_debug_si_imprime_traceback():
+    dummy = types.SimpleNamespace()
+    cmd = InteractiveCommand(dummy)
+    cmd._debug_mode = True
+
+    entradas = iter(["imprimir(1)", "salir"])
+
+    def _leer_linea(_prompt):
+        return next(entradas)
+
+    with patch.object(
+        cmd,
+        "ejecutar_codigo",
+        side_effect=CondicionNoBooleanaError(),
+    ), patch.object(cmd, "_log_error") as mock_log_error:
+        cmd._run_repl_loop(
+            args=types.SimpleNamespace(),
+            validador=None,
+            leer_linea=_leer_linea,
+            sandbox=False,
+            sandbox_docker=None,
+        )
+
+    mock_log_error.assert_called_once()
+
+
+def test_log_error_no_debug_solo_mostrar_error_sin_print():
+    cmd = InteractiveCommand(types.SimpleNamespace())
+    cmd._debug_mode = False
+    mock_error = Mock()
+    mock_print = Mock()
+    globals_log_error = InteractiveCommand._log_error.__globals__
+
+    with patch.dict(
+        globals_log_error,
+        {"mostrar_error": mock_error, "print": mock_print},
+    ):
+        cmd._log_error(_("Error general"), CondicionNoBooleanaError())
+
+    mock_error.assert_called_once()
+    mock_print.assert_not_called()
+
+
+def test_log_error_debug_muestra_traceback():
+    cmd = InteractiveCommand(types.SimpleNamespace())
+    cmd._debug_mode = True
+    mock_error = Mock()
+    mock_print = Mock()
+    globals_log_error = InteractiveCommand._log_error.__globals__
+    mock_traceback = Mock(return_value="TRACEBACK")
+
+    with patch.dict(
+        globals_log_error,
+        {
+            "mostrar_error": mock_error,
+            "print": mock_print,
+            "format_traceback": mock_traceback,
+        },
+    ):
+        cmd._log_error(_("Error general"), CondicionNoBooleanaError())
+
+    mock_error.assert_called_once()
+    mock_traceback.assert_called_once()
+    mock_print.assert_called_once_with("TRACEBACK")


### PR DESCRIPTION
### Motivation
- Asegurar el contrato de UX frente a errores en REPL: emitir un único mensaje visible por error y no duplicar salida al usuario.
- Verificar que el traceback solo se muestra cuando `debug` está activo.
- Detectar y prevenir duplicación de salida cuando el `root` logger tiene handlers configurados.

### Description
- Añadí pruebas en `tests/unit/test_interactive_cmd_logging.py` que simulan una excepción runtime (`CondicionNoBooleanaError`) en `_run_repl_loop` y verifican que el loop delega en `_log_error` exactamente una vez.
- Añadí pruebas unitarias de `_log_error` para comprobar que en `debug=False` solo se llama a `mostrar_error` y no se llama a `print`, y que en `debug=True` se invoca `format_traceback` y se imprime el traceback una vez.
- Añadí una prueba en `tests/unit/test_cli_execution_error_output.py` que configura un `root` logger con handler explícito para comprobar que `_handle_execution_error` no duplica la salida (solo una llamada a `mostrar_error`, `logging.exception` una vez y sin `print` en no-debug).
- Las pruebas emplean `unittest.mock.patch` y sustituyen funciones en los globals de la función cuando es necesario para evitar colisiones de import path y asegurar la observabilidad de llamadas.

### Testing
- Ejecuté `pytest -q tests/unit/test_interactive_cmd_logging.py tests/unit/test_cli_execution_error_output.py` y todos los tests pasaron (`15 passed`).
- Las aserciones verifican explícitamente las llamadas a `mostrar_error`, `logging.exception`, `print` y `format_traceback` en los escenarios definidos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da06fa5e588327b4fcf1fb6e011c13)