### PR TITLE
Add RuntimeManager for binding routes and ABI/security validation

### DIFF
--- a/docs/architecture/binding-contract.md
+++ b/docs/architecture/binding-contract.md
@@ -46,8 +46,32 @@ Este módulo expone:
 
 ## Consumo en runners
 
-- `execute_cmd.py` debe resolver contrato vía `resolve_binding(...)` para runtime Python y ejecución en contenedor.
-- Runners futuros deben consumir este contrato para decidir la ruta técnica sin duplicar reglas.
+- `execute_cmd.py` consume `RuntimeManager` para:
+  - resolver contrato + bridge,
+  - validar seguridad por ruta (`python_direct_import`, `javascript_runtime_bridge`, `rust_compiled_ffi`),
+  - validar ABI efectiva por backend.
+- `build/backend_pipeline.py` expone `resolve_backend_runtime(...)` y agrega `runtime` al resultado de `build(...)` para que los flujos de compilación tengan metadatos de compatibilidad.
+- Runners futuros deben consumir `RuntimeManager` para decidir la ruta técnica sin duplicar reglas.
+
+## Contrato de versionado ABI
+
+- **Versión de ABI actual:** `1.0`
+- **Regla de compatibilidad:** una ruta solo es compatible si su `abi_version` está en el conjunto soportado por esa ruta.
+- **Punto de validación:** `RuntimeManager.validate_abi_route(language, abi_version)`.
+
+### Tabla de compatibilidad ABI por backend
+
+| Backend | Ruta contractual | Contrato ABI/API | ABI soportadas |
+|---|---|---|---|
+| Python | `python_direct_import` | API pública Python + typing estable | `1.0` |
+| JavaScript | `javascript_runtime_bridge` | Mensajería/IPC versionada | `1.0` |
+| Rust | `rust_compiled_ffi` | ABI nativa estable/versionada | `1.0` |
+
+## Validaciones de seguridad por ruta
+
+- `python_direct_import`: ejecución en proceso local, no se considera ruta containerizada.
+- `javascript_runtime_bridge`: requiere runtime gestionado (sandbox o contenedor) para preservar aislamiento.
+- `rust_compiled_ffi`: frontera nativa FFI; no se ejecuta como sandbox Python directo.
 
 ## Regla de evolución
 

--- a/src/pcobra/cobra/bindings/__init__.py
+++ b/src/pcobra/cobra/bindings/__init__.py
@@ -10,6 +10,13 @@ from pcobra.cobra.bindings.contract import (
     resolve_binding,
 )
 
