### PR TITLE
Restaurar mode con _set_mode en errores y añadir pruebas de regresión

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1076,7 +1076,7 @@ class InterpretadorCobra:
                 if resultado is not None:
                     return resultado
             finally:
-                self.mode = modo_prev
+                self._set_mode(modo_prev)
         return None
 
     # -- Generación de IR ----------------------------------------------------
@@ -1777,7 +1777,7 @@ class InterpretadorCobra:
                 self._set_mode("execution")
                 self.ejecutar_nodo(subnodo)
             finally:
-                self.mode = modo_prev
+                self._set_mode(modo_prev)
 
     def ejecutar_usar(self, nodo):
         """Importa un módulo de Python instalándolo si es necesario."""

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -11,6 +11,7 @@ from core.ast_nodes import (
     NodoFuncion,
     NodoIdentificador,
     NodoImprimir,
+    NodoImport,
     NodoLlamadaFuncion,
     NodoOperacionBinaria,
     NodoRetorno,
@@ -566,3 +567,78 @@ def test_retorno_corta_flujo_y_no_reingresa_al_body():
     inter.ejecutar_nodo(corta)
     assert inter.ejecutar_nodo(NodoLlamadaFuncion("corta", [])) == 7
     assert inter.obtener_variable("contador") == 0
+
+
+def test_mode_se_restaura_en_ejecutar_ast_si_falla_validacion(monkeypatch):
+    """Evita phase leak: tras error en _validar no debe quedar analysis ni warnings duplicados."""
+    inter = InterpretadorCobra()
+    modo_inicial = inter.mode
+
+    def _falla_validacion(_nodo):
+        raise RuntimeError("fallo validacion")
+
+    monkeypatch.setattr(inter, "_validar", _falla_validacion)
+
+    with pytest.raises(RuntimeError, match="fallo validacion"):
+        inter.ejecutar_ast([NodoValor(1)])
+
+    assert inter.mode == modo_inicial
+    assert inter._validador.emitir_side_effects is True
+
+
+def test_mode_se_restaura_en_ejecutar_ast_si_falla_ejecucion(monkeypatch):
+    """Evita phase leak: si ejecutar_nodo falla, el modo vuelve y no deja side effects en análisis."""
+    inter = InterpretadorCobra()
+    modo_inicial = inter.mode
+
+    monkeypatch.setattr(inter, "_validar", lambda _nodo: None)
+
+    def _falla_ejecucion(_nodo):
+        raise ValueError("fallo ejecucion")
+
+    monkeypatch.setattr(inter, "ejecutar_nodo", _falla_ejecucion)
+
+    with pytest.raises(ValueError, match="fallo ejecucion"):
+        inter.ejecutar_ast([NodoValor(2)])
+
+    assert inter.mode == modo_inicial
+    assert inter._validador.emitir_side_effects is True
+
+
+def test_mode_se_restaura_en_import_si_falla_validacion(monkeypatch):
+    """Previene WARNING duplicados por phase leak al romperse la validación de import."""
+    inter = InterpretadorCobra()
+    modo_inicial = inter.mode
+
+    monkeypatch.setattr("core.interpreter.cargar_ast_modulo", lambda *a, **k: [NodoValor(1)])
+
+    def _falla_validacion(_nodo):
+        raise RuntimeError("validacion import")
+
+    monkeypatch.setattr(inter, "_validar", _falla_validacion)
+
+    with pytest.raises(RuntimeError, match="validacion import"):
+        inter.ejecutar_import(NodoImport("modulo.cobra"))
+
+    assert inter.mode == modo_inicial
+    assert inter._validador.emitir_side_effects is True
+
+
+def test_mode_se_restaura_en_import_si_falla_ejecucion(monkeypatch):
+    """Previene WARNING duplicados por phase leak si import falla al ejecutar_nodo."""
+    inter = InterpretadorCobra()
+    modo_inicial = inter.mode
+
+    monkeypatch.setattr("core.interpreter.cargar_ast_modulo", lambda *a, **k: [NodoValor(3)])
+    monkeypatch.setattr(inter, "_validar", lambda _nodo: None)
+
+    def _falla_ejecucion(_nodo):
+        raise LookupError("ejecucion import")
+
+    monkeypatch.setattr(inter, "ejecutar_nodo", _falla_ejecucion)
+
+    with pytest.raises(LookupError, match="ejecucion import"):
+        inter.ejecutar_import(NodoImport("modulo.cobra"))
+
+    assert inter.mode == modo_inicial
+    assert inter._validador.emitir_side_effects is True


### PR DESCRIPTION
### Motivation
- Evitar que una excepción durante la fase de análisis/ejecución deje el intérprete en modo `analysis` y provoque efectos secundarios no deseados del validador (duplicados de WARNING por "phase leak").
- Cubrir con pruebas las rutas que alternan modo: ejecución principal de AST (`ejecutar_ast`) y la ruta de `ejecutar_import` para detectar regresiones futuras.

### Description
- Añadí pruebas unitarias en `tests/unit/test_interpreter.py` que simulan excepciones en `_validar` y en `ejecutar_nodo` para las rutas de `ejecutar_ast` y `ejecutar_import`, documentando en los comentarios que esto previene duplicados de WARNING por "phase leak".
- Reemplacé las asignaciones directas a `self.mode = modo_prev` por llamadas a `self._set_mode(modo_prev)` en `ejecutar_ast` y `ejecutar_import` para que la restauración del modo propague correctamente el estado al validador (`emitir_side_effects` / `mode`).
- Los cambios mantienen el contrato del intérprete respecto a fases (`analysis` vs `execution`) incluso cuando se producen excepciones durante el flujo.

### Testing
- Ejecuté `pytest -q tests/unit/test_interpreter.py -k "mode_se_restaura"` y las pruebas específicas de regresión pasaron (`4 passed, 27 deselected`).
- Ejecuté `pytest -q tests/unit/test_interpreter.py` contra la suite completa de tests unitarios del intérprete y todos pasaron (`31 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ae78cca483278b154f086562ad48)