### PR TITLE
REPL: explicitar mode "analysis"/"execution" durante doble pasada AST

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -481,8 +481,10 @@ class InteractiveCommand(BaseCommand):
             # (sin emisión); la ejecución con emisión se habilita únicamente
             # dentro de ``_ejecutar_ast_en_repl``.
             if ast_preparseado is None:
+                self.interpretador.mode = "analysis"
                 self._validar_ast_para_analisis(ast, validador)
             validacion_no_silenciosa_realizada = False
+            self.interpretador.mode = "execution"
             ast, resultado = self._ejecutar_ast_en_repl(
                 ast,
                 validador,
@@ -498,6 +500,7 @@ class InteractiveCommand(BaseCommand):
             codigo_fallback = f"imprimir({codigo.strip()})"
             try:
                 ast_fallback = prevalidar_y_parsear_codigo(codigo_fallback)
+                self.interpretador.mode = "execution"
                 ast, resultado = self._ejecutar_ast_en_repl(
                     ast_fallback,
                     validador,
@@ -509,6 +512,10 @@ class InteractiveCommand(BaseCommand):
                 ):
                     raise err_original
                 raise
+        finally:
+            # REPL reutiliza la misma instancia de intérprete por sesión;
+            # restablecemos ejecución para no contaminar la siguiente entrada.
+            self.interpretador.mode = "execution"
         self.logger.debug("[EXEC] Ejecutando AST en intérprete")
         self.logger.debug("[EVAL] Resultado de evaluación: %r", resultado)
         self._imprimir_resultado_repl(ast, resultado)
@@ -532,6 +539,7 @@ class InteractiveCommand(BaseCommand):
         ast = prevalidar_fn(codigo)
         # Contrato de prevalidación/parseo en REPL: esta fase es solo de
         # análisis y no debe emitir side effects de auditoría.
+        self.interpretador.mode = "analysis"
         self._validar_ast_para_analisis(ast, validador)
         # Contrato de dispatch:
         # REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.


### PR DESCRIPTION
### Motivation
- Evitar que la instancia persistente del intérprete en el REPL mezcle fases de validación/análisis con la fase de ejecución y permitir trazabilidad explícita de la fase actual del evaluador.
- Mantener el contrato existente del REPL (dos pasadas: análisis silencioso + ejecución real) sin introducir pipelines adicionales ni tocar `BackendPipeline`.

### Description
- Se modificó `src/pcobra/cobra/cli/commands/interactive_cmd.py` para fijar `self.interpretador.mode = "analysis"` justo antes de la pasada preliminar de validación silenciosa en `parsear_y_ejecutar_codigo_repl` y en `ejecutar_codigo` cuando el AST no viene preparseado.
- Se estableció `self.interpretador.mode = "execution"` inmediatamente antes de la pasada real que invoca `_ejecutar_ast_en_repl`, incluyendo el camino de fallback con `imprimir(...)`.
- Se añadió un bloque `finally` que restaura `self.interpretador.mode = "execution"` al terminar el ciclo para no contaminar la siguiente entrada del REPL cuando se reutiliza la misma instancia del intérprete.
- No se añadieron pasos de compilación ni se tocaron componentes de backend o `BackendPipeline`.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py` y la verificación de sintaxis compiló correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e4b0eb188327af44b6bd2c11b4ae)