### PR TITLE
Evitar fuga de resultados internos en REPL para sentencias de control

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -33,6 +33,7 @@ except ModuleNotFoundError:  # pragma: no cover - entornos sin prompt_toolkit
 from pcobra.cobra.core import Lexer, LexerError, TipoToken, UnclosedStringError
 from pcobra.cobra.core import Parser, ParserError
 from pcobra.cobra.transpilers import module_map
+from pcobra.core.ast_nodes import NodoBucleMientras, NodoCondicional, NodoPara, NodoSwitch, NodoTryCatch
 from pcobra.core.interpreter import InterpretadorCobra
 from pcobra.core.resource_limits import limitar_memoria_mb
 from pcobra.core.sandbox import (
@@ -173,6 +174,13 @@ class InteractiveCommand(BaseCommand):
             TipoToken.INTENTAR,
             TipoToken.SWITCH,
         }
+    )
+    _NODOS_CONTROL_SIN_ECHO_REPL = (
+        NodoCondicional,
+        NodoBucleMientras,
+        NodoPara,
+        NodoTryCatch,
+        NodoSwitch,
     )
 
     def __init__(self, interpretador: InterpretadorCobra) -> None:
@@ -322,7 +330,12 @@ class InteractiveCommand(BaseCommand):
         self.logger.debug("[EXEC] Ejecutando AST en intérprete")
         resultado = self.interpretador.ejecutar_ast(ast)
         self.logger.debug("[EVAL] Resultado de evaluación: %r", resultado)
-        if resultado is not None:
+        debe_imprimir_resultado = (
+            resultado is not None
+            and len(ast) == 1
+            and not isinstance(ast[0], self._NODOS_CONTROL_SIN_ECHO_REPL)
+        )
+        if debe_imprimir_resultado:
             if isinstance(resultado, bool):
                 print("verdadero" if resultado else "falso")
             else:

--- a/tests/unit/test_interactive_block_depth.py
+++ b/tests/unit/test_interactive_block_depth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from io import StringIO
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -7,6 +8,7 @@ import pytest
 
 from cobra.cli.commands.interactive_cmd import InteractiveCommand
 from cobra.core import ParserError
+from core.interpreter import InterpretadorCobra
 
 
 def _args() -> SimpleNamespace:
@@ -119,3 +121,20 @@ def test_exceso_lineas_blanco_consecutivas_en_bloque_lanza_error() -> None:
         match=r"^Máximo de 2 líneas en blanco consecutivas dentro de un bloque\.$",
     ):
         cmd._manejar_linea_blanca(estado)
+
+
+def test_repl_no_imprime_resultados_intermedios_de_mientras() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+    codigo = "\n".join(
+        [
+            "mientras verdadero:",
+            "    7",
+            "    romper",
+            "fin",
+        ]
+    )
+
+    with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+        cmd.ejecutar_codigo(codigo)
+
+    assert mock_stdout.getvalue() == ""


### PR DESCRIPTION
### Motivation
- El REPL actualmente imprimía cualquier valor no-`None` devuelto por `ejecutar_ast(ast)` sin discriminar el tipo de nodo top-level, lo que permitía que expresiones internas de bloques de control (p. ej. dentro de `mientras`) se filtraran a la salida.
- El cambio debe ser solo de presentación (eco del REPL) y no tocar sintaxis ni parser.

### Description
- Añadida la tupla `_NODOS_CONTROL_SIN_ECHO_REPL` en `InteractiveCommand` que lista los nodos top-level que no deben provocar impresión automática: `NodoCondicional`, `NodoBucleMientras`, `NodoPara`, `NodoTryCatch`, `NodoSwitch`.
- Modificado `InteractiveCommand.ejecutar_codigo` para imprimir el `resultado` solo cuando `resultado is not None`, el `ast` contiene exactamente un nodo top-level y ese nodo no es una instancia de `_NODOS_CONTROL_SIN_ECHO_REPL`.
- Importados los nodos AST necesarios desde `pcobra.core.ast_nodes` y no se realizan cambios en el parser o en la semántica del intérprete; el ajuste es estrictamente de presentación REPL.
- Archivos modificados: `src/pcobra/cobra/cli/commands/interactive_cmd.py` y `tests/unit/test_interactive_block_depth.py` (añadido test que valida que un `mientras` no produce salida intermedia inesperada).

### Testing
- Ejecuté los tests focalizados con `pytest -q tests/unit/test_interactive_block_depth.py tests/unit/test_cli_interactive_cmd.py -k "ejecutar_codigo or mientras or intermedios"` y el resultado final fue exitoso (`6 passed, 31 deselected`).
- Añadí el test `test_repl_no_imprime_resultados_intermedios_de_mientras` en `tests/unit/test_interactive_block_depth.py` que verifica que un bloque `mientras` con expresiones internas no imprime valores intermedios en el REPL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8cf402348327acef8ad54f34cd8e)