### PR TITLE
Añadir backend_pipeline y unificar resolución/transpilación en comandos CLI

### DIFF
--- a/src/pcobra/cobra/build/__init__.py
+++ b/src/pcobra/cobra/build/__init__.py
@@ -1,5 +1,6 @@
 """Build orchestration utilities."""
 
+from pcobra.cobra.build.backend_pipeline import build, resolve_backend, transpile
 from pcobra.cobra.build.orchestrator import BackendResolution, BuildOrchestrator
 
-__all__ = ["BackendResolution", "BuildOrchestrator"]
+__all__ = ["BackendResolution", "BuildOrchestrator", "build", "resolve_backend", "transpile"]

--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -1,0 +1,69 @@
+"""Façade interna para resolución de backend y transpilación."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pcobra.cobra.build.orchestrator import BackendResolution, BuildOrchestrator
+from pcobra.cobra.transpilers.registry import build_official_transpilers
+from pcobra.core.ast_cache import obtener_ast
+
+ORCHESTRATOR = BuildOrchestrator()
+TRANSPILERS: dict[str, type] = build_official_transpilers()
+
+
+def resolve_backend(source: str, hints: dict[str, Any] | None = None) -> BackendResolution:
+    """Resuelve backend canónico a partir de un source file y pistas opcionales."""
+    context = hints or {}
+    preferred_backend = context.get("preferred_backend")
+    required_capabilities = tuple(context.get("required_capabilities", ()))
+    return ORCHESTRATOR.resolve_backend(
+        source_file=source,
+        preferred_backend=preferred_backend,
+        required_capabilities=required_capabilities,
+    )
+
+
+def transpile(ast: Any, backend: str) -> str:
+    """Transpila un AST al backend indicado usando el registro oficial."""
+    if backend not in TRANSPILERS:
+        raise ValueError(f"Transpilador no soportado: {backend}")
+    transpiler = TRANSPILERS[backend]()
+    return transpiler.generate_code(ast)
+
+
+def build(source: str, mode: dict[str, Any] | str | None = None) -> dict[str, Any]:
+    """Pipeline completo: resolver backend, construir AST y transpilar código."""
+    hints: dict[str, Any]
+    if isinstance(mode, dict):
+        hints = dict(mode)
+    else:
+        hints = {"preferred_backend": mode} if mode else {}
+
+    source_path = Path(source)
+    if source_path.exists() and source_path.is_file():
+        source_file = str(source_path)
+        codigo = source_path.read_text(encoding="utf-8")
+    else:
+        source_file = str(hints.get("source_file", "<memory>"))
+        codigo = source
+
+    resolution = resolve_backend(source_file, hints)
+    ast = obtener_ast(codigo)
+    code = transpile(ast, resolution.backend)
+    return {
+        "backend": resolution.backend,
+        "reason": resolution.reason,
+        "ast": ast,
+        "code": code,
+    }
+
+
+__all__ = [
+    "ORCHESTRATOR",
+    "TRANSPILERS",
+    "build",
+    "resolve_backend",
+    "transpile",
+]

--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -6,17 +6,14 @@ from argparse import ArgumentTypeError
 from importlib import import_module
 from importlib.metadata import entry_points
 
-from pcobra.cobra.build.orchestrator import BuildOrchestrator
+from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.transpilers import module_map
 from pcobra.cobra.cli.target_policies import (
     OFFICIAL_TRANSPILATION_TARGETS,
     parse_target,
     parse_target_list,
 )
-from pcobra.cobra.transpilers.registry import (
-    build_official_transpilers,
-    official_transpiler_targets,
-)
+from pcobra.cobra.transpilers.registry import official_transpiler_targets
 from pcobra.cobra.transpilers.target_utils import (
     build_target_help_by_tier,
     resolution_candidates,
@@ -47,9 +44,9 @@ MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
 PROCESS_TIMEOUT = tiempo_max_transpilacion()
 MAX_LANGUAGES = 10
 
-TRANSPILERS = build_official_transpilers()
+TRANSPILERS = dict(backend_pipeline.TRANSPILERS)
 _ENTRYPOINTS_LOADED = False
-ORCHESTRATOR = BuildOrchestrator()
+ORCHESTRATOR = backend_pipeline.ORCHESTRATOR
 
 
 def register_transpiler_backend(backend: str, transpiler_cls, *, context: str) -> str:
@@ -73,6 +70,7 @@ def register_transpiler_backend(backend: str, transpiler_cls, *, context: str) -
         context=context,
     )
     TRANSPILERS[canonical] = transpiler_cls
+    backend_pipeline.TRANSPILERS = TRANSPILERS
     return canonical
 
 
@@ -348,8 +346,10 @@ class CompileCommand(BaseCommand):
     def _ejecutar_transpilador(self, parametros: tuple) -> tuple:
         """Ejecuta un transpilador específico."""
         lang, ast = parametros
+        backend_pipeline.TRANSPILERS = TRANSPILERS
+        code = backend_pipeline.transpile(ast, lang)
         transp = TRANSPILERS[lang]()
-        return lang, transp.__class__.__name__, transp.generate_code(ast)
+        return lang, transp.__class__.__name__, code
 
     def run(self, args):
         """Ejecuta la lógica del comando."""
@@ -384,9 +384,10 @@ class CompileCommand(BaseCommand):
                 _("La opción --backend está deprecada en 'compilar'; use --tipo. Se eliminará en una versión futura.")
             )
         try:
-            resolution = ORCHESTRATOR.resolve_backend(
-                source_file=archivo,
-                preferred_backend=preferred_backend,
+            backend_pipeline.TRANSPILERS = TRANSPILERS
+            resolution = backend_pipeline.resolve_backend(
+                archivo,
+                {"preferred_backend": preferred_backend},
             )
             transpilador_objetivo = _validate_official_backend_or_raise(
                 resolution.backend,
@@ -453,8 +454,9 @@ class CompileCommand(BaseCommand):
                 transpilador = transpilador_objetivo
                 if transpilador not in TRANSPILERS:
                     raise ValueError(_("Transpilador no soportado."))
+                backend_pipeline.TRANSPILERS = TRANSPILERS
+                resultado = backend_pipeline.transpile(ast, transpilador)
                 transp = TRANSPILERS[transpilador]()
-                resultado = transp.generate_code(ast)
                 mostrar_info(
                     _("Código generado ({name}):").format(
                         name=transp.__class__.__name__

--- a/src/pcobra/cobra/cli/commands/verify_cmd.py
+++ b/src/pcobra/cobra/cli/commands/verify_cmd.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
 from argparse import ArgumentParser
 
-from pcobra.cobra.cli.commands.compile_cmd import TRANSPILERS
+from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.target_policies import (
     OFFICIAL_TRANSPILATION_TARGETS,
     OFFICIAL_TRANSPILATION_TARGETS_HELP,
@@ -166,24 +166,22 @@ class VerifyCommand(BaseCommand):
     def _compile_and_execute(
         self, 
         ast: Any, 
-        lang: str, 
-        transpiler: Any
+        lang: str
     ) -> Tuple[Optional[str], Optional[str]]:
         """Compila y ejecuta el código en el lenguaje especificado.
         
         Args:
             ast: AST a compilar
             lang: Lenguaje objetivo
