### PR TITLE
Add configurable import collision policies, hybrid-module config, and precedence_reason metadata

### DIFF
--- a/docs/architecture/import-resolution-contract.md
+++ b/docs/architecture/import-resolution-contract.md
@@ -20,16 +20,33 @@ En términos prácticos:
 
 Se considera ambiguo un import sin namespace (sin `.`) que tenga más de un candidato válido entre los orígenes del contrato.
 
-### Modo por defecto (no estricto)
+La política se configura por proyecto en `cobra.toml`:
+
+```toml
+[imports]
+collision_policy = "warn" # warn | strict_error | namespace_required
+```
+
+Si no se declara nada, el resolver usa `warn` por compatibilidad.
+
+### `warn` (modo por defecto)
 
 - El resolver emite `UserWarning`.
 - Se selecciona automáticamente el candidato de mayor prioridad según `_SOURCE_ORDER`.
 
-### Strict mode (`strict_ambiguous_imports=True`)
+### `strict_error`
 
 - El resolver **falla** con `ImportResolutionError`.
 - La resolución automática queda deshabilitada para imports ambiguos.
 - Se exige import explícito para desambiguar.
+
+### `namespace_required`
+
+- El resolver **falla** con `ImportResolutionError` ante colisiones sin namespace.
+- El mensaje exige usar namespace explícito (`cobra.*`, `app.*`, etc.).
+- Mantiene el mismo orden de precedencia como contrato estable, pero no permite aplicarlo de forma implícita en imports ambiguos.
+
+> Compatibilidad: `strict_ambiguous_imports=True` sigue soportado y fuerza `strict_error`.
 
 ## 3) Prefijos recomendados para evitar colisiones
 
@@ -51,5 +68,51 @@ Cuando el resolvedor carga un módulo Python (`load_module`), inyecta metadata p
   - `resolved_name`
   - `backend`
   - `import_path`
+  - `precedence_reason` (motivo de precedencia: selección única o aplicación de orden estable)
 
 Esta metadata habilita trazabilidad de resolución y debugging en runtime sin inspección adicional del resolvedor.
+
+## 5) Casos de referencia (debug operativo)
+
+### Caso A — `importar pandas` (`python_bridge`)
+
+- Si no existe `cobra.pandas` ni módulo de proyecto `pandas`, el candidato único es `python_bridge`.
+- Resultado esperado:
+  - `source = "python_bridge"`
+  - `resolved_name = "pandas"`
+  - `precedence_reason = "unique_source:python_bridge"`
+
+### Caso B — `importar datos` (stdlib Cobra)
+
+- Si existe `cobra.datos`, se resuelve a stdlib.
+- Si además hay `datos` de proyecto o bridge Python, hay colisión y:
+  - con `warn`: se selecciona `cobra.datos` + warning,
+  - con `strict_error` o `namespace_required`: falla hasta que el import sea explícito.
+- En resolución implícita por colisión:
+  - `precedence_reason = "source_order:stdlib > project > python_bridge > hybrid"`
+
+### Caso C — módulo híbrido declarado en config
+
+Declaración en `cobra.toml`:
+
+```toml
+[imports.hybrid_modules.mi_hibrido]
+import_path = "mi_hibrido_runtime"
+backend = "javascript"
+```
+
+- `importar mi_hibrido` produce:
+  - `source = "hybrid"`
+  - `import_path = "mi_hibrido_runtime"`
+  - `backend = "javascript"` (si no hay override de contrato por módulo)
+  - `precedence_reason = "unique_source:hybrid"`
+
+## 6) Ejemplos de conflictos y resolución explícita
+
+- Conflicto `datos` entre stdlib y proyecto:
+  - Implícito: `importar datos` (ambigüedad)
+  - Explícito recomendado:
+    - stdlib: `importar cobra.datos`
+    - proyecto: `importar app.datos`
+- Conflicto con bridge Python:
+  - Si existe paquete Python `datos`, usar nombre explícito de proyecto o stdlib para evitar depender de orden de precedencia.

--- a/docs/config_cli.md
+++ b/docs/config_cli.md
@@ -144,6 +144,37 @@ javascript = "build/modulo.js"
 - Para proyectos que solo distribuyen un subconjunto de backends, ajusta
   explícitamente `required_targets` para evitar errores de validación.
 
