### PR TITLE
Fix legacy internal targets in compile runtime validation (follow-up to #2106)

### DIFF
--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -185,7 +185,7 @@ class CompileCommand(BaseCommand):
             return 1
 
         _ensure_entrypoints_loaded_once()
-        current_lang_choices = set(get_lang_choices())
+        current_lang_choices = set(get_lang_choices()) | set(enabled_internal_legacy_targets())
 
         tipos_argument = getattr(args, "tipos", None)
         if isinstance(tipos_argument, str):


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where runtime validation rejected internal legacy targets (e.g. `go`) even though the parser allowed them when `COBRA_INTERNAL_LEGACY_TARGETS=1`.

### Description
- Updated `src/pcobra/cobra/cli/commands/compile_cmd.py` so `CompileCommand.run` builds the runtime snapshot with both dynamic public targets and legacy internal targets by setting `current_lang_choices = set(get_lang_choices()) | set(enabled_internal_legacy_targets())`.
- This aligns runtime validation with `register_subparser`, which already permits `enabled_internal_legacy_targets()` at parse time, restoring compatibility mode.
- The change is a single-line fix that keeps error reporting via `invalid_target_error` unchanged and does not alter parsing behavior.

### Testing
- Ran the targeted test focusing on legacy behavior with `pytest -q tests/unit/test_compile_cmd_target_choices_aliases.py -k legacy -q` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39c0e8f3c832780f3f35915283296)