### PR TITLE
Fijar backend_pipeline como entrypoint interno inmutable

### DIFF
--- a/docs/architecture/backend-pipeline-checklist.md
+++ b/docs/architecture/backend-pipeline-checklist.md
@@ -1,0 +1,23 @@
+# Checklist arquitectónica: Backend Pipeline
+
+Usar esta checklist antes de mergear nuevas features que afecten compile/transpile/runtime.
+
+## Flujo oficial (obligatorio)
+
+- [ ] La feature respeta el flujo `Frontend Cobra -> BackendPipeline -> Bindings`.
+- [ ] No se introduce un nuevo entrypoint paralelo a `pcobra.cobra.build.backend_pipeline`.
+
+## Contrato de llamadas internas
+
+- [ ] CLI, imports y stdlib llaman únicamente a:
+  - `backend_pipeline.resolve_backend_runtime(...)`
+  - `backend_pipeline.build(...)`
+  - `backend_pipeline.transpile(...)`
+- [ ] No hay imports directos a registro de transpiladores oficiales desde CLI/imports/stdlib.
+- [ ] No hay llamadas directas a `generate_code(...)` de transpiladores oficiales fuera de `backend_pipeline`.
+
+## Validación y CI
+
+- [ ] Se ejecutó el auditor `scripts/ci/audit_backend_pipeline_entrypoint.py`.
+- [ ] La documentación de arquitectura (`docs/architecture/overview.md`) sigue reflejando el flujo oficial.
+- [ ] Si hubo excepciones temporales por migración, están justificadas y acotadas en ADR/ticket.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,6 +2,14 @@
 
 Este resumen documenta **cómo funciona internamente** la CLI unificada sin ampliar la superficie pública (`cobra run`, `cobra build`, `cobra test`, `cobra mod`).
 
+## Flujo oficial inmutable
+
+La ruta oficial y estable de arquitectura es:
+
+```text
+Frontend Cobra -> BackendPipeline -> Bindings
+```
+
 ## Diagrama corto
 
 ```text
@@ -18,7 +26,9 @@ El frontend procesa el código fuente, valida sintaxis y construye el AST base q
 
 ## 2) BackendPipeline
 
-En la ruta pública, `cobra build` delega la elección del backend a `backend_pipeline.resolve_backend(...)`, evitando exponer flags de backend como paso principal para usuario final.
+En la ruta pública, `cobra build` delega la elección del backend a `backend_pipeline.resolve_backend_runtime(...)` y/o `backend_pipeline.build(...)`, evitando exponer flags de backend como paso principal para usuario final.
+
+`pcobra.cobra.build.backend_pipeline` se considera contrato interno inmutable para compile/transpile/runtime.
 
 ## 3) Bindings (python/js/rust)
 
@@ -39,3 +49,4 @@ La resolución de imports usa prioridad determinista (`stdlib > project > python
 - `src/pcobra/cobra/build/backend_pipeline.py`
 - `src/pcobra/cobra/imports/resolver.py`
 - `src/pcobra/cobra/transpilers/module_map.py`
+- `docs/architecture/backend-pipeline-checklist.md`

