### PR TITLE
Centralizar control de logging CLI y pruebas de regresión de trazas debug

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -49,14 +49,19 @@ def _reconfigurar_consola_utf8() -> None:
 def configure_logging(debug: bool) -> None:
     """Configura logging de CLI con un único handler de consola."""
 
-    app_logger = logging.getLogger("pcobra")
-    app_logger.handlers.clear()
-    app_logger.setLevel(logging.DEBUG if debug else logging.WARNING)
-
+    level = logging.DEBUG if debug else logging.WARNING
     handler = logging.StreamHandler()
     handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
-    app_logger.addHandler(handler)
-    app_logger.propagate = False
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.setLevel(level)
+    root_logger.addHandler(handler)
+
+    app_logger = logging.getLogger("pcobra")
+    app_logger.handlers.clear()
+    app_logger.setLevel(level)
+    app_logger.propagate = True
 
 
 def _activar_compatibilidad_legacy_si_corresponde(ruta_modulo: str) -> None:

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -136,15 +136,9 @@ class InteractiveCommand(BaseCommand):
         self.interpretador = interpretador
         self._allow_insecure_fallback = False
         self.logger = logging.getLogger(__name__)
-        if self.logger.handlers:
-            # Evita salida duplicada en consola del REPL cuando este logger ya
-            # tiene un handler propio.
-            self.logger.propagate = False
-        else:
-            # Sin handler local, dejamos que el root gestione el logging
-            # técnico pero evitando ruido innecesario por defecto.
-            self.logger.propagate = True
-            self.logger.setLevel(logging.INFO)
+        # El nivel y handler se controlan centralmente desde el entrypoint CLI.
+        self.logger.propagate = True
+        self.logger.setLevel(logging.NOTSET)
         self._estado_repl = self._crear_estado_repl()
         self._debug_mode = False
 
@@ -695,7 +689,7 @@ class InteractiveCommand(BaseCommand):
             exc_info=debug_enabled,
         )
 
-        print(f"Error: {mensaje_usuario}")
+        mostrar_error(mensaje_usuario, registrar_log=False)
         if debug_enabled:
             self.logger.debug(format_traceback(error))
 

--- a/tests/unit/test_cli_logging_regression.py
+++ b/tests/unit/test_cli_logging_regression.py
@@ -1,0 +1,39 @@
+import logging
+from contextlib import redirect_stderr
+from io import StringIO
+from types import SimpleNamespace
+
+from pcobra.cli import configure_logging
+from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+
+
+def _run_interactive_and_capture_debug_traces(debug: bool) -> str:
+    configure_logging(debug=debug)
+    cmd = InteractiveCommand(SimpleNamespace(ejecutar_ast=lambda ast: None))
+    cmd.procesar_ast = lambda codigo, validador=None: []  # type: ignore[assignment]
+    buffer = StringIO()
+    root_logger = logging.getLogger()
+    original_streams = []
+    for handler in root_logger.handlers:
+        if hasattr(handler, "stream"):
+            original_streams.append((handler, handler.stream))
+            handler.setStream(buffer)
+    with redirect_stderr(buffer):
+        cmd.ejecutar_codigo("imprimir(1)")
+    for handler, stream in original_streams:
+        handler.setStream(stream)
+    return buffer.getvalue()
+
+
+def test_sin_debug_no_aparecen_trazas_internas():
+    salida = _run_interactive_and_capture_debug_traces(debug=False)
+    assert "[RUN]" not in salida
+    assert "[EXEC]" not in salida
+    assert "[EVAL]" not in salida
+
+
+def test_con_debug_si_aparecen_trazas_internas():
+    salida = _run_interactive_and_capture_debug_traces(debug=True)
+    assert "[RUN] Ejecutando snippet en REPL" in salida
+    assert "[EXEC] Ejecutando AST en intérprete" in salida
+    assert "[EVAL] Resultado de evaluación" in salida

--- a/tests/unit/test_interactive_cmd_logging.py
+++ b/tests/unit/test_interactive_cmd_logging.py
@@ -10,7 +10,7 @@ from pcobra.core.errors import CondicionNoBooleanaError
 def test_context_logging(caplog):
     dummy = types.SimpleNamespace()
     cmd = InteractiveCommand(dummy)
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.DEBUG):
         with cmd:
             pass
     messages = [r.message for r in caplog.records]
