### PR TITLE
Ajusta ejecución de REPL v2 para mantener estado y limpiar buffer correctamente

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -13,6 +13,7 @@ from pcobra.cobra.cli.execution_pipeline import (
 )
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.parser_error_classifier import (
+    _extraer_token_desde_error as extraer_token_desde_error_parser,
     es_parser_error_de_bloque_incompleto,
 )
 from pcobra.cobra.cli.utils.messages import mostrar_info
@@ -38,6 +39,12 @@ class ReplCommandV2(BaseCommand):
     def es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
         """Delega la clasificación de entrada incompleta al clasificador central."""
         return es_parser_error_de_bloque_incompleto(exc)
+
+    def _extraer_token_desde_error(self, err: Exception) -> Any | None:
+        """Compatibilidad con pruebas históricas de extracción de token."""
+        if not isinstance(err, ParserError):
+            return None
+        return extraer_token_desde_error_parser(err)
 
     def _manejar_error_prevalidacion(self, err: Exception, buffer: list[str]) -> None:
         """Procesa errores de prevalidación delegando la clasificación central."""
@@ -184,10 +191,14 @@ class ReplCommandV2(BaseCommand):
             except (PrimitivaPeligrosaError, RuntimeError) as err:
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
+                self._reset_buffer_local(buffer)
+                self._reset_estado_delegate()
                 continue
             except Exception as err:
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
+                self._reset_buffer_local(buffer)
+                self._reset_estado_delegate()
                 continue
 
         return 0


### PR DESCRIPTION
### Motivation

- Evitar que bloques fallidos queden concatenados con la siguiente entrada del REPL y mantener compatibilidad con las utilidades de clasificación de errores del parser.
- Reusar el estado del interpretador entre invocaciones del REPL para preservar variables y configuración del usuario.

### Description

- Añade la compatibilidad `_extraer_token_desde_error` en `ReplCommandV2` delegando a `_extraer_token_desde_error` del módulo `pcobra.cobra.cli.utils.parser_error_classifier` para compatibilidad con pruebas históricas.
- Mantiene el flujo normal de ejecución usando `ejecutar_pipeline_explicito(PipelineInput(...))` reutilizando `self._interpretador_persistente` para preservar el estado del interpretador entre comandos.
- Después de una ejecución exitosa actualiza `self._interpretador_persistente`, `self._seguro_repl` y `self._extra_validators_repl` desde `setup` y delega la impresión del resultado con `self._delegate._imprimir_resultado_repl(...)` para conservar la UX.
- Limpia el `buffer` y el `estado` local del delegado también en los manejadores de excepción de ejecución (`RuntimeError` y excepciones generales) para evitar que el siguiente comando se concatene con el anterior.

### Testing

- Ejecutado `pytest -q tests/unit/test_repl_command_v2.py tests/unit/cli/commands_v2/test_repl_cmd_v2.py` y la suite combinada terminó con `51 passed, 1 warning`.
- Antes del cambio algunas pruebas del REPL fallaban; tras aplicar los ajustes los tests unitarios relevantes pasan de forma estable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede4fe39c88327a0a4a5d7c4d2bd39)