### PR TITLE
Blueprint de arquitectura unificada y plan de refactor por fases para Cobra

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Esta organización actúa como contrato técnico entre la interfaz pública y la
 ## Ecosistema unificado Cobra
 
 Cobra expone una sola interfaz de entrada (`cobra`) y desacopla internamente la orquestación, los adapters y los runtimes de ejecución. Revisa el diagrama por capas en [docs/architecture/unified-ecosystem.md](docs/architecture/unified-ecosystem.md).
+Para el plan de transición arquitectónica incremental, consulta [docs/architecture/cobra_unified_refactor_plan.md](docs/architecture/cobra_unified_refactor_plan.md).
 
 ## Migración a CLI unificada
 

--- a/docs/architecture/cobra_unified_refactor_plan.md
+++ b/docs/architecture/cobra_unified_refactor_plan.md
@@ -1,0 +1,171 @@
+# Plan de arquitectura y refactor parcial seguro: Cobra Ecosystem Unified
+
+Este documento define una estrategia **incremental** para consolidar Cobra como único lenguaje visible para usuario final, con tres backends oficiales internos: `python`, `javascript` y `rust`.
+
+> Restricciones aplicadas en este plan: no tocar lexer, parser, AST ni transpilers existentes.
+
+---
+
+## A) Architecture overview
+
+### Objetivo macro
+- **Entrada única**: usuario escribe y opera solamente en Cobra.
+- **Backends oficiales internos**: Python, JavaScript y Rust.
+- **Transpilación oculta**: la CLI pública no expone selección manual de transpiler.
+- **Contrato de stdlib**: módulos públicos orientados por backend primario y fallbacks controlados.
+
+### Capas objetivo
+1. **Frontend de lenguaje (intocable)**: lexer/parser/AST.
+2. **Orquestación interna**: `build.backend_pipeline`, `build.orchestrator`, adapters de backend.
+3. **Bindings runtime**: rutas Python direct import, JS runtime bridge, Rust FFI.
+4. **CLI pública mínima**: `run`, `build`, `test`, `mod`.
+
+---
+
+## B) Core module alignment
+
+### Estado contractual
+- Fuente pública de verdad de backends: `PUBLIC_BACKENDS = (python, javascript, rust)`.
+- Backends legacy se mantienen solo en modo compatibilidad interna.
+
+### Alineación propuesta
+- Mantener front-end intacto.
+- Reforzar que cualquier ruta pública consulte `PUBLIC_BACKENDS`.
+- Tratar módulos legacy como **inventario de retiro**, no como opciones para usuario final.
+
+### Candidatos legacy a retirar
+- `go`, `cpp`, `java`, `wasm`, `asm`.
+
+---
+
+## C) CLI redesign
+
+### UX pública objetivo
+```bash
+cobra run archivo.cobra
+cobra build archivo.cobra
+cobra test archivo.cobra
+cobra mod list
+```
+
+### Reglas
+- El usuario no indica transpiler directamente en la CLI pública v2.
+- Los comandos legacy quedan encapsulados para migración interna, fuera de la UX pública principal.
+
+---
+
+## D) Transpiler integration
+
+### Enfoque
+- No modificar transpilers existentes.
+- Invocarlos por una única fachada interna (`backend_pipeline` / adapters).
+
+### Selección backend interna
+1. Resolver backend por orquestador y contexto (archivo/capacidades).
+2. Validar ruta runtime (ABI + seguridad).
+3. Invocar transpiler oficial correspondiente.
+
+---
+
+## E) Stdlib design
+
+### Módulos públicos
+- `cobra.core`: base transversal.
+- `cobra.datos`: prioridad Python.
+- `cobra.web`: prioridad JavaScript.
+- `cobra.system`: híbrido Python/Rust con fallback JS.
+
+### Política
+- API Cobra estable para el usuario.
+- Implementación interna guiada por `stdlib_contract`.
+- Fallbacks explícitos y auditables.
+
+---
+
+## F) Import system
+
+### Casos requeridos
+1. **Import Python bridge**: `importar pandas`.
+2. **Import stdlib Cobra**: `importar datos` / `importar cobra.datos`.
+3. **Módulos híbridos**: mapeados por configuración.
+
+### Orden de resolución
+1. `stdlib`
+2. `project`
+3. `python_bridge`
+4. `hybrid`
+
+### Conflictos
+- Modo transición: `warn`.
+- Producción recomendada: `namespace_required`.
+
+### Inyección
+- Adjuntar metadata de resolución y `backend_adapter` al módulo cargado.
+
+---
+
+## G) Binding system
+
+### Rutas contractuales
+- **Python**: `python_direct_import`.
+- **JavaScript**: `javascript_runtime_bridge`.
+- **Rust**: `rust_compiled_ffi`.
+
+### Validaciones mínimas
+- Seguridad por comando (`run`/`test`).
+- Negociación ABI por backend.
+- Selección de bridge consistente por ruta.
+
+---
+
+## H) Elements to remove (safe retirement backlog)
+
+> Fasear en releases para evitar ruptura.
+
+1. Comandos CLI ligados a targets retirados (solo tras auditoría de uso).
+2. Scripts de benchmark/transpilación exclusivos de backends legacy.
+3. Documentación pública que mencione targets fuera de `python/javascript/rust`.
+
+---
+
+## I) Documentation updates
+
+Actualizar progresivamente:
+- `README.md`:
+  - Cobra como interfaz única.
+  - Backends oficiales internos.
+  - CLI pública simplificada.
+- `docs/architecture/*`:
+  - diagrama de capas y rutas de binding.
+  - contrato de import/bindings/stdlib.
+- Guías de migración:
+  - desuso de comandos legacy y rutas directas a transpilers.
+
+---
+
+## Tareas estructuradas (paso a paso)
+
+### Fase 1 — Alineación contractual (bajo riesgo)
+1. Validar que rutas públicas usan solo `PUBLIC_BACKENDS`.
+2. Publicar inventario de legados y ventana de retiro.
+3. Añadir chequeos CI de coherencia contrato ↔ documentación.
+
+### Fase 2 — UX CLI unificada (bajo riesgo)
+1. Consolidar documentación oficial alrededor de `run/build/test/mod`.
+2. Mantener compatibilidad legacy solo por perfil de desarrollo.
+3. Eliminar exposición pública de flags ligados a transpilers.
+
+### Fase 3 — Contrato stdlib/imports/bindings (riesgo medio)
+1. Completar cobertura por módulo en `stdlib_contract`.
+2. Forzar política de conflictos de imports por entorno.
+3. Auditar adapters inyectados y metadatos de resolución.
+
+### Fase 4 — Retiro legacy (riesgo medio/alto)
+1. Medir uso de backends legacy en CI/scripts.
+2. Retirar comandos/paths obsoletos por lotes pequeños.
+3. Validar no regresión con suite de integración.
+
+### Fase 5 — Endurecimiento final
+1. Bloquear por defecto rutas internas legacy en builds estables.
+2. Documentar sólo arquitectura unificada y bridges oficiales.
+3. Publicar changelog de transición cerrada.

