### PR TITLE
Separar registro de transpiladores en fuentes pública e internal_compat

### DIFF
--- a/src/pcobra/cobra/transpilers/registry.py
+++ b/src/pcobra/cobra/transpilers/registry.py
@@ -21,6 +21,10 @@ TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
     "python": ("pcobra.cobra.transpilers.transpiler.to_python", "TranspiladorPython"),
     "javascript": ("pcobra.cobra.transpilers.transpiler.to_js", "TranspiladorJavaScript"),
     "rust": ("pcobra.cobra.transpilers.transpiler.to_rust", "TranspiladorRust"),
+}
+
+# Bloque dedicado de compatibilidad interna (no público).
+INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
     "go": ("pcobra.cobra.transpilers.transpiler.to_go", "TranspiladorGo"),
     "cpp": ("pcobra.cobra.transpilers.transpiler.to_cpp", "TranspiladorCPP"),
     "java": ("pcobra.cobra.transpilers.transpiler.to_java", "TranspiladorJava"),
@@ -28,14 +32,12 @@ TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
     "asm": ("pcobra.cobra.transpilers.transpiler.to_asm", "TranspiladorASM"),
 }
 
+PUBLIC_TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = TRANSPILER_CLASS_PATHS
 
-PUBLIC_TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
-    target: TRANSPILER_CLASS_PATHS[target] for target in PUBLIC_BACKENDS
-}
-
-INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
-    target: TRANSPILER_CLASS_PATHS[target] for target in INTERNAL_BACKENDS
-}
+# Alias explícito para continuidad semántica en módulos/tests internos.
+INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = (
+    INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS
+)
 INTERNAL_LEGACY_TRANSPILER_LIFECYCLE_STATUS: Final[
     dict[str, str]
 ] = {
@@ -46,27 +48,29 @@ INTERNAL_LEGACY_TRANSPILER_LIFECYCLE_STATUS: Final[
 
 def _validate_complete_registry_contract() -> tuple[str, ...]:
     """Valida que el inventario completo preserve el contrato total de backends."""
-    configured_keys = tuple(TRANSPILER_CLASS_PATHS)
+    configured_keys = tuple(TRANSPILER_CLASS_PATHS) + tuple(
+        INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS
+    )
     missing = tuple(target for target in ALL_BACKENDS if target not in configured_keys)
     extras = tuple(target for target in configured_keys if target not in ALL_BACKENDS)
 
     if missing or extras:
         raise RuntimeError(
-            "[CI CONTRACT] TRANSPILER_CLASS_PATHS tiene claves fuera de contrato y debe usar exactamente ALL_BACKENDS. "
+            "[CI CONTRACT] TRANSPILER_CLASS_PATHS + INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS tienen claves fuera de contrato y deben usar exactamente ALL_BACKENDS. "
             f"missing={missing or '∅'}; extras={extras or '∅'}; "
             f"current={configured_keys}; expected={ALL_BACKENDS}"
         )
 
     if len(configured_keys) != len(ALL_BACKENDS):
         raise RuntimeError(
-            "[CI CONTRACT] TRANSPILER_CLASS_PATHS tiene cardinalidad inválida. "
+            "[CI CONTRACT] TRANSPILER_CLASS_PATHS + INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS tienen cardinalidad inválida. "
             f"len(current)={len(configured_keys)}; len(expected)={len(ALL_BACKENDS)}; "
             f"current={configured_keys}; expected={ALL_BACKENDS}"
         )
 
     if configured_keys != ALL_BACKENDS:
         raise RuntimeError(
-            "[CI CONTRACT] TRANSPILER_CLASS_PATHS debe preservar el orden de backend_policy.ALL_BACKENDS. "
+            "[CI CONTRACT] TRANSPILER_CLASS_PATHS + INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS deben preservar el orden de backend_policy.ALL_BACKENDS. "
             f"current={configured_keys}; expected={ALL_BACKENDS}"
         )
     return configured_keys
@@ -100,7 +104,7 @@ def _validate_public_registry_contract() -> tuple[str, ...]:
 
 def _validate_internal_legacy_registry_contract() -> tuple[str, ...]:
     """Valida inventario separado para backends legacy internos."""
-    configured_keys = tuple(INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS)
+    configured_keys = tuple(INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS)
     missing = tuple(
         target for target in INTERNAL_BACKENDS if target not in configured_keys
     )
@@ -110,7 +114,7 @@ def _validate_internal_legacy_registry_contract() -> tuple[str, ...]:
 
     if missing or extras:
         raise RuntimeError(
-            "[CI CONTRACT] INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS debe usar exactamente INTERNAL_BACKENDS. "
+            "[CI CONTRACT] INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS debe usar exactamente INTERNAL_BACKENDS. "
             f"missing={missing or '∅'}; extras={extras or '∅'}; "
             f"current={configured_keys}; expected={INTERNAL_BACKENDS}"
         )
@@ -129,7 +133,7 @@ def _validate_internal_legacy_registry_contract() -> tuple[str, ...]:
 
     if configured_keys != INTERNAL_BACKENDS:
         raise RuntimeError(
-            "[CI CONTRACT] INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS debe preservar el orden de backend_policy.INTERNAL_BACKENDS. "
+            "[CI CONTRACT] INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS debe preservar el orden de backend_policy.INTERNAL_BACKENDS. "
             f"current={configured_keys}; expected={INTERNAL_BACKENDS}"
         )
     return configured_keys

--- a/tests/unit/test_registry_contract_guardrail.py
+++ b/tests/unit/test_registry_contract_guardrail.py
@@ -19,7 +19,7 @@ from pcobra.cobra.transpilers import registry
             {
                 key: value
                 for key, value in registry.TRANSPILER_CLASS_PATHS.items()
-                if key != "asm"
+                if key != "rust"
             },
             "claves fuera de contrato",
         ),
@@ -53,16 +53,16 @@ def test_validate_public_registry_contract_falla_con_clave_extra(monkeypatch):
 def test_validate_internal_legacy_registry_contract_falla_si_falta_backend(monkeypatch):
     monkeypatch.setattr(
         registry,
-        "INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS",
+        "INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS",
         {
             key: value
-            for key, value in registry.INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS.items()
+            for key, value in registry.INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS.items()
             if key != "asm"
         },
     )
 
     with pytest.raises(
         RuntimeError,
-        match="INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS",
+        match="INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS",
     ):
         registry._validate_internal_legacy_registry_contract()


### PR DESCRIPTION
### Motivation
- Mantener `TRANSPILER_CLASS_PATHS` como el diccionario canónico público para `python/javascript/rust` y aislar los targets legacy internos en una estructura separada para clarificar contratos y evitar mezclar superficies públicas y compatibilidad interna.
- Evitar cambios de firma en la API pública existente como `build_official_transpilers` y `official_transpiler_targets` para prevenir regresiones.

### Description
- Reduje `TRANSPILER_CLASS_PATHS` para que contenga únicamente los targets públicos (`python`, `javascript`, `rust`) en `src/pcobra/cobra/transpilers/registry.py`.
- Introduje `INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS` como bloque dedicado para targets legacy internos (`go`, `cpp`, `java`, `wasm`, `asm`).
- Mantuve `INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS` como alias hacia `INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS` para continuidad semántica con llamadas y tests internos existentes.
- Ajusté las validaciones para que `_validate_complete_registry_contract` combine las dos fuentes (`TRANSPILER_CLASS_PATHS` + `INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS`) y `_validate_internal_legacy_registry_contract` opere directamente sobre `INTERNAL_COMPAT_TRANSPILER_CLASS_PATHS`.
- Conservé las funciones públicas y su firma (`build_official_transpilers`, `official_transpiler_targets`, etc.) sin cambios y actualicé los tests de guardarraíl para reflejar los nuevos nombres y la separación de fuentes.

### Testing
- Ejecuté `pytest -q tests/unit/test_registry_contract_guardrail.py tests/unit/test_legacy_backend_lifecycle.py` y ambos módulos pasaron correctamente.
- Resultado de pruebas automáticas: `10 passed` (todas las pruebas ejecutadas pasaron).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e305fabb048327a3ee6d482fb2545c)