### PR TITLE
tests: migrate compilar --tipos unit test to canonical CLI transpiler registry

### DIFF
--- a/tests/unit/test_cli_compilar_tipos.py
+++ b/tests/unit/test_cli_compilar_tipos.py
@@ -3,6 +3,8 @@ from unittest.mock import patch
 
 import pytest
 
+from pcobra.cobra.cli import transpiler_registry
+
 
 @pytest.mark.timeout(5)
 def test_cli_compilar_con_tipos(tmp_path, monkeypatch):
@@ -15,6 +17,7 @@ def test_cli_compilar_con_tipos(tmp_path, monkeypatch):
     monkeypatch.setattr(cli_module, "setup_gettext", lambda lang=None: (lambda s: s))
     monkeypatch.setattr(cli_module.messages, "mostrar_logo", lambda: None)
     monkeypatch.setattr(cli_module.messages, "disable_colors", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli_module, "resolve_command_profile", lambda: "development")
 
     monkeypatch.setattr(cli_module.AppConfig, "BASE_COMMAND_CLASSES", [compile_module.CompileCommand])
 
@@ -44,7 +47,18 @@ def test_cli_compilar_con_tipos(tmp_path, monkeypatch):
         def generate_code(self, _ast):
             return "js"
 
-    monkeypatch.setattr(compile_module, "TRANSPILERS", {"python": FakePython, "javascript": FakeJS})
+    monkeypatch.setattr(
+        transpiler_registry,
+        "cli_transpilers",
+        lambda: {"python": FakePython, "javascript": FakeJS},
+    )
+    monkeypatch.setattr(
+        transpiler_registry,
+        "cli_transpiler_targets",
+        lambda: ("python", "javascript"),
+    )
+    monkeypatch.setattr(compile_module, "cli_transpiler_targets", lambda: ("python", "javascript"))
+    monkeypatch.setattr(compile_module, "cli_plugin_transpilers", lambda: {"python": FakePython, "javascript": FakeJS})
 
     class DummyPool:
         def __init__(self, processes=None):
@@ -76,5 +90,7 @@ def test_cli_compilar_con_tipos(tmp_path, monkeypatch):
 
     assert exit_code == 0
     salida = out.getvalue()
-    assert "Código generado (FakePython) para Python (python):" in salida
-    assert "Código generado (FakeJS) para JavaScript (javascript):" in salida
+    assert "Código generado para Python (python):" in salida
+    assert "Código generado para Javascript (javascript):" in salida
+    assert "py" in salida
+    assert "js" in salida


### PR DESCRIPTION
### Motivation
- Evitar parcheos locales de `TRANSPILERS` en comandos y hacer que el test consuma la capa canónica del registro CLI para respetar el contrato del código.
- Mantener cobertura sobre la opción `--tipos` multi-target sin reintroducir imports cruzados entre comandos.
- Evitar la migración automática pública de `compilar -> build` dentro del test aislado para asegurar que se prueba `CompileCommand` legacy.

### Description
- Se actualizó `tests/unit/test_cli_compilar_tipos.py` para importar `pcobra.cobra.cli.transpiler_registry` y parchear `cli_transpilers` y `cli_transpiler_targets` en lugar de `compile_module.TRANSPILERS`.
- Se añadieron parches auxiliares a `compile_module` para `cli_transpiler_targets` y `cli_plugin_transpilers` para mantener la compatibilidad con el flujo de `CompileCommand` en la prueba.
- Se añadió `monkeypatch.setattr(cli_module, "resolve_command_profile", lambda: "development")` para prevenir la migración automática del comando legacy durante la ejecución del test.
- Se ajustaron las aserciones de salida para reflejar el formato actual de `CompileCommand` (`"Código generado para {Lang} ({target}):"`) y para verificar el contenido generado (`py` / `js`).

### Testing
- Ejecutado `rg -n "compile_module\.TRANSPILERS|from .*compile_cmd import TRANSPILERS" tests` y no se encontraron coincidencias (migración completada).
- Ejecutado `pytest -q tests/unit/test_cli_compilar_tipos.py` y la prueba pasó exitosamente (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4e509834832780f086a0dc00f1bc)