### PR TITLE
feat(cli): unificar la resolución de backend en BuildOrchestrator

### DIFF
--- a/src/pcobra/cobra/build/__init__.py
+++ b/src/pcobra/cobra/build/__init__.py
@@ -1,0 +1,5 @@
+"""Build orchestration utilities."""
+
+from pcobra.cobra.build.orchestrator import BackendResolution, BuildOrchestrator
+
+__all__ = ["BackendResolution", "BuildOrchestrator"]

--- a/src/pcobra/cobra/build/orchestrator.py
+++ b/src/pcobra/cobra/build/orchestrator.py
@@ -1,0 +1,192 @@
+"""Orquestador unificado de backend para flujos de build/compilar."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pcobra.cobra.config.transpile_targets import OFFICIAL_TARGETS, target_metadata
+from pcobra.cobra.transpilers.module_map import get_toml_map
+from pcobra.cobra.transpilers.target_utils import normalize_target_name
+
+
+@dataclass(frozen=True)
+class BackendResolution:
+    backend: str
+    reason: str
+
+
+class BuildOrchestrator:
+    """Selecciona backend objetivo con reglas unificadas.
+
+    Orden de decisión:
+    1) metadata del módulo,
+    2) tipo de proyecto,
+    3) capacidades requeridas.
+
+    También acepta una preferencia explícita (ruta legacy) para mantener
+    compatibilidad en ``cobra compilar --backend`` / ``--tipo``.
+    """
+
+    _PROJECT_TYPE_PRIORITIES: dict[str, tuple[str, ...]] = {
+        "library": ("python", "rust", "javascript"),
+        "web": ("javascript", "python", "rust"),
+        "systems": ("rust", "python", "javascript"),
+        "embedded": ("rust", "python", "javascript"),
+        "application": ("python", "javascript", "rust"),
+    }
+
+    def resolve_backend(
+        self,
+        *,
+        source_file: str,
+        preferred_backend: str | None = None,
+        required_capabilities: tuple[str, ...] = (),
+    ) -> BackendResolution:
+        config = get_toml_map()
+        normalized_preferred = self._normalize_optional_target(preferred_backend)
+        project_type = self._project_type(config)
+        module_meta = self._module_metadata(config, source_file)
+
+        module_target = self._normalize_optional_target(
+            module_meta.get("preferred_target")
+            or module_meta.get("target")
+            or module_meta.get("backend")
+        )
+
+        capabilities = self._collect_capabilities(
+            config=config,
+            module_meta=module_meta,
+            requested=required_capabilities,
+        )
+
+        if normalized_preferred is not None:
+            return BackendResolution(
+                backend=normalized_preferred,
+                reason="preferencia explícita (legacy/CLI)",
+            )
+
+        ordered_candidates = self._ordered_candidates(
+            project_type=project_type,
+            module_target=module_target,
+        )
+
+        eligible = [backend for backend in ordered_candidates if self._supports_capabilities(backend, capabilities)]
+        if not eligible:
+            eligible = [
+                backend for backend in self._default_priority() if self._supports_capabilities(backend, capabilities)
+            ]
+
+        if not eligible:
+            # Fallback de seguridad: nunca devolver un backend fuera de política.
+            eligible = list(self._default_priority())
+
+        selected = eligible[0]
+        reason_parts = [
+            f"project_type={project_type}",
+            f"module_target={module_target or '∅'}",
+            f"capabilities={','.join(capabilities) if capabilities else '∅'}",
+        ]
+        return BackendResolution(backend=selected, reason="; ".join(reason_parts))
+
+    def _normalize_optional_target(self, value: Any) -> str | None:
+        if not isinstance(value, str) or not value.strip():
+            return None
+        canonical = normalize_target_name(value)
+        if canonical not in OFFICIAL_TARGETS:
+            raise ValueError(
+                f"Backend no permitido: {value}. Permitidos: {', '.join(OFFICIAL_TARGETS)}"
+            )
+        return canonical
+
+    def _project_type(self, config: dict[str, Any]) -> str:
+        project = config.get("project", {}) if isinstance(config, dict) else {}
+        if not isinstance(project, dict):
+            return "application"
+        raw = (
+            project.get("type")
+            or project.get("project_type")
+            or project.get("kind")
+            or "application"
+        )
+        normalized = str(raw).strip().lower()
+        if normalized in self._PROJECT_TYPE_PRIORITIES:
+            return normalized
+        return "application"
+
+    def _module_metadata(self, config: dict[str, Any], source_file: str) -> dict[str, Any]:
+        if not isinstance(config, dict):
+            return {}
+        modulos = config.get("modulos", {})
+        if not isinstance(modulos, dict):
+            return {}
+
+        source = Path(source_file)
+        candidates = (
+            str(source),
+            source.name,
+            source.as_posix(),
+        )
+        for key in candidates:
+            metadata = modulos.get(key)
+            if isinstance(metadata, dict):
+                return metadata
+        return {}
+
+    def _collect_capabilities(
+        self,
+        *,
+        config: dict[str, Any],
+        module_meta: dict[str, Any],
+        requested: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        project = config.get("project", {}) if isinstance(config, dict) else {}
+        project_caps = project.get("required_capabilities", []) if isinstance(project, dict) else []
+        module_caps = module_meta.get("required_capabilities", []) if isinstance(module_meta, dict) else []
+
+        merged: list[str] = []
+        for group in (project_caps, module_caps, list(requested)):
+            if isinstance(group, (list, tuple)):
+                for value in group:
+                    if isinstance(value, str):
+                        cap = value.strip().lower()
+                        if cap and cap not in merged:
+                            merged.append(cap)
+        return tuple(merged)
+
+    def _ordered_candidates(self, *, project_type: str, module_target: str | None) -> list[str]:
+        ordered: list[str] = []
+        if module_target is not None:
+            ordered.append(module_target)
+        for backend in self._PROJECT_TYPE_PRIORITIES.get(project_type, self._default_priority()):
+            if backend not in ordered:
+                ordered.append(backend)
+        for backend in self._default_priority():
+            if backend not in ordered:
+                ordered.append(backend)
+        return ordered
+
+    def _default_priority(self) -> tuple[str, ...]:
+        weighted = sorted(
+            OFFICIAL_TARGETS,
+            key=lambda backend: target_metadata(backend)["release_priority"],
+        )
+        return tuple(weighted)
+
+    def _supports_capabilities(self, backend: str, capabilities: tuple[str, ...]) -> bool:
+        if not capabilities:
+            return True
+
+        metadata = target_metadata(backend)
+        for capability in capabilities:
+            if capability in {"sdk", "sdk_full", "holobit_sdk"} and metadata["sdk_contract"] != "full":
+                return False
+            if capability in {"holobit", "holobit_full"} and metadata["holobit_contract"] != "full":
+                return False
+            if capability in {"holobit_partial", "holobit_runtime"} and metadata["holobit_contract"] == "none":
+                return False
+        return True
+
+
+__all__ = ["BackendResolution", "BuildOrchestrator"]

--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -6,6 +6,7 @@ from argparse import ArgumentTypeError
 from importlib import import_module
 from importlib.metadata import entry_points
 
+from pcobra.cobra.build.orchestrator import BuildOrchestrator
 from pcobra.cobra.transpilers import module_map
 from pcobra.cobra.cli.target_policies import (
     OFFICIAL_TRANSPILATION_TARGETS,
@@ -30,7 +31,7 @@ from pcobra.core.semantic_validators import (
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.mode_policy import validar_politica_modo
-from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
+from pcobra.cobra.cli.utils.messages import mostrar_advertencia, mostrar_error, mostrar_info
 from pcobra.cobra.cli.utils.validators import validar_archivo_existente
 from pcobra.cobra.cli.utils.autocomplete import files_completer
 from pcobra.cobra.core import ParserError
@@ -44,6 +45,7 @@ MAX_LANGUAGES = 10
 
 TRANSPILERS = build_official_transpilers()
 _ENTRYPOINTS_LOADED = False
+ORCHESTRATOR = BuildOrchestrator()
 
 
 def register_transpiler_backend(backend: str, transpiler_cls, *, context: str) -> str:
@@ -365,9 +367,18 @@ class CompileCommand(BaseCommand):
                 return 1
 
         mod_info = module_map.get_toml_map()
+        preferred_backend = getattr(args, "backend", None) or getattr(args, "tipo", None)
+        if getattr(args, "backend", None):
+            mostrar_advertencia(
+                _("La opción --backend está deprecada en 'compilar'; use --tipo. Se eliminará en una versión futura.")
+            )
         try:
+            resolution = ORCHESTRATOR.resolve_backend(
+                source_file=archivo,
+                preferred_backend=preferred_backend,
+            )
             transpilador_objetivo = _validate_official_backend_or_raise(
-                getattr(args, "backend", None) or args.tipo,
+                resolution.backend,
                 context="CLI",
             )
         except ValueError as validation_err:

--- a/src/pcobra/cobra/cli/commands_v2/build_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/build_cmd.py
@@ -2,7 +2,8 @@ from argparse import Namespace
 from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
-from pcobra.cobra.cli.commands.compile_cmd import CompileCommand, LANG_CHOICES
+from pcobra.cobra.build.orchestrator import BuildOrchestrator
+from pcobra.cobra.cli.commands.compile_cmd import CompileCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.autocomplete import files_completer
 
@@ -16,24 +17,22 @@ class BuildCommandV2(BaseCommand):
     def __init__(self) -> None:
         super().__init__()
         self._legacy = CompileCommand()
+        self._orchestrator = BuildOrchestrator()
 
     def register_subparser(self, subparsers: Any):
         parser = subparsers.add_parser(self.name, help=_("Build/transpile a Cobra file"))
         parser.add_argument("file", help=_("Source Cobra file")).completer = files_completer()
-        parser.add_argument("--target", choices=LANG_CHOICES, help=_("Target language"))
-        parser.add_argument(
-            "--targets",
-            help=_("Comma-separated target languages"),
-        )
         parser.set_defaults(cmd=self)
         return parser
 
     def run(self, args: Any) -> int:
+        resolution = self._orchestrator.resolve_backend(source_file=args.file)
         legacy_args = Namespace(
             archivo=args.file,
-            tipo=getattr(args, "target", None),
-            backend=getattr(args, "target", None),
-            tipos=getattr(args, "targets", None),
+            tipo=resolution.backend,
+            backend=None,
+            tipos=None,
             modo=getattr(args, "modo", "mixto"),
+            backend_reason=resolution.reason,
         )
         return self._legacy.run(legacy_args)

--- a/tests/unit/test_build_orchestrator.py
+++ b/tests/unit/test_build_orchestrator.py
@@ -1,0 +1,45 @@
+from cobra.build.orchestrator import BuildOrchestrator
+
+
+def test_build_orchestrator_prioriza_metadata_modulo(monkeypatch):
+    monkeypatch.setattr(
+        "cobra.build.orchestrator.get_toml_map",
+        lambda: {
+            "project": {"type": "systems"},
+            "modulos": {
+                "demo.co": {
+                    "preferred_target": "javascript",
+                }
+            },
+        },
+    )
+
+    resolution = BuildOrchestrator().resolve_backend(source_file="demo.co")
+
+    assert resolution.backend == "javascript"
+    assert "module_target=javascript" in resolution.reason
+
+
+def test_build_orchestrator_aplica_capacidad_sdk_full(monkeypatch):
+    monkeypatch.setattr(
+        "cobra.build.orchestrator.get_toml_map",
+        lambda: {
+            "project": {
+                "required_capabilities": ["sdk_full"],
+                "type": "web",
+            }
+        },
+    )
+
+    resolution = BuildOrchestrator().resolve_backend(source_file="demo.co")
+
+    assert resolution.backend == "python"
+
+
+def test_build_orchestrator_respeta_preferencia_legacy(monkeypatch):
+    monkeypatch.setattr("cobra.build.orchestrator.get_toml_map", lambda: {})
+
+    resolution = BuildOrchestrator().resolve_backend(source_file="demo.co", preferred_backend="rust")
+
+    assert resolution.backend == "rust"
+    assert "legacy" in resolution.reason

--- a/tests/unit/test_compile_cmd_errors.py
+++ b/tests/unit/test_compile_cmd_errors.py
@@ -83,3 +83,32 @@ def test_exceso_tipos(monkeypatch, tmp_path):
 
     assert rc == 1
     assert any("Demasiados lenguajes" in m for m in mensajes)
+
+
+@pytest.mark.timeout(5)
+def test_backend_legacy_muestra_warning_deprecacion(monkeypatch, tmp_path):
+    archivo = tmp_path / "code.co"
+    archivo.write_text("x = 1")
+    advertencias = []
+
+    monkeypatch.setattr("cobra.cli.commands.compile_cmd._ensure_entrypoints_loaded_once", lambda: None)
+    monkeypatch.setattr(
+        "cobra.cli.commands.compile_cmd.ORCHESTRATOR.resolve_backend",
+        lambda **kwargs: SimpleNamespace(backend="python", reason="legacy"),
+    )
+    monkeypatch.setattr("cobra.cli.commands.compile_cmd.validar_dependencias", lambda *a, **k: None)
+    monkeypatch.setattr("cobra.cli.commands.compile_cmd.obtener_ast", lambda codigo: [])
+    monkeypatch.setattr("cobra.cli.commands.compile_cmd.construir_cadena", lambda: SimpleNamespace())
+
+    class _DummyTranspiler:
+        def generate_code(self, _ast):
+            return "ok"
+
+    monkeypatch.setattr("cobra.cli.commands.compile_cmd.TRANSPILERS", {"python": _DummyTranspiler})
+    monkeypatch.setattr("cobra.cli.commands.compile_cmd.mostrar_advertencia", lambda msg, registrar_log=True: advertencias.append(msg))
+
+    args = SimpleNamespace(archivo=str(archivo), tipo="python", backend="python", tipos=None, modo="mixto")
+    rc = CompileCommand().run(args)
+
+    assert rc == 0
+    assert any("--backend está deprecada" in msg for msg in advertencias)


### PR DESCRIPTION
### Motivation

- Centralizar la lógica de selección de backend para los flujos de `build`/`compilar` evitando decisiones dispersas en la CLI. 
- Que la elección use metadatos del proyecto/módulo, tipo de proyecto y capacidades requeridas en una única regla determinista. 
- Mantener compatibilidad legacy con `--backend` pero marcarla como deprecada y redirigir internamente al orquestador unificado.

### Description

- Se añadió `BuildOrchestrator` en `src/pcobra/cobra/build/orchestrator.py` que resuelve el backend por prioridad: metadata de módulo, tipo de proyecto y capacidades, y soporta preferencia explícita legacy. 
- Se exportó el orquestador desde `src/pcobra/cobra/build/__init__.py` para uso desde la CLI. 
- `BuildCommandV2` (`src/pcobra/cobra/cli/commands_v2/build_cmd.py`) dejó de exponer `--target/--targets` públicamente y ahora llama a `BuildOrchestrator.resolve_backend` para decidir el backend y redirige al flujo legado `CompileCommand`. 
- `CompileCommand` (`src/pcobra/cobra/cli/commands/compile_cmd.py`) ahora invoca el orquestador (`ORCHESTRATOR.resolve_backend`) y emite una advertencia de deprecación cuando se usa `--backend`, manteniendo la ruta funcional por compatibilidad. 
- Se añadieron pruebas unitarias: `tests/unit/test_build_orchestrator.py` (prioridad por metadata, capacidad `sdk_full`, respeto de preferencia legacy) y un test en `tests/unit/test_compile_cmd_errors.py` que verifica el `warning` deprecatorio para `--backend`.

### Testing

- Se compiló por bytecode con `python -m py_compile` sobre los módulos nuevos y modificados y la comprobación final fue satisfactoria. 
- `pytest -q tests/unit/test_build_orchestrator.py` pasó con `3 passed`. 
- Un intento de ejecutar `pytest -q tests/unit/test_build_orchestrator.py tests/unit/test_compile_cmd_errors.py` falló en la fase de colección por una validación de política de targets (`Targets fuera del conjunto canónico ...`), que es una restricción previa del entorno de pruebas y no un fallo del orquestador en sí. 
- Nota: las nuevas pruebas unitarias están incluidas; la ejecución completa del conjunto afectado por políticas de targets puede requerir ajustar el entorno de pruebas para permitir la colección de todos los tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3596acd483279e7f9dbdce13b6b0)