### PR TITLE
docs: archivar guías frontend legacy y alinear CLI/targets oficiales

### DIFF
--- a/docs/frontend/index.rst
+++ b/docs/frontend/index.rst
@@ -20,7 +20,6 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    backends
    ../../docs/lenguajes_soportados
    ../../docs/lenguajes
-   sintaxis
    avances
    proximos_pasos
    optimizaciones
@@ -45,7 +44,6 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    cobra_lock
    cache
    instalacion_pypi
-   primeros_pasos
    como_contribuir
    ../../CONTRIBUTING
    entorno_desarrollo
@@ -58,7 +56,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
 Introducción
 --------------------
 
-Cobra fue creado con la idea de facilitar la programación en español y añadir soporte para trabajar con datos complejos como los holobits. En su documentación pública, la salida oficial del proyecto se resume en una sola narrativa: pCobra transpila a 8 backends oficiales agrupados por tiers, con una política separada de runtime, Holobit y SDK.
+Cobra fue creado con la idea de facilitar la programación en español y añadir soporte para trabajar con datos complejos como los holobits. En su documentación pública, la salida oficial del proyecto se resume en una sola narrativa: pCobra transpila a 3 targets oficiales (python, javascript y rust), con una política separada de runtime, Holobit y SDK.
 
 .. include:: ../_generated/target_policy_summary.rst
 
@@ -68,3 +66,14 @@ Repositorio de Ejemplos
 ----------------------
 
 Los proyectos de demostración se encuentran en `cobra-ejemplos <https://github.com/Alphonsus411/pCobra/tree/work/examples>`_.
+
+
+Contenido histórico
+-------------------
+
+Las guías ``primeros_pasos`` y ``sintaxis`` de esta sección se movieron a ``docs/historico/`` como material de referencia histórica/no operativa:
+
+- :doc:`../../docs/historico/primeros_pasos`
+- :doc:`../../docs/historico/sintaxis`
+
+Para el camino principal de aprendizaje usa el Libro y el Manual canónico enlazados en el README del repositorio.

--- a/docs/frontend/primeros_pasos.rst
+++ b/docs/frontend/primeros_pasos.rst
@@ -1,53 +1,14 @@
 Primeros pasos con Cobra
 =======================
 
-Esta breve guía explica cómo instalar el proyecto y ejecutar un programa sencillo.
+.. warning::
 
-Instalación
------------
+   Esta página se movió a ``docs/historico/primeros_pasos.rst`` y se considera
+   contenido histórico/no operativo.
 
-1. Clona el repositorio y entra al directorio:
+   Consulta la ruta canónica vigente:
 
-.. code-block:: bash
+   - `Libro de Programación Cobra <../../docs/LIBRO_PROGRAMACION_COBRA.md>`_
+   - `Manual de Cobra <../../docs/MANUAL_COBRA.md>`_
 
-   git clone https://github.com/Alphonsus411/pCobra.git
-   cd pCobra
-
-2. Crea un entorno virtual y actívalo:
-
-.. code-block:: bash
-
-   python -m venv .venv
-   source .venv/bin/activate  # Linux o macOS
-   .\\.venv\\Scripts\\activate  # Windows
-
-3. Instala las dependencias y la CLI:
-
-.. code-block:: bash
-
-   pip install -r requirements-dev.txt
-   pip install -e .
-
-   # También puedes usar ``pip install -e .[dev]`` para instalar los extras de desarrollo
-
-Uso básico
-----------
-
-Puedes ejecutar archivos ``.co`` directamente con la CLI.
-Por ejemplo, si tienes ``hola.co``:
-
-.. code-block:: cobra
-
-   imprimir("Hola, Cobra")
-
-Lo ejecutas con:
-
-.. code-block:: bash
-
-   cobra ejecutar hola.co
-
-Para generar la documentación en HTML usa:
-
-.. code-block:: bash
-
-   make html
+Referencia histórica: :doc:`../../docs/historico/primeros_pasos`

--- a/docs/frontend/sintaxis.rst
+++ b/docs/frontend/sintaxis.rst
@@ -1,120 +1,14 @@
 Sintaxis de Cobra
 =================
 
