### PR TITLE
Refactor CLI run/test/mod to use stable DTO contracts

### DIFF
--- a/docs/architecture/cli_input_output_contracts.md
+++ b/docs/architecture/cli_input_output_contracts.md
@@ -1,0 +1,61 @@
+# Contrato de entrada/salida de servicios CLI (run/test/mod)
+
+Este documento define el **Single Source of Truth** para la entrada de servicios de aplicación usados por:
+
+- CLI pública v2 (`cobra run`, `cobra test`, `cobra mod`)
+- CLI legacy (`ejecutar`, `verificar`, `modulos`)
+- grupo `legacy` en UI v2
+- invocaciones programáticas (scripts internos/REPL)
+
+## Objetivo
+
+Evitar divergencias entre capas de parsing (`argparse`) y capa de aplicación.  
+Los servicios **no consumen `argparse.Namespace`**, consumen DTOs estables.
+
+## DTOs canónicos
+
+Ubicación: `src/pcobra/cobra/cli/services/contracts.py`.
+
+- `RunRequest`
+  - Entrada mínima: `archivo`
+  - Campos opcionales/defaults: `debug=False`, `sandbox=False`, `contenedor=None`, `formatear=False`, `modo="mixto"`, `seguro=True`, `verbose=0`, `depurar=False`, `extra_validators=None`, `allow_insecure_fallback=False`, `backend_reason=None`.
+
+- `TestRequest`
+  - Entrada mínima: `archivo`, `lenguajes`
+  - Campos opcionales/defaults: `modo="mixto"`, `backend_reason=None`.
+
+- `ModRequest`
+  - Entrada mínima: `accion`
+  - Reglas por acción:
+    - `instalar|publicar` requieren `ruta`
+    - `remover|buscar` requieren `nombre`
+
+## Normalización (una función por DTO)
+
+- `normalize_run_request(...)`
+- `normalize_test_request(...)`
+- `normalize_mod_request(...)`
+
+Cada función aplica:
+
+1. validación de obligatorios,
+2. defaults,
+3. coerción básica de tipos,
+4. compatibilidad de alias de parser (`file`/`archivo`, `langs`/`lenguajes`, etc.).
+
+## Flujo recomendado
+
+1. El comando CLI parsea argumentos (`argparse`).
+2. El comando mapea explícitamente a DTO canónico.
+3. El servicio invoca su normalizador (defensa en profundidad).
+4. El servicio ejecuta la lógica y retorna código de salida (`int`).
+
+## Contrato de salida
+
+Los servicios `RunService`, `TestService`, `ModService` retornan:
+
+- `0`: éxito.
+- `1`: error funcional/validación/runtime manejado.
+
+No retornan estructuras ad-hoc; el canal de detalle es logging/mensajes CLI.
+

