### PR TITLE
[PR #2153 follow-up] Fix REPL v2 memory-limit handling before input loop

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -6,8 +6,8 @@ from pcobra.cobra.cli.commands.interactive_cmd import (
     SANDBOX_DOCKER_CHOICES,
 )
 from pcobra.cobra.cli.i18n import _
-from pcobra.cobra.cli.utils.messages import mostrar_info
-from pcobra.cobra.core.runtime import InterpretadorCobra
+from pcobra.cobra.cli.utils.messages import mostrar_advertencia, mostrar_error, mostrar_info
+from pcobra.cobra.core.runtime import InterpretadorCobra, limitar_memoria_mb
 from pcobra.cobra.cli.target_policies import parse_runtime_target
 from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input
 
@@ -56,6 +56,30 @@ class ReplCommandV2(BaseCommand):
         return parser
 
     def run(self, args: Any) -> int:
+        memory_limit = getattr(args, "memory_limit", self._delegate.MEMORY_LIMIT_MB)
+        ignore_memory_limit = getattr(args, "ignore_memory_limit", False)
+
+        if memory_limit <= 0:
+            mostrar_error(_("El límite de memoria debe ser positivo"))
+            return 1
+
+        try:
+            limitar_memoria_mb(memory_limit)
+        except NotImplementedError as err:
+            mostrar_advertencia(
+                _("No se pudo aplicar el límite de memoria: {err}").format(err=err)
+            )
+        except RuntimeError as err:
+            if ignore_memory_limit:
+                mostrar_advertencia(
+                    _("No se pudo aplicar el límite de memoria: {err}").format(err=err)
+                )
+            else:
+                mostrar_error(
+                    _("Error al establecer límite de memoria: {err}").format(err=err)
+                )
+                return 1
+
         buffer: list[str] = []
         self._delegate._estado_repl = self._delegate._crear_estado_repl()
 


### PR DESCRIPTION
### Motivation
- Fix a high-priority regression where `ReplCommandV2` started the input loop before enforcing `--memory-limit` / `--ignore-memory-limit`, causing those flags to be ignored.
- Restore the previous contract from `InteractiveCommand.run()` so invalid memory settings fail fast and user-requested guards are not silently dropped.

### Description
- Added imports for `limitar_memoria_mb`, `mostrar_advertencia` and `mostrar_error` and implemented memory-limit handling in `ReplCommandV2.run()` before entering the REPL loop.
- Enforced that non-positive `--memory-limit` values cause a user-facing error via `mostrar_error` and return exit status `1`.
- Applied the same `RuntimeError` / `NotImplementedError` semantics as `InteractiveCommand.run()`: show warnings when appropriate and respect `--ignore-memory-limit`; otherwise exit with `1` on failure.
- Kept the explicit REPL loop and delegation to the existing `InteractiveCommand` for parsing/execution unchanged aside from the pre-loop validation (file modified: `src/pcobra/cobra/cli/commands_v2/repl_cmd.py`).

### Testing
- Ran `python -m compileall -q src/pcobra/cobra/cli/commands_v2/repl_cmd.py` and the file compiled successfully.
- Verified basic REPL startup/exit with `printf 'exit\n' | python -m pcobra.cobra.cli.cli repl` and observed normal exit messaging.
- Verified `python -m pcobra.cobra.cli.cli repl --memory-limit -1` now fails fast with exit code `1` and emits a user-facing error about the memory limit (previously launched silently).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46c04ab248327940ba0c6c51eeeaf)