### PR TITLE
Consolidar `pcobra.cobra` como fuente única y añadir guardia CI para shims legacy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,8 @@ jobs:
         run: python scripts/ci/lint_public_no_direct_transpiler_imports.py
       - name: Lint legacy bindings imports in src
         run: python scripts/ci/lint_no_legacy_bindings_imports.py
+      - name: Lint legacy cobra tree is shim-only
+        run: python scripts/ci/lint_legacy_cobra_shims.py
       - name: Gate de arquitectura de imports (ciclos y capas)
         shell: bash
         run: python scripts/ci/check_import_cycles.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,8 @@ jobs:
         run: python scripts/ci/lint_public_no_direct_transpiler_imports.py
       - name: Lint legacy bindings imports in src
         run: python scripts/ci/lint_no_legacy_bindings_imports.py
+      - name: Lint legacy cobra tree is shim-only
+        run: python scripts/ci/lint_legacy_cobra_shims.py
       - name: Gate de arquitectura de imports (ciclos y capas)
         run: python scripts/ci/check_import_cycles.py
       - name: Validate runtime contract matrix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,8 @@ jobs:
         run: python scripts/ci/validate_syntax_report_contract.py
       - name: Lint public surfaces without direct transpiler imports
         run: python scripts/ci/lint_public_no_direct_transpiler_imports.py
