### PR TITLE
feat(cobra): introducir capa de backends con API `compile` unificada

### DIFF
--- a/src/pcobra/cobra/backends/__init__.py
+++ b/src/pcobra/cobra/backends/__init__.py
@@ -1,0 +1,5 @@
+"""Backends internos para unificar la compilación por artefacto."""
+
+from pcobra.cobra.backends.resolver import compile, resolve_backend
+
+__all__ = ["compile", "resolve_backend"]

--- a/src/pcobra/cobra/backends/base.py
+++ b/src/pcobra/cobra/backends/base.py
@@ -1,0 +1,15 @@
+"""Interfaces base para adapters de compilación interna."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Mapping
+
+
+class BackendAdapter(ABC):
+    """Contrato mínimo que deben implementar los adapters de backend."""
+
+    @abstractmethod
+    def compile(self, ast: Any, options: Mapping[str, Any] | None = None) -> str:
+        """Compila un AST de Cobra y retorna el artefacto generado."""
+        raise NotImplementedError

--- a/src/pcobra/cobra/backends/javascript_adapter.py
+++ b/src/pcobra/cobra/backends/javascript_adapter.py
@@ -1,0 +1,17 @@
+"""Adapter interno para compilación a JavaScript."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from pcobra.cobra.backends.base import BackendAdapter
+from pcobra.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
+
+
+class JavaScriptAdapter(BackendAdapter):
+    """Wrapper sobre ``TranspiladorJavaScript`` sin modificar su implementación."""
+
+    def compile(self, ast: Any, options: Mapping[str, Any] | None = None) -> str:
+        _ = options or {}
+        transpiler = TranspiladorJavaScript()
+        return transpiler.generate_code(ast)

--- a/src/pcobra/cobra/backends/python_adapter.py
+++ b/src/pcobra/cobra/backends/python_adapter.py
@@ -1,0 +1,17 @@
+"""Adapter interno para compilación a Python."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from pcobra.cobra.backends.base import BackendAdapter
+from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
+
+
+class PythonAdapter(BackendAdapter):
+    """Wrapper sobre ``TranspiladorPython`` sin modificar su implementación."""
+
+    def compile(self, ast: Any, options: Mapping[str, Any] | None = None) -> str:
+        _ = options or {}
+        transpiler = TranspiladorPython()
+        return transpiler.generate_code(ast)

--- a/src/pcobra/cobra/backends/resolver.py
+++ b/src/pcobra/cobra/backends/resolver.py
@@ -1,0 +1,47 @@
+"""Resolución y API interna única de compilación por backend."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from pcobra.cobra.backends.base import BackendAdapter
+from pcobra.cobra.backends.javascript_adapter import JavaScriptAdapter
+from pcobra.cobra.backends.python_adapter import PythonAdapter
+from pcobra.cobra.backends.rust_adapter import RustAdapter
+
+_BACKEND_ALIASES = {
+    "python": "python",
+    "py": "python",
+    "javascript": "javascript",
+    "js": "javascript",
+    "rust": "rust",
+    "rs": "rust",
+}
+
+
+def resolve_backend(artifact_kind: str) -> BackendAdapter:
+    """Retorna el adapter adecuado para el ``artifact_kind`` solicitado."""
+    normalized = _BACKEND_ALIASES.get((artifact_kind or "").strip().lower())
+    if normalized == "python":
+        return PythonAdapter()
+    if normalized == "javascript":
+        return JavaScriptAdapter()
+    if normalized == "rust":
+        return RustAdapter()
+    raise ValueError(f"artifact_kind no soportado: {artifact_kind!r}")
+
+
+def compile(
+    ast: Any,
+    artifact_kind: str,
+    options: Mapping[str, Any] | None = None,
+) -> str:
+    """API interna unificada de compilación.
+
+    Args:
+        ast: AST de Cobra (o estructura normalizable por el transpiler).
+        artifact_kind: Tipo de artefacto de salida (python/javascript/rust).
+        options: Opciones internas del backend (reservado para evolución futura).
+    """
+    adapter = resolve_backend(artifact_kind)
+    return adapter.compile(ast, options=options)

--- a/src/pcobra/cobra/backends/rust_adapter.py
+++ b/src/pcobra/cobra/backends/rust_adapter.py
@@ -1,0 +1,17 @@
+"""Adapter interno para compilación a Rust."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from pcobra.cobra.backends.base import BackendAdapter
+from pcobra.cobra.transpilers.transpiler.to_rust import TranspiladorRust
+
+
+class RustAdapter(BackendAdapter):
+    """Wrapper sobre ``TranspiladorRust`` sin modificar su implementación."""
+
+    def compile(self, ast: Any, options: Mapping[str, Any] | None = None) -> str:
+        _ = options or {}
+        transpiler = TranspiladorRust()
+        return transpiler.generate_code(ast)


### PR DESCRIPTION
### Motivation
- Estandarizar la forma interna de invocar los transpiladores creando una capa de adapters que exponga una única API de compilación. 
- Permitir seleccionar internamente el backend por `artifact_kind` (python/js/rust) y encapsular la lógica de instanciación de los transpiladores existentes.

### Description
- Se añadió el paquete `src/pcobra/cobra/backends/` con una interfaz base `BackendAdapter` y archivos nuevos: `base.py`, `python_adapter.py`, `javascript_adapter.py`, `rust_adapter.py`, `resolver.py` y `__init__.py`.
- Cada adapter (`PythonAdapter`, `JavaScriptAdapter`, `RustAdapter`) envuelve sin modificar los transpiladores existentes y delega en `TranspiladorPython`, `TranspiladorJavaScript` y `TranspiladorRust` respectivamente llamando a `generate_code(ast)`.
- Se implementó `resolve_backend(artifact_kind)` con aliases (`py/js/rs`) y la API interna única `compile(ast, artifact_kind, options)` para compilar a la salida solicitada.
- No se tocó ninguna implementación de los transpiladores; los cambios son solo wrappers y resolución de backend.

### Testing
- Se ejecutó `python -m compileall -q src/pcobra/cobra/backends` y la compilación de los módulos nuevos finalizó correctamente (sin errores).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd387173f48327bb79aa015c6218b2)