### PR TITLE
Fix import-cycle baseline regression after ast_cache decoupling (follow-up to #2122)

### DIFF
--- a/scripts/ci/check_import_cycles.py
+++ b/scripts/ci/check_import_cycles.py
@@ -31,14 +31,9 @@ KNOWN_CYCLE_BASELINES: tuple[frozenset[str], ...] = (
     frozenset(
         {
             "pcobra.cobra.core.lark_parser",
-            "pcobra.cobra.core.lexer",
             "pcobra.cobra.core.parser",
-            "pcobra.core.ast_cache",
-            "pcobra.core.ast_nodes",
-            "pcobra.core.lexer",
-            "pcobra.core.parser",
         }
-    ),  # SCC histórica heredada entre parser/lexer legacy+unificado
+    ),  # ciclo legado acotado entre parser y lark_parser
 )
 
 


### PR DESCRIPTION
### Motivation
- The `ast_cache` refactor changed import edges and therefore the SCC shape observed by the import-cycle gate, causing the global gate to fail on the branch.
- The baseline in `KNOWN_CYCLE_BASELINES` no longer matched the actual legacy SCC and must be updated to avoid a false-negative CI failure.

### Description
- Updated `scripts/ci/check_import_cycles.py` `KNOWN_CYCLE_BASELINES` to replace the outdated multi-module historical SCC with the current 2-node legacy cycle containing `pcobra.cobra.core.parser` and `pcobra.cobra.core.lark_parser`.
- Adjusted the inline comment to reflect the baseline now represents the small legacy cycle between `parser` and `lark_parser`.
- No changes were made to runtime code paths beyond aligning the CI baseline to the refactor's resulting import graph.

### Testing
- Ran `python scripts/ci/check_import_cycles.py` and it exits 0 (pass) after the baseline update.
- Ran `python scripts/ci/check_core_scc.py` and it exits 0 (pass) confirming no SCCs > 1 in `src/pcobra/core`.
- Observed the prior failing run of `python scripts/ci/check_import_cycles.py` exit 1 on the branch before the baseline update, demonstrating the regression was caused by the baseline mismatch and is now resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4548186c48327944d3c45693d4a23)