### PR TITLE
Endurecer detección de imports legacy y contrato de shims

### DIFF
--- a/scripts/ci/lint_no_legacy_bindings_imports.py
+++ b/scripts/ci/lint_no_legacy_bindings_imports.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Bloquea imports legacy `bindings.*` dentro de `src/pcobra/**`."""
+"""Bloquea imports legacy ``bindings.*`` y ``core.*`` en ``src/pcobra/**``."""
 
 from __future__ import annotations
 
@@ -8,13 +8,15 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 SRC_ROOT = ROOT / "src" / "pcobra"
-FORBIDDEN_PREFIX = "bindings"
+FORBIDDEN_PREFIXES = ("bindings", "core")
 
 
 def _node_import_targets(node: ast.AST) -> list[str]:
     if isinstance(node, ast.Import):
         return [alias.name for alias in node.names]
     if isinstance(node, ast.ImportFrom):
+        if node.level and node.level > 0:
+            return []
         return [node.module] if node.module else []
     return []
 
@@ -22,7 +24,10 @@ def _node_import_targets(node: ast.AST) -> list[str]:
 def _is_forbidden(target: str | None) -> bool:
     if not target:
         return False
-    return target == FORBIDDEN_PREFIX or target.startswith(f"{FORBIDDEN_PREFIX}.")
+    return any(
+        target == prefix or target.startswith(f"{prefix}.")
+        for prefix in FORBIDDEN_PREFIXES
+    )
 
 
 def find_violations(root: Path = ROOT) -> list[str]:
@@ -36,7 +41,7 @@ def find_violations(root: Path = ROOT) -> list[str]:
                     rel = path.relative_to(root)
                     failures.append(
                         f"{rel}:{node.lineno}: import no permitido a {target}; "
-                        "usa pcobra.cobra.* o imports relativos dentro de pcobra"
+                        "usa pcobra.cobra.* / pcobra.core.* o imports relativos dentro de pcobra"
                     )
     return failures
 

--- a/src/bindings/__init__.py
+++ b/src/bindings/__init__.py
@@ -1,6 +1,12 @@
 """Shim legacy de ``bindings`` dentro de ``src``.
 
-Este módulo delega en :mod:`pcobra.cobra.bindings` y está deprecado.
+Alcance explícito de compatibilidad:
+- **Permitido únicamente** para consumidores legacy externos al código
+  productivo de ``src/pcobra/**``.
+- Código nuevo debe usar imports canónicos ``pcobra.cobra.bindings.*``.
+- Este módulo existe sólo como puente temporal y está deprecado.
+
+Implementación: delega en :mod:`pcobra.cobra.bindings`.
 """
 # pcobra-compat: allow-legacy-imports
 

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,11 +1,15 @@
 """Shim histórico para importaciones absolutas del paquete ``core``.
 
-Este módulo delega todas las referencias a :mod:`pcobra.core` para que el
-código legado que utilice ``import core`` continúe funcionando sin necesidad de
-ajustes adicionales. Se replica la ruta de búsqueda del paquete original para
-que ``import core.algo`` cargue los submódulos reales de ``pcobra.core``.
+Alcance explícito de compatibilidad:
+- **Permitido únicamente** para consumidores legacy externos al código
+  productivo de ``src/pcobra/**``.
+- Código nuevo debe usar imports canónicos ``pcobra.core.*``.
+- Este módulo existe sólo como puente temporal y está deprecado.
 
-Ruta canónica runtime: ``src/pcobra/core``.
+Implementación:
+- delega todas las referencias a :mod:`pcobra.core`;
+- replica ``__path__`` para que ``import core.algo`` siga resolviendo los
+  submódulos reales de ``pcobra.core``.
 """
 # pcobra-compat: allow-legacy-imports
 
@@ -14,6 +18,13 @@ from __future__ import annotations
 from importlib import import_module
 import sys
 from types import ModuleType
+import warnings
+
+warnings.warn(
+    "`core` está deprecado; usa `pcobra.core`.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 _target_name = "pcobra.core"
 _target: ModuleType = import_module(_target_name)

--- a/tests/unit/test_ci_lint_import_resolution_contract.py
+++ b/tests/unit/test_ci_lint_import_resolution_contract.py
@@ -42,8 +42,12 @@ def test_permite_import_canonico_pcobra(tmp_path: Path) -> None:
 
 def test_permite_modulo_marcado_como_compatibilidad(tmp_path: Path) -> None:
     _write(
-        tmp_path / "src" / "compat_shims" / "legacy_bridge.py",
-        "# pcobra-compat: allow-legacy-imports\nfrom cobra.cli import run\nimport bindings\nimport core\n",
+        tmp_path / "src" / "core" / "__init__.py",
+        (
+            '"""shim deprecado de compatibilidad."""\n'
+            "# pcobra-compat: allow-legacy-imports\n"
+            "import core\n"
+        ),
     )
 
     violations = find_violations(tmp_path)

--- a/tests/unit/test_ci_lint_no_legacy_bindings_imports.py
+++ b/tests/unit/test_ci_lint_no_legacy_bindings_imports.py
@@ -22,6 +22,19 @@ def test_detecta_import_legacy_bindings_en_src_pcobra(tmp_path: Path) -> None:
     assert "src/pcobra/cobra/foo.py:1" in violations[0]
 
 
+def test_detecta_import_legacy_core_en_src_pcobra(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "foo.py",
+        "from core.interpreter import InterpretadorCobra\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "src/pcobra/cobra/foo.py:1" in violations[0]
+    assert "core.interpreter" in violations[0]
+
+
 def test_permite_import_canonico_pcobra_bindings(tmp_path: Path) -> None:
     _write(
         tmp_path / "src" / "pcobra" / "cobra" / "foo.py",

--- a/tests/unit/test_legacy_import_shims_contract.py
+++ b/tests/unit/test_legacy_import_shims_contract.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import warnings
+
+def _purge_module_prefix(prefix: str) -> None:
+    for name in list(sys.modules):
+        if name == prefix or name.startswith(f"{prefix}."):
+            sys.modules.pop(name, None)
+
+
+def test_import_canonico_pcobra_cobra_bindings_funciona() -> None:
+    modulo = importlib.import_module("pcobra.cobra.bindings.contract")
+
+    assert hasattr(modulo, "resolve_binding")
+    assert callable(modulo.resolve_binding)
+
+
+def test_import_legacy_bindings_solo_via_shim_con_deprecacion() -> None:
+    _purge_module_prefix("bindings")
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always", DeprecationWarning)
+        legacy = importlib.import_module("bindings")
+
+    assert any(issubclass(item.category, DeprecationWarning) for item in captured)
+    assert any("bindings" in str(item.message) for item in captured)
+    assert callable(legacy.resolve_binding)
+
+
+def test_import_legacy_core_solo_via_shim_con_deprecacion() -> None:
+    _purge_module_prefix("core")
+    legacy = importlib.import_module("core")
+    resource_limits = importlib.import_module("core.resource_limits")
+
+    assert "compatibilidad" in (legacy.__doc__ or "").lower()
+    assert legacy.__name__ == "core"
+    assert hasattr(resource_limits, "limitar_cpu_segundos")


### PR DESCRIPTION
### Motivation
- Evitar imports legacy absolutos (`bindings`, `core`, `cobra`) desde código productivo bajo `src/pcobra/**` y forzar el uso de imports canónicos `pcobra.*`.
- Mantener compatibilidad controlada solo a través de módulos shim explícitos y documentados, con aviso deprecatorio cuando corresponda.
- Asegurar que las reglas CI/lint detecten regresiones y que exista cobertura de pruebas que valide tanto los imports canónicos como el comportamiento de los shims.

### Description
- Refuerzo del lint `scripts/ci/lint_no_legacy_bindings_imports.py` para bloquear imports absolutos legacy de `bindings.*` y `core.*` en `src/pcobra/**` y para ignorar imports relativos (soporta `from ...` relativos); ajusté mensajes de error a `pcobra.cobra.* / pcobra.core.*`.
- Documentación del alcance de compatibilidad en los shims `src/core/__init__.py` y `src/bindings/__init__.py`, y añadido un `DeprecationWarning` visible al importar `core` para dejar claro que está deprecado.
- Ajuste del test de contrato `tests/unit/test_ci_lint_import_resolution_contract.py` para validar un shim permitido real (`src/core/__init__.py`) marcado con `# pcobra-compat: allow-legacy-imports`.
- Nuevas/actualizadas pruebas unitarias en `tests/unit/`:
  - `tests/unit/test_ci_lint_no_legacy_bindings_imports.py` (nuevo caso que detecta `core` en `src/pcobra/**`).
  - `tests/unit/test_ci_lint_import_resolution_contract.py` (ajuste del caso de shim permitido).
  - `tests/unit/test_legacy_import_shims_contract.py` (nuevo archivo) que valida que el import canónico `pcobra.cobra.bindings.contract` funciona, que `bindings` legacy solo se importa vía shim y emite `DeprecationWarning`, y que `core` legacy funciona vía shim con la documentación/contrato esperado.

### Testing
- Ejecuté `python scripts/ci/lint_no_legacy_bindings_imports.py` y obtuvo resultado `OK`.
- Ejecuté `python scripts/ci/lint_import_resolution_contract.py` y obtuvo resultado `OK`.
- Ejecuté `pytest -q tests/unit/test_ci_lint_no_legacy_bindings_imports.py tests/unit/test_ci_lint_import_resolution_contract.py tests/unit/test_legacy_import_shims_contract.py` y la suite relevante finalizó con todos los tests pasando (`9 passed`) y un `DeprecationWarning` observado y esperado durante las pruebas de shim.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8bc82c388327bd49081b7297e61c)