### PR TITLE
test: strengthen interpreter loop scope regression assertions

### DIFF
--- a/tests/unit/test_interpreter_loop_scope_regression.py
+++ b/tests/unit/test_interpreter_loop_scope_regression.py
@@ -44,7 +44,8 @@ imprimir(i)
     salida = _ejecutar_codigo_y_capturar_stdout(codigo)
     lineas = _lineas_sin_trazas(salida)
     assert lineas[-1] == "12"
-    assert "NameError: Variable no declarada: i" not in salida
+    assert "Variable no declarada: i" not in salida
+    assert "NameError" not in salida
 
 
 def test_si_reutiliza_variable_externa_sin_crear_scope() -> None:
@@ -59,4 +60,5 @@ imprimir(i)
     salida = _ejecutar_codigo_y_capturar_stdout(codigo)
     lineas = _lineas_sin_trazas(salida)
     assert lineas[-1] == "12"
-    assert "NameError: Variable no declarada: i" not in salida
+    assert "Variable no declarada: i" not in salida
+    assert "NameError" not in salida


### PR DESCRIPTION
### Motivation
- Reforzar las aserciones en pruebas que verifican la reutilización de variables externas en `mientras`/`si` para detectar regresiones de scope/nombre sin añadir dependencias.

### Description
- Actualiza `tests/unit/test_interpreter_loop_scope_regression.py` para afirmar explícitamente la ausencia de las cadenas `Variable no declarada: i` y `NameError` y mantiene la captura de `stdout` con `StringIO` y `patch`.

### Testing
- Ejecuté `pytest -q tests/unit/test_interpreter_loop_scope_regression.py` y obtuvo `1 failed, 1 passed` porque `test_mientras_reutiliza_variable_externa_sin_crear_scope` espera salida `12` pero la salida observada fue `11`, indicando que la implementación actual no cumple aún la expectativa funcional.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db934cdd888327a17813186f2bf459)