### PR TITLE
test(repl-v2): cubrir delegación de parseo y comportamiento sandbox-docker

### DIFF
--- a/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
+++ b/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
@@ -63,6 +63,59 @@ def test_repl_v2_contrato_llama_prevalidacion_y_pipeline_compartido(monkeypatch)
     assert runtime_alternativo_calls == []
 
 
+def test_repl_v2_ejecutar_modo_normal_delega_parseo_al_delegate(monkeypatch):
+    command = repl_module.ReplCommandV2()
+    called: dict[str, object] = {}
+
+    def _fake_delegate(codigo: str, prevalidar_fn):
+        called["codigo"] = codigo
+        called["prevalidar_fn"] = prevalidar_fn
+
+    monkeypatch.setattr(
+        command._delegate,
+        "parsear_y_ejecutar_codigo_repl",
+        _fake_delegate,
+    )
+
+    command._ejecutar_en_modo_normal("imprimir(1)", object)
+
+    assert called == {
+        "codigo": "imprimir(1)",
+        "prevalidar_fn": repl_module.prevalidar_y_parsear_codigo,
+    }
+
+
+def test_repl_v2_sandbox_docker_no_usa_camino_normal(monkeypatch):
+    command = repl_module.ReplCommandV2()
+    entradas = iter(["imprimir(1)", "exit"])
+    prevalidaciones: list[str] = []
+    docker_calls: list[tuple[str, str]] = []
+    normal_calls: list[str] = []
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+    monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", lambda codigo: prevalidaciones.append(codigo))
+    monkeypatch.setattr(
+        command._delegate,
+        "_ejecutar_en_docker",
+        lambda codigo, backend: docker_calls.append((codigo, backend)),
+    )
+    monkeypatch.setattr(
+        command,
+        "_ejecutar_en_modo_normal",
+        lambda codigo, _interpretador_cls: normal_calls.append(codigo),
+    )
+
+    args = _args_repl()
+    args.sandbox_docker = "python"
+
+    status = command.run(args)
+
+    assert status == 0
+    assert prevalidaciones == ["imprimir(1)"]
+    assert docker_calls == [("imprimir(1)", "python")]
+    assert normal_calls == []
+
+
 def test_repl_v2_persistencia_estado_var_x_e_imprimir_x(monkeypatch, capsys):
     command = repl_module.ReplCommandV2()
     command._interpretador_persistente = {}


### PR DESCRIPTION
### Motivation
- Asegurar que la ruta normal del REPL delega el parseo y ejecución al `InteractiveCommand` sin introducir parseos alternativos ni rutas paralelas, y que el comportamiento de `sandbox`/`sandbox-docker` no cambia.

### Description
- Añadí pruebas unitarias en `tests/unit/cli/commands_v2/test_repl_cmd_v2.py` que verifican que `_ejecutar_en_modo_normal(...)` llama a `parsear_y_ejecutar_codigo_repl(...)` con `prevalidar_fn=prevalidar_y_parsear_codigo`.
- Añadí una prueba que asegura que cuando `sandbox_docker` está activo se utiliza la ruta docker y no se invoca el camino normal de ejecución.
- No se modificó la implementación de `src/pcobra/cobra/cli/commands_v2/repl_cmd.py`, por lo que la lógica de buffering multilinea y la recuperación ante `ParserError` de bloque incompleto se conservan intactas.

### Testing
- Ejecuté `pytest -q tests/unit/cli/commands_v2/test_repl_cmd_v2.py` y todas las pruebas pasaron: `7 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee00d04200832788390b4d61010df7)