### PR TITLE
Sanitize stdin reads in CLI secure input helper

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -57,6 +57,7 @@ from pcobra.cobra.cli.plugin import (
 )
 from pcobra.cobra.cli.utils import messages
 from pcobra.cobra.cli.utils import config as config_module
+from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
 from pcobra.cobra.cli.utils.autocomplete import (
     autocomplete_available,
     directories_completer,
@@ -556,7 +557,7 @@ class CliApplication:
 
     def _leer_input_seguro(self, prompt: str) -> Optional[str]:
         try:
-            return input(prompt)
+            return sanitize_input(input(prompt))
         except EOFError:
             messages.mostrar_info(_("Entrada finalizada (EOF). Cancelando menú interactivo."))
             return None


### PR DESCRIPTION
### Motivation
- Evitar entradas con caracteres inválidos o unicode malformado provenientes de stdin en el helper seguro de la CLI sin cambiar la semántica de los comandos.

### Description
- Importé `sanitize_input` desde `pcobra.cobra.cli.utils.unicode_sanitize` y envolví la llamada a `input(prompt)` en `_leer_input_seguro` con `sanitize_input(input(prompt))`, manteniendo intacto el manejo de `EOFError` y `KeyboardInterrupt`, y verifiqué que no haya otras lecturas directas de `input(...)` en `cli.py` que requieran cambios.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/cobra/cli/cli.py` y la comprobación de compilación pasó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8174d8b08327b9bc53521141ccaf)