### PR TITLE
Centraliza contrato de capacidades públicas para selección de backends

### DIFF
--- a/src/pcobra/cobra/architecture/__init__.py
+++ b/src/pcobra/cobra/architecture/__init__.py
@@ -1,2 +1,13 @@
 """Módulos de arquitectura interna de pCobra."""
 
+from pcobra.cobra.architecture.capabilities_contract import (
+    PROJECT_TYPE_PUBLIC_POLICY,
+    PUBLIC_CAPABILITIES_CONTRACT,
+    PUBLIC_FALLBACK_POLICY,
+)
+
+__all__ = [
+    "PROJECT_TYPE_PUBLIC_POLICY",
+    "PUBLIC_CAPABILITIES_CONTRACT",
+    "PUBLIC_FALLBACK_POLICY",
+]

--- a/src/pcobra/cobra/architecture/capabilities_contract.py
+++ b/src/pcobra/cobra/architecture/capabilities_contract.py
@@ -1,0 +1,130 @@
+"""Contrato único de capacidades públicas para resolución de backend.
+
+Este contrato centraliza:
+1) backends públicos permitidos,
+2) ruta de binding por backend público,
+3) política de fallback para rutas públicas.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS, PUBLIC_BACKENDS
+from pcobra.cobra.bindings.contract import BindingRoute
+
+
+@dataclass(frozen=True, slots=True)
+class PublicBackendCapability:
+    """Capacidad pública canónica para un backend soportado."""
+
+    backend: str
+    binding_route: BindingRoute
+    fallback_rank: int
+
+
+PUBLIC_CAPABILITIES_CONTRACT: Final[dict[str, PublicBackendCapability]] = {
+    "python": PublicBackendCapability(
+        backend="python",
+        binding_route=BindingRoute.PYTHON_DIRECT_IMPORT,
+        fallback_rank=1,
+    ),
+    "javascript": PublicBackendCapability(
+        backend="javascript",
+        binding_route=BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE,
+        fallback_rank=2,
+    ),
+    "rust": PublicBackendCapability(
+        backend="rust",
+        binding_route=BindingRoute.RUST_COMPILED_FFI,
+        fallback_rank=3,
+    ),
+}
+
+# Política de fallback contractual para rutas públicas.
+PUBLIC_FALLBACK_POLICY: Final[tuple[str, ...]] = tuple(
+    backend
+    for backend, _metadata in sorted(
+        PUBLIC_CAPABILITIES_CONTRACT.items(),
+        key=lambda item: item[1].fallback_rank,
+    )
+)
+
+# Preferencias públicas por tipo de proyecto (siempre restringidas al contrato público).
+PROJECT_TYPE_PUBLIC_POLICY: Final[dict[str, tuple[str, ...]]] = {
+    "library": ("python", "rust", "javascript"),
+    "web": ("javascript", "python", "rust"),
+    "systems": ("rust", "python", "javascript"),
+    "embedded": ("rust", "python", "javascript"),
+    "application": ("python", "javascript", "rust"),
+}
+
+
+def validate_capabilities_contract() -> None:
+    """Valida consistencia interna del contrato público."""
+
+    configured_public = tuple(PUBLIC_CAPABILITIES_CONTRACT)
+    if configured_public != PUBLIC_BACKENDS:
+        raise RuntimeError(
+            "PUBLIC_CAPABILITIES_CONTRACT debe listar exactamente PUBLIC_BACKENDS. "
+            f"configured={configured_public}; expected={PUBLIC_BACKENDS}"
+        )
+
+    missing = tuple(backend for backend in PUBLIC_BACKENDS if backend not in PUBLIC_FALLBACK_POLICY)
+    extras = tuple(backend for backend in PUBLIC_FALLBACK_POLICY if backend not in PUBLIC_BACKENDS)
+    if missing or extras:
+        raise RuntimeError(
+            "PUBLIC_FALLBACK_POLICY debe cubrir exactamente PUBLIC_BACKENDS. "
+            f"missing={missing or '∅'}; extras={extras or '∅'}"
+        )
+
+    for project_type, candidates in PROJECT_TYPE_PUBLIC_POLICY.items():
+        invalid = tuple(backend for backend in candidates if backend not in PUBLIC_BACKENDS)
+        if invalid:
+            raise RuntimeError(
+                "PROJECT_TYPE_PUBLIC_POLICY contiene backends fuera del contrato público. "
+                f"project_type={project_type}; invalid={invalid}"
+            )
+
+
+def assert_backend_allowed_for_scope(*, backend: str, scope: str) -> None:
+    """Garantiza que un backend pertenezca al scope autorizado."""
+
+    canonical = (backend or "").strip().lower()
+    if scope == "public":
+        if canonical not in PUBLIC_BACKENDS:
+            raise ValueError(
+                f"Backend no permitido en ruta pública: {backend}. "
+                f"Permitidos: {', '.join(PUBLIC_BACKENDS)}"
+            )
+        return
+    if scope == "internal_migration":
+        if canonical not in PUBLIC_BACKENDS and canonical not in INTERNAL_BACKENDS:
+            raise ValueError(
+                f"Backend no reconocido para migración interna: {backend}. "
+                f"Permitidos: {', '.join(PUBLIC_BACKENDS + INTERNAL_BACKENDS)}"
+            )
+        return
+    raise ValueError(f"Scope de backend no soportado: {scope}")
+
+
+def binding_route_for_public_backend(backend: str) -> BindingRoute:
+    """Devuelve la ruta de binding contractual de un backend público."""
+
+    assert_backend_allowed_for_scope(backend=backend, scope="public")
+    return PUBLIC_CAPABILITIES_CONTRACT[backend].binding_route
+
+
+validate_capabilities_contract()
+
+
+__all__ = [
+    "PROJECT_TYPE_PUBLIC_POLICY",
+    "PUBLIC_CAPABILITIES_CONTRACT",
+    "PUBLIC_FALLBACK_POLICY",
+    "PublicBackendCapability",
+    "assert_backend_allowed_for_scope",
+    "binding_route_for_public_backend",
+    "validate_capabilities_contract",
+]

--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from pcobra.cobra.architecture.capabilities_contract import (
+    PUBLIC_BACKENDS,
+    assert_backend_allowed_for_scope,
+    binding_route_for_public_backend,
+)
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 from pcobra.cobra.build.orchestrator import BackendResolution, BuildOrchestrator
 from pcobra.cobra.transpilers.registry import build_official_transpilers
@@ -15,15 +20,43 @@ RUNTIME_MANAGER = RuntimeManager()
 TRANSPILERS: dict[str, type] = build_official_transpilers()
 
 
+def _public_route_backend_matrix() -> dict[str, tuple[str, ...]]:
+    """Matriz explícita de rutas públicas que usan resolución de backend."""
+    return {
+        "build_pipeline.resolve_backend": PUBLIC_BACKENDS,
+        "build_pipeline.resolve_backend_runtime": PUBLIC_BACKENDS,
+        "build_pipeline.build": PUBLIC_BACKENDS,
+    }
+
+
+def _validate_public_route_startup_contract() -> None:
+    """Falla en arranque si una ruta pública deriva en backend fuera del contrato."""
+    for route_name, backends in _public_route_backend_matrix().items():
+        for backend in backends:
+            assert_backend_allowed_for_scope(backend=backend, scope="public")
+            binding_route_for_public_backend(backend)
+        out_of_contract = tuple(backend for backend in backends if backend not in PUBLIC_BACKENDS)
+        if out_of_contract:
+            raise RuntimeError(
+                "Ruta pública configurada con backend fuera de python/javascript/rust. "
+                f"route={route_name}; invalid={out_of_contract}; public={PUBLIC_BACKENDS}"
+            )
+
+
+_validate_public_route_startup_contract()
+
+
 def resolve_backend(source: str, hints: dict[str, Any] | None = None) -> BackendResolution:
     """Resuelve backend canónico a partir de un source file y pistas opcionales."""
     context = hints or {}
     preferred_backend = context.get("preferred_backend")
     required_capabilities = tuple(context.get("required_capabilities", ()))
+    route_scope = "internal_migration" if context.get("internal_migration", False) else "public"
     return ORCHESTRATOR.resolve_backend(
         source_file=source,
         preferred_backend=preferred_backend,
         required_capabilities=required_capabilities,
+        route_scope=route_scope,
     )
 
 

--- a/src/pcobra/cobra/build/orchestrator.py
+++ b/src/pcobra/cobra/build/orchestrator.py
@@ -6,8 +6,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
-from pcobra.cobra.config.transpile_targets import OFFICIAL_TARGETS, target_metadata
+from pcobra.cobra.architecture.capabilities_contract import (
+    PROJECT_TYPE_PUBLIC_POLICY,
+    PUBLIC_BACKENDS,
+    PUBLIC_FALLBACK_POLICY,
+    assert_backend_allowed_for_scope,
+    validate_capabilities_contract,
+)
+from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS
+from pcobra.cobra.config.transpile_targets import target_metadata
 from pcobra.cobra.transpilers.module_map import get_toml_map
 from pcobra.cobra.transpilers.target_utils import normalize_target_name
 
@@ -22,18 +29,6 @@ class BackendResolution:
         return self.reason if debug else None
 
 
-def _ordered_public_priority(*preferred: str) -> tuple[str, ...]:
-    """Compone prioridad sin duplicar listas completas hardcodeadas."""
-    ordered: list[str] = []
-    for backend in preferred:
-        if backend in OFFICIAL_TARGETS and backend not in ordered:
-            ordered.append(backend)
-    for backend in OFFICIAL_TARGETS:
-        if backend not in ordered:
-            ordered.append(backend)
-    return tuple(ordered)
-
-
 class BuildOrchestrator:
     """Selecciona backend objetivo con reglas unificadas.
 
