### PR TITLE
Fix explicit cobra.* import precedence over local modules

### DIFF
--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -150,6 +150,8 @@ class CobraImportResolver:
     def _resolve_local_module(self, name: str) -> ResolutionResult | None:
         if self.project_root is None:
             return None
+        if name.startswith("cobra."):
+            return None
 
         relative = Path(*name.split("."))
         local_patterns = (

--- a/tests/unit/test_imports_resolver.py
+++ b/tests/unit/test_imports_resolver.py
@@ -22,8 +22,10 @@ def test_resuelve_modulo_local_antes_que_stdlib_y_bridge(tmp_path):
     assert result.resolved_name == "datos"
 
 
-def test_prefiere_namespace_explicito_cobra_datos():
-    resolver = CobraImportResolver()
+def test_prefiere_namespace_explicito_cobra_datos_aun_si_existe_local(tmp_path):
+    (tmp_path / "cobra").mkdir()
+    (tmp_path / "cobra" / "datos.co").write_text("usar local")
+    resolver = CobraImportResolver(project_root=tmp_path)
 
     result = resolver.resolve("cobra.datos")
 


### PR DESCRIPTION
### Motivation
- Evitar que imports calificados del namespace `cobra.*` sean resueltos contra archivos locales del repositorio (por ejemplo `cobra/datos.co`) y cambien silenciosamente el comportamiento en tiempo de ejecución.
- Añadir cobertura de regresión para garantizar que `resolve("cobra.datos")` prefiera la stdlib aun cuando exista un árbol `cobra/` en el proyecto.

### Description
- Evitar la comprobación de archivos locales para peticiones que empiecen con `cobra.` añadiendo un `return None` al inicio de `_resolve_local_module` cuando el nombre comienza con `cobra.`.
- Actualizar el test `test_prefiere_namespace_explicito_cobra_datos` (renombrado a `test_prefiere_namespace_explicito_cobra_datos_aun_si_existe_local`) para crear `cobra/datos.co` en un `tmp_path` y verificar que la resolución usa `pcobra.standard_library.datos`.

### Testing
- Ejecutado `pytest -q tests/unit/test_imports_resolver.py` y los tests unitarios pasaron correctamente (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e488a718d883278ec8d97856551f3f)