### PR TITLE
Fortalecer captura y recuperación de errores en REPL v2

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -13,8 +13,9 @@ from pcobra.cobra.cli.execution_pipeline import (
 )
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.messages import mostrar_info
-from pcobra.cobra.core import ParserError
+from pcobra.cobra.core import LexerError, ParserError
 from pcobra.cobra.core.runtime import InterpretadorCobra
+from pcobra.cobra.core.semantic_validators import PrimitivaPeligrosaError
 from pcobra.cobra.cli.target_policies import parse_runtime_target
 from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
 
@@ -129,9 +130,15 @@ class ReplCommandV2(BaseCommand):
             codigo = "\n".join(buffer)
             try:
                 prevalidar_y_parsear_codigo(codigo)
-            except Exception as err:
+            except (LexerError, ParserError) as err:
                 if self.es_error_de_bloque_incompleto(err):
                     continue
+                categoria = self._delegate._clasificar_error_repl(err)
+                self._delegate._log_error(categoria, err)
+                buffer.clear()
+                self._delegate._estado_repl = self._delegate._crear_estado_repl()
+                continue
+            except Exception as err:
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
                 buffer.clear()
@@ -157,9 +164,17 @@ class ReplCommandV2(BaseCommand):
                     self._seguro_repl = setup.safe_mode
                     self._extra_validators_repl = setup.validadores_extra
                 buffer.clear()
+            except (PrimitivaPeligrosaError, RuntimeError) as err:
+                categoria = self._delegate._clasificar_error_repl(err)
+                self._delegate._log_error(categoria, err)
+                buffer.clear()
+                self._delegate._estado_repl = self._delegate._crear_estado_repl()
+                continue
             except Exception as err:
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
+                buffer.clear()
+                self._delegate._estado_repl = self._delegate._crear_estado_repl()
                 continue
 
         return 0


### PR DESCRIPTION
### Motivation
- Evitar que errores léxicos/sintácticos, semánticos/runtime y excepciones inesperadas rompan o impriman stacktraces en el loop del REPL v2. 
- Mantener el comportamiento de bloques incompletos (no cerrar sesión ni mostrar traceback) y garantizar que ante un error real se muestre un mensaje limpio, se limpie el buffer y el loop continúe. 
- Reutilizar las utilidades de mensajes existentes para mantener una UX consistente sin cambiar la semántica de impresión del lenguaje.

### Description
- Se actualizaron importaciones en `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` para incluir `LexerError` y `PrimitivaPeligrosaError`. 
- En la fase de prevalidación se agregó `except (LexerError, ParserError)` para detectar bloques incompletos y distinguirlos de errores reales, limpiando `buffer` y reiniciando `_estado_repl` en esos casos. 
- Durante la ejecución del pipeline se añadió captura explícita de `PrimitivaPeligrosaError` y `RuntimeError`, y se mantiene una rama `except Exception` para excepciones inesperadas; en ambos casos se registra el error vía `_delegate._log_error`, se limpia `buffer` y se reinicia el estado REPL antes de continuar. 
- No se modificó `InteractiveCommand.ejecutar_codigo` ni la semántica de `imprimir()`, por lo que el comportamiento de salida del lenguaje permanece intacto.

### Testing
- Se ejecutó `pytest -q tests/unit/test_repl_command_v2.py` y todas las pruebas relacionadas pasaron (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece9c878ec8327b803465e8f53f984)