### PR TITLE
[PR #2192 follow-up] fix(cli): preservar fallback de tipo de token con token opaco

### DIFF
--- a/src/pcobra/cobra/cli/utils/parser_error_classifier.py
+++ b/src/pcobra/cobra/cli/utils/parser_error_classifier.py
@@ -80,10 +80,11 @@ def _es_entrada_incompleta_por_metadata(err: ParserError) -> bool | None:
     """
 
     token_actual = _extraer_token_desde_error(err)
-    tipo_token_actual = _normalizar_tipo_token(
-        getattr(token_actual, "tipo", None)
-        if token_actual is not None
-        else getattr(err, "tipo_token_actual", None)
+    tipo_token_desde_token = _normalizar_tipo_token(
+        getattr(token_actual, "tipo", None) if token_actual is not None else None
+    )
+    tipo_token_actual = tipo_token_desde_token or _normalizar_tipo_token(
+        getattr(err, "tipo_token_actual", None)
         or getattr(err, "current_token_type", None)
         or getattr(err, "actual_token_type", None)
         or getattr(err, "token_type", None)

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -171,6 +171,15 @@ def test_es_error_de_bloque_incompleto_prioriza_metadata(err, es_incompleto):
         (
             {
                 "expected": [TipoToken.FIN],
+                "token_actual": object(),
+                "token_type": TipoToken.EOF,
+                "unexpected_eof": True,
+            },
+            True,
+        ),
+        (
+            {
+                "expected": [TipoToken.FIN],
             },
             False,
         ),


### PR DESCRIPTION
### Motivation
- Corregir una regresión que hace que un `ParserError` con un `token_actual` opaco (sin atributo `tipo` útil) ignore los campos de fallback `*_token_type`, provocando que entradas incompletas se clasifiquen como errores reales y el REPL borre el buffer prematuramente.

### Description
- Ajusta `_es_entrada_incompleta_por_metadata` para primero normalizar `tipo` desde `token_actual` y luego usar los campos de fallback (`tipo_token_actual`, `current_token_type`, `token_type`, etc.) cuando el `token_actual` sea opaco o no aporte un `tipo` válido. 
- Renombra y separa la extracción del tipo en `tipo_token_desde_token` y `tipo_token_actual` para garantizar que los campos de fallback se consideren siempre que el token real no proporcione un tipo.
- Añade un caso de prueba de regresión en `tests/unit/test_repl_command_v2.py` que valida que un `token_actual` opaco más `token_type=EOF` y un token esperado de cierre se clasifiquen como entrada incompleta.

### Testing
- Compilación de módulos afectos con `python -m compileall` completada exitosamente según la verificación previa. 
- Ejecutado `pytest -q tests/unit/test_repl_command_v2.py -k "bloque_incompleto or metadata_parcial"` y todos los tests seleccionados pasaron (22 passed, 25 deselected, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47398e39483279d9763cd4263b4a3)