### PR TITLE
Refuerza fases analysis/execution en InterpretadorCobra

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -412,8 +412,8 @@ class InterpretadorCobra:
             extra = self._cargar_validadores(extra)
 
         self.safe_mode = safe_mode
-        # Fase interna del intérprete; por defecto en ejecución para preservar
-        # el comportamiento actual fuera del REPL.
+        # Regla de fases: analysis = sin efectos, execution = con efectos.
+        # Por defecto iniciamos en ejecución para preservar compatibilidad fuera del REPL.
         self.mode = "execution"
         self._validador = (
             construir_cadena(extra, emitir_side_effects=False) if safe_mode else None
@@ -1085,6 +1085,9 @@ class InterpretadorCobra:
 
     def ejecutar_nodo(self, nodo):
         self._trace_debug(f"[EXEC] node_type={type(nodo).__name__} node_id={id(nodo)}")
+        if self.mode == "analysis":
+            # En análisis no se ejecutan nodos: evita prints, mutaciones y efectos observables.
+            return None
         if isinstance(nodo, NodoAsignacion):
             return self.ejecutar_asignacion(nodo)
         elif isinstance(nodo, NodoCondicional):


### PR DESCRIPTION
### Motivation
- Asegurar que la pasada de análisis del REPL no produzca efectos observables (prints, warnings, mutaciones) manteniendo la ejecución real intacta.

### Description
- Documenté la regla de fases en `InterpretadorCobra` como: “analysis = sin efectos, execution = con efectos”, y mantuve `self.mode = "execution"` por defecto para compatibilidad fuera del REPL.
- Añadí un guard explícito al inicio de `ejecutar_nodo` que retorna `None` cuando `self.mode == "analysis"`, evitando así prints y mutaciones durante la fase de análisis.
- No se modificó la lógica de doble pasada existente (`_set_mode("analysis")` → `_validar` → `_set_mode("execution")`), de modo que el flujo de validación/ejecución sigue funcionando.

### Testing
- Ejecuté pruebas focalizadas con: `pytest -q tests/integration/test_run_repl_equivalence.py -k "fallback_expresion_sin_duplicar_salida_y_nameerror_real_preservado or statement_normal_imprimir_no_duplica_salida"`.
- Resultado: las pruebas específicas pasaron (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f59b5cc9e8832799b03a39442a7a3c)