-***1. Declaracion de variables***
+.. warning::
 
-Para declarar variables en Cobra, usamos `var`:
+   Esta página se movió a ``docs/historico/sintaxis.rst`` y se considera
+   contenido histórico/no operativo.
 
-var nombre = "Cobra"
-var numero = 10
-var año = 1  # Identificadores Unicode permitidos
+   Consulta la ruta canónica vigente:
 
-Los nombres de variables no pueden ser palabras reservadas como ``si`` o ``mientras``. Usarlas como identificador generará un ``ParserError``.
+   - `Libro de Programación Cobra <../../docs/LIBRO_PROGRAMACION_COBRA.md>`_
+   - `Manual de Cobra <../../docs/MANUAL_COBRA.md>`_
 
-**2. Funciones**
-
-Las funciones se declaran con `func` y el cuerpo se delimita con `:`  :
-
-func sumar(a, b) :
-    return a + b
-
-Al igual que con las variables, el nombre de la función no puede coincidir con palabras reservadas.
-
-**3. Condicionales**
-
-Para condicionales, se usan `si` y `sino` :
-
-si x > 10 :
-    imprimir("x es mayor que 10")
-sino :
-    imprimir("x es menor o igual a 10")
-
-**4. Bucles**
-
-Cobra soporta los bucles `mientras` y `para` :
-
-mientras x < 5 :
-    imprimir(x)
-    x += 1
-
-para var i en rango(5) :
-    imprimir(i)
-
-**5. Holobits**
-
-Los holobits permiten trabajar con datos multidimensionales:
-
-var h = holobit([0.8, -0.5, 1.2])
-imprimir(h)
-
-**6. Importación de módulos**
-
-Puedes dividir tu código en varios archivos y cargarlos con ``import``:
-
-.. code-block:: cobra
-
-   import 'utilidades.co'
-   imprimir(variable_definida_en_utilidades)
-
-**7. Manejo de excepciones**
-
-Para capturar errores se utiliza la estructura ``try`` / ``catch``. Puedes
-lanzar excepciones con ``throw``:
-
-.. code-block:: cobra
-
-   try:
-       throw "problema"
-   catch e:
-       imprimir(e)
-
-**8. Concurrencia con hilos**
-
-Es posible ejecutar funciones de forma concurrente:
-
-.. code-block:: cobra
-
-   func trabajo():
-       imprimir('hola')
-   fin
-
-   hilo trabajo()
-
-**10. Decoradores de funciones**
-
-Puedes anteponer `@` a una función para modificar su comportamiento con un decorador:
-
-.. code-block:: cobra
-
-   @temporizador
-   func saluda():
-       imprimir('hola')
-   fin
-
-**Transpilación a los 8 backends oficiales**
-
-Cobra transpila únicamente a ``python``, ``rust``, ``javascript``, ``wasm``, ``go``, ``cpp``, ``java`` y ``asm``.
-
-- ``imprimir`` genera la forma idiomática equivalente de cada backend oficial.
-- ``mientras`` y ``para`` se traducen a construcciones de control equivalentes del backend de salida o a la representación contractual que corresponda.
-- ``holobit``, ``proyectar``, ``transformar`` y ``graficar`` se emiten según el contrato público vigente del backend:
-
-  - ``python`` ofrece soporte ``full`` y compatibilidad SDK completa.
-  - ``rust``, ``javascript`` y ``cpp`` ofrecen runtime oficial verificable con adaptador Holobit mantenido por el proyecto, en estado contractual ``partial``.
-  - ``go`` y ``java`` mantienen hooks/adaptadores ``partial`` sobre runtime best-effort no público.
-  - ``wasm`` y ``asm`` generan hooks/puentes contractuales de solo transpilación y no deben documentarse como runtime oficial público.
-
-Cuando una librería o hook no alcanza paridad completa en un backend ``partial``, la documentación pública debe describirlo como soporte contractual limitado, no como equivalencia total con el runtime Python.
-
-Activar el parser de Lark
--------------------------
-
-Si deseas utilizar el parser alternativo implementado con ``Lark`` establece la variable
-de entorno ``COBRA_PARSER`` a ``lark`` antes de ejecutar Cobra:
-
-.. code-block:: bash
-
-   export COBRA_PARSER=lark
-   cobra ejecutar programa.co
-
-Si no defines esta variable se seguirá empleando el parser tradicional.
+Referencia histórica: :doc:`../../docs/historico/sintaxis`

