### PR TITLE
Follow-up: avoid stdout warnings in phase-1 advanced profile policy

### DIFF
--- a/src/pcobra/cobra/cli/deprecation_policy.py
+++ b/src/pcobra/cobra/cli/deprecation_policy.py
@@ -102,7 +102,7 @@ def enforce_advanced_profile_policy(*, command: str, args: Namespace | object | 
     )
     if phase < 2:
         if profile != "avanzado":
-            mostrar_advertencia(
+            logging.getLogger(__name__).warning(
                 _("El comando '{command}' expone capacidades avanzadas de backend; use --perfil avanzado.").format(
                     command=command
                 )

--- a/tests/unit/test_deprecation_policy.py
+++ b/tests/unit/test_deprecation_policy.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+
+import pytest
+
+import cobra.cli.deprecation_policy as policy
+
+
+def test_enforce_advanced_profile_phase1_does_not_emit_stdout_warning(monkeypatch, caplog):
+    monkeypatch.setenv(policy.DEPRECATION_PHASE_ENV, "1")
+    monkeypatch.delenv(policy.LEGACY_TARGETS_MODE_ENV, raising=False)
+
+    stdout_warnings: list[str] = []
+    monkeypatch.setattr(policy, "mostrar_advertencia", lambda msg: stdout_warnings.append(msg))
+
+    policy.enforce_advanced_profile_policy(command="bench", args=SimpleNamespace(perfil="publico"))
+
+    assert stdout_warnings == []
+    assert "advanced_command_usage" in caplog.text
+    assert "--perfil avanzado" in caplog.text
+
+
+def test_enforce_advanced_profile_phase2_requires_avanzado_or_legacy(monkeypatch):
+    monkeypatch.setenv(policy.DEPRECATION_PHASE_ENV, "2")
+    monkeypatch.delenv(policy.LEGACY_TARGETS_MODE_ENV, raising=False)
+
+    with pytest.raises(ValueError):
+        policy.enforce_advanced_profile_policy(command="bench", args=SimpleNamespace(perfil="publico"))


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where `enforce_advanced_profile_policy` emitted user-facing warnings to stdout via `mostrar_advertencia`, which prepended lines to machine-readable command output (e.g., JSON from `bench`) and broke consumers.

### Description
- Replace the phase-1 user-facing `mostrar_advertencia(...)` call with a `logging.getLogger(__name__).warning(...)` call inside `enforce_advanced_profile_policy` to keep warnings out of stdout.
- Add `tests/unit/test_deprecation_policy.py` with tests that assert phase-1 does not write warnings to stdout and that phase-2 still raises `ValueError` when `perfil` is not `avanzado` and legacy mode is disabled.
- Preserve existing telemetry logging (`advanced_command_usage`) and otherwise leave enforcement behavior for phase 2 and legacy mode unchanged.

### Testing
- Ran `pytest -q tests/unit/test_deprecation_policy.py` and the focused tests passed (`2 passed`).
- Attempted a broader bench-related test collection (`pytest -q tests/unit/test_deprecation_policy.py tests/unit/test_bench_cmd.py tests/unit/test_benchmarks2_cmd.py tests/unit/test_bench_transpilers_cmd.py tests/unit/test_cli_transpilar_inverso_cmd.py`) but collection failed due to an unrelated import error in `tests/unit/test_bench_cmd.py` before test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e489928220832798a74532a506b77a)