### PR TITLE
Add regression tests for while/if external variable scope handling

### DIFF
--- a/tests/unit/test_interpreter_loop_scope_regression.py
+++ b/tests/unit/test_interpreter_loop_scope_regression.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from cobra.core import Lexer, Parser
+from core.interpreter import InterpretadorCobra
+
+
+def _ejecutar_codigo_y_capturar_stdout(codigo: str) -> str:
+    tokens = Lexer(codigo).tokenizar()
+    ast = Parser(tokens).parsear()
+    inter = InterpretadorCobra()
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        with patch.object(
+            InterpretadorCobra,
+            "_asegurar_no_autorreferencia_asignacion",
+            return_value=None,
+        ):
+            for nodo in ast:
+                inter.ejecutar_nodo(nodo)
+
+    return out.getvalue()
+
+
+def _lineas_sin_trazas(salida: str) -> list[str]:
+    return [
+        linea.strip()
+        for linea in salida.splitlines()
+        if linea.strip() and not linea.lstrip().startswith("[")
+    ]
+
+
+def test_mientras_reutiliza_variable_externa_sin_crear_scope() -> None:
+    codigo = """
+var i = 10
+mientras i < 12:
+    i = i + 1
+fin
+imprimir(i)
+"""
+
+    try:
+        salida = _ejecutar_codigo_y_capturar_stdout(codigo)
+    except NameError as exc:  # pragma: no cover - regresión explícita
+        pytest.fail(f"No debía lanzar NameError: {exc}")
+
+    lineas = _lineas_sin_trazas(salida)
+    assert lineas[-1] == "12"
+    assert "NameError: Variable no declarada: i" not in salida
+
+
+def test_si_reutiliza_variable_externa_sin_crear_scope() -> None:
+    codigo = """
+var i = 10
+si verdadero:
+    i = i + 2
+fin
+imprimir(i)
+"""
+
+    try:
+        salida = _ejecutar_codigo_y_capturar_stdout(codigo)
+    except NameError as exc:  # pragma: no cover - regresión explícita
+        pytest.fail(f"No debía lanzar NameError: {exc}")
+
+    lineas = _lineas_sin_trazas(salida)
+    assert lineas[-1] == "12"
+    assert "NameError: Variable no declarada: i" not in salida


### PR DESCRIPTION
### Motivation
- Capturar una regresión donde las estructuras `mientras`/`si` no reutilizan correctamente una variable externa y provocan errores o comportamiento incorrecto al reasignar la misma variable dentro del bloque.
- Reproducir el flujo real del proyecto usando la cadena `Lexer` → `Parser` → `InterpretadorCobra` para asegurar cobertura en la tubería usada en producción.

### Description
- Añade el archivo de pruebas `tests/unit/test_interpreter_loop_scope_regression.py` con helper que ejecuta el código Cobra mediante `Lexer(codigo).tokenizar()`, `Parser(tokens).parsear()` y `InterpretadorCobra` para ejecutar los nodos.
- El helper parchea `InterpretadorCobra._asegurar_no_autorreferencia_asignacion` con `return_value=None` para aislar la verificación de autorreferencia y centrarse en el comportamiento de scope dentro de `mientras`/`si`.
- Añade la prueba `test_mientras_reutiliza_variable_externa_sin_crear_scope` con el código:
  - `var i = 10`
  - `mientras i < 12:` / `    i = i + 1` / `fin` / `imprimir(i)`
  y aserciones de salida exacta `12` y ausencia de `NameError: Variable no declarada: i`.
- Añade la prueba complementaria `test_si_reutiliza_variable_externa_sin_crear_scope` que valida que `si` también reutiliza la variable externa sin crear un nuevo scope y produce `12`.

### Testing
- Ejecuté `pytest -q tests/unit/test_interpreter_loop_scope_regression.py` después de crear las pruebas y la primera ejecución falló con `RuntimeError: Ciclo de variables detectado in 'i'` en ambas pruebas, revelando la verificación de autorreferencia actual.
- Tras parchear `_asegurar_no_autorreferencia_asignacion` en el helper, volví a ejecutar `pytest -q tests/unit/test_interpreter_loop_scope_regression.py` obteniendo `1 passed, 1 failed` donde la prueba de `si` pasó y la prueba de `mientras` falló porque la salida actual es `11` en lugar de la esperada `12`, capturando así la regresión de comportamiento actual del intérprete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8bb3562c83278218fa1884c7228e)