--- a/docs/historico/primeros_pasos.rst
+++ b/docs/historico/primeros_pasos.rst
@@ -1,0 +1,68 @@
+Primeros pasos con Cobra (histórico)
+====================================
+
+.. warning::
+
+   Documento histórico / no operativo. Para la guía vigente consulta el
+   `Libro de Programación Cobra <../LIBRO_PROGRAMACION_COBRA.md>`_ y el
+   `Manual de Cobra <../MANUAL_COBRA.md>`_.
+
+Esta guía se conserva como referencia de versiones anteriores.
+
+Instalación
+-----------
+
+1. Clona el repositorio y entra al directorio:
+
+.. code-block:: bash
+
+   git clone https://github.com/Alphonsus411/pCobra.git
+   cd pCobra
+
+2. Crea un entorno virtual y actívalo:
+
+.. code-block:: bash
+
+   python -m venv .venv
+   source .venv/bin/activate  # Linux o macOS
+   .\\.venv\\Scripts\\activate  # Windows
+
+3. Instala las dependencias y la CLI:
+
+.. code-block:: bash
+
+   pip install -r requirements-dev.txt
+   pip install -e .
+
+   # También puedes usar ``pip install -e .[dev]`` para instalar los extras de desarrollo
+
+Uso básico
+----------
+
+Puedes ejecutar archivos ``.co`` directamente con la CLI.
+Por ejemplo, si tienes ``hola.co``:
+
+.. code-block:: cobra
+
+   imprimir("Hola, Cobra")
+
+Lo ejecutas con:
+
+.. code-block:: bash
+
+   cobra run hola.co
+
+Comandos públicos actuales de la CLI:
+
+.. code-block:: bash
+
+   cobra run hola.co
+   cobra build hola.co
+   cobra test hola.co
+   cobra mod list
+
+Para generar la documentación en HTML usa:
+
+.. code-block:: bash
+
+   make html

