### PR TITLE
Unificar pipeline de análisis/ejecución entre execute e interactive

### DIFF
--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -21,8 +21,9 @@ from pcobra.cobra.cli.target_policies import (
     parse_runtime_target,
     resolve_docker_backend,
 )
-from pcobra.cobra.core import Lexer, LexerError
-from pcobra.cobra.core import Parser, ParserError
+from pcobra.cobra.core import LexerError
+from pcobra.cobra.core import ParserError
+from pcobra.cobra.cli.execution_pipeline import analizar_codigo, ejecutar_ast
 from pcobra.cobra.transpilers import module_map
 from pcobra.core.interpreter import InterpretadorCobra
 from pcobra.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
@@ -443,14 +444,14 @@ class ExecuteCommand(BaseCommand):
     def _analizar_codigo(self, codigo: str) -> Any:
         """Pipeline canónico: Lexer(codigo).tokenizar() + Parser(tokens).parsear()."""
 
-        tokens = Lexer(codigo).tokenizar()
-        return Parser(tokens).parsear()
+        return analizar_codigo(codigo)
 
     def _ejecutar_ast(self, ast: Any, **interpreter_kwargs: Any) -> None:
         """Ejecuta un AST con el intérprete de Cobra."""
 
         interpretador_cls = _obtener_interpretador_cls()
-        interpretador_cls(**interpreter_kwargs).ejecutar_ast(ast)
+        interpreter = interpretador_cls(**interpreter_kwargs)
+        ejecutar_ast(ast, interpreter)
 
     @staticmethod
     def _formatear_codigo(archivo: str) -> bool:

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -32,6 +32,7 @@ except ModuleNotFoundError:  # pragma: no cover - entornos sin prompt_toolkit
 
 from pcobra.cobra.core import Lexer, LexerError, TipoToken, UnclosedStringError
 from pcobra.cobra.core import Parser, ParserError
+from pcobra.cobra.cli.execution_pipeline import analizar_codigo, ejecutar_ast
 from pcobra.cobra.transpilers import module_map
 from pcobra.core.ast_nodes import NodoBucleMientras, NodoCondicional, NodoPara, NodoSwitch, NodoTryCatch
 from pcobra.core.interpreter import InterpretadorCobra
@@ -321,10 +322,7 @@ class InteractiveCommand(BaseCommand):
         if depth > self.MAX_AST_DEPTH:
             raise RuntimeError(_("Se excedió la profundidad máxima del AST"))
 
-        tokens = Lexer(linea).tokenizar()
-        self.logger.debug(_("Tokens generados: {tokens}").format(tokens=tokens))
-
-        ast = Parser(tokens).parsear()
+        ast = analizar_codigo(linea)
         self.logger.debug(_("AST generado: {ast}").format(ast=ast))
 
         if validador:
@@ -339,7 +337,7 @@ class InteractiveCommand(BaseCommand):
         self.logger.debug("[RUN] Ejecutando snippet en REPL")
         ast = self.procesar_ast(codigo, validador)
         self.logger.debug("[EXEC] Ejecutando AST en intérprete")
