### PR TITLE
docs: reforzar CLI pública y aislar referencias legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Versión 10.0.13
 
 Cobra consolida su experiencia de uso en una **única interfaz pública**: la CLI `cobra`. Todas las tareas de ejecución, build, pruebas y módulos se coordinan desde este frente común, mientras la orquestación interna y los adaptadores de backend permanecen encapsulados.
 
+Ejemplos públicos mínimos:
+
+```bash
+cobra run archivo.cobra
+cobra build archivo.cobra
+cobra test archivo.cobra
+cobra mod list
+```
+
 La superficie pública oficial mantiene tres backends: **Python**, **JavaScript** y **Rust**.
 
 pCobra es un lenguaje de programación escrito en español y pensado para la creación de herramientas, simulaciones y análisis en disciplinas como biología, computación y astrofísica. El proyecto integra un lexer, parser y un sistema de transpilación con una lista canónica de destinos de salida derivada automáticamente de `src/pcobra/cobra/config/transpile_targets.py` + `src/pcobra/cobra/transpilers/registry.py`.
@@ -364,16 +373,9 @@ Namespaces recomendados:
 
 ### Guía de migración a la CLI unificada
 
-Si vienes de comandos legacy (`cobra compilar`, `cobra modulos`) o de flujos centrados en `--backend`, sigue la guía: [docs/migracion_cli_unificada.md](docs/migracion_cli_unificada.md).
+La guía histórica de migración y compatibilidad se mantiene fuera del onboarding público, dentro de los anexos internos:
 
-### Guía de migración de usuario final
-
-Migración recomendada sin exponer transpilers ni flags de backend en la UX principal:
-
-1. Reemplaza `cobra ejecutar archivo.co` por `cobra run archivo.cobra`.
-2. Reemplaza `cobra compilar archivo.co --tipo ...` por `cobra build archivo.cobra` (backend automático).
-3. Reemplaza `cobra modulos <accion>` por `cobra mod <acción equivalente>`.
-4. Mantén banderas legacy (`--backend`, `--tipo`, `--tipos`) únicamente en scripts de compatibilidad temporal, no en tutoriales para usuario final.
+- [docs/anexos_legacy_internal/README.md](docs/anexos_legacy_internal/README.md)
 
 ### Anexos legacy/internal (fuera de onboarding)
 
@@ -914,24 +916,14 @@ resultado = transpiler.generate_code(arbol)
 print(resultado)
 ```
 
-Para otros lenguajes puedes invocar los nuevos transpiladores así:
+Para mantenerte en la interfaz pública, enfoca los ejemplos en los transpiladores oficiales:
 
 ```python
 from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 from cobra.transpilers.transpiler.to_rust import TranspiladorRust
-from cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
-from cobra.transpilers.transpiler.to_go import TranspiladorGo
-from cobra.transpilers.transpiler.to_java import TranspiladorJava
-from cobra.transpilers.transpiler.to_asm import TranspiladorASM
-from cobra.transpilers.transpiler.to_wasm import TranspiladorWasm
 
 codigo_js = TranspiladorJavaScript().generate_code(arbol)
 codigo_rust = TranspiladorRust().generate_code(arbol)
