### PR TITLE
Unificar salida y logging técnico en _handle_execution_error

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -590,13 +590,16 @@ class CliApplication:
         error_ya_mostrado = isinstance(exc, CliErrorYaMostrado) or bool(
             getattr(exc, "error_ya_mostrado", False)
         )
-        if not error_ya_mostrado:
-            mensaje = str(exc).strip() or _("Ha ocurrido un error inesperado.")
-            messages.mostrar_error(mensaje)
+        mensaje = str(exc).strip() or _("Ha ocurrido un error inesperado.")
 
-        logging.exception("Error in execution")
+        if not error_ya_mostrado:
+            messages.mostrar_error(mensaje, registrar_log=False)
+
         if debug_activo:
+            logging.exception("Error in execution")
             print(format_traceback(exc, language))
+        else:
+            logging.error("Error in execution: %s", mensaje)
         return 1
 
     def _leer_input_seguro(self, prompt: str) -> Optional[str]:


### PR DESCRIPTION
### Motivation
- Evitar duplicación de logs y centralizar la emisión del mensaje de error al usuario en `CliApplication._handle_execution_error` para distinguir claramente la salida al usuario y el log técnico según `debug_activo`.

### Description
- Se consolida el mensaje en la variable `mensaje` y se mantiene la salida al usuario con `messages.mostrar_error(mensaje, registrar_log=False)` para no generar un segundo `logging.error` implícito.
- Se deja un único log técnico: si `debug_activo` es `True` se llama a `logging.exception("Error in execution")` y se imprime el traceback con `print(format_traceback(...))`, y si es `False` se usa `logging.error("Error in execution: %s", mensaje)` sin traceback.
- No se relanza la excepción y el método sigue devolviendo `1` como antes.

### Testing
- Se compiló el archivo modificado con `python -m compileall -q src/pcobra/cobra/cli/cli.py` y la compilación automática finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da0c661dbc8327b5f5038e8298968b)