### PR TITLE
Unificar criterio de echo en REPL v2 y cubrir salida con pruebas

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -375,6 +375,11 @@ class InteractiveCommand(BaseCommand):
         resultado = resultado_pipeline.resultado
         self.logger.debug("[EXEC] Ejecutando AST en intérprete")
         self.logger.debug("[EVAL] Resultado de evaluación: %r", resultado)
+        self._imprimir_resultado_repl(ast, resultado)
+
+    def _imprimir_resultado_repl(self, ast: list[Any], resultado: Any) -> None:
+        """Imprime el resultado del REPL cuando aplica contrato de echo."""
+
         debe_imprimir_resultado = (
             resultado is not None
             and len(ast) == 1

--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -118,6 +118,11 @@ class ReplCommandV2(BaseCommand):
         self._interpretador_persistente = setup.interpretador
         self._seguro_repl = setup.safe_mode
         self._extra_validators_repl = setup.validadores_extra
+        if _resultado_pipeline is not None:
+            self._delegate._imprimir_resultado_repl(
+                _resultado_pipeline.ast,
+                _resultado_pipeline.resultado,
+            )
 
     def run(self, args: Any) -> int:
         buffer: list[str] = []

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -3,6 +3,7 @@ import argparse
 import pytest
 
 from pcobra.cobra.cli.commands_v2 import repl_cmd as repl_module
+from pcobra.cobra.cli.commands import interactive_cmd as interactive_module
 from pcobra.cobra.core import ParserError
 
 ReplCommandV2 = repl_module.ReplCommandV2
@@ -573,3 +574,89 @@ def test_repl_v2_anidamiento_real_no_ejecuta_hasta_cierre_completo_y_persiste_es
         "imprimir(total)",
     ]
     assert interpretadores_recibidos == [None, estado]
+
+
+@pytest.mark.parametrize(
+    ("entrada", "resultado", "ast", "salida_esperada"),
+    [
+        ("imprimir('hola')", None, [object()], ""),
+        ("1 + 1", 2, [object()], "2\n"),
+    ],
+    ids=["sentencia-imprimir-no-duplica", "expresion-simple-con-echo"],
+)
+def test_repl_v2_salida_homogenea_para_sentencia_y_expresion(
+    monkeypatch, capsys, entrada, resultado, ast, salida_esperada
+):
+    command = ReplCommandV2()
+    entradas = iter([entrada, "exit"])
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+    monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", lambda _codigo: ast)
+    monkeypatch.setattr(repl_module, "mostrar_info", lambda *_args, **_kwargs: None)
+
+    class _Setup:
+        def __init__(self):
+            self.interpretador = object()
+            self.safe_mode = False
+            self.validadores_extra = None
+
+    class _Resultado:
+        def __init__(self):
+            self.ast = ast
+            self.resultado = resultado
+
+    monkeypatch.setattr(
+        repl_module,
+        "ejecutar_pipeline_explicito",
+        lambda *_args, **_kwargs: (_Setup(), _Resultado()),
+    )
+
+    status = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+
+    assert status == 0
+    assert capsys.readouterr().out == salida_esperada
+
+
+def test_repl_v2_no_hace_echo_automatico_para_estructuras_de_control(monkeypatch, capsys):
+    command = ReplCommandV2()
+    entradas = iter(["si verdadero:\nfin", "exit"])
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+    monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", lambda _codigo: [object()])
+    monkeypatch.setattr(repl_module, "mostrar_info", lambda *_args, **_kwargs: None)
+
+    class _Setup:
+        def __init__(self):
+            self.interpretador = object()
+            self.safe_mode = False
+            self.validadores_extra = None
+
+    class _Resultado:
+        def __init__(self):
+            self.ast = [interactive_module.NodoCondicional(True, [], [])]
+            self.resultado = "resultado-interno"
+
+    monkeypatch.setattr(
+        repl_module,
+        "ejecutar_pipeline_explicito",
+        lambda *_args, **_kwargs: (_Setup(), _Resultado()),
+    )
+
+    status = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+
+    assert status == 0
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
### Motivation
- Homogeneizar la política de "echo" entre el REPL clásico (`InteractiveCommand`) y el REPL v2, porque `repl_cmd.py` ejecutaba el pipeline en modo no sandbox sin aplicar explícitamente el mismo criterio de impresión.
- Evitar doble impresión cuando la sentencia `imprimir(...)` ya produce salida propia y garantizar que expresiones simples hagan `echo` y que estructuras de control no lo hagan automáticamente.

### Description
- Se extrajo el criterio de impresión en `InteractiveCommand` a un nuevo método `_imprimir_resultado_repl(ast, resultado)` y se invoca desde `ejecutar_codigo` para centralizar la lógica de salida del REPL.
- `ReplCommandV2._ejecutar_en_modo_normal` ahora reutiliza la misma rutina (`self._delegate._imprimir_resultado_repl(...)`) cuando el pipeline devuelve un resultado, unificando el comportamiento entre implementaciones.
- Se añadieron pruebas unitarias en `tests/unit/test_repl_command_v2.py` que cubren: sentencia `imprimir(...)` (no duplicar salida), expresión simple (echo automático) y estructura de control (sin echo automático), y en los tests se silencia la salida informativa que interfería con las aserciones.

### Testing
- Se ejecutaron casos puntuales con `pytest -q tests/unit/test_repl_command_v2.py::test_repl_v2_salida_homogenea_para_sentencia_y_expresion tests/unit/test_repl_command_v2.py::test_repl_v2_no_hace_echo_automatico_para_estructuras_de_control tests/unit/test_repl_command_v2.py::test_repl_v2_mantiene_buffer_hasta_parseo_valido` y tras ajustar los tests fallidos por salida informativa, las pruebas específicas pasaron.
- Se ejecutó `pytest -q tests/unit/test_repl_command_v2.py` y el conjunto de pruebas del archivo pasó (22 tests passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0ae9a7848327867fd22c0a886eb2)