### PR TITLE
REPL v2: detectar bloque incompleto por metadata EOF y ajustar pruebas

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -19,33 +19,6 @@ from pcobra.cobra.core.semantic_validators import PrimitivaPeligrosaError
 from pcobra.cobra.cli.target_policies import parse_runtime_target
 from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
 
-_PATRONES_ERROR_BLOQUE_INCOMPLETO: tuple[tuple[str, str], ...] = (
-    (
-        "se esperaba 'fin' para cerrar",
-        "El parser llegó a EOF con un bloque de control sin cerrar con 'fin'.",
-    ),
-    (
-        "tipotoken.eof",
-        "El parser encontró EOF donde esperaba más tokens válidos para completar la sentencia.",
-    ),
-    (
-        "se esperaba ')' para cerrar",
-        "El parser detectó delimitador de paréntesis pendiente de cierre.",
-    ),
-    (
-        "se esperaba ')' al final",
-        "El parser detectó delimitador de paréntesis pendiente de cierre al finalizar la entrada.",
-    ),
-    (
-        "se esperaba ']' al final",
-        "El parser detectó delimitador de lista pendiente de cierre al finalizar la entrada.",
-    ),
-    (
-        "se esperaba '}' al final",
-        "El parser detectó delimitador de diccionario pendiente de cierre al finalizar la entrada.",
-    ),
-)
-
 _TOKENS_CIERRE_INCOMPLETO = {
     TipoToken.FIN,
     TipoToken.RPAREN,
@@ -85,9 +58,27 @@ class ReplCommandV2(BaseCommand):
 
     def _extraer_token_desde_error(self, err: ParserError) -> Any | None:
         """Obtiene el token actual desde metadatos del ``ParserError`` si existe."""
-        for attr in ("token_actual", "token", "current_token", "actual_token"):
+        for attr in (
+            "token_actual",
+            "token",
+            "current_token",
+            "actual_token",
+            "last_token",
+            "ultimo_token",
+        ):
             if hasattr(err, attr):
-                return getattr(err, attr)
+                token = getattr(err, attr)
+                if token is not None:
+                    return token
+        for attr in ("estado", "state", "parser_state"):
+            if hasattr(err, attr):
+                estado = getattr(err, attr)
+                if estado is None:
+                    continue
+                for token_attr in ("token_actual", "token", "current_token"):
+                    token = getattr(estado, token_attr, None)
+                    if token is not None:
+                        return token
         return None
 
     def _es_entrada_incompleta_por_metadata(self, err: ParserError) -> bool:
@@ -112,41 +103,37 @@ class ReplCommandV2(BaseCommand):
         tipos_esperados = {self._normalizar_tipo_token(item) for item in esperados}
         tipos_esperados.discard(None)
 
-        eof_explicito = bool(
+        cierre_esperado = bool(tipos_esperados & _TOKENS_CIERRE_INCOMPLETO)
+        if not cierre_esperado:
+            return False
+
+        eof_por_flag = bool(
             getattr(err, "eof", False)
             or getattr(err, "es_eof", False)
             or getattr(err, "unexpected_eof", False)
             or getattr(err, "is_eof", False)
-            or tipo_token_actual == TipoToken.EOF
+            or getattr(err, "at_eof", False)
+            or getattr(err, "en_eof", False)
+        )
+        eof_por_token = tipo_token_actual == TipoToken.EOF
+        posicion_eof = bool(
+            getattr(err, "posicion_eof", False)
+            or getattr(err, "position_eof", False)
+            or getattr(err, "eof_position", False)
+            or getattr(err, "at_end_of_input", False)
         )
 
-        if eof_explicito and bool(tipos_esperados & _TOKENS_CIERRE_INCOMPLETO):
-            return True
-
-        posicion = (
-            getattr(err, "posicion", None)
-            or getattr(err, "position", None)
-            or getattr(err, "indice", None)
-            or getattr(err, "index", None)
-        )
-        if eof_explicito and tipos_esperados and posicion is not None:
-            return True
-
-        return False
+        return eof_por_flag or eof_por_token or posicion_eof
 
     def es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
         """Detecta si la excepción corresponde a una entrada aún incompleta.
 
-        Prioriza metadatos de ``ParserError`` (tipo/token/posición) y usa
-        matching textual como *fallback* controlado para compatibilidad.
+        Prioriza metadatos de ``ParserError`` (tipo/token/estado EOF).
         """
 
         if not isinstance(exc, ParserError):
             return False
-        if self._es_entrada_incompleta_por_metadata(exc):
-            return True
-        mensaje = str(exc).strip().lower()
-        return any(patron in mensaje for patron, _razon in _PATRONES_ERROR_BLOQUE_INCOMPLETO)
+        return self._es_entrada_incompleta_por_metadata(exc)
 
     def register_subparser(self, subparsers: Any):
         parser = subparsers.add_parser(self.name, help=_("Start Cobra REPL"))

--- a/tests/cli/test_repl_v2_pipeline_security_contract.py
+++ b/tests/cli/test_repl_v2_pipeline_security_contract.py
@@ -3,8 +3,15 @@ from __future__ import annotations
 import argparse
 
 from pcobra.cobra.cli.commands_v2 import repl_cmd as repl_module
-from pcobra.cobra.core import ParserError
+from pcobra.cobra.core import ParserError, TipoToken
 
+
+def _parser_error_incompleto(esperado):
+    err = ParserError("entrada incompleta")
+    err.esperado = [esperado]
+    err.token_actual = type("Tok", (), {"tipo": TipoToken.EOF})()
+    err.eof = True
+    return err
 
 
 def _args_repl() -> argparse.Namespace:
@@ -102,7 +109,7 @@ def test_repl_v2_bloque_anidado_real_mientras_si_fin_fin_acumula_hasta_completar
     def _fake_parse(codigo: str):
         parse_calls.append(codigo)
         if codigo != bloque_completo:
-            raise ParserError("Se esperaba 'fin' para cerrar el bloque")
+            raise _parser_error_incompleto(TipoToken.FIN)
         return [object()]
 
     class _Setup:
@@ -142,7 +149,7 @@ def test_repl_v2_error_sintactico_real_limpia_buffer_y_repl_sigue(monkeypatch):
     def _fake_parse(codigo: str):
         parse_calls.append(codigo)
         if codigo == "si verdadero:":
-            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+            raise _parser_error_incompleto(TipoToken.FIN)
         if codigo == "si verdadero:\nimprimir(1":
             raise ParserError("Token inesperado: '('")
         return [object()]
@@ -181,7 +188,7 @@ def test_repl_v2_bloque_incompleto_no_ejecuta_ni_limpia_hasta_completar(monkeypa
     def _fake_parse(codigo: str):
         parse_calls.append(codigo)
         if codigo != bloque_completo:
-            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+            raise _parser_error_incompleto(TipoToken.FIN)
         return [object()]
 
     class _Setup:

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -32,14 +32,14 @@ def _parser_error_con_metadata(
 @pytest.mark.parametrize(
     ("mensaje", "es_incompleto"),
     [
-        ("Se esperaba 'fin' para cerrar el bloque condicional", True),
-        ("Token inesperado en término: TipoToken.EOF", True),
-        ("Se esperaba ']' al final de la lista", True),
+        ("Se esperaba 'fin' para cerrar el bloque condicional", False),
+        ("Token inesperado en término: TipoToken.EOF", False),
+        ("Se esperaba ']' al final de la lista", False),
         ("Token inesperado: '('", False),
         ("Se encontró 'fin' inesperado", False),
     ],
 )
-def test_es_error_de_bloque_incompleto_por_mensajes_parser(mensaje, es_incompleto):
+def test_es_error_de_bloque_incompleto_no_depende_de_mensajes_parser(mensaje, es_incompleto):
     command = ReplCommandV2()
     assert command.es_error_de_bloque_incompleto(ParserError(mensaje)) is es_incompleto
 
@@ -130,7 +130,12 @@ def test_repl_v2_mantiene_buffer_hasta_parseo_valido(monkeypatch):
     def _fake_parse(codigo: str):
         parse_calls.append(codigo)
         if codigo != "si verdadero:\nimprimir(1)\nfin":
-            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+            raise _parser_error_con_metadata(
+                "Se esperaba 'fin' para cerrar el bloque condicional",
+                esperado=[TipoToken.FIN],
+                token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                eof=True,
+            )
         return []
 
     monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", _fake_parse)
@@ -177,7 +182,12 @@ def test_repl_v2_prompts_primario_y_secundario_en_bloque(monkeypatch):
 
     def _fake_parse(codigo: str):
         if codigo != "si verdadero:\nimprimir(1)\nfin":
-            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+            raise _parser_error_con_metadata(
+                "Se esperaba 'fin' para cerrar el bloque condicional",
+                esperado=[TipoToken.FIN],
+                token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                eof=True,
+            )
         return []
 
     monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", _fake_parse)
@@ -262,7 +272,12 @@ def test_repl_v2_sale_con_exit_si_hay_bloque_pendiente(monkeypatch):
     def _fake_parse(codigo: str):
         parse_calls.append(codigo)
         if codigo != "si verdadero:\nexit\nfin":
-            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+            raise _parser_error_con_metadata(
+                "Se esperaba 'fin' para cerrar el bloque condicional",
+                esperado=[TipoToken.FIN],
+                token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                eof=True,
+            )
         return []
 
     class _Setup:
@@ -328,7 +343,12 @@ def test_repl_v2_limpia_buffer_ante_error_real(monkeypatch):
         (
             ["si verdadero :", "fin", "exit"],
             {
-                "si verdadero :": "Se esperaba 'fin' para cerrar el bloque condicional",
+                "si verdadero :": _parser_error_con_metadata(
+                    "Se esperaba 'fin' para cerrar el bloque condicional",
+                    esperado=[TipoToken.FIN],
+                    token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                    eof=True,
+                ),
             },
             ["si verdadero :", "si verdadero :\nfin"],
             ["si verdadero :\nfin"],
@@ -337,7 +357,12 @@ def test_repl_v2_limpia_buffer_ante_error_real(monkeypatch):
         (
             ["mientras verdadero :", "fin", "exit"],
             {
-                "mientras verdadero :": "Se esperaba 'fin' para cerrar el bloque mientras",
+                "mientras verdadero :": _parser_error_con_metadata(
+                    "Se esperaba 'fin' para cerrar el bloque mientras",
+                    esperado=[TipoToken.FIN],
+                    token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                    eof=True,
+                ),
             },
             ["mientras verdadero :", "mientras verdadero :\nfin"],
             ["mientras verdadero :\nfin"],
@@ -346,7 +371,12 @@ def test_repl_v2_limpia_buffer_ante_error_real(monkeypatch):
         (
             ["si verdadero :", "imprimir(1", "var z = 9", "exit"],
             {
-                "si verdadero :": "Se esperaba 'fin' para cerrar el bloque condicional",
+                "si verdadero :": _parser_error_con_metadata(
+                    "Se esperaba 'fin' para cerrar el bloque condicional",
+                    esperado=[TipoToken.FIN],
+                    token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                    eof=True,
+                ),
                 "si verdadero :\nimprimir(1": "Token inesperado: '('",
             },
             ["si verdadero :", "si verdadero :\nimprimir(1", "var z = 9"],
@@ -379,7 +409,10 @@ def test_repl_v2_incompleto_vs_error_real_buffer(
     def _fake_parse(codigo: str):
         parse_calls.append(codigo)
         if codigo in errores_por_codigo:
-            raise ParserError(errores_por_codigo[codigo])
+            err = errores_por_codigo[codigo]
+            if isinstance(err, ParserError):
+                raise err
+            raise ParserError(err)
         return []
 
     class _Setup:
@@ -469,7 +502,12 @@ def test_repl_v2_error_sintaxis_real_limpia_buffer_y_continua(monkeypatch):
     def _fake_parse(codigo: str):
         parse_calls.append(codigo)
         if codigo == "si verdadero:":
-            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+            raise _parser_error_con_metadata(
+                "Se esperaba 'fin' para cerrar el bloque condicional",
+                esperado=[TipoToken.FIN],
+                token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                eof=True,
+            )
         if codigo == "si verdadero:\nimprimir(1":
             raise ParserError("Token inesperado: '('")
         return []
@@ -514,7 +552,12 @@ def test_repl_v2_error_ejecucion_limpia_buffer_actual_y_continua(monkeypatch):
 
     def _fake_parse(codigo: str):
         if codigo == "si verdadero:":
-            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+            raise _parser_error_con_metadata(
+                "Se esperaba 'fin' para cerrar el bloque condicional",
+                esperado=[TipoToken.FIN],
+                token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                eof=True,
+            )
         return []
 
     monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", _fake_parse)
@@ -616,7 +659,12 @@ def test_repl_v2_anidamiento_real_no_ejecuta_hasta_cierre_completo_y_persiste_es
             "mientras verdadero:\nsi verdadero:\nvar total = 5\nromper\nfin\nfin",
             "imprimir(total)",
         }:
-            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+            raise _parser_error_con_metadata(
+                "Se esperaba 'fin' para cerrar el bloque condicional",
+                esperado=[TipoToken.FIN],
+                token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                eof=True,
+            )
         return []
 
     class _Setup:
@@ -806,7 +854,12 @@ def test_repl_v2_bloque_incompleto_acumula_buffer_y_sesion_sigue_activa(monkeypa
     def _fake_parse(codigo: str):
         parse_calls.append(codigo)
         if codigo != "si verdadero:\nimprimir(1)\nfin":
-            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+            raise _parser_error_con_metadata(
+                "Se esperaba 'fin' para cerrar el bloque condicional",
+                esperado=[TipoToken.FIN],
+                token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+                eof=True,
+            )
         return []
 
     class _Setup:


### PR DESCRIPTION
### Motivation

- El REPL debía dejar de depender de patrones textuales para decidir si un error de parser indica una entrada incompleta y, en su lugar, usar metadata estructurada del `ParserError` (EOF + tokens de cierre esperados). 

### Description

- Eliminé la dependencia en matching textual y reforcé `es_error_de_bloque_incompleto` para basarse exclusivamente en metadata del `ParserError` en `src/pcobra/cobra/cli/commands_v2/repl_cmd.py`.
- Amplié `_extraer_token_desde_error` para inspeccionar más atributos del error y posibles objetos de estado internos del parser (`estado/state/parser_state`) y devolver el token actual cuando exista.
- Reescribí `_es_entrada_incompleta_por_metadata` para requerir intersección con tokens de cierre esperados (`FIN`, `RPAREN`, `RBRACKET`, `RBRACE`) y detectar EOF por flags, por token actual `EOF` o por marcas de posición/estado EOF.
- Actualicé las pruebas para inyectar `ParserError` con metadata (EOF/esperado) y cubrir los casos solicitados ajustando `tests/unit/test_repl_command_v2.py` y `tests/cli/test_repl_v2_pipeline_security_contract.py`.

### Testing

- Ejecuté `pytest -q tests/unit/test_repl_command_v2.py tests/cli/test_repl_v2_pipeline_security_contract.py` y todas las pruebas relevantes pasaron con éxito (35 passed, 1 warning).
- Las pruebas verifican: acumulación de buffer en bloques anidados incompletos, limpieza de buffer ante errores de sintaxis reales, y que no se ejecuta hasta completarse el parseo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edbc411cb88327a9a28c13af9703cf)