### PR TITLE
Alinear superficie pública de backends y registrar inventario legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Resumen normativo visible (generado desde la política canónica):
 - **Targets con adaptador Holobit mantenido por el proyecto (partial fuera de python)**: `python`, `javascript`, `rust`.
 - **Compatibilidad SDK completa (solo python)**: `python`.
 - **Targets solo de transpilación**: .
-- **Orígenes de transpilación inversa**: python, javascript, java. Este alcance reverse de entrada está separado de los 3 targets oficiales de salida.
+- **Orígenes de transpilación inversa**: python, javascript, java (java se mantiene como **entrada histórica, no salida oficial**). Este alcance reverse de entrada está separado de los 3 targets oficiales de salida.
 
 Tiers oficiales de soporte de backends:
 
@@ -1042,7 +1042,7 @@ El subcomando `gui` abre el iddle integrado y requiere tener instalado Flet.
 `cobra transpilar-inverso` documenta una capacidad distinta de la transpilación de salida normal. Aquí conviene separar dos listas para evitar ambigüedades:
 
 - **Targets oficiales de salida**: consultar el resumen normativo generado al inicio de este README.
-- **Orígenes reverse de entrada**: `python`, `javascript`, `java`.
+- **Orígenes reverse de entrada**: `python`, `javascript`, `java` (**java** como *entrada histórica, no salida oficial*).
 
 Los nombres `python`, `javascript` y `java` aparecen en ambas listas, pero con papeles distintos: como `--origen` describen **entradas aceptadas** por la ruta reverse; como `--destino` vuelven a significar **targets oficiales de salida ya existentes**. La capacidad reverse no añade targets nuevos ni amplía la lista oficial de salida.
 

--- a/docs/compatibility/internal_only_backend_removal_checklist.md
+++ b/docs/compatibility/internal_only_backend_removal_checklist.md
@@ -12,7 +12,9 @@ Backends en retiro interno: `go`, `cpp`, `java`, `wasm`, `asm`.
 - [ ] Las guías públicas eliminan ejemplos de uso directo `--backend go/cpp/java/wasm/asm`.
 - [ ] Los comandos obsoletos (`dependencias`, `bench*`, `profile`, `transpilar-inverso`, `validar-sintaxis`, `qa-validar`) no aparecen en help/documentación pública.
 - [ ] Se conserva únicamente documentación de migración/compatibilidad para targets internal-only.
+- [ ] `java` en `transpilar-inverso` queda documentado solo como **entrada histórica, no salida oficial**.
 - [ ] Se ejecuta inventario: `python scripts/ci/generate_internal_only_inventory.py` y se revisa `docs/compatibility/internal_only_refs_inventory.md`.
+- [ ] Se mantiene actualizado `docs/compatibility/legacy_assets_inventory.md` con estado por carpeta (`mantener interno` / `deprecado` / `retirar`).
 
 ## Fase 2 — CLI pública
 
@@ -27,6 +29,20 @@ Backends en retiro interno: `go`, `cpp`, `java`, `wasm`, `asm`.
 - [ ] Eliminar entradas legacy del registro interno una vez sin tráfico.
 - [ ] Eliminar flags de compatibilidad (`COBRA_INTERNAL_LEGACY_TARGETS`, `COBRA_LEGACY_TARGETS_MODE`) al cierre.
 - [ ] Ejecutar auditoría final del repositorio y bloquear reintroducciones en CI.
+
+## Orden de ejecución obligatorio (anti-regresión)
+
+1. **Primero** retirar exposición documental y referencias públicas.
+2. **Después** limpiar código muerto interno.
+
+No invertir este orden para evitar romper compatibilidad durante la migración.
+
+## Gating de limpieza física (flag de migración)
+
+La eliminación de código legacy se ejecuta solamente cuando la migración interna está habilitada por feature flag:
+
+- `COBRA_INTERNAL_LEGACY_TARGETS=1`
+- y/o `--legacy-targets` (sesiones internas)
 
 ## Priorización explícita de limpieza de transpilers legacy (al vencer ventana)
 

