### PR TITLE
Endurecer gestión de colisiones de imports y añadir pruebas para casos namespaced

### DIFF
--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -46,7 +46,7 @@ class ResolutionResult:
 
 API_CONTRACT_VERSION = "2026-04-import-resolution-v1"
 RESOLUTION_SOURCE_ORDER: tuple[str, ...] = ("stdlib", "project", "python_bridge", "hybrid")
-DEFAULT_COLLISION_POLICY = "warn"
+DEFAULT_COLLISION_POLICY = "namespace_required"
 # Backward-compatible alias (internal histórico).
 _SOURCE_ORDER: tuple[str, ...] = RESOLUTION_SOURCE_ORDER
 _SUPPORTED_COLLISION_POLICIES: frozenset[str] = frozenset(
@@ -112,7 +112,10 @@ class CobraImportResolver:
             return "strict_error"
 
         configured_policy = CobraImportResolver._collision_policy_from_config(config)
-        chosen = explicit_policy or configured_policy or DEFAULT_COLLISION_POLICY
+        migration_policy = (
+            "warn" if CobraImportResolver._is_migration_mode_enabled(config) else None
+        )
+        chosen = explicit_policy or configured_policy or migration_policy or DEFAULT_COLLISION_POLICY
         if chosen not in _SUPPORTED_COLLISION_POLICIES:
             raise ImportResolutionError(
                 "Política de colisiones inválida. "
@@ -129,6 +132,14 @@ class CobraImportResolver:
         if isinstance(policy, str):
             return policy.strip()
         return None
+
+    @staticmethod
+    def _is_migration_mode_enabled(config: Mapping[str, Any]) -> bool:
+        imports_section = config.get("imports", {})
+        if not isinstance(imports_section, Mapping):
+            return False
+        migration_mode = imports_section.get("migration_mode")
+        return migration_mode is True
 
     @staticmethod
     def _normalize_hybrid_modules(
@@ -190,8 +201,9 @@ class CobraImportResolver:
                 f"({RESOLUTION_SOURCE_ORDER[0]} > {RESOLUTION_SOURCE_ORDER[1]} > "
                 f"{RESOLUTION_SOURCE_ORDER[2]} > {RESOLUTION_SOURCE_ORDER[3]}). "
                 f"Seleccionado: {candidates[0].resolved_name}. Candidatos: {details}. "
-                f"Recomendación: usa prefijo explícito ('cobra.{name}') para stdlib o namespace de proyecto "
-                f"(por ejemplo 'app.{name}')."
+                f"Conflicto potencial: comando/import corto como 'importar {name}' puede colisionar "
+                f"con módulo local '{name}'. Recomendación explícita: usa 'cobra.{name}' para stdlib "
+                f"o 'app.{name}' para módulo de proyecto."
             )
             if self.collision_policy in {"strict_error", "namespace_required"}:
                 suffix = (

--- a/tests/unit/test_imports_resolver.py
+++ b/tests/unit/test_imports_resolver.py
@@ -13,7 +13,7 @@ from pcobra.cobra.imports.resolver import (
 
 def test_resuelve_stdlib_antes_que_modulo_proyecto(tmp_path):
     (tmp_path / "datos.co").write_text("usar algo")
-    resolver = CobraImportResolver(project_root=tmp_path)
+    resolver = CobraImportResolver(project_root=tmp_path, collision_policy="warn")
 
     with pytest.warns(UserWarning, match="Colisión de import"):
         result = resolver.resolve("datos")
@@ -23,7 +23,7 @@ def test_resuelve_stdlib_antes_que_modulo_proyecto(tmp_path):
 
 
 def test_prefiere_namespace_explicito_cobra_datos():
-    resolver = CobraImportResolver()
+    resolver = CobraImportResolver(collision_policy="warn")
 
     result = resolver.resolve("cobra.datos")
 
@@ -56,7 +56,7 @@ def test_colision_stdlib_vs_bridge_genera_warning(monkeypatch):
 
 def test_colision_stdlib_proyecto_y_bridge_respeta_orden(monkeypatch, tmp_path):
     (tmp_path / "datos.co").write_text("usar algo")
-    resolver = CobraImportResolver(project_root=tmp_path)
+    resolver = CobraImportResolver(project_root=tmp_path, collision_policy="warn")
 
     import importlib.util
 
@@ -197,7 +197,7 @@ def test_modulo_hibrido_inyecta_adapter_backend(monkeypatch):
     assert getattr(module, "__cobra_resolution_metadata__") == {
         "api_contract_version": "2026-04-import-resolution-v1",
         "resolution_source_order": ["stdlib", "project", "python_bridge", "hybrid"],
-        "collision_policy": "warn",
+        "collision_policy": "namespace_required",
         "request": "mi_hibrido",
         "source": "hybrid",
         "resolved_name": "mi_hibrido",
@@ -252,7 +252,7 @@ def test_metadata_uniforme_en_ruta_stdlib():
     assert metadata["source"] == "stdlib"
     assert metadata["api_contract_version"] == "2026-04-import-resolution-v1"
     assert metadata["resolution_source_order"] == ["stdlib", "project", "python_bridge", "hybrid"]
-    assert metadata["collision_policy"] == "warn"
+    assert metadata["collision_policy"] == "namespace_required"
 
 
 def test_metadata_uniforme_en_ruta_python_bridge():
@@ -266,7 +266,7 @@ def test_metadata_uniforme_en_ruta_python_bridge():
     assert metadata["source"] == "python_bridge"
     assert metadata["api_contract_version"] == "2026-04-import-resolution-v1"
     assert metadata["resolution_source_order"] == ["stdlib", "project", "python_bridge", "hybrid"]
-    assert metadata["collision_policy"] == "warn"
+    assert metadata["collision_policy"] == "namespace_required"
 
 
 def test_resolver_adjunta_adapter_desde_resolucion():
@@ -289,9 +289,59 @@ def test_resolver_usa_contrato_publico_para_backend_stdlib():
     assert result.backend_adapter is not None
 
 
-def test_motivo_precedencia_en_colision(tmp_path):
+def test_modo_migracion_habilita_warn_desde_config(monkeypatch, tmp_path):
+    (tmp_path / "datos.co").write_text("usar algo")
+    monkeypatch.setattr(
+        "pcobra.cobra.imports.resolver.get_toml_map",
+        lambda: {"imports": {"migration_mode": True}},
+    )
+    resolver = CobraImportResolver(project_root=tmp_path)
+
+    with pytest.warns(UserWarning, match="Colisión de import"):
+        result = resolver.resolve("datos")
+
+    assert result.source == "stdlib"
+    assert resolver.collision_policy == "warn"
+
+
+def test_colision_short_import_namespace_required_incluye_recomendacion(tmp_path):
     (tmp_path / "datos.co").write_text("usar algo")
     resolver = CobraImportResolver(project_root=tmp_path)
+
+    with pytest.raises(ImportResolutionError) as excinfo:
+        resolver.resolve("datos")
+
+    message = str(excinfo.value)
+    assert "cobra.datos" in message
+    assert "app.datos" in message
+    assert "importar datos" in message
+
+
+def test_import_namespaced_no_colision_con_modulo_local(tmp_path):
+    app_dir = tmp_path / "app"
+    app_dir.mkdir()
+    (app_dir / "datos.co").write_text("usar algo")
+    resolver = CobraImportResolver(project_root=tmp_path)
+
+    stdlib_result = resolver.resolve("cobra.datos")
+    project_result = resolver.resolve("app.datos")
+
+    assert stdlib_result.source == "stdlib"
+    assert project_result.source == "project"
+
+
+def test_load_module_inyecta_backend_adapter_en_ruta_namespaced_stdlib():
+    resolver = CobraImportResolver()
+
+    _, module = resolver.load_module("cobra.datos")
+
+    assert module is not None
+    assert getattr(module, "__cobra_backend_adapter__", None) is not None
+
+
+def test_motivo_precedencia_en_colision(tmp_path):
+    (tmp_path / "datos.co").write_text("usar algo")
+    resolver = CobraImportResolver(project_root=tmp_path, collision_policy="warn")
 
     with pytest.warns(UserWarning, match="Colisión de import"):
         result = resolver.resolve("datos")


### PR DESCRIPTION
### Motivation
- Evitar ambigüedades en producción forzando imports namespaced cuando hay colisiones entre stdlib y módulos locales. 
- Permitir un modo de migración controlado por configuración que mantenga el comportamiento `warn` durante transiciones. 
- Hacer los mensajes de conflicto más accionables para desarrolladores (p. ej. conflicto entre `importar datos` y un módulo local `datos`).

### Description
- Cambia el valor por defecto de la política de colisiones a `namespace_required` en `src/pcobra/cobra/imports/resolver.py` y mantiene el orden de resolución `stdlib > project > python_bridge > hybrid`.
- Introduce la detección de modo migración por configuración `imports.migration_mode` y usa `warn` únicamente cuando este modo está activado, respetando siempre una `collision_policy` explícita o `strict_ambiguous_imports`.
- Formaliza el mensaje de colisión para imports cortos para mencionar explícitamente la posibilidad de choque con comandos tipo `importar <modulo>` y recomienda `cobra.<modulo>` o `app.<modulo>`.
- Añade y actualiza tests en `tests/unit/test_imports_resolver.py` para cubrir: migración (`migration_mode`) que habilita `warn`, colisión en imports cortos que incluye la recomendación, resolución namespaced (`cobra.datos` vs `app.datos`) sin ambigüedad, y verificación de inyección de `__cobra_backend_adapter__` en rutas namespaced de la stdlib; además se actualizan expectativas de metadata al nuevo default `namespace_required`.

### Testing
- Ejecuté `pytest -q tests/unit/test_imports_resolver.py` para validar las pruebas nuevas/actualizadas y la ejecución falló en la fase de colección por un `ImportError` preexistente (no relacionado con estos cambios): `cannot import name 'resolve_backend' from pcobra.cobra.build.backend_pipeline`.
- Los cambios en tests reflejan las nuevas expectativas (metadata y comportamiento en modo migración) y están incluidos en la rama para cuando se resuelva el error de importación externo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e34d9aa1b483278257d4df892fc2f9)