### PR TITLE
test: reforzar saneamiento unicode en pruebas del REPL

### DIFF
--- a/tests/unit/test_unicode_sanitize_repl.py
+++ b/tests/unit/test_unicode_sanitize_repl.py
@@ -97,6 +97,8 @@ def test_interactive_command_sanitiza_surrogate_invalido_y_no_crashea(tmp_path):
     assert ret == 0
     assert capturado["history"] == ["�"]
     assert capturado["validar"][0] == "�"
+    assert all(not (0xD800 <= ord(ch) <= 0xDFFF) for ch in capturado["validar"][0])
+    assert capturado["validar"][0].encode("utf-8") == "�".encode("utf-8")
 
 
 def test_run_repl_loop_debug_detecta_surrogate_remanente_en_frontera():
@@ -162,6 +164,32 @@ def test_safe_file_history_append_string_objeto_custom_usa_str(tmp_path, monkeyp
     history.append_string(EntradaCustom())
 
     assert capturado == ["objeto-🚀-válido"]
+
+
+def test_safe_file_history_append_string_surrogate_aislado_no_lanza_unicode_encode_error(
+    tmp_path, monkeypatch
+):
+    if SafeFileHistory is None:
+        return
+
+    capturado: list[str] = []
+    monkeypatch.setattr(
+        SafeFileHistory.__mro__[1],
+        "append_string",
+        lambda _self, value: capturado.append(value),
+        raising=False,
+    )
+    history = SafeFileHistory(str(tmp_path / ".cobra_history"))
+
+    try:
+        history.append_string("\ud83d")
+    except UnicodeEncodeError as exc:  # pragma: no cover - condición de regresión explícita
+        assert False, f"No debía propagarse UnicodeEncodeError: {exc}"
+
+    payload = capturado[0]
+    assert payload == "�"
+    assert all(not (0xD800 <= ord(ch) <= 0xDFFF) for ch in payload)
+    assert payload.encode("utf-8") == "�".encode("utf-8")
 
 
 def test_safe_file_history_append_string_muy_larga_multilenguaje_surrogate(tmp_path, monkeypatch):


### PR DESCRIPTION
### Motivation
- Asegurar que el REPL y la persistencia de historial manejan correctamente texto multilenguaje, emoji y surrogates rotos sin propagar `UnicodeEncodeError` ni dejar surrogates remanentes.
- Proteger flujos interactivos donde la sesión intenta persistir líneas potencialmente dañadas y validar que el texto final se pueda codificar en UTF-8.

### Description
- Se extendió `test_interactive_command_sanitiza_surrogate_invalido_y_no_crashea` para añadir aserciones que verifican que el texto validado no contiene surrogates (rango U+D800–U+DFFF) y que se codifica correctamente con `encode("utf-8")`.
- Se añadió `test_safe_file_history_append_string_surrogate_aislado_no_lanza_unicode_encode_error` que monkeypatcha la implementación base de `append_string` y comprueba que `SafeFileHistory.append_string("\ud83d")` no lanza `UnicodeEncodeError`, produce el carácter de reemplazo `�`, no deja surrogates y codifica en UTF-8.
- Mantiene las pruebas existentes que cubren: texto multilenguaje + emoji intacto, surrogate alto/bajo aislado reemplazado y par surrogate válido convertido al emoji esperado en `tests/unit/test_unicode_sanitize_repl.py`.

### Testing
- Ejecutado `pytest -q tests/unit/test_unicode_sanitize_repl.py` y todos los tests pasaron: `11 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8f48870c832796b7f04d13045d16)