### PR TITLE
Stabilizar API de backend_pipeline y bloquear imports directos a transpilers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,8 @@ jobs:
       - name: Validate syntax report JSON contract
         shell: bash
         run: python scripts/ci/validate_syntax_report_contract.py
+      - name: Lint public surfaces without direct transpiler imports
+        run: python scripts/ci/lint_public_no_direct_transpiler_imports.py
       - name: Validate runtime contract matrix
         shell: bash
         run: python scripts/validate_runtime_contract.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,5 +20,7 @@ jobs:
         run: python scripts/validate_targets_policy.py
       - name: Validate policy drift in public target text
         run: python scripts/lint_policy_drift.py
+      - name: Lint public surfaces without direct transpiler imports
+        run: python scripts/ci/lint_public_no_direct_transpiler_imports.py
       - name: Validate runtime contract matrix
         run: python scripts/validate_runtime_contract.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,8 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: python scripts/ci/validate_syntax_report_contract.py
+      - name: Lint public surfaces without direct transpiler imports
+        run: python scripts/ci/lint_public_no_direct_transpiler_imports.py
       - name: Validate runtime contract matrix
         if: runner.os != 'Windows'
         shell: bash

--- a/scripts/ci/lint_public_no_direct_transpiler_imports.py
+++ b/scripts/ci/lint_public_no_direct_transpiler_imports.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Bloquea imports directos a transpilers `to_*` en superficies públicas."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PUBLIC_SCOPES = (
+    ROOT / "src/pcobra/cobra/cli",
+    ROOT / "src/pcobra/cobra/imports",
+    ROOT / "src/pcobra/cobra/stdlib_contract",
+)
+FORBIDDEN_PREFIX = "pcobra.cobra.transpilers.transpiler.to_"
+
+
+def _node_import_targets(node: ast.AST) -> list[str]:
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    if isinstance(node, ast.ImportFrom):
+        return [node.module] if node.module else []
+    return []
+
+
+def _scan_scope(scope: Path) -> list[tuple[Path, int, str]]:
+    violations: list[tuple[Path, int, str]] = []
+    for path in sorted(scope.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            for target in _node_import_targets(node):
+                if target and target.startswith(FORBIDDEN_PREFIX):
+                    violations.append((path, node.lineno, target))
+    return violations
+
+
+def find_violations(root: Path = ROOT) -> list[str]:
+    scopes = (
+        root / "src/pcobra/cobra/cli",
+        root / "src/pcobra/cobra/imports",
+        root / "src/pcobra/cobra/stdlib_contract",
+    )
+    failures: list[str] = []
+    for scope in scopes:
+        if not scope.exists():
+            continue
+        for path, line, target in _scan_scope(scope):
+            rel = path.relative_to(root)
+            failures.append(
+                f"{rel}:{line}: import no permitido a {target}; "
+                "usa pcobra.cobra.build.backend_pipeline"
+            )
+    return failures
+
+
+def main() -> int:
+    failures = find_violations(ROOT)
+    if failures:
+        print("❌ Lint imports directos a transpilers en superficies públicas: FALLÓ")
+        for item in failures:
+            print(f" - {item}")
+        return 1
+
+    print("✅ Lint imports directos a transpilers en superficies públicas: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pcobra/cobra/backends/resolver.py
+++ b/src/pcobra/cobra/backends/resolver.py
@@ -3,6 +3,8 @@
 Este módulo existe solo para compatibilidad técnica temporal.
 La API interna aprobada para resolver/transpilar está en
 ``pcobra.cobra.build.backend_pipeline``.
+
+Fecha objetivo de retiro del shim: 2026-09-30.
 """
 
 from __future__ import annotations
@@ -11,6 +13,8 @@ from typing import Any, Mapping
 
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.backends.base import BackendAdapter
+
+SHIM_RETIREMENT_TARGET = "2026-09-30"
 
 _BACKEND_ALIASES = {
     "python": "python",

--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -30,6 +30,9 @@ INTERNAL_BACKEND_API_CONTRACT: tuple[str, ...] = (
     "transpile",
 )
 
+# API mínima estable para capas superiores.
+STABLE_BACKEND_PIPELINE_API: tuple[str, ...] = INTERNAL_BACKEND_API_CONTRACT
+
 
 def _load_official_transpilers() -> dict[str, type]:
     """Helper interno: encapsula acceso al registro canónico."""
@@ -79,9 +82,13 @@ def _validate_internal_entrypoint_contract() -> None:
             "El contrato interno del backend pipeline debe ser "
             "resolve_backend_runtime/build/transpile."
         )
+    exported_api = tuple(__all__) if isinstance(__all__, list) else tuple(__all__)
+    if exported_api != STABLE_BACKEND_PIPELINE_API:
+        raise RuntimeError(
+            "La API exportada de backend_pipeline debe permanecer mínima y estable: "
+            "resolve_backend_runtime/build/transpile."
+        )
 
-
-_validate_internal_entrypoint_contract()
 
 
 def _resolve_backend(source: str, hints: dict[str, Any] | None = None) -> BackendResolution:
@@ -96,6 +103,14 @@ def _resolve_backend(source: str, hints: dict[str, Any] | None = None) -> Backen
         required_capabilities=required_capabilities,
         route_scope=route_scope,
     )
+
+
+def resolve_backend(source: str, hints: dict[str, Any] | None = None) -> BackendResolution:
+    """Compat temporal: delega en la resolución interna del pipeline.
+
+    Nota: la API estable para capas superiores es ``resolve_backend_runtime``.
+    """
+    return _resolve_backend(source, hints)
 
 
 def resolve_backend_runtime(
@@ -150,7 +165,10 @@ def build(source: str, hints: dict[str, Any] | None = None) -> dict[str, Any]:
     ast = obtener_ast(codigo)
     code = transpile(ast, resolution.backend)
     debug = bool(context.get("debug", False))
-    reason = resolution.reason_for(debug=debug)
+    if hasattr(resolution, "reason_for"):
+        reason = resolution.reason_for(debug=debug)
+    else:
+        reason = getattr(resolution, "reason", None) if debug else None
     return {
         "backend": resolution.backend,
         "reason": reason,
@@ -160,12 +178,7 @@ def build(source: str, hints: dict[str, Any] | None = None) -> dict[str, Any]:
     }
 
 
-__all__ = [
-    "INTERNAL_BACKEND_ENTRYPOINT",
-    "INTERNAL_BACKEND_API_CONTRACT",
-    "ORCHESTRATOR",
-    "TRANSPILERS",
-    "build",
-    "resolve_backend_runtime",
-    "transpile",
-]
+__all__ = list(STABLE_BACKEND_PIPELINE_API)
+
+
+_validate_internal_entrypoint_contract()

--- a/tests/unit/test_ci_lint_public_no_direct_transpiler_imports.py
+++ b/tests/unit/test_ci_lint_public_no_direct_transpiler_imports.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.ci.lint_public_no_direct_transpiler_imports import find_violations
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_detecta_import_directo_transpiler_en_cli(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "foo.py",
+        "from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "src/pcobra/cobra/cli/commands/foo.py:1" in violations[0]
+
+
+def test_permite_imports_desde_backend_pipeline(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "imports" / "ok.py",
+        "from pcobra.cobra.build.backend_pipeline import transpile\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert violations == []

--- a/tests/unit/test_public_commands_no_direct_transpilers_contract.py
+++ b/tests/unit/test_public_commands_no_direct_transpilers_contract.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_public_surfaces_no_direct_transpiler_imports_contract() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "scripts/ci/lint_public_no_direct_transpiler_imports.py"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
### Motivation

- Forzar un punto de entrada interno estable para resolución/build/transpile y evitar llamadas directas a los transpilers oficiales desde superficies públicas. 
- Añadir una regla de CI que impida imports directos a módulos `to_*` desde `cli`/`imports`/`stdlib_contract` para preservar la abstracción del pipeline. 

### Description

- Se fija la API mínima estable en `pcobra.cobra.build.backend_pipeline` con la tupla `STABLE_BACKEND_PIPELINE_API` que expone solo `resolve_backend_runtime`, `build` y `transpile`, y se valida que `__all__` permanezca igual. 
- Se mantiene `resolve_backend` como compat shim temporal delegando en la resolución interna y se adapta `build` para aceptar objetos `resolution` que no implementen `reason_for` (compatibilidad con dobles de prueba). 
- Se documenta `src/pcobra/cobra/backends/resolver.py` como shim temporal y se añade la constante `SHIM_RETIREMENT_TARGET = "2026-09-30"` como fecha objetivo de retiro. 
- Se añade el lint/CI `scripts/ci/lint_public_no_direct_transpiler_imports.py` y los tests `tests/unit/test_ci_lint_public_no_direct_transpiler_imports.py` y `tests/unit/test_public_commands_no_direct_transpilers_contract.py`, y se integra la regla en los workflows `.github/workflows/{lint,ci,test}.yml`.

### Testing

- Ejecuté `python scripts/ci/lint_public_no_direct_transpiler_imports.py` y confirmó salida OK (sin violaciones). 
- Ejecuté `pytest -q tests/unit/test_backend_pipeline_runtime_manager.py tests/unit/test_ci_lint_public_no_direct_transpiler_imports.py tests/unit/test_public_commands_no_direct_transpilers_contract.py` y todos los tests unitarios indicados pasaron exitosamente. 
- No se detectaron fallos en las validaciones locales tras los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37ca9bbec832790da9c5b0f14c924)