### PR TITLE
Restringir exposición de comandos legacy a perfil development y reforzar migración a CLI v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,12 +177,12 @@ de clases. Cada tema cuenta con su propia carpeta:
 
 ## Notebooks de ejemplo
 
-En la carpeta `notebooks/` se incluye el cuaderno `ejemplo_basico.ipynb` con un ejemplo básico de uso de Cobra. Además, los cuadernos de `notebooks/casos_reales/` muestran cómo ejecutar los ejemplos avanzados. Para abrirlo ejecuta:
+En la carpeta `notebooks/` se incluye el cuaderno `ejemplo_basico.ipynb` con un ejemplo básico de uso de Cobra. Además, los cuadernos de `notebooks/casos_reales/` muestran cómo ejecutar los ejemplos avanzados. Para abrirlo puedes usar Jupyter directamente:
 
 ```bash
-cobra jupyter --notebook notebooks/ejemplo_basico.ipynb
+jupyter notebook notebooks/ejemplo_basico.ipynb
 ```
-Si omites el argumento ``--notebook`` se abrirá Jupyter Notebook de manera convencional y podrás escoger el archivo desde la interfaz web.
+También puedes abrir Jupyter sin ruta inicial y elegir el archivo desde la interfaz web.
 
 
 

--- a/docs/config_cli.md
+++ b/docs/config_cli.md
@@ -14,7 +14,7 @@ Ejemplos concretos:
 
 ```bash
 cobra --modo cobra run programa.co
-cobra --modo transpilar build programa.co --backend python
+cobra --modo transpilar build programa.co
 ```
 
 ## Ruta del archivo
@@ -27,7 +27,7 @@ cobra --modo transpilar build programa.co --backend python
 | Clave            | Valor por defecto                                    | Descripción                                           |
 |------------------|------------------------------------------------------|-------------------------------------------------------|
 | `language`       | `es`                                                 | Idioma de la interfaz de la CLI.                      |
-| `default_command`| `interactive`                                       | Subcomando ejecutado si no se especifica otro.        |
+| `default_command`| `run`                                               | Subcomando ejecutado si no se especifica otro.        |
 | `log_format`     | `%(asctime)s - %(levelname)s - %(message)s`          | Formato para los mensajes de registro (*logging*).    |
 | `log_formatter`  | `text`                                                | Formato del handler raíz: `text` (default) o `json`.  |
 | `program_name`   | `cobra`                                              | Nombre con el que aparece la aplicación en la ayuda.  |
@@ -81,7 +81,7 @@ print(secrets.token_urlsafe(32))
 PY
 )"
 
-cobra build ejemplo.co --backend python
+cobra build ejemplo.co
 ```
 
 #### Opción B (solo dev local): clave efímera por ejecución
@@ -89,7 +89,7 @@ cobra build ejemplo.co --backend python
 ```bash
 COBRA_DEV_MODE=1 \
 COBRA_DEV_ALLOW_EPHEMERAL_KEY=1 \
-cobra --dev-ephemeral-key build ejemplo.co --backend python
+cobra --dev-ephemeral-key build ejemplo.co
 ```
 
 > Nota: evita esta opción en CI/prod; está diseñada únicamente para sesiones
@@ -100,7 +100,7 @@ cobra --dev-ephemeral-key build ejemplo.co --backend python
 ```toml
 # cobra-cli.toml
 language = "en"
-default_command = "compile"
+default_command = "run"
 log_format = "%(levelname)s: %(message)s"
 log_formatter = "json"
 program_name = "cobra"

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -131,7 +131,7 @@ class AppConfig:
         logging.error(f"Failed to load configuration: {e}")
         config_data: Dict[str, str] = {}
     DEFAULT_LANGUAGE = config_data.get("language", "es")
