### PR TITLE
docs(repl): reforzar contrato de dispatch incremental en REPL

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -425,8 +425,10 @@ class InteractiveCommand(BaseCommand):
         """
 
         prevalidar_fn(codigo)
-        # Contrato REPL (normal): este helper delega en ``ejecutar_codigo`` y,
-        # por diseño, no debe introducir pipeline explícito para snippets.
+        # Contrato de dispatch:
+        # REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.
+        # Este helper delega en ``ejecutar_codigo`` y, por diseño, no debe
+        # introducir pipeline explícito para snippets normales.
         if validador is None:
             self.ejecutar_codigo(codigo)
             return
@@ -770,9 +772,9 @@ class InteractiveCommand(BaseCommand):
                 elif sandbox_docker:
                     self._ejecutar_en_docker(codigo, sandbox_docker)
                 else:
-                    # Contrato de dispatch: en la rama no-sandbox/no-docker se
-                    # mantiene ejecución directa en REPL (sin pipeline explícito).
-                    # ruta normal = AST directo con entorno persistente
+                    # Contrato de dispatch:
+                    # REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.
+                    # Rama normal: AST directo con entorno persistente.
                     self.ejecutar_codigo(codigo, validador)
                 estado["buffer_lineas"].clear()
             except Exception as err:  # pragma: no cover - ruta unificada de errores


### PR DESCRIPTION
### Motivation
- Aclarar y reforzar por comentario el contrato de dispatch del REPL para dejar explícito que el camino normal usa el intérprete incremental y que el pipeline explícito sólo aplica a sandbox/setup, evitando ambigüedades que puedan inducir a usar ejecución por pipeline para snippets interactivos.

### Description
- Se añadieron comentarios de contrato en `InteractiveCommand.parsear_y_ejecutar_codigo_repl` y en el punto de dispatch dentro de `_run_repl_loop` con el texto: `REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.`

### Testing
- Se verificó la cadena de ejecución y la ausencia de rutas incorrectas con `rg -n "def _ejecutar_en_modo_normal|parsear_y_ejecutar_codigo_repl\(|def parsear_y_ejecutar_codigo_repl|def ejecutar_codigo|def _ejecutar_ast_en_repl|ejecutar_nodo\(|ejecutar_ast\("` y se comprobó la sintaxis compilando los módulos con `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py src/pcobra/cobra/cli/commands_v2/repl_cmd.py`, ambos comandos completaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef98761a3883278e299cb4a8b08d64)