### PR TITLE
Restore error-level REPL exception logging

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -656,8 +656,8 @@ class InteractiveCommand(BaseCommand):
         """
         mensaje_usuario = f"{categoria}: {error}"
 
-        # Log técnico único (sin duplicar salida en consola del usuario).
-        self.logger.debug("Error en REPL: %s", mensaje_usuario, exc_info=True)
+        # Log técnico único al nivel error (sin duplicar salida en consola del usuario).
+        self.logger.error("Error en REPL: %s", mensaje_usuario, exc_info=True)
 
         if self._debug_mode:
             traza = traceback.format_exc()

--- a/tests/unit/test_interactive_cmd_logging.py
+++ b/tests/unit/test_interactive_cmd_logging.py
@@ -16,14 +16,13 @@ def test_context_logging(caplog):
     assert _("Finalizando REPL de Cobra") in messages
 
 
-def test_log_error_emits_debug_once(caplog):
+def test_log_error_emits_error_once(caplog):
     dummy = types.SimpleNamespace()
     cmd = InteractiveCommand(dummy)
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.ERROR):
         cmd._log_error(_("Error de prueba"), RuntimeError("fallo"))
 
     record = caplog.records[-1]
     assert "Error en REPL" in record.message
     assert _("Error de prueba") in record.message
-    assert record.levelno == logging.DEBUG
-
+    assert record.levelno == logging.ERROR


### PR DESCRIPTION
### Motivation
- Restore observability for REPL failures after a prior change downgraded exception logs to `DEBUG`, which made syntax/runtime errors invisible under the default `INFO` CLI logging.

### Description
- Change `InteractiveCommand._log_error` to emit a single technical log at `ERROR` with `exc_info=True` and continue showing a single user-facing message via `mostrar_error(..., registrar_log=False)` to avoid duplicate console output.

### Testing
- Ran `pytest -q tests/unit/test_interactive_cmd_logging.py tests/unit/test_cli_execution_error_output.py` and the focused suite passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db3ff8e98c832781221f1f78da5b23)