--- a/src/pcobra/cobra/architecture/__init__.py
+++ b/src/pcobra/cobra/architecture/__init__.py
@@ -5,9 +5,25 @@ from pcobra.cobra.architecture.capabilities_contract import (
     PUBLIC_CAPABILITIES_CONTRACT,
     PUBLIC_FALLBACK_POLICY,
 )
+from pcobra.cobra.architecture.unified_ecosystem import (
+    BINDING_BLUEPRINTS,
+    IMPORT_POLICY_BLUEPRINT,
+    LEGACY_BACKEND_REMOVAL_CANDIDATES,
+    OFFICIAL_EXECUTION_BACKENDS,
+    OFFICIAL_USER_LANGUAGE,
+    STDLIB_BLUEPRINTS,
+    build_refactor_workplan,
+)
 
 __all__ = [
     "PROJECT_TYPE_PUBLIC_POLICY",
     "PUBLIC_CAPABILITIES_CONTRACT",
     "PUBLIC_FALLBACK_POLICY",
+    "OFFICIAL_USER_LANGUAGE",
+    "OFFICIAL_EXECUTION_BACKENDS",
+    "LEGACY_BACKEND_REMOVAL_CANDIDATES",
+    "STDLIB_BLUEPRINTS",
+    "IMPORT_POLICY_BLUEPRINT",
+    "BINDING_BLUEPRINTS",
+    "build_refactor_workplan",
 ]

