### PR TITLE
CLI: hacer `v2` pública por defecto y encapsular comandos legacy en perfil development

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -45,6 +45,7 @@ from pcobra.cobra.cli.commands.validar_sintaxis_cmd import ValidarSintaxisComman
 from pcobra.cobra.cli.commands.qa_validar_cmd import QaValidarCommand
 from pcobra.cobra.cli.commands_v2 import (
     BuildCommandV2,
+    COBRA_ENABLE_LEGACY_CLI_ENV,
     LegacyCommandGroupV2,
     ModCommandV2,
     RunCommandV2,
@@ -141,11 +142,21 @@ class CommandRegistry:
         self,
         subparsers: Any,
         *,
-        ui: str = "v1",
+        ui: str = "v2",
         profile: str = PROFILE_PUBLIC,
     ) -> Dict[str, BaseCommand]:
         base_commands = []
         command_classes = AppConfig.V2_COMMAND_CLASSES if ui == "v2" else AppConfig.BASE_COMMAND_CLASSES
+        if ui == "v2" and profile == PROFILE_DEVELOPMENT and LegacyCommandGroupV2 is None:
+            try:
+                from pcobra.cobra.cli.commands_v2.legacy_cmd import LegacyCommandGroupV2 as _LegacyCommandGroupV2
+                command_classes = command_classes + [_LegacyCommandGroupV2]
+            except Exception as exc:
+                logging.getLogger(__name__).debug(
+                    "No fue posible cargar grupo legacy para perfil development: %s",
+                    exc,
+                )
+
         for cmd_class in command_classes:
             try:
                 base_commands.append(self.create_command(cmd_class))
@@ -212,7 +223,7 @@ class CliApplication:
         self.command_registry: Optional[CommandRegistry] = None
         self._subparsers: Optional[argparse._SubParsersAction] = None
         self._commands_registered = False
-        self._selected_ui = "v1"
+        self._selected_ui = "v2"
 
     @contextmanager
     def resource_management(self) -> ContextManager[None]:
@@ -247,7 +258,7 @@ class CliApplication:
         command_profile = resolve_command_profile()
         self.command_registry.register_base_commands(
             self._subparsers,
-            ui=getattr(self, "_selected_ui", "v1"),
+            ui=getattr(self, "_selected_ui", "v2"),
             profile=command_profile,
         )
         menu_parser = self._subparsers.add_parser("menu", help=_("Modo interactivo"))
