### PR TITLE
Centralizar pipeline de build v2, ocultar flags de backend en UI pública y consolidar telemetría

### DIFF
--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -112,11 +112,7 @@ def build(source: str, hints: dict[str, Any] | None = None) -> dict[str, Any]:
     ast = obtener_ast(codigo)
     code = transpile(ast, resolution.backend)
     debug = bool(context.get("debug", False))
-    reason = (
-        resolution.reason_for(debug=debug)
-        if hasattr(resolution, "reason_for")
-        else (getattr(resolution, "reason", None) if debug else None)
-    )
+    reason = resolution.reason_for(debug=debug)
     return {
         "backend": resolution.backend,
         "reason": reason,

--- a/src/pcobra/cobra/build/orchestrator.py
+++ b/src/pcobra/cobra/build/orchestrator.py
@@ -25,8 +25,10 @@ class BackendResolution:
     reason: str
 
     def reason_for(self, *, debug: bool) -> str | None:
-        """Expone razón solo cuando el flujo se ejecuta en modo debug."""
-        return self.reason if debug else None
+        """Expone telemetría de resolución únicamente en modo debug."""
+        if not debug:
+            return None
+        return f"[backend_resolution] backend={self.backend}; reason={self.reason}"
 
 
 class BuildOrchestrator:

--- a/src/pcobra/cobra/cli/commands_v2/build_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/build_cmd.py
@@ -1,10 +1,9 @@
-from argparse import Namespace
 from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.build import backend_pipeline
-from pcobra.cobra.cli.commands.compile_cmd import CompileCommand
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.cli.utils.autocomplete import files_completer
 
 
@@ -16,7 +15,6 @@ class BuildCommandV2(BaseCommand):
 
     def __init__(self) -> None:
         super().__init__()
-        self._legacy = CompileCommand()
 
     def register_subparser(self, subparsers: Any):
         parser = subparsers.add_parser(self.name, help=_("Build/transpile a Cobra file"))
@@ -26,13 +24,23 @@ class BuildCommandV2(BaseCommand):
 
     def run(self, args: Any) -> int:
         debug = bool(getattr(args, "debug", False))
-        resolution = backend_pipeline.resolve_backend(args.file, {})
-        legacy_args = Namespace(
-            archivo=args.file,
-            tipo=resolution.backend,
-            backend=None,
-            tipos=None,
-            modo=getattr(args, "modo", "mixto"),
-            backend_reason=resolution.reason_for(debug=debug),
-        )
-        return self._legacy.run(legacy_args)
+        try:
+            build_result = backend_pipeline.build(
+                args.file,
+                {
+                    "debug": debug,
+                    "source_file": args.file,
+                },
+            )
+        except Exception as exc:
+            mostrar_error(str(exc), registrar_log=False)
+            return 1
+
+        if build_result.get("reason"):
+            mostrar_info(
+                _("Resolución de backend (debug): {reason}").format(reason=build_result["reason"]),
+                registrar_log=False,
+            )
+        mostrar_info(_("Código generado:"), registrar_log=False)
+        print(build_result["code"])
+        return 0

--- a/src/pcobra/cobra/cli/public_command_policy.py
+++ b/src/pcobra/cobra/cli/public_command_policy.py
@@ -13,7 +13,6 @@ INTERNAL_COMMANDS: tuple[str, ...] = (
 )
 LEGACY_PUBLIC_COMMANDS: tuple[str, ...] = (
     "interactive",
-    "compilar",
     "ejecutar",
     "modulos",
     "verificar",
@@ -24,6 +23,7 @@ LEGACY_PUBLIC_COMMANDS: tuple[str, ...] = (
     "paquete",
 )
 LEGACY_INTERNAL_COMMANDS: tuple[str, ...] = (
+    "compilar",
     "cache",
     "contenedor",
     "gui",
@@ -48,8 +48,8 @@ COMMAND_VISIBILITY_MATRIX_MARKDOWN = """| Clase | Comandos |
 |---|---|
 | Públicos (UI v2) | run, build, test, mod |
 | Internos (UI v2 / development) | legacy, debug, devops |
-| Legacy públicos (UI v1) | interactive, compilar, ejecutar, modulos, verificar, docs, plugins, init, crear, paquete |
-| Legacy internos (UI v1) | cache, contenedor, gui, jupyter, qualia, agix |
+| Legacy públicos (UI v1) | interactive, ejecutar, modulos, verificar, docs, plugins, init, crear, paquete |
+| Legacy internos (UI v1) | compilar, cache, contenedor, gui, jupyter, qualia, agix |
 | Legacy obsoletos (UI v1) | dependencias, empaquetar, bench, benchmarks, benchmarks2, benchtranspilers, benchthreads, profile, transpilar-inverso, validar-sintaxis, qa-validar |
 |"""
 

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -36,6 +36,25 @@ def test_cli_help_public_contract_snapshot():
     ).read_text(encoding="utf-8")
     assert " ".join(result.stdout.lower().split()) == " ".join(expected_snapshot.split())
     assert "\n  legacy " not in result.stdout.lower()
+    assert "--backend" not in result.stdout.lower()
+    assert "--tipo" not in result.stdout.lower()
+    assert "--tipos" not in result.stdout.lower()
+
+
+def test_cli_build_help_public_contract_no_expone_flags_backend():
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "-m", "cobra.cli.cli", "build", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=_public_env(),
+    )
+    assert result.returncode == 0
+    output = result.stdout.lower()
+    assert "--backend" not in output
+    assert "--tipo" not in output
+    assert "--tipos" not in output
 
 
 def test_cli_help_public_contract_bloquea_ui_v1_en_perfil_publico():

--- a/tests/unit/test_cli_v2_command_contract.py
+++ b/tests/unit/test_cli_v2_command_contract.py
@@ -42,19 +42,36 @@ def test_build_v2_resuelve_backend_via_pipeline(monkeypatch):
     called = {}
 
     monkeypatch.setattr(
-        "cobra.cli.commands_v2.build_cmd.backend_pipeline.resolve_backend",
+        "cobra.cli.commands_v2.build_cmd.backend_pipeline.build",
         lambda file, hints: called.setdefault(
-            "resolution",
-            type("R", (), {"backend": "python", "reason_for": lambda self, debug: None})(),
+            "build",
+            {
+                "backend": "python",
+                "reason": None,
+                "runtime": {"language": "python"},
+                "ast": [],
+                "code": "print('ok')",
+            },
         ),
     )
-    monkeypatch.setattr(command._legacy, "run", lambda _args: 0)
 
     status = command.run(
         argparse.Namespace(file="programa.co", modo="mixto", debug=False)
     )
     assert status == 0
-    assert "resolution" in called
+    assert "build" in called
+
+
+def test_build_v2_help_no_expone_flags_backend():
+    subparsers = _build_subparsers()
+    command = BuildCommandV2()
+    command.register_subparser(subparsers)
+    parser = subparsers.choices[command.name]
+    help_text = parser.format_help().lower()
+
+    assert "--tipo" not in help_text
+    assert "--backend" not in help_text
+    assert "--tipos" not in help_text
 
 
 def test_run_v2_valida_seguridad_por_ruta_binding(monkeypatch):


### PR DESCRIPTION
### Motivation
- Unificar la ruta pública de compilación/transpilación en un único punto (`src/pcobra/cobra/build/backend_pipeline.py`) para reducir acoplamientos con el comando legacy `compilar`.
- Evitar que la UX pública UI v2 muestre o acepte flags de control de target/backend visible (`--backend`, `--tipo`, `--tipos`).
- Centralizar la salida de telemetría/debug de resolución de backend en un único método audit-friendly para trazabilidad interna.

### Description
- `BuildCommandV2` ahora invoca `backend_pipeline.build(...)` y muestra el `code` devuelto, eliminando la dependencia directa con `CompileCommand` legacy y evitando propagar flags de backend a la ruta pública (archivo modificado: `src/pcobra/cobra/cli/commands_v2/build_cmd.py`).
- `BackendResolution.reason_for` fue reforzado para exponer telemetría audit-friendly solo en modo debug y con formato único, y `backend_pipeline.build` usa exclusivamente ese método para poblar `reason` (archivo modificado: `src/pcobra/cobra/build/orchestrator.py` y `src/pcobra/cobra/build/backend_pipeline.py`).
- El comando legacy `compilar` fue movido fuera de `LEGACY_PUBLIC_COMMANDS` a `LEGACY_INTERNAL_COMMANDS` para limitar su exposición al perfil `development` (archivo modificado: `src/pcobra/cobra/cli/public_command_policy.py`).
- Se añadieron y ajustaron tests para garantizar el contrato público: se actualizó el test unitario de `BuildCommandV2` para mockear `backend_pipeline.build` y se añadieron pruebas que verifican que la ayuda pública (global y `build --help`) no muestra `--backend/--tipo/--tipos` (archivos modificados: `tests/unit/test_cli_v2_command_contract.py`, `tests/integration/test_cli_public_help_contract.py`).

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_v2_command_contract.py tests/integration/test_cli_public_help_contract.py tests/unit/test_build_orchestrator.py` y todos los tests ejecutados pasaron (`17 passed, 1 warning`).
- Las nuevas aserciones comprueban explícitamente que `build` v2 no registra flags de backend en la ayuda y que `BuildCommandV2` llama al pipeline unificado (`backend_pipeline.build`).
- Se preservaron y verificaron tests del `BuildOrchestrator` para asegurar la razón y priorización de selección de backend bajo distintas condiciones.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e26a5db25c8327a0455a1c2ed4777f)