### PR TITLE
Congelar orden de resolución de imports, política de colisiones y metadata uniforme

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,10 @@ La documentación pública usa resolución determinista de módulos y evita ruta
 
 Orden de resolución (alto nivel): `stdlib > project > python_bridge > hybrid`.
 
+Política por defecto ante colisiones ambiguas: `warn` (modo compatibilidad). En proyectos
+productivos se recomienda `namespace_required` y usar imports con namespace explícito
+(`cobra.datos`, `app.datos`, etc.).
+
 Namespaces canónicos de la librería estándar para ejemplos/documentación:
 
 - `cobra.core`

--- a/docs/architecture/import-resolution-contract.md
+++ b/docs/architecture/import-resolution-contract.md
@@ -2,14 +2,17 @@
 
 Este documento define el contrato **oficial** y estable del resolvedor de imports de Cobra para eliminar ambigüedades operativas entre stdlib, módulos de proyecto, bridge Python e híbridos.
 
-## 1) Orden oficial de resolución (`_SOURCE_ORDER`)
+## 1) Orden oficial de resolución (API contractual)
 
-El orden vigente de precedencia es:
+El orden vigente de precedencia se congela como contrato público en
+`RESOLUTION_SOURCE_ORDER`:
 
 1. `stdlib`
 2. `project`
 3. `python_bridge`
 4. `hybrid`
+
+Este orden debe tratarse como **API contractual** (estable entre releases menores).
 
 En términos prácticos:
 
