### PR TITLE
Handle intermediate missing packages in python bridge probe

### DIFF
--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -432,8 +432,9 @@ class CobraImportResolver:
             spec = importlib.util.find_spec(name)
         except ModuleNotFoundError as exc:
             missing_module = exc.name
-            top_level_name = name.split(".", maxsplit=1)[0]
-            if missing_module in {name, top_level_name}:
+            if missing_module == name or (
+                isinstance(missing_module, str) and name.startswith(f"{missing_module}.")
+            ):
                 return None
             raise
         if spec is None:

--- a/tests/unit/test_imports_resolver.py
+++ b/tests/unit/test_imports_resolver.py
@@ -157,6 +157,26 @@ def test_bridge_python_repropaga_module_not_found_inesperado(monkeypatch):
         resolver.resolve("pkg.sub")
 
 
+def test_bridge_python_modulo_intermedio_faltante_se_trata_como_no_encontrado(monkeypatch):
+    resolver = CobraImportResolver()
+
+    import importlib.util
+
+    original_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name: str):
+        if name == "json.foo.bar":
+            raise ModuleNotFoundError("No module named 'json.foo'", name="json.foo")
+        return original_find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    with pytest.raises(ImportResolutionError) as excinfo:
+        resolver.resolve("json.foo.bar")
+
+    assert excinfo.value.code == "IMP-NOT-FOUND-001"
+
+
 def test_ruta_oficial_importar_pandas_via_python_bridge(monkeypatch):
     resolver = CobraImportResolver()
 


### PR DESCRIPTION
### Motivation
- `importlib.util.find_spec()` can raise `ModuleNotFoundError` for an intermediate dotted segment (e.g. resolving `json.foo.bar` may raise with `exc.name == "json.foo"`), which should be treated as a normal unresolved-module case rather than an unexpected runtime error.
- The resolver previously only accepted exact matches or top-level misses, causing unrelated intermediate misses to leak raw `ModuleNotFoundError` and break the resolver's stable not-found contract.

### Description
- Update `_resolve_python_bridge` in `src/pcobra/cobra/imports/resolver.py` to treat `ModuleNotFoundError` as "not found" when `exc.name` equals the requested name or when the requested name starts with `f"{exc.name}."` (i.e. the exception refers to an intermediate dotted prefix), and re-raise in all other cases.
- Add `test_bridge_python_modulo_intermedio_faltante_se_trata_como_no_encontrado` in `tests/unit/test_imports_resolver.py` which fakes `importlib.util.find_spec` to raise `ModuleNotFoundError(name="json.foo")` for `json.foo.bar` and asserts the resolver raises `ImportResolutionError` with code `IMP-NOT-FOUND-001`.
- Preserve existing test `test_bridge_python_repropaga_module_not_found_inesperado` that verifies unrelated `ModuleNotFoundError` (e.g. `name="missing_dep"`) is still re-raised.

### Testing
- Ran `pytest -q tests/unit/test_imports_resolver.py` and the suite passed with `30 passed` tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4aebcdd188327ae6c48dd3c38b8f3)