### PR TITLE
Refuerza flujo REPL incremental en interactive_cmd

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -356,16 +356,14 @@ class InteractiveCommand(BaseCommand):
     ) -> tuple[list[Any], Any]:
         """Flujo canónico del REPL incremental.
 
-        Contrato interno para snippets interactivos:
-        1) construir AST con ``prevalidar_y_parsear_codigo``;
-        2) iterar ``for nodo in ast``;
-        3) ejecutar cada nodo con ``self.interpretador.ejecutar_nodo(nodo)``.
-
-        Este camino evita explícitamente cualquier pipeline batch para conservar
-        semántica incremental (estado persistente del intérprete entre entradas).
+        Contrato: REPL incremental = intérprete; no batch pipeline.
+        Patrón explícito del flujo normal:
+        1) ``ast = prevalidar_y_parsear_codigo(codigo)``;
+        2) ``for nodo in ast: self.interpretador.ejecutar_nodo(nodo)``.
         """
 
         ast = prevalidar_y_parsear_codigo(codigo)
+        # Contrato: REPL incremental = intérprete; no batch pipeline.
         if self._seguro_repl:
             validar_ast_seguro(
                 ast,
@@ -383,9 +381,9 @@ class InteractiveCommand(BaseCommand):
     def ejecutar_codigo(self, codigo: str, validador: Optional[Any] = None) -> None:
         """Ejecuta un snippet en modo REPL incremental.
 
-        Este método mantiene la semántica de intérprete interactivo: cada
-        entrada se evalúa sobre ``self.interpretador`` (estado acumulado), no
-        como una compilación por lotes/batch aislada.
+        Contrato: REPL incremental = intérprete; no batch pipeline.
+        Cada entrada se evalúa sobre ``self.interpretador`` (estado acumulado),
+        no como una compilación por lotes/batch aislada.
         """
 
         self.logger.debug("[RUN] Ejecutando snippet en REPL")
@@ -422,31 +420,22 @@ class InteractiveCommand(BaseCommand):
         *,
         prevalidar_fn: Any = prevalidar_y_parsear_codigo,
     ) -> None:
-        """Valida sintaxis y ejecuta código REPL en el camino normal.
+        """Valida sintaxis y delega la ejecución REPL al intérprete.
 
-        Este helper concentra el camino canónico parseo+ejecución para
-        implementaciones de REPL que delegan en ``InteractiveCommand``.
-        La ejecución reutiliza ``ejecutar_codigo``, incluyendo su fallback
-        para expresiones top-level.
-
-        Nota técnica:
-        REPL implica evaluación incremental sobre un intérprete persistente
-        (``self.interpretador``). No es una compilación/lote "batch" por
-        entrada; cada snippet se evalúa con el contexto acumulado.
+        Contrato: REPL incremental = intérprete; no batch pipeline.
+        Este helper del flujo normal solo debe hacer:
+        1) prevalidación/parseo;
+        2) delegación a ``ejecutar_codigo``.
         """
 
-        _ = prevalidar_fn  # Compatibilidad con firmas históricas en pruebas.
         self._sincronizar_interpretador_sesion()
-        prevalidar_y_parsear_codigo(codigo)
+        prevalidar_fn(codigo)
         # Contrato de dispatch:
         # REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.
         # Este helper delega en ``ejecutar_codigo`` y, por diseño, no debe
         # introducir pipeline explícito para snippets normales.
         # Invariante antirregresión: conservar este método como "thin wrapper"
         # (prevalidar + delegar a ejecutar_codigo) sin rutas batch adicionales.
-        if validador is None:
-            self.ejecutar_codigo(codigo)
-            return
         self.ejecutar_codigo(codigo, validador)
 
     def _debe_intentar_fallback_expresion_top_level(


### PR DESCRIPTION
### Motivation
- Garantizar que el flujo normal del REPL use exclusivamente el intérprete incremental y no invoque pipelines batch por error. 
- Hacer explícito y documentado el patrón parseo→ejecución incremental para reducir riesgo de regresiones. 
- Simplificar el helper de parseo/ejecución para que sea un wrapper mínimo: prevalidación/parseo y delegación a la ejecución sobre `self.interpretador`.

### Description
- En `_ejecutar_ast_en_repl` se añadió un docstring de contrato y se dejó explícito el patrón `ast = prevalidar_y_parsear_codigo(codigo)` seguido de `for nodo in ast: self.interpretador.ejecutar_nodo(nodo)` y validación segura opcional con `validar_ast_seguro`.
- En `ejecutar_codigo` se reforzó el comentario/contrato indicando “REPL incremental = intérprete; no batch pipeline” y se confirmó la delegación normal hacia `_ejecutar_ast_en_repl` para la evaluación incremental.
- `parsear_y_ejecutar_codigo_repl` fue simplificado para que solo haga sincronización de sesión, invoque `prevalidar_fn(codigo)` y delegue a `ejecutar_codigo`, eliminando ramas adicionales que pudieran introducir ejecución batch.
- Se preservaron las rutas y código que usan pipeline explícito para sandbox/setup sin modificarlas, y no se añadieron nuevas dependencias de pipeline al flujo normal del REPL.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py` y la verificación de compilación de sintaxis fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18f2f9f1c8327b5ea1121432b6697)