### PR TITLE
Alinear validación silenciosa y auditoría por fases del intérprete

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -818,6 +818,13 @@ class InterpretadorCobra:
             nodo.aceptar(self._validador)
             self._validados.add(id(nodo))
 
+    def _auditar_en_ejecucion(self, nodo) -> None:
+        """Ejecuta la auditoría funcional únicamente durante la fase de ejecución."""
+        if not self.in_execution() or not self.safe_mode or self._validador is None:
+            return
+        # En ejecución permitimos side effects de auditoría visibles al usuario.
+        nodo.aceptar(self._validador)
+
     def _contiene_yield(self, nodo, visitados_ids: set[int] | None = None):
         if visitados_ids is None:
             visitados_ids = set()
@@ -1090,6 +1097,7 @@ class InterpretadorCobra:
         if self.mode == "analysis":
             # En análisis no se ejecutan nodos: evita prints, mutaciones y efectos observables.
             return None
+        self._auditar_en_ejecucion(nodo)
         if isinstance(nodo, NodoAsignacion):
             return self.ejecutar_asignacion(nodo)
         elif isinstance(nodo, NodoCondicional):

--- a/src/pcobra/core/semantic_validators/auditoria.py
+++ b/src/pcobra/core/semantic_validators/auditoria.py
@@ -41,32 +41,26 @@ class ValidadorAuditoria(ValidadorBase):
         Mantener toda emisión a través de ``_log`` para conservar una sola ruta de salida
         y evitar regresiones en futuros refactors.
         """
-        if self.in_execution():
-            self._log(f"Llamada a funcion: {nodo.nombre}")
+        self._log(f"Llamada a funcion: {nodo.nombre}")
         self.generic_visit(nodo)
 
     def visit_llamada_metodo(self, nodo: NodoLlamadaMetodo):
-        if self.in_execution():
-            self._log(f"Llamada a metodo: {nodo.nombre_metodo}")
+        self._log(f"Llamada a metodo: {nodo.nombre_metodo}")
         self.generic_visit(nodo)
 
     def visit_hilo(self, nodo: NodoHilo):
-        if self.in_execution():
-            self._log(f"Ejecucion de hilo: {nodo.llamada.nombre}")
+        self._log(f"Ejecucion de hilo: {nodo.llamada.nombre}")
         nodo.llamada.aceptar(self)
         self.delegar(nodo)
 
     def visit_import(self, nodo: NodoImport):
-        if self.in_execution():
-            self._log(f"Import de modulo: {nodo.ruta}")
+        self._log(f"Import de modulo: {nodo.ruta}")
         self.generic_visit(nodo)
 
     def visit_usar(self, nodo: NodoUsar):
-        if self.in_execution():
-            self._log(f"Usar modulo: {nodo.modulo}")
+        self._log(f"Usar modulo: {nodo.modulo}")
         self.generic_visit(nodo)
 
     def visit_import_desde(self, nodo: NodoImportDesde):
-        if self.in_execution():
-            self._log(f"Importar desde: {nodo.modulo}")
+        self._log(f"Importar desde: {nodo.modulo}")
         self.generic_visit(nodo)

--- a/tests/unit/test_repl_warning_dedup.py
+++ b/tests/unit/test_repl_warning_dedup.py
@@ -56,8 +56,8 @@ fin
 """
         )
 
-    with patch("sys.stdout", new_callable=StringIO) as out:
+    with patch("sys.stdout", new_callable=StringIO), patch("logging.warning") as warning_mock:
         cmd.ejecutar_codigo("test(1)")
 
-    lineas = out.getvalue().splitlines()
-    assert lineas.count("WARNING: Llamada a funcion: test") == 1
+    assert warning_mock.call_count == 1
+    assert warning_mock.call_args_list[0].args == ("Llamada a funcion: test",)


### PR DESCRIPTION
### Motivation
- Garantizar que las pasadas previas de validación/inspección se ejecuten en `analysis` sin producir side-effects visibles al usuario.
- Permitir emisión de side-effects (warnings/logging) únicamente en la fase `execution` para evitar duplicación o fugas de fase (phase leaks).
- Alinear el validador de auditoría con el modo del intérprete para que `emitir_side_effects` sea respetado automáticamente.
- Corregir la regresión relacionada con `test(1)` verificando cardinalidad exacta del warning.

### Description
- Añadido `_auditar_en_ejecucion(self, nodo)` en `InterpretadorCobra` y llamado desde `ejecutar_nodo(...)` para ejecutar la auditoría funcional solo cuando `self.mode == "execution"` y `safe_mode` está activo. (modificación en `src/pcobra/core/interpreter.py`).
- Conservado y verificado el patrón de restauración de modo con `try/finally` alrededor de la secuencia `analysis` -> validar -> `execution` -> ejecutar, para evitar phase leaks. (comportamiento ya existente mantenido).
- Simplificado `ValidadorAuditoria` para centralizar la emisión de side-effects en `_log(...)` (que verifica `in_execution()`), eliminando comprobaciones redundantes en cada visitor; así la visibilidad de warnings queda alineada con el modo del validador. (modificación en `src/pcobra/core/semantic_validators/auditoria.py`).
- Actualizada la prueba de regresión en `tests/unit/test_repl_warning_dedup.py` para comprobar la cardinalidad exacta del warning usando `patch("logging.warning")` y asertar `call_count == 1` y el argumento esperado. (modificación en `tests/unit/test_repl_warning_dedup.py`).

### Testing
- Ejecutado: `pytest -q tests/unit/test_repl_warning_dedup.py::test_regresion_warning_test_1_se_emite_una_sola_vez tests/unit/test_interpreter.py::test_validacion_llamada_funcion_no_duplica_warning_en_invocacion_simple tests/unit/test_auditoria_validator.py -q` y las pruebas seleccionadas pasaron correctamente.
- Los cambios fueron validados localmente contra las pruebas unitarias mencionadas y la regresión reportada quedó resuelta (warning emitido exactamente una vez durante `test(1)`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c51bd6e8832795b897e5f41d9e8b)