### PR TITLE
Refactoriza detección de entrada incompleta en ReplCommandV2 y añade tests parametrizados

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -19,21 +19,39 @@ from pcobra.cobra.core.semantic_validators import PrimitivaPeligrosaError
 from pcobra.cobra.cli.target_policies import parse_runtime_target
 from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
 
+_PATRONES_ERROR_BLOQUE_INCOMPLETO: tuple[tuple[str, str], ...] = (
+    (
+        "se esperaba 'fin' para cerrar",
+        "El parser llegó a EOF con un bloque de control sin cerrar con 'fin'.",
+    ),
+    (
+        "tipotoken.eof",
+        "El parser encontró EOF donde esperaba más tokens válidos para completar la sentencia.",
+    ),
+    (
+        "se esperaba ')' para cerrar",
+        "El parser detectó delimitador de paréntesis pendiente de cierre.",
+    ),
+    (
+        "se esperaba ')' al final",
+        "El parser detectó delimitador de paréntesis pendiente de cierre al finalizar la entrada.",
+    ),
+    (
+        "se esperaba ']' al final",
+        "El parser detectó delimitador de lista pendiente de cierre al finalizar la entrada.",
+    ),
+    (
+        "se esperaba '}' al final",
+        "El parser detectó delimitador de diccionario pendiente de cierre al finalizar la entrada.",
+    ),
+)
+
 
 class ReplCommandV2(BaseCommand):
     """Comando v2 público para iniciar el REPL de Cobra."""
 
     name = "repl"
     capability = "execute"
-    _MARCADORES_BLOQUE_INCOMPLETO = (
-        "se esperaba 'fin' para cerrar",
-        "tipotoken.eof",
-        "se esperaba ')' para cerrar",
-        "se esperaba ')' al final",
-        "se esperaba ']' al final",
-        "se esperaba '}' al final",
-    )
-
     def __init__(self) -> None:
         super().__init__()
         self._delegate = InteractiveCommand(InterpretadorCobra())
@@ -43,14 +61,16 @@ class ReplCommandV2(BaseCommand):
         self._extra_validators_repl: Any = None
 
     def es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
-        """Detecta si la excepción corresponde a un bloque aún incompleto."""
+        """Detecta si la excepción corresponde a una entrada aún incompleta.
+
+        Se basa únicamente en `ParserError` y en mensajes canónicos emitidos por
+        el parser oficial.
+        """
 
         if not isinstance(exc, ParserError):
             return False
         mensaje = str(exc).strip().lower()
-        return any(
-            marcador in mensaje for marcador in self._MARCADORES_BLOQUE_INCOMPLETO
-        )
+        return any(patron in mensaje for patron, _razon in _PATRONES_ERROR_BLOQUE_INCOMPLETO)
 
     def register_subparser(self, subparsers: Any):
         parser = subparsers.add_parser(self.name, help=_("Start Cobra REPL"))

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -1,25 +1,30 @@
 import argparse
 
+import pytest
+
 from pcobra.cobra.cli.commands_v2 import repl_cmd as repl_module
 from pcobra.cobra.core import ParserError
 
 ReplCommandV2 = repl_module.ReplCommandV2
 
-def test_es_error_de_bloque_incompleto_por_mensajes_parser():
-    command = ReplCommandV2()
 
-    assert command.es_error_de_bloque_incompleto(
-        ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
-    )
-    assert command.es_error_de_bloque_incompleto(
-        ParserError("Token inesperado en término: TipoToken.EOF")
-    )
-    assert command.es_error_de_bloque_incompleto(
-        ParserError("Se esperaba ']' al final de la lista")
-    )
-    assert not command.es_error_de_bloque_incompleto(
-        ParserError("Se encontró 'fin' inesperado")
-    )
+@pytest.mark.parametrize(
+    ("mensaje", "es_incompleto"),
+    [
+        ("Se esperaba 'fin' para cerrar el bloque condicional", True),
+        ("Token inesperado en término: TipoToken.EOF", True),
+        ("Se esperaba ']' al final de la lista", True),
+        ("Token inesperado: '('", False),
+        ("Se encontró 'fin' inesperado", False),
+    ],
+)
+def test_es_error_de_bloque_incompleto_por_mensajes_parser(mensaje, es_incompleto):
+    command = ReplCommandV2()
+    assert command.es_error_de_bloque_incompleto(ParserError(mensaje)) is es_incompleto
+
+
+def test_es_error_de_bloque_incompleto_rechaza_excepciones_que_no_son_parser():
+    command = ReplCommandV2()
     assert not command.es_error_de_bloque_incompleto(ValueError("no parser"))
 
 
