### PR TITLE
tests: migrate compile --tipos unit test to canonical CLI registry

### DIFF
--- a/tests/unit/test_cli_compilar_tipos.py
+++ b/tests/unit/test_cli_compilar_tipos.py
@@ -1,16 +1,15 @@
 from io import StringIO
+import importlib
 from unittest.mock import patch
 
 import pytest
-
-from pcobra.cobra.cli import transpiler_registry
-
 
 @pytest.mark.timeout(5)
 def test_cli_compilar_con_tipos(tmp_path, monkeypatch):
     """Ejecuta ``cobra compilar`` con ``--tipos`` sin errores de tipo."""
 
     from pcobra.cobra.cli import cli as cli_module
+    from pcobra.cobra.cli import transpiler_registry
     from pcobra.cobra.cli.commands import compile_cmd as compile_module
 
     # Evita dependencias externas de localización y banner interactivo.
@@ -47,18 +46,15 @@ def test_cli_compilar_con_tipos(tmp_path, monkeypatch):
         def generate_code(self, _ast):
             return "js"
 
+    monkeypatch.setattr(transpiler_registry, "cli_transpilers", lambda: {"python": FakePython, "javascript": FakeJS})
+    monkeypatch.setattr(transpiler_registry, "cli_transpiler_targets", lambda: ("python", "javascript"))
     monkeypatch.setattr(
         transpiler_registry,
-        "cli_transpilers",
+        "cli_plugin_transpilers",
         lambda: {"python": FakePython, "javascript": FakeJS},
     )
-    monkeypatch.setattr(
-        transpiler_registry,
-        "cli_transpiler_targets",
-        lambda: ("python", "javascript"),
-    )
-    monkeypatch.setattr(compile_module, "cli_transpiler_targets", lambda: ("python", "javascript"))
-    monkeypatch.setattr(compile_module, "cli_plugin_transpilers", lambda: {"python": FakePython, "javascript": FakeJS})
+    monkeypatch.setattr(transpiler_registry, "cli_ensure_entrypoint_transpilers_loaded_once", lambda: None)
+    compile_module = importlib.reload(compile_module)
 
     class DummyPool:
         def __init__(self, processes=None):


### PR DESCRIPTION
### Motivation

- Evitar que el test parchee catálogos locales en `compile_cmd` y asegurar que los comandos CLI consuman la fuente canónica de transpiladores.
- Mantener la cobertura del flujo multi-target `--tipos` sin introducir imports cruzados ni constantes locales (`TRANSPILERS`) en comandos.

### Description

- Actualiza `tests/unit/test_cli_compilar_tipos.py` para parchear la capa de registro CLI en `pcobra.cobra.cli.transpiler_registry` en lugar de símbolos importados en `compile_cmd`.
- Añade `importlib.reload(compile_module)` tras parchear `transpiler_registry` para que `compile_cmd` recoja las dependencias inyectadas en tiempo de prueba.
- Parchea `cli_transpilers`, `cli_transpiler_targets`, `cli_plugin_transpilers` y `cli_ensure_entrypoint_transpilers_loaded_once`, y elimina los parches previos dirigidos a `compile_module`.
- Conserva la simulación del pool paralelo con `DummyPool` y las aserciones que verifican el etiquetado `Código generado para <Label> (<target>)` y la salida de los transpiladores fake (`py`/`js`).

### Testing

- Ejecutado `rg -n "compile_module\.TRANSPILERS|from .*compile_cmd import TRANSPILERS" tests` y no se encontraron coincidencias pendientes de migración.
- Ejecutado `pytest -q tests/unit/test_cli_compilar_tipos.py` y pasó correctamente con `1 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7937e5a083279946fd2b61137260)