### PR TITLE
Asegura referencia única de interpretador en REPL v2

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -90,8 +90,8 @@ class ReplCommandV2(BaseCommand):
 
     def _sincronizar_estado_hacia_delegate(self) -> None:
         """Sincroniza estado persistente local hacia el comando delegado."""
-        # En modo normal siempre se reinyecta la misma referencia persistente
-        # para evitar re-instanciación accidental entre snippets.
+        # En modo normal siempre se reinyecta la MISMA referencia persistente
+        # para evitar re-instanciación accidental entre snippets del REPL.
         if self._interpretador_persistente is not None:
             self._delegate.interpretador = self._interpretador_persistente
         self._delegate._seguro_repl = self._seguro_repl
@@ -99,8 +99,12 @@ class ReplCommandV2(BaseCommand):
 
     def _sincronizar_estado_desde_delegate(self) -> None:
         """Sincroniza estado del comando delegado hacia el estado local."""
-        if self._delegate.interpretador is not None:
+        # El delegado no debe introducir una referencia nueva de interpretador:
+        # si ocurre por error, se restaura la referencia persistente actual.
+        if self._interpretador_persistente is None:
             self._interpretador_persistente = self._delegate.interpretador
+        elif self._delegate.interpretador is not self._interpretador_persistente:
+            self._delegate.interpretador = self._interpretador_persistente
         self._seguro_repl = self._delegate._seguro_repl
         self._extra_validators_repl = self._delegate._extra_validators_repl
 
@@ -126,7 +130,11 @@ class ReplCommandV2(BaseCommand):
         self._delegate._log_error(categoria, err)
 
     def _reset_buffer_local(self, buffer: list[str]) -> None:
-        """Limpia el buffer de entrada local del REPL v2."""
+        """Limpia el buffer de entrada local del REPL v2.
+
+        Importante: limpiar buffer solo descarta texto pendiente de entrada,
+        no reinicia el entorno de variables del interpretador persistente.
+        """
         buffer.clear()
 
     def _reset_estado_delegate(self) -> None:


### PR DESCRIPTION
### Motivation
- Garantizar que exista una única instancia de `interpretador` persistente durante toda la sesión REPL para preservar el contexto de variables.
- Evitar que el comando delegado reemplace accidentalmente la referencia de `interpretador` y romper el entorno compartido entre snippets.

### Description
- Refuerza la sincronización en `ReplCommandV2` haciendo que `_sincronizar_estado_hacia_delegate` siempre reinyecte la misma referencia persistente a `self._delegate.interpretador` antes de ejecutar código en el delegado. 
- Cambia `_sincronizar_estado_desde_delegate` para que, si no existe una instancia persistente, la adopte del delegado, y si el delegado contiene una referencia distinta, se restaure la instancia persistente en el delegado para evitar sustituirla. 
- Añade documentación en la docstring de `_reset_buffer_local` dejando claro que limpiar el buffer no reinicia el entorno de variables del `interpretador` persistente. 
- Mantiene `_reset_estado_delegate` limitado a recrear los metadatos de estado/buffer del REPL sin tocar el `interpretador`.

### Testing
- Se compiló el archivo modificado con `python -m py_compile src/pcobra/cobra/cli/commands_v2/repl_cmd.py` y la verificación automatizada finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ba6230308327b6152e59dfcbd0f3)