### PR TITLE
feat(cli): registrar subcomando v2 `repl` de forma explícita

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -1,8 +1,13 @@
 from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
-from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+from pcobra.cobra.cli.commands.interactive_cmd import (
+    InteractiveCommand,
+    SANDBOX_DOCKER_CHOICES,
+)
+from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.core.runtime import InterpretadorCobra
+from pcobra.cobra.cli.target_policies import parse_runtime_target
 
 
 class ReplCommandV2(BaseCommand):
@@ -17,7 +22,36 @@ class ReplCommandV2(BaseCommand):
         self._delegate.name = self.name
 
     def register_subparser(self, subparsers: Any):
-        return self._delegate.register_subparser(subparsers)
+        parser = subparsers.add_parser(self.name, help=_("Start Cobra REPL"))
+        parser.add_argument(
+            "--sandbox",
+            action="store_true",
+            help=_("Execute each line in sandbox mode"),
+        )
+        parser.add_argument(
+            "--sandbox-docker",
+            type=lambda value: parse_runtime_target(
+                value,
+                allowed_targets=SANDBOX_DOCKER_CHOICES,
+                capability="modo interactivo con Docker",
+            ),
+            choices=SANDBOX_DOCKER_CHOICES,
+            help=_("Docker runtime target for REPL"),
+        )
+        parser.add_argument(
+            "--memory-limit",
+            type=int,
+            default=self._delegate.MEMORY_LIMIT_MB,
+            help=_("Memory limit in MB"),
+            metavar="MB",
+        )
+        parser.add_argument(
+            "--ignore-memory-limit",
+            action="store_true",
+            help=_("Continue even if memory limit cannot be applied"),
+        )
+        parser.set_defaults(cmd=self)
+        return parser
 
     def run(self, args: Any) -> int:
         return self._delegate.run(args)


### PR DESCRIPTION
### Motivation
- Alinear el comando v2 `repl` con el patrón de los demás comandos v2 para registrar su propio subparser en lugar de depender de rutas legacy o delegaciones implícitas.
- Exponer las opciones del REPL de forma pública en la interfaz de línea de comandos sin introducir aliases ni rutas legacy.

### Description
- Modifiqué `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` para que `ReplCommandV2` tenga `name = "repl"` y registre su subparser con `subparsers.add_parser(self.name, ...)` siguiendo el patrón v2. 
- Añadí los flags del REPL (`--sandbox`, `--sandbox-docker`, `--memory-limit`, `--ignore-memory-limit`) y dejé `parser.set_defaults(cmd=self)` para que el dispatcher use la instancia v2. 
- Mantengo la delegación de `run()` a `InteractiveCommand(InterpretadorCobra())` para preservar el comportamiento existente del REPL. 
- Verifiqué que `AppConfig.V2_COMMAND_ROUTES` en `src/pcobra/cobra/cli/cli.py` ya contiene la entrada `pcobra.cobra.cli.commands_v2.repl_cmd.ReplCommandV2`, por lo que no fue necesaria ninguna modificación adicional en `cli.py`.

### Testing
- Ejecuté `python -m compileall src/pcobra/cobra/cli/commands_v2/repl_cmd.py src/pcobra/cobra/cli/cli.py` y la compilación tuvo éxito. 
- Verifiqué la presencia de la ruta `ReplCommandV2` con búsquedas (`rg`) en los ficheros relevantes y confirmé que `V2_COMMAND_ROUTES` incluye `repl`.
- No se ejecutaron tests unitarios adicionales automatizados en esta rama.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc349d0ec83278320f9152382a315)