### PR TITLE
Refuerza backend_pipeline como fachada interna única

### DIFF
--- a/docs/ADR/001-backend-pipeline-facade.md
+++ b/docs/ADR/001-backend-pipeline-facade.md
@@ -1,0 +1,23 @@
+# ADR 001: Fachada interna única para resolución/transpilación
+
+## Contexto
+El código tenía múltiples puntos internos que invocaban transpilers o adapters de backend de forma directa desde CLI/imports.
+Eso fragmenta el contrato interno, duplica reglas de resolución y dificulta la gobernanza de backends.
+
+## Decisión
+Se define `pcobra.cobra.build.backend_pipeline` como única API interna aprobada para resolver/transpilar:
+
+- `resolve_backend_runtime(source, hints)`
+- `build(source, hints)`
+- `transpile(ast, backend)`
+
+Además, se establece explícitamente la regla:
+
+> No usar transpilers directamente desde CLI/stdlib/imports.
+
+Los módulos legacy (`pcobra.cobra.backends.resolver`) quedan como *shim* técnico mínimo y redirigen a la fachada del pipeline.
+
+## Consecuencias
+- CLI/imports usan una ruta única para resolución y transpilación.
+- Se reduce el acoplamiento con clases de transpilers/adapters concretos.
+- Cambios futuros de política/runtime se concentran en el pipeline.

--- a/src/pcobra/cobra/backends/resolver.py
+++ b/src/pcobra/cobra/backends/resolver.py
@@ -1,13 +1,16 @@
-"""Resolución y API interna única de compilación por backend."""
+"""Compat shim: resolución mínima de backend redirigida a backend_pipeline.
+
+Este módulo existe solo para compatibilidad técnica temporal.
+La API interna aprobada para resolver/transpilar está en
+``pcobra.cobra.build.backend_pipeline``.
+"""
 
 from __future__ import annotations
 
 from typing import Any, Mapping
 
