### PR TITLE
Actualizar test de bootstrap para sobrescribir PYTHONIOENCODING a utf-8

### DIFF
--- a/tests/unit/test_cli_bootstrap_utf8.py
+++ b/tests/unit/test_cli_bootstrap_utf8.py
@@ -52,12 +52,12 @@ def test_bootstrap_no_rompe_si_stream_no_tiene_reconfigure(monkeypatch):
     assert os.environ["PYTHONIOENCODING"] == "utf-8"
 
 
-def test_bootstrap_no_sobrescribe_pythonioencoding_existente(monkeypatch):
+def test_bootstrap_sobrescribe_pythonioencoding_existente_a_utf8(monkeypatch):
     monkeypatch.setenv("PYTHONIOENCODING", "latin-1")
 
     reconfigurar_consola_utf8()
 
-    assert os.environ["PYTHONIOENCODING"] == "latin-1"
+    assert os.environ["PYTHONIOENCODING"] == "utf-8"
 
 
 def test_cli_subprocess_preserva_utf8_en_salida_acentuada():


### PR DESCRIPTION
### Motivation
- Actualizar el contrato del bootstrap para que `reconfigurar_consola_utf8()` sobrescriba una variable de entorno `PYTHONIOENCODING` previamente establecida a `latin-1` y la deje como `utf-8`.

### Description
- Renombré `test_bootstrap_no_sobrescribe_pythonioencoding_existente` a `test_bootstrap_sobrescribe_pythonioencoding_existente_a_utf8` y cambié la aserción para esperar que `os.environ["PYTHONIOENCODING"] == "utf-8"` en `tests/unit/test_cli_bootstrap_utf8.py`, sin modificar otras pruebas ni añadir dependencias.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_bootstrap_utf8.py` y todas las pruebas pasaron (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7574d8fc8327b9b75af4e1de17c3)