### PR TITLE
Clarifica control de side effects en ValidadorAuditoria

### DIFF
--- a/src/pcobra/core/semantic_validators/auditoria.py
+++ b/src/pcobra/core/semantic_validators/auditoria.py
@@ -12,13 +12,19 @@ from ..ast_nodes import (
 
 
 class ValidadorAuditoria(ValidadorBase):
-    """Validador que registra las primitivas utilizadas."""
+    """Validador que registra las primitivas utilizadas.
+
+    Modos de uso:
+    - análisis semántico: ``emitir_side_effects=False`` (sin efectos secundarios)
+    - ejecución/auditoría activa: ``emitir_side_effects=True`` (emite logs)
+    """
 
     def __init__(self, emitir_side_effects: bool = True) -> None:
         super().__init__()
         self.emitir_side_effects = emitir_side_effects
 
     def _log(self, mensaje: str) -> None:
+        # Fuente de verdad centralizada para side effects de auditoría.
         if not self.emitir_side_effects:
             return
         logging.warning(mensaje)


### PR DESCRIPTION
### Motivation
- Asegurar que `emitir_side_effects` sea la fuente de verdad para la emisión de logs y documentar los modos de uso (análisis vs ejecución), además de garantizar que los métodos `visit_*` usen `_log(...)` en vez de llamar `logging.warning(...)` directamente.

### Description
- Se añadió docstring en `ValidadorAuditoria` que explica los dos modos: análisis (`emitir_side_effects=False`) y ejecución/auditoría activa (`emitir_side_effects=True`), se añadió un comentario en `_log(...)` indicando que es la fuente de verdad para side effects y se mantiene el `return` inmediato cuando `emitir_side_effects=False`, sin modificar nodos AST, parser ni lexer; todos los `visit_*` usan `self._log(...)`.

### Testing
- Se ejecutó `python -m compileall src/pcobra/core/semantic_validators/auditoria.py` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4dd0ea8088327b85dbfd23a361c2d)