### PR TITLE
Unificar política de manejo de errores en CLI

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -639,7 +639,8 @@ class CliApplication:
                     campo=campo,
                     valor=valor.strip(),
                     opciones=opciones_mostrables,
-                )
+                ),
+                registrar_log=False,
             )
             if restantes > 0:
                 messages.mostrar_info(
@@ -649,7 +650,8 @@ class CliApplication:
         messages.mostrar_error(
             _(
                 "Demasiados intentos inválidos para {campo}. Finalizando menú interactivo."
-            ).format(campo=campo)
+            ).format(campo=campo),
+            registrar_log=False,
         )
         return None, 1
 
@@ -659,6 +661,7 @@ class CliApplication:
         if not sys.stdin.isatty():
             messages.mostrar_error(
                 _("El menú interactivo requiere una terminal (TTY). Ejecuta un comando directo."),
+                registrar_log=False,
             )
             return 1
         modo = str(getattr(parsed_args, "modo", MODO_POR_DEFECTO)).strip().lower()
@@ -680,6 +683,7 @@ class CliApplication:
         if not acciones:
             messages.mostrar_error(
                 _("No hay acciones disponibles para --modo {}.").format(modo),
+                registrar_log=False,
             )
             return 1
 
@@ -714,7 +718,7 @@ class CliApplication:
                 return 0
             ejecutar_cmd = self.command_registry.commands.get("ejecutar")
             if not ejecutar_cmd:
-                messages.mostrar_error(_("Comando 'ejecutar' no disponible"))
+                messages.mostrar_error(_("Comando 'ejecutar' no disponible"), registrar_log=False)
                 return 1
             command_args = argparse.Namespace(
                 archivo=archivo.strip(),
@@ -756,7 +760,7 @@ class CliApplication:
             )
             compile_cmd = self.command_registry.commands.get("compilar")
             if not compile_cmd:
-                messages.mostrar_error(_("Comando 'compilar' no disponible"))
+                messages.mostrar_error(_("Comando 'compilar' no disponible"), registrar_log=False)
                 return 1
             return compile_cmd.run(command_args)
         else:
@@ -780,7 +784,7 @@ class CliApplication:
             archivo = archivo.strip()
             inv_cmd = self.command_registry.commands.get("transpilar-inverso")
             if not inv_cmd:
-                messages.mostrar_error(_("Comando 'transpilar-inverso' no disponible"))
+                messages.mostrar_error(_("Comando 'transpilar-inverso' no disponible"), registrar_log=False)
                 return 1
             command_args = argparse.Namespace(
                 archivo=archivo,
@@ -811,9 +815,10 @@ class CliApplication:
                 messages.mostrar_error(
                     _("CLI no inicializada completamente: parser no disponible. "
                       "Ejecute initialize() antes de execute_command()."),
+                    registrar_log=False,
                 )
                 return 1
-            messages.mostrar_error(_("Comando inválido. Use --help para ver opciones."))
+            messages.mostrar_error(_("Comando inválido. Use --help para ver opciones."), registrar_log=False)
             return 1
             
         try:
@@ -825,6 +830,7 @@ class CliApplication:
     def run(self, argv: Optional[List[str]] = None) -> int:
         with self.resource_management():
             self.initialize()
+            debug_activo = False
             if argv is None:
                 argv = sys.argv[1:]
                 if "PYTEST_CURRENT_TEST" in environ and not argv:
@@ -856,7 +862,10 @@ class CliApplication:
 
                 return self.execute_command(args, debug_activo=debug_activo)
             except Exception as e:
-                logging.exception("Fatal error in application")
+                if debug_activo:
+                    logging.exception("Fatal error in application")
+                else:
+                    logging.error("Fatal error in application: %s", str(e).strip() or repr(e))
                 mensaje_error = str(e).strip() or _("Ha ocurrido un error inesperado.")
                 messages.mostrar_error(
                     _("Fatal error: {}").format(mensaje_error),

--- a/src/pcobra/cobra/cli/utils/messages.py
+++ b/src/pcobra/cobra/cli/utils/messages.py
@@ -91,7 +91,7 @@ def _mostrar(msg: str, nivel: LogLevel = "info", registrar_log: bool = True) -> 
         return
 
     try:
-        texto = _(msg)
+        texto = _(" ".join(str(msg).splitlines()).strip())
         
         # Determinar el color según el nivel
         color_map: Dict[LogLevel, ColorCode] = {


### PR DESCRIPTION
### Motivation
- Unificar el comportamiento de errores para que el usuario vea mensajes en una sola línea y el log interno registre una sola entrada por excepción.
- Evitar dobles registros cuando `messages.mostrar_error` imprime y además se registra implícitamente en el logger.
- Mantener la frontera del REPL (`InteractiveCommand._log_error`) sin cambios para no alterar el comportamiento del intérprete.

### Description
- En `src/pcobra/cobra/cli/utils/messages.py` se normalizan los mensajes multilínea a una sola línea con `" ".join(str(msg).splitlines()).strip()` antes de imprimir y loguear.
- En `src/pcobra/cobra/cli/cli.py` se modificaron puntos de frontera de comando (`run_menu`, `_leer_opcion_validada`, y resolución de comandos) para invocar `messages.mostrar_error(..., registrar_log=False)` y así evitar logging implícito duplicado.
- En `CliApplication.run()` el manejo fatal ahora usa `logging.exception(...)` únicamente cuando `debug_activo` es verdadero y, en modo normal, registra una sola línea técnica con `logging.error(...)` sin traceback visible al usuario.
- Se inicializa `debug_activo = False` antes del parseo para evitar que se impriman tracebacks fuera del modo debug.

### Testing
- Se compiló el código modificado con `python -m compileall -q src/pcobra/cobra/cli/cli.py src/pcobra/cobra/cli/utils/messages.py` y la compilación fue exitosa.
- Se verificó el diff de los archivos modificados para confirmar que sólo se aplicaron los cambios previstos y no hubo efectos colaterales automáticos detectados por las comprobaciones básicas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da0e5c07348327a26efd7de9bfadd6)