### PR TITLE
Controlar warning de 'Llamada a funcion' según fase de ejecución

### DIFF
--- a/src/pcobra/core/semantic_validators/auditoria.py
+++ b/src/pcobra/core/semantic_validators/auditoria.py
@@ -29,8 +29,13 @@ class ValidadorAuditoria(ValidadorBase):
             return
         logging.warning(mensaje)
 
+    def in_execution(self) -> bool:
+        """Indica si la auditoría debe emitir side effects en fase de ejecución."""
+        return self.emitir_side_effects
+
     def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
-        self._log(f"Llamada a funcion: {nodo.nombre}")
+        if self.in_execution():
+            self._log(f"Llamada a funcion: {nodo.nombre}")
         self.generic_visit(nodo)
 
     def visit_llamada_metodo(self, nodo: NodoLlamadaMetodo):


### PR DESCRIPTION
### Motivation
- Evitar que el validador de auditoría emita el warning `Llamada a funcion` durante el análisis semántico manteniendo la semántica de recorrido intacta.

### Description
- Se añadió el helper `in_execution()` en `ValidadorAuditoria` y se encapsuló la emisión `self._log(f"Llamada a funcion: {nodo.nombre}")` dentro de `if self.in_execution():`, dejando `self.generic_visit(nodo)` sin modificar.

### Testing
- Se ejecutó `pytest -q tests/unit/test_auditoria_validator.py` que pasó (1 passed) y se verificó con búsquedas en `src/pcobra/core/semantic_validators` que no existen otros logs equivalentes que deban silenciarse.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e3a7e5808327807898a78e53704e)