### PR TITLE
cli: blindar perfil público y contrato run/build/test/mod

### DIFF
--- a/docs/migracion_cli_unificada.md
+++ b/docs/migracion_cli_unificada.md
@@ -22,15 +22,19 @@ Con backends públicos oficiales:
 - **Interfaz pública**: comandos `cobra run/build/test/mod` y backends oficiales `python`, `javascript`, `rust`.
 - **Compatibilidad interna**: aliases legacy y backends internos usados solo para migración controlada.
 
-## Mapeo de comandos legacy
+## Mapeo de comandos legacy (equivalencia viejo → nuevo)
 
-| Legacy | Nuevo comando recomendado |
+| Comando legacy (viejo) | Comando unificado (nuevo) |
 |---|---|
 | `cobra archivo.co` | `cobra run archivo.co` |
 | `cobra compilar archivo.co --backend <target>` | `cobra build archivo.co --backend <target>` |
+| `cobra ejecutar archivo.co` | `cobra run archivo.co` |
+| `cobra verificar archivo.co -l python,javascript,rust` | `cobra test archivo.co --langs python javascript rust` |
 | `cobra modulos listar` | `cobra mod list` |
 | `cobra modulos instalar ruta/al/modulo.co` | `cobra mod install ruta/al/modulo.co` |
 | `cobra modulos remover modulo.co` | `cobra mod remove modulo.co` |
+| `cobra modulos buscar nombre` | `cobra mod search nombre` |
+| `cobra modulos publicar ruta/al/modulo.co` | `cobra mod publish ruta/al/modulo.co` |
 
 ## Migración de flags `--backend`
 

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -17,7 +17,8 @@ from pcobra.cobra.cli.commands.benchmarks_cmd import BenchmarksCommand
 from pcobra.cobra.cli.commands.benchmarks2_cmd import BenchmarksV2Command
 from pcobra.cobra.cli.commands.benchthreads_cmd import BenchThreadsCommand
 from pcobra.cobra.cli.commands.cache_cmd import CacheCommand
-from pcobra.cobra.cli.commands.compile_cmd import CompileCommand, LANG_CHOICES
+from pcobra.cobra.cli.commands.compile_cmd import CompileCommand
+from pcobra.cobra.cli.target_policies import OFFICIAL_TRANSPILATION_TARGETS
 from pcobra.cobra.cli.commands.container_cmd import ContainerCommand
 from pcobra.cobra.cli.commands.crear_cmd import CrearCommand
 from pcobra.cobra.cli.commands.dependencias_cmd import DependenciasCommand
@@ -45,7 +46,6 @@ from pcobra.cobra.cli.commands.validar_sintaxis_cmd import ValidarSintaxisComman
 from pcobra.cobra.cli.commands.qa_validar_cmd import QaValidarCommand
 from pcobra.cobra.cli.commands_v2 import (
     BuildCommandV2,
-    COBRA_ENABLE_LEGACY_CLI_ENV,
     LegacyCommandGroupV2,
     ModCommandV2,
     RunCommandV2,
@@ -88,6 +88,7 @@ COBRA_DEV_MODE_ENV = "COBRA_DEV_MODE"
 COBRA_DEV_EPHEMERAL_CONFIRM_ENV = "COBRA_DEV_ALLOW_EPHEMERAL_KEY"
 COBRA_ALLOW_INSECURE_FALLBACK_ENV = "COBRA_ALLOW_INSECURE_FALLBACK"
 COBRA_ALLOW_INSECURE_NON_INTERACTIVE_ENV = "COBRA_ALLOW_INSECURE_NON_INTERACTIVE"
+LANG_CHOICES = tuple(OFFICIAL_TRANSPILATION_TARGETS)
 
 
 class CliErrorYaMostrado(Exception):
@@ -148,15 +149,6 @@ class CommandRegistry:
     ) -> Dict[str, BaseCommand]:
         base_commands = []
         command_classes = AppConfig.V2_COMMAND_CLASSES if ui == "v2" else AppConfig.BASE_COMMAND_CLASSES
-        if ui == "v2" and profile == PROFILE_DEVELOPMENT and LegacyCommandGroupV2 is None:
-            try:
-                from pcobra.cobra.cli.commands_v2.legacy_cmd import LegacyCommandGroupV2 as _LegacyCommandGroupV2
-                command_classes = command_classes + [_LegacyCommandGroupV2]
-            except Exception as exc:
-                logging.getLogger(__name__).debug(
-                    "No fue posible cargar grupo legacy para perfil development: %s",
-                    exc,
-                )
 
         for cmd_class in command_classes:
             try:
@@ -397,8 +389,7 @@ class CliApplication:
                 "Selecciona la interfaz CLI: v2 (recomendada para usuarios finales) o v1 (compatibilidad legacy). "
                 "En v2, la superficie pública es run/build/test/mod. "
                 "Los comandos internos quedan disponibles solo en perfil development "
-                "(COBRA_DEV_MODE=1 o COBRA_CLI_COMMAND_PROFILE=development) "
-                f"o con {COBRA_ENABLE_LEGACY_CLI_ENV}=1."
+                "(COBRA_DEV_MODE=1 o COBRA_CLI_COMMAND_PROFILE=development)."
             ),
         )
         parser.add_argument("--lang",

--- a/src/pcobra/cobra/cli/commands_v2/__init__.py
+++ b/src/pcobra/cobra/cli/commands_v2/__init__.py
@@ -5,7 +5,7 @@ from pcobra.cobra.cli.commands_v2.mod_cmd import ModCommandV2
 from pcobra.cobra.cli.commands_v2.run_cmd import RunCommandV2
 from pcobra.cobra.cli.commands_v2.test_cmd import TestCommandV2
 
-COBRA_ENABLE_LEGACY_CLI_ENV = "COBRA_ENABLE_LEGACY_CLI"
+COBRA_ENABLE_LEGACY_CLI_ENV = "COBRA_INTERNAL_ENABLE_LEGACY_CLI"
 
 
 def is_legacy_cli_enabled() -> bool:

--- a/tests/integration/golden/cli_help_public_no_legacy.golden
+++ b/tests/integration/golden/cli_help_public_no_legacy.golden
@@ -31,7 +31,7 @@ options:
                         (solo generar código), mixto (ejecutar y transpilar).
   --solo-cobra          Alias semántico de --modo cobra: sesión para solo
                         programar/interpretar Cobra sin rutas de codegen.
-  --ui {v1,v2}          Selecciona la interfaz CLI: v2 (recomendada para usuarios finales) o v1 (compatibilidad legacy). En v2, la superficie pública es run/build/test/mod. Los comandos internos quedan disponibles solo en perfil development (COBRA_DEV_MODE=1 o COBRA_CLI_COMMAND_PROFILE=development) o con COBRA_ENABLE_LEGACY_CLI=1.
+  --ui {v1,v2}          Selecciona la interfaz CLI: v2 (recomendada para usuarios finales) o v1 (compatibilidad legacy). En v2, la superficie pública es run/build/test/mod. Los comandos internos quedan disponibles solo en perfil development (COBRA_DEV_MODE=1 o COBRA_CLI_COMMAND_PROFILE=development).
   --lang LANG           Interface language code
   --no-color            Disable colored output
   --extra-validators EXTRA_VALIDATORS

--- a/tests/integration/golden/cli_ui_v2_help_public.golden
+++ b/tests/integration/golden/cli_ui_v2_help_public.golden
@@ -31,7 +31,7 @@ options:
                         (solo generar código), mixto (ejecutar y transpilar).
   --solo-cobra          alias semántico de --modo cobra: sesión para solo
                         programar/interpretar cobra sin rutas de codegen.
-  --ui {v1,v2}          selecciona la interfaz cli: v2 (recomendada para usuarios finales) o v1 (compatibilidad legacy). en v2, la superficie pública es run/build/test/mod. los comandos internos quedan disponibles solo en perfil development (cobra_dev_mode=1 o cobra_cli_command_profile=development) o con cobra_enable_legacy_cli=1.
+  --ui {v1,v2}          selecciona la interfaz cli: v2 (recomendada para usuarios finales) o v1 (compatibilidad legacy). en v2, la superficie pública es run/build/test/mod. los comandos internos quedan disponibles solo en perfil development (cobra_dev_mode=1 o cobra_cli_command_profile=development).
   --lang lang           interface language code
   --no-color            disable colored output
   --extra-validators extra_validators

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -1,0 +1,37 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from pcobra.cobra.cli.public_command_policy import PUBLIC_COMMANDS
+
+
+def _public_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("SQLITE_DB_KEY", None)
+    env.pop("COBRA_DEV_MODE", None)
+    env.pop("COBRA_CLI_COMMAND_PROFILE", None)
+    env.pop("COBRA_INTERNAL_ENABLE_LEGACY_CLI", None)
+    return env
+
+
+def test_cli_public_commands_contract_is_stable():
+    assert PUBLIC_COMMANDS == ("run", "build", "test", "mod")
+
+
+def test_cli_help_public_contract_snapshot():
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "-m", "cobra.cli.cli", "--ui", "v2", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=_public_env(),
+    )
+    assert result.returncode == 0
+
+    expected_snapshot = (
+        Path(__file__).parent / "golden" / "cli_ui_v2_help_public.golden"
+    ).read_text(encoding="utf-8")
+    assert " ".join(result.stdout.lower().split()) == " ".join(expected_snapshot.split())
+    assert "\n  legacy " not in result.stdout.lower()

