### PR TITLE
Centraliza contratos públicos y agrega guard de imports para superficies públicas

### DIFF
--- a/scripts/ci/check_public_import_boundaries.py
+++ b/scripts/ci/check_public_import_boundaries.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Guarda imports de superficies públicas contra rutas de migración interna."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = ROOT / "src"
+PUBLIC_SCOPES = (
+    SRC_ROOT / "pcobra/cobra/build",
+    SRC_ROOT / "pcobra/cobra/architecture",
+    SRC_ROOT / "pcobra/cobra/imports",
+    SRC_ROOT / "pcobra/cobra/bindings",
+)
+
+FORBIDDEN_IMPORT_PREFIXES = (
+    "pcobra.cobra.cli.internal_compat",
+    "pcobra.cobra.architecture.legacy_backend_lifecycle",
+)
+FORBIDDEN_IMPORT_CONTAINS = (
+    ".internal_compat.",
+    ".internal_compat",
+)
+
+
+def _node_import_targets(node: ast.AST) -> list[str]:
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    if isinstance(node, ast.ImportFrom):
+        return [node.module] if node.module else []
+    return []
+
+
+def _is_forbidden_import(target: str) -> bool:
+    return target.startswith(FORBIDDEN_IMPORT_PREFIXES) or any(
+        token in target for token in FORBIDDEN_IMPORT_CONTAINS
+    )
+
+
+def _scan_scope(scope: Path) -> list[tuple[Path, int, str]]:
+    violations: list[tuple[Path, int, str]] = []
+    for path in sorted(scope.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            for target in _node_import_targets(node):
+                if target and _is_forbidden_import(target):
+                    violations.append((path, node.lineno, target))
+    return violations
+
+
+def main() -> int:
+    violations: list[tuple[Path, int, str]] = []
+    for scope in PUBLIC_SCOPES:
+        if scope.exists():
+            violations.extend(_scan_scope(scope))
+
+    if violations:
+        print("❌ Se detectaron imports no permitidos en superficies públicas:")
+        for path, lineno, target in violations:
+            rel = path.relative_to(ROOT)
+            print(f" - {rel}:{lineno}: {target}")
+        return 1
+
+    print("✅ Import boundary guard: sin imports de internal_compat ni inventario legacy.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pcobra/cobra/architecture/__init__.py
+++ b/src/pcobra/cobra/architecture/__init__.py
@@ -1,6 +1,6 @@
 """Módulos de arquitectura interna de pCobra."""
 
-from pcobra.cobra.architecture.capabilities_contract import (
+from pcobra.cobra.architecture.contracts import (
     PROJECT_TYPE_PUBLIC_POLICY,
     PUBLIC_CAPABILITIES_CONTRACT,
     PUBLIC_FALLBACK_POLICY,

--- a/src/pcobra/cobra/architecture/capabilities_contract.py
+++ b/src/pcobra/cobra/architecture/capabilities_contract.py
@@ -1,130 +1,15 @@
-"""Contrato único de capacidades públicas para resolución de backend.
+"""Compatibilidad de contrato: re-exporta el canon desde ``architecture.contracts``."""
 
-Este contrato centraliza:
-1) backends públicos permitidos,
-2) ruta de binding por backend público,
-3) política de fallback para rutas públicas.
-"""
-
-from __future__ import annotations
-
-from dataclasses import dataclass
-from typing import Final
-
-from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS
-from pcobra.cobra.bindings.contract import BindingRoute
-
-
-PUBLIC_BACKENDS: Final[tuple[str, ...]] = (
-    "python",
-    "javascript",
-    "rust",
+from pcobra.cobra.architecture.contracts import (
+    PROJECT_TYPE_PUBLIC_POLICY,
+    PUBLIC_BACKENDS,
+    PUBLIC_CAPABILITIES_CONTRACT,
+    PUBLIC_FALLBACK_POLICY,
+    PublicBackendCapability,
+    assert_backend_allowed_for_scope,
+    binding_route_for_public_backend,
+    validate_capabilities_contract,
 )
-
-
-@dataclass(frozen=True, slots=True)
-class PublicBackendCapability:
-    """Capacidad pública canónica para un backend soportado."""
-
-    backend: str
-    binding_route: BindingRoute
-    fallback_rank: int
-
-
-PUBLIC_CAPABILITIES_CONTRACT: Final[dict[str, PublicBackendCapability]] = {
-    "python": PublicBackendCapability(
-        backend="python",
-        binding_route=BindingRoute.PYTHON_DIRECT_IMPORT,
-        fallback_rank=1,
-    ),
-    "javascript": PublicBackendCapability(
-        backend="javascript",
-        binding_route=BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE,
-        fallback_rank=2,
-    ),
-    "rust": PublicBackendCapability(
-        backend="rust",
-        binding_route=BindingRoute.RUST_COMPILED_FFI,
-        fallback_rank=3,
-    ),
-}
-
-# Política de fallback contractual para rutas públicas.
-PUBLIC_FALLBACK_POLICY: Final[tuple[str, ...]] = tuple(
-    backend
-    for backend, _metadata in sorted(
-        PUBLIC_CAPABILITIES_CONTRACT.items(),
-        key=lambda item: item[1].fallback_rank,
-    )
-)
-
-# Preferencias públicas por tipo de proyecto (siempre restringidas al contrato público).
-PROJECT_TYPE_PUBLIC_POLICY: Final[dict[str, tuple[str, ...]]] = {
-    "library": ("python", "rust", "javascript"),
-    "web": ("javascript", "python", "rust"),
-    "systems": ("rust", "python", "javascript"),
-    "embedded": ("rust", "python", "javascript"),
-    "application": ("python", "javascript", "rust"),
-}
-
-
-def validate_capabilities_contract() -> None:
-    """Valida consistencia interna del contrato público."""
-
-    configured_public = tuple(PUBLIC_CAPABILITIES_CONTRACT)
-    if configured_public != PUBLIC_BACKENDS:
-        raise RuntimeError(
-            "PUBLIC_CAPABILITIES_CONTRACT debe listar exactamente PUBLIC_BACKENDS. "
-            f"configured={configured_public}; expected={PUBLIC_BACKENDS}"
-        )
-
-    missing = tuple(backend for backend in PUBLIC_BACKENDS if backend not in PUBLIC_FALLBACK_POLICY)
-    extras = tuple(backend for backend in PUBLIC_FALLBACK_POLICY if backend not in PUBLIC_BACKENDS)
-    if missing or extras:
-        raise RuntimeError(
-            "PUBLIC_FALLBACK_POLICY debe cubrir exactamente PUBLIC_BACKENDS. "
-            f"missing={missing or '∅'}; extras={extras or '∅'}"
-        )
-
-    for project_type, candidates in PROJECT_TYPE_PUBLIC_POLICY.items():
-        invalid = tuple(backend for backend in candidates if backend not in PUBLIC_BACKENDS)
-        if invalid:
-            raise RuntimeError(
-                "PROJECT_TYPE_PUBLIC_POLICY contiene backends fuera del contrato público. "
-                f"project_type={project_type}; invalid={invalid}"
-            )
-
-
-def assert_backend_allowed_for_scope(*, backend: str, scope: str) -> None:
-    """Garantiza que un backend pertenezca al scope autorizado."""
-
-    canonical = (backend or "").strip().lower()
-    if scope == "public":
-        if canonical not in PUBLIC_BACKENDS:
-            raise ValueError(
-                f"Backend no permitido en ruta pública: {backend}. "
-                f"Permitidos: {', '.join(PUBLIC_BACKENDS)}"
-            )
-        return
-    if scope == "internal_migration":
-        if canonical not in PUBLIC_BACKENDS and canonical not in INTERNAL_BACKENDS:
-            raise ValueError(
-                f"Backend no reconocido para migración interna: {backend}. "
-                f"Permitidos: {', '.join(PUBLIC_BACKENDS + INTERNAL_BACKENDS)}"
-            )
-        return
-    raise ValueError(f"Scope de backend no soportado: {scope}")
-
-
-def binding_route_for_public_backend(backend: str) -> BindingRoute:
-    """Devuelve la ruta de binding contractual de un backend público."""
-
-    assert_backend_allowed_for_scope(backend=backend, scope="public")
-    return PUBLIC_CAPABILITIES_CONTRACT[backend].binding_route
-
-
-validate_capabilities_contract()
-
 
 __all__ = [
     "PROJECT_TYPE_PUBLIC_POLICY",

--- a/src/pcobra/cobra/architecture/contracts.py
+++ b/src/pcobra/cobra/architecture/contracts.py
@@ -1,0 +1,131 @@
+"""Contrato arquitectónico canónico para rutas públicas de backend.
+
+Este módulo centraliza:
+1) backends públicos permitidos,
+2) rutas de binding por backend público,
+3) política de fallback para rutas públicas.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS, PUBLIC_BACKENDS
+from pcobra.cobra.bindings.contract import BindingRoute
+
+
+@dataclass(frozen=True, slots=True)
+class PublicBackendCapability:
+    """Capacidad pública canónica para un backend soportado."""
+
+    backend: str
+    binding_route: BindingRoute
+    fallback_rank: int
+
+
+PUBLIC_CAPABILITIES_CONTRACT: Final[dict[str, PublicBackendCapability]] = {
+    "python": PublicBackendCapability(
+        backend="python",
+        binding_route=BindingRoute.PYTHON_DIRECT_IMPORT,
+        fallback_rank=1,
+    ),
+    "javascript": PublicBackendCapability(
+        backend="javascript",
+        binding_route=BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE,
+        fallback_rank=2,
+    ),
+    "rust": PublicBackendCapability(
+        backend="rust",
+        binding_route=BindingRoute.RUST_COMPILED_FFI,
+        fallback_rank=3,
+    ),
+}
+
+# Política de fallback contractual para rutas públicas.
+PUBLIC_FALLBACK_POLICY: Final[tuple[str, ...]] = tuple(
+    backend
+    for backend, _metadata in sorted(
+        PUBLIC_CAPABILITIES_CONTRACT.items(),
+        key=lambda item: item[1].fallback_rank,
+    )
+)
+
+# Preferencias públicas por tipo de proyecto (siempre restringidas al contrato público).
+PROJECT_TYPE_PUBLIC_POLICY: Final[dict[str, tuple[str, ...]]] = {
+    "library": ("python", "rust", "javascript"),
+    "web": ("javascript", "python", "rust"),
+    "systems": ("rust", "python", "javascript"),
+    "embedded": ("rust", "python", "javascript"),
+    "application": ("python", "javascript", "rust"),
+}
+
+
+def validate_capabilities_contract() -> None:
+    """Valida consistencia interna del contrato público."""
+
+    configured_public = tuple(PUBLIC_CAPABILITIES_CONTRACT)
+    if configured_public != PUBLIC_BACKENDS:
+        raise RuntimeError(
+            "PUBLIC_CAPABILITIES_CONTRACT debe listar exactamente PUBLIC_BACKENDS. "
+            f"configured={configured_public}; expected={PUBLIC_BACKENDS}"
+        )
+
+    missing = tuple(backend for backend in PUBLIC_BACKENDS if backend not in PUBLIC_FALLBACK_POLICY)
+    extras = tuple(backend for backend in PUBLIC_FALLBACK_POLICY if backend not in PUBLIC_BACKENDS)
+    if missing or extras:
+        raise RuntimeError(
+            "PUBLIC_FALLBACK_POLICY debe cubrir exactamente PUBLIC_BACKENDS. "
+            f"missing={missing or '∅'}; extras={extras or '∅'}"
+        )
+
+    for project_type, candidates in PROJECT_TYPE_PUBLIC_POLICY.items():
+        invalid = tuple(backend for backend in candidates if backend not in PUBLIC_BACKENDS)
+        if invalid:
+            raise RuntimeError(
+                "PROJECT_TYPE_PUBLIC_POLICY contiene backends fuera del contrato público. "
+                f"project_type={project_type}; invalid={invalid}"
+            )
+
+
+def assert_backend_allowed_for_scope(*, backend: str, scope: str) -> None:
+    """Garantiza que un backend pertenezca al scope autorizado."""
+
+    canonical = (backend or "").strip().lower()
+    if scope == "public":
+        if canonical not in PUBLIC_BACKENDS:
+            raise ValueError(
+                f"Backend no permitido en ruta pública: {backend}. "
+                f"Permitidos: {', '.join(PUBLIC_BACKENDS)}"
+            )
+        return
+    if scope == "internal_migration":
+        if canonical not in PUBLIC_BACKENDS and canonical not in INTERNAL_BACKENDS:
+            raise ValueError(
+                f"Backend no reconocido para migración interna: {backend}. "
+                f"Permitidos: {', '.join(PUBLIC_BACKENDS + INTERNAL_BACKENDS)}"
+            )
+        return
+    raise ValueError(f"Scope de backend no soportado: {scope}")
+
+
+def binding_route_for_public_backend(backend: str) -> BindingRoute:
+    """Devuelve la ruta de binding contractual de un backend público."""
+
+    assert_backend_allowed_for_scope(backend=backend, scope="public")
+    return PUBLIC_CAPABILITIES_CONTRACT[backend].binding_route
+
+
+validate_capabilities_contract()
+
+
+__all__ = [
+    "PROJECT_TYPE_PUBLIC_POLICY",
+    "PUBLIC_BACKENDS",
+    "PUBLIC_CAPABILITIES_CONTRACT",
+    "PUBLIC_FALLBACK_POLICY",
+    "PublicBackendCapability",
+    "assert_backend_allowed_for_scope",
+    "binding_route_for_public_backend",
+    "validate_capabilities_contract",
+]

--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from pcobra.cobra.architecture.capabilities_contract import (
+from pcobra.cobra.architecture.contracts import (
     PUBLIC_BACKENDS,
     PUBLIC_CAPABILITIES_CONTRACT,
     assert_backend_allowed_for_scope,

--- a/src/pcobra/cobra/build/orchestrator.py
+++ b/src/pcobra/cobra/build/orchestrator.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from pcobra.cobra.architecture.capabilities_contract import (
+from pcobra.cobra.architecture.contracts import (
     PROJECT_TYPE_PUBLIC_POLICY,
     PUBLIC_BACKENDS,
     PUBLIC_FALLBACK_POLICY,

--- a/tests/unit/test_public_import_boundaries_guard.py
+++ b/tests/unit/test_public_import_boundaries_guard.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_public_import_boundaries_guard_passes_on_repo() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "scripts/ci/check_public_import_boundaries.py"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
### Motivation

- Consolidar la definición del contrato público de backends, rutas de binding y política de fallback en una capa única para evitar deriva entre módulos.
- Prohibir que superficies públicas (build/architecture/imports/bindings) dependan de rutas de compatibilidad interna o inventarios legacy para reducir acoplamientos peligrosos.
- Mantener `legacy_backend_lifecycle.py` como inventario interno y no como dependencia de flujos públicos durante la migración.

### Description

- Añade la capa canónica `src/pcobra/cobra/architecture/contracts.py` que centraliza `PUBLIC_BACKENDS`, rutas de binding y políticas de fallback, y valida el contrato.
- Mantiene `src/pcobra/cobra/architecture/capabilities_contract.py` como shim de compatibilidad que re-exporta desde `architecture.contracts` para no romper imports existentes.
- Actualiza imports consumidores para usar la nueva capa canónica en `src/pcobra/cobra/build/orchestrator.py`, `src/pcobra/cobra/build/backend_pipeline.py` y `src/pcobra/cobra/architecture/__init__.py`.
- Añade el guard CI `scripts/ci/check_public_import_boundaries.py` que falla si los scopes públicos importan `internal_compat` o `architecture.legacy_backend_lifecycle`, y la prueba `tests/unit/test_public_import_boundaries_guard.py` que ejecuta el guard sobre el repo.

### Testing

- Ejecuté `python scripts/ci/check_public_import_boundaries.py` y el script devolvió éxito (`0`) comprobando que no hay imports prohibidos en las superficies públicas.
- Ejecuté `pytest tests/unit/test_public_import_boundaries_guard.py` y la prueba pasó correctamente.
- Intenté ejecutar la suite combinada que incluye `scripts/lint_policy_drift.py` (`pytest ... tests/unit/test_lint_policy_drift.py`) y falló con `ModuleNotFoundError: No module named 'bindings'` al ejecutar un script que carga dependencias externas, lo cual es un problema de entorno y no un fallo derivado de estos cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e257dd2a008327806a08eb0af30225)