### PR TITLE
fix(cli): ignore quotes inside line comments during Unicode source sanitization

### DIFF
--- a/src/pcobra/cobra/cli/utils/unicode_sanitize.py
+++ b/src/pcobra/cobra/cli/utils/unicode_sanitize.py
@@ -36,10 +36,24 @@ def sanitize_source_for_tokenizer(text: str) -> str:
     out: list[str] = []
     quote: str | None = None
     escaped = False
+    in_line_comment = False
 
-    for ch in source:
+    for idx, ch in enumerate(source):
+        nxt = source[idx + 1] if idx + 1 < len(source) else ""
+
+        if in_line_comment:
+            out.append(ch)
+            if ch == "\n":
+                in_line_comment = False
+            continue
+
         if quote is None:
             out.append(ch)
+
+            if ch == "#" or (ch == "/" and nxt == "/"):
+                in_line_comment = True
+                continue
+
             if ch in {"'", '"'}:
                 quote = ch
                 escaped = False

--- a/tests/unit/test_unicode_sanitize_repl.py
+++ b/tests/unit/test_unicode_sanitize_repl.py
@@ -75,6 +75,14 @@ def test_sanitize_source_for_tokenizer_no_muta_identificadores_unicode() -> None
     assert saneado == codigo
 
 
+def test_sanitize_source_for_tokenizer_ignora_comillas_dentro_de_comentario() -> None:
+    codigo = '# comentario con comilla "\nimprimir("á")'
+
+    saneado = sanitize_source_for_tokenizer(codigo)
+
+    assert saneado == '# comentario con comilla "\nimprimir("\\xe1")'
+
+
 def test_interactive_command_sanitiza_surrogate_invalido_y_no_crashea(tmp_path):
     cmd = InteractiveCommand(MagicMock())
     capturado = {"history": [], "validar": []}


### PR DESCRIPTION
### Motivation

- A lone `"` or `'` inside a line comment (`#` or `//`) was being treated as a string delimiter by `sanitize_source_for_tokenizer`, leaving the sanitizer stuck in string mode and causing subsequent real string literals to skip escaping and produce mojibake at runtime. 

### Description

- Updated `sanitize_source_for_tokenizer` in `src/pcobra/cobra/cli/utils/unicode_sanitize.py` to track line-comment state and ignore quote characters while inside a comment. 
- Switched the loop to index-based iteration to peek the next character and detect `//` comment starts in addition to `#`. 
- Preserved existing behavior of escaping non-ASCII characters inside real string literals and of `sanitize_input` repairing surrogates. 
- Added a regression test `test_sanitize_source_for_tokenizer_ignora_comillas_dentro_de_comentario` in `tests/unit/test_unicode_sanitize_repl.py` to cover the reported scenario where a comment contains a quote followed by a Unicode literal.

### Testing

- Ran `pytest -q tests/unit/test_unicode_sanitize_repl.py::test_sanitize_source_for_tokenizer_escapa_unicode_en_cadenas tests/unit/test_unicode_sanitize_repl.py::test_sanitize_source_for_tokenizer_no_muta_identificadores_unicode tests/unit/test_unicode_sanitize_repl.py::test_sanitize_source_for_tokenizer_ignora_comillas_dentro_de_comentario` and received `3 passed`.
- The changed unit tests in `tests/unit/test_unicode_sanitize_repl.py` passed locally and confirm the sanitizer now ignores comment quotes and still escapes real string literals correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a03f48a0832789f3f2fc50199b66)