### PR TITLE
Enforce CLI transpiler registry contract and lint local backend constants

### DIFF
--- a/scripts/ci/lint_no_cross_command_imports.py
+++ b/scripts/ci/lint_no_cross_command_imports.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Lint interno: prohíbe imports entre módulos de comandos CLI (excepto base.py)."""
+"""Lint interno para comandos CLI.
+
+Reglas:
+1) Prohíbe imports entre módulos de comandos CLI (excepto ``base.py``).
+2) Prohíbe constantes locales de backends/transpiladores en comandos
+   (la fuente canónica es ``pcobra.cobra.cli.transpiler_registry``).
+"""
 
 from __future__ import annotations
 
@@ -15,6 +21,10 @@ FORBIDDEN_PREFIXES = (
     "pcobra.cobra.cli.commands",
     "cobra.cli.commands",
 )
+FORBIDDEN_DIRECT_REGISTRY_IMPORTS = {
+    "pcobra.cobra.transpilers.registry",
+    "cobra.transpilers.registry",
+}
 
 
 def _is_forbidden_module_name(module: str) -> bool:
@@ -56,6 +66,59 @@ def _scan_file(path: Path) -> list[tuple[int, str]]:
     return violations
 
 
+def _scan_direct_registry_imports(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in FORBIDDEN_DIRECT_REGISTRY_IMPORTS:
+                    violations.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module in FORBIDDEN_DIRECT_REGISTRY_IMPORTS:
+                violations.append((node.lineno, module))
+    return violations
+
+
+def _is_constant_assignment_target(target: ast.expr) -> str | None:
+    if isinstance(target, ast.Name) and target.id.isupper():
+        return target.id
+    return None
+
+
+def _is_backend_constant_literal(value: ast.AST) -> bool:
+    if isinstance(value, ast.Dict):
+        if not value.keys:
+            return False
+        return all(isinstance(key, ast.Constant) and isinstance(key.value, str) for key in value.keys)
+    if isinstance(value, (ast.Tuple, ast.List, ast.Set)):
+        if not value.elts:
+            return False
+        return all(isinstance(elt, ast.Constant) and isinstance(elt.value, str) for elt in value.elts)
+    return False
+
+
+def _scan_backend_constant_violations(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        target_name: str | None = None
+        value: ast.AST | None = None
+        if isinstance(node, ast.Assign):
+            if len(node.targets) == 1:
+                target_name = _is_constant_assignment_target(node.targets[0])
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            target_name = _is_constant_assignment_target(node.target)
+            value = node.value
+        if not target_name or value is None:
+            continue
+        if target_name in {"TRANSPILERS", "BACKENDS", "LANG_CHOICES", "LANGUAGES"} and _is_backend_constant_literal(value):
+            violations.append((node.lineno, target_name))
+    return violations
+
+
 def find_violations(root: Path = ROOT) -> list[str]:
     failures: list[str] = []
     scopes = (
@@ -72,18 +135,28 @@ def find_violations(root: Path = ROOT) -> list[str]:
                     f"{rel}:{line}: import entre comandos no permitido ({target}); "
                     "extrae código a un servicio compartido o usa commands.base"
                 )
+            for line, target in _scan_direct_registry_imports(path):
+                failures.append(
+                    f"{rel}:{line}: import directo no permitido ({target}); "
+                    "usa pcobra.cobra.cli.transpiler_registry.cli_transpilers()/cli_transpiler_targets()"
+                )
+            for line, constant_name in _scan_backend_constant_violations(path):
+                failures.append(
+                    f"{rel}:{line}: constante local no permitida en comandos ({constant_name}); "
+                    "usa pcobra.cobra.cli.transpiler_registry.cli_transpilers()/cli_transpiler_targets()"
+                )
     return failures
 
 
 def main() -> int:
     failures = find_violations(ROOT)
     if failures:
-        print("❌ Lint imports cruzados entre comandos: FALLÓ")
+        print("❌ Lint de contratos en comandos (imports cruzados + constantes locales): FALLÓ")
         for item in failures:
             print(f" - {item}")
         return 1
 
-    print("✅ Lint imports cruzados entre comandos: OK")
+    print("✅ Lint de contratos en comandos (imports cruzados + constantes locales): OK")
     return 0
 
 

--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -20,8 +20,13 @@ from pcobra.core.semantic_validators import (
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.mode_policy import validar_politica_modo
-from pcobra.cobra.cli.transpiler_registry import cli_transpiler_targets
-from pcobra.cobra.transpilers import registry as transpiler_registry
+from pcobra.cobra.cli.transpiler_registry import (
+    cli_ensure_entrypoint_transpilers_loaded_once,
+    cli_load_entrypoint_transpilers,
+    cli_plugin_transpilers,
+    cli_register_transpiler_backend,
+    cli_transpiler_targets,
+)
 from pcobra.cobra.cli.deprecation_policy import (
     enforce_target_deprecation_policy,
     visible_public_targets,
@@ -43,7 +48,7 @@ LANG_CHOICES = cli_transpiler_targets()
 
 def register_transpiler_backend(backend: str, transpiler_cls, *, context: str) -> str:
     """Compatibilidad: delega registro de plugins al registro consolidado."""
-    return transpiler_registry.register_transpiler_backend(
+    return cli_register_transpiler_backend(
         backend,
         transpiler_cls,
         context=context,
@@ -52,12 +57,12 @@ def register_transpiler_backend(backend: str, transpiler_cls, *, context: str) -
 
 def load_entrypoint_transpilers() -> tuple[int, int, int]:
     """Compatibilidad: delega carga de entry points al registro consolidado."""
-    return transpiler_registry.load_entrypoint_transpilers()
+    return cli_load_entrypoint_transpilers()
 
 
 def _ensure_entrypoints_loaded_once() -> None:
     """Compatibilidad: delega carga idempotente al registro consolidado."""
-    transpiler_registry.ensure_entrypoint_transpilers_loaded_once()
+    cli_ensure_entrypoint_transpilers_loaded_once()
 
 def _validate_official_backend_or_raise(backend: str, *, context: str) -> str:
     """Validador único de backend oficial conectado a la matriz canónica."""
@@ -95,7 +100,7 @@ def _target_label(target: str) -> str:
 
 
 def _transpile_with_pipeline_or_plugin(ast, lang: str) -> str:
-    plugin_cls = transpiler_registry.plugin_transpilers().get(lang)
+    plugin_cls = cli_plugin_transpilers().get(lang)
     if plugin_cls is not None:
         return plugin_cls().generate_code(ast)
     return backend_pipeline.transpile(ast, lang)

--- a/src/pcobra/cobra/cli/transpiler_registry.py
+++ b/src/pcobra/cobra/cli/transpiler_registry.py
@@ -1,4 +1,15 @@
-"""Helpers CLI para consumir el registro canónico de transpiladores."""
+"""Contrato CLI para acceso a transpiladores.
+
+ÚNICA FUENTE:
+- Esta capa CLI debe consumir exclusivamente ``pcobra.cobra.transpilers.registry``.
+- Los comandos CLI no deben declarar catálogos locales de backends/transpiladores.
+- Los comandos CLI deben usar ``cli_transpilers()`` y/o ``cli_transpiler_targets()``
+  para obtener snapshots canónicos.
+
+Compatibilidad:
+- El ciclo de plugins/entrypoints se mantiene a través de
+  ``ensure_entrypoint_transpilers_loaded_once()``.
+"""
 
 from __future__ import annotations
 
@@ -8,7 +19,10 @@ from typing import Mapping
 from pcobra.cobra.transpilers.registry import (
     ensure_entrypoint_transpilers_loaded_once,
     get_transpilers,
+    load_entrypoint_transpilers,
     official_transpiler_targets,
+    plugin_transpilers,
+    register_transpiler_backend,
 )
 
 
@@ -21,3 +35,24 @@ def cli_transpilers() -> Mapping[str, type]:
 def cli_transpiler_targets() -> tuple[str, ...]:
     """Devuelve los targets públicos canónicos para ``choices`` en CLI."""
     return official_transpiler_targets()
+
+
+def cli_ensure_entrypoint_transpilers_loaded_once() -> None:
+    """Garantiza (idempotente) la carga de transpiladores registrados por entrypoints."""
+    ensure_entrypoint_transpilers_loaded_once()
+
+
+def cli_plugin_transpilers() -> Mapping[str, type]:
+    """Devuelve el mapping de transpiladores registrados por plugins."""
+    ensure_entrypoint_transpilers_loaded_once()
+    return MappingProxyType(plugin_transpilers())
+
+
+def cli_register_transpiler_backend(backend: str, transpiler_cls, *, context: str) -> str:
+    """Registra un backend de plugin delegando al registro canónico."""
+    return register_transpiler_backend(backend, transpiler_cls, context=context)
+
+
+def cli_load_entrypoint_transpilers() -> tuple[int, int, int]:
+    """Carga explícita de entrypoints, manteniendo contrato legacy de retorno."""
+    return load_entrypoint_transpilers()

--- a/tests/unit/test_ci_lint_no_cross_command_imports.py
+++ b/tests/unit/test_ci_lint_no_cross_command_imports.py
@@ -31,3 +31,29 @@ def test_permite_import_desde_base(tmp_path: Path) -> None:
     violations = find_violations(tmp_path)
 
     assert violations == []
+
+
+def test_detecta_import_directo_registry_en_comando(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "a.py",
+        "from pcobra.cobra.transpilers.registry import get_transpilers\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "import directo no permitido" in violations[0]
+    assert "src/pcobra/cobra/cli/commands/a.py:1" in violations[0]
+
+
+def test_detecta_constante_transpilers_en_comando(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "a.py",
+        "TRANSPILERS = {'python': object()}\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "constante local no permitida en comandos (TRANSPILERS)" in violations[0]
+    assert "src/pcobra/cobra/cli/commands/a.py:1" in violations[0]

--- a/tests/unit/test_cli_commands_no_local_transpilers_constant_contract.py
+++ b/tests/unit/test_cli_commands_no_local_transpilers_constant_contract.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _has_transpilers_dict_literal(path: Path) -> list[int]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    lines: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+                continue
+            if node.targets[0].id != "TRANSPILERS":
+                continue
+            if isinstance(node.value, ast.Dict):
+                lines.append(node.lineno)
+        elif isinstance(node, ast.AnnAssign):
+            if not isinstance(node.target, ast.Name):
+                continue
+            if node.target.id != "TRANSPILERS":
+                continue
+            if isinstance(node.value, ast.Dict):
+                lines.append(node.lineno)
+    return lines
+
+
+def test_commands_contract_no_local_transpilers_dict_literal() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    commands_dir = repo_root / "src" / "pcobra" / "cobra" / "cli" / "commands"
+
+    violations: list[str] = []
+    for path in sorted(commands_dir.rglob("*.py")):
+        lines = _has_transpilers_dict_literal(path)
+        rel = path.relative_to(repo_root)
+        for line in lines:
+            violations.append(f"{rel}:{line}")
+
+    assert violations == [], (
+        "Contrato CLI roto: no se permite `TRANSPILERS = {...}` en comandos. "
+        f"Encontrado en: {violations}"
+    )


### PR DESCRIPTION
### Motivation

- Forzar que la capa CLI consuma la fuente canónica de transpiladores (`pcobra.cobra.transpilers.registry`) y evitar catálogos locales dentro de comandos que introduzcan divergencias. 
- Evitar imports directos al registry o la aparición de constantes literales de backends/transpiladores en `src/pcobra/cobra/cli/commands` para mantener un único punto de verdad y facilitar la compatibilidad con plugins/entrypoints.

### Description

- Documenté explícitamente el contrato en `src/pcobra/cobra/cli/transpiler_registry.py` y añadí helpers de superficie CLI: `cli_transpilers()`, `cli_transpiler_targets()`, `cli_ensure_entrypoint_transpilers_loaded_once()`, `cli_plugin_transpilers()`, `cli_register_transpiler_backend()` y `cli_load_entrypoint_transpilers()` para mantener compatibilidad con plugins/entrypoints.
- Reemplacé usos directos del registro canónico en `src/pcobra/cobra/cli/commands/compile_cmd.py` para consumir únicamente los helpers de la capa CLI (`cli_plugin_transpilers()`, `cli_transpiler_targets()`, `cli_ensure_entrypoint_transpilers_loaded_once()` y wrappers de carga/registro).
- Extendí el lint CI existente `scripts/ci/lint_no_cross_command_imports.py` para que además de bloquear imports cruzados entre comandos, también:
  - detecte y bloquee imports directos a `pcobra.cobra.transpilers.registry` / `cobra.transpilers.registry` desde comandos, y
  - detecte y bloquee constantes locales literales relacionadas con backends/transpiladores (`TRANSPILERS`, `BACKENDS`, `LANG_CHOICES`, `LANGUAGES`) dentro de `src/pcobra/cobra/cli/commands`.
- Añadí/extendí tests: amplío `tests/unit/test_ci_lint_no_cross_command_imports.py` para cubrir import directo al registry y la constante `TRANSPILERS`, y añadí `tests/unit/test_cli_commands_no_local_transpilers_constant_contract.py` que falla si existe `TRANSPILERS = {...}` en comandos.

### Testing

- Ejecuté `python scripts/ci/lint_no_cross_command_imports.py` y la verificación local devolvió `OK`.
- Ejecuté `pytest -q tests/unit/test_ci_lint_no_cross_command_imports.py tests/unit/test_cli_commands_no_local_transpilers_constant_contract.py tests/unit/test_bench_transpilers_cmd.py tests/unit/test_compile_backend_registration.py` y todos los tests pasaron (`19 passed`).
- Ejecuté `pytest -q tests/unit/test_cli_official_language_restrictions.py tests/unit/test_compile_cmd_target_choices_aliases.py` y hubo fallos (5 failed) por aserciones sobre conjuntos/orden de `OFFICIAL_TARGETS` en el entorno actual; estos parecen corresponder a expectativas de targets oficiales en este checkout y no a las reglas de lint/consumo implementadas en este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77c33597483279a502ba71ecb9a68)