### PR TITLE
Aplicar límites de imports en comandos CLI y forzar acceso a transpiladores vía registry

### DIFF
--- a/scripts/ci/lint_no_cross_command_imports.py
+++ b/scripts/ci/lint_no_cross_command_imports.py
@@ -2,11 +2,16 @@
 """Lint interno para comandos CLI.
 
 Reglas:
-1) Prohíbe imports entre módulos de comandos CLI.
-2) Permite únicamente ``from ...commands.base import BaseCommand``
-   (salvo excepciones explícitas y justificadas).
-3) Prohíbe estado compartido local en módulos comando
+1) Construye el grafo de imports Python bajo ``cli/commands``.
+2) Prohíbe edges ``commands.X -> commands.Y`` (salvo ``commands.base``).
+3) En imports internos de ``pcobra.cobra.cli.*`` permite solo:
+   ``commands.base``, ``services/*``, ``utils/*``, ``i18n``,
+   ``target_policies`` y registries dedicados.
+4) Prohíbe estado compartido local en módulos comando
    (por ejemplo, ``TRANSPILERS = {...}`` y constantes similares).
+5) Contrato de transpiladores: el acceso compartido debe pasar por
+   ``pcobra.cobra.cli.transpiler_registry`` o
+   ``pcobra.cobra.transpilers.registry``.
 """
 
 from __future__ import annotations
@@ -15,10 +20,8 @@ import ast
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-FORBIDDEN_PREFIXES = (
-    "pcobra.cobra.cli.commands",
-    "cobra.cli.commands",
-)
+COMMANDS_PACKAGE_PREFIXES = ("pcobra.cobra.cli.commands", "cobra.cli.commands")
+CLI_PACKAGE_PREFIXES = ("pcobra.cobra.cli", "cobra.cli")
 ALLOWED_BASE_IMPORT_MODULES = {
     "pcobra.cobra.cli.commands.base",
     "cobra.cli.commands.base",
@@ -32,14 +35,41 @@ ALLOWED_COMMAND_IMPORT_EXCEPTIONS: dict[str, set[str]] = {
         "pcobra.cobra.cli.commands.base",
     },
 }
