### PR TITLE
Auditar paridad stdlib por función desde contratos declarativos

### DIFF
--- a/docs/standard_library/matriz_api_runtime.md
+++ b/docs/standard_library/matriz_api_runtime.md
@@ -62,3 +62,16 @@ Este flujo actualiza:
 - `docs/_generated/stdlib_contract_matrix.md` (API pública + backend primario + fallback + cobertura `full/partial`)
 - `docs/_generated/stdlib_contract_matrix.json` (matriz estructurada para consumo de CLI/docs)
 - `docs/standard_library/matriz_stdlib_unificada.md` (publicación única para documentación funcional)
+
+
+Auditoría CI de paridad por función (python/javascript/rust):
+
+```bash
+python scripts/ci/audit_stdlib_parity.py
+```
+
+Este flujo actualiza:
+
+- `docs/_generated/audit_stdlib_parity_report.md` (artefacto CI por función)
+- `docs/standard_library/paridad_stdlib_por_funcion.md` (tabla pública para usuarios)
+

--- a/docs/standard_library/paridad_stdlib_por_funcion.md
+++ b/docs/standard_library/paridad_stdlib_por_funcion.md
@@ -1,12 +1,7 @@
-# Auditoría CI: paridad stdlib por función
+# Paridad de stdlib pública por función
 
-Fuente única de API pública y cobertura:
-- `src/pcobra/cobra/stdlib_contract/core.py`
-- `src/pcobra/cobra/stdlib_contract/datos.py`
-- `src/pcobra/cobra/stdlib_contract/web.py`
-- `src/pcobra/cobra/stdlib_contract/system.py`
-
-## Cobertura por función (python/javascript/rust)
+Tabla publicada para usuarios finales. Se genera desde los contratos de
+`src/pcobra/cobra/stdlib_contract/{core,datos,web,system}.py`.
 
 | módulo | función | primario | python | javascript | rust | notas |
 |---|---|---|---|---|---|---|

--- a/scripts/ci/audit_stdlib_parity.py
+++ b/scripts/ci/audit_stdlib_parity.py
@@ -1,261 +1,175 @@
 #!/usr/bin/env python3
-"""Audita paridad de standard_library entre exports, backends y documentación.
+"""Audita la paridad de stdlib pública por función desde contratos declarativos.
 
-Reglas de severidad:
-- error: símbolo público sin estrategia declarada de backend.
-- warning: símbolo con soporte parcial sin workaround documentado.
+Fuente única de verdad:
+- src/pcobra/cobra/stdlib_contract/core.py
+- src/pcobra/cobra/stdlib_contract/datos.py
+- src/pcobra/cobra/stdlib_contract/web.py
+- src/pcobra/cobra/stdlib_contract/system.py
 
