### PR TITLE
docs: priorizar ruta pública de Cobra y aislar opciones legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ El objetivo de pCobra es brindar a la comunidad hispanohablante una alternativa 
 - Arquitectura del compilador
 - Architecture Overview
 - Ecosistema unificado Cobra
-- Migración a CLI unificada
+- Anexos internos (NO PÚBLICO)
 - Instalación
 - Cómo usar la CLI
 - Cómo decide backend internamente
@@ -151,7 +151,6 @@ El objetivo de pCobra es brindar a la comunidad hispanohablante una alternativa 
 - [Blog del minilenguaje](docs/blog_minilenguaje.md)
 - [Casos de uso reales](docs/casos_reales.md)
 - [Limitaciones del sandbox de Node](docs/limitaciones_node_sandbox.md)
-- [Migración de targets retirados de la UX pública](docs/migracion_targets_retirados.md)
 - [Anexos legacy/internal](docs/anexos_legacy_internal/README.md)
 - Notebooks de ejemplo y casos reales
 - Probar Cobra en línea
@@ -230,9 +229,13 @@ Cobra expone una sola interfaz de entrada (`cobra`) y desacopla internamente la 
 Para el plan de transición arquitectónica incremental, consulta [docs/architecture/cobra_unified_refactor_plan.md](docs/architecture/cobra_unified_refactor_plan.md).
 Para una guía ejecutable por fases (A–I) con tareas paso a paso, consulta [docs/architecture/cobra_unified_architecture_execution_plan.md](docs/architecture/cobra_unified_architecture_execution_plan.md).
 
-## Migración a CLI unificada
+## Anexos internos (NO PÚBLICO)
 
-Para migrar desde comandos legacy y usos históricos de `--backend`, consulta [docs/migracion_cli_unificada.md](docs/migracion_cli_unificada.md).
+> ⚠️ **NO PÚBLICO / SOLO MANTENEDORES**: la documentación de migración, compatibilidad histórica y rutas legacy vive en anexos internos y queda fuera del onboarding principal.
+
+Si necesitas migrar scripts antiguos o revisar compatibilidad histórica, consulta:
+
+- [docs/anexos_legacy_internal/README.md](docs/anexos_legacy_internal/README.md)
 
 ## Instalación
 

--- a/docs/config_cli.md
+++ b/docs/config_cli.md
@@ -1,28 +1,22 @@
 # Configuración de la CLI
 
-La interfaz de línea de comandos de Cobra puede personalizarse mediante un archivo de configuración.
+La configuración de Cobra se documenta en dos bloques para evitar mezclar onboarding de usuario con rutas internas de migración.
 
-## Modos de operación (`--modo`)
+## 1) Configuración pública (usuarios)
 
-El flag global `--modo` delimita qué tipo de acciones permite la sesión:
+Esta sección es la que forma parte del contrato público para quienes usan Cobra en el día a día con la ruta principal:
 
-- `cobra`: solo ejecución/interpretación de programas Cobra.
-- `transpilar`: solo generación de código (transpilación).
-- `mixto` (por defecto): permite ambos flujos.
+- `cobra run`
+- `cobra build`
+- `cobra test`
+- `cobra mod`
 
-Ejemplos concretos:
-
-```bash
-cobra --modo cobra run programa.co
-cobra --modo transpilar build programa.co
-```
-
-## Ruta del archivo
+## Archivo de configuración
 
 - **Nombre:** `cobra-cli.toml`
 - **Ubicación:** directorio de trabajo desde el que se ejecuta `cobra`.
 
-## Claves soportadas
+## Claves públicas soportadas
 
 | Clave            | Valor por defecto                                    | Descripción                                           |
 |------------------|------------------------------------------------------|-------------------------------------------------------|
@@ -32,70 +26,21 @@ cobra --modo transpilar build programa.co
 | `log_formatter`  | `text`                                                | Formato del handler raíz: `text` (default) o `json`.  |
 | `program_name`   | `cobra`                                              | Nombre con el que aparece la aplicación en la ayuda.  |
 
