### PR TITLE
REPL interactivo: decidir ejecución multilínea a través del parser

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -564,7 +564,7 @@ class InteractiveCommand(BaseCommand):
         self._estado_repl = estado
         while True:
             try:
-                prompt = "... " if estado["nivel_bloque"] > 0 else "cobra> "
+                prompt = "... " if estado["buffer_lineas"] else ">>> "
                 raw_linea = leer_linea(prompt)
                 linea = sanitize_input(raw_linea if isinstance(raw_linea, str) else str(raw_linea))
                 linea = linea.strip()
@@ -595,21 +595,35 @@ class InteractiveCommand(BaseCommand):
             if not self.validar_entrada(linea):
                 continue
 
-            if estado["nivel_bloque"] == 0 and linea in ["salir", "salir()"]:
+            if not estado["buffer_lineas"] and linea in ["salir", "salir()"]:
                 break
 
-            if estado["nivel_bloque"] == 0 and self._procesar_comando_especial(
+            if not estado["buffer_lineas"] and self._procesar_comando_especial(
                 linea, validador
             ):
                 continue
 
             try:
-                codigo = self._actualizar_buffer_y_obtener_codigo_listo(
-                    estado["buffer_lineas"],
-                    linea,
-                )
-                if codigo is None:
+                estado["buffer_lineas"].append(linea)
+                codigo = "\n".join(estado["buffer_lineas"])
+                prevalidar_y_parsear_codigo(codigo)
+                estado["lineas_blanco_consecutivas"] = 0
+            except (LexerError, ParserError) as err:
+                if self._es_error_de_bloque_incompleto(err):
                     continue
+                estado["buffer_lineas"].clear()
+                estado["lineas_blanco_consecutivas"] = 0
+                categoria = self._clasificar_error_repl(err)
+                self._log_error(categoria, err)
+                continue
+            except Exception as err:  # pragma: no cover - ruta unificada de errores
+                estado["buffer_lineas"].clear()
+                estado["lineas_blanco_consecutivas"] = 0
+                categoria = self._clasificar_error_repl(err)
+                self._log_error(categoria, err)
+                continue
+
+            try:
                 codigo = sanitize_input(codigo)
                 _debug_assert_boundary_text_sanitized(
                     codigo,
@@ -622,7 +636,9 @@ class InteractiveCommand(BaseCommand):
                     self._ejecutar_en_docker(codigo, sandbox_docker)
                 else:
                     self.ejecutar_codigo(codigo, validador)
+                estado["buffer_lineas"].clear()
             except Exception as err:  # pragma: no cover - ruta unificada de errores
+                estado["buffer_lineas"].clear()
                 categoria = self._clasificar_error_repl(err)
                 self._log_error(categoria, err)
 
@@ -641,7 +657,7 @@ class InteractiveCommand(BaseCommand):
 
     def _manejar_linea_blanca(self, estado: dict[str, Any]) -> None:
         """Aplica política de líneas en blanco en sesión REPL."""
-        if estado["nivel_bloque"] > 0:
+        if estado["buffer_lineas"]:
             estado["lineas_blanco_consecutivas"] += 1
             if (
                 estado["lineas_blanco_consecutivas"]
@@ -654,6 +670,67 @@ class InteractiveCommand(BaseCommand):
                 )
         else:
             estado["lineas_blanco_consecutivas"] = 0
+
+    def _normalizar_tipo_token(self, valor: Any) -> Optional[TipoToken]:
+        """Normaliza posibles representaciones de token a ``TipoToken``."""
+        if isinstance(valor, TipoToken):
+            return valor
+        if valor is None:
+            return None
+        nombre = str(valor).strip()
+        if not nombre:
+            return None
+        if "." in nombre:
+            nombre = nombre.split(".")[-1]
+        try:
+            return TipoToken[nombre]
+        except KeyError:
+            return None
+
+    def _es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
+        """Determina si el parser reportó una entrada todavía incompleta."""
+        if not isinstance(exc, ParserError):
+            return False
+
+        token_actual = (
+            getattr(exc, "token_actual", None)
+            or getattr(exc, "token", None)
+            or getattr(exc, "current_token", None)
+        )
+        tipo_token_actual = self._normalizar_tipo_token(
+            getattr(token_actual, "tipo", None)
+            or getattr(exc, "tipo_token_actual", None)
+            or getattr(exc, "current_token_type", None)
+        )
+        esperado_raw = (
+            getattr(exc, "esperado", None)
+            or getattr(exc, "expected", None)
+            or getattr(exc, "tokens_esperados", None)
+            or getattr(exc, "expected_tokens", None)
+        )
+        esperados = (
+            esperado_raw
+            if isinstance(esperado_raw, (list, tuple, set))
+            else [esperado_raw]
+        )
+        tipos_esperados = {self._normalizar_tipo_token(item) for item in esperados}
+        tipos_esperados.discard(None)
+        tokens_cierre = {
+            TipoToken.FIN,
+            TipoToken.RPAREN,
+            TipoToken.RBRACKET,
+            TipoToken.RBRACE,
+        }
+        if not (tipos_esperados & tokens_cierre):
+            return False
+
+        eof_por_flag = bool(
+            getattr(exc, "unexpected_eof", False)
+            or getattr(exc, "eof", False)
+            or getattr(exc, "es_eof", False)
+            or getattr(exc, "is_eof", False)
+        )
+        return eof_por_flag or tipo_token_actual == TipoToken.EOF
 
     def _bloque_con_solo_lineas_vacias(self, buffer_lineas: list[str]) -> bool:
         """Indica si el bloque actual no contiene sentencias no vacías."""


### PR DESCRIPTION
### Motivation
- Eliminar la decisión de "entrada completa" basada en el contador manual `nivel_bloque` y unificar la lógica de multilinea con la estrategia usada en `ReplCommandV2.run`.
- Usar el parser compartido (`prevalidar_y_parsear_codigo`) como único criterio para determinar cuándo ejecutar el código y cuándo seguir acumulando líneas.
- Mantener la compatibilidad de comandos especiales y la política de líneas en blanco, pero sólo cuando no hay un buffer pendiente.

### Description
- Cambiado el prompt a `>>> ` cuando `buffer_lineas` está vacío y `... ` cuando hay buffer pendiente, descartando `nivel_bloque` para esta decisión.
- Reemplazada la lógica de actualización/decisión por: acumular en `estado['buffer_lineas']`, construir `codigo = "\n".join(buffer_lineas)` y llamar a `prevalidar_y_parsear_codigo(codigo)` antes de ejecutar.
- Añadidos los helpers `_normalizar_tipo_token` y `_es_error_de_bloque_incompleto` para detectar, a partir de metadatos del `ParserError`, si la entrada está incompleta y por tanto debe seguir acumulándose.
- Ajustada la gestión de líneas en blanco para aplicarse según la existencia del buffer pendiente; el buffer se limpia tras ejecución o en errores no recuperables.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py` y la verificación de compilación de Python fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd2b2dbe48327841d4a23b6ed8d0d)