### PR TITLE
test: add REPL integration coverage for expression persistence and real errors

### DIFF
--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -166,6 +166,59 @@ def test_persistencia_basica_var_x_e_impresion_equivale_entre_run_y_repl():
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize(
+    ("expresion", "salida_esperada"),
+    [
+        ("x + 10", "15"),
+        ("x * 2", "10"),
+    ],
+)
+def test_repl_evalua_expresiones_con_estado_persistente(expresion: str, salida_esperada: str):
+    repl = InteractiveCommand(InterpretadorCobra())
+    repl._seguro_repl = False
+    repl._extra_validators_repl = None
+    out_repl, err_repl = StringIO(), StringIO()
+
+    with redirect_stdout(out_repl), redirect_stderr(err_repl):
+        repl.ejecutar_codigo("var x = 5")
+        repl.ejecutar_codigo(expresion)
+
+    assert err_repl.getvalue() == ""
+    assert out_repl.getvalue().strip().endswith(salida_esperada)
+
+
+@pytest.mark.integration
+def test_repl_no_suprime_error_real_en_expresion_con_variable_no_declarada():
+    repl = InteractiveCommand(InterpretadorCobra())
+    repl._seguro_repl = False
+    repl._extra_validators_repl = None
+    out_repl, err_repl = StringIO(), StringIO()
+
+    with redirect_stdout(out_repl), redirect_stderr(err_repl):
+        with pytest.raises(NameError, match=r"^Variable no declarada: x$"):
+            repl.ejecutar_codigo("x + 10")
+
+    assert out_repl.getvalue() == ""
+    assert err_repl.getvalue() == ""
+
+
+@pytest.mark.integration
+def test_repl_statement_normal_imprimir_no_duplica_salida():
+    repl = InteractiveCommand(InterpretadorCobra())
+    repl._seguro_repl = False
+    repl._extra_validators_repl = None
+    out_repl, err_repl = StringIO(), StringIO()
+
+    with redirect_stdout(out_repl), redirect_stderr(err_repl):
+        repl.ejecutar_codigo("var x = 5")
+        repl.ejecutar_codigo("imprimir(x)")
+
+    lineas_salida = [linea for linea in out_repl.getvalue().splitlines() if linea.strip()]
+    assert err_repl.getvalue() == ""
+    assert lineas_salida == ["5"]
+
+
+@pytest.mark.integration
 def test_repl_mantiene_estado_tras_error_intermedio():
     interpretador_cls = resolver_interpretador_cls(
         module_name="pcobra.cobra.cli.services.run_service",


### PR DESCRIPTION
### Motivation

- Añadir pruebas de integración que verifiquen que el REPL mantiene estado entre entradas y evalúa expresiones top-level correctamente.
- Detectar regresiones donde el REPL podría suprimir un `NameError` real o producir salida duplicada al ejecutar un `imprimir(...)` como statement.

### Description

- Se agregaron tests en `tests/integration/test_run_repl_equivalence.py` para validar evaluación de expresiones con estado persistente (`var x = 5` seguido de `x + 10` y `x * 2`).
- Se agregó un test que asegura que en un REPL limpio `x + 10` lanza un `NameError` con mensaje `Variable no declarada: x` y no se transforma en un falso éxito.
- Se agregó un test que verifica que un statement normal `imprimir(x)` no genera impresión duplicada en stdout.
- Todos los tests usan `redirect_stdout`/`redirect_stderr` y siguen el estilo existente del archivo de pruebas.

### Testing

- Ejecutado: `pytest -q tests/integration/test_run_repl_equivalence.py -k "expresiones_con_estado_persistente or no_suprime_error_real or statement_normal_imprimir_no_duplica_salida"`.
- Resultado: 2 tests pasaron y 2 fallaron; los fallos evidencian las regresiones objetivo: la ejecución de `x + 10` en REPL actualmente termina mostrando internamente un `ValueError: Nodo no soportado...` en lugar del `NameError` original, y `imprimir(x)` produce salida duplicada en stdout, por lo que los tests fallaron (comportamiento esperado para detección de regresiones automáticas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edeefb42408327908a9c909c3d66dd)