### PR TITLE
Fix run/test v2 to avoid backend-resolution failures from unrelated module metadata

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/run_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/run_cmd.py
@@ -1,7 +1,6 @@
 from argparse import Namespace
 from typing import Any
 
-from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
 from pcobra.cobra.cli.i18n import _
@@ -33,8 +32,6 @@ class RunCommandV2(BaseCommand):
         return parser
 
     def run(self, args: Any) -> int:
-        debug = bool(getattr(args, "debug", False))
-        resolution = backend_pipeline.resolve_backend(args.file, {})
         legacy_args = Namespace(
             archivo=args.file,
             debug=bool(getattr(args, "debug", False)),
@@ -42,6 +39,5 @@ class RunCommandV2(BaseCommand):
             contenedor=getattr(args, "container", None),
             formatear=bool(getattr(args, "formatear", False)),
             modo=getattr(args, "modo", "mixto"),
-            backend_reason=resolution.reason_for(debug=debug),
         )
         return self._legacy.run(legacy_args)

--- a/src/pcobra/cobra/cli/commands_v2/test_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/test_cmd.py
@@ -1,7 +1,6 @@
 from argparse import Namespace
 from typing import Any
 
-from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
 from pcobra.cobra.cli.i18n import _
@@ -43,13 +42,10 @@ class TestCommandV2(BaseCommand):
         return parser
 
     def run(self, args: Any) -> int:
-        debug = bool(getattr(args, "debug", False))
-        resolution = backend_pipeline.resolve_backend(args.file, {})
         langs = getattr(args, "langs", self._default_langs)
         legacy_args = Namespace(
             archivo=args.file,
             lenguajes=langs,
             modo=getattr(args, "modo", "mixto"),
-            backend_reason=resolution.reason_for(debug=debug),
         )
         return self._legacy.run(legacy_args)

--- a/tests/unit/test_cli_v2_command_contract.py
+++ b/tests/unit/test_cli_v2_command_contract.py
@@ -55,3 +55,57 @@ def test_build_v2_resuelve_backend_via_pipeline(monkeypatch):
     )
     assert status == 0
     assert "resolution" in called
+
+
+def test_run_v2_no_resuelve_backend_antes_de_delegar(monkeypatch):
+    command = RunCommandV2()
+
+    import cobra.cli.commands_v2.run_cmd as run_cmd_module
+
+    assert not hasattr(run_cmd_module, "backend_pipeline")
+
+    received = {}
+
+    def _legacy_run(args):
+        received["args"] = args
+        return 0
+
+    monkeypatch.setattr(command._legacy, "run", _legacy_run)
+
+    status = command.run(
+        argparse.Namespace(
+            file="programa.co",
+            debug=True,
+            sandbox=False,
+            container="python",
+            formatear=False,
+            modo="mixto",
+        )
+    )
+
+    assert status == 0
+    assert received["args"].archivo == "programa.co"
+    assert not hasattr(received["args"], "backend_reason")
+
+
+def test_test_v2_no_resuelve_backend_antes_de_delegar(monkeypatch):
+    command = TestCommandV2()
+
+    import cobra.cli.commands_v2.test_cmd as test_cmd_module
+
+    assert not hasattr(test_cmd_module, "backend_pipeline")
+
+    received = {}
+
+    def _legacy_run(args):
+        received["args"] = args
+        return 0
+
+    monkeypatch.setattr(command._legacy, "run", _legacy_run)
+
+    status = command.run(argparse.Namespace(file="programa.co", langs=["python"], modo="mixto"))
+
+    assert status == 0
+    assert received["args"].archivo == "programa.co"
+    assert received["args"].lenguajes == ["python"]
+    assert not hasattr(received["args"], "backend_reason")


### PR DESCRIPTION
### Motivation

- Prevent `cobra run` from failing early when project metadata contains non-public or legacy module backends by avoiding eager backend resolution in the v2 `run` flow.
- Prevent `cobra test` from failing before verification when backend policy checks are unrelated to the verification `--langs` flow.

### Description

- Removed the eager `backend_pipeline.resolve_backend(...)` call and its import from `src/pcobra/cobra/cli/commands_v2/run_cmd.py` and no longer pass `backend_reason` to the legacy `ExecuteCommand` wrapper.
- Removed the eager `backend_pipeline.resolve_backend(...)` call and its import from `src/pcobra/cobra/cli/commands_v2/test_cmd.py` and no longer pass `backend_reason` to the legacy `VerifyCommand` wrapper.
- Added contract tests in `tests/unit/test_cli_v2_command_contract.py` that assert `RunCommandV2` and `TestCommandV2` delegate directly to legacy handlers without importing `backend_pipeline` and without injecting `backend_reason`.
- Kept `BuildCommandV2` backend-resolution behavior unchanged so `build` still resolves via the pipeline as intended.

### Testing

- Ran `pytest -q tests/unit/test_cli_v2_command_contract.py` and it passed with `5 passed, 1 warning`.
- The new/updated unit tests specifically verify that `run` and `test` v2 do not call `resolve_backend` before delegation and do not attach `backend_reason` to the legacy arguments, and those assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49240db1483278f54e449929e8126)