### PR TITLE
Unificar superficie de errores de CLI: evitar duplicados visibles

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -551,8 +551,6 @@ class CliApplication:
         if debug_activo:
             logging.exception("Error in execution")
             logging.getLogger(__name__).debug(format_traceback(exc, language))
-        else:
-            logging.error("Error in execution: %s", mensaje)
         return 1
 
     @staticmethod
@@ -828,8 +826,6 @@ class CliApplication:
             except Exception as e:
                 if debug_activo:
                     logging.exception("Fatal error in application")
-                else:
-                    logging.error("Fatal error in application: %s", str(e).strip() or repr(e))
                 mensaje_error = str(e).strip() or _("Ha ocurrido un error inesperado.")
                 messages.mostrar_error(
                     _("Fatal error: {}").format(mensaje_error),


### PR DESCRIPTION
### Motivation
- Evitar que un mismo error se muestre dos veces al usuario en modo no-debug y centralizar la salida visible de errores en `messages.mostrar_error`.

### Description
- Eliminado `logging.error("Error in execution: %s", mensaje)` en `CliApplication._handle_execution_error` para que no haya duplicado visible fuera de debug.
- Eliminado `logging.error("Fatal error in application: %s", ...)` en el `except` fatal de `CliApplication.run` para aplicar la misma política de una sola superficie de error.
- Se mantiene `messages.mostrar_error(..., registrar_log=False)` como la única salida visible al usuario cuando el error no fue mostrado previamente.
- Se conserva `logging.exception(...)` y el volcado de traceback solo cuando `debug_activo=True` para preservar la información de depuración sin afectar la UX en producción.

### Testing
- Compilé el archivo modificado con `python -m compileall src/pcobra/cobra/cli/cli.py` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6413d47883278f22dc89c72a18a1)