### PR TITLE
Definir contrato de bindings y adoptarlo en execute_cmd

### DIFF
--- a/docs/architecture/binding-contract.md
+++ b/docs/architecture/binding-contract.md
@@ -1,0 +1,58 @@
+# Contrato de bindings Cobra (Python / JavaScript / Rust)
+
+- **Estado:** Aprobado
+- **Fecha:** 2026-04-14
+- **Alcance:** CLI runners (`execute_cmd`) y futuros runners/runtime bridges
+
+## Objetivo
+
+Definir un contrato técnico único para evitar lógica ad-hoc en runners sobre cómo conectar Cobra con cada runtime soportado.
+
+## Rutas oficiales de binding
+
+### 1) Python: import bridge directo
+
+- **Ruta contractual:** `python_direct_import`
+- **Estrategia:** importación directa de módulos Python canónicos desde el proceso de ejecución Cobra.
+- **Frontera de ejecución:** mismo proceso.
+- **Contrato:** API Python estable + typing.
+
+### 2) JavaScript: runtime bridge (proceso/VM controlada)
+
+- **Ruta contractual:** `javascript_runtime_bridge`
+- **Estrategia:** bridge hacia runtime JS dedicado (proceso o VM controlada).
+- **Frontera de ejecución:** aislada respecto al proceso principal.
+- **Contrato:** mensajes/IPC versionados.
+
+### 3) Rust: bindings compilados / FFI con ABI estable
+
+- **Ruta contractual:** `rust_compiled_ffi`
+- **Estrategia:** bindings compilados sobre librería compartida.
+- **Frontera de ejecución:** interfaz nativa FFI.
+- **Contrato:** ABI estable y versionada.
+
+## Módulo técnico
+
+Se establece como fuente de verdad:
+
+- `src/pcobra/cobra/bindings/contract.py`
+
+Este módulo expone:
+
+- `BindingRoute` (enum de rutas),
+- `BindingCapabilities` (tipo estructurado de capacidades),
+- contratos concretos para `python`, `javascript`, `rust`,
+- `resolve_binding(language)` para consumo uniforme desde runners.
+
+## Consumo en runners
+
+- `execute_cmd.py` debe resolver contrato vía `resolve_binding(...)` para runtime Python y ejecución en contenedor.
+- Runners futuros deben consumir este contrato para decidir la ruta técnica sin duplicar reglas.
+
+## Regla de evolución
+
+Si se añade un backend oficial nuevo:
+
+1. actualizar `contract.py`,
+2. documentar la ruta en este documento,
+3. adoptar `resolve_binding(...)` en el runner correspondiente.

--- a/src/pcobra/cobra/bindings/__init__.py
+++ b/src/pcobra/cobra/bindings/__init__.py
@@ -1,0 +1,21 @@
+"""Superficie pública de contrato de bindings Cobra."""
+
+from pcobra.cobra.bindings.contract import (
+    BINDINGS_BY_LANGUAGE,
+    BindingCapabilities,
+    BindingRoute,
+    JAVASCRIPT_BINDING,
+    PYTHON_BINDING,
+    RUST_BINDING,
+    resolve_binding,
+)
+
+__all__ = [
+    "BindingCapabilities",
+    "BindingRoute",
+    "BINDINGS_BY_LANGUAGE",
+    "PYTHON_BINDING",
+    "JAVASCRIPT_BINDING",
+    "RUST_BINDING",
+    "resolve_binding",
+]

