### PR TITLE
Refuerza contratos públicos de targets y separa legacy de help

### DIFF
--- a/src/pcobra/cobra/build/orchestrator.py
+++ b/src/pcobra/cobra/build/orchestrator.py
@@ -37,6 +37,9 @@ class BuildOrchestrator:
         "application": ("python", "javascript", "rust"),
     }
 
+    def __init__(self) -> None:
+        self._validate_public_backend_routes_contract()
+
     def resolve_backend(
         self,
         *,
@@ -99,6 +102,26 @@ class BuildOrchestrator:
                 f"Backend no permitido: {value}. Permitidos: {', '.join(OFFICIAL_TARGETS)}"
             )
         return canonical
+
+    def _validate_public_backend_routes_contract(self) -> None:
+        """Asegura que las rutas públicas de selección no usen backends fuera del canon oficial."""
+        official = set(OFFICIAL_TARGETS)
+        covered: set[str] = set()
+        for project_type, priorities in self._PROJECT_TYPE_PRIORITIES.items():
+            invalid = tuple(target for target in priorities if target not in official)
+            if invalid:
+                raise RuntimeError(
+                    "BuildOrchestrator._PROJECT_TYPE_PRIORITIES contiene backends fuera de OFFICIAL_TARGETS. "
+                    f"project_type={project_type}; invalid={invalid}; official={OFFICIAL_TARGETS}"
+                )
+            covered.update(priorities)
+
+        missing = tuple(target for target in OFFICIAL_TARGETS if target not in covered)
+        if missing:
+            raise RuntimeError(
+                "BuildOrchestrator._PROJECT_TYPE_PRIORITIES debe cubrir todos los OFFICIAL_TARGETS. "
+                f"missing={missing}; official={OFFICIAL_TARGETS}"
+            )
 
     def _project_type(self, config: dict[str, Any]) -> str:
         project = config.get("project", {}) if isinstance(config, dict) else {}

--- a/src/pcobra/cobra/cli/target_policies.py
+++ b/src/pcobra/cobra/cli/target_policies.py
@@ -6,6 +6,7 @@ from argparse import ArgumentTypeError
 from typing import Literal
 
 from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS, PUBLIC_BACKENDS
+from pcobra.cobra.config.transpile_targets import OFFICIAL_TARGETS
 from pcobra.cobra.cli.internal_compat.legacy_targets import (
     LEGACY_BACKENDS_FEATURE_FLAG,
     enabled_internal_legacy_targets,
@@ -44,7 +45,7 @@ def accepted_target_aliases_examples_text() -> str:
 
 # Todos los destinos oficiales de generación/transpilación.
 OFFICIAL_TRANSPILATION_TARGETS = require_exact_official_targets(
-    PUBLIC_BACKENDS,
+    OFFICIAL_TARGETS,
     context="pcobra.cobra.cli.target_policies.OFFICIAL_TRANSPILATION_TARGETS",
 )
 
@@ -175,6 +176,32 @@ def _validate_runtime_categories_contract() -> None:
 
 _validate_runtime_categories_contract()
 
+
+def _validate_public_routes_contract() -> None:
+    """Bloquea inicialización si las rutas públicas se salen de PUBLIC_BACKENDS."""
+    if OFFICIAL_TRANSPILATION_TARGETS != PUBLIC_BACKENDS:
+        raise RuntimeError(
+            "OFFICIAL_TRANSPILATION_TARGETS debe ser exactamente PUBLIC_BACKENDS "
+            f"en rutas públicas. official={OFFICIAL_TRANSPILATION_TARGETS}; public={PUBLIC_BACKENDS}"
+        )
+
+    for route_name, route_targets in (
+        ("OFFICIAL_RUNTIME_TARGETS", OFFICIAL_RUNTIME_TARGETS),
+        ("BEST_EFFORT_RUNTIME_TARGETS", BEST_EFFORT_RUNTIME_TARGETS),
+        ("TRANSPILATION_ONLY_TARGETS", TRANSPILATION_ONLY_TARGETS),
+        ("SDK_COMPATIBLE_TARGETS", SDK_COMPATIBLE_TARGETS),
+    ):
+        out_of_contract = tuple(
+            target for target in route_targets if target not in PUBLIC_BACKENDS
+        )
+        if out_of_contract:
+            raise RuntimeError(
+                f"{route_name} contiene backends fuera de PUBLIC_BACKENDS: {out_of_contract}"
+            )
+
+
+_validate_public_routes_contract()
+
 OFFICIAL_TRANSPILATION_TARGETS_HELP = build_target_help_by_tier(OFFICIAL_TRANSPILATION_TARGETS)
 OFFICIAL_RUNTIME_TARGETS_HELP = build_target_help_by_tier(OFFICIAL_RUNTIME_TARGETS)
 VERIFICATION_EXECUTABLE_TARGETS_HELP = build_target_help_by_tier(VERIFICATION_EXECUTABLE_TARGETS)
@@ -247,11 +274,6 @@ def iter_public_policy_items() -> tuple[tuple[str, str, tuple[str, ...]], ...]:
             "Targets solo de transpilación",
             TRANSPILATION_ONLY_TARGETS,
         ),
