### PR TITLE
Restore legacy implicit first-assignment behavior in global scope

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1172,7 +1172,16 @@ class InterpretadorCobra:
             else:
                 indice_contexto = self._indice_entorno_variable(nombre)
                 if indice_contexto is None:
-                    raise NameError(f"Variable no declarada: {nombre}")
+                    # Compatibilidad hacia atrás: preservar la creación
+                    # implícita en la primera asignación global para
+                    # flujos legacy que construyen NodoAsignacion directo.
+                    indice_contexto = len(self.mem_contextos) - 1
+                    if indice_contexto != 0:
+                        raise NameError(f"Variable no declarada: {nombre}")
+                    self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
+                    indice = self.solicitar_memoria(1)
+                    self.mem_contextos[indice_contexto][nombre] = (indice, 1)
+                    self.contextos[-1].define(nombre, valor)
                 else:
                     # Mutación sobre una variable existente: ``set`` solo
                     # actualiza en el scope donde ya está declarada.


### PR DESCRIPTION
### Motivation
- Fix a regression where non-declarative first assignments constructed via `NodoAsignacion` raised `NameError`, breaking legacy runtime flows (generators and thread setup) that relied on implicit global creation. 
- Preserve the stricter scope contract introduced for mutative `set` assignments while restoring minimal backward compatibility for initial global setup.

### Description
- Updated `InterpretadorCobra.ejecutar_asignacion` in `src/pcobra/core/interpreter.py` to allow implicit creation only when the missing variable is being assigned in the global context (when `len(self.mem_contextos) - 1 == 0`).
- When the variable is missing and the current memory context is not global, the interpreter still raises `NameError` as intended; when missing in global, it allocates memory and calls `define` to create the variable as before.
- Kept existing mutation path intact: when a variable exists in some enclosing context, the code continues to update memory bookkeeping and call `set` on the context where it is declared.
- Applied the change in-place and committed the fix to the branch used for the follow-up PR.

### Testing
- Ran `pytest -q tests/unit/test_generadores.py::test_generador_limpia_contexto_exactamente_una_vez_en_finally` after the fix: passed.
- Ran `pytest -q tests/unit/test_interpreter_concurrency.py::test_hilos_preservan_variables_globales_concurrentes` after the fix: failed (global `contador` mutated to non-zero values; assertion expecting `0` failed).
- Ran `pytest -q tests/unit/test_hilos.py::test_hilos_preservan_variables_globales` after the fix: failed (same concurrent/global mutation expectation failure).
- The patch addresses the P1 `NameError` regression for implicit first assignment in legacy global setup but additional failures in concurrency tests remain to investigate separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f461aa924c83278d084688c72c3b65)