### PR TITLE
Follow-up: reset REPL v2 buffer/state after execution exceptions

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -135,6 +135,8 @@ class ReplCommandV2(BaseCommand):
             except Exception as err:
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
+                buffer.clear()
+                self._delegate._estado_repl = self._delegate._crear_estado_repl()
                 continue
 
         return 0

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -84,3 +84,38 @@ def test_repl_v2_limpia_buffer_ante_error_real(monkeypatch):
     assert status == 0
     assert parse_calls == ["algo_mal"]
     assert logged == ["Se encontró 'fin' inesperado"]
+
+
+def test_repl_v2_limpia_buffer_si_falla_ejecucion(monkeypatch):
+    command = ReplCommandV2()
+    entradas = iter(["imprimir(1)", "exit"])
+    parse_calls: list[str] = []
+    executed: list[str] = []
+    logged: list[str] = []
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+    monkeypatch.setattr(
+        "cobra.cli.commands_v2.repl_cmd.prevalidar_y_parsear_codigo",
+        lambda codigo: parse_calls.append(codigo),
+    )
+
+    def _fake_execute(codigo: str):
+        executed.append(codigo)
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(command._delegate, "ejecutar_codigo", _fake_execute)
+    monkeypatch.setattr(command._delegate, "_log_error", lambda _cat, err: logged.append(str(err)))
+
+    status = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+
+    assert status == 0
+    assert parse_calls == ["imprimir(1)"]
+    assert executed == ["imprimir(1)"]
+    assert logged == ["boom"]


### PR DESCRIPTION
### Motivation

- Corregir un bug P1 en el REPL v2 donde excepciones durante la ejecución dejaban `buffer` con código antiguo, provocando reintentos automáticos y que `exit` se tratara como código.

### Description

- En `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` se limpia `buffer` y se reinicia `_estado_repl` cuando la ejecución falla (ruta de `ejecutar_codigo`, sandbox o docker) para evitar que código obsoleto persista.
- Se añadió un test `test_repl_v2_limpia_buffer_si_falla_ejecucion` en `tests/unit/test_repl_command_v2.py` que simula una excepción en tiempo de ejecución y verifica que el buffer se limpia, el error se registra y no se reintenta el mismo snippet.
- Se mantiene la lógica previa que conserva `buffer` cuando el parseo indica un bloque incompleto mediante `prevalidar_y_parsear_codigo` y `es_error_de_bloque_incompleto`.

### Testing

- Ejecutado `pytest -q tests/unit/test_repl_command_v2.py` y todos los tests de la unidad pasaron (`4 passed`).
- El nuevo test reproduce la ruta de error de ejecución y confirma que `buffer` se borra y que el error queda logueado correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46d055ae88327939ff58bc7af5662)