### PR TITLE
fix: package canonical bindings module in distributable src layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ include = [
     "core*",
     "cli*",
     "lsp*",
+    "bindings*",
 ]
 exclude = [
     "*.tests",

--- a/src/bindings/__init__.py
+++ b/src/bindings/__init__.py
@@ -1,0 +1,21 @@
+"""Superficie pública canónica del contrato de bindings."""
+
+from bindings.contract import (
+    BINDINGS_BY_LANGUAGE,
+    BindingCapabilities,
+    BindingRoute,
+    JAVASCRIPT_BINDING,
+    PYTHON_BINDING,
+    RUST_BINDING,
+    resolve_binding,
+)
+
+__all__ = [
+    "BindingCapabilities",
+    "BindingRoute",
+    "BINDINGS_BY_LANGUAGE",
+    "PYTHON_BINDING",
+    "JAVASCRIPT_BINDING",
+    "RUST_BINDING",
+    "resolve_binding",
+]

--- a/src/bindings/contract.py
+++ b/src/bindings/contract.py
@@ -1,0 +1,85 @@
+"""Contrato técnico canónico de rutas de bindings entre Cobra y runtimes externos."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Final
+
+
+class BindingRoute(str, Enum):
+    """Rutas soportadas por el bridge canónico de bindings."""
+
+    PYTHON_DIRECT_IMPORT = "python_direct_import"
+    JAVASCRIPT_RUNTIME_BRIDGE = "javascript_runtime_bridge"
+    RUST_COMPILED_FFI = "rust_compiled_ffi"
+
+
+@dataclass(frozen=True, slots=True)
+class BindingCapabilities:
+    """Describe capacidades y restricciones contractuales por ruta."""
+
+    route: BindingRoute
+    language: str
+    import_strategy: str
+    execution_boundary: str
+    abi_contract: str
+    managed_runtime: bool
+
+
+PYTHON_BINDING: Final[BindingCapabilities] = BindingCapabilities(
+    route=BindingRoute.PYTHON_DIRECT_IMPORT,
+    language="python",
+    import_strategy="Import bridge directo sobre módulos Python canónicos",
+    execution_boundary="Mismo proceso del intérprete Cobra",
+    abi_contract="Contrato Python estable por API pública y typing",
+    managed_runtime=False,
+)
+
+JAVASCRIPT_BINDING: Final[BindingCapabilities] = BindingCapabilities(
+    route=BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE,
+    language="javascript",
+    import_strategy="Bridge de runtime sobre proceso/VM controlada",
+    execution_boundary="Aislado en runtime JS dedicado (proceso o VM)",
+    abi_contract="Contrato de mensajes/IPC versionado",
+    managed_runtime=True,
+)
+
+RUST_BINDING: Final[BindingCapabilities] = BindingCapabilities(
+    route=BindingRoute.RUST_COMPILED_FFI,
+    language="rust",
+    import_strategy="Bindings compilados sobre capa FFI",
+    execution_boundary="Frontera nativa vía librería compartida",
+    abi_contract="ABI estable y versionada",
+    managed_runtime=False,
+)
+
+BINDINGS_BY_LANGUAGE: Final[dict[str, BindingCapabilities]] = {
+    "python": PYTHON_BINDING,
+    "javascript": JAVASCRIPT_BINDING,
+    "rust": RUST_BINDING,
+}
+
+
+def resolve_binding(language: str) -> BindingCapabilities:
+    """Resuelve el contrato de bindings para un lenguaje canónico."""
+
+    key = (language or "").strip().lower()
+    try:
+        return BINDINGS_BY_LANGUAGE[key]
+    except KeyError as exc:
+        raise ValueError(
+            f"No existe contrato de bindings para '{language}'. "
+            f"Lenguajes soportados: {', '.join(sorted(BINDINGS_BY_LANGUAGE))}."
+        ) from exc
+
+
+__all__ = [
+    "BindingCapabilities",
+    "BindingRoute",
+    "BINDINGS_BY_LANGUAGE",
+    "JAVASCRIPT_BINDING",
+    "PYTHON_BINDING",
+    "RUST_BINDING",
+    "resolve_binding",
+]


### PR DESCRIPTION
### Motivation

- Fix a P1 packaging regression where `pcobra.cobra.bindings.contract` re-exports from `bindings.contract` but `bindings` lived at repository root and was not included in built distributions due to the current setuptools layout.

### Description

- Add a distributable `bindings` package under `src/` by adding `src/bindings/contract.py` and `src/bindings/__init__.py` so the canonical binding contract is available in installed packages.
- Update `[tool.setuptools.packages.find]` in `pyproject.toml` to include `"bindings*"` so the new package is discovered and shipped in wheel/sdist installs.
- Maintain the `pcobra.cobra.bindings.contract` re-export of the canonical API while ensuring it resolves correctly both in-repo and when installed.

### Testing

- Ran `pytest -q tests/unit/test_binding_contract_canonical.py tests/unit/test_execute_cmd_binding_contract.py` and both tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4944ddd2083279ecf2ff97ff7e2c0)