### PR TITLE
Preserve control-flow scope for while/if and implement romper/continuar handling

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -54,6 +54,8 @@ from .ast_nodes import (
     NodoWith,
     NodoImportDesde,
     NodoAST,
+    NodoRomper,
+    NodoContinuar,
 )
 from .memoria.gestor_memoria import GestorMemoriaGenetico
 from .internal_ir import InternalIRModule, build_internal_ir
@@ -103,6 +105,14 @@ class ExcepcionCobra(Exception):
     def __init__(self, valor):
         super().__init__(valor)
         self.valor = valor
+
+
+class _ControlRomper(Exception):
+    """Señal interna para cortar la ejecución del bucle actual."""
+
+
+class _ControlContinuar(Exception):
+    """Señal interna para avanzar a la siguiente iteración del bucle."""
 
 
 class InterpretadorCobra:
@@ -1135,6 +1145,10 @@ class InterpretadorCobra:
             return self.ejecutar_hilo(nodo)
         elif isinstance(nodo, NodoRetorno):
             return self.evaluar_expresion(nodo.expresion)
+        elif isinstance(nodo, NodoRomper):
+            raise _ControlRomper
+        elif isinstance(nodo, NodoContinuar):
+            raise _ControlContinuar
         elif isinstance(nodo, NodoEsperar):
             return self.evaluar_expresion(nodo.expresion)
         elif isinstance(nodo, NodoValor):
@@ -1494,12 +1508,17 @@ class InterpretadorCobra:
         # bucle reutiliza ``self.contextos[-1]`` en cada vuelta y, por tanto,
         # las mutaciones del contexto persisten entre iteraciones y después.
         while self._evaluar_condicion_control(nodo.condicion):
-            for instruccion in nodo.cuerpo:
-                resultado = self.ejecutar_nodo(instruccion)
-                if isinstance(instruccion, NodoAsignacion):
-                    continue
-                if resultado is not None:
-                    return resultado
+            try:
+                for instruccion in nodo.cuerpo:
+                    resultado = self.ejecutar_nodo(instruccion)
+                    if isinstance(instruccion, NodoAsignacion):
+                        continue
+                    if resultado is not None:
+                        return resultado
+            except _ControlContinuar:
+                continue
+            except _ControlRomper:
+                break
         return None
 
     def ejecutar_try_catch(self, nodo):

