### PR TITLE
Centralizar validación de seguridad y ABI en RuntimeManager y alinear comandos v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v10.0.13 - 2026-03-29
 - Fix: la CLI ya no depende de `scripts.benchmarks` en tiempo de ejecución.
+- RuntimeManager ahora centraliza la validación de seguridad+ABI para `run`, `test` y `build` en CLI v2 mediante `validate_command_runtime`, evitando atajos directos fuera del manager.
+- Se unificaron los mensajes de error por ruta contractual de bindings (`Python direct import`, `JavaScript runtime bridge`, `Rust compiled FFI`) con un prefijo canónico.
+- Nuevas pruebas de contrato ABI que validan `abi_by_backend` y `backend_abi` leyendo `cobra.toml`/`pcobra.toml`.
+- **Breaking changes de ABI (gobernanza):** cualquier cambio incompatible de ABI debe anunciarse explícitamente en changelog y registrarse con ADR dedicado antes de su liberación.
 
 ## v10.1.0 - 2025-08-24
 - Integración completa de Hololang como lenguaje intermedio oficial del compilador.

--- a/docs/architecture/adr-unified-backends.md
+++ b/docs/architecture/adr-unified-backends.md
@@ -69,3 +69,14 @@ Esta decisión se refleja en:
 
 - `docs/architecture/unified-ecosystem.md` (modelo de 5 capas).
 - `docs/targets_policy.md` (normativa única de público vs interno y API estable).
+
+## Gobernanza de ABI (breaking changes)
+
+Para sostener el contrato externo estable en la capa de bindings/runtime:
+
+1. Todo breaking change de ABI (por backend o ruta contractual) debe publicarse explícitamente en `CHANGELOG.md`.
+2. Además, debe documentarse en un ADR nuevo o enmienda de ADR con:
+   - versiones ABI afectadas,
+   - matriz de compatibilidad hacia atrás,
+   - plan de migración y ventana de deprecación.
+3. La CLI v2 (`run`, `test`, `build`) debe validar seguridad y ABI únicamente vía `RuntimeManager` para evitar rutas de ejecución paralelas no gobernadas.

--- a/src/pcobra/cobra/bindings/runtime_manager.py
+++ b/src/pcobra/cobra/bindings/runtime_manager.py
@@ -32,6 +32,11 @@ SECURITY_POLICY_BY_COMMAND: Final[dict[str, dict[BindingRoute, dict[str, bool]]]
         BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE: {"sandbox_required": False, "container_required": True},
         BindingRoute.RUST_COMPILED_FFI: {"sandbox_required": False, "container_required": True},
     },
+    "build": {
+        BindingRoute.PYTHON_DIRECT_IMPORT: {"sandbox_required": False, "container_required": False},
+        BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE: {"sandbox_required": False, "container_required": False},
+        BindingRoute.RUST_COMPILED_FFI: {"sandbox_required": False, "container_required": False},
+    },
 }
 
 
@@ -47,6 +52,12 @@ class RuntimeBridgeDescriptor:
 
 class RuntimeManager:
     """Resuelve rutas de binding y centraliza validaciones de seguridad/ABI."""
