### PR TITLE
Alinear ejecución sandbox del REPL con contrato de RunService

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -620,11 +620,7 @@ class InteractiveCommand(BaseCommand):
                 )
 
                 if sandbox:
-                    self._ejecutar_en_sandbox(
-                        codigo,
-                        safe_mode=self._seguro_repl,
-                        extra_validators=self._extra_validators_repl,
-                    )
+                    self._ejecutar_en_sandbox(codigo)
                 elif sandbox_docker:
                     self._ejecutar_en_docker(codigo, sandbox_docker)
                 else:
@@ -782,23 +778,18 @@ class InteractiveCommand(BaseCommand):
     def _ejecutar_en_sandbox(
         self,
         linea: str,
-        *,
-        safe_mode: bool,
-        extra_validators: Any,
     ) -> None:
         """Ejecuta código en un sandbox.
 
         Args:
             linea: Código a ejecutar
-            safe_mode: Política de seguridad activa del REPL.
-            extra_validators: Validadores extra activos en la sesión REPL.
         """
         analizar_codigo(linea)
 
         script = construir_script_sandbox_canonico(
             linea,
-            safe_mode=safe_mode,
-            extra_validators=extra_validators,
+            safe_mode=self._seguro_repl,
+            extra_validators=self._extra_validators_repl,
             imprimir_resultado=True,
         )
 

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -410,11 +410,7 @@ def test_ejecutar_en_sandbox_arma_script_con_captura_y_booleanos():
         mock_lexer.return_value.tokenizar.return_value = ['TOK']
         mock_parser.return_value.parsear.return_value = ['AST']
 
-        cmd._ejecutar_en_sandbox(
-            'imprimir(1)',
-            safe_mode=cmd._seguro_repl,
-            extra_validators=cmd._extra_validators_repl,
-        )
+        cmd._ejecutar_en_sandbox('imprimir(1)')
 
     script_enviado = mock_sandbox.call_args.args[0]
     assert "safe_mode=False" in script_enviado
@@ -448,8 +444,29 @@ def test_run_repl_loop_pasa_estado_repl_a_ejecucion_sandbox():
 
     mock_sandbox.assert_called_once_with(
         "imprimir(1)",
-        safe_mode=False,
-        extra_validators=["extra.py"],
+    )
+
+
+def test_ejecutar_en_sandbox_usa_estado_repl_y_contrato_de_run_service():
+    cmd = InteractiveCommand(MagicMock())
+    cmd._seguro_repl = True
+    cmd._extra_validators_repl = ["extra_repl.py"]
+
+    with patch("cobra.cli.commands.interactive_cmd.analizar_codigo") as mock_analizar, \
+         patch("cobra.cli.commands.interactive_cmd.construir_script_sandbox_canonico", return_value="SCRIPT") as mock_script, \
+         patch("cobra.cli.commands.interactive_cmd.ejecutar_en_sandbox", return_value=None) as mock_ejecutar:
+        cmd._ejecutar_en_sandbox("imprimir(7)")
+
+    mock_analizar.assert_called_once_with("imprimir(7)")
+    mock_script.assert_called_once_with(
+        "imprimir(7)",
+        safe_mode=True,
+        extra_validators=["extra_repl.py"],
+        imprimir_resultado=True,
+    )
+    mock_ejecutar.assert_called_once_with(
+        "SCRIPT",
+        allow_insecure_fallback=False,
     )
 
 
@@ -482,3 +499,24 @@ def test_log_error_imprime_mensaje_limpio_sin_categoria_tecnica():
         cmd._log_error("Error de sintaxis", RuntimeError("Error: Error general: fallo"))
 
     assert mock_stdout.getvalue().strip() == "Error: fallo"
+
+
+def test_run_repl_loop_reporta_error_sandbox_una_sola_vez():
+    cmd = InteractiveCommand(MagicMock())
+
+    def _leer_linea_factory():
+        entradas = iter(["imprimir(1)", "salir"])
+        return lambda _prompt: next(entradas)
+
+    with patch.object(cmd, "validar_entrada", return_value=True), \
+         patch.object(cmd, "_ejecutar_en_sandbox", side_effect=RuntimeError("Error general: fallo controlado")), \
+         patch("cobra.cli.commands.interactive_cmd.mostrar_error") as mock_error:
+        cmd._run_repl_loop(
+            args=_args(),
+            validador=None,
+            leer_linea=_leer_linea_factory(),
+            sandbox=True,
+            sandbox_docker=None,
+        )
+
+    mock_error.assert_called_once_with("fallo controlado", registrar_log=False)


### PR DESCRIPTION
### Motivation
- Evitar pasar parámetros duplicados desde el loop REPL y garantizar que la ejecución sandbox use el estado de sesión del REPL como fuente única de verdad (`safe_mode` y `extra_validators`).
- Mantener el mismo flujo funcional que `RunService.ejecutar_en_sandbox` (analizar → construir script → ejecutar) y evitar reinicializar un intérprete paralelo para el sandbox.
- Asegurar que la política de mensajes de error del REPL no duplique trazas visibles al usuario final y sea consistente con `run`.

### Description
- Cambiado el dispatch en `_run_repl_loop` para llamar a `_ejecutar_en_sandbox(codigo)` sin reenviar `safe_mode` ni `extra_validators` explícitos. 
- Refactorizado `_ejecutar_en_sandbox` para usar `self._seguro_repl` y `self._extra_validators_repl` al llamar a `construir_script_sandbox_canonico`, preservando `imprimir_resultado=True` y reenviando `allow_insecure_fallback` a `ejecutar_en_sandbox`.
- Conservada la ruta unificada de manejo de errores en el loop REPL para que los mensajes al usuario sean normalizados por `_log_error` (sin duplicar trazas). 
- Actualizadas pruebas en `tests/unit/test_cli_interactive_cmd.py` para reflejar la nueva firma y añadidas pruebas que verifican que `_ejecutar_en_sandbox` sigue el mismo contrato que el servicio `run` y que los errores de sandbox se reportan una sola vez.

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_interactive_cmd.py -k "sandbox or log_error or run_repl_loop"` y la suite dirigida pasó con éxito (`5 passed, 29 deselected`).
- Las pruebas nuevas y modificadas en `tests/unit/test_cli_interactive_cmd.py` verifican la construcción del script usando el estado REPL y la política de error, y todas ellas pasaron en la ejecución anterior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e1f8c4d08327ad21454794bf8631)