### PR TITLE
Restringe emisiones de llamadas a modo `execution` y añade prueba de regresión para llamadas anidadas

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1594,6 +1594,7 @@ class InterpretadorCobra:
 
     def ejecutar_llamada_funcion(self, nodo):
         """Ejecuta la invocación de una función, interna o del usuario."""
+        emitir_salida_llamada = self.in_execution()
         if nodo.nombre == "imprimir":
             for arg in nodo.argumentos:
                 if isinstance(arg, Token) and arg.tipo == TipoToken.IDENTIFICADOR:
@@ -1603,19 +1604,19 @@ class InterpretadorCobra:
                     valor = "verdadero"
                 elif valor is False:
                     valor = "falso"
-                if self.in_execution():
+                if emitir_salida_llamada:
                     print(valor)
         else:
-            if self.in_execution():
+            if emitir_salida_llamada:
                 print(f"WARNING: Llamada a funcion: {nodo.nombre}")
             funcion = self.obtener_variable(nodo.nombre)
             if not isinstance(funcion, dict) or funcion.get("tipo") != "funcion":
-                if self.in_execution():
+                if emitir_salida_llamada:
                     print(f"Funci\u00f3n '{nodo.nombre}' no implementada")
                 return None
 
             if len(funcion["parametros"]) != len(nodo.argumentos):
-                if self.in_execution():
+                if emitir_salida_llamada:
                     print(
                         f"Error: se esperaban {len(funcion['parametros'])} argumentos"
                     )

--- a/tests/unit/test_repl_function_definition_contract.py
+++ b/tests/unit/test_repl_function_definition_contract.py
@@ -112,6 +112,28 @@ fin
     assert not any("WARNING: Llamada a funcion: doble" in ln for ln in salida_logging)
 
 
+def test_no_regresion_llamadas_anidadas_triple_warning_unico_por_funcion() -> None:
+    cmd = InteractiveCommand(InterpretadorCobra())
+    salida_def, _ = _capturar_repl(
+        cmd,
+        """
+func doble(x):
+    retorno x + x
+fin
+func triple(x):
+    retorno doble(x) + x
+fin
+""",
+    )
+    assert salida_def == ""
+
+    salida_stdout, _ = _capturar_repl(cmd, "triple(3)")
+    lineas = salida_stdout.splitlines()
+    assert lineas.count("WARNING: Llamada a funcion: triple") == 1
+    assert lineas.count("WARNING: Llamada a funcion: doble") == 1
+    assert lineas[-1] == "9"
+
+
 def test_regresion_repl_fase_analisis_y_ejecucion_para_func_test() -> None:
     cmd = InteractiveCommand(InterpretadorCobra())
 


### PR DESCRIPTION
### Motivation

- Evitar que los mensajes observables relacionados con llamadas (warnings, mensajes de función no implementada y errores de aridad) se impriman durante la fase de análisis/definición en lugar de en la ejecución real. 
- Asegurar que llamadas anidadas como `triple(3)` produzcan warnings observables exactamente una vez por función y que el resultado final siga siendo correcto.

### Description

- Centraliza el modo efectivo de emisión en `ejecutar_llamada_funcion` calculando `emitir_salida_llamada = self.in_execution()` y reutilizándolo para todas las impresiones relacionadas con la llamada.  
- Aplica la compuerta `emitir_salida_llamada` a: el `WARNING: Llamada a funcion: ...`, `Función '...' no implementada` y al mensaje de error de aridad.  
- Añade la prueba `test_no_regresion_llamadas_anidadas_triple_warning_unico_por_funcion` en `tests/unit/test_repl_function_definition_contract.py` que define `doble` y `triple`, ejecuta `triple(3)` y valida un warning por `triple`, uno por `doble` y el resultado `9`.
- Archivos modificados: `src/pcobra/core/interpreter.py` y `tests/unit/test_repl_function_definition_contract.py`.

### Testing

- Ejecuté `pytest -q tests/unit/test_repl_function_definition_contract.py` y todos los tests pasaron (`6 passed`) con 1 advertencia de deprecación.  
- Se verificó además que el dispatch de nodos mantiene la separación de fases (`ejecutar_nodo` retorna `None` en modo `analysis`), por lo que las salidas no se generan durante la definición/análisis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c0d7acd483278c00ca0fd7bfb862)