### PR TITLE
REPL: omitir echo para nodos de control `si` y `mientras`

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -186,6 +186,8 @@ class InteractiveCommand(BaseCommand):
         {
             "NodoCondicional",
             "NodoBucleMientras",
+            "NodoSi",
+            "NodoMientras",
             "NodoPara",
             "NodoTryCatch",
             "NodoSwitch",

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -367,6 +367,16 @@ def test_ejecutar_codigo_no_imprime_cuando_resultado_es_none():
     assert mock_stdout.getvalue() == ''
 
 
+def test_es_nodo_control_sin_echo_repl_reconoce_alias_si_y_mientras_por_nombre():
+    cmd = InteractiveCommand(MagicMock())
+
+    NodoSi = type("NodoSi", (), {})
+    NodoMientras = type("NodoMientras", (), {})
+
+    assert cmd._es_nodo_control_sin_echo_repl(NodoSi()) is True
+    assert cmd._es_nodo_control_sin_echo_repl(NodoMientras()) is True
+
+
 def test_ejecutar_codigo_traduce_booleano_solo_en_salida_no_en_semantica_interna():
     class _InterpretadorDummy:
         def __init__(self):


### PR DESCRIPTION
### Motivation

- Evitar que bucles y condicionales en el REPL muestren resultados intermedios como si fueran expresiones sueltas. 
- Mantener la puerta de impresión del REPL con las tres condiciones existentes: `resultado is not None`, `len(ast) == 1` y `not self._es_nodo_control_sin_echo_repl(ast[0])`.

### Description

- Se añadieron los alias por nombre de clase `"NodoSi"` y `"NodoMientras"` a la colección `_NOMBRES_NODOS_CONTROL_SIN_ECHO_REPL` en `InteractiveCommand` para que sean tratados como nodos de control sin echo. 
- No se modificó la lógica de decisión de impresión en `ejecutar_codigo`; las condiciones permanecen intactas. 
- Se agregó la prueba `test_es_nodo_control_sin_echo_repl_reconoce_alias_si_y_mientras_por_nombre` en `tests/unit/test_cli_interactive_cmd.py` para verificar que `_es_nodo_control_sin_echo_repl` reconozca los alias por nombre.

### Testing

- Se ejecutaron las pruebas unitarias `pytest -q tests/unit/test_cli_interactive_cmd.py::test_es_nodo_control_sin_echo_repl_reconoce_alias_si_y_mientras_por_nombre` y `pytest -q tests/unit/test_interactive_block_depth.py::test_repl_no_imprime_resultados_intermedios_de_mientras` y ambas pasaron. 
- Resultado de la ejecución: `2 passed` (las pruebas invocadas completaron correctamente).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db96dcddc08327b9f42ce56b1608ec)