### PR TITLE
test(repl): add regression coverage for interactive var/var/imprimir session

### DIFF
--- a/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
+++ b/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
@@ -255,3 +255,20 @@ def test_repl_v2_bloque_incompleto_no_ejecuta_ni_limpia_hasta_completar(monkeypa
     assert status == 0
     assert parse_calls == ["si verdadero:", "si verdadero:\nimprimir(1)", bloque_completo]
     assert ejecucion_calls == [bloque_completo]
+
+
+def test_repl_v2_regresion_sesion_interactiva_var_var_imprimir_sin_error_cse0(monkeypatch, capsys):
+    command = repl_module.ReplCommandV2()
+    entradas = iter(["var x = 5", "var y = x * 2", "imprimir(y)", "exit"])
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+    monkeypatch.setattr(repl_module, "mostrar_info", lambda *_args, **_kwargs: None)
+
+    status = command.run(_args_repl())
+    salida = capsys.readouterr()
+    evidencia = f"{salida.out}\n{salida.err}"
+
+    assert status == 0
+    assert "Variable no declarada: _cse0" not in evidencia
+    assert salida.err == ""
+    assert salida.out.strip().endswith("10")


### PR DESCRIPTION
### Motivation
- Asegurar que la sesión REPL incremental preserve el `interpretador` persistente y prevenir una regresión que filtraba nombres temporales internos (`_cse0`) durante secuencias interactivas de declaraciones y expresiones.

### Description
- Añade la prueba `test_repl_v2_regresion_sesion_interactiva_var_var_imprimir_sin_error_cse0` en `tests/unit/cli/commands_v2/test_repl_cmd_v2.py` que simula las entradas `var x = 5`, `var y = x * 2`, `imprimir(y)` y comprueba que la salida es `10`, que `stderr` está vacío y que no aparece `Variable no declarada: _cse0`.
- No se cambiaron rutas de ejecución del REPL; verifiqué que `InteractiveCommand._ejecutar_ast_en_repl` usa siempre `self.interpretador`, que `parsear_y_ejecutar_codigo_repl` delega en `ejecutar_codigo`, y que en `ReplCommandV2` las funciones `_sincronizar_estado_hacia_delegate`, `_sincronizar_estado_desde_delegate` y `_reset_estado_delegate` mantienen el contrato de no reiniciar el runtime.

### Testing
- Ejecuté `pytest -q tests/unit/cli/commands_v2/test_repl_cmd_v2.py::test_repl_v2_regresion_sesion_interactiva_var_var_imprimir_sin_error_cse0 tests/unit/cli/commands_v2/test_repl_cmd_v2.py::test_repl_v2_reset_estado_delegate_no_reinicia_interpretador tests/unit/cli/commands_v2/test_repl_cmd_v2.py::test_repl_v2_ejecutar_modo_normal_delega_parseo_al_delegate` y las 3 pruebas pasaron exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee693449483278784b2c973639a10)