### PR TITLE
Corregir regresión de CSE en secuencia REPL incremental (var y imprimir)

### DIFF
--- a/src/pcobra/core/optimizations/common_subexpr.py
+++ b/src/pcobra/core/optimizations/common_subexpr.py
@@ -51,6 +51,11 @@ class _ExprCounter(NodeVisitor):
         self.counts[key] = self.counts.get(key, 0) + 1
         self.visit(nodo.operando)
 
+    def visit_asignacion(self, nodo: NodoAsignacion):
+        # ``NodoAsignacion`` expone alias ``expresion`` y ``valor`` al mismo nodo;
+        # contar ambos duplica subexpresiones y genera CSE espurio.
+        self.visit(nodo.expresion)
+
     def generic_visit(self, node: Any):
         if not isinstance(node, NodoAST):
             raise RuntimeError(
@@ -93,7 +98,11 @@ class _CommonSubexprEliminator(NodeVisitor):
             nombre = f"_cse{len(cur)}"
             cur[key] = nombre
             self._current_assigns().append(
-                NodoAsignacion(nombre, copy.deepcopy(expr))
+                NodoAsignacion(
+                    nombre,
+                    copy.deepcopy(expr),
+                    declaracion=True,
+                )
             )
         return NodoIdentificador(cur[key])
 
@@ -113,6 +122,12 @@ class _CommonSubexprEliminator(NodeVisitor):
         key = _expr_key(nodo)
         if self.counts.get(key, 0) > 1:
             return self._replace(key, NodoOperacionUnaria(nodo.operador, nodo.operando))
+        return nodo
+
+    def visit_asignacion(self, nodo: NodoAsignacion):
+        nodo.expresion = self.visit(nodo.expresion)
+        # Mantener alias de compatibilidad alineados.
+        nodo.valor = nodo.expresion
         return nodo
 
     def visit_funcion(self, nodo: NodoFuncion):

--- a/tests/cli/test_repl_script_parity_contract.py
+++ b/tests/cli/test_repl_script_parity_contract.py
@@ -447,3 +447,33 @@ def test_repl_v2_no_altera_semantica_en_statements_var_imprimir_y_si_fin() -> No
 
     assert resultado["stderr"] == ""
     assert lineas == ["10", "20"]
+
+
+@pytest.mark.integration
+def test_repl_incremental_var_var_imprimir_sin_regresion_cse_y_estado_final() -> None:
+    snippets = [
+        "var x = 5",
+        "var y = x * 2",
+        "imprimir(y)",
+    ]
+    resultado = _ejecutar_snippets_secuenciales_repl(
+        snippets,
+        variables_estado=("x", "y"),
+    )
+
+    evidencia = "\n".join(
+        fragmento
+        for fragmento in (
+            str(resultado["stdout"]),
+            str(resultado["stderr"]),
+            str(resultado["error"]) if resultado["error"] is not None else "",
+        )
+        if fragmento
+    )
+
+    assert resultado["error"] is None
+    assert "Variable no declarada: _cse0" not in evidencia
+    assert "Variable no declarada: _cse" not in evidencia
+    assert resultado["stderr"] == ""
+    assert str(resultado["stdout"]).strip().endswith("10")
+    assert resultado["estado"] == {"x": 5, "y": 10}


### PR DESCRIPTION
### Motivation
- Evitar que la optimización de eliminación de subexpresiones comunes (CSE) genere temporales `_cseN` no declarados al procesar asignaciones en entradas REPL secuenciales como `var x = 5` / `var y = x * 2` / `imprimir(y)`. 
- Garantizar paridad semántica entre la ejecución por ruta (`run`) y el REPL manteniendo el estado y sin lanzar errores espurios por temporales CSE.

### Description
- Añadido un test de integración `test_repl_incremental_var_var_imprimir_sin_regresion_cse_y_estado_final` en `tests/cli/test_repl_script_parity_contract.py` que ejecuta la secuencia REPL incremental y valida ausencia de excepción, `stderr` vacío, `stdout` termina en `10`, estado final `{"x": 5, "y": 10}` y asserts negativos para mensajes que mencionen `_cse`.
- En `src/pcobra/core/optimizations/common_subexpr.py` se evita el doble conteo de subexpresiones en asignaciones implementando `visit_asignacion` en `_ExprCounter` para recorrer solo `nodo.expresion` (evitando contar también el alias `valor`).
- En `_CommonSubexprEliminator` se añadió `visit_asignacion` para transformar únicamente `nodo.expresion` y mantener el alias `nodo.valor` consistente tras la transformación.
- Al crear los temporales CSE (`_cseN`) ahora la asignación temporal se marca con `declaracion=True` para que el intérprete los trate como declaración local y no falle por variable no declarada.

### Testing
- Ejecutado `pytest -q tests/cli/test_repl_script_parity_contract.py -k 'incremental_var_var_imprimir_sin_regresion_cse_y_estado_final or repl_v2_echo_expresiones_y_estado_persistente_en_entradas_secuenciales'` y las pruebas relevantes pasaron localmente.
- Ejecutado `pytest -q tests/cli/test_repl_script_parity_contract.py tests/integration/test_run_repl_equivalence.py` con resultado `29 passed` sobre el conjunto ejecutado.
- El cambio fue verificado manualmente contra la secuencia problemática ejecutando el pipeline que provocaba el error y comprobando que `imprimir(y)` ya no falla y el estado final contiene `x=5` y `y=10`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee43423c088327aadcead494a45d71)