### PR TITLE
Use canonical pcobra runtime imports in transpiler outputs

### DIFF
--- a/src/pcobra/cobra/transpilers/common/utils.py
+++ b/src/pcobra/cobra/transpilers/common/utils.py
@@ -62,9 +62,11 @@ class BaseTranspiler(NodeVisitor, ABC):
 
 STANDARD_IMPORTS = {
     "python": (
-        "from core.nativos import *\n"
-        "from corelibs import *\n"
-        "from standard_library import *\n"
+        "from pcobra.core.nativos import *\n"
+        "import pcobra.corelibs as _pcobra_corelibs\n"
+        "import pcobra.standard_library as _pcobra_standard_library\n"
+        "globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})\n"
+        "globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})\n"
     ),
     "javascript": [
         "import * as io from './nativos/io.js';",
@@ -220,8 +222,8 @@ RUNTIME_HOOKS = {
 
 MINIMAL_RUNTIME_ROUTE_MARKERS = {
     "python": {
-        "corelibs": "from corelibs import *",
-        "standard_library": "from standard_library import *",
+        "corelibs": "import pcobra.corelibs as _pcobra_corelibs",
+        "standard_library": "import pcobra.standard_library as _pcobra_standard_library",
         "minimal_symbols": (),
     },
     "javascript": {

--- a/tests/data/expected_examples/async_await.py
+++ b/tests/data/expected_examples/async_await.py
@@ -1,6 +1,8 @@
-from core.nativos import *
-from corelibs import *
-from standard_library import *
+from pcobra.core.nativos import *
+import pcobra.corelibs as _pcobra_corelibs
+import pcobra.standard_library as _pcobra_standard_library
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 async def saluda():
     with contextlib.ExitStack() as __cobra_defer_stack_0:
         print(1)

--- a/tests/data/expected_examples/ejemplo.py
+++ b/tests/data/expected_examples/ejemplo.py
@@ -1,4 +1,6 @@
-from core.nativos import *
-from corelibs import *
-from standard_library import *
+from pcobra.core.nativos import *
+import pcobra.corelibs as _pcobra_corelibs
+import pcobra.standard_library as _pcobra_standard_library
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 print('hola')

--- a/tests/data/expected_examples/factorial_recursivo.py
+++ b/tests/data/expected_examples/factorial_recursivo.py
@@ -1,6 +1,8 @@
-from core.nativos import *
-from corelibs import *
-from standard_library import *
+from pcobra.core.nativos import *
+import pcobra.corelibs as _pcobra_corelibs
+import pcobra.standard_library as _pcobra_standard_library
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 def factorial(n):
     if (NodoIdentificador(n) <= 1):
         return 1

--- a/tests/data/expected_examples/hola.py
+++ b/tests/data/expected_examples/hola.py
@@ -1,4 +1,6 @@
-from core.nativos import *
-from corelibs import *
-from standard_library import *
+from pcobra.core.nativos import *
+import pcobra.corelibs as _pcobra_corelibs
+import pcobra.standard_library as _pcobra_standard_library
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 print('Hola Cobra')

--- a/tests/data/expected_examples/suma.py
+++ b/tests/data/expected_examples/suma.py
@@ -1,6 +1,8 @@
-from core.nativos import *
-from corelibs import *
-from standard_library import *
+from pcobra.core.nativos import *
+import pcobra.corelibs as _pcobra_corelibs
+import pcobra.standard_library as _pcobra_standard_library
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 def sumar(a, b):
     c = (NodoIdentificador(a) + NodoIdentificador(b))
     print(c)

--- a/tests/data/expected_examples/suma_matrices.py
+++ b/tests/data/expected_examples/suma_matrices.py
@@ -1,6 +1,8 @@
-from core.nativos import *
-from corelibs import *
-from standard_library import *
+from pcobra.core.nativos import *
+import pcobra.corelibs as _pcobra_corelibs
+import pcobra.standard_library as _pcobra_standard_library
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 def sumar_matriz():
     a11 = 1
     a12 = 2

--- a/tests/integration/transpilers/backend_contracts.py
+++ b/tests/integration/transpilers/backend_contracts.py
@@ -65,8 +65,8 @@ FEATURE_NODES = {
 STRICT_FULL_EXPECTATIONS: dict[str, dict[str, tuple[str, ...]]] = {
     "python": {
         "holobit": (
-            "from corelibs import *",
-            "from standard_library import *",
+            "import pcobra.corelibs as _pcobra_corelibs",
+            "import pcobra.standard_library as _pcobra_standard_library",
             "hb = cobra_holobit([1, 2, 3])",
         ),
         "proyectar": ("def cobra_proyectar", "cobra_proyectar(hb, '2d')"),

--- a/tests/integration/transpilers/golden/python.golden
+++ b/tests/integration/transpilers/golden/python.golden
@@ -1,6 +1,8 @@
-from core.nativos import *
-from corelibs import *
-from standard_library import *
+from pcobra.core.nativos import *
+import pcobra.corelibs as _pcobra_corelibs
+import pcobra.standard_library as _pcobra_standard_library
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 def _cobra_missing_holobit(feature):
     raise ModuleNotFoundError(
         f"Runtime Holobit Python: '{feature}' requiere 'holobit_sdk', dependencia obligatoria de pcobra en Python >=3.10."

--- a/tests/integration/transpilers/golden_language_equivalence/python.async.golden
+++ b/tests/integration/transpilers/golden_language_equivalence/python.async.golden
@@ -1,8 +1,10 @@
 import asyncio
 import contextlib
-from core.nativos import *
-from corelibs import *
-from standard_library import *
+from pcobra.core.nativos import *
+import pcobra.corelibs as _pcobra_corelibs
+import pcobra.standard_library as _pcobra_standard_library
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 async def obtener_datos():
     with contextlib.ExitStack() as __cobra_defer_stack_0:
         return await fetch()

--- a/tests/integration/transpilers/golden_language_equivalence/python.decoradores.golden
+++ b/tests/integration/transpilers/golden_language_equivalence/python.decoradores.golden
@@ -1,3 +1,5 @@
-from core.nativos import *
-from corelibs import *
-from standard_library import *
+from pcobra.core.nativos import *
+import pcobra.corelibs as _pcobra_corelibs
+import pcobra.standard_library as _pcobra_standard_library
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})

--- a/tests/integration/transpilers/golden_language_equivalence/python.imports_corelibs.golden
+++ b/tests/integration/transpilers/golden_language_equivalence/python.imports_corelibs.golden
@@ -1,4 +1,6 @@
-from core.nativos import *
-from corelibs import *
-from standard_library import *
+from pcobra.core.nativos import *
+import pcobra.corelibs as _pcobra_corelibs
+import pcobra.standard_library as _pcobra_standard_library
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 longitud(3)

--- a/tests/integration/transpilers/golden_language_equivalence/python.manejo_errores.golden
+++ b/tests/integration/transpilers/golden_language_equivalence/python.manejo_errores.golden
@@ -1,6 +1,8 @@
-from core.nativos import *
-from corelibs import *
-from standard_library import *
+from pcobra.core.nativos import *
+import pcobra.corelibs as _pcobra_corelibs
+import pcobra.standard_library as _pcobra_standard_library
+globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})
+globals().update({name: getattr(_pcobra_standard_library, name) for name in dir(_pcobra_standard_library) if not name.startswith('_')})
 try:
     raise Exception('fallo')
 except Exception as error:

--- a/tests/integration/transpilers/test_backend_runtime_imports_minimal.py
+++ b/tests/integration/transpilers/test_backend_runtime_imports_minimal.py
@@ -6,7 +6,7 @@ from pcobra.cobra.transpilers.common.utils import get_standard_imports
 from tests.integration.transpilers.backend_contracts import generate_code
 
 IMPORT_MARKERS = {
-    "python": ("from corelibs import *", "from standard_library import *"),
+    "python": ("import pcobra.corelibs as _pcobra_corelibs", "import pcobra.standard_library as _pcobra_standard_library"),
     "javascript": (
         "import * as io from './nativos/io.js';",
         "import * as texto from './nativos/texto.js';",

--- a/tests/integration/transpilers/test_official_backends_contracts.py
+++ b/tests/integration/transpilers/test_official_backends_contracts.py
@@ -36,7 +36,7 @@ HOOK_EXPECTATIONS = {
 }
 
 IMPORT_EXPECTATIONS = {
-    "python": ("from corelibs import *", "from standard_library import *"),
+    "python": ("import pcobra.corelibs as _pcobra_corelibs", "import pcobra.standard_library as _pcobra_standard_library"),
     "javascript": ("import * as io from './nativos/io.js';", "import * as interfaz from './nativos/interfaz.js';"),
     "rust": ("use crate::corelibs::*;", "use crate::standard_library::*;", "fn longitud<T: ToString>(valor: T) -> usize {"),
     "wasm": (

--- a/tests/unit/test_cli_commands_extra.py
+++ b/tests/unit/test_cli_commands_extra.py
@@ -24,7 +24,7 @@ class _DummyValidator(ValidadorBase):
             "python",
             [
                 "Código generado (TranspiladorPython):",
-                "from core.nativos import *",
+                "from pcobra.core.nativos import *",
                 "x = 5",
             ],
         ),

--- a/tests/unit/test_smoke_transpilation_official_targets.py
+++ b/tests/unit/test_smoke_transpilation_official_targets.py
@@ -32,7 +32,7 @@ def ast_holobit_runtime():
 @pytest.mark.parametrize(
     "transpilador, fragmentos",
     [
-        (TranspiladorPython, ["from corelibs import *", "from standard_library import *", "def cobra_holobit(", "def cobra_proyectar(", "def cobra_transformar(", "def cobra_graficar("]),
+        (TranspiladorPython, ["import pcobra.corelibs as _pcobra_corelibs", "import pcobra.standard_library as _pcobra_standard_library", "def cobra_holobit(", "def cobra_proyectar(", "def cobra_transformar(", "def cobra_graficar("]),
         (TranspiladorJavaScript, ["import * as io from './nativos/io.js';", "import * as interfaz from './nativos/interfaz.js';", "function cobra_holobit(valores)", "function cobra_proyectar(hb, modo)", "function cobra_transformar(hb, op", "function cobra_graficar(hb)"]),
         (TranspiladorRust, ["use crate::corelibs::*;", "use crate::standard_library::*;", "fn longitud<T: ToString>(valor: T) -> usize {", "fn cobra_holobit(", "fn cobra_proyectar(", "fn cobra_transformar(", "fn cobra_graficar("]),
         (TranspiladorWasm, ["(func $cobra_holobit", "(func $cobra_proyectar", "(func $cobra_transformar", "(func $cobra_graficar", "host-managed"]),

--- a/tests/unit/test_transpiler_backend_regression.py
+++ b/tests/unit/test_transpiler_backend_regression.py
@@ -36,12 +36,12 @@ FEATURE_NODES = {
 
 FULL_EXPECTATIONS = {
     "python": {
-        "holobit": ["from corelibs import *", "from standard_library import *", "hb = cobra_holobit([1, 2, 3])"],
+        "holobit": ["import pcobra.corelibs as _pcobra_corelibs", "import pcobra.standard_library as _pcobra_standard_library", "hb = cobra_holobit([1, 2, 3])"],
         "proyectar": ["def cobra_proyectar", "cobra_proyectar(hb, '2d')"],
         "transformar": ["def cobra_transformar", "cobra_transformar(hb, 'rotar', 90)"],
         "graficar": ["def cobra_graficar", "cobra_graficar(hb)"],
-        "corelibs": ["from corelibs import *", "longitud('cobra')"],
-        "standard_library": ["from standard_library import *", "mostrar('hola')"],
+        "corelibs": ["import pcobra.corelibs as _pcobra_corelibs", "longitud('cobra')"],
+        "standard_library": ["import pcobra.standard_library as _pcobra_standard_library", "mostrar('hola')"],
     },
 }
 


### PR DESCRIPTION
### Motivation
- Evitar que el código generado emita rutas de import legacy (`corelibs`, `standard_library`) y unificar las importaciones en rutas canónicas del paquete instalado (`pcobra.*`).
- Mantener equivalencia funcional con el runtime actual para no romper programas ya transpilados mientras se migra los literales en los fixtures y las expectativas de tests.

### Description
- Cambié `STANDARD_IMPORTS["python"]` en `src/pcobra/cobra/transpilers/common/utils.py` para emitir `from pcobra.core.nativos import *` y `import pcobra.corelibs as _pcobra_corelibs` / `import pcobra.standard_library as _pcobra_standard_library` y añadí una hidratación con `globals().update(...)` para exponer los símbolos no privados (p.ej. `longitud`, `mostrar`) sin volver a emitir imports legacy.
- Ajusté `MINIMAL_RUNTIME_ROUTE_MARKERS` en el mismo archivo para que las claves `corelibs` y `standard_library` devuelvan rutas canónicas (`import pcobra.corelibs as _pcobra_corelibs`, `import pcobra.standard_library as _pcobra_standard_library`).
- Actualicé fixtures y golden/expectativas que dependían de los literales antiguos para reflejar los nuevos imports y la capa de compatibilidad (`tests/data/expected_examples/*.py`, varias `tests/integration/transpilers/golden*.golden` y archivos de expectativas en `tests/integration/transpilers` y `tests/unit`).
- Conservé una capa de compatibilidad en tiempo de ejecución mediante la hidratación de `globals()` para evitar romper resolución directa de símbolos, sin restaurar los imports legacy en la salida generada.

### Testing
- Ejecuté un conjunto de pruebas enfocadas con `pytest` y las comprobaciones dirigidas relacionadas con imports y generación de runtime para Python pasaron (targeted checks sobre `test_backend_runtime_imports_minimal`, `test_official_backends_contracts` (python case), `test_smoke_transpilation_official_targets` y `test_transpiler_backend_regression[python-corelibs]` se completaron correctamente).
- Una ejecución más amplia del conjunto de tests de transpilers mostró 5 fallos iniciales que quedaron resueltos por las correcciones iterativas en fixtures (fallos informados durante la validación inicial).
- La suite `tests/test_ejemplos_io.py` sigue mostrando fallos en este entorno por diferencias en el flujo/CLI legacy (`transpilar`/`ejecutar` y salidas esperadas) que no están causados por esta migración de imports; esos fallos se mantienen como issue separado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65a7e9d548327832da914d72a47a2)