### PR TITLE
Unify public run/build/test compilation flow via backend_pipeline

### DIFF
--- a/docs/architecture/adr-unified-backends.md
+++ b/docs/architecture/adr-unified-backends.md
@@ -41,6 +41,15 @@ Durante esta fase se declara explícitamente que **lexer, parser, AST y transpil
 
 Cualquier ajuste en esas piezas debe mantenerse como cambio interno sin impacto en la API pública estable.
 
+#### Nota explícita sobre transpiladores internos
+
+Los módulos `pcobra.cobra.transpilers.transpiler.to_python`,
+`pcobra.cobra.transpilers.transpiler.to_js` y
+`pcobra.cobra.transpilers.transpiler.to_rust` son **detalles internos de implementación**.
+
+No forman parte de la API pública para usuarios finales ni para integraciones externas:
+la ruta pública soportada es el pipeline de build/orquestación (`run/build/test` + backend pipeline).
+
 ## Consecuencias
 
 ### Positivas

--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -58,28 +58,33 @@ def transpile(ast: Any, backend: str) -> str:
     return transpiler.generate_code(ast)
 
 
-def build(source: str, mode: dict[str, Any] | str | None = None) -> dict[str, Any]:
-    """Pipeline completo: resolver backend, construir AST y transpilar código."""
-    hints: dict[str, Any]
-    if isinstance(mode, dict):
-        hints = dict(mode)
-    else:
-        hints = {"preferred_backend": mode} if mode else {}
+def build(source: str, hints: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Pipeline completo: resolver backend, construir AST y transpilar código.
+
+    Contrato interno de invocación: ``build(source, hints)``.
+    """
+    context = dict(hints or {})
 
     source_path = Path(source)
     if source_path.exists() and source_path.is_file():
         source_file = str(source_path)
         codigo = source_path.read_text(encoding="utf-8")
     else:
-        source_file = str(hints.get("source_file", "<memory>"))
+        source_file = str(context.get("source_file", "<memory>"))
         codigo = source
 
-    resolution, runtime_context = resolve_backend_runtime(source_file, hints)
+    resolution, runtime_context = resolve_backend_runtime(source_file, context)
     ast = obtener_ast(codigo)
     code = transpile(ast, resolution.backend)
+    debug = bool(context.get("debug", False))
+    reason = (
+        resolution.reason_for(debug=debug)
+        if hasattr(resolution, "reason_for")
+        else (getattr(resolution, "reason", None) if debug else None)
+    )
     return {
         "backend": resolution.backend,
-        "reason": resolution.reason,
+        "reason": reason,
         "runtime": runtime_context,
         "ast": ast,
         "code": code,

--- a/src/pcobra/cobra/build/orchestrator.py
+++ b/src/pcobra/cobra/build/orchestrator.py
@@ -17,6 +17,10 @@ class BackendResolution:
     backend: str
     reason: str
 
+    def reason_for(self, *, debug: bool) -> str | None:
+        """Expone razón solo cuando el flujo se ejecuta en modo debug."""
+        return self.reason if debug else None
+
 
 def _ordered_public_priority(*preferred: str) -> tuple[str, ...]:
     """Compone prioridad sin duplicar listas completas hardcodeadas."""

--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -352,8 +352,7 @@ class CompileCommand(BaseCommand):
         lang, ast = parametros
         backend_pipeline.TRANSPILERS = TRANSPILERS
         code = backend_pipeline.transpile(ast, lang)
-        transp = TRANSPILERS[lang]()
-        return lang, transp.__class__.__name__, code
+        return lang, code
 
     def run(self, args):
         """Ejecuta la lógica del comando."""
@@ -443,10 +442,9 @@ class CompileCommand(BaseCommand):
                 
                 try:
                     resultados = run_transpiler_pool(lenguajes, ast, self._ejecutar_transpilador)
-                    for lang, nombre, resultado in resultados:
+                    for lang, resultado in resultados:
                         mostrar_info(
-                            _("Código generado ({nombre}) para {lang}:").format(
-                                nombre=nombre,
+                            _("Código generado para {lang}:").format(
                                 lang=f"{target_label(lang)} ({lang})",
                             )
                         )
@@ -460,11 +458,8 @@ class CompileCommand(BaseCommand):
                     raise ValueError(_("Transpilador no soportado."))
                 backend_pipeline.TRANSPILERS = TRANSPILERS
                 resultado = backend_pipeline.transpile(ast, transpilador)
-                transp = TRANSPILERS[transpilador]()
                 mostrar_info(
-                    _("Código generado ({name}):").format(
-                        name=transp.__class__.__name__
-                    )
+                    _("Código generado:")
                 )
                 print(resultado)
             return 0

--- a/src/pcobra/cobra/cli/commands_v2/build_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/build_cmd.py
@@ -25,6 +25,7 @@ class BuildCommandV2(BaseCommand):
         return parser
 
     def run(self, args: Any) -> int:
+        debug = bool(getattr(args, "debug", False))
         resolution = backend_pipeline.resolve_backend(args.file, {})
         legacy_args = Namespace(
             archivo=args.file,
@@ -32,6 +33,6 @@ class BuildCommandV2(BaseCommand):
             backend=None,
             tipos=None,
             modo=getattr(args, "modo", "mixto"),
-            backend_reason=resolution.reason,
+            backend_reason=resolution.reason_for(debug=debug),
         )
         return self._legacy.run(legacy_args)

--- a/src/pcobra/cobra/cli/commands_v2/run_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/run_cmd.py
@@ -1,6 +1,7 @@
 from argparse import Namespace
 from typing import Any
 
+from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
 from pcobra.cobra.cli.i18n import _
@@ -32,6 +33,8 @@ class RunCommandV2(BaseCommand):
         return parser
 
     def run(self, args: Any) -> int:
+        debug = bool(getattr(args, "debug", False))
+        resolution = backend_pipeline.resolve_backend(args.file, {})
         legacy_args = Namespace(
             archivo=args.file,
             debug=bool(getattr(args, "debug", False)),
@@ -39,5 +42,6 @@ class RunCommandV2(BaseCommand):
             contenedor=getattr(args, "container", None),
             formatear=bool(getattr(args, "formatear", False)),
             modo=getattr(args, "modo", "mixto"),
+            backend_reason=resolution.reason_for(debug=debug),
         )
         return self._legacy.run(legacy_args)

--- a/src/pcobra/cobra/cli/commands_v2/test_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/test_cmd.py
@@ -1,6 +1,7 @@
 from argparse import Namespace
 from typing import Any
 
+from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
 from pcobra.cobra.cli.i18n import _
@@ -42,10 +43,13 @@ class TestCommandV2(BaseCommand):
         return parser
 
     def run(self, args: Any) -> int:
+        debug = bool(getattr(args, "debug", False))
+        resolution = backend_pipeline.resolve_backend(args.file, {})
         langs = getattr(args, "langs", self._default_langs)
         legacy_args = Namespace(
             archivo=args.file,
             lenguajes=langs,
             modo=getattr(args, "modo", "mixto"),
+            backend_reason=resolution.reason_for(debug=debug),
         )
         return self._legacy.run(legacy_args)

--- a/tests/unit/test_backend_pipeline_runtime_manager.py
+++ b/tests/unit/test_backend_pipeline_runtime_manager.py
@@ -25,8 +25,33 @@ def test_backend_pipeline_build_expone_contexto_runtime(monkeypatch):
     monkeypatch.setattr(backend_pipeline, "obtener_ast", lambda _codigo: ["ast"])
     monkeypatch.setattr(backend_pipeline, "TRANSPILERS", {"python": _DummyTranspiler})
 
-    result = backend_pipeline.build("imprimir(1)", mode="python")
+    result = backend_pipeline.build("imprimir(1)", hints={"preferred_backend": "python"})
 
     assert result["backend"] == "python"
+    assert result["reason"] is None
     assert result["runtime"]["abi_version"] == "1.0"
     assert result["runtime"]["route"] == "python_direct_import"
+
+
+def test_backend_pipeline_build_expone_reason_solo_en_debug(monkeypatch):
+    monkeypatch.setattr(
+        backend_pipeline,
+        "resolve_backend_runtime",
+        lambda source, hints=None: (
+            type("R", (), {"backend": "python", "reason": "debug-reason"})(),
+            {
+                "language": "python",
+                "route": "python_direct_import",
+                "bridge": "python_direct_bridge",
+                "security_profile": "same_process_safe_mode",
+                "abi_contract": "Contrato Python estable por API pública y typing",
+                "abi_version": "1.0",
+            },
+        ),
+    )
+    monkeypatch.setattr(backend_pipeline, "obtener_ast", lambda _codigo: ["ast"])
+    monkeypatch.setattr(backend_pipeline, "TRANSPILERS", {"python": _DummyTranspiler})
+
+    result = backend_pipeline.build("imprimir(1)", hints={"preferred_backend": "python", "debug": True})
+
+    assert result["reason"] == "debug-reason"

--- a/tests/unit/test_cli_v2_command_contract.py
+++ b/tests/unit/test_cli_v2_command_contract.py
@@ -3,6 +3,7 @@ import argparse
 import pytest
 
 from cobra.cli.commands_v2.run_cmd import RunCommandV2
+from cobra.cli.commands_v2.build_cmd import BuildCommandV2
 from cobra.cli.commands_v2.test_cmd import TestCommandV2
 from cobra.cli.target_policies import VERIFICATION_EXECUTABLE_TARGETS
 
@@ -34,3 +35,23 @@ def test_test_v2_langs_es_opcional_y_usa_default_de_politica_oficial():
     parsed = parser.parse_args(["programa.co"])
 
     assert parsed.langs == list(VERIFICATION_EXECUTABLE_TARGETS)
+
+
+def test_build_v2_resuelve_backend_via_pipeline(monkeypatch):
+    command = BuildCommandV2()
+    called = {}
+
+    monkeypatch.setattr(
+        "cobra.cli.commands_v2.build_cmd.backend_pipeline.resolve_backend",
+        lambda file, hints: called.setdefault(
+            "resolution",
+            type("R", (), {"backend": "python", "reason_for": lambda self, debug: None})(),
+        ),
+    )
+    monkeypatch.setattr(command._legacy, "run", lambda _args: 0)
+
+    status = command.run(
+        argparse.Namespace(file="programa.co", modo="mixto", debug=False)
+    )
+    assert status == 0
+    assert "resolution" in called


### PR DESCRIPTION
### Motivation

- Forzar que las rutas públicas de compilación/ejecución (`run/build/test`) usen el pipeline unificado para evitar instanciaciones directas de transpilers desde la CLI. 
- Centralizar y controlar la exposición del motivo de resolución de backend para no filtrar información en modo normal. 
- Normalizar un contrato interno de invocación del pipeline (`build(source, hints)`) para facilitar extensiones futuras sin tocar transpilers. 
- Documentar explícitamente que los módulos `to_python/to_js/to_rust` son detalles internos de implementación y no forman parte de la API pública.

### Description

- Añadido `BackendResolution.reason_for(debug=...)` para exponer `reason` solo en modo debug y evitar filtrados en ejecución normal; implementado en `src/pcobra/cobra/build/orchestrator.py`. 
- Cambiado el contrato de `backend_pipeline.build` a `build(source, hints)` y la función ahora aplica gating del `reason` según `debug`; preserva compatibilidad con mocks que no implementen `reason_for` en `src/pcobra/cobra/build/backend_pipeline.py`. 
- Rutas públicas v2 (`run`, `build`, `test`) ahora resuelven backend vía `pcobra.cobra.build.backend_pipeline.resolve_backend(...)` antes de delegar en legacy, y pasan `backend_reason` solo en debug (`src/pcobra/cobra/cli/commands_v2/run_cmd.py`, `build_cmd.py`, `test_cmd.py`). 
- Eliminada la instanciación directa de transpiladores en la ruta pública de compilación; `CompileCommand` ahora usa únicamente `backend_pipeline.transpile(...)` y no crea `TRANSPILERS[lang]()` para metadatos (`src/pcobra/cobra/cli/commands/compile_cmd.py`). 
- Documentación actualizada indicando que `pcobra.cobra.transpilers.transpiler.to_python`, `to_js` y `to_rust` son implementación interna (`docs/architecture/adr-unified-backends.md`). 
- Añadidos/ajustados tests para cubrir el nuevo contrato `build(source, hints)`, la exposición de `reason` solo en debug y la resolución vía pipeline desde `build` v2 (`tests/unit/test_backend_pipeline_runtime_manager.py`, `tests/unit/test_cli_v2_command_contract.py`).

### Testing

- Ejecutado `pytest -q tests/unit/test_backend_pipeline_runtime_manager.py tests/unit/test_cli_v2_command_contract.py tests/unit/test_compile_backend_registration.py` y los tests relevantes pasaron: `20 passed, 1 warning`. 
- Las pruebas unitarias nuevas/ajustadas cubren: contexto runtime devuelto por `build`, `reason` expuesto solo con `debug=True`, y que `BuildCommandV2` invoca la resolución del backend vía el pipeline; todas las aserciones pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfae4c393c8327a4c0bd38d1693bbd)