### PR TITLE
Ajusta UX de 'cobra' sin argumentos y refuerza ayuda pública

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -1029,8 +1029,8 @@ class CliApplication:
             if self.parser is not None:
                 messages.mostrar_info(
                     _(
-                        "Comandos principales: run, build, test, mod, repl. "
-                        "Usa --help para ver la ayuda completa."
+                        "No se indicó ningún comando. "
+                        "Usa --help para ver la ayuda disponible."
                     )
                 )
                 return 1

--- a/tests/unit/test_cli_default_command.py
+++ b/tests/unit/test_cli_default_command.py
@@ -1,5 +1,6 @@
 import argparse
 from contextlib import ExitStack
+import re
 from unittest.mock import patch
 
 import pytest
@@ -54,7 +55,7 @@ def test_no_command_prints_help_and_does_not_run_default():
         result = app.run([])
     mock_run.assert_not_called()
     mock_info.assert_called_once()
-    assert "comandos principales" in mock_info.call_args.args[0].lower()
+    assert "no se indicó ningún comando" in mock_info.call_args.args[0].lower()
     assert result == 1
 
 
@@ -196,6 +197,26 @@ def test_cli_sin_argumentos_no_imprime_ayuda_detallada_de_subcomandos(capsys):
         result = app.run([])
     assert result == 1
     stdout = capsys.readouterr().out
-    assert "comandos principales" in stdout.lower()
-    assert "repl" in stdout.lower()
+    assert "no se indicó ningún comando" in stdout.lower()
+    assert "run" not in stdout.lower()
+    assert "repl" not in stdout.lower()
     assert "--sandbox" not in stdout
+
+
+def test_public_help_no_expone_aliases_legacy_en_superficie_visible(capsys):
+    with ExitStack() as stack:
+        _patch_cli_env(stack)
+        stack.enter_context(
+            patch("cobra.cli.cli.AppConfig.V2_COMMAND_CLASSES", [_DummyRunCommand, _DummyReplCommand])
+        )
+        stack.enter_context(patch("cobra.cli.cli.resolve_command_profile", return_value="public"))
+        app = CliApplication()
+        with pytest.raises(SystemExit) as excinfo:
+            app.run(["--help"])
+
+    assert excinfo.value.code == 0
+    stdout = capsys.readouterr().out.lower()
+    assert "run" in stdout
+    assert "repl" in stdout
+    legacy_as_command = re.compile(r"^\s+(ejecutar|compilar|verificar|modulos)\b", re.MULTILINE)
+    assert legacy_as_command.search(stdout) is None


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia cuando se invoca `cobra` sin argumentos mostrando un mensaje breve y sugerente en lugar de listar subcomandos.
- Mantener explícitos los ejemplos públicos en la ayuda completa (`--help`) para `run/build/test/mod/repl`.
- Evitar que la superficie pública muestre comandos o aliases legacy accidentalmente en la ayuda.

### Description
- Modificado `execute_command()` en `src/pcobra/cobra/cli/cli.py` para que cuando `cmd` sea `None` muestre: "No se indicó ningún comando. Usa --help para ver la ayuda disponible." en vez de listar comandos.
- Conservado el `epilog` de `_build_argument_parser()` con los ejemplos públicos (`run/build/test/mod/repl`) sin cambios.
- Añadida/verificada la política pública para evitar exposición de rutas/aliases legacy en la ayuda (se respeta `_apply_public_cli_policy` y el guard de startup).
- Actualizados y añadidos tests en `tests/unit/test_cli_default_command.py` para comprobar el comportamiento diferencial entre `cobra` (sin args) y `cobra --help`, y se añadió `test_public_help_no_expone_aliases_legacy_en_superficie_visible` para asegurar que la ayuda pública no lista subcomandos legacy.

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_default_command.py` y todos los tests del archivo pasaron (`10 passed`).
- Las pruebas verifican que `cobra` sin argumentos retorna código `1` y muestra el mensaje breve, y que `cobra --help` sigue exponiendo los comandos públicos sin reintroducir aliases legacy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edb9b1ccb08327b613375c7e1cb03a)