### PR TITLE
Eliminar legado TRANSPILERS en compile y bloquear imports cruzados entre comandos

### DIFF
--- a/scripts/ci/lint_no_cross_command_imports.py
+++ b/scripts/ci/lint_no_cross_command_imports.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Lint interno: prohíbe imports entre módulos de comandos CLI (excepto base.py)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COMMAND_SCOPES = (
+    ROOT / "src/pcobra/cobra/cli/commands",
+    ROOT / "src/pcobra/cobra/cli/commands_v2",
+)
+FORBIDDEN_PREFIXES = (
+    "pcobra.cobra.cli.commands",
+    "cobra.cli.commands",
+)
+
+
+def _is_forbidden_module_name(module: str) -> bool:
+    for prefix in FORBIDDEN_PREFIXES:
+        if module == prefix:
+            return True
+        if module.startswith(f"{prefix}."):
+            suffix = module[len(prefix) + 1 :]
+            if suffix == "base":
+                return False
+            return True
+    return False
+
+
+def _is_forbidden_import_from(node: ast.ImportFrom) -> bool:
+    module = node.module or ""
+    if _is_forbidden_module_name(module):
+        return True
+
+    if module in FORBIDDEN_PREFIXES:
+        allowed_names = {"base"}
+        imported_names = {alias.name for alias in node.names}
+        return not imported_names.issubset(allowed_names)
+    return False
+
+
+def _scan_file(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _is_forbidden_module_name(alias.name):
+                    violations.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            if _is_forbidden_import_from(node):
+                label = node.module or "<relative>"
+                violations.append((node.lineno, label))
+    return violations
+
+
+def find_violations(root: Path = ROOT) -> list[str]:
+    failures: list[str] = []
+    scopes = (
+        root / "src/pcobra/cobra/cli/commands",
+        root / "src/pcobra/cobra/cli/commands_v2",
+    )
+    for scope in scopes:
+        if not scope.exists():
+            continue
+        for path in sorted(scope.rglob("*.py")):
+            rel = path.relative_to(root)
+            for line, target in _scan_file(path):
+                failures.append(
+                    f"{rel}:{line}: import entre comandos no permitido ({target}); "
+                    "extrae código a un servicio compartido o usa commands.base"
+                )
+    return failures
+
+
+def main() -> int:
+    failures = find_violations(ROOT)
+    if failures:
+        print("❌ Lint imports cruzados entre comandos: FALLÓ")
+        for item in failures:
+            print(f" - {item}")
+        return 1
+
+    print("✅ Lint imports cruzados entre comandos: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -2,7 +2,6 @@ import logging
 import multiprocessing
 import os
 import inspect
-import warnings
 from argparse import ArgumentTypeError
 from importlib import import_module
 from importlib.metadata import entry_points
@@ -25,6 +24,7 @@ from pcobra.core.semantic_validators import (
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.mode_policy import validar_politica_modo
+from pcobra.cobra.cli.transpiler_registry import cli_transpiler_targets
 from pcobra.cobra.cli.deprecation_policy import (
     enforce_target_deprecation_policy,
     visible_public_targets,
@@ -34,10 +34,6 @@ from pcobra.cobra.cli.utils.validators import validar_archivo_existente
 from pcobra.cobra.cli.utils.autocomplete import files_completer
 from pcobra.cobra.core import ParserError
 from pcobra.core.cobra_config import tiempo_max_transpilacion
-from pcobra.cobra.transpilers.registry import (
-    get_transpilers,
-    official_transpiler_targets,
-)
 
 # Constantes de configuración
 MAX_PROCESSES = 4
@@ -48,7 +44,7 @@ MAX_LANGUAGES = 10
 _PLUGIN_TRANSPILERS: dict[str, type] = {}
 _ENTRYPOINTS_LOADED = False
 
-LANG_CHOICES = official_transpiler_targets()
+LANG_CHOICES = cli_transpiler_targets()
 
 def register_transpiler_backend(backend: str, transpiler_cls, *, context: str) -> str:
     """Registra un backend externo solo si usa nombre canónico oficial exacto."""
@@ -253,20 +249,6 @@ def _ensure_entrypoints_loaded_once() -> None:
 
     load_entrypoint_transpilers()
     _ENTRYPOINTS_LOADED = True
-
-
-
-def __getattr__(name: str):
-    """Compatibilidad legacy para compile_cmd.TRANSPILERS (deprecado)."""
-    if name == "TRANSPILERS":
-        warnings.warn(
-            "compile_cmd.TRANSPILERS está deprecado y será retirado el 2026-09-30. "
-            "Use pcobra.cobra.transpilers.registry.get_transpilers().",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return get_transpilers()
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 TARGETS_HELP = ", ".join(visible_public_targets(OFFICIAL_TRANSPILATION_TARGETS))
 

--- a/src/pcobra/cobra/cli/commands/package_cmd.py
+++ b/src/pcobra/cobra/cli/commands/package_cmd.py
@@ -4,7 +4,6 @@ from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from typing import List, Any
 
-from pcobra.cobra.cli.commands import modules_cmd
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
@@ -14,6 +13,7 @@ from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 MAX_ZIP_SIZE = 1024 * 1024 * 50  # 50MB
 MAX_FILES = 100
 ALLOWED_EXTENSIONS = {".co"}
+MODULES_PATH = Path.home() / ".cobra" / "modules"
 
 class PaqueteCommand(BaseCommand):
     """Crea e instala paquetes Cobra."""
@@ -164,7 +164,7 @@ class PaqueteCommand(BaseCommand):
                 return 1
 
             PaqueteCommand._validar_zip(pkg)
-            modules_dir = Path(modules_cmd.MODULES_PATH).resolve()
+            modules_dir = Path(MODULES_PATH).resolve()
             modules_dir.mkdir(parents=True, exist_ok=True)
 
             with zipfile.ZipFile(pkg) as zf:
@@ -193,7 +193,7 @@ class PaqueteCommand(BaseCommand):
                         out.write(src.read())
 
             mostrar_info(
-                _("Paquete instalado en {dest}").format(dest=modules_cmd.MODULES_PATH)
+                _("Paquete instalado en {dest}").format(dest=MODULES_PATH)
             )
             return 0
 

--- a/tests/unit/test_ci_lint_no_cross_command_imports.py
+++ b/tests/unit/test_ci_lint_no_cross_command_imports.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.ci.lint_no_cross_command_imports import find_violations
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_detecta_import_entre_comandos(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "a.py",
+        "from pcobra.cobra.cli.commands.compile_cmd import CompileCommand\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "src/pcobra/cobra/cli/commands/a.py:1" in violations[0]
+
+
+def test_permite_import_desde_base(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands_v2" / "ok.py",
+        "from pcobra.cobra.cli.commands.base import BaseCommand\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert violations == []

--- a/tests/unit/test_ci_lint_no_cross_command_imports_guard.py
+++ b/tests/unit/test_ci_lint_no_cross_command_imports_guard.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_ci_lint_no_cross_command_imports_guard_passes_on_repo() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "scripts/ci/lint_no_cross_command_imports.py"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
### Motivation
- Quitar la vía legacy que exponía `compile_cmd.TRANSPILERS` ahora que los consumidores han sido migrados y consolidar acceso a los transpiladores desde la capa CLI.  
- Evitar dependencias cruzadas entre módulos de comandos que generan acoplamiento y dificultan el mantenimiento.  
- Añadir una regla de lint automática que garantice la arquitectura: los comandos sólo pueden importar `commands.base` y no otros comandos.  

### Description
- Eliminé el accesor `__getattr__` que devolvía `TRANSPILERS` en `src/pcobra/cobra/cli/commands/compile_cmd.py` y cambié `LANG_CHOICES` para usar `pcobra.cobra.cli.transpiler_registry.cli_transpiler_targets`.  
- Eliminé el import cruzado `from pcobra.cobra.cli.commands import modules_cmd` en `src/pcobra/cobra/cli/commands/package_cmd.py` y localicé `MODULES_PATH` en ese módulo para romper el acoplamiento entre comandos.  
- Añadí un nuevo lint CI `scripts/ci/lint_no_cross_command_imports.py` que analiza el AST y prohíbe imports entre `pcobra.cobra.cli.commands.<otro>` / `cobra.cli.commands.<otro>` permitiendo solo `commands.base`.  
- Añadí tests unitarios `tests/unit/test_ci_lint_no_cross_command_imports.py` y `tests/unit/test_ci_lint_no_cross_command_imports_guard.py` que validan la detección y ejecutan el lint sobre el repositorio.  

### Testing
- Ejecuté `python scripts/ci/lint_no_cross_command_imports.py` y el lint devolvió OK (sin violaciones) en el árbol actual.  
- Ejecuté `python scripts/ci/lint_public_no_direct_transpiler_imports.py` y el lint existente devolvió OK.  
- Ejecuté `pytest -q tests/unit/test_ci_lint_no_cross_command_imports.py tests/unit/test_ci_lint_no_cross_command_imports_guard.py tests/unit/test_compile_backend_registration.py` y las pruebas automatizadas pasaron (todos los tests incluidos en esa invocación pasaron).
- Durante la iteración inicial una ejecución de `pytest` que incluía `tests/unit/test_cli_compilar_tipos.py` falló por un cambio temporal en los tests relacionado con el acceso a `TRANSPILERS`, ese fallo se resolvió (los cambios de test problemáticos fueron revertidos) y las corridas finales de CI-local pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6621146788327a425b55cbce37e71)