### PR TITLE
Restringe warning 'Llamada a funcion' a fase `execution`

### DIFF
--- a/src/pcobra/core/semantic_validators/auditoria.py
+++ b/src/pcobra/core/semantic_validators/auditoria.py
@@ -36,8 +36,8 @@ class ValidadorAuditoria(ValidadorBase):
         return self.emitir_side_effects and self.mode == "execution"
 
     def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
-        if self.in_execution():
-            self._log(f"Llamada a funcion: {nodo.nombre}")
+        if self.mode == "execution":
+            print(f"WARNING: Llamada a funcion: {nodo.nombre}")
         self.generic_visit(nodo)
 
     def visit_llamada_metodo(self, nodo: NodoLlamadaMetodo):


### PR DESCRIPTION
### Motivation
- Limitar la impresión del warning `Llamada a funcion` para que sólo se emita en la fase de ejecución y así evitar duplicados y filtrado de fase (phase leaks).

### Description
- En `src/pcobra/core/semantic_validators/auditoria.py` se actualizó `visit_llamada_funcion` para reemplazar `if self.in_execution(): self._log(f"Llamada a funcion: {nodo.nombre}")` por `if self.mode == "execution": print(f"WARNING: Llamada a funcion: {nodo.nombre}")`, manteniendo una única ruta responsable de emitir el warning por invocación efectiva.

### Testing
- Se verificó con búsquedas exactas `rg -n "WARNING: Llamada a funcion"` y `rg -n "Llamada a funcion|WARNING"` que la ocurrencia del warning queda en un único punto y las comprobaciones completaron correctamente; no se ejecutaron tests unitarios automáticos en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b35cd1688327b8963d884d105758)