### PR TITLE
[PR #2069 Follow-up] Restaurar SafeFileHistory en la configuración del historial REPL

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -843,6 +843,8 @@ class InteractiveCommand(BaseCommand):
             )
         self.logger.debug(_("Finalizando REPL de Cobra"))
     def _construir_historial(self, history_path: str) -> Any:
+        if SafeFileHistory is not None:
+            return SafeFileHistory(history_path)
         if FileHistory is not None:
             return FileHistory(history_path)
         return _SessionHistoryFallback(history_path)

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -116,7 +116,7 @@ def test_interactive_history_setup(tmp_path):
     fake_path = tmp_path / '.cobra_history'
     with patch('cobra.cli.commands.interactive_cmd.os.path.expanduser', return_value=str(fake_path)) as mock_expanduser, \
          patch('cobra.cli.commands.interactive_cmd.os.makedirs') as mock_makedirs, \
-         patch('cobra.cli.commands.interactive_cmd.FileHistory') as mock_history, \
+         patch('cobra.cli.commands.interactive_cmd.SafeFileHistory') as mock_history, \
          patch('prompt_toolkit.PromptSession.prompt', side_effect=['salir']), \
          patch('cobra.cli.commands.interactive_cmd.validar_dependencias'):
         cmd.run(_args())


### PR DESCRIPTION
### Motivation
- Corregir una regresión que hizo que el REPL use `FileHistory` crudo, saltándose la sanitización de `append_string` y provocando fallos al persistir entradas con Unicode malformed.
- Garantizar que la escritura del historial en la sesión interactiva vuelva a pasar por la capa de seguridad de `SafeFileHistory` para evitar cierres inesperados del REPL.

### Description
- Se modificó `InteractiveCommand._construir_historial` para preferir `SafeFileHistory(history_path)` cuando está disponible y sólo caer a `FileHistory` o `_SessionHistoryFallback` en último caso.
- Se actualizó el test `test_interactive_history_setup` para parchear `SafeFileHistory` en lugar de `FileHistory`, ajustando el test a la nueva construcción segura del historial.
- Archivos cambiados: `src/pcobra/cobra/cli/commands/interactive_cmd.py` y `tests/unit/test_cli_interactive_cmd.py`.

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_interactive_cmd.py` y la suite relevante pasó completamente (31 passed).
- Antes de la corrección la ejecución del mismo fichero unitario reportó 1 fallo relacionado con la expectativa de llamada a `FileHistory`, y tras aplicar el cambio el fallo fue resuelto.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35b32e33883279eb7cc9f87da30d7)