### PR TITLE
feat(imports): formalizar contrato de precedencia, códigos estables y auditoría debug

### DIFF
--- a/docs/architecture/import-resolution-contract.md
+++ b/docs/architecture/import-resolution-contract.md
@@ -12,14 +12,19 @@ El orden vigente de precedencia se congela como contrato público en
 3. `python_bridge`
 4. `hybrid`
 
-Este orden debe tratarse como **API contractual** (estable entre releases menores).
+Este orden debe tratarse como **API contractual** y solo puede cambiar en una versión mayor.
+
+En el runtime queda expuesto como:
+
+- `RESOLUTION_SOURCE_ORDER` (tupla contractual vigente)
+- `RESOLUTION_SOURCE_ORDER_STABILITY = "major"` (política de estabilidad)
 
 En términos prácticos:
 
 - Si `importar datos` coincide con `cobra.datos` y también existe un módulo local `datos`, se resuelve primero como stdlib (`cobra.datos`).
 - Cuando un nombre sin namespace coincide en múltiples orígenes, el resultado efectivo siempre sigue el orden anterior.
 
-## 2) Política explícita para imports ambiguos
+## 2) Política explícita para imports ambiguos y códigos de error estables
 
 Se considera ambiguo un import sin namespace (sin `.`) que tenga más de un candidato válido entre los orígenes del contrato.
 
@@ -30,12 +35,12 @@ La política se configura por proyecto en `cobra.toml`:
 collision_policy = "warn" # warn | strict_error | namespace_required
 ```
 
-Si no se declara nada, el resolver usa `warn` por compatibilidad (`DEFAULT_COLLISION_POLICY`).
+Si no se declara nada, el resolver usa `namespace_required` (`DEFAULT_COLLISION_POLICY`).
 
-### `warn` (modo por defecto)
+### `warn` (modo de migración/compatibilidad)
 
 - El resolver emite `UserWarning`.
-- Se selecciona automáticamente el candidato de mayor prioridad según `_SOURCE_ORDER`.
+- Se selecciona automáticamente el candidato de mayor prioridad según `RESOLUTION_SOURCE_ORDER`.
 
 ### `strict_error`
 
@@ -51,6 +56,18 @@ Si no se declara nada, el resolver usa `warn` por compatibilidad (`DEFAULT_COLLI
 
 > Compatibilidad: `strict_ambiguous_imports=True` sigue soportado y fuerza `strict_error`.
 
+### Códigos de error estables (`ImportResolutionError`)
+
+El resolver adjunta un código máquina estable en `ImportResolutionError.code`
+(y en el texto como prefijo `[CODIGO]`) para tooling/CI:
+
+- `IMP-COLLISION-001`: colisión de import sin namespace en `strict_error`/`namespace_required`.
+- `IMP-NOT-FOUND-001`: no existe candidato de resolución para el módulo solicitado.
+- `IMP-REQUEST-001`: request vacío.
+- `IMP-CONFIG-001`: `collision_policy` inválida en configuración.
+
+
+
 ## 3) Prefijos recomendados para evitar colisiones
 
 Recomendaciones normativas:
@@ -59,7 +76,7 @@ Recomendaciones normativas:
 - **Módulos de proyecto**: usar namespace de aplicación (por ejemplo `app.datos`, `mi_equipo.datos`) en lugar de nombres planos como `datos`.
 - **Bridge Python**: preferir nombres plenamente calificados cuando aplique (`json`, `datetime`, `paquete.submodulo`) y evitar nombres genéricos que colisionen con stdlib/proyecto.
 
-## 4) Metadata de observabilidad en módulos cargados
+## 4) Metadata de observabilidad en módulos cargados y auditoría opcional
 
 Cuando el resolvedor carga un módulo Python (`load_module`), inyecta metadata para diagnóstico:
 
@@ -72,6 +89,16 @@ Cuando el resolvedor carga un módulo Python (`load_module`), inyecta metadata p
   - `backend`
   - `import_path`
   - `precedence_reason` (motivo de precedencia: selección única o aplicación de orden estable)
+  - `audit_debug` (si la auditoría de debug está activa)
+
+Adicionalmente, se puede habilitar auditoría opcional:
+
+```toml
+[imports]
+audit_debug = true
+```
+
+Con `audit_debug=true`, cada resolución agrega un evento en `resolver.audit_events` y escribe log `DEBUG` con `request`, `source`, `resolved_name` y `precedence_reason`.
 
 Esta metadata habilita trazabilidad de resolución y debugging en runtime sin inspección adicional del resolvedor.
 
@@ -113,12 +140,29 @@ backend = "javascript"
 Estos 3 casos (`importar pandas`, `importar datos`/`importar cobra.datos`, e híbridos
 en `imports.hybrid_modules`) son rutas oficiales del contrato de resolución.
 
