### PR TITLE
feat(cli): add opt-in --ui v2 commands with legacy compatibility group

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -43,6 +43,13 @@ from pcobra.cobra.cli.commands.transpilar_inverso_cmd import (
 from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
 from pcobra.cobra.cli.commands.validar_sintaxis_cmd import ValidarSintaxisCommand
 from pcobra.cobra.cli.commands.qa_validar_cmd import QaValidarCommand
+from pcobra.cobra.cli.commands_v2 import (
+    BuildCommandV2,
+    LegacyCommandGroupV2,
+    ModCommandV2,
+    RunCommandV2,
+    TestCommandV2,
+)
 from pcobra.cobra.cli.i18n import _, format_traceback, setup_gettext
 from pcobra.cobra.cli.mode_policy import (
     CLI_MODOS_PERMITIDOS,
@@ -102,6 +109,13 @@ class AppConfig:
         TranspilarInversoCommand, VerifyCommand,
         ValidarSintaxisCommand, QaValidarCommand, PluginsCommand, AgixCommand
     ]
+    V2_COMMAND_CLASSES: List[Type[BaseCommand]] = [
+        RunCommandV2,
+        BuildCommandV2,
+        TestCommandV2,
+        ModCommandV2,
+        LegacyCommandGroupV2,
+    ]
 
 
 class CommandRegistry:
@@ -121,9 +135,10 @@ class CommandRegistry:
             logging.error(f"Error creating command {command_class.__name__}: {e}")
             raise
 
-    def register_base_commands(self, subparsers: Any) -> Dict[str, BaseCommand]:
+    def register_base_commands(self, subparsers: Any, *, ui: str = "v1") -> Dict[str, BaseCommand]:
         base_commands = []
-        for cmd_class in AppConfig.BASE_COMMAND_CLASSES:
+        command_classes = AppConfig.V2_COMMAND_CLASSES if ui == "v2" else AppConfig.BASE_COMMAND_CLASSES
+        for cmd_class in command_classes:
             try:
                 base_commands.append(self.create_command(cmd_class))
             except Exception as e:
@@ -175,6 +190,7 @@ class CliApplication:
         self.command_registry: Optional[CommandRegistry] = None
         self._subparsers: Optional[argparse._SubParsersAction] = None
         self._commands_registered = False
+        self._selected_ui = "v1"
 
     @contextmanager
     def resource_management(self) -> ContextManager[None]:
@@ -206,7 +222,10 @@ class CliApplication:
         if self._commands_registered:
             return
 
-        self.command_registry.register_base_commands(self._subparsers)
+        self.command_registry.register_base_commands(
+            self._subparsers,
+            ui=getattr(self, "_selected_ui", "v1"),
+        )
         menu_parser = self._subparsers.add_parser("menu", help=_("Modo interactivo"))
         menu_parser.set_defaults(cmd="menu")
         self._commands_registered = True
@@ -321,6 +340,12 @@ class CliApplication:
                 "Alias semántico de --modo cobra: sesión para solo programar/interpretar "
                 "Cobra sin rutas de codegen."
             ),
