### PR TITLE
Desacoplar GUI de CLI mediante módulo neutral `pcobra.cobra.gui.deps`

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -25,7 +25,6 @@ from pcobra.cobra.cli.commands.dependencias_cmd import DependenciasCommand
 from pcobra.cobra.cli.commands.docs_cmd import DocsCommand
 from pcobra.cobra.cli.commands.empaquetar_cmd import EmpaquetarCommand
 from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
-from pcobra.cobra.cli.commands.flet_cmd import FletCommand
 from pcobra.cobra.cli.commands.init_cmd import InitCommand
 from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
 from pcobra.cobra.cli.commands.agix_cmd import AgixCommand
@@ -138,7 +137,7 @@ class AppConfig:
         InteractiveCommand, CompileCommand, ExecuteCommand, ModulesCommand,
         DependenciasCommand, DocsCommand, EmpaquetarCommand,
         PaqueteCommand, CrearCommand, InitCommand,
-        JupyterCommand, FletCommand, ContainerCommand,
+        JupyterCommand, ContainerCommand,
         BenchCommand, BenchmarksCommand, BenchmarksV2Command,
         BenchTranspilersCommand, BenchThreadsCommand,
         ProfileCommand, QualiaCommand, CacheCommand,
@@ -179,6 +178,14 @@ class CommandRegistry:
             )
         return classes
 
+    def _resolve_v1_command_classes(self) -> List[Type[BaseCommand]]:
+        """Carga comandos v1 y difiere imports GUI/opcionales hasta el registro."""
+        classes = list(AppConfig.BASE_COMMAND_CLASSES)
+        from pcobra.cobra.cli.commands.flet_cmd import FletCommand
+
+        classes.append(FletCommand)
+        return classes
+
     def register_base_commands(
         self,
         subparsers: Any,
@@ -190,7 +197,7 @@ class CommandRegistry:
         command_classes = (
             self._resolve_v2_command_classes(profile)
             if ui == "v2"
-            else AppConfig.BASE_COMMAND_CLASSES
+            else self._resolve_v1_command_classes()
         )
 
         for cmd_class in command_classes:

--- a/src/pcobra/cobra/cli/commands/flet_cmd.py
+++ b/src/pcobra/cobra/cli/commands/flet_cmd.py
@@ -14,17 +14,17 @@ class FletCommand(BaseCommand):
     name = "gui"
     requires_sqlite_key: bool = False
     _CRITICAL_GUI_MODULES = (
-        "pcobra.cobra.transpilers.registry",
-        "pcobra.cobra.core",
-        "pcobra.cobra.transpilers.target_utils",
-        "pcobra.cobra.transpilers.targets",
-        "pcobra.core.interpreter",
+        "pcobra.cobra.gui.deps",
     )
     _CRITICAL_GUI_SYMBOLS = {
-        "pcobra.cobra.core": ("Lexer", "Parser"),
-        "pcobra.core.interpreter": ("InterpretadorCobra",),
-        "pcobra.cobra.transpilers.registry": ("get_transpilers",),
-        "pcobra.cobra.transpilers.target_utils": ("target_cli_choices",),
+        "pcobra.cobra.gui.deps": (
+            "Lexer",
+            "Parser",
+            "InterpretadorCobra",
+            "get_transpilers",
+            "target_cli_choices",
+            "OFFICIAL_TARGETS",
+        ),
     }
 
     def __init__(self) -> None:

--- a/src/pcobra/cobra/gui/__init__.py
+++ b/src/pcobra/cobra/gui/__init__.py
@@ -1,0 +1,2 @@
+"""Módulos neutrales para integración GUI de Cobra."""
+

--- a/src/pcobra/cobra/gui/deps.py
+++ b/src/pcobra/cobra/gui/deps.py
@@ -1,0 +1,29 @@
+"""Dependencias neutrales de runtime para GUI.
+
+Este módulo evita acoplar GUI con rutas de comandos CLI concretas.
+Expone únicamente:
+- Lexer/Parser (+ tipos de error asociados)
+- intérprete
+- registro de transpiladores
+- helpers/choices de targets
+"""
+
+from __future__ import annotations
+
+from pcobra.cobra.core import Lexer, LexerError, Parser, ParserError
+from pcobra.cobra.transpilers.registry import get_transpilers
+from pcobra.cobra.transpilers.target_utils import target_cli_choices
+from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
+from pcobra.core.interpreter import InterpretadorCobra
+
+__all__ = [
+    "Lexer",
+    "LexerError",
+    "Parser",
+    "ParserError",
+    "InterpretadorCobra",
+    "get_transpilers",
+    "target_cli_choices",
+    "OFFICIAL_TARGETS",
+]
+

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -13,11 +13,7 @@ from typing import Any
 def require_gui_dependencies() -> dict[str, Any]:
     """Importa dependencias de núcleo/transpiladores de forma diferida."""
     try:
-        from pcobra.cobra.build import backend_pipeline
-        from pcobra.cobra.core import Lexer, LexerError, Parser, ParserError
-        from pcobra.cobra.transpilers.target_utils import target_cli_choices
-        from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
-        from pcobra.core.interpreter import InterpretadorCobra
+        from pcobra.cobra.gui import deps as gui_deps
     except (ImportError, ModuleNotFoundError) as exc:  # pragma: no cover - validado desde CLI
         missing_target, action = _parse_missing_target(exc)
         detail = str(exc) or repr(exc)
@@ -29,14 +25,14 @@ def require_gui_dependencies() -> dict[str, Any]:
         ) from exc
 
     return {
-        "Lexer": Lexer,
-        "LexerError": LexerError,
-        "Parser": Parser,
-        "ParserError": ParserError,
-        "target_cli_choices": target_cli_choices,
-        "OFFICIAL_TARGETS": OFFICIAL_TARGETS,
-        "InterpretadorCobra": InterpretadorCobra,
-        "TRANSPILERS": backend_pipeline.TRANSPILERS,
+        "Lexer": gui_deps.Lexer,
+        "LexerError": gui_deps.LexerError,
+        "Parser": gui_deps.Parser,
+        "ParserError": gui_deps.ParserError,
+        "target_cli_choices": gui_deps.target_cli_choices,
+        "OFFICIAL_TARGETS": gui_deps.OFFICIAL_TARGETS,
+        "InterpretadorCobra": gui_deps.InterpretadorCobra,
+        "TRANSPILERS": gui_deps.get_transpilers(),
     }
 
 


