### PR TITLE
[PR #2088 Follow-up] Fix relative ImportFrom dependency resolution in CI import graph

### DIFF
--- a/scripts/ci/check_import_cycles.py
+++ b/scripts/ci/check_import_cycles.py
@@ -79,8 +79,13 @@ def _extract_imported_modules(tree: ast.AST, current_module: str) -> set[str]:
         elif isinstance(node, ast.ImportFrom):
             if node.level:
                 resolved = _resolve_relative_module(current_module, node.level, node.module)
-                if resolved:
-                    imports.add(resolved)
+                if not resolved:
+                    continue
+                for alias in node.names:
+                    if alias.name == "*":
+                        imports.add(resolved)
+                    else:
+                        imports.add(f"{resolved}.{alias.name}")
                 continue
             if node.module:
                 imports.add(node.module)

--- a/tests/unit/test_ci_check_import_cycles.py
+++ b/tests/unit/test_ci_check_import_cycles.py
@@ -82,3 +82,15 @@ def test_permite_import_base_entre_comandos(tmp_path: Path) -> None:
     violations = find_layer_violations(graph)
 
     assert not violations
+
+
+def test_resuelve_importfrom_relativo_con_nombres(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    _write(src / "pkg" / "a.py", "from . import b\nfrom .subpkg import c\n")
+    _write(src / "pkg" / "b.py", "VALUE = 1\n")
+    _write(src / "pkg" / "subpkg" / "c.py", "VALUE = 2\n")
+
+    graph = build_import_graph(src)
+
+    assert "pkg.b" in graph["pkg.a"]
+    assert "pkg.subpkg.c" in graph["pkg.a"]


### PR DESCRIPTION
### Motivation
- Relative `from ... import ...` statements were only recorded as their resolved base module, dropping the imported names and allowing real dependency edges to be missed which produced false negatives in cycle detection and layer-rule checks.

### Description
- Update `scripts/ci/check_import_cycles.py` to resolve relative `ImportFrom` aliases into concrete module edges by adding `resolved.<name>` for each `alias` and preserving a conservative `resolved` edge for `*` imports.
- Add a regression test `test_resuelve_importfrom_relativo_con_nombres` in `tests/unit/test_ci_check_import_cycles.py` that asserts `from . import b` produces `pkg.b` and `from .subpkg import c` produces `pkg.subpkg.c` in the graph.
- These changes ensure the import graph includes per-name edges for relative imports so cycle detection and layer-violation checks are not silently bypassed.

### Testing
- Ran `python -m pytest -q tests/unit/test_ci_check_import_cycles.py` which returned all tests passing (`5 passed`).
- The updated unit test verifies the new relative `ImportFrom` resolution and the existing tests ensure no regressions in cycle/layer detection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24bb02df4832797a33ff083233dc2)