### PR TITLE
Inventory and phased removal plan for internal-only backends (go/cpp/java/wasm/asm)

### DIFF
--- a/docs/compatibility/internal_only_backend_removal_checklist.md
+++ b/docs/compatibility/internal_only_backend_removal_checklist.md
@@ -1,0 +1,36 @@
+# Checklist de eliminación final por fases (targets internal-only)
+
+Backends en retiro interno: `go`, `cpp`, `java`, `wasm`, `asm`.
+
+**Modo de compatibilidad temporal:** `legacy mode` (`--legacy-targets` o `COBRA_LEGACY_TARGETS_MODE=1`).
+
+**Fecha de retiro total (freeze + eliminación de hooks no usados):** **2027-06-30**.
+
+## Fase 1 — Documentación pública
+
+- [ ] El README público solo sugiere `python`, `javascript`, `rust` como elección de usuario.
+- [ ] Las guías públicas eliminan ejemplos de uso directo `--backend go/cpp/java/wasm/asm`.
+- [ ] Se conserva únicamente documentación de migración/compatibilidad para targets internal-only.
+- [ ] Se ejecuta inventario: `python scripts/ci/generate_internal_only_inventory.py` y se revisa `docs/compatibility/internal_only_refs_inventory.md`.
+
+## Fase 2 — CLI pública
+
+- [ ] El help público oculta targets internal-only por defecto.
+- [ ] Cualquier ejecución de targets internal-only falla fuera de `legacy mode` en Fase 2.
+- [ ] Los warnings incluyen destino público recomendado y estado de retiro.
+- [ ] La telemetría de uso legacy se mantiene habilitada para trazabilidad de migración.
+
+## Fase 3 — Hooks internos no usados
+
+- [ ] Identificar hooks/adaptadores legacy sin uso real (basado en telemetría + CI).
+- [ ] Eliminar entradas legacy del registro interno una vez sin tráfico.
+- [ ] Eliminar flags de compatibilidad (`COBRA_INTERNAL_LEGACY_TARGETS`, `COBRA_LEGACY_TARGETS_MODE`) al cierre.
+- [ ] Ejecutar auditoría final del repositorio y bloquear reintroducciones en CI.
+
+## Criterio de salida
+
+La eliminación se considera completada cuando:
+
+1. La documentación pública no sugiere targets internal-only como opción de usuario.
+2. La CLI pública no permite esos targets fuera de `legacy mode`.
+3. No quedan hooks legacy activos ni referencias operativas fuera de histórico/migración.

