### PR TITLE
Use canonical primary backend for cobra.system stdlib manifest

### DIFF
--- a/src/pcobra/cobra/stdlib_contract/system.py
+++ b/src/pcobra/cobra/stdlib_contract/system.py
@@ -11,7 +11,7 @@ SYSTEM_CONTRACT = ContractDescriptor(
         "cobra.system.ejecutar",
         "cobra.system.obtener_env",
     ),
-    primary_backend="python+rust",
+    primary_backend="python",
     allowed_fallback=("rust", "javascript"),
     runtime_mapping=RuntimeMapping(
         standard_library=("src/pcobra/standard_library/archivo.py",),

--- a/src/pcobra/cobra/stdlib_contract/validator.py
+++ b/src/pcobra/cobra/stdlib_contract/validator.py
@@ -18,7 +18,7 @@ PRIMARY_BACKEND_POLICY: Final[dict[str, tuple[str, ...]]] = {
     "cobra.core": ("python",),
     "cobra.datos": ("python",),
     "cobra.web": ("javascript",),
-    "cobra.system": ("python", "rust"),
+    "cobra.system": ("python",),
 }
 
 


### PR DESCRIPTION
### Motivation

- Ensure the stdlib manifest emits a single canonical `backend_preferido` target for `cobra.system` so `mod_validator`'s canonical-target checks do not raise `ValueError` for built-in stdlib contracts.

### Description

- Changed `primary_backend` in `src/pcobra/cobra/stdlib_contract/system.py` from `"python+rust"` to `"python"` and updated the expected `PRIMARY_BACKEND_POLICY` for `cobra.system` in `src/pcobra/cobra/stdlib_contract/validator.py` to `("python",)` to keep contract manifests and validator expectations aligned.

### Testing

- Ran `python scripts/ci/validate_stdlib_function_coverage.py` which completed successfully; ran `pytest -q tests/unit/test_stdlib_contract_validator.py tests/unit/test_stdlib_contract_descriptor.py` which passed; running the broader test set including `tests/unit/test_mod_validator.py` still shows 5 pre-existing failures unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49f5b233c832790a33fc535e287e2)