### PR TITLE
Forzar UI v2 pública y migración automática de comandos legacy

### DIFF
--- a/docs/migracion_cli_unificada.md
+++ b/docs/migracion_cli_unificada.md
@@ -22,6 +22,18 @@ Con backends públicos oficiales:
 - **Interfaz pública**: comandos `cobra run/build/test/mod` y backends oficiales `python`, `javascript`, `rust`.
 - **Compatibilidad interna**: aliases legacy y backends internos usados solo para migración controlada.
 
+## Matriz de comandos (públicos vs internos vs obsoletos)
+
+| Clase | Comandos |
+|---|---|
+| **Públicos (UI v2)** | `run`, `build`, `test`, `mod` |
+| **Internos (UI v2 / development)** | `legacy`, `debug`, `devops` |
+| **Legacy públicos (UI v1, migración)** | `interactive`, `compilar`, `ejecutar`, `modulos`, `verificar`, `docs`, `plugins`, `init`, `crear`, `paquete` |
+| **Legacy internos (UI v1)** | `cache`, `contenedor`, `gui`, `jupyter`, `qualia`, `agix` |
+| **Legacy obsoletos (UI v1)** | `dependencias`, `empaquetar`, `bench`, `benchmarks`, `benchmarks2`, `benchtranspilers`, `benchthreads`, `profile`, `transpilar-inverso`, `validar-sintaxis`, `qa-validar` |
+
+> Fuente de verdad de superficie pública: `PUBLIC_COMMANDS=("run","build","test","mod")`.
+
 ## Mapeo de comandos legacy (equivalencia viejo → nuevo)
 
 | Comando legacy (viejo) | Comando unificado (nuevo) |

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -64,6 +64,7 @@ from pcobra.cobra.cli.mode_policy import (
     validar_politica_modo,
 )
 from pcobra.cobra.cli.public_command_policy import (
+    COMMAND_VISIBILITY_MATRIX_MARKDOWN,
     PROFILE_DEVELOPMENT,
     PROFILE_PUBLIC,
     filter_commands_for_profile,
@@ -96,6 +97,12 @@ COBRA_DEV_EPHEMERAL_CONFIRM_ENV = "COBRA_DEV_ALLOW_EPHEMERAL_KEY"
 COBRA_ALLOW_INSECURE_FALLBACK_ENV = "COBRA_ALLOW_INSECURE_FALLBACK"
 COBRA_ALLOW_INSECURE_NON_INTERACTIVE_ENV = "COBRA_ALLOW_INSECURE_NON_INTERACTIVE"
 LANG_CHOICES = tuple(OFFICIAL_TRANSPILATION_TARGETS)
+LEGACY_COMMAND_MIGRATION_MAP: dict[str, str] = {
+    "ejecutar": "run",
+    "compilar": "build",
+    "verificar": "test",
+    "modulos": "mod",
+}
 
 
 class CliErrorYaMostrado(Exception):
@@ -401,12 +408,7 @@ class CliApplication:
             "--ui",
             choices=("v1", "v2"),
             default="v2",
-            help=_(
-                "Selecciona la interfaz CLI: v2 (recomendada para usuarios finales) o v1 (compatibilidad interna). "
-                "En v2, la superficie pública es run/build/test/mod. "
-                "Los comandos internos quedan disponibles solo en perfil development "
-                "(COBRA_DEV_MODE=1 o COBRA_CLI_COMMAND_PROFILE=development)."
-            ),
+            help=argparse.SUPPRESS,
         )
         parser.add_argument("--lang",
                           default=environ.get("COBRA_LANG", AppConfig.DEFAULT_LANGUAGE),
@@ -634,8 +636,6 @@ class CliApplication:
             return
 
         blocked_routes: list[str] = []
-        if selected_ui == "v1":
-            blocked_routes.append("cli v1 (internal migration only)")
         if is_legacy_cli_enabled():
             blocked_routes.append(f"legacy command group ({COBRA_ENABLE_LEGACY_CLI_ENV}=1)")
         if is_internal_legacy_targets_enabled():
@@ -650,6 +650,58 @@ class CliApplication:
             "Use CLI v2 pública (run/build/test/mod) y enrute por "
             f"{USER_ROUTE_BACKEND_ENTRYPOINT}."
         )
