### PR TITLE
Ajusta clasificación de ParserError incompleto y recuperación en REPL v2

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -160,7 +160,12 @@ class ReplCommandV2(BaseCommand):
             try:
                 prevalidar_y_parsear_codigo(codigo)
             except (LexerError, ParserError) as err:
-                self._manejar_error_prevalidacion(err, buffer)
+                if self.es_error_de_bloque_incompleto(err):
+                    continue
+                categoria = self._delegate._clasificar_error_repl(err)
+                self._delegate._log_error(categoria, err)
+                self._reset_buffer_local(buffer)
+                self._reset_estado_delegate()
                 continue
             except Exception as err:
                 categoria = self._delegate._clasificar_error_repl(err)

--- a/src/pcobra/cobra/cli/utils/parser_error_classifier.py
+++ b/src/pcobra/cobra/cli/utils/parser_error_classifier.py
@@ -143,16 +143,6 @@ def _es_entrada_incompleta_por_mensaje(err: ParserError) -> bool:
     if "sin bloque" in mensaje:
         return False
 
-    indicadores_eof = (
-        "fin de entrada",
-        "final de entrada",
-        "unexpected eof",
-        "unexpected end of input",
-        "eof",
-    )
-    if not any(indicador in mensaje for indicador in indicadores_eof):
-        return False
-
     indicadores_cierre = (
         "se esperaba 'fin'",
         'se esperaba "fin"',

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -32,14 +32,14 @@ def _parser_error_con_metadata(
 @pytest.mark.parametrize(
     ("mensaje", "es_incompleto"),
     [
-        ("Se esperaba 'fin' para cerrar el bloque condicional", False),
+        ("Se esperaba 'fin' para cerrar el bloque condicional", True),
         ("Token inesperado en término: TipoToken.EOF", False),
         ("Se esperaba ']' al final de la lista", False),
         ("Token inesperado: '('", False),
         ("Se encontró 'fin' inesperado", False),
     ],
 )
-def test_es_error_de_bloque_incompleto_no_depende_de_mensajes_parser(mensaje, es_incompleto):
+def test_es_error_de_bloque_incompleto_fallback_textual_cubre_variantes_parser(mensaje, es_incompleto):
     command = ReplCommandV2()
     assert command.es_error_de_bloque_incompleto(ParserError(mensaje)) is es_incompleto
 


### PR DESCRIPTION
### Motivation
- Mejorar la recuperación del REPL cuando el parser reporta un bloque incompleto para no perder el buffer ni el estado de la sesión.
- Priorizar metadata del `ParserError` y usar un fallback textual limitado para cubrir variantes comunes de mensajes de cierre pendiente sin cambiar los mensajes del parser.

### Description
- En `ReplCommandV2.run` cambié el manejo de `except (LexerError, ParserError) as err` para que si `self.es_error_de_bloque_incompleto(err)` es `True` haga `continue` y preserve el `buffer`, y si es `False` clasifique/loguee el error y luego limpie el `buffer` y resetee el estado delegado con `_reset_buffer_local(buffer)` y `_reset_estado_delegate()`.
- En `src/pcobra/cobra/cli/utils/parser_error_classifier.py` mantuve la prioridad en metadata (token actual, esperados, flags de EOF inesperado) y refiné el fallback textual para detectar explícitamente indicadores de cierre pendiente (por ejemplo variantes de `Se esperaba 'fin'`) sin basarse en heurísticas amplias de EOF.
- No se modificaron los mensajes emitidos por el parser; solo se ajustó cómo se clasifican como "entrada incompleta".
- Actualicé una prueba parametrizada en `tests/unit/test_repl_command_v2.py` para reflejar el nuevo comportamiento del fallback textual.

### Testing
- Ejecuté pruebas unitarias dirigidas con `pytest -q tests/unit/test_repl_command_v2.py::test_es_error_de_bloque_incompleto_fallback_textual_cubre_variantes_parser tests/unit/cli/commands_v2/test_repl_cmd_v2.py::test_repl_v2_error_sintactico_real_limpia_buffer_y_repl_sigue tests/unit/cli/commands_v2/test_repl_cmd_v2.py::test_repl_v2_bloque_incompleto_no_ejecuta_ni_limpia_hasta_completar tests/unit/test_cli_interactive_cmd.py::test_es_error_de_bloque_incompleto_usa_fallback_textual_si_falta_metadata` y tras ajustes las pruebas dirigidas pasaron.
- Resultado final de las pruebas seleccionadas: `8 passed, 1 warning` en el conjunto ejecutado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede2af39408327991767e32029ccac)