### PR TITLE
Fix UTF-8 output in CLI startup path (REPL + ejecutar)

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import ast
 from importlib import import_module
 from pathlib import Path
 from typing import Iterable, List, Optional
@@ -45,6 +46,32 @@ def configure_encoding() -> None:
     except Exception:
         pass
     os.environ["PYTHONIOENCODING"] = "utf-8"
+
+
+def _apply_cli_startup_unicode_patch() -> None:
+    """Aplica un parche de arranque para literales UTF-8 en sesiones CLI.
+
+    Este parche vive en startup del CLI para evitar modificar módulos del lenguaje.
+    Reemplaza temporalmente ``Lexer._procesar_cadena`` con una versión basada en
+    ``ast.literal_eval`` que respeta UTF-8 y secuencias de escape.
+    """
+
+    from pcobra.cobra.core.lexer import Lexer, UnclosedStringError
+
+    if getattr(Lexer, "_pcobra_cli_unicode_patch_applied", False):
+        return
+
+    def _procesar_cadena_cli(self, valor: str) -> str:
+        try:
+            parsed = ast.literal_eval(valor)
+        except (SyntaxError, ValueError, UnicodeError) as exc:
+            raise UnclosedStringError(
+                f"Cadena mal formada: {str(exc)}", self.linea, self.columna
+            )
+        return parsed if isinstance(parsed, str) else str(parsed)
+
+    Lexer._procesar_cadena = _procesar_cadena_cli  # type: ignore[method-assign]
+    Lexer._pcobra_cli_unicode_patch_applied = True  # type: ignore[attr-defined]
 
 
 def configure_logging(debug: bool) -> None:
@@ -199,6 +226,7 @@ def _normalizar_argumentos(argumentos: Optional[Iterable[str]]) -> Optional[List
 def main(argumentos: Optional[List[str]] = None) -> int:
     """Punto de entrada principal para la ejecución del CLI."""
     configure_encoding()
+    _apply_cli_startup_unicode_patch()
     _bootstrap_dev_path_si_opt_in()
     argv_entrada: Iterable[str] = argumentos if argumentos is not None else sys.argv[1:]
     argv = _normalizar_argumentos(argv_entrada)

--- a/tests/test_cli_entrypoint_imports.py
+++ b/tests/test_cli_entrypoint_imports.py
@@ -104,3 +104,29 @@ def test_import_bench_cmd_no_depende_de_scripts_py_path() -> None:
         "`pcobra.cobra`. "
         f"stderr={result.stderr!r}"
     )
+
+
+def test_cli_startup_preserva_utf8_en_literal_imprimir() -> None:
+    """Contrato: startup de CLI debe preservar UTF-8 sin mojibake en salida."""
+
+    result = _run_python_isolated(
+        "import tempfile; "
+        "from pathlib import Path; "
+        "from pcobra.cli import main; "
+        "tmp = Path(tempfile.gettempdir()) / 'pcobra_utf8_test.co'; "
+        "tmp.write_text('imprimir(\"áéíóú ñ € 🚀\")\\n', encoding='utf-8'); "
+        "raise SystemExit(main(['ejecutar', str(tmp)]))"
+    )
+
+    assert result.returncode == 0, (
+        "La ejecución de `imprimir` con literal UTF-8 debe finalizar correctamente. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "áéíóú ñ € 🚀" in result.stdout, (
+        "La salida UTF-8 del CLI debe preservarse sin mojibake. "
+        f"stdout={result.stdout!r}"
+    )
+    assert "Ã¡" not in result.stdout and "â" not in result.stdout, (
+        "Se detectó posible mojibake en salida de CLI. "
+        f"stdout={result.stdout!r}"
+    )


### PR DESCRIPTION
### Motivation
- Corregir mojibake (`Ã¡`, `â`, etc.) en la salida de literales UTF-8 emitidos desde la CLI (REPL y `ejecutar`).
- Aplicar la corrección en el arranque del CLI para no tocar la lógica del lenguaje ni los módulos del lexer/parser/interpreter.

### Description
- Se añadió `_apply_cli_startup_unicode_patch()` en `src/pcobra/cli.py` y se invoca desde `main` para aplicar el parche al arrancar la CLI; el parche reemplaza `Lexer._procesar_cadena` por una versión basada en `ast.literal_eval` que respeta UTF-8 y secuencias de escape.
- El parche incluye una guardia para aplicarse solo una vez mediante `Lexer._pcobra_cli_unicode_patch_applied` y traduce errores a `UnclosedStringError` para mantener la API de errores existente.
- Se agregó una prueba de regresión `test_cli_startup_preserva_utf8_en_literal_imprimir` en `tests/test_cli_entrypoint_imports.py` que valida que `imprimir("áéíóú ñ € 🚀")` desde `cobra ejecutar` conserva UTF-8.
- No se modificaron archivos del lenguaje ni la implementación del lexer en el paquete `pcobra.cobra.core`, la intervención es un override en tiempo de ejecución exclusivo del arranque de la CLI.

### Testing
- Se ejecutó `pytest -q tests/test_cli_entrypoint_imports.py -k 'startup_preserva_utf8 or main_smoke_help_en_entorno_aislado'` y la suite relevante pasó correctamente (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6e7f131083278eada6292bfc9644)