### PR TITLE
Centraliza consumidores en transpilers.registry y añade shim deprecated en compile_cmd

### DIFF
--- a/scripts/ci/validate_targets.py
+++ b/scripts/ci/validate_targets.py
@@ -20,7 +20,6 @@ if str(ROOT) not in sys.path:
 
 from pcobra.cobra.cli.commands.benchmarks_cmd import BACKENDS as BENCHMARKS_BACKENDS
 from pcobra.cobra.cli.commands.benchmarks_cmd import BenchmarksCommand
-from pcobra.cobra.cli.commands.compile_cmd import LANG_CHOICES, TRANSPILERS
 from pcobra.cobra.cli.commands.compile_cmd import CompileCommand
 from pcobra.cobra.cli.commands.transpilar_inverso_cmd import TranspilarInversoCommand
 from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
@@ -35,6 +34,7 @@ from pcobra.cobra.transpilers.compatibility_matrix import (
 )
 from pcobra.cobra.transpilers.registry import (
     TRANSPILER_CLASS_PATHS,
+    get_transpilers,
     official_transpiler_module_filenames,
     official_transpiler_registry_literal,
     official_transpiler_targets,
@@ -371,15 +371,11 @@ def validate_registry_tables() -> list[str]:
             "src/pcobra/cobra/transpilers/registry.py: official_transpiler_targets() no coincide con OFFICIAL_TARGETS -> "
             f"registry={official_transpiler_targets()}, official={expected}"
         )
