### PR TITLE
Skip JS managed-runtime enforcement for `build` in RuntimeManager

### DIFF
--- a/src/pcobra/cobra/bindings/runtime_manager.py
+++ b/src/pcobra/cobra/bindings/runtime_manager.py
@@ -115,7 +115,11 @@ class RuntimeManager:
                 route,
                 "la ruta no puede marcarse como containerizada; use ejecución en mismo proceso",
             )
-        if route is BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE and not (sandbox or containerized):
+        if (
+            route is BindingRoute.JAVASCRIPT_RUNTIME_BRIDGE
+            and normalized_command != "build"
+            and not (sandbox or containerized)
+        ):
             self._raise_route_error(
                 route,
                 "la ruta requiere runtime gestionado (sandbox o contenedor) para mantener aislamiento",

--- a/tests/unit/test_runtime_manager.py
+++ b/tests/unit/test_runtime_manager.py
@@ -23,6 +23,12 @@ def test_runtime_manager_valida_ruta_js_requiere_runtime_gestionado():
         raise AssertionError("Se esperaba error de seguridad para JS sin aislamiento")
 
 
+def test_runtime_manager_build_javascript_no_exige_runtime_gestionado():
+    manager = RuntimeManager()
+
+    manager.validate_security_route("javascript", sandbox=False, containerized=False, command="build")
+
+
 def test_runtime_manager_valida_abi_por_ruta():
     manager = RuntimeManager()
 


### PR DESCRIPTION
### Motivation
- Fix a regression where JavaScript `build` requests were turned into hard errors because `validate_security_route` enforced a managed-runtime requirement even though `build` is a code-generation path that does not execute user code.

### Description
- Update `RuntimeManager.validate_security_route` to skip the JavaScript managed-runtime (`sandbox`/`containerized`) check when `command` is `"build"`, and add the unit test `tests/unit/test_runtime_manager.py::test_runtime_manager_build_javascript_no_exige_runtime_gestionado` to assert the intended behavior.

### Testing
- Run `pytest -q tests/unit/test_runtime_manager.py tests/unit/test_cli_v2_command_contract.py` and confirm the test suite passed with `17 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a08e385c8327b3a49f28df85a31a)