### PR TITLE
Asegura validación silenciosa en preparseo REPL y fallback

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -477,6 +477,11 @@ class InteractiveCommand(BaseCommand):
         # persistente para preservar la semántica incremental del lenguaje.
         try:
             ast = ast_preparseado if ast_preparseado is not None else prevalidar_y_parsear_codigo(codigo)
+            # Si no viene AST preparseado, esta fase sigue siendo de análisis
+            # (sin emisión); la ejecución con emisión se habilita únicamente
+            # dentro de ``_ejecutar_ast_en_repl``.
+            if ast_preparseado is None:
+                self._validar_ast_para_analisis(ast, validador)
             validacion_no_silenciosa_realizada = False
             ast, resultado = self._ejecutar_ast_en_repl(
                 ast,
@@ -486,7 +491,7 @@ class InteractiveCommand(BaseCommand):
             validacion_no_silenciosa_realizada = True
         except Exception as err_original:
             if not self._debe_intentar_fallback_expresion_top_level(
-                codigo, err_original
+                codigo, err_original, validador
             ):
                 raise
 
@@ -500,7 +505,7 @@ class InteractiveCommand(BaseCommand):
                 )
             except Exception as err_fallback:
                 if self._debe_intentar_fallback_expresion_top_level(
-                    codigo, err_fallback
+                    codigo, err_fallback, validador
                 ):
                     raise err_original
                 raise
@@ -525,6 +530,9 @@ class InteractiveCommand(BaseCommand):
 
         self._sincronizar_interpretador_sesion()
         ast = prevalidar_fn(codigo)
+        # Contrato de prevalidación/parseo en REPL: esta fase es solo de
+        # análisis y no debe emitir side effects de auditoría.
+        self._validar_ast_para_analisis(ast, validador)
         # Contrato de dispatch:
         # REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.
         # Este helper delega en ``ejecutar_codigo`` y, por diseño, no debe
@@ -534,7 +542,10 @@ class InteractiveCommand(BaseCommand):
         self.ejecutar_codigo(codigo, validador, ast_preparseado=ast)
 
     def _debe_intentar_fallback_expresion_top_level(
-        self, codigo: str, err_original: Exception
+        self,
+        codigo: str,
+        err_original: Exception,
+        validador: Optional[Any] = None,
     ) -> bool:
         """Determina si aplica fallback a ``imprimir(...)`` para expresiones top-level."""
 
@@ -543,6 +554,9 @@ class InteractiveCommand(BaseCommand):
             return False
 
         ast = prevalidar_y_parsear_codigo(codigo)
+        # Ruta de análisis para decidir fallback: validar en modo silencioso
+        # para evitar auditoría ruidosa antes de la ejecución real del AST.
+        self._validar_ast_para_analisis(ast, validador)
         if not self._es_expresion_top_level_elegible(ast):
             return False
 


### PR DESCRIPTION
### Motivation
- Evitar que la fase de prevalidación/parseo dispare efectos observables o auditoría ruidosa antes de la ejecución real del AST en el REPL.

### Description
- En `parsear_y_ejecutar_codigo_repl` se añade llamada a `self._validar_ast_para_analisis(ast, validador)` para dejar explícito que la prevalidación es silenciosa (sin emisión).  
- En `ejecutar_codigo` se valida en modo análisis cuando `ast_preparseado` es `None`, garantizando que la emisión sólo se produzca dentro de `_ejecutar_ast_en_repl`.  
- Se modifica `_debe_intentar_fallback_expresion_top_level` para aceptar `validador: Optional[Any]` y ejecutar validación silenciosa en la ruta de decisión de fallback, y se propaga `validador` en las llamadas desde `ejecutar_codigo` y en el manejo de fallback.  
- Se añadieron comentarios de contrato en los puntos clave para dejar claro: prevalidación/parseo = sin emisión; ejecución del AST = emisión permitida.

### Testing
- Se compiló el archivo modificado con `python -m compileall src/pcobra/cobra/cli/commands/interactive_cmd.py` y la compilación completó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e0fe8a7483279ee9c38075b675b0)