### PR TITLE
test: priorizar error original cuando falla fallback REPL

### DIFF
--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -400,15 +400,21 @@ def test_ejecutar_codigo_intenta_fallback_para_expresion_top_level_no_soportada(
     assert llamadas == ["1 + 2", "imprimir(1 + 2)"]
 
 
-def test_ejecutar_codigo_relanza_error_original_si_fallback_falla():
+def test_ejecutar_codigo_prioriza_error_original_cuando_fallback_tambien_falla():
     cmd = InteractiveCommand(MagicMock())
     NodoOperacionBinaria = type("NodoOperacionBinaria", (), {})
     ast_expr = [NodoOperacionBinaria()]
+    llamadas = []
+    error_original = "Nodo no soportado: <class 'pcobra.core.ast_nodes.NodoOperacionBinaria'>"
+    error_fallback = "falló fallback al envolver en imprimir(...)"
 
     def _pipeline_fake(pipeline_input, analizar_codigo_fn):
+        llamadas.append(pipeline_input.codigo)
         if pipeline_input.codigo == "1 + 2":
-            raise ValueError("Nodo no soportado: <class 'pcobra.core.ast_nodes.NodoOperacionBinaria'>")
-        raise RuntimeError("falló fallback")
+            raise ValueError(error_original)
+        if pipeline_input.codigo == "imprimir(1 + 2)":
+            raise RuntimeError(error_fallback)
+        raise AssertionError(f"Código inesperado: {pipeline_input.codigo}")
 
     with patch(
         "cobra.cli.commands.interactive_cmd.prevalidar_y_parsear_codigo",
@@ -421,7 +427,10 @@ def test_ejecutar_codigo_relanza_error_original_si_fallback_falla():
             cmd.ejecutar_codigo("1 + 2")
             assert False, "Se esperaba excepción"
         except ValueError as err:
-            assert "Nodo no soportado" in str(err)
+            assert str(err) == error_original
+            assert error_fallback not in str(err)
+
+    assert llamadas == ["1 + 2", "imprimir(1 + 2)"]
 
 
 def test_ejecutar_codigo_no_intenta_fallback_si_no_es_expresion_top_level():


### PR DESCRIPTION
### Motivation
- Asegurar que el REPL priorice y propague el error original producido al ejecutar una expresión top-level cuando el fallback que envuelve la expresión en `imprimir(...)` también falla.

### Description
- Añadí/renombré el test `test_ejecutar_codigo_prioriza_error_original_cuando_fallback_tambien_falla` en `tests/unit/test_cli_interactive_cmd.py` para dejar explícita la intención funcional.
- El test simula con `monkeypatch`/`patch` un primer error tipo `"Nodo no soportado: ..."` al ejecutar `1 + 2` y un error distinto al intentar el fallback `imprimir(1 + 2)`.
- Se verifica explícitamente que la excepción final sea exactamente el mensaje del error original y que el mensaje del fallback no aparezca, y además se comprueba la secuencia de llamadas (`"1 + 2"` seguido de `"imprimir(1 + 2)"`).

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_interactive_cmd.py -k "prioriza_error_original_cuando_fallback_tambien_falla or intenta_fallback_para_expresion_top_level_no_soportada or no_intenta_fallback_si_no_es_expresion_top_level"`, resultado: `3 passed` (39 deselected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf135518c8327aa7a3becb2a22db4)