### PR TITLE
Refuerza política de validación por fase en REPL

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -409,7 +409,11 @@ class InteractiveCommand(BaseCommand):
         self._recorrer_validacion_ast(ast, validador, silencioso=False)
 
     def _ejecutar_ast_en_repl(
-        self, ast: list[Any], validador: Optional[Any] = None
+        self,
+        ast: list[Any],
+        validador: Optional[Any] = None,
+        *,
+        validar_no_silencioso: bool = True,
     ) -> tuple[list[Any], Any]:
         """Flujo canónico del REPL incremental.
 
@@ -441,7 +445,8 @@ class InteractiveCommand(BaseCommand):
                 validadores_extra=self._extra_validators_repl,
             )
         resultado = None
-        self._validar_ast_para_ejecucion(ast, validador)
+        if validar_no_silencioso:
+            self._validar_ast_para_ejecucion(ast, validador)
 
         for nodo in ast:
             resultado_nodo = self.interpretador.ejecutar_nodo(nodo)
@@ -472,7 +477,13 @@ class InteractiveCommand(BaseCommand):
         # persistente para preservar la semántica incremental del lenguaje.
         try:
             ast = ast_preparseado if ast_preparseado is not None else prevalidar_y_parsear_codigo(codigo)
-            ast, resultado = self._ejecutar_ast_en_repl(ast, validador)
+            validacion_no_silenciosa_realizada = False
+            ast, resultado = self._ejecutar_ast_en_repl(
+                ast,
+                validador,
+                validar_no_silencioso=True,
+            )
+            validacion_no_silenciosa_realizada = True
         except Exception as err_original:
             if not self._debe_intentar_fallback_expresion_top_level(
                 codigo, err_original
@@ -482,7 +493,11 @@ class InteractiveCommand(BaseCommand):
             codigo_fallback = f"imprimir({codigo.strip()})"
             try:
                 ast_fallback = prevalidar_y_parsear_codigo(codigo_fallback)
-                ast, resultado = self._ejecutar_ast_en_repl(ast_fallback, validador)
+                ast, resultado = self._ejecutar_ast_en_repl(
+                    ast_fallback,
+                    validador,
+                    validar_no_silencioso=not validacion_no_silenciosa_realizada,
+                )
             except Exception as err_fallback:
                 if self._debe_intentar_fallback_expresion_top_level(
                     codigo, err_fallback


### PR DESCRIPTION
### Motivation
- Asegurar que la fase de análisis ejecute validación en modo silencioso (`silencioso=True`) y la fase de ejecución en modo no silencioso (`silencioso=False`).
- Evitar rutas en las que, para el mismo snippet, se invoque dos veces la validación no silenciosa y por tanto se generen side effects duplicados de auditoría.

### Description
- Añade el parámetro `validar_no_silencioso: bool = True` a `_ejecutar_ast_en_repl` y condiciona la llamada a `self._validar_ast_para_ejecucion` a ese flag. 
- Mantiene la validación silenciosa en `procesar_ast` mediante `self._validar_ast_para_analisis` sin cambios funcionales. 
- En `ejecutar_codigo` se introduce la variable `validacion_no_silenciosa_realizada` para marcar si ya se ejecutó la validación no silenciosa y en la ruta de fallback (`imprimir(...)`) invocar `_ejecutar_ast_en_repl` con `validar_no_silencioso=not validacion_no_silenciosa_realizada` para evitar duplicados. 
- No se alteran las llamadas a `validar_ast_seguro` ni la semántica del REPL incremental fuera de la política explícita de fase.

### Testing
- Se ejecutó la compilación sintáctica del módulo con `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py` y completó con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4dbfddc1c83279eb77434031a4ac0)