### PR TITLE
Añade `--debug` al REPL interactive y centraliza logging (nivel DEBUG)

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -219,11 +219,11 @@ class CliApplication:
             handler.close()
         self._owned_logging_handlers.clear()
 
-    def initialize(self) -> None:
+    def initialize(self, debug_enabled: bool = False) -> None:
         if self.parser and self.command_registry and self.interpreter:
             return
         setup_gettext()
-        self._setup_logging()
+        self._setup_logging(debug_enabled=debug_enabled)
         self.interpreter = InterpretadorCobra()
         self.command_registry = CommandRegistry(self.interpreter)
         self.parser = self._build_argument_parser()
@@ -290,19 +290,17 @@ class CliApplication:
             f"{COBRA_DEV_EPHEMERAL_CONFIRM_ENV}=1 y el flag --dev-ephemeral-key."
         )
 
-    def _setup_logging(self) -> None:
+    def _setup_logging(self, debug_enabled: bool = False) -> None:
         root_logger = logging.getLogger()
-        if root_logger.handlers:
-            return
-
-        handler = logging.StreamHandler()
-        if AppConfig.LOG_FORMATTER == "json":
-            handler.setFormatter(self._SecurityEventJsonFormatter())
-        else:
-            handler.setFormatter(logging.Formatter(AppConfig.LOG_FORMAT))
-        root_logger.addHandler(handler)
-        root_logger.setLevel(LogLevel.INFO.value)
-        self._owned_logging_handlers.append(handler)
+        if not root_logger.handlers:
+            handler = logging.StreamHandler()
+            if AppConfig.LOG_FORMATTER == "json":
+                handler.setFormatter(self._SecurityEventJsonFormatter())
+            else:
+                handler.setFormatter(logging.Formatter(AppConfig.LOG_FORMAT))
+            root_logger.addHandler(handler)
+            self._owned_logging_handlers.append(handler)
+        root_logger.setLevel(logging.DEBUG if debug_enabled else LogLevel.INFO.value)
 
     def _configure_cli_options(self, parser: CustomArgumentParser) -> None:
         parser.add_argument(
@@ -829,7 +827,7 @@ class CliApplication:
 
     def run(self, argv: Optional[List[str]] = None) -> int:
         with self.resource_management():
-            self.initialize()
+            self.initialize(debug_enabled=False)
             debug_activo = False
             if argv is None:
                 argv = sys.argv[1:]
@@ -848,8 +846,7 @@ class CliApplication:
                     )
                 self._enforce_runtime_safety_policy(args)
                 debug_activo = args.verbose > 0 or args.debug
-                log_level = logging.DEBUG if debug_activo else logging.INFO
-                logging.getLogger().setLevel(log_level)
+                self._setup_logging(debug_enabled=debug_activo)
                 setup_gettext(args.lang)
                 messages.disable_colors(args.no_color)
                 if getattr(args, "legacy_imports", False):

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -150,6 +150,7 @@ class InteractiveCommand(BaseCommand):
             "buffer_lineas": [],
             "nivel_bloque": 0,
             "lineas_blanco_consecutivas": 0,
+            "debug_enabled": False,
         }
 
     def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
@@ -205,6 +206,11 @@ class InteractiveCommand(BaseCommand):
             "--ignore-memory-limit",
             action="store_true",
             help=_("Continúa aun si no se puede aplicar el límite de memoria"),
+        )
+        parser.add_argument(
+            "--debug",
+            action="store_true",
+            help=_("Muestra trazas internas de depuración"),
         )
         parser.set_defaults(cmd=self)
         return parser
@@ -267,8 +273,11 @@ class InteractiveCommand(BaseCommand):
     def ejecutar_codigo(self, codigo: str, validador: Optional[Any] = None) -> None:
         """Ejecuta un snippet completo con el pipeline canónico Lexer/Parser/AST."""
 
+        self.logger.debug("[RUN] Ejecutando snippet en REPL")
         ast = self.procesar_ast(codigo, validador)
+        self.logger.debug("[EXEC] Ejecutando AST en intérprete")
         resultado = self.interpretador.ejecutar_ast(ast)
+        self.logger.debug("[EVAL] Resultado de evaluación: %r", resultado)
         if resultado is not None:
             if isinstance(resultado, bool):
                 print("verdadero" if resultado else "falso")
@@ -322,6 +331,7 @@ class InteractiveCommand(BaseCommand):
             return 1
 
         self._debug_mode = bool(getattr(args, "debug", False))
+        self._estado_repl["debug_enabled"] = self._debug_mode
 
         # Configurar modo seguro y validadores
         seguro = getattr(args, "seguro", True)
