### PR TITLE
docs(historico): convertir sintaxis y primeros_pasos en documentos de archivo

### DIFF
--- a/docs/historico/primeros_pasos.rst
+++ b/docs/historico/primeros_pasos.rst
@@ -3,66 +3,35 @@ Primeros pasos con Cobra (histórico)
 
 .. warning::
 
-   Documento histórico / no operativo. Para la guía vigente consulta el
-   `Libro de Programación Cobra <../LIBRO_PROGRAMACION_COBRA.md>`_ y el
-   `Manual de Cobra <../MANUAL_COBRA.md>`_.
+   Documento de archivo (no operativo). Esta guía refleja un flujo de adopción
+   usado en etapas tempranas del proyecto y no debe emplearse como referencia
+   práctica actual.
 
-Esta guía se conserva como referencia de versiones anteriores.
+Contexto histórico
+------------------
 
-Instalación
------------
+Este material corresponde al ciclo inicial de difusión de Cobra, cuando se
+priorizaban instrucciones rápidas de arranque local. Se conserva únicamente
+como registro histórico del proceso de onboarding de versiones anteriores.
 
-1. Clona el repositorio y entra al directorio:
+Ejemplo legacy
+--------------
 
-.. code-block:: bash
-
-   git clone https://github.com/Alphonsus411/pCobra.git
-   cd pCobra
-
-2. Crea un entorno virtual y actívalo:
-
-.. code-block:: bash
-
-   python -m venv .venv
-   source .venv/bin/activate  # Linux o macOS
-   .\\.venv\\Scripts\\activate  # Windows
-
-3. Instala las dependencias y la CLI:
-
-.. code-block:: bash
-
-   pip install -r requirements-dev.txt
-   pip install -e .
-
-   # También puedes usar ``pip install -e .[dev]`` para instalar los extras de desarrollo
-
-Uso básico
-----------
-
-Puedes ejecutar archivos ``.co`` directamente con la CLI.
-Por ejemplo, si tienes ``hola.co``:
+Se conserva un ejemplo mínimo de estilo antiguo, sin carácter normativo:
 
 .. code-block:: cobra
 
    imprimir("Hola, Cobra")
 
-Lo ejecutas con:
+Notas de archivo
+----------------
 
-.. code-block:: bash
+- Se retiraron comandos de instalación, ejecución y build para evitar
+  superposición con el flujo vigente.
+- Cualquier instrucción operativa debe consultarse en la documentación actual.
 
-   cobra run hola.co
+Ruta vigente
+------------
 
-Comandos públicos actuales de la CLI:
-
-.. code-block:: bash
-
-   cobra run hola.co
-   cobra build hola.co
-   cobra test hola.co
-   cobra mod list
-
-Para generar la documentación en HTML usa:
-
-.. code-block:: bash
-
-   make html
+- `Libro de Programación Cobra <../LIBRO_PROGRAMACION_COBRA.md>`_
+- `Manual de Cobra <../MANUAL_COBRA.md>`_

--- a/docs/historico/sintaxis.rst
+++ b/docs/historico/sintaxis.rst
@@ -3,120 +3,42 @@ Sintaxis de Cobra (histórico)
 
 .. warning::
 
-   Documento histórico / no operativo. Para la sintaxis y contrato vigentes
-   consulta el `Libro de Programación Cobra <../LIBRO_PROGRAMACION_COBRA.md>`_
-   y el `Manual de Cobra <../MANUAL_COBRA.md>`_.
+   Documento de archivo (no operativo). Este contenido describe convenciones de
+   sintaxis usadas en ciclos iniciales de Cobra, previos a la consolidación de
+   la documentación canónica actual.
 
-***1. Declaración de variables***
+Contexto histórico
+------------------
 
-Para declarar variables en Cobra, usamos `var`:
+Este documento resume una etapa temprana del lenguaje en la que se difundían
+fragmentos sintácticos sueltos para aprendizaje rápido. Se conserva solo para
+trazabilidad documental de decisiones y términos usados en versiones anteriores.
 
-var nombre = "Cobra"
-var numero = 10
-var año = 1  # Identificadores Unicode permitidos
+Ejemplo legacy
+--------------
 
-Los nombres de variables no pueden ser palabras reservadas como ``si`` o ``mientras``.
-Usarlas como identificador generará un ``ParserError``.
-
-**2. Funciones**
-
-Las funciones se declaran con `func` y el cuerpo se delimita con `:`:
-
-func sumar(a, b) :
-    return a + b
-
-Al igual que con las variables, el nombre de la función no puede coincidir con palabras reservadas.
-
-**3. Condicionales**
-
-Para condicionales, se usan `si` y `sino`:
-
-si x > 10 :
-    imprimir("x es mayor que 10")
-sino :
-    imprimir("x es menor o igual a 10")
-
-**4. Bucles**
-
-Cobra soporta los bucles `mientras` y `para`:
-
-mientras x < 5 :
-    imprimir(x)
-    x += 1
-
-para var i en rango(5) :
-    imprimir(i)
-
-**5. Holobits**
-
-Los holobits permiten trabajar con datos multidimensionales:
-
-var h = holobit([0.8, -0.5, 1.2])
-imprimir(h)
-
-**6. Importación de módulos**
-
-Puedes dividir tu código en varios archivos y cargarlos con ``import``:
+El siguiente snippet se mantiene únicamente como referencia histórica:
 
 .. code-block:: cobra
 
