### PR TITLE
Crear contrato declarativo para módulos stdlib y docs autogeneradas

### DIFF
--- a/docs/_generated/stdlib_contract_matrix.md
+++ b/docs/_generated/stdlib_contract_matrix.md
@@ -1,0 +1,106 @@
+# Contrato de stdlib Cobra (autogenerado)
+
+Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
+
+## `cobra.core`
+
+- **Backend primario:** `python`
+- **Fallback permitido:** `rust, javascript`
+- **Mapeo `standard_library`:** `src/pcobra/standard_library/util.py`
+- **Mapeo `corelibs`:** `src/pcobra/corelibs/numero.py`
+- **Mapeo `core/nativos`:** `src/pcobra/core/nativos/numero.js`
+
+### API pública
+
+- `cobra.core.lex`
+- `cobra.core.parse`
+- `cobra.core.ast`
+
+### Cobertura por función
+
+| Función | Backend | Nivel |
+|---|---|---|
+| `cobra.core.lex` | `python` | `full` |
+| `cobra.core.lex` | `rust` | `partial` |
+| `cobra.core.lex` | `javascript` | `full` |
+| `cobra.core.parse` | `python` | `full` |
+| `cobra.core.parse` | `rust` | `partial` |
+| `cobra.core.parse` | `javascript` | `partial` |
+| `cobra.core.ast` | `python` | `full` |
+| `cobra.core.ast` | `rust` | `partial` |
+| `cobra.core.ast` | `javascript` | `partial` |
+
+## `cobra.datos`
+
+- **Backend primario:** `python`
+- **Fallback permitido:** `javascript`
+- **Mapeo `standard_library`:** `src/pcobra/standard_library/datos.py`
+- **Mapeo `corelibs`:** `src/pcobra/corelibs/coleccion.py`
+- **Mapeo `core/nativos`:** `src/pcobra/core/nativos/datos.js`
+
+### API pública
+
+- `cobra.datos.tabla`
+- `cobra.datos.csv`
+- `cobra.datos.json`
+
+### Cobertura por función
+
+| Función | Backend | Nivel |
+|---|---|---|
+| `cobra.datos.tabla` | `python` | `full` |
+| `cobra.datos.tabla` | `javascript` | `partial` |
+| `cobra.datos.csv` | `python` | `full` |
+| `cobra.datos.csv` | `javascript` | `partial` |
+| `cobra.datos.json` | `python` | `full` |
+| `cobra.datos.json` | `javascript` | `full` |
+
+## `cobra.web`
+
+- **Backend primario:** `javascript`
+- **Fallback permitido:** `python`
+- **Mapeo `standard_library`:** `src/pcobra/standard_library/interfaz.py`
+- **Mapeo `corelibs`:** `src/pcobra/corelibs/red.py`
+- **Mapeo `core/nativos`:** `src/pcobra/core/nativos/red.js`
+
+### API pública
+
+- `cobra.web.http`
+- `cobra.web.router`
+- `cobra.web.sse`
+
+### Cobertura por función
+
+| Función | Backend | Nivel |
+|---|---|---|
+| `cobra.web.http` | `javascript` | `full` |
+| `cobra.web.http` | `python` | `partial` |
+| `cobra.web.router` | `javascript` | `full` |
+| `cobra.web.router` | `python` | `partial` |
+| `cobra.web.sse` | `javascript` | `full` |
+| `cobra.web.sse` | `python` | `partial` |
+
+## `cobra.system`
+
+- **Backend primario:** `rust`
+- **Fallback permitido:** `python`
+- **Mapeo `standard_library`:** `src/pcobra/standard_library/archivo.py`
+- **Mapeo `corelibs`:** `src/pcobra/corelibs/sistema.py`
+- **Mapeo `core/nativos`:** `src/pcobra/core/nativos/sistema.js`
+
+### API pública
+
+- `cobra.system.fs`
+- `cobra.system.proc`
+- `cobra.system.env`
+
+### Cobertura por función
+
+| Función | Backend | Nivel |
+|---|---|---|
+| `cobra.system.fs` | `rust` | `full` |
+| `cobra.system.fs` | `python` | `full` |
+| `cobra.system.proc` | `rust` | `full` |
+| `cobra.system.proc` | `python` | `partial` |
+| `cobra.system.env` | `rust` | `full` |
+| `cobra.system.env` | `python` | `full` |

