### PR TITLE
Alinear retiro de backends legacy con calendario oficial y documentar fases

### DIFF
--- a/docs/compatibility/legacy_backend_retirement_calendar.md
+++ b/docs/compatibility/legacy_backend_retirement_calendar.md
@@ -1,0 +1,71 @@
+# Calendario oficial de retiro de backends legacy internos
+
+Este documento toma `INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW` como calendario canónico de deprecación para `go`, `cpp`, `java`, `wasm`, `asm`.
+
+Fuente normativa:
+
+- `src/pcobra/cobra/architecture/backend_policy.py` (`INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW`)
+- `src/pcobra/cobra/architecture/legacy_backend_lifecycle.py` (metadatos por backend consumidos por CLI/docs)
+
+## Calendario oficial (canónico)
+
+| Backend | Ventana oficial |
+|---|---|
+| `go` | `Q4 2026` |
+| `cpp` | `Q4 2026` |
+| `java` | `Q1 2027` |
+| `wasm` | `Q2 2027` |
+| `asm` | `Q3 2026` |
+
+## Clasificación de dependencias actuales por backend
+
+> Alcance: comandos (`src/pcobra/cobra/cli/commands`), scripts (`scripts/`) y tests (`tests/`).
+
+### `go`
+
+- **Comandos**: `validar_sintaxis_cmd.py`, `qa_validar_cmd.py`.
+- **Scripts**: `targets_policy_common.py`, `audit_retired_targets.py`, `scripts/ci/validate_targets.py`, `scripts/ci/audit_targets_contract.py`, `scripts/ci/generate_internal_only_inventory.py`, y scripts de benchmarks.
+- **Tests**: cobertura amplia en unit/integration/performance con foco en contratos de targets internos (ej.: `test_runtime_manager.py`, `test_cli_target_aliases.py`, `test_holobit_backend_contract_matrix.py`).
+
+### `cpp`
+
+- **Comandos**: `verify_cmd.py`, `validar_sintaxis_cmd.py`, `qa_validar_cmd.py`.
+- **Scripts**: `targets_policy_common.py`, `hello_clang.py`, `lint_legacy_aliases.py`, `scripts/ci/validate_targets.py`, `scripts/ci/audit_targets_contract.py`.
+- **Tests**: cobertura de verificación/ejecución y contratos de targets (ej.: `test_verify_cmd.py`, `test_target_execution_policy.py`, `test_interactive_cmd_sandbox_docker_targets.py`).
+
+### `java`
+
+- **Comandos**: `validar_sintaxis_cmd.py`, `qa_validar_cmd.py`, `transpilar_inverso_cmd.py`.
+- **Scripts**: `targets_policy_common.py`, `audit_retired_targets.py`, `scripts/ci/validate_targets.py`, `scripts/ci/audit_targets_contract.py`, scripts de benchmarks.
+- **Tests**: cobertura de transpilación inversa y contratos tier2 (ej.: `test_cli_transpilar_inverso_cmd.py`, `tests/integration/transpilers/test_official_backends_tier2.py`).
+
+### `wasm`
+
+- **Comandos**: `validar_sintaxis_cmd.py`, `qa_validar_cmd.py`.
+- **Scripts**: `targets_policy_common.py`, `lint_legacy_aliases.py`, `scripts/ci/validate_workflow_target_matrix.py`, `scripts/ci/validate_targets.py`, scripts de benchmarks.
+- **Tests**: cobertura de equivalencia de lenguaje y contratos de runtime (ej.: `test_cli_qa_validar_cmd.py`, `test_language_equivalence_contract.py`, `test_official_backends_contracts.py`).
+
+### `asm`
+
+- **Comandos**: `validar_sintaxis_cmd.py`, `qa_validar_cmd.py`.
+- **Scripts**: `targets_policy_common.py`, `audit_retired_targets.py`, `scripts/ci/validate_targets.py`, `scripts/ci/audit_targets_contract.py`, scripts de benchmarks.
+- **Tests**: cobertura de contrato/registro y choices legacy (ej.: `test_target_validation_contract.py`, `test_registry_contract_guardrail.py`, `test_compile_cmd_target_choices_aliases.py`).
+
+## Fases por backend
+
+Regla operativa común: **primero retirar exposición CLI y docs**, luego eliminar código muerto tras validación de no uso (telemetría + CI verde + inventario).
+
+| Backend | Fase read-only | Fase disabled by default | Fase delete code |
+|---|---|---|---|
+| `asm` (`Q3 2026`) | Solo lectura y mantenimiento mínimo, sin features nuevas. | Bloqueado por defecto en CLI pública; habilitable solo en rutas internas controladas. | Al cierre de `Q3 2026`: eliminar transpiler/tests/hooks si no hay uso. |
+| `go` (`Q4 2026`) | Congelar cambios funcionales; mantener únicamente compatibilidad de migración. | Deshabilitado por defecto fuera de modo legacy interno. | Al cierre de `Q4 2026`: eliminar `to_go.py`, tests y registros asociados sin tráfico. |
+| `cpp` (`Q4 2026`) | Congelar cambios funcionales; soporte correctivo mínimo. | Deshabilitado por defecto fuera de modo legacy interno. | Al cierre de `Q4 2026`: eliminar `to_cpp.py`, tests y registros asociados sin tráfico. |
+| `java` (`Q1 2027`) | Congelar cambios funcionales; foco en migración a `javascript`. | Deshabilitado por defecto fuera de modo legacy interno. | Al cierre de `Q1 2027`: eliminar `to_java.py`, tests y registros asociados sin tráfico. |
+| `wasm` (`Q2 2027`) | Estado frozen/read-only (correcciones críticas únicamente). | Deshabilitado por defecto fuera de modo legacy interno. | Al cierre de `Q2 2027`: eliminar `to_wasm.py`, tests y registros asociados sin tráfico. |
+
+## Secuencia obligatoria de ejecución
+
+1. **Retiro de exposición CLI + docs**: comandos/flags legacy no visibles en superficie pública.
+2. **Gating por defecto**: ejecución legacy bloqueada salvo modo interno temporal.
+3. **Validación de no uso**: telemetría de uso legacy + inventario (`generate_internal_only_inventory.py`) + CI contract.
+4. **Delete code**: eliminación física de transpilers/tests/hook internos por backend al vencer su ventana.

