### PR TITLE
legacy: clasificar lifecycle por fases y reforzar gate CI contra exposición pública

### DIFF
--- a/docs/compatibility/internal_only_backend_removal_checklist.md
+++ b/docs/compatibility/internal_only_backend_removal_checklist.md
@@ -10,6 +10,7 @@ Backends en retiro interno: `go`, `cpp`, `java`, `wasm`, `asm`.
 
 - [ ] El README público solo sugiere `python`, `javascript`, `rust` como elección de usuario.
 - [ ] Las guías públicas eliminan ejemplos de uso directo `--backend go/cpp/java/wasm/asm`.
+- [ ] Los comandos obsoletos (`dependencias`, `bench*`, `profile`, `transpilar-inverso`, `validar-sintaxis`, `qa-validar`) no aparecen en help/documentación pública.
 - [ ] Se conserva únicamente documentación de migración/compatibilidad para targets internal-only.
 - [ ] Se ejecuta inventario: `python scripts/ci/generate_internal_only_inventory.py` y se revisa `docs/compatibility/internal_only_refs_inventory.md`.
 
@@ -26,6 +27,28 @@ Backends en retiro interno: `go`, `cpp`, `java`, `wasm`, `asm`.
 - [ ] Eliminar entradas legacy del registro interno una vez sin tráfico.
 - [ ] Eliminar flags de compatibilidad (`COBRA_INTERNAL_LEGACY_TARGETS`, `COBRA_LEGACY_TARGETS_MODE`) al cierre.
 - [ ] Ejecutar auditoría final del repositorio y bloquear reintroducciones en CI.
+
+## Priorización explícita de limpieza de transpilers legacy (al vencer ventana)
+
+> **Regla:** no borrar físicamente antes de vencer la ventana de retiro del backend.
+
+1. `src/pcobra/cobra/transpilers/transpiler/to_asm.py` (Q3 2026).
+2. `src/pcobra/cobra/transpilers/transpiler/to_go.py` (Q4 2026).
+3. `src/pcobra/cobra/transpilers/transpiler/to_cpp.py` (Q4 2026).
+4. `src/pcobra/cobra/transpilers/transpiler/to_java.py` (Q1 2027).
+5. `src/pcobra/cobra/transpilers/transpiler/to_wasm.py` (Q2 2027).
+
+Para cada backend en ventana vencida:
+
+- [ ] Eliminar código del transpilador y nodos asociados.
+- [ ] Eliminar tests/unit + tests/integration/goldens expirados del backend.
+- [ ] Eliminar hooks internos/registro y referencias operativas restantes.
+
+## Checklist CI — No exposición pública de legacy targets
+
+- [ ] `python scripts/ci/validate_targets.py` incluye gate de **no exposición pública** en superficies help/docs.
+- [ ] `tests/integration/test_cli_public_help_contract.py` sigue en verde (sin `go/cpp/java/wasm/asm` en help público).
+- [ ] Cualquier hallazgo de exposición pública bloquea merge.
 
 ## Criterio de salida
 

--- a/docs/compatibility/internal_only_refs_inventory.md
+++ b/docs/compatibility/internal_only_refs_inventory.md
@@ -145,3 +145,9 @@ Este reporte se genera con `scripts/ci/generate_internal_only_inventory.py`.
 ## Nota de uso
 
 Este inventario es de diagnóstico. La eliminación se ejecuta por fases según `docs/compatibility/internal_only_backend_removal_checklist.md`.
+
+## Clasificación operativa por fase (sin borrado físico anticipado)
+
+- **Fase 1 (ocultar de UX pública):** `asm`.
+- **Fase 2 (bloqueo fuera de profile development):** `go`, `cpp`, `java`, `wasm`.
+- **Fase 3 (eliminar código/tests internos expirados):** aplicar solo al vencer ventana por backend.

