### PR TITLE
fix(repl): enforce single-emission audit flow per executed call

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -403,6 +403,14 @@ class InteractiveCommand(BaseCommand):
 
     def _validar_ast_para_analisis(self, ast: list[Any], validador: Optional[Any]) -> None:
         """Valida AST para análisis estático sin side effects observables."""
+        # Guarda de consistencia: en fase efectiva de ejecución no se debe
+        # disparar esta validación para evitar doble emisión de auditoría
+        # sobre un mismo nodo ya ejecutado.
+        if self.mode == "execution" or getattr(self.interpretador, "mode", None) == "execution":
+            self.logger.debug(
+                "[GUARD] Se omite validación de análisis porque el modo efectivo es execution."
+            )
+            return
         self._recorrer_validacion_ast(ast, validador, silencioso=True)
 
     def _validar_ast_para_ejecucion(self, ast: list[Any], validador: Optional[Any]) -> None:
@@ -476,7 +484,8 @@ class InteractiveCommand(BaseCommand):
         - **Análisis: silencioso** (parseo/prevalidación sin side effects
           observables de auditoría).
         - **Ejecución: un único recorrido con side effects** sobre el AST,
-          para preservar semántica y evitar duplicar eventos de auditoría.
+          para preservar semántica y evitar duplicar eventos de auditoría
+          (single-emission per executed call).
         """
 
         self.logger.debug("[RUN] Ejecutando snippet en REPL")


### PR DESCRIPTION
### Motivation
- Evitar que el validador de auditoría se dispare dos veces por la misma línea ejecutada en el REPL al asegurar la secuencia clara de `analysis` (sin efectos) seguida de `execution` (con side effects). 

### Description
- Añadida una guarda en `_validar_ast_para_analisis` para omitir la validación de análisis si el modo efectivo (`self.mode` o `self.interpretador.mode`) ya es `"execution"` y así prevenir emisiones duplicadas de auditoría. 
- Documentado en el comentario del flujo REPL que la auditoría de llamadas es “single-emission per executed call”.

### Testing
- Compilación sintáctica ejecutada con `python -m compileall` sobre los archivos modificados y completada correctamente. 
- Búsqueda realizada con `rg` confirmó que la advertencia `"Llamada a funcion:"` solo existe en `visit_llamada_funcion` y no hay duplicados en el repositorio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5a31d7f50832783f761f0fe6dffc5)