### PR TITLE
Endurece contratos CLI entre comandos y acceso a registro de transpiladores

### DIFF
--- a/scripts/ci/lint_no_cross_command_imports.py
+++ b/scripts/ci/lint_no_cross_command_imports.py
@@ -49,13 +49,17 @@ ALLOWED_CLI_INFRA_MODULES = {
 }
 TRANSPILER_SHARED_ALLOWED_MODULES = {
     "pcobra.cobra.cli.transpiler_registry",
-    "pcobra.cobra.transpilers.registry",
     "cobra.cli.transpiler_registry",
-    "cobra.transpilers.registry",
 }
 FORBIDDEN_TRANSPILER_SHARED_MODULES = {
     "pcobra.cobra.transpilers",
+    "pcobra.cobra.transpilers.registry",
+    "pcobra.cobra.transpilers.targets",
     "pcobra.cobra.transpilers.module_map",
+    "cobra.transpilers",
+    "cobra.transpilers.registry",
+    "cobra.transpilers.targets",
+    "cobra.transpilers.module_map",
 }
 
 
@@ -156,6 +160,28 @@ def _scan_cross_cmd_pattern_imports(path: Path, root: Path) -> list[tuple[int, s
     return violations
 
 
+def _scan_explicit_cross_command_from_imports(path: Path, root: Path) -> list[tuple[int, str]]:
+    """Detecta `from ...commands.<modulo> import ...` (excepto commands.base)."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        module = _resolve_relative_module(path, node.module, node.level, root)
+        if not module:
+            continue
+        for prefix in COMMANDS_PACKAGE_PREFIXES:
+            prefix_dot = f"{prefix}."
+            if not module.startswith(prefix_dot):
+                continue
+            leaf = module[len(prefix_dot) :]
+            if leaf == "base":
+                break
+            violations.append((node.lineno, module))
+            break
+    return violations
+
+
 def _is_allowed_cli_registry_module(module: str) -> bool:
     leaf = module.rsplit(".", 1)[-1]
     return leaf.endswith(ALLOWED_CLI_REGISTRY_SUFFIX)
@@ -193,9 +219,18 @@ def _scan_transpiler_shared_access(path: Path, root: Path) -> list[tuple[int, st
             if module.startswith("pcobra.cobra.transpilers.") and module.endswith(".module_map"):
                 violations.append((node.lineno, module))
                 continue
+            if module.startswith("pcobra.cobra.transpilers.targets"):
+                violations.append((node.lineno, module))
+                continue
             if module.startswith("pcobra.cobra.transpilers.registry"):
-                if module in TRANSPILER_SHARED_ALLOWED_MODULES:
-                    continue
+                violations.append((node.lineno, module))
+                continue
+            if module.startswith("cobra.transpilers.targets"):
+                violations.append((node.lineno, module))
+                continue
+            if module.startswith("cobra.transpilers.registry"):
+                violations.append((node.lineno, module))
+                continue
     return violations
 
 
@@ -264,6 +299,11 @@ def find_violations(root: Path = ROOT) -> list[str]:
                     failures.append(
                         f"{rel}:{line}: patrón *_cmd no permitido ({target}); "
                         "los comandos no deben importar otros *_cmd.py (solo BaseCommand desde commands.base)"
+                    )
+                for line, target in _scan_explicit_cross_command_from_imports(path, root):
+                    failures.append(
+                        f"{rel}:{line}: import explícito from ...commands.<otro_comando> no permitido ({target}); "
+                        "los comandos CLI no deben depender de otros comandos (solo commands.base)"
                     )
                 for line, target in _scan_cli_dependency_boundaries(path, root):
                     failures.append(

--- a/src/pcobra/cobra/cli/commands/qa_validar_cmd.py
+++ b/src/pcobra/cobra/cli/commands/qa_validar_cmd.py
@@ -7,7 +7,10 @@ from pathlib import Path
 from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
-from pcobra.cobra.cli.transpiler_registry import cli_transpilers
+from pcobra.cobra.cli.transpiler_registry import (
+    cli_transpiler_targets_csv,
+    cli_transpilers,
+)
 from pcobra.cobra.qa.syntax_validation import execute_syntax_validation
 from pcobra.cobra.qa.syntax_validation import ValidationResult
 from pcobra.cobra.cli.i18n import _
@@ -62,7 +65,9 @@ class QaValidarCommand(BaseCommand):
         parser.add_argument(
             "--targets",
             default="",
-            help=_("Lista CSV de targets (python,javascript,rust,go,cpp,java,wasm,asm)"),
+            help=_("Lista CSV de targets ({targets})").format(
+                targets=cli_transpiler_targets_csv(),
+            ),
         )
         parser.add_argument(
             "--strict",

--- a/src/pcobra/cobra/cli/commands/transpilar_inverso_cmd.py
+++ b/src/pcobra/cobra/cli/commands/transpilar_inverso_cmd.py
@@ -51,7 +51,6 @@ from pcobra.cobra.cli.utils.validators import validar_archivo_existente
 from pcobra.cobra.transpilers.target_utils import (
     build_target_help_by_tier,
 )
-from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
 
 # Configuración del logging
 logger = logging.getLogger(__name__)
@@ -156,7 +155,7 @@ def _runtime_destino_choices() -> tuple[str, ...]:
 def _validate_official_target_or_raise(target: str, *, context: str) -> str:
     """Valida que un target pertenezca a la whitelist oficial."""
     canonical = parse_target(target)
-    if canonical not in OFFICIAL_TARGETS:
+    if canonical not in _runtime_destino_choices():
         raise UnsupportedLanguageError(
             "Lenguaje de destino fuera de Tier 1/Tier 2 en {context}: "
             "'{target}'. Usa uno de: {allowed}".format(

--- a/src/pcobra/cobra/cli/commands/validar_sintaxis_cmd.py
+++ b/src/pcobra/cobra/cli/commands/validar_sintaxis_cmd.py
@@ -5,7 +5,10 @@ from pathlib import Path
 from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
-from pcobra.cobra.cli.transpiler_registry import cli_transpilers
+from pcobra.cobra.cli.transpiler_registry import (
+    cli_transpiler_targets_csv,
+    cli_transpilers,
+)
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.mode_policy import validar_politica_modo
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
@@ -56,7 +59,9 @@ class ValidarSintaxisCommand(BaseCommand):
         parser.add_argument(
             "--targets",
             default="",
-            help=_("Lista CSV de targets a validar (python,javascript,rust,go,cpp,java,wasm,asm)"),
+            help=_("Lista CSV de targets a validar ({targets})").format(
+                targets=cli_transpiler_targets_csv(),
+            ),
         )
         parser.add_argument(
             "--strict",

--- a/src/pcobra/cobra/cli/transpiler_registry.py
+++ b/src/pcobra/cobra/cli/transpiler_registry.py
@@ -36,6 +36,11 @@ def cli_transpiler_targets() -> tuple[str, ...]:
     return official_transpiler_targets()
 
 
+def cli_transpiler_targets_csv() -> str:
+    """Devuelve targets públicos canónicos formateados como CSV para ayuda CLI."""
+    return ",".join(cli_transpiler_targets())
+
+
 def cli_ensure_entrypoint_transpilers_loaded_once() -> None:
     """Garantiza (idempotente) la carga de transpiladores registrados por entrypoints."""
     ensure_entrypoint_transpilers_loaded_once()

--- a/tests/unit/test_ci_lint_no_cross_command_imports.py
+++ b/tests/unit/test_ci_lint_no_cross_command_imports.py
@@ -10,6 +10,22 @@ def _write(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+def test_contrato_repo_ningun_comando_depende_de_otro_comando() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    violations = find_violations(repo_root)
+    cross_command_violations = [
+        item
+        for item in violations
+        if (
+            "import entre comandos no permitido" in item
+            or "edge no permitido en grafo de imports" in item
+            or "patrón *_cmd no permitido" in item
+            or "import explícito from ...commands.<otro_comando> no permitido" in item
+        )
+    ]
+    assert cross_command_violations == []
+
+
 def test_detecta_import_entre_comandos(tmp_path: Path) -> None:
     _write(
         tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "a.py",
@@ -90,6 +106,7 @@ def test_detecta_import_relativo_a_otro_comando(tmp_path: Path) -> None:
 
     assert any("import entre comandos no permitido" in item for item in violations)
     assert any("patrón *_cmd no permitido" in item for item in violations)
+    assert any("import explícito from ...commands.<otro_comando> no permitido" in item for item in violations)
     assert any("src/pcobra/cobra/cli/commands/bad.py:1" in item for item in violations)
 
 
@@ -101,8 +118,32 @@ def test_detecta_acceso_compartido_transpilers_fuera_registry(tmp_path: Path) ->
 
     violations = find_violations(tmp_path)
 
-    assert "acceso compartido de transpiladores no permitido" in violations[0]
-    assert "src/pcobra/cobra/cli/commands/a.py:1" in violations[0]
+    assert any("acceso compartido de transpiladores no permitido" in item for item in violations)
+    assert any("src/pcobra/cobra/cli/commands/a.py:1" in item for item in violations)
+
+
+def test_detecta_acceso_directo_a_targets_en_transpilers(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "a.py",
+        "from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert any("acceso compartido de transpiladores no permitido" in item for item in violations)
+    assert any("pcobra.cobra.transpilers.targets" in item for item in violations)
+
+
+def test_detecta_acceso_directo_a_registry_en_transpilers(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "a.py",
+        "from pcobra.cobra.transpilers.registry import official_transpiler_targets\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert any("acceso compartido de transpiladores no permitido" in item for item in violations)
+    assert any("pcobra.cobra.transpilers.registry" in item for item in violations)
 
 
 def test_detecta_constante_transpilers_en_comando(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Evitar imports cruzados entre comandos CLI y centralizar el acceso a catálogos de transpiladores/targets para reducir acoplamientos y snapshots locales.
- Forzar que los comandos usen la fachada CLI en vez de importar directamente `pcobra.cobra.transpilers.registry` o `pcobra.cobra.transpilers.targets`.

### Description
- Endurece el lint `scripts/ci/lint_no_cross_command_imports.py` añadiendo `_scan_explicit_cross_command_from_imports()` para detectar patrones `from ...commands.<otro_comando> import ...` y ampliando la lista de módulos prohibidos de `pcobra.cobra.transpilers` (incluyendo `registry` y `targets`).
- Agrega `cli_transpiler_targets_csv()` en `src/pcobra/cobra/cli/transpiler_registry.py` para exponer el catálogo canónico formateado como CSV para los `help` de CLI.
- Cambia comandos para usar la fachada: actualiza `qa_validar_cmd.py` y `validar_sintaxis_cmd.py` para consumir `cli_transpiler_targets_csv()` en la ayuda de `--targets` y modifica `transpilar_inverso_cmd.py` para validar targets usando `cli_transpiler_targets()` en lugar de importar `OFFICIAL_TARGETS` directamente.
- Amplía tests en `tests/unit/test_ci_lint_no_cross_command_imports.py` agregando un test de contrato de repositorio (`ningún comando CLI depende de otro comando`) y casos que cubren accesos prohibidos a `transpilers.targets` y `transpilers.registry`, y la nueva detección explícita `from ...commands.<otro_comando> import ...`.

### Testing
- Ejecuté `python scripts/ci/lint_no_cross_command_imports.py` y obtuvo salida: `OK`.
- Ejecuté `pytest -q tests/unit/test_ci_lint_no_cross_command_imports.py tests/unit/test_ci_lint_no_cross_command_imports_guard.py` y todos los tests pasaron (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8db588d48327b4b2cfd718fc4b8e)