### PR TITLE
Fortalecer contratos stdlib y validar cobertura por función contra runtime_api_matrix

### DIFF
--- a/docs/_generated/stdlib_contract_matrix.json
+++ b/docs/_generated/stdlib_contract_matrix.json
@@ -38,7 +38,7 @@
         {
           "function": "cobra.core.es_finito",
           "backend": "javascript",
-          "level": "full"
+          "level": "partial"
         },
         {
           "function": "cobra.core.es_infinito",
@@ -53,7 +53,7 @@
         {
           "function": "cobra.core.es_infinito",
           "backend": "javascript",
-          "level": "full"
+          "level": "partial"
         },
         {
           "function": "cobra.core.copiar_signo",
@@ -68,7 +68,7 @@
         {
           "function": "cobra.core.copiar_signo",
           "backend": "javascript",
-          "level": "full"
+          "level": "partial"
         },
         {
           "function": "cobra.core.signo",
@@ -83,7 +83,7 @@
         {
           "function": "cobra.core.signo",
           "backend": "javascript",
-          "level": "full"
+          "level": "partial"
         }
       ]
     },
@@ -119,7 +119,7 @@
         {
           "function": "cobra.datos.filtrar",
           "backend": "javascript",
-          "level": "full"
+          "level": "partial"
         },
         {
           "function": "cobra.datos.seleccionar_columnas",
@@ -129,7 +129,7 @@
         {
           "function": "cobra.datos.seleccionar_columnas",
           "backend": "javascript",
-          "level": "full"
+          "level": "partial"
         },
         {
           "function": "cobra.datos.a_listas",
@@ -139,7 +139,7 @@
         {
           "function": "cobra.datos.a_listas",
           "backend": "javascript",
-          "level": "full"
+          "level": "partial"
         },
         {
           "function": "cobra.datos.de_listas",
@@ -149,7 +149,7 @@
         {
           "function": "cobra.datos.de_listas",
           "backend": "javascript",
-          "level": "full"
+          "level": "partial"
         }
       ]
     },
@@ -177,7 +177,7 @@
         {
           "function": "cobra.web.obtener_url",
           "backend": "javascript",
-          "level": "full"
+          "level": "partial"
         },
         {
           "function": "cobra.web.obtener_url",
@@ -187,7 +187,7 @@
         {
           "function": "cobra.web.enviar_post",
           "backend": "javascript",
-          "level": "full"
+          "level": "partial"
         },
         {
           "function": "cobra.web.enviar_post",
@@ -197,7 +197,7 @@
         {
           "function": "cobra.web.descargar_archivo",
           "backend": "javascript",
-          "level": "full"
+          "level": "partial"
         },
         {
           "function": "cobra.web.descargar_archivo",
@@ -208,7 +208,7 @@
     },
     {
       "module": "cobra.system",
-      "primary_backend": "python",
+      "primary_backend": "python+rust",
       "allowed_fallback": [
         "rust",
         "javascript"
@@ -274,7 +274,7 @@
         {
           "function": "cobra.system.ejecutar",
           "backend": "javascript",
-          "level": "full"
+          "level": "partial"
         },
         {
           "function": "cobra.system.obtener_env",
@@ -289,7 +289,7 @@
         {
           "function": "cobra.system.obtener_env",
           "backend": "javascript",
-          "level": "full"
+          "level": "partial"
         }
       ]
     }

--- a/docs/_generated/stdlib_contract_matrix.md
+++ b/docs/_generated/stdlib_contract_matrix.md
@@ -2,6 +2,15 @@
 
 Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 
+## Tabla de garantías por módulo
+
+| Módulo | API pública | Backend primario | Fallback | Límites |
+|---|---|---|---|---|
+| `cobra.core` | 4 | `python` | `rust, javascript` | es_finito:rust, es_finito:javascript, es_infinito:rust, es_infinito:javascript, copiar_signo:rust, copiar_signo:javascript, signo:rust, signo:javascript |
+| `cobra.datos` | 4 | `python` | `javascript` | filtrar:javascript, seleccionar_columnas:javascript, a_listas:javascript, de_listas:javascript |
+| `cobra.web` | 3 | `javascript` | `python` | obtener_url:javascript, enviar_post:javascript, descargar_archivo:javascript |
+| `cobra.system` | 4 | `python+rust` | `rust, javascript` | leer:rust, leer:javascript, escribir:rust, escribir:javascript, ejecutar:rust, ejecutar:javascript, obtener_env:rust, obtener_env:javascript |
+
 ## `cobra.core`
 
 - **Backend primario:** `python`
@@ -23,16 +32,16 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 |---|---|---|
 | `cobra.core.es_finito` | `python` | `full` |
 | `cobra.core.es_finito` | `rust` | `partial` |
-| `cobra.core.es_finito` | `javascript` | `full` |
+| `cobra.core.es_finito` | `javascript` | `partial` |
 | `cobra.core.es_infinito` | `python` | `full` |
 | `cobra.core.es_infinito` | `rust` | `partial` |
-| `cobra.core.es_infinito` | `javascript` | `full` |
+| `cobra.core.es_infinito` | `javascript` | `partial` |
 | `cobra.core.copiar_signo` | `python` | `full` |
 | `cobra.core.copiar_signo` | `rust` | `partial` |
-| `cobra.core.copiar_signo` | `javascript` | `full` |
+| `cobra.core.copiar_signo` | `javascript` | `partial` |
 | `cobra.core.signo` | `python` | `full` |
 | `cobra.core.signo` | `rust` | `partial` |
-| `cobra.core.signo` | `javascript` | `full` |
+| `cobra.core.signo` | `javascript` | `partial` |
 
 ## `cobra.datos`
 
@@ -54,13 +63,13 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 | Función | Backend | Nivel |
 |---|---|---|
 | `cobra.datos.filtrar` | `python` | `full` |
-| `cobra.datos.filtrar` | `javascript` | `full` |
+| `cobra.datos.filtrar` | `javascript` | `partial` |
 | `cobra.datos.seleccionar_columnas` | `python` | `full` |
-| `cobra.datos.seleccionar_columnas` | `javascript` | `full` |
+| `cobra.datos.seleccionar_columnas` | `javascript` | `partial` |
 | `cobra.datos.a_listas` | `python` | `full` |
-| `cobra.datos.a_listas` | `javascript` | `full` |
+| `cobra.datos.a_listas` | `javascript` | `partial` |
 | `cobra.datos.de_listas` | `python` | `full` |
-| `cobra.datos.de_listas` | `javascript` | `full` |
+| `cobra.datos.de_listas` | `javascript` | `partial` |
 
 ## `cobra.web`
 
@@ -80,16 +89,16 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 
 | Función | Backend | Nivel |
 |---|---|---|
-| `cobra.web.obtener_url` | `javascript` | `full` |
+| `cobra.web.obtener_url` | `javascript` | `partial` |
 | `cobra.web.obtener_url` | `python` | `full` |
-| `cobra.web.enviar_post` | `javascript` | `full` |
+| `cobra.web.enviar_post` | `javascript` | `partial` |
 | `cobra.web.enviar_post` | `python` | `full` |
-| `cobra.web.descargar_archivo` | `javascript` | `full` |
+| `cobra.web.descargar_archivo` | `javascript` | `partial` |
 | `cobra.web.descargar_archivo` | `python` | `full` |
 
 ## `cobra.system`
 
-- **Backend primario:** `python`
+- **Backend primario:** `python+rust`
 - **Fallback permitido:** `rust, javascript`
 - **Mapeo `standard_library`:** `src/pcobra/standard_library/archivo.py`
 - **Mapeo `corelibs`:** `src/pcobra/corelibs/sistema.py`
@@ -114,7 +123,7 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 | `cobra.system.escribir` | `javascript` | `partial` |
 | `cobra.system.ejecutar` | `python` | `full` |
 | `cobra.system.ejecutar` | `rust` | `partial` |
-| `cobra.system.ejecutar` | `javascript` | `full` |
+| `cobra.system.ejecutar` | `javascript` | `partial` |
 | `cobra.system.obtener_env` | `python` | `full` |
 | `cobra.system.obtener_env` | `rust` | `partial` |
-| `cobra.system.obtener_env` | `javascript` | `full` |
+| `cobra.system.obtener_env` | `javascript` | `partial` |

--- a/docs/standard_library/matriz_stdlib_unificada.md
+++ b/docs/standard_library/matriz_stdlib_unificada.md
@@ -2,6 +2,15 @@
 
 Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 
+## Tabla de garantías por módulo
+
+| Módulo | API pública | Backend primario | Fallback | Límites |
+|---|---|---|---|---|
+| `cobra.core` | 4 | `python` | `rust, javascript` | es_finito:rust, es_finito:javascript, es_infinito:rust, es_infinito:javascript, copiar_signo:rust, copiar_signo:javascript, signo:rust, signo:javascript |
+| `cobra.datos` | 4 | `python` | `javascript` | filtrar:javascript, seleccionar_columnas:javascript, a_listas:javascript, de_listas:javascript |
+| `cobra.web` | 3 | `javascript` | `python` | obtener_url:javascript, enviar_post:javascript, descargar_archivo:javascript |
+| `cobra.system` | 4 | `python+rust` | `rust, javascript` | leer:rust, leer:javascript, escribir:rust, escribir:javascript, ejecutar:rust, ejecutar:javascript, obtener_env:rust, obtener_env:javascript |
+
 ## `cobra.core`
 
 - **Backend primario:** `python`
@@ -23,16 +32,16 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 |---|---|---|
 | `cobra.core.es_finito` | `python` | `full` |
 | `cobra.core.es_finito` | `rust` | `partial` |
-| `cobra.core.es_finito` | `javascript` | `full` |
+| `cobra.core.es_finito` | `javascript` | `partial` |
 | `cobra.core.es_infinito` | `python` | `full` |
 | `cobra.core.es_infinito` | `rust` | `partial` |
-| `cobra.core.es_infinito` | `javascript` | `full` |
+| `cobra.core.es_infinito` | `javascript` | `partial` |
 | `cobra.core.copiar_signo` | `python` | `full` |
 | `cobra.core.copiar_signo` | `rust` | `partial` |
-| `cobra.core.copiar_signo` | `javascript` | `full` |
+| `cobra.core.copiar_signo` | `javascript` | `partial` |
 | `cobra.core.signo` | `python` | `full` |
 | `cobra.core.signo` | `rust` | `partial` |
-| `cobra.core.signo` | `javascript` | `full` |
+| `cobra.core.signo` | `javascript` | `partial` |
 
 ## `cobra.datos`
 
@@ -54,13 +63,13 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 | Función | Backend | Nivel |
 |---|---|---|
 | `cobra.datos.filtrar` | `python` | `full` |
-| `cobra.datos.filtrar` | `javascript` | `full` |
+| `cobra.datos.filtrar` | `javascript` | `partial` |
 | `cobra.datos.seleccionar_columnas` | `python` | `full` |
-| `cobra.datos.seleccionar_columnas` | `javascript` | `full` |
+| `cobra.datos.seleccionar_columnas` | `javascript` | `partial` |
 | `cobra.datos.a_listas` | `python` | `full` |
-| `cobra.datos.a_listas` | `javascript` | `full` |
+| `cobra.datos.a_listas` | `javascript` | `partial` |
 | `cobra.datos.de_listas` | `python` | `full` |
-| `cobra.datos.de_listas` | `javascript` | `full` |
+| `cobra.datos.de_listas` | `javascript` | `partial` |
 
 ## `cobra.web`
 
@@ -80,16 +89,16 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 
 | Función | Backend | Nivel |
 |---|---|---|
-| `cobra.web.obtener_url` | `javascript` | `full` |
+| `cobra.web.obtener_url` | `javascript` | `partial` |
 | `cobra.web.obtener_url` | `python` | `full` |
-| `cobra.web.enviar_post` | `javascript` | `full` |
+| `cobra.web.enviar_post` | `javascript` | `partial` |
 | `cobra.web.enviar_post` | `python` | `full` |
-| `cobra.web.descargar_archivo` | `javascript` | `full` |
+| `cobra.web.descargar_archivo` | `javascript` | `partial` |
 | `cobra.web.descargar_archivo` | `python` | `full` |
 
 ## `cobra.system`
 
-- **Backend primario:** `python`
+- **Backend primario:** `python+rust`
 - **Fallback permitido:** `rust, javascript`
 - **Mapeo `standard_library`:** `src/pcobra/standard_library/archivo.py`
 - **Mapeo `corelibs`:** `src/pcobra/corelibs/sistema.py`
@@ -114,7 +123,7 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 | `cobra.system.escribir` | `javascript` | `partial` |
 | `cobra.system.ejecutar` | `python` | `full` |
 | `cobra.system.ejecutar` | `rust` | `partial` |
-| `cobra.system.ejecutar` | `javascript` | `full` |
+| `cobra.system.ejecutar` | `javascript` | `partial` |
 | `cobra.system.obtener_env` | `python` | `full` |
 | `cobra.system.obtener_env` | `rust` | `partial` |
-| `cobra.system.obtener_env` | `javascript` | `full` |
+| `cobra.system.obtener_env` | `javascript` | `partial` |

--- a/scripts/ci/validate_stdlib_function_coverage.py
+++ b/scripts/ci/validate_stdlib_function_coverage.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Valida cobertura por función (`full`/`partial`) frente a runtime_api_matrix."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from pcobra.cobra.stdlib_contract.validator import (  # noqa: E402
+    validate_contracts,
+    validate_contracts_against_runtime_matrix,
+)
+
+
+def main() -> int:
+    validate_contracts()
+    validate_contracts_against_runtime_matrix()
+    print("✅ Stdlib coverage by function valida contra runtime_api_matrix")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_runtime_contract.py
+++ b/scripts/validate_runtime_contract.py
@@ -22,6 +22,7 @@ from pcobra.cobra.cli.target_policies import (
     validate_runtime_support_contract,
 )
 from pcobra.cobra.stdlib_contract.validator import validate_contracts
+from pcobra.cobra.stdlib_contract.validator import validate_contracts_against_runtime_matrix
 from pcobra.cobra.transpilers.compatibility_matrix import (
     BACKEND_COMPATIBILITY,
     BACKEND_FEATURE_GAPS,
@@ -32,6 +33,7 @@ from pcobra.cobra.transpilers.compatibility_matrix import (
 def main() -> int:
     validate_runtime_support_contract()
     validate_contracts()
+    validate_contracts_against_runtime_matrix()
 
     for backend in OFFICIAL_RUNTIME_TARGETS:
         contract = BACKEND_COMPATIBILITY[backend]

--- a/src/pcobra/cobra/stdlib_contract/cobra.system
+++ b/src/pcobra/cobra/stdlib_contract/cobra.system
@@ -1,3 +1,3 @@
 public_api = ["cobra.system.leer", "cobra.system.escribir", "cobra.system.ejecutar", "cobra.system.obtener_env"]
-backend_preferido = "python"
+backend_preferido = "python+rust"
 fallback_permitido = ["rust", "javascript"]

--- a/src/pcobra/cobra/stdlib_contract/core.py
+++ b/src/pcobra/cobra/stdlib_contract/core.py
@@ -21,19 +21,19 @@ CORE_CONTRACT = ContractDescriptor(
     coverage=(
         FunctionCoverage(
             "cobra.core.es_finito",
-            {"python": "full", "rust": "partial", "javascript": "full"},
+            {"python": "full", "rust": "partial", "javascript": "partial"},
         ),
         FunctionCoverage(
             "cobra.core.es_infinito",
-            {"python": "full", "rust": "partial", "javascript": "full"},
+            {"python": "full", "rust": "partial", "javascript": "partial"},
         ),
         FunctionCoverage(
             "cobra.core.copiar_signo",
-            {"python": "full", "rust": "partial", "javascript": "full"},
+            {"python": "full", "rust": "partial", "javascript": "partial"},
         ),
         FunctionCoverage(
             "cobra.core.signo",
-            {"python": "full", "rust": "partial", "javascript": "full"},
+            {"python": "full", "rust": "partial", "javascript": "partial"},
         ),
     ),
 )

--- a/src/pcobra/cobra/stdlib_contract/datos.py
+++ b/src/pcobra/cobra/stdlib_contract/datos.py
@@ -19,12 +19,12 @@ DATOS_CONTRACT = ContractDescriptor(
         core_nativos=("src/pcobra/core/nativos/datos.js",),
     ),
     coverage=(
-        FunctionCoverage("cobra.datos.filtrar", {"python": "full", "javascript": "full"}),
+        FunctionCoverage("cobra.datos.filtrar", {"python": "full", "javascript": "partial"}),
         FunctionCoverage(
             "cobra.datos.seleccionar_columnas",
-            {"python": "full", "javascript": "full"},
+            {"python": "full", "javascript": "partial"},
         ),
-        FunctionCoverage("cobra.datos.a_listas", {"python": "full", "javascript": "full"}),
-        FunctionCoverage("cobra.datos.de_listas", {"python": "full", "javascript": "full"}),
+        FunctionCoverage("cobra.datos.a_listas", {"python": "full", "javascript": "partial"}),
+        FunctionCoverage("cobra.datos.de_listas", {"python": "full", "javascript": "partial"}),
     ),
 )

--- a/src/pcobra/cobra/stdlib_contract/generator.py
+++ b/src/pcobra/cobra/stdlib_contract/generator.py
@@ -66,10 +66,39 @@ def _format_paths(paths: tuple[str, ...]) -> str:
 
 def render_contract_markdown() -> str:
     """Construye documentación Markdown desde descriptores Python."""
+    summary_rows = [
+        "| Módulo | API pública | Backend primario | Fallback | Límites |",
+        "|---|---|---|---|---|",
+    ]
+    for descriptor in CONTRACTS:
+        partial_rows = []
+        for coverage in descriptor.coverage:
+            for backend, level in coverage.backend_levels.items():
+                if level == "partial":
+                    partial_rows.append(f"{coverage.function.rsplit('.', 1)[-1]}:{backend}")
+        limits = ", ".join(partial_rows) if partial_rows else "-"
+        summary_rows.append(
+            "| "
+            + " | ".join(
+                (
+                    f"`{descriptor.module}`",
+                    str(len(descriptor.public_api)),
+                    f"`{descriptor.primary_backend}`",
+                    f"`{', '.join(descriptor.allowed_fallback) or 'ninguno'}`",
+                    limits,
+                )
+            )
+            + " |"
+        )
+
     lines: list[str] = [
         "# Matriz única de stdlib Cobra (autogenerado)",
         "",
         "Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.",
+        "",
+        "## Tabla de garantías por módulo",
+        "",
+        *summary_rows,
         "",
     ]
     for descriptor in CONTRACTS:

--- a/src/pcobra/cobra/stdlib_contract/system.py
+++ b/src/pcobra/cobra/stdlib_contract/system.py
@@ -11,7 +11,7 @@ SYSTEM_CONTRACT = ContractDescriptor(
         "cobra.system.ejecutar",
         "cobra.system.obtener_env",
     ),
-    primary_backend="python",
+    primary_backend="python+rust",
     allowed_fallback=("rust", "javascript"),
     runtime_mapping=RuntimeMapping(
         standard_library=("src/pcobra/standard_library/archivo.py",),
@@ -26,11 +26,11 @@ SYSTEM_CONTRACT = ContractDescriptor(
         ),
         FunctionCoverage(
             "cobra.system.ejecutar",
-            {"python": "full", "rust": "partial", "javascript": "full"},
+            {"python": "full", "rust": "partial", "javascript": "partial"},
         ),
         FunctionCoverage(
             "cobra.system.obtener_env",
-            {"python": "full", "rust": "partial", "javascript": "full"},
+            {"python": "full", "rust": "partial", "javascript": "partial"},
         ),
     ),
 )

--- a/src/pcobra/cobra/stdlib_contract/validator.py
+++ b/src/pcobra/cobra/stdlib_contract/validator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import json
 import re
 from pathlib import Path
 from typing import Final
@@ -12,6 +13,13 @@ from pcobra.cobra.stdlib_contract.base import ContractDescriptor
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[4]
 VALID_LEVELS: Final[set[str]] = {"full", "partial"}
+RUNTIME_API_MATRIX_PATH: Final[Path] = REPO_ROOT / "docs" / "_generated" / "runtime_api_matrix.json"
+PRIMARY_BACKEND_POLICY: Final[dict[str, tuple[str, ...]]] = {
+    "cobra.core": ("python",),
+    "cobra.datos": ("python",),
+    "cobra.web": ("javascript",),
+    "cobra.system": ("python", "rust"),
+}
 
 
 class ContractValidationError(RuntimeError):
@@ -54,6 +62,10 @@ def _iter_mapping_paths(contract: ContractDescriptor) -> list[Path]:
     return paths
 
 
+def _primary_backends(contract: ContractDescriptor) -> tuple[str, ...]:
+    return tuple(part for part in contract.primary_backend.split("+") if part)
+
+
 def _validate_mapping_paths(contract: ContractDescriptor) -> None:
     for path in _iter_mapping_paths(contract):
         if not path.exists():
@@ -78,9 +90,19 @@ def _validate_public_api(contract: ContractDescriptor) -> None:
             f"{contract.module}: API pública no encontrada en runtime mapping: {missing}"
         )
 
+    expected_prefix = f"{contract.module}."
+    invalid_api = [api for api in contract.public_api if not api.startswith(expected_prefix)]
+    if invalid_api:
+        raise ContractValidationError(
+            f"{contract.module}: API pública fuera del namespace del módulo: {invalid_api}"
+        )
+
 
 def _validate_coverage(contract: ContractDescriptor) -> None:
-    expected_backends = {contract.primary_backend, *contract.allowed_fallback}
+    primary_backends = set(_primary_backends(contract))
+    if not primary_backends:
+        raise ContractValidationError(f"{contract.module}: primary_backend vacío")
+    expected_backends = {*primary_backends, *contract.allowed_fallback}
     declared_functions = set(contract.public_api)
 
     if len(contract.coverage) != len(contract.public_api):
@@ -110,12 +132,70 @@ def _validate_coverage(contract: ContractDescriptor) -> None:
                 )
 
 
+def _validate_primary_backend_policy(contract: ContractDescriptor) -> None:
+    expected = PRIMARY_BACKEND_POLICY.get(contract.module)
+    if expected is None:
+        return
+    resolved = _primary_backends(contract)
+    if resolved != expected:
+        raise ContractValidationError(
+            f"{contract.module}: backend primario inválido. "
+            f"esperado={'+'.join(expected)} recibido={contract.primary_backend}"
+        )
+
+
+def _load_runtime_api_matrix() -> dict[str, object]:
+    try:
+        payload = json.loads(RUNTIME_API_MATRIX_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ContractValidationError(
+            f"No existe runtime_api_matrix requerido para validación: {RUNTIME_API_MATRIX_PATH}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ContractValidationError("runtime_api_matrix inválido: estructura raíz no es objeto")
+    return payload
+
+
+def validate_coverage_against_runtime_matrix(contract: ContractDescriptor) -> None:
+    """Valida que `coverage` (full/partial) coincida con disponibilidad en runtime_api_matrix."""
+    matrix = _load_runtime_api_matrix()
+    available_by_backend = matrix.get("available_api_by_backend")
+    if not isinstance(available_by_backend, dict):
+        raise ContractValidationError("runtime_api_matrix inválido: falta `available_api_by_backend`")
+
+    for function_coverage in contract.coverage:
+        symbol = function_coverage.function.rsplit(".", 1)[-1]
+        for backend, level in function_coverage.backend_levels.items():
+            backend_data = available_by_backend.get(backend)
+            if not isinstance(backend_data, dict):
+                raise ContractValidationError(
+                    f"runtime_api_matrix inválido: backend ausente o inválido `{backend}`"
+                )
+            global_api = backend_data.get("global")
+            if not isinstance(global_api, list):
+                raise ContractValidationError(
+                    f"runtime_api_matrix inválido: `{backend}.global` no es lista"
+                )
+            is_available = symbol in set(global_api)
+            if level == "full" and not is_available:
+                raise ContractValidationError(
+                    f"{function_coverage.function}.{backend}: marcado full pero no aparece "
+                    "en runtime_api_matrix.available_api_by_backend.global"
+                )
+            if level == "partial" and is_available:
+                raise ContractValidationError(
+                    f"{function_coverage.function}.{backend}: marcado partial pero aparece "
+                    "como disponible en runtime_api_matrix; usar full o actualizar matriz."
+                )
+
+
 def validate_contract_descriptor(contract: ContractDescriptor) -> None:
     """Valida mapping, API pública y cobertura de un descriptor."""
 
     _validate_mapping_paths(contract)
     _validate_public_api(contract)
     _validate_coverage(contract)
+    _validate_primary_backend_policy(contract)
 
 
 def validate_contracts() -> None:
@@ -127,3 +207,9 @@ def validate_contracts() -> None:
             raise ContractValidationError(f"Módulo duplicado en contrato: {contract.module}")
         modules_seen.add(contract.module)
         validate_contract_descriptor(contract)
+
+
+def validate_contracts_against_runtime_matrix() -> None:
+    """Valida cobertura full/partial por función contra `runtime_api_matrix`."""
+    for contract in CONTRACTS:
+        validate_coverage_against_runtime_matrix(contract)

--- a/src/pcobra/cobra/stdlib_contract/web.py
+++ b/src/pcobra/cobra/stdlib_contract/web.py
@@ -18,11 +18,11 @@ WEB_CONTRACT = ContractDescriptor(
         core_nativos=("src/pcobra/core/nativos/red.js",),
     ),
     coverage=(
-        FunctionCoverage("cobra.web.obtener_url", {"javascript": "full", "python": "full"}),
-        FunctionCoverage("cobra.web.enviar_post", {"javascript": "full", "python": "full"}),
+        FunctionCoverage("cobra.web.obtener_url", {"javascript": "partial", "python": "full"}),
+        FunctionCoverage("cobra.web.enviar_post", {"javascript": "partial", "python": "full"}),
         FunctionCoverage(
             "cobra.web.descargar_archivo",
-            {"javascript": "full", "python": "full"},
+            {"javascript": "partial", "python": "full"},
         ),
     ),
 )

--- a/tests/unit/test_stdlib_contract_descriptor.py
+++ b/tests/unit/test_stdlib_contract_descriptor.py
@@ -14,7 +14,10 @@ def test_contracts_declaran_campos_minimos_para_module_map():
 
 def test_markdown_generado_incluye_tabla_cobertura_por_funcion():
     markdown = render_contract_markdown()
+    assert "Tabla de garantías por módulo" in markdown
+    assert "| Módulo | API pública | Backend primario | Fallback | Límites |" in markdown
     assert "Cobertura por función" in markdown
     assert "| Función | Backend | Nivel |" in markdown
     for descriptor in CONTRACTS:
+        assert f"| `{descriptor.module}` |" in markdown
         assert f"## `{descriptor.module}`" in markdown

--- a/tests/unit/test_stdlib_contract_validator.py
+++ b/tests/unit/test_stdlib_contract_validator.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 from pcobra.cobra.stdlib_contract import CONTRACTS, get_contract_matrix
-from pcobra.cobra.stdlib_contract.validator import validate_contracts
+from pcobra.cobra.stdlib_contract.validator import (
+    validate_contracts,
+    validate_contracts_against_runtime_matrix,
+)
 
 
 def test_stdlib_contracts_validate() -> None:
     validate_contracts()
+
+
+def test_stdlib_contracts_validate_against_runtime_matrix() -> None:
+    validate_contracts_against_runtime_matrix()
 
 
 def test_stdlib_matrix_contains_all_contract_modules() -> None:


### PR DESCRIPTION
### Motivation

- Asegurar que los contratos de la stdlib (`cobra.core`, `cobra.datos`, `cobra.web`, `cobra.system`) reflejen la disponibilidad real de implementaciones por backend y evitar drift entre descriptor contractual y runtime.
- Forzar una política explícita de backend primario y garantizar que la API pública permanezca en el namespace esperado por módulo.
- Añadir una validación automática en CI que verifique la cobertura por función (`full`/`partial`) frente a la matriz viva `runtime_api_matrix`.
- Publicar una tabla resumida de garantías por módulo (API pública, backend primario, fallback, límites) para la documentación generada.

### Description

- Actualicé descriptores de contrato en `src/pcobra/cobra/stdlib_contract/{core,datos,web,system}.py` para reflejar niveles `full/partial` coherentes con la matriz runtime y, en `cobra.system`, soportar backend primario híbrido `python+rust`.
- Endurecí las validaciones en `src/pcobra/cobra/stdlib_contract/validator.py`: comprobación de rutas de mapping, validación de namespace de API pública, parsing de backends primarios híbridos (`+`), política explícita `PRIMARY_BACKEND_POLICY` por módulo y nuevas funciones que comparan `coverage` con `docs/_generated/runtime_api_matrix.json`.
- Añadí un script CI `scripts/ci/validate_stdlib_function_coverage.py` que ejecuta las validaciones de contratos y la verificación contra la matriz runtime y lo integré en `scripts/validate_runtime_contract.py`.
- Extendí el generador documental `src/pcobra/cobra/stdlib_contract/generator.py` para publicar una "Tabla de garantías por módulo" (API pública, backend primario, fallback, límites) y regeneré los artefactos `docs/_generated/stdlib_contract_matrix.md`, `docs/_generated/stdlib_contract_matrix.json` y `docs/standard_library/matriz_stdlib_unificada.md`.
- Actualicé tests unitarios en `tests/unit/test_stdlib_contract_validator.py` y `tests/unit/test_stdlib_contract_descriptor.py` para cubrir la validación contra la matriz runtime y la presencia de la nueva tabla de garantías.

### Testing

- Ejecuté `python scripts/ci/validate_stdlib_function_coverage.py` y el script imprimió confirmación de validación exitosa.
- Ejecuté `pytest -q tests/unit/test_stdlib_contract_validator.py tests/unit/test_stdlib_contract_descriptor.py` y los tests pasaron (`5 passed`).
- Ejecuté `python scripts/validate_runtime_contract.py` para la validación combinada de runtime y contratos y la comprobación salió OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e26d08ca508327aec067716a5a9cf7)