### PR TITLE
Refuerza flujo incremental canónico del REPL

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -352,7 +352,7 @@ class InteractiveCommand(BaseCommand):
         return ast
 
     def _ejecutar_ast_en_repl(
-        self, codigo: str, validador: Optional[Any] = None
+        self, ast: list[Any], validador: Optional[Any] = None
     ) -> tuple[list[Any], Any]:
         """Flujo canónico del REPL incremental.
 
@@ -368,7 +368,6 @@ class InteractiveCommand(BaseCommand):
         actual del intérprete de sesión.
         """
 
-        ast = prevalidar_y_parsear_codigo(codigo)
         # Contrato: REPL incremental = intérprete; no batch pipeline.
         if self._seguro_repl:
             validar_ast_seguro(
@@ -385,7 +384,13 @@ class InteractiveCommand(BaseCommand):
             resultado = resultado_nodo
         return ast, resultado
 
-    def ejecutar_codigo(self, codigo: str, validador: Optional[Any] = None) -> None:
+    def ejecutar_codigo(
+        self,
+        codigo: str,
+        validador: Optional[Any] = None,
+        *,
+        ast_preparseado: Optional[list[Any]] = None,
+    ) -> None:
         """Ejecuta un snippet en modo REPL incremental.
 
         Contrato: REPL incremental = intérprete; no batch pipeline.
@@ -400,7 +405,8 @@ class InteractiveCommand(BaseCommand):
         # Este camino ejecuta snippets interactivos normales sobre el intérprete
         # persistente para preservar la semántica incremental del lenguaje.
         try:
-            ast, resultado = self._ejecutar_ast_en_repl(codigo, validador)
+            ast = ast_preparseado if ast_preparseado is not None else prevalidar_y_parsear_codigo(codigo)
+            ast, resultado = self._ejecutar_ast_en_repl(ast, validador)
         except Exception as err_original:
             if not self._debe_intentar_fallback_expresion_top_level(
                 codigo, err_original
@@ -409,7 +415,8 @@ class InteractiveCommand(BaseCommand):
 
             codigo_fallback = f"imprimir({codigo.strip()})"
             try:
-                ast, resultado = self._ejecutar_ast_en_repl(codigo_fallback, validador)
+                ast_fallback = prevalidar_y_parsear_codigo(codigo_fallback)
+                ast, resultado = self._ejecutar_ast_en_repl(ast_fallback, validador)
             except Exception as err_fallback:
                 if self._debe_intentar_fallback_expresion_top_level(
                     codigo, err_fallback
@@ -436,14 +443,14 @@ class InteractiveCommand(BaseCommand):
         """
 
         self._sincronizar_interpretador_sesion()
-        prevalidar_fn(codigo)
+        ast = prevalidar_fn(codigo)
         # Contrato de dispatch:
         # REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.
         # Este helper delega en ``ejecutar_codigo`` y, por diseño, no debe
         # introducir pipeline explícito para snippets normales.
         # Invariante antirregresión: conservar este método como "thin wrapper"
         # (prevalidar + delegar a ejecutar_codigo) sin rutas batch adicionales.
-        self.ejecutar_codigo(codigo, validador)
+        self.ejecutar_codigo(codigo, validador, ast_preparseado=ast)
 
     def _debe_intentar_fallback_expresion_top_level(
         self, codigo: str, err_original: Exception
@@ -787,7 +794,7 @@ class InteractiveCommand(BaseCommand):
                     # Contrato de dispatch:
                     # REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.
                     # Rama normal: AST directo con entorno persistente.
-                    self.ejecutar_codigo(codigo, validador)
+                    self.ejecutar_codigo(codigo, validador, ast_preparseado=ast)
                 estado["buffer_lineas"].clear()
             except Exception as err:  # pragma: no cover - ruta unificada de errores
                 estado["buffer_lineas"].clear()


### PR DESCRIPTION
### Motivation
- Garantizar que el camino normal del REPL sea estrictamente incremental: parseo/prevalidación seguido de ejecución nodo a nodo en el intérprete, evitando rutas batch/pipeline explícitas en ese flujo.

### Description
- `_ejecutar_ast_en_repl` ahora acepta un `AST` ya parseado y únicamente valida seguridad y ejecuta cada nodo con `self.interpretador.ejecutar_nodo(nodo)` sin invocar pipelines batch.
- `ejecutar_codigo` fue extendido con el parámetro opcional `ast_preparseado` para reutilizar el AST preparseado cuando exista y así evitar parseo redundante en el camino normal.
- `parsear_y_ejecutar_codigo_repl` ahora realiza la prevalidación/parseo y delega a `ejecutar_codigo` pasando el `AST` preparseado, manteniendo el comportamiento de "thin wrapper" (prevalidar + delegar).
- Se verificó que la delegación desde `ReplCommandV2._ejecutar_en_modo_normal` permanece intacta y que no se modificó el lexer/parser/backend.

### Testing
- Se compiló el archivo modificado con `python -m compileall src/pcobra/cobra/cli/commands/interactive_cmd.py` y la compilación finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d8b122c48327b77c88cea3fb18f5)