--- a/docs/compatibility/legacy_cli_command_inventory.md
+++ b/docs/compatibility/legacy_cli_command_inventory.md
@@ -43,3 +43,4 @@ Este inventario clasifica la superficie v1 de la CLI en tres categorías para la
 - En CLI v1 con perfil `public`, se desactivan comandos internos y obsoletos.
 - En CLI v1 con perfil `development`, se conservan para migración técnica y pruebas de regresión.
 - En CLI v2, la UX pública ya permanece limitada a `run`, `build`, `test`, `mod`.
+- Antes de borrado físico, los comandos obsoletos deben retirarse del help/documentación pública y validarse en CI.

--- a/docs/compatibility/legacy_ux_retirement_plan.md
+++ b/docs/compatibility/legacy_ux_retirement_plan.md
@@ -42,3 +42,18 @@ Este flag es transitorio y no debe usarse en documentación pública ni en nuevo
    - Confirmar readiness antes del 30/06/2027 y remover la ruta de compatibilidad.
 
 Checklist operativo por fases: `docs/compatibility/internal_only_backend_removal_checklist.md`.
+
+## Inventario por fase (fuente canónica: `legacy_backend_lifecycle.py`)
+
+| Backend | Fase actual | Ventana | Acción |
+|---|---|---|---|
+| `asm` | Fase 1 — ocultar de UX pública | Q3 2026 | Mantener solo diagnóstico acotado; retirar primero cuando venza ventana. |
+| `go` | Fase 2 — solo profile `development` | Q4 2026 | Bloquear fuera de desarrollo y migrar pipelines a `rust`. |
+| `cpp` | Fase 2 — solo profile `development` | Q4 2026 | Bloquear fuera de desarrollo y migrar pipelines a `rust`. |
+| `java` | Fase 2 — solo profile `development` | Q1 2027 | Bloquear fuera de desarrollo y migrar flujos a `javascript`. |
+| `wasm` | Fase 2 — solo profile `development` | Q2 2027 | Mantener congelado; sin features nuevas. |
+
+## Nota de limpieza física
+
+La eliminación de `to_go.py`, `to_cpp.py`, `to_java.py`, `to_wasm.py` y `to_asm.py`
+se ejecuta únicamente cuando la ventana de retiro de cada backend esté vencida.

--- a/docs/issues/target_cleanup_checklist.md
+++ b/docs/issues/target_cleanup_checklist.md
@@ -137,6 +137,7 @@ Antes de fusionar cambios de política:
 - [x] Política de targets validada (`python scripts/ci/validate_targets.py`).
 - [x] Coherencia de docs públicas validada (`python scripts/validate_targets_policy.py`).
 - [x] Contrato de compatibilidad por backend validado (`python scripts/validate_runtime_contract.py`).
+- [x] Checklist CI activo de **no exposición pública de legacy targets** (help/superficies públicas).
 - [x] Cualquier guardrail en fallo bloquea merge (jobs CI en estado failed).
 
 ## Checklist de retiro seguro por backend interno

