### PR TITLE
Add unicode sanitize utility for CLI input

### DIFF
--- a/src/pcobra/cobra/cli/utils/unicode_sanitize.py
+++ b/src/pcobra/cobra/cli/utils/unicode_sanitize.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+
+def sanitize_input(text: str) -> str:
+    """Sanitiza texto Unicode preservando pares válidos y reparando surrogates inválidos.
+
+    Esta función hace un round-trip por UTF-16 usando ``surrogatepass`` para
+    conservar secuencias Unicode válidas (por ejemplo, emoji correctos) y luego
+    decodifica con ``errors='replace'`` para convertir surrogates rotos en el
+    carácter de reemplazo ``U+FFFD``.
+
+    Ejemplos:
+        >>> sanitize_input("áéíóú 🚀")
+        'áéíóú 🚀'
+        >>> sanitize_input("\ud83d")
+        '�'
+    """
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        text = str(text)
+
+    data = text.encode("utf-16", "surrogatepass")
+    return data.decode("utf-16", "replace")


### PR DESCRIPTION
### Motivation
- Asegurar que la entrada de la CLI preserve caracteres Unicode válidos (por ejemplo emoji) y que los surrogates inválidos se reemplacen por `U+FFFD`, además de soportar valores no-`str` y `None`.

### Description
- Añadido `sanitize_input(text: str) -> str` en `src/pcobra/cobra/cli/utils/unicode_sanitize.py` que normaliza entradas para la CLI.
- Si `text` es `None` devuelve `""` y si no es `str` lo convierte con `str(text)` antes de procesar.
- Realiza un round-trip por UTF-16 usando `surrogatepass` y luego decodifica con `errors='replace'` para preservar pares válidos y convertir surrogates rotos en `U+FFFD`, y añade un docstring con ejemplos.

### Testing
- Ejecutado un snippet de Python que verificó que `sanitize_input("áéíóú 🚀")` permanece igual, `sanitize_input("\ud83d")` se convierte en el carácter de reemplazo `"�"`, y `sanitize_input(None)` devuelve `""`, y los resultados fueron los esperados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7f7e37a08327b8d950a015c742ac)