### PR TITLE
tests: migrate bindings contract import to canonical pcobra path

### DIFF
--- a/tests/unit/test_binding_contract_canonical.py
+++ b/tests/unit/test_binding_contract_canonical.py
@@ -1,4 +1,4 @@
-from bindings.contract import BindingRoute, OFFICIAL_PUBLIC_ROUTE_MATRIX, resolve_binding
+from pcobra.cobra.bindings.contract import BindingRoute, OFFICIAL_PUBLIC_ROUTE_MATRIX, resolve_binding
 
 
 def test_binding_contract_canonical_route_python():


### PR DESCRIPTION
### Motivation
- Canonicalizar el import de `bindings.contract` a `pcobra.cobra.bindings.contract` en los tests para evitar rutas ambiguas y asegurar que las importaciones funcionen igual al ejecutar con `python -m pcobra` o como paquete instalado.

### Description
- Se actualizó el import en `tests/unit/test_binding_contract_canonical.py` cambiando `from bindings.contract ...` por `from pcobra.cobra.bindings.contract ...` y se buscó en el repositorio patrones `from bindings.` / `import bindings` confirmando que no quedan ocurrencias.

### Testing
- Ejecuté `pytest -q tests/unit/test_binding_contract_canonical.py tests/test_legacy_import_aliases.py tests/unit/test_legacy_import_deprecation.py` y todos los tests pasaron (`8 passed`) con una advertencia de deprecación esperada relacionada con la compatibilidad de imports legacy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e506a0902483278aa34a00207f22c7)