### PR TITLE
Alinear contrato stdlib con STDLIB_BLUEPRINTS y propagar al resolver de imports

### DIFF
--- a/docs/_generated/stdlib_contract_matrix.json
+++ b/docs/_generated/stdlib_contract_matrix.json
@@ -208,7 +208,7 @@
     },
     {
       "module": "cobra.system",
-      "primary_backend": "python+rust",
+      "primary_backend": "python",
       "allowed_fallback": [
         "rust",
         "javascript"

--- a/docs/_generated/stdlib_contract_matrix.md
+++ b/docs/_generated/stdlib_contract_matrix.md
@@ -9,7 +9,7 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 | `cobra.core` | 4 | `python` | `rust, javascript` | es_finito:rust, es_finito:javascript, es_infinito:rust, es_infinito:javascript, copiar_signo:rust, copiar_signo:javascript, signo:rust, signo:javascript |
 | `cobra.datos` | 4 | `python` | `javascript` | filtrar:javascript, seleccionar_columnas:javascript, a_listas:javascript, de_listas:javascript |
 | `cobra.web` | 3 | `javascript` | `python` | obtener_url:javascript, enviar_post:javascript, descargar_archivo:javascript |
-| `cobra.system` | 4 | `python+rust` | `rust, javascript` | leer:rust, leer:javascript, escribir:rust, escribir:javascript, ejecutar:rust, ejecutar:javascript, obtener_env:rust, obtener_env:javascript |
+| `cobra.system` | 4 | `python` | `rust, javascript` | leer:rust, leer:javascript, escribir:rust, escribir:javascript, ejecutar:rust, ejecutar:javascript, obtener_env:rust, obtener_env:javascript |
 
 ## `cobra.core`
 
@@ -98,7 +98,7 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 
 ## `cobra.system`
 
-- **Backend primario:** `python+rust`
+- **Backend primario:** `python`
 - **Fallback permitido:** `rust, javascript`
 - **Mapeo `standard_library`:** `src/pcobra/standard_library/archivo.py`
 - **Mapeo `corelibs`:** `src/pcobra/corelibs/sistema.py`

--- a/docs/standard_library/matriz_stdlib_unificada.md
+++ b/docs/standard_library/matriz_stdlib_unificada.md
@@ -9,7 +9,7 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 | `cobra.core` | 4 | `python` | `rust, javascript` | es_finito:rust, es_finito:javascript, es_infinito:rust, es_infinito:javascript, copiar_signo:rust, copiar_signo:javascript, signo:rust, signo:javascript |
 | `cobra.datos` | 4 | `python` | `javascript` | filtrar:javascript, seleccionar_columnas:javascript, a_listas:javascript, de_listas:javascript |
 | `cobra.web` | 3 | `javascript` | `python` | obtener_url:javascript, enviar_post:javascript, descargar_archivo:javascript |
-| `cobra.system` | 4 | `python+rust` | `rust, javascript` | leer:rust, leer:javascript, escribir:rust, escribir:javascript, ejecutar:rust, ejecutar:javascript, obtener_env:rust, obtener_env:javascript |
+| `cobra.system` | 4 | `python` | `rust, javascript` | leer:rust, leer:javascript, escribir:rust, escribir:javascript, ejecutar:rust, ejecutar:javascript, obtener_env:rust, obtener_env:javascript |
 
 ## `cobra.core`
 
@@ -98,7 +98,7 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 
 ## `cobra.system`
 
-- **Backend primario:** `python+rust`
+- **Backend primario:** `python`
 - **Fallback permitido:** `rust, javascript`
 - **Mapeo `standard_library`:** `src/pcobra/standard_library/archivo.py`
 - **Mapeo `corelibs`:** `src/pcobra/corelibs/sistema.py`

--- a/scripts/ci/validate_stdlib_function_coverage.py
+++ b/scripts/ci/validate_stdlib_function_coverage.py
@@ -14,12 +14,14 @@ if str(SRC_ROOT) not in sys.path:
 from pcobra.cobra.stdlib_contract.validator import (  # noqa: E402
     validate_contracts,
     validate_contracts_against_runtime_matrix,
+    validate_generated_stdlib_contract_matrix,
 )
 
 
 def main() -> int:
     validate_contracts()
     validate_contracts_against_runtime_matrix()
+    validate_generated_stdlib_contract_matrix()
     print("✅ Stdlib coverage by function valida contra runtime_api_matrix")
     return 0
 

--- a/scripts/validate_runtime_contract.py
+++ b/scripts/validate_runtime_contract.py
@@ -23,6 +23,7 @@ from pcobra.cobra.cli.target_policies import (
 )
 from pcobra.cobra.stdlib_contract.validator import validate_contracts
 from pcobra.cobra.stdlib_contract.validator import validate_contracts_against_runtime_matrix
+from pcobra.cobra.stdlib_contract.validator import validate_generated_stdlib_contract_matrix
 from pcobra.cobra.transpilers.compatibility_matrix import (
     BACKEND_COMPATIBILITY,
     BACKEND_FEATURE_GAPS,
@@ -34,6 +35,7 @@ def main() -> int:
     validate_runtime_support_contract()
     validate_contracts()
     validate_contracts_against_runtime_matrix()
+    validate_generated_stdlib_contract_matrix()
 
     for backend in OFFICIAL_RUNTIME_TARGETS:
         contract = BACKEND_COMPATIBILITY[backend]

--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -11,8 +11,8 @@ from types import ModuleType
 from typing import Any, Mapping
 
 from pcobra.cobra.backends.resolver import resolve_backend
+from pcobra.cobra.stdlib_contract import get_public_stdlib_module_contracts
 from pcobra.cobra.transpilers.module_map import (
-    get_stdlib_contracts,
     get_toml_map,
     resolve_backend_for_module,
 )
@@ -149,9 +149,9 @@ class CobraImportResolver:
         return normalized
 
     @staticmethod
-    def _load_stdlib_modules() -> set[str]:
-        contracts = get_stdlib_contracts()
-        return {name for name in contracts if name.startswith("cobra.")}
+    def _load_stdlib_modules() -> dict[str, dict[str, object]]:
+        contracts = get_public_stdlib_module_contracts()
+        return {name: metadata for name, metadata in contracts.items() if name.startswith("cobra.")}
 
     @staticmethod
     def _load_project_modules() -> set[str]:
@@ -312,22 +312,34 @@ class CobraImportResolver:
 
     def _resolve_stdlib_module(self, name: str) -> ResolutionResult | None:
         if name.startswith("cobra."):
-            if name in self.stdlib_modules:
+            metadata = self.stdlib_modules.get(name)
+            if metadata is not None:
                 return ResolutionResult(
                     request=name,
                     source="stdlib",
                     resolved_name=name,
                     import_path=self._cobra_stdlib_to_python(name),
+                    backend=(
+                        str(metadata["backend_preferido"])
+                        if isinstance(metadata.get("backend_preferido"), str)
+                        else None
+                    ),
                 )
             return None
 
         qualified = f"cobra.{name}"
-        if qualified in self.stdlib_modules:
+        metadata = self.stdlib_modules.get(qualified)
+        if metadata is not None:
             return ResolutionResult(
                 request=name,
                 source="stdlib",
                 resolved_name=qualified,
                 import_path=self._cobra_stdlib_to_python(qualified),
+                backend=(
+                    str(metadata["backend_preferido"])
+                    if isinstance(metadata.get("backend_preferido"), str)
+                    else None
+                ),
             )
         return None
 

--- a/src/pcobra/cobra/stdlib_contract/__init__.py
+++ b/src/pcobra/cobra/stdlib_contract/__init__.py
@@ -1,5 +1,8 @@
 """Contrato declarativo de módulos públicos de la stdlib Cobra."""
 
+import ast
+from pathlib import Path
+
 from pcobra.cobra.stdlib_contract.base import ContractDescriptor
 from pcobra.cobra.stdlib_contract.core import CORE_CONTRACT
 from pcobra.cobra.stdlib_contract.datos import DATOS_CONTRACT
@@ -12,6 +15,99 @@ CONTRACTS: tuple[ContractDescriptor, ...] = (
     WEB_CONTRACT,
     SYSTEM_CONTRACT,
 )
+
+
+def _parse_literal_tuple(node: ast.AST) -> tuple[str, ...]:
+    if not isinstance(node, (ast.Tuple, ast.List)):
+        raise RuntimeError("Estructura inválida en STDLIB_BLUEPRINTS: se esperaba tupla/lista")
+    values: list[str] = []
+    for item in node.elts:
+        if not isinstance(item, ast.Constant) or not isinstance(item.value, str):
+            raise RuntimeError("STDLIB_BLUEPRINTS contiene valores no literales")
+        values.append(item.value)
+    return tuple(values)
+
+
+def _load_stdlib_blueprints() -> tuple[dict[str, object], ...]:
+    module_path = Path(__file__).resolve().parents[1] / "architecture" / "unified_ecosystem.py"
+    source = module_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(module_path))
+    blueprints: list[dict[str, object]] = []
+    for node in ast.walk(tree):
+        value_node: ast.AST | None = None
+        if isinstance(node, ast.Assign):
+            has_target = any(
+                isinstance(target, ast.Name) and target.id == "STDLIB_BLUEPRINTS"
+                for target in node.targets
+            )
+            if has_target:
+                value_node = node.value
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name) and node.target.id == "STDLIB_BLUEPRINTS":
+                value_node = node.value
+
+        if not isinstance(value_node, (ast.Tuple, ast.List)):
+            continue
+
+        for item in value_node.elts:
+            if not isinstance(item, ast.Call):
+                continue
+            keywords = {kw.arg: kw.value for kw in item.keywords if kw.arg}
+            module_node = keywords.get("module")
+            primary_node = keywords.get("primary_backend")
+            rationale_node = keywords.get("rationale")
+            api_node = keywords.get("api_contract")
+            fallback_node = keywords.get("fallback_backends")
+            if not (
+                isinstance(module_node, ast.Constant)
+                and isinstance(module_node.value, str)
+                and isinstance(primary_node, ast.Constant)
+                and isinstance(primary_node.value, str)
+                and isinstance(rationale_node, ast.Constant)
+                and isinstance(rationale_node.value, str)
+                and api_node is not None
+                and fallback_node is not None
+            ):
+                raise RuntimeError("STDLIB_BLUEPRINTS contiene campos no literales")
+            blueprints.append(
+                {
+                    "module": module_node.value,
+                    "primary_backend": primary_node.value,
+                    "api_contract": _parse_literal_tuple(api_node),
+                    "fallback_backends": _parse_literal_tuple(fallback_node),
+                    "rationale": rationale_node.value,
+                }
+            )
+    if not blueprints:
+        raise RuntimeError("No se pudo extraer STDLIB_BLUEPRINTS de unified_ecosystem.py")
+    return blueprints
+
+
+def get_blueprint_contract_manifests() -> dict[str, dict[str, object]]:
+    """Devuelve manifiestos de módulos públicos desde ``STDLIB_BLUEPRINTS``."""
+    blueprints = _load_stdlib_blueprints()
+    return {
+        str(blueprint["module"]): {
+            "backend_preferido": str(blueprint["primary_backend"]),
+            "fallback_permitido": list(blueprint["fallback_backends"]),
+            "capacidades": list(blueprint["api_contract"]),
+            "rationale": str(blueprint["rationale"]),
+        }
+        for blueprint in blueprints
+    }
+
+
+def get_public_stdlib_module_contracts() -> dict[str, dict[str, object]]:
+    """Expone el contrato mínimo para resolver módulos públicos ``cobra.*``."""
+    manifests = get_blueprint_contract_manifests()
+    return {
+        module: {
+            "backend_preferido": manifest["backend_preferido"],
+            "fallback_permitido": manifest["fallback_permitido"],
+            "capacidades": manifest["capacidades"],
+        }
+        for module, manifest in manifests.items()
+    }
 
 
 def get_contract_manifests() -> dict[str, dict[str, object]]:
@@ -55,6 +151,8 @@ def get_contract_matrix() -> dict[str, object]:
 __all__ = [
     "CONTRACTS",
     "ContractDescriptor",
+    "get_blueprint_contract_manifests",
     "get_contract_manifests",
     "get_contract_matrix",
+    "get_public_stdlib_module_contracts",
 ]

--- a/src/pcobra/cobra/stdlib_contract/cobra.system
+++ b/src/pcobra/cobra/stdlib_contract/cobra.system
@@ -1,3 +1,3 @@
 public_api = ["cobra.system.leer", "cobra.system.escribir", "cobra.system.ejecutar", "cobra.system.obtener_env"]
-backend_preferido = "python+rust"
+backend_preferido = "python"
 fallback_permitido = ["rust", "javascript"]

--- a/src/pcobra/cobra/stdlib_contract/system.py
+++ b/src/pcobra/cobra/stdlib_contract/system.py
@@ -11,7 +11,7 @@ SYSTEM_CONTRACT = ContractDescriptor(
         "cobra.system.ejecutar",
         "cobra.system.obtener_env",
     ),
-    primary_backend="python+rust",
+    primary_backend="python",
     allowed_fallback=("rust", "javascript"),
     runtime_mapping=RuntimeMapping(
         standard_library=("src/pcobra/standard_library/archivo.py",),

--- a/src/pcobra/cobra/stdlib_contract/validator.py
+++ b/src/pcobra/cobra/stdlib_contract/validator.py
@@ -8,17 +8,24 @@ import re
 from pathlib import Path
 from typing import Final
 
-from pcobra.cobra.stdlib_contract import CONTRACTS
+from pcobra.cobra.stdlib_contract import CONTRACTS, get_blueprint_contract_manifests
 from pcobra.cobra.stdlib_contract.base import ContractDescriptor
+from pcobra.cobra.stdlib_contract.generator import build_contract_matrix, render_contract_markdown
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[4]
 VALID_LEVELS: Final[set[str]] = {"full", "partial"}
 RUNTIME_API_MATRIX_PATH: Final[Path] = REPO_ROOT / "docs" / "_generated" / "runtime_api_matrix.json"
+STDLIB_CONTRACT_MATRIX_JSON_PATH: Final[Path] = (
+    REPO_ROOT / "docs" / "_generated" / "stdlib_contract_matrix.json"
+)
+STDLIB_CONTRACT_MATRIX_MD_PATH: Final[Path] = (
+    REPO_ROOT / "docs" / "_generated" / "stdlib_contract_matrix.md"
+)
 PRIMARY_BACKEND_POLICY: Final[dict[str, tuple[str, ...]]] = {
     "cobra.core": ("python",),
     "cobra.datos": ("python",),
     "cobra.web": ("javascript",),
-    "cobra.system": ("python", "rust"),
+    "cobra.system": ("python",),
 }
 
 
@@ -198,6 +205,39 @@ def validate_contract_descriptor(contract: ContractDescriptor) -> None:
     _validate_primary_backend_policy(contract)
 
 
+def validate_contracts_against_blueprints() -> None:
+    """Valida consistencia del contrato stdlib con ``STDLIB_BLUEPRINTS``."""
+    contract_by_module = {contract.module: contract for contract in CONTRACTS}
+    blueprint_by_module = get_blueprint_contract_manifests()
+
+    contract_modules = set(contract_by_module)
+    blueprint_modules = set(blueprint_by_module)
+    if contract_modules != blueprint_modules:
+        raise ContractValidationError(
+            "Módulos públicos inconsistentes entre contrato y STDLIB_BLUEPRINTS. "
+            f"solo_contrato={sorted(contract_modules - blueprint_modules)} "
+            f"solo_blueprint={sorted(blueprint_modules - contract_modules)}"
+        )
+
+    for module in sorted(contract_modules):
+        contract = contract_by_module[module]
+        blueprint = blueprint_by_module[module]
+
+        primary_backend = blueprint.get("backend_preferido")
+        if contract.primary_backend != primary_backend:
+            raise ContractValidationError(
+                f"{module}: primary_backend inconsistente con STDLIB_BLUEPRINTS. "
+                f"contract={contract.primary_backend} blueprint={primary_backend}"
+            )
+
+        fallback_backends = tuple(blueprint.get("fallback_permitido", []))
+        if contract.allowed_fallback != fallback_backends:
+            raise ContractValidationError(
+                f"{module}: fallbacks inconsistentes con STDLIB_BLUEPRINTS. "
+                f"contract={contract.allowed_fallback} blueprint={fallback_backends}"
+            )
+
+
 def validate_contracts() -> None:
     """Valida todos los contratos de stdlib definidos en el proyecto."""
 
@@ -207,9 +247,37 @@ def validate_contracts() -> None:
             raise ContractValidationError(f"Módulo duplicado en contrato: {contract.module}")
         modules_seen.add(contract.module)
         validate_contract_descriptor(contract)
+    validate_contracts_against_blueprints()
 
 
 def validate_contracts_against_runtime_matrix() -> None:
     """Valida cobertura full/partial por función contra `runtime_api_matrix`."""
     for contract in CONTRACTS:
         validate_coverage_against_runtime_matrix(contract)
+
+
+def validate_generated_stdlib_contract_matrix() -> None:
+    """Valida consistencia entre contrato vivo y docs generadas de stdlib."""
+    expected_json = build_contract_matrix()
+    try:
+        rendered_json = json.loads(STDLIB_CONTRACT_MATRIX_JSON_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ContractValidationError(
+            "No existe stdlib_contract_matrix.json generado en docs/_generated"
+        ) from exc
+    if rendered_json != expected_json:
+        raise ContractValidationError(
+            "docs/_generated/stdlib_contract_matrix.json está desactualizado respecto al contrato."
+        )
+
+    expected_md = render_contract_markdown().strip()
+    try:
+        rendered_md = STDLIB_CONTRACT_MATRIX_MD_PATH.read_text(encoding="utf-8").strip()
+    except FileNotFoundError as exc:
+        raise ContractValidationError(
+            "No existe stdlib_contract_matrix.md generado en docs/_generated"
+        ) from exc
+    if rendered_md != expected_md:
+        raise ContractValidationError(
+            "docs/_generated/stdlib_contract_matrix.md está desactualizado respecto al contrato."
+        )

--- a/tests/unit/test_imports_resolver.py
+++ b/tests/unit/test_imports_resolver.py
@@ -279,6 +279,16 @@ def test_resolver_adjunta_adapter_desde_resolucion():
     assert result.precedence_reason == "unique_source:python_bridge"
 
 
+def test_resolver_usa_contrato_publico_para_backend_stdlib():
+    resolver = CobraImportResolver()
+
+    result = resolver.resolve("cobra.web")
+
+    assert result.source == "stdlib"
+    assert result.backend == "javascript"
+    assert result.backend_adapter is not None
+
+
 def test_motivo_precedencia_en_colision(tmp_path):
     (tmp_path / "datos.co").write_text("usar algo")
     resolver = CobraImportResolver(project_root=tmp_path)

--- a/tests/unit/test_stdlib_contract_descriptor.py
+++ b/tests/unit/test_stdlib_contract_descriptor.py
@@ -1,4 +1,9 @@
-from pcobra.cobra.stdlib_contract import CONTRACTS, get_contract_manifests
+from pcobra.cobra.stdlib_contract import (
+    CONTRACTS,
+    get_blueprint_contract_manifests,
+    get_contract_manifests,
+    get_public_stdlib_module_contracts,
+)
 from pcobra.cobra.stdlib_contract.generator import render_contract_markdown
 
 
@@ -21,3 +26,19 @@ def test_markdown_generado_incluye_tabla_cobertura_por_funcion():
     for descriptor in CONTRACTS:
         assert f"| `{descriptor.module}` |" in markdown
         assert f"## `{descriptor.module}`" in markdown
+
+
+def test_manifest_blueprint_toma_stdlib_blueprints_como_fuente_de_verdad():
+    manifests = get_blueprint_contract_manifests()
+    public_contract = get_public_stdlib_module_contracts()
+
+    modules_from_blueprint = set(manifests)
+    assert set(manifests) == modules_from_blueprint
+    assert set(public_contract) == modules_from_blueprint
+
+    for module in modules_from_blueprint:
+        manifest = manifests[module]
+        public_manifest = public_contract[module]
+        assert public_manifest["backend_preferido"] == manifest["backend_preferido"]
+        assert public_manifest["fallback_permitido"] == manifest["fallback_permitido"]
+        assert public_manifest["capacidades"] == manifest["capacidades"]

--- a/tests/unit/test_stdlib_contract_validator.py
+++ b/tests/unit/test_stdlib_contract_validator.py
@@ -4,6 +4,7 @@ from pcobra.cobra.stdlib_contract import CONTRACTS, get_contract_matrix
 from pcobra.cobra.stdlib_contract.validator import (
     validate_contracts,
     validate_contracts_against_runtime_matrix,
+    validate_generated_stdlib_contract_matrix,
 )
 
 
@@ -13,6 +14,10 @@ def test_stdlib_contracts_validate() -> None:
 
 def test_stdlib_contracts_validate_against_runtime_matrix() -> None:
     validate_contracts_against_runtime_matrix()
+
+
+def test_stdlib_contracts_validate_against_generated_docs() -> None:
+    validate_generated_stdlib_contract_matrix()
 
 
 def test_stdlib_matrix_contains_all_contract_modules() -> None:


### PR DESCRIPTION
### Motivation
- Usar `STDLIB_BLUEPRINTS` en `unified_ecosystem.py` como fuente de verdad para los módulos públicos `cobra.core`, `cobra.datos`, `cobra.web` y `cobra.system` y exponer esa información sin alterar la implementación runtime existente.
- Proveer una capa descriptor/manifest que ofrezca backend primario, fallbacks y capacidades para consumo por el import resolver y herramientas de generación de artefactos.
- Asegurar que la resolución de imports (`cobra.*`) y la documentación autogenerada permanezcan consistentes con el contrato declarado.

### Description
- Se añadió extracción segura de `STDLIB_BLUEPRINTS` mediante parsing AST de `src/pcobra/cobra/architecture/unified_ecosystem.py` y nuevas APIs en `src/pcobra/cobra/stdlib_contract/__init__.py`: `get_blueprint_contract_manifests()` y `get_public_stdlib_module_contracts()` para exponer manifiestos públicos sin provocar import cycles. 
- `CobraImportResolver` fue conectado al contrato público mediante `get_public_stdlib_module_contracts()` y ahora incluye el `backend` primario en el `ResolutionResult` cuando resuelve rutas `cobra.*` (`src/pcobra/cobra/imports/resolver.py`).
- Se añadieron validaciones de consistencia en `src/pcobra/cobra/stdlib_contract/validator.py`: `validate_contracts_against_blueprints()` y `validate_generated_stdlib_contract_matrix()` para comprobar contrato vs blueprints y contrato vs `docs/_generated/stdlib_contract_matrix.{json,md}` respectivamente, y se integraron esas validaciones en los scripts de verificación (`scripts/ci/validate_stdlib_function_coverage.py` y `scripts/validate_runtime_contract.py`).
- Se alineó `cobra.system` para declarar `primary_backend="python"` (antes `python+rust`) y se regeneraron los artefactos de matriz/documentación en `docs/_generated/` y `docs/standard_library/` para reflejar el cambio; además se actualizaron tests que verifican la nueva integración y contratos.

### Testing
- Se regeneró el contrato y la documentación con `python scripts/generar_contrato_stdlib.py` y la generación finalizó correctamente (salida sin errores). 
- Se ejecutaron unit tests relevantes con `pytest tests/unit/test_stdlib_contract_descriptor.py tests/unit/test_stdlib_contract_validator.py` y ambos pasaron (`7 passed`).
- Se ejecutó `python scripts/ci/validate_stdlib_function_coverage.py` y `python scripts/validate_runtime_contract.py` y ambos scripts finalizaron correctamente y devolvieron validaciones OK.
- `pytest tests/unit/test_imports_resolver.py` no se pudo ejecutar completamente en este entorno porque la colección falló por un `ImportError` preexistente al intentar importar `pcobra.cobra.build.backend_pipeline` (problema fuera del alcance de estos cambios).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e34a6898f083278d3509ebd22ddf11)