### PR TITLE
test(cli): enforce v2 public repl contract

### DIFF
--- a/tests/integration/golden/cli_ui_v2_help_public.golden
+++ b/tests/integration/golden/cli_ui_v2_help_public.golden
@@ -59,4 +59,4 @@ options:
                         cobra_plugins_allowlist.
 
 ejemplos públicos: cobra run <archivo.co> cobra build <archivo.co> cobra test
-<archivo.co> cobra mod <list|install|remove|publish|search>
+<archivo.co> cobra mod <list|install|remove|publish|search> cobra repl

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -1,8 +1,10 @@
+import argparse
 import os
 import subprocess
 import sys
 from pathlib import Path
 
+import cobra.cli.cli as cli_module
 from pcobra.cobra.cli.public_command_policy import PUBLIC_COMMANDS
 
 
@@ -23,6 +25,22 @@ def test_cli_public_commands_contract_is_stable():
 def test_cli_public_commands_contract_keeps_repl_as_official_command():
     # `repl` debe permanecer en el contrato público oficial (no alias legacy).
     assert "repl" in PUBLIC_COMMANDS
+
+
+def test_cli_ui_v2_registra_repl_oficial_y_no_alias_interactive_legacy():
+    registry = cli_module.CommandRegistry()
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+
+    commands = registry.register_base_commands(
+        subparsers,
+        ui="v2",
+        profile="public",
+    )
+
+    assert "repl" in commands
+    assert commands["repl"].__class__.__name__ == "ReplCommandV2"
+    assert "interactive" not in commands
 
 
 def test_cli_help_public_contract_snapshot():

--- a/tests/unit/test_public_command_policy.py
+++ b/tests/unit/test_public_command_policy.py
@@ -1,6 +1,7 @@
 from cobra.cli.public_command_policy import (
     PROFILE_DEVELOPMENT,
     PROFILE_PUBLIC,
+    PUBLIC_COMMANDS_CONTRACT,
     filter_commands_for_profile,
     filter_legacy_commands_for_profile,
 )
@@ -18,6 +19,11 @@ def test_filter_commands_development_permite_toda_superficie_v2():
     comandos = ("run", "build", "test", "mod", "repl", "legacy", "debug")
     visibles = filter_commands_for_profile(comandos, PROFILE_DEVELOPMENT)
     assert visibles == set(comandos)
+
+
+def test_public_commands_contract_oficial_v2_no_incluye_alias_legacy():
+    assert PUBLIC_COMMANDS_CONTRACT == ("run", "build", "test", "mod", "repl")
+    assert "interactive" not in PUBLIC_COMMANDS_CONTRACT
 
 
 def test_filter_legacy_commands_publico_bloquea_toda_superficie_v1():


### PR DESCRIPTION
### Motivation
- Asegurar que la superficie pública de la CLI v2 exponga `repl` como comando oficial (implementado por `ReplCommandV2`) y que no se filtre el alias legacy `interactive` al perfil público.
- Evitar regresiones en la visibilidad de comandos públicas mediante pruebas de contrato que fijen explícitamente la tupla oficial de comandos v2.

### Description
- Añadido test de integración `tests/integration/test_cli_public_help_contract.py` que instancia `CommandRegistry` y verifica que con `ui="v2"` y `profile="public"` se registre `repl` implementado por `ReplCommandV2` y que no exista `interactive` en el mapeo de comandos.
- Añadido test unitario `tests/unit/test_public_command_policy.py` que comprueba `PUBLIC_COMMANDS_CONTRACT == ("run", "build", "test", "mod", "repl")` y asegura que `interactive` no forme parte del contrato público.
- Actualizado el snapshot golden `tests/integration/golden/cli_ui_v2_help_public.golden` para reflejar que los ejemplos públicos incluyen `cobra repl` y mantener consistencia con la salida actual del CLI.

### Testing
- Ejecutado `pytest -q tests/integration/test_cli_public_help_contract.py tests/unit/test_public_command_policy.py` y los tests pasaron con salida: `13 passed, 1 warning`.
- Se validó localmente registro de comandos vía `CommandRegistry.register_base_commands(...)` cubierto por el nuevo test de integración que confirma `ReplCommandV2` y ausencia de `interactive`.
- Se actualizó y verificó la golden snapshot para que la comparación de `--help` pública sea estable con la política pública actual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edbb3051608327ac4a3288fcef1d21)