### PR TITLE
fix(repl): evaluar AST parseado sin artefactos batch

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -360,6 +360,12 @@ class InteractiveCommand(BaseCommand):
         Patrón explícito del flujo normal:
         1) ``ast = prevalidar_y_parsear_codigo(codigo)``;
         2) ``for nodo in ast: self.interpretador.ejecutar_nodo(nodo)``.
+
+        Nota de mantenimiento:
+        Los nombres temporales ``_cse*`` pertenecen a optimizaciones internas
+        de pipelines batch/backend y no deben filtrarse al flujo normal del REPL.
+        Aquí se evalúan nodos AST ya parseados directamente sobre el entorno
+        actual del intérprete de sesión.
         """
 
         ast = prevalidar_y_parsear_codigo(codigo)
@@ -374,8 +380,9 @@ class InteractiveCommand(BaseCommand):
             if validador:
                 nodo.aceptar(validador)
             resultado_nodo = self.interpretador.ejecutar_nodo(nodo)
-            if resultado is None and resultado_nodo is not None:
-                resultado = resultado_nodo
+            # El resultado observable del REPL debe ser el valor realmente
+            # evaluado por el último nodo ejecutado en el entorno actual.
+            resultado = resultado_nodo
         return ast, resultado
 
     def ejecutar_codigo(self, codigo: str, validador: Optional[Any] = None) -> None:


### PR DESCRIPTION
### Motivation

- Asegurar que el REPL evalúe nodos AST ya parseados directamente en el intérprete de sesión y no pase por transformaciones de backend/pipeline batch.
- Garantizar que las asignaciones y expresiones (`var y = x * 2` u otros) se resuelvan usando `ejecutar_nodo` en el entorno actual para preservar la semántica incremental.
- Evitar que artefactos intermedios de reescritura (ej. nombres temporales `_cse*`) influyan en el valor mostrado en REPL.

### Description

- Añadí una nota de mantenimiento en el docstring de `def _ejecutar_ast_en_repl` indicando que los nombres `_cse*` son internos de pipelines batch/backend y no deben aparecer en REPL normal.
- Cambié la lógica de cálculo de `resultado` en `_ejecutar_ast_en_repl` para que siempre refleje el valor retornado por el *último* nodo ejecutado (antes se usaba el primer valor no-`None`).
- Confirmé que cada `nodo` sigue siendo validado con `nodo.aceptar(validador)` (cuando aplica) y que la ejecución se realiza con `self.interpretador.ejecutar_nodo(nodo)` en el entorno de sesión.

### Testing

- Ejecuté `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py` y la compilación de bytecode de Python fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1bd07ea908327b36ef2420c5880c1)