### PR TITLE
Enforce canonical imports in src/pcobra/cobra and add CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,8 @@ jobs:
         run: python scripts/ci/lint_public_no_direct_transpiler_imports.py
       - name: Lint legacy bindings imports in src
         run: python scripts/ci/lint_no_legacy_bindings_imports.py
+      - name: Lint no legacy cobra/core imports
+        run: python scripts/ci/lint_no_legacy_cobra_core_imports.py
       - name: Lint legacy cobra tree is shim-only
         run: python scripts/ci/lint_legacy_cobra_shims.py
       - name: Lint canonical import resolution contract

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,8 @@ jobs:
         run: python scripts/ci/lint_public_no_direct_transpiler_imports.py
       - name: Lint legacy bindings imports in src
         run: python scripts/ci/lint_no_legacy_bindings_imports.py
+      - name: Lint no legacy cobra/core imports
+        run: python scripts/ci/lint_no_legacy_cobra_core_imports.py
       - name: Lint legacy cobra tree is shim-only
         run: python scripts/ci/lint_legacy_cobra_shims.py
       - name: Lint canonical import resolution contract

--- a/docs/architecture/import-resolution-contract.md
+++ b/docs/architecture/import-resolution-contract.md
@@ -183,3 +183,9 @@ Regla operativa obligatoria para código Python del runtime (`src/pcobra/**`):
 
 Este contrato se valida en CI mediante `scripts/ci/lint_import_resolution_contract.py` y su test guard en `tests/unit/test_ci_lint_import_resolution_contract_guard.py`.
 
+Regla adicional para el namespace interno `src/pcobra/cobra/**`:
+
+- Está prohibido importar `pcobra.core.*`, `core.*` o `cobra.*` desde módulos productivos bajo `src/pcobra/cobra/`.
+- Dentro de `src/pcobra/cobra/`, solo se permiten rutas canónicas `pcobra.cobra.*` o imports relativos locales coherentes.
+- La CI aplica esta garantía con `scripts/ci/lint_no_legacy_cobra_core_imports.py` y su guard test `tests/unit/test_ci_lint_no_legacy_cobra_core_imports_guard.py`.
+

