### PR TITLE
Refuerza contrato de bloques para `mientras` y `NodoBloque`

### DIFF
--- a/src/pcobra/cobra/core/parser.py
+++ b/src/pcobra/cobra/core/parser.py
@@ -529,6 +529,8 @@ class ClassicParser:
 
         self._exigir_dospuntos("la condición del bucle 'mientras'")
 
+        # El cuerpo de ``mientras`` siempre se parsea como bloque completo para
+        # evitar rutas antiguas de sentencia única.
         cuerpo = self._parse_bloque_condicional(
             [TipoToken.FIN, TipoToken.EOF],
             "mientras",

--- a/src/pcobra/core/ast_nodes.py
+++ b/src/pcobra/core/ast_nodes.py
@@ -1,7 +1,7 @@
 """Definiciones de los nodos del árbol de sintaxis abstracta de Cobra."""
 
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import Any, Iterator, List, Optional, TYPE_CHECKING
 from collections.abc import Mapping
 import warnings
 
@@ -38,7 +38,8 @@ class NodoBloque(NodoAST):
     def __post_init__(self) -> None:
         self.instrucciones = list(self.instrucciones or [])
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[NodoAST]:
+        """Itera las instrucciones en el mismo orden en que se declararon."""
         return iter(self.instrucciones)
 
     def __len__(self):

--- a/tests/unit/test_ast_contract.py
+++ b/tests/unit/test_ast_contract.py
@@ -62,3 +62,12 @@ def test_regresion_ejecutar_ast_no_revive_error_de_dict_en_listas() -> None:
 
     with pytest.raises(RuntimeError, match=r"^Estructura AST inválida en fase 'parseo':"):
         inter.ejecutar_ast([nodo])
+
+
+def test_nodo_bloque_preserva_orden_e_iteracion() -> None:
+    primero = NodoValor(1)
+    segundo = NodoValor(2)
+    bloque = NodoBloque([primero, segundo])
+
+    assert list(bloque) == [primero, segundo]
+    assert bloque.instrucciones == [primero, segundo]


### PR DESCRIPTION
### Motivation
- Asegurar el contrato de bloques para estructuras de control dejando claro que los bloques mantienen orden e iteración y que los cuerpos de `mientras` siempre se parsean como bloques completos.
- Evitar rutas antiguas que pudieran permitir una única sentencia en lugar de un bloque homogéneo sin realizar un refactor global del parser.

### Description
- Tipé y documenté `NodoBloque.__iter__` para garantizar que itera las `instrucciones` en el mismo orden y preserva ese contrato (`src/pcobra/core/ast_nodes.py`).
- Añadí un comentario en `declaracion_mientras` para dejar explícito que el cuerpo se obtiene vía `_parse_bloque_condicional` y se normaliza con `self._bloque(cuerpo)` sin introducir rutas de sentencia única (`src/pcobra/cobra/core/parser.py`).
- Añadí una prueba de regresión que valida la preservación del orden e iteración de `NodoBloque` (`tests/unit/test_ast_contract.py`).
- Verifiqué que `NodoBucleMientras.cuerpo` ya se normaliza con `_asegurar_bloque` en su `__post_init__` y no cambié esa lógica (`src/pcobra/core/ast_nodes.py`).

### Testing
- Ejecuté `pytest -q tests/unit/test_ast_contract.py tests/unit/test_parser_block_contract.py` y la suite reportó éxito con `21 passed` (aprox. 0.45s).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8fd4acc08327af837d0cbfe3f452)