### PR TITLE
refactor(cli): extraer servicios reutilizables de QA/benchmark/formateo

### DIFF
--- a/src/pcobra/cobra/cli/commands/bench_cmd.py
+++ b/src/pcobra/cobra/cli/commands/bench_cmd.py
@@ -1,52 +1,21 @@
-import contextlib
 import cProfile
 import json
-import os
-import re
-from typing import Any, Dict, List, Optional, Tuple
-try:
-    import resource
-except ImportError:  # pragma: no cover - Windows
-    resource = None  # type: ignore
-    try:
-        import psutil  # type: ignore
-    except Exception:
-        psutil = None  # type: ignore
-else:
-    psutil = None  # type: ignore
-import shutil
+from typing import Any, Dict, List
 import subprocess
 import sys
-import tempfile
-import time
-from argparse import ArgumentParser
 from pathlib import Path
 
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.target_policies import OFFICIAL_RUNTIME_TARGETS
-from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+from pcobra.cobra.cli.services.benchmark_service import run_benchmarks
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.cli.deprecation_policy import enforce_advanced_profile_policy
-from pcobra.core.cobra_config import tiempo_max_transpilacion
-from pcobra.cobra.transpilers.target_utils import target_label
 from pcobra.cobra.benchmarks.targets_policy import (
     BENCHMARK_BACKEND_METADATA,
     validate_backend_metadata,
 )