-codigo_cpp = TranspiladorCPP().generate_code(arbol)
-codigo_go = TranspiladorGo().generate_code(arbol)
-codigo_java = TranspiladorJava().generate_code(arbol)
-codigo_asm = TranspiladorASM().generate_code(arbol)
-codigo_wasm = TranspiladorWasm().generate_code(arbol)
 ```
 
 Tras obtener el código con ``generate_code`` puedes guardarlo usando ``save_file``:
@@ -990,8 +982,8 @@ terminal ejecuta uno de los siguientes comandos según tu *shell*:
   ```
 
 ```bash
-# Compilar un archivo a: python, rust o javascript (UX pública)
-cobra build programa.co --backend python
+# Compilar un archivo (backend automático dentro del set oficial)
+cobra build programa.co
 
 # Transpilar inverso de Python a JavaScript
 cobra transpilar-inverso script.py --origen=python --destino=javascript
@@ -1142,11 +1134,10 @@ PYTHONPATH=$PWD pytest tests --cov=pcobra --cov-report=term-missing \
   --cov-fail-under=95
 ````
 
- Algunas pruebas internas de migración/regresión generan código en targets legacy además de los públicos. Para ejecutar ese subconjunto en local debes disponer de toolchains extra. En particular se requiere:
+ Algunas pruebas internas de migración/regresión usan toolchains adicionales fuera del contrato público. Para ejecutar ese subconjunto en local debes disponer de toolchains extra. En particular se requiere:
 
 - Node.js
 - gcc y g++
-- Go (`golang-go`) para pruebas internas legacy
 - Rust (`rustc`)
 - Java (`default-jdk`)
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -586,24 +586,14 @@ resultado = transpiler.generate_code(arbol)
 print(resultado)
 ```
 
-For other languages you can invoke the additional transpilers like this:
+For the public backend contract, keep examples focused on the official transpilers:
 
 ```python
 from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 from cobra.transpilers.transpiler.to_rust import TranspiladorRust
-from cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
-from cobra.transpilers.transpiler.to_go import TranspiladorGo
-from cobra.transpilers.transpiler.to_java import TranspiladorJava
-from cobra.transpilers.transpiler.to_asm import TranspiladorASM
-from cobra.transpilers.transpiler.to_wasm import TranspiladorWasm
 
 codigo_js = TranspiladorJavaScript().generate_code(arbol)
 codigo_rust = TranspiladorRust().generate_code(arbol)
-codigo_cpp = TranspiladorCPP().generate_code(arbol)
-codigo_go = TranspiladorGo().generate_code(arbol)
-codigo_java = TranspiladorJava().generate_code(arbol)
-codigo_asm = TranspiladorASM().generate_code(arbol)
-codigo_wasm = TranspiladorWasm().generate_code(arbol)
 ```
 
 After obtaining the code with ``generate_code`` you can save it using ``save_file``:

--- a/docs/_generated/target_policy_summary.md
+++ b/docs/_generated/target_policy_summary.md
@@ -7,7 +7,6 @@
 - **Targets con adaptador Holobit mantenido por el proyecto (partial fuera de python)**: `python`, `javascript`, `rust`.
 - **Compatibilidad SDK completa (solo python)**: `python`.
 - **Targets solo de transpilación**: .
-- **Targets legacy/internal (no públicos)**: go, cpp, java, wasm, asm.
 - **Orígenes de transpilación inversa**: python, javascript, java. Este alcance reverse de entrada está separado de los 3 targets oficiales de salida.
 
 Tiers oficiales de soporte de backends:

--- a/docs/_generated/target_policy_summary.rst
+++ b/docs/_generated/target_policy_summary.rst
@@ -7,7 +7,6 @@
 - **Targets con adaptador Holobit mantenido por el proyecto (partial fuera de python)**: ``python``, ``javascript``, ``rust``.
 - **Compatibilidad SDK completa (solo python)**: ``python``.
 - **Targets solo de transpilación**: .
-- **Targets legacy/internal (no públicos)**: go, cpp, java, wasm, asm.
 - **Orígenes de transpilación inversa**: python, javascript, java. Este alcance reverse de entrada está separado de los 3 targets oficiales de salida.
 
 Tiers oficiales de soporte de backends:

--- a/docs/anexos_legacy_internal/README.md
+++ b/docs/anexos_legacy_internal/README.md
@@ -1,5 +1,8 @@
 # Anexos legacy/internal
 
+> ⚠️ **NO PÚBLICO / NO ONBOARDING**: este directorio concentra material histórico y de compatibilidad interna.
+> No debe usarse como documentación principal para usuarios nuevos.
+
 Este directorio agrupa documentación histórica y notas internas para mantener limpio el onboarding del README principal.
 
 ## Contenido

