### PR TITLE
Fix public CLI --ui v1 auto-migration path

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -707,7 +707,8 @@ class CliApplication:
         if profile != PROFILE_PUBLIC:
             return normalized
 
-        if self._resolve_selected_ui_from_argv(normalized) == "v1":
+        requested_ui = self._resolve_ui_token_from_argv(normalized)
+        if requested_ui == "v1" and not self._is_internal_v1_ui_enabled():
             for index, token in enumerate(normalized):
                 if token == "--ui" and index + 1 < len(normalized):
                     normalized[index + 1] = "v2"


### PR DESCRIPTION
### Motivation
- Resolver un fallo donde `--ui v1` en perfil público podía fallar la validación de `argparse` porque la comprobación previa usaba `_resolve_selected_ui_from_argv` (que ya coerciona a `v2`) y por tanto nunca aplicaba la reescritura/migración/advertencia prevista.

### Description
- En `src/pcobra/cobra/cli/cli.py` se modificó `_apply_public_cli_policy()` para leer el token crudo con `_resolve_ui_token_from_argv()` y reescribir `--ui v1` a `v2` sólo cuando la activación interna de `v1` no está habilitada, restaurando el comportamiento de migración y advertencia para llamadas públicas.

### Testing
- Ejecutado `python -m compileall src/pcobra/cobra/cli/cli.py` y la compilación del módulo fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a7d653788327bd086e2f014a1824)