### PR TITLE
Mejorar fallback UTF-8 en CLI y añadir pruebas para streams sin `reconfigure`

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -37,13 +37,20 @@ if _CANONICAL_CLI_PACKAGE_DIR.is_dir():
 
 def _reconfigurar_consola_utf8() -> None:
     """Fuerza UTF-8 en stdout/stderr cuando el runtime lo soporta."""
+    # Mitigación para consolas Windows/legacy con codificación no-UTF8.
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name, None)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(encoding="utf-8")
+        except Exception:
+            # Fail-safe: no bloquear el arranque del CLI por la consola.
+            pass
 
-    try:
-        sys.stdout.reconfigure(encoding="utf-8")
-        sys.stderr.reconfigure(encoding="utf-8")
-    except Exception:
-        # Compatibilidad con runtimes donde ``reconfigure`` no existe.
-        pass
+    # Solo define fallback de codificación si el usuario no la fijó explícitamente.
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
 
 
 def configure_logging(debug: bool) -> None:

--- a/tests/unit/test_cli_configurar_entorno.py
+++ b/tests/unit/test_cli_configurar_entorno.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 import types
 
@@ -53,7 +54,7 @@ jsonschema_stub.ValidationError = _JsonSchemaValidationError
 jsonschema_stub.validate = lambda *args, **kwargs: None
 sys.modules.setdefault("jsonschema", jsonschema_stub)
 
-from pcobra.cli import configurar_entorno
+from pcobra.cli import _reconfigurar_consola_utf8, configurar_entorno
 
 
 def test_configurar_entorno_permiso_denegado(monkeypatch, caplog):
@@ -69,3 +70,39 @@ def test_configurar_entorno_permiso_denegado(monkeypatch, caplog):
     configurar_entorno()
 
     assert "No se pudo acceder al archivo .env" in caplog.text
+
+
+class _DummyStreamSinReconfigure:
+    def __init__(self):
+        self.buffer: list[str] = []
+
+    def write(self, text: str) -> int:
+        self.buffer.append(text)
+        return len(text)
+
+    def getvalue(self) -> str:
+        return "".join(self.buffer)
+
+
+def test_reconfigurar_consola_utf8_fallback_no_rompe_sin_reconfigure(monkeypatch):
+    out = _DummyStreamSinReconfigure()
+    err = _DummyStreamSinReconfigure()
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(sys, "stderr", err)
+    monkeypatch.delenv("PYTHONIOENCODING", raising=False)
+
+    _reconfigurar_consola_utf8()
+
+    out.write("Salida legible: áéíóú")
+    err.write("Error legible: ñ")
+    assert out.getvalue() == "Salida legible: áéíóú"
+    assert err.getvalue() == "Error legible: ñ"
+    assert os.environ["PYTHONIOENCODING"] == "utf-8"
+
+
+def test_reconfigurar_consola_utf8_no_sobrescribe_pythonioencoding(monkeypatch):
+    monkeypatch.setenv("PYTHONIOENCODING", "latin-1")
+
+    _reconfigurar_consola_utf8()
+
+    assert os.environ["PYTHONIOENCODING"] == "latin-1"


### PR DESCRIPTION
### Motivation
- Garantizar que el arranque del CLI fuerza UTF-8 cuando sea posible sin romper en runtimes/consolas legacy que no exponen `reconfigure` en `stdout`/`stderr`.
- Respetar cualquier codificación definida por el usuario mediante la variable `PYTHONIOENCODING` y sólo aplicar un fallback si no existe.

### Description
- Mantiene `_reconfigurar_consola_utf8()` como punto único de configuración y ahora itera por `stdout` y `stderr` aplicando `reconfigure(encoding="utf-8")` de forma independiente y en modo fail-safe para no bloquear el arranque si falla.
- Añade un comentario corto indicando que es una mitigación para consolas Windows/legacy y usa `os.environ.setdefault("PYTHONIOENCODING", "utf-8")` para el fallback sin sobrescribir valores del usuario.
- Añade pruebas unitarias nuevas en `tests/unit/test_cli_configurar_entorno.py` con dobles de `sys.stdout`/`sys.stderr` que no tienen `reconfigure`, comprobando que no rompe el inicio, que la salida sigue siendo legible y que `PYTHONIOENCODING` sólo se define si no existía.
- Archivos modificados: `src/pcobra/cli.py` y `tests/unit/test_cli_configurar_entorno.py`.

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_configurar_entorno.py` y todas las pruebas pasaron (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1e9054e08327bfb71c441ac4c3e7)