+## Política de colisiones de imports en `cobra.toml`
+
+El resolvedor de imports (`CobraImportResolver`) mantiene **orden estable** de
+precedencia:
+
+1. `stdlib`
+2. `project`
+3. `python_bridge`
+4. `hybrid`
+
+La política de qué hacer ante colisiones de nombres sin namespace se configura
+por proyecto:
+
+```toml
+[imports]
+collision_policy = "warn" # warn | strict_error | namespace_required
+```
+
+- `warn`: mantiene comportamiento actual (warning + selección por precedencia).
+- `strict_error`: convierte la colisión en error.
+- `namespace_required`: exige imports explícitos con namespace cuando hay
+  colisión (`cobra.*`, `app.*`, etc.).
+
+También puedes declarar módulos híbridos:
+
+```toml
+[imports.hybrid_modules.mi_hibrido]
+import_path = "mi_hibrido_runtime"
+backend = "javascript"
+```
+
 ## Terminología: interfaz pública vs backend interno
 
 - **Interfaz pública**: comandos y documentación para usuarios (`cobra run`, `cobra build`, `cobra test`, `cobra mod`) y backends oficiales `python`, `javascript`, `rust`.

--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -41,9 +41,13 @@ class ResolutionResult:
     import_path: str | None = None
     backend: str | None = None
     backend_adapter: object | None = None
+    precedence_reason: str | None = None
 
 
 _SOURCE_ORDER: tuple[str, ...] = ("stdlib", "project", "python_bridge", "hybrid")
+_SUPPORTED_COLLISION_POLICIES: frozenset[str] = frozenset(
+    {"warn", "strict_error", "namespace_required"}
+)
 
 
 class CobraImportResolver:
@@ -56,13 +60,68 @@ class CobraImportResolver:
         hybrid_modules: Mapping[str, HybridModuleSpec | Mapping[str, Any]] | None = None,
         default_backend: str = "python",
         strict_ambiguous_imports: bool = False,
+        collision_policy: str | None = None,
     ) -> None:
         self.project_root = Path(project_root).resolve() if project_root else None
-        self.hybrid_modules = self._normalize_hybrid_modules(hybrid_modules or {})
+        config = get_toml_map()
+        self.hybrid_modules = self._load_hybrid_modules(config, hybrid_modules)
         self.default_backend = default_backend
-        self.strict_ambiguous_imports = strict_ambiguous_imports
+        self.collision_policy = self._resolve_collision_policy(
+            config=config,
+            strict_ambiguous_imports=strict_ambiguous_imports,
+            explicit_policy=collision_policy,
+        )
         self.stdlib_modules = self._load_stdlib_modules()
         self.project_modules = self._load_project_modules()
