### PR TITLE
docs: corregir flujo CLI del libro para comandos públicos v2

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -301,9 +301,9 @@ Cobra incluye módulos de soporte para flujos asíncronos y coordinación.
 Flujo mínimo sugerido:
 
 ```bash
-cobra validar-sintaxis src/app.cobra
-cobra ejecutar src/app.cobra
-cobra compilar src/app.cobra --tipo python
+cobra run src/app.cobra
+cobra test
+cobra build src/app.cobra --target python
 ```
 
 Comandos útiles adicionales (según el setup del proyecto):
@@ -457,7 +457,7 @@ Checklist rápido:
 
 ## 18) Apéndice: checklist de publicación de un proyecto Cobra
 
-- [ ] `cobra validar-sintaxis` en todo `src/`.
+- [ ] `cobra test` ejecutado en local/CI para validar el código de `src/`.
 - [ ] tests pasando en CI.
 - [ ] documentación de uso actualizada.
 - [ ] ejemplos ejecutables y verificados.


### PR DESCRIPTION
### Motivation

- Evitar que la "Guía principal recomendada" del libro use comandos de CLI obsoletos o no expuestos en el perfil público, lo que provoca una primera instrucción rota.
- Alinear el flujo sugerido y el checklist de publicación con la superficie pública v2 de la CLI (`run/test/build`).

### Description

- Reemplacé el flujo mínimo sugerido en `docs/LIBRO_PROGRAMACION_COBRA.md` para usar `cobra run src/app.cobra`, `cobra test` y `cobra build src/app.cobra --target python` en lugar de los comandos legacy/obsoletos.
- Actualicé el checklist de publicación en el mismo archivo para eliminar la entrada `cobra validar-sintaxis` y exigir `cobra test` ejecutado en local/CI como verificación ejecutable.

### Testing

- Ejecuté `rg -n "validar-sintaxis|cobra ejecutar|cobra compilar|Flujo mínimo sugerido|cobra run|cobra build|cobra test" docs/LIBRO_PROGRAMACION_COBRA.md` para verificar que las ocurrencias del flujo fueron actualizadas, y la búsqueda devolvió las líneas esperadas.
- Ejecuté `git diff --check` para comprobar problemas de formato/espaciado y no se detectaron advertencias.
- Inspeccioné las líneas afectadas con `nl -ba docs/LIBRO_PROGRAMACION_COBRA.md | sed -n '296,316p;452,466p'` para confirmar el contenido actualizado en contexto.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4aaf66670832782ed9dbdf9627847)