### PR TITLE
docs: alinear guías con interfaz pública canónica de Cobra

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -301,9 +301,10 @@ Cobra incluye módulos de soporte para flujos asíncronos y coordinación.
 Flujo mínimo sugerido:
 
 ```bash
-cobra validar-sintaxis src/app.cobra
-cobra ejecutar src/app.cobra
-cobra compilar src/app.cobra --tipo python
+cobra run src/app.cobra
+cobra build src/app.cobra
+cobra test src/app.cobra
+cobra mod list
 ```
 
 Comandos útiles adicionales (según el setup del proyecto):
@@ -312,6 +313,12 @@ Comandos útiles adicionales (según el setup del proyecto):
 - `cobra plugins`
 - `cobra docs`
 - `cobra profile`
+
+### Comandos legacy y migración
+
+Si vienes de comandos legacy como `cobra validar-sintaxis`, `cobra ejecutar` o
+`cobra compilar`, migra al contrato público `run/build/test/mod` y revisa la
+guía de transición en [`docs/migracion_cli_unificada.md`](migracion_cli_unificada.md).
 
 ---
 
@@ -457,7 +464,7 @@ Checklist rápido:
 
 ## 18) Apéndice: checklist de publicación de un proyecto Cobra
 
-- [ ] `cobra validar-sintaxis` en todo `src/`.
+- [ ] `cobra run` sobre smoke tests de `src/`.
 - [ ] tests pasando en CI.
 - [ ] documentación de uso actualizada.
 - [ ] ejemplos ejecutables y verificados.

--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -255,9 +255,11 @@ imprimir(saludo)
 ## 7. Paquetes Cobra
 
 - Agrupa varios módulos en un archivo con manifest ``cobra.pkg``.
-- Crea un paquete con ``cobra paquete crear carpeta paquete.cobra``.
-- Instálalo posteriormente con ``cobra paquete instalar paquete.cobra``.
+- Legacy: ``cobra paquete crear carpeta paquete.cobra``.
+- Legacy: ``cobra paquete instalar paquete.cobra``.
 - Los archivos ``.cobra`` corresponden a paquetes completos, mientras que los scripts usan la extensión ``.co``.
+
+> Nota: los comandos `cobra paquete ...` se conservan como compatibilidad histórica y no forman parte de la interfaz pública canónica `run/build/test/mod`.
 
 ## 8. Macros
 
@@ -455,6 +457,13 @@ Los orígenes reverse se mantienen en una categoría separada: describen lenguaj
 
 - Construye artefactos con `cobra build archivo.co`.
 - Ejecuta directamente con `cobra run archivo.co`.
+
+### Comandos legacy y migración
+
+Si encuentras documentación antigua con `cobra ejecutar`, `cobra compilar`,
+`cobra validar-sintaxis` o `cobra paquete ...`, trátalos como comandos legacy.
+Para el flujo público actual usa `cobra run`, `cobra build`, `cobra test` y
+`cobra mod`, y consulta [`docs/migracion_cli_unificada.md`](migracion_cli_unificada.md).
 
 ### Ejemplo de transpilación a Python
 

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -67,8 +67,8 @@ Módulos y paquetes
 ------------------
 
 Los módulos se importan con ``import``. Para agrupar varios módulos puede
-crearse un archivo ``cobra.pkg`` y usar ``cobra paquete crear`` para
-empaquetarlos.
+crearse un archivo ``cobra.pkg``. El flujo ``cobra paquete crear`` se conserva
+como comando legacy para empaquetados históricos.
 
 Macros y concurrencia
 ---------------------
@@ -436,8 +436,8 @@ con el mismo signo que el divisor incluso si se usan valores negativos.
 Transpilación y ejecución
 -------------------------
 
-El comando ``cobra compilar`` genera código para múltiples lenguajes. También
-puede ejecutarse un archivo directamente con ``cobra ejecutar``.
+La interfaz pública canónica usa ``cobra build`` para generar artefactos y
+``cobra run`` para ejecutar archivos Cobra.
 El subcomando ``cobra verificar`` (``cobra verify`` en la versión en inglés)
 permite comparar la salida de un programa transpilado a distintos lenguajes
 (actualmente Python y JavaScript) y avisa si alguna difiere.
