### PR TITLE
Restringir targets en cobra.toml a PUBLIC_BACKENDS y validar configuraciones

### DIFF
--- a/pcobra.toml
+++ b/pcobra.toml
@@ -3,15 +3,9 @@
 # Este archivo se genera o mantiene manualmente tras usar comandos como `cobra transpilar`.
 
 [project]
-# Targets soportados por la plataforma Cobra (oficiales):
-# - Tier 1: python, rust, javascript, wasm
-# - Tier 2: go, cpp, java, asm
-#
-# Targets requeridos por proyecto (política local de CI/build):
-# - Por defecto usamos Tier 1 completo para asegurar cobertura mínima oficial.
-# - Tier 2 puede declararse de forma opcional en `cobra.mod`/mapeos sin hacerlo obligatorio.
-# - Si tu proyecto quiere exigir también Tier 2, añádelo explícitamente aquí.
-required_targets = ["python", "rust", "javascript", "wasm"]
+# Targets públicos soportados por la plataforma Cobra:
+# - python, javascript, rust
+required_targets = ["python", "javascript", "rust"]
 
 
 # Negociación ABI por backend para bridges/runtime manager.
@@ -22,21 +16,11 @@ rust = "1.0"
 
 [modulos."modulo.co"]
 python = "modulo.py"
-rust = "modulo.rs"
 javascript = "modulo.js"
-wasm = "modulo.wasm"
-go = "modulo.go"
-cpp = "modulo.cpp"
-java = "modulo.java"
-asm = "modulo.asm"
+rust = "modulo.rs"
 
 # Puedes añadir más entradas como:
 # [modulos."ciencia/genetica.co"]
 # python = "ciencia/genetica.py"
-# rust = "ciencia/genetica.rs"
 # javascript = "ciencia/genetica.js"
-# wasm = "ciencia/genetica.wasm"
-# go = "ciencia/genetica.go"
-# cpp = "ciencia/genetica.cpp"
-# java = "ciencia/genetica.java"
-# asm = "ciencia/genetica.asm"
+# rust = "ciencia/genetica.rs"

--- a/src/pcobra/cobra/transpilers/module_map.py
+++ b/src/pcobra/cobra/transpilers/module_map.py
@@ -7,6 +7,7 @@ try:
 except ModuleNotFoundError:  # pragma: no cover
     import tomli as tomllib
 
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 from pcobra.cobra.transpilers.target_utils import normalize_target_name
 from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
 from pcobra.cobra.stdlib_contract import get_contract_manifests
@@ -127,6 +128,72 @@ def _is_runtime_path_forbidden(mapped_path: str) -> bool:
     return any(segment in canonical for segment in _RUNTIME_PATH_FORBIDDEN_SEGMENTS)
 
 
+
+
+def _validate_public_backend_policy(data: Dict[str, Any]) -> None:
+    """Valida que ``cobra.toml`` solo declare backends públicos en secciones de runtime."""
+    allowed = set(PUBLIC_BACKENDS)
+    allowed_text = ", ".join(PUBLIC_BACKENDS)
+
+    project_cfg = data.get("project")
+    if isinstance(project_cfg, dict):
+        raw_targets = project_cfg.get("required_targets")
+        if raw_targets is None:
+            raw_targets = project_cfg.get("targets_requeridos")
+
+        if raw_targets is not None:
+            if not isinstance(raw_targets, list):
+                raise ValueError(
+                    "Config local inválida: [project].required_targets debe ser una lista de strings. "
+                    f"Permitidos: {allowed_text}"
+                )
+            invalid_targets: list[str] = []
+            for raw_target in raw_targets:
+                if not isinstance(raw_target, str):
+                    invalid_targets.append(repr(raw_target))
+                    continue
+                canonical = normalize_target_name(raw_target)
+                if canonical not in allowed:
+                    invalid_targets.append(raw_target)
+
+            if invalid_targets:
+                raise ValueError(
+                    "Config local inválida: [project].required_targets contiene targets fuera de PUBLIC_BACKENDS: "
+                    f"{', '.join(invalid_targets)}. Permitidos: {allowed_text}"
+                )
+
+    modulos = data.get("modulos")
+    if not isinstance(modulos, dict):
+        return
+
+    invalid_by_module: dict[str, list[str]] = {}
+    for module_name, module_mapping in modulos.items():
+        if not isinstance(module_mapping, dict):
+            continue
+
+        invalid_keys: list[str] = []
+        for key in module_mapping:
+            if not isinstance(key, str):
+                invalid_keys.append(repr(key))
+                continue
+            canonical = normalize_target_name(key)
+            if canonical not in allowed:
+                invalid_keys.append(key)
+
+        if invalid_keys:
+            invalid_by_module[str(module_name)] = invalid_keys
+
+    if invalid_by_module:
+        rendered = "; ".join(
+            f"{module}: {', '.join(keys)}"
+            for module, keys in sorted(invalid_by_module.items())
+        )
+        raise ValueError(
+            "Config local inválida: [modulos.<nombre>] contiene targets fuera de PUBLIC_BACKENDS. "
+            f"Detalle: {rendered}. Permitidos: {allowed_text}"
+        )
+
+
 def get_toml_map() -> Dict[str, Any]:
     """Devuelve la configuración del archivo ``cobra.toml``."""
     global _toml_cache
