### PR TITLE
[PR #2032 Follow-up] Avoid capability metadata crashes for internal legacy module targets

### DIFF
--- a/src/pcobra/cobra/build/orchestrator.py
+++ b/src/pcobra/cobra/build/orchestrator.py
@@ -179,6 +179,11 @@ class BuildOrchestrator:
     def _supports_capabilities(self, backend: str, capabilities: tuple[str, ...]) -> bool:
         if not capabilities:
             return True
+        if backend not in OFFICIAL_TARGETS:
+            # Backends internos legacy no publican metadata oficial de capacidades.
+            # Evitamos consultar ``target_metadata`` para no disparar KeyError cuando
+            # llegan por metadata del módulo bajo la flag temporal de compatibilidad.
+            return True
 
         metadata = target_metadata(backend)
         for capability in capabilities:

--- a/tests/unit/test_build_orchestrator.py
+++ b/tests/unit/test_build_orchestrator.py
@@ -68,3 +68,22 @@ def test_build_orchestrator_rechaza_backend_internal_only_sin_flag(monkeypatch):
 
     assert "Backend no permitido" in error
     assert "go" not in error.split("Permitidos: ", 1)[-1]
+
+
+def test_build_orchestrator_backend_internal_desde_metadata_ignora_filtro_capacidades(monkeypatch):
+    monkeypatch.setattr(
+        "cobra.build.orchestrator.get_toml_map",
+        lambda: {
+            "project": {"required_capabilities": ["sdk_full"]},
+            "modulos": {
+                "demo.co": {
+                    "preferred_target": "go",
+                }
+            },
+        },
+    )
+    monkeypatch.setenv("COBRA_INTERNAL_LEGACY_TARGETS", "1")
+
+    resolution = BuildOrchestrator().resolve_backend(source_file="demo.co")
+
+    assert resolution.backend == "go"


### PR DESCRIPTION
### Motivation

- Fix a high-priority regression where module-derived internal legacy targets (e.g. `go`) allowed by the temporary `COBRA_INTERNAL_LEGACY_TARGETS` flag caused `KeyError` during capability checks because `target_metadata()` only supports official backends. 
- Keep the compatibility gate but ensure module-specified internal targets do not trigger unsafe metadata lookups during resolution.

### Description

- Added a guard in `BuildOrchestrator._supports_capabilities` to skip `target_metadata()` lookups for backends not in `OFFICIAL_TARGETS`, returning `True` for capability checks on internal legacy backends. 
- Added `test_build_orchestrator_backend_internal_desde_metadata_ignora_filtro_capacidades` in `tests/unit/test_build_orchestrator.py` to reproduce the scenario (`COBRA_INTERNAL_LEGACY_TARGETS=1`, module `preferred_target: go`, non-empty `required_capabilities`) and verify resolution succeeds. 
- Committed the changes to the branch and prepared this follow-up PR on top of the previous changes to avoid runtime crashes.

### Testing

- Ran `pytest -q tests/unit/test_build_orchestrator.py` and the suite completed successfully with `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ab9889948327a06621260299c841)