--- a/scripts/ci/validate_targets.py
+++ b/scripts/ci/validate_targets.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import ast
+import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 import inspect
@@ -56,6 +58,7 @@ from scripts.targets_policy_common import (
 from scripts.generar_matriz_transpiladores import _build_markdown as build_transpilers_matrix_markdown
 
 FINAL_OFFICIAL_TARGETS = tuple(OFFICIAL_TARGETS)
+INTERNAL_LEGACY_TARGETS = ("go", "cpp", "java", "wasm", "asm")
 EXPECTED_TRANSPILER_MODULES = tuple(
     f"src/pcobra/cobra/transpilers/transpiler/{filename}"
     for filename in official_transpiler_module_filenames()
@@ -1105,6 +1108,46 @@ def validate_cli_public_surfaces_no_legacy_aliases() -> list[str]:
     return errors
 
 
+def _public_cli_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("SQLITE_DB_KEY", None)
+    env.pop("COBRA_DEV_MODE", None)
+    env.pop("COBRA_CLI_COMMAND_PROFILE", None)
+    env.pop("COBRA_INTERNAL_ENABLE_LEGACY_CLI", None)
+    env.pop("COBRA_INTERNAL_LEGACY_TARGETS", None)
+    return env
+
+
+def validate_ci_checklist_no_public_legacy_targets() -> list[str]:
+    """Checklist CI: prohíbe exposición de targets legacy en help público."""
+    errors: list[str] = []
+    commands = (
+        ("root_help", [sys.executable, "-m", "cobra.cli.cli", "--help"]),
+        ("build_help", [sys.executable, "-m", "cobra.cli.cli", "build", "--help"]),
+    )
+    for surface_name, command in commands:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+            env=_public_cli_env(),
+            check=False,
+        )
+        if result.returncode != 0:
+            errors.append(
+                f"ci-checklist:{surface_name}: comando help falló con exit={result.returncode}"
+            )
+            continue
+        lowered = f"{result.stdout}\n{result.stderr}".lower()
+        for target in INTERNAL_LEGACY_TARGETS:
+            if re.search(rf"(?<![\w.+/-]){re.escape(target)}(?![\w.+/-])", lowered):
+                errors.append(
+                    f"ci-checklist:{surface_name}: exposición pública de target legacy '{target}'"
+                )
+    return errors
+
+
 def _run_stage(name: str, errors: list[str]) -> int | None:
     if not errors:
         return None
@@ -1149,6 +1192,10 @@ def main() -> int:
         (
             "comandos/help sin aliases legacy",
             validate_cli_public_surfaces_no_legacy_aliases(),
+        ),
+        (
+            "checklist ci no exposición pública legacy targets",
+            validate_ci_checklist_no_public_legacy_targets(),
         ),
     )
     for stage_name, errors in stages:

--- a/src/pcobra/cobra/architecture/legacy_backend_lifecycle.py
+++ b/src/pcobra/cobra/architecture/legacy_backend_lifecycle.py
@@ -12,6 +12,11 @@ from typing import Final, Literal
 from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS
 
 LegacyLifecycleStatus = Literal["active-migration", "frozen", "removal-candidate"]
