### PR TITLE
tests: eliminar expectativa explícita de NameError en pruebas de scope

### DIFF
--- a/tests/unit/test_interpreter_loop_scope_regression.py
+++ b/tests/unit/test_interpreter_loop_scope_regression.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from io import StringIO
 from unittest.mock import patch
 
-import pytest
-
 from cobra.core import Lexer, Parser
 from core.interpreter import InterpretadorCobra
 
@@ -43,11 +41,7 @@ fin
 imprimir(i)
 """
 
-    try:
-        salida = _ejecutar_codigo_y_capturar_stdout(codigo)
-    except NameError as exc:  # pragma: no cover - regresión explícita
-        pytest.fail(f"No debía lanzar NameError: {exc}")
-
+    salida = _ejecutar_codigo_y_capturar_stdout(codigo)
     lineas = _lineas_sin_trazas(salida)
     assert lineas[-1] == "12"
     assert "NameError: Variable no declarada: i" not in salida
@@ -62,11 +56,7 @@ fin
 imprimir(i)
 """
 
-    try:
-        salida = _ejecutar_codigo_y_capturar_stdout(codigo)
-    except NameError as exc:  # pragma: no cover - regresión explícita
-        pytest.fail(f"No debía lanzar NameError: {exc}")
-
+    salida = _ejecutar_codigo_y_capturar_stdout(codigo)
     lineas = _lineas_sin_trazas(salida)
     assert lineas[-1] == "12"
     assert "NameError: Variable no declarada: i" not in salida


### PR DESCRIPTION
### Motivation
- Evitar que las pruebas de regresión de scope silencien un `NameError` esperado y permitir que las fallas reales afloren, manteniendo los casos de `mientras` y `si` que reutilizan una variable externa.

### Description
- Se modificó `tests/unit/test_interpreter_loop_scope_regression.py` para eliminar el `try/except` que capturaba `NameError` y dejar la ejecución con `salida = _ejecutar_codigo_y_capturar_stdout(codigo)`, manteniendo intactos los casos de prueba y sin tocar parser/lexer.

### Testing
- Ejecuté `pytest -q tests/unit/test_interpreter_loop_scope_regression.py` y el resultado fue `1 failed, 1 passed`, donde `test_mientras_reutiliza_variable_externa_sin_crear_scope` falla porque la salida actual es `11` en lugar de la `12` esperada y `test_si_reutiliza_variable_externa_sin_crear_scope` pasa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db90ff8c888327bd3d3eccf483db2b)