### PR TITLE
[PR #2295 follow-up] fix(cli): prioritize legacy execute_cmd sandbox hook alias

### DIFF
--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -101,8 +101,8 @@ def validar_dependencias(*args: Any, **kwargs: Any) -> Any:
 
 def _resolver_hook_sandbox_legacy() -> Any:
     legacy_aliases = (
-        "pcobra.cobra.cli.commands.execute_cmd",
         "cobra.cli.commands.execute_cmd",
+        "pcobra.cobra.cli.commands.execute_cmd",
     )
     for module_name in legacy_aliases:
         legacy_module = sys.modules.get(module_name)


### PR DESCRIPTION
### Motivation
- The sandbox hook resolver returned the canonical `pcobra.cobra.cli.commands.execute_cmd` hook before the legacy alias, causing monkeypatches applied to `cobra.cli.commands.execute_cmd` to be ignored when both module objects existed.

### Description
- Reordered the `legacy_aliases` tuple in `_resolver_hook_sandbox_legacy()` to check `"cobra.cli.commands.execute_cmd"` before `"pcobra.cobra.cli.commands.execute_cmd"`, so the first callable `ejecutar_en_sandbox` found on either alias is returned and otherwise falls back to the canonical `ejecutar_en_sandbox`.

### Testing
- Ran `pytest -q tests/unit/test_cli_sandbox_mode.py` which completed successfully with `3 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f490b554448327941ba586a4e3236f)