### PR TITLE
Refactor imports de runtime a rutas canónicas y agregar test de contrato

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -5,7 +5,7 @@ import os
 import hashlib
 from typing import Mapping, Optional
 
-from pcobra.core.lexer import (
+from .lexer import (
     Token,
     TipoToken,
 )
@@ -61,7 +61,7 @@ from .semantic_validators import (
     construir_cadena,
     PrimitivaPeligrosaError,
 )
-from pcobra.core.semantico import AnalizadorSemantico
+from .semantico import AnalizadorSemantico
 from .cobra_config import (
     limite_nodos,
     limite_memoria_mb,
@@ -1709,7 +1709,7 @@ class InterpretadorCobra:
 
     def ejecutar_usar(self, nodo):
         """Importa un módulo de Python instalándolo si es necesario."""
-        from pcobra.core.usar_loader import obtener_modulo
+        from .usar_loader import obtener_modulo
 
         try:
             modulo = obtener_modulo(nodo.modulo)

--- a/tests/unit/test_runtime_import_contract_no_pcobra_core_refs.py
+++ b/tests/unit/test_runtime_import_contract_no_pcobra_core_refs.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_SCOPES = (
+    ROOT / "src" / "pcobra" / "core" / "interpreter.py",
+    ROOT / "src" / "pcobra" / "cobra" / "core" / "runtime.py",
+    ROOT / "src" / "pcobra" / "cobra" / "core" / "interpreter.py",
+)
+
+
+def _collect_pcobra_core_imports(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        targets: list[str] = []
+        if isinstance(node, ast.Import):
+            targets = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            if node.level and node.level > 0:
+                continue
+            if node.module:
+                targets = [node.module]
+
+        for target in targets:
+            if target == "pcobra.core" or target.startswith("pcobra.core."):
+                violations.append((node.lineno, target))
+
+    return violations
+
+
+def test_runtime_critico_no_referencia_pcobra_core_directo() -> None:
+    """Evita reintroducir imports productivos legacy en runtime crítico."""
+    failures: list[str] = []
+
+    for path in RUNTIME_SCOPES:
+        violations = _collect_pcobra_core_imports(path)
+        failures.extend(f"{path.relative_to(ROOT)}:{line} -> {target}" for line, target in violations)
+
+    assert failures == []


### PR DESCRIPTION
### Motivation
- Evitar referencias productivas a `pcobra.core.*` dentro del runtime crítico para prevenir rutas dobles de import y problemas de resolución en tiempo de ejecución.
- Mantener el puente de compatibilidad bajo `pcobra.cobra.core` como reexportador sin introducir imports legacy en caliente.

### Description
- Reemplacé imports absolutos legacy en `src/pcobra/core/interpreter.py` por imports relativos canónicos, por ejemplo `from .lexer import ...`, `from .semantico import AnalizadorSemantico` y `from .usar_loader import obtener_modulo` dentro de `ejecutar_usar`.
- Confirmé que `src/pcobra/cobra/core/interpreter.py` permanece como adaptador de compatibilidad que reexporta el intérprete canónico y no introduce `pcobra.core.*` productivo.
- Añadí el test de contrato `tests/unit/test_runtime_import_contract_no_pcobra_core_refs.py` que analiza el AST y falla si aparece un import directo a `pcobra.core.*` en los ficheros runtime críticos listados.

### Testing
- Ejecuté `pytest -q tests/unit/test_runtime_import_contract_no_pcobra_core_refs.py tests/unit/test_ci_lint_no_legacy_cobra_core_imports.py` y ambos tests terminaron correctamente.
- Resultado de la ejecución de pruebas: `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec864a5ba083278daff6aff3c05877)