### PR TITLE
Eliminar log redundante en el manejador de excepciones de `declaracion`

### DIFF
--- a/src/pcobra/cobra/core/parser.py
+++ b/src/pcobra/cobra/core/parser.py
@@ -386,7 +386,6 @@ class ClassicParser:
             return self.expresion()
 
         except Exception as e:
-            logger.error(f"Error en la declaración: {e}")
             raise
 
     def declaracion_para(self, asincronico: bool = False):


### PR DESCRIPTION
### Motivation
- Eliminar una línea de logging que generaba mensajes redundantes en el bloque `except Exception as e:` de `declaracion` sin alterar el flujo de excepciones ni las reglas de parseo.

### Description
- Se borró únicamente la línea `logger.error(f"Error en la declaración: {e}")` en `src/pcobra/cobra/core/parser.py` dentro de `ClassicParser.declaracion`, manteniendo el `raise` intacto y sin modificar ninguna lógica de parseo ni consumo de tokens.

### Testing
- Se compiló el archivo con `python -m py_compile src/pcobra/cobra/core/parser.py` y la comprobación devolvió éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db72692570832790fc5226e1c2be8f)