### PR TITLE
Refuerza reglas operativas del REPL y agrega prueba de auditoría única

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -428,10 +428,10 @@ class InteractiveCommand(BaseCommand):
         3) ``for nodo in ast: self.interpretador.ejecutar_nodo(nodo)``.
 
         Invariantes de fase (antirregresión):
-        - La fase de análisis usa ``_validar_ast_para_analisis`` (silenciosa,
-          sin side effects observables de auditoría).
-        - La fase de ejecución delega la validación con side effects en
-          ``InterpretadorCobra.ejecutar_nodo``.
+        - Regla operativa: **Análisis: silencioso** (sin side effects
+          observables de auditoría).
+        - Regla operativa: **Ejecución: un único recorrido con side effects**,
+          delegado en ``InterpretadorCobra.ejecutar_nodo``.
         - Para un mismo propósito de logging/auditoría, no duplicar validación
           con side effects sobre el mismo AST en una única corrida de ejecución.
 
@@ -471,6 +471,12 @@ class InteractiveCommand(BaseCommand):
         Contrato: REPL incremental = intérprete; no batch pipeline.
         Cada entrada se evalúa sobre ``self.interpretador`` (estado acumulado),
         no como una compilación por lotes/batch aislada.
+
+        Regla operativa explícita del REPL:
+        - **Análisis: silencioso** (parseo/prevalidación sin side effects
+          observables de auditoría).
+        - **Ejecución: un único recorrido con side effects** sobre el AST,
+          para preservar semántica y evitar duplicar eventos de auditoría.
         """
 
         self.logger.debug("[RUN] Ejecutando snippet en REPL")

--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -254,6 +254,34 @@ def test_repl_statement_normal_imprimir_no_duplica_salida():
 
 
 @pytest.mark.integration
+def test_repl_llamada_funcion_auditoria_una_sola_vez_y_retorno_correcto(caplog):
+    repl = InteractiveCommand(InterpretadorCobra())
+    repl._seguro_repl = False
+    repl._extra_validators_repl = None
+    out_repl, err_repl = StringIO(), StringIO()
+
+    with caplog.at_level("WARNING"):
+        with redirect_stdout(out_repl), redirect_stderr(err_repl):
+            repl.ejecutar_codigo(
+                "func duplicar(n):\n"
+                "    retorno n * 2\n"
+                "fin"
+            )
+            repl.ejecutar_codigo("duplicar(21)")
+
+    warnings_llamada = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage() == "Llamada a funcion: duplicar"
+    ]
+    lineas_salida = [linea.strip() for linea in out_repl.getvalue().splitlines() if linea.strip()]
+
+    assert err_repl.getvalue() == ""
+    assert warnings_llamada == ["Llamada a funcion: duplicar"]
+    assert lineas_salida[-1] == "42"
+
+
+@pytest.mark.integration
 def test_repl_incremental_var_var_imprimir_y_nameerror_sin_temporales_internas() -> None:
     repl = InteractiveCommand(InterpretadorCobra())
     repl._seguro_repl = False


### PR DESCRIPTION
### Motivation
- Aclarar y formalizar el contrato operacional del REPL para evitar validaciones/efectos de auditoría duplicados y preservar la semántica incremental del intérprete.
- Añadir una prueba de integración que prevenga regresiones donde una llamada a función en REPL podría generar más de un evento de auditoría o duplicar ejecuciones.

### Description
- Se reforzaron los docstrings en `InteractiveCommand._ejecutar_ast_en_repl` y `InteractiveCommand.ejecutar_codigo` para declarar explícitamente las reglas: **Análisis: silencioso** y **Ejecución: un único recorrido con side effects** (archivo `src/pcobra/cobra/cli/commands/interactive_cmd.py`).
- Se añadió la prueba de integración `test_repl_llamada_funcion_auditoria_una_sola_vez_y_retorno_correcto` en `tests/integration/test_run_repl_equivalence.py` que define una función en REPL, la invoca una vez, verifica que la advertencia `Llamada a funcion: duplicar` aparece exactamente una vez y que el resultado impreso es `42`.
- No se modificaron el lexer, parser, tokens ni la gramática del lenguaje.

### Testing
- Ejecuté `pytest -q tests/integration/test_run_repl_equivalence.py -k "auditoria_una_sola_vez"` inicialmente, lo que falló por un `ParserError` debido a una palabra clave usada incorrectamente en la prueba (se detectó y corregió el literal de retorno en la prueba).
- Después de corregir la prueba, volví a ejecutar `pytest -q tests/integration/test_run_repl_equivalence.py -k "auditoria_una_sola_vez"` y el resultado fue exitoso: `1 passed, 22 deselected, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f96d1be88327bed2b2dc962fdf38)