-Las variables de entorno `COBRA_LANG`, `COBRA_DEFAULT_COMMAND`, `COBRA_LOG_FORMAT`, `COBRA_LOG_FORMATTER` y `COBRA_PROGRAM_NAME` permiten sobrescribir estos valores.
+Variables de entorno equivalentes: `COBRA_LANG`, `COBRA_DEFAULT_COMMAND`, `COBRA_LOG_FORMAT`, `COBRA_LOG_FORMATTER` y `COBRA_PROGRAM_NAME`.
 
-## Eventos de auditoría de política de seguridad
+## Eventos de auditoría de seguridad (públicos)
 
-Cuando la CLI detecta rutas críticas de seguridad en runtime, emite warnings con
-campos estructurados para auditoría:
+Cuando la CLI detecta rutas críticas de seguridad en runtime, emite warnings con campos estructurados para auditoría:
 
 - `event`: tipo de evento de seguridad.
 - `command`: subcomando activo.
 - `reason`: causa concreta de la decisión.
 - `audit_id`: identificador estable de auditoría (`SEC-RUNTIME-00x`).
 
-En modo `text`, el `msg` incluye los campos en línea:
+En modo `text`, el `msg` incluye los campos en línea.
+En modo `json` (`log_formatter = "json"` o `COBRA_LOG_FORMATTER=json`), el handler escribe un objeto JSON por línea apto para pipelines CI/SIEM.
 
-```text
-security_policy_warning event=insecure_fallback command=run reason=explicit_allow_insecure_fallback audit_id=SEC-RUNTIME-003
-```
-
-En modo `json` (`log_formatter = "json"` o `COBRA_LOG_FORMATTER=json`), el
-handler escribe un objeto JSON por línea apto para pipelines CI/SIEM.
-
-## Política de seguridad para `SQLITE_DB_KEY` en la CLI
-
-Para comandos que requieren base de datos (`cache`, `build`, `benchtranspilers`,
-`qualia`, `interactive`), la CLI exige `SQLITE_DB_KEY`.
-
-- **Producción/CI recomendado:** exporta siempre una clave real (`SQLITE_DB_KEY`)
-  gestionada por tu secret manager.
-- **Desarrollo local controlado:** se permite clave efímera **solo** con triple
-  confirmación explícita en la misma ejecución:
-  1. `COBRA_DEV_MODE=1`
-  2. `COBRA_DEV_ALLOW_EPHEMERAL_KEY=1`
-  3. flag CLI `--dev-ephemeral-key`
-
-Cuando se cumplen las tres condiciones, la CLI genera una clave nueva por
-ejecución con `secrets.token_urlsafe(...)` y registra un warning de seguridad no
-sensible indicando que se está usando una clave efímera de desarrollo.
-
-### Ejemplos seguros de arranque local
-
-#### Opción A (preferida): clave explícita
-
-```bash
-export SQLITE_DB_KEY="$(python - <<'PY'
-import secrets
-print(secrets.token_urlsafe(32))
-PY
-)"
-
-cobra build ejemplo.co
-```
-
-#### Opción B (solo dev local): clave efímera por ejecución
-
-```bash
-COBRA_DEV_MODE=1 \
-COBRA_DEV_ALLOW_EPHEMERAL_KEY=1 \
-cobra --dev-ephemeral-key build ejemplo.co
-```
-
-> Nota: evita esta opción en CI/prod; está diseñada únicamente para sesiones
-> locales temporales.
-
-## Ejemplo
+## Ejemplo público
 
 ```toml
 # cobra-cli.toml
@@ -113,90 +58,41 @@ language = "es"
 program_name = "cobra-cli"
 ```
 
-## Mappings multi-backend en `cobra.toml`
+## 2) Opciones internas de migración (NO PÚBLICO)
 
