### PR TITLE
Implementar resolver de imports Cobra con precedencia fija y warnings de colisión

### DIFF
--- a/src/pcobra/cobra/imports/__init__.py
+++ b/src/pcobra/cobra/imports/__init__.py
@@ -1,7 +1,6 @@
 """Utilidades de resolución de imports para Cobra."""
 
 from pcobra.cobra.imports.resolver import (
-    AmbiguousImportError,
     CobraImportResolver,
     HybridModuleSpec,
     ImportResolutionError,
@@ -9,7 +8,6 @@ from pcobra.cobra.imports.resolver import (
 )
 
 __all__ = [
-    "AmbiguousImportError",
     "CobraImportResolver",
     "HybridModuleSpec",
     "ImportResolutionError",

--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -4,21 +4,22 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Mapping
 
 from pcobra.cobra.backends.resolver import resolve_backend
-from pcobra.cobra.transpilers.module_map import get_stdlib_contracts, resolve_backend_for_module
+from pcobra.cobra.transpilers.module_map import (
+    get_stdlib_contracts,
+    get_toml_map,
+    resolve_backend_for_module,
+)
 
 
 class ImportResolutionError(RuntimeError):
     """Error base al resolver imports Cobra."""
-
-
-class AmbiguousImportError(ImportResolutionError):
-    """Error determinista para imports ambiguos sin calificación de namespace."""
 
 
 @dataclass(frozen=True)
@@ -39,15 +40,11 @@ class ResolutionResult:
     resolved_name: str
     import_path: str | None = None
     backend: str | None = None
+    backend_adapter: object | None = None
 
 
+_SOURCE_ORDER: tuple[str, ...] = ("stdlib", "project", "python_bridge", "hybrid")
 
-_SOURCE_PRIORITY: dict[str, int] = {
-    "local": 1,
-    "stdlib": 2,
-    "python_bridge": 3,
-    "hybrid": 4,
-}
 
 class CobraImportResolver:
     """Resuelve imports con prioridad fija y conflictos explícitos."""
@@ -57,10 +54,13 @@ class CobraImportResolver:
         *,
         project_root: str | Path | None = None,
         hybrid_modules: Mapping[str, HybridModuleSpec | Mapping[str, Any]] | None = None,
+        default_backend: str = "python",
     ) -> None:
         self.project_root = Path(project_root).resolve() if project_root else None
         self.hybrid_modules = self._normalize_hybrid_modules(hybrid_modules or {})
+        self.default_backend = default_backend
         self.stdlib_modules = self._load_stdlib_modules()
+        self.project_modules = self._load_project_modules()
 
     @staticmethod
     def _normalize_hybrid_modules(
@@ -85,69 +85,102 @@ class CobraImportResolver:
         contracts = get_stdlib_contracts()
         return {name for name in contracts if name.startswith("cobra.")}
 
+    @staticmethod
+    def _load_project_modules() -> set[str]:
+        config = get_toml_map()
+        if not isinstance(config, dict):
+            return set()
+        modulos = config.get("modulos", {})
+        if not isinstance(modulos, dict):
+            return set()
+        return {name for name, value in modulos.items() if isinstance(name, str) and isinstance(value, dict)}
+
     def resolve(self, module_name: str) -> ResolutionResult:
         name = (module_name or "").strip()
         if not name:
             raise ImportResolutionError("Nombre de módulo vacío")
 
         candidates: list[ResolutionResult] = []
-
-        local_candidate = self._resolve_local_module(name)
-        if local_candidate is not None:
-            candidates.append(local_candidate)
-
-        stdlib_candidate = self._resolve_stdlib_module(name)
-        if stdlib_candidate is not None:
-            candidates.append(stdlib_candidate)
-
-        python_candidate = self._resolve_python_bridge(name)
-        if python_candidate is not None:
-            candidates.append(python_candidate)
-
-        hybrid_candidate = self._resolve_hybrid_module(name)
-        if hybrid_candidate is not None:
-            candidates.append(hybrid_candidate)
+        for source in _SOURCE_ORDER:
+            candidate = self._build_candidate(source, name)
+            if candidate is not None:
+                candidates.append(candidate)
 
         if not candidates:
             raise ImportResolutionError(f"No se encontró módulo para '{name}'")
 
-        sorted_candidates = sorted(candidates, key=lambda c: _SOURCE_PRIORITY[c.source])
-        top_priority = _SOURCE_PRIORITY[sorted_candidates[0].source]
-        top_candidates = [
-            candidate
-            for candidate in sorted_candidates
-            if _SOURCE_PRIORITY[candidate.source] == top_priority
-        ]
+        if "." not in name and len(candidates) > 1:
+            details = ", ".join(f"{c.source}:{c.resolved_name}" for c in candidates)
+            warnings.warn(
+                f"Colisión de import para '{name}'. Se aplica precedencia fija "
+                f"({_SOURCE_ORDER[0]} > {_SOURCE_ORDER[1]} > {_SOURCE_ORDER[2]} > {_SOURCE_ORDER[3]}). "
+                f"Seleccionado: {candidates[0].resolved_name}. Candidatos: {details}",
+                category=UserWarning,
+                stacklevel=2,
+            )
 
-        if "." not in name and len(sorted_candidates) > 1:
-            has_local = any(candidate.source == "local" for candidate in sorted_candidates)
-            if not has_local or len(top_candidates) > 1:
-                details = ", ".join(
-                    f"{c.source}:{c.resolved_name}" for c in sorted_candidates
-                )
-                raise AmbiguousImportError(
-                    f"Import ambiguo sin namespace para '{name}'. "
-                    f"Use un nombre calificado. Candidatos: {details}"
-                )
+        return self._attach_backend_adapter(candidates[0])
 
-        return sorted_candidates[0]
-
-    def load_module(self, module_name: str, fallback_backend: str = "python") -> tuple[ResolutionResult, ModuleType | None]:
-        """Carga módulo Python cuando aplique e inyecta adapter de backend."""
+    def load_module(
+        self,
+        module_name: str,
+        fallback_backend: str = "python",
+    ) -> tuple[ResolutionResult, ModuleType | None]:
+        """Carga módulo Python cuando aplique usando el resultado resuelto."""
 
         resolution = self.resolve(module_name)
         if resolution.import_path is None:
             return resolution, None
 
         module = importlib.import_module(resolution.import_path)
-        backend = resolution.backend or fallback_backend
-        backend = resolve_backend_for_module(resolution.resolved_name, backend)
-        adapter = resolve_backend(backend)
-        setattr(module, "__cobra_backend__", backend)
-        setattr(module, "__cobra_backend_adapter__", adapter)
+        if resolution.backend:
+            setattr(module, "__cobra_backend__", resolution.backend)
+        if resolution.backend_adapter is not None:
+            setattr(module, "__cobra_backend_adapter__", resolution.backend_adapter)
+        elif fallback_backend:
+            effective_backend = resolve_backend_for_module(
+                resolution.resolved_name,
+                fallback_backend,
+            )
+            adapter = resolve_backend(effective_backend)
+            setattr(module, "__cobra_backend__", effective_backend)
+            setattr(module, "__cobra_backend_adapter__", adapter)
         return resolution, module
 
-    def _resolve_local_module(self, name: str) -> ResolutionResult | None:
+    def _attach_backend_adapter(self, resolution: ResolutionResult) -> ResolutionResult:
+        base_backend = resolution.backend or self.default_backend
+        effective_backend = resolve_backend_for_module(resolution.resolved_name, base_backend)
+        adapter = resolve_backend(effective_backend)
+        return ResolutionResult(
+            request=resolution.request,
+            source=resolution.source,
+            resolved_name=resolution.resolved_name,
+            import_path=resolution.import_path,
+            backend=effective_backend,
+            backend_adapter=adapter,
+        )
+
+    def _build_candidate(self, source: str, name: str) -> ResolutionResult | None:
+        if source == "stdlib":
+            return self._resolve_stdlib_module(name)
+        if source == "project":
+            return self._resolve_project_module(name)
+        if source == "python_bridge":
+            return self._resolve_python_bridge(name)
+        if source == "hybrid":
+            return self._resolve_hybrid_module(name)
+        return None
+
+    def _resolve_project_module(self, name: str) -> ResolutionResult | None:
+        if name in self.project_modules:
+            return ResolutionResult(request=name, source="project", resolved_name=name)
+
+        file_candidate = self._resolve_local_file_module(name)
+        if file_candidate is not None:
+            return file_candidate
+        return None
+
+    def _resolve_local_file_module(self, name: str) -> ResolutionResult | None:
         if self.project_root is None:
             return None
 
@@ -162,7 +195,7 @@ class CobraImportResolver:
             if (self.project_root / pattern).exists():
                 return ResolutionResult(
                     request=name,
-                    source="local",
+                    source="project",
                     resolved_name=name,
                 )
         return None

--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 import sys
 
+
 # Intentamos cargar configuración dinámica desde cobra.toml
 try:
     import tomli
@@ -165,11 +166,22 @@ def obtener_modulo(nombre: str):
         raise PermissionError(f"Paquete '{nombre}' no está permitido.")
     spec = USAR_WHITELIST[nombre]
 
+    base = Path(__file__).resolve()
+    from pcobra.cobra.imports.resolver import CobraImportResolver, ImportResolutionError
+
+    resolver = CobraImportResolver(project_root=base.parents[3])
+    try:
+        _, module = resolver.load_module(nombre, fallback_backend="python")
+    except ImportResolutionError:
+        module = None
+    else:
+        if module is not None:
+            return module
+
     try:
         return importlib.import_module(nombre)
     except ModuleNotFoundError:
         # Buscar primero en corelibs
-        base = Path(__file__).resolve()
         for parent in base.parents:
             corelibs = parent / "corelibs"
             if corelibs.exists():

--- a/tests/unit/test_imports_resolver.py
+++ b/tests/unit/test_imports_resolver.py
@@ -5,21 +5,21 @@ from types import ModuleType
 import pytest
 
 from pcobra.cobra.imports.resolver import (
-    AmbiguousImportError,
     CobraImportResolver,
     HybridModuleSpec,
     ImportResolutionError,
 )
 
 
-def test_resuelve_modulo_local_antes_que_stdlib_y_bridge(tmp_path):
+def test_resuelve_stdlib_antes_que_modulo_proyecto(tmp_path):
     (tmp_path / "datos.co").write_text("usar algo")
     resolver = CobraImportResolver(project_root=tmp_path)
 
-    result = resolver.resolve("datos")
+    with pytest.warns(UserWarning, match="Colisión de import"):
+        result = resolver.resolve("datos")
 
-    assert result.source == "local"
-    assert result.resolved_name == "datos"
+    assert result.source == "stdlib"
+    assert result.resolved_name == "cobra.datos"
 
 
 def test_prefiere_namespace_explicito_cobra_datos():
@@ -31,8 +31,8 @@ def test_prefiere_namespace_explicito_cobra_datos():
     assert result.import_path == "pcobra.standard_library.datos"
 
 
-def test_ambiguedad_sin_namespace_es_determinista(tmp_path, monkeypatch):
-    resolver = CobraImportResolver(project_root=tmp_path)
+def test_colision_stdlib_vs_bridge_genera_warning(monkeypatch):
+    resolver = CobraImportResolver()
 
     import importlib.util
 
@@ -48,10 +48,10 @@ def test_ambiguedad_sin_namespace_es_determinista(tmp_path, monkeypatch):
 
     monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
 
-    with pytest.raises(AmbiguousImportError) as exc:
-        resolver.resolve("datos")
+    with pytest.warns(UserWarning, match="Colisión de import"):
+        result = resolver.resolve("datos")
 
-    assert "Import ambiguo" in str(exc.value)
+    assert result.source == "stdlib"
 
 
 def test_bridge_python_directo():
@@ -93,6 +93,15 @@ def test_modulo_hibrido_inyecta_adapter_backend(monkeypatch):
     assert module is fake_module
     assert getattr(module, "__cobra_backend__") == "javascript"
     assert getattr(module, "__cobra_backend_adapter__").__class__.__name__ == "JavaScriptAdapter"
+
+
+def test_resolver_adjunta_adapter_desde_resolucion():
+    resolver = CobraImportResolver()
+
+    result = resolver.resolve("json")
+
+    assert result.backend is not None
+    assert result.backend_adapter is not None
 
 
 def test_error_si_no_hay_candidato():

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -148,3 +148,25 @@ def test_interpreter_usar_registra_modulo(monkeypatch):
     interp = InterpretadorCobra()
     interp.ejecutar_nodo(NodoUsar('math'))
     assert interp.variables['math'] is mod
+
+
+def test_obtener_modulo_delega_en_nuevo_resolver(monkeypatch):
+    mock_mod = ModuleType('json')
+    monkeypatch.setitem(usar_loader.USAR_WHITELIST, 'json', 'json')
+
+    class FakeResolver:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def load_module(self, nombre, fallback_backend='python'):
+            assert nombre == 'json'
+            assert fallback_backend == 'python'
+            return object(), mock_mod
+
+    from pcobra.cobra.imports import resolver as imports_resolver
+
+    monkeypatch.setattr(imports_resolver, 'CobraImportResolver', FakeResolver)
+
+    mod = usar_loader.obtener_modulo('json')
+
+    assert mod is mock_mod


### PR DESCRIPTION
### Motivation
- Unificar y determinizar la resolución de imports Cobra para evitar ambigüedades en proyectos con stdlib, módulos de proyecto y paquetes Python externos. 
- Detectar y alertar colisiones de nombres (p.ej. `datos` vs `cobra.datos`) con una regla reproducible en lugar de lanzar errores inesperados. 
- Simplificar la inyección de adaptadores de backend para que ocurra al resolver el módulo y no en el parser/AST. 

### Description
- Reescribí `src/pcobra/cobra/imports/resolver.py` para aplicar una precedencia fija de resolución `stdlib -> project -> python_bridge -> hybrid` y construir candidatos por origen en ese orden. 
- Implementé detección de colisiones de nombres no calificados y emisión de `UserWarning` indicando los candidatos y la selección determinista por precedencia. 
- Moví la inyección de adaptadores de backend al proceso de resolución: `ResolutionResult` ahora incluye `backend` y `backend_adapter` y `_attach_backend_adapter` adjunta el adaptador apropiado. 
- Actualicé `src/pcobra/cobra/usar_loader.py` para delegar primero en el nuevo `CobraImportResolver.load_module(...)` y mantener los flujos de fallback previos (import directo, `corelibs`, `standard_library`, `pip`) cuando no haya módulo cargable. 
- Ajusté `src/pcobra/cobra/imports/__init__.py` y añadí/actualicé tests en `tests/unit/test_imports_resolver.py` y `tests/unit/test_usar.py` para cubrir precedencia, conflicto/warning, inyección de adapters y delegación desde `usar_loader`. 

### Testing
- Ejecuté `pytest -q tests/unit/test_imports_resolver.py tests/unit/test_usar.py` como suite de verificación automatizada. 
- Todas las pruebas ejecutadas pasaron: `17 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df0f1be8488327a09def3a943f1a99)