### PR TITLE
Asegura bootstrap UTF-8 en arranque canónico del CLI

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -37,20 +37,9 @@ if _CANONICAL_CLI_PACKAGE_DIR.is_dir():
 
 def _reconfigurar_consola_utf8() -> None:
     """Fuerza UTF-8 en stdout/stderr cuando el runtime lo soporta."""
-    # Mitigación para consolas Windows/legacy con codificación no-UTF8.
-    for stream_name in ("stdout", "stderr"):
-        stream = getattr(sys, stream_name, None)
-        reconfigure = getattr(stream, "reconfigure", None)
-        if not callable(reconfigure):
-            continue
-        try:
-            reconfigure(encoding="utf-8")
-        except Exception:
-            # Fail-safe: no bloquear el arranque del CLI por la consola.
-            pass
+    from pcobra.cobra.cli.bootstrap import reconfigurar_consola_utf8
 
-    # Solo define fallback de codificación si el usuario no la fijó explícitamente.
-    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+    reconfigurar_consola_utf8()
 
 
 def configure_logging(debug: bool) -> None:

--- a/src/pcobra/cobra/cli/bootstrap.py
+++ b/src/pcobra/cobra/cli/bootstrap.py
@@ -1,0 +1,22 @@
+"""Bootstrap utilities for CLI startup concerns."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def reconfigurar_consola_utf8() -> None:
+    """Fuerza UTF-8 en stdout/stderr cuando el runtime lo soporta."""
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name, None)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(encoding="utf-8")
+        except Exception:
+            # Fail-safe: no bloquear el arranque del CLI por la consola.
+            pass
+
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -44,6 +44,7 @@ from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
 from pcobra.cobra.cli.commands.validar_sintaxis_cmd import ValidarSintaxisCommand
 from pcobra.cobra.cli.commands.qa_validar_cmd import QaValidarCommand
 from pcobra.cobra.cli.i18n import _, format_traceback, setup_gettext
+from pcobra.cobra.cli.bootstrap import reconfigurar_consola_utf8
 from pcobra.cobra.cli.mode_policy import (
     CLI_MODOS_PERMITIDOS,
     MODO_POR_DEFECTO,
@@ -826,6 +827,7 @@ class CliApplication:
 
 def main(argv: Optional[List[str]] = None) -> int:
     """Main entry point for the CLI."""
+    reconfigurar_consola_utf8()
     application = CliApplication()
     return application.run(argv)
 


### PR DESCRIPTION
### Motivation
- Garantizar que la inicialización de la consola force UTF-8 en todas las rutas de arranque del CLI para evitar problemas de codificación en consolas legacy.
- Evitar ciclos de import y mantener un punto de inicialización liviano reutilizable para el bootstrap UTF-8.
- Mantener alcance mínimo del cambio: no tocar lexer/parser/AST/interpreter/runtime, no cambiar `print()` ni introducir dependencias.

### Description
- Añade `src/pcobra/cobra/cli/bootstrap.py` con la función liviana `reconfigurar_consola_utf8()` que implementa el contrato existente (uso condicional de `stream.reconfigure(encoding="utf-8")`, `try/except Exception` fail-safe y `os.environ.setdefault("PYTHONIOENCODING", "utf-8")`).
- Actualiza `src/pcobra/cli.py` para delegar `_reconfigurar_consola_utf8()` al nuevo módulo `pcobra.cobra.cli.bootstrap` conservando la compatibilidad del API interno.
- Invoca `reconfigurar_consola_utf8()` al inicio de `src/pcobra/cobra/cli/cli.py::main()` antes de crear la instancia `CliApplication`, asegurando que el entrypoint canónico siempre pase por el bootstrap.
- No se añadieron dependencias ni se modificó la semántica del lenguaje ni componentes de ejecución/interpretación.

### Testing
- Se compiló el código afectado con `python -m compileall -q src/pcobra/cli.py src/pcobra/cobra/cli/bootstrap.py src/pcobra/cobra/cli/cli.py` y la compilación terminó sin errores.
- Se verificaron los cambios con `git diff` y la estructura de módulos importables fue inspeccionada localmente (sin pruebas unitarias nuevas añadidas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da31c90b148327a5bd6c9918121f36)