### PR TITLE
docs(ci): unificar versión pública en la documentación

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,6 +33,8 @@ jobs:
           extra: "sphinx sphinx-rtd-theme"
       - name: Install LaTeX packages
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive-latex-recommended texlive-latex-extra latexmk
+      - name: Validate public docs version consistency
+        run: python scripts/ci/validate_public_docs_version.py
       - name: Build docs
         run: sphinx-build -b html docs/frontend docs/build/html
       - name: Build root docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,14 @@ Fixtures de regresión para `validar-sintaxis`:
 
 ## Dependencias y versionado
 
+- Usa `pyproject.toml` (`[project].version`) como **única fuente visible de
+  versión** para documentación pública.
+- Cada vez que cambie la versión, sincroniza cabeceras y tablas públicas en:
+  `docs/MANUAL_COBRA.md`, `docs/MANUAL_COBRA.rst`, `docs/README.en.md` y
+  `docs/guia_basica.md`.
+- Antes de abrir PR ejecuta `python scripts/ci/validate_public_docs_version.py`.
+  Esta validación falla si detecta versiones públicas múltiples o distintas de
+  `pyproject.toml`.
 - Mantén sincronizadas las versiones fijadas en `pyproject.toml`,
   `requirements.txt` y `requirements-dev.txt`. Cuando se actualice una
   dependencia, revisa los tres archivos y aplica el mismo número de versión.

--- a/docs/MANUAL_COBRA.md
+++ b/docs/MANUAL_COBRA.md
@@ -1,13 +1,13 @@
 # Manual del Lenguaje Cobra
 
-Versión 10.0.12
+Versión 10.0.13
 
 Este manual presenta en español los conceptos básicos para programar en Cobra. Se organiza en tareas que puedes seguir paso a paso.
 
 ## 1. Preparación del entorno
 
 1. Clona el repositorio y entra en el directorio `pCobra`.
-2. Crea y activa un entorno virtual de **Python 3.9 o superior**.
+2. Crea y activa un entorno virtual de **Python 3.10 o superior**.
 3. Instala las dependencias con `./scripts/install_dev.sh`.
    Este script instala tanto las dependencias de ejecución como las de desarrollo.
    Aseg\u00farate tambi\u00e9n de tener disponible la herramienta `cbindgen`:
@@ -20,7 +20,7 @@ Este manual presenta en español los conceptos básicos para programar en Cobra.
 
 ### Instalación con pipx
 
