### PR TITLE
Corrige liberación de memoria en `del` para entornos léxicos capturados

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -429,16 +429,25 @@ class InterpretadorCobra:
         """Permite reemplazar solo el mapeo local del entorno activo."""
         self.contextos[-1].values = valor
 
-    def _indice_entorno_variable(self, nombre: str) -> int | None:
-        """Retorna el índice del primer entorno (de adentro hacia afuera) con ``nombre``."""
+    def _entorno_variable(self, nombre: str) -> Environment | None:
+        """Retorna el entorno léxico donde ``nombre`` existe, partiendo del activo."""
+        entorno = self.contextos[-1]
+        while entorno is not None:
+            if nombre in entorno.values:
+                return entorno
+            entorno = entorno.parent
+        return None
+
+    def _indice_contexto_por_entorno(self, entorno_objetivo: Environment) -> int | None:
+        """Retorna el índice de ``self.contextos`` asociado a ``entorno_objetivo``."""
         for indice in range(len(self.contextos) - 1, -1, -1):
-            if nombre in self.contextos[indice].values:
+            if self.contextos[indice] is entorno_objetivo:
                 return indice
         return None
 
-    def _liberar_memoria_variable_en_contexto(self, nombre: str, indice_contexto: int) -> None:
+    def _liberar_memoria_variable_en_contexto(self, nombre: str, indice_contexto: int | None) -> None:
         """Libera el bloque de memoria asociado a ``nombre`` en un contexto concreto."""
-        if indice_contexto < 0 or indice_contexto >= len(self.mem_contextos):
+        if indice_contexto is None or indice_contexto < 0 or indice_contexto >= len(self.mem_contextos):
             return
         mem_ctx = self.mem_contextos[indice_contexto]
         if nombre not in mem_ctx:
@@ -1090,10 +1099,12 @@ class InterpretadorCobra:
                     f"se recibió: {type(nodo.objetivo).__name__}"
                 )
             nombre = nodo.objetivo.nombre
-            indice_contexto = self._indice_entorno_variable(nombre)
-            self.contextos[-1].delete(nombre)
-            if indice_contexto is not None:
-                self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
+            entorno_variable = self._entorno_variable(nombre)
+            if entorno_variable is None:
+                raise NameError(f"Variable no declarada: {nombre}")
+            indice_contexto = self._indice_contexto_por_entorno(entorno_variable)
+            del entorno_variable.values[nombre]
+            self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
         elif isinstance(nodo, NodoGlobal):
             pass  # sin efecto en este intérprete simplificado
         elif isinstance(nodo, NodoNoLocal):

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -240,6 +240,30 @@ def test_del_libera_memoria_del_scope_ancestro():
     assert "x" not in inter.mem_contextos[0]
 
 
+def test_del_no_libera_memoria_de_contexto_no_relacionado_si_entorno_capturado_no_esta_en_pila():
+    inter = InterpretadorCobra()
+    entorno_global = inter.contextos[0]
+    entorno_capturado = Environment(parent=entorno_global)
+    entorno_capturado.define("x", 99)
+
+    inter.contextos.append(Environment(parent=entorno_capturado))
+    inter.mem_contextos.append({})
+    inter.mem_contextos[0]["x"] = (22, 1)
+
+    liberaciones = []
+    inter.liberar_memoria = lambda idx, tam: liberaciones.append((idx, tam))
+
+    try:
+        inter.ejecutar_nodo(NodoDel(NodoIdentificador("x")))
+    finally:
+        inter.mem_contextos.pop()
+        inter.contextos.pop()
+
+    assert not entorno_capturado.contains("x")
+    assert liberaciones == []
+    assert inter.mem_contextos[0]["x"] == (22, 1)
+
+
 def test_del_objetivo_no_identificador_lanza_typeerror():
     inter = InterpretadorCobra()
 


### PR DESCRIPTION
### Motivation

- Evitar que `del` borre la variable en un entorno léxico pero libere la metadata de memoria en un contexto distinto cuando existe un cierre (entorno capturado) fuera de la pila de `self.contextos`.  
- Unificar la resolución léxica de `del` con la semántica de entornos encadenados para mantener la coherencia entre eliminación y bookkeeping de memoria.

### Description

- Reemplazada la búsqueda por índice de pila ` _indice_entorno_variable` por ` _entorno_variable` que camina `Environment.parent` desde el contexto activo para resolver el entorno exacto que contiene la variable.  
- Añadida la función ` _indice_contexto_por_entorno` para mapear un objeto `Environment` a su índice en `self.contextos` solo si ese entorno está en la pila.  
- Actualizado el caso `NodoDel` para eliminar el identificador del `Environment` resuelto (`del entorno_variable.values[nombre]`) y solo liberar metadata de `self.mem_contextos` cuando el entorno resuelto está representado en la pila usando ` _liberar_memoria_variable_en_contexto`.  
- Agregada la prueba `test_del_no_libera_memoria_de_contexto_no_relacionado_si_entorno_capturado_no_esta_en_pila` que cubre el caso de cierre/captura donde la metadata de memoria colisionante no debe liberarse.

### Testing

- Ejecutado `pytest -q tests/unit/test_interpreter.py -k "del"` y el subconjunto relevante pasó correctamente con `5 passed, 15 deselected`.  
- La nueva prueba de regresión para entornos capturados fue incluida en la suite anterior y fue exitosa.  
- Se recomienda ejecutar la suite completa en CI antes de fusionar para validar integraciones adicionales.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3973b0cb48327b31049619e49a89b)