### PR TITLE
test: ajustar caso REPL anidado a triple(3) con esperado 9

### DIFF
--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -288,7 +288,7 @@ def test_repl_llamada_funcion_auditoria_una_sola_vez_y_retorno_correcto():
                 "func triple(n):\n"
                 "    retorno doble(n) + n\n"
                 "fin\n"
-                "triple(2)"
+                "triple(3)"
             )
         warnings_llamada_anidada = list(warning_mock.call_args_list)
 
@@ -301,7 +301,7 @@ def test_repl_llamada_funcion_auditoria_una_sola_vez_y_retorno_correcto():
         call("Llamada a funcion: triple"),
         call("Llamada a funcion: doble"),
     ]
-    assert lineas_salida[-2:] == ["2", "6"]
+    assert lineas_salida[-2:] == ["2", "9"]
 
 
 


### PR DESCRIPTION
### Motivation
- Alinear el caso de ejecución anidada en la suite REPL con la semántica esperada (invocar `triple(3)` y comprobar warnings por `triple` y `doble`) sin tocar lexer/parser/gramática/backend.

### Description
- Modifiqué `tests/integration/test_run_repl_equivalence.py` para cambiar la entrada `"triple(2)"` a `"triple(3)"` y actualizar la aserción esperada de `["2", "6"]` a `["2", "9"]`, sin tocar snapshots ni otros módulos.

### Testing
- Ejecuté `pytest -q tests/integration/test_run_repl_equivalence.py::test_repl_llamada_funcion_auditoria_una_sola_vez_y_retorno_correcto` y `pytest -q tests/unit/test_interpreter.py -k "definicion_triple or llamada_funcion_no_duplica or triple_tres"`, y ambos comandos completaron con los tests seleccionados pasando exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b4804bc88327974fb79886c9e6b6)