### PR TITLE
[PR #2187 follow-up] Fix classic ParserError handling for multiline REPL blocks

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -609,7 +609,7 @@ class InteractiveCommand(BaseCommand):
                 prevalidar_y_parsear_codigo(codigo)
                 estado["lineas_blanco_consecutivas"] = 0
             except (LexerError, ParserError) as err:
-                if self._es_error_de_bloque_incompleto(err):
+                if self._es_error_de_bloque_incompleto(err, codigo):
                     continue
                 estado["buffer_lineas"].clear()
                 estado["lineas_blanco_consecutivas"] = 0
@@ -687,7 +687,7 @@ class InteractiveCommand(BaseCommand):
         except KeyError:
             return None
 
-    def _es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
+    def _es_error_de_bloque_incompleto(self, exc: Exception, codigo: str = "") -> bool:
         """Determina si el parser reportó una entrada todavía incompleta."""
         if not isinstance(exc, ParserError):
             return False
@@ -722,13 +722,17 @@ class InteractiveCommand(BaseCommand):
             TipoToken.RBRACE,
         }
         if not (tipos_esperados & tokens_cierre):
-            return False
+            # El parser clásico no siempre publica metadata de tokens esperados.
+            # En ese caso, usamos el balance estructural del buffer como fallback.
+            return bool(codigo and self._calcular_balance_estructural(codigo) > 0)
 
         eof_por_flag = bool(
             getattr(exc, "unexpected_eof", False)
             or getattr(exc, "eof", False)
             or getattr(exc, "es_eof", False)
             or getattr(exc, "is_eof", False)
+            or getattr(exc, "is_unexpected_eof", False)
+            or getattr(exc, "unexpected_end_of_input", False)
         )
         return eof_por_flag or tipo_token_actual == TipoToken.EOF
 

--- a/tests/cli/test_repl_error_recovery_contract.py
+++ b/tests/cli/test_repl_error_recovery_contract.py
@@ -108,3 +108,37 @@ def test_repl_error_runtime_no_cierra_sesion_y_permite_recuperacion(monkeypatch)
     assert any("fallo de runtime controlado" in msg for msg in errores)
     assert cmd._estado_repl["nivel_bloque"] == 0
     assert cmd._estado_repl["buffer_lineas"] == []
+
+
+@pytest.mark.integration
+def test_repl_parser_error_clasico_sin_metadata_conserva_buffer(monkeypatch):
+    cmd = InteractiveCommand(MagicMock())
+    entradas = iter(["si 1 == 1 :", 'imprimir("ok")', "fin", "salir"])
+
+    def _leer_linea(_prompt: str) -> str:
+        return next(entradas)
+
+    ejecutar_spy = MagicMock()
+    monkeypatch.setattr(cmd, "ejecutar_codigo", ejecutar_spy)
+
+    def _prevalidar(codigo: str):
+        if codigo.startswith("si 1 == 1 :") and not codigo.rstrip().endswith("fin"):
+            from pcobra.cobra.core import ParserError
+
+            raise ParserError("Se esperaba 'fin' para cerrar el bloque condicional")
+        return None
+
+    monkeypatch.setattr(
+        "pcobra.cobra.cli.commands.interactive_cmd.prevalidar_y_parsear_codigo",
+        _prevalidar,
+    )
+
+    cmd._run_repl_loop(
+        args=SimpleNamespace(),
+        validador=None,
+        leer_linea=_leer_linea,
+        sandbox=False,
+        sandbox_docker=None,
+    )
+
+    ejecutar_spy.assert_called_once_with('si 1 == 1 :\nimprimir("ok")\nfin', None)


### PR DESCRIPTION
### Motivation
- Fix a high-priority regression where the REPL cleared the input buffer when the classic `ParserError` was raised without metadata, breaking multiline block execution.
- Make incomplete-block detection robust across parser implementations by considering the current buffered code when parser metadata is absent.

### Description
- Updated `InteractiveCommand._run_repl_loop` to pass the buffered `codigo` into the incomplete-block detector call to provide parsing context to the classifier.
- Changed `_es_error_de_bloque_incompleto` signature to `(..., codigo: str = "")` and added a fallback for classic `ParserError` instances that lack `esperado`/expected-token metadata by using structural balance via `_calcular_balance_estructural(codigo) > 0`.
- Extended EOF-flag detection to accept extra flag names (`is_unexpected_eof`, `unexpected_end_of_input`) for compatibility with alternate parsers.
- Added an integration test `test_repl_parser_error_clasico_sin_metadata_conserva_buffer` in `tests/cli/test_repl_error_recovery_contract.py` that simulates a bare `ParserError` and verifies the REPL preserves the buffer until `fin` is provided.

### Testing
- Ran `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py tests/cli/test_repl_error_recovery_contract.py` and compilation succeeded.
- Ran `pytest -q tests/cli/test_repl_error_recovery_contract.py -q` which initially produced 4 failures unrelated to the change (prompt text and error-message expectations), indicating existing contract differences in that test file.
- Ran the targeted test `pytest -q tests/cli/test_repl_error_recovery_contract.py -k parser_error_clasico_sin_metadata_conserva_buffer` which passed, confirming the fix preserves buffer behavior for classic `ParserError` without metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f472633ed48327b56f4d6e811e4890)