### PR TITLE
[Follow-up] Restore non-debug execution error logging for CLI error unification

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -551,6 +551,8 @@ class CliApplication:
         if debug_activo:
             logging.exception("Error in execution")
             logging.getLogger(__name__).debug(format_traceback(exc, language))
+        else:
+            logging.error("Error in execution: %s", mensaje)
         return 1
 
     @staticmethod


### PR DESCRIPTION
### Motivation
- Fix a regression where non-debug execution errors stopped emitting to the configured root logger/stderr because `logging.error` was removed, which reduced diagnosability and violated expectations in `tests/unit/test_cli_execution_error_output.py`.

### Description
- Restored a non-debug logger emission by adding `logging.error("Error in execution: %s", mensaje)` to `CliApplication._handle_execution_error` in `src/pcobra/cobra/cli/cli.py`.
- Preserved the single user-visible surface via `messages.mostrar_error(..., registrar_log=False)` and left debug behavior (`logging.exception` + traceback logged to `logger.debug`) unchanged.

### Testing
- Ran `pytest -q tests/unit/test_cli_execution_error_output.py` and all tests passed (`9 passed`).
- Confirmed the modified module compiles without syntax errors during local validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e47d41c5588327ac01aea88baa22ce)