### PR TITLE
refactor(cli): centralizar clasificación de ParserError en helper compartido

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -66,6 +66,9 @@ from pcobra.cobra.cli.utils.messages import (
     mostrar_error,
     mostrar_info,
 )
+from pcobra.cobra.cli.utils.parser_error_classifier import (
+    es_parser_error_de_bloque_incompleto,
+)
 from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
 from pcobra.cobra.cli.repl.cobra_lexer import CobraLexer
 from pcobra.cobra.cli.target_policies import (
@@ -671,122 +674,9 @@ class InteractiveCommand(BaseCommand):
         else:
             estado["lineas_blanco_consecutivas"] = 0
 
-    def _normalizar_tipo_token(self, valor: Any) -> Optional[TipoToken]:
-        """Normaliza posibles representaciones de token a ``TipoToken``."""
-        if isinstance(valor, TipoToken):
-            return valor
-        if valor is None:
-            return None
-        nombre = str(valor).strip()
-        if not nombre:
-            return None
-        if "." in nombre:
-            nombre = nombre.split(".")[-1]
-        try:
-            return TipoToken[nombre]
-        except KeyError:
-            return None
-
     def _es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
         """Determina si el parser reportó una entrada todavía incompleta."""
-        if not isinstance(exc, ParserError):
-            return False
-        metadata_resultado = self._es_error_de_bloque_incompleto_por_metadata(exc)
-        if metadata_resultado is not None:
-            return metadata_resultado
-        return self._es_error_de_bloque_incompleto_por_mensaje(exc)
-
-    def _es_error_de_bloque_incompleto_por_metadata(
-        self, err: ParserError
-    ) -> Optional[bool]:
-        """Evalúa incompletitud con metadata del parser.
-
-        Retorna ``None`` cuando no hay metadata suficiente para decidir.
-        """
-
-        token_actual = (
-            getattr(err, "token_actual", None)
-            or getattr(err, "token", None)
-            or getattr(err, "actual_token", None)
-            or getattr(err, "current_token", None)
-        )
-        tipo_token_actual = self._normalizar_tipo_token(
-            getattr(token_actual, "tipo", None)
-            or getattr(err, "tipo_token_actual", None)
-            or getattr(err, "current_token_type", None)
-            or getattr(err, "actual_token_type", None)
-            or getattr(err, "token_type", None)
-            or getattr(err, "last_token_type", None)
-        )
-        esperado_raw = (
-            getattr(err, "esperado", None)
-            or getattr(err, "expected", None)
-            or getattr(err, "tokens_esperados", None)
-            or getattr(err, "expected_tokens", None)
-            or getattr(err, "expected_types", None)
-            or getattr(err, "expected_terminals", None)
-            or getattr(err, "esperados", None)
-        )
-        if esperado_raw is None:
-            esperados = []
-        elif isinstance(esperado_raw, (list, tuple, set)):
-            esperados = list(esperado_raw)
-        else:
-            esperados = [esperado_raw]
-        tipos_esperados = {self._normalizar_tipo_token(item) for item in esperados}
-        tipos_esperados.discard(None)
-        tokens_cierre = {
-            TipoToken.FIN,
-            TipoToken.RPAREN,
-            TipoToken.RBRACKET,
-            TipoToken.RBRACE,
-        }
-        if tipos_esperados and not (tipos_esperados & tokens_cierre):
-            return False
-
-        eof_por_flag = bool(
-            getattr(err, "unexpected_eof", False)
-            or getattr(err, "eof", False)
-            or getattr(err, "es_eof", False)
-            or getattr(err, "is_eof", False)
-            or getattr(err, "is_unexpected_eof", False)
-            or getattr(err, "unexpected_end_of_input", False)
-        )
-        eof_por_token = tipo_token_actual == TipoToken.EOF
-        if tipos_esperados:
-            return eof_por_flag or eof_por_token
-        if tipo_token_actual is None and not eof_por_flag:
-            return None
-        if eof_por_flag or eof_por_token:
-            return None
-        return False
-
-    def _es_error_de_bloque_incompleto_por_mensaje(self, err: ParserError) -> bool:
-        """Fallback textual para detectar bloque incompleto sin metadata útil."""
-        mensaje = str(err or "").strip().lower()
-        if not mensaje:
-            return False
-        if "sin bloque" in mensaje:
-            return False
-
-        indicadores_eof = (
-            "fin de entrada",
-            "final de entrada",
-            "unexpected eof",
-            "unexpected end of input",
-            "eof",
-        )
-        if not any(indicador in mensaje for indicador in indicadores_eof):
-            return False
-
-        indicadores_cierre = (
-            "se esperaba 'fin'",
-            'se esperaba "fin"',
-            "se esperaba fin",
-            "se esperaba cierre",
-            "cierre pendiente",
-        )
-        return any(indicador in mensaje for indicador in indicadores_cierre)
+        return es_parser_error_de_bloque_incompleto(exc)
 
     def _bloque_con_solo_lineas_vacias(self, buffer_lineas: list[str]) -> bool:
         """Indica si el bloque actual no contiene sentencias no vacías."""

--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -12,20 +12,15 @@ from pcobra.cobra.cli.execution_pipeline import (
     resolver_interpretador_cls,
 )
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.parser_error_classifier import (
+    es_parser_error_de_bloque_incompleto,
+)
 from pcobra.cobra.cli.utils.messages import mostrar_info
-from pcobra.cobra.core import LexerError, ParserError, TipoToken
+from pcobra.cobra.core import LexerError, ParserError
 from pcobra.cobra.core.runtime import InterpretadorCobra
 from pcobra.cobra.core.semantic_validators import PrimitivaPeligrosaError
 from pcobra.cobra.cli.target_policies import parse_runtime_target
 from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
-
-_TOKENS_CIERRE_INCOMPLETO = {
-    TipoToken.FIN,
-    TipoToken.RPAREN,
-    TipoToken.RBRACKET,
-    TipoToken.RBRACE,
-}
-
 
 class ReplCommandV2(BaseCommand):
     """Comando v2 público para iniciar el REPL de Cobra."""
@@ -40,153 +35,14 @@ class ReplCommandV2(BaseCommand):
         self._seguro_repl: bool = True
         self._extra_validators_repl: Any = None
 
-    def _normalizar_tipo_token(self, valor: Any) -> TipoToken | None:
-        """Normaliza posibles representaciones de token a ``TipoToken``."""
-        if isinstance(valor, TipoToken):
-            return valor
-        if valor is None:
-            return None
-        nombre = str(valor).strip()
-        if not nombre:
-            return None
-        if "." in nombre:
-            nombre = nombre.split(".")[-1]
-        try:
-            return TipoToken[nombre]
-        except KeyError:
-            return None
-
-    def _extraer_token_desde_error(self, err: ParserError) -> Any | None:
-        """Obtiene el token actual desde metadatos del ``ParserError`` si existe."""
-        for attr in (
-            "token_actual",
-            "token",
-            "current_token",
-            "actual_token",
-            "last_token",
-            "ultimo_token",
-            "unexpected_token",
-        ):
-            if hasattr(err, attr):
-                token = getattr(err, attr)
-                if token is not None:
-                    return token
-        for attr in ("estado", "state", "parser_state"):
-            if hasattr(err, attr):
-                estado = getattr(err, attr)
-                if estado is None:
-                    continue
-                for token_attr in (
-                    "token_actual",
-                    "token",
-                    "current_token",
-                    "actual_token",
-                    "last_token",
-                    "ultimo_token",
-                    "unexpected_token",
-                ):
-                    token = getattr(estado, token_attr, None)
-                    if token is not None:
-                        return token
-        return None
-
-    def _es_entrada_incompleta_por_metadata(self, err: ParserError) -> bool:
-        """Determina incompleto **solo** con metadatos del ``ParserError``.
-
-        El criterio es único y auditable: la entrada se considera incompleta
-        únicamente cuando ``prevalidar_y_parsear_codigo`` emite un ``ParserError``
-        que reporta EOF inesperado y, además, al menos un token de cierre
-        pendiente en ``esperado`` (por ejemplo ``FIN``, ``RPAREN``,
-        ``RBRACKET`` o ``RBRACE``).
-        """
-        token_actual = self._extraer_token_desde_error(err)
-        tipo_token_actual = self._normalizar_tipo_token(
-            getattr(token_actual, "tipo", None)
-            if token_actual is not None
-            else getattr(err, "tipo_token_actual", None)
-            or getattr(err, "current_token_type", None)
-            or getattr(err, "token_type", None)
-            or getattr(err, "actual_token_type", None)
-            or getattr(err, "last_token_type", None)
-        )
-
-        esperado_raw = (
-            getattr(err, "esperado", None)
-            or getattr(err, "expected", None)
-            or getattr(err, "esperados", None)
-            or getattr(err, "tokens_esperados", None)
-            or getattr(err, "expected_tokens", None)
-            or getattr(err, "expected_types", None)
-            or getattr(err, "expected_terminals", None)
-            or getattr(err, "token_esperado", None)
-            or getattr(err, "expected_token", None)
-        )
-        esperados = esperado_raw if isinstance(esperado_raw, (list, tuple, set)) else [esperado_raw]
-        tipos_esperados = {self._normalizar_tipo_token(item) for item in esperados}
-        tipos_esperados.discard(None)
-
-        cierre_esperado = bool(tipos_esperados & _TOKENS_CIERRE_INCOMPLETO)
-        if not cierre_esperado:
-            return False
-
-        eof_por_flag = bool(
-            getattr(err, "unexpected_eof", False)
-            or getattr(err, "eof", False)
-            or getattr(err, "es_eof", False)
-            or getattr(err, "is_eof", False)
-            or getattr(err, "is_unexpected_eof", False)
-            or getattr(err, "unexpected_end_of_input", False)
-        )
-        eof_por_token = tipo_token_actual == TipoToken.EOF
-        return eof_por_flag or eof_por_token
-
     def es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
         """Detecta si la excepción corresponde a una entrada aún incompleta.
 
-        Orden de decisión:
-
-        1. **Metadata primero**: usa ``_es_entrada_incompleta_por_metadata``.
-        2. **Mensaje después** (fallback): solo cuando no hay metadata suficiente
-           en un ``ParserError`` y el texto sugiere cierre pendiente.
-
-        Este fallback no aplica a ``LexerError`` ni a errores de runtime.
+        Orden de decisión: metadata primero y fallback textual después.
+        La fuente de verdad sigue siendo el parser existente; no se
+        reimplementa la gramática en este comando.
         """
-
-        if not isinstance(exc, ParserError):
-            return False
-        if self._es_entrada_incompleta_por_metadata(exc):
-            return True
-        return self._es_entrada_incompleta_por_mensaje(exc)
-
-    def _es_entrada_incompleta_por_mensaje(self, err: ParserError) -> bool:
-        """Fallback textual para detectar bloque incompleto sin metadata útil."""
-        mensaje = str(err or "").strip().lower()
-        if not mensaje:
-            return False
-
-        # Evitar falsos positivos en errores explícitos de estructura inválida.
-        if "sin bloque" in mensaje:
-            return False
-
-        # Debe parecer un error de final/cierre pendiente.
-        indicadores_eof = (
-            "fin de entrada",
-            "final de entrada",
-            "unexpected eof",
-            "unexpected end of input",
-            "eof",
-        )
-        if not any(indicador in mensaje for indicador in indicadores_eof):
-            return False
-
-        indicadores_cierre = (
-            "se esperaba 'fin'",
-            'se esperaba "fin"',
-            "se esperaba fin",
-            "se esperaba cierre",
-            "cierre pendiente",
-        )
-        return any(indicador in mensaje for indicador in indicadores_cierre)
+        return es_parser_error_de_bloque_incompleto(exc)
 
     def register_subparser(self, subparsers: Any):
         parser = subparsers.add_parser(self.name, help=_("Start Cobra REPL"))

--- a/src/pcobra/cobra/cli/utils/parser_error_classifier.py
+++ b/src/pcobra/cobra/cli/utils/parser_error_classifier.py
@@ -1,0 +1,184 @@
+"""Clasificación de ``ParserError`` para uso en CLI.
+
+La fuente de verdad sigue siendo el parser existente de Cobra. Este módulo solo
+interpreta metadatos y mensajes ya emitidos por ese parser, sin reimplementar
+la gramática del lenguaje.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pcobra.cobra.core import ParserError, TipoToken
+
+_TOKENS_CIERRE_INCOMPLETO = {
+    TipoToken.FIN,
+    TipoToken.RPAREN,
+    TipoToken.RBRACKET,
+    TipoToken.RBRACE,
+}
+
+
+def _normalizar_tipo_token(valor: Any) -> TipoToken | None:
+    """Normaliza posibles representaciones de token a ``TipoToken``."""
+    if isinstance(valor, TipoToken):
+        return valor
+    if valor is None:
+        return None
+    nombre = str(valor).strip()
+    if not nombre:
+        return None
+    if "." in nombre:
+        nombre = nombre.split(".")[-1]
+    try:
+        return TipoToken[nombre]
+    except KeyError:
+        return None
+
+
+def _extraer_token_desde_error(err: ParserError) -> Any | None:
+    """Obtiene el token actual desde metadatos del ``ParserError`` si existe."""
+    for attr in (
+        "token_actual",
+        "token",
+        "current_token",
+        "actual_token",
+        "last_token",
+        "ultimo_token",
+        "unexpected_token",
+    ):
+        if hasattr(err, attr):
+            token = getattr(err, attr)
+            if token is not None:
+                return token
+
+    for attr in ("estado", "state", "parser_state"):
+        if not hasattr(err, attr):
+            continue
+        estado = getattr(err, attr)
+        if estado is None:
+            continue
+        for token_attr in (
+            "token_actual",
+            "token",
+            "current_token",
+            "actual_token",
+            "last_token",
+            "ultimo_token",
+            "unexpected_token",
+        ):
+            token = getattr(estado, token_attr, None)
+            if token is not None:
+                return token
+    return None
+
+
+def _es_entrada_incompleta_por_metadata(err: ParserError) -> bool | None:
+    """Evalúa incompletitud con metadata del parser.
+
+    Retorna ``None`` cuando no hay metadata suficiente para decidir.
+    """
+
+    token_actual = _extraer_token_desde_error(err)
+    tipo_token_actual = _normalizar_tipo_token(
+        getattr(token_actual, "tipo", None)
+        if token_actual is not None
+        else getattr(err, "tipo_token_actual", None)
+        or getattr(err, "current_token_type", None)
+        or getattr(err, "actual_token_type", None)
+        or getattr(err, "token_type", None)
+        or getattr(err, "last_token_type", None)
+    )
+
+    esperado_raw = (
+        getattr(err, "esperado", None)
+        or getattr(err, "expected", None)
+        or getattr(err, "tokens_esperados", None)
+        or getattr(err, "expected_tokens", None)
+        or getattr(err, "expected_types", None)
+        or getattr(err, "expected_terminals", None)
+        or getattr(err, "esperados", None)
+        or getattr(err, "token_esperado", None)
+        or getattr(err, "expected_token", None)
+    )
+
+    if esperado_raw is None:
+        esperados: list[Any] = []
+    elif isinstance(esperado_raw, (list, tuple, set)):
+        esperados = list(esperado_raw)
+    else:
+        esperados = [esperado_raw]
+
+    tipos_esperados = {_normalizar_tipo_token(item) for item in esperados}
+    tipos_esperados.discard(None)
+
+    if tipos_esperados and not (tipos_esperados & _TOKENS_CIERRE_INCOMPLETO):
+        return False
+
+    eof_por_flag = bool(
+        getattr(err, "unexpected_eof", False)
+        or getattr(err, "eof", False)
+        or getattr(err, "es_eof", False)
+        or getattr(err, "is_eof", False)
+        or getattr(err, "is_unexpected_eof", False)
+        or getattr(err, "unexpected_end_of_input", False)
+    )
+    eof_por_token = tipo_token_actual == TipoToken.EOF
+
+    if tipos_esperados:
+        return eof_por_flag or eof_por_token
+    if tipo_token_actual is None and not eof_por_flag:
+        return None
+    if eof_por_flag or eof_por_token:
+        return None
+    return False
+
+
+def _es_entrada_incompleta_por_mensaje(err: ParserError) -> bool:
+    """Fallback textual para detectar bloque incompleto sin metadata útil."""
+    mensaje = str(err or "").strip().lower()
+    if not mensaje:
+        return False
+
+    if "sin bloque" in mensaje:
+        return False
+
+    indicadores_eof = (
+        "fin de entrada",
+        "final de entrada",
+        "unexpected eof",
+        "unexpected end of input",
+        "eof",
+    )
+    if not any(indicador in mensaje for indicador in indicadores_eof):
+        return False
+
+    indicadores_cierre = (
+        "se esperaba 'fin'",
+        'se esperaba "fin"',
+        "se esperaba fin",
+        "se esperaba cierre",
+        "cierre pendiente",
+    )
+    return any(indicador in mensaje for indicador in indicadores_cierre)
+
+
+def es_parser_error_de_bloque_incompleto(exc: Exception) -> bool:
+    """Clasifica un error del parser como entrada incompleta vs error real.
+
+    Prioridad de decisión:
+
+    1. Metadata del parser.
+    2. Fallback textual del mensaje cuando la metadata no alcanza.
+
+    La fuente de verdad sigue siendo el parser existente; esta función no
+    reimplementa la gramática de Cobra.
+    """
+
+    if not isinstance(exc, ParserError):
+        return False
+
+    metadata_resultado = _es_entrada_incompleta_por_metadata(exc)
+    if metadata_resultado is not None:
+        return metadata_resultado
+    return _es_entrada_incompleta_por_mensaje(exc)


### PR DESCRIPTION
### Motivation
- Eliminar duplicación de lógica entre los comandos REPL y mantener un único criterio auditable para distinguir `ParserError` por entrada incompleta vs error real.
- Preservar que la fuente de verdad sea el parser existente y mantener la prioridad solicitada (metadata primero, fallback textual después) sin reimplementar la gramática.

### Description
- Se añadió el módulo `src/pcobra/cobra/cli/utils/parser_error_classifier.py` con la función pública `es_parser_error_de_bloque_incompleto(exc)` y helpers internos para normalizar tokens, extraer metadata y aplicar el fallback textual; la docstring explica que la fuente de verdad es el parser existente.
- `InteractiveCommand._es_error_de_bloque_incompleto` ahora delega a `es_parser_error_de_bloque_incompleto` en lugar de su implementación local.
- `ReplCommandV2.es_error_de_bloque_incompleto` también delega a `es_parser_error_de_bloque_incompleto` y se eliminó la lógica duplicada previa en ambos comandos.
- Se mantuvo explícitamente el orden de decisión (metadata primero, fallback textual después) y se documentó en el helper y en el docstring del comando V2.

### Testing
- Se compiló el código afectado con `python -m compileall src/pcobra/cobra/cli/utils/parser_error_classifier.py src/pcobra/cobra/cli/commands/interactive_cmd.py src/pcobra/cobra/cli/commands_v2/repl_cmd.py` y la compilación fue exitosa.
- Se ejecutaron las pruebas unitarias focalizadas con `pytest -q tests/unit/test_cli_interactive_cmd.py -k "es_error_de_bloque_incompleto"` y pasaron (2 tests ejecutados).
- Se ejecutaron las pruebas unitarias focalizadas con `pytest -q tests/unit/test_repl_command_v2.py -k "bloque_incompleto"` y pasaron (21 tests ejecutados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd93ad02c832782bf8f7a8d977fd1)