### PR TITLE
feat(cli): gate legacy core.sandbox fallback behind explicit compatibility flag

### DIFF
--- a/docs/compatibility/runtime_shim_audit_2026-04-21.md
+++ b/docs/compatibility/runtime_shim_audit_2026-04-21.md
@@ -1,0 +1,32 @@
+# Auditoría runtime de shims (`core`, `cobra`, `bindings`) — 2026-04-21
+
+## Objetivo
+Documentar el estado actual de los shims legacy con patrón de reexport/alias y definir qué rutas siguen permitidas en runtime productivo vs. transición controlada.
+
+## Resumen ejecutivo
+- **Canónico en productivo**: `pcobra.*`.
+- **Compatibilidad de transición explícita**: solo el fallback `core.sandbox` desde `execute_cmd`, protegido por la flag `PCOBRA_ENABLE_LEGACY_CORE_SANDBOX`.
+- **Shims legacy permitidos solo transición**: `core`, `cobra`, `cobra.cli`, `bindings` y `bindings.contract`.
+
+## Inventario auditado
+
+| Shim / patrón | Implementación | Estado en runtime productivo | Estado transición | Notas de control |
+|---|---|---|---|---|
+| `pcobra.core.sandbox` (ruta canónica) | `src/pcobra/cobra/cli/commands/execute_cmd.py` | **Permitido** | **Permitido** | Ruta principal; se intenta primero siempre. |
+| Fallback `core.sandbox` | `src/pcobra/cobra/cli/commands/execute_cmd.py` | **No permitido por defecto** | **Permitido solo con flag** | Requiere `PCOBRA_ENABLE_LEGACY_CORE_SANDBOX=1`. Emite warning estructurado `event=legacy_core_sandbox_fallback`. |
+| `core` (shim paquete raíz) | `src/core/__init__.py` | **No recomendado** | **Permitido temporal** | Reexporta `pcobra.core` y mantiene alias en `sys.modules`. |
+| `cobra` (shim paquete raíz) | `src/cobra/__init__.py` | **No recomendado** | **Permitido temporal** | Reexporta `pcobra.cobra`, inyecta alias `core`/`cobra.core`. |
+| `cobra.cli` (shim compat) | `src/cobra/cli/__init__.py`, `src/cobra/cli/cli.py` | **No recomendado** | **Permitido temporal** | Marcado como `INTERNAL COMPATIBILITY ONLY`. |
+| `bindings` | `src/bindings/__init__.py` | **No recomendado** | **Permitido temporal** | Deprecado explícitamente, sugiere `pcobra.cobra.bindings`. |
+| `bindings.contract` | `src/bindings/contract.py` | **No recomendado** | **Permitido temporal** | Deprecado explícitamente, sugiere `pcobra.cobra.bindings.contract`. |
+| `cli` (shim top-level) | `src/cli/__init__.py` | **No recomendado** | **Permitido temporal** | Activa compat legacy condicionada por mecanismo interno de `pcobra.cli`. |
+
+## Política propuesta de operación
+1. **Producción**: usar exclusivamente imports `pcobra.*` para rutas runtime críticas.
+2. **Transición**:
+   - habilitar fallback `core.sandbox` solo cuando sea estrictamente necesario,
+   - registrar y monitorear warnings con `event=legacy_core_sandbox_fallback`,
+   - planificar retiro de shims de alto nivel (`core`, `cobra`, `bindings`, `cli`) en ventanas controladas.
+3. **Trazabilidad**:
+   - conservar el nombre de la flag (`PCOBRA_ENABLE_LEGACY_CORE_SANDBOX`) en logs y runbooks,
+   - revisar periódicamente uso real de fallback antes de eliminar compatibilidad.

