### PR TITLE
Unificar backends públicos (python/javascript/rust) y documentar migración legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,39 +22,40 @@ pCobra es un lenguaje de programación escrito en español y pensado para la cre
 Resumen normativo visible (generado desde la política canónica):
 
 <!-- BEGIN GENERATED TARGET POLICY SUMMARY -->
-- **Backends oficiales de salida**: 8 targets canónicos.
-- **Targets oficiales de transpilación**: `python`, `rust`, `javascript`, `wasm`, `go`, `cpp`, `java`, `asm`.
-- **Targets con runtime oficial verificable (full SDK solo en python)**: `python`, `rust`, `javascript`, `cpp`.
-- **Targets con verificación ejecutable explícita en CLI**: `python`, `rust`, `javascript`, `cpp`.
-- **Targets con runtime best-effort**: `go`, `java`.
-- **Targets con soporte oficial mantenido de `corelibs`/`standard_library` (partial fuera de python)**: `python`, `rust`, `javascript`, `cpp`.
-- **Targets con adaptador Holobit mantenido por el proyecto (partial fuera de python)**: `python`, `rust`, `javascript`, `cpp`.
+- **Backends oficiales de salida**: 3 targets canónicos.
+- **Targets oficiales de transpilación**: `python`, `javascript`, `rust`.
+- **Targets con runtime oficial verificable (full SDK solo en python)**: `python`, `javascript`, `rust`.
+- **Targets con verificación ejecutable explícita en CLI**: `python`, `javascript`, `rust`.
+- **Targets con runtime best-effort**: _ninguno en superficie pública_.
+- **Targets con soporte oficial mantenido de `corelibs`/`standard_library` (partial fuera de python)**: `python`, `javascript`, `rust`.
+- **Targets con adaptador Holobit mantenido por el proyecto (partial fuera de python)**: `python`, `javascript`, `rust`.
 - **Compatibilidad SDK completa (solo python)**: `python`.
-- **Targets solo de transpilación**: `wasm`, `asm`.
-- **Orígenes de transpilación inversa**: `python`, `javascript`, `java`. Este alcance reverse de entrada está separado de los 8 targets oficiales de salida.
+- **Targets solo de transpilación**: _ninguno en superficie pública_.
+- **Targets legacy/internal (no públicos)**: `go`, `cpp`, `java`, `wasm`, `asm`.
+- **Orígenes de transpilación inversa**: `python`, `javascript`, `java`. Este alcance reverse de entrada está separado de los 3 targets oficiales de salida.
 
 Tiers oficiales de soporte de backends:
 
-- **Tier 1**: `python`, `rust`, `javascript`, `wasm`.
-- **Tier 2**: `go`, `cpp`, `java`, `asm`.
+- **Tier 1**: `python`, `javascript`, `rust`.
+- **Tier 2**: _sin targets públicos_.
 <!-- END GENERATED TARGET POLICY SUMMARY -->
 
 Fuentes normativas: `src/pcobra/cobra/config/transpile_targets.py` para la lista canónica y los tiers, y `src/pcobra/cobra/cli/target_policies.py` para la separación entre transpilación, runtime oficial y verificación ejecutable.
 
 ### Política de targets oficial
 
-La política oficial de targets exige que toda documentación pública, snippets de CLI, tablas y ejemplos utilicen exclusivamente los nombres canónicos `python`, `rust`, `javascript`, `wasm`, `go`, `cpp`, `java` y `asm`. Los tiers oficiales se derivan de `TIER1_TARGETS`, `TIER2_TARGETS` y `OFFICIAL_TARGETS` definidos en `src/pcobra/cobra/config/transpile_targets.py`, con el registro canónico de backends en `src/pcobra/cobra/transpilers/registry.py`.
+La política oficial de targets exige que toda documentación pública, snippets de CLI, tablas y ejemplos utilicen exclusivamente los nombres canónicos `python`, `javascript` y `rust`. Los tiers oficiales se derivan de `TIER1_TARGETS`, `TIER2_TARGETS` y `OFFICIAL_TARGETS` definidos en `src/pcobra/cobra/config/transpile_targets.py`, con el registro canónico de backends en `src/pcobra/cobra/transpilers/registry.py`.
 