-            transpiler: Transpilador a utilizar
             
         Returns:
             Tupla con (salida, error)
         """
         try:
-            if lang not in TRANSPILERS:
+            if lang not in backend_pipeline.TRANSPILERS:
                 return None, _("Transpilador no encontrado para {}").format(lang)
-                
-            codigo_gen = transpiler.generate_code(ast)
+
+            codigo_gen = backend_pipeline.transpile(ast, lang)
             
             if lang == "python":
                 salida = ejecutar_en_sandbox(codigo_gen)
@@ -217,8 +215,7 @@ class VerifyCommand(BaseCommand):
         Returns:
             Tupla con (lenguaje, error si existe)
         """
-        transpiler = TRANSPILERS[lang]()
-        salida, error = self._compile_and_execute(ast, lang, transpiler)
+        salida, error = self._compile_and_execute(ast, lang)
         
         if error:
             return lang, error

--- a/src/pcobra/cobra/cli/commands_v2/build_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/build_cmd.py
@@ -2,7 +2,7 @@ from argparse import Namespace
 from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
-from pcobra.cobra.build.orchestrator import BuildOrchestrator
+from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.commands.compile_cmd import CompileCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.autocomplete import files_completer
@@ -17,7 +17,6 @@ class BuildCommandV2(BaseCommand):
     def __init__(self) -> None:
         super().__init__()
         self._legacy = CompileCommand()
