### PR TITLE
fix: preservar SCCs entre scopes en auditoría de imports sobre PR #2137

### DIFF
--- a/scripts/ci/check_import_cycles.py
+++ b/scripts/ci/check_import_cycles.py
@@ -226,22 +226,26 @@ def _scc_components(graph: dict[str, set[str]]) -> list[set[str]]:
     return components
 
 
-def _scope_graph(graph: dict[str, set[str]], scope_prefix: str) -> dict[str, set[str]]:
-    scoped_nodes = {
+def _scope_nodes(graph: dict[str, set[str]], scope_prefix: str) -> set[str]:
+    return {
         module for module in graph if module == scope_prefix or module.startswith(f"{scope_prefix}.")
     }
-    return {
-        module: {target for target in targets if target in scoped_nodes}
-        for module, targets in graph.items()
-        if module in scoped_nodes
-    }
+
+
+def _scope_graph(graph: dict[str, set[str]], scope_prefix: str) -> dict[str, set[str]]:
+    scoped_nodes = _scope_nodes(graph, scope_prefix)
+    return {module: set(targets) for module, targets in graph.items() if module in scoped_nodes}
 
 
 def find_scope_cycle_components(
     graph: dict[str, set[str]], scope_prefix: str
 ) -> tuple[list[set[str]], list[set[str]], list[set[str]]]:
-    scoped = _scope_graph(graph, scope_prefix)
-    cyclic_components = [component for component in _scc_components(scoped) if len(component) > 1]
+    scoped_nodes = _scope_nodes(graph, scope_prefix)
+    cyclic_components = [
+        component
+        for component in _scc_components(graph)
+        if len(component) > 1 and component & scoped_nodes
+    ]
     allowed_baseline = set(ALLOWED_SCOPE_SCCS.get(scope_prefix, ()))
     forbidden_baseline = set(FORBIDDEN_SCOPE_SCCS.get(scope_prefix, ()))
     allowed = [component for component in cyclic_components if frozenset(component) in allowed_baseline]

--- a/tests/unit/test_ci_check_import_cycles.py
+++ b/tests/unit/test_ci_check_import_cycles.py
@@ -35,6 +35,21 @@ def test_detecta_ciclo_en_grafo(tmp_path: Path) -> None:
     assert "pcobra.cobra.cli.c" in report
 
 
+
+
+def test_detecta_scc_que_cruza_scopes_auditados(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    _write(src / "pcobra" / "cobra" / "cli" / "a.py", "import pcobra.cobra.transpilers.b\n")
+    _write(src / "pcobra" / "cobra" / "transpilers" / "b.py", "import pcobra.cobra.cli.a\n")
+
+    graph = build_import_graph(src)
+    _, _, cli_cycles = find_scope_cycle_components(graph, "pcobra.cobra.cli")
+    _, _, transpiler_cycles = find_scope_cycle_components(graph, "pcobra.cobra.transpilers")
+
+    expected = {"pcobra.cobra.cli.a", "pcobra.cobra.transpilers.b"}
+    assert any(component == expected for component in cli_cycles)
+    assert any(component == expected for component in transpiler_cycles)
+
 def test_detecta_violaciones_de_capas(tmp_path: Path) -> None:
     src = tmp_path / "src"
     _write(


### PR DESCRIPTION
### Motivation
- Corregir una regresión en la auditoría de SCCs que perdía ciclos que cruzan ámbitos auditados (p. ej. `pcobra.cobra.cli` ↔ `pcobra.cobra.transpilers`).
- Evitar falsos negativos en el gate de imports que permitían pasar cambios que introducen ciclos distribuidos entre scopes.

### Description
- Añadido `_scope_nodes` y ajustado `_scope_graph` para no recortar aristas salientes de módulos scopeados y así mantener conectividad para reporting.
- `find_scope_cycle_components` ahora calcula los SCCs sobre el grafo global y filtra componentes que intersectan el scope auditado en lugar de construir SCCs sobre un subgrafo recortado.
- Añadida prueba de regresión `test_detecta_scc_que_cruza_scopes_auditados` en `tests/unit/test_ci_check_import_cycles.py` que valida detección de un SCC compartido entre `pcobra.cobra.cli` y `pcobra.cobra.transpilers`.

### Testing
- Ejecutado `python -m pytest -q tests/unit/test_ci_check_import_cycles.py` y la suite completó correctamente con todos los tests pasando (`6 passed`).
- Las modificaciones fueron verificadas ejecutando el chequeo localmente con el script afectado y no se detectaron fallos automáticos tras los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46084304c832792e06b66c855e6bd)