### PR TITLE
docs: corregir ejemplos v2 de test/build en LIBRO_PROGRAMACION_COBRA.md

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -302,8 +302,8 @@ Flujo mínimo sugerido:
 
 ```bash
 cobra run src/app.cobra
-cobra test
-cobra build src/app.cobra --target python
+cobra test src/app.cobra
+cobra build src/app.cobra
 ```
 
 Comandos útiles adicionales (según el setup del proyecto):


### PR DESCRIPTION
### Motivation

- Evitar que la guía muestre comandos incompatibles con la CLI pública v2 que provocaban errores de parsing y confusión para usuarios nuevos.

### Description

- En `docs/LIBRO_PROGRAMACION_COBRA.md` se actualizó el bloque "Flujo mínimo sugerido" para usar `cobra test src/app.cobra` en lugar de `cobra test` y `cobra build src/app.cobra` en lugar de `cobra build src/app.cobra --target python`.

### Testing

- Ejecuté `rg -n "Flujo mínimo sugerido|cobra test src/app.cobra|cobra build src/app.cobra|--target" docs/LIBRO_PROGRAMACION_COBRA.md`, `git diff --check`, y `nl -ba docs/LIBRO_PROGRAMACION_COBRA.md | sed -n '300,310p'`, y las comprobaciones confirmaron las líneas actualizadas sin advertencias.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4afc3eed883279a27de9de6221ebb)