### PR TITLE
Refuerza fronteras públicas y encapsula compatibilidad interna

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,9 @@ jobs:
       - name: Validate no duplicated public backend literals
         shell: bash
         run: python scripts/ci/validate_public_backend_literals.py
+      - name: Validate public import boundaries against internal_compat
+        shell: bash
+        run: python scripts/ci/check_public_import_boundaries.py
       - name: Lint legacy target aliases in tests/docs
         shell: bash
         run: python scripts/lint_legacy_aliases.py
@@ -468,6 +471,9 @@ jobs:
       - name: Validate no duplicated public backend literals
         shell: bash
         run: python scripts/ci/validate_public_backend_literals.py
+      - name: Validate public import boundaries against internal_compat
+        shell: bash
+        run: python scripts/ci/check_public_import_boundaries.py
       - name: Run Tier 2 backend suite
         shell: bash
         run: |

--- a/scripts/ci/check_public_import_boundaries.py
+++ b/scripts/ci/check_public_import_boundaries.py
@@ -13,6 +13,8 @@ PUBLIC_SCOPES = (
     SRC_ROOT / "pcobra/cobra/architecture",
     SRC_ROOT / "pcobra/cobra/imports",
     SRC_ROOT / "pcobra/cobra/bindings",
+    SRC_ROOT / "pcobra/cobra/cli/commands",
+    SRC_ROOT / "pcobra/cobra/cli/commands_v2",
 )
 
 FORBIDDEN_IMPORT_PREFIXES = (
@@ -34,8 +36,9 @@ def _node_import_targets(node: ast.AST) -> list[str]:
 
 
 def _is_forbidden_import(target: str) -> bool:
-    return target.startswith(FORBIDDEN_IMPORT_PREFIXES) or any(
-        token in target for token in FORBIDDEN_IMPORT_CONTAINS
+    canonical = target or ""
+    return canonical.startswith(FORBIDDEN_IMPORT_PREFIXES) or any(
+        token in canonical for token in FORBIDDEN_IMPORT_CONTAINS
     )
 
 

--- a/src/pcobra/cobra/architecture/unified_ecosystem.py
+++ b/src/pcobra/cobra/architecture/unified_ecosystem.py
@@ -1,7 +1,9 @@
 """Plano arquitectónico para el ecosistema unificado de Cobra.
 
-Fuente canónica contractual única (junto con backend_policy/contracts) para
-blueprints de ejecución y retiro legacy del ecosistema.
+Blueprint operativo interno alineado con `backend_policy` y `contracts`.
+
+Las fuentes públicas de verdad para política/contrato de backends son
+exclusivamente `backend_policy.py` y `contracts.py`.
 
 Este módulo no altera el front-end del lenguaje ni los transpilers existentes.
 Su propósito es concentrar decisiones de arquitectura y un plan de ejecución
@@ -66,6 +68,8 @@ class RefactorTask:
     id: str
     area: str
     objective: str
+    owner: str
+    definition_of_done: tuple[str, ...]
     changes: tuple[str, ...]
     safe_checks: tuple[str, ...]
 
@@ -145,6 +149,11 @@ def build_refactor_workplan() -> tuple[RefactorTask, ...]:
             id="T1",
             area="core-alignment",
             objective="Alinear módulos core con el contrato de 3 backends oficiales.",
+            owner="core-architecture",
+            definition_of_done=(
+                "Rutas públicas usan backend_policy/contracts sin redefinir listas.",
+                "No hay imports de compatibilidad interna en rutas públicas.",
+            ),
             changes=(
                 "Reusar PUBLIC_BACKENDS como única fuente en rutas públicas.",
                 "Conservar INTERNAL_BACKENDS solo para compatibilidad temporal.",
@@ -158,6 +167,11 @@ def build_refactor_workplan() -> tuple[RefactorTask, ...]:
             id="T2",
             area="cli-simplification",
             objective="Consolidar UX en run/build/test/mod sin exposición de transpilers.",
+            owner="cli-platform",
+            definition_of_done=(
+                "Comandos v2 mantienen contrato público con 3 targets oficiales.",
+                "Flags de compatibilidad legacy quedan encapsuladas en internal_compat.",
+            ),
             changes=(
                 "Mantener comandos v2 como interfaz por defecto.",
                 "Encapsular decisiones de backend en build.backend_pipeline.",
@@ -171,6 +185,11 @@ def build_refactor_workplan() -> tuple[RefactorTask, ...]:
             id="T3",
             area="stdlib-contract",
             objective="Operar stdlib pública por contratos cobra.core/datos/web/system.",
+            owner="stdlib-core",
+            definition_of_done=(
+                "Paridad validada entre contrato público y módulos desplegados.",
+                "Sin divergencias en auditorías de stdlib contract validator.",
+            ),
             changes=(
                 "Mantener manifest único en pcobra.cobra.stdlib_contract.",
                 "Declarar backend primario + fallbacks por módulo.",
@@ -184,6 +203,11 @@ def build_refactor_workplan() -> tuple[RefactorTask, ...]:
             id="T4",
             area="imports-bindings",
             objective="Formalizar resolución de imports + bridges de runtime.",
+            owner="runtime-bindings",
+            definition_of_done=(
+                "Orden de resolución aplicado en resolver con pruebas verdes.",
+                "Adapters inyectados con metadata contractual verificable.",
+            ),
             changes=(
                 "Aplicar orden stdlib > proyecto > python_bridge > hybrid.",
                 "Inyectar adapters por módulo resuelto en tiempo de carga.",
@@ -197,6 +221,11 @@ def build_refactor_workplan() -> tuple[RefactorTask, ...]:
             id="T5",
             area="legacy-removal",
             objective="Retirar componentes legacy no oficiales de forma segura.",
+            owner="decommission-track",
+            definition_of_done=(
+                "Inventario legacy auditado y ventanas de retiro actualizadas.",
+                "Rutas retiradas eliminadas sin romper contrato público oficial.",
+            ),
             changes=(
                 "Marcar go/cpp/java/wasm/asm como candidatos de retiro.",
                 "Eliminar comandos y scripts de backends retirados después de auditoría.",

--- a/src/pcobra/cobra/cli/commands/benchmarks_cmd.py
+++ b/src/pcobra/cobra/cli/commands/benchmarks_cmd.py
@@ -7,7 +7,10 @@ from typing import Any
 from pathlib import Path
 
 from pcobra.cobra.transpilers.target_utils import target_label
-from pcobra.cobra.cli.target_policies import parse_target
+from pcobra.cobra.cli.target_policies import (
+    add_internal_legacy_targets_flag,
+    parse_target,
+)
 
 from pcobra.cobra.benchmarks.targets_policy import BENCHMARK_BACKEND_METADATA, benchmark_backends, validate_backend_metadata
 
@@ -17,7 +20,6 @@ from pcobra.cobra.cli.deprecation_policy import (
     enforce_advanced_profile_policy,
     enforce_target_deprecation_policy,
 )
-from pcobra.cobra.cli.internal_compat.legacy_flags import add_internal_legacy_targets_flag
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info

--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -9,6 +9,8 @@ from importlib.metadata import entry_points
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.target_policies import (
     OFFICIAL_TRANSPILATION_TARGETS,
+    add_internal_legacy_targets_flag,
+    enabled_internal_legacy_targets,
     parse_target,
     parse_target_list,
 )
@@ -26,8 +28,6 @@ from pcobra.cobra.cli.deprecation_policy import (
     enforce_target_deprecation_policy,
     visible_public_targets,
 )
-from pcobra.cobra.cli.internal_compat.legacy_targets import enabled_internal_legacy_targets
-from pcobra.cobra.cli.internal_compat.legacy_flags import add_internal_legacy_targets_flag
 from pcobra.cobra.cli.utils.messages import mostrar_advertencia, mostrar_error, mostrar_info
 from pcobra.cobra.cli.utils.validators import validar_archivo_existente
 from pcobra.cobra.cli.utils.autocomplete import files_completer

--- a/src/pcobra/cobra/cli/commands/transpilar_inverso_cmd.py
+++ b/src/pcobra/cobra/cli/commands/transpilar_inverso_cmd.py
@@ -32,7 +32,6 @@ from pcobra.cobra.transpilers.reverse.policy import (
 from pcobra.cobra.cli.commands.base import BaseCommand, CommandError
 from pcobra.cobra.cli.commands.compile_cmd import TRANSPILERS
 from pcobra.cobra.cli.i18n import _
-from pcobra.cobra.cli.internal_compat.legacy_flags import add_internal_legacy_targets_flag
 from pcobra.cobra.cli.mode_policy import validar_politica_modo
 from pcobra.cobra.cli.deprecation_policy import (
     enforce_advanced_profile_policy,
@@ -41,8 +40,11 @@ from pcobra.cobra.cli.deprecation_policy import (
 )
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
-from pcobra.cobra.cli.target_policies import parse_target
-from pcobra.cobra.cli.target_policies import OFFICIAL_TRANSPILATION_TARGETS
+from pcobra.cobra.cli.target_policies import (
+    OFFICIAL_TRANSPILATION_TARGETS,
+    add_internal_legacy_targets_flag,
+    parse_target,
+)
 from pcobra.cobra.transpilers.import_helper import get_standard_imports
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.utils.validators import validar_archivo_existente

--- a/src/pcobra/cobra/cli/internal_compat/legacy_targets.py
+++ b/src/pcobra/cobra/cli/internal_compat/legacy_targets.py
@@ -10,8 +10,10 @@ import os
 from datetime import date
 from typing import Final
 
-from pcobra.cobra.architecture.backend_policy import INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW
-from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS
+from pcobra.cobra.internal_compat.legacy_contracts import (
+    INTERNAL_BACKENDS,
+    INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW,
+)
 
 LEGACY_BACKENDS_FEATURE_FLAG: Final[str] = "COBRA_INTERNAL_LEGACY_TARGETS"
 

--- a/src/pcobra/cobra/cli/target_policies.py
+++ b/src/pcobra/cobra/cli/target_policies.py
@@ -16,6 +16,7 @@ from pcobra.cobra.cli.internal_compat.legacy_targets import (
     enabled_internal_legacy_targets,
     is_internal_legacy_targets_enabled,
 )
+from pcobra.cobra.cli.internal_compat.legacy_flags import add_internal_legacy_targets_flag
 from pcobra.cobra.transpilers.compatibility_matrix import (
     BACKEND_COMPATIBILITY,
     BEST_EFFORT_RUNTIME_BACKENDS,

--- a/src/pcobra/cobra/config/transpile_targets.py
+++ b/src/pcobra/cobra/config/transpile_targets.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from typing import Final, Literal, TypedDict
 
 from pcobra.cobra.architecture.backend_policy import (
-    INTERNAL_BACKENDS,
-    INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW,
     PUBLIC_BACKENDS,
     assert_public_targets_contract,
+)
+from pcobra.cobra.internal_compat.legacy_contracts import (
+    INTERNAL_BACKENDS,
+    INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW,
 )
 
 

--- a/tests/unit/test_ci_check_public_import_boundaries.py
+++ b/tests/unit/test_ci_check_public_import_boundaries.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.ci.check_public_import_boundaries import _scan_scope
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_detecta_import_from_internal_compat(tmp_path: Path) -> None:
+    scope = tmp_path / "src" / "pcobra" / "cobra" / "build"
+    _write(
+        scope / "pipeline.py",
+        "from pcobra.cobra.cli.internal_compat.legacy_targets import enabled_internal_legacy_targets\n",
+    )
+
+    violations = _scan_scope(scope)
+
+    assert len(violations) == 1
+    path, line, target = violations[0]
+    assert path.name == "pipeline.py"
+    assert line == 1
+    assert target == "pcobra.cobra.cli.internal_compat.legacy_targets"
+
+
+def test_detecta_import_modulo_internal_compat(tmp_path: Path) -> None:
+    scope = tmp_path / "src" / "pcobra" / "cobra" / "imports"
+    _write(
+        scope / "resolver.py",
+        "import pcobra.cobra.cli.internal_compat.legacy_targets as legacy\n",
+    )
+
+    violations = _scan_scope(scope)
+
+    assert len(violations) == 1
+    _, line, target = violations[0]
+    assert line == 1
+    assert target == "pcobra.cobra.cli.internal_compat.legacy_targets"
+
+
+def test_permite_imports_publicos(tmp_path: Path) -> None:
+    scope = tmp_path / "src" / "pcobra" / "cobra" / "bindings"
+    _write(
+        scope / "bridge.py",
+        "from pcobra.cobra.architecture.contracts import binding_route_for_public_backend\n",
+    )
+
+    violations = _scan_scope(scope)
+
+    assert violations == []


### PR DESCRIPTION
### Motivation

- Garantizar que `backend_policy.py` y `contracts.py` sean las únicas fuentes públicas de verdad para la política/contratos de backends y evitar dependencias públicas directas a artefactos legacy.
- Forzar que el código que maneja compatibilidad legacy dependa de `internal_compat` y no al revés para mejorar el aislamiento de la superficie pública.
- Hacer trazables las tareas de refactor con responsables técnicos y criterios de salida (DoD) para facilitar gobernanza del plan de migración.
- Evitar regresiones en la exposición pública añadiendo una validación CI que falle si rutas públicas importan desde `internal_compat`.

### Description

- Documenté `unified_ecosystem.py` como blueprint interno y amplié `RefactorTask` con campos `owner` y `definition_of_done`, además de rellenar esos campos para T1..T5 en `build_refactor_workplan`.
- Reubicé referencias de compatibilidad interna para importar `INTERNAL_BACKENDS` e `INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW` desde `pcobra.cobra.internal_compat.legacy_contracts` en lugar de `architecture.backend_policy`, y actualicé los módulos afectados (`config/transpile_targets.py`, `cli/internal_compat/legacy_targets.py`, y usage en `cli/target_policies.py`).
- Modifiqué comandos públicos (`compile_cmd.py`, `benchmarks_cmd.py`, `transpilar_inverso_cmd.py`) para obtener flags/funcionalidad de compatibilidad legacy a través de `cli.target_policies` en lugar de importar directamente de `cli.internal_compat`.
- Endurecí el guard de imports públicos en `scripts/ci/check_public_import_boundaries.py` para incluir `cli/commands` y `cli/commands_v2` y mejorar detección de imports prohibidos, añadí un conjunto de pruebas unitarias (`tests/unit/test_ci_check_public_import_boundaries.py`) y conecté el chequeo al workflow CI (`.github/workflows/ci.yml`).

### Testing

- Ejecuté el chequeo directo `python scripts/ci/check_public_import_boundaries.py` y se completó sin detectar violaciones tras los cambios (exit code 0).
- Corrí `pytest -q tests/unit/test_ci_check_public_import_boundaries.py tests/unit/test_public_import_boundaries_guard.py tests/test_unified_ecosystem_plan.py` y todos los tests pasaron.
- Corrí `pytest -q tests/unit/test_ci_lint_public_commands_internal_backends.py tests/unit/test_public_commands_internal_backends_lint_guard.py` y ambos tests pasaron.
- Integré la nueva validación en el workflow CI para ejecutarla en los jobs relevantes, por lo que la falla sería visible en la integración continua si aparecen imports no permitidos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3797bb90083278ecb37f369123519)