--- a/docs/frontend/arquitectura.rst
+++ b/docs/frontend/arquitectura.rst
@@ -15,18 +15,18 @@ Command (ver :ref:`patron_command`).
 Core
 ----
 Contiene el corazón del lenguaje: lexer, parser, intérprete y
-transpiladores a ``python``, ``rust``, ``javascript``, ``wasm``, ``go``, ``cpp``, ``java`` y ``asm``. Estos elementos trabajan en
-conjunto para analizar el código fuente y transformarlo en otras
-representaciones o ejecutarlo de forma directa.
+transpiladores oficiales a ``python``, ``rust`` y ``javascript``. Estos
+componentes trabajan en conjunto para analizar el código fuente y
+transformarlo en otras representaciones o ejecutarlo de forma directa.
 Las clases que componen el AST se definen en ``src.core.ast_nodes`` para facilitar su reutilización.
 El recorrido de estos nodos puede realizarse mediante la clase ``NodeVisitor``
 ubicada en ``src.core.visitor``, que despacha automáticamente al método
 ``visit_<Clase>`` correspondiente.
 Para mantener el código modular, la lógica específica de cada nodo del AST se
-almacena en paquetes independientes. Los transpiladores a ``python``, ``rust``, ``javascript``, ``wasm``, ``go``, ``cpp``, ``java`` y ``asm``
-importan estas funciones desde ``src.core.transpiler.python_nodes`` y
-``src.core.transpiler.js_nodes`` (o ``asm_nodes`` o ``rust_nodes``) respectivamente, delegando la operación de
-``visit_<nodo>`` a dichas funciones.
+almacena en paquetes independientes. Los transpiladores oficiales importan
+estas funciones desde ``src.core.transpiler.python_nodes``,
+``src.core.transpiler.js_nodes`` y ``src.core.transpiler.rust_nodes``,
+delegando la operación de ``visit_<nodo>`` a dichas funciones.
 
 Para una visión esquemática de la interacción entre lexer, parser y transpiladores consulta :doc:`../../docs/arquitectura_parser_transpiladores`.
 
@@ -62,7 +62,7 @@ optimizar el rendimiento y evitar fugas de memoria.
        CLI -> Lexer;
    Interprete -> Memoria;
    Interprete -> ModulosNativos;
-   Transpiladores -> {Python JavaScript Asm Rust Cpp Go Java Wasm};
+   Transpiladores -> {Python JavaScript Rust};
    }
  
 Interacción de los módulos

--- a/docs/frontend/cli.rst
+++ b/docs/frontend/cli.rst
@@ -142,33 +142,13 @@ Ejemplo:
    Ruta al archivo Cobra: hola.co
    Lenguaje destino: python
 
-Subcomando ``modulos``
----------------------
-Gestiona módulos instalados.
+Subcomandos legacy/internal
+----------------------------
 
-Acciones disponibles:
-
-- ``listar`` muestra los módulos instalados.
-
-- ``instalar <ruta>`` copia un archivo ``.co`` al directorio de módulos.
-- ``remover <nombre>`` elimina un módulo instalado.
-
-Al instalar un módulo se valida la versión indicada en ``cobra.mod`` y se
-actualiza ``cobra.lock``. Este fichero almacena el nombre de cada módulo
-y su versión semver bajo la clave ``modules``.
-
-El formato del archivo es:
-
-.. code-block:: yaml
-
-   modules:
-     modulo.co: "1.0.0"
-
-Ejemplo:
-
-.. code-block:: bash
-
-   cobra modulos instalar extra/modulo.co
+.. warning::
+   Los comandos históricos y aliases de compatibilidad (v1/legacy) no forman
+   parte de la interfaz pública recomendada. Su documentación se mantiene en
+   ``docs/anexos_legacy_internal/`` y no debe usarse como onboarding.
 
 Subcomando ``dependencias``
 --------------------------
