### PR TITLE
Add lifecycle metadata for internal legacy backends

### DIFF
--- a/docs/issues/target_cleanup_checklist.md
+++ b/docs/issues/target_cleanup_checklist.md
@@ -139,6 +139,18 @@ Antes de fusionar cambios de política:
 - [x] Contrato de compatibilidad por backend validado (`python scripts/validate_runtime_contract.py`).
 - [x] Cualquier guardrail en fallo bloquea merge (jobs CI en estado failed).
 
+## Checklist de retiro seguro por backend interno
+
+> Fuente canónica: `src/pcobra/cobra/architecture/legacy_backend_lifecycle.py` (consumida por CLI y documentación).
+
+| Backend | Estado lifecycle | Target público recomendado | Checklist de retiro seguro |
+| --- | --- | --- | --- |
+| `go` | `active-migration` | `rust` | 1) Inventariar jobs/pipelines internos que todavía emiten `--tipo go`. 2) Migrar cada pipeline a `rust` con validación de salida funcional. 3) Eliminar banderas temporales (`COBRA_INTERNAL_LEGACY_TARGETS`) asociadas a esos flujos. |
+| `cpp` | `active-migration` | `rust` | 1) Congelar nuevas dependencias a backend `cpp`. 2) Migrar scripts de CI y fixtures a `rust`. 3) Borrar referencias en tooling interno cuando no queden consumidores activos. |
+| `java` | `active-migration` | `javascript` | 1) Reemplazar comandos internos `--tipo java` por `javascript`. 2) Confirmar paridad mínima de runtime (`corelibs`/`standard_library`) en los casos migrados. 3) Retirar snippets/doc interna que todavía instruyan `java`. |
+| `wasm` | `frozen` | `javascript` | 1) Mantener solo fixes críticos (sin features nuevas). 2) Documentar explícitamente dependencias host-managed restantes. 3) Definir fecha de congelamiento final y plan de salida a target público. |
+| `asm` | `removal-candidate` | `python` | 1) Confirmar que se usa solo en diagnóstico acotado. 2) Sustituir validaciones automáticas por alternativas en `python`. 3) Programar PR de retiro definitivo con limpieza de `to_asm.py`, `asm_nodes` y `asm.golden` cuando quede sin uso. |
+
 ## Registro de ejecución (2026-03-28)
 
 Este bloque deja trazabilidad explícita de la ejecución por fases solicitada para