--- a/scripts/ci/audit_backend_pipeline_entrypoint.py
+++ b/scripts/ci/audit_backend_pipeline_entrypoint.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Audita que CLI/imports/stdlib usen backend_pipeline como entrypoint interno."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+SCOPES = (
+    SRC / "pcobra/cobra/cli",
+    SRC / "pcobra/cobra/imports",
+    SRC / "pcobra/core",
+)
+
+FORBIDDEN_IMPORTS = {
+    "pcobra.cobra.transpilers.registry",
+}
+ALLOWED_GENERATE_CODE_CALLERS = {
+    SRC / "pcobra/cobra/build/backend_pipeline.py",
+    SRC / "pcobra/cobra/cli/commands/compile_cmd.py",  # plugins externos, no transpilador oficial
+}
+
+
+def _targets_from_import(node: ast.AST) -> list[str]:
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    if isinstance(node, ast.ImportFrom):
+        return [node.module] if node.module else []
+    return []
+
+
+def _is_forbidden_import(target: str) -> bool:
+    return any(target == prefix or target.startswith(prefix + ".") for prefix in FORBIDDEN_IMPORTS)
+
+
+def _is_generate_code_call(node: ast.Call) -> bool:
+    return isinstance(node.func, ast.Attribute) and node.func.attr == "generate_code"
+
+
+def _audit_file(path: Path) -> list[tuple[int, str]]:
+    issues: list[tuple[int, str]] = []
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        for target in _targets_from_import(node):
+            if target and _is_forbidden_import(target):
+                issues.append((node.lineno, f"import directo prohibido: {target}"))
+        if isinstance(node, ast.Call) and _is_generate_code_call(node):
+            if path not in ALLOWED_GENERATE_CODE_CALLERS:
+                issues.append((node.lineno, "llamada directa a generate_code() fuera de backend_pipeline"))
+    return issues
+
+
+def main() -> int:
+    violations: list[tuple[Path, int, str]] = []
+    for scope in SCOPES:
+        if not scope.exists():
+            continue
+        for path in sorted(scope.rglob("*.py")):
+            for lineno, issue in _audit_file(path):
+                violations.append((path, lineno, issue))
+
+    if violations:
+        print("❌ Violaciones: entrypoint interno no pasa por backend_pipeline.")
+        for path, lineno, issue in violations:
+            print(f" - {path.relative_to(ROOT)}:{lineno}: {issue}")
+        return 1
+
+    print("✅ Auditoría backend_pipeline: CLI/imports/stdlib sin llamadas directas a transpiladores oficiales.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pcobra/cobra/architecture/overview.py
+++ b/src/pcobra/cobra/architecture/overview.py
@@ -17,6 +17,11 @@ PUBLIC_CLI_V2_COMMANDS: Final[tuple[str, ...]] = ("run", "build", "test", "mod")
 
 # Toda ruta de usuario termina resolviendo backend mediante esta fachada.
 USER_ROUTE_BACKEND_ENTRYPOINT: Final[str] = "pcobra.cobra.build.backend_pipeline"
+OFFICIAL_FLOW: Final[tuple[str, ...]] = (
+    "Frontend Cobra",
+    "BackendPipeline",
+    "Bindings",
+)
 
 # Superficies no públicas: mantener solo para transición interna controlada.
 INTERNAL_MIGRATION_ONLY_SURFACES: Final[dict[str, tuple[str, ...] | str]] = {
@@ -59,8 +64,7 @@ PUBLIC_ARCHITECTURE_OVERVIEW: Final[PublicArchitectureOverview] = (
 
 # Diagrama de flujo corto (sin cambios en AST).
 PUBLIC_FLOW_DIAGRAM: Final[str] = (
-    "Cobra source -> AST (sin cambios) -> backend_pipeline -> "
-    "transpiler interno -> runtime/binding"
+    "Frontend Cobra -> BackendPipeline -> Bindings"
 )
 
 
@@ -78,6 +82,10 @@ def validate_public_architecture_overview() -> None:
         raise RuntimeError(
             "Toda ruta de usuario debe pasar por pcobra.cobra.build.backend_pipeline."
         )
+    if OFFICIAL_FLOW != ("Frontend Cobra", "BackendPipeline", "Bindings"):
+        raise RuntimeError(
+            "El flujo oficial debe permanecer fijo: Frontend Cobra -> BackendPipeline -> Bindings."
+        )
 
 
 validate_public_architecture_overview()
@@ -87,6 +95,7 @@ __all__ = [
     "PUBLIC_LANGUAGE_BOUNDARY",
     "PUBLIC_CLI_V2_COMMANDS",
     "USER_ROUTE_BACKEND_ENTRYPOINT",
+    "OFFICIAL_FLOW",
     "INTERNAL_MIGRATION_ONLY_SURFACES",
     "PublicArchitectureOverview",
     "PUBLIC_ARCHITECTURE_OVERVIEW",

--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -1,8 +1,9 @@
-"""Façade interna aprobada para resolución de runtime y transpilación.
+"""Façade interna oficial para compile/transpile/runtime.
 
-Contrato interno:
-- Usar únicamente ``resolve_backend_runtime``, ``build`` y ``transpile``.
-- No invocar transpiladores/adapters de forma directa desde CLI/imports/stdlib.
+Contrato inmutable para capas superiores (CLI/imports/stdlib):
+- El único punto de entrada interno aprobado es ``pcobra.cobra.build.backend_pipeline``.
+- La invocación debe hacerse solo vía ``resolve_backend_runtime``, ``build`` o ``transpile``.
+- Queda prohibido llamar transpiladores/adapters oficiales de forma directa.
 """
 
 from __future__ import annotations
@@ -22,6 +23,12 @@ from pcobra.core.ast_cache import obtener_ast
 
 ORCHESTRATOR = BuildOrchestrator()
 RUNTIME_MANAGER = RuntimeManager()
+INTERNAL_BACKEND_ENTRYPOINT = "pcobra.cobra.build.backend_pipeline"
+INTERNAL_BACKEND_API_CONTRACT: tuple[str, ...] = (
+    "resolve_backend_runtime",
+    "build",
+    "transpile",
+)
 
 
 def _load_official_transpilers() -> dict[str, type]:
@@ -59,6 +66,22 @@ def _validate_public_route_startup_contract() -> None:
 
 
 _validate_public_route_startup_contract()
+
+
+def _validate_internal_entrypoint_contract() -> None:
+    """Valida que el contrato interno de entrypoint permanezca inmutable."""
+    if INTERNAL_BACKEND_ENTRYPOINT != "pcobra.cobra.build.backend_pipeline":
+        raise RuntimeError(
+            "El entrypoint interno oficial debe ser pcobra.cobra.build.backend_pipeline."
+        )
+    if INTERNAL_BACKEND_API_CONTRACT != ("resolve_backend_runtime", "build", "transpile"):
+        raise RuntimeError(
+            "El contrato interno del backend pipeline debe ser "
+            "resolve_backend_runtime/build/transpile."
+        )
+
+
+_validate_internal_entrypoint_contract()
 
 
 def _resolve_backend(source: str, hints: dict[str, Any] | None = None) -> BackendResolution:
@@ -138,6 +161,8 @@ def build(source: str, hints: dict[str, Any] | None = None) -> dict[str, Any]:
 
 
 __all__ = [
+    "INTERNAL_BACKEND_ENTRYPOINT",
+    "INTERNAL_BACKEND_API_CONTRACT",
     "ORCHESTRATOR",
     "TRANSPILERS",
     "build",

--- a/src/pcobra/cobra/cli/commands/qa_validar_cmd.py
+++ b/src/pcobra/cobra/cli/commands/qa_validar_cmd.py
@@ -9,7 +9,7 @@ from typing import Any
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.commands.validar_sintaxis_cmd import ValidationResult, ValidarSintaxisCommand
 from pcobra.cobra.qa.syntax_validation import execute_syntax_validation
-from pcobra.cobra.transpilers.registry import build_official_transpilers
+from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.mode_policy import validar_politica_modo
@@ -150,7 +150,7 @@ class QaValidarCommand(BaseCommand):
             profile=profile,
             targets_raw=str(getattr(args, "targets", "")),
             strict=strict,
-            transpilers=build_official_transpilers(),
+            transpilers=backend_pipeline.TRANSPILERS,
         )
 
         transpilers: dict[str, Any] = {

--- a/src/pcobra/cobra/cli/commands/transpilar_inverso_cmd.py
+++ b/src/pcobra/cobra/cli/commands/transpilar_inverso_cmd.py
@@ -43,7 +43,6 @@ from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.cli.target_policies import parse_target
 from pcobra.cobra.cli.target_policies import OFFICIAL_TRANSPILATION_TARGETS
-from pcobra.cobra.transpilers.registry import official_transpiler_targets
 from pcobra.cobra.transpilers.import_helper import get_standard_imports
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.utils.validators import validar_archivo_existente
@@ -136,7 +135,7 @@ REVERSE_TRANSPILERS: Dict[str, Type] = {
     if language in reverse_module.REGISTERED_REVERSE_TRANSPILERS
 }
 ORIGIN_CHOICES = tuple(reverse_module.REVERSE_SCOPE_LANGUAGES)
-DESTINO_CHOICES = list(official_transpiler_targets())
+DESTINO_CHOICES = sorted(backend_pipeline.TRANSPILERS.keys())
 TARGETS_HELP = build_target_help_by_tier(
     tuple(visible_public_targets(OFFICIAL_TRANSPILATION_TARGETS))
 )

--- a/src/pcobra/cobra/cli/commands/validar_sintaxis_cmd.py
+++ b/src/pcobra/cobra/cli/commands/validar_sintaxis_cmd.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.mode_policy import validar_politica_modo
@@ -84,7 +85,6 @@ class ValidarSintaxisCommand(BaseCommand):
 
     def _run_transpilers_syntax(self, targets: list[str], strict: bool) -> tuple[dict[str, TargetSummary], dict[str, list[str]], bool]:
         from pcobra.cobra.qa.syntax_validation import TRANSPILER_FIXTURES
-        from pcobra.cobra.transpilers.registry import build_official_transpilers
 
         fixtures = [fixture for fixture in TRANSPILER_FIXTURES if fixture.exists()]
         if not fixtures:
@@ -93,7 +93,7 @@ class ValidarSintaxisCommand(BaseCommand):
         report, _, has_failures = run_transpiler_syntax_validation(
             fixtures=fixtures,
             targets=targets,
-            transpilers=build_official_transpilers(),
+            transpilers=backend_pipeline.TRANSPILERS,
             strict=strict,
         )
         return report.targets, report.errors_by_target, has_failures
@@ -126,13 +126,11 @@ class ValidarSintaxisCommand(BaseCommand):
             if bool(getattr(args, "solo_cobra", False)):
                 profile = "solo-cobra"
 
-            from pcobra.cobra.transpilers.registry import build_official_transpilers
-
             execution = execute_syntax_validation(
                 profile=profile,
                 targets_raw=str(getattr(args, "targets", "")),
                 strict=strict,
-                transpilers=build_official_transpilers(),
+                transpilers=backend_pipeline.TRANSPILERS,
             )
             self._emit_report(
                 execution.report,


### PR DESCRIPTION
### Motivation
- Garantizar un único punto de entrada interno para compile/transpile/runtime y evitar que capas superiores (CLI/imports/stdlib) invoquen transpiladores o registries directamente.
- Asegurar que la documentación, validaciones en arranque y CI reflejen y protejan ese contrato arquitectónico.
- Proveer herramientas y documentación (checklist + auditoría CI) para evitar regresiones en futuras features.

### Description
- Declaré el entrypoint interno y su API como contrato inmutable en `src/pcobra/cobra/build/backend_pipeline.py` mediante las constantes `INTERNAL_BACKEND_ENTRYPOINT` e `INTERNAL_BACKEND_API_CONTRACT` y validaciones de arranque.
- Fijé explícitamente el flujo oficial en `src/pcobra/cobra/architecture/overview.py` (`OFFICIAL_FLOW`) y actualicé `PUBLIC_FLOW_DIAGRAM` y validaciones para que falle si el flujo se altera.
- Redirigí consumos directos del registro de transpiladores en la CLI/imports para que pasen por la fachada: `validar-sintaxis`, `qa-validar` y `transpilar-inverso` ahora usan `backend_pipeline.TRANSPILERS` en lugar de importar `transpilers.registry` o `official_transpiler_targets` directamente.
- Añadí la checklist arquitectónica `docs/architecture/backend-pipeline-checklist.md` y actualicé `docs/architecture/overview.md` para documentar el flujo inmutable.
- Implementé el guardrail CI `scripts/ci/audit_backend_pipeline_entrypoint.py` que audita scopes (`cli`, `imports`, `pcobra/core`) y detecta imports directos al registry o llamadas a `generate_code()` fuera de los puntos permitidos.

### Testing
- Ejecuté el auditor localmente con `python scripts/ci/audit_backend_pipeline_entrypoint.py` y devolvió éxito (`exit 0`).
- Verifiqué boundaries públicos con `python scripts/ci/check_public_import_boundaries.py` y devolvió éxito (`exit 0`).
- Comprobé la compilación de los módulos cambiados con `python -m compileall -q src/pcobra/cobra/build/backend_pipeline.py src/pcobra/cobra/architecture/overview.py src/pcobra/cobra/cli/commands/qa_validar_cmd.py src/pcobra/cobra/cli/commands/validar_sintaxis_cmd.py src/pcobra/cobra/cli/commands/transpilar_inverso_cmd.py scripts/ci/audit_backend_pipeline_entrypoint.py` y la verificación fue satisfactoria (sin errores).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e377a9c27c8327b39e1e523c8c3e3b)