-Además, el proyecto separa explícitamente **targets oficiales de salida** de **targets con runtime oficial de ejecución**. Hoy la ejecución oficial verificable —en sandbox, contenedor o comando de verificación— cubre `python`, `javascript`, `cpp` y `rust`, tal y como reflejan `src/pcobra/cobra/cli/target_policies.py`, `src/pcobra/core/sandbox.py`, `src/pcobra/cobra/cli/commands/verify_cmd.py` y el objetivo `make docker`. En la misma categoría quedan el soporte oficial mantenido de `corelibs`/`standard_library` y el soporte Holobit mantenido por el proyecto en esos runtimes. Los targets `go` y `java` se conservan como **runtime best-effort**, mientras que `wasm` y `asm` son **targets solo de transpilación**. Ninguna de esas categorías debe interpretarse como runtime Docker/sandbox oficial equivalente, ni como soporte oficial de librerías en ejecución comparable al de `python`, `rust`, `javascript` o `cpp`.
+Además, el proyecto separa explícitamente **targets oficiales de salida** de **targets legacy/internal**. La ejecución oficial verificable —en sandbox, contenedor o comando de verificación— cubre `python`, `javascript` y `rust`. Los targets `go`, `cpp`, `java`, `wasm` y `asm` quedan fuera de la promesa pública y se conservan únicamente para compatibilidad interna o migración.
 
-La compatibilidad mínima por backend no es uniforme: `src/pcobra/cobra/transpilers/compatibility_matrix.py` declara `python` como `full` para la matriz contractual actual, mientras `javascript`, `rust`, `wasm`, `go`, `cpp`, `java` y `asm` se mantienen en `partial`. Eso significa que la **paridad SDK total** solo puede prometerse para `python`. `javascript`, `rust` y `cpp` sí cuentan con runtime oficial verificable y adaptadores mantenidos por el proyecto, pero siguen siendo `partial` en Holobit/SDK. `go` y `java` se mantienen como runtimes best-effort; `wasm` y `asm` como salidas oficiales solo de transpilación. Ninguna de esas categorías debe venderse como runtime oficial verificable ni como compatibilidad SDK equivalente.
+La compatibilidad mínima por backend no es uniforme: `src/pcobra/cobra/transpilers/compatibility_matrix.py` declara `python` como `full` para la matriz contractual actual, mientras `javascript` y `rust` se mantienen en `partial`. Eso significa que la **paridad SDK total** solo puede prometerse para `python`.
 
 ### Política de soporte por tiers (SLA y gobernanza)
 
 Definición operativa oficial:
 
-- **Tier 1** (`python`, `rust`, `javascript`, `wasm`): prioridad alta de corrección para regresiones de transpilación y coherencia documental.
-- **Tier 2** (`go`, `cpp`, `java`, `asm`): soporte contractual mantenido con prioridad secundaria frente a Tier 1.
+- **Tier 1** (`python`, `javascript`, `rust`): prioridad alta de corrección para regresiones de transpilación y coherencia documental.
+- **Tier 2** (sin targets públicos): reservado para uso interno/legacy fuera del contrato público.
 
 SLA de mantenimiento documental/técnico:
 
@@ -94,6 +95,13 @@ Sin estos prerrequisitos, pCobra puede conservar generación de código, pero no
 
 Guía de migración para consumidores de targets retirados: `docs/migracion_targets_retirados.md`.
 
