### PR TITLE
refactor(cli): centralizar gestión de entorno en `src/pcobra/cli.py`

### DIFF
--- a/cobra/cli/cli.py
+++ b/cobra/cli/cli.py
@@ -1,5 +1,6 @@
 """Proxy mínimo hacia el shim canónico de ``src/cobra/cli/cli.py``."""
 
+# pcobra-compat: allow-legacy-imports
 from __future__ import annotations
 
 import sys

--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import secrets
 import shutil
 import sys
 from importlib import import_module
@@ -23,6 +24,12 @@ logger = logging.getLogger(__name__)
 _CLI_BOOTSTRAP_PATH_ENV = "PCOBRA_CLI_BOOTSTRAP_PATH"
 _CLI_BOOTSTRAP_PATH_ENV_ALIAS = "COBRA_CLI_BOOTSTRAP_PATH"
 _DEFAULT_DB_PATH = str(Path("~/.cobra/sqliteplus/core.db").expanduser())
+SQLITE_DB_KEY_ENV = "SQLITE_DB_KEY"
+COBRA_DEV_MODE_ENV = "COBRA_DEV_MODE"
+COBRA_DEV_EPHEMERAL_CONFIRM_ENV = "COBRA_DEV_ALLOW_EPHEMERAL_KEY"
+COBRA_ALLOW_INSECURE_FALLBACK_ENV = "COBRA_ALLOW_INSECURE_FALLBACK"
+COBRA_ALLOW_INSECURE_NON_INTERACTIVE_ENV = "COBRA_ALLOW_INSECURE_NON_INTERACTIVE"
+COBRA_LANG_ENV = "COBRA_LANG"
 _ENV_FILE = Path(".env")
 _ENV_EXAMPLE_FILE = Path(".env.example")
 _LEGACY_SHIM_ALIAS_CONTRACT = {
@@ -199,12 +206,55 @@ def configurar_entorno() -> None:
             logger.exception("Error inesperado al cargar variables de entorno")
             raise
 
-    if not (os.environ.get("SQLITE_DB_KEY") or "").strip():
+    if not (os.environ.get(SQLITE_DB_KEY_ENV) or "").strip():
         raise RuntimeError(
-            "Falta SQLITE_DB_KEY en el entorno. Defínela en .env o en variables de entorno antes de ejecutar la CLI."
+            f"Falta {SQLITE_DB_KEY_ENV} en el entorno. Defínela en .env o en variables de entorno antes de ejecutar la CLI."
         )
 
     os.environ.setdefault("COBRA_DB_PATH", _DEFAULT_DB_PATH)
+
+
+def env_flag_activado(nombre_variable: str) -> bool:
+    """Evalúa flags de entorno con contrato estricto ``== '1'``."""
+    return os.environ.get(nombre_variable, "").strip() == "1"
+
+
+def ensure_sqlite_db_key_for_command(
+    *,
+    command_name: str,
+    dev_ephemeral_cli_confirmation: bool,
+) -> None:
+    """Garantiza ``SQLITE_DB_KEY`` para comandos que la requieren.
+
+    La validación de entorno se centraliza aquí para mantener a la CLI canónica
+    enfocada en parseo/dispatch.
+    """
+    sqlite_db_key = (os.environ.get(SQLITE_DB_KEY_ENV) or "").strip()
+    if sqlite_db_key:
+        return
+
+    dev_mode_enabled = env_flag_activado(COBRA_DEV_MODE_ENV)
+    dev_ephemeral_env_confirmation = env_flag_activado(COBRA_DEV_EPHEMERAL_CONFIRM_ENV)
+
+    if dev_mode_enabled and dev_ephemeral_env_confirmation and dev_ephemeral_cli_confirmation:
+        os.environ[SQLITE_DB_KEY_ENV] = secrets.token_urlsafe(32)
+        logging.getLogger(__name__).warning(
+            "Modo desarrollo confirmado para comando '%s' (%s=1 + %s=1 + --dev-ephemeral-key): usando clave efímera local para %s.",
+            command_name,
+            COBRA_DEV_MODE_ENV,
+            COBRA_DEV_EPHEMERAL_CONFIRM_ENV,
+            SQLITE_DB_KEY_ENV,
+        )
+        return
+
+    raise RuntimeError(
+        f"Falta la variable de entorno '{SQLITE_DB_KEY_ENV}' (clave requerida por comando '{command_name}'). "
+        "Configúrala antes de iniciar la CLI (ejemplo: "
+        "export SQLITE_DB_KEY='clave-segura'). Para pruebas locales "
+        "controladas puedes habilitar una clave efímera solo si confirmas "
+        f"explícitamente {COBRA_DEV_MODE_ENV}=1, "
+        f"{COBRA_DEV_EPHEMERAL_CONFIRM_ENV}=1 y el flag --dev-ephemeral-key."
+    )
 
 
 def _normalizar_argumentos(argumentos: Optional[Iterable[str]]) -> Optional[List[str]]:

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -1,7 +1,6 @@
 import argparse
 import logging
 import os
-import secrets
 import sys
 from os import environ
 from pathlib import Path
@@ -9,6 +8,16 @@ from typing import List, Dict, Optional, Type, Any, ContextManager
 from contextlib import contextmanager
 
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
+from pcobra.cli import (
+    COBRA_ALLOW_INSECURE_FALLBACK_ENV,
+    COBRA_ALLOW_INSECURE_NON_INTERACTIVE_ENV,
+    COBRA_DEV_EPHEMERAL_CONFIRM_ENV,
+    COBRA_DEV_MODE_ENV,
+    COBRA_LANG_ENV,
+    SQLITE_DB_KEY_ENV,
+    ensure_sqlite_db_key_for_command,
+    env_flag_activado,
+)
 
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.target_policies import OFFICIAL_TRANSPILATION_TARGETS
@@ -56,11 +65,6 @@ from pcobra.cobra.cli.utils.autocomplete import (
 # Metadata injected at build time
 CLI_VERSION = environ.get("COBRA_CLI_VERSION", "dev")
 CLI_COMMIT = environ.get("COBRA_CLI_COMMIT", "unknown")
-SQLITE_DB_KEY_ENV = "SQLITE_DB_KEY"
-COBRA_DEV_MODE_ENV = "COBRA_DEV_MODE"
-COBRA_DEV_EPHEMERAL_CONFIRM_ENV = "COBRA_DEV_ALLOW_EPHEMERAL_KEY"
-COBRA_ALLOW_INSECURE_FALLBACK_ENV = "COBRA_ALLOW_INSECURE_FALLBACK"
-COBRA_ALLOW_INSECURE_NON_INTERACTIVE_ENV = "COBRA_ALLOW_INSECURE_NON_INTERACTIVE"
 COBRA_INTERNAL_ENABLE_CLI_V1_ENV = "COBRA_INTERNAL_ENABLE_CLI_V1"
 COBRA_ENABLE_LEGACY_CLI_ENV = "COBRA_INTERNAL_ENABLE_LEGACY_CLI"
 LANG_CHOICES = tuple(OFFICIAL_TRANSPILATION_TARGETS)
@@ -349,7 +353,7 @@ class CliApplication:
         return False
 
     def _is_enabled_env_flag(self, env_name: str) -> bool:
-        return environ.get(env_name, "").strip() == "1"
+        return env_flag_activado(env_name)
 
     def _is_internal_v1_ui_enabled(self) -> bool:
         return (
@@ -360,32 +364,9 @@ class CliApplication:
     def _ensure_sqlite_db_key(self, args: argparse.Namespace) -> None:
         command = getattr(args, "cmd", None)
         command_name = command.name if isinstance(command, BaseCommand) else _("desconocido")
-        sqlite_db_key = (environ.get(SQLITE_DB_KEY_ENV) or "").strip()
-        if sqlite_db_key:
-            return
-
-        dev_mode_enabled = self._is_enabled_env_flag(COBRA_DEV_MODE_ENV)
-        dev_ephemeral_env_confirmation = self._is_enabled_env_flag(COBRA_DEV_EPHEMERAL_CONFIRM_ENV)
-        dev_ephemeral_cli_confirmation = bool(getattr(args, "dev_ephemeral_key", False))
-
-        if dev_mode_enabled and dev_ephemeral_env_confirmation and dev_ephemeral_cli_confirmation:
-            environ[SQLITE_DB_KEY_ENV] = secrets.token_urlsafe(32)
-            logging.getLogger(__name__).warning(
-                "Modo desarrollo confirmado para comando '%s' (%s=1 + %s=1 + --dev-ephemeral-key): usando clave efímera local para %s.",
-                command_name,
-                COBRA_DEV_MODE_ENV,
-                COBRA_DEV_EPHEMERAL_CONFIRM_ENV,
-                SQLITE_DB_KEY_ENV,
-            )
-            return
-
-        raise RuntimeError(
-            f"Falta la variable de entorno 'SQLITE_DB_KEY' (clave requerida por comando '{command_name}'). "
-            "Configúrala antes de iniciar la CLI (ejemplo: "
-            "export SQLITE_DB_KEY='clave-segura'). Para pruebas locales "
-            "controladas puedes habilitar una clave efímera solo si confirmas "
-            f"explícitamente {COBRA_DEV_MODE_ENV}=1, "
-            f"{COBRA_DEV_EPHEMERAL_CONFIRM_ENV}=1 y el flag --dev-ephemeral-key."
+        ensure_sqlite_db_key_for_command(
+            command_name=command_name,
+            dev_ephemeral_cli_confirmation=bool(getattr(args, "dev_ephemeral_key", False)),
         )
 
     def _configure_cli_options(self, parser: CustomArgumentParser) -> None:
@@ -456,7 +437,7 @@ class CliApplication:
         ui_choices = ("v1", "v2") if self._is_internal_v1_ui_enabled() else ("v2",)
         parser.add_argument("--ui", choices=ui_choices, default="v2", help=argparse.SUPPRESS)
         parser.add_argument("--lang",
-                          default=environ.get("COBRA_LANG", AppConfig.DEFAULT_LANGUAGE),
+                          default=environ.get(COBRA_LANG_ENV, AppConfig.DEFAULT_LANGUAGE),
                           help=_("Interface language code"))
         parser.add_argument("--no-color", action="store_true",
                           help=_("Disable colored output"))

--- a/tests/unit/test_cli_sqlite_db_key.py
+++ b/tests/unit/test_cli_sqlite_db_key.py
@@ -34,7 +34,7 @@ def test_cli_genera_clave_efimera_solo_con_triple_confirmacion(monkeypatch):
     app = CliApplication()
     args = type("Args", (), {"dev_ephemeral_key": True})()
 
-    with patch("cobra.cli.cli.secrets.token_urlsafe", return_value="ephemeral-key") as token_mock:
+    with patch("pcobra.cli.secrets.token_urlsafe", return_value="ephemeral-key") as token_mock:
         app._ensure_sqlite_db_key(args=args)
 
     assert token_mock.call_count == 1


### PR DESCRIPTION
### Motivation
- Separar responsabilidades para que la gestión de entorno (.env, defaults y validaciones) viva en el entrypoint canónico `src/pcobra/cli.py` y la lógica de parseo/dispatch quede en `src/pcobra/cobra/cli/cli.py`.
- Evitar duplicación de lógica en wrappers legacy y garantizar que sigan delegando al entrypoint canónico sin implementar validaciones de entorno por su cuenta.

### Description
- Añadí constantes de entorno compartidas y helpers en `src/pcobra/cli.py`: `SQLITE_DB_KEY_ENV`, `COBRA_DEV_MODE_ENV`, `COBRA_DEV_EPHEMERAL_CONFIRM_ENV`, `COBRA_ALLOW_INSECURE_*`, `COBRA_LANG_ENV`, la función `env_flag_activado(...)` y `ensure_sqlite_db_key_for_command(...)` para centralizar la validación/generación de la clave `SQLITE_DB_KEY`.
- Cambié `src/pcobra/cobra/cli/cli.py` para importar y delegar en los helpers de `pcobra.cli` (`ensure_sqlite_db_key_for_command`, `env_flag_activado`, y constantes) y así reducir la lógica de entorno dentro del flujo de comandos.
- Ajusté el proxy legacy `cobra/cli/cli.py` con una anotación de compatibilidad mínima para mantener la paridad textual con el shim canónico y pasar la verificación de consistencia entre wrappers.
- Actualicé un test unitario para mockear la generación efímera desde la nueva ubicación (`pcobra.cli.secrets.token_urlsafe`) y añadí/importé los símbolos necesarios en `src/pcobra/cobra/cli/cli.py`.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_env_bootstrap.py tests/unit/test_cli_sqlite_db_key.py tests/unit/test_cli_wrapper_consistency.py` y corregí una divergencia en el proxy legacy que provocó una primera falla; tras el ajuste todos los tests relevantes pasaron.
- Resultado final de la suite ejecutada: `8 passed` con `1` advertencia externa de deprecación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca7579a8c83279d3f08171cce8346)