### PR TITLE
Unificar API canónica de ejecución y contrato REPL/script

### DIFF
--- a/docs/architecture/repl-script-parity-contract.md
+++ b/docs/architecture/repl-script-parity-contract.md
@@ -58,8 +58,21 @@ Si cualquier test de esta batería falla, el job falla y el check de GitHub qued
 La ruta de script (`RunService.ejecutar_normal`) y la ruta REPL (`InteractiveCommand.ejecutar_codigo`) deben usar el mismo pipeline canónico de ejecución:
 
 - Resolución de clase de intérprete con `resolver_interpretador_cls`.
-- Ejecución del flujo `analizar + validar + ejecutar` con `ejecutar_pipeline_explicito`.
-- Normalización de validadores de seguridad desde el propio pipeline compartido.
+- Ejecución del flujo `analizar + validar + ejecutar` con la API de alto nivel `ejecutar_pipeline_explicito`.
+- Normalización de `safe_mode` y `extra_validators` **únicamente** desde el pipeline compartido (`normalizar_opciones_pipeline`).
+
+### Regla obligatoria para nuevas rutas de ejecución
+
+Toda nueva ruta de ejecución (por ejemplo: comando CLI adicional, modo batch, endpoint HTTP, integración GUI o adaptador de sandbox) **debe** pasar por `ejecutar_pipeline_explicito` como API canónica.
+
+No se permite reimplementar parcial o localmente pasos de:
+
+- análisis (`Lexer`/`Parser`),
+- validación de seguridad,
+- normalización de `safe_mode`/`extra_validators`,
+- ni preparación de intérprete persistente.
+
+Si una ruta no puede usar el pipeline canónico, debe existir una ADR aprobada y tests de paridad equivalentes antes de merge.
 
 Además de la paridad de `stdout/stderr`, el contrato exige equivalencia de estado final del entorno observable (`interpretador.contextos[-1].values`) para confirmar que ambas rutas dejan el mismo contexto semántico tras ejecutar el mismo código.
 

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -66,7 +66,6 @@ from pcobra.cobra.cli.utils.messages import (
     mostrar_info,
 )
 from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
