### PR TITLE
docs: aclarar gate `--ui v2` y eliminar `--backend` no soportado en guía v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,9 @@ Este comportamiento solo aplica al arranque de la CLI (`pcobra/cli.py`) y mantie
 
 ### CLI simplificada (interfaz oficial)
 
-La interfaz recomendada se organiza en cuatro comandos base:
+> **Importante:** la CLI usa `--ui v1` por defecto actualmente. Para usar la interfaz unificada (`run/build/test/mod`) debes activar explícitamente `--ui v2`.
+
+La interfaz recomendada (en modo `--ui v2`) se organiza en cuatro comandos base:
 
 - `cobra run`: ejecutar programas Cobra.
 - `cobra build`: transpilación y artefactos por backend oficial.
@@ -294,10 +296,10 @@ La interfaz recomendada se organiza en cuatro comandos base:
 Ejemplos rápidos:
 
 ```bash
-cobra run archivo.co
-cobra build hola.co --backend python
-cobra test
-cobra mod list
+cobra --ui v2 run archivo.co
+cobra --ui v2 build hola.co
+cobra --ui v2 test
+cobra --ui v2 mod list
 ```
 
 Para listar todas las opciones disponibles:
@@ -306,7 +308,7 @@ Para listar todas las opciones disponibles:
 cobra --help
 ```
 
-Backends oficiales públicos para `cobra build`: `python`, `javascript`, `rust`.
+En `cobra --ui v2 build`, la selección de backend se resuelve internamente (sin flag `--backend`) sobre los backends públicos oficiales: `python`, `javascript`, `rust`.
 
 Más detalle técnico de capas y contratos internos en [docs/architecture/unified-ecosystem.md](docs/architecture/unified-ecosystem.md).
 
@@ -316,7 +318,7 @@ Si vienes de comandos legacy (`cobra compilar`, `cobra modulos`) o de flujos cen
 
 ### Compatibilidad legacy
 
-Los proyectos antiguos pueden seguir funcionando con aliases legacy y con el modo de compatibilidad. Recomendamos mantenerlos solo como transición y migrar progresivamente a `run/build/test/mod`.
+Los proyectos antiguos pueden seguir funcionando con aliases legacy y con el modo de compatibilidad. Recomendamos mantenerlos solo como transición y migrar progresivamente a `--ui v2` con `run/build/test/mod`.
 
 ### Validar sintaxis (paso a paso)
 

--- a/docs/migracion_cli_unificada.md
+++ b/docs/migracion_cli_unificada.md
@@ -6,10 +6,10 @@ Esta guía ayuda a migrar desde comandos legacy y flujos dependientes de flags d
 
 Adoptar el modelo unificado:
 
-- `cobra run`
-- `cobra build`
-- `cobra test`
-- `cobra mod`
+- `cobra --ui v2 run`
+- `cobra --ui v2 build`
+- `cobra --ui v2 test`
+- `cobra --ui v2 mod`
 
 Con backends públicos oficiales:
 
@@ -21,26 +21,27 @@ Con backends públicos oficiales:
 
 | Legacy | Nuevo comando recomendado |
 |---|---|
-| `cobra archivo.co` | `cobra run archivo.co` |
-| `cobra compilar archivo.co --backend <target>` | `cobra build archivo.co --backend <target>` |
-| `cobra modulos listar` | `cobra mod list` |
-| `cobra modulos instalar ruta/al/modulo.co` | `cobra mod install ruta/al/modulo.co` |
-| `cobra modulos remover modulo.co` | `cobra mod remove modulo.co` |
+| `cobra archivo.co` | `cobra --ui v2 run archivo.co` |
+| `cobra compilar archivo.co --backend <target>` | `cobra --ui v2 build archivo.co` |
+| `cobra modulos listar` | `cobra --ui v2 mod list` |
+| `cobra modulos instalar ruta/al/modulo.co` | `cobra --ui v2 mod install ruta/al/modulo.co` |
+| `cobra modulos remover modulo.co` | `cobra --ui v2 mod remove modulo.co` |
 
-## Migración de flags `--backend`
+## Migración de selección de backend
 
 1. Identifica usos de backends no públicos en scripts/CI (`go`, `cpp`, `java`, `wasm`, `asm`).
-2. Sustituye por uno de los oficiales según necesidad:
+2. En `cobra --ui v2 build`, elimina `--backend`: la selección se resuelve internamente por el orquestador.
+3. Alinea artefactos/pipelines hacia uno de los oficiales según necesidad:
    - `python`: máxima cobertura SDK.
    - `javascript`: integración Node/web.
    - `rust`: compilación nativa y rendimiento.
-3. Estandariza pipelines para que `build` y validaciones usen exclusivamente `python`, `javascript` o `rust`.
+4. Estandariza pipelines para que `build` y validaciones apunten al conjunto oficial `python`, `javascript` o `rust`.
 
 ## Plan de migración recomendado (paso a paso)
 
 1. **Inventario**: lista comandos legacy usados en repositorio y CI.
-2. **Sustitución**: aplica mapeo a `run/build/test/mod`.
-3. **Backends**: elimina targets no públicos en flags `--backend`.
+2. **Sustitución**: aplica mapeo a `--ui v2` con `run/build/test/mod`.
+3. **Backends**: elimina flags `--backend` en comandos v2 y retira targets no públicos de pipelines.
 4. **Validación**: ejecuta pruebas/regresión del proyecto.
 5. **Limpieza**: documenta fecha de retiro interno de aliases legacy.
 


### PR DESCRIPTION
### Motivation
- Corregir inconsistencias entre la documentación y el parser real de la CLI, donde `README.md` mostraba comandos v2 como top-level aunque la CLI sigue en `--ui v1` por defecto. 
- Evitar que la guía de migración promueva la opción `--backend` para `build` v2 cuando `BuildCommandV2` no acepta ese flag.

### Description
- Actualiza `README.md` para advertir que la CLI usa `--ui v1` por defecto y que la interfaz unificada se activa con `--ui v2`, además de ajustar los ejemplos a `cobra --ui v2 ...` y aclarar que `build` v2 resuelve el backend internamente (sin `--backend`).
- Modifica `docs/migracion_cli_unificada.md` para mapear comandos legacy a las formas `cobra --ui v2 ...` y eliminar el uso de `--backend` en las recomendaciones de `build`, reescribiendo la sección de migración de selección de backend para reflejar la resolución por el orquestador.
- Archivos modificados: `README.md` y `docs/migracion_cli_unificada.md`.

### Testing
- Ejecuté `git diff --check` y no reportó errores (éxito). 
- Ejecuté `python -m pytest -k "build and v2"`, la colección de tests falló por aserciones globales en `tests/utils/targets.py` (`SUPPORTED_TARGETS != EXPECTED_CANONICAL_TARGETS`), lo cual parece una precondición de tests de integración no relacionada con este cambio de documentación (fallo en la colección, no en lógica aplicada a los docs).
- No se ejecutaron tests que validen cambios de documentación en tiempo de ejecución porque las modificaciones son de contenido estático (no se cambiaron parsers ni comandos en código).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48aae9b0c8327a09a08d9f7d03967)