### PR TITLE
Emitir warning de llamada en REPL y añadir tests de cardinalidad/orden

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1606,6 +1606,8 @@ class InterpretadorCobra:
                 if self.in_execution():
                     print(valor)
         else:
+            if self.in_execution():
+                print(f"WARNING: Llamada a funcion: {nodo.nombre}")
             funcion = self.obtener_variable(nodo.nombre)
             if not isinstance(funcion, dict) or funcion.get("tipo") != "funcion":
                 if self.in_execution():

--- a/tests/unit/test_repl_function_definition_contract.py
+++ b/tests/unit/test_repl_function_definition_contract.py
@@ -20,7 +20,7 @@ fin
 
     with patch("sys.stdout", new_callable=StringIO) as out:
         cmd.ejecutar_codigo("hola()")
-    assert out.getvalue().strip() == "EJECUTADO"
+    assert out.getvalue().splitlines()[-1] == "EJECUTADO"
 
 
 def test_definir_funcion_no_ejecuta_cuerpo_en_repl() -> None:
@@ -49,3 +49,56 @@ fin
         simbolo_triple = cmd.interpretador.variables.get("triple")
 
     assert simbolo_triple is not None
+
+
+def _capturar_repl(cmd: InteractiveCommand, codigo: str) -> tuple[str, list[str]]:
+    import logging
+
+    logger = logging.getLogger()
+    prev_handlers = list(logger.handlers)
+    prev_level = logger.level
+    stream_logs = StringIO()
+    logger.handlers = [logging.StreamHandler(stream_logs)]
+    logger.setLevel(logging.WARNING)
+    try:
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            cmd.ejecutar_codigo(codigo)
+        return out.getvalue(), [ln.strip() for ln in stream_logs.getvalue().splitlines() if ln.strip()]
+    finally:
+        logger.handlers = prev_handlers
+        logger.setLevel(prev_level)
+
+
+def test_repl_warning_llamada_funcion_simple_conteo_unico_y_resultado_visible() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+    _capturar_repl(cmd, """
+func test(x):
+    retorno x
+fin
+""")
+    salida_stdout, salida_logging = _capturar_repl(cmd, "test(1)")
+
+    assert salida_stdout.splitlines().count("WARNING: Llamada a funcion: test") == 1
+    assert "1" in salida_stdout
+    assert not any("WARNING: Llamada a funcion: test" in ln for ln in salida_logging)
+
+
+def test_repl_warning_llamada_funcion_anidada_orden_cardinalidad_y_resultado() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+    _capturar_repl(cmd, """
+func doble(x):
+    retorno x + x
+fin
+func triple(x):
+    retorno doble(x) + x
+fin
+""")
+    salida_stdout, salida_logging = _capturar_repl(cmd, "triple(3)")
+
+    warnings = [ln for ln in salida_stdout.splitlines() if ln.startswith("WARNING: Llamada a funcion:")]
+    assert warnings.count("WARNING: Llamada a funcion: triple") == 1
+    assert warnings.count("WARNING: Llamada a funcion: doble") == 1
+    assert warnings.index("WARNING: Llamada a funcion: triple") < warnings.index("WARNING: Llamada a funcion: doble")
+    assert "9" in salida_stdout
+    assert not any("WARNING: Llamada a funcion: triple" in ln for ln in salida_logging)
+    assert not any("WARNING: Llamada a funcion: doble" in ln for ln in salida_logging)


### PR DESCRIPTION
### Motivation
- Hacer visible en la salida del REPL cuándo se realiza una llamada a función para facilitar auditoría y permitir aserciones sobre warnings en pruebas.
- Evitar falsos positivos cuando el entorno mezcla `logging` y `print` capturando ambos canales por separado en los tests.

### Description
- Se añade emisión por stdout de `WARNING: Llamada a funcion: <nombre>` en `ejecutar_llamada_funcion` cuando `in_execution()` es verdadero. (modificado: `src/pcobra/core/interpreter.py`).
- Se incorpora la utilidad `_capturar_repl(...)` que separa `stdout` y `logging` para los tests y se añaden pruebas que verifican conteo exacto y orden de warnings y la presencia del resultado visible en REPL. (modificado: `tests/unit/test_repl_function_definition_contract.py`).
- Se ajusta una aserción existente para tolerar que el warning preceda a la línea `EJECUTADO`, comprobando que `EJECUTADO` sigue siendo la última línea visible.

### Testing
- Ejecutado `pytest -q tests/unit/test_repl_function_definition_contract.py` y todos los tests relevantes pasaron (4 tests, 0 fallos).
- Las pruebas verifican explícitamente que `WARNING: Llamada a funcion: test` aparece exactamente una vez para `test(1)`, y que para `triple(3)` aparecen `triple` y `doble` una vez cada una en el orden esperado, además de comprobar los resultados visibles `1` y `9` respectivamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b6b584988327a86603e27680973e)