### PR TITLE
Unifica contrato de logging en CLI y evita duplicación de emisiones

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -54,7 +54,14 @@ def _reconfigurar_consola_utf8() -> None:
 
 
 def configure_logging(debug: bool) -> None:
-    """Configura logging de CLI con un único handler efectivo de consola."""
+    """Configura logging de CLI con un único handler efectivo de consola.
+
+    Contrato de logging del proyecto:
+    - El *único* ``StreamHandler`` de consola vive en el logger raíz.
+    - Los módulos (incluido ``pcobra`` y sus submódulos) **no** deben adjuntar
+      handlers locales; sólo deben obtener su logger con ``getLogger(__name__)``
+      y propagar al root.
+    """
 
     level = logging.DEBUG if debug else logging.WARNING
     formatter = logging.Formatter("%(levelname)s: %(message)s")
@@ -69,9 +76,7 @@ def configure_logging(debug: bool) -> None:
     root_logger.addHandler(handler)
 
     app_logger = logging.getLogger("pcobra")
-    for existing_handler in list(app_logger.handlers):
-        app_logger.removeHandler(existing_handler)
-        existing_handler.close()
+    app_logger.handlers = []
     app_logger.setLevel(logging.NOTSET)
     app_logger.propagate = True
 

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -135,9 +135,9 @@ class InteractiveCommand(BaseCommand):
         super().__init__()
         self.interpretador = interpretador
         self._allow_insecure_fallback = False
+        # Contrato de logging: no agregar handlers por comando; la emisión se
+        # centraliza en root configurado desde ``pcobra.cli.configure_logging``.
         self.logger = logging.getLogger(__name__)
-        # El nivel y handlers se controlan centralmente desde el entrypoint CLI.
-        self.logger.propagate = True
         self._estado_repl = self._crear_estado_repl()
         # Estado local para tracebacks técnicos en REPL.
         # Fuente canónica: flag global --debug parseado por la CLI principal.

--- a/tests/unit/test_cli_logging.py
+++ b/tests/unit/test_cli_logging.py
@@ -59,7 +59,7 @@ def test_cli_no_debug(caplog):
             ret = app.run([])
 
     assert ret == 0
-    assert logging.getLogger().getEffectiveLevel() == logging.INFO
+    assert logging.getLogger().getEffectiveLevel() == logging.WARNING
     assert not any(rec.levelno == logging.DEBUG for rec in caplog.records)
 
 

--- a/tests/unit/test_cli_logging_regression.py
+++ b/tests/unit/test_cli_logging_regression.py
@@ -61,3 +61,37 @@ def test_configure_logging_es_idempotente_y_no_duplica_emision():
 
     salida = buffer.getvalue()
     assert salida.count("mensaje único") == 1
+
+
+def test_configure_logging_no_duplica_debug_ni_error_en_consola():
+    configure_logging(debug=True)
+    configure_logging(debug=True)
+
+    root_logger = logging.getLogger()
+    assert len(root_logger.handlers) == 1
+
+    buffer = StringIO()
+    handler = root_logger.handlers[0]
+    original_stream = getattr(handler, "stream", None)
+    if hasattr(handler, "setStream"):
+        handler.setStream(buffer)
+
+    try:
+        logger = logging.getLogger("pcobra.test")
+        logger.debug("debug sin duplicación")
+        logger.error("error sin duplicación")
+    finally:
+        if original_stream is not None and hasattr(handler, "setStream"):
+            handler.setStream(original_stream)
+
+    salida = buffer.getvalue()
+    assert salida.count("debug sin duplicación") == 1
+    assert salida.count("error sin duplicación") == 1
+
+
+def test_configure_logging_pcobra_sin_handlers_locales_y_con_propagacion():
+    configure_logging(debug=False)
+    app_logger = logging.getLogger("pcobra")
+
+    assert app_logger.handlers == []
+    assert app_logger.propagate is True


### PR DESCRIPTION
### Motivation
- Establecer un contrato claro de logging para el CLI para evitar duplicación de mensajes en consola y asegurar que los módulos no añadan handlers locales.
- Preferir un único `StreamHandler` en el logger raíz y hacer que los loggers de módulo propaguen para simplificar la estrategia de emisión.

### Description
- Documenté el contrato de logging en el docstring de `configure_logging` y centralicé el `StreamHandler` en el logger raíz (`root`).
- Cambié la estrategia del logger `pcobra` a la opción recomendada asignando `app_logger.handlers = []`, `app_logger.setLevel(logging.NOTSET)` y `app_logger.propagate = True` para evitar handlers locales.
- Revisé `InteractiveCommand` en `src/pcobra/cobra/cli/commands/interactive_cmd.py` para dejar explícito que no se deben agregar handlers por comando y mantener el patrón `logging.getLogger(__name__)`.
- Ajusté una expectativa de prueba para el nivel por defecto a `WARNING` y añadí pruebas de regresión que verifican que eventos `debug` y `error` se emiten una sola vez y que `pcobra` no conserva handlers locales.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_logging_regression.py tests/unit/test_cli_logging.py tests/unit/test_interactive_cmd_logging.py` y todas las pruebas pasaron.
- Resultado: `14 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da2dadf2948327a5e455659ef8d277)