--- a/docs/compatibility/internal_only_refs_inventory.md
+++ b/docs/compatibility/internal_only_refs_inventory.md
@@ -1,0 +1,147 @@
+# Inventario de referencias internal-only (go/cpp/java/wasm/asm)
+
+Este reporte se genera con `scripts/ci/generate_internal_only_inventory.py`.
+
+## Método
+
+1. **Búsqueda por path**: se recorren archivos de texto fuera de rutas internas permitidas.
+2. **Búsqueda por símbolos**: detección de tokens directos, flags (`--backend`/`--tipo`) y claves de registro.
+
+## Rutas internas excluidas
+
+- `src/pcobra/cobra/cli/internal_compat/`
+- `docs/compatibility/`
+- `docs/historico/`
+- `docs/migracion_targets_retirados.md`
+- `docs/migracion_cli_unificada.md`
+- `tests/`
+
+## Resumen
+
+- Hallazgos fuera de rutas internas: **724**.
+- Archivos afectados: **103**.
+
+### Hallazgos por símbolo
+
+- `backend_flag`: 0
+- `registry_key`: 0
+- `target_token`: 724
+
+### Top paths con más hallazgos
+
+| path | hallazgos |
+|---|---:|
+| `data/language_equivalence.yml` | 82 |
+| `src/pcobra/cobra/transpilers/compatibility_matrix.py` | 47 |
+| `docs/contrato_runtime_holobit.md` | 36 |
+| `data/language_equivalence_baseline.yml` | 35 |
+| `src/pcobra/cobra/transpilers/common/utils.py` | 32 |
+| `src/pcobra/cobra/qa/syntax_validation.py` | 24 |
+| `docs/proposals/plan_nuevas_funcionalidades.md` | 23 |
+| `data/language_equivalence_backlog.md` | 22 |
+| `src/pcobra/cobra/benchmarks/targets_policy.py` | 19 |
+| `src/pcobra/cobra/transpilers/library_compatibility.py` | 17 |
+| `scripts/generar_matriz_transpiladores.py` | 15 |
+| `src/pcobra/cobra/transpilers/target_utils.py` | 14 |
+| `CONTRIBUTING.md` | 13 |
+| `pcobra.toml` | 13 |
+| `docs/library_compatibility_matrix.md` | 12 |
+| `docs/frontend/backends.rst` | 11 |
+| `docs/frontend/transpilers_tier_plan.md` | 11 |
+| `docs/_generated/runtime_api_matrix.json` | 10 |
+| `docs/_generated/runtime_api_matrix.md` | 10 |
+| `scripts/audit_retired_targets.py` | 10 |
+| `src/pcobra/cobra/architecture/backend_policy.py` | 10 |
+| `src/pcobra/cobra/semantico/cobra_mod_schema.yaml` | 10 |
+| `src/pcobra/corelibs/__init__.py` | 9 |
+| `docs/frontend/avances.rst` | 8 |
+| `src/pcobra/core/sandbox.py` | 8 |
+
+### Muestra de hallazgos
+
+| path | línea | símbolo | extracto |
+|---|---:|---|---|
+| `CHANGELOG.md` | 17 | `target_token` | `- Migración recomendada: normalizar todo a nombres canónicos (`python`, `rust`, `javascript`, `wasm`, `go`, `cpp`, `java`, `asm`) en scripts, docs y pipelines.` |
+| `CONTRIBUTING.md` | 142 | `target_token` | `- Go` |
+| `CONTRIBUTING.md` | 144 | `target_token` | `- Java (`javac`)` |
+| `CONTRIBUTING.md` | 163 | `target_token` | `- [ ] No se añadieron referencias a targets fuera de la política oficial (`python`, `rust`, `javascript`, `wasm`, `go`, `cpp`, `java`, `asm`).` |
+| `CONTRIBUTING.md` | 164 | `target_token` | `- [ ] No se añadieron referencias de `transpilar-inverso` fuera de los orígenes oficiales (`python`, `javascript`, `java`).` |
+| `CONTRIBUTING.md` | 175 | `target_token` | `- `wasm`` |
+| `CONTRIBUTING.md` | 176 | `target_token` | `- `go`` |
+| `CONTRIBUTING.md` | 177 | `target_token` | `- `cpp`` |
+| `CONTRIBUTING.md` | 178 | `target_token` | `- `java`` |
+| `CONTRIBUTING.md` | 179 | `target_token` | `- `asm`` |
+| `CONTRIBUTING.md` | 183 | `target_token` | `- **Tier 1**: `python`, `rust`, `javascript`, `wasm`.` |
+| `CONTRIBUTING.md` | 184 | `target_token` | `- **Tier 2**: `go`, `cpp`, `java`, `asm`.` |
+| `CONTRIBUTING.md` | 190 | `target_token` | `- `java`` |
+| `CONTRIBUTING.md` | 242 | `target_token` | `1. Set canónico de targets oficiales (`python`, `rust`, `javascript`, `wasm`, `go`, `cpp`, `java`, `asm`).` |
+| `README.md` | 314 | `target_token` | `Las rutas legacy/internal (`go`, `cpp`, `java`, `wasm`, `asm`) se mantienen fuera de la interfaz pública y solo como soporte transitorio para migración técnica.` |
+| `README.md` | 327 | `target_token` | `- **Fase 1 (default):** warning + telemetría cuando se usan `wasm`, `go`, `cpp`, `java` o `asm`.` |
+| `README.md` | 995 | `target_token` | `- **Orígenes reverse de entrada**: `python`, `javascript`, `java`.` |
+| `README.md` | 997 | `target_token` | `Los nombres `python`, `javascript` y `java` aparecen en ambas listas, pero con papeles distintos: como `--origen` describen **entradas aceptadas** por la ruta reverse; como `--destino` vuelven a significar **targets oficiales de salida ya existentes**. La capacidad reverse no añade targets nuevos ni amplía la lista oficial de salida.` |
+| `README.md` | 1095 | `target_token` | `- Go (`golang-go`) para pruebas internas legacy` |
+| `README.md` | 1097 | `target_token` | `- Java (`default-jdk`)` |
+| `data/language_equivalence.yml` | 7 | `target_token` | `- go` |
+| `data/language_equivalence.yml` | 8 | `target_token` | `- cpp` |
+| `data/language_equivalence.yml` | 9 | `target_token` | `- java` |
+| `data/language_equivalence.yml` | 10 | `target_token` | `- wasm` |
+| `data/language_equivalence.yml` | 11 | `target_token` | `- asm` |
+| `data/language_equivalence.yml` | 46 | `target_token` | `go:` |
+| `data/language_equivalence.yml` | 57 | `target_token` | `cpp:` |
+| `data/language_equivalence.yml` | 69 | `target_token` | `java:` |
+| `data/language_equivalence.yml` | 81 | `target_token` | `wasm:` |
+| `data/language_equivalence.yml` | 91 | `target_token` | `asm:` |
+| `data/language_equivalence.yml` | 99 | `target_token` | `- '; backend asm: imports de runtime administrados externamente'` |
+| `data/language_equivalence.yml` | 105 | `target_token` | `go: full` |
+| `data/language_equivalence.yml` | 106 | `target_token` | `cpp: partial` |
+| `data/language_equivalence.yml` | 107 | `target_token` | `java: partial` |
+| `data/language_equivalence.yml` | 108 | `target_token` | `wasm: partial` |
+| `data/language_equivalence.yml` | 109 | `target_token` | `asm: partial` |
+| `data/language_equivalence.yml` | 114 | `target_token` | `go: full` |
+| `data/language_equivalence.yml` | 115 | `target_token` | `cpp: partial` |
+| `data/language_equivalence.yml` | 116 | `target_token` | `java: partial` |
+| `data/language_equivalence.yml` | 117 | `target_token` | `wasm: partial` |
+| `data/language_equivalence.yml` | 118 | `target_token` | `asm: partial` |
+| `data/language_equivalence.yml` | 123 | `target_token` | `go: full` |
+| `data/language_equivalence.yml` | 124 | `target_token` | `cpp: partial` |
+| `data/language_equivalence.yml` | 125 | `target_token` | `java: partial` |
+| `data/language_equivalence.yml` | 126 | `target_token` | `wasm: partial` |
+| `data/language_equivalence.yml` | 127 | `target_token` | `asm: partial` |
+| `data/language_equivalence.yml` | 132 | `target_token` | `go: full` |
+| `data/language_equivalence.yml` | 133 | `target_token` | `cpp: partial` |
+| `data/language_equivalence.yml` | 134 | `target_token` | `java: partial` |
+| `data/language_equivalence.yml` | 135 | `target_token` | `wasm: partial` |
+| `data/language_equivalence.yml` | 136 | `target_token` | `asm: partial` |
+| `data/language_equivalence.yml` | 141 | `target_token` | `go: full` |
+| `data/language_equivalence.yml` | 142 | `target_token` | `cpp: partial` |
+| `data/language_equivalence.yml` | 143 | `target_token` | `java: partial` |
+| `data/language_equivalence.yml` | 144 | `target_token` | `wasm: partial` |
+| `data/language_equivalence.yml` | 145 | `target_token` | `asm: partial` |
+| `data/language_equivalence.yml` | 150 | `target_token` | `go: full` |
+| `data/language_equivalence.yml` | 151 | `target_token` | `cpp: partial` |
+| `data/language_equivalence.yml` | 152 | `target_token` | `java: partial` |
+| `data/language_equivalence.yml` | 153 | `target_token` | `wasm: partial` |
+| `data/language_equivalence.yml` | 154 | `target_token` | `asm: partial` |
+| `data/language_equivalence.yml` | 159 | `target_token` | `go: full` |
+| `data/language_equivalence.yml` | 160 | `target_token` | `cpp: partial` |
+| `data/language_equivalence.yml` | 161 | `target_token` | `java: partial` |
+| `data/language_equivalence.yml` | 162 | `target_token` | `wasm: partial` |
+| `data/language_equivalence.yml` | 163 | `target_token` | `asm: partial` |
+| `data/language_equivalence.yml` | 168 | `target_token` | `go: full` |
+| `data/language_equivalence.yml` | 169 | `target_token` | `cpp: partial` |
+| `data/language_equivalence.yml` | 170 | `target_token` | `java: partial` |
+| `data/language_equivalence.yml` | 171 | `target_token` | `wasm: partial` |
+| `data/language_equivalence.yml` | 172 | `target_token` | `asm: partial` |
+| `data/language_equivalence.yml` | 177 | `target_token` | `go: full` |
+| `data/language_equivalence.yml` | 178 | `target_token` | `cpp: partial` |
+| `data/language_equivalence.yml` | 179 | `target_token` | `java: partial` |
+| `data/language_equivalence.yml` | 180 | `target_token` | `wasm: partial` |
+| `data/language_equivalence.yml` | 181 | `target_token` | `asm: partial` |
+| `data/language_equivalence.yml` | 230 | `target_token` | `go:` |
+| `data/language_equivalence.yml` | 244 | `target_token` | `cpp:` |
+| `data/language_equivalence.yml` | 256 | `target_token` | `java:` |
+| `data/language_equivalence.yml` | 268 | `target_token` | `wasm:` |
+
+## Nota de uso
+
+Este inventario es de diagnóstico. La eliminación se ejecuta por fases según `docs/compatibility/internal_only_backend_removal_checklist.md`.

