### PR TITLE
fix(cli): force UTF-8 output configuration at CLI startup

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -836,11 +836,22 @@ class CliApplication:
 
 def main(argv: Optional[List[str]] = None) -> int:
     """Main entry point for the CLI."""
-    from pcobra.cobra.cli.bootstrap import reconfigurar_consola_utf8
-
-    reconfigurar_consola_utf8()
+    configure_encoding()
     application = CliApplication()
     return application.run(argv)
+
+
+def configure_encoding() -> None:
+    import os
+    import sys
+
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
+    os.environ["PYTHONIOENCODING"] = "utf-8"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `configure_encoding()` in `src/pcobra/cobra/cli/cli.py`
- configure `sys.stdout` and `sys.stderr` to UTF-8 via `reconfigure()`
- set `PYTHONIOENCODING=utf-8`
- call `configure_encoding()` at the very beginning of `main()` before creating `CliApplication`

## Scope
- minimal startup-only CLI change
- no parser/interpreter/language logic touched

## Testing
- not run (per requested strict minimal startup fix)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6a1e395c83279110993fbb1f553c)