+
+    @staticmethod
+    def _first_non_option_token_index(argv: list[str]) -> Optional[int]:
+        for index, token in enumerate(argv):
+            if token == "--":
+                return index + 1 if index + 1 < len(argv) else None
+            if not token.startswith("-"):
+                return index
+        return None
+
+    def _apply_public_cli_policy(self, argv: list[str]) -> list[str]:
+        """Fuerza UI v2 para usuarios y migra comandos legacy automáticamente."""
+        normalized = list(argv)
+        profile = resolve_command_profile()
+        if profile != PROFILE_PUBLIC:
+            return normalized
+
+        if self._resolve_selected_ui_from_argv(normalized) == "v1":
+            for index, token in enumerate(normalized):
+                if token == "--ui" and index + 1 < len(normalized):
+                    normalized[index + 1] = "v2"
+            messages.mostrar_advertencia(
+                _(
+                    "CLI v1 está reservada para desarrollo interno. "
+                    "Se aplicó migración automática a UI v2 pública."
+                )
+            )
+
+        command_idx = self._first_non_option_token_index(normalized)
+        if command_idx is None:
+            return normalized
+
+        command_token = normalized[command_idx].strip().lower()
+        migrated_to = LEGACY_COMMAND_MIGRATION_MAP.get(command_token)
+        if not migrated_to:
+            return normalized
+
+        normalized[command_idx] = migrated_to
+        messages.mostrar_advertencia(
+            _(
+                "Comando legacy '{legacy}' detectado fuera de entorno interno. "
+                "Migración automática aplicada: use '{current}'."
+            ).format(legacy=command_token, current=migrated_to)
+        )
+        logging.getLogger(__name__).warning(
+            "legacy_command_auto_migrated legacy=%s target=%s profile=%s matrix=%s",
+            command_token,
+            migrated_to,
+            profile,
+            COMMAND_VISIBILITY_MATRIX_MARKDOWN.replace("\n", " | "),
+        )
+        return normalized
 
     @staticmethod
     def _resolve_selected_ui_from_argv(argv: list[str]) -> str:
@@ -920,6 +972,7 @@ class CliApplication:
 
             try:
                 argv = self._sanear_argv(argv)
+                argv = self._apply_public_cli_policy(argv)
                 self._selected_ui = self._resolve_selected_ui_from_argv(argv)
                 self._enforce_public_startup_guard()
                 args = self._parse_arguments(argv)

--- a/src/pcobra/cobra/cli/public_command_policy.py
+++ b/src/pcobra/cobra/cli/public_command_policy.py
@@ -44,6 +44,14 @@ LEGACY_OBSOLETE_COMMANDS: tuple[str, ...] = (
     "validar-sintaxis",
     "qa-validar",
 )
+COMMAND_VISIBILITY_MATRIX_MARKDOWN = """| Clase | Comandos |
+|---|---|
+| Públicos (UI v2) | run, build, test, mod |
+| Internos (UI v2 / development) | legacy, debug, devops |
+| Legacy públicos (UI v1) | interactive, compilar, ejecutar, modulos, verificar, docs, plugins, init, crear, paquete |
+| Legacy internos (UI v1) | cache, contenedor, gui, jupyter, qualia, agix |
+| Legacy obsoletos (UI v1) | dependencias, empaquetar, bench, benchmarks, benchmarks2, benchtranspilers, benchthreads, profile, transpilar-inverso, validar-sintaxis, qa-validar |
+|"""
 
 PROFILE_PUBLIC = "public"
 PROFILE_DEVELOPMENT = "development"
