### PR TITLE
Preserva intérprete persistente en REPL normal

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -407,6 +407,11 @@ class InteractiveCommand(BaseCommand):
         implementaciones de REPL que delegan en ``InteractiveCommand``.
         La ejecución reutiliza ``ejecutar_codigo``, incluyendo su fallback
         para expresiones top-level.
+
+        Nota técnica:
+        REPL implica evaluación incremental sobre un intérprete persistente
+        (``self.interpretador``). No es una compilación/lote "batch" por
+        entrada; cada snippet se evalúa con el contexto acumulado.
         """
 
         prevalidar_fn(codigo)

--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -33,7 +33,8 @@ class ReplCommandV2(BaseCommand):
         super().__init__()
         self._delegate = InteractiveCommand(InterpretadorCobra())
         self._delegate.name = self.name
-        self._interpretador_persistente: Any | None = None
+        # Mantener una única instancia viva para todo el ciclo de la sesión.
+        self._interpretador_persistente: Any | None = self._delegate.interpretador
         self._seguro_repl: bool = True
         self._extra_validators_repl: Any = None
 
@@ -89,6 +90,8 @@ class ReplCommandV2(BaseCommand):
 
     def _sincronizar_estado_hacia_delegate(self) -> None:
         """Sincroniza estado persistente local hacia el comando delegado."""
+        # En modo normal siempre se reinyecta la misma referencia persistente
+        # para evitar re-instanciación accidental entre snippets.
         if self._interpretador_persistente is not None:
             self._delegate.interpretador = self._interpretador_persistente
         self._delegate._seguro_repl = self._seguro_repl
@@ -96,7 +99,8 @@ class ReplCommandV2(BaseCommand):
 
     def _sincronizar_estado_desde_delegate(self) -> None:
         """Sincroniza estado del comando delegado hacia el estado local."""
-        self._interpretador_persistente = self._delegate.interpretador
+        if self._delegate.interpretador is not None:
+            self._interpretador_persistente = self._delegate.interpretador
         self._seguro_repl = self._delegate._seguro_repl
         self._extra_validators_repl = self._delegate._extra_validators_repl
 
@@ -126,7 +130,11 @@ class ReplCommandV2(BaseCommand):
         buffer.clear()
 
     def _reset_estado_delegate(self) -> None:
-        """Restablece el estado base del REPL delegado."""
+        """Restablece el estado base del REPL delegado.
+
+        Solo limpia metadatos de captura/buffer del REPL y no toca el runtime
+        (`interpretador`) para preservar contexto de variables.
+        """
         self._delegate._estado_repl = self._delegate._crear_estado_repl()
 
     def run(self, args: Any) -> int:

--- a/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
+++ b/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
@@ -218,6 +218,15 @@ def test_repl_v2_error_sintactico_real_limpia_buffer_y_repl_sigue(monkeypatch):
     assert errores_reportados == ["Token inesperado: '('"]
 
 
+def test_repl_v2_reset_estado_delegate_no_reinicia_interpretador():
+    command = repl_module.ReplCommandV2()
+    interpretador_inicial = command._delegate.interpretador
+
+    command._reset_estado_delegate()
+
+    assert command._delegate.interpretador is interpretador_inicial
+
+
 def test_repl_v2_bloque_incompleto_no_ejecuta_ni_limpia_hasta_completar(monkeypatch):
     command = repl_module.ReplCommandV2()
     entradas = iter(["si verdadero:", "imprimir(1)", "fin", "exit"])


### PR DESCRIPTION
### Motivation
- Evitar que el intérprete del REPL se re-instancie entre snippets en el camino normal y proteger el contexto de variables acumulado en la sesión.
- Aclarar en la documentación interna que la REPL es un intérprete incremental y no una compilación por lotes por entrada.

### Description
- Añadida una nota técnica a `InteractiveCommand.parsear_y_ejecutar_codigo_repl` que documenta que el REPL evalúa incrementalmente sobre `self.interpretador` y no realiza compilación batch por entrada.
- Inicializado `ReplCommandV2._interpretador_persistente` con la instancia del delegate para arrancar la sesión con una referencia persistente en lugar de `None`.
- En `ReplCommandV2._sincronizar_estado_hacia_delegate` y `_sincronizar_estado_desde_delegate` se reforzó la lógica para reinyectar y preservar la misma referencia de intérprete sin sobrescribir con `None`.
- Actualizado `_reset_estado_delegate` para dejar explícito y documentado que solo reinicia metadatos de captura/buffer (`_estado_repl`) y no reemplaza el `interpretador`, y agregado test que verifica este comportamiento.

### Testing
- Ejecutado `pytest -q tests/unit/cli/commands_v2/test_repl_cmd_v2.py` y todos los tests pasaron (`8 passed`) con 1 advertencia reportada.
- La nueva prueba `test_repl_v2_reset_estado_delegate_no_reinicia_interpretador` valida que `_reset_estado_delegate()` no reinicia el intérprete y pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4c8d69288327829008d031ddfb0c)