### PR TITLE
fix: preservar alias `_reconfigurar_consola_utf8` en arranque CLI

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -47,6 +47,12 @@ def configure_encoding() -> None:
     os.environ["PYTHONIOENCODING"] = "utf-8"
 
 
+def _reconfigurar_consola_utf8() -> None:
+    """Alias retrocompatible para callers que importan el helper legacy."""
+
+    configure_encoding()
+
+
 def configure_logging(debug: bool) -> None:
     """Configura logging de CLI con un único handler efectivo de consola.
 
@@ -198,7 +204,7 @@ def _normalizar_argumentos(argumentos: Optional[Iterable[str]]) -> Optional[List
 
 def main(argumentos: Optional[List[str]] = None) -> int:
     """Punto de entrada principal para la ejecución del CLI."""
-    configure_encoding()
+    _reconfigurar_consola_utf8()
     _bootstrap_dev_path_si_opt_in()
     argv_entrada: Iterable[str] = argumentos if argumentos is not None else sys.argv[1:]
     argv = _normalizar_argumentos(argv_entrada)


### PR DESCRIPTION
### Motivation
- Evitar una ruptura inmediata para consumidores que importan el helper legacy con `from pcobra.cli import _reconfigurar_consola_utf8`, que provocaba `ImportError` tras renombrar la función de reconfiguración de encoding.
- Mantener la configuración UTF-8 en el arranque del CLI sin forzar cambios en call sites existentes.

### Description
- Se añade `def _reconfigurar_consola_utf8():` en `src/pcobra/cli.py` como alias retrocompatible que delega en `configure_encoding()` para preservar el símbolo legacy.
- Se actualiza `main()` para invocar `
_reconfigurar_consola_utf8()` al inicio, conservando el orden de inicialización previo y permitiendo monkeypatch en tests y consumidores.
- No se cambia la lógica de reconfiguración de encoding ni se introducen nuevas dependencias; sólo se restaura el nombre legacy como wrapper.

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_configurar_entorno.py`, resultando en `6 passed` y todas las pruebas verdes.
- Las pruebas verifican cobertura de los casos: streams sin `reconfigure`, streams con `reconfigure`, y que la llamada en `main()` respeta el orden de inicialización; todos pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e47e37f7348327b7d6b85e3bcf6d5c)