### PR TITLE
REPL: ejecutar AST nodo-a-nodo

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -366,7 +366,11 @@ class InteractiveCommand(BaseCommand):
         if validador:
             for nodo in ast:
                 nodo.aceptar(validador)
-        resultado = self.interpretador.ejecutar_ast(ast)
+        resultado = None
+        for nodo in ast:
+            resultado = self.interpretador.ejecutar_nodo(nodo)
+            if resultado is not None:
+                break
         return ast, resultado
 
     def ejecutar_codigo(self, codigo: str, validador: Optional[Any] = None) -> None:


### PR DESCRIPTION
### Motivation
- Ejecutar los nodos del AST uno a uno en el REPL para reutilizar `ejecutar_nodo` del runtime y controlar el corte temprano sin modificar el lexer/parser ni el pipeline.

### Description
- Reemplacé la llamada a `self.interpretador.ejecutar_ast(ast)` por un bucle que hace `for nodo in ast: resultado = self.interpretador.ejecutar_nodo(nodo)` y rompe cuando `resultado is not None`, manteniendo intactos `prevalidar_y_parsear_codigo`, `validar_ast_seguro` y el validador opcional, y devolviendo la misma tupla `(ast, resultado)`.

### Testing
- Compilé el archivo modificado con `python -m compileall src/pcobra/cobra/cli/commands/interactive_cmd.py` y la compilación finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee5aed43a88327b34ffcdf9c7a29a1)