### PR TITLE
Refina UX de `cobra` sin argumentos y añade cobertura de `--help`

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -1039,7 +1039,7 @@ class CliApplication:
                 messages.mostrar_info(
                     _(
                         "No se indicó ningún comando. "
-                        "Usa --help para ver la ayuda disponible."
+                        "Prueba 'cobra --help' para ver los comandos públicos."
                     )
                 )
                 return 1

--- a/tests/unit/test_cli_default_command.py
+++ b/tests/unit/test_cli_default_command.py
@@ -92,6 +92,7 @@ def test_no_command_prints_help_and_does_not_run_default():
     mock_run.assert_not_called()
     mock_info.assert_called_once()
     assert "no se indicó ningún comando" in mock_info.call_args.args[0].lower()
+    assert "cobra --help" in mock_info.call_args.args[0].lower()
     assert result == 1
 
 
@@ -269,12 +270,37 @@ def test_cli_sin_argumentos_no_imprime_ayuda_detallada_de_subcomandos(capsys):
     assert result == 1
     stdout = capsys.readouterr().out
     assert "no se indicó ningún comando" in stdout.lower()
+    assert "cobra --help" in stdout.lower()
     assert "ejemplos públicos" not in stdout.lower()
     assert "positional arguments" not in stdout.lower()
     assert "comandos disponibles" not in stdout.lower()
     assert "run" not in stdout.lower()
     assert "repl" not in stdout.lower()
     assert "--sandbox" not in stdout
+
+
+def test_cli_help_y_sin_argumentos_cubren_flujos_principales(capsys):
+    with ExitStack() as stack:
+        _patch_cli_env(stack)
+        stack.enter_context(
+            patch("cobra.cli.cli.AppConfig.V2_COMMAND_CLASSES", [_DummyRunCommand, _DummyReplCommand])
+        )
+        stack.enter_context(patch("cobra.cli.cli.resolve_command_profile", return_value="public"))
+        app = CliApplication()
+
+        with pytest.raises(SystemExit) as help_exit:
+            app.run(["--help"])
+        assert help_exit.value.code == 0
+        help_stdout = capsys.readouterr().out.lower()
+        assert "run" in help_stdout
+        assert "repl" in help_stdout
+
+        rc = app.run([])
+        assert rc == 1
+        no_args_stdout = capsys.readouterr().out.lower()
+        assert "no se indicó ningún comando" in no_args_stdout
+        assert "cobra --help" in no_args_stdout
+        assert "--sandbox" not in no_args_stdout
 
 
 def test_cobra_sin_args_no_muestra_logo_ni_ejecuta_comandos():


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia cuando el usuario invoca `cobra` sin argumentos proporcionando un mensaje más directo y útil sin volcar la ayuda completa.
- Mantener la capacidad existente de `-h/--help/--ayuda` para construir y mostrar los subcomandos públicos de la CLI.

### Description
- Cambia el copy en `CliApplication.execute_command` para que, cuando no se indique comando, muestre "Prueba 'cobra --help' para ver los comandos públicos." en lugar de la indicación anterior a `--help` completa.
- Conserva el comportamiento de `return 1` para la invocación sin argumentos y el flujo corto (no imprime ayuda detallada ni ejecuta comandos).
- Actualiza pruebas unitarias en `tests/unit/test_cli_default_command.py` para validar el nuevo texto y añade `test_cli_help_y_sin_argumentos_cubren_flujos_principales` que cubre explícitamente ambos flujos (`--help` y sin argumentos).
- Archivos modificados: `src/pcobra/cobra/cli/cli.py` y `tests/unit/test_cli_default_command.py`.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_default_command.py -k 'help_y_sin_argumentos_cubren_flujos_principales or no_command_prints_help_and_does_not_run_default or cli_sin_argumentos_no_imprime_ayuda_detallada_de_subcomandos or help_sigue_ruta_de_ayuda_y_lista_comandos_publicos'` y todos los tests seleccionados pasaron (`4 passed, 10 deselected`).
- Las pruebas verifican que `cobra --help` produce `SystemExit(0)` y lista comandos públicos, y que `cobra` sin argumentos devuelve `1` con el mensaje breve sugerido y sin volcar la ayuda detallada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edcf54bf8c8327b69d50c1ced4339e)