--- a/tests/integration/test_cli_ui_v2.py
+++ b/tests/integration/test_cli_ui_v2.py
@@ -33,7 +33,7 @@ def test_cli_ui_v2_help_snapshot_publico_no_expone_legacy():
 
 
 def test_cli_ui_v2_help_muestra_legacy_solo_con_flag_interno(monkeypatch):
-    monkeypatch.setenv("COBRA_ENABLE_LEGACY_CLI", "1")
+    monkeypatch.setenv("COBRA_INTERNAL_ENABLE_LEGACY_CLI", "1")
     for module_name in (
         "cobra.cli.commands_v2",
         "pcobra.cobra.cli.commands_v2",
@@ -50,7 +50,7 @@ def test_cli_ui_v2_help_muestra_legacy_solo_con_flag_interno(monkeypatch):
 
 
 def test_cli_ui_v2_sin_flag_no_registra_legacy(monkeypatch):
-    monkeypatch.delenv("COBRA_ENABLE_LEGACY_CLI", raising=False)
+    monkeypatch.delenv("COBRA_INTERNAL_ENABLE_LEGACY_CLI", raising=False)
     for module_name in (
         "cobra.cli.commands_v2",
         "pcobra.cobra.cli.commands_v2",
@@ -66,8 +66,8 @@ def test_cli_ui_v2_sin_flag_no_registra_legacy(monkeypatch):
     assert "legacy" not in commands
 
 
-def test_cli_ui_v2_modo_desarrollo_expone_comandos_internos(monkeypatch):
-    monkeypatch.delenv("COBRA_ENABLE_LEGACY_CLI", raising=False)
+def test_cli_ui_v2_modo_desarrollo_no_expone_legacy_sin_flag_interno(monkeypatch):
+    monkeypatch.delenv("COBRA_INTERNAL_ENABLE_LEGACY_CLI", raising=False)
     monkeypatch.setenv("COBRA_DEV_MODE", "1")
     for module_name in (
         "cobra.cli.commands_v2",
@@ -87,4 +87,4 @@ def test_cli_ui_v2_modo_desarrollo_expone_comandos_internos(monkeypatch):
         profile=cli_reloaded.resolve_command_profile(),
     )
 
-    assert "legacy" in commands
+    assert "legacy" not in commands


### PR DESCRIPTION
### Motivation
- Proteger la superficie pública de la CLI para que solo exponga los comandos `run/build/test/mod` como contrato inmutable.
- Evitar que el grupo `legacy` quede expuesto por accidente en perfiles `development` sin un flag interno explícito.
- Detectar regresiones futuras en la ayuda pública mediante una prueba de snapshot que capture la salida de `--help`.

### Description
- Renombrado del flag interno de legacy a `COBRA_INTERNAL_ENABLE_LEGACY_CLI` y encapsulado en `src/pcobra/cobra/cli/commands_v2/__init__.py` para que la carga de `LegacyCommandGroupV2` requiera ese flag explícito.
- Eliminado el fallback que importaba/registraba automáticamente `legacy` en modo `development` dentro de `src/pcobra/cobra/cli/cli.py` para impedir exposición sin el flag interno.
- Ajustado el texto de ayuda de `--ui` para no documentar ningún flag interno y actualizado `LANG_CHOICES` en la CLI para derivarlo de `OFFICIAL_TRANSPILATION_TARGETS` (evita error de importación durante tests).
- Añadida prueba de contrato y snapshot pública en `tests/integration/test_cli_public_help_contract.py` que verifica `PUBLIC_COMMANDS == ("run", "build", "test", "mod")` y compara el `--ui v2 --help` en entorno público contra el golden; actualizados los goldens y tests afectados (`tests/integration/test_cli_ui_v2.py`).
- Documentación actualizada en `docs/migracion_cli_unificada.md` con equivalencias adicionales viejo → nuevo para facilitar la migración.

### Testing
- Ejecutado `pytest -q tests/integration/test_cli_ui_v2.py tests/integration/test_cli_public_help_contract.py -q` y las pruebas seleccionadas pasaron correctamente.
- Ejecutado `pytest -q tests/integration/test_cli_ayuda.py::test_cobra_help_snapshot_publico_no_expone_comandos_legacy -q` y la prueba pasó correctamente.
- Se actualizó el snapshot golden de ayuda pública (`tests/integration/golden/...`) para reflejar el texto no documentado del flag interno y se validó contra la nueva salida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e972fb048327aeb1cfe1ff87c823)