### PR TITLE
docs: reforzar contrato de paridad REPL/script

### DIFF
--- a/docs/architecture/repl-script-parity-contract.md
+++ b/docs/architecture/repl-script-parity-contract.md
@@ -60,6 +60,41 @@ La ruta de script (`RunService.ejecutar_normal`) y la ruta REPL (`InteractiveCom
 - Resolución de clase de intérprete con `resolver_interpretador_cls`.
 - Ejecución del flujo `analizar + validar + ejecutar` con la API de alto nivel `ejecutar_pipeline_explicito`.
 - Normalización de `safe_mode` y `extra_validators` **únicamente** desde el pipeline compartido (`normalizar_opciones_pipeline`).
+- Entrada REPL encauzada por `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` y pipeline compartido en `src/pcobra/cobra/cli/execution_pipeline.py`.
+- Entrada script encauzada por servicios CLI que reutilizan el mismo pipeline canónico definido en `src/pcobra/cobra/cli/execution_pipeline.py`.
+
+### Principio explícito de paridad sintáctica y gramatical
+
+**REPL no cambia sintaxis ni gramática; solo cambia el origen de entrada.**
+
+Esto implica que:
+
+- El mismo lexer/parser debe procesar código idéntico sin bifurcaciones por modo de ejecución.
+- Las reglas de bloque con `fin` y las validaciones semánticas son equivalentes entre archivo y sesión interactiva.
+- Cualquier diferencia permitida entre modos se limita al origen del texto (archivo vs entrada de usuario), no al lenguaje aceptado.
+
+### Ejemplos mínimos del contrato (anidación y persistencia)
+
+Ejemplo 1: bloque anidado con `fin` (debe comportarse igual en script y REPL)
+
+```cobra
+var x = 1
+si x == 1
+    mientras x < 3
+        imprimir(x)
+        x = x + 1
+    fin
+fin
+```
+
+Ejemplo 2: persistencia de estado entre entradas REPL (equivalente al estado final en script)
+
+```cobra
+var x = 10
+imprimir(x)
+```
+
+En REPL, tras declarar `var x = 10`, una entrada posterior con `imprimir(x)` debe resolver el mismo valor persistido en entorno que en ejecución continua por archivo.
 
 ### Regla obligatoria para nuevas rutas de ejecución
 

--- a/docs/frontend/cli.rst
+++ b/docs/frontend/cli.rst
@@ -121,6 +121,10 @@ Subcomando ``interactive``
 El subcomando ``interactive`` se mantiene solo como alias legacy de
 migración. El flujo interactivo oficial en la CLI pública es ``cobra repl``.
 
+Para el contrato de paridad entre ejecución por archivo y REPL (misma sintaxis,
+misma gramática y misma ruta canónica de pipeline), consulta:
+``docs/architecture/repl-script-parity-contract.md``.
+
 Ejemplo:
 
 .. code-block:: bash


### PR DESCRIPTION
### Motivation

- Aclarar y reforzar el contrato de paridad entre ejecución por archivo y REPL para evitar discrepancias semánticas o sintácticas entre modos de entrada.
- Especificar las rutas canónicas de ejecución compartida para guiar implementaciones y nuevas integraciones hacia un pipeline único y comprobable.

### Description

- Actualiza `docs/architecture/repl-script-parity-contract.md` para incluir la regla explícita: **"REPL no cambia sintaxis ni gramática; solo cambia el origen de entrada"** y detallar las implicaciones sobre lexer/parser y reglas de bloque con `fin`.
- Documenta las rutas canónicas de ejecución compartida: `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` y `src/pcobra/cobra/cli/execution_pipeline.py`.
- Añade ejemplos mínimos que deben comportarse igual en script y REPL, incluyendo un bloque anidado con `fin` y un ejemplo de persistencia de estado (`var x = 10` seguido de `imprimir(x)`).
- Vincula la guía de paridad desde `docs/frontend/cli.rst` para mejorar la visibilidad en la documentación de la CLI.

### Testing

- Ejecutado: `python -m pytest -q tests/unit/test_cli_execution_pipeline_contract.py::test_matriz_minima_paridad_execute_script_vs_repl` y el test pasó satisfactoriamente (8 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc9e875b883278365b3444255293d)