+from pcobra.cobra.bindings.runtime_manager import (
+    DEFAULT_ABI_VERSION,
+    SUPPORTED_ABI_VERSIONS,
+    RuntimeBridgeDescriptor,
+    RuntimeManager,
+)
+
 __all__ = [
     "BindingCapabilities",
     "BindingRoute",
@@ -18,4 +25,8 @@ __all__ = [
     "JAVASCRIPT_BINDING",
     "RUST_BINDING",
     "resolve_binding",
+    "DEFAULT_ABI_VERSION",
+    "SUPPORTED_ABI_VERSIONS",
+    "RuntimeBridgeDescriptor",
+    "RuntimeManager",
 ]

--- a/src/pcobra/cobra/bindings/runtime_manager.py
+++ b/src/pcobra/cobra/bindings/runtime_manager.py
@@ -1,0 +1,110 @@
+"""Manager unificado para resolver y validar rutas de bindings/runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from pcobra.cobra.bindings.contract import (
+    BindingCapabilities,
+    BindingRoute,
+    resolve_binding,
+)
+
+DEFAULT_ABI_VERSION: Final[str] = "1.0"
+SUPPORTED_ABI_VERSIONS: Final[dict[BindingRoute, tuple[str, ...]]] = {
+    BindingRoute.PYTHON_DIRECT_IMPORT: ("1.0",),
+    BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE: ("1.0",),
+    BindingRoute.RUST_COMPILED_FFI: ("1.0",),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeBridgeDescriptor:
+    """Describe la implementación de bridge concreta para una ruta contractual."""
+
+    route: BindingRoute
+    implementation: str
+    security_profile: str
+    abi_version: str
+
+
+class RuntimeManager:
+    """Resuelve rutas de binding y centraliza validaciones de seguridad/ABI."""
+
+    _BRIDGES: Final[dict[BindingRoute, RuntimeBridgeDescriptor]] = {
+        BindingRoute.PYTHON_DIRECT_IMPORT: RuntimeBridgeDescriptor(
+            route=BindingRoute.PYTHON_DIRECT_IMPORT,
+            implementation="python_direct_bridge",
+            security_profile="same_process_safe_mode",
+            abi_version=DEFAULT_ABI_VERSION,
+        ),
+        BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE: RuntimeBridgeDescriptor(
+            route=BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE,
+            implementation="javascript_controlled_runtime_bridge",
+            security_profile="managed_runtime_isolation",
+            abi_version=DEFAULT_ABI_VERSION,
+        ),
+        BindingRoute.RUST_COMPILED_FFI: RuntimeBridgeDescriptor(
+            route=BindingRoute.RUST_COMPILED_FFI,
+            implementation="rust_compiled_ffi_bridge",
+            security_profile="native_ffi_boundary",
+            abi_version=DEFAULT_ABI_VERSION,
+        ),
+    }
+
+    def resolve_runtime(self, language: str) -> tuple[BindingCapabilities, RuntimeBridgeDescriptor]:
+        """Resuelve contrato y bridge asociado para un lenguaje."""
+
+        capabilities = resolve_binding(language)
+        bridge = self._BRIDGES[capabilities.route]
+        return capabilities, bridge
+
+    def validate_security_route(
+        self,
+        language: str,
+        *,
+        sandbox: bool = False,
+        containerized: bool = False,
+    ) -> None:
+        """Valida que la ruta elegida cumpla expectativas mínimas de seguridad."""
+
+        capabilities, _bridge = self.resolve_runtime(language)
+        route = capabilities.route
+
+        if route is BindingRoute.PYTHON_DIRECT_IMPORT and containerized:
+            raise ValueError(
+                "La ruta python_direct_import no puede marcarse como containerizada. "
+                "Use bridge Python directo (mismo proceso) o ruta de runtime gestionado."
+            )
+        if route is BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE and not (sandbox or containerized):
+            raise ValueError(
+                "La ruta javascript_runtime_bridge requiere runtime gestionado "
+                "(sandbox o contenedor) para mantener aislamiento."
+            )
+        if route is BindingRoute.RUST_COMPILED_FFI and sandbox:
+            raise ValueError(
+                "La ruta rust_compiled_ffi usa frontera nativa FFI y no se ejecuta "
+                "en sandbox Python directo."
+            )
+
+    def validate_abi_route(self, language: str, abi_version: str | None = None) -> str:
+        """Valida compatibilidad ABI de la ruta seleccionada."""
+
+        capabilities, bridge = self.resolve_runtime(language)
+        selected = (abi_version or bridge.abi_version or DEFAULT_ABI_VERSION).strip()
+        supported = SUPPORTED_ABI_VERSIONS[capabilities.route]
+        if selected not in supported:
+            raise ValueError(
+                f"ABI '{selected}' no soportada para '{language}'. "
+                f"Versiones soportadas: {', '.join(supported)}."
+            )
+        return selected
+
+
+__all__ = [
+    "DEFAULT_ABI_VERSION",
+    "SUPPORTED_ABI_VERSIONS",
+    "RuntimeBridgeDescriptor",
+    "RuntimeManager",
+]

--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 from pcobra.cobra.build.orchestrator import BackendResolution, BuildOrchestrator
 from pcobra.cobra.transpilers.registry import build_official_transpilers
 from pcobra.core.ast_cache import obtener_ast
 
 ORCHESTRATOR = BuildOrchestrator()
+RUNTIME_MANAGER = RuntimeManager()
 TRANSPILERS: dict[str, type] = build_official_transpilers()
 
 
@@ -23,6 +25,29 @@ def resolve_backend(source: str, hints: dict[str, Any] | None = None) -> Backend
         preferred_backend=preferred_backend,
         required_capabilities=required_capabilities,
     )
+
+
+def resolve_backend_runtime(
+    source: str,
+    hints: dict[str, Any] | None = None,
+) -> tuple[BackendResolution, dict[str, str]]:
+    """Resuelve backend y metadatos de bridge/runtime para el contrato de bindings."""
+    context = hints or {}
+    resolution = resolve_backend(source, context)
+    capabilities, bridge = RUNTIME_MANAGER.resolve_runtime(resolution.backend)
+    abi_version = RUNTIME_MANAGER.validate_abi_route(
+        resolution.backend,
+        abi_version=context.get("abi_version"),
+    )
+    runtime_context = {
+        "language": capabilities.language,
+        "route": capabilities.route.value,
+        "bridge": bridge.implementation,
+        "security_profile": bridge.security_profile,
+        "abi_contract": capabilities.abi_contract,
+        "abi_version": abi_version,
+    }
+    return resolution, runtime_context
 
 
 def transpile(ast: Any, backend: str) -> str:
@@ -49,12 +74,13 @@ def build(source: str, mode: dict[str, Any] | str | None = None) -> dict[str, An
         source_file = str(hints.get("source_file", "<memory>"))
         codigo = source
 
-    resolution = resolve_backend(source_file, hints)
+    resolution, runtime_context = resolve_backend_runtime(source_file, hints)
     ast = obtener_ast(codigo)
     code = transpile(ast, resolution.backend)
     return {
         "backend": resolution.backend,
         "reason": resolution.reason,
+        "runtime": runtime_context,
         "ast": ast,
         "code": code,
     }
@@ -65,5 +91,6 @@ __all__ = [
     "TRANSPILERS",
     "build",
     "resolve_backend",
+    "resolve_backend_runtime",
     "transpile",
 ]

--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -13,7 +13,7 @@ from pcobra.cobra.cli.utils.validators import (
     validar_archivo_existente,
 )
 from pcobra.cobra.cli.utils.autocomplete import files_completer
-from pcobra.cobra.bindings.contract import resolve_binding
+from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 from pcobra.cobra.cli.target_policies import (
     DOCKER_EXECUTABLE_TARGETS,
     OFFICIAL_RUNTIME_TARGETS_HELP,
@@ -86,6 +86,7 @@ class _SandboxModuleProxy:
 
 
 sandbox_module = _SandboxModuleProxy()
+RUNTIME_MANAGER = RuntimeManager()
 
 
 def ejecutar_en_sandbox(*args: Any, **kwargs: Any) -> Any:
@@ -117,10 +118,10 @@ def _obtener_interpretador_cls():
     return getattr(sys.modules[__name__], "InterpretadorCobra", InterpretadorCobra)
 
 
-def _resolver_contrato_binding(target: str):
-    """Resuelve el contrato de bindings usado por runners CLI."""
+def _resolver_runtime_binding(target: str):
+    """Resuelve contrato + bridge de bindings usado por runners CLI."""
 
-    return resolve_binding(target)
+    return RUNTIME_MANAGER.resolve_runtime(target)
 
 
 class ExecuteCommand(BaseCommand):
@@ -250,7 +251,9 @@ class ExecuteCommand(BaseCommand):
 
         try:
             raiz_proyecto = _detectar_raiz_proyecto_desde_archivo(str(archivo_resuelto))
-            contrato_python = _resolver_contrato_binding("python")
+            contrato_python, _bridge_python = _resolver_runtime_binding("python")
+            RUNTIME_MANAGER.validate_security_route("python", sandbox=sandbox, containerized=False)
+            RUNTIME_MANAGER.validate_abi_route("python")
             validar_dependencias(
                 contrato_python.language,
                 module_map.get_toml_map(),
@@ -349,12 +352,16 @@ class ExecuteCommand(BaseCommand):
     def _ejecutar_en_contenedor(self, codigo: str, contenedor: str) -> int:
         """Ejecuta el código en un contenedor Docker."""
         try:
-            contrato = _resolver_contrato_binding(contenedor)
+            contrato, bridge = _resolver_runtime_binding(contenedor)
+            RUNTIME_MANAGER.validate_security_route(contenedor, sandbox=False, containerized=True)
+            abi_version = RUNTIME_MANAGER.validate_abi_route(contenedor)
             self.logger.debug(
-                "Ruta de bindings para contenedor '%s': %s (%s)",
+                "Ruta de bindings para contenedor '%s': %s (%s) bridge=%s abi=%s",
                 contenedor,
                 contrato.route.value,
                 contrato.execution_boundary,
+                bridge.implementation,
+                abi_version,
             )
 
             backend_runtime = resolve_docker_backend(contenedor)

--- a/tests/unit/test_backend_pipeline_runtime_manager.py
+++ b/tests/unit/test_backend_pipeline_runtime_manager.py
@@ -1,0 +1,32 @@
+from pcobra.cobra.build import backend_pipeline
+
+
+class _DummyTranspiler:
+    def generate_code(self, ast):
+        return f"code:{len(ast)}"
+
+
+def test_backend_pipeline_build_expone_contexto_runtime(monkeypatch):
+    monkeypatch.setattr(
+        backend_pipeline,
+        "resolve_backend_runtime",
+        lambda source, hints=None: (
+            type("R", (), {"backend": "python", "reason": "test"})(),
+            {
+                "language": "python",
+                "route": "python_direct_import",
+                "bridge": "python_direct_bridge",
+                "security_profile": "same_process_safe_mode",
+                "abi_contract": "Contrato Python estable por API pública y typing",
+                "abi_version": "1.0",
+            },
+        ),
+    )
+    monkeypatch.setattr(backend_pipeline, "obtener_ast", lambda _codigo: ["ast"])
+    monkeypatch.setattr(backend_pipeline, "TRANSPILERS", {"python": _DummyTranspiler})
+
+    result = backend_pipeline.build("imprimir(1)", mode="python")
+
+    assert result["backend"] == "python"
+    assert result["runtime"]["abi_version"] == "1.0"
+    assert result["runtime"]["route"] == "python_direct_import"

--- a/tests/unit/test_execute_cmd_binding_contract.py
+++ b/tests/unit/test_execute_cmd_binding_contract.py
@@ -12,10 +12,24 @@ def test_ejecutar_en_contenedor_resuelve_contrato(monkeypatch):
         class _Contrato:
             route = type("R", (), {"value": "javascript_runtime_bridge"})()
             execution_boundary = "Aislado"
+            language = "javascript"
 
-        return _Contrato()
+        class _Bridge:
+            implementation = "javascript_controlled_runtime_bridge"
 
-    monkeypatch.setattr(execute_module, "_resolver_contrato_binding", _resolver)
+        return _Contrato(), _Bridge()
+
+    monkeypatch.setattr(execute_module, "_resolver_runtime_binding", _resolver)
+    monkeypatch.setattr(
+        execute_module.RUNTIME_MANAGER,
+        "validate_security_route",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        execute_module.RUNTIME_MANAGER,
+        "validate_abi_route",
+        lambda *_args, **_kwargs: "1.0",
+    )
     monkeypatch.setattr(execute_module, "resolve_docker_backend", lambda value: value)
     monkeypatch.setattr(execute_module, "ejecutar_en_contenedor", lambda _codigo, _backend: "ok")
 

--- a/tests/unit/test_runtime_manager.py
+++ b/tests/unit/test_runtime_manager.py
@@ -1,0 +1,33 @@
+from pcobra.cobra.bindings.contract import BindingRoute
+from pcobra.cobra.bindings.runtime_manager import RuntimeManager
+
+
+def test_runtime_manager_resuelve_bridge_python():
+    capabilities, bridge = RuntimeManager().resolve_runtime("python")
+
+    assert capabilities.route is BindingRoute.PYTHON_DIRECT_IMPORT
+    assert bridge.implementation == "python_direct_bridge"
+
+
+def test_runtime_manager_valida_ruta_js_requiere_runtime_gestionado():
+    manager = RuntimeManager()
+
+    try:
+        manager.validate_security_route("javascript", sandbox=False, containerized=False)
+    except ValueError as exc:
+        assert "runtime gestionado" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Se esperaba error de seguridad para JS sin aislamiento")
+
+
+def test_runtime_manager_valida_abi_por_ruta():
+    manager = RuntimeManager()
+
+    assert manager.validate_abi_route("rust", abi_version="1.0") == "1.0"
+
+    try:
+        manager.validate_abi_route("rust", abi_version="2.0")
+    except ValueError as exc:
+        assert "Versiones soportadas" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Se esperaba error ABI por versión no soportada")


### PR DESCRIPTION
### Motivation

- Centralizar la resolución de rutas de binding y las validaciones de seguridad/ABI para evitar lógica ad-hoc replicada en runners y pipelines. 
- Soportar explícitamente las tres rutas solicitadas: bridge Python directo, runtime JS gestionado y FFI Rust compilado. 
- Proveer metadatos de runtime/bridge en el pipeline de build para que los flujos de compilación y ejecución tomen decisiones coherentes.

### Description

- Se creó `src/pcobra/cobra/bindings/runtime_manager.py` con `RuntimeManager` y `RuntimeBridgeDescriptor` que usan `resolve_binding(language)` y modelan las tres rutas (`python_direct_import`, `javascript_runtime_bridge`, `rust_compiled_ffi`) y su versión ABI por defecto (`1.0`).
- Se exportó el manager y constantes relacionadas en `src/pcobra/cobra/bindings/__init__.py` para uso público por runners/pipelines.
- Se integró el manager en `src/pcobra/cobra/cli/commands/execute_cmd.py` reemplazando la resolución directa por `RUNTIME_MANAGER.resolve_runtime(...)` y añadiendo validaciones de seguridad (`validate_security_route`) y ABI (`validate_abi_route`) para los flujos normal, sandbox y contenedor, además de incluir información de bridge/ABI en logs.
- Se añadió `resolve_backend_runtime(...)` en `src/pcobra/cobra/build/backend_pipeline.py` y se agregó la clave `runtime` al resultado de `build(...)` con metadatos (`language`, `route`, `bridge`, `security_profile`, `abi_contract`, `abi_version`).
- Se actualizó `docs/architecture/binding-contract.md` con la sección de versionado ABI, tabla de compatibilidad por backend y reglas de seguridad por ruta, y se añadieron pruebas unitarias en `tests/unit/` para cubrir el manager, la integración en `execute_cmd` y el pipeline.

### Testing

- Se ejecutaron pruebas unitarias específicas con `pytest -q tests/unit/test_bindings_contract.py tests/unit/test_runtime_manager.py tests/unit/test_execute_cmd_binding_contract.py tests/unit/test_backend_pipeline_runtime_manager.py` y todas pasaron (`7 passed`).
- Se añadieron tests nuevos: `tests/unit/test_runtime_manager.py` y `tests/unit/test_backend_pipeline_runtime_manager.py`, y se adaptó `tests/unit/test_execute_cmd_binding_contract.py` para la nueva API del runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df16483a0c83278d5f4b7a6eb1caf5)