### PR TITLE
test: reforzar casos REPL incremental contra temporales _cse

### DIFF
--- a/tests/unit/test_repl_no_backend_pipeline_temporaries.py
+++ b/tests/unit/test_repl_no_backend_pipeline_temporaries.py
@@ -1,4 +1,5 @@
 from io import StringIO
+import re
 from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
 import sys
@@ -65,7 +66,7 @@ def test_repl_incremental_var_var_evalua_resultado_sin_error_temporal_cse() -> N
     assert ret == 0
     assert "20" in evidencia
     assert "Variable no declarada: _cse0" not in evidencia
-    assert "Variable no declarada: _cse" not in evidencia
+    assert re.search(r"Variable no declarada:\s*_cse\d*", evidencia) is None
 
 
 def test_repl_incremental_con_bloque_si_comparte_entorno_sin_error_temporal_cse() -> None:
@@ -89,4 +90,5 @@ def test_repl_incremental_con_bloque_si_comparte_entorno_sin_error_temporal_cse(
 
     assert ret == 0
     assert "20" in evidencia
-    assert "Variable no declarada: _cse" not in evidencia
+    assert "Variable no declarada: _cse0" not in evidencia
+    assert re.search(r"Variable no declarada:\s*_cse\d*", evidencia) is None


### PR DESCRIPTION
### Motivation
- Evitar regresiones donde el REPL incremental exponga errores de temporales internos como `Variable no declarada: _cse*` durante evaluaciones interactivas y en bloques.

### Description
- Se actualiza `tests/unit/test_repl_no_backend_pipeline_temporaries.py` para usar `import re` y reemplazar la comprobación literal por una búsqueda con `re.search(r"Variable no declarada:\s*_cse\d*")` que detecta cualquier variante `_cseN`.
- No se modifica lexer, parser ni backend; solo se fortalecen las aserciones de las pruebas para validar el comportamiento incremental del REPL.

### Testing
- Se ejecutó `pytest -q tests/unit/test_repl_no_backend_pipeline_temporaries.py` y los tests pasaron (`2 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f85d69608327b7173f415242ffd0)