### PR TITLE
[PR #2173 follow-up] Restore legacy ParserError fallback in REPL v2

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -125,6 +125,34 @@ class ReplCommandV2(BaseCommand):
 
         return eof_por_flag or eof_por_token or posicion_eof
 
+    def _es_entrada_incompleta_por_texto(self, err: ParserError) -> bool:
+        """Fallback textual para `ParserError` legacy sin metadata estructurada."""
+        mensaje = str(err).lower()
+        if not mensaje:
+            return False
+
+        pistas_cierre = (
+            "se esperaba",
+            "expected",
+            "falt",
+            "missing",
+        )
+        pistas_objetivo = (
+            "fin",
+            "rparen",
+            "rbracket",
+            "rbrace",
+            ")",
+            "]",
+            "}",
+        )
+        menciona_eof = "eof" in mensaje or "fin de archivo" in mensaje
+
+        return (
+            any(pista in mensaje for pista in pistas_cierre)
+            and any(pista in mensaje for pista in pistas_objetivo)
+        ) or menciona_eof
+
     def es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
         """Detecta si la excepción corresponde a una entrada aún incompleta.
 
@@ -133,7 +161,7 @@ class ReplCommandV2(BaseCommand):
 
         if not isinstance(exc, ParserError):
             return False
-        return self._es_entrada_incompleta_por_metadata(exc)
+        return self._es_entrada_incompleta_por_metadata(exc) or self._es_entrada_incompleta_por_texto(exc)
 
     def register_subparser(self, subparsers: Any):
         parser = subparsers.add_parser(self.name, help=_("Start Cobra REPL"))

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -32,14 +32,14 @@ def _parser_error_con_metadata(
 @pytest.mark.parametrize(
     ("mensaje", "es_incompleto"),
     [
-        ("Se esperaba 'fin' para cerrar el bloque condicional", False),
-        ("Token inesperado en término: TipoToken.EOF", False),
-        ("Se esperaba ']' al final de la lista", False),
+        ("Se esperaba 'fin' para cerrar el bloque condicional", True),
+        ("Token inesperado en término: TipoToken.EOF", True),
+        ("Se esperaba ']' al final de la lista", True),
         ("Token inesperado: '('", False),
         ("Se encontró 'fin' inesperado", False),
     ],
 )
-def test_es_error_de_bloque_incompleto_no_depende_de_mensajes_parser(mensaje, es_incompleto):
+def test_es_error_de_bloque_incompleto_tiene_fallback_textual_legacy(mensaje, es_incompleto):
     command = ReplCommandV2()
     assert command.es_error_de_bloque_incompleto(ParserError(mensaje)) is es_incompleto
 


### PR DESCRIPTION
### Motivation

- The REPL started relying only on structured `ParserError` metadata to detect incomplete input, which breaks multiline behavior when `ClassicParser` raises plain `ParserError` messages without metadata.

### Description

- Add `_es_entrada_incompleta_por_texto` (fallback textual heuristic) in `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` to detect legacy parser messages mentioning EOF or missing closing delimiters.
- Keep metadata-first detection and change `es_error_de_bloque_incompleto` to return `metadata-based OR textual-fallback` so legacy `ParserError` instances are correctly classified as incomplete.
- Update unit expectations and test name in `tests/unit/test_repl_command_v2.py` to cover message-only `ParserError` cases (e.g., `fin`, `EOF`, `]`) while preserving negative cases.

### Testing

- Ran `pytest -q tests/unit/test_repl_command_v2.py tests/cli/test_repl_v2_pipeline_security_contract.py` and all tests passed with expected output (`35 passed, 1 warning`).
- Unit tests now verify buffer accumulation for multiline inputs, proper prompt switching, and that real syntax errors do not keep the multiline buffer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47056ccec8327a5366764db23a62f)