-    DEFAULT_COMMAND = config_data.get("default_command", "interactive")
+    DEFAULT_COMMAND = config_data.get("default_command", "run")
     PROGRAM_NAME = config_data.get("program_name", "cobra")
     BASE_COMMAND_CLASSES: List[Type[BaseCommand]] = [
         InteractiveCommand, CompileCommand, ExecuteCommand, ModulesCommand,

--- a/src/pcobra/cobra/cli/commands_v2/legacy_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/legacy_cmd.py
@@ -7,6 +7,15 @@ from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
 from pcobra.cobra.cli.commands.modules_cmd import ModulesCommand
 from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils import messages
+
+
+LEGACY_GROUP_MIGRATION_HINTS: dict[str, str] = {
+    "ejecutar": "cobra run <archivo.co>",
+    "compilar": "cobra build <archivo.co>",
+    "verificar": "cobra test <archivo.co>",
+    "modulos": "cobra mod <list|install|remove|publish|search>",
+}
 
 
 class LegacyCommandGroupV2(BaseCommand):
@@ -57,6 +66,13 @@ class LegacyCommandGroupV2(BaseCommand):
 
     def run(self, args: Any) -> int:
         command = getattr(args, "legacy_command", None)
+        if command in LEGACY_GROUP_MIGRATION_HINTS:
+            messages.mostrar_advertencia(
+                _(
+                    "Comando legacy '{legacy}' en grupo 'legacy'. "
+                    "Migra a interfaz pública: {hint}."
+                ).format(legacy=command, hint=LEGACY_GROUP_MIGRATION_HINTS[command])
+            )
         if command == "ejecutar":
             return self._execute.run(
                 Namespace(

--- a/src/pcobra/cobra/cli/public_command_policy.py
+++ b/src/pcobra/cobra/cli/public_command_policy.py
@@ -11,17 +11,7 @@ INTERNAL_COMMANDS: tuple[str, ...] = (
     "debug",
     "devops",
 )
-LEGACY_PUBLIC_COMMANDS: tuple[str, ...] = (
-    "interactive",
-    "ejecutar",
-    "modulos",
-    "verificar",
-    "docs",
-    "plugins",
-    "init",
-    "crear",
-    "paquete",
-)
+LEGACY_PUBLIC_COMMANDS: tuple[str, ...] = ()
 LEGACY_INTERNAL_COMMANDS: tuple[str, ...] = (
     "compilar",
     "cache",
@@ -48,7 +38,7 @@ COMMAND_VISIBILITY_MATRIX_MARKDOWN = """| Clase | Comandos |
 |---|---|
 | Públicos (UI v2) | run, build, test, mod |
 | Internos (UI v2 / development) | legacy, debug, devops |
-| Legacy públicos (UI v1) | interactive, ejecutar, modulos, verificar, docs, plugins, init, crear, paquete |
+| Legacy públicos (UI v1) | *(ninguno; reservado a `development`)* |
 | Legacy internos (UI v1) | compilar, cache, contenedor, gui, jupyter, qualia, agix |
 | Legacy obsoletos (UI v1) | dependencias, empaquetar, bench, benchmarks, benchmarks2, benchtranspilers, benchthreads, profile, transpilar-inverso, validar-sintaxis, qa-validar |
 |"""
@@ -93,7 +83,7 @@ def filter_commands_for_profile(command_names: Iterable[str], profile: str) -> s
 def filter_legacy_commands_for_profile(command_names: Iterable[str], profile: str) -> set[str]:
     """Filtra comandos de CLI legacy (v1) según perfil de exposición.
 
-    Perfil `public`: conserva únicamente `LEGACY_PUBLIC_COMMANDS`.
+    Perfil `public`: bloquea todos los comandos legacy (UI v1).
     Perfil `development`: permite toda la superficie incluida la obsoleta para
     migración interna y pruebas de regresión.
     """

--- a/tests/unit/test_cli_v2_command_contract.py
+++ b/tests/unit/test_cli_v2_command_contract.py
@@ -5,6 +5,7 @@ import pytest
 from cobra.cli.commands_v2.run_cmd import RunCommandV2
 from cobra.cli.commands_v2.build_cmd import BuildCommandV2
 from cobra.cli.commands_v2.test_cmd import TestCommandV2
+from cobra.cli.commands_v2.legacy_cmd import LegacyCommandGroupV2
 from cobra.cli.cli import LEGACY_COMMAND_MIGRATION_MAP
 from cobra.cli.target_policies import VERIFICATION_EXECUTABLE_TARGETS
 
@@ -209,3 +210,16 @@ def test_legacy_command_migration_map_cubre_comandos_legacy_principales():
     assert LEGACY_COMMAND_MIGRATION_MAP["verificar"]["target"] == "test"
     assert LEGACY_COMMAND_MIGRATION_MAP["modulos"]["target"] == "mod"
     assert LEGACY_COMMAND_MIGRATION_MAP["modulos"]["hint"].startswith("cobra mod ")
+
+
+def test_legacy_group_muestra_mensaje_corto_de_migracion(monkeypatch):
+    command = LegacyCommandGroupV2()
+    warnings: list[str] = []
+    monkeypatch.setattr("cobra.cli.commands_v2.legacy_cmd.messages.mostrar_advertencia", warnings.append)
+    monkeypatch.setattr(command._execute, "run", lambda _args: 0)
+
+    status = command.run(argparse.Namespace(legacy_command="ejecutar", archivo="app.co"))
+
+    assert status == 0
+    assert warnings
+    assert "cobra run <archivo.co>" in warnings[0]

--- a/tests/unit/test_public_command_policy.py
+++ b/tests/unit/test_public_command_policy.py
@@ -1,0 +1,19 @@
+from cobra.cli.public_command_policy import (
+    PROFILE_DEVELOPMENT,
+    PROFILE_PUBLIC,
+    filter_legacy_commands_for_profile,
+)
+
+
+def test_filter_legacy_commands_publico_bloquea_toda_superficie_v1():
+    visibles = filter_legacy_commands_for_profile(
+        ("interactive", "ejecutar", "docs"),
+        PROFILE_PUBLIC,
+    )
+    assert visibles == set()
+
+
+def test_filter_legacy_commands_development_permite_superficie_v1_para_migracion():
+    comandos = ("interactive", "ejecutar", "docs")
+    visibles = filter_legacy_commands_for_profile(comandos, PROFILE_DEVELOPMENT)
+    assert visibles == set(comandos)


### PR DESCRIPTION
### Motivation
- Consolidar la UX pública en la interfaz `commands_v2` (run/build/test/mod) y evitar que rutas/flags legacy queden expuestas a usuarios en producción. 
- Facilitar la migración guiada desde comandos legacy hacia la superficie pública evitando ejemplos/documentación que promuevan flags o flows internos.

### Description
- Cambia `AppConfig.DEFAULT_COMMAND` de `interactive` a `run` para que la experiencia por defecto use la interfaz v2 (`src/pcobra/cobra/cli/cli.py`).
- Restringe la exposición de comandos legacy en `public` dejando `LEGACY_PUBLIC_COMMANDS` vacío y actualizando la matriz de visibilidad y docstring (`src/pcobra/cobra/cli/public_command_policy.py`).
- Añade un aviso corto de migración dentro del grupo `legacy` (mapa `LEGACY_GROUP_MIGRATION_HINTS` y `messages.mostrar_advertencia`) que sugiere automáticamente `run/build/test/mod` cuando se invocan `ejecutar|compilar|verificar|modulos` (`src/pcobra/cobra/cli/commands_v2/legacy_cmd.py`).
- Limpia ejemplos/documentación que exponían flags backend o comandos legacy en flujos principales al actualizar `docs/config_cli.md` y `README.md` (remueve `--backend` en ejemplos y ajusta `default_command` a `run`).
- Añade pruebas unitarias que verifican la política pública para legacy y que el grupo `legacy` emite el mensaje de migración (`tests/unit/test_public_command_policy.py`, y añadido test en `tests/unit/test_cli_v2_command_contract.py`).

### Testing
- Ejecuté `pytest -q tests/unit/test_public_command_policy.py` y pasó exitosamente (`2 passed`).
- Ejecuté comprobación de bytecode con `python -m compileall` sobre los módulos modificados y los tests añadidos y la compilación fue exitosa.
- Intenté ejecutar `pytest -q tests/unit/test_cli_v2_command_contract.py tests/integration/test_cli_public_help_contract.py` pero la colección falló por una importación previa no relacionada en el entorno de pruebas: `ImportError` en `pcobra.cobra.build.backend_pipeline` que impidió completar esos tests; el fallo ocurre durante la importación y no es causado por los cambios de esta PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e36ca8aa6883278a57f2206c43a52e)