### PR TITLE
Refina UX del comando build v2 para ocultar detalles internos

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/build_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/build_cmd.py
@@ -38,7 +38,7 @@ class BuildCommandV2(BaseCommand):
             mostrar_error(str(exc), registrar_log=False)
             return 1
 
-        if build_result.get("reason"):
+        if debug and build_result.get("reason"):
             mostrar_info(
                 _("Resolución de backend (debug): {reason}").format(reason=build_result["reason"]),
                 registrar_log=False,
@@ -49,6 +49,8 @@ class BuildCommandV2(BaseCommand):
         except ValueError as exc:
             mostrar_error(str(exc), registrar_log=False)
             return 1
-        mostrar_info(_("Código generado:"), registrar_log=False)
+        artifact_path = str(build_result.get("artifact_path") or "<stdout>")
+        mostrar_info(_("Artefacto Cobra generado."), registrar_log=False)
+        mostrar_info(_("Ruta de artefacto: {path}").format(path=artifact_path), registrar_log=False)
         print(build_result["code"])
         return 0

--- a/tests/unit/test_cli_v2_command_contract.py
+++ b/tests/unit/test_cli_v2_command_contract.py
@@ -71,6 +71,74 @@ def test_build_v2_resuelve_backend_via_pipeline(monkeypatch):
     assert called["runtime"][1]["command"] == "build"
 
 
+def test_build_v2_ux_salida_estable_sin_terminos_internos(monkeypatch):
+    command = BuildCommandV2()
+    messages: list[str] = []
+
+    monkeypatch.setattr(
+        "cobra.cli.commands_v2.build_cmd.backend_pipeline.build",
+        lambda *_args, **_kwargs: {
+            "backend": "python",
+            "reason": "[backend_resolution] backend=python; reason=contract",
+            "runtime": {"language": "python"},
+            "ast": [],
+            "code": "print('ok')",
+            "artifact_path": "/tmp/programa.py",
+        },
+    )
+    monkeypatch.setattr(
+        command._runtime_manager,
+        "validate_command_runtime",
+        lambda *_args, **_kwargs: ("1.0", object(), object()),
+    )
+    monkeypatch.setattr(
+        "cobra.cli.commands_v2.build_cmd.mostrar_info",
+        lambda message, **_kwargs: messages.append(message),
+    )
+
+    status = command.run(
+        argparse.Namespace(file="programa.co", modo="mixto", debug=False)
+    )
+
+    assert status == 0
+    assert "Artefacto Cobra generado." in messages
+    assert "Ruta de artefacto: /tmp/programa.py" in messages
+    assert all("backend_resolution" not in message for message in messages)
+    assert all("Transpilador" not in message for message in messages)
+
+
+def test_build_v2_muestra_reason_solo_en_debug(monkeypatch):
+    command = BuildCommandV2()
+    messages: list[str] = []
+
+    monkeypatch.setattr(
+        "cobra.cli.commands_v2.build_cmd.backend_pipeline.build",
+        lambda *_args, **_kwargs: {
+            "backend": "python",
+            "reason": "[backend_resolution] backend=python; reason=contract",
+            "runtime": {"language": "python"},
+            "ast": [],
+            "code": "print('ok')",
+        },
+    )
+    monkeypatch.setattr(
+        command._runtime_manager,
+        "validate_command_runtime",
+        lambda *_args, **_kwargs: ("1.0", object(), object()),
+    )
+    monkeypatch.setattr(
+        "cobra.cli.commands_v2.build_cmd.mostrar_info",
+        lambda message, **_kwargs: messages.append(message),
+    )
+
+    status = command.run(
+        argparse.Namespace(file="programa.co", modo="mixto", debug=True)
+    )
+
+    assert status == 0
+    assert any("Resolución de backend (debug):" in message for message in messages)
+
+
 def test_build_v2_help_no_expone_flags_backend():
     subparsers = _build_subparsers()
     command = BuildCommandV2()


### PR DESCRIPTION
### Motivation

- Evitar que el comando `build` exponga detalles internos de resolución o nombres de transpilador en el flujo normal de usuario.
- Conservar la información de diagnóstico (`reason`) únicamente cuando se ejecuta en modo debug (`--debug`).
- Proveer una salida estable y predecible (resumen + ruta de artefacto) para facilitar consumo por usuarios y tooling.

### Description

- Modifica `BuildCommandV2.run` en `src/pcobra/cobra/cli/commands_v2/build_cmd.py` para imprimir `reason` sólo cuando `debug` es verdadero. 
- Cambia la salida UX normal para mostrar dos mensajes estables: `Artefacto Cobra generado.` y `Ruta de artefacto: {path}` usando `artifact_path` del `build_result` o `"<stdout>"` como fallback, y mantiene la impresión del código en `stdout`.
- Añade pruebas en `tests/unit/test_cli_v2_command_contract.py` que verifican la ausencia de términos internos en la salida normal y que `reason` se muestra sólo en modo debug, con mocks adecuados de `backend_pipeline.build` y `validate_command_runtime`.

### Testing

- Ejecuté `pytest -q tests/unit/test_cli_v2_command_contract.py` y la suite de tests relevante pasó correctamente. 
- Resultado: `9 passed` con `1 warning` de colección no bloqueante relacionado con una clase de test, y sin fallos en los tests nuevos. 
- Los tests nuevos verifican que la salida contiene `Artefacto Cobra generado.` y `Ruta de artefacto: ...`, y que no aparecen cadenas como `backend_resolution` o `Transpilador` en el flujo normal, mientras que `Resolución de backend (debug):` aparece cuando `debug=True`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e315f9091c832780bdf8a685a0cd4e)