### PR TITLE
Follow-up: align registry/benchmark contracts with public+legacy target policy

### DIFF
--- a/src/pcobra/cobra/benchmarks/targets_policy.py
+++ b/src/pcobra/cobra/benchmarks/targets_policy.py
@@ -18,8 +18,8 @@ from pcobra.cobra.cli.target_policies import (
     NO_RUNTIME_TARGETS,
     OFFICIAL_RUNTIME_TARGETS,
 )
+from pcobra.cobra.config.transpile_targets import LEGACY_INTERNAL_TARGETS
 from pcobra.cobra.transpilers.target_utils import normalize_target_name, target_cli_choices
-from pcobra.cobra.transpilers.target_utils import require_exact_official_targets
 from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
 
 BEST_EFFORT_BENCHMARK_RUNTIME_TARGETS: Final[tuple[str, ...]] = BEST_EFFORT_RUNTIME_TARGETS
@@ -135,8 +135,18 @@ def validate_local_targets_policy(repo_root: Path) -> None:
 
 
 def validate_backend_metadata(backends: Mapping[str, object], *, context: str) -> None:
-    """Falla rápido si existe metadata para targets fuera de la whitelist oficial."""
-    require_exact_official_targets(backends, context=context)
+    """Falla rápido si existe metadata fuera del canon oficial+legacy conocido."""
+    normalized = tuple(normalize_target_name(target) for target in backends)
+    official_set = set(OFFICIAL_TARGETS)
+    allowed_set = official_set | set(LEGACY_INTERNAL_TARGETS)
+    extras = tuple(sorted(set(normalized) - allowed_set))
+    missing = tuple(target for target in OFFICIAL_TARGETS if target not in normalized)
+    if missing or extras:
+        raise RuntimeError(
+            "Metadata de backends desalineada con la política canónica. "
+            f"missing_official={missing or '∅'}; extras={extras or '∅'}; "
+            f"official={OFFICIAL_TARGETS}; legacy={LEGACY_INTERNAL_TARGETS}; context={context}"
+        )
 
 
 

--- a/src/pcobra/cobra/transpilers/registry.py
+++ b/src/pcobra/cobra/transpilers/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Final
 
+from pcobra.cobra.config.transpile_targets import LEGACY_INTERNAL_TARGETS
 from pcobra.cobra.transpilers.target_utils import (
     require_exact_official_targets,
     target_cli_choices,
@@ -24,33 +25,29 @@ TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {
 
 
 def _validate_registry_contract() -> tuple[str, ...]:
-    """Valida que el registro declare exactamente los 8 targets oficiales."""
+    """Valida que el registro cubra el canon oficial y solo admita legacy conocido."""
     configured_keys = tuple(TRANSPILER_CLASS_PATHS)
+    official_set = set(OFFICIAL_TARGETS)
+    legacy_set = set(LEGACY_INTERNAL_TARGETS)
+
     missing = tuple(target for target in OFFICIAL_TARGETS if target not in configured_keys)
-    extras = tuple(target for target in configured_keys if target not in OFFICIAL_TARGETS)
+    extras = tuple(
+        target
+        for target in configured_keys
+        if target not in official_set and target not in legacy_set
+    )
 
     if missing or extras:
         raise RuntimeError(
-            "[CI CONTRACT] TRANSPILER_CLASS_PATHS tiene claves fuera de contrato y debe usar exactamente los 8 targets canónicos. "
+            "[CI CONTRACT] TRANSPILER_CLASS_PATHS debe cubrir todos los targets oficiales y solo puede añadir targets legacy/internal conocidos. "
             f"missing={missing or '∅'}; extras={extras or '∅'}; "
-            f"current={configured_keys}; expected={OFFICIAL_TARGETS}"
+            f"current={configured_keys}; official={OFFICIAL_TARGETS}; legacy={LEGACY_INTERNAL_TARGETS}"
         )
 
-    if len(configured_keys) != len(OFFICIAL_TARGETS):
-        raise RuntimeError(
-            "[CI CONTRACT] TRANSPILER_CLASS_PATHS tiene cardinalidad inválida. "
-            f"len(current)={len(configured_keys)}; len(expected)={len(OFFICIAL_TARGETS)}; "
-            f"current={configured_keys}; expected={OFFICIAL_TARGETS}"
-        )
-
-    if configured_keys != OFFICIAL_TARGETS:
-        raise RuntimeError(
-            "[CI CONTRACT] TRANSPILER_CLASS_PATHS debe preservar el orden canónico. "
-            f"current={configured_keys}; expected={OFFICIAL_TARGETS}"
-        )
+    official_keys_in_registry = tuple(target for target in configured_keys if target in official_set)
 
     return require_exact_official_targets(
-        TRANSPILER_CLASS_PATHS,
+        official_keys_in_registry,
         context="pcobra.cobra.transpilers.registry.TRANSPILER_CLASS_PATHS",
     )
 


### PR DESCRIPTION
### Motivation
- After shrinking the public canon to `python/javascript/rust`, import-time validations in the transpiler registry and benchmark metadata still demanded an exact 1:1 match with the old canonical set, which caused `RuntimeError` during normal imports when legacy/internal backends (`wasm/go/cpp/java/asm`) remained present.

### Description
- Modified `pcobra.cobra.transpilers.registry._validate_registry_contract` to require that all official targets are present while allowing additional known `LEGACY_INTERNAL_TARGETS`, and to validate the official subset ordering via `require_exact_official_targets` applied to the official keys found in the registry (file: `src/pcobra/cobra/transpilers/registry.py`).
- Updated `pcobra.cobra.benchmarks.targets_policy.validate_backend_metadata` to accept metadata that covers `official + LEGACY_INTERNAL_TARGETS` and to raise only for truly unknown extras or missing official entries (file: `src/pcobra/cobra/benchmarks/targets_policy.py`).
- Added imports of `LEGACY_INTERNAL_TARGETS` where required and changed error messages to reflect the new contract so import-time crashes are avoided when legacy entries are present.

### Testing
- Ran `python -m compileall` on the modified modules (`src/pcobra/cobra/transpilers/registry.py` and `src/pcobra/cobra/benchmarks/targets_policy.py`) which compiled successfully. 
- Performed smoke imports `import pcobra.cobra.transpilers.registry` and `import pcobra.cobra.benchmarks.targets_policy` and verified `official_transpiler_targets()` returns `('python','javascript','rust')` and `validate_backend_metadata(BENCHMARK_BACKEND_METADATA, ...)` passes, both of which succeeded. 
- An earlier attempt to run a broader inline import/check failed when trying to import a non-existent module (`pcobra.cobra.cli.main`) and a bad symbol reference in an inline check, but this was unrelated to the changes and did not block the targeted validations above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4823ad2ec8327bf58df0ffe0e869b)