### PR TITLE
Harden CLI command import contract and docs

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -46,6 +46,23 @@ En la ruta pública, `cobra build` delega la elección del backend a `backend_pi
 
 `pcobra.cobra.build.backend_pipeline` se considera contrato interno inmutable para compile/transpile/runtime.
 
+## 2.1) Contrato de datos compartidos para CLI de comandos
+
+Para evitar divergencias entre comandos (`commands/` y `commands_v2/`), se define un
+contrato explícito de **únicos puntos autorizados** para catálogo de transpiladores:
+
+- `pcobra.cobra.transpilers.registry` → fuente canónica de inventario interno.
+- `pcobra.cobra.cli.transpiler_registry` → fachada obligatoria para consumo desde CLI.
+
+Reglas operativas:
+
+1. Los comandos CLI no deben declarar constantes locales tipo `TRANSPILERS`, `BACKENDS`,
+   `LANG_CHOICES` o `LANGUAGES`.
+2. Los comandos CLI no deben importar otros módulos `*_cmd.py` (solo se permite
+   compartir base común vía `commands.base`).
+3. Si un comando necesita targets/transpiladores, debe usar exclusivamente
+   `cli_transpilers()` y/o `cli_transpiler_targets()`.
+
 ## 3) Bindings (python/js/rust)
 
 Tras resolver backend, el pipeline valida capacidades/runtime y produce contexto de bridge (`route`, `bridge`, `abi_contract`, `abi_version`). Así la unión con runtime nativo queda encapsulada por contrato de ruta.

--- a/scripts/ci/lint_no_cross_command_imports.py
+++ b/scripts/ci/lint_no_cross_command_imports.py
@@ -19,7 +19,9 @@ COMMAND_SCOPES = (
 )
 FORBIDDEN_PREFIXES = (
     "pcobra.cobra.cli.commands",
+    "pcobra.cobra.cli.commands_v2",
     "cobra.cli.commands",
+    "cobra.cli.commands_v2",
 )
 FORBIDDEN_DIRECT_REGISTRY_IMPORTS = {
     "pcobra.cobra.transpilers.registry",
@@ -63,6 +65,30 @@ def _scan_file(path: Path) -> list[tuple[int, str]]:
             if _is_forbidden_import_from(node):
                 label = node.module or "<relative>"
                 violations.append((node.lineno, label))
+    return violations
+
+
+def _scan_cross_cmd_pattern_imports(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if not module.endswith("_cmd"):
+                continue
+            for prefix in FORBIDDEN_PREFIXES:
+                if module.startswith(f"{prefix}."):
+                    violations.append((node.lineno, module))
+                    break
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                module = alias.name
+                if not module.endswith("_cmd"):
+                    continue
+                for prefix in FORBIDDEN_PREFIXES:
+                    if module.startswith(f"{prefix}."):
+                        violations.append((node.lineno, module))
+                        break
     return violations
 
 
@@ -130,11 +156,17 @@ def find_violations(root: Path = ROOT) -> list[str]:
             continue
         for path in sorted(scope.rglob("*.py")):
             rel = path.relative_to(root)
-            for line, target in _scan_file(path):
-                failures.append(
-                    f"{rel}:{line}: import entre comandos no permitido ({target}); "
-                    "extrae código a un servicio compartido o usa commands.base"
-                )
+            if path.name != "__init__.py":
+                for line, target in _scan_file(path):
+                    failures.append(
+                        f"{rel}:{line}: import entre comandos no permitido ({target}); "
+                        "extrae código a un servicio compartido o usa commands.base"
+                    )
+                for line, target in _scan_cross_cmd_pattern_imports(path):
+                    failures.append(
+                        f"{rel}:{line}: patrón *_cmd no permitido ({target}); "
+                        "los comandos no deben importar otros *_cmd.py (solo commands.base)"
+                    )
             for line, target in _scan_direct_registry_imports(path):
                 failures.append(
                     f"{rel}:{line}: import directo no permitido ({target}); "

--- a/tests/unit/test_ci_lint_no_cross_command_imports.py
+++ b/tests/unit/test_ci_lint_no_cross_command_imports.py
@@ -18,8 +18,22 @@ def test_detecta_import_entre_comandos(tmp_path: Path) -> None:
 
     violations = find_violations(tmp_path)
 
-    assert len(violations) == 1
-    assert "src/pcobra/cobra/cli/commands/a.py:1" in violations[0]
+    assert any("import entre comandos no permitido" in item for item in violations)
+    assert any("patrón *_cmd no permitido" in item for item in violations)
+    assert any("src/pcobra/cobra/cli/commands/a.py:1" in item for item in violations)
+
+
+def test_detecta_import_entre_comandos_v2(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands_v2" / "run_cmd.py",
+        "from pcobra.cobra.cli.commands_v2.build_cmd import BuildCommandV2\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert any("import entre comandos no permitido" in item for item in violations)
+    assert any("patrón *_cmd no permitido" in item for item in violations)
+    assert any("src/pcobra/cobra/cli/commands_v2/run_cmd.py:1" in item for item in violations)
 
 
 def test_permite_import_desde_base(tmp_path: Path) -> None:
@@ -41,7 +55,6 @@ def test_detecta_import_directo_registry_en_comando(tmp_path: Path) -> None:
 
     violations = find_violations(tmp_path)
 
-    assert len(violations) == 1
     assert "import directo no permitido" in violations[0]
     assert "src/pcobra/cobra/cli/commands/a.py:1" in violations[0]
 


### PR DESCRIPTION
### Motivation

- Formalizar el contrato de la CLI para que `pcobra.cobra.transpilers.registry` y `pcobra.cobra.cli.transpiler_registry` sean las únicas fuentes canónicas para catálogo de transpiladores en la CLI. 
- Evitar dependencias accidentales entre módulos de comandos y prevenir tablas/constantes locales que diverjan del registro canónico. 
- Cubrir tanto el árbol legacy `commands` como `commands_v2` con guardias automáticas en CI. 

### Description

- Extiende `scripts/ci/lint_no_cross_command_imports.py` para incluir los prefijos de `commands_v2` en `FORBIDDEN_PREFIXES` y escanear ambos scopes. 
- Añade una nueva regla `_scan_cross_cmd_pattern_imports` que detecta imports explícitos a módulos `*_cmd.py` (tanto `import` como `from ... import ...`) y produce un mensaje específico de violación. 
- Evita romper el patrón agregador del paquete al excluir `__init__.py` de los chequeos de import entre comandos. 
- Actualiza `tests/unit/test_ci_lint_no_cross_command_imports.py` para cubrir detección de `*_cmd` y añadir un caso para `commands_v2`, y actualiza `docs/architecture/overview.md` para documentar los puntos de datos compartidos y las reglas operativas de la CLI. 

### Testing

- Ejecutado `python scripts/ci/lint_no_cross_command_imports.py` y la verificación devolvió OK. 
- Ejecutado `pytest -q tests/unit/test_ci_lint_no_cross_command_imports.py` y los tests unitarios pasaron (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b1e0cc70832782fd75746a6a3ab5)