### PR TITLE
Follow-up: isolate bare assignment mutations in nested scopes

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1183,12 +1183,21 @@ class InterpretadorCobra:
                     self.mem_contextos[indice_contexto][nombre] = (indice, 1)
                     self.contextos[-1].define(nombre, valor)
                 else:
-                    # Mutación sobre una variable existente: ``set`` solo
-                    # actualiza en el scope donde ya está declarada.
-                    self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
-                    indice = self.solicitar_memoria(1)
-                    self.mem_contextos[indice_contexto][nombre] = (indice, 1)
-                    self.contextos[-1].set(nombre, valor)
+                    indice_actual = len(self.mem_contextos) - 1
+                    if indice_contexto == indice_actual:
+                        # Mutación local: se mantiene en el scope actual.
+                        self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
+                        indice = self.solicitar_memoria(1)
+                        self.mem_contextos[indice_contexto][nombre] = (indice, 1)
+                        self.contextos[indice_contexto].set(nombre, valor)
+                    else:
+                        # Aislamiento de scope para asignación desnuda en
+                        # contextos anidados (funciones/hilos): se crea una
+                        # variable local y no se muta el entorno externo.
+                        self._liberar_memoria_variable_en_contexto(nombre, indice_actual)
+                        indice = self.solicitar_memoria(1)
+                        self.mem_contextos[indice_actual][nombre] = (indice, 1)
+                        self.contextos[indice_actual].define(nombre, valor)
         return valor
 
     def evaluar_expresion(self, expresion, visitados=None):


### PR DESCRIPTION
### Motivation
- Prevent cross-thread/global-state mutation caused by the legacy implicit-global first-assignment compatibility path.
- Restore scope isolation so bare assignments inside functions/threads do not overwrite outer/global bindings once a global has been created.
- Preserve backward compatibility for implicit global creation only at top-level while keeping strict `NameError` behavior for missing non-global bare assignments.

### Description
- Modified `InterpretadorCobra.ejecutar_asignacion` to check where a name is declared and branch by context: if the declaration is in the current context, perform a local `set`, otherwise create a new local binding in the current context instead of mutating the outer scope. 
- Kept the implicit-first-assignment compatibility path that allocates and `define`s a missing name only when executing at global scope. 
- Adjusted memory bookkeeping to free and allocate memory in the correct context (`_liberar_memoria_variable_en_contexto` and `solicitar_memoria`) and to use `define`/`set` on the appropriate `Environment` instance so nested contexts remain isolated.

### Testing
- Ran `pytest -q tests/unit/test_hilos.py::test_hilos_preservan_variables_globales`, `pytest -q tests/unit/test_interpreter_concurrency.py::test_hilos_preservan_variables_globales_concurrentes`, and `pytest -q tests/unit/test_generadores.py::test_generador_limpia_contexto_exactamente_una_vez_en_finally`. 
- All three tests passed in this environment (`3 passed, 1 warning`) and confirmed that bare assignments no longer leak mutations into global state while preserving legacy global creation semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f462f8de1c8327bcfe61b24f71b4dd)