### PR TITLE
Normalizar contrato de exportación `__all__` para `usar` en REPL

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1825,7 +1825,10 @@ class InterpretadorCobra:
                 if not isinstance(nombre, str) or nombre.startswith("_"):
                     continue
 
-                simbolo = getattr(modulo, nombre, None)
+                if not hasattr(modulo, nombre):
+                    continue
+
+                simbolo = getattr(modulo, nombre)
                 if not callable(simbolo):
                     continue
 

--- a/src/pcobra/standard_library/logica.py
+++ b/src/pcobra/standard_library/logica.py
@@ -1,4 +1,8 @@
-"""Operaciones lógicas simples."""
+"""Operaciones lógicas simples.
+
+Contrato de exportación: ``usar`` en REPL consume ``__all__`` como lista
+de API pública invocable de este módulo.
+"""
 
 from __future__ import annotations
 

--- a/src/pcobra/standard_library/numero.py
+++ b/src/pcobra/standard_library/numero.py
@@ -1,4 +1,8 @@
-"""Atajos numéricos de la biblioteca estándar."""
+"""Atajos numéricos de la biblioteca estándar.
+
+Contrato de exportación: ``usar`` en REPL consume ``__all__`` como lista
+de API pública invocable de este módulo.
+"""
 
 from __future__ import annotations
 

--- a/src/pcobra/standard_library/texto.py
+++ b/src/pcobra/standard_library/texto.py
@@ -1,5 +1,8 @@
 """Funciones de texto de alto nivel basadas en ``pcobra.corelibs.texto``.
 
+Contrato de exportación: ``usar`` en REPL consume ``__all__`` como lista
+de API pública invocable de este módulo.
+
 Ejemplo rápido::
 
     import standard_library.texto as texto


### PR DESCRIPTION
### Motivation
- Asegurar que la instrucción `usar` en el REPL solo inyecte la API pública invocable definida por cada módulo de `standard_library` y evitar exponer constantes/objetos auxiliares o nombres internos.
- Hacer explícito el contrato de exportación para que la superficie pública esperada esté documentada en los módulos relevantes.

### Description
- Añadí comentario de módulo en `src/pcobra/standard_library/numero.py`, `src/pcobra/standard_library/texto.py` y `src/pcobra/standard_library/logica.py` indicando que `usar` en REPL consume `__all__` como lista de API pública invocable.
- Cambié la lógica de inyección en `InterpretadorCobra.ejecutar_usar` (`src/pcobra/core/interpreter.py`) para comprobar `hasattr(modulo, nombre)` antes de `getattr` y mantener la validación `callable(simbolo)` antes de definirlo en el contexto.
- Mantengo el fallback existente a `dir(modulo)` cuando no existe `__all__`, y sigo excluyendo nombres no-string o que empiezan por `_` y las colisiones de nombres siguen generando `NameError`.

### Testing
- Ejecuté un script de validación que importa `pcobra.standard_library.numero`, `pcobra.standard_library.texto` y `pcobra.standard_library.logica` y verifica que cada entrada en `__all__` existe y es `callable`, y el resultado fue `OK` para los tres módulos.
- No se ejecutaron tests unitarios adicionales en esta rama; los cambios son puntuales y la comprobación automatizada de importación/`__all__` pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d28072d083279f1448485659aa36)