--- a/docs/compatibility/legacy_ux_retirement_plan.md
+++ b/docs/compatibility/legacy_ux_retirement_plan.md
@@ -10,8 +10,8 @@ Este plan aplica a los backends legacy mantenidos solo por compatibilidad intern
 
 ## Fecha de retiro comprometida
 
-- **Retiro de UX legacy:** **31 de julio de 2026**.
-- A partir de **1 de agosto de 2026**, la CLI pública no debe aceptar rutas legacy ni feature flags de bypass.
+- **Retiro total de compatibilidad legacy internal-only:** **30 de junio de 2027**.
+- A partir de **1 de julio de 2027**, la CLI pública no debe aceptar rutas legacy ni feature flags de bypass.
 
 ## Flag temporal para equipos dependientes
 
@@ -39,4 +39,6 @@ Este flag es transitorio y no debe usarse en documentación pública ni en nuevo
    - Verificar que no queden referencias legacy en docs públicas.
 5. **Cierre**
    - Congelar nuevos cambios funcionales sobre UX legacy.
-   - Confirmar readiness antes del 31/07/2026 y remover la ruta de compatibilidad.
+   - Confirmar readiness antes del 30/06/2027 y remover la ruta de compatibilidad.
+
+Checklist operativo por fases: `docs/compatibility/internal_only_backend_removal_checklist.md`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,18 +4,11 @@ Este directorio reúne distintos ejemplos de uso de Cobra y material relacionado
 
 ## Política canónica de targets en ejemplos públicos
 