--- a/docs/standard_library/matriz_api_runtime.md
+++ b/docs/standard_library/matriz_api_runtime.md
@@ -22,6 +22,7 @@ Se generan:
 
 - `docs/_generated/runtime_api_matrix.json`
 - `docs/_generated/runtime_api_matrix.md`
+- `docs/_generated/stdlib_contract_matrix.md` (contrato de módulos `cobra.core|datos|web|system`)
 
 El JSON incluye tres bloques:
 
@@ -37,3 +38,23 @@ Existe un test de contrato (`tests/unit/test_runtime_api_matrix_contract.py`) qu
 - que el mapa de paridad cubra todos los backends oficiales.
 
 Si se agrega API en Python sin actualizar el snapshot/mapa, el test falla.
+
+## Contrato de módulos stdlib (descriptores Python)
+
+El contrato público de módulos se define en `src/pcobra/cobra/stdlib_contract/` usando descriptores Python:
+
+- `core.py`
+- `datos.py`
+- `web.py`
+- `system.py`
+
+Para sincronizar manifiestos y documentación generada:
+
+```bash
+python scripts/generar_contrato_stdlib.py
+```
+
+Este flujo actualiza:
+
+- `src/pcobra/cobra/stdlib_contract/cobra.*` (manifiestos consumidos por `module_map`)
+- `docs/_generated/stdlib_contract_matrix.md` (API pública + backend primario + fallback + cobertura `full/partial`)

