### PR TITLE
Guard semantic interpreter outputs behind `in_execution()`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -130,7 +130,7 @@ class InterpretadorCobra:
 
     def _trace_debug(self, mensaje: str) -> None:
         """Imprime trazas internas solo cuando el modo debug está activo."""
-        if self._debug_trazas_habilitadas():
+        if self.in_execution() and self._debug_trazas_habilitadas():
             print(mensaje)
 
     @staticmethod
@@ -1094,10 +1094,11 @@ class InterpretadorCobra:
                 nodo_origen=expresion,
                 operador="imprimir",
             )
-            if isinstance(valor, bool):
-                print("verdadero" if valor else "falso")
-            else:
-                print(valor)
+            if self.in_execution():
+                if isinstance(valor, bool):
+                    print("verdadero" if valor else "falso")
+                else:
+                    print(valor)
         elif isinstance(nodo, NodoImport):
             return self.ejecutar_import(nodo)
         elif isinstance(nodo, NodoUsar):
@@ -1569,7 +1570,8 @@ class InterpretadorCobra:
                     valor = "verdadero"
                 elif valor is False:
                     valor = "falso"
-                print(valor)
+                if self.in_execution():
+                    print(valor)
         else:
             funcion = self.obtener_variable(nodo.nombre)
             if not isinstance(funcion, dict) or funcion.get("tipo") != "funcion":
@@ -1744,7 +1746,8 @@ class InterpretadorCobra:
 
     def ejecutar_holobit(self, nodo):
         """Simula la ejecución de un holobit y devuelve sus valores."""
-        print(f"Simulando holobit: {nodo.nombre}")
+        if self.in_execution():
+            print(f"Simulando holobit: {nodo.nombre}")
         valores = []
         for v in nodo.valores:
             if isinstance(v, NodoValor):


### PR DESCRIPTION
### Motivation
- Evitar salidas a consola/log durante fases de análisis/visita que no deben tener efectos semánticos, manteniendo intacto el comportamiento de impresión en ejecución real.
- Proteger trazas y mensajes informativos emitidos por el visitor/evaluator para que solo ocurran cuando `InterpretadorCobra` esté en modo de ejecución (`mode == "execution"`).

### Description
- Se cambió `InterpretadorCobra._trace_debug` para que imprima solo si `self.in_execution()` y la variable de entorno `PCOBRA_DEBUG_TRACES` está activa, evitando trazas durante análisis.
- Se protegió la salida de la instrucción/nodo `imprimir` en `ejecutar_nodo` con `if self.in_execution():` para suprimir efectos fuera de ejecución.
- Se protegió la impresión de la builtin `imprimir(...)` en `ejecutar_llamada_funcion` con `if self.in_execution():` para preservar `imprimir` solo en ejecución real.
- Se protegió el mensaje informativo en `ejecutar_holobit` con `if self.in_execution():`.
- El archivo modificado es `src/pcobra/core/interpreter.py` y no se silencian excepciones ni mensajes de error reales (por ejemplo, mensajes sobre función no implementada o número de argumentos inválido permanecen).

### Testing
- Ejecuté `pytest -q tests/unit/test_interpreter.py tests/unit/test_interpreter_no_node_stringify.py` y ambos conjuntos unitarios pasaron correctamente (`22 passed`).
- Ejecuté `pytest -q tests/unit/test_interpreter.py tests/unit/test_interpreter_no_node_stringify.py tests/integration/test_run_repl_equivalence.py` y hubo 1 fallo en integración: `test_anidacion_condicional_bucle_equivale_en_salida_y_estado` falló porque no se lanzó la excepción esperada (las pruebas unitarias siguieron pasando).
- Las pruebas automatizadas mostraron que los cambios no rompen los tests unitarios relevantes pero hay una regresión en un caso de integración que conviene investigar adicionalmente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e5c5bf3c8327a06231c86a3694c3)