### PR TITLE
Actualizar ejemplos públicos de CLI v2 para incluir `cobra repl`

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -629,7 +629,8 @@ class CliApplication:
                 "  cobra run <archivo.co>\n"
                 "  cobra build <archivo.co>\n"
                 "  cobra test <archivo.co>\n"
-                "  cobra mod <list|install|remove|publish|search>"
+                "  cobra mod <list|install|remove|publish|search>\n"
+                "  cobra repl"
             ),
         )
         self._configure_cli_options(parser)


### PR DESCRIPTION
### Motivation
- Añadir explícitamente `cobra repl` a la sección de ejemplos públicos del epílogo de ayuda para que la documentación de la CLI refleje el contrato público de comandos v2. 
- Mantener la lista alineada con los comandos v2 públicos (`run`, `build`, `test`, `mod`, `repl`) sin introducir refactors funcionales.

### Description
- Modifiqué `CliApplication._build_argument_parser()` en `src/pcobra/cobra/cli/cli.py` para añadir la línea `  cobra repl` dentro del `epilog` de ayuda. 
- El cambio es puramente de documentación/ayuda en la cadena `epilog` y no altera el comportamiento de ejecución de los comandos. 

### Testing
- Ejecuté `git diff -- src/pcobra/cobra/cli/cli.py` para revisar el diff y confirmó la inserción de la línea, y la comprobación devolvió la diferencia esperada. (éxito)
- Visualicé el bloque afectado con `nl -ba src/pcobra/cobra/cli/cli.py | sed -n '620,645p'` para verificar la correcta ubicación y formato de la adición. (éxito)
- Verifiqué el estado del árbol con `git status --short` y confirmé el fichero modificado. (éxito)
- Realicé `git add` y `git commit` con el mensaje `cli: agrega cobra repl a ejemplos publicos del epilog` para dejar el cambio registrado en el repositorio. (éxito)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda29544948327ba25ae9dab38a156)