--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -255,6 +255,21 @@ def test_error_semantico_y_runtime_equivalen_en_tipo_y_mensaje(codigo_erroneo):
             {"total": 4},
         ),
         (
+            "mientras_con_continuar_romper_y_variable_local_visible",
+            "var paso = falso",
+            (
+                "mientras verdadero:\n"
+                "    si paso:\n"
+                "        var ultimo = 2\n"
+                "        romper\n"
+                "    fin\n"
+                "    paso = verdadero\n"
+                "    continuar\n"
+                "fin"
+            ),
+            {"paso": True},
+        ),
+        (
             "bloque_anidado_shadowing_y_set_dirigido",
             "var raiz = 100",
             (

--- a/tests/unit/test_interpreter_scope_contract.py
+++ b/tests/unit/test_interpreter_scope_contract.py
@@ -10,10 +10,13 @@ from cobra.core import Token, TipoToken
 from core.ast_nodes import (
     NodoAsignacion,
     NodoBucleMientras,
+    NodoCondicional,
+    NodoContinuar,
     NodoFuncion,
     NodoIdentificador,
     NodoLlamadaFuncion,
     NodoOperacionBinaria,
+    NodoRomper,
     NodoRetorno,
     NodoValor,
 )
@@ -90,6 +93,136 @@ def test_mientras_reasigna_memoria_en_entorno_real_y_persiste_fuera() -> None:
     assert liberaciones == [(11, 1), (22, 1)]
     assert inter.mem_contextos[0]["i"] == (33, 1)
 
+
+def test_variable_definida_fuera_y_mutada_en_mientras_persiste() -> None:
+    inter = InterpretadorCobra()
+    inter.ejecutar_asignacion(NodoAsignacion("acumulado", NodoValor(0), declaracion=True))
+    inter.ejecutar_asignacion(NodoAsignacion("i", NodoValor(0), declaracion=True))
+
+    condicion = NodoOperacionBinaria(
+        NodoIdentificador("i"),
+        Token(TipoToken.MENORQUE, "<"),
+        NodoValor(3),
+    )
+    cuerpo = [
+        NodoAsignacion(
+            "acumulado",
+            NodoOperacionBinaria(
+                NodoIdentificador("acumulado"),
+                Token(TipoToken.SUMA, "+"),
+                NodoValor(2),
+            ),
+        ),
+        NodoAsignacion(
+            "i",
+            NodoOperacionBinaria(
+                NodoIdentificador("i"),
+                Token(TipoToken.SUMA, "+"),
+                NodoValor(1),
+            ),
+        ),
+    ]
+
+    with patch.object(
+        InterpretadorCobra,
+        "_asegurar_no_autorreferencia_asignacion",
+        return_value=None,
+    ):
+        inter.ejecutar_mientras(NodoBucleMientras(condicion, cuerpo))
+
+    assert inter.obtener_variable("acumulado") == 6
+    assert inter.obtener_variable("i") == 3
+
+
+def test_variable_creada_en_mientras_se_lee_despues_del_bucle() -> None:
+    inter = InterpretadorCobra()
+    inter.ejecutar_asignacion(NodoAsignacion("i", NodoValor(0), declaracion=True))
+
+    condicion = NodoOperacionBinaria(
+        NodoIdentificador("i"),
+        Token(TipoToken.MENORQUE, "<"),
+        NodoValor(2),
+    )
+    cuerpo = [
+        NodoAsignacion("ultima", NodoIdentificador("i"), declaracion=True),
+        NodoAsignacion(
+            "i",
+            NodoOperacionBinaria(
+                NodoIdentificador("i"),
+                Token(TipoToken.SUMA, "+"),
+                NodoValor(1),
+            ),
+        ),
+    ]
+    with patch.object(
+        InterpretadorCobra,
+        "_asegurar_no_autorreferencia_asignacion",
+        return_value=None,
+    ):
+        inter.ejecutar_mientras(NodoBucleMientras(condicion, cuerpo))
+
+    assert inter.obtener_variable("ultima") == 1
+
+
+def test_mientras_respeta_romper_y_continuar_sin_perder_scope() -> None:
+    inter = InterpretadorCobra()
+    inter.ejecutar_asignacion(NodoAsignacion("i", NodoValor(0), declaracion=True))
+    inter.ejecutar_asignacion(NodoAsignacion("suma", NodoValor(0), declaracion=True))
+
+    condicion = NodoOperacionBinaria(
+        NodoIdentificador("i"),
+        Token(TipoToken.MENORQUE, "<"),
+        NodoValor(6),
+    )
+    incremento = NodoAsignacion(
+        "i",
+        NodoOperacionBinaria(
+            NodoIdentificador("i"),
+            Token(TipoToken.SUMA, "+"),
+            NodoValor(1),
+        ),
+    )
+    continuar_si_i_es_dos = NodoCondicional(
+        NodoOperacionBinaria(
+            NodoIdentificador("i"),
+            Token(TipoToken.IGUAL, "=="),
+            NodoValor(2),
+        ),
+        [NodoContinuar()],
+        [],
+    )
+    romper_si_i_es_cuatro = NodoCondicional(
+        NodoOperacionBinaria(
+            NodoIdentificador("i"),
+            Token(TipoToken.IGUAL, "=="),
+            NodoValor(4),
+        ),
+        [NodoRomper()],
+        [],
+    )
+    acumular = NodoAsignacion(
+        "suma",
+        NodoOperacionBinaria(
+            NodoIdentificador("suma"),
+            Token(TipoToken.SUMA, "+"),
+            NodoIdentificador("i"),
+        ),
+    )
+
+    with patch.object(
+        InterpretadorCobra,
+        "_asegurar_no_autorreferencia_asignacion",
+        return_value=None,
+    ):
+        inter.ejecutar_mientras(
+            NodoBucleMientras(
+                condicion,
+                [incremento, continuar_si_i_es_dos, romper_si_i_es_cuatro, acumular],
+            )
+        )
+
+    assert inter.obtener_variable("i") == 4
+    assert inter.obtener_variable("suma") == 4
 
 
 def test_closure_mutacion_reasigna_en_padre_y_persiste_tras_salir() -> None:


### PR DESCRIPTION
### Motivation

- Asegurar que los bloques de control (`si`/`mientras`) no creen nuevos scopes y que las mutaciones al contexto activo persistan entre iteraciones/ramas.
- Evitar mezcla accidental de reglas de scope entre control-flow y llamadas (estas últimas deben seguir abriendo scope).
- Cubrir con pruebas casos relevantes sobre mutación dentro de bucles y el comportamiento de `romper`/`continuar`, además de detectar divergencias entre ejecución en script y REPL.

### Description

- Añadido el manejo explícito de `NodoRomper` y `NodoContinuar` importándolos en el intérprete y despachando estas sentencias en `ejecutar_nodo` para señales de control internas. 
- Introducidas las excepciones internas `_ControlRomper` y `_ControlContinuar` para señalizar control-flow desde `ejecutar_nodo` y capturarlas en `ejecutar_mientras` sin crear nuevos entornos por iteración. 
- Modificado `ejecutar_mientras` para ejecutar el cuerpo sobre `self.contextos[-1]` y capturar las señales de `continuar` (salta a siguiente iteración) y `romper` (sale del bucle). 
- Revisado y confirmado que las llamadas de función y método mantienen la semántica de abrir nuevo scope mediante `self.contextos.append(Environment(...))`. 
- Añadidas pruebas unitarias en `tests/unit/test_interpreter_scope_contract.py` para: variable definida fuera y mutada dentro del loop; variable creada dentro del `mientras` y leída después; y combinación de `romper/continuar` preservando el scope. 
- Añadida una prueba de integración espejo en `tests/integration/test_run_repl_equivalence.py` para detectar divergencias entre ejecución en modo script y REPL usando `continuar/romper`.

### Testing

- Ejecutado: `pytest -q tests/unit/test_interpreter_scope_contract.py tests/integration/test_run_repl_equivalence.py -q` y la ejecución final reportó todas las pruebas pasadas (sin fallos).
- También se ejecutaron localmente los tests mencionados previamente durante el desarrollo iterativo para validar comportamiento de memoria y scope (todos verdes en la batería apuntada).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec927062b08327b6a0638115fdc671)