### PR TITLE
Agregar estado de fase e in_execution() al intérprete REPL

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -412,6 +412,9 @@ class InterpretadorCobra:
             extra = self._cargar_validadores(extra)
 
         self.safe_mode = safe_mode
+        # Fase interna del intérprete; por defecto en ejecución para preservar
+        # el comportamiento actual fuera del REPL.
+        self.mode = "execution"
         self._validador = construir_cadena(extra) if safe_mode else None
         # Analizador semántico persistente para mantener contexto entre ejecuciones
         self.analizador = AnalizadorSemantico()
@@ -428,6 +431,10 @@ class InterpretadorCobra:
         self._eval_stack = set()
         # Último IR generado a partir del AST ejecutado
         self.ultimo_ir: Optional[InternalIRModule] = None
+
+    def in_execution(self) -> bool:
+        """Indica si el intérprete se encuentra en fase de ejecución."""
+        return self.mode == "execution"
 
     @property
     def variables(self):


### PR DESCRIPTION
### Motivation
- Añadir una bandera de fase en el intérprete REPL para distinguir análisis frente a ejecución y así facilitar decisiones de control de flujo sin dispersar condicionales por el código.

### Description
- En `src/pcobra/core/interpreter.py` se añadió `self.mode = "execution"` en `InterpretadorCobra.__init__` y se implementó el helper `def in_execution(self) -> bool` que retorna `self.mode == "execution"`, sin modificar nodos AST, tokens, parser ni lexer.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/core/interpreter.py` y la compilación estática del archivo finalizó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e2b9fb7c8327ac418d25ace20f80)