### PR TITLE
test(cli): ampliar cobertura de ayuda y comportamiento REPL v2

### DIFF
--- a/tests/unit/test_cli_default_command.py
+++ b/tests/unit/test_cli_default_command.py
@@ -5,6 +5,32 @@ from unittest.mock import patch
 import pytest
 
 from cobra.cli.cli import CliApplication, InteractiveCommand, CustomArgumentParser, main
+from pcobra.cobra.cli.commands.base import BaseCommand
+
+
+class _DummyRunCommand(BaseCommand):
+    name = "run"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help="Ejecuta script Cobra")
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, _args):
+        return 0
+
+
+class _DummyReplCommand(BaseCommand):
+    name = "repl"
+
+    def register_subparser(self, subparsers):
+        parser = subparsers.add_parser(self.name, help="Inicia REPL público")
+        parser.add_argument("--sandbox", action="store_true", help="Sandbox REPL")
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, _args):
+        return 0
 
 
 def _patch_cli_env(stack: ExitStack) -> None:
@@ -140,3 +166,34 @@ def test_execute_command_without_parser_returns_controlled_error():
     assert result == 1
     mock_error.assert_called_once()
     assert "parser no disponible" in mock_error.call_args.args[0].lower()
+
+
+def test_help_principal_lista_repl_como_comando_publico(capsys):
+    with ExitStack() as stack:
+        _patch_cli_env(stack)
+        stack.enter_context(
+            patch("cobra.cli.cli.AppConfig.V2_COMMAND_CLASSES", [_DummyRunCommand, _DummyReplCommand])
+        )
+        stack.enter_context(patch("cobra.cli.cli.resolve_command_profile", return_value="public"))
+        app = CliApplication()
+        with pytest.raises(SystemExit) as excinfo:
+            app.run(["--help"])
+    assert excinfo.value.code == 0
+    stdout = capsys.readouterr().out
+    assert "repl" in stdout
+    assert "run" in stdout
+
+
+def test_cli_sin_argumentos_no_imprime_ayuda_detallada_de_subcomandos(capsys):
+    with ExitStack() as stack:
+        _patch_cli_env(stack)
+        stack.enter_context(
+            patch("cobra.cli.cli.AppConfig.V2_COMMAND_CLASSES", [_DummyRunCommand, _DummyReplCommand])
+        )
+        stack.enter_context(patch("cobra.cli.cli.resolve_command_profile", return_value="public"))
+        app = CliApplication()
+        result = app.run([])
+    assert result == 1
+    stdout = capsys.readouterr().out
+    assert "repl" in stdout
+    assert "--sandbox" not in stdout

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -660,3 +660,92 @@ def test_repl_v2_no_hace_echo_automatico_para_estructuras_de_control(monkeypatch
 
     assert status == 0
     assert capsys.readouterr().out == ""
+
+
+def test_repl_v2_var_e_imprimir_persisten_estado_y_muestran_valor(monkeypatch, capsys):
+    command = ReplCommandV2()
+    entradas = iter(["var x = 10", "imprimir(x)", "exit"])
+    estado: dict[str, int] = {}
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+    monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", lambda _codigo: [object()])
+
+    class _Setup:
+        def __init__(self, interpretador):
+            self.interpretador = interpretador
+            self.safe_mode = False
+            self.validadores_extra = None
+
+    class _Resultado:
+        def __init__(self, ast, resultado):
+            self.ast = ast
+            self.resultado = resultado
+
+    def _fake_pipeline(pipeline_input, **_kwargs):
+        interpretador = pipeline_input.interpretador or estado
+        if pipeline_input.codigo == "var x = 10":
+            interpretador["x"] = 10
+            return _Setup(interpretador), _Resultado([object()], None)
+        assert pipeline_input.codigo == "imprimir(x)"
+        return _Setup(interpretador), _Resultado([object()], interpretador["x"])
+
+    monkeypatch.setattr(repl_module, "ejecutar_pipeline_explicito", _fake_pipeline)
+    monkeypatch.setattr(repl_module, "mostrar_info", lambda *_args, **_kwargs: None)
+
+    status = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+
+    assert status == 0
+    assert capsys.readouterr().out == "10\n"
+
+
+def test_repl_v2_bloque_incompleto_acumula_buffer_y_sesion_sigue_activa(monkeypatch):
+    command = ReplCommandV2()
+    entradas = iter(["si verdadero:", "imprimir(1)", "fin", "exit"])
+    parse_calls: list[str] = []
+    pipeline_calls: list[str] = []
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+
+    def _fake_parse(codigo: str):
+        parse_calls.append(codigo)
+        if codigo != "si verdadero:\nimprimir(1)\nfin":
+            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+        return []
+
+    class _Setup:
+        def __init__(self):
+            self.interpretador = {}
+            self.safe_mode = False
+            self.validadores_extra = None
+
+    monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", _fake_parse)
+    monkeypatch.setattr(
+        repl_module,
+        "ejecutar_pipeline_explicito",
+        lambda pipeline_input, **_kwargs: pipeline_calls.append(pipeline_input.codigo)
+        or (_Setup(), None),
+    )
+
+    status = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+
+    assert status == 0
+    assert parse_calls == [
+        "si verdadero:",
+        "si verdadero:\nimprimir(1)",
+        "si verdadero:\nimprimir(1)\nfin",
+    ]
+    assert pipeline_calls == ["si verdadero:\nimprimir(1)\nfin"]


### PR DESCRIPTION
### Motivation

- Añadir pruebas que verifiquen la superficie pública de la CLI y el contrato de comportamiento del REPL v2 para cubrir casos críticos de UX y persistencia de estado.
- Evitar regresiones en la presentación de `--help` y en el manejo de entradas multilinea / errores dentro del REPL al compartir el pipeline de ejecución.
- Proveer tests aislados que usen dobles/mocks para no depender de implementaciones externas al flujo de CLI.

### Description

- Se añadieron pruebas en `tests/unit/test_cli_default_command.py` que inyectan comandos v2 dummy y verifican que `cobra --help` lista comandos públicos (incluye `repl`) y que ejecutar `cobra` sin argumentos no imprime la ayuda detallada de subcomandos (p. ej. `--sandbox`).
- Se añadieron pruebas en `tests/unit/test_repl_command_v2.py` que validan que el REPL v2: persiste estado entre entradas (`var x = 10` seguido de `imprimir(x)` imprime `10`), acumula buffer para bloques incompletos hasta completar `fin` sin cerrar la sesión, y usa el mismo flujo de pipeline compartido mediante mocks de `prevalidar_y_parsear_codigo` y `ejecutar_pipeline_explicito`.
- Se introdujeron dos clases dummy de comando (`_DummyRunCommand`, `_DummyReplCommand`) para aislar la verificación de la ayuda principal sin cargar la implementación completa de los comandos.

### Testing

- Ejecutado: `pytest -q tests/unit/test_cli_default_command.py tests/unit/test_repl_command_v2.py` y el conjunto devolvió `33 passed` y 1 warning.
- Los tests usan `monkeypatch`/`patch` para reemplazar `prevalidar_y_parsear_codigo`, `ejecutar_pipeline_explicito` y entrada por teclado (`builtins.input`) según cada escenario y todos los casos automatizados pasaron correctamente.
- Se verificó además que los cambios no alteran otros contratos de CLI al mantener las pruebas enfocadas y aisladas con dobles y parsers dummy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edb3358fa48327a286f28cfddc173a)