### PR TITLE
Mantener buffer multilinea del REPL en errores no sintácticos

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -166,8 +166,6 @@ class ReplCommandV2(BaseCommand):
             except Exception as err:
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
-                self._reset_buffer_local(buffer)
-                self._reset_estado_delegate()
                 continue
 
             try:
@@ -182,14 +180,10 @@ class ReplCommandV2(BaseCommand):
             except (PrimitivaPeligrosaError, RuntimeError) as err:
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
-                self._reset_buffer_local(buffer)
-                self._reset_estado_delegate()
                 continue
             except Exception as err:
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
-                self._reset_buffer_local(buffer)
-                self._reset_estado_delegate()
                 continue
 
         return 0


### PR DESCRIPTION
### Motivation
- Evitar que el buffer multilinea del REPL se pierda ante excepciones genéricas de prevalidación o ejecución para que el usuario pueda continuar editando el bloque pendiente.

### Description
- Se mantiene la inicialización `buffer: list[str] = []` y el prompt condicional `input(">>> " if not buffer else "... ")` para distinguir entrada nueva y continuación.
- Las líneas no vacías se acumulan en `buffer` y se construye `codigo = "\n".join(buffer)` antes de prevalidar y ejecutar.
- Se eliminaron los reseteos de `buffer` y del estado delegado en excepciones genéricas durante la prevalidación y en excepciones de ejecución, y se conserva la limpieza únicamente en ejecución exitosa y en errores léxicos/sintácticos reales (salvo bloque incompleto) y en la cancelación explícita.

### Testing
- Se compiló el archivo modificado con `python -m compileall src/pcobra/cobra/cli/commands_v2/repl_cmd.py` y la compilación finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede08af30483279e90dfec1fa5b87f)