### PR TITLE
Centralizar logging del CLI y evitar handlers duplicados

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -35,6 +35,19 @@ if _CANONICAL_CLI_PACKAGE_DIR.is_dir():
     __path__ = [str(_CANONICAL_CLI_PACKAGE_DIR)]
 
 
+def configure_logging(debug: bool) -> None:
+    """Configura logging de CLI con un único handler de consola."""
+
+    app_logger = logging.getLogger("pcobra")
+    app_logger.handlers.clear()
+    app_logger.setLevel(logging.DEBUG if debug else logging.WARNING)
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    app_logger.addHandler(handler)
+    app_logger.propagate = False
+
+
 def _activar_compatibilidad_legacy_si_corresponde(ruta_modulo: str) -> None:
     """Activa alias legacy mínimos solo para entrypoints heredados."""
 
@@ -161,6 +174,8 @@ def main(argumentos: Optional[List[str]] = None) -> int:
     _bootstrap_dev_path_si_opt_in()
     argv_entrada: Iterable[str] = argumentos if argumentos is not None else sys.argv[1:]
     argv = _normalizar_argumentos(argv_entrada)
+    debug = bool(argv and "--debug" in argv)
+    configure_logging(debug=debug)
 
     flag_legacy_imports = argv is not None and "--legacy-imports" in argv
     env_legacy_imports = os.environ.get("PCOBRA_ENABLE_LEGACY_IMPORTS") == "1"

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -1,10 +1,8 @@
 import argparse
-import json
 import logging
 import os
 import secrets
 import sys
-from enum import Enum
 from os import environ
 from pathlib import Path
 from typing import List, Dict, Optional, Type, Any, ContextManager
@@ -82,13 +80,6 @@ class CliErrorYaMostrado(Exception):
     error_ya_mostrado = True
 
 
-class LogLevel(Enum):
-    DEBUG = logging.DEBUG
-    INFO = logging.INFO
-    WARNING = logging.WARNING
-    ERROR = logging.ERROR
-
-
 class AppConfig:
     # Cargar configuración desde archivo
     try:
@@ -98,8 +89,6 @@ class AppConfig:
         config_data: Dict[str, str] = {}
     DEFAULT_LANGUAGE = config_data.get("language", "es")
     DEFAULT_COMMAND = config_data.get("default_command", "interactive")
-    LOG_FORMAT = config_data.get("log_format", "%(asctime)s - %(levelname)s - %(message)s")
-    LOG_FORMATTER = str(config_data.get("log_formatter", "text")).strip().lower()
     PROGRAM_NAME = config_data.get("program_name", "cobra")
     BASE_COMMAND_CLASSES: List[Type[BaseCommand]] = [
         InteractiveCommand, CompileCommand, ExecuteCommand, ModulesCommand,
@@ -185,22 +174,6 @@ class CliApplication:
         self.command_registry: Optional[CommandRegistry] = None
         self._subparsers: Optional[argparse._SubParsersAction] = None
         self._commands_registered = False
-        self._owned_logging_handlers: list[logging.Handler] = []
-
-    class _SecurityEventJsonFormatter(logging.Formatter):
-        """Formatter JSON opt-in para eventos de auditoría de seguridad."""
-
-        def format(self, record: logging.LogRecord) -> str:
-            payload = {
-                "timestamp": self.formatTime(record, self.datefmt),
-                "level": record.levelname,
-                "logger": record.name,
-                "msg": record.getMessage(),
-            }
-            for field in ("event", "command", "reason", "audit_id"):
-                if hasattr(record, field):
-                    payload[field] = getattr(record, field)
-            return json.dumps(payload, ensure_ascii=False)
 
     @contextmanager
     def resource_management(self) -> ContextManager[None]:
@@ -212,18 +185,11 @@ class CliApplication:
     def cleanup(self) -> None:
         if self.interpreter and hasattr(self.interpreter, "cleanup"):
             self.interpreter.cleanup()
-        root_logger = logging.getLogger()
-        for handler in self._owned_logging_handlers:
-            if handler in root_logger.handlers:
-                root_logger.removeHandler(handler)
-            handler.close()
-        self._owned_logging_handlers.clear()
 
-    def initialize(self, debug_enabled: bool = False) -> None:
+    def initialize(self) -> None:
         if self.parser and self.command_registry and self.interpreter:
             return
         setup_gettext()
-        self._setup_logging(debug_enabled=debug_enabled)
         self.interpreter = InterpretadorCobra()
         self.command_registry = CommandRegistry(self.interpreter)
         self.parser = self._build_argument_parser()
@@ -289,18 +255,6 @@ class CliApplication:
             f"explícitamente {COBRA_DEV_MODE_ENV}=1, "
             f"{COBRA_DEV_EPHEMERAL_CONFIRM_ENV}=1 y el flag --dev-ephemeral-key."
         )