+        )
+        parser.add_argument(
+            "--ui",
+            choices=("v1", "v2"),
+            default="v1",
+            help=_("Selecciona la interfaz CLI: v1 (legacy) o v2 (opt-in)."),
         )
         parser.add_argument("--lang",
                           default=environ.get("COBRA_LANG", AppConfig.DEFAULT_LANGUAGE),
@@ -518,6 +543,7 @@ class CliApplication:
 
         preliminary_args, _ = self.parser.parse_known_args(argv)
         preliminary_args = self._normalizar_flags_sesion(preliminary_args)
+        self._selected_ui = str(getattr(preliminary_args, "ui", "v1")).strip().lower()
         configure_plugin_policy(
             safe_mode=getattr(preliminary_args, "plugins_safe_mode", True),
             allowlist=getattr(preliminary_args, "plugins_allowlist", ""),

--- a/src/pcobra/cobra/cli/commands_v2/__init__.py
+++ b/src/pcobra/cobra/cli/commands_v2/__init__.py
@@ -1,0 +1,13 @@
+from pcobra.cobra.cli.commands_v2.build_cmd import BuildCommandV2
+from pcobra.cobra.cli.commands_v2.legacy_cmd import LegacyCommandGroupV2
+from pcobra.cobra.cli.commands_v2.mod_cmd import ModCommandV2
+from pcobra.cobra.cli.commands_v2.run_cmd import RunCommandV2
+from pcobra.cobra.cli.commands_v2.test_cmd import TestCommandV2
+
+__all__ = [
+    "RunCommandV2",
+    "BuildCommandV2",
+    "TestCommandV2",
+    "ModCommandV2",
+    "LegacyCommandGroupV2",
+]

--- a/src/pcobra/cobra/cli/commands_v2/build_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/build_cmd.py
@@ -1,0 +1,39 @@
+from argparse import Namespace
+from typing import Any
+
+from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.cli.commands.compile_cmd import CompileCommand, LANG_CHOICES
+from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.autocomplete import files_completer
+
+
+class BuildCommandV2(BaseCommand):
+    """Comando v2 para compilación/transpilación interna."""
+
+    name = "build"
+    capability = "codegen"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._legacy = CompileCommand()
+
+    def register_subparser(self, subparsers: Any):
+        parser = subparsers.add_parser(self.name, help=_("Build/transpile a Cobra file"))
+        parser.add_argument("file", help=_("Source Cobra file")).completer = files_completer()
+        parser.add_argument("--target", choices=LANG_CHOICES, help=_("Target language"))
+        parser.add_argument(
+            "--targets",
+            help=_("Comma-separated target languages"),
+        )
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args: Any) -> int:
+        legacy_args = Namespace(
+            archivo=args.file,
+            tipo=getattr(args, "target", None),
+            backend=getattr(args, "target", None),
+            tipos=getattr(args, "targets", None),
+            modo=getattr(args, "modo", "mixto"),
+        )
+        return self._legacy.run(legacy_args)

--- a/src/pcobra/cobra/cli/commands_v2/legacy_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/legacy_cmd.py
@@ -1,0 +1,97 @@
+from argparse import Namespace
+from typing import Any
+
+from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.cli.commands.compile_cmd import CompileCommand
+from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
+from pcobra.cobra.cli.commands.modules_cmd import ModulesCommand
+from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
+from pcobra.cobra.cli.i18n import _
+
+
+class LegacyCommandGroupV2(BaseCommand):
+    """Grupo de compatibilidad para comandos legacy en UI v2."""
+
+    name = "legacy"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._execute = ExecuteCommand()
+        self._compile = CompileCommand()
+        self._verify = VerifyCommand()
+        self._modules = ModulesCommand()
+
+    def register_subparser(self, subparsers: Any):
+        parser = subparsers.add_parser(self.name, help=_("Legacy compatibility command group"))
+        legacy_sub = parser.add_subparsers(dest="legacy_command")
+
+        ejecutar = legacy_sub.add_parser("ejecutar", help=_("Legacy ejecutar"))
+        ejecutar.add_argument("archivo")
+        ejecutar.add_argument("--debug", action="store_true", default=False)
+        ejecutar.add_argument("--sandbox", action="store_true")
+        ejecutar.add_argument("--contenedor")
+
+        compilar = legacy_sub.add_parser("compilar", help=_("Legacy compilar"))
+        compilar.add_argument("archivo")
+        compilar.add_argument("--tipo")
+        compilar.add_argument("--tipos")
+
+        verificar = legacy_sub.add_parser("verificar", help=_("Legacy verificar"))
+        verificar.add_argument("archivo")
+        verificar.add_argument("--lenguajes", "-l", required=True)
+
+        modulos = legacy_sub.add_parser("modulos", help=_("Legacy modulos"))
+        modulos_sub = modulos.add_subparsers(dest="accion")
+        modulos_sub.add_parser("listar")
+        inst = modulos_sub.add_parser("instalar")
+        inst.add_argument("ruta")
+        rem = modulos_sub.add_parser("remover")
+        rem.add_argument("nombre")
+        pub = modulos_sub.add_parser("publicar")
+        pub.add_argument("ruta")
+        bus = modulos_sub.add_parser("buscar")
+        bus.add_argument("nombre")
+
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args: Any) -> int:
+        command = getattr(args, "legacy_command", None)
+        if command == "ejecutar":
+            return self._execute.run(
+                Namespace(
+                    archivo=args.archivo,
+                    debug=getattr(args, "debug", False),
+                    sandbox=getattr(args, "sandbox", False),
+                    contenedor=getattr(args, "contenedor", None),
+                    formatear=getattr(args, "formatear", False),
+                    modo=getattr(args, "modo", "mixto"),
+                )
+            )
+        if command == "compilar":
+            return self._compile.run(
+                Namespace(
+                    archivo=args.archivo,
+                    tipo=getattr(args, "tipo", None),
+                    backend=getattr(args, "tipo", None),
+                    tipos=getattr(args, "tipos", None),
+                    modo=getattr(args, "modo", "mixto"),
+                )
+            )
+        if command == "verificar":
+            return self._verify.run(
+                Namespace(
+                    archivo=args.archivo,
+                    lenguajes=getattr(args, "lenguajes", ""),
+                    modo=getattr(args, "modo", "mixto"),
+                )
+            )
+        if command == "modulos":
+            return self._modules.run(
+                Namespace(
+                    accion=getattr(args, "accion", None),
+                    ruta=getattr(args, "ruta", None),
+                    nombre=getattr(args, "nombre", None),
+                )
+            )
+        return 1

