### PR TITLE
Endurecer contrato CLI público y restringir acceso legacy/v1 a entornos internos

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -96,6 +96,7 @@ COBRA_DEV_MODE_ENV = "COBRA_DEV_MODE"
 COBRA_DEV_EPHEMERAL_CONFIRM_ENV = "COBRA_DEV_ALLOW_EPHEMERAL_KEY"
 COBRA_ALLOW_INSECURE_FALLBACK_ENV = "COBRA_ALLOW_INSECURE_FALLBACK"
 COBRA_ALLOW_INSECURE_NON_INTERACTIVE_ENV = "COBRA_ALLOW_INSECURE_NON_INTERACTIVE"
+COBRA_INTERNAL_ENABLE_CLI_V1_ENV = "COBRA_INTERNAL_ENABLE_CLI_V1"
 LANG_CHOICES = tuple(OFFICIAL_TRANSPILATION_TARGETS)
 LEGACY_COMMAND_MIGRATION_MAP: dict[str, dict[str, str]] = {
     "ejecutar": {
@@ -164,9 +165,13 @@ class CommandRegistry:
             logging.error(f"Error creating command {command_class.__name__}: {e}")
             raise
 
-    def _resolve_v2_command_classes(self) -> List[Type[BaseCommand]]:
+    def _resolve_v2_command_classes(self, profile: str) -> List[Type[BaseCommand]]:
         classes = list(AppConfig.V2_COMMAND_CLASSES)
-        if LegacyCommandGroupV2 is not None and is_legacy_cli_enabled():
+        if (
+            profile == PROFILE_DEVELOPMENT
+            and LegacyCommandGroupV2 is not None
+            and is_legacy_cli_enabled()
+        ):
             classes.append(LegacyCommandGroupV2)
             logging.getLogger(__name__).debug(
                 "Compatibilidad legacy v2 habilitada por flag interno %s=1.",
@@ -182,7 +187,11 @@ class CommandRegistry:
         profile: str = PROFILE_PUBLIC,
     ) -> Dict[str, BaseCommand]:
         base_commands = []
-        command_classes = self._resolve_v2_command_classes() if ui == "v2" else AppConfig.BASE_COMMAND_CLASSES
+        command_classes = (
+            self._resolve_v2_command_classes(profile)
+            if ui == "v2"
+            else AppConfig.BASE_COMMAND_CLASSES
+        )
 
         for cmd_class in command_classes:
             try:
@@ -322,6 +331,12 @@ class CliApplication:
     def _is_enabled_env_flag(self, env_name: str) -> bool:
         return environ.get(env_name, "").strip() == "1"
 
+    def _is_internal_v1_ui_enabled(self) -> bool:
+        return (
+            resolve_command_profile() == PROFILE_DEVELOPMENT
+            and self._is_enabled_env_flag(COBRA_INTERNAL_ENABLE_CLI_V1_ENV)
+        )
+
     def _ensure_sqlite_db_key(self, args: argparse.Namespace) -> None:
         command = getattr(args, "cmd", None)
         command_name = command.name if isinstance(command, BaseCommand) else _("desconocido")
@@ -418,12 +433,8 @@ class CliApplication:
                 "Cobra sin rutas de codegen."
             ),
         )
-        parser.add_argument(
-            "--ui",
-            choices=("v1", "v2"),
-            default="v2",
-            help=argparse.SUPPRESS,
-        )
+        ui_choices = ("v1", "v2") if self._is_internal_v1_ui_enabled() else ("v2",)
+        parser.add_argument("--ui", choices=ui_choices, default="v2", help=argparse.SUPPRESS)
         parser.add_argument("--lang",
                           default=environ.get("COBRA_LANG", AppConfig.DEFAULT_LANGUAGE),
                           help=_("Interface language code"))
@@ -610,6 +621,13 @@ class CliApplication:
                 "según --modo (cobra, transpilar, mixto). "
                 "Modo cobra = solo programar/interpretar Cobra sin codegen."
             ),
+            epilog=_(
+                "Ejemplos públicos:\n"
+                "  cobra run <archivo.co>\n"
+                "  cobra build <archivo.co>\n"
+                "  cobra test <archivo.co>\n"
+                "  cobra mod <list|install|remove|publish|search>"
+            ),
         )
         self._configure_cli_options(parser)
         return parser
@@ -732,10 +750,24 @@ class CliApplication:
         return normalized
 
     @staticmethod
-    def _resolve_selected_ui_from_argv(argv: list[str]) -> str:
+    def _resolve_ui_token_from_argv(argv: list[str]) -> str:
         for index, token in enumerate(argv):
             if token == "--ui" and index + 1 < len(argv):
                 return argv[index + 1].strip().lower()
+        return "v2"
+
+    def _resolve_selected_ui_from_argv(self, argv: list[str]) -> str:
+        requested_ui = self._resolve_ui_token_from_argv(argv)
+        if requested_ui != "v1":
+            return "v2"
+        if self._is_internal_v1_ui_enabled():
+            return "v1"
+        messages.mostrar_advertencia(
+            _(
+                "UI v1 está deshabilitada para uso público. "
+                "Se mantiene UI v2 (cobra run/build/test/mod)."
+            )
+        )
         return "v2"
 
     def _handle_execution_error(self, exc: Exception, language: str, debug_activo: bool = False) -> int:

