### PR TITLE
Restore no-arg interactive default when UI v2 is selected

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -189,6 +189,20 @@ class CommandRegistry:
                 logging.error(f"Failed to register subparser for {command.name}: {e}")
                 del self.commands[command.name]
 
+        if (
+            ui == "v2"
+            and self.default_command_name == "interactive"
+            and "interactive" not in self.commands
+            and self.interpreter is not None
+        ):
+            try:
+                self.commands["interactive"] = InteractiveCommand(self.interpreter)
+            except Exception as exc:
+                logging.getLogger(__name__).warning(
+                    "No fue posible preparar comando default interactivo en ui=v2: %s",
+                    exc,
+                )
+
         if self.default_command_name not in self.commands:
             fallback = "interactive" if "interactive" in self.commands else next(iter(self.commands), None)
             logging.warning(

--- a/tests/unit/test_cli_default_command.py
+++ b/tests/unit/test_cli_default_command.py
@@ -28,6 +28,21 @@ def test_default_command_runs_interactive():
     assert result == 0
 
 
+
+
+def test_default_command_stays_interactive_when_ui_v2_is_default():
+    with ExitStack() as stack:
+        _patch_cli_env(stack)
+        stack.enter_context(patch("cobra.cli.cli.AppConfig.V2_COMMAND_CLASSES", []))
+        stack.enter_context(patch("cobra.cli.cli.AppConfig.DEFAULT_COMMAND", "interactive"))
+        mock_run = stack.enter_context(patch("cobra.cli.cli.InteractiveCommand.run", return_value=0))
+        app = CliApplication()
+
+        result = app.run([])
+
+    assert result == 0
+    mock_run.assert_called_once()
+
 def test_unknown_command_shows_error_and_help():
     with ExitStack() as stack:
         _patch_cli_env(stack)


### PR DESCRIPTION
### Motivation
- Defaulting the CLI `--ui` to `v2` caused a regression where invoking `main([])` registered only v2 public commands while `AppConfig.DEFAULT_COMMAND` remained `interactive`, which made the no-arg path fall back to `run` and fail because `RunCommandV2` requires a positional `file` argument. 
- The goal is to preserve the previous no-arg interactive behavior while keeping the v2 public surface unchanged.

### Description
- Modified `CommandRegistry.register_base_commands` to inject an internal `InteractiveCommand` into `self.commands` when `ui == "v2"`, `self.default_command_name == "interactive"`, `"interactive"` is not already present, and `self.interpreter` is available, so the no-arg default continues to resolve to interactive without exposing it as a public v2 subparser. (`src/pcobra/cobra/cli/cli.py`) 
- The injected `interactive` command is prepared but not registered as a public subparser, preserving v2 help output while restoring expected default behavior. (`src/pcobra/cobra/cli/cli.py`) 
- Added a unit test `test_default_command_stays_interactive_when_ui_v2_is_default` to `tests/unit/test_cli_default_command.py` that asserts running the app with no args under the v2-default configuration executes `InteractiveCommand.run`.

### Testing
- Successfully type-compiled the modified files with `python -m compileall -q src/pcobra/cobra/cli/cli.py tests/unit/test_cli_default_command.py` (passed). 
- Attempted to run the focused unit tests with `pytest -q tests/unit/test_cli_default_command.py`, but test collection was blocked by a pre-existing import error `ImportError: cannot import name 'LANG_CHOICES' from pcobra.cobra.cli.commands.compile_cmd`, which prevented running the new test (failure unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48ff76bd48327bf5faf36b85db0d4)