### PR TITLE
Restore REPL short-circuit on first non-None AST node result

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -369,8 +369,9 @@ class InteractiveCommand(BaseCommand):
         resultado = None
         for nodo in ast:
             resultado_nodo = self.interpretador.ejecutar_nodo(nodo)
-            if resultado is None and resultado_nodo is not None:
+            if resultado_nodo is not None:
                 resultado = resultado_nodo
+                break
         return ast, resultado
 
     def ejecutar_codigo(self, codigo: str, validador: Optional[Any] = None) -> None:


### PR DESCRIPTION
### Motivation
- Ensure REPL incremental execution matches script-mode semantics by stopping AST-node execution as soon as a node returns a non-`None` value to avoid applying later side effects that scripts do not run.

### Description
- Modify `_ejecutar_ast_en_repl` to break the node-execution loop when the first non-`None` `resultado_nodo` is produced, returning that as the REPL result; change applied in `src/pcobra/cobra/cli/commands/interactive_cmd.py`.

### Testing
- Ran `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py` which succeeded, and ran `pytest -q tests/unit/test_cli_interactive_cmd.py -k "ejecutar_ast_en_repl or ejecutar_codigo"` and `pytest -q tests/unit/test_cli_execution_pipeline_contract.py -k "interactive or repl"`, which show existing failures (5 failing tests in each targeted suite) that reflect remaining parity/validation issues unrelated to this short-circuit fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47f9b13448327b1935bbe59a62ea4)