@@ -27,7 +30,7 @@ La política se configura por proyecto en `cobra.toml`:
 collision_policy = "warn" # warn | strict_error | namespace_required
 ```
 
-Si no se declara nada, el resolver usa `warn` por compatibilidad.
+Si no se declara nada, el resolver usa `warn` por compatibilidad (`DEFAULT_COLLISION_POLICY`).
 
 ### `warn` (modo por defecto)
 
@@ -106,6 +109,9 @@ backend = "javascript"
   - `import_path = "mi_hibrido_runtime"`
   - `backend = "javascript"` (si no hay override de contrato por módulo)
   - `precedence_reason = "unique_source:hybrid"`
+
+Estos 3 casos (`importar pandas`, `importar datos`/`importar cobra.datos`, e híbridos
+en `imports.hybrid_modules`) son rutas oficiales del contrato de resolución.
 
 ## 6) Ejemplos de conflictos y resolución explícita
 

--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -44,7 +44,11 @@ class ResolutionResult:
     precedence_reason: str | None = None
 
 
-_SOURCE_ORDER: tuple[str, ...] = ("stdlib", "project", "python_bridge", "hybrid")
+API_CONTRACT_VERSION = "2026-04-import-resolution-v1"
+RESOLUTION_SOURCE_ORDER: tuple[str, ...] = ("stdlib", "project", "python_bridge", "hybrid")
+DEFAULT_COLLISION_POLICY = "warn"
+# Backward-compatible alias (internal histórico).
+_SOURCE_ORDER: tuple[str, ...] = RESOLUTION_SOURCE_ORDER
 _SUPPORTED_COLLISION_POLICIES: frozenset[str] = frozenset(
     {"warn", "strict_error", "namespace_required"}
 )
@@ -52,6 +56,9 @@ _SUPPORTED_COLLISION_POLICIES: frozenset[str] = frozenset(
 
 class CobraImportResolver:
     """Resuelve imports con prioridad fija y conflictos explícitos."""
+    resolution_source_order = RESOLUTION_SOURCE_ORDER
+    default_collision_policy = DEFAULT_COLLISION_POLICY
+    api_contract_version = API_CONTRACT_VERSION
 
     def __init__(
         self,
@@ -105,7 +112,7 @@ class CobraImportResolver:
             return "strict_error"
 
         configured_policy = CobraImportResolver._collision_policy_from_config(config)
-        chosen = explicit_policy or configured_policy or "warn"
+        chosen = explicit_policy or configured_policy or DEFAULT_COLLISION_POLICY
         if chosen not in _SUPPORTED_COLLISION_POLICIES:
             raise ImportResolutionError(
                 "Política de colisiones inválida. "
@@ -162,7 +169,7 @@ class CobraImportResolver:
             raise ImportResolutionError("Nombre de módulo vacío")
 
         candidates: list[ResolutionResult] = []
-        for source in _SOURCE_ORDER:
+        for source in RESOLUTION_SOURCE_ORDER:
             candidate = self._build_candidate(source, name)
             if candidate is not None:
                 candidates.append(candidate)
@@ -173,14 +180,15 @@ class CobraImportResolver:
         precedence_reason = (
             f"unique_source:{candidates[0].source}"
             if len(candidates) == 1
-            else f"source_order:{' > '.join(_SOURCE_ORDER)}"
+            else f"source_order:{' > '.join(RESOLUTION_SOURCE_ORDER)}"
         )
 
         if "." not in name and len(candidates) > 1:
             details = ", ".join(f"{c.source}:{c.resolved_name}" for c in candidates)
             message = (
                 f"Colisión de import para '{name}'. Se aplica precedencia fija "
-                f"({_SOURCE_ORDER[0]} > {_SOURCE_ORDER[1]} > {_SOURCE_ORDER[2]} > {_SOURCE_ORDER[3]}). "
+                f"({RESOLUTION_SOURCE_ORDER[0]} > {RESOLUTION_SOURCE_ORDER[1]} > "
+                f"{RESOLUTION_SOURCE_ORDER[2]} > {RESOLUTION_SOURCE_ORDER[3]}). "
                 f"Seleccionado: {candidates[0].resolved_name}. Candidatos: {details}. "
                 f"Recomendación: usa prefijo explícito ('cobra.{name}') para stdlib o namespace de proyecto "
                 f"(por ejemplo 'app.{name}')."
@@ -232,9 +240,11 @@ class CobraImportResolver:
         self._attach_module_metadata(module, resolution)
         return resolution, module
 
-    @staticmethod
-    def _attach_module_metadata(module: ModuleType, resolution: ResolutionResult) -> None:
+    def _attach_module_metadata(self, module: ModuleType, resolution: ResolutionResult) -> None:
         metadata = {
+            "api_contract_version": API_CONTRACT_VERSION,
+            "resolution_source_order": list(RESOLUTION_SOURCE_ORDER),
+            "collision_policy": self.collision_policy,
             "request": resolution.request,
             "source": resolution.source,
             "resolved_name": resolution.resolved_name,

--- a/tests/unit/test_imports_resolver.py
+++ b/tests/unit/test_imports_resolver.py
@@ -54,6 +54,54 @@ def test_colision_stdlib_vs_bridge_genera_warning(monkeypatch):
     assert result.source == "stdlib"
 
 
+def test_colision_stdlib_proyecto_y_bridge_respeta_orden(monkeypatch, tmp_path):
+    (tmp_path / "datos.co").write_text("usar algo")
+    resolver = CobraImportResolver(project_root=tmp_path)
+
+    import importlib.util
+
+    original_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name: str):
+        if name == "datos":
+            class DummySpec:
+                loader = object()
+
+            return DummySpec()
+        return original_find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    with pytest.warns(UserWarning, match="Colisión de import"):
+        result = resolver.resolve("datos")
+
+    assert result.source == "stdlib"
+    assert result.resolved_name == "cobra.datos"
+    assert result.precedence_reason == "source_order:stdlib > project > python_bridge > hybrid"
+
+
+def test_colision_total_namespace_required_falla(monkeypatch, tmp_path):
+    (tmp_path / "datos.co").write_text("usar algo")
+    resolver = CobraImportResolver(project_root=tmp_path, collision_policy="namespace_required")
+
+    import importlib.util
+
+    original_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name: str):
+        if name == "datos":
+            class DummySpec:
+                loader = object()
+
+            return DummySpec()
+        return original_find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    with pytest.raises(ImportResolutionError, match="namespace_required"):
+        resolver.resolve("datos")
+
+
 def test_colision_en_modo_estricto_falla(tmp_path):
     (tmp_path / "datos.co").write_text("usar algo")
     resolver = CobraImportResolver(project_root=tmp_path, strict_ambiguous_imports=True)
@@ -91,6 +139,29 @@ def test_bridge_python_directo():
     assert result.import_path == "json"
 
 
+def test_ruta_oficial_importar_pandas_via_python_bridge(monkeypatch):
+    resolver = CobraImportResolver()
+
+    import importlib.util
+
+    original_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name: str):
+        if name == "pandas":
+            class DummySpec:
+                loader = object()
+
+            return DummySpec()
+        return original_find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    result = resolver.resolve("pandas")
+
+    assert result.source == "python_bridge"
+    assert result.resolved_name == "pandas"
+
+
 def test_modulo_hibrido_inyecta_adapter_backend(monkeypatch):
     fake_module = ModuleType("mi_hibrido_runtime")
 
@@ -124,6 +195,9 @@ def test_modulo_hibrido_inyecta_adapter_backend(monkeypatch):
     assert getattr(module, "__cobra_resolution_source__") == "hybrid"
     assert getattr(module, "__cobra_backend_injected__") == "javascript"
     assert getattr(module, "__cobra_resolution_metadata__") == {
+        "api_contract_version": "2026-04-import-resolution-v1",
+        "resolution_source_order": ["stdlib", "project", "python_bridge", "hybrid"],
+        "collision_policy": "warn",
         "request": "mi_hibrido",
         "source": "hybrid",
         "resolved_name": "mi_hibrido",
@@ -165,6 +239,34 @@ def test_modulo_hibrido_desde_config(monkeypatch):
 
     assert resolution.source == "hybrid"
     assert module is fake_module
+
+
+def test_metadata_uniforme_en_ruta_stdlib():
+    resolver = CobraImportResolver()
+
+    resolution, module = resolver.load_module("cobra.datos")
+
+    assert resolution.source == "stdlib"
+    assert module is not None
+    metadata = getattr(module, "__cobra_resolution_metadata__")
+    assert metadata["source"] == "stdlib"
+    assert metadata["api_contract_version"] == "2026-04-import-resolution-v1"
+    assert metadata["resolution_source_order"] == ["stdlib", "project", "python_bridge", "hybrid"]
+    assert metadata["collision_policy"] == "warn"
+
+
+def test_metadata_uniforme_en_ruta_python_bridge():
+    resolver = CobraImportResolver()
+
+    resolution, module = resolver.load_module("json")
+
+    assert resolution.source == "python_bridge"
+    assert module is not None
+    metadata = getattr(module, "__cobra_resolution_metadata__")
+    assert metadata["source"] == "python_bridge"
+    assert metadata["api_contract_version"] == "2026-04-import-resolution-v1"
+    assert metadata["resolution_source_order"] == ["stdlib", "project", "python_bridge", "hybrid"]
+    assert metadata["collision_policy"] == "warn"
 
 
 def test_resolver_adjunta_adapter_desde_resolucion():


### PR DESCRIPTION
### Motivation
- Establecer el orden de resolución de imports como contrato público y evitar ambigüedades operativas entre stdlib, módulos de proyecto, bridge Python e híbridos. 
- Definir y documentar las rutas oficiales (`importar pandas` → `python_bridge`, `importar datos` / `importar cobra.datos` → `stdlib`, híbridos desde `imports.hybrid_modules`).
- Fijar una política por defecto de colisiones con recomendación de usar namespaces explícitos en producción.
- Mejorar la trazabilidad de resolución inyectando metadata uniforme en módulos cargados.

### Description
- Congelé el contrato de resolución añadiendo `API_CONTRACT_VERSION`, `RESOLUTION_SOURCE_ORDER` y `DEFAULT_COLLISION_POLICY` y exposé esos valores como atributos en `CobraImportResolver` (archivo `src/pcobra/cobra/imports/resolver.py`).
- Reemplacé usos internos de `_SOURCE_ORDER` por `RESOLUTION_SOURCE_ORDER` en la lógica de `resolve()` para garantizar precedencia estable `stdlib > project > python_bridge > hybrid` y actualicé la construcción de `precedence_reason` y mensajes de colisión.
- Establecí la política por defecto de colisiones a `warn` (`DEFAULT_COLLISION_POLICY`) y respeté `collision_policy` desde `cobra.toml` o parámetros explícitos; se soportan `warn`, `strict_error` y `namespace_required`.
- Inyecté metadata uniforme en `load_module()` bajo `__cobra_resolution_metadata__` incluyendo `api_contract_version`, `resolution_source_order`, `collision_policy` y los campos de resolución existentes; además se conservan `__cobra_resolution_source__` y `__cobra_backend_injected__`.
- Añadí y amplié pruebas en `tests/unit/test_imports_resolver.py` que cubren colisiones entre stdlib/proyecto/python-bridge, la ruta oficial `pandas` vía `python_bridge`, y verificaciones de metadata uniforme para rutas `stdlib` y `python_bridge`.
- Actualicé documentación en `docs/architecture/import-resolution-contract.md` y `README.md` para declarar el orden como API contractual, la política por defecto y las rutas oficiales de resolución.

### Testing
- Ejecuté `pytest -q tests/unit/test_imports_resolver.py` y todos los tests pasaron: `17 passed`.
- Las nuevas pruebas verifican comportamiento de precedencia en colisiones (modo `warn` y `namespace_required`), resolución de `pandas` como `python_bridge` y la presencia/estructura de `__cobra_resolution_metadata__` en módulos cargados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2722bf2388327b6b72bd9ff174db9)