@@ -368,11 +379,13 @@ class CliApplication:
         parser.add_argument(
             "--ui",
             choices=("v1", "v2"),
-            default="v1",
+            default="v2",
             help=_(
-                "Selecciona la interfaz CLI: v1 (legacy) o v2 (superficie pública run/build/test/mod). "
-                "Los comandos internos quedan disponibles solo en desarrollo explícito (COBRA_DEV_MODE=1 "
-                "o COBRA_CLI_COMMAND_PROFILE=development)."
+                "Selecciona la interfaz CLI: v2 (recomendada para usuarios finales) o v1 (compatibilidad legacy). "
+                "En v2, la superficie pública es run/build/test/mod. "
+                "Los comandos internos quedan disponibles solo en perfil development "
+                "(COBRA_DEV_MODE=1 o COBRA_CLI_COMMAND_PROFILE=development) "
+                f"o con {COBRA_ENABLE_LEGACY_CLI_ENV}=1."
             ),
         )
         parser.add_argument("--lang",
@@ -571,7 +584,7 @@ class CliApplication:
 
         preliminary_args, _ = self.parser.parse_known_args(argv)
         preliminary_args = self._normalizar_flags_sesion(preliminary_args)
-        self._selected_ui = str(getattr(preliminary_args, "ui", "v1")).strip().lower()
+        self._selected_ui = str(getattr(preliminary_args, "ui", "v2")).strip().lower()
         configure_plugin_policy(
             safe_mode=getattr(preliminary_args, "plugins_safe_mode", True),
             allowlist=getattr(preliminary_args, "plugins_allowlist", ""),

--- a/tests/integration/golden/cli_help_public_no_legacy.golden
+++ b/tests/integration/golden/cli_help_public_no_legacy.golden
@@ -31,7 +31,7 @@ options:
                         (solo generar código), mixto (ejecutar y transpilar).
   --solo-cobra          Alias semántico de --modo cobra: sesión para solo
                         programar/interpretar Cobra sin rutas de codegen.
-  --ui {v1,v2}          Selecciona la interfaz CLI: v1 (legacy) o v2 (superficie pública run/build/test/mod). Los comandos internos quedan disponibles solo en desarrollo explícito (COBRA_DEV_MODE=1 o COBRA_CLI_COMMAND_PROFILE=development).
+  --ui {v1,v2}          Selecciona la interfaz CLI: v2 (recomendada para usuarios finales) o v1 (compatibilidad legacy). En v2, la superficie pública es run/build/test/mod. Los comandos internos quedan disponibles solo en perfil development (COBRA_DEV_MODE=1 o COBRA_CLI_COMMAND_PROFILE=development) o con COBRA_ENABLE_LEGACY_CLI=1.
   --lang LANG           Interface language code
   --no-color            Disable colored output
   --extra-validators EXTRA_VALIDATORS

--- a/tests/integration/golden/cli_ui_v2_help_public.golden
+++ b/tests/integration/golden/cli_ui_v2_help_public.golden
@@ -31,7 +31,7 @@ options:
                         (solo generar código), mixto (ejecutar y transpilar).
   --solo-cobra          alias semántico de --modo cobra: sesión para solo
                         programar/interpretar cobra sin rutas de codegen.
-  --ui {v1,v2}          selecciona la interfaz cli: v1 (legacy) o v2 (superficie pública run/build/test/mod). los comandos internos quedan disponibles solo en desarrollo explícito (cobra_dev_mode=1 o cobra_cli_command_profile=development).
+  --ui {v1,v2}          selecciona la interfaz cli: v2 (recomendada para usuarios finales) o v1 (compatibilidad legacy). en v2, la superficie pública es run/build/test/mod. los comandos internos quedan disponibles solo en perfil development (cobra_dev_mode=1 o cobra_cli_command_profile=development) o con cobra_enable_legacy_cli=1.
   --lang lang           interface language code
   --no-color            disable colored output
   --extra-validators extra_validators

--- a/tests/integration/test_cli_ui_v2.py
+++ b/tests/integration/test_cli_ui_v2.py
@@ -67,7 +67,7 @@ def test_cli_ui_v2_sin_flag_no_registra_legacy(monkeypatch):
 
 
 def test_cli_ui_v2_modo_desarrollo_expone_comandos_internos(monkeypatch):
-    monkeypatch.setenv("COBRA_ENABLE_LEGACY_CLI", "1")
+    monkeypatch.delenv("COBRA_ENABLE_LEGACY_CLI", raising=False)
     monkeypatch.setenv("COBRA_DEV_MODE", "1")
     for module_name in (
         "cobra.cli.commands_v2",


### PR DESCRIPTION
### Motivation
- Unificar la experiencia para usuario final exponiendo la superficie pública `v2` como ruta por defecto y evitando que rutas legacy internas aparezcan en `--help` público.
- Mantener compatibilidad interna con los comandos legacy delegando la ejecución a los módulos antiguos sin exponerlos públicamente.
- Permitir que el grupo `legacy` esté disponible en sesiones de `development` (o por feature-flag) sin requerir que la flag esté presente para el modo de desarrollo.

### Description
- Cambiado el valor por defecto de la UI a `v2` en la construcción del parser y en el registro de comandos (`_selected_ui` y argumento `--ui` ahora `default="v2"`).
- Hice que `CommandRegistry.register_base_commands` use `ui="v2"` por defecto y añadí carga dinámica del `LegacyCommandGroupV2` cuando `ui=="v2"` y `profile==PROFILE_DEVELOPMENT` si el grupo no estaba presente por la flag de import.
- Actualicé el texto de ayuda de `--ui` para recomendar `v2` a usuarios finales y documentar las condiciones en las que los comandos internos/legacy quedan expuestos (`COBRA_DEV_MODE` / `COBRA_CLI_COMMAND_PROFILE` / `COBRA_ENABLE_LEGACY_CLI`).
- No se cambió la delegación a comandos legacy; los comandos `RunCommandV2`, `BuildCommandV2`, `TestCommandV2`, `ModCommandV2` siguen delegando internamente a las implementaciones antiguas para preservar compatibilidad.
- Actualizados snapshots/golden de ayuda y ajuste menor en la prueba de integración para reflejar que `development` expone internals sin depender de la feature-flag.

### Testing
- Ejecuté compilación rápida con `python -m compileall -q src/pcobra/cobra/cli/cli.py tests/integration/test_cli_ui_v2.py` y finalizó correctamente.
- Intenté ejecutar la batería específica con `pytest -q tests/integration/test_cli_ui_v2.py::test_cli_ui_v2_help_snapshot_publico_no_expone_legacy ...`, pero la ejecución falló antes de correr los tests debido a un `ImportError: cannot import name 'LANG_CHOICES' from pcobra.cobra.cli.commands.compile_cmd`, que es un error de importación preexistente que bloqueó la ejecución de las pruebas seleccionadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9868b96483278534c97b444cb230)