### PR TITLE
Unificar pipeline de ejecución y reforzar paridad run/REPL

### DIFF
--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -27,8 +27,8 @@ from pcobra.cobra.core import ParserError
 from pcobra.cobra.cli.execution_pipeline import (
     analizar_codigo,
     construir_script_sandbox_canonico,
-    ejecutar_codigo_canonico,
-    preparar_interpretador,
+    ejecutar_pipeline_explicito,
+    PipelineInput,
     resolver_interpretador_cls,
 )
 from pcobra.cobra.transpilers import module_map
@@ -375,20 +375,16 @@ class ExecuteCommand(BaseCommand):
     def _ejecutar_normal(self, codigo: str, seguro: bool, extra_validators: Any) -> int:
         """Ejecuta el código normalmente con el intérprete."""
         try:
-            interpreter_setup = preparar_interpretador(
-                interpretador_cls=resolver_interpretador_cls(
-                    module_name=__name__,
-                    default_cls=InterpretadorCobra,
+            ejecutar_pipeline_explicito(
+                PipelineInput(
+                    codigo=codigo,
+                    interpretador_cls=resolver_interpretador_cls(
+                        module_name=__name__,
+                        default_cls=InterpretadorCobra,
+                    ),
+                    safe_mode=seguro,
+                    extra_validators=extra_validators,
                 ),
-                safe_mode=seguro,
-                extra_validators=extra_validators,
-            )
-            ejecutar_codigo_canonico(
-                codigo,
-                interpretador=interpreter_setup.interpretador,
-                seguro=interpreter_setup.safe_mode,
-                extra_validators=interpreter_setup.validadores_extra,
-                interpretador_cls=interpreter_setup.interpretador_cls,
                 construir_cadena_fn=construir_cadena,
                 analizar_codigo_fn=analizar_codigo,
             )

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -36,8 +36,8 @@ from pcobra.cobra.core import Parser, ParserError
 from pcobra.cobra.cli.execution_pipeline import (
     analizar_codigo,
     construir_script_sandbox_canonico,
-    ejecutar_codigo_canonico,
-    preparar_interpretador,
+    ejecutar_pipeline_explicito,
+    PipelineInput,
     resolver_interpretador_cls,
     validar_ast_seguro,
 )
@@ -358,14 +358,19 @@ class InteractiveCommand(BaseCommand):
             module_name=__name__,
             default_cls=type(self.interpretador),
         )
-        resultado_pipeline = ejecutar_codigo_canonico(
-            codigo,
-            interpretador=self.interpretador,
-            seguro=self._seguro_repl,
-            extra_validators=self._extra_validators_repl,
-            interpretador_cls=interpretador_cls,
+        setup, resultado_pipeline = ejecutar_pipeline_explicito(
+            PipelineInput(
+                codigo=codigo,
+                interpretador_cls=interpretador_cls,
+                safe_mode=self._seguro_repl,
+                extra_validators=self._extra_validators_repl,
+                interpretador=self.interpretador,
+            ),
             analizar_codigo_fn=analizar_codigo,
         )
+        self.interpretador = setup.interpretador
+        self._seguro_repl = setup.safe_mode
+        self._extra_validators_repl = setup.validadores_extra
         ast = resultado_pipeline.ast
         resultado = resultado_pipeline.resultado
         self.logger.debug("[EXEC] Ejecutando AST en intérprete")
@@ -448,21 +453,26 @@ class InteractiveCommand(BaseCommand):
         self._seguro_repl = bool(seguro)
         self._extra_validators_repl = extra_validators
         try:
-            interpreter_setup = preparar_interpretador(
-                interpretador_cls=resolver_interpretador_cls(
+            interpretador_cls = resolver_interpretador_cls(
                     module_name=__name__,
                     default_cls=InterpretadorCobra,
+                )
+            setup, _pipeline_result = ejecutar_pipeline_explicito(
+                PipelineInput(
+                    codigo="",
+                    interpretador_cls=interpretador_cls,
+                    safe_mode=self._seguro_repl,
+                    extra_validators=self._extra_validators_repl,
                 ),
-                safe_mode=self._seguro_repl,
-                extra_validators=self._extra_validators_repl,
+                analizar_codigo_fn=lambda _codigo: [],
             )
         except (TypeError, ValueError, PrimitivaPeligrosaError) as err:
             mostrar_error(str(err))
             return 1
 
-        self._seguro_repl = interpreter_setup.safe_mode
-        self._extra_validators_repl = interpreter_setup.validadores_extra
-        self.interpretador = interpreter_setup.interpretador
+        self._seguro_repl = setup.safe_mode
+        self._extra_validators_repl = setup.validadores_extra
+        self.interpretador = setup.interpretador
 
         # Obtener modos de ejecución
         sandbox = getattr(args, "sandbox", False)

--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -21,6 +21,17 @@ class PipelineResult:
 
 
 @dataclass(frozen=True)
+class PipelineInput:
+    """Entrada explícita para ejecutar el pipeline canónico completo."""
+
+    codigo: str
+    interpretador_cls: Any
+    safe_mode: bool
+    extra_validators: Any = None
+    interpretador: Any | None = None
+
+
+@dataclass(frozen=True)
 class InterpreterSetup:
     """Configuración derivada y componentes del intérprete para ejecución."""
 
@@ -208,3 +219,46 @@ def ejecutar_codigo_canonico(
         resultado=resultado,
         validadores_extra=validadores_normalizados,
     )
+
+
+def ejecutar_pipeline_explicito(
+    pipeline_input: PipelineInput,
+    *,
+    construir_cadena_fn: Callable[[Any], Any] = construir_cadena,
+    analizar_codigo_fn: Callable[[str], Any] = analizar_codigo,
+) -> tuple[InterpreterSetup, PipelineResult]:
+    """API única y explícita para análisis, validación, preparación y ejecución.
+
+    Flujo:
+    1) Analizar ``codigo``.
+    2) Validar AST si ``safe_mode`` está activo.
+    3) Preparar intérprete (o reutilizar uno provisto para estado persistente).
+    4) Ejecutar AST.
+    """
+
+    setup = preparar_interpretador(
+        interpretador_cls=pipeline_input.interpretador_cls,
+        safe_mode=pipeline_input.safe_mode,
+        extra_validators=pipeline_input.extra_validators,
+    )
+    interpretador = (
+        pipeline_input.interpretador
+        if pipeline_input.interpretador is not None
+        else setup.interpretador
+    )
+    resultado = ejecutar_codigo_canonico(
+        pipeline_input.codigo,
+        interpretador=interpretador,
+        seguro=setup.safe_mode,
+        extra_validators=setup.validadores_extra,
+        interpretador_cls=setup.interpretador_cls,
+        construir_cadena_fn=construir_cadena_fn,
+        analizar_codigo_fn=analizar_codigo_fn,
+    )
+    setup_final = InterpreterSetup(
+        interpretador_cls=setup.interpretador_cls,
+        safe_mode=setup.safe_mode,
+        validadores_extra=setup.validadores_extra,
+        interpretador=interpretador,
+    )
+    return setup_final, resultado

--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -1,0 +1,68 @@
+from argparse import Namespace
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+
+import pytest
+
+from pcobra.cobra.cli.commands_v2.run_cmd import RunCommandV2
+from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+from pcobra.cobra.core.runtime import InterpretadorCobra
+
+
+def _run_args(file_path: str) -> Namespace:
+    return Namespace(
+        file=file_path,
+        debug=False,
+        sandbox=False,
+        container=None,
+        formatear=False,
+        modo="mixto",
+    )
+
+
+@pytest.mark.integration
+def test_misma_secuencia_semantica_equivale_entre_run_y_repl(tmp_path, monkeypatch):
+    monkeypatch.setattr("pcobra.cobra.cli.commands.execute_cmd.limitar_cpu_segundos", lambda *_: None)
+    codigo = (
+        "mientras verdadero:\n"
+        "    total = 7\n"
+        "    romper\n"
+        "fin"
+    )
+    archivo = tmp_path / "programa.co"
+    archivo.write_text(codigo, encoding="utf-8")
+
+    out_run, err_run = StringIO(), StringIO()
+    with redirect_stdout(out_run), redirect_stderr(err_run):
+        rc_run = RunCommandV2().run(_run_args(str(archivo)))
+
+    repl = InteractiveCommand(InterpretadorCobra())
+    repl._seguro_repl = False
+    repl._extra_validators_repl = None
+    out_repl, err_repl = StringIO(), StringIO()
+    with redirect_stdout(out_repl), redirect_stderr(err_repl):
+        repl.ejecutar_codigo(codigo)
+
+    assert rc_run == 0
+    assert err_run.getvalue() == err_repl.getvalue() == ""
+    assert out_run.getvalue() == out_repl.getvalue()
+
+
+@pytest.mark.integration
+def test_mutacion_en_mientras_y_lectura_posterior_persisten_en_repl():
+    repl = InteractiveCommand(InterpretadorCobra())
+    repl._seguro_repl = False
+    repl._extra_validators_repl = None
+    out_repl, err_repl = StringIO(), StringIO()
+    with redirect_stdout(out_repl), redirect_stderr(err_repl):
+        repl.ejecutar_codigo(
+            "mientras verdadero:\n"
+            "    dato = 2\n"
+            "    romper\n"
+            "fin"
+        )
+        repl.ejecutar_codigo("imprimir(dato)")
+
+    assert err_repl.getvalue() == ""
+    assert out_repl.getvalue().strip().endswith("2")
+    assert repl.interpretador.contextos[-1].get("dato") == 2

--- a/tests/unit/test_cli_execution_pipeline_contract.py
+++ b/tests/unit/test_cli_execution_pipeline_contract.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
-from pcobra.cobra.cli.execution_pipeline import preparar_interpretador
+from pcobra.cobra.cli.execution_pipeline import PipelineInput, ejecutar_pipeline_explicito
 from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
 from pcobra.cobra.core.runtime import InterpretadorCobra
 
@@ -175,21 +175,15 @@ def test_contrato_repl_igual_script_estado_final_con_bucles_y_asignaciones():
         "var acumulado = 42\n"
         "var ultimo = 42"
     )
-    cmd_execute = ExecuteCommand()
-    estado_script = {}
-
-    def _capturar_setup(**kwargs):
-        setup = preparar_interpretador(**kwargs)
-        estado_script["interpreter"] = setup.interpretador
-        return setup
-
-    with patch(
-        "pcobra.cobra.cli.commands.execute_cmd.preparar_interpretador",
-        side_effect=_capturar_setup,
-    ):
-        assert cmd_execute._ejecutar_normal(codigo, seguro=False, extra_validators=None) == 0
-
-    contexto_script = estado_script["interpreter"].contextos[-1]
+    setup_script, _ = ejecutar_pipeline_explicito(
+        PipelineInput(
+            codigo=codigo,
+            interpretador_cls=InterpretadorCobra,
+            safe_mode=False,
+            extra_validators=None,
+        )
+    )
+    contexto_script = setup_script.interpretador.contextos[-1]
 
     repl = InteractiveCommand(InterpretadorCobra())
     repl._seguro_repl = False


### PR DESCRIPTION
### Motivation
- Centralizar y exponer una única API para el flujo análisis → validación → preparación de intérprete → ejecución para evitar duplicación entre `run` y REPL.
- Asegurar que la misma secuencia semántica produzca resultados equivalentes entre ejecutar un archivo con `cobra run` y ejecutar snippets desde el REPL.
- Cubrir casos con mutación dentro de bucles `mientras` y lectura posterior para garantizar persistencia de estado cuando corresponde.

### Description
- Se añadió `PipelineInput` y la función `ejecutar_pipeline_explicito(...)` en `src/pcobra/cobra/cli/execution_pipeline.py` que orquesta análisis, validación, preparación del intérprete y ejecución en un único punto.
- `ExecuteCommand._ejecutar_normal` ahora utiliza `ejecutar_pipeline_explicito` y `PipelineInput`, eliminando la duplicación de lógica de preparación/validación/ejecución.
- `InteractiveCommand.ejecutar_codigo` y la inicialización del intérprete en `InteractiveCommand.run` consumen la misma API del pipeline para reutilizar/intercambiar intérpretes y preservar estado REPL cuando procede.
- Se actualizaron tests de contrato para usar la nueva API y se añadieron tests de integración (`tests/integration/test_run_repl_equivalence.py`) que validan paridad semántica entre `run` y REPL y persisten mutaciones dentro de `mientras`.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_execution_pipeline_contract.py tests/integration/test_run_repl_equivalence.py` y los tests automatizados pasaron: all tests passed (`13 passed`).
- Durante iteraciones previas localmente se resolvieron fallos relacionados con límites de recursos en el entorno de CI neutralizando `limitar_cpu_segundos` en los tests de integración; la ejecución final de los tests mencionados fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66851f50c83279923ce3351d4e884)