### PR TITLE
Formalizar fases "analysis"/"execution" en el intérprete

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -436,6 +436,14 @@ class InterpretadorCobra:
         """Indica si el intérprete se encuentra en fase de ejecución."""
         return self.mode == "execution"
 
+    def _set_mode(self, mode: str) -> str:
+        """Actualiza la fase del intérprete y retorna el modo previo."""
+        if mode not in {"analysis", "execution"}:
+            raise ValueError(f"Modo inválido: {mode}")
+        previo = self.mode
+        self.mode = mode
+        return previo
+
     @property
     def variables(self):
         """Devuelve el mapeo local del entorno activo (compatibilidad)."""
@@ -797,7 +805,9 @@ class InterpretadorCobra:
 
     # -- Utilidades ---------------------------------------------------------
     def _validar(self, nodo):
-        """Valida un nodo si el modo seguro está activo."""
+        """Valida un nodo en fase de análisis si el modo seguro está activo."""
+        if self.mode != "analysis":
+            return
         if self.safe_mode and id(nodo) not in self._validados:
             nodo.aceptar(self._validador)
             self._validados.add(id(nodo))
@@ -1051,11 +1061,16 @@ class InterpretadorCobra:
             self._trace_debug(
                 f"[RUN] index={index} node_type={type(nodo).__name__} node_id={id(nodo)}"
             )
-            self._validar(nodo)
-            self._trace_debug("[RUN] antes de ejecutar_nodo")
-            resultado = self.ejecutar_nodo(nodo)
-            if resultado is not None:
-                return resultado
+            modo_prev = self._set_mode("analysis")
+            try:
+                self._validar(nodo)
+                self._set_mode("execution")
+                self._trace_debug("[RUN] antes de ejecutar_nodo")
+                resultado = self.ejecutar_nodo(nodo)
+                if resultado is not None:
+                    return resultado
+            finally:
+                self.mode = modo_prev
         return None
 
     # -- Generación de IR ----------------------------------------------------
@@ -1066,7 +1081,6 @@ class InterpretadorCobra:
 
     def ejecutar_nodo(self, nodo):
         self._trace_debug(f"[EXEC] node_type={type(nodo).__name__} node_id={id(nodo)}")
-        self._validar(nodo)
         if isinstance(nodo, NodoAsignacion):
             return self.ejecutar_asignacion(nodo)
         elif isinstance(nodo, NodoCondicional):
@@ -1732,8 +1746,13 @@ class InterpretadorCobra:
         if total > max_nodos:
             raise RuntimeError(f"El AST excede el límite de {max_nodos} nodos")
         for subnodo in ast:
-            self._validar(subnodo)
-            self.ejecutar_nodo(subnodo)
+            modo_prev = self._set_mode("analysis")
+            try:
+                self._validar(subnodo)
+                self._set_mode("execution")
+                self.ejecutar_nodo(subnodo)
+            finally:
+                self.mode = modo_prev
 
     def ejecutar_usar(self, nodo):
         """Importa un módulo de Python instalándolo si es necesario."""


### PR DESCRIPTION
### Motivation
- Centralizar y formalizar el ciclo de fases del intérprete para distinguir claramente entre la fase de análisis/validación y la fase de ejecución. 
- Evitar validaciones que produzcan efectos visibles durante la ejecución y prevenir fugas de estado de fase entre nodos.

### Description
- Añadí el helper `def _set_mode(self, mode: str) -> str` para forzar que `self.mode` solo tome `"analysis"` o `"execution"` y devolver el modo previo. 
- Envolví el flujo por nodo en `ejecutar_ast` con `self._set_mode("analysis")` antes de `_validar(...)`, luego `self._set_mode("execution")` antes de `ejecutar_nodo(...)`, y siempre restaurando el modo previo en `finally`. 
- Apliqué el mismo patrón de `analysis -> execution -> restore` en `ejecutar_import` para los subnodos del módulo importado. 
- Modifiqué `_validar` para que solo realice la validación cuando `self.mode == "analysis"` y eliminé la llamada redundante a `_validar` dentro de `ejecutar_nodo` para que la validación ocurra únicamente en la fase de análisis controlada.

### Testing
- Ejecuté compilación estática del archivo modificado con `python -m py_compile src/pcobra/core/interpreter.py` y la verificación final fue exitosa. 
- No se añadieron tests automatizados nuevos para esta modificación y todos los cambios se limitaron a `src/pcobra/core/interpreter.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58078b6a48327b9afa7758332a2b7)