### PR TITLE
Fix bridge probe to re-raise unexpected ModuleNotFoundError

### DIFF
--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -430,8 +430,12 @@ class CobraImportResolver:
             return None
         try:
             spec = importlib.util.find_spec(name)
-        except ModuleNotFoundError:
-            return None
+        except ModuleNotFoundError as exc:
+            missing_module = exc.name
+            top_level_name = name.split(".", maxsplit=1)[0]
+            if missing_module in {name, top_level_name}:
+                return None
+            raise
         if spec is None:
             return None
         return ResolutionResult(

--- a/tests/unit/test_imports_resolver.py
+++ b/tests/unit/test_imports_resolver.py
@@ -139,6 +139,24 @@ def test_bridge_python_directo():
     assert result.import_path == "json"
 
 
+def test_bridge_python_repropaga_module_not_found_inesperado(monkeypatch):
+    resolver = CobraImportResolver()
+
+    import importlib.util
+
+    original_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name: str):
+        if name == "pkg.sub":
+            raise ModuleNotFoundError("No module named 'missing_dep'", name="missing_dep")
+        return original_find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    with pytest.raises(ModuleNotFoundError, match="missing_dep"):
+        resolver.resolve("pkg.sub")
+
+
 def test_ruta_oficial_importar_pandas_via_python_bridge(monkeypatch):
     resolver = CobraImportResolver()
 


### PR DESCRIPTION
### Motivation
- `importlib.util.find_spec()` can raise `ModuleNotFoundError` for missing dependencies inside a real package (e.g. resolving `pkg.sub` when `pkg.__init__` imports a missing dep), and swallowing all `ModuleNotFoundError` hides these real package errors and misroutes resolution.

### Description
- Tighten `_resolve_python_bridge` in `src/pcobra/cobra/imports/resolver.py` so it only treats `ModuleNotFoundError` as "not found" when the exception `name` matches the requested import or its top-level package, and re-raises the exception otherwise.
- Add `test_bridge_python_repropaga_module_not_found_inesperado` to `tests/unit/test_imports_resolver.py` which simulates a dotted import (`pkg.sub`) raising `ModuleNotFoundError` for an unrelated missing dependency and asserts the error is propagated.

### Testing
- Ran `pytest -q tests/unit/test_imports_resolver.py` and all tests passed (`29 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a8f97a4083278ae034d3e27c5992)