### PR TITLE
Add CI gate to detect import cycles and enforce CLI/runtime layer rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,9 @@ jobs:
         run: python scripts/ci/lint_public_no_direct_transpiler_imports.py
       - name: Lint legacy bindings imports in src
         run: python scripts/ci/lint_no_legacy_bindings_imports.py
+      - name: Gate de arquitectura de imports (ciclos y capas)
+        shell: bash
+        run: python scripts/ci/check_import_cycles.py
       - name: Validate runtime contract matrix
         shell: bash
         run: python scripts/validate_runtime_contract.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,5 +24,7 @@ jobs:
         run: python scripts/ci/lint_public_no_direct_transpiler_imports.py
       - name: Lint legacy bindings imports in src
         run: python scripts/ci/lint_no_legacy_bindings_imports.py
+      - name: Gate de arquitectura de imports (ciclos y capas)
+        run: python scripts/ci/check_import_cycles.py
       - name: Validate runtime contract matrix
         run: python scripts/validate_runtime_contract.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,8 @@ jobs:
         run: python scripts/ci/validate_syntax_report_contract.py
       - name: Lint public surfaces without direct transpiler imports
         run: python scripts/ci/lint_public_no_direct_transpiler_imports.py
+      - name: Gate de arquitectura de imports (ciclos y capas)
+        run: python scripts/ci/check_import_cycles.py
       - name: Validate runtime contract matrix
         if: runner.os != 'Windows'
         shell: bash

