### PR TITLE
test: enfocar regresión de scope en bucle mientras

### DIFF
--- a/tests/unit/test_interpreter_loop_scope_regression.py
+++ b/tests/unit/test_interpreter_loop_scope_regression.py
@@ -35,30 +35,17 @@ def _lineas_sin_trazas(salida: str) -> list[str]:
 def test_mientras_reutiliza_variable_externa_sin_crear_scope() -> None:
     codigo = """
 var i = 10
+
 mientras i < 12:
     i = i + 1
 fin
+
 imprimir(i)
 """
 
     salida = _ejecutar_codigo_y_capturar_stdout(codigo)
     lineas = _lineas_sin_trazas(salida)
-    assert lineas[-1] == "12"
-    assert "Variable no declarada: i" not in salida
-    assert "NameError" not in salida
 
-
-def test_si_reutiliza_variable_externa_sin_crear_scope() -> None:
-    codigo = """
-var i = 10
-si verdadero:
-    i = i + 2
-fin
-imprimir(i)
-"""
-
-    salida = _ejecutar_codigo_y_capturar_stdout(codigo)
-    lineas = _lineas_sin_trazas(salida)
     assert lineas[-1] == "12"
     assert "Variable no declarada: i" not in salida
     assert "NameError" not in salida


### PR DESCRIPTION
### Motivation
- Añadir una prueba pequeña y enfocada que detecte una regresión en el manejo de scope dentro de un bucle `mientras` donde una variable externa no se incrementa hasta el valor esperado.

### Description
- Actualiza `tests/unit/test_interpreter_loop_scope_regression.py` para dejar un único caso equivalente al snippet proporcionado (`var i = 10` → `mientras i < 12: i = i + 1` → `imprimir(i)`), manteniendo los helpers de ejecución/captura y validando que la salida final sea `"12"` y que no aparezcan `"Variable no declarada: i"` ni `"NameError"`.

### Testing
- Ejecutado `pytest -q tests/unit/test_interpreter_loop_scope_regression.py` y la prueba falla porque la salida observada es `11` en lugar de la esperada `12`, lo que confirma la regresión que se quería cubrir.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db97da866883278502ceabb07465b8)