### PR TITLE
Endurecer coerción en SafeFileHistory y añadir tests Unicode para REPL

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -111,8 +111,15 @@ if FileHistory is not None:
     class SafeFileHistory(FileHistory):
         """Historial endurecido que sanitiza entradas antes de persistir."""
 
-        def append_string(self, value: str) -> None:
-            sanitized = sanitize_input(value)
+        def append_string(self, value: object) -> None:
+            if isinstance(value, str):
+                raw_value = value
+            elif value is None:
+                raw_value = ""
+            else:
+                raw_value = str(value)
+
+            sanitized = sanitize_input(raw_value)
             _debug_assert_boundary_text_sanitized(
                 sanitized,
                 context="SafeFileHistory.append_string",

--- a/tests/unit/test_unicode_sanitize_repl.py
+++ b/tests/unit/test_unicode_sanitize_repl.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+from pcobra.cobra.cli.commands.interactive_cmd import (
+    InteractiveCommand,
+    SafeFileHistory,
+)
 from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
 
 
@@ -120,3 +123,66 @@ def test_run_repl_loop_debug_detecta_surrogate_remanente_en_frontera():
             assert False, "Se esperaba AssertionError por surrogate aislado remanente."
         except AssertionError as exc:
             assert "pre-validacion" in str(exc)
+
+
+def test_safe_file_history_append_string_none_se_coacciona_y_sanea(tmp_path, monkeypatch):
+    if SafeFileHistory is None:
+        return
+
+    capturado: list[str] = []
+    monkeypatch.setattr(
+        SafeFileHistory.__mro__[1],
+        "append_string",
+        lambda _self, value: capturado.append(value),
+        raising=False,
+    )
+    history = SafeFileHistory(str(tmp_path / ".cobra_history"))
+    history.append_string(None)
+
+    assert capturado == [""]
+
+
+def test_safe_file_history_append_string_objeto_custom_usa_str(tmp_path, monkeypatch):
+    if SafeFileHistory is None:
+        return
+
+    capturado: list[str] = []
+    monkeypatch.setattr(
+        SafeFileHistory.__mro__[1],
+        "append_string",
+        lambda _self, value: capturado.append(value),
+        raising=False,
+    )
+
+    class EntradaCustom:
+        def __str__(self) -> str:
+            return "objeto-🚀-válido"
+
+    history = SafeFileHistory(str(tmp_path / ".cobra_history"))
+    history.append_string(EntradaCustom())
+
+    assert capturado == ["objeto-🚀-válido"]
+
+
+def test_safe_file_history_append_string_muy_larga_multilenguaje_surrogate(tmp_path, monkeypatch):
+    if SafeFileHistory is None:
+        return
+
+    capturado: list[str] = []
+    monkeypatch.setattr(
+        SafeFileHistory.__mro__[1],
+        "append_string",
+        lambda _self, value: capturado.append(value),
+        raising=False,
+    )
+
+    segmento = "Español العربية हिंदी 日本語 🚀\ud83d"
+    entrada = segmento * 2000
+    esperado = sanitize_input(entrada)
+    history = SafeFileHistory(str(tmp_path / ".cobra_history"))
+    history.append_string(entrada)
+    payload = capturado[0]
+
+    assert payload == esperado
+    assert "�" in payload
+    assert all(not (0xD800 <= ord(ch) <= 0xDFFF) for ch in payload)


### PR DESCRIPTION
### Motivation
- Evitar que `SafeFileHistory.append_string` falle al recibir entradas que no sean `str` y asegurar que siempre se aplique el sanitizado Unicode antes de persistir.
- Cubrir casos límite de entrada en el REPL relacionados con `None`, objetos personalizados y cadenas muy largas que mezclan varios idiomas y surrogates inválidos.

### Description
- Cambiado `SafeFileHistory.append_string` en `src/pcobra/cobra/cli/commands/interactive_cmd.py` para aceptar `value: object` y realizar coerción controlada: conservar `str`, convertir `None` a `""` y usar `str(value)` para otros objetos antes de llamar a `sanitize_input`.
- Se mantiene la aserción de frontera `_debug_assert_boundary_text_sanitized` y la delegación final al comportamiento base de `FileHistory` con la cadena ya saneada.
- Añadidos tests en `tests/unit/test_unicode_sanitize_repl.py` que verifican `append_string(None)`, la coerción de objetos custom con `__str__`, y el tratamiento de cadenas muy largas multilenguaje con surrogates inválidos.
- Los tests parchean la implementación parental (`append_string` de la superclase) para capturar y afirmar el payload final saneado sin depender de detalles internos del backend de `prompt_toolkit`.

### Testing
- Ejecutado `pytest -q tests/unit/test_unicode_sanitize_repl.py` y todos los tests del archivo pasaron (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8a0387d883278a3869cf71299061)