### PR TITLE
docs/cli: documentar sanitize_input en fronteras y añadir aserciones debug en REPL

### DIFF
--- a/docs/issues/windows_unicode_manual_checklist.md
+++ b/docs/issues/windows_unicode_manual_checklist.md
@@ -2,6 +2,22 @@
 
 Objetivo: validar manualmente que el REPL no falla con entradas Unicode mixtas y surrogates inválidos en Windows.
 
+## Contrato de saneamiento en frontera (CLI)
+
+Todo texto que cruce el boundary de entrada de la CLI/REPL **debe** pasar por
+`sanitize_input` antes de validación, dispatch o persistencia en historial.
+
+Puntos de referencia del contrato:
+
+- `sanitize_input`: normaliza Unicode y reemplaza surrogates inválidos por `�`.
+- `InteractiveCommand._run_repl_loop`: sanea cada línea antes de
+  validación/comandos especiales/ejecución.
+- `SafeFileHistory.append_string`: sanea antes de persistir en el historial.
+
+Además, en modo debug (y mientras Python no se ejecute con `-O`) existen
+aserciones ligeras en frontera para detectar tempranamente cualquier surrogate
+aislado remanente.
+
 ## Pasos
 
 - [ ] Pegar emoji válido (`🚀`) en modo interactivo.

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -65,6 +65,20 @@ SANDBOX_DOCKER_CHOICES = DOCKER_EXECUTABLE_TARGETS
 SANDBOX_DOCKER_HELP = OFFICIAL_RUNTIME_TARGETS_HELP
 
 
+def _contains_isolated_surrogate(text: str) -> bool:
+    """Detecta si aún hay code points surrogate en la cadena."""
+    return any(0xD800 <= ord(ch) <= 0xDFFF for ch in text)
+
+
+def _debug_assert_boundary_text_sanitized(text: str, *, context: str) -> None:
+    """Aserción ligera de frontera para detectar surrogates aislados remanentes."""
+    if __debug__:
+        assert not _contains_isolated_surrogate(text), (
+            f"Entrada Unicode no saneada en frontera ({context}); "
+            "debe pasar por sanitize_input antes de validar/dispatch."
+        )
+
+
 def format_user_error(exc: Exception) -> str:
     """Normaliza mensajes de error para salida limpia en la CLI."""
     msg = " ".join(str(exc).strip().split())
@@ -98,7 +112,12 @@ if FileHistory is not None:
         """Historial endurecido que sanitiza entradas antes de persistir."""
 
         def append_string(self, value: str) -> None:
-            super().append_string(sanitize_input(value))
+            sanitized = sanitize_input(value)
+            _debug_assert_boundary_text_sanitized(
+                sanitized,
+                context="SafeFileHistory.append_string",
+            )
+            super().append_string(sanitized)
 
 else:
     SafeFileHistory = None  # type: ignore[assignment]
@@ -452,6 +471,10 @@ class InteractiveCommand(BaseCommand):
                 prompt = "... " if estado["nivel_bloque"] > 0 else "cobra> "
                 linea = sanitize_input(leer_linea(prompt))
                 linea = linea.strip()
+                _debug_assert_boundary_text_sanitized(
+                    linea,
+                    context="InteractiveCommand._run_repl_loop:pre-validacion",
+                )
             except (KeyboardInterrupt, EOFError):
                 if estado["buffer_lineas"]:
                     mostrar_error(_("Bloque incompleto; se limpiará la entrada actual."))
@@ -485,6 +508,10 @@ class InteractiveCommand(BaseCommand):
                 )
                 if codigo is None:
                     continue
+                _debug_assert_boundary_text_sanitized(
+                    codigo,
+                    context="InteractiveCommand._run_repl_loop:pre-dispatch",
+                )
 
                 if sandbox:
                     self._ejecutar_en_sandbox(codigo)

--- a/tests/unit/test_unicode_sanitize_repl.py
+++ b/tests/unit/test_unicode_sanitize_repl.py
@@ -94,3 +94,29 @@ def test_interactive_command_sanitiza_surrogate_invalido_y_no_crashea(tmp_path):
     assert ret == 0
     assert capturado["history"] == ["�"]
     assert capturado["validar"][0] == "�"
+
+
+def test_run_repl_loop_debug_detecta_surrogate_remanente_en_frontera():
+    cmd = InteractiveCommand(MagicMock())
+    cmd._debug_mode = True
+    args = _args()
+    entradas = iter(["\ud83d"])
+
+    def _leer_linea(_prompt: str) -> str:
+        return next(entradas)
+
+    with patch(
+        "pcobra.cobra.cli.commands.interactive_cmd.sanitize_input",
+        side_effect=lambda value: value,
+    ):
+        try:
+            cmd._run_repl_loop(
+                args=args,
+                validador=None,
+                leer_linea=_leer_linea,
+                sandbox=False,
+                sandbox_docker=None,
+            )
+            assert False, "Se esperaba AssertionError por surrogate aislado remanente."
+        except AssertionError as exc:
+            assert "pre-validacion" in str(exc)


### PR DESCRIPTION
### Motivation
- Evitar regresiones relacionadas con Unicode (especialmente en Windows) asegurando que todo texto que cruza la frontera de entrada se sanee correctamente.
- Detectar temprano en desarrollo (modo debug) cualquier surrogate aislado remanente que no haya pasado por `sanitize_input` para facilitar el diagnóstico de fallos.

### Description
- Añadidas funciones helper ` _contains_isolated_surrogate` y `_debug_assert_boundary_text_sanitized` para detección y aserciones ligeras en fronteras textuales. 
- Insertadas aserciones de frontera en `InteractiveCommand._run_repl_loop` justo después de sanear la línea (pre-validación) y justo antes del dispatch/ejecución del código (pre-dispatch). 
- Endurecido `SafeFileHistory.append_string` para sanear con `sanitize_input` y ejecutar la aserción de frontera antes de persistir en historial. 
- Documentado el contrato de saneamiento en `docs/issues/windows_unicode_manual_checklist.md` y añadida la prueba unitaria `test_run_repl_loop_debug_detecta_surrogate_remanente_en_frontera` en `tests/unit/test_unicode_sanitize_repl.py`.

### Testing
- Ejecutado `pytest -q tests/unit/test_unicode_sanitize_repl.py` y todos los tests pasaron (`7 passed`).
- La nueva prueba confirma que, si `sanitize_input` dejara pasar un surrogate aislado (simulado), la aserción en modo debug lanza `AssertionError` en la frontera esperada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da853d023883278021c78446a11bfe)