### PR TITLE
Añadir cobertura REPL v2 (multilínea/errores) y actualizar snapshots de ayuda pública

### DIFF
--- a/tests/cli/test_repl_script_parity_contract.py
+++ b/tests/cli/test_repl_script_parity_contract.py
@@ -247,13 +247,15 @@ def test_paridad_script_vs_repl_con_snippets_secuenciales_y_estado_final() -> No
     ]
     variables = ("acumulado",)
 
-    codigo_script = "\n".join(snippets)
-    resultado_script = _ejecutar_por_ruta_script(codigo_script, variables)
+    resultado_script = _ejecutar_snippets_secuenciales_script(
+        snippets, variables_estado=variables
+    )
     resultado_repl = _ejecutar_snippets_secuenciales_repl(
         snippets, variables_estado=variables
     )
 
     assert resultado_repl["error"] is None
+    assert resultado_script["error"] is None
     assert resultado_script["stderr"] == resultado_repl["stderr"] == ""
     assert _normalizar_stdout_paridad(resultado_script["stdout"]) == _normalizar_stdout_paridad(
         resultado_repl["stdout"]
@@ -278,3 +280,32 @@ def test_paridad_script_vs_repl_con_error_en_snippet_secuencial() -> None:
     assert resultado_repl["error"] is not None
     assert type(resultado_script["error"]) is type(resultado_repl["error"])
     assert str(resultado_script["error"]) == str(resultado_repl["error"])
+
+
+@pytest.mark.integration
+def test_paridad_script_vs_repl_bloque_anidado_mientras_con_si_y_fin() -> None:
+    snippets = [
+        "var acumulado = 0",
+        (
+            "mientras verdadero:\n"
+            "    si acumulado == 0:\n"
+            "        imprimir(acumulado)\n"
+            "    fin\n"
+            "    romper\n"
+            "fin"
+        ),
+    ]
+    variables = ("acumulado",)
+
+    codigo_script = "\n".join(snippets)
+    resultado_script = _ejecutar_por_ruta_script(codigo_script, variables)
+    resultado_repl = _ejecutar_snippets_secuenciales_repl(
+        snippets, variables_estado=variables
+    )
+
+    assert resultado_script["stderr"] == resultado_repl["stderr"] == ""
+    assert resultado_repl["error"] is None
+    assert _normalizar_stdout_paridad(resultado_script["stdout"]) == _normalizar_stdout_paridad(
+        resultado_repl["stdout"]
+    )
+    assert resultado_script["estado"] == resultado_repl["estado"] == {"acumulado": 0}

--- a/tests/integration/golden/cli_help_public_no_legacy.golden
+++ b/tests/integration/golden/cli_help_public_no_legacy.golden
@@ -1,13 +1,22 @@
 usage: cobra [-h] [--version] [--ayuda] [--format] [--debug] [-v] [--no-safe]
              [--allow-insecure-fallback] [--allow-insecure-non-interactive]
-             [--modo {cobra,transpilar,mixto}] [--solo-cobra]
-             [--lang LANG] [--no-color] [--extra-validators EXTRA_VALIDATORS]
+             [--modo {cobra,transpilar,mixto}] [--solo-cobra] [--lang LANG]
+             [--no-color] [--extra-validators EXTRA_VALIDATORS]
              [--legacy-imports] [--dev-ephemeral-key] [--plugins-safe-mode]
              [--plugins-unsafe-mode] [--plugins-allowlist PLUGINS_ALLOWLIST]
+             {run,build,test,mod,repl} ...
 
 CLI de Cobra para ejecutar e interpretar scripts, transpilar código a otros
 lenguajes o usar ambos flujos según --modo (cobra, transpilar, mixto). Modo
 cobra = solo programar/interpretar Cobra sin codegen.
+
+positional arguments:
+  {run,build,test,mod,repl}
+    run                 Run a Cobra file
+    build               Build/transpile a Cobra file
+    test                Validate project output across runtimes
+    mod                 Manage Cobra modules
+    repl                Start Cobra REPL
 
 options:
   -h, --help            show this help message and exit
@@ -48,3 +57,6 @@ options:
                         Lista permitida de plugins separados por coma (ruta
                         exacta, módulo o prefix:/sha256:hash). También vía
                         COBRA_PLUGINS_ALLOWLIST.
+
+Ejemplos públicos: cobra run <archivo.co> cobra build <archivo.co> cobra test
+<archivo.co> cobra mod <list|install|remove|publish|search>

--- a/tests/integration/golden/cli_ui_v2_help_public.golden
+++ b/tests/integration/golden/cli_ui_v2_help_public.golden
@@ -16,7 +16,7 @@ positional arguments:
     build               build/transpile a cobra file
     test                validate project output across runtimes
     mod                 manage cobra modules
-    repl                inicia el modo interactivo
+    repl                start cobra repl
 
 options:
   -h, --help            show this help message and exit

--- a/tests/unit/test_cli_v2_command_contract.py
+++ b/tests/unit/test_cli_v2_command_contract.py
@@ -5,6 +5,7 @@ import pytest
 from cobra.cli.commands_v2.run_cmd import RunCommandV2
 from cobra.cli.commands_v2.build_cmd import BuildCommandV2
 from cobra.cli.commands_v2.test_cmd import TestCommandV2
+from cobra.cli.commands_v2.repl_cmd import ReplCommandV2
 from cobra.cli.commands_v2.legacy_cmd import LegacyCommandGroupV2
 from cobra.cli.cli import LEGACY_COMMAND_MIGRATION_MAP
 from cobra.cli.target_policies import VERIFICATION_EXECUTABLE_TARGETS
@@ -37,6 +38,20 @@ def test_test_v2_langs_es_opcional_y_usa_default_de_politica_oficial():
     parsed = parser.parse_args(["programa.co"])
 
     assert parsed.langs == list(VERIFICATION_EXECUTABLE_TARGETS)
+
+
+def test_repl_v2_parsea_comando_publico_y_flags_soportadas():
+    subparsers = _build_subparsers()
+    command = ReplCommandV2()
+    command.register_subparser(subparsers)
+
+    parser = subparsers.choices[command.name]
+    parsed = parser.parse_args(["--sandbox", "--sandbox-docker", "python", "--memory-limit", "256"])
+
+    assert parsed.cmd is command
+    assert parsed.sandbox is True
+    assert parsed.sandbox_docker == "python"
+    assert parsed.memory_limit == 256
 
 
 def test_build_v2_resuelve_backend_via_pipeline(monkeypatch):

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -1,8 +1,9 @@
 import argparse
 
-from cobra.cli.commands_v2.repl_cmd import ReplCommandV2
+from pcobra.cobra.cli.commands_v2 import repl_cmd as repl_module
 from pcobra.cobra.core import ParserError
 
+ReplCommandV2 = repl_module.ReplCommandV2
 
 def test_es_error_de_bloque_incompleto_por_mensajes_parser():
     command = ReplCommandV2()
@@ -36,7 +37,7 @@ def test_repl_v2_mantiene_buffer_hasta_parseo_valido(monkeypatch):
             raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
         return []
 
-    monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.prevalidar_y_parsear_codigo", _fake_parse)
+    monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", _fake_parse)
     class _Setup:
         def __init__(self, safe_mode, validadores_extra):
             self.interpretador = object()
@@ -47,7 +48,7 @@ def test_repl_v2_mantiene_buffer_hasta_parseo_valido(monkeypatch):
         executed.append(pipeline_input.codigo)
         return _Setup(pipeline_input.safe_mode, pipeline_input.extra_validators), None
 
-    monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.ejecutar_pipeline_explicito", _fake_pipeline)
+    monkeypatch.setattr(repl_module, "ejecutar_pipeline_explicito", _fake_pipeline)
 
     status = command.run(
         argparse.Namespace(
@@ -67,6 +68,93 @@ def test_repl_v2_mantiene_buffer_hasta_parseo_valido(monkeypatch):
     assert executed == ["si verdadero:\nimprimir(1)\nfin"]
 
 
+def test_repl_v2_prompts_primario_y_secundario_en_bloque(monkeypatch):
+    command = ReplCommandV2()
+    entradas = iter(["si verdadero:", "imprimir(1)", "fin", "exit"])
+    prompts: list[str] = []
+
+    def _fake_input(prompt: str) -> str:
+        prompts.append(prompt)
+        return next(entradas)
+
+    monkeypatch.setattr("builtins.input", _fake_input)
+
+    def _fake_parse(codigo: str):
+        if codigo != "si verdadero:\nimprimir(1)\nfin":
+            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+        return []
+
+    monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", _fake_parse)
+
+    class _Setup:
+        def __init__(self):
+            self.interpretador = object()
+            self.safe_mode = False
+            self.validadores_extra = None
+
+    monkeypatch.setattr(
+        repl_module, "ejecutar_pipeline_explicito", lambda *_args, **_kwargs: (_Setup(), None)
+    )
+
+    status = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+
+    assert status == 0
+    assert prompts == [">>> ", "... ", "... ", ">>> "]
+
+
+def test_repl_v2_sale_por_salir_y_por_exit(monkeypatch):
+    command = ReplCommandV2()
+    entradas = iter(["salir"])
+    prompts_salir: list[str] = []
+
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda prompt: prompts_salir.append(prompt) or next(entradas),
+    )
+    monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", lambda _codigo: [])
+    monkeypatch.setattr(
+        repl_module,
+        "ejecutar_pipeline_explicito",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("no debe ejecutar")),
+    )
+
+    status_salir = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+    assert status_salir == 0
+    assert prompts_salir == [">>> "]
+
+    command = ReplCommandV2()
+    entradas_exit = iter(["exit"])
+    prompts_exit: list[str] = []
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda prompt: prompts_exit.append(prompt) or next(entradas_exit),
+    )
+    status_exit = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+    assert status_exit == 0
+    assert prompts_exit == [">>> "]
+
+
 def test_repl_v2_limpia_buffer_ante_error_real(monkeypatch):
     command = ReplCommandV2()
     entradas = iter(["algo_mal", "exit"])
