### PR TITLE
docs(repl): documentar doble pasada análisis + ejecución en flujo interactivo

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -533,6 +533,12 @@ class InteractiveCommand(BaseCommand):
         Este helper del flujo normal solo debe hacer:
         1) prevalidación/parseo;
         2) delegación a ``ejecutar_codigo``.
+
+        Nota técnica (doble pasada REPL):
+        - Pasada 1 (análisis): parseo + ``_validar_ast_para_analisis`` sin
+          side effects observables.
+        - Pasada 2 (ejecución): ``_validar_ast_para_ejecucion`` + evaluación
+          real nodo a nodo en ``self.interpretador``.
         """
 
         self._sincronizar_interpretador_sesion()


### PR DESCRIPTION
### Motivation
- Hacer explícito en el código el flujo de doble pasada del REPL (análisis silencioso + ejecución con efectos) para facilitar mantenimiento y evitar regresiones al trabajar con validadores/auditoría.

### Description
- Se añadió una nota técnica breve en el docstring de `InteractiveCommand.parsear_y_ejecutar_codigo_repl` describiendo las dos pasadas: 1) pasada de análisis (parseo + `_validar_ast_para_analisis` sin side effects) y 2) pasada de ejecución (`_validar_ast_para_ejecucion` + evaluación nodo a nodo en `self.interpretador`).
- Ningún comportamiento de runtime fue modificado y no se tocaron lexer, parser, tokens ni reglas gramaticales.
- Archivos relevantes inspeccionados durante el cambio: `src/pcobra/core/semantic_validators/auditoria.py` (contiene `visit_llamada_funcion` que emite `Llamada a funcion`), `src/pcobra/core/interpreter.py` (donde `NodoLlamadaFuncion` es evaluado y delega en `ejecutar_llamada_funcion`) y `src/pcobra/cobra/cli/commands/interactive_cmd.py` (donde se documentó el flujo REPL).

### Testing
- Se ejecutaron búsquedas automatizadas con `rg` para verificar la presencia y relación de cadenas y métodos relevantes (`Llamada a funcion`, `visit_llamada_funcion`, `ejecutar_llamada_funcion`, `_validar_ast_para_analisis`, `_validar_ast_para_ejecucion`, y la nota técnica) y todas las búsquedas devolvieron las ubicaciones esperadas (éxito).
- Se ejecutó `git commit` para registrar el cambio y el commit se completó correctamente (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e89d18748327afdcb436cb6b009e)