### PR TITLE
Restore resolve_backend compatibility export in backend_pipeline

### DIFF
--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -67,6 +67,11 @@ def _resolve_backend(source: str, hints: dict[str, Any] | None = None) -> Backen
     )
 
 
+def resolve_backend(source: str, hints: dict[str, Any] | None = None) -> BackendResolution:
+    """Alias de compatibilidad para imports legacy de ``pcobra.cobra.build``."""
+    return _resolve_backend(source, hints)
+
+
 def resolve_backend_runtime(
     source: str,
     hints: dict[str, Any] | None = None,
@@ -131,6 +136,7 @@ __all__ = [
     "ORCHESTRATOR",
     "TRANSPILERS",
     "build",
+    "resolve_backend",
     "resolve_backend_runtime",
     "transpile",
 ]


### PR DESCRIPTION
### Motivation
- Restore backward compatibility after `resolve_backend` was renamed to `_resolve_backend`, which caused `ImportError` when importing `pcobra.cobra.build` because `src/pcobra/cobra/build/__init__.py` still expects the public symbol.

### Description
- Add a public alias `resolve_backend(source, hints)` that delegates to the internal `_resolve_backend(...)` and re-export `resolve_backend` in `__all__` in `src/pcobra/cobra/build/backend_pipeline.py` to preserve the package import surface.

### Testing
- Ran `python -m compileall src/pcobra/cobra/build/backend_pipeline.py src/pcobra/cobra/build/__init__.py` and `python -c "import pcobra.cobra.build as b; assert hasattr(b, 'resolve_backend'); print('ok', b.resolve_backend.__name__)"`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a3d84bc48327a175442d296062ff)