### PR TITLE
Cambiar `usar` para importar solo callables públicos sin sobrescritura

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1793,12 +1793,31 @@ class InterpretadorCobra:
                 self._set_mode(modo_prev)
 
     def ejecutar_usar(self, nodo):
-        """Importa un módulo de Python instalándolo si es necesario."""
+        """Importa callables públicos de un módulo Python al contexto actual."""
         from .usar_loader import obtener_modulo
 
         try:
             modulo = obtener_modulo(nodo.modulo)
-            self.contextos[-1].define(nodo.modulo, modulo)
+            exportables = getattr(modulo, "__all__", None)
+            if exportables is None:
+                exportables = dir(modulo)
+
+            contexto_actual = self.contextos[-1]
+            for nombre in exportables:
+                if not isinstance(nombre, str) or nombre.startswith("_"):
+                    continue
+
+                simbolo = getattr(modulo, nombre, None)
+                if not callable(simbolo):
+                    continue
+
+                if contexto_actual.contains(nombre):
+                    raise NameError(
+                        "No se puede usar el módulo "
+                        f"'{nodo.modulo}': el símbolo '{nombre}' ya existe en el contexto actual"
+                    )
+
+                contexto_actual.define(nombre, simbolo)
         except Exception as exc:
             logging.exception(f"Error al usar el módulo '{nodo.modulo}': {exc}")
             raise


### PR DESCRIPTION
### Motivation
- Evitar exponer el objeto módulo completo en el contexto de ejecución y prevenir acceso mediante `.` que no forma parte del diseño del lenguaje. 
- Limitar la superficie exportada a símbolos públicos relevantes para reducir sorpresas y riesgos de seguridad al traer dependencias.
- Prevenir sobrescritura silenciosa de variables de usuario con una política explícita de error en caso de colisiones. 

### Description
- Se modificó `InterpretadorCobra.ejecutar_usar` en `src/pcobra/core/interpreter.py` para seguir usando `obtener_modulo(nodo.modulo)` y dejar de registrar el módulo entero en el entorno. 
- Ahora se determina la lista de exportables usando `modulo.__all__` si existe, y `dir(modulo)` como fallback. 
- Se filtran nombres que comienzan por `_` y se inyectan únicamente los atributos que son `callable`. 
- Antes de definir cada símbolo en el `contexto_actual` se comprueba con `contains` si ya existe y en caso de colisión se lanza un `NameError` con mensaje claro en lugar de sobrescribir. 

### Testing
- Se compiló el archivo modificado con `python -m compileall src/pcobra/core/interpreter.py` y la compilación finalizó sin errores. 
- Se realizaron búsquedas y verificaciones estáticas del cambio en el árbol de código para asegurar que no se dejó el antiguo `define(nodo.modulo, modulo)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5cf40640c8327bf80b38e60e6252b)