### PR TITLE
Preserve validator paths when building sandbox script for run and REPL

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -780,6 +780,7 @@ class InteractiveCommand(BaseCommand):
             module_name=__name__,
             default_cls=type(self.interpretador),
         )
+        extra_validators_script = self._extra_validators_repl
         setup, _ = ejecutar_pipeline_explicito(
             PipelineInput(
                 codigo="",
@@ -798,7 +799,7 @@ class InteractiveCommand(BaseCommand):
         script = construir_script_sandbox_canonico(
             linea,
             safe_mode=setup.safe_mode,
-            extra_validators=setup.validadores_extra,
+            extra_validators=extra_validators_script,
             imprimir_resultado=True,
         )
 

--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -180,7 +180,7 @@ class RunService:
         script = construir_script_sandbox_canonico(
             codigo,
             safe_mode=setup.safe_mode,
-            extra_validators=setup.validadores_extra,
+            extra_validators=extra_validators,
         )
 
         try:

--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -392,5 +392,5 @@ def test_sandbox_normaliza_safe_mode_y_validadores_igual_en_run_y_repl(monkeypat
     assert rc == 0
     assert len(capturas) == 2
     assert capturas[0][1] is True and capturas[1][1] is True
-    assert [getattr(v, "origen", None) for v in capturas[0][2]] == ["uno.py", "dos.py"]
-    assert [getattr(v, "origen", None) for v in capturas[1][2]] == ["uno.py", "dos.py"]
+    assert capturas[0][2] == ["uno.py", "dos.py"]
+    assert capturas[1][2] == ["uno.py", "dos.py"]


### PR DESCRIPTION
### Motivation
- Sandbox script builder serializes `extra_validators` via `repr`, so passing resolved validator instances can produce invalid Python source like `<... object at ...>` and break sandbox execution before user code runs. 
- The run and REPL flows previously passed normalized validator instances into the script builder, causing the failure when `--extra-validators` were provided as file paths. 
- The intent is to preserve the original validator path inputs when generating the sandbox script while still using the normalized `safe_mode` from the pipeline setup to keep run/interactive parity.

### Description
- `RunService.ejecutar_en_sandbox` now passes the original `extra_validators` argument into `construir_script_sandbox_canonico` instead of `setup.validadores_extra` to avoid serializing validator objects. 
- `InteractiveCommand._ejecutar_en_sandbox` captures the pre-normalized validator input in `extra_validators_script` and uses it for script generation so REPL matches `run` behavior. 
- Updated `tests/integration/test_run_repl_equivalence.py` to assert the sandbox script builder receives validator path lists (`["uno.py", "dos.py"]`) for both run and REPL cases.

### Testing
- Ran the integration test file with `pytest -q tests/integration/test_run_repl_equivalence.py`. 
- Result: all tests in that file passed (`12 passed`, `1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f465ace7ac8327907431dc067e5006)