### PR TITLE
Alinear asignación léxica con contrato mínimo de Environment

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1164,17 +1164,15 @@ class InterpretadorCobra:
         else:
             if getattr(nodo, "inferencia", False) or getattr(nodo, "declaracion", False):
                 # Declaración local (explícita o por inferencia)
+                indice_contexto = len(self.mem_contextos) - 1
+                self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
+                indice = self.solicitar_memoria(1)
+                self.mem_contextos[indice_contexto][nombre] = (indice, 1)
                 self.contextos[-1].define(nombre, valor)
             else:
                 indice_contexto = self._indice_entorno_variable(nombre)
                 if indice_contexto is None:
-                    # Creación local implícita cuando no existe en la cadena
-                    # de scopes.
-                    indice_contexto = len(self.mem_contextos) - 1
-                    self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
-                    indice = self.solicitar_memoria(1)
-                    self.mem_contextos[indice_contexto][nombre] = (indice, 1)
-                    self.contextos[-1].define(nombre, valor)
+                    raise NameError(f"Variable no declarada: {nombre}")
                 else:
                     # Mutación sobre una variable existente: ``set`` solo
                     # actualiza en el scope donde ya está declarada.

--- a/tests/unit/test_interpreter_memoria.py
+++ b/tests/unit/test_interpreter_memoria.py
@@ -5,7 +5,7 @@ from core.ast_nodes import NodoAsignacion, NodoValor, NodoFuncion, NodoLlamadaFu
 def test_asignaciones_intensivas_libera_memoria():
     inter = InterpretadorCobra()
     for i in range(500):
-        inter.ejecutar_asignacion(NodoAsignacion(f"v{i}", NodoValor(i)))
+        inter.ejecutar_asignacion(NodoAsignacion(f"v{i}", NodoValor(i), declaracion=True))
     assert len(inter.mem_contextos[0]) == 500
 
     # Reasignar algunas variables para liberar memoria
@@ -19,4 +19,3 @@ def test_evolucion_durante_programa_largo():
     for i in range(1200):
         inter.solicitar_memoria(1)
     assert inter.gestor_memoria.generacion >= 1
-

--- a/tests/unit/test_interpreter_scope_contract.py
+++ b/tests/unit/test_interpreter_scope_contract.py
@@ -275,6 +275,19 @@ def test_asignar_sin_declarar_falla_con_name_error() -> None:
         _ejecutar([NodoAsignacion("x", NodoValor(10))])
 
 
+def test_declaracion_y_reasignacion_mantienen_contexto_y_memoria_sin_desfase() -> None:
+    inter = InterpretadorCobra()
+    inter.ejecutar_asignacion(NodoAsignacion("x", NodoValor(1), declaracion=True))
+    assert "x" in inter.contextos[0].values
+    assert "x" in inter.mem_contextos[0]
+    inter.ejecutar_asignacion(NodoAsignacion("x", NodoValor(2)))
+
+    assert inter.contextos[0].values["x"] == 2
+    idx, tam = inter.mem_contextos[0]["x"]
+    assert isinstance(idx, int)
+    assert tam == 1
+
+
 def test_environment_set_no_copia_entorno_usa_referencias_vivas() -> None:
     global_env = Environment(values={"x": 1})
     hijo = Environment(parent=global_env)


### PR DESCRIPTION
### Motivation
- Evitar estados inconsistentes entre la pila de `contextos` y los metadatos de `mem_contextos` cuando se realizan asignaciones en runtime.
- Forzar una API mínima de entorno: `get` resuelve en cadena, `define` siempre local y `set` actualiza en el scope más cercano existente.
- Prohibir implícita creación de variables en asignaciones mutativas para mantener scopes encadenados por referencia.

### Description
- En `InterpretadorCobra.ejecutar_asignacion` se cambia el comportamiento de las asignaciones declarativas para que además de `define` registren un bloque en `mem_contextos` y liberen/soliciten memoria de forma explícita con `solicitar_memoria`/`_liberar_memoria_variable_en_contexto` (sin clonado de dicts).
- Las asignaciones que no marcan `declaracion`/`inferencia` ya no crean implícitamente una variable local cuando no existe en la cadena de scopes; ahora lanzan `NameError` con el mensaje `Variable no declarada: <nombre>`; las mutaciones sólo pueden aplicarse a variables ya declaradas (se usa `_indice_entorno_variable` + `set`).
- Se actualizó la prueba intensiva de memoria para crear variables mediante `declaracion=True` cuando procede, evitando depender de creación implícita.
- Se añadió una prueba (`test_declaracion_y_reasignacion_mantienen_contexto_y_memoria_sin_desfase`) que verifica la sincronía entre `contextos` y `mem_contextos` tras declarar y reasignar una variable en el scope global.
- No se introdujeron patrones de copia de entorno; las pruebas de lint que buscan `env.copy()` y clonados siguen pasando.

### Testing
- Ejecutado `pytest -q tests/unit/test_environment.py tests/unit/test_interpreter_scope_contract.py tests/unit/test_interpreter_memoria.py`, resultado: todas las pruebas pasaron (`23 passed, 1 warning` en el conjunto ejecutado localmente para estos archivos).
- Ejecutado `pytest -q tests/unit/test_ci_lint_control_flow_no_scope_copy.py`, resultado: `5 passed, 1 warning`.
- Las pruebas unitarias de contrato relevantes (shadowing, mutación en scope padre, error en `set` de variable no declarada) se ejecutaron y pasaron tras los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec909bde6c8327a1138b852b1c9c7c)