--- a/docs/compatibility/legacy_assets_inventory.md
+++ b/docs/compatibility/legacy_assets_inventory.md
@@ -1,0 +1,57 @@
+# Inventario de activos legacy por carpeta (internal-only)
+
+Este inventario clasifica activos legacy para orientar la migración en dos etapas:
+
+1. **Retirar primero exposición documental y referencias públicas**.
+2. **Luego limpiar código muerto** únicamente con flag de migración interna activa.
+
+Estado permitido por activo:
+
+- `mantener interno`: se conserva fuera de contrato público mientras exista dependencia interna explícita.
+- `deprecado`: congelado; no se amplía y se prepara retiro.
+- `retirar`: remover al vencer la ventana de compatibilidad y tras validar cero dependencias.
+
+## 1) Transpiladores legacy (`src/pcobra/cobra/transpilers/transpiler/`)
+
+| Activo | Carpeta | Estado | Nota |
+|---|---|---|---|
+| `to_go.py` | `src/pcobra/cobra/transpilers/transpiler/` | deprecado | Mantener solo por compatibilidad interna temporal. |
+| `to_cpp.py` | `src/pcobra/cobra/transpilers/transpiler/` | deprecado | Sin exposición en UX pública; retiro por calendario legacy. |
+| `to_java.py` | `src/pcobra/cobra/transpilers/transpiler/` | deprecado | No backend oficial de salida; congelado para migración interna. |
+| `to_wasm.py` | `src/pcobra/cobra/transpilers/transpiler/` | deprecado | Sin roadmap de promoción pública; mantener aislado. |
+| `to_asm.py` | `src/pcobra/cobra/transpilers/transpiler/` | retirar | Prioridad de retiro temprana al vencer su ventana (`Q3 2026`). |
+
+## 2) Docker de backends no oficiales (`docker/backends/`)
+
+| Activo | Carpeta | Estado | Nota |
+|---|---|---|---|
+| `cpp.Dockerfile` | `docker/backends/` | deprecado | Imagen de soporte interno; no documentar como opción pública. |
+
+> `python.Dockerfile`, `javascript.Dockerfile` y `rust.Dockerfile` no son legacy y quedan fuera de este inventario.
+
+## 3) Ejemplos legacy (`examples/`)
+
+| Activo | Carpeta | Estado | Nota |
+|---|---|---|---|
+| `examples/hello_world/go/` y `go.*` | `examples/hello_world/` | deprecado | Mantener solo en ruta interna/histórica durante migración. |
+| `examples/hello_world/cpp/` y `cpp.*` | `examples/hello_world/` | deprecado | No mostrar en guías públicas de “primeros pasos”. |
+| `examples/hello_world/java/` y `java.*` | `examples/hello_world/` | mantener interno | Útiles para validación de entrada histórica reverse y regresión interna. |
+| `examples/hello_world/wasm/` y `wasm.*` | `examples/hello_world/` | deprecado | Sin soporte público activo; mantener solo pruebas de compatibilidad. |
+| `examples/hello_world/asm/` y `asm.*` | `examples/hello_world/` | retirar | Reducir primero exposición pública y retirar tras ventana contractual. |
+
+## 4) Reverse transpile desde Java (aclaración normativa)
+
+`java` se mantiene **solo** como **entrada histórica** de `transpilar-inverso` cuando exista requisito interno explícito.
+
+- No es backend oficial de salida.
+- No debe aparecer en tablas/listas públicas de targets oficiales.
+- Debe permanecer documentado como: **“entrada histórica, no salida oficial”**.
+
+## 5) Regla operativa de limpieza (flag de migración)
+
+Toda limpieza física de código legacy debe ejecutarse únicamente con el flujo de migración interna habilitado por:
+
+- `COBRA_INTERNAL_LEGACY_TARGETS=1`
+- y/o `--legacy-targets` en sesiones internas donde aplique.
+
+Sin ese flag, la prioridad es **ocultar exposición pública** y preservar compatibilidad temporal interna.

--- a/src/pcobra/cobra/cli/__init__.py
+++ b/src/pcobra/cobra/cli/__init__.py
@@ -7,12 +7,11 @@ de línea de comandos del lenguaje Cobra, incluyendo:
 - Procesamiento de argumentos
 - Gestión de comandos
 - Utilidades de CLI
-- Selección de *backends* canónicos: ``python``, ``rust``, ``javascript``, ``wasm``,
-  ``go``, ``cpp``, ``java`` y ``asm``.
+- Selección de *backends* públicos oficiales: ``python``, ``javascript`` y ``rust``.
 
 Tier de soporte de backends:
-- Tier 1: ``python``, ``rust``, ``javascript``, ``wasm``
-- Tier 2: ``go``, ``cpp``, ``java``, ``asm``
+- Tier 1: ``python``, ``javascript``, ``rust``
+- Tier 2: sin targets públicos (reservado para compatibilidad interna/legacy)
 
 Fuente de verdad: ``src/pcobra/cobra/transpilers/targets.py``.
 


### PR DESCRIPTION
### Motivation
- Alinear la documentación y la superficie visible de la CLI con la política actual que limita los backends públicos oficiales a `python`, `javascript` y `rust`.
- Proveer un inventario operativo de activos legacy por carpeta para orientar la migración y evitar borrados accidentales.
- Forzar un orden de retirada que retire primero la exposición documental pública y solo luego proceda a la limpieza de código muerto bajo flag de migración interna.
- Aclarar el estado del flujo reverse desde `java` como entrada histórica y no como backend de salida oficial.

### Description
- Actualiza el encabezado informativo de `src/pcobra/cobra/cli/__init__.py` para reflejar únicamente los backends públicos oficiales y los tiers vigentes (`Tier 1: python, javascript, rust`; `Tier 2: sin targets públicos`).
- Añade `docs/compatibility/legacy_assets_inventory.md` con inventario por carpeta de activos legacy (transpiladores `to_go.py`, `to_cpp.py`, `to_java.py`, `to_wasm.py`, `to_asm.py`, Docker legacy, ejemplos) y su estado (`mantener interno` / `deprecado` / `retirar`).
- Refuerza `docs/compatibility/internal_only_backend_removal_checklist.md` para exigir el orden operativo obligatorio (primero ocultar documentación pública, después limpieza física) y para requerir gating por `COBRA_INTERNAL_LEGACY_TARGETS=1` y/o `--legacy-targets` antes de borrar código.
- Actualiza `README.md` para explicitar que los orígenes de `transpilar-inverso` incluyen `java` pero que `java` es «entrada histórica, no salida oficial». No se realizan cambios funcionales en los transpiladores ni en la lógica de runtime en este PR.

### Testing
- Se compiló el módulo modificado con `python -m py_compile src/pcobra/cobra/cli/__init__.py` y la compilación fue satisfactoria.
- Se inspeccionó el diff de los archivos modificados con revisión local de contenidos (`README.md`, `docs/compatibility/internal_only_backend_removal_checklist.md`, `docs/compatibility/legacy_assets_inventory.md`, `src/pcobra/cobra/cli/__init__.py`) y no se detectaron cambios de comportamiento en runtime.
- Se verificó el estado del árbol de trabajo y la presencia de los ficheros añadidos/modificados para asegurar trazabilidad de los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e382ed24808327a1118be5572014e5)