### PR TITLE
Allow `--contenedor=python`: fix RuntimeManager container validation regression

### DIFF
--- a/src/pcobra/cobra/bindings/runtime_manager.py
+++ b/src/pcobra/cobra/bindings/runtime_manager.py
@@ -72,11 +72,6 @@ class RuntimeManager:
         capabilities, _bridge = self.resolve_runtime(language)
         route = capabilities.route
 
-        if route is BindingRoute.PYTHON_DIRECT_IMPORT and containerized:
-            raise ValueError(
-                "La ruta python_direct_import no puede marcarse como containerizada. "
-                "Use bridge Python directo (mismo proceso) o ruta de runtime gestionado."
-            )
         if route is BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE and not (sandbox or containerized):
             raise ValueError(
                 "La ruta javascript_runtime_bridge requiere runtime gestionado "

--- a/tests/unit/test_runtime_manager.py
+++ b/tests/unit/test_runtime_manager.py
@@ -31,3 +31,9 @@ def test_runtime_manager_valida_abi_por_ruta():
         assert "Versiones soportadas" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("Se esperaba error ABI por versión no soportada")
+
+
+def test_runtime_manager_permite_python_en_contenedor():
+    manager = RuntimeManager()
+
+    manager.validate_security_route("python", sandbox=False, containerized=True)


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where `RuntimeManager.validate_security_route` unconditionally rejected the `python_direct_import` route when `containerized=True`, causing `--contenedor=python` to fail before `ejecutar_en_contenedor(...)` could run. 

### Description
- Removed the guard in `RuntimeManager.validate_security_route` that raised for `BindingRoute.PYTHON_DIRECT_IMPORT` with `containerized=True` so Python container execution reaches `ejecutar_en_contenedor`. 
- Preserved the existing security checks for JavaScript (requires managed runtime: sandbox or container) and Rust FFI (disallowed in Python sandbox). 
- Added `test_runtime_manager_permite_python_en_contenedor` in `tests/unit/test_runtime_manager.py` to assert Python is permitted in container execution mode. 

### Testing
- Ran `pytest -q tests/unit/test_runtime_manager.py tests/unit/test_execute_cmd_binding_contract.py` and the suite completed successfully with `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48c3ae13483278e639a01e474392d)