### PR TITLE
Enforce official public binding routes and internal-only bridge policy

### DIFF
--- a/bindings/contract.py
+++ b/bindings/contract.py
@@ -15,6 +15,15 @@ class BindingRoute(str, Enum):
     RUST_COMPILED_FFI = "rust_compiled_ffi"
 
 
+OFFICIAL_PUBLIC_LANGUAGES: Final[tuple[str, ...]] = ("python", "javascript", "rust")
+
+OFFICIAL_PUBLIC_ROUTE_MATRIX: Final[dict[str, BindingRoute]] = {
+    "python": BindingRoute.PYTHON_DIRECT_IMPORT,
+    "javascript": BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE,
+    "rust": BindingRoute.RUST_COMPILED_FFI,
+}
+
+
 @dataclass(frozen=True, slots=True)
 class BindingCapabilities:
     """Describe capacidades y restricciones contractuales por ruta."""
@@ -126,7 +135,7 @@ ROUTE_OPERATIONAL_LIMITS: Final[dict[BindingRoute, RouteOperationalLimits]] = {
 def resolve_binding(language: str) -> BindingCapabilities:
     """Resuelve el contrato de bindings para un lenguaje canónico."""
 
-    key = (language or "").strip().lower()
+    key = validate_public_language(language)
     try:
         return BINDINGS_BY_LANGUAGE[key]
     except KeyError as exc:
@@ -136,16 +145,47 @@ def resolve_binding(language: str) -> BindingCapabilities:
         ) from exc
 
 
+def validate_public_language(language: str) -> str:
+    """Valida temprano que el lenguaje pertenezca a la superficie pública oficial."""
+
+    key = (language or "").strip().lower()
+    if key in OFFICIAL_PUBLIC_LANGUAGES:
+        return key
+
+    raise ValueError(
+        "Lenguaje no permitido en rutas públicas de bindings: "
+        f"'{language}'. Lenguajes oficiales: {', '.join(OFFICIAL_PUBLIC_LANGUAGES)}."
+    )
+
+
+def route_matrix_markdown() -> str:
+    """Documenta la matriz oficial de rutas públicas de bindings."""
+
+    return "\n".join(
+        (
+            "| Lenguaje | Ruta oficial |", 
+            "| --- | --- |",
+            "| Python | direct import bridge |",
+            "| JavaScript | runtime bridge |",
+            "| Rust | compiled FFI |",
+        )
+    )
+
+
 __all__ = [
     "AbiCompatibilityPolicy",
     "BindingCapabilities",
     "BindingRoute",
     "BINDINGS_BY_LANGUAGE",
+    "OFFICIAL_PUBLIC_LANGUAGES",
+    "OFFICIAL_PUBLIC_ROUTE_MATRIX",
     "ABI_POLICY_BY_ROUTE",
     "ROUTE_OPERATIONAL_LIMITS",
     "RouteOperationalLimits",
     "JAVASCRIPT_BINDING",
     "PYTHON_BINDING",
     "RUST_BINDING",
+    "route_matrix_markdown",
+    "validate_public_language",
     "resolve_binding",
 ]

