### PR TITLE
Contrato canónico de bindings, políticas de seguridad por comando y negociación ABI por backend

### DIFF
--- a/bindings/__init__.py
+++ b/bindings/__init__.py
@@ -1,9 +1,6 @@
-"""Compatibilidad del contrato de bindings dentro del namespace ``pcobra``.
+"""Superficie pública canónica del contrato de bindings."""
 
-Fuente canónica: ``bindings/contract.py``.
-"""
-
-from bindings.contract import (  # re-export canónico
+from bindings.contract import (
     BINDINGS_BY_LANGUAGE,
     BindingCapabilities,
     BindingRoute,

--- a/bindings/contract.py
+++ b/bindings/contract.py
@@ -1,0 +1,85 @@
+"""Contrato técnico canónico de rutas de bindings entre Cobra y runtimes externos."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Final
+
+
+class BindingRoute(str, Enum):
+    """Rutas soportadas por el bridge canónico de bindings."""
+
+    PYTHON_DIRECT_IMPORT = "python_direct_import"
+    JAVASCRIPT_RUNTIME_BRIDGE = "javascript_runtime_bridge"
+    RUST_COMPILED_FFI = "rust_compiled_ffi"
+
+
+@dataclass(frozen=True, slots=True)
+class BindingCapabilities:
+    """Describe capacidades y restricciones contractuales por ruta."""
+
+    route: BindingRoute
+    language: str
+    import_strategy: str
+    execution_boundary: str
+    abi_contract: str
+    managed_runtime: bool
+
+
+PYTHON_BINDING: Final[BindingCapabilities] = BindingCapabilities(
+    route=BindingRoute.PYTHON_DIRECT_IMPORT,
+    language="python",
+    import_strategy="Import bridge directo sobre módulos Python canónicos",
+    execution_boundary="Mismo proceso del intérprete Cobra",
+    abi_contract="Contrato Python estable por API pública y typing",
+    managed_runtime=False,
+)
+
+JAVASCRIPT_BINDING: Final[BindingCapabilities] = BindingCapabilities(
+    route=BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE,
+    language="javascript",
+    import_strategy="Bridge de runtime sobre proceso/VM controlada",
+    execution_boundary="Aislado en runtime JS dedicado (proceso o VM)",
+    abi_contract="Contrato de mensajes/IPC versionado",
+    managed_runtime=True,
+)
+
+RUST_BINDING: Final[BindingCapabilities] = BindingCapabilities(
+    route=BindingRoute.RUST_COMPILED_FFI,
+    language="rust",
+    import_strategy="Bindings compilados sobre capa FFI",
+    execution_boundary="Frontera nativa vía librería compartida",
+    abi_contract="ABI estable y versionada",
+    managed_runtime=False,
+)
+
+BINDINGS_BY_LANGUAGE: Final[dict[str, BindingCapabilities]] = {
+    "python": PYTHON_BINDING,
+    "javascript": JAVASCRIPT_BINDING,
+    "rust": RUST_BINDING,
+}
+
+
+def resolve_binding(language: str) -> BindingCapabilities:
+    """Resuelve el contrato de bindings para un lenguaje canónico."""
+
+    key = (language or "").strip().lower()
+    try:
+        return BINDINGS_BY_LANGUAGE[key]
+    except KeyError as exc:
+        raise ValueError(
+            f"No existe contrato de bindings para '{language}'. "
+            f"Lenguajes soportados: {', '.join(sorted(BINDINGS_BY_LANGUAGE))}."
+        ) from exc
+
+
+__all__ = [
+    "BindingCapabilities",
+    "BindingRoute",
+    "BINDINGS_BY_LANGUAGE",
+    "JAVASCRIPT_BINDING",
+    "PYTHON_BINDING",
+    "RUST_BINDING",
+    "resolve_binding",
+]

--- a/cobra.toml
+++ b/cobra.toml
@@ -27,3 +27,8 @@ tiempo_max_transpilacion_seg = 300
 # Validaciones opcionales para expresiones "coincidir"
 coincidir_exhaustivo = false
 patrones_inaccesibles = false
+
+[project.abi_by_backend]
+python = "1.0"
+javascript = "1.0"
+rust = "1.0"

--- a/docs/architecture/binding-contract.md
+++ b/docs/architecture/binding-contract.md
@@ -33,11 +33,15 @@ Definir un contrato técnico único para evitar lógica ad-hoc en runners sobre 
 
 ## Módulo técnico
 
-Se establece como fuente de verdad:
+Se establece como fuente de verdad canónica:
+
+- `bindings/contract.py`
+
+Compatibilidad interna (`pcobra`) via re-export:
 
 - `src/pcobra/cobra/bindings/contract.py`
 
-Este módulo expone:
+El contrato expone:
 
 - `BindingRoute` (enum de rutas),
 - `BindingCapabilities` (tipo estructurado de capacidades),
@@ -48,8 +52,8 @@ Este módulo expone:
 
 - `execute_cmd.py` consume `RuntimeManager` para:
   - resolver contrato + bridge,
-  - validar seguridad por ruta (`python_direct_import`, `javascript_runtime_bridge`, `rust_compiled_ffi`),
-  - validar ABI efectiva por backend.
+  - validar seguridad por ruta y por comando (`run`/`test`),
+  - validar ABI efectiva por backend (incluye ABI negociada por proyecto).
 - `build/backend_pipeline.py` expone `resolve_backend_runtime(...)` y agrega `runtime` al resultado de `build(...)` para que los flujos de compilación tengan metadatos de compatibilidad.
 - Runners futuros deben consumir `RuntimeManager` para decidir la ruta técnica sin duplicar reglas.
 
@@ -58,6 +62,7 @@ Este módulo expone:
 - **Versión de ABI actual:** `1.0`
 - **Regla de compatibilidad:** una ruta solo es compatible si su `abi_version` está en el conjunto soportado por esa ruta.
 - **Punto de validación:** `RuntimeManager.validate_abi_route(language, abi_version)`.
+- **Negociación por proyecto:** si no se pasa `abi_version`, el manager intenta leerla de `cobra.toml` y `pcobra.toml` (`[project].abi_by_backend` o `[project].backend_abi`).
 
 ### Tabla de compatibilidad ABI por backend
 
@@ -73,10 +78,54 @@ Este módulo expone:
 - `javascript_runtime_bridge`: requiere runtime gestionado (sandbox o contenedor) para preservar aislamiento.
 - `rust_compiled_ffi`: frontera nativa FFI; no se ejecuta como sandbox Python directo.
 
+## Políticas por comando (`run`/`test`)
+
+- `run`: aplica reglas base por ruta.
+- `test`: endurece aislamiento:
+  - `python_direct_import`: exige `sandbox=true`.
+  - `javascript_runtime_bridge`: exige `containerized=true`.
+  - `rust_compiled_ffi`: exige `containerized=true`.
+
+## Ejemplos de interoperabilidad por backend
+
+### Python (`python_direct_import`)
+
+```python
+from bindings.contract import resolve_binding
+from pcobra.cobra.bindings.runtime_manager import RuntimeManager
+
+cap = resolve_binding("python")
+abi = RuntimeManager().validate_abi_route("python")
+print(cap.route.value, abi)
+```
+
+### JavaScript (`javascript_runtime_bridge`)
+
+```python
+from pcobra.cobra.bindings.runtime_manager import RuntimeManager
+
+manager = RuntimeManager()
+manager.validate_security_route(
+    "javascript",
+    sandbox=False,
+    containerized=True,
+    command="run",
+)
+```
+
+### Rust (`rust_compiled_ffi`)
+
+```python
+from pcobra.cobra.bindings.runtime_manager import RuntimeManager
+
+manager = RuntimeManager()
+manager.validate_security_route("rust", sandbox=False, containerized=True, command="test")
+```
+
 ## Regla de evolución
 
 Si se añade un backend oficial nuevo:
 
-1. actualizar `contract.py`,
+1. actualizar `bindings/contract.py`,
 2. documentar la ruta en este documento,
 3. adoptar `resolve_binding(...)` en el runner correspondiente.

--- a/pcobra.toml
+++ b/pcobra.toml
@@ -13,6 +13,13 @@
 # - Si tu proyecto quiere exigir también Tier 2, añádelo explícitamente aquí.
 required_targets = ["python", "rust", "javascript", "wasm"]
 
+
+# Negociación ABI por backend para bridges/runtime manager.
+[project.abi_by_backend]
+python = "1.0"
+javascript = "1.0"
+rust = "1.0"
+
 [modulos."modulo.co"]
 python = "modulo.py"
 rust = "modulo.rs"

--- a/src/pcobra/cobra/bindings/runtime_manager.py
+++ b/src/pcobra/cobra/bindings/runtime_manager.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Final
+
+try:
+    import tomllib  # Python >= 3.11
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
 
 from pcobra.cobra.bindings.contract import (
     BindingCapabilities,
@@ -16,6 +23,19 @@ SUPPORTED_ABI_VERSIONS: Final[dict[BindingRoute, tuple[str, ...]]] = {
     BindingRoute.PYTHON_DIRECT_IMPORT: ("1.0",),
     BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE: ("1.0",),
     BindingRoute.RUST_COMPILED_FFI: ("1.0",),
+}
+
+SECURITY_POLICY_BY_COMMAND: Final[dict[str, dict[BindingRoute, dict[str, bool]]]] = {
+    "run": {
+        BindingRoute.PYTHON_DIRECT_IMPORT: {"sandbox_required": False, "container_required": False},
+        BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE: {"sandbox_required": False, "container_required": False},
+        BindingRoute.RUST_COMPILED_FFI: {"sandbox_required": False, "container_required": False},
+    },
+    "test": {
+        BindingRoute.PYTHON_DIRECT_IMPORT: {"sandbox_required": True, "container_required": False},
+        BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE: {"sandbox_required": False, "container_required": True},
+        BindingRoute.RUST_COMPILED_FFI: {"sandbox_required": False, "container_required": True},
+    },
 }
 
 
@@ -66,12 +86,19 @@ class RuntimeManager:
         *,
         sandbox: bool = False,
         containerized: bool = False,
+        command: str = "run",
     ) -> None:
         """Valida que la ruta elegida cumpla expectativas mínimas de seguridad."""
+
+        normalized_command = (command or "run").strip().lower()
+        if normalized_command not in SECURITY_POLICY_BY_COMMAND:
+            allowed = ", ".join(sorted(SECURITY_POLICY_BY_COMMAND))
+            raise ValueError(f"Comando '{command}' no soportado en política de seguridad. Use: {allowed}.")
 
         capabilities, _bridge = self.resolve_runtime(language)
         route = capabilities.route
 
+        # Reglas base por tipo de ruta
         if route is BindingRoute.PYTHON_DIRECT_IMPORT and containerized:
             raise ValueError(
                 "La ruta python_direct_import no puede marcarse como containerizada. "
@@ -88,11 +115,23 @@ class RuntimeManager:
                 "en sandbox Python directo."
             )
 
+        # Reglas por comando (run/test)
+        command_policy = SECURITY_POLICY_BY_COMMAND[normalized_command][route]
+        if command_policy["sandbox_required"] and not sandbox:
+            raise ValueError(
+                f"La política '{normalized_command}' exige sandbox para la ruta {route.value}."
+            )
+        if command_policy["container_required"] and not containerized:
+            raise ValueError(
+                f"La política '{normalized_command}' exige contenedor para la ruta {route.value}."
+            )
+
     def validate_abi_route(self, language: str, abi_version: str | None = None) -> str:
         """Valida compatibilidad ABI de la ruta seleccionada."""
 
         capabilities, bridge = self.resolve_runtime(language)
-        selected = (abi_version or bridge.abi_version or DEFAULT_ABI_VERSION).strip()
+        negotiated_abi = abi_version or self._resolve_project_abi_for_backend(capabilities.language)
+        selected = (negotiated_abi or bridge.abi_version or DEFAULT_ABI_VERSION).strip()
         supported = SUPPORTED_ABI_VERSIONS[capabilities.route]
         if selected not in supported:
             raise ValueError(
@@ -101,10 +140,52 @@ class RuntimeManager:
             )
         return selected
 
+    def _resolve_project_abi_for_backend(self, backend: str) -> str | None:
+        """Obtiene ABI negociada por backend desde cobra.toml/pcobra.toml."""
+
+        normalized_backend = (backend or "").strip().lower()
+        if not normalized_backend:
+            return None
+
+        for config_path in self._project_config_candidates():
+            data = self._load_toml(config_path)
+            if not isinstance(data, dict):
+                continue
+            project = data.get("project")
+            if not isinstance(project, dict):
+                continue
+
+            for key in ("abi_by_backend", "backend_abi"):
+                mapping = project.get(key)
+                if not isinstance(mapping, dict):
+                    continue
+                abi_value = mapping.get(normalized_backend)
+                if isinstance(abi_value, str) and abi_value.strip():
+                    return abi_value.strip()
+        return None
+
+    def _project_config_candidates(self) -> tuple[Path, ...]:
+        root = Path.cwd()
+        cobra = Path(os.environ.get("COBRA_TOML", str(root / "cobra.toml")))
+        pcobra = Path(os.environ.get("PCOBRA_CONFIG", str(root / "pcobra.toml")))
+        return cobra, pcobra
+
+    @staticmethod
+    def _load_toml(path: Path) -> dict:
+        if not path.exists() or not path.is_file():
+            return {}
+        try:
+            with path.open("rb") as handle:
+                data = tomllib.load(handle)
+                return data if isinstance(data, dict) else {}
+        except (OSError, tomllib.TOMLDecodeError):
+            return {}
+
 
 __all__ = [
     "DEFAULT_ABI_VERSION",
     "SUPPORTED_ABI_VERSIONS",
+    "SECURITY_POLICY_BY_COMMAND",
     "RuntimeBridgeDescriptor",
     "RuntimeManager",
 ]

--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -252,7 +252,7 @@ class ExecuteCommand(BaseCommand):
         try:
             raiz_proyecto = _detectar_raiz_proyecto_desde_archivo(str(archivo_resuelto))
             contrato_python, _bridge_python = _resolver_runtime_binding("python")
-            RUNTIME_MANAGER.validate_security_route("python", sandbox=sandbox, containerized=False)
+            RUNTIME_MANAGER.validate_security_route("python", sandbox=sandbox, containerized=False, command="run")
             RUNTIME_MANAGER.validate_abi_route("python")
             validar_dependencias(
                 contrato_python.language,
@@ -353,7 +353,7 @@ class ExecuteCommand(BaseCommand):
         """Ejecuta el código en un contenedor Docker."""
         try:
             contrato, bridge = _resolver_runtime_binding(contenedor)
-            RUNTIME_MANAGER.validate_security_route(contenedor, sandbox=False, containerized=True)
+            RUNTIME_MANAGER.validate_security_route(contenedor, sandbox=False, containerized=True, command="run")
             abi_version = RUNTIME_MANAGER.validate_abi_route(contenedor)
             self.logger.debug(
                 "Ruta de bindings para contenedor '%s': %s (%s) bridge=%s abi=%s",

--- a/tests/unit/test_binding_contract_canonical.py
+++ b/tests/unit/test_binding_contract_canonical.py
@@ -1,0 +1,5 @@
+from bindings.contract import BindingRoute, resolve_binding
+
+
+def test_binding_contract_canonical_route_python():
+    assert resolve_binding("python").route is BindingRoute.PYTHON_DIRECT_IMPORT

--- a/tests/unit/test_runtime_manager.py
+++ b/tests/unit/test_runtime_manager.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from pcobra.cobra.bindings.contract import BindingRoute
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 
@@ -31,3 +33,38 @@ def test_runtime_manager_valida_abi_por_ruta():
         assert "Versiones soportadas" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("Se esperaba error ABI por versión no soportada")
+
+
+def test_runtime_manager_politica_test_exige_sandbox_para_python():
+    manager = RuntimeManager()
+
+    try:
+        manager.validate_security_route("python", sandbox=False, containerized=False, command="test")
+    except ValueError as exc:
+        assert "exige sandbox" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Se esperaba error de política test para python")
+
+
+def test_runtime_manager_negocia_abi_desde_config(monkeypatch, tmp_path: Path):
+    manager = RuntimeManager()
+    cobra_toml = tmp_path / "cobra.toml"
+    cobra_toml.write_text(
+        """
+[project.abi_by_backend]
+rust = "1.0"
+""".strip()
+    )
+    pcobra_toml = tmp_path / "pcobra.toml"
+    pcobra_toml.write_text(
+        """
+[project.backend_abi]
+rust = "2.0"
+""".strip()
+    )
+
+    monkeypatch.setenv("COBRA_TOML", str(cobra_toml))
+    monkeypatch.setenv("PCOBRA_CONFIG", str(pcobra_toml))
+
+    # cobra.toml tiene prioridad y define una ABI soportada.
+    assert manager.validate_abi_route("rust") == "1.0"


### PR DESCRIPTION
### Motivation

- Centralizar y canonizar las rutas de binding (Python/JavaScript/Rust) para evitar lógica ad-hoc en runners y facilitar puentes en distintos lenguajes.  
- Reforzar validaciones de seguridad según el tipo de operación (`run` vs `test`) para aplicar aislamiento más estricto cuando proceda.  
- Soportar negociación de versión ABI por backend desde la configuración del proyecto para permitir compatibilidad negociada entre runtime y native FFI.

### Description

- Se añadió el módulo canónico `bindings/contract.py` y su re-export en `src/pcobra/cobra/bindings/contract.py`; esto centraliza `BindingRoute`, `BindingCapabilities` y `resolve_binding`.  
- `RuntimeManager` (en `src/pcobra/cobra/bindings/runtime_manager.py`) se amplió con `SECURITY_POLICY_BY_COMMAND`, el parámetro `command` en `validate_security_route(...)`, validaciones por comando (`run`/`test`) y negociación ABI por backend leyendo `cobra.toml`/`pcobra.toml` (`[project].abi_by_backend` y `[project].backend_abi`).  
- Se actualizó la CLI (`execute_cmd`) para invocar la validación de seguridad con `command="run"` donde procede, y se añadió la lógica auxiliar para cargar ABI negociada desde archivos TOML de proyecto.  
- Documentación actualizada en `docs/architecture/binding-contract.md` con ejemplos de interoperabilidad por backend y detalle de la negociación ABI, y añadidas entradas de ejemplo en `cobra.toml` / `pcobra.toml`.  
- Tests añadidos/actualizados: `tests/unit/test_binding_contract_canonical.py` (nuevo) y ampliación de `tests/unit/test_runtime_manager.py` para cubrir políticas `test` y negociación ABI desde config.

### Testing

- Se ejecutó: `pytest -q tests/unit/test_runtime_manager.py tests/unit/test_execute_cmd_binding_contract.py tests/unit/test_binding_contract_canonical.py`.  
- Resultado: `7 passed` (todos los tests unitarios especificados pasaron exitosamente).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08729299c8327a7bedf55e187a59f)