### PR TITLE
Endurecer contrato de imports legacy y actualizar smoke de empaquetado

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,9 @@ dev = [
 
 [tool.setuptools]
 include-package-data = true
+# Fuente canónica runtime/publicada: únicamente `src/pcobra`.
+# Los shims de raíz (`src/cobra`, `src/core`, `src/bindings` y análogos fuera de
+# `src/pcobra`) son compatibilidad interna del repositorio y NO contrato runtime.
 package-dir = {"" = "src"}
 
 [tool.setuptools.exclude-package-data]

--- a/scripts/ci/lint_import_resolution_contract.py
+++ b/scripts/ci/lint_import_resolution_contract.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Valida que `src/pcobra/**/*.py` use imports canónicos y no aliases legacy."""
+"""Valida imports canónicos en código productivo.
+
+Regla contractual:
+- En código productivo (``src/**/*.py``) se prohíben imports absolutos legacy
+  ``cobra.*``, ``core.*`` y ``bindings.*``.
+- Única excepción: módulos marcados explícitamente con
+  ``# pcobra-compat: allow-legacy-imports``.
+"""
 
 from __future__ import annotations
 
@@ -7,13 +14,9 @@ import ast
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-SCAN_ROOT = ROOT / "src" / "pcobra"
-
-ALLOWLIST_DIR_SUFFIXES = (
-    Path("cobra/internal_compat"),
-    Path("cobra/cli/internal_compat"),
-)
+SCAN_ROOT = ROOT / "src"
 COMPAT_MARKER = "pcobra-compat: allow-legacy-imports"
+LEGACY_ROOT_MODULES = ("cobra", "core", "bindings")
 
 
 class LegacyImportVisitor(ast.NodeVisitor):
@@ -23,7 +26,9 @@ class LegacyImportVisitor(ast.NodeVisitor):
     def visit_Import(self, node: ast.Import) -> None:  # noqa: N802
         for alias in node.names:
             target = alias.name
-            if target == "bindings" or target.startswith("bindings."):
+            if target in LEGACY_ROOT_MODULES or target.startswith(
+                tuple(f"{legacy}." for legacy in LEGACY_ROOT_MODULES)
+            ):
                 self.violations.append((node.lineno, f"import legacy no permitido: {target}"))
         self.generic_visit(node)
 
@@ -33,24 +38,20 @@ class LegacyImportVisitor(ast.NodeVisitor):
             return
 
         module = node.module or ""
-        if module == "bindings" or module.startswith("bindings."):
-            self.violations.append((node.lineno, f"import legacy no permitido: from {module}"))
-        if module == "cobra" or module.startswith("cobra."):
+        if module in LEGACY_ROOT_MODULES or module.startswith(
+            tuple(f"{legacy}." for legacy in LEGACY_ROOT_MODULES)
+        ):
             self.violations.append((node.lineno, f"import legacy no permitido: from {module}"))
         self.generic_visit(node)
 
 
 def _is_compat_module(path: Path, root: Path) -> bool:
-    rel_to_scan = path.relative_to(root / "src" / "pcobra")
-    if any(rel_to_scan.is_relative_to(suffix) for suffix in ALLOWLIST_DIR_SUFFIXES):
-        return True
-
     header = "\n".join(path.read_text(encoding="utf-8").splitlines()[:20])
     return COMPAT_MARKER in header
 
 
 def find_violations(root: Path = ROOT) -> list[str]:
-    scan_root = root / "src" / "pcobra"
+    scan_root = root / "src"
     failures: list[str] = []
     if not scan_root.exists():
         return failures
@@ -64,7 +65,7 @@ def find_violations(root: Path = ROOT) -> list[str]:
         for lineno, reason in visitor.violations:
             rel = path.relative_to(root)
             failures.append(
-                f"{rel}:{lineno}: {reason}; usa pcobra.cobra.* y rutas canónicas en producción"
+                f"{rel}:{lineno}: {reason}; usa `pcobra.*` o imports relativos en código productivo"
             )
 
     return failures
@@ -72,7 +73,7 @@ def find_violations(root: Path = ROOT) -> list[str]:
 
 def main() -> int:
     if not SCAN_ROOT.exists():
-        print("⚠️ Lint import-resolution-contract: src/pcobra/ no existe, se omite.")
+        print("⚠️ Lint import-resolution-contract: src/ no existe, se omite.")
         return 0
 
     failures = find_violations(ROOT)
@@ -82,7 +83,7 @@ def main() -> int:
             print(f" - {item}")
         return 1
 
-    print("✅ Lint import-resolution-contract: OK (sin imports legacy en src/pcobra).")
+    print("✅ Lint import-resolution-contract: OK (sin imports legacy en src productivo).")
     return 0
 
 

--- a/tests/cli/test_packaging_smoke.py
+++ b/tests/cli/test_packaging_smoke.py
@@ -15,7 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 @pytest.mark.integration
 def test_packaging_smoke_build_install_and_run_help(tmp_path: Path) -> None:
-    """Valida artefactos de packaging e invocación de `cobra --ayuda` en entorno aislado."""
+    """Valida artefactos de packaging y `pcobra.cli:main(['--help'])` en entorno limpio."""
 
     dist_dir = tmp_path / "dist"
     dist_dir.mkdir(parents=True, exist_ok=True)
@@ -48,11 +48,9 @@ def test_packaging_smoke_build_install_and_run_help(tmp_path: Path) -> None:
     if os.name == "nt":
         venv_python = venv_dir / "Scripts" / "python.exe"
         venv_pip = venv_dir / "Scripts" / "pip.exe"
-        cobra_cmd = venv_dir / "Scripts" / "cobra.exe"
     else:
         venv_python = venv_dir / "bin" / "python"
         venv_pip = venv_dir / "bin" / "pip"
-        cobra_cmd = venv_dir / "bin" / "cobra"
 
     subprocess.run(
         [str(venv_pip), "install", "--no-deps", "--force-reinstall", str(wheels[0])],
@@ -62,18 +60,17 @@ def test_packaging_smoke_build_install_and_run_help(tmp_path: Path) -> None:
     )
 
     smoke_script = (
-        "import subprocess, sys\n"
-        f"r = subprocess.run([{str(cobra_cmd)!r}, '--ayuda'], capture_output=True, text=True)\n"
-        "bad_tokens = ('ModuleNotFoundError', 'scripts.benchmarks')\n"
-        "stderr = r.stderr or ''\n"
-        "for token in bad_tokens:\n"
-        "    if token in stderr:\n"
-        "        raise SystemExit("
-        "f'Smoke packaging falló: token prohibido {token!r} en stderr={stderr!r}')\n"
-        "if r.returncode != 0:\n"
-        "    raise SystemExit("
-        "f'cobra --ayuda devolvió código {r.returncode}. stderr={stderr!r}')\n"
-        "print(r.stdout)\n"
+        "from pcobra.cli import main\n"
+        "import sys\n"
+        "antes = set(sys.modules)\n"
+        "code = main(['--help'])\n"
+        "despues = set(sys.modules)\n"
+        "if code != 0:\n"
+        "    raise SystemExit(f'pcobra.cli.main([\\'--help\\']) devolvió {code}')\n"
+        "prohibidos = {'cobra', 'core', 'bindings'}\n"
+        "cargados = sorted(name for name in (despues - antes) if name in prohibidos)\n"
+        "if cargados:\n"
+        "    raise SystemExit(f'Se cargaron paquetes raíz legacy en smoke limpio: {cargados!r}')\n"
     )
     run_help = subprocess.run(
         [str(venv_python), "-I", "-c", smoke_script],
@@ -84,6 +81,6 @@ def test_packaging_smoke_build_install_and_run_help(tmp_path: Path) -> None:
     )
 
     assert run_help.returncode == 0, (
-        "El smoke test aislado de packaging debe ejecutar `cobra --ayuda` sin errores. "
+        "El smoke test aislado de packaging debe importar `pcobra.cli:main` y ejecutar --help sin depender de paquetes raíz. "
         f"stdout={run_help.stdout!r} stderr={run_help.stderr!r}"
     )

--- a/tests/unit/test_ci_lint_import_resolution_contract.py
+++ b/tests/unit/test_ci_lint_import_resolution_contract.py
@@ -10,17 +10,23 @@ def _write(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
-def test_detecta_import_legacy_bindings_y_cobra(tmp_path: Path) -> None:
+def test_detecta_imports_legacy_en_codigo_productivo(tmp_path: Path) -> None:
     _write(
         tmp_path / "src" / "pcobra" / "cobra" / "foo.py",
-        "from bindings.contract import resolve_binding\nfrom cobra.cli import run\n",
+        "from bindings.contract import resolve_binding\nfrom cobra.cli import run\nimport core\n",
+    )
+    _write(
+        tmp_path / "src" / "legacy_pkg" / "bar.py",
+        "from core.interpreter import InterpretadorCobra\n",
     )
 
     violations = find_violations(tmp_path)
 
-    assert len(violations) == 2
+    assert len(violations) == 4
     assert any("from bindings.contract" in item for item in violations)
     assert any("from cobra.cli" in item for item in violations)
+    assert any("import legacy no permitido: core" in item for item in violations)
+    assert any("from core.interpreter" in item for item in violations)
 
 
 def test_permite_import_canonico_pcobra(tmp_path: Path) -> None:
@@ -36,8 +42,8 @@ def test_permite_import_canonico_pcobra(tmp_path: Path) -> None:
 
 def test_permite_modulo_marcado_como_compatibilidad(tmp_path: Path) -> None:
     _write(
-        tmp_path / "src" / "pcobra" / "cobra" / "legacy_bridge.py",
-        "# pcobra-compat: allow-legacy-imports\nfrom cobra.cli import run\nimport bindings\n",
+        tmp_path / "src" / "compat_shims" / "legacy_bridge.py",
+        "# pcobra-compat: allow-legacy-imports\nfrom cobra.cli import run\nimport bindings\nimport core\n",
     )
 
     violations = find_violations(tmp_path)


### PR DESCRIPTION
### Motivation
- Evitar que código productivo importe módulos legacy en la raíz (`cobra`, `core`, `bindings`) y dejar claro que los shims de raíz son compatibilidad de repo, no contrato runtime. 
- Asegurar que el empaquetado/entrypoint funcione en entornos limpios sin depender de paquetes raíz legacy. 

### Description
- Amplié `scripts/ci/lint_import_resolution_contract.py` para que escanee `src/**/*.py` (todo el código productivo) y detecte imports absolutos legacy de `cobra`, `core` y `bindings`, con excepción solo para archivos que contengan el marcador `# pcobra-compat: allow-legacy-imports`. 
- Añadí la tupla `LEGACY_ROOT_MODULES = ("cobra", "core", "bindings")` y adapté la lógica AST para `Import`/`ImportFrom` para rechazar esos imports en `src/`. 
- Actualicé `tests/unit/test_ci_lint_import_resolution_contract.py` para cubrir detección en `src` fuera de `src/pcobra`, probar `core` como import legacy y preservar la excepción por marcador. 
- Modifiqué `tests/cli/test_packaging_smoke.py` para que el smoke de instalación aislada importe `pcobra.cli:main` y ejecute `--help` directamente, comprobando además que no se carguen los paquetes raíz legacy durante ese flujo. 
- Documenté en `pyproject.toml` que la fuente canónica runtime/publicada es `src/pcobra` y que los shims de raíz son compatibilidad de repositorio y no parte del contrato runtime. 

### Testing
- Ejecuté `python scripts/ci/lint_import_resolution_contract.py` y el script devolvió OK (sin imports legacy detectados en el árbol `src/`). 
- Ejecuté `pytest -q tests/unit/test_ci_lint_import_resolution_contract.py` y las pruebas unitarias del lint pasaron (`3 passed`). 
- Ejecuté `pytest -q tests/test_cli_entrypoint_imports.py -k cli_main_smoke_help_en_entorno_aislado` y la prueba relevante pasó (`1 passed, 4 deselected`). 
- Intenté ejecutar `pytest -q tests/cli/test_packaging_smoke.py` en este entorno; la prueba se saltó o no pudo ejecutarse por la ausencia del paquete `build` en el entorno, por lo que quedó marcada como saltada en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d473871483279604f25b10bb0471)