### PR TITLE
test(repl): cubrir regresiones incrementales var/si sin temporales CSE

### DIFF
--- a/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
+++ b/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
@@ -322,3 +322,50 @@ def test_repl_v2_regresion_sesion_interactiva_var_var_imprimir_sin_error_cse0(mo
     assert "Variable no declarada: _cse0" not in evidencia
     assert salida.err == ""
     assert salida.out.strip().endswith("10")
+
+
+def test_repl_v2_regresion_sesion_interactiva_var_var_evaluar_identificador_sin_temporales_cse(
+    monkeypatch, capsys
+):
+    command = repl_module.ReplCommandV2()
+    entradas = iter(["var x = 10", "var y = x * 2", "y", "exit"])
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+    monkeypatch.setattr(repl_module, "mostrar_info", lambda *_args, **_kwargs: None)
+
+    status = command.run(_args_repl())
+    salida = capsys.readouterr()
+    evidencia = f"{salida.out}\n{salida.err}"
+
+    assert status == 0
+    assert "Variable no declarada: _cse0" not in evidencia
+    assert "_cse" not in evidencia
+    assert salida.err == ""
+    assert salida.out.strip().endswith("20")
+
+
+def test_repl_v2_regresion_bloque_si_fin_comparte_entorno_sin_temporales_cse(monkeypatch, capsys):
+    command = repl_module.ReplCommandV2()
+    entradas = iter(
+        [
+            "var x = 10",
+            "si verdadero:",
+            "var y = x * 2",
+            "fin",
+            "y",
+            "exit",
+        ]
+    )
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+    monkeypatch.setattr(repl_module, "mostrar_info", lambda *_args, **_kwargs: None)
+
+    status = command.run(_args_repl())
+    salida = capsys.readouterr()
+    evidencia = f"{salida.out}\n{salida.err}"
+
+    assert status == 0
+    assert "Variable no declarada: _cse0" not in evidencia
+    assert "_cse" not in evidencia
+    assert salida.err == ""
+    assert salida.out.strip().endswith("20")


### PR DESCRIPTION
### Motivation
- Añadir pruebas que validen el comportamiento incremental del REPL (`ReplCommandV2`) frente a regresiones relacionadas con temporales generadas por CSE (_cse*). 
- Comprobar que variables definidas en envíos previos y dentro de bloques comparten entorno y no filtran identificadores temporales al usuario.

### Description
- Se extendió `tests/unit/cli/commands_v2/test_repl_cmd_v2.py` añadiendo dos tests nuevos que ejercitan el REPL incremental sin tocar lexer/parser/backend. 
- `test_repl_v2_regresion_sesion_interactiva_var_var_evaluar_identificador_sin_temporales_cse` envía `var x = 10`, `var y = x * 2` y evalúa `y`, verificando la salida `20` y ausencia de `_cse0` y `_cse*` en stdout/stderr. 
- `test_repl_v2_regresion_bloque_si_fin_comparte_entorno_sin_temporales_cse` define `x`, abre un bloque `si ... fin` donde se asigna `y = x * 2`, evalúa `y` fuera del bloque y verifica salida `20` y ausencia de temporales `_cse`. 
- No se modificaron componentes de compilación o ejecución; los cambios quedan confinados al archivo de pruebas `tests/unit/cli/commands_v2/test_repl_cmd_v2.py`.

### Testing
- Ejecuté `pytest -q tests/unit/cli/commands_v2/test_repl_cmd_v2.py` como prueba automatizada del cambio. 
- Resultado: todos los tests del archivo pasaron (`13 passed`) y apareció una advertencia deprecatoria relacionada con imports; no hay fallos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0712e71f083278c854d7528151eb7)