### PR TITLE
test(repl): asegurar que definir funciones no ejecuta su cuerpo en REPL

### DIFF
--- a/tests/unit/test_repl_function_definition_contract.py
+++ b/tests/unit/test_repl_function_definition_contract.py
@@ -1,0 +1,23 @@
+from io import StringIO
+from unittest.mock import patch
+
+from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+from pcobra.cobra.core.runtime import InterpretadorCobra
+
+
+def test_repl_definir_funcion_no_ejecuta_cuerpo_ni_postprocesa_echo() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+
+    codigo_def = """
+func hola():
+    imprimir('EJECUTADO')
+fin
+"""
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        cmd.ejecutar_codigo(codigo_def)
+    assert out.getvalue() == ""
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        cmd.ejecutar_codigo("hola()")
+    assert out.getvalue().strip() == "EJECUTADO"


### PR DESCRIPTION
### Motivation
- Asegurar el contrato del REPL donde `func ... fin` sólo registra la función en el entorno persistente y no recorre/ejecuta su `cuerpo`, evitando efectos observables en la fase de definición.

### Description
- Agrega una prueba de regresión `tests/unit/test_repl_function_definition_contract.py` que verifica que `InteractiveCommand.ejecutar_codigo` no imprime ni ejecuta el cuerpo al definir una función y que el cuerpo se ejecuta únicamente al invocarla.

### Testing
- Se ejecutó `pytest -q tests/unit/test_repl_function_definition_contract.py` y pasó (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b0eb6818832794c5ea435934d4c4)