### PR TITLE
Follow-up: restore command-level SQLITE_DB_KEY enforcement in CLI bootstrap

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -187,11 +187,6 @@ def configurar_entorno() -> None:
             logger.exception("Error inesperado al cargar variables de entorno")
             raise
 
-    if not (os.environ.get("SQLITE_DB_KEY") or "").strip():
-        raise RuntimeError(
-            "Falta SQLITE_DB_KEY en el entorno. Defínela en .env o en variables de entorno antes de ejecutar la CLI."
-        )
-
     os.environ.setdefault("COBRA_DB_PATH", _DEFAULT_DB_PATH)
 
 
@@ -247,13 +242,7 @@ def main(argumentos: Optional[List[str]] = None) -> int:
 
     from .cobra.cli.cli import CliApplication
 
-    try:
-        configurar_entorno()
-    except RuntimeError as exc:
-        if debug:
-            raise
-        logger.error("%s", exc)
-        return 1
+    configurar_entorno()
     aplicacion = CliApplication()
     return aplicacion.run(argv)
 

--- a/tests/unit/test_cli_configurar_entorno.py
+++ b/tests/unit/test_cli_configurar_entorno.py
@@ -155,21 +155,6 @@ def test_main_reconfigura_consola_antes_de_logging_y_cli(monkeypatch):
     assert "cli" in orden
 
 
-def test_main_devuelve_exit_code_1_si_falla_configuracion_entorno(monkeypatch, caplog):
-    monkeypatch.setattr(cli, "configure_encoding", lambda: None)
-    monkeypatch.setattr(cli, "_bootstrap_dev_path_si_opt_in", lambda: None)
-    monkeypatch.setattr(cli, "configure_logging", lambda debug: None)
-    monkeypatch.setattr(
-        cli,
-        "configurar_entorno",
-        lambda: (_ for _ in ()).throw(RuntimeError("Falta SQLITE_DB_KEY en el entorno")),
-    )
-
-    caplog.set_level(logging.ERROR, logger="pcobra.cli")
-    assert cli.main(["comando-ficticio"]) == 1
-    assert "Falta SQLITE_DB_KEY en el entorno" in caplog.text
-
-
 def test_smoke_cli_unicode_salida_bytes_utf8():
     env = os.environ.copy()
     env.pop("PYTHONIOENCODING", None)

--- a/tests/unit/test_cli_env_bootstrap.py
+++ b/tests/unit/test_cli_env_bootstrap.py
@@ -38,19 +38,6 @@ def test_configurar_entorno_autocrea_env_desde_example(tmp_path, monkeypatch, ca
     assert "COBRA_DB_PATH" in cli.os.environ
 
 
-def test_configurar_entorno_falla_si_falta_sqlite_db_key(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.delenv("SQLITE_DB_KEY", raising=False)
-
-    monkeypatch.setattr(cli, "load_dotenv", lambda **_kwargs: False)
-
-    try:
-        cli.configurar_entorno()
-        raise AssertionError("Se esperaba RuntimeError cuando falta SQLITE_DB_KEY")
-    except RuntimeError as exc:
-        assert "Falta SQLITE_DB_KEY" in str(exc)
-
-
 def test_configurar_entorno_setea_db_path_por_default_con_sqlite_db_key(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("SQLITE_DB_KEY", "clave-segura")


### PR DESCRIPTION
### Motivation
- The CLI previously started failing before argument parsing when `SQLITE_DB_KEY` was enforced at bootstrap time, breaking `--help`, `--version`, and commands that do not require DB access.
- Enforcement should remain selective at command execution time (the existing `CliApplication.run` / `requires_sqlite_key` policy) so bootstrap and non-DB commands behave normally.

### Description
- Removed the bootstrap-time hard failure for a missing `SQLITE_DB_KEY` from `src/pcobra/cli.py::configurar_entorno()` so it no longer raises `RuntimeError` during initial env setup. 
- Restored `main()` bootstrap flow to call `configurar_entorno()` without catching-and-exiting on that specific `RuntimeError`, allowing argument parsing and command-level enforcement to run as intended. 
- Kept `.env` loading and `COBRA_DB_PATH` defaulting behavior in place and unchanged. 
- Updated unit tests to match the restored behavior by removing assertions that expected a bootstrap failure while preserving tests that validate env-file handling and `COBRA_DB_PATH` defaulting. 

### Testing
- Ran `pytest -q tests/unit/test_cli_env_bootstrap.py tests/unit/test_cli_configurar_entorno.py` and all tests passed with the current changes: `8 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f466c0d9408327b82096cf21a2c5ec)