--- a/docs/historico/sintaxis.rst
+++ b/docs/historico/sintaxis.rst
@@ -1,0 +1,122 @@
+Sintaxis de Cobra (histórico)
+=============================
+
+.. warning::
+
+   Documento histórico / no operativo. Para la sintaxis y contrato vigentes
+   consulta el `Libro de Programación Cobra <../LIBRO_PROGRAMACION_COBRA.md>`_
+   y el `Manual de Cobra <../MANUAL_COBRA.md>`_.
+
+***1. Declaración de variables***
+
+Para declarar variables en Cobra, usamos `var`:
+
+var nombre = "Cobra"
+var numero = 10
+var año = 1  # Identificadores Unicode permitidos
+
+Los nombres de variables no pueden ser palabras reservadas como ``si`` o ``mientras``.
+Usarlas como identificador generará un ``ParserError``.
+
+**2. Funciones**
+
+Las funciones se declaran con `func` y el cuerpo se delimita con `:`:
+
+func sumar(a, b) :
+    return a + b
+
+Al igual que con las variables, el nombre de la función no puede coincidir con palabras reservadas.
+
+**3. Condicionales**
+
+Para condicionales, se usan `si` y `sino`:
+
+si x > 10 :
+    imprimir("x es mayor que 10")
+sino :
+    imprimir("x es menor o igual a 10")
+
+**4. Bucles**
+
+Cobra soporta los bucles `mientras` y `para`:
+
+mientras x < 5 :
+    imprimir(x)
+    x += 1
+
+para var i en rango(5) :
+    imprimir(i)
+
+**5. Holobits**
+
+Los holobits permiten trabajar con datos multidimensionales:
+
+var h = holobit([0.8, -0.5, 1.2])
+imprimir(h)
+
+**6. Importación de módulos**
+
+Puedes dividir tu código en varios archivos y cargarlos con ``import``:
+
+.. code-block:: cobra
+
+   import 'utilidades.co'
+   imprimir(variable_definida_en_utilidades)
+
+**7. Manejo de excepciones**
+
+Para capturar errores se utiliza la estructura ``try`` / ``catch``. Puedes
+lanzar excepciones con ``throw``:
+
+.. code-block:: cobra
+
+   try:
+       throw "problema"
+   catch e:
+       imprimir(e)
+
+**8. Concurrencia con hilos**
+
+Es posible ejecutar funciones de forma concurrente:
+
+.. code-block:: cobra
+
+   func trabajo():
+       imprimir('hola')
+   fin
+
+   hilo trabajo()
+
+**9. Decoradores de funciones**
+
+Puedes anteponer `@` a una función para modificar su comportamiento con un decorador:
+
+.. code-block:: cobra
+
+   @temporizador
+   func saluda():
+       imprimir('hola')
+   fin
+
+**Targets oficiales de salida (estado vigente)**
+
+Cobra documenta como salida oficial únicamente a ``python``, ``javascript`` y ``rust``.
+
+- ``python``: soporte contractual ``full``.
+- ``javascript`` y ``rust``: soporte contractual ``partial``.
+
+Targets legacy como ``wasm``, ``go``, ``cpp``, ``java`` y ``asm`` se tratan como
+históricos/internos y no forman parte del contrato público de salida.
+
+Activar el parser de Lark
+-------------------------
+
+Si deseas utilizar el parser alternativo implementado con ``Lark`` establece la variable
+ de entorno ``COBRA_PARSER`` a ``lark`` antes de ejecutar Cobra:
+
+.. code-block:: bash
+
+   export COBRA_PARSER=lark
+   cobra run programa.co
+
+Si no defines esta variable se seguirá empleando el parser tradicional.


### PR DESCRIPTION
### Motivation
- Eliminar referencias legacy y términos engañosos en las guías de frontend para alinear la documentación con el contrato público de la CLI y los targets oficiales actuales. 
- Evitar que páginas obsoletas rompan la navegación y dejar claro qué contenido es histórico/no operativo. 

### Description
- Moví el contenido completo de `docs/frontend/primeros_pasos.rst` y `docs/frontend/sintaxis.rst` a `docs/historico/primeros_pasos.rst` y `docs/historico/sintaxis.rst` con un banner de "histórico/no operativo" y enlaces al `Libro de Programación Cobra` y al `Manual de Cobra`.
- Reemplacé las páginas originales en `docs/frontend/` por stubs que referencian la copia histórica para mantener rutas existentes y evitar roturas visibles. 
- Actualicé los ejemplos y bloques de comandos para usar el contrato CLI vigente: `cobra run`, `cobra build`, `cobra test` y `cobra mod`.
- Modifiqué `docs/frontend/index.rst` para eliminar `sintaxis` y `primeros_pasos` del `toctree`, substituir la narrativa de "8 backends oficiales" por la lista canónica de 3 targets (`python`, `javascript`, `rust`) e incluir una sección "Contenido histórico" con enlaces a las nuevas páginas en `docs/historico/`.

### Testing
- Ejecuté búsquedas con `rg` para localizar referencias legacy y confirmar que `cobra ejecutar` y la narrativa de "8 backends oficiales" ya no aparecen en las páginas activas, y la comprobación tuvo éxito. 
- Verifiqué enlaces y rutas entrantes desde `README.md` y los índices con `rg` para detectar rutas rotas y no se encontraron referencias pendientes a las páginas movidas. 
- Intenté construir `docs/frontend` con `sphinx-build -b dummy docs/frontend /tmp/sphinx-frontend` y la ejecución falló por una dependencia del entorno (`PlantUML no está instalado en el sistema`), lo cual es un fallo de entorno que no está relacionado con las rutas o el contenido modificado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d13051f08327b69667f49aecc1ee)