@@ -106,6 +114,7 @@ __all__ = [
     "LEGACY_PUBLIC_COMMANDS",
     "LEGACY_INTERNAL_COMMANDS",
     "LEGACY_OBSOLETE_COMMANDS",
+    "COMMAND_VISIBILITY_MATRIX_MARKDOWN",
     "PROFILE_PUBLIC",
     "PROFILE_DEVELOPMENT",
     "COMMAND_PROFILES",

--- a/tests/integration/golden/cli_help_public_no_legacy.golden
+++ b/tests/integration/golden/cli_help_public_no_legacy.golden
@@ -1,6 +1,6 @@
 usage: cobra [-h] [--version] [--ayuda] [--format] [--debug] [-v] [--no-safe]
              [--allow-insecure-fallback] [--allow-insecure-non-interactive]
-             [--modo {cobra,transpilar,mixto}] [--solo-cobra] [--ui {v1,v2}]
+             [--modo {cobra,transpilar,mixto}] [--solo-cobra]
              [--lang LANG] [--no-color] [--extra-validators EXTRA_VALIDATORS]
              [--legacy-imports] [--dev-ephemeral-key] [--plugins-safe-mode]
              [--plugins-unsafe-mode] [--plugins-allowlist PLUGINS_ALLOWLIST]
@@ -31,7 +31,6 @@ options:
                         (solo generar código), mixto (ejecutar y transpilar).
   --solo-cobra          Alias semántico de --modo cobra: sesión para solo
                         programar/interpretar Cobra sin rutas de codegen.
-  --ui {v1,v2}          Selecciona la interfaz CLI: v2 (recomendada para usuarios finales) o v1 (compatibilidad legacy). En v2, la superficie pública es run/build/test/mod. Los comandos internos quedan disponibles solo en perfil development (COBRA_DEV_MODE=1 o COBRA_CLI_COMMAND_PROFILE=development).
   --lang LANG           Interface language code
   --no-color            Disable colored output
   --extra-validators EXTRA_VALIDATORS

--- a/tests/integration/golden/cli_ui_v2_help_public.golden
+++ b/tests/integration/golden/cli_ui_v2_help_public.golden
@@ -1,6 +1,6 @@
 usage: cobra [-h] [--version] [--ayuda] [--format] [--debug] [-v] [--no-safe]
              [--allow-insecure-fallback] [--allow-insecure-non-interactive]
-             [--modo {cobra,transpilar,mixto}] [--solo-cobra] [--ui {v1,v2}]
+             [--modo {cobra,transpilar,mixto}] [--solo-cobra]
              [--lang lang] [--no-color] [--extra-validators extra_validators]
              [--legacy-imports] [--dev-ephemeral-key] [--plugins-safe-mode]
              [--plugins-unsafe-mode] [--plugins-allowlist plugins_allowlist]
@@ -31,12 +31,6 @@ options:
                         (solo generar código), mixto (ejecutar y transpilar).
   --solo-cobra          alias semántico de --modo cobra: sesión para solo
                         programar/interpretar cobra sin rutas de codegen.
-  --ui {v1,v2}          selecciona la interfaz cli: v2 (recomendada para
-                        usuarios finales) o v1 (compatibilidad interna). en
-                        v2, la superficie pública es run/build/test/mod. los
-                        comandos internos quedan disponibles solo en perfil
-                        development (cobra_dev_mode=1 o
-                        cobra_cli_command_profile=development).
   --lang lang           interface language code
   --no-color            disable colored output
   --extra-validators extra_validators

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -23,7 +23,7 @@ def test_cli_public_commands_contract_is_stable():
 def test_cli_help_public_contract_snapshot():
     repo_root = Path(__file__).resolve().parents[2]
     result = subprocess.run(
-        [sys.executable, "-m", "cobra.cli.cli", "--ui", "v2", "--help"],
+        [sys.executable, "-m", "cobra.cli.cli", "--help"],
         capture_output=True,
         text=True,
         cwd=str(repo_root),
@@ -47,12 +47,10 @@ def test_cli_help_public_contract_bloquea_ui_v1_en_perfil_publico():
         cwd=str(repo_root),
         env=_public_env(),
     )
-    assert result.returncode == 1
-
-    lower_error = result.stderr.lower() + result.stdout.lower()
-    assert "perfil público bloqueado" in lower_error
-    assert "cli v1" in lower_error
-    assert "run/build/test/mod" in lower_error
+    assert result.returncode == 0
+    lower_output = result.stderr.lower() + result.stdout.lower()
+    assert "cli v1 está reservada para desarrollo interno" in lower_output
+    assert "migración automática a ui v2 pública" in lower_output
 
 
 def test_cli_help_public_contract_bloquea_flags_legacy_en_arranque():
@@ -60,7 +58,7 @@ def test_cli_help_public_contract_bloquea_flags_legacy_en_arranque():
     env = _public_env()
     env["COBRA_INTERNAL_ENABLE_LEGACY_CLI"] = "1"
     result = subprocess.run(
-        [sys.executable, "-m", "cobra.cli.cli", "--ui", "v2", "--help"],
+        [sys.executable, "-m", "cobra.cli.cli", "--help"],
         capture_output=True,
         text=True,
         cwd=str(repo_root),
@@ -70,3 +68,18 @@ def test_cli_help_public_contract_bloquea_flags_legacy_en_arranque():
     lower_error = result.stderr.lower() + result.stdout.lower()
     assert "internal migration only" in lower_error
     assert "cobra_internal_enable_legacy_cli=1" in lower_error
+
+
+def test_cli_help_public_contract_muestra_warning_migracion_en_comando_legacy():
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "-m", "cobra.cli.cli", "compilar", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=_public_env(),
+    )
+    assert result.returncode == 0
+    lower_output = result.stderr.lower() + result.stdout.lower()
+    assert "comando legacy 'compilar'" in lower_output
+    assert "migración automática aplicada: use 'build'" in lower_output


### PR DESCRIPTION
### Motivation
- Evitar que usuarios finales usen la UI v1 y forzar la superficie pública unificada `run/build/test/mod`. 
- Mantener `PUBLIC_COMMANDS=("run","build","test","mod")` como única fuente de verdad para la superficie pública. 
- Permitir compatibilidad controlada para migración interna y proporcionar advertencias cuando se invoquen comandos legacy desde entornos no internos. 
- Documentar explícitamente la matriz de visibilidad de comandos (públicos / internos / legacy / obsoletos) para guiar la migración. 

### Description
- Oculté `--ui` del help público cambiando su `help` a `argparse.SUPPRESS` y forzo el tratamiento a UI v2 en ejecuciones públicas; la UI v1 queda reservada para uso interno explícito. (`src/pcobra/cobra/cli/cli.py`).
- Añadí migración automática de comandos legacy en perfil público mediante `LEGACY_COMMAND_MIGRATION_MAP` y la función `_apply_public_cli_policy`, que reemplaza el token de comando legacy por su equivalente v2, emite una advertencia al usuario y registra un warning estructurado con la matriz de visibilidad. (`src/pcobra/cobra/cli/cli.py`).
- Conservé `PUBLIC_COMMANDS` intacto y añadí `COMMAND_VISIBILITY_MATRIX_MARKDOWN` como representación documentada de la matriz de visibilidad en `public_command_policy.py`. (`src/pcobra/cobra/cli/public_command_policy.py`).
- Documenté la matriz de comandos en la guía de migración `docs/migracion_cli_unificada.md` y actualicé snapshots/help golden para reflejar la ausencia pública de `--ui` y las nuevas advertencias de migración. (`docs/migracion_cli_unificada.md`, `tests/integration/golden/*`).
- Ajusté e introduje tests de integración para verificar: help público sin `--ui`, comportamiento de `--ui v1` en perfil público (migra con warning en lugar de bloquear), bloqueo de flags legacy cuando están habilitados accidentalmente en perfil público, y advertencia explícita cuando se invoca un comando legacy (`compilar`). (`tests/integration/test_cli_public_help_contract.py`, `tests/integration/test_cli_ui_v2.py`, `tests/integration/test_cli_ayuda.py`).

### Testing
- Ejecuté: `pytest -q tests/integration/test_cli_public_help_contract.py tests/integration/test_cli_ui_v2.py tests/integration/test_cli_ayuda.py` y todos los tests pasaron: `13 passed, 1 skipped`.
- Validé manualmente salidas de help y mensajes de advertencia para `--help`, `--ui v1` y invocation de `compilar --help` en perfil público; las advertencias y logs se emitieron según lo esperado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2624305788327958bde66ccf3e307)