### PR TITLE
[PR #2204 follow-up] Fix unsafe first REPL execution delegate state sync

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -88,8 +88,7 @@ class ReplCommandV2(BaseCommand):
 
     def _sincronizar_estado_hacia_delegate(self) -> None:
         """Sincroniza estado persistente local hacia el comando delegado."""
-        if self._interpretador_persistente is not None:
-            self._delegate.interpretador = self._interpretador_persistente
+        self._delegate.interpretador = self._interpretador_persistente
         self._delegate._seguro_repl = self._seguro_repl
         self._delegate._extra_validators_repl = self._extra_validators_repl
 

--- a/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
+++ b/tests/unit/cli/commands_v2/test_repl_cmd_v2.py
@@ -93,6 +93,29 @@ def test_repl_v2_persistencia_estado_var_x_e_imprimir_x(monkeypatch, capsys):
     assert capsys.readouterr().out == "10\n"
 
 
+def test_repl_v2_primer_ejecutar_sync_interpretador_none_en_modo_no_seguro(monkeypatch):
+    command = repl_module.ReplCommandV2()
+    entradas = iter(["var x = 1", "exit"])
+    interpretadores_recibidos: list[object | None] = []
+    seguros_recibidos: list[bool] = []
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(entradas))
+    monkeypatch.setattr(repl_module, "prevalidar_y_parsear_codigo", lambda _codigo: [object()])
+    monkeypatch.setattr(repl_module, "mostrar_info", lambda *_args, **_kwargs: None)
+
+    def _fake_delegate(_codigo: str):
+        interpretadores_recibidos.append(command._delegate.interpretador)
+        seguros_recibidos.append(command._delegate._seguro_repl)
+
+    monkeypatch.setattr(command._delegate, "ejecutar_codigo", _fake_delegate)
+
+    status = command.run(argparse.Namespace(**{**vars(_args_repl()), "seguro": False}))
+
+    assert status == 0
+    assert interpretadores_recibidos == [None]
+    assert seguros_recibidos == [False]
+
+
 def test_repl_v2_bloque_anidado_real_mientras_si_fin_fin_acumula_hasta_completar(monkeypatch):
     command = repl_module.ReplCommandV2()
     entradas = iter(["mientras verdadero:", "si verdadero:", "fin", "fin", "exit"])


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where the delegated `InteractiveCommand` could keep its constructor-created safe `Interpretador` on the first REPL run when the session was started with `seguro=False` and no persistent interpreter was present.

### Description
- Always propagate the local persistent interpreter state to the delegate by setting `self._delegate.interpretador = self._interpretador_persistente` in `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` so that `None` is forwarded on first run.
- Preserve synchronization of `_seguro_repl` and `_extra_validators_repl` and continue delegating execution to `InteractiveCommand.ejecutar_codigo` in the normal execution path.
- Add regression test `test_repl_v2_primer_ejecutar_sync_interpretador_none_en_modo_no_seguro` in `tests/unit/cli/commands_v2/test_repl_cmd_v2.py` to assert the delegate receives `interpretador is None` and `_seguro_repl is False` on the first delegated execution.

### Testing
- Ran `pytest -q tests/unit/cli/commands_v2/test_repl_cmd_v2.py tests/unit/test_repl_command_v2.py` and observed `53 passed, 1 warning`.
- The new regression test verifies the specific P1 scenario and the full affected REPL v2 test suite passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4766081f88327bce0896ce33bb979)