+Migración desde targets legacy (`go`, `cpp`, `java`, `wasm`, `asm`) hacia backends oficiales:
+
+1. Sustituye en CLI y CI los usos de `--backend` legacy por `python`, `javascript` o `rust`.
+2. Prioriza `rust` cuando busques rendimiento/compilación nativa, `javascript` para entornos Node/web y `python` para máxima cobertura SDK.
+3. Ejecuta regresión funcional después del cambio para validar paridad en tu pipeline.
+4. Mantén los targets legacy solo como fallback interno temporal, sin exposición pública.
+
 ### Compatibilidad explícita por target (Holobit SDK + librerías)
 
 | Target | Tier | Holobit SDK | `holobit`/`proyectar`/`transformar`/`graficar` | `corelibs` | `standard_library` |
@@ -101,11 +109,8 @@ Guía de migración para consumidores de targets retirados: `docs/migracion_targ
 | `python` | Tier 1 | ✅ `full` (requiere `holobit-sdk`) | ✅ `full` | ✅ `full` | ✅ `full` |
 | `rust` | Tier 1 | 🟡 `partial` (sin dependencia de SDK Python) | 🟡 `partial` | 🟡 `partial` | 🟡 `partial` |
 | `javascript` | Tier 1 | 🟡 `partial` (sin dependencia de SDK Python) | 🟡 `partial` | 🟡 `partial` | 🟡 `partial` |
-| `wasm` | Tier 1 | 🟡 `partial` vía host (`pcobra:*`) | 🟡 `partial` | 🟡 `partial` | 🟡 `partial` |
-| `go` | Tier 2 | 🟡 `partial` best-effort | 🟡 `partial` | 🟡 `partial` | 🟡 `partial` |
-| `cpp` | Tier 2 | 🟡 `partial` con adaptador mantenido | 🟡 `partial` | 🟡 `partial` | 🟡 `partial` |
-| `java` | Tier 2 | 🟡 `partial` best-effort | 🟡 `partial` | 🟡 `partial` | 🟡 `partial` |
-| `asm` | Tier 2 | 🟡 `partial` de inspección/diagnóstico | 🟡 `partial` | 🟡 `partial` | 🟡 `partial` |
+
+Los targets `go`, `cpp`, `java`, `wasm` y `asm` permanecen disponibles solo como **legacy/internal** (sin contrato público).
 
 Fuente normativa de detalle: `docs/contrato_runtime_holobit.md` y `docs/matriz_transpiladores.md`.
 
@@ -202,7 +207,7 @@ La cadena de herramientas de Cobra separa el front-end de los generadores de có
 2. Ese AST se normaliza internamente para coordinar estructuras de control, módulos y tipos antes de la generación de código.
 3. Los transpiladores consumen esa IR para generar código en los distintos backends soportados.
 
-Esta organización actúa como contrato técnico entre el front-end y los generadores de código, permitiendo incorporar mejoras internas sin modificar el parser original. Gracias a ello, Cobra ofrece un generador para el target canónico `asm` que produce instrucciones simbólicas optimizadas para depuración y diagnóstico de rendimiento. En la documentación pública, la salida oficial sigue limitada a `python`, `rust`, `javascript`, `wasm`, `go`, `cpp`, `java` y `asm`.
+Esta organización actúa como contrato técnico entre el front-end y los generadores de código, permitiendo incorporar mejoras internas sin modificar el parser original. Gracias a ello, Cobra mantiene generadores adicionales para casos internos y legacy. En la documentación pública, la salida oficial queda limitada a `python`, `javascript` y `rust`.
 
 ## Instalación
 

--- a/docs/architecture/adr-unified-backends.md
+++ b/docs/architecture/adr-unified-backends.md
@@ -1,0 +1,96 @@
+# ADR: Unificación de backends públicos en Cobra
+
+- **Estado:** Aprobado
+- **Fecha:** 2026-04-13
+- **Decisores:** Equipo Core de pCobra
+- **Relacionado con:** política de targets, CLI pública, documentación de onboarding
+
+## Contexto
+
+La superficie pública de backends había crecido mezclando objetivos distintos:
+
+- targets oficialmente soportados para usuarios finales,
+- targets mantenidos por compatibilidad histórica,
+- y targets útiles para experimentación interna.
+
+Esa mezcla introducía ambigüedad en documentación, CLI y expectativas de soporte.
+
+## Decisión
+
+1. **Cobra es la única interfaz pública del proyecto** para compilación/transpilación y ejecución de flujos soportados.
+2. Los **únicos backends oficiales públicos** pasan a ser:
+   - `python`
+   - `javascript`
+   - `rust`
+3. Los targets `go`, `cpp`, `java`, `wasm` y `asm` se clasifican como **`legacy/internal`**:
+   - no son parte de la promesa pública,
+   - no deben promocionarse en documentación de usuario,
+   - pueden existir para migración, compatibilidad o uso interno.
+
+## Impacto técnico (mapeo solicitado)
+
+### 1) `src/pcobra/cobra/config/transpile_targets.py`
+
+- `ALLOWED_TARGETS` se reduce a `python`, `javascript`, `rust`.
+- Se introduce `LEGACY_INTERNAL_TARGETS` con `go`, `cpp`, `java`, `wasm`, `asm`.
+- La validación canónica asegura:
+  - que el canon público y metadatos solo cubran los 3 backends oficiales,
+  - que no exista solape entre oficiales y `legacy/internal`.
+
+### 2) `src/pcobra/cobra/cli/target_policies.py`
+
+- Las categorías públicas (`OFFICIAL_RUNTIME_TARGETS`, `BEST_EFFORT_RUNTIME_TARGETS`, `TRANSPILATION_ONLY_TARGETS`, `SDK_COMPATIBLE_TARGETS`) se filtran contra el canon oficial actual.
+- Se añade categoría visible de `legacy/internal` para trazabilidad (`LEGACY_INTERNAL_TARGETS`).
+- Resultado práctico:
+  - `OFFICIAL_TRANSPILATION_TARGETS`: `python`, `javascript`, `rust`.
+  - `BEST_EFFORT_RUNTIME_TARGETS` y `TRANSPILATION_ONLY_TARGETS` pueden quedar vacíos en superficie pública.
+
+### 3) `README.md`
+
+- Se actualiza la narrativa para declarar explícitamente:
+  - Cobra como interfaz pública,
+  - solo 3 backends oficiales (`python`, `javascript`, `rust`),
+  - resto como `legacy/internal`.
+- Se incluye guía de migración de targets legacy hacia los 3 backends oficiales.
+
+## Consecuencias
+
+### Positivas
+
+- Menor ambigüedad contractual para usuarios y contribuyentes.
+- Más foco en calidad y testing de los 3 backends oficiales.
+- Documentación pública más coherente con soporte real.
+
+### Negativas / trade-offs
+
+- Consumidores que dependan de `go/cpp/java/wasm/asm` deben migrar su operación principal.
+- Requiere actualizar ejemplos antiguos y pipelines que asumían esos targets como públicos.
+
+## Plan de migración desde targets legacy
+
+Targets legacy afectados: `go`, `cpp`, `java`, `wasm`, `asm`.
+
+### Ruta recomendada
+
+1. **Inventario**
+   - Identificar comandos/pipelines que usen `--backend go|cpp|java|wasm|asm`.
+2. **Selección de backend oficial destino**
+   - Elegir `python`, `javascript` o `rust` según runtime y ecosistema requerido.
+3. **Actualización de CLI/configuración**
+   - Sustituir backend legacy por backend oficial en scripts, CI y documentación interna.
+4. **Verificación funcional**
+   - Ejecutar pruebas de regresión equivalentes con el backend oficial escogido.
+5. **Retirada progresiva**
+   - Mantener fallback legacy temporal solo para contingencias internas, sin exposición pública.
+
+### Recomendaciones de mapeo inicial
+
+- `go` ⟶ `rust` o `python`.
+- `cpp` ⟶ `rust`.
+- `java` ⟶ `javascript` o `python`.
+- `wasm` ⟶ `javascript` (si el objetivo principal es entorno web/runtime JS) o `rust`.
+- `asm` ⟶ `rust` (si se necesita control de bajo nivel dentro del conjunto oficial).
+
+## Estado de cumplimiento
+
+Este ADR queda implementado en configuración central, políticas CLI y README.

--- a/src/pcobra/cobra/cli/target_policies.py
+++ b/src/pcobra/cobra/cli/target_policies.py
@@ -25,6 +25,7 @@ from pcobra.cobra.transpilers.target_utils import (
     require_official_target_subset,
     target_cli_choices,
 )
+from pcobra.cobra.config.transpile_targets import LEGACY_INTERNAL_TARGETS
 from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
 
 RenderMarkup = Literal["plain", "markdown", "rst"]
@@ -45,13 +46,19 @@ OFFICIAL_TRANSPILATION_TARGETS = require_exact_official_targets(
 )
 
 # Targets oficiales con tooling oficial de ejecución en contenedor/sandbox Docker.
-OFFICIAL_RUNTIME_TARGETS = target_cli_choices(OFFICIAL_RUNTIME_BACKENDS)
+OFFICIAL_RUNTIME_TARGETS = target_cli_choices(
+    tuple(target for target in OFFICIAL_RUNTIME_BACKENDS if target in OFFICIAL_TRANSPILATION_TARGETS)
+)
 
 # Targets best-effort conservados fuera del contrato oficial de runtime.
-BEST_EFFORT_RUNTIME_TARGETS = target_cli_choices(BEST_EFFORT_RUNTIME_BACKENDS)
+BEST_EFFORT_RUNTIME_TARGETS = target_cli_choices(
+    tuple(target for target in BEST_EFFORT_RUNTIME_BACKENDS if target in OFFICIAL_TRANSPILATION_TARGETS)
+)
 
 # Targets oficiales que hoy son solo de generación y no prometen runtime.
-TRANSPILATION_ONLY_TARGETS = target_cli_choices(TRANSPILATION_ONLY_BACKENDS)
+TRANSPILATION_ONLY_TARGETS = target_cli_choices(
+    tuple(target for target in TRANSPILATION_ONLY_BACKENDS if target in OFFICIAL_TRANSPILATION_TARGETS)
+)
 
 # Targets sin runtime automatizado en la CLI/suite actual.
 NO_RUNTIME_TARGETS = TRANSPILATION_ONLY_TARGETS
@@ -76,7 +83,9 @@ OFFICIAL_STANDARD_LIBRARY_TARGETS = OFFICIAL_RUNTIME_TARGETS
 ADVANCED_HOLOBIT_RUNTIME_TARGETS = OFFICIAL_RUNTIME_TARGETS
 
 # Compatibilidad SDK completa: se deriva de la matriz contractual.
-SDK_COMPATIBLE_TARGETS = SDK_FULL_BACKENDS
+SDK_COMPATIBLE_TARGETS = target_cli_choices(
+    tuple(target for target in SDK_FULL_BACKENDS if target in OFFICIAL_TRANSPILATION_TARGETS)
+)
 
 require_official_target_subset(
     OFFICIAL_RUNTIME_TARGETS,
@@ -196,6 +205,10 @@ def transpilation_only_targets_text() -> str:
     return ", ".join(TRANSPILATION_ONLY_TARGETS)
 
 
+def legacy_internal_targets_text() -> str:
+    return ", ".join(LEGACY_INTERNAL_TARGETS)
+
+
 def build_cli_compile_examples(
     *,
     source_file: str = "programa.co",
@@ -230,6 +243,11 @@ def iter_public_policy_items() -> tuple[tuple[str, str, tuple[str, ...]], ...]:
             "transpilation_only_targets",
             "Targets solo de transpilación",
             TRANSPILATION_ONLY_TARGETS,
+        ),
+        (
+            "legacy_internal_targets",
+            "Targets legacy/internal (no públicos)",
+            LEGACY_INTERNAL_TARGETS,
         ),
     )
 

--- a/src/pcobra/cobra/config/transpile_targets.py
+++ b/src/pcobra/cobra/config/transpile_targets.py
@@ -15,20 +15,25 @@ class TargetMetadata(TypedDict):
     sdk_contract: Literal["full", "partial", "none"]
 
 
+# Superficie pública oficial de backends de salida.
 ALLOWED_TARGETS: Final[tuple[str, ...]] = (
     "python",
-    "rust",
     "javascript",
-    "wasm",
+    "rust",
+)
+
+# Targets conservados solo por compatibilidad interna/legacy.
+LEGACY_INTERNAL_TARGETS: Final[tuple[str, ...]] = (
     "go",
     "cpp",
     "java",
+    "wasm",
     "asm",
 )
 
 TARGETS_BY_TIER: Final[dict[str, tuple[str, ...]]] = {
-    "tier_1": ("python", "rust", "javascript", "wasm"),
-    "tier_2": ("go", "cpp", "java", "asm"),
+    "tier_1": ALLOWED_TARGETS,
+    "tier_2": (),
 }
 
 TARGET_METADATA: Final[dict[str, TargetMetadata]] = {
@@ -39,51 +44,16 @@ TARGET_METADATA: Final[dict[str, TargetMetadata]] = {
         "holobit_contract": "full",
         "sdk_contract": "full",
     },
-    "rust": {
+    "javascript": {
         "status": "supported",
         "release_priority": 2,
         "maintainer": None,
         "holobit_contract": "partial",
         "sdk_contract": "partial",
     },
-    "javascript": {
+    "rust": {
         "status": "supported",
         "release_priority": 3,
-        "maintainer": None,
-        "holobit_contract": "partial",
-        "sdk_contract": "partial",
-    },
-    "wasm": {
-        "status": "supported",
-        "release_priority": 4,
-        "maintainer": None,
-        "holobit_contract": "partial",
-        "sdk_contract": "partial",
-    },
-    "go": {
-        "status": "supported",
-        "release_priority": 5,
-        "maintainer": None,
-        "holobit_contract": "partial",
-        "sdk_contract": "partial",
-    },
-    "cpp": {
-        "status": "supported",
-        "release_priority": 6,
-        "maintainer": None,
-        "holobit_contract": "partial",
-        "sdk_contract": "partial",
-    },
-    "java": {
-        "status": "supported",
-        "release_priority": 7,
-        "maintainer": None,
-        "holobit_contract": "partial",
-        "sdk_contract": "partial",
-    },
-    "asm": {
-        "status": "supported",
-        "release_priority": 8,
         "maintainer": None,
         "holobit_contract": "partial",
         "sdk_contract": "partial",
@@ -105,7 +75,7 @@ def _validate_target_config() -> None:
     merged = tier_1 + tier_2
     if tuple(merged) != ALLOWED_TARGETS:
         raise RuntimeError(
-            "Los tiers deben concatenar exactamente los targets permitidos. "
+            "Los tiers deben concatenar exactamente los targets públicos permitidos. "
             f"tier_1={tier_1}; tier_2={tier_2}; allowed={ALLOWED_TARGETS}"
         )
 
@@ -122,8 +92,15 @@ def _validate_target_config() -> None:
         extras = tuple(sorted(metadata_keys - allowed))
         missing = tuple(sorted(allowed - metadata_keys))
         raise RuntimeError(
-            "TARGET_METADATA debe cubrir exactamente la lista permitida. "
+            "TARGET_METADATA debe cubrir exactamente la lista pública permitida. "
             f"missing={missing or '∅'}; extras={extras or '∅'}"
+        )
+
+    legacy_collisions = tuple(sorted(set(LEGACY_INTERNAL_TARGETS) & allowed))
+    if legacy_collisions:
+        raise RuntimeError(
+            "LEGACY_INTERNAL_TARGETS no puede solaparse con targets públicos. "
+            f"overlap={legacy_collisions}"
         )
 
     for target, meta in TARGET_METADATA.items():
@@ -143,7 +120,6 @@ def _validate_target_config() -> None:
             raise RuntimeError(
                 f"Target '{target}' debe declarar sdk_contract en none|partial|full"
             )
-
 
 
 _validate_target_config()

--- a/src/pcobra/cobra/transpilers/compatibility_matrix.py
+++ b/src/pcobra/cobra/transpilers/compatibility_matrix.py
@@ -20,6 +20,7 @@ from typing import Final
 
 from pcobra.cobra.transpilers.target_utils import normalize_target_name
 from pcobra.cobra.transpilers.runtime_api_matrix import build_runtime_api_matrix
+from pcobra.cobra.config.transpile_targets import LEGACY_INTERNAL_TARGETS
 from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS, TIER1_TARGETS
 
 CONTRACT_FEATURES: Final[tuple[str, ...]] = (
@@ -38,12 +39,12 @@ FEATURE_FULL_BACKENDS: Final[dict[str, tuple[str, ...]]] = {
     "proyectar": SDK_FULL_BACKENDS,
     "transformar": SDK_FULL_BACKENDS,
     "graficar": SDK_FULL_BACKENDS,
-    "corelibs": ("python", "rust", "go"),
-    "standard_library": ("python", "rust", "go"),
+    "corelibs": ("python", "rust"),
+    "standard_library": ("python", "rust"),
 }
-OFFICIAL_RUNTIME_BACKENDS: Final[tuple[str, ...]] = ("python", "javascript", "cpp", "rust")
-BEST_EFFORT_RUNTIME_BACKENDS: Final[tuple[str, ...]] = ("go", "java")
-TRANSPILATION_ONLY_BACKENDS: Final[tuple[str, ...]] = ("wasm", "asm")
+OFFICIAL_RUNTIME_BACKENDS: Final[tuple[str, ...]] = ("python", "javascript", "rust")
+BEST_EFFORT_RUNTIME_BACKENDS: Final[tuple[str, ...]] = ()
+TRANSPILATION_ONLY_BACKENDS: Final[tuple[str, ...]] = ()
 SDK_PARTIAL_BACKENDS: Final[tuple[str, ...]] = tuple(
     backend for backend in OFFICIAL_TARGETS if backend not in SDK_FULL_BACKENDS
 )
@@ -637,10 +638,12 @@ def _validate_contract_shape(name: str, matrix: dict[str, dict[str, str]]) -> No
             f"{name} no define compatibilidad para backends oficiales: {missing_backends}"
         )
 
-    extra_backends = sorted(set(matrix) - set(OFFICIAL_TARGETS))
+    extra_backends = sorted(
+        set(matrix) - set(OFFICIAL_TARGETS) - set(LEGACY_INTERNAL_TARGETS)
+    )
     if extra_backends:
         raise RuntimeError(
-            f"{name} contiene backends no oficiales o sin registrar: {extra_backends}"
+            f"{name} contiene backends no oficiales, legacy o sin registrar: {extra_backends}"
         )
 
     for backend, contract in matrix.items():
@@ -760,7 +763,7 @@ def validate_backend_compatibility_contract() -> None:
         raise RuntimeError(
             f"BACKEND_COMPATIBILITY_NOTES no define backends oficiales: {missing_notes_backends}"
         )
-    extra_notes_backends = sorted(set(BACKEND_COMPATIBILITY_NOTES) - set(OFFICIAL_TARGETS))
+    extra_notes_backends = sorted(set(BACKEND_COMPATIBILITY_NOTES) - set(OFFICIAL_TARGETS) - set(LEGACY_INTERNAL_TARGETS))
     if extra_notes_backends:
         raise RuntimeError(
             f"BACKEND_COMPATIBILITY_NOTES contiene backends no oficiales: {extra_notes_backends}"
@@ -790,7 +793,7 @@ def validate_backend_compatibility_contract() -> None:
         raise RuntimeError(
             f"BACKEND_FEATURE_GAPS no define backends oficiales: {missing_gaps_backends}"
         )
-    extra_gaps_backends = sorted(set(BACKEND_FEATURE_GAPS) - set(OFFICIAL_TARGETS))
+    extra_gaps_backends = sorted(set(BACKEND_FEATURE_GAPS) - set(OFFICIAL_TARGETS) - set(LEGACY_INTERNAL_TARGETS))
     if extra_gaps_backends:
         raise RuntimeError(
             f"BACKEND_FEATURE_GAPS contiene backends no oficiales: {extra_gaps_backends}"
@@ -828,7 +831,7 @@ def validate_backend_compatibility_contract() -> None:
             f"{missing_capability_backends}"
         )
     extra_capability_backends = sorted(
-        set(BACKEND_HOLOBIT_SDK_CAPABILITIES) - set(OFFICIAL_TARGETS)
+        set(BACKEND_HOLOBIT_SDK_CAPABILITIES) - set(OFFICIAL_TARGETS) - set(LEGACY_INTERNAL_TARGETS)
     )
     if extra_capability_backends:
         raise RuntimeError(


### PR DESCRIPTION
### Motivation
- Reducir la ambigüedad entre backends públicos y objetivos históricos/internos concentrando la promesa pública en tres backends oficiales: `python`, `javascript` y `rust`.
- Facilitar gobernanza, documentación y testing estableciendo los demás targets (`go`, `cpp`, `java`, `wasm`, `asm`) como `legacy/internal` y proveyendo un plan de migración.

### Description
- Añadido ADR `docs/architecture/adr-unified-backends.md` que formaliza la decisión, el impacto técnico y el plan de migración desde targets legacy hacia los tres backends oficiales.
- `src/pcobra/cobra/config/transpile_targets.py` se actualizó para que `ALLOWED_TARGETS` contenga solo `python`, `javascript`, `rust`, y se añadió `LEGACY_INTERNAL_TARGETS` con validaciones que evitan solapes entre públicos y legacy/internal.
- `src/pcobra/cobra/cli/target_policies.py` se adaptó para filtrar las categorías públicas contra el canon actual, exponer `legacy_internal` en el resumen público y construir las listas públicas dinámicamente desde el canon.
- `src/pcobra/cobra/transpilers/compatibility_matrix.py` se ajustó para alinear `OFFICIAL_RUNTIME_BACKENDS`, `BEST_EFFORT_RUNTIME_BACKENDS`, `TRANSPILATION_ONLY_BACKENDS` y `FEATURE_FULL_BACKENDS` con el nuevo canon y para permitir que entradas legacy/internal existan en matrices auxiliares sin romper las validaciones.
- `README.md` se actualizó con el resumen de política generado, la declaración explícita de la interfaz pública y una breve guía de migración para consumidores de targets legacy.

### Testing
- Se compiló el código modificado con `python -m compileall src/pcobra/cobra/config/transpile_targets.py src/pcobra/cobra/cli/target_policies.py src/pcobra/cobra/transpilers/compatibility_matrix.py` y la compilación final fue satisfactoria.
- Se validó la carga e introspección con `python - <<'PY'` importando `pcobra.cobra.cli.target_policies` y verificando que `OFFICIAL_TRANSPILATION_TARGETS == ('python','javascript','rust')` y `LEGACY_INTERNAL_TARGETS == ('go','cpp','java','wasm','asm')`, lo que completó exitosamente después de los ajustes.
- Se creó el commit con mensaje `Define unified public backends policy and legacy migration ADR` y se generó el PR titulado `Unificar backends públicos de Cobra y documentar migración legacy` con el resumen y la validación ejecutada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1736695c8327b66fb6f9c8e29e5f)