### PR TITLE
Fix REPL top-level fallback execution in interactive command

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -379,16 +379,23 @@ class InteractiveCommand(BaseCommand):
                 raise
 
             codigo_fallback = f"imprimir({codigo.strip()})"
-            setup, resultado_pipeline = ejecutar_pipeline_explicito(
-                PipelineInput(
-                    codigo=codigo_fallback,
-                    interpretador_cls=interpretador_cls,
-                    safe_mode=self._seguro_repl,
-                    extra_validators=self._extra_validators_repl,
-                    interpretador=self.interpretador,
-                ),
-                analizar_codigo_fn=analizar_codigo,
-            )
+            try:
+                setup, resultado_pipeline = ejecutar_pipeline_explicito(
+                    PipelineInput(
+                        codigo=codigo_fallback,
+                        interpretador_cls=interpretador_cls,
+                        safe_mode=self._seguro_repl,
+                        extra_validators=self._extra_validators_repl,
+                        interpretador=self.interpretador,
+                    ),
+                    analizar_codigo_fn=analizar_codigo,
+                )
+            except Exception as err_fallback:
+                if self._debe_intentar_fallback_expresion_top_level(
+                    codigo_fallback, err_fallback
+                ):
+                    raise err_original
+                raise
         self.interpretador = setup.interpretador
         self._seguro_repl = setup.safe_mode
         self._extra_validators_repl = setup.validadores_extra
@@ -503,6 +510,7 @@ class InteractiveCommand(BaseCommand):
         debe_imprimir_resultado = (
             resultado is not None
             and len(ast) == 1
+            and ast[0].__class__.__name__ not in {"NodoImprimir", "NodoAsignacion"}
             and not self._es_nodo_control_sin_echo_repl(ast[0])
         )
         if debe_imprimir_resultado:


### PR DESCRIPTION
### Motivation
- Mantener el flujo canónico de ejecución en el REPL usando `PipelineInput` y `ejecutar_pipeline_explicito` con el snippet original y preservar el intérprete persistente entre reintentos.
- Evitar que el fallback para expresiones top-level oculte errores reales (por ejemplo `NameError` por variable no declarada) y prevenir eco duplicado en sentencias explícitas como `imprimir(...)`.

### Description
- En `InteractiveCommand.ejecutar_codigo` se añadió un reintento del pipeline que envuelve el snippet como `imprimir(<codigo.strip()>)` y lo ejecuta con el mismo `interpretador=self.interpretador` para conservar estado de sesión.
- El reintento está envuelto en su propio `try/except` y solo relanza el error original cuando el fallback falla por el mismo patrón de "Nodo no soportado" detectado inicialmente, dejando pasar otros errores del fallback para que no se silencien.
- Se ajustó la lógica de eco en REPL para excluir explícitamente nodos `NodoImprimir` y `NodoAsignacion` del print automático y así evitar salidas duplicadas.
- No se modificaron el lexer ni el parser; toda la lógica queda encapsulada en métodos de `InteractiveCommand` y helpers privados.

### Testing
- Ejecutado `pytest -q tests/integration/test_run_repl_equivalence.py` y al finalizar todos los tests pasaron: `18 passed, 1 warning`.
- Se verificó localmente que casos relevantes cubiertos por las pruebas de integración (fallback top-level, preservación de estado y no duplicación de echo) pasan correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edfec03fc4832795db2fc704218d41)