### PR TITLE
Forzar frontera pública Cobra + bloquear exposición legacy en arranque del CLI

### DIFF
--- a/src/pcobra/cobra/architecture/__init__.py
+++ b/src/pcobra/cobra/architecture/__init__.py
@@ -14,6 +14,14 @@ from pcobra.cobra.architecture.unified_ecosystem import (
     STDLIB_BLUEPRINTS,
     build_refactor_workplan,
 )
+from pcobra.cobra.architecture.overview import (
+    INTERNAL_MIGRATION_ONLY_SURFACES,
+    PUBLIC_ARCHITECTURE_OVERVIEW,
+    PUBLIC_CLI_V2_COMMANDS,
+    PUBLIC_FLOW_DIAGRAM,
+    PUBLIC_LANGUAGE_BOUNDARY,
+    USER_ROUTE_BACKEND_ENTRYPOINT,
+)
 
 __all__ = [
     "PROJECT_TYPE_PUBLIC_POLICY",
@@ -26,4 +34,10 @@ __all__ = [
     "IMPORT_POLICY_BLUEPRINT",
     "BINDING_BLUEPRINTS",
     "build_refactor_workplan",
+    "PUBLIC_LANGUAGE_BOUNDARY",
+    "PUBLIC_CLI_V2_COMMANDS",
+    "USER_ROUTE_BACKEND_ENTRYPOINT",
+    "INTERNAL_MIGRATION_ONLY_SURFACES",
+    "PUBLIC_ARCHITECTURE_OVERVIEW",
+    "PUBLIC_FLOW_DIAGRAM",
 ]

--- a/src/pcobra/cobra/architecture/overview.py
+++ b/src/pcobra/cobra/architecture/overview.py
@@ -1,0 +1,95 @@
+"""Resumen arquitectónico oficial de frontera pública e internas.
+
+Este módulo define el contrato de alto nivel para evitar deriva entre:
+- documentación,
+- validaciones de arranque de CLI,
+- y rutas de ejecución build/runtime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+
+PUBLIC_LANGUAGE_BOUNDARY: Final[str] = "cobra"
+PUBLIC_CLI_V2_COMMANDS: Final[tuple[str, ...]] = ("run", "build", "test", "mod")
+
+# Toda ruta de usuario termina resolviendo backend mediante esta fachada.
+USER_ROUTE_BACKEND_ENTRYPOINT: Final[str] = "pcobra.cobra.build.backend_pipeline"
+
+# Superficies no públicas: mantener solo para transición interna controlada.
+INTERNAL_MIGRATION_ONLY_SURFACES: Final[dict[str, tuple[str, ...] | str]] = {
+    "cli_v1": "internal migration only",
+    "legacy_targets": "internal migration only",
+    "obsolete_commands": (
+        "dependencias",
+        "empaquetar",
+        "bench",
+        "benchmarks",
+        "benchmarks2",
+        "benchtranspilers",
+        "benchthreads",
+        "profile",
+        "transpilar-inverso",
+        "validar-sintaxis",
+        "qa-validar",
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class PublicArchitectureOverview:
+    """Snapshot corto del contrato público efectivo."""
+
+    language: str
+    cli_commands_v2: tuple[str, ...]
+    user_backend_entrypoint: str
+    internal_migration_only: dict[str, tuple[str, ...] | str]
+
+
+PUBLIC_ARCHITECTURE_OVERVIEW: Final[PublicArchitectureOverview] = (
+    PublicArchitectureOverview(
+        language=PUBLIC_LANGUAGE_BOUNDARY,
+        cli_commands_v2=PUBLIC_CLI_V2_COMMANDS,
+        user_backend_entrypoint=USER_ROUTE_BACKEND_ENTRYPOINT,
+        internal_migration_only=INTERNAL_MIGRATION_ONLY_SURFACES,
+    )
+)
+
+# Diagrama de flujo corto (sin cambios en AST).
+PUBLIC_FLOW_DIAGRAM: Final[str] = (
+    "Cobra source -> AST (sin cambios) -> backend_pipeline -> "
+    "transpiler interno -> runtime/binding"
+)
+
+
+def validate_public_architecture_overview() -> None:
+    """Garantiza una frontera pública única y estable."""
+    if PUBLIC_LANGUAGE_BOUNDARY != "cobra":
+        raise RuntimeError("La frontera pública de lenguaje debe ser únicamente 'cobra'.")
+
+    if PUBLIC_CLI_V2_COMMANDS != ("run", "build", "test", "mod"):
+        raise RuntimeError(
+            "La CLI pública v2 debe exponer exactamente run/build/test/mod."
+        )
+
+    if USER_ROUTE_BACKEND_ENTRYPOINT != "pcobra.cobra.build.backend_pipeline":
+        raise RuntimeError(
+            "Toda ruta de usuario debe pasar por pcobra.cobra.build.backend_pipeline."
+        )
+
+
+validate_public_architecture_overview()
+
+
+__all__ = [
+    "PUBLIC_LANGUAGE_BOUNDARY",
+    "PUBLIC_CLI_V2_COMMANDS",
+    "USER_ROUTE_BACKEND_ENTRYPOINT",
+    "INTERNAL_MIGRATION_ONLY_SURFACES",
+    "PublicArchitectureOverview",
+    "PUBLIC_ARCHITECTURE_OVERVIEW",
+    "PUBLIC_FLOW_DIAGRAM",
+    "validate_public_architecture_overview",
+]

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -53,6 +53,10 @@ from pcobra.cobra.cli.commands_v2 import (
     TestCommandV2,
     is_legacy_cli_enabled,
 )
+from pcobra.cobra.cli.internal_compat.legacy_targets import (
+    LEGACY_BACKENDS_FEATURE_FLAG,
+    is_internal_legacy_targets_enabled,
+)
 from pcobra.cobra.cli.i18n import _, format_traceback, setup_gettext
 from pcobra.cobra.cli.mode_policy import (
     CLI_MODOS_PERMITIDOS,
@@ -66,6 +70,7 @@ from pcobra.cobra.cli.public_command_policy import (
     filter_legacy_commands_for_profile,
     resolve_command_profile,
 )
+from pcobra.cobra.architecture.overview import USER_ROUTE_BACKEND_ENTRYPOINT
 from pcobra.cobra.cli.plugin import (
     descubrir_plugins,
     configure_plugin_policy,
@@ -272,11 +277,6 @@ class CliApplication:
 
         command_profile = resolve_command_profile()
         selected_ui = getattr(self, "_selected_ui", "v2")
-        if command_profile == PROFILE_PUBLIC and selected_ui == "v1":
-            logging.getLogger(__name__).debug(
-                "Perfil público activo: forzando UI v2 para evitar exposición de comandos legacy en --help.",
-            )
-            selected_ui = "v2"
         self.command_registry.register_base_commands(
             self._subparsers,
             ui=selected_ui,
@@ -626,6 +626,38 @@ class CliApplication:
         parsed = self.parser.parse_args(argv)
         return self._normalizar_flags_sesion(parsed)
 
+    def _enforce_public_startup_guard(self) -> None:
+        """Bloquea exposición accidental de rutas legacy en perfil público."""
+        command_profile = resolve_command_profile()
+        selected_ui = getattr(self, "_selected_ui", "v2")
+        if command_profile != PROFILE_PUBLIC:
+            return
+
+        blocked_routes: list[str] = []
+        if selected_ui == "v1":
+            blocked_routes.append("cli v1 (internal migration only)")
+        if is_legacy_cli_enabled():
+            blocked_routes.append(f"legacy command group ({COBRA_ENABLE_LEGACY_CLI_ENV}=1)")
+        if is_internal_legacy_targets_enabled():
+            blocked_routes.append(f"legacy targets ({LEGACY_BACKENDS_FEATURE_FLAG}=1)")
+
+        if not blocked_routes:
+            return
+
+        raise RuntimeError(
+            "Perfil público bloqueado por rutas legacy/internal migration only: "
+            f"{', '.join(blocked_routes)}. "
+            "Use CLI v2 pública (run/build/test/mod) y enrute por "
+            f"{USER_ROUTE_BACKEND_ENTRYPOINT}."
+        )
+
+    @staticmethod
+    def _resolve_selected_ui_from_argv(argv: list[str]) -> str:
+        for index, token in enumerate(argv):
+            if token == "--ui" and index + 1 < len(argv):
+                return argv[index + 1].strip().lower()
+        return "v2"
+
     def _handle_execution_error(self, exc: Exception, language: str, debug_activo: bool = False) -> int:
         error_ya_mostrado = isinstance(exc, CliErrorYaMostrado) or bool(
             getattr(exc, "error_ya_mostrado", False)
@@ -888,6 +920,8 @@ class CliApplication:
 
             try:
                 argv = self._sanear_argv(argv)
+                self._selected_ui = self._resolve_selected_ui_from_argv(argv)
+                self._enforce_public_startup_guard()
                 args = self._parse_arguments(argv)
                 command = getattr(args, "cmd", None)
                 command_name = command.name if isinstance(command, BaseCommand) else _("desconocido")

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -12,6 +12,7 @@ def _public_env() -> dict[str, str]:
     env.pop("COBRA_DEV_MODE", None)
     env.pop("COBRA_CLI_COMMAND_PROFILE", None)
     env.pop("COBRA_INTERNAL_ENABLE_LEGACY_CLI", None)
+    env.pop("COBRA_INTERNAL_LEGACY_TARGETS", None)
     return env
 
 
@@ -37,7 +38,7 @@ def test_cli_help_public_contract_snapshot():
     assert "\n  legacy " not in result.stdout.lower()
 
 
-def test_cli_help_public_contract_snapshot_no_expone_legacy_aun_con_ui_v1():
+def test_cli_help_public_contract_bloquea_ui_v1_en_perfil_publico():
     repo_root = Path(__file__).resolve().parents[2]
     result = subprocess.run(
         [sys.executable, "-m", "cobra.cli.cli", "--ui", "v1", "--help"],
@@ -46,13 +47,26 @@ def test_cli_help_public_contract_snapshot_no_expone_legacy_aun_con_ui_v1():
         cwd=str(repo_root),
         env=_public_env(),
     )
-    assert result.returncode == 0
+    assert result.returncode == 1
 
-    expected_snapshot = (
-        Path(__file__).parent / "golden" / "cli_ui_v2_help_public.golden"
-    ).read_text(encoding="utf-8")
-    assert " ".join(result.stdout.lower().split()) == " ".join(expected_snapshot.split())
-    lower_help = result.stdout.lower()
-    assert "\n  legacy " not in lower_help
-    assert "\n  compilar " not in lower_help
-    assert "\n  ejecutar " not in lower_help
+    lower_error = result.stderr.lower() + result.stdout.lower()
+    assert "perfil público bloqueado" in lower_error
+    assert "cli v1" in lower_error
+    assert "run/build/test/mod" in lower_error
+
+
+def test_cli_help_public_contract_bloquea_flags_legacy_en_arranque():
+    repo_root = Path(__file__).resolve().parents[2]
+    env = _public_env()
+    env["COBRA_INTERNAL_ENABLE_LEGACY_CLI"] = "1"
+    result = subprocess.run(
+        [sys.executable, "-m", "cobra.cli.cli", "--ui", "v2", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=env,
+    )
+    assert result.returncode == 1
+    lower_error = result.stderr.lower() + result.stdout.lower()
+    assert "internal migration only" in lower_error
+    assert "cobra_internal_enable_legacy_cli=1" in lower_error

--- a/tests/unit/test_architecture_overview.py
+++ b/tests/unit/test_architecture_overview.py
@@ -1,0 +1,31 @@
+from pcobra.cobra.architecture.overview import (
+    INTERNAL_MIGRATION_ONLY_SURFACES,
+    PUBLIC_CLI_V2_COMMANDS,
+    PUBLIC_FLOW_DIAGRAM,
+    PUBLIC_LANGUAGE_BOUNDARY,
+    USER_ROUTE_BACKEND_ENTRYPOINT,
+    validate_public_architecture_overview,
+)
+
+
+def test_overview_declara_frontera_publica_unica():
+    assert PUBLIC_LANGUAGE_BOUNDARY == "cobra"
+    assert PUBLIC_CLI_V2_COMMANDS == ("run", "build", "test", "mod")
+    assert USER_ROUTE_BACKEND_ENTRYPOINT == "pcobra.cobra.build.backend_pipeline"
+
+
+def test_overview_marca_superficies_migracion_interna():
+    assert INTERNAL_MIGRATION_ONLY_SURFACES["cli_v1"] == "internal migration only"
+    assert INTERNAL_MIGRATION_ONLY_SURFACES["legacy_targets"] == "internal migration only"
+    assert "bench" in INTERNAL_MIGRATION_ONLY_SURFACES["obsolete_commands"]
+
+
+def test_overview_publica_diagrama_corto():
+    assert "Cobra source" in PUBLIC_FLOW_DIAGRAM
+    assert "AST (sin cambios)" in PUBLIC_FLOW_DIAGRAM
+    assert "backend_pipeline" in PUBLIC_FLOW_DIAGRAM
+    assert "runtime/binding" in PUBLIC_FLOW_DIAGRAM
+
+
+def test_overview_validate_contract_no_falla():
+    validate_public_architecture_overview()


### PR DESCRIPTION
### Motivation
- Evitar deriva entre documentación, validaciones de arranque y rutas de ejecución dejando una única frontera pública: lenguaje `cobra` y la CLI v2 (`run/build/test/mod`).
- Asegurar que todas las rutas de usuario resuelvan backend por una única fachada contractual y que las superficies legacy no se expongan por accidente en perfiles públicos.

### Description
- Añadido el módulo `src/pcobra/cobra/architecture/overview.py` que declara la frontera pública (`PUBLIC_LANGUAGE_BOUNDARY`), la lista de comandos públicos v2 (`PUBLIC_CLI_V2_COMMANDS`), el entrypoint obligatorio de rutas de usuario (`USER_ROUTE_BACKEND_ENTRYPOINT = "pcobra.cobra.build.backend_pipeline"`), las superficies marcadas como `internal migration only` y un diagrama de flujo corto (`PUBLIC_FLOW_DIAGRAM`).
- Exportados los símbolos del nuevo `overview` desde `src/pcobra/cobra/architecture/__init__.py` para uso centralizado.
- Añadida una guardia de arranque en `CliApplication` (`src/pcobra/cobra/cli/cli.py`) que bloquea el inicio en perfil público cuando detecta exposición legacy (solicitud de `--ui v1`, `COBRA_INTERNAL_ENABLE_LEGACY_CLI=1` o `COBRA_INTERNAL_LEGACY_TARGETS=1`) y sugiere enrutar por `pcobra.cobra.build.backend_pipeline`.
- Marcado explícito `cli v1`, `legacy targets` y comandos obsoletos como "internal migration only" en el contrato arquitectónico.
- Tests: nuevo test unitario `tests/unit/test_architecture_overview.py` y actualización de `tests/integration/test_cli_public_help_contract.py` para verificar bloqueo en perfil público y que la ayuda pública sigue exponiendo solo la superficie esperada.

### Testing
- Ejecutado `pytest -q tests/unit/test_architecture_overview.py tests/integration/test_cli_public_help_contract.py` y todos los tests relevantes pasaron (`8 passed`).
- Las pruebas de integración confirman que la CLI en perfil público devuelve error de arranque al intentar exponer rutas legacy y que la ayuda pública v2 mantiene la snapshot esperada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2359e8370832794f15d0f5bb472f1)