### PR TITLE
[Follow-up] Preservar fallback legacy de sandbox en puente runtime canónico

### DIFF
--- a/src/pcobra/cobra/core/runtime.py
+++ b/src/pcobra/cobra/core/runtime.py
@@ -7,14 +7,10 @@ canónico (``pcobra.cobra.*``) sin modificar la implementación base.
 
 from __future__ import annotations
 
+from typing import Any
+
 from pcobra.core.interpreter import InterpretadorCobra
 from pcobra.core.resource_limits import limitar_cpu_segundos, limitar_memoria_mb
-from pcobra.core.sandbox import (
-    SecurityError,
-    ejecutar_en_contenedor,
-    ejecutar_en_sandbox,
-    validar_dependencias,
-)
 from pcobra.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 from pcobra.core.semantic_validators.base import ValidadorBase
 
@@ -30,3 +26,18 @@ __all__ = [
     "limitar_memoria_mb",
     "validar_dependencias",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Resuelve símbolos de sandbox de forma perezosa para preservar fallback legacy."""
+
+    if name in {
+        "SecurityError",
+        "ejecutar_en_contenedor",
+        "ejecutar_en_sandbox",
+        "validar_dependencias",
+    }:
+        from pcobra.core import sandbox as _sandbox
+
+        return getattr(_sandbox, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
### Motivation
- Corregir un fallo donde `pcobra.cobra.core.runtime` importaba `pcobra.core.sandbox` en tiempo de carga, impidiendo que la lógica de compatibilidad legacy en `execute_cmd._importar_modulo_sandbox()` intentara el `core.sandbox` de fallback.

### Description
- Eliminados los `from pcobra.core.sandbox import ...` eager del módulo `src/pcobra/cobra/core/runtime.py` para evitar fallos en la importación cuando el sandbox canónico no está disponible.
- Añadido un resolutor perezoso `__getattr__` que exporta bajo demanda solo los símbolos de sandbox (`SecurityError`, `ejecutar_en_sandbox`, `ejecutar_en_contenedor`, `validar_dependencias`).
- Conservada la exportación pública (`__all__`) y las importaciones eager de las primitivas no relacionadas con sandbox para mantener la API estable.

### Testing
- Ejecutado: `pytest -q tests/unit/test_execute_cmd_extra_validators_normalization.py` y resultado: `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22c782fc083279c5da2c6b647e5db)