### PR TITLE
Forzar políticas de backends públicos y aislar acceso legacy en internal_compat

### DIFF
--- a/scripts/ci/lint_public_commands_internal_backends.py
+++ b/scripts/ci/lint_public_commands_internal_backends.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Lint interno: bloquea uso directo de INTERNAL_BACKENDS en comandos públicos."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PUBLIC_COMMAND_SCOPES = (
+    ROOT / "src/pcobra/cobra/cli/commands",
+    ROOT / "src/pcobra/cobra/cli/commands_v2",
+)
+
+
+class _InternalBackendsVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.violations: list[tuple[int, str]] = []
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = node.module or ""
+        if module == "pcobra.cobra.architecture.backend_policy":
+            for alias in node.names:
+                if alias.name == "INTERNAL_BACKENDS":
+                    self.violations.append((node.lineno, "import-from backend_policy"))
+        self.generic_visit(node)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if node.id == "INTERNAL_BACKENDS":
+            self.violations.append((node.lineno, "referencia directa"))
+        self.generic_visit(node)
+
+
+def _scan_file(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    visitor = _InternalBackendsVisitor()
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def find_violations(root: Path = ROOT) -> list[str]:
+    failures: list[str] = []
+    scopes = (
+        root / "src/pcobra/cobra/cli/commands",
+        root / "src/pcobra/cobra/cli/commands_v2",
+    )
+    for scope in scopes:
+        if not scope.exists():
+            continue
+        for path in sorted(scope.rglob("*.py")):
+            rel = path.relative_to(root)
+            violations = _scan_file(path)
+            for line, reason in violations:
+                failures.append(
+                    f"{rel}:{line}: uso no permitido de INTERNAL_BACKENDS ({reason}); "
+                    "usa pcobra.cobra.cli.internal_compat.*"
+                )
+    return failures
+
+
+def main() -> int:
+    failures = find_violations(ROOT)
+
+    if failures:
+        print("❌ Lint INTERNAL_BACKENDS en comandos públicos: FALLÓ")
+        for item in failures:
+            print(f" - {item}")
+        return 1
+
+    print("✅ Lint INTERNAL_BACKENDS en comandos públicos: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -74,6 +74,8 @@ def resolve_backend_runtime(
     """Resuelve backend y metadatos de bridge/runtime para el contrato de bindings."""
     context = hints or {}
     resolution = _resolve_backend(source, context)
+    if not context.get("internal_migration", False):
+        assert_backend_allowed_for_scope(backend=resolution.backend, scope="public")
     capabilities, bridge = RUNTIME_MANAGER.resolve_runtime(resolution.backend)
     abi_version = RUNTIME_MANAGER.validate_abi_route(
         resolution.backend,

--- a/src/pcobra/cobra/cli/commands_v2/build_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/build_cmd.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.architecture.contracts import assert_backend_allowed_for_scope
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.i18n import _
@@ -44,6 +45,7 @@ class BuildCommandV2(BaseCommand):
                 registrar_log=False,
             )
         runtime_language = str(build_result.get("runtime", {}).get("language", "python"))
+        assert_backend_allowed_for_scope(backend=runtime_language, scope="public")
         try:
             self._runtime_manager.validate_command_runtime(runtime_language, command="build")
         except ValueError as exc:

--- a/src/pcobra/cobra/cli/commands_v2/run_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/run_cmd.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+from pcobra.cobra.architecture.contracts import assert_backend_allowed_for_scope
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
@@ -42,6 +43,7 @@ class RunCommandV2(BaseCommand):
         sandbox = bool(getattr(args, "sandbox", False))
         container = getattr(args, "container", None)
         binding_language = container or "python"
+        assert_backend_allowed_for_scope(backend=binding_language, scope="public")
         try:
             self._runtime_manager.validate_command_runtime(
                 binding_language,

--- a/src/pcobra/cobra/cli/commands_v2/test_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/test_cmd.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.architecture.contracts import assert_backend_allowed_for_scope
 from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 from pcobra.cobra.cli.i18n import _
@@ -52,6 +53,7 @@ class TestCommandV2(BaseCommand):
         else:
             langs = list(raw_langs)
         for lang in langs:
+            assert_backend_allowed_for_scope(backend=lang, scope="public")
             try:
                 sandbox = lang == "python"
                 containerized = lang in {"javascript", "rust"}

--- a/src/pcobra/cobra/cli/target_policies.py
+++ b/src/pcobra/cobra/cli/target_policies.py
@@ -6,8 +6,9 @@ from argparse import ArgumentTypeError
 import warnings
 from typing import Literal
 
-from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS, PUBLIC_BACKENDS
-from pcobra.cobra.architecture.legacy_backend_lifecycle import (
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+from pcobra.cobra.internal_compat.legacy_contracts import (
+    INTERNAL_BACKENDS,
     legacy_backend_warning_message,
 )
 from pcobra.cobra.cli.internal_compat.legacy_targets import (

--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -11,6 +11,7 @@ from types import ModuleType
 from typing import Any, Mapping
 
 from pcobra.cobra.backends.resolver import resolve_backend
+from pcobra.cobra.architecture.contracts import assert_backend_allowed_for_scope
 from pcobra.cobra.stdlib_contract import get_public_stdlib_module_contracts
 from pcobra.cobra.transpilers.module_map import (
     get_toml_map,
@@ -72,6 +73,7 @@ class CobraImportResolver:
         self.project_root = Path(project_root).resolve() if project_root else None
         config = get_toml_map()
         self.hybrid_modules = self._load_hybrid_modules(config, hybrid_modules)
+        assert_backend_allowed_for_scope(backend=default_backend, scope="public")
         self.default_backend = default_backend
         self.collision_policy = self._resolve_collision_policy(
             config=config,
@@ -271,6 +273,7 @@ class CobraImportResolver:
     def _attach_backend_adapter(self, resolution: ResolutionResult) -> ResolutionResult:
         base_backend = resolution.backend or self.default_backend
         effective_backend = resolve_backend_for_module(resolution.resolved_name, base_backend)
+        assert_backend_allowed_for_scope(backend=effective_backend, scope="public")
         adapter = resolve_backend(effective_backend)
         return ResolutionResult(
             request=resolution.request,

--- a/src/pcobra/cobra/internal_compat/__init__.py
+++ b/src/pcobra/cobra/internal_compat/__init__.py
@@ -1,0 +1,19 @@
+"""Namespace explícito para compatibilidad interna/legacy.
+
+Este paquete encapsula contratos que no forman parte de la superficie pública
+estable y deben consumirse únicamente por rutas de migración interna.
+"""
+
+from pcobra.cobra.internal_compat.legacy_contracts import (
+    INTERNAL_BACKENDS,
+    INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW,
+    lifecycle_status_for_backend,
+    legacy_backend_warning_message,
+)
+
+__all__ = [
+    "INTERNAL_BACKENDS",
+    "INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW",
+    "lifecycle_status_for_backend",
+    "legacy_backend_warning_message",
+]

--- a/src/pcobra/cobra/internal_compat/legacy_contracts.py
+++ b/src/pcobra/cobra/internal_compat/legacy_contracts.py
@@ -1,0 +1,23 @@
+"""Façade interna para acceso a inventario/estado legacy.
+
+Regla arquitectónica: rutas públicas no deben importar directamente módulos
+legacy del dominio principal; usar este namespace `internal_compat`.
+"""
+
+from __future__ import annotations
+
+from pcobra.cobra.architecture.backend_policy import (
+    INTERNAL_BACKENDS,
+    INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW,
+)
+from pcobra.cobra.architecture.legacy_backend_lifecycle import (
+    lifecycle_status_for_backend,
+    legacy_backend_warning_message,
+)
+
+__all__ = [
+    "INTERNAL_BACKENDS",
+    "INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW",
+    "lifecycle_status_for_backend",
+    "legacy_backend_warning_message",
+]

--- a/src/pcobra/cobra/transpilers/registry.py
+++ b/src/pcobra/cobra/transpilers/registry.py
@@ -7,12 +7,12 @@ from typing import Final
 
 from pcobra.cobra.architecture.backend_policy import (
     ALL_BACKENDS,
-    INTERNAL_BACKENDS,
-    INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW,
     PUBLIC_BACKENDS,
     assert_public_targets_contract,
 )
-from pcobra.cobra.architecture.legacy_backend_lifecycle import (
+from pcobra.cobra.internal_compat.legacy_contracts import (
+    INTERNAL_BACKENDS,
+    INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW,
     lifecycle_status_for_backend,
 )
 from pcobra.cobra.config.transpile_targets import OFFICIAL_TARGETS

--- a/tests/unit/test_ci_lint_public_commands_internal_backends.py
+++ b/tests/unit/test_ci_lint_public_commands_internal_backends.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.ci.lint_public_commands_internal_backends import find_violations
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_detecta_uso_directo_internal_backends_en_comando_publico(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "foo.py",
+        "from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "src/pcobra/cobra/cli/commands/foo.py:1" in violations[0]
+
+
+def test_permite_comandos_sin_internal_backends(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands_v2" / "ok.py",
+        "from pcobra.cobra.cli.internal_compat.legacy_targets import enabled_internal_legacy_targets\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert violations == []

--- a/tests/unit/test_public_commands_internal_backends_lint_guard.py
+++ b/tests/unit/test_public_commands_internal_backends_lint_guard.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_public_commands_internal_backends_lint_guard_passes_on_repo() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "scripts/ci/lint_public_commands_internal_backends.py"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
### Motivation

- Garantizar que la superficie pública use únicamente `PUBLIC_BACKENDS` como contrato único y evitar fugas de backends legacy en flujos públicos. 
- Añadir verificaciones en todos los puntos de entrada público (CLI v2, imports, build) para bloquear backends fuera del contrato. 
- Encapsular el inventario/estado legacy en un namespace explícito para que las rutas públicas no importen directamente datos internos. 
- Prevenir por lint/CI referencias directas a `INTERNAL_BACKENDS` desde módulos de comandos públicos.

### Description

- Añadido `assert_backend_allowed_for_scope(..., scope="public")` en flujos públicos: `cobra.cli.commands_v2.run_cmd.RunCommandV2`, `TestCommandV2`, y `BuildCommandV2` para validar el backend usado por la UX pública. 
- Incorporado el mismo aserto en el resolvedor de imports `CobraImportResolver` (validación de `default_backend` y `effective_backend`) y en `build.backend_pipeline.resolve_backend_runtime` para rutas que no sean `internal_migration`. 
- Creado namespace explícito `pcobra.cobra.internal_compat` con `legacy_contracts.py` que exporta `INTERNAL_BACKENDS`, `INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW` y helpers de ciclo de vida; actualizados consumidores internos (`cli.target_policies`, `transpilers.registry`) para importar desde `internal_compat` en lugar de acceder directamente a módulos legacy. 
- Añadido lint CI `scripts/ci/lint_public_commands_internal_backends.py` que detecta importaciones/referencias directas a `INTERNAL_BACKENDS` dentro de `src/pcobra/cobra/cli/commands*`, más tests unitarios de soporte en `tests/unit/`.

### Testing

- Ejecutados tests unitarios focalizados: `pytest -q tests/unit/test_ci_lint_public_commands_internal_backends.py tests/unit/test_public_commands_internal_backends_lint_guard.py tests/unit/test_public_import_boundaries_guard.py` — resultado: todos pasaron. 
- Ejecutados linters/guards de repo: `python scripts/ci/lint_public_commands_internal_backends.py` y `python scripts/ci/check_public_import_boundaries.py` — ambos devolvieron OK. 
- Compilación sintáctica de módulos cambiados con `python -m py_compile` sobre los ficheros modificados — OK. 
- Nota: durante la implementación se detectó un fallo inicial en una ejecución amplia de `pytest` por un import temporal (resuelto durante los cambios); las validaciones finales automatizadas indicadas arriba han pasado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e36abd20088327a00ef47d2099a2ef)