--- a/src/pcobra/cobra/cli/commands_v2/legacy_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/legacy_cmd.py
@@ -7,6 +7,7 @@ from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
 from pcobra.cobra.cli.commands.modules_cmd import ModulesCommand
 from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.public_command_policy import PROFILE_DEVELOPMENT, resolve_command_profile
 from pcobra.cobra.cli.utils import messages
 
 
@@ -70,9 +71,19 @@ class LegacyCommandGroupV2(BaseCommand):
             messages.mostrar_advertencia(
                 _(
                     "Comando legacy '{legacy}' en grupo 'legacy'. "
-                    "Migra a interfaz pública: {hint}."
+                    "Esta ruta es solo para perfil development y será retirada. "
+                    "Migra ahora a interfaz pública: {hint}."
                 ).format(legacy=command, hint=LEGACY_GROUP_MIGRATION_HINTS[command])
             )
+        if resolve_command_profile() != PROFILE_DEVELOPMENT:
+            messages.mostrar_error(
+                _(
+                    "El grupo 'legacy' está restringido a development. "
+                    "Use comandos públicos: cobra run/build/test/mod."
+                ),
+                registrar_log=False,
+            )
+            return 1
         if command == "ejecutar":
             return self._execute.run(
                 Namespace(

--- a/src/pcobra/cobra/cli/public_command_policy.py
+++ b/src/pcobra/cobra/cli/public_command_policy.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from os import environ
 from typing import Iterable
 
-PUBLIC_COMMANDS: tuple[str, ...] = ("run", "build", "test", "mod")
+PUBLIC_COMMANDS_CONTRACT: tuple[str, ...] = ("run", "build", "test", "mod")
+PUBLIC_COMMANDS: tuple[str, ...] = PUBLIC_COMMANDS_CONTRACT
+if PUBLIC_COMMANDS != PUBLIC_COMMANDS_CONTRACT:
+    raise RuntimeError(
+        "Contrato público inválido: PUBLIC_COMMANDS debe mantenerse en "
+        "('run', 'build', 'test', 'mod')."
+    )
 INTERNAL_COMMANDS: tuple[str, ...] = (
     "legacy",
     "debug",
@@ -99,6 +105,7 @@ def filter_legacy_commands_for_profile(command_names: Iterable[str], profile: st
 
 
 __all__ = [
+    "PUBLIC_COMMANDS_CONTRACT",
     "PUBLIC_COMMANDS",
     "INTERNAL_COMMANDS",
     "LEGACY_PUBLIC_COMMANDS",


### PR DESCRIPTION
### Motivation
- Asegurar que la superficie pública de la CLI permanezca estable y evitar exposición accidental de rutas/v1 legacy; las únicas operaciones públicas deben ser `run`, `build`, `test`, `mod`.
- Mover cualquier inicialización/v1 detrás de flags internas y del perfil `development` para que la UX pública use solo la interfaz v2 pública.
- Mantener el grupo `legacy` como herramienta de migración solo en `development` y reforzar mensajes cuando se use fuera de ese perfil.
- Alinear la ayuda global para que los ejemplos públicos muestren únicamente los comandos públicos canónicos.

### Description
- En `src/pcobra/cobra/cli/public_command_policy.py` se introdujo `PUBLIC_COMMANDS_CONTRACT` y se enlaza con `PUBLIC_COMMANDS`, añadiendo una validación en tiempo de importación que lanza `RuntimeError` si el contrato se altera; además se exporta `PUBLIC_COMMANDS_CONTRACT` en `__all__`.
- En `src/pcobra/cobra/cli/cli.py` se añadió la variable de entorno interna `COBRA_INTERNAL_ENABLE_CLI_V1`, se implementó `_is_internal_v1_ui_enabled()` (requiere perfil `development` + flag activa), se cambió la resolución de clases v2 para recibir `profile`, y se limitó la opción `--ui` para que `v1` solo sea selectable cuando el gating interno esté activo.
- En `src/pcobra/cobra/cli/cli.py` se agregó un `epilog` al parser global con ejemplos públicos: `cobra run`, `cobra build`, `cobra test`, `cobra mod`.
- En `src/pcobra/cobra/cli/commands_v2/legacy_cmd.py` se reforzaron los mensajes de migración y se añadió una comprobación que bloquea la ejecución del grupo `legacy` cuando el perfil no es `development`, mostrando un error instructivo para usar los comandos públicos.

### Testing
- `python -m compileall src/pcobra/cobra/cli` — éxito (todos los módulos modificados compilados correctamente).
- Comprobación de presencia de los textos de ayuda mediante `rg` para `Ejemplos públicos` y las cadenas `cobra run/build/test/mod` — éxito.
- Intento de instanciar y formatear la ayuda completa (`app = CliApplication(); app.initialize(); app.parser.format_help()`) falló por un problema preexistente no relacionado con estos cambios (`ImportError` en `pcobra.cobra.build.backend_pipeline`), por lo que la verificación funcional completa del runtime quedó pendiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37b320d1083279e28dc590ccd8ef6)