--- a/docs/compatibility/legacy_ux_retirement_plan.md
+++ b/docs/compatibility/legacy_ux_retirement_plan.md
@@ -42,6 +42,7 @@ Este flag es transitorio y no debe usarse en documentación pública ni en nuevo
    - Confirmar readiness antes del 30/06/2027 y remover la ruta de compatibilidad.
 
 Checklist operativo por fases: `docs/compatibility/internal_only_backend_removal_checklist.md`.
+Calendario y clasificación de dependencias por backend: `docs/compatibility/legacy_backend_retirement_calendar.md`.
 
 ## Inventario por fase (fuente canónica: `legacy_backend_lifecycle.py`)
 

--- a/src/pcobra/cobra/architecture/legacy_backend_lifecycle.py
+++ b/src/pcobra/cobra/architecture/legacy_backend_lifecycle.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final, Literal
 
-from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS
+from pcobra.cobra.architecture.backend_policy import (
+    INTERNAL_BACKENDS,
+    INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW,
+)
 
 LegacyLifecycleStatus = Literal["active-migration", "frozen", "removal-candidate"]
 LegacyLifecyclePhase = Literal[
@@ -35,7 +38,7 @@ LEGACY_BACKEND_LIFECYCLE: Final[dict[str, LegacyBackendLifecycle]] = {
     "go": LegacyBackendLifecycle(
         status="active-migration",
         phase="phase-2-development-profile-only",
-        retirement_window="Q4 2026",
+        retirement_window=INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW["go"],
         recommended_public_target="rust",
         owner_track="runtime-migration",
         notes="Backend interno con uso residual en migración activa de pipelines.",
@@ -43,7 +46,7 @@ LEGACY_BACKEND_LIFECYCLE: Final[dict[str, LegacyBackendLifecycle]] = {
     "cpp": LegacyBackendLifecycle(
         status="active-migration",
         phase="phase-2-development-profile-only",
-        retirement_window="Q4 2026",
+        retirement_window=INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW["cpp"],
         recommended_public_target="rust",
         owner_track="runtime-migration",
         notes="Se mantiene temporalmente por compatibilidad de integraciones históricas.",
@@ -51,7 +54,7 @@ LEGACY_BACKEND_LIFECYCLE: Final[dict[str, LegacyBackendLifecycle]] = {
     "java": LegacyBackendLifecycle(
         status="active-migration",
         phase="phase-2-development-profile-only",
-        retirement_window="Q1 2027",
+        retirement_window=INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW["java"],
         recommended_public_target="javascript",
         owner_track="runtime-migration",
         notes="Uso interno controlado durante el retiro de rutas no públicas.",
@@ -59,7 +62,7 @@ LEGACY_BACKEND_LIFECYCLE: Final[dict[str, LegacyBackendLifecycle]] = {
     "wasm": LegacyBackendLifecycle(
         status="frozen",
         phase="phase-2-development-profile-only",
-        retirement_window="Q2 2027",
+        retirement_window=INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW["wasm"],
         recommended_public_target="javascript",
         owner_track="maintenance-only",
         notes="Congelado: solo correcciones críticas sin expansión funcional.",
@@ -67,7 +70,7 @@ LEGACY_BACKEND_LIFECYCLE: Final[dict[str, LegacyBackendLifecycle]] = {
     "asm": LegacyBackendLifecycle(
         status="removal-candidate",
         phase="phase-1-hide-public-ux",
-        retirement_window="Q3 2026",
+        retirement_window=INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW["asm"],
         recommended_public_target="python",
         owner_track="decommission",
         notes="Candidato explícito a retiro; mantener únicamente para diagnóstico acotado.",
@@ -84,6 +87,18 @@ def _validate_legacy_lifecycle_contract() -> None:
             "LEGACY_BACKEND_LIFECYCLE debe cubrir exactamente INTERNAL_BACKENDS. "
             f"missing={missing or '∅'}; extras={extras or '∅'}; "
             f"configured={configured}; expected={INTERNAL_BACKENDS}"
+        )
+
+    mismatched_windows = tuple(
+        backend
+        for backend, metadata in LEGACY_BACKEND_LIFECYCLE.items()
+        if metadata.retirement_window != INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW[backend]
+    )
+    if mismatched_windows:
+        raise RuntimeError(
+            "LEGACY_BACKEND_LIFECYCLE.retirement_window debe derivarse de "
+            "INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW. "
+            f"mismatched={mismatched_windows}"
         )
 
 

--- a/tests/unit/test_legacy_backend_lifecycle.py
+++ b/tests/unit/test_legacy_backend_lifecycle.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS
+from pcobra.cobra.architecture.backend_policy import (
+    INTERNAL_BACKENDS,
+    INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW,
+)
 from pcobra.cobra.architecture.legacy_backend_lifecycle import (
     LEGACY_BACKEND_LIFECYCLE,
     iter_legacy_backend_lifecycle_rows,
@@ -16,6 +19,12 @@ from pcobra.cobra.transpilers.registry import (
 def test_lifecycle_metadata_cubre_todos_los_backends_internos():
     assert tuple(LEGACY_BACKEND_LIFECYCLE) == INTERNAL_BACKENDS
 
+
+
+
+def test_retirement_window_usa_calendario_oficial_de_compatibilidad():
+    for backend, metadata in LEGACY_BACKEND_LIFECYCLE.items():
+        assert metadata.retirement_window == INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW[backend]
 
 def test_registry_internal_legacy_expone_etiqueta_lifecycle_por_backend():
     assert tuple(INTERNAL_LEGACY_TRANSPILER_LIFECYCLE_STATUS) == INTERNAL_BACKENDS


### PR DESCRIPTION
### Motivation
- Unificar la fuente de verdad para las ventanas de deprecación usando `INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW` para evitar duplicación y desalineaciones. 
- Clasificar qué comandos, scripts y tests dependen aún de cada backend legacy (`go/cpp/java/wasm/asm`) para planificar la retirada. 
- Definir las fases operativas por backend (`read-only`, `disabled by default`, `delete code`) asegurando que primero se retire la exposición en CLI/docs y solo después se elimine código tras validar no uso. 

### Description
- Se modificó `src/pcobra/cobra/architecture/legacy_backend_lifecycle.py` para que cada `retirement_window` se derive de `INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW` y se añadió una validación que falla si hay desalineaciones entre ambos orígenes. 
- Se añadió una prueba en `tests/unit/test_legacy_backend_lifecycle.py` llamada `test_retirement_window_usa_calendario_oficial_de_compatibilidad` que verifica que las ventanas de `LEGACY_BACKEND_LIFECYCLE` coincidan con el calendario oficial. 
- Se creó `docs/compatibility/legacy_backend_retirement_calendar.md` con el calendario canónico, inventario por backend (comandos/scripts/tests) y las tres fases por backend, y se enlazó desde `docs/compatibility/legacy_ux_retirement_plan.md`. 
- Cambios clave en archivos: `legacy_backend_lifecycle.py`, `tests/unit/test_legacy_backend_lifecycle.py`, `docs/compatibility/legacy_backend_retirement_calendar.md`, y actualización de `docs/compatibility/legacy_ux_retirement_plan.md`. 

### Testing
- Se ejecutó `pytest -q tests/unit/test_legacy_backend_lifecycle.py` y la suite pasó correctamente con `7 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e374a76b90832782d0310812f6533d)