### PR TITLE
fix(lsp): prevent stdout pollution when black fails

### DIFF
--- a/src/pcobra/lsp/cobra_plugin.py
+++ b/src/pcobra/lsp/cobra_plugin.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 import re
+import shutil
+import subprocess
 
 try:
     from pylsp import hookimpl, lsp  # type: ignore[import-not-found]
@@ -29,7 +31,6 @@ except ModuleNotFoundError:  # pragma: no cover - dependencia opcional
 from pcobra.standard_library import __all__ as STD_FUNCS
 from pcobra.cobra.core import Lexer, LexerError
 from pcobra.cobra.core import Parser, ParserError
-from pcobra.cobra.cli.services.format_service import format_code_with_black
 
 # Palabras reservadas más comunes de Cobra
 KEYWORDS = [
@@ -57,6 +58,24 @@ KEYWORDS = [
 
 # Funciones incluidas en la biblioteca estándar
 BUILTINS = list(STD_FUNCS) + ["imprimir"]
+
+
+def _format_code_for_lsp(path: str) -> None:
+    """Ejecuta ``black`` sin emitir salida por stdout para preservar el protocolo LSP."""
+    if not shutil.which("black"):
+        raise RuntimeError("Herramienta 'black' no encontrada en el PATH")
+
+    result = subprocess.run(
+        ["black", path],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        raise RuntimeError(stderr or f"black finalizó con código {result.returncode}")
+
 
 
 def lint_lines(lines: list[str]):
@@ -187,8 +206,7 @@ def pylsp_format_document(config, workspace, document):
     """Formatea el archivo actual utilizando el formateador de Cobra."""
     path = document.path
     try:
-        if not format_code_with_black(path):
-            raise RuntimeError(f"Fallo de formateo con black para el documento {path}")
+        _format_code_for_lsp(path)
         with open(path, "r", encoding="utf-8") as fh:
             formatted = fh.read()
     except Exception as exc:

--- a/tests/unit/test_lsp_cobra_plugin.py
+++ b/tests/unit/test_lsp_cobra_plugin.py
@@ -19,11 +19,10 @@ def test_pylsp_format_document_devuelve_edits_si_formatea(monkeypatch, tmp_path)
     archivo.write_text("imprimir(1)\n", encoding="utf-8")
     documento = _DummyDocument(path=archivo, source=archivo.read_text(encoding="utf-8"))
 
-    def _fake_format(path: str) -> bool:
+    def _fake_format(path: str) -> None:
         Path(path).write_text("imprimir(1)\n", encoding="utf-8")
-        return True
 
-    monkeypatch.setattr(cobra_plugin, "format_code_with_black", _fake_format)
+    monkeypatch.setattr(cobra_plugin, "_format_code_for_lsp", _fake_format)
 
     edits = cobra_plugin.pylsp_format_document(None, None, documento)
 
@@ -37,9 +36,12 @@ def test_pylsp_format_document_lanza_runtimeerror_si_falla_formateo(monkeypatch,
     archivo.write_text("imprimir(1)\n", encoding="utf-8")
     documento = _DummyDocument(path=archivo, source=archivo.read_text(encoding="utf-8"))
 
-    monkeypatch.setattr(cobra_plugin, "format_code_with_black", lambda _path: False)
+    def _fail_format(_path: str) -> None:
+        raise RuntimeError("black missing")
 
-    with pytest.raises(RuntimeError, match="Fallo de formateo con black"):
+    monkeypatch.setattr(cobra_plugin, "_format_code_for_lsp", _fail_format)
+
+    with pytest.raises(RuntimeError, match="No se pudo formatear el documento"):
         cobra_plugin.pylsp_format_document(None, None, documento)
 
 


### PR DESCRIPTION
### Motivation
- Avoid routing CLI stdout/stderr messages through the LSP process because any non-JSON output on stdout can corrupt the stdio JSON-RPC stream.
- The previous path called the CLI helper that used `mostrar_error(...)` which prints to stdout on failures and is unsafe for LSP deployments.
- Ensure formatting failures are propagated as exceptions and logged, not printed to CLI output.

### Description
- Removed the LSP's use of the CLI formatter and added an internal `_format_code_for_lsp(path: str)` helper that runs `black` with `stdout`/`stderr` captured and raises `RuntimeError` for missing `black` or non-zero exits.
- Updated `pylsp_format_document` to call `_format_code_for_lsp` and retain the existing exception wrapping and logging behavior instead of allowing CLI printers to run.
- Updated `tests/unit/test_lsp_cobra_plugin.py` to patch `_format_code_for_lsp` and validate successful edit generation and wrapped failure behavior, and to assert the plugin does not expose `ExecuteCommand`.
- Kept the returned `TextEdit` shape identical so editor behavior is unchanged on success.

### Testing
- Ran `pytest -q tests/unit/test_lsp_cobra_plugin.py` and the test suite passed (`3 passed`).
- Unit tests cover successful formatting (returns edits), failing formatting (raises `RuntimeError` wrapped by the LSP handler), and absence of the old `ExecuteCommand` dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f242a658ec83279f468b8347f7bb05)