### PR TITLE
fix(cli): forzar PYTHONIOENCODING en bootstrap UTF-8

### DIFF
--- a/src/pcobra/cobra/cli/bootstrap.py
+++ b/src/pcobra/cobra/cli/bootstrap.py
@@ -27,7 +27,7 @@ def reconfigurar_consola_utf8() -> None:
         pass
 
     try:
-        os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+        os.environ["PYTHONIOENCODING"] = "utf-8"
     except Exception:
         # Fail-safe: no bloquear el arranque del CLI por variables de entorno.
         pass


### PR DESCRIPTION
### Motivation
- Asegurar que `PYTHONIOENCODING` se asigne directamente en el bootstrap CLI para forzar UTF-8 sin eliminar las protecciones en entornos restringidos.

### Description
- En `src/pcobra/cobra/cli/bootstrap.py` se modificó `reconfigurar_consola_utf8()` reemplazando `os.environ.setdefault("PYTHONIOENCODING", "utf-8")` por `os.environ["PYTHONIOENCODING"] = "utf-8"`, manteniendo el bloque `try/except` y dejando intactos `sys.stdout.reconfigure(...)`, `sys.stderr.reconfigure(...)` y el bloque Windows `chcp 65001 > nul`.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/cobra/cli/bootstrap.py` y la comprobación finalizó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da74a13ddc83278ac6de1a2659c758)