### PR TITLE
refactor(interpreter): usar define/set en contextos en lugar de escrituras directas en `variables`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1073,8 +1073,7 @@ class InterpretadorCobra:
                     f"se recibió: {type(nodo.objetivo).__name__}"
                 )
             nombre = nodo.objetivo.nombre
-            if nombre in self.variables:
-                del self.variables[nombre]
+            self.contextos[-1].values.pop(nombre, None)
         elif isinstance(nodo, NodoGlobal):
             pass  # sin efecto en este intérprete simplificado
         elif isinstance(nodo, NodoNoLocal):
@@ -1465,7 +1464,11 @@ class InterpretadorCobra:
                     return resultado
         except ExcepcionCobra as exc:
             if nodo.nombre_excepcion:
-                self.variables[nodo.nombre_excepcion] = exc.valor
+                contexto_actual = self.contextos[-1]
+                if contexto_actual.contains(nodo.nombre_excepcion):
+                    contexto_actual.set(nodo.nombre_excepcion, exc.valor)
+                else:
+                    contexto_actual.define(nodo.nombre_excepcion, exc.valor)
             for instruccion in nodo.bloque_catch:
                 resultado = self.ejecutar_nodo(instruccion)
                 if resultado is not None:
@@ -1480,7 +1483,7 @@ class InterpretadorCobra:
         """Registra una función definida por el usuario."""
         funcion = self._construir_funcion(nodo)
         self._verificar_valor_contexto(funcion)
-        self.variables[nodo.nombre] = funcion
+        self.contextos[-1].define(nodo.nombre, funcion)
 
     def ejecutar_llamada_funcion(self, nodo):
         """Ejecuta la invocación de una función, interna o del usuario."""
@@ -1568,7 +1571,7 @@ class InterpretadorCobra:
             bases_resueltas.append(base)
         clase = self._construir_clase(nodo, bases_resueltas)
         self._verificar_valor_contexto(clase)
-        self.variables[nodo.nombre] = clase
+        self.contextos[-1].define(nodo.nombre, clase)
 
     def ejecutar_instancia(self, nodo):
         """Crea una instancia de la clase indicada."""
@@ -1661,7 +1664,7 @@ class InterpretadorCobra:
 
         try:
             modulo = obtener_modulo(nodo.modulo)
-            self.variables[nodo.modulo] = modulo
+            self.contextos[-1].define(nodo.modulo, modulo)
         except Exception as exc:
             logging.exception(f"Error al usar el módulo '{nodo.modulo}': {exc}")
             raise


### PR DESCRIPTION
### Motivation
- Evitar escrituras directas en `self.variables` y consolidar `Environment` (`define`/`set`) como la API de mutación de scope.
- Mantener `variables` como compatibilidad de lectura y reducir puntos frágiles donde se ignoraba la lógica de scopes y ancestros.
- Corregir comportamientos en `try/catch`, definición de funciones/clases e importaciones para que respeten la semántica léxica del intérprete.

### Description
- Reemplacé escrituras por `self.variables[...]` en `InterpretadorCobra` por operaciones sobre el contexto activo usando `self.contextos[-1].define(...)` o `self.contextos[-1].set(...)` según corresponda.
- En `ejecutar_try_catch` la variable de excepción ahora usa `set(...)` cuando el nombre ya existe en la cadena de entornos y `define(...)` cuando debe declararse localmente.
- En `ejecutar_funcion`, `ejecutar_clase` y `ejecutar_usar` el registro de símbolos se hace con `self.contextos[-1].define(...)` en lugar de asignar en `variables`.
- En el manejador `del` se dejó de usar `self.variables` para borrado y se eliminó desde el `values` del contexto local activo.

### Testing
- Ejecuté comandos focalizados: `pytest -q tests/unit/test_try_catch.py -k "interpreter"` y `pytest -q tests/unit/test_interpreter.py tests/unit/test_interpreter_herencia.py tests/unit/test_interpreter_inferencia.py`, y esas suites focalizadas del intérprete pasaron correctamente.
- Al ejecutar un conjunto más amplio con `pytest -q tests/unit/test_try_catch.py tests/unit/test_interpreter.py tests/unit/test_interpreter_inferencia.py tests/unit/test_interpreter_herencia.py tests/unit/test_safe_mode_imports.py` se observaron 4 fallos (relacionados con expectativas de transpiladores y con `__import__` en pruebas de modo seguro) que no parecen estar directamente causados por este cambio de mutación de contexto; las pruebas del intérprete relevantes pasaron.
- Los cambios aplicados están en `src/pcobra/core/interpreter.py` y fueron validados mediante los tests mencionados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51ba6a9a48327bbf31be91ca36f64)