@@ -445,6 +445,14 @@ Adicionalmente puedes convertir código escrito en otros lenguajes a Cobra y
 volver a transpilarlos con ``cobra transpilar-inverso``::
 
    cobra transpilar-inverso ejemplo.py --origen=python --destino=javascript
+
+Comandos legacy y migración
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Si encuentras referencias a ``cobra compilar``, ``cobra ejecutar`` o
+``cobra validar-sintaxis``, trátalas como rutas legacy. Para migrar al flujo
+estable ``run/build/test/mod`` revisa
+``docs/migracion_cli_unificada.md``.
 
 Caché incremental con SQLitePlus
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -40,6 +40,13 @@ cobra build archivo.co
 
 > Si migras desde `cobra archivo.co`, `cobra compilar` o flags de backend legacy, revisa [docs/migracion_cli_unificada.md](migracion_cli_unificada.md).
 
+### Comandos legacy y migración
+
+Los comandos `cobra ejecutar`, `cobra compilar` y `cobra validar-sintaxis`
+deben considerarse legacy. Para la interfaz pública usa `cobra run`,
+`cobra build`, `cobra test` y `cobra mod`. Guía completa:
+[`docs/migracion_cli_unificada.md`](migracion_cli_unificada.md).
+
 ### Ejecución en GitHub Codespaces
 
 1. En la página del repositorio en GitHub pulsa **Code** y luego la pestaña **Codespaces**.
@@ -51,7 +58,7 @@ cobra build archivo.co
 
 1. Abre [Replit](https://replit.com/) e importa este repositorio desde GitHub.
 2. Al cargarse el entorno, se instalarán las dependencias indicadas en `requirements.txt` gracias al archivo `replit.nix`.
-3. El archivo `.replit` ya define el comando de ejecución `python -m cobra examples/replit/main.cobra`.
+3. El archivo `.replit` puede usar todavía el shim legacy `python -m cobra examples/replit/main.cobra`; para documentación pública prioriza `cobra run examples/replit/main.cobra`.
 4. Presiona **Run** para ejecutar el ejemplo inicial ubicado en `examples/replit/main.cobra`.
 
 ### Ejecución en Binder


### PR DESCRIPTION
### Motivation

- Unificar la documentación pública para exponer solo la interfaz canónica de CLI `cobra` con los subcomandos `run`, `build`, `test` y `mod`. 
- Señalar y preservar explícitamente comandos históricos/legacy para evitar confusión y orientar la migración a la CLI unificada.

### Description

- Actualiza snippets en `docs/LIBRO_PROGRAMACION_COBRA.md` para usar `cobra run`, `cobra build`, `cobra test` y `cobra mod list` en el flujo mínimo sugerido. 
- Añade la sección corta "Comandos legacy y migración" en `docs/LIBRO_PROGRAMACION_COBRA.md`, `docs/MANUAL_COBRA.md`, `docs/MANUAL_COBRA.rst` y `docs/guia_basica.md` que apunta a `docs/migracion_cli_unificada.md`. 
- Marca ejemplos concretos de comandos no canónicos como legacy (por ejemplo `cobra compilar`, `cobra ejecutar`, `cobra validar-sintaxis`, `cobra paquete ...`) y deja el shim `python -m cobra ...` en Replit claramente etiquetado como legado. 
- Ajusta un checklist y referencias menores para reemplazar `cobra validar-sintaxis` por el flujo público (`cobra run` sobre smoke tests). 

### Testing

- Se ejecutó una búsqueda de regresión en `docs/` por las cadenas `validar-sintaxis`, `ejecutar` y `compilar` y las ocurrencias relevantes en los documentos objetivo quedaron marcadas o reemplazadas conforme a la convención; la búsqueda devolvió resultados esperados. 
- Se verificó específicamente con búsquedas focalizadas que las cuatro páginas modificadas (`docs/LIBRO_PROGRAMACION_COBRA.md`, `docs/MANUAL_COBRA.md`, `docs/MANUAL_COBRA.rst`, `docs/guia_basica.md`) contienen la nueva sección de migración y no promueven los comandos legacy como la interfaz pública; las comprobaciones automatizadas de texto tuvieron éxito. 
- No se ejecutaron tests unitarios del código fuente en esta PR porque los cambios son puramente documentales.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3b738b0e083278fa99810a49d4048)