### PR TITLE
Centraliza validación runtime por comando y agrega logging estructurado

### DIFF
--- a/src/pcobra/cobra/bindings/runtime_manager.py
+++ b/src/pcobra/cobra/bindings/runtime_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
@@ -86,6 +87,7 @@ class RuntimeManager:
             internal_only=False,
         ),
     }
+    _runtime_logger = logging.getLogger("pcobra.runtime")
 
     def __init__(self) -> None:
         self._validate_public_contracts()
@@ -197,6 +199,18 @@ class RuntimeManager:
             command=command,
         )
         negotiated_abi = self.negotiate_abi(capabilities, abi_version)
+        self._runtime_logger.info(
+            "runtime.command.validation",
+            extra={
+                "command": (command or "").strip().lower(),
+                "language": capabilities.language,
+                "route": capabilities.route.value,
+                "bridge": bridge.implementation,
+                "abi_version": negotiated_abi,
+                "sandbox": sandbox,
+                "containerized": containerized,
+            },
+        )
         return negotiated_abi, capabilities, bridge
 
     def select_bridge(self, capabilities: BindingCapabilities) -> RuntimeBridgeDescriptor:

--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -118,12 +118,6 @@ def _obtener_interpretador_cls():
     return getattr(sys.modules[__name__], "InterpretadorCobra", InterpretadorCobra)
 
 
-def _resolver_runtime_binding(target: str):
-    """Resuelve contrato + bridge de bindings usado por runners CLI."""
-
-    return RUNTIME_MANAGER.resolve_runtime(target)
-
-
 class ExecuteCommand(BaseCommand):
     """Ejecuta un script Cobra desde un archivo."""
 
@@ -251,9 +245,12 @@ class ExecuteCommand(BaseCommand):
 
         try:
             raiz_proyecto = _detectar_raiz_proyecto_desde_archivo(str(archivo_resuelto))
