### PR TITLE
Ajusta UX de arranque de CLI para mostrar comandos principales y ayuda explícita

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -1027,7 +1027,12 @@ class CliApplication:
             return self.run_menu(args)
         if command is None:
             if self.parser is not None:
-                self.parser.print_help()
+                messages.mostrar_info(
+                    _(
+                        "Comandos principales: run, build, test, mod, repl. "
+                        "Usa --help para ver la ayuda completa."
+                    )
+                )
                 return 1
             messages.mostrar_error(
                 _("CLI no inicializada completamente: parser no disponible. "
@@ -1076,7 +1081,8 @@ class CliApplication:
                         "Compatibilidad legacy habilitada para esta ejecución. "
                         "Actualiza tus imports a `pcobra.*` antes de fase 3."
                     )
-                messages.mostrar_logo()
+                if command is not None:
+                    messages.mostrar_logo()
 
                 return self.execute_command(args, debug_activo=debug_activo)
             except Exception as e:

--- a/tests/unit/test_cli_default_command.py
+++ b/tests/unit/test_cli_default_command.py
@@ -49,11 +49,12 @@ def test_no_command_prints_help_and_does_not_run_default():
         _patch_cli_env(stack)
         stack.enter_context(patch("cobra.cli.cli.AppConfig.BASE_COMMAND_CLASSES", [InteractiveCommand]))
         mock_run = stack.enter_context(patch("cobra.cli.cli.InteractiveCommand.run", return_value=0))
-        mock_help = stack.enter_context(patch.object(CustomArgumentParser, "print_help"))
+        mock_info = stack.enter_context(patch("cobra.cli.cli.messages.mostrar_info"))
         app = CliApplication()
         result = app.run([])
     mock_run.assert_not_called()
-    mock_help.assert_called_once()
+    mock_info.assert_called_once()
+    assert "comandos principales" in mock_info.call_args.args[0].lower()
     assert result == 1
 
 
@@ -63,12 +64,12 @@ def test_main_without_args_prints_help_and_returns_one():
         stack.enter_context(patch("cobra.cli.cli.AppConfig.BASE_COMMAND_CLASSES", [InteractiveCommand]))
         stack.enter_context(patch("cobra.cli.cli.configure_encoding"))
         mock_run = stack.enter_context(patch("cobra.cli.cli.InteractiveCommand.run", return_value=0))
-        mock_help = stack.enter_context(patch.object(CustomArgumentParser, "print_help"))
+        mock_info = stack.enter_context(patch("cobra.cli.cli.messages.mostrar_info"))
 
         result = main([])
 
     mock_run.assert_not_called()
-    mock_help.assert_called_once()
+    mock_info.assert_called_once()
     assert result == 1
 
 
@@ -195,5 +196,6 @@ def test_cli_sin_argumentos_no_imprime_ayuda_detallada_de_subcomandos(capsys):
         result = app.run([])
     assert result == 1
     stdout = capsys.readouterr().out
-    assert "repl" in stdout
+    assert "comandos principales" in stdout.lower()
+    assert "repl" in stdout.lower()
     assert "--sandbox" not in stdout


### PR DESCRIPTION
### Motivation
- Evitar que la CLI imprima la ayuda completa automáticamente cuando no se pasa ningún subcomando, ofreciendo en su lugar una pista concisa sobre los comandos principales y manteniendo `--help` como mecanismo explícito para desplegar la ayuda detallada.
- Reducir ruido visual al inicio al no mostrar el logo cuando no se va a ejecutar ningún comando.
- Mantener intacto el contrato del REPL y el pipeline de ejecución (no se tocan lexer/parser/gramática y se reutiliza el runtime existente). 

### Description
- Reemplaza la llamada a `parser.print_help()` cuando no hay subcomando por `messages.mostrar_info(...)` que muestra un mensaje corto con los comandos principales (`run`, `build`, `test`, `mod`, `repl`). (archivo modificado: `src/pcobra/cobra/cli/cli.py`).
- Evita mostrar el logo en arranques sin comando al condicionar `messages.mostrar_logo()` para que solo se muestre si hay un comando real que ejecutar. (archivo modificado: `src/pcobra/cobra/cli/cli.py`).
- Actualiza pruebas unitarias para reflejar el nuevo comportamiento y validar que ahora se llama a `messages.mostrar_info` y que el texto esperado aparece en la salida; se modificó `tests/unit/test_cli_default_command.py` en consecuencia.
- No se introdujeron cambios en la implementación del REPL; la clase `ReplCommandV2` y el flujo que reutiliza `prevalidar_y_parsear_codigo` / `ejecutar_pipeline_explicito` permanecen sin alterar (`src/pcobra/cobra/cli/commands_v2/repl_cmd.py`).

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_default_command.py` y todos los tests pasaron: `9 passed, 1 warning`.
- Ejecutado `pytest -q tests/integration/test_run_repl_equivalence.py -k "persistencia_basica_var_x"` y el caso seleccionado pasó: `1 passed, 13 deselected, 1 warning`.
- Las pruebas automatizadas anteriores confirmaron que el comportamiento nuevo cumple el contrato de UX inicial sin afectar la funcionalidad del REPL ni del pipeline de ejecución.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edb4a896cc8327a87a135134457b8d)