--- a/src/pcobra/cobra/bindings/contract.py
+++ b/src/pcobra/cobra/bindings/contract.py
@@ -1,0 +1,85 @@
+"""Contrato técnico de bindings entre Cobra y runtimes externos."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Final
+
+
+class BindingRoute(str, Enum):
+    """Rutas soportadas por el bridge canónico de bindings."""
+
+    PYTHON_DIRECT_IMPORT = "python_direct_import"
+    JAVASCRIPT_RUNTIME_BRIDGE = "javascript_runtime_bridge"
+    RUST_COMPILED_FFI = "rust_compiled_ffi"
+
+
+@dataclass(frozen=True, slots=True)
+class BindingCapabilities:
+    """Describe capacidades y restricciones contractuales por ruta."""
+
+    route: BindingRoute
+    language: str
+    import_strategy: str
+    execution_boundary: str
+    abi_contract: str
+    managed_runtime: bool
+
+
+PYTHON_BINDING: Final[BindingCapabilities] = BindingCapabilities(
+    route=BindingRoute.PYTHON_DIRECT_IMPORT,
+    language="python",
+    import_strategy="Import bridge directo sobre módulos Python canónicos",
+    execution_boundary="Mismo proceso del intérprete Cobra",
+    abi_contract="Contrato Python estable por API pública y typing",
+    managed_runtime=False,
+)
+
+JAVASCRIPT_BINDING: Final[BindingCapabilities] = BindingCapabilities(
+    route=BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE,
+    language="javascript",
+    import_strategy="Bridge de runtime sobre proceso/VM controlada",
+    execution_boundary="Aislado en runtime JS dedicado (proceso o VM)",
+    abi_contract="Contrato de mensajes/IPC versionado",
+    managed_runtime=True,
+)
+
+RUST_BINDING: Final[BindingCapabilities] = BindingCapabilities(
+    route=BindingRoute.RUST_COMPILED_FFI,
+    language="rust",
+    import_strategy="Bindings compilados sobre capa FFI",
+    execution_boundary="Frontera nativa vía librería compartida",
+    abi_contract="ABI estable y versionada",
+    managed_runtime=False,
+)
+
+BINDINGS_BY_LANGUAGE: Final[dict[str, BindingCapabilities]] = {
+    "python": PYTHON_BINDING,
+    "javascript": JAVASCRIPT_BINDING,
+    "rust": RUST_BINDING,
+}
+
+
+def resolve_binding(language: str) -> BindingCapabilities:
+    """Resuelve el contrato de bindings para un lenguaje canónico."""
+
+    key = (language or "").strip().lower()
+    try:
+        return BINDINGS_BY_LANGUAGE[key]
+    except KeyError as exc:
+        raise ValueError(
+            f"No existe contrato de bindings para '{language}'. "
+            f"Lenguajes soportados: {', '.join(sorted(BINDINGS_BY_LANGUAGE))}."
+        ) from exc
+
+
+__all__ = [
+    "BindingCapabilities",
+    "BindingRoute",
+    "BINDINGS_BY_LANGUAGE",
+    "JAVASCRIPT_BINDING",
+    "PYTHON_BINDING",
+    "RUST_BINDING",
+    "resolve_binding",
+]

--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -13,6 +13,7 @@ from pcobra.cobra.cli.utils.validators import (
     validar_archivo_existente,
 )
 from pcobra.cobra.cli.utils.autocomplete import files_completer
+from pcobra.cobra.bindings.contract import resolve_binding
 from pcobra.cobra.cli.target_policies import (
     DOCKER_EXECUTABLE_TARGETS,
     OFFICIAL_RUNTIME_TARGETS_HELP,
@@ -114,6 +115,12 @@ def _obtener_interpretador_cls():
     """Obtiene la clase de intérprete respetando posibles mocks de pruebas."""
 
     return getattr(sys.modules[__name__], "InterpretadorCobra", InterpretadorCobra)
+
+
+def _resolver_contrato_binding(target: str):
+    """Resuelve el contrato de bindings usado por runners CLI."""
+
+    return resolve_binding(target)
 
 
 class ExecuteCommand(BaseCommand):
@@ -243,8 +250,9 @@ class ExecuteCommand(BaseCommand):
 
         try:
             raiz_proyecto = _detectar_raiz_proyecto_desde_archivo(str(archivo_resuelto))
+            contrato_python = _resolver_contrato_binding("python")
             validar_dependencias(
-                "python",
+                contrato_python.language,
                 module_map.get_toml_map(),
                 base_dir=raiz_proyecto,
             )
@@ -341,11 +349,22 @@ class ExecuteCommand(BaseCommand):
     def _ejecutar_en_contenedor(self, codigo: str, contenedor: str) -> int:
         """Ejecuta el código en un contenedor Docker."""
         try:
+            contrato = _resolver_contrato_binding(contenedor)
+            self.logger.debug(
+                "Ruta de bindings para contenedor '%s': %s (%s)",
+                contenedor,
+                contrato.route.value,
+                contrato.execution_boundary,
+            )
+
             backend_runtime = resolve_docker_backend(contenedor)
             salida = ejecutar_en_contenedor(codigo, backend_runtime)
             if salida:
                 mostrar_info(str(salida))
             return 0
+        except ValueError as e:
+            mostrar_error(str(e), registrar_log=False)
+            return 1
         except RuntimeError as e:
             mostrar_error(f"Error ejecutando en contenedor Docker: {e}", registrar_log=False)
             return 1

--- a/tests/unit/test_bindings_contract.py
+++ b/tests/unit/test_bindings_contract.py
@@ -1,0 +1,16 @@
+from pcobra.cobra.bindings.contract import BindingRoute, resolve_binding
+
+
+def test_resolve_binding_define_tres_rutas_contractuales():
+    assert resolve_binding("python").route is BindingRoute.PYTHON_DIRECT_IMPORT
+    assert resolve_binding("javascript").route is BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE
+    assert resolve_binding("rust").route is BindingRoute.RUST_COMPILED_FFI
+
+
+def test_resolve_binding_falla_en_backend_no_soportado():
+    try:
+        resolve_binding("go")
+    except ValueError as exc:
+        assert "Lenguajes soportados" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Se esperaba ValueError para backend no soportado")

--- a/tests/unit/test_execute_cmd_binding_contract.py
+++ b/tests/unit/test_execute_cmd_binding_contract.py
@@ -1,0 +1,23 @@
+from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
+
+
+def test_ejecutar_en_contenedor_resuelve_contrato(monkeypatch):
+    import pcobra.cobra.cli.commands.execute_cmd as execute_module
+
+    llamadas: list[str] = []
+
+    def _resolver(target: str):
+        llamadas.append(target)
+
+        class _Contrato:
+            route = type("R", (), {"value": "javascript_runtime_bridge"})()
+            execution_boundary = "Aislado"
+
+        return _Contrato()
+
+    monkeypatch.setattr(execute_module, "_resolver_contrato_binding", _resolver)
+    monkeypatch.setattr(execute_module, "resolve_docker_backend", lambda value: value)
+    monkeypatch.setattr(execute_module, "ejecutar_en_contenedor", lambda _codigo, _backend: "ok")
+
+    assert ExecuteCommand()._ejecutar_en_contenedor("imprimir(1)", "javascript") == 0
+    assert llamadas == ["javascript"]


### PR DESCRIPTION
### Motivation
- Evitar lógica ad-hoc en runners sobre cómo conectar Cobra con runtimes y centralizar la decisión técnica en un único contrato.  
- Definir explícitamente las 3 rutas oficiales de binding (Python, JavaScript, Rust) con sus capacidades y fronteras de ejecución.  
- Permitir que `execute_cmd` y futuros runners consuman un contrato estable para tomar decisiones (import, IPC, FFI) en lugar de suponer detalles por conveniencia.

### Description
- Se añade la especificación arquitectónica `docs/architecture/binding-contract.md` que documenta las 3 rutas: `python_direct_import`, `javascript_runtime_bridge` y `rust_compiled_ffi`.  
- Se crea `src/pcobra/cobra/bindings/contract.py` que expone `BindingRoute`, `BindingCapabilities`, contratos concretos por lenguaje y la función `resolve_binding(language)` como fuente de verdad.  
- Se añade `src/pcobra/cobra/bindings/__init__.py` para exponer la API pública del módulo de bindings.  
- Se modifica `src/pcobra/cobra/cli/commands/execute_cmd.py` para resolver el contrato vía `resolve_binding(...)` (usado en validación de dependencias y en la ejecución en contenedor) y se introduce el helper `_resolver_contrato_binding` para los runners.  
- Se agregan pruebas unitarias `tests/unit/test_bindings_contract.py` y `tests/unit/test_execute_cmd_binding_contract.py` que verifican la resolución del contrato y su consumo desde `execute_cmd`.

### Testing
- `pytest -q tests/unit/test_bindings_contract.py tests/unit/test_execute_cmd_binding_contract.py` se ejecutó y pasó (3 tests).  
- Se compiló con `python -m compileall` los nuevos módulos y el runner modificado sin errores.  
- Se intentó ejecutar una batería más amplia de tests; algunas fallas aparecieron por resolución de alias legacy (`cobra.*`) en este entorno y no son debidas a los cambios introducidos en este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de1cc71a1c832785b7516372716782)