### PR TITLE
fix(repl): evitar renormalizar validadores extra ya resueltos en REPL seguro

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -50,6 +50,7 @@ from pcobra.cobra.core import (
     NodoSwitch,
     NodoTryCatch,
 )
+from pcobra.core.semantic_validators.base import ValidadorBase
 from pcobra.cobra.core.runtime import (
     InterpretadorCobra,
     ejecutar_en_contenedor,
@@ -359,7 +360,13 @@ class InteractiveCommand(BaseCommand):
     def _obtener_validadores_extra_para_ast_seguro(self) -> Any:
         """Resuelve rutas de validadores extra al formato exigido por validar_ast_seguro."""
 
-        normalizados = normalizar_validadores_extra(self._extra_validators_repl)
+        extra_validators = self._extra_validators_repl
+        if isinstance(extra_validators, list) and extra_validators and all(
+            isinstance(validador, ValidadorBase) for validador in extra_validators
+        ):
+            normalizados = extra_validators
+        else:
+            normalizados = normalizar_validadores_extra(extra_validators)
         interpretador_cls = resolver_interpretador_cls(
             module_name=__name__,
             default_cls=type(self.interpretador),


### PR DESCRIPTION
### Motivation

- Evitar el `TypeError` que ocurría cuando `--extra-validators` ya estaba resuelto a instancias de validadores en el flujo `interactive` en modo seguro, ya que la re-normalización trataba instancias como rutas.

### Description

- Importa `ValidadorBase` y modifica `_obtener_validadores_extra_para_ast_seguro()` para detectar una lista pre-resuelta de `ValidadorBase` y así saltarse `normalizar_validadores_extra(...)`, manteniendo la normalización para entradas no resueltas antes de llamar a `resolver_validadores_seguridad`.

### Testing

- Ejecuté `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py` y la compilación pasó correctamente; y ejecuté `pytest -q tests/unit/test_cli_interactive_cmd.py -k extra_validators` que no seleccionó tests (pytest salió con código 5 por filtro sin coincidencias).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47a3c1f2c8327a3c3dcf1c460a348)