--- a/src/pcobra/cobra/architecture/unified_ecosystem.py
+++ b/src/pcobra/cobra/architecture/unified_ecosystem.py
@@ -1,0 +1,246 @@
+"""Plano arquitectónico para el ecosistema unificado de Cobra.
+
+Este módulo no altera el front-end del lenguaje ni los transpilers existentes.
+Su propósito es concentrar decisiones de arquitectura y un plan de ejecución
+seguro para migración incremental.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS, PUBLIC_BACKENDS
+
+
+OFFICIAL_USER_LANGUAGE: Final[str] = "cobra"
+OFFICIAL_EXECUTION_BACKENDS: Final[tuple[str, ...]] = PUBLIC_BACKENDS
+
+# Inventario de legados que se conservan solo para compatibilidad interna.
+LEGACY_BACKEND_REMOVAL_CANDIDATES: Final[dict[str, str]] = {
+    "go": "Desalineado del contrato oficial (python/javascript/rust)",
+    "cpp": "Fuera del ecosistema oficial de runtime y stdlib",
+    "java": "Solo aplica para reverse transpile histórico, no para salida oficial",
+    "wasm": "No participa en bindings oficiales del runtime actual",
+    "asm": "Sin cobertura del contrato público ni de stdlib",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class StdlibBlueprint:
+    """Describe la orientación de un módulo público de stdlib."""
+
+    module: str
+    api_contract: tuple[str, ...]
+    primary_backend: str
+    fallback_backends: tuple[str, ...]
+    rationale: str
+
+
+@dataclass(frozen=True, slots=True)
+class ImportPolicyBlueprint:
+    """Contrato de resolución para `importar` en Cobra."""
+
+    resolution_order: tuple[str, ...]
+    conflict_policy: str
+    adapter_injection: str
+
+
+@dataclass(frozen=True, slots=True)
+class BindingRouteBlueprint:
+    """Especificación de integración entre Cobra y un runtime externo."""
+
+    backend: str
+    route: str
+    adapter: str
+    abi_contract: str
+
+
+@dataclass(frozen=True, slots=True)
+class RefactorTask:
+    """Tarea atómica del plan de refactor incremental."""
+
+    id: str
+    area: str
+    objective: str
+    changes: tuple[str, ...]
+    safe_checks: tuple[str, ...]
+
+
+STDLIB_BLUEPRINTS: Final[tuple[StdlibBlueprint, ...]] = (
+    StdlibBlueprint(
+        module="cobra.core",
+        api_contract=("numeros", "texto", "logica"),
+        primary_backend="python",
+        fallback_backends=("rust", "javascript"),
+        rationale="Base transversal y estable para ejecución general.",
+    ),
+    StdlibBlueprint(
+        module="cobra.datos",
+        api_contract=("tablas", "columnas", "series"),
+        primary_backend="python",
+        fallback_backends=("javascript",),
+        rationale="Ecosistema de datos y puentes de librerías Python.",
+    ),
+    StdlibBlueprint(
+        module="cobra.web",
+        api_contract=("http", "json", "clientes"),
+        primary_backend="javascript",
+        fallback_backends=("python",),
+        rationale="Aprovecha el runtime JS para integración web y APIs.",
+    ),
+    StdlibBlueprint(
+        module="cobra.system",
+        api_contract=("archivos", "procesos", "entorno"),
+        primary_backend="python",
+        fallback_backends=("rust", "javascript"),
+        rationale="Operaciones de sistema con ruta híbrida Python/Rust.",
+    ),
+)
+
+
+IMPORT_POLICY_BLUEPRINT: Final[ImportPolicyBlueprint] = ImportPolicyBlueprint(
+    resolution_order=("stdlib", "project", "python_bridge", "hybrid"),
+    conflict_policy="namespace_required para producción; warn en modo migración",
+    adapter_injection=(
+        "Inyección automática de backend_adapter + metadata __cobra_resolution_metadata__"
+    ),
+)
+
+
+BINDING_BLUEPRINTS: Final[tuple[BindingRouteBlueprint, ...]] = (
+    BindingRouteBlueprint(
+        backend="python",
+        route="python_direct_import",
+        adapter="python_direct_bridge",
+        abi_contract="abi-python-v1",
+    ),
+    BindingRouteBlueprint(
+        backend="javascript",
+        route="javascript_runtime_bridge",
+        adapter="javascript_controlled_runtime_bridge",
+        abi_contract="abi-js-v1",
+    ),
+    BindingRouteBlueprint(
+        backend="rust",
+        route="rust_compiled_ffi",
+        adapter="rust_compiled_ffi_bridge",
+        abi_contract="abi-rust-v1",
+    ),
+)
+
+
+def build_refactor_workplan() -> tuple[RefactorTask, ...]:
+    """Devuelve tareas estructuradas para implementar la transición.
+
+    Las tareas están ordenadas por riesgo y dependencia, para ejecutarse de forma
+    incremental sin romper funcionalidad existente.
+    """
+
+    return (
+        RefactorTask(
+            id="T1",
+            area="core-alignment",
+            objective="Alinear módulos core con el contrato de 3 backends oficiales.",
+            changes=(
+                "Reusar PUBLIC_BACKENDS como única fuente en rutas públicas.",
+                "Conservar INTERNAL_BACKENDS solo para compatibilidad temporal.",
+            ),
+            safe_checks=(
+                "pytest tests/integration/test_cli_public_help_contract.py",
+                "pytest tests/integration/transpilers/test_official_backends_tier2.py",
+            ),
+        ),
+        RefactorTask(
+            id="T2",
+            area="cli-simplification",
+            objective="Consolidar UX en run/build/test/mod sin exposición de transpilers.",
+            changes=(
+                "Mantener comandos v2 como interfaz por defecto.",
+                "Encapsular decisiones de backend en build.backend_pipeline.",
+            ),
+            safe_checks=(
+                "pytest tests/integration/test_cli_ui_v2.py",
+                "pytest tests/integration/test_cli_public_help_contract.py",
+            ),
+        ),
+        RefactorTask(
+            id="T3",
+            area="stdlib-contract",
+            objective="Operar stdlib pública por contratos cobra.core/datos/web/system.",
+            changes=(
+                "Mantener manifest único en pcobra.cobra.stdlib_contract.",
+                "Declarar backend primario + fallbacks por módulo.",
+            ),
+            safe_checks=(
+                "python scripts/ci/audit_stdlib_parity.py",
+                "pytest tests/integration/test_standard_library_async.py",
+            ),
+        ),
+        RefactorTask(
+            id="T4",
+            area="imports-bindings",
+            objective="Formalizar resolución de imports + bridges de runtime.",
+            changes=(
+                "Aplicar orden stdlib > proyecto > python_bridge > hybrid.",
+                "Inyectar adapters por módulo resuelto en tiempo de carga.",
+            ),
+            safe_checks=(
+                "pytest tests/integration/test_cli_import.py",
+                "pytest tests/integration/transpilers/test_backend_runtime_imports_minimal.py",
+            ),
+        ),
+        RefactorTask(
+            id="T5",
+            area="legacy-removal",
+            objective="Retirar componentes legacy no oficiales de forma segura.",
+            changes=(
+                "Marcar go/cpp/java/wasm/asm como candidatos de retiro.",
+                "Eliminar comandos y scripts de backends retirados después de auditoría.",
+            ),
+            safe_checks=(
+                "python scripts/audit_retired_targets.py",
+                "python scripts/ci/validate_targets.py",
+            ),
+        ),
+    )
+
+
+def validate_unified_ecosystem_contract() -> None:
+    """Garantiza que el blueprint siga alineado al contrato público actual."""
+    if OFFICIAL_USER_LANGUAGE != "cobra":
+        raise RuntimeError("La interfaz pública debe ser exclusivamente 'cobra'.")
+
+    if OFFICIAL_EXECUTION_BACKENDS != PUBLIC_BACKENDS:
+        raise RuntimeError(
+            "El blueprint unificado debe usar exactamente PUBLIC_BACKENDS "
+            f"({PUBLIC_BACKENDS}), actual={OFFICIAL_EXECUTION_BACKENDS}."
+        )
+
+    # Evita que el inventario de retiro diverja de los legados declarados.
+    missing = tuple(sorted(set(INTERNAL_BACKENDS) - set(LEGACY_BACKEND_REMOVAL_CANDIDATES)))
+    extras = tuple(sorted(set(LEGACY_BACKEND_REMOVAL_CANDIDATES) - set(INTERNAL_BACKENDS)))
+    if missing or extras:
+        raise RuntimeError(
+            "Inventario legacy inconsistente. "
+            f"missing={missing or '∅'} extras={extras or '∅'}"
+        )
+
+
+validate_unified_ecosystem_contract()
+
+
+__all__ = [
+    "OFFICIAL_USER_LANGUAGE",
+    "OFFICIAL_EXECUTION_BACKENDS",
+    "LEGACY_BACKEND_REMOVAL_CANDIDATES",
+    "STDLIB_BLUEPRINTS",
+    "IMPORT_POLICY_BLUEPRINT",
+    "BINDING_BLUEPRINTS",
+    "RefactorTask",
+    "StdlibBlueprint",
+    "ImportPolicyBlueprint",
+    "BindingRouteBlueprint",
+    "build_refactor_workplan",
+    "validate_unified_ecosystem_contract",
+]

--- a/tests/test_unified_ecosystem_plan.py
+++ b/tests/test_unified_ecosystem_plan.py
@@ -1,0 +1,33 @@
+from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS, PUBLIC_BACKENDS
+from pcobra.cobra.architecture.unified_ecosystem import (
+    IMPORT_POLICY_BLUEPRINT,
+    LEGACY_BACKEND_REMOVAL_CANDIDATES,
+    OFFICIAL_EXECUTION_BACKENDS,
+    OFFICIAL_USER_LANGUAGE,
+    build_refactor_workplan,
+)
+
+
+def test_unified_blueprint_keeps_public_contract() -> None:
+    assert OFFICIAL_USER_LANGUAGE == "cobra"
+    assert OFFICIAL_EXECUTION_BACKENDS == PUBLIC_BACKENDS
+
+
+def test_legacy_inventory_matches_internal_backends() -> None:
+    assert set(LEGACY_BACKEND_REMOVAL_CANDIDATES) == set(INTERNAL_BACKENDS)
+
+
+def test_refactor_workplan_is_structured() -> None:
+    tasks = build_refactor_workplan()
+    assert len(tasks) >= 5
+    assert tasks[0].id == "T1"
+    assert all(task.safe_checks for task in tasks)
+
+
+def test_import_policy_resolution_order() -> None:
+    assert IMPORT_POLICY_BLUEPRINT.resolution_order == (
+        "stdlib",
+        "project",
+        "python_bridge",
+        "hybrid",
+    )


### PR DESCRIPTION
### Motivation
- Consolidar la arquitectura para que Cobra sea la única interfaz pública mientras internaliza los transpilers y mantiene solo tres backends oficiales: `python`, `javascript` y `rust`.
- Proveer una hoja de ruta incremental y de bajo riesgo para alinear módulos core, estandarizar la stdlib y formalizar import/bindings sin tocar lexer/parser/AST/transpiladores.
- Facilitar la retirada controlada de backends legacy y reducir exposición de opciones internas en la UX pública (CLI).

### Description
- Se añadió `src/pcobra/cobra/architecture/unified_ecosystem.py` que declara blueprints ejecutables para `stdlib`, `imports`, `bindings`, inventario de legados y un `build_refactor_workplan()` con tareas y checks de validación.
- Se exportó la nueva superficie desde `src/pcobra/cobra/architecture/__init__.py` para que el blueprint sea accesible desde el paquete de arquitectura.
- Se añadió el documento de diseño y plan de transición `docs/architecture/cobra_unified_refactor_plan.md` y se enlazó desde `README.md` en la sección de ecosistema unificado.
- Se añadieron tests estructurales en `tests/test_unified_ecosystem_plan.py` que comprueban el contrato público de backends, la correspondencia del inventario legacy, la estructura del workplan y el orden de resolución de imports.
- El cambio preserva la estructura base del repo y no modifica lexer, parser, AST ni los transpilers existentes; los transpilers permanecen ocultos y serán invocados vía las fachadas internas ya existentes.

### Testing
- Se ejecutaron las pruebas automatizadas añadidas con `pytest -q tests/test_unified_ecosystem_plan.py` y todas las pruebas pasaron (`4 passed`).
- El módulo `unified_ecosystem` realiza validaciones de contrato en inicialización import-safe, que fueron verificadas por las pruebas unitarias anteriores.
- Las tareas del `build_refactor_workplan()` incluyen checks recomendados a ejecutar posteriormente (`pytest` y scripts de auditoría referenciados) para validar cambios en fases posteriores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22961f4b483279ec3f7c49795cbb3)