### PR TITLE
test: cubrir REPL incremental sin fugas _cse en NameError

### DIFF
--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -1,6 +1,7 @@
 from argparse import Namespace
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
+import re
 
 import pytest
 from unittest.mock import patch
@@ -253,30 +254,34 @@ def test_repl_statement_normal_imprimir_no_duplica_salida():
 
 
 @pytest.mark.integration
-def test_repl_incremental_var_var_imprimir_preserva_estado_y_sin_cse0() -> None:
+def test_repl_incremental_var_var_imprimir_y_nameerror_sin_temporales_internas() -> None:
     repl = InteractiveCommand(InterpretadorCobra())
     repl._seguro_repl = False
     repl._extra_validators_repl = None
     out_repl, err_repl = StringIO(), StringIO()
 
     with redirect_stdout(out_repl), redirect_stderr(err_repl):
-        repl.ejecutar_codigo("var x = 5")
+        repl.ejecutar_codigo("var x = 10")
         repl.ejecutar_codigo("var y = x * 2")
         repl.ejecutar_codigo("imprimir(y)")
+        with pytest.raises(NameError) as exc_info:
+            repl.ejecutar_codigo("no_definida + 1")
 
     evidencia = "\n".join(
         fragmento
         for fragmento in (
             out_repl.getvalue(),
             err_repl.getvalue(),
+            str(exc_info.value),
         )
         if fragmento
     )
 
     assert err_repl.getvalue() == ""
-    assert "10" in out_repl.getvalue()
-    assert repl.interpretador.contextos[-1].get("y") == 10
-    assert "_cse0" not in evidencia
+    assert "20" in out_repl.getvalue()
+    assert repl.interpretador.contextos[-1].get("y") == 20
+    assert str(exc_info.value) == "Variable no declarada: no_definida"
+    assert not re.search(r"_cse\d+", evidencia)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Motivation
- Asegurar que la evaluación incremental del REPL preserve el estado entre entradas y que los errores de resolución de nombres no expongan variables temporales internas como `_cse0`, `_cse1`, etc.

### Description
- Renombré y actualicé el test a `test_repl_incremental_var_var_imprimir_y_nameerror_sin_temporales_internas` y lo adapté para usar la secuencia mínima `var x = 10`, `var y = x * 2`, `imprimir(y)`.
- Añadí una comprobación que ejecuta `no_definida + 1` y exige que se lance un `NameError` con el mensaje exacto `Variable no declarada: no_definida`.
- Importé `re` y añadí una aserción que verifica que no aparezcan patrones `r"_cse\d+"` en la evidencia agregada (salida estándar, errores y texto de la excepción).
- Reforcé las aserciones de estado persistente para asegurar que `y == 20` en el contexto del intérprete y que `stderr` esté vacío.

### Testing
- Ejecuté `pytest -q tests/integration/test_run_repl_equivalence.py -k incremental_var_var_imprimir_y_nameerror_sin_temporales_internas` y el test pasó correctamente (`1 passed, 21 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f99e7c588327a1529e00e4d9f000)