### PR TITLE
Refactor: carga lazy de comandos CLI mediante rutas declarativas

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -42,6 +42,7 @@ from pcobra.cobra.cli.utils import messages
 from pcobra.cobra.cli.utils import config as config_module
 from pcobra.cobra.cli.services.command_factory import (
     CommandClassRoute,
+    build_command_from_route,
     load_command_class,
 )
 from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
@@ -211,8 +212,20 @@ class CommandRegistry:
 
         for route in command_routes:
             try:
-                cmd_class = load_command_class(route.module_path, route.class_name)
-                base_commands.append(self.create_command(cmd_class))
+                base_commands.append(
+                    build_command_from_route(
+                        route,
+                        command_builder=self.create_command,
+                    )
+                )
+            except TypeError as e:
+                logging.error(
+                    "Contrato inválido en comando %s.%s: %s. "
+                    "Se omite el comando y la CLI continúa en modo degradado.",
+                    route.module_path,
+                    route.class_name,
+                    e,
+                )
             except Exception as e:
                 logging.error(
                     "Failed to load/create command %s.%s: %s",

--- a/src/pcobra/cobra/cli/services/command_factory.py
+++ b/src/pcobra/cobra/cli/services/command_factory.py
@@ -95,3 +95,13 @@ def load_command_class(module_path: str, class_name: str) -> Type[BaseCommand]:
             f"{module_path}.{class_name} debe heredar de BaseCommand."
         )
     return command_class
+
+
+def build_command_from_route(
+    route: CommandClassRoute,
+    *,
+    command_builder: Callable[[Type[BaseCommand]], BaseCommand],
+) -> BaseCommand:
+    """Resuelve e instancia un comando desde una ruta declarativa."""
+    command_class = load_command_class(route.module_path, route.class_name)
+    return command_builder(command_class)

--- a/tests/cli/test_cli_imports.py
+++ b/tests/cli/test_cli_imports.py
@@ -52,6 +52,21 @@ def test_import_canonical_cli_application_no_module_not_found_scripts() -> None:
     assert "scripts" not in result.stderr.lower()
 
 
+def test_import_cli_application_no_precarga_modulos_de_comandos() -> None:
+    result = _run_python_isolated(
+        "import sys; "
+        "from pcobra.cobra.cli.cli import CliApplication; "
+        "mods=[m for m in sys.modules if m.startswith('pcobra.cobra.cli.commands.') and m.endswith('_cmd')]; "
+        "print(len(mods))"
+    )
+
+    assert result.returncode == 0, (
+        "Importar CliApplication no debe precargar módulos de comandos concretos. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert int(result.stdout.strip().splitlines()[-1]) == 0
+
+
 def test_cli_application_prepare_parser_carga_comandos_sin_imports_rotos() -> None:
     result = _run_python_isolated(
         "from pcobra.cobra.cli.cli import CliApplication; "

--- a/tests/unit/test_command_factory.py
+++ b/tests/unit/test_command_factory.py
@@ -3,8 +3,13 @@ import sys
 
 import pytest
 
+import pcobra.cobra.cli.services.command_factory as command_factory_module
 from cobra.cli.services.command_factory import CommandFactory
-from pcobra.cobra.cli.services.command_factory import load_command_class
+from pcobra.cobra.cli.services.command_factory import (
+    CommandClassRoute,
+    build_command_from_route,
+    load_command_class,
+)
 from pcobra.cobra.cli.commands.base import BaseCommand
 
 
@@ -68,3 +73,30 @@ def test_load_command_class_acepta_subclase_valida():
         assert loaded is ComandoValido
     finally:
         sys.modules.pop(module_name, None)
+
+
+def test_build_command_from_route_importa_modulo_bajo_demanda(monkeypatch):
+    loaded_modules: list[str] = []
+
+    class ComandoValido(BaseCommand):
+        name = "fake"
+
+        def register_subparser(self, subparsers):
+            return subparsers
+
+        def run(self, args):
+            return 0
+
+    def _import_stub(module_path: str):
+        loaded_modules.append(module_path)
+        module = types.ModuleType(module_path)
+        module.ComandoValido = ComandoValido
+        return module
+
+    monkeypatch.setattr(command_factory_module, "import_module", _import_stub)
+
+    route = CommandClassRoute("tests.fake_lazy_cmd", "ComandoValido")
+    instance = build_command_from_route(route, command_builder=lambda klass: klass())
+
+    assert instance.name == "fake"
+    assert loaded_modules == ["tests.fake_lazy_cmd"]


### PR DESCRIPTION
### Motivation

- Reducir el acoplamiento y la precarga de módulos de comandos durante el arranque del CLI moviendo la resolución a rutas declarativas (`module_path`, `class_name`).
- Centralizar la lógica de `import_module` + `getattr` para crear comandos bajo demanda y facilitar validación temprana de contrato `BaseCommand`.

### Description

- Añadido `build_command_from_route(route, command_builder=...)` en `src/pcobra/cobra/cli/services/command_factory.py` que resuelve e instancia comandos desde rutas declarativas usando `load_command_class`.
- Reemplazada la carga inline de clases en `CommandRegistry.register_base_commands` (`src/pcobra/cobra/cli/cli.py`) por llamadas a `build_command_from_route`, preservando la API pública y las rutas existentes de comandos v1/v2.
- Mejorada la gestión de errores de contrato: las `TypeError` generadas cuando una clase no cumple `BaseCommand` se registran con un mensaje claro y el registro continúa (degradación controlada omitiendo solo el comando inválido).
- Añadidas pruebas: `tests/unit/test_command_factory.py` (verifica carga bajo demanda vía helper) y `tests/cli/test_cli_imports.py` (asegura que importar `CliApplication` no precarga módulos `_cmd`).

### Testing

- Ejecuté `pytest -q tests/unit/test_command_factory.py tests/unit/test_command_registry_interactive.py tests/cli/test_cli_imports.py` y las pruebas relevantes pasaron: `14 passed`.
- Se verificó el commit y diffs con `git show --stat` y `git status` para confirmar los cambios en `src/pcobra/cobra/cli/cli.py`, `src/pcobra/cobra/cli/services/command_factory.py` y las pruebas añadidas/ajustadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75ac25e508327b0dc8b1e6e1ee9ae)