-Además genera un reporte Markdown como artefacto de CI.
+El reporte de CI y la tabla pública en docs se generan exclusivamente desde
+``ContractDescriptor.coverage``.
 """
 
 from __future__ import annotations
 
 import argparse
-import ast
-import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
-
-import yaml
 
 ROOT: Final[Path] = Path(__file__).resolve().parents[2]
 SRC: Final[Path] = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
-from pcobra.cobra.transpilers.compatibility_matrix import (  # noqa: E402
-    BACKEND_FEATURE_NODE_SUPPORT,
-    BACKEND_COMPATIBILITY,
-)
-from pcobra.cobra.transpilers.runtime_api_matrix import (  # noqa: E402
-    SNAPSHOT_PATH,
-    build_runtime_api_matrix,
-)
-from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS  # noqa: E402
+from pcobra.cobra.stdlib_contract import CONTRACTS  # noqa: E402
 
-STANDARD_LIBRARY_INIT = ROOT / "src" / "pcobra" / "standard_library" / "__init__.py"
-DECORADORES_MODULE = ROOT / "src" / "pcobra" / "standard_library" / "decoradores.py"
-LANGUAGE_EQ_PATH = ROOT / "data" / "language_equivalence.yml"
-LANGUAGE_EQ_DOC = ROOT / "docs" / "language_equivalence_matrix.md"
-LIBRARY_COMPAT_DOC = ROOT / "docs" / "library_compatibility_matrix.md"
-DECORATORS_DOC = ROOT / "docs" / "standard_library" / "decoradores.md"
 
 
 @dataclass(frozen=True)
-class Finding:
-    severity: str
-    symbol: str
-    message: str
+class CoverageRow:
+    module: str
+    function: str
+    primary_backend: str
+    python: str
+    javascript: str
+    rust: str
+    notes: str
 
 
-def _read_all_exports(path: Path) -> list[str]:
-    source = path.read_text(encoding="utf-8")
-    module = ast.parse(source, filename=str(path))
-    for node in module.body:
-        value = None
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name) and target.id == "__all__":
-                    value = node.value
-                    break
-        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id == "__all__":
-            value = node.value
-        if value is None:
-            continue
-        resolved = ast.literal_eval(value)
-        if not isinstance(resolved, list) or not all(isinstance(item, str) for item in resolved):
-            raise RuntimeError(f"{path}: __all__ inválido")
-        return resolved
-    raise RuntimeError(f"{path}: no se encontró __all__")
+def _build_rows() -> list[CoverageRow]:
+    rows: list[CoverageRow] = []
+    for contract in CONTRACTS:
+        coverage_by_function = {item.function: item.backend_levels for item in contract.coverage}
+        for function in contract.public_api:
+            levels = coverage_by_function.get(function)
+            if levels is None:
+                raise RuntimeError(f"{contract.module}: cobertura faltante para {function}")
 
-
-def _load_language_equivalence() -> dict:
-    payload = yaml.safe_load(LANGUAGE_EQ_PATH.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise RuntimeError(f"Contrato inválido en {LANGUAGE_EQ_PATH}")
-    return payload
-
-
-def _decorator_sections_with_workaround(doc: str) -> dict[str, bool]:
-    sections: dict[str, bool] = {}
-    current: str | None = None
-    buffer: list[str] = []
-
-    for line in doc.splitlines():
-        if line.startswith("## `") and line.endswith("`"):
-            if current is not None:
-                text = "\n".join(buffer)
-                sections[current] = "Limitación real fuera de Python runtime" in text
-            current = line.replace("## `", "", 1)[:-1]
-            buffer = []
-            continue
-        if current is not None:
-            buffer.append(line)
-
-    if current is not None:
-        text = "\n".join(buffer)
-        sections[current] = "Limitación real fuera de Python runtime" in text
-
-    return sections
-
-
-def _markdown_status_row(symbol: str, status_by_backend: dict[str, str], severity: str, notes: str) -> str:
-    ordered = [status_by_backend.get(backend, "none") for backend in OFFICIAL_TARGETS]
-    return "| " + " | ".join([symbol, *ordered, severity, notes]) + " |"
-
-
-def run_audit(report_path: Path) -> int:
-    stdlib_exports = _read_all_exports(STANDARD_LIBRARY_INIT)
-    decorator_exports = _read_all_exports(DECORADORES_MODULE)
-
-    runtime_matrix = build_runtime_api_matrix()
-    snapshot = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
-    python_snapshot = set(snapshot.get("python_global_api_snapshot", []))
-
-    equivalence = _load_language_equivalence()
-    features = {feature["id"]: feature for feature in equivalence.get("features", [])}
-    decoradores_contract = features.get("decoradores", {})
-    decorator_support = decoradores_contract.get("decorator_support", {})
-
-    decorators_doc_text = DECORATORS_DOC.read_text(encoding="utf-8")
-    decorators_workarounds = _decorator_sections_with_workaround(decorators_doc_text)
-
-    language_eq_doc = LANGUAGE_EQ_DOC.read_text(encoding="utf-8")
-    library_compat_doc = LIBRARY_COMPAT_DOC.read_text(encoding="utf-8")
-
-    findings: list[Finding] = []
-    table_rows: list[str] = []
-
-    # Reglas de error: símbolo público sin estrategia declarada.
-    for symbol in stdlib_exports:
-        if symbol not in python_snapshot:
-            findings.append(
-                Finding(
-                    severity="error",
-                    symbol=symbol,
-                    message="Símbolo público sin estrategia declarada en runtime_api_parity_snapshot.",
-                )
+            row = CoverageRow(
+                module=contract.module,
+                function=function,
+                primary_backend=contract.primary_backend,
+                python=levels.get("python", "n/a"),
+                javascript=levels.get("javascript", "n/a"),
+                rust=levels.get("rust", "n/a"),
+                notes="",
             )
+            rows.append(row)
 
-    # Auditoría detallada de decoradores (equivalencia + nodos + workaround docs)
-    for symbol in decorator_exports:
-        status_by_backend: dict[str, str] = {}
-        notes: list[str] = []
+    rows.sort(key=lambda row: (row.module, row.function))
+    return rows
 
-        if symbol not in stdlib_exports:
-            findings.append(
-                Finding(
-                    severity="error",
-                    symbol=symbol,
-                    message="Decorador público no re-exportado en standard_library.__all__.",
-                )
-            )
 
-        if symbol not in decorator_support:
-            findings.append(
-                Finding(
-                    severity="error",
-                    symbol=symbol,
-                    message="Decorador sin estrategia declarada en data/language_equivalence.yml.decorator_support.",
-                )
-            )
-            # Fallback para no romper el reporte
-            status_by_backend = {backend: "none" for backend in OFFICIAL_TARGETS}
+def _build_web_notes(rows: list[CoverageRow]) -> dict[str, str]:
+    web_rows = [row for row in rows if row.module == "cobra.web"]
+    if not web_rows:
+        raise RuntimeError("No se encontraron funciones para cobra.web en el contrato")
+
+    fallback_full = [
+        row.function
+        for row in web_rows
+        if row.primary_backend == "javascript" and row.javascript == "partial" and row.python == "full"
+    ]
+
+    notes: dict[str, str] = {}
+    for row in web_rows:
+        if row.function in fallback_full:
+            notes[row.function] = "JS primario partial; fallback python full"
+        elif row.primary_backend == "javascript" and row.javascript == "partial":
+            notes[row.function] = "JS primario partial; fallback python no-full"
         else:
-            raw = decorator_support[symbol]
-            status_by_backend = {backend: raw.get(backend, "none") for backend in OFFICIAL_TARGETS}
+            notes[row.function] = "-"
+    return notes
 
-        for backend in OFFICIAL_TARGETS:
-            status = status_by_backend.get(backend, "none")
-            node_support = BACKEND_FEATURE_NODE_SUPPORT.get(backend, {}).get("decoradores", ())
-            if status in {"partial", "full"} and not node_support:
-                findings.append(
-                    Finding(
-                        severity="error",
-                        symbol=symbol,
-                        message=(
-                            f"Backend `{backend}` marca `{status}` en equivalencia, "
-                            "pero no declara nodos/visitadores en BACKEND_FEATURE_NODE_SUPPORT.decoradores."
-                        ),
-                    )
-                )
-            if status == "partial" and not decorators_workarounds.get(symbol, False):
-                findings.append(
-                    Finding(
-                        severity="warning",
-                        symbol=symbol,
-                        message=(
-                            "Soporte parcial sin workaround documentado en "
-                            "docs/standard_library/decoradores.md."
-                        ),
-                    )
-                )
 
-        if "| decoradores |" not in language_eq_doc:
-            findings.append(
-                Finding(
-                    severity="error",
-                    symbol=symbol,
-                    message="La tabla de docs/language_equivalence_matrix.md no contiene la fila `decoradores`.",
-                )
-            )
-        if "standard_library" not in library_compat_doc:
-            findings.append(
-                Finding(
-                    severity="error",
-                    symbol=symbol,
-                    message="docs/library_compatibility_matrix.md no documenta `standard_library`.",
-                )
-            )
-
-        severity = "error" if any(f.severity == "error" and f.symbol == symbol for f in findings) else (
-            "warning" if any(f.severity == "warning" and f.symbol == symbol for f in findings) else "ok"
-        )
-        if status_by_backend.get("python") != "full":
-            notes.append("python debería permanecer en full para decoradores")
-        if BACKEND_COMPATIBILITY["python"]["standard_library"] != "full":
-            notes.append("contrato backend python/standard_library degradado")
-
-        table_rows.append(_markdown_status_row(symbol, status_by_backend, severity, "; ".join(notes) or "-"))
-
-    errors = [f for f in findings if f.severity == "error"]
-    warnings = [f for f in findings if f.severity == "warning"]
-
+def _render_table(rows: list[CoverageRow]) -> list[str]:
+    web_notes = _build_web_notes(rows)
     lines = [
-        "# Auditoría CI: paridad de `standard_library`",
+        "| módulo | función | primario | python | javascript | rust | notas |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for row in rows:
+        notes = web_notes.get(row.function, row.notes) if row.module == "cobra.web" else "-"
+        lines.append(
+            "| "
+            + " | ".join(
+                (
+                    f"`{row.module}`",
+                    f"`{row.function}`",
+                    f"`{row.primary_backend}`",
+                    row.python,
+                    row.javascript,
+                    row.rust,
+                    notes,
+                )
+            )
+            + " |"
+        )
+    return lines
+
+
+def _render_web_summary(rows: list[CoverageRow]) -> list[str]:
+    web_rows = [row for row in rows if row.module == "cobra.web"]
+    fallback_full = [
+        row.function
+        for row in web_rows
+        if row.primary_backend == "javascript" and row.javascript == "partial" and row.python == "full"
+    ]
+    fallback_list = ", ".join(f"`{fn}`" for fn in fallback_full)
+    return [
+        "## Estado explícito de `cobra.web`",
         "",
-        "## Resumen",
-        "",
-        f"- Símbolos públicos auditados en `standard_library.__all__`: **{len(stdlib_exports)}**.",
-        f"- Decoradores auditados en detalle: **{len(decorator_exports)}**.",
-        f"- Errores: **{len(errors)}**.",
-        f"- Warnings: **{len(warnings)}**.",
-        "",
-        "## Tabla de paridad (funcionalidad / python / javascript / rust / go / cpp / java / wasm / asm)",
-        "",
-        "| funcionalidad | python | javascript | rust | go | cpp | java | wasm | asm | severidad | notas |",
-        "|---|---|---|---|---|---|---|---|---|---|---|",
-        *table_rows,
-        "",
-        "## Hallazgos",
+        "- El backend primario se mantiene en `javascript`.",
+        "- Estado del primario JS: `partial` en todas las funciones públicas declaradas.",
+        f"- Funciones con fallback `python` en `full`: {fallback_list}.",
         "",
     ]
 
-    if not findings:
-        lines.append("Sin hallazgos: contrato de paridad consistente.")
-    else:
-        for finding in findings:
-            lines.append(f"- **{finding.severity.upper()}** `{finding.symbol}`: {finding.message}")
+
+def run_audit(report_path: Path, docs_table_path: Path) -> int:
+    rows = _build_rows()
+
+    report_lines = [
+        "# Auditoría CI: paridad stdlib por función",
+        "",
+        "Fuente única de API pública y cobertura:",
+        "- `src/pcobra/cobra/stdlib_contract/core.py`",
+        "- `src/pcobra/cobra/stdlib_contract/datos.py`",
+        "- `src/pcobra/cobra/stdlib_contract/web.py`",
+        "- `src/pcobra/cobra/stdlib_contract/system.py`",
+        "",
+        "## Cobertura por función (python/javascript/rust)",
+        "",
+        *_render_table(rows),
+        "",
+        *_render_web_summary(rows),
+    ]
+
+    docs_lines = [
+        "# Paridad de stdlib pública por función",
+        "",
+        "Tabla publicada para usuarios finales. Se genera desde los contratos de",
+        "`src/pcobra/cobra/stdlib_contract/{core,datos,web,system}.py`.",
+        "",
+        *_render_table(rows),
+        "",
+        *_render_web_summary(rows),
+    ]
 
     report_path.parent.mkdir(parents=True, exist_ok=True)
-    report_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    report_path.write_text("\n".join(report_lines) + "\n", encoding="utf-8")
+
+    docs_table_path.parent.mkdir(parents=True, exist_ok=True)
+    docs_table_path.write_text("\n".join(docs_lines) + "\n", encoding="utf-8")
 
     print(f"Reporte generado en: {report_path}")
-    print(f"Errores={len(errors)} Warnings={len(warnings)}")
+    print(f"Tabla pública generada en: {docs_table_path}")
+    print(f"Funciones auditadas: {len(rows)}")
 
-    return 1 if errors else 0
+    return 0
 
 
 def main() -> int:
@@ -264,10 +178,16 @@ def main() -> int:
         "--report",
         type=Path,
         default=ROOT / "docs" / "_generated" / "audit_stdlib_parity_report.md",
-        help="Ruta de salida para el reporte Markdown.",
+        help="Ruta de salida para el reporte Markdown de CI.",
+    )
+    parser.add_argument(
+        "--docs-table",
+        type=Path,
+        default=ROOT / "docs" / "standard_library" / "paridad_stdlib_por_funcion.md",
+        help="Ruta de salida para tabla pública de paridad.",
     )
     args = parser.parse_args()
-    return run_audit(args.report)
+    return run_audit(args.report, args.docs_table)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_ci_audit_stdlib_parity.py
+++ b/tests/unit/test_ci_audit_stdlib_parity.py
@@ -11,15 +11,29 @@ SCRIPT = ROOT / "scripts" / "ci" / "audit_stdlib_parity.py"
 
 def test_audit_stdlib_parity_generates_markdown_report(tmp_path: Path) -> None:
     report = tmp_path / "audit_stdlib_parity_report.md"
+    docs_table = tmp_path / "paridad_stdlib_por_funcion.md"
 
     result = subprocess.run(
-        [sys.executable, str(SCRIPT), "--report", str(report)],
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--report",
+            str(report),
+            "--docs-table",
+            str(docs_table),
+        ],
         cwd=ROOT,
         text=True,
         capture_output=True,
     )
 
     assert result.returncode == 0, result.stdout + "\n" + result.stderr
+
     content = report.read_text(encoding="utf-8")
-    assert "# Auditoría CI: paridad de `standard_library`" in content
-    assert "| funcionalidad | python | javascript | rust | go | cpp | java | wasm | asm |" in content
+    assert "# Auditoría CI: paridad stdlib por función" in content
+    assert "| módulo | función | primario | python | javascript | rust | notas |" in content
+    assert "## Estado explícito de `cobra.web`" in content
+
+    docs_content = docs_table.read_text(encoding="utf-8")
+    assert "# Paridad de stdlib pública por función" in docs_content
+    assert "`src/pcobra/cobra/stdlib_contract/{core,datos,web,system}.py`" in docs_content


### PR DESCRIPTION
### Motivation
- Mantener los descriptores en `src/pcobra/cobra/stdlib_contract/{core,datos,web,system}.py` como fuente única de verdad para la API pública y su cobertura por backend. 
- Proveer un reporte CI y una tabla pública por función (cobertura `python/javascript/rust`) que permitan a usuarios entender el comportamiento esperado sin revisar transpilers. 
- Hacer explícito el estado de `cobra.web` indicando que el primario JS es `partial` y qué funciones tienen fallback Python `full`.

### Description
- Reescribe `scripts/ci/audit_stdlib_parity.py` para construir la auditoría exclusivamente desde `CONTRACTS` importado de `pcobra.cobra.stdlib_contract` y generar un reporte por función con columnas `python`, `javascript` y `rust` (`full`/`partial`/`n/a`).
- Añade soporte CLI `--docs-table` en el script para producir una tabla pública en `docs/standard_library/paridad_stdlib_por_funcion.md` y ajusta la salida en `docs/_generated/audit_stdlib_parity_report.md` para incluir la sección explícita de `cobra.web`.
- Elimina la lógica previa centrada en decoradores/snapshot/equivalence y las importaciones relacionadas (ya no se usa `runtime_api_matrix`/`language_equivalence`/`BACKEND_FEATURE_NODE_SUPPORT`).
- Actualiza la documentación de flujo en `docs/standard_library/matriz_api_runtime.md` y adapta el test `tests/unit/test_ci_audit_stdlib_parity.py` para validar el nuevo formato y la generación de la tabla pública.

### Testing
- Ejecutado `pytest -q tests/unit/test_ci_audit_stdlib_parity.py` y el test pasó correctamente. 
- Ejecutado `python scripts/ci/validate_stdlib_function_coverage.py` y la validación de cobertura contra `runtime_api_matrix` finalizó sin errores. 
- Ejecutado `python scripts/ci/audit_stdlib_parity.py` para generar los artefactos y confirmada la creación de `docs/_generated/audit_stdlib_parity_report.md` y `docs/standard_library/paridad_stdlib_por_funcion.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37e769344832785f6cbe9ea3b236a)