+
+    def _load_hybrid_modules(
+        self,
+        config: Mapping[str, Any],
+        explicit_modules: Mapping[str, HybridModuleSpec | Mapping[str, Any]] | None,
+    ) -> dict[str, HybridModuleSpec]:
+        declared_in_config = self._hybrid_modules_from_config(config)
+        declared_explicit = self._normalize_hybrid_modules(explicit_modules or {})
+        declared_in_config.update(declared_explicit)
+        return declared_in_config
+
+    @staticmethod
+    def _hybrid_modules_from_config(config: Mapping[str, Any]) -> dict[str, HybridModuleSpec]:
+        imports_section = config.get("imports", {})
+        if not isinstance(imports_section, Mapping):
+            return {}
+        raw_hybrid = imports_section.get("hybrid_modules", {})
+        if not isinstance(raw_hybrid, Mapping):
+            return {}
+        return CobraImportResolver._normalize_hybrid_modules(raw_hybrid)
+
+    @staticmethod
+    def _resolve_collision_policy(
+        *,
+        config: Mapping[str, Any],
+        strict_ambiguous_imports: bool,
+        explicit_policy: str | None,
+    ) -> str:
+        if strict_ambiguous_imports:
+            return "strict_error"
+
+        configured_policy = CobraImportResolver._collision_policy_from_config(config)
+        chosen = explicit_policy or configured_policy or "warn"
+        if chosen not in _SUPPORTED_COLLISION_POLICIES:
+            raise ImportResolutionError(
+                "Política de colisiones inválida. "
+                "Usa 'warn', 'strict_error' o 'namespace_required'."
+            )
+        return chosen
+
+    @staticmethod
+    def _collision_policy_from_config(config: Mapping[str, Any]) -> str | None:
+        imports_section = config.get("imports", {})
+        if not isinstance(imports_section, Mapping):
+            return None
+        policy = imports_section.get("collision_policy")
+        if isinstance(policy, str):
+            return policy.strip()
+        return None
 
     @staticmethod
     def _normalize_hybrid_modules(
@@ -111,6 +170,12 @@ class CobraImportResolver:
         if not candidates:
             raise ImportResolutionError(f"No se encontró módulo para '{name}'")
 
+        precedence_reason = (
+            f"unique_source:{candidates[0].source}"
+            if len(candidates) == 1
+            else f"source_order:{' > '.join(_SOURCE_ORDER)}"
+        )
+
         if "." not in name and len(candidates) > 1:
             details = ", ".join(f"{c.source}:{c.resolved_name}" for c in candidates)
             message = (
@@ -120,11 +185,25 @@ class CobraImportResolver:
                 f"Recomendación: usa prefijo explícito ('cobra.{name}') para stdlib o namespace de proyecto "
                 f"(por ejemplo 'app.{name}')."
             )
-            if self.strict_ambiguous_imports:
-                raise ImportResolutionError(f"{message} Activa resolución explícita en strict mode.")
+            if self.collision_policy in {"strict_error", "namespace_required"}:
+                suffix = (
+                    " Modo namespace_required: debes importar con namespace explícito."
+                    if self.collision_policy == "namespace_required"
+                    else " Activa resolución explícita en strict mode."
+                )
+                raise ImportResolutionError(f"{message}{suffix}")
             warnings.warn(message, category=UserWarning, stacklevel=2)
 
-        return self._attach_backend_adapter(candidates[0])
+        selected = ResolutionResult(
+            request=candidates[0].request,
+            source=candidates[0].source,
+            resolved_name=candidates[0].resolved_name,
+            import_path=candidates[0].import_path,
+            backend=candidates[0].backend,
+            backend_adapter=candidates[0].backend_adapter,
+            precedence_reason=precedence_reason,
+        )
+        return self._attach_backend_adapter(selected)
 
     def load_module(
         self,
@@ -161,6 +240,7 @@ class CobraImportResolver:
             "resolved_name": resolution.resolved_name,
             "backend": resolution.backend,
             "import_path": resolution.import_path,
+            "precedence_reason": resolution.precedence_reason,
         }
         setattr(module, "__cobra_resolution_source__", resolution.source)
         setattr(module, "__cobra_backend_injected__", resolution.backend)
@@ -177,6 +257,7 @@ class CobraImportResolver:
             import_path=resolution.import_path,
             backend=effective_backend,
             backend_adapter=adapter,
+            precedence_reason=resolution.precedence_reason,
         )
 
     def _build_candidate(self, source: str, name: str) -> ResolutionResult | None:

--- a/tests/unit/test_imports_resolver.py
+++ b/tests/unit/test_imports_resolver.py
@@ -62,6 +62,26 @@ def test_colision_en_modo_estricto_falla(tmp_path):
         resolver.resolve("datos")
 
 
+def test_colision_en_namespace_required_falla(tmp_path):
+    (tmp_path / "datos.co").write_text("usar algo")
+    resolver = CobraImportResolver(project_root=tmp_path, collision_policy="namespace_required")
+
+    with pytest.raises(ImportResolutionError, match="namespace_required"):
+        resolver.resolve("datos")
+
+
+def test_politica_colisiones_desde_config(monkeypatch, tmp_path):
+    (tmp_path / "datos.co").write_text("usar algo")
+    monkeypatch.setattr(
+        "pcobra.cobra.imports.resolver.get_toml_map",
+        lambda: {"imports": {"collision_policy": "strict_error"}},
+    )
+    resolver = CobraImportResolver(project_root=tmp_path)
+
+    with pytest.raises(ImportResolutionError, match="strict mode"):
+        resolver.resolve("datos")
+
+
 def test_bridge_python_directo():
     resolver = CobraImportResolver()
 
