### PR TITLE
test(cli): adaptar stub a choices dinámicos de transpilers

### DIFF
--- a/tests/unit/test_cli_config_defaults.py
+++ b/tests/unit/test_cli_config_defaults.py
@@ -40,7 +40,7 @@ def stub_cli_dependencies() -> None:
         setattr(module, class_name, create_command(class_name))
         sys.modules[module_name] = module
 
-    sys.modules["cobra.cli.commands.compile_cmd"].LANG_CHOICES = []
+    sys.modules["cobra.cli.commands.compile_cmd"].get_lang_choices = lambda: ()
     sys.modules["cobra.cli.commands.transpilar_inverso_cmd"].ORIGIN_CHOICES = []
 
     core_mod = types.ModuleType("core.interpreter")


### PR DESCRIPTION
### Motivation
- Alinear los tests con el contrato actual de la CLI para targets: la CLI ya expone choices dinámicos vía `get_lang_choices()`/`cli_transpiler_targets()` y los stubs de prueba no deben depender de un `LANG_CHOICES` estático.

### Description
- Actualicé el stub de dependencias en `tests/unit/test_cli_config_defaults.py` para exponer `get_lang_choices = lambda: ()` en lugar de `LANG_CHOICES = []`, garantizando que las pruebas simulen el contrato dinámico de `compile_cmd`.

### Testing
- Ejecuté `pytest -q tests/unit/test_compile_cmd_target_choices_aliases.py tests/unit/test_cli_config_defaults.py tests/unit/test_bench_transpilers_cmd.py` y se observaron 3 fallos preexistentes en un conjunto más amplio; estos reflejaban expectativas de help/valores por defecto no relacionadas con el cambio.
- Ejecuté pruebas dirigidas con `pytest -q tests/unit/test_compile_cmd_target_choices_aliases.py::test_get_lang_choices_es_dinamico_tras_carga_de_entrypoints tests/unit/test_compile_cmd_target_choices_aliases.py::test_compile_register_subparser_evalua_choices_en_tiempo_de_registro tests/unit/test_bench_transpilers_cmd.py::test_bench_transpilers_importa_registro_cli_sin_depender_de_otros_comandos tests/unit/test_cli_config_defaults.py::test_cli_starts_with_defaults_when_config_absent` y todas pasaron.
- Ejecuté `pytest -q tests/unit/test_ci_lint_no_cross_command_imports.py` y pasó (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fb293e4083278944ead61c68b4d8)