### PR TITLE
refactor(cli): centralizar resolución de comandos legacy v2 con CommandFactory

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/build_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/build_cmd.py
@@ -4,6 +4,7 @@ from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.architecture.contracts import assert_backend_allowed_for_scope
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 from pcobra.cobra.build import backend_pipeline
+from pcobra.cobra.cli.services.command_factory import CommandFactory
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.cli.utils.autocomplete import files_completer
@@ -17,6 +18,7 @@ class BuildCommandV2(BaseCommand):
 
     def __init__(self) -> None:
         super().__init__()
+        self._command_factory = CommandFactory()
         self._runtime_manager = RuntimeManager()
 
     def register_subparser(self, subparsers: Any):

--- a/src/pcobra/cobra/cli/commands_v2/legacy_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/legacy_cmd.py
@@ -2,10 +2,7 @@ from argparse import Namespace
 from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
-from pcobra.cobra.cli.commands.compile_cmd import CompileCommand
-from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
-from pcobra.cobra.cli.commands.modules_cmd import ModulesCommand
-from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
+from pcobra.cobra.cli.services.command_factory import CommandFactory
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.public_command_policy import PROFILE_DEVELOPMENT, resolve_command_profile
 from pcobra.cobra.cli.utils import messages
@@ -26,10 +23,11 @@ class LegacyCommandGroupV2(BaseCommand):
 
     def __init__(self) -> None:
         super().__init__()
-        self._execute = ExecuteCommand()
-        self._compile = CompileCommand()
-        self._verify = VerifyCommand()
-        self._modules = ModulesCommand()
+        self._command_factory = CommandFactory()
+        self._execute = self._command_factory.create("ejecutar")
+        self._compile = self._command_factory.create("compilar")
+        self._verify = self._command_factory.create("verificar")
+        self._modules = self._command_factory.create("modulos")
 
     def register_subparser(self, subparsers: Any):
         parser = subparsers.add_parser(self.name, help=_("Legacy compatibility command group"))

--- a/src/pcobra/cobra/cli/commands_v2/mod_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/mod_cmd.py
@@ -2,7 +2,7 @@ from argparse import Namespace
 from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
-from pcobra.cobra.cli.commands.modules_cmd import ModulesCommand
+from pcobra.cobra.cli.services.command_factory import CommandFactory
 from pcobra.cobra.cli.i18n import _
 
 
@@ -13,7 +13,8 @@ class ModCommandV2(BaseCommand):
 
     def __init__(self) -> None:
         super().__init__()
-        self._legacy = ModulesCommand()
+        self._command_factory = CommandFactory()
+        self._legacy = self._command_factory.create("modulos")
 
     def register_subparser(self, subparsers: Any):
         parser = subparsers.add_parser(self.name, help=_("Manage Cobra modules"))

--- a/src/pcobra/cobra/cli/commands_v2/run_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/run_cmd.py
@@ -5,8 +5,8 @@ from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 from pcobra.cobra.architecture.contracts import assert_backend_allowed_for_scope
 from pcobra.cobra.cli.commands.base import BaseCommand
-from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
+from pcobra.cobra.cli.services.command_factory import CommandFactory
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.messages import mostrar_error
 from pcobra.cobra.cli.utils.autocomplete import files_completer
@@ -20,7 +20,8 @@ class RunCommandV2(BaseCommand):
 
     def __init__(self) -> None:
         super().__init__()
-        self._legacy = ExecuteCommand()
+        self._command_factory = CommandFactory()
+        self._legacy = self._command_factory.create("ejecutar")
         self._runtime_manager = RuntimeManager()
 
     def register_subparser(self, subparsers: Any):

