### PR TITLE
docs(env): aclarar variables de onboarding y defaults seguros en .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,20 @@
-# Required (onboarding local): encryption key for SQLitePlus cache.
+# === Configuración mínima para onboarding local ===
+# Obligatoria: clave de cifrado/derivación para SQLitePlus.
+# Seguridad por defecto: reemplaza este valor en entornos no locales.
 SQLITE_DB_KEY=dev-key-change-me
 
-# Optional: override SQLitePlus database location.
+# Opcional: ruta explícita de la base SQLitePlus.
+# Si no se define en runtime, la CLI puede usar este mismo valor por defecto.
 COBRA_DB_PATH=~/.cobra/sqliteplus/core.db
 
-# Optional (safe default): keep dynamic package install disabled.
+# Opcional (seguro por defecto): 0 mantiene desactivada la instalación dinámica.
+# Para habilitarla explícitamente (riesgo mayor), usar 1 solo en entornos controlados.
 COBRA_USAR_INSTALL=0
 
-# Optional (safe default): do not alter PATH during CLI bootstrap.
-# Compatibility: CLI acepta COBRA_CLI_BOOTSTRAP_PATH y PCOBRA_CLI_BOOTSTRAP_PATH.
+# Opcional (seguro por defecto): 0 evita modificar PATH durante bootstrap de la CLI.
+# Compatibilidad runtime: la CLI acepta COBRA_CLI_BOOTSTRAP_PATH (preferido)
+# y también PCOBRA_CLI_BOOTSTRAP_PATH (alias heredado).
 COBRA_CLI_BOOTSTRAP_PATH=0
 
-# Optional: plaintext logs for local development.
+# Opcional: formato de logs legible para desarrollo local.
 COBRA_LOG_FORMATTER=text


### PR DESCRIPTION
### Motivation
- Clarificar las variables de entorno mínimas para onboarding local (`SQLITE_DB_KEY`, `COBRA_DB_PATH`) y evitar activar comportamientos peligrosos por defecto (`COBRA_USAR_INSTALL`, `COBRA_CLI_BOOTSTRAP_PATH`).

### Description
- Actualiza `.env.example` para incluir `SQLITE_DB_KEY=dev-key-change-me` (obligatoria), `COBRA_DB_PATH=~/.cobra/sqliteplus/core.db`, `COBRA_USAR_INSTALL=0`, `COBRA_CLI_BOOTSTRAP_PATH=0` y `COBRA_LOG_FORMATTER=text`, añadiendo comentarios que indican obligatoriedad/opcionalidad, consideraciones de seguridad y la compatibilidad runtime con el alias `PCOBRA_CLI_BOOTSTRAP_PATH`.

### Testing
- Ejecutado `pytest -q tests/unit/test_env_example_contract.py` y pasó (1 test, 1 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecabf9ee708327ab7d2adebfc05aa5)