### PR TITLE
Alinear default command en CLI y eliminar acoplamiento de fallback implícito

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -143,7 +143,6 @@ class CommandRegistry:
     def __init__(self, interpreter: Optional[InterpretadorCobra] = None) -> None:
         self.commands: Dict[str, BaseCommand] = {}
         self.interpreter = interpreter
-        self.default_command_name: Optional[str] = AppConfig.DEFAULT_COMMAND
 
     @staticmethod
     def _is_legacy_cli_enabled() -> bool:
@@ -273,13 +272,6 @@ class CommandRegistry:
                 del self.commands[command.name]
 
         return self.commands
-
-    def get_default_command(self) -> Optional[BaseCommand]:
-        return self.commands.get(self.default_command_name)
-
-    def get_default_command_name(self) -> Optional[str]:
-        return self.default_command_name
-
 
 class CliApplication:
     """Aplicación principal de CLI con inicialización idempotente por instancia.

--- a/src/pcobra/cobra/cli/utils/config.py
+++ b/src/pcobra/cobra/cli/utils/config.py
@@ -13,7 +13,7 @@ except ModuleNotFoundError:  # pragma: no cover
 
 DEFAULTS = {
     "language": "es",
-    "default_command": "interactive",
+    "default_command": "run",
     "log_format": "%(asctime)s - %(levelname)s - %(message)s",
     "log_formatter": "text",
     "program_name": "cobra",

--- a/tests/unit/test_cli_config_defaults.py
+++ b/tests/unit/test_cli_config_defaults.py
@@ -72,7 +72,7 @@ def test_cli_starts_with_defaults_when_config_absent(tmp_path, monkeypatch):
     cli_mod = importlib.import_module("cobra.cli.cli")
 
     assert cli_mod.AppConfig.DEFAULT_LANGUAGE == "es"
-    assert cli_mod.AppConfig.DEFAULT_COMMAND == "interactive"
+    assert cli_mod.AppConfig.DEFAULT_COMMAND == "run"
 
 
 def test_cli_uses_defaults_when_config_load_fails(monkeypatch, caplog):
@@ -92,4 +92,4 @@ def test_cli_uses_defaults_when_config_load_fails(monkeypatch, caplog):
     assert "boom" in caplog.text
     assert cli_mod.AppConfig.config_data == {}
     assert cli_mod.AppConfig.DEFAULT_LANGUAGE == "es"
-    assert cli_mod.AppConfig.DEFAULT_COMMAND == "interactive"
+    assert cli_mod.AppConfig.DEFAULT_COMMAND == "run"

--- a/tests/unit/test_cli_default_command.py
+++ b/tests/unit/test_cli_default_command.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from cobra.cli.cli import CliApplication, InteractiveCommand, CustomArgumentParser, CommandRegistry
+from cobra.cli.cli import CliApplication, InteractiveCommand, CustomArgumentParser, main
 
 
 def _patch_cli_env(stack: ExitStack) -> None:
@@ -26,6 +26,21 @@ def test_no_command_prints_help_and_does_not_run_default():
         mock_help = stack.enter_context(patch.object(CustomArgumentParser, "print_help"))
         app = CliApplication()
         result = app.run([])
+    mock_run.assert_not_called()
+    mock_help.assert_called_once()
+    assert result == 1
+
+
+def test_main_without_args_prints_help_and_returns_one():
+    with ExitStack() as stack:
+        _patch_cli_env(stack)
+        stack.enter_context(patch("cobra.cli.cli.AppConfig.BASE_COMMAND_CLASSES", [InteractiveCommand]))
+        stack.enter_context(patch("cobra.cli.cli.configure_encoding"))
+        mock_run = stack.enter_context(patch("cobra.cli.cli.InteractiveCommand.run", return_value=0))
+        mock_help = stack.enter_context(patch.object(CustomArgumentParser, "print_help"))
+
+        result = main([])
+
     mock_run.assert_not_called()
     mock_help.assert_called_once()
     assert result == 1
@@ -92,12 +107,13 @@ def test_run_is_reentrant_on_same_instance_without_command_conflict():
         stack.enter_context(patch("cobra.cli.cli.AppConfig.BASE_COMMAND_CLASSES", [InteractiveCommand]))
         mock_run = stack.enter_context(patch("cobra.cli.cli.InteractiveCommand.run", return_value=0))
         app = CliApplication()
+        app.initialize()
 
         register_spy = stack.enter_context(
-            patch(
-                "cobra.cli.cli.CommandRegistry.register_base_commands",
-                autospec=True,
-                wraps=CommandRegistry.register_base_commands,
+            patch.object(
+                app.command_registry,
+                "register_base_commands",
+                wraps=app.command_registry.register_base_commands,
             )
         )
 

--- a/tests/unit/test_command_registry_interactive.py
+++ b/tests/unit/test_command_registry_interactive.py
@@ -20,30 +20,31 @@ def test_register_base_commands_includes_interactive():
     assert commands['interactive'].__class__.__name__ == InteractiveCommand.__name__
 
 
-def test_get_default_command_returns_interactive():
+def test_command_registry_no_expone_default_command_operativo():
     registry = CommandRegistry(MagicMock())
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers()
     with patch('cobra.cli.cli.descubrir_plugins', return_value=[]):
-        registry.register_base_commands(subparsers, ui="v1", profile=PROFILE_DEVELOPMENT)
-    default_cmd = registry.get_default_command()
-    assert default_cmd.__class__.__name__ == InteractiveCommand.__name__
+        commands = registry.register_base_commands(subparsers, ui="v1", profile=PROFILE_DEVELOPMENT)
+    assert 'interactive' in commands
+    assert not hasattr(registry, "default_command_name")
+    assert not hasattr(registry, "get_default_command")
 
 
-def test_register_base_commands_uses_fallback_for_missing_default(monkeypatch, caplog):
+def test_register_base_commands_ignora_default_command_configurado(monkeypatch, caplog):
     monkeypatch.setattr(AppConfig, 'DEFAULT_COMMAND', 'missing')
     registry = CommandRegistry(MagicMock())
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers()
     with patch('cobra.cli.cli.descubrir_plugins', return_value=[]):
         with caplog.at_level(logging.WARNING):
-            registry.register_base_commands(subparsers, ui="v1", profile=PROFILE_DEVELOPMENT)
+            commands = registry.register_base_commands(subparsers, ui="v1", profile=PROFILE_DEVELOPMENT)
     assert AppConfig.DEFAULT_COMMAND == 'missing'
-    assert registry.default_command_name == 'interactive'
-    assert "Default command 'missing' not found" in caplog.text
+    assert "interactive" in commands
+    assert "Default command 'missing' not found" not in caplog.text
 
 
-def test_command_registry_keeps_default_isolated_across_instances(monkeypatch):
+def test_command_registry_no_acopla_default_entre_instancias(monkeypatch):
     parser_one = argparse.ArgumentParser()
     parser_two = argparse.ArgumentParser()
     subparsers_one = parser_one.add_subparsers()
@@ -52,13 +53,15 @@ def test_command_registry_keeps_default_isolated_across_instances(monkeypatch):
     with patch('cobra.cli.cli.descubrir_plugins', return_value=[]):
         monkeypatch.setattr(AppConfig, 'DEFAULT_COMMAND', 'interactive')
         first_registry = CommandRegistry(MagicMock())
-        first_registry.register_base_commands(subparsers_one, ui="v1", profile=PROFILE_DEVELOPMENT)
+        first_commands = first_registry.register_base_commands(subparsers_one, ui="v1", profile=PROFILE_DEVELOPMENT)
         monkeypatch.setattr(AppConfig, 'DEFAULT_COMMAND', 'missing')
         second_registry = CommandRegistry(MagicMock())
-        second_registry.register_base_commands(subparsers_two, ui="v1", profile=PROFILE_DEVELOPMENT)
+        second_commands = second_registry.register_base_commands(subparsers_two, ui="v1", profile=PROFILE_DEVELOPMENT)
 
-    assert first_registry.default_command_name == 'interactive'
-    assert second_registry.default_command_name == 'interactive'
+    assert "interactive" in first_commands
+    assert "interactive" in second_commands
+    assert not hasattr(first_registry, "default_command_name")
+    assert not hasattr(second_registry, "default_command_name")
     assert AppConfig.DEFAULT_COMMAND == 'missing'
 
 


### PR DESCRIPTION
### Motivation
- Alinear el valor por defecto de la CLI con la UX pública (usar `run` en lugar de `interactive`).
- Evitar un acoplamiento operativo donde `CommandRegistry` expone un `default_command_name` que no participa en el dispatch real.
- Hacer explícito el comportamiento cuando no se pasa ningún comando: mostrar help y devolver código `1` sin ejecutar ningún comando por defecto.

### Description
- Se eliminó el estado/métodos relativos a `default_command_name` (`self.default_command_name`, `get_default_command`, `get_default_command_name`) del `CommandRegistry` para quitar el acoplamiento implícito al fallback. (modificado: `src/pcobra/cobra/cli/cli.py`).
- Se mantuvo y verificó la ruta en `CliApplication.execute_command` para el caso sin comando que llama a `self.parser.print_help()` y `return 1` sin intentar ningún `get_default_command()` ni usar `default_command_name`. (modificado: `src/pcobra/cobra/cli/cli.py`).
- Se cambió `DEFAULTS["default_command"]` de `"interactive"` a `"run"` en `src/pcobra/cobra/cli/utils/config.py` para reflejar la expectativa pública.
- Se actualizaron y añadieron tests: se adaptaron las expectativas en `tests/unit/test_cli_config_defaults.py` a `run`, se ajustaron tests de `CommandRegistry` para validar que no exista el acoplamiento al default, y se añadió `test_main_without_args_prints_help_and_returns_one()` en `tests/unit/test_cli_default_command.py` que invoca `main([])` y comprueba que se muestra help y retorna `1`.

### Testing
- Se ejecutaron los tests unitarios relevantes con `pytest -q tests/unit/test_cli_config_defaults.py tests/unit/test_cli_default_command.py tests/unit/test_command_registry_interactive.py` y todos pasaron. (Resultado: `14 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca19d4ef4832799fe785c02e5c78f)