### PR TITLE
Expose `repl` in public CLI v2 command contract

### DIFF
--- a/src/pcobra/cobra/architecture/overview.py
+++ b/src/pcobra/cobra/architecture/overview.py
@@ -13,7 +13,7 @@ from typing import Final
 
 
 PUBLIC_LANGUAGE_BOUNDARY: Final[str] = "cobra"
-PUBLIC_CLI_V2_COMMANDS: Final[tuple[str, ...]] = ("run", "build", "test", "mod")
+PUBLIC_CLI_V2_COMMANDS: Final[tuple[str, ...]] = ("run", "build", "test", "mod", "repl")
 
 # Toda ruta de usuario termina resolviendo backend mediante esta fachada.
 USER_ROUTE_BACKEND_ENTRYPOINT: Final[str] = "pcobra.cobra.build.backend_pipeline"
@@ -73,9 +73,9 @@ def validate_public_architecture_overview() -> None:
     if PUBLIC_LANGUAGE_BOUNDARY != "cobra":
         raise RuntimeError("La frontera pública de lenguaje debe ser únicamente 'cobra'.")
 
-    if PUBLIC_CLI_V2_COMMANDS != ("run", "build", "test", "mod"):
+    if PUBLIC_CLI_V2_COMMANDS != ("run", "build", "test", "mod", "repl"):
         raise RuntimeError(
-            "La CLI pública v2 debe exponer exactamente run/build/test/mod."
+            "La CLI pública v2 debe exponer exactamente run/build/test/mod/repl."
         )
 
     if USER_ROUTE_BACKEND_ENTRYPOINT != "pcobra.cobra.build.backend_pipeline":

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -139,6 +139,7 @@ class AppConfig:
         CommandClassRoute("pcobra.cobra.cli.commands_v2.build_cmd", "BuildCommandV2"),
         CommandClassRoute("pcobra.cobra.cli.commands_v2.test_cmd", "TestCommandV2"),
         CommandClassRoute("pcobra.cobra.cli.commands_v2.mod_cmd", "ModCommandV2"),
+        CommandClassRoute("pcobra.cobra.cli.commands_v2.repl_cmd", "ReplCommandV2"),
     ]
     V2_COMMAND_CLASSES: List[Type[BaseCommand]] = []
 

--- a/src/pcobra/cobra/cli/commands_v2/__init__.py
+++ b/src/pcobra/cobra/cli/commands_v2/__init__.py
@@ -3,6 +3,7 @@ from os import environ
 from pcobra.cobra.cli.commands_v2.build_cmd import BuildCommandV2
 from pcobra.cobra.cli.commands_v2.mod_cmd import ModCommandV2
 from pcobra.cobra.cli.commands_v2.run_cmd import RunCommandV2
+from pcobra.cobra.cli.commands_v2.repl_cmd import ReplCommandV2
 from pcobra.cobra.cli.commands_v2.test_cmd import TestCommandV2
 
 COBRA_ENABLE_LEGACY_CLI_ENV = "COBRA_INTERNAL_ENABLE_LEGACY_CLI"
