### PR TITLE
Follow-up: enforce mode policy in BuildCommandV2 and restore backend reason fallback

### DIFF
--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -112,7 +112,10 @@ def build(source: str, hints: dict[str, Any] | None = None) -> dict[str, Any]:
     ast = obtener_ast(codigo)
     code = transpile(ast, resolution.backend)
     debug = bool(context.get("debug", False))
-    reason = resolution.reason_for(debug=debug)
+    if hasattr(resolution, "reason_for"):
+        reason = resolution.reason_for(debug=debug)
+    else:
+        reason = getattr(resolution, "reason", None) if debug else None
     return {
         "backend": resolution.backend,
         "reason": reason,

--- a/src/pcobra/cobra/cli/commands_v2/build_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/build_cmd.py
@@ -3,6 +3,7 @@ from typing import Any
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.mode_policy import validar_politica_modo
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.cli.utils.autocomplete import files_completer
 
@@ -25,6 +26,7 @@ class BuildCommandV2(BaseCommand):
     def run(self, args: Any) -> int:
         debug = bool(getattr(args, "debug", False))
         try:
+            validar_politica_modo(self.name, args, capability=self.capability)
             build_result = backend_pipeline.build(
                 args.file,
                 {

--- a/tests/unit/test_cli_v2_command_contract.py
+++ b/tests/unit/test_cli_v2_command_contract.py
@@ -62,6 +62,28 @@ def test_build_v2_resuelve_backend_via_pipeline(monkeypatch):
     assert "build" in called
 
 
+
+
+def test_build_v2_aplica_politica_modo_antes_de_pipeline(monkeypatch):
+    command = BuildCommandV2()
+    called = {"build": False}
+
+    monkeypatch.setattr(
+        "cobra.cli.commands_v2.build_cmd.validar_politica_modo",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("blocked-by-mode")),
+    )
+    monkeypatch.setattr(
+        "cobra.cli.commands_v2.build_cmd.backend_pipeline.build",
+        lambda *_args, **_kwargs: called.__setitem__("build", True),
+    )
+
+    status = command.run(
+        argparse.Namespace(file="programa.co", modo="cobra", debug=False)
+    )
+
+    assert status == 1
+    assert called["build"] is False
+
 def test_build_v2_help_no_expone_flags_backend():
     subparsers = _build_subparsers()
     command = BuildCommandV2()


### PR DESCRIPTION
### Motivation
- Restore the pre-existing mode-policy behavior so the public `build` v2 command cannot execute codegen routes when `--modo` disallows them (e.g., `--modo cobra`).
- Prevent regressions when `backend_pipeline.build` receives resolution-like objects that lack a `reason_for` method to avoid raising `AttributeError` at runtime.

### Description
- Call `validar_politica_modo(self.name, args, capability=self.capability)` at the start of `BuildCommandV2.run` to enforce CLI mode policy before invoking the pipeline (file: `src/pcobra/cobra/cli/commands_v2/build_cmd.py`).
- Make `backend_pipeline.build` use `resolution.reason_for(debug=...)` when present and fall back to `resolution.reason` only when `debug=True` (otherwise `None`) to support legacy resolution shapes (file: `src/pcobra/cobra/build/backend_pipeline.py`).
- Add a unit test `test_build_v2_aplica_politica_modo_antes_de_pipeline` to `tests/unit/test_cli_v2_command_contract.py` that verifies the mode validator blocks pipeline invocation and that the pipeline is not called when the mode is disallowed.

### Testing
- Ran `pytest -q tests/unit/test_backend_pipeline_runtime_manager.py tests/unit/test_cli_v2_command_contract.py` and the run completed successfully with `10 passed, 1 warning`.
- The new test verifies that `BuildCommandV2` returns a failure status when mode validation raises and does not call `backend_pipeline.build`, and existing tests confirm `reason` is only exposed in debug mode.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49e5c3ffc8327bbdf08f7513ac42d)