### PR TITLE
refactor(cli): remove startup lexer monkey patch and enforce Unicode sanitization at input boundary

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import sys
-import ast
 from importlib import import_module
 from pathlib import Path
 from typing import Iterable, List, Optional
@@ -46,32 +45,6 @@ def configure_encoding() -> None:
     except Exception:
         pass
     os.environ["PYTHONIOENCODING"] = "utf-8"
-
-
-def _apply_cli_startup_unicode_patch() -> None:
-    """Aplica un parche de arranque para literales UTF-8 en sesiones CLI.
-
-    Este parche vive en startup del CLI para evitar modificar módulos del lenguaje.
-    Reemplaza temporalmente ``Lexer._procesar_cadena`` con una versión basada en
-    ``ast.literal_eval`` que respeta UTF-8 y secuencias de escape.
-    """
-
-    from pcobra.cobra.core.lexer import Lexer, UnclosedStringError
-
-    if getattr(Lexer, "_pcobra_cli_unicode_patch_applied", False):
-        return
-
-    def _procesar_cadena_cli(self, valor: str) -> str:
-        try:
-            parsed = ast.literal_eval(valor)
-        except (SyntaxError, ValueError, UnicodeError) as exc:
-            raise UnclosedStringError(
-                f"Cadena mal formada: {str(exc)}", self.linea, self.columna
-            )
-        return parsed if isinstance(parsed, str) else str(parsed)
-
-    Lexer._procesar_cadena = _procesar_cadena_cli  # type: ignore[method-assign]
-    Lexer._pcobra_cli_unicode_patch_applied = True  # type: ignore[attr-defined]
 
 
 def configure_logging(debug: bool) -> None:
