### PR TITLE
Aclarar reutilización de contexto en `ejecutar_mientras`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1449,8 +1449,8 @@ class InterpretadorCobra:
 
     def ejecutar_mientras(self, nodo):
         """Ejecuta un bucle ``mientras`` hasta que la condición sea falsa."""
-        # Importante: este bucle reutiliza el contexto actual (sin crear
-        # ámbitos nuevos) para que las asignaciones sean visibles fuera.
+        # Importante: este bucle reutiliza el contexto actual (self.variables)
+        # sin crear ámbitos nuevos, de modo que las asignaciones persisten.
         while self._evaluar_condicion_control(nodo.condicion):
             for instruccion in nodo.cuerpo:
                 resultado = self.ejecutar_nodo(instruccion)


### PR DESCRIPTION
### Motivation
- Dejar explícito en el código que el bucle `ejecutar_mientras` reutiliza el contexto activo (`self.variables`) y no crea nuevos ámbitos por iteración para que las asignaciones dentro del bucle sean visibles fuera.

### Description
- Se actualizó el comentario del método `ejecutar_mientras` en `src/pcobra/core/interpreter.py` para mencionar explícitamente `self.variables` y precisar que no se crean ámbitos nuevos; no se realizó ningún cambio en la lógica del bucle ni en la ejecución de `self.ejecutar_nodo(instruccion)`.

### Testing
- Se ejecutó `python -m compileall src/pcobra/core/interpreter.py` y la compilación del archivo fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8eb79c0c8327a3a6bf2ee486bc3e)