### PR TITLE
Aclarar alcance de contexto en `ejecutar_mientras`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1449,11 +1449,14 @@ class InterpretadorCobra:
 
     def ejecutar_mientras(self, nodo):
         """Ejecuta un bucle ``mientras`` hasta que la condición sea falsa."""
+        # Importante: este bucle reutiliza el contexto actual (sin crear
+        # ámbitos nuevos) para que las asignaciones sean visibles fuera.
         while self._evaluar_condicion_control(nodo.condicion):
             for instruccion in nodo.cuerpo:
                 resultado = self.ejecutar_nodo(instruccion)
                 if resultado is not None:
                     return resultado
+        return None
 
     def ejecutar_try_catch(self, nodo):
         """Ejecuta un bloque ``try`` con manejo de excepciones Cobra."""


### PR DESCRIPTION
### Motivation
- Hacer explícito que el bucle `ejecutar_mientras` reutiliza el contexto actual (no crea nuevos ámbitos) para que las asignaciones dentro del bucle afecten el entorno visible.

### Description
- Se añadió un comentario aclaratorio y un `return None` explícito al final de `def ejecutar_mientras(self, nodo):`, manteniendo exactamente el patrón de ejecución del cuerpo `while self._evaluar_condicion_control(nodo.condicion):`, `for instruccion in nodo.cuerpo:` y `resultado = self.ejecutar_nodo(instruccion)`, sin introducir llamadas a `self.contextos.append(...)`, `Entorno()` ni restauraciones de contexto.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/core/interpreter.py` y una verificación textual con `rg` para confirmar la ausencia de operaciones de creación/restauración de contexto dentro de `ejecutar_mientras`, y ambos checks completaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8a713254832793837fe36f366944)