### PR TITLE
Restore generated markers in targets_policy.md to fix docs generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Resumen normativo visible (generado desde la política canónica):
 - **Targets con adaptador Holobit mantenido por el proyecto (partial fuera de python)**: `python`, `javascript`, `rust`.
 - **Compatibilidad SDK completa (solo python)**: `python`.
 - **Targets solo de transpilación**: .
+- **Targets legacy/internal (no públicos)**: go, cpp, java, wasm, asm.
 - **Orígenes de transpilación inversa**: python, javascript, java. Este alcance reverse de entrada está separado de los 3 targets oficiales de salida.
 
 Tiers oficiales de soporte de backends:

--- a/docs/targets_policy.md
+++ b/docs/targets_policy.md
@@ -1,5 +1,8 @@
 # Política normativa de exposición: público vs interno
 
+> ⚠️ Documento parcialmente derivado: los bloques marcados como `BEGIN/END GENERATED`
+> son **obligatorios**, se regeneran automáticamente y no deben editarse manualmente.
+
 Este es el **documento normativo único** para distinguir módulos y superficies **públicas** frente a **internas** en el ecosistema unificado de Cobra.
 
 ## Fuente normativa de backends
@@ -26,6 +29,18 @@ En particular:
 - Implementación de compilación/transpilación: lexer, parser, AST, IR, adapters y transpiladores internos.
 - Backends internos/legacy definidos en `INTERNAL_BACKENDS`.
 
+## Tiers oficiales de backends públicos
+
+<!-- BEGIN GENERATED TARGET TIERS -->
+### Tier 1
+
+- `python`
+- `javascript`
+- `rust`
+
+### Tier 2
+<!-- END GENERATED TARGET TIERS -->
+
 ## API pública estable
 
 | Categoría | Superficie estable |
@@ -33,6 +48,29 @@ En particular:
 | Comandos CLI | `run`, `build`, `test`, `mod` |
 | Backends | `python`, `javascript`, `rust` |
 | Módulos stdlib | `cobra.core`, `cobra.datos`, `cobra.web`, `cobra.system` |
+
+## Estado público por backend
+
+<!-- BEGIN GENERATED TARGET STATUS TABLE -->
+| Backend | Tier | Runtime público | Estado Holobit público | Compatibilidad SDK real |
+|---|---|---|---|---|
+| `python` | Tier 1 | oficial verificable | `full`; usa el contrato completo del SDK Python | completa |
+| `javascript` | Tier 1 | oficial verificable | adaptador mantenido por el proyecto; estado contractual `partial` | parcial |
+| `rust` | Tier 1 | oficial verificable | adaptador mantenido por el proyecto; estado contractual `partial` | parcial |
+<!-- END GENERATED TARGET STATUS TABLE -->
+
+## Alcance contractual de runtime
+
+<!-- BEGIN GENERATED TARGET RUNTIME SPLIT -->
+- `OFFICIAL_RUNTIME_TARGETS`: `python`, `javascript`, `rust`
+- `VERIFICATION_EXECUTABLE_TARGETS`: `python`, `javascript`, `rust`
+- `BEST_EFFORT_RUNTIME_TARGETS`: 
+- `TRANSPILATION_ONLY_TARGETS`: 
+- `NO_RUNTIME_TARGETS`: 
+- `OFFICIAL_STANDARD_LIBRARY_TARGETS`: `python`, `javascript`, `rust`
+- `ADVANCED_HOLOBIT_RUNTIME_TARGETS`: `python`, `javascript`, `rust`
+- `SDK_COMPATIBLE_TARGETS`: `python`
+<!-- END GENERATED TARGET RUNTIME SPLIT -->
 
 ## Declaración explícita de estabilidad en esta fase
 


### PR DESCRIPTION
### Motivation

- The doc rewrite removed the generated-block markers that `scripts/generate_target_policy_docs.py` expects, causing `_inject_between_markers()` to raise `RuntimeError` and breaking the docs-generation CI step.
- Restore the markers and generated sections so the generator can safely inject/upsert derived content while preserving the new public/internal policy narrative.

### Description

- Reinserted the required markers in `docs/targets_policy.md`: `<!-- BEGIN/END GENERATED TARGET TIERS -->`, `<!-- BEGIN/END GENERATED TARGET STATUS TABLE -->`, and `<!-- BEGIN/END GENERATED TARGET RUNTIME SPLIT -->` and restored the wrapped generated content (tiers, status table, runtime split) so marker-based injection works.
- Ran the generator to regenerate the policy summary and runtime-derived artifacts and updated the visible summary in `README.md` to match the generated output.
- Kept the formalized public/internal policy text and links to the canonical source (`src/pcobra/cobra/architecture/backend_policy.py`) intact while making the file compatible with automated regeneration.

### Testing

- Ran `python scripts/generate_target_policy_docs.py` and it completed successfully, producing/refreshing the generated sections and updating `README.md` and `docs/targets_policy.md` as expected.
- No unit tests were modified or required for this documentation-only fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48f469f5c83279b8b31d0ae57f19d)