### PR TITLE
Alinear side effects de auditoría con fases de análisis/ejecución

### DIFF
--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -244,7 +244,7 @@ class CompileCommand(BaseCommand):
                 codigo = f.read()
 
             ast = obtener_ast(codigo)
-            validador = construir_cadena()
+            validador = construir_cadena(emitir_side_effects=False)
             for nodo in ast:
                 nodo.aceptar(validador)
 

--- a/src/pcobra/cobra/cli/commands/profile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/profile_cmd.py
@@ -138,7 +138,8 @@ class ProfileCommand(BaseCommand):
                 validador = construir_cadena(
                     InterpretadorCobra._cargar_validadores(extra_validators)
                     if isinstance(extra_validators, str)
-                    else extra_validators
+                    else extra_validators,
+                    emitir_side_effects=False,
                 )
                 for nodo in ast:
                     nodo.aceptar(validador)

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -415,7 +415,9 @@ class InterpretadorCobra:
         # Fase interna del intérprete; por defecto en ejecución para preservar
         # el comportamiento actual fuera del REPL.
         self.mode = "execution"
-        self._validador = construir_cadena(extra) if safe_mode else None
+        self._validador = (
+            construir_cadena(extra, emitir_side_effects=False) if safe_mode else None
+        )
         # Analizador semántico persistente para mantener contexto entre ejecuciones
         self.analizador = AnalizadorSemantico()
         # Conjunto para evitar validar el mismo nodo varias veces
@@ -442,6 +444,8 @@ class InterpretadorCobra:
             raise ValueError(f"Modo inválido: {mode}")
         previo = self.mode
         self.mode = mode
+        if self._validador is not None and hasattr(self._validador, "emitir_side_effects"):
+            self._validador.emitir_side_effects = mode == "execution"
         return previo
 
     @property

--- a/src/pcobra/core/semantic_validators/__init__.py
+++ b/src/pcobra/core/semantic_validators/__init__.py
@@ -18,10 +18,10 @@ from ..cobra_config import auditoria_activa
 
 # Instancia por defecto reutilizable de la cadena de validación
 _CADENA_DEFECTO = None
-_CACHE_INFO: tuple[FunctionType, bool] | None = None
+_CACHE_INFO: tuple[FunctionType, bool, bool] | None = None
 
 
-def construir_cadena(extra_validators=None):
+def construir_cadena(extra_validators=None, *, emitir_side_effects: bool = False):
     """Devuelve la cadena de validadores por defecto.
 
     Si no se proporcionan validadores extra, la cadena se crea una única vez y
@@ -34,12 +34,12 @@ def construir_cadena(extra_validators=None):
     if (
         extra_validators is None
         and _CADENA_DEFECTO is not None
-        and _CACHE_INFO == (ValidadorPrimitivaPeligrosa.__init__, auditoria)
+        and _CACHE_INFO == (ValidadorPrimitivaPeligrosa.__init__, auditoria, emitir_side_effects)
     ):
         return _CADENA_DEFECTO
 
     if auditoria:
-        primero = ValidadorAuditoria()
+        primero = ValidadorAuditoria(emitir_side_effects=emitir_side_effects)
         actual = primero.set_siguiente(ValidadorPrimitivaPeligrosa())
     else:
         primero = ValidadorPrimitivaPeligrosa()
@@ -54,7 +54,7 @@ def construir_cadena(extra_validators=None):
 
     if extra_validators is None:
         _CADENA_DEFECTO = primero
-        _CACHE_INFO = (ValidadorPrimitivaPeligrosa.__init__, auditoria)
+        _CACHE_INFO = (ValidadorPrimitivaPeligrosa.__init__, auditoria, emitir_side_effects)
 
     return primero
 

--- a/src/pcobra/core/semantic_validators/auditoria.py
+++ b/src/pcobra/core/semantic_validators/auditoria.py
@@ -39,22 +39,27 @@ class ValidadorAuditoria(ValidadorBase):
         self.generic_visit(nodo)
 
     def visit_llamada_metodo(self, nodo: NodoLlamadaMetodo):
-        self._log(f"Llamada a metodo: {nodo.nombre_metodo}")
+        if self.in_execution():
+            self._log(f"Llamada a metodo: {nodo.nombre_metodo}")
         self.generic_visit(nodo)
 
     def visit_hilo(self, nodo: NodoHilo):
-        self._log(f"Ejecucion de hilo: {nodo.llamada.nombre}")
+        if self.in_execution():
+            self._log(f"Ejecucion de hilo: {nodo.llamada.nombre}")
         nodo.llamada.aceptar(self)
         self.delegar(nodo)
 
     def visit_import(self, nodo: NodoImport):
-        self._log(f"Import de modulo: {nodo.ruta}")
+        if self.in_execution():
+            self._log(f"Import de modulo: {nodo.ruta}")
         self.generic_visit(nodo)
 
     def visit_usar(self, nodo: NodoUsar):
-        self._log(f"Usar modulo: {nodo.modulo}")
+        if self.in_execution():
+            self._log(f"Usar modulo: {nodo.modulo}")
         self.generic_visit(nodo)
 
     def visit_import_desde(self, nodo: NodoImportDesde):
-        self._log(f"Importar desde: {nodo.modulo}")
+        if self.in_execution():
+            self._log(f"Importar desde: {nodo.modulo}")
         self.generic_visit(nodo)


### PR DESCRIPTION
### Motivation
- Evitar que el validador de auditoría emita efectos secundarios (warnings/logs) durante la fase de análisis, usando una única fuente de verdad para ese comportamiento.
- Garantizar que la misma política se respete en todas las visitas relevantes (`llamada funcion`, `llamada metodo`, `hilo`, `import`, `usar`, `import desde`) y cuando se reutiliza la cadena de validadores.
- Permitir construir/configurar la cadena de validadores para análisis sin side effects y activarlos solo en ejecución.

### Description
- Hice que todos los visitantes relevantes de `ValidadorAuditoria` usen el gate central `in_execution()` y el patrón `if self.in_execution(): self._log(...)` para prevenir side effects en análisis (arch: `src/pcobra/core/semantic_validators/auditoria.py`).
- Añadí el parámetro `emitir_side_effects` a `construir_cadena(...)` y extendí la cache para distinguir cadenas según esa bandera, y propagué la bandera a `ValidadorAuditoria` al construir la cadena (arch: `src/pcobra/core/semantic_validators/__init__.py`).
- En `InterpretadorCobra` configuro la cadena segura con `emitir_side_effects=False` para la fase de análisis y sincronizo la propiedad `emitir_side_effects` del validador reutilizado cuando el intérprete cambia de modo en `_set_mode` (`execution`/`analysis`) (arch: `src/pcobra/core/interpreter.py`).
- Ajusté las rutas de análisis en la CLI para construir la cadena sin side effects durante el análisis estático en `compile_cmd` y `profile_cmd` (arch: `src/pcobra/cobra/cli/commands/compile_cmd.py`, `src/pcobra/cobra/cli/commands/profile_cmd.py`).

### Testing
- Ejecuté `python -m compileall` sobre los módulos modificados (`src/pcobra/core/semantic_validators/auditoria.py`, `src/pcobra/core/semantic_validators/__init__.py`, `src/pcobra/core/interpreter.py`, `src/pcobra/cobra/cli/commands/compile_cmd.py`, `src/pcobra/cobra/cli/commands/profile_cmd.py`) y compilación exitosa sin errores de sintaxis.
- No se observaron excepciones en la fase de compilación estática tras los cambios, indicando que la API modificada es consistente con los usos actualizados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5833606b08327a00daca9ce6f00b3)