-Para resolver imports de módulos transpilados en varios backends, define rutas por
-backend en `cobra.toml` bajo la tabla canónica `[modulos."..."]`. La resolución
-multi-backend ya no usa `cobra.mod`, `pcobra.toml` ni mappings en raíz.
+> ⚠️ **NO PÚBLICO / SOLO MANTENEDORES**: lo siguiente existe para compatibilidad histórica, migraciones graduales y operación interna. No es material de onboarding para usuarios nuevos.
 
-```toml
-[project]
-required_targets = ["python", "javascript"]
+### Modos de operación (`--modo`)
 
-[modulos."modulo.co"]
-python = "build/modulo.py"
-rust = "build/modulo.rs"
-javascript = "build/modulo.js"
-```
+El flag global `--modo` delimita internamente qué tipo de acciones permite la sesión (`cobra`, `transpilar`, `mixto`).
 
-### Reglas de validación
+### Política de seguridad para `SQLITE_DB_KEY` en rutas internas
 
-- Solo se aceptan nombres canónicos contenidos en `PUBLIC_BACKENDS`:
-  `python`, `javascript` y `rust`.
-- Los aliases legacy, abreviaturas históricas y traducciones antiguas de nombres de backend no son válidos; usa siempre los identificadores canónicos públicos.
-- Los mappings de módulos deben vivir dentro de `[modulos."..."]`; las estructuras en raíz ya no se resuelven.
-- `cobra.mod` sigue siendo el archivo validado por `modulos`/empaquetado, pero sus backends públicos deben respetar exclusivamente `PUBLIC_BACKENDS`.
+Para comandos con base de datos (`cache`, `build`, `benchtranspilers`, `qualia`, `interactive`), la CLI exige `SQLITE_DB_KEY`.
 
-### ¿Qué targets pueden omitirse intencionalmente?
+En desarrollo local controlado existe una ruta efímera con triple confirmación explícita (`COBRA_DEV_MODE=1`, `COBRA_DEV_ALLOW_EPHEMERAL_KEY=1`, `--dev-ephemeral-key`), reservada a escenarios de desarrollo interno.
 
-- Puedes omitir cualquier target **no incluido** en `required_targets`.
-- Si no declaras política, la validación asume por defecto el Tier 1 público completo: `python`, `javascript` y `rust`.
-- Para proyectos que solo distribuyen un subconjunto de backends, ajusta
-  explícitamente `required_targets` para evitar errores de validación.
+### Mappings multi-backend en `cobra.toml`
 
-## Política de colisiones de imports en `cobra.toml`
+La resolución multi-backend de módulos usa la tabla canónica `[modulos."..."]` y validación con `PUBLIC_BACKENDS` (`python`, `javascript`, `rust`).
 
-El resolvedor de imports (`CobraImportResolver`) mantiene **orden estable** de
-precedencia:
+### Política de colisiones de imports en `cobra.toml`
 
-1. `stdlib`
-2. `project`
-3. `python_bridge`
-4. `hybrid`
+El resolvedor conserva precedencia estable: `stdlib > project > python_bridge > hybrid`, con políticas `warn`, `strict_error`, `namespace_required`.
 
-La política de qué hacer ante colisiones de nombres sin namespace se configura
-por proyecto:
+### Política de targets oficial
 
-```toml
-[imports]
-collision_policy = "warn" # warn | strict_error | namespace_required
-```
+La fuente de verdad para targets públicos es `src/pcobra/cobra/architecture/backend_policy.py` mediante `PUBLIC_BACKENDS`; `INTERNAL_BACKENDS` se reserva para compatibilidad legacy interna.
 
-- `warn`: mantiene comportamiento actual (warning + selección por precedencia).
-- `strict_error`: convierte la colisión en error.
-- `namespace_required`: exige imports explícitos con namespace cuando hay
-  colisión (`cobra.*`, `app.*`, etc.).
+## Cómo elige backend Cobra internamente
 
-También puedes declarar módulos híbridos:
+Cobra decide backend como parte de su orquestación interna, sin exigir que la persona usuaria gestione flags de backend ni se acople a detalles de transpiladores.
 