-
-# Constantes
-ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
-SUBPROCESS_TIMEOUT = tiempo_max_transpilacion()
-
-CODE = """
-var x = 0
-mientras x <= 1000 :
-    x = x + 1
-fin
-imprimir(x)
-"""
 
 validate_backend_metadata(
     BENCHMARK_BACKEND_METADATA,
@@ -57,70 +26,6 @@ BACKENDS = {
     for target in OFFICIAL_RUNTIME_TARGETS
     if target in BENCHMARK_BACKEND_METADATA
 }
-
-def run_and_measure(
-    cmd: List[str], env: Optional[Dict[str, str]] = None
-) -> Tuple[float, int]:
-    """Ejecuta un comando y mide su tiempo de ejecución y uso de memoria.
-
-    Args:
-        cmd: Lista de argumentos del comando a ejecutar
-        env: Diccionario con variables de entorno
-
-    Returns:
-        Tupla con (tiempo_ejecución, memoria_kb)
-    """
-    try:
-        if resource is not None:
-            start_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
-            start_time = time.perf_counter()
-            subprocess.run(
-                cmd,
-                env=env,
-                check=False,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.STDOUT,
-                timeout=SUBPROCESS_TIMEOUT
-            )
-            elapsed = time.perf_counter() - start_time
-            end_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
-            mem_kb = max(0, end_usage.ru_maxrss - start_usage.ru_maxrss)
-            return elapsed, mem_kb
-        elif psutil is not None:
-            start_time = time.perf_counter()
-            proc = psutil.Popen(
-                cmd,
-                env=env,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.STDOUT,
-            )  # type: ignore
-            max_mem = 0
-            while proc.poll() is None:
-                try:
-                    mem = proc.memory_info().rss  # type: ignore
-                    max_mem = max(max_mem, mem)
-                except Exception:  # pragma: no cover - process ended
-                    break
-                time.sleep(0.05)
-            proc.wait(timeout=SUBPROCESS_TIMEOUT)
-            elapsed = time.perf_counter() - start_time
-            mem_kb = max_mem // 1024
-            return elapsed, mem_kb
-        else:
-            start_time = time.perf_counter()
-            subprocess.run(
-                cmd,
-                env=env,
-                check=False,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.STDOUT,
-                timeout=SUBPROCESS_TIMEOUT
-            )
-            elapsed = time.perf_counter() - start_time
-            return elapsed, 0
-    except subprocess.TimeoutExpired:
-        mostrar_error(_("Timeout al ejecutar {cmd}").format(cmd=" ".join(cmd)))
-        return 0.0, 0
 
 class BenchCommand(BaseCommand):
     """Ejecuta benchmarks y opcionalmente los perfila."""
@@ -162,116 +67,7 @@ class BenchCommand(BaseCommand):
         Returns:
             Lista de diccionarios con resultados de los benchmarks
         """
-        env = os.environ.copy()
-        
-        results = []
-        with tempfile.NamedTemporaryFile(suffix=".toml", delete=False) as tmp_file:
-            tmp_path = Path(tmp_file.name)
-            env["COBRA_TOML"] = str(tmp_path)
-
-        try:
-            with tempfile.TemporaryDirectory() as tmpdir:
-                co_file = Path(tmpdir) / "program.co"
-                co_file.write_text(CODE)
-
-                # Benchmark del intérprete Cobra
-                cobra_cmd = [sys.executable, "-m", "pcobra.cobra.cli.cli", "ejecutar", str(co_file)]
-                elapsed, mem = run_and_measure(cobra_cmd, env)
-                results.append(
-                    {"backend": "cobra", "time": round(elapsed, 4), "memory_kb": mem}
-                )
-
-                # Benchmark de los backends con runner local definido.
-                for backend, cfg in BACKENDS.items():
-                    results.extend(self._benchmark_backend(backend, cfg, co_file, tmpdir, env))
-        finally:
-            os.unlink(tmp_path)
-            import gc
-            gc.collect()
-
-        return results
-
-    def _benchmark_backend(
-        self, 
-        backend: str, 
-        cfg: Dict[str, Any], 
-        co_file: Path, 
-        tmpdir: str, 
-        env: Dict[str, str]
-    ) -> List[Dict[str, Any]]:
-        """Ejecuta benchmark para un backend específico.
-
-        Args:
-            backend: Nombre del backend
-            cfg: Configuración del backend
-            co_file: Archivo con código Cobra
-            tmpdir: Directorio temporal
-            env: Variables de entorno
-
-        Returns:
-            Lista con resultados del benchmark
-        """
-        results = []
-        backend_display = f"{target_label(backend)} ({backend})" if backend in PUBLIC_BACKENDS else backend
-        run_cmd = cfg["run"]
-        src_file = Path(tmpdir) / f"program.{cfg['ext']}"
-        
-        # Compilar código
-        transp_cmd = [
-            sys.executable,
-            "-m",
-            "pcobra.cobra.cli.cli",
-            "compilar",
-            str(co_file),
-            "--tipo",
-            backend,
-        ]
-        
-        try:
-            out = subprocess.check_output(transp_cmd, env=env, text=True)
-        except subprocess.CalledProcessError as e:
-            mostrar_info(_("Error al compilar {backend}: {error}").format(
-                backend=backend_display, error=str(e)
-            ))
-            return results
-
-        # Procesar salida
-        out = ANSI_ESCAPE.sub("", out)
-        lines = [
-            line
-            for line in out.splitlines()
-            if not line.startswith(("DEBUG:", "INFO:"))
-        ]
-        if lines and lines[0].startswith("Código generado"):
-            lines = lines[1:]
-        src_file.write_text("\n".join(lines))
-
-        # Compilar si es necesario
-        if "compile" in cfg:
-            compile_cmd = [
-                arg.format(file=src_file, tmp=tmpdir) for arg in cfg["compile"]
-            ]
-            try:
-                subprocess.run(compile_cmd, check=True, timeout=SUBPROCESS_TIMEOUT)
-            except (subprocess.SubprocessError, subprocess.TimeoutExpired) as e:
-                mostrar_info(_("Error al compilar {backend}: {error}").format(
-                    backend=backend_display, error=str(e)
-                ))
-                return results
-
-        # Ejecutar
-        cmd = [arg.format(file=src_file, tmp=tmpdir) for arg in run_cmd]
-        if not shutil.which(cmd[0]) and not os.path.exists(cmd[0]):
-            mostrar_info(_("Ejecutable no encontrado para {backend}: {cmd}").format(
-                backend=backend_display, cmd=cmd[0]
-            ))
-            return results
-
-        elapsed, mem = run_and_measure(cmd, env)
-        results.append(
-            {"backend": backend, "time": round(elapsed, 4), "memory_kb": mem}
-        )
-        return results
+        return run_benchmarks(BACKENDS)
 
     def run(self, args: Any) -> int:
         """Ejecuta la lógica del comando.

--- a/src/pcobra/cobra/cli/commands/benchmarks_cmd.py
+++ b/src/pcobra/cobra/cli/commands/benchmarks_cmd.py
@@ -15,12 +15,12 @@ from pcobra.cobra.cli.target_policies import (
 from pcobra.cobra.benchmarks.targets_policy import BENCHMARK_BACKEND_METADATA, benchmark_backends, validate_backend_metadata
 
 from pcobra.cobra.cli.commands.base import BaseCommand
-from pcobra.cobra.cli.commands.bench_cmd import BenchCommand
 from pcobra.cobra.cli.deprecation_policy import (
     enforce_advanced_profile_policy,
     enforce_target_deprecation_policy,
 )
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.services.benchmark_service import run_benchmarks
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 
@@ -103,9 +103,8 @@ class BenchmarksCommand(BaseCommand):
                     args=args,
                 )
 
-            bench_cmd = BenchCommand()
             for _iteration in range(iteraciones):
-                data = bench_cmd._run_benchmarks()
+                data = run_benchmarks(BACKENDS)
                 if backend_filtro:
                     data = [d for d in data if d.get("backend") == backend_filtro]
                 results.extend(data)

--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -7,6 +7,7 @@ from typing import Any
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.mode_policy import validar_politica_modo
+from pcobra.cobra.cli.services.format_service import format_code_with_black
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.cli.utils.validators import (
     normalizar_validadores_extra,
@@ -261,7 +262,7 @@ class ExecuteCommand(BaseCommand):
             mostrar_error(f"Error de dependencias: {dep_err}", registrar_log=False)
             return 1
 
-        if formatear and not self._formatear_codigo(str(archivo_resuelto)):
+        if formatear and not format_code_with_black(str(archivo_resuelto)):
             return 1
 
         self.logger.setLevel(logging.DEBUG if depurar else logging.INFO)
@@ -452,35 +453,3 @@ class ExecuteCommand(BaseCommand):
         interpretador_cls = _obtener_interpretador_cls()
         interpreter = interpretador_cls(**interpreter_kwargs)
         ejecutar_ast(ast, interpreter)
-
-    @staticmethod
-    def _formatear_codigo(archivo: str) -> bool:
-        """Formatea el código usando black.
-
-        Args:
-            archivo: Ruta al archivo a formatear
-
-        Returns:
-            bool: True si el formateo fue exitoso, False en caso contrario
-        """
-        try:
-            import shutil
-            if not shutil.which("black"):
-                mostrar_error(_("Herramienta 'black' no encontrada en el PATH"), registrar_log=False)
-                return False
-
-            import subprocess
-            resultado = subprocess.run(
-                ["black", archivo],
-                check=False,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True
-            )
-            if resultado.returncode != 0:
-                mostrar_error(f"Error al formatear: {resultado.stderr}", registrar_log=False)
-                return False
-            return True
-        except Exception as e:
-            mostrar_error(f"Error inesperado al formatear: {e}", registrar_log=False)
-            return False

--- a/src/pcobra/cobra/cli/commands/profile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/profile_cmd.py
@@ -20,8 +20,8 @@ from pcobra.core.interpreter import InterpretadorCobra
 from pcobra.core.sandbox import validar_dependencias
 from pcobra.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 from pcobra.cobra.cli.commands.base import BaseCommand
-from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.services.format_service import format_code_with_black
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.cli.utils.validators import (
@@ -114,8 +114,8 @@ class ProfileCommand(BaseCommand):
             mostrar_error(f"Error de dependencias: {dep_err}")
             return 1
 
-        if formatear:
-            ExecuteCommand._formatear_codigo(archivo)  # type: ignore[attr-defined]
+        if formatear and not format_code_with_black(archivo):
+            return 1
 
         self.logger.setLevel(logging.DEBUG if depurar else logging.ERROR)
 

--- a/src/pcobra/cobra/cli/commands/qa_validar_cmd.py
+++ b/src/pcobra/cobra/cli/commands/qa_validar_cmd.py
@@ -7,13 +7,16 @@ from pathlib import Path
 from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
-from pcobra.cobra.cli.commands.validar_sintaxis_cmd import ValidationResult, ValidarSintaxisCommand
 from pcobra.cobra.qa.syntax_validation import execute_syntax_validation
 from pcobra.cobra.build import backend_pipeline
-from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
+from pcobra.cobra.qa.syntax_validation import ValidationResult
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.mode_policy import validar_politica_modo
-from pcobra.cobra.cli.target_policies import VERIFICATION_EXECUTABLE_TARGETS
+from pcobra.cobra.cli.services.verification_service import (
+    execute_runtime_verification,
+    parse_verification_targets,
+    resolve_executable_targets,
+)
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.transpilers.compatibility_matrix import build_feature_gap_report
@@ -187,9 +190,8 @@ class QaValidarCommand(BaseCommand):
         if not getattr(args, "archivo", None):
             raise ValueError(_("El argumento 'archivo' es obligatorio para scope runtime/all"))
 
-        syntax_command = ValidarSintaxisCommand()
-        requested_targets = syntax_command._parse_targets(str(getattr(args, "targets", "")))
-        executable_targets = [t for t in requested_targets if t in VERIFICATION_EXECUTABLE_TARGETS]
+        requested_targets = parse_verification_targets(str(getattr(args, "targets", "")))
+        executable_targets = resolve_executable_targets(requested_targets)
 
         if not executable_targets:
             message = "no hay targets con runtime ejecutable en --targets"
@@ -210,7 +212,10 @@ class QaValidarCommand(BaseCommand):
             archivo=getattr(args, "archivo"),
             lenguajes=executable_targets,
         )
-        rc = VerifyCommand().run(verify_args)
+        rc = execute_runtime_verification(
+            archivo=verify_args.archivo,
+            lenguajes=list(verify_args.lenguajes),
+        )
         has_failures = rc != 0
         message = "equivalencia runtime verificada" if rc == 0 else "falló equivalencia runtime"
 

--- a/src/pcobra/cobra/cli/services/__init__.py
+++ b/src/pcobra/cobra/cli/services/__init__.py
@@ -1,0 +1,2 @@
+"""Servicios reutilizables para comandos CLI."""
+

--- a/src/pcobra/cobra/cli/services/benchmark_service.py
+++ b/src/pcobra/cobra/cli/services/benchmark_service.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+try:
+    import resource
+except ImportError:  # pragma: no cover - Windows
+    resource = None  # type: ignore
+    try:
+        import psutil  # type: ignore
+    except Exception:
+        psutil = None  # type: ignore
+else:
+    psutil = None  # type: ignore
+
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+from pcobra.cobra.benchmarks.targets_policy import BENCHMARK_BACKEND_METADATA
+from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
+from pcobra.cobra.transpilers.target_utils import target_label
+from pcobra.core.cobra_config import tiempo_max_transpilacion
+
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
+SUBPROCESS_TIMEOUT = tiempo_max_transpilacion()
+
+BENCHMARK_CODE = """
+var x = 0
+mientras x <= 1000 :
+    x = x + 1
+fin
+imprimir(x)
+"""
+
+
+def run_and_measure(cmd: list[str], env: dict[str, str] | None = None) -> tuple[float, int]:
+    try:
+        if resource is not None:
+            start_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+            start_time = time.perf_counter()
+            subprocess.run(cmd, env=env, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT, timeout=SUBPROCESS_TIMEOUT)
+            elapsed = time.perf_counter() - start_time
+            end_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+            mem_kb = max(0, end_usage.ru_maxrss - start_usage.ru_maxrss)
+            return elapsed, mem_kb
+        if psutil is not None:
+            start_time = time.perf_counter()
+            proc = psutil.Popen(cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)  # type: ignore
+            max_mem = 0
+            while proc.poll() is None:
+                with contextlib.suppress(Exception):
+                    max_mem = max(max_mem, proc.memory_info().rss)  # type: ignore
+                time.sleep(0.05)
+            proc.wait(timeout=SUBPROCESS_TIMEOUT)
+            return time.perf_counter() - start_time, max_mem // 1024
+
+        start_time = time.perf_counter()
+        subprocess.run(cmd, env=env, check=False, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT, timeout=SUBPROCESS_TIMEOUT)
+        return time.perf_counter() - start_time, 0
+    except subprocess.TimeoutExpired:
+        mostrar_error(_("Timeout al ejecutar {cmd}").format(cmd=" ".join(cmd)))
+        return 0.0, 0
+
+
+def run_backend_benchmark(backend: str, cfg: dict[str, Any], co_file: Path, tmpdir: str, env: dict[str, str]) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    backend_display = f"{target_label(backend)} ({backend})" if backend in PUBLIC_BACKENDS else backend
+    src_file = Path(tmpdir) / f"program.{cfg['ext']}"
+
+    transp_cmd = [sys.executable, "-m", "pcobra.cobra.cli.cli", "compilar", str(co_file), "--tipo", backend]
+    try:
+        out = subprocess.check_output(transp_cmd, env=env, text=True)
+    except subprocess.CalledProcessError as exc:
+        mostrar_info(_("Error al compilar {backend}: {error}").format(backend=backend_display, error=str(exc)))
+        return results
+
+    out = ANSI_ESCAPE.sub("", out)
+    lines = [line for line in out.splitlines() if not line.startswith(("DEBUG:", "INFO:"))]
+    if lines and lines[0].startswith("Código generado"):
+        lines = lines[1:]
+    src_file.write_text("\n".join(lines))
+
+    if "compile" in cfg:
+        compile_cmd = [arg.format(file=src_file, tmp=tmpdir) for arg in cfg["compile"]]
+        try:
+            subprocess.run(compile_cmd, check=True, timeout=SUBPROCESS_TIMEOUT)
+        except (subprocess.SubprocessError, subprocess.TimeoutExpired) as exc:
+            mostrar_info(_("Error al compilar {backend}: {error}").format(backend=backend_display, error=str(exc)))
+            return results
+
+    cmd = [arg.format(file=src_file, tmp=tmpdir) for arg in cfg["run"]]
+    if not shutil.which(cmd[0]) and not os.path.exists(cmd[0]):
+        mostrar_info(_("Ejecutable no encontrado para {backend}: {cmd}").format(backend=backend_display, cmd=cmd[0]))
+        return results
+
+    elapsed, mem = run_and_measure(cmd, env)
+    results.append({"backend": backend, "time": round(elapsed, 4), "memory_kb": mem})
+    return results
+
+
+def run_benchmarks(backends: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    env = os.environ.copy()
+    results: list[dict[str, Any]] = []
+
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False) as tmp_file:
+        tmp_path = Path(tmp_file.name)
+        env["COBRA_TOML"] = str(tmp_path)
+
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            co_file = Path(tmpdir) / "program.co"
+            co_file.write_text(BENCHMARK_CODE)
+
+            cobra_cmd = [sys.executable, "-m", "pcobra.cobra.cli.cli", "ejecutar", str(co_file)]
+            elapsed, mem = run_and_measure(cobra_cmd, env)
+            results.append({"backend": "cobra", "time": round(elapsed, 4), "memory_kb": mem})
+
+            for backend, cfg in backends.items():
+                results.extend(run_backend_benchmark(backend, cfg, co_file, tmpdir, env))
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    return results
+
+
+def benchmark_backends_config(allowed_backends: set[str]) -> dict[str, dict[str, Any]]:
+    return {
+        backend: BENCHMARK_BACKEND_METADATA[backend]
+        for backend in allowed_backends
+        if backend in BENCHMARK_BACKEND_METADATA
+    }

--- a/src/pcobra/cobra/cli/services/format_service.py
+++ b/src/pcobra/cobra/cli/services/format_service.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.messages import mostrar_error
+
+
+def format_code_with_black(archivo: str) -> bool:
+    """Formatea un archivo de código usando black."""
+    try:
+        if not shutil.which("black"):
+            mostrar_error(_("Herramienta 'black' no encontrada en el PATH"), registrar_log=False)
+            return False
+
+        resultado = subprocess.run(
+            ["black", archivo],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if resultado.returncode != 0:
+            mostrar_error(f"Error al formatear: {resultado.stderr}", registrar_log=False)
+            return False
+        return True
+    except Exception as exc:  # pragma: no cover - salvaguarda defensiva CLI
+        mostrar_error(f"Error inesperado al formatear: {exc}", registrar_log=False)
+        return False

--- a/src/pcobra/cobra/cli/services/verification_service.py
+++ b/src/pcobra/cobra/cli/services/verification_service.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import StringIO
+from typing import Any
+from unittest.mock import patch
+
+from pcobra.cobra.build import backend_pipeline
+from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.target_policies import VERIFICATION_EXECUTABLE_TARGETS
+from pcobra.cobra.core import Lexer, Parser
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.sandbox import ejecutar_en_contenedor, ejecutar_en_sandbox, ejecutar_en_sandbox_js
+from pcobra.cobra.cli.utils.validators import validar_archivo_existente
+from pcobra.cobra.qa.syntax_validation import SUPPORTED_VALIDATOR_TARGETS
+
+
+MAX_FILE_SIZE = 10 * 1024 * 1024
+VALID_EXTENSIONS = {".cobra", ".cbr", ".co"}
+
+
+@dataclass
+class RuntimeVerificationExecution:
+    exit_code: int
+    requested_targets: list[str]
+    executable_targets: list[str]
+
+
+def parse_verification_targets(targets_raw: str) -> list[str]:
+    if not targets_raw.strip():
+        return list(SUPPORTED_VALIDATOR_TARGETS)
+    parsed = [item.strip().lower() for item in targets_raw.split(",") if item.strip()]
+    if not parsed:
+        raise ValueError(_("La lista --targets está vacía"))
+    invalid = sorted(set(parsed) - set(SUPPORTED_VALIDATOR_TARGETS))
+    if invalid:
+        raise ValueError(_("Targets no soportados en --targets: {}.").format(", ".join(invalid)))
+    return parsed
+
+
+def resolve_executable_targets(requested_targets: list[str]) -> list[str]:
+    return [target for target in requested_targets if target in VERIFICATION_EXECUTABLE_TARGETS]
+
+
+def _compile_and_execute(ast: Any, lang: str) -> tuple[str | None, str | None]:
+    try:
+        code = backend_pipeline.transpile(ast, lang)
+        if lang == "python":
+            output = ejecutar_en_sandbox(code)
+        elif lang == "javascript":
+            output = ejecutar_en_sandbox_js(code)
+        elif lang in {"cpp", "rust"}:
+            output = ejecutar_en_contenedor(code, lang)
+        else:
+            return None, _("Runtime no soportado para {}").format(lang)
+        return output.replace("\r\n", "\n"), None
+    except ValueError:
+        return None, _("Transpilador no encontrado para {}").format(lang)
+    except Exception as exc:
+        return None, str(exc)
+
+
+def execute_runtime_verification(archivo: str, lenguajes: list[str]) -> int:
+    if not lenguajes:
+        raise ValueError(_("La lista de lenguajes no puede estar vacía"))
+
+    unsupported = set(lenguajes) - set(VERIFICATION_EXECUTABLE_TARGETS)
+    if unsupported:
+        raise ValueError(
+            _("Lenguajes no soportados: {unsupported}. Soportados: {supported}").format(
+                unsupported=", ".join(sorted(unsupported)),
+                supported=", ".join(VERIFICATION_EXECUTABLE_TARGETS),
+            )
+        )
+
+    path = validar_archivo_existente(archivo)
+    if path.suffix not in VALID_EXTENSIONS:
+        raise ValueError(_("Extensión de archivo no válida. Debe ser: {}").format(", ".join(sorted(VALID_EXTENSIONS))))
+    if path.stat().st_size > MAX_FILE_SIZE:
+        raise ValueError(_("El archivo es demasiado grande (máximo {} MB)").format(MAX_FILE_SIZE // (1024 * 1024)))
+
+    code = path.read_text(encoding="utf-8")
+    tokens = Lexer(code).tokenizar()
+    ast = Parser(tokens).parsear()
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        InterpretadorCobra().ejecutar_ast(ast)
+    expected = out.getvalue().replace("\r\n", "\n")
+
+    for language in lenguajes:
+        output, error = _compile_and_execute(ast, language)
+        if error is not None:
+            return 1
+        if output != expected:
+            return 1
+    return 0


### PR DESCRIPTION
### Motivation

- Reducir imports cruzados entre comandos y mover lógica reutilizable fuera de las clases de comando para mantener cada comando enfocado en parseo/validación/Salida.
- Centralizar la lógica de verificación runtime, ejecución de benchmarks y formateo de código en servicios reutilizables.

### Description

- Se añadió el paquete `src/pcobra/cobra/cli/services/` con tres servicios: `verification_service.py` (parseo de targets y ejecución de verificación runtime), `benchmark_service.py` (ejecución y medición de benchmarks por backend) y `format_service.py` (formateo con `black`).
- `qa_validar_cmd.py` ahora consume `verification_service` (`parse_verification_targets`, `resolve_executable_targets`, `execute_runtime_verification`) y dejó de importar/instanciar comandos para la verificación runtime.
- `benchmarks_cmd.py` y `bench_cmd.py` delegan la ejecución de benchmarks a `benchmark_service.run_benchmarks` y eliminaron la implementación duplicada/los imports internos relacionados.
- `execute_cmd.py` y `profile_cmd.py` usan `format_service.format_code_with_black` para formatear código en lugar de depender de un método estático interno o de otro comando, y se removió la función de formateo original de `ExecuteCommand`.
- Se revisaron y limpiaron imports en los comandos modificados para que importen `BaseCommand` y servicios/utilidades, evitando imports entre comandos.

### Testing

- Ejecutado: `python -m compileall src/pcobra/cobra/cli/services src/pcobra/cobra/cli/commands/qa_validar_cmd.py src/pcobra/cobra/cli/commands/profile_cmd.py src/pcobra/cobra/cli/commands/benchmarks_cmd.py src/pcobra/cobra/cli/commands/bench_cmd.py src/pcobra/cobra/cli/commands/execute_cmd.py`, y la compilación de los módulos afectados fue exitosa.
- Ejecutado: `rg -n "from pcobra\.cobra\.cli\.commands\.[a-z_]+ import" src/pcobra/cobra/cli/commands/*.py` para detectar imports cruzados entre comandos, y la verificación mostró que los comandos importan `BaseCommand` y los nuevos servicios en lugar de otros comandos (no se detectaron imports cruzados de comandos en los módulos modificados).
- Se inspeccionaron los archivos modificados para confirmar que las responsabilidades se trasladaron a servicios y que las firmas públicas necesarias (`execute_runtime_verification`, `run_benchmarks`, `format_code_with_black`, etc.) están disponibles y compilables.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4df4af174832799b9b4bb92ed8dd8)