### PR TITLE
Formalizar contrato público unificado de 3 backends

### DIFF
--- a/docs/architecture/adr-unified-3-backends.md
+++ b/docs/architecture/adr-unified-3-backends.md
@@ -1,0 +1,30 @@
+# ADR: Cobra unifica la superficie pública en 3 backends
+
+- **Estado:** Aprobado
+- **Fecha:** 2026-04-16
+- **Decisores:** Equipo Core de pCobra
+- **Relacionado con:** `docs/architecture/adr-unified-backends.md`, `docs/targets_policy.md`
+
+## Decisión
+
+1. **Cobra es la única interfaz pública** para usuarios e integraciones externas.
+2. Los **backends oficiales públicos** son exclusivamente: `python`, `javascript`, `rust`.
+3. Los transpiladores legacy (`go`, `cpp`, `java`, `wasm`, `asm`) se mantienen como **internos** y **no soportados públicamente**.
+
+## Compatibilidad interna (no pública)
+
+Los backends legacy se aceptan solo para migración operativa interna con ventana de retiro:
+
+- `go`: retiro objetivo **Q4 2026**
+- `cpp`: retiro objetivo **Q4 2026**
+- `java`: retiro objetivo **Q1 2027**
+- `wasm`: retiro objetivo **Q2 2027**
+- `asm`: retiro objetivo **Q3 2026**
+
+Fuera de ese contexto, no deben aparecer en rutas ni documentación públicas.
+
+## Criterio de salida
+
+Cualquier API pública, CLI pública o documentación orientada a usuario **solo puede listar 3 targets** y deben ser exactamente:
+
+`python`, `javascript`, `rust`.

--- a/src/pcobra/cobra/architecture/backend_policy.py
+++ b/src/pcobra/cobra/architecture/backend_policy.py
@@ -1,17 +1,23 @@
-"""Política de exposición de backends (públicos vs internos)."""
+"""Política normativa de backends (públicos vs internos)."""
 
 from __future__ import annotations
 
 from typing import Final
 
-# Superficie pública soportada por CLI y documentación.
+# Cobra es la única interfaz pública soportada para usuarios e integraciones.
+PUBLIC_INTERFACE_NAME: Final[str] = "cobra"
+
+# Superficie pública soportada por CLI y documentación de usuario.
 PUBLIC_BACKENDS: Final[tuple[str, ...]] = (
     "python",
     "javascript",
     "rust",
 )
 
