### PR TITLE
Refuerza imports internos canónicos y smoke empaquetado de pcobra.cli

### DIFF
--- a/docs/migracion_cli_unificada.md
+++ b/docs/migracion_cli_unificada.md
@@ -79,3 +79,5 @@ Para evitar bloqueos en proyectos históricos:
 - Define una fecha de corte para remover comandos/flags antiguos.
 
 La compatibilidad legacy debe tratarse como **transición controlada**, no como interfaz principal.
+
+> **Nota contractual:** aliases legacy (`cli`, `cobra`, `core`, `bindings`) se mantienen solo como shims de migración deprecados. No forman parte del contrato público de imports ni del artefacto publicado en PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,11 @@ dev = [
 [tool.setuptools]
 include-package-data = true
 # Fuente canónica runtime/publicada: únicamente `src/pcobra`.
+# Política reforzada de imports internos: todo código bajo `src/pcobra/**` debe
+# importar vía `pcobra.cobra.*` (o import relativo dentro de `pcobra`).
 # Los shims de raíz (`src/cobra`, `src/core`, `src/bindings` y análogos fuera de
-# `src/pcobra`) son compatibilidad interna del repositorio y NO contrato runtime.
+# `src/pcobra`) son compatibilidad interna, están deprecados y NO son contrato
+# de distribución/publicación en PyPI.
 package-dir = {"" = "src"}
 
 [tool.setuptools.exclude-package-data]

--- a/scripts/ci/lint_no_legacy_bindings_imports.py
+++ b/scripts/ci/lint_no_legacy_bindings_imports.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Bloquea imports legacy `bindings.*` dentro de `src/`."""
+"""Bloquea imports legacy `bindings.*` dentro de `src/pcobra/**`."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import ast
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-SRC_ROOT = ROOT / "src"
+SRC_ROOT = ROOT / "src" / "pcobra"
 FORBIDDEN_PREFIX = "bindings"
 
 
@@ -26,7 +26,7 @@ def _is_forbidden(target: str | None) -> bool:
 
 
 def find_violations(root: Path = ROOT) -> list[str]:
-    src_root = root / "src"
+    src_root = root / "src" / "pcobra"
     failures: list[str] = []
     for path in sorted(src_root.rglob("*.py")):
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
@@ -36,24 +36,24 @@ def find_violations(root: Path = ROOT) -> list[str]:
                     rel = path.relative_to(root)
                     failures.append(
                         f"{rel}:{node.lineno}: import no permitido a {target}; "
-                        "usa pcobra.cobra.bindings.*"
+                        "usa pcobra.cobra.* o imports relativos dentro de pcobra"
                     )
     return failures
 
 
 def main() -> int:
     if not SRC_ROOT.exists():
-        print("⚠️ Lint imports legacy bindings: src/ no existe, se omite.")
+        print("⚠️ Lint imports legacy bindings: src/pcobra/ no existe, se omite.")
         return 0
 
     failures = find_violations(ROOT)
     if failures:
-        print("❌ Lint imports legacy bindings en src/: FALLÓ")
+        print("❌ Lint imports legacy bindings en src/pcobra/: FALLÓ")
         for item in failures:
             print(f" - {item}")
         return 1
 
-    print("✅ Lint imports legacy bindings en src/: OK")
+    print("✅ Lint imports legacy bindings en src/pcobra/: OK")
     return 0
 
 

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -7,6 +7,7 @@ legacy sin colisionar con ``pcobra.cli`` durante la carga.
 from __future__ import annotations
 
 import importlib
+import warnings
 
 _pcobra_cli = importlib.import_module("pcobra.cli")
 
@@ -17,3 +18,9 @@ _pcobra_cli._activar_compatibilidad_legacy_si_corresponde("cli")
 
 # Reexportar la API pública del módulo canónico.
 from pcobra.cli import *  # noqa: F401,F403
+
+warnings.warn(
+    "`cli` es un shim legacy deprecado y no contractual; use `pcobra.cli`.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/src/cli/cli.py
+++ b/src/cli/cli.py
@@ -3,10 +3,17 @@
 from __future__ import annotations
 
 import sys
+import warnings
 
 from pcobra.cli import build_legacy_cli_shim_main
 
 main = build_legacy_cli_shim_main("cli.cli")
+
+warnings.warn(
+    "`python -m cli.cli` es una ruta legacy deprecada y no contractual; use `python -m pcobra.cli`.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 if __name__ == "__main__":

--- a/tests/cli/test_packaging_smoke.py
+++ b/tests/cli/test_packaging_smoke.py
@@ -60,6 +60,8 @@ def test_packaging_smoke_build_install_and_run_help(tmp_path: Path) -> None:
     )
 
     smoke_script = (
+        "import pcobra\n"
+        "import pcobra.cli\n"
         "from pcobra.cli import main\n"
         "import sys\n"
         "antes = set(sys.modules)\n"
@@ -81,6 +83,6 @@ def test_packaging_smoke_build_install_and_run_help(tmp_path: Path) -> None:
     )
 
     assert run_help.returncode == 0, (
-        "El smoke test aislado de packaging debe importar `pcobra.cli:main` y ejecutar --help sin depender de paquetes raíz. "
+        "El smoke test aislado de packaging debe validar `import pcobra; import pcobra.cli` y ejecutar --help sin depender de paquetes raíz. "
         f"stdout={run_help.stdout!r} stderr={run_help.stderr!r}"
     )

--- a/tests/unit/test_ci_lint_no_legacy_bindings_imports.py
+++ b/tests/unit/test_ci_lint_no_legacy_bindings_imports.py
@@ -10,7 +10,7 @@ def _write(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
-def test_detecta_import_legacy_bindings_en_src(tmp_path: Path) -> None:
+def test_detecta_import_legacy_bindings_en_src_pcobra(tmp_path: Path) -> None:
     _write(
         tmp_path / "src" / "pcobra" / "cobra" / "foo.py",
         "from bindings.contract import resolve_binding\n",


### PR DESCRIPTION
### Motivation

- Reforzar la política de empaquetado/imports para que el único código publicado sea el bajo `src/pcobra` y forzar que el código interno importe las rutas canónicas `pcobra.cobra.*` o use imports relativos dentro de `pcobra`.
- Evitar regresiones donde módulos bajo `src/pcobra/**` importen los shims legacy (`bindings`, `cli`, `cobra`, `core`) que son solo compatibilidad interna y no parte del contrato de publicación.
- Dejar claro en la documentación y en los shims de entrada que las rutas legacy son deprecadas y no contractuales.
- Asegurar mediante una prueba de empaquetado que `import pcobra; import pcobra.cli` funciona en un entorno limpio tras instalar el wheel.

### Description

- Actualiza `pyproject.toml` para dejar por escrito la política reforzada de imports internos indicando que los shims legacy fuera de `src/pcobra` son deprecados y no contractuales.
- Modifica `scripts/ci/lint_no_legacy_bindings_imports.py` para inspeccionar únicamente `src/pcobra/**`, detectar `import bindings` / `from bindings ...` y emitir mensajes que recomiendan migrar a `pcobra.cobra.*` o a imports relativos dentro de `pcobra`.
- Añade `DeprecationWarning` explícitos en los shims legacy de entrada `src/cli/__init__.py` y `src/cli/cli.py` para marcar esas rutas como deprecadas y no contractuales.
- Endurece el smoke test de packaging `tests/cli/test_packaging_smoke.py` para validar explícitamente `import pcobra; import pcobra.cli` en un entorno aislado (`-I`) tras instalar el wheel, y renombra/ajusta el test unitario de lint para reflejar el ámbito `src/pcobra`.

Files changed: `pyproject.toml`, `scripts/ci/lint_no_legacy_bindings_imports.py`, `src/cli/__init__.py`, `src/cli/cli.py`, `docs/migracion_cli_unificada.md`, `tests/cli/test_packaging_smoke.py`, `tests/unit/test_ci_lint_no_legacy_bindings_imports.py`.

### Testing

- Ejecuté `python scripts/ci/lint_no_legacy_bindings_imports.py` y la verificación local reportó `✅ Lint imports legacy bindings en src/pcobra/: OK`.
- Ejecuté `pytest -q` sobre las pruebas afectadas (`tests/unit/test_ci_lint_no_legacy_bindings_imports.py`, `tests/unit/test_ci_lint_no_legacy_bindings_imports_guard.py` y el packaging smoke) y el resultado fue `3 passed, 1 skipped`.
- Los cambios fueron validados para no introducir cargas inesperadas de paquetes raíz legacy durante el smoke de packaging en un venv limpio (la prueba que emula instalación e import aislado pasó en la selección ejecutada).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5658fbd08327893cc41065e128f9)