### PR TITLE
Unificar emisión de auditoría por fase y añadir prueba del contrato del visitor

### DIFF
--- a/src/pcobra/core/semantic_validators/auditoria.py
+++ b/src/pcobra/core/semantic_validators/auditoria.py
@@ -36,8 +36,13 @@ class ValidadorAuditoria(ValidadorBase):
         return self.emitir_side_effects and self.mode == "execution"
 
     def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
-        if self.mode == "execution":
-            print(f"WARNING: Llamada a funcion: {nodo.nombre}")
+        """Contrato: este visitor nunca debe emitir side effects fuera de ejecución.
+
+        Mantener toda emisión a través de ``_log`` para conservar una sola ruta de salida
+        y evitar regresiones en futuros refactors.
+        """
+        if self.in_execution():
+            self._log(f"Llamada a funcion: {nodo.nombre}")
         self.generic_visit(nodo)
 
     def visit_llamada_metodo(self, nodo: NodoLlamadaMetodo):

--- a/tests/unit/test_auditoria_validator.py
+++ b/tests/unit/test_auditoria_validator.py
@@ -4,12 +4,28 @@ import pytest
 from core.interpreter import InterpretadorCobra
 from core.ast_nodes import NodoLlamadaFuncion, NodoValor
 from core.semantic_validators import PrimitivaPeligrosaError
+from core.semantic_validators.auditoria import ValidadorAuditoria
 
 
-def test_auditoria_registra_primitiva(caplog):
+def test_auditoria_no_emite_en_analysis_durante_semantica(caplog):
     interp = InterpretadorCobra()
     nodo = NodoLlamadaFuncion("leer_archivo", [NodoValor("x")])
     with caplog.at_level(logging.WARNING):
         with pytest.raises(PrimitivaPeligrosaError):
             interp.ejecutar_ast([nodo])
-    assert any("leer_archivo" in rec.message for rec in caplog.records)
+    assert not caplog.records
+
+
+def test_validador_auditoria_emite_solo_en_execution(caplog):
+    nodo = NodoLlamadaFuncion("funcion_demo", [])
+
+    validador_analysis = ValidadorAuditoria(emitir_side_effects=False)
+    with caplog.at_level(logging.WARNING):
+        validador_analysis.visit_llamada_funcion(nodo)
+    assert not caplog.records
+
+    caplog.clear()
+    validador_execution = ValidadorAuditoria(emitir_side_effects=True)
+    with caplog.at_level(logging.WARNING):
+        validador_execution.visit_llamada_funcion(nodo)
+    assert any("funcion_demo" in rec.message for rec in caplog.records)


### PR DESCRIPTION
### Motivation
- El visitor `visit_llamada_funcion` emitía side effects con `print`, lo que rompía la ruta centralizada de logs y la invariancia de fase.
- Se necesita garantizar que la auditoría no produzca efectos observables durante la fase de `analysis` y que toda emisión pase por un único punto (`_log`).

### Description
- Reemplacé el `print` en `visit_llamada_funcion` por una llamada a la ruta central `_log` y añadí un comentario de contrato junto a `visit_llamada_funcion` que explícita la regla de no emitir en `analysis`.
- Mantengo la guardia de fase usando la función `in_execution` como única condición para emitir side effects.
- Añadí una prueba aislada que construye un `NodoLlamadaFuncion`, ejecuta el visitor en `analysis` y `execution`, y verifica que solo en `execution` hay emisión observable.
- Ajusté la prueba previa para reflejar el contrato estricto de no emisión durante la semántica.

### Testing
- Ejecuté `pytest -q tests/unit/test_auditoria_validator.py` y las pruebas relevantes pasaron (`2 passed, 1 warning`).
- Verifiqué localmente que `visit_llamada_funcion`, `_log` e `in_execution` operan según el contrato sin producir side effects en `analysis`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5b95a13ac83279497b0e971c6ac26)