### PR TITLE
[PR #2117 follow-up] Remove known-failing parity suite from blocking runtime gate

### DIFF
--- a/.github/workflows/runtime-stabilization-contract.yml
+++ b/.github/workflows/runtime-stabilization-contract.yml
@@ -39,7 +39,6 @@ jobs:
             tests/unit/test_cli_execution_pipeline_contract.py::test_contrato_salida_y_error_iguales_entre_execute_e_interactive \
             tests/unit/test_cli_execution_pipeline_contract.py::test_paridad_repl_script_mientras_con_mutacion_persistente_mismo_entorno \
             tests/unit/test_cli_execution_pipeline_contract.py::test_contrato_repl_igual_script_estado_final_con_bucles_y_asignaciones \
-            tests/unit/test_parity_contract_run_vs_repl.py \
             tests/unit/test_interpreter_loop_scope_regression.py \
             tests/test_lexer.py \
             tests/unit/test_lark_parser_tokens.py \


### PR DESCRIPTION
### Motivation
- The newly added parity suite `tests/unit/test_parity_contract_run_vs_repl.py` is failing and was included in the blocking `runtime-stabilization-contract` workflow, causing CI to be red-by-construction; it must be excluded from the blocking battery until parity divergences are fixed.

### Description
- Removed `tests/unit/test_parity_contract_run_vs_repl.py` from the pytest invocation in `.github/workflows/runtime-stabilization-contract.yml` and committed the change with message `ci: remove failing parity suite from blocking contract workflow`, without modifying runtime or production code.

### Testing
- No automated unit tests were executed for this CI-only change; the update was validated by inspecting the updated workflow file with `nl -ba .github/workflows/runtime-stabilization-contract.yml | sed -n '28,70p'` and committing the patch successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4515783d48327a893970082e928eb)