### PR TITLE
Centraliza logging de CLI y evita duplicación al inicializar varias veces

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -47,20 +47,25 @@ def _reconfigurar_consola_utf8() -> None:
 
 
 def configure_logging(debug: bool) -> None:
-    """Configura logging de CLI con un único handler de consola."""
+    """Configura logging de CLI con un único handler efectivo de consola."""
 
     level = logging.DEBUG if debug else logging.WARNING
+    formatter = logging.Formatter("%(levelname)s: %(message)s")
     handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    handler.setFormatter(formatter)
 
     root_logger = logging.getLogger()
-    root_logger.handlers.clear()
+    for existing_handler in list(root_logger.handlers):
+        root_logger.removeHandler(existing_handler)
+        existing_handler.close()
     root_logger.setLevel(level)
     root_logger.addHandler(handler)
 
     app_logger = logging.getLogger("pcobra")
-    app_logger.handlers.clear()
-    app_logger.setLevel(level)
+    for existing_handler in list(app_logger.handlers):
+        app_logger.removeHandler(existing_handler)
+        existing_handler.close()
+    app_logger.setLevel(logging.NOTSET)
     app_logger.propagate = True
 
 

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -136,9 +136,8 @@ class InteractiveCommand(BaseCommand):
         self.interpretador = interpretador
         self._allow_insecure_fallback = False
         self.logger = logging.getLogger(__name__)
-        # El nivel y handler se controlan centralmente desde el entrypoint CLI.
+        # El nivel y handlers se controlan centralmente desde el entrypoint CLI.
         self.logger.propagate = True
-        self.logger.setLevel(logging.NOTSET)
         self._estado_repl = self._crear_estado_repl()
         self._debug_mode = False
 

--- a/tests/unit/test_cli_logging_regression.py
+++ b/tests/unit/test_cli_logging_regression.py
@@ -37,3 +37,27 @@ def test_con_debug_si_aparecen_trazas_internas():
     assert "[RUN] Ejecutando snippet en REPL" in salida
     assert "[EXEC] Ejecutando AST en intérprete" in salida
     assert "[EVAL] Resultado de evaluación" in salida
+
+
+def test_configure_logging_es_idempotente_y_no_duplica_emision():
+    configure_logging(debug=True)
+    configure_logging(debug=True)
+
+    root_logger = logging.getLogger()
+    assert len(root_logger.handlers) == 1
+
+    buffer = StringIO()
+    original_stream = None
+    handler = root_logger.handlers[0]
+    if hasattr(handler, "stream"):
+        original_stream = handler.stream
+        handler.setStream(buffer)
+
+    try:
+        logging.getLogger("pcobra.test").debug("mensaje único")
+    finally:
+        if original_stream is not None:
+            handler.setStream(original_stream)
+
+    salida = buffer.getvalue()
+    assert salida.count("mensaje único") == 1


### PR DESCRIPTION
### Motivation
- Evitar que comandos locales (REPL) impongan handlers o niveles que provoquen duplicación o formatos inconsistentes al inicializar la CLI varias veces.  
- Simplificar la estrategia de logging para que un único handler efectivo en el root controle salida y niveles para todo el paquete `pcobra`.

### Description
- Elimina el ajuste local de nivel en `InteractiveCommand.__init__` para que el REPL herede la configuración global y mantiene `self.logger.propagate = True` como estrategia única de propagación.  
- `configure_logging` en `pcobra/cli.py` ahora remueve y cierra explícitamente handlers previos en `root` y en el logger `pcobra` antes de añadir un único `StreamHandler`.  
- Se establece `pcobra` con `setLevel(logging.NOTSET)` y `propagate = True` para heredar nivel/formato del root y evitar duplicación por handlers locales.  
- Añade prueba de regresión `test_configure_logging_es_idempotente_y_no_duplica_emision` que inicializa logging dos veces y verifica que solo exista un handler y que un mensaje se emita una sola vez.

### Testing
- Se ejecutaron los tests afectados con `pytest -q tests/unit/test_cli_logging_regression.py tests/unit/test_interactive_cmd_logging.py` y ambos archivos pasaron exitosamente (`10 passed`).  
- La nueva prueba de idempotencia se añadió en `tests/unit/test_cli_logging_regression.py` y fue verificada como parte de la ejecución anterior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1d96f4a48327b9244633d992c7aa)