### PR TITLE
Validar SQLITE_DB_KEY en inicialización de CLI y propagar fallo (exit 1)

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -188,7 +188,7 @@ def configurar_entorno() -> None:
             raise
 
     if not (os.environ.get("SQLITE_DB_KEY") or "").strip():
-        logger.error(
+        raise RuntimeError(
             "Falta SQLITE_DB_KEY en el entorno. Defínela en .env o en variables de entorno antes de ejecutar la CLI."
         )
 
@@ -247,7 +247,13 @@ def main(argumentos: Optional[List[str]] = None) -> int:
 
     from .cobra.cli.cli import CliApplication
 
-    configurar_entorno()
+    try:
+        configurar_entorno()
+    except RuntimeError as exc:
+        if debug:
+            raise
+        logger.error("%s", exc)
+        return 1
     aplicacion = CliApplication()
     return aplicacion.run(argv)
 

--- a/tests/unit/test_cli_configurar_entorno.py
+++ b/tests/unit/test_cli_configurar_entorno.py
@@ -62,6 +62,7 @@ import pcobra.cli as cli
 
 def test_configurar_entorno_permiso_denegado(monkeypatch, caplog):
     """Debe registrar un error y continuar cuando .env no se puede leer."""
+    monkeypatch.setenv("SQLITE_DB_KEY", "test-key")
 
     def _raise_permission_error(**_kwargs):
         raise PermissionError("sin permiso")
@@ -152,6 +153,21 @@ def test_main_reconfigura_consola_antes_de_logging_y_cli(monkeypatch):
     assert cli.main(["comando-ficticio"]) == 0
     assert orden[:3] == ["utf8", "bootstrap", "logging"]
     assert "cli" in orden
+
+
+def test_main_devuelve_exit_code_1_si_falla_configuracion_entorno(monkeypatch, caplog):
+    monkeypatch.setattr(cli, "configure_encoding", lambda: None)
+    monkeypatch.setattr(cli, "_bootstrap_dev_path_si_opt_in", lambda: None)
+    monkeypatch.setattr(cli, "configure_logging", lambda debug: None)
+    monkeypatch.setattr(
+        cli,
+        "configurar_entorno",
+        lambda: (_ for _ in ()).throw(RuntimeError("Falta SQLITE_DB_KEY en el entorno")),
+    )
+
+    caplog.set_level(logging.ERROR, logger="pcobra.cli")
+    assert cli.main(["comando-ficticio"]) == 1
+    assert "Falta SQLITE_DB_KEY en el entorno" in caplog.text
 
 
 def test_smoke_cli_unicode_salida_bytes_utf8():

--- a/tests/unit/test_cli_env_bootstrap.py
+++ b/tests/unit/test_cli_env_bootstrap.py
@@ -38,13 +38,25 @@ def test_configurar_entorno_autocrea_env_desde_example(tmp_path, monkeypatch, ca
     assert "COBRA_DB_PATH" in cli.os.environ
 
 
-def test_configurar_entorno_registra_error_si_falta_sqlite_db_key(tmp_path, monkeypatch, caplog):
+def test_configurar_entorno_falla_si_falta_sqlite_db_key(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("SQLITE_DB_KEY", raising=False)
 
     monkeypatch.setattr(cli, "load_dotenv", lambda **_kwargs: False)
 
-    caplog.set_level("ERROR", logger="pcobra.cli")
+    try:
+        cli.configurar_entorno()
+        raise AssertionError("Se esperaba RuntimeError cuando falta SQLITE_DB_KEY")
+    except RuntimeError as exc:
+        assert "Falta SQLITE_DB_KEY" in str(exc)
+
+
+def test_configurar_entorno_setea_db_path_por_default_con_sqlite_db_key(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SQLITE_DB_KEY", "clave-segura")
+    monkeypatch.delenv("COBRA_DB_PATH", raising=False)
+    monkeypatch.setattr(cli, "load_dotenv", lambda **_kwargs: True)
+
     cli.configurar_entorno()
 
-    assert "Falta SQLITE_DB_KEY" in caplog.text
+    assert cli.os.environ["COBRA_DB_PATH"] == cli._DEFAULT_DB_PATH


### PR DESCRIPTION
### Motivation
- Asegurar que la CLI no siga ejecutándose sin la clave de cifrado requerida `SQLITE_DB_KEY` y proporcionar un error claro al usuario cuando falte.
- Evitar que el fallback de `COBRA_DB_PATH` oculte la falta de la clave crítica al iniciar el runtime.

### Description
- En `src/pcobra/cli.py` `configurar_entorno()` ahora lanza `RuntimeError` si `SQLITE_DB_KEY` está ausente o vacío después de cargar `.env` y mantiene `os.environ.setdefault("COBRA_DB_PATH", _DEFAULT_DB_PATH)` como fallback opcional sin enmascarar el error.
- En `src/pcobra/cli.py` `main()` envuelve la llamada a `configurar_entorno()` en un `try/except RuntimeError` y devuelve `1` registrando el mensaje de error cuando ocurre la excepción, pero relanza la excepción si `--debug` está activo para permitir stacktraces en modo debug.
- Se actualizaron tests en `tests/unit/test_cli_env_bootstrap.py` para esperar un fallo (`RuntimeError`) cuando falta `SQLITE_DB_KEY` y se añadió un caso positivo que verifica que `COBRA_DB_PATH` se setea al default cuando `SQLITE_DB_KEY` está presente.
- Se actualizaron tests en `tests/unit/test_cli_configurar_entorno.py` para fijar `SQLITE_DB_KEY` en el test de permiso denegado y se añadió un test que verifica que `main()` devuelve `1` y registra el mensaje cuando la configuración del entorno falla.

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_env_bootstrap.py tests/unit/test_cli_configurar_entorno.py`, todos los tests pasaron: `10 passed` con `1 warning` deprecación no bloqueante.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca452ad208327b660274b7c1009e2)