### PR TITLE
[PR #1930 follow-up] Bloquear publicación con manifiestos stdlib malformados

### DIFF
--- a/src/pcobra/cobra/semantico/mod_validator.py
+++ b/src/pcobra/cobra/semantico/mod_validator.py
@@ -312,10 +312,10 @@ def _validate_stdlib_contract_manifest(name: str, contract: Dict[str, Any]) -> l
 
 def _validate_stdlib_contracts() -> list[str]:
     contracts = module_map.get_stdlib_contracts()
+    errors = module_map.get_stdlib_contract_load_errors()
     if not contracts:
-        return []
+        return errors
 
-    errors: list[str] = []
     for name, contract in contracts.items():
         if not name.startswith("cobra."):
             errors.append(

--- a/src/pcobra/cobra/transpilers/module_map.py
+++ b/src/pcobra/cobra/transpilers/module_map.py
@@ -33,17 +33,20 @@ STDLIB_CONTRACTS_DIR = os.path.abspath(
 )
 
 _stdlib_contract_cache: dict[str, Dict[str, Any]] | None = None
+_stdlib_contract_load_errors: list[str] | None = None
 
 
 def _load_stdlib_contracts() -> dict[str, Dict[str, Any]]:
     """Carga manifiestos contractuales de ``stdlib_contract``."""
-    global _stdlib_contract_cache
+    global _stdlib_contract_cache, _stdlib_contract_load_errors
     if _stdlib_contract_cache is not None:
         return _stdlib_contract_cache
 
     loaded: dict[str, Dict[str, Any]] = {}
+    errors: list[str] = []
     if not os.path.isdir(STDLIB_CONTRACTS_DIR):
         _stdlib_contract_cache = loaded
+        _stdlib_contract_load_errors = errors
         return loaded
 
     for entry in sorted(os.listdir(STDLIB_CONTRACTS_DIR)):
@@ -53,19 +56,38 @@ def _load_stdlib_contracts() -> dict[str, Dict[str, Any]]:
         try:
             with open(contract_path, 'rb') as handle:
                 parsed = tomllib.load(handle)
-        except (OSError, tomllib.TOMLDecodeError):
+        except OSError as exc:
             logger.warning('No se pudo cargar manifest contractual: %s', contract_path)
+            errors.append(
+                "No se pudo leer manifest contractual: "
+                f"{entry} ({exc.__class__.__name__}: {exc})"
+            )
+            continue
+        except tomllib.TOMLDecodeError as exc:
+            logger.warning('No se pudo parsear manifest contractual: %s', contract_path)
+            errors.append(
+                "Manifest contractual inválido (TOML malformado): "
+                f"{entry} ({exc})"
+            )
             continue
         if isinstance(parsed, dict):
             loaded[entry] = parsed
 
     _stdlib_contract_cache = loaded
+    _stdlib_contract_load_errors = errors
     return loaded
 
 
 def get_stdlib_contracts() -> Dict[str, Dict[str, Any]]:
     """Devuelve todos los manifiestos contractuales cargados."""
     return dict(_load_stdlib_contracts())
+
+
+def get_stdlib_contract_load_errors() -> list[str]:
+    """Devuelve errores de carga/parseo detectados en manifests stdlib."""
+    if _stdlib_contract_cache is None:
+        _load_stdlib_contracts()
+    return list(_stdlib_contract_load_errors or [])
 
 
 def get_stdlib_contract(module: str) -> Dict[str, Any]:

--- a/tests/unit/test_mod_validator.py
+++ b/tests/unit/test_mod_validator.py
@@ -247,3 +247,27 @@ def test_validador_falla_si_manifest_stdlib_contract_invalido(tmp_path, monkeypa
 
     with pytest.raises(ValueError, match="fallback_permitido contiene backend no oficial"):
         validar_mod(str(tmp_path / "cobra.mod"))
+
+
+def test_validador_falla_si_manifest_stdlib_contract_no_parsea(tmp_path, monkeypatch):
+    py = tmp_path / "m.py"
+    py.write_text("x = 1")
+    mod = tmp_path / "m.co"
+    data = {str(mod): {"version": "0.1.0", "python": str(py)}}
+    _write_yaml(tmp_path / "cobra.mod", data)
+
+    monkeypatch.setattr(
+        "cobra.semantico.mod_validator.module_map.get_toml_map",
+        lambda: {"project": {"required_targets": ["python"]}},
+    )
+    monkeypatch.setattr(
+        "cobra.semantico.mod_validator.module_map.get_stdlib_contracts",
+        lambda: {},
+    )
+    monkeypatch.setattr(
+        "cobra.semantico.mod_validator.module_map.get_stdlib_contract_load_errors",
+        lambda: ["Manifest contractual inválido (TOML malformado): cobra.web (line 1, column 1)"],
+    )
+
+    with pytest.raises(ValueError, match="TOML malformado"):
+        validar_mod(str(tmp_path / "cobra.mod"))


### PR DESCRIPTION
### Motivation
- Corregir un bug de prioridad alta donde errores de lectura/parseo (`TOMLDecodeError`/`OSError`) en `stdlib_contract/` se ignoraban y no llegaban a la validación, permitiendo publicar con manifests sintácticamente rotos.  
- Asegurar que la nueva "validación de manifiestos" bloquee la publicación cuando exista cualquier manifiesto stdlib inválido o ilegible.  

### Description
- Se añadió captura y acumulación de errores de carga en `src/pcobra/cobra/transpilers/module_map.py` mediante una cache `_stdlib_contract_load_errors` y la API `get_stdlib_contract_load_errors()`.  
- La función `_load_stdlib_contracts()` ahora distingue `OSError` y `TOMLDecodeError`, registra mensajes detallados y guarda esos errores para ser consultados por el validador.  
- `src/pcobra/cobra/semantico/mod_validator.py` fue actualizado para incorporar los errores de carga retornados por `module_map.get_stdlib_contract_load_errors()` en `_validate_stdlib_contracts()`, de modo que `validar_mod()` falle cuando existan errores de lectura/parseo.  
- Se añadió un test que comprueba explícitamente que la validación falla ante un manifiesto stdlib con error de parseo (`tests/unit/test_mod_validator.py::test_validador_falla_si_manifest_stdlib_contract_no_parsea`) y se mantuvo el test de resolución contractual en `module_map`.  

### Testing
- Ejecutado `pytest -q tests/unit/test_mod_validator.py::test_validador_falla_si_manifest_stdlib_contract_invalido tests/unit/test_mod_validator.py::test_validador_falla_si_manifest_stdlib_contract_no_parsea tests/unit/test_module_map.py::test_module_map_resuelve_backend_por_contrato_stdlib` y los tres tests pasaron (`3 passed`).  
- Los cambios garantizan que errores de lectura/parseo en `stdlib_contract/` se incluyan en el listado de errores devuelto por `validar_mod()` y así bloqueen la publicación cuando corresponda.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4877c4e488327aa731fb807994cae)