### PR TITLE
test: agregar regresión REPL para definición de función silenciosa

### DIFF
--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -304,6 +304,31 @@ def test_repl_llamada_funcion_auditoria_una_sola_vez_y_retorno_correcto():
     assert lineas_salida[-2:] == ["2", "9"]
 
 
+@pytest.mark.integration
+def test_repl_definir_funcion_triple_no_produce_salida_en_definicion() -> None:
+    repl = InteractiveCommand(InterpretadorCobra())
+    repl._seguro_repl = False
+    repl._extra_validators_repl = None
+    out_repl, err_repl = StringIO(), StringIO()
+
+    with patch("logging.warning") as warning_mock:
+        with redirect_stdout(out_repl), redirect_stderr(err_repl):
+            repl.ejecutar_codigo(
+                "func doble(x):\n"
+                "    retorno x * 2\n"
+                "fin"
+            )
+            repl.ejecutar_codigo(
+                "func triple(x):\n"
+                "    retorno doble(x) + x\n"
+                "fin"
+            )
+
+    assert err_repl.getvalue() == ""
+    assert out_repl.getvalue() == ""
+    assert warning_mock.call_args_list == []
+
+
 
 @pytest.mark.integration
 def test_repl_incremental_var_var_imprimir_y_nameerror_sin_temporales_internas() -> None:


### PR DESCRIPTION
### Motivation
- Asegurar que la definición de funciones en el flujo REPL no ejecute ni recorra el cuerpo, ni produzca salida en `stdout`/`stderr` o `warnings`, y prevenir regresiones sobre ese comportamiento.

### Description
- Añade una prueba de integración `test_repl_definir_funcion_triple_no_produce_salida_en_definicion` en `tests/integration/test_run_repl_equivalence.py` que define `doble` y `triple` en el REPL y verifica que `stdout` y `stderr` queden vacíos y que no se hayan emitido `logging.warning` durante la fase de definición.
- Verifiqué el comportamiento de `InterpretadorCobra.ejecutar_funcion`: construye el descriptor mediante `_construir_funcion(nodo)`, llama a `self.contextos[-1].define(nodo.nombre, funcion)` y retorna `None` sin recorrer ni evaluar `nodo.cuerpo`.

### Testing
- Ejecuté `pytest -q tests/integration/test_run_repl_equivalence.py -k "triple_no_produce_salida_en_definicion"` y la nueva prueba pasó ✅.
- Ejecuté `pytest -q tests/integration/test_run_repl_equivalence.py -k "triple_no_produce_salida_en_definicion or llamada_funcion_auditoria_una_sola_vez"` y hubo una falla en la prueba existente `test_repl_llamada_funcion_auditoria_una_sola_vez_y_retorno_correcto` relacionada con una expectativa de `logging.warning` que no se cumplió (fallo no introducido por el nuevo test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5bab9b0e08327bd9fb65a9b19d273)