### PR TITLE
Gate interpreter internal trace output behind debug flag and add tests

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -188,6 +188,10 @@ def main(argumentos: Optional[List[str]] = None) -> int:
     argv = _normalizar_argumentos(argv_entrada)
     debug = bool(argv and "--debug" in argv)
     configure_logging(debug=debug)
+    if debug:
+        os.environ["PCOBRA_DEBUG_TRACES"] = "1"
+    else:
+        os.environ.pop("PCOBRA_DEBUG_TRACES", None)
 
     flag_legacy_imports = argv is not None and "--legacy-imports" in argv
     env_legacy_imports = os.environ.get("PCOBRA_ENABLE_LEGACY_IMPORTS") == "1"

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -108,6 +108,21 @@ class InterpretadorCobra:
     """Interpreta y ejecuta nodos del lenguaje Cobra."""
 
     @staticmethod
+    def _debug_trazas_habilitadas() -> bool:
+        """Indica si las trazas internas de depuración están activadas."""
+        return os.getenv("PCOBRA_DEBUG_TRACES", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+    def _trace_debug(self, mensaje: str) -> None:
+        """Imprime trazas internas solo cuando el modo debug está activo."""
+        if self._debug_trazas_habilitadas():
+            print(mensaje)
+
+    @staticmethod
     def _registrar_auditoria_validador(
         ruta_real: str,
         resultado: str,
@@ -961,11 +976,11 @@ class InterpretadorCobra:
 
         self._asegurar_ast_tipado(ast, "pre_optimizacion")
         self._asegurar_ast_aciclico_por_identidad(ast, "pre_optimizacion")
-        print("[AST BEFORE OPT]")
-        print(self._resumir_ast(ast))
+        self._trace_debug("[AST BEFORE OPT]")
+        self._trace_debug(self._resumir_ast(ast))
         if self._debug_resumen_ast_habilitado():
-            print("[AST BEFORE OPT][SUMMARY]")
-            print(self._resumir_ast(ast))
+            self._trace_debug("[AST BEFORE OPT][SUMMARY]")
+            self._trace_debug(self._resumir_ast(ast))
 
         ast = optimize_constants(ast)
         self._asegurar_ast_aciclico_por_identidad(ast, "post_optimize_constants")
@@ -978,18 +993,20 @@ class InterpretadorCobra:
         ast = remove_dead_code(ast)
         self._asegurar_ast_aciclico_por_identidad(ast, "post_remove_dead_code")
 
-        print("[AST AFTER OPT]")
-        print(self._resumir_ast(ast))
+        self._trace_debug("[AST AFTER OPT]")
+        self._trace_debug(self._resumir_ast(ast))
         if self._debug_resumen_ast_habilitado():
-            print("[AST AFTER OPT][SUMMARY]")
-            print(self._resumir_ast(ast))
+            self._trace_debug("[AST AFTER OPT][SUMMARY]")
+            self._trace_debug(self._resumir_ast(ast))
         self._asegurar_ast_tipado(ast, "post_optimizacion")
         self.ultimo_ir = None
-        print("[RUN] antes de iterar AST")
+        self._trace_debug("[RUN] antes de iterar AST")
         for index, nodo in enumerate(ast):
-            print(f"[RUN] index={index} node_type={type(nodo).__name__} node_id={id(nodo)}")
+            self._trace_debug(
+                f"[RUN] index={index} node_type={type(nodo).__name__} node_id={id(nodo)}"
+            )
             self._validar(nodo)
-            print("[RUN] antes de ejecutar_nodo")
+            self._trace_debug("[RUN] antes de ejecutar_nodo")
             resultado = self.ejecutar_nodo(nodo)
             if resultado is not None:
                 return resultado
@@ -1002,7 +1019,7 @@ class InterpretadorCobra:
         return build_internal_ir(ast)
 
     def ejecutar_nodo(self, nodo):
-        print(f"[EXEC] node_type={type(nodo).__name__} node_id={id(nodo)}")
+        self._trace_debug(f"[EXEC] node_type={type(nodo).__name__} node_id={id(nodo)}")
         self._validar(nodo)
         if isinstance(nodo, NodoAsignacion):
             return self.ejecutar_asignacion(nodo)
@@ -1141,11 +1158,9 @@ class InterpretadorCobra:
         """
         visitados = set() if visitados is None else visitados
         expresion_id = id(expresion)
-        print(
-            f"[EVAL] tipo={type(expresion).__name__} id={expresion_id}"
-        )
+        self._trace_debug(f"[EVAL] tipo={type(expresion).__name__} id={expresion_id}")
         if expresion_id in self._eval_stack:
-            print(
+            self._trace_debug(
                 f"[RECURSION DETECTED] tipo={type(expresion).__name__} id={expresion_id}"
             )
             raise Exception("Recursive evaluation detected")
@@ -1171,7 +1186,7 @@ class InterpretadorCobra:
                 # Resuelve asignaciones anidadas y devuelve su valor
                 return self.ejecutar_asignacion(expresion, visitados)
             elif isinstance(expresion, NodoIdentificador):
-                print(f"[ID] resolving {expresion.nombre}")
+                self._trace_debug(f"[ID] resolving {expresion.nombre}")
                 valor = self._resolver_identificador(expresion.nombre, visitados)
 
                 if valor is None:
@@ -1189,7 +1204,7 @@ class InterpretadorCobra:
                         f"({type(valor).__name__}) en lugar de un valor materializado"
                     )
 
-                print(
+                self._trace_debug(
                     "[ID] "
                     f"value_type={type(valor).__name__} value_id={id(valor)} "
                     f"is_primitive={isinstance(valor, (int, float, bool, str))}"
@@ -1219,22 +1234,22 @@ class InterpretadorCobra:
                 return self.ejecutar_holobit(expresion)
             elif isinstance(expresion, NodoOperacionBinaria):
                 tipo = expresion.operador.tipo
-                print(
+                self._trace_debug(
                     "[BIN-ENTER] "
                     f"id={id(expresion)} op={expresion.operador.valor} op_tipo={tipo} "
                     f"left_type={type(expresion.izquierda).__name__} "
                     f"right_type={type(expresion.derecha).__name__}"
                 )
-                print(f"[BIN] op_tipo={tipo} op_valor={expresion.operador.valor}")
+                self._trace_debug(f"[BIN] op_tipo={tipo} op_valor={expresion.operador.valor}")
 
                 left = self.evaluar_expresion(expresion.izquierda, visitados)
-                print(
+                self._trace_debug(
                     "[BIN-LEFT] "
                     f"type={type(left).__name__} id={id(left)} "
                     f"is_primitive={isinstance(left, (int, float, bool, str))}"
                 )
                 right = self.evaluar_expresion(expresion.derecha, visitados)
-                print(
+                self._trace_debug(
                     "[BIN-RIGHT] "
                     f"type={type(right).__name__} id={id(right)} "
                     f"is_primitive={isinstance(right, (int, float, bool, str))}"
@@ -1280,66 +1295,66 @@ class InterpretadorCobra:
                 if tipo == TipoToken.MAYORQUE:
                     verificar_comparables(left, right, ">")
                     result = left > right
-                    print(f"[BIN-RESULT] value={result} type={type(result).__name__}")
+                    self._trace_debug(f"[BIN-RESULT] value={result} type={type(result).__name__}")
                     return result
                 elif tipo == TipoToken.MENORQUE:
                     verificar_comparables(left, right, "<")
                     result = left < right
-                    print(f"[BIN-RESULT] value={result} type={type(result).__name__}")
+                    self._trace_debug(f"[BIN-RESULT] value={result} type={type(result).__name__}")
                     return result
                 elif tipo == TipoToken.MAYORIGUAL:
                     verificar_comparables(left, right, ">=")
                     result = left >= right
-                    print(f"[BIN-RESULT] value={result} type={type(result).__name__}")
+                    self._trace_debug(f"[BIN-RESULT] value={result} type={type(result).__name__}")
                     return result
                 elif tipo == TipoToken.MENORIGUAL:
                     verificar_comparables(left, right, "<=")
                     result = left <= right
-                    print(f"[BIN-RESULT] value={result} type={type(result).__name__}")
+                    self._trace_debug(f"[BIN-RESULT] value={result} type={type(result).__name__}")
                     return result
                 elif tipo == TipoToken.IGUAL:
                     result = left == right
-                    print(f"[BIN-RESULT] value={result} type={type(result).__name__}")
+                    self._trace_debug(f"[BIN-RESULT] value={result} type={type(result).__name__}")
                     return result
                 elif tipo == TipoToken.DIFERENTE:
                     result = left != right
-                    print(f"[BIN-RESULT] value={result} type={type(result).__name__}")
+                    self._trace_debug(f"[BIN-RESULT] value={result} type={type(result).__name__}")
                     return result
 
                 if tipo == TipoToken.SUMA:
                     verificar_sumables(left, right)
                     result = left + right
-                    print(f"[BIN-RESULT] value={result} type={type(result).__name__}")
+                    self._trace_debug(f"[BIN-RESULT] value={result} type={type(result).__name__}")
                     return result
                 elif tipo == TipoToken.RESTA:
                     verificar_numeros(left, right, "-")
                     result = left - right
-                    print(f"[BIN-RESULT] value={result} type={type(result).__name__}")
+                    self._trace_debug(f"[BIN-RESULT] value={result} type={type(result).__name__}")
                     return result
                 elif tipo == TipoToken.MULT:
                     verificar_numeros(left, right, "*")
                     result = left * right
-                    print(f"[BIN-RESULT] value={result} type={type(result).__name__}")
+                    self._trace_debug(f"[BIN-RESULT] value={result} type={type(result).__name__}")
                     return result
                 elif tipo == TipoToken.DIV:
                     verificar_numeros(left, right, "/")
                     result = left / right
-                    print(f"[BIN-RESULT] value={result} type={type(result).__name__}")
+                    self._trace_debug(f"[BIN-RESULT] value={result} type={type(result).__name__}")
                     return result
                 elif tipo == TipoToken.MOD:
                     verificar_numeros(left, right, "%")
                     result = left % right
-                    print(f"[BIN-RESULT] value={result} type={type(result).__name__}")
+                    self._trace_debug(f"[BIN-RESULT] value={result} type={type(result).__name__}")
                     return result
                 elif tipo == TipoToken.AND:
                     verificar_booleanos(left, right, "&&")
                     result = left and right
-                    print(f"[BIN-RESULT] value={result} type={type(result).__name__}")
+                    self._trace_debug(f"[BIN-RESULT] value={result} type={type(result).__name__}")
                     return result
                 elif tipo == TipoToken.OR:
                     verificar_booleanos(left, right, "||")
                     result = left or right
-                    print(f"[BIN-RESULT] value={result} type={type(result).__name__}")
+                    self._trace_debug(f"[BIN-RESULT] value={result} type={type(result).__name__}")
                     return result
                 else:
                     raise ValueError(f"Operador no soportado: {tipo}")

--- a/tests/unit/test_interpreter_identifier_comparisons.py
+++ b/tests/unit/test_interpreter_identifier_comparisons.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from io import StringIO
 from unittest.mock import patch
 
@@ -389,12 +390,13 @@ def test_operacion_or_materializa_identificador_y_alias() -> None:
 
 
 def test_debug_traces_en_comparacion_identificador_simple() -> None:
-    salida = _ejecutar_codigo_y_capturar_stdout_completo(
-        """
+    with patch.dict("os.environ", {"PCOBRA_DEBUG_TRACES": "1"}):
+        salida = _ejecutar_codigo_y_capturar_stdout_completo(
+            """
 x = 10
 imprimir x == 10
 """
-    )
+        )
 
     assert "[AST BEFORE OPT]" in salida
     assert "[AST AFTER OPT]" in salida
@@ -407,12 +409,13 @@ imprimir x == 10
 
 
 def test_debug_traces_en_comparacion_identificador_con_suma() -> None:
-    salida = _ejecutar_codigo_y_capturar_stdout_completo(
-        """
+    with patch.dict("os.environ", {"PCOBRA_DEBUG_TRACES": "1"}):
+        salida = _ejecutar_codigo_y_capturar_stdout_completo(
+            """
 x = 5
 imprimir x + 5 == 10
 """
-    )
+        )
 
     assert "[AST BEFORE OPT]" in salida
     assert "[AST AFTER OPT]" in salida
@@ -435,6 +438,29 @@ imprimir x == y
             _ejecutar_codigo_y_capturar_stdout_completo(codigo)
     except RecursionError as exc:  # pragma: no cover - contrato explícito
         pytest.fail(f"No debía lanzar RecursionError: {exc}")
+
+
+def test_trazas_internas_aparecen_una_sola_vez_en_debug() -> None:
+    with patch.dict("os.environ", {"PCOBRA_DEBUG_TRACES": "1"}):
+        salida = _ejecutar_codigo_y_capturar_stdout_completo("imprimir 1 == 1\n")
+
+    assert salida.count("[AST BEFORE OPT]") == 1
+    assert salida.count("[RUN] antes de iterar AST") == 1
+    assert salida.count("[EXEC]") == 1
+    assert salida.count("[EVAL]") == 1
+
+
+def test_trazas_internas_no_aparecen_en_modo_normal() -> None:
+    with patch.dict(os.environ, {"PCOBRA_DEBUG_TRACES": ""}, clear=False):
+        salida = _ejecutar_codigo_y_capturar_stdout_completo(
+            "imprimir 'condición después'\n"
+        )
+
+    assert "[AST BEFORE OPT]" not in salida
+    assert "[RUN]" not in salida
+    assert "[EXEC]" not in salida
+    assert "[EVAL]" not in salida
+    assert "condici" in salida
 
 
 def test_ast_ciclico_en_evaluacion_lanza_error_controlado_sin_recursionerror() -> None:


### PR DESCRIPTION
### Motivation
- Reducir ruido en salida normal del REPL e impedir que las trazas internas (`[AST BEFORE OPT]`, `[RUN]`, `[EXEC]`, `[EVAL]`, `[BIN-*]`, etc.) se impriman salvo en modo depuración para mejorar la ergonomía y evitar duplicados visibles.
- Asegurar que el flag de CLI `--debug` active explícitamente las trazas internas y que el modo normal no deje marcado ese comportamiento por accidente.

### Description
- Añadido helper `InterpretadorCobra._trace_debug(...)` y comprobación `InterpretadorCobra._debug_trazas_habilitadas()` que leen `PCOBRA_DEBUG_TRACES` para decidir si imprimir trazas internas, y reemplazadas las llamadas directas a `print(...)` de trazas por este helper en `src/pcobra/core/interpreter.py`.
- Conectado el entrypoint CLI para que `--debug` ponga `PCOBRA_DEBUG_TRACES=1` y que en modo normal se elimine la variable, en `src/pcobra/cli.py`.
- Actualizados y ampliados tests en `tests/unit/test_interpreter_identifier_comparisons.py` para habilitar trazas sólo en casos de debug, verificar ausencia de trazas en modo normal y comprobar que marcadores críticos aparecen una sola vez en salida debug.

### Testing
- Se ejecutaron pruebas unitarias específicas con `pytest` sobre el módulo de comparaciones del intérprete y las nuevas comprobaciones de trazas, y las siguientes colecciones pasaron: `tests/unit/test_interpreter_identifier_comparisons.py::test_debug_traces_en_comparacion_identificador_simple`, `tests/unit/test_interpreter_identifier_comparisons.py::test_debug_traces_en_comparacion_identificador_con_suma`, `tests/unit/test_interpreter_identifier_comparisons.py::test_trazas_internas_aparecen_una_sola_vez_en_debug` y `tests/unit/test_interpreter_identifier_comparisons.py::test_trazas_internas_no_aparecen_en_modo_normal` (todos `✅ passed`).
- Se probaron ejecuciones manuales de CLI en este entorno con: `printf "imprimir(1)\nsalir\n" | python -m pcobra.cli` (modo normal) y `printf "imprimir(1)\nsalir\n" | python -m pcobra.cli --debug` (modo debug), validando la presencia/ausencia de trazas internas según el modo (`✅` comprobado); también se verificó el caso de error REPL que imprime `Error: La condición debe ser booleana` (resultado funcional correcto) aunque en este entorno no interactivo se observaron `MemoryError` de `prompt_toolkit` al finalizar flujos multilinea por limitación del entorno (`⚠️ nota de entorno`).
- Comandos utilizados para verificación incluyeron `pytest -q ...` para los tests seleccionados y varios `printf | python -m pcobra.cli [--debug]` con conteo de ocurrencias de marcadores para asegurar que no se duplican (`✅ conteos verificados`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da184bd7008327bcc3dc6280a0648e)