### PR TITLE
fix(cli): preservar hook legacy de ejecutar_en_sandbox en RunService

### DIFF
--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -1,6 +1,7 @@
 import importlib
 import logging
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -96,6 +97,16 @@ def ejecutar_en_contenedor(*args: Any, **kwargs: Any) -> Any:
 
 def validar_dependencias(*args: Any, **kwargs: Any) -> Any:
     return sandbox_module.validar_dependencias(*args, **kwargs)
+
+
+def _resolver_hook_sandbox_legacy() -> Any:
+    legacy_module = sys.modules.get("pcobra.cobra.cli.commands.execute_cmd")
+    if legacy_module is None:
+        return ejecutar_en_sandbox
+    legacy_hook = getattr(legacy_module, "ejecutar_en_sandbox", None)
+    if callable(legacy_hook):
+        return legacy_hook
+    return ejecutar_en_sandbox
 
 
 def detectar_raiz_proyecto_desde_archivo(archivo: str) -> str:
@@ -210,7 +221,8 @@ class RunService:
         script = construir_script_sandbox_canonico(codigo, safe_mode=seguro, extra_validators=extra_validators)
 
         try:
-            salida = ejecutar_en_sandbox(script, allow_insecure_fallback=allow_insecure_fallback)
+            sandbox_executor = _resolver_hook_sandbox_legacy()
+            salida = sandbox_executor(script, allow_insecure_fallback=allow_insecure_fallback)
             if salida:
                 mostrar_info(str(salida))
             return 0


### PR DESCRIPTION
### Motivation
- La refactorización hacía que `RunService` invocara la implementación canónica de sandbox directamente, rompiendo las sobreescrituras/monkeypatches previas sobre `execute_cmd.ejecutar_en_sandbox` y provocando fallos en callers y tests que dependen de ese seam de compatibilidad.

### Description
- Se añadió la importación de `sys` y la función `_resolver_hook_sandbox_legacy()` que resuelve en tiempo de ejecución el hook legacy `pcobra.cobra.cli.commands.execute_cmd.ejecutar_en_sandbox` cuando el módulo está cargado. 
- `RunService.ejecutar_en_sandbox` ahora ejecuta a través del hook resuelto (`_resolver_hook_sandbox_legacy()`), y usa la implementación canónica como fallback cuando no existe el hook legado.

### Testing
- Se compiló el archivo modificado con `python -m compileall src/pcobra/cobra/cli/services/run_service.py` y la compilación fue exitosa. 
- Se ejecutó la suite con `python -m pytest -q tests`, la cual falló durante la recolección de tests por aserciones preexistentes sobre la matriz de targets (`SUPPORTED_TARGETS == EXPECTED_CANONICAL_TARGETS`) que son independientes de este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3888e5094832798abb892be883749)