-        self._orchestrator = BuildOrchestrator()
 
     def register_subparser(self, subparsers: Any):
         parser = subparsers.add_parser(self.name, help=_("Build/transpile a Cobra file"))
@@ -26,7 +25,7 @@ class BuildCommandV2(BaseCommand):
         return parser
 
     def run(self, args: Any) -> int:
-        resolution = self._orchestrator.resolve_backend(source_file=args.file)
+        resolution = backend_pipeline.resolve_backend(args.file, {})
         legacy_args = Namespace(
             archivo=args.file,
             tipo=resolution.backend,


### PR DESCRIPTION
### Motivation
- Centralizar la resolución de backend y la generación de código en una façade interna para evitar lógica duplicada en los comandos CLI. 
- Reutilizar `BuildOrchestrator` y el registro oficial de transpilers (`build_official_transpilers()`) como fuente única de verdad para backends y transpiladores. 
- Mantener intactas las interfaces públicas de los comandos (`compilar`, `build`, `verificar`) para no romper compatibilidad.

### Description
- Se añade el módulo `src/pcobra/cobra/build/backend_pipeline.py` con la API interna `resolve_backend(source, hints)`, `transpile(ast, backend)` y `build(source, mode)`, usando internamente `BuildOrchestrator` y `build_official_transpilers()`.
- Se exportan `build`, `resolve_backend` y `transpile` desde `src/pcobra/cobra/build/__init__.py` para consumo interno del paquete `pcobra.cobra.build`.
- Se migra `src/pcobra/cobra/cli/commands/compile_cmd.py` para delegar en la façade al resolver backends y generar código, manteniendo la semántica actual de flags (`--tipo`, `--backend`, `--tipos`) y preservando el mecanismo de entry points/plugins; además se sincroniza el mapa mutable `TRANSPILERS` con la façade para soportar tests que hacen `monkeypatch`.
- Se actualiza `src/pcobra/cobra/cli/commands_v2/build_cmd.py` para usar `backend_pipeline.resolve_backend(...)` y seguir delegando en el comando legacy sin cambiar la UX.
- Se adapta `src/pcobra/cobra/cli/commands/verify_cmd.py` para usar `backend_pipeline.transpile(...)` y `backend_pipeline.TRANSPILERS` para centralizar la generación de código.

### Testing
- Ejecuté `pytest -q tests/unit/test_compile_backend_registration.py tests/unit/test_run_transpiler_pool.py` y todos los tests de ese conjunto pasaron (`18 passed`).
- Ejecuté una batería ampliada de tests CLI/compile que incluyó `tests/unit/test_compile_cmd_errors.py`, `tests/unit/test_cli_compile_parallel.py`, `tests/unit/test_cli_target_aliases.py`, entre otros, y se observaron fallos relacionados con políticas/targets del entorno (`5 failed` y un `AssertionError` en colección en una ejecución), los cuales parecen corresponder a expectativas de lista de targets/política y no a la lógica de la fachada en sí.
- Las modificaciones preservan la superficie pública de los comandos y la compatibilidad con los tests que parchean `TRANSPILERS`; recomendar ejecutar la suite completa en CI para validar políticas de targets en el entorno de integración.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de86e5d41c8327b27cf6d690ad6bc4)