### PR TITLE
cli: incluir 'repl' en la guía pública de CLI v2

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/legacy_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/legacy_cmd.py
@@ -78,7 +78,7 @@ class LegacyCommandGroupV2(BaseCommand):
             messages.mostrar_error(
                 _(
                     "El grupo 'legacy' está restringido a development. "
-                    "Use comandos públicos: cobra run/build/test/mod."
+                    "Use comandos públicos: cobra run/build/test/mod/repl."
                 ),
                 registrar_log=False,
             )


### PR DESCRIPTION
### Motivation
- Asegurar consistencia entre la lista de comandos públicos de la UI v2, la ayuda interna y los mensajes de guía para usuarios, haciendo explícito que `repl` forma parte del contrato público v2 y no debe exponerse `InteractiveCommand` en el perfil público.

### Description
- Verificado que `AppConfig.V2_COMMAND_ROUTES` incluye `pcobra.cobra.cli.commands_v2.repl_cmd.ReplCommandV2` y que `PUBLIC_COMMANDS_CONTRACT` es exactamente `("run", "build", "test", "mod", "repl")`.
- Confirmado que `InteractiveCommand` permanece en rutas legacy/base y no forma parte del contrato público UI v2.
- Actualizada la guía/error en `src/pcobra/cobra/cli/commands_v2/legacy_cmd.py` para indicar `cobra run/build/test/mod/repl` y mantener la coherencia con el contrato público.

### Testing
- Ejecutadas búsquedas automáticas con `rg` para validar presencia de `V2_COMMAND_ROUTES`, `ReplCommandV2`, `PUBLIC_COMMANDS_CONTRACT` y referencias a `run/build/test/mod/repl`, y todas devolvieron las ubicaciones esperadas (éxito).
- Comparado el diff de `src/pcobra/cobra/cli/commands_v2/legacy_cmd.py` para verificar el cambio textual y confirmar que solo se modificó la línea de guía (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edbfe90dd4832796940d88277b3607)