### PR TITLE
Refuerza contrato de bindings con matriz ABI y validación por ruta en run/test

### DIFF
--- a/bindings/contract.py
+++ b/bindings/contract.py
@@ -27,6 +27,26 @@ class BindingCapabilities:
     managed_runtime: bool
 
 
+@dataclass(frozen=True, slots=True)
+class AbiCompatibilityPolicy:
+    """Matriz ABI por ruta y política explícita de compatibilidad."""
+
+    current: str
+    supported: tuple[str, ...]
+    backwards_compatible_with: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RouteOperationalLimits:
+    """Límites operativos contractuales por ruta de binding."""
+
+    process_model: str
+    isolation_boundary: str
+    ffi_boundary: str
+    sandbox_support: str
+    container_support: str
+
+
 PYTHON_BINDING: Final[BindingCapabilities] = BindingCapabilities(
     route=BindingRoute.PYTHON_DIRECT_IMPORT,
     language="python",
@@ -60,6 +80,48 @@ BINDINGS_BY_LANGUAGE: Final[dict[str, BindingCapabilities]] = {
     "rust": RUST_BINDING,
 }
 
+ABI_POLICY_BY_ROUTE: Final[dict[BindingRoute, AbiCompatibilityPolicy]] = {
+    BindingRoute.PYTHON_DIRECT_IMPORT: AbiCompatibilityPolicy(
+        current="1.0",
+        supported=("1.0",),
+        backwards_compatible_with=("1.0",),
+    ),
+    BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE: AbiCompatibilityPolicy(
+        current="1.1",
+        supported=("1.1", "1.0"),
+        backwards_compatible_with=("1.0",),
+    ),
+    BindingRoute.RUST_COMPILED_FFI: AbiCompatibilityPolicy(
+        current="2.0",
+        supported=("2.0", "1.1", "1.0"),
+        backwards_compatible_with=("1.1", "1.0"),
+    ),
+}
+
+ROUTE_OPERATIONAL_LIMITS: Final[dict[BindingRoute, RouteOperationalLimits]] = {
+    BindingRoute.PYTHON_DIRECT_IMPORT: RouteOperationalLimits(
+        process_model="Mismo proceso del runtime principal",
+        isolation_boundary="Sin aislamiento de proceso; depende de safe_mode/validadores",
+        ffi_boundary="No aplica (sin frontera FFI nativa)",
+        sandbox_support="Soportado en sandbox Python",
+        container_support="No soportado como ruta directa",
+    ),
+    BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE: RouteOperationalLimits(
+        process_model="Proceso/VM de runtime JS gestionado",
+        isolation_boundary="Aislamiento obligatorio (sandbox JS o contenedor)",
+        ffi_boundary="No usa FFI nativa; IPC/mensajería versionada",
+        sandbox_support="Soportado en sandbox de runtime gestionado",
+        container_support="Soportado y recomendado para pruebas reproducibles",
+    ),
+    BindingRoute.RUST_COMPILED_FFI: RouteOperationalLimits(
+        process_model="Proceso principal + librería nativa cargada",
+        isolation_boundary="Frontera nativa por ABI/FFI",
+        ffi_boundary="Requiere ABI explícita y artefactos compilados",
+        sandbox_support="No soportado en sandbox Python",
+        container_support="Soportado para aislamiento operativo",
+    ),
+}
+
 
 def resolve_binding(language: str) -> BindingCapabilities:
     """Resuelve el contrato de bindings para un lenguaje canónico."""
@@ -75,9 +137,13 @@ def resolve_binding(language: str) -> BindingCapabilities:
 
 
 __all__ = [
+    "AbiCompatibilityPolicy",
     "BindingCapabilities",
     "BindingRoute",
     "BINDINGS_BY_LANGUAGE",
+    "ABI_POLICY_BY_ROUTE",
+    "ROUTE_OPERATIONAL_LIMITS",
+    "RouteOperationalLimits",
     "JAVASCRIPT_BINDING",
     "PYTHON_BINDING",
     "RUST_BINDING",

--- a/docs/bindings_runtime_contract.md
+++ b/docs/bindings_runtime_contract.md
@@ -1,0 +1,51 @@
+# Contrato de rutas de binding (normativo)
+
+Este documento resume el contrato normativo declarado en `bindings/contract.py`.
+La **fuente normativa única** para rutas, matriz ABI y límites operativos es ese archivo.
+
+## Rutas contractuales
+
+- `python_direct_import`
+- `javascript_runtime_bridge`
+- `rust_compiled_ffi`
+
+## Matriz ABI por ruta y compatibilidad hacia atrás
+
+| Ruta | ABI actual | ABI soportadas | Compatibilidad hacia atrás |
+| --- | --- | --- | --- |
+| `python_direct_import` | `1.0` | `1.0` | `1.0` |
+| `javascript_runtime_bridge` | `1.1` | `1.1`, `1.0` | `1.0` |
+| `rust_compiled_ffi` | `2.0` | `2.0`, `1.1`, `1.0` | `1.1`, `1.0` |
+
+Política:
+
+1. Si no se especifica ABI, se negocia la ABI actual por ruta.
+2. Si se especifica ABI y está en soportadas, se acepta si coincide con la actual
+   o si está incluida en la lista de compatibilidad hacia atrás.
+3. Cualquier ABI fuera de `soportadas` se rechaza.
+
+## Límites operativos por ruta
+
+### `python_direct_import`
+
+- Proceso: mismo proceso del runtime principal.
+- Aislamiento: no hay aislamiento de proceso; depende de `safe_mode` + validadores.
+- FFI: no aplica.
+- Sandbox: soportado (sandbox Python).
+- Contenedor: no soportado como ruta directa.
+
+### `javascript_runtime_bridge`
+
+- Proceso: runtime JS gestionado (proceso/VM dedicado).
+- Aislamiento: obligatorio (sandbox de runtime gestionado o contenedor).
+- FFI: no usa FFI nativa; usa IPC/mensajería versionada.
+- Sandbox: soportado.
+- Contenedor: soportado (recomendado para reproducibilidad de pruebas).
+
+### `rust_compiled_ffi`
+
+- Proceso: proceso principal + librería nativa cargada.
+- Aislamiento: frontera nativa por ABI/FFI.
+- FFI: requiere ABI explícita y artefactos compilados.
+- Sandbox: no soportado en sandbox Python.
+- Contenedor: soportado para aislamiento operativo.

--- a/src/pcobra/cobra/bindings/contract.py
+++ b/src/pcobra/cobra/bindings/contract.py
@@ -4,7 +4,10 @@ Fuente canónica: ``bindings/contract.py``.
 """
 
 from bindings.contract import (  # re-export canónico
+    ABI_POLICY_BY_ROUTE,
     BINDINGS_BY_LANGUAGE,
+    ROUTE_OPERATIONAL_LIMITS,
+    AbiCompatibilityPolicy,
     BindingCapabilities,
     BindingRoute,
     JAVASCRIPT_BINDING,
@@ -14,9 +17,12 @@ from bindings.contract import (  # re-export canónico
 )
 
 __all__ = [
+    "AbiCompatibilityPolicy",
     "BindingCapabilities",
     "BindingRoute",
     "BINDINGS_BY_LANGUAGE",
+    "ABI_POLICY_BY_ROUTE",
+    "ROUTE_OPERATIONAL_LIMITS",
     "PYTHON_BINDING",
     "JAVASCRIPT_BINDING",
     "RUST_BINDING",

--- a/src/pcobra/cobra/bindings/runtime_manager.py
+++ b/src/pcobra/cobra/bindings/runtime_manager.py
@@ -13,17 +13,13 @@ except ModuleNotFoundError:  # pragma: no cover
     import tomli as tomllib
 
 from pcobra.cobra.bindings.contract import (
+    ABI_POLICY_BY_ROUTE,
     BindingCapabilities,
     BindingRoute,
     resolve_binding,
 )
 
 DEFAULT_ABI_VERSION: Final[str] = "1.0"
-SUPPORTED_ABI_VERSIONS: Final[dict[BindingRoute, tuple[str, ...]]] = {
-    BindingRoute.PYTHON_DIRECT_IMPORT: ("1.0",),
-    BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE: ("1.0",),
-    BindingRoute.RUST_COMPILED_FFI: ("1.0",),
-}
 
 SECURITY_POLICY_BY_COMMAND: Final[dict[str, dict[BindingRoute, dict[str, bool]]]] = {
     "run": {
@@ -57,28 +53,32 @@ class RuntimeManager:
             route=BindingRoute.PYTHON_DIRECT_IMPORT,
             implementation="python_direct_bridge",
             security_profile="same_process_safe_mode",
-            abi_version=DEFAULT_ABI_VERSION,
+            abi_version=ABI_POLICY_BY_ROUTE[BindingRoute.PYTHON_DIRECT_IMPORT].current,
         ),
         BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE: RuntimeBridgeDescriptor(
             route=BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE,
             implementation="javascript_controlled_runtime_bridge",
             security_profile="managed_runtime_isolation",
-            abi_version=DEFAULT_ABI_VERSION,
+            abi_version=ABI_POLICY_BY_ROUTE[BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE].current,
         ),
         BindingRoute.RUST_COMPILED_FFI: RuntimeBridgeDescriptor(
             route=BindingRoute.RUST_COMPILED_FFI,
             implementation="rust_compiled_ffi_bridge",
             security_profile="native_ffi_boundary",
-            abi_version=DEFAULT_ABI_VERSION,
+            abi_version=ABI_POLICY_BY_ROUTE[BindingRoute.RUST_COMPILED_FFI].current,
         ),
     }
 
     def resolve_runtime(self, language: str) -> tuple[BindingCapabilities, RuntimeBridgeDescriptor]:
-        """Resuelve contrato y bridge asociado para un lenguaje."""
+        """Resuelve contrato, negocia ABI y retorna bridge asociado."""
 
-        capabilities = resolve_binding(language)
-        bridge = self._BRIDGES[capabilities.route]
+        capabilities = self._resolve_capabilities(language)
+        bridge = self.select_bridge(capabilities)
+        self.negotiate_abi(capabilities)
         return capabilities, bridge
+
+    def _resolve_capabilities(self, language: str) -> BindingCapabilities:
+        return resolve_binding(language)
 
     def validate_security_route(
         self,
@@ -88,17 +88,17 @@ class RuntimeManager:
         containerized: bool = False,
         command: str = "run",
     ) -> None:
-        """Valida que la ruta elegida cumpla expectativas mínimas de seguridad."""
+        """Valida seguridad por ruta contractual y política del comando."""
 
         normalized_command = (command or "run").strip().lower()
         if normalized_command not in SECURITY_POLICY_BY_COMMAND:
             allowed = ", ".join(sorted(SECURITY_POLICY_BY_COMMAND))
             raise ValueError(f"Comando '{command}' no soportado en política de seguridad. Use: {allowed}.")
 
-        capabilities, _bridge = self.resolve_runtime(language)
+        capabilities = self._resolve_capabilities(language)
         route = capabilities.route
 
-        # Reglas base por tipo de ruta
+        # Validación base por ruta
         if route is BindingRoute.PYTHON_DIRECT_IMPORT and containerized:
             raise ValueError(
                 "La ruta python_direct_import no puede marcarse como containerizada. "
@@ -115,7 +115,7 @@ class RuntimeManager:
                 "en sandbox Python directo."
             )
 
-        # Reglas por comando (run/test)
+        # Validación por comando público
         command_policy = SECURITY_POLICY_BY_COMMAND[normalized_command][route]
         if command_policy["sandbox_required"] and not sandbox:
             raise ValueError(
@@ -126,19 +126,40 @@ class RuntimeManager:
                 f"La política '{normalized_command}' exige contenedor para la ruta {route.value}."
             )
 
-    def validate_abi_route(self, language: str, abi_version: str | None = None) -> str:
-        """Valida compatibilidad ABI de la ruta seleccionada."""
+    def negotiate_abi(self, capabilities: BindingCapabilities, abi_version: str | None = None) -> str:
+        """Negocia ABI por ruta usando matriz canónica y compatibilidad hacia atrás."""
 
-        capabilities, bridge = self.resolve_runtime(language)
-        negotiated_abi = abi_version or self._resolve_project_abi_for_backend(capabilities.language)
-        selected = (negotiated_abi or bridge.abi_version or DEFAULT_ABI_VERSION).strip()
-        supported = SUPPORTED_ABI_VERSIONS[capabilities.route]
-        if selected not in supported:
+        policy = ABI_POLICY_BY_ROUTE[capabilities.route]
+        project_selected = abi_version or self._resolve_project_abi_for_backend(capabilities.language)
+        selected = (project_selected or policy.current or DEFAULT_ABI_VERSION).strip()
+
+        if selected not in policy.supported:
             raise ValueError(
-                f"ABI '{selected}' no soportada para '{language}'. "
-                f"Versiones soportadas: {', '.join(supported)}."
+                f"ABI '{selected}' no soportada para '{capabilities.language}'. "
+                f"Versiones soportadas: {', '.join(policy.supported)}."
             )
-        return selected
+
+        if selected == policy.current:
+            return selected
+
+        if selected in policy.backwards_compatible_with:
+            return selected
+
+        raise ValueError(
+            f"ABI '{selected}' está soportada pero no es compatible hacia atrás "
+            f"con la versión actual '{policy.current}' para '{capabilities.language}'."
+        )
+
+    def validate_abi_route(self, language: str, abi_version: str | None = None) -> str:
+        """Wrapper público para mantener compatibilidad con llamadas existentes."""
+
+        capabilities = self._resolve_capabilities(language)
+        return self.negotiate_abi(capabilities, abi_version)
+
+    def select_bridge(self, capabilities: BindingCapabilities) -> RuntimeBridgeDescriptor:
+        """Selecciona la implementación de bridge para una ruta contractual."""
+
+        return self._BRIDGES[capabilities.route]
 
     def _resolve_project_abi_for_backend(self, backend: str) -> str | None:
         """Obtiene ABI negociada por backend desde cobra.toml/pcobra.toml."""
@@ -181,6 +202,10 @@ class RuntimeManager:
         except (OSError, tomllib.TOMLDecodeError):
             return {}
 
+
+SUPPORTED_ABI_VERSIONS: Final[dict[BindingRoute, tuple[str, ...]]] = {
+    route: policy.supported for route, policy in ABI_POLICY_BY_ROUTE.items()
+}
 
 __all__ = [
     "DEFAULT_ABI_VERSION",

--- a/src/pcobra/cobra/cli/commands_v2/run_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/run_cmd.py
@@ -4,7 +4,9 @@ from typing import Any
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
+from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.messages import mostrar_error
 from pcobra.cobra.cli.utils.autocomplete import files_completer
 
 
@@ -17,6 +19,7 @@ class RunCommandV2(BaseCommand):
     def __init__(self) -> None:
         super().__init__()
         self._legacy = ExecuteCommand()
+        self._runtime_manager = RuntimeManager()
 
     def register_subparser(self, subparsers: Any):
         parser = subparsers.add_parser(self.name, help=_("Run a Cobra file"))
@@ -34,12 +37,27 @@ class RunCommandV2(BaseCommand):
 
     def run(self, args: Any) -> int:
         debug = bool(getattr(args, "debug", False))
+        sandbox = bool(getattr(args, "sandbox", False))
+        container = getattr(args, "container", None)
+        binding_language = container or "python"
+        try:
+            self._runtime_manager.validate_security_route(
+                binding_language,
+                sandbox=sandbox,
+                containerized=bool(container),
+                command="run",
+            )
+            self._runtime_manager.validate_abi_route(binding_language)
+        except ValueError as exc:
+            mostrar_error(str(exc), registrar_log=False)
+            return 1
+
         resolution = backend_pipeline.resolve_backend(args.file, {})
         legacy_args = Namespace(
             archivo=args.file,
             debug=bool(getattr(args, "debug", False)),
-            sandbox=bool(getattr(args, "sandbox", False)),
-            contenedor=getattr(args, "container", None),
+            sandbox=sandbox,
+            contenedor=container,
             formatear=bool(getattr(args, "formatear", False)),
             modo=getattr(args, "modo", "mixto"),
             backend_reason=resolution.reason_for(debug=debug),

--- a/src/pcobra/cobra/cli/commands_v2/test_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/test_cmd.py
@@ -4,7 +4,9 @@ from typing import Any
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
+from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.messages import mostrar_error
 from pcobra.cobra.cli.target_policies import (
     VERIFICATION_EXECUTABLE_TARGETS,
     VERIFICATION_EXECUTABLE_TARGETS_HELP,
@@ -22,6 +24,7 @@ class TestCommandV2(BaseCommand):
     def __init__(self) -> None:
         super().__init__()
         self._legacy = VerifyCommand()
+        self._runtime_manager = RuntimeManager()
         self._default_langs = ",".join(VERIFICATION_EXECUTABLE_TARGETS)
 
     def register_subparser(self, subparsers: Any):
@@ -44,8 +47,29 @@ class TestCommandV2(BaseCommand):
 
     def run(self, args: Any) -> int:
         debug = bool(getattr(args, "debug", False))
+        raw_langs = getattr(args, "langs", self._default_langs)
+        if isinstance(raw_langs, str):
+            langs = parse_restricted_target_list(
+                raw_langs, VERIFICATION_EXECUTABLE_TARGETS, "verificación ejecutable"
+            )
+        else:
+            langs = list(raw_langs)
+        for lang in langs:
+            try:
+                sandbox = lang == "python"
+                containerized = lang in {"javascript", "rust"}
+                self._runtime_manager.validate_security_route(
+                    lang,
+                    sandbox=sandbox,
+                    containerized=containerized,
+                    command="test",
+                )
+                self._runtime_manager.validate_abi_route(lang)
+            except ValueError as exc:
+                mostrar_error(str(exc), registrar_log=False)
+                return 1
+
         resolution = backend_pipeline.resolve_backend(args.file, {})
-        langs = getattr(args, "langs", self._default_langs)
         legacy_args = Namespace(
             archivo=args.file,
             lenguajes=langs,

--- a/tests/unit/test_bindings_contract.py
+++ b/tests/unit/test_bindings_contract.py
@@ -1,4 +1,9 @@
-from pcobra.cobra.bindings.contract import BindingRoute, resolve_binding
+from pcobra.cobra.bindings.contract import (
+    ABI_POLICY_BY_ROUTE,
+    ROUTE_OPERATIONAL_LIMITS,
+    BindingRoute,
+    resolve_binding,
+)
 
 
 def test_resolve_binding_define_tres_rutas_contractuales():
@@ -14,3 +19,10 @@ def test_resolve_binding_falla_en_backend_no_soportado():
         assert "Lenguajes soportados" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("Se esperaba ValueError para backend no soportado")
+
+
+def test_contrato_declara_matriz_abi_y_limites_por_cada_ruta():
+    for route in BindingRoute:
+        assert route in ABI_POLICY_BY_ROUTE
+        assert route in ROUTE_OPERATIONAL_LIMITS
+        assert ABI_POLICY_BY_ROUTE[route].current in ABI_POLICY_BY_ROUTE[route].supported

--- a/tests/unit/test_cli_v2_command_contract.py
+++ b/tests/unit/test_cli_v2_command_contract.py
@@ -55,3 +55,60 @@ def test_build_v2_resuelve_backend_via_pipeline(monkeypatch):
     )
     assert status == 0
     assert "resolution" in called
+
+
+def test_run_v2_valida_seguridad_por_ruta_binding(monkeypatch):
+    command = RunCommandV2()
+    called = {}
+
+    monkeypatch.setattr(
+        command._runtime_manager,
+        "validate_security_route",
+        lambda language, **kwargs: called.setdefault("security", (language, kwargs)),
+    )
+    monkeypatch.setattr(
+        command._runtime_manager,
+        "validate_abi_route",
+        lambda language: called.setdefault("abi", language) or "1.0",
+    )
+    monkeypatch.setattr(
+        "cobra.cli.commands_v2.run_cmd.backend_pipeline.resolve_backend",
+        lambda _file, _hints: type("R", (), {"reason_for": lambda self, debug: "ok"})(),
+    )
+    monkeypatch.setattr(command._legacy, "run", lambda _args: 0)
+
+    status = command.run(
+        argparse.Namespace(file="programa.co", debug=False, sandbox=False, container="rust", modo="mixto")
+    )
+
+    assert status == 0
+    assert called["security"][0] == "rust"
+    assert called["security"][1]["containerized"] is True
+    assert called["security"][1]["command"] == "run"
+    assert called["abi"] == "rust"
+
+
+def test_test_v2_valida_seguridad_por_ruta_binding(monkeypatch):
+    command = TestCommandV2()
+    calls: list[tuple[str, dict]] = []
+
+    monkeypatch.setattr(
+        command._runtime_manager,
+        "validate_security_route",
+        lambda language, **kwargs: calls.append((language, kwargs)),
+    )
+    monkeypatch.setattr(command._runtime_manager, "validate_abi_route", lambda _language: "1.0")
+    monkeypatch.setattr(
+        "cobra.cli.commands_v2.test_cmd.backend_pipeline.resolve_backend",
+        lambda _file, _hints: type("R", (), {"reason_for": lambda self, debug: "ok"})(),
+    )
+    monkeypatch.setattr(command._legacy, "run", lambda _args: 0)
+
+    status = command.run(
+        argparse.Namespace(file="programa.co", debug=False, langs=["python", "javascript", "rust"], modo="mixto")
+    )
+
+    assert status == 0
+    assert calls[0][0] == "python" and calls[0][1]["sandbox"] is True
+    assert calls[1][0] == "javascript" and calls[1][1]["containerized"] is True
+    assert calls[2][0] == "rust" and calls[2][1]["containerized"] is True

--- a/tests/unit/test_runtime_manager.py
+++ b/tests/unit/test_runtime_manager.py
@@ -28,7 +28,7 @@ def test_runtime_manager_valida_abi_por_ruta():
     assert manager.validate_abi_route("rust", abi_version="1.0") == "1.0"
 
     try:
-        manager.validate_abi_route("rust", abi_version="2.0")
+        manager.validate_abi_route("rust", abi_version="9.9")
     except ValueError as exc:
         assert "Versiones soportadas" in str(exc)
     else:  # pragma: no cover
@@ -68,3 +68,32 @@ rust = "2.0"
 
     # cobra.toml tiene prioridad y define una ABI soportada.
     assert manager.validate_abi_route("rust") == "1.0"
+
+
+def test_runtime_manager_negocia_abi_actual_por_defecto_javascript(monkeypatch, tmp_path: Path):
+    manager = RuntimeManager()
+    monkeypatch.setenv("COBRA_TOML", str(tmp_path / "missing-cobra.toml"))
+    monkeypatch.setenv("PCOBRA_CONFIG", str(tmp_path / "missing-pcobra.toml"))
+
+    assert manager.validate_abi_route("javascript") == "1.1"
+
+
+def test_runtime_manager_rechaza_abi_no_compatible_hacia_atras(monkeypatch, tmp_path: Path):
+    manager = RuntimeManager()
+    cobra_toml = tmp_path / "cobra.toml"
+    cobra_toml.write_text(
+        """
+[project.abi_by_backend]
+javascript = "1.2"
+""".strip()
+    )
+
+    monkeypatch.setenv("COBRA_TOML", str(cobra_toml))
+    monkeypatch.delenv("PCOBRA_CONFIG", raising=False)
+
+    try:
+        manager.validate_abi_route("javascript")
+    except ValueError as exc:
+        assert "Versiones soportadas" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Se esperaba rechazo de ABI no soportada")


### PR DESCRIPTION
### Motivation
- Definir `bindings/contract.py` como la fuente normativa única para rutas de binding, añadiendo soporte explícito para versionado ABI y límites operativos por ruta. 
- Separar responsabilidades en el manager de runtime para hacer la validación de seguridad, la negociación de ABI y la selección de bridge más claras y testeables. 
- Garantizar que los comandos públicos (`run`, `test`) apliquen de forma consistente las validaciones de seguridad y ABI por ruta de binding antes de delegar a la lógica legacy. 

### Description
- Añadido en `bindings/contract.py` los tipos `AbiCompatibilityPolicy` y `RouteOperationalLimits` y las estructuras `ABI_POLICY_BY_ROUTE` y `ROUTE_OPERATIONAL_LIMITS` que declaran la matriz ABI y los límites operativos por ruta. 
- Reexport actualizado en `src/pcobra/cobra/bindings/contract.py` para mantener compatibilidad con el namespace `pcobra` y exponer la matriz ABI y límites operativos. 
- Refactor en `src/pcobra/cobra/bindings/runtime_manager.py` para: separar `_resolve_capabilities`, `negotiate_abi` (con política de compatibilidad hacia atrás), `select_bridge`, y usar `ABI_POLICY_BY_ROUTE` al negociar/validar ABI; además `_BRIDGES` ahora refleja las ABI actuales por ruta. 
- Integración en comandos v2: `RunCommandV2` y `TestCommandV2` usan `RuntimeManager` para ejecutar `validate_security_route` y `validate_abi_route` por ruta/idioma antes de delegar al legacy command; añadido el documento `docs/bindings_runtime_contract.md` y se actualizaron pruebas unitarias relacionadas. 

### Testing
- Se ejecutó la batería de pruebas objetivo con `pytest -q tests/unit/test_bindings_contract.py tests/unit/test_runtime_manager.py tests/unit/test_cli_v2_command_contract.py`. 
- Resultado: todas las pruebas seleccionadas pasaron (`15 passed`) y apareció un `PytestCollectionWarning` pero no afectó el paso de la suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c943c0dc83279b01db5077047ce0)