-```toml
-[imports.hybrid_modules.mi_hibrido]
-import_path = "mi_hibrido_runtime"
-backend = "javascript"
-```
+Flujo de decisión de alto nivel:
 
-## Terminología: interfaz pública vs backend interno
+1. Detecta contexto del proyecto y metadatos disponibles.
+2. Evalúa el tipo de operación solicitada (`run`, `build`, `test`, `mod`).
+3. Selecciona automáticamente un backend oficial compatible.
+4. Ejecuta el pipeline interno manteniendo la UX pública estable (`run/build/test/mod`).
 
-- **Interfaz pública**: comandos y documentación para usuarios (`cobra run`, `cobra build`, `cobra test`, `cobra mod`) y backends oficiales `python`, `javascript`, `rust`.
-- **Backend interno**: rutas de compatibilidad o migración usadas por mantenedores, fuera del contrato público.
-
-Toda referencia en documentación de usuario debe priorizar la terminología de interfaz pública.
-
-## Política de targets oficial
-
-La CLI no debe mantener listas duplicadas de lenguajes soportados. La fuente de
-verdad para los targets públicos es
-`src/pcobra/cobra/architecture/backend_policy.py` a través de
-`PUBLIC_BACKENDS` (y `INTERNAL_BACKENDS` para legacy interno). La documentación
-pública y los archivos de configuración deben usar únicamente los nombres
-canónicos `python`, `javascript` y `rust`.
-
-En consecuencia:
-
-- `cobra build` debe derivar `TRANSPILERS` y `LANG_CHOICES` desde
-  `PUBLIC_BACKENDS` y un registro canónico compartido.
-- Los scripts auxiliares, especialmente benchmarks y validaciones CI, deben
-  reutilizar utilidades comunes basadas en esa misma política.
-- Cualquier nuevo backend oficial requiere actualizar primero esa fuente única y
-  después el registro canónico correspondiente; no se permiten listas
-  hardcodeadas duplicadas en la CLI o en scripts.
+Regla de documentación: para usuarios finales, la guía siempre debe priorizar la interfaz pública y evitar exponer rutas legacy de migración como flujo normal.


### PR DESCRIPTION
### Motivation

- Clarificar la experiencia de onboarding para usuarios dejando como ruta principal solo los comandos públicos `cobra run/build/test/mod` y evitar exponer contenido legacy en la documentación principal.
- Agrupar y marcar explícitamente como no público la documentación de migración/compatibilidad para que solo la consulten mantenedores y no nuevos usuarios.
- Documentar a alto nivel cómo el sistema selecciona backend internamente sin acoplar a la persona usuaria a flags de transpiladores ni detalles de implementación.

### Description

- Actualiza `README.md` para reemplazar la sección de "Migración a CLI unificada" por una sección `Anexos internos (NO PÚBLICO)` y elimina el enlace directo a `docs/migracion_targets_retirados.md` en el TOC.
- Reestructura `docs/config_cli.md` en dos bloques: `1) Configuración pública (usuarios)` con las claves públicas y ejemplos, y `2) Opciones internas de migración (NO PÚBLICO)` con modos, políticas internas y notas de compatibilidad.
- Añade en `docs/config_cli.md` una sección de alto nivel `Cómo elige backend Cobra internamente` que describe el flujo de decisión (detectar contexto, evaluar operación, seleccionar backend oficial, ejecutar pipeline) sin exponer flags o detalles de transpiladores.
- Ajusta redacción y ejemplos para priorizar la interfaz pública (`cobra run/build/test/mod`) y marcar claramente qué contenido queda fuera del onboarding.

### Testing

- Ejecutado `git diff --check` para verificar el diff y no se detectaron errores en el formato del patch, y la comprobación pasó correctamente.
- Verificado el estado con `git status --short` y creado el commit con mensaje `docs: separar configuración pública de opciones internas`, resultando en el commit `30dc135`.
- Creada la PR con el cuerpo y título correspondientes mediante la herramienta de creación de PRs, y no se ejecutaron tests de unidad automáticos en este cambio de documentación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e375ebfc54832792be8c9650f0b9d7)