### PR TITLE
Silencia el validador de auditoría durante el pase de análisis del REPL

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -371,6 +371,11 @@ class InteractiveCommand(BaseCommand):
                 nodo.aceptar(validador)
 
         if not silencioso:
+            if hasattr(validador, "emitir_side_effects"):
+                try:
+                    setattr(validador, "emitir_side_effects", True)
+                except Exception:
+                    pass
             _visitar()
             return
 
@@ -381,6 +386,13 @@ class InteractiveCommand(BaseCommand):
             except Exception:
                 verbose_prev = None
 
+        emitir_prev = getattr(validador, "emitir_side_effects", None)
+        if emitir_prev is not None:
+            try:
+                setattr(validador, "emitir_side_effects", False)
+            except Exception:
+                emitir_prev = None
+
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             _visitar()
@@ -388,6 +400,12 @@ class InteractiveCommand(BaseCommand):
         if verbose_prev is not None:
             try:
                 setattr(validador, "verbose", verbose_prev)
+            except Exception:
+                pass
+
+        if emitir_prev is not None:
+            try:
+                setattr(validador, "emitir_side_effects", emitir_prev)
             except Exception:
                 pass
 

--- a/src/pcobra/core/semantic_validators/auditoria.py
+++ b/src/pcobra/core/semantic_validators/auditoria.py
@@ -14,7 +14,13 @@ from ..ast_nodes import (
 class ValidadorAuditoria(ValidadorBase):
     """Validador que registra las primitivas utilizadas."""
 
+    def __init__(self, emitir_side_effects: bool = True) -> None:
+        super().__init__()
+        self.emitir_side_effects = emitir_side_effects
+
     def _log(self, mensaje: str) -> None:
+        if not self.emitir_side_effects:
+            return
         logging.warning(mensaje)
 
     def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):


### PR DESCRIPTION
### Motivation
- Evitar que el validador de auditoría emita logs/side-effects durante el pase de análisis del REPL para no duplicar advertencias ni producir efectos observables antes del pase de ejecución real.

### Description
- Añadido `emitir_side_effects: bool` a `ValidadorAuditoria` (por defecto `True`) y modificado `_log(...)` para no emitir cuando `emitir_side_effects` es `False` en `src/pcobra/core/semantic_validators/auditoria.py`.
- En `InteractiveCommand._recorrer_validacion_ast` (`src/pcobra/cobra/cli/commands/interactive_cmd.py`) se desactiva temporalmente `emitir_side_effects` para el pase silencioso (`silencioso=True`) y se fuerza a `True` en el pase real (`silencioso=False`), restaurando el valor original al finalizar, sin modificar los métodos `visit_*` ni la semántica de recorrido (`generic_visit/delegar`).

### Testing
- Ejecutado: `pytest -q tests/unit/test_interactive_cmd_repl_pipeline_coupling.py tests/unit/test_cli_interactive_cmd.py -q`.
- Resultado: la ejecución de pruebas muestra fallos en `tests/unit/test_cli_interactive_cmd.py` (5 tests fallidos) relacionados con expectativas de mocks y mensajes de error sobre `'fin'`; no hubo crashes ni errores de importación atribuibles a este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d9372b8083278964ad214c5b19aa)