### PR TITLE
Endurecer sanitización Unicode en REPL de la CLI

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -49,6 +49,7 @@ from pcobra.cobra.cli.utils.messages import (
     mostrar_error,
     mostrar_info,
 )
+from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
 from pcobra.cobra.cli.utils.validators import normalizar_validadores_extra
 from pcobra.cobra.cli.repl.cobra_lexer import CobraLexer
 from pcobra.cobra.cli.target_policies import (
@@ -88,8 +89,19 @@ class _SessionHistoryFallback:
         self._path = path
 
     def append_string(self, value: str) -> None:
+        value = sanitize_input(value)
         with open(self._path, "a", encoding="utf-8") as fh:
             fh.write(f"{value}\n")
+
+if FileHistory is not None:
+    class SafeFileHistory(FileHistory):
+        """Historial endurecido que sanitiza entradas antes de persistir."""
+
+        def append_string(self, value: str) -> None:
+            super().append_string(sanitize_input(value))
+
+else:
+    SafeFileHistory = None  # type: ignore[assignment]
 
 
 class InteractiveCommand(BaseCommand):
@@ -368,7 +380,7 @@ class InteractiveCommand(BaseCommand):
         try:
             session = PromptSession(
                 lexer=PygmentsLexer(CobraLexer),
-                history=FileHistory(history_path),
+                history=SafeFileHistory(history_path),
             )
         except NoConsoleScreenBufferError:
             mostrar_advertencia(
@@ -378,7 +390,7 @@ class InteractiveCommand(BaseCommand):
             )
             session = PromptSession(
                 lexer=PygmentsLexer(CobraLexer),
-                history=FileHistory(history_path),
+                history=SafeFileHistory(history_path),
                 output=DummyOutput(),
             )
         if not hasattr(session, "history"):
@@ -438,7 +450,8 @@ class InteractiveCommand(BaseCommand):
         while True:
             try:
                 prompt = "... " if estado["nivel_bloque"] > 0 else "cobra> "
-                linea = leer_linea(prompt).strip()
+                linea = sanitize_input(leer_linea(prompt))
+                linea = linea.strip()
             except (KeyboardInterrupt, EOFError):
                 if estado["buffer_lineas"]:
                     mostrar_error(_("Bloque incompleto; se limpiará la entrada actual."))


### PR DESCRIPTION
### Motivation
- Evitar que entradas con Unicode inválido o surrogates rotos provoquen escritura corrupta en el historial o comportamiento inesperado en el REPL; la sanitización debe ocurrir en el boundary CLI sin tocar el intérprete. 
- Asegurar que tanto el REPL interactivo con `prompt_toolkit` como el fallback de sesiones de prueba persistan solo texto saneado.

### Description
- Importé `sanitize_input` desde `pcobra.cobra.cli.utils.unicode_sanitize` en `interactive_cmd.py` y lo apliqué inmediatamente después de leer la línea con `leer_linea(prompt)` y antes de llamar a `strip()` y la validación posterior usando `linea = sanitize_input(leer_linea(prompt))` seguido de `linea = linea.strip()`.
- Añadí una subclase local `SafeFileHistory(FileHistory)` que sobreescribe `append_string` para sanitizar el valor antes de delegar a `super().append_string(...)` y reemplacé el uso de `FileHistory(history_path)` por `SafeFileHistory(history_path)` al crear la `PromptSession` en ambos caminos (normal y con `DummyOutput`).
- Actualicé `_SessionHistoryFallback.append_string` para sanitizar el texto antes de escribirlo al archivo de historial, manteniendo la compatibilidad con dobles de pruebas.
- Mantengo explícitamente el alcance del cambio en la capa de CLI/historial; no se modificaron el lexer, parser, AST ni el intérprete.

### Testing
- Ejecuté la compilación estática del módulo con `python -m compileall -q src/pcobra/cobra/cli/commands/interactive_cmd.py`, la cual finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da808fca548327bab7f8af2ff7376a)