### PR TITLE
refactor: centraliza consumo de registro de transpiladores

### DIFF
--- a/src/pcobra/cobra/cli/commands/bench_transpilers_cmd.py
+++ b/src/pcobra/cobra/cli/commands/bench_transpilers_cmd.py
@@ -7,7 +7,6 @@ from timeit import timeit
 from typing import Any, Dict, List
 
 from pcobra.cobra.cli.commands.base import BaseCommand
-from pcobra.cobra.cli.commands.compile_cmd import TRANSPILERS
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.deprecation_policy import enforce_advanced_profile_policy
 from pcobra.cobra.cli.i18n import _
@@ -171,7 +170,7 @@ class BenchTranspilersCommand(BaseCommand):
             with profile_context(profiler):
                 for size, code in programs.items():
                     ast = obtener_ast(code)
-                    for lang in TRANSPILERS:
+                    for lang in backend_pipeline.TRANSPILERS:
                         elapsed = timeit(lambda: backend_pipeline.transpile(ast, lang), number=1)
                         results.append({"size": size, "lang": lang, "time": elapsed})
 

--- a/src/pcobra/cobra/cli/commands/flet_cmd.py
+++ b/src/pcobra/cobra/cli/commands/flet_cmd.py
@@ -14,7 +14,7 @@ class FletCommand(BaseCommand):
     name = "gui"
     requires_sqlite_key: bool = False
     _CRITICAL_GUI_MODULES = (
-        "pcobra.cobra.cli.commands.compile_cmd",
+        "pcobra.cobra.transpilers.registry",
         "pcobra.cobra.core",
         "pcobra.cobra.transpilers.target_utils",
         "pcobra.cobra.transpilers.targets",
@@ -23,7 +23,7 @@ class FletCommand(BaseCommand):
     _CRITICAL_GUI_SYMBOLS = {
         "pcobra.cobra.core": ("Lexer", "Parser"),
         "pcobra.core.interpreter": ("InterpretadorCobra",),
-        "pcobra.cobra.cli.commands.compile_cmd": ("TRANSPILERS",),
+        "pcobra.cobra.transpilers.registry": ("get_transpilers",),
         "pcobra.cobra.transpilers.target_utils": ("target_cli_choices",),
     }
 

--- a/src/pcobra/cobra/cli/commands/transpilar_inverso_cmd.py
+++ b/src/pcobra/cobra/cli/commands/transpilar_inverso_cmd.py
@@ -30,7 +30,6 @@ from pcobra.cobra.transpilers.reverse.policy import (
     parse_reverse_source_language,
 )
 from pcobra.cobra.cli.commands.base import BaseCommand, CommandError
-from pcobra.cobra.cli.commands.compile_cmd import TRANSPILERS
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.mode_policy import validar_politica_modo
 from pcobra.cobra.cli.deprecation_policy import (
@@ -328,7 +327,7 @@ class TranspilarInversoCommand(BaseCommand):
             raise UnsupportedLanguageError(
                 f"No hay parser reverse disponible para el lenguaje de origen '{origen}'"
             )
-        if destino not in TRANSPILERS:
+        if destino not in backend_pipeline.TRANSPILERS:
             raise UnsupportedLanguageError(
                 f"No hay transpilador oficial disponible para el lenguaje de destino '{destino}'"
             )
@@ -386,7 +385,7 @@ class TranspilarInversoCommand(BaseCommand):
 
             # Validar transpiladores
             reverse_cls = REVERSE_TRANSPILERS.get(origen)
-            transp_cls = TRANSPILERS.get(destino)
+            transp_cls = backend_pipeline.TRANSPILERS.get(destino)
 
             logger.debug(
                 f"Usando transpilador {reverse_cls.__name__} para origen {origen}"

--- a/src/pcobra/cobra/transpilers/registry.py
+++ b/src/pcobra/cobra/transpilers/registry.py
@@ -183,6 +183,11 @@ def build_official_transpilers() -> dict[str, type]:
     return registry
 
 
+def get_transpilers() -> dict[str, type]:
+    """API pública interna para obtener el registro oficial cargado."""
+    return build_official_transpilers()
+
+
 def build_internal_legacy_transpilers() -> dict[str, type]:
     """Carga las clases legacy internas para procesos de migración interna."""
     registry: dict[str, type] = {}

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -13,7 +13,7 @@ from typing import Any
 def require_gui_dependencies() -> dict[str, Any]:
     """Importa dependencias de núcleo/transpiladores de forma diferida."""
     try:
-        from pcobra.cobra.cli.commands.compile_cmd import TRANSPILERS
+        from pcobra.cobra.build import backend_pipeline
         from pcobra.cobra.core import Lexer, LexerError, Parser, ParserError
         from pcobra.cobra.transpilers.target_utils import target_cli_choices
         from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
@@ -36,7 +36,7 @@ def require_gui_dependencies() -> dict[str, Any]:
         "target_cli_choices": target_cli_choices,
         "OFFICIAL_TARGETS": OFFICIAL_TARGETS,
         "InterpretadorCobra": InterpretadorCobra,
-        "TRANSPILERS": TRANSPILERS,
+        "TRANSPILERS": backend_pipeline.TRANSPILERS,
     }
 
 


### PR DESCRIPTION
### Motivation

- Reducir el acoplamiento transversal a `compile_cmd` y exponer un punto claro de acceso al registro de transpiladores para consumo interno.
- Evitar imports circulares o dependencias frágiles desde módulos GUI/CLI contra `compile_cmd.TRANSPILERS` usando el pipeline/registro canónico.

### Description

- Añade la API interna `get_transpilers()` en `src/pcobra/cobra/transpilers/registry.py` que delega en `build_official_transpilers()` para obtener el registro oficial.
- Sustituye usos de `compile_cmd.TRANSPILERS` por el registro canónico en `src/pcobra/cobra/cli/commands/bench_transpilers_cmd.py` usando `backend_pipeline.TRANSPILERS` en los bucles de benchmark.
- Sustituye referencias a `TRANSPILERS` en `src/pcobra/cobra/cli/commands/transpilar_inverso_cmd.py` por `backend_pipeline.TRANSPILERS` para validación y resolución de clases.
- Actualiza `src/pcobra/gui/runtime.py` para importar diferidamente `backend_pipeline` y exponer `TRANSPILERS` desde `backend_pipeline.TRANSPILERS` en el runtime de GUI.
- Modifica `src/pcobra/cobra/cli/commands/flet_cmd.py` para que `_CRITICAL_GUI_MODULES` y `_CRITICAL_GUI_SYMBOLS` dependan de `pcobra.cobra.transpilers.registry` y su `get_transpilers` en lugar de `compile_cmd.TRANSPILERS`.
- Mantiene la API pública de comandos sin cambios de interfaz para usuarios finales (`cobra run`, `cobra build`, `cobra test`, `cobra mod`).

### Testing

- Ejecuté `python -m compileall` sobre los archivos modificados (`registry.py`, `bench_transpilers_cmd.py`, `transpilar_inverso_cmd.py`, `runtime.py`, `flet_cmd.py`) y la compilación fue correcta.
- Ejecuté `PYTHONPATH=src python -m pcobra.cobra.cli.cli run --help`, `... build --help`, `... test --help` y `... mod --help` y obtuve las ayudas esperadas, confirmando que la interfaz pública de CLI no cambió.
- Intenté `python -m pcobra.cobra.cli.main run --help` y falló por ausencia del módulo en este entorno (`No module named pcobra.cobra.cli.main`), lo cual no está relacionado con el refactor aplicado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4cb04df688327a85b08889449ef72)