### PR TITLE
Refuerza ejecución REPL v2 por pipeline compartido y añade pruebas de persistencia

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -104,6 +104,21 @@ class ReplCommandV2(BaseCommand):
         parser.set_defaults(cmd=self)
         return parser
 
+    def _ejecutar_en_modo_normal(self, codigo: str, interpretador_cls: type) -> None:
+        """Ejecuta una entrada REPL usando el pipeline CLI compartido."""
+        setup, _resultado_pipeline = ejecutar_pipeline_explicito(
+            PipelineInput(
+                codigo=codigo,
+                interpretador_cls=interpretador_cls,
+                safe_mode=self._seguro_repl,
+                extra_validators=self._extra_validators_repl,
+                interpretador=self._interpretador_persistente,
+            ),
+        )
+        self._interpretador_persistente = setup.interpretador
+        self._seguro_repl = setup.safe_mode
+        self._extra_validators_repl = setup.validadores_extra
+
     def run(self, args: Any) -> int:
         buffer: list[str] = []
         self._delegate._estado_repl = self._delegate._crear_estado_repl()
@@ -171,18 +186,7 @@ class ReplCommandV2(BaseCommand):
                 elif sandbox_docker:
                     self._delegate._ejecutar_en_docker(codigo, sandbox_docker)
                 else:
-                    setup, _resultado_pipeline = ejecutar_pipeline_explicito(
-                        PipelineInput(
-                            codigo=codigo,
-                            interpretador_cls=interpretador_cls,
-                            safe_mode=self._seguro_repl,
-                            extra_validators=self._extra_validators_repl,
-                            interpretador=self._interpretador_persistente,
-                        ),
-                    )
-                    self._interpretador_persistente = setup.interpretador
-                    self._seguro_repl = setup.safe_mode
-                    self._extra_validators_repl = setup.validadores_extra
+                    self._ejecutar_en_modo_normal(codigo, interpretador_cls)
                 buffer.clear()
             except (PrimitivaPeligrosaError, RuntimeError) as err:
                 categoria = self._delegate._clasificar_error_repl(err)

--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -152,6 +152,70 @@ def test_mutacion_en_mientras_y_lectura_posterior_persisten_en_repl():
 
 
 @pytest.mark.integration
+def test_persistencia_basica_var_x_e_impresion_equivale_entre_run_y_repl():
+    resultado_script, resultado_repl = _run_pipeline_and_repl(
+        prelude="var x = 10",
+        snippet="imprimir(x)",
+        variables_estado=("x",),
+    )
+
+    assert resultado_script["stderr"] == resultado_repl["stderr"] == ""
+    assert resultado_script["stdout"].strip().endswith("10")
+    assert resultado_repl["stdout"].strip().endswith("10")
+    assert resultado_script["estado"] == resultado_repl["estado"] == {"x": 10}
+
+
+@pytest.mark.integration
+def test_repl_mantiene_estado_tras_error_intermedio():
+    interpretador_cls = resolver_interpretador_cls(
+        module_name="pcobra.cobra.cli.services.run_service",
+        default_cls=InterpretadorCobra,
+    )
+
+    with patch.object(
+        InterpretadorCobra,
+        "_asegurar_no_autorreferencia_asignacion",
+        return_value=None,
+    ):
+        setup_ok, _ = ejecutar_pipeline_explicito(
+            PipelineInput(
+                codigo="var x = 10",
+                interpretador_cls=interpretador_cls,
+                safe_mode=False,
+                extra_validators=None,
+            )
+        )
+        interpretador_persistente = setup_ok.interpretador
+
+        with pytest.raises(Exception):  # noqa: BLE001 - contrato integración
+            ejecutar_pipeline_explicito(
+                PipelineInput(
+                    codigo="var y = 10 / 0",
+                    interpretador_cls=interpretador_cls,
+                    safe_mode=False,
+                    extra_validators=None,
+                    interpretador=interpretador_persistente,
+                )
+            )
+
+        out_repl, err_repl = StringIO(), StringIO()
+        with redirect_stdout(out_repl), redirect_stderr(err_repl):
+            setup_final, _ = ejecutar_pipeline_explicito(
+                PipelineInput(
+                    codigo="imprimir(x)",
+                    interpretador_cls=interpretador_cls,
+                    safe_mode=False,
+                    extra_validators=None,
+                    interpretador=interpretador_persistente,
+                )
+            )
+
+    assert err_repl.getvalue() == ""
+    assert out_repl.getvalue().strip().endswith("10")
+    assert setup_final.interpretador.contextos[-1].get("x") == 10
+
+
+@pytest.mark.integration
 def test_anidacion_condicional_bucle_equivale_en_salida_y_estado(tmp_path, monkeypatch):
     monkeypatch.setattr("pcobra.cobra.cli.services.run_service.limitar_cpu_segundos", lambda *_: None)
     codigo = (


### PR DESCRIPTION
### Motivation
- Garantizar que el REPL v2 use siempre el pipeline CLI compartido en modo normal y no adopte rutas alternas que salten la lógica de `PipelineInput`/`ejecutar_pipeline_explicito`.
- Asegurar el contrato de persistencia del interpretador entre ejecuciones del REPL (pasar `self._interpretador_persistente` y actualizarlo con `setup.interpretador`).
- Cubrir casos de persistencia básica y de persistencia tras un error intermedio en pruebas de integración para evitar regresiones.

### Description
- Extraído el camino de ejecución normal a `_ejecutar_en_modo_normal(...)` que construye `PipelineInput` y llama a `ejecutar_pipeline_explicito(...)` como único flujo no-sandbox en `ReplCommandV2`.
- En `_ejecutar_en_modo_normal` se pasa siempre `self._interpretador_persistente` al pipeline y, tras ejecución exitosa, se actualizan `self._interpretador_persistente`, `self._seguro_repl` y `self._extra_validators_repl` con los valores de `setup`.
- Reemplazado el bloque inline en `run()` por una llamada a `_ejecutar_en_modo_normal(...)` para evitar caminos alternos que no pasen por el pipeline compartido.
- Añadidas dos pruebas de integración en `tests/integration/test_run_repl_equivalence.py`: `test_persistencia_basica_var_x_e_impresion_equivale_entre_run_y_repl` y `test_repl_mantiene_estado_tras_error_intermedio` para verificar persistencia y comportamiento tras errores intermedios.

### Testing
- Ejecutado: `pytest -q tests/unit/test_repl_command_v2.py tests/integration/test_run_repl_equivalence.py`.
- Resultado: todas las pruebas seleccionadas pasaron correctamente (33 passed) con 1 warning sobre deprecación; no hay fallos en las pruebas nuevas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed078722548327afb78836d6b5d588)