### PR TITLE
test: cubrir regresión CSE en sesión incremental del REPL

### DIFF
--- a/tests/unit/test_interactive_block_depth.py
+++ b/tests/unit/test_interactive_block_depth.py
@@ -138,3 +138,28 @@ def test_repl_no_imprime_resultados_intermedios_de_mientras() -> None:
         cmd.ejecutar_codigo(codigo)
 
     assert mock_stdout.getvalue() == ""
+
+
+def test_repl_no_filtra_temporales_cse_en_asignaciones_incrementales() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+
+    with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+        cmd.ejecutar_codigo("var x = 10")
+        cmd.ejecutar_codigo("var y = x * 2")
+        cmd.ejecutar_codigo("y")
+
+    assert "_cse0" not in mock_stdout.getvalue()
+    assert cmd.interpretador.contextos[-1].get("y") == 20
+
+
+def test_repl_reutiliza_entorno_tras_bloque_si_fin_en_sesion_incremental() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+    bloque = "\n".join(["si verdadero:", "    var y = x * 2", "fin"])
+
+    with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+        cmd.ejecutar_codigo("var x = 10")
+        cmd.ejecutar_codigo(bloque)
+        cmd.ejecutar_codigo("y")
+
+    assert "_cse0" not in mock_stdout.getvalue()
+    assert cmd.interpretador.contextos[-1].get("y") == 20


### PR DESCRIPTION
### Motivation
- Añadir una prueba que detecte la regresión donde temporales de CSE (`_cse0`) podían filtrarse en asignaciones incrementales del REPL y verificar que el entorno compartido persiste tras ejecución y bloques de control.

### Description
- Añadí dos tests en `tests/unit/test_interactive_block_depth.py`: `test_repl_no_filtra_temporales_cse_en_asignaciones_incrementales` y `test_repl_reutiliza_entorno_tras_bloque_si_fin_en_sesion_incremental`.
- Cada test simula una sesión incremental con las entradas `var x = 10`, `var y = x * 2` y `y`, y una variante que ejecuta `var x = 10` seguido de un bloque `si ... fin` que define `y`.
- Las aserciones comprueban que la salida no contiene `"_cse0"` y que `y` está presente en el entorno compartido con valor `20` mediante `cmd.interpretador.contextos[-1].get("y")`.
- Cambios limitados a pruebas unitarias, sin modificaciones a código de producción.

### Testing
- Ejecuté `pytest -q tests/unit/test_interactive_block_depth.py -k "cse_en_asignaciones_incrementales or reutiliza_entorno_tras_bloque_si_fin"` y obtuvo `2 passed`.
- No se reportaron fallos en las pruebas ejecutadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f041f00a38832785715c89e1ac10ff)