--- a/src/pcobra/cobra/architecture/legacy_backend_lifecycle.py
+++ b/src/pcobra/cobra/architecture/legacy_backend_lifecycle.py
@@ -1,0 +1,93 @@
+"""Metadata contractual del ciclo de vida de backends legacy internos.
+
+Este módulo centraliza el estado de retiro de cada backend **interno** para que
+CLI y documentación compartan el mismo inventario.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal
+
+from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS
+
+LegacyLifecycleStatus = Literal["active-migration", "frozen", "removal-candidate"]
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyBackendLifecycle:
+    """Describe el estado de retiro de un backend interno."""
+
+    status: LegacyLifecycleStatus
+    recommended_public_target: str
+    owner_track: str
+    notes: str
+
+
+LEGACY_BACKEND_LIFECYCLE: Final[dict[str, LegacyBackendLifecycle]] = {
+    "go": LegacyBackendLifecycle(
+        status="active-migration",
+        recommended_public_target="rust",
+        owner_track="runtime-migration",
+        notes="Backend interno con uso residual en migración activa de pipelines.",
+    ),
+    "cpp": LegacyBackendLifecycle(
+        status="active-migration",
+        recommended_public_target="rust",
+        owner_track="runtime-migration",
+        notes="Se mantiene temporalmente por compatibilidad de integraciones históricas.",
+    ),
+    "java": LegacyBackendLifecycle(
+        status="active-migration",
+        recommended_public_target="javascript",
+        owner_track="runtime-migration",
+        notes="Uso interno controlado durante el retiro de rutas no públicas.",
+    ),
+    "wasm": LegacyBackendLifecycle(
+        status="frozen",
+        recommended_public_target="javascript",
+        owner_track="maintenance-only",
+        notes="Congelado: solo correcciones críticas sin expansión funcional.",
+    ),
+    "asm": LegacyBackendLifecycle(
+        status="removal-candidate",
+        recommended_public_target="python",
+        owner_track="decommission",
+        notes="Candidato explícito a retiro; mantener únicamente para diagnóstico acotado.",
+    ),
+}
+
+
+def _validate_legacy_lifecycle_contract() -> None:
+    configured = tuple(LEGACY_BACKEND_LIFECYCLE)
+    missing = tuple(target for target in INTERNAL_BACKENDS if target not in configured)
+    extras = tuple(target for target in configured if target not in INTERNAL_BACKENDS)
+    if missing or extras:
+        raise RuntimeError(
+            "LEGACY_BACKEND_LIFECYCLE debe cubrir exactamente INTERNAL_BACKENDS. "
+            f"missing={missing or '∅'}; extras={extras or '∅'}; "
+            f"configured={configured}; expected={INTERNAL_BACKENDS}"
+        )
+
+
+_validate_legacy_lifecycle_contract()
+
+
+def lifecycle_status_for_backend(target: str) -> LegacyLifecycleStatus:
+    """Devuelve el estado de retiro para un backend interno."""
+    return LEGACY_BACKEND_LIFECYCLE[target].status
+
+
+def legacy_backend_warning_message(*, target: str, route: str) -> str:
+    """Mensaje único para advertencias de uso por rutas no públicas."""
+    metadata = LEGACY_BACKEND_LIFECYCLE[target]
+    return (
+        f"[INTERNAL LEGACY BACKEND] '{target}' usado vía ruta no pública ({route}). "
+        f"estado={metadata.status}; destino público recomendado={metadata.recommended_public_target}; "
+        "uso permitido solo para migración interna temporal."
+    )
+
+
+def iter_legacy_backend_lifecycle_rows() -> tuple[tuple[str, LegacyBackendLifecycle], ...]:
+    """Filas ordenadas para consumo en CLI/docs."""
+    return tuple((backend, LEGACY_BACKEND_LIFECYCLE[backend]) for backend in INTERNAL_BACKENDS)

--- a/src/pcobra/cobra/cli/target_policies.py
+++ b/src/pcobra/cobra/cli/target_policies.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from argparse import ArgumentTypeError
+import warnings
 from typing import Literal
 
 from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS, PUBLIC_BACKENDS
+from pcobra.cobra.architecture.legacy_backend_lifecycle import (
+    legacy_backend_warning_message,
+)
 from pcobra.cobra.cli.internal_compat.legacy_targets import (
     LEGACY_BACKENDS_FEATURE_FLAG,
     enabled_internal_legacy_targets,
@@ -520,6 +524,14 @@ def parse_target(value: str) -> str:
     canonical = normalize_target_name(raw)
     legacy_enabled = is_internal_legacy_targets_enabled()
     if canonical in enabled_internal_legacy_targets():
+        warnings.warn(
+            legacy_backend_warning_message(
+                target=canonical,
+                route=f"CLI.parse_target ({LEGACY_BACKENDS_FEATURE_FLAG}=1)",
+            ),
+            category=UserWarning,
+            stacklevel=2,
+        )
         return canonical
     if canonical not in OFFICIAL_TRANSPILATION_TARGETS:
         feature_flag_hint = (

--- a/src/pcobra/cobra/transpilers/registry.py
+++ b/src/pcobra/cobra/transpilers/registry.py
@@ -10,6 +10,9 @@ from pcobra.cobra.architecture.backend_policy import (
     INTERNAL_BACKENDS,
     PUBLIC_BACKENDS,
 )
+from pcobra.cobra.architecture.legacy_backend_lifecycle import (
+    lifecycle_status_for_backend,
+)
 from pcobra.cobra.config.transpile_targets import OFFICIAL_TARGETS
 
 TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
@@ -30,6 +33,12 @@ PUBLIC_TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
 
 INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
     target: TRANSPILER_CLASS_PATHS[target] for target in INTERNAL_BACKENDS
+}
+INTERNAL_LEGACY_TRANSPILER_LIFECYCLE_STATUS: Final[
+    dict[str, str]
+] = {
+    target: lifecycle_status_for_backend(target)
+    for target in INTERNAL_BACKENDS
 }
 
 
@@ -132,6 +141,18 @@ def ordered_internal_legacy_transpiler_paths() -> tuple[tuple[str, tuple[str, st
     """Devuelve el inventario legacy interno en orden contractual."""
     return tuple(
         (target, INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS[target])
+        for target in _ORDERED_INTERNAL_LEGACY_TARGETS
+    )
+
+
+def ordered_internal_legacy_transpiler_entries() -> tuple[tuple[str, tuple[str, str], str], ...]:
+    """Devuelve inventario interno legacy con etiqueta de estado lifecycle."""
+    return tuple(
+        (
+            target,
+            INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS[target],
+            INTERNAL_LEGACY_TRANSPILER_LIFECYCLE_STATUS[target],
+        )
         for target in _ORDERED_INTERNAL_LEGACY_TARGETS
     )
 

--- a/tests/unit/test_legacy_backend_lifecycle.py
+++ b/tests/unit/test_legacy_backend_lifecycle.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS
+from pcobra.cobra.architecture.legacy_backend_lifecycle import (
+    LEGACY_BACKEND_LIFECYCLE,
+    iter_legacy_backend_lifecycle_rows,
+    legacy_backend_warning_message,
+)
+from pcobra.cobra.transpilers.registry import (
+    INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS,
+    INTERNAL_LEGACY_TRANSPILER_LIFECYCLE_STATUS,
+    ordered_internal_legacy_transpiler_entries,
+)
+
+
+def test_lifecycle_metadata_cubre_todos_los_backends_internos():
+    assert tuple(LEGACY_BACKEND_LIFECYCLE) == INTERNAL_BACKENDS
+
+
+def test_registry_internal_legacy_expone_etiqueta_lifecycle_por_backend():
+    assert tuple(INTERNAL_LEGACY_TRANSPILER_LIFECYCLE_STATUS) == INTERNAL_BACKENDS
+    for backend in INTERNAL_BACKENDS:
+        assert backend in INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS
+        assert INTERNAL_LEGACY_TRANSPILER_LIFECYCLE_STATUS[backend] in {
+            "active-migration",
+            "frozen",
+            "removal-candidate",
+        }
+
+
+def test_ordered_internal_legacy_entries_incluye_estado():
+    entries = ordered_internal_legacy_transpiler_entries()
+    assert tuple(entry[0] for entry in entries) == INTERNAL_BACKENDS
+    assert all(len(entry) == 3 for entry in entries)
+
+
+def test_warning_message_usa_formato_unificado():
+    msg = legacy_backend_warning_message(target="asm", route="CLI.parse_target")
+    assert "ruta no pública" in msg
+    assert "estado=removal-candidate" in msg
+    assert "destino público recomendado=python" in msg
+
+
+def test_iter_rows_respeta_orden_canonic():
+    rows = iter_legacy_backend_lifecycle_rows()
+    assert tuple(backend for backend, _ in rows) == INTERNAL_BACKENDS

--- a/tests/unit/test_target_policies.py
+++ b/tests/unit/test_target_policies.py
@@ -37,3 +37,9 @@ def test_parse_target_list_rechaza_valores_fuera_del_set_canonico_en_cualquier_p
 
     with pytest.raises(ArgumentTypeError):
         parse_target_list("python,fantasy")
+
+
+def test_parse_target_emite_advertencia_consistente_en_backend_interno(monkeypatch):
+    monkeypatch.setenv("COBRA_INTERNAL_LEGACY_TARGETS", "1")
+    with pytest.warns(UserWarning, match=r"INTERNAL LEGACY BACKEND.*estado=active-migration"):
+        assert parse_target("go") == "go"


### PR DESCRIPTION
### Motivation

- Centralizar el estado de retiro de los backends internos legacy para que CLI, registro y docs compartan la misma fuente de verdad. 
- Emitir advertencias consistentes cuando se permita el uso de backends internos a través de rutas no públicas y facilitar una hoja de ruta operativa de retiro. 

### Description

- Añade `src/pcobra/cobra/architecture/legacy_backend_lifecycle.py` con metadata per-backend (`active-migration`, `frozen`, `removal-candidate`), validación de cobertura y utilidades para mensajes y filas ordenadas. 
- Marca las entradas internas en `src/pcobra/cobra/transpilers/registry.py` con `INTERNAL_LEGACY_TRANSPILER_LIFECYCLE_STATUS` y expone `ordered_internal_legacy_transpiler_entries()` que devuelve `(target, class_path, status)`. 
- Emite un `UserWarning` consistente desde `parse_target` (CLI) cuando un backend interno se acepta vía la flag temporal `COBRA_INTERNAL_LEGACY_TARGETS=1`, reutilizando el builder de mensajes del nuevo módulo. 
- Actualiza `docs/issues/target_cleanup_checklist.md` con un checklist operativo por backend alineado al lifecycle metadata y añade tests unitarios que cubren el contrato y la emisión de advertencias. 

### Testing

- Ejecutados: `pytest -q tests/unit/test_legacy_backend_lifecycle.py tests/unit/test_target_policies.py tests/unit/test_registry_contract_guardrail.py`. 
- Resultado: todos los tests pasaron (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df6935b4e083278034376e218cedf9)