### PR TITLE
Evita doble registro de errores fatales en CliApplication.run

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -857,7 +857,11 @@ class CliApplication:
                 return self.execute_command(args, debug_activo=debug_activo)
             except Exception as e:
                 logging.exception("Fatal error in application")
-                messages.mostrar_error(_("Fatal error: {}").format(str(e)))
+                mensaje_error = str(e).strip() or _("Ha ocurrido un error inesperado.")
+                messages.mostrar_error(
+                    _("Fatal error: {}").format(mensaje_error),
+                    registrar_log=False,
+                )
                 return 1
 
 


### PR DESCRIPTION
### Motivation
- Evitar que una excepción fatal en `CliApplication.run` genere dos registros técnicos idénticos y al mismo tiempo muestre un mensaje duplicado al usuario.
- Mantener un mensaje de usuario conciso y sin traceback redundante, preservando el código de salida actual.

### Description
- Mantener `logging.exception("Fatal error in application")` como único log técnico para incidentes fatales en el bloque `except` de `CliApplication.run`.
- Cambiar la notificación al usuario para usar `messages.mostrar_error(..., registrar_log=False)` y así evitar duplicar el registro en logs.
- Normalizar el texto mostrado al usuario a `Fatal error: <mensaje>` con fallback a `"Ha ocurrido un error inesperado."` cuando la excepción no provee mensaje.
- Dejar el flujo de control igual: no relanzar la excepción y retornar `1` al finalizar el manejo del error.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/cobra/cli/cli.py` y la compilación estática del módulo fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da0d750f60832792026cfc5679b54e)