-Puedes instalar Cobra utilizando [pipx](https://pypa.github.io/pipx/), una herramienta que permite ejecutar aplicaciones de Python aisladas y requiere Python 3.9 o superior.
+Puedes instalar Cobra utilizando [pipx](https://pypa.github.io/pipx/), una herramienta que permite ejecutar aplicaciones de Python aisladas y requiere Python 3.10 o superior.
 
 ```bash
 pipx install pcobra

--- a/docs/MANUAL_COBRA.rst
+++ b/docs/MANUAL_COBRA.rst
@@ -1,7 +1,7 @@
 Manual de Cobra
 ===============
 
-Versión 10.0.12
+Versión 10.0.13
 
 Este documento resume la sintaxis y los elementos fundamentales del lenguaje
 Cobra. Incluye ejemplos de uso idiomático, limitaciones de los backends y
@@ -14,12 +14,10 @@ Preparación del entorno
 ----------------------
 
 1. Clona el repositorio y entra en ``pCobra``.
-2. Crea y activa un entorno virtual de **Python 3.9 o superior**.
-3. Instala las dependencias con ``pip install -r requirements-dev.txt``.
+2. Crea y activa un entorno virtual de **Python 3.10 o superior**.
+3. Instala dependencias de ejecución y desarrollo con
+   ``./scripts/install_dev.sh``.
 4. Instala Cobra en modo editable con ``pip install -e .``.
-
-   También puedes ejecutar ``pip install -e .[dev]`` para incluir los extras de
-   desarrollo.
 
 Sintaxis básica
 ---------------

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -4,7 +4,7 @@
 [![Tier 2 Nightly](https://github.com/Alphonsus411/pCobra/actions/workflows/test.yml/badge.svg?event=schedule)](https://github.com/Alphonsus411/pCobra/actions/workflows/test.yml)
 [![Stable release](https://img.shields.io/github/v/release/Alphonsus411/pCobra?label=stable)](https://github.com/Alphonsus411/pCobra/releases/latest)
 
-Version 10.0.12
+Version 10.0.13
 
 - The incremental AST/token cache now lives in **SQLitePlus**, with `SQLITE_DB_KEY`/`COBRA_DB_PATH` to define the encrypted database and a helper script to migrate previous JSON entries.
 - `corelibs.asincrono` ships `grupo_tareas` and `reintentar_async`, re-exported by the standard library to coordinate coroutines with structured concurrency and retries featuring exponential backoff and jitter.
@@ -162,7 +162,7 @@ If you prefer to automate the process, run:
 ./scripts/install.sh --dev      # install in editable mode
 ```
 
-3. Create a virtual environment and activate it:
+3. Create a virtual environment and activate it (Python 3.10 or higher):
 
 ```bash
 python -m venv .venv
@@ -183,8 +183,6 @@ source .venv/bin/activate  # Unix
 ```bash
 pip install -e .
 ```
-
-Optionally, you may run ``pip install -e .[dev]`` to include the development extras.
 
 6. Copy ``.env.example`` to ``.env`` and customize the paths or keys if necessary. These variables will be loaded automatically thanks to ``python-dotenv``:
 
@@ -219,7 +217,7 @@ PYTHONPATH=$PWD/src python -c "from src.core.main import main; main()"
 
 ### Installation with pipx
 
-[pipx](https://pypa.github.io/pipx/) is a tool to install and run Python applications in isolation and requires Python 3.9 or higher. To install Cobra with pipx run:
+[pipx](https://pypa.github.io/pipx/) is a tool to install and run Python applications in isolation and requires Python 3.10 or higher. To install Cobra with pipx run:
 
 ```bash
 pipx install pcobra
@@ -247,9 +245,9 @@ Precompiled executables for Cobra are published in the repository's [Releases](h
 
 | Version | Platform | Link |
 | --- | --- | --- |
-| 10.0.12 | Linux x86_64 | [cobra-linux](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.12/cobra-linux) |
-| 10.0.12 | Windows x86_64 | [cobra.exe](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.12/cobra.exe) |
-| 10.0.12 | macOS arm64 | [cobra-macos](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.12/cobra-macos) |
+| 10.0.13 | Linux x86_64 | [cobra-linux](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.13/cobra-linux) |
+| 10.0.13 | Windows x86_64 | [cobra.exe](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.13/cobra.exe) |
+| 10.0.13 | macOS arm64 | [cobra-macos](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.13/cobra-macos) |
 
 To verify the integrity of the downloaded file, compute its SHA256 hash and compare it with the published value:
 

--- a/docs/guia_basica.md
+++ b/docs/guia_basica.md
@@ -2,15 +2,28 @@
 
 Este documento presenta un recorrido introductorio por el lenguaje Cobra con veinte ejemplos sencillos.
 
+## Prerrequisitos e instalación recomendada
+
+- Python **3.10 o superior**.
+- Entorno virtual activo.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Unix
+# .\.venv\Scripts\activate  # Windows PowerShell
+./scripts/install_dev.sh
+pip install -e .
+```
+
 ## Descargas
 
 Puedes obtener binarios precompilados desde la sección de [Releases](https://github.com/Alphonsus411/pCobra/releases).
 
 | Versión | Plataforma | Enlace |
 | --- | --- | --- |
-| 10.0.12 | Linux x86_64 | [cobra-linux](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.12/cobra-linux) |
-| 10.0.12 | Windows x86_64 | [cobra.exe](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.12/cobra.exe) |
-| 10.0.12 | macOS arm64 | [cobra-macos](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.12/cobra-macos) |
+| 10.0.13 | Linux x86_64 | [cobra-linux](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.13/cobra-linux) |
+| 10.0.13 | Windows x86_64 | [cobra.exe](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.13/cobra.exe) |
+| 10.0.13 | macOS arm64 | [cobra-macos](https://github.com/Alphonsus411/pCobra/releases/download/v10.0.13/cobra-macos) |
 
 Para verificar la integridad del archivo descargado calcula su hash SHA256 y compáralo con el valor publicado:
 

--- a/scripts/ci/validate_public_docs_version.py
+++ b/scripts/ci/validate_public_docs_version.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Valida que la versión pública en documentación esté unificada."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
+ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = ROOT / "pyproject.toml"
+PUBLIC_DOCS = (
+    ROOT / "docs/MANUAL_COBRA.md",
+    ROOT / "docs/MANUAL_COBRA.rst",
+    ROOT / "docs/README.en.md",
+    ROOT / "docs/guia_basica.md",
+)
+SEMVER_RE = re.compile(r"\b(\d+\.\d+\.\d+)\b")
+
+
+def project_version() -> str:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    version = data.get("project", {}).get("version")
+    if not isinstance(version, str) or not SEMVER_RE.fullmatch(version):
+        raise ValueError("[project].version inválida en pyproject.toml")
+    return version
+
+
+def extract_doc_versions(path: Path) -> set[str]:
+    content = path.read_text(encoding="utf-8")
+    versions: set[str] = set()
+
+    for match in re.finditer(r"(?mi)^\s*(?:versión|version)\s+(\d+\.\d+\.\d+)\s*$", content):
+        versions.add(match.group(1))
+    for match in re.finditer(r"releases/download/v(\d+\.\d+\.\d+)/", content):
+        versions.add(match.group(1))
+
+    return versions
+
+
+def main() -> int:
+    canonical = project_version()
+    all_versions: set[str] = set()
+    mismatches: list[tuple[Path, set[str]]] = []
+
+    for doc in PUBLIC_DOCS:
+        versions = extract_doc_versions(doc)
+        if not versions:
+            print(f"ERROR: no se encontró versión pública en {doc.relative_to(ROOT)}.", file=sys.stderr)
+            return 1
+        if versions != {canonical}:
+            mismatches.append((doc, versions))
+        all_versions.update(versions)
+
+    if len(all_versions) > 1 or mismatches:
+        print(
+            "ERROR: se detectaron versiones públicas inconsistentes. "
+            f"Versión canónica (pyproject.toml): {canonical}.",
+            file=sys.stderr,
+        )
+        for doc, versions in mismatches:
+            printable = ", ".join(sorted(versions))
+            print(f" - {doc.relative_to(ROOT)} => {printable}", file=sys.stderr)
+        return 1
+
+    print(f"OK: documentación pública unificada en versión {canonical}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Establecer una única fuente visible de versión para la documentación pública usando `pyproject.toml` (`[project].version`).
- Evitar discrepancias manuales entre cabeceras públicas y la versión canónica al publicar releases.
- Unificar prerrequisitos y comandos de instalación en la documentación para evitar mensajes contradictorios sobre Python y flujo de instalación.
- Añadir una verificación automática en el pipeline documental que falle si hay versiones públicas incoherentes.

### Description

- Alineé las cabeceras y referencias públicas a la versión `10.0.13` en `docs/MANUAL_COBRA.md`, `docs/MANUAL_COBRA.rst`, `docs/README.en.md` y `docs/guia_basica.md`.
- Unifiqué los prerrequisitos y comandos de instalación en la documentación pública a Python `3.10+`, `./scripts/install_dev.sh` y `pip install -e .` en los documentos relevantes.
- Añadí `scripts/ci/validate_public_docs_version.py`, un script que comprueba que las versiones visibles en los documentos públicos coincidan con `pyproject.toml` y falla si detecta inconsistencia.
- Integré la validación en el workflow de documentación (`.github/workflows/pages.yml`) y documenté la política en `CONTRIBUTING.md` instruyendo a ejecutar `python scripts/ci/validate_public_docs_version.py` antes de abrir PRs.

### Testing

- Ejecuté `python scripts/ci/validate_public_docs_version.py` localmente y el chequeo devolvió `OK` (documentación pública unificada en la versión del proyecto).
- Compilé el script con `python -m compileall scripts/ci/validate_public_docs_version.py` para verificar que no haya errores de sintaxis; la compilación fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3bb71d58c8327bcfb240cff7d12db)