### PR TITLE
Añade prueba de regresión: definición de función no debe ejecutar su cuerpo

### DIFF
--- a/tests/unit/test_retornos.py
+++ b/tests/unit/test_retornos.py
@@ -1,6 +1,17 @@
+from io import StringIO
+from unittest.mock import patch
+
 import pytest
 from core.interpreter import InterpretadorCobra
-from core.ast_nodes import NodoFuncion, NodoRetorno, NodoValor, NodoLlamadaFuncion
+from core.lexer import Token, TipoToken
+from core.ast_nodes import (
+    NodoFuncion,
+    NodoRetorno,
+    NodoValor,
+    NodoLlamadaFuncion,
+    NodoIdentificador,
+    NodoOperacionBinaria,
+)
 from cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 
 
@@ -24,3 +35,46 @@ def test_transpiladores_retorno():
     js = TranspiladorJavaScript()
     codigo_js = js.generate_code([func])
     assert "return 7;" in codigo_js
+
+
+def test_definicion_triple_no_evalua_cuerpo_ni_dispara_warning_o_nameerror(monkeypatch):
+    inter = InterpretadorCobra()
+    llamadas_durante_definicion = []
+
+    original = inter.ejecutar_llamada_funcion
+
+    def _spy_llamada(nodo):
+        llamadas_durante_definicion.append(nodo.nombre)
+        return original(nodo)
+
+    monkeypatch.setattr(inter, "ejecutar_llamada_funcion", _spy_llamada)
+
+    doble = NodoFuncion(
+        "doble",
+        ["x"],
+        [
+            NodoRetorno(
+                NodoOperacionBinaria(
+                    NodoIdentificador("x"),
+                    Token(TipoToken.MULT, "*"),
+                    NodoValor(2),
+                )
+            )
+        ],
+    )
+    triple = NodoFuncion(
+        "triple",
+        ["x"],
+        [
+            NodoRetorno(
+                NodoLlamadaFuncion("doble", [NodoIdentificador("x")])
+            )
+        ],
+    )
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        inter.ejecutar_nodo(doble)
+        inter.ejecutar_nodo(triple)
+
+    assert llamadas_durante_definicion == []
+    assert out.getvalue() == ""


### PR DESCRIPTION
### Motivation
- Asegurar que la definición de funciones no pre-ejecute ni recorra `nodo.cuerpo`, preservando el contrato de que `ejecutar_funcion` solo construye el descriptor/closure, lo registra en el entorno y retorna `None`.
- Evitar regresiones donde el REPL o rutas incrementales provoquen llamadas/advertencias o errores de variable no declarada al definir funciones que referencian otras funciones.

### Description
- Se añadió la prueba `test_definicion_triple_no_evalua_cuerpo_ni_dispara_warning_o_nameerror` en `tests/unit/test_retornos.py` que espía `ejecutar_llamada_funcion` y comprueba que definir `doble` y `triple` no provoca llamadas ni salida en `stdout`.
- Revisé `InterpretadorCobra.ejecutar_funcion` y confirmé que construye el descriptor vía `_construir_funcion`, valida el valor, lo registra con `define` en el contexto actual y devuelve `None` sin recorrer el cuerpo. 
- Verifiqué también la ruta REPL relevante (`parsear_y_ejecutar_codigo_repl` y helpers asociados) y no fue necesario introducir cambios porque la prevalidación/parseo en REPL no debe producir efectos observables ni pre-ejecutar cuerpos de función.

### Testing
- Ejecuté pruebas unitarias focalizadas: `tests/unit/test_retornos.py::test_definicion_triple_no_evalua_cuerpo_ni_dispara_warning_o_nameerror`, `tests/unit/test_interpreter.py::test_ejecutar_funcion_solo_registra_en_entorno_sin_recorrer_cuerpo` y `tests/unit/test_interpreter.py::test_definicion_triple_no_emite_warning_ni_error_variable_x`, y las tres pasaron correctamente.
- En una ejecución más amplia de `tests/unit/test_retornos.py` inicialmente apareció una falla en `test_transpiladores_retorno` por una expectativa sobre código transpilado a Python; esa falla no está relacionada con la prueba de regresión añadida ni con `ejecutar_funcion`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5be822a848327b8cbff624251f240)