### PR TITLE
docs: priorizar flujo unificado run/build/test/mod y añadir Architecture Overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ El objetivo de pCobra es brindar a la comunidad hispanohablante una alternativa 
 
 - Descripción del Proyecto
 - Arquitectura del compilador
+- Architecture Overview
 - Ecosistema unificado Cobra
 - Migración a CLI unificada
 - Instalación
@@ -189,6 +190,10 @@ La especificación completa del lenguaje se encuentra en [SPEC_COBRA.md](docs/SP
 ## Arquitectura del compilador
 
 La cadena de herramientas de Cobra separa el front-end de los generadores de código mediante una arquitectura interna de compilación. Esa arquitectura es un detalle de implementación y no forma parte de la interfaz pública.
+
+## Architecture Overview
+
+Consulta el resumen corto en [docs/architecture/overview.md](docs/architecture/overview.md): describe selección automática de backend, resolución de imports híbridos y bindings por ruta sin exponer complejidad en el flujo principal `run/build/test/mod`.
 
 Diagrama corto del flujo principal:
 
@@ -275,14 +280,16 @@ La interfaz recomendada se organiza en cuatro comandos base:
 - `cobra test`: ejecución de pruebas del proyecto.
 - `cobra mod`: gestión de módulos y dependencias.
 
-Ejemplos rápidos:
+Ejemplos rápidos (flujo oficial):
 
 ```bash
 cobra run archivo.co
-cobra build hola.co --backend python
+cobra build hola.co
 cobra test
 cobra mod list
 ```
+
+> Nota: `cobra build` selecciona backend de forma automática en la ruta pública. Si necesitas forzar backend por compatibilidad, revisa la sección avanzada en `docs/config_cli.md` y la guía legacy en `docs/migracion_cli_unificada.md`.
 
 Para listar todas las opciones disponibles:
 
@@ -1124,8 +1131,8 @@ cobra run tests/data/suma.co
 También puedes transpilar los ejemplos para ver el código Python generado:
 
 ```bash
-cobra build tests/data/hola.cobra --backend python
-cobra build tests/data/suma.co --backend python
+cobra build tests/data/hola.cobra
+cobra build tests/data/suma.co
 ```
 
 #### Regenerar snapshots de transpilación (`tests/data/expected_examples`)
@@ -1179,20 +1186,13 @@ de error.
 ### Comandos válidos por destino
 
 La interfaz pública mantiene únicamente tres destinos oficiales (`python`,
-`javascript`, `rust`) para `cobra build`:
-
-````bash
-cobra build programa.co --backend python
-cobra build programa.co --backend javascript
-cobra build programa.co --backend rust
-````
+`javascript`, `rust`) para `cobra build`. En flujo estándar no necesitas fijarlo manualmente; úsalo solo en modo avanzado.
 
 ### Ejemplos de subcomandos
 
 ````bash
-cobra build programa.co --backend python
-cobra build programa.co --backend javascript
-cobra build programa.co --backend rust
+cobra run programa.co
+cobra build programa.co
 cobra test
 cobra mod list
 echo $?  # 0 al compilar sin problemas

--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -453,13 +453,13 @@ Las fuentes normativas visibles para evitar divergencias son `src/pcobra/cobra/t
 
 Los orígenes reverse se mantienen en una categoría separada: describen lenguajes de **entrada** aceptados por `cobra transpilar-inverso`, no targets oficiales adicionales de salida.
 
-- Compila a cualquiera de los targets oficiales de transpilación con `cobra compilar archivo.co --tipo python`.
-- Ejecuta directamente con `cobra ejecutar archivo.co`.
+- Construye artefactos con `cobra build archivo.co`.
+- Ejecuta directamente con `cobra run archivo.co`.
 
 ### Ejemplo de transpilación a Python
 
 ```bash
