### PR TITLE
Evitar doble limpieza de contexto en llamadas de función (intérprete)

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1562,13 +1562,15 @@ class InterpretadorCobra:
                 return generador()
             else:
                 preparar_contexto()
-                resultado = None
-                for instruccion in funcion["cuerpo"]:
-                    resultado = self.ejecutar_nodo(instruccion)
-                    if resultado is not None:
-                        break
-                limpiar_contexto()
-                return resultado
+                try:
+                    resultado = None
+                    for instruccion in funcion["cuerpo"]:
+                        resultado = self.ejecutar_nodo(instruccion)
+                        if resultado is not None:
+                            break
+                    return resultado
+                finally:
+                    limpiar_contexto()
 
     def ejecutar_clase(self, nodo):
         """Registra una clase definida por el usuario."""

--- a/tests/unit/test_generadores.py
+++ b/tests/unit/test_generadores.py
@@ -1,4 +1,4 @@
-from core.ast_nodes import NodoFuncion, NodoYield, NodoValor
+from core.ast_nodes import NodoAsignacion, NodoFuncion, NodoYield, NodoValor
 from core.ast_nodes import NodoLlamadaFuncion
 from core.interpreter import InterpretadorCobra
 
@@ -10,3 +10,25 @@ def test_interpretador_generador_simple():
     gen = inter.ejecutar_llamada_funcion(NodoLlamadaFuncion("gen", []))
     assert next(gen) == 1
     assert next(gen) == 2
+
+
+def test_generador_limpia_contexto_exactamente_una_vez_en_finally():
+    inter = InterpretadorCobra()
+    inter.ejecutar_asignacion(NodoAsignacion("global_previa", NodoValor(7)))
+    contextos_iniciales = len(inter.contextos)
+    mem_contextos_iniciales = len(inter.mem_contextos)
+
+    funcion = NodoFuncion("gen", [], [NodoYield(NodoValor(1))])
+    inter.ejecutar_funcion(funcion)
+    gen = inter.ejecutar_llamada_funcion(NodoLlamadaFuncion("gen", []))
+
+    assert next(gen) == 1
+
+    try:
+        next(gen)
+    except StopIteration:
+        pass
+
+    assert inter.obtener_variable("global_previa") == 7
+    assert len(inter.contextos) == contextos_iniciales
+    assert len(inter.mem_contextos) == mem_contextos_iniciales

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -84,6 +84,26 @@ def test_preservacion_de_variables_globales():
     assert inter.variables["a"] == 5
 
 
+def test_regresion_llamada_funcion_no_yield_limpia_contexto_una_sola_vez():
+    """Evita doble limpieza de contexto y underflow de pilas internas."""
+    inter = InterpretadorCobra()
+    inter.ejecutar_asignacion(NodoAsignacion("global_previa", NodoValor(99)))
+    contextos_iniciales = len(inter.contextos)
+    mem_contextos_iniciales = len(inter.mem_contextos)
+
+    funcion = NodoFuncion(
+        "sin_yield",
+        [],
+        [NodoAsignacion("local_tmp", NodoValor(1))],
+    )
+    inter.ejecutar_funcion(funcion)
+    inter.ejecutar_llamada_funcion(NodoLlamadaFuncion("sin_yield", []))
+
+    assert inter.obtener_variable("global_previa") == 99
+    assert len(inter.contextos) == contextos_iniciales
+    assert len(inter.mem_contextos) == mem_contextos_iniciales
+
+
 def test_imprimir_cadena_literal():
     inter = InterpretadorCobra()
     nodo = NodoImprimir(NodoValor("Hola"))


### PR DESCRIPTION
### Motivation
- Corregir una ruta de salida de `ejecutar_llamada_funcion` que podía invocar `limpiar_contexto()` de forma redundante y provocar underflow en las pilas internas de contexto/memoria. 
- Asegurar que la limpieza del contexto ocurra exactamente una vez tanto en la rama con `yield` como en la rama sin `yield`.

### Description
- Reescribo la rama sin `yield` en `ejecutar_llamada_funcion` para envolver la ejecución del cuerpo en un `try/finally` y llamar a `limpiar_contexto()` únicamente en el `finally` en lugar de hacerlo antes del `return` (archivo modificado: `src/pcobra/core/interpreter.py`).
- Mantengo la limpieza del contexto en la ruta con `yield` dentro del `finally` del generador para que la limpieza siga ocurriendo exactamente una vez al agotarse el generador (misma función, misma ubicación).
- Añado un test de regresión que define e invoca una función sin `yield` y comprueba que una variable global previa sigue accesible y que `len(self.contextos)` y `len(self.mem_contextos)` vuelven a sus valores iniciales (archivo modificado: `tests/unit/test_interpreter.py`).
- Añado un test que agota un generador y verifica que la limpieza ocurre una sola vez y que las pilas quedan balanceadas (archivo modificado: `tests/unit/test_generadores.py`).

### Testing
- Se ejecutó `pytest -q tests/unit/test_interpreter.py tests/unit/test_generadores.py` y todos los tests automatizados pasaron (15 passed).
- Los tests de regresión añadidos verifican que no hay underflow en `self.contextos` ni en `self.mem_contextos` y que variables globales permanecen accesibles después de la llamada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c1bc06a0832785fcaac1e744b467)