### PR TITLE
Ajusta ReplCommandV2 para parseo canónico incremental y detección de bloque incompleto

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -5,8 +5,10 @@ from pcobra.cobra.cli.commands.interactive_cmd import (
     InteractiveCommand,
     SANDBOX_DOCKER_CHOICES,
 )
+from pcobra.cobra.cli.execution_pipeline import prevalidar_y_parsear_codigo
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.messages import mostrar_info
+from pcobra.cobra.core import ParserError
 from pcobra.cobra.core.runtime import InterpretadorCobra
 from pcobra.cobra.cli.target_policies import parse_runtime_target
 from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
@@ -17,11 +19,29 @@ class ReplCommandV2(BaseCommand):
 
     name = "repl"
     capability = "execute"
+    _MARCADORES_BLOQUE_INCOMPLETO = (
+        "se esperaba 'fin' para cerrar",
+        "tipotoken.eof",
+        "se esperaba ')' para cerrar",
+        "se esperaba ')' al final",
+        "se esperaba ']' al final",
+        "se esperaba '}' al final",
+    )
 
     def __init__(self) -> None:
         super().__init__()
         self._delegate = InteractiveCommand(InterpretadorCobra())
         self._delegate.name = self.name
+
+    def es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
+        """Detecta si la excepción corresponde a un bloque aún incompleto."""
+
+        if not isinstance(exc, ParserError):
+            return False
+        mensaje = str(exc).strip().lower()
+        return any(
+            marcador in mensaje for marcador in self._MARCADORES_BLOQUE_INCOMPLETO
+        )
 
     def register_subparser(self, subparsers: Any):
         parser = subparsers.add_parser(self.name, help=_("Start Cobra REPL"))
@@ -91,19 +111,17 @@ class ReplCommandV2(BaseCommand):
                 mostrar_info(_("Saliendo..."))
                 break
 
+            buffer.append(linea)
+            codigo = "\n".join(buffer)
             try:
-                codigo = self._delegate._actualizar_buffer_y_obtener_codigo_listo(
-                    buffer,
-                    linea,
-                )
+                prevalidar_y_parsear_codigo(codigo)
             except Exception as err:
+                if self.es_error_de_bloque_incompleto(err):
+                    continue
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
                 buffer.clear()
                 self._delegate._estado_repl = self._delegate._crear_estado_repl()
-                continue
-
-            if codigo is None:
                 continue
 
             try:
@@ -113,6 +131,7 @@ class ReplCommandV2(BaseCommand):
                     self._delegate._ejecutar_en_docker(codigo, sandbox_docker)
                 else:
                     self._delegate.ejecutar_codigo(codigo)
+                buffer.clear()
             except Exception as err:
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -1,0 +1,86 @@
+import argparse
+
+from cobra.cli.commands_v2.repl_cmd import ReplCommandV2
+from pcobra.cobra.core import ParserError
+
+
+def test_es_error_de_bloque_incompleto_por_mensajes_parser():
+    command = ReplCommandV2()
+
+    assert command.es_error_de_bloque_incompleto(
+        ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+    )
+    assert command.es_error_de_bloque_incompleto(
+        ParserError("Token inesperado en término: TipoToken.EOF")
+    )
+    assert command.es_error_de_bloque_incompleto(
+        ParserError("Se esperaba ']' al final de la lista")
+    )
+    assert not command.es_error_de_bloque_incompleto(
+        ParserError("Se encontró 'fin' inesperado")
+    )
+    assert not command.es_error_de_bloque_incompleto(ValueError("no parser"))
+
+
+def test_repl_v2_mantiene_buffer_hasta_parseo_valido(monkeypatch):
+    command = ReplCommandV2()
+    entradas = iter(["si verdadero:", "imprimir(1)", "fin", "exit"])
+    parse_calls: list[str] = []
+    executed: list[str] = []
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+
+    def _fake_parse(codigo: str):
+        parse_calls.append(codigo)
+        if codigo != "si verdadero:\nimprimir(1)\nfin":
+            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+        return []
+
+    monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.prevalidar_y_parsear_codigo", _fake_parse)
+    monkeypatch.setattr(command._delegate, "ejecutar_codigo", lambda codigo: executed.append(codigo))
+
+    status = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+
+    assert status == 0
+    assert parse_calls == [
+        "si verdadero:",
+        "si verdadero:\nimprimir(1)",
+        "si verdadero:\nimprimir(1)\nfin",
+    ]
+    assert executed == ["si verdadero:\nimprimir(1)\nfin"]
+
+
+def test_repl_v2_limpia_buffer_ante_error_real(monkeypatch):
+    command = ReplCommandV2()
+    entradas = iter(["algo_mal", "exit"])
+    parse_calls: list[str] = []
+    logged: list[str] = []
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+
+    def _fake_parse(codigo: str):
+        parse_calls.append(codigo)
+        raise ParserError("Se encontró 'fin' inesperado")
+
+    monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.prevalidar_y_parsear_codigo", _fake_parse)
+    monkeypatch.setattr(command._delegate, "_log_error", lambda _cat, err: logged.append(str(err)))
+
+    status = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+
+    assert status == 0
+    assert parse_calls == ["algo_mal"]
+    assert logged == ["Se encontró 'fin' inesperado"]


### PR DESCRIPTION
### Motivation

- Unificar el REPL v2 con el pipeline canónico de análisis para detectar bloque incompleto frente a errores reales y mejorar el manejo incremental de entradas multilínea.
- Evitar ejecutar código parcialmente parseado y conservar el buffer hasta que el parseo sea válido.

### Description

- Cambia el bucle de `ReplCommandV2` para agregar cada línea a `buffer` y construir `codigo = "\n".join(buffer)` antes de intentar parsear con `prevalidar_y_parsear_codigo(codigo)`.
- Implementa el helper local `es_error_de_bloque_incompleto(exc)` en `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` que clasifica `ParserError` por patrones reales del parser para distinguir bloques incompletos.
- Si el parseo indica bloque incompleto se mantiene el `buffer` y se continúa pidiendo más líneas (`... `), mientras que en un error real se muestra el error y se limpia el `buffer` y el estado REPL; el `buffer` se limpia solo tras una ejecución satisfactoria.
- Sustituye el flujo anterior basado en `_actualizar_buffer_y_obtener_codigo_listo` por el parseo canónico y añade pruebas unitarias en `tests/unit/test_repl_command_v2.py` que cubren detección de bloque incompleto, acumulación hasta parseo válido y limpieza ante error real.

### Testing

- Ejecutado `pytest -q tests/unit/test_repl_command_v2.py` y las tres pruebas nuevas pasaron (`3 passed`).
- Se verificó manualmente que `prevalidar_y_parsear_codigo` reconoce los mensajes de `ParserError` relevantes y que el REPL conserva/limpia el `buffer` según lo esperado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd3597fb883278ce28ef5b6ac95ea)