### PR TITLE
test: cubrir preservación de PYTHONIOENCODING en bootstrap CLI

### DIFF
--- a/tests/unit/test_cli_bootstrap_utf8.py
+++ b/tests/unit/test_cli_bootstrap_utf8.py
@@ -52,6 +52,14 @@ def test_bootstrap_no_rompe_si_stream_no_tiene_reconfigure(monkeypatch):
     assert os.environ["PYTHONIOENCODING"] == "utf-8"
 
 
+def test_bootstrap_no_sobrescribe_pythonioencoding_existente(monkeypatch):
+    monkeypatch.setenv("PYTHONIOENCODING", "latin-1")
+
+    reconfigurar_consola_utf8()
+
+    assert os.environ["PYTHONIOENCODING"] == "latin-1"
+
+
 def test_cli_subprocess_preserva_utf8_en_salida_acentuada():
     # Objetivo: cubrir mojibake típico de Windows (Ã©, Ã±, etc.)
     # en salida de consola sin tocar semántica del lenguaje.


### PR DESCRIPTION
### Motivation
- Asegurar explícitamente que el bootstrap de la CLI no sobrescribe valores preexistentes de `PYTHONIOENCODING` y dejar cobertura unitaria que lo valide.

### Description
- No se cambió la lógica de `src/pcobra/cobra/cli/bootstrap.py`, que ya usa `os.environ.setdefault("PYTHONIOENCODING", "utf-8")` y por tanto preserva valores existentes.
- Se añadió un test en `tests/unit/test_cli_bootstrap_utf8.py` llamado `test_bootstrap_no_sobrescribe_pythonioencoding_existente` que establece `PYTHONIOENCODING` a `latin-1`, llama a `reconfigurar_consola_utf8()` y verifica que la variable no se sobrescribe.
- No se introdujeron dependencias nuevas ni se modificaron archivos fuera del área de bootstrap/entrypoint CLI y sus tests.

### Testing
- Se ejecutó `pytest -q tests/unit/test_cli_bootstrap_utf8.py tests/unit/test_cli_configurar_entorno.py`.
- Resultado de las pruebas: `10 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3692a0788327a005361d1a509910)