### PR TITLE
fix(ci): detect legacy targets in slash-separated help output

### DIFF
--- a/scripts/ci/validate_targets.py
+++ b/scripts/ci/validate_targets.py
@@ -1101,7 +1101,7 @@ def validate_cli_public_surfaces_no_legacy_aliases() -> list[str]:
     for surface_name, help_text in help_surfaces.items():
         lowered = help_text.lower()
         for alias in forbidden_aliases:
-            if re.search(rf"(?<![\w.+/-]){re.escape(alias)}(?![\w.+/-])", lowered):
+            if _contains_token(lowered, alias):
                 errors.append(
                     f"cli:{surface_name}: ayuda pública contiene alias legacy '{alias}'"
                 )
@@ -1141,11 +1141,20 @@ def validate_ci_checklist_no_public_legacy_targets() -> list[str]:
             continue
         lowered = f"{result.stdout}\n{result.stderr}".lower()
         for target in INTERNAL_LEGACY_TARGETS:
-            if re.search(rf"(?<![\w.+/-]){re.escape(target)}(?![\w.+/-])", lowered):
+            if _contains_token(lowered, target):
                 errors.append(
                     f"ci-checklist:{surface_name}: exposición pública de target legacy '{target}'"
                 )
     return errors
+
+
+def _contains_token(text: str, token: str) -> bool:
+    token = token.lower()
+    token_chars = r"[\w.+-]"
+    return (
+        re.search(rf"(?<!{token_chars}){re.escape(token)}(?!{token_chars})", text)
+        is not None
+    )
 
 
 def _run_stage(name: str, errors: list[str]) -> int | None:


### PR DESCRIPTION
### Motivation
- Fix a P1 false-negative in the CI gate that missed legacy targets when public help showed slash-separated lists like `go/cpp/java/wasm/asm` so the validator reliably flags exposed legacy targets.

### Description
- Replaced inline boundary-regex checks with a shared helper `_contains_token(text, token)` in `scripts/ci/validate_targets.py` and updated `validate_ci_checklist_no_public_legacy_targets` and `validate_cli_public_surfaces_no_legacy_aliases` to call it.
- The `_contains_token` matcher treats `/` as a separator (by excluding it from the token character class) so tokens like `go` inside `go/cpp/...` are detected while avoiding substring matches such as `go` in `golang`.

### Testing
- Ran `pytest -q tests/unit/test_legacy_backend_lifecycle.py tests/integration/test_cli_public_help_contract.py` and all tests passed (`12 passed`).
- Executing the full validator with `python scripts/ci/validate_targets.py` fails early due to a preexisting `ImportError` when importing `LANG_CHOICES` from `compile_cmd`, which is unrelated to this token-detection fix and blocks end-to-end run of the script in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a18f08a08327a0daf048eff6d499)