### PR TITLE
Remove implicit ABI negotiation from resolve_runtime to restore ABI override path

### DIFF
--- a/src/pcobra/cobra/bindings/runtime_manager.py
+++ b/src/pcobra/cobra/bindings/runtime_manager.py
@@ -70,11 +70,10 @@ class RuntimeManager:
     }
 
     def resolve_runtime(self, language: str) -> tuple[BindingCapabilities, RuntimeBridgeDescriptor]:
-        """Resuelve contrato, negocia ABI y retorna bridge asociado."""
+        """Resuelve contrato y retorna bridge asociado sin negociar ABI implícitamente."""
 
         capabilities = self._resolve_capabilities(language)
         bridge = self.select_bridge(capabilities)
-        self.negotiate_abi(capabilities)
         return capabilities, bridge
 
     def _resolve_capabilities(self, language: str) -> BindingCapabilities:

--- a/tests/unit/test_runtime_manager.py
+++ b/tests/unit/test_runtime_manager.py
@@ -97,3 +97,23 @@ javascript = "1.2"
         assert "Versiones soportadas" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("Se esperaba rechazo de ABI no soportada")
+
+
+def test_runtime_manager_no_negocia_abi_en_resolve_runtime_permite_override(monkeypatch, tmp_path: Path):
+    manager = RuntimeManager()
+    cobra_toml = tmp_path / "cobra.toml"
+    cobra_toml.write_text(
+        """
+[project.abi_by_backend]
+rust = "9.9"
+""".strip()
+    )
+
+    monkeypatch.setenv("COBRA_TOML", str(cobra_toml))
+    monkeypatch.delenv("PCOBRA_CONFIG", raising=False)
+
+    capabilities, bridge = manager.resolve_runtime("rust")
+
+    assert capabilities.route is BindingRoute.RUST_COMPILED_FFI
+    assert bridge.route is BindingRoute.RUST_COMPILED_FFI
+    assert manager.validate_abi_route("rust", abi_version="1.0") == "1.0"


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where `RuntimeManager.resolve_runtime` implicitly called ABI negotiation and raised on stale project ABI config before callers could supply an explicit `abi_version` override.

### Description
- Removed the implicit `negotiate_abi` call from `RuntimeManager.resolve_runtime` so runtime resolution only returns capabilities and the associated bridge without performing ABI negotiation (`src/pcobra/cobra/bindings/runtime_manager.py`).
- Added a regression test that places an unsupported ABI in `cobra.toml`, verifies `resolve_runtime("rust")` still succeeds, and confirms an explicit override via `validate_abi_route("rust", abi_version="1.0")` is accepted (`tests/unit/test_runtime_manager.py`).

### Testing
- Ran `pytest -q tests/unit/test_runtime_manager.py` and the suite passed: `8 passed` (the new regression test included).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e497bcec948327946971a1f46203e3)