### PR TITLE
Resolver de imports Cobra determinista con inyección de adapters de backend

### DIFF
--- a/src/pcobra/cobra/imports/__init__.py
+++ b/src/pcobra/cobra/imports/__init__.py
@@ -1,0 +1,17 @@
+"""Utilidades de resolución de imports para Cobra."""
+
+from pcobra.cobra.imports.resolver import (
+    AmbiguousImportError,
+    CobraImportResolver,
+    HybridModuleSpec,
+    ImportResolutionError,
+    ResolutionResult,
+)
+
+__all__ = [
+    "AmbiguousImportError",
+    "CobraImportResolver",
+    "HybridModuleSpec",
+    "ImportResolutionError",
+    "ResolutionResult",
+]

--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -1,0 +1,219 @@
+"""Resolvedor de imports Cobra con estrategia determinista por origen."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Mapping
+
+from pcobra.cobra.backends.resolver import resolve_backend
+from pcobra.cobra.transpilers.module_map import get_stdlib_contracts, resolve_backend_for_module
+
+
+class ImportResolutionError(RuntimeError):
+    """Error base al resolver imports Cobra."""
+
+
+class AmbiguousImportError(ImportResolutionError):
+    """Error determinista para imports ambiguos sin calificación de namespace."""
+
+
+@dataclass(frozen=True)
+class HybridModuleSpec:
+    """Declaración de módulo híbrido."""
+
+    module: str
+    import_path: str
+    backend: str | None = None
+
+
+@dataclass(frozen=True)
+class ResolutionResult:
+    """Resultado de resolución de un import Cobra."""
+
+    request: str
+    source: str
+    resolved_name: str
+    import_path: str | None = None
+    backend: str | None = None
+
+
+
+_SOURCE_PRIORITY: dict[str, int] = {
+    "local": 1,
+    "stdlib": 2,
+    "python_bridge": 3,
+    "hybrid": 4,
+}
+
+class CobraImportResolver:
+    """Resuelve imports con prioridad fija y conflictos explícitos."""
+
+    def __init__(
+        self,
+        *,
+        project_root: str | Path | None = None,
+        hybrid_modules: Mapping[str, HybridModuleSpec | Mapping[str, Any]] | None = None,
+    ) -> None:
+        self.project_root = Path(project_root).resolve() if project_root else None
+        self.hybrid_modules = self._normalize_hybrid_modules(hybrid_modules or {})
+        self.stdlib_modules = self._load_stdlib_modules()
+
+    @staticmethod
+    def _normalize_hybrid_modules(
+        modules: Mapping[str, HybridModuleSpec | Mapping[str, Any]],
+    ) -> dict[str, HybridModuleSpec]:
+        normalized: dict[str, HybridModuleSpec] = {}
+        for name, raw in modules.items():
+            if isinstance(raw, HybridModuleSpec):
+                normalized[name] = raw
+                continue
+            import_path = str(raw.get("import_path", name))
+            backend = raw.get("backend")
+            normalized[name] = HybridModuleSpec(
+                module=str(raw.get("module", name)),
+                import_path=import_path,
+                backend=str(backend) if isinstance(backend, str) else None,
+            )
+        return normalized
+
+    @staticmethod
+    def _load_stdlib_modules() -> set[str]:
+        contracts = get_stdlib_contracts()
+        return {name for name in contracts if name.startswith("cobra.")}
+
+    def resolve(self, module_name: str) -> ResolutionResult:
+        name = (module_name or "").strip()
+        if not name:
+            raise ImportResolutionError("Nombre de módulo vacío")
+
+        candidates: list[ResolutionResult] = []
+
+        local_candidate = self._resolve_local_module(name)
+        if local_candidate is not None:
+            candidates.append(local_candidate)
+
+        stdlib_candidate = self._resolve_stdlib_module(name)
+        if stdlib_candidate is not None:
+            candidates.append(stdlib_candidate)
+
+        python_candidate = self._resolve_python_bridge(name)
+        if python_candidate is not None:
+            candidates.append(python_candidate)
+
+        hybrid_candidate = self._resolve_hybrid_module(name)
+        if hybrid_candidate is not None:
+            candidates.append(hybrid_candidate)
+
+        if not candidates:
+            raise ImportResolutionError(f"No se encontró módulo para '{name}'")
+
+        sorted_candidates = sorted(candidates, key=lambda c: _SOURCE_PRIORITY[c.source])
+        top_priority = _SOURCE_PRIORITY[sorted_candidates[0].source]
+        top_candidates = [
+            candidate
+            for candidate in sorted_candidates
+            if _SOURCE_PRIORITY[candidate.source] == top_priority
+        ]
+
+        if "." not in name and len(sorted_candidates) > 1:
+            has_local = any(candidate.source == "local" for candidate in sorted_candidates)
+            if not has_local or len(top_candidates) > 1:
+                details = ", ".join(
+                    f"{c.source}:{c.resolved_name}" for c in sorted_candidates
+                )
+                raise AmbiguousImportError(
+                    f"Import ambiguo sin namespace para '{name}'. "
+                    f"Use un nombre calificado. Candidatos: {details}"
+                )
+
+        return sorted_candidates[0]
+
+    def load_module(self, module_name: str, fallback_backend: str = "python") -> tuple[ResolutionResult, ModuleType | None]:
+        """Carga módulo Python cuando aplique e inyecta adapter de backend."""
+
+        resolution = self.resolve(module_name)
+        if resolution.import_path is None:
+            return resolution, None
+
+        module = importlib.import_module(resolution.import_path)
+        backend = resolution.backend or fallback_backend
+        backend = resolve_backend_for_module(resolution.resolved_name, backend)
+        adapter = resolve_backend(backend)
+        setattr(module, "__cobra_backend__", backend)
+        setattr(module, "__cobra_backend_adapter__", adapter)
+        return resolution, module
+
+    def _resolve_local_module(self, name: str) -> ResolutionResult | None:
+        if self.project_root is None:
+            return None
+
+        relative = Path(*name.split("."))
+        local_patterns = (
+            relative.with_suffix(".co"),
+            relative.with_suffix(".cobra"),
+            relative / "__init__.co",
+            relative / "__init__.cobra",
+        )
+        for pattern in local_patterns:
+            if (self.project_root / pattern).exists():
+                return ResolutionResult(
+                    request=name,
+                    source="local",
+                    resolved_name=name,
+                )
+        return None
+
+    def _resolve_stdlib_module(self, name: str) -> ResolutionResult | None:
+        if name.startswith("cobra."):
+            if name in self.stdlib_modules:
+                return ResolutionResult(
+                    request=name,
+                    source="stdlib",
+                    resolved_name=name,
+                    import_path=self._cobra_stdlib_to_python(name),
+                )
+            return None
+
+        qualified = f"cobra.{name}"
+        if qualified in self.stdlib_modules:
+            return ResolutionResult(
+                request=name,
+                source="stdlib",
+                resolved_name=qualified,
+                import_path=self._cobra_stdlib_to_python(qualified),
+            )
+        return None
+
+    @staticmethod
+    def _cobra_stdlib_to_python(qualified_name: str) -> str:
+        tail = qualified_name.removeprefix("cobra.")
+        return f"pcobra.standard_library.{tail}"
+
+    @staticmethod
+    def _resolve_python_bridge(name: str) -> ResolutionResult | None:
+        if name.startswith("cobra."):
+            return None
+        if importlib.util.find_spec(name) is None:
+            return None
+        return ResolutionResult(
+            request=name,
+            source="python_bridge",
+            resolved_name=name,
+            import_path=name,
+        )
+
+    def _resolve_hybrid_module(self, name: str) -> ResolutionResult | None:
+        spec = self.hybrid_modules.get(name)
+        if spec is None:
+            return None
+        return ResolutionResult(
+            request=name,
+            source="hybrid",
+            resolved_name=spec.module,
+            import_path=spec.import_path,
+            backend=spec.backend,
+        )

--- a/tests/unit/test_imports_resolver.py
+++ b/tests/unit/test_imports_resolver.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+
+from pcobra.cobra.imports.resolver import (
+    AmbiguousImportError,
+    CobraImportResolver,
+    HybridModuleSpec,
+    ImportResolutionError,
+)
+
+
+def test_resuelve_modulo_local_antes_que_stdlib_y_bridge(tmp_path):
+    (tmp_path / "datos.co").write_text("usar algo")
+    resolver = CobraImportResolver(project_root=tmp_path)
+
+    result = resolver.resolve("datos")
+
+    assert result.source == "local"
+    assert result.resolved_name == "datos"
+
+
+def test_prefiere_namespace_explicito_cobra_datos():
+    resolver = CobraImportResolver()
+
+    result = resolver.resolve("cobra.datos")
+
+    assert result.source == "stdlib"
+    assert result.import_path == "pcobra.standard_library.datos"
+
+
+def test_ambiguedad_sin_namespace_es_determinista(tmp_path, monkeypatch):
+    resolver = CobraImportResolver(project_root=tmp_path)
+
+    import importlib.util
+
+    original_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name: str):
+        if name == "datos":
+            class DummySpec:
+                loader = object()
+
+            return DummySpec()
+        return original_find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    with pytest.raises(AmbiguousImportError) as exc:
+        resolver.resolve("datos")
+
+    assert "Import ambiguo" in str(exc.value)
+
+
+def test_bridge_python_directo():
+    resolver = CobraImportResolver()
+
+    result = resolver.resolve("json")
+
+    assert result.source == "python_bridge"
+    assert result.import_path == "json"
+
+
+def test_modulo_hibrido_inyecta_adapter_backend(monkeypatch):
+    fake_module = ModuleType("mi_hibrido_runtime")
+
+    import importlib
+
+    original_import_module = importlib.import_module
+
+    def fake_import_module(name: str):
+        if name == "mi_hibrido_runtime":
+            return fake_module
+        return original_import_module(name)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    resolver = CobraImportResolver(
+        hybrid_modules={
+            "mi_hibrido": HybridModuleSpec(
+                module="mi_hibrido",
+                import_path="mi_hibrido_runtime",
+                backend="javascript",
+            )
+        }
+    )
+
+    resolution, module = resolver.load_module("mi_hibrido", fallback_backend="python")
+
+    assert resolution.source == "hybrid"
+    assert module is fake_module
+    assert getattr(module, "__cobra_backend__") == "javascript"
+    assert getattr(module, "__cobra_backend_adapter__").__class__.__name__ == "JavaScriptAdapter"
+
+
+def test_error_si_no_hay_candidato():
+    resolver = CobraImportResolver()
+
+    with pytest.raises(ImportResolutionError):
+        resolver.resolve("__modulo_improbable_no_existente__")


### PR DESCRIPTION
### Motivation
- Implementar un resolvedor de imports que aplique un orden claro de resolución para módulos Cobra y puentes Python. 
- Resolver conflictos de nombres de forma determinista y explicitar cuándo un import no calificado es ambiguo. 
- Permitir la inyección en tiempo de carga del adapter requerido por el backend declarado para módulos híbridos.

### Description
- Se añadió `src/pcobra/cobra/imports/resolver.py` que define `CobraImportResolver`, los tipos `ResolutionResult` y `HybridModuleSpec`, y los errores `ImportResolutionError` y `AmbiguousImportError`.
- El resolvedor aplica la prioridad configurada `local` → `stdlib` (`cobra.*`) → `python_bridge` → `hybrid` y convierte `cobra.<mod>` a `pcobra.standard_library.<mod>` cuando aplica.
- La estrategia de conflictos prioriza nombres explícitos (`cobra.datos`) y lanza `AmbiguousImportError` cuando un import no calificado es ambiguo entre candidatos de igual prioridad.
- Se añadió `load_module(...)` que carga el módulo Python correspondiente y le inyecta `__cobra_backend__` y `__cobra_backend_adapter__` usando `resolve_backend_for_module` y la fábrica `resolve_backend`.
- Se creó `src/pcobra/cobra/imports/__init__.py` para exponer la API pública del resolvedor y se añadieron tests en `tests/unit/test_imports_resolver.py` que cubren casos locales, stdlib, bridge, híbridos e errores.

### Testing
- Ejecutado `pytest -q tests/unit/test_imports_resolver.py` y los tests unitarios nuevos pasaron correctamente (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dddef12fd48327af8573c19cb3c601)