### PR TITLE
Eliminar logging de error en recuperación de bloques condicionales

### DIFF
--- a/src/pcobra/cobra/core/parser.py
+++ b/src/pcobra/cobra/core/parser.py
@@ -681,7 +681,6 @@ class ClassicParser:
             except ParserError as e:
                 if not recuperar_errores:
                     raise
-                logger.error(f"Error en el bloque '{nombre_bloque}': {e}")
                 self.reportar_error(f"Error en el bloque '{nombre_bloque}': {e}")
                 if self.token_actual().tipo != TipoToken.EOF:
                     self.avanzar()


### PR DESCRIPTION
### Motivation
- Eliminar un mensaje de logging redundante dentro de `_parse_bloque_condicional` para reducir ruido sin alterar la lógica de recuperación de errores.

### Description
- Se eliminó la línea `logger.error(f"Error en el bloque '{nombre_bloque}': {e}")` en `src/pcobra/cobra/core/parser.py` dentro del `except ParserError`, manteniéndose `if not recuperar_errores: raise`, `self.reportar_error(...)` y la llamada a `self.avanzar()` sin cambios.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/cobra/core/parser.py` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db7353cf0c8327b58df8f81af4aca4)