### PR TITLE
test(cli): enforce public v2 command contract and update help snapshot

### DIFF
--- a/tests/cli/test_public_v2_commands_contract.py
+++ b/tests/cli/test_public_v2_commands_contract.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import argparse
+
+from pcobra.cobra.cli.cli import AppConfig, CommandRegistry
+
+
+EXPECTED_PUBLIC_V2_COMMANDS = {"run", "build", "test", "mod", "repl"}
+
+
+def test_app_config_v2_routes_include_repl_command_v2() -> None:
+    routes = {
+        (route.module_path, route.class_name)
+        for route in AppConfig.V2_COMMAND_ROUTES
+    }
+
+    assert (
+        "pcobra.cobra.cli.commands_v2.repl_cmd",
+        "ReplCommandV2",
+    ) in routes
+
+
+def test_app_config_v2_routes_do_not_expose_interactive_as_public_command() -> None:
+    route_modules = {route.module_path for route in AppConfig.V2_COMMAND_ROUTES}
+    route_classes = {route.class_name for route in AppConfig.V2_COMMAND_ROUTES}
+
+    assert "pcobra.cobra.cli.commands.interactive_cmd" not in route_modules
+    assert "InteractiveCommand" not in route_classes
+
+
+def test_public_v2_subcommands_match_contract_exactly() -> None:
+    registry = CommandRegistry()
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+
+    commands = registry.register_base_commands(
+        subparsers,
+        ui="v2",
+        profile="public",
+    )
+
+    assert set(commands) == EXPECTED_PUBLIC_V2_COMMANDS

--- a/tests/integration/golden/cli_help_public_no_legacy.golden
+++ b/tests/integration/golden/cli_help_public_no_legacy.golden
@@ -59,4 +59,4 @@ options:
                         COBRA_PLUGINS_ALLOWLIST.
 
 Ejemplos públicos: cobra run <archivo.co> cobra build <archivo.co> cobra test
-<archivo.co> cobra mod <list|install|remove|publish|search>
+<archivo.co> cobra mod <list|install|remove|publish|search> cobra repl


### PR DESCRIPTION
### Motivation

- Asegurar que la configuración de comandos v2 sigue incluyendo `pcobra.cobra.cli.commands_v2.repl_cmd.ReplCommandV2` y que no se publica el alias legacy `interactive` en la superficie pública v2.
- Garantizar por contrato que los subcomandos públicos v2 expuestos son exactamente `run`, `build`, `test`, `mod`, `repl` y que la ayuda pública refleja ese conjunto.

### Description

- Añade el test de contrato `tests/cli/test_public_v2_commands_contract.py` que verifica que `AppConfig.V2_COMMAND_ROUTES` contiene `ReplCommandV2`, que no aparece `interactive`/`InteractiveCommand`, y que `CommandRegistry.register_base_commands(ui="v2", profile="public")` devuelve exactamente el set esperado de subcomandos.
- Actualiza el snapshot `tests/integration/golden/cli_help_public_no_legacy.golden` para incluir `cobra repl` en la sección de ejemplos públicos.
- Los cambios quedaron commiteados como parte del PR (archivo de test añadido y snapshot actualizado).

### Testing

- Ejecutado `pytest -q tests/cli/test_public_v2_commands_contract.py tests/integration/test_cli_ayuda.py::test_cobra_help_snapshot_publico_no_expone_comandos_legacy tests/integration/test_cli_public_help_contract.py::test_cli_help_public_contract_snapshot`.
- Resultado de las pruebas automatizadas: `5 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edcb6a38648327afaa29a3b37318de)