+LegacyLifecyclePhase = Literal[
+    "phase-1-hide-public-ux",
+    "phase-2-development-profile-only",
+    "phase-3-remove-expired-code-and-tests",
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -19,6 +24,8 @@ class LegacyBackendLifecycle:
     """Describe el estado de retiro de un backend interno."""
 
     status: LegacyLifecycleStatus
+    phase: LegacyLifecyclePhase
+    retirement_window: str
     recommended_public_target: str
     owner_track: str
     notes: str
@@ -27,30 +34,40 @@ class LegacyBackendLifecycle:
 LEGACY_BACKEND_LIFECYCLE: Final[dict[str, LegacyBackendLifecycle]] = {
     "go": LegacyBackendLifecycle(
         status="active-migration",
+        phase="phase-2-development-profile-only",
+        retirement_window="Q4 2026",
         recommended_public_target="rust",
         owner_track="runtime-migration",
         notes="Backend interno con uso residual en migración activa de pipelines.",
     ),
     "cpp": LegacyBackendLifecycle(
         status="active-migration",
+        phase="phase-2-development-profile-only",
+        retirement_window="Q4 2026",
         recommended_public_target="rust",
         owner_track="runtime-migration",
         notes="Se mantiene temporalmente por compatibilidad de integraciones históricas.",
     ),
     "java": LegacyBackendLifecycle(
         status="active-migration",
+        phase="phase-2-development-profile-only",
+        retirement_window="Q1 2027",
         recommended_public_target="javascript",
         owner_track="runtime-migration",
         notes="Uso interno controlado durante el retiro de rutas no públicas.",
     ),
     "wasm": LegacyBackendLifecycle(
         status="frozen",
+        phase="phase-2-development-profile-only",
+        retirement_window="Q2 2027",
         recommended_public_target="javascript",
         owner_track="maintenance-only",
         notes="Congelado: solo correcciones críticas sin expansión funcional.",
     ),
     "asm": LegacyBackendLifecycle(
         status="removal-candidate",
+        phase="phase-1-hide-public-ux",
+        retirement_window="Q3 2026",
         recommended_public_target="python",
         owner_track="decommission",
         notes="Candidato explícito a retiro; mantener únicamente para diagnóstico acotado.",
@@ -83,7 +100,8 @@ def legacy_backend_warning_message(*, target: str, route: str) -> str:
     metadata = LEGACY_BACKEND_LIFECYCLE[target]
     return (
         f"[INTERNAL LEGACY BACKEND] '{target}' usado vía ruta no pública ({route}). "
-        f"estado={metadata.status}; destino público recomendado={metadata.recommended_public_target}; "
+        f"estado={metadata.status}; fase={metadata.phase}; ventana={metadata.retirement_window}; "
+        f"destino público recomendado={metadata.recommended_public_target}; "
         "uso permitido solo para migración interna temporal."
     )
 

--- a/tests/unit/test_legacy_backend_lifecycle.py
+++ b/tests/unit/test_legacy_backend_lifecycle.py
@@ -38,9 +38,18 @@ def test_warning_message_usa_formato_unificado():
     msg = legacy_backend_warning_message(target="asm", route="CLI.parse_target")
     assert "ruta no pública" in msg
     assert "estado=removal-candidate" in msg
+    assert "fase=phase-1-hide-public-ux" in msg
+    assert "ventana=Q3 2026" in msg
     assert "destino público recomendado=python" in msg
 
 
 def test_iter_rows_respeta_orden_canonic():
     rows = iter_legacy_backend_lifecycle_rows()
     assert tuple(backend for backend, _ in rows) == INTERNAL_BACKENDS
+
+
+def test_iter_rows_expone_clasificacion_por_fase():
+    rows = dict(iter_legacy_backend_lifecycle_rows())
+    assert rows["asm"].phase == "phase-1-hide-public-ux"
+    assert rows["go"].phase == "phase-2-development-profile-only"
+    assert rows["wasm"].retirement_window == "Q2 2027"


### PR DESCRIPTION
### Motivation
- Centralizar el inventario y la estrategia de retiro de backends legacy para que CLI, documentación y CI compartan la misma fuente de verdad. 
- Forzar la clasificación por fases (ocultar UX pública / solo perfil development / eliminación al vencer ventana) para evitar borrados prematuros y coordinar migraciones. 
- Añadir una verificación CI que evite la exposición pública accidental de targets legacy (`go`, `cpp`, `java`, `wasm`, `asm`).

### Description
- Amplié `src/pcobra/cobra/architecture/legacy_backend_lifecycle.py` para incluir `phase` y `retirement_window` por backend y enriquecer el `legacy_backend_warning_message` con `fase` y `ventana`.
- Actualicé tests en `tests/unit/test_legacy_backend_lifecycle.py` para validar el nuevo formato y la clasificación por fase/ventana.
- Sincronizé documentación en `docs/compatibility/*` para exponer la clasificación por Fase 1/2/3, la priorización de limpieza de `to_*.py` (solo al vencer la ventana) y la regla de retirar comandos obsoletos del help antes de borrado físico.
- Añadí un gate CI en `scripts/ci/validate_targets.py` que ejecuta `cobra --help` y `cobra build --help` en modo público y falla si detecta cualquiera de `go/cpp/java/wasm/asm` en la salida; además registré la checklist correspondiente en `docs/issues/target_cleanup_checklist.md`.

### Testing
- Ejecuté `pytest -q tests/unit/test_legacy_backend_lifecycle.py tests/integration/test_cli_public_help_contract.py` y ambos conjuntos pasaron (`12 passed`).
- Ejecuté `python scripts/ci/validate_targets.py` y la herramienta falló con un `ImportError` al importar `LANG_CHOICES` desde `compile_cmd`; este error parece preexistente y no fue introducido por los cambios realizados (validator abortó antes de ejecutar el nuevo gate de help).
- Cambios commiteados en el branch y preparados como PR; no se eliminaron transpiladores legacy (`to_*.py`) ya que la regla exige borrado físico solo cuando la ventana de retiro correspondiente haya vencido.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27954b7cc8327ab9dd53c88b299b8)