-cobra compilar ejemplo.co --tipo python
+cobra build ejemplo.co
 ```
 
 Si prefieres usar las clases del proyecto, llama al módulo
@@ -510,7 +510,7 @@ Convierte programas entre distintos lenguajes usando la CLI:
 - **De Cobra a `rust` (target oficial de salida pública)**
 
   ```bash
-  cobra compilar hola.co --tipo rust
+  cobra build hola.co
   ```
 
 - **De Python a JavaScript mediante reverse (`python` como origen de entrada y `javascript` como destino oficial)**
@@ -565,7 +565,7 @@ El modo seguro se encuentra activado por defecto y evita operaciones peligrosas
 como `leer_archivo` o `hilo`. Para desactivarlo:
 
 ```bash
-cobra ejecutar programa.co --no-seguro
+cobra run programa.co --no-seguro
 ```
 
 ## 13. Próximos pasos

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,22 @@
+# Architecture Overview
+
+Este resumen documenta **cómo funciona internamente** la CLI unificada sin ampliar la superficie pública (`cobra run`, `cobra build`, `cobra test`, `cobra mod`).
+
+## 1) Selección automática de backend
+
+En la ruta pública, `cobra build` delega la elección del backend a `backend_pipeline.resolve_backend(...)`, en lugar de pedir `--backend` como paso principal. El comando V2 traduce esa resolución hacia la ejecución interna manteniendo la UX estable.
+
+## 2) Imports híbridos
+
+La resolución de imports usa prioridad determinista (`stdlib > project > python_bridge > hybrid`) y adjunta metadatos de resolución/backend al módulo cargado. Esto permite convivir módulos del proyecto, puentes Python e imports híbridos sin ambigüedad silenciosa.
+
+## 3) Bindings por ruta
+
+Tras resolver backend, el pipeline valida capacidades/runtime y produce contexto de bridge (`route`, `bridge`, `abi_contract`, `abi_version`). De esta forma, la unión con runtime nativo queda encapsulada por contrato de ruta en vez de exponer lógica de backend al usuario final.
+
+## Referencias técnicas
+
+- `src/pcobra/cobra/cli/commands_v2/build_cmd.py`
+- `src/pcobra/cobra/build/backend_pipeline.py`
+- `src/pcobra/cobra/imports/resolver.py`
+- `src/pcobra/cobra/transpilers/module_map.py`

--- a/docs/blog_minilenguaje.md
+++ b/docs/blog_minilenguaje.md
@@ -7,11 +7,13 @@ En esta entrada se presenta un vistazo rápido al minilenguaje de Cobra.
 ```cobra
 imprimir("Hola mundo")
 ```
-Para transpilar este código a Python ejecuta:
+Para ejecutar y construir con la CLI unificada:
 ```bash
-cobra compilar archivo.co --tipo python
+cobra run archivo.co
+cobra build archivo.co
 ```
 
 ## Referencias
 - [Guía básica](guia_basica.md)
+- [Migración CLI unificada](migracion_cli_unificada.md)
 - [Repositorio oficial](https://github.com/Alphonsus411/pCobra)

--- a/docs/casos_reales.md
+++ b/docs/casos_reales.md
@@ -16,7 +16,7 @@ imprimir "Porcentaje de GC:", conteo
 Ejecuta el script con:
 
 ```bash
-cobra ejecutar bioinfo.co
+cobra run bioinfo.co
 ```
 También puedes ejecutar el cuaderno `notebooks/casos_reales/bioinformatica.ipynb` para verlo paso a paso.
 
@@ -36,7 +36,7 @@ imprimir resultado
 Para ejecutar:
 
 ```bash
-cobra ejecutar ia.co
+cobra run ia.co
 ```
 También puedes ejecutar el cuaderno `notebooks/casos_reales/inteligencia_artificial.ipynb` para una versión interactiva.
 
@@ -77,7 +77,7 @@ matplotlib.guardar(figura, "salida.png")
 Ejecuta el programa así:
 
 ```bash
