### PR TITLE
docs: unificar interfaz Cobra y añadir arquitectura y guía de migración

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Versión 10.0.13
 
 [English version available here](docs/README.en.md)
 
+## Cobra como interfaz única
+
+Cobra consolida su experiencia de uso en una **única interfaz pública**: la CLI `cobra`. Todas las tareas de ejecución, build, pruebas y módulos se coordinan desde este frente común, mientras la orquestación interna y los adaptadores de backend permanecen encapsulados.
+
+La superficie pública oficial mantiene tres backends: **Python**, **JavaScript** y **Rust**.
+
 pCobra es un lenguaje de programación escrito en español y pensado para la creación de herramientas, simulaciones y análisis en disciplinas como biología, computación y astrofísica. El proyecto integra un lexer, parser y un sistema de transpilación con una lista canónica de destinos de salida derivada automáticamente de `src/pcobra/cobra/config/transpile_targets.py` + `src/pcobra/cobra/transpilers/registry.py`.
 
 Resumen normativo visible (generado desde la política canónica):
@@ -126,6 +132,8 @@ El objetivo de pCobra es brindar a la comunidad hispanohablante una alternativa 
 
 - Descripción del Proyecto
 - Arquitectura del compilador
+- Ecosistema unificado Cobra
+- Migración a CLI unificada
 - Instalación
 - Cómo usar la CLI
 - Descargas
@@ -214,6 +222,14 @@ La cadena de herramientas de Cobra separa el front-end de los generadores de có
 
 Esta organización actúa como contrato técnico entre el front-end y los generadores de código, permitiendo incorporar mejoras internas sin modificar el parser original. Gracias a ello, Cobra mantiene generadores adicionales para casos internos y legacy. En la documentación pública, la salida oficial queda limitada a `python`, `javascript` y `rust`.
 
+## Ecosistema unificado Cobra
+
+Cobra expone una sola interfaz de entrada (`cobra`) y desacopla internamente la orquestación, los adapters y los runtimes de ejecución. Revisa el diagrama por capas en [docs/architecture/unified-ecosystem.md](docs/architecture/unified-ecosystem.md).
+
+## Migración a CLI unificada
+
+Para migrar desde comandos legacy y usos históricos de `--backend`, consulta [docs/migracion_cli_unificada.md](docs/migracion_cli_unificada.md).
+
 ## Instalación
 
 ```bash
@@ -266,31 +282,41 @@ Este comportamiento solo aplica al arranque de la CLI (`pcobra/cli.py`) y mantie
 
 ## Cómo usar la CLI
 
-Ejecuta un archivo de Cobra con:
+### CLI simplificada (interfaz oficial)
+
+La interfaz recomendada se organiza en cuatro comandos base:
+
+- `cobra run`: ejecutar programas Cobra.
+- `cobra build`: transpilación y artefactos por backend oficial.
+- `cobra test`: ejecución de pruebas del proyecto.
+- `cobra mod`: gestión de módulos y dependencias.
+
+Ejemplos rápidos:
 
 ```bash
-cobra archivo.co
+cobra run archivo.co
+cobra build hola.co --backend python
+cobra test
+cobra mod list
 ```
 
-Para listar las opciones disponibles ejecuta:
+Para listar todas las opciones disponibles:
 
 ```bash
 cobra --help
 ```
 
-El intérprete se ejecuta en modo seguro por defecto. Si deseas desactivarlo utiliza la opción `--no-seguro`:
+Backends oficiales públicos para `cobra build`: `python`, `javascript`, `rust`.
 
-```bash
-cobra archivo.co --no-seguro
-```
+Más detalle técnico de capas y contratos internos en [docs/architecture/unified-ecosystem.md](docs/architecture/unified-ecosystem.md).
 
-### Ejemplo de transpilación
+### Guía de migración a la CLI unificada
 
-```bash
-cobra compilar hola.co --backend python
-```
+Si vienes de comandos legacy (`cobra compilar`, `cobra modulos`) o de flujos centrados en `--backend`, sigue la guía: [docs/migracion_cli_unificada.md](docs/migracion_cli_unificada.md).
 
-Esto generará `hola.py`. Para conocer otros destinos y opciones, consulta la [documentación detallada](docs/) o revisa [docs/frontend](docs/frontend).
+### Compatibilidad legacy
+
+Los proyectos antiguos pueden seguir funcionando con aliases legacy y con el modo de compatibilidad. Recomendamos mantenerlos solo como transición y migrar progresivamente a `run/build/test/mod`.
 
 ### Validar sintaxis (paso a paso)
 

--- a/docs/architecture/unified-ecosystem.md
+++ b/docs/architecture/unified-ecosystem.md
@@ -1,0 +1,44 @@
+# Ecosistema unificado de Cobra
+
+Este documento describe la arquitectura de alto nivel donde **Cobra** es la única interfaz pública de entrada y coordina, de forma interna, la ejecución sobre backends oficiales.
+
+## Diagrama de capas
+
+```text
++-----------------------------------------------------------+
+|                    Frontend Cobra (CLI)                   |
+|        Comandos: cobra run | cobra build | cobra test |   |
+|                          cobra mod                        |
++-------------------------------+---------------------------+
+                                |
+                                v
++-----------------------------------------------------------+
+|                 Orquestador interno de Cobra              |
+|  - Resolución de comandos                                 |
+|  - Pipeline AST/IR                                        |
+|  - Validación y políticas de targets                      |
+|  - Coordinación de ejecución y artefactos                 |
++-------------------------------+---------------------------+
+                                |
+                                v
++-----------------------------------------------------------+
+|                    Adapters de backend                    |
+|          python adapter | javascript adapter | rust       |
++-------------------------------+---------------------------+
+                                |
+                                v
++-----------------------------------------------------------+
+|                    Runtimes / bindings                    |
+|      Python runtime | Node.js runtime | Rust toolchain    |
++-----------------------------------------------------------+
+```
+
+## Contrato público
+
+- **Interfaz pública única:** `cobra`.
+- **Comandos simplificados oficiales:** `run`, `build`, `test`, `mod`.
+- **Backends oficiales públicos:** `python`, `javascript`, `rust`.
+
+## Nota de compatibilidad
+
+Los componentes legacy existen para mantener proyectos antiguos, pero fuera del contrato público principal. La recomendación es migrar gradualmente a la CLI unificada y a los backends oficiales.

--- a/docs/migracion_cli_unificada.md
+++ b/docs/migracion_cli_unificada.md
@@ -1,0 +1,55 @@
+# Guía de migración a la CLI unificada
+
+Esta guía ayuda a migrar desde comandos legacy y flujos dependientes de flags de backend hacia la superficie oficial de Cobra.
+
+## Objetivo
+
+Adoptar el modelo unificado:
+
+- `cobra run`
+- `cobra build`
+- `cobra test`
+- `cobra mod`
+
+Con backends públicos oficiales:
+
+- `python`
+- `javascript`
+- `rust`
+
+## Mapeo de comandos legacy
+
+| Legacy | Nuevo comando recomendado |
+|---|---|
+| `cobra archivo.co` | `cobra run archivo.co` |
+| `cobra compilar archivo.co --backend <target>` | `cobra build archivo.co --backend <target>` |
+| `cobra modulos listar` | `cobra mod list` |
+| `cobra modulos instalar ruta/al/modulo.co` | `cobra mod install ruta/al/modulo.co` |
+| `cobra modulos remover modulo.co` | `cobra mod remove modulo.co` |
+
+## Migración de flags `--backend`
+
+1. Identifica usos de backends no públicos en scripts/CI (`go`, `cpp`, `java`, `wasm`, `asm`).
+2. Sustituye por uno de los oficiales según necesidad:
+   - `python`: máxima cobertura SDK.
+   - `javascript`: integración Node/web.
+   - `rust`: compilación nativa y rendimiento.
+3. Estandariza pipelines para que `build` y validaciones usen exclusivamente `python`, `javascript` o `rust`.
+
+## Plan de migración recomendado (paso a paso)
+
+1. **Inventario**: lista comandos legacy usados en repositorio y CI.
+2. **Sustitución**: aplica mapeo a `run/build/test/mod`.
+3. **Backends**: elimina targets no públicos en flags `--backend`.
+4. **Validación**: ejecuta pruebas/regresión del proyecto.
+5. **Limpieza**: documenta fecha de retiro interno de aliases legacy.
+
+## Compatibilidad legacy (proyectos antiguos)
+
+Para evitar bloqueos en proyectos históricos:
+
+- Mantén temporalmente aliases legacy en scripts críticos.
+- Conserva solo el mínimo de rutas legacy mientras se completa la migración.
+- Define una fecha de corte para remover comandos/flags antiguos.
+
+La compatibilidad legacy debe tratarse como **transición controlada**, no como interfaz principal.


### PR DESCRIPTION
### Motivation
- Aclarar que la superficie pública del proyecto es una única CLI `cobra` y reducir la dispersión de comandos legacy y flags por backend. 
- Facilitar la migración de usuarios y CI desde comandos y targets legacy hacia un conjunto oficial y mantenible de backends (`python`, `javascript`, `rust`).
- Proveer documentación técnica de alto nivel sobre la arquitectura por capas para apoyar decisiones de integración y mantenimiento.

### Description
- Actualiza `README.md` para introducir la sección `Cobra como interfaz única`, reforzar la CLI simplificada y añadir referencias a la arquitectura y migración; los comandos recomendados son `cobra run`, `cobra build`, `cobra test` y `cobra mod`.
- Declara explícitamente los backends oficiales públicos soportados por la superficie pública: `python`, `javascript` y `rust`.
- Añade `docs/architecture/unified-ecosystem.md` con un diagrama por capas (Frontend Cobra, Orquestador interno, Adapters backend, Runtimes/bindings) y el contrato público asociado.
- Añade `docs/migracion_cli_unificada.md` con mapeo de comandos legacy a los nuevos comandos, recomendaciones para sustituir `--backend` legacy y un plan de migración paso a paso, y mantiene orientación sobre compatibilidad legacy transitoria.

### Testing
- Ejecuté `git diff --check` y no reportó errores (éxito).
- Intenté ejecutar `markdownlint README.md docs/architecture/unified-ecosystem.md docs/migracion_cli_unificada.md` pero la herramienta no está disponible en el entorno (`markdownlint: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4dd6e4748327a903b5f6bf79cc1c)