### PR TITLE
Follow-up: fix REPL sandbox validator serialization regression on #2110

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -230,6 +230,7 @@ class InteractiveCommand(BaseCommand):
         self._debug_mode = False
         self._seguro_repl = True
         self._extra_validators_repl: Any = None
+        self._extra_validators_repl_script: Any = None
 
     @staticmethod
     def _crear_estado_repl() -> dict[str, Any]:
@@ -452,6 +453,7 @@ class InteractiveCommand(BaseCommand):
             return 1
         self._seguro_repl = bool(seguro)
         self._extra_validators_repl = extra_validators
+        self._extra_validators_repl_script = extra_validators
         try:
             interpretador_cls = resolver_interpretador_cls(
                     module_name=__name__,
@@ -623,7 +625,7 @@ class InteractiveCommand(BaseCommand):
                     self._ejecutar_en_sandbox(
                         codigo,
                         safe_mode=self._seguro_repl,
-                        extra_validators=self._extra_validators_repl,
+                        extra_validators=self._extra_validators_repl_script,
                     )
                 elif sandbox_docker:
                     self._ejecutar_en_docker(codigo, sandbox_docker)

--- a/tests/unit/test_cli_interactive_cmd.py
+++ b/tests/unit/test_cli_interactive_cmd.py
@@ -431,6 +431,7 @@ def test_run_repl_loop_pasa_estado_repl_a_ejecucion_sandbox():
     cmd = InteractiveCommand(MagicMock())
     cmd._seguro_repl = False
     cmd._extra_validators_repl = ["extra.py"]
+    cmd._extra_validators_repl_script = ["extra.py"]
 
     def _leer_linea_factory():
         entradas = iter(["imprimir(1)", "salir"])


### PR DESCRIPTION
### Motivation
- Prevent passing non-serializable validator instances into sandbox script generation which caused `SyntaxError` when `--extra-validators` was used. 
- Keep REPL and `run` behavior aligned so the sandbox script receives only serializable validator configuration for code generation.

### Description
- Added a new field `self._extra_validators_repl_script` to preserve the script-safe form of extra validators separately from runtime validator instances.  
- Store the normalized CLI validator input into `self._extra_validators_repl_script` in `run()` before the pipeline mutates `self._extra_validators_repl` into validator objects.  
- Updated `_run_repl_loop` to pass `self._extra_validators_repl_script` to `_ejecutar_en_sandbox` so `construir_script_sandbox_canonico` always receives serializable values.  
- Adjusted the unit test setup in `test_run_repl_loop_pasa_estado_repl_a_ejecucion_sandbox` to initialize `cmd._extra_validators_repl_script` for the sandbox-forwarding assertion.

### Testing
- Ran `pytest -q tests/unit/test_cli_interactive_cmd.py -k "sandbox or run_repl_loop_pasa_estado_repl_a_ejecucion_sandbox"` and the result was `2 passed, 30 deselected`.
- The updated tests verify the generated sandbox script contains `safe_mode` and `extra_validators` and that the REPL loop forwards the script-facing validator state to sandbox execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39ea863b08327816e6188d8b363af)