### PR TITLE
test(cli): actualizar pruebas de `configurar_entorno` y verificar severidad INFO al bootstrap .env

### DIFF
--- a/tests/unit/test_cli_configurar_entorno.py
+++ b/tests/unit/test_cli_configurar_entorno.py
@@ -56,14 +56,14 @@ jsonschema_stub.ValidationError = _JsonSchemaValidationError
 jsonschema_stub.validate = lambda *args, **kwargs: None
 sys.modules.setdefault("jsonschema", jsonschema_stub)
 
-from pcobra.cli import _reconfigurar_consola_utf8, configurar_entorno
+from pcobra.cli import configure_encoding, configurar_entorno
 import pcobra.cli as cli
 
 
 def test_configurar_entorno_permiso_denegado(monkeypatch, caplog):
     """Debe registrar un error y continuar cuando .env no se puede leer."""
 
-    def _raise_permission_error():
+    def _raise_permission_error(**_kwargs):
         raise PermissionError("sin permiso")
 
     monkeypatch.setattr("pcobra.cli.load_dotenv", _raise_permission_error)
@@ -87,14 +87,14 @@ class _DummyStreamSinReconfigure:
         return "".join(self.buffer)
 
 
-def test_reconfigurar_consola_utf8_fallback_no_rompe_sin_reconfigure(monkeypatch):
+def test_configure_encoding_fallback_no_rompe_sin_reconfigure(monkeypatch):
     out = _DummyStreamSinReconfigure()
     err = _DummyStreamSinReconfigure()
     monkeypatch.setattr(sys, "stdout", out)
     monkeypatch.setattr(sys, "stderr", err)
     monkeypatch.delenv("PYTHONIOENCODING", raising=False)
 
-    _reconfigurar_consola_utf8()
+    configure_encoding()
 
     out.write("Salida legible: áéíóú")
     err.write("Error legible: ñ")
@@ -103,10 +103,10 @@ def test_reconfigurar_consola_utf8_fallback_no_rompe_sin_reconfigure(monkeypatch
     assert os.environ["PYTHONIOENCODING"] == "utf-8"
 
 
-def test_reconfigurar_consola_utf8_sobrescribe_pythonioencoding_a_utf8(monkeypatch):
+def test_configure_encoding_sobrescribe_pythonioencoding_a_utf8(monkeypatch):
     monkeypatch.setenv("PYTHONIOENCODING", "latin-1")
 
-    _reconfigurar_consola_utf8()
+    configure_encoding()
 
     assert os.environ["PYTHONIOENCODING"] == "utf-8"
 
@@ -120,14 +120,14 @@ class _DummyStreamConReconfigure(_DummyStreamSinReconfigure):
         self.calls.append({"encoding": encoding})
 
 
-def test_reconfigurar_consola_utf8_reconfigura_stdout_y_stderr(monkeypatch):
+def test_configure_encoding_reconfigura_stdout_y_stderr(monkeypatch):
     out = _DummyStreamConReconfigure()
     err = _DummyStreamConReconfigure()
     monkeypatch.setattr(sys, "stdout", out)
     monkeypatch.setattr(sys, "stderr", err)
     monkeypatch.delenv("PYTHONIOENCODING", raising=False)
 
-    _reconfigurar_consola_utf8()
+    configure_encoding()
 
     assert out.calls == [{"encoding": "utf-8"}]
     assert err.calls == [{"encoding": "utf-8"}]
@@ -137,7 +137,7 @@ def test_reconfigurar_consola_utf8_reconfigura_stdout_y_stderr(monkeypatch):
 def test_main_reconfigura_consola_antes_de_logging_y_cli(monkeypatch):
     orden: list[str] = []
 
-    monkeypatch.setattr(cli, "_reconfigurar_consola_utf8", lambda: orden.append("utf8"))
+    monkeypatch.setattr(cli, "configure_encoding", lambda: orden.append("utf8"))
     monkeypatch.setattr(cli, "_bootstrap_dev_path_si_opt_in", lambda: orden.append("bootstrap"))
     monkeypatch.setattr(cli, "configure_logging", lambda debug: orden.append("logging"))
     monkeypatch.setattr(cli, "configurar_entorno", lambda: orden.append("entorno"))
@@ -162,8 +162,8 @@ def test_smoke_cli_unicode_salida_bytes_utf8():
         [
             sys.executable,
             "-c",
-            "from pcobra.cli import _reconfigurar_consola_utf8; "
-            "_reconfigurar_consola_utf8(); print('después')",
+            "from pcobra.cli import configure_encoding; "
+            "configure_encoding(); print('después')",
         ],
         env=env,
         capture_output=True,

--- a/tests/unit/test_cli_env_bootstrap.py
+++ b/tests/unit/test_cli_env_bootstrap.py
@@ -29,6 +29,12 @@ def test_configurar_entorno_autocrea_env_desde_example(tmp_path, monkeypatch, ca
     assert env_file.exists()
     assert env_file.read_text(encoding="utf-8") == env_example.read_text(encoding="utf-8")
     assert "No se encontró .env; se creó automáticamente" in caplog.text
+    assert any(
+        record.levelname == "INFO"
+        and "No se encontró .env; se creó automáticamente" in record.getMessage()
+        for record in caplog.records
+    )
+    assert "WARNING: El archivo .env no se cargó" not in caplog.text
     assert "COBRA_DB_PATH" in cli.os.environ
 
 


### PR DESCRIPTION
### Motivation
- Asegurar que el comportamiento actual de bootstrap de `.env` queda cubierto por tests que validen que la autocreación se registra con severidad `INFO`, que `load_dotenv(dotenv_path=...)` se usa sin romper compatibilidad y que el manejo de `OSError` no imprime tracebacks ruidosos.

### Description
- Actualicé `tests/unit/test_cli_configurar_entorno.py` para usar la API actual `configure_encoding` en lugar del símbolo legacy `_reconfigurar_consola_utf8` y adaptar el stub de `load_dotenv` para aceptar kwargs como `dotenv_path`.
- Añadí aserciones en `tests/unit/test_cli_env_bootstrap.py` que verifican explícitamente que la autocreación de `.env` se registra con nivel `INFO` y que no aparece el mensaje `"WARNING: El archivo .env no se cargó"` en el flujo normal.
- No se realizaron cambios en `src/pcobra/cli.py` porque su implementación ya cumple los requisitos: copia con `shutil.copyfile`, `logger.info(...)` al crear `.env`, llamada `load_dotenv(dotenv_path=...)` y manejo de `OSError` con `logger.error(...)` y retorno temprano.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_configurar_entorno.py tests/unit/test_cli_env_bootstrap.py` y todos los tests pasaron: `8 passed`.
- Los tests que se enfocan en `configurar_entorno` cubren la autocreación de `.env`, el comportamiento de `load_dotenv` ante permiso denegado y la configuración de la codificación de consola; todos finalizaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca323f1c48327ada99585e7f56d00)