### PR TITLE
Unifica criterio de bloque incompleto en REPL v2

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -82,7 +82,14 @@ class ReplCommandV2(BaseCommand):
         return None
 
     def _es_entrada_incompleta_por_metadata(self, err: ParserError) -> bool:
-        """Clasifica entrada incompleta priorizando metadatos del ``ParserError``."""
+        """Determina incompleto **solo** con metadatos del ``ParserError``.
+
+        El criterio es único y auditable: la entrada se considera incompleta
+        únicamente cuando ``prevalidar_y_parsear_codigo`` emite un ``ParserError``
+        que reporta EOF inesperado y, además, al menos un token de cierre
+        pendiente en ``esperado`` (por ejemplo ``FIN``, ``RPAREN``,
+        ``RBRACKET`` o ``RBRACE``).
+        """
         token_actual = self._extraer_token_desde_error(err)
         tipo_token_actual = self._normalizar_tipo_token(
             getattr(token_actual, "tipo", None)
@@ -108,27 +115,19 @@ class ReplCommandV2(BaseCommand):
             return False
 
         eof_por_flag = bool(
-            getattr(err, "eof", False)
+            getattr(err, "unexpected_eof", False)
+            or getattr(err, "eof", False)
             or getattr(err, "es_eof", False)
-            or getattr(err, "unexpected_eof", False)
-            or getattr(err, "is_eof", False)
-            or getattr(err, "at_eof", False)
-            or getattr(err, "en_eof", False)
         )
         eof_por_token = tipo_token_actual == TipoToken.EOF
-        posicion_eof = bool(
-            getattr(err, "posicion_eof", False)
-            or getattr(err, "position_eof", False)
-            or getattr(err, "eof_position", False)
-            or getattr(err, "at_end_of_input", False)
-        )
-
-        return eof_por_flag or eof_por_token or posicion_eof
+        return eof_por_flag or eof_por_token
 
     def es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
         """Detecta si la excepción corresponde a una entrada aún incompleta.
 
-        Prioriza metadatos de ``ParserError`` (tipo/token/estado EOF).
+        La decisión sale exclusivamente del ``ParserError`` emitido por
+        ``prevalidar_y_parsear_codigo``: EOF inesperado + cierres pendientes
+        en tokens esperados.
         """
 
         if not isinstance(exc, ParserError):

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -119,6 +119,39 @@ def test_es_error_de_bloque_incompleto_prioriza_metadata(err, es_incompleto):
     assert command.es_error_de_bloque_incompleto(err) is es_incompleto
 
 
+def test_incompleto_bloque_simple_por_eof_inesperado_y_fin_pendiente():
+    command = ReplCommandV2()
+    err = _parser_error_con_metadata(
+        "bloque sin cierre",
+        esperado=[TipoToken.FIN],
+        token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+        eof=True,
+    )
+    assert command.es_error_de_bloque_incompleto(err) is True
+
+
+def test_incompleto_bloque_anidado_por_eof_inesperado_y_cierres_pendientes():
+    command = ReplCommandV2()
+    err = _parser_error_con_metadata(
+        "bloque anidado sin cierres",
+        esperado=[TipoToken.RPAREN, TipoToken.FIN],
+        token_actual=type("Tok", (), {"tipo": TipoToken.EOF})(),
+        eof=True,
+    )
+    assert command.es_error_de_bloque_incompleto(err) is True
+
+
+def test_error_sintactico_real_no_se_clasifica_como_incompleto():
+    command = ReplCommandV2()
+    err = _parser_error_con_metadata(
+        "token inesperado real",
+        esperado=[TipoToken.IDENTIFICADOR],
+        token_actual=type("Tok", (), {"tipo": TipoToken.SI})(),
+        eof=False,
+    )
+    assert command.es_error_de_bloque_incompleto(err) is False
+
+
 def test_repl_v2_mantiene_buffer_hasta_parseo_valido(monkeypatch):
     command = ReplCommandV2()
     entradas = iter(["si verdadero:", "imprimir(1)", "fin", "exit"])


### PR DESCRIPTION
### Motivation
- Unificar y hacer auditable la detección de entradas incompletas en el REPL para evitar heurísticas externas y discrepancias entre parsers. 
- Garantizar que la decisión provenga exclusivamente de los metadatos del `ParserError` emitido por `prevalidar_y_parsear_codigo`.

### Description
- Cambiado `ReplCommandV2._es_entrada_incompleta_por_metadata` para que considere incompleto únicamente cuando el `ParserError` indica EOF inesperado (por flags como `unexpected_eof`/`eof`/`es_eof` o token actual `TipoToken.EOF`) y además hay al menos un token de cierre pendiente en los `esperado` (p. ej. `FIN`, `RPAREN`, `RBRACKET`, `RBRACE`).
- Eliminadas señales auxiliares no necesarias (metadatos de posición EOF y flags redundantes) para mantener un criterio único y auditable.
- Actualizados los docstrings de `_es_entrada_incompleta_por_metadata` y `es_error_de_bloque_incompleto` para declarar explícitamente que la decisión depende exclusivamente del `ParserError` emitido por `prevalidar_y_parsear_codigo`.
- Añadidas pruebas unitarias en `tests/unit/test_repl_command_v2.py` que cubren: bloque simple incompleto por EOF inesperado y `FIN` pendiente, bloque anidado incompleto con múltiples cierres pendientes, y un error sintáctico real que no debe clasificarse como incompleto.

### Testing
- Se ejecutó `pytest -q tests/unit/test_repl_command_v2.py -k "incompleto or sintactico_real or prioriza_metadata or no_depende"` y las pruebas relevantes pasaron correctamente. 
- La batería de tests sobre el archivo de pruebas del REPL arrojó resultados exitosos sin fallos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc104bff88327b2572318f81f11c5)