### PR TITLE
cli: reforzar contrato público y aislar registro legacy por flag interno

### DIFF
--- a/docs/migracion_cli_unificada.md
+++ b/docs/migracion_cli_unificada.md
@@ -35,6 +35,10 @@ Con backends públicos oficiales:
 | `cobra modulos remover modulo.co` | `cobra mod remove modulo.co` |
 | `cobra modulos buscar nombre` | `cobra mod search nombre` |
 | `cobra modulos publicar ruta/al/modulo.co` | `cobra mod publish ruta/al/modulo.co` |
+| `cobra interactive archivo.co` | `cobra run archivo.co` |
+| `cobra init` | `cobra mod init` |
+| `cobra crear` | `cobra mod init` |
+| `cobra paquete` | `cobra mod publish` |
 
 ## Migración de flags `--backend`
 

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -46,10 +46,12 @@ from pcobra.cobra.cli.commands.validar_sintaxis_cmd import ValidarSintaxisComman
 from pcobra.cobra.cli.commands.qa_validar_cmd import QaValidarCommand
 from pcobra.cobra.cli.commands_v2 import (
     BuildCommandV2,
+    COBRA_ENABLE_LEGACY_CLI_ENV,
     LegacyCommandGroupV2,
     ModCommandV2,
     RunCommandV2,
     TestCommandV2,
+    is_legacy_cli_enabled,
 )
 from pcobra.cobra.cli.i18n import _, format_traceback, setup_gettext
 from pcobra.cobra.cli.mode_policy import (
@@ -119,8 +121,6 @@ class AppConfig:
         ValidarSintaxisCommand, QaValidarCommand, PluginsCommand, AgixCommand
     ]
     V2_COMMAND_CLASSES: List[Type[BaseCommand]] = [RunCommandV2, BuildCommandV2, TestCommandV2, ModCommandV2]
-    if LegacyCommandGroupV2 is not None:
-        V2_COMMAND_CLASSES.append(LegacyCommandGroupV2)
 
 
 class CommandRegistry:
@@ -140,6 +140,16 @@ class CommandRegistry:
             logging.error(f"Error creating command {command_class.__name__}: {e}")
             raise
 
+    def _resolve_v2_command_classes(self) -> List[Type[BaseCommand]]:
+        classes = list(AppConfig.V2_COMMAND_CLASSES)
+        if LegacyCommandGroupV2 is not None and is_legacy_cli_enabled():
+            classes.append(LegacyCommandGroupV2)
+            logging.getLogger(__name__).debug(
+                "Compatibilidad legacy v2 habilitada por flag interno %s=1.",
+                COBRA_ENABLE_LEGACY_CLI_ENV,
+            )
+        return classes
+
     def register_base_commands(
         self,
         subparsers: Any,
@@ -148,7 +158,7 @@ class CommandRegistry:
         profile: str = PROFILE_PUBLIC,
     ) -> Dict[str, BaseCommand]:
         base_commands = []
-        command_classes = AppConfig.V2_COMMAND_CLASSES if ui == "v2" else AppConfig.BASE_COMMAND_CLASSES
+        command_classes = self._resolve_v2_command_classes() if ui == "v2" else AppConfig.BASE_COMMAND_CLASSES
 
         for cmd_class in command_classes:
             try:
@@ -261,9 +271,15 @@ class CliApplication:
             return
 
         command_profile = resolve_command_profile()
+        selected_ui = getattr(self, "_selected_ui", "v2")
+        if command_profile == PROFILE_PUBLIC and selected_ui == "v1":
+            logging.getLogger(__name__).debug(
+                "Perfil público activo: forzando UI v2 para evitar exposición de comandos legacy en --help.",
+            )
+            selected_ui = "v2"
         self.command_registry.register_base_commands(
             self._subparsers,
-            ui=getattr(self, "_selected_ui", "v2"),
+            ui=selected_ui,
             profile=command_profile,
         )
         menu_parser = self._subparsers.add_parser("menu", help=_("Modo interactivo"))
