### PR TITLE
docs(frontend): corregir rutas relativas y referencias históricas

### DIFF
--- a/docs/frontend/index.rst
+++ b/docs/frontend/index.rst
@@ -14,12 +14,12 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
 
    caracteristicas
    arquitectura
-   ../../docs/estructura_ast
+   ../estructura_ast
    design_patterns
    cli
    backends
-   ../../docs/lenguajes_soportados
-   ../../docs/lenguajes
+   ../lenguajes_soportados
+   ../lenguajes
    avances
    proximos_pasos
    optimizaciones
@@ -31,10 +31,10 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    rfc_plugins
    ejemplos
    ejemplos_avanzados
-   ../../docs/casos_reales
+   ../casos_reales
    referencia
-   ../../docs/standard_library/util
-   ../../docs/standard_library/numero
+   ../standard_library/util
+   ../standard_library/numero
    validador
    modo_seguro
    empaquetar
@@ -50,7 +50,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    qualia
    jupyter
    recursos_adicionales
-   ../../docs/MANUAL_COBRA
+   ../MANUAL_COBRA
    api/modules
 
 Introducción
@@ -73,7 +73,7 @@ Contenido histórico
 
 Las guías ``primeros_pasos`` y ``sintaxis`` de esta sección se movieron a ``docs/historico/`` como material de referencia histórica/no operativa:
 
-- :doc:`../../docs/historico/primeros_pasos`
-- :doc:`../../docs/historico/sintaxis`
+- :doc:`../historico/primeros_pasos`
+- :doc:`../historico/sintaxis`
 
 Para el camino principal de aprendizaje usa el Libro y el Manual canónico enlazados en el README del repositorio.

--- a/docs/frontend/primeros_pasos.rst
+++ b/docs/frontend/primeros_pasos.rst
@@ -8,7 +8,7 @@ Primeros pasos con Cobra
 
    Consulta la ruta canónica vigente:
 
-   - `Libro de Programación Cobra <../../docs/LIBRO_PROGRAMACION_COBRA.md>`_
-   - `Manual de Cobra <../../docs/MANUAL_COBRA.md>`_
+   - `Libro de Programación Cobra <../LIBRO_PROGRAMACION_COBRA.md>`_
+   - `Manual de Cobra <../MANUAL_COBRA.md>`_
 
-Referencia histórica: :doc:`../../docs/historico/primeros_pasos`
+Referencia histórica: :doc:`../historico/primeros_pasos`

--- a/docs/frontend/sintaxis.rst
+++ b/docs/frontend/sintaxis.rst
@@ -8,7 +8,7 @@ Sintaxis de Cobra
 
    Consulta la ruta canónica vigente:
 
-   - `Libro de Programación Cobra <../../docs/LIBRO_PROGRAMACION_COBRA.md>`_
-   - `Manual de Cobra <../../docs/MANUAL_COBRA.md>`_
+   - `Libro de Programación Cobra <../LIBRO_PROGRAMACION_COBRA.md>`_
+   - `Manual de Cobra <../MANUAL_COBRA.md>`_
 
-Referencia histórica: :doc:`../../docs/historico/sintaxis`
+Referencia histórica: :doc:`../historico/sintaxis`


### PR DESCRIPTION
### Motivation
- Evitar rutas relativas incorrectas o redundantes en la documentación frontend y asegurar que las referencias canónicas y el material histórico apunten a ubicaciones locales claras en lugar de `../../docs/...`.

### Description
- Se actualizaron `docs/frontend/sintaxis.rst`, `docs/frontend/primeros_pasos.rst` y `docs/frontend/index.rst` para usar rutas locales más claras en el `toctree` y enlaces internos.
- Se sustituyeron `../../docs/LIBRO_PROGRAMACION_COBRA.md` por `../LIBRO_PROGRAMACION_COBRA.md` y `../../docs/MANUAL_COBRA.md` por `../MANUAL_COBRA.md` en las páginas históricas.
- Se normalizaron las referencias históricas `:doc:` para que apunten a `../historico/...` de forma consistente.
- Los cambios quedaron committeados con el mensaje `docs(frontend): corrige rutas relativas en enlaces y docs historicos`.

### Testing
- Se inspeccionaron los archivos con `sed -n` para verificar el contenido actualizado y la inspección tuvo éxito.
- Se buscó cualquier ocurrencia de `../../docs/` en los tres archivos con `rg` y no se encontraron coincidencias, verificando la corrección.
- Se revisó el `git diff` de los archivos modificados y se realizó un `git commit` con el cambio, ambos pasos completados con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4796a5b608327861f6fb1d7547313)