--- a/src/pcobra/cobra/cli/commands_v2/test_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/test_cmd.py
@@ -4,8 +4,8 @@ from typing import Any
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.architecture.contracts import assert_backend_allowed_for_scope
-from pcobra.cobra.cli.commands.verify_cmd import VerifyCommand
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
+from pcobra.cobra.cli.services.command_factory import CommandFactory
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.messages import mostrar_error
 from pcobra.cobra.cli.target_policies import (
@@ -23,7 +23,8 @@ class TestCommandV2(BaseCommand):
 
     def __init__(self) -> None:
         super().__init__()
-        self._legacy = VerifyCommand()
+        self._command_factory = CommandFactory()
+        self._legacy = self._command_factory.create("verificar")
         self._runtime_manager = RuntimeManager()
         self._default_langs = ",".join(VERIFICATION_EXECUTABLE_TARGETS)
 

--- a/src/pcobra/cobra/cli/services/__init__.py
+++ b/src/pcobra/cobra/cli/services/__init__.py
@@ -1,2 +1,5 @@
 """Servicios reutilizables para comandos CLI."""
 
+from pcobra.cobra.cli.services.command_factory import CommandFactory
+
+__all__ = ["CommandFactory"]

--- a/src/pcobra/cobra/cli/services/command_factory.py
+++ b/src/pcobra/cobra/cli/services/command_factory.py
@@ -1,0 +1,74 @@
+"""Factory/registry para resolución de comandos CLI por nombre/capacidad."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Callable
+
+from pcobra.cobra.cli.commands.base import BaseCommand, CommandCapability
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """Metadatos mínimos para instanciar un comando de forma lazy."""
+
+    name: str
+    capability: CommandCapability
+    module_path: str
+    class_name: str
+
+
+class CommandFactory:
+    """Resuelve instancias de comandos sin imports directos en consumidores."""
+
+    _SPECS: tuple[CommandSpec, ...] = (
+        CommandSpec(
+            name="ejecutar",
+            capability="execute",
+            module_path="pcobra.cobra.cli.commands.execute_cmd",
+            class_name="ExecuteCommand",
+        ),
+        CommandSpec(
+            name="compilar",
+            capability="codegen",
+            module_path="pcobra.cobra.cli.commands.compile_cmd",
+            class_name="CompileCommand",
+        ),
+        CommandSpec(
+            name="verificar",
+            capability="codegen",
+            module_path="pcobra.cobra.cli.commands.verify_cmd",
+            class_name="VerifyCommand",
+        ),
+        CommandSpec(
+            name="modulos",
+            capability="mixed",
+            module_path="pcobra.cobra.cli.commands.modules_cmd",
+            class_name="ModulesCommand",
+        ),
+    )
+
+    def __init__(self) -> None:
+        self._spec_by_name: dict[str, CommandSpec] = {spec.name: spec for spec in self._SPECS}
+
+    def create(self, command_name: str) -> BaseCommand:
+        """Crea una instancia de comando por nombre lógico."""
+        spec = self._spec_by_name.get(command_name)
+        if spec is None:
+            raise ValueError(f"Comando no registrado en factory: {command_name}")
+        return self._create_from_spec(spec)
+
+    def create_by_capability(self, capability: CommandCapability) -> list[BaseCommand]:
+        """Crea todas las instancias asociadas a una capacidad."""
+        return [
+            self._create_from_spec(spec)
+            for spec in self._SPECS
+            if spec.capability == capability
+        ]
+
+    @staticmethod
+    def _create_from_spec(spec: CommandSpec) -> BaseCommand:
+        module = import_module(spec.module_path)
+        command_class: Callable[[], BaseCommand] = getattr(module, spec.class_name)
+        return command_class()

--- a/tests/unit/test_command_factory.py
+++ b/tests/unit/test_command_factory.py
@@ -1,0 +1,25 @@
+from cobra.cli.services.command_factory import CommandFactory
+
+
+def test_command_factory_resuelve_por_nombre():
+    factory = CommandFactory()
+
+    ejecutar = factory.create("ejecutar")
+    compilar = factory.create("compilar")
+    verificar = factory.create("verificar")
+    modulos = factory.create("modulos")
+
+    assert ejecutar.name == "ejecutar"
+    assert compilar.name == "compilar"
+    assert verificar.name == "verificar"
+    assert modulos.name == "modulos"
+
+
+def test_command_factory_resuelve_por_capacidad():
+    factory = CommandFactory()
+
+    execute_commands = factory.create_by_capability("execute")
+    codegen_commands = factory.create_by_capability("codegen")
+
+    assert [cmd.name for cmd in execute_commands] == ["ejecutar"]
+    assert {cmd.name for cmd in codegen_commands} == {"compilar", "verificar"}


### PR DESCRIPTION
### Motivation
- Evitar imports directos de comandos legacy desde los comandos v2 y centralizar la resolución en una capa que entregue instancias por nombre/capacidad. 
- Facilitar carga lazy y desacoplar la UI pública (`run/build/test/mod`) de las implementaciones legacy internas.

### Description
- Se añadió `CommandFactory` en `src/pcobra/cobra/cli/services/command_factory.py` que registra comandos legacy por `name` y `capability` y los instancia con `import_module` de forma lazy. 
- Se refactoraron los comandos v2 `run`, `build`, `test` y `mod` para usar la factory en lugar de importar clases legacy concretas. 
- Se refactoró el grupo `legacy` v2 para crear sus subcomandos (`ejecutar/compilar/verificar/modulos`) mediante la factory. 
- Se exportó la factory desde `src/pcobra/cobra/cli/services/__init__.py` y se añadieron pruebas unitarias en `tests/unit/test_command_factory.py` que validan resolución por nombre y por capacidad. 
- La interfaz pública no cambia: `cobra run`, `cobra build`, `cobra test`, `cobra mod` siguen mapeando a los mismos nombres internos.

### Testing
- Ejecuté `pytest -q tests/unit/test_command_factory.py tests/unit/test_cli_v2_command_contract.py` y obtuvo 1 fallo en la prueba preexistente `test_legacy_group_muestra_mensaje_corto_de_migracion` debido a la restricción de perfil `legacy` en el entorno de ejecución; este comportamiento no se modificó. 
- Ejecuté `pytest -q tests/unit/test_command_factory.py tests/unit/test_cli_v2_command_contract.py -k 'not legacy_group_muestra_mensaje_corto_de_migracion'` y todos los tests seleccionados pasaron (11 passed). 
- Las nuevas pruebas unitarias `tests/unit/test_command_factory.py` pasan y verifican la resolución por nombre y por capacidad.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e510634eac83279175be89efc5cbbc)