### PR TITLE
fix(cli): restore UTF-8 bootstrap in legacy CLI entrypoints

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -826,6 +826,9 @@ class CliApplication:
 
 def main(argv: Optional[List[str]] = None) -> int:
     """Main entry point for the CLI."""
+    from .bootstrap import reconfigurar_consola_utf8
+
+    reconfigurar_consola_utf8()
     application = CliApplication()
     return application.run(argv)
 


### PR DESCRIPTION
### Motivation

- Fix a high-priority regression where legacy entrypoints (`python -m cli.cli` / `python -m cobra.cli.cli`) could raise `UnicodeEncodeError` in non-UTF-8 environments because the UTF-8 bootstrap was no longer invoked by the callable returned from `build_legacy_cli_shim_main`.
- Ensure the defensive UTF-8 bootstrap runs at the legacy shim entrypoint without changing the centralized bootstrap implementation.

### Description

- Reintroduced a call to `reconfigurar_consola_utf8()` inside `pcobra.cobra.cli.cli.main()` by adding `from .bootstrap import reconfigurar_consola_utf8` and invoking `reconfigurar_consola_utf8()` before constructing `CliApplication` in `src/pcobra/cobra/cli/cli.py`.
- Kept the bootstrap implementation unchanged and centralized in `src/pcobra/cobra/cli/bootstrap.py` so only the entrypoint invocation was restored.
- This ensures `main()` (the callable returned by `build_legacy_cli_shim_main`) restores the previous UTF-8-forcing behavior for legacy wrappers without altering internal modules.

### Testing

- Ran `python -m compileall src/pcobra/cobra/cli/cli.py` and compilation completed successfully.
- Executed `PYTHONPATH=src python -m pcobra --ayuda` and the CLI help printed successfully.
- Executed `LANG=C LC_ALL=C PYTHONUTF8=0 PYTHONPATH=src python -m cli.cli --ayuda` to validate legacy shim behavior in a non-UTF-8 environment and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db42b858588327b646221bec5fa261)