### PR TITLE
[PR #1941 follow-up] Fix resolver ModuleNotFoundError fallback in usar_loader

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -172,7 +172,7 @@ def obtener_modulo(nombre: str):
     resolver = CobraImportResolver(project_root=base.parents[3])
     try:
         _, module = resolver.load_module(nombre, fallback_backend="python")
-    except ImportResolutionError:
+    except (ImportResolutionError, ModuleNotFoundError):
         module = None
     else:
         if module is not None:

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -170,3 +170,24 @@ def test_obtener_modulo_delega_en_nuevo_resolver(monkeypatch):
     mod = usar_loader.obtener_modulo('json')
 
     assert mod is mock_mod
+
+
+def test_obtener_modulo_hace_fallback_si_resolver_lanza_module_not_found(monkeypatch):
+    mock_mod = ModuleType('json')
+    monkeypatch.setitem(usar_loader.USAR_WHITELIST, 'json', 'json')
+
+    class FakeResolver:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def load_module(self, *_args, **_kwargs):
+            raise ModuleNotFoundError("pcobra.standard_library.core")
+
+    from pcobra.cobra.imports import resolver as imports_resolver
+
+    monkeypatch.setattr(imports_resolver, 'CobraImportResolver', FakeResolver)
+    monkeypatch.setattr(usar_loader.importlib, 'import_module', lambda name: mock_mod)
+
+    mod = usar_loader.obtener_modulo('json')
+
+    assert mod is mock_mod


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where `CobraImportResolver.load_module(...)` raising `ModuleNotFoundError` aborted `obtener_modulo` early and prevented the existing fallback import chain from running. 
- Preserve backward-compatible behavior so whitelisted modules that are loadable via the previous fallbacks (`importlib`, `corelibs`, `standard_library`, or pip) still resolve when a resolver candidate lacks a runtime module.

### Description
- Updated `src/pcobra/cobra/usar_loader.py` so the `try`/`except` around `resolver.load_module(...)` catches both `ImportResolutionError` and `ModuleNotFoundError` and continues to the fallback logic when either occurs. 
- Added a regression test `test_obtener_modulo_hace_fallback_si_resolver_lanza_module_not_found` in `tests/unit/test_usar.py` which simulates the resolver raising `ModuleNotFoundError` and verifies `obtener_modulo` falls back to direct import successfully. 

### Testing
- Ran `pytest -q tests/unit/test_usar.py` and the suite completed successfully with all tests passing (`11 passed`). 
- The newly added regression test passed and confirms the fallback path is reachable when the resolver raises `ModuleNotFoundError`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48b6dd6a883278e4c0572aa5b7f9f)