### PR TITLE
Ajusta warnings de llamadas anidadas en REPL

### DIFF
--- a/tests/unit/test_repl_function_definition_contract.py
+++ b/tests/unit/test_repl_function_definition_contract.py
@@ -85,7 +85,7 @@ fin
 
 def test_repl_warning_llamada_funcion_anidada_orden_cardinalidad_y_resultado() -> None:
     cmd = InteractiveCommand(InterpretadorCobra())
-    _capturar_repl(cmd, """
+    salida_def, logs_def = _capturar_repl(cmd, """
 func doble(x):
     retorno x + x
 fin
@@ -93,12 +93,20 @@ func triple(x):
     retorno doble(x) + x
 fin
 """)
+    assert salida_def == ""
+    assert logs_def == []
+
     salida_stdout, salida_logging = _capturar_repl(cmd, "triple(3)")
 
-    warnings = [ln for ln in salida_stdout.splitlines() if ln.startswith("WARNING: Llamada a funcion:")]
-    assert warnings.count("WARNING: Llamada a funcion: triple") == 1
-    assert warnings.count("WARNING: Llamada a funcion: doble") == 1
-    assert warnings.index("WARNING: Llamada a funcion: triple") < warnings.index("WARNING: Llamada a funcion: doble")
+    warnings = [
+        ln
+        for ln in salida_stdout.splitlines()
+        if ln.startswith("WARNING: Llamada a funcion:")
+    ]
+    assert warnings == [
+        "WARNING: Llamada a funcion: triple",
+        "WARNING: Llamada a funcion: doble",
+    ]
     assert "9" in salida_stdout
     assert not any("WARNING: Llamada a funcion: triple" in ln for ln in salida_logging)
     assert not any("WARNING: Llamada a funcion: doble" in ln for ln in salida_logging)


### PR DESCRIPTION
### Motivation
- Asegurar el contrato de diagnóstico: los warnings de llamadas a función deben emitirse solo en la fase de ejecución y no durante la definición/analisis.
- Hacer el test de llamada anidada más estricto para validar orden y cardinalidad de warnings emitidos en ejecución.

### Description
- Se actualizó `tests/unit/test_repl_function_definition_contract.py` para capturar la salida durante la definición de funciones y añadir aserciones que garanticen que no hay salida ni logs en la fase de definición usando `_capturar_repl`.
- Se reforzó la verificación en el escenario anidado para asegurar que la lista de warnings en la salida estándar sea exactamente `['WARNING: Llamada a funcion: triple', 'WARNING: Llamada a funcion: doble']` en ese orden.
- Se conservaron las comprobaciones de que los warnings no aparezcan en los handlers de logging y que el resultado de la llamada `triple(3)` incluya el valor esperado.

### Testing
- Ejecutado `pytest -q tests/unit/test_repl_function_definition_contract.py` y todas las pruebas relacionadas pasaron (`5 passed`).
- No se modificaron otros tests en este cambio y no se reportaron fallos en la suite ejecutada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5bd42ed1c8327ad8f4c234373e1d0)