### PR TITLE
Centraliza setup del intérprete para ejecución CLI y REPL

### DIFF
--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -26,9 +26,9 @@ from pcobra.cobra.core import LexerError
 from pcobra.cobra.core import ParserError
 from pcobra.cobra.cli.execution_pipeline import (
     analizar_codigo,
-    construir_interprete,
     ejecutar_codigo_canonico,
-    resolver_validadores_seguridad,
+    preparar_interpretador,
+    resolver_interpretador_cls,
 )
 from pcobra.cobra.transpilers import module_map
 from pcobra.core.interpreter import InterpretadorCobra
@@ -116,12 +116,6 @@ def _detectar_raiz_proyecto_desde_archivo(archivo: str) -> str:
         if (ruta / "cobra.toml").exists() or (ruta / "cobra.mod").exists():
             return str(ruta)
     return str(Path(module_map.COBRA_TOML_PATH).resolve().parent)
-
-
-def _obtener_interpretador_cls():
-    """Obtiene la clase de intérprete respetando posibles mocks de pruebas."""
-
-    return getattr(sys.modules[__name__], "InterpretadorCobra", InterpretadorCobra)
 
 
 class ExecuteCommand(BaseCommand):
@@ -385,22 +379,20 @@ class ExecuteCommand(BaseCommand):
     def _ejecutar_normal(self, codigo: str, seguro: bool, extra_validators: Any) -> int:
         """Ejecuta el código normalmente con el intérprete."""
         try:
-            interpretador_cls = _obtener_interpretador_cls()
-            validadores_normalizados = resolver_validadores_seguridad(
-                extra_validators,
-                interpretador_cls=interpretador_cls,
-            )
-            interpreter = construir_interprete(
-                interpretador_cls=interpretador_cls,
+            interpreter_setup = preparar_interpretador(
+                interpretador_cls=resolver_interpretador_cls(
+                    module_name=__name__,
+                    default_cls=InterpretadorCobra,
+                ),
                 safe_mode=seguro,
-                extra_validators=validadores_normalizados,
+                extra_validators=extra_validators,
             )
             ejecutar_codigo_canonico(
                 codigo,
-                interpretador=interpreter,
-                seguro=seguro,
-                extra_validators=validadores_normalizados,
-                interpretador_cls=interpretador_cls,
+                interpretador=interpreter_setup.interpretador,
+                seguro=interpreter_setup.safe_mode,
+                extra_validators=interpreter_setup.validadores_extra,
+                interpretador_cls=interpreter_setup.interpretador_cls,
                 construir_cadena_fn=construir_cadena,
                 analizar_codigo_fn=analizar_codigo,
             )

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import sys
 from typing import Optional, Any
 from types import TracebackType
 
@@ -34,9 +35,9 @@ from pcobra.cobra.core import Lexer, LexerError, TipoToken, UnclosedStringError
 from pcobra.cobra.core import Parser, ParserError
 from pcobra.cobra.cli.execution_pipeline import (
     analizar_codigo,
-    construir_interprete,
     ejecutar_codigo_canonico,
-    resolver_validadores_seguridad,
+    preparar_interpretador,
+    resolver_interpretador_cls,
     validar_ast_seguro,
 )
 from pcobra.cobra.transpilers import module_map
@@ -72,6 +73,8 @@ from pcobra.cobra.cli.target_policies import (
 DOCKER_RUNTIME_TARGETS = tuple(DOCKER_RUNTIME_BY_TARGET.values())
 SANDBOX_DOCKER_CHOICES = DOCKER_EXECUTABLE_TARGETS
 SANDBOX_DOCKER_HELP = OFFICIAL_RUNTIME_TARGETS_HELP
+
+sys.modules.setdefault("cli.commands.interactive_cmd", sys.modules[__name__])
 
 
 def _contains_isolated_surrogate(text: str) -> bool:
@@ -344,7 +347,10 @@ class InteractiveCommand(BaseCommand):
         """Ejecuta un snippet usando el pipeline canónico compartido con `run`."""
 
         self.logger.debug("[RUN] Ejecutando snippet en REPL")
-        interpretador_cls = type(self.interpretador)
+        interpretador_cls = resolver_interpretador_cls(
+            module_name=__name__,
+            default_cls=type(self.interpretador),
+        )
         resultado_pipeline = ejecutar_codigo_canonico(
             codigo,
             interpretador=self.interpretador,
@@ -435,19 +441,21 @@ class InteractiveCommand(BaseCommand):
         self._seguro_repl = bool(seguro)
         self._extra_validators_repl = extra_validators
         try:
-            self._extra_validators_repl = resolver_validadores_seguridad(
-                self._extra_validators_repl,
-                interpretador_cls=InterpretadorCobra,
+            interpreter_setup = preparar_interpretador(
+                interpretador_cls=resolver_interpretador_cls(
+                    module_name=__name__,
+                    default_cls=InterpretadorCobra,
+                ),
+                safe_mode=self._seguro_repl,
+                extra_validators=self._extra_validators_repl,
             )
         except (TypeError, ValueError, PrimitivaPeligrosaError) as err:
             mostrar_error(str(err))
             return 1
 
-        self.interpretador = construir_interprete(
-            interpretador_cls=InterpretadorCobra,
-            safe_mode=self._seguro_repl,
-            extra_validators=self._extra_validators_repl,
-        )
+        self._seguro_repl = interpreter_setup.safe_mode
+        self._extra_validators_repl = interpreter_setup.validadores_extra
+        self.interpretador = interpreter_setup.interpretador
 
         # Obtener modos de ejecución
         sandbox = getattr(args, "sandbox", False)

--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -18,6 +19,16 @@ class PipelineResult:
     ast: Any
     resultado: Any
     validadores_extra: Any
+
+
+@dataclass(frozen=True)
+class InterpreterSetup:
+    """Configuración derivada y componentes del intérprete para ejecución."""
+
+    interpretador_cls: Any
+    safe_mode: bool
+    validadores_extra: Any
+    interpretador: Any
 
 
 def analizar_codigo(codigo: str) -> Any:
@@ -93,6 +104,44 @@ def construir_interprete(
     return interpretador_cls(
         safe_mode=safe_mode,
         extra_validators=extra_validators,
+    )
+
+
+def resolver_interpretador_cls(
+    *,
+    module_name: str,
+    default_cls: Any,
+) -> Any:
+    """Obtiene la clase de intérprete desde globals del módulo (amigable a tests)."""
+
+    module = sys.modules.get(module_name)
+    if module is None:
+        return default_cls
+    return getattr(module, "InterpretadorCobra", default_cls)
+
+
+def preparar_interpretador(
+    *,
+    interpretador_cls: Any,
+    safe_mode: bool,
+    extra_validators: Any,
+) -> InterpreterSetup:
+    """Centraliza normalización de validadores, flags de seguridad e intérprete."""
+
+    validadores_normalizados = resolver_validadores_seguridad(
+        extra_validators,
+        interpretador_cls=interpretador_cls,
+    )
+    interpretador = construir_interprete(
+        interpretador_cls=interpretador_cls,
+        safe_mode=safe_mode,
+        extra_validators=validadores_normalizados,
+    )
+    return InterpreterSetup(
+        interpretador_cls=interpretador_cls,
+        safe_mode=bool(safe_mode),
+        validadores_extra=validadores_normalizados,
+        interpretador=interpretador,
     )
 
 

--- a/tests/unit/test_cli_execution_pipeline_contract.py
+++ b/tests/unit/test_cli_execution_pipeline_contract.py
@@ -135,3 +135,31 @@ def test_repl_ejecuta_bloque_completo_sin_parseo_parcial_por_linea():
 
     assert ret == 0
     mock_ejecutar_codigo.assert_called_once_with("si verdadero:\nimprimir(1)\nfin", None)
+
+
+def test_paridad_repl_script_mientras_con_mutacion_persistente_mismo_entorno():
+    cmd_execute = ExecuteCommand()
+    out_script, err_script = StringIO(), StringIO()
+    codigo_script = (
+        "var base = 0\n"
+        "mientras falso:\n"
+        "    pasar\n"
+        "fin\n"
+        "var acumulado = 42"
+    )
+    with redirect_stdout(out_script), redirect_stderr(err_script):
+        rc_script = cmd_execute._ejecutar_normal(codigo_script, seguro=False, extra_validators=None)
+
+    cmd_interactive = InteractiveCommand(InterpretadorCobra())
+    out_repl, err_repl = StringIO(), StringIO()
+    with redirect_stdout(out_repl), redirect_stderr(err_repl):
+        cmd_interactive.ejecutar_codigo(
+            "var base = 0\nmientras falso:\n    pasar\nfin"
+        )
+        cmd_interactive.ejecutar_codigo("var acumulado = 42")
+
+    assert rc_script == 0
+    assert out_script.getvalue() == ""
+    assert err_script.getvalue() == err_repl.getvalue() == ""
+    assert cmd_interactive.interpretador.contextos[-1].get("base") == 0
+    assert cmd_interactive.interpretador.contextos[-1].get("acumulado") == 42

--- a/tests/unit/test_execute_cmd_extra_validators_normalization.py
+++ b/tests/unit/test_execute_cmd_extra_validators_normalization.py
@@ -42,7 +42,7 @@ def test_ejecutar_normal_carga_validadores_desde_una_ruta(monkeypatch):
             assert ruta == "ruta_unica.py"
             return cargado
 
-    monkeypatch.setattr(execute_module, "_obtener_interpretador_cls", lambda: DummyInterp)
+    monkeypatch.setattr(execute_module, "InterpretadorCobra", DummyInterp)
 
     resultado = ExecuteCommand()._ejecutar_normal("imprimir(1)", True, "ruta_unica.py")
 
@@ -73,7 +73,7 @@ def test_ejecutar_normal_carga_y_acumula_multiples_rutas(monkeypatch):
             rutas_cargadas.append(ruta)
             return [v1] if ruta == "uno.py" else [v2]
 
-    monkeypatch.setattr(execute_module, "_obtener_interpretador_cls", lambda: DummyInterp)
+    monkeypatch.setattr(execute_module, "InterpretadorCobra", DummyInterp)
 
     resultado = ExecuteCommand()._ejecutar_normal("imprimir(1)", True, ["uno.py", "dos.py"])
 
@@ -101,7 +101,7 @@ def test_ejecutar_normal_acepta_lista_vacia_y_none(monkeypatch):
         def _cargar_validadores(_ruta):
             raise AssertionError("No debería cargar rutas para None o lista vacía")
 
-    monkeypatch.setattr(execute_module, "_obtener_interpretador_cls", lambda: DummyInterp)
+    monkeypatch.setattr(execute_module, "InterpretadorCobra", DummyInterp)
 
     cmd = ExecuteCommand()
     assert cmd._ejecutar_normal("imprimir(1)", True, []) == 0
@@ -131,7 +131,7 @@ def test_ejecutar_normal_muestra_error_claro_si_falla_una_ruta(monkeypatch):
                 raise FileNotFoundError("archivo inexistente")
             return [DummyValidator()]
 
-    monkeypatch.setattr(execute_module, "_obtener_interpretador_cls", lambda: DummyInterp)
+    monkeypatch.setattr(execute_module, "InterpretadorCobra", DummyInterp)
     monkeypatch.setattr(execute_module, "mostrar_error", lambda msg, **_kwargs: errores.append(msg))
 
     resultado = ExecuteCommand()._ejecutar_normal("imprimir(1)", True, ["buena.py", "mala.py"])


### PR DESCRIPTION
### Motivation
- Unificar y centralizar la lógica usada por los comandos CLI para preparar el intérprete, de modo que `ExecuteCommand` y `InteractiveCommand` compartan la misma política de normalización de validadores y flags de seguridad. 
- Evitar duplicación de lógica y facilitar los tests permitiendo resolver la clase de intérprete (`InterpretadorCobra`) desde un único origen intercambiable en pruebas. 

### Description
- Se agregó `InterpreterSetup`, `resolver_interpretador_cls` y `preparar_interpretador` en `src/pcobra/cobra/cli/execution_pipeline.py` para encapsular la normalización de validadores, la construcción del intérprete y la propagación de `safe_mode`.
- `ExecuteCommand._ejecutar_normal` ahora utiliza `preparar_interpretador` y pasa el `interpretador` / `validadores` resultantes a `ejecutar_codigo_canonico` en lugar de replicar la lógica.
- `InteractiveCommand` fue adaptado para usar el mismo origen de `interpretador_cls` y el mismo helper tanto en `run` como en `ejecutar_codigo`, y se añadió el alias en `sys.modules` para compatibilidad con dobles en pruebas.
- Se actualizaron tests: `tests/unit/test_execute_cmd_extra_validators_normalization.py` para mockear `InterpretadorCobra` en su nuevo lugar y se añadió `test_paridad_repl_script_mientras_con_mutacion_persistente_mismo_entorno` en `tests/unit/test_cli_execution_pipeline_contract.py` que verifica paridad REPL/script con un caso de `mientras` y mutación persistente en el entorno REPL.

### Testing
- Ejecutado: `pytest -q tests/unit/test_cli_execution_pipeline_contract.py tests/unit/test_execute_cmd_extra_validators_normalization.py`.
- Resultado: las pruebas especificadas pasaron (todos los tests en esos archivos completaron correctamente).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51dae217c83278ed36213d361f439)