### PR TITLE
test: skip pexpect REPL integration tests when spawn is unavailable

### DIFF
--- a/tests/unit/test_repl_cli_integration_pexpect.py
+++ b/tests/unit/test_repl_cli_integration_pexpect.py
@@ -9,6 +9,9 @@ import pytest
 
 pexpect = pytest.importorskip("pexpect")
 
+if sys.platform == "win32" or not hasattr(pexpect, "spawn"):
+    pytest.skip("pexpect REPL integration tests require non-Windows pexpect.spawn", allow_module_level=True)
+
 
 @pytest.fixture()
 def cli_env() -> dict[str, str]:


### PR DESCRIPTION
### Motivation
- Evitar que la suite de integración REPL falle en entornos Windows o donde `pexpect` se importa pero no exporta `spawn`, lo que provocaba `AttributeError` al ejecutar las pruebas en CI.

### Description
- Añadido un guard a nivel de módulo en `tests/unit/test_repl_cli_integration_pexpect.py` que salta la colección cuando `sys.platform == "win32"` o `not hasattr(pexpect, "spawn")` usando `pytest.skip`.

### Testing
- Ejecutado: `PYTHONPATH=src pytest -q tests/unit/test_repl_cli_integration_pexpect.py`, y las pruebas del archivo pasaron (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46f1cca08832793dceb5db09966a4)