-from pcobra.cobra.cli.utils.validators import normalizar_validadores_extra
 from pcobra.cobra.cli.repl.cobra_lexer import CobraLexer
 from pcobra.cobra.cli.target_policies import (
     DOCKER_EXECUTABLE_TARGETS,
@@ -444,12 +443,7 @@ class InteractiveCommand(BaseCommand):
 
         # Configurar modo seguro y validadores
         seguro = getattr(args, "seguro", True)
-        raw_extra_validators = getattr(args, "extra_validators", None)
-        try:
-            extra_validators = normalizar_validadores_extra(raw_extra_validators)
-        except TypeError:
-            mostrar_error(_("Los validadores extra deben ser una ruta o lista de rutas"))
-            return 1
+        extra_validators = getattr(args, "extra_validators", None)
         self._seguro_repl = bool(seguro)
         self._extra_validators_repl = extra_validators
         try:

--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -13,6 +13,7 @@ from typing import Any, Callable
 from pcobra.cobra.core import Lexer, Parser
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_source_for_tokenizer
+from pcobra.cobra.cli.utils.validators import normalizar_validadores_extra
 from pcobra.cobra.core.runtime import ValidadorBase, construir_cadena
 
 
@@ -44,6 +45,14 @@ class InterpreterSetup:
     safe_mode: bool
     validadores_extra: Any
     interpretador: Any
+
+
+@dataclass(frozen=True)
+class NormalizedPipelineOptions:
+    """Opciones de ejecución normalizadas para el pipeline canónico."""
+
+    safe_mode: bool
+    validadores_extra: Any
 
 
 def construir_script_sandbox_canonico(
@@ -179,21 +188,41 @@ def preparar_interpretador(
     extra_validators: Any,
 ) -> InterpreterSetup:
     """Centraliza normalización de validadores, flags de seguridad e intérprete."""
-
-    validadores_normalizados = resolver_validadores_seguridad(
-        extra_validators,
+    opciones = normalizar_opciones_pipeline(
+        safe_mode=safe_mode,
+        extra_validators=extra_validators,
         interpretador_cls=interpretador_cls,
     )
     interpretador = construir_interprete(
         interpretador_cls=interpretador_cls,
-        safe_mode=safe_mode,
-        extra_validators=validadores_normalizados,
+        safe_mode=opciones.safe_mode,
+        extra_validators=opciones.validadores_extra,
     )
     return InterpreterSetup(
         interpretador_cls=interpretador_cls,
-        safe_mode=bool(safe_mode),
-        validadores_extra=validadores_normalizados,
+        safe_mode=opciones.safe_mode,
+        validadores_extra=opciones.validadores_extra,
         interpretador=interpretador,
+    )
+
+
+def normalizar_opciones_pipeline(
+    *,
+    safe_mode: bool,
+    extra_validators: Any,
+    interpretador_cls: Any,
+) -> NormalizedPipelineOptions:
+    """Punto único para normalizar safe_mode y extra_validators del pipeline."""
+
+    safe_mode_normalizado = bool(safe_mode)
+    extra_validators_normalizados = normalizar_validadores_extra(extra_validators)
+    validadores_resueltos = resolver_validadores_seguridad(
+        extra_validators_normalizados,
+        interpretador_cls=interpretador_cls,
+    )
+    return NormalizedPipelineOptions(
+        safe_mode=safe_mode_normalizado,
+        validadores_extra=validadores_resueltos,
     )
 
 
@@ -203,28 +232,23 @@ def ejecutar_codigo_canonico(
     interpretador: Any,
     seguro: bool,
     extra_validators: Any,
-    interpretador_cls: Any,
     construir_cadena_fn: Callable[[Any], Any] = construir_cadena,
     analizar_codigo_fn: Callable[[str], Any] = analizar_codigo,
 ) -> PipelineResult:
     """Función canónica para analizar+validar+ejecutar código Cobra."""
 
     ast = analizar_codigo_fn(codigo)
-    validadores_normalizados = resolver_validadores_seguridad(
-        extra_validators,
-        interpretador_cls=interpretador_cls,
-    )
     if seguro:
         validar_ast_seguro(
             ast,
-            validadores_extra=validadores_normalizados,
+            validadores_extra=extra_validators,
             construir_cadena_fn=construir_cadena_fn,
         )
     resultado = ejecutar_ast(ast, interpretador)
     return PipelineResult(
         ast=ast,
         resultado=resultado,
-        validadores_extra=validadores_normalizados,
+        validadores_extra=extra_validators,
     )
 
 
@@ -258,7 +282,6 @@ def ejecutar_pipeline_explicito(
         interpretador=interpretador,
         seguro=setup.safe_mode,
         extra_validators=setup.validadores_extra,
-        interpretador_cls=setup.interpretador_cls,
         construir_cadena_fn=construir_cadena_fn,
         analizar_codigo_fn=analizar_codigo_fn,
     )

--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -20,7 +20,7 @@ from pcobra.cobra.cli.services.contracts import RunRequest, normalize_run_reques
 from pcobra.cobra.cli.services.format_service import format_code_with_black
 from pcobra.cobra.cli.target_policies import resolve_docker_backend
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
-from pcobra.cobra.cli.utils.validators import normalizar_validadores_extra, validar_archivo_existente
+from pcobra.cobra.cli.utils.validators import validar_archivo_existente
 from pcobra.cobra.core import LexerError, ParserError
 from pcobra.cobra.core.runtime import (
     InterpretadorCobra,
@@ -92,11 +92,7 @@ class RunService:
         contenedor = request.contenedor
         allow_insecure_fallback = bool(request.allow_insecure_fallback)
 
-        try:
-            extra_validators = normalizar_validadores_extra(request.extra_validators)
-        except TypeError:
-            mostrar_error(_("Los validadores extra deben ser una ruta o lista de rutas"), registrar_log=False)
-            return 1
+        extra_validators = request.extra_validators
 
         try:
             raiz_proyecto = detectar_raiz_proyecto_desde_archivo(str(archivo_resuelto))

--- a/tests/cli/test_repl_script_parity_contract.py
+++ b/tests/cli/test_repl_script_parity_contract.py
@@ -24,6 +24,13 @@ def _valor_en_contextos(interpretador: InterpretadorCobra, nombre: str):
     raise NameError(f"Variable no declarada: {nombre}")
 
 
+def _normalizar_stdout_paridad(salida: str) -> str:
+    """Filtra eco implícito del REPL para comparar con la ruta script."""
+
+    lineas = [linea.strip() for linea in salida.splitlines() if linea.strip()]
+    return "\n".join(linea for linea in lineas if not linea.isdigit())
+
+
 def _ejecutar_por_ruta_script(
     codigo: str,
     variables_estado: tuple[str, ...],
@@ -105,6 +112,88 @@ def _ejecutar_por_ruta_repl(
     }
 
 
+def _ejecutar_snippets_secuenciales_script(
+    snippets: list[str], *, variables_estado: tuple[str, ...]
+) -> dict[str, object]:
+    interpretador_cls = resolver_interpretador_cls(
+        module_name="pcobra.cobra.cli.services.run_service",
+        default_cls=InterpretadorCobra,
+    )
+    out_script, err_script = StringIO(), StringIO()
+    excepcion: Exception | None = None
+    setup = None
+    with redirect_stdout(out_script), redirect_stderr(err_script):
+        with patch.object(
+            InterpretadorCobra,
+            "_asegurar_no_autorreferencia_asignacion",
+            return_value=None,
+        ):
+            try:
+                interpretador = None
+                for snippet in snippets:
+                    setup, resultado_pipeline = ejecutar_pipeline_explicito(
+                        PipelineInput(
+                            codigo=snippet,
+                            interpretador_cls=interpretador_cls,
+                            safe_mode=False,
+                            extra_validators=None,
+                            interpretador=interpretador,
+                        )
+                    )
+                    interpretador = setup.interpretador
+            except Exception as err:  # noqa: BLE001 - contrato de paridad
+                excepcion = err
+
+    estado = {}
+    if setup is not None:
+        for nombre in variables_estado:
+            try:
+                estado[nombre] = _valor_en_contextos(setup.interpretador, nombre)
+            except NameError:
+                continue
+    return {
+        "stdout": out_script.getvalue(),
+        "stderr": err_script.getvalue(),
+        "estado": estado,
+        "error": excepcion,
+    }
+
+
+def _ejecutar_snippets_secuenciales_repl(
+    snippets: list[str], *, variables_estado: tuple[str, ...]
+) -> dict[str, object]:
+    repl = InteractiveCommand(InterpretadorCobra())
+    repl._seguro_repl = False
+    repl._extra_validators_repl = None
+    out_repl, err_repl = StringIO(), StringIO()
+    excepcion: Exception | None = None
+    with redirect_stdout(out_repl), redirect_stderr(err_repl):
+        with patch.object(
+            InterpretadorCobra,
+            "_asegurar_no_autorreferencia_asignacion",
+            return_value=None,
+        ):
+            try:
+                for snippet in snippets:
+                    repl.ejecutar_codigo(snippet)
+            except Exception as err:  # noqa: BLE001 - contrato de paridad
+                excepcion = err
+
+    estado = {}
+    if excepcion is None:
+        for nombre in variables_estado:
+            try:
+                estado[nombre] = _valor_en_contextos(repl.interpretador, nombre)
+            except NameError:
+                continue
+    return {
+        "stdout": out_repl.getvalue(),
+        "stderr": err_repl.getvalue(),
+        "estado": estado,
+        "error": excepcion,
+    }
+
+
 @pytest.mark.integration
 def test_paridad_script_vs_repl_mientras_asignaciones_y_retorno_observable() -> None:
     codigo = (
@@ -147,3 +236,45 @@ def test_paridad_error_identificador_no_declarado_en_script_y_repl() -> None:
 
     assert type(err_script.value) is type(err_repl.value)
     assert str(err_script.value) == str(err_repl.value)
+
+
+@pytest.mark.integration
+def test_paridad_script_vs_repl_con_snippets_secuenciales_y_estado_final() -> None:
+    snippets = [
+        "var acumulado = 1",
+        "var salida = 15",
+        "var eco = salida",
+    ]
+    variables = ("acumulado",)
+
+    codigo_script = "\n".join(snippets)
+    resultado_script = _ejecutar_por_ruta_script(codigo_script, variables)
+    resultado_repl = _ejecutar_snippets_secuenciales_repl(
+        snippets, variables_estado=variables
+    )
+
+    assert resultado_repl["error"] is None
+    assert resultado_script["stderr"] == resultado_repl["stderr"] == ""
+    assert _normalizar_stdout_paridad(resultado_script["stdout"]) == _normalizar_stdout_paridad(
+        resultado_repl["stdout"]
+    ) == ""
+    assert resultado_script["estado"] == resultado_repl["estado"] == {
+        "acumulado": 1,
+    }
+
+
+@pytest.mark.integration
+def test_paridad_script_vs_repl_con_error_en_snippet_secuencial() -> None:
+    snippets = [
+        "var base = 7",
+        "var siguiente = base + 1",
+        "imprimir(no_existe_en_ambas_rutas)",
+    ]
+
+    resultado_script = _ejecutar_snippets_secuenciales_script(snippets, variables_estado=("base",))
+    resultado_repl = _ejecutar_snippets_secuenciales_repl(snippets, variables_estado=("base",))
+
+    assert resultado_script["error"] is not None
+    assert resultado_repl["error"] is not None
+    assert type(resultado_script["error"]) is type(resultado_repl["error"])
+    assert str(resultado_script["error"]) == str(resultado_repl["error"])


### PR DESCRIPTION
### Motivation

- Evitar lógica duplicada entre la ruta script y la ruta REPL consolidando un único pipeline de alto nivel para analizar + validar + ejecutar.
- Centralizar la normalización de `safe_mode` y `extra_validators` en un único punto para garantizar comportamiento idéntico entre modos.
- Añadir tests de paridad/contrato que detecten regresiones en salida, errores y estado final entre ejecución por archivo y REPL.
- Documentar la regla arquitectónica que obliga a usar la API canónica para nuevas rutas de ejecución.

### Description

- Se introduce `normalizar_opciones_pipeline(...)` y el dataclass `NormalizedPipelineOptions` en `execution_pipeline.py` y `preparar_interpretador(...)` ahora consume esa normalización centralizada.
- `ejecutar_pipeline_explicito(...)` se consolida como la API canónica y `ejecutar_codigo_canonico(...)` deja de re-normalizar validadores evitando duplicación.
- `RunService.run` y `InteractiveCommand.run` dejaron de normalizar localmente `extra_validators` y delegan completamente en el pipeline compartido, manteniéndose `RunService.ejecutar_normal` e `InteractiveCommand.ejecutar_codigo` usando exactamente dicha API.
- Se añadieron helpers y casos de prueba en `tests/cli/test_repl_script_parity_contract.py` para snippets secuenciales (éxito y error) y se actualizó la documentación en `docs/architecture/repl-script-parity-contract.md` imponiendo la regla de pasar por `ejecutar_pipeline_explicito`.

### Testing

- Ejecutado `python -m pytest -q tests/cli/test_repl_script_parity_contract.py` y la suite resultó en `4 passed` (éxitos).
- Ejecutado `python -m pytest -q tests/unit/test_cli_execution_pipeline_contract.py::test_contrato_resultado_igual_entre_modo_archivo_y_interactivo tests/unit/test_cli_execution_pipeline_contract.py::test_contrato_salida_y_error_iguales_entre_execute_e_interactive` y ambos tests pasaron (`4 passed` reported for that run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8186ad348327a4c77852644397c0)