### PR TITLE
[PR #2180 follow-up] Fix unexpected_token fallback in REPL EOF completeness detection

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -58,6 +58,16 @@ class ReplCommandV2(BaseCommand):
 
     def _extraer_token_desde_error(self, err: ParserError) -> Any | None:
         """Obtiene el token actual desde metadatos del ``ParserError`` si existe."""
+        def _token_con_tipo_normalizable(token: Any) -> Any | None:
+            if token is None:
+                return None
+            tipo_normalizado = self._normalizar_tipo_token(
+                getattr(token, "tipo", None)
+                or getattr(token, "type", None)
+                or getattr(token, "token_type", None),
+            )
+            return token if tipo_normalizado is not None else None
+
         for attr in (
             "token_actual",
             "token",
@@ -65,12 +75,15 @@ class ReplCommandV2(BaseCommand):
             "actual_token",
             "last_token",
             "ultimo_token",
-            "unexpected_token",
         ):
             if hasattr(err, attr):
                 token = getattr(err, attr)
                 if token is not None:
                     return token
+        if hasattr(err, "unexpected_token"):
+            token = _token_con_tipo_normalizable(getattr(err, "unexpected_token"))
+            if token is not None:
+                return token
         for attr in ("estado", "state", "parser_state"):
             if hasattr(err, attr):
                 estado = getattr(err, attr)
@@ -83,11 +96,13 @@ class ReplCommandV2(BaseCommand):
                     "actual_token",
                     "last_token",
                     "ultimo_token",
-                    "unexpected_token",
                 ):
                     token = getattr(estado, token_attr, None)
                     if token is not None:
                         return token
+                token = _token_con_tipo_normalizable(getattr(estado, "unexpected_token", None))
+                if token is not None:
+                    return token
         return None
 
     def _es_entrada_incompleta_por_metadata(self, err: ParserError) -> bool:
@@ -101,7 +116,11 @@ class ReplCommandV2(BaseCommand):
         """
         token_actual = self._extraer_token_desde_error(err)
         tipo_token_actual = self._normalizar_tipo_token(
-            getattr(token_actual, "tipo", None)
+            (
+                getattr(token_actual, "tipo", None)
+                or getattr(token_actual, "type", None)
+                or getattr(token_actual, "token_type", None)
+            )
             if token_actual is not None
             else getattr(err, "tipo_token_actual", None)
             or getattr(err, "current_token_type", None)

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -210,6 +210,25 @@ def test_extrae_token_desde_unexpected_token_si_no_hay_token_actual():
     assert token.tipo == TipoToken.EOF
 
 
+def test_no_prioriza_unexpected_token_sin_tipo_y_usa_fallback_de_error():
+    command = ReplCommandV2()
+    err = ParserError("metadata inesperada sin tipo")
+    err.expected = [TipoToken.FIN]
+    err.unexpected_token = object()
+    err.current_token_type = TipoToken.EOF
+    err.unexpected_eof = True
+    assert command.es_error_de_bloque_incompleto(err) is True
+
+
+def test_extrae_unexpected_token_con_alias_type():
+    command = ReplCommandV2()
+    err = ParserError("metadata unexpected token type")
+    err.unexpected_token = type("Tok", (), {"type": TipoToken.EOF})()
+    token = command._extraer_token_desde_error(err)
+    assert token is not None
+    assert token.type == TipoToken.EOF
+
+
 def test_incompleto_bloque_simple_por_eof_inesperado_y_fin_pendiente():
     command = ReplCommandV2()
     err = _parser_error_con_metadata(


### PR DESCRIPTION
### Motivation
- Prevent regressions where an `unexpected_token` object without usable type metadata causes the REPL to misclassify EOF-incomplete input as a hard parse error and drop the multiline buffer.
- Preserve the original metadata-only classification rule (EOF unexpected + pending closing token) while improving resilience to parser token variants exposing different attribute names.

### Description
- Add a helper `_token_con_tipo_normalizable` in `ReplCommandV2._extraer_token_desde_error` to accept `unexpected_token` only when its token type can be normalized via `tipo`, `type`, or `token_type`.
- Apply the same normalized-type check when inspecting `parser_state`/`state`/`estado` for `unexpected_token` aliases so unusable objects are ignored in favor of error-level metadata.
- Extend token-type extraction in `_es_entrada_incompleta_por_metadata` to normalize token objects exposing `.type` or `.token_type` in addition to `.tipo`.
- Maintain fallback to parser-error fields like `current_token_type`, `token_type`, `actual_token_type`, and EOF flags when `unexpected_token` is not usable.

### Testing
- Added regression tests in `tests/unit/test_repl_command_v2.py` that verify an unusable `unexpected_token` does not block fallback metadata and that `unexpected_token` with a `.type` alias is extracted correctly.
- Ran `pytest -q tests/unit/test_repl_command_v2.py tests/unit/cli/commands_v2/test_repl_cmd_v2.py` with result: `50 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4715e8e58832793f1263c82cc7d41)