### PR TITLE
docs: aclarar alcance de bootstrap UTF-8 en CLI

### DIFF
--- a/src/pcobra/cobra/cli/bootstrap.py
+++ b/src/pcobra/cobra/cli/bootstrap.py
@@ -7,7 +7,7 @@ import sys
 
 
 def reconfigurar_consola_utf8() -> None:
-    """Fuerza UTF-8 en stdout/stderr cuando el runtime lo soporta."""
+    """Fuerza UTF-8 en la frontera Python↔OS sin romper el arranque."""
     for stream_name in ("stdout", "stderr"):
         stream = getattr(sys, stream_name, None)
         reconfigure = getattr(stream, "reconfigure", None)


### PR DESCRIPTION
### Motivation
- Aclarar en la docstring que `reconfigurar_consola_utf8` es responsable de la frontera Python↔OS y que debe ser fail-safe sin cambiar su comportamiento.

### Description
- Se actualizó la docstring de la función `reconfigurar_consola_utf8` en `src/pcobra/cobra/cli/bootstrap.py`; no se tocó la lógica, se mantienen las tres acciones (llamar `reconfigure(encoding="utf-8")` en `sys.stdout`/`sys.stderr` cuando exista, ejecutar `os.system("chcp 65001 > nul")` solo en `os.name == "nt"`, y ajustar `os.environ["PYTHONIOENCODING"] = "utf-8"`) y no se añadieron dependencias ni cambios en parser/interpreter/runtime.

### Testing
- Se compiló el archivo con `python -m compileall -q src/pcobra/cobra/cli/bootstrap.py` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7c474cec8327a62e9f2a900ba775)