### PR TITLE
Ajusta validaciones de REPL v2 para runtime persistente

### DIFF
--- a/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
+++ b/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
@@ -240,14 +240,14 @@ def test_repl_v2_sincronizacion_hacia_y_desde_delegate_conserva_interpretador():
     assert command._delegate._seguro_repl is False
     assert command._delegate._extra_validators_repl == ("v1",)
 
-    nuevo_interpretador = object()
-    command._delegate.interpretador = nuevo_interpretador
+    command._delegate.interpretador = object()
     command._delegate._seguro_repl = True
     command._delegate._extra_validators_repl = ("v2",)
 
     command._sincronizar_estado_desde_delegate()
 
-    assert command._interpretador_persistente is nuevo_interpretador
+    assert command._interpretador_persistente is interpretador_persistente
+    assert command._delegate.interpretador is interpretador_persistente
     assert command._seguro_repl is True
     assert command._extra_validators_repl == ("v2",)
 
@@ -274,6 +274,32 @@ def test_repl_v2_ejecutar_modo_normal_reutiliza_interpretador_persistente(monkey
     command._ejecutar_en_modo_normal("imprimir(2)")
 
     assert observaciones == [interpretador_persistente, interpretador_persistente]
+    assert command._interpretador_persistente is interpretador_persistente
+
+
+def test_repl_v2_bloque_multilinea_y_sentencias_subsiguientes_comparten_runtime(monkeypatch):
+    command = repl_module.ReplCommandV2()
+    interpretador_persistente = object()
+    command._interpretador_persistente = interpretador_persistente
+    observaciones: list[tuple[str, object]] = []
+
+    def _fake_parsear_y_ejecutar(codigo: str, prevalidar_fn):
+        assert prevalidar_fn is repl_module.prevalidar_y_parsear_codigo
+        observaciones.append((codigo, command._delegate.interpretador))
+
+    monkeypatch.setattr(
+        command._delegate,
+        "parsear_y_ejecutar_codigo_repl",
+        _fake_parsear_y_ejecutar,
+    )
+
+    command._ejecutar_en_modo_normal("si verdadero:\nimprimir(1)\nfin")
+    command._ejecutar_en_modo_normal("imprimir(2)")
+
+    assert observaciones == [
+        ("si verdadero:\nimprimir(1)\nfin", interpretador_persistente),
+        ("imprimir(2)", interpretador_persistente),
+    ]
     assert command._interpretador_persistente is interpretador_persistente
 
 


### PR DESCRIPTION
### Motivation
- Asegurar que el REPL V2 preserve la referencia del runtime persistente (`_interpretador_persistente`) durante el flujo normal y que las operaciones de reset no reinicien las variables del runtime.
- Verificar que bloques multilínea (`si ... fin`) se ejecuten en el mismo entorno acumulado que sentencias posteriores.

### Description
- Actualiza la prueba de sincronización para validar que `_sincronizar_estado_desde_delegate` no reemplace la referencia de `_interpretador_persistente` y que el `delegate.interpretador` se restaure a la referencia persistente cuando sea necesario.
- Añade la prueba `test_repl_v2_bloque_multilinea_y_sentencias_subsiguientes_comparten_runtime` que ejecuta un bloque `si ... fin` seguido de otra sentencia y verifica que ambos se ejecutan sobre la misma referencia de runtime persistente.
- Mantiene la prueba que confirma que `_reset_estado_delegate` no reinicia el `interpretador` y conserva la prueba que valida la reutilización del `interpretador` en ejecuciones normales consecutivas.
- Cambios realizados únicamente en `tests/unit/cli/commands_v2/test_repl_cmd_v2.py` sin modificaciones al código de producción.

### Testing
- Ejecutado: `pytest -q tests/unit/cli/commands_v2/test_repl_cmd_v2.py -k "sincronizacion_hacia_y_desde_delegate_conserva_interpretador or bloque_multilinea_y_sentencias_subsiguientes_comparten_runtime or reset_estado_delegate_no_reinicia_interpretador or ejecutar_modo_normal_reutiliza_interpretador_persistente"`.
- Resultado: las pruebas focalizadas pasaron: `4 passed, 10 deselected, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e7509a988327acff24bcdc5e7040)