### PR TITLE
Restore compat-marker exemptions in import-resolution lint

### DIFF
--- a/scripts/ci/lint_import_resolution_contract.py
+++ b/scripts/ci/lint_import_resolution_contract.py
@@ -100,6 +100,10 @@ def find_violations(root: Path = ROOT) -> list[str]:
                         )
                 continue
 
+            if has_compat_marker:
+                # Módulos de compatibilidad explícita fuera de rutas shim permanecen exentos.
+                continue
+
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
             visitor = LegacyImportVisitor()
             visitor.visit(tree)


### PR DESCRIPTION
### Motivation

- Fix a regression where modules outside the shim directories that declare the compatibility marker were being flagged as legacy imports, which broke the existing contract validated by tests.

### Description

- Updated `scripts/ci/lint_import_resolution_contract.py` to skip legacy-import checks for any file that contains the header marker `# pcobra-compat: allow-legacy-imports` by adding an early `if has_compat_marker: continue` branch.
- Preserved strict enforcement for shim directories (`src/cobra/**`, `src/core/**`, `src/bindings/**`) so those paths still require the compat marker and `src/bindings/**` still requires visible deprecation hints.

### Testing

- Ran `pytest -q tests/unit/test_ci_lint_import_resolution_contract.py` and the suite passed with `3 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f44993f75c8327a8cff8719561fc33)