### PR TITLE
Ajusta salida de REPL con `salir`/`exit` aun con buffer activo

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -238,8 +238,13 @@ class ReplCommandV2(BaseCommand):
                 continue
 
             comando = linea.strip()
-            if comando in {"salir", "exit"} and not buffer:
-                mostrar_info(_("Saliendo..."))
+            if comando in {"salir", "exit"}:
+                if buffer:
+                    mostrar_info(_("Entrada multilinea cancelada. Saliendo del REPL."))
+                    buffer.clear()
+                    self._delegate._estado_repl = self._delegate._crear_estado_repl()
+                else:
+                    mostrar_info(_("Saliendo..."))
                 break
 
             buffer.append(linea)

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -251,7 +251,7 @@ def test_repl_v2_sale_por_salir_y_por_exit(monkeypatch):
     assert prompts_exit == [">>> "]
 
 
-def test_repl_v2_no_sale_con_exit_si_hay_bloque_pendiente(monkeypatch):
+def test_repl_v2_sale_con_exit_si_hay_bloque_pendiente(monkeypatch):
     command = ReplCommandV2()
     entradas = iter(["si verdadero:", "exit", "fin", "exit"])
     parse_calls: list[str] = []
@@ -289,8 +289,8 @@ def test_repl_v2_no_sale_con_exit_si_hay_bloque_pendiente(monkeypatch):
     )
 
     assert status == 0
-    assert parse_calls == ["si verdadero:", "si verdadero:\nexit", "si verdadero:\nexit\nfin"]
-    assert pipeline_calls == ["si verdadero:\nexit\nfin"]
+    assert parse_calls == ["si verdadero:"]
+    assert pipeline_calls == []
 
 
 def test_repl_v2_limpia_buffer_ante_error_real(monkeypatch):


### PR DESCRIPTION
### Motivation
- Permitir que los comandos de salida `salir` y `exit` finalicen la sesión del REPL incluso cuando hay una entrada multilinea en curso, cancelando el buffer y restaurando el estado REPL en ese caso.

### Description
- En `ReplCommandV2.run()` se evalúa `comando = linea.strip()` antes de hacer `buffer.append(linea)` y se cambia la lógica para que `comando in {'salir','exit'}` siempre termine el bucle.
- Cuando se recibe `salir`/`exit` con `buffer` no vacío, ahora se muestra el mensaje de cancelación, se limpia `buffer` y se reinicia el estado REPL con `self._delegate._crear_estado_repl()` antes de salir.
- Se dejó intacto el manejo de `KeyboardInterrupt` y `EOFError` y no se modificó el parser ni reglas de sintaxis.
- Se actualizó la prueba unitaria correspondiente en `tests/unit/test_repl_command_v2.py` para reflejar el nuevo comportamiento esperado.

### Testing
- Se ejecutó `pytest -q tests/unit/test_repl_command_v2.py` y todos los tests del archivo pasaron (`30 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edb77a6c408327a369b96e91b573c9)