### PR TITLE
fix(repl): separar fases de análisis/ejecución y silenciar validación en análisis

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import sys
+import warnings
 from typing import Optional, Any
 from types import TracebackType
 
@@ -345,11 +346,50 @@ class InteractiveCommand(BaseCommand):
         ast = prevalidar_y_parsear_codigo(linea)
         self.logger.debug(_("AST generado: {ast}").format(ast=ast))
 
-        if validador:
+        self._recorrer_validacion_ast(ast, validador, silencioso=True)
+
+        return ast
+
+
+    def _recorrer_validacion_ast(
+        self,
+        ast: list[Any],
+        validador: Optional[Any],
+        *,
+        silencioso: bool = False,
+    ) -> None:
+        """Recorre el AST con el validador opcional.
+
+        En fase de análisis del REPL se fuerza modo silencioso para evitar
+        duplicidad de warnings/logs antes de la fase de ejecución.
+        """
+        if not validador:
+            return
+
+        def _visitar() -> None:
             for nodo in ast:
                 nodo.aceptar(validador)
 
-        return ast
+        if not silencioso:
+            _visitar()
+            return
+
+        verbose_prev = getattr(validador, "verbose", None)
+        if verbose_prev is not None:
+            try:
+                setattr(validador, "verbose", False)
+            except Exception:
+                verbose_prev = None
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            _visitar()
+
+        if verbose_prev is not None:
+            try:
+                setattr(validador, "verbose", verbose_prev)
+            except Exception:
+                pass
 
     def _ejecutar_ast_en_repl(
         self, ast: list[Any], validador: Optional[Any] = None
@@ -375,9 +415,9 @@ class InteractiveCommand(BaseCommand):
                 validadores_extra=self._extra_validators_repl,
             )
         resultado = None
+        self._recorrer_validacion_ast(ast, validador, silencioso=False)
+
         for nodo in ast:
-            if validador:
-                nodo.aceptar(validador)
             resultado_nodo = self.interpretador.ejecutar_nodo(nodo)
             # El resultado observable del REPL debe ser el valor realmente
             # evaluado por el último nodo ejecutado en el entorno actual.
@@ -716,6 +756,7 @@ class InteractiveCommand(BaseCommand):
         """Bucle único de REPL para evitar divergencias entre implementaciones."""
         estado = self._crear_estado_repl()
         estado["debug_enabled"] = self._debug_mode
+        estado["fase"] = "analisis"
         self._estado_repl = estado
         self._interpretador_sesion = self.interpretador
         while True:
@@ -762,7 +803,8 @@ class InteractiveCommand(BaseCommand):
             try:
                 estado["buffer_lineas"].append(linea)
                 codigo = "\n".join(estado["buffer_lineas"])
-                prevalidar_y_parsear_codigo(codigo)
+                estado["fase"] = "analisis"
+                ast = self.procesar_ast(codigo, validador)
                 estado["lineas_blanco_consecutivas"] = 0
             except (LexerError, ParserError) as err:
                 if self._es_error_de_bloque_incompleto(err):
@@ -791,13 +833,16 @@ class InteractiveCommand(BaseCommand):
                 elif sandbox_docker:
                     self._ejecutar_en_docker(codigo, sandbox_docker)
                 else:
+                    estado["fase"] = "ejecucion"
                     # Contrato de dispatch:
                     # REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.
                     # Rama normal: AST directo con entorno persistente.
                     self.ejecutar_codigo(codigo, validador, ast_preparseado=ast)
                 estado["buffer_lineas"].clear()
+                estado["fase"] = "analisis"
             except Exception as err:  # pragma: no cover - ruta unificada de errores
                 estado["buffer_lineas"].clear()
+                estado["fase"] = "analisis"
                 categoria = self._clasificar_error_repl(err)
                 self._log_error(categoria, err)
 


### PR DESCRIPTION
### Motivation
- Evitar la emisión duplicada de warnings/logs durante la prevalidación en el REPL separando explícitamente la fase de análisis de la de ejecución.
- Hacer explícito el flujo incremental del REPL para que la validación ocurra en modo silencioso durante el análisis y solo se ejecute el AST en la fase de ejecución.

### Description
- Añadido `estado["fase"]` al estado del REPL y transiciones a `"analisis"` y `"ejecucion"` en `_run_repl_loop` para representar las fases explícitas del REPL.
- Centralizado el recorrido de validación en `_recorrer_validacion_ast(ast, validador, silencioso=...)` que soporta modo silencioso usando `warnings.catch_warnings()` y, si existe, temporariamente desactiva `validador.verbose` para evitar ruido durante el análisis.
- `procesar_ast` ahora usa la validación silenciosa (`_recorrer_validacion_ast(..., silencioso=True)`) y devuelve el `ast` preparseado para su uso posterior.
- `_ejecutar_ast_en_repl` llama a `_recorrer_validacion_ast(..., silencioso=False)` antes de ejecutar nodos y se eliminó el doble `nodo.aceptar(validador)` preexistente para garantizar que `self.interpretador.ejecutar_nodo(nodo)` se ejecute únicamente en la fase de ejecución, preservando el intérprete de sesión y la semántica incremental.
- Cambios limitados al archivo `src/pcobra/cobra/cli/commands/interactive_cmd.py` y diseñados para no alterar la semántica de bloques (`si`, `mientras`), funciones (`func`, `retorno`) ni asignaciones, solo el momento y el ruido de la validación.

### Testing
- Se verificó la sintaxis compilando el módulo con `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py` y la compilación completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d8189b5c8327abdebb1f5d870e1c)