--- a/src/pcobra/cobra/cli/commands/execute_cmd.py
+++ b/src/pcobra/cobra/cli/commands/execute_cmd.py
@@ -4,6 +4,7 @@ from typing import Any
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.services.contracts import RunRequest
 from pcobra.cobra.cli.services.run_service import (
     LEGACY_SANDBOX_COMPAT_FLAG,
     RunService,
@@ -18,8 +19,10 @@ from pcobra.cobra.cli.target_policies import (
     OFFICIAL_RUNTIME_TARGETS_HELP,
     build_runtime_capability_message,
     parse_runtime_target,
+    resolve_docker_backend,
 )
 from pcobra.cobra.cli.utils.autocomplete import files_completer
+from pcobra.cobra.cli.utils.messages import mostrar_error
 
 sys.modules.setdefault("cli.commands.execute_cmd", sys.modules[__name__])
 RUNTIME_MANAGER = RuntimeManager()
@@ -64,4 +67,17 @@ class ExecuteCommand(BaseCommand):
         return parser
 
     def run(self, args: Any) -> int:
-        return self._service.run(args)
+        request = RunRequest(
+            archivo=args.archivo,
+            debug=bool(getattr(args, "debug", False)),
+            sandbox=bool(getattr(args, "sandbox", False)),
+            contenedor=getattr(args, "contenedor", None),
+            formatear=bool(getattr(args, "formatear", False)),
+            modo=getattr(args, "modo", "mixto"),
+            seguro=bool(getattr(args, "seguro", True)),
+            verbose=int(getattr(args, "verbose", 0) or 0),
+            depurar=bool(getattr(args, "depurar", False)),
+            extra_validators=getattr(args, "extra_validators", None),
+            allow_insecure_fallback=bool(getattr(args, "allow_insecure_fallback", False)),
+        )
+        return self._service.run(request)

--- a/src/pcobra/cobra/cli/commands/modules_cmd.py
+++ b/src/pcobra/cobra/cli/commands/modules_cmd.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.services.contracts import ModRequest
 from pcobra.cobra.cli.services.mod_service import (
     LOCK_FILE,
     LOCK_KEY,
@@ -47,4 +48,9 @@ class ModulesCommand(BaseCommand):
         return parser
 
     def run(self, args: Any) -> int:
-        return self._service.run(args)
+        request = ModRequest(
+            accion=getattr(args, "accion", ""),
+            ruta=getattr(args, "ruta", None),
+            nombre=getattr(args, "nombre", None),
+        )
+        return self._service.run(request)

--- a/src/pcobra/cobra/cli/commands/verify_cmd.py
+++ b/src/pcobra/cobra/cli/commands/verify_cmd.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.services.contracts import TestRequest
 from pcobra.cobra.cli.services.test_service import TestService
 from pcobra.cobra.cli.target_policies import (
     OFFICIAL_TRANSPILATION_TARGETS,
@@ -12,6 +13,7 @@ from pcobra.cobra.cli.target_policies import (
     parse_restricted_target_list,
 )
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
+from pcobra.cobra.cli.utils.messages import mostrar_error
 
 
 def _target_cli_choices(values: tuple[str, ...] | list[str]) -> tuple[str, ...]:
@@ -59,4 +61,9 @@ class VerifyCommand(BaseCommand):
         return parser
 
     def run(self, args: Any) -> int:
-        return self._service.run(args)
+        request = TestRequest(
+            archivo=args.archivo,
+            lenguajes=list(getattr(args, "lenguajes", []) or []),
+            modo=getattr(args, "modo", "mixto"),
+        )
+        return self._service.run(request)

--- a/src/pcobra/cobra/cli/commands_v2/legacy_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/legacy_cmd.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.services.command_factory import CommandFactory
+from pcobra.cobra.cli.services.contracts import ModRequest, RunRequest, TestRequest
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.public_command_policy import PROFILE_DEVELOPMENT, resolve_command_profile
 from pcobra.cobra.cli.utils import messages
@@ -84,7 +85,7 @@ class LegacyCommandGroupV2(BaseCommand):
             return 1
         if command == "ejecutar":
             return self._execute.run(
-                Namespace(
+                RunRequest(
                     archivo=args.archivo,
                     debug=getattr(args, "debug", False),
                     sandbox=getattr(args, "sandbox", False),
@@ -105,7 +106,7 @@ class LegacyCommandGroupV2(BaseCommand):
             )
         if command == "verificar":
             return self._verify.run(
-                Namespace(
+                TestRequest(
                     archivo=args.archivo,
                     lenguajes=getattr(args, "lenguajes", ""),
                     modo=getattr(args, "modo", "mixto"),
@@ -113,7 +114,7 @@ class LegacyCommandGroupV2(BaseCommand):
             )
         if command == "modulos":
             return self._modules.run(
-                Namespace(
+                ModRequest(
                     accion=getattr(args, "accion", None),
                     ruta=getattr(args, "ruta", None),
                     nombre=getattr(args, "nombre", None),

--- a/src/pcobra/cobra/cli/commands_v2/mod_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/mod_cmd.py
@@ -1,7 +1,7 @@
-from argparse import Namespace
 from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.cli.services.contracts import ModRequest
 from pcobra.cobra.cli.services.mod_service import ModService
 from pcobra.cobra.cli.i18n import _
 
@@ -45,9 +45,9 @@ class ModCommandV2(BaseCommand):
             "search": "buscar",
         }
         action = action_map.get(getattr(args, "action", ""), "")
-        legacy_args = Namespace(
+        request = ModRequest(
             accion=action,
             ruta=getattr(args, "path", None),
             nombre=getattr(args, "name", None),
         )
-        return self._service.run(legacy_args)
+        return self._service.run(request)

--- a/src/pcobra/cobra/cli/commands_v2/run_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/run_cmd.py
@@ -1,4 +1,4 @@
-from argparse import Namespace, SUPPRESS
+from argparse import SUPPRESS
 from typing import Any
 
 from pcobra.cobra.build import backend_pipeline
@@ -6,6 +6,7 @@ from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 from pcobra.cobra.architecture.contracts import assert_backend_allowed_for_scope
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
+from pcobra.cobra.cli.services.contracts import RunRequest
 from pcobra.cobra.cli.services.run_service import RunService
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.messages import mostrar_error
@@ -56,7 +57,7 @@ class RunCommandV2(BaseCommand):
             return 1
 
         resolution, _runtime = backend_pipeline.resolve_backend_runtime(args.file, {})
-        legacy_args = Namespace(
+        request = RunRequest(
             archivo=args.file,
             debug=bool(getattr(args, "debug", False)),
             sandbox=sandbox,
@@ -65,4 +66,4 @@ class RunCommandV2(BaseCommand):
             modo=getattr(args, "modo", "mixto"),
             backend_reason=resolution.reason_for(debug=debug),
         )
-        return self._service.run(legacy_args)
+        return self._service.run(request)

--- a/src/pcobra/cobra/cli/commands_v2/test_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/test_cmd.py
@@ -1,10 +1,11 @@
-from argparse import Namespace, SUPPRESS
+from argparse import SUPPRESS
 from typing import Any
 
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.architecture.contracts import assert_backend_allowed_for_scope
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
+from pcobra.cobra.cli.services.contracts import TestRequest
 from pcobra.cobra.cli.services.test_service import TestService
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.messages import mostrar_error
@@ -68,10 +69,10 @@ class TestCommandV2(BaseCommand):
                 return 1
 
         resolution, _runtime = backend_pipeline.resolve_backend_runtime(args.file, {})
-        legacy_args = Namespace(
+        request = TestRequest(
             archivo=args.file,
             lenguajes=langs,
             modo=getattr(args, "modo", "mixto"),
             backend_reason=resolution.reason_for(debug=debug),
         )
-        return self._service.run(legacy_args)
+        return self._service.run(request)

--- a/src/pcobra/cobra/cli/services/contracts.py
+++ b/src/pcobra/cobra/cli/services/contracts.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class RunRequest:
+    archivo: str
+    debug: bool = False
+    sandbox: bool = False
+    contenedor: str | None = None
+    formatear: bool = False
+    modo: str = "mixto"
+    backend_reason: str | None = None
+    seguro: bool = True
+    verbose: int = 0
+    depurar: bool = False
+    extra_validators: str | list[str] | None = None
+    allow_insecure_fallback: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class TestRequest:
+    archivo: str
+    lenguajes: list[str]
+    modo: str = "mixto"
+    backend_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ModRequest:
+    accion: str
+    ruta: str | None = None
+    nombre: str | None = None
+
+
+def _to_mapping(raw: Any) -> Mapping[str, Any]:
+    if isinstance(raw, Mapping):
+        return raw
+    if hasattr(raw, "__dict__"):
+        return vars(raw)
+    raise TypeError(f"No se puede normalizar request desde tipo: {type(raw)!r}")
+
+
+def normalize_run_request(raw: RunRequest | Mapping[str, Any] | Any) -> RunRequest:
+    if isinstance(raw, RunRequest):
+        if not raw.archivo:
+            raise ValueError("El campo 'archivo' es obligatorio")
+        return raw
+
+    payload = _to_mapping(raw)
+    archivo = str(payload.get("archivo") or payload.get("file") or "").strip()
+    if not archivo:
+        raise ValueError("El campo 'archivo' es obligatorio")
+
+    extra = payload.get("extra_validators")
+    if isinstance(extra, (str, Path)):
+        extra = str(extra)
+    elif isinstance(extra, list):
+        extra = [str(item) for item in extra]
+
+    return RunRequest(
+        archivo=archivo,
+        debug=bool(payload.get("debug", False)),
+        sandbox=bool(payload.get("sandbox", False)),
+        contenedor=payload.get("contenedor") or payload.get("container"),
+        formatear=bool(payload.get("formatear", False)),
+        modo=str(payload.get("modo", "mixto") or "mixto"),
+        backend_reason=payload.get("backend_reason"),
+        seguro=bool(payload.get("seguro", True)),
+        verbose=int(payload.get("verbose", 0) or 0),
+        depurar=bool(payload.get("depurar", False)),
+        extra_validators=extra,
+        allow_insecure_fallback=bool(payload.get("allow_insecure_fallback", False)),
+    )
+
+
+def normalize_test_request(raw: TestRequest | Mapping[str, Any] | Any) -> TestRequest:
+    if isinstance(raw, TestRequest):
+        archivo = str(raw.archivo or "").strip()
+        if not archivo:
+            raise ValueError("El campo 'archivo' es obligatorio")
+        if isinstance(raw.lenguajes, str):
+            lenguajes = [lang.strip() for lang in raw.lenguajes.split(",") if lang.strip()]
+        else:
+            lenguajes = [str(lang).strip() for lang in raw.lenguajes if str(lang).strip()]
+        if not lenguajes:
+            raise ValueError("El campo 'lenguajes' es obligatorio")
+        return TestRequest(
+            archivo=archivo,
+            lenguajes=lenguajes,
+            modo=str(raw.modo or "mixto"),
+            backend_reason=raw.backend_reason,
+        )
+
+    payload = _to_mapping(raw)
+    archivo = str(payload.get("archivo") or payload.get("file") or "").strip()
+    if not archivo:
+        raise ValueError("El campo 'archivo' es obligatorio")
+
+    raw_langs = payload.get("lenguajes")
+    if raw_langs is None:
+        raw_langs = payload.get("langs")
+    if isinstance(raw_langs, str):
+        lenguajes = [lang.strip() for lang in raw_langs.split(",") if lang.strip()]
+    else:
+        lenguajes = [str(lang).strip() for lang in (raw_langs or []) if str(lang).strip()]
+
+    if not lenguajes:
+        raise ValueError("El campo 'lenguajes' es obligatorio")
+
+    return TestRequest(
+        archivo=archivo,
+        lenguajes=lenguajes,
+        modo=str(payload.get("modo", "mixto") or "mixto"),
+        backend_reason=payload.get("backend_reason"),
+    )
+
+
+def normalize_mod_request(raw: ModRequest | Mapping[str, Any] | Any) -> ModRequest:
+    if isinstance(raw, ModRequest):
+        request = raw
+    else:
+        payload = _to_mapping(raw)
+        request = ModRequest(
+            accion=str(payload.get("accion") or payload.get("action") or "").strip(),
+            ruta=payload.get("ruta") or payload.get("path"),
+            nombre=payload.get("nombre") or payload.get("name"),
+        )
+
+    action_aliases = {
+        "list": "listar",
+        "install": "instalar",
+        "remove": "remover",
+        "publish": "publicar",
+        "search": "buscar",
+    }
+    request = ModRequest(
+        accion=action_aliases.get(request.accion, request.accion),
+        ruta=request.ruta,
+        nombre=request.nombre,
+    )
+
+    if not request.accion:
+        raise ValueError("El campo 'accion' es obligatorio")
+
+    requires_ruta = {"instalar", "publicar"}
+    requires_nombre = {"remover", "buscar"}
+    if request.accion in requires_ruta and not request.ruta:
+        raise ValueError(f"La acción '{request.accion}' requiere el campo 'ruta'")
+    if request.accion in requires_nombre and not request.nombre:
+        raise ValueError(f"La acción '{request.accion}' requiere el campo 'nombre'")
+
+    return request

--- a/src/pcobra/cobra/cli/services/mod_service.py
+++ b/src/pcobra/cobra/cli/services/mod_service.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 
 from pcobra.cobra.cli.cobrahub_client import CobraHubClient
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.services.contracts import ModRequest, normalize_mod_request
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.cli.utils.semver import es_nueva_version, es_version_valida
 from pcobra.cobra.semantico import mod_validator
@@ -154,11 +155,14 @@ def obtener_version(ruta: str) -> Optional[str]:
 
 
 class ModService:
-    def run(self, args: Any) -> int:
-        accion = args.accion
-        if not accion:
-            mostrar_error(_("Debe especificar una acción"))
+    def run(self, request: ModRequest) -> int:
+        try:
+            request = normalize_mod_request(request)
+        except ValueError as err:
+            mostrar_error(str(err))
             return 1
+
+        accion = request.accion
 
         if yaml is None and accion in {"publicar", "buscar"}:
             mostrar_error(_("El comando de módulos requiere la dependencia opcional 'PyYAML' para la acción solicitada."))
@@ -166,10 +170,10 @@ class ModService:
 
         acciones = {
             "listar": listar_modulos,
-            "instalar": lambda: instalar_modulo(args.ruta),
-            "remover": lambda: remover_modulo(args.nombre),
-            "publicar": lambda: 0 if get_client().publicar_modulo(args.ruta) else 1,
-            "buscar": lambda: buscar_modulo(args.nombre),
+            "instalar": lambda: instalar_modulo(request.ruta),
+            "remover": lambda: remover_modulo(request.nombre),
+            "publicar": lambda: 0 if get_client().publicar_modulo(request.ruta) else 1,
+            "buscar": lambda: buscar_modulo(request.nombre),
         }
 
         try:

--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -14,6 +14,7 @@ from pcobra.cobra.cli.execution_pipeline import (
 )
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.mode_policy import validar_politica_modo
+from pcobra.cobra.cli.services.contracts import RunRequest, normalize_run_request
 from pcobra.cobra.cli.services.format_service import format_code_with_black
 from pcobra.cobra.cli.target_policies import resolve_docker_backend
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
@@ -113,29 +114,30 @@ class RunService:
     max_file_size = 10 * 1024 * 1024
     execution_timeout = 30
 
-    def run(self, args: Any) -> int:
+    def run(self, request: RunRequest) -> int:
+        request = normalize_run_request(request)
         try:
-            validar_politica_modo("ejecutar", args, capability="execute")
+            validar_politica_modo("ejecutar", request, capability="execute")
         except ValueError as e:
             mostrar_error(str(e), registrar_log=False)
             return 1
 
         try:
-            archivo_resuelto = self.validar_archivo(args.archivo)
+            archivo_resuelto = self.validar_archivo(request.archivo)
         except ValueError as e:
             mostrar_error(str(e), registrar_log=False)
             return 1
 
-        depurar = bool(getattr(args, "debug", False)) or int(getattr(args, "verbose", 0) or 0) > 0
-        depurar = depurar or bool(getattr(args, "depurar", False))
-        formatear = bool(getattr(args, "formatear", False))
-        seguro = getattr(args, "seguro", True)
-        sandbox = getattr(args, "sandbox", False)
-        contenedor = getattr(args, "contenedor", None)
-        allow_insecure_fallback = bool(getattr(args, "allow_insecure_fallback", False))
+        depurar = bool(request.debug) or int(request.verbose or 0) > 0
+        depurar = depurar or bool(request.depurar)
+        formatear = bool(request.formatear)
+        seguro = request.seguro
+        sandbox = request.sandbox
+        contenedor = request.contenedor
+        allow_insecure_fallback = bool(request.allow_insecure_fallback)
 
         try:
-            extra_validators = normalizar_validadores_extra(getattr(args, "extra_validators", None))
+            extra_validators = normalizar_validadores_extra(request.extra_validators)
         except TypeError:
             mostrar_error(_("Los validadores extra deben ser una ruta o lista de rutas"), registrar_log=False)
             return 1

--- a/src/pcobra/cobra/cli/services/test_service.py
+++ b/src/pcobra/cobra/cli/services/test_service.py
@@ -10,6 +10,7 @@ from pcobra.core.sandbox import ejecutar_en_contenedor, ejecutar_en_sandbox, eje
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.mode_policy import validar_politica_modo
+from pcobra.cobra.cli.services.contracts import TestRequest, normalize_test_request
 from pcobra.cobra.cli.target_policies import (
     OFFICIAL_TRANSPILATION_TARGETS,
     VERIFICATION_EXECUTABLE_TARGETS,
@@ -34,17 +35,15 @@ class TestService:
         self._interprete = InterpretadorCobra()
         self._logger = logging.getLogger(__name__)
 
-    def run(self, args: Any) -> int:
+    def run(self, request: TestRequest) -> int:
+        request = normalize_test_request(request)
         try:
-            validar_politica_modo("verificar", args, capability="codegen")
+            validar_politica_modo("verificar", request, capability="codegen")
 
-            if not args.archivo or not args.lenguajes:
-                raise ValueError(_("Se requieren archivo y lenguajes"))
-
-            lenguajes = list(args.lenguajes)
+            lenguajes = list(request.lenguajes)
             self.validate_languages(lenguajes)
 
-            codigo = self.read_source_file(args.archivo)
+            codigo = self.read_source_file(request.archivo)
             tokens = Lexer(codigo).tokenizar()
             ast = Parser(tokens).parsear()
 

--- a/tests/unit/test_cli_service_contracts.py
+++ b/tests/unit/test_cli_service_contracts.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+
+import pytest
+
+from pcobra.cobra.cli.services.contracts import (
+    ModRequest,
+    RunRequest,
+    TestRequest as CliTestRequest,
+    normalize_mod_request,
+    normalize_run_request,
+    normalize_test_request,
+)
+
+
+def test_normalize_run_request_defaults_and_aliases() -> None:
+    req = normalize_run_request({"file": "main.co"})
+    assert req == RunRequest(archivo="main.co")
+
+
+def test_normalize_test_request_parses_languajes_string() -> None:
+    req = normalize_test_request({"archivo": "main.co", "lenguajes": "python,javascript"})
+    assert req == CliTestRequest(archivo="main.co", lenguajes=["python", "javascript"])
+
+
+def test_normalize_mod_request_requires_action_fields() -> None:
+    with pytest.raises(ValueError, match="obligatorio"):
+        normalize_mod_request({})
+
+    with pytest.raises(ValueError, match="requiere el campo 'ruta'"):
+        normalize_mod_request({"accion": "instalar"})
+
+    ok = normalize_mod_request({"action": "search", "name": "math"})
+    assert ok == ModRequest(accion="buscar", nombre="math")
+
+
+def test_normalize_test_request_from_namespace() -> None:
+    ns = SimpleNamespace(file="programa.co", langs=["python"])
+    req = normalize_test_request(ns)
+    assert req.archivo == "programa.co"
+    assert req.lenguajes == ["python"]


### PR DESCRIPTION
### Motivation

- Evitar divergencias entre el parsing de la CLI (`argparse`) y la capa de aplicación consolidando un contrato de entrada estable.
- Unificar validación/defaults y facilitar la interoperabilidad entre CLI v2, legacy, REPL y llamadas programáticas.

### Description

- Añadidos DTOs inmutables y normalizadores en `src/pcobra/cobra/cli/services/contracts.py`: `RunRequest`, `TestRequest`, `ModRequest` y las funciones `normalize_*` que validan campos obligatorios, aplican defaults y manejan aliases (`file`/`archivo`, `langs`/`lenguajes`, `action`/`accion`).
- Servicios actualizados para consumir DTOs en lugar de `argparse.Namespace`: `RunService.run(request: RunRequest)`, `TestService.run(request: TestRequest)`, `ModService.run(request: ModRequest)`; cada servicio realiza normalización defensiva con las funciones de `contracts`.
- Reemplazado el armado manual de `Namespace(...)` por creación explícita de DTOs en comandos v2 y legacy: `commands_v2/run_cmd.py`, `commands_v2/test_cmd.py`, `commands_v2/mod_cmd.py`, `commands/execute_cmd.py`, `commands/verify_cmd.py`, `commands/modules_cmd.py` y el grupo `legacy` en `commands_v2/legacy_cmd.py`.
- Documentado el contrato de entrada/salida en `docs/architecture/cli_input_output_contracts.md` y añadida una suite de pruebas unitarias de normalización en `tests/unit/test_cli_service_contracts.py`.

### Testing

- Ejecutado `pytest -q tests/unit/test_cli_service_contracts.py tests/unit/test_cli_target_runtime_ux.py`, resultado: `14 passed, 2 skipped`.
- La nueva prueba `tests/unit/test_cli_service_contracts.py` fue añadida y pasó correctamente, verificando defaults, aliases y reglas por acción.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c04d185c8327bddbe672c91ab786)