### PR TITLE
Normaliza imports de bindings y agrega gate CI anti-legacy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,8 @@ jobs:
         run: python scripts/ci/validate_syntax_report_contract.py
       - name: Lint public surfaces without direct transpiler imports
         run: python scripts/ci/lint_public_no_direct_transpiler_imports.py
+      - name: Lint legacy bindings imports in src
+        run: python scripts/ci/lint_no_legacy_bindings_imports.py
       - name: Validate runtime contract matrix
         shell: bash
         run: python scripts/validate_runtime_contract.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,5 +22,7 @@ jobs:
         run: python scripts/lint_policy_drift.py
       - name: Lint public surfaces without direct transpiler imports
         run: python scripts/ci/lint_public_no_direct_transpiler_imports.py
+      - name: Lint legacy bindings imports in src
+        run: python scripts/ci/lint_no_legacy_bindings_imports.py
       - name: Validate runtime contract matrix
         run: python scripts/validate_runtime_contract.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,9 @@ Las tareas etiquetadas como `good first issue` están orientadas a la comunidad 
   `pyright src` (o `make typecheck`).
 - Cualquier cambio en el lenguaje debe seguir lo descrito en
   [SPEC_COBRA.md](docs/SPEC_COBRA.md).
+- **Imports internos oficiales**: en `src/` usa `pcobra.cobra.*` o imports
+  relativos del propio paquete. Evita `from bindings...`; ese namespace se
+  mantiene únicamente como shim legacy deprecado.
 
 ## Nueva feature del lenguaje
 

--- a/README.md
+++ b/README.md
@@ -410,6 +410,12 @@ Namespaces recomendados:
 - Dominio app/proyecto: `app.*`
 - Evitar imports “planos” en módulos grandes si existe riesgo de colisión.
 
+Ruta oficial para imports internos del proyecto (código Python de `src/`):
+
+- Usar siempre `pcobra.cobra.*` (ejemplo: `pcobra.cobra.bindings.contract`).
+- No usar `bindings.*` en código interno nuevo; `bindings` queda solo como shim legacy deprecado.
+- Si estás dentro del mismo paquete, también se permiten imports relativos explícitos (`from .modulo import ...`).
+
 ### Guía de migración a la CLI unificada
 
 La guía histórica de migración y compatibilidad se mantiene fuera del onboarding público, dentro de los anexos internos:

--- a/bindings/__init__.py
+++ b/bindings/__init__.py
@@ -1,4 +1,8 @@
-"""Superficie pública canónica del contrato de bindings."""
+"""Superficie pública canónica del contrato de bindings (shim deprecado)."""
+
+from __future__ import annotations
+
+import warnings
 
 from .contract import (
     BINDINGS_BY_LANGUAGE,
@@ -8,6 +12,12 @@ from .contract import (
     PYTHON_BINDING,
     RUST_BINDING,
     resolve_binding,
+)
+
+warnings.warn(
+    "`bindings` está deprecado; usa `pcobra.cobra.bindings` para imports internos.",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
 __all__ = [

--- a/bindings/contract.py
+++ b/bindings/contract.py
@@ -1,9 +1,13 @@
-"""Fachada legacy del contrato de bindings.
+"""Fachada legacy del contrato de bindings (shim deprecado).
 
-Fuente canónica: ``pcobra.cobra.bindings._contract_impl``.
+Fuente canónica: ``pcobra.cobra.bindings.contract``.
 """
 
-from pcobra.cobra.bindings._contract_impl import (
+from __future__ import annotations
+
+import warnings
+
+from pcobra.cobra.bindings.contract import (
     ABI_POLICY_BY_ROUTE,
     BINDINGS_BY_LANGUAGE,
     COMMAND_EVENT_SCHEMA,
@@ -23,6 +27,12 @@ from pcobra.cobra.bindings._contract_impl import (
     resolve_command_event,
     route_matrix_markdown,
     validate_public_language,
+)
+
+warnings.warn(
+    "`bindings.contract` está deprecado; usa `pcobra.cobra.bindings.contract`.",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
 __all__ = [

--- a/docs/architecture/binding-contract.md
+++ b/docs/architecture/binding-contract.md
@@ -137,7 +137,7 @@ manager.validate_security_route("rust", command="run", sandbox=True, containeriz
 ### Python (`python_direct_import`)
 
 ```python
-from bindings.contract import resolve_binding
+from pcobra.cobra.bindings.contract import resolve_binding
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 
 cap = resolve_binding("python")
@@ -172,6 +172,6 @@ manager.validate_security_route("rust", sandbox=False, containerized=True, comma
 
 Si se añade un backend oficial nuevo:
 
-1. actualizar `bindings/contract.py`,
+1. actualizar `src/pcobra/cobra/bindings/contract.py`,
 2. documentar la ruta en este documento,
 3. adoptar `resolve_binding(...)` en el runner correspondiente.

--- a/scripts/ci/lint_no_legacy_bindings_imports.py
+++ b/scripts/ci/lint_no_legacy_bindings_imports.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Bloquea imports legacy `bindings.*` dentro de `src/`."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = ROOT / "src"
+FORBIDDEN_PREFIX = "bindings"
+
+
+def _node_import_targets(node: ast.AST) -> list[str]:
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    if isinstance(node, ast.ImportFrom):
+        return [node.module] if node.module else []
+    return []
+
+
+def _is_forbidden(target: str | None) -> bool:
+    if not target:
+        return False
+    return target == FORBIDDEN_PREFIX or target.startswith(f"{FORBIDDEN_PREFIX}.")
+
+
+def find_violations(root: Path = ROOT) -> list[str]:
+    src_root = root / "src"
+    failures: list[str] = []
+    for path in sorted(src_root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            for target in _node_import_targets(node):
+                if _is_forbidden(target):
+                    rel = path.relative_to(root)
+                    failures.append(
+                        f"{rel}:{node.lineno}: import no permitido a {target}; "
+                        "usa pcobra.cobra.bindings.*"
+                    )
+    return failures
+
+
+def main() -> int:
+    if not SRC_ROOT.exists():
+        print("⚠️ Lint imports legacy bindings: src/ no existe, se omite.")
+        return 0
+
+    failures = find_violations(ROOT)
+    if failures:
+        print("❌ Lint imports legacy bindings en src/: FALLÓ")
+        for item in failures:
+            print(f" - {item}")
+        return 1
+
+    print("✅ Lint imports legacy bindings en src/: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bindings/__init__.py
+++ b/src/bindings/__init__.py
@@ -1,7 +1,11 @@
 """Shim legacy de ``bindings`` dentro de ``src``.
 
-Este módulo solo delega en :mod:`pcobra.cobra.bindings`.
+Este módulo delega en :mod:`pcobra.cobra.bindings` y está deprecado.
 """
+
+from __future__ import annotations
+
+import warnings
 
 from .contract import (
     BINDINGS_BY_LANGUAGE,
@@ -11,6 +15,12 @@ from .contract import (
     PYTHON_BINDING,
     RUST_BINDING,
     resolve_binding,
+)
+
+warnings.warn(
+    "`bindings` está deprecado; usa `pcobra.cobra.bindings`.",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
 __all__ = [

--- a/src/bindings/contract.py
+++ b/src/bindings/contract.py
@@ -3,6 +3,10 @@
 Fuente de verdad: :mod:`pcobra.cobra.bindings.contract`.
 """
 
+from __future__ import annotations
+
+import warnings
+
 from pcobra.cobra.bindings.contract import (
     ABI_POLICY_BY_ROUTE,
     BINDINGS_BY_LANGUAGE,
@@ -23,6 +27,12 @@ from pcobra.cobra.bindings.contract import (
     resolve_command_event,
     route_matrix_markdown,
     validate_public_language,
+)
+
+warnings.warn(
+    "`bindings.contract` está deprecado; usa `pcobra.cobra.bindings.contract`.",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
 __all__ = [

--- a/tests/unit/test_ci_lint_no_legacy_bindings_imports.py
+++ b/tests/unit/test_ci_lint_no_legacy_bindings_imports.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.ci.lint_no_legacy_bindings_imports import find_violations
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_detecta_import_legacy_bindings_en_src(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "foo.py",
+        "from bindings.contract import resolve_binding\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "src/pcobra/cobra/foo.py:1" in violations[0]
+
+
+def test_permite_import_canonico_pcobra_bindings(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "foo.py",
+        "from pcobra.cobra.bindings.contract import resolve_binding\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert violations == []

--- a/tests/unit/test_ci_lint_no_legacy_bindings_imports_guard.py
+++ b/tests/unit/test_ci_lint_no_legacy_bindings_imports_guard.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_ci_lint_no_legacy_bindings_imports_guard_passes_on_repo() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "scripts/ci/lint_no_legacy_bindings_imports.py"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
### Motivation

- Evitar que código nuevo en `src/` importe el namespace legacy `bindings.*` por accidente y consolidar una ruta canónica interna. 
- Establecer una estrategia única para `bindings/` (compat shims) que permita mantener compatibilidad temporal pero avisar deprecación. 
- Documentar la ruta oficial de imports internos para evitar ambigüedades en ejemplos y contribuciones. 
- Añadir una verificación automática en CI para bloquear regresiones que reintroduzcan imports legacy en `src/`.

### Description

- Añadido el script de lint `scripts/ci/lint_no_legacy_bindings_imports.py` que detecta e informa imports `bindings`/`bindings.*` en `src/` y falla con código 1 cuando hay violaciones. 
- Integrado el gate en los workflows `.github/workflows/lint.yml` y `.github/workflows/ci.yml` para ejecutar el lint en PRs y runs de CI. 
- Implementado shims deprecados en `bindings/` y `src/bindings/` (ambos `__init__.py` y `contract.py`) que reexportan la API desde `pcobra.cobra.bindings.*` y emiten `DeprecationWarning`. 
- Actualizada documentación y guías (`README.md`, `CONTRIBUTING.md`, `docs/architecture/binding-contract.md`) para recomendar la ruta oficial `pcobra.cobra.*` y normalizar ejemplos a `pcobra.cobra.bindings.contract`. 
- Añadidos tests unitarios `tests/unit/test_ci_lint_no_legacy_bindings_imports.py` y `tests/unit/test_ci_lint_no_legacy_bindings_imports_guard.py` que cubren detección y validación del lint contra el repositorio.

### Testing

- Ejecutado el lint localmente con `python scripts/ci/lint_no_legacy_bindings_imports.py` y mostró `OK` en el árbol actual. 
- Ejecutados los tests específicos con `pytest -q tests/unit/test_ci_lint_no_legacy_bindings_imports.py tests/unit/test_ci_lint_no_legacy_bindings_imports_guard.py` y todos pasaron (`3 passed`). 
- Las modificaciones se integraron en los workflows de CI para que la verificación se ejecute automáticamente en PRs y pipelines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65e63a9e08327b7e6811606c0201e)