### PR TITLE
test(cli): cubrir UTF-8 y mojibake en bootstrap de consola

### DIFF
--- a/tests/unit/test_cli_bootstrap_utf8.py
+++ b/tests/unit/test_cli_bootstrap_utf8.py
@@ -1,0 +1,77 @@
+import os
+import subprocess
+import sys
+
+from pcobra.cobra.cli.bootstrap import reconfigurar_consola_utf8
+
+
+class _DummyStreamConReconfigure:
+    def __init__(self):
+        self.calls: list[dict[str, str]] = []
+
+    def reconfigure(self, *, encoding: str) -> None:
+        self.calls.append({"encoding": encoding})
+
+
+class _DummyStreamSinReconfigure:
+    def __init__(self):
+        self.buffer: list[str] = []
+
+    def write(self, text: str) -> int:
+        self.buffer.append(text)
+        return len(text)
+
+
+def test_bootstrap_reconfigura_streams_utf8(monkeypatch):
+    out = _DummyStreamConReconfigure()
+    err = _DummyStreamConReconfigure()
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(sys, "stderr", err)
+    monkeypatch.delenv("PYTHONIOENCODING", raising=False)
+
+    reconfigurar_consola_utf8()
+
+    assert out.calls == [{"encoding": "utf-8"}]
+    assert err.calls == [{"encoding": "utf-8"}]
+    assert os.environ["PYTHONIOENCODING"] == "utf-8"
+
+
+def test_bootstrap_no_rompe_si_stream_no_tiene_reconfigure(monkeypatch):
+    out = _DummyStreamSinReconfigure()
+    err = _DummyStreamSinReconfigure()
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(sys, "stderr", err)
+    monkeypatch.delenv("PYTHONIOENCODING", raising=False)
+
+    reconfigurar_consola_utf8()
+
+    out.write("Salida: áéíóú")
+    err.write("Error: ñ")
+    assert "".join(out.buffer) == "Salida: áéíóú"
+    assert "".join(err.buffer) == "Error: ñ"
+    assert os.environ["PYTHONIOENCODING"] == "utf-8"
+
+
+def test_cli_subprocess_preserva_utf8_en_salida_acentuada():
+    # Objetivo: cubrir mojibake típico de Windows (Ã©, Ã±, etc.)
+    # en salida de consola sin tocar semántica del lenguaje.
+    env = os.environ.copy()
+    env.pop("PYTHONIOENCODING", None)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from pcobra.cobra.cli.bootstrap import reconfigurar_consola_utf8; "
+            "reconfigurar_consola_utf8(); print('después')",
+        ],
+        env=env,
+        capture_output=True,
+        check=True,
+    )
+
+    assert result.stdout == "después\n".encode("utf-8")
+    texto = result.stdout.decode("utf-8")
+    assert texto == "después\n"
+    assert "Ã©" not in texto
+    assert "Ã±" not in texto


### PR DESCRIPTION
### Motivation
- Asegurar que el bootstrap del CLI fuerza/expone UTF-8 en las salidas de consola para evitar mojibake típico de Windows (p. ej. `Ã©`, `Ã±`).
- Cubrir tanto el caso en que los streams exponen `reconfigure` como el fallback cuando no existe dicho método.
- Verificar mediante una ejecución mínima tipo CLI que una salida acentuada como `después` se captura y decodifica correctamente como UTF-8.

### Description
- Añade `tests/unit/test_cli_bootstrap_utf8.py` con tres pruebas que ejercitan el bootstrap de consola del CLI.
- Implementa la prueba `test_bootstrap_reconfigura_streams_utf8` que mockea `stdout`/`stderr` con `reconfigure` y comprueba llamadas a `reconfigure(encoding="utf-8")` y `PYTHONIOENCODING`.
- Implementa la prueba `test_bootstrap_no_rompe_si_stream_no_tiene_reconfigure` que valida el comportamiento fail-safe cuando los streams no exponen `reconfigure` y que la escritura sigue soportando caracteres acentuados.
- Implementa la prueba de integración mínima `test_cli_subprocess_preserva_utf8_en_salida_acentuada` que lanza un subprocess que imprime `después` y verifica los bytes UTF-8 y ausencia de mojibake en la salida.

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_bootstrap_utf8.py` y las tres pruebas pasaron (`3 passed`).
- Las pruebas verifican explícitamente las llamadas a `reconfigure`, el fallback sin `reconfigure` y la preservación de UTF-8 en una ejecución real de Python via `subprocess`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da33cd49a88327a4a156f4fcd2801b)