### PR TITLE
[PR #2128 follow-up] Fix Python standard import path for transpiled output

### DIFF
--- a/src/pcobra/cobra/transpilers/common/utils.py
+++ b/src/pcobra/cobra/transpilers/common/utils.py
@@ -62,7 +62,7 @@ class BaseTranspiler(NodeVisitor, ABC):
 
 STANDARD_IMPORTS = {
     "python": (
-        "from pcobra.cobra.core.nativos import *\n"
+        "from pcobra.core.nativos import *\n"
         "import pcobra.corelibs as _pcobra_corelibs\n"
         "import pcobra.standard_library as _pcobra_standard_library\n"
         "globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})\n"


### PR DESCRIPTION
### Motivation

- Transpiled Python programs were emitting `from pcobra.cobra.core.nativos import *`, but the `pcobra.cobra.core.nativos` package does not exist in the repository and would cause `ModuleNotFoundError` at startup.

### Description

- Updated `STANDARD_IMPORTS["python"]` in `src/pcobra/cobra/transpilers/common/utils.py` to emit `from pcobra.core.nativos import *` so generated Python headers reference the existing package path.

### Testing

- Ran `python scripts/ci/lint_no_legacy_cobra_core_imports.py` and it passed with no violations.
- Performed a smoke check by printing the first line of `STANDARD_IMPORTS['python']` and verified it is `from pcobra.core.nativos import *`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f45c9d767883278076e746e5eb16d6)