### PR TITLE
Fix REPL extra-validator reuse in canonical pipeline

### DIFF
--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -215,7 +215,12 @@ def normalizar_opciones_pipeline(
     """Punto único para normalizar safe_mode y extra_validators del pipeline."""
 
     safe_mode_normalizado = bool(safe_mode)
-    extra_validators_normalizados = normalizar_validadores_extra(extra_validators)
+    extra_validators_normalizados = extra_validators
+    if not (
+        isinstance(extra_validators, list)
+        and all(isinstance(validador, ValidadorBase) for validador in extra_validators)
+    ):
+        extra_validators_normalizados = normalizar_validadores_extra(extra_validators)
     validadores_resueltos = resolver_validadores_seguridad(
         extra_validators_normalizados,
         interpretador_cls=interpretador_cls,

--- a/tests/unit/test_execution_pipeline_normalization.py
+++ b/tests/unit/test_execution_pipeline_normalization.py
@@ -1,0 +1,25 @@
+from pcobra.cobra.cli.execution_pipeline import normalizar_opciones_pipeline
+from pcobra.cobra.core.runtime import ValidadorBase
+
+
+class DummyValidator(ValidadorBase):
+    pass
+
+
+class DummyInterp:
+    @staticmethod
+    def _cargar_validadores(_ruta):
+        raise AssertionError("No debería cargar rutas al recibir validadores ya resueltos")
+
+
+def test_normalizar_opciones_pipeline_reutiliza_validadores_ya_resueltos():
+    validator = DummyValidator()
+
+    opciones = normalizar_opciones_pipeline(
+        safe_mode=True,
+        extra_validators=[validator],
+        interpretador_cls=DummyInterp,
+    )
+
+    assert opciones.safe_mode is True
+    assert opciones.validadores_extra == [validator]


### PR DESCRIPTION
### Motivation

- Fix a regression where REPL-stored validator instances were being re-normalized as file paths and caused a `TypeError`, breaking sessions started with `--extra-validators`.
- Ensure the canonical pipeline preserves already-resolved validator objects while keeping existing normalization for path-based inputs.

### Description

- Update `normalizar_opciones_pipeline` in `src/pcobra/cobra/cli/execution_pipeline.py` to skip calling `normalizar_validadores_extra` when `extra_validators` is already a `list` of `ValidadorBase` instances.
- Keep the existing resolution path via `resolver_validadores_seguridad` for `str`/`Path` and iterable-of-paths inputs so path-based loading is unchanged.
- Add `tests/unit/test_execution_pipeline_normalization.py` to assert that pre-resolved validators are reused and not reloaded.

### Testing

- Ran `pytest -q tests/unit/test_execution_pipeline_normalization.py` together with `tests/unit/test_cli_execution_pipeline_contract.py::test_contrato_resultado_igual_entre_modo_archivo_y_interactivo` and `tests/unit/test_cli_execution_pipeline_contract.py::test_contrato_salida_y_error_iguales_entre_execute_e_interactive` using `python -m pytest -q`, and the run reported `5 passed`.
- All automated tests executed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f45f6447b083278756d93f98600a4d)