### PR TITLE
Consolidar pipeline único run/interactive y ampliar pruebas de paridad

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -776,12 +776,29 @@ class InteractiveCommand(BaseCommand):
         Args:
             linea: Código a ejecutar
         """
+        interpretador_cls = resolver_interpretador_cls(
+            module_name=__name__,
+            default_cls=type(self.interpretador),
+        )
+        setup, _ = ejecutar_pipeline_explicito(
+            PipelineInput(
+                codigo="",
+                interpretador_cls=interpretador_cls,
+                safe_mode=self._seguro_repl,
+                extra_validators=self._extra_validators_repl,
+                interpretador=self.interpretador,
+            ),
+            analizar_codigo_fn=lambda _codigo: [],
+        )
+        self.interpretador = setup.interpretador
+        self._seguro_repl = setup.safe_mode
+        self._extra_validators_repl = setup.validadores_extra
         prevalidar_y_parsear_codigo(linea)
 
         script = construir_script_sandbox_canonico(
             linea,
-            safe_mode=self._seguro_repl,
-            extra_validators=self._extra_validators_repl,
+            safe_mode=setup.safe_mode,
+            extra_validators=setup.validadores_extra,
             imprimir_resultado=True,
         )
 

--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -71,12 +71,9 @@ def construir_script_sandbox_canonico(
         else f", safe_mode={safe_mode!r}, extra_validators={extra_repr}"
     )
     script = (
-        "from pcobra.cobra.core import Lexer, Parser\n"
-        "from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_source_for_tokenizer\n"
+        "from pcobra.cobra.cli.execution_pipeline import prevalidar_y_parsear_codigo\n"
         "from pcobra.cobra.core.runtime import InterpretadorCobra\n"
-        f"_codigo = sanitize_source_for_tokenizer({codigo!r})\n"
-        "_tokens = Lexer(_codigo).tokenizar()\n"
-        "_ast = Parser(_tokens).parsear()\n"
+        f"_ast = prevalidar_y_parsear_codigo({codigo!r})\n"
         f"_interp = InterpretadorCobra({safe_mode_fragment.lstrip(', ')})\n"
         "_resultado = _interp.ejecutar_ast(_ast)\n"
     )

--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -156,12 +156,32 @@ class RunService:
         allow_insecure_fallback: bool = False,
     ) -> int:
         try:
+            interpretador_cls = resolver_interpretador_cls(
+                module_name=__name__,
+                default_cls=InterpretadorCobra,
+            )
+            setup, _ = ejecutar_pipeline_explicito(
+                PipelineInput(
+                    codigo="",
+                    interpretador_cls=interpretador_cls,
+                    safe_mode=seguro,
+                    extra_validators=extra_validators,
+                ),
+                analizar_codigo_fn=lambda _codigo: [],
+            )
             prevalidar_y_parsear_codigo(codigo)
         except (LexerError, ParserError) as e:
             mostrar_error(f"Error de análisis: {e}", registrar_log=False)
             return 1
+        except (TypeError, ValueError, PrimitivaPeligrosaError) as e:
+            mostrar_error(str(e), registrar_log=False)
+            return 1
 
-        script = construir_script_sandbox_canonico(codigo, safe_mode=seguro, extra_validators=extra_validators)
+        script = construir_script_sandbox_canonico(
+            codigo,
+            safe_mode=setup.safe_mode,
+            extra_validators=setup.validadores_extra,
+        )
 
         try:
             salida = ejecutar_en_sandbox(script, allow_insecure_fallback=allow_insecure_fallback)

--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -12,7 +12,8 @@ from pcobra.cobra.cli.execution_pipeline import (
     ejecutar_pipeline_explicito,
     resolver_interpretador_cls,
 )
-from pcobra.cobra.core.runtime import InterpretadorCobra
+from pcobra.cobra.cli.services.run_service import RunService
+from pcobra.cobra.core.runtime import InterpretadorCobra, ValidadorBase
 
 
 def _run_args(file_path: str) -> Namespace:
@@ -230,6 +231,40 @@ def test_error_semantico_y_runtime_equivalen_en_tipo_y_mensaje(codigo_erroneo):
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
+    "codigo_erroneo",
+    [
+        'imprimir("cadena sin cerrar)',
+        "si verdadero imprimir(1)",
+    ],
+)
+def test_error_sintactico_equivale_en_tipo_y_mensaje(codigo_erroneo):
+    interpretador_cls = resolver_interpretador_cls(
+        module_name="pcobra.cobra.cli.services.run_service",
+        default_cls=InterpretadorCobra,
+    )
+
+    with pytest.raises(Exception) as err_script:  # noqa: BLE001 - contrato integración
+        ejecutar_pipeline_explicito(
+            PipelineInput(
+                codigo=codigo_erroneo,
+                interpretador_cls=interpretador_cls,
+                safe_mode=False,
+                extra_validators=None,
+            )
+        )
+
+    repl = InteractiveCommand(InterpretadorCobra())
+    repl._seguro_repl = False
+    repl._extra_validators_repl = None
+    with pytest.raises(Exception) as err_repl:  # noqa: BLE001 - contrato integración
+        repl.ejecutar_codigo(codigo_erroneo)
+
+    assert type(err_script.value) is type(err_repl.value)
+    assert str(err_script.value) == str(err_repl.value)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
     ("caso", "prelude", "snippet", "variables_esperadas"),
     [
         (
@@ -305,3 +340,57 @@ def test_runtime_estado_final_paridad_run_vs_repl(
     assert resultado_script["estado"] == variables_esperadas, (
         f"{caso}: el estado final debe respetar semántica de scope esperada"
     )
+
+
+@pytest.mark.integration
+def test_sandbox_normaliza_safe_mode_y_validadores_igual_en_run_y_repl(monkeypatch):
+    import pcobra.cobra.cli.services.run_service as run_service_module
+    import pcobra.cobra.cli.commands.interactive_cmd as interactive_module
+
+    class DummyInterp:
+        def __init__(self, safe_mode=True, extra_validators=None):
+            self.safe_mode = safe_mode
+            self.extra_validators = extra_validators
+            self.contextos = [{}]
+
+        def ejecutar_ast(self, _ast):
+            return None
+
+        @staticmethod
+        def _cargar_validadores(ruta):
+            class _DummyValidador(ValidadorBase):
+                pass
+
+            validador = _DummyValidador()
+            setattr(validador, "origen", ruta)
+            return [validador]
+
+    capturas: list[tuple[str, bool | None, object]] = []
+
+    def _capturar_script(codigo, *, safe_mode=None, extra_validators=None, imprimir_resultado=False):
+        capturas.append((codigo, safe_mode, extra_validators))
+        return "print('ok')"
+
+    monkeypatch.setattr(run_service_module, "InterpretadorCobra", DummyInterp)
+    monkeypatch.setattr(interactive_module, "InterpretadorCobra", DummyInterp)
+    monkeypatch.setattr(run_service_module, "construir_script_sandbox_canonico", _capturar_script)
+    monkeypatch.setattr(interactive_module, "construir_script_sandbox_canonico", _capturar_script)
+    monkeypatch.setattr(run_service_module, "ejecutar_en_sandbox", lambda *_args, **_kwargs: "")
+    monkeypatch.setattr(interactive_module, "ejecutar_en_sandbox", lambda *_args, **_kwargs: "")
+
+    servicio = RunService()
+    rc = servicio.ejecutar_en_sandbox(
+        "var valor = 1",
+        seguro=1,
+        extra_validators=["uno.py", "dos.py"],
+    )
+    repl = InteractiveCommand(DummyInterp())
+    repl._seguro_repl = 1
+    repl._extra_validators_repl = ["uno.py", "dos.py"]
+    repl._ejecutar_en_sandbox("var valor = 1")
+
+    assert rc == 0
+    assert len(capturas) == 2
+    assert capturas[0][1] is True and capturas[1][1] is True
+    assert [getattr(v, "origen", None) for v in capturas[0][2]] == ["uno.py", "dos.py"]
+    assert [getattr(v, "origen", None) for v in capturas[1][2]] == ["uno.py", "dos.py"]


### PR DESCRIPTION
### Motivation
- Evitar rutas ad-hoc de parseo/validación en el REPL y garantizar que `run` y `interactive` compartan un único camino canónico de análisis y validación.
- Asegurar que `safe_mode` y `extra_validators` se normalicen de la misma forma en ambos flujos para mantener paridad en salidas, errores y persistencia de estado.

### Description
- `construir_script_sandbox_canonico` ahora reutiliza `prevalidar_y_parsear_codigo` en vez de embeder un flujo `Lexer/Parser` ad-hoc para generar el `_ast` del script sandbox. (modificado: `src/pcobra/cobra/cli/execution_pipeline.py`)
- `RunService.ejecutar_en_sandbox` normaliza opciones creando un `setup` vía `ejecutar_pipeline_explicito` (resuelve `safe_mode` y `validadores_extra`) antes de prevalidar y construir el script sandbox con los valores normalizados. (modificado: `src/pcobra/cobra/cli/services/run_service.py`)
- `InteractiveCommand._ejecutar_en_sandbox` hace la misma normalización (usa `ejecutar_pipeline_explicito` y actualiza el intérprete/flags del REPL) y usa `prevalidar_y_parsear_codigo` para el chequeo sintáctico canónico, eliminando la ruta ad-hoc previa. (modificado: `src/pcobra/cobra/cli/commands/interactive_cmd.py`)
- Se ampliaron las pruebas de integración en `tests/integration/test_run_repl_equivalence.py` para cubrir:
  - equivalencia de errores sintácticos (tipo y mensaje) entre `run` y REPL, y
  - normalización equivalente de `safe_mode` y `extra_validators` en el flujo sandbox para ambos caminos.

### Testing
- Ejecutado: `pytest -q tests/integration/test_run_repl_equivalence.py`.
- Resultado: Todas las pruebas del archivo pasaron (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec941acb9083278dbec83a65c79586)