### PR TITLE
Estabilizar CLI sin argumentos y bootstrap determinista de .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Required: encryption key for SQLitePlus cache
+SQLITE_DB_KEY=dev-key-change-me
+
+# Optional: database path
+COBRA_DB_PATH=~/.cobra/sqliteplus/core.db
+
+# Optional: enable dynamic package install
+COBRA_USAR_INSTALL=0
+
+# Optional: CLI behavior
+COBRA_CLI_BOOTSTRAP_PATH=0
+
+# Optional: logging format (text/json)
+COBRA_LOG_FORMATTER=text

--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shutil
 import sys
 from importlib import import_module
 from pathlib import Path
@@ -20,6 +21,9 @@ except ModuleNotFoundError:  # pragma: no cover - rama dependiente del entorno
 
 logger = logging.getLogger(__name__)
 _CLI_BOOTSTRAP_PATH_ENV = "PCOBRA_CLI_BOOTSTRAP_PATH"
+_DEFAULT_DB_PATH = str(Path("~/.cobra/sqliteplus/core.db").expanduser())
+_ENV_FILE = Path(".env")
+_ENV_EXAMPLE_FILE = Path(".env.example")
 _LEGACY_SHIM_ALIAS_CONTRACT = {
     # Siempre preservamos el módulo canónico para los wrappers legacy.
     "always": ("pcobra.cli",),
@@ -161,22 +165,34 @@ def __getattr__(name: str):
 
 
 def configurar_entorno() -> None:
-    """Carga variables de entorno desde un archivo .env si está presente."""
+    """Carga variables de entorno y valida precondiciones críticas del runtime."""
+    if not _ENV_FILE.exists() and _ENV_EXAMPLE_FILE.exists():
+        shutil.copyfile(_ENV_EXAMPLE_FILE, _ENV_FILE)
+        logger.info(
+            "No se encontró .env; se creó automáticamente desde %s",
+            _ENV_EXAMPLE_FILE,
+        )
+
     if load_dotenv is None:
         logger.debug(
             "python-dotenv no está instalado; se omite la carga automática del archivo .env"
         )
-        return
-    try:
-        cargado = load_dotenv()
-    except OSError as exc:
-        logger.error("No se pudo acceder al archivo .env: %s", exc)
-        return
-    except Exception:  # pragma: no cover - registro y propagación
-        logger.exception("Error inesperado al cargar variables de entorno")
-        raise
-    if not cargado:
-        logger.warning("El archivo .env no se cargó")
+    else:
+        try:
+            load_dotenv(dotenv_path=_ENV_FILE if _ENV_FILE.exists() else None)
+        except OSError as exc:
+            logger.error("No se pudo acceder al archivo .env: %s", exc)
+            return
+        except Exception:  # pragma: no cover - registro y propagación
+            logger.exception("Error inesperado al cargar variables de entorno")
+            raise
+
+    if not (os.environ.get("SQLITE_DB_KEY") or "").strip():
+        logger.error(
+            "Falta SQLITE_DB_KEY en el entorno. Defínela en .env o en variables de entorno antes de ejecutar la CLI."
+        )
+
+    os.environ.setdefault("COBRA_DB_PATH", _DEFAULT_DB_PATH)
 
 
 def _normalizar_argumentos(argumentos: Optional[Iterable[str]]) -> Optional[List[str]]:

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -272,13 +272,6 @@ class CommandRegistry:
                 logging.error(f"Failed to register subparser for {command.name}: {e}")
                 del self.commands[command.name]
 
-        if self.default_command_name not in self.commands:
-            fallback = "interactive" if "interactive" in self.commands else next(iter(self.commands), None)
-            logging.warning(
-                "Default command '%s' not found. Falling back to '%s'", self.default_command_name, fallback
-            )
-            self.default_command_name = fallback
-
         return self.commands
 
     def get_default_command(self) -> Optional[BaseCommand]:
@@ -688,10 +681,6 @@ class CliApplication:
         )
         self._ensure_command_structure()
 
-        default_command_name = self.command_registry.get_default_command_name()
-        default_command = self.command_registry.commands.get(default_command_name)
-        if default_command:
-            self.parser.set_defaults(cmd=default_command)
         if autocomplete_available():
             self._configure_autocomplete(self.parser)
             enable_autocomplete(self.parser)
@@ -1057,20 +1046,18 @@ class CliApplication:
         if not self.command_registry:
             raise RuntimeError("Command registry not initialized")
             