@@ -89,23 +89,23 @@ def test_format_user_error_elimina_prefijos_duplicados():
 def test_log_error_no_debug_solo_imprime_error_limpio():
     cmd = InteractiveCommand(types.SimpleNamespace())
     cmd._debug_mode = False
-    mock_print = Mock()
+    mock_mostrar_error = Mock()
     globals_log_error = InteractiveCommand._log_error.__globals__
 
     with patch.dict(
         globals_log_error,
-        {"print": mock_print},
+        {"mostrar_error": mock_mostrar_error},
     ):
         cmd._log_error(_("Error general"), Exception("Error general: Error: fallo"))
 
-    mock_print.assert_called_once_with("Error: fallo")
+    mock_mostrar_error.assert_called_once_with("fallo", registrar_log=False)
 
 
 def test_log_error_debug_muestra_traceback_en_logger():
     cmd = InteractiveCommand(types.SimpleNamespace())
     cmd._debug_mode = True
     cmd._estado_repl["debug_enabled"] = True
-    mock_print = Mock()
+    mock_mostrar_error = Mock()
     mock_logger = Mock()
     globals_log_error = InteractiveCommand._log_error.__globals__
     mock_traceback = Mock(return_value="TRACEBACK")
@@ -113,7 +113,7 @@ def test_log_error_debug_muestra_traceback_en_logger():
     with patch.dict(
         globals_log_error,
         {
-            "print": mock_print,
+            "mostrar_error": mock_mostrar_error,
             "format_traceback": mock_traceback,
         },
     ):
@@ -121,7 +121,7 @@ def test_log_error_debug_muestra_traceback_en_logger():
         cmd._log_error(_("Error general"), CondicionNoBooleanaError())
 
     mock_traceback.assert_called_once()
-    mock_print.assert_called_once()
-    primer_mensaje = mock_print.call_args_list[0].args[0]
-    assert primer_mensaje.startswith("Error: ")
+    mock_mostrar_error.assert_called_once()
+    assert mock_mostrar_error.call_args.kwargs == {"registrar_log": False}
+    assert isinstance(mock_mostrar_error.call_args.args[0], str)
     mock_logger.debug.assert_any_call("TRACEBACK")


### PR DESCRIPTION
### Motivation
- Evitar ruido inesperado de módulos externos y asegurar que `--debug` sea el único interruptor que active trazas técnicas a nivel CLI. 
- Sustituir salidas técnicas directas por logging/funciones de mensajes para mantener separación entre diagnóstico técnico y mensajes de usuario.

### Description
- `configure_logging` ahora configura también el logger raíz (`root`) con un único `StreamHandler` y aplica un único nivel (`DEBUG` cuando `debug` es True, `WARNING` en modo normal). (archivo `src/pcobra/cli.py`).
- `InteractiveCommand` delega la gestión de niveles/handlers al entrypoint CLI eliminando la configuración local y quedando con `propagate=True` y `NOTSET` para heredar la configuración central. (archivo `src/pcobra/cobra/cli/commands/interactive_cmd.py`).
- En `_log_error` se reemplaza la `print(...)` técnica por `mostrar_error(..., registrar_log=False)` para la salida al usuario y se conserva el detalle técnico en `self.logger.debug(...)` solo si aplica `debug`. (archivo `src/pcobra/cobra/cli/commands/interactive_cmd.py`).
- Se añadieron y actualizaron pruebas: nueva regresión `tests/unit/test_cli_logging_regression.py` que verifica la presencia/ausencia de las trazas `[RUN]`, `[EXEC]`, `[EVAL]` según `--debug`, y se adaptaron tests existentes de logging en `tests/unit/test_interactive_cmd_logging.py` para el comportamiento centralizado.

### Testing
- Ejecutado: `pytest -q tests/unit/test_cli_logging_regression.py tests/unit/test_interactive_cmd_logging.py`.
- Resultado: todas las pruebas ejecutadas pasaron (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1c1a51e48327a8f349e8fcd0b574)