--- a/src/pcobra/cobra/cli/commands_v2/mod_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/mod_cmd.py
@@ -1,0 +1,53 @@
+from argparse import Namespace
+from typing import Any
+
+from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.cli.commands.modules_cmd import ModulesCommand
+from pcobra.cobra.cli.i18n import _
+
+
+class ModCommandV2(BaseCommand):
+    """Comando v2 para gestión de módulos."""
+
+    name = "mod"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._legacy = ModulesCommand()
+
+    def register_subparser(self, subparsers: Any):
+        parser = subparsers.add_parser(self.name, help=_("Manage Cobra modules"))
+        mod_sub = parser.add_subparsers(dest="action")
+
+        mod_sub.add_parser("list", help=_("List modules"))
+
+        install = mod_sub.add_parser("install", help=_("Install module from file"))
+        install.add_argument("path", help=_("Path to module file"))
+
+        remove = mod_sub.add_parser("remove", help=_("Remove an installed module"))
+        remove.add_argument("name", help=_("Module name"))
+
+        publish = mod_sub.add_parser("publish", help=_("Publish module to CobraHub"))
+        publish.add_argument("path", help=_("Path to module file"))
+
+        search = mod_sub.add_parser("search", help=_("Download module from CobraHub"))
+        search.add_argument("name", help=_("Module name"))
+
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args: Any) -> int:
+        action_map = {
+            "list": "listar",
+            "install": "instalar",
+            "remove": "remover",
+            "publish": "publicar",
+            "search": "buscar",
+        }
+        action = action_map.get(getattr(args, "action", ""), "")
+        legacy_args = Namespace(
+            accion=action,
+            ruta=getattr(args, "path", None),
+            nombre=getattr(args, "name", None),
+        )
+        return self._legacy.run(legacy_args)

--- a/src/pcobra/cobra/cli/commands_v2/run_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/run_cmd.py
@@ -1,0 +1,43 @@
+from argparse import Namespace
+from typing import Any
+
+from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
+from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.autocomplete import files_completer
+
+
+class RunCommandV2(BaseCommand):
+    """Comando v2 para ejecutar código Cobra."""
+
+    name = "run"
+    capability = "execute"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._legacy = ExecuteCommand()
+
+    def register_subparser(self, subparsers: Any):
+        parser = subparsers.add_parser(self.name, help=_("Run a Cobra file"))
+        parser.add_argument("file", help=_("Path to Cobra file")).completer = files_completer()
+        parser.add_argument("--debug", action="store_true", default=False, help=_("Show debug messages"))
+        parser.add_argument("--sandbox", action="store_true", help=_("Execute code in sandbox"))
+        parser.add_argument(
+            "--container",
+            dest="container",
+            choices=("python", "javascript", "cpp", "rust"),
+            help=_("Run the code in a Docker container runtime"),
+        )
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args: Any) -> int:
+        legacy_args = Namespace(
+            archivo=args.file,
+            debug=bool(getattr(args, "debug", False)),
+            sandbox=bool(getattr(args, "sandbox", False)),
+            contenedor=getattr(args, "container", None),
+            formatear=bool(getattr(args, "formatear", False)),
+            modo=getattr(args, "modo", "mixto"),
+        )
+        return self._legacy.run(legacy_args)

