### PR TITLE
Follow-up: block legacy UI exposure for `--ui=v1` in public profile

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -654,6 +654,8 @@ class CliApplication:
     @staticmethod
     def _resolve_selected_ui_from_argv(argv: list[str]) -> str:
         for index, token in enumerate(argv):
+            if token.startswith("--ui="):
+                return token.split("=", 1)[1].strip().lower()
             if token == "--ui" and index + 1 < len(argv):
                 return argv[index + 1].strip().lower()
         return "v2"

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -55,6 +55,23 @@ def test_cli_help_public_contract_bloquea_ui_v1_en_perfil_publico():
     assert "run/build/test/mod" in lower_error
 
 
+def test_cli_help_public_contract_bloquea_ui_v1_en_forma_inline_en_perfil_publico():
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "-m", "cobra.cli.cli", "--ui=v1", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=_public_env(),
+    )
+    assert result.returncode == 1
+
+    lower_error = result.stderr.lower() + result.stdout.lower()
+    assert "perfil público bloqueado" in lower_error
+    assert "cli v1" in lower_error
+    assert "run/build/test/mod" in lower_error
+
+
 def test_cli_help_public_contract_bloquea_flags_legacy_en_arranque():
     repo_root = Path(__file__).resolve().parents[2]
     env = _public_env()


### PR DESCRIPTION
### Motivation
- Close a bypass where the public startup guard only detected the split form `--ui v1` and ignored the argparse inline form `--ui=v1`, which could expose the legacy v1 surface in public profile. 
- Ensure consistent UI resolution so the public profile blocks any legacy CLI exposure regardless of valid argparse token formats.

### Description
- Updated `CliApplication._resolve_selected_ui_from_argv` in `src/pcobra/cobra/cli/cli.py` to parse inline tokens of the form `--ui=<value>` in addition to the existing split form. 
- Added an integration test `test_cli_help_public_contract_bloquea_ui_v1_en_forma_inline_en_perfil_publico` to `tests/integration/test_cli_public_help_contract.py` that asserts `--ui=v1 --help` is blocked in the public profile. 
- Kept existing behavior for the split form (`--ui v1`) unchanged so both argparse forms resolve identically.

### Testing
- Ran `pytest -q tests/integration/test_cli_public_help_contract.py` and all tests passed (`5 passed`).
- The integration tests confirm the startup guard now blocks legacy UI exposure for both `--ui v1` and `--ui=v1` invocations in the public profile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e498c754748327933b197ef501b4ff)