### PR TITLE
ci: auditar SCCs por alcance y reforzar regresiones de imports

### DIFF
--- a/scripts/ci/check_core_scc.py
+++ b/scripts/ci/check_core_scc.py
@@ -9,6 +9,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 CORE_DIR = ROOT / "src" / "pcobra" / "core"
 MODULE_PREFIX = "pcobra.core"
+ALLOWED_CORE_SCCS: tuple[frozenset[str], ...] = ()
+FORBIDDEN_CORE_SCCS: tuple[frozenset[str], ...] = ()
 
 
 def _iter_python_files() -> list[Path]:
@@ -114,16 +116,32 @@ def _scc_components(graph: dict[str, set[str]]) -> list[set[str]]:
     return components
 
 
+def classify_core_sccs(
+    cyclic_components: list[set[str]],
+) -> tuple[list[set[str]], list[set[str]], list[set[str]]]:
+    allowed_baseline = set(ALLOWED_CORE_SCCS)
+    forbidden_baseline = set(FORBIDDEN_CORE_SCCS)
+    allowed = [component for component in cyclic_components if frozenset(component) in allowed_baseline]
+    forbidden = [component for component in cyclic_components if frozenset(component) in forbidden_baseline]
+    unexpected = [
+        component
+        for component in cyclic_components
+        if frozenset(component) not in allowed_baseline and frozenset(component) not in forbidden_baseline
+    ]
+    return allowed, forbidden, unexpected
+
+
 def main() -> int:
     graph = build_graph()
     cyclic_components = sorted(
         [component for component in _scc_components(graph) if len(component) > 1],
         key=lambda item: sorted(item),
     )
+    _, forbidden, unexpected = classify_core_sccs(cyclic_components)
 
-    if cyclic_components:
+    if forbidden or unexpected:
         print("❌ Se detectaron ciclos de imports en src/pcobra/core (SCC > 1):")
-        for component in cyclic_components:
+        for component in [*forbidden, *unexpected]:
             for module in sorted(component):
                 rel = ROOT / "src" / Path(*module.split(".")).with_suffix(".py")
                 print(f"   - {module} ({rel.relative_to(ROOT)})")

--- a/scripts/ci/check_import_cycles.py
+++ b/scripts/ci/check_import_cycles.py
@@ -9,37 +9,34 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 SRC_DIR = ROOT / "src"
+AUDIT_SCOPE_PREFIXES: tuple[str, ...] = (
+    "pcobra.cobra.cli",
+    "pcobra.cobra.transpilers",
+    "pcobra.core",
+)
 
 COMMAND_MODULE_PREFIXES = (
     "pcobra.cobra.cli.commands",
     "pcobra.cobra.cli.commands_v2",
 )
 ALLOWED_COMMAND_SIBLING = {"base"}
