### PR TITLE
fix(repl): restaurar echo de resultados en REPL v2 sobre #2155

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -144,7 +144,7 @@ class ReplCommandV2(BaseCommand):
                 elif sandbox_docker:
                     self._delegate._ejecutar_en_docker(codigo, sandbox_docker)
                 else:
-                    setup, _resultado_pipeline = ejecutar_pipeline_explicito(
+                    setup, resultado_pipeline = ejecutar_pipeline_explicito(
                         PipelineInput(
                             codigo=codigo,
                             interpretador_cls=interpretador_cls,
@@ -156,6 +156,18 @@ class ReplCommandV2(BaseCommand):
                     self._interpretador_persistente = setup.interpretador
                     self._seguro_repl = setup.safe_mode
                     self._extra_validators_repl = setup.validadores_extra
+                    ast = resultado_pipeline.ast
+                    resultado = resultado_pipeline.resultado
+                    debe_imprimir_resultado = (
+                        resultado is not None
+                        and len(ast) == 1
+                        and not self._delegate._es_nodo_control_sin_echo_repl(ast[0])
+                    )
+                    if debe_imprimir_resultado:
+                        if isinstance(resultado, bool):
+                            print("verdadero" if resultado else "falso")
+                        else:
+                            print(resultado)
                 buffer.clear()
             except Exception as err:
                 categoria = self._delegate._clasificar_error_repl(err)

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -43,9 +43,14 @@ def test_repl_v2_mantiene_buffer_hasta_parseo_valido(monkeypatch):
             self.safe_mode = safe_mode
             self.validadores_extra = validadores_extra
 
+    class _Resultado:
+        def __init__(self):
+            self.ast = []
+            self.resultado = None
+
     def _fake_pipeline(pipeline_input, **_kwargs):
         executed.append(pipeline_input.codigo)
-        return _Setup(pipeline_input.safe_mode, pipeline_input.extra_validators), None
+        return _Setup(pipeline_input.safe_mode, pipeline_input.extra_validators), _Resultado()
 
     monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.ejecutar_pipeline_explicito", _fake_pipeline)
 
@@ -110,6 +115,11 @@ def test_repl_v2_persiste_interpretador_entre_bloques(monkeypatch):
             self.safe_mode = False
             self.validadores_extra = None
 
+    class _Resultado:
+        def __init__(self):
+            self.ast = []
+            self.resultado = None
+
     def _fake_pipeline(pipeline_input, **_kwargs):
         interpretadores_recibidos.append(pipeline_input.interpretador)
         interpretador = pipeline_input.interpretador or estado
@@ -117,7 +127,7 @@ def test_repl_v2_persiste_interpretador_entre_bloques(monkeypatch):
             interpretador["x"] = 10
         if pipeline_input.codigo.strip() == "imprimir(x)":
             assert interpretador["x"] == 10
-        return _Setup(interpretador), None
+        return _Setup(interpretador), _Resultado()
 
     monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.ejecutar_pipeline_explicito", _fake_pipeline)
     monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.prevalidar_y_parsear_codigo", lambda _codigo: [])
@@ -135,3 +145,41 @@ def test_repl_v2_persiste_interpretador_entre_bloques(monkeypatch):
 
     assert status == 0
     assert interpretadores_recibidos == [None, estado]
+
+
+def test_repl_v2_imprime_resultado_de_expresion(monkeypatch, capsys):
+    command = ReplCommandV2()
+    entradas = iter(["1+2", "exit"])
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+
+    class _Setup:
+        def __init__(self):
+            self.interpretador = object()
+            self.safe_mode = True
+            self.validadores_extra = None
+
+    class _Resultado:
+        def __init__(self):
+            self.ast = [object()]
+            self.resultado = 3
+
+    monkeypatch.setattr(command._delegate, "_es_nodo_control_sin_echo_repl", lambda _nodo: False)
+    monkeypatch.setattr("cobra.cli.commands_v2.repl_cmd.prevalidar_y_parsear_codigo", lambda _codigo: [object()])
+    monkeypatch.setattr(
+        "cobra.cli.commands_v2.repl_cmd.ejecutar_pipeline_explicito",
+        lambda *_args, **_kwargs: (_Setup(), _Resultado()),
+    )
+
+    status = command.run(
+        argparse.Namespace(
+            sandbox=False,
+            sandbox_docker=None,
+            memory_limit=128,
+            ignore_memory_limit=False,
+        )
+    )
+
+    salida = capsys.readouterr().out
+    assert status == 0
+    assert "3" in salida


### PR DESCRIPTION
### Motivation
- Corregir una regresión introducida en la ruta no-sandbox del REPL v2 donde el resultado del pipeline se asignaba y no se consumía, por lo que expresiones como `1+2` no mostraban salida para el usuario.
- Mantener compatibilidad con la convención de impresión del REPL clásico, incluyendo la normalización booleana a `verdadero`/`falso`.

### Description
- En `ReplCommandV2.run` se vuelve a consumir `resultado_pipeline` devuelto por `ejecutar_pipeline_explicito` y se restaura la lógica que imprime resultados no-`None` para entradas que produzcan un solo nodo no-control, replicando el comportamiento de `InteractiveCommand.ejecutar_codigo`.
- Se preserva la actualización del intérprete persistente y los flags de seguridad/validadores leyendo `setup.interpretador`, `setup.safe_mode` y `setup.validadores_extra`.
- Se añadieron/ajustaron tests en `tests/unit/test_repl_command_v2.py` para que los dobles de `ejecutar_pipeline_explicito` devuelvan un objeto resultado con `ast` y `resultado`, y se añadió `test_repl_v2_imprime_resultado_de_expresion` que verifica que `1+2` imprime `3`.
- Archivos modificados: `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` y `tests/unit/test_repl_command_v2.py`.

### Testing
- Ejecutado `pytest -q tests/unit/test_repl_command_v2.py` y todos los tests unitarios pasaron (`5 passed`).
- Las pruebas cubren buffer/manejo de parseo, persistencia del intérprete entre ejecuciones y la impresión de resultados de expresiones en el REPL v2.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46e0495288327afe6e62f3b508589)