### PR TITLE
Aísla fallback legacy de sandbox y fija contrato canónico en entrypoints

### DIFF
--- a/src/pcobra/cobra/cli/internal_compat/legacy_core_sandbox.py
+++ b/src/pcobra/cobra/cli/internal_compat/legacy_core_sandbox.py
@@ -1,0 +1,76 @@
+"""Compatibilidad temporal para el namespace legacy ``core.sandbox``.
+
+Este módulo encapsula todo el fallback legacy fuera del flujo principal de
+servicios como ``run``. La ruta canónica contractual es
+``pcobra.core.sandbox``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import warnings
+from pathlib import Path
+from types import ModuleType
+from typing import Final
+
+LEGACY_SANDBOX_COMPAT_FLAG: Final[str] = "PCOBRA_ENABLE_LEGACY_CORE_SANDBOX"
+LEGACY_SANDBOX_RETIREMENT_DATE: Final[str] = "2026-12-31"
+
+_logger = logging.getLogger(__name__)
+
+
+def legacy_core_sandbox_compat_enabled() -> bool:
+    raw = (os.environ.get(LEGACY_SANDBOX_COMPAT_FLAG, "") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _expected_legacy_target_path() -> Path:
+    return Path(__file__).resolve().parents[3] / "core" / "sandbox.py"
+
+
+def _validar_modulo_sandbox_legacy(module: ModuleType) -> None:
+    module_file = getattr(module, "__file__", None)
+    if not module_file:
+        raise ImportError("El módulo legacy 'core.sandbox' no expone __file__")
+
+    detected = Path(module_file).resolve()
+    expected = _expected_legacy_target_path().resolve()
+    if not detected.is_file() or detected != expected:
+        raise ImportError(
+            "El módulo legacy 'core.sandbox' no apunta al paquete esperado "
+            f"('{expected}'). Ruta detectada: {detected}"
+        )
+
+
+def load_legacy_core_sandbox(*, canonical_error: ModuleNotFoundError) -> ModuleType:
+    if not legacy_core_sandbox_compat_enabled():
+        raise ImportError(
+            "No se pudo importar 'pcobra.core.sandbox'. "
+            "El fallback legacy 'core.sandbox' está deshabilitado por defecto. "
+            f"Para transición controlada habilite {LEGACY_SANDBOX_COMPAT_FLAG}=1."
+        ) from canonical_error
+
+    try:
+        module = importlib.import_module("core.sandbox")
+    except ModuleNotFoundError:
+        raise canonical_error
+
+    _validar_modulo_sandbox_legacy(module)
+    warnings.warn(
+        "Compatibilidad legacy activa: 'core.sandbox' está deprecado y será retirado "
+        f"el {LEGACY_SANDBOX_RETIREMENT_DATE}. Use 'pcobra.core.sandbox'.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    _logger.warning(
+        "Fallback legacy core.sandbox activado (retiro %s)",
+        LEGACY_SANDBOX_RETIREMENT_DATE,
+        extra={
+            "event": "legacy_core_sandbox_fallback",
+            "compatibility_flag": LEGACY_SANDBOX_COMPAT_FLAG,
+            "retirement_date": LEGACY_SANDBOX_RETIREMENT_DATE,
+        },
+    )
+    return module

--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -1,6 +1,4 @@
-import importlib
 import logging
-import os
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +11,10 @@ from pcobra.cobra.cli.execution_pipeline import (
     resolver_interpretador_cls,
 )
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.internal_compat.legacy_core_sandbox import (
+    LEGACY_SANDBOX_COMPAT_FLAG,
+    load_legacy_core_sandbox,
+)
 from pcobra.cobra.cli.mode_policy import validar_politica_modo
 from pcobra.cobra.cli.services.contracts import RunRequest, normalize_run_request
 from pcobra.cobra.cli.services.format_service import format_code_with_black
@@ -28,63 +30,17 @@ from pcobra.cobra.core.runtime import (
 )
 from pcobra.cobra.transpilers import module_map
 
-LEGACY_SANDBOX_COMPAT_FLAG = "PCOBRA_ENABLE_LEGACY_CORE_SANDBOX"
+try:
+    from pcobra.core import sandbox as sandbox_module
+except ModuleNotFoundError as canon_exc:  # pragma: no cover
+    sandbox_module = load_legacy_core_sandbox(canonical_error=canon_exc)
+
 RUNTIME_MANAGER = RuntimeManager()
 
 
-class _SandboxModuleProxy:
-    def __getattr__(self, name: str) -> Any:
-        return getattr(_importar_modulo_sandbox(), name)
-
-
-def _legacy_sandbox_compat_enabled() -> bool:
-    raw = (os.environ.get(LEGACY_SANDBOX_COMPAT_FLAG, "") or "").strip().lower()
-    return raw in {"1", "true", "yes", "on"}
-
-
-def _validar_modulo_sandbox_legacy(module: Any) -> None:
-    module_file = getattr(module, "__file__", None)
-    if not module_file:
-        raise ImportError("El módulo legacy 'core.sandbox' no expone __file__")
-
-    resolved = Path(module_file).resolve().parts
-    expected_suffix = ("pcobra", "core", "sandbox.py")
-    if tuple(resolved[-len(expected_suffix) :]) != expected_suffix:
-        raise ImportError(
-            "El módulo legacy 'core.sandbox' no apunta al paquete esperado "
-            f"('pcobra.core.sandbox'). Ruta detectada: {module_file}"
-        )
-
-
 def _importar_modulo_sandbox() -> Any:
-    try:
-        module = importlib.import_module("pcobra.core.sandbox")
-    except ModuleNotFoundError as canon_exc:  # pragma: no cover
-        if not _legacy_sandbox_compat_enabled():
-            raise ImportError(
-                "No se pudo importar 'pcobra.core.sandbox'. "
-                "El fallback legacy 'core.sandbox' está deshabilitado por defecto. "
-                f"Para transición controlada habilite {LEGACY_SANDBOX_COMPAT_FLAG}=1."
-            ) from canon_exc
-        try:
-            module = importlib.import_module("core.sandbox")
-        except ModuleNotFoundError:
-            raise canon_exc
-        _validar_modulo_sandbox_legacy(module)
-
-    required = (
-        "ejecutar_en_sandbox",
-        "ejecutar_en_contenedor",
-        "SecurityError",
-        "validar_dependencias",
-    )
-    missing = [name for name in required if not hasattr(module, name)]
-    if missing:
-        raise ImportError(f"El módulo '{module.__name__}' no define: {', '.join(missing)}")
-    return module
-
-
-sandbox_module = _SandboxModuleProxy()
+    """Compatibilidad para tests/adaptadores legacy; evita import dinámico en run."""
+    return sandbox_module
 
 
 def ejecutar_en_sandbox(*args: Any, **kwargs: Any) -> Any:

--- a/tests/unit/test_sandbox_namespace_entrypoint_contract.py
+++ b/tests/unit/test_sandbox_namespace_entrypoint_contract.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import tomllib
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from pcobra.cobra.cli.internal_compat import legacy_core_sandbox
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_entrypoints_publicos_apuntan_al_namespace_pcobra() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    scripts = pyproject["project"]["scripts"]
+
+    assert scripts["cobra"] == "pcobra.cli:main"
+
+    source_main = (ROOT / "src" / "pcobra" / "__main__.py").read_text(encoding="utf-8")
+    assert "from pcobra.cli import main" in source_main
+
+
+def test_run_service_declara_solo_namespace_canonico_para_sandbox() -> None:
+    source = (ROOT / "src" / "pcobra" / "cobra" / "cli" / "services" / "run_service.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "from pcobra.core import sandbox as sandbox_module" in source
+    assert 'import_module("core.sandbox")' not in source
+
+
+def test_legacy_core_sandbox_emite_deprecacion_con_fecha(monkeypatch):
+    canonical_error = ModuleNotFoundError("pcobra.core.sandbox")
+    monkeypatch.setenv(legacy_core_sandbox.LEGACY_SANDBOX_COMPAT_FLAG, "1")
+
+    module = ModuleType("core.sandbox")
+    expected_path = (ROOT / "src" / "pcobra" / "core" / "sandbox.py").resolve()
+    module.__file__ = str(expected_path)
+
+    monkeypatch.setattr(
+        legacy_core_sandbox.importlib,
+        "import_module",
+        lambda name: module if name == "core.sandbox" else (_ for _ in ()).throw(ModuleNotFoundError(name)),
+    )
+
+    with pytest.warns(DeprecationWarning, match=legacy_core_sandbox.LEGACY_SANDBOX_RETIREMENT_DATE):
+        resolved = legacy_core_sandbox.load_legacy_core_sandbox(canonical_error=canonical_error)
+
+    assert resolved is module
+
+
+def test_legacy_core_sandbox_rechaza_modulo_homonimo(monkeypatch, tmp_path):
+    canonical_error = ModuleNotFoundError("pcobra.core.sandbox")
+    monkeypatch.setenv(legacy_core_sandbox.LEGACY_SANDBOX_COMPAT_FLAG, "1")
+
+    fake = tmp_path / "core" / "sandbox.py"
+    fake.parent.mkdir(parents=True)
+    fake.write_text("", encoding="utf-8")
+
+    module = ModuleType("core.sandbox")
+    module.__file__ = str(fake)
+
+    monkeypatch.setattr(
+        legacy_core_sandbox.importlib,
+        "import_module",
+        lambda name: module if name == "core.sandbox" else (_ for _ in ()).throw(ModuleNotFoundError(name)),
+    )
+
+    with pytest.raises(ImportError, match="no apunta al paquete esperado"):
+        legacy_core_sandbox.load_legacy_core_sandbox(canonical_error=canonical_error)
+
+
+def test_namespace_instalado_resuelve_sandbox_canonico() -> None:
+    for key in tuple(sys.modules):
+        if key.startswith("pcobra.cobra.cli.services.run_service"):
+            sys.modules.pop(key, None)
+
+    run_service = importlib.import_module("pcobra.cobra.cli.services.run_service")
+    resolved = run_service._importar_modulo_sandbox()
+
+    assert resolved.__name__ == "pcobra.core.sandbox"


### PR DESCRIPTION
### Motivation
- Forzar que la resolución del sandbox use la ruta canónica `pcobra.core.sandbox` y evitar que importaciones homónimas externas afecten la ejecución normal.
- Extraer la lógica de compatibilidad legacy hacia un módulo separado para mantener el flujo principal de `run` limpio y seguro.
- Emitir una advertencia deprecatoria y validar la ruta del módulo legacy para proteger contra módulos homónimos no intencionados.

### Description
- `RunService` ahora importa explícitamente el sandbox canónico `pcobra.core.sandbox` y delega a un helper `_importar_modulo_sandbox()` que devuelve el módulo resuelto para adaptadores/tests; el fallback legacy ya no está en el flujo principal (`src/pcobra/cobra/cli/services/run_service.py`).
- Se añadió `pcobra.cobra.cli.internal_compat.legacy_core_sandbox` que encapsula el fallback a `core.sandbox` con flag de activación `PCOBRA_ENABLE_LEGACY_CORE_SANDBOX`, validación estricta de `__file__`, y emisión de `DeprecationWarning` con fecha de retiro `2026-12-31` además de logging estructurado del evento.
- Se agregó la prueba `tests/unit/test_sandbox_namespace_entrypoint_contract.py` que verifica los entrypoints/entrypoint packaging, que `run_service` declara solo el namespace canónico, que el fallback legacy emite la deprecación y rechaza homónimos, y que la resolución instalada devuelve `pcobra.core.sandbox`.
- Se corrigió un literal multi-línea en `run_service.py` que provocaba un `SyntaxError` durante las pruebas.

### Testing
- Ejecutado: `pytest -q tests/unit/test_sandbox_namespace_entrypoint_contract.py tests/unit/test_cli_startup_import_contract.py` y la suite indicó `8 passed`.
- Las pruebas iniciales fallaron por un `SyntaxError` causado por un literal roto y fueron corregidas antes de la ejecución final, tras lo cual todas las pruebas relevantes pasaron exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb7d182f4832782438264a06863c5)