-## 6) Ejemplos de conflictos y resolución explícita
+## 6) Patrón recomendado de namespaces y migración de conflictos reales
 
-- Conflicto `datos` entre stdlib y proyecto:
-  - Implícito: `importar datos` (ambigüedad)
-  - Explícito recomendado:
-    - stdlib: `importar cobra.datos`
-    - proyecto: `importar app.datos`
-- Conflicto con bridge Python:
-  - Si existe paquete Python `datos`, usar nombre explícito de proyecto o stdlib para evitar depender de orden de precedencia.
+Patrón normativo recomendado:
+
+- **stdlib Cobra**: `cobra.*`
+- **módulos de app/proyecto**: `app.*` (o un namespace organizacional equivalente)
+
+Migraciones sugeridas (casos reales frecuentes):
+
+1. Conflicto `datos` (stdlib vs módulo local):
+   - Antes: `importar datos`
+   - Después (stdlib): `importar cobra.datos`
+   - Después (app): `importar app.datos`
+
+2. Conflicto `web` (stdlib `cobra.web` vs carpeta local `web/`):
+   - Antes: `importar web`
+   - Después (stdlib): `importar cobra.web`
+   - Después (app): `importar app.web`
+
+3. Conflicto con bridge Python (`json`):
+   - Si el proyecto crea `app/json.co`, evitar `importar json` en código nuevo.
+   - Preferir:
+     - bridge Python: `importar json` solo cuando no exista colisión local/stdlib
+     - app explícita: `importar app.json`
+
+Esta convención minimiza deuda de migración y evita depender de precedencia implícita en conflictos.

--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import logging
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,8 +18,25 @@ from pcobra.cobra.stdlib_contract import get_public_stdlib_module_contracts
 
 
 class ImportResolutionError(RuntimeError):
-    """Error base al resolver imports Cobra."""
+    """Error base al resolver imports Cobra con código estable para tooling."""
 
+    def __init__(self, message: str, *, code: str = "IMP-RESOLUTION-000") -> None:
+        self.code = code
+        self.message = message
+        super().__init__(f"[{code}] {message}")
+
+
+
+
+@dataclass(frozen=True)
+class ImportResolutionAuditEvent:
+    """Evento de auditoría de una resolución de import."""
+
+    request: str
+    source: str
+    resolved_name: str
+    precedence_reason: str | None
+    collision_policy: str
 
 @dataclass(frozen=True)
 class HybridModuleSpec:
@@ -45,6 +63,7 @@ class ResolutionResult:
 API_CONTRACT_VERSION = "2026-04-import-resolution-v1"
 RESOLUTION_SOURCE_ORDER: tuple[str, ...] = ("stdlib", "project", "python_bridge", "hybrid")
 DEFAULT_COLLISION_POLICY = "namespace_required"
+RESOLUTION_SOURCE_ORDER_STABILITY = "major"
 # Backward-compatible alias (internal histórico).
 _SOURCE_ORDER: tuple[str, ...] = RESOLUTION_SOURCE_ORDER
 _SUPPORTED_COLLISION_POLICIES: frozenset[str] = frozenset(
@@ -55,6 +74,7 @@ _SUPPORTED_COLLISION_POLICIES: frozenset[str] = frozenset(
 class CobraImportResolver:
     """Resuelve imports con prioridad fija y conflictos explícitos."""
     resolution_source_order = RESOLUTION_SOURCE_ORDER
+    resolution_source_order_stability = RESOLUTION_SOURCE_ORDER_STABILITY
     default_collision_policy = DEFAULT_COLLISION_POLICY
     api_contract_version = API_CONTRACT_VERSION
 
@@ -66,6 +86,7 @@ class CobraImportResolver:
         default_backend: str = "python",
         strict_ambiguous_imports: bool = False,
         collision_policy: str | None = None,
+        audit_debug: bool | None = None,
     ) -> None:
         self.project_root = Path(project_root).resolve() if project_root else None
         config = get_toml_map()
@@ -77,6 +98,8 @@ class CobraImportResolver:
             strict_ambiguous_imports=strict_ambiguous_imports,
             explicit_policy=collision_policy,
         )
+        self.audit_debug = self._resolve_audit_debug(config=config, explicit=audit_debug)
+        self.audit_events: list[ImportResolutionAuditEvent] = []
         self.stdlib_modules = self._load_stdlib_modules()
         self.project_modules = self._load_project_modules()
 
