### PR TITLE
refactor(repl): encapsular uso de pipeline explícito a setup de sandbox

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -960,6 +960,31 @@ class InteractiveCommand(BaseCommand):
 
         return False
 
+    def _ejecutar_pipeline_explicito_solo_setup_sandbox(self, interpretador_cls: type[Any]) -> Any:
+        """Inicializa setup de sandbox con pipeline explícito (uso restringido).
+
+        Contrato: este helper existe para aislar el único uso permitido de
+        ``ejecutar_pipeline_explicito`` dentro del REPL: preparación de
+        sandbox/setup. No debe reutilizarse para el flujo normal incremental.
+        """
+        from pcobra.cobra.cli.execution_pipeline import (
+            ejecutar_pipeline_explicito,
+            PipelineInput,
+        )
+
+        setup_input = PipelineInput(
+            codigo="",
+            interpretador_cls=interpretador_cls,
+            safe_mode=self._seguro_repl,
+            extra_validators=self._extra_validators_repl,
+            interpretador=self.interpretador,
+        )
+        setup, _ = ejecutar_pipeline_explicito(
+            setup_input,
+            analizar_codigo_fn=lambda _codigo: [],
+        )
+        return setup
+
     def _ejecutar_en_sandbox(
         self,
         linea: str,
@@ -973,26 +998,10 @@ class InteractiveCommand(BaseCommand):
             module_name=__name__,
             default_cls=type(self.interpretador),
         )
-        from pcobra.cobra.cli.execution_pipeline import (
-            ejecutar_pipeline_explicito,
-            PipelineInput,
-        )
-
         # REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.
-        # Contrato sandbox/setup: ``ejecutar_pipeline_explicito`` se usa aquí
-        # únicamente para normalizar configuración de intérprete/opciones antes
-        # de construir el script sandbox; no para ejecutar snippets normales.
-        setup_input = PipelineInput(
-            codigo="",
-            interpretador_cls=interpretador_cls,
-            safe_mode=self._seguro_repl,
-            extra_validators=self._extra_validators_repl,
-            interpretador=self.interpretador,
-        )
-        setup, _ = ejecutar_pipeline_explicito(
-            setup_input,
-            analizar_codigo_fn=lambda _codigo: [],
-        )
+        # Contrato sandbox/setup: llamada encapsulada para evitar reutilización
+        # accidental en flujo normal del REPL incremental.
+        setup = self._ejecutar_pipeline_explicito_solo_setup_sandbox(interpretador_cls)
         self.interpretador = setup.interpretador
         self._seguro_repl = setup.safe_mode
         self._extra_validators_repl = setup.validadores_extra


### PR DESCRIPTION
### Motivation
- Asegurar el contrato del REPL incremental: que el flujo normal use el intérprete acumulado y no reintroduzca pipelines batch, permitiendo `ejecutar_pipeline_explicito` únicamente en rutas de sandbox/setup.

### Description
- Se conservaron los docstrings/comentarios de contrato en `_ejecutar_ast_en_repl`, `ejecutar_codigo` y `parsear_y_ejecutar_codigo_repl` para dejar explícita la invariancia REPL incremental = intérprete.
- Se añadió `_ejecutar_pipeline_explicito_solo_setup_sandbox` en `src/pcobra/cobra/cli/commands/interactive_cmd.py` para encapsular la llamada a `ejecutar_pipeline_explicito` y documentar su uso restringido a setup/sandbox.
- Se modificó `_ejecutar_en_sandbox` para usar el nuevo helper y así confinar el uso del pipeline explícito a la ruta de setup/sandbox sin afectar el flujo normal del REPL.

### Testing
- Compilé el módulo con `python -m compileall src/pcobra/cobra/cli/commands/interactive_cmd.py`, y la compilación finalizó correctamente.
- Verifiqué con búsquedas (`rg`) la presencia del helper y que los métodos del REPL todavía contienen los comentarios/docstrings de contrato, confirmando que no se reintrodujo pipeline batch en el flujo normal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2245a63588327993ecff794434f54)