### PR TITLE
docs: ampliar checklist manual Unicode en Windows

### DIFF
--- a/docs/issues/windows_unicode_manual_checklist.md
+++ b/docs/issues/windows_unicode_manual_checklist.md
@@ -1,6 +1,6 @@
 # Checklist manual Windows — Unicode en REPL
 
-Objetivo: validar manualmente que el REPL no falla con entradas Unicode mixtas y surrogates inválidos en Windows.
+Objetivo: validar de forma reproducible que el REPL se mantiene estable en Windows ante entradas Unicode válidas e inválidas, tanto en modo interactivo como con `stdin` redirigido.
 
 ## Contrato de saneamiento en frontera (CLI)
 
@@ -18,17 +18,86 @@ Además, en modo debug (y mientras Python no se ejecute con `-O`) existen
 aserciones ligeras en frontera para detectar tempranamente cualquier surrogate
 aislado remanente.
 
-## Pasos
+## Preparación del entorno (una sola vez)
 
-- [ ] Pegar emoji válido (`🚀`) en modo interactivo.
-  - Esperado: se procesa correctamente y persiste en historial sin corrupción.
-- [ ] Pegar texto roto con surrogate huérfano (por ejemplo `\ud83d`).
-  - Esperado: no crashea; la entrada se sanea con `�`.
-- [ ] Ejecutar con `stdin` redirigido que combine texto válido + surrogate inválido.
-  - Esperado: ejecución estable, sin excepción por Unicode.
+1. Abrir terminal en Windows (PowerShell recomendado).
+2. Ir al directorio del proyecto.
+3. Activar entorno virtual si aplica.
+4. Lanzar el REPL de la herramienta/proyecto.
 
-## Criterio de aceptación
+> Nota: en pasos de “pegado”, usar siempre **Ctrl+V** (o clic derecho) para evitar diferencias con escritura automática.
 
-- [ ] Cero crashes por errores tipo `surrogates not allowed`.
+## Pasos reproducibles
+
+### 1) Tecleo de emoji
+
+- [ ] En el prompt del REPL, teclear manualmente un emoji válido, por ejemplo: `🚀`.
+- [ ] Confirmar envío con Enter.
+
+**Resultado esperado**
+
+- [ ] El REPL sigue operativo (acepta siguiente comando/input).
+- [ ] No hay excepción Unicode en pantalla.
+- [ ] La entrada con emoji queda registrada en historial sin corrupción.
+
+### 2) Pegado de texto multilenguaje
+
+- [ ] Copiar y pegar en el REPL una línea con mezcla de scripts, por ejemplo:
+  `Español: niño | Português: ação | 中文: 你好 | العربية: مرحبا | हिन्दी: नमस्ते | emoji: 😄`
+- [ ] Confirmar envío con Enter.
+
+**Resultado esperado**
+
+- [ ] El REPL permanece estable.
+- [ ] El contenido Unicode válido se preserva (sin pérdida ni sustituciones inesperadas).
+- [ ] El historial se escribe correctamente y contiene los caracteres válidos.
+
+### 3) Pegado con surrogate roto
+
+- [ ] Preparar una cadena con surrogate huérfano (ejemplo conceptual: `\ud83d`).
+- [ ] Pegar esa entrada en el REPL y enviar con Enter.
+
+**Resultado esperado**
+
+- [ ] No hay crash.
+- [ ] El surrogate inválido se reemplaza por `�` de forma consistente.
+- [ ] El REPL continúa aceptando entradas después del saneamiento.
+- [ ] El historial se persiste sin fallar.
+
+### 4) Ejecución con redirección de `stdin`
+
+- [ ] Crear un archivo de entrada que combine:
+  - una línea Unicode válida (por ejemplo con emoji y texto multilenguaje), y
+  - una línea con surrogate inválido.
+- [ ] Ejecutar la CLI con `stdin` redirigido desde ese archivo.
+
+Ejemplo orientativo en PowerShell (adaptar comando de arranque a tu CLI):
+
+```powershell
+# 1) Línea válida
+"hola 😄 | 你好 | مرحبا" | Out-File -Encoding utf8 .\tmp_unicode_input.txt
+
+# 2) Línea con surrogate roto (literal de ejemplo para prueba manual)
+"\ud83d" | Add-Content -Encoding utf8 .\tmp_unicode_input.txt
+
+# 3) Ejecución con redirección
+Get-Content .\tmp_unicode_input.txt | <COMANDO_CLI_REPL>
+```
+
+**Resultado esperado**
+
+- [ ] Proceso estable durante toda la ejecución.
+- [ ] Sin excepciones por Unicode/surrogates en runtime.
 - [ ] Unicode válido preservado.
-- [ ] Sin cambios en parser/AST/interpreter.
+- [ ] Reemplazo consistente de inválidos por `�`.
+
+## Criterios de aceptación
+
+Se considera validado cuando se cumplen **todos** los puntos:
+
+- [ ] REPL estable en todas las pruebas (sin cierres inesperados ni bloqueos).
+- [ ] Historial escrito correctamente en todos los casos, sin crash.
+- [ ] Preservación de Unicode válido (emoji y texto multilenguaje intactos).
+- [ ] Reemplazo consistente de entradas inválidas por `�`.
+- [ ] Cero errores tipo `surrogates not allowed`.
+- [ ] Sin cambios en parser/AST/interpreter (la validación es de frontera de entrada e historial).


### PR DESCRIPTION
### Motivation

- Proveer un flujo reproducible para validar que el REPL en Windows maneja entradas Unicode válidas e inválidas sin fallos. 
- Cubrir explícitamente los escenarios solicitados: tecleo de emoji, pegado multilenguaje, pegado con surrogate roto y ejecución con `stdin` redirigido.
- Establecer criterios de aceptación claros para comprobar estabilidad del REPL y la preservación/sustitución correcta de Unicode.

### Description

- Se actualiza `docs/issues/windows_unicode_manual_checklist.md` para ampliar el checklist y hacerlo reproducible en Windows. 
- Se añade una sección de "Preparación del entorno" con pasos previos (abrir PowerShell, ir al proyecto, activar entorno, lanzar REPL). 
- Se documentan los cuatro pasos reproducibles con resultados esperados y un ejemplo orientativo en PowerShell para la prueba con redirección de `stdin`.
- Se incorporan criterios de aceptación explícitos: REPL estable, historial persistido sin crash, preservación de Unicode válido y reemplazo consistente de inválidos por `�`.

### Testing

- Se revisó el diff del fichero modificado con `git diff` para verificar los cambios en el checklist y la cobertura de escenarios; la revisión fue satisfactoria. 
- Se inspeccionó el contenido final del archivo con una visualización paginada (`nl -ba`) para validar formato y redacción; la inspección fue satisfactoria. 
- Se generó la PR vía la herramienta de creación de PR del entorno y la carga del cuerpo del PR fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8b2f6f248327b7f1b12b95bffd14)