### PR TITLE
Mejora la normalización de errores de usuario en el REPL

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -68,7 +68,7 @@ def format_user_error(exc: Exception) -> str:
     """Normaliza mensajes de error para salida limpia en la CLI."""
     msg = " ".join(str(exc).strip().split())
     prefijos_redundantes = re.compile(
-        r"^(?:error\s+general|error)\s*[:：\-–—]?\s*",
+        r"^(?:error\s+general|error\s+cr[ií]tico|error\s+de\s+sintaxis|error)\s*[:：\-–—]?\s*",
         re.IGNORECASE,
     )
 
@@ -674,7 +674,7 @@ class InteractiveCommand(BaseCommand):
         """Registra y muestra un error.
 
         Args:
-            categoria: Categoría del error
+            categoria: Categoría técnica usada solo para logging interno
             error: Excepción ocurrida
         """
         mensaje_usuario = format_user_error(error)

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -420,6 +420,18 @@ def test_format_user_error_elimina_prefijos_redundantes_en_bucle():
     assert mensaje == "La condición debe ser booleana"
 
 
+def test_format_user_error_normaliza_prefijos_redundantes_adicionales():
+    assert (
+        format_user_error(RuntimeError("Error general: La condición debe ser booleana"))
+        == "La condición debe ser booleana"
+    )
+    assert (
+        format_user_error(RuntimeError("Error: Error general: La condición debe ser booleana"))
+        == "La condición debe ser booleana"
+    )
+    assert format_user_error(RuntimeError("Error crítico - Error: mensaje")) == "mensaje"
+
+
 def test_log_error_imprime_mensaje_limpio_sin_categoria_tecnica():
     cmd = InteractiveCommand(MagicMock())
 


### PR DESCRIPTION
### Motivation
- Evitar que los mensajes de excepción mostrados al usuario repitan prefijos técnicos (p. ej. "Error", "Error general", "Error crítico", "Error de sintaxis") cuando vienen encadenados en `str(exc)`. 
- Dejar claro que la `categoria` usada en `_log_error` es solo para logging técnico y no forma parte del mensaje visible al usuario. 

### Description
- Amplié `format_user_error(exc)` para normalizar defensivamente y eliminar iterativamente prefijos redundantes adicionales al inicio del mensaje (soporta variantes como `Error general`, `Error crítico`, `Error de sintaxis`, y `Error`, con distintos separadores). (`src/pcobra/cobra/cli/commands/interactive_cmd.py`)
- Documenté en `_log_error` que el parámetro `categoria` es una etiqueta técnica usada únicamente para logging interno. (`src/pcobra/cobra/cli/commands/interactive_cmd.py`)
- Añadí pruebas unitarias que cubren los casos solicitados: `"Error general: La condición debe ser booleana"`, `"Error: Error general: La condición debe ser booleana"` y `"Error crítico - Error: mensaje"`. (`tests/unit/test_cli_interactive_cmd.py`)
- Revisé los puntos de llamada del REPL y confirmé que las excepciones se canalizan por `_log_error`, que invoca `mostrar_error(...)` con el `mensaje_usuario` ya limpiado.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_interactive_cmd.py -k "format_user_error"` y todas las pruebas relacionadas con `format_user_error` pasaron. (OK)
- Ejecuté `pytest -q tests/unit/test_interactive_cmd_logging.py` y todas las pruebas en ese módulo pasaron. (OK)
- Ejecuté `pytest -q tests/unit/test_cli_interactive_cmd.py -k "format_user_error or log_error_imprime_mensaje_limpio_sin_categoria_tecnica"` y se produjo una falla en un test existente debido a códigos ANSI de color en la salida esperada (la diferencia fue la presencia de secuencias de color en la salida real), por lo que ese caso concreto requiere ajustar la expectativa del test o la función que imprime colores; sin embargo, la lógica de normalización añadida fue verificada por las pruebas nuevas y existentes relacionadas con `format_user_error`. (Parcial)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2032a89483279a54a7ef603d0683)