--- a/scripts/ci/lint_no_legacy_cobra_core_imports.py
+++ b/scripts/ci/lint_no_legacy_cobra_core_imports.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Bloquea imports legacy dentro de ``src/pcobra/cobra/**``."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COBRA_SRC = ROOT / "src" / "pcobra" / "cobra"
+FORBIDDEN_PREFIXES = ("pcobra.core", "core", "cobra")
+
+
+def _node_import_targets(node: ast.AST) -> list[str]:
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    if isinstance(node, ast.ImportFrom):
+        if node.level and node.level > 0:
+            return []
+        return [node.module] if node.module else []
+    return []
+
+
+def _is_forbidden(target: str | None) -> bool:
+    if not target:
+        return False
+    return any(
+        target == prefix or target.startswith(f"{prefix}.")
+        for prefix in FORBIDDEN_PREFIXES
+    )
+
+
+def find_violations(root: Path = ROOT) -> list[str]:
+    cobra_root = root / "src" / "pcobra" / "cobra"
+    failures: list[str] = []
+    for path in sorted(cobra_root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            for target in _node_import_targets(node):
+                if _is_forbidden(target):
+                    rel = path.relative_to(root)
+                    failures.append(
+                        f"{rel}:{node.lineno}: import no permitido a {target}; "
+                        "usa pcobra.cobra.* o imports relativos locales"
+                    )
+    return failures
+
+
+def main() -> int:
+    if not COBRA_SRC.exists():
+        print("⚠️ Lint imports legacy cobra/core: src/pcobra/cobra/ no existe, se omite.")
+        return 0
+
+    failures = find_violations(ROOT)
+    if failures:
+        print("❌ Lint imports legacy cobra/core en src/pcobra/cobra/: FALLÓ")
+        for item in failures:
+            print(f" - {item}")
+        return 1
+
+    print("✅ Lint imports legacy cobra/core en src/pcobra/cobra/: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pcobra/cobra/benchmarks/binary_bench.py
+++ b/src/pcobra/cobra/benchmarks/binary_bench.py
@@ -22,7 +22,7 @@ from pcobra.cobra.benchmarks.targets_policy import (
     executable_benchmark_backends,
     validate_backend_metadata,
 )
-from pcobra.core.cobra_config import tiempo_max_transpilacion
+from pcobra.cobra.core.cobra_config import tiempo_max_transpilacion
 
 try:
     import resource

--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -19,7 +19,7 @@ from pcobra.cobra.architecture.contracts import (
 )
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 from pcobra.cobra.build.orchestrator import BackendResolution, BuildOrchestrator
-from pcobra.core.ast_cache import obtener_ast
+from pcobra.cobra.core.ast_cache import obtener_ast
 
 ORCHESTRATOR = BuildOrchestrator()
 RUNTIME_MANAGER = RuntimeManager()

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -12,7 +12,7 @@ from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.target_policies import OFFICIAL_TRANSPILATION_TARGETS
-from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.cobra.core.interpreter import InterpretadorCobra
 from pcobra.cobra.cli.internal_compat.legacy_targets import (
     LEGACY_BACKENDS_FEATURE_FLAG,
     is_internal_legacy_targets_enabled,

--- a/src/pcobra/cobra/cli/commands/bench_transpilers_cmd.py
+++ b/src/pcobra/cobra/cli/commands/bench_transpilers_cmd.py
@@ -12,7 +12,7 @@ from pcobra.cobra.cli.deprecation_policy import enforce_advanced_profile_policy
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
-from pcobra.core.ast_cache import obtener_ast
+from pcobra.cobra.core.ast_cache import obtener_ast
 
 # Constantes del proyecto
 

--- a/src/pcobra/cobra/cli/commands/benchthreads_cmd.py
+++ b/src/pcobra/cobra/cli/commands/benchthreads_cmd.py
@@ -22,7 +22,7 @@ else:
 
 from pcobra.cobra.core import Lexer
 from pcobra.cobra.core import Parser
-from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.cobra.core.interpreter import InterpretadorCobra
 
 try:  # pragma: no cover - dependencia opcional
     from jupyter_kernel import CobraKernel
@@ -31,7 +31,7 @@ except ModuleNotFoundError:  # pragma: no cover - entornos sin ipykernel
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
-from pcobra.core.cobra_config import tiempo_max_transpilacion
+from pcobra.cobra.core.cobra_config import tiempo_max_transpilacion
 
 # Constantes de configuración
 PROCESS_TIMEOUT = tiempo_max_transpilacion()

--- a/src/pcobra/cobra/cli/commands/cache_cmd.py
+++ b/src/pcobra/cobra/cli/commands/cache_cmd.py
@@ -1,8 +1,8 @@
 from typing import Any
 import sqlite3
 
-from pcobra.core.ast_cache import limpiar_cache
-from pcobra.core.database import DatabaseDependencyError, DatabaseKeyError
+from pcobra.cobra.core.ast_cache import limpiar_cache
+from pcobra.cobra.core.database import DatabaseDependencyError, DatabaseKeyError
 
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _

--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -12,9 +12,9 @@ from pcobra.cobra.cli.target_policies import (
     parse_target_list,
 )
 from pcobra.cobra.imports._module_map_api import get_toml_map
-from pcobra.core.ast_cache import obtener_ast
-from pcobra.core.sandbox import validar_dependencias
-from pcobra.core.semantic_validators import (
+from pcobra.cobra.core.ast_cache import obtener_ast
+from pcobra.cobra.core.sandbox import validar_dependencias
+from pcobra.cobra.core.semantic_validators import (
     PrimitivaPeligrosaError,
     construir_cadena,
 )
@@ -36,7 +36,7 @@ from pcobra.cobra.cli.utils.messages import mostrar_advertencia, mostrar_error, 
 from pcobra.cobra.cli.utils.validators import validar_archivo_existente
 from pcobra.cobra.cli.utils.autocomplete import files_completer
 from pcobra.cobra.core import ParserError
-from pcobra.core.cobra_config import tiempo_max_transpilacion
+from pcobra.cobra.core.cobra_config import tiempo_max_transpilacion
 
 # Constantes de configuración
 MAX_PROCESSES = 4

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -746,7 +746,7 @@ class InteractiveCommand(BaseCommand):
 
         if linea == "sugerencias":
             try:
-                from pcobra.core.qualia_bridge import (
+                from pcobra.cobra.core.qualia_bridge import (
                     get_suggestions,  # optional subsystem
                 )
             except (ImportError, ModuleNotFoundError):

--- a/src/pcobra/cobra/cli/commands/profile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/profile_cmd.py
@@ -15,9 +15,9 @@ from typing import Optional, Any
 
 from pcobra.cobra.core import Lexer
 from pcobra.cobra.core import Parser
-from pcobra.core.interpreter import InterpretadorCobra
-from pcobra.core.sandbox import validar_dependencias
-from pcobra.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
+from pcobra.cobra.core.interpreter import InterpretadorCobra
+from pcobra.cobra.core.sandbox import validar_dependencias
+from pcobra.cobra.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.services.format_service import format_code_with_black

--- a/src/pcobra/cobra/cli/commands/qualia_cmd.py
+++ b/src/pcobra/cobra/cli/commands/qualia_cmd.py
@@ -6,7 +6,7 @@ from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
-from pcobra.core import qualia_bridge
+from pcobra.cobra.core import qualia_bridge
 
 
 class QualiaCommand(BaseCommand):

--- a/src/pcobra/cobra/cli/services/benchmark_service.py
+++ b/src/pcobra/cobra/cli/services/benchmark_service.py
@@ -28,7 +28,7 @@ from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.target_policies import OFFICIAL_RUNTIME_TARGETS
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.transpilers.target_utils import target_label
-from pcobra.core.cobra_config import tiempo_max_transpilacion
+from pcobra.cobra.core.cobra_config import tiempo_max_transpilacion
 
 ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
 SUBPROCESS_TIMEOUT = tiempo_max_transpilacion()

--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -31,7 +31,7 @@ from pcobra.cobra.core.runtime import (
 from pcobra.cobra.transpilers import module_map
 
 try:
-    from pcobra.core import sandbox as sandbox_module
+    from pcobra.cobra.core import sandbox as sandbox_module
 except ModuleNotFoundError as canon_exc:  # pragma: no cover
     sandbox_module = load_legacy_core_sandbox(canonical_error=canon_exc)
 

--- a/src/pcobra/cobra/cli/services/test_service.py
+++ b/src/pcobra/cobra/cli/services/test_service.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
 
-from pcobra.core.interpreter import InterpretadorCobra
-from pcobra.core.sandbox import ejecutar_en_contenedor, ejecutar_en_sandbox, ejecutar_en_sandbox_js
+from pcobra.cobra.core.interpreter import InterpretadorCobra
+from pcobra.cobra.core.sandbox import ejecutar_en_contenedor, ejecutar_en_sandbox, ejecutar_en_sandbox_js
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.mode_policy import validar_politica_modo

--- a/src/pcobra/cobra/cli/services/verification_service.py
+++ b/src/pcobra/cobra/cli/services/verification_service.py
@@ -9,8 +9,8 @@ from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.target_policies import VERIFICATION_EXECUTABLE_TARGETS
 from pcobra.cobra.core import Lexer, Parser
-from pcobra.core.interpreter import InterpretadorCobra
-from pcobra.core.sandbox import ejecutar_en_contenedor, ejecutar_en_sandbox, ejecutar_en_sandbox_js
+from pcobra.cobra.core.interpreter import InterpretadorCobra
+from pcobra.cobra.core.sandbox import ejecutar_en_contenedor, ejecutar_en_sandbox, ejecutar_en_sandbox_js
 from pcobra.cobra.cli.utils.validators import validar_archivo_existente
 from pcobra.cobra.qa.syntax_validation import SUPPORTED_VALIDATOR_TARGETS
 

--- a/src/pcobra/cobra/core/__init__.py
+++ b/src/pcobra/cobra/core/__init__.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import sys
 
-from pcobra.core import ast_nodes as _ast_nodes
-from pcobra.core.errors import InvalidTokenError, LexerError, UnclosedStringError
+from pcobra.cobra.core import ast_nodes as _ast_nodes
+from pcobra.cobra.core.errors import InvalidTokenError, LexerError, UnclosedStringError
 from .lexer import Lexer, TipoToken, Token
 
 # Reexportar los nodos del AST directamente desde ``pcobra.core``.
@@ -40,7 +40,7 @@ def __getattr__(name: str):
     evitar dependencias circulares y tiempos de carga innecesarios.
     """
     if name in {"Parser", "ParserError"}:
-        from pcobra.core import parser as _parser
+        from pcobra.cobra.core import parser as _parser
 
         globals().update({"Parser": _parser.Parser, "ParserError": _parser.ParserError})
         return globals()[name]

--- a/src/pcobra/cobra/core/ast_cache.py
+++ b/src/pcobra/cobra/core/ast_cache.py
@@ -1,0 +1,6 @@
+"""Adaptador canónico de caché AST."""
+
+from ...core.ast_cache import *  # noqa: F403
+from ...core import ast_cache as _ast_cache
+
+__all__ = [name for name in dir(_ast_cache) if not name.startswith("_")]

--- a/src/pcobra/cobra/core/ast_nodes.py
+++ b/src/pcobra/cobra/core/ast_nodes.py
@@ -1,8 +1,6 @@
-"""Reexporta los nodos del módulo ``core.ast_nodes`` para el paquete ``cobra``."""
+"""Adaptador canónico de nodos AST bajo ``pcobra.cobra.core``."""
 
-from pcobra.core import ast_nodes as _ast_nodes
+from ...core import ast_nodes as _ast_nodes
 
-# Reexportar todos los símbolos públicos definidos en ``core.ast_nodes``.
 __all__ = [name for name in dir(_ast_nodes) if not name.startswith("_")]
 globals().update({name: getattr(_ast_nodes, name) for name in __all__})
-

--- a/src/pcobra/cobra/core/cobra_config.py
+++ b/src/pcobra/cobra/core/cobra_config.py
@@ -1,0 +1,6 @@
+"""Adaptador canónico de configuración Cobra."""
+
+from ...core.cobra_config import *  # noqa: F403
+from ...core import cobra_config as _cobra_config
+
+__all__ = [name for name in dir(_cobra_config) if not name.startswith("_")]

--- a/src/pcobra/cobra/core/database.py
+++ b/src/pcobra/cobra/core/database.py
@@ -1,0 +1,6 @@
+"""Adaptador canónico de helpers de base de datos."""
+
+from ...core.database import *  # noqa: F403
+from ...core import database as _database
+
+__all__ = [name for name in dir(_database) if not name.startswith("_")]

--- a/src/pcobra/cobra/core/errors.py
+++ b/src/pcobra/cobra/core/errors.py
@@ -1,0 +1,6 @@
+"""Adaptador canónico de errores bajo ``pcobra.cobra.core``."""
+
+from ...core.errors import *  # noqa: F403
+from ...core import errors as _errors
+
+__all__ = [name for name in dir(_errors) if not name.startswith("_")]

--- a/src/pcobra/cobra/core/import_utils.py
+++ b/src/pcobra/cobra/core/import_utils.py
@@ -1,0 +1,6 @@
+"""Adaptador canónico de utilidades de importación."""
+
+from ...core.import_utils import *  # noqa: F403
+from ...core import import_utils as _import_utils
+
+__all__ = [name for name in dir(_import_utils) if not name.startswith("_")]

--- a/src/pcobra/cobra/core/internal_ir.py
+++ b/src/pcobra/cobra/core/internal_ir.py
@@ -1,0 +1,6 @@
+"""Adaptador canónico de IR interno."""
+
+from ...core.internal_ir import *  # noqa: F403
+from ...core import internal_ir as _internal_ir
+
+__all__ = [name for name in dir(_internal_ir) if not name.startswith("_")]

--- a/src/pcobra/cobra/core/interpreter.py
+++ b/src/pcobra/cobra/core/interpreter.py
@@ -1,0 +1,6 @@
+"""Adaptador canónico del intérprete Cobra."""
+
+from ...core.interpreter import *  # noqa: F403
+from ...core import interpreter as _interpreter
+
+__all__ = [name for name in dir(_interpreter) if not name.startswith("_")]

--- a/src/pcobra/cobra/core/lexer.py
+++ b/src/pcobra/cobra/core/lexer.py
@@ -10,7 +10,7 @@ import re
 from enum import Enum
 from typing import Dict, List, Optional, Pattern, Tuple, Union, cast
 
-from pcobra.core.errors import InvalidTokenError, LexerError, UnclosedStringError
+from pcobra.cobra.core.errors import InvalidTokenError, LexerError, UnclosedStringError
 
 logger = logging.getLogger(__name__)
 
@@ -518,7 +518,7 @@ class Lexer:
         Returns:
             Lista de tokens
         """
-        from pcobra.core.ast_cache import obtener_tokens_fragmento
+        from pcobra.cobra.core.ast_cache import obtener_tokens_fragmento
 
         self.tokens = []
         for linea in self.codigo_fuente.splitlines(keepends=True):

--- a/src/pcobra/cobra/core/optimizations/__init__.py
+++ b/src/pcobra/cobra/core/optimizations/__init__.py
@@ -1,0 +1,6 @@
+"""Adaptador canónico de optimizaciones."""
+
+from ....core.optimizations import *  # noqa: F403
+from ....core import optimizations as _optimizations
+
+__all__ = [name for name in dir(_optimizations) if not name.startswith("_")]

--- a/src/pcobra/cobra/core/parser.py
+++ b/src/pcobra/cobra/core/parser.py
@@ -5,14 +5,14 @@ import json
 import os
 from typing import Any, List
 
-from pcobra.core.lexer import TipoToken, Token
+from pcobra.cobra.core.lexer import TipoToken, Token
 from .utils import (
     PALABRAS_RESERVADAS,
     ALIAS_METODOS_ESPECIALES,
     sugerir_palabra_clave,
 )
 
-from pcobra.core.ast_nodes import (
+from pcobra.cobra.core.ast_nodes import (
     NodoAsignacion,
     NodoHolobit,
     NodoCondicional,
@@ -69,7 +69,7 @@ from pcobra.core.ast_nodes import (
     NodoBloque,
 )
 
-from pcobra.core import NodoYield
+from pcobra.cobra.core import NodoYield
 
 
 logger = logging.getLogger(__name__)
@@ -283,7 +283,7 @@ class ClassicParser:
     def parsear(self, *, incremental: bool = False, profile: bool = False):
         """Parsea tokens con soporte de caché incremental y perfilado."""
         if incremental:
-            from pcobra.core.ast_cache import obtener_ast_fragmento
+            from pcobra.cobra.core.ast_cache import obtener_ast_fragmento
 
             codigo = "\n".join(
                 token.valor if token.valor is not None else ""

--- a/src/pcobra/cobra/core/qualia_bridge.py
+++ b/src/pcobra/cobra/core/qualia_bridge.py
@@ -1,0 +1,6 @@
+"""Adaptador canónico de Qualia bridge."""
+
+from ...core.qualia_bridge import *  # noqa: F403
+from ...core import qualia_bridge as _qualia_bridge
+
+__all__ = [name for name in dir(_qualia_bridge) if not name.startswith("_")]

--- a/src/pcobra/cobra/core/resource_limits.py
+++ b/src/pcobra/cobra/core/resource_limits.py
@@ -1,0 +1,6 @@
+"""Adaptador canónico de límites de recursos."""
+
+from ...core.resource_limits import *  # noqa: F403
+from ...core import resource_limits as _resource_limits
+
+__all__ = [name for name in dir(_resource_limits) if not name.startswith("_")]

--- a/src/pcobra/cobra/core/runtime.py
+++ b/src/pcobra/cobra/core/runtime.py
@@ -7,16 +7,16 @@ canónico (``pcobra.cobra.*``) sin modificar la implementación base.
 
 from __future__ import annotations
 
-from pcobra.core.interpreter import InterpretadorCobra
-from pcobra.core.resource_limits import limitar_cpu_segundos, limitar_memoria_mb
-from pcobra.core.sandbox import (
+from pcobra.cobra.core.interpreter import InterpretadorCobra
+from pcobra.cobra.core.resource_limits import limitar_cpu_segundos, limitar_memoria_mb
+from pcobra.cobra.core.sandbox import (
     SecurityError,
     ejecutar_en_contenedor,
     ejecutar_en_sandbox,
     validar_dependencias,
 )
-from pcobra.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
-from pcobra.core.semantic_validators.base import ValidadorBase
+from pcobra.cobra.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
+from pcobra.cobra.core.semantic_validators.base import ValidadorBase
 
 __all__ = [
     "InterpretadorCobra",

--- a/src/pcobra/cobra/core/sandbox.py
+++ b/src/pcobra/cobra/core/sandbox.py
@@ -1,0 +1,6 @@
+"""Adaptador canónico de sandbox."""
+
+from ...core.sandbox import *  # noqa: F403
+from ...core import sandbox as _sandbox
+
+__all__ = [name for name in dir(_sandbox) if not name.startswith("_")]

--- a/src/pcobra/cobra/core/semantic_validators/__init__.py
+++ b/src/pcobra/cobra/core/semantic_validators/__init__.py
@@ -1,0 +1,6 @@
+"""Adaptador canónico de validadores semánticos."""
+
+from ....core.semantic_validators import *  # noqa: F403
+from ....core import semantic_validators as _semantic_validators
+
+__all__ = [name for name in dir(_semantic_validators) if not name.startswith("_")]

--- a/src/pcobra/cobra/core/semantic_validators/base.py
+++ b/src/pcobra/cobra/core/semantic_validators/base.py
@@ -1,0 +1,6 @@
+"""Adaptador canónico de base de validadores semánticos."""
+
+from ....core.semantic_validators.base import *  # noqa: F403
+from ....core.semantic_validators import base as _base
+
+__all__ = [name for name in dir(_base) if not name.startswith("_")]

--- a/src/pcobra/cobra/core/visitor.py
+++ b/src/pcobra/cobra/core/visitor.py
@@ -1,0 +1,6 @@
+"""Adaptador canónico de visitor bajo ``pcobra.cobra.core``."""
+
+from ...core.visitor import *  # noqa: F403
+from ...core import visitor as _visitor
+
+__all__ = [name for name in dir(_visitor) if not name.startswith("_")]

--- a/src/pcobra/cobra/gui/deps.py
+++ b/src/pcobra/cobra/gui/deps.py
@@ -14,7 +14,7 @@ from pcobra.cobra.core import Lexer, LexerError, Parser, ParserError
 from pcobra.cobra.transpilers.registry import get_transpilers
 from pcobra.cobra.transpilers.target_utils import target_cli_choices
 from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
-from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.cobra.core.interpreter import InterpretadorCobra
 
 __all__ = [
     "Lexer",

--- a/src/pcobra/cobra/macro/__init__.py
+++ b/src/pcobra/cobra/macro/__init__.py
@@ -1,5 +1,5 @@
 from typing import List, Dict, Any
-from pcobra.core.ast_nodes import NodoMacro, NodoLlamadaFuncion
+from pcobra.cobra.core.ast_nodes import NodoMacro, NodoLlamadaFuncion
 
 class MacroExpander:
     def __init__(self):

--- a/src/pcobra/cobra/semantico/analizador.py
+++ b/src/pcobra/cobra/semantico/analizador.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from typing import List, Optional, Any, Set
 
-from pcobra.core.ast_nodes import (
+from pcobra.cobra.core.ast_nodes import (
     NodoAST,
     NodoAsignacion,
     NodoBloque,
@@ -21,9 +21,9 @@ from pcobra.core.ast_nodes import (
     NodoCondicional,
     NodoImport,
 )
-from pcobra.core.visitor import NodeVisitor
+from pcobra.cobra.core.visitor import NodeVisitor
 from pcobra.cobra.semantico.tabla import Ambito
-from pcobra.core.import_utils import obtener_simbolos_modulo
+from pcobra.cobra.core.import_utils import obtener_simbolos_modulo
 
 
 class AnalizadorSemantico(NodeVisitor):

--- a/src/pcobra/cobra/transpilers/common/utils.py
+++ b/src/pcobra/cobra/transpilers/common/utils.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 import re
 from typing import List, Tuple, Union
 
-from pcobra.core.visitor import NodeVisitor
+from pcobra.cobra.core.visitor import NodeVisitor
 from pcobra.cobra.transpilers.compatibility_matrix import CONTRACT_FEATURES
 from pcobra.cobra.transpilers.module_map import get_mapped_path
 from pcobra.cobra.transpilers.target_utils import normalize_target_name
@@ -62,7 +62,7 @@ class BaseTranspiler(NodeVisitor, ABC):
 
 STANDARD_IMPORTS = {
     "python": (
-        "from pcobra.core.nativos import *\n"
+        "from pcobra.cobra.core.nativos import *\n"
         "import pcobra.corelibs as _pcobra_corelibs\n"
         "import pcobra.standard_library as _pcobra_standard_library\n"
         "globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})\n"
@@ -170,7 +170,7 @@ RUNTIME_HOOKS = {
         "    )",
         "",
         "def _cobra_import_holobit_runtime():",
-        "    from pcobra.core.holobits import Holobit, proyectar, transformar, graficar",
+        "    from pcobra.cobra.core.holobits import Holobit, proyectar, transformar, graficar",
         "    return Holobit, proyectar, transformar, graficar",
         "",
         "def cobra_holobit(valores):",

--- a/src/pcobra/cobra/transpilers/internal_ir_bridge.py
+++ b/src/pcobra/cobra/transpilers/internal_ir_bridge.py
@@ -7,7 +7,7 @@ import re
 from collections.abc import Sequence
 from typing import Any, Iterable, List
 
-from pcobra.core.internal_ir import (
+from pcobra.cobra.core.internal_ir import (
     InternalIRAssignment,
     InternalIRCall,
     InternalIRExpressionStatement,

--- a/src/pcobra/cobra/transpilers/reverse/base.py
+++ b/src/pcobra/cobra/transpilers/reverse/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import List, Any
-from pcobra.core.visitor import NodeVisitor
+from pcobra.cobra.core.visitor import NodeVisitor
 
 class BaseReverseTranspiler(NodeVisitor, ABC):
     """Clase base para transpiladores inversos que generan el AST de Cobra."""

--- a/src/pcobra/cobra/transpilers/semantica.py
+++ b/src/pcobra/cobra/transpilers/semantica.py
@@ -1,4 +1,4 @@
-from pcobra.core.ast_nodes import NodoAtributo
+from pcobra.cobra.core.ast_nodes import NodoAtributo
 
 
 def datos_asignacion(transpilador, nodo):

--- a/src/pcobra/cobra/transpilers/transpiler/cpp_nodes/funcion.py
+++ b/src/pcobra/cobra/transpilers/transpiler/cpp_nodes/funcion.py
@@ -1,4 +1,4 @@
-from pcobra.core.ast_nodes import NodoRetorno
+from pcobra.cobra.core.ast_nodes import NodoRetorno
 
 
 def visit_funcion(self, nodo):

--- a/src/pcobra/cobra/transpilers/transpiler/to_asm.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_asm.py
@@ -9,7 +9,7 @@ from pcobra.cobra.transpilers.common.utils import (
     get_runtime_hooks,
     get_standard_imports,
 )
-from pcobra.core.internal_ir import (
+from pcobra.cobra.core.internal_ir import (
     InternalIRAssignment,
     InternalIRCall,
     InternalIRExpressionStatement,
@@ -25,7 +25,7 @@ from pcobra.core.internal_ir import (
     InternalIRWhile,
     build_internal_ir,
 )
-from pcobra.core.optimizations import (
+from pcobra.cobra.core.optimizations import (
     eliminate_common_subexpressions,
     inline_functions,
     optimize_constants,

--- a/src/pcobra/cobra/transpilers/transpiler/to_cpp.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_cpp.py
@@ -3,7 +3,7 @@
 Los parámetros de tipo de Cobra se traducen a plantillas ``template`` propias
 de C++."""
 
-from pcobra.core.ast_nodes import (
+from pcobra.cobra.core.ast_nodes import (
     NodoLista,
     NodoDiccionario,
     NodoListaTipo,
@@ -35,13 +35,13 @@ from pcobra.core.ast_nodes import (
     NodoGraficar,
 )
 from pcobra.cobra.core import TipoToken
-from pcobra.core.visitor import NodeVisitor
+from pcobra.cobra.core.visitor import NodeVisitor
 from pcobra.cobra.transpilers.common.utils import (
     BaseTranspiler,
     get_runtime_hooks,
     get_standard_imports,
 )
-from pcobra.core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from pcobra.cobra.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from pcobra.cobra.macro import expandir_macros
 
 from pcobra.cobra.transpilers.transpiler.cpp_nodes.asignacion import visit_asignacion as _visit_asignacion

--- a/src/pcobra/cobra/transpilers/transpiler/to_go.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_go.py
@@ -2,7 +2,7 @@
 
 import re
 
-from pcobra.core.ast_nodes import (
+from pcobra.cobra.core.ast_nodes import (
     NodoDecorador,
     NodoImport,
     NodoUsar,
@@ -31,7 +31,7 @@ from pcobra.cobra.transpilers.common.utils import (
     get_runtime_hooks,
     get_standard_imports,
 )
-from pcobra.core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from pcobra.cobra.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from pcobra.cobra.macro import expandir_macros
 
 from pcobra.cobra.transpilers.transpiler.go_nodes.asignacion import (

--- a/src/pcobra/cobra/transpilers/transpiler/to_java.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_java.py
@@ -29,7 +29,7 @@ from pcobra.cobra.transpilers.common.utils import (
     get_runtime_hooks,
     get_standard_imports,
 )
-from pcobra.core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from pcobra.cobra.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from pcobra.cobra.macro import expandir_macros
 
 from pcobra.cobra.transpilers.transpiler.java_nodes.asignacion import (

--- a/src/pcobra/cobra/transpilers/transpiler/to_js.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_js.py
@@ -3,7 +3,7 @@
 Los parámetros de tipo se omiten porque JavaScript no soporta genéricos de
 forma nativa, por lo que se recurre a tipos dinámicos."""
 
-from pcobra.core.ast_nodes import (
+from pcobra.cobra.core.ast_nodes import (
     NodoHolobit,
     NodoLista,
     NodoDiccionario,
@@ -39,9 +39,9 @@ from pcobra.core.ast_nodes import (
     NodoDefer,
 )
 from pcobra.cobra.core import TipoToken
-from pcobra.core.visitor import NodeVisitor
+from pcobra.cobra.core.visitor import NodeVisitor
 from pcobra.cobra.transpilers.common.utils import BaseTranspiler
-from pcobra.core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from pcobra.cobra.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from pcobra.cobra.macro import expandir_macros
 from pcobra.cobra.transpilers.common.utils import (
     ast_requires_holobit_runtime,

--- a/src/pcobra/cobra/transpilers/transpiler/to_python.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_python.py
@@ -1,6 +1,6 @@
 """Transpilador que convierte código Cobra en código Python."""
 
-from pcobra.core.ast_nodes import (
+from pcobra.cobra.core.ast_nodes import (
     NodoAsignacion,
     NodoCondicional,
     NodoGarantia,
@@ -51,9 +51,9 @@ from pcobra.core.ast_nodes import (
 )
 from pcobra.cobra.core import Parser
 from pcobra.cobra.core import TipoToken, Lexer
-from pcobra.core.visitor import NodeVisitor
+from pcobra.cobra.core.visitor import NodeVisitor
 from pcobra.cobra.transpilers.common.utils import BaseTranspiler
-from pcobra.core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from pcobra.cobra.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from pcobra.cobra.macro import expandir_macros
 from pcobra.cobra.transpilers.common.utils import (
     ast_requires_holobit_runtime,

--- a/src/pcobra/cobra/transpilers/transpiler/to_rust.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_rust.py
@@ -37,13 +37,13 @@ from pcobra.cobra.core.ast_nodes import (
     NodoGraficar,
 )
 from pcobra.cobra.core import TipoToken
-from pcobra.core.visitor import NodeVisitor
+from pcobra.cobra.core.visitor import NodeVisitor
 from pcobra.cobra.transpilers.common.utils import (
     BaseTranspiler,
     get_runtime_hooks,
     get_standard_imports,
 )
-from pcobra.core.optimizations import optimize_constants, remove_dead_code, inline_functions
+from pcobra.cobra.core.optimizations import optimize_constants, remove_dead_code, inline_functions
 from pcobra.cobra.macro import expandir_macros
 from pcobra.cobra.transpilers.internal_ir_bridge import normalize_to_cobra_ast
 

--- a/src/pcobra/cobra/transpilers/transpiler/to_wasm.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_wasm.py
@@ -19,13 +19,13 @@ from pcobra.cobra.core.ast_nodes import (
     NodoTryCatch,
 )
 from pcobra.cobra.core import TipoToken
-from pcobra.core.visitor import NodeVisitor
+from pcobra.cobra.core.visitor import NodeVisitor
 from pcobra.cobra.transpilers.common.utils import (
     BaseTranspiler,
     get_runtime_hooks,
     get_standard_imports,
 )
-from pcobra.core.optimizations import optimize_constants, remove_dead_code
+from pcobra.cobra.core.optimizations import optimize_constants, remove_dead_code
 from pcobra.cobra.macro import expandir_macros
 
 

--- a/tests/unit/test_ci_lint_no_legacy_cobra_core_imports.py
+++ b/tests/unit/test_ci_lint_no_legacy_cobra_core_imports.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.ci.lint_no_legacy_cobra_core_imports import find_violations
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_detecta_import_legacy_pcobra_core_en_cobra_namespace(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "foo.py",
+        "from pcobra.core.interpreter import InterpretadorCobra\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "src/pcobra/cobra/foo.py:1" in violations[0]
+
+
+def test_detecta_import_legacy_core_alias_en_cobra_namespace(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "foo.py",
+        "import core.sandbox as sandbox\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "src/pcobra/cobra/foo.py:1" in violations[0]
+
+
+def test_permite_import_canonico_en_cobra_namespace(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "foo.py",
+        "from pcobra.cobra.core.runtime import InterpretadorCobra\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert violations == []

--- a/tests/unit/test_ci_lint_no_legacy_cobra_core_imports_guard.py
+++ b/tests/unit/test_ci_lint_no_legacy_cobra_core_imports_guard.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_ci_lint_no_legacy_cobra_core_imports_guard_passes_on_repo() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "scripts/ci/lint_no_legacy_cobra_core_imports.py"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
### Motivation

- Evitar imports legacy que rompan el contrato de resolución de imports dentro del namespace `src/pcobra/cobra/` y forzar el uso de rutas canónicas internas. 
- Mantener compatibilidad de tests y adaptadores sin permitir aliases legacy en módulos productivos. 
- Detectar regresiones automáticamente en pipelines mediante una regla CI específica.

### Description

- Audité y migré imports en `src/pcobra/cobra/**` para referenciar las rutas canónicas `pcobra.cobra.*` en lugar de `pcobra.core.*`, `core.*` o `cobra.*` en módulos productivos. 
- Añadí adaptadores/shims bajo `src/pcobra/cobra/core/` (p. ej. `interpreter`, `sandbox`, `ast_cache`, `optimizations`, `semantic_validators`, `visitor`, etc.) que reexportan los símbolos reales desde `src/pcobra/core/` para mantener compatibilidad sin reintroducir imports legacy en producción. 
- Implementé el nuevo lint `scripts/ci/lint_no_legacy_cobra_core_imports.py` que falla si aparecen imports a `pcobra.core.*`, `core.*` o `cobra.*` dentro de `src/pcobra/cobra/` y que ignora imports relativos (`from .` / `from ..`). 
- Integré la nueva regla en los workflows CI (`.github/workflows/ci.yml` y `.github/workflows/lint.yml`), añadí pruebas unitarias `tests/unit/test_ci_lint_no_legacy_cobra_core_imports.py` y un guard test `tests/unit/test_ci_lint_no_legacy_cobra_core_imports_guard.py`, y documenté la política en `docs/architecture/import-resolution-contract.md`.

### Testing

- Ejecuté `python scripts/ci/lint_no_legacy_cobra_core_imports.py` y obtuvo salida `OK` (sin violaciones). 
- Ejecuté `python scripts/ci/lint_no_legacy_bindings_imports.py` y obtuvo salida `OK`. 
- Ejecuté `pytest -q tests/unit/test_ci_lint_no_legacy_cobra_core_imports.py tests/unit/test_ci_lint_no_legacy_cobra_core_imports_guard.py` y los tests pasaron (`4 passed`). 
- Realicé una comprobación de humo importando `pcobra.cobra.core.runtime.InterpretadorCobra` y `pcobra.cobra.semantico.analizador.AnalizadorSemantico` para verificar que los adaptadores funcionan correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7e04e3cc8327af8bab8f9f7c7e60)