+      - name: Lint legacy cobra tree is shim-only
+        run: python scripts/ci/lint_legacy_cobra_shims.py
       - name: Gate de arquitectura de imports (ciclos y capas)
         run: python scripts/ci/check_import_cycles.py
       - name: Validate runtime contract matrix

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -66,3 +66,4 @@ La resolución de imports usa prioridad determinista (`stdlib > project > python
 - `src/pcobra/cobra/imports/resolver.py`
 - `src/pcobra/cobra/transpilers/module_map.py`
 - `docs/architecture/backend-pipeline-checklist.md`
+- `docs/architecture/single_source_of_truth.md`

--- a/docs/architecture/single_source_of_truth.md
+++ b/docs/architecture/single_source_of_truth.md
@@ -1,0 +1,52 @@
+# Política de arquitectura: single source of truth (`pcobra.cobra`)
+
+## Objetivo
+
+Desde este cambio, **`src/pcobra/cobra/**` es la única implementación productiva** de Cobra.
+El árbol `src/cobra/**` queda reservado exclusivamente para compatibilidad hacia atrás
+(shims/reexports).
+
+## Inventario actual de duplicados
+
+Se inventarió cada módulo Python presente en `src/cobra/**` y su espejo en
+`src/pcobra/cobra/**`.
+
+| Módulo legacy (`src/cobra`) | Módulo canónico (`src/pcobra/cobra`) | Estado |
+| --- | --- | --- |
+| `transpilers/registry.py` | `transpilers/registry.py` | Shim por reexport (sin lógica productiva) |
+| `transpilers/targets.py` | `transpilers/targets.py` | Shim por reexport (sin lógica productiva) |
+| `transpilers/compatibility_matrix.py` | `transpilers/compatibility_matrix.py` | Shim por reexport (sin lógica productiva) |
+| `transpilers/__init__.py` | `transpilers/__init__.py` | Shim por reexport |
+| `cli/target_policies.py` | `cli/target_policies.py` | Shim por reexport |
+| `cli/__init__.py` | `cli/__init__.py` | Shim mínimo por reexport |
+| `cli/cli.py` | `cli/cli.py` | Wrapper legacy de entrada (bootstrap de CLI) |
+| `__init__.py` | `__init__.py` | Bootstrap de paquete legacy (alias compat) |
+
+## Reglas de mantenimiento
+
+1. Toda lógica nueva debe vivir en `src/pcobra/cobra/**`.
+2. `src/cobra/**` no puede contener nuevas implementaciones funcionales.
+3. Los módulos legacy deben limitarse a:
+   - docstring,
+   - import/reexport hacia `pcobra.cobra.*`,
+   - y opcionalmente `__all__`.
+4. Excepciones permitidas de bootstrap legacy:
+   - `src/cobra/__init__.py`,
+   - `src/cobra/cli/cli.py`.
+
+## Empaquetado
+
+El empaquetado oficial ya excluye `cobra*` y publica únicamente `pcobra*`.
+Por tanto, los módulos de `src/cobra/**` se mantienen sólo para compatibilidad en
+entornos de desarrollo/migración interna.
+
+## Guardia CI
+
+Se añade `scripts/ci/lint_legacy_cobra_shims.py`, que falla si:
+
+- aparece un módulo en `src/cobra/**` sin espejo en `src/pcobra/cobra/**`,
+- un módulo legacy (salvo bootstraps exentos) contiene código más allá de reexports,
+- o un shim no reexporta explícitamente desde `pcobra.cobra.*`.
+
+Esta guardia protege la política de **single source of truth** y evita divergencias
+silenciosas entre ambos árboles.

--- a/scripts/ci/lint_legacy_cobra_shims.py
+++ b/scripts/ci/lint_legacy_cobra_shims.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Garantiza que `src/cobra/**` sea solo una capa shim sin implementación productiva."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LEGACY_ROOT = ROOT / "src" / "cobra"
+CANONICAL_ROOT = ROOT / "src" / "pcobra" / "cobra"
+EXEMPT_BOOTSTRAP_MODULES = {Path("__init__.py"), Path("cli/cli.py")}
+
+
+def _is_docstring_expr(node: ast.stmt) -> bool:
+    if not isinstance(node, ast.Expr):
+        return False
+    value = node.value
+    if isinstance(value, ast.Constant):
+        return isinstance(value.value, str)
+    return isinstance(value, ast.Str)
+
+
+def _is_allowed_shim_statement(node: ast.stmt) -> bool:
+    if isinstance(node, (ast.Import, ast.ImportFrom)):
+        return True
+    if isinstance(node, ast.Assign):
+        return any(isinstance(target, ast.Name) and target.id == "__all__" for target in node.targets)
+    if isinstance(node, ast.AnnAssign):
+        target = node.target
+        return isinstance(target, ast.Name) and target.id == "__all__"
+    return False
+
+
+def _has_corresponding_canonical_module(path: Path) -> bool:
+    rel = path.relative_to(LEGACY_ROOT)
+    return (CANONICAL_ROOT / rel).exists()
+
+
+def find_violations(root: Path = ROOT) -> list[str]:
+    legacy_root = root / "src" / "cobra"
+    canonical_root = root / "src" / "pcobra" / "cobra"
+    failures: list[str] = []
+
+    if not legacy_root.exists():
+        return failures
+    if not canonical_root.exists():
+        failures.append("src/pcobra/cobra no existe; no hay source of truth canónico.")
+        return failures
+
+    for path in sorted(legacy_root.rglob("*.py")):
+        rel = path.relative_to(root)
+        legacy_rel = path.relative_to(legacy_root)
+
+        if legacy_rel in EXEMPT_BOOTSTRAP_MODULES:
+            continue
+        if not _has_corresponding_canonical_module(path):
+            failures.append(
+                f"{rel}: no tiene módulo canónico espejo en src/pcobra/cobra; "
+                "no se permiten implementaciones exclusivas en src/cobra."
+            )
+            continue
+
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        body = list(tree.body)
+        if body and _is_docstring_expr(body[0]):
+            body = body[1:]
+
+        has_canonical_import = False
+        for node in body:
+            if not _is_allowed_shim_statement(node):
+                failures.append(
+                    f"{rel}:{node.lineno}: solo se permiten shims (imports y __all__)."
+                )
+                continue
+            if isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("pcobra.cobra"):
+                has_canonical_import = True
+            if isinstance(node, ast.Import):
+                if any(alias.name.startswith("pcobra.cobra") for alias in node.names):
+                    has_canonical_import = True
+
+        if not has_canonical_import:
+            failures.append(
+                f"{rel}: shim inválido; debe reexportar explícitamente desde pcobra.cobra.*"
+            )
+
+    return failures
+
+
+def main() -> int:
+    if not LEGACY_ROOT.exists():
+        print("✅ Lint legacy cobra shims: src/cobra/ no existe, se omite.")
+        return 0
+
+    failures = find_violations(ROOT)
+    if failures:
+        print("❌ Lint legacy cobra shims: FALLÓ")
+        for item in failures:
+            print(f" - {item}")
+        return 1
+
+    print("✅ Lint legacy cobra shims: OK (src/cobra/** sólo contiene reexports).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cobra/cli/__init__.py
+++ b/src/cobra/cli/__init__.py
@@ -1,15 +1,6 @@
-"""INTERNAL COMPATIBILITY ONLY. Shim histórico mínimo para :mod:`pcobra.cobra.cli`.
+"""INTERNAL COMPATIBILITY ONLY. Shim histórico mínimo para ``cobra.cli``.
 
 Ruta canónica runtime: ``src/pcobra/cobra/cli``.
-Este módulo sólo existe para compatibilidad hacia atrás.
 """
 
-from importlib import import_module
-import sys as _sys
-
-_target = import_module("pcobra.cobra.cli")
-_sys.modules.setdefault("pcobra.cobra.cli", _target)
-_sys.modules.setdefault(__name__, _target)
-__all__ = getattr(_target, "__all__", [])
-for _name in __all__:
-    globals()[_name] = getattr(_target, _name)
+from pcobra.cobra.cli import *  # noqa: F401,F403

--- a/tests/unit/test_ci_lint_legacy_cobra_shims_guard.py
+++ b/tests/unit/test_ci_lint_legacy_cobra_shims_guard.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_ci_lint_legacy_cobra_shims_guard_passes_on_repo() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "scripts/ci/lint_legacy_cobra_shims.py"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
### Motivation

- Evitar divergencias y duplicación de lógica entre `src/cobra/**` y `src/pcobra/cobra/**` estableciendo un único origen de verdad. 
- Mantener `src/cobra/**` solo como capa de compatibilidad (shims/reexports) para no introducir implementación productiva en el árbol legacy. 
- Automatizar la protección arquitectónica mediante un gate CI que detecte nuevas implementaciones divergentes o shims inválidos.

### Description

- Se añadió el documento de arquitectura `docs/architecture/single_source_of_truth.md` que inventaría duplicados y formaliza la política de `pcobra.cobra` como fuente canónica. 
- Se creó el lint de CI `scripts/ci/lint_legacy_cobra_shims.py` que valida que `src/cobra/**` solo contenga shims (imports/reexports y `__all__`) y que cada módulo legacy tenga espejo en `src/pcobra/cobra/**`, con exenciones para bootstrap (`src/cobra/__init__.py` y `src/cobra/cli/cli.py`). 
- Se simplificó el shim legacy `src/cobra/cli/__init__.py` a un reexport mínimo (`from pcobra.cobra.cli import *`). 
- Se integró el nuevo lint en los workflows `.github/workflows/lint.yml`, `.github/workflows/ci.yml` y `.github/workflows/test.yml`, y se añadió el test de guardia `tests/unit/test_ci_lint_legacy_cobra_shims_guard.py` para ejecutar el script en CI. 

### Testing

- Ejecuté `python scripts/ci/lint_legacy_cobra_shims.py` localmente y su salida fue de éxito (`OK`).
- Ejecuté `pytest -q tests/unit/test_ci_lint_legacy_cobra_shims_guard.py tests/unit/test_ci_lint_no_legacy_bindings_imports_guard.py` y ambos tests pasaron (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7aaf7d7348327ae42675f6f9ba64c)