### PR TITLE
feat(cli): aplicar política de exposición pública en UI v2

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -56,6 +56,12 @@ from pcobra.cobra.cli.mode_policy import (
     MODO_POR_DEFECTO,
     validar_politica_modo,
 )
+from pcobra.cobra.cli.public_command_policy import (
+    PROFILE_DEVELOPMENT,
+    PROFILE_PUBLIC,
+    filter_commands_for_profile,
+    resolve_command_profile,
+)
 from pcobra.cobra.cli.plugin import (
     descubrir_plugins,
     configure_plugin_policy,
@@ -131,7 +137,13 @@ class CommandRegistry:
             logging.error(f"Error creating command {command_class.__name__}: {e}")
             raise
 
-    def register_base_commands(self, subparsers: Any, *, ui: str = "v1") -> Dict[str, BaseCommand]:
+    def register_base_commands(
+        self,
+        subparsers: Any,
+        *,
+        ui: str = "v1",
+        profile: str = PROFILE_PUBLIC,
+    ) -> Dict[str, BaseCommand]:
         base_commands = []
         command_classes = AppConfig.V2_COMMAND_CLASSES if ui == "v2" else AppConfig.BASE_COMMAND_CLASSES
         for cmd_class in command_classes:
@@ -143,6 +155,20 @@ class CommandRegistry:
 
         plugin_commands = descubrir_plugins()
         all_commands = base_commands + plugin_commands
+
+        if ui == "v2":
+            allowed_names = filter_commands_for_profile((cmd.name for cmd in all_commands), profile)
+            all_commands = [cmd for cmd in all_commands if cmd.name in allowed_names]
+            if profile == PROFILE_PUBLIC:
+                logging.getLogger(__name__).debug(
+                    "Perfil público activo: comandos expuestos=%s",
+                    sorted(allowed_names),
+                )
+            elif profile == PROFILE_DEVELOPMENT:
+                logging.getLogger(__name__).debug(
+                    "Perfil desarrollo activo: comandos internos habilitados."
+                )
+
         self.commands = {cmd.name: cmd for cmd in all_commands}
 
         for command in all_commands:
@@ -218,9 +244,11 @@ class CliApplication:
         if self._commands_registered:
             return
 
+        command_profile = resolve_command_profile()
         self.command_registry.register_base_commands(
             self._subparsers,
             ui=getattr(self, "_selected_ui", "v1"),
+            profile=command_profile,
         )
         menu_parser = self._subparsers.add_parser("menu", help=_("Modo interactivo"))
         menu_parser.set_defaults(cmd="menu")
@@ -341,7 +369,11 @@ class CliApplication:
             "--ui",
             choices=("v1", "v2"),
             default="v1",
-            help=_("Selecciona la interfaz CLI: v1 (legacy) o v2 (opt-in)."),
+            help=_(
+                "Selecciona la interfaz CLI: v1 (legacy) o v2 (superficie pública run/build/test/mod). "
+                "Los comandos internos quedan disponibles solo en desarrollo explícito (COBRA_DEV_MODE=1 "
+                "o COBRA_CLI_COMMAND_PROFILE=development)."
+            ),
         )
         parser.add_argument("--lang",
                           default=environ.get("COBRA_LANG", AppConfig.DEFAULT_LANGUAGE),

--- a/src/pcobra/cobra/cli/public_command_policy.py
+++ b/src/pcobra/cobra/cli/public_command_policy.py
@@ -1,0 +1,60 @@
+"""Política de exposición de comandos CLI según perfil de visibilidad."""
+
+from __future__ import annotations
+
+from os import environ
+from typing import Iterable
+
+PUBLIC_COMMANDS: tuple[str, ...] = ("run", "build", "test", "mod")
+INTERNAL_COMMANDS: tuple[str, ...] = (
+    "legacy",
+    "debug",
+    "devops",
+)
+
+PROFILE_PUBLIC = "public"
+PROFILE_DEVELOPMENT = "development"
+COMMAND_PROFILES: tuple[str, ...] = (PROFILE_PUBLIC, PROFILE_DEVELOPMENT)
+
+
+def resolve_command_profile(default: str = PROFILE_PUBLIC) -> str:
+    """Resuelve el perfil de exposición desde entorno.
+
+    Prioridad:
+    1) COBRA_CLI_COMMAND_PROFILE con valores explícitos (public/development).
+    2) COBRA_DEV_MODE=1 fuerza `development` para sesiones internas.
+    3) `default` como fallback seguro.
+    """
+
+    profile = (environ.get("COBRA_CLI_COMMAND_PROFILE") or "").strip().lower()
+    if profile in COMMAND_PROFILES:
+        return profile
+
+    if (environ.get("COBRA_DEV_MODE") or "").strip() == "1":
+        return PROFILE_DEVELOPMENT
+
+    return default
+
+
+def filter_commands_for_profile(command_names: Iterable[str], profile: str) -> set[str]:
+    """Devuelve el subconjunto de comandos visibles para `profile`."""
+
+    normalized_profile = str(profile).strip().lower() or PROFILE_PUBLIC
+    names = {name.strip().lower() for name in command_names}
+
+    if normalized_profile == PROFILE_DEVELOPMENT:
+        return names
+
+    allowed = set(PUBLIC_COMMANDS)
+    return names.intersection(allowed)
+
+
+__all__ = [
+    "PUBLIC_COMMANDS",
+    "INTERNAL_COMMANDS",
+    "PROFILE_PUBLIC",
+    "PROFILE_DEVELOPMENT",
+    "COMMAND_PROFILES",
+    "resolve_command_profile",
+    "filter_commands_for_profile",
+]

--- a/tests/integration/golden/cli_help_public_no_legacy.golden
+++ b/tests/integration/golden/cli_help_public_no_legacy.golden
@@ -31,7 +31,7 @@ options:
                         (solo generar código), mixto (ejecutar y transpilar).
   --solo-cobra          Alias semántico de --modo cobra: sesión para solo
                         programar/interpretar Cobra sin rutas de codegen.
-  --ui {v1,v2}          Selecciona la interfaz CLI: v1 (legacy) o v2 (opt-in).
+  --ui {v1,v2}          Selecciona la interfaz CLI: v1 (legacy) o v2 (superficie pública run/build/test/mod). Los comandos internos quedan disponibles solo en desarrollo explícito (COBRA_DEV_MODE=1 o COBRA_CLI_COMMAND_PROFILE=development).
   --lang LANG           Interface language code
   --no-color            Disable colored output
   --extra-validators EXTRA_VALIDATORS

--- a/tests/integration/golden/cli_ui_v2_help_public.golden
+++ b/tests/integration/golden/cli_ui_v2_help_public.golden
@@ -31,7 +31,7 @@ options:
                         (solo generar código), mixto (ejecutar y transpilar).
   --solo-cobra          alias semántico de --modo cobra: sesión para solo
                         programar/interpretar cobra sin rutas de codegen.
-  --ui {v1,v2}          selecciona la interfaz cli: v1 (legacy) o v2 (opt-in).
+  --ui {v1,v2}          selecciona la interfaz cli: v1 (legacy) o v2 (superficie pública run/build/test/mod). los comandos internos quedan disponibles solo en desarrollo explícito (cobra_dev_mode=1 o cobra_cli_command_profile=development).
   --lang lang           interface language code
   --no-color            disable colored output
   --extra-validators extra_validators

--- a/tests/integration/test_cli_ui_v2.py
+++ b/tests/integration/test_cli_ui_v2.py
@@ -45,7 +45,7 @@ def test_cli_ui_v2_help_muestra_legacy_solo_con_flag_interno(monkeypatch):
     registry = cli_reloaded.CommandRegistry()
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command")
-    commands = registry.register_base_commands(subparsers, ui="v2")
+    commands = registry.register_base_commands(subparsers, ui="v2", profile="development")
     assert "legacy" in commands
 
 
@@ -64,3 +64,27 @@ def test_cli_ui_v2_sin_flag_no_registra_legacy(monkeypatch):
     subparsers = parser.add_subparsers(dest="command")
     commands = registry.register_base_commands(subparsers, ui="v2")
     assert "legacy" not in commands
+
+
+def test_cli_ui_v2_modo_desarrollo_expone_comandos_internos(monkeypatch):
+    monkeypatch.setenv("COBRA_ENABLE_LEGACY_CLI", "1")
+    monkeypatch.setenv("COBRA_DEV_MODE", "1")
+    for module_name in (
+        "cobra.cli.commands_v2",
+        "pcobra.cobra.cli.commands_v2",
+        "cobra.cli.cli",
+        "pcobra.cobra.cli.cli",
+    ):
+        sys.modules.pop(module_name, None)
+    import cobra.cli.cli as cli_reloaded
+
+    registry = cli_reloaded.CommandRegistry()
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    commands = registry.register_base_commands(
+        subparsers,
+        ui="v2",
+        profile=cli_reloaded.resolve_command_profile(),
+    )
+
+    assert "legacy" in commands


### PR DESCRIPTION
### Motivation
- Limitar la superficie pública de la CLI en la interfaz `v2` a un conjunto curado de comandos (`run`, `build`, `test`, `mod`) y mantener comandos internos/legacy ocultos salvo que se active explícitamente un modo de desarrollo.

### Description
- Añadido `src/pcobra/cobra/cli/public_command_policy.py` con la lista `PUBLIC_COMMANDS`, perfiles `public`/`development`, y las funciones `resolve_command_profile()` y `filter_commands_for_profile()`.
- Modificada la firma de `CommandRegistry.register_base_commands` para aceptar `profile` y aplicarse el filtrado de comandos cuando `ui == "v2"` usando `filter_commands_for_profile`.
- Integrado `resolve_command_profile()` en `CliApplication._ensure_command_structure()` para resolver el perfil desde entorno (`COBRA_CLI_COMMAND_PROFILE` o `COBRA_DEV_MODE=1`) y pasar `profile` al registro de comandos.
- Actualizado el texto de ayuda de la opción `--ui` y los snapshots de ayuda, y añadida una prueba de integración que verifica que los comandos internos aparecen solo en modo desarrollo (`tests/integration/test_cli_ui_v2.py`).

### Testing
- Ejecutado `pytest -q tests/integration/test_cli_ui_v2.py tests/integration/test_cli_ayuda.py tests/unit/test_command_registry_interactive.py` y el resultado fue `12 passed, 1 skipped`.
- Verificados y actualizados los snapshots en `tests/integration/golden/cli_help_public_no_legacy.golden` y `tests/integration/golden/cli_ui_v2_help_public.golden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de81b4d8248327ac224062752ed3f0)