### PR TITLE
refactor(repl): priorizar metadatos de ParserError para detectar entrada incompleta

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -13,7 +13,7 @@ from pcobra.cobra.cli.execution_pipeline import (
 )
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.messages import mostrar_info
-from pcobra.cobra.core import LexerError, ParserError
+from pcobra.cobra.core import LexerError, ParserError, TipoToken
 from pcobra.cobra.core.runtime import InterpretadorCobra
 from pcobra.cobra.core.semantic_validators import PrimitivaPeligrosaError
 from pcobra.cobra.cli.target_policies import parse_runtime_target
@@ -46,6 +46,13 @@ _PATRONES_ERROR_BLOQUE_INCOMPLETO: tuple[tuple[str, str], ...] = (
     ),
 )
 
+_TOKENS_CIERRE_INCOMPLETO = {
+    TipoToken.FIN,
+    TipoToken.RPAREN,
+    TipoToken.RBRACKET,
+    TipoToken.RBRACE,
+}
+
 
 class ReplCommandV2(BaseCommand):
     """Comando v2 público para iniciar el REPL de Cobra."""
@@ -60,15 +67,84 @@ class ReplCommandV2(BaseCommand):
         self._seguro_repl: bool = True
         self._extra_validators_repl: Any = None
 
+    def _normalizar_tipo_token(self, valor: Any) -> TipoToken | None:
+        """Normaliza posibles representaciones de token a ``TipoToken``."""
+        if isinstance(valor, TipoToken):
+            return valor
+        if valor is None:
+            return None
+        nombre = str(valor).strip()
+        if not nombre:
+            return None
+        if "." in nombre:
+            nombre = nombre.split(".")[-1]
+        try:
+            return TipoToken[nombre]
+        except KeyError:
+            return None
+
+    def _extraer_token_desde_error(self, err: ParserError) -> Any | None:
+        """Obtiene el token actual desde metadatos del ``ParserError`` si existe."""
+        for attr in ("token_actual", "token", "current_token", "actual_token"):
+            if hasattr(err, attr):
+                return getattr(err, attr)
+        return None
+
+    def _es_entrada_incompleta_por_metadata(self, err: ParserError) -> bool:
+        """Clasifica entrada incompleta priorizando metadatos del ``ParserError``."""
+        token_actual = self._extraer_token_desde_error(err)
+        tipo_token_actual = self._normalizar_tipo_token(
+            getattr(token_actual, "tipo", None)
+            if token_actual is not None
+            else getattr(err, "tipo_token_actual", None)
+            or getattr(err, "current_token_type", None)
+        )
+
+        esperado_raw = (
+            getattr(err, "esperado", None)
+            or getattr(err, "expected", None)
+            or getattr(err, "tokens_esperados", None)
+            or getattr(err, "expected_tokens", None)
+            or getattr(err, "token_esperado", None)
+            or getattr(err, "expected_token", None)
+        )
+        esperados = esperado_raw if isinstance(esperado_raw, (list, tuple, set)) else [esperado_raw]
+        tipos_esperados = {self._normalizar_tipo_token(item) for item in esperados}
+        tipos_esperados.discard(None)
+
+        eof_explicito = bool(
+            getattr(err, "eof", False)
+            or getattr(err, "es_eof", False)
+            or getattr(err, "unexpected_eof", False)
+            or getattr(err, "is_eof", False)
+            or tipo_token_actual == TipoToken.EOF
+        )
+
+        if eof_explicito and bool(tipos_esperados & _TOKENS_CIERRE_INCOMPLETO):
+            return True
+
+        posicion = (
+            getattr(err, "posicion", None)
+            or getattr(err, "position", None)
+            or getattr(err, "indice", None)
+            or getattr(err, "index", None)
+        )
+        if eof_explicito and tipos_esperados and posicion is not None:
+            return True
+
+        return False
+
     def es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
         """Detecta si la excepción corresponde a una entrada aún incompleta.
 
-        Se basa únicamente en `ParserError` y en mensajes canónicos emitidos por
-        el parser oficial.
+        Prioriza metadatos de ``ParserError`` (tipo/token/posición) y usa
+        matching textual como *fallback* controlado para compatibilidad.
         """
 
         if not isinstance(exc, ParserError):
             return False
+        if self._es_entrada_incompleta_por_metadata(exc):
+            return True
         mensaje = str(exc).strip().lower()
         return any(patron in mensaje for patron, _razon in _PATRONES_ERROR_BLOQUE_INCOMPLETO)
 

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -4,9 +4,29 @@ import pytest
 
 from pcobra.cobra.cli.commands_v2 import repl_cmd as repl_module
 from pcobra.cobra.cli.commands import interactive_cmd as interactive_module