+from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.backends.base import BackendAdapter
-from pcobra.cobra.backends.javascript_adapter import JavaScriptAdapter
-from pcobra.cobra.backends.python_adapter import PythonAdapter
-from pcobra.cobra.backends.rust_adapter import RustAdapter
 
 _BACKEND_ALIASES = {
     "python": "python",
@@ -19,15 +22,21 @@ _BACKEND_ALIASES = {
 }
 
 
+class PipelineBackendAdapter(BackendAdapter):
+    """Adapter mínimo que delega en la fachada interna del pipeline."""
+
+    def __init__(self, backend: str) -> None:
+        self.backend = backend
+
+    def compile(self, ast: Any, options: Mapping[str, Any] | None = None) -> str:
+        return backend_pipeline.transpile(ast, self.backend)
+
+
 def resolve_backend(artifact_kind: str) -> BackendAdapter:
-    """Retorna el adapter adecuado para el ``artifact_kind`` solicitado."""
+    """Retorna un adapter shim que delega en ``backend_pipeline.transpile``."""
     normalized = _BACKEND_ALIASES.get((artifact_kind or "").strip().lower())
-    if normalized == "python":
-        return PythonAdapter()
-    if normalized == "javascript":
-        return JavaScriptAdapter()
-    if normalized == "rust":
-        return RustAdapter()
+    if normalized in {"python", "javascript", "rust"}:
+        return PipelineBackendAdapter(normalized)
     raise ValueError(f"artifact_kind no soportado: {artifact_kind!r}")
 
 
@@ -36,12 +45,15 @@ def compile(
     artifact_kind: str,
     options: Mapping[str, Any] | None = None,
 ) -> str:
-    """API interna unificada de compilación.
+    """API de compatibilidad que redirige explícitamente al pipeline.
 
     Args:
         ast: AST de Cobra (o estructura normalizable por el transpiler).
         artifact_kind: Tipo de artefacto de salida (python/javascript/rust).
         options: Opciones internas del backend (reservado para evolución futura).
     """
-    adapter = resolve_backend(artifact_kind)
-    return adapter.compile(ast, options=options)
+    del options  # Reservado para mantener firma compat.
+    normalized = _BACKEND_ALIASES.get((artifact_kind or "").strip().lower())
+    if normalized is None:
+        raise ValueError(f"artifact_kind no soportado: {artifact_kind!r}")
+    return backend_pipeline.transpile(ast, normalized)

--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -1,4 +1,9 @@
-"""Façade interna para resolución de backend y transpilación."""
+"""Façade interna aprobada para resolución de runtime y transpilación.
+
+Contrato interno:
+- Usar únicamente ``resolve_backend_runtime``, ``build`` y ``transpile``.
+- No invocar transpiladores/adapters de forma directa desde CLI/imports/stdlib.
+"""
 
 from __future__ import annotations
 
@@ -48,8 +53,8 @@ def _validate_public_route_startup_contract() -> None:
 _validate_public_route_startup_contract()
 
 
-def resolve_backend(source: str, hints: dict[str, Any] | None = None) -> BackendResolution:
-    """Resuelve backend canónico a partir de un source file y pistas opcionales."""
+def _resolve_backend(source: str, hints: dict[str, Any] | None = None) -> BackendResolution:
+    """Resuelve backend canónico internamente a partir de source/hints."""
     context = hints or {}
     preferred_backend = context.get("preferred_backend")
     required_capabilities = tuple(context.get("required_capabilities", ()))
@@ -68,7 +73,7 @@ def resolve_backend_runtime(
 ) -> tuple[BackendResolution, dict[str, str]]:
     """Resuelve backend y metadatos de bridge/runtime para el contrato de bindings."""
     context = hints or {}
-    resolution = resolve_backend(source, context)
+    resolution = _resolve_backend(source, context)
     capabilities, bridge = RUNTIME_MANAGER.resolve_runtime(resolution.backend)
     abi_version = RUNTIME_MANAGER.validate_abi_route(
         resolution.backend,
@@ -126,7 +131,6 @@ __all__ = [
     "ORCHESTRATOR",
     "TRANSPILERS",
     "build",
-    "resolve_backend",
     "resolve_backend_runtime",
     "transpile",
 ]

--- a/src/pcobra/cobra/cli/commands/bench_transpilers_cmd.py
+++ b/src/pcobra/cobra/cli/commands/bench_transpilers_cmd.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List
 
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.commands.compile_cmd import TRANSPILERS
+from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.deprecation_policy import enforce_advanced_profile_policy
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
@@ -170,9 +171,8 @@ class BenchTranspilersCommand(BaseCommand):
             with profile_context(profiler):
                 for size, code in programs.items():
                     ast = obtener_ast(code)
-                    for lang, cls in TRANSPILERS.items():
-                        transpiler = cls()
-                        elapsed = timeit(lambda: transpiler.generate_code(ast), number=1)
+                    for lang in TRANSPILERS:
+                        elapsed = timeit(lambda: backend_pipeline.transpile(ast, lang), number=1)
                         results.append({"size": size, "lang": lang, "time": elapsed})
 
             if profiler:

--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -388,7 +388,7 @@ class CompileCommand(BaseCommand):
             )
         try:
             backend_pipeline.TRANSPILERS = TRANSPILERS
-            resolution = backend_pipeline.resolve_backend(
+            resolution, _runtime = backend_pipeline.resolve_backend_runtime(
                 archivo,
                 {"preferred_backend": preferred_backend},
             )

--- a/src/pcobra/cobra/cli/commands/transpilar_inverso_cmd.py
+++ b/src/pcobra/cobra/cli/commands/transpilar_inverso_cmd.py
@@ -44,6 +44,7 @@ from pcobra.cobra.cli.target_policies import parse_target
 from pcobra.cobra.cli.target_policies import OFFICIAL_TRANSPILATION_TARGETS
 from pcobra.cobra.transpilers.registry import official_transpiler_targets
 from pcobra.cobra.transpilers.import_helper import get_standard_imports
+from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.utils.validators import validar_archivo_existente
 from pcobra.cobra.transpilers.target_utils import (
     build_target_help_by_tier,
@@ -412,7 +413,7 @@ class TranspilarInversoCommand(BaseCommand):
                 destino,
             )
             ast = reverse_cls().load_file(args.archivo)
-            codigo = transp_cls().generate_code(ast)
+            codigo = backend_pipeline.transpile(ast, destino)
             report = _build_roundtrip_loss_report(
                 destino=destino,
                 ast_original=ast,

--- a/src/pcobra/cobra/cli/commands_v2/run_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/run_cmd.py
@@ -51,7 +51,7 @@ class RunCommandV2(BaseCommand):
             mostrar_error(str(exc), registrar_log=False)
             return 1
 
-        resolution = backend_pipeline.resolve_backend(args.file, {})
+        resolution, _runtime = backend_pipeline.resolve_backend_runtime(args.file, {})
         legacy_args = Namespace(
             archivo=args.file,
             debug=bool(getattr(args, "debug", False)),

--- a/src/pcobra/cobra/cli/commands_v2/test_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/test_cmd.py
@@ -68,7 +68,7 @@ class TestCommandV2(BaseCommand):
                 mostrar_error(str(exc), registrar_log=False)
                 return 1
 
-        resolution = backend_pipeline.resolve_backend(args.file, {})
+        resolution, _runtime = backend_pipeline.resolve_backend_runtime(args.file, {})
         legacy_args = Namespace(
             archivo=args.file,
             lenguajes=langs,


### PR DESCRIPTION
### Motivation
- Centralizar la resolución y la transpilación en una única API interna para reducir el acoplamiento y evitar llamadas directas a transpilers desde CLI/imports/stdlib.
- Asegurar que la lógica de selección de runtime y bindings quede en un único punto controlado por la fachada.
- Establecer una regla de contrato interno para guiar futuras migraciones y políticas de backends.

### Description
- Documenta el contrato interno en `src/pcobra/cobra/build/backend_pipeline.py` y expone solo las APIs aprobadas `resolve_backend_runtime`, `build` y `transpile`, retirando `resolve_backend` de la API pública del módulo y añadiendo `/_resolve_backend` como función interna.
- Convierte `src/pcobra/cobra/backends/resolver.py` en un shim de compatibilidad que delega en la fachada del pipeline mediante `PipelineBackendAdapter` y redirige la función `compile` a `backend_pipeline.transpile`.
- Migra llamadas directas a transpiladores desde CLI para usar la fachada: reemplaza invocaciones de `TranspiladorClass().generate_code(...)` por `backend_pipeline.transpile(...)` en `bench_transpilers_cmd.py` y `transpilar_inverso_cmd.py`.
- Actualiza consumidores de resolución para usar `resolve_backend_runtime(...)` en lugar del resolver antiguo en `compile_cmd.py` y en los comandos v2 `run_cmd.py` y `test_cmd.py` para obtener además el contexto runtime.
- Añade un ADR corto en `docs/ADR/001-backend-pipeline-facade.md` que formaliza la decisión y la regla "No usar transpilers directamente desde CLI/stdlib/imports".

### Testing
- Se ejecutó `python -m compileall` sobre los módulos modificados para verificar sintaxis y referencias, y la compilación de bytecode finalizó sin errores.
- No se añadieron tests automatizados nuevos en este cambio; la verificación fue estática (compilación) y no reportó fallos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e34223d804832786de3208986f6316)