--- a/scripts/ci/check_import_cycles.py
+++ b/scripts/ci/check_import_cycles.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Gate de arquitectura: detecta ciclos de imports y violaciones de capas."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = ROOT / "src"
+
+COMMAND_MODULE_PREFIXES = (
+    "pcobra.cobra.cli.commands",
+    "pcobra.cobra.cli.commands_v2",
+)
+ALLOWED_COMMAND_SIBLING = {"base"}
+RUNTIME_PREFIXES = (
+    "pcobra.cobra.core.runtime",
+    "pcobra.cobra.bindings.runtime_manager",
+)
+CLI_PREFIX = "pcobra.cobra.cli"
+KNOWN_CYCLE_BASELINES: tuple[frozenset[str], ...] = (
+    frozenset(
+        {
+            "pcobra.core.ast_cache",
+            "pcobra.core.lexer",
+            "pcobra.cobra.core.lexer",
+        }
+    ),  # ciclo histórico puntual
+    frozenset(
+        {
+            "pcobra.cobra.core.lark_parser",
+            "pcobra.cobra.core.lexer",
+            "pcobra.cobra.core.parser",
+            "pcobra.core.ast_cache",
+            "pcobra.core.ast_nodes",
+            "pcobra.core.lexer",
+            "pcobra.core.parser",
+        }
+    ),  # SCC histórica heredada entre parser/lexer legacy+unificado
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    kind: str
+    source: str
+    target: str
+
+
+def _module_name_for(path: Path, root: Path) -> str:
+    rel = path.relative_to(root).with_suffix("")
+    return ".".join(rel.parts)
+
+
+def _iter_python_files(src_dir: Path) -> list[Path]:
+    if not src_dir.exists():
+        return []
+    return sorted(path for path in src_dir.rglob("*.py") if path.is_file())
+
+
+def _resolve_relative_module(current_module: str, level: int, module: str | None) -> str | None:
+    parts = current_module.split(".")
+    if level > len(parts):
+        return None
+    base = parts[:-level]
+    if module:
+        return ".".join((*base, *module.split(".")))
+    return ".".join(base)
+
+
+def _extract_imported_modules(tree: ast.AST, current_module: str) -> set[str]:
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                resolved = _resolve_relative_module(current_module, node.level, node.module)
+                if resolved:
+                    imports.add(resolved)
+                continue
+            if node.module:
+                imports.add(node.module)
+    return imports
+
+
+def _project_module_prefixes(modules: set[str]) -> tuple[str, ...]:
+    prefixes = sorted({module.split(".")[0] for module in modules if module})
+    return tuple(prefixes)
+
+
+def build_import_graph(src_dir: Path = SRC_DIR) -> dict[str, set[str]]:
+    files = _iter_python_files(src_dir)
+    module_to_path = {_module_name_for(path, src_dir): path for path in files}
+    all_modules = set(module_to_path)
+    project_prefixes = _project_module_prefixes(all_modules)
+
+    graph: dict[str, set[str]] = {module: set() for module in all_modules}
+    for module, path in module_to_path.items():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        imported_modules = _extract_imported_modules(tree, module)
+
+        for imported in imported_modules:
+            if imported in all_modules:
+                graph[module].add(imported)
+                continue
+
+            for prefix in project_prefixes:
+                if not imported.startswith(f"{prefix}."):
+                    continue
+                candidate = imported
+                while "." in candidate:
+                    candidate = candidate.rsplit(".", 1)[0]
+                    if candidate in all_modules:
+                        graph[module].add(candidate)
+                        break
+                break
+    return graph
+
+
+def _is_command_module(module: str) -> bool:
+    return any(module == prefix or module.startswith(f"{prefix}.") for prefix in COMMAND_MODULE_PREFIXES)
+
+
+def _is_cross_command_forbidden(source: str, target: str) -> bool:
+    if not (_is_command_module(source) and _is_command_module(target)):
+        return False
+    if source == target:
+        return False
+    if source.endswith(".__init__"):
+        return False
+
+    for prefix in COMMAND_MODULE_PREFIXES:
+        if target == prefix:
+            return False
+        if target.startswith(f"{prefix}."):
+            suffix = target[len(prefix) + 1 :]
+            root = suffix.split(".", 1)[0]
+            return root not in ALLOWED_COMMAND_SIBLING
+    return True
+
+
+def _is_runtime_to_cli_forbidden(source: str, target: str) -> bool:
+    if not any(source == prefix or source.startswith(f"{prefix}.") for prefix in RUNTIME_PREFIXES):
+        return False
+    return target == CLI_PREFIX or target.startswith(f"{CLI_PREFIX}.")
+
+
+def find_layer_violations(graph: dict[str, set[str]]) -> list[Violation]:
+    violations: list[Violation] = []
+    for source, targets in graph.items():
+        for target in targets:
+            if _is_cross_command_forbidden(source, target):
+                violations.append(Violation("cross_command", source, target))
+            if _is_runtime_to_cli_forbidden(source, target):
+                violations.append(Violation("runtime_depends_on_cli", source, target))
+    return violations
+
+
+def _first_cycle(graph: dict[str, set[str]]) -> list[str] | None:
+    state: dict[str, int] = {}
+    stack: list[str] = []
+
+    def dfs(node: str) -> list[str] | None:
+        state[node] = 1
+        stack.append(node)
+        for neighbor in sorted(graph.get(node, ())):
+            neighbor_state = state.get(neighbor, 0)
+            if neighbor_state == 0:
+                found = dfs(neighbor)
+                if found:
+                    return found
+            elif neighbor_state == 1:
+                idx = stack.index(neighbor)
+                return [*stack[idx:], neighbor]
+        stack.pop()
+        state[node] = 2
+        return None
+
+    for node in sorted(graph):
+        if state.get(node, 0) == 0:
+            found = dfs(node)
+            if found:
+                return found
+    return None
+
+
+def _scc_components(graph: dict[str, set[str]]) -> list[set[str]]:
+    index = 0
+    stack: list[str] = []
+    on_stack: set[str] = set()
+    indexes: dict[str, int] = {}
+    lowlinks: dict[str, int] = {}
+    components: list[set[str]] = []
+
+    def strongconnect(node: str) -> None:
+        nonlocal index
+        indexes[node] = index
+        lowlinks[node] = index
+        index += 1
+        stack.append(node)
+        on_stack.add(node)
+
+        for neighbor in sorted(graph.get(node, ())):
+            if neighbor not in indexes:
+                strongconnect(neighbor)
+                lowlinks[node] = min(lowlinks[node], lowlinks[neighbor])
+            elif neighbor in on_stack:
+                lowlinks[node] = min(lowlinks[node], indexes[neighbor])
+
+        if lowlinks[node] == indexes[node]:
+            component: set[str] = set()
+            while stack:
+                member = stack.pop()
+                on_stack.remove(member)
+                component.add(member)
+                if member == node:
+                    break
+            components.append(component)
+
+    for node in sorted(graph):
+        if node not in indexes:
+            strongconnect(node)
+    return components
+
+
+def find_new_cycle_components(graph: dict[str, set[str]]) -> list[set[str]]:
+    cyclic_components = [component for component in _scc_components(graph) if len(component) > 1]
+    return [
+        component
+        for component in cyclic_components
+        if frozenset(component) not in KNOWN_CYCLE_BASELINES
+    ]
+
+
+def _module_to_file(module: str, src_dir: Path = SRC_DIR) -> Path:
+    return src_dir / Path(*module.split(".")).with_suffix(".py")
+
+
+def format_cycle_report(cycle: list[str], src_dir: Path = SRC_DIR, root: Path = ROOT) -> str:
+    chain = " -> ".join(cycle)
+    lines = ["❌ Se detectó ciclo de imports.", f"   Cadena: {chain}", "   Archivos implicados:"]
+    for module in cycle[:-1]:
+        rel = _module_to_file(module, src_dir).relative_to(root)
+        lines.append(f"   - {module} ({rel})")
+    return "\n".join(lines)
+
+
+def format_layer_report(violations: list[Violation], src_dir: Path = SRC_DIR, root: Path = ROOT) -> str:
+    lines = ["❌ Violaciones de capas detectadas:"]
+    for item in violations:
+        source_file = _module_to_file(item.source, src_dir).relative_to(root)
+        target_file = _module_to_file(item.target, src_dir).relative_to(root)
+        if item.kind == "cross_command":
+            reason = (
+                "comandos CLI no deben importarse entre sí para compartir datos; "
+                "mueve lo compartido a módulos registry/service"
+            )
+        else:
+            reason = "runtime no debe depender de módulos CLI"
+        lines.append(
+            f"   - {item.source} ({source_file}) -> {item.target} ({target_file}) :: {reason}"
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    graph = build_import_graph(SRC_DIR)
+    new_cycles = find_new_cycle_components(graph)
+    cycle = _first_cycle(graph) if new_cycles else None
+    layer_violations = find_layer_violations(graph)
+
+    if cycle:
+        print(format_cycle_report(cycle, src_dir=SRC_DIR, root=ROOT))
+    if layer_violations:
+        print(format_layer_report(layer_violations, src_dir=SRC_DIR, root=ROOT))
+
+    if cycle or layer_violations:
+        return 1
+
+    print("✅ Gate de arquitectura de imports: OK (sin ciclos ni violaciones de capas)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_ci_check_import_cycles.py
+++ b/tests/unit/test_ci_check_import_cycles.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.ci.check_import_cycles import (
+    build_import_graph,
+    find_new_cycle_components,
+    find_layer_violations,
+    format_cycle_report,
+    main,
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_detecta_ciclo_en_grafo(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    _write(src / "pkg" / "a.py", "import pkg.b\n")
+    _write(src / "pkg" / "b.py", "import pkg.c\n")
+    _write(src / "pkg" / "c.py", "import pkg.a\n")
+
+    graph = build_import_graph(src)
+    cycle_components = find_new_cycle_components(graph)
+
+    assert cycle_components
+    cycle = sorted(cycle_components[0])
+    cycle.append(cycle[0])
+    report = format_cycle_report(cycle, src_dir=src, root=tmp_path)
+    assert "Cadena:" in report
+    assert "pkg.a" in report
+    assert "pkg.b" in report
+    assert "pkg.c" in report
+
+
+def test_detecta_violaciones_de_capas(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    _write(
+        src / "pcobra" / "cobra" / "cli" / "commands" / "a.py",
+        "from pcobra.cobra.cli.commands.compile_cmd import CompileCommand\n",
+    )
+    _write(
+        src / "pcobra" / "cobra" / "cli" / "commands" / "compile_cmd.py",
+        "class CompileCommand:\n    pass\n",
+    )
+    _write(
+        src / "pcobra" / "cobra" / "core" / "runtime.py",
+        "from pcobra.cobra.cli.public_command_policy import PUBLIC_COMMANDS\n",
+    )
+    _write(
+        src / "pcobra" / "cobra" / "cli" / "public_command_policy.py",
+        "PUBLIC_COMMANDS = ()\n",
+    )
+
+    graph = build_import_graph(src)
+    violations = find_layer_violations(graph)
+
+    kinds = {item.kind for item in violations}
+    assert "cross_command" in kinds
+    assert "runtime_depends_on_cli" in kinds
+
+
+def test_main_pasa_en_repositorio_actual() -> None:
+    code = main()
+    assert code == 0
+
+
+def test_permite_import_base_entre_comandos(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    _write(
+        src / "pcobra" / "cobra" / "cli" / "commands_v2" / "ok.py",
+        "from pcobra.cobra.cli.commands.base import BaseCommand\n",
+    )
+    _write(
+        src / "pcobra" / "cobra" / "cli" / "commands" / "base.py",
+        "class BaseCommand:\n    pass\n",
+    )
+
+    graph = build_import_graph(src)
+    violations = find_layer_violations(graph)
+
+    assert not violations

--- a/tests/unit/test_ci_check_import_cycles_guard.py
+++ b/tests/unit/test_ci_check_import_cycles_guard.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_ci_check_import_cycles_guard_passes_on_repo() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "scripts/ci/check_import_cycles.py"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
### Motivation
- Detectar ciclos de imports Python dentro de `src/` y evitar que aparezcan ciclos nuevos que rompan la arquitectura.
- Aplicar reglas mínimas de capas para evitar acoplamientos indebidos entre comandos CLI, módulos compartidos y runtime.
- Integrar la comprobación como gate en los pipelines de QA/CI para que falle la build si se introduce un ciclo nuevo o una violación de capas.

### Description
- Añade `scripts/ci/check_import_cycles.py` que construye el grafo de imports (resolviendo imports absolutos y relativos) y detecta ciclos mediante componentes fuertemente conexas (SCC) y búsqueda de primer ciclo; además detecta violaciones de capas (`cross_command` y `runtime_depends_on_cli`).
- Implementa una `KNOWN_CYCLE_BASELINES` para ignorar ciclos históricos ya existentes y así sólo fallar ante ciclos nuevos; el script imprime una cadena legible del ciclo y los archivos implicados cuando detecta un ciclo.
- Las reglas de capas implementadas son: comandos CLI no deben importarse entre sí para compartir datos (se permite `base` y se evita penalizar `__init__` agregadores), los compartidos deben moverse a módulos registry/service y el runtime no debe depender de CLI.
- Integra el gate en workflows: ` .github/workflows/lint.yml`, `.github/workflows/ci.yml` y `.github/workflows/test.yml` para ejecutar `python scripts/ci/check_import_cycles.py` como paso de validación.
- Añade pruebas unitarias: `tests/unit/test_ci_check_import_cycles.py` (cobertura de detección de ciclo, violaciones de capas y casos permitidos) y `tests/unit/test_ci_check_import_cycles_guard.py` (ejecución real del script sobre el repo).

### Testing
- Se ejecutó `python scripts/ci/check_import_cycles.py` y comprobó salida de OK en el árbol con la baseline aplicada (no se falla por los SCC históricos); resultado: OK.
- Se ejecutaron las pruebas unitarias `python -m pytest -q tests/unit/test_ci_check_import_cycles.py tests/unit/test_ci_check_import_cycles_guard.py` y pasaron (5 passed).
- Se ejecutaron las pruebas relacionadas previas para asegurar compatibilidad `python -m pytest -q tests/unit/test_ci_lint_no_cross_command_imports.py tests/unit/test_ci_lint_no_cross_command_imports_guard.py` y pasaron (3 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e746e282d48327957d4e797dd171a8)