@@ -118,7 +141,8 @@ class CobraImportResolver:
         if chosen not in _SUPPORTED_COLLISION_POLICIES:
             raise ImportResolutionError(
                 "Política de colisiones inválida. "
-                "Usa 'warn', 'strict_error' o 'namespace_required'."
+                "Usa 'warn', 'strict_error' o 'namespace_required'.",
+                code="IMP-CONFIG-001",
             )
         return chosen
 
@@ -131,6 +155,35 @@ class CobraImportResolver:
         if isinstance(policy, str):
             return policy.strip()
         return None
+
+    @staticmethod
+    def _resolve_audit_debug(*, config: Mapping[str, Any], explicit: bool | None) -> bool:
+        if explicit is not None:
+            return explicit
+        imports_section = config.get("imports", {})
+        if not isinstance(imports_section, Mapping):
+            return False
+        return imports_section.get("audit_debug") is True
+
+    def _emit_audit(self, resolution: ResolutionResult) -> None:
+        if not self.audit_debug:
+            return
+        event = ImportResolutionAuditEvent(
+            request=resolution.request,
+            source=resolution.source,
+            resolved_name=resolution.resolved_name,
+            precedence_reason=resolution.precedence_reason,
+            collision_policy=self.collision_policy,
+        )
+        self.audit_events.append(event)
+        logging.getLogger(__name__).debug(
+            "IMPORT_AUDIT request=%s source=%s resolved_name=%s precedence_reason=%s collision_policy=%s",
+            event.request,
+            event.source,
+            event.resolved_name,
+            event.precedence_reason,
+            event.collision_policy,
+        )
 
     @staticmethod
     def _is_migration_mode_enabled(config: Mapping[str, Any]) -> bool:
@@ -176,7 +229,7 @@ class CobraImportResolver:
     def resolve(self, module_name: str) -> ResolutionResult:
         name = (module_name or "").strip()
         if not name:
-            raise ImportResolutionError("Nombre de módulo vacío")
+            raise ImportResolutionError("Nombre de módulo vacío", code="IMP-REQUEST-001")
 
         candidates: list[ResolutionResult] = []
         for source in RESOLUTION_SOURCE_ORDER:
@@ -185,7 +238,10 @@ class CobraImportResolver:
                 candidates.append(candidate)
 
         if not candidates:
-            raise ImportResolutionError(f"No se encontró módulo para '{name}'")
+            raise ImportResolutionError(
+                f"No se encontró módulo para '{name}'",
+                code="IMP-NOT-FOUND-001",
+            )
 
         precedence_reason = (
             f"unique_source:{candidates[0].source}"
@@ -210,7 +266,7 @@ class CobraImportResolver:
                     if self.collision_policy == "namespace_required"
                     else " Activa resolución explícita en strict mode."
                 )
-                raise ImportResolutionError(f"{message}{suffix}")
+                raise ImportResolutionError(f"{message}{suffix}", code="IMP-COLLISION-001")
             warnings.warn(message, category=UserWarning, stacklevel=2)
 
         selected = ResolutionResult(
@@ -222,7 +278,9 @@ class CobraImportResolver:
             backend_adapter=candidates[0].backend_adapter,
             precedence_reason=precedence_reason,
         )
-        return self._attach_backend_adapter(selected)
+        resolved = self._attach_backend_adapter(selected)
+        self._emit_audit(resolved)
+        return resolved
 
     def load_module(
         self,
@@ -262,6 +320,7 @@ class CobraImportResolver:
             "backend": resolution.backend,
             "import_path": resolution.import_path,
             "precedence_reason": resolution.precedence_reason,
+            "audit_debug": self.audit_debug,
         }
         setattr(module, "__cobra_resolution_source__", resolution.source)
         setattr(module, "__cobra_backend_injected__", resolution.backend)

--- a/tests/unit/test_imports_resolver.py
+++ b/tests/unit/test_imports_resolver.py
@@ -204,6 +204,7 @@ def test_modulo_hibrido_inyecta_adapter_backend(monkeypatch):
         "backend": "javascript",
         "import_path": "mi_hibrido_runtime",
         "precedence_reason": "unique_source:hybrid",
+        "audit_debug": False,
     }
 
 
@@ -253,6 +254,7 @@ def test_metadata_uniforme_en_ruta_stdlib():
     assert metadata["api_contract_version"] == "2026-04-import-resolution-v1"
     assert metadata["resolution_source_order"] == ["stdlib", "project", "python_bridge", "hybrid"]
     assert metadata["collision_policy"] == "namespace_required"
+    assert metadata["audit_debug"] is False
 
 
 def test_metadata_uniforme_en_ruta_python_bridge():
@@ -267,6 +269,7 @@ def test_metadata_uniforme_en_ruta_python_bridge():
     assert metadata["api_contract_version"] == "2026-04-import-resolution-v1"
     assert metadata["resolution_source_order"] == ["stdlib", "project", "python_bridge", "hybrid"]
     assert metadata["collision_policy"] == "namespace_required"
