### PR TITLE
Add REPL contract test for non-executing function definitions

### DIFF
--- a/tests/unit/test_repl_function_definition_contract.py
+++ b/tests/unit/test_repl_function_definition_contract.py
@@ -21,3 +21,31 @@ fin
     with patch("sys.stdout", new_callable=StringIO) as out:
         cmd.ejecutar_codigo("hola()")
     assert out.getvalue().strip() == "EJECUTADO"
+
+
+def test_definir_funcion_no_ejecuta_cuerpo_en_repl() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+
+    codigo_def = """
+func doble(y):
+    retorno y + y
+fin
+func triple(x):
+    retorno doble(x) + x
+fin
+"""
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        cmd.ejecutar_codigo(codigo_def)
+
+    salida = out.getvalue()
+    assert "WARNING: Llamada a funcion: doble" not in salida
+    assert "Variable no declarada: x" not in salida
+
+    simbolo_triple = None
+    if hasattr(cmd.interpretador, "contextos") and cmd.interpretador.contextos:
+        simbolo_triple = cmd.interpretador.contextos[-1].get("triple")
+    if simbolo_triple is None and hasattr(cmd.interpretador, "variables"):
+        simbolo_triple = cmd.interpretador.variables.get("triple")
+
+    assert simbolo_triple is not None


### PR DESCRIPTION
### Motivation
- Verificar que la definición de funciones en el REPL no ejecuta el cuerpo ni produce advertencias o errores por referencias a parámetros durante la definición, y que la función queda registrada en el entorno activo.

### Description
- Se añadió `test_definir_funcion_no_ejecuta_cuerpo_en_repl` en `tests/unit/test_repl_function_definition_contract.py`, que envía a REPL la definición de `doble` y `triple` en una sola entrada, captura `stdout` para asegurar que no aparecen los mensajes `WARNING: Llamada a funcion: doble` ni `Variable no declarada: x`, y comprueba que `triple` quedó registrado consultando `contextos[-1]` con fallback a `variables`.

### Testing
- Ejecutado `pytest -q tests/unit/test_repl_function_definition_contract.py` y resultó en "2 passed" con una advertencia de deprecación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b5ba0a5c83278d94beab70660369)