### PR TITLE
cli: proteger ajuste de PYTHONIOENCODING con fail-safe

### DIFF
--- a/src/pcobra/cobra/cli/bootstrap.py
+++ b/src/pcobra/cobra/cli/bootstrap.py
@@ -26,4 +26,8 @@ def reconfigurar_consola_utf8() -> None:
         # Fail-safe: no bloquear el arranque del CLI por ajustes del OS.
         pass
 
-    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+    try:
+        os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+    except Exception:
+        # Fail-safe: no bloquear el arranque del CLI por variables de entorno.
+        pass


### PR DESCRIPTION
### Motivation
- Encapsular la asignación de `PYTHONIOENCODING=utf-8` en `reconfigurar_consola_utf8` para que fallos al modificar `os.environ` no impidan el arranque del CLI, manteniendo el enfoque mínimo de startup.

### Description
- Se añadió un `try/except` alrededor de `os.environ.setdefault("PYTHONIOENCODING", "utf-8")` en `src/pcobra/cobra/cli/bootstrap.py` y en caso de excepción se ignora de forma segura; no se realizaron otros cambios al runtime, parser, lexer, semántica ni a `print()`.

### Testing
- Se compiló el archivo con `python -m compileall -q src/pcobra/cobra/cli/bootstrap.py` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da508770c48327852691c4edb2ff01)