### PR TITLE
Unificar fuente de verdad de --debug en la CLI y añadir prueba de trazas

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -799,7 +799,7 @@ class CliApplication:
                         "SQLITE_DB_KEY no requerida por comando '%s'.", command_name
                     )
                 self._enforce_runtime_safety_policy(args)
-                debug_activo = args.verbose > 0 or args.debug
+                debug_activo = bool(args.debug)
                 setup_gettext(args.lang)
                 messages.disable_colors(args.no_color)
                 if getattr(args, "legacy_imports", False):

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -139,6 +139,8 @@ class InteractiveCommand(BaseCommand):
         # El nivel y handlers se controlan centralmente desde el entrypoint CLI.
         self.logger.propagate = True
         self._estado_repl = self._crear_estado_repl()
+        # Estado local para tracebacks técnicos en REPL.
+        # Fuente canónica: flag global --debug parseado por la CLI principal.
         self._debug_mode = False
 
     @staticmethod
@@ -204,11 +206,6 @@ class InteractiveCommand(BaseCommand):
             "--ignore-memory-limit",
             action="store_true",
             help=_("Continúa aun si no se puede aplicar el límite de memoria"),
-        )
-        parser.add_argument(
-            "--debug",
-            action="store_true",
-            help=_("Muestra trazas internas de depuración"),
         )
         parser.set_defaults(cmd=self)
         return parser

--- a/tests/integration/test_cli_debug_flag_traces.py
+++ b/tests/integration/test_cli_debug_flag_traces.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+TRACE_TAGS = ("[AST BEFORE OPT]", "[RUN]", "[EXEC]", "[EVAL]")
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_cli(debug: bool) -> str:
+    cmd = [sys.executable, "-m", "pcobra.cli"]
+    if debug:
+        cmd.append("--debug")
+    cmd.extend(["ejecutar", "tests/data/ejemplo.co"])
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(ROOT / "src"), str(ROOT), env.get("PYTHONPATH", "")]
+    )
+    env.pop("PYTEST_CURRENT_TEST", None)
+    env["PCOBRA_DEBUG_TRACES"] = "1"
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=ROOT,
+        env=env,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    return f"{result.stdout}\n{result.stderr}"
+
+
+def test_cli_sin_debug_no_emite_trazas_internas():
+    salida = _run_cli(debug=False)
+    for tag in TRACE_TAGS:
+        assert tag not in salida
+
+
+def test_cli_con_debug_emite_trazas_internas():
+    salida = _run_cli(debug=True)
+    for tag in TRACE_TAGS:
+        assert tag in salida

--- a/tests/unit/test_cli_execution_error_output.py
+++ b/tests/unit/test_cli_execution_error_output.py
@@ -106,7 +106,7 @@ def test_run_propaga_debug_activo_hacia_execute_command():
         result = app.run([])
 
     assert result == 0
-    mock_execute_command.assert_called_once_with(args, debug_activo=True)
+    mock_execute_command.assert_called_once_with(args, debug_activo=False)
 
 
 def test_run_bloquea_fallback_inseguro_en_ci_sin_override(monkeypatch):

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -151,15 +151,14 @@ def test_interactive_help_refleja_politica_de_bloques_y_lineas_blancas():
     assert 'se prohíben bloques vacíos' in subparser.description
 
 
-def test_interactive_help_incluye_flag_debug():
+def test_interactive_help_no_define_flag_debug_local():
     cmd = InteractiveCommand(MagicMock())
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='command')
     subparser = cmd.register_subparser(subparsers)
 
     acciones = {action.dest: action for action in subparser._actions}
-    assert "debug" in acciones
-    assert acciones["debug"].help == "Muestra trazas internas de depuración"
+    assert "debug" not in acciones
 
 
 def test_interactive_persist_debug_enabled_en_estado_repl():


### PR DESCRIPTION
### Motivation
- Evitar doble fuente de verdad para el modo debug entre la CLI global y subcomandos y garantizar que las trazas internas solo se habiliten cuando el usuario pase explícitamente `--debug`.
- Garantizar que la variable de entorno `PCOBRA_DEBUG_TRACES` se gestione en el entrypoint y no quede activada por flags locales o por `--verbose` accidentalmente.
- Mantener un estado local en el REPL (`_debug_mode`) solo para manejo técnico de tracebacks sin convertirse en la fuente canónica de verdad.
- Añadir una prueba de integración que verifique la presencia/ausencia de etiquetas de trazas según el flag global `--debug`.

### Description
- Cambiado en `src/pcobra/cobra/cli/cli.py` la determinación de `debug_activo` para depender exclusivamente de `args.debug` (`debug_activo = bool(args.debug)`) y eliminar la activación implícita por `args.verbose`.
- Modificado `src/pcobra/cobra/cli/commands/interactive_cmd.py` para eliminar el argumento local `--debug` del subcomando `interactive` y añadir comentario que documenta que la fuente canónica es el flag global; se conserva `_debug_mode` como estado local técnico para tracebacks.
- Añadida la prueba de integración `tests/integration/test_cli_debug_flag_traces.py` que invoca la CLI real (`python -m pcobra.cli ejecutar tests/data/ejemplo.co`) y comprueba que las etiquetas `"[AST BEFORE OPT]"`, `"[RUN]"`, `"[EXEC]"`, `"[EVAL]"` solo aparecen cuando se pasa `--debug`.
- Actualizadas pruebas unitarias para reflejar el nuevo contrato: `tests/unit/test_cli_interactive_cmd.py` ahora espera que el subparser interactivo no declare `--debug`, y `tests/unit/test_cli_execution_error_output.py` adapta la aserción sobre cómo se propaga `debug_activo`.
- Verificado que en el entrypoint `src/pcobra/cli.py` la gestión de `PCOBRA_DEBUG_TRACES` ya fija la variable solo cuando `--debug` está presente y la limpia en caso contrario.

### Testing
- Ejecutado `pytest -q tests/integration/test_cli_debug_flag_traces.py tests/unit/test_cli_execution_error_output.py::test_run_propaga_debug_activo_hacia_execute_command tests/unit/test_cli_interactive_cmd.py::test_interactive_help_no_define_flag_debug_local tests/unit/test_cli_logging_regression.py` y todas las pruebas pasaron (`7 passed`).
- Ejecutadas también pruebas unitarias relevantes que verifican logging y comportamiento del REPL (`tests/unit/test_cli_logging_regression.py` y pruebas de `interactive_cmd`) y se validó la compatibilidad con la nueva política de debug.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da218002ac8327aee4c070dc8152a5)