### PR TITLE
Normaliza el formato de errores del REPL en la capa CLI

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -64,6 +64,18 @@ SANDBOX_DOCKER_CHOICES = DOCKER_EXECUTABLE_TARGETS
 SANDBOX_DOCKER_HELP = OFFICIAL_RUNTIME_TARGETS_HELP
 
 
+def format_user_error(exc: Exception) -> str:
+    """Normaliza mensajes de error para salida limpia en la CLI."""
+    msg = str(exc).strip()
+    prefijos_redundantes = ("Error general:", "Error:")
+    while msg.startswith(prefijos_redundantes):
+        for prefijo in prefijos_redundantes:
+            if msg.startswith(prefijo):
+                msg = msg[len(prefijo):].strip()
+                break
+    return " ".join(msg.split()) or _("Error desconocido")
+
+
 class _SessionHistoryFallback:
     """Historial mínimo para dobles de sesión usados en pruebas."""
 
@@ -656,16 +668,17 @@ class InteractiveCommand(BaseCommand):
             categoria: Categoría del error
             error: Excepción ocurrida
         """
-        mensaje_usuario = f"{categoria}: {error}"
+        mensaje_usuario = format_user_error(error)
 
         # Log técnico único (sin duplicar salida en consola del usuario).
         logging.debug(
-            "Error en REPL: %s",
+            "Error en REPL (%s): %s",
+            categoria,
             mensaje_usuario,
             exc_info=self._debug_mode,
         )
 
-        mostrar_error(mensaje_usuario, registrar_log=False)
+        print(f"Error: {mensaje_usuario}")
         if self._debug_mode:
             print(format_traceback(error))
 

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -205,12 +205,12 @@ def test_interactive_rechaza_fin_sin_bloque_abierto():
     with patch('cobra.cli.commands.interactive_cmd.validar_dependencias'), \
          patch('prompt_toolkit.PromptSession.prompt', side_effect=['fin', 'salir']), \
          patch.object(cmd, 'ejecutar_codigo') as mock_ejecutar, \
-         patch('cobra.cli.commands.interactive_cmd.mostrar_error') as mock_error:
+         patch('sys.stdout', new_callable=StringIO) as mock_stdout:
         ret = cmd.run(_args())
 
     assert ret == 0
     assert mock_ejecutar.call_count == 0
-    assert any("'fin' sin bloque abierto." in str(call.args[0]) for call in mock_error.call_args_list)
+    assert "Error: 'fin' sin bloque abierto." in mock_stdout.getvalue()
 
 
 def test_interactive_rechaza_bloque_vacio():
@@ -218,16 +218,13 @@ def test_interactive_rechaza_bloque_vacio():
     with patch('cobra.cli.commands.interactive_cmd.validar_dependencias'), \
          patch('prompt_toolkit.PromptSession.prompt', side_effect=['si 1 == 1 :', 'fin', 'salir']), \
          patch.object(cmd, 'ejecutar_codigo') as mock_ejecutar, \
-         patch('cobra.cli.commands.interactive_cmd.mostrar_error') as mock_error, \
+         patch('sys.stdout', new_callable=StringIO) as mock_stdout, \
          patch('cobra.cli.commands.interactive_cmd.InteractiveCommand.validar_entrada', return_value=True):
         ret = cmd.run(_args())
 
     assert ret == 0
     assert mock_ejecutar.call_count == 0
-    assert any(
-        "no puede cerrarse con 'fin' sin sentencias no vacías" in str(call.args[0])
-        for call in mock_error.call_args_list
-    )
+    assert "Error: El bloque no puede cerrarse con 'fin' sin sentencias no vacías." in mock_stdout.getvalue()
 
 
 def test_interactive_lineas_blancas_en_bloque_se_ignoran():
@@ -272,13 +269,13 @@ def test_repl_basico_comparte_validacion_fin_sin_bloque():
     cmd = InteractiveCommand(MagicMock())
     args = _args()
     with patch('builtins.input', side_effect=['fin', 'salir']), \
-         patch('cobra.cli.commands.interactive_cmd.mostrar_error') as mock_error, \
+         patch('sys.stdout', new_callable=StringIO) as mock_stdout, \
          patch.object(cmd, 'ejecutar_codigo') as mock_ejecutar:
         ret = cmd._run_repl_basico(args, validador=None)
 
     assert ret == 0
     assert mock_ejecutar.call_count == 0
-    assert any("'fin' sin bloque abierto." in str(call.args[0]) for call in mock_error.call_args_list)
+    assert "Error: 'fin' sin bloque abierto." in mock_stdout.getvalue()
 
 
 def test_interactive_rechaza_exceso_lineas_blanco_consecutivas_en_bloque():
@@ -286,12 +283,12 @@ def test_interactive_rechaza_exceso_lineas_blanco_consecutivas_en_bloque():
     with patch('cobra.cli.commands.interactive_cmd.validar_dependencias'), \
          patch('prompt_toolkit.PromptSession.prompt', side_effect=['si 1 == 1 :', '', '', '', 'fin', 'salir']), \
          patch.object(cmd, 'ejecutar_codigo') as mock_ejecutar, \
-         patch('cobra.cli.commands.interactive_cmd.mostrar_error') as mock_error:
+         patch('sys.stdout', new_callable=StringIO) as mock_stdout:
         ret = cmd.run(_args())
 
     assert ret == 0
     assert mock_ejecutar.call_count == 0
-    assert any("Máximo de 2 líneas en blanco consecutivas" in str(call.args[0]) for call in mock_error.call_args_list)
+    assert "Error: Máximo de 2 líneas en blanco consecutivas" in mock_stdout.getvalue()
 
 
 def test_ejecutar_codigo_imprime_booleano_verdadero():

--- a/tests/unit/test_interactive_cmd_logging.py
+++ b/tests/unit/test_interactive_cmd_logging.py
@@ -2,7 +2,7 @@ import logging
 import types
 from unittest.mock import Mock, patch
 
-from cobra.cli.commands.interactive_cmd import InteractiveCommand
+from cobra.cli.commands.interactive_cmd import InteractiveCommand, format_user_error
 from cobra.cli.i18n import _
 from pcobra.core.errors import CondicionNoBooleanaError
 
@@ -82,27 +82,28 @@ def test_run_repl_loop_runtime_error_debug_si_imprime_traceback():
     mock_log_error.assert_called_once()
 
 
-def test_log_error_no_debug_solo_mostrar_error_sin_print():
+def test_format_user_error_elimina_prefijos_duplicados():
+    assert format_user_error(Exception("Error general: Error: fallo")) == "fallo"
+
+
+def test_log_error_no_debug_solo_imprime_error_limpio():
     cmd = InteractiveCommand(types.SimpleNamespace())
     cmd._debug_mode = False
-    mock_error = Mock()
     mock_print = Mock()
     globals_log_error = InteractiveCommand._log_error.__globals__
 
     with patch.dict(
         globals_log_error,
-        {"mostrar_error": mock_error, "print": mock_print},
+        {"print": mock_print},
     ):
-        cmd._log_error(_("Error general"), CondicionNoBooleanaError())
+        cmd._log_error(_("Error general"), Exception("Error general: Error: fallo"))
 
-    mock_error.assert_called_once()
-    mock_print.assert_not_called()
+    mock_print.assert_called_once_with("Error: fallo")
 
 
 def test_log_error_debug_muestra_traceback():
     cmd = InteractiveCommand(types.SimpleNamespace())
     cmd._debug_mode = True
-    mock_error = Mock()
     mock_print = Mock()
     globals_log_error = InteractiveCommand._log_error.__globals__
     mock_traceback = Mock(return_value="TRACEBACK")
@@ -110,13 +111,14 @@ def test_log_error_debug_muestra_traceback():
     with patch.dict(
         globals_log_error,
         {
-            "mostrar_error": mock_error,
             "print": mock_print,
             "format_traceback": mock_traceback,
         },
     ):
         cmd._log_error(_("Error general"), CondicionNoBooleanaError())
 
-    mock_error.assert_called_once()
     mock_traceback.assert_called_once()
-    mock_print.assert_called_once_with("TRACEBACK")
+    assert mock_print.call_count == 2
+    primer_mensaje = mock_print.call_args_list[0].args[0]
+    assert primer_mensaje.startswith("Error: ")
+    mock_print.assert_any_call("TRACEBACK")


### PR DESCRIPTION
### Motivation
- Evitar mensajes duplicados y prefijos redundantes mostrados al usuario desde el REPL centralizando el formateo en la capa CLI.
- Mantener la lógica del intérprete y las clases de excepción sin cambios mientras se limpia la salida visible.
- Proveer un único punto de control para normalizar texto de excepciones antes de imprimirse en consola.

### Description
- Añadida la función `format_user_error(exc: Exception) -> str` en `interactive_cmd.py` que hace `msg = str(exc).strip()`, elimina prefijos redundantes (`"Error general:", "Error:"`) e normaliza espacios.
- Actualizado `_log_error` para usar `format_user_error` y siempre imprimir un único prefijo desde la CLI con `print(f"Error: {mensaje_usuario}")`, y ajustar el mensaje de logging técnico a `logging.debug("Error en REPL (%s): %s", categoria, mensaje_usuario, ...)`.
- Actualizadas pruebas unitarias (`tests/unit/test_interactive_cmd_logging.py`, `tests/unit/test_cli_interactive_cmd.py`) para comprobar el formateador y el nuevo comportamiento de salida sin duplicidad; no se tocaron excepciones del core ni la lógica del intérprete.

### Testing
- Ejecutado `pytest -q tests/unit/test_interactive_cmd_logging.py` y la suite específica pasó: `7 passed`.
- Ejecutado `pytest -q tests/unit/test_interactive_cmd_logging.py tests/unit/test_cli_interactive_cmd.py` y todas las pruebas afectadas pasaron: `31 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da12025d248327b0354e920575c0a1)