### PR TITLE
Restringe distribución a `pcobra*` y añade pruebas de contrato de imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,11 +102,6 @@ package-dir = {"" = "src"}
 where = ["src"]
 include = [
     "pcobra*",
-    "cobra*",
-    "core*",
-    "cli*",
-    "lsp*",
-    "bindings*",
 ]
 exclude = [
     "*.tests",

--- a/tests/unit/test_cli_startup_import_contract.py
+++ b/tests/unit/test_cli_startup_import_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+import tomllib
 
 
 def test_cli_bootstrap_no_importa_comandos_directamente() -> None:
@@ -26,3 +27,26 @@ def test_cli_bootstrap_no_importa_comandos_directamente() -> None:
                 offenders.append(module)
 
     assert offenders == []
+
+
+def test_distribucion_publica_no_expone_namespaces_legacy() -> None:
+    pyproject_path = Path("pyproject.toml")
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+    package_find = data["tool"]["setuptools"]["packages"]["find"]
+    include = package_find.get("include", [])
+
+    assert include == ["pcobra*"]
+    assert "cobra*" not in include
+    assert "core*" not in include
+    assert "cli*" not in include
+    assert "lsp*" not in include
+    assert "bindings*" not in include
+
+
+def test_script_entrypoint_cobra_se_mantiene_en_pcobra_cli_main() -> None:
+    pyproject_path = Path("pyproject.toml")
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+    scripts = data["project"]["scripts"]
+    assert scripts["cobra"] == "pcobra.cli:main"


### PR DESCRIPTION
### Motivation
- Limitar el contrato público de la distribución para exponer únicamente el namespace principal `pcobra*` y evitar empaquetado masivo de nombres legacy.
- Forzar que las compatibilidades legacy se ofrezcan mediante wrappers/shims controlados y no por inclusión automática de múltiples namespaces.
- Asegurar que el entrypoint CLI `cobra` continúe apuntando a `pcobra.cli:main` para no romper integraciones existentes.

### Description
- Actualiza `[tool.setuptools.packages.find].include` en `pyproject.toml` para dejar solo `"pcobra*"` y eliminar los includes legacy (`cobra*`, `core*`, `cli*`, `lsp*`, `bindings*`).
- Añade import de `tomllib` y dos pruebas nuevas en `tests/unit/test_cli_startup_import_contract.py`: `test_distribucion_publica_no_expone_namespaces_legacy` que falla si reaparecen los includes legacy, y `test_script_entrypoint_cobra_se_mantiene_en_pcobra_cli_main` que valida el entrypoint `cobra`.
- Cambios realizados en los archivos `pyproject.toml` y `tests/unit/test_cli_startup_import_contract.py` para reforzar el contrato de imports.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_startup_import_contract.py` que devolvió `3 passed` y todas las pruebas del archivo pasaron correctamente.
- La suite de pruebas añadida verifica explícitamente el contenido de `tool.setuptools.packages.find.include` y la entrada `project.scripts.cobra` en `pyproject.toml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e796fa924c83278fc62fa55dfba573)