### PR TITLE
Unificar wiring de runtime CLI en namespace canónico pcobra.cobra

### DIFF
--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -26,14 +26,18 @@ from pcobra.cobra.core import LexerError
 from pcobra.cobra.core import ParserError
 from pcobra.cobra.cli.execution_pipeline import (
     analizar_codigo,
+    construir_script_sandbox_canonico,
     ejecutar_codigo_canonico,
     preparar_interpretador,
     resolver_interpretador_cls,
 )
 from pcobra.cobra.transpilers import module_map
-from pcobra.core.interpreter import InterpretadorCobra
-from pcobra.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
-from pcobra.core.resource_limits import limitar_cpu_segundos
+from pcobra.cobra.core.runtime import (
+    InterpretadorCobra,
+    PrimitivaPeligrosaError,
+    construir_cadena,
+    limitar_cpu_segundos,
+)
 
 sys.modules.setdefault("cli.commands.execute_cmd", sys.modules[__name__])
 
@@ -305,18 +309,10 @@ class ExecuteCommand(BaseCommand):
             mostrar_error(f"Error de análisis: {e}", registrar_log=False)
             return 1
 
-        extra_repr = "None"
-        if isinstance(extra_validators, (str, list)):
-            extra_repr = repr(extra_validators)
-
-        script = (
-            "from pcobra.cobra.core import Lexer, Parser\n"
-            "from pcobra.core.interpreter import InterpretadorCobra\n"
-            f"_codigo = {codigo!r}\n"
-            "_tokens = Lexer(_codigo).tokenizar()\n"
-            "_ast = Parser(_tokens).parsear()\n"
-            f"_interp = InterpretadorCobra(safe_mode={seguro!r}, extra_validators={extra_repr})\n"
-            "_interp.ejecutar_ast(_ast)\n"
+        script = construir_script_sandbox_canonico(
+            codigo,
+            safe_mode=seguro,
+            extra_validators=extra_validators,
         )
 
         try:

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -35,21 +35,28 @@ from pcobra.cobra.core import Lexer, LexerError, TipoToken, UnclosedStringError
 from pcobra.cobra.core import Parser, ParserError
 from pcobra.cobra.cli.execution_pipeline import (
     analizar_codigo,
+    construir_script_sandbox_canonico,
     ejecutar_codigo_canonico,
     preparar_interpretador,
     resolver_interpretador_cls,
     validar_ast_seguro,
 )
 from pcobra.cobra.transpilers import module_map
-from pcobra.core.ast_nodes import NodoBucleMientras, NodoCondicional, NodoPara, NodoSwitch, NodoTryCatch
-from pcobra.core.interpreter import InterpretadorCobra
-from pcobra.core.resource_limits import limitar_memoria_mb
-from pcobra.core.sandbox import (
+from pcobra.cobra.core import (
+    NodoBucleMientras,
+    NodoCondicional,
+    NodoPara,
+    NodoSwitch,
+    NodoTryCatch,
+)
+from pcobra.cobra.core.runtime import (
+    InterpretadorCobra,
     ejecutar_en_contenedor,
     ejecutar_en_sandbox,
+    limitar_memoria_mb,
+    PrimitivaPeligrosaError,
     validar_dependencias,
 )
-from pcobra.core.semantic_validators import PrimitivaPeligrosaError
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _, format_traceback
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
@@ -766,19 +773,11 @@ class InteractiveCommand(BaseCommand):
         """
         analizar_codigo(linea)
 
-        script = (
-            "from pcobra.cobra.core import Lexer, Parser\n"
-            "from pcobra.core.interpreter import InterpretadorCobra\n"
-            f"_codigo = {linea!r}\n"
-            "_tokens = Lexer(_codigo).tokenizar()\n"
-            "_ast = Parser(_tokens).parsear()\n"
-            "_interp = InterpretadorCobra()\n"
-            "_resultado = _interp.ejecutar_ast(_ast)\n"
-            "if _resultado is not None:\n"
-            "    if isinstance(_resultado, bool):\n"
-            "        print('verdadero' if _resultado else 'falso')\n"
-            "    else:\n"
-            "        print(_resultado)\n"
+        script = construir_script_sandbox_canonico(
+            linea,
+            safe_mode=None,
+            extra_validators=None,
+            imprimir_resultado=True,
         )
 
         salida = ejecutar_en_sandbox(

--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -8,8 +8,7 @@ from typing import Any, Callable
 
 from pcobra.cobra.core import Lexer, Parser
 from pcobra.cobra.cli.i18n import _
-from pcobra.core.semantic_validators import construir_cadena
-from pcobra.core.semantic_validators.base import ValidadorBase
+from pcobra.cobra.core.runtime import ValidadorBase, construir_cadena
 
 
 @dataclass(frozen=True)
@@ -29,6 +28,41 @@ class InterpreterSetup:
     safe_mode: bool
     validadores_extra: Any
     interpretador: Any
+
+
+def construir_script_sandbox_canonico(
+    codigo: str,
+    *,
+    safe_mode: bool | None = None,
+    extra_validators: Any = None,
+    imprimir_resultado: bool = False,
+) -> str:
+    """Genera un script sandbox con imports canónicos del runtime Cobra."""
+
+    extra_repr = repr(extra_validators if extra_validators is not None else None)
+    safe_mode_fragment = (
+        ""
+        if safe_mode is None
+        else f", safe_mode={safe_mode!r}, extra_validators={extra_repr}"
+    )
+    script = (
+        "from pcobra.cobra.core import Lexer, Parser\n"
+        "from pcobra.cobra.core.runtime import InterpretadorCobra\n"
+        f"_codigo = {codigo!r}\n"
+        "_tokens = Lexer(_codigo).tokenizar()\n"
+        "_ast = Parser(_tokens).parsear()\n"
+        f"_interp = InterpretadorCobra({safe_mode_fragment.lstrip(', ')})\n"
+        "_resultado = _interp.ejecutar_ast(_ast)\n"
+    )
+    if imprimir_resultado:
+        script += (
+            "if _resultado is not None:\n"
+            "    if isinstance(_resultado, bool):\n"
+            "        print('verdadero' if _resultado else 'falso')\n"
+            "    else:\n"
+            "        print(_resultado)\n"
+        )
+    return script
 
 
 def analizar_codigo(codigo: str) -> Any:

--- a/src/pcobra/cobra/core/runtime.py
+++ b/src/pcobra/cobra/core/runtime.py
@@ -1,0 +1,32 @@
+"""Puente canónico de runtime bajo ``pcobra.cobra.core``.
+
+Este módulo reexporta primitivas de runtime históricamente ubicadas en
+``pcobra.core`` para que la capa CLI pueda depender de un namespace interno
+canónico (``pcobra.cobra.*``) sin modificar la implementación base.
+"""
+
+from __future__ import annotations
+
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.resource_limits import limitar_cpu_segundos, limitar_memoria_mb
+from pcobra.core.sandbox import (
+    SecurityError,
+    ejecutar_en_contenedor,
+    ejecutar_en_sandbox,
+    validar_dependencias,
+)
+from pcobra.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
+from pcobra.core.semantic_validators.base import ValidadorBase
+
+__all__ = [
+    "InterpretadorCobra",
+    "PrimitivaPeligrosaError",
+    "SecurityError",
+    "ValidadorBase",
+    "construir_cadena",
+    "ejecutar_en_contenedor",
+    "ejecutar_en_sandbox",
+    "limitar_cpu_segundos",
+    "limitar_memoria_mb",
+    "validar_dependencias",
+]

--- a/tests/unit/test_cli_execution_pipeline_contract.py
+++ b/tests/unit/test_cli_execution_pipeline_contract.py
@@ -6,8 +6,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
+from pcobra.cobra.cli.execution_pipeline import preparar_interpretador
 from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
-from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.cobra.core.runtime import InterpretadorCobra
 
 
 def _args_interactive():
@@ -163,3 +164,38 @@ def test_paridad_repl_script_mientras_con_mutacion_persistente_mismo_entorno():
     assert err_script.getvalue() == err_repl.getvalue() == ""
     assert cmd_interactive.interpretador.contextos[-1].get("base") == 0
     assert cmd_interactive.interpretador.contextos[-1].get("acumulado") == 42
+
+
+def test_contrato_repl_igual_script_estado_final_con_bucles_y_asignaciones():
+    codigo = (
+        "var base = 0\n"
+        "mientras falso:\n"
+        "    pasar\n"
+        "fin\n"
+        "var acumulado = 42\n"
+        "var ultimo = 42"
+    )
+    cmd_execute = ExecuteCommand()
+    estado_script = {}
+
+    def _capturar_setup(**kwargs):
+        setup = preparar_interpretador(**kwargs)
+        estado_script["interpreter"] = setup.interpretador
+        return setup
+
+    with patch(
+        "pcobra.cobra.cli.commands.execute_cmd.preparar_interpretador",
+        side_effect=_capturar_setup,
+    ):
+        assert cmd_execute._ejecutar_normal(codigo, seguro=False, extra_validators=None) == 0
+
+    contexto_script = estado_script["interpreter"].contextos[-1]
+
+    repl = InteractiveCommand(InterpretadorCobra())
+    repl._seguro_repl = False
+    repl._extra_validators_repl = None
+    repl.ejecutar_codigo(codigo)
+    estado_repl = repl.interpretador.contextos[-1]
+
+    assert estado_repl.values == contexto_script.values
+    assert estado_repl.get("base") == 0


### PR DESCRIPTION
### Motivation
- Establecer un namespace canónico interno para las primitivas de runtime de la CLI (`pcobra.cobra.*`) y evitar dependencias directas al paquete `pcobra.core` desde múltiples puntos.
- Alinear los imports de REPL (`interactive_cmd.py`) y ejecución por archivo (`execute_cmd.py`) para que ambos consumidores usen exactamente las mismas funciones y clases base.
- Centralizar la construcción del script usado por sandboxes para eliminar divergencias de wiring entre caminos de ejecución.
- Añadir una prueba de contrato que verifique que ejecutar un programa en modo script y en REPL deja el mismo estado final del intérprete.

### Description
- Añadido `src/pcobra/cobra/core/runtime.py` como puente canónico que reexporta `InterpretadorCobra`, sandbox, límites de recursos y validadores (puente a `pcobra.core`).
- En `src/pcobra/cobra/cli/execution_pipeline.py` se introdujo `construir_script_sandbox_canonico(...)` y se cambió el uso de `construir_cadena`/`ValidadorBase` para importarlos desde el runtime canónico.
- `src/pcobra/cobra/cli/commands/execute_cmd.py` y `src/pcobra/cobra/cli/commands/interactive_cmd.py` fueron ajustados para usar `pcobra.cobra.core` / `pcobra.cobra.core.runtime` y para reutilizar `construir_script_sandbox_canonico(...)` en las rutas de sandbox.
- Añadida la prueba `test_contrato_repl_igual_script_estado_final_con_bucles_y_asignaciones` en `tests/unit/test_cli_execution_pipeline_contract.py` que ejecuta el mismo programa con bucles/asignaciones en modo script y REPL y compara el estado final del entorno; no se tocaron gramática ni tokens del lexer/parser.

### Testing
- Ejecutado: `pytest -q tests/unit/test_cli_execution_pipeline_contract.py tests/unit/test_execute_cmd_extra_validators_normalization.py tests/test_interactive_cmd_no_console.py`.
- Resultado: las pruebas ejecutadas completaron correctamente con todos los casos locales verdes (`16 passed`).
- Durante el desarrollo se ejecutaron iterativamente las mismas pruebas hasta resolver fallos de sincronización de estado entre script y REPL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f5fbb7a883279307539a30643d32)