### PR TITLE
test(cli): validate UTF-8 bootstrap entry behavior across platforms

### DIFF
--- a/tests/unit/test_cli_bootstrap_utf8.py
+++ b/tests/unit/test_cli_bootstrap_utf8.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 
 from pcobra.cobra.cli.bootstrap import reconfigurar_consola_utf8
+import pcobra.cobra.cli.bootstrap as bootstrap_module
 
 
 class _DummyStreamConReconfigure:
@@ -58,6 +59,30 @@ def test_bootstrap_sobrescribe_pythonioencoding_existente_a_utf8(monkeypatch):
     reconfigurar_consola_utf8()
 
     assert os.environ["PYTHONIOENCODING"] == "utf-8"
+
+
+def test_bootstrap_en_windows_ejecuta_chcp(monkeypatch):
+    llamadas: list[str] = []
+    monkeypatch.setattr(bootstrap_module.os, "name", "nt", raising=False)
+    monkeypatch.setattr(
+        bootstrap_module.os, "system", lambda cmd: llamadas.append(cmd), raising=False
+    )
+
+    reconfigurar_consola_utf8()
+
+    assert llamadas == ["chcp 65001 > nul"]
+
+
+def test_bootstrap_fuera_de_windows_no_ejecuta_chcp(monkeypatch):
+    llamadas: list[str] = []
+    monkeypatch.setattr(bootstrap_module.os, "name", "posix", raising=False)
+    monkeypatch.setattr(
+        bootstrap_module.os, "system", lambda cmd: llamadas.append(cmd), raising=False
+    )
+
+    reconfigurar_consola_utf8()
+
+    assert llamadas == []
 
 
 def test_cli_subprocess_preserva_utf8_en_salida_acentuada():

--- a/tests/unit/test_cli_configurar_entorno.py
+++ b/tests/unit/test_cli_configurar_entorno.py
@@ -103,12 +103,12 @@ def test_reconfigurar_consola_utf8_fallback_no_rompe_sin_reconfigure(monkeypatch
     assert os.environ["PYTHONIOENCODING"] == "utf-8"
 
 
-def test_reconfigurar_consola_utf8_no_sobrescribe_pythonioencoding(monkeypatch):
+def test_reconfigurar_consola_utf8_sobrescribe_pythonioencoding_a_utf8(monkeypatch):
     monkeypatch.setenv("PYTHONIOENCODING", "latin-1")
 
     _reconfigurar_consola_utf8()
 
-    assert os.environ["PYTHONIOENCODING"] == "latin-1"
+    assert os.environ["PYTHONIOENCODING"] == "utf-8"
 
 
 class _DummyStreamConReconfigure(_DummyStreamSinReconfigure):


### PR DESCRIPTION
### Motivation
- Asegurar que el arranque del CLI siempre invoque el bootstrap UTF-8 y que la llamada a `chcp` solo ocurra en Windows.
- Añadir cobertura automática para las rutas de inicio y el comportamiento específico por plataforma sin mover la lógica de bootstrap fuera del startup.

### Description
- Añadí pruebas en `tests/unit/test_cli_bootstrap_utf8.py` que verifican que `pcobra.cobra.cli.bootstrap.reconfigurar_consola_utf8()` ejecuta `chcp 65001 > nul` cuando `os.name == 'nt'` y no lo ejecuta en `posix`.
- Importé el módulo `pcobra.cobra.cli.bootstrap` en el test para poder parchear `os.name` y `os.system` localmente.
- Actualicé y renombré la prueba en `tests/unit/test_cli_configurar_entorno.py` para reflejar el contrato actual del bootstrap que fuerza `PYTHONIOENCODING` a `utf-8`.
- No se movió ni cambió la lógica de bootstrap en tiempo de ejecución; todos los cambios son pruebas y ajustes de expectativas de tests.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_bootstrap_utf8.py tests/unit/test_cli_configurar_entorno.py` y todos los tests en esos archivos pasaron (`12 passed`).
- Ejecuté `pytest -q tests/unit/test_cli_entrypoint_subprocess.py tests/test_cli_entrypoint_imports.py` y hubo fallos ajenos a estos cambios: 2 tests fallaron por falta de la dependencia `prompt_toolkit.auto_suggest` y una aserción en `test_cli_agix_help`, lo que parece ser un problema de entorno/fixtures, no de las modificaciones realizadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da769bb5a4832785dcb2843c1e3b7e)