### PR TITLE
[Follow-up] Restore BACKENDS compatibility exports for benchmark CLI commands

### DIFF
--- a/src/pcobra/cobra/cli/commands/bench_cmd.py
+++ b/src/pcobra/cobra/cli/commands/bench_cmd.py
@@ -23,6 +23,7 @@ validate_backend_metadata(
     BENCHMARK_BACKEND_METADATA,
     context="pcobra.cobra.cli.commands.bench_cmd.BENCHMARK_BACKEND_METADATA",
 )
+BACKENDS = tuple(cli_runtime_benchmark_backends())
 
 class BenchCommand(BaseCommand):
     """Ejecuta benchmarks y opcionalmente los perfila."""

--- a/src/pcobra/cobra/cli/commands/benchmarks_cmd.py
+++ b/src/pcobra/cobra/cli/commands/benchmarks_cmd.py
@@ -25,6 +25,7 @@ from pcobra.cobra.cli.services.benchmark_service import benchmark_backends_confi
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 
+BACKENDS = tuple(benchmark_backends(BENCHMARK_BACKEND_METADATA))
 
 class BenchmarksCommand(BaseCommand):
     """Comando para ejecutar benchmarks."""


### PR DESCRIPTION
### Motivation

- Preserve backward-compatible module exports after centralizing backend state in `benchmark_service`, because callers and tests import `BACKENDS` from the CLI command modules. 

### Description

- Restored `BACKENDS` export in `src/pcobra/cobra/cli/commands/bench_cmd.py` as `BACKENDS = tuple(cli_runtime_benchmark_backends())` so imports like `from ...bench_cmd import BACKENDS` continue to work. 
- Restored `BACKENDS` export in `src/pcobra/cobra/cli/commands/benchmarks_cmd.py` as `BACKENDS = tuple(benchmark_backends(BENCHMARK_BACKEND_METADATA))` to keep the module-level compatibility alias while retaining the metadata-driven source. 
- Committed the two-file change and created a follow-up PR summarizing the compatibility fix.

### Testing

- Ran focused benchmark CLI tests: `pytest -q tests/unit/test_cli_target_option_validations.py -k benchmarks`, which succeeded (`7 passed, 18 deselected`).
- Ran the broader official-targets consistency suite: `pytest -q tests/unit/test_official_targets_consistency.py`, which failed during collection due to a pre-existing assertion in `tests/utils/targets.py` unrelated to these changes.
- Verified that the introduced exports resolve the import errors reported by Codex review (import-time failures when `BACKENDS` was removed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3855b4dec8327b435b608d6b09dc9)