-    if tuple(TRANSPILERS) != expected:
+    registry_transpilers = get_transpilers()
+    if tuple(registry_transpilers) != expected:
         errors.append(
-            "src/pcobra/cobra/cli/commands/compile_cmd.py: TRANSPILERS no coincide con OFFICIAL_TARGETS -> "
-            f"transpilers={tuple(TRANSPILERS)}, official={expected}"
-        )
-    if tuple(LANG_CHOICES) != expected:
-        errors.append(
-            "src/pcobra/cobra/cli/commands/compile_cmd.py: LANG_CHOICES no coincide con OFFICIAL_TARGETS -> "
-            f"choices={tuple(LANG_CHOICES)}, official={expected}"
+            "src/pcobra/cobra/transpilers/registry.py: get_transpilers() no coincide con OFFICIAL_TARGETS -> "
+            f"transpilers={tuple(registry_transpilers)}, official={expected}"
         )
     if tuple(BENCHMARKS_BACKENDS) != expected:
         errors.append(

--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -3,6 +3,7 @@ import multiprocessing
 import os
 import inspect
 from argparse import ArgumentTypeError
+from types import MappingProxyType
 from importlib import import_module
 from importlib.metadata import entry_points
 
@@ -33,6 +34,10 @@ from pcobra.cobra.cli.utils.validators import validar_archivo_existente
 from pcobra.cobra.cli.utils.autocomplete import files_completer
 from pcobra.cobra.core import ParserError
 from pcobra.core.cobra_config import tiempo_max_transpilacion
+from pcobra.cobra.transpilers.registry import (
+    get_transpilers,
+    official_transpiler_targets,
+)
 
 # Constantes de configuración
 MAX_PROCESSES = 4
@@ -42,6 +47,11 @@ MAX_LANGUAGES = 10
 
 _PLUGIN_TRANSPILERS: dict[str, type] = {}
 _ENTRYPOINTS_LOADED = False
+
+LANG_CHOICES = official_transpiler_targets()
+# DEPRECATED (retirar cuando no existan consumidores legacy de compile_cmd.TRANSPILERS):
+# shim de solo lectura que delega al registro canónico en transpilers.registry.
+TRANSPILERS = MappingProxyType(get_transpilers())
 
 
 def register_transpiler_backend(backend: str, transpiler_cls, *, context: str) -> str:
@@ -305,7 +315,7 @@ class CompileCommand(BaseCommand):
 
     def register_subparser(self, subparsers):
         """Registra los argumentos del subcomando."""
-        lang_choices = list(OFFICIAL_TRANSPILATION_TARGETS) + list(enabled_internal_legacy_targets())
+        lang_choices = list(LANG_CHOICES) + list(enabled_internal_legacy_targets())
         parser = subparsers.add_parser(
             self.name,
             help=_("Transpila un archivo"),

--- a/tests/unit/test_compile_backend_registration.py
+++ b/tests/unit/test_compile_backend_registration.py
@@ -13,7 +13,7 @@ class DummyTranspiler:
 
 
 def test_register_transpiler_backend_rechaza_backend_no_oficial(monkeypatch):
-    monkeypatch.setattr(compile_cmd, "TRANSPILERS", {})
+    monkeypatch.setattr(compile_cmd, "_PLUGIN_TRANSPILERS", {})
 
     with pytest.raises(
         ValueError, match=r"Target no soportado: 'backend_no_soportado'"
@@ -24,12 +24,12 @@ def test_register_transpiler_backend_rechaza_backend_no_oficial(monkeypatch):
 
 
 def test_register_transpiler_backend_acepta_backend_canonico(monkeypatch):
-    monkeypatch.setattr(compile_cmd, "TRANSPILERS", {})
+    monkeypatch.setattr(compile_cmd, "_PLUGIN_TRANSPILERS", {})
 
     canonical = compile_cmd.register_transpiler_backend("javascript", DummyTranspiler, context="tests")
 
     assert canonical == "javascript"
-    assert compile_cmd.TRANSPILERS["javascript"] is DummyTranspiler
+    assert compile_cmd._PLUGIN_TRANSPILERS["javascript"] is DummyTranspiler
 
 
 def test_validate_entrypoint_backend_rechaza_backend_fuera_del_set_oficial():
@@ -46,7 +46,7 @@ def test_load_entrypoint_transpilers_omite_backend_fuera_del_set_oficial(monkeyp
         value="tests.unit.test_compile_backend_registration:DummyTranspiler",
         group="cobra.transpilers",
     )
-    monkeypatch.setattr(compile_cmd, "TRANSPILERS", {})
+    monkeypatch.setattr(compile_cmd, "_PLUGIN_TRANSPILERS", {})
     monkeypatch.setattr(
         compile_cmd,
         "_iter_transpiler_entry_points",
@@ -55,7 +55,7 @@ def test_load_entrypoint_transpilers_omite_backend_fuera_del_set_oficial(monkeyp
 
     compile_cmd.load_entrypoint_transpilers()
 
-    assert compile_cmd.TRANSPILERS == {}
+    assert compile_cmd._PLUGIN_TRANSPILERS == {}
     assert "rechazado por política/contrato" in caplog.text
     assert "Target no soportado: 'fantasy'" in caplog.text
 
@@ -66,7 +66,7 @@ def test_load_entrypoint_transpilers_rechaza_alias_no_canonico(monkeypatch, capl
         value="tests.unit.test_compile_backend_registration:DummyTranspiler",
         group="cobra.transpilers",
     )
-    monkeypatch.setattr(compile_cmd, "TRANSPILERS", {})
+    monkeypatch.setattr(compile_cmd, "_PLUGIN_TRANSPILERS", {})
     monkeypatch.setattr(
         compile_cmd,
         "_iter_transpiler_entry_points",
@@ -75,7 +75,7 @@ def test_load_entrypoint_transpilers_rechaza_alias_no_canonico(monkeypatch, capl
 
     compile_cmd.load_entrypoint_transpilers()
 
-    assert compile_cmd.TRANSPILERS == {}
+    assert compile_cmd._PLUGIN_TRANSPILERS == {}
     assert "rechazado por política/contrato" in caplog.text
     assert "c++" in caplog.text
 
@@ -87,7 +87,7 @@ def test_load_entrypoint_transpilers_rechaza_backends_legacy_o_ambiguos(monkeypa
         value="tests.unit.test_compile_backend_registration:DummyTranspiler",
         group="cobra.transpilers",
     )
-    monkeypatch.setattr(compile_cmd, "TRANSPILERS", {})
+    monkeypatch.setattr(compile_cmd, "_PLUGIN_TRANSPILERS", {})
     monkeypatch.setattr(
         compile_cmd,
         "_iter_transpiler_entry_points",
@@ -96,7 +96,7 @@ def test_load_entrypoint_transpilers_rechaza_backends_legacy_o_ambiguos(monkeypa
 
     compile_cmd.load_entrypoint_transpilers()
 
-    assert compile_cmd.TRANSPILERS == {}
+    assert compile_cmd._PLUGIN_TRANSPILERS == {}
     assert "rechazado por política/contrato" in caplog.text
     assert "legacy/ambiguo" in caplog.text
 
@@ -107,7 +107,7 @@ def test_load_entrypoint_transpilers_registra_backend_canonico(monkeypatch):
         value="fake.module:DummyExternalTranspiler",
         group="cobra.transpilers",
     )
-    monkeypatch.setattr(compile_cmd, "TRANSPILERS", {})
+    monkeypatch.setattr(compile_cmd, "_PLUGIN_TRANSPILERS", {})
     monkeypatch.setattr(
         compile_cmd,
         "_iter_transpiler_entry_points",
@@ -121,7 +121,7 @@ def test_load_entrypoint_transpilers_registra_backend_canonico(monkeypatch):
 
     compile_cmd.load_entrypoint_transpilers()
 
-    assert compile_cmd.TRANSPILERS == {"python": DummyTranspiler}
+    assert compile_cmd._PLUGIN_TRANSPILERS == {"python": DummyTranspiler}
 
 
 def test_load_entrypoint_transpilers_no_sobrescribe_backend_canonico_existente(monkeypatch, caplog):
@@ -130,7 +130,7 @@ def test_load_entrypoint_transpilers_no_sobrescribe_backend_canonico_existente(m
         value="fake.module:DummyExternalTranspiler",
         group="cobra.transpilers",
     )
-    monkeypatch.setattr(compile_cmd, "TRANSPILERS", {"python": object})
+    monkeypatch.setattr(compile_cmd, "_PLUGIN_TRANSPILERS", {"python": object})
     monkeypatch.setattr(
         compile_cmd,
         "_iter_transpiler_entry_points",
@@ -144,7 +144,7 @@ def test_load_entrypoint_transpilers_no_sobrescribe_backend_canonico_existente(m
 
     compile_cmd.load_entrypoint_transpilers()
 
-    assert compile_cmd.TRANSPILERS == {"python": object}
+    assert compile_cmd._PLUGIN_TRANSPILERS == {"python": object}
     assert "ya existe en el registro canónico" in caplog.text
 
 
@@ -157,7 +157,7 @@ def test_load_entrypoint_transpilers_rechaza_clase_sin_generate_code(monkeypatch
         value="fake.module:InvalidNoGenerateCode",
         group="cobra.transpilers",
     )
-    monkeypatch.setattr(compile_cmd, "TRANSPILERS", {})
+    monkeypatch.setattr(compile_cmd, "_PLUGIN_TRANSPILERS", {})
     monkeypatch.setattr(
         compile_cmd,
         "_iter_transpiler_entry_points",
@@ -172,7 +172,7 @@ def test_load_entrypoint_transpilers_rechaza_clase_sin_generate_code(monkeypatch
     loaded, rejected, skipped = compile_cmd.load_entrypoint_transpilers()
 
     assert (loaded, rejected, skipped) == (0, 1, 0)
-    assert compile_cmd.TRANSPILERS == {}
+    assert compile_cmd._PLUGIN_TRANSPILERS == {}
     assert "python" in caplog.text
     assert "no implementa el método callable 'generate_code'" in caplog.text
 
@@ -184,7 +184,7 @@ def test_load_entrypoint_transpilers_rechaza_objeto_que_no_es_clase(monkeypatch,
         value="fake.module:not_a_class",
         group="cobra.transpilers",
     )
-    monkeypatch.setattr(compile_cmd, "TRANSPILERS", {})
+    monkeypatch.setattr(compile_cmd, "_PLUGIN_TRANSPILERS", {})
     monkeypatch.setattr(
         compile_cmd,
         "_iter_transpiler_entry_points",
@@ -199,7 +199,7 @@ def test_load_entrypoint_transpilers_rechaza_objeto_que_no_es_clase(monkeypatch,
     loaded, rejected, skipped = compile_cmd.load_entrypoint_transpilers()
 
     assert (loaded, rejected, skipped) == (0, 1, 0)
-    assert compile_cmd.TRANSPILERS == {}
+    assert compile_cmd._PLUGIN_TRANSPILERS == {}
     assert "python" in caplog.text
     assert "se esperaba una clase" in caplog.text
 
@@ -217,7 +217,7 @@ def test_load_entrypoint_transpilers_rechaza_constructor_con_argumentos_obligato
         value="fake.module:InvalidConstructorTranspiler",
         group="cobra.transpilers",
     )
-    monkeypatch.setattr(compile_cmd, "TRANSPILERS", {})
+    monkeypatch.setattr(compile_cmd, "_PLUGIN_TRANSPILERS", {})
     monkeypatch.setattr(
         compile_cmd,
         "_iter_transpiler_entry_points",
@@ -234,7 +234,7 @@ def test_load_entrypoint_transpilers_rechaza_constructor_con_argumentos_obligato
     loaded, rejected, skipped = compile_cmd.load_entrypoint_transpilers()
 
     assert (loaded, rejected, skipped) == (0, 1, 0)
-    assert compile_cmd.TRANSPILERS == {}
+    assert compile_cmd._PLUGIN_TRANSPILERS == {}
     assert "python" in caplog.text
     assert "constructor sin argumentos" in caplog.text
 

--- a/tests/unit/test_official_targets_consistency.py
+++ b/tests/unit/test_official_targets_consistency.py
@@ -4,7 +4,6 @@ import pytest
 
 from pcobra.cobra.cli.commands.bench_cmd import BACKENDS as BENCH_BACKENDS
 from pcobra.cobra.cli.commands.benchmarks_cmd import BACKENDS as BENCHMARKS_BACKENDS
-from pcobra.cobra.cli.commands.compile_cmd import LANG_CHOICES, TRANSPILERS
 from pcobra.cobra.cli.commands.transpilar_inverso_cmd import EXTENSIONES_POR_LENGUAJE
 from pcobra.cobra.cli.target_policies import (
     ADVANCED_HOLOBIT_RUNTIME_TARGETS,
@@ -24,6 +23,7 @@ from pcobra.cobra.transpilers.feature_inspector import (
 )
 from pcobra.cobra.transpilers.registry import (
     TRANSPILER_CLASS_PATHS,
+    get_transpilers,
     official_transpiler_targets,
 )
 import pcobra.cobra.transpilers.registry as transpiler_registry
@@ -71,7 +71,8 @@ EXPECTED_CANONICAL_TARGETS = (
 
 def test_fuente_canonica_y_registros_comparten_los_8_backends_oficiales():
     oficiales = tuple(OFFICIAL_TARGETS)
-    particion = assert_official_targets_partition(transpilers=TRANSPILERS)
+    registry_transpilers = get_transpilers()
+    particion = assert_official_targets_partition(transpilers=registry_transpilers)
 
     assert len(oficiales) == 8
     assert len(set(oficiales)) == 8
@@ -85,8 +86,7 @@ def test_fuente_canonica_y_registros_comparten_los_8_backends_oficiales():
     assert oficiales == TIER1_TARGETS + TIER2_TARGETS
     assert tuple(official_transpiler_targets()) == oficiales
     assert tuple(TRANSPILER_CLASS_PATHS) == oficiales
-    assert tuple(TRANSPILERS) == oficiales
-    assert tuple(LANG_CHOICES) == oficiales
+    assert tuple(registry_transpilers) == oficiales
     assert tuple(BENCHMARKS_BACKENDS) == oficiales
     assert set(BENCH_BACKENDS).issubset(oficiales)
     assert set(STANDARD_IMPORTS).issubset(oficiales)
@@ -242,7 +242,7 @@ def test_registry_falla_explicito_si_aparece_novena_clave(monkeypatch):
     monkeypatch.setattr(transpiler_registry, "TRANSPILER_CLASS_PATHS", registry_with_extra)
 
     with pytest.raises(RuntimeError, match="claves fuera de contrato"):
-        transpiler_registry._validate_registry_contract()
+        transpiler_registry._validate_complete_registry_contract()
 
 
 def test_summary_publico_no_promociona_sdk_full_fuera_de_python():


### PR DESCRIPTION
### Motivation
- Unificar la fuente de verdad de los transpiladores para que consumidores (CI y tests) dependan del registro canónico en `pcobra.cobra.transpilers.registry` en lugar de `compile_cmd`.
- Exponer una API clara: `get_transpilers()` y `official_transpiler_targets()` para uso interno y validaciones.
- Proveer compatibilidad temporal para consumidores legacy mediante un shim de solo lectura en `compile_cmd` marcado como deprecado.

### Description
- `src/pcobra/cobra/cli/commands/compile_cmd.py`: importa `get_transpilers()` y `official_transpiler_targets()` desde `transpilers.registry`, define `LANG_CHOICES = official_transpiler_targets()` y añade un shim de solo lectura `TRANSPILERS = MappingProxyType(get_transpilers())` con comentario deprecatorio, y usa `LANG_CHOICES` para construir `lang_choices` en el parser del comando `compilar`.
- `scripts/ci/validate_targets.py`: deja de depender de `compile_cmd.TRANSPILERS/LANG_CHOICES` y ahora valida contra `get_transpilers()` y `official_transpiler_targets()` del registro canónico.
- `tests/unit/test_official_targets_consistency.py`: actualiza importaciones y comprobaciones para consumir `get_transpilers()` y `official_transpiler_targets()` desde `transpilers.registry`, y llama a `_validate_complete_registry_contract()` cuando corresponde.
- `tests/unit/test_compile_backend_registration.py`: actualiza mocks y aserciones para manipular el registro de plugins interno `_PLUGIN_TRANSPILERS` en lugar de `compile_cmd.TRANSPILERS`, preservando el comportamiento de tests que ejercitan registro de entry points.

### Testing
- Ejecuté `python -m py_compile` sobre los módulos modificados y la compilación de bytecode fue satisfactoria (sin errores).
- Ejecuté `pytest` sobre `tests/unit/test_compile_backend_registration.py` y `tests/unit/test_compile_cmd_target_choices_aliases.py`, donde `tests/unit/test_compile_backend_registration.py` pasó (19 tests) y `test_compile_help_refleja_solo_nombres_canonicos` falló por mismatch en el texto de ayuda (1 fallo).
- Intenté ejecutar la batería combinada `pytest` incluyendo `tests/unit/test_official_targets_consistency.py`, la colección falló en tiempo de importación debido a un `AssertionError` preexistente en `tests/utils/targets.py`, por lo que no se completó esa ejecución.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e508b2ce508327ba4adab10a28463f)