### PR TITLE
Fix runtime backend resolution to enforce public scope

### DIFF
--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -46,17 +46,24 @@ def _validate_public_route_startup_contract() -> None:
 _validate_public_route_startup_contract()
 
 
-def resolve_backend(source: str, hints: dict[str, Any] | None = None) -> BackendResolution:
+def resolve_backend(
+    source: str,
+    hints: dict[str, Any] | None = None,
+    *,
+    route_scope: str | None = None,
+) -> BackendResolution:
     """Resuelve backend canónico a partir de un source file y pistas opcionales."""
     context = hints or {}
     preferred_backend = context.get("preferred_backend")
     required_capabilities = tuple(context.get("required_capabilities", ()))
-    route_scope = "internal_migration" if context.get("internal_migration", False) else "public"
+    effective_route_scope = route_scope or (
+        "internal_migration" if context.get("internal_migration", False) else "public"
+    )
     return ORCHESTRATOR.resolve_backend(
         source_file=source,
         preferred_backend=preferred_backend,
         required_capabilities=required_capabilities,
-        route_scope=route_scope,
+        route_scope=effective_route_scope,
     )
 
 
@@ -66,7 +73,9 @@ def resolve_backend_runtime(
 ) -> tuple[BackendResolution, dict[str, str]]:
     """Resuelve backend y metadatos de bridge/runtime para el contrato de bindings."""
     context = hints or {}
-    resolution = resolve_backend(source, context)
+    # La resolución de runtime solo soporta backends públicos del contrato de bindings.
+    # Incluso en flujos de migración interna, esta ruta no debe seleccionar targets legacy.
+    resolution = resolve_backend(source, context, route_scope="public")
     capabilities, bridge = RUNTIME_MANAGER.resolve_runtime(resolution.backend)
     abi_version = RUNTIME_MANAGER.validate_abi_route(
         resolution.backend,

--- a/tests/unit/test_backend_pipeline_runtime_manager.py
+++ b/tests/unit/test_backend_pipeline_runtime_manager.py
@@ -72,3 +72,29 @@ def test_backend_pipeline_resolve_backend_envia_scope_migracion(monkeypatch):
     )
 
     assert captured["route_scope"] == "internal_migration"
+
+
+def test_backend_pipeline_resolve_backend_runtime_fuerza_scope_publico(monkeypatch):
+    captured = {}
+
+    def _fake_resolve_backend(self, *, source_file, preferred_backend, required_capabilities, route_scope):
+        captured["route_scope"] = route_scope
+        return type("R", (), {"backend": "python", "reason": "public"})()
+
+    monkeypatch.setattr(backend_pipeline, "ORCHESTRATOR", type("O", (), {"resolve_backend": _fake_resolve_backend})())
+    monkeypatch.setattr(
+        backend_pipeline.RUNTIME_MANAGER,
+        "resolve_runtime",
+        lambda _backend: (
+            type("C", (), {"language": "python", "route": type("Route", (), {"value": "python_direct_import"})(), "abi_contract": "abi"})(),
+            type("B", (), {"implementation": "python_direct_bridge", "security_profile": "same_process_safe_mode"})(),
+        ),
+    )
+    monkeypatch.setattr(backend_pipeline.RUNTIME_MANAGER, "validate_abi_route", lambda _backend, abi_version=None: abi_version or "1.0")
+
+    backend_pipeline.resolve_backend_runtime(
+        "demo.co",
+        {"preferred_backend": "go", "internal_migration": True},
+    )
+
+    assert captured["route_scope"] == "public"


### PR DESCRIPTION
### Motivation
- Prevent internal-only/legacy backends (e.g. `go`) from being passed to runtime metadata paths that only support public backends (`python/javascript/rust`).
- Keep the existing `internal_migration` behavior for build/orchestration flows while ensuring runtime-binding paths stay within the public contract.

### Description
- `resolve_backend` in `src/pcobra/cobra/build/backend_pipeline.py` now accepts an optional `route_scope` override (`route_scope: str | None`) while preserving the existing hints-based default behavior. 
- `resolve_backend_runtime` now forces the orchestrator to resolve using `route_scope="public"` to ensure only public backends reach `RuntimeManager` and binding metadata resolution. 
- Added regression test `test_backend_pipeline_resolve_backend_runtime_fuerza_scope_publico` in `tests/unit/test_backend_pipeline_runtime_manager.py` to assert runtime resolution always uses the public scope even when `internal_migration=True` is supplied in hints.

### Testing
- Ran unit tests: `pytest -q tests/unit/test_build_orchestrator.py tests/unit/test_backend_pipeline_runtime_manager.py` and all tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49549e7bc83279a2f0c664486b660)