### PR TITLE
Restringir `usar` en REPL a módulos de `standard_library`

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -213,6 +213,20 @@ class InteractiveCommand(BaseCommand):
         }
     )
 
+    _USAR_ALIAS_REPL = {
+        "archivo": "archivo",
+        "asincrono": "asincrono",
+        "datos": "datos",
+        "decoradores": "decoradores",
+        "fecha": "fecha",
+        "interfaz": "interfaz",
+        "lista": "lista",
+        "logica": "logica",
+        "numero": "numero",
+        "texto": "texto",
+        "util": "util",
+    }
+
     def __init__(self, interpretador: InterpretadorCobra) -> None:
         """Inicializa el comando interactivo.
 
@@ -237,6 +251,11 @@ class InteractiveCommand(BaseCommand):
         # - execution: evaluación real con efectos controlados del lenguaje.
         self._allowed_modes = frozenset({"analysis", "execution"})
         self.mode = "analysis"
+        self._configurar_restriccion_usar_repl()
+
+    def _configurar_restriccion_usar_repl(self) -> None:
+        if hasattr(self.interpretador, "configurar_restriccion_usar_repl"):
+            self.interpretador.configurar_restriccion_usar_repl(self._USAR_ALIAS_REPL)
 
     @staticmethod
     def _crear_estado_repl() -> dict[str, Any]:
@@ -946,9 +965,11 @@ class InteractiveCommand(BaseCommand):
 
         if self._interpretador_sesion is None:
             self._interpretador_sesion = self.interpretador
+            self._configurar_restriccion_usar_repl()
             return
         if self.interpretador is not self._interpretador_sesion:
             self.interpretador = self._interpretador_sesion
+            self._configurar_restriccion_usar_repl()
 
     def _clasificar_error_repl(self, error: Exception) -> str:
         """Clasifica errores del REPL para un reporte único en el loop principal."""
@@ -1143,6 +1164,7 @@ class InteractiveCommand(BaseCommand):
         # accidental en flujo normal del REPL incremental.
         setup = self._ejecutar_pipeline_explicito_solo_setup_sandbox(interpretador_cls)
         self.interpretador = setup.interpretador
+        self._configurar_restriccion_usar_repl()
         self._seguro_repl = setup.safe_mode
         self._extra_validators_repl = setup.validadores_extra
         prevalidar_y_parsear_codigo(linea)

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -433,6 +433,15 @@ class InterpretadorCobra:
         self._eval_stack = set()
         # Último IR generado a partir del AST ejecutado
         self.ultimo_ir: Optional[InternalIRModule] = None
+        # Restricción opcional para `usar` en REPL/evaluador incremental.
+        self._repl_usar_alias_map: dict[str, str] | None = None
+
+    def configurar_restriccion_usar_repl(self, alias_map: dict[str, str] | None) -> None:
+        """Configura whitelist explícita de módulos `usar` para flujo REPL.
+
+        Cuando ``alias_map`` es ``None``, no se aplica restricción adicional.
+        """
+        self._repl_usar_alias_map = alias_map.copy() if alias_map is not None else None
 
     def in_execution(self) -> bool:
         """Indica si el intérprete se encuentra en fase de ejecución."""
@@ -1797,7 +1806,16 @@ class InterpretadorCobra:
         from .usar_loader import obtener_modulo
 
         try:
-            modulo = obtener_modulo(nodo.modulo)
+            nombre_modulo = nodo.modulo
+            if self._repl_usar_alias_map is not None:
+                modulo_resuelto = self._repl_usar_alias_map.get(nombre_modulo)
+                if modulo_resuelto is None:
+                    raise PermissionError(
+                        "módulos externos no soportados en REPL"
+                    )
+                nombre_modulo = modulo_resuelto
+
+            modulo = obtener_modulo(nombre_modulo)
             exportables = getattr(modulo, "__all__", None)
             if exportables is None:
                 exportables = dir(modulo)


### PR DESCRIPTION
### Motivation
- Evitar que en el flujo REPL/evaluador incremental se puedan traer módulos externos no controlados que dejen el intérprete en un estado mixto (módulo “cargado” pero sin funciones disponibles). 
- Forzar un conjunto explícito y estable de alias de módulo Cobra hacia implementaciones internas en `src/pcobra/standard_library/` para mantener seguridad y previsibilidad en sesiones interactivas.
- Aplicar la restricción solo al flujo REPL/evaluador incremental sin tocar el lexer, parser ni la gramática del lenguaje.

### Description
- Añadido en `src/pcobra/core/interpreter.py` un nuevo estado `self._repl_usar_alias_map` y el método `configurar_restriccion_usar_repl(...)` para activar/desactivar una whitelist de aliases en tiempo de ejecución. 
- Modificado `InterpretadorCobra.ejecutar_usar` para resolver nombres mediante el mapa cuando la restricción está activa y fallar explícitamente con el mensaje estable `"módulos externos no soportados en REPL"` si el alias no está permitido. 
- Introducido en `src/pcobra/cobra/cli/commands/interactive_cmd.py` el mapa `_USAR_ALIAS_REPL` con aliases soportados (`numero`, `texto`, `logica`, `archivo`, `datos`, `lista`, `interfaz`, `decoradores`, `fecha`, `asincrono`, `util`, etc.) y el helper `_configurar_restriccion_usar_repl()` para aplicar la política al intérprete. 
- La política se aplica/reaplica al inicializar `InteractiveCommand`, al sincronizar la instancia de intérprete de sesión y después del setup de sandbox para evitar estados mixtos donde el módulo figura como cargado pero sus funciones no estén disponibles.

### Testing
- Se compiló el código modificado con `python -m py_compile src/pcobra/core/interpreter.py src/pcobra/cobra/cli/commands/interactive_cmd.py` y no se reportaron errores. 
- Se verificó que los ficheros se añadieron y commit fueron creados en el repositorio (cambios en `src/pcobra/core/interpreter.py` y `src/pcobra/cobra/cli/commands/interactive_cmd.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d0c83d608327a25e5921ebc5f010)