### PR TITLE
Desacopla ast_cache de wrappers y añade gate SCC para pcobra.core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,9 @@ jobs:
       - name: Gate de arquitectura de imports (ciclos y capas)
         shell: bash
         run: python scripts/ci/check_import_cycles.py
+      - name: Gate de SCC en pcobra.core
+        shell: bash
+        run: python scripts/ci/check_core_scc.py
       - name: Validate runtime contract matrix
         shell: bash
         run: python scripts/validate_runtime_contract.py

--- a/scripts/ci/check_core_scc.py
+++ b/scripts/ci/check_core_scc.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Falla si existen ciclos de imports (SCC > 1) dentro de `src/pcobra/core`."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CORE_DIR = ROOT / "src" / "pcobra" / "core"
+MODULE_PREFIX = "pcobra.core"
+
+
+def _iter_python_files() -> list[Path]:
+    return sorted(path for path in CORE_DIR.rglob("*.py") if path.is_file())
+
+
+def _module_name_for(path: Path) -> str:
+    rel = path.relative_to(CORE_DIR).with_suffix("")
+    suffix = ".".join(rel.parts)
+    return f"{MODULE_PREFIX}.{suffix}" if suffix else MODULE_PREFIX
+
+
+def _resolve_relative_module(current_module: str, level: int, module: str | None) -> str | None:
+    parts = current_module.split(".")
+    if level > len(parts):
+        return None
+    base = parts[:-level]
+    if module:
+        return ".".join((*base, *module.split(".")))
+    return ".".join(base)
+
+
+def _extract_imported_modules(tree: ast.AST, current_module: str) -> set[str]:
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                resolved = _resolve_relative_module(current_module, node.level, node.module)
+                if resolved:
+                    imports.add(resolved)
+                continue
+            if node.module:
+                imports.add(node.module)
+    return imports
+
+
+def _canonical_module(imported: str, all_modules: set[str]) -> str | None:
+    if imported in all_modules:
+        return imported
+    candidate = imported
+    while "." in candidate:
+        candidate = candidate.rsplit(".", 1)[0]
+        if candidate in all_modules:
+            return candidate
+    return None
+
+
+def build_graph() -> dict[str, set[str]]:
+    files = _iter_python_files()
+    module_to_path = {_module_name_for(path): path for path in files}
+    all_modules = set(module_to_path)
+    graph: dict[str, set[str]] = {module: set() for module in all_modules}
+
+    for module, path in module_to_path.items():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for imported in _extract_imported_modules(tree, module):
+            if not imported.startswith(f"{MODULE_PREFIX}."):
+                continue
+            canonical = _canonical_module(imported, all_modules)
+            if canonical is not None:
+                graph[module].add(canonical)
+    return graph
+
+
+def _scc_components(graph: dict[str, set[str]]) -> list[set[str]]:
+    index = 0
+    stack: list[str] = []
+    on_stack: set[str] = set()
+    indexes: dict[str, int] = {}
+    lowlinks: dict[str, int] = {}
+    components: list[set[str]] = []
+
+    def strongconnect(node: str) -> None:
+        nonlocal index
+        indexes[node] = index
+        lowlinks[node] = index
+        index += 1
+        stack.append(node)
+        on_stack.add(node)
+
+        for neighbor in sorted(graph.get(node, ())):
+            if neighbor not in indexes:
+                strongconnect(neighbor)
+                lowlinks[node] = min(lowlinks[node], lowlinks[neighbor])
+            elif neighbor in on_stack:
+                lowlinks[node] = min(lowlinks[node], indexes[neighbor])
+
+        if lowlinks[node] == indexes[node]:
+            component: set[str] = set()
+            while stack:
+                member = stack.pop()
+                on_stack.remove(member)
+                component.add(member)
+                if member == node:
+                    break
+            components.append(component)
+
+    for node in sorted(graph):
+        if node not in indexes:
+            strongconnect(node)
+    return components
+
+
+def main() -> int:
+    graph = build_graph()
+    cyclic_components = sorted(
+        [component for component in _scc_components(graph) if len(component) > 1],
+        key=lambda item: sorted(item),
+    )
+
+    if cyclic_components:
+        print("❌ Se detectaron ciclos de imports en src/pcobra/core (SCC > 1):")
+        for component in cyclic_components:
+            for module in sorted(component):
+                rel = ROOT / "src" / Path(*module.split(".")).with_suffix(".py")
+                print(f"   - {module} ({rel.relative_to(ROOT)})")
+            print("   ---")
+        return 1
+
+    print("✅ Sin ciclos de imports en src/pcobra/core (todas las SCC son de tamaño 1).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pcobra/core/ast_cache.py
+++ b/src/pcobra/core/ast_cache.py
@@ -13,6 +13,12 @@ from pathlib import Path
 from typing import Any, Callable
 
 from . import database
+from .token_contract import (
+    deserialize_token,
+    is_token_like,
+    serialize_token,
+    token_enum_classes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -89,32 +95,6 @@ _FRAGMENT_TOKENS_KEY = "fragment_tokens"
 _FRAGMENT_AST_KEY = "fragment_ast"
 
 
-def _is_token_like(obj: Any) -> bool:
-    try:
-        from pcobra.core.lexer import Token
-    except ModuleNotFoundError:  # pragma: no cover - entornos acotados
-        Token = None  # type: ignore
-
-    if Token is not None and isinstance(obj, Token):
-        return True
-
-    if obj.__class__.__name__ != "Token":
-        return False
-    return all(hasattr(obj, attr) for attr in ("tipo", "valor", "linea", "columna"))
-
-
-def _serialize_token(obj: Any) -> dict[str, Any]:
-    tipo = getattr(obj, "tipo", None)
-    tipo_valor = getattr(tipo, "value", tipo)
-    return {
-        "__token__": True,
-        "tipo": tipo_valor,
-        "valor": getattr(obj, "valor", None),
-        "linea": getattr(obj, "linea", None),
-        "columna": getattr(obj, "columna", None),
-    }
-
-
 def _get_node_classes() -> dict[str, type]:
     global _NODE_CLASSES
     if _NODE_CLASSES is None:
@@ -127,9 +107,7 @@ def _get_node_classes() -> dict[str, type]:
 def _get_enum_classes() -> dict[str, type]:
     global _ENUM_CLASSES
     if _ENUM_CLASSES is None:
-        from pcobra.core.lexer import TipoToken
-
-        _ENUM_CLASSES = {"TipoToken": TipoToken}
+        _ENUM_CLASSES = token_enum_classes()
     return _ENUM_CLASSES
 
 
@@ -139,8 +117,8 @@ def _serialize(obj: Any) -> Any:
         for f in fields(obj):
             data[f.name] = _serialize(getattr(obj, f.name))
         return data
-    if _is_token_like(obj):
-        return _serialize_token(obj)
+    if is_token_like(obj):
+        return serialize_token(obj)
     if isinstance(obj, Enum):
         return {"__enum__": obj.__class__.__name__, "value": obj.value}
     if isinstance(obj, list):
@@ -151,18 +129,11 @@ def _serialize(obj: Any) -> Any:
 
 
 def _deserialize(data: Any) -> Any:
-    from pcobra.core.lexer import Token, TipoToken
-
     if isinstance(data, list):
         return [_deserialize(i) for i in data]
     if isinstance(data, dict):
         if data.get("__token__"):
-            return Token(
-                TipoToken(data["tipo"]),
-                data.get("valor"),
-                data.get("linea"),
-                data.get("columna"),
-            )
+            return deserialize_token(data)
         if "__enum__" in data:
             enum_cls = _get_enum_classes()[data["__enum__"]]
             return enum_cls(data["value"])
@@ -345,9 +316,10 @@ def obtener_tokens(codigo: str):
     if tokens is not None:
         return tokens
 
-    from pcobra.core.lexer import Lexer
+    from importlib import import_module
 
-    tokens = Lexer(codigo).tokenizar()
+    lexer_cls = getattr(import_module("pcobra.cobra.core.lexer"), "Lexer")
+    tokens = lexer_cls(codigo).tokenizar()
     _store_fragment(hash_key, codigo, _FULL_TOKENS_KEY, tokens)
     return tokens
 
@@ -361,9 +333,10 @@ def obtener_ast(codigo: str):
         return ast
 
     tokens = obtener_tokens(codigo)
-    from pcobra.core.parser import Parser
+    from importlib import import_module
 
-    ast = Parser(tokens).parsear()
+    parser_cls = getattr(import_module("pcobra.cobra.core.parser"), "Parser")
+    ast = parser_cls(tokens).parsear()
     _store_ast(hash_key, codigo, ast)
     return ast
 
@@ -376,9 +349,10 @@ def obtener_tokens_fragmento(codigo: str):
     if tokens is not None:
         return tokens
 
-    from pcobra.core.lexer import Lexer
+    from importlib import import_module
 
-    tokens = Lexer(codigo).tokenizar()
+    lexer_cls = getattr(import_module("pcobra.cobra.core.lexer"), "Lexer")
+    tokens = lexer_cls(codigo).tokenizar()
     _store_fragment(hash_key, codigo, _FRAGMENT_TOKENS_KEY, tokens)
     return tokens
 
@@ -392,9 +366,10 @@ def obtener_ast_fragmento(codigo: str):
         return ast
 
     tokens = obtener_tokens_fragmento(codigo)
-    from pcobra.core.parser import Parser
+    from importlib import import_module
 
-    ast = Parser(tokens).parsear()
+    parser_cls = getattr(import_module("pcobra.cobra.core.parser"), "Parser")
+    ast = parser_cls(tokens).parsear()
     _store_fragment(hash_key, codigo, _FRAGMENT_AST_KEY, ast)
     return ast
 

--- a/src/pcobra/core/token_contract.py
+++ b/src/pcobra/core/token_contract.py
@@ -1,0 +1,71 @@
+"""Contrato neutral para serializar/deserializar tokens del AST.
+
+Este módulo define un adaptador desacoplado de los *wrappers* públicos
+(`pcobra.core.lexer`) para evitar dependencias transitivas durante import time.
+
+Contrato de serialización:
+- Un token se representa como `{"__token__": true, "tipo": str, "valor": Any,
+  "linea": int|None, "columna": int|None}`.
+- `tipo` almacena el valor serializable del enum (normalmente `TipoToken.value`).
+- La deserialización reconstruye `Token` y `TipoToken` desde el backend canónico
+  (`pcobra.cobra.core.lexer`) de forma perezosa.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+
+_TOKEN_CLASS: type | None = None
+_TOKEN_TYPE_ENUM: type | None = None
+
+
+def _resolve_token_runtime() -> tuple[type, type]:
+    """Resuelve `Token` y `TipoToken` desde el runtime canónico en diferido."""
+    global _TOKEN_CLASS, _TOKEN_TYPE_ENUM
+    if _TOKEN_CLASS is None or _TOKEN_TYPE_ENUM is None:
+        lexer_module = import_module("pcobra.cobra.core.lexer")
+        _TOKEN_CLASS = getattr(lexer_module, "Token")
+        _TOKEN_TYPE_ENUM = getattr(lexer_module, "TipoToken")
+    return _TOKEN_CLASS, _TOKEN_TYPE_ENUM
+
+
+def is_token_like(obj: Any) -> bool:
+    """Indica si el objeto cumple el contrato estructural de token."""
+    token_cls, _ = _resolve_token_runtime()
+    if isinstance(obj, token_cls):
+        return True
+    if obj.__class__.__name__ != "Token":
+        return False
+    return all(hasattr(obj, attr) for attr in ("tipo", "valor", "linea", "columna"))
+
+
+def serialize_token(token: Any) -> dict[str, Any]:
+    """Serializa un token en el formato estable usado por la caché de AST."""
+    tipo = getattr(token, "tipo", None)
+    tipo_valor = getattr(tipo, "value", tipo)
+    return {
+        "__token__": True,
+        "tipo": tipo_valor,
+        "valor": getattr(token, "valor", None),
+        "linea": getattr(token, "linea", None),
+        "columna": getattr(token, "columna", None),
+    }
+
+
+def deserialize_token(payload: dict[str, Any]) -> Any:
+    """Reconstruye un token desde su representación serializada."""
+    token_cls, token_type_enum = _resolve_token_runtime()
+    return token_cls(
+        token_type_enum(payload["tipo"]),
+        payload.get("valor"),
+        payload.get("linea"),
+        payload.get("columna"),
+    )
+
+
+def token_enum_classes() -> dict[str, type]:
+    """Retorna enums soportados por el contrato para deserialización."""
+    _, token_type_enum = _resolve_token_runtime()
+    return {"TipoToken": token_type_enum}


### PR DESCRIPTION
### Motivation
- Evitar dependencias transitivas en tiempo de importación entre la caché AST y los wrappers públicos del lexer/parser para romper ciclos y permitir carga perezosa. 
- Formalizar un contrato estable para serialización/deserialización de tokens AST para evitar acoplamientos con wrappers que cierran el ciclo. 
- Añadir una verificación automática en CI que detecte cualquier SCC > 1 dentro de `src/pcobra/core`.

### Description
- Se crea `src/pcobra/core/token_contract.py` como adaptador neutral que documenta y centraliza el contrato de token (`__token__`, `tipo`, `valor`, `linea`, `columna`) y resuelve `Token`/`TipoToken` de forma lazy vía `import_module`.
- Se refactoriza `src/pcobra/core/ast_cache.py` para usar el adaptador (`is_token_like`, `serialize_token`, `deserialize_token`, `token_enum_classes`) y para realizar import diferido de `Lexer`/`Parser` (`import_module(...)`) únicamente en las funciones que lo requieren (`obtener_tokens*`, `obtener_ast*`).
- Se añade `scripts/ci/check_core_scc.py` que construye el grafo de imports de `src/pcobra/core` y falla si existe cualquier componente fuertemente conexa (SCC) de tamaño > 1.
- Se integra el nuevo gate en CI añadiendo la ejecución de `python scripts/ci/check_core_scc.py` en `.github/workflows/ci.yml`.
- No se modificaron los módulos frontend/legacy del lexer/parser (`src/pcobra/cobra/core/lexer.py` y `src/pcobra/cobra/core/parser.py`), que se mantienen como contratos inmutables y reexports finos bajo `pcobra.core`.

### Testing
- Ejecuté compilación estática: `python -m compileall src/pcobra/core/ast_cache.py src/pcobra/core/token_contract.py scripts/ci/check_core_scc.py` (éxito).
- Ejecuté la nueva verificación: `python scripts/ci/check_core_scc.py` (éxito, sin SCC en `src/pcobra/core`).
- Ejecuté la comprobación global de ciclos existente: `python scripts/ci/check_import_cycles.py` (falló por un ciclo preexistente fuera del ámbito de este cambio: `pcobra.cobra.core.parser <-> pcobra.cobra.core.lark_parser`).
- Intenté invocar `obtener_tokens` localmente para validar el flujo runtime; la llamada falló con `DatabaseKeyError` por ausencia de la variable de entorno `SQLITE_DB_KEY`, que es un requisito del subsistema de base de datos (comportamiento esperado en entornos sin clave configurada).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba47e6e2c83278af485d0a50ce051)