### PR TITLE
fix(repl): normalizar y resolver `--extra-validators` antes de validar AST en modo seguro

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -40,6 +40,7 @@ from pcobra.cobra.cli.execution_pipeline import (
     PipelineInput,
     prevalidar_y_parsear_codigo,
     resolver_interpretador_cls,
+    resolver_validadores_seguridad,
     validar_ast_seguro,
 )
 from pcobra.cobra.core import (
@@ -60,6 +61,7 @@ from pcobra.cobra.core.runtime import (
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _, format_traceback
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
+from pcobra.cobra.cli.utils.validators import normalizar_validadores_extra
 from pcobra.cobra.cli.utils.messages import (
     color_disabled,
     mostrar_advertencia,
@@ -353,6 +355,20 @@ class InteractiveCommand(BaseCommand):
 
         return ast
 
+
+    def _obtener_validadores_extra_para_ast_seguro(self) -> Any:
+        """Resuelve rutas de validadores extra al formato exigido por validar_ast_seguro."""
+
+        normalizados = normalizar_validadores_extra(self._extra_validators_repl)
+        interpretador_cls = resolver_interpretador_cls(
+            module_name=__name__,
+            default_cls=type(self.interpretador),
+        )
+        return resolver_validadores_seguridad(
+            normalizados,
+            interpretador_cls=interpretador_cls,
+        )
+
     def ejecutar_codigo(self, codigo: str, validador: Optional[Any] = None) -> None:
         """Ejecuta un snippet en el intérprete persistente del REPL."""
 
@@ -362,7 +378,7 @@ class InteractiveCommand(BaseCommand):
             if self._seguro_repl:
                 validar_ast_seguro(
                     ast,
-                    validadores_extra=self._extra_validators_repl,
+                    validadores_extra=self._obtener_validadores_extra_para_ast_seguro(),
                 )
             if validador:
                 for nodo in ast:
@@ -380,7 +396,7 @@ class InteractiveCommand(BaseCommand):
                 if self._seguro_repl:
                     validar_ast_seguro(
                         ast,
-                        validadores_extra=self._extra_validators_repl,
+                        validadores_extra=self._obtener_validadores_extra_para_ast_seguro(),
                     )
                 if validador:
                     for nodo in ast:
@@ -925,7 +941,7 @@ class InteractiveCommand(BaseCommand):
                 if self._seguro_repl:
                     validar_ast_seguro(
                         ast,
-                        validadores_extra=self._extra_validators_repl,
+                        validadores_extra=self._obtener_validadores_extra_para_ast_seguro(),
                     )
                 mostrar_info(_("AST generado:"))
                 mostrar_info(str(ast))


### PR DESCRIPTION
### Motivation

- Evitar que REPL v2 en modo seguro lance `TypeError` cuando `--extra-validators` se propaga como `Path`/lista de rutas sin haber sido resuelto a instancias de validadores.
- Mantener la misma política de normalización/resolución de validadores que usa el pipeline canónico para preservar compatibilidad entre el flujo REPL directo y el pipeline completo.

### Description

- Añade importaciones de `resolver_validadores_seguridad` y `normalizar_validadores_extra` y un helper `_obtener_validadores_extra_para_ast_seguro()` en `InteractiveCommand` para normalizar y resolver rutas a instancias de validadores antes de la validación del AST. 
- Reemplaza las llamadas directas que pasaban `self._extra_validators_repl` a `validar_ast_seguro` por llamadas al helper en la ruta principal de `ejecutar_codigo` y en su fallback para expresiones top-level. 
- Alinea el comando especial `ast` para usar la misma resolución de validadores en modo seguro, manteniendo el resto del comportamiento del REPL (parseo con `prevalidar_y_parsear_codigo`, ejecución en el `interpretador` persistente y la impresión del resultado).

### Testing

- Ejecuté `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py` y la verificación de sintaxis pasó correctamente. 
- Ejecuté `pytest -q tests/unit/test_cli_interactive_cmd.py -k extra_validators` y no se seleccionaron tests relevantes con ese filtro (pytest terminó con código no cero debido a filtro sin coincidencias). 
- Ejecuté `pytest -q tests/unit/test_cli_interactive_cmd.py` y obtuve fallos preexistentes en 5 tests de REPL que no son causados por la corrección de resolución de validadores (la corrección evita el `TypeError` reportado pero no soluciona las discrepancias de paridad/estado detectadas en la rama base).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47904eb3c8327bd56c9336ebbd2da)