### PR TITLE
Centraliza el flujo normal de ejecución en ReplCommandV2

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -398,6 +398,27 @@ class InteractiveCommand(BaseCommand):
         self.logger.debug("[EVAL] Resultado de evaluación: %r", resultado)
         self._imprimir_resultado_repl(ast, resultado)
 
+    def parsear_y_ejecutar_codigo_repl(
+        self,
+        codigo: str,
+        validador: Optional[Any] = None,
+        *,
+        prevalidar_fn: Any = prevalidar_y_parsear_codigo,
+    ) -> None:
+        """Valida sintaxis y ejecuta código REPL en el camino normal.
+
+        Este helper concentra el camino canónico parseo+ejecución para
+        implementaciones de REPL que delegan en ``InteractiveCommand``.
+        La ejecución reutiliza ``ejecutar_codigo``, incluyendo su fallback
+        para expresiones top-level.
+        """
+
+        prevalidar_fn(codigo)
+        if validador is None:
+            self.ejecutar_codigo(codigo)
+            return
+        self.ejecutar_codigo(codigo, validador)
+
     def _debe_intentar_fallback_expresion_top_level(
         self, codigo: str, err_original: Exception
     ) -> bool:

--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -24,6 +24,10 @@ from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
 
 class ReplCommandV2(BaseCommand):
     """Comando v2 público para iniciar el REPL de Cobra."""
+    # Nota técnica:
+    # La semántica del camino normal (parseo + ejecución + fallback de
+    # expresiones top-level) se define en InteractiveCommand.
+    # ReplCommandV2 coordina IO/estado y delega ese contrato.
 
     name = "repl"
     capability = "execute"
@@ -49,8 +53,7 @@ class ReplCommandV2(BaseCommand):
         """Procesa errores de prevalidación delegando la clasificación central."""
         if self.es_error_de_bloque_incompleto(err):
             return
-        categoria = self._delegate._clasificar_error_repl(err)
-        self._delegate._log_error(categoria, err)
+        self._registrar_error_repl(err)
         self._reset_buffer_local(buffer)
         self._reset_estado_delegate()
 
@@ -104,9 +107,17 @@ class ReplCommandV2(BaseCommand):
         _ = interpretador_cls
         self._sincronizar_estado_hacia_delegate()
         try:
-            self._delegate.ejecutar_codigo(codigo)
+            self._delegate.parsear_y_ejecutar_codigo_repl(
+                codigo,
+                prevalidar_fn=prevalidar_y_parsear_codigo,
+            )
         finally:
             self._sincronizar_estado_desde_delegate()
+
+    def _registrar_error_repl(self, err: Exception) -> None:
+        """Centraliza clasificación + visualización de errores REPL."""
+        categoria = self._delegate._clasificar_error_repl(err)
+        self._delegate._log_error(categoria, err)
 
     def _reset_buffer_local(self, buffer: list[str]) -> None:
         """Limpia el buffer de entrada local del REPL v2."""
@@ -165,20 +176,19 @@ class ReplCommandV2(BaseCommand):
 
             buffer.append(linea)
             codigo = "\n".join(buffer)
-            try:
-                prevalidar_y_parsear_codigo(codigo)
-            except (LexerError, ParserError) as err:
-                if self.es_error_de_bloque_incompleto(err):
+            if sandbox or sandbox_docker:
+                try:
+                    prevalidar_y_parsear_codigo(codigo)
+                except (LexerError, ParserError) as err:
+                    if self.es_error_de_bloque_incompleto(err):
+                        continue
+                    self._registrar_error_repl(err)
+                    self._reset_buffer_local(buffer)
+                    self._reset_estado_delegate()
                     continue
-                categoria = self._delegate._clasificar_error_repl(err)
-                self._delegate._log_error(categoria, err)
-                self._reset_buffer_local(buffer)
-                self._reset_estado_delegate()
-                continue
-            except Exception as err:
-                categoria = self._delegate._clasificar_error_repl(err)
-                self._delegate._log_error(categoria, err)
-                continue
+                except Exception as err:
+                    self._registrar_error_repl(err)
+                    continue
 
             try:
                 if sandbox:
@@ -189,15 +199,20 @@ class ReplCommandV2(BaseCommand):
                     self._ejecutar_en_modo_normal(codigo, interpretador_cls)
                 self._reset_buffer_local(buffer)
                 self._reset_estado_delegate()
+            except (LexerError, ParserError) as err:
+                if self.es_error_de_bloque_incompleto(err):
+                    continue
+                self._registrar_error_repl(err)
+                self._reset_buffer_local(buffer)
+                self._reset_estado_delegate()
+                continue
             except (PrimitivaPeligrosaError, RuntimeError) as err:
-                categoria = self._delegate._clasificar_error_repl(err)
-                self._delegate._log_error(categoria, err)
+                self._registrar_error_repl(err)
                 self._reset_buffer_local(buffer)
                 self._reset_estado_delegate()
                 continue
             except Exception as err:
-                categoria = self._delegate._clasificar_error_repl(err)
-                self._delegate._log_error(categoria, err)
+                self._registrar_error_repl(err)
                 self._reset_buffer_local(buffer)
                 self._reset_estado_delegate()
                 continue

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -1054,3 +1054,31 @@ def test_repl_v2_bloque_incompleto_acumula_buffer_y_sesion_sigue_activa(monkeypa
         "si verdadero:\nimprimir(1)\nfin",
     ]
     assert delegate_calls == ["si verdadero:\nimprimir(1)\nfin"]
+
+
+def test_regresion_paridad_interactive_vs_repl_v2_para_expresion_top_level(monkeypatch, capsys):
+    repl_interactivo = interactive_module.InteractiveCommand(repl_module.InterpretadorCobra())
+    repl_interactivo.ejecutar_codigo("var x = 5")
+    repl_interactivo.ejecutar_codigo("x + 10")
+    salida_interactive = capsys.readouterr().out
+
+    command = ReplCommandV2()
+    entradas = iter(["var x = 5", "x + 10", "exit"])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+    monkeypatch.setattr(repl_module, "mostrar_info", lambda *_args, **_kwargs: None)
+
+    status = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+            seguro=True,
+            extra_validators=None,
+        )
+    )
+
+    assert status == 0
+    salida_repl_v2 = capsys.readouterr().out
+    assert salida_repl_v2 == salida_interactive
+    assert salida_repl_v2.endswith("15\n")


### PR DESCRIPTION
### Motivation
- Evitar duplicación y asegurar que la semántica del camino normal de ejecución REPL (parseo + ejecución + fallback de expresiones top-level) esté definida en un único lugar.
- Unificar criterio de clasificación y visualización de errores REPL para evitar inconsistencias entre `ReplCommandV2` e `InteractiveCommand`.
- Añadir una prueba de regresión que garantice paridad de comportamiento entre ambos caminos frente a la misma sesión/estado inicial.

### Description
- Añadido `InteractiveCommand.parsear_y_ejecutar_codigo_repl(...)` que concentra el camino canónico de `prevalidar` + `ejecutar_codigo` (y reutiliza el fallback implícito de `ejecutar_codigo`).
- Documentado en `ReplCommandV2` con un comentario técnico que deja explícito que la semántica de ejecución normal la define `InteractiveCommand` y que `ReplCommandV2` coordina IO/estado.
- Centralizado el criterio de clasificación/visualización de errores en `ReplCommandV2` con el helper `_registrar_error_repl(...)` y reemplazadas llamadas repetidas a `_delegate._clasificar_error_repl`/`_delegate._log_error` por este único punto de entrada.
- Añadida prueba de regresión `test_regresion_paridad_interactive_vs_repl_v2_para_expresion_top_level` que compara la salida de `InteractiveCommand.ejecutar_codigo("x + 10")` vs ejecutar las mismas entradas por `ReplCommandV2` en la misma sesión inicial (`var x = 5`).
- Archivos modificados: `src/pcobra/cobra/cli/commands/interactive_cmd.py`, `src/pcobra/cobra/cli/commands_v2/repl_cmd.py`, y `tests/unit/test_repl_command_v2.py`.

### Testing
- Ejecutado `pytest -q tests/unit/test_repl_command_v2.py` y la suite afectada pasó correctamente con `48 passed`.
- Se ejecutó también una corrida focalizada de las pruebas nuevas/relacionadas y estas pasaron (`3 passed` en la ejecución focal).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edfcbdc13c8327869831743ea4e80e)