### PR TITLE
Refactoriza ejecución CLI en un pipeline canónico compartido

### DIFF
--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -24,11 +24,15 @@ from pcobra.cobra.cli.target_policies import (
 )
 from pcobra.cobra.core import LexerError
 from pcobra.cobra.core import ParserError
-from pcobra.cobra.cli.execution_pipeline import analizar_codigo, ejecutar_ast
+from pcobra.cobra.cli.execution_pipeline import (
+    analizar_codigo,
+    construir_interprete,
+    ejecutar_codigo_canonico,
+    resolver_validadores_seguridad,
+)
 from pcobra.cobra.transpilers import module_map
 from pcobra.core.interpreter import InterpretadorCobra
 from pcobra.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
-from pcobra.core.semantic_validators.base import ValidadorBase
 from pcobra.core.resource_limits import limitar_cpu_segundos
 
 sys.modules.setdefault("cli.commands.execute_cmd", sys.modules[__name__])
@@ -381,63 +385,35 @@ class ExecuteCommand(BaseCommand):
     def _ejecutar_normal(self, codigo: str, seguro: bool, extra_validators: Any) -> int:
         """Ejecuta el código normalmente con el intérprete."""
         try:
-            ast = self._analizar_codigo(codigo)
-        except (LexerError, ParserError) as e:
-            mostrar_error(f"Error de análisis: {e}", registrar_log=False)
-            return 1
-
-        interpretador_cls = _obtener_interpretador_cls()
-        validadores_normalizados = extra_validators
-
-        if seguro:
-            try:
-                if extra_validators is None:
-                    validadores_normalizados = None
-                elif isinstance(extra_validators, str):
-                    validadores_normalizados = interpretador_cls._cargar_validadores(extra_validators)
-                elif isinstance(extra_validators, list):
-                    if all(isinstance(ruta, str) for ruta in extra_validators):
-                        acumulado: list[Any] = []
-                        for ruta in extra_validators:
-                            try:
-                                acumulado.extend(interpretador_cls._cargar_validadores(ruta))
-                            except Exception as exc:
-                                raise ValueError(
-                                    _("No se pudieron cargar los validadores extra desde '{path}': {error}").format(
-                                        path=ruta,
-                                        error=exc,
-                                    )
-                                ) from exc
-                        validadores_normalizados = acumulado
-                    else:
-                        validadores_normalizados = extra_validators
-
-                if validadores_normalizados is not None:
-                    if not isinstance(validadores_normalizados, list) or not all(
-                        isinstance(validador, ValidadorBase)
-                        for validador in validadores_normalizados
-                    ):
-                        raise TypeError(
-                            _("Los validadores extra deben ser una lista de instancias de validadores")
-                        )
-
-                validador = construir_cadena(validadores_normalizados)
-                for nodo in ast:
-                    nodo.aceptar(validador)
-            except (TypeError, ValueError) as e:
-                mostrar_error(str(e), registrar_log=False)
-                return 1
-            except PrimitivaPeligrosaError as pe:
-                mostrar_error(str(pe), registrar_log=False)
-                return 1
-
-        try:
-            self._ejecutar_ast(
-                ast,
+            interpretador_cls = _obtener_interpretador_cls()
+            validadores_normalizados = resolver_validadores_seguridad(
+                extra_validators,
+                interpretador_cls=interpretador_cls,
+            )
+            interpreter = construir_interprete(
+                interpretador_cls=interpretador_cls,
                 safe_mode=seguro,
                 extra_validators=validadores_normalizados,
             )
+            ejecutar_codigo_canonico(
+                codigo,
+                interpretador=interpreter,
+                seguro=seguro,
+                extra_validators=validadores_normalizados,
+                interpretador_cls=interpretador_cls,
+                construir_cadena_fn=construir_cadena,
+                analizar_codigo_fn=analizar_codigo,
+            )
             return 0
+        except (LexerError, ParserError) as e:
+            mostrar_error(f"Error de análisis: {e}", registrar_log=False)
+            return 1
+        except (TypeError, ValueError) as e:
+            mostrar_error(str(e), registrar_log=False)
+            return 1
+        except PrimitivaPeligrosaError as pe:
+            mostrar_error(str(pe), registrar_log=False)
+            return 1
         except Exception as e:
             mostrar_error(f"Error ejecutando el script: {e}", registrar_log=False)
             return 1
@@ -446,10 +422,3 @@ class ExecuteCommand(BaseCommand):
         """Pipeline canónico: Lexer(codigo).tokenizar() + Parser(tokens).parsear()."""
 
         return analizar_codigo(codigo)
-
-    def _ejecutar_ast(self, ast: Any, **interpreter_kwargs: Any) -> None:
-        """Ejecuta un AST con el intérprete de Cobra."""
-
-        interpretador_cls = _obtener_interpretador_cls()
-        interpreter = interpretador_cls(**interpreter_kwargs)
-        ejecutar_ast(ast, interpreter)

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -32,7 +32,13 @@ except ModuleNotFoundError:  # pragma: no cover - entornos sin prompt_toolkit
 
 from pcobra.cobra.core import Lexer, LexerError, TipoToken, UnclosedStringError
 from pcobra.cobra.core import Parser, ParserError
-from pcobra.cobra.cli.execution_pipeline import analizar_codigo, ejecutar_ast
+from pcobra.cobra.cli.execution_pipeline import (
+    analizar_codigo,
+    construir_interprete,
+    ejecutar_codigo_canonico,
+    resolver_validadores_seguridad,
+    validar_ast_seguro,
+)
 from pcobra.cobra.transpilers import module_map
 from pcobra.core.ast_nodes import NodoBucleMientras, NodoCondicional, NodoPara, NodoSwitch, NodoTryCatch
 from pcobra.core.interpreter import InterpretadorCobra
@@ -42,11 +48,12 @@ from pcobra.core.sandbox import (
     ejecutar_en_sandbox,
     validar_dependencias,
 )
-from pcobra.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
+from pcobra.core.semantic_validators import PrimitivaPeligrosaError
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _, format_traceback
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import (
+    color_disabled,
     mostrar_advertencia,
     mostrar_error,
     mostrar_info,
@@ -211,6 +218,8 @@ class InteractiveCommand(BaseCommand):
         # Estado local para tracebacks técnicos en REPL.
         # Fuente canónica: flag global --debug parseado por la CLI principal.
         self._debug_mode = False
+        self._seguro_repl = True
+        self._extra_validators_repl: Any = None
 
     @staticmethod
     def _crear_estado_repl() -> dict[str, Any]:
@@ -332,12 +341,21 @@ class InteractiveCommand(BaseCommand):
         return ast
 
     def ejecutar_codigo(self, codigo: str, validador: Optional[Any] = None) -> None:
-        """Ejecuta un snippet completo con el pipeline canónico Lexer/Parser/AST."""
+        """Ejecuta un snippet usando el pipeline canónico compartido con `run`."""
 
         self.logger.debug("[RUN] Ejecutando snippet en REPL")
-        ast = self.procesar_ast(codigo, validador)
+        interpretador_cls = type(self.interpretador)
+        resultado_pipeline = ejecutar_codigo_canonico(
+            codigo,
+            interpretador=self.interpretador,
+            seguro=self._seguro_repl,
+            extra_validators=self._extra_validators_repl,
+            interpretador_cls=interpretador_cls,
+            analizar_codigo_fn=analizar_codigo,
+        )
+        ast = resultado_pipeline.ast
+        resultado = resultado_pipeline.resultado
         self.logger.debug("[EXEC] Ejecutando AST en intérprete")
-        resultado = ejecutar_ast(ast, self.interpretador)
         self.logger.debug("[EVAL] Resultado de evaluación: %r", resultado)
         debe_imprimir_resultado = (
             resultado is not None
@@ -414,13 +432,22 @@ class InteractiveCommand(BaseCommand):
         except TypeError:
             mostrar_error(_("Los validadores extra deben ser una ruta o lista de rutas"))
             return 1
-        validador = None
-        if seguro:
-            validador = construir_cadena(
-                InterpretadorCobra._cargar_validadores(extra_validators)
-                if isinstance(extra_validators, str)
-                else extra_validators
+        self._seguro_repl = bool(seguro)
+        self._extra_validators_repl = extra_validators
+        try:
+            self._extra_validators_repl = resolver_validadores_seguridad(
+                self._extra_validators_repl,
+                interpretador_cls=InterpretadorCobra,
             )
+        except (TypeError, ValueError, PrimitivaPeligrosaError) as err:
+            mostrar_error(str(err))
+            return 1
+
+        self.interpretador = construir_interprete(
+            interpretador_cls=InterpretadorCobra,
+            safe_mode=self._seguro_repl,
+            extra_validators=self._extra_validators_repl,
+        )
 
         # Obtener modos de ejecución
         sandbox = getattr(args, "sandbox", False)
@@ -440,13 +467,13 @@ class InteractiveCommand(BaseCommand):
                     "'prompt_toolkit' no está disponible; se activará un REPL básico sin autocompletado."
                 )
             )
-            return self._run_repl_basico(args, validador)
+            return self._run_repl_basico(args, validador=None)
         history_path = os.path.expanduser("~/.cobra_history")
         os.makedirs(os.path.dirname(history_path), exist_ok=True)
         try:
             session = PromptSession(
                 lexer=PygmentsLexer(CobraLexer),
-                history=SafeFileHistory(history_path),
+                history=self._construir_historial(history_path),
             )
         except NoConsoleScreenBufferError:
             mostrar_advertencia(
@@ -456,7 +483,7 @@ class InteractiveCommand(BaseCommand):
             )
             session = PromptSession(
                 lexer=PygmentsLexer(CobraLexer),
-                history=SafeFileHistory(history_path),
+                history=self._construir_historial(history_path),
                 output=DummyOutput(),
             )
         if not hasattr(session, "history"):
@@ -469,7 +496,7 @@ class InteractiveCommand(BaseCommand):
 
             self._run_repl_loop(
                 args=args,
-                validador=validador,
+                validador=None,
                 leer_linea=_leer_prompt_toolkit,
                 sandbox=sandbox,
                 sandbox_docker=sandbox_docker,
@@ -477,7 +504,7 @@ class InteractiveCommand(BaseCommand):
 
         return 0
 
-    def _run_repl_basico(self, args: Any, validador: Optional[Any]) -> int:
+    def _run_repl_basico(self, args: Any, validador: Optional[Any] = None) -> int:
         """Ejecuta un bucle REPL simplificado sin ``prompt_toolkit``."""
 
         sandbox = getattr(args, "sandbox", False)
@@ -493,7 +520,7 @@ class InteractiveCommand(BaseCommand):
         with self:
             self._run_repl_loop(
                 args=args,
-                validador=validador,
+                validador=None,
                 leer_linea=input,
                 sandbox=sandbox,
                 sandbox_docker=None,
@@ -709,7 +736,12 @@ class InteractiveCommand(BaseCommand):
 
         if linea == "ast":
             try:
-                ast = self.procesar_ast(linea, validador)
+                ast = self.procesar_ast(linea, None)
+                if self._seguro_repl:
+                    validar_ast_seguro(
+                        ast,
+                        validadores_extra=self._extra_validators_repl,
+                    )
                 mostrar_info(_("AST generado:"))
                 mostrar_info(str(ast))
             except PrimitivaPeligrosaError as err:
@@ -724,8 +756,7 @@ class InteractiveCommand(BaseCommand):
         Args:
             linea: Código a ejecutar
         """
-        tokens = Lexer(linea).tokenizar()
-        Parser(tokens).parsear()
+        analizar_codigo(linea)
 
         script = (
             "from pcobra.cobra.core import Lexer, Parser\n"
@@ -779,7 +810,8 @@ class InteractiveCommand(BaseCommand):
             exc_info=debug_enabled,
         )
 
-        mostrar_error(mensaje_usuario, registrar_log=False)
+        with color_disabled():
+            mostrar_error(mensaje_usuario, registrar_log=False)
         if debug_enabled:
             self.logger.debug(format_traceback(error))
 
@@ -810,3 +842,7 @@ class InteractiveCommand(BaseCommand):
                 _("Error al finalizar REPL: {exc_val}").format(exc_val=exc_val)
             )
         self.logger.debug(_("Finalizando REPL de Cobra"))
+    def _construir_historial(self, history_path: str) -> Any:
+        if FileHistory is not None:
+            return FileHistory(history_path)
+        return _SessionHistoryFallback(history_path)

--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -2,9 +2,22 @@
 
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Callable
 
 from pcobra.cobra.core import Lexer, Parser
+from pcobra.cobra.cli.i18n import _
+from pcobra.core.semantic_validators import construir_cadena
+from pcobra.core.semantic_validators.base import ValidadorBase
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    """Resultado canónico del pipeline analizar+validar+ejecutar."""
+
+    ast: Any
+    resultado: Any
+    validadores_extra: Any
 
 
 def analizar_codigo(codigo: str) -> Any:
@@ -18,3 +31,97 @@ def ejecutar_ast(ast: Any, interpreter: Any) -> Any:
     """Ejecuta un AST usando una instancia explícita de intérprete."""
 
     return interpreter.ejecutar_ast(ast)
+
+
+def resolver_validadores_seguridad(
+    extra_validators: Any,
+    *,
+    interpretador_cls: Any,
+) -> Any:
+    """Normaliza validadores extra usando la misma política en run y REPL."""
+
+    if extra_validators is None:
+        return None
+    if isinstance(extra_validators, str):
+        return interpretador_cls._cargar_validadores(extra_validators)
+    if isinstance(extra_validators, list) and all(
+        isinstance(ruta, str) for ruta in extra_validators
+    ):
+        acumulado: list[Any] = []
+        for ruta in extra_validators:
+            try:
+                acumulado.extend(interpretador_cls._cargar_validadores(ruta))
+            except Exception as exc:
+                raise ValueError(
+                    _("No se pudieron cargar los validadores extra desde '{path}': {error}").format(
+                        path=ruta,
+                        error=exc,
+                    )
+                ) from exc
+        return acumulado
+    return extra_validators
+
+
+def validar_ast_seguro(
+    ast: Any,
+    *,
+    validadores_extra: Any,
+    construir_cadena_fn: Callable[[Any], Any] = construir_cadena,
+) -> None:
+    """Aplica la cadena de validadores de seguridad sobre el AST."""
+
+    if validadores_extra is not None:
+        if not isinstance(validadores_extra, list) or not all(
+            isinstance(validador, ValidadorBase) for validador in validadores_extra
+        ):
+            raise TypeError(
+                _("Los validadores extra deben ser una lista de instancias de validadores")
+            )
+    validador = construir_cadena_fn(validadores_extra)
+    for nodo in ast:
+        nodo.aceptar(validador)
+
+
+def construir_interprete(
+    *,
+    interpretador_cls: Any,
+    safe_mode: bool,
+    extra_validators: Any,
+) -> Any:
+    """Construye una instancia del intérprete con la configuración común."""
+
+    return interpretador_cls(
+        safe_mode=safe_mode,
+        extra_validators=extra_validators,
+    )
+
+
+def ejecutar_codigo_canonico(
+    codigo: str,
+    *,
+    interpretador: Any,
+    seguro: bool,
+    extra_validators: Any,
+    interpretador_cls: Any,
+    construir_cadena_fn: Callable[[Any], Any] = construir_cadena,
+    analizar_codigo_fn: Callable[[str], Any] = analizar_codigo,
+) -> PipelineResult:
+    """Función canónica para analizar+validar+ejecutar código Cobra."""
+
+    ast = analizar_codigo_fn(codigo)
+    validadores_normalizados = resolver_validadores_seguridad(
+        extra_validators,
+        interpretador_cls=interpretador_cls,
+    )
+    if seguro:
+        validar_ast_seguro(
+            ast,
+            validadores_extra=validadores_normalizados,
+            construir_cadena_fn=construir_cadena_fn,
+        )
+    resultado = ejecutar_ast(ast, interpretador)
+    return PipelineResult(
+        ast=ast,
+        resultado=resultado,
+        validadores_extra=validadores_normalizados,
+    )


### PR DESCRIPTION
### Motivation
- Unificar el flujo de `analizar + validar + ejecutar AST` en una única función canónica para evitar duplicación entre los comandos `run` y el REPL. 
- Centralizar la resolución/normalización de validadores seguros y la construcción del intérprete para aplicar la misma política de seguridad en todas las rutas de ejecución. 
- Evitar que el REPL introduzca reglas semánticas distintas para bloques/loops respecto a la ejecución por archivo (`run`) manteniendo solo diferencias en I/O (prompt, impresión, manejo de sesión). 

### Description
- Se añadió `PipelineResult` y los helpers en `src/pcobra/cobra/cli/execution_pipeline.py`: `resolver_validadores_seguridad`, `validar_ast_seguro`, `construir_interprete` y `ejecutar_codigo_canonico` (que hace `analizar + validar + ejecutar`). 
- `ExecuteCommand` (`src/pcobra/cobra/cli/commands/execute_cmd.py`) ahora reutiliza `resolver_validadores_seguridad`, `construir_interprete` y `ejecutar_codigo_canonico` para la ejecución normal, eliminando bloques duplicados de inicialización y validación de validadores extras. 
- `InteractiveCommand` (`src/pcobra/cobra/cli/commands/interactive_cmd.py`) fue adaptado para ejecutar snippets mediante `ejecutar_codigo_canonico`, conservar la lógica de control/entrada del REPL (buffer multilinea, `fin`, límites de líneas en blanco) y normalizar validadores con los mismos helpers; además el sandbox local del REPL usa `analizar_codigo` antes de armar el script. 
- Ajustes menores para compatibilidad de pruebas y UX: helper para construir historial (`_construir_historial`), respetar la firma esperada de `ejecutar_codigo` en tests, y deshabilitar colores al imprimir errores de REPL en la ruta de logging (`with color_disabled(): mostrar_error(...)`). 
- Archivos modificados: `execution_pipeline.py`, `commands/execute_cmd.py`, `commands/interactive_cmd.py`.

### Testing
- Ejecuté los tests unitarios dirigidos: `pytest -q tests/unit/test_execute_cmd_extra_validators_normalization.py tests/unit/test_cli_interactive_cmd.py tests/unit/test_interactive_block_depth.py` y todos pasaron (pasaron 42 tests en la ejecución final). 
- Ejecuté pruebas adicionales relevantes para el contrato de bindings y multiline REPL: `pytest -q tests/unit/test_execute_cmd_binding_contract.py tests/unit/test_cli_interactive_cmd.py::test_interactive_multiline_bloque_con_multiples_sentencias_se_ejecuta_igual` y ambas pasaron. 
- Corrigieron regresiones detectadas durante la integración de la refactorización y volví a ejecutar las baterías focales hasta que todas las pruebas dirigidas completaron exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f29db4988327b2de795ed4ce25fb)