### PR TITLE
Fix bypass in public import boundaries guard for ImportFrom symbols

### DIFF
--- a/scripts/ci/check_public_import_boundaries.py
+++ b/scripts/ci/check_public_import_boundaries.py
@@ -29,7 +29,15 @@ def _node_import_targets(node: ast.AST) -> list[str]:
     if isinstance(node, ast.Import):
         return [alias.name for alias in node.names]
     if isinstance(node, ast.ImportFrom):
-        return [node.module] if node.module else []
+        if not node.module:
+            return []
+
+        targets = [node.module]
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            targets.append(f"{node.module}.{alias.name}")
+        return targets
     return []
 
 

--- a/tests/unit/test_check_public_import_boundaries_script.py
+++ b/tests/unit/test_check_public_import_boundaries_script.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+
+def _load_guard_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "ci" / "check_public_import_boundaries.py"
+    spec = importlib.util.spec_from_file_location("check_public_import_boundaries", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_node_import_targets_flags_importfrom_symbol_paths() -> None:
+    guard = _load_guard_module()
+    node = ast.parse(
+        "from pcobra.cobra.cli import internal_compat, helpers\n"
+    ).body[0]
+
+    targets = guard._node_import_targets(node)
+
+    assert "pcobra.cobra.cli" in targets
+    assert "pcobra.cobra.cli.internal_compat" in targets
+    assert "pcobra.cobra.cli.helpers" in targets
+
+
+def test_node_import_targets_skips_wildcard_suffix_for_importfrom() -> None:
+    guard = _load_guard_module()
+    node = ast.parse("from pcobra.cobra.cli.internal_compat import *\n").body[0]
+
+    targets = guard._node_import_targets(node)
+
+    assert targets == ["pcobra.cobra.cli.internal_compat"]


### PR DESCRIPTION
### Motivation

- Close a high-priority bypass where `from X import y` style imports were not being checked down to the imported symbol, allowing forbidden paths like `pcobra.cobra.cli.internal_compat` to slip through.
- Ensure the CI import-boundary guard enforces that public surfaces do not depend on internal compatibility shims or legacy inventories.

### Description

- Update `scripts/ci/check_public_import_boundaries.py` so `ast.ImportFrom` nodes now emit the base module and each imported symbol as a fully-qualified target (`{module}.{symbol}`), while skipping expansion for wildcard (`*`) imports.
- Preserve the module-level target for `ImportFrom` nodes and avoid reporting empty `node.module` cases.
- Add unit tests `tests/unit/test_check_public_import_boundaries_script.py` that verify symbol-qualified targets are produced and that wildcard imports only include the module target.

### Testing

- Ran `python scripts/ci/check_public_import_boundaries.py` and the guard exited successfully (`0`) with no forbidden imports detected.
- Ran `pytest -q tests/unit/test_check_public_import_boundaries_script.py tests/unit/test_public_import_boundaries_guard.py` and all tests passed (`3 passed`).
- The new tests exercise `_node_import_targets` for ImportFrom symbol expansion and wildcard behavior and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e499e485ac8327b60be3b656a4e3e2)