### PR TITLE
Unificar acceso al mapa TOML en CLI mediante la fachada `transpiler_registry`

### DIFF
--- a/scripts/ci/lint_no_parallel_transpilers_registry.py
+++ b/scripts/ci/lint_no_parallel_transpilers_registry.py
@@ -6,6 +6,9 @@ Reglas:
 2) Dentro de ``pcobra.cobra.cli`` prohíbe importar directamente
    ``pcobra.cobra.transpilers.registry`` (debe usarse la fachada
    ``pcobra.cobra.cli.transpiler_registry``).
+3) Dentro de ``pcobra.cobra.cli.commands`` prohíbe importar directamente el
+   mapa TOML desde módulos internos (debe usarse ``cli_toml_map`` de la
+   fachada ``pcobra.cobra.cli.transpiler_registry``).
 """
 
 from __future__ import annotations
@@ -31,6 +34,10 @@ FORBIDDEN_PARALLEL_CATALOG_NAMES = {
 
 CLI_FACADE_MODULE = "pcobra.cobra.cli.transpiler_registry"
 CANONICAL_REGISTRY_MODULE = "pcobra.cobra.transpilers.registry"
+CANONICAL_MODULE_MAP_MODULES = {
+    "pcobra.cobra.transpilers.module_map",
+    "pcobra.cobra.imports._module_map_api",
+}
 
 def _find_transpilers_literal_violations(root: Path) -> list[str]:
     violations: list[str] = []
@@ -133,11 +140,29 @@ def _find_cli_registry_facade_violations(root: Path) -> list[str]:
     return violations
 
 
+def _find_cli_module_map_facade_violations(root: Path) -> list[str]:
+    violations: list[str] = []
+    cli_commands_root = root / "src" / "pcobra" / "cobra" / "cli" / "commands"
+    if not cli_commands_root.exists():
+        return violations
+
+    for path in sorted(cli_commands_root.rglob("*.py")):
+        rel = path.relative_to(root)
+        for lineno, module in _iter_import_modules(path, root):
+            if module not in CANONICAL_MODULE_MAP_MODULES:
+                continue
+            violations.append(
+                f"{rel}:{lineno}: import directo de `{module}` no permitido en comandos CLI; use `{CLI_FACADE_MODULE}.cli_toml_map`"
+            )
+    return violations
+
+
 def find_violations(root: Path = ROOT) -> list[str]:
     return (
         _find_transpilers_literal_violations(root)
         + _find_parallel_catalog_name_violations(root)
         + _find_cli_registry_facade_violations(root)
+        + _find_cli_module_map_facade_violations(root)
     )
 
 

--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -11,7 +11,6 @@ from pcobra.cobra.cli.target_policies import (
     parse_target,
     parse_target_list,
 )
-from pcobra.cobra.imports._module_map_api import get_toml_map
 from pcobra.cobra.core.ast_cache import obtener_ast
 from pcobra.cobra.core.sandbox import validar_dependencias
 from pcobra.cobra.core.semantic_validators import (
@@ -25,6 +24,7 @@ from pcobra.cobra.cli.transpiler_registry import (
     cli_load_entrypoint_transpilers,
     cli_plugin_transpilers,
     cli_register_transpiler_backend,
+    cli_toml_map,
     cli_transpilers,
     cli_transpiler_targets,
 )
@@ -194,7 +194,7 @@ class CompileCommand(BaseCommand):
                 mostrar_error(str(parse_error))
                 return 1
 
-        mod_info = get_toml_map()
+        mod_info = cli_toml_map()
         preferred_backend = getattr(args, "backend", None) or getattr(args, "tipo", None)
         if preferred_backend and preferred_backend not in current_lang_choices:
             mostrar_error(invalid_target_error(preferred_backend))

--- a/tests/performance/test_transpile_time.py
+++ b/tests/performance/test_transpile_time.py
@@ -54,7 +54,7 @@ def test_transpile_time(tmp_path, monkeypatch):
     """Verifica que la transpilación de múltiples archivos se realiza rápidamente."""
     # Evita cargas de dependencias externas en la transpilación
     monkeypatch.setattr(
-        "cobra.cli.commands.compile_cmd.module_map.get_toml_map", lambda: {}
+        "cobra.cli.commands.compile_cmd.cli_toml_map", lambda: {}
     )
 
     num_archivos = 5

--- a/tests/unit/test_ci_lint_no_parallel_transpilers_registry.py
+++ b/tests/unit/test_ci_lint_no_parallel_transpilers_registry.py
@@ -58,6 +58,30 @@ def test_permite_fachada_cli_transpiler_registry(tmp_path: Path) -> None:
     assert violations == []
 
 
+def test_detecta_import_directo_module_map_en_comandos_cli(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "bad_map.py",
+        "from pcobra.cobra.imports._module_map_api import get_toml_map\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "import directo de `pcobra.cobra.imports._module_map_api`" in violations[0]
+    assert "src/pcobra/cobra/cli/commands/bad_map.py:1" in violations[0]
+
+
+def test_permite_cli_toml_map_en_comandos_cli(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "ok_map.py",
+        "from pcobra.cobra.cli.transpiler_registry import cli_toml_map\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert violations == []
+
+
 def test_detecta_catalogo_paralelo_con_nombre_contractual(tmp_path: Path) -> None:
     _write(
         tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "bad_catalog.py",

--- a/tests/unit/test_compile_cmd_errors.py
+++ b/tests/unit/test_compile_cmd_errors.py
@@ -20,7 +20,7 @@ def test_transpilador_inexistente(monkeypatch, tmp_path):
     monkeypatch.setattr("cobra.cli.commands.compile_cmd.validar_dependencias", lambda *a, **k: None)
     monkeypatch.setattr("cobra.cli.commands.compile_cmd.obtener_ast", lambda codigo: [])
     monkeypatch.setattr("cobra.cli.commands.compile_cmd.mostrar_error", lambda msg: mensajes.append(msg))
-    monkeypatch.setattr("cobra.cli.commands.compile_cmd.module_map.get_toml_map", lambda: {})
+    monkeypatch.setattr("cobra.cli.commands.compile_cmd.cli_toml_map", lambda: {})
 
     args = SimpleNamespace(archivo=str(archivo), tipo="fantasia", backend=None, tipos=None)
     rc = CompileCommand().run(args)
@@ -41,7 +41,7 @@ def test_dependencia_faltante(monkeypatch, tmp_path):
     monkeypatch.setattr("cobra.cli.commands.compile_cmd.validar_dependencias", fake_validar)
     monkeypatch.setattr("cobra.cli.commands.compile_cmd.obtener_ast", lambda codigo: [])
     monkeypatch.setattr("cobra.cli.commands.compile_cmd.mostrar_error", lambda msg: mensajes.append(msg))
-    monkeypatch.setattr("cobra.cli.commands.compile_cmd.module_map.get_toml_map", lambda: {})
+    monkeypatch.setattr("cobra.cli.commands.compile_cmd.cli_toml_map", lambda: {})
 
     args = SimpleNamespace(archivo=str(archivo), tipo="python", backend=None, tipos=None)
     rc = CompileCommand().run(args)
@@ -75,7 +75,7 @@ def test_exceso_tipos(monkeypatch, tmp_path):
     monkeypatch.setattr("cobra.cli.commands.compile_cmd.validar_dependencias", lambda *a, **k: None)
     monkeypatch.setattr("cobra.cli.commands.compile_cmd.obtener_ast", lambda codigo: [])
     monkeypatch.setattr("cobra.cli.commands.compile_cmd.mostrar_error", lambda msg: mensajes.append(msg))
-    monkeypatch.setattr("cobra.cli.commands.compile_cmd.module_map.get_toml_map", lambda: {})
+    monkeypatch.setattr("cobra.cli.commands.compile_cmd.cli_toml_map", lambda: {})
 
     many_langs = "python,javascript,cpp,go,java,asm,rust,wasm,python,javascript,rust"
     args = SimpleNamespace(archivo=str(archivo), tipo="python", backend=None, tipos=many_langs)


### PR DESCRIPTION
### Motivation
- Evitar accesos directos a módulos internos del mapa TOML desde comandos CLI y centralizar el punto de acceso en la fachada del registro de transpiladores.
- Asegurar el contrato de la capa CLI para que los comandos consuman únicamente adaptadores públicos y no importen implementaciones internas de otros dominios.
- Mantener la interfaz pública de la CLI intacta mientras se refactoriza el acoplamiento interno.

### Description
- Reemplacé el uso directo de `get_toml_map` por `cli_toml_map` en `src/pcobra/cobra/cli/commands/compile_cmd.py` y añadí el importe correspondiente desde `pcobra.cobra.cli.transpiler_registry`.
- Añadí detección al lint de contrato (`scripts/ci/lint_no_parallel_transpilers_registry.py`) para prohibir imports directos de `pcobra.cobra.transpilers.module_map` y `pcobra.cobra.imports._module_map_api` dentro de `src/pcobra/cobra/cli/commands` y sugerir `cli_toml_map` como punto único de acceso.
- Actualicé pruebas del lint (`tests/unit/test_ci_lint_no_parallel_transpilers_registry.py`) para cubrir la nueva regla y ajusté tests que parcheaban el antiguo símbolo para mockear ahora `cobra.cli.commands.compile_cmd.cli_toml_map` (`tests/unit/test_compile_cmd_errors.py`, `tests/performance/test_transpile_time.py`).
- No se modificó la interfaz pública de comandos ni los nombres de subcomandos existentes.

### Testing
- Ejecuté `pytest -q tests/unit/test_ci_lint_no_parallel_transpilers_registry.py` y `tests/unit/test_cli_transpiler_registry_contract.py` y ambos pasaron correctamente.
- Ejecuté `pytest -q tests/unit/test_cli_compilar_tipos.py` y la prueba pasó (con una advertencia de deprecación en el entorno de pruebas).
- Ejecuté el lint `python scripts/ci/lint_no_parallel_transpilers_registry.py` y no detectó violaciones en el árbol actual.
- Al ejecutar `pytest -q tests/unit/test_compile_cmd_errors.py tests/performance/test_transpile_time.py` surgieron fallos por resolución de import-path en el entorno de pruebas (`AttributeError` al resolver `cobra.cli.commands.compile_cmd`), lo que impidió completar esas pruebas en esta sesión; los cambios en las pruebas se aplicaron para referenciar `cli_toml_map` según el nuevo contrato.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec87ac22b083279a21fadc76ce3616)