### PR TITLE
Capture léxico por referencia (Environment) en llamadas y corregir semántica de asignación

### DIFF
--- a/src/pcobra/core/environment.py
+++ b/src/pcobra/core/environment.py
@@ -26,12 +26,20 @@ class Environment:
         self.values[name] = value
         return value
 
+    def contains(self, name: str) -> bool:
+        """Indica si ``name`` existe en este entorno o en alguno ancestro."""
+        if name in self.values:
+            return True
+        if self.parent is not None:
+            return self.parent.contains(name)
+        return False
+
     def set(self, name: str, value: Any) -> Any:
         """Actualiza ``name`` en su scope más cercano; si no existe, lo define local."""
         if name in self.values:
             self.values[name] = value
             return value
-        if self.parent is not None:
+        if self.parent is not None and self.parent.contains(name):
             return self.parent.set(name, value)
         self.values[name] = value
         return value

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -552,7 +552,7 @@ class InterpretadorCobra:
             "nombre": nodo.nombre,
             "parametros": list(nodo.parametros),
             "cuerpo": list(nodo.cuerpo),
-            "contexto": self.variables.copy(),
+            "entorno": self.contextos[-1],
         }
 
     def _construir_clase(self, nodo, bases):
@@ -583,7 +583,7 @@ class InterpretadorCobra:
           contexto con valores ya materializados.
         """
         visitados = set() if visitados is None else visitados
-        primitivos = (int, float, bool, str, type(None))
+        primitivos = (int, float, bool, str, type(None), Environment)
         contenedores = (list, tuple, dict, set)
 
         def _normalizar_contenedor(contenedor):
@@ -660,10 +660,9 @@ class InterpretadorCobra:
                 actual = actual.valor
                 continue
 
-            if (
-                origen == "resolucion_variable"
-                and isinstance(actual, dict)
-                and actual.get("tipo") in {"funcion", "clase", "instancia"}
+            if isinstance(actual, dict) and (
+                actual.get("tipo") in {"funcion", "clase", "instancia"}
+                or "__clase__" in actual
             ):
                 return actual
 
@@ -1136,10 +1135,7 @@ class InterpretadorCobra:
                     self.liberar_memoria(idx, tam)
                 indice = self.solicitar_memoria(1)
                 mem_ctx[nombre] = (indice, 1)
-                if nombre in self.variables:
-                    self.contextos[-1].set(nombre, valor)
-                else:
-                    self.contextos[-1].define(nombre, valor)
+                self.contextos[-1].set(nombre, valor)
         return valor
 
     def evaluar_expresion(self, expresion, visitados=None):
@@ -1208,15 +1204,8 @@ class InterpretadorCobra:
                 self._trace_debug(
                     "[ID] "
                     f"value_type={type(valor).__name__} value_id={id(valor)} "
-                    f"is_primitive={isinstance(valor, (int, float, bool, str))}"
+                    f"is_runtime_value={not isinstance(valor, NodoAST)}"
                 )
-
-                if not isinstance(valor, (int, float, bool, str)):
-                    raise RuntimeError(
-                        "Error semántico: identificador "
-                        f"'{expresion.nombre}' no resolvió a un valor primitivo "
-                        f"(se obtuvo {type(valor).__name__})"
-                    )
 
                 return _retorno_critico(valor, operador="identificador")
             elif isinstance(expresion, NodoInstancia):
@@ -1524,18 +1513,15 @@ class InterpretadorCobra:
             def preparar_contexto():
                 # Regla semántica opuesta al control de flujo: cada llamada de
                 # función sí encapsula su scope creando un nuevo contexto local.
-                contexto_base = funcion.get("contexto", {}).copy()
-                self._verificar_valor_contexto(contexto_base)
-                self.contextos.append(
-                    Environment(values=contexto_base, parent=self.contextos[-1])
-                )
+                entorno_capturado = funcion.get("entorno", self.contextos[-1])
+                self.contextos.append(Environment(parent=entorno_capturado))
                 self.mem_contextos.append({})
                 for nombre_param, arg in zip(funcion["parametros"], nodo.argumentos):
                     valor = self.evaluar_expresion(arg)
                     self._verificar_valor_contexto(valor)
                     indice = self.solicitar_memoria(1)
                     self.mem_contextos[-1][nombre_param] = (indice, 1)
-                    self.variables[nombre_param] = valor
+                    self.contextos[-1].define(nombre_param, valor)
 
             def limpiar_contexto():
                 # Se restaura el scope anterior al finalizar la llamada.
@@ -1619,29 +1605,27 @@ class InterpretadorCobra:
         if metodo is None:
             raise ValueError(f"Método '{nodo.nombre_metodo}' no encontrado")
 
-        contexto = {"self": objeto}
-        contexto_base = metodo.get("contexto", {}).copy()
-        contexto_base.update(contexto)
-        self._verificar_valor_contexto(contexto_base)
-        self.contextos.append(
-            Environment(values=contexto_base, parent=self.contextos[-1])
-        )
+        entorno_capturado = metodo.get("entorno", self.contextos[-1])
+        self.contextos.append(Environment(parent=entorno_capturado))
         self.mem_contextos.append({})
+        self.contextos[-1].define("self", objeto)
         for nombre_param, arg in zip(metodo.get("parametros", [])[1:], nodo.argumentos):
             valor = self.evaluar_expresion(arg)
             self._verificar_valor_contexto(valor)
-            self.variables[nombre_param] = valor
+            self.contextos[-1].define(nombre_param, valor)
 
-        resultado = None
-        for instruccion in metodo.get("cuerpo", []):
-            resultado = self.ejecutar_nodo(instruccion)
-            if resultado is not None:
-                break
-        memoria_local = self.mem_contextos.pop()
-        for idx, tam in memoria_local.values():
-            self.liberar_memoria(idx, tam)
-        self.contextos.pop()
-        return resultado
+        try:
+            resultado = None
+            for instruccion in metodo.get("cuerpo", []):
+                resultado = self.ejecutar_nodo(instruccion)
+                if resultado is not None:
+                    break
+            return resultado
+        finally:
+            memoria_local = self.mem_contextos.pop()
+            for idx, tam in memoria_local.values():
+                self.liberar_memoria(idx, tam)
+            self.contextos.pop()
 
     def ejecutar_import(self, nodo):
         """Carga y ejecuta un módulo especificado en la declaración import."""

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -66,8 +66,8 @@ def test_aislamiento_de_contexto_en_funciones():
     assert "z" not in inter.variables
 
 
-def test_preservacion_de_variables_globales():
-    """Verifica que las variables globales no se modifiquen dentro de una función."""
+def test_actualizacion_de_variables_globales_en_scope_capturado():
+    """Verifica que set actualiza la variable existente en el scope capturado."""
     inter = InterpretadorCobra()
 
     inter.ejecutar_asignacion(NodoAsignacion("a", NodoValor(5)))
@@ -81,7 +81,23 @@ def test_preservacion_de_variables_globales():
     inter.ejecutar_funcion(funcion)
     inter.ejecutar_llamada_funcion(NodoLlamadaFuncion("modificar", []))
 
-    assert inter.variables["a"] == 5
+    assert inter.variables["a"] == 1
+
+
+def test_funcion_actualiza_scope_lexico_capturado():
+    """Una función definida en global muta su entorno léxico capturado."""
+    inter = InterpretadorCobra()
+    inter.ejecutar_asignacion(NodoAsignacion("a", NodoValor(10)))
+
+    incrementar = NodoFuncion(
+        "incrementar",
+        [],
+        [NodoAsignacion("a", NodoValor(1))],
+    )
+    inter.ejecutar_funcion(incrementar)
+
+    inter.ejecutar_llamada_funcion(NodoLlamadaFuncion("incrementar", []))
+    assert inter.obtener_variable("a") == 1
 
 
 def test_regresion_llamada_funcion_no_yield_limpia_contexto_una_sola_vez():


### PR DESCRIPTION
### Motivation
- Evitar copias completas del mapa de variables al definir funciones/objetos y preservar la relación léxica con el entorno activo.
- Garantizar que las actualizaciones de variables usen la regla de `set` que modifica la variable en el scope más cercano existente.
- Mantener la cadena de padres estable ante alta/baja de contexto en llamadas a funciones y métodos para evitar corrupción de scopes o pérdidas de enlace padre.

### Description
- Reemplacé la captura de contexto por `dict.copy()` en la construcción de funciones por la captura estructural del `Environment` activo guardándolo en la clave `"entorno"` (archivo modificado: `src/pcobra/core/interpreter.py`).
- En las invocaciones, ahora se crea un `Environment(parent=entorno_capturado)` y los parámetros (y `self` en métodos) se registran con `define` en el entorno hijo en lugar de clonar diccionarios (cambio en `ejecutar_llamada_funcion` y `ejecutar_llamada_metodo`).
- Cambié la semántica de asignación para usar `Environment.set` siempre en la rama no inferida y añadí `Environment.contains` para que `set` actualice la variable en el scope más cercano si ya existe, o la defina en el scope local, preservando la regla de actualización de scopes (archivo modificado: `src/pcobra/core/environment.py` y ajustes en `interpreter.py`).
- Robustecí las rutas de entrada/salida de contexto (push/pop de `contextos` y `mem_contextos`) con `try/finally` para asegurar que la cadena padre no se rompa y la memoria local se libere correctamente; además ajusté la materialización para aceptar `Environment`/valores runtime en las comprobaciones.
- Actualicé/añadí pruebas unitarias relevantes para reflejar el comportamiento de scope esperado (archivo modificado: `tests/unit/test_interpreter.py`).

### Testing
- Ejecuté las pruebas unitarias específicas con `pytest -q tests/unit/test_interpreter.py tests/unit/test_interpreter_objects.py tests/unit/test_interpreter_inheritance.py` y todas pasaron en este entorno salvo casos aislados durante la iteración de cambios que fueron corregidos posteriori.
- Ejecuté `pytest -q tests/unit/...` combinadas y el resultado final fue 18 pruebas unitarias/funcionales verdes y 1 prueba de integración fallida.
- La prueba de integración `tests/integration/test_interactive_persistence.py` falló por un EOF en el proceso REPL (`pexpect` no recibió el prompt `cobra> `) en este entorno de CI local, lo que parece causado por la ejecución interactiva fuera de un TTY y no por el cambio de semántica de scopes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f038c8c083279202f268bc27af78)