### PR TITLE
Implementar bucle principal del comando repl v2

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -6,8 +6,10 @@ from pcobra.cobra.cli.commands.interactive_cmd import (
     SANDBOX_DOCKER_CHOICES,
 )
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.messages import mostrar_info
 from pcobra.cobra.core.runtime import InterpretadorCobra
 from pcobra.cobra.cli.target_policies import parse_runtime_target
+from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
 
 
 class ReplCommandV2(BaseCommand):
@@ -54,4 +56,66 @@ class ReplCommandV2(BaseCommand):
         return parser
 
     def run(self, args: Any) -> int:
-        return self._delegate.run(args)
+        buffer: list[str] = []
+        self._delegate._estado_repl = self._delegate._crear_estado_repl()
+
+        sandbox = bool(getattr(args, "sandbox", False))
+        sandbox_docker = getattr(args, "sandbox_docker", None)
+
+        while True:
+            try:
+                linea = input(">>> " if not buffer else "... ")
+            except KeyboardInterrupt:
+                if buffer:
+                    mostrar_info(_("Entrada multilinea cancelada."))
+                    buffer.clear()
+                    self._delegate._estado_repl = self._delegate._crear_estado_repl()
+                    continue
+                mostrar_info(_("Interrupción recibida. Saliendo del REPL."))
+                break
+            except EOFError:
+                if buffer:
+                    mostrar_info(_("Entrada multilinea cancelada por fin de archivo."))
+                    buffer.clear()
+                    self._delegate._estado_repl = self._delegate._crear_estado_repl()
+                    continue
+                mostrar_info(_("Fin de entrada. Saliendo del REPL."))
+                break
+
+            linea = sanitize_input(linea)
+            if not linea:
+                continue
+
+            comando = linea.strip()
+            if comando in {"salir", "exit"} and not buffer:
+                mostrar_info(_("Saliendo..."))
+                break
+
+            try:
+                codigo = self._delegate._actualizar_buffer_y_obtener_codigo_listo(
+                    buffer,
+                    linea,
+                )
+            except Exception as err:
+                categoria = self._delegate._clasificar_error_repl(err)
+                self._delegate._log_error(categoria, err)
+                buffer.clear()
+                self._delegate._estado_repl = self._delegate._crear_estado_repl()
+                continue
+
+            if codigo is None:
+                continue
+
+            try:
+                if sandbox:
+                    self._delegate._ejecutar_en_sandbox(codigo)
+                elif sandbox_docker:
+                    self._delegate._ejecutar_en_docker(codigo, sandbox_docker)
+                else:
+                    self._delegate.ejecutar_codigo(codigo)
+            except Exception as err:
+                categoria = self._delegate._clasificar_error_repl(err)
+                self._delegate._log_error(categoria, err)
+                continue
+
+        return 0


### PR DESCRIPTION
### Motivation
- Implementar en `ReplCommandV2` un bucle REPL explícito que cumpla las reglas de interacción solicitadas (buffer de líneas, prompts `>>> ` / `... `, y manejo de interrupciones). 
- Evitar introducir comandos especiales o cambios semánticos en el comportamiento del REPL v2 y garantizar que errores de sintaxis/ejecución se muestren y el loop continúe.

### Description
- Se añadió un bucle principal en `src/pcobra/cobra/cli/commands_v2/repl_cmd.py::ReplCommandV2.run` que usa `buffer: list[str] = []` y alterna el prompt entre `>>> ` y `... ` según el contenido del buffer. 
- Se incorporó saneado de entrada con `sanitize_input`, y se importó `mostrar_info` para mensajes amigables sobre cancelaciones y salida. 
- Reglas de flujo implementadas: líneas vacías se ignoran, `salir`/`exit` terminan la sesión solo si no hay buffer, y `KeyboardInterrupt`/`EOFError` muestran mensajes y limpian estado cuando hay entrada multilinea en curso. 
- El loop delega análisis/ejecución al `InteractiveCommand` existente llamando a `_actualizar_buffer_y_obtener_codigo_listo`, `_ejecutar_en_sandbox`/`_ejecutar_en_docker` o `ejecutar_codigo`, y captura/registro de errores usando `_clasificar_error_repl` y `_log_error` para continuar la sesión tras fallos.

### Testing
- Se compiló el archivo modificado con `python -m compileall -q src/pcobra/cobra/cli/commands_v2/repl_cmd.py` y la compilación fue exitosa. 
- Se probó de manera automatizada la sesión REPL con `printf 'exit\n' | python -m pcobra.cobra.cli.cli repl` y el REPL respondió mostrando el mensaje de salida exitosamente. 
- Se intentó ejecutar `python -m pytest tests/unit/test_cli2.py -q`, la ejecución reportó fallos (`3 failed`) por `SystemExit` proveniente del parseo de argumentos en ese test; esos fallos parecen relacionados con la invocación de `main()` en el contexto de pytest y no con la lógica del bucle añadido.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eccf33ecf4832783553b7ba8493a21)