### PR TITLE
Refactoriza validación AST por fases en REPL

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -346,7 +346,7 @@ class InteractiveCommand(BaseCommand):
         ast = prevalidar_y_parsear_codigo(linea)
         self.logger.debug(_("AST generado: {ast}").format(ast=ast))
 
-        self._recorrer_validacion_ast(ast, validador, silencioso=True)
+        self._validar_ast_para_analisis(ast, validador)
 
         return ast
 
@@ -356,13 +356,9 @@ class InteractiveCommand(BaseCommand):
         ast: list[Any],
         validador: Optional[Any],
         *,
-        silencioso: bool = False,
+        silencioso: bool,
     ) -> None:
-        """Recorre el AST con el validador opcional.
-
-        En fase de análisis del REPL se fuerza modo silencioso para evitar
-        duplicidad de warnings/logs antes de la fase de ejecución.
-        """
+        """Recorre el AST con el validador opcional y política explícita de efectos."""
         if not validador:
             return
 
@@ -371,11 +367,6 @@ class InteractiveCommand(BaseCommand):
                 nodo.aceptar(validador)
 
         if not silencioso:
-            if hasattr(validador, "emitir_side_effects"):
-                try:
-                    setattr(validador, "emitir_side_effects", True)
-                except Exception:
-                    pass
             _visitar()
             return
 
@@ -409,6 +400,14 @@ class InteractiveCommand(BaseCommand):
             except Exception:
                 pass
 
+    def _validar_ast_para_analisis(self, ast: list[Any], validador: Optional[Any]) -> None:
+        """Valida AST para análisis estático sin side effects observables."""
+        self._recorrer_validacion_ast(ast, validador, silencioso=True)
+
+    def _validar_ast_para_ejecucion(self, ast: list[Any], validador: Optional[Any]) -> None:
+        """Valida AST para ejecución con side effects de auditoría habilitados."""
+        self._recorrer_validacion_ast(ast, validador, silencioso=False)
+
     def _ejecutar_ast_en_repl(
         self, ast: list[Any], validador: Optional[Any] = None
     ) -> tuple[list[Any], Any]:
@@ -417,7 +416,16 @@ class InteractiveCommand(BaseCommand):
         Contrato: REPL incremental = intérprete; no batch pipeline.
         Patrón explícito del flujo normal:
         1) ``ast = prevalidar_y_parsear_codigo(codigo)``;
-        2) ``for nodo in ast: self.interpretador.ejecutar_nodo(nodo)``.
+        2) validación de seguridad/validadores de ejecución (fase de ejecución);
+        3) ``for nodo in ast: self.interpretador.ejecutar_nodo(nodo)``.
+
+        Invariantes de fase (antirregresión):
+        - La fase de análisis usa ``_validar_ast_para_analisis`` (silenciosa,
+          sin side effects observables de auditoría).
+        - La fase de ejecución usa ``_validar_ast_para_ejecucion`` (con side
+          effects de auditoría cuando aplica).
+        - Para un mismo propósito de logging/auditoría, no mezclar ambas fases
+          sobre el mismo AST en una única corrida de ejecución.
 
         Nota de mantenimiento:
         Los nombres temporales ``_cse*`` pertenecen a optimizaciones internas
@@ -433,7 +441,7 @@ class InteractiveCommand(BaseCommand):
                 validadores_extra=self._extra_validators_repl,
             )
         resultado = None
-        self._recorrer_validacion_ast(ast, validador, silencioso=False)
+        self._validar_ast_para_ejecucion(ast, validador)
 
         for nodo in ast:
             resultado_nodo = self.interpretador.ejecutar_nodo(nodo)


### PR DESCRIPTION
### Motivation
- Evitar que la misma ruta de validación mezcle análisis silencioso y validación con side effects de auditoría, y proporcionar una única fuente de verdad para cuándo ejecutar cada tipo de validación.
- Reducir la probabilidad de warnings/duplicidad de logging al separar la validación de preanálisis de la validación en fase de ejecución.

### Description
- Introduce dos wrappers explícitos de validación: ` _validar_ast_para_analisis` (silenciosa, sin side effects observables) y ` _validar_ast_para_ejecucion` (con side effects para auditoría), y actualiza los puntos de uso para delegar en ellos.
- Centraliza el recorrido del validador en ` _recorrer_validacion_ast` con el parámetro obligatorio `silencioso` y elimina la activación implícita de `emitir_side_effects=True` en el camino genérico para evitar doble propósito de logging.
- Ajusta `procesar_ast` para usar la ruta de análisis silenciosa y modifica `_ejecutar_ast_en_repl` para documentar y aplicar las invariantes de fase (análisis vs ejecución) y usar la ruta de validación de ejecución.
- Añade la documentación en el docstring de `_ejecutar_ast_en_repl` describiendo las invariantes de fase para prevenir regresiones futuras.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py` y la compilación sintáctica fue exitosa.
- No se añadieron tests unitarios en este cambio; no se observaron fallos en comprobación estática básica.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4da472ddc8327a49448699cb5ed1b)