### PR TITLE
Canonicalize internal LSP import to pcobra.lsp

### DIFF
--- a/src/pcobra/lsp/server.py
+++ b/src/pcobra/lsp/server.py
@@ -27,7 +27,7 @@ else:
     _PYLSP_ERROR = None
     _fallback_start_io_lang_server = None  # type: ignore[assignment]
 
-from lsp import cobra_plugin
+from pcobra.lsp import cobra_plugin
 
 
 def _obtener_start_callable():


### PR DESCRIPTION
### Motivation
- Cambiar los imports internos que apuntaban al shim `lsp` para que usen la ruta interna canónica `pcobra.lsp`, manteniendo el shim sólo para compatibilidad externa y asegurando que la ausencia del extra opcional no rompa el arranque LSP.

### Description
- Reemplacé `from lsp import cobra_plugin` por `from pcobra.lsp import cobra_plugin` en `src/pcobra/lsp/server.py`, dejando `src/lsp/__init__.py` intacto y comprobando que no quedan imports no canónicos bajo `src/pcobra/**`.

### Testing
- Ejecuté `rg -n "from lsp(\\b|\\.)|import lsp" src/pcobra` (sin coincidencias), `python -c 'import importlib; importlib.import_module("pcobra.lsp.server")'` (módulo importado; `_PYLSP_ERROR` es `ModuleNotFoundError` cuando falta el extra) y `python -m pcobra.lsp.server` (muestra advertencia sobre el extra `lsp` y sale con código 0), y todas las comprobaciones automatizadas pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c53d36cc8327949e49d06e67cdb9)