@@ -386,7 +402,7 @@ class CliApplication:
             choices=("v1", "v2"),
             default="v2",
             help=_(
-                "Selecciona la interfaz CLI: v2 (recomendada para usuarios finales) o v1 (compatibilidad legacy). "
+                "Selecciona la interfaz CLI: v2 (recomendada para usuarios finales) o v1 (compatibilidad interna). "
                 "En v2, la superficie pública es run/build/test/mod. "
                 "Los comandos internos quedan disponibles solo en perfil development "
                 "(COBRA_DEV_MODE=1 o COBRA_CLI_COMMAND_PROFILE=development)."

--- a/tests/integration/golden/cli_ui_v2_help_public.golden
+++ b/tests/integration/golden/cli_ui_v2_help_public.golden
@@ -31,7 +31,12 @@ options:
                         (solo generar código), mixto (ejecutar y transpilar).
   --solo-cobra          alias semántico de --modo cobra: sesión para solo
                         programar/interpretar cobra sin rutas de codegen.
-  --ui {v1,v2}          selecciona la interfaz cli: v2 (recomendada para usuarios finales) o v1 (compatibilidad legacy). en v2, la superficie pública es run/build/test/mod. los comandos internos quedan disponibles solo en perfil development (cobra_dev_mode=1 o cobra_cli_command_profile=development).
+  --ui {v1,v2}          selecciona la interfaz cli: v2 (recomendada para
+                        usuarios finales) o v1 (compatibilidad interna). en
+                        v2, la superficie pública es run/build/test/mod. los
+                        comandos internos quedan disponibles solo en perfil
+                        development (cobra_dev_mode=1 o
+                        cobra_cli_command_profile=development).
   --lang lang           interface language code
   --no-color            disable colored output
   --extra-validators extra_validators

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -35,3 +35,24 @@ def test_cli_help_public_contract_snapshot():
     ).read_text(encoding="utf-8")
     assert " ".join(result.stdout.lower().split()) == " ".join(expected_snapshot.split())
     assert "\n  legacy " not in result.stdout.lower()
+
+
+def test_cli_help_public_contract_snapshot_no_expone_legacy_aun_con_ui_v1():
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "-m", "cobra.cli.cli", "--ui", "v1", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=_public_env(),
+    )
+    assert result.returncode == 0
+
+    expected_snapshot = (
+        Path(__file__).parent / "golden" / "cli_ui_v2_help_public.golden"
+    ).read_text(encoding="utf-8")
+    assert " ".join(result.stdout.lower().split()) == " ".join(expected_snapshot.split())
+    lower_help = result.stdout.lower()
+    assert "\n  legacy " not in lower_help
+    assert "\n  compilar " not in lower_help
+    assert "\n  ejecutar " not in lower_help


### PR DESCRIPTION
### Motivation
- Proteger la superficie pública de la CLI para que `--help` no exponga comandos legacy/obsoletos. 
- Encapsular el registro de los comandos legacy detrás de un feature flag interno para que sólo equipos de migración puedan habilitarlo. 
- Detectar regresiones en la exposición pública mediante una prueba de contrato (snapshot) de la ayuda.

### Description
- Mantiene el contrato público inmutable `PUBLIC_COMMANDS = ("run", "build", "test", "mod")` y evita su reintroducción en la ayuda pública. 
- Mueve la inclusión de `LegacyCommandGroupV2` a una resolución dinámica en `CommandRegistry._resolve_v2_command_classes()` y la condiciona al flag interno `COBRA_INTERNAL_ENABLE_LEGACY_CLI=1` usando `is_legacy_cli_enabled()`. 
- En `CliApplication._ensure_command_structure()` se fuerza la UI efectiva a `v2` cuando el perfil resuelto es `public` y el usuario solicitó `--ui v1`, para evitar que `--help` muestre comandos legacy. 
- Ajusta el texto de ayuda de la opción `--ui` para indicar que `v1` es "compatibilidad interna" y no una superficie pública. 
- Añade una prueba de contrato `test_cli_help_public_contract_snapshot_no_expone_legacy_aun_con_ui_v1` que valida que `--help` en entorno público produce el snapshot público esperado incluso si se pasa `--ui v1`, y actualiza el golden `cli_ui_v2_help_public.golden`. 
- Amplía la documentación `docs/migracion_cli_unificada.md` con equivalencias adicionales de comandos legacy → nuevos.

### Testing
- Ejecutado `pytest -q tests/integration/test_cli_public_help_contract.py tests/integration/test_cli_ui_v2.py` y todos los tests relevantes pasaron (7 passed). 
- Se regeneró el snapshot de ayuda pública `tests/integration/golden/cli_ui_v2_help_public.golden` y la nueva prueba de contrato confirmó que `--ui v1` no reintroduce comandos legacy en perfil público.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1308717548327a2d19da406da5623)