@@ -137,6 +204,8 @@ def get_toml_map() -> Dict[str, Any]:
                     data = tomllib.load(f) or {}
             else:
                 data = {}
+            if isinstance(data, dict):
+                _validate_public_backend_policy(data)
             _toml_cache = data
         except (tomllib.TOMLDecodeError, OSError) as e:
             logger.error(f"Error al cargar cobra.toml: {e}")

--- a/tests/unit/test_module_map.py
+++ b/tests/unit/test_module_map.py
@@ -1,8 +1,8 @@
+import pytest
 from cobra.transpilers import module_map
 
 
-def test_module_map_resuelve_target_tier2_en_cobra_toml(tmp_path, monkeypatch):
-    mod = "biblioteca.co"
+def test_module_map_rechaza_target_fuera_de_public_backends_en_cobra_toml(tmp_path, monkeypatch):
     toml_file = tmp_path / "cobra.toml"
     toml_file.write_text(
         "[modulos]\n"
@@ -15,7 +15,8 @@ def test_module_map_resuelve_target_tier2_en_cobra_toml(tmp_path, monkeypatch):
     module_map.COBRA_TOML_PATH = str(toml_file)
     module_map._toml_cache = None
 
-    assert module_map.get_mapped_path(mod, "go") == "biblioteca.go"
+    with pytest.raises(ValueError, match="PUBLIC_BACKENDS"):
+        module_map.get_toml_map()
 
 
 def test_module_map_ignora_cobra_mod_para_resolucion(tmp_path, monkeypatch):

--- a/tests/unit/test_module_map_errors.py
+++ b/tests/unit/test_module_map_errors.py
@@ -1,6 +1,8 @@
 import builtins
 import logging
 
+import pytest
+
 from cobra.transpilers import module_map
 
 
@@ -32,6 +34,32 @@ def test_get_toml_map_invalid_file_returns_empty_and_logs_error(tmp_path, monkey
 
     assert result == {}
     assert "Error al cargar cobra.toml" in caplog.text
+
+
+def test_get_toml_map_rechaza_required_targets_fuera_de_public_backends(tmp_path, monkeypatch):
+    module_map._toml_cache = None
+    bad_toml = tmp_path / "cobra.toml"
+    bad_toml.write_text(
+        "[project]\nrequired_targets = ['python', 'go']\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module_map, "COBRA_TOML_PATH", str(bad_toml))
+
+    with pytest.raises(ValueError, match="required_targets"):
+        module_map.get_toml_map()
+
+
+def test_get_toml_map_rechaza_targets_legacy_en_modulos(tmp_path, monkeypatch):
+    module_map._toml_cache = None
+    bad_toml = tmp_path / "cobra.toml"
+    bad_toml.write_text(
+        "[modulos]\n[modulos.'demo.co']\ngo = 'demo.go'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module_map, "COBRA_TOML_PATH", str(bad_toml))
+
+    with pytest.raises(ValueError, match="\\[modulos"):
+        module_map.get_toml_map()
 
 
 def test_get_mapped_path_returns_original_when_no_mapping(monkeypatch):

--- a/tests/unit/test_smoke_transpilation_official_targets.py
+++ b/tests/unit/test_smoke_transpilation_official_targets.py
@@ -73,7 +73,7 @@ def test_smoke_runtime_holobit_asm_expone_fallo_explicito_y_homogeneo(ast_holobi
     assert "la visualización requiere runtime externo" in code
 
 
-def test_module_map_resuelve_targets_solo_desde_cobra_toml(tmp_path, monkeypatch):
+def test_module_map_resuelve_targets_publicos_solo_desde_cobra_toml(tmp_path, monkeypatch):
     modulo = "biblioteca.co"
     toml_file = tmp_path / "cobra.toml"
     toml_file.write_text(
@@ -81,8 +81,7 @@ def test_module_map_resuelve_targets_solo_desde_cobra_toml(tmp_path, monkeypatch
         "[modulos.'biblioteca.co']\n"
         "python = 'biblioteca.py'\n"
         "javascript = 'biblioteca.js'\n"
-        "rust = 'biblioteca.rs'\n"
-        "go = 'biblioteca.go'\n",
+        "rust = 'biblioteca.rs'\n",
         encoding="utf-8",
     )
 
@@ -96,4 +95,23 @@ def test_module_map_resuelve_targets_solo_desde_cobra_toml(tmp_path, monkeypatch
     assert module_map.get_mapped_path(modulo, "python") == "biblioteca.py"
     assert module_map.get_mapped_path(modulo, "javascript") == "biblioteca.js"
     assert module_map.get_mapped_path(modulo, "rust") == "biblioteca.rs"
-    assert module_map.get_mapped_path(modulo, "go") == "biblioteca.go"
+
+
+def test_module_map_falla_si_toml_declara_target_no_publico(tmp_path, monkeypatch):
+    toml_file = tmp_path / "cobra.toml"
+    toml_file.write_text(
+        "[modulos]\n"
+        "[modulos.'biblioteca.co']\n"
+        "go = 'biblioteca.go'\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("COBRA_TOML", str(toml_file))
+
+    import pcobra.cobra.transpilers.module_map as module_map
+
+    module_map.COBRA_TOML_PATH = str(toml_file)
+    module_map._toml_cache = None
+
+    with pytest.raises(ValueError, match="PUBLIC_BACKENDS"):
+        module_map.get_toml_map()


### PR DESCRIPTION
### Motivation
- Forzar que los archivos de configuración públicos solo declaren los backends soportados públicamente (`python`, `javascript`, `rust`) para evitar aceptación silenciosa de targets legacy no públicos.
- Evitar inconsistencias entre la política pública y los lectores de configuración que consumen `cobra.toml` por parte de los transpilers y la lógica de resolución de módulos.

### Description
- Actualicé `pcobra.toml` de ejemplo para que `[project].required_targets` contenga únicamente `python`, `javascript` y `rust` y limpié la sección `[modulos."modulo.co"]` dejando solo las claves públicas.
- Añadí la función `_validate_public_backend_policy(data: Dict[str, Any])` en `src/pcobra/cobra/transpilers/module_map.py` que valida `project.required_targets` y las claves dentro de `modulos.<nombre>` contra `PUBLIC_BACKENDS` y lanza `ValueError` con mensajes claros si encuentra entradas no permitidas.
- Integré la validación dentro de `get_toml_map()` para que la carga de `cobra.toml` falle rápidamente ante configuraciones inválidas y mantuve la lógica previa de resolución de mappings en `get_mapped_path()`.
- Actualicé y añadí tests en `tests/unit/test_module_map.py`, `tests/unit/test_module_map_errors.py` y `tests/unit/test_smoke_transpilation_official_targets.py` para cubrir los casos positivos y los rechazos explícitos de targets no públicos.

### Testing
- Ejecuté `pytest -q tests/unit/test_module_map.py tests/unit/test_module_map_errors.py tests/unit/test_smoke_transpilation_official_targets.py` y todos los tests que afectan esta modificación pasaron: `30 passed`.
- Añadí tests que verifican que `get_toml_map()` lanza `ValueError` cuando `cobra.toml` declara `required_targets` o mappings en `[modulos]` fuera de `PUBLIC_BACKENDS`, y estos tests se ejecutaron con éxito.
- Las pruebas existentes de `get_mapped_path()` y resolución por contratos de stdlib se mantuvieron y pasaron sin cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e280d9e2408327acc6a77394424321)