### PR TITLE
fix(repl): desacoplar REPL normal del pipeline explícito de backend

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -35,8 +35,6 @@ from pcobra.cobra.core import Lexer, LexerError, TipoToken, UnclosedStringError
 from pcobra.cobra.core import ParserError
 from pcobra.cobra.cli.execution_pipeline import (
     construir_script_sandbox_canonico,
-    ejecutar_pipeline_explicito,
-    PipelineInput,
     prevalidar_y_parsear_codigo,
     resolver_interpretador_cls,
     validar_ast_seguro,
@@ -774,6 +772,7 @@ class InteractiveCommand(BaseCommand):
                 else:
                     # Contrato de dispatch: en la rama no-sandbox/no-docker se
                     # mantiene ejecución directa en REPL (sin pipeline explícito).
+                    # ruta normal = AST directo con entorno persistente
                     self.ejecutar_codigo(codigo, validador)
                 estado["buffer_lineas"].clear()
             except Exception as err:  # pragma: no cover - ruta unificada de errores
@@ -944,6 +943,11 @@ class InteractiveCommand(BaseCommand):
             module_name=__name__,
             default_cls=type(self.interpretador),
         )
+        from pcobra.cobra.cli.execution_pipeline import (
+            ejecutar_pipeline_explicito,
+            PipelineInput,
+        )
+
         # Contrato sandbox/setup: ``ejecutar_pipeline_explicito`` se usa aquí
         # únicamente para normalizar configuración de intérprete/opciones antes
         # de construir el script sandbox; no para ejecutar snippets normales.

--- a/tests/unit/test_interactive_cmd_repl_pipeline_coupling.py
+++ b/tests/unit/test_interactive_cmd_repl_pipeline_coupling.py
@@ -1,0 +1,63 @@
+"""Regresiones de acoplamiento para REPL interactivo.
+
+Nota changelog interno: se corrige la ejecución interactiva para que la ruta
+normal no dependa de temporales internos del backend.
+"""
+
+from types import ModuleType
+import sys
+
+# Dependencias opcionales simuladas para aislar estas pruebas unitarias.
+fake_rp = ModuleType("RestrictedPython")
+fake_rp.compile_restricted = lambda *a, **k: None
+fake_rp.safe_builtins = {}
+sys.modules.setdefault("RestrictedPython", fake_rp)
+
+_eval_mod = ModuleType("Eval")
+_eval_mod.default_guarded_getitem = lambda seq, key: seq[key]
+sys.modules.setdefault("RestrictedPython.Eval", _eval_mod)
+
+_guards_mod = ModuleType("Guards")
+_guards_mod.guarded_iter_unpack_sequence = lambda *a, **k: iter([])
+_guards_mod.guarded_unpack_sequence = lambda *a, **k: []
+sys.modules.setdefault("RestrictedPython.Guards", _guards_mod)
+
+_pc_mod = ModuleType("PrintCollector")
+_pc_mod.PrintCollector = list
+sys.modules.setdefault("RestrictedPython.PrintCollector", _pc_mod)
+
+from unittest.mock import patch
+
+from cobra.cli.commands.interactive_cmd import InteractiveCommand
+from core.interpreter import InterpretadorCobra
+
+
+def test_parsear_y_ejecutar_repl_normal_no_usa_pipeline_explicito() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+
+    with patch(
+        "pcobra.cobra.cli.execution_pipeline.ejecutar_pipeline_explicito",
+        side_effect=AssertionError("No debe usarse pipeline explícito en ruta normal"),
+    ):
+        cmd.parsear_y_ejecutar_codigo_repl("var x = 1")
+        cmd.parsear_y_ejecutar_codigo_repl("x")
+
+
+def test_repl_sandbox_setup_si_usa_pipeline_explicito() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+
+    setup_stub = ModuleType("setup")
+    setup_stub.interpretador = cmd.interpretador
+    setup_stub.safe_mode = False
+    setup_stub.validadores_extra = None
+
+    with patch(
+        "pcobra.cobra.cli.execution_pipeline.ejecutar_pipeline_explicito",
+        return_value=(setup_stub, None),
+    ) as pipeline_mock, patch(
+        "cobra.cli.commands.interactive_cmd.ejecutar_en_sandbox",
+        return_value="",
+    ):
+        cmd._ejecutar_en_sandbox("var x = 1")
+
+    pipeline_mock.assert_called_once()


### PR DESCRIPTION
### Motivation

- Evitar que la ruta normal del REPL dependa del pipeline explícito del backend para que la ejecución interactiva use directamente el AST sobre un intérprete persistente.
- Reducir acoplamiento que podía introducir temporales internos del backend en la evaluación incremental del REPL.

### Description

- Quité `ejecutar_pipeline_explicito` y `PipelineInput` de los imports de módulo y los importé de forma local dentro de `_ejecutar_en_sandbox` para limitar su uso solo a la ruta sandbox/setup.
- Añadí el comentario corto solicitado en el dispatch del loop REPL: `ruta normal = AST directo con entorno persistente` para documentar el contrato de la ruta normal.
- No modifiqué archivos de lexer, parser ni `BackendPipeline`/`execution_pipeline` salvo por la reubicación de import, manteniendo intacta la implementación de backend.
- Añadí pruebas unitarias en `tests/unit/test_interactive_cmd_repl_pipeline_coupling.py` que validan que la ruta normal (`parsear_y_ejecutar_codigo_repl`) no invoca el pipeline explícito y que la ruta sandbox/setup sí lo hace, incluyendo nota de changelog interno en el docstring de la prueba.

### Testing

- Ejecuté `pytest -q tests/unit/test_interactive_cmd_repl_pipeline_coupling.py` y la suite de pruebas nueva pasó con éxito (`2 passed`).
- Ejecuté `pytest -q tests/unit/test_repl_no_backend_pipeline_temporaries.py` para verificar regresiones existentes y pasó con éxito (`2 passed`).
- No se introdujeron fallos en pruebas relacionadas con REPL y sandbox durante la verificación automatizada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6079ff288327880f33e735f6417f)