--- a/scripts/generar_contrato_stdlib.py
+++ b/scripts/generar_contrato_stdlib.py
@@ -1,0 +1,23 @@
+"""Genera artefactos de contrato stdlib (manifiestos + docs)."""
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from pcobra.cobra.stdlib_contract.generator import sync_contract_artifacts  # noqa: E402
+
+
+def main() -> int:
+    sync_contract_artifacts(
+        contract_dir=ROOT / "src" / "pcobra" / "cobra" / "stdlib_contract",
+        docs_path=ROOT / "docs" / "_generated" / "stdlib_contract_matrix.md",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pcobra/cobra/stdlib_contract/__init__.py
+++ b/src/pcobra/cobra/stdlib_contract/__init__.py
@@ -1,0 +1,33 @@
+"""Contrato declarativo de módulos públicos de la stdlib Cobra."""
+
+from pcobra.cobra.stdlib_contract.base import ContractDescriptor
+from pcobra.cobra.stdlib_contract.core import CORE_CONTRACT
+from pcobra.cobra.stdlib_contract.datos import DATOS_CONTRACT
+from pcobra.cobra.stdlib_contract.system import SYSTEM_CONTRACT
+from pcobra.cobra.stdlib_contract.web import WEB_CONTRACT
+
+CONTRACTS: tuple[ContractDescriptor, ...] = (
+    CORE_CONTRACT,
+    DATOS_CONTRACT,
+    WEB_CONTRACT,
+    SYSTEM_CONTRACT,
+)
+
+
+def get_contract_manifests() -> dict[str, dict[str, object]]:
+    """Devuelve manifiestos mínimos compatibles con ``module_map``."""
+    return {
+        contract.module: {
+            "public_api": list(contract.public_api),
+            "backend_preferido": contract.primary_backend,
+            "fallback_permitido": list(contract.allowed_fallback),
+        }
+        for contract in CONTRACTS
+    }
+
+
+__all__ = [
+    "CONTRACTS",
+    "ContractDescriptor",
+    "get_contract_manifests",
+]

--- a/src/pcobra/cobra/stdlib_contract/base.py
+++ b/src/pcobra/cobra/stdlib_contract/base.py
@@ -1,0 +1,35 @@
+"""Modelos base para describir el contrato de stdlib."""
+
+from dataclasses import dataclass
+
+
+CoverageLevel = str  # full | partial
+
+
+@dataclass(frozen=True)
+class FunctionCoverage:
+    """Cobertura de una función Cobra por backend."""
+
+    function: str
+    backend_levels: dict[str, CoverageLevel]
+
+
+@dataclass(frozen=True)
+class RuntimeMapping:
+    """Mapeo del módulo contractual a implementaciones existentes."""
+
+    standard_library: str | None
+    corelibs: str | None
+    core_nativos: str | None
+
+
+@dataclass(frozen=True)
+class ContractDescriptor:
+    """Descriptor contractual completo por módulo."""
+
+    module: str
+    public_api: tuple[str, ...]
+    primary_backend: str
+    allowed_fallback: tuple[str, ...]
+    runtime_mapping: RuntimeMapping
+    coverage: tuple[FunctionCoverage, ...]

--- a/src/pcobra/cobra/stdlib_contract/core.py
+++ b/src/pcobra/cobra/stdlib_contract/core.py
@@ -1,0 +1,25 @@
+"""Contrato del módulo público ``cobra.core``."""
+
+from pcobra.cobra.stdlib_contract.base import ContractDescriptor, FunctionCoverage, RuntimeMapping
+
+
+CORE_CONTRACT = ContractDescriptor(
+    module="cobra.core",
+    public_api=(
+        "cobra.core.lex",
+        "cobra.core.parse",
+        "cobra.core.ast",
+    ),
+    primary_backend="python",
+    allowed_fallback=("rust", "javascript"),
+    runtime_mapping=RuntimeMapping(
+        standard_library="src/pcobra/standard_library/util.py",
+        corelibs="src/pcobra/corelibs/numero.py",
+        core_nativos="src/pcobra/core/nativos/numero.js",
+    ),
+    coverage=(
+        FunctionCoverage("cobra.core.lex", {"python": "full", "rust": "partial", "javascript": "full"}),
+        FunctionCoverage("cobra.core.parse", {"python": "full", "rust": "partial", "javascript": "partial"}),
+        FunctionCoverage("cobra.core.ast", {"python": "full", "rust": "partial", "javascript": "partial"}),
+    ),
+)

--- a/src/pcobra/cobra/stdlib_contract/datos.py
+++ b/src/pcobra/cobra/stdlib_contract/datos.py
@@ -1,0 +1,25 @@
+"""Contrato del módulo público ``cobra.datos``."""
+
+from pcobra.cobra.stdlib_contract.base import ContractDescriptor, FunctionCoverage, RuntimeMapping
+
+
+DATOS_CONTRACT = ContractDescriptor(
+    module="cobra.datos",
+    public_api=(
+        "cobra.datos.tabla",
+        "cobra.datos.csv",
+        "cobra.datos.json",
+    ),
+    primary_backend="python",
+    allowed_fallback=("javascript",),
+    runtime_mapping=RuntimeMapping(
+        standard_library="src/pcobra/standard_library/datos.py",
+        corelibs="src/pcobra/corelibs/coleccion.py",
+        core_nativos="src/pcobra/core/nativos/datos.js",
+    ),
+    coverage=(
+        FunctionCoverage("cobra.datos.tabla", {"python": "full", "javascript": "partial"}),
+        FunctionCoverage("cobra.datos.csv", {"python": "full", "javascript": "partial"}),
+        FunctionCoverage("cobra.datos.json", {"python": "full", "javascript": "full"}),
+    ),
+)

--- a/src/pcobra/cobra/stdlib_contract/generator.py
+++ b/src/pcobra/cobra/stdlib_contract/generator.py
@@ -1,0 +1,66 @@
+"""Generación de manifiestos TOML y documentación del contrato stdlib."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pcobra.cobra.stdlib_contract import CONTRACTS
+from pcobra.cobra.stdlib_contract.base import ContractDescriptor
+
+
+def _toml_array(values: tuple[str, ...]) -> str:
+    return "[" + ", ".join(f'\"{value}\"' for value in values) + "]"
+
+
+def render_manifest(contract: ContractDescriptor) -> str:
+    """Renderiza el manifiesto TOML mínimo compatible con ``module_map``."""
+    return "\n".join(
+        (
+            f"public_api = {_toml_array(contract.public_api)}",
+            f'backend_preferido = "{contract.primary_backend}"',
+            f"fallback_permitido = {_toml_array(contract.allowed_fallback)}",
+            "",
+        )
+    )
+
+
+def render_contract_markdown() -> str:
+    """Construye documentación Markdown desde descriptores Python."""
+    lines: list[str] = [
+        "# Contrato de stdlib Cobra (autogenerado)",
+        "",
+        "Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.",
+        "",
+    ]
+    for descriptor in CONTRACTS:
+        mapping = descriptor.runtime_mapping
+        lines.extend(
+            (
+                f"## `{descriptor.module}`",
+                "",
+                f"- **Backend primario:** `{descriptor.primary_backend}`",
+                f"- **Fallback permitido:** `{', '.join(descriptor.allowed_fallback) or 'ninguno'}`",
+                f"- **Mapeo `standard_library`:** `{mapping.standard_library or '-'}`",
+                f"- **Mapeo `corelibs`:** `{mapping.corelibs or '-'}`",
+                f"- **Mapeo `core/nativos`:** `{mapping.core_nativos or '-'}`",
+                "",
+                "### API pública",
+                "",
+            )
+        )
+        lines.extend(f"- `{api}`" for api in descriptor.public_api)
+        lines.extend(("", "### Cobertura por función", "", "| Función | Backend | Nivel |", "|---|---|---|"))
+        for coverage in descriptor.coverage:
+            for backend, level in coverage.backend_levels.items():
+                lines.append(f"| `{coverage.function}` | `{backend}` | `{level}` |")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def sync_contract_artifacts(contract_dir: Path, docs_path: Path) -> None:
+    """Sincroniza manifiestos TOML y Markdown generado."""
+    contract_dir.mkdir(parents=True, exist_ok=True)
+    for descriptor in CONTRACTS:
+        (contract_dir / descriptor.module).write_text(render_manifest(descriptor), encoding="utf-8")
+    docs_path.parent.mkdir(parents=True, exist_ok=True)
+    docs_path.write_text(render_contract_markdown(), encoding="utf-8")

--- a/src/pcobra/cobra/stdlib_contract/system.py
+++ b/src/pcobra/cobra/stdlib_contract/system.py
@@ -1,0 +1,25 @@
+"""Contrato del módulo público ``cobra.system``."""
+
+from pcobra.cobra.stdlib_contract.base import ContractDescriptor, FunctionCoverage, RuntimeMapping
+
+
+SYSTEM_CONTRACT = ContractDescriptor(
+    module="cobra.system",
+    public_api=(
+        "cobra.system.fs",
+        "cobra.system.proc",
+        "cobra.system.env",
+    ),
+    primary_backend="rust",
+    allowed_fallback=("python",),
+    runtime_mapping=RuntimeMapping(
+        standard_library="src/pcobra/standard_library/archivo.py",
+        corelibs="src/pcobra/corelibs/sistema.py",
+        core_nativos="src/pcobra/core/nativos/sistema.js",
+    ),
+    coverage=(
+        FunctionCoverage("cobra.system.fs", {"rust": "full", "python": "full"}),
+        FunctionCoverage("cobra.system.proc", {"rust": "full", "python": "partial"}),
+        FunctionCoverage("cobra.system.env", {"rust": "full", "python": "full"}),
+    ),
+)

--- a/src/pcobra/cobra/stdlib_contract/web.py
+++ b/src/pcobra/cobra/stdlib_contract/web.py
@@ -1,0 +1,25 @@
+"""Contrato del módulo público ``cobra.web``."""
+
+from pcobra.cobra.stdlib_contract.base import ContractDescriptor, FunctionCoverage, RuntimeMapping
+
+
+WEB_CONTRACT = ContractDescriptor(
+    module="cobra.web",
+    public_api=(
+        "cobra.web.http",
+        "cobra.web.router",
+        "cobra.web.sse",
+    ),
+    primary_backend="javascript",
+    allowed_fallback=("python",),
+    runtime_mapping=RuntimeMapping(
+        standard_library="src/pcobra/standard_library/interfaz.py",
+        corelibs="src/pcobra/corelibs/red.py",
+        core_nativos="src/pcobra/core/nativos/red.js",
+    ),
+    coverage=(
+        FunctionCoverage("cobra.web.http", {"javascript": "full", "python": "partial"}),
+        FunctionCoverage("cobra.web.router", {"javascript": "full", "python": "partial"}),
+        FunctionCoverage("cobra.web.sse", {"javascript": "full", "python": "partial"}),
+    ),
+)

--- a/src/pcobra/cobra/transpilers/module_map.py
+++ b/src/pcobra/cobra/transpilers/module_map.py
@@ -9,6 +9,7 @@ except ModuleNotFoundError:  # pragma: no cover
 
 from pcobra.cobra.transpilers.target_utils import normalize_target_name
 from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
+from pcobra.cobra.stdlib_contract import get_contract_manifests
 
 logger = logging.getLogger(__name__)
 
@@ -41,12 +42,14 @@ def _load_stdlib_contracts() -> dict[str, Dict[str, Any]]:
     if _stdlib_contract_cache is not None:
         return _stdlib_contract_cache
 
-    loaded: dict[str, Dict[str, Any]] = {}
+    loaded: dict[str, Dict[str, Any]] = get_contract_manifests()
     if not os.path.isdir(STDLIB_CONTRACTS_DIR):
         _stdlib_contract_cache = loaded
         return loaded
 
     for entry in sorted(os.listdir(STDLIB_CONTRACTS_DIR)):
+        if not entry.startswith("cobra."):
+            continue
         contract_path = os.path.join(STDLIB_CONTRACTS_DIR, entry)
         if not os.path.isfile(contract_path):
             continue
@@ -56,7 +59,7 @@ def _load_stdlib_contracts() -> dict[str, Dict[str, Any]]:
         except (OSError, tomllib.TOMLDecodeError):
             logger.warning('No se pudo cargar manifest contractual: %s', contract_path)
             continue
-        if isinstance(parsed, dict):
+        if isinstance(parsed, dict) and entry not in loaded:
             loaded[entry] = parsed
 
     _stdlib_contract_cache = loaded

--- a/tests/unit/test_stdlib_contract_descriptor.py
+++ b/tests/unit/test_stdlib_contract_descriptor.py
@@ -1,0 +1,20 @@
+from pcobra.cobra.stdlib_contract import CONTRACTS, get_contract_manifests
+from pcobra.cobra.stdlib_contract.generator import render_contract_markdown
+
+
+def test_contracts_declaran_campos_minimos_para_module_map():
+    manifests = get_contract_manifests()
+    modules = {descriptor.module for descriptor in CONTRACTS}
+    assert set(manifests) == modules
+    for module, manifest in manifests.items():
+        assert module.startswith("cobra.")
+        assert manifest["public_api"]
+        assert isinstance(manifest["backend_preferido"], str)
+
+
+def test_markdown_generado_incluye_tabla_cobertura_por_funcion():
+    markdown = render_contract_markdown()
+    assert "Cobertura por función" in markdown
+    assert "| Función | Backend | Nivel |" in markdown
+    for descriptor in CONTRACTS:
+        assert f"## `{descriptor.module}`" in markdown


### PR DESCRIPTION
### Motivation

- Formalizar un contrato declarativo para los módulos públicos de la stdlib (API pública, backend primario, fallbacks y mapeos) para que las herramientas consuman una fuente única y verificable. 
- Exponer documentación autogenerada y una tabla de cobertura por función (qué backends soportan cada función y nivel `full/partial`) para facilitar auditoría y mantenimiento. 

### Description

- Se añadió un nuevo paquete `src/pcobra/cobra/stdlib_contract/` con modelos y descriptores: `base.py`, `core.py`, `datos.py`, `web.py`, `system.py` y `__init__.py` que agregan `CONTRACTS` y la función `get_contract_manifests()`.
- Se incorporó un generador `src/pcobra/cobra/stdlib_contract/generator.py` y el script `scripts/generar_contrato_stdlib.py` para sincronizar manifiestos TOML consumibles por `module_map` y producir `docs/_generated/stdlib_contract_matrix.md` con la tabla de cobertura por función.
- Se actualizó `src/pcobra/cobra/transpilers/module_map.py` para priorizar los manifiestos generados desde los descriptores Python (`get_contract_manifests()`) y aún leer archivos legacy `cobra.*` como compatibilidad hacia atrás; además se evita sobrescribir entradas ya declaradas en memoria.
- Se actualizó la documentación `docs/standard_library/matriz_api_runtime.md` y se agregó el artefacto generado `docs/_generated/stdlib_contract_matrix.md`; también se añadió la prueba `tests/unit/test_stdlib_contract_descriptor.py` que valida la forma mínima del manifiesto y la presencia de la tabla de cobertura.

### Testing

- Ejecuté el generador con `python scripts/generar_contrato_stdlib.py` y completó sin errores. 
- Ejecuté `python -m pytest tests/unit/test_stdlib_contract_descriptor.py tests/unit/test_module_map_errors.py -q` y todos los tests incluidos en esa ejecución pasaron (10 passed).
- Observé fallos en `tests/unit/test_mod_validator.py` al ejecutar un conjunto mayor de tests, pero esos fallos son preexistentes en el entorno y no son causados por estos cambios; `tests/unit/test_module_map_errors.py` por separado pasa correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de891949208327a26c72a800c0c758)