### PR TITLE
test: asegurar persistencia de estado en REPL interactive

### DIFF
--- a/tests/unit/test_interactive_cmd_repl_state_persistence.py
+++ b/tests/unit/test_interactive_cmd_repl_state_persistence.py
@@ -1,0 +1,68 @@
+from io import StringIO
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+import sys
+
+# Módulos opcionales simulados para evitar dependencias externas en pruebas unitarias.
+fake_rp = ModuleType("RestrictedPython")
+fake_rp.compile_restricted = lambda *a, **k: None
+fake_rp.safe_builtins = {}
+sys.modules.setdefault("RestrictedPython", fake_rp)
+
+_eval_mod = ModuleType("Eval")
+_eval_mod.default_guarded_getitem = lambda seq, key: seq[key]
+sys.modules.setdefault("RestrictedPython.Eval", _eval_mod)
+
+_guards_mod = ModuleType("Guards")
+_guards_mod.guarded_iter_unpack_sequence = lambda *a, **k: iter([])
+_guards_mod.guarded_unpack_sequence = lambda *a, **k: []
+sys.modules.setdefault("RestrictedPython.Guards", _guards_mod)
+
+_pc_mod = ModuleType("PrintCollector")
+_pc_mod.PrintCollector = list
+sys.modules.setdefault("RestrictedPython.PrintCollector", _pc_mod)
+
+_yaml_mod = ModuleType("yaml")
+_yaml_mod.safe_load = lambda *a, **k: {}
+sys.modules.setdefault("yaml", _yaml_mod)
+
+_tsl_mod = ModuleType("tree_sitter_languages")
+_tsl_mod.get_parser = lambda *a, **k: None
+sys.modules.setdefault("tree_sitter_languages", _tsl_mod)
+
+_jsonschema_mod = ModuleType("jsonschema")
+_jsonschema_mod.validate = lambda *a, **k: None
+_jsonschema_mod.ValidationError = Exception
+sys.modules.setdefault("jsonschema", _jsonschema_mod)
+
+from cobra.cli.commands.interactive_cmd import InteractiveCommand
+from core.interpreter import InterpretadorCobra
+
+
+def _args() -> SimpleNamespace:
+    return SimpleNamespace(
+        seguro=False,
+        extra_validators=None,
+        sandbox=False,
+        sandbox_docker=None,
+        ignore_memory_limit=True,
+        debug=False,
+    )
+
+
+def test_repl_normal_persiste_estado_entre_snippets_y_no_filtra_cse() -> None:
+    entradas = ["var x = 21", "var y = x * 2", "y", "salir"]
+
+    with patch("cobra.cli.commands.interactive_cmd.validar_dependencias"), \
+         patch("prompt_toolkit.PromptSession.prompt", side_effect=entradas), \
+         patch("cobra.cli.commands.interactive_cmd.InteractiveCommand.validar_entrada", return_value=True), \
+         patch("sys.stdout", new_callable=StringIO) as salida:
+        cmd = InteractiveCommand(InterpretadorCobra())
+        ret = cmd.run(_args())
+
+    assert ret == 0
+
+    evidencia = salida.getvalue()
+    assert "42" in evidencia
+    assert "Variable no declarada" not in evidencia
+    assert "_cse" not in evidencia


### PR DESCRIPTION
### Motivation
- Asegurar que el REPL normal mantiene la instancia del intérprete entre snippets para que las variables persistan y no aparezcan errores por referencias a temporales de optimización (`_cse`).
- Añadir una prueba de regresión que valide el comportamiento interactivo secuencial típico (declarar variable, usarla para calcular otra, evaluar resultado).

### Description
- Se añadió la prueba unitaria `tests/unit/test_interactive_cmd_repl_state_persistence.py` que simula el flujo REPL con entradas `var x = 21`, `var y = x * 2`, `y` y verifica que la salida contiene `42` y no contiene `Variable no declarada` ni `_cse`.
- Durante la verificación se inspeccionó `InteractiveCommand` y se confirmó que `self.interpretador` se inicializa en `__init__` y que `_run_repl_loop` en la rama normal invoca `self.ejecutar_codigo(codigo, validador)` reutilizando la misma instancia del intérprete; no se cambiaron otras rutas de código.

### Testing
- Ejecutado `pytest -q tests/unit/test_interactive_cmd_repl_state_persistence.py` y la prueba pasó correctamente (`1 passed`, se mostró 1 warning relacionado con import deprecado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef210a2d18832792c832f2862d9640)