### PR TITLE
docs(repl): clarify explicit pipeline is setup-only in interactive command

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -373,6 +373,9 @@ class InteractiveCommand(BaseCommand):
         """Ejecuta un snippet en el intérprete persistente del REPL."""
 
         self.logger.debug("[RUN] Ejecutando snippet en REPL")
+        # Contrato REPL (normal): no usar ``ejecutar_pipeline_explicito`` aquí.
+        # Este camino ejecuta snippets interactivos normales sobre el intérprete
+        # persistente para preservar la semántica incremental del lenguaje.
         try:
             ast, resultado = self._ejecutar_ast_en_repl(codigo, validador)
         except Exception as err_original:
@@ -415,6 +418,8 @@ class InteractiveCommand(BaseCommand):
         """
 
         prevalidar_fn(codigo)
+        # Contrato REPL (normal): este helper delega en ``ejecutar_codigo`` y,
+        # por diseño, no debe introducir pipeline explícito para snippets.
         if validador is None:
             self.ejecutar_codigo(codigo)
             return
@@ -758,6 +763,8 @@ class InteractiveCommand(BaseCommand):
                 elif sandbox_docker:
                     self._ejecutar_en_docker(codigo, sandbox_docker)
                 else:
+                    # Contrato de dispatch: en la rama no-sandbox/no-docker se
+                    # mantiene ejecución directa en REPL (sin pipeline explícito).
                     self.ejecutar_codigo(codigo, validador)
                 estado["buffer_lineas"].clear()
             except Exception as err:  # pragma: no cover - ruta unificada de errores
@@ -928,6 +935,9 @@ class InteractiveCommand(BaseCommand):
             module_name=__name__,
             default_cls=type(self.interpretador),
         )
+        # Contrato sandbox/setup: ``ejecutar_pipeline_explicito`` se usa aquí
+        # únicamente para normalizar configuración de intérprete/opciones antes
+        # de construir el script sandbox; no para ejecutar snippets normales.
         setup, _ = ejecutar_pipeline_explicito(
             PipelineInput(
                 codigo="",


### PR DESCRIPTION
### Motivation
- Evitar el uso de `ejecutar_pipeline_explicito` para la ejecución de snippets REPL normales y dejar claro su uso solo en la preparación del entorno sandbox.
- Codificar en comentarios el contrato de ejecución interactiva para preservar la semántica incremental del intérprete persistente.

### Description
- Auditada la presencia de `ejecutar_pipeline_explicito` y confirmada su única invocación operativa en `_ejecutar_en_sandbox` para normalización de configuración antes del script sandbox.
- Añadidos comentarios explicativos en `ejecutar_codigo` indicando que no debe llamarse a `ejecutar_pipeline_explicito` en el camino REPL normal.
- Añadidos comentarios en `parsear_y_ejecutar_codigo_repl` y en la rama no-sandbox de `_run_repl_loop` reafirmando que el camino normal delega en `ejecutar_codigo` sin pipeline explícito.
- Añadido comentario junto a la llamada en `_ejecutar_en_sandbox` aclarando que `ejecutar_pipeline_explicito` se usa únicamente para normalizar intérprete/opciones antes de construir el script sandbox.

### Testing
- Ejecutado `rg -n "ejecutar_pipeline_explicito|def ejecutar_codigo|def parsear_y_ejecutar_codigo_repl|def _run_repl_loop|def _ejecutar_en_sandbox" src/pcobra/cobra/cli/commands/interactive_cmd.py` y verificado la presencia de los nuevos comentarios, resultado OK.
- Ejecutado `python -m compileall -q src/pcobra/cobra/cli/commands/interactive_cmd.py` para validar que el archivo compila y la comprobación fue satisfactoria.
- Ejecutado `git diff -- src/pcobra/cobra/cli/commands/interactive_cmd.py` para revisar el diff producido y confirmar que solo se añadieron comentarios, resultado OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee54e94f208327b4777b0a183683a0)