### PR TITLE
REPL: fallback a `imprimir(...)` para expresiones top-level no soportadas

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -361,16 +361,37 @@ class InteractiveCommand(BaseCommand):
             module_name=__name__,
             default_cls=type(self.interpretador),
         )
-        setup, resultado_pipeline = ejecutar_pipeline_explicito(
-            PipelineInput(
-                codigo=codigo,
-                interpretador_cls=interpretador_cls,
-                safe_mode=self._seguro_repl,
-                extra_validators=self._extra_validators_repl,
-                interpretador=self.interpretador,
-            ),
-            analizar_codigo_fn=analizar_codigo,
-        )
+        try:
+            setup, resultado_pipeline = ejecutar_pipeline_explicito(
+                PipelineInput(
+                    codigo=codigo,
+                    interpretador_cls=interpretador_cls,
+                    safe_mode=self._seguro_repl,
+                    extra_validators=self._extra_validators_repl,
+                    interpretador=self.interpretador,
+                ),
+                analizar_codigo_fn=analizar_codigo,
+            )
+        except Exception as err_original:
+            if not self._debe_intentar_fallback_expresion_top_level(
+                codigo, err_original
+            ):
+                raise
+
+            codigo_fallback = f"imprimir({codigo.strip()})"
+            try:
+                setup, resultado_pipeline = ejecutar_pipeline_explicito(
+                    PipelineInput(
+                        codigo=codigo_fallback,
+                        interpretador_cls=interpretador_cls,
+                        safe_mode=self._seguro_repl,
+                        extra_validators=self._extra_validators_repl,
+                        interpretador=self.interpretador,
+                    ),
+                    analizar_codigo_fn=analizar_codigo,
+                )
+            except Exception:
+                raise err_original
         self.interpretador = setup.interpretador
         self._seguro_repl = setup.safe_mode
         self._extra_validators_repl = setup.validadores_extra
@@ -379,6 +400,54 @@ class InteractiveCommand(BaseCommand):
         self.logger.debug("[EXEC] Ejecutando AST en intérprete")
         self.logger.debug("[EVAL] Resultado de evaluación: %r", resultado)
         self._imprimir_resultado_repl(ast, resultado)
+
+    def _debe_intentar_fallback_expresion_top_level(
+        self, codigo: str, err_original: Exception
+    ) -> bool:
+        """Determina si aplica fallback a ``imprimir(...)`` para expresiones top-level."""
+
+        mensaje_error = str(err_original)
+        if "Nodo no soportado" not in mensaje_error or "Nodo" not in mensaje_error:
+            return False
+
+        ast = prevalidar_y_parsear_codigo(codigo)
+        if len(ast) != 1:
+            return False
+
+        nodo = ast[0]
+        nombre_nodo_ast = nodo.__class__.__name__
+        match_nodo = re.search(r"(Nodo[A-Za-z0-9_]+)", mensaje_error)
+        if match_nodo and match_nodo.group(1) != nombre_nodo_ast:
+            return False
+
+        nodos_no_expresion = (
+            "NodoAsignacion",
+            "NodoImprimir",
+            "NodoCondicional",
+            "NodoBucleMientras",
+            "NodoMientras",
+            "NodoPara",
+            "NodoFor",
+            "NodoFuncion",
+            "NodoClase",
+            "NodoRetorno",
+            "NodoImport",
+            "NodoUsar",
+            "NodoTryCatch",
+            "NodoThrow",
+            "NodoAssert",
+            "NodoDel",
+            "NodoGlobal",
+            "NodoNoLocal",
+            "NodoWith",
+            "NodoHolobit",
+            "NodoHilo",
+            "NodoRomper",
+            "NodoContinuar",
+            "NodoEsperar",
+            "NodoSwitch",
+        )
+        return nombre_nodo_ast not in nodos_no_expresion
 
     def _imprimir_resultado_repl(self, ast: list[Any], resultado: Any) -> None:
         """Imprime el resultado del REPL cuando aplica contrato de echo."""

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -368,6 +368,85 @@ def test_ejecutar_codigo_no_imprime_cuando_resultado_es_none():
     assert mock_stdout.getvalue() == ''
 
 
