### PR TITLE
Ensure UTF-8 console bootstrap in canonical CLI entrypoint

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -826,6 +826,9 @@ class CliApplication:
 
 def main(argv: Optional[List[str]] = None) -> int:
     """Main entry point for the CLI."""
+    from pcobra.cobra.cli.bootstrap import reconfigurar_consola_utf8
+
+    reconfigurar_consola_utf8()
     application = CliApplication()
     return application.run(argv)
 


### PR DESCRIPTION
### Motivation
- Garantizar que la ruta de arranque canónica del CLI ejecute la reconfiguración de consola a UTF-8 antes de construir/ejecutar la `CliApplication`, alineando su comportamiento con `src/pcobra/cli.py` y evitando salidas de usuario con encoding incorrecto.

### Description
- Se añadió la importación y llamada a `reconfigurar_consola_utf8()` (delegando a `pcobra.cobra.cli.bootstrap.reconfigurar_consola_utf8`) al inicio de `main()` en `src/pcobra/cobra/cli/cli.py`, sin modificar parser, lexer, AST, intérprete ni runtime.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/cli.py src/pcobra/cobra/cli/cli.py` y la comprobación de sintaxis completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3541419083279bd6477312ba93ab)