### PR TITLE
Fix generated reverse-scope summary for historical java input

### DIFF
--- a/src/pcobra/cobra/cli/target_policies.py
+++ b/src/pcobra/cobra/cli/target_policies.py
@@ -295,9 +295,15 @@ def render_reverse_scope_summary(reverse_scope: tuple[str, ...], *, markup: Rend
     """Renderiza la línea pública de orígenes reverse oficiales."""
     official_targets_count = len(OFFICIAL_TRANSPILATION_TARGETS)
     reverse_rendered = ", ".join(reverse_scope)
+    java_historical_note = (
+        " (java se mantiene como **entrada histórica, no salida oficial**)"
+        if "java" in reverse_scope
+        else ""
+    )
     return (
         "- **Orígenes de transpilación inversa**: "
         + reverse_rendered
+        + java_historical_note
         + f". Este alcance reverse de entrada está separado de los {official_targets_count} targets oficiales de salida."
     )
 


### PR DESCRIPTION
### Motivation
- Fix a documentation-generator drift where the README line about reverse-transpile origins was edited manually but `render_reverse_scope_summary` in `src/pcobra/cobra/cli/target_policies.py` still emitted the old sentence, causing the docs-regeneration CI check to produce a diff and fail.

### Description
- Update `render_reverse_scope_summary` in `src/pcobra/cobra/cli/target_policies.py` to append the historical-note text for `java` when `java` appears in the reverse-scope inputs so generator output matches the README generated block.
- Keep the change localized to generator/rendering logic and do not modify transpiler or runtime behavior.
- Provide a short validation step so the generated sentence produced by the generator functions matches the existing README wording for the reverse-scope line.

### Testing
- Ran `python - <<'PY' ... render_reverse_scope_summary(...) ... PY` to verify the rendered sentence includes the `java` historical note, and the output matched the README generated line (success).
- Ran `python -m py_compile src/pcobra/cobra/cli/target_policies.py` to confirm the modified module compiles (success).
- Ran `python scripts/generate_target_policy_docs.py` which failed due to missing README markers (`<!-- BEGIN GENERATED TARGET TIERS -->` / `<!-- END GENERATED TARGET TIERS -->`), a pre-existing issue outside the scope of this change (failure unrelated to the `java` sentence fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a9e48fc88327bdabb9b40b6b6f5f)