### PR TITLE
[PR #2255 follow-up] fix(cli): resolve legacy sandbox hook for execute_cmd aliases

### DIFF
--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -100,12 +100,17 @@ def validar_dependencias(*args: Any, **kwargs: Any) -> Any:
 
 
 def _resolver_hook_sandbox_legacy() -> Any:
-    legacy_module = sys.modules.get("pcobra.cobra.cli.commands.execute_cmd")
-    if legacy_module is None:
-        return ejecutar_en_sandbox
-    legacy_hook = getattr(legacy_module, "ejecutar_en_sandbox", None)
-    if callable(legacy_hook):
-        return legacy_hook
+    legacy_aliases = (
+        "pcobra.cobra.cli.commands.execute_cmd",
+        "cobra.cli.commands.execute_cmd",
+    )
+    for module_name in legacy_aliases:
+        legacy_module = sys.modules.get(module_name)
+        if legacy_module is None:
+            continue
+        legacy_hook = getattr(legacy_module, "ejecutar_en_sandbox", None)
+        if callable(legacy_hook):
+            return legacy_hook
     return ejecutar_en_sandbox
 
 


### PR DESCRIPTION
### Motivation
- The resolver for the legacy sandbox hook only checked `sys.modules["pcobra.cobra.cli.commands.execute_cmd"]`, which ignored monkeypatches applied using legacy import aliases like `cobra.cli.commands.execute_cmd` and broke compatibility for callers/tests that patch the legacy path.

### Description
- Updated `_resolver_hook_sandbox_legacy()` to iterate over both legacy aliases (`"pcobra.cobra.cli.commands.execute_cmd"` and `"cobra.cli.commands.execute_cmd"`) and return the first callable `ejecutar_en_sandbox` found, falling back to the canonical `ejecutar_en_sandbox` when none are present.

### Testing
- Ran `python -m compileall src/pcobra/cobra/cli/services/run_service.py` which completed successfully. 
- The full test suite (`python -m pytest -q tests`) was previously executed in the original PR and failed during collection due to unrelated preexisting assertions, not because of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f482d4d6dc83279adb7b49cc2200db)