### PR TITLE
Asegurar transiciones de modo REPL y agregar test de deduplicación de warnings

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -563,18 +563,22 @@ class InteractiveCommand(BaseCommand):
         """
 
         self._sincronizar_interpretador_sesion()
-        ast = prevalidar_fn(codigo)
-        # Contrato de prevalidación/parseo en REPL: esta fase es solo de
-        # análisis y no debe emitir side effects de auditoría.
-        self._fijar_modo_repl("analysis")
-        self._validar_ast_para_analisis(ast, validador)
-        # Contrato de dispatch:
-        # REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.
-        # Este helper delega en ``ejecutar_codigo`` y, por diseño, no debe
-        # introducir pipeline explícito para snippets normales.
-        # Invariante antirregresión: conservar este método como "thin wrapper"
-        # (prevalidar + delegar a ejecutar_codigo) sin rutas batch adicionales.
-        self.ejecutar_codigo(codigo, validador, ast_preparseado=ast)
+        modo_previo = self.mode
+        try:
+            # Contrato de prevalidación/parseo en REPL: esta fase es solo de
+            # análisis y no debe emitir side effects de auditoría.
+            self._fijar_modo_repl("analysis")
+            ast = prevalidar_fn(codigo)
+            self._validar_ast_para_analisis(ast, validador)
+            # Contrato de dispatch:
+            # REPL = intérprete incremental; pipeline explícito solo para sandbox/setup.
+            # Este helper delega en ``ejecutar_codigo`` y, por diseño, no debe
+            # introducir pipeline explícito para snippets normales.
+            # Invariante antirregresión: conservar este método como "thin wrapper"
+            # (prevalidar + delegar a ejecutar_codigo) sin rutas batch adicionales.
+            self.ejecutar_codigo(codigo, validador, ast_preparseado=ast)
+        finally:
+            self._fijar_modo_repl(modo_previo)
 
     def _debe_intentar_fallback_expresion_top_level(
         self,

--- a/tests/unit/test_repl_warning_dedup.py
+++ b/tests/unit/test_repl_warning_dedup.py
@@ -1,0 +1,63 @@
+from io import StringIO
+from unittest.mock import patch
+
+from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+from pcobra.cobra.core.runtime import InterpretadorCobra
+from pcobra.cobra.cli.execution_pipeline import prevalidar_y_parsear_codigo
+
+
+class _NodoDummy:
+    def aceptar(self, validador):
+        validador.calls.append((validador.verbose, validador.emitir_side_effects))
+
+
+class _ValidadorDummy:
+    def __init__(self) -> None:
+        self.verbose = True
+        self.emitir_side_effects = True
+        self.calls = []
+
+
+def test_analisis_silencioso_fuerza_emitir_side_effects_false_y_restauracion() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+    validador = _ValidadorDummy()
+
+    cmd._fijar_modo_repl("analysis")
+    cmd._validar_ast_para_analisis([_NodoDummy()], validador)
+
+    assert validador.calls == [(False, False)]
+    assert validador.verbose is True
+    assert validador.emitir_side_effects is True
+
+
+def test_parsear_y_ejecutar_restaura_modo_y_sincroniza_interpretador() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+    cmd._fijar_modo_repl("execution")
+    modo_anterior_interpretador = cmd.interpretador.mode
+
+    ast = prevalidar_y_parsear_codigo("1")
+    with patch.object(cmd, "ejecutar_codigo") as mock_ejecutar:
+        cmd.parsear_y_ejecutar_codigo_repl("1", prevalidar_fn=lambda _codigo: ast)
+
+    mock_ejecutar.assert_called_once_with("1", None, ast_preparseado=ast)
+    assert cmd.mode == "execution"
+    assert cmd.interpretador.mode == modo_anterior_interpretador
+
+
+def test_regresion_warning_test_1_se_emite_una_sola_vez() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+
+    with patch("sys.stdout", new_callable=StringIO):
+        cmd.ejecutar_codigo(
+            """
+func test(x):
+    retorno x
+fin
+"""
+        )
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        cmd.ejecutar_codigo("test(1)")
+
+    lineas = out.getvalue().splitlines()
+    assert lineas.count("WARNING: Llamada a funcion: test") == 1


### PR DESCRIPTION
### Motivation
- Garantizar el contrato de fases del REPL: la fase previa de análisis debe ejecutarse en `mode = "analysis"`, la ejecución real en `mode = "execution"`, y siempre restaurar el modo previo al terminar el snippet. 
- Asegurar la sincronización entre el modo del REPL y el intérprete mediante el mecanismo de `._fijar_modo_repl` para evitar contaminación entre entradas interactivas.
- Evitar emisión duplicada de advertencias de auditoría durante la doble pasada (análisis silencioso + ejecución) y validar que la validación silenciosa fuerce `emitir_side_effects=False` cuando exista ese atributo.

### Description
- Modifica `parsear_y_ejecutar_codigo_repl` en `src/pcobra/cobra/cli/commands/interactive_cmd.py` para guardar `modo_previo`, fijar `mode = "analysis"` antes de la prevalidación/validación silenciosa, delegar la ejecución y siempre restaurar `modo_previo` en un bloque `finally` usando `._fijar_modo_repl` para sincronizar con el intérprete.
- Mantiene y usa la función `._fijar_modo_repl` que sincroniza el `mode` local con el intérprete llamando a `_set_mode` si está disponible o ajustando `interpretador.mode` como fallback.
- Añade la prueba de regresión `tests/unit/test_repl_warning_dedup.py` que comprueba que la validación silenciosa fuerza `emitir_side_effects=False` y se restaura el estado, verifica la restauración/sincronización del modo tras `parsear_y_ejecutar_codigo_repl` y asegura que `test(1)` emite exactamente un `WARNING: Llamada a funcion: test` una sola vez.

### Testing
- Ejecuté `pytest -q tests/unit/test_repl_warning_dedup.py tests/unit/test_repl_function_definition_contract.py` y ambas suites unitarias pasaron correctamente (todos los tests pasaron, con 1 warning deprecatorio sobre import). 
- Durante el desarrollo se reprodujo un fallo inicial en la conversión del test que fue corregido cambiando la creación de `ast` a usar `prevalidar_y_parsear_codigo`, y tras esa corrección los tests completaron exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5bfb6d7d48327a39df6c268866934)