@@ -22,6 +23,7 @@ __all__ = [
     "BuildCommandV2",
     "TestCommandV2",
     "ModCommandV2",
+    "ReplCommandV2",
     "LegacyCommandGroupV2",
     "COBRA_ENABLE_LEGACY_CLI_ENV",
     "is_legacy_cli_enabled",

--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+from pcobra.cobra.core.runtime import InterpretadorCobra
+
+
+class ReplCommandV2(BaseCommand):
+    """Comando v2 público para iniciar el REPL de Cobra."""
+
+    name = "repl"
+    capability = "execute"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._delegate = InteractiveCommand(InterpretadorCobra())
+        self._delegate.name = self.name
+
+    def register_subparser(self, subparsers: Any):
+        return self._delegate.register_subparser(subparsers)
+
+    def run(self, args: Any) -> int:
+        return self._delegate.run(args)

--- a/src/pcobra/cobra/cli/public_command_policy.py
+++ b/src/pcobra/cobra/cli/public_command_policy.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from os import environ
 from typing import Iterable
 
-PUBLIC_COMMANDS_CONTRACT: tuple[str, ...] = ("run", "build", "test", "mod")
+PUBLIC_COMMANDS_CONTRACT: tuple[str, ...] = ("run", "build", "test", "mod", "repl")
 PUBLIC_COMMANDS: tuple[str, ...] = PUBLIC_COMMANDS_CONTRACT
 if PUBLIC_COMMANDS != PUBLIC_COMMANDS_CONTRACT:
     raise RuntimeError(
         "Contrato público inválido: PUBLIC_COMMANDS debe mantenerse en "
-        "('run', 'build', 'test', 'mod')."
+        "('run', 'build', 'test', 'mod', 'repl')."
     )
 INTERNAL_COMMANDS: tuple[str, ...] = (
     "legacy",
@@ -42,7 +42,7 @@ LEGACY_OBSOLETE_COMMANDS: tuple[str, ...] = (
 )
 COMMAND_VISIBILITY_MATRIX_MARKDOWN = """| Clase | Comandos |
 |---|---|
-| Públicos (UI v2) | run, build, test, mod |
+| Públicos (UI v2) | run, build, test, mod, repl |
 | Internos (UI v2 / development) | legacy, debug, devops |
 | Legacy públicos (UI v1) | *(ninguno; reservado a `development`)* |
 | Legacy internos (UI v1) | compilar, cache, contenedor, gui, jupyter, qualia, agix |

--- a/tests/integration/golden/cli_ui_v2_help_public.golden
+++ b/tests/integration/golden/cli_ui_v2_help_public.golden
@@ -4,18 +4,19 @@ usage: cobra [-h] [--version] [--ayuda] [--format] [--debug] [-v] [--no-safe]
              [--no-color] [--extra-validators extra_validators]
              [--legacy-imports] [--dev-ephemeral-key] [--plugins-safe-mode]
              [--plugins-unsafe-mode] [--plugins-allowlist plugins_allowlist]
-             {run,build,test,mod} ...
+             {run,build,test,mod,repl} ...
 
 cli de cobra para ejecutar e interpretar scripts, transpilar código a otros
 lenguajes o usar ambos flujos según --modo (cobra, transpilar, mixto). modo
 cobra = solo programar/interpretar cobra sin codegen.
 
 positional arguments:
-  {run,build,test,mod}
+  {run,build,test,mod,repl}
     run                 run a cobra file
     build               build/transpile a cobra file
     test                validate project output across runtimes
     mod                 manage cobra modules
+    repl                inicia el modo interactivo
 
 options:
   -h, --help            show this help message and exit
@@ -56,3 +57,6 @@ options:
                         lista permitida de plugins separados por coma (ruta
                         exacta, módulo o prefix:/sha256:hash). también vía
                         cobra_plugins_allowlist.
+
+ejemplos públicos: cobra run <archivo.co> cobra build <archivo.co> cobra test
+<archivo.co> cobra mod <list|install|remove|publish|search>

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -17,7 +17,7 @@ def _public_env() -> dict[str, str]:
 
 
 def test_cli_public_commands_contract_is_stable():
-    assert PUBLIC_COMMANDS == ("run", "build", "test", "mod")
+    assert PUBLIC_COMMANDS == ("run", "build", "test", "mod", "repl")
 
 
 def test_cli_help_public_contract_snapshot():
@@ -35,7 +35,7 @@ def test_cli_help_public_contract_snapshot():
         Path(__file__).parent / "golden" / "cli_ui_v2_help_public.golden"
     ).read_text(encoding="utf-8")
     assert " ".join(result.stdout.lower().split()) == " ".join(expected_snapshot.split())
-    for command in ("run", "build", "test", "mod"):
+    for command in ("run", "build", "test", "mod", "repl"):
         assert f" {command} " in f" {result.stdout.lower()} "
     assert "\n  menu " not in result.stdout.lower()
     assert "\n  legacy " not in result.stdout.lower()

--- a/tests/unit/test_architecture_overview.py
+++ b/tests/unit/test_architecture_overview.py
@@ -10,7 +10,7 @@ from pcobra.cobra.architecture.overview import (
 
 def test_overview_declara_frontera_publica_unica():
     assert PUBLIC_LANGUAGE_BOUNDARY == "cobra"
-    assert PUBLIC_CLI_V2_COMMANDS == ("run", "build", "test", "mod")
+    assert PUBLIC_CLI_V2_COMMANDS == ("run", "build", "test", "mod", "repl")
     assert USER_ROUTE_BACKEND_ENTRYPOINT == "pcobra.cobra.build.backend_pipeline"
 
 

--- a/tests/unit/test_public_command_policy.py
+++ b/tests/unit/test_public_command_policy.py
@@ -1,8 +1,23 @@
 from cobra.cli.public_command_policy import (
     PROFILE_DEVELOPMENT,
     PROFILE_PUBLIC,
+    filter_commands_for_profile,
     filter_legacy_commands_for_profile,
 )
+
+
+def test_filter_commands_publico_permite_solo_superficie_v2_publica():
+    visibles = filter_commands_for_profile(
+        ("run", "build", "test", "mod", "repl", "legacy", "debug"),
+        PROFILE_PUBLIC,
+    )
+    assert visibles == {"run", "build", "test", "mod", "repl"}
+
+
+def test_filter_commands_development_permite_toda_superficie_v2():
+    comandos = ("run", "build", "test", "mod", "repl", "legacy", "debug")
+    visibles = filter_commands_for_profile(comandos, PROFILE_DEVELOPMENT)
+    assert visibles == set(comandos)
 
 
 def test_filter_legacy_commands_publico_bloquea_toda_superficie_v1():


### PR DESCRIPTION
### Motivation
- Hacer que el REPL sea parte de la superficie pública de la CLI v2 para que aparezca en la ayuda pública y forme parte del contrato estable de comandos expuestos.
- Mantener coherencia entre el contrato público usado por validaciones/arquitectura y la lista real de comandos registrados en runtime.

### Description
- Añadido `repl` a `PUBLIC_COMMANDS_CONTRACT` y actualizado `COMMAND_VISIBILITY_MATRIX_MARKDOWN` en `src/pcobra/cobra/cli/public_command_policy.py`.
- Implementado `ReplCommandV2` como wrapper que delega en el `InteractiveCommand` existente y añadido en `src/pcobra/cobra/cli/commands_v2/repl_cmd.py`.
- Registrado `ReplCommandV2` en la lista de rutas v2 y exportado desde `src/pcobra/cobra/cli/commands_v2/__init__.py`, y registrado el route en `src/pcobra/cobra/cli/cli.py`.
- Alineado el literal de contrato en `src/pcobra/cobra/architecture/overview.py` y ajustada la validación que esperaba la tupla exacta de comandos.
- Actualizados archivos de prueba y golden: `tests/integration/golden/cli_ui_v2_help_public.golden`, `tests/integration/test_cli_public_help_contract.py`, `tests/unit/test_public_command_policy.py` y `tests/unit/test_architecture_overview.py` para incluir `repl` en las aserciones y snapshot.

### Testing
- Ejecuté `pytest -q tests/unit/test_public_command_policy.py tests/integration/test_cli_public_help_contract.py tests/integration/test_cli_ui_v2.py tests/unit/test_architecture_overview.py` inicialmente, lo que mostró errores relacionados con snapshot/ayuda y un par de aserciones de arquitectura (4 fallos); esto motivó actualizar el golden y las aserciones.
- Después de ajustar golden y tests, volví a ejecutar un conjunto focalizado con `pytest -q tests/unit/test_public_command_policy.py tests/integration/test_cli_public_help_contract.py::test_cli_public_commands_contract_is_stable tests/integration/test_cli_public_help_contract.py::test_cli_help_public_contract_snapshot tests/integration/test_cli_ui_v2.py::test_cli_ui_v2_help_snapshot_publico_no_expone_legacy tests/unit/test_architecture_overview.py::test_overview_declara_frontera_publica_unica` y todos los tests objetivo pasaron (8 passed, 1 warning).
- El cambio quedó commiteado y listo para revisión; el commit contiene los archivos listados en la descripción y el snapshot actualizado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc0cbef788327be32d14757c97019)