@@ -79,7 +167,7 @@ def test_repl_v2_limpia_buffer_ante_error_real(monkeypatch):
         parse_calls.append(codigo)
         raise ParserError("Se encontró 'fin' inesperado")
 
-    monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.prevalidar_y_parsear_codigo", _fake_parse)
+    monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", _fake_parse)
     monkeypatch.setattr(command._delegate, "_log_error", lambda _cat, err: logged.append(str(err)))
 
     status = command.run(
@@ -94,6 +182,53 @@ def test_repl_v2_limpia_buffer_ante_error_real(monkeypatch):
     assert status == 0
     assert parse_calls == ["algo_mal"]
     assert logged == ["Se encontró 'fin' inesperado"]
+
+
+def test_repl_v2_error_sintaxis_real_limpia_buffer_y_continua(monkeypatch):
+    command = ReplCommandV2()
+    entradas = iter(["si verdadero:", "imprimir(1", "var z = 9", "exit"])
+    parse_calls: list[str] = []
+    pipeline_calls: list[str] = []
+    logged: list[str] = []
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+
+    def _fake_parse(codigo: str):
+        parse_calls.append(codigo)
+        if codigo == "si verdadero:":
+            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+        if codigo == "si verdadero:\nimprimir(1":
+            raise ParserError("Token inesperado: '('")
+        return []
+
+    class _Setup:
+        def __init__(self):
+            self.interpretador = object()
+            self.safe_mode = False
+            self.validadores_extra = None
+
+    monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", _fake_parse)
+    monkeypatch.setattr(
+        repl_module,
+        "ejecutar_pipeline_explicito",
+        lambda pipeline_input, **_kwargs: pipeline_calls.append(pipeline_input.codigo)
+        or (_Setup(), None),
+    )
+    monkeypatch.setattr(command._delegate, "_log_error", lambda _cat, err: logged.append(str(err)))
+
+    status = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+
+    assert status == 0
+    assert parse_calls == ["si verdadero:", "si verdadero:\nimprimir(1", "var z = 9"]
+    assert pipeline_calls == ["var z = 9"]
+    assert logged == ["Token inesperado: '('"]
 
 
 def test_repl_v2_persiste_interpretador_entre_bloques(monkeypatch):
@@ -119,8 +254,8 @@ def test_repl_v2_persiste_interpretador_entre_bloques(monkeypatch):
             assert interpretador["x"] == 10
         return _Setup(interpretador), None
 
-    monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.ejecutar_pipeline_explicito", _fake_pipeline)
-    monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.prevalidar_y_parsear_codigo", lambda _codigo: [])
+    monkeypatch.setattr(repl_module, "ejecutar_pipeline_explicito", _fake_pipeline)
+    monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", lambda _codigo: [])
 
     status = command.run(
         argparse.Namespace(
@@ -135,3 +270,72 @@ def test_repl_v2_persiste_interpretador_entre_bloques(monkeypatch):
 
     assert status == 0
     assert interpretadores_recibidos == [None, estado]
+
+
+def test_repl_v2_soporta_bloque_anidado_con_fin(monkeypatch):
+    command = ReplCommandV2()
+    entradas = iter(
+        [
+            "mientras verdadero:",
+            "si verdadero:",
+            "var total = 5",
+            "romper",
+            "fin",
+            "fin",
+            "imprimir(total)",
+            "exit",
+        ]
+    )
+    parse_calls: list[str] = []
+    pipeline_calls: list[str] = []
+    estado: dict[str, int] = {}
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+
+    def _fake_parse(codigo: str):
+        parse_calls.append(codigo)
+        if codigo not in {
+            "mientras verdadero:\nsi verdadero:\nvar total = 5\nromper\nfin\nfin",
+            "imprimir(total)",
+        }:
+            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+        return []
+
+    class _Setup:
+        def __init__(self, interpretador):
+            self.interpretador = interpretador
+            self.safe_mode = False
+            self.validadores_extra = None
+
+    def _fake_pipeline(pipeline_input, **_kwargs):
+        pipeline_calls.append(pipeline_input.codigo)
+        interpretador = pipeline_input.interpretador or estado
+        if pipeline_input.codigo.startswith("mientras verdadero:"):
+            interpretador["total"] = 5
+        if pipeline_input.codigo == "imprimir(total)":
+            assert interpretador["total"] == 5
+        return _Setup(interpretador), None
+
+    monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", _fake_parse)
+    monkeypatch.setattr(repl_module, "ejecutar_pipeline_explicito", _fake_pipeline)
+
+    status = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            seguro=False,
+            extra_validators=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+
+    assert status == 0
+    assert parse_calls[-2:] == [
+        "mientras verdadero:\nsi verdadero:\nvar total = 5\nromper\nfin\nfin",
+        "imprimir(total)",
+    ]
+    assert pipeline_calls == [
+        "mientras verdadero:\nsi verdadero:\nvar total = 5\nromper\nfin\nfin",
+        "imprimir(total)",
+    ]


### PR DESCRIPTION
### Motivation
- Mejorar la cobertura de pruebas del REPL público (UI v2) para asegurar comportamiento en entradas multilínea, prompts y errores sintácticos.
- Garantizar la paridad entre ejecución por script y REPL en casos de bloques anidados y persistencia de estado.
- Mantener actualizados los snapshots públicos de `--help` para el UI v2 que exponen el comando `repl`.

### Description
- Añadidos tests unitarios en `tests/unit/test_repl_command_v2.py` que cubren prompts primario/secundario (`>>>` / `...`), salida por `salir`/`exit`, acumulación de buffer para bloques incompletos, limpieza de buffer tras error real de sintaxis, persistencia del intérprete entre entradas y soporte de bloque anidado con `fin`.
- Ajustado el uso de monkeypatch en esos tests para referenciar el módulo real `pcobra.cobra.cli.commands_v2.repl_cmd` (se introduce `repl_module` y `ReplCommandV2 = repl_module.ReplCommandV2`) para evitar ambigüedades al parchear funciones como `prevalidar_y_parsear_codigo` y `ejecutar_pipeline_explicito`.
- Añadida prueba en `tests/unit/test_cli_v2_command_contract.py` para validar el parseo público de `repl` y flags soportadas (`--sandbox`, `--sandbox-docker`, `--memory-limit`).
- Ampliada paridad REPL/script en `tests/cli/test_repl_script_parity_contract.py` con un caso de bloque anidado (`mientras` + `si` + `fin`) y ajustes para comparar rutas script vs REPL usando los helpers de snippets secuenciales.
- Actualizados snapshots/help públicos en `tests/integration/golden/cli_help_public_no_legacy.golden` y `tests/integration/golden/cli_ui_v2_help_public.golden` para reflejar el listado y texto actual del `--help` (incluye `repl`).
- Archivos modificados principales: `tests/unit/test_repl_command_v2.py`, `tests/unit/test_cli_v2_command_contract.py`, `tests/cli/test_repl_script_parity_contract.py`, `tests/integration/golden/cli_help_public_no_legacy.golden`, `tests/integration/golden/cli_ui_v2_help_public.golden`.

### Testing
- Ejecutados tests focalizados con `pytest` sobre los módulos modificados: `tests/unit/test_repl_command_v2.py`, `tests/cli/test_repl_script_parity_contract.py`, la prueba `test_repl_v2_parsea_comando_publico_y_flags_soportadas` y las pruebas de ayuda pública (`test_cobra_help_snapshot_publico_no_expone_comandos_legacy`, `test_cli_help_public_contract_snapshot`).
- Comando usado (ejemplos): `pytest -q tests/unit/test_repl_command_v2.py tests/cli/test_repl_script_parity_contract.py tests/unit/test_cli_v2_command_contract.py::test_repl_v2_parsea_comando_publico_y_flags_soportadas tests/integration/test_cli_ayuda.py::test_cobra_help_snapshot_publico_no_expone_comandos_legacy tests/integration/test_cli_public_help_contract.py::test_cli_help_public_contract_snapshot`.
- Resultado automatizado final: todos los tests ejecutados pasaron correctamente (16 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecec9bb4bc83279cc6cd87ef04eee7)