### PR TITLE
Add CI lint to enforce import-resolution contract (ban legacy aliases in src/pcobra)

### DIFF
--- a/docs/architecture/import-resolution-contract.md
+++ b/docs/architecture/import-resolution-contract.md
@@ -172,3 +172,14 @@ Migraciones sugeridas (casos reales frecuentes):
      - app explícita: `importar app.json`
 
 Esta convención minimiza deuda de migración y evita depender de precedencia implícita en conflictos.
+
+## 7) Contrato de imports en runtime productivo (sin aliases legacy)
+
+Regla operativa obligatoria para código Python del runtime (`src/pcobra/**`):
+
+- El runtime productivo debe importar siempre desde rutas canónicas `pcobra.cobra.*`.
+- No se permite depender de aliases legacy como `bindings.*`, `import bindings` o `from cobra.*` en módulos productivos.
+- Las únicas excepciones válidas son módulos dedicados de compatibilidad explícitamente marcados para migración (por ejemplo, capas `internal_compat` o archivos con marcador de compatibilidad).
+
+Este contrato se valida en CI mediante `scripts/ci/lint_import_resolution_contract.py` y su test guard en `tests/unit/test_ci_lint_import_resolution_contract_guard.py`.
+

--- a/scripts/ci/lint_import_resolution_contract.py
+++ b/scripts/ci/lint_import_resolution_contract.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Valida que `src/pcobra/**/*.py` use imports canónicos y no aliases legacy."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCAN_ROOT = ROOT / "src" / "pcobra"
+
+ALLOWLIST_DIR_SUFFIXES = (
+    Path("cobra/internal_compat"),
+    Path("cobra/cli/internal_compat"),
+)
+COMPAT_MARKER = "pcobra-compat: allow-legacy-imports"
+
+
+class LegacyImportVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.violations: list[tuple[int, str]] = []
+
+    def visit_Import(self, node: ast.Import) -> None:  # noqa: N802
+        for alias in node.names:
+            target = alias.name
+            if target == "bindings" or target.startswith("bindings."):
+                self.violations.append((node.lineno, f"import legacy no permitido: {target}"))
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802
+        if node.level:
+            self.generic_visit(node)
+            return
+
+        module = node.module or ""
+        if module == "bindings" or module.startswith("bindings."):
+            self.violations.append((node.lineno, f"import legacy no permitido: from {module}"))
+        if module == "cobra" or module.startswith("cobra."):
+            self.violations.append((node.lineno, f"import legacy no permitido: from {module}"))
+        self.generic_visit(node)
+
+
+def _is_compat_module(path: Path, root: Path) -> bool:
+    rel_to_scan = path.relative_to(root / "src" / "pcobra")
+    if any(rel_to_scan.is_relative_to(suffix) for suffix in ALLOWLIST_DIR_SUFFIXES):
+        return True
+
+    header = "\n".join(path.read_text(encoding="utf-8").splitlines()[:20])
+    return COMPAT_MARKER in header
+
+
+def find_violations(root: Path = ROOT) -> list[str]:
+    scan_root = root / "src" / "pcobra"
+    failures: list[str] = []
+    if not scan_root.exists():
+        return failures
+
+    for path in sorted(scan_root.rglob("*.py")):
+        if _is_compat_module(path, root):
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        visitor = LegacyImportVisitor()
+        visitor.visit(tree)
+        for lineno, reason in visitor.violations:
+            rel = path.relative_to(root)
+            failures.append(
+                f"{rel}:{lineno}: {reason}; usa pcobra.cobra.* y rutas canónicas en producción"
+            )
+
+    return failures
+
+
+def main() -> int:
+    if not SCAN_ROOT.exists():
+        print("⚠️ Lint import-resolution-contract: src/pcobra/ no existe, se omite.")
+        return 0
+
+    failures = find_violations(ROOT)
+    if failures:
+        print("❌ Lint import-resolution-contract: FALLÓ")
+        for item in failures:
+            print(f" - {item}")
+        return 1
+
+    print("✅ Lint import-resolution-contract: OK (sin imports legacy en src/pcobra).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_ci_lint_import_resolution_contract.py
+++ b/tests/unit/test_ci_lint_import_resolution_contract.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.ci.lint_import_resolution_contract import find_violations
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_detecta_import_legacy_bindings_y_cobra(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "foo.py",
+        "from bindings.contract import resolve_binding\nfrom cobra.cli import run\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert len(violations) == 2
+    assert any("from bindings.contract" in item for item in violations)
+    assert any("from cobra.cli" in item for item in violations)
+
+
+def test_permite_import_canonico_pcobra(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "foo.py",
+        "from pcobra.cobra.bindings.contract import resolve_binding\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert violations == []
+
+
+def test_permite_modulo_marcado_como_compatibilidad(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "legacy_bridge.py",
+        "# pcobra-compat: allow-legacy-imports\nfrom cobra.cli import run\nimport bindings\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert violations == []

--- a/tests/unit/test_ci_lint_import_resolution_contract_guard.py
+++ b/tests/unit/test_ci_lint_import_resolution_contract_guard.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_ci_lint_import_resolution_contract_guard_passes_on_repo() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "scripts/ci/lint_import_resolution_contract.py"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
### Motivation

- Evitar que el runtime productivo dependa de aliases legacy (`bindings.*`, `cobra.*`) y forzar el uso de rutas canónicas `pcobra.cobra.*` en `src/pcobra/**`.
- Detectar y prevenir regresiones mediante una verificación automática en CI y dejar el contrato explícito en la documentación.

### Description

- Añade `scripts/ci/lint_import_resolution_contract.py`, un lint AST que escanea `src/pcobra/**/*.py` y falla si encuentra `from bindings...`, `import bindings` o `from cobra...` en módulos productivos, con mensaje que recomienda usar `pcobra.cobra.*`.
- Permite excepciones únicamente para módulos de compatibilidad dedicados `src/pcobra/cobra/internal_compat/**`, `src/pcobra/cobra/cli/internal_compat/**` o archivos con el marcador `# pcobra-compat: allow-legacy-imports` en la cabecera.
- Añade pruebas de contrato en `tests/unit/test_ci_lint_import_resolution_contract.py` que cubren detección de imports legacy, aceptación de imports canónicos y aceptación de módulos marcados como compatibilidad.
- Añade el guard CI `tests/unit/test_ci_lint_import_resolution_contract_guard.py` que ejecuta el script real sobre el repositorio.
- Documenta el contrato en `docs/architecture/import-resolution-contract.md` con una sección nueva que exige imports canónicos en runtime productivo y explica las excepciones.

### Testing

- Ejecuté `pytest -q tests/unit/test_ci_lint_import_resolution_contract.py tests/unit/test_ci_lint_import_resolution_contract_guard.py` y ambas pruebas unitarias pasaron (`4 passed`).
- El guard test ejecuta el script sobre el repo y confirmó retorno `0` durante la validación automática en los tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7bdc65c388327a7e3c13a5318b06b)