### PR TITLE
[PR #1981 follow-up] Preserve namespace_required enforcement in usar import flow

### DIFF
--- a/src/pcobra/cobra/imports/__init__.py
+++ b/src/pcobra/cobra/imports/__init__.py
@@ -3,6 +3,8 @@
 from pcobra.cobra.imports.resolver import (
     CobraImportResolver,
     HybridModuleSpec,
+    ImportCollisionError,
+    ImportNotFoundError,
     ImportResolutionError,
     ResolutionResult,
 )
@@ -10,6 +12,8 @@ from pcobra.cobra.imports.resolver import (
 __all__ = [
     "CobraImportResolver",
     "HybridModuleSpec",
+    "ImportCollisionError",
+    "ImportNotFoundError",
     "ImportResolutionError",
     "ResolutionResult",
 ]

--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -22,6 +22,14 @@ class ImportResolutionError(RuntimeError):
     """Error base al resolver imports Cobra."""
 
 
+class ImportNotFoundError(ImportResolutionError):
+    """No se encontró un módulo resoluble para el nombre solicitado."""
+
+
+class ImportCollisionError(ImportResolutionError):
+    """El import es ambiguo y requiere namespace explícito o strict mode."""
+
+
 @dataclass(frozen=True)
 class HybridModuleSpec:
     """Declaración de módulo híbrido."""
@@ -186,7 +194,7 @@ class CobraImportResolver:
                 candidates.append(candidate)
 
         if not candidates:
-            raise ImportResolutionError(f"No se encontró módulo para '{name}'")
+            raise ImportNotFoundError(f"No se encontró módulo para '{name}'")
 
         precedence_reason = (
             f"unique_source:{candidates[0].source}"
@@ -211,7 +219,7 @@ class CobraImportResolver:
                     if self.collision_policy == "namespace_required"
                     else " Activa resolución explícita en strict mode."
                 )
-                raise ImportResolutionError(f"{message}{suffix}")
+                raise ImportCollisionError(f"{message}{suffix}")
             warnings.warn(message, category=UserWarning, stacklevel=2)
 
         selected = ResolutionResult(

--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -167,12 +167,12 @@ def obtener_modulo(nombre: str):
     spec = USAR_WHITELIST[nombre]
 
     base = Path(__file__).resolve()
-    from pcobra.cobra.imports.resolver import CobraImportResolver, ImportResolutionError
+    from pcobra.cobra.imports.resolver import CobraImportResolver, ImportNotFoundError
 
     resolver = CobraImportResolver(project_root=base.parents[3])
     try:
         _, module = resolver.load_module(nombre, fallback_backend="python")
-    except ImportResolutionError:
+    except ImportNotFoundError:
         module = None
     else:
         if module is not None:

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -170,3 +170,23 @@ def test_obtener_modulo_delega_en_nuevo_resolver(monkeypatch):
     mod = usar_loader.obtener_modulo('json')
 
     assert mod is mock_mod
+
+
+def test_obtener_modulo_no_silencia_colisiones_de_import(monkeypatch):
+    monkeypatch.setitem(usar_loader.USAR_WHITELIST, 'json', 'json')
+
+    from pcobra.cobra.imports import resolver as imports_resolver
+
+    class FakeResolver:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def load_module(self, nombre, fallback_backend='python'):
+            raise imports_resolver.ImportCollisionError(
+                f"Colisión de import para '{nombre}' en namespace_required"
+            )
+
+    monkeypatch.setattr(imports_resolver, 'CobraImportResolver', FakeResolver)
+
+    with pytest.raises(imports_resolver.ImportCollisionError, match="namespace_required"):
+        usar_loader.obtener_modulo('json')


### PR DESCRIPTION
### Motivation
- Prevent `namespace_required` collision hardening from being silently bypassed by the legacy `usar` fallback path. 
- Distinguish between a truly missing module and an ambiguous/collision error so that fallback/install only runs for the missing case. 

### Description
- Introduce two specific resolver exceptions: `ImportNotFoundError` and `ImportCollisionError` and use them instead of the generic `ImportResolutionError` in the relevant branches of `src/pcobra/cobra/imports/resolver.py`. 
- Make `CobraImportResolver.resolve()` raise `ImportNotFoundError` when no candidate is found and `ImportCollisionError` when a short-name collision occurs under `strict_error`/`namespace_required`. 
- Change `src/pcobra/cobra/usar_loader.py` so `obtener_modulo()` only falls back to the legacy `importlib` / manual lookup when the resolver raised `ImportNotFoundError`, allowing collision errors to propagate. 
- Export the new exceptions from `src/pcobra/cobra/imports/__init__.py` and add a unit test `tests/unit/test_usar.py::test_obtener_modulo_no_silencia_colisiones_de_import` to assert collisions are not silenced by `usar`. 

### Testing
- Ran `pytest -q tests/unit/test_imports_resolver.py`, which failed during collection due to a pre-existing import error unrelated to this change: `ImportError: cannot import name 'resolve_backend' from pcobra.cobra.build.backend_pipeline`. 
- Ran `pytest -q tests/unit/test_usar.py`, which in this environment reported `5 failed, 1 passed` because the resolver import path reached the same pre-existing dependency issue and some tests exercised resolver-backed flows; the newly added collision propagation test asserts the intended behavior and will pass once the upstream import error is resolved. 
- The change is limited to error type separation and control flow in `obtener_modulo()`, and the test failures seen are due to an external import-chain issue rather than the collision-handling logic itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a5b790e883279b2067168857e799)