-        (
-            "legacy_internal_targets",
-            "Targets legacy/internal (no públicos)",
-            INTERNAL_BACKENDS,
-        ),
     )
 
 
@@ -263,11 +285,7 @@ def render_public_policy_summary(*, markup: RenderMarkup = "plain") -> str:
         + " targets canónicos."
     ]
     for policy_id, label, targets in iter_public_policy_items():
-        rendered = (
-            ", ".join(targets)
-            if policy_id == "legacy_internal_targets"
-            else format_target_sequence(targets, markup=markup)
-        )
+        rendered = format_target_sequence(targets, markup=markup)
         lines.append(f"- **{label}**: {rendered}.")
     return "\n".join(lines)
 
@@ -515,15 +533,13 @@ def parse_target(value: str) -> str:
     legacy_enabled = is_internal_legacy_targets_enabled()
     if canonical in enabled_internal_legacy_targets():
         return canonical
-    if canonical not in PUBLIC_BACKENDS:
+    if canonical not in OFFICIAL_TRANSPILATION_TARGETS:
         feature_flag_hint = (
             f" (compat interna temporal: export {LEGACY_BACKENDS_FEATURE_FLAG}=1)"
             if canonical in INTERNAL_BACKENDS and not legacy_enabled
             else ""
         )
         raise ArgumentTypeError(invalid_target_error(value) + feature_flag_hint)
-    if canonical not in OFFICIAL_TRANSPILATION_TARGETS:
-        raise ArgumentTypeError(invalid_target_error(value))
     return canonical
 
 

--- a/src/pcobra/cobra/transpilers/registry.py
+++ b/src/pcobra/cobra/transpilers/registry.py
@@ -10,6 +10,7 @@ from pcobra.cobra.architecture.backend_policy import (
     INTERNAL_BACKENDS,
     PUBLIC_BACKENDS,
 )
+from pcobra.cobra.config.transpile_targets import OFFICIAL_TARGETS
 
 TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
     "python": ("pcobra.cobra.transpilers.transpiler.to_python", "TranspiladorPython"),
@@ -24,7 +25,7 @@ TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
 
 
 PUBLIC_TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
-    target: TRANSPILER_CLASS_PATHS[target] for target in PUBLIC_BACKENDS
+    target: TRANSPILER_CLASS_PATHS[target] for target in OFFICIAL_TARGETS
 }
 
 INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
@@ -61,22 +62,28 @@ def _validate_complete_registry_contract() -> tuple[str, ...]:
 
 
 def _validate_public_registry_contract() -> tuple[str, ...]:
-    """Valida contrato estricto del registro público frente a PUBLIC_BACKENDS."""
+    """Valida contrato estricto del registro público frente a OFFICIAL_TARGETS/PUBLIC_BACKENDS."""
+    if OFFICIAL_TARGETS != PUBLIC_BACKENDS:
+        raise RuntimeError(
+            "[CI CONTRACT] OFFICIAL_TARGETS debe ser equivalente a PUBLIC_BACKENDS para rutas públicas. "
+            f"official={OFFICIAL_TARGETS}; public={PUBLIC_BACKENDS}"
+        )
+
     configured_keys = tuple(PUBLIC_TRANSPILER_CLASS_PATHS)