-   import 'utilidades.co'
-   imprimir(variable_definida_en_utilidades)
+   func sumar(a, b) :
+       return a + b
 
-**7. Manejo de excepciones**
+   si x > 10 :
+       imprimir("x es mayor que 10")
+   sino :
+       imprimir("x es menor o igual a 10")
 
-Para capturar errores se utiliza la estructura ``try`` / ``catch``. Puedes
-lanzar excepciones con ``throw``:
+Notas de archivo
+----------------
 
-.. code-block:: cobra
+- Targets y mecanismos mencionados históricamente pueden no representar el
+  contrato vigente.
+- Variables de entorno, comandos y flujos de ejecución antiguos se omiten para
+  evitar conflicto con la guía actual.
 
-   try:
-       throw "problema"
-   catch e:
-       imprimir(e)
+Ruta vigente
+------------
 
-**8. Concurrencia con hilos**
-
-Es posible ejecutar funciones de forma concurrente:
-
-.. code-block:: cobra
-
-   func trabajo():
-       imprimir('hola')
-   fin
-
-   hilo trabajo()
-
-**9. Decoradores de funciones**
-
-Puedes anteponer `@` a una función para modificar su comportamiento con un decorador:
-
-.. code-block:: cobra
-
-   @temporizador
-   func saluda():
-       imprimir('hola')
-   fin
-
-**Targets oficiales de salida (estado vigente)**
-
-Cobra documenta como salida oficial únicamente a ``python``, ``javascript`` y ``rust``.
-
-- ``python``: soporte contractual ``full``.
-- ``javascript`` y ``rust``: soporte contractual ``partial``.
-
-Targets legacy como ``wasm``, ``go``, ``cpp``, ``java`` y ``asm`` se tratan como
-históricos/internos y no forman parte del contrato público de salida.
-
-Activar el parser de Lark
--------------------------
-
-Si deseas utilizar el parser alternativo implementado con ``Lark`` establece la variable
- de entorno ``COBRA_PARSER`` a ``lark`` antes de ejecutar Cobra:
-
-.. code-block:: bash
-
-   export COBRA_PARSER=lark
-   cobra run programa.co
-
-Si no defines esta variable se seguirá empleando el parser tradicional.
+- `Libro de Programación Cobra <../LIBRO_PROGRAMACION_COBRA.md>`_
+- `Manual de Cobra <../MANUAL_COBRA.md>`_


### PR DESCRIPTION
### Motivation

- Mantener en el árbol de documentación dos páginas históricas como archivos de referencia no operativa para evitar que usuarios sigan instrucciones obsoletas.
- Evitar la duplicidad o la competencia con la documentación vigente (`LIBRO_PROGRAMACION_COBRA.md` y `MANUAL_COBRA.md`).

### Description

- Reescribí `docs/historico/sintaxis.rst` para convertirla en un documento de archivo con un breve `Contexto histórico`, una sección `Ejemplo legacy` y un bloque `Ruta vigente` que enlaza al `Libro de Programación Cobra` y al `Manual de Cobra`.
- Reescribí `docs/historico/primeros_pasos.rst` con el mismo enfoque de archivo, moviendo el ejemplo mínimo a `Ejemplo legacy` y eliminando pasos de instalación y comandos operativos.
- Eliminé snippets y comandos operativos (instalación, ejecución, build, variables de entorno) que podían competir con el flujo actual y añadí notas de archivo que advierten sobre su carácter histórico.
- Alineé ambas páginas en estilo y estructura para facilitar su uso como referencias históricas no normativas.

### Testing

- Ejecuté `sed -n '1,220p' docs/historico/sintaxis.rst && sed -n '1,260p' docs/historico/primeros_pasos.rst` para inspeccionar los contenidos reescritos, y la salida mostró las secciones previstas (éxito).
- Verifiqué los cambios con `git diff -- docs/historico/sintaxis.rst docs/historico/primeros_pasos.rst` para confirmar las eliminaciones y reubicaciones de contenido (éxito).
- Registré los cambios con `git commit -m "docs(historico): convertir sintaxis y primeros pasos en archivos"` y el commit se creó correctamente (éxito).
- Mostré los archivos con `nl -ba` para revisión final de líneas y formato, confirmando que ambas páginas reflejan el nuevo enfoque histórico (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e47a3575448327845828b3caac525e)