### PR TITLE
Fix false positive for `from . import base` in cross-command lint

### DIFF
--- a/scripts/ci/lint_no_cross_command_imports.py
+++ b/scripts/ci/lint_no_cross_command_imports.py
@@ -29,15 +29,14 @@ def _is_forbidden_module_name(module: str) -> bool:
     return False
 
 
-def _is_forbidden_import_from(node: ast.ImportFrom) -> bool:
-    module = node.module or ""
+def _is_forbidden_import_from_module(module: str, imported_names: set[str]) -> bool:
+    if module in FORBIDDEN_PREFIXES:
+        allowed_names = {"base"}
+        return not imported_names.issubset(allowed_names)
+
     if _is_forbidden_module_name(module):
         return True
 
-    if module in FORBIDDEN_PREFIXES:
-        allowed_names = {"base"}
-        imported_names = {alias.name for alias in node.names}
-        return not imported_names.issubset(allowed_names)
     return False
 
 
@@ -84,13 +83,15 @@ def _scan_file(path: Path, root: Path) -> list[tuple[int, str]]:
                 if _is_forbidden_module_name(alias.name):
                     violations.append((node.lineno, alias.name))
         elif isinstance(node, ast.ImportFrom):
-            if _is_forbidden_import_from(node):
+            imported_names = {alias.name for alias in node.names}
+            module = node.module or ""
+            if _is_forbidden_import_from_module(module, imported_names):
                 label = node.module or "<relative>"
                 violations.append((node.lineno, label))
                 continue
 
             resolved_module = _resolve_import_from_module(node, path, root)
-            if _is_forbidden_module_name(resolved_module):
+            if _is_forbidden_import_from_module(resolved_module, imported_names):
                 label = resolved_module or node.module or "<relative>"
                 violations.append((node.lineno, label))
     return violations

--- a/tests/unit/test_ci_lint_no_cross_command_imports.py
+++ b/tests/unit/test_ci_lint_no_cross_command_imports.py
@@ -43,3 +43,14 @@ def test_detecta_import_relativo_entre_comandos(tmp_path: Path) -> None:
 
     assert len(violations) == 1
     assert "pcobra.cobra.cli.commands.compile_cmd" in violations[0]
+
+
+def test_permite_import_relativo_base(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pcobra" / "cobra" / "cli" / "commands" / "a.py",
+        "from . import base\n",
+    )
+
+    violations = find_violations(tmp_path)
+
+    assert violations == []


### PR DESCRIPTION
### Motivation

- Prevent a CI-blocking false positive where `from . import base` inside `...cli.commands` was flagged as a forbidden cross-command import despite `commands.base` being explicitly allowed.  
- Ensure relative `from ... import ...` statements are resolved and checked without losing the `base` allowlist.  

### Description

- Refactored the ImportFrom check into `_is_forbidden_import_from_module(module: str, imported_names: set[str])` so the module and imported symbol names are evaluated together.  
- Updated `_scan_file` to collect `imported_names` and validate both the original `node.module` and the `resolved_module` from `_resolve_import_from_module(node, path, root)`.  
- Preserved the `commands.base` allowlist for both absolute imports and module-less relative imports (e.g., `from . import base`).  
- Added a regression unit test `test_permite_import_relativo_base` in `tests/unit/test_ci_lint_no_cross_command_imports.py` that asserts `from . import base` is allowed.  

### Testing

- Ran `pytest -q tests/unit/test_ci_lint_no_cross_command_imports.py` and all tests passed (`4 passed`).  
- The new unit test verifies the previously failing case is now accepted while other forbidden relative imports (e.g., `from .compile_cmd import ...`) are still detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f481b899bc832798948585f98101d8)