--- a/src/pcobra/cobra/cli/commands_v2/test_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/test_cmd.py
@@ -1,0 +1,38 @@
+from argparse import Namespace
+from typing import Any
+
+from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
+from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.autocomplete import files_completer
+
+
+class TestCommandV2(BaseCommand):
+    """Comando v2 para validación de proyectos Cobra."""
+
+    name = "test"
+    capability = "codegen"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._legacy = VerifyCommand()
+
+    def register_subparser(self, subparsers: Any):
+        parser = subparsers.add_parser(self.name, help=_("Validate project output across runtimes"))
+        parser.add_argument("file", help=_("Source Cobra file")).completer = files_completer()
+        parser.add_argument(
+            "--langs",
+            "-l",
+            required=True,
+            help=_("Comma-separated runtime languages to validate"),
+        )
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args: Any) -> int:
+        legacy_args = Namespace(
+            archivo=args.file,
+            lenguajes=getattr(args, "langs", ""),
+            modo=getattr(args, "modo", "mixto"),
+        )
+        return self._legacy.run(legacy_args)

--- a/tests/integration/test_cli_ui_v2.py
+++ b/tests/integration/test_cli_ui_v2.py
@@ -1,0 +1,32 @@
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+import cobra.cli.cli as cli_module
+from cobra.cli.cli import main
+
+
+@pytest.fixture(autouse=True)
+def _stub_gettext(monkeypatch):
+    monkeypatch.setattr(cli_module, "setup_gettext", lambda _lang=None: (lambda msg: msg))
+
+
+def test_cli_ui_v2_help_muestra_comandos_v2():
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        with pytest.raises(SystemExit) as exc:
+            main(["--ui", "v2", "--help"])
+    assert exc.value.code == 0
+    texto = out.getvalue().lower()
+    for command in ("run", "build", "test", "mod", "legacy"):
+        assert command in texto
+
+
+def test_cli_ui_v2_legacy_help_esta_disponible():
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        with pytest.raises(SystemExit) as exc:
+            main(["--ui", "v2", "legacy", "--help"])
+    assert exc.value.code == 0
+    texto = out.getvalue().lower()
+    for command in ("ejecutar", "compilar", "verificar", "modulos"):
+        assert command in texto


### PR DESCRIPTION
### Motivation
- Introducir una superficie de comandos v2 opt-in (`--ui v2`) con nombres más modernos (`run`, `build`, `test`, `mod`) manteniendo comportamiento estable al delegar en las implementaciones existentes. 
- Proveer un `legacy` command group en la UI v2 para exponer temporalmente los comandos legacy (`ejecutar`, `compilar`, `verificar`, `modulos`) y facilitar la migración sin romper users existentes.

### Description
- Añadido paquete `src/pcobra/cobra/cli/commands_v2/` con los wrappers `run`, `build`, `test`, `mod` y el grupo `legacy` que delegan a las implementaciones legacy correspondientes (`ExecuteCommand`, `CompileCommand`, `VerifyCommand`, `ModulesCommand`).
- Registrado el flag global `--ui` en `src/pcobra/cobra/cli/cli.py` con opciones `v1|v2` y lógica para seleccionar qué conjunto de comandos registrar antes de crear los subparsers. 
- `CommandRegistry.register_base_commands` ahora acepta el parámetro `ui` y el `CliApplication` captura el valor preliminar de `--ui` para decidir entre `BASE_COMMAND_CLASSES` (v1) y `V2_COMMAND_CLASSES` (v2).
- Agregado test de integración `tests/integration/test_cli_ui_v2.py` que verifica la ayuda de `--ui v2` y la disponibilidad del grupo `legacy`.

### Testing
- Ejecutado `python -m compileall -q src/pcobra/cobra/cli/cli.py src/pcobra/cobra/cli/commands_v2 tests/integration/test_cli_ui_v2.py`, que completó correctamente sin errores de sintaxis. 
- Ejecutado `pytest -q tests/integration/test_cli_ui_v2.py`, que falló en la fase de colección por un `RuntimeError` proveniente de la validación canónica de targets durante la importación de `compile_cmd` (un problema preexistente en la política de targets y no introducido por la lógica de UI v2).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3237f4a48327b810315182ab3473)