### PR TITLE
Fix `with` memory-context stack cleanup and add regression tests

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1081,12 +1081,16 @@ class InterpretadorCobra:
         elif isinstance(nodo, NodoWith):
             self.evaluar_expresion(nodo.contexto)
             self.contextos.append(Environment(parent=self.contextos[-1]))
+            self.mem_contextos.append({})
             try:
                 for instr in nodo.cuerpo:
                     resultado = self.ejecutar_nodo(instr)
                     if resultado is not None:
                         return resultado
             finally:
+                memoria_local = self.mem_contextos.pop()
+                for idx, tam in memoria_local.values():
+                    self.liberar_memoria(idx, tam)
                 self.contextos.pop()
         elif isinstance(nodo, NodoImportDesde):
             return self.ejecutar_import(NodoImport(nodo.modulo))

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -7,12 +7,14 @@ from cobra.core import Token, TipoToken
 from core.ast_nodes import (
     NodoAsignacion,
     NodoDel,
-    NodoValor,
-    NodoLlamadaFuncion,
     NodoFuncion,
-    NodoImprimir,
     NodoIdentificador,
+    NodoImprimir,
+    NodoLlamadaFuncion,
     NodoOperacionBinaria,
+    NodoRetorno,
+    NodoValor,
+    NodoWith,
 )
 def test_interpretador_asignacion_y_llamada_funcion():
 
@@ -204,3 +206,70 @@ def test_del_objetivo_no_identificador_lanza_typeerror():
 
     with pytest.raises(TypeError, match=r"^del requiere un identificador como objetivo"):
         inter.ejecutar_nodo(NodoDel(NodoValor(1)))
+
+
+def test_with_limpia_contexto_y_memoria_en_retorno_temprano():
+    inter = InterpretadorCobra()
+    inter.ejecutar_nodo(NodoAsignacion("x", NodoValor(0), declaracion=True))
+    contextos_iniciales = len(inter.contextos)
+    mem_contextos_iniciales = len(inter.mem_contextos)
+
+    resultado = inter.ejecutar_nodo(
+        NodoWith(
+            NodoValor("ctx"),
+            None,
+            [
+                NodoAsignacion("x", NodoValor(7)),
+                NodoRetorno(NodoIdentificador("x")),
+            ],
+        )
+    )
+
+    assert resultado == 7
+    assert inter.obtener_variable("x") == 7
+    assert len(inter.contextos) == contextos_iniciales
+    assert len(inter.mem_contextos) == mem_contextos_iniciales
+
+
+def test_with_limpia_contexto_y_memoria_si_hay_excepcion():
+    inter = InterpretadorCobra()
+    contextos_iniciales = len(inter.contextos)
+    mem_contextos_iniciales = len(inter.mem_contextos)
+
+    with pytest.raises(NameError, match=r"^Variable no declarada: no_definida$"):
+        inter.ejecutar_nodo(
+            NodoWith(
+                NodoValor("ctx"),
+                None,
+                [NodoImprimir(NodoIdentificador("no_definida"))],
+            )
+        )
+
+    assert len(inter.contextos) == contextos_iniciales
+    assert len(inter.mem_contextos) == mem_contextos_iniciales
+
+
+def test_with_declara_local_y_no_contamina_scope_vecino():
+    inter = InterpretadorCobra()
+    inter.ejecutar_nodo(NodoAsignacion("base", NodoValor(1), declaracion=True))
+
+    inter.ejecutar_nodo(
+        NodoWith(
+            NodoValor("ctx1"),
+            None,
+            [NodoAsignacion("solo_with", NodoValor(123), declaracion=True)],
+        )
+    )
+
+    assert inter.obtener_variable("base") == 1
+    with pytest.raises(NameError, match=r"^Variable no declarada: solo_with$"):
+        inter.obtener_variable("solo_with")
+
+    inter.ejecutar_nodo(
+        NodoWith(
+            NodoValor("ctx2"),
+            None,
+            [NodoAsignacion("base", NodoValor(3))],
+        )
+    )
+    assert inter.obtener_variable("base") == 3


### PR DESCRIPTION
### Motivation
- Corregir una asimetría en la gestión de memoria al entrar/salir de un bloque `with` que podía dejar `mem_contextos` desbalanceado cuando había `return` temprano o excepciones en el bloque.
- Evitar fugas de bloques de memoria asignados localmente dentro de `with` que no se liberaban sistemáticamente como sí ocurre en funciones/métodos.
- Añadir pruebas de regresión que garanticen que asignaciones y mutaciones dentro de `with` no corrompen `mem_contextos` ni afectan scopes vecinos inesperadamente.

### Description
- Al abrir un `NodoWith` se agrega `self.mem_contextos.append({})` para reservar un contexto de memoria local paralelo al nuevo `Environment` del scope. 
- En el `finally` del manejo de `with` se añade la limpieza simétrica: `memoria_local = self.mem_contextos.pop()` y liberación de cada bloque con `self.liberar_memoria(idx, tam)` antes de `self.contextos.pop()`.
- Se agregaron pruebas en `tests/unit/test_interpreter.py`: `test_with_limpia_contexto_y_memoria_en_retorno_temprano`, `test_with_limpia_contexto_y_memoria_si_hay_excepcion` y `test_with_declara_local_y_no_contamina_scope_vecino` que validan balanceo de pilas y aislamiento de variables entre `with`.

### Testing
- Ejecuté `pytest -q tests/unit/test_interpreter.py` y los tests relevantes completaron correctamente (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76969d86083278aff8bf71a5e2484)