### PR TITLE
Add REPL echo and fallback regression tests

### DIFF
--- a/tests/unit/test_interactive_cmd_repl_state_persistence.py
+++ b/tests/unit/test_interactive_cmd_repl_state_persistence.py
@@ -2,6 +2,7 @@ from io import StringIO
 from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
 import sys
+import pytest
 
 # Módulos opcionales simulados para evitar dependencias externas en pruebas unitarias.
 fake_rp = ModuleType("RestrictedPython")
@@ -66,3 +67,79 @@ def test_repl_normal_persiste_estado_entre_snippets_y_no_filtra_cse() -> None:
     assert "42" in evidencia
     assert "Variable no declarada" not in evidencia
     assert "_cse" not in evidencia
+
+
+def test_repl_imprime_resultado_en_expresion_simple() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+
+    with patch("sys.stdout", new_callable=StringIO) as salida:
+        cmd.ejecutar_codigo("1 + 2")
+
+    assert salida.getvalue() == "3\n"
+
+
+def test_repl_asignacion_no_hace_echo_extra_y_lectura_posterior_si_imprime() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+
+    with patch("sys.stdout", new_callable=StringIO) as salida:
+        cmd.ejecutar_codigo("var a = 5")
+        cmd.ejecutar_codigo("a")
+
+    assert salida.getvalue() == "5\n"
+
+
+def test_repl_condicional_con_mutacion_estado_no_hace_echo_automatico() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+
+    with patch("sys.stdout", new_callable=StringIO) as salida:
+        cmd.ejecutar_codigo("var total = 0")
+        cmd.ejecutar_codigo("si verdadero:\n    total = 7\nfin")
+        cmd.ejecutar_codigo("total")
+
+    assert salida.getvalue() == "7\n"
+
+
+def test_fallback_imprimir_top_level_aplica_solo_en_expresiones() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+    llamadas: list[str] = []
+    error = ValueError(
+        "Nodo no soportado: <class 'pcobra.core.ast_nodes.NodoOperacionBinaria'>"
+    )
+
+    def _fake_ejecutar(codigo: str, validador=None):
+        del validador
+        llamadas.append(codigo)
+        if codigo == "1 + 2":
+            raise error
+        if codigo == "imprimir(1 + 2)":
+            return ([object()], None)
+        raise AssertionError(f"Código inesperado en fallback: {codigo}")
+
+    with patch.object(cmd, "_ejecutar_ast_en_repl", side_effect=_fake_ejecutar), patch.object(
+        cmd,
+        "_debe_intentar_fallback_expresion_top_level",
+        side_effect=lambda codigo, _err: codigo == "1 + 2",
+    ), patch.object(cmd, "_imprimir_resultado_repl"):
+        cmd.ejecutar_codigo("1 + 2")
+
+    assert llamadas == ["1 + 2", "imprimir(1 + 2)"]
+
+
+def test_fallback_no_modifica_statements_normales() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+    llamadas: list[str] = []
+
+    def _fake_ejecutar(codigo: str, validador=None):
+        del validador
+        llamadas.append(codigo)
+        raise ValueError("Nodo no soportado: <class 'pcobra.core.ast_nodes.NodoAsignacion'>")
+
+    with patch.object(cmd, "_ejecutar_ast_en_repl", side_effect=_fake_ejecutar), patch.object(
+        cmd,
+        "_debe_intentar_fallback_expresion_top_level",
+        return_value=False,
+    ), patch.object(cmd, "_imprimir_resultado_repl"):
+        with pytest.raises(ValueError):
+            cmd.ejecutar_codigo("var a = 5")
+
+    assert llamadas == ["var a = 5"]


### PR DESCRIPTION
### Motivation
- Asegurar que el REPL imprima resultados para expresiones, no duplique salida para `NodoAsignacion`/`NodoImprimir`, y que las estructuras de control no produzcan echo indebido.
- Verificar que el fallback top-level que envuelve en `imprimir(...)` solo se active para expresiones elegibles y no cambie la semántica de statements normales.

### Description
- Se añadieron pruebas en `tests/unit/test_interactive_cmd_repl_state_persistence.py` que cubren la impresión de una expresión simple (`1 + 2` => `3`).
- Se añadió una prueba que comprueba que `var a = 5` no hace echo adicional y que la lectura posterior (`a`) imprime `5`.
- Se añadió una prueba que valida que un bloque condicional que muta estado no hace echo automático y que el estado persiste (ej. `total` termina en `7`).
- Se añadieron pruebas que comprueban el comportamiento del fallback top-level para `imprimir(...)`, incluyendo que se invoque para expresiones elegibles y que no envuelva ni modifique statements normales.

### Testing
- Ejecuté `pytest -q tests/unit/test_interactive_cmd_repl_state_persistence.py` y los tests completaron correctamente.
- Resultado: `6 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f032c907a0832786a3b80a4d386274)