### PR TITLE
cli: reforzar perfil público y migración de comandos legacy

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -97,11 +97,23 @@ COBRA_DEV_EPHEMERAL_CONFIRM_ENV = "COBRA_DEV_ALLOW_EPHEMERAL_KEY"
 COBRA_ALLOW_INSECURE_FALLBACK_ENV = "COBRA_ALLOW_INSECURE_FALLBACK"
 COBRA_ALLOW_INSECURE_NON_INTERACTIVE_ENV = "COBRA_ALLOW_INSECURE_NON_INTERACTIVE"
 LANG_CHOICES = tuple(OFFICIAL_TRANSPILATION_TARGETS)
-LEGACY_COMMAND_MIGRATION_MAP: dict[str, str] = {
-    "ejecutar": "run",
-    "compilar": "build",
-    "verificar": "test",
-    "modulos": "mod",
+LEGACY_COMMAND_MIGRATION_MAP: dict[str, dict[str, str]] = {
+    "ejecutar": {
+        "target": "run",
+        "hint": "cobra run <archivo.co>",
+    },
+    "compilar": {
+        "target": "build",
+        "hint": "cobra build <archivo.co>",
+    },
+    "verificar": {
+        "target": "test",
+        "hint": "cobra test <archivo.co>",
+    },
+    "modulos": {
+        "target": "mod",
+        "hint": "cobra mod <list|install|remove|publish|search>",
+    },
 }
 
 
@@ -289,8 +301,10 @@ class CliApplication:
             ui=selected_ui,
             profile=command_profile,
         )
-        menu_parser = self._subparsers.add_parser("menu", help=_("Modo interactivo"))
-        menu_parser.set_defaults(cmd="menu")
+        command_profile = resolve_command_profile()
+        if command_profile != PROFILE_PUBLIC:
+            menu_parser = self._subparsers.add_parser("menu", help=_("Modo interactivo"))
+            menu_parser.set_defaults(cmd="menu")
         self._commands_registered = True
 
     def _normalizar_flags_sesion(self, args: argparse.Namespace) -> argparse.Namespace:
@@ -604,9 +618,17 @@ class CliApplication:
         if not self.parser or not self.command_registry:
             raise RuntimeError("Application not properly initialized")
 
+        self._selected_ui = self._resolve_selected_ui_from_argv(argv)
+        if any(token in {"-h", "--help", "--ayuda"} for token in argv):
+            configure_plugin_policy(safe_mode=True, allowlist="")
+            self._ensure_command_structure()
+            if autocomplete_available():
+                self._configure_autocomplete(self.parser)
+                enable_autocomplete(self.parser)
+            return self._normalizar_flags_sesion(self.parser.parse_args(argv))
+
         preliminary_args, _ = self.parser.parse_known_args(argv)
         preliminary_args = self._normalizar_flags_sesion(preliminary_args)
-        self._selected_ui = str(getattr(preliminary_args, "ui", "v2")).strip().lower()
         configure_plugin_policy(
             safe_mode=getattr(preliminary_args, "plugins_safe_mode", True),
             allowlist=getattr(preliminary_args, "plugins_allowlist", ""),
@@ -683,16 +705,22 @@ class CliApplication:
             return normalized
 
         command_token = normalized[command_idx].strip().lower()
-        migrated_to = LEGACY_COMMAND_MIGRATION_MAP.get(command_token)
-        if not migrated_to:
+        migration = LEGACY_COMMAND_MIGRATION_MAP.get(command_token)
+        if not migration:
             return normalized
 
+        migrated_to = migration["target"]
         normalized[command_idx] = migrated_to
         messages.mostrar_advertencia(
             _(
                 "Comando legacy '{legacy}' detectado fuera de entorno interno. "
-                "Migración automática aplicada: use '{current}'."
-            ).format(legacy=command_token, current=migrated_to)
+                "Migración automática aplicada: use '{current}'. "
+                "Sugerencia: {hint}."
+            ).format(
+                legacy=command_token,
+                current=migrated_to,
+                hint=migration["hint"],
+            )
         )
         logging.getLogger(__name__).warning(
             "legacy_command_auto_migrated legacy=%s target=%s profile=%s matrix=%s",

--- a/tests/integration/golden/cli_ui_v2_help_public.golden
+++ b/tests/integration/golden/cli_ui_v2_help_public.golden
@@ -1,13 +1,21 @@
 usage: cobra [-h] [--version] [--ayuda] [--format] [--debug] [-v] [--no-safe]
              [--allow-insecure-fallback] [--allow-insecure-non-interactive]
-             [--modo {cobra,transpilar,mixto}] [--solo-cobra]
-             [--lang lang] [--no-color] [--extra-validators extra_validators]
+             [--modo {cobra,transpilar,mixto}] [--solo-cobra] [--lang lang]
+             [--no-color] [--extra-validators extra_validators]
              [--legacy-imports] [--dev-ephemeral-key] [--plugins-safe-mode]
              [--plugins-unsafe-mode] [--plugins-allowlist plugins_allowlist]
+             {run,build,test,mod} ...
 
 cli de cobra para ejecutar e interpretar scripts, transpilar código a otros
 lenguajes o usar ambos flujos según --modo (cobra, transpilar, mixto). modo
 cobra = solo programar/interpretar cobra sin codegen.
+
+positional arguments:
+  {run,build,test,mod}
+    run                 run a cobra file
+    build               build/transpile a cobra file
+    test                validate project output across runtimes
+    mod                 manage cobra modules
 
 options:
   -h, --help            show this help message and exit

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -35,6 +35,9 @@ def test_cli_help_public_contract_snapshot():
         Path(__file__).parent / "golden" / "cli_ui_v2_help_public.golden"
     ).read_text(encoding="utf-8")
     assert " ".join(result.stdout.lower().split()) == " ".join(expected_snapshot.split())
