### PR TITLE
Documentar contrato de resolución de imports e introducir strict mode para ambigüedades

### DIFF
--- a/docs/architecture/import-resolution-contract.md
+++ b/docs/architecture/import-resolution-contract.md
@@ -1,0 +1,55 @@
+# Contrato oficial de resolución de imports (`CobraImportResolver`)
+
+Este documento define el contrato **oficial** y estable del resolvedor de imports de Cobra para eliminar ambigüedades operativas entre stdlib, módulos de proyecto, bridge Python e híbridos.
+
+## 1) Orden oficial de resolución (`_SOURCE_ORDER`)
+
+El orden vigente de precedencia es:
+
+1. `stdlib`
+2. `project`
+3. `python_bridge`
+4. `hybrid`
+
+En términos prácticos:
+
+- Si `importar datos` coincide con `cobra.datos` y también existe un módulo local `datos`, se resuelve primero como stdlib (`cobra.datos`).
+- Cuando un nombre sin namespace coincide en múltiples orígenes, el resultado efectivo siempre sigue el orden anterior.
+
+## 2) Política explícita para imports ambiguos
+
+Se considera ambiguo un import sin namespace (sin `.`) que tenga más de un candidato válido entre los orígenes del contrato.
+
+### Modo por defecto (no estricto)
+
+- El resolver emite `UserWarning`.
+- Se selecciona automáticamente el candidato de mayor prioridad según `_SOURCE_ORDER`.
+
+### Strict mode (`strict_ambiguous_imports=True`)
+
+- El resolver **falla** con `ImportResolutionError`.
+- La resolución automática queda deshabilitada para imports ambiguos.
+- Se exige import explícito para desambiguar.
+
+## 3) Prefijos recomendados para evitar colisiones
+
+Recomendaciones normativas:
+
+- **Stdlib Cobra**: usar siempre `cobra.*` cuando el módulo pueda colisionar (`cobra.datos`, `cobra.web`, etc.).
+- **Módulos de proyecto**: usar namespace de aplicación (por ejemplo `app.datos`, `mi_equipo.datos`) en lugar de nombres planos como `datos`.
+- **Bridge Python**: preferir nombres plenamente calificados cuando aplique (`json`, `datetime`, `paquete.submodulo`) y evitar nombres genéricos que colisionen con stdlib/proyecto.
+
+## 4) Metadata de observabilidad en módulos cargados
+
+Cuando el resolvedor carga un módulo Python (`load_module`), inyecta metadata para diagnóstico:
+
+- `__cobra_resolution_source__`: origen efectivo (`stdlib`, `project`, `python_bridge`, `hybrid`).
+- `__cobra_backend_injected__`: backend efectivo inyectado.
+- `__cobra_resolution_metadata__`: snapshot estructurado con:
+  - `request`
+  - `source`
+  - `resolved_name`
+  - `backend`
+  - `import_path`
+
+Esta metadata habilita trazabilidad de resolución y debugging en runtime sin inspección adicional del resolvedor.

--- a/docs/architecture/unified-ecosystem.md
+++ b/docs/architecture/unified-ecosystem.md
@@ -49,6 +49,7 @@ La superficie pública estable para esta fase es:
 - CLI: `run`, `build`, `test`, `mod`.
 - Backends oficiales: `python`, `javascript`, `rust`.
 - Módulos stdlib públicos: `cobra.core`, `cobra.datos`, `cobra.web`, `cobra.system`.
+- Resolución de imports: ver contrato oficial en `docs/architecture/import-resolution-contract.md`.
 
 ## Estabilidad contractual en esta fase
 

--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -55,10 +55,12 @@ class CobraImportResolver:
         project_root: str | Path | None = None,
         hybrid_modules: Mapping[str, HybridModuleSpec | Mapping[str, Any]] | None = None,
         default_backend: str = "python",
+        strict_ambiguous_imports: bool = False,
     ) -> None:
         self.project_root = Path(project_root).resolve() if project_root else None
         self.hybrid_modules = self._normalize_hybrid_modules(hybrid_modules or {})
         self.default_backend = default_backend
+        self.strict_ambiguous_imports = strict_ambiguous_imports
         self.stdlib_modules = self._load_stdlib_modules()
         self.project_modules = self._load_project_modules()
 
@@ -111,13 +113,16 @@ class CobraImportResolver:
 
         if "." not in name and len(candidates) > 1:
             details = ", ".join(f"{c.source}:{c.resolved_name}" for c in candidates)
