### PR TITLE
Pass `session.prompt` directly to REPL loop and remove wrapper function

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -516,13 +516,10 @@ class InteractiveCommand(BaseCommand):
             session.history = _SessionHistoryFallback(history_path)  # type: ignore[attr-defined]
 
         with self:
-            def _leer_prompt_toolkit(prompt: str) -> str:
-                return session.prompt(prompt)
-
             self._run_repl_loop(
                 args=args,
                 validador=None,
-                leer_linea=_leer_prompt_toolkit,
+                leer_linea=session.prompt,
                 sandbox=sandbox,
                 sandbox_docker=sandbox_docker,
             )


### PR DESCRIPTION
### Motivation
- Simplify the REPL input handling by removing an unnecessary local wrapper and passing the `PromptSession` prompt callable directly to the REPL loop to improve readability and reduce indirection.

### Description
- Remove the `_leer_prompt_toolkit` nested function and call `_run_repl_loop` with `leer_linea=session.prompt` instead of the wrapper, keeping the existing `PromptSession` construction and fallback behavior unchanged.

### Testing
- Ran the test suite with `pytest` and linting with `flake8`, and the automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d8490ac883278566f092919ade7d)