@@ -46,13 +41,7 @@ class BuildOrchestrator:
     compatibilidad en ``cobra compilar --backend`` / ``--tipo``.
     """
 
-    _PROJECT_TYPE_PRIORITIES: dict[str, tuple[str, ...]] = {
-        "library": _ordered_public_priority("python", "rust"),
-        "web": _ordered_public_priority("javascript", "python"),
-        "systems": _ordered_public_priority("rust", "python"),
-        "embedded": _ordered_public_priority("rust", "python"),
-        "application": _ordered_public_priority("python", "javascript"),
-    }
+    _PROJECT_TYPE_PRIORITIES: dict[str, tuple[str, ...]] = dict(PROJECT_TYPE_PUBLIC_POLICY)
 
     def __init__(self) -> None:
         self._validate_public_backend_routes_contract()
@@ -63,16 +52,18 @@ class BuildOrchestrator:
         source_file: str,
         preferred_backend: str | None = None,
         required_capabilities: tuple[str, ...] = (),
+        route_scope: str = "public",
     ) -> BackendResolution:
         config = get_toml_map()
-        normalized_preferred = self._normalize_optional_target(preferred_backend)
+        normalized_preferred = self._normalize_optional_target(preferred_backend, route_scope=route_scope)
         project_type = self._project_type(config)
         module_meta = self._module_metadata(config, source_file)
 
         module_target = self._normalize_optional_target(
             module_meta.get("preferred_target")
             or module_meta.get("target")
-            or module_meta.get("backend")
+            or module_meta.get("backend"),
+            route_scope="public",
         )
 
         capabilities = self._collect_capabilities(
@@ -80,6 +71,12 @@ class BuildOrchestrator:
             module_meta=module_meta,
             requested=required_capabilities,
         )
+
+        if normalized_preferred is not None and normalized_preferred in INTERNAL_BACKENDS:
+            return BackendResolution(
+                backend=normalized_preferred,
+                reason="preferencia explícita en ruta de migración interna",
+            )
 
         if normalized_preferred is not None:
             return BackendResolution(
@@ -110,23 +107,16 @@ class BuildOrchestrator:
         ]
         return BackendResolution(backend=selected, reason="; ".join(reason_parts))
 
-    def _normalize_optional_target(self, value: Any) -> str | None:
+    def _normalize_optional_target(self, value: Any, *, route_scope: str) -> str | None:
         if not isinstance(value, str) or not value.strip():
             return None
         canonical = normalize_target_name(value)
-        if canonical not in PUBLIC_BACKENDS:
-            raise ValueError(
-                f"Backend no permitido: {value}. Permitidos: {', '.join(PUBLIC_BACKENDS)}"
-            )
+        assert_backend_allowed_for_scope(backend=canonical, scope=route_scope)
         return canonical
 
     def _validate_public_backend_routes_contract(self) -> None:
         """Asegura que las rutas públicas de selección no usen backends fuera del canon oficial."""
-        if OFFICIAL_TARGETS != PUBLIC_BACKENDS:
-            raise RuntimeError(
-                "BuildOrchestrator requiere OFFICIAL_TARGETS == PUBLIC_BACKENDS en rutas públicas. "
-                f"official={OFFICIAL_TARGETS}; public={PUBLIC_BACKENDS}"
-            )
+        validate_capabilities_contract()
 
         official = set(PUBLIC_BACKENDS)
         covered: set[str] = set()
@@ -214,10 +204,7 @@ class BuildOrchestrator:
         return ordered
 
     def _default_priority(self) -> tuple[str, ...]:
-        weighted = sorted(
-            OFFICIAL_TARGETS,
-            key=lambda backend: target_metadata(backend)["release_priority"],
-        )
+        weighted = sorted(PUBLIC_FALLBACK_POLICY, key=lambda backend: target_metadata(backend)["release_priority"])
         return tuple(weighted)
 
     def _supports_capabilities(self, backend: str, capabilities: tuple[str, ...]) -> bool:

--- a/tests/unit/test_backend_pipeline_runtime_manager.py
+++ b/tests/unit/test_backend_pipeline_runtime_manager.py
@@ -55,3 +55,20 @@ def test_backend_pipeline_build_expone_reason_solo_en_debug(monkeypatch):
     result = backend_pipeline.build("imprimir(1)", hints={"preferred_backend": "python", "debug": True})
 
     assert result["reason"] == "debug-reason"
+
+
+def test_backend_pipeline_resolve_backend_envia_scope_migracion(monkeypatch):
+    captured = {}
+
+    def _fake_resolve_backend(self, *, source_file, preferred_backend, required_capabilities, route_scope):
+        captured["route_scope"] = route_scope
+        return type("R", (), {"backend": "go", "reason": "migration"})()
+
+    monkeypatch.setattr(backend_pipeline, "ORCHESTRATOR", type("O", (), {"resolve_backend": _fake_resolve_backend})())
+
+    backend_pipeline.resolve_backend(
+        "demo.co",
+        {"preferred_backend": "go", "internal_migration": True},
+    )
+
+    assert captured["route_scope"] == "internal_migration"

--- a/tests/unit/test_build_orchestrator.py
+++ b/tests/unit/test_build_orchestrator.py
@@ -43,3 +43,27 @@ def test_build_orchestrator_respeta_preferencia_legacy(monkeypatch):
 
     assert resolution.backend == "rust"
     assert "legacy" in resolution.reason
+
+
+def test_build_orchestrator_bloquea_backend_legacy_en_ruta_publica(monkeypatch):
+    monkeypatch.setattr("cobra.build.orchestrator.get_toml_map", lambda: {})
+
+    try:
+        BuildOrchestrator().resolve_backend(source_file="demo.co", preferred_backend="go")
+    except ValueError as exc:
+        assert "ruta pública" in str(exc)
+        return
+    raise AssertionError("Se esperaba ValueError para backend legacy en ruta pública")
+
+
+def test_build_orchestrator_permite_backend_legacy_en_migracion_interna(monkeypatch):
+    monkeypatch.setattr("cobra.build.orchestrator.get_toml_map", lambda: {})
+
+    resolution = BuildOrchestrator().resolve_backend(
+        source_file="demo.co",
+        preferred_backend="go",
+        route_scope="internal_migration",
+    )
+
+    assert resolution.backend == "go"
+    assert "migración interna" in resolution.reason


### PR DESCRIPTION
### Motivation
- Unificar la fuente de verdad para qué backends son públicos, su ruta de binding y la política de fallback para evitar drifts entre orquestador, pipeline y bindings. 
- Encapsular el acceso a targets legacy detrás de rutas explícitas de migración para que no formen parte del flujo público de usuario. 
- Forzar validación de arranque para que cualquier ruta pública que intente exponer un backend distinto a `python/javascript/rust` falle temprano.

### Description
- Se añadió `src/pcobra/cobra/architecture/capabilities_contract.py` que centraliza el contrato público (`PUBLIC_CAPABILITIES_CONTRACT`, `PUBLIC_FALLBACK_POLICY`, `PROJECT_TYPE_PUBLIC_POLICY`) y funciones auxiliares como `assert_backend_allowed_for_scope` y `binding_route_for_public_backend`.
- `BuildOrchestrator` ahora consume exclusivamente el contrato público: reemplazó las prioridades hardcodeadas por `PROJECT_TYPE_PUBLIC_POLICY`, usa `PUBLIC_FALLBACK_POLICY` para fallback y valida consistencia llamando a `validate_capabilities_contract`; además introdujo el parámetro `route_scope` para distinguir entre `public` e `internal_migration` y bloquea preferencias legacy en el scope público.
- `backend_pipeline` ahora valida en arranque que las rutas públicas estén atadas al contrato público mediante `_validate_public_route_startup_contract`, y transmite `route_scope` (`public` por defecto, `internal_migration` si se pasa `internal_migration=True`) hacia el orquestador.
- Se actualizó `src/pcobra/cobra/architecture/__init__.py` para exportar el nuevo contrato y se añadieron pruebas unitarias en `tests/unit/test_build_orchestrator.py` y `tests/unit/test_backend_pipeline_runtime_manager.py` que cubren bloqueo de legacy en rutas públicas, permiso en migración interna y la propagación del scope desde `backend_pipeline`.
- Se respetó la restricción de no tocar `lexer`, `parser`, `ast_nodes` ni archivos `to_*.py` (ninguno de esos archivos fue modificado).

### Testing
- Se ejecutaron las pruebas unitarias `pytest -q tests/unit/test_build_orchestrator.py tests/unit/test_backend_pipeline_runtime_manager.py` y todas pasaron (`8 passed`).
- Las nuevas pruebas verifican que `BuildOrchestrator` rechaza un `preferred_backend` legacy en scope `public` y permite el mismo cuando `route_scope="internal_migration"`, y que `backend_pipeline.resolve_backend` envía correctamente el `route_scope` al orquestador.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e01475cc8327b8865e36b5580b3c)