+    for command in ("run", "build", "test", "mod"):
+        assert f" {command} " in f" {result.stdout.lower()} "
+    assert "\n  menu " not in result.stdout.lower()
     assert "\n  legacy " not in result.stdout.lower()
     assert "--backend" not in result.stdout.lower()
     assert "--tipo" not in result.stdout.lower()
@@ -102,3 +105,4 @@ def test_cli_help_public_contract_muestra_warning_migracion_en_comando_legacy():
     lower_output = result.stderr.lower() + result.stdout.lower()
     assert "comando legacy 'compilar'" in lower_output
     assert "migración automática aplicada: use 'build'" in lower_output
+    assert "sugerencia: cobra build <archivo.co>" in lower_output

--- a/tests/unit/test_cli_v2_command_contract.py
+++ b/tests/unit/test_cli_v2_command_contract.py
@@ -5,6 +5,7 @@ import pytest
 from cobra.cli.commands_v2.run_cmd import RunCommandV2
 from cobra.cli.commands_v2.build_cmd import BuildCommandV2
 from cobra.cli.commands_v2.test_cmd import TestCommandV2
+from cobra.cli.cli import LEGACY_COMMAND_MIGRATION_MAP
 from cobra.cli.target_policies import VERIFICATION_EXECUTABLE_TARGETS
 
 
@@ -131,3 +132,12 @@ def test_test_v2_valida_seguridad_por_ruta_binding(monkeypatch):
     assert calls[0][0] == "python" and calls[0][1]["sandbox"] is True
     assert calls[1][0] == "javascript" and calls[1][1]["containerized"] is True
     assert calls[2][0] == "rust" and calls[2][1]["containerized"] is True
+
+
+def test_legacy_command_migration_map_cubre_comandos_legacy_principales():
+    assert set(LEGACY_COMMAND_MIGRATION_MAP) == {"ejecutar", "compilar", "verificar", "modulos"}
+    assert LEGACY_COMMAND_MIGRATION_MAP["ejecutar"]["target"] == "run"
+    assert LEGACY_COMMAND_MIGRATION_MAP["compilar"]["target"] == "build"
+    assert LEGACY_COMMAND_MIGRATION_MAP["verificar"]["target"] == "test"
+    assert LEGACY_COMMAND_MIGRATION_MAP["modulos"]["target"] == "mod"
+    assert LEGACY_COMMAND_MIGRATION_MAP["modulos"]["hint"].startswith("cobra mod ")


### PR DESCRIPTION
### Motivation
- Reducir la superficie pública del CLI para exponer únicamente los comandos v2 aprobados y evitar fugas de rutas legacy en el `PROFILE_PUBLIC`.
- Mantener los comandos legacy accesibles solo vía flags internos/entorno para migraciones controladas (`COBRA_INTERNAL_ENABLE_LEGACY_CLI`).
- Guiar a los usuarios que usen tokens legacy (`ejecutar/compilar/verificar/modulos`) hacia la nueva UX v2 con mensajes de migración útiles.

### Description
- Cambiada la estructura de `LEGACY_COMMAND_MIGRATION_MAP` en `src/pcobra/cobra/cli/cli.py` para mapear cada comando legacy a un `target` y un `hint` de uso (`target` + `hint`).
- Al parsear argumentos, el help principal ahora construye la estructura de subcomandos antes de imprimir ayuda cuando se detecta `-h/--help/--ayuda`, garantizando que la ayuda pública muestre solo `{run,build,test,mod}` en perfil público.
- Ocultado el subcomando `menu` del perfil `PROFILE_PUBLIC` en `CliApplication._ensure_command_structure()` para mantener la superficie pública estricta.
- Mejorado el aviso de migración automática en `_apply_public_cli_policy()` para incluir la `Sugerencia` (hint) y usar el nuevo formato del mapa de migración.
- Actualizados los snapshots y pruebas relevantes: `tests/integration/golden/cli_ui_v2_help_public.golden`, `tests/integration/test_cli_public_help_contract.py` y añadido test unitario en `tests/unit/test_cli_v2_command_contract.py` para verificar el mapa de migración.

### Testing
- Ejecutado `pytest -q tests/integration/test_cli_public_help_contract.py tests/unit/test_cli_v2_command_contract.py` y el resultado fue `13 passed, 1 warning` (warning de colección no bloqueante sobre una clase con `__init__`).
- Verificado manualmente la salida de `python -m cobra.cli.cli --help` y actualizado el snapshot `tests/integration/golden/cli_ui_v2_help_public.golden` para reflejar la ayuda pública esperada.
- Todas las pruebas automatizadas mencionadas pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3127edeb08327a6726bcf3e197079)