### PR TITLE
Add REPL incremental coupling regression coverage

### DIFF
--- a/tests/unit/test_interactive_cmd_repl_pipeline_coupling.py
+++ b/tests/unit/test_interactive_cmd_repl_pipeline_coupling.py
@@ -27,9 +27,22 @@ _pc_mod.PrintCollector = list
 sys.modules.setdefault("RestrictedPython.PrintCollector", _pc_mod)
 
 from unittest.mock import patch
+from io import StringIO
+from types import SimpleNamespace
 
 from cobra.cli.commands.interactive_cmd import InteractiveCommand
 from core.interpreter import InterpretadorCobra
+
+
+def _args() -> SimpleNamespace:
+    return SimpleNamespace(
+        seguro=False,
+        extra_validators=None,
+        sandbox=False,
+        sandbox_docker=None,
+        ignore_memory_limit=True,
+        debug=False,
+    )
 
 
 def test_parsear_y_ejecutar_repl_normal_no_usa_pipeline_explicito() -> None:
@@ -61,3 +74,23 @@ def test_repl_sandbox_setup_si_usa_pipeline_explicito() -> None:
         cmd._ejecutar_en_sandbox("var x = 1")
 
     pipeline_mock.assert_called_once()
+
+
+def test_run_repl_normal_incremental_no_invoca_pipeline_batch_y_comparte_entorno() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+    entradas = ["var x = 10", "var y = x * 2", "si verdadero:", "var z = y", "fin", "z", "salir"]
+
+    with patch("cobra.cli.commands.interactive_cmd.validar_dependencias"), patch(
+        "prompt_toolkit.PromptSession.prompt", side_effect=entradas
+    ), patch(
+        "cobra.cli.commands.interactive_cmd.InteractiveCommand.validar_entrada", return_value=True
+    ), patch(
+        "pcobra.cobra.cli.execution_pipeline.ejecutar_pipeline_explicito",
+        side_effect=AssertionError("No debe usarse pipeline explícito en flujo REPL normal"),
+    ), patch("sys.stdout", new_callable=StringIO) as salida:
+        ret = cmd.run(_args())
+
+    evidencia = salida.getvalue()
+    assert ret == 0
+    assert "20" in evidencia
+    assert "Variable no declarada: _cse0" not in evidencia


### PR DESCRIPTION
### Motivation

- Asegurar que la ejecución interactiva REPL mantiene un entorno compartido entre declaraciones y bloques y que no depende de temporales internos del backend.
- Evitar regresiones donde aparezca el error `Variable no declarada: _cse0` al ejecutar secuencias incrementales en la misma sesión.

### Description

- Añadido helper `_args()` en `tests/unit/test_interactive_cmd_repl_pipeline_coupling.py` para poder invocar `InteractiveCommand.run()` en pruebas de sesión REPL completa.
- Agregado test `test_run_repl_normal_incremental_no_invoca_pipeline_batch_y_comparte_entorno` que ejecuta en la misma sesión la secuencia `var x = 10`, `var y = x * 2`, un bloque `si ... fin` que usa `y` y consulta de `z`, y valida el comportamiento esperado.
- El nuevo test comprueba que la salida contiene `20`, que no aparece `Variable no declarada: _cse0`, y que la ruta normal del REPL no invoca `ejecutar_pipeline_explicito` (se fuerza un `AssertionError` si se llama).
- No se modificó lógica de producción; solo se agregaron pruebas para cubrir el contrato de acoplamiento del REPL.

### Testing

- Ejecutado `pytest -q tests/unit/test_repl_no_backend_pipeline_temporaries.py tests/unit/test_interactive_cmd_repl_pipeline_coupling.py` y todos los tests pasaron (5 passed) con 1 warning.
- El test nuevo se ejecutó y pasó exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c79756888327af7ee025be2c1097)