### PR TITLE
fix(cli): evitar emisión duplicada de errores en compile_cmd

### DIFF
--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -432,14 +432,11 @@ class CompileCommand(BaseCommand):
             return 0
 
         except PrimitivaPeligrosaError as pe:
-            logging.error("Primitiva peligrosa: %s", pe)
             mostrar_error(str(pe))
             return 1
         except ParserError as se:
-            logging.error("Error de sintaxis durante la transpilación: %s", se)
             mostrar_error(f"Error durante la transpilación: {se}")
             return 1
         except Exception as e:
-            logging.error("Error general durante la transpilación: %s", e)
             mostrar_error(str(e))
             return 1


### PR DESCRIPTION
### Motivation
- Evitar que `CompileCommand.run` emita el mismo error dos veces (por `logging.error` y por la superficie CLI `mostrar_error`), dejando que solo la capa CLI muestre mensajes al usuario.

### Description
- Eliminadas las llamadas duplicadas a `logging.error(...)` en los bloques `except` de `src/pcobra/cobra/cli/commands/compile_cmd.py`, manteniendo intactos los mensajes y el flujo (`return 1`).
- Líneas removidas exactamente: `logging.error("Primitiva peligrosa: %s", pe)`, `logging.error("Error de sintaxis durante la transpilación: %s", se)` y `logging.error("Error general durante la transpilación: %s", e)`.

### Testing
- Ejecutado `pytest -q tests/unit/test_compile_cmd_errors.py` (intento automatizado); la ejecución falló por errores de importación en el entorno de tests (`AttributeError` al resolver rutas legacy), por lo que no se completó la suite; esto es un problema de entorno de pruebas y no de la remoción de las líneas en `compile_cmd`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db74cc547c8327b00f82dd0fa74ebc)