### PR TITLE
[PR #1980 Follow-up] Preserve default backend overrides for stdlib import resolution

### DIFF
--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -319,11 +319,6 @@ class CobraImportResolver:
                     source="stdlib",
                     resolved_name=name,
                     import_path=self._cobra_stdlib_to_python(name),
-                    backend=(
-                        str(metadata["backend_preferido"])
-                        if isinstance(metadata.get("backend_preferido"), str)
-                        else None
-                    ),
                 )
             return None
 
@@ -335,11 +330,6 @@ class CobraImportResolver:
                 source="stdlib",
                 resolved_name=qualified,
                 import_path=self._cobra_stdlib_to_python(qualified),
-                backend=(
-                    str(metadata["backend_preferido"])
-                    if isinstance(metadata.get("backend_preferido"), str)
-                    else None
-                ),
             )
         return None
 

--- a/tests/unit/test_imports_resolver.py
+++ b/tests/unit/test_imports_resolver.py
@@ -279,8 +279,18 @@ def test_resolver_adjunta_adapter_desde_resolucion():
     assert result.precedence_reason == "unique_source:python_bridge"
 
 
-def test_resolver_usa_contrato_publico_para_backend_stdlib():
+def test_resolver_respeta_default_backend_si_esta_permitido_en_stdlib():
     resolver = CobraImportResolver()
+
+    result = resolver.resolve("cobra.web")
+
+    assert result.source == "stdlib"
+    assert result.backend == "python"
+    assert result.backend_adapter is not None
+
+
+def test_resolver_fuerza_backend_preferido_stdlib_si_default_no_esta_permitido():
+    resolver = CobraImportResolver(default_backend="rust")
 
     result = resolver.resolve("cobra.web")
 


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where stdlib import candidates were pre-populated with `backend_preferido`, which prevented caller-configured `default_backend` values from being honored during backend selection.
- Ensure the resolver still enforces stdlib preference when the caller default is not permitted by the stdlib contract while allowing the caller default to take effect when allowed by fallbacks.

### Description
- Stop injecting `backend_preferido` into `ResolutionResult` in `CobraImportResolver._resolve_stdlib_module()` so `_attach_backend_adapter()` can use `resolution.backend or self.default_backend` as intended (`src/pcobra/cobra/imports/resolver.py`).
- Update resolver unit tests in `tests/unit/test_imports_resolver.py` to assert that a configured `default_backend` is respected when allowed and that the stdlib preferred backend is enforced when the default is not permitted.
- No changes were made to the adapter-attachment logic; this change only adjusts candidate construction to restore correct precedence between caller defaults and stdlib preferences.

### Testing
- Ran `pytest tests/unit/test_imports_resolver.py -k "stdlib or backend"` to validate the updated cases and test collection failed during import with an unrelated `ImportError` originating in `pcobra.cobra.build.backend_pipeline`, so the new assertions were not executed in this environment.
- The test updates are included and will run in CI where the existing import error does not occur; local failure is environmental and unrelated to the resolver change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a4c88b488327b1547b087b9aed6b)