-        resultado = self.interpretador.ejecutar_ast(ast)
+        resultado = ejecutar_ast(ast, self.interpretador)
         self.logger.debug("[EVAL] Resultado de evaluación: %r", resultado)
         debe_imprimir_resultado = (
             resultado is not None

--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -1,0 +1,20 @@
+"""Pipeline compartido de análisis/ejecución para CLI Cobra."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pcobra.cobra.core import Lexer, Parser
+
+
+def analizar_codigo(codigo: str) -> Any:
+    """Analiza código fuente con el pipeline canónico Lexer+Parser."""
+
+    tokens = Lexer(codigo).tokenizar()
+    return Parser(tokens).parsear()
+
+
+def ejecutar_ast(ast: Any, interpreter: Any) -> Any:
+    """Ejecuta un AST usando una instancia explícita de intérprete."""
+
+    return interpreter.ejecutar_ast(ast)

--- a/tests/unit/test_cli_execution_pipeline_contract.py
+++ b/tests/unit/test_cli_execution_pipeline_contract.py
@@ -1,13 +1,13 @@
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cobra.cli.commands.execute_cmd import ExecuteCommand
-from cobra.cli.commands.interactive_cmd import InteractiveCommand
-from core.interpreter import InterpretadorCobra
-
+from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
+from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+from pcobra.core.interpreter import InterpretadorCobra
 
 
 def _args_interactive():
@@ -20,7 +20,6 @@ def _args_interactive():
         ignore_memory_limit=True,
         allow_insecure_fallback=False,
     )
-
 
 
 def test_contrato_resultado_igual_entre_modo_archivo_y_interactivo():
@@ -37,6 +36,38 @@ def test_contrato_resultado_igual_entre_modo_archivo_y_interactivo():
     assert result_file == 0
     assert out_file.getvalue() == out_repl.getvalue()
 
+
+@pytest.mark.parametrize(
+    ("caso", "codigo"),
+    [
+        (
+            "mientras multilinea",
+            "x = 0\nmientras falso:\n    imprimir(99)\nfin\nimprimir(x)",
+        ),
+        (
+            "si_sino multilinea",
+            "x = 2\nsi x < 1:\n    imprimir('menor')\nsino:\n    imprimir('mayor')\nfin",
+        ),
+        (
+            "funcion con mutacion",
+            "func incrementar(v):\n    retorno v + 1\nfin\nx = 1\nx = incrementar(x)\nimprimir(x)",
+        ),
+    ],
+)
+def test_contrato_salida_y_error_iguales_entre_execute_e_interactive(caso, codigo):
+    cmd_execute = ExecuteCommand()
+    out_execute, err_execute = StringIO(), StringIO()
+    with redirect_stdout(out_execute), redirect_stderr(err_execute):
+        rc_execute = cmd_execute._ejecutar_normal(codigo, seguro=False, extra_validators=None)
+
+    cmd_interactive = InteractiveCommand(InterpretadorCobra())
+    out_repl, err_repl = StringIO(), StringIO()
+    with redirect_stdout(out_repl), redirect_stderr(err_repl):
+        cmd_interactive.ejecutar_codigo(codigo)
+
+    assert rc_execute == 0, f"{caso}: execute devolvió código distinto de 0"
+    assert out_execute.getvalue() == out_repl.getvalue(), f"{caso}: salida divergente"
+    assert err_execute.getvalue() == err_repl.getvalue(), f"{caso}: error divergente"
 
 
 def test_contrato_error_igual_entre_modo_archivo_y_interactivo():
@@ -90,12 +121,11 @@ def test_contrato_pipeline_error_y_mensaje_entre_no_interactivo_y_repl(
     assert str(err_execute) == str(err_repl), f"{caso}: mensaje de error divergente"
 
 
-
 def test_repl_ejecuta_bloque_completo_sin_parseo_parcial_por_linea():
     inputs = ["si verdadero:", "imprimir(1)", "fin", "salir"]
     cmd = InteractiveCommand(MagicMock())
 
-    with patch("cobra.cli.commands.interactive_cmd.validar_dependencias"), patch(
+    with patch("pcobra.cobra.cli.commands.interactive_cmd.validar_dependencias"), patch(
         "prompt_toolkit.PromptSession.prompt", side_effect=inputs
     ), patch.object(
         cmd,

--- a/tests/unit/test_execute_cmd_extra_validators_normalization.py
+++ b/tests/unit/test_execute_cmd_extra_validators_normalization.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 
-from cobra.cli.commands.execute_cmd import ExecuteCommand
+from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
 from pcobra.core.semantic_validators.base import ValidadorBase
 
 
@@ -14,8 +14,7 @@ class DummyNodo:
 
 
 def _preparar_parser_lexer(monkeypatch, execute_module):
-    monkeypatch.setattr(execute_module, "Lexer", lambda _codigo: SimpleNamespace(tokenizar=lambda: ["tok"]))
-    monkeypatch.setattr(execute_module, "Parser", lambda _tokens: SimpleNamespace(parsear=lambda: [DummyNodo()]))
+    monkeypatch.setattr(execute_module, "analizar_codigo", lambda _codigo: [DummyNodo()])
 
 
 def _preparar_construir_cadena(monkeypatch, execute_module):
@@ -23,7 +22,7 @@ def _preparar_construir_cadena(monkeypatch, execute_module):
 
 
 def test_ejecutar_normal_carga_validadores_desde_una_ruta(monkeypatch):
-    import cobra.cli.commands.execute_cmd as execute_module
+    import pcobra.cobra.cli.commands.execute_cmd as execute_module
 
     _preparar_parser_lexer(monkeypatch, execute_module)
     _preparar_construir_cadena(monkeypatch, execute_module)
@@ -51,7 +50,7 @@ def test_ejecutar_normal_carga_validadores_desde_una_ruta(monkeypatch):
 
 
 def test_ejecutar_normal_carga_y_acumula_multiples_rutas(monkeypatch):
-    import cobra.cli.commands.execute_cmd as execute_module
+    import pcobra.cobra.cli.commands.execute_cmd as execute_module
 
     _preparar_parser_lexer(monkeypatch, execute_module)
     _preparar_construir_cadena(monkeypatch, execute_module)
@@ -84,7 +83,7 @@ def test_ejecutar_normal_carga_y_acumula_multiples_rutas(monkeypatch):
 
 
 def test_ejecutar_normal_acepta_lista_vacia_y_none(monkeypatch):
-    import cobra.cli.commands.execute_cmd as execute_module
+    import pcobra.cobra.cli.commands.execute_cmd as execute_module
 
     _preparar_parser_lexer(monkeypatch, execute_module)
     _preparar_construir_cadena(monkeypatch, execute_module)
@@ -111,7 +110,7 @@ def test_ejecutar_normal_acepta_lista_vacia_y_none(monkeypatch):
 
 
 def test_ejecutar_normal_muestra_error_claro_si_falla_una_ruta(monkeypatch):
-    import cobra.cli.commands.execute_cmd as execute_module
+    import pcobra.cobra.cli.commands.execute_cmd as execute_module
 
     _preparar_parser_lexer(monkeypatch, execute_module)
     _preparar_construir_cadena(monkeypatch, execute_module)
@@ -133,7 +132,7 @@ def test_ejecutar_normal_muestra_error_claro_si_falla_una_ruta(monkeypatch):
             return [DummyValidator()]
 
     monkeypatch.setattr(execute_module, "_obtener_interpretador_cls", lambda: DummyInterp)
-    monkeypatch.setattr(execute_module, "mostrar_error", lambda msg: errores.append(msg))
+    monkeypatch.setattr(execute_module, "mostrar_error", lambda msg, **_kwargs: errores.append(msg))
 
     resultado = ExecuteCommand()._ejecutar_normal("imprimir(1)", True, ["buena.py", "mala.py"])
 


### PR DESCRIPTION
### Motivation
- Centralizar el pipeline canónico de análisis y ejecución para evitar duplicación y asegurar que `execute` e `interactive` comparten la misma semántica runtime.
- Separar la lógica de presentación (REPL echo/prompt) de la lógica de runtime para que las diferencias UX no afecten el comportamiento del intérprete.

### Description
- Añade `src/pcobra/cobra/cli/execution_pipeline.py` con las funciones públicas `analizar_codigo(codigo)` (usa exactamente `Lexer(...).tokenizar()` + `Parser(...).parsear()`) y `ejecutar_ast(ast, interpreter)` (usa una instancia explícita de intérprete). 
- Refactoriza `ExecuteCommand` para delegar `_analizar_codigo` y `_ejecutar_ast` en el nuevo módulo y crear explícitamente la instancia del intérprete antes de llamar a `ejecutar_ast`.
- Refactoriza `InteractiveCommand` para delegar `procesar_ast` y `ejecutar_codigo` en el mismo módulo manteniendo en la clase solo la lógica de UX (echo/impresión y prompt).
- Actualiza tests: `tests/unit/test_cli_execution_pipeline_contract.py` se amplía para comparar `stdout` y `stderr` entre `execute` e `interactive` usando snippets multilinea (`mientras`, `si/sino`, funciones con mutación), y `tests/unit/test_execute_cmd_extra_validators_normalization.py` se adapta para mockear `analizar_codigo` en lugar de `Lexer/Parser`.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_execution_pipeline_contract.py tests/unit/test_execute_cmd_extra_validators_normalization.py`.
- Resultado: todos los tests relevantes pasaron correctamente (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c43c5bd48327bf5f77de48ea5a59)