-    missing = tuple(target for target in PUBLIC_BACKENDS if target not in configured_keys)
-    extras = tuple(target for target in configured_keys if target not in PUBLIC_BACKENDS)
+    missing = tuple(target for target in OFFICIAL_TARGETS if target not in configured_keys)
+    extras = tuple(target for target in configured_keys if target not in OFFICIAL_TARGETS)
 
     if missing or extras:
         raise RuntimeError(
-            "[CI CONTRACT] PUBLIC_TRANSPILER_CLASS_PATHS debe usar exactamente PUBLIC_BACKENDS. "
+            "[CI CONTRACT] PUBLIC_TRANSPILER_CLASS_PATHS debe usar exactamente OFFICIAL_TARGETS. "
             f"missing={missing or '∅'}; extras={extras or '∅'}; "
-            f"current={configured_keys}; expected={PUBLIC_BACKENDS}"
+            f"current={configured_keys}; expected={OFFICIAL_TARGETS}"
         )
 
-    if configured_keys != PUBLIC_BACKENDS:
+    if configured_keys != OFFICIAL_TARGETS:
         raise RuntimeError(
-            "[CI CONTRACT] PUBLIC_TRANSPILER_CLASS_PATHS debe preservar el orden de backend_policy.PUBLIC_BACKENDS. "
-            f"current={configured_keys}; expected={PUBLIC_BACKENDS}"
+            "[CI CONTRACT] PUBLIC_TRANSPILER_CLASS_PATHS debe preservar el orden de config.transpile_targets.OFFICIAL_TARGETS. "
+            f"current={configured_keys}; expected={OFFICIAL_TARGETS}"
         )
     return configured_keys
 
@@ -114,7 +121,7 @@ _ORDERED_INTERNAL_LEGACY_TARGETS: Final[tuple[str, ...]] = (
 
 
 def ordered_official_transpiler_paths() -> tuple[tuple[str, tuple[str, str]], ...]:
-    """Devuelve el registro público en el orden de ``PUBLIC_BACKENDS``."""
+    """Devuelve el registro público en el orden de ``OFFICIAL_TARGETS``."""
     return tuple(
         (target, PUBLIC_TRANSPILER_CLASS_PATHS[target])
         for target in _ORDERED_OFFICIAL_TARGETS


### PR DESCRIPTION
### Motivation
- Centralizar el consumo público de targets en la fuente canónica para evitar listas residuales y discrepancias entre componentes. 
- Prevenir la exposición o uso accidental de backends no públicos en rutas/UX públicas mediante validaciones de contrato en tiempo de inicialización. 
- Mantener la compatibilidad legacy únicamente en namespaces internos y bajo flags de compatibilidad, sin aparecer en la ayuda pública.

### Description
- Reemplacé consumos públicos directos de `PUBLIC_BACKENDS` por `OFFICIAL_TARGETS` en `src/pcobra/cobra/transpilers/registry.py` y `src/pcobra/cobra/cli/target_policies.py` para unificar la fuente canónica. 
- En `src/pcobra/cobra/transpilers/registry.py` ajusté la validación pública para comparar el registro con `OFFICIAL_TARGETS` y exigir orden/cobertura exacta del canon público. 
- En `src/pcobra/cobra/cli/target_policies.py` añadí `_validate_public_routes_contract()` que bloquea la inicialización si las rutas públicas contienen backends fuera de `PUBLIC_BACKENDS`, y eliminé la exposición de `legacy_internal_targets` del resumen público. 
- En `src/pcobra/cobra/build/orchestrator.py` añadí validación en `__init__` (`_validate_public_backend_routes_contract`) que asegura que `_PROJECT_TYPE_PRIORITIES` no incluya backends fuera de `OFFICIAL_TARGETS` y que cubra el conjunto oficial.

### Testing
- Ejecuté `python -m compileall src/pcobra/cobra/config/transpile_targets.py src/pcobra/cobra/transpilers/registry.py src/pcobra/cobra/cli/target_policies.py src/pcobra/cobra/build/orchestrator.py` y la compilación fue exitosa. 
- Ejecuté un smoke test de import/inicialización con `BuildOrchestrator` y lectura de targets públicos (script de import), que devolvió `orchestrator_ok` y los targets oficiales esperados, por lo que el chequeo pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4d3d14488327bd15d6c8f21eede9)