### PR TITLE
Refuerza contrato REPL incremental y acota pipeline explícito a sandbox

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -389,6 +389,7 @@ class InteractiveCommand(BaseCommand):
         """
 
         self.logger.debug("[RUN] Ejecutando snippet en REPL")
+        # REPL = intérprete incremental (estado acumulado en self.interpretador).
         # Contrato REPL (normal): no usar ``ejecutar_pipeline_explicito`` aquí.
         # Este camino ejecuta snippets interactivos normales sobre el intérprete
         # persistente para preservar la semántica incremental del lenguaje.
@@ -438,6 +439,8 @@ class InteractiveCommand(BaseCommand):
         # REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.
         # Este helper delega en ``ejecutar_codigo`` y, por diseño, no debe
         # introducir pipeline explícito para snippets normales.
+        # Invariante antirregresión: conservar este método como "thin wrapper"
+        # (prevalidar + delegar a ejecutar_codigo) sin rutas batch adicionales.
         if validador is None:
             self.ejecutar_codigo(codigo)
             return
@@ -959,6 +962,7 @@ class InteractiveCommand(BaseCommand):
             PipelineInput,
         )
 
+        # REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.
         # Contrato sandbox/setup: ``ejecutar_pipeline_explicito`` se usa aquí
         # únicamente para normalizar configuración de intérprete/opciones antes
         # de construir el script sandbox; no para ejecutar snippets normales.


### PR DESCRIPTION
### Motivation
- Asegurar que el camino REPL permanezca como evaluación incremental (`REPL = intérprete incremental`) y que `ejecutar_pipeline_explicito` quede restringido solo a la ruta de sandbox/setup para evitar regresiones semánticas.

### Description
- Añade comentarios de contrato técnico en `src/pcobra/cobra/cli/commands/interactive_cmd.py` cerca de `ejecutar_codigo`, `parsear_y_ejecutar_codigo_repl` y `_ejecutar_en_sandbox` para dejar explícito que `parsear_y_ejecutar_codigo_repl` es un wrapper delgado (prevalidar + delegar) y que el pipeline explícito solo se usa en sandbox/setup; no se cambió la lógica de ejecución.

### Testing
- Ejecuté una búsqueda con `rg` para verificar las referencias a `ejecutar_pipeline_explicito` y `REPL = intérprete incremental`, y compilé el módulo con `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py`, ambos pasos completaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f067c7daac8327950861c6323cc09d)