-RUNTIME_PREFIXES = (
+CORE_PREFIXES = (
     "pcobra.cobra.core.runtime",
     "pcobra.cobra.bindings.runtime_manager",
+    "pcobra.core",
 )
+CORE_TO_CLI_EXEMPT_PREFIXES = ("pcobra.core.cli",)
 CLI_PREFIX = "pcobra.cobra.cli"
-KNOWN_CYCLE_BASELINES: tuple[frozenset[str], ...] = (
-    frozenset(
-        {
-            "pcobra.core.ast_cache",
-            "pcobra.core.lexer",
-            "pcobra.cobra.core.lexer",
-        }
-    ),  # ciclo histórico puntual
-    frozenset(
-        {
-            "pcobra.cobra.core.lark_parser",
-            "pcobra.cobra.core.lexer",
-            "pcobra.cobra.core.parser",
-            "pcobra.core.ast_cache",
-            "pcobra.core.ast_nodes",
-            "pcobra.core.lexer",
-            "pcobra.core.parser",
-        }
-    ),  # SCC histórica heredada entre parser/lexer legacy+unificado
-)
+ALLOWED_SCOPE_SCCS: dict[str, tuple[frozenset[str], ...]] = {
+    "pcobra.cobra.cli": (),
+    "pcobra.cobra.transpilers": (),
+    "pcobra.core": (),
+}
+FORBIDDEN_SCOPE_SCCS: dict[str, tuple[frozenset[str], ...]] = {
+    "pcobra.cobra.cli": (),
+    "pcobra.cobra.transpilers": (),
+    "pcobra.core": (),
+}
 
 
 @dataclass(frozen=True)
@@ -143,8 +140,10 @@ def _is_cross_command_forbidden(source: str, target: str) -> bool:
     return True
 
 
-def _is_runtime_to_cli_forbidden(source: str, target: str) -> bool:
-    if not any(source == prefix or source.startswith(f"{prefix}.") for prefix in RUNTIME_PREFIXES):
+def _is_core_to_cli_forbidden(source: str, target: str) -> bool:
+    if not any(source == prefix or source.startswith(f"{prefix}.") for prefix in CORE_PREFIXES):
+        return False
+    if any(source == prefix or source.startswith(f"{prefix}.") for prefix in CORE_TO_CLI_EXEMPT_PREFIXES):
         return False
     return target == CLI_PREFIX or target.startswith(f"{CLI_PREFIX}.")
 
@@ -155,8 +154,8 @@ def find_layer_violations(graph: dict[str, set[str]]) -> list[Violation]:
         for target in targets:
             if _is_cross_command_forbidden(source, target):
                 violations.append(Violation("cross_command", source, target))
-            if _is_runtime_to_cli_forbidden(source, target):
-                violations.append(Violation("runtime_depends_on_cli", source, target))
+            if _is_core_to_cli_forbidden(source, target):
+                violations.append(Violation("core_depends_on_cli", source, target))
     return violations
 
 
@@ -227,13 +226,32 @@ def _scc_components(graph: dict[str, set[str]]) -> list[set[str]]:
     return components
 
 
-def find_new_cycle_components(graph: dict[str, set[str]]) -> list[set[str]]:
-    cyclic_components = [component for component in _scc_components(graph) if len(component) > 1]
-    return [
+def _scope_graph(graph: dict[str, set[str]], scope_prefix: str) -> dict[str, set[str]]:
+    scoped_nodes = {
+        module for module in graph if module == scope_prefix or module.startswith(f"{scope_prefix}.")
+    }
+    return {
+        module: {target for target in targets if target in scoped_nodes}
+        for module, targets in graph.items()
+        if module in scoped_nodes
+    }
+
+
+def find_scope_cycle_components(
+    graph: dict[str, set[str]], scope_prefix: str
+) -> tuple[list[set[str]], list[set[str]], list[set[str]]]:
+    scoped = _scope_graph(graph, scope_prefix)
+    cyclic_components = [component for component in _scc_components(scoped) if len(component) > 1]
+    allowed_baseline = set(ALLOWED_SCOPE_SCCS.get(scope_prefix, ()))
+    forbidden_baseline = set(FORBIDDEN_SCOPE_SCCS.get(scope_prefix, ()))
+    allowed = [component for component in cyclic_components if frozenset(component) in allowed_baseline]
+    forbidden = [component for component in cyclic_components if frozenset(component) in forbidden_baseline]
+    new = [
         component
         for component in cyclic_components
-        if frozenset(component) not in KNOWN_CYCLE_BASELINES
+        if frozenset(component) not in allowed_baseline and frozenset(component) not in forbidden_baseline
     ]
+    return allowed, forbidden, new
 
 
 def _module_to_file(module: str, src_dir: Path = SRC_DIR) -> Path:
@@ -260,7 +278,7 @@ def format_layer_report(violations: list[Violation], src_dir: Path = SRC_DIR, ro
                 "mueve lo compartido a módulos registry/service"
             )
         else:
-            reason = "runtime no debe depender de módulos CLI"
+            reason = "core/runtime no debe depender de módulos CLI"
         lines.append(
             f"   - {item.source} ({source_file}) -> {item.target} ({target_file}) :: {reason}"
         )
@@ -269,16 +287,28 @@ def format_layer_report(violations: list[Violation], src_dir: Path = SRC_DIR, ro
 
 def main() -> int:
     graph = build_import_graph(SRC_DIR)
-    new_cycles = find_new_cycle_components(graph)
-    cycle = _first_cycle(graph) if new_cycles else None
+    scope_cycle_failures: list[str] = []
+    cycle: list[str] | None = None
+    for scope_prefix in AUDIT_SCOPE_PREFIXES:
+        _, forbidden, new = find_scope_cycle_components(graph, scope_prefix)
+        if forbidden or new:
+            scoped_graph = _scope_graph(graph, scope_prefix)
+            cycle = cycle or _first_cycle(scoped_graph)
+            scope_cycle_failures.append(scope_prefix)
+
     layer_violations = find_layer_violations(graph)
 
     if cycle:
         print(format_cycle_report(cycle, src_dir=SRC_DIR, root=ROOT))
+    if scope_cycle_failures:
+        print(
+            "❌ SCC no permitidas detectadas en auditoría de imports para: "
+            + ", ".join(scope_cycle_failures)
+        )
     if layer_violations:
         print(format_layer_report(layer_violations, src_dir=SRC_DIR, root=ROOT))
 
-    if cycle or layer_violations:
+    if cycle or scope_cycle_failures or layer_violations:
         return 1
 
     print("✅ Gate de arquitectura de imports: OK (sin ciclos ni violaciones de capas)")

--- a/tests/unit/test_ci_check_core_scc.py
+++ b/tests/unit/test_ci_check_core_scc.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from scripts.ci.check_core_scc import classify_core_sccs
+
+
+def test_classifica_scc_inesperada_como_no_permitida() -> None:
+    cyclic_components = [
+        {"pcobra.core.alpha", "pcobra.core.beta"},
+    ]
+
+    allowed, forbidden, unexpected = classify_core_sccs(cyclic_components)
+
+    assert allowed == []
+    assert forbidden == []
+    assert unexpected == cyclic_components

--- a/tests/unit/test_ci_check_import_cycles.py
+++ b/tests/unit/test_ci_check_import_cycles.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from scripts.ci.check_import_cycles import (
     build_import_graph,
-    find_new_cycle_components,
+    find_scope_cycle_components,
     find_layer_violations,
     format_cycle_report,
     main,
@@ -18,21 +18,21 @@ def _write(path: Path, content: str) -> None:
 
 def test_detecta_ciclo_en_grafo(tmp_path: Path) -> None:
     src = tmp_path / "src"
-    _write(src / "pkg" / "a.py", "import pkg.b\n")
-    _write(src / "pkg" / "b.py", "import pkg.c\n")
-    _write(src / "pkg" / "c.py", "import pkg.a\n")
+    _write(src / "pcobra" / "cobra" / "cli" / "a.py", "import pcobra.cobra.cli.b\n")
+    _write(src / "pcobra" / "cobra" / "cli" / "b.py", "import pcobra.cobra.cli.c\n")
+    _write(src / "pcobra" / "cobra" / "cli" / "c.py", "import pcobra.cobra.cli.a\n")
 
     graph = build_import_graph(src)
-    cycle_components = find_new_cycle_components(graph)
+    _, _, cycle_components = find_scope_cycle_components(graph, "pcobra.cobra.cli")
 
     assert cycle_components
     cycle = sorted(cycle_components[0])
     cycle.append(cycle[0])
     report = format_cycle_report(cycle, src_dir=src, root=tmp_path)
     assert "Cadena:" in report
-    assert "pkg.a" in report
-    assert "pkg.b" in report
-    assert "pkg.c" in report
+    assert "pcobra.cobra.cli.a" in report
+    assert "pcobra.cobra.cli.b" in report
+    assert "pcobra.cobra.cli.c" in report
 
 
 def test_detecta_violaciones_de_capas(tmp_path: Path) -> None:
@@ -59,7 +59,24 @@ def test_detecta_violaciones_de_capas(tmp_path: Path) -> None:
 
     kinds = {item.kind for item in violations}
     assert "cross_command" in kinds
-    assert "runtime_depends_on_cli" in kinds
+    assert "core_depends_on_cli" in kinds
+
+
+def test_detecta_dependencia_de_pcobra_core_hacia_cli(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    _write(
+        src / "pcobra" / "core" / "runtime_guard.py",
+        "from pcobra.cobra.cli.public_command_policy import PUBLIC_COMMANDS\n",
+    )
+    _write(
+        src / "pcobra" / "cobra" / "cli" / "public_command_policy.py",
+        "PUBLIC_COMMANDS = ()\n",
+    )
+
+    graph = build_import_graph(src)
+    violations = find_layer_violations(graph)
+
+    assert any(item.kind == "core_depends_on_cli" for item in violations)
 
 
 def test_main_pasa_en_repositorio_actual() -> None:


### PR DESCRIPTION
### Motivation
- Centralizar y acotar la auditoría de dependencias a los ámbitos solicitados (`pcobra.cobra.cli`, `pcobra.cobra.transpilers`, `pcobra.core`) para detectar SCCs relevantes por scope. 
- Registrar explícitamente cuáles SCCs son permitidas/denegadas por alcance y reforzar las reglas de capas para prevenir regresiones arquitectónicas (por ejemplo, `core` -> `cli`).
- Añadir tests de regresión que garanticen que los comandos CLI no importan otros comandos y que `core` no dependa de `cli`.

### Description
- `scripts/ci/check_import_cycles.py`: añadido `AUDIT_SCOPE_PREFIXES`, separación de `CORE_PREFIXES` y excepciones `CORE_TO_CLI_EXEMPT_PREFIXES`, mapas `ALLOWED_SCOPE_SCCS`/`FORBIDDEN_SCOPE_SCCS`, función `_scope_graph` y `find_scope_cycle_components`, y cambio de la regla/etiqueta de violación a `core_depends_on_cli` (antes `runtime_depends_on_cli`).
- `scripts/ci/check_core_scc.py`: añadidos `ALLOWED_CORE_SCCS` y `FORBIDDEN_CORE_SCCS` y la función `classify_core_sccs` para clasificar SCCs en permitidas/prohibidas/inesperadas y usar esa clasificación en `main`.
- Tests: actualizados `tests/unit/test_ci_check_import_cycles.py` para usar `find_scope_cycle_components` y para verificar la nueva clase de violación `core_depends_on_cli`, y añadido `tests/unit/test_ci_check_core_scc.py` que cubre la clasificación de SCCs inesperadas.
- Mensajes de salida y condición de fallo del gate de imports actualizados para informar por alcance cuando se detecten SCCs no permitidas y para incluir la nueva verificación de capas.

### Testing
- Ejecutados los scripts de comprobación y suites unitarias relevantes con `python scripts/ci/check_import_cycles.py` y `python scripts/ci/check_core_scc.py`, ambos devolvieron éxito (no hay ciclos ni violaciones en el repo actual).
- Ejecutados los tests unitarios: `python -m pytest -q tests/unit/test_ci_check_import_cycles.py tests/unit/test_ci_check_core_scc.py tests/unit/test_ci_check_import_cycles_guard.py` y `python -m pytest -q tests/unit/test_ci_lint_no_cross_command_imports.py`, ambos completaron exitosamente (todos los tests pasaron).
- También ejecuté `python -m pytest -q tests/unit/test_ci_lint_no_cross_command_imports.py` para validar que las reglas de import entre comandos siguen protegiendo el contrato, y el conjunto de tests pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8f1be3d08327b5e35775aea4cb75)