### PR TITLE
cli: configurar codificación UTF-8 en el arranque del CLI

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -35,11 +35,16 @@ if _CANONICAL_CLI_PACKAGE_DIR.is_dir():
     __path__ = [str(_CANONICAL_CLI_PACKAGE_DIR)]
 
 
-def _reconfigurar_consola_utf8() -> None:
-    """Fuerza UTF-8 en stdout/stderr cuando el runtime lo soporta."""
-    from pcobra.cobra.cli.bootstrap import reconfigurar_consola_utf8
+def configure_encoding() -> None:
+    import sys
+    import os
 
-    reconfigurar_consola_utf8()
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+    os.environ["PYTHONIOENCODING"] = "utf-8"
 
 
 def configure_logging(debug: bool) -> None:
@@ -193,7 +198,7 @@ def _normalizar_argumentos(argumentos: Optional[Iterable[str]]) -> Optional[List
 
 def main(argumentos: Optional[List[str]] = None) -> int:
     """Punto de entrada principal para la ejecución del CLI."""
-    _reconfigurar_consola_utf8()
+    configure_encoding()
     _bootstrap_dev_path_si_opt_in()
     argv_entrada: Iterable[str] = argumentos if argumentos is not None else sys.argv[1:]
     argv = _normalizar_argumentos(argv_entrada)


### PR DESCRIPTION
### Motivation
- Asegurar que la salida del CLI use UTF-8 desde el inicio para evitar problemas de codificación al escribir en `stdout`/`stderr` en distintos entornos.
- Mantener la lógica de inicialización de codificación localizada en el módulo de arranque del CLI sin agregar dependencias ni módulos nuevos.

### Description
- Se añadió en `src/pcobra/cli.py` una única función `configure_encoding()` que importa `sys` y `os` dentro de la función, intenta `sys.stdout.reconfigure(encoding='utf-8')` y `sys.stderr.reconfigure(encoding='utf-8')`, atrapa cualquier excepción con `except Exception: pass`, y finalmente establece `os.environ["PYTHONIOENCODING"] = "utf-8"`.
- En `main()` se reemplazó la llamada previa de inicialización de consola por `configure_encoding()` para ejecutar esta configuración al inicio del proceso.
- La modificación se limitó a `src/pcobra/cli.py` y no introduce helpers, clases, wrappers ni módulos nuevos.
- Se eliminó la dependencia directa del helper previo de reconfiguración y la lógica de encoding queda autocontenida en el archivo de arranque.

### Testing
- Ejecuté `python -m py_compile src/pcobra/cli.py` y la comprobación de compilación pasó correctamente (sin errores).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6b62ab0483279d74e10d3bb22769)