### PR TITLE
test: add regression coverage for function-definition execution leaks

### DIFF
--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -103,6 +103,51 @@ def test_funcion_actualiza_scope_lexico_capturado():
     assert inter.obtener_variable("a") == 1
 
 
+def test_definicion_funcion_no_ejecuta_cuerpo_ni_evalua_parametros(monkeypatch):
+    """Regresión: definir una función no debe ejecutar su cuerpo."""
+    inter = InterpretadorCobra()
+    inter.ejecutar_asignacion(NodoAsignacion("contador", NodoValor(0), declaracion=True))
+
+    llamadas = []
+    evaluaciones_x = []
+
+    original_evaluar = inter.evaluar_expresion
+
+    def spy_llamada(nodo):
+        llamadas.append(nodo.nombre)
+        return None
+
+    def spy_evaluar(expr):
+        if isinstance(expr, NodoIdentificador) and expr.nombre == "x":
+            evaluaciones_x.append("x")
+        return original_evaluar(expr)
+
+    monkeypatch.setattr(inter, "ejecutar_llamada_funcion", spy_llamada)
+    monkeypatch.setattr(inter, "evaluar_expresion", spy_evaluar)
+
+    funcion = NodoFuncion(
+        "combinar",
+        ["x"],
+        [
+            NodoLlamadaFuncion("doble", [NodoIdentificador("x")]),
+            NodoRetorno(
+                NodoOperacionBinaria(
+                    NodoIdentificador("x"),
+                    Token(TipoToken.SUMA, "+"),
+                    NodoValor(1),
+                )
+            ),
+            NodoAsignacion("contador", NodoValor(99)),
+        ],
+    )
+
+    inter.ejecutar_funcion(funcion)
+
+    assert llamadas == []
+    assert evaluaciones_x == []
+    assert inter.obtener_variable("contador") == 0
+
+
 def test_regresion_llamada_funcion_no_yield_limpia_contexto_una_sola_vez():
     """Evita doble limpieza de contexto y underflow de pilas internas."""
     inter = InterpretadorCobra()


### PR DESCRIPTION
### Motivation

- Asegurar que `ejecutar_funcion` solo registre la definición de la función y no ejecute su cuerpo ni evalúe parámetros en tiempo de definición.
- Evitar regresiones donde la definición de una función provocara llamadas, evaluación de identificadores o side effects en el intérprete.

### Description

- Se añadió el test `test_definicion_funcion_no_ejecuta_cuerpo_ni_evalua_parametros` en `tests/unit/test_interpreter.py` que define `combinar(x)` cuyo cuerpo contiene una llamada a `doble(x)`, una expresión de retorno `x + 1` y una asignación que produciría un side effect observable (`contador = 99`).
- El test usa `monkeypatch` para espiar `ejecutar_llamada_funcion` y `evaluar_expresion` y verificar que durante la llamada a `ejecutar_funcion` no se invocan llamadas, no se evalúa el identificador `x` y no hay cambios en `contador`.
- El cambio se limitó únicamente al archivo de tests y se mantuvo el alcance en la capa de intérprete sin tocar lexer/parser/gramática.

### Testing

- Se ejecutó el conjunto objetivo con `pytest -q tests/unit/test_interpreter.py -k "definicion_funcion_no_ejecuta_cuerpo_ni_evalua_parametros or funcion_actualiza_scope_lexico_capturado or aislamiento_de_contexto_en_funciones"` y los tests seleccionados pasaron correctamente.
- Resultado observado: `3 passed, 24 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5aa68388c832788d819825c451cd3)