+
+    _ROUTE_LABEL_BY_ROUTE: Final[dict[BindingRoute, str]] = {
+        BindingRoute.PYTHON_DIRECT_IMPORT: "Python direct import",
+        BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE: "JavaScript runtime bridge",
+        BindingRoute.RUST_COMPILED_FFI: "Rust compiled FFI",
+    }
 
     _BRIDGES: Final[dict[BindingRoute, RuntimeBridgeDescriptor]] = {
         BindingRoute.PYTHON_DIRECT_IMPORT: RuntimeBridgeDescriptor(
@@ -100,19 +111,19 @@ class RuntimeManager:
 
         # Validación base por ruta
         if route is BindingRoute.PYTHON_DIRECT_IMPORT and containerized:
-            raise ValueError(
-                "La ruta python_direct_import no puede marcarse como containerizada. "
-                "Use bridge Python directo (mismo proceso) o ruta de runtime gestionado."
+            self._raise_route_error(
+                route,
+                "la ruta no puede marcarse como containerizada; use ejecución en mismo proceso",
             )
         if route is BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE and not (sandbox or containerized):
-            raise ValueError(
-                "La ruta javascript_runtime_bridge requiere runtime gestionado "
-                "(sandbox o contenedor) para mantener aislamiento."
+            self._raise_route_error(
+                route,
+                "la ruta requiere runtime gestionado (sandbox o contenedor) para mantener aislamiento",
             )
         if route is BindingRoute.RUST_COMPILED_FFI and sandbox:
-            raise ValueError(
-                "La ruta rust_compiled_ffi usa frontera nativa FFI y no se ejecuta "
-                "en sandbox Python directo."
+            self._raise_route_error(
+                route,
+                "la ruta usa frontera nativa FFI y no se ejecuta en sandbox Python directo",
             )
 
         # Validación por comando público
@@ -156,10 +167,35 @@ class RuntimeManager:
         capabilities = self._resolve_capabilities(language)
         return self.negotiate_abi(capabilities, abi_version)
 
+    def validate_command_runtime(
+        self,
+        language: str,
+        *,
+        command: str,
+        sandbox: bool = False,
+        containerized: bool = False,
+        abi_version: str | None = None,
+    ) -> tuple[str, BindingCapabilities, RuntimeBridgeDescriptor]:
+        """Valida de forma canónica seguridad+ABI para un comando público."""
+
+        capabilities, bridge = self.resolve_runtime(language)
+        self.validate_security_route(
+            language,
+            sandbox=sandbox,
+            containerized=containerized,
+            command=command,
+        )
+        negotiated_abi = self.negotiate_abi(capabilities, abi_version)
+        return negotiated_abi, capabilities, bridge
+
     def select_bridge(self, capabilities: BindingCapabilities) -> RuntimeBridgeDescriptor:
         """Selecciona la implementación de bridge para una ruta contractual."""
 
         return self._BRIDGES[capabilities.route]
+
+    def _raise_route_error(self, route: BindingRoute, detail: str) -> None:
+        route_label = self._ROUTE_LABEL_BY_ROUTE[route]
+        raise ValueError(f"[{route_label}] {detail}.")
 
     def _resolve_project_abi_for_backend(self, backend: str) -> str | None:
         """Obtiene ABI negociada por backend desde cobra.toml/pcobra.toml."""

--- a/src/pcobra/cobra/cli/commands_v2/build_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/build_cmd.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
@@ -15,6 +16,7 @@ class BuildCommandV2(BaseCommand):
 
     def __init__(self) -> None:
         super().__init__()
+        self._runtime_manager = RuntimeManager()
 
     def register_subparser(self, subparsers: Any):
         parser = subparsers.add_parser(self.name, help=_("Build/transpile a Cobra file"))
@@ -41,6 +43,12 @@ class BuildCommandV2(BaseCommand):
                 _("Resolución de backend (debug): {reason}").format(reason=build_result["reason"]),
                 registrar_log=False,
             )
+        runtime_language = str(build_result.get("runtime", {}).get("language", "python"))
+        try:
+            self._runtime_manager.validate_command_runtime(runtime_language, command="build")
+        except ValueError as exc:
+            mostrar_error(str(exc), registrar_log=False)
+            return 1
         mostrar_info(_("Código generado:"), registrar_log=False)
         print(build_result["code"])
         return 0

--- a/src/pcobra/cobra/cli/commands_v2/run_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/run_cmd.py
@@ -41,13 +41,12 @@ class RunCommandV2(BaseCommand):
         container = getattr(args, "container", None)
         binding_language = container or "python"
         try:
-            self._runtime_manager.validate_security_route(
+            self._runtime_manager.validate_command_runtime(
                 binding_language,
+                command="run",
                 sandbox=sandbox,
                 containerized=bool(container),
-                command="run",
             )
-            self._runtime_manager.validate_abi_route(binding_language)
         except ValueError as exc:
             mostrar_error(str(exc), registrar_log=False)
             return 1

--- a/src/pcobra/cobra/cli/commands_v2/test_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/test_cmd.py
@@ -58,13 +58,12 @@ class TestCommandV2(BaseCommand):
             try:
                 sandbox = lang == "python"
                 containerized = lang in {"javascript", "rust"}
-                self._runtime_manager.validate_security_route(
+                self._runtime_manager.validate_command_runtime(
                     lang,
+                    command="test",
                     sandbox=sandbox,
                     containerized=containerized,
-                    command="test",
                 )
-                self._runtime_manager.validate_abi_route(lang)
             except ValueError as exc:
                 mostrar_error(str(exc), registrar_log=False)
                 return 1

--- a/tests/unit/test_cli_v2_command_contract.py
+++ b/tests/unit/test_cli_v2_command_contract.py
@@ -54,12 +54,20 @@ def test_build_v2_resuelve_backend_via_pipeline(monkeypatch):
             },
         ),
     )
+    monkeypatch.setattr(
+        command._runtime_manager,
+        "validate_command_runtime",
+        lambda language, **kwargs: called.setdefault("runtime", (language, kwargs))
+        or ("1.0", object(), object()),
+    )
 
     status = command.run(
         argparse.Namespace(file="programa.co", modo="mixto", debug=False)
     )
     assert status == 0
     assert "build" in called
+    assert called["runtime"][0] == "python"
+    assert called["runtime"][1]["command"] == "build"
 
 
 def test_build_v2_help_no_expone_flags_backend():
@@ -80,13 +88,9 @@ def test_run_v2_valida_seguridad_por_ruta_binding(monkeypatch):
 
     monkeypatch.setattr(
         command._runtime_manager,
-        "validate_security_route",
-        lambda language, **kwargs: called.setdefault("security", (language, kwargs)),
-    )
-    monkeypatch.setattr(
-        command._runtime_manager,
-        "validate_abi_route",
-        lambda language: called.setdefault("abi", language) or "1.0",
+        "validate_command_runtime",
+        lambda language, **kwargs: called.setdefault("runtime", (language, kwargs))
+        or ("1.0", object(), object()),
     )
     monkeypatch.setattr(
         "cobra.cli.commands_v2.run_cmd.backend_pipeline.resolve_backend",
@@ -99,10 +103,9 @@ def test_run_v2_valida_seguridad_por_ruta_binding(monkeypatch):
     )
 
     assert status == 0
-    assert called["security"][0] == "rust"
-    assert called["security"][1]["containerized"] is True
-    assert called["security"][1]["command"] == "run"
-    assert called["abi"] == "rust"
+    assert called["runtime"][0] == "rust"
+    assert called["runtime"][1]["containerized"] is True
+    assert called["runtime"][1]["command"] == "run"
 
 
 def test_test_v2_valida_seguridad_por_ruta_binding(monkeypatch):
@@ -111,10 +114,9 @@ def test_test_v2_valida_seguridad_por_ruta_binding(monkeypatch):
 
     monkeypatch.setattr(
         command._runtime_manager,
-        "validate_security_route",
-        lambda language, **kwargs: calls.append((language, kwargs)),
+        "validate_command_runtime",
+        lambda language, **kwargs: calls.append((language, kwargs)) or ("1.0", object(), object()),
     )
-    monkeypatch.setattr(command._runtime_manager, "validate_abi_route", lambda _language: "1.0")
     monkeypatch.setattr(
         "cobra.cli.commands_v2.test_cmd.backend_pipeline.resolve_backend",
         lambda _file, _hints: type("R", (), {"reason_for": lambda self, debug: "ok"})(),

--- a/tests/unit/test_runtime_manager.py
+++ b/tests/unit/test_runtime_manager.py
@@ -17,6 +17,7 @@ def test_runtime_manager_valida_ruta_js_requiere_runtime_gestionado():
     try:
         manager.validate_security_route("javascript", sandbox=False, containerized=False)
     except ValueError as exc:
+        assert "[JavaScript runtime bridge]" in str(exc)
         assert "runtime gestionado" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("Se esperaba error de seguridad para JS sin aislamiento")
@@ -44,6 +45,20 @@ def test_runtime_manager_politica_test_exige_sandbox_para_python():
         assert "exige sandbox" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("Se esperaba error de política test para python")
+
+
+def test_runtime_manager_validate_command_runtime_retorna_abi_capabilities_y_bridge():
+    manager = RuntimeManager()
+
+    abi, capabilities, bridge = manager.validate_command_runtime(
+        "rust",
+        command="build",
+        abi_version="2.0",
+    )
+
+    assert abi == "2.0"
+    assert capabilities.route is BindingRoute.RUST_COMPILED_FFI
+    assert bridge.implementation == "rust_compiled_ffi_bridge"
 
 
 def test_runtime_manager_negocia_abi_desde_config(monkeypatch, tmp_path: Path):
@@ -97,3 +112,39 @@ javascript = "1.2"
         assert "Versiones soportadas" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("Se esperaba rechazo de ABI no soportada")
+
+
+def test_runtime_manager_abi_contract_lee_abi_by_backend_desde_cobra_toml(monkeypatch, tmp_path: Path):
+    manager = RuntimeManager()
+    cobra_toml = tmp_path / "cobra.toml"
+    cobra_toml.write_text(
+        """
+[project.abi_by_backend]
+python = "1.0"
+javascript = "1.0"
+rust = "1.1"
+""".strip()
+    )
+    monkeypatch.setenv("COBRA_TOML", str(cobra_toml))
+    monkeypatch.delenv("PCOBRA_CONFIG", raising=False)
+
+    assert manager.validate_abi_route("python") == "1.0"
+    assert manager.validate_abi_route("javascript") == "1.0"
+    assert manager.validate_abi_route("rust") == "1.1"
+
+
+def test_runtime_manager_abi_contract_lee_backend_abi_desde_pcobra_toml(monkeypatch, tmp_path: Path):
+    manager = RuntimeManager()
+    pcobra_toml = tmp_path / "pcobra.toml"
+    pcobra_toml.write_text(
+        """
+[project.backend_abi]
+javascript = "1.0"
+rust = "1.1"
+""".strip()
+    )
+    monkeypatch.setenv("COBRA_TOML", str(tmp_path / "missing-cobra.toml"))
+    monkeypatch.setenv("PCOBRA_CONFIG", str(pcobra_toml))
+
+    assert manager.validate_abi_route("javascript") == "1.0"
+    assert manager.validate_abi_route("rust") == "1.1"


### PR DESCRIPTION
### Motivation
- Garantizar que los comandos públicos `run`, `test` y `build` realicen validaciones de seguridad y ABI vía un único responsable (`RuntimeManager`).
- Evitar atajos o validaciones dispersas que ejecuten backends fuera del flujo gobernado por el manager.
- Unificar mensajes de error por ruta contractual (Python / JavaScript / Rust) para facilitar diagnóstico y trazabilidad.
- Establecer gobernanza para cambios breaking de ABI (registro en `CHANGELOG.md` y ADR).

### Description
- Se añadió `RuntimeManager.validate_command_runtime(...)` que realiza en un solo flujo la validación de seguridad y la negociación de ABI y devuelve `(abi, capabilities, bridge)`; además se agregó el helper `_raise_route_error` y etiquetas canónicas por ruta. (modificado: `src/pcobra/cobra/bindings/runtime_manager.py`).
- Se amplió la política de seguridad para el comando `build` y se reemplazaron llamadas separadas a `validate_security_route`/`validate_abi_route` por `validate_command_runtime` en los comandos v2 `run`, `test` y `build`. (modificados: `src/pcobra/cobra/cli/commands_v2/run_cmd.py`, `.../test_cmd.py`, `.../build_cmd.py`).
- Se añadieron y ajustaron tests unitarios para cubrir la API unificada y la lectura de `abi_by_backend` / `backend_abi` desde `cobra.toml` / `pcobra.toml` y se adaptaron los tests de contrato CLI v2 para validar las nuevas llamadas. (modificados: `tests/unit/test_runtime_manager.py`, `tests/unit/test_cli_v2_command_contract.py`).
- Documentación y changelog actualizados con la política de gobernanza de ABI y el resumen de los cambios. (modificados: `CHANGELOG.md`, `docs/architecture/adr-unified-backends.md`).

### Testing
- Ejecutado: `pytest -q tests/unit/test_runtime_manager.py tests/unit/test_cli_v2_command_contract.py`.
- Resultado: todos los tests pasaron en esta ejecución: `16 passed, 1 warning`.
- Los tests automatizados verifican la negociación de ABI desde `cobra.toml`/`pcobra.toml`, la selección de bridge y que `run/test/build` usen la API unificada de `RuntimeManager`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2746091e88327bf98a24845ef8bc1)