### PR TITLE
docs: reforzar contrato unificado en README y docs/architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Versión 10.0.13
 
 ## Cobra como interfaz única
 
-Cobra consolida su experiencia de uso en una **única interfaz pública**: la CLI `cobra`. Todas las tareas de ejecución, build, pruebas y módulos se coordinan desde este frente común, mientras la orquestación interna y los adaptadores de backend permanecen encapsulados.
+Cobra consolida su experiencia de uso en una **única interfaz pública**: la CLI `cobra`. Todas las tareas de ejecución, build, pruebas y módulos se coordinan desde este frente común.
 
-Ejemplos públicos mínimos:
+### Comandos oficiales (visibles y estables)
 
 ```bash
 cobra run archivo.cobra
@@ -30,9 +30,35 @@ cobra test archivo.cobra
 cobra mod list
 ```
 
-La superficie pública oficial mantiene tres backends: **Python**, **JavaScript** y **Rust**.
+> Contrato público: el lenguaje visible es **Cobra** y los comandos oficiales son `run`, `build`, `test` y `mod`.
 
-pCobra es un lenguaje de programación escrito en español y pensado para la creación de herramientas, simulaciones y análisis en disciplinas como biología, computación y astrofísica. El proyecto integra un lexer, parser y un sistema de transpilación con una lista canónica de destinos de salida derivada automáticamente de `src/pcobra/cobra/config/transpile_targets.py` + `src/pcobra/cobra/transpilers/registry.py`.
+### Contrato de backends internos oficiales
+
+La superficie oficial mantiene exactamente **3 backends internos**:
+
+- `python`
+- `javascript`
+- `rust`
+
+La selección de backend la realiza internamente el pipeline y **no** es un parámetro de configuración para usuario final.
+
+### Qué es interno y no público
+
+No forman parte del contrato público:
+
+- Transpiladores legacy (`go`, `cpp`, `java`, `wasm`, `asm`).
+- Compat shims y rutas de compatibilidad histórica.
+- Comandos y flujos de CLI v1 fuera del set `run/build/test/mod`.
+
+### Tabla de decisión de backend interno (no configurable por usuario final)
+
+| Contexto técnico detectado por el pipeline | Backend interno preferente | Override permitido |
+|---|---|---|
+| Ejecución estándar y paridad máxima de librerías | `python` | Solo hints internos controlados por Core |
+| Integración runtime web/bridge JS | `javascript` | Solo hints internos controlados por Core |
+| Integración nativa/FFI y ABI contractual | `rust` | Solo hints internos controlados por Core |
+
+pCobra es un lenguaje de programación escrito en español y pensado para la creación de herramientas, simulaciones y análisis en disciplinas como biología, computación y astrofísica.
 
 Resumen normativo visible (generado desde la política canónica):
 

--- a/docs/architecture/adr-unified-3-backends.md
+++ b/docs/architecture/adr-unified-3-backends.md
@@ -1,5 +1,11 @@
 # ADR: Cobra unifica la superficie pública en 3 backends
 
+## Contrato unificado (aplica a toda esta ADR)
+
+- Cobra es el **único lenguaje/interfaz pública**.
+- Solo existen **3 backends internos oficiales**: `python`, `javascript`, `rust`.
+- La decisión de backend es **interna** (no configurable por usuario final), salvo hints internos controlados.
+
 - **Estado:** Aprobado
 - **Fecha:** 2026-04-16
 - **Decisores:** Equipo Core de pCobra

--- a/docs/architecture/adr-unified-backends.md
+++ b/docs/architecture/adr-unified-backends.md
@@ -1,5 +1,11 @@
 # ADR: Backends unificados y contrato externo estable
 
+## Contrato unificado (aplica a toda esta ADR)
+
+- Cobra es el **único lenguaje/interfaz pública**.
+- Solo existen **3 backends internos oficiales**: `python`, `javascript`, `rust`.
+- La decisión de backend es **interna** (no configurable por usuario final), salvo hints internos controlados.
+
 - **Estado:** Aprobado
 - **Fecha:** 2026-04-15
 - **Decisores:** Equipo Core de pCobra

