### PR TITLE
Corregir rama de mutación en asignaciones y ampliar pruebas de scope/paridad

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1166,17 +1166,22 @@ class InterpretadorCobra:
                 # Declaración local (explícita o por inferencia)
                 self.contextos[-1].define(nombre, valor)
             else:
-                # Mutación: resolver primero en qué entorno vive la variable.
-                # Si no existe todavía, ``set`` la creará en el scope actual.
                 indice_contexto = self._indice_entorno_variable(nombre)
                 if indice_contexto is None:
+                    # Creación local implícita cuando no existe en la cadena
+                    # de scopes.
                     indice_contexto = len(self.mem_contextos) - 1
-
-                # Liberar/reasignar en el contexto real (no forzar el actual).
-                self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
-                indice = self.solicitar_memoria(1)
-                self.mem_contextos[indice_contexto][nombre] = (indice, 1)
-                self.contextos[-1].set(nombre, valor)
+                    self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
+                    indice = self.solicitar_memoria(1)
+                    self.mem_contextos[indice_contexto][nombre] = (indice, 1)
+                    self.contextos[-1].define(nombre, valor)
+                else:
+                    # Mutación sobre una variable existente: ``set`` solo
+                    # actualiza en el scope donde ya está declarada.
+                    self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
+                    indice = self.solicitar_memoria(1)
+                    self.mem_contextos[indice_contexto][nombre] = (indice, 1)
+                    self.contextos[-1].set(nombre, valor)
         return valor
 
     def evaluar_expresion(self, expresion, visitados=None):

--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -244,6 +244,17 @@ def test_error_semantico_y_runtime_equivalen_en_tipo_y_mensaje(codigo_erroneo):
             {"contador": 15},
         ),
         (
+            "mutacion_en_mientras_persiste_fuera_del_bucle",
+            "var total = 1",
+            (
+                "mientras verdadero:\n"
+                "    total = 4\n"
+                "    romper\n"
+                "fin"
+            ),
+            {"total": 4},
+        ),
+        (
             "bloque_anidado_shadowing_y_set_dirigido",
             "var raiz = 100",
             (

--- a/tests/unit/test_interpreter_loop_scope_regression.py
+++ b/tests/unit/test_interpreter_loop_scope_regression.py
@@ -99,3 +99,30 @@ imprimir(base)
     esperadas = ["contador", "2", "base", "15"]
     assert salida_ejecutar[-len(esperadas) :] == esperadas
     assert salida_interactive[-len(esperadas) :] == esperadas
+
+
+def test_mutacion_en_mientras_persiste_fuera_del_bucle() -> None:
+    codigo = """
+var total = 1
+mientras total < 4:
+    total = total + 1
+fin
+imprimir(total)
+"""
+    salida = _lineas_sin_trazas(_ejecutar_codigo_y_capturar_stdout(codigo))
+    assert salida[-1] == "4"
+
+
+def test_variable_externa_se_actualiza_en_scope_correcto_durante_mientras() -> None:
+    codigo = """
+var acumulado = 0
+func sumar_hasta_dos():
+    mientras acumulado < 2:
+        acumulado = acumulado + 1
+    fin
+fin
+sumar_hasta_dos()
+imprimir(acumulado)
+"""
+    salida = _lineas_sin_trazas(_ejecutar_codigo_y_capturar_stdout(codigo))
+    assert salida[-1] == "2"


### PR DESCRIPTION
### Motivation
- El contrato de `Environment` exige que `set` solo actualice variables ya existentes y que la creación local se haga con `define`; la implementación previa y sus comentarios eran contradictorios y provocaban inconsistencias en `mientras`/REPL.
- Es necesario reforzar pruebas de contrato para asegurar que las mutaciones dentro de `mientras` persisten correctamente y que el comportamiento es idéntico entre ejecución en script y REPL.
- Mantener la regla de diseño: `mientras` no crea un scope nuevo por iteración y no introducir `env.copy()` ni cambios de diseño de scopes.

### Description
- Ajustada la lógica de la rama de mutación en `InterpretadorCobra.ejecutar_asignacion` para: usar `set` solo cuando `_indice_entorno_variable(nombre)` encuentra la variable, y usar `define` explícito cuando no existe en la cadena de scopes; la gestión de `mem_contextos` y liberación/solicitud de memoria se conserva en ambos caminos. (`src/pcobra/core/interpreter.py`).
- Actualizados/elimindados comentarios contradictorios para reflejar correctamente el contrato de `Environment` (ya no se afirma que `set` crea variables). (`src/pcobra/core/interpreter.py`).
- Añadidas pruebas unitarias que verifican persistencia de mutación de `mientras` y actualización de variable externa en el scope correcto, y ampliada la matriz de paridad run vs REPL con un caso de mutación en `mientras`. (`tests/unit/test_interpreter_loop_scope_regression.py`, `tests/integration/test_run_repl_equivalence.py`).

### Testing
- Ejecutado: `pytest -q tests/unit/test_interpreter_loop_scope_regression.py tests/integration/test_run_repl_equivalence.py -k 'mientras or runtime_estado_final_paridad'` y la ejecución finalizada con éxito (todos los tests relevantes pasaron: 7 passed, 5 deselected en la sesión focalizada).
- Durante el desarrollo se usaron pruebas adicionales locales de paridad REPL/run para iterar sobre la corrección y validar que las fallas iniciales se resolvieron tras los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3eecc3348327b52d093a964eae2f)