### PR TITLE
Restringir warnings de auditoría de llamadas por fase de ejecución

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -416,7 +416,7 @@ class InterpretadorCobra:
         # Por defecto iniciamos en ejecución para preservar compatibilidad fuera del REPL.
         self.mode = "execution"
         self._validador = (
-            construir_cadena(extra, emitir_side_effects=False) if safe_mode else None
+            construir_cadena(extra, emitir_side_effects=True) if safe_mode else None
         )
         # Analizador semántico persistente para mantener contexto entre ejecuciones
         self.analizador = AnalizadorSemantico()
@@ -446,6 +446,8 @@ class InterpretadorCobra:
         self.mode = mode
         if self._validador is not None and hasattr(self._validador, "emitir_side_effects"):
             self._validador.emitir_side_effects = mode == "execution"
+            if hasattr(self._validador, "mode"):
+                self._validador.mode = mode
         return previo
 
     @property

--- a/src/pcobra/core/semantic_validators/auditoria.py
+++ b/src/pcobra/core/semantic_validators/auditoria.py
@@ -22,16 +22,18 @@ class ValidadorAuditoria(ValidadorBase):
     def __init__(self, emitir_side_effects: bool = True) -> None:
         super().__init__()
         self.emitir_side_effects = emitir_side_effects
+        # Fase explícita para alinear los side effects con el intérprete.
+        self.mode = "execution" if emitir_side_effects else "analysis"
 
     def _log(self, mensaje: str) -> None:
         # Fuente de verdad centralizada para side effects de auditoría.
-        if not self.emitir_side_effects:
+        if not self.in_execution():
             return
         logging.warning(mensaje)
 
     def in_execution(self) -> bool:
         """Indica si la auditoría debe emitir side effects en fase de ejecución."""
-        return self.emitir_side_effects
+        return self.emitir_side_effects and self.mode == "execution"
 
     def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
         if self.in_execution():


### PR DESCRIPTION
### Motivation
- Evitar que la auditoría emita advertencias de llamadas a función fuera de la fase de ejecución para prevenir duplicados y emisiones durante la definición de funciones.

### Description
- Centralicé la guardia en el helper `_log` de `ValidadorAuditoria` para que use `logging.warning` solo cuando `in_execution()` sea verdadero en vez de comprobaciones dispersas.
- Añadí un atributo `mode` a `ValidadorAuditoria` y actualicé `in_execution()` para requerir simultáneamente `emitir_side_effects` y `mode == "execution"`.
- Sincronicé el modo del validador desde `InterpretadorCobra._set_mode(...)` asignando `self._validador.mode = mode` cuando el validador lo soporte.
- Ajusté la inicialización de la cadena de validadores en el intérprete para crear el validador con `emitir_side_effects=True` en el caso de `safe_mode` activo, preservando la emisión durante ejecución normal.

### Testing
- Ejecuté `pytest -q tests/unit/test_auditoria_validator.py` durante la iteración y observé 2 fallos antes de ajustar el intérprete (fallos relacionados con la captura de warnings).
- Después de los cambios, ejecuté `pytest -q tests/unit/test_interpreter.py -k "validacion_llamada_funcion_no_duplica_warning_en_invocacion_simple or definir_funcion_retorna_none_y_no_evalua_cuerpo_en_definicion"` y los tests relevantes pasaron (2 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f59ff1cb248327b2069863ca6fdf61)