### PR TITLE
Refuerza contrato de ejecución entre REPL normal y sandbox

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -979,14 +979,15 @@ class InteractiveCommand(BaseCommand):
         # Contrato sandbox/setup: ``ejecutar_pipeline_explicito`` se usa aquí
         # únicamente para normalizar configuración de intérprete/opciones antes
         # de construir el script sandbox; no para ejecutar snippets normales.
+        setup_input = PipelineInput(
+            codigo="",
+            interpretador_cls=interpretador_cls,
+            safe_mode=self._seguro_repl,
+            extra_validators=self._extra_validators_repl,
+            interpretador=self.interpretador,
+        )
         setup, _ = ejecutar_pipeline_explicito(
-            PipelineInput(
-                codigo="",
-                interpretador_cls=interpretador_cls,
-                safe_mode=self._seguro_repl,
-                extra_validators=self._extra_validators_repl,
-                interpretador=self.interpretador,
-            ),
+            setup_input,
             analizar_codigo_fn=lambda _codigo: [],
         )
         self.interpretador = setup.interpretador

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -552,6 +552,26 @@ def test_parsear_y_ejecutar_codigo_repl_restaurar_interpretador_de_sesion():
     mock_ejecutar.assert_called_once_with("imprimir(1)")
 
 
+def test_parsear_y_ejecutar_codigo_repl_no_invoca_pipeline_explicito_en_ruta_normal():
+    cmd = InteractiveCommand(MagicMock())
+
+    with patch(
+        "cobra.cli.commands.interactive_cmd.prevalidar_y_parsear_codigo",
+        return_value=[],
+    ) as mock_prevalidar, patch.object(
+        cmd,
+        "ejecutar_codigo",
+    ) as mock_ejecutar, patch(
+        "pcobra.cobra.cli.execution_pipeline.ejecutar_pipeline_explicito",
+        side_effect=AssertionError("ruta normal no debe invocar pipeline explícito"),
+    ) as mock_pipeline:
+        cmd.parsear_y_ejecutar_codigo_repl("imprimir(1)")
+
+    mock_prevalidar.assert_called_once_with("imprimir(1)")
+    mock_ejecutar.assert_called_once_with("imprimir(1)")
+    assert mock_pipeline.call_count == 0
+
+
 def test_ejecutar_en_sandbox_arma_script_con_captura_y_booleanos():
     cmd = InteractiveCommand(MagicMock())
     cmd._seguro_repl = False
@@ -575,6 +595,52 @@ def test_ejecutar_en_sandbox_arma_script_con_captura_y_booleanos():
     assert "print('verdadero' if _resultado else 'falso')" in script_enviado
     assert 'print(_resultado)' in script_enviado
     mock_info.assert_called_once_with('ok')
+
+
+def test_ejecutar_en_sandbox_invoca_pipeline_explicito_solo_para_setup():
+    cmd = InteractiveCommand(MagicMock(name="interp_original"))
+    cmd._seguro_repl = False
+    cmd._extra_validators_repl = ["extra_repl.py"]
+    setup = SimpleNamespace(
+        interpretador=MagicMock(name="interp_setup"),
+        safe_mode=True,
+        validadores_extra=["normalizado.py"],
+    )
+
+    with patch(
+        "pcobra.cobra.cli.execution_pipeline.ejecutar_pipeline_explicito",
+        return_value=(setup, SimpleNamespace()),
+    ) as mock_pipeline, patch(
+        "cobra.cli.commands.interactive_cmd.prevalidar_y_parsear_codigo",
+        return_value=[],
+    ) as mock_prevalidar, patch(
+        "cobra.cli.commands.interactive_cmd.construir_script_sandbox_canonico",
+        return_value="SCRIPT",
+    ) as mock_script, patch(
+        "cobra.cli.commands.interactive_cmd.ejecutar_en_sandbox",
+        return_value=None,
+    ) as mock_sandbox:
+        cmd._ejecutar_en_sandbox("imprimir(7)")
+
+    pipeline_input = mock_pipeline.call_args.args[0]
+    assert pipeline_input.codigo == ""
+    assert pipeline_input.safe_mode is False
+    assert pipeline_input.extra_validators == ["extra_repl.py"]
+    assert pipeline_input.interpretador is not None
+    mock_prevalidar.assert_called_once_with("imprimir(7)")
+    mock_script.assert_called_once_with(
+        "imprimir(7)",
+        safe_mode=True,
+        extra_validators=["normalizado.py"],
+        imprimir_resultado=True,
+    )
+    mock_sandbox.assert_called_once_with(
+        "SCRIPT",
+        allow_insecure_fallback=False,
+    )
+    assert cmd.interpretador is setup.interpretador
+    assert cmd._seguro_repl is True
+    assert cmd._extra_validators_repl == ["normalizado.py"]
 
 
 def test_run_repl_loop_pasa_estado_repl_a_ejecucion_sandbox():


### PR DESCRIPTION
### Motivation

- Asegurar que `ejecutar_pipeline_explicito` se utilice únicamente para normalizar configuración (setup) en la ruta sandbox y no para ejecutar snippets interactivos del usuario en la ruta REPL normal. 
- Evitar regresiones futuras añadiendo pruebas que verifiquen explícitamente la separación de responsabilidades entre la ruta normal y la sandbox.

### Description

- En `InteractiveCommand._ejecutar_en_sandbox` se hace explícito el `PipelineInput` de setup creando la variable `setup_input` y pasándola a `ejecutar_pipeline_explicito` para dejar claro que `codigo==""` se usa solo para normalización; el resto del flujo sigue construyendo el script sandbox y llamando a `ejecutar_en_sandbox` con ese script (archivo modificado: `src/pcobra/cobra/cli/commands/interactive_cmd.py`).
- Se añadieron dos pruebas de no regresión en `tests/unit/test_cli_interactive_cmd.py`: `test_parsear_y_ejecutar_codigo_repl_no_invoca_pipeline_explicito_en_ruta_normal` que verifica que la ruta normal (`parsear_y_ejecutar_codigo_repl` → `ejecutar_codigo`) no invoca `ejecutar_pipeline_explicito`, y `test_ejecutar_en_sandbox_invoca_pipeline_explicito_solo_para_setup` que verifica que `_ejecutar_en_sandbox` invoca el pipeline solo para el `setup` y luego ejecuta el snippet vía script sandbox.

### Testing

- Se ejecutó inicialmente un conjunto amplio de tests con `pytest -q tests/unit/test_cli_interactive_cmd.py -k "sandbox or parsear_y_ejecutar or ejecutar_codigo"` que falló en tests preexistentes no relacionados con este cambio (5 fallos) antes de aislar las pruebas de regresión solicitadas. 
- Se ejecutó el conjunto focalizado para las pruebas añadidas con `pytest -q tests/unit/test_cli_interactive_cmd.py -k "no_invoca_pipeline_explicito_en_ruta_normal or invoca_pipeline_explicito_solo_para_setup"` y ambas pruebas pasaron (2 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e2ee64508327b71c7ff901bd9782)