### PR TITLE
Fix --ui validation in help fast-path (follow-up to #1977)

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -618,8 +618,14 @@ class CliApplication:
         if not self.parser or not self.command_registry:
             raise RuntimeError("Application not properly initialized")
 
-        self._selected_ui = self._resolve_selected_ui_from_argv(argv)
+        selected_ui = self._resolve_selected_ui_from_argv(argv)
+        self._selected_ui = selected_ui
         if any(token in {"-h", "--help", "--ayuda"} for token in argv):
+            if selected_ui not in {"v1", "v2"}:
+                self.parser.error(
+                    f"argument --ui: invalid choice: '{selected_ui}' "
+                    "(choose from 'v1', 'v2')"
+                )
             configure_plugin_policy(safe_mode=True, allowlist="")
             self._ensure_command_structure()
             if autocomplete_available():

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -75,6 +75,21 @@ def test_cli_help_public_contract_bloquea_ui_v1_en_perfil_publico():
     assert "migración automática a ui v2 pública" in lower_output
 
 
+def test_cli_help_public_contract_rechaza_ui_invalida():
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "-m", "cobra.cli.cli", "--help", "--ui", "foo"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env=_public_env(),
+    )
+    assert result.returncode == 2
+    lower_error = result.stderr.lower() + result.stdout.lower()
+    assert "invalid choice" in lower_error
+    assert "'foo'" in lower_error
+
+
 def test_cli_help_public_contract_bloquea_flags_legacy_en_arranque():
     repo_root = Path(__file__).resolve().parents[2]
     env = _public_env()


### PR DESCRIPTION
### Motivation
- Prevent accidental exposure of legacy CLI surface in `PROFILE_PUBLIC` when `--help` is requested together with an invalid `--ui` value. 
- Ensure the help fast-path uses the same `argparse` validation semantics for `--ui` as the normal parse path so invalid UI values are rejected before command-tree registration.

### Description
- Updated `CliApplication._parse_arguments()` in `src/pcobra/cobra/cli/cli.py` to compute `selected_ui` from `argv`, assign it to `self._selected_ui`, and validate it in the help fast-path; if the value is not one of `v1`/`v2` the code now calls `self.parser.error(...)` to produce an argparse-style error and exit with code `2`.
- This change stops building the help command tree when `--ui` is invalid, avoiding legacy fallback registration under the public profile.
- Added integration test `test_cli_help_public_contract_rechaza_ui_invalida` to `tests/integration/test_cli_public_help_contract.py` which asserts `cobra --help --ui foo` exits with code `2` and reports an "invalid choice" message.

### Testing
- Ran `pytest -q tests/integration/test_cli_public_help_contract.py tests/unit/test_cli_v2_command_contract.py` and the test run completed with `14 passed, 1 warning` (the warning is a non-blocking pytest collection warning). 
- The newly added `test_cli_help_public_contract_rechaza_ui_invalida` passed as part of that run. 
- Manual reasoning: the fix enforces `--ui` validation on the help fast-path and reproduces argparse semantics (SystemExit(2)) to match expected behavior in public profile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a2a98e1483279c12a3b9e2697682)