### PR TITLE
Implementa `Environment.delete` y unifica semántica de `del` con liberación de memoria

### DIFF
--- a/src/pcobra/core/environment.py
+++ b/src/pcobra/core/environment.py
@@ -42,3 +42,13 @@ class Environment:
         if self.parent is not None and self.parent.contains(name):
             return self.parent.set(name, value)
         raise NameError(f"Variable no declarada: {name}")
+
+    def delete(self, name: str) -> None:
+        """Elimina ``name`` en el primer scope donde exista."""
+        if name in self.values:
+            del self.values[name]
+            return
+        if self.parent is not None:
+            self.parent.delete(name)
+            return
+        raise NameError(f"Variable no declarada: {name}")

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -429,6 +429,23 @@ class InterpretadorCobra:
         """Permite reemplazar solo el mapeo local del entorno activo."""
         self.contextos[-1].values = valor
 
+    def _indice_entorno_variable(self, nombre: str) -> int | None:
+        """Retorna el índice del primer entorno (de adentro hacia afuera) con ``nombre``."""
+        for indice in range(len(self.contextos) - 1, -1, -1):
+            if nombre in self.contextos[indice].values:
+                return indice
+        return None
+
+    def _liberar_memoria_variable_en_contexto(self, nombre: str, indice_contexto: int) -> None:
+        """Libera el bloque de memoria asociado a ``nombre`` en un contexto concreto."""
+        if indice_contexto < 0 or indice_contexto >= len(self.mem_contextos):
+            return
+        mem_ctx = self.mem_contextos[indice_contexto]
+        if nombre not in mem_ctx:
+            return
+        idx, tam = mem_ctx.pop(nombre)
+        self.liberar_memoria(idx, tam)
+
     def obtener_variable(self, nombre, visitados=None):
         """Busca una variable en la pila de contextos.
 
@@ -1073,7 +1090,10 @@ class InterpretadorCobra:
                     f"se recibió: {type(nodo.objetivo).__name__}"
                 )
             nombre = nodo.objetivo.nombre
-            self.contextos[-1].values.pop(nombre, None)
+            indice_contexto = self._indice_entorno_variable(nombre)
+            self.contextos[-1].delete(nombre)
+            if indice_contexto is not None:
+                self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
         elif isinstance(nodo, NodoGlobal):
             pass  # sin efecto en este intérprete simplificado
         elif isinstance(nodo, NodoNoLocal):

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -3,6 +3,7 @@ from io import StringIO
 from unittest.mock import patch
 
 from core.interpreter import InterpretadorCobra
+from core.environment import Environment
 from cobra.core import Token, TipoToken
 from core.ast_nodes import (
     NodoAsignacion,
@@ -199,6 +200,44 @@ def test_del_elimina_variable_por_identificador():
 
     assert "x" not in inter.variables
     assert 1 not in inter.variables
+
+
+def test_del_elimina_variable_en_scope_ancestro_y_lanza_nameerror_si_no_existe():
+    inter = InterpretadorCobra()
+    inter.ejecutar_nodo(NodoAsignacion("x", NodoValor(1), declaracion=True))
+    inter.contextos.append(Environment(parent=inter.contextos[-1]))
+    inter.mem_contextos.append({})
+
+    try:
+        inter.ejecutar_nodo(NodoDel(NodoIdentificador("x")))
+        with pytest.raises(NameError, match=r"^Variable no declarada: x$"):
+            inter.obtener_variable("x")
+        with pytest.raises(NameError, match=r"^Variable no declarada: no_existe$"):
+            inter.ejecutar_nodo(NodoDel(NodoIdentificador("no_existe")))
+    finally:
+        inter.mem_contextos.pop()
+        inter.contextos.pop()
+
+
+def test_del_libera_memoria_del_scope_ancestro():
+    inter = InterpretadorCobra()
+    inter.ejecutar_nodo(NodoAsignacion("x", NodoValor(1), declaracion=True))
+    inter.mem_contextos[0]["x"] = (11, 1)
+
+    liberaciones = []
+    inter.liberar_memoria = lambda idx, tam: liberaciones.append((idx, tam))
+
+    inter.contextos.append(Environment(parent=inter.contextos[-1]))
+    inter.mem_contextos.append({})
+
+    try:
+        inter.ejecutar_nodo(NodoDel(NodoIdentificador("x")))
+    finally:
+        inter.mem_contextos.pop()
+        inter.contextos.pop()
+
+    assert liberaciones == [(11, 1)]
+    assert "x" not in inter.mem_contextos[0]
 
 
 def test_del_objetivo_no_identificador_lanza_typeerror():


### PR DESCRIPTION
### Motivation

- Centralizar la semántica de borrado para que `del` funcione igual en REPL y en scripts mediante la API de `Environment`.
- Evitar inconsistencias entre manipulación directa de `values` y el bookkeeping de memoria en `self.mem_contextos`.
- Prevenir metadatos de memoria huérfanos cuando se borra una variable definida en un scope ancestro.

### Description

- Se añadió `Environment.delete(name)` que elimina el identificador buscando desde el scope actual hacia los ancestros y lanza `NameError` si no existe (archivo: `src/pcobra/core/environment.py`).
- En el intérprete se reemplazó la eliminación directa de `self.contextos[-1].values.pop(...)` por la llamada a la API: `self.contextos[-1].delete(nombre)` (archivo: `src/pcobra/core/interpreter.py`).
- Se añadieron utilidades internas `_indice_entorno_variable` y `_liberar_memoria_variable_en_contexto` para localizar el contexto que contiene la variable y liberar el bloque correspondiente en `self.mem_contextos` cuando `del` elimina una variable en un scope actual o ancestro (archivo: `src/pcobra/core/interpreter.py`).
- Se agregaron pruebas unitarias que cubren `del` en scope local, `del` en scope ancestro, error al borrar inexistentes y la liberación de memoria asociada (archivo: `tests/unit/test_interpreter.py`).

### Testing

- Ejecutado: `pytest -q tests/unit/test_interpreter.py -k "del or with_limpia_contexto_y_memoria_en_retorno_temprano or with_limpia_contexto_y_memoria_si_hay_excepcion"` y la suite seleccionada pasó correctamente (`6 passed, 13 deselected`).
- Las nuevas pruebas agregadas verifican la eliminación léxica y la liberación de memoria y fueron exitosas en la ejecución indicada.
- No se ejecutaron otros tests del repositorio en este cambio; se recomienda ejecutar la suite completa en CI antes de fusionar.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c51abcac8327b6377eed1b2ea567)