### PR TITLE
Agregar manifiestos de contrato stdlib y validación

### DIFF
--- a/src/pcobra/cobra/semantico/mod_validator.py
+++ b/src/pcobra/cobra/semantico/mod_validator.py
@@ -256,6 +256,75 @@ def _schema_for_module(datos: Dict[str, Any], modulo: str, info: Dict[str, Any])
     return SCHEMA_V1, OFFICIAL_TARGETS, DEFAULT_REQUIRED_TARGETS, "v1"
 
 
+
+
+def _validate_stdlib_contract_manifest(name: str, contract: Dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(contract, dict):
+        return [f"Manifest contractual inválido para {name}: contenido no es objeto TOML."]
+
+    public_api = contract.get("public_api")
+    if not isinstance(public_api, list) or not public_api or not all(isinstance(item, str) and item.strip() for item in public_api):
+        errors.append(
+            f"Manifest contractual inválido para {name}: public_api debe ser lista no vacía de strings."
+        )
+
+    preferred = contract.get("backend_preferido")
+    if not isinstance(preferred, str) or normalize_target_name(preferred) not in OFFICIAL_TARGETS:
+        errors.append(
+            f"Manifest contractual inválido para {name}: backend_preferido debe ser un backend canónico oficial."
+        )
+
+    fallback = contract.get("fallback_permitido")
+    if fallback is None:
+        fallback = []
+    if not isinstance(fallback, list):
+        errors.append(
+            f"Manifest contractual inválido para {name}: fallback_permitido debe ser una lista."
+        )
+        fallback = []
+
+    normalized_fallback: list[str] = []
+    for backend in fallback:
+        if not isinstance(backend, str):
+            errors.append(
+                f"Manifest contractual inválido para {name}: fallback_permitido contiene valor no string ({backend!r})."
+            )
+            continue
+        canonical = normalize_target_name(backend)
+        if canonical not in OFFICIAL_TARGETS:
+            errors.append(
+                f"Manifest contractual inválido para {name}: fallback_permitido contiene backend no oficial ({backend})."
+            )
+            continue
+        if canonical not in normalized_fallback:
+            normalized_fallback.append(canonical)
+
+    if isinstance(preferred, str):
+        preferred_normalized = normalize_target_name(preferred)
+        if preferred_normalized in normalized_fallback:
+            errors.append(
+                f"Manifest contractual inválido para {name}: fallback_permitido no puede incluir backend_preferido."
+            )
+
+    return errors
+
+
+def _validate_stdlib_contracts() -> list[str]:
+    contracts = module_map.get_stdlib_contracts()
+    if not contracts:
+        return []
+
+    errors: list[str] = []
+    for name, contract in contracts.items():
+        if not name.startswith("cobra."):
+            errors.append(
+                f"Manifest contractual inválido para {name}: el nombre debe empezar por 'cobra.'."
+            )
+            continue
+        errors.extend(_validate_stdlib_contract_manifest(name, contract))
+    return errors
+
 def validar_mod(path: str | None = None) -> None:
     """Valida el contenido de ``cobra.mod``.
 
@@ -359,6 +428,8 @@ def validar_mod(path: str | None = None) -> None:
                         errores.append(f"No existe el archivo {ruta} para {modulo}")
                 except OSError as e:
                     errores.append(f"Error al verificar archivo {ruta}: {e}")
+
+    errores.extend(_validate_stdlib_contracts())
 
     if errores:
         mensaje = "; ".join(errores)

--- a/src/pcobra/cobra/stdlib_contract/cobra.core
+++ b/src/pcobra/cobra/stdlib_contract/cobra.core
@@ -1,0 +1,3 @@
+public_api = ["cobra.core.lex", "cobra.core.parse", "cobra.core.ast"]
+backend_preferido = "python"
+fallback_permitido = ["rust", "javascript"]

--- a/src/pcobra/cobra/stdlib_contract/cobra.datos
+++ b/src/pcobra/cobra/stdlib_contract/cobra.datos
@@ -1,0 +1,3 @@
+public_api = ["cobra.datos.tabla", "cobra.datos.csv", "cobra.datos.json"]
+backend_preferido = "python"
+fallback_permitido = ["javascript"]

--- a/src/pcobra/cobra/stdlib_contract/cobra.system
+++ b/src/pcobra/cobra/stdlib_contract/cobra.system
@@ -1,0 +1,3 @@
+public_api = ["cobra.system.fs", "cobra.system.proc", "cobra.system.env"]
+backend_preferido = "rust"
+fallback_permitido = ["python"]

--- a/src/pcobra/cobra/stdlib_contract/cobra.web
+++ b/src/pcobra/cobra/stdlib_contract/cobra.web
@@ -1,0 +1,3 @@
+public_api = ["cobra.web.http", "cobra.web.router", "cobra.web.sse"]
+backend_preferido = "javascript"
+fallback_permitido = ["python"]

--- a/src/pcobra/cobra/transpilers/module_map.py
+++ b/src/pcobra/cobra/transpilers/module_map.py
@@ -27,6 +27,81 @@ COBRA_TOML_PATH = os.environ.get(
 )
 
 _toml_cache = None
+
+STDLIB_CONTRACTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'stdlib_contract')
+)
+
+_stdlib_contract_cache: dict[str, Dict[str, Any]] | None = None
+
+
+def _load_stdlib_contracts() -> dict[str, Dict[str, Any]]:
+    """Carga manifiestos contractuales de ``stdlib_contract``."""
+    global _stdlib_contract_cache
+    if _stdlib_contract_cache is not None:
+        return _stdlib_contract_cache
+
+    loaded: dict[str, Dict[str, Any]] = {}
+    if not os.path.isdir(STDLIB_CONTRACTS_DIR):
+        _stdlib_contract_cache = loaded
+        return loaded
+
+    for entry in sorted(os.listdir(STDLIB_CONTRACTS_DIR)):
+        contract_path = os.path.join(STDLIB_CONTRACTS_DIR, entry)
+        if not os.path.isfile(contract_path):
+            continue
+        try:
+            with open(contract_path, 'rb') as handle:
+                parsed = tomllib.load(handle)
+        except (OSError, tomllib.TOMLDecodeError):
+            logger.warning('No se pudo cargar manifest contractual: %s', contract_path)
+            continue
+        if isinstance(parsed, dict):
+            loaded[entry] = parsed
+
+    _stdlib_contract_cache = loaded
+    return loaded
+
+
+def get_stdlib_contracts() -> Dict[str, Dict[str, Any]]:
+    """Devuelve todos los manifiestos contractuales cargados."""
+    return dict(_load_stdlib_contracts())
+
+
+def get_stdlib_contract(module: str) -> Dict[str, Any]:
+    """Devuelve el manifiesto contractual declarado para ``module``."""
+    contracts = _load_stdlib_contracts()
+    contract = contracts.get(module)
+    if isinstance(contract, dict):
+        return contract
+    return {}
+
+
+def resolve_backend_for_module(module: str, backend: str) -> str:
+    """Resuelve backend efectivo por contrato sin exponer transpilers internos."""
+    canonical_backend = normalize_target_name(backend)
+    contract = get_stdlib_contract(module)
+    if not contract:
+        return canonical_backend
+
+    preferred_backend = contract.get('backend_preferido')
+    if not isinstance(preferred_backend, str):
+        return canonical_backend
+    preferred = normalize_target_name(preferred_backend)
+
+    fallback = contract.get('fallback_permitido', [])
+    if not isinstance(fallback, list):
+        fallback = []
+    allowed_fallbacks = {
+        normalize_target_name(item)
+        for item in fallback
+        if isinstance(item, str)
+    }
+
+    if canonical_backend == preferred or canonical_backend in allowed_fallbacks:
+        return canonical_backend
+    return preferred
+
 _RUNTIME_PATH_FORBIDDEN_SEGMENTS = (
     "core/nativos",
     "corelibs",
@@ -73,8 +148,8 @@ def get_mapped_path(module: str, backend: str) -> str:
     exclusivamente desde ``cobra.toml`` usando la estructura
     ``[modulos."<module>"]``. Si no hay mapeo válido, devuelve ``module``.
     """
-    canonical_backend = normalize_target_name(backend)
-    if backend != canonical_backend or canonical_backend not in OFFICIAL_TARGETS:
+    canonical_backend = resolve_backend_for_module(module, backend)
+    if canonical_backend not in OFFICIAL_TARGETS:
         return module
 
     mapa = get_toml_map()

--- a/tests/unit/test_mod_validator.py
+++ b/tests/unit/test_mod_validator.py
@@ -221,3 +221,29 @@ def test_validador_v1_emite_warning_migracion(tmp_path, monkeypatch, caplog):
 
     validar_mod(str(tmp_path / "cobra.mod"))
     assert "esquema v1 está deprecado" in caplog.text
+
+
+def test_validador_falla_si_manifest_stdlib_contract_invalido(tmp_path, monkeypatch):
+    py = tmp_path / "m.py"
+    py.write_text("x = 1")
+    mod = tmp_path / "m.co"
+    data = {str(mod): {"version": "0.1.0", "python": str(py)}}
+    _write_yaml(tmp_path / "cobra.mod", data)
+
+    monkeypatch.setattr(
+        "cobra.semantico.mod_validator.module_map.get_toml_map",
+        lambda: {"project": {"required_targets": ["python"]}},
+    )
+    monkeypatch.setattr(
+        "cobra.semantico.mod_validator.module_map.get_stdlib_contracts",
+        lambda: {
+            "cobra.system": {
+                "public_api": ["cobra.system.fs"],
+                "backend_preferido": "python",
+                "fallback_permitido": ["fantasy"],
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="fallback_permitido contiene backend no oficial"):
+        validar_mod(str(tmp_path / "cobra.mod"))

--- a/tests/unit/test_module_map.py
+++ b/tests/unit/test_module_map.py
@@ -37,3 +37,30 @@ def test_module_map_ignora_cobra_mod_para_resolucion(tmp_path, monkeypatch):
     module_map._toml_cache = None
 
     assert module_map.get_mapped_path(mod, "go") == mod
+
+
+def test_module_map_resuelve_backend_por_contrato_stdlib(tmp_path, monkeypatch):
+    contracts_dir = tmp_path / "stdlib_contract"
+    contracts_dir.mkdir()
+    (contracts_dir / "cobra.web").write_text(
+        "public_api=['cobra.web.http']\n"
+        "backend_preferido='javascript'\n"
+        "fallback_permitido=['python']\n",
+        encoding="utf-8",
+    )
+
+    toml_file = tmp_path / "cobra.toml"
+    toml_file.write_text(
+        "[modulos]\n"
+        "[modulos.'cobra.web']\n"
+        "javascript = 'cobra_web.js'\n"
+        "python = 'cobra_web.py'\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(module_map, "STDLIB_CONTRACTS_DIR", str(contracts_dir))
+    monkeypatch.setattr(module_map, "COBRA_TOML_PATH", str(toml_file))
+    module_map._stdlib_contract_cache = None
+    module_map._toml_cache = None
+
+    assert module_map.get_mapped_path("cobra.web", "rust") == "cobra_web.js"


### PR DESCRIPTION
### Motivation

- Permitir declarar, por módulo stdlib, la API pública, el backend preferido y backfills permitidos para seleccionar backends sin exponer nombres de transpiler al usuario.  
- Evitar mapeos erróneos desde `cobra.toml` cuando existe un contrato de stdlib que impone un `backend_preferido` y controlar validez de esos manifiestos antes de publicar.

### Description

- Se creó la carpeta `src/pcobra/cobra/stdlib_contract/` con los manifests `cobra.core`, `cobra.datos`, `cobra.web` y `cobra.system`, cada uno con `public_api`, `backend_preferido` y `fallback_permitido`.
- En `src/pcobra/cobra/transpilers/module_map.py` se añadió la carga y cacheo de manifests (`_load_stdlib_contracts`), la API de acceso (`get_stdlib_contracts`, `get_stdlib_contract`) y la función `resolve_backend_for_module` que determina el backend efectivo por contrato, integrándola en `get_mapped_path` para ocultar detalles de transpilers.
- En `src/pcobra/cobra/semantico/mod_validator.py` se añadió `_validate_stdlib_contract_manifest` y `_validate_stdlib_contracts` para verificar forma y semántica de los manifests (API pública no vacía, `backend_preferido` canónico, `fallback_permitido` lista de backends oficiales y sin incluir el preferido) y se integró la comprobación en `validar_mod` acumulando errores en el informe final.
- Se añadieron tests unitarios que cubren la resolución contractual en `module_map` y el rechazo por manifests inválidos en `mod_validator` (`tests/unit/test_module_map.py` y `tests/unit/test_mod_validator.py`).

### Testing

- Ejecutado `pytest -q tests/unit/test_module_map.py::test_module_map_resuelve_backend_por_contrato_stdlib tests/unit/test_mod_validator.py::test_validador_falla_si_manifest_stdlib_contract_invalido` y ambos tests pasaron correctamente.  
- Las nuevas validaciones devuelven errores acumulados a través de `validar_mod` cuando se detectan manifests invalidos, y la resolución contractual modifica la elección de backend en `get_mapped_path` según lo esperado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddc31d007c83278008695c5b4f4af1)