### PR TITLE
Endurecer saneamiento Unicode en REPL y entradas del menú CLI

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -555,9 +555,20 @@ class CliApplication:
             logging.error("Error in execution: %s", mensaje)
         return 1
 
+    @staticmethod
+    def _sanear_texto_entrada(value: object) -> str:
+        if isinstance(value, str):
+            return sanitize_input(value)
+        if value is None:
+            return ""
+        return sanitize_input(str(value))
+
+    def _sanear_argv(self, argv: List[str]) -> List[str]:
+        return [self._sanear_texto_entrada(token) for token in argv]
+
     def _leer_input_seguro(self, prompt: str) -> Optional[str]:
         try:
-            return sanitize_input(input(prompt))
+            return self._sanear_texto_entrada(input(prompt))
         except EOFError:
             messages.mostrar_info(_("Entrada finalizada (EOF). Cancelando menú interactivo."))
             return None
@@ -580,6 +591,7 @@ class CliApplication:
             if valor is None:
                 return None, 0
 
+            valor = self._sanear_texto_entrada(valor)
             valor_normalizado = valor.strip().lower()
             if valor_normalizado in opciones_normalizadas:
                 return valor_normalizado, 0
@@ -790,6 +802,7 @@ class CliApplication:
                     argv = []
 
             try:
+                argv = self._sanear_argv(argv)
                 args = self._parse_arguments(argv)
                 command = getattr(args, "cmd", None)
                 command_name = command.name if isinstance(command, BaseCommand) else _("desconocido")

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -487,7 +487,8 @@ class InteractiveCommand(BaseCommand):
         while True:
             try:
                 prompt = "... " if estado["nivel_bloque"] > 0 else "cobra> "
-                linea = sanitize_input(leer_linea(prompt))
+                raw_linea = leer_linea(prompt)
+                linea = sanitize_input(raw_linea if isinstance(raw_linea, str) else str(raw_linea))
                 linea = linea.strip()
                 _debug_assert_boundary_text_sanitized(
                     linea,
@@ -508,6 +509,11 @@ class InteractiveCommand(BaseCommand):
                     self._log_error(_("Error de sintaxis"), err)
                 continue
 
+            linea = sanitize_input(linea)
+            _debug_assert_boundary_text_sanitized(
+                linea,
+                context="InteractiveCommand._run_repl_loop:pre-lexer-parser",
+            )
             if not self.validar_entrada(linea):
                 continue
 
@@ -526,6 +532,7 @@ class InteractiveCommand(BaseCommand):
                 )
                 if codigo is None:
                     continue
+                codigo = sanitize_input(codigo)
                 _debug_assert_boundary_text_sanitized(
                     codigo,
                     context="InteractiveCommand._run_repl_loop:pre-dispatch",


### PR DESCRIPTION
### Motivation
- Evitar que texto con surrogates inválidos alcance el lexer, parser, intérprete o el historial y cause errores o corrupción de salida.

### Description
- En `interactive_cmd.py` se sanea inmediatamente la cadena devuelta por `leer_linea(prompt)` usando coerción segura a `str` y `sanitize_input` para cubrir dobles no-string; además se añadió un punto de saneamiento antes de la validación léxica/sintáctica y otro antes del dispatch/ejecución del bloque (`codigo`).
- Se añadieron comprobaciones de frontera `_debug_assert_boundary_text_sanitized` alrededor de los puntos críticos del REPL para detectar surrogates remanentes en modo debug.
- En `cli.py` se introdujeron helpers `_sanear_texto_entrada` y `_sanear_argv`, se hizo que `_leer_input_seguro` use el nuevo helper y se re-sanea el valor en `_leer_opcion_validada` antes de normalizarlo y compararlo.
- Antes de parsear argumentos en `run(...)` ahora se sanea `argv` completo con `_sanear_argv` para cubrir rutas no interactivas/entrada redirigida y evitar que texto inválido alcance el parser.

### Testing
- Se ejecutaron los tests unitarios relevantes con `pytest -q tests/unit/test_unicode_sanitize_repl.py tests/unit/test_cli_input_unicode_non_tty.py tests/unit/test_cli_menu.py` y todos pasaron (`26 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8e34eecc83278a4b16bbb9f0ae7e)