### PR TITLE
Fix memory bookkeeping for assignments in captured scopes

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1166,13 +1166,16 @@ class InterpretadorCobra:
                 # Declaración local (explícita o por inferencia)
                 self.contextos[-1].define(nombre, valor)
             else:
-                # Si la variable ya tiene memoria reservada, se libera
-                mem_ctx = self.mem_contextos[-1]
-                if nombre in mem_ctx:
-                    idx, tam = mem_ctx.pop(nombre)
-                    self.liberar_memoria(idx, tam)
+                # Mutación: resolver primero en qué entorno vive la variable.
+                # Si no existe todavía, ``set`` la creará en el scope actual.
+                indice_contexto = self._indice_entorno_variable(nombre)
+                if indice_contexto is None:
+                    indice_contexto = len(self.mem_contextos) - 1
+
+                # Liberar/reasignar en el contexto real (no forzar el actual).
+                self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
                 indice = self.solicitar_memoria(1)
-                mem_ctx[nombre] = (indice, 1)
+                self.mem_contextos[indice_contexto][nombre] = (indice, 1)
                 self.contextos[-1].set(nombre, valor)
         return valor
 

--- a/tests/unit/test_interpreter_scope_contract.py
+++ b/tests/unit/test_interpreter_scope_contract.py
@@ -55,6 +55,82 @@ def test_reasignacion_en_mientras_persiste_fuera_del_loop() -> None:
     assert inter.obtener_variable("i") == 3
 
 
+def test_mientras_reasigna_memoria_en_entorno_real_y_persiste_fuera() -> None:
+    inter = InterpretadorCobra()
+    inter.ejecutar_asignacion(NodoAsignacion("i", NodoValor(0), declaracion=True))
+    inter.mem_contextos[0]["i"] = (11, 1)
+
+    liberaciones: list[tuple[int, int]] = []
+    solicitudes = iter([22, 33])
+    inter.liberar_memoria = lambda idx, tam: liberaciones.append((idx, tam))
+    inter.solicitar_memoria = lambda tam: next(solicitudes)
+
+    condicion = NodoOperacionBinaria(
+        NodoIdentificador("i"),
+        Token(TipoToken.MENORQUE, "<"),
+        NodoValor(2),
+    )
+    incremento = NodoAsignacion(
+        "i",
+        NodoOperacionBinaria(
+            NodoIdentificador("i"),
+            Token(TipoToken.SUMA, "+"),
+            NodoValor(1),
+        ),
+    )
+
+    with patch.object(
+        InterpretadorCobra,
+        "_asegurar_no_autorreferencia_asignacion",
+        return_value=None,
+    ):
+        inter.ejecutar_mientras(NodoBucleMientras(condicion, [incremento]))
+
+    assert inter.obtener_variable("i") == 2
+    assert liberaciones == [(11, 1), (22, 1)]
+    assert inter.mem_contextos[0]["i"] == (33, 1)
+
+
+
+def test_closure_mutacion_reasigna_en_padre_y_persiste_tras_salir() -> None:
+    inter = InterpretadorCobra()
+    inter.ejecutar_asignacion(NodoAsignacion("base", NodoValor(10), declaracion=True))
+    inter.mem_contextos[0]["base"] = (100, 1)
+
+    liberaciones: list[tuple[int, int]] = []
+    inter.liberar_memoria = lambda idx, tam: liberaciones.append((idx, tam))
+    inter.solicitar_memoria = lambda tam: 200
+
+    closure = NodoFuncion(
+        "sumar_uno",
+        [],
+        [
+            NodoAsignacion(
+                "base",
+                NodoOperacionBinaria(
+                    NodoIdentificador("base"),
+                    Token(TipoToken.SUMA, "+"),
+                    NodoValor(1),
+                ),
+            )
+        ],
+    )
+
+    with patch.object(
+        InterpretadorCobra,
+        "_asegurar_no_autorreferencia_asignacion",
+        return_value=None,
+    ):
+        inter.ejecutar_funcion(closure)
+        inter.ejecutar_llamada_funcion(NodoLlamadaFuncion("sumar_uno", []))
+
+    assert inter.obtener_variable("base") == 11
+    assert liberaciones == [(100, 1)]
+    assert inter.mem_contextos[0]["base"] == (200, 1)
+    assert len(inter.contextos) == 1
+    assert len(inter.mem_contextos) == 1
+
+
 def test_reasignacion_en_funcion_actualiza_scope_capturado_padre() -> None:
     with patch.object(
         InterpretadorCobra,


### PR DESCRIPTION
### Motivation
- Corrige una inconsistencia donde las mutaciones (`set`) siempre modificaban `mem_contextos[-1]` en lugar del contexto real donde vive la variable, provocando liberaciones/asignaciones de memoria en el scope equivocado.
- Garantizar que las reasignaciones dentro de `mientras` y closures afecten al entorno léxico capturado y persistan tras salir del bloque.
- Mantener la semántica existente: `define` para declaraciones locales y `set` para mutación de variables ya existentes.

### Description
- En `InterpretadorCobra.ejecutar_asignacion` se resuelve primero el índice del entorno donde vive la variable usando `self._indice_entorno_variable(nombre)` y se usa ese índice para operar `mem_contextos` en lugar de asumir el contexto actual.
- Se usa `_liberar_memoria_variable_en_contexto(nombre, indice_contexto)` para liberar la memoria previa y luego se registra la nueva asignación en `self.mem_contextos[indice_contexto][nombre] = (indice, 1)`.
- Se preserva `self.contextos[-1].define(...)` para declaraciones (`declaracion`/`inferencia`) y `set` para mutaciones, dejando el bookkeeping consistente por índice de entorno.
- Se añadieron dos pruebas unitarias en `tests/unit/test_interpreter_scope_contract.py` que verifican reasignación/visibilidad/persistencia y el correcto liberado/reasignado de bloques de memoria dentro de `mientras` y dentro de closures que mutan variables capturadas.

### Testing
- Ejecutados los tests específicos añadidos con `pytest -q tests/unit/test_interpreter_scope_contract.py -k "mientras_reasigna_memoria_en_entorno_real_y_persiste_fuera or closure_mutacion_reasigna_en_padre_y_persiste_tras_salir"`, resultado: `2 passed, 12 deselected`.
- Ejecutado todo el archivo de contrato de scope con `pytest -q tests/unit/test_interpreter_scope_contract.py`, resultado: `14 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1a675bc88327a4b421b0eecc4057)