### PR TITLE
Forzar uso del registro canónico de transpiladores y añadir lint CI

### DIFF
--- a/docs/architecture/cli-decoupling.md
+++ b/docs/architecture/cli-decoupling.md
@@ -27,6 +27,20 @@ from .compile_cmd import CompileCommand
 2. Reduce ciclos de import y efectos secundarios al cargar CLI.
 3. Obliga a compartir contrato común vía `commands.base` y servicios/utilidades del CLI.
 
+## Registro canónico de targets/transpiladores (fuente única)
+
+Para la capa CLI, el **único source of truth** para targets y transpiladores es
+`pcobra.cobra.transpilers.registry`, consumido indirectamente mediante la fachada:
+
+- `pcobra.cobra.cli.transpiler_registry`
+
+Reglas derivadas:
+
+- ✅ Los comandos/utilidades CLI deben usar `cli_transpilers()` y `cli_transpiler_targets()`.
+- ❌ No se permite declarar mappings paralelos como `TRANSPILERS = {...}` en módulos CLI.
+- ❌ No se permite importar directamente `pcobra.cobra.transpilers.registry` desde módulos CLI
+  (excepto la propia fachada `cli/transpiler_registry.py`).
+
 ## Cómo se valida
 
 La regla se valida con el linter de CI:
@@ -36,3 +50,11 @@ python scripts/ci/lint_no_cross_command_imports.py
 ```
 
 Si detecta imports cruzados, CI falla y reporta archivo + línea.
+
+También se valida el contrato de registro canónico:
+
+```bash
+python scripts/ci/lint_no_parallel_transpilers_registry.py
+```
+
+Si detecta mappings paralelos o bypass de la fachada CLI, CI falla y reporta archivo + línea.

--- a/scripts/ci/lint_no_parallel_transpilers_registry.py
+++ b/scripts/ci/lint_no_parallel_transpilers_registry.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Lint para evitar fuentes paralelas de truth de transpiladores.
+
+Reglas:
+1) Prohíbe el patrón ``TRANSPILERS = {`` fuera de módulos explícitamente permitidos.
+2) Dentro de ``pcobra.cobra.cli`` prohíbe importar directamente
+   ``pcobra.cobra.transpilers.registry`` (debe usarse la fachada
+   ``pcobra.cobra.cli.transpiler_registry``).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+ALLOWED_TRANSPILERS_LITERAL_MODULES = {
+    Path("src/pcobra/cobra/transpilers/registry.py"),
+    Path("tests/integration/transpilers/backend_contracts.py"),
+    Path("tests/unit/test_transpiler_backend_regression.py"),
+}
+
+CLI_FACADE_MODULE = "pcobra.cobra.cli.transpiler_registry"
+CANONICAL_REGISTRY_MODULE = "pcobra.cobra.transpilers.registry"
+
+def _find_transpilers_literal_violations(root: Path) -> list[str]:
+    violations: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        rel = path.relative_to(root)
+        if rel in ALLOWED_TRANSPILERS_LITERAL_MODULES:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            target_name: str | None = None
+            value: ast.AST | None = None
+            if isinstance(node, ast.Assign):
+                if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+                    target_name = node.targets[0].id
+                    value = node.value
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                target_name = node.target.id
+                value = node.value
+            if target_name == "TRANSPILERS" and isinstance(value, ast.Dict):
+                violations.append(
+                    f"{rel}:{node.lineno}: patrón prohibido `TRANSPILERS = {{` fuera del registro canónico"
+                )
+    return violations
+
+
+def _resolve_relative_module(path: Path, module: str | None, level: int, root: Path) -> str | None:
+    if level <= 0:
+        return module
+    try:
+        rel = path.relative_to(root / "src")
+    except ValueError:
+        return None
+    package_parts = list(rel.with_suffix("").parts[:-1])
+    if level > len(package_parts) + 1:
+        return None
+    keep_parts = len(package_parts) - (level - 1)
+    base_parts = package_parts[:keep_parts]
+    if module:
+        base_parts.extend(module.split("."))
+    return ".".join(base_parts)
+
+
+def _iter_import_modules(path: Path, root: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            module = _resolve_relative_module(path, node.module, node.level, root)
+            if module:
+                imports.append((node.lineno, module))
+    return imports
+
+
+def _find_cli_registry_facade_violations(root: Path) -> list[str]:
+    violations: list[str] = []
+    cli_root = root / "src" / "pcobra" / "cobra" / "cli"
+    if not cli_root.exists():
+        return violations
+
+    for path in sorted(cli_root.rglob("*.py")):
+        rel = path.relative_to(root)
+        if rel == Path("src/pcobra/cobra/cli/transpiler_registry.py"):
+            continue
+        for lineno, module in _iter_import_modules(path, root):
+            if module != CANONICAL_REGISTRY_MODULE:
+                continue
+            violations.append(
+                f"{rel}:{lineno}: import directo de `{CANONICAL_REGISTRY_MODULE}` no permitido en CLI; use `{CLI_FACADE_MODULE}`"
+            )
+    return violations
+
+
+def find_violations(root: Path = ROOT) -> list[str]:
+    return _find_transpilers_literal_violations(root) + _find_cli_registry_facade_violations(root)
+
+
+def main() -> int:
+    violations = find_violations(ROOT)
+    if not violations:
+        print("OK: no se detectaron registros paralelos de transpiladores.")
+        return 0
+    for violation in violations:
+        print(violation)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pcobra/cobra/transpilers/feature_inspector.py
+++ b/src/pcobra/cobra/transpilers/feature_inspector.py
@@ -10,8 +10,8 @@ from pathlib import Path
 import re
 from typing import Dict, List
 
+from pcobra.cobra.transpilers.registry import official_transpiler_targets
 from pcobra.cobra.transpilers.target_utils import normalize_target_name, target_label
-from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
 
 # Carpeta donde se encuentran los transpiladores individuales
 BASE_DIR = Path(__file__).resolve().parent / "transpiler"
@@ -28,10 +28,6 @@ def _resolve_transpiler_file(target: str) -> str:
     return _TRANSPILER_FILE_BY_TARGET.get(canonical, f"to_{canonical}.py")
 
 
-TRANSPILERS: Dict[str, str] = {
-    normalize_target_name(target): _resolve_transpiler_file(target) for target in OFFICIAL_TARGETS
-}
-
 # Patrones para detectar características registradas en los transpiladores
 # 1) Asignaciones como `TranspiladorX.visit_algo = ...`
 _ASSIGN_PATTERN = re.compile(r"visit_([a-zA-Z_]+)\s*=")
@@ -42,7 +38,9 @@ _DICT_PATTERN = re.compile(r"['\"]([a-zA-Z_]+)['\"]\s*:\s*visit_[a-zA-Z_]+")
 def extract_features() -> Dict[str, List[str]]:
     """Devuelve un mapeo de lenguaje a la lista de características soportadas."""
     features: Dict[str, List[str]] = {}
-    for canonical, transpiler_file in TRANSPILERS.items():
+    for canonical in official_transpiler_targets():
+        canonical = normalize_target_name(canonical)
+        transpiler_file = _resolve_transpiler_file(canonical)
         language = target_label(canonical)
         path = BASE_DIR / transpiler_file
         if not path.exists():

--- a/tests/unit/test_ci_lint_no_parallel_transpilers_registry.py
+++ b/tests/unit/test_ci_lint_no_parallel_transpilers_registry.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.ci.lint_no_parallel_transpilers_registry import find_violations
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_detecta_patron_transpilers_literal_fuera_allowlist(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "tools" / "bad.py",
+        "TRANSPILERS = {'python': object()}\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "patrón prohibido `TRANSPILERS = {`" in violations[0]
+    assert "src/pcobra/cobra/tools/bad.py:1" in violations[0]
+
+
+def test_permite_patron_transpilers_literal_en_modulo_explicito(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "tests" / "unit" / "test_transpiler_backend_regression.py",
+        "TRANSPILERS = {'python': object()}\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert violations == []
+
+
+def test_detecta_import_directo_registry_en_cli(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "bad.py",
+        "from pcobra.cobra.transpilers.registry import get_transpilers\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "import directo de `pcobra.cobra.transpilers.registry`" in violations[0]
+    assert "src/pcobra/cobra/cli/commands/bad.py:1" in violations[0]
+
+
+def test_permite_fachada_cli_transpiler_registry(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "ok.py",
+        "from pcobra.cobra.cli.transpiler_registry import cli_transpilers\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert violations == []


### PR DESCRIPTION
### Motivation

- Centralizar la fuente de verdad para targets/transpiladores evitando que módulos declaren mappings paralelos como `TRANSPILERS = {...}`.
- Forzar que la capa CLI use la fachada dedicada en lugar de importar directamente el registro canónico para reducir acoplamientos y bypasses.
- Añadir una validación estática en CI para detectar regresiones y usos indebidos del registro de transpiladores.

### Description

- Reemplacé el dict local en `src/pcobra/cobra/transpilers/feature_inspector.py` para iterar sobre `official_transpiler_targets()` proveniente de `src/pcobra/cobra/transpilers/registry.py` y resolver archivos `to_*.py` por target.
- Añadí `scripts/ci/lint_no_parallel_transpilers_registry.py` que prohíbe literales `TRANSPILERS = {` fuera de una allowlist y prohíbe imports directos de `pcobra.cobra.transpilers.registry` desde módulos bajo la CLI, exigiendo el uso de la fachada `pcobra.cobra.cli.transpiler_registry`.
- Incorporé pruebas unitarias en `tests/unit/test_ci_lint_no_parallel_transpilers_registry.py` que cubren detección de literales prohibidos, allowlist y la regla de la fachada CLI.
- Actualicé `docs/architecture/cli-decoupling.md` para documentar que `pcobra.cobra.transpilers.registry` (accedido vía `pcobra.cobra.cli.transpiler_registry`) es la única fuente de verdad para targets/transpiladores.

### Testing

- Ejecuté `python scripts/ci/lint_no_parallel_transpilers_registry.py` y la herramienta salió con éxito (`0`) imprimiendo `OK: no se detectaron registros paralelos de transpiladores.`; se observó un `SyntaxWarning` preexistente en tests no relacionado con estos cambios.
- Ejecuté `pytest -q tests/unit/test_ci_lint_no_parallel_transpilers_registry.py` y pasó correctamente (`4 passed`).
- Ejecuté `pytest -q tests/unit/test_cli_commands_no_local_transpilers_constant_contract.py` y pasó correctamente (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba90e00b88327bf427dd413e16542)