### PR TITLE
fix(cli): restaurar bootstrap UTF-8 en main legado cobra.cli.cli

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -836,6 +836,11 @@ class CliApplication:
 
 def main(argv: Optional[List[str]] = None) -> int:
     """Main entry point for the CLI."""
+    # Reaplica bootstrap de encoding para invocaciones legacy que delegan
+    # directamente en este main (p. ej. ``python -m cobra.cli.cli``).
+    from pcobra.cli import configure_encoding
+
+    configure_encoding()
     application = CliApplication()
     return application.run(argv)
 


### PR DESCRIPTION
### Motivation
- Evitar la regresión que rompía las invocaciones legacy/directas que delegan en `pcobra.cobra.cli.cli.main` bajo locales no UTF-8, causando errores de codificación en la salida de ayuda.

### Description
- Se reintrodujo una llamada a `configure_encoding()` al inicio de `pcobra.cobra.cli.cli.main` para reaplicar el bootstrap UTF-8 antes de instanciar `CliApplication` en `src/pcobra/cobra/cli/cli.py`.
- Se añadió un comentario inline que aclara que este bootstrap es necesario para rutas legacy como `python -m cobra.cli.cli` y no cambia el entrypoint canónico.
- El cambio es intencionalmente mínimo y localizado para preservar el comportamiento centralizado del entrypoint principal mientras restaura compatibilidad legacy.

### Testing
- Ejecuté `PYTHONPATH=src PYTHONCOERCECLOCALE=0 PYTHONUTF8=0 LC_ALL=C python -m cobra.cli.cli --help` y comprobé salida de ayuda con `EXIT:0` (éxito).
- Ejecuté `PYTHONPATH=src PYTHONCOERCECLOCALE=0 PYTHONUTF8=0 LC_ALL=C python -m pcobra --help` y comprobé salida de ayuda con `EXIT:0` (éxito).
- Ejecuté `PYTHONPATH=src pytest -q tests/unit/suite_cli.py` y no se recogieron tests en ese objetivo (salida "no tests ran", exit code 5), consistente con el estado previo del suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e47f3f5d8c832793d1aa7568366679)