### PR TITLE
lint: detect relative cross-command imports

### DIFF
--- a/scripts/ci/lint_no_cross_command_imports.py
+++ b/scripts/ci/lint_no_cross_command_imports.py
@@ -41,7 +41,41 @@ def _is_forbidden_import_from(node: ast.ImportFrom) -> bool:
     return False
 
 
-def _scan_file(path: Path) -> list[tuple[int, str]]:
+def _module_path_from_file(path: Path, root: Path) -> str | None:
+    src_root = root / "src"
+    try:
+        rel = path.relative_to(src_root)
+    except ValueError:
+        return None
+
+    parts = list(rel.parts)
+    if not parts or parts[-1] == "__init__.py":
+        parts = parts[:-1]
+    elif parts[-1].endswith(".py"):
+        parts[-1] = parts[-1][:-3]
+    return ".".join(parts)
+
+
+def _resolve_import_from_module(node: ast.ImportFrom, path: Path, root: Path) -> str:
+    module = node.module or ""
+    if node.level == 0:
+        return module
+
+    current_module = _module_path_from_file(path, root)
+    if not current_module:
+        return module
+
+    package_parts = current_module.split(".")[:-1]
+    if node.level > len(package_parts):
+        return module
+
+    base_parts = package_parts[: len(package_parts) - node.level + 1]
+    if module:
+        base_parts.extend(module.split("."))
+    return ".".join(base_parts)
+
+
+def _scan_file(path: Path, root: Path) -> list[tuple[int, str]]:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     violations: list[tuple[int, str]] = []
     for node in ast.walk(tree):
@@ -52,6 +86,12 @@ def _scan_file(path: Path) -> list[tuple[int, str]]:
         elif isinstance(node, ast.ImportFrom):
             if _is_forbidden_import_from(node):
                 label = node.module or "<relative>"
+                violations.append((node.lineno, label))
+                continue
+
+            resolved_module = _resolve_import_from_module(node, path, root)
+            if _is_forbidden_module_name(resolved_module):
+                label = resolved_module or node.module or "<relative>"
                 violations.append((node.lineno, label))
     return violations
 
@@ -67,7 +107,7 @@ def find_violations(root: Path = ROOT) -> list[str]:
             continue
         for path in sorted(scope.rglob("*.py")):
             rel = path.relative_to(root)
-            for line, target in _scan_file(path):
+            for line, target in _scan_file(path, root):
                 failures.append(
                     f"{rel}:{line}: import entre comandos no permitido ({target}); "
                     "extrae código a un servicio compartido o usa commands.base"

--- a/tests/unit/test_ci_lint_no_cross_command_imports.py
+++ b/tests/unit/test_ci_lint_no_cross_command_imports.py
@@ -31,3 +31,15 @@ def test_permite_import_desde_base(tmp_path: Path) -> None:
     violations = find_violations(tmp_path)
 
     assert violations == []
+
+
+def test_detecta_import_relativo_entre_comandos(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "a.py",
+        "from .compile_cmd import CompileCommand\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "pcobra.cobra.cli.commands.compile_cmd" in violations[0]


### PR DESCRIPTION
### Motivation
- Close a bypass in the command-isolation lint where relative `from .module import ...` statements were not resolved and thus not reported, which allowed cross-command coupling to slip past CI.  
- Enforce the architectural rule that CLI command modules may only import `commands.base` and not other `commands.*` modules.  

### Description
- Updated `scripts/ci/lint_no_cross_command_imports.py` to resolve `ast.ImportFrom` relative imports using `node.level` and the file path so relative imports are mapped to fully-qualified module names.  
- Added helper functions ` _module_path_from_file` and `_resolve_import_from_module` and changed `_scan_file` to accept `root` and use the resolved module name when checking `FORBIDDEN_PREFIXES`.  
- Kept existing absolute `Import` checks and the `commands.base` exception intact.  
- Added a unit test `test_detecta_import_relativo_entre_comandos` in `tests/unit/test_ci_lint_no_cross_command_imports.py` that verifies `from .compile_cmd import ...` is detected as a violation.  

### Testing
- Ran `pytest -q tests/unit/test_ci_lint_no_cross_command_imports.py` and the test suite passed (`3 passed`).  
- The added unit test confirms the previously unreported relative import case is now detected as a violation.  
- The lint script `scripts/ci/lint_no_cross_command_imports.py` was exercised by the tests and behaves as expected on the sample inputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23ab2d40c8327a8bb206dd807a09c)