@@ -428,6 +438,7 @@ class InteractiveCommand(BaseCommand):
     ) -> None:
         """Bucle único de REPL para evitar divergencias entre implementaciones."""
         estado = self._crear_estado_repl()
+        estado["debug_enabled"] = self._debug_mode
         self._estado_repl = estado
         while True:
             try:
@@ -671,15 +682,16 @@ class InteractiveCommand(BaseCommand):
         mensaje_usuario = format_user_error(error)
 
         # Log técnico único (sin duplicar salida en consola del usuario).
+        debug_enabled = bool(self._estado_repl.get("debug_enabled", self._debug_mode))
         logging.debug(
             "Error en REPL (%s): %s",
             categoria,
             mensaje_usuario,
-            exc_info=self._debug_mode,
+            exc_info=debug_enabled,
         )
 
         print(f"Error: {mensaje_usuario}")
-        if self._debug_mode:
+        if debug_enabled:
             print(format_traceback(error))
 
     def __enter__(self) -> "InteractiveCommand":
@@ -688,7 +700,7 @@ class InteractiveCommand(BaseCommand):
         Returns:
             Self para uso en context manager
         """
-        self.logger.info(_("Iniciando REPL de Cobra"))
+        self.logger.debug(_("Iniciando REPL de Cobra"))
         return self
 
     def __exit__(
@@ -708,4 +720,4 @@ class InteractiveCommand(BaseCommand):
             self.logger.error(
                 _("Error al finalizar REPL: {exc_val}").format(exc_val=exc_val)
             )
-        self.logger.info(_("Finalizando REPL de Cobra"))
+        self.logger.debug(_("Finalizando REPL de Cobra"))

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -45,6 +45,7 @@ def _args():
         sandbox=False,
         sandbox_docker=None,
         ignore_memory_limit=True,
+        debug=False,
     )
 
 
@@ -148,6 +149,30 @@ def test_interactive_help_refleja_politica_de_bloques_y_lineas_blancas():
     assert subparser.description is not None
     assert 'como máximo 2 líneas en blanco consecutivas' in subparser.description
     assert 'se prohíben bloques vacíos' in subparser.description
+
+
+def test_interactive_help_incluye_flag_debug():
+    cmd = InteractiveCommand(MagicMock())
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='command')
+    subparser = cmd.register_subparser(subparsers)
+
+    acciones = {action.dest: action for action in subparser._actions}
+    assert "debug" in acciones
+    assert acciones["debug"].help == "Muestra trazas internas de depuración"
+
+
+def test_interactive_persist_debug_enabled_en_estado_repl():
+    cmd = InteractiveCommand(MagicMock())
+    args = _args()
+    args.debug = True
+
+    with patch('cobra.cli.commands.interactive_cmd.validar_dependencias'), \
+         patch('prompt_toolkit.PromptSession.prompt', side_effect=['salir']):
+        ret = cmd.run(args)
+
+    assert ret == 0
+    assert cmd._estado_repl["debug_enabled"] is True
 
 
 def test_interactive_multiline_si_ejecuta_al_cerrar_bloque():


### PR DESCRIPTION
### Motivation

- Permitir activar trazas internas de depuración desde la CLI del REPL y controlar el nivel global de logging desde el inicializador central para facilitar diagnóstico sin ensuciar la salida de usuario por defecto.

### Description

- Agrega el flag `--debug` al subcomando `interactive` con `action='store_true'` y ayuda en español: "Muestra trazas internas de depuración".
- Guarda el valor en el estado de sesión REPL (`_estado_repl['debug_enabled']`) y lo usa para habilitar trazas y mostrar traceback solo cuando corresponde.
- Extiende `CliApplication.initialize` y `_setup_logging` para aceptar `debug_enabled` y fijar el nivel del root logger a `DEBUG` cuando esté activo, manteniendo `INFO` por defecto; además se evita duplicar handlers al inicializar.
- Añade trazas de diagnóstico etiquetadas (`[RUN]`, `[EXEC]`, `[EVAL]`) en el flujo de ejecución del REPL y cambia los logs de inicio/fin del REPL a `DEBUG` para no producir ruido sin `--debug`.
- Añade pruebas unitarias que verifican la presencia y ayuda del flag `--debug` en el `help` del subcomando y que `debug_enabled` se persiste en el estado del REPL.

### Testing

- Se ejecutaron tests unitarios focalizados: `tests/unit/test_cli_interactive_cmd.py -k "help_incluye_flag_debug or persist_debug_enabled"` y ambos pasaron.
- Se ejecutó `tests/unit/test_cli_logging.py -k "setup or debug"` y pasó correctamente.
- Un intento de ejecutar una corrida más amplia (`pytest` sobre varios tests) falló por `MemoryError` del entorno durante el reporting de pytest, no por asertos relacionados con los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1343b1948327a8b720bbba1392df)