-            contrato_python, _bridge_python = _resolver_runtime_binding("python")
-            RUNTIME_MANAGER.validate_security_route("python", sandbox=sandbox, containerized=False, command="run")
-            RUNTIME_MANAGER.validate_abi_route("python")
+            _abi_python, contrato_python, _bridge_python = RUNTIME_MANAGER.validate_command_runtime(
+                "python",
+                command="run",
+                sandbox=sandbox,
+                containerized=False,
+            )
             validar_dependencias(
                 contrato_python.language,
                 module_map.get_toml_map(),
@@ -352,9 +349,12 @@ class ExecuteCommand(BaseCommand):
     def _ejecutar_en_contenedor(self, codigo: str, contenedor: str) -> int:
         """Ejecuta el código en un contenedor Docker."""
         try:
-            contrato, bridge = _resolver_runtime_binding(contenedor)
-            RUNTIME_MANAGER.validate_security_route(contenedor, sandbox=False, containerized=True, command="run")
-            abi_version = RUNTIME_MANAGER.validate_abi_route(contenedor)
+            abi_version, contrato, bridge = RUNTIME_MANAGER.validate_command_runtime(
+                contenedor,
+                command="run",
+                sandbox=False,
+                containerized=True,
+            )
             self.logger.debug(
                 "Ruta de bindings para contenedor '%s': %s (%s) bridge=%s abi=%s",
                 contenedor,

--- a/tests/unit/test_binding_contract_canonical.py
+++ b/tests/unit/test_binding_contract_canonical.py
@@ -1,5 +1,22 @@
-from bindings.contract import BindingRoute, resolve_binding
+from bindings.contract import BindingRoute, OFFICIAL_PUBLIC_ROUTE_MATRIX, resolve_binding
 
 
 def test_binding_contract_canonical_route_python():
     assert resolve_binding("python").route is BindingRoute.PYTHON_DIRECT_IMPORT
+
+
+def test_binding_contract_canonical_route_javascript():
+    assert resolve_binding("javascript").route is BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE
+
+
+def test_binding_contract_canonical_route_rust():
+    assert resolve_binding("rust").route is BindingRoute.RUST_COMPILED_FFI
+
+
+def test_binding_contract_public_backends_tienen_mapeo_1_a_1_con_matriz_oficial():
+    expected = {
+        "python": BindingRoute.PYTHON_DIRECT_IMPORT,
+        "javascript": BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE,
+        "rust": BindingRoute.RUST_COMPILED_FFI,
+    }
+    assert OFFICIAL_PUBLIC_ROUTE_MATRIX == expected

--- a/tests/unit/test_execute_cmd_binding_contract.py
+++ b/tests/unit/test_execute_cmd_binding_contract.py
@@ -4,34 +4,23 @@ from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
 def test_ejecutar_en_contenedor_resuelve_contrato(monkeypatch):
     import pcobra.cobra.cli.commands.execute_cmd as execute_module
 
-    llamadas: list[str] = []
+    llamadas: list[tuple[str, str]] = []
 
-    def _resolver(target: str):
-        llamadas.append(target)
+    class _Contrato:
+        route = type("R", (), {"value": "javascript_runtime_bridge"})()
+        execution_boundary = "Aislado"
+        language = "javascript"
 
-        class _Contrato:
-            route = type("R", (), {"value": "javascript_runtime_bridge"})()
-            execution_boundary = "Aislado"
-            language = "javascript"
+    class _Bridge:
+        implementation = "javascript_controlled_runtime_bridge"
 
-        class _Bridge:
-            implementation = "javascript_controlled_runtime_bridge"
-
-        return _Contrato(), _Bridge()
-
-    monkeypatch.setattr(execute_module, "_resolver_runtime_binding", _resolver)
     monkeypatch.setattr(
         execute_module.RUNTIME_MANAGER,
-        "validate_security_route",
-        lambda *_args, **_kwargs: None,
-    )
-    monkeypatch.setattr(
-        execute_module.RUNTIME_MANAGER,
-        "validate_abi_route",
-        lambda *_args, **_kwargs: "1.0",
+        "validate_command_runtime",
+        lambda target, **kwargs: llamadas.append((target, kwargs["command"])) or ("1.0", _Contrato(), _Bridge()),
     )
     monkeypatch.setattr(execute_module, "resolve_docker_backend", lambda value: value)
     monkeypatch.setattr(execute_module, "ejecutar_en_contenedor", lambda _codigo, _backend: "ok")
 
     assert ExecuteCommand()._ejecutar_en_contenedor("imprimir(1)", "javascript") == 0
-    assert llamadas == ["javascript"]
+    assert llamadas == [("javascript", "run")]

--- a/tests/unit/test_runtime_manager.py
+++ b/tests/unit/test_runtime_manager.py
@@ -62,6 +62,24 @@ def test_runtime_manager_validate_command_runtime_retorna_abi_capabilities_y_bri
     assert bridge.internal_only is False
 
 
+def test_runtime_manager_validate_command_runtime_loguea_contexto_estructurado(caplog):
+    manager = RuntimeManager()
+
+    with caplog.at_level("INFO", logger="pcobra.runtime"):
+        manager.validate_command_runtime(
+            "javascript",
+            command="run",
+            sandbox=False,
+            containerized=True,
+        )
+
+    record = next(rec for rec in caplog.records if rec.message == "runtime.command.validation")
+    assert record.command == "run"
+    assert record.route == "javascript_runtime_bridge"
+    assert record.bridge == "javascript_controlled_runtime_bridge"
+    assert record.abi_version == manager.validate_abi_route("javascript")
+
+
 def test_runtime_manager_negocia_abi_desde_config(monkeypatch, tmp_path: Path):
     manager = RuntimeManager()
     cobra_toml = tmp_path / "cobra.toml"


### PR DESCRIPTION
### Motivation

- Unificar la validación de seguridad y ABI para comandos públicos en un único punto para evitar bypasses y mantener políticas consistentes.
- Mejorar la observabilidad operativa exponiendo en logs estructurados la `route`, `bridge` y `abi_version` resueltos por comando.
- Asegurar que la matriz pública de backends tiene mapeo 1:1 con las rutas contractuales oficiales (`python_direct_import`, `javascript_runtime_bridge`, `rust_compiled_ffi`).

### Description

- Centraliza la validación de seguridad y ABI por comando en `RuntimeManager.validate_command_runtime` y emite un log estructurado (`pcobra.runtime`) con `command`, `language`, `route`, `bridge`, `abi_version`, `sandbox` y `containerized`.
- Sustituye validaciones y resoluciones manuales en `ExecuteCommand` por una única llamada a `RUNTIME_MANAGER.validate_command_runtime` tanto en la validación inicial de dependencias (Python) como en la ejecución en contenedor.
- Añade/actualiza tests que verifican el mapeo 1:1 entre backends públicos y rutas oficiales, que el camino de contenedor usa `validate_command_runtime`, y que se emite el evento de log estructurado con los campos esperados.

### Testing

- Ejecuté `pytest -q tests/unit/test_runtime_manager.py tests/unit/test_execute_cmd_binding_contract.py tests/unit/test_binding_contract_canonical.py` y las pruebas pasaron (17 passed).
- Intenté ejecutar también `tests/unit/test_cli_v2_command_contract.py` pero la recolección falló por un `ImportError` preexistente al importar `resolve_backend` desde `pcobra.cobra.build.backend_pipeline`, lo cual es ajeno a este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37344fecc8327992d14a15b6a133e)