### PR TITLE
Evitar que temporales CSE corten la ejecución de snippets REPL incrementales

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1194,6 +1194,10 @@ class InterpretadorCobra:
                     indice = self.solicitar_memoria(1)
                     self.mem_contextos[indice_contexto][nombre] = (indice, 1)
                     self.contextos[-1].set(nombre, valor)
+        if getattr(nodo, "temporal_cse", False):
+            # Las temporales introducidas por optimización no deben cortar la
+            # ejecución secuencial de un snippet REPL.
+            return None
         return valor
 
     def evaluar_expresion(self, expresion, visitados=None):

--- a/src/pcobra/core/optimizations/common_subexpr.py
+++ b/src/pcobra/core/optimizations/common_subexpr.py
@@ -104,6 +104,9 @@ class _CommonSubexprEliminator(NodeVisitor):
                     declaracion=True,
                 )
             )
+            # Señal interna: evitar que el REPL trate la temporal como
+            # resultado observable de la entrada.
+            setattr(self._current_assigns()[-1], "temporal_cse", True)
         return NodoIdentificador(cur[key])
 
     # Visit methods --------------------------------------------------------

--- a/tests/cli/test_repl_script_parity_contract.py
+++ b/tests/cli/test_repl_script_parity_contract.py
@@ -477,3 +477,32 @@ def test_repl_incremental_var_var_imprimir_sin_regresion_cse_y_estado_final() ->
     assert resultado["stderr"] == ""
     assert str(resultado["stdout"]).strip().endswith("10")
     assert resultado["estado"] == {"x": 5, "y": 10}
+
+
+@pytest.mark.integration
+def test_repl_incremental_var_con_cse_no_corta_asignacion_usuario() -> None:
+    snippets = [
+        "var x = 5",
+        "var y = (x * 2) + (x * 2)",
+        "imprimir(y)",
+    ]
+    resultado = _ejecutar_snippets_secuenciales_repl(
+        snippets,
+        variables_estado=("x", "y"),
+    )
+
+    evidencia = "\n".join(
+        fragmento
+        for fragmento in (
+            str(resultado["stdout"]),
+            str(resultado["stderr"]),
+            str(resultado["error"]) if resultado["error"] is not None else "",
+        )
+        if fragmento
+    )
+
+    assert resultado["error"] is None
+    assert "Variable no declarada: y" not in evidencia
+    assert resultado["stderr"] == ""
+    assert str(resultado["stdout"]).strip().endswith("20")
+    assert resultado["estado"] == {"x": 5, "y": 20}


### PR DESCRIPTION
### Motivation
- Corregir un comportamiento donde las asignaciones temporales generadas por la eliminación de subexpresiones comunes (CSE) producían un resultado no-`None` y provocaban que `InterpretadorCobra.ejecutar_ast` dejara de ejecutar el resto del snippet REPL, saltándose la asignación del usuario y dejando variables sin declarar.
- Mantener las temporales como declaraciones locales para evitar `NameError` pero sin exponerlas como resultados observables que interrumpan la ejecución secuencial.

### Description
- En `src/pcobra/core/optimizations/common_subexpr.py` se marca la asignación temporal CSE con un flag interno `temporal_cse` justo al crear el `NodoAsignacion` (`_cseN`).
- En `src/pcobra/core/interpreter.py` se modifica la ejecución de asignaciones para que, cuando `nodo.temporal_cse` sea `True`, la función devuelva `None` y por tanto no interrumpa la ejecución del bucle en `ejecutar_ast`.
- Se añadió un test de regresión en `tests/cli/test_repl_script_parity_contract.py` llamado `test_repl_incremental_var_con_cse_no_corta_asignacion_usuario` que reproduce `var y = (x * 2) + (x * 2)` seguido de `imprimir(y)` y verifica salida, `stderr` vacío y estado final correcto.

### Testing
- Ejecutado `pytest -q tests/cli/test_repl_script_parity_contract.py -k 'incremental_var_var_imprimir_sin_regresion_cse_y_estado_final or incremental_var_con_cse_no_corta_asignacion_usuario'` y ambos tests relevantes pasaron (`2 passed`).
- Los cambios fueron validados como parte de la integración específica que reproducía la regresión y confirmaron que `imprimir(y)` ya no falla y el estado final contiene las variables esperadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47b60574883278078bb3a99e9677a)