-cobra ejecutar analisis.co
+cobra run analisis.co
 ```
 Puedes revisar el cuaderno interactivo `notebooks/casos_reales/analisis_datos.ipynb` para seguirlo paso a paso.
 
@@ -94,12 +94,14 @@ def hola():
     regresar 'Hola desde Cobra'
 ```
 
-Compila y lanza el servidor con:
+Genera y lanza el servidor con flujo unificado:
 
 ```bash
-cobra compilar app_web.co --tipo python -o build/app_web.py
+cobra build app_web.co
 python build/app_web.py
 ```
+
+> Para forzar backend/ruta de salida en pipelines legacy, consulta `docs/migracion_cli_unificada.md`.
 
 ## Videojuego básico
 Un pequeño juego usando Pygame:
@@ -113,6 +115,6 @@ pantalla = pygame.nueva_pantalla(640, 480)
 Para ejecutarlo:
 
 ```bash
-cobra compilar juego.co --tipo python
+cobra build juego.co
 python juego.py
 ```

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -29,14 +29,16 @@ CertUtil -hashfile cobra.exe SHA256
 Para ejecutar un archivo Cobra desde la línea de comandos:
 
 ```bash
-cobra archivo.co
+cobra run archivo.co
 ```
 
-También puedes transpilar el programa a otros lenguajes usando el subcomando `compilar` con la opción canónica `--tipo` (o `--backend`, si integras herramientas externas):
+Para generar artefactos usa el flujo unificado:
 
 ```bash
-cobra compilar archivo.co --tipo python
+cobra build archivo.co
 ```
+
+> Si migras desde `cobra archivo.co`, `cobra compilar` o flags de backend legacy, revisa [docs/migracion_cli_unificada.md](migracion_cli_unificada.md).
 
 ### Ejecución en GitHub Codespaces
 


### PR DESCRIPTION
### Motivation
- Unificar la experiencia pública de la CLI para que la documentación priorice exclusivamente el flujo `cobra run`, `cobra build`, `cobra test`, `cobra mod` y evitar promover comandos legacy en ejemplos primarios. 
- Ofrecer un punto de referencia claro para migraciones legacy enlazando a `docs/migracion_cli_unificada.md` y relegando la fijación manual de backends a secciones avanzadas. 
- Homologar las guías de `docs/` para presentar el backend como un detalle interno/avanzado y reducir ambigüedad en ejemplos de usuario. 
- Publicar un resumen arquitectónico corto que explique la selección automática de backend, resolución híbrida de imports y bindings por ruta.

### Description
- Actualicé `README.md` para priorizar el flujo oficial `cobra run`, `cobra build`, `cobra test`, `cobra mod`, añadir enlace a `docs/architecture/overview.md` y anotar que la selección de backend es automática en el flujo público. 
- Homologé ejemplos y comandos en `docs/guia_basica.md`, `docs/casos_reales.md`, `docs/blog_minilenguaje.md` y `docs/MANUAL_COBRA.md` para usar `cobra run`/`cobra build` en lugar de `cobra archivo.co`, `cobra compilar` o `cobra ejecutar`, y añadí referencias a la guía de migración legacy `docs/migracion_cli_unificada.md`. 
- Añadí `docs/architecture/overview.md` con un resumen técnico (selección automática de backend vía `backend_pipeline.resolve_backend(...)`, prioridad determinista de imports `stdlib > project > python_bridge > hybrid`, y generación de contexto de bridge/ABI por ruta). 
- Cambios limitados a documentación; no se modificó código ejecutable ni interfaces públicas en el runtime.

### Testing
- Ejecuté `git diff --check` para validar problemas triviales de diff y no se reportaron errores. 
- Intenté ejecutar `markdownlint README.md docs/guia_basica.md docs/casos_reales.md docs/blog_minilenguaje.md docs/MANUAL_COBRA.md docs/architecture/overview.md`, pero `markdownlint` no está disponible en el entorno de ejecución (herramienta no instalada). 
- No se ejecutaron suites unitarias porque los cambios son solo de documentación y no afectan código fuente ejecutable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ba16a4008327828fa780e3c108d8)