### PR TITLE
Fix public legacy command remap when valued global options precede command

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -653,11 +653,31 @@ class CliApplication:
 
     @staticmethod
     def _first_non_option_token_index(argv: list[str]) -> Optional[int]:
-        for index, token in enumerate(argv):
+        options_with_value = {
+            "--modo",
+            "--ui",
+            "--lang",
+            "--extra-validators",
+            "--plugins-allowlist",
+        }
+
+        index = 0
+        while index < len(argv):
+            token = argv[index]
             if token == "--":
                 return index + 1 if index + 1 < len(argv) else None
+
             if not token.startswith("-"):
                 return index
+
+            if token.startswith("--"):
+                option_name = token.split("=", 1)[0]
+                if option_name in options_with_value and "=" not in token:
+                    index += 2
+                    continue
+
+            index += 1
+
         return None
 
     def _apply_public_cli_policy(self, argv: list[str]) -> list[str]:

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -83,3 +83,18 @@ def test_cli_help_public_contract_muestra_warning_migracion_en_comando_legacy():
     lower_output = result.stderr.lower() + result.stdout.lower()
     assert "comando legacy 'compilar'" in lower_output
     assert "migración automática aplicada: use 'build'" in lower_output
+
+
+def test_cli_help_public_contract_migra_comando_legacy_tras_opcion_global_con_valor():
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "-m", "cobra.cli.cli", "--lang", "es", "compilar", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=_public_env(),
+    )
+    assert result.returncode == 0
+    lower_output = result.stderr.lower() + result.stdout.lower()
+    assert "comando legacy 'compilar'" in lower_output
+    assert "migración automática aplicada: use 'build'" in lower_output


### PR DESCRIPTION
### Motivation
- Fix a P1 bug where `_first_non_option_token_index` treated option values (e.g. the `es` in `--lang es`) as the command token, causing legacy-to-v2 migration to be skipped and resulting in `invalid choice` errors. 
- Ensure public-profile auto-migration works for common invocations like `cobra --lang es compilar ...` so legacy commands are remapped to their v2 equivalents. 
- Preserve existing `--` separator semantics while correctly handling valued global options.

### Description
- Updated token scanning in `src/pcobra/cobra/cli/cli.py` by changing `_first_non_option_token_index` to skip values consumed by valued global options and by introducing an `options_with_value` set that includes `--modo`, `--ui`, `--lang`, `--extra-validators`, and `--plugins-allowlist`.
- Kept the public auto-migration flow in `_apply_public_cli_policy` intact so detected legacy commands are still remapped and warnings/logging remain unchanged.
- Added an integration regression test `test_cli_help_public_contract_migra_comando_legacy_tras_opcion_global_con_valor` in `tests/integration/test_cli_public_help_contract.py` that exercises `--lang es compilar --help` in the public profile and asserts the legacy migration warning and remap to `build`.

### Testing
- Ran `pytest -q tests/integration/test_cli_public_help_contract.py` and the suite passed: `6 passed`.
- The added integration test verifies that invoking `cobra --lang es compilar --help` in the public profile triggers the legacy migration warning and remaps `compilar` to `build` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49d3a21a083278e371e427f964b76)