### PR TITLE
Fix coverage row uniqueness check for stdlib contracts

### DIFF
--- a/src/pcobra/cobra/stdlib_contract/validator.py
+++ b/src/pcobra/cobra/stdlib_contract/validator.py
@@ -82,18 +82,18 @@ def _validate_public_api(contract: ContractDescriptor) -> None:
 def _validate_coverage(contract: ContractDescriptor) -> None:
     expected_backends = {contract.primary_backend, *contract.allowed_fallback}
     declared_functions = set(contract.public_api)
-
-    if len(contract.coverage) != len(contract.public_api):
-        raise ContractValidationError(
-            f"{contract.module}: cobertura incompleta. "
-            f"public_api={len(contract.public_api)} coverage={len(contract.coverage)}"
-        )
+    covered_functions: set[str] = set()
 
     for function_coverage in contract.coverage:
         if function_coverage.function not in declared_functions:
             raise ContractValidationError(
                 f"{contract.module}: cobertura para función no declarada: {function_coverage.function}"
             )
+        if function_coverage.function in covered_functions:
+            raise ContractValidationError(
+                f"{contract.module}: cobertura duplicada para función: {function_coverage.function}"
+            )
+        covered_functions.add(function_coverage.function)
 
         coverage_backends = set(function_coverage.backend_levels)
         if coverage_backends != expected_backends:
@@ -108,6 +108,13 @@ def _validate_coverage(contract: ContractDescriptor) -> None:
                     f"{contract.module}.{function_coverage.function}.{backend}: "
                     f"nivel inválido '{level}', use full|partial"
                 )
+
+    missing_functions = declared_functions - covered_functions
+    if missing_functions:
+        raise ContractValidationError(
+            f"{contract.module}: cobertura incompleta para funciones declaradas: "
+            f"{sorted(missing_functions)}"
+        )
 
 
 def validate_contract_descriptor(contract: ContractDescriptor) -> None:

--- a/tests/unit/test_stdlib_contract_validator.py
+++ b/tests/unit/test_stdlib_contract_validator.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from pcobra.cobra.stdlib_contract import CONTRACTS, get_contract_matrix
-from pcobra.cobra.stdlib_contract.validator import validate_contracts
+from pcobra.cobra.stdlib_contract.base import FunctionCoverage
+from pcobra.cobra.stdlib_contract.validator import (
+    ContractValidationError,
+    validate_contract_descriptor,
+    validate_contracts,
+)
 
 
 def test_stdlib_contracts_validate() -> None:
@@ -25,3 +32,22 @@ def test_stdlib_matrix_contains_all_contract_modules() -> None:
         assert coverage_rows
         for row in coverage_rows:
             assert row["level"] in {"full", "partial"}
+
+
+def test_stdlib_contract_rejects_duplicate_coverage_rows() -> None:
+    contract = CONTRACTS[0]
+    duplicated_coverage = (
+        contract.coverage[0],
+        FunctionCoverage(
+            function=contract.coverage[0].function,
+            backend_levels=contract.coverage[1].backend_levels,
+        ),
+    )
+    duplicated_contract = replace(contract, coverage=duplicated_coverage)
+
+    try:
+        validate_contract_descriptor(duplicated_contract)
+    except ContractValidationError as exc:
+        assert "cobertura duplicada" in str(exc)
+    else:
+        raise AssertionError("Se esperaba ContractValidationError por cobertura duplicada")


### PR DESCRIPTION
### Motivation

- Prevent incomplete coverage contracts from being accepted when a coverage row is duplicated and another declared function is omitted, by enforcing exactly one coverage row per declared public API function.

### Description

- Replace the `len(coverage) == len(public_api)` cardinality check with explicit set tracking (`covered_functions`) and a final diff to detect missing functions. 
- Add detection and rejection of duplicate coverage rows for the same function during validation. 
- Keep existing backend membership and coverage-level (`full`/`partial`) validations intact and integrate them in the new flow. 
- Add a regression test `test_stdlib_contract_rejects_duplicate_coverage_rows` that constructs a duplicated-coverage scenario and asserts a `ContractValidationError` is raised.

### Testing

- Ran `pytest -q tests/unit/test_stdlib_contract_validator.py` which passed (`3 passed`).
- Ran `pytest -q tests/unit/test_stdlib_contract_validator.py tests/unit/test_runtime_api_matrix_contract.py` which passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49357e5d48327b0e93d3469289f20)