-Toda la documentación y los ejemplos públicos de este directorio deben usar solo
-los 8 nombres canónicos de targets oficiales de transpilación:
-`python`, `rust`, `javascript`, `wasm`, `go`, `cpp`, `java` y `asm`.
-No deben publicarse aliases o variantes fuera de contrato; usa siempre el nombre
-canónico exacto definido por la política oficial.
+Para recorrido de usuario final, este directorio debe sugerir únicamente:
+`python`, `rust`, `javascript`.
 
-Además, conviene leerlos con esta distinción:
-
-- **Transpilación oficial**: `python`, `rust`, `javascript`, `wasm`, `go`, `cpp`, `java`, `asm`.
-- **Runtime oficial**: `python`, `rust`, `javascript`, `cpp`.
-- **Runtime best-effort**: `go`, `java`.
-- **Solo transpilación sin runtime público**: `wasm`, `asm`.
+Los targets `go`, `cpp`, `java`, `wasm` y `asm` se mantienen como **internal-only**
+para migración/regresión técnica y no deben presentarse como opción pública de CLI.
 
 ## Subcarpetas
 
@@ -23,7 +16,7 @@ Además, conviene leerlos con esta distinción:
   ```bash
   cobra ejecutar examples/avanzados/<tema>/<archivo>.co
   ```
