### PR TITLE
Reset REPL buffer/state after execution exceptions

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -180,10 +180,14 @@ class ReplCommandV2(BaseCommand):
             except (PrimitivaPeligrosaError, RuntimeError) as err:
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
+                self._reset_buffer_local(buffer)
+                self._reset_estado_delegate()
                 continue
             except Exception as err:
                 categoria = self._delegate._clasificar_error_repl(err)
                 self._delegate._log_error(categoria, err)
+                self._reset_buffer_local(buffer)
+                self._reset_estado_delegate()
                 continue
 
         return 0


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where execution-time exceptions left the multiline REPL `buffer` intact, causing subsequent input to be appended to the failing snippet and preventing normal recovery.

### Description
- In `ReplCommandV2.run` (`src/pcobra/cobra/cli/commands_v2/repl_cmd.py`) added calls to `_reset_buffer_local(buffer)` and `_reset_estado_delegate()` inside both execution exception handlers: `except (PrimitivaPeligrosaError, RuntimeError)` and the general `except Exception`.
- This aligns execution-time failure handling with existing cleanup on successful execution and on lexing/parsing errors, ensuring the REPL clears pending multiline state after runtime failures.
- No other behavioral changes were made; syntax-error/incomplete-block handling and explicit cancellation remain unchanged.

### Testing
- Ran `python -m compileall src/pcobra/cobra/cli/commands_v2/repl_cmd.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f474a6e2308327893f71d83d7064a9)