-# Backends legacy mantenidos para compatibilidad interna del registro.
+# Criterio de salida: toda API pública o doc de usuario solo puede listar 3 targets.
+PUBLIC_TARGET_LISTING_LIMIT: Final[int] = 3
+
+# Backends legacy mantenidos exclusivamente para compatibilidad interna.
 INTERNAL_BACKENDS: Final[tuple[str, ...]] = (
     "go",
     "cpp",
@@ -20,5 +26,28 @@ INTERNAL_BACKENDS: Final[tuple[str, ...]] = (
     "asm",
 )
 
+# Ventana de retiro contractual para compatibilidad interna no pública.
+INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW: Final[dict[str, str]] = {
+    "go": "Q4 2026",
+    "cpp": "Q4 2026",
+    "java": "Q1 2027",
+    "wasm": "Q2 2027",
+    "asm": "Q3 2026",
+}
+
 ALL_BACKENDS: Final[tuple[str, ...]] = PUBLIC_BACKENDS + INTERNAL_BACKENDS
 
+
+def assert_public_targets_contract(targets: tuple[str, ...], *, source: str) -> None:
+    """Valida que una superficie pública cumpla el contrato oficial de 3 targets."""
+    if len(targets) != PUBLIC_TARGET_LISTING_LIMIT:
+        raise RuntimeError(
+            "[PUBLIC CONTRACT] Toda API pública o doc de usuario debe listar exactamente "
+            f"{PUBLIC_TARGET_LISTING_LIMIT} targets. source={source}; targets={targets}"
+        )
+
+    if targets != PUBLIC_BACKENDS:
+        raise RuntimeError(
+            "[PUBLIC CONTRACT] La superficie pública debe usar exactamente PUBLIC_BACKENDS. "
+            f"source={source}; current={targets}; expected={PUBLIC_BACKENDS}"
+        )

--- a/src/pcobra/cobra/config/transpile_targets.py
+++ b/src/pcobra/cobra/config/transpile_targets.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from typing import Final, Literal, TypedDict
 
-from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS, PUBLIC_BACKENDS
+from pcobra.cobra.architecture.backend_policy import (
+    INTERNAL_BACKENDS,
+    INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW,
+    PUBLIC_BACKENDS,
+    assert_public_targets_contract,
+)
 
 
 class TargetMetadata(TypedDict):
@@ -58,11 +63,7 @@ TARGET_METADATA: Final[dict[str, TargetMetadata]] = {
 def _validate_target_config() -> None:
     allowed = set(ALLOWED_TARGETS)
 
-    if ALLOWED_TARGETS != PUBLIC_BACKENDS:
-        raise RuntimeError(
-            "ALLOWED_TARGETS debe ser exactamente PUBLIC_BACKENDS para rutas públicas. "
-            f"allowed={ALLOWED_TARGETS}; public={PUBLIC_BACKENDS}"
-        )
+    assert_public_targets_contract(ALLOWED_TARGETS, source="config.transpile_targets.ALLOWED_TARGETS")
 
     if set(TARGETS_BY_TIER) != {"tier_1", "tier_2"}:
         raise RuntimeError(
@@ -93,6 +94,17 @@ def _validate_target_config() -> None:
         missing = tuple(sorted(allowed - metadata_keys))
         raise RuntimeError(
             "TARGET_METADATA debe cubrir exactamente la lista pública permitida. "
+            f"missing={missing or '∅'}; extras={extras or '∅'}"
+        )
+
+
+    lifecycle_keys = set(INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW)
+    internal_keys = set(INTERNAL_BACKENDS)
+    if lifecycle_keys != internal_keys:
+        extras = tuple(sorted(lifecycle_keys - internal_keys))
+        missing = tuple(sorted(internal_keys - lifecycle_keys))
+        raise RuntimeError(
+            "INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW debe cubrir exactamente INTERNAL_BACKENDS. "
             f"missing={missing or '∅'}; extras={extras or '∅'}"
         )
 

--- a/src/pcobra/cobra/transpilers/registry.py
+++ b/src/pcobra/cobra/transpilers/registry.py
@@ -8,7 +8,9 @@ from typing import Final
 from pcobra.cobra.architecture.backend_policy import (
     ALL_BACKENDS,
     INTERNAL_BACKENDS,
+    INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW,
     PUBLIC_BACKENDS,
+    assert_public_targets_contract,
 )
 from pcobra.cobra.architecture.legacy_backend_lifecycle import (
     lifecycle_status_for_backend,
@@ -72,11 +74,10 @@ def _validate_complete_registry_contract() -> tuple[str, ...]:
 
 def _validate_public_registry_contract() -> tuple[str, ...]:
     """Valida contrato estricto del registro público frente a OFFICIAL_TARGETS/PUBLIC_BACKENDS."""
-    if OFFICIAL_TARGETS != PUBLIC_BACKENDS:
-        raise RuntimeError(
-            "[CI CONTRACT] OFFICIAL_TARGETS debe ser equivalente a PUBLIC_BACKENDS para rutas públicas. "
-            f"official={OFFICIAL_TARGETS}; public={PUBLIC_BACKENDS}"
-        )
+    assert_public_targets_contract(
+        OFFICIAL_TARGETS,
+        source="transpilers.registry.OFFICIAL_TARGETS",
+    )
 
     configured_keys = tuple(PUBLIC_TRANSPILER_CLASS_PATHS)
     missing = tuple(target for target in PUBLIC_BACKENDS if target not in configured_keys)
@@ -112,6 +113,18 @@ def _validate_internal_legacy_registry_contract() -> tuple[str, ...]:
             "[CI CONTRACT] INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS debe usar exactamente INTERNAL_BACKENDS. "
             f"missing={missing or '∅'}; extras={extras or '∅'}; "
             f"current={configured_keys}; expected={INTERNAL_BACKENDS}"
+        )
+
+
+    lifecycle_keys = set(INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW)
+    internal_keys = set(INTERNAL_BACKENDS)
+    if lifecycle_keys != internal_keys:
+        extras = tuple(sorted(lifecycle_keys - internal_keys))
+        missing = tuple(sorted(internal_keys - lifecycle_keys))
+        raise RuntimeError(
+            "[CI CONTRACT] INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW debe cubrir "
+            "exactamente INTERNAL_BACKENDS. "
+            f"missing={missing or '∅'}; extras={extras or '∅'}"
         )
 
     if configured_keys != INTERNAL_BACKENDS:


### PR DESCRIPTION
### Motivation

- Unificar y evitar duplicación de reglas sobre qué backends son públicos vs internos y establecer un criterio claro de exposición en la API/Docs. 
- Documentar la decisión (ADR) y dejar una ventana de retiro para backends legacy usados solo internamente.

### Description

- Añadido ADR en `docs/architecture/adr-unified-3-backends.md` que declara a `cobra` como única interfaz pública, los backends oficiales `python`, `javascript`, `rust`, y marca `go/cpp/java/wasm/asm` como internos con ventanas de retiro.
- `src/pcobra/cobra/architecture/backend_policy.py` centraliza la política: agrega `PUBLIC_INTERFACE_NAME`, `PUBLIC_TARGET_LISTING_LIMIT`, `INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW` y el helper `assert_public_targets_contract(...)` para validar superficies públicas.
- `src/pcobra/cobra/config/transpile_targets.py` se alinea para usar `assert_public_targets_contract(...)` y añade validación que la ventana de retiro cubre exactamente los `INTERNAL_BACKENDS`.
- `src/pcobra/cobra/transpilers/registry.py` se actualiza para usar el helper central, validar el contrato público frente a `OFFICIAL_TARGETS` y comprobar que la tabla de ventanas de retiro cubre los backends internos.

### Testing

- Se compiló todo localmente con `python -m compileall src/pcobra/cobra/architecture/backend_policy.py src/pcobra/cobra/config/transpile_targets.py src/pcobra/cobra/transpilers/registry.py` y la compilación finalizó correctamente.
- Se ejecutó un script de importación/consulta (importando `PUBLIC_INTERFACE_NAME`, `PUBLIC_BACKENDS`, `OFFICIAL_TARGETS` y `official_transpiler_targets()`) y devolvió `cobra` y `('python', 'javascript', 'rust')` como esperado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ce050db083278c4915addd707c57)