### PR TITLE
feat(repl): usar pipeline explícito con intérprete persistente

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -5,7 +5,12 @@ from pcobra.cobra.cli.commands.interactive_cmd import (
     InteractiveCommand,
     SANDBOX_DOCKER_CHOICES,
 )
-from pcobra.cobra.cli.execution_pipeline import prevalidar_y_parsear_codigo
+from pcobra.cobra.cli.execution_pipeline import (
+    PipelineInput,
+    ejecutar_pipeline_explicito,
+    prevalidar_y_parsear_codigo,
+    resolver_interpretador_cls,
+)
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.messages import mostrar_info
 from pcobra.cobra.core import ParserError
@@ -32,6 +37,9 @@ class ReplCommandV2(BaseCommand):
         super().__init__()
         self._delegate = InteractiveCommand(InterpretadorCobra())
         self._delegate.name = self.name
+        self._interpretador_persistente: Any | None = None
+        self._seguro_repl: bool = True
+        self._extra_validators_repl: Any = None
 
     def es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
         """Detecta si la excepción corresponde a un bloque aún incompleto."""
@@ -78,6 +86,12 @@ class ReplCommandV2(BaseCommand):
     def run(self, args: Any) -> int:
         buffer: list[str] = []
         self._delegate._estado_repl = self._delegate._crear_estado_repl()
+        self._seguro_repl = bool(getattr(args, "seguro", True))
+        self._extra_validators_repl = getattr(args, "extra_validators", None)
+        interpretador_cls = resolver_interpretador_cls(
+            module_name=__name__,
+            default_cls=InterpretadorCobra,
+        )
 
         sandbox = bool(getattr(args, "sandbox", False))
         sandbox_docker = getattr(args, "sandbox_docker", None)
@@ -130,7 +144,18 @@ class ReplCommandV2(BaseCommand):
                 elif sandbox_docker:
                     self._delegate._ejecutar_en_docker(codigo, sandbox_docker)
                 else:
-                    self._delegate.ejecutar_codigo(codigo)
+                    setup, _resultado_pipeline = ejecutar_pipeline_explicito(
+                        PipelineInput(
+                            codigo=codigo,
+                            interpretador_cls=interpretador_cls,
+                            safe_mode=self._seguro_repl,
+                            extra_validators=self._extra_validators_repl,
+                            interpretador=self._interpretador_persistente,
+                        ),
+                    )
+                    self._interpretador_persistente = setup.interpretador
+                    self._seguro_repl = setup.safe_mode
+                    self._extra_validators_repl = setup.validadores_extra
                 buffer.clear()
             except Exception as err:
                 categoria = self._delegate._clasificar_error_repl(err)

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -37,7 +37,17 @@ def test_repl_v2_mantiene_buffer_hasta_parseo_valido(monkeypatch):
         return []
 
     monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.prevalidar_y_parsear_codigo", _fake_parse)
-    monkeypatch.setattr(command._delegate, "ejecutar_codigo", lambda codigo: executed.append(codigo))
+    class _Setup:
+        def __init__(self, safe_mode, validadores_extra):
+            self.interpretador = object()
+            self.safe_mode = safe_mode
+            self.validadores_extra = validadores_extra
+
+    def _fake_pipeline(pipeline_input, **_kwargs):
+        executed.append(pipeline_input.codigo)
+        return _Setup(pipeline_input.safe_mode, pipeline_input.extra_validators), None
+
+    monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.ejecutar_pipeline_explicito", _fake_pipeline)
 
     status = command.run(
         argparse.Namespace(
@@ -84,3 +94,44 @@ def test_repl_v2_limpia_buffer_ante_error_real(monkeypatch):
     assert status == 0
     assert parse_calls == ["algo_mal"]
     assert logged == ["Se encontró 'fin' inesperado"]
+
+
+def test_repl_v2_persiste_interpretador_entre_bloques(monkeypatch):
+    command = ReplCommandV2()
+    entradas = iter(["var x = 10", "imprimir(x)", "exit"])
+    interpretadores_recibidos = []
+    estado: dict[str, int] = {}
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+
+    class _Setup:
+        def __init__(self, interpretador):
+            self.interpretador = interpretador
+            self.safe_mode = False
+            self.validadores_extra = None
+
+    def _fake_pipeline(pipeline_input, **_kwargs):
+        interpretadores_recibidos.append(pipeline_input.interpretador)
+        interpretador = pipeline_input.interpretador or estado
+        if pipeline_input.codigo.strip() == "var x = 10":
+            interpretador["x"] = 10
+        if pipeline_input.codigo.strip() == "imprimir(x)":
+            assert interpretador["x"] == 10
+        return _Setup(interpretador), None
+
+    monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.ejecutar_pipeline_explicito", _fake_pipeline)
+    monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.prevalidar_y_parsear_codigo", lambda _codigo: [])
+
+    status = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            seguro=False,
+            extra_validators=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+
+    assert status == 0
+    assert interpretadores_recibidos == [None, estado]


### PR DESCRIPTION
### Motivation
- Garantizar que el REPL v2 reutilice el pipeline canónico de análisis/validación/ejecución y comparta la normalización de `safe_mode`/`extra_validators` usada por `RunService`.
- Mantener un intérprete persistente durante la sesión REPL para que asignaciones en entradas separadas conserven estado.

### Description
- Se añadió estado en `ReplCommandV2`: `self._interpretador_persistente`, `self._seguro_repl` y `self._extra_validators_repl` para controlar la sesión REPL.
- Antes del bucle se resuelve la clase de intérprete con `resolver_interpretador_cls(module_name=__name__, default_cls=InterpretadorCobra)` para replicar el comportamiento de `RunService`.
- En ejecución normal (no `--sandbox` ni `--sandbox-docker`) ahora se invoca `ejecutar_pipeline_explicito(PipelineInput(..., interpretador=self._interpretador_persistente))` y se actualiza `self._interpretador_persistente` con `setup.interpretador`; también se actualizan `safe_mode` y `validadores_extra` desde el `setup` devuelto.
- No se duplicó la lógica de normalización de validadores/seguridad; el pipeline compartido sigue siendo responsable de `safe_mode` y `extra_validators`.
- Archivos modificados: `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` y `tests/unit/test_repl_command_v2.py` (ajustes y nueva prueba de persistencia de intérprete).

### Testing
- Se ejecutó `pytest -q tests/unit/test_repl_command_v2.py` y todos los tests pasaron (`4 passed`).
- Las pruebas incluyen el caso de verificación de persistencia donde `var x = 10` seguido de `imprimir(x)` en entradas separadas conserva el valor entre ejecuciones.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece28455cc832794bfb1d37d75afb5)