-- **hello_world/**: demostraciones "Hola Mundo" para los 8 targets oficiales (`python`, `rust`, `javascript`, `wasm`, `go`, `cpp`, `java`, `asm`).
+- **hello_world/**: demostraciones para targets públicos (`python`, `rust`, `javascript`) y artefactos legacy internal-only de referencia técnica.
 - **[hola_mundo](hola_mundo/)**: ejemplo mínimo para transpilar a Python.
   ```bash
   cobra compilar examples/hola_mundo/hola.co --backend python

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -1,30 +1,24 @@
 # Ejemplos de Hola mundo
 
-Esta carpeta usa exclusivamente los 8 targets oficiales con sus nombres
-canónicos: `python`, `rust`, `javascript`, `wasm`, `go`, `cpp`, `java` y `asm`.
+Para experiencia pública de usuario, esta carpeta recomienda solo:
+`python`, `rust`, `javascript`.
 
-Lectura recomendada de la política asociada:
+Los artefactos `go`, `cpp`, `java`, `wasm` y `asm` permanecen como compatibilidad
+**internal-only** (migración/regresión), no como recomendación de uso en CLI pública.
 
-- **Transpilación oficial**: los 8 targets anteriores.
-- **Runtime oficial**: `python`, `rust`, `javascript`, `cpp`.
-- **Runtime best-effort**: `go`, `java`.
-- **Solo transpilación sin runtime público**: `wasm`, `asm`.
-- **Orígenes reverse de entrada**: se documentan por separado (`python`, `javascript`, `java`) y no alteran esta tabla de salidas oficiales.
-
-Cada ejemplo se puede generar ejecutando (reemplaza ``<backend_oficial>`` por uno
-de los 8 nombres canónicos):
+Comando público recomendado:
 
 ```bash
-cobra compilar examples/hello_world/<backend_oficial>.co --backend <backend_oficial>
+cobra build examples/hello_world/<target_publico>.co --backend <target_publico>
 ```
 
-Resultados pre-generados para cada transpilador oficial:
+Resultados pre-generados:
 
 - `python`: `cobra compilar examples/hello_world/python.co --backend python` → [python.py](python.py)
 - `rust`: `cobra compilar examples/hello_world/rust.co --backend rust` → [rust.rs](rust.rs)
 - `javascript`: `cobra compilar examples/hello_world/javascript.co --backend javascript` → [javascript.js](javascript.js)
-- `wasm`: `cobra compilar examples/hello_world/wasm.co --backend wasm` → [wasm.wat](wasm.wat)
-- `go`: `cobra compilar examples/hello_world/go.co --backend go` → [go.go](go.go)
-- `cpp`: `cobra compilar examples/hello_world/cpp.co --backend cpp` → [cpp.cpp](cpp.cpp)
-- `java`: `cobra compilar examples/hello_world/java.co --backend java` → [java.java](java.java)
-- `asm`: `cobra compilar examples/hello_world/asm.co --backend asm` → [asm.asm](asm.asm)
+- `wasm` *(internal-only)*: [wasm.wat](wasm.wat)
+- `go` *(internal-only)*: [go.go](go.go)
+- `cpp` *(internal-only)*: [cpp.cpp](cpp.cpp)
+- `java` *(internal-only)*: [java.java](java.java)
+- `asm` *(internal-only)*: [asm.asm](asm.asm)

--- a/examples/tutorial_basico/README.md
+++ b/examples/tutorial_basico/README.md
@@ -3,9 +3,9 @@
 Este directorio contiene un ejemplo mínimo de un programa escrito en Cobra y su
 transpilación manual a Python.
 
-Aunque este tutorial usa Python, la política pública del proyecto mantiene 8
-targets oficiales de salida con nombres canónicos: `python`, `rust`,
-`javascript`, `wasm`, `go`, `cpp`, `java` y `asm`.
+Aunque este tutorial usa Python, la política pública para usuarios recomienda
+solo `python`, `rust` y `javascript`. Los targets `go`, `cpp`, `java`, `wasm`
+y `asm` quedan en compatibilidad **internal-only** para migración/regresión.
 
 ## Archivos
 

--- a/scripts/ci/generate_internal_only_inventory.py
+++ b/scripts/ci/generate_internal_only_inventory.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Genera inventario de referencias a backends internal-only fuera de rutas internas.
+
+Estrategia:
+1) Búsqueda por path (rutas/documentos públicos vigilados).
+2) Búsqueda por símbolos (tokens backend y claves de diccionarios de registro).
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+OUTPUT = ROOT / "docs/compatibility/internal_only_refs_inventory.md"
+
+TARGETS = ("go", "cpp", "java", "wasm", "asm")
+
+TEXT_EXTENSIONS = {
+    ".py",
+    ".md",
+    ".rst",
+    ".txt",
+    ".toml",
+    ".yaml",
+    ".yml",
+    ".json",
+    ".sh",
+}
+
+# Rutas con scope interno/histórico permitido para conservar compatibilidad temporal.
+INTERNAL_ALLOWED_PREFIXES = (
+    "src/pcobra/cobra/cli/internal_compat/",
+    "docs/compatibility/",
+    "docs/historico/",
+    "docs/migracion_targets_retirados.md",
+    "docs/migracion_cli_unificada.md",
+    "tests/",
+)
+
+SYMBOL_PATTERNS: dict[str, re.Pattern[str]] = {
+    "target_token": re.compile(r"(?<![\w.+/-])(?:go|cpp|java|wasm|asm)(?![\w.+/-])", re.IGNORECASE),
+    "backend_flag": re.compile(r"--(?:backend|tipo)\s+(?:go|cpp|java|wasm|asm)(?![A-Za-z0-9_])", re.IGNORECASE),
+    "registry_key": re.compile(r"[\"'](?:go|cpp|java|wasm|asm)[\"']\s*:", re.IGNORECASE),
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    rel_path: str
+    line_number: int
+    symbol: str
+    line: str
+
+
+def _is_scannable(path: Path) -> bool:
+    if path.suffix.lower() not in TEXT_EXTENSIONS:
+        return False
+    parts = set(path.parts)
+    if {".git", "node_modules", "__pycache__"} & parts:
+        return False
+    return path.is_file()
+
+
+def _is_internal_allowed(rel: str) -> bool:
+    return rel.startswith(INTERNAL_ALLOWED_PREFIXES)
+
+
+def _scan() -> list[Finding]:
+    findings: list[Finding] = []
+    for path in ROOT.rglob("*"):
+        if not _is_scannable(path):
+            continue
+        rel = path.relative_to(ROOT).as_posix()
+        if _is_internal_allowed(rel):
+            continue
+
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+
+        for idx, line in enumerate(lines, start=1):
+            for symbol, pattern in SYMBOL_PATTERNS.items():
+                if pattern.search(line):
+                    findings.append(Finding(rel, idx, symbol, line.strip()))
+                    break
+    return findings
+
+
+def _render(findings: list[Finding]) -> str:
+    grouped_by_path: dict[str, int] = defaultdict(int)
+    grouped_by_symbol: dict[str, int] = defaultdict(int)
+    for f in findings:
+        grouped_by_path[f.rel_path] += 1
+        grouped_by_symbol[f.symbol] += 1
+
+    top_paths = sorted(grouped_by_path.items(), key=lambda item: (-item[1], item[0]))[:25]
+    sample = sorted(findings, key=lambda item: (item.rel_path, item.line_number))[:80]
+
+    lines = [
+        "# Inventario de referencias internal-only (go/cpp/java/wasm/asm)",
+        "",
+        "Este reporte se genera con `scripts/ci/generate_internal_only_inventory.py`.",
+        "",
+        "## Método",
+        "",
+        "1. **Búsqueda por path**: se recorren archivos de texto fuera de rutas internas permitidas.",
+        "2. **Búsqueda por símbolos**: detección de tokens directos, flags (`--backend`/`--tipo`) y claves de registro.",
+        "",
+        "## Rutas internas excluidas",
+        "",
+    ]
+    lines.extend(f"- `{prefix}`" for prefix in INTERNAL_ALLOWED_PREFIXES)
+    lines.extend(
+        [
+            "",
+            "## Resumen",
+            "",
+            f"- Hallazgos fuera de rutas internas: **{len(findings)}**.",
+            f"- Archivos afectados: **{len(grouped_by_path)}**.",
+            "",
+            "### Hallazgos por símbolo",
+            "",
+        ]
+    )
+    for symbol in sorted(SYMBOL_PATTERNS):
+        lines.append(f"- `{symbol}`: {grouped_by_symbol.get(symbol, 0)}")
+
+    lines.extend(["", "### Top paths con más hallazgos", "", "| path | hallazgos |", "|---|---:|"])
+    for rel, count in top_paths:
+        lines.append(f"| `{rel}` | {count} |")
+
+    lines.extend(["", "### Muestra de hallazgos", "", "| path | línea | símbolo | extracto |", "|---|---:|---|---|"])
+    for finding in sample:
+        excerpt = finding.line.replace("|", "\\|")
+        lines.append(
+            f"| `{finding.rel_path}` | {finding.line_number} | `{finding.symbol}` | `{excerpt}` |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Nota de uso",
+            "",
+            "Este inventario es de diagnóstico. La eliminación se ejecuta por fases según `docs/compatibility/internal_only_backend_removal_checklist.md`.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    findings = _scan()
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(_render(findings), encoding="utf-8")
+    print(f"[inventory] generado: {OUTPUT.relative_to(ROOT)} ({len(findings)} hallazgos)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pcobra/cobra/architecture/backend_policy.py
+++ b/src/pcobra/cobra/architecture/backend_policy.py
@@ -35,6 +35,9 @@ INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW: Final[dict[str, str]] = {
     "asm": "Q3 2026",
 }
 
+# Fecha de corte global para retirar la compatibilidad legacy internal-only.
+INTERNAL_LEGACY_RETIREMENT_DATE: Final[str] = "2027-06-30"
+
 ALL_BACKENDS: Final[tuple[str, ...]] = PUBLIC_BACKENDS + INTERNAL_BACKENDS
 
 

--- a/src/pcobra/cobra/cli/deprecation_policy.py
+++ b/src/pcobra/cobra/cli/deprecation_policy.py
@@ -9,8 +9,11 @@ from argparse import Namespace
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.messages import mostrar_advertencia
 
+# internal-only: estos targets existen únicamente para compatibilidad temporal
+# en rutas no públicas. No deben anunciarse como opción de usuario final.
 DEPRECATED_PUBLIC_TARGETS: tuple[str, ...] = ("wasm", "go", "cpp", "java", "asm")
 DEPRECATION_PHASE_ENV = "COBRA_TARGET_DEPRECATION_PHASE"
+# internal-only: habilita compatibilidad temporal para migración controlada.
 LEGACY_TARGETS_MODE_ENV = "COBRA_LEGACY_TARGETS_MODE"
 
 


### PR DESCRIPTION
### Motivation

- Reducir la exposición pública de backends legacy (`go`, `cpp`, `java`, `wasm`, `asm`) marcándolos como internal-only y proveer una hoja de ruta y artefactos para su retirada controlada.
- Proporcionar un inventario accionable de referencias externas a esos targets para guiar la limpieza de docs/CLI/hooks.
- Mantener compatibilidad interna temporal detrás de un modo legacy con una fecha objetivo de retirada global.

### Description

- Añadí un script de inventario `scripts/ci/generate_internal_only_inventory.py` que escanea fuera de rutas internas autorizadas por path y por símbolos (`target_token`, `backend_flag`, `registry_key`) y genera `docs/compatibility/internal_only_refs_inventory.md` con resumen y muestras.
- Creé el checklist operativo por fases en `docs/compatibility/internal_only_backend_removal_checklist.md` que cubre: (1) limpieza documental, (2) bloqueo en la CLI pública, (3) eliminación de hooks internos no usados, y criterio de salida.
- Actualicé la planificación de retiro en `docs/compatibility/legacy_ux_retirement_plan.md` para fijar la fecha objetivo de retiro total en `2027-06-30` y enlazar el checklist operativo.
- Señalicé en código que los targets legacy son internal-only y añadí una constante de política de retiro: `INTERNAL_LEGACY_RETIREMENT_DATE = "2027-06-30"` en `src/pcobra/cobra/architecture/backend_policy.py` y clarifiqué los flags/constantes en `src/pcobra/cobra/cli/deprecation_policy.py`.
- Actualicé documentación de ejemplos (`examples/README.md`, `examples/hello_world/README.md`, `examples/tutorial_basico/README.md`) para que la narrativa pública recomiende solo `python`, `rust`, `javascript` y marque los demás como internal-only de referencia técnica.

### Testing

- Ejecuté `python scripts/ci/generate_internal_only_inventory.py` y el script generó `docs/compatibility/internal_only_refs_inventory.md` con hallazgos (resumen generado satisfactoriamente).
- Corrí `pytest -q tests/unit/test_legacy_backend_lifecycle.py` y todos los tests de ese módulo pasaron (`5 passed`).
- Intenté `pytest -q tests/unit/test_public_docs_scope.py tests/unit/test_legacy_backend_lifecycle.py` y la colección falló por una import error preexistente al importar `LANG_CHOICES` desde `compile_cmd`, por lo que no se completó la suite documental; este fallo es una condición existente de importación y no es causado por los cambios de este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e217318ab4832783ff98e54e5ee2da)