--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -41,6 +42,14 @@ from pcobra.cobra.core.runtime import (
 
 sys.modules.setdefault("cli.commands.execute_cmd", sys.modules[__name__])
 
+LEGACY_SANDBOX_COMPAT_FLAG = "PCOBRA_ENABLE_LEGACY_CORE_SANDBOX"
+
+
+def _legacy_sandbox_compat_enabled() -> bool:
+    """Indica si la ruta legacy `core.sandbox` está habilitada explícitamente."""
+    raw = (os.environ.get(LEGACY_SANDBOX_COMPAT_FLAG, "") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
 
 def _importar_modulo_sandbox() -> Any:
     """Resuelve sandbox runtime priorizando namespace canónico."""
@@ -48,14 +57,31 @@ def _importar_modulo_sandbox() -> Any:
     try:
         module = importlib.import_module("pcobra.core.sandbox")
     except ModuleNotFoundError as canon_exc:  # pragma: no cover - fallback legacy
+        if not _legacy_sandbox_compat_enabled():
+            raise ImportError(
+                "No se pudo importar 'pcobra.core.sandbox'. "
+                "El fallback legacy 'core.sandbox' está deshabilitado por defecto. "
+                f"Para transición controlada habilite {LEGACY_SANDBOX_COMPAT_FLAG}=1."
+            ) from canon_exc
         try:
             module = importlib.import_module("core.sandbox")
         except ModuleNotFoundError:
             raise canon_exc
         _validar_modulo_sandbox_legacy(module)
         logging.getLogger(__name__).warning(
-            "Se usó compatibilidad legacy para resolver 'core.sandbox'. "
-            "Migre a 'pcobra.core.sandbox'."
+            "legacy_runtime_compat event=legacy_core_sandbox_fallback "
+            "canonical_module=pcobra.core.sandbox fallback_module=core.sandbox "
+            "flag=%s module_file=%s migration_target=pcobra.core.sandbox",
+            LEGACY_SANDBOX_COMPAT_FLAG,
+            getattr(module, "__file__", "<unknown>"),
+            extra={
+                "event": "legacy_core_sandbox_fallback",
+                "canonical_module": "pcobra.core.sandbox",
+                "fallback_module": "core.sandbox",
+                "compatibility_flag": LEGACY_SANDBOX_COMPAT_FLAG,
+                "module_file": getattr(module, "__file__", None),
+                "migration_target": "pcobra.core.sandbox",
+            },
         )
 
     required = (

--- a/tests/unit/test_runtime_import_resolution.py
+++ b/tests/unit/test_runtime_import_resolution.py
@@ -37,6 +37,7 @@ def test_execute_cmd_hace_fallback_legacy_si_falta_canonico(monkeypatch, caplog)
     calls: list[str] = []
     legacy = _sandbox_mod()
     legacy.__name__ = "core.sandbox"
+    monkeypatch.setenv(execute_cmd.LEGACY_SANDBOX_COMPAT_FLAG, "1")
 
     def fake_import(name: str):
         calls.append(name)
@@ -52,13 +53,35 @@ def test_execute_cmd_hace_fallback_legacy_si_falta_canonico(monkeypatch, caplog)
 
     assert resolved is legacy
     assert calls == ["pcobra.core.sandbox", "core.sandbox"]
-    assert "compatibilidad legacy" in caplog.text
+    assert "legacy_core_sandbox_fallback" in caplog.text
+    assert any(
+        getattr(record, "event", "") == "legacy_core_sandbox_fallback"
+        and getattr(record, "compatibility_flag", "")
+        == execute_cmd.LEGACY_SANDBOX_COMPAT_FLAG
+        for record in caplog.records
+    )
+
+
+def test_execute_cmd_bloquea_fallback_legacy_si_flag_inactiva(monkeypatch):
+    def fake_import(name: str):
+        if name == "pcobra.core.sandbox":
+            raise ModuleNotFoundError(name)
+        if name == "core.sandbox":
+            return _sandbox_mod()
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(execute_cmd.importlib, "import_module", fake_import)
+    monkeypatch.delenv(execute_cmd.LEGACY_SANDBOX_COMPAT_FLAG, raising=False)
+
+    with pytest.raises(ImportError, match="deshabilitado por defecto"):
+        execute_cmd._importar_modulo_sandbox()
 
 
 def test_execute_cmd_rechaza_fallback_legacy_fuera_de_pcobra(monkeypatch):
     legacy = _sandbox_mod()
     legacy.__name__ = "core.sandbox"
     legacy.__file__ = "/tmp/fake/core/sandbox.py"
+    monkeypatch.setenv(execute_cmd.LEGACY_SANDBOX_COMPAT_FLAG, "1")
 
     def fake_import(name: str):
         if name == "pcobra.core.sandbox":


### PR DESCRIPTION
### Motivation
- Evitar que el fallback legacy `core.sandbox` se utilice accidentalmente en entornos productivos y ofrecer un mecanismo de transición controlado.
- Consolidar `pcobra.core.sandbox` como la ruta canónica por defecto y añadir trazabilidad cuando se use compatibilidad legacy.

### Description
- Añadida la flag de compatibilidad controlada `PCOBRA_ENABLE_LEGACY_CORE_SANDBOX` y la función `_legacy_sandbox_compat_enabled()` en `src/pcobra/cobra/cli/commands/execute_cmd.py` para habilitar explícitamente el fallback legacy.
- Modificado `_importar_modulo_sandbox()` para intentar primero `pcobra.core.sandbox` y rechazar el fallback a `core.sandbox` salvo que la flag esté activada, lanzando un `ImportError` instructivo si está deshabilitado.
- Cuando se usa el fallback legacy se emite un warning estructurado y trazable con `event=legacy_core_sandbox_fallback` y metadatos (`canonical_module`, `fallback_module`, `compatibility_flag`, `module_file`, `migration_target`) para facilitar auditoría y observabilidad.
- Actualizados tests unitarios en `tests/unit/test_runtime_import_resolution.py` para cubrir: prioridad del módulo canónico, uso del fallback solo con la flag, bloqueo por defecto sin flag, y validación de la ruta legacy; además se añadió documentación de auditoría en `docs/compatibility/runtime_shim_audit_2026-04-21.md` que inventaría y marca el estado de los shims (`core`, `cobra`, `bindings`, etc.).

### Testing
- Ejecuté `pytest -q tests/unit/test_execute_cmd_binding_contract.py` y pasó correctamente. ✅
- Ejecuté `pytest -q tests/unit/test_runtime_import_resolution.py` y la colección falló con un `ImportError` durante la importación del módulo de prueba en este entorno: `ImportError: cannot import name 'execute_cmd' from 'pcobra.cobra.cli.commands'`; el fallo parece ser un problema de colección/alias en el entorno de prueba, no de la lógica del gate en sí. ❌
- Se añadió la documentación de auditoría en `docs/compatibility/runtime_shim_audit_2026-04-21.md` para uso operativo y revisión durante la migración.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e73f76d15c8327a4c199f6f3819137)