--- a/src/pcobra/cobra/bindings/contract.py
+++ b/src/pcobra/cobra/bindings/contract.py
@@ -6,6 +6,8 @@ Fuente canónica: ``bindings/contract.py``.
 from bindings.contract import (  # re-export canónico
     ABI_POLICY_BY_ROUTE,
     BINDINGS_BY_LANGUAGE,
+    OFFICIAL_PUBLIC_LANGUAGES,
+    OFFICIAL_PUBLIC_ROUTE_MATRIX,
     ROUTE_OPERATIONAL_LIMITS,
     AbiCompatibilityPolicy,
     BindingCapabilities,
@@ -13,6 +15,8 @@ from bindings.contract import (  # re-export canónico
     JAVASCRIPT_BINDING,
     PYTHON_BINDING,
     RUST_BINDING,
+    route_matrix_markdown,
+    validate_public_language,
     resolve_binding,
 )
 
@@ -21,10 +25,14 @@ __all__ = [
     "BindingCapabilities",
     "BindingRoute",
     "BINDINGS_BY_LANGUAGE",
+    "OFFICIAL_PUBLIC_LANGUAGES",
+    "OFFICIAL_PUBLIC_ROUTE_MATRIX",
     "ABI_POLICY_BY_ROUTE",
     "ROUTE_OPERATIONAL_LIMITS",
     "PYTHON_BINDING",
     "JAVASCRIPT_BINDING",
     "RUST_BINDING",
+    "route_matrix_markdown",
+    "validate_public_language",
     "resolve_binding",
 ]

--- a/src/pcobra/cobra/bindings/runtime_manager.py
+++ b/src/pcobra/cobra/bindings/runtime_manager.py
@@ -14,9 +14,12 @@ except ModuleNotFoundError:  # pragma: no cover
 
 from pcobra.cobra.bindings.contract import (
     ABI_POLICY_BY_ROUTE,
+    BINDINGS_BY_LANGUAGE,
+    OFFICIAL_PUBLIC_ROUTE_MATRIX,
     BindingCapabilities,
     BindingRoute,
     resolve_binding,
+    validate_public_language,
 )
 
 DEFAULT_ABI_VERSION: Final[str] = "1.0"
@@ -48,6 +51,7 @@ class RuntimeBridgeDescriptor:
     implementation: str
     security_profile: str
     abi_version: str
+    internal_only: bool = True
 
 
 class RuntimeManager:
@@ -65,20 +69,26 @@ class RuntimeManager:
             implementation="python_direct_bridge",
             security_profile="same_process_safe_mode",
             abi_version=ABI_POLICY_BY_ROUTE[BindingRoute.PYTHON_DIRECT_IMPORT].current,
+            internal_only=False,
         ),
         BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE: RuntimeBridgeDescriptor(
             route=BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE,
             implementation="javascript_controlled_runtime_bridge",
             security_profile="managed_runtime_isolation",
             abi_version=ABI_POLICY_BY_ROUTE[BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE].current,
+            internal_only=False,
         ),
         BindingRoute.RUST_COMPILED_FFI: RuntimeBridgeDescriptor(
             route=BindingRoute.RUST_COMPILED_FFI,
             implementation="rust_compiled_ffi_bridge",
             security_profile="native_ffi_boundary",
             abi_version=ABI_POLICY_BY_ROUTE[BindingRoute.RUST_COMPILED_FFI].current,
+            internal_only=False,
         ),
     }
+
+    def __init__(self) -> None:
+        self._validate_public_contracts()
 
     def resolve_runtime(self, language: str) -> tuple[BindingCapabilities, RuntimeBridgeDescriptor]:
         """Resuelve contrato, negocia ABI y retorna bridge asociado."""
@@ -89,6 +99,7 @@ class RuntimeManager:
         return capabilities, bridge
 
     def _resolve_capabilities(self, language: str) -> BindingCapabilities:
