### PR TITLE
repl: fallback textual para ParserError en bloques incompletos

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -143,14 +143,50 @@ class ReplCommandV2(BaseCommand):
     def es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
         """Detecta si la excepción corresponde a una entrada aún incompleta.
 
-        La decisión sale exclusivamente del ``ParserError`` emitido por
-        ``prevalidar_y_parsear_codigo``: EOF inesperado + cierres pendientes
-        en tokens esperados.
+        Orden de decisión:
+
+        1. **Metadata primero**: usa ``_es_entrada_incompleta_por_metadata``.
+        2. **Mensaje después** (fallback): solo cuando no hay metadata suficiente
+           en un ``ParserError`` y el texto sugiere cierre pendiente.
+
+        Este fallback no aplica a ``LexerError`` ni a errores de runtime.
         """
 
         if not isinstance(exc, ParserError):
             return False
-        return self._es_entrada_incompleta_por_metadata(exc)
+        if self._es_entrada_incompleta_por_metadata(exc):
+            return True
+        return self._es_entrada_incompleta_por_mensaje(exc)
+
+    def _es_entrada_incompleta_por_mensaje(self, err: ParserError) -> bool:
+        """Fallback textual para detectar bloque incompleto sin metadata útil."""
+        mensaje = str(err or "").strip().lower()
+        if not mensaje:
+            return False
+
+        # Evitar falsos positivos en errores explícitos de estructura inválida.
+        if "sin bloque" in mensaje:
+            return False
+
+        # Debe parecer un error de final/cierre pendiente.
+        indicadores_eof = (
+            "fin de entrada",
+            "final de entrada",
+            "unexpected eof",
+            "unexpected end of input",
+            "eof",
+        )
+        if not any(indicador in mensaje for indicador in indicadores_eof):
+            return False
+
+        indicadores_cierre = (
+            "se esperaba 'fin'",
+            'se esperaba "fin"',
+            "se esperaba fin",
+            "se esperaba cierre",
+            "cierre pendiente",
+        )
+        return any(indicador in mensaje for indicador in indicadores_cierre)
 
     def register_subparser(self, subparsers: Any):
         parser = subparsers.add_parser(self.name, help=_("Start Cobra REPL"))


### PR DESCRIPTION
### Motivation

- Mantener `_es_entrada_incompleta_por_metadata` como criterio primario para decidir si una excepción indica una entrada REPL incompleta.  
- Añadir un fallback conservador que detecte por texto patrones típicos de cierre pendiente cuando no hay metadata suficiente.  
- Asegurar que el fallback solo se aplique a `ParserError` y evitar falsos positivos en mensajes como "fin sin bloque".  

### Description

- Se modificó `es_error_de_bloque_incompleto` para comprobar primero `_es_entrada_incompleta_por_metadata` y, solo si falla, llamar al nuevo fallback textual `_es_entrada_incompleta_por_mensaje`.  
- Se agregó la función `_es_entrada_incompleta_por_mensaje` que normaliza el mensaje a minúsculas y busca indicadores de EOF y cierres pendientes (por ejemplo variantes de `se esperaba 'fin'`), y descarta mensajes que contienen `sin bloque`.  
- El chequeo sigue devolviendo `False` para excepciones que no sean `ParserError`, por lo que `LexerError` y errores de runtime no usan el fallback textual.  
- Cambios aplicados en `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` y docstring actualizado para documentar el orden de decisión (metadata primero, mensaje después).  

### Testing

- Se ejecutó `python -m compileall src/pcobra/cobra/cli/commands_v2/repl_cmd.py` y la compilación del módulo fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd3d745508327bf33cd0a9568356a)