### PR TITLE
Restore legacy REPL fallback for EOF and block-close ParserError messages

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -159,7 +159,11 @@ class ReplCommandV2(BaseCommand):
         )
         menciona_eof = any(pista in mensaje for pista in pistas_eof)
 
-        return menciona_cierre and menciona_eof
+        menciona_bloque = any(pista in mensaje for pista in ("bloque", "condicional", "bucle"))
+
+        # Compatibilidad legacy: en REPL priorizamos señales de EOF y aceptamos
+        # mensajes de cierre de bloque sin metadata estructurada.
+        return menciona_eof or (menciona_cierre and menciona_bloque)
 
     def es_error_de_bloque_incompleto(self, exc: Exception) -> bool:
         """Detecta si la excepción corresponde a una entrada aún incompleta.

--- a/tests/unit/test_repl_command_v2.py
+++ b/tests/unit/test_repl_command_v2.py
@@ -35,6 +35,8 @@ def _parser_error_con_metadata(
         ("Se esperaba 'fin' al final de la entrada", True),
         ("Se esperaba ')' al final de la entrada (EOF)", True),
         ("Se esperaba ']' al final de la entrada", True),
+        ("Token inesperado en término: TipoToken.EOF", True),
+        ("Se esperaba 'fin' para cerrar el bloque condicional", True),
         ("Se esperaba ')' al final de 'proyectar'", False),
         ("Se encontró 'fin' inesperado", False),
     ],


### PR DESCRIPTION
### Motivation

- Fix a high-priority regression where plain `ParserError` messages from the REPL parser (which often lack structured metadata) were misclassified as hard syntax errors, causing the multiline REPL buffer to be cleared instead of allowing continuation.

### Description

- Relaxed the textual fallback in `ReplCommandV2._es_entrada_incompleta_por_texto` to treat a message as incomplete when it explicitly indicates EOF, or when it contains both an expected-close hint and an explicit block-closing word (`"bloque"`, `"condicional"`, `"bucle"`).
- Added a `menciona_bloque` predicate and updated the final predicate to `menciona_eof or (menciona_cierre and menciona_bloque)` so one-line syntax errors (e.g. `Se esperaba ')' al final de 'proyectar'`) are not misclassified.
- Updated unit tests in `tests/unit/test_repl_command_v2.py` to include legacy messages observed in REPL (`"Token inesperado en término: TipoToken.EOF"` and `"Se esperaba 'fin' para cerrar el bloque condicional"`) and preserved negative cases to ensure buffer-clearing behavior remains correct.
- Files changed: `src/pcobra/cobra/cli/commands_v2/repl_cmd.py` and `tests/unit/test_repl_command_v2.py`.

### Testing

- Ran `pytest -q tests/unit/test_repl_command_v2.py` and all tests passed with `32 passed, 1 warning`.
- Unit tests exercise both metadata-based and textual legacy detection, REPL buffer accumulation behavior, and prompt switching, confirming the regression is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4919cb8708327a9502947e729456e)