### PR TITLE
Restaurar carga de entrypoints de plugins en la fachada CLI

### DIFF
--- a/src/pcobra/cobra/cli/transpiler_registry.py
+++ b/src/pcobra/cobra/cli/transpiler_registry.py
@@ -43,6 +43,7 @@ def cli_ensure_entrypoint_transpilers_loaded_once() -> None:
 
 def cli_plugin_transpilers() -> Mapping[str, type]:
     """Devuelve el mapping de transpiladores registrados por plugins."""
+    ensure_entrypoint_transpilers_loaded_once()
     return plugin_transpilers()
 
 


### PR DESCRIPTION
### Motivation
- Corregir una regresión donde `cli_plugin_transpilers()` devolvía `plugin_transpilers()` directamente sin forzar la carga de entrypoints por proceso, lo que provocaba que procesos hijos (con `spawn`) no vieran los plugins y se degradaran silenciosamente al transpilador oficial.

### Description
- Añadida una llamada a `ensure_entrypoint_transpilers_loaded_once()` en `cli_plugin_transpilers()` en `src/pcobra/cobra/cli/transpiler_registry.py` para restaurar la carga idempotente de entrypoints por proceso.

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_transpiler_registry_contract.py tests/unit/test_cli_compilar_tipos.py` y ambos pasaron (`5 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f45e8d43208327932b3b7489218244)