-            warnings.warn(
+            message = (
                 f"Colisión de import para '{name}'. Se aplica precedencia fija "
                 f"({_SOURCE_ORDER[0]} > {_SOURCE_ORDER[1]} > {_SOURCE_ORDER[2]} > {_SOURCE_ORDER[3]}). "
-                f"Seleccionado: {candidates[0].resolved_name}. Candidatos: {details}",
-                category=UserWarning,
-                stacklevel=2,
+                f"Seleccionado: {candidates[0].resolved_name}. Candidatos: {details}. "
+                f"Recomendación: usa prefijo explícito ('cobra.{name}') para stdlib o namespace de proyecto "
+                f"(por ejemplo 'app.{name}')."
             )
+            if self.strict_ambiguous_imports:
+                raise ImportResolutionError(f"{message} Activa resolución explícita en strict mode.")
+            warnings.warn(message, category=UserWarning, stacklevel=2)
 
         return self._attach_backend_adapter(candidates[0])
 
@@ -145,7 +150,21 @@ class CobraImportResolver:
             adapter = resolve_backend(effective_backend)
             setattr(module, "__cobra_backend__", effective_backend)
             setattr(module, "__cobra_backend_adapter__", adapter)
+        self._attach_module_metadata(module, resolution)
         return resolution, module
+
+    @staticmethod
+    def _attach_module_metadata(module: ModuleType, resolution: ResolutionResult) -> None:
+        metadata = {
+            "request": resolution.request,
+            "source": resolution.source,
+            "resolved_name": resolution.resolved_name,
+            "backend": resolution.backend,
+            "import_path": resolution.import_path,
+        }
+        setattr(module, "__cobra_resolution_source__", resolution.source)
+        setattr(module, "__cobra_backend_injected__", resolution.backend)
+        setattr(module, "__cobra_resolution_metadata__", metadata)
 
     def _attach_backend_adapter(self, resolution: ResolutionResult) -> ResolutionResult:
         base_backend = resolution.backend or self.default_backend

--- a/tests/unit/test_imports_resolver.py
+++ b/tests/unit/test_imports_resolver.py
@@ -54,6 +54,14 @@ def test_colision_stdlib_vs_bridge_genera_warning(monkeypatch):
     assert result.source == "stdlib"
 
 
+def test_colision_en_modo_estricto_falla(tmp_path):
+    (tmp_path / "datos.co").write_text("usar algo")
+    resolver = CobraImportResolver(project_root=tmp_path, strict_ambiguous_imports=True)
+
+    with pytest.raises(ImportResolutionError, match="strict mode"):
+        resolver.resolve("datos")
+
+
 def test_bridge_python_directo():
     resolver = CobraImportResolver()
 
@@ -93,6 +101,15 @@ def test_modulo_hibrido_inyecta_adapter_backend(monkeypatch):
     assert module is fake_module
     assert getattr(module, "__cobra_backend__") == "javascript"
     assert getattr(module, "__cobra_backend_adapter__").__class__.__name__ == "JavaScriptAdapter"
+    assert getattr(module, "__cobra_resolution_source__") == "hybrid"
+    assert getattr(module, "__cobra_backend_injected__") == "javascript"
+    assert getattr(module, "__cobra_resolution_metadata__") == {
+        "request": "mi_hibrido",
+        "source": "hybrid",
+        "resolved_name": "mi_hibrido",
+        "backend": "javascript",
+        "import_path": "mi_hibrido_runtime",
+    }
 
 
 def test_resolver_adjunta_adapter_desde_resolucion():


### PR DESCRIPTION
### Motivation

- Formalizar y dejar por contrato el orden de precedencia del resolvedor de imports para evitar ambigüedades operativas.
- Añadir una política explícita para imports ambiguos y una opción estricta que obligue a desambiguar en entornos sensibles.
- Recomendar prefijos/namespace para reducir colisiones entre stdlib, proyecto y bridge Python.
- Mejorar observabilidad registrando metadatos de resolución en los módulos cargados.

### Description

- Se añade `docs/architecture/import-resolution-contract.md` que documenta el orden oficial `_SOURCE_ORDER` (`stdlib > project > python_bridge > hybrid`), la política por defecto y el `strict mode`, y recomendaciones de prefijos (`cobra.*`, namespaces de proyecto). 
- `CobraImportResolver.__init__` incorpora el nuevo parámetro `strict_ambiguous_imports: bool` y la lógica pasa a lanzar `ImportResolutionError` cuando está activo en caso de colisiones de nombres cortos; en modo por defecto se emite `UserWarning` y se aplica la precedencia fija. 
- `load_module` ahora inyecta metadata de observabilidad en el módulo cargado: `__cobra_resolution_source__`, `__cobra_backend_injected__` y `__cobra_resolution_metadata__` con un snapshot estructurado. 
- Se actualiza `docs/architecture/unified-ecosystem.md` para referenciar el nuevo contrato y se añaden pruebas unitarias en `tests/unit/test_imports_resolver.py` para cubrir el modo estricto y la metadata inyectada.

### Testing

- Ejecutado `pytest -q tests/unit/test_imports_resolver.py` y todos los tests pasaron: `8 passed`.
- Las pruebas verifican advertencias en colisiones por defecto, fallo en `strict` y que la metadata esperada queda inyectada en módulos híbridos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc3b93dec83279deafc2e374d990c)