### PR TITLE
test: cubrir flujo REPL incremental var-var-imprimir

### DIFF
--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -253,6 +253,33 @@ def test_repl_statement_normal_imprimir_no_duplica_salida():
 
 
 @pytest.mark.integration
+def test_repl_incremental_var_var_imprimir_preserva_estado_y_sin_cse0() -> None:
+    repl = InteractiveCommand(InterpretadorCobra())
+    repl._seguro_repl = False
+    repl._extra_validators_repl = None
+    out_repl, err_repl = StringIO(), StringIO()
+
+    with redirect_stdout(out_repl), redirect_stderr(err_repl):
+        repl.ejecutar_codigo("var x = 5")
+        repl.ejecutar_codigo("var y = x * 2")
+        repl.ejecutar_codigo("imprimir(y)")
+
+    evidencia = "\n".join(
+        fragmento
+        for fragmento in (
+            out_repl.getvalue(),
+            err_repl.getvalue(),
+        )
+        if fragmento
+    )
+
+    assert err_repl.getvalue() == ""
+    assert "10" in out_repl.getvalue()
+    assert repl.interpretador.contextos[-1].get("y") == 10
+    assert "_cse0" not in evidencia
+
+
+@pytest.mark.integration
 def test_repl_mantiene_estado_tras_error_intermedio():
     interpretador_cls = resolver_interpretador_cls(
         module_name="pcobra.cobra.cli.services.run_service",


### PR DESCRIPTION
### Motivation
- Añadir una prueba mínima que verifique el flujo REPL interpretado incremental (modo normal, sin sandbox) para proteger contra regresiones de transformaciones internas como CSE.

### Description
- Se agregó `test_repl_incremental_var_var_imprimir_preserva_estado_y_sin_cse0` en `tests/integration/test_run_repl_equivalence.py`, que ejecuta secuencialmente `var x = 5`, `var y = x * 2` y `imprimir(y)` y aserta que no hay excepción, la salida contiene `10`, el contexto persiste con `y == 10` y que `_cse0` no aparece en la evidencia.

### Testing
- Se ejecutó `pytest -q tests/integration/test_run_repl_equivalence.py -k "incremental_var_var_imprimir_preserva_estado_y_sin_cse0"` y la prueba pasó (`1 passed`, 21 deselected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef0fbe27883279d8bdfebbb617b5e)