### PR TITLE
Fix REPL AST reuse NameError in normal dispatch

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -762,7 +762,7 @@ class InteractiveCommand(BaseCommand):
             try:
                 estado["buffer_lineas"].append(linea)
                 codigo = "\n".join(estado["buffer_lineas"])
-                prevalidar_y_parsear_codigo(codigo)
+                ast = prevalidar_y_parsear_codigo(codigo)
                 estado["lineas_blanco_consecutivas"] = 0
             except (LexerError, ParserError) as err:
                 if self._es_error_de_bloque_incompleto(err):


### PR DESCRIPTION
### Motivation
- Fix a regression where the normal (non-sandbox) REPL path referenced an unassigned `ast` variable, causing a `NameError` and preventing parsed input from being executed in the incremental REPL flow.

### Description
- In `InteractiveCommand._run_repl_loop` the call to `prevalidar_y_parsear_codigo(codigo)` is now stored as `ast = prevalidar_y_parsear_codigo(codigo)` and that `ast` is passed to `ejecutar_codigo(codigo, validador, ast_preparseado=ast)` so the pre-parsed AST is reused for execution.

### Testing
- Ran `python -m compileall src/pcobra/cobra/cli/commands/interactive_cmd.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f480d96aac832782a9e7310b3140e0)