### PR TITLE
Sincroniza fases analysis/execution entre REPL e intérprete

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -426,7 +426,10 @@ class InteractiveCommand(BaseCommand):
         if modo not in self._allowed_modes:
             raise ValueError(f"Modo REPL inválido: {modo}")
         self.mode = modo
-        self.interpretador.mode = modo
+        if hasattr(self.interpretador, "_set_mode"):
+            self.interpretador._set_mode(modo)
+        else:
+            self.interpretador.mode = modo
 
     def _ejecutar_ast_en_repl(
         self,

--- a/tests/unit/test_repl_function_definition_contract.py
+++ b/tests/unit/test_repl_function_definition_contract.py
@@ -102,3 +102,23 @@ fin
     assert "9" in salida_stdout
     assert not any("WARNING: Llamada a funcion: triple" in ln for ln in salida_logging)
     assert not any("WARNING: Llamada a funcion: doble" in ln for ln in salida_logging)
+
+
+def test_regresion_repl_fase_analisis_y_ejecucion_para_func_test() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+
+    salida_def, logs_def = _capturar_repl(
+        cmd,
+        """
+func test(x):
+    retorno x
+fin
+""",
+    )
+    assert salida_def == ""
+    assert logs_def == []
+
+    salida_call, _ = _capturar_repl(cmd, "test(1)")
+    lineas = salida_call.splitlines()
+    assert lineas.count("WARNING: Llamada a funcion: test") == 1
+    assert lineas[-1] == "1"


### PR DESCRIPTION
### Motivation
- Evitar drift de fase entre el REPL y el intérprete para que las validaciones y la emisión de side effects se comporten coherentemente entre la pasada de análisis y la de ejecución.
- Añadir una prueba de regresión que verifique el contrato REPL: definir una función no debe ejecutar su cuerpo en la fase de análisis y llamar a la función debe emitir exactamente un warning y devolver el valor.

### Description
- Actualiza `_fijar_modo_repl` en `src/pcobra/cobra/cli/commands/interactive_cmd.py` para delegar en `InterpretadorCobra._set_mode(modo)` cuando esté disponible, y en caso contrario mantener la asignación directa a `interpretador.mode`.
- Agrega la prueba `test_regresion_repl_fase_analisis_y_ejecucion_para_func_test` en `tests/unit/test_repl_function_definition_contract.py` que valida la secuencia: definición de `func test(x): retorno x fin` sin salida, y `test(1)` produce un único warning y el resultado `1`.
- Durante la modificación se verificó que `InterpretadorCobra` ya implementa `self.mode` con valores válidos (`analysis`/`execution`), el guard clause en `ejecutar_nodo` y el flujo `analysis -> validar -> execution -> restore` en `ejecutar_ast`, por lo que la corrección se centra en sincronizar el REPL con ese API.

### Testing
- Ejecutado `pytest -q tests/unit/test_repl_function_definition_contract.py` y la suite de prueba del archivo pasó correctamente con `5 passed`.
- Se comprobó con `git status --short` que los archivos modificados son `src/pcobra/cobra/cli/commands/interactive_cmd.py` y `tests/unit/test_repl_function_definition_contract.py`.
- Commit realizado con mensaje `Sincroniza modo REPL con intérprete y agrega regresión de fases` y validado localmente durante la ejecución de las pruebas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5bbeeef9c83278094017115aecdd7)