### PR TITLE
[PR #2151 follow-up] Enforce mode policy before running v2 repl

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+from pcobra.cobra.cli.mode_policy import validar_politica_modo
 from pcobra.cobra.core.runtime import InterpretadorCobra
 
 
@@ -20,4 +21,5 @@ class ReplCommandV2(BaseCommand):
         return self._delegate.register_subparser(subparsers)
 
     def run(self, args: Any) -> int:
+        validar_politica_modo(self.name, args, capability=self.capability)
         return self._delegate.run(args)

--- a/tests/unit/test_cli_v2_command_contract.py
+++ b/tests/unit/test_cli_v2_command_contract.py
@@ -6,6 +6,7 @@ from cobra.cli.commands_v2.run_cmd import RunCommandV2
 from cobra.cli.commands_v2.build_cmd import BuildCommandV2
 from cobra.cli.commands_v2.test_cmd import TestCommandV2
 from cobra.cli.commands_v2.legacy_cmd import LegacyCommandGroupV2
+from cobra.cli.commands_v2.repl_cmd import ReplCommandV2
 from cobra.cli.cli import LEGACY_COMMAND_MIGRATION_MAP
 from cobra.cli.target_policies import VERIFICATION_EXECUTABLE_TARGETS
 
@@ -201,6 +202,23 @@ def test_test_v2_valida_seguridad_por_ruta_binding(monkeypatch):
     assert calls[0][0] == "python" and calls[0][1]["sandbox"] is True
     assert calls[1][0] == "javascript" and calls[1][1]["containerized"] is True
     assert calls[2][0] == "rust" and calls[2][1]["containerized"] is True
+
+
+def test_repl_v2_valida_politica_modo_antes_de_delegar(monkeypatch):
+    command = ReplCommandV2()
+    called: list[tuple[str, object, str]] = []
+
+    monkeypatch.setattr(
+        "cobra.cli.commands_v2.repl_cmd.validar_politica_modo",
+        lambda cmd, args, capability: called.append((cmd, args, capability)),
+    )
+    monkeypatch.setattr(command._delegate, "run", lambda _args: 0)
+
+    args = argparse.Namespace(modo="transpilar")
+    status = command.run(args)
+
+    assert status == 0
+    assert called == [("repl", args, "execute")]
 
 
 def test_legacy_command_migration_map_cubre_comandos_legacy_principales():


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where `repl` v2 wrapper delegated to the interactive REPL without enforcing the `--modo` policy, letting users execute code even when `--modo transpilar` should block execution.

### Description
- Add `from pcobra.cobra.cli.mode_policy import validar_politica_modo` and call `validar_politica_modo(self.name, args, capability=self.capability)` at the start of `ReplCommandV2.run` in `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` to enforce the mode policy before delegation.
- Add a focused unit test `test_repl_v2_valida_politica_modo_antes_de_delegar` in `tests/unit/test_cli_v2_command_contract.py` that asserts `ReplCommandV2.run` invokes the policy validator with `("repl", args, "execute")` before delegating.

### Testing
- Ran the focused unit test with `pytest -q tests/unit/test_cli_v2_command_contract.py -k repl_v2_valida_politica_modo_antes_de_delegar` and it passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f468a0066083279cc5c3292b38a1c7)