### PR TITLE
fix(cli): eliminar configure_encoding duplicado en módulo no-entrypoint

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -836,22 +836,8 @@ class CliApplication:
 
 def main(argv: Optional[List[str]] = None) -> int:
     """Main entry point for the CLI."""
-    configure_encoding()
     application = CliApplication()
     return application.run(argv)
-
-
-def configure_encoding() -> None:
-    import os
-    import sys
-
-    try:
-        sys.stdout.reconfigure(encoding="utf-8")
-        sys.stderr.reconfigure(encoding="utf-8")
-    except Exception:
-        pass
-
-    os.environ["PYTHONIOENCODING"] = "utf-8"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Evitar llamadas duplicadas a `configure_encoding()` manteniendo la inicialización de encoding centralizada en el entrypoint canónico (`pcobra.cli:main`).

### Description
- Se eliminó la invocación a `configure_encoding()` y la función local `configure_encoding()` del módulo `src/pcobra/cobra/cli/cli.py`, dejando la llamada únicamente en `src/pcobra/cli.py` (entrypoint).

### Testing
- Ejecuté `rg -n "configure_encoding\(" src/pcobra` para verificar que la llamada queda solo en el entrypoint; resultado OK.
- Probé la ayuda del CLI con `python -m pcobra --help` y devolvió la salida esperada; resultado OK.
- Ejecuté `pytest -q tests/unit/suite_cli.py` y el runner informó "no tests ran" (no fallos durante la verificación de ese archivo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6c4440e483278ac9e9fff9c14593)