### PR TITLE
Align interactive REPL sandbox with run validation settings

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -620,7 +620,11 @@ class InteractiveCommand(BaseCommand):
                 )
 
                 if sandbox:
-                    self._ejecutar_en_sandbox(codigo)
+                    self._ejecutar_en_sandbox(
+                        codigo,
+                        safe_mode=self._seguro_repl,
+                        extra_validators=self._extra_validators_repl,
+                    )
                 elif sandbox_docker:
                     self._ejecutar_en_docker(codigo, sandbox_docker)
                 else:
@@ -775,18 +779,26 @@ class InteractiveCommand(BaseCommand):
 
         return False
 
-    def _ejecutar_en_sandbox(self, linea: str) -> None:
+    def _ejecutar_en_sandbox(
+        self,
+        linea: str,
+        *,
+        safe_mode: bool,
+        extra_validators: Any,
+    ) -> None:
         """Ejecuta código en un sandbox.
 
         Args:
             linea: Código a ejecutar
+            safe_mode: Política de seguridad activa del REPL.
+            extra_validators: Validadores extra activos en la sesión REPL.
         """
         analizar_codigo(linea)
 
         script = construir_script_sandbox_canonico(
             linea,
-            safe_mode=None,
-            extra_validators=None,
+            safe_mode=safe_mode,
+            extra_validators=extra_validators,
             imprimir_resultado=True,
         )
 

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -400,6 +400,8 @@ def test_ejecutar_codigo_traduce_booleano_solo_en_salida_no_en_semantica_interna
 
 def test_ejecutar_en_sandbox_arma_script_con_captura_y_booleanos():
     cmd = InteractiveCommand(MagicMock())
+    cmd._seguro_repl = False
+    cmd._extra_validators_repl = ["validador.py"]
 
     with patch('cobra.cli.commands.interactive_cmd.Lexer') as mock_lexer, \
          patch('cobra.cli.commands.interactive_cmd.Parser') as mock_parser, \
@@ -408,15 +410,47 @@ def test_ejecutar_en_sandbox_arma_script_con_captura_y_booleanos():
         mock_lexer.return_value.tokenizar.return_value = ['TOK']
         mock_parser.return_value.parsear.return_value = ['AST']
 
-        cmd._ejecutar_en_sandbox('imprimir(1)')
+        cmd._ejecutar_en_sandbox(
+            'imprimir(1)',
+            safe_mode=cmd._seguro_repl,
+            extra_validators=cmd._extra_validators_repl,
+        )
 
     script_enviado = mock_sandbox.call_args.args[0]
+    assert "safe_mode=False" in script_enviado
+    assert "extra_validators=['validador.py']" in script_enviado
     assert '_resultado = _interp.ejecutar_ast(_ast)' in script_enviado
     assert "if _resultado is not None:" in script_enviado
     assert "if isinstance(_resultado, bool):" in script_enviado
     assert "print('verdadero' if _resultado else 'falso')" in script_enviado
     assert 'print(_resultado)' in script_enviado
     mock_info.assert_called_once_with('ok')
+
+
+def test_run_repl_loop_pasa_estado_repl_a_ejecucion_sandbox():
+    cmd = InteractiveCommand(MagicMock())
+    cmd._seguro_repl = False
+    cmd._extra_validators_repl = ["extra.py"]
+
+    def _leer_linea_factory():
+        entradas = iter(["imprimir(1)", "salir"])
+        return lambda _prompt: next(entradas)
+
+    with patch.object(cmd, "validar_entrada", return_value=True), \
+         patch.object(cmd, "_ejecutar_en_sandbox") as mock_sandbox:
+        cmd._run_repl_loop(
+            args=_args(),
+            validador=None,
+            leer_linea=_leer_linea_factory(),
+            sandbox=True,
+            sandbox_docker=None,
+        )
+
+    mock_sandbox.assert_called_once_with(
+        "imprimir(1)",
+        safe_mode=False,
+        extra_validators=["extra.py"],
+    )
 
 
 def test_format_user_error_limpia_prefijo_error_general():


### PR DESCRIPTION
### Motivation
- Evitar divergencias entre el REPL y la ejecución normal para que la política de validación (`safe_mode` y `extra_validators`) sea la misma en ambos modos.
- Mantener el contrato funcional con `RunService.ejecutar_en_sandbox` y evitar que el REPL reconstruya un intérprete paralelo sin respetar el estado de sesión.
- Conservar la política de errores unificada para no duplicar trazas al usuario final.

### Description
- En `_run_repl_loop` se pasa explícitamente el estado REPL a la ejecución en sandbox usando `safe_mode=self._seguro_repl` y `extra_validators=self._extra_validators_repl` al llamar a `_ejecutar_en_sandbox`.
- Se refactorizó la firma de `_ejecutar_en_sandbox` para aceptar `safe_mode` y `extra_validators` y se reenvían esos valores a `construir_script_sandbox_canonico` (antes eran `None`).
- Se actualizó la prueba `test_ejecutar_en_sandbox_arma_script_con_captura_y_booleanos` para comprobar que el script generado incorpora `safe_mode` y `extra_validators`.
- Se añadió `test_run_repl_loop_pasa_estado_repl_a_ejecucion_sandbox` para verificar que `_run_repl_loop` reenvía el estado REPL a la invocación sandbox.

### Testing
- Se ejecutaron las pruebas unitarias relevantes con `pytest -q tests/unit/test_cli_interactive_cmd.py -k "sandbox or run_repl_loop_pasa_estado_repl_a_ejecucion_sandbox"` y el resultado fue `2 passed, 30 deselected`.
- Las pruebas añadidas/ajustadas confirmaron que el script sandbox en REPL contiene `safe_mode` y `extra_validators` y que el loop REPL pasa correctamente el estado de sesión.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90f4727088327afcb00fd9db53d5f)