--- a/docs/architecture/backend-pipeline-checklist.md
+++ b/docs/architecture/backend-pipeline-checklist.md
@@ -1,5 +1,11 @@
 # Checklist arquitectónica: Backend Pipeline
 
+## Contrato unificado (aplica a toda esta checklist)
+
+- Cobra es el **único lenguaje/interfaz pública**.
+- Solo existen **3 backends internos oficiales**: `python`, `javascript`, `rust`.
+- La decisión de backend es **interna** (no configurable por usuario final), salvo hints internos controlados.
+
 Usar esta checklist antes de mergear nuevas features que afecten compile/transpile/runtime.
 
 ## Flujo oficial (obligatorio)

--- a/docs/architecture/binding-contract.md
+++ b/docs/architecture/binding-contract.md
@@ -1,5 +1,11 @@
 # Contrato de bindings Cobra (Python / JavaScript / Rust)
 
+## Contrato unificado (aplica a toda esta guía)
+
+- Cobra es el **único lenguaje/interfaz pública**.
+- Solo existen **3 backends internos oficiales**: `python`, `javascript`, `rust`.
+- La decisión de backend es **interna** (no configurable por usuario final), salvo hints internos controlados.
+
 - **Estado:** Aprobado
 - **Fecha:** 2026-04-14
 - **Alcance:** CLI runners (`execute_cmd`) y futuros runners/runtime bridges

--- a/docs/architecture/cobra_unified_architecture_execution_plan.md
+++ b/docs/architecture/cobra_unified_architecture_execution_plan.md
@@ -1,5 +1,11 @@
 # Cobra unificado: diseño objetivo y refactor parcial seguro (A–I)
 
+## Contrato unificado (aplica a todo el plan)
+
+- Cobra es el **único lenguaje/interfaz pública**.
+- Solo existen **3 backends internos oficiales**: `python`, `javascript`, `rust`.
+- La decisión de backend es **interna** (no configurable por usuario final), salvo hints internos controlados.
+
 Este plan aterriza la transición de Cobra como **lenguaje único visible** con tres backends oficiales internos: `python`, `javascript`, `rust`, manteniendo intactos lexer/parser/AST/transpiladores existentes.
 
 ---

--- a/docs/architecture/cobra_unified_refactor_plan.md
+++ b/docs/architecture/cobra_unified_refactor_plan.md
@@ -1,5 +1,11 @@
 # Plan de arquitectura y refactor parcial seguro: Cobra Ecosystem Unified
 
+## Contrato unificado (aplica a todo el plan)
+
+- Cobra es el **único lenguaje/interfaz pública**.
+- Solo existen **3 backends internos oficiales**: `python`, `javascript`, `rust`.
+- La decisión de backend es **interna** (no configurable por usuario final), salvo hints internos controlados.
+
 Este documento define una estrategia **incremental** para consolidar Cobra como único lenguaje visible para usuario final, con tres backends oficiales internos: `python`, `javascript` y `rust`.
 
 > Restricciones aplicadas en este plan: no tocar lexer, parser, AST ni transpilers existentes.

--- a/docs/architecture/import-resolution-contract.md
+++ b/docs/architecture/import-resolution-contract.md
@@ -1,5 +1,11 @@
 # Contrato oficial de resolución de imports (`CobraImportResolver`)
 
+## Contrato unificado (aplica a toda esta guía)
+
+- Cobra es el **único lenguaje/interfaz pública**.
+- Solo existen **3 backends internos oficiales**: `python`, `javascript`, `rust`.
+- La decisión de backend es **interna** (no configurable por usuario final), salvo hints internos controlados.
+
 Este documento define el contrato **oficial** y estable del resolvedor de imports de Cobra para eliminar ambigüedades operativas entre stdlib, módulos de proyecto, bridge Python e híbridos.
 
 ## 1) Orden oficial de resolución (API contractual)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,5 +1,11 @@
 # Architecture Overview
 
