### PR TITLE
Estandariza exportaciones públicas del contrato stdlib

### DIFF
--- a/docs/_generated/stdlib_contract_matrix.json
+++ b/docs/_generated/stdlib_contract_matrix.json
@@ -24,6 +24,28 @@
         "cobra.core.copiar_signo",
         "cobra.core.signo"
       ],
+      "public_exports": [
+        {
+          "alias": "cobra.core.es_finito",
+          "source_path": "src/pcobra/standard_library/numero.py",
+          "python_symbol": "es_finito"
+        },
+        {
+          "alias": "cobra.core.es_infinito",
+          "source_path": "src/pcobra/standard_library/numero.py",
+          "python_symbol": "es_infinito"
+        },
+        {
+          "alias": "cobra.core.copiar_signo",
+          "source_path": "src/pcobra/standard_library/numero.py",
+          "python_symbol": "copiar_signo"
+        },
+        {
+          "alias": "cobra.core.signo",
+          "source_path": "src/pcobra/standard_library/numero.py",
+          "python_symbol": "signo"
+        }
+      ],
       "coverage": [
         {
           "function": "cobra.core.es_finito",
@@ -110,6 +132,28 @@
         "cobra.datos.a_listas",
         "cobra.datos.de_listas"
       ],
+      "public_exports": [
+        {
+          "alias": "cobra.datos.filtrar",
+          "source_path": "src/pcobra/standard_library/datos.py",
+          "python_symbol": "filtrar"
+        },
+        {
+          "alias": "cobra.datos.seleccionar_columnas",
+          "source_path": "src/pcobra/standard_library/datos.py",
+          "python_symbol": "seleccionar_columnas"
+        },
+        {
+          "alias": "cobra.datos.a_listas",
+          "source_path": "src/pcobra/standard_library/datos.py",
+          "python_symbol": "a_listas"
+        },
+        {
+          "alias": "cobra.datos.de_listas",
+          "source_path": "src/pcobra/standard_library/datos.py",
+          "python_symbol": "de_listas"
+        }
+      ],
       "coverage": [
         {
           "function": "cobra.datos.filtrar",
@@ -173,6 +217,23 @@
         "cobra.web.enviar_post",
         "cobra.web.descargar_archivo"
       ],
+      "public_exports": [
+        {
+          "alias": "cobra.web.obtener_url",
+          "source_path": "src/pcobra/corelibs/red.py",
+          "python_symbol": "obtener_url"
+        },
+        {
+          "alias": "cobra.web.enviar_post",
+          "source_path": "src/pcobra/corelibs/red.py",
+          "python_symbol": "enviar_post"
+        },
+        {
+          "alias": "cobra.web.descargar_archivo",
+          "source_path": "src/pcobra/corelibs/red.py",
+          "python_symbol": "descargar_archivo"
+        }
+      ],
       "coverage": [
         {
           "function": "cobra.web.obtener_url",
@@ -229,6 +290,28 @@
         "cobra.system.escribir",
         "cobra.system.ejecutar",
         "cobra.system.obtener_env"
+      ],
+      "public_exports": [
+        {
+          "alias": "cobra.system.leer",
+          "source_path": "src/pcobra/standard_library/archivo.py",
+          "python_symbol": "leer"
+        },
+        {
+          "alias": "cobra.system.escribir",
+          "source_path": "src/pcobra/standard_library/archivo.py",
+          "python_symbol": "escribir"
+        },
+        {
+          "alias": "cobra.system.ejecutar",
+          "source_path": "src/pcobra/corelibs/sistema.py",
+          "python_symbol": "ejecutar"
+        },
+        {
+          "alias": "cobra.system.obtener_env",
+          "source_path": "src/pcobra/corelibs/sistema.py",
+          "python_symbol": "obtener_env"
+        }
       ],
       "coverage": [
         {

--- a/docs/_generated/stdlib_contract_matrix.md
+++ b/docs/_generated/stdlib_contract_matrix.md
@@ -26,6 +26,15 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 - `cobra.core.copiar_signo`
 - `cobra.core.signo`
 
+### Exportaciones públicas (alias Cobra estables)
+
+| Alias Cobra | Módulo runtime trazable |
+|---|---|
+| `cobra.core.es_finito` | `src/pcobra/standard_library/numero.py` |
+| `cobra.core.es_infinito` | `src/pcobra/standard_library/numero.py` |
+| `cobra.core.copiar_signo` | `src/pcobra/standard_library/numero.py` |
+| `cobra.core.signo` | `src/pcobra/standard_library/numero.py` |
+
 ### Cobertura por función
 
 | Función | Backend | Nivel |
@@ -58,6 +67,15 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 - `cobra.datos.a_listas`
 - `cobra.datos.de_listas`
 
+### Exportaciones públicas (alias Cobra estables)
+
+| Alias Cobra | Módulo runtime trazable |
+|---|---|
+| `cobra.datos.filtrar` | `src/pcobra/standard_library/datos.py` |
+| `cobra.datos.seleccionar_columnas` | `src/pcobra/standard_library/datos.py` |
+| `cobra.datos.a_listas` | `src/pcobra/standard_library/datos.py` |
+| `cobra.datos.de_listas` | `src/pcobra/standard_library/datos.py` |
+
 ### Cobertura por función
 
 | Función | Backend | Nivel |
@@ -85,6 +103,14 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 - `cobra.web.enviar_post`
 - `cobra.web.descargar_archivo`
 
+### Exportaciones públicas (alias Cobra estables)
+
+| Alias Cobra | Módulo runtime trazable |
+|---|---|
+| `cobra.web.obtener_url` | `src/pcobra/corelibs/red.py` |
+| `cobra.web.enviar_post` | `src/pcobra/corelibs/red.py` |
+| `cobra.web.descargar_archivo` | `src/pcobra/corelibs/red.py` |
+
 ### Cobertura por función
 
 | Función | Backend | Nivel |
@@ -110,6 +136,15 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 - `cobra.system.escribir`
 - `cobra.system.ejecutar`
 - `cobra.system.obtener_env`
+
+### Exportaciones públicas (alias Cobra estables)
+
+| Alias Cobra | Módulo runtime trazable |
+|---|---|
+| `cobra.system.leer` | `src/pcobra/standard_library/archivo.py` |
+| `cobra.system.escribir` | `src/pcobra/standard_library/archivo.py` |
+| `cobra.system.ejecutar` | `src/pcobra/corelibs/sistema.py` |
+| `cobra.system.obtener_env` | `src/pcobra/corelibs/sistema.py` |
 
 ### Cobertura por función
 

--- a/docs/standard_library/matriz_stdlib_unificada.md
+++ b/docs/standard_library/matriz_stdlib_unificada.md
@@ -26,6 +26,15 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 - `cobra.core.copiar_signo`
 - `cobra.core.signo`
 
+### Exportaciones públicas (alias Cobra estables)
+
+| Alias Cobra | Módulo runtime trazable |
+|---|---|
+| `cobra.core.es_finito` | `src/pcobra/standard_library/numero.py` |
+| `cobra.core.es_infinito` | `src/pcobra/standard_library/numero.py` |
+| `cobra.core.copiar_signo` | `src/pcobra/standard_library/numero.py` |
+| `cobra.core.signo` | `src/pcobra/standard_library/numero.py` |
+
 ### Cobertura por función
 
 | Función | Backend | Nivel |
@@ -58,6 +67,15 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 - `cobra.datos.a_listas`
 - `cobra.datos.de_listas`
 
+### Exportaciones públicas (alias Cobra estables)
+
+| Alias Cobra | Módulo runtime trazable |
+|---|---|
+| `cobra.datos.filtrar` | `src/pcobra/standard_library/datos.py` |
+| `cobra.datos.seleccionar_columnas` | `src/pcobra/standard_library/datos.py` |
+| `cobra.datos.a_listas` | `src/pcobra/standard_library/datos.py` |
+| `cobra.datos.de_listas` | `src/pcobra/standard_library/datos.py` |
+
 ### Cobertura por función
 
 | Función | Backend | Nivel |
@@ -85,6 +103,14 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 - `cobra.web.enviar_post`
 - `cobra.web.descargar_archivo`
 
+### Exportaciones públicas (alias Cobra estables)
+
+| Alias Cobra | Módulo runtime trazable |
+|---|---|
+| `cobra.web.obtener_url` | `src/pcobra/corelibs/red.py` |
+| `cobra.web.enviar_post` | `src/pcobra/corelibs/red.py` |
+| `cobra.web.descargar_archivo` | `src/pcobra/corelibs/red.py` |
+
 ### Cobertura por función
 
 | Función | Backend | Nivel |
@@ -110,6 +136,15 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 - `cobra.system.escribir`
 - `cobra.system.ejecutar`
 - `cobra.system.obtener_env`
+
+### Exportaciones públicas (alias Cobra estables)
+
+| Alias Cobra | Módulo runtime trazable |
+|---|---|
+| `cobra.system.leer` | `src/pcobra/standard_library/archivo.py` |
+| `cobra.system.escribir` | `src/pcobra/standard_library/archivo.py` |
+| `cobra.system.ejecutar` | `src/pcobra/corelibs/sistema.py` |
+| `cobra.system.obtener_env` | `src/pcobra/corelibs/sistema.py` |
 
 ### Cobertura por función
 

--- a/src/pcobra/cobra/stdlib_contract/__init__.py
+++ b/src/pcobra/cobra/stdlib_contract/__init__.py
@@ -115,6 +115,14 @@ def get_contract_manifests() -> dict[str, dict[str, object]]:
     return {
         contract.module: {
             "public_api": list(contract.public_api),
+            "public_exports": [
+                {
+                    "alias": export.alias,
+                    "source_path": export.source_path,
+                    "python_symbol": export.python_symbol,
+                }
+                for export in contract.public_exports
+            ],
             "backend_preferido": contract.primary_backend,
             "fallback_permitido": list(contract.allowed_fallback),
         }
@@ -142,6 +150,14 @@ def get_contract_matrix() -> dict[str, object]:
                     "core_nativos": list(mapping.core_nativos),
                 },
                 "public_api": list(contract.public_api),
+                "public_exports": [
+                    {
+                        "alias": export.alias,
+                        "source_path": export.source_path,
+                        "python_symbol": export.python_symbol,
+                    }
+                    for export in contract.public_exports
+                ],
                 "coverage": rows,
             }
         )

--- a/src/pcobra/cobra/stdlib_contract/base.py
+++ b/src/pcobra/cobra/stdlib_contract/base.py
@@ -25,11 +25,21 @@ class RuntimeMapping:
 
 
 @dataclass(frozen=True)
+class PublicApiExport:
+    """Alias público Cobra y su enlace interno para validación."""
+
+    alias: str
+    source_path: str
+    python_symbol: str
+
+
+@dataclass(frozen=True)
 class ContractDescriptor:
     """Descriptor contractual completo por módulo."""
 
     module: str
     public_api: tuple[str, ...]
+    public_exports: tuple[PublicApiExport, ...]
     primary_backend: str
     allowed_fallback: tuple[str, ...]
     runtime_mapping: RuntimeMapping

--- a/src/pcobra/cobra/stdlib_contract/cobra.core
+++ b/src/pcobra/cobra/stdlib_contract/cobra.core
@@ -1,3 +1,9 @@
 public_api = ["cobra.core.es_finito", "cobra.core.es_infinito", "cobra.core.copiar_signo", "cobra.core.signo"]
+public_exports = [
+  { alias = "cobra.core.es_finito", source_path = "src/pcobra/standard_library/numero.py", python_symbol = "es_finito" },
+  { alias = "cobra.core.es_infinito", source_path = "src/pcobra/standard_library/numero.py", python_symbol = "es_infinito" },
+  { alias = "cobra.core.copiar_signo", source_path = "src/pcobra/standard_library/numero.py", python_symbol = "copiar_signo" },
+  { alias = "cobra.core.signo", source_path = "src/pcobra/standard_library/numero.py", python_symbol = "signo" },
+]
 backend_preferido = "python"
 fallback_permitido = ["rust", "javascript"]

--- a/src/pcobra/cobra/stdlib_contract/cobra.datos
+++ b/src/pcobra/cobra/stdlib_contract/cobra.datos
@@ -1,3 +1,9 @@
 public_api = ["cobra.datos.filtrar", "cobra.datos.seleccionar_columnas", "cobra.datos.a_listas", "cobra.datos.de_listas"]
+public_exports = [
+  { alias = "cobra.datos.filtrar", source_path = "src/pcobra/standard_library/datos.py", python_symbol = "filtrar" },
+  { alias = "cobra.datos.seleccionar_columnas", source_path = "src/pcobra/standard_library/datos.py", python_symbol = "seleccionar_columnas" },
+  { alias = "cobra.datos.a_listas", source_path = "src/pcobra/standard_library/datos.py", python_symbol = "a_listas" },
+  { alias = "cobra.datos.de_listas", source_path = "src/pcobra/standard_library/datos.py", python_symbol = "de_listas" },
+]
 backend_preferido = "python"
 fallback_permitido = ["javascript"]

--- a/src/pcobra/cobra/stdlib_contract/cobra.system
+++ b/src/pcobra/cobra/stdlib_contract/cobra.system
@@ -1,3 +1,9 @@
 public_api = ["cobra.system.leer", "cobra.system.escribir", "cobra.system.ejecutar", "cobra.system.obtener_env"]
+public_exports = [
+  { alias = "cobra.system.leer", source_path = "src/pcobra/standard_library/archivo.py", python_symbol = "leer" },
+  { alias = "cobra.system.escribir", source_path = "src/pcobra/standard_library/archivo.py", python_symbol = "escribir" },
+  { alias = "cobra.system.ejecutar", source_path = "src/pcobra/corelibs/sistema.py", python_symbol = "ejecutar" },
+  { alias = "cobra.system.obtener_env", source_path = "src/pcobra/corelibs/sistema.py", python_symbol = "obtener_env" },
+]
 backend_preferido = "python"
 fallback_permitido = ["rust", "javascript"]

--- a/src/pcobra/cobra/stdlib_contract/cobra.web
+++ b/src/pcobra/cobra/stdlib_contract/cobra.web
@@ -1,3 +1,8 @@
 public_api = ["cobra.web.obtener_url", "cobra.web.enviar_post", "cobra.web.descargar_archivo"]
+public_exports = [
+  { alias = "cobra.web.obtener_url", source_path = "src/pcobra/corelibs/red.py", python_symbol = "obtener_url" },
+  { alias = "cobra.web.enviar_post", source_path = "src/pcobra/corelibs/red.py", python_symbol = "enviar_post" },
+  { alias = "cobra.web.descargar_archivo", source_path = "src/pcobra/corelibs/red.py", python_symbol = "descargar_archivo" },
+]
 backend_preferido = "javascript"
 fallback_permitido = ["python"]

--- a/src/pcobra/cobra/stdlib_contract/core.py
+++ b/src/pcobra/cobra/stdlib_contract/core.py
@@ -1,6 +1,11 @@
 """Contrato del módulo público ``cobra.core``."""
 
-from pcobra.cobra.stdlib_contract.base import ContractDescriptor, FunctionCoverage, RuntimeMapping
+from pcobra.cobra.stdlib_contract.base import (
+    ContractDescriptor,
+    FunctionCoverage,
+    PublicApiExport,
+    RuntimeMapping,
+)
 
 
 CORE_CONTRACT = ContractDescriptor(
@@ -10,6 +15,12 @@ CORE_CONTRACT = ContractDescriptor(
         "cobra.core.es_infinito",
         "cobra.core.copiar_signo",
         "cobra.core.signo",
+    ),
+    public_exports=(
+        PublicApiExport("cobra.core.es_finito", "src/pcobra/standard_library/numero.py", "es_finito"),
+        PublicApiExport("cobra.core.es_infinito", "src/pcobra/standard_library/numero.py", "es_infinito"),
+        PublicApiExport("cobra.core.copiar_signo", "src/pcobra/standard_library/numero.py", "copiar_signo"),
+        PublicApiExport("cobra.core.signo", "src/pcobra/standard_library/numero.py", "signo"),
     ),
     primary_backend="python",
     allowed_fallback=("rust", "javascript"),

--- a/src/pcobra/cobra/stdlib_contract/datos.py
+++ b/src/pcobra/cobra/stdlib_contract/datos.py
@@ -1,6 +1,11 @@
 """Contrato del módulo público ``cobra.datos``."""
 
-from pcobra.cobra.stdlib_contract.base import ContractDescriptor, FunctionCoverage, RuntimeMapping
+from pcobra.cobra.stdlib_contract.base import (
+    ContractDescriptor,
+    FunctionCoverage,
+    PublicApiExport,
+    RuntimeMapping,
+)
 
 
 DATOS_CONTRACT = ContractDescriptor(
@@ -10,6 +15,16 @@ DATOS_CONTRACT = ContractDescriptor(
         "cobra.datos.seleccionar_columnas",
         "cobra.datos.a_listas",
         "cobra.datos.de_listas",
+    ),
+    public_exports=(
+        PublicApiExport("cobra.datos.filtrar", "src/pcobra/standard_library/datos.py", "filtrar"),
+        PublicApiExport(
+            "cobra.datos.seleccionar_columnas",
+            "src/pcobra/standard_library/datos.py",
+            "seleccionar_columnas",
+        ),
+        PublicApiExport("cobra.datos.a_listas", "src/pcobra/standard_library/datos.py", "a_listas"),
+        PublicApiExport("cobra.datos.de_listas", "src/pcobra/standard_library/datos.py", "de_listas"),
     ),
     primary_backend="python",
     allowed_fallback=("javascript",),

--- a/src/pcobra/cobra/stdlib_contract/generator.py
+++ b/src/pcobra/cobra/stdlib_contract/generator.py
@@ -18,6 +18,14 @@ def render_manifest(contract: ContractDescriptor) -> str:
     return "\n".join(
         (
             f"public_api = {_toml_array(contract.public_api)}",
+            "public_exports = [",
+            *(
+                "  { "
+                + f'alias = "{export.alias}", source_path = "{export.source_path}", python_symbol = "{export.python_symbol}"'
+                + " },"
+                for export in contract.public_exports
+            ),
+            "]",
             f'backend_preferido = "{contract.primary_backend}"',
             f"fallback_permitido = {_toml_array(contract.allowed_fallback)}",
             "",
@@ -53,6 +61,14 @@ def build_contract_matrix() -> dict[str, object]:
                     "core_nativos": list(mapping.core_nativos),
                 },
                 "public_api": list(descriptor.public_api),
+                "public_exports": [
+                    {
+                        "alias": export.alias,
+                        "source_path": export.source_path,
+                        "python_symbol": export.python_symbol,
+                    }
+                    for export in descriptor.public_exports
+                ],
                 "coverage": coverage_rows,
             }
         )
@@ -118,6 +134,17 @@ def render_contract_markdown() -> str:
             )
         )
         lines.extend(f"- `{api}`" for api in descriptor.public_api)
+        lines.extend(
+            (
+                "",
+                "### Exportaciones públicas (alias Cobra estables)",
+                "",
+                "| Alias Cobra | Módulo runtime trazable |",
+                "|---|---|",
+            )
+        )
+        for export in descriptor.public_exports:
+            lines.append(f"| `{export.alias}` | `{export.source_path}` |")
         lines.extend(("", "### Cobertura por función", "", "| Función | Backend | Nivel |", "|---|---|---|"))
         for coverage in descriptor.coverage:
             for backend, level in coverage.backend_levels.items():

--- a/src/pcobra/cobra/stdlib_contract/system.py
+++ b/src/pcobra/cobra/stdlib_contract/system.py
@@ -1,6 +1,11 @@
 """Contrato del módulo público ``cobra.system``."""
 
-from pcobra.cobra.stdlib_contract.base import ContractDescriptor, FunctionCoverage, RuntimeMapping
+from pcobra.cobra.stdlib_contract.base import (
+    ContractDescriptor,
+    FunctionCoverage,
+    PublicApiExport,
+    RuntimeMapping,
+)
 
 
 SYSTEM_CONTRACT = ContractDescriptor(
@@ -10,6 +15,16 @@ SYSTEM_CONTRACT = ContractDescriptor(
         "cobra.system.escribir",
         "cobra.system.ejecutar",
         "cobra.system.obtener_env",
+    ),
+    public_exports=(
+        PublicApiExport("cobra.system.leer", "src/pcobra/standard_library/archivo.py", "leer"),
+        PublicApiExport("cobra.system.escribir", "src/pcobra/standard_library/archivo.py", "escribir"),
+        PublicApiExport("cobra.system.ejecutar", "src/pcobra/corelibs/sistema.py", "ejecutar"),
+        PublicApiExport(
+            "cobra.system.obtener_env",
+            "src/pcobra/corelibs/sistema.py",
+            "obtener_env",
+        ),
     ),
     primary_backend="python",
     allowed_fallback=("rust", "javascript"),

--- a/src/pcobra/cobra/stdlib_contract/validator.py
+++ b/src/pcobra/cobra/stdlib_contract/validator.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Final
 
 from pcobra.cobra.stdlib_contract import CONTRACTS, get_blueprint_contract_manifests
-from pcobra.cobra.stdlib_contract.base import ContractDescriptor
+from pcobra.cobra.stdlib_contract.base import ContractDescriptor, PublicApiExport
 from pcobra.cobra.stdlib_contract.generator import build_contract_matrix, render_contract_markdown
 
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[4]
@@ -82,26 +82,55 @@ def _validate_mapping_paths(contract: ContractDescriptor) -> None:
 
 
 def _validate_public_api(contract: ContractDescriptor) -> None:
-    available_symbols: set[str] = set()
-    for path in _iter_mapping_paths(contract):
-        available_symbols.update(_extract_symbols(path))
-
-    missing = []
-    for api in contract.public_api:
-        expected_symbol = api.rsplit(".", 1)[-1]
-        if expected_symbol not in available_symbols:
-            missing.append(api)
-
-    if missing:
-        raise ContractValidationError(
-            f"{contract.module}: API pública no encontrada en runtime mapping: {missing}"
-        )
-
     expected_prefix = f"{contract.module}."
     invalid_api = [api for api in contract.public_api if not api.startswith(expected_prefix)]
     if invalid_api:
         raise ContractValidationError(
             f"{contract.module}: API pública fuera del namespace del módulo: {invalid_api}"
+        )
+    if len(contract.public_exports) != len(contract.public_api):
+        raise ContractValidationError(
+            f"{contract.module}: cantidad de public_exports no coincide con public_api. "
+            f"public_api={len(contract.public_api)} public_exports={len(contract.public_exports)}"
+        )
+
+    allowed_paths = {
+        *contract.runtime_mapping.standard_library,
+        *contract.runtime_mapping.corelibs,
+    }
+    allowed_prefixes = ("src/pcobra/standard_library/", "src/pcobra/corelibs/")
+    export_by_alias: dict[str, PublicApiExport] = {}
+    for export in contract.public_exports:
+        if export.alias in export_by_alias:
+            raise ContractValidationError(
+                f"{contract.module}: alias público duplicado en public_exports: {export.alias}"
+            )
+        export_by_alias[export.alias] = export
+        if not export.alias.startswith(expected_prefix):
+            raise ContractValidationError(
+                f"{contract.module}: alias fuera del namespace del módulo: {export.alias}"
+            )
+        if export.source_path not in allowed_paths:
+            raise ContractValidationError(
+                f"{contract.module}: source_path fuera de runtime_mapping standard_library/corelibs: "
+                f"{export.source_path}"
+            )
+        if not export.source_path.startswith(allowed_prefixes):
+            raise ContractValidationError(
+                f"{contract.module}: source_path inválido para trazabilidad pública: {export.source_path}"
+            )
+
+        path = (REPO_ROOT / export.source_path).resolve()
+        symbols = _extract_symbols(path)
+        if export.python_symbol not in symbols:
+            raise ContractValidationError(
+                f"{contract.module}: símbolo `{export.python_symbol}` no encontrado en {export.source_path}"
+            )
+
+    missing_exports = [api for api in contract.public_api if api not in export_by_alias]
+    if missing_exports:
+        raise ContractValidationError(
+            f"{contract.module}: public_api sin entrada en public_exports: {missing_exports}"
         )
 
 

--- a/src/pcobra/cobra/stdlib_contract/web.py
+++ b/src/pcobra/cobra/stdlib_contract/web.py
@@ -1,6 +1,11 @@
 """Contrato del módulo público ``cobra.web``."""
 
-from pcobra.cobra.stdlib_contract.base import ContractDescriptor, FunctionCoverage, RuntimeMapping
+from pcobra.cobra.stdlib_contract.base import (
+    ContractDescriptor,
+    FunctionCoverage,
+    PublicApiExport,
+    RuntimeMapping,
+)
 
 
 WEB_CONTRACT = ContractDescriptor(
@@ -9,6 +14,15 @@ WEB_CONTRACT = ContractDescriptor(
         "cobra.web.obtener_url",
         "cobra.web.enviar_post",
         "cobra.web.descargar_archivo",
+    ),
+    public_exports=(
+        PublicApiExport("cobra.web.obtener_url", "src/pcobra/corelibs/red.py", "obtener_url"),
+        PublicApiExport("cobra.web.enviar_post", "src/pcobra/corelibs/red.py", "enviar_post"),
+        PublicApiExport(
+            "cobra.web.descargar_archivo",
+            "src/pcobra/corelibs/red.py",
+            "descargar_archivo",
+        ),
     ),
     primary_backend="javascript",
     allowed_fallback=("python",),

--- a/tests/unit/test_stdlib_contract_descriptor.py
+++ b/tests/unit/test_stdlib_contract_descriptor.py
@@ -14,6 +14,7 @@ def test_contracts_declaran_campos_minimos_para_module_map():
     for module, manifest in manifests.items():
         assert module.startswith("cobra.")
         assert manifest["public_api"]
+        assert manifest["public_exports"]
         assert isinstance(manifest["backend_preferido"], str)
 
 
@@ -21,6 +22,8 @@ def test_markdown_generado_incluye_tabla_cobertura_por_funcion():
     markdown = render_contract_markdown()
     assert "Tabla de garantías por módulo" in markdown
     assert "| Módulo | API pública | Backend primario | Fallback | Límites |" in markdown
+    assert "Exportaciones públicas (alias Cobra estables)" in markdown
+    assert "| Alias Cobra | Módulo runtime trazable |" in markdown
     assert "Cobertura por función" in markdown
     assert "| Función | Backend | Nivel |" in markdown
     for descriptor in CONTRACTS:

--- a/tests/unit/test_stdlib_contract_validator.py
+++ b/tests/unit/test_stdlib_contract_validator.py
@@ -31,9 +31,11 @@ def test_stdlib_matrix_contains_all_contract_modules() -> None:
 
     for module in modules:
         assert isinstance(module["public_api"], list)
+        assert isinstance(module["public_exports"], list)
         assert isinstance(module["coverage"], list)
         assert isinstance(module["runtime_mapping"], dict)
         coverage_rows = module["coverage"]
         assert coverage_rows
+        assert module["public_exports"]
         for row in coverage_rows:
             assert row["level"] in {"full", "partial"}


### PR DESCRIPTION
### Motivation

- Formalizar `src/pcobra/cobra/stdlib_contract/*.py` como manifiesto oficial de la API pública y evitar depender de convenciones implícitas en tiempo de ejecución. 
- Evitar exponer nombres internos Python directamente y garantizar aliases estables de la API Cobra con trazabilidad a implementaciones runtime. 
- Detectar automáticamente desalineos entre contrato, implementaciones (`standard_library/*` o `corelibs/*`) y la documentación para prevenir drift manual. 

### Description

- Se añadió el modelo `PublicApiExport` y `public_exports` a `ContractDescriptor` para declarar por alias Cobra el `source_path` y el `python_symbol`. 
- Se actualizaron los descriptores de módulo (`cobra.core`, `cobra.datos`, `cobra.web`, `cobra.system`) para incluir `public_exports` mapeando cada alias Cobra a su archivo runtime trazable y símbolo Python. 
- El validador ahora exige correspondencia 1:1 entre `public_api` y `public_exports`, comprueba que los alias estén en el namespace del módulo, limita la trazabilidad a rutas en `standard_library`/`corelibs` declaradas en `runtime_mapping` y verifica que el `python_symbol` exista en el archivo indicado. 
- El generador y las funciones de exportación (`get_contract_manifests`, `get_contract_matrix`, `render_manifest`, `render_contract_markdown`) incluyen `public_exports` en los manifiestos TOML, JSON y en la documentación Markdown (se añadió la tabla "Exportaciones públicas (alias Cobra estables)" por módulo). 
- Se regeneraron artefactos de contrato en `docs/_generated/stdlib_contract_matrix.{md,json}` y en `docs/standard_library/matriz_stdlib_unificada.md`, y se ajustaron pruebas unitarias relacionadas para exigir `public_exports`. 

### Testing

- Ejecuté `python scripts/generar_contrato_stdlib.py` y completó sin errores. 
- Ejecuté `pytest -q tests/unit/test_stdlib_contract_descriptor.py tests/unit/test_stdlib_contract_validator.py` y todos los tests pasaron (`7 passed`). 
- Se verificó que los artefactos en `docs/_generated/` y `docs/standard_library/` fueron actualizados para reflejar las nuevas `public_exports`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3702abfbc83279d21bda4c1625e1a)