### PR TITLE
cli: limitar bootstrap UTF-8 al entrypoint de inicialización

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -44,7 +44,6 @@ from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
 from pcobra.cobra.cli.commands.validar_sintaxis_cmd import ValidarSintaxisCommand
 from pcobra.cobra.cli.commands.qa_validar_cmd import QaValidarCommand
 from pcobra.cobra.cli.i18n import _, format_traceback, setup_gettext
-from pcobra.cobra.cli.bootstrap import reconfigurar_consola_utf8
 from pcobra.cobra.cli.mode_policy import (
     CLI_MODOS_PERMITIDOS,
     MODO_POR_DEFECTO,
@@ -827,7 +826,6 @@ class CliApplication:
 
 def main(argv: Optional[List[str]] = None) -> int:
     """Main entry point for the CLI."""
-    reconfigurar_consola_utf8()
     application = CliApplication()
     return application.run(argv)
 


### PR DESCRIPTION
### Motivation

- Asegurar que el patrón defensivo de forzar UTF-8 en streams se mantenga tal cual y no cambie su comportamiento.
- Ejecutar la lógica de bootstrap de encoding únicamente en la inicialización externa del CLI para evitar efectos secundarios en capas internas.
- No sobrescribir configuraciones explícitas del usuario manteniendo `os.environ.setdefault("PYTHONIOENCODING", "utf-8")`.

### Description

- Eliminada la llamada a `reconfigurar_consola_utf8()` desde `src/pcobra/cobra/cli/cli.py::main` para evitar ejecutar el bootstrap en capas internas.
- Se mantiene intacta la implementación defensiva en `src/pcobra/cobra/cli/bootstrap.py` usando `getattr(sys, "stdout"/"stderr", None)`, `getattr(stream, "reconfigure", None)`, comprobación `callable`, `try/except Exception: pass` y `os.environ.setdefault("PYTHONIOENCODING", "utf-8")`.
- La inicialización oficial del CLI sigue centralizando el bootstrap llamando a `_reconfigurar_consola_utf8()` desde `src/pcobra/cli.py::main`.

### Testing

- Se compiló el módulo modificado con `python -m compileall src/pcobra/cobra/cli/cli.py` y la compilación finalizó correctamente.
- Se ejecutó `python -m pcobra --ayuda` y el comando devolvió la ayuda del CLI correctamente sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da32da42e083278ff92683a8467add)