### PR TITLE
Evitar ejecución del cuerpo al definir funciones en el REPL

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1585,6 +1585,7 @@ class InterpretadorCobra:
         funcion = self._construir_funcion(nodo)
         self._verificar_valor_contexto(funcion)
         self.contextos[-1].define(nodo.nombre, funcion)
+        return None
 
     def ejecutar_llamada_funcion(self, nodo):
         """Ejecuta la invocación de una función, interna o del usuario."""

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -336,6 +336,36 @@ def test_ejecutar_funcion_solo_registra_en_entorno_sin_recorrer_cuerpo():
         inter.ejecutar_nodo(triple)
 
     assert out.getvalue() == ""
+
+
+def test_definir_funcion_retorna_none_y_no_evalua_cuerpo_en_definicion():
+    inter = InterpretadorCobra()
+
+    funcion = NodoFuncion(
+        "f",
+        ["x"],
+        [
+            NodoRetorno(
+                NodoOperacionBinaria(
+                    NodoIdentificador("x"),
+                    TipoToken.SUMA,
+                    NodoValor(1),
+                )
+            )
+        ],
+    )
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        resultado = inter.ejecutar_nodo(funcion)
+
+    assert resultado is None
+    assert out.getvalue() == ""
+    registro = inter.obtener_variable("f")
+    assert isinstance(registro, dict)
+    assert registro.get("tipo") == "funcion"
+    assert registro.get("nombre") == "f"
+    assert registro.get("parametros") == ["x"]
+    assert registro.get("cuerpo") == funcion.cuerpo.instrucciones
 def test_validacion_llamada_funcion_no_duplica_warning_en_invocacion_simple(monkeypatch):
     inter = InterpretadorCobra()
     warnings_emitidos = []


### PR DESCRIPTION
### Motivation
- Asegurar que la definición de funciones en el REPL no ejecute ni recorra el `cuerpo` en el momento de la definición y que la operación sea sin efectos secundarios.
- Garantizar que el descriptor/AST de la función quede registrado en el entorno persistente con la metadata necesaria (`tipo`, `nombre`, `parametros`, `cuerpo`).

### Description
- Se añadió un `return None` explícito al final de `InterpretadorCobra.ejecutar_funcion` para evitar efectos colaterales tras registrar la función en el entorno (archivo `src/pcobra/core/interpreter.py`).
- Se añadió la prueba `test_definir_funcion_retorna_none_y_no_evalua_cuerpo_en_definicion` en `tests/unit/test_interpreter.py` que verifica que definir `f(x): retorno x + 1 fin` devuelve `None`, no imprime nada y registra la función con `tipo`, `nombre`, `parametros` y `cuerpo` (comparando `cuerpo` con `funcion.cuerpo.instrucciones`).
- Se actualizó la aserción del test para comparar el `cuerpo` almacenado con `funcion.cuerpo.instrucciones` cuando aplica (archivo `tests/unit/test_interpreter.py`).

### Testing
- Ejecutado `pytest -q tests/unit/test_interpreter.py -k "ejecutar_funcion_solo_registra or definir_funcion_retorna_none"` y ambos tests relevantes pasaron exitosamente.
- Las pruebas específicas confirman que la definición no produce salida ni evaluación del cuerpo y que el registro de la función conserva la metadata esperada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f598f82fe48327b76e83609890c39a)