### PR TITLE
Añadir tests de contrato de paridad entre ejecución por script y REPL

### DIFF
--- a/.github/workflows/runtime-stabilization-contract.yml
+++ b/.github/workflows/runtime-stabilization-contract.yml
@@ -39,6 +39,7 @@ jobs:
             tests/unit/test_cli_execution_pipeline_contract.py::test_contrato_salida_y_error_iguales_entre_execute_e_interactive \
             tests/unit/test_cli_execution_pipeline_contract.py::test_paridad_repl_script_mientras_con_mutacion_persistente_mismo_entorno \
             tests/unit/test_cli_execution_pipeline_contract.py::test_contrato_repl_igual_script_estado_final_con_bucles_y_asignaciones \
+            tests/unit/test_parity_contract_run_vs_repl.py \
             tests/unit/test_interpreter_loop_scope_regression.py \
             tests/test_lexer.py \
             tests/unit/test_lark_parser_tokens.py \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ markers = [
     "timeout: tiempo máximo de ejecución de una prueba",
     "slow: pruebas lentas",
     "integration: pruebas de integración",
+    "parity_contract: pruebas contractuales de paridad bloqueantes entre run script y REPL",
     "fuzz: pruebas de mutación/fuzzing",
     "performance: pruebas de rendimiento",
     "experimental: pruebas best-effort o manuales fuera del contrato oficial de runtime",

--- a/tests/unit/test_parity_contract_run_vs_repl.py
+++ b/tests/unit/test_parity_contract_run_vs_repl.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+from pcobra.cobra.cli.services.run_service import RunService
+from pcobra.cobra.core.runtime import InterpretadorCobra
+
+pytestmark = pytest.mark.parity_contract
+
+
+def _normalizar_salida(texto: str) -> str:
+    return "\n".join(linea.strip() for linea in texto.splitlines() if linea.strip())
+
+
+def _ejecutar_modo_script(snippets: list[str]) -> dict[str, str | int]:
+    codigo = "\n\n".join(snippets)
+    servicio = RunService()
+    out, err = StringIO(), StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        with patch.object(
+            InterpretadorCobra,
+            "_asegurar_no_autorreferencia_asignacion",
+            return_value=None,
+        ):
+            rc = servicio.ejecutar_normal(codigo, seguro=False, extra_validators=None)
+    return {
+        "rc": rc,
+        "stdout": _normalizar_salida(out.getvalue()),
+        "stderr": _normalizar_salida(err.getvalue()),
+    }
+
+
+def _ejecutar_modo_repl(snippets: list[str]) -> dict[str, str]:
+    repl = InteractiveCommand(InterpretadorCobra())
+    repl._seguro_repl = False
+    repl._extra_validators_repl = None
+    out, err = StringIO(), StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        with patch.object(
+            InterpretadorCobra,
+            "_asegurar_no_autorreferencia_asignacion",
+            return_value=None,
+        ):
+            for snippet in snippets:
+                repl.ejecutar_codigo(snippet)
+    return {
+        "stdout": _normalizar_salida(out.getvalue()),
+        "stderr": _normalizar_salida(err.getvalue()),
+    }
+
+
+@pytest.mark.parametrize(
+    ("caso", "snippets", "salida_esperada"),
+    [
+        (
+            "declaracion_externa_mutacion_en_mientras_y_lectura_posterior",
+            [
+                "var contador = 0\nmientras contador < 3:\n    contador = contador + 1\nfin",
+                "imprimir(contador)",
+            ],
+            "3",
+        ),
+        (
+            "si_sino_no_crea_scope_nuevo",
+            [
+                "var estado = 0\nsi verdadero:\n    estado = 11\nsino:\n    estado = 22\nfin",
+                "imprimir(estado)",
+            ],
+            "11",
+        ),
+        (
+            "funcion_con_captura_de_entorno",
+            [
+                "var base = 7\nfunc sumar_base(valor):\n    retorno valor + base\nfin",
+                "imprimir(sumar_base(5))",
+            ],
+            "12",
+        ),
+    ],
+)
+def test_parity_contract_run_service_vs_repl(caso: str, snippets: list[str], salida_esperada: str) -> None:
+    resultado_script = _ejecutar_modo_script(snippets)
+    resultado_repl = _ejecutar_modo_repl(snippets)
+
+    assert resultado_script["rc"] == 0, f"{caso}: RunService debe finalizar con éxito"
+    assert resultado_script["stderr"] == resultado_repl["stderr"] == "", (
+        f"{caso}: no debe haber salida de error entre rutas"
+    )
+    assert resultado_script["stdout"] == resultado_repl["stdout"], (
+        f"{caso}: la salida observable debe ser idéntica entre script y REPL"
+    )
+    assert resultado_script["stdout"].endswith(salida_esperada), (
+        f"{caso}: la salida final observable debe reflejar el estado esperado"
+    )


### PR DESCRIPTION
### Motivation
- Garantizar paridad observable entre la ruta de ejecución por script y la ruta REPL en casos críticos de scope y mutación para convertirlo en un contrato bloqueante de CI.
- Cubrir los escenarios mínimos: declaración fuera de bucle + mutación dentro de `mientras` + lectura posterior, `si/sino` sin crear nuevo scope, y función que captura el entorno.

### Description
- Añadí la suite de pruebas `tests/unit/test_parity_contract_run_vs_repl.py` marcada con `@pytest.mark.parity_contract` que ejecuta los mismos snippets por dos rutas (modo script vía `RunService.ejecutar_normal` y modo REPL vía `InteractiveCommand.ejecutar_codigo` con intérprete persistente) y compara `stdout`, `stderr` y código de retorno.
- Registré el marker `parity_contract` en `pyproject.toml` para mantener compatibilidad con `--strict-markers`.
- Incluí el nuevo test en la batería bloqueante del workflow `runtime-stabilization-contract.yml` para que la prueba actúe como gate en CI.
- En las pruebas se parchea `_asegurar_no_autorreferencia_asignacion` sobre `InterpretadorCobra` para evitar interferencias de autoreferencia en el contexto de los snippets ejecutados por las rutas.

### Testing
- Ejecuté localmente `pytest -q tests/unit/test_parity_contract_run_vs_repl.py` para validar la nueva suite.
- Resultado: las 3 pruebas definidas fallaron (3 failures), mostrando divergencias reales entre la ejecución por script y la REPL en los escenarios contractuales añadidos.
- El fallo indica que la suite está detectando inconsistencias observables (salida/estado/excepciones) que deben investigarse antes de aceptar la paridad como garantizada en CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3b72099083278f8b58927a7c944c)