### PR TITLE
Fix runtime regression in `del` after entorno helper refactor

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1116,7 +1116,8 @@ class InterpretadorCobra:
                     f"se recibió: {type(nodo.objetivo).__name__}"
                 )
             nombre = nodo.objetivo.nombre
-            indice_contexto = self._indice_entorno_variable(nombre)
+            entorno_variable = self._entorno_variable_desde_actual(nombre)
+            indice_contexto = self._indice_entorno(entorno_variable)
             self.contextos[-1].delete(nombre)
             if indice_contexto is not None:
                 self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)


### PR DESCRIPTION
### Motivation
- Fix a runtime regression where `NodoDel` still called the removed helper and raised `AttributeError`, and ensure memory bookkeeping remains correct when deleting variables resolved through the lexical parent chain.

### Description
- Replace the removed `_indice_entorno_variable(nombre)` call with resolving the owning environment via `_entorno_variable_desde_actual(nombre)` and mapping it to an active index with `_indice_entorno(entorno_variable)` in `InterpretadorCobra.ejecutar_nodo` (`NodoDel` branch) so deletion and memory cleanup only run when the owning environment is on the active stack.

### Testing
- Ran `pytest -q tests/unit/test_interpreter.py -k 'del'` with result: `4 passed, 15 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f45d7a160c8327b5ac81704628b2a9)