-
-    def _setup_logging(self, debug_enabled: bool = False) -> None:
-        root_logger = logging.getLogger()
-        if not root_logger.handlers:
-            handler = logging.StreamHandler()
-            if AppConfig.LOG_FORMATTER == "json":
-                handler.setFormatter(self._SecurityEventJsonFormatter())
-            else:
-                handler.setFormatter(logging.Formatter(AppConfig.LOG_FORMAT))
-            root_logger.addHandler(handler)
-            self._owned_logging_handlers.append(handler)
-        root_logger.setLevel(logging.DEBUG if debug_enabled else LogLevel.INFO.value)
 
     def _configure_cli_options(self, parser: CustomArgumentParser) -> None:
         parser.add_argument(
@@ -827,7 +781,7 @@ class CliApplication:
 
     def run(self, argv: Optional[List[str]] = None) -> int:
         with self.resource_management():
-            self.initialize(debug_enabled=False)
+            self.initialize()
             debug_activo = False
             if argv is None:
                 argv = sys.argv[1:]
@@ -846,7 +800,6 @@ class CliApplication:
                     )
                 self._enforce_runtime_safety_policy(args)
                 debug_activo = args.verbose > 0 or args.debug
-                self._setup_logging(debug_enabled=debug_activo)
                 setup_gettext(args.lang)
                 messages.disable_colors(args.no_color)
                 if getattr(args, "legacy_imports", False):


### PR DESCRIPTION
### Motivation
- Evitar configuración de logging dispersa que causa mensajes duplicados y niveles inconsistentes al iniciar la CLI.
- Proveer un punto único y sencillo para controlar nivel (`WARNING` por defecto, `DEBUG` con `--debug`) y formato de salida en consola.

### Description
- Añade `configure_logging(debug: bool)` en `src/pcobra/cli.py` para configurar el logger de aplicación `pcobra` limpiando handlers previos, añadiendo un único `StreamHandler` con `'%(levelname)s: %(message)s'` y desactivando `propagate`.
- Invoca `configure_logging()` una sola vez al arrancar el `main()` de la capa CLI, pasando `debug=True` cuando `--debug` esté presente en los argumentos.
- Elimina la configuración duplicada de logging dentro de `CliApplication` en `src/pcobra/cobra/cli/cli.py` (se retiró `_setup_logging`, el `LogLevel` y el formateador JSON opcional), para que la CLI no vuelva a añadir handlers ni modificar el root logger.
- Ajusta `initialize()`/`run()` de `CliApplication` para no reconfigurar el logging y mantener la inicialización idempotente.

### Testing
- Compilación estática: ejecutado `python -m py_compile src/pcobra/cli.py src/pcobra/cobra/cli/cli.py` y pasó correctamente.
- Verificación funcional de logging: ejecutados snippets automáticos que llaman a `configure_logging()` y emiten mensajes; se confirmó que en modo normal `INFO` queda oculto, en modo `--debug` aparece `DEBUG`, y cada línea de log se imprime una sola vez (comprobado mediante `python - <<'PY' ... PY`).
- Inspección del logger: script automático comprobó que el logger `pcobra` tiene `1` handler, `propagate=False` y nivel `WARNING` por defecto, y la verificación pasó.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da14ada1c083278df874e2a5d61c87)