+    assert metadata["audit_debug"] is False
 
 
 def test_resolver_adjunta_adapter_desde_resolucion():
@@ -354,3 +357,43 @@ def test_error_si_no_hay_candidato():
 
     with pytest.raises(ImportResolutionError):
         resolver.resolve("__modulo_improbable_no_existente__")
+
+
+def test_error_colision_expone_codigo_estable(tmp_path):
+    (tmp_path / "datos.co").write_text("usar algo")
+    resolver = CobraImportResolver(project_root=tmp_path)
+
+    with pytest.raises(ImportResolutionError) as excinfo:
+        resolver.resolve("datos")
+
+    assert excinfo.value.code == "IMP-COLLISION-001"
+    assert "[IMP-COLLISION-001]" in str(excinfo.value)
+
+
+def test_audit_debug_registra_resolucion_y_precedence_reason(tmp_path):
+    (tmp_path / "datos.co").write_text("usar algo")
+    resolver = CobraImportResolver(
+        project_root=tmp_path,
+        collision_policy="warn",
+        audit_debug=True,
+    )
+
+    with pytest.warns(UserWarning, match="Colisión de import"):
+        resolver.resolve("datos")
+
+    assert len(resolver.audit_events) == 1
+    event = resolver.audit_events[0]
+    assert event.request == "datos"
+    assert event.source == "stdlib"
+    assert event.precedence_reason == "source_order:stdlib > project > python_bridge > hybrid"
+
+
+def test_resolver_expone_estabilidad_de_orden_en_major():
+    assert CobraImportResolver.resolution_source_order == (
+        "stdlib",
+        "project",
+        "python_bridge",
+        "hybrid",
+    )
+    assert CobraImportResolver.resolution_source_order_stability == "major"
+


### PR DESCRIPTION
### Motivation
- Congelar `RESOLUTION_SOURCE_ORDER` como parte del contrato público y hacer explícita su estabilidad a nivel de cambios mayores. 
- Facilitar integraciones y tooling mediante códigos de error estables en `ImportResolutionError`. 
- Proveer trazabilidad opcional de resolución de imports (audit/debug) para depuración y auditoría en runtime. 
- Documentar un patrón recomendado de namespaces (`cobra.*`, `app.*`) y ejemplos de migración en conflictos reales.

### Description
- Mantiene `RESOLUTION_SOURCE_ORDER` y expone `RESOLUTION_SOURCE_ORDER_STABILITY = "major"` como indicador de que solo cambia en versiones mayores, y añade el mismo atributo a `CobraImportResolver`.
- Enriquece `ImportResolutionError` con un campo `code` y formato de mensaje prefijado (`[CODE] ...`) y añade códigos concretos: `IMP-COLLISION-001`, `IMP-NOT-FOUND-001`, `IMP-REQUEST-001`, `IMP-CONFIG-001`.
- Añade auditoría opcional: nuevo parámetro `audit_debug` en `CobraImportResolver`, lectura desde `cobra.toml` (`[imports] audit_debug = true`), estructura `ImportResolutionAuditEvent`, almacenamiento en `resolver.audit_events` y log `DEBUG` con `precedence_reason`; además incluye `audit_debug` en `__cobra_resolution_metadata__`.
- Actualiza la documentación contractual `docs/architecture/import-resolution-contract.md` para reflejar la estabilidad del orden, el catálogo de códigos, la opción de auditoría y el patrón de namespaces con ejemplos de migración.
- Actualiza y extiende `tests/unit/test_imports_resolver.py` para cubrir la metadata nueva, el código de error estable y la auditoría opcional.

### Testing
- Se validó la sintaxis de los archivos modificados con `python -m py_compile src/pcobra/cobra/imports/resolver.py tests/unit/test_imports_resolver.py`, que pasó correctamente. 
- Se añadió/actualizó test cases en `tests/unit/test_imports_resolver.py` que comprueban `audit_debug` en metadata, el contenido de `resolver.audit_events` y la presencia del código `IMP-COLLISION-001` en `ImportResolutionError`.
- Intento de ejecutar `pytest -q tests/unit/test_imports_resolver.py` falló en la fase de colección por un `ImportError` preexistente del entorno (`cannot import name 'resolve_backend' from pcobra.cobra.build.backend_pipeline`), por lo que la ejecución completa de los tests unitarios quedó interrumpida.
- Resumen: compilación estática OK; pruebas unitarias actualizadas pero ejecución parcial interrumpida por un error de importación ajeno a los cambios realizados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3719bcc00832784f200aadd43fba2)