### PR TITLE
Unificar validación de archivo en `cobra ejecutar`

### DIFF
--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -1,6 +1,5 @@
 import importlib
 import logging
-import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -11,6 +10,7 @@ from pcobra.cobra.cli.mode_policy import validar_politica_modo
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.cli.utils.validators import (
     normalizar_validadores_extra,
+    validar_archivo_existente,
 )
 from pcobra.cobra.cli.utils.autocomplete import files_completer
 from pcobra.cobra.cli.target_policies import (
@@ -179,22 +179,16 @@ class ExecuteCommand(BaseCommand):
                 permitido. Los errores de archivo inexistente se convierten
                 en ValueError con un mensaje amigable para la CLI.
         """
-        input_path = Path(archivo).expanduser()
-        resolved_path = (Path.cwd() / input_path).resolve(strict=False)
-
-        if not resolved_path.exists():
+        try:
+            resolved_path = validar_archivo_existente(archivo)
+        except FileNotFoundError as error:
+            self.logger.debug("Validación de archivo falló: %s", error)
             raise ValueError(
                 _(
                     "No se encontró el archivo '{path}'. "
                     "Verifica la ruta e inténtalo de nuevo."
                 ).format(path=archivo)
-            )
-        if not resolved_path.is_file():
-            raise ValueError(
-                _(
-                    "La ruta '{path}' no corresponde a un archivo válido."
-                ).format(path=archivo)
-            )
+            ) from error
         if resolved_path.stat().st_size > self.MAX_FILE_SIZE:
             raise ValueError(f"El archivo excede el tamaño máximo permitido ({self.MAX_FILE_SIZE} bytes)")
         return resolved_path


### PR DESCRIPTION
### Motivation
- Centralizar la normalización y validación de rutas usando `pathlib` para evitar chequeos duplicados y variantes con strings crudos.
- Evitar comprobaciones alternativas con `os.path` dentro del flujo de `ejecutar` y mantener un único punto de validación reutilizable.
- Preservar el mensaje amigable de error CLI y que la salida de error pase por `mostrar_error` en `run`.

### Description
- Reemplacé la lógica local de `_validar_archivo` en `ExecuteCommand` para reutilizar `validar_archivo_existente` desde `src/pcobra/cobra/cli/utils/validators.py` y así usar `Path(archivo).expanduser()`, `Path.cwd() / input_path`, y `.resolve(strict=False)` de forma consistente.
- Capturo `FileNotFoundError` lanzado por la utilidad y lo convierto en `ValueError` con el mensaje amigable ya usado por el comando `ejecutar` para que la CLI muestre exactamente la misma salida de error.
- Eliminé el `import os` ya no utilizado y quité los chequeos locales duplicados (`exists()` / `is_file()`), manteniendo la validación de tamaño máximo (`MAX_FILE_SIZE`).
- No se modificó arquitectura fuera de la frontera CLI ni se cambió la semántica de `mostrar_error` en el flujo de `run`.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_execute_missing_file.py tests/unit/test_execute_cmd_extra_validators_normalization.py tests/unit/test_cli_execute_timeout.py` y la ejecución falló en la colección con un `ImportError: cannot import name 'execute_cmd' from 'pcobra.cobra.cli.commands'`.
- Ejecuté `pytest -q tests/unit/test_cli_execute_missing_file.py tests/unit/test_execute_cmd_extra_validators_normalization.py` y obtuve `1 passed, 4 failed` donde los fallos están relacionados con el mismo problema de importación durante la carga de los módulos de prueba.
- No se observaron fallos atribuibles a la nueva validación en sí en estos runs; los errores de los tests provienen de un problema de importación/compatibilidad en el entorno de pruebas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6668f98483278b9e022a984824e4)