### PR TITLE
fix(orchestrator): respetar backend explícito antes de metadata de módulo

### DIFF
--- a/src/pcobra/cobra/build/orchestrator.py
+++ b/src/pcobra/cobra/build/orchestrator.py
@@ -46,26 +46,25 @@ class BuildOrchestrator:
     ) -> BackendResolution:
         config = get_toml_map()
         normalized_preferred = self._normalize_optional_target(preferred_backend)
-        project_type = self._project_type(config)
-        module_meta = self._module_metadata(config, source_file)
-
-        module_target = self._normalize_optional_target(
-            module_meta.get("preferred_target")
-            or module_meta.get("target")
-            or module_meta.get("backend")
-        )
-
-        capabilities = self._collect_capabilities(
-            config=config,
-            module_meta=module_meta,
-            requested=required_capabilities,
-        )
 
         if normalized_preferred is not None:
             return BackendResolution(
                 backend=normalized_preferred,
                 reason="preferencia explícita (legacy/CLI)",
             )
+
+        project_type = self._project_type(config)
+        module_meta = self._module_metadata(config, source_file)
+        module_target = self._normalize_optional_target(
+            module_meta.get("preferred_target")
+            or module_meta.get("target")
+            or module_meta.get("backend")
+        )
+        capabilities = self._collect_capabilities(
+            config=config,
+            module_meta=module_meta,
+            requested=required_capabilities,
+        )
 
         ordered_candidates = self._ordered_candidates(
             project_type=project_type,

--- a/tests/unit/test_build_orchestrator.py
+++ b/tests/unit/test_build_orchestrator.py
@@ -43,3 +43,20 @@ def test_build_orchestrator_respeta_preferencia_legacy(monkeypatch):
 
     assert resolution.backend == "rust"
     assert "legacy" in resolution.reason
+
+
+def test_build_orchestrator_preferencia_legacy_evade_metadata_invalida(monkeypatch):
+    monkeypatch.setattr(
+        "cobra.build.orchestrator.get_toml_map",
+        lambda: {
+            "modulos": {
+                "demo.co": {
+                    "preferred_target": "backend-invalido",
+                }
+            }
+        },
+    )
+
+    resolution = BuildOrchestrator().resolve_backend(source_file="demo.co", preferred_backend="python")
+
+    assert resolution.backend == "python"


### PR DESCRIPTION
### Motivation

- Corregir una regresión donde una preferencia explícita de backend (legacy/CLI) quedaba bloqueada por metadata inválida en `cobra.toml` durante la resolución centralizada en `BuildOrchestrator.resolve_backend`.
- Restaurar la compatibilidad anterior que permitía forzar un backend válido desde la CLI aun cuando `modulos.<file>.preferred_target/target/backend` fuera stale o inválido.

### Description

- Reordené `BuildOrchestrator.resolve_backend` para normalizar y comprobar `preferred_backend` primero y devolverla inmediatamente cuando está presente y válida, evitando así la lectura/normalización de metadata de módulo antes de aplicar la preferencia explícita (`src/pcobra/cobra/build/orchestrator.py`).
- Mantengo intacta la lógica de resolución por metadata, tipo de proyecto y capacidades para los casos sin preferencia explícita, ejecutándola solo cuando `preferred_backend` no está presente.
- Añadí una prueba de regresión `test_build_orchestrator_preferencia_legacy_evade_metadata_invalida` que verifica que una metadata de módulo inválida no impide el uso de la preferencia explícita (`tests/unit/test_build_orchestrator.py`).

### Testing

- Ejecuté `pytest -q tests/unit/test_build_orchestrator.py` y obtuvo `4 passed` (incluye la nueva prueba de regresión).
- Verifiqué la validez sintáctica mediante `python -m py_compile src/pcobra/cobra/build/orchestrator.py tests/unit/test_build_orchestrator.py` sin errores.
- No se ejecutó la batería completa de pruebas del repositorio en esta rama; las comprobaciones realizadas se enfocaron en el módulo y las pruebas unitarias añadidas que validan el comportamiento corregido.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4868bbec48327a12f06e93754b6b7)