### PR TITLE
Alinear mensajes públicos de la CLI v2 para incluir `repl` en el contrato

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -687,7 +687,7 @@ class CliApplication:
         raise RuntimeError(
             "Perfil público bloqueado por rutas legacy/internal migration only: "
             f"{', '.join(blocked_routes)}. "
-            "Use CLI v2 pública (run/build/test/mod) y enrute por "
+            "Use CLI v2 pública (run/build/test/mod/repl) y enrute por "
             f"{USER_ROUTE_BACKEND_ENTRYPOINT}."
         )
 
@@ -765,7 +765,7 @@ class CliApplication:
         messages.mostrar_advertencia(
             _(
                 "UI v1 está deshabilitada para uso público. "
-                "Se mantiene UI v2 (cobra run/build/test/mod)."
+                "Se mantiene UI v2 (cobra run/build/test/mod/repl)."
             )
         )
         return "v2"

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -95,7 +95,7 @@ def test_cli_help_public_contract_bloquea_ui_v1_en_perfil_publico():
     assert result.returncode == 2
     lower_output = result.stderr.lower() + result.stdout.lower()
     assert "ui v1 está deshabilitada para uso público" in lower_output
-    assert "se mantiene ui v2 (cobra run/build/test/mod)" in lower_output
+    assert "se mantiene ui v2 (cobra run/build/test/mod/repl)" in lower_output
     assert "argument --ui: invalid choice: 'v1' (choose from v2)" in lower_output
 
 


### PR DESCRIPTION
### Motivation
- Los mensajes de bloqueo/advertencia en arranque público referenciaban incompletamente el contrato público de comandos v2 omitiendo `repl`, lo que podía causar ambigüedad frente al contrato oficial.

### Description
- Actualicé el texto de la guarda de arranque público en `CliApplication._enforce_public_startup_guard` para mencionar explícitamente `run/build/test/mod/repl` en lugar de solo `run/build/test/mod` (archivo `src/pcobra/cobra/cli/cli.py`).
- Ajusté el mensaje mostrado cuando `--ui v1` está bloqueado para uso público en `CliApplication._resolve_selected_ui_from_argv` para incluir `repl` (archivo `src/pcobra/cobra/cli/cli.py`).
- Actualicé la aserción correspondiente en el test de integración `tests/integration/test_cli_public_help_contract.py` para validar el nuevo texto alineado con el contrato público.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_default_command.py tests/integration/test_cli_public_help_contract.py` y las pruebas unitarias e de integración relevantes pasaron (`18 passed, 1 warning`).
- No se modificó el snapshot `tests/integration/golden/cli_ui_v2_help_public.golden` y la salida de `--help` permaneció sin cambios funcionales, por lo que las comprobaciones de `--help` siguen siendo válidas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edbe3a190c8327b93961612c455e2d)