### PR TITLE
docs(repl): document canonical AST execution path

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -353,12 +353,17 @@ class InteractiveCommand(BaseCommand):
     def _ejecutar_ast_en_repl(
         self, codigo: str, validador: Optional[Any] = None
     ) -> tuple[list[Any], Any]:
-        """Flujo canónico del REPL: parsear AST, validar opcionalmente y ejecutar."""
+        """Flujo canónico del REPL incremental.
 
-        # Nota técnica REPL:
-        # ``_cse*`` son temporales internos generados por el pipeline de
-        # optimización (batch/sandbox). En REPL incremental NO deben aparecer:
-        # cada entrada debe ejecutarse nodo a nodo sobre el entorno persistente.
+        Contrato interno para snippets interactivos:
+        1) construir AST con ``prevalidar_y_parsear_codigo``;
+        2) iterar ``for nodo in ast``;
+        3) ejecutar cada nodo con ``self.interpretador.ejecutar_nodo(nodo)``.
+
+        Este camino evita explícitamente cualquier pipeline batch para conservar
+        semántica incremental (estado persistente del intérprete entre entradas).
+        """
+
         ast = prevalidar_y_parsear_codigo(codigo)
         if self._seguro_repl:
             validar_ast_seguro(


### PR DESCRIPTION
### Motivation
- Hacer explícito el contrato interno del camino REPL incremental para evitar usos accidentales del pipeline batch en snippets interactivos y reducir la posibilidad de regresiones de comportamiento.

### Description
- Se actualizó la documentación interna (docstring) de `_ejecutar_ast_en_repl` en `src/pcobra/cobra/cli/commands/interactive_cmd.py` para declarar claramente: construir el AST con `prevalidar_y_parsear_codigo`, iterar `for nodo in ast` y ejecutar cada nodo con `self.interpretador.ejecutar_nodo(nodo)`, sin cambiar la firma ni el comportamiento externo.

### Testing
- Se ejecutó `python -m compileall -q src/pcobra/cobra/cli/commands/interactive_cmd.py` y la comprobación de compilación fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f059d3f8808327bad896b9099f92ce)