### PR TITLE
Fix v1 routing regression: force v2 only for public root help

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -259,7 +259,7 @@ class CliApplication:
         self.command_registry = CommandRegistry(self.interpreter)
         self.parser = self._build_argument_parser()
 
-    def _ensure_command_structure(self) -> None:
+    def _ensure_command_structure(self, *, force_public_ui_v2_for_help: bool = False) -> None:
         if not self.parser or not self.command_registry:
             raise RuntimeError("Application not properly initialized")
         if self._subparsers is None:
@@ -272,9 +272,13 @@ class CliApplication:
 
         command_profile = resolve_command_profile()
         selected_ui = getattr(self, "_selected_ui", "v2")
-        if command_profile == PROFILE_PUBLIC and selected_ui == "v1":
+        if (
+            force_public_ui_v2_for_help
+            and command_profile == PROFILE_PUBLIC
+            and selected_ui == "v1"
+        ):
             logging.getLogger(__name__).debug(
-                "Perfil público activo: forzando UI v2 para evitar exposición de comandos legacy en --help.",
+                "Perfil público activo: forzando UI v2 para ayuda raíz y evitar exposición de comandos legacy en --help.",
             )
             selected_ui = "v2"
         self.command_registry.register_base_commands(
@@ -598,6 +602,13 @@ class CliApplication:
         self._configure_cli_options(parser)
         return parser
 
+    @staticmethod
+    def _is_root_help_request(argv: List[str]) -> bool:
+        help_flags = {"-h", "--help", "--ayuda"}
+        if not any(token in help_flags for token in argv):
+            return False
+        return not any(token and not token.startswith("-") for token in argv)
+
     def _parse_arguments(self, argv: List[str]) -> argparse.Namespace:
         if not self.parser or not self.command_registry:
             raise RuntimeError("Application not properly initialized")
@@ -609,7 +620,9 @@ class CliApplication:
             safe_mode=getattr(preliminary_args, "plugins_safe_mode", True),
             allowlist=getattr(preliminary_args, "plugins_allowlist", ""),
         )
-        self._ensure_command_structure()
+        self._ensure_command_structure(
+            force_public_ui_v2_for_help=self._is_root_help_request(argv)
+        )
 
         default_command_name = self.command_registry.get_default_command_name()
         default_command = self.command_registry.commands.get(default_command_name)

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -56,3 +56,18 @@ def test_cli_help_public_contract_snapshot_no_expone_legacy_aun_con_ui_v1():
     assert "\n  legacy " not in lower_help
     assert "\n  compilar " not in lower_help
     assert "\n  ejecutar " not in lower_help
+
+
+def test_cli_ui_v1_preserva_ruteo_comandos_legacy_publicos():
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "-m", "cobra.cli.cli", "--ui", "v1", "interactive", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=_public_env(),
+    )
+    assert result.returncode == 0
+    lower_help = result.stdout.lower()
+    assert "usage:" in lower_help
+    assert "interactive" in lower_help


### PR DESCRIPTION
### Motivation
- A prior change forced UI `v2` for all public-profile runs when `--ui v1` was requested, which broke legacy public command routing (for example `interactive`, `compilar`, `ejecutar`).
- The public top-level help must still avoid exposing legacy commands, so the UI override should be scoped to root-help rendering only.

### Description
- Added an optional `force_public_ui_v2_for_help` parameter to `CliApplication._ensure_command_structure()` and scoped the `v1`→`v2` override to that flag. 
- Implemented `CliApplication._is_root_help_request(argv)` to detect root help invocations (`-h`, `--help`, `--ayuda`) without a positional command. 
- Wired the detection into `_parse_arguments()` by calling `_ensure_command_structure(force_public_ui_v2_for_help=self._is_root_help_request(argv))` so only root help rendering in public profile uses `v2` to hide legacy commands. 
- Added `test_cli_ui_v1_preserva_ruteo_comandos_legacy_publicos` to `tests/integration/test_cli_public_help_contract.py` to verify that `--ui v1 interactive --help` still routes and parses correctly in public environments.

### Testing
- Ran `pytest -q tests/integration/test_cli_public_help_contract.py tests/integration/test_cli_ui_v2.py` and the suite passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e496b412d88327a77ef49736e6d57b)