@@ -224,6 +229,96 @@ def test_repl_v2_limpia_buffer_ante_error_real(monkeypatch):
     assert status == 0
     assert parse_calls == ["algo_mal"]
     assert logged == ["Se encontró 'fin' inesperado"]
+
+
+@pytest.mark.parametrize(
+    ("entradas", "errores_por_codigo", "parse_esperado", "pipeline_esperado", "errores_esperados"),
+    [
+        (
+            ["si verdadero :", "fin", "exit"],
+            {
+                "si verdadero :": "Se esperaba 'fin' para cerrar el bloque condicional",
+            },
+            ["si verdadero :", "si verdadero :\nfin"],
+            ["si verdadero :\nfin"],
+            [],
+        ),
+        (
+            ["mientras verdadero :", "fin", "exit"],
+            {
+                "mientras verdadero :": "Se esperaba 'fin' para cerrar el bloque mientras",
+            },
+            ["mientras verdadero :", "mientras verdadero :\nfin"],
+            ["mientras verdadero :\nfin"],
+            [],
+        ),
+        (
+            ["si verdadero :", "imprimir(1", "var z = 9", "exit"],
+            {
+                "si verdadero :": "Se esperaba 'fin' para cerrar el bloque condicional",
+                "si verdadero :\nimprimir(1": "Token inesperado: '('",
+            },
+            ["si verdadero :", "si verdadero :\nimprimir(1", "var z = 9"],
+            ["var z = 9"],
+            ["Token inesperado: '('"],
+        ),
+    ],
+    ids=[
+        "incompleto_si_conserva_buffer",
+        "incompleto_mientras_conserva_buffer",
+        "error_real_limpia_buffer",
+    ],
+)
+def test_repl_v2_incompleto_vs_error_real_buffer(
+    monkeypatch,
+    entradas,
+    errores_por_codigo,
+    parse_esperado,
+    pipeline_esperado,
+    errores_esperados,
+):
+    command = ReplCommandV2()
+    entradas_iter = iter(entradas)
+    parse_calls: list[str] = []
+    pipeline_calls: list[str] = []
+    logged: list[str] = []
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas_iter))
+
+    def _fake_parse(codigo: str):
+        parse_calls.append(codigo)
+        if codigo in errores_por_codigo:
+            raise ParserError(errores_por_codigo[codigo])
+        return []
+
+    class _Setup:
+        def __init__(self):
+            self.interpretador = object()
+            self.safe_mode = False
+            self.validadores_extra = None
+
+    monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", _fake_parse)
+    monkeypatch.setattr(
+        repl_module,
+        "ejecutar_pipeline_explicito",
+        lambda pipeline_input, **_kwargs: pipeline_calls.append(pipeline_input.codigo)
+        or (_Setup(), None),
+    )
+    monkeypatch.setattr(command._delegate, "_log_error", lambda _cat, err: logged.append(str(err)))
+
+    status = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+
+    assert status == 0
+    assert parse_calls == parse_esperado
+    assert pipeline_calls == pipeline_esperado
+    assert logged == errores_esperados
 
 
 def test_repl_v2_linea_en_blanco_no_ejecuta_ni_resetea_estado_global(monkeypatch):


### PR DESCRIPTION
### Motivation
- Centralizar y documentar los patrones del `ParserError` que indican entrada incompleta para evitar heurísticas dispersas. 
- Basarse únicamente en las excepciones y mensajes canónicos del parser oficial (`ParserError`) y no introducir parsing propio. 
- Asegurar con pruebas que el REPL conserva el `buffer` cuando el error es recuperable (entrada incompleta) y lo limpia en errores reales.

### Description
- Se introduce la constante de módulo `_PATRONES_ERROR_BLOQUE_INCOMPLETO` con pares `(patrón, razón)` que documentan por qué cada mensaje representa incompletitud. 
- `es_error_de_bloque_incompleto` ahora verifica solo `isinstance(exc, ParserError)` y busca los patrones documentados en el `str(exc).lower()` sin lógica de parsing adicional. 
- Se añadieron tests parametrizados en `tests/unit/test_repl_command_v2.py` para clasificar mensajes del parser entre incompleto vs error real y para verificar flujos del REPL que confirman conservación o limpieza del buffer según el caso. 
- Se importó `pytest` y se reescribieron/añadieron casos de prueba existentes para usar `@pytest.mark.parametrize` y cubrir `si`/`mientras` incompletos y errores reales no recuperables.

### Testing
- Ejecutado `pytest -q tests/unit/test_repl_command_v2.py` con resultado `19 passed, 1 warning` (las pruebas añadidas y existentes pasaron correctamente).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed03c38f408327938a13d1c23cc285)