### PR TITLE
Fix CSE temporary declarations on top of #2086

### DIFF
--- a/src/pcobra/core/optimizations/common_subexpr.py
+++ b/src/pcobra/core/optimizations/common_subexpr.py
@@ -93,7 +93,7 @@ class _CommonSubexprEliminator(NodeVisitor):
             nombre = f"_cse{len(cur)}"
             cur[key] = nombre
             self._current_assigns().append(
-                NodoAsignacion(nombre, copy.deepcopy(expr))
+                NodoAsignacion(nombre, copy.deepcopy(expr), declaracion=True)
             )
         return NodoIdentificador(cur[key])
 

--- a/tests/unit/test_optimizations.py
+++ b/tests/unit/test_optimizations.py
@@ -202,6 +202,7 @@ def test_eliminate_common_subexpressions_global():
     assert len(optimizado) == 3
     temp = optimizado[0]
     assert temp.identificador == "_cse0"
+    assert temp.declaracion is True
     assert isinstance(optimizado[1].expresion, NodoIdentificador)
     assert optimizado[1].expresion.nombre == "_cse0"
     assert isinstance(optimizado[2].expresion, NodoIdentificador)
@@ -226,6 +227,7 @@ def test_eliminate_common_subexpressions_in_function():
     optimizado = eliminate_common_subexpressions([func])
     cuerpo = optimizado[0].cuerpo
     assert cuerpo[0].identificador == "_cse0"
+    assert cuerpo[0].declaracion is True
     assert isinstance(cuerpo[1].expresion, NodoIdentificador)
     assert cuerpo[1].expresion.nombre == "_cse0"
     assert isinstance(cuerpo[2].expresion, NodoIdentificador)


### PR DESCRIPTION
### Motivation

- Recent hardening made `Environment.set` refuse implicit declarations, which caused optimizer-generated temporaries (e.g. `_cse0`) to raise `NameError` because they were emitted as plain assignments. 
- The optimizer must emit temporaries as explicit declarations so they are created with `define` semantics instead of triggering `set` errors.

### Description

- Mark optimizer-generated CSE temporaries as declarations by constructing them with `declaracion=True` in `eliminate_common_subexpressions` (`src/pcobra/core/optimizations/common_subexpr.py`).
- Updated unit tests to assert the `_cse*` temporaries carry `declaracion is True` both at global scope and inside function bodies (`tests/unit/test_optimizations.py`).
- This change preserves the scope-hardening contract where non-declaration writes go through `Environment.set` and require a prior declaration.

### Testing

- Ran the optimizations and interpreter unit test suites with `pytest -q tests/unit/test_optimizations.py tests/unit/test_interpreter_scope_contract.py tests/unit/test_interpreter.py tests/unit/test_interpreter_inferencia.py tests/unit/test_interpreter_loop_scope_regression.py`.
- Result: all tests passed (`37 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2476f563c83279a450ba0c50c08ca)