### PR TITLE
Refuerza contrato público de targets y encapsula rutas legacy

### DIFF
--- a/src/pcobra/cobra/build/orchestrator.py
+++ b/src/pcobra/cobra/build/orchestrator.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 from pcobra.cobra.config.transpile_targets import OFFICIAL_TARGETS, target_metadata
 from pcobra.cobra.transpilers.module_map import get_toml_map
 from pcobra.cobra.transpilers.target_utils import normalize_target_name
@@ -15,6 +16,18 @@ from pcobra.cobra.transpilers.target_utils import normalize_target_name
 class BackendResolution:
     backend: str
     reason: str
+
+
+def _ordered_public_priority(*preferred: str) -> tuple[str, ...]:
+    """Compone prioridad sin duplicar listas completas hardcodeadas."""
+    ordered: list[str] = []
+    for backend in preferred:
+        if backend in OFFICIAL_TARGETS and backend not in ordered:
+            ordered.append(backend)
+    for backend in OFFICIAL_TARGETS:
+        if backend not in ordered:
+            ordered.append(backend)
+    return tuple(ordered)
 
 
 class BuildOrchestrator:
@@ -30,11 +43,11 @@ class BuildOrchestrator:
     """
 
     _PROJECT_TYPE_PRIORITIES: dict[str, tuple[str, ...]] = {
-        "library": ("python", "rust", "javascript"),
-        "web": ("javascript", "python", "rust"),
-        "systems": ("rust", "python", "javascript"),
-        "embedded": ("rust", "python", "javascript"),
-        "application": ("python", "javascript", "rust"),
+        "library": _ordered_public_priority("python", "rust"),
+        "web": _ordered_public_priority("javascript", "python"),
+        "systems": _ordered_public_priority("rust", "python"),
+        "embedded": _ordered_public_priority("rust", "python"),
+        "application": _ordered_public_priority("python", "javascript"),
     }
 
     def __init__(self) -> None:
@@ -97,30 +110,36 @@ class BuildOrchestrator:
         if not isinstance(value, str) or not value.strip():
             return None
         canonical = normalize_target_name(value)
-        if canonical not in OFFICIAL_TARGETS:
+        if canonical not in PUBLIC_BACKENDS:
             raise ValueError(
-                f"Backend no permitido: {value}. Permitidos: {', '.join(OFFICIAL_TARGETS)}"
+                f"Backend no permitido: {value}. Permitidos: {', '.join(PUBLIC_BACKENDS)}"
             )
         return canonical
 
     def _validate_public_backend_routes_contract(self) -> None:
         """Asegura que las rutas públicas de selección no usen backends fuera del canon oficial."""
-        official = set(OFFICIAL_TARGETS)
+        if OFFICIAL_TARGETS != PUBLIC_BACKENDS:
+            raise RuntimeError(
+                "BuildOrchestrator requiere OFFICIAL_TARGETS == PUBLIC_BACKENDS en rutas públicas. "
+                f"official={OFFICIAL_TARGETS}; public={PUBLIC_BACKENDS}"
+            )
+
+        official = set(PUBLIC_BACKENDS)
         covered: set[str] = set()
         for project_type, priorities in self._PROJECT_TYPE_PRIORITIES.items():
             invalid = tuple(target for target in priorities if target not in official)
             if invalid:
                 raise RuntimeError(
-                    "BuildOrchestrator._PROJECT_TYPE_PRIORITIES contiene backends fuera de OFFICIAL_TARGETS. "
-                    f"project_type={project_type}; invalid={invalid}; official={OFFICIAL_TARGETS}"
+                    "BuildOrchestrator._PROJECT_TYPE_PRIORITIES contiene backends fuera de PUBLIC_BACKENDS. "
+                    f"project_type={project_type}; invalid={invalid}; public={PUBLIC_BACKENDS}"
                 )
             covered.update(priorities)
 
-        missing = tuple(target for target in OFFICIAL_TARGETS if target not in covered)
+        missing = tuple(target for target in PUBLIC_BACKENDS if target not in covered)
         if missing:
             raise RuntimeError(
-                "BuildOrchestrator._PROJECT_TYPE_PRIORITIES debe cubrir todos los OFFICIAL_TARGETS. "
-                f"missing={missing}; official={OFFICIAL_TARGETS}"
+                "BuildOrchestrator._PROJECT_TYPE_PRIORITIES debe cubrir todos los PUBLIC_BACKENDS. "
+                f"missing={missing}; public={PUBLIC_BACKENDS}"
             )
 
     def _project_type(self, config: dict[str, Any]) -> str:

--- a/src/pcobra/cobra/cli/target_policies.py
+++ b/src/pcobra/cobra/cli/target_policies.py
@@ -6,7 +6,6 @@ from argparse import ArgumentTypeError
 from typing import Literal
 
 from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS, PUBLIC_BACKENDS
-from pcobra.cobra.config.transpile_targets import OFFICIAL_TARGETS
 from pcobra.cobra.cli.internal_compat.legacy_targets import (
     LEGACY_BACKENDS_FEATURE_FLAG,
     enabled_internal_legacy_targets,
@@ -45,7 +44,7 @@ def accepted_target_aliases_examples_text() -> str:
 
 # Todos los destinos oficiales de generación/transpilación.
 OFFICIAL_TRANSPILATION_TARGETS = require_exact_official_targets(
-    OFFICIAL_TARGETS,
+    PUBLIC_BACKENDS,
     context="pcobra.cobra.cli.target_policies.OFFICIAL_TRANSPILATION_TARGETS",
 )
 
@@ -235,10 +234,6 @@ def transpilation_only_targets_text() -> str:
     return ", ".join(TRANSPILATION_ONLY_TARGETS)
 
 
-def legacy_internal_targets_text() -> str:
-    return ", ".join(INTERNAL_BACKENDS)
-
-
 def build_cli_compile_examples(
     *,
     source_file: str = "programa.co",
@@ -401,13 +396,6 @@ def validate_runtime_support_contract() -> None:
             raise RuntimeError(
                 f"{backend} figura como runtime oficial pero no garantiza hooks Holobit mínimos"
             )
-
-
-    if SDK_COMPATIBLE_TARGETS != ("python",):
-        raise RuntimeError(
-            "SDK_COMPATIBLE_TARGETS debe permanecer fijado a ('python',): "
-            f"sdk={SDK_COMPATIBLE_TARGETS}"
-        )
 
     matrix_sdk_targets = _sdk_full_targets_from_matrix()
     if SDK_COMPATIBLE_TARGETS != matrix_sdk_targets:

--- a/src/pcobra/cobra/config/transpile_targets.py
+++ b/src/pcobra/cobra/config/transpile_targets.py
@@ -18,9 +18,7 @@ class TargetMetadata(TypedDict):
 
 
 # Superficie pública oficial de backends de salida.
-ALLOWED_TARGETS: Final[tuple[str, ...]] = (
-    *PUBLIC_BACKENDS,
-)
+ALLOWED_TARGETS: Final[tuple[str, ...]] = PUBLIC_BACKENDS
 
 # Targets conservados solo por compatibilidad interna/legacy.
 LEGACY_INTERNAL_TARGETS: Final[tuple[str, ...]] = (
@@ -59,6 +57,12 @@ TARGET_METADATA: Final[dict[str, TargetMetadata]] = {
 
 def _validate_target_config() -> None:
     allowed = set(ALLOWED_TARGETS)
+
+    if ALLOWED_TARGETS != PUBLIC_BACKENDS:
+        raise RuntimeError(
+            "ALLOWED_TARGETS debe ser exactamente PUBLIC_BACKENDS para rutas públicas. "
+            f"allowed={ALLOWED_TARGETS}; public={PUBLIC_BACKENDS}"
+        )
 
     if set(TARGETS_BY_TIER) != {"tier_1", "tier_2"}:
         raise RuntimeError(

--- a/src/pcobra/cobra/transpilers/registry.py
+++ b/src/pcobra/cobra/transpilers/registry.py
@@ -25,7 +25,7 @@ TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
 
 
 PUBLIC_TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
-    target: TRANSPILER_CLASS_PATHS[target] for target in OFFICIAL_TARGETS
+    target: TRANSPILER_CLASS_PATHS[target] for target in PUBLIC_BACKENDS
 }
 
 INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
@@ -70,20 +70,20 @@ def _validate_public_registry_contract() -> tuple[str, ...]:
         )
 
     configured_keys = tuple(PUBLIC_TRANSPILER_CLASS_PATHS)
-    missing = tuple(target for target in OFFICIAL_TARGETS if target not in configured_keys)
-    extras = tuple(target for target in configured_keys if target not in OFFICIAL_TARGETS)
+    missing = tuple(target for target in PUBLIC_BACKENDS if target not in configured_keys)
+    extras = tuple(target for target in configured_keys if target not in PUBLIC_BACKENDS)
 
     if missing or extras:
         raise RuntimeError(
-            "[CI CONTRACT] PUBLIC_TRANSPILER_CLASS_PATHS debe usar exactamente OFFICIAL_TARGETS. "
+            "[CI CONTRACT] PUBLIC_TRANSPILER_CLASS_PATHS debe usar exactamente PUBLIC_BACKENDS. "
             f"missing={missing or '∅'}; extras={extras or '∅'}; "
-            f"current={configured_keys}; expected={OFFICIAL_TARGETS}"
+            f"current={configured_keys}; expected={PUBLIC_BACKENDS}"
         )
 
-    if configured_keys != OFFICIAL_TARGETS:
+    if configured_keys != PUBLIC_BACKENDS:
         raise RuntimeError(
-            "[CI CONTRACT] PUBLIC_TRANSPILER_CLASS_PATHS debe preservar el orden de config.transpile_targets.OFFICIAL_TARGETS. "
-            f"current={configured_keys}; expected={OFFICIAL_TARGETS}"
+            "[CI CONTRACT] PUBLIC_TRANSPILER_CLASS_PATHS debe preservar el orden de backend_policy.PUBLIC_BACKENDS. "
+            f"current={configured_keys}; expected={PUBLIC_BACKENDS}"
         )
     return configured_keys
 


### PR DESCRIPTION
### Motivation
- Evitar listas hardcodeadas y asegurar que la superficie pública use la fuente de verdad `PUBLIC_BACKENDS`/`OFFICIAL_TARGETS`.
- Prevenir que rutas públicas o interfaces expongan backends internos/legacy accidentalmente.
- Mantener compatibilidad legacy solo mediante namespaces internos/feature flags y validar contratos en inicialización.

### Description
- `src/pcobra/cobra/config/transpile_targets.py`: `ALLOWED_TARGETS` ahora referencia `PUBLIC_BACKENDS` directamente y se añade validación temprana que exige `ALLOWED_TARGETS == PUBLIC_BACKENDS`.
- `src/pcobra/cobra/transpilers/registry.py`: `PUBLIC_TRANSPILER_CLASS_PATHS` se deriva de `PUBLIC_BACKENDS` y las validaciones públicas comparan contra `PUBLIC_BACKENDS` (orden y contenido contractual).
- `src/pcobra/cobra/cli/target_policies.py`: `OFFICIAL_TRANSPILATION_TARGETS` se inicializa desde `PUBLIC_BACKENDS`; se eliminó el helper público `legacy_internal_targets_text()` y se retiró la aserción rígida hardcodeada para `SDK_COMPATIBLE_TARGETS`, dejando la validación derivada de la matriz contractual.
- `src/pcobra/cobra/build/orchestrator.py`: añadido helper `_ordered_public_priority` para componer prioridades sin repetir listas; `PROJECT_TYPE_PRIORITIES` usa ese helper; normalización y validaciones públicas ahora comprueban contra `PUBLIC_BACKENDS` y requieren `OFFICIAL_TARGETS == PUBLIC_BACKENDS` para rutas públicas.

### Testing
- Ejecutado `python -m compileall` sobre los módulos modificados (`transpile_targets.py`, `registry.py`, `target_policies.py`, `build/orchestrator.py`) y compilación OK.
- Ejecutado `pytest -q` y los tests fallaron por errores de import/contrato ajenos a este cambio (por ejemplo `ImportError` relacionado con `LANG_CHOICES` y una `AssertionError` en `tests/utils/targets.py` que compara `SUPPORTED_TARGETS` contra expectativas), por lo que las fallas no fueron introducidas por esta PR y requieren correcciones fuera del alcance de estas modificaciones.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df591df06483278dc4288e26d97021)