+## Contrato unificado (aplica a toda esta sección)
+
+- Cobra es el **único lenguaje/interfaz pública**.
+- Solo existen **3 backends internos oficiales**: `python`, `javascript`, `rust`.
+- La decisión de backend es **interna** (no configurable por usuario final), salvo hints internos controlados.
+
 Este resumen documenta **cómo funciona internamente** la CLI unificada sin ampliar la superficie pública (`cobra run`, `cobra build`, `cobra test`, `cobra mod`).
 
 ## Flujo oficial inmutable
@@ -19,6 +25,16 @@ BackendPipeline
       ↓
 Bindings (python/js/rust)
 ```
+
+## Tabla de decisión de backend interno
+
+> Esta tabla es de contrato interno. No expone configuración al usuario final.
+
+| Señal técnica evaluada por el pipeline | Backend interno resultante | Ajuste permitido |
+|---|---|---|
+| Flujo estándar con prioridad de paridad de librerías | `python` | Hints internos controlados |
+| Integración orientada a bridge/runtime web | `javascript` | Hints internos controlados |
+| Requisito nativo/FFI con ABI contractual | `rust` | Hints internos controlados |
 
 ## 1) Frontend Cobra
 

--- a/docs/architecture/unified-ecosystem.md
+++ b/docs/architecture/unified-ecosystem.md
@@ -1,5 +1,11 @@
 # Índice del ecosistema unificado de Cobra
 
+## Contrato unificado (aplica a toda esta guía)
+
+- Cobra es el **único lenguaje/interfaz pública**.
+- Solo existen **3 backends internos oficiales**: `python`, `javascript`, `rust`.
+- La decisión de backend es **interna** (no configurable por usuario final), salvo hints internos controlados.
+
 Este documento define el **índice contractual** para evitar ambigüedad sobre qué módulos son fuente canónica y cuáles existen únicamente por compatibilidad.
 
 ## 1) Fuente canónica contractual única


### PR DESCRIPTION
### Motivation
- Aclarar y garantizar que la interfaz pública se limite a la CLI `cobra` con comandos estables y sin exponer la selección de transpilers. 
- Unificar el mensaje arquitectónico en `docs/architecture/*` para que todas las páginas repitan el mismo contrato: un lenguaje visible (Cobra) y tres backends internos oficiales. 
- Señalar explícitamente qué componentes son internos/no públicos (transpiladores legacy, compat shims, comandos v1) para evitar su aparición en documentación de usuario. 
- Proveer una guía operativa básica sobre cómo el pipeline decide internamente el backend sin dejar esa opción a usuarios finales. 

### Description
- Actualicé `README.md` para mostrar una sección corta y visible con los comandos oficiales `cobra run`, `cobra build`, `cobra test` y `cobra mod` y añadí el bloque de contrato de backends internos, la sección "qué es interno y no público" y la tabla de decisión de backend interno. 
- Inserté el mismo bloque de "Contrato unificado" en las páginas bajo `docs/architecture/` (`adr-unified-3-backends.md`, `adr-unified-backends.md`, `backend-pipeline-checklist.md`, `binding-contract.md`, `cobra_unified_architecture_execution_plan.md`, `cobra_unified_refactor_plan.md`, `import-resolution-contract.md`, `overview.md`, `unified-ecosystem.md`) para homogeneizar el mensaje. 
- Añadí una tabla de decisión de backend interno en `docs/architecture/overview.md` que describe las señales técnicas y el backend preferente, y dejé claro que los overrides solo se permiten vía hints internos controlados por Core. 
- Todos los cambios son documentales; no se modificó código ejecutable ni lógica de runtime. 

### Testing
- Ejecuté `git diff --check` para validar que no hay errores de formato en el diff y la comprobación pasó correctamente. 
- Verifiqué el estado del árbol con `git status --short` para confirmar que los cambios quedaron comprometidos y no hay archivos pendientes. 
- Realicé un commit con el mensaje `docs: unificar contrato público e interno en README y arquitectura` y creé la PR titulada `docs: reforzar contrato unificado en README y docs/architecture` como paso final de la validación documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38470964483278c7e73eb98513db9)