@@ -284,9 +264,7 @@ ejecutar o limpiar el código. Es una forma rápida de probar programas sin usar
 la terminal.
 
 Cuando uses ``--sandbox-docker``, la CLI solo ofrece runtimes Docker oficiales:
-``python``, ``javascript``, ``cpp`` y ``rust``. Los demás targets oficiales
-(``wasm``, ``go``, ``java``, ``asm``) siguen siendo destinos de transpilación y
-no deben leerse como equivalentes de ejecución real.
+``python``, ``javascript`` y ``rust``.
 
 Subcomando ``plugins``
 ---------------------
@@ -334,7 +312,7 @@ Compara el rendimiento de los backends con runner configurado en la suite y
 muestra un resumen en formato JSON. Opcionalmente puede guardarse en un
 archivo mediante ``--output``. Esto no implica paridad de ejecución para
 todos los targets oficiales de transpilación: la política pública de runtime
-solo cubre ``python``, ``javascript``, ``cpp`` y ``rust``.
+solo cubre ``python``, ``javascript`` y ``rust``.
 
 Ejemplo:
 


### PR DESCRIPTION
### Motivation

- Aclarar y reforzar la interfaz pública oficial de la CLI para usuarios nuevos, mostrando ejemplos mínimos y evitando exponer flags/targets/commands legacy en el onboarding principal. 
- Conservar la documentación histórica/legacy en un área separada y marcada como no pública para evitar confusión en el uso cotidiano.
- Alinear los fragmentos visibles y las tablas generadas de `target_policy` con la fuente canónica.

### Description

- Añadí ejemplos públicos mínimos a la sección `Cobra como interfaz única` en `README.md` mostrando `cobra run`, `cobra build`, `cobra test` y `cobra mod list`.
- Eliminé y/o simplifiqué snippets que referenciaban targets legacy, comandos v1 o flags como `--tipo/--tipos/--backend` en los documentos públicos principales: `README.md`, `docs/README.en.md`, `docs/frontend/cli.rst` y `docs/frontend/arquitectura.rst`.
- Reemplacé el detalle operativo de migración legacy en el onboarding público por un enlace a `docs/anexos_legacy_internal/` y añadí un aviso claro de "NO PÚBLICO / NO ONBOARDING" en `docs/anexos_legacy_internal/README.md`.
- Actualicé ejemplos de invocación de transpiladores para mostrar únicamente los transpiladores/backends oficiales públicos (`python`, `javascript`, `rust`) en `README.md` y `docs/README.en.md`.
- Regeneré los resúmenes de política de targets en `docs/_generated/` (`target_policy_summary.md` y `.rst`) desde las funciones del script canon (`scripts/generate_target_policy_docs.py` helpers) y limpié la línea que listaba explícitamente targets legacy en el output generado.

### Testing

- Ejecuté búsquedas con `rg` sobre la documentación clave para localizar menciones legacy/flags y verifiqué que las coincidencias objetivo fueron eliminadas; la búsqueda completó correctamente.
- Intenté ejecutar `python scripts/generate_target_policy_docs.py`, pero falló por marcadores faltantes en `docs/targets_policy.md` (`<!-- BEGIN GENERATED TARGET TIERS --> / <!-- END GENERATED TARGET TIERS -->`).
- Regeneré manualmente los archivos en `docs/_generated/` invocando las funciones internas del script y la regeneración de los archivos `target_policy_summary.*` y relacionados se completó correctamente.
- Ejecuté `python scripts/validate_targets_policy.py` y la validación falló por un problema de importación en la cadena de scripts (`resolve_backend` no exportado en `pcobra.cobra.build.backend_pipeline`), que es ajeno a estos cambios de documentación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e360ce8bcc8327bfac684e13eda18f)