### PR TITLE
Harden REPL history sanitization boundaries

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -102,10 +102,21 @@ class _SessionHistoryFallback:
     def __init__(self, path: str) -> None:
         self._path = path
 
-    def append_string(self, value: str) -> None:
-        value = sanitize_input(value)
+    def append_string(self, value: object) -> None:
+        if isinstance(value, str):
+            raw_value = value
+        elif value is None:
+            raw_value = ""
+        else:
+            raw_value = str(value)
+
+        sanitized = sanitize_input(raw_value)
+        _debug_assert_boundary_text_sanitized(
+            sanitized,
+            context="_SessionHistoryFallback.append_string",
+        )
         with open(self._path, "a", encoding="utf-8") as fh:
-            fh.write(f"{value}\n")
+            fh.write(f"{sanitized}\n")
 
 if FileHistory is not None:
     class SafeFileHistory(FileHistory):


### PR DESCRIPTION
### Motivation
- Garantizar que las entradas del historial del REPL queden saneadas y que no se persistan code points surrogate residuales; además hacer que el historial acepte `None` y objetos no-`str` sin fallar.
- Alinear el comportamiento del historial de fallback para pruebas con la política ya aplicada por `SafeFileHistory` usada por `PromptSession`.

### Description
- Cambiado `_SessionHistoryFallback.append_string` para aceptar `object` y normalizar valores (`None` → `""`, otros → `str(value)`).
- Aplicado `sanitize_input` al valor normalizado y añadido una aserción de frontera debug `_debug_assert_boundary_text_sanitized` antes de escribir al archivo.
- No se modificó la implementación de `SafeFileHistory(FileHistory)` existente y `PromptSession` ya usa `SafeFileHistory(history_path)` en los puntos de construcción.

### Testing
- Ejecutado `python -m compileall src/pcobra/cobra/cli/commands/interactive_cmd.py`, que compiló correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8d62c6288327ac01c9cae1e97be6)