### PR TITLE
[PR #1943 Follow-up] Allow internal legacy targets in BuildOrchestrator when feature flag set

### DIFF
--- a/src/pcobra/cobra/build/orchestrator.py
+++ b/src/pcobra/cobra/build/orchestrator.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from pcobra.cobra.cli.internal_compat.legacy_targets import enabled_internal_legacy_targets
 from pcobra.cobra.config.transpile_targets import OFFICIAL_TARGETS, target_metadata
 from pcobra.cobra.transpilers.module_map import get_toml_map
 from pcobra.cobra.transpilers.target_utils import normalize_target_name
@@ -94,9 +95,10 @@ class BuildOrchestrator:
         if not isinstance(value, str) or not value.strip():
             return None
         canonical = normalize_target_name(value)
-        if canonical not in OFFICIAL_TARGETS:
+        allowed_targets = OFFICIAL_TARGETS + enabled_internal_legacy_targets()
+        if canonical not in allowed_targets:
             raise ValueError(
-                f"Backend no permitido: {value}. Permitidos: {', '.join(OFFICIAL_TARGETS)}"
+                f"Backend no permitido: {value}. Permitidos: {', '.join(allowed_targets)}"
             )
         return canonical
 

--- a/tests/unit/test_build_orchestrator.py
+++ b/tests/unit/test_build_orchestrator.py
@@ -43,3 +43,28 @@ def test_build_orchestrator_respeta_preferencia_legacy(monkeypatch):
 
     assert resolution.backend == "rust"
     assert "legacy" in resolution.reason
+
+
+def test_build_orchestrator_permite_backend_internal_only_con_flag(monkeypatch):
+    monkeypatch.setattr("cobra.build.orchestrator.get_toml_map", lambda: {})
+    monkeypatch.setenv("COBRA_INTERNAL_LEGACY_TARGETS", "1")
+
+    resolution = BuildOrchestrator().resolve_backend(source_file="demo.co", preferred_backend="go")
+
+    assert resolution.backend == "go"
+    assert "legacy" in resolution.reason
+
+
+def test_build_orchestrator_rechaza_backend_internal_only_sin_flag(monkeypatch):
+    monkeypatch.setattr("cobra.build.orchestrator.get_toml_map", lambda: {})
+    monkeypatch.delenv("COBRA_INTERNAL_LEGACY_TARGETS", raising=False)
+
+    try:
+        BuildOrchestrator().resolve_backend(source_file="demo.co", preferred_backend="go")
+    except ValueError as exc:
+        error = str(exc)
+    else:
+        raise AssertionError("Se esperaba ValueError para backend internal-only sin flag")
+
+    assert "Backend no permitido" in error
+    assert "go" not in error.split("Permitidos: ", 1)[-1]


### PR DESCRIPTION
### Motivation

- Fix a high-priority regression where `parse_target` accepted internal legacy backends under the temporary `COBRA_INTERNAL_LEGACY_TARGETS` flag but orchestration/runtime resolution rejected them, causing `cobra compilar --tipo go` to fail at runtime.
- Keep the temporary migration gate so internal-only targets remain hidden by default while allowing a controlled compatibility path for teams that opt in.

### Description

- Updated `BuildOrchestrator._normalize_optional_target` to consult `enabled_internal_legacy_targets()` and permit internal legacy backends in addition to `OFFICIAL_TARGETS` when the feature flag is active by constructing `allowed_targets = OFFICIAL_TARGETS + enabled_internal_legacy_targets()`.
- Adjusted the validation error message in `_normalize_optional_target` to list the effective `allowed_targets` so diagnostics reflect the current policy.
- Added unit tests `test_build_orchestrator_permite_backend_internal_only_con_flag` and `test_build_orchestrator_rechaza_backend_internal_only_sin_flag` in `tests/unit/test_build_orchestrator.py` to cover the flagged and unflagged behaviors, and added the necessary import of `enabled_internal_legacy_targets`.

### Testing

- Ran `pytest -q tests/unit/test_build_orchestrator.py tests/unit/test_cli_target_option_validations.py` and the run completed with `30 passed`.
- Executed the new tests verifying that a `preferred_backend="go"` is accepted when `COBRA_INTERNAL_LEGACY_TARGETS=1` and rejected when the flag is not set, and both expectations succeeded.
- No other test failures were observed in the exercised test subset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48d2353a48327a2419bb9a81ab509)