-        command = getattr(args, "cmd", self.command_registry.get_default_command())
+        command = getattr(args, "cmd", None)
         if command == "menu":
             return self.run_menu(args)
         if not command:
             if self.parser is not None:
                 self.parser.print_help()
-            else:
-                messages.mostrar_error(
-                    _("CLI no inicializada completamente: parser no disponible. "
-                      "Ejecute initialize() antes de execute_command()."),
-                    registrar_log=False,
-                )
                 return 1
-            messages.mostrar_error(_("Comando inválido. Use --help para ver opciones."), registrar_log=False)
+            messages.mostrar_error(
+                _("CLI no inicializada completamente: parser no disponible. "
+                  "Ejecute initialize() antes de execute_command()."),
+                registrar_log=False,
+            )
             return 1
             
         try:

--- a/tests/unit/test_cli_default_command.py
+++ b/tests/unit/test_cli_default_command.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from cobra.cli.cli import CliApplication, InteractiveCommand, CustomArgumentParser, AppConfig, CommandRegistry
+from cobra.cli.cli import CliApplication, InteractiveCommand, CustomArgumentParser, CommandRegistry
 
 
 def _patch_cli_env(stack: ExitStack) -> None:
@@ -18,15 +18,17 @@ def _patch_cli_env(stack: ExitStack) -> None:
     stack.enter_context(patch("cobra.cli.cli.resolve_command_profile", return_value="development"))
 
 
-def test_default_command_runs_interactive():
+def test_no_command_prints_help_and_does_not_run_default():
     with ExitStack() as stack:
         _patch_cli_env(stack)
         stack.enter_context(patch("cobra.cli.cli.AppConfig.BASE_COMMAND_CLASSES", [InteractiveCommand]))
         mock_run = stack.enter_context(patch("cobra.cli.cli.InteractiveCommand.run", return_value=0))
+        mock_help = stack.enter_context(patch.object(CustomArgumentParser, "print_help"))
         app = CliApplication()
         result = app.run([])
-    mock_run.assert_called_once()
-    assert result == 0
+    mock_run.assert_not_called()
+    mock_help.assert_called_once()
+    assert result == 1
 
 
 def test_unknown_command_shows_error_and_help():
@@ -43,25 +45,22 @@ def test_unknown_command_shows_error_and_help():
     mock_error.assert_called()
 
 
-def test_consecutive_initializations_keep_default_command_isolated():
+def test_parse_arguments_without_command_keeps_cmd_undefined():
     with ExitStack() as stack:
         _patch_cli_env(stack)
         stack.enter_context(patch("cobra.cli.cli.AppConfig.BASE_COMMAND_CLASSES", [InteractiveCommand]))
-        stack.enter_context(patch("cobra.cli.cli.AppConfig.DEFAULT_COMMAND", "interactive"))
         first_app = CliApplication()
         first_app.initialize()
         first_args = first_app._parse_arguments([])
-        assert first_args.cmd.name == "interactive"
+        assert getattr(first_args, "cmd", None) is None
 
     with ExitStack() as stack:
         _patch_cli_env(stack)
         stack.enter_context(patch("cobra.cli.cli.AppConfig.BASE_COMMAND_CLASSES", [InteractiveCommand]))
-        stack.enter_context(patch("cobra.cli.cli.AppConfig.DEFAULT_COMMAND", "missing"))
         second_app = CliApplication()
         second_app.initialize()
         second_args = second_app._parse_arguments([])
-        assert second_args.cmd.name == "interactive"
-        assert AppConfig.DEFAULT_COMMAND == "missing"
+        assert getattr(second_args, "cmd", None) is None
 
 
 def test_parse_arguments_is_reentrant_on_same_instance():
@@ -81,8 +80,8 @@ def test_parse_arguments_is_reentrant_on_same_instance():
         first_args = app._parse_arguments([])
         second_args = app._parse_arguments([])
 
-    assert first_args.cmd.name == "interactive"
-    assert second_args.cmd.name == "interactive"
+    assert getattr(first_args, "cmd", None) is None
+    assert getattr(second_args, "cmd", None) is None
     assert register_spy.call_count == 1
     assert add_subparsers_spy.call_count == 1
 
@@ -105,9 +104,9 @@ def test_run_is_reentrant_on_same_instance_without_command_conflict():
         first_result = app.run([])
         second_result = app.run([])
 
