### PR TITLE
Refuerza limpieza de errores de usuario en comando interactivo

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -66,14 +66,19 @@ SANDBOX_DOCKER_HELP = OFFICIAL_RUNTIME_TARGETS_HELP
 
 def format_user_error(exc: Exception) -> str:
     """Normaliza mensajes de error para salida limpia en la CLI."""
-    msg = str(exc).strip()
-    prefijos_redundantes = ("Error general:", "Error:")
-    while msg.startswith(prefijos_redundantes):
-        for prefijo in prefijos_redundantes:
-            if msg.startswith(prefijo):
-                msg = msg[len(prefijo):].strip()
-                break
-    return " ".join(msg.split()) or _("Error desconocido")
+    msg = " ".join(str(exc).strip().split())
+    prefijos_redundantes = re.compile(
+        r"^(?:error\s+general|error)\s*[:：\-–—]?\s*",
+        re.IGNORECASE,
+    )
+
+    while msg:
+        limpio = prefijos_redundantes.sub("", msg, count=1)
+        if limpio == msg:
+            break
+        msg = " ".join(limpio.split())
+
+    return msg or _("Error desconocido")
 
 
 class _SessionHistoryFallback:

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -34,7 +34,7 @@ sys.modules.setdefault("jsonschema", jsonschema_mod)
 import cobra.cli
 import cobra.cli.commands
 
-from cobra.cli.commands.interactive_cmd import InteractiveCommand
+from cobra.cli.commands.interactive_cmd import InteractiveCommand, format_user_error
 from core.interpreter import InterpretadorCobra
 
 
@@ -408,3 +408,22 @@ def test_ejecutar_en_sandbox_arma_script_con_captura_y_booleanos():
     assert "print('verdadero' if _resultado else 'falso')" in script_enviado
     assert 'print(_resultado)' in script_enviado
     mock_info.assert_called_once_with('ok')
+
+
+def test_format_user_error_limpia_prefijo_error_general():
+    mensaje = format_user_error(RuntimeError("Error general: La condición debe ser booleana"))
+    assert mensaje == "La condición debe ser booleana"
+
+
+def test_format_user_error_elimina_prefijos_redundantes_en_bucle():
+    mensaje = format_user_error(RuntimeError("Error: Error general: La condición debe ser booleana"))
+    assert mensaje == "La condición debe ser booleana"
+
+
+def test_log_error_imprime_mensaje_limpio_sin_categoria_tecnica():
+    cmd = InteractiveCommand(MagicMock())
+
+    with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+        cmd._log_error("Error de sintaxis", RuntimeError("Error: Error general: fallo"))
+
+    assert mock_stdout.getvalue().strip() == "Error: fallo"


### PR DESCRIPTION
### Motivation
- Mejorar la presentación de mensajes de error en el REPL para eliminar prefijos redundantes y normalizar espacios antes de mostrarlos al usuario.
- Evitar que la categoría técnica se mezcle con el texto mostrado al usuario y garantizar un fallback localizado cuando el mensaje queda vacío.

### Description
- Reescribe `format_user_error(exc)` para colapsar espacios internos, recortar bordes y normalizar el mensaje antes de procesarlo con regex; la función ahora elimina en bucle prefijos equivalentes a `Error general` y `Error` (soporta variantes de separador `:`, `：`, `-`, `–`, `—` y es insensible a mayúsculas/minúsculas).
- Mantiene el fallback localizado `"Error desconocido"` cuando el mensaje resultante queda vacío.
- Conserva `_log_error()` usando `format_user_error()` y asegurando que la salida de usuario sea exactamente `Error: <mensaje_limpio>` sin concatenar la categoría técnica al texto mostrado.
- Añade pruebas unitarias en `tests/unit/test_cli_interactive_cmd.py` que cubren eliminación de `Error general:` y limpieza en bucle para `Error: Error general: ...`, y verifican que `_log_error()` imprime sólo el prefijo `Error:` seguido del mensaje limpio.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_interactive_cmd.py -k "format_user_error or log_error"` y las pruebas relevantes pasaron (`3 passed, 26 deselected`).
- Ejecuté `pytest -q tests/unit/test_cli_interactive_cmd.py tests/unit/test_cli_execution_error_output.py` y la ejecución mostró fallos preexistentes en la suite completa además de un `MemoryError` interno de `pytest` en este entorno, por lo que esos fallos no parecen originarse de este cambio.
- Las pruebas añadidas específicas a la funcionalidad modificada se ejecutaron y pasaron correctamente en las ejecuciones dirigidas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1b1507f483279a0262def13ac2f4)