-FORBIDDEN_DIRECT_REGISTRY_IMPORTS = {
+ALLOWED_CLI_IMPORT_PREFIXES = (
+    "pcobra.cobra.cli.commands.base",
+    "pcobra.cobra.cli.services.",
+    "pcobra.cobra.cli.utils.",
+    "pcobra.cobra.cli.i18n",
+    "pcobra.cobra.cli.target_policies",
+    "cobra.cli.commands.base",
+    "cobra.cli.services.",
+    "cobra.cli.utils.",
+    "cobra.cli.i18n",
+    "cobra.cli.target_policies",
+)
+ALLOWED_CLI_REGISTRY_SUFFIX = "_registry"
+# Módulos de infraestructura existentes que siguen siendo válidos dentro del CLI
+# y que no forman parte de la regla principal de imports para commands.
+ALLOWED_CLI_INFRA_MODULES = {
+    "pcobra.cobra.cli.mode_policy",
+    "pcobra.cobra.cli.deprecation_policy",
+    "pcobra.cobra.cli.execution_pipeline",
+    "pcobra.cobra.cli.repl.cobra_lexer",
+}
+TRANSPILER_SHARED_ALLOWED_MODULES = {
+    "pcobra.cobra.cli.transpiler_registry",
     "pcobra.cobra.transpilers.registry",
+    "cobra.cli.transpiler_registry",
     "cobra.transpilers.registry",
+}
+FORBIDDEN_TRANSPILER_SHARED_MODULES = {
+    "pcobra.cobra.transpilers",
+    "pcobra.cobra.transpilers.module_map",
 }
 
 
 def _is_forbidden_module_name(module: str) -> bool:
-    for prefix in FORBIDDEN_PREFIXES:
+    for prefix in COMMANDS_PACKAGE_PREFIXES:
         if module == prefix:
             return True
         if module.startswith(f"{prefix}."):
@@ -47,18 +77,6 @@ def _is_forbidden_module_name(module: str) -> bool:
             if suffix == "base":
                 return False
             return True
-    return False
-
-
-def _is_forbidden_import_from(node: ast.ImportFrom) -> bool:
-    module = node.module or ""
-    if _is_forbidden_module_name(module):
-        return True
-
-    if module in FORBIDDEN_PREFIXES:
-        allowed_names = {"base"}
-        imported_names = {alias.name for alias in node.names}
-        return not imported_names.issubset(allowed_names)
     return False
 
 
@@ -77,6 +95,29 @@ def _resolve_relative_module(path: Path, module: str | None, level: int, root: P
     if module:
         base_parts.extend(module.split("."))
     return ".".join(base_parts)
+
+
+def _node_import_targets(path: Path, node: ast.AST, root: Path) -> list[str]:
+    targets: list[str] = []
+    if isinstance(node, ast.Import):
+        targets.extend(alias.name for alias in node.names)
+    elif isinstance(node, ast.ImportFrom):
+        module = _resolve_relative_module(path, node.module, node.level, root)
+        if module:
+            targets.append(module)
+    return targets
+
+
+def _build_import_graph(path: Path, root: Path) -> dict[str, set[str]]:
+    source_module = _resolve_relative_module(path, None, 0, root)
+    if not source_module:
+        return {}
+    graph: dict[str, set[str]] = {source_module: set()}
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        for target in _node_import_targets(path, node, root):
+            graph[source_module].add(target)
+    return graph
 
 
 def _scan_restricted_command_imports(path: Path, root: Path) -> list[tuple[int, str]]:
@@ -108,21 +149,6 @@ def _scan_restricted_command_imports(path: Path, root: Path) -> list[tuple[int, 
     return violations
 
 
-def _scan_file(path: Path) -> list[tuple[int, str]]:
-    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    violations: list[tuple[int, str]] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                if _is_forbidden_module_name(alias.name):
-                    violations.append((node.lineno, alias.name))
-        elif isinstance(node, ast.ImportFrom):
-            if _is_forbidden_import_from(node):
-                label = node.module or "<relative>"
-                violations.append((node.lineno, label))
-    return violations
-
-
 def _scan_cross_cmd_pattern_imports(path: Path, root: Path) -> list[tuple[int, str]]:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     violations: list[tuple[int, str]] = []
@@ -131,7 +157,7 @@ def _scan_cross_cmd_pattern_imports(path: Path, root: Path) -> list[tuple[int, s
             module = _resolve_relative_module(path, node.module, node.level, root) or ""
             if not module.endswith("_cmd"):
                 continue
-            for prefix in FORBIDDEN_PREFIXES:
+            for prefix in COMMANDS_PACKAGE_PREFIXES:
                 if module.startswith(f"{prefix}."):
                     violations.append((node.lineno, module))
                     break
@@ -140,25 +166,53 @@ def _scan_cross_cmd_pattern_imports(path: Path, root: Path) -> list[tuple[int, s
                 module = alias.name
                 if not module.endswith("_cmd"):
                     continue
-                for prefix in FORBIDDEN_PREFIXES:
+                for prefix in COMMANDS_PACKAGE_PREFIXES:
                     if module.startswith(f"{prefix}."):
                         violations.append((node.lineno, module))
                         break
     return violations
 
 
-def _scan_direct_registry_imports(path: Path) -> list[tuple[int, str]]:
+def _is_allowed_cli_registry_module(module: str) -> bool:
+    leaf = module.rsplit(".", 1)[-1]
+    return leaf.endswith(ALLOWED_CLI_REGISTRY_SUFFIX)
+
+
+def _is_allowed_cli_dependency(module: str) -> bool:
+    if module in ALLOWED_CLI_INFRA_MODULES:
+        return True
+    if _is_allowed_cli_registry_module(module):
+        return True
+    return any(module == prefix or module.startswith(prefix) for prefix in ALLOWED_CLI_IMPORT_PREFIXES)
+
+
+def _scan_cli_dependency_boundaries(path: Path, root: Path) -> list[tuple[int, str]]:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     violations: list[tuple[int, str]] = []
     for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                if alias.name in FORBIDDEN_DIRECT_REGISTRY_IMPORTS:
-                    violations.append((node.lineno, alias.name))
-        elif isinstance(node, ast.ImportFrom):
-            module = node.module or ""
-            if module in FORBIDDEN_DIRECT_REGISTRY_IMPORTS:
+        for module in _node_import_targets(path, node, root):
+            if not module.startswith(CLI_PACKAGE_PREFIXES):
+                continue
+            if _is_allowed_cli_dependency(module):
+                continue
+            violations.append((node.lineno, module))
+    return violations
+
+
+def _scan_transpiler_shared_access(path: Path, root: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        for module in _node_import_targets(path, node, root):
+            if module in FORBIDDEN_TRANSPILER_SHARED_MODULES:
                 violations.append((node.lineno, module))
+                continue
+            if module.startswith("pcobra.cobra.transpilers.") and module.endswith(".module_map"):
+                violations.append((node.lineno, module))
+                continue
+            if module.startswith("pcobra.cobra.transpilers.registry"):
+                if module in TRANSPILER_SHARED_ALLOWED_MODULES:
+                    continue
     return violations
 
 
@@ -208,21 +262,35 @@ def find_violations(root: Path = ROOT) -> list[str]:
             continue
         for path in sorted(scope.rglob("*.py")):
             rel = path.relative_to(root)
+            graph = _build_import_graph(path, root)
             if path.name != "__init__.py":
                 for line, target in _scan_restricted_command_imports(path, root):
                     failures.append(
                         f"{rel}:{line}: import entre comandos no permitido ({target}); "
                         "solo se permite `from ...commands.base import BaseCommand` (o excepción explícita)"
                     )
+                for source, edges in graph.items():
+                    for target in sorted(edges):
+                        if not _is_forbidden_module_name(target):
+                            continue
+                        failures.append(
+                            f"{rel}: edge no permitido en grafo de imports ({source} -> {target}); "
+                            "los comandos no deben depender de comandos concretos"
+                        )
                 for line, target in _scan_cross_cmd_pattern_imports(path, root):
                     failures.append(
                         f"{rel}:{line}: patrón *_cmd no permitido ({target}); "
                         "los comandos no deben importar otros *_cmd.py (solo BaseCommand desde commands.base)"
                     )
-            for line, target in _scan_direct_registry_imports(path):
+                for line, target in _scan_cli_dependency_boundaries(path, root):
+                    failures.append(
+                        f"{rel}:{line}: dependencia CLI no permitida ({target}); "
+                        "en commands solo se permite base/services/utils/i18n/target_policies/registries"
+                    )
+            for line, target in _scan_transpiler_shared_access(path, root):
                 failures.append(
-                    f"{rel}:{line}: import directo no permitido ({target}); "
-                    "usa pcobra.cobra.cli.transpiler_registry.cli_transpilers()/cli_transpiler_targets()"
+                    f"{rel}:{line}: acceso compartido de transpiladores no permitido ({target}); "
+                    "usa pcobra.cobra.cli.transpiler_registry o pcobra.cobra.transpilers.registry"
                 )
             for line, constant_name in _scan_backend_constant_violations(path):
                 failures.append(
@@ -235,12 +303,12 @@ def find_violations(root: Path = ROOT) -> list[str]:
 def main() -> int:
     failures = find_violations(ROOT)
     if failures:
-        print("❌ Lint de contratos en comandos (imports cruzados + constantes locales): FALLÓ")
+        print("❌ Lint de contratos en comandos (grafo imports + fronteras + contrato transpiladores): FALLÓ")
         for item in failures:
             print(f" - {item}")
         return 1
 
-    print("✅ Lint de contratos en comandos (imports cruzados + constantes locales): OK")
+    print("✅ Lint de contratos en comandos (grafo imports + fronteras + contrato transpiladores): OK")
     return 0
 
 

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -41,7 +41,6 @@ from pcobra.cobra.cli.execution_pipeline import (
     resolver_interpretador_cls,
     validar_ast_seguro,
 )
-from pcobra.cobra.transpilers import module_map
 from pcobra.cobra.core import (
     NodoBucleMientras,
     NodoCondicional,
@@ -77,6 +76,7 @@ from pcobra.cobra.cli.target_policies import (
     parse_runtime_target,
     resolve_docker_backend,
 )
+from pcobra.cobra.cli.transpiler_registry import cli_toml_map
 DOCKER_RUNTIME_TARGETS = tuple(DOCKER_RUNTIME_BY_TARGET.values())
 SANDBOX_DOCKER_CHOICES = DOCKER_EXECUTABLE_TARGETS
 SANDBOX_DOCKER_HELP = OFFICIAL_RUNTIME_TARGETS_HELP
@@ -430,7 +430,7 @@ class InteractiveCommand(BaseCommand):
                     return 1
 
             # Validar dependencias
-            validar_dependencias("python", module_map.get_toml_map())
+            validar_dependencias("python", cli_toml_map())
         except (ValueError, FileNotFoundError) as err:
             mostrar_error(
                 _("Error de dependencias durante la inicialización: {err}").format(

--- a/src/pcobra/cobra/cli/commands/profile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/profile_cmd.py
@@ -15,7 +15,6 @@ from typing import Optional, Any
 
 from pcobra.cobra.core import Lexer
 from pcobra.cobra.core import Parser
-from pcobra.cobra.transpilers import module_map
 from pcobra.core.interpreter import InterpretadorCobra
 from pcobra.core.sandbox import validar_dependencias
 from pcobra.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
@@ -28,6 +27,7 @@ from pcobra.cobra.cli.utils.validators import (
     normalizar_validadores_extra,
     validar_archivo_existente,
 )
+from pcobra.cobra.cli.transpiler_registry import cli_toml_map
 
 
 class ProfileCommand(BaseCommand):
@@ -109,7 +109,7 @@ class ProfileCommand(BaseCommand):
             return 1
 
         try:
-            validar_dependencias("python", module_map.get_toml_map())
+            validar_dependencias("python", cli_toml_map())
         except (ValueError, FileNotFoundError) as dep_err:
             mostrar_error(f"Error de dependencias: {dep_err}")
             return 1

--- a/src/pcobra/cobra/cli/transpiler_registry.py
+++ b/src/pcobra/cobra/cli/transpiler_registry.py
@@ -24,6 +24,7 @@ from pcobra.cobra.transpilers.registry import (
     plugin_transpilers,
     register_transpiler_backend,
 )
+from pcobra.cobra.transpilers.module_map import get_toml_map
 
 
 def cli_transpilers() -> Mapping[str, type]:
@@ -56,3 +57,8 @@ def cli_register_transpiler_backend(backend: str, transpiler_cls, *, context: st
 def cli_load_entrypoint_transpilers() -> tuple[int, int, int]:
     """Carga explícita de entrypoints, manteniendo contrato legacy de retorno."""
     return load_entrypoint_transpilers()
+
+
+def cli_toml_map() -> dict:
+    """Devuelve el mapa de configuración TOML para consumo compartido en CLI."""
+    return get_toml_map()

--- a/tests/unit/test_ci_lint_no_cross_command_imports.py
+++ b/tests/unit/test_ci_lint_no_cross_command_imports.py
@@ -82,15 +82,15 @@ def test_detecta_import_relativo_a_otro_comando(tmp_path: Path) -> None:
     assert any("src/pcobra/cobra/cli/commands/bad.py:1" in item for item in violations)
 
 
-def test_detecta_import_directo_registry_en_comando(tmp_path: Path) -> None:
+def test_detecta_acceso_compartido_transpilers_fuera_registry(tmp_path: Path) -> None:
     _write(
         tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "a.py",
-        "from pcobra.cobra.transpilers.registry import get_transpilers\n",
+        "from pcobra.cobra.transpilers import module_map\n",
     )
 
     violations = find_violations(tmp_path)
 
-    assert "import directo no permitido" in violations[0]
+    assert "acceso compartido de transpiladores no permitido" in violations[0]
     assert "src/pcobra/cobra/cli/commands/a.py:1" in violations[0]
 
 


### PR DESCRIPTION
### Motivation
- Evitar dependencias cruzadas entre módulos concretos de `src/pcobra/cobra/cli/commands` que rompan la separación de responsabilidades.
- Restringir los imports internos del espacio `pcobra.cobra.cli.*` a una superficie bien definida para facilitar auditoría y refactorizaciones.
- Proteger el contrato de acceso a transpiladores para que todo acceso compartido pase por el registro canónico en lugar de usar `module_map` u otros módulos internos.

### Description
- Refactoricé `scripts/ci/lint_no_cross_command_imports.py` para construir explícitamente el grafo de imports de `cli/commands` y fallar cuando exista un edge `commands.X -> commands.Y` (salvo `commands.base`).
- Añadí comprobaciones de frontera para imports desde ficheros de `commands` permitiendo solo `commands.base`, `services/*`, `utils/*`, `i18n`, `target_policies` y registries dedicados, y documenté excepciones de infraestructura.
- Introduje reglas específicas para el contrato de transpiladores que bloquean imports directos a `pcobra.cobra.transpilers` o a `module_map` desde `commands`, y emití mensaje que obliga a usar `pcobra.cobra.cli.transpiler_registry` o `pcobra.cobra.transpilers.registry`.
- Expuse `cli_toml_map()` en `src/pcobra/cobra/cli/transpiler_registry.py` y migré `interactive_cmd.py` y `profile_cmd.py` para usarlo en lugar de `pcobra.cobra.transpilers.module_map`.
- Actualicé el test unitario correspondiente en `tests/unit/test_ci_lint_no_cross_command_imports.py` para cubrir el nuevo caso del contrato de transpiladores.

### Testing
- Ejecuté el lint localmente con `python scripts/ci/lint_no_cross_command_imports.py` y obtuvo salida OK.
- Ejecuté los tests relevantes con `python -m pytest -q tests/unit/test_ci_lint_no_cross_command_imports.py tests/unit/test_ci_lint_no_cross_command_imports_guard.py` y ambos pasaron (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb02c5c4388327871bad3dfd4818b4)