### PR TITLE
Controlar emisión de mensajes en llamadas de función según fase

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1575,13 +1575,15 @@ class InterpretadorCobra:
         else:
             funcion = self.obtener_variable(nodo.nombre)
             if not isinstance(funcion, dict) or funcion.get("tipo") != "funcion":
-                print(f"Funci\u00f3n '{nodo.nombre}' no implementada")
+                if self.in_execution():
+                    print(f"Funci\u00f3n '{nodo.nombre}' no implementada")
                 return None
 
             if len(funcion["parametros"]) != len(nodo.argumentos):
-                print(
-                    f"Error: se esperaban {len(funcion['parametros'])} argumentos"
-                )
+                if self.in_execution():
+                    print(
+                        f"Error: se esperaban {len(funcion['parametros'])} argumentos"
+                    )
                 return None
 
             contiene_yield = any(


### PR DESCRIPTION
### Motivation
- Evitar que los mensajes de consola (warnings/prints) relacionados con llamadas a función se emitan durante la fase de análisis y solo aparecer en la fase de ejecución, evitando duplicados en pipelines de análisis.
- Mantener intacta la semántica de evaluación y los valores de retorno de `ejecutar_llamada_funcion` mientras se reduce el ruido de side effects en fases no ejecutivas.

### Description
- Se modificó `src/pcobra/core/interpreter.py` en el método `ejecutar_llamada_funcion` para envolver los `print(...)` de las rutas de error con `if self.in_execution():` (mensajes de "función no implementada" y de mismatch de argumentos).
- Se mantuvo el comportamiento existente de `print` para la función `imprimir` ya condicionado por fase, y no se eliminaron mensajes, solo se controló cuándo se emiten.
- No se alteró la lógica de evaluación ni los `return None` en las ramas afectadas.

### Testing
- Se ejecutó `python -m pytest -q tests/unit/test_interpreter_loop_scope_regression.py` y todas las pruebas unitarias de ese módulo pasaron (`4 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f322692083278d651dd9415c7c90)