### PR TITLE
fix: hacer neutral a plataforma la aserción UTF-8 del smoke test de CLI

### DIFF
--- a/tests/unit/test_cli_configurar_entorno.py
+++ b/tests/unit/test_cli_configurar_entorno.py
@@ -171,5 +171,6 @@ def test_smoke_cli_unicode_salida_bytes_utf8():
         cwd=str(Path(__file__).resolve().parents[2]),
     )
 
-    assert result.stdout == "después\n".encode("utf-8")
-    assert result.stdout.decode("utf-8") == "después\n"
+    salida = result.stdout.decode("utf-8")
+
+    assert salida.splitlines() == ["después"]


### PR DESCRIPTION
### Motivation
- Evitar falsos negativos en CI en Windows por la comparación exacta de bytes que asume `\n` en la salida, preservando la verificación del contrato UTF-8 del bootstrap del CLI.

### Description
- Se actualizó la prueba `test_smoke_cli_unicode_salida_bytes_utf8` en `tests/unit/test_cli_configurar_entorno.py` para decodificar `stdout` con UTF-8 y validar el contenido usando `splitlines()` en lugar de comparar bytes con un salto de línea literal.

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_configurar_entorno.py` y todos los tests pasaron (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db416f03e08327b3c7a1e1c86e65d3)