-from pcobra.cobra.core import ParserError
+from pcobra.cobra.core import ParserError, TipoToken
 
 ReplCommandV2 = repl_module.ReplCommandV2
+
+
+def _parser_error_con_metadata(
+    mensaje: str,
+    *,
+    esperado=None,
+    token_actual=None,
+    eof: bool | None = None,
+    posicion: int | None = None,
+):
+    err = ParserError(mensaje)
+    if esperado is not None:
+        err.esperado = esperado
+    if token_actual is not None:
+        err.token_actual = token_actual
+    if eof is not None:
+        err.eof = eof
+    if posicion is not None:
+        err.posicion = posicion
+    return err
 
 
 @pytest.mark.parametrize(
@@ -27,6 +47,76 @@ def test_es_error_de_bloque_incompleto_por_mensajes_parser(mensaje, es_incomplet
 def test_es_error_de_bloque_incompleto_rechaza_excepciones_que_no_son_parser():
     command = ReplCommandV2()
     assert not command.es_error_de_bloque_incompleto(ValueError("no parser"))
+
+
+@pytest.mark.parametrize(
+    ("err", "es_incompleto"),
+    [
+        (
+            _parser_error_con_metadata(
+                "bloque sin cierre",
+                esperado=[TipoToken.FIN],
+                token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                eof=True,
+                posicion=15,
+            ),
+            True,
+        ),
+        (
+            _parser_error_con_metadata(
+                "paren sin cierre",
+                esperado=[TipoToken.RPAREN],
+                token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                eof=True,
+                posicion=8,
+            ),
+            True,
+        ),
+        (
+            _parser_error_con_metadata(
+                "lista sin cierre",
+                esperado=[TipoToken.RBRACKET],
+                token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                eof=True,
+                posicion=3,
+            ),
+            True,
+        ),
+        (
+            _parser_error_con_metadata(
+                "dict sin cierre",
+                esperado=[TipoToken.RBRACE],
+                token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                eof=True,
+                posicion=21,
+            ),
+            True,
+        ),
+        (
+            _parser_error_con_metadata(
+                "EOF prematuro",
+                esperado=[TipoToken.RPAREN],
+                token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                eof=True,
+                posicion=1,
+            ),
+            True,
+        ),
+        (
+            _parser_error_con_metadata(
+                "error real",
+                esperado=[TipoToken.IDENTIFICADOR],
+                token_actual=type("Tok", (), {"tipo": TipoToken.SI})(),
+                eof=False,
+                posicion=4,
+            ),
+            False,
+        ),
+    ],
+)
+def test_es_error_de_bloque_incompleto_prioriza_metadata(err, es_incompleto):
+    command = ReplCommandV2()
+    assert command.es_error_de_bloque_incompleto(err) is es_incompleto
 
 
 def test_repl_v2_mantiene_buffer_hasta_parseo_valido(monkeypatch):


### PR DESCRIPTION
### Motivation
- Evitar depender únicamente del matching textual en mensajes de `ParserError` para determinar si la entrada REPL está incompleta, y aprovechar metadatos (token actual/esperado/EOF/posición) cuando estén disponibles.\n
### Description
- Se añadió detección basada en metadatos en `ReplCommandV2` importando `TipoToken` y definiendo `_TOKENS_CIERRE_INCOMPLETO`.\n- Se implementaron los helpers `_normalizar_tipo_token`, `_extraer_token_desde_error` y `_es_entrada_incompleta_por_metadata` para normalizar representaciones de tokens y clasificar entradas incompletas por campos del `ParserError`.\n- `es_error_de_bloque_incompleto` ahora prioriza la ruta basada en metadatos y mantiene el matching textual existente como fallback compatible.\n- Se agregaron pruebas unitarias en `tests/unit/test_repl_command_v2.py` para cubrir casos mínimos (bloque sin `fin`, `(` sin cierre, `[` sin cierre, `{` sin cierre, EOF prematuro) y un caso negativo; no se alteró el flujo `prevalidar_y_parsear_codigo(codigo)` + `ejecutar_pipeline_explicito(...)`.\n
### Testing
- Ejecutado `pytest -q tests/unit/test_repl_command_v2.py` y todos los tests pasaron (`30 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edb6566c688327b113ca4bb603da03)