### PR TITLE
fix(cli): address v2 test/build delegation regressions from PR #1927

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/build_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/build_cmd.py
@@ -12,6 +12,7 @@ class BuildCommandV2(BaseCommand):
 
     name = "build"
     capability = "codegen"
+    requires_sqlite_key: bool = True
 
     def __init__(self) -> None:
         super().__init__()
@@ -29,10 +30,11 @@ class BuildCommandV2(BaseCommand):
         return parser
 
     def run(self, args: Any) -> int:
+        target = getattr(args, "target", None) or "python"
         legacy_args = Namespace(
             archivo=args.file,
-            tipo=getattr(args, "target", None),
-            backend=getattr(args, "target", None),
+            tipo=target,
+            backend=target,
             tipos=getattr(args, "targets", None),
             modo=getattr(args, "modo", "mixto"),
         )

--- a/src/pcobra/cobra/cli/commands_v2/test_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/test_cmd.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
+from pcobra.cobra.cli.target_policies import parse_restricted_target_list
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.autocomplete import files_completer
 
@@ -30,9 +31,17 @@ class TestCommandV2(BaseCommand):
         return parser
 
     def run(self, args: Any) -> int:
+        langs = getattr(args, "langs", "")
+        if isinstance(langs, str):
+            langs = parse_restricted_target_list(
+                langs,
+                self._legacy.SUPPORTED_LANGUAGES,
+                "verificación ejecutable",
+            )
+
         legacy_args = Namespace(
             archivo=args.file,
-            lenguajes=getattr(args, "langs", ""),
+            lenguajes=langs,
             modo=getattr(args, "modo", "mixto"),
         )
         return self._legacy.run(legacy_args)

--- a/tests/unit/cli/commands/test_commands_v2_wrappers.py
+++ b/tests/unit/cli/commands/test_commands_v2_wrappers.py
@@ -1,0 +1,42 @@
+from argparse import Namespace
+
+from pcobra.cobra.cli.commands_v2.build_cmd import BuildCommandV2
+from pcobra.cobra.cli.commands_v2.test_cmd import TestCommandV2
+
+
+def test_test_v2_parses_langs_before_delegating(monkeypatch):
+    command = TestCommandV2()
+    captured = {}
+
+    def fake_run(args):
+        captured["args"] = args
+        return 0
+
+    monkeypatch.setattr(command._legacy, "run", fake_run)
+
+    rc = command.run(Namespace(file="sample.cobra", langs="python,rust", modo="mixto"))
+
+    assert rc == 0
+    assert captured["args"].archivo == "sample.cobra"
+    assert captured["args"].lenguajes == ["python", "rust"]
+
+
+def test_build_v2_defaults_target_to_python(monkeypatch):
+    command = BuildCommandV2()
+    captured = {}
+
+    def fake_run(args):
+        captured["args"] = args
+        return 0
+
+    monkeypatch.setattr(command._legacy, "run", fake_run)
+
+    rc = command.run(Namespace(file="sample.cobra", target=None, targets=None, modo="mixto"))
+
+    assert rc == 0
+    assert captured["args"].tipo == "python"
+    assert captured["args"].backend == "python"
+
+
+def test_build_v2_requires_sqlite_key_enabled():
+    assert BuildCommandV2.requires_sqlite_key is True


### PR DESCRIPTION
### Motivation
- Repair three high-priority regressions introduced by the v2 CLI wrappers: `--ui v2 test` forwarded raw language strings, `--ui v2 build` passed `None` for target (breaking legacy validation), and `--ui v2 build` bypassed the `SQLITE_DB_KEY` gate.
- Ensure v2 wrappers preserve legacy behavior and validation semantics when delegating to existing commands.

### Description
- `TestCommandV2` now imports and uses `parse_restricted_target_list` to normalize `args.langs` so the wrapper forwards a parsed list as `lenguajes` to `VerifyCommand` instead of a raw string (file: `src/pcobra/cobra/cli/commands_v2/test_cmd.py`).
- `BuildCommandV2` sets `requires_sqlite_key: bool = True` to restore top-level sqlite key enforcement and maps a missing `--target` to the canonical default `"python"` for both `tipo` and `backend` before delegating to `CompileCommand` (file: `src/pcobra/cobra/cli/commands_v2/build_cmd.py`).
- Added focused unit tests that exercise the wrappers: `tests/unit/cli/commands/test_commands_v2_wrappers.py` which verifies language parsing, default target mapping, and the `requires_sqlite_key` flag on `BuildCommandV2`.

### Testing
- Ran `python -m compileall -q src/pcobra/cobra/cli/commands_v2/test_cmd.py src/pcobra/cobra/cli/commands_v2/build_cmd.py tests/unit/cli/commands/test_commands_v2_wrappers.py`, which succeeded with no syntax errors. 
- Ran `pytest -q tests/unit/cli/commands/test_commands_v2_wrappers.py`, which failed during import/collection due to a pre-existing canonical target-policy mismatch in `compile_cmd` (a `RuntimeError` from `build_target_help_by_tier`) and not because of the wrapper changes. 
- The new wrapper unit tests were added and validate the intended behavior when the surrounding target-policy initialization error is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e484f48a00832781fd225c38f9f1bb)