### PR TITLE
fix(repl): mantener instancia del intérprete durante toda la sesión interactiva

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -230,6 +230,7 @@ class InteractiveCommand(BaseCommand):
         self._debug_mode = False
         self._seguro_repl = True
         self._extra_validators_repl: Any = None
+        self._interpretador_sesion: Optional[InterpretadorCobra] = None
 
     @staticmethod
     def _crear_estado_repl() -> dict[str, Any]:
@@ -388,6 +389,7 @@ class InteractiveCommand(BaseCommand):
         """
 
         self.logger.debug("[RUN] Ejecutando snippet en REPL")
+        self._sincronizar_interpretador_sesion()
         # REPL = intérprete incremental (estado acumulado en self.interpretador).
         # Contrato REPL (normal): no usar ``ejecutar_pipeline_explicito`` aquí.
         # Este camino ejecuta snippets interactivos normales sobre el intérprete
@@ -434,6 +436,7 @@ class InteractiveCommand(BaseCommand):
         """
 
         _ = prevalidar_fn  # Compatibilidad con firmas históricas en pruebas.
+        self._sincronizar_interpretador_sesion()
         prevalidar_y_parsear_codigo(codigo)
         # Contrato de dispatch:
         # REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.
@@ -711,6 +714,7 @@ class InteractiveCommand(BaseCommand):
         estado = self._crear_estado_repl()
         estado["debug_enabled"] = self._debug_mode
         self._estado_repl = estado
+        self._interpretador_sesion = self.interpretador
         while True:
             try:
                 prompt = "... " if estado["buffer_lineas"] else ">>> "
@@ -793,6 +797,15 @@ class InteractiveCommand(BaseCommand):
                 estado["buffer_lineas"].clear()
                 categoria = self._clasificar_error_repl(err)
                 self._log_error(categoria, err)
+
+    def _sincronizar_interpretador_sesion(self) -> None:
+        """Garantiza que el REPL use la misma instancia de intérprete por sesión."""
+
+        if self._interpretador_sesion is None:
+            self._interpretador_sesion = self.interpretador
+            return
+        if self.interpretador is not self._interpretador_sesion:
+            self.interpretador = self._interpretador_sesion
 
     def _clasificar_error_repl(self, error: Exception) -> str:
         """Clasifica errores del REPL para un reporte único en el loop principal."""

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -112,6 +112,24 @@ def test_interactive_session_persistence():
     assert salida[-1] == '5'
 
 
+def test_interactive_session_persistence_reutiliza_misma_instancia_en_toda_la_sesion():
+    inputs = ['var x = 10', 'var y = x * 2', 'imprimir(y)', 'salir']
+    cmd = InteractiveCommand(InterpretadorCobra())
+    interpretador_sesion = cmd.interpretador
+
+    with patch('cobra.cli.commands.interactive_cmd.validar_dependencias'), \
+         patch('prompt_toolkit.PromptSession.prompt', side_effect=inputs), \
+         patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+        ret = cmd.run(_args())
+
+    salida = mock_stdout.getvalue()
+    assert ret == 0
+    assert cmd.interpretador is interpretador_sesion
+    assert cmd._interpretador_sesion is interpretador_sesion
+    assert '20' in salida
+    assert 'Variable no declarada: _cse0' not in salida
+
+
 def test_interactive_history_setup(tmp_path):
     cmd = InteractiveCommand(MagicMock())
     fake_path = tmp_path / '.cobra_history'
@@ -519,6 +537,19 @@ def test_ejecutar_ast_en_repl_ejecuta_nodo_a_nodo_y_no_batch_ejecutar_ast():
     assert ast == ast_dummy
     assert interp.nodos_ejecutados == ["n1", "n2"]
     assert resultado == 20
+
+
+def test_parsear_y_ejecutar_codigo_repl_restaurar_interpretador_de_sesion():
+    cmd = InteractiveCommand(MagicMock(name="interp_sesion"))
+    cmd._interpretador_sesion = cmd.interpretador
+    cmd.interpretador = MagicMock(name="interp_temporal")
+
+    with patch('cobra.cli.commands.interactive_cmd.prevalidar_y_parsear_codigo'), \
+         patch.object(cmd, 'ejecutar_codigo') as mock_ejecutar:
+        cmd.parsear_y_ejecutar_codigo_repl("imprimir(1)")
+
+    assert cmd.interpretador is cmd._interpretador_sesion
+    mock_ejecutar.assert_called_once_with("imprimir(1)")
 
 
 def test_ejecutar_en_sandbox_arma_script_con_captura_y_booleanos():


### PR DESCRIPTION
### Motivation
- Evitar que la instancia de `self.interpretador` cambie durante una sesión REPL y cause pérdida de estado o errores por variables temporales no declaradas (ej. `Variable no declarada: _cse0`).

### Description
- Añadido el atributo de sesión `self._interpretador_sesion: Optional[InterpretadorCobra]` en `InteractiveCommand.__init__` para anclar la instancia del intérprete por sesión en `src/pcobra/cobra/cli/commands/interactive_cmd.py`.
- Guardada la instancia de sesión al comenzar el loop interactivo con `self._interpretador_sesion = self.interpretador` en `_run_repl_loop`.
- Implementado `_sincronizar_interpretador_sesion()` que restaura `self.interpretador` a la instancia de sesión si hubo drift, y llamado desde `ejecutar_codigo` y `parsear_y_ejecutar_codigo_repl` para asegurar consistencia.
- Añadidas pruebas unitarias en `tests/unit/test_cli_interactive_cmd.py` que verifican la secuencia interactiva `var x = 10`, `var y = x * 2`, `imprimir(y)` produce `20`, que la instancia se mantiene durante la sesión y que no aparece `Variable no declarada: _cse0`, y una prueba que comprueba que `parsear_y_ejecutar_codigo_repl` restaura el intérprete de sesión si fue reemplazado.

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_interactive_cmd.py -k "session_persistence_reutiliza_misma_instancia or parsear_y_ejecutar_codigo_repl_restaurar_interpretador_de_sesion"` y las pruebas nuevas pasaron ✅.
- Ejecutado `pytest -q tests/unit/test_cli_interactive_cmd.py` y el archivo completo mostró fallos preexistentes no relacionados con este cambio (5 tests fallidos); las fallas están en `test_interactive_rechaza_fin_sin_bloque_abierto`, `test_interactive_rechaza_bloque_vacio`, `test_repl_basico_comparte_validacion_fin_sin_bloque`, `test_interactive_rechaza_exceso_lineas_blanco_consecutivas_en_bloque` y `test_ejecutar_codigo_imprime_booleano_verdadero` ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b66f29648327921ef7868be61975)