### PR TITLE
Refuerza delegación interpretativa del REPL v2 en modo normal

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -6,9 +6,7 @@ from pcobra.cobra.cli.commands.interactive_cmd import (
     SANDBOX_DOCKER_CHOICES,
 )
 from pcobra.cobra.cli.execution_pipeline import (
-    ejecutar_pipeline_explicito,  # Compatibilidad con pruebas que monkeypatchean este símbolo.
     prevalidar_y_parsear_codigo,
-    resolver_interpretador_cls,
 )
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.parser_error_classifier import (
@@ -102,9 +100,13 @@ class ReplCommandV2(BaseCommand):
         self._seguro_repl = self._delegate._seguro_repl
         self._extra_validators_repl = self._delegate._extra_validators_repl
 
-    def _ejecutar_en_modo_normal(self, codigo: str, interpretador_cls: type) -> None:
+    def _ejecutar_en_modo_normal(
+        self,
+        codigo: str,
+        interpretador_cls: type | None = None,
+    ) -> None:
         """Ejecuta una entrada REPL reutilizando la lógica canónica de InteractiveCommand."""
-        _ = interpretador_cls
+        _ = interpretador_cls  # Compatibilidad con contratos de pruebas existentes.
         self._sincronizar_estado_hacia_delegate()
         try:
             self._delegate.parsear_y_ejecutar_codigo_repl(
@@ -132,11 +134,6 @@ class ReplCommandV2(BaseCommand):
         self._delegate._estado_repl = self._delegate._crear_estado_repl()
         self._seguro_repl = bool(getattr(args, "seguro", True))
         self._extra_validators_repl = getattr(args, "extra_validators", None)
-        interpretador_cls = resolver_interpretador_cls(
-            module_name=__name__,
-            default_cls=InterpretadorCobra,
-        )
-
         sandbox = bool(getattr(args, "sandbox", False))
         sandbox_docker = getattr(args, "sandbox_docker", None)
 
@@ -196,7 +193,7 @@ class ReplCommandV2(BaseCommand):
                 elif sandbox_docker:
                     self._delegate._ejecutar_en_docker(codigo, sandbox_docker)
                 else:
-                    self._ejecutar_en_modo_normal(codigo, interpretador_cls)
+                    self._ejecutar_en_modo_normal(codigo)
                 self._reset_buffer_local(buffer)
                 self._reset_estado_delegate()
             except (LexerError, ParserError) as err:


### PR DESCRIPTION
### Motivation
- Aclarar y asegurar que el camino normal del REPL v2 delega la lógica de parseo/ejecución al `InteractiveCommand` que ya trabaja con AST directo, eliminando arrastres residuales que inducían a usar el pipeline explícito.
- Mantener compatibilidad con pruebas existentes que podían pasar un `interpretador_cls` a `_ejecutar_en_modo_normal` sin alterar la ruta interpretativa real.

### Description
- Eliminé los imports no usados `ejecutar_pipeline_explicito` y `resolver_interpretador_cls` de `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` para evitar confusión sobre la ruta normal del REPL.
- Cambié la firma de `_ejecutar_en_modo_normal` a `def _ejecutar_en_modo_normal(self, codigo: str, interpretador_cls: type | None = None) -> None` y ahora se ignora `interpretador_cls` con ` _ = interpretador_cls` para preservar compatibilidad de pruebas.
- Eliminé la resolución de `interpretador_cls` en `run()` y actualicé la llamada para usar `self._ejecutar_en_modo_normal(codigo)` en el camino normal; las ramas `--sandbox` y `--sandbox-docker` permanecen sin cambios.

### Testing
- Ejecuté `pytest -q tests/unit/cli/commands_v2/test_repl_cmd_v2.py tests/unit/test_repl_command_v2.py -q`, que inicialmente falló por un cambio de firma, luego pasaron correctamente tras añadir el parámetro opcional; la ejecución final reportó éxito en ambos archivos de pruebas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee30c632f48327ad843b020b3c4c42)