### PR TITLE
refactor(lsp): desacoplar formateo de ExecuteCommand

### DIFF
--- a/src/pcobra/lsp/cobra_plugin.py
+++ b/src/pcobra/lsp/cobra_plugin.py
@@ -29,7 +29,7 @@ except ModuleNotFoundError:  # pragma: no cover - dependencia opcional
 from pcobra.standard_library import __all__ as STD_FUNCS
 from pcobra.cobra.core import Lexer, LexerError
 from pcobra.cobra.core import Parser, ParserError
-from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand
+from pcobra.cobra.cli.services.format_service import format_code_with_black
 
 # Palabras reservadas más comunes de Cobra
 KEYWORDS = [
@@ -187,7 +187,8 @@ def pylsp_format_document(config, workspace, document):
     """Formatea el archivo actual utilizando el formateador de Cobra."""
     path = document.path
     try:
-        ExecuteCommand._formatear_codigo(path)
+        if not format_code_with_black(path):
+            raise RuntimeError(f"Fallo de formateo con black para el documento {path}")
         with open(path, "r", encoding="utf-8") as fh:
             formatted = fh.read()
     except Exception as exc:

--- a/tests/unit/test_lsp_cobra_plugin.py
+++ b/tests/unit/test_lsp_cobra_plugin.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pcobra.lsp import cobra_plugin
+
+
+class _DummyDocument:
+    def __init__(self, path: Path, source: str) -> None:
+        self.path = str(path)
+        self.source = source
+        self.lines = source.splitlines()
+
+
+def test_pylsp_format_document_devuelve_edits_si_formatea(monkeypatch, tmp_path):
+    archivo = tmp_path / "demo.co"
+    archivo.write_text("imprimir(1)\n", encoding="utf-8")
+    documento = _DummyDocument(path=archivo, source=archivo.read_text(encoding="utf-8"))
+
+    def _fake_format(path: str) -> bool:
+        Path(path).write_text("imprimir(1)\n", encoding="utf-8")
+        return True
+
+    monkeypatch.setattr(cobra_plugin, "format_code_with_black", _fake_format)
+
+    edits = cobra_plugin.pylsp_format_document(None, None, documento)
+
+    assert isinstance(edits, list)
+    assert edits[0]["newText"] == "imprimir(1)\n"
+    assert edits[0]["range"]["start"] == {"line": 0, "character": 0}
+
+
+def test_pylsp_format_document_lanza_runtimeerror_si_falla_formateo(monkeypatch, tmp_path):
+    archivo = tmp_path / "demo.co"
+    archivo.write_text("imprimir(1)\n", encoding="utf-8")
+    documento = _DummyDocument(path=archivo, source=archivo.read_text(encoding="utf-8"))
+
+    monkeypatch.setattr(cobra_plugin, "format_code_with_black", lambda _path: False)
+
+    with pytest.raises(RuntimeError, match="Fallo de formateo con black"):
+        cobra_plugin.pylsp_format_document(None, None, documento)
+
+
+def test_lsp_plugin_no_depende_de_executecommand():
+    assert not hasattr(cobra_plugin, "ExecuteCommand")
+


### PR DESCRIPTION
### Motivation
- El plugin LSP dependía directamente de `ExecuteCommand` para formatear código, lo que acoplaba la lógica de editor a la implementación CLI.
- Se busca reutilizar el servicio de formateo existente (`format_code_with_black`) para centralizar la responsabilidad de formateo y simplificar dependencias.
- Mantener la semántica de error del LSP cuando el formateo falla para que el servidor propague errores de forma explícita.
- Añadir pruebas unitarias específicas para garantizar comportamiento correcto y ausencia de la dependencia antigua.

### Description
- Reemplacé el import `from pcobra.cobra.cli.commands.execute_cmd import ExecuteCommand` por `from pcobra.cobra.cli.services.format_service import format_code_with_black` en `src/pcobra/lsp/cobra_plugin.py`.
- En `pylsp_format_document` sustitui la llamada a `ExecuteCommand._formatear_codigo(path)` por `format_code_with_black(path)` y lanzo `RuntimeError` explícito cuando la función devuelve `False` para preservar la semántica de error en el flujo LSP.
- La lectura del archivo formateado y la construcción del `TextEdit` de respuesta se mantienen intactas sin cambios en la estructura del retorno.
- Añadí `tests/unit/test_lsp_cobra_plugin.py` con pruebas para formateo exitoso (devuelve edits), fallo de formateo (lanza `RuntimeError`) y comprobación de que el plugin ya no expone `ExecuteCommand`.

### Testing
- Ejecuté `pytest -q tests/unit/test_lsp_cobra_plugin.py` y las tres pruebas pasaron exitosamente (`3 passed`).
- Verifiqué con `rg -n "pcobra\.cobra\.cli\.commands\.|cobra\.cli\.commands\." src/pcobra/lsp` y no se encontraron importaciones remanentes desde `pcobra.cobra.cli.commands`.
- Las pruebas unitarias añadidas cubren los casos de éxito y fallo del formateo y la ausencia de la dependencia anterior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6fb0b7a908327bde9ceb69e0f1f12)