### PR TITLE
Centralizar limpieza del REPL v2: buffer y estado delegado

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -240,6 +240,14 @@ class ReplCommandV2(BaseCommand):
                 _resultado_pipeline.resultado,
             )
 
+    def _reset_buffer_local(self, buffer: list[str]) -> None:
+        """Limpia el buffer de entrada local del REPL v2."""
+        buffer.clear()
+
+    def _reset_estado_delegate(self) -> None:
+        """Restablece el estado base del REPL delegado."""
+        self._delegate._estado_repl = self._delegate._crear_estado_repl()
+
     def run(self, args: Any) -> int:
         buffer: list[str] = []
         self._delegate._estado_repl = self._delegate._crear_estado_repl()
@@ -259,16 +267,16 @@ class ReplCommandV2(BaseCommand):
             except KeyboardInterrupt:
                 if buffer:
                     mostrar_info(_("Entrada multilinea cancelada."))
-                    buffer.clear()
-                    self._delegate._estado_repl = self._delegate._crear_estado_repl()
+                    self._reset_buffer_local(buffer)
+                    self._reset_estado_delegate()
                     continue
                 mostrar_info(_("Interrupción recibida. Saliendo del REPL."))
                 break
             except EOFError:
                 if buffer:
                     mostrar_info(_("Entrada multilinea cancelada por fin de archivo."))
-                    buffer.clear()
-                    self._delegate._estado_repl = self._delegate._crear_estado_repl()
+                    self._reset_buffer_local(buffer)
+                    self._reset_estado_delegate()
                     continue
                 mostrar_info(_("Fin de entrada. Saliendo del REPL."))
                 break
@@ -281,8 +289,8 @@ class ReplCommandV2(BaseCommand):
             if comando in {"salir", "exit"}:
                 if buffer:
                     mostrar_info(_("Entrada multilinea cancelada. Saliendo del REPL."))
-                    buffer.clear()
-                    self._delegate._estado_repl = self._delegate._crear_estado_repl()
+                    self._reset_buffer_local(buffer)
+                    self._reset_estado_delegate()
                 else:
                     mostrar_info(_("Saliendo..."))
                 break
@@ -296,14 +304,14 @@ class ReplCommandV2(BaseCommand):
                     continue
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
-                buffer.clear()
-                self._delegate._estado_repl = self._delegate._crear_estado_repl()
+                self._reset_buffer_local(buffer)
+                self._reset_estado_delegate()
                 continue
             except Exception as err:
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
-                buffer.clear()
-                self._delegate._estado_repl = self._delegate._crear_estado_repl()
+                self._reset_buffer_local(buffer)
+                self._reset_estado_delegate()
                 continue
 
             try:
@@ -313,18 +321,19 @@ class ReplCommandV2(BaseCommand):
                     self._delegate._ejecutar_en_docker(codigo, sandbox_docker)
                 else:
                     self._ejecutar_en_modo_normal(codigo, interpretador_cls)
-                buffer.clear()
+                self._reset_buffer_local(buffer)
+                self._reset_estado_delegate()
             except (PrimitivaPeligrosaError, RuntimeError) as err:
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
-                buffer.clear()
-                self._delegate._estado_repl = self._delegate._crear_estado_repl()
+                self._reset_buffer_local(buffer)
+                self._reset_estado_delegate()
                 continue
             except Exception as err:
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
-                buffer.clear()
-                self._delegate._estado_repl = self._delegate._crear_estado_repl()
+                self._reset_buffer_local(buffer)
+                self._reset_estado_delegate()
                 continue
 
         return 0


### PR DESCRIPTION
### Motivation
- Evitar divergencias en el manejo de limpieza del REPL v2 y garantizar comportamiento coherente entre ramas `except` y flujos normales. 
- Asegurar que las entradas multilinea sean canceladas sin cerrar la sesión ante `KeyboardInterrupt`/`EOFError`, y que los bloques incompletos preserven el buffer. 
- Mantener la persistencia del intérprete (`self._interpretador_persistente`) únicamente tras ejecuciones válidas, sin mutarla en parseos fallidos.

### Description
- Se añadieron los helpers `def _reset_buffer_local(self, buffer: list[str])` y `def _reset_estado_delegate(self)` en `ReplCommandV2` para centralizar la limpieza del buffer y el estado delegado en `src/pcobra/cobra/cli/commands_v2/repl_cmd.py`. 
- Se reemplazaron las llamadas directas a `buffer.clear()` y a `self._delegate._estado_repl = self._delegate._crear_estado_repl()` por los nuevos helpers en los manejadores de `KeyboardInterrupt`, `EOFError`, salida por `salir/exit`, errores de prevalidación/parseo y errores de ejecución. 
- Se preserva el buffer cuando `es_error_de_bloque_incompleto(err)` detecta un bloque incompleto, y se limpian buffer+estado en errores sintácticos reales u otros errores no recuperables. 
- La asignación de `self._interpretador_persistente` sigue realizándose únicamente dentro de `_ejecutar_en_modo_normal` tras un `ejecutar_pipeline_explicito` exitoso, de modo que los parseos fallidos no afectan su persistencia.

### Testing
- Ejecutado `pytest -q tests/unit/test_repl_command_v2.py`. 
- Resultado: `43 passed, 1 warning` (todos los tests unitarios relevantes pasaron).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd4c689048327875bbf5a016faeb1)