### PR TITLE
fix(cli): proteger ajuste de code page UTF-8 en Windows

### DIFF
--- a/src/pcobra/cobra/cli/bootstrap.py
+++ b/src/pcobra/cobra/cli/bootstrap.py
@@ -19,4 +19,11 @@ def reconfigurar_consola_utf8() -> None:
             # Fail-safe: no bloquear el arranque del CLI por la consola.
             pass
 
+    try:
+        if os.name == "nt":
+            os.system("chcp 65001 > nul")
+    except Exception:
+        # Fail-safe: no bloquear el arranque del CLI por ajustes del OS.
+        pass
+
     os.environ.setdefault("PYTHONIOENCODING", "utf-8")


### PR DESCRIPTION
### Motivation
- Asegurar que en Windows el intento de forzar UTF-8 no rompa el arranque del CLI cuando cambiar la code page falla o no está permitido, manteniendo la lógica existente de reconfiguración de streams.

### Description
- Mantiene la llamada existente a `reconfigure(encoding="utf-8")` para `stdout` y `stderr` y luego añade un bloque específico Windows protegido por `try/except` que ejecuta `os.system("chcp 65001 > nul")` solo si `os.name == "nt"`.
- El bloque está envuelto en `try/except` para que cualquier fallo en el comando del sistema no impida el startup del CLI.
- No se mueve la lógica a otros módulos ni se altera la semántica del lenguaje; se preserva la llamada a `os.environ.setdefault("PYTHONIOENCODING", "utf-8")`.

### Testing
- Se ejecutó `python -m compileall -q src/pcobra/cobra/cli/bootstrap.py` y compiló correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da4d6f4df48327a6a8c1c9bd8df6ca)