@@ -109,7 +129,42 @@ def test_modulo_hibrido_inyecta_adapter_backend(monkeypatch):
         "resolved_name": "mi_hibrido",
         "backend": "javascript",
         "import_path": "mi_hibrido_runtime",
+        "precedence_reason": "unique_source:hybrid",
     }
+
+
+def test_modulo_hibrido_desde_config(monkeypatch):
+    fake_module = ModuleType("hibrido_config_runtime")
+
+    import importlib
+
+    original_import_module = importlib.import_module
+
+    def fake_import_module(name: str):
+        if name == "hibrido_config_runtime":
+            return fake_module
+        return original_import_module(name)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(
+        "pcobra.cobra.imports.resolver.get_toml_map",
+        lambda: {
+            "imports": {
+                "hybrid_modules": {
+                    "mod_hibrido": {
+                        "import_path": "hibrido_config_runtime",
+                        "backend": "python",
+                    }
+                }
+            }
+        },
+    )
+    resolver = CobraImportResolver()
+
+    resolution, module = resolver.load_module("mod_hibrido")
+
+    assert resolution.source == "hybrid"
+    assert module is fake_module
 
 
 def test_resolver_adjunta_adapter_desde_resolucion():
@@ -119,6 +174,17 @@ def test_resolver_adjunta_adapter_desde_resolucion():
 
     assert result.backend is not None
     assert result.backend_adapter is not None
+    assert result.precedence_reason == "unique_source:python_bridge"
+
+
+def test_motivo_precedencia_en_colision(tmp_path):
+    (tmp_path / "datos.co").write_text("usar algo")
+    resolver = CobraImportResolver(project_root=tmp_path)
+
+    with pytest.warns(UserWarning, match="Colisión de import"):
+        result = resolver.resolve("datos")
+
+    assert result.precedence_reason == "source_order:stdlib > project > python_bridge > hybrid"
 
 
 def test_error_si_no_hay_candidato():


### PR DESCRIPTION
### Motivation

- Mantener el orden de precedencia existente (`stdlib > project > python_bridge > hybrid`) como contrato estable mientras se da control por proyecto sobre el comportamiento ante colisiones.
- Permitir que proyectos configuren la política de colisiones para evitar warnings silenciosos o permitir modos más estrictos.
- Facilitar debugging y observabilidad aportando un motivo de precedencia consumible por la CLI/runtime.
- Soportar la declaración de módulos híbridos desde `cobra.toml` para un registro centralizado y reproducible.

### Description

- Añade soporte de política de colisiones configurable en `CobraImportResolver` con valores `warn`, `strict_error` y `namespace_required`, y permite leer la política desde `cobra.toml` en `[imports].collision_policy` o pasarla como `collision_policy` al resolver, manteniendo la compatibilidad de `strict_ambiguous_imports=True` como alias de `strict_error`.
- Extiende `ResolutionResult` con el campo `precedence_reason` y lo inyecta en la metadata del módulo (`__cobra_resolution_metadata__`) como `precedence_reason` (ej.: `unique_source:<origen>` o `source_order:stdlib > project > python_bridge > hybrid`).
- Lee y mezcla la declaración de módulos híbridos desde `cobra.toml` en `[imports.hybrid_modules.*]` y la combina con módulos híbridos provistos explícitamente en el constructor, priorizando los explícitos.
- Ajusta la lógica de resolución para aplicar la política de colisiones (emitir warning, lanzar `ImportResolutionError` o exigir namespace explícito) y preservar/incluir `precedence_reason` en el resultado final y en los adaptadores de backend.
- Actualiza documentación en `docs/architecture/import-resolution-contract.md` y `docs/config_cli.md` para describir la nueva `collision_policy`, ejemplos de casos (`importar pandas`, `importar datos`, módulo híbrido en config) y recomendaciones de desambiguación explícita.
- Añade y actualiza pruebas en `tests/unit/test_imports_resolver.py` para cubrir los modos `namespace_required`, lectura de política desde config, `precedence_reason` y carga de módulos híbridos desde configuración.

### Testing

- Ejecutado `pytest -q tests/unit/test_imports_resolver.py`, resultado: `12 passed` (todos los tests unitarios modificados y existentes pasaron).
- No se ejecutaron cambios adicionales de integración o CI en este PR; los tests unitarios locales confirmaron el comportamiento esperado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c1ac04ec832799fbeb9993803f1c)