### PR TITLE
Preserve captured-scope mutation for bare reassignment while isolating nested global writes

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1191,13 +1191,22 @@ class InterpretadorCobra:
                         self.mem_contextos[indice_contexto][nombre] = (indice, 1)
                         self.contextos[indice_contexto].set(nombre, valor)
                     else:
-                        # Aislamiento de scope para asignación desnuda en
-                        # contextos anidados (funciones/hilos): se crea una
-                        # variable local y no se muta el entorno externo.
-                        self._liberar_memoria_variable_en_contexto(nombre, indice_actual)
-                        indice = self.solicitar_memoria(1)
-                        self.mem_contextos[indice_actual][nombre] = (indice, 1)
-                        self.contextos[indice_actual].define(nombre, valor)
+                        if indice_contexto == 0:
+                            # Compatibilidad con el aislamiento de scope:
+                            # dentro de scopes anidados, una asignación desnuda
+                            # no debe mutar el binding global existente.
+                            self._liberar_memoria_variable_en_contexto(nombre, indice_actual)
+                            indice = self.solicitar_memoria(1)
+                            self.mem_contextos[indice_actual][nombre] = (indice, 1)
+                            self.contextos[indice_actual].define(nombre, valor)
+                        else:
+                            # Si la variable existe en un scope léxico externo
+                            # no global, la reasignación debe mutar ese binding
+                            # capturado para preservar semántica de cierres.
+                            self._liberar_memoria_variable_en_contexto(nombre, indice_contexto)
+                            indice = self.solicitar_memoria(1)
+                            self.mem_contextos[indice_contexto][nombre] = (indice, 1)
+                            self.contextos[indice_contexto].set(nombre, valor)
         return valor
 
     def evaluar_expresion(self, expresion, visitados=None):


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where bare reassignment in nested scopes shadowed outer bindings instead of mutating captured non-global bindings, breaking closure semantics.
- Keep the intended scope-isolation behavior that prevents nested scopes from mutating global bindings created earlier via the implicit-first-assignment compatibility path.
- Maintain existing contracts for explicit declarations/inference and `NameError` for missing non-global bare assignments.

### Description
- Updated `InterpretadorCobra.ejecutar_asignacion` to distinguish three cases: local mutation in the current context, mutation of a captured non-global outer binding, and nested-scope writes that should create a new local binding when the outer binding is global.
- Implemented the change by choosing the correct `mem_contextos` index and calling `Environment.set` on captured non-global scopes or `Environment.define` on the current scope for isolated/global cases, and by using `_liberar_memoria_variable_en_contexto`/`solicitar_memoria` against the appropriate context.
- Preserved the top-level implicit-first-assignment compatibility path and the explicit/inferred declaration path untouched so legacy behavior and declarations remain consistent.

### Testing
- Ran targeted regression checks with `pytest -q tests/unit/test_hilos.py::test_hilos_preservan_variables_globales`, `pytest -q tests/unit/test_interpreter_concurrency.py::test_hilos_preservan_variables_globales_concurrentes`, and `pytest -q tests/unit/test_generadores.py::test_generador_limpia_contexto_exactamente_una_vez_en_finally`.
- An initial test run showed failures for the threaded-global tests, a subsequent patch corrected the logic and the final run returned `3 passed, 1 warning` for the three targeted tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f477ebd774832795c9805f56771a74)