### PR TITLE
Ampliar extracción de token y detección de EOF inesperado en REPL v2 (aliases de metadata)

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -65,6 +65,7 @@ class ReplCommandV2(BaseCommand):
             "actual_token",
             "last_token",
             "ultimo_token",
+            "unexpected_token",
         ):
             if hasattr(err, attr):
                 token = getattr(err, attr)
@@ -75,7 +76,15 @@ class ReplCommandV2(BaseCommand):
                 estado = getattr(err, attr)
                 if estado is None:
                     continue
-                for token_attr in ("token_actual", "token", "current_token"):
+                for token_attr in (
+                    "token_actual",
+                    "token",
+                    "current_token",
+                    "actual_token",
+                    "last_token",
+                    "ultimo_token",
+                    "unexpected_token",
+                ):
                     token = getattr(estado, token_attr, None)
                     if token is not None:
                         return token
@@ -96,13 +105,19 @@ class ReplCommandV2(BaseCommand):
             if token_actual is not None
             else getattr(err, "tipo_token_actual", None)
             or getattr(err, "current_token_type", None)
+            or getattr(err, "token_type", None)
+            or getattr(err, "actual_token_type", None)
+            or getattr(err, "last_token_type", None)
         )
 
         esperado_raw = (
             getattr(err, "esperado", None)
             or getattr(err, "expected", None)
+            or getattr(err, "esperados", None)
             or getattr(err, "tokens_esperados", None)
             or getattr(err, "expected_tokens", None)
+            or getattr(err, "expected_types", None)
+            or getattr(err, "expected_terminals", None)
             or getattr(err, "token_esperado", None)
             or getattr(err, "expected_token", None)
         )
@@ -118,6 +133,9 @@ class ReplCommandV2(BaseCommand):
             getattr(err, "unexpected_eof", False)
             or getattr(err, "eof", False)
             or getattr(err, "es_eof", False)
+            or getattr(err, "is_eof", False)
+            or getattr(err, "is_unexpected_eof", False)
+            or getattr(err, "unexpected_end_of_input", False)
         )
         eof_por_token = tipo_token_actual == TipoToken.EOF
         return eof_por_flag or eof_por_token

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -119,6 +119,97 @@ def test_es_error_de_bloque_incompleto_prioriza_metadata(err, es_incompleto):
     assert command.es_error_de_bloque_incompleto(err) is es_incompleto
 
 
+@pytest.mark.parametrize(
+    ("atributos", "es_incompleto"),
+    [
+        (
+            {
+                "expected_tokens": [TipoToken.FIN],
+                "token_type": TipoToken.EOF,
+                "unexpected_eof": True,
+            },
+            True,
+        ),
+        (
+            {
+                "expected_types": [TipoToken.RPAREN],
+                "current_token_type": TipoToken.EOF,
+            },
+            True,
+        ),
+        (
+            {
+                "expected_terminals": [TipoToken.RBRACKET],
+                "actual_token_type": TipoToken.EOF,
+                "is_eof": True,
+            },
+            True,
+        ),
+        (
+            {
+                "esperados": [TipoToken.RBRACE],
+                "last_token_type": TipoToken.EOF,
+                "is_unexpected_eof": True,
+            },
+            True,
+        ),
+        (
+            {
+                "expected": [TipoToken.FIN],
+                "token_type": TipoToken.EOF,
+                "unexpected_eof": False,
+            },
+            True,
+        ),
+        (
+            {
+                "expected": [TipoToken.FIN],
+                "unexpected_eof": True,
+            },
+            True,
+        ),
+        (
+            {
+                "expected": [TipoToken.FIN],
+            },
+            False,
+        ),
+        (
+            {
+                "expected": [TipoToken.IDENTIFICADOR],
+                "current_token_type": TipoToken.EOF,
+                "unexpected_eof": True,
+            },
+            False,
+        ),
+    ],
+)
+def test_es_error_de_bloque_incompleto_con_metadata_parcial(atributos, es_incompleto):
+    command = ReplCommandV2()
+    err = ParserError("metadata parcial")
+    for nombre, valor in atributos.items():
+        setattr(err, nombre, valor)
+    assert command.es_error_de_bloque_incompleto(err) is es_incompleto
+
+
+def test_extrae_token_desde_state_con_alias_de_parser_real():
+    command = ReplCommandV2()
+    err = ParserError("metadata state")
+    err.state = type("State", (), {"actual_token": type("Tok", (), {"tipo": TipoToken.EOF})()})()
+    token = command._extraer_token_desde_error(err)
+    assert token is not None
+    assert token.tipo == TipoToken.EOF
+
+
+def test_extrae_token_desde_unexpected_token_si_no_hay_token_actual():
+    command = ReplCommandV2()
+    err = ParserError("metadata unexpected token")
+    err.unexpected_token = type("Tok", (), {"tipo": TipoToken.EOF})()
+    token = command._extraer_token_desde_error(err)
+    assert token is not None
+    assert token.tipo == TipoToken.EOF
+
+
 def test_incompleto_bloque_simple_por_eof_inesperado_y_fin_pendiente():
     command = ReplCommandV2()
     err = _parser_error_con_metadata(


### PR DESCRIPTION
### Motivation
- Mejorar la robustez de la detección de entradas multilinea incompletas en `ReplCommandV2` usando únicamente metadatos del `ParserError` y no dependencias en el texto del mensaje. 
- Cubrir aliases y variantes de metadatos usados por parsers alternativos para evitar falsos negativos cuando la excepción expone campos con nombres distintos. 
- Mantener un único criterio auditable de clasificación: EOF inesperado + cierre pendiente en `{FIN, RPAREN, RBRACKET, RBRACE}`.

### Description
- Amplié `ReplCommandV2._extraer_token_desde_error` para inspeccionar aliases adicionales de token en el error (`unexpected_token` y variantes dentro de `state`/`estado`/`parser_state`).
- Extendí `ReplCommandV2._es_entrada_incompleta_por_metadata` para reconocer más formas de indicar el tipo de token actual (`token_type`, `actual_token_type`, `last_token_type`), listas/aliases de esperados (`esperados`, `expected_types`, `expected_terminals`) y flags de EOF (`is_eof`, `is_unexpected_eof`, `unexpected_end_of_input`).
- Conservé la lógica que exige simultáneamente un token de cierre pendiente en los esperados y la señalización de EOF (por flag o por token `EOF`) para considerar la entrada como incompleta.
- Agregué tests en `tests/unit/test_repl_command_v2.py` para combinaciones de metadata parcial (combinando/omitiendo flags `eof`, `token_actual`, y usando aliases), y tests que verifican la extracción desde `state` y `unexpected_token`.

### Testing
- Ejecuté `pytest -q tests/unit/test_repl_command_v2.py tests/unit/cli/commands_v2/test_repl_cmd_v2.py` y todas las pruebas unitarias relacionadas pasaron: `48 passed, 1 warning`.
- Verifiqué que no haya dependencias de regex sobre mensajes de error en estos tests ejecutando búsquedas relevantes y confirmando que no aparecen coincidencias problemáticas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc74a060883279a497427b5ba68ee)