### PR TITLE
Agregar shim de compatibilidad en src/bindings y pruebas de importación

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ include = [
     "core*",
     "cli*",
     "lsp*",
+    "bindings*",
 ]
 exclude = [
     "*.tests",

--- a/src/bindings/__init__.py
+++ b/src/bindings/__init__.py
@@ -1,4 +1,7 @@
-"""Superficie pública canónica del contrato de bindings."""
+"""Shim legacy de ``bindings`` dentro de ``src``.
+
+Este módulo solo delega en :mod:`pcobra.cobra.bindings`.
+"""
 
 from .contract import (
     BINDINGS_BY_LANGUAGE,

--- a/src/bindings/contract.py
+++ b/src/bindings/contract.py
@@ -1,0 +1,48 @@
+"""Shim legacy para el contrato de bindings.
+
+Fuente de verdad: :mod:`pcobra.cobra.bindings.contract`.
+"""
+
+from pcobra.cobra.bindings.contract import (
+    ABI_POLICY_BY_ROUTE,
+    BINDINGS_BY_LANGUAGE,
+    COMMAND_EVENT_SCHEMA,
+    EVENT_VALIDATION_FIELDS,
+    OFFICIAL_PUBLIC_LANGUAGES,
+    OFFICIAL_PUBLIC_ROUTE_MATRIX,
+    PUBLIC_RUNTIME_COMMANDS,
+    ROUTE_OPERATIONAL_LIMITS,
+    AbiCompatibilityPolicy,
+    BindingCapabilities,
+    BindingRoute,
+    JAVASCRIPT_BINDING,
+    PYTHON_BINDING,
+    RUST_BINDING,
+    RouteOperationalLimits,
+    resolve_binding,
+    resolve_command_event,
+    route_matrix_markdown,
+    validate_public_language,
+)
+
+__all__ = [
+    "AbiCompatibilityPolicy",
+    "BindingCapabilities",
+    "BindingRoute",
+    "BINDINGS_BY_LANGUAGE",
+    "COMMAND_EVENT_SCHEMA",
+    "EVENT_VALIDATION_FIELDS",
+    "OFFICIAL_PUBLIC_LANGUAGES",
+    "OFFICIAL_PUBLIC_ROUTE_MATRIX",
+    "PUBLIC_RUNTIME_COMMANDS",
+    "ABI_POLICY_BY_ROUTE",
+    "ROUTE_OPERATIONAL_LIMITS",
+    "RouteOperationalLimits",
+    "PYTHON_BINDING",
+    "JAVASCRIPT_BINDING",
+    "RUST_BINDING",
+    "resolve_command_event",
+    "route_matrix_markdown",
+    "validate_public_language",
+    "resolve_binding",
+]

--- a/tests/unit/test_bindings_import_smoke.py
+++ b/tests/unit/test_bindings_import_smoke.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import importlib
+import runpy
+import sys
+from types import ModuleType
+
+import pytest
+
+
+def test_import_pcobra_cobra_bindings_smoke() -> None:
+    modulo = importlib.import_module("pcobra.cobra.bindings")
+
+    assert hasattr(modulo, "resolve_binding")
+    assert hasattr(modulo, "BindingRoute")
+
+
+def test_import_bindings_legacy_smoke() -> None:
+    modulo = importlib.import_module("bindings")
+
+    assert hasattr(modulo, "resolve_binding")
+    assert modulo.__name__ == "bindings"
+
+
+def test_python_m_pcobra_delega_en_pcobra_cli_main(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_cli = ModuleType("pcobra.cli")
+    fake_cli.main = lambda: 0
+    monkeypatch.setitem(sys.modules, "pcobra.cli", fake_cli)
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_module("pcobra", run_name="__main__")
+
+    assert excinfo.value.code == 0


### PR DESCRIPTION
### Motivation
- Mantener compatibilidad legacy permitiendo `import bindings` sin cambiar la superficie canónica `pcobra.cobra.bindings`.
- Evitar imports autoreferenciales dentro del paquete `bindings` para prevenir ciclos y confusión en resolución de módulos.
- Asegurar que el paquete alias `bindings*` se incluya en la detección de paquetes para instalaciones desde `src`.

### Description
- Añadí un shim en `src/bindings` con `src/bindings/__init__.py` y `src/bindings/contract.py` que reexportan la funcionalidad desde `pcobra.cobra.bindings.contract` y delegan como fuente de verdad en `pcobra.cobra.bindings.*`.
- Modifiqué el `bindings/__init__.py` top-level para usar un import relativo (`from .contract import ...`) y evitar autoreferencias.
- Actualicé `pyproject.toml` para incluir explícitamente `bindings*` en `[tool.setuptools.packages.find].include` para que el alias legacy se empaquete correctamente.
- Añadí pruebas de import smoke en `tests/unit/test_bindings_import_smoke.py` que cubren `import pcobra.cobra.bindings`, `import bindings` y la ejecución vía `python -m pcobra`.

### Testing
- Ejecuté `pytest -q tests/unit/test_bindings_import_smoke.py tests/unit/test_bindings_contract.py tests/unit/test_binding_contract_canonical.py` como verificación automatizada.
- Resultado: todas las pruebas ejecutadas pasaron (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5af526814832798f19dbdfb6915f3)