### PR TITLE
Prevent mem_contextos corruption when mutating escaped captured variables

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -444,10 +444,21 @@ class InterpretadorCobra:
         contexto_activo.values.clear()
         contexto_activo.values.update(nuevos_valores)
 
-    def _indice_entorno_variable(self, nombre: str) -> int | None:
-        """Retorna el índice del primer entorno (de adentro hacia afuera) con ``nombre``."""
+    def _entorno_variable_desde_actual(self, nombre: str) -> Environment | None:
+        """Resuelve el entorno real que posee ``nombre`` siguiendo la cadena parent."""
+        entorno = self.contextos[-1] if self.contextos else None
+        while entorno is not None:
+            if nombre in entorno.values:
+                return entorno
+            entorno = entorno.parent
+        return None
+
+    def _indice_entorno(self, entorno_objetivo: Environment | None) -> int | None:
+        """Devuelve el índice de ``entorno_objetivo`` en ``self.contextos`` por identidad."""
+        if entorno_objetivo is None:
+            return None
         for indice in range(len(self.contextos) - 1, -1, -1):
-            if nombre in self.contextos[indice].values:
+            if self.contextos[indice] is entorno_objetivo:
                 return indice
         return None
 
@@ -1166,16 +1177,16 @@ class InterpretadorCobra:
                 # Declaración local (explícita o por inferencia)
                 self.contextos[-1].define(nombre, valor)
             else:
-                # Mutación: resolver primero en qué entorno vive la variable.
-                # Si no existe todavía, ``set`` la creará en el scope actual.
-                indice_contexto = self._indice_entorno_variable(nombre)
-                if indice_contexto is None:
-                    indice_contexto = len(self.mem_contextos) - 1
+                # Mutación: resolver primero el entorno real que posee la variable.
+                entorno_objetivo = self._entorno_variable_desde_actual(nombre)
+                indice_contexto = self._indice_entorno(entorno_objetivo)
 
-                # Liberar/reasignar en el contexto real (no forzar el actual).
-                self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
-                indice = self.solicitar_memoria(1)
-                self.mem_contextos[indice_contexto][nombre] = (indice, 1)
+                # Solo registrar memoria si el entorno vive en la pila activa.
+                if indice_contexto is not None:
+                    self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
+                    indice = self.solicitar_memoria(1)
+                    self.mem_contextos[indice_contexto][nombre] = (indice, 1)
+
                 self.contextos[-1].set(nombre, valor)
         return valor
 

--- a/tests/unit/test_interpreter_scope_contract.py
+++ b/tests/unit/test_interpreter_scope_contract.py
@@ -373,3 +373,31 @@ def test_interpreter_control_flow_sin_copy_ni_clonado_en_bloques_y_bucles() -> N
 
     assert "copy(" not in agregado
     assert "deepcopy(" not in agregado
+
+def test_closure_escapado_no_corrompe_memoria_global_homonima() -> None:
+    inter = InterpretadorCobra()
+
+    global_env = inter.contextos[0]
+    global_env.define("x", 999)
+    inter.mem_contextos[0]["x"] = (10, 1)
+
+    capturado = Environment(values={"x": 1}, parent=None)
+    closure_local = Environment(parent=capturado)
+
+    inter.contextos.append(closure_local)
+    inter.mem_contextos.append({})
+
+    liberaciones: list[tuple[int, int]] = []
+    inter.liberar_memoria = lambda idx, tam: liberaciones.append((idx, tam))
+
+    with patch.object(
+        InterpretadorCobra,
+        "_asegurar_no_autorreferencia_asignacion",
+        return_value=None,
+    ):
+        inter.ejecutar_asignacion(NodoAsignacion("x", NodoValor(2)))
+
+    assert capturado.get("x") == 2
+    assert global_env.get("x") == 999
+    assert inter.mem_contextos[0]["x"] == (10, 1)
+    assert liberaciones == []


### PR DESCRIPTION
### Motivation
- Fix a bug where mutating a captured variable could free/reassign memory for a different visible variable because bookkeeping used a name-based lookup on the active stack instead of the actual owning environment. 
- Ensure that `set` semantics for closures remain (mutate the captured environment) while keeping `mem_contextos` consistent and not corrupting unrelated state.

### Description
- Add `_entorno_variable_desde_actual` to resolve the real owning `Environment` by following the runtime `parent` chain, and `_indice_entorno` to map an `Environment` to its index in `self.contextos` by identity. 
- Update `InterpretadorCobra.ejecutar_asignacion` so mutations resolve the owning environment first and only free/reassign `mem_contextos` when that environment is still on the active stack. 
- Preserve `self.contextos[-1].set(...)` so captured-variable mutation behavior is unchanged even when the owning environment is detached. 
- Add a regression test `test_closure_escapado_no_corrompe_memoria_global_homonima` reproducing the escaped-closure/global homonym case and asserting that captured mutation does not touch global memory entries.

### Testing
- Ran the scoped tests with `pytest -q tests/unit/test_interpreter_scope_contract.py -k "closure_escapado_no_corrompe_memoria_global_homonima or closure_mutacion_reasigna_en_padre_y_persiste_tras_salir or mientras_reasigna_memoria_en_entorno_real_y_persiste_fuera"`, result: `3 passed, 12 deselected`.
- The added regression asserts that captured `x` is updated, the global `x` value and its `mem_contextos` entry remain unchanged, and no unrelated memory frees occurred (test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a1e531a48327867d2e330c757525)