### PR TITLE
Add REPL v2 regressions for persistent session state

### DIFF
--- a/tests/cli/test_repl_script_parity_contract.py
+++ b/tests/cli/test_repl_script_parity_contract.py
@@ -542,3 +542,36 @@ def test_repl_v2_fallback_expresion_sin_duplicar_y_nameerror_real() -> None:
     assert resultado["stderr"] == ""
     assert len(lineas_15) == 2
     assert "Variable no declarada: no_definida" in "\n".join(lineas)
+
+
+@pytest.mark.integration
+def test_repl_v2_regresion_var_21_y_expresion_usa_misma_sesion() -> None:
+    resultado = _ejecutar_repl_v2_con_entradas([
+        "var x = 21",
+        "x * 2",
+    ])
+
+    lineas = _lineas_stdout_repl_v2(resultado)
+    interpretador = resultado["interpretador"]
+
+    assert resultado["stderr"] == ""
+    assert lineas[-1] == "42"
+    assert _valor_en_contextos(interpretador, "x") == 21
+
+
+@pytest.mark.integration
+def test_repl_v2_regresion_bloque_si_muta_variable_y_persiste_fuera() -> None:
+    resultado = _ejecutar_repl_v2_con_entradas([
+        "var x = 21",
+        "si verdadero:",
+        "    x = x * 2",
+        "fin",
+        "x",
+    ])
+
+    lineas = _lineas_stdout_repl_v2(resultado)
+    interpretador = resultado["interpretador"]
+
+    assert resultado["stderr"] == ""
+    assert lineas[-1] == "42"
+    assert _valor_en_contextos(interpretador, "x") == 42


### PR DESCRIPTION
### Motivation
- Añadir pruebas de regresión que aseguren que el REPL v2 preserva el `Interpretador` y el estado entre entradas consecutivas, incluyendo casos con asignación simple y mutación dentro de un bloque `si ... fin`.

### Description
- Se añadieron dos pruebas de integración en `tests/cli/test_repl_script_parity_contract.py`: `test_repl_v2_regresion_var_21_y_expresion_usa_misma_sesion` y `test_repl_v2_regresion_bloque_si_muta_variable_y_persiste_fuera`, que ejecutan secuencias REPL y verifican salida y estado del `interpretador` persistente; no se modificó la lógica de producción.

### Testing
- Ejecutado `pytest -q tests/cli/test_repl_script_parity_contract.py -k "regresion_var_21 or regresion_bloque_si_muta"` y las pruebas relevantes pasaron con resultado `2 passed, 14 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa95c77388327ba1bb1d366dbb01e)