+def test_ejecutar_codigo_intenta_fallback_para_expresion_top_level_no_soportada():
+    cmd = InteractiveCommand(MagicMock())
+    setup = SimpleNamespace(
+        interpretador=cmd.interpretador,
+        safe_mode=cmd._seguro_repl,
+        validadores_extra=cmd._extra_validators_repl,
+    )
+    NodoOperacionBinaria = type("NodoOperacionBinaria", (), {})
+    ast_expr = [NodoOperacionBinaria()]
+    resultado = SimpleNamespace(ast=ast_expr, resultado=None)
+    llamadas = []
+
+    def _pipeline_fake(pipeline_input, analizar_codigo_fn):
+        llamadas.append(pipeline_input.codigo)
+        if pipeline_input.codigo == "1 + 2":
+            raise ValueError("Nodo no soportado: <class 'pcobra.core.ast_nodes.NodoOperacionBinaria'>")
+        if pipeline_input.codigo == "imprimir(1 + 2)":
+            return setup, resultado
+        raise AssertionError(f"Código inesperado: {pipeline_input.codigo}")
+
+    with patch(
+        "cobra.cli.commands.interactive_cmd.prevalidar_y_parsear_codigo",
+        return_value=ast_expr,
+    ), patch(
+        "cobra.cli.commands.interactive_cmd.ejecutar_pipeline_explicito",
+        side_effect=_pipeline_fake,
+    ):
+        cmd.ejecutar_codigo("1 + 2")
+
+    assert llamadas == ["1 + 2", "imprimir(1 + 2)"]
+
+
+def test_ejecutar_codigo_relanza_error_original_si_fallback_falla():
+    cmd = InteractiveCommand(MagicMock())
+    NodoOperacionBinaria = type("NodoOperacionBinaria", (), {})
+    ast_expr = [NodoOperacionBinaria()]
+
+    def _pipeline_fake(pipeline_input, analizar_codigo_fn):
+        if pipeline_input.codigo == "1 + 2":
+            raise ValueError("Nodo no soportado: <class 'pcobra.core.ast_nodes.NodoOperacionBinaria'>")
+        raise RuntimeError("falló fallback")
+
+    with patch(
+        "cobra.cli.commands.interactive_cmd.prevalidar_y_parsear_codigo",
+        return_value=ast_expr,
+    ), patch(
+        "cobra.cli.commands.interactive_cmd.ejecutar_pipeline_explicito",
+        side_effect=_pipeline_fake,
+    ):
+        try:
+            cmd.ejecutar_codigo("1 + 2")
+            assert False, "Se esperaba excepción"
+        except ValueError as err:
+            assert "Nodo no soportado" in str(err)
+
+
+def test_ejecutar_codigo_no_intenta_fallback_si_no_es_expresion_top_level():
+    cmd = InteractiveCommand(MagicMock())
+    NodoAsignacion = type("NodoAsignacion", (), {})
+    ast_stmt = [NodoAsignacion()]
+
+    with patch(
+        "cobra.cli.commands.interactive_cmd.prevalidar_y_parsear_codigo",
+        return_value=ast_stmt,
+    ), patch(
+        "cobra.cli.commands.interactive_cmd.ejecutar_pipeline_explicito",
+        side_effect=ValueError(
+            "Nodo no soportado: <class 'pcobra.core.ast_nodes.NodoAsignacion'>"
+        ),
+    ) as mock_pipeline:
+        try:
+            cmd.ejecutar_codigo("var x = 1")
+            assert False, "Se esperaba excepción"
+        except ValueError as err:
+            assert "Nodo no soportado" in str(err)
+
+    assert mock_pipeline.call_count == 1
+
+
 def test_es_nodo_control_sin_echo_repl_reconoce_alias_si_y_mientras_por_nombre():
     cmd = InteractiveCommand(MagicMock())
 


### PR DESCRIPTION
### Motivation
- Evitar que expresiones top-level (p. ej. operaciones binarias) produzcan un error de UX cuando el pipeline falla por "Nodo no soportado" y permitir mostrar su valor en REPL usando `imprimir(...)` como fallback.

### Description
- Envuelve el intento principal de `ejecutar_pipeline_explicito` en `InteractiveCommand.ejecutar_codigo` dentro de un `try/except` y conserva el intento original como primera opción.
- Añade la función auxiliar `_debe_intentar_fallback_expresion_top_level` que inspecciona el mensaje de error y vuelve a parsear con `prevalidar_y_parsear_codigo(codigo)` para validar `len(ast) == 1` y que el nodo sea candidato a expresión top-level.
- Cuando aplica el fallback construye `codigo_fallback = f"imprimir({codigo.strip()})"` y reintenta con el mismo pipeline/interprete persistente/safe mode/validadores, y si el fallback falla relanza el `err_original` para preservar el error original.
- No se modificó la lógica estructural de `_imprimir_resultado_repl(...)` y los cambios se aplicaron en `src/pcobra/cobra/cli/commands/interactive_cmd.py` además de pruebas nuevas en `tests/unit/test_cli_interactive_cmd.py`.

### Testing
- Se añadieron tres pruebas unitarias nuevas que cubren el fallback exitoso, la relanzación del error original si el fallback falla, y la no-activación del fallback para nodos no expresivos; estas pruebas pasaron (`3 passed`).
- Se volvieron a ejecutar pruebas existentes relacionadas con `ejecutar_codigo` y contrato REPL y continuaron pasando (`4 passed` para el conjunto ejecutado inicialmente).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edea9888408327b0b2218abe6792ea)