### PR TITLE
Registrar funciones con `scope_lexico` y evitar ejecución/prints en definición

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -615,7 +615,7 @@ class InterpretadorCobra:
             "nombre": nodo.nombre,
             "parametros": list(nodo.parametros),
             "cuerpo": list(nodo.cuerpo),
-            "entorno": self.contextos[-1],
+            "scope_lexico": self.contextos[-1],
         }
 
     def _construir_clase(self, nodo, bases):
@@ -1607,8 +1607,6 @@ class InterpretadorCobra:
                 if emitir_salida_llamada:
                     print(valor)
         else:
-            if emitir_salida_llamada:
-                print(f"WARNING: Llamada a funcion: {nodo.nombre}")
             funcion = self.obtener_variable(nodo.nombre)
             if not isinstance(funcion, dict) or funcion.get("tipo") != "funcion":
                 if emitir_salida_llamada:
@@ -1637,7 +1635,9 @@ class InterpretadorCobra:
 
                 # Regla semántica opuesta al control de flujo: cada llamada de
                 # función sí encapsula su scope creando un nuevo contexto local.
-                entorno_capturado = funcion.get("entorno", self.contextos[-1])
+                entorno_capturado = funcion.get(
+                    "scope_lexico", funcion.get("entorno", self.contextos[-1])
+                )
                 self.contextos.append(Environment(parent=entorno_capturado))
                 self.mem_contextos.append({})
                 for nombre_param, valor in zip(funcion["parametros"], argumentos_resueltos):


### PR DESCRIPTION
### Motivation
- Garantizar que la definición de `NodoFuncion` solo registre el descriptor en el entorno y no recorra ni ejecute su `cuerpo` en la fase de definición. 
- Almacenar explícitamente el cierre léxico para soportar ejecución diferida (closures) al invocar la función. 
- Evitar salidas/warnings espurios durante definición o en llamadas de función de usuario que rompan contratos de silencio. 

### Description
- Cambia el descriptor de función construido por `_construir_funcion` para incluir `"scope_lexico": self.contextos[-1]` en lugar de `"entorno"`. 
- Mantiene `ejecutar_funcion` como registro puro que construye el descriptor y hace `define(...)` retornando `None` sin recorrer `nodo.cuerpo`. 
- Elimina la impresión de warning `WARNING: Llamada a funcion: ...` en `ejecutar_llamada_funcion` para no producir salida innecesaria durante el contrato. 
- En la preparación del contexto de llamada, prioriza `scope_lexico` con fallback a `entorno` para preservar compatibilidad con descriptores antiguos. 

### Testing
- `python -m py_compile src/pcobra/core/interpreter.py` se ejecutó correctamente y no reportó errores. 
- Un `pytest -q` inicial falló por un `IndentationError` introducido durante la edición, el problema fue corregido y verificado. 
- `pytest -q tests/cli/test_public_v2_commands_contract.py` se ejecutó y pasó con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c3cf8b408327b8bcecdd8a3deaf5)