### PR TITLE
Robustecer flujo CLI sin comando y acceso seguro a atributos opcionales

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -1022,7 +1022,7 @@ class CliApplication:
         command = getattr(args, "cmd", None)
         if command == "menu":
             return self.run_menu(args)
-        if not command:
+        if command is None:
             if self.parser is not None:
                 self.parser.print_help()
                 return 1
@@ -1037,7 +1037,8 @@ class CliApplication:
             result = command.run(args)
             return 0 if result is None else result
         except Exception as exc:
-            return self._handle_execution_error(exc, args.lang, debug_activo)
+            language = str(getattr(args, "lang", AppConfig.DEFAULT_LANGUAGE))
+            return self._handle_execution_error(exc, language, debug_activo)
 
     def run(self, argv: Optional[List[str]] = None) -> int:
         with self.resource_management():
@@ -1063,9 +1064,9 @@ class CliApplication:
                         "SQLITE_DB_KEY no requerida por comando '%s'.", command_name
                     )
                 self._enforce_runtime_safety_policy(args)
-                debug_activo = bool(args.debug)
-                setup_gettext(args.lang)
-                messages.disable_colors(args.no_color)
+                debug_activo = bool(getattr(args, "debug", False))
+                setup_gettext(str(getattr(args, "lang", AppConfig.DEFAULT_LANGUAGE)))
+                messages.disable_colors(bool(getattr(args, "no_color", False)))
                 if getattr(args, "legacy_imports", False):
                     os.environ["PCOBRA_ENABLE_LEGACY_IMPORTS"] = "1"
                     messages.mostrar_info(

--- a/tests/unit/test_cli_execution_error_output.py
+++ b/tests/unit/test_cli_execution_error_output.py
@@ -109,6 +109,23 @@ def test_run_propaga_debug_activo_hacia_execute_command():
     mock_execute_command.assert_called_once_with(args, debug_activo=False)
 
 
+def test_run_tolera_argumentos_opcionales_ausentes_fuera_de_comando():
+    app = CliApplication()
+    args = argparse.Namespace(cmd=None)
+
+    with patch.object(app, "initialize"), patch.object(app, "_parse_arguments", return_value=args), patch.object(
+        app, "execute_command", return_value=1
+    ) as mock_execute_command, patch("cobra.cli.cli.messages.mostrar_logo"), patch(
+        "cobra.cli.cli.messages.disable_colors"
+    ) as mock_disable_colors, patch("cobra.cli.cli.setup_gettext") as mock_setup_gettext:
+        result = app.run([])
+
+    assert result == 1
+    mock_execute_command.assert_called_once_with(args, debug_activo=False)
+    mock_setup_gettext.assert_called()
+    mock_disable_colors.assert_called_once_with(False)
+
+
 def test_run_bloquea_fallback_inseguro_en_ci_sin_override(monkeypatch):
     app = CliApplication()
     args = argparse.Namespace(


### PR DESCRIPTION
### Motivation
- Asegurar que el flujo `run() -> _parse_arguments() -> execute_command()` maneje explícitamente el caso en que no existe `args.cmd` mostrando la ayuda y retornando `1` en lugar de caer en un comportamiento implícito.
- Evitar cualquier fallback implícito a `InteractiveCommand` cuando `cmd` es `None` y prevenir `AttributeError` por accesos a atributos opcionales fuera de comandos concretos.

### Description
- En `execute_command()` se cambia la comprobación a `command is None` y se invoca `self.parser.print_help()` devolviendo `1` si no hay comando resuelto y el parser está disponible, evitando ejecutar `command.run(...)` en ese caso.
- Al manejar excepciones en `execute_command()` se obtiene `lang` con `getattr(args, "lang", AppConfig.DEFAULT_LANGUAGE)` para evitar `AttributeError` si `lang` falta en `args`.
- En `run()` se endurecen los accesos a `debug`, `lang` y `no_color` usando `getattr(..., default)` antes de configurar `setup_gettext()` y `messages.disable_colors()` para tolerar `Namespace` parciales fuera de comandos.
- Se añadió la prueba `test_run_tolera_argumentos_opcionales_ausentes_fuera_de_comando` en `tests/unit/test_cli_execution_error_output.py` que valida que `run()` tolera un `args` mínimo con solo `cmd=None` y sigue un comportamiento controlado.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_default_command.py tests/unit/test_cli_execution_error_output.py` y se detectaron 3 fallos en `test_handle_execution_error_*` relacionados con expectativas sobre llamadas a `logging.error`, por lo que esos tests fallaron (preexistente/efecto colateral de la ruta de logging en tests concretos).
- Ejecuté de forma focalizada `pytest -q tests/unit/test_cli_default_command.py::test_no_command_prints_help_and_does_not_run_default tests/unit/test_cli_execution_error_output.py::test_run_tolera_argumentos_opcionales_ausentes_fuera_de_comando` y ambas pruebas pasaron correctamente.
- Los cambios introducidos no tocan la superficie pública de comandos `run`, `build`, `test` y `mod` y las pruebas añadidas verifican la regresión específica que se busca corregir.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca89fb0748327a32bbfe3fd63be67)