+        validate_public_language(language)
         return resolve_binding(language)
 
     def validate_security_route(
@@ -192,6 +203,39 @@ class RuntimeManager:
         """Selecciona la implementación de bridge para una ruta contractual."""
 
         return self._BRIDGES[capabilities.route]
+
+    @classmethod
+    def _validate_public_contracts(cls) -> None:
+        expected_languages = set(OFFICIAL_PUBLIC_ROUTE_MATRIX)
+        binding_languages = set(BINDINGS_BY_LANGUAGE)
+        if binding_languages != expected_languages:
+            extras = sorted(binding_languages - expected_languages)
+            missing = sorted(expected_languages - binding_languages)
+            raise RuntimeError(
+                "Contrato de bindings públicos inválido. "
+                f"missing={missing or '∅'}; extras={extras or '∅'}"
+            )
+
+        for language, route in OFFICIAL_PUBLIC_ROUTE_MATRIX.items():
+            capabilities = BINDINGS_BY_LANGUAGE[language]
+            if capabilities.route is not route:
+                raise RuntimeError(
+                    "Matriz oficial inconsistente entre lenguaje y ruta. "
+                    f"language={language}; expected={route.value}; got={capabilities.route.value}"
+                )
+
+        for route, descriptor in cls._BRIDGES.items():
+            if route in OFFICIAL_PUBLIC_ROUTE_MATRIX.values():
+                if descriptor.internal_only:
+                    raise RuntimeError(
+                        f"Bridge oficial '{descriptor.implementation}' no puede ser internal_only."
+                    )
+                continue
+            if not descriptor.internal_only:
+                raise RuntimeError(
+                    "Bridge no oficial expuesto sin bandera internal_only. "
+                    f"route={route.value}; implementation={descriptor.implementation}"
+                )
 
     def _raise_route_error(self, route: BindingRoute, detail: str) -> None:
         route_label = self._ROUTE_LABEL_BY_ROUTE[route]

--- a/tests/unit/test_bindings_contract.py
+++ b/tests/unit/test_bindings_contract.py
@@ -1,7 +1,12 @@
 from pcobra.cobra.bindings.contract import (
     ABI_POLICY_BY_ROUTE,
+    BINDINGS_BY_LANGUAGE,
+    OFFICIAL_PUBLIC_LANGUAGES,
+    OFFICIAL_PUBLIC_ROUTE_MATRIX,
     ROUTE_OPERATIONAL_LIMITS,
     BindingRoute,
+    route_matrix_markdown,
+    validate_public_language,
     resolve_binding,
 )
 
@@ -16,7 +21,7 @@ def test_resolve_binding_falla_en_backend_no_soportado():
     try:
         resolve_binding("go")
     except ValueError as exc:
-        assert "Lenguajes soportados" in str(exc)
+        assert "Lenguaje no permitido en rutas públicas" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("Se esperaba ValueError para backend no soportado")
 
@@ -26,3 +31,26 @@ def test_contrato_declara_matriz_abi_y_limites_por_cada_ruta():
         assert route in ABI_POLICY_BY_ROUTE
         assert route in ROUTE_OPERATIONAL_LIMITS
         assert ABI_POLICY_BY_ROUTE[route].current in ABI_POLICY_BY_ROUTE[route].supported
+
+
+def test_contrato_publico_lenguajes_oficiales_no_admite_bindings_extra():
+    assert OFFICIAL_PUBLIC_LANGUAGES == ("python", "javascript", "rust")
+    assert set(BINDINGS_BY_LANGUAGE) == set(OFFICIAL_PUBLIC_LANGUAGES)
+    assert set(OFFICIAL_PUBLIC_ROUTE_MATRIX) == set(OFFICIAL_PUBLIC_LANGUAGES)
+
+
+def test_validate_public_language_rechaza_lenguaje_no_oficial():
+    try:
+        validate_public_language("go")
+    except ValueError as exc:
+        assert "Lenguaje no permitido en rutas públicas" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Se esperaba ValueError para lenguaje no oficial")
+
+
+def test_route_matrix_markdown_documenta_rutas_oficiales():
+    markdown = route_matrix_markdown()
+
+    assert "| Python | direct import bridge |" in markdown
+    assert "| JavaScript | runtime bridge |" in markdown
+    assert "| Rust | compiled FFI |" in markdown

--- a/tests/unit/test_runtime_manager.py
+++ b/tests/unit/test_runtime_manager.py
@@ -59,6 +59,7 @@ def test_runtime_manager_validate_command_runtime_retorna_abi_capabilities_y_bri
     assert abi == "2.0"
     assert capabilities.route is BindingRoute.RUST_COMPILED_FFI
     assert bridge.implementation == "rust_compiled_ffi_bridge"
+    assert bridge.internal_only is False
 
 
 def test_runtime_manager_negocia_abi_desde_config(monkeypatch, tmp_path: Path):
@@ -148,3 +149,14 @@ rust = "1.1"
 
     assert manager.validate_abi_route("javascript") == "1.0"
     assert manager.validate_abi_route("rust") == "1.1"
+
+
+def test_runtime_manager_rechaza_backend_no_oficial_en_ruta_publica():
+    manager = RuntimeManager()
+
+    try:
+        manager.resolve_runtime("go")
+    except ValueError as exc:
+        assert "Lenguaje no permitido en rutas públicas" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Se esperaba rechazo temprano para backend no oficial")


### PR DESCRIPTION
### Motivation

- Rechazar temprano lenguajes no oficiales en rutas públicas para evitar exposición accidental de bindings no autorizados.
- Documentar de forma canónica la matriz oficial de rutas públicas (Python → direct import, JavaScript → runtime bridge, Rust → compiled FFI) para claridad operativa.
- Forzar que cualquier bridge no oficial permanezca marcado como `internal_only` hasta su promoción formal para prevenir fugas de surface pública.

### Description

- Añadido `OFFICIAL_PUBLIC_LANGUAGES` y `OFFICIAL_PUBLIC_ROUTE_MATRIX` en `bindings/contract.py` y re-exportado en `src/pcobra/cobra/bindings/contract.py` para declarar la matriz oficial de rutas públicas.
- Implementada la validación temprana `validate_public_language(...)` y adaptado `resolve_binding(...)` para rechazar lenguajes no oficiales antes de resolver capacidades.
- Añadida la ayuda `route_matrix_markdown()` que documenta la matriz solicitada con las tres rutas oficiales.
- Extendido `RuntimeBridgeDescriptor` con la bandera `internal_only` (por defecto `True`), marcado los bridges oficiales actuales como `internal_only=False`, y añadido `_validate_public_contracts()` en `RuntimeManager` para comprobar al iniciar que la matriz pública, las capabilities y las banderas `internal_only` son consistentes.
- Añadidas/actualizadas pruebas unitarias en `tests/unit/test_bindings_contract.py` y `tests/unit/test_runtime_manager.py` que fallarán si aparece un binding público extra o si se permite un lenguaje no oficial en rutas públicas.

### Testing

- Ejecutado: `pytest -q tests/unit/test_bindings_contract.py tests/unit/test_runtime_manager.py tests/unit/test_binding_contract_canonical.py`.
- Resultado: todas las pruebas seleccionadas pasaron (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3510117008327bdd0ddff623f91f0)