### PR TITLE
fix(cli): restore compile_cmd TRANSPILERS compatibility export

### DIFF
--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -5,8 +5,10 @@ import inspect
 from argparse import ArgumentTypeError
 from importlib import import_module
 from importlib.metadata import entry_points
+from typing import Iterator, Mapping
 
 from pcobra.cobra.build import backend_pipeline
+from pcobra.cobra.build.backend_pipeline import TRANSPILERS as _OFFICIAL_TRANSPILERS
 from pcobra.cobra.cli.target_policies import (
     OFFICIAL_TRANSPILATION_TARGETS,
     parse_target,
@@ -42,6 +44,32 @@ MAX_LANGUAGES = 10
 
 _PLUGIN_TRANSPILERS: dict[str, type] = {}
 _ENTRYPOINTS_LOADED = False
+
+
+class _TranspilerRegistryView(Mapping[str, type]):
+    """Vista pública compatible para consumidores legacy de ``compile_cmd.TRANSPILERS``."""
+
+    def __getitem__(self, backend: str) -> type:
+        if backend in _PLUGIN_TRANSPILERS:
+            return _PLUGIN_TRANSPILERS[backend]
+        return _OFFICIAL_TRANSPILERS[backend]
+
+    def __iter__(self) -> Iterator[str]:
+        seen: set[str] = set()
+        for backend in _OFFICIAL_TRANSPILERS:
+            seen.add(backend)
+            yield backend
+        for backend in _PLUGIN_TRANSPILERS:
+            if backend in seen:
+                continue
+            yield backend
+
+    def __len__(self) -> int:
+        return len(set(_OFFICIAL_TRANSPILERS) | set(_PLUGIN_TRANSPILERS))
+
+
+# Alias público estable para módulos que importan ``TRANSPILERS`` desde compile_cmd.
+TRANSPILERS: Mapping[str, type] = _TranspilerRegistryView()
 
 
 def register_transpiler_backend(backend: str, transpiler_cls, *, context: str) -> str:


### PR DESCRIPTION
### Motivation
- Downstream modules still import `TRANSPILERS` from `compile_cmd`, and the previous change hid that symbol causing import-time failures; restore a public alias to preserve compatibility.
- Preserve the backend pipeline facade direction by exposing a compatibility view without reverting the migration that routes resolution/transpilation through `backend_pipeline`.

### Description
- Import the official registry as `_OFFICIAL_TRANSPILERS` from `pcobra.cobra.build.backend_pipeline` and keep plugin registrations in the local `_PLUGIN_TRANSPILERS` map.
- Add `_TranspilerRegistryView`, a `Mapping[str, type]` that merges official transpilers and plugin-registered transpilers and implements lookup, iteration (official first, then plugins), and `len()` as a union.
- Export a public `TRANSPILERS` alias referencing the compatibility view so modules importing `TRANSPILERS` from `compile_cmd` continue to work while the CLI still uses the backend pipeline facade.

### Testing
- Ran `python -m py_compile src/pcobra/cobra/cli/commands/compile_cmd.py src/pcobra/cobra/cli/commands/bench_transpilers_cmd.py src/pcobra/gui/runtime.py` and compilation succeeded.
- Ran `python -m pytest tests/unit/test_public_commands_transpiler_import_contract.py -q` and the test suite passed (`2 passed`).
- Performed a runtime import check for `compile_cmd.TRANSPILERS` which failed due to a pre-existing `pcobra.cobra.build.__init__` import issue unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a6d2e5c483278d24eaf6ee54e82b)