-    assert first_result == 0
-    assert second_result == 0
-    assert mock_run.call_count == 2
+    assert first_result == 1
+    assert second_result == 1
+    assert mock_run.call_count == 0
     assert register_spy.call_count == 1
 
 

--- a/tests/unit/test_cli_env_bootstrap.py
+++ b/tests/unit/test_cli_env_bootstrap.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pcobra.cli as cli
+
+
+def test_configurar_entorno_autocrea_env_desde_example(tmp_path, monkeypatch, caplog):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SQLITE_DB_KEY", raising=False)
+    monkeypatch.delenv("COBRA_DB_PATH", raising=False)
+
+    env_example = tmp_path / ".env.example"
+    env_example.write_text("SQLITE_DB_KEY=dev-key\n", encoding="utf-8")
+
+    def _fake_load_dotenv(*, dotenv_path=None):
+        assert dotenv_path == Path(".env")
+        for line in Path(dotenv_path).read_text(encoding="utf-8").splitlines():
+            if "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            monkeypatch.setenv(key.strip(), value.strip())
+        return True
+
+    monkeypatch.setattr(cli, "load_dotenv", _fake_load_dotenv)
+
+    caplog.set_level("INFO", logger="pcobra.cli")
+    cli.configurar_entorno()
+
+    env_file = tmp_path / ".env"
+    assert env_file.exists()
+    assert env_file.read_text(encoding="utf-8") == env_example.read_text(encoding="utf-8")
+    assert "No se encontró .env; se creó automáticamente" in caplog.text
+    assert "COBRA_DB_PATH" in cli.os.environ
+
+
+def test_configurar_entorno_registra_error_si_falta_sqlite_db_key(tmp_path, monkeypatch, caplog):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SQLITE_DB_KEY", raising=False)
+
+    monkeypatch.setattr(cli, "load_dotenv", lambda **_kwargs: False)
+
+    caplog.set_level("ERROR", logger="pcobra.cli")
+    cli.configurar_entorno()
+
+    assert "Falta SQLITE_DB_KEY" in caplog.text


### PR DESCRIPTION
### Motivation
- Evitar el crash al ejecutar `cobra` sin argumentos causado por fallback inválido a un comando interactivo y accesos a atributos inexistentes de `argparse`.
- Asegurar un punto de partida reproducible para variables de entorno críticas (especialmente `SQLITE_DB_KEY`) sin ocultar errores de configuración.

### Description
- Eliminado el fallback implícito a `interactive` y la inyección automática del comando por defecto; cuando no hay subcomando la CLI muestra la ayuda y retorna `1` en lugar de ejecutar un comando oculto (`src/pcobra/cobra/cli/cli.py`).
- Evitado el uso de `args` con atributos no garantizados: `execute_command` ahora respeta `args.cmd` solo si está presente y no intenta resoluciones implícitas.
- Implementado bootstrap determinista de entorno en el entrypoint: si falta `.env` y existe `.env.example` se copia automáticamente y se registra un `INFO`; la carga usa `python-dotenv` cuando está disponible (`src/pcobra/cli.py`).
- Validación explícita de variables críticas: se registra `ERROR` si `SQLITE_DB_KEY` no queda definida tras carga automática (se mantiene `COBRA_DB_PATH` opcional y se asegura un `COBRA_DB_PATH` por defecto determinista si no existe).
- Añadido un `.env.example` con valores seguros para desarrollo (`SQLITE_DB_KEY=dev-key-change-me`, ruta por defecto en `COBRA_DB_PATH`, y flags opcionales seguros).
- Tests actualizados/adicionados para reflejar el nuevo contrato: `tests/unit/test_cli_default_command.py` adaptado y `tests/unit/test_cli_env_bootstrap.py` añadido.

### Testing
- Ejecutadas pruebas unitarias específicas con `PYTHONPATH=src pytest -q tests/unit/test_cli_default_command.py tests/unit/test_cli_env_bootstrap.py` y todas las pruebas incluidas pasaron (`8 passed` localmente para esas suites).
- Pruebas manuales de humo: `PYTHONPATH=src python -m pcobra` mostró la ayuda y retornó código `1` sin crash; `PYTHONPATH=src python -m pcobra run tests/data/hola.cobra` ejecutó correctamente y produjo salida esperada.
- Resultado general: cambios verificados con las pruebas automatizadas listadas y cheques de smoke execution; no se introdujeron regresiones en los escenarios probados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec990d85608327b608fc1042530f3c)