### PR TITLE
cli: asegurar consola UTF-8 al arranque

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -35,6 +35,17 @@ if _CANONICAL_CLI_PACKAGE_DIR.is_dir():
     __path__ = [str(_CANONICAL_CLI_PACKAGE_DIR)]
 
 
+def _reconfigurar_consola_utf8() -> None:
+    """Fuerza UTF-8 en stdout/stderr cuando el runtime lo soporta."""
+
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
+    except Exception:
+        # Compatibilidad con runtimes donde ``reconfigure`` no existe.
+        pass
+
+
 def configure_logging(debug: bool) -> None:
     """Configura logging de CLI con un único handler de consola."""
 
@@ -171,6 +182,7 @@ def _normalizar_argumentos(argumentos: Optional[Iterable[str]]) -> Optional[List
 
 def main(argumentos: Optional[List[str]] = None) -> int:
     """Punto de entrada principal para la ejecución del CLI."""
+    _reconfigurar_consola_utf8()
     _bootstrap_dev_path_si_opt_in()
     argv_entrada: Iterable[str] = argumentos if argumentos is not None else sys.argv[1:]
     argv = _normalizar_argumentos(argv_entrada)


### PR DESCRIPTION
### Motivation
- Garantizar que `sys.stdout` y `sys.stderr` usen `utf-8` desde el inicio del CLI para evitar problemas de codificación en distintos runtimes sin modificar la lógica del lenguaje.

### Description
- Añadida la rutina `_reconfigurar_consola_utf8()` en `src/pcobra/cli.py` que intenta `sys.stdout.reconfigure(encoding='utf-8')` y `sys.stderr.reconfigure(encoding='utf-8')` protegida con `try/except` para compatibilidad con runtimes donde `reconfigure` no exista; la rutina se invoca al inicio de `main()` para aplicarse lo antes posible sin alterar el flujo del CLI.

### Testing
- Ejecutado `python -m py_compile src/pcobra/cli.py` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1739486c8327998bbea970043ccc)