### PR TITLE
test(cli): cover non-TTY stdin and sanitize mixed Unicode with invalid surrogate

### DIFF
--- a/tests/unit/test_cli_input_unicode_non_tty.py
+++ b/tests/unit/test_cli_input_unicode_non_tty.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pcobra.cobra.cli.cli import CliApplication
+
+
+def test_leer_input_seguro_en_no_tty_sanea_unicode_mixto(monkeypatch):
+    app = CliApplication()
+    monkeypatch.setattr("pcobra.cobra.cli.cli.sys.stdin", SimpleNamespace(isatty=lambda: False))
+    monkeypatch.setattr("builtins.input", lambda _prompt: "áéíóú 🚀\ud83d")
+
+    saneado = app._leer_input_seguro("prompt> ")
+
+    assert saneado == "áéíóú 🚀�"
+    assert all(not (0xD800 <= ord(ch) <= 0xDFFF) for ch in saneado)
+    assert saneado.encode("utf-8") == "áéíóú 🚀�".encode("utf-8")

--- a/tests/unit/test_cli_menu.py
+++ b/tests/unit/test_cli_menu.py
@@ -158,6 +158,20 @@ def test_menu_no_tty_aborta_con_error(monkeypatch):
     assert main(["menu"]) == 1
 
 
+def test_menu_no_tty_no_intenta_leer_input_con_unicode_roto(monkeypatch):
+    _set_tty(monkeypatch, False)
+    called = {"input": False}
+
+    def fake_input(_prompt: str) -> str:
+        called["input"] = True
+        return "áéíóú 🚀\ud83d"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    assert main(["menu"]) == 1
+    assert called["input"] is False
+
+
 def test_menu_eof_inmediato_devuelve_cancelacion(monkeypatch):
     _set_tty(monkeypatch, True)
     monkeypatch.setattr("builtins.input", lambda _: (_ for _ in ()).throw(EOFError()))

--- a/tests/unit/test_unicode_sanitize_repl.py
+++ b/tests/unit/test_unicode_sanitize_repl.py
@@ -40,6 +40,19 @@ def test_sanitize_input_par_valido_se_conserva():
     assert sanitize_input(texto) == "🚀"
 
 
+def test_sanitize_input_mezcla_unicode_valido_y_surrogate_invalido():
+    texto = "áéíóú 🚀\ud83d"
+
+    saneado = sanitize_input(texto)
+
+    # Se preserva el Unicode válido visible y el surrogate roto se reemplaza.
+    assert saneado == "áéíóú 🚀�"
+    # No deben quedar surrogates aislados internamente.
+    assert all(not (0xD800 <= ord(ch) <= 0xDFFF) for ch in saneado)
+    # Debe poder codificarse a UTF-8 sin UnicodeEncodeError.
+    assert saneado.encode("utf-8") == "áéíóú 🚀�".encode("utf-8")
+
+
 def test_interactive_command_sanitiza_surrogate_invalido_y_no_crashea(tmp_path):
     cmd = InteractiveCommand(MagicMock())
     capturado = {"history": [], "validar": []}


### PR DESCRIPTION
### Motivation
- Asegurar que la CLI maneje entrada en contextos no interactivos (`sys.stdin.isatty() == False`) y que el saneado Unicode elimine surrogates aislados para evitar errores de codificación.

### Description
- Añadido test unitario `tests/unit/test_unicode_sanitize_repl.py::test_sanitize_input_mezcla_unicode_valido_y_surrogate_invalido` que verifica que `sanitize_input` preserve el Unicode visible y reemplace surrogates inválidos (por ejemplo `"áéíóú 🚀\ud83d"`).
- Añadido test unitario `tests/unit/test_cli_input_unicode_non_tty.py` que invoca `CliApplication._leer_input_seguro` en un contexto no-TTY y verifica el resultado saneado y que se pueda codificar en UTF-8 sin `UnicodeEncodeError`.
- Añadido test en `tests/unit/test_cli_menu.py` que asegura que `main(["menu"])` en no-TTY no intenta leer `input()` aunque `input` estuviera parcheado para devolver texto con surrogate inválido.
- Las pruebas reutilizan la función existente `sanitize_input` y las rutas de entrada en `src/pcobra/cobra/cli/cli.py` para cubrir los puntos de lectura directo y el flujo de menú.

### Testing
- Ejecutado `pytest -q tests/unit/test_unicode_sanitize_repl.py tests/unit/test_cli_menu.py tests/unit/test_cli_input_unicode_non_tty.py`.
- Resultado: `22 passed` (todos los tests ejecutados pasaron).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da83ffaedc83278becc461e1423c00)