### PR TITLE
Unificar prevalidación de parsing entre REPL y ejecución de scripts

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -32,12 +32,13 @@ except ModuleNotFoundError:  # pragma: no cover - entornos sin prompt_toolkit
     PROMPT_TOOLKIT_AVAILABLE = False
 
 from pcobra.cobra.core import Lexer, LexerError, TipoToken, UnclosedStringError
-from pcobra.cobra.core import Parser, ParserError
+from pcobra.cobra.core import ParserError
 from pcobra.cobra.cli.execution_pipeline import (
     analizar_codigo,
     construir_script_sandbox_canonico,
     ejecutar_pipeline_explicito,
     PipelineInput,
+    prevalidar_y_parsear_codigo,
     resolver_interpretador_cls,
     validar_ast_seguro,
 )
@@ -340,7 +341,7 @@ class InteractiveCommand(BaseCommand):
         if depth > self.MAX_AST_DEPTH:
             raise RuntimeError(_("Se excedió la profundidad máxima del AST"))
 
-        ast = analizar_codigo(linea)
+        ast = prevalidar_y_parsear_codigo(linea)
         self.logger.debug(_("AST generado: {ast}").format(ast=ast))
 
         if validador:
@@ -775,7 +776,7 @@ class InteractiveCommand(BaseCommand):
         Args:
             linea: Código a ejecutar
         """
-        analizar_codigo(linea)
+        prevalidar_y_parsear_codigo(linea)
 
         script = construir_script_sandbox_canonico(
             linea,

--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -94,6 +94,14 @@ def construir_script_sandbox_canonico(
 def analizar_codigo(codigo: str) -> Any:
     """Analiza código fuente con el pipeline canónico Lexer+Parser."""
 
+    return prevalidar_y_parsear_codigo(codigo)
+
+
+def prevalidar_y_parsear_codigo(codigo: str) -> Any:
+    """Normaliza/sanea código y centraliza el parseo para script y REPL."""
+
+    if not isinstance(codigo, str):
+        raise TypeError(_("El código fuente debe ser una cadena de texto"))
     codigo_saneado = sanitize_source_for_tokenizer(codigo)
     tokens = Lexer(codigo_saneado).tokenizar()
     return Parser(tokens).parsear()

--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -5,9 +5,9 @@ from typing import Any
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 from pcobra.cobra.cli.execution_pipeline import (
     PipelineInput,
-    analizar_codigo,
     construir_script_sandbox_canonico,
     ejecutar_pipeline_explicito,
+    prevalidar_y_parsear_codigo,
     resolver_interpretador_cls,
 )
 from pcobra.cobra.cli.i18n import _
@@ -156,7 +156,7 @@ class RunService:
         allow_insecure_fallback: bool = False,
     ) -> int:
         try:
-            analizar_codigo(codigo)
+            prevalidar_y_parsear_codigo(codigo)
         except (LexerError, ParserError) as e:
             mostrar_error(f"Error de análisis: {e}", registrar_log=False)
             return 1
@@ -208,7 +208,7 @@ class RunService:
                     extra_validators=extra_validators,
                 ),
                 construir_cadena_fn=construir_cadena,
-                analizar_codigo_fn=analizar_codigo,
+                analizar_codigo_fn=prevalidar_y_parsear_codigo,
             )
             return 0
         except (LexerError, ParserError) as e:

--- a/tests/unit/test_cli_execution_pipeline_contract.py
+++ b/tests/unit/test_cli_execution_pipeline_contract.py
@@ -12,6 +12,7 @@ from pcobra.cobra.cli.execution_pipeline import (
     PipelineInput,
     analizar_codigo,
     ejecutar_pipeline_explicito,
+    prevalidar_y_parsear_codigo,
     resolver_interpretador_cls,
 )
 from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
@@ -134,6 +135,75 @@ def _run_script_pipeline(
         "error_kind": _clasificar_error_repl(exc),
         "persistente": persistente,
         "contexto_values": contexto,
+        "exc": exc,
+    }
+
+
+def _run_script_pipeline_secuencial(
+    *,
+    snippets: list[str],
+    variables_estado: tuple[str, ...],
+) -> dict[str, object]:
+    out, err = StringIO(), StringIO()
+    exc: Exception | None = None
+    interpretador = None
+    with redirect_stdout(out), redirect_stderr(err):
+        try:
+            interpretador_cls = resolver_interpretador_cls(
+                module_name="pcobra.cobra.cli.services.run_service",
+                default_cls=InterpretadorCobra,
+            )
+            for snippet in snippets:
+                setup, _ = ejecutar_pipeline_explicito(
+                    PipelineInput(
+                        codigo=snippet,
+                        interpretador_cls=interpretador_cls,
+                        safe_mode=False,
+                        extra_validators=None,
+                        interpretador=interpretador,
+                    ),
+                    analizar_codigo_fn=prevalidar_y_parsear_codigo,
+                )
+                interpretador = setup.interpretador
+        except Exception as captured:  # noqa: BLE001 - contrato explícito entre rutas
+            exc = captured
+
+    estado: dict[str, object | None] = {}
+    if interpretador is not None:
+        for variable in variables_estado:
+            estado[variable] = interpretador.contextos[-1].get(variable)
+    return {
+        "stdout": out.getvalue(),
+        "stderr": err.getvalue(),
+        "estado": estado,
+        "exc": exc,
+    }
+
+
+def _run_repl_secuencial(
+    *,
+    snippets: list[str],
+    variables_estado: tuple[str, ...],
+) -> dict[str, object]:
+    repl = InteractiveCommand(InterpretadorCobra())
+    repl._seguro_repl = False
+    repl._extra_validators_repl = None
+    out, err = StringIO(), StringIO()
+    exc: Exception | None = None
+    with redirect_stdout(out), redirect_stderr(err):
+        try:
+            for snippet in snippets:
+                repl.ejecutar_codigo(snippet)
+        except Exception as captured:  # noqa: BLE001 - contrato explícito entre rutas
+            exc = captured
+    estado = {
+        variable: repl.interpretador.contextos[-1].get(variable)
+        for variable in variables_estado
+    }
+    return {
+        "stdout": out.getvalue(),
+        "stderr": err.getvalue(),
+        "estado": estado,
         "exc": exc,
     }
 
@@ -507,4 +577,65 @@ def test_contrato_error_semantico_runtime_mismo_tipo_y_mensaje(caso, codigo_erro
     )
     assert str(err_script.value) == str(err_repl.value), (
         f"{caso}: mensaje de error divergente entre script y REPL"
+    )
+
+
+@pytest.mark.parametrize(
+    ("caso", "snippets", "variables_estado"),
+    [
+        (
+            "paridad_mientras",
+            [
+                "var i = 0",
+                "mientras i < 3:\n    i = i + 1\nfin",
+                "imprimir(i)",
+            ],
+            ("i",),
+        ),
+        (
+            "paridad_asignacion_acumulativa",
+            [
+                "var acumulado = 1",
+                "acumulado = acumulado + 4",
+                "acumulado = acumulado + 5",
+                "imprimir(acumulado)",
+            ],
+            ("acumulado",),
+        ),
+        (
+            "paridad_visibilidad_variables",
+            [
+                "var base = 10",
+                "si verdadero:\n    base = base + 1\nfin",
+                "var visible = base",
+                "imprimir(visible)",
+            ],
+            ("base", "visible"),
+        ),
+    ],
+)
+def test_paridad_explicita_repl_vs_script_en_casos_clave(
+    caso: str,
+    snippets: list[str],
+    variables_estado: tuple[str, ...],
+) -> None:
+    resultado_script = _run_script_pipeline_secuencial(
+        snippets=snippets,
+        variables_estado=variables_estado,
+    )
+    resultado_repl = _run_repl_secuencial(
+        snippets=snippets,
+        variables_estado=variables_estado,
+    )
+
+    assert resultado_script["exc"] is None, f"{caso}: script no debe fallar"
+    assert resultado_repl["exc"] is None, f"{caso}: REPL no debe fallar"
+    assert resultado_script["stderr"] == resultado_repl["stderr"] == "", (
+        f"{caso}: no se esperan errores en stderr"
+    )
+    assert _normalizar_salida_repl(str(resultado_script["stdout"])) == _normalizar_salida_repl(
+        str(resultado_repl["stdout"])
+    ), f"{caso}: stdout divergente entre rutas"
+    assert resultado_script["estado"] == resultado_repl["estado"], (
+        f"{caso}: estado final de variables divergente entre rutas"
     )

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -451,13 +451,19 @@ def test_ejecutar_en_sandbox_usa_estado_repl_y_contrato_de_run_service():
     cmd = InteractiveCommand(MagicMock())
     cmd._seguro_repl = True
     cmd._extra_validators_repl = ["extra_repl.py"]
-
-    with patch("cobra.cli.commands.interactive_cmd.analizar_codigo") as mock_analizar, \
-         patch("cobra.cli.commands.interactive_cmd.construir_script_sandbox_canonico", return_value="SCRIPT") as mock_script, \
-         patch("cobra.cli.commands.interactive_cmd.ejecutar_en_sandbox", return_value=None) as mock_ejecutar:
+    with patch.dict(
+        cmd._ejecutar_en_sandbox.__globals__,
+        {
+            "prevalidar_y_parsear_codigo": MagicMock(),
+            "construir_script_sandbox_canonico": MagicMock(return_value="SCRIPT"),
+            "ejecutar_en_sandbox": MagicMock(return_value=None),
+        },
+    ) as patched_globals:
+        mock_prevalidar = patched_globals["prevalidar_y_parsear_codigo"]
+        mock_script = patched_globals["construir_script_sandbox_canonico"]
+        mock_ejecutar = patched_globals["ejecutar_en_sandbox"]
         cmd._ejecutar_en_sandbox("imprimir(7)")
-
-    mock_analizar.assert_called_once_with("imprimir(7)")
+    mock_prevalidar.assert_called_once_with("imprimir(7)")
     mock_script.assert_called_once_with(
         "imprimir(7)",
         safe_mode=True,


### PR DESCRIPTION
### Motivation

- Centralizar la normalización/saneado y el parsing para evitar discrepancias entre la ruta interactiva (REPL) y la ejecución por script, garantizando paridad de errores y comportamiento.
- Evitar llamadas dispersas a `analizar_codigo` fuera del pipeline explícito y exponer una API única para prevalidación y parsing reutilizable en REPL, sandbox y ejecución de archivos.

### Description

- Se agregó `prevalidar_y_parsear_codigo(codigo)` en `src/pcobra/cobra/cli/execution_pipeline.py` que valida el tipo de entrada, sanea la fuente y ejecuta `Lexer`+`Parser`; `analizar_codigo` ahora delega a esta función para compatibilidad.
- Se reemplazaron llamadas directas a `analizar_codigo` en `src/pcobra/cobra/cli/commands/interactive_cmd.py` por `prevalidar_y_parsear_codigo`, incluyendo `procesar_ast` y la ruta de sandbox del REPL, para usar la misma normalización/errores.
- Se alineó `src/pcobra/cobra/cli/services/run_service.py` para usar `prevalidar_y_parsear_codigo` en las rutas de sandbox y en el pipeline no interactivo, y se pasó la nueva función como `analizar_codigo_fn` donde procede.
- Se añadieron/ajustaron tests en `tests/unit/test_cli_execution_pipeline_contract.py` y `tests/unit/test_cli_interactive_cmd.py`: helpers secuenciales para comparar ejecución por script vs REPL y un test parametrizado que verifica paridad en `mientras`, asignaciones acumulativas y visibilidad de variables; además se actualizó un test de sandbox REPL para comprobar la invocación de la nueva API.

### Testing

- Ejecuté tests focalizados: `pytest -q tests/unit/test_cli_interactive_cmd.py::test_ejecutar_en_sandbox_usa_estado_repl_y_contrato_de_run_service tests/unit/test_cli_execution_pipeline_contract.py::test_paridad_explicita_repl_vs_script_en_casos_clave tests/unit/test_cli_execution_pipeline_contract.py::test_contrato_error_igual_entre_modo_archivo_y_interactivo` y los tres pasaron (todos los tests invocados pasaron tras ajustar mocks en los tests).
- Ejecuté las suites modificadas `pytest -q tests/unit/test_cli_interactive_cmd.py tests/unit/test_cli_execution_pipeline_contract.py` durante la iteración; inicialmente detectaron fallos relacionados con el alcance de parches/mocking en tests (no con la nueva lógica de parsing), los cuales fueron corregidos en los tests, y las ejecuciones focalizadas finales pasaron.
- Registro: las modificaciones fueron verificadas con las pruebas unitarias relevantes y los cambios en tests fueron actualizados para reflejar la nueva API de prevalidación; los tests automatizados apuntados en este PR pasan en el entorno donde se ejecutaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8928399c8327a92bdb7a9702a16e)