### PR TITLE
test: validar ejecución única del body de funciones y que `retorno` corta flujo

### DIFF
--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -418,3 +418,44 @@ def test_validacion_llamada_anidada_emite_un_warning_por_funcion(monkeypatch):
 
     assert warnings_emitidos.count("triple") == 1
     assert warnings_emitidos.count("doble") == 1
+
+
+def test_llamada_funcion_ejecuta_cuerpo_una_sola_vez_por_invocacion(monkeypatch):
+    """Garantiza que cada invocación recorre el body exactamente una vez."""
+    inter = InterpretadorCobra()
+    ejecuciones_retorno = []
+
+    identidad = NodoFuncion("identidad", ["x"], [NodoRetorno(NodoIdentificador("x"))])
+    inter.ejecutar_nodo(identidad)
+
+    original = inter.ejecutar_nodo
+
+    def _spy(nodo):
+        if isinstance(nodo, NodoRetorno):
+            ejecuciones_retorno.append(id(nodo))
+        return original(nodo)
+
+    monkeypatch.setattr(inter, "ejecutar_nodo", _spy)
+
+    assert inter.ejecutar_llamada_funcion(NodoLlamadaFuncion("identidad", [NodoValor(10)])) == 10
+    assert inter.ejecutar_llamada_funcion(NodoLlamadaFuncion("identidad", [NodoValor(20)])) == 20
+    assert len(ejecuciones_retorno) == 2
+
+
+def test_retorno_corta_flujo_y_no_reingresa_al_body():
+    """Tras retorno temprano no debe ejecutarse ninguna instrucción posterior."""
+    inter = InterpretadorCobra()
+    inter.ejecutar_nodo(NodoAsignacion("contador", NodoValor(0), declaracion=True))
+
+    corta = NodoFuncion(
+        "corta",
+        [],
+        [
+            NodoRetorno(NodoValor(7)),
+            NodoAsignacion("contador", NodoValor(99)),
+        ],
+    )
+
+    inter.ejecutar_nodo(corta)
+    assert inter.ejecutar_nodo(NodoLlamadaFuncion("corta", [])) == 7
+    assert inter.obtener_variable("contador") == 0


### PR DESCRIPTION
### Motivation
- Asegurar el contrato de ejecución de llamadas a función: resolver la función desde el entorno, crear un scope local para parámetros y ejecutar el `body` exactamente una vez por invocación.
- Evitar regresiones que produzcan dobles recorridos del `body` o reingreso tras un `retorno` por control-flow.

### Description
- Añadí pruebas unitarias en `tests/unit/test_interpreter.py` que verifican que el cuerpo de la función se recorre una sola vez por invocación (`test_llamada_funcion_ejecuta_cuerpo_una_sola_vez_por_invocacion`).
- Añadí una prueba que confirma que un `retorno` temprano corta el flujo y no ejecuta instrucciones posteriores del `body` (`test_retorno_corta_flujo_y_no_reingresa_al_body`).
- No se modificó la lógica del intérprete; durante la revisión confirmé que `ejecutar_llamada_funcion` resuelve la función con `self.obtener_variable(...)`, prepara el contexto local (`preparar_contexto`) y ejecuta el body en un único bucle retornando al detectar un resultado.

### Testing
- Ejecutado: `pytest -q tests/unit/test_interpreter.py -k "validacion_llamada or ejecuta_cuerpo_una_sola_vez or retorno_corta_flujo"` y la ejecución final resultó en `4 passed, 21 deselected`.
- También lancé `pytest -q tests/unit/test_interpreter.py -k "validacion_llamada or ejecuta_cuerpo_una_sola_vez or retorno_corta_flujo"` durante el desarrollo para depurar un falso positivo y confirmé tras el ajuste que todas las nuevas pruebas pasan.
- Confirmé el commit con mensaje `test: validate single-pass function call execution` que incluye solo cambios en `tests/unit/test_interpreter.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5a14a40648327b5bbb644d5aa7c93)