### PR TITLE
Follow-up: restore Run/Test service exit-code contract on normalization errors

### DIFF
--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -115,8 +115,8 @@ class RunService:
     execution_timeout = 30
 
     def run(self, request: RunRequest) -> int:
-        request = normalize_run_request(request)
         try:
+            request = normalize_run_request(request)
             validar_politica_modo("ejecutar", request, capability="execute")
         except ValueError as e:
             mostrar_error(str(e), registrar_log=False)

--- a/src/pcobra/cobra/cli/services/test_service.py
+++ b/src/pcobra/cobra/cli/services/test_service.py
@@ -36,8 +36,8 @@ class TestService:
         self._logger = logging.getLogger(__name__)
 
     def run(self, request: TestRequest) -> int:
-        request = normalize_test_request(request)
         try:
+            request = normalize_test_request(request)
             validar_politica_modo("verificar", request, capability="codegen")
 
             lenguajes = list(request.lenguajes)


### PR DESCRIPTION
### Motivation

- The DTO-based refactor moved request normalization to the top of service methods, which caused `ValueError` from `normalize_*` to escape the service and break the expected exit-code contract for programmatic callers. 
- The intent is to preserve existing service semantics where malformed input produces a user-facing error and returns `1` instead of raising an exception.

### Description

- Moved `normalize_run_request(request)` inside the existing `try/except ValueError` block in `RunService.run` so normalization failures are handled by the same error path. 
- Moved `normalize_test_request(request)` into the method `try` block in `TestService.run` so normalization errors fall through the existing `(ValueError, PermissionError)` handling. 
- Changes applied to `src/pcobra/cobra/cli/services/run_service.py` and `src/pcobra/cobra/cli/services/test_service.py` to restore the prior service-level error behavior.

### Testing

- Ran `pytest -q tests/unit/test_cli_service_contracts.py tests/unit/test_cli_target_runtime_ux.py` after the changes. 
- Result: `14 passed, 2 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38f3a3cec83278e3992b88dff89b0)