### PR TITLE
refactor(repl): delegar manejo de prevalidación al clasificador

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -36,13 +36,17 @@ class ReplCommandV2(BaseCommand):
         self._extra_validators_repl: Any = None
 
     def es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
-        """Detecta si la excepción corresponde a una entrada aún incompleta.
-
-        Orden de decisión: metadata primero y fallback textual después.
-        La fuente de verdad sigue siendo el parser existente; no se
-        reimplementa la gramática en este comando.
-        """
+        """Delega la clasificación de entrada incompleta al clasificador central."""
         return es_parser_error_de_bloque_incompleto(exc)
+
+    def _manejar_error_prevalidacion(self, err: Exception, buffer: list[str]) -> None:
+        """Procesa errores de prevalidación delegando la clasificación central."""
+        if self.es_error_de_bloque_incompleto(err):
+            return
+        categoria = self._delegate._clasificar_error_repl(err)
+        self._delegate._log_error(categoria, err)
+        self._reset_buffer_local(buffer)
+        self._reset_estado_delegate()
 
     def register_subparser(self, subparsers: Any):
         parser = subparsers.add_parser(self.name, help=_("Start Cobra REPL"))
@@ -156,12 +160,7 @@ class ReplCommandV2(BaseCommand):
             try:
                 prevalidar_y_parsear_codigo(codigo)
             except (LexerError, ParserError) as err:
-                if self.es_error_de_bloque_incompleto(err):
-                    continue
-                categoria = self._delegate._clasificar_error_repl(err)
-                self._delegate._log_error(categoria, err)
-                self._reset_buffer_local(buffer)
-                self._reset_estado_delegate()
+                self._manejar_error_prevalidacion(err, buffer)
                 continue
             except Exception as err:
                 categoria = self._delegate._clasificar_error_repl(err)


### PR DESCRIPTION
### Motivation
- Garantizar que `ReplCommandV2.run` invoque `prevalidar_y_parsear_codigo(codigo)` justo después de construir `codigo` y antes de ejecutar el pipeline.
- Evitar heurísticas sintácticas locales en `run` para decidir si una entrada es un bloque incompleto y delegar esa decisión al clasificador central.
- Mantener los componentes de lexer/parser inmutables sin tocar archivos en `core/lexer*` ni `core/parser*`.

### Description
- Se añadió el método `_manejar_error_prevalidacion(self, err, buffer)` en `ReplCommandV2` que delega la clasificación de bloque incompleto a `es_error_de_bloque_incompleto` y solo reporta/loggea y reinicia estado si es un error real.
- Se reemplazó el manejo inline de `LexerError`/`ParserError` en `run` por una llamada a `_manejar_error_prevalidacion(err, buffer)` tras `prevalidar_y_parsear_codigo(codigo)`.
- Se simplificó la documentación de `es_error_de_bloque_incompleto` para dejar claro que delega en el clasificador central; el resto de la lógica de parsing y lexer no fue modificada.
- Único archivo modificado: `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` (commit: `87b29fc`).

### Testing
- Ejecuté `pytest -q tests/unit/cli/commands_v2/test_repl_cmd_v2.py` y todos los tests pasaron (`5 passed, 1 warning`).
- Ejecuté `pytest -q tests/unit/test_repl_command_v2.py` y se detectaron fallos en 3 tests mientras 43 pasaron; los fallos son dos `AttributeError` por ausencia del método `_extraer_token_desde_error` y una expectativa fallida sobre comportamiento del buffer tras un error de ejecución.
- Los cambios aplicados afectan solo al flujo de prevalidación en el REPL y no tocan los módulos de `core/lexer*` ni `core/parser*`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede15b08208327990cda47f6bfe69b)