### PR TITLE
Centralizar contrato público de capacidades para resolución de backend

### DIFF
--- a/src/pcobra/cobra/architecture/capabilities_contract.py
+++ b/src/pcobra/cobra/architecture/capabilities_contract.py
@@ -11,8 +11,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
-from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS, PUBLIC_BACKENDS
+from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS
 from pcobra.cobra.bindings.contract import BindingRoute
+
+
+PUBLIC_BACKENDS: Final[tuple[str, ...]] = (
+    "python",
+    "javascript",
+    "rust",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -121,6 +128,7 @@ validate_capabilities_contract()
 
 __all__ = [
     "PROJECT_TYPE_PUBLIC_POLICY",
+    "PUBLIC_BACKENDS",
     "PUBLIC_CAPABILITIES_CONTRACT",
     "PUBLIC_FALLBACK_POLICY",
     "PublicBackendCapability",

--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pcobra.cobra.architecture.capabilities_contract import (
     PUBLIC_BACKENDS,
+    PUBLIC_CAPABILITIES_CONTRACT,
     assert_backend_allowed_for_scope,
     binding_route_for_public_backend,
 )
@@ -22,10 +23,11 @@ TRANSPILERS: dict[str, type] = build_official_transpilers()
 
 def _public_route_backend_matrix() -> dict[str, tuple[str, ...]]:
     """Matriz explícita de rutas públicas que usan resolución de backend."""
+    contract_backends = tuple(PUBLIC_CAPABILITIES_CONTRACT)
     return {
-        "build_pipeline.resolve_backend": PUBLIC_BACKENDS,
-        "build_pipeline.resolve_backend_runtime": PUBLIC_BACKENDS,
-        "build_pipeline.build": PUBLIC_BACKENDS,
+        "build_pipeline.resolve_backend": contract_backends,
+        "build_pipeline.resolve_backend_runtime": contract_backends,
+        "build_pipeline.build": contract_backends,
     }
 
 

--- a/src/pcobra/cobra/build/orchestrator.py
+++ b/src/pcobra/cobra/build/orchestrator.py
@@ -204,8 +204,7 @@ class BuildOrchestrator:
         return ordered
 
     def _default_priority(self) -> tuple[str, ...]:
-        weighted = sorted(PUBLIC_FALLBACK_POLICY, key=lambda backend: target_metadata(backend)["release_priority"])
-        return tuple(weighted)
+        return tuple(PUBLIC_FALLBACK_POLICY)
 
     def _supports_capabilities(self, backend: str, capabilities: tuple[str, ...]) -> bool:
         if not capabilities:


### PR DESCRIPTION
### Motivation
- Consolidar en una única fuente el conjunto de backends públicos, sus rutas de binding y la política de fallback para que todas las decisiones públicas de selección de backend dependan del mismo contrato.
- Evitar que rutas públicas utilicen backends legacy fuera del canon oficial (`python/javascript/rust`) y mantener acceso a backends legacy solo vía rutas internas de migración.
- Reducir la dispersión de lógica entre módulos de build/orquestador y garantizar validaciones en arranque sobre superficies públicas.

### Description
- Definí `PUBLIC_BACKENDS` dentro de `src/pcobra/cobra/architecture/capabilities_contract.py` y lo expuse en `__all__` para que el contrato de arquitectura sea la fuente canónica de backends públicos y rutas de binding.
- En `src/pcobra/cobra/build/orchestrator.py` simplifiqué la prioridad por defecto para rutas públicas devolviendo directamente `PUBLIC_FALLBACK_POLICY` y eliminé la ordenación adicional por metadata pública.
- En `src/pcobra/cobra/build/backend_pipeline.py` derivé la matriz de rutas públicas desde `PUBLIC_CAPABILITIES_CONTRACT` y mantuve/añadí validación de arranque que verifica `assert_backend_allowed_for_scope` y `binding_route_for_public_backend` para cada backend expuesto públicamente.
- Mantengo la separación de scope `public` vs `internal_migration` (legacy solo permitido bajo `internal_migration`) y no toqué `lexer`, `parser`, `ast_nodes` ni archivos `to_*.py`.

### Testing
- Ejecuté `pytest -q tests/unit/test_build_orchestrator.py tests/unit/test_backend_pipeline_runtime_manager.py` y ambas colecciones de tests pasaron exitosamente.
- Resultado de tests: `8 passed` (sin fallos).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e122c9c57483278937a759f2c621b2)