### PR DESCRIPTION
### Motivation
- Evitar que la inicialización del CLI cargue prematuramente dependencias y rutas relacionadas con la GUI y `flet` al mantener un boundary claro de runtime.
- Centralizar un contrato estable y pequeño que exponga únicamente los símbolos que la GUI necesita (lexer/parser, intérprete, registro de transpiladores y utilidades de targets).

### Description
- Se añadió el módulo neutral `pcobra.cobra.gui.deps` que exporta `Lexer`, `LexerError`, `Parser`, `ParserError`, `InterpretadorCobra`, `get_transpilers`, `target_cli_choices` y `OFFICIAL_TARGETS` (archivo `src/pcobra/cobra/gui/deps.py`).
- `src/pcobra/gui/runtime.py` ahora importa solo `pcobra.cobra.gui.deps` desde `require_gui_dependencies()` y obtiene el registro de transpilers vía `get_transpilers()` en lugar de depender de `backend_pipeline` o imports dispersos.
- El preflight de `FletCommand` fue adaptado para validar los símbolos requeridos contra `pcobra.cobra.gui.deps` (en `src/pcobra/cobra/cli/commands/flet_cmd.py`) en vez de consultar múltiples módulos dispersos.
- En el bootstrap del CLI (`src/pcobra/cobra/cli/cli.py`) se difirió la importación de `FletCommand` moviéndola a `_resolve_v1_command_classes()` y ajustando la resolución de clases de comandos v1 para evitar traer la GUI en imports top-level.

### Testing
- Se compiló en frío el código modificado con `python -m compileall -q src/pcobra/cobra/gui src/pcobra/gui/runtime.py src/pcobra/cobra/cli/commands/flet_cmd.py src/pcobra/cobra/cli/cli.py`, y la compilación finalizó correctamente.
- Se verificó que la importación de `pcobra.cli` no cargue módulos GUI ni `flet` prematuramente mediante scripts de comprobación de `sys.modules`, y las comprobaciones reportaron que `pcobra.gui.runtime`, `pcobra.gui.idle` y `pcobra.cobra.cli.commands.flet_cmd` no estaban cargados tras importar `pcobra.cli` (éxito).
- Se ejecutó `pcobra.cli.main(['--help'])` en un run controlado para validar comportamiento de arranque y confirmar que no se importó `flet`, y la ejecución de ayuda terminó sin cargar dependencias GUI (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e48b843c83279f56043f178d8210)