### PR TITLE
Ajusta logging de .env en entrypoints/CLI para evitar warnings en arranque

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -200,13 +200,20 @@ def configurar_entorno() -> None:
         try:
             load_dotenv(dotenv_path=_ENV_FILE)
         except OSError as exc:
-            logger.error("No se pudo acceder al archivo .env: %s", exc)
+            logger.error(
+                "No se pudo acceder al archivo .env: %s. Verifica permisos de lectura/escritura y la ruta del proyecto.",
+                exc,
+            )
             return
         except Exception:  # pragma: no cover - registro y propagación
             logger.exception("Error inesperado al cargar variables de entorno")
             raise
 
     if not (os.environ.get(SQLITE_DB_KEY_ENV) or "").strip():
+        logger.error(
+            "Falta %s en el entorno. Defínela en .env o expórtala antes de ejecutar la CLI.",
+            SQLITE_DB_KEY_ENV,
+        )
         raise RuntimeError(
             f"{SQLITE_DB_KEY_ENV} es obligatoria y está ausente o vacía. "
             f"Define {SQLITE_DB_KEY_ENV}=<tu_clave> en .env o exporta la variable antes de ejecutar la CLI."

--- a/src/pcobra/core/main.py
+++ b/src/pcobra/core/main.py
@@ -27,7 +27,10 @@ def _cargar_dotenv() -> None:
     try:
         cargado = load_dotenv()
     except OSError as exc:
-        logger.error("No se pudo acceder al archivo .env: %s", exc)
+        logger.error(
+            "No se pudo acceder al archivo .env: %s. Verifica permisos y que el archivo exista en el directorio actual.",
+            exc,
+        )
         return
     except Exception:  # pragma: no cover - registro defensivo
         logger.exception("Error inesperado al cargar el archivo .env")

--- a/tests/unit/test_cli_env_bootstrap.py
+++ b/tests/unit/test_cli_env_bootstrap.py
@@ -38,17 +38,19 @@ def test_configurar_entorno_autocrea_env_desde_example(tmp_path, monkeypatch, ca
     assert "COBRA_DB_PATH" in cli.os.environ
 
 
-def test_configurar_entorno_falla_si_falta_sqlite_db_key(tmp_path, monkeypatch):
+def test_configurar_entorno_falla_si_falta_sqlite_db_key(tmp_path, monkeypatch, caplog):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("SQLITE_DB_KEY", raising=False)
 
     monkeypatch.setattr(cli, "load_dotenv", lambda **_kwargs: False)
+    caplog.set_level("ERROR", logger="pcobra.cli")
 
     try:
         cli.configurar_entorno()
         raise AssertionError("Se esperaba RuntimeError cuando falta SQLITE_DB_KEY")
     except RuntimeError as exc:
-        assert "Falta SQLITE_DB_KEY" in str(exc)
+        assert "SQLITE_DB_KEY es obligatoria y está ausente o vacía" in str(exc)
+    assert "Falta SQLITE_DB_KEY en el entorno" in caplog.text
 
 
 def test_configurar_entorno_setea_db_path_por_default_con_sqlite_db_key(tmp_path, monkeypatch):


### PR DESCRIPTION
### Motivation
- Evitar mensajes tipo warning innecesarios durante el arranque normal y ofrecer mensajes de error más accionables en español cuando realmente falle la carga de `.env`.
- Asegurar que la ausencia de la variable crítica `SQLITE_DB_KEY` quede registrada explícitamente como `ERROR` antes de lanzar la excepción para facilitar diagnóstico en entornos de usuario.

### Description
- En `src/pcobra/cli.py` se mejoró el `logger.error` para `OSError` al intentar `load_dotenv` y se añadió un `logger.error` explícito cuando falta `SQLITE_DB_KEY`, dejando la autocreación desde `.env.example` en `INFO`.
- En `src/pcobra/core/main.py` se mejoró el `logger.error` para `OSError` al cargar `.env` para que el mensaje sea más accionable (permiso/ruta).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecad5ac72c8327bcfc1cd258702a7c)