### PR TITLE
Corregir filtro de echo del REPL para nodos de control

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -182,6 +182,15 @@ class InteractiveCommand(BaseCommand):
         NodoTryCatch,
         NodoSwitch,
     )
+    _NOMBRES_NODOS_CONTROL_SIN_ECHO_REPL = frozenset(
+        {
+            "NodoCondicional",
+            "NodoBucleMientras",
+            "NodoPara",
+            "NodoTryCatch",
+            "NodoSwitch",
+        }
+    )
 
     def __init__(self, interpretador: InterpretadorCobra) -> None:
         """Inicializa el comando interactivo.
@@ -333,13 +342,20 @@ class InteractiveCommand(BaseCommand):
         debe_imprimir_resultado = (
             resultado is not None
             and len(ast) == 1
-            and not isinstance(ast[0], self._NODOS_CONTROL_SIN_ECHO_REPL)
+            and not self._es_nodo_control_sin_echo_repl(ast[0])
         )
         if debe_imprimir_resultado:
             if isinstance(resultado, bool):
                 print("verdadero" if resultado else "falso")
             else:
                 print(resultado)
+
+    def _es_nodo_control_sin_echo_repl(self, nodo: Any) -> bool:
+        """Determina si un nodo de control debe omitir echo de resultado en REPL."""
+
+        return isinstance(nodo, self._NODOS_CONTROL_SIN_ECHO_REPL) or (
+            nodo.__class__.__name__ in self._NOMBRES_NODOS_CONTROL_SIN_ECHO_REPL
+        )
 
     def run(self, args: Any) -> int:
         """Ejecuta el REPL de Cobra.


### PR DESCRIPTION
### Motivation

- Evitar que nodos de control de alto nivel (p. ej. `NodoBucleMientras`, `NodoCondicional`, `NodoPara`, `NodoTryCatch`, `NodoSwitch`) disparen la impresión implícita de resultados intermedios en el REPL sin rediseñar la lógica existente.  

### Description

- Se añadió el helper ` _es_nodo_control_sin_echo_repl` y se reemplazó la comprobación previa por su uso en `InteractiveCommand.ejecutar_codigo`.  
- Se añadió una colección de nombres de clase `_NOMBRES_NODOS_CONTROL_SIN_ECHO_REPL` como fallback por nombre para cubrir casos donde las clases puedan venir vía alias/import equivalentes.  
- Cambio mínimo localizado en `src/pcobra/cobra/cli/commands/interactive_cmd.py` que mantiene la condición original (`resultado is not None` y `len(ast) == 1`) y solo mejora la detección de nodos de control.  

### Testing

- Ejecutado `pytest -q tests/unit/test_interactive_block_depth.py::test_repl_no_imprime_resultados_intermedios_de_mientras` y la prueba pasó.  
- Ejecutado `pytest -q tests/unit/test_interactive_block_depth.py::test_multilinea_con_bloque_completo_se_ejecuta_una_vez` y la prueba pasó.  
- Ejecutado `pytest -q tests/unit/test_interactive_block_depth.py` y todos los tests del archivo pasaron (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db925e30948327b442de7e2395c9e6)