@@ -223,13 +196,22 @@ def _normalizar_argumentos(argumentos: Optional[Iterable[str]]) -> Optional[List
     return normalizados
 
 
+def _preprocesar_argumentos_cli(argumentos: Optional[Iterable[str]]) -> Optional[List[str]]:
+    """Aplica saneamiento Unicode y normalización de alias a ``argumentos``."""
+    from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
+
+    normalizados = _normalizar_argumentos(argumentos)
+    if normalizados is None:
+        return None
+    return [sanitize_input(arg) for arg in normalizados]
+
+
 def main(argumentos: Optional[List[str]] = None) -> int:
     """Punto de entrada principal para la ejecución del CLI."""
     configure_encoding()
-    _apply_cli_startup_unicode_patch()
     _bootstrap_dev_path_si_opt_in()
     argv_entrada: Iterable[str] = argumentos if argumentos is not None else sys.argv[1:]
-    argv = _normalizar_argumentos(argv_entrada)
+    argv = _preprocesar_argumentos_cli(argv_entrada)
     debug = bool(argv and "--debug" in argv)
     configure_logging(debug=debug)
     if debug:

--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -12,6 +12,7 @@ from typing import Any, Callable
 
 from pcobra.cobra.core import Lexer, Parser
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_source_for_tokenizer
 from pcobra.cobra.core.runtime import ValidadorBase, construir_cadena
 
 
@@ -62,8 +63,9 @@ def construir_script_sandbox_canonico(
     )
     script = (
         "from pcobra.cobra.core import Lexer, Parser\n"
+        "from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_source_for_tokenizer\n"
         "from pcobra.cobra.core.runtime import InterpretadorCobra\n"
-        f"_codigo = {codigo!r}\n"
+        f"_codigo = sanitize_source_for_tokenizer({codigo!r})\n"
         "_tokens = Lexer(_codigo).tokenizar()\n"
         "_ast = Parser(_tokens).parsear()\n"
         f"_interp = InterpretadorCobra({safe_mode_fragment.lstrip(', ')})\n"
@@ -83,7 +85,8 @@ def construir_script_sandbox_canonico(
 def analizar_codigo(codigo: str) -> Any:
     """Analiza código fuente con el pipeline canónico Lexer+Parser."""
 
-    tokens = Lexer(codigo).tokenizar()
+    codigo_saneado = sanitize_source_for_tokenizer(codigo)
+    tokens = Lexer(codigo_saneado).tokenizar()
     return Parser(tokens).parsear()
 
 

--- a/src/pcobra/cobra/cli/utils/unicode_sanitize.py
+++ b/src/pcobra/cobra/cli/utils/unicode_sanitize.py
@@ -21,3 +21,49 @@ def sanitize_input(text: str) -> str:
 
     data = text.encode("utf-16", "surrogatepass")
     return data.decode("utf-16", "replace")
+
+
+def sanitize_source_for_tokenizer(text: str) -> str:
+    """Sanitiza código fuente para tokenización sin mutar Lexer/Parser.
+
+    - Repara surrogates inválidos mediante ``sanitize_input``.
+    - Dentro de literales de cadena simples/dobles, convierte caracteres
+      no-ASCII a secuencias de escape Unicode (``\\u``/``\\U``), para que el
+      ``Lexer`` actual los reconstruya correctamente al decodificar
+      ``unicode_escape``.
+    """
+    source = sanitize_input(text)
+    out: list[str] = []
+    quote: str | None = None
+    escaped = False
+
+    for ch in source:
+        if quote is None:
+            out.append(ch)
+            if ch in {"'", '"'}:
+                quote = ch
+                escaped = False
+            continue
+
+        if escaped:
+            out.append(ch)
+            escaped = False
+            continue
+
+        if ch == "\\":
+            out.append(ch)
+            escaped = True
+            continue
+
+        if ch == quote:
+            out.append(ch)
+            quote = None
+            continue
+
+        if ord(ch) > 127:
+            out.append(ch.encode("unicode_escape").decode("ascii"))
+            continue
+
+        out.append(ch)
+
+    return "".join(out)

--- a/tests/test_cli_entrypoint_imports.py
+++ b/tests/test_cli_entrypoint_imports.py
@@ -130,3 +130,23 @@ def test_cli_startup_preserva_utf8_en_literal_imprimir() -> None:
         "Se detectó posible mojibake en salida de CLI. "
         f"stdout={result.stdout!r}"
     )
+
+
+def test_cli_bootstrap_no_monkey_patchea_lexer() -> None:
+    """Contrato: bootstrap de CLI no debe mutar métodos de ``Lexer``."""
+
+    result = _run_python_isolated(
+        "from pcobra.cobra.core.lexer import Lexer; "
+        "before = Lexer._procesar_cadena; "
+        "from pcobra.cli import main; "
+        "rc = main(['--ayuda']); "
+        "after = Lexer._procesar_cadena; "
+        "assert rc == 0; "
+        "assert before is after, "
+        "'pcobra.cli bootstrap no debe monkey-patchear Lexer._procesar_cadena'; "
+    )
+
+    assert result.returncode == 0, (
+        "El bootstrap CLI debe preservar el método original del lexer. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )

--- a/tests/unit/test_unicode_sanitize_repl.py
+++ b/tests/unit/test_unicode_sanitize_repl.py
@@ -7,7 +7,10 @@ from pcobra.cobra.cli.commands.interactive_cmd import (
     InteractiveCommand,
     SafeFileHistory,
 )
-from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
+from pcobra.cobra.cli.utils.unicode_sanitize import (
+    sanitize_input,
+    sanitize_source_for_tokenizer,
+)
 
 
 def _args() -> SimpleNamespace:
@@ -54,6 +57,22 @@ def test_sanitize_input_mezcla_unicode_valido_y_surrogate_invalido():
     assert all(not (0xD800 <= ord(ch) <= 0xDFFF) for ch in saneado)
     # Debe poder codificarse a UTF-8 sin UnicodeEncodeError.
     assert saneado.encode("utf-8") == "áéíóú 🚀�".encode("utf-8")
+
+
+def test_sanitize_source_for_tokenizer_escapa_unicode_en_cadenas() -> None:
+    codigo = 'imprimir("áéíóú ñ € 🚀")'
+
+    saneado = sanitize_source_for_tokenizer(codigo)
+
+    assert saneado == 'imprimir("\\xe1\\xe9\\xed\\xf3\\xfa \\xf1 \\u20ac \\U0001f680")'
+
+
+def test_sanitize_source_for_tokenizer_no_muta_identificadores_unicode() -> None:
+    codigo = "var canción = 1"
+
+    saneado = sanitize_source_for_tokenizer(codigo)
+
+    assert saneado == codigo
 
 
 def test_interactive_command_sanitiza_surrogate_invalido_y_no_crashea(tmp_path):


### PR DESCRIPTION
### Motivation

- Evitar monkey-patching del `Lexer` durante el bootstrap del CLI y mover el saneamiento Unicode a la frontera de entrada para mantener inmutabilidad de las clases del frontend.
- Asegurar que tanto `pcobra.cli:main` como `python -m pcobra` compartan el mismo preprocesamiento de texto y evitar bifurcaciones de comportamiento.
- Mantener la cobertura de integraciones UTF-8 sin modificar el lexer/parser.

### Description

- Eliminado `_apply_cli_startup_unicode_patch` y su invocación en `pcobra.cli:main`, eliminando el reemplazo dinámico de `Lexer._procesar_cadena` (no se muta la clase del frontend).
- Añadido `_preprocesar_argumentos_cli` en `src/pcobra/cli.py` para normalizar alias y aplicar `sanitize_input` a los argumentos antes de inicializar la aplicación CLI.
- Implementada `sanitize_source_for_tokenizer` en `src/pcobra/cobra/cli/utils/unicode_sanitize.py` que repara surrogates inválidos y escapa caracteres Unicode dentro de literales de cadena para que el lexer existente (que usa `unicode_escape`) reconstruya correctamente valores UTF-8 sin cambiar el lexer.
- Aplicado `sanitize_source_for_tokenizer` en el pipeline canónico: `analizar_codigo` y `construir_script_sandbox_canonico` en `src/pcobra/cobra/cli/execution_pipeline.py`, de modo que ejecución normal y sandbox usen el mismo preprocesamiento.
- Añadida prueba de contrato `test_cli_bootstrap_no_monkey_patchea_lexer` que garantiza que `Lexer._procesar_cadena` no se monkey-patchea durante el arranque del CLI.
- Añadidos tests unitarios para `sanitize_source_for_tokenizer` que verifican que escapa correctamente Unicode en literales y no altera identificadores Unicode.

### Testing

- Ejecutado: `pytest -q tests/test_cli_entrypoint_imports.py::test_cli_bootstrap_no_monkey_patchea_lexer tests/test_cli_entrypoint_imports.py::test_cli_startup_preserva_utf8_en_literal_imprimir tests/unit/test_unicode_sanitize_repl.py::test_sanitize_source_for_tokenizer_escapa_unicode_en_cadenas tests/unit/test_unicode_sanitize_repl.py::test_sanitize_source_for_tokenizer_no_muta_identificadores_unicode` — Resultado: `4 passed`.
- Ejecutado: `pytest -q tests/unit/test_cli_entrypoint_subprocess.py::test_entrypoints_python_m_pcobra_y_cobra_comparten_inicializacion` — Resultado: `1 passed`.
- Todas las pruebas automatizadas relacionadas modificadas y los checks de integración empleados en esta rama han pasado en los comandos indicados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99e4e2cc883279611dbac801f75d1)