### PR TITLE
Separar registro de transpiladores en público y legacy interno

### DIFF
--- a/src/pcobra/cobra/transpilers/registry.py
+++ b/src/pcobra/cobra/transpilers/registry.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Final
 
-from pcobra.cobra.architecture.backend_policy import ALL_BACKENDS
+from pcobra.cobra.architecture.backend_policy import (
+    ALL_BACKENDS,
+    INTERNAL_BACKENDS,
+    PUBLIC_BACKENDS,
+)
 
 TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
     "python": ("pcobra.cobra.transpilers.transpiler.to_python", "TranspiladorPython"),
@@ -19,15 +23,24 @@ TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
 }
 
 
-def _validate_registry_contract() -> tuple[str, ...]:
-    """Valida que el registro mantenga backends públicos e internos legacy."""
+PUBLIC_TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
+    target: TRANSPILER_CLASS_PATHS[target] for target in PUBLIC_BACKENDS
+}
+
+INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
+    target: TRANSPILER_CLASS_PATHS[target] for target in INTERNAL_BACKENDS
+}
+
+
+def _validate_complete_registry_contract() -> tuple[str, ...]:
+    """Valida que el inventario completo preserve el contrato total de backends."""
     configured_keys = tuple(TRANSPILER_CLASS_PATHS)
     missing = tuple(target for target in ALL_BACKENDS if target not in configured_keys)
     extras = tuple(target for target in configured_keys if target not in ALL_BACKENDS)
 
     if missing or extras:
         raise RuntimeError(
-            "[CI CONTRACT] TRANSPILER_CLASS_PATHS tiene claves fuera de contrato y debe usar exactamente los backends declarados en la política de arquitectura. "
+            "[CI CONTRACT] TRANSPILER_CLASS_PATHS tiene claves fuera de contrato y debe usar exactamente ALL_BACKENDS. "
             f"missing={missing or '∅'}; extras={extras or '∅'}; "
             f"current={configured_keys}; expected={ALL_BACKENDS}"
         )
@@ -47,16 +60,77 @@ def _validate_registry_contract() -> tuple[str, ...]:
     return configured_keys
 
 
-_ORDERED_OFFICIAL_TARGETS: Final[tuple[str, ...]] = _validate_registry_contract()
+def _validate_public_registry_contract() -> tuple[str, ...]:
+    """Valida contrato estricto del registro público frente a PUBLIC_BACKENDS."""
+    configured_keys = tuple(PUBLIC_TRANSPILER_CLASS_PATHS)
+    missing = tuple(target for target in PUBLIC_BACKENDS if target not in configured_keys)
+    extras = tuple(target for target in configured_keys if target not in PUBLIC_BACKENDS)
+
+    if missing or extras:
+        raise RuntimeError(
+            "[CI CONTRACT] PUBLIC_TRANSPILER_CLASS_PATHS debe usar exactamente PUBLIC_BACKENDS. "
+            f"missing={missing or '∅'}; extras={extras or '∅'}; "
+            f"current={configured_keys}; expected={PUBLIC_BACKENDS}"
+        )
+
+    if configured_keys != PUBLIC_BACKENDS:
+        raise RuntimeError(
+            "[CI CONTRACT] PUBLIC_TRANSPILER_CLASS_PATHS debe preservar el orden de backend_policy.PUBLIC_BACKENDS. "
+            f"current={configured_keys}; expected={PUBLIC_BACKENDS}"
+        )
+    return configured_keys
+
+
+def _validate_internal_legacy_registry_contract() -> tuple[str, ...]:
+    """Valida inventario separado para backends legacy internos."""
+    configured_keys = tuple(INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS)
+    missing = tuple(
+        target for target in INTERNAL_BACKENDS if target not in configured_keys
+    )
+    extras = tuple(
+        target for target in configured_keys if target not in INTERNAL_BACKENDS
+    )
+
+    if missing or extras:
+        raise RuntimeError(
+            "[CI CONTRACT] INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS debe usar exactamente INTERNAL_BACKENDS. "
+            f"missing={missing or '∅'}; extras={extras or '∅'}; "
+            f"current={configured_keys}; expected={INTERNAL_BACKENDS}"
+        )
+
+    if configured_keys != INTERNAL_BACKENDS:
+        raise RuntimeError(
+            "[CI CONTRACT] INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS debe preservar el orden de backend_policy.INTERNAL_BACKENDS. "
+            f"current={configured_keys}; expected={INTERNAL_BACKENDS}"
+        )
+    return configured_keys
+
+
+_ORDERED_ALL_TARGETS: Final[tuple[str, ...]] = _validate_complete_registry_contract()
+_ORDERED_OFFICIAL_TARGETS: Final[tuple[str, ...]] = _validate_public_registry_contract()
+_ORDERED_INTERNAL_LEGACY_TARGETS: Final[tuple[str, ...]] = (
+    _validate_internal_legacy_registry_contract()
+)
 
 
 def ordered_official_transpiler_paths() -> tuple[tuple[str, tuple[str, str]], ...]:
-    """Devuelve el registro canónico en el orden de ``OFFICIAL_TARGETS``."""
-    return tuple((target, TRANSPILER_CLASS_PATHS[target]) for target in _ORDERED_OFFICIAL_TARGETS)
+    """Devuelve el registro público en el orden de ``PUBLIC_BACKENDS``."""
+    return tuple(
+        (target, PUBLIC_TRANSPILER_CLASS_PATHS[target])
+        for target in _ORDERED_OFFICIAL_TARGETS
+    )
+
+
+def ordered_internal_legacy_transpiler_paths() -> tuple[tuple[str, tuple[str, str]], ...]:
+    """Devuelve el inventario legacy interno en orden contractual."""
+    return tuple(
+        (target, INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS[target])
+        for target in _ORDERED_INTERNAL_LEGACY_TARGETS
+    )
 
 
 def build_official_transpilers() -> dict[str, type]:
-    """Carga las clases oficiales desde el registro canónico."""
+    """Carga las clases públicas oficiales desde el registro público."""
     registry: dict[str, type] = {}
     for target, (module_name, class_name) in ordered_official_transpiler_paths():
         module = import_module(module_name)
@@ -64,8 +138,17 @@ def build_official_transpilers() -> dict[str, type]:
     return registry
 
 
+def build_internal_legacy_transpilers() -> dict[str, type]:
+    """Carga las clases legacy internas para procesos de migración interna."""
+    registry: dict[str, type] = {}
+    for target, (module_name, class_name) in ordered_internal_legacy_transpiler_paths():
+        module = import_module(module_name)
+        registry[target] = getattr(module, class_name)
+    return registry
+
+
 def official_transpiler_targets() -> tuple[str, ...]:
-    """Devuelve los targets del registro canónico en el orden contractual."""
+    """Devuelve los targets del registro público en el orden contractual."""
     return _ORDERED_OFFICIAL_TARGETS
 
 

--- a/tests/unit/test_registry_contract_guardrail.py
+++ b/tests/unit/test_registry_contract_guardrail.py
@@ -33,4 +33,36 @@ def test_validate_registry_contract_falla_si_el_registro_sale_de_la_matriz_ofici
     monkeypatch.setattr(registry, "TRANSPILER_CLASS_PATHS", patched_registry)
 
     with pytest.raises(RuntimeError, match=expected_fragment):
-        registry._validate_registry_contract()
+        registry._validate_complete_registry_contract()
+
+
+def test_validate_public_registry_contract_falla_con_clave_extra(monkeypatch):
+    monkeypatch.setattr(
+        registry,
+        "PUBLIC_TRANSPILER_CLASS_PATHS",
+        {
+            **registry.PUBLIC_TRANSPILER_CLASS_PATHS,
+            "asm": ("pcobra.cobra.transpilers.transpiler.to_asm", "TranspiladorASM"),
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="PUBLIC_TRANSPILER_CLASS_PATHS"):
+        registry._validate_public_registry_contract()
+
+
+def test_validate_internal_legacy_registry_contract_falla_si_falta_backend(monkeypatch):
+    monkeypatch.setattr(
+        registry,
+        "INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS",
+        {
+            key: value
+            for key, value in registry.INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS.items()
+            if key != "asm"
+        },
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS",
+    ):
+        registry._validate_internal_legacy_registry_contract()


### PR DESCRIPTION
### Motivation
- Diferenciar la superficie pública usada por CLI/SDK del inventario legacy interno para permitir un contrato estricto por público y otro separado para migraciones internas.

### Description
- Mantener `TRANSPILER_CLASS_PATHS` como inventario completo y derivar dos vistas explícitas: `PUBLIC_TRANSPILER_CLASS_PATHS` y `INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS` en `src/pcobra/cobra/transpilers/registry.py`.
- Reemplazar la validación única por tres validadores: `_validate_complete_registry_contract()`, `_validate_public_registry_contract()` y `_validate_internal_legacy_registry_contract()` para chequear `ALL_BACKENDS`, `PUBLIC_BACKENDS` e `INTERNAL_BACKENDS` respectivamente.
- Conservar `build_official_transpilers()` para cargar solo el registro público y añadir `build_internal_legacy_transpilers()` para cargas internas/legacy.
- Actualizar pruebas para usar las nuevas validaciones y añadir casos que validan contratos público e interno en `tests/unit/test_registry_contract_guardrail.py`.
- Confirmar que la CLI por defecto sigue consumiendo `build_official_transpilers()` y `official_transpiler_targets()` (pública) sin exponer el inventario legacy.

### Testing
- Ejecuté `pytest -q tests/unit/test_registry_contract_guardrail.py` y todos los tests en ese archivo pasaron correctamente.
- Ejecuté un chequeo interactivo con `python - <<'PY' ...` que imprimió los targets públicos e internos esperados (`python, javascript, rust` y `go, cpp, java, wasm, asm`).
- Un intento previo de ejecutar `pytest -q tests/unit/test_registry_contract_guardrail.py tests/unit/test_official_targets_consistency.py` falló en la fase de colección por una aserción preexistente en `tests/utils/targets.py` no relacionada con los cambios presentados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7197f2008327bffa53933ef3ad6e)