### PR TITLE
test(repl-v2): cubrir sincronización y persistencia del intérprete

### DIFF
--- a/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
+++ b/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
@@ -227,6 +227,56 @@ def test_repl_v2_reset_estado_delegate_no_reinicia_interpretador():
     assert command._delegate.interpretador is interpretador_inicial
 
 
+def test_repl_v2_sincronizacion_hacia_y_desde_delegate_conserva_interpretador():
+    command = repl_module.ReplCommandV2()
+    interpretador_persistente = object()
+    command._interpretador_persistente = interpretador_persistente
+    command._seguro_repl = False
+    command._extra_validators_repl = ("v1",)
+
+    command._sincronizar_estado_hacia_delegate()
+
+    assert command._delegate.interpretador is interpretador_persistente
+    assert command._delegate._seguro_repl is False
+    assert command._delegate._extra_validators_repl == ("v1",)
+
+    nuevo_interpretador = object()
+    command._delegate.interpretador = nuevo_interpretador
+    command._delegate._seguro_repl = True
+    command._delegate._extra_validators_repl = ("v2",)
+
+    command._sincronizar_estado_desde_delegate()
+
+    assert command._interpretador_persistente is nuevo_interpretador
+    assert command._seguro_repl is True
+    assert command._extra_validators_repl == ("v2",)
+
+
+def test_repl_v2_ejecutar_modo_normal_reutiliza_interpretador_persistente(monkeypatch):
+    command = repl_module.ReplCommandV2()
+    interpretador_persistente = object()
+    command._interpretador_persistente = interpretador_persistente
+    observaciones: list[object] = []
+
+    def _fake_parsear_y_ejecutar(_codigo: str, prevalidar_fn):
+        assert prevalidar_fn is repl_module.prevalidar_y_parsear_codigo
+        observaciones.append(command._delegate.interpretador)
+        # Simula que el delegate mutó/retornó la misma referencia de runtime.
+        command._delegate.interpretador = command._delegate.interpretador
+
+    monkeypatch.setattr(
+        command._delegate,
+        "parsear_y_ejecutar_codigo_repl",
+        _fake_parsear_y_ejecutar,
+    )
+
+    command._ejecutar_en_modo_normal("imprimir(1)")
+    command._ejecutar_en_modo_normal("imprimir(2)")
+
+    assert observaciones == [interpretador_persistente, interpretador_persistente]
+    assert command._interpretador_persistente is interpretador_persistente
+
+
 def test_repl_v2_bloque_incompleto_no_ejecuta_ni_limpia_hasta_completar(monkeypatch):
     command = repl_module.ReplCommandV2()
     entradas = iter(["si verdadero:", "imprimir(1)", "fin", "exit"])


### PR DESCRIPTION
### Motivation
- Asegurar el contrato del REPL v2 para preservar el contexto de ejecución entre iteraciones y evitar reinstanciación accidental del runtime.
- Verificar que la sincronización de estado entre `ReplCommandV2` y su `delegate` mantiene el mismo `interpretador` y las flags/metadatos de REPL.
- Confirmar que el camino normal siempre delega en `parsear_y_ejecutar_codigo_repl` usando `prevalidar_y_parsear_codigo`.

### Description
- Añade la prueba `test_repl_v2_sincronizacion_hacia_y_desde_delegate_conserva_interpretador` que valida que `_sincronizar_estado_hacia_delegate` reinyecta `self._interpretador_persistente` y flags, y que `_sincronizar_estado_desde_delegate` copia de vuelta el `interpretador` y metadatos.
- Añade la prueba `test_repl_v2_ejecutar_modo_normal_reutiliza_interpretador_persistente` que verifica que `_ejecutar_en_modo_normal` delega en `parsear_y_ejecutar_codigo_repl` con `prevalidar_y_parsear_codigo` y reutiliza la misma instancia de `_interpretador_persistente` en llamadas consecutivas.
- Mantiene la prueba existente que garantiza que `_reset_estado_delegate` no reinicia el `interpretador`.
- Archivo modificado: `tests/unit/cli/commands_v2/test_repl_cmd_v2.py` (añadidas ~50 líneas de tests).

### Testing
- Ejecutado `pytest -q tests/unit/cli/commands_v2/test_repl_cmd_v2.py` y todos los tests pasaron: `11 passed`.
- No hubo fallos en las pruebas añadidas ni en las pruebas preexistentes al ejecutar el conjunto mencionado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05b8f57f4832793a9c27a538b37e4)