### PR TITLE
Asegura estrategia de dos fases en `usar` y evita inyecciones parciales

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1826,6 +1826,8 @@ class InterpretadorCobra:
 
             simbolos_a_inyectar = []
             contexto_actual = self.contextos[-1]
+
+            # Fase A: recolectar y validar todos los símbolos exportables.
             for nombre in exportables:
                 if not isinstance(nombre, str) or nombre.startswith("_"):
                     continue
@@ -1837,13 +1839,17 @@ class InterpretadorCobra:
                 if not callable(simbolo):
                     continue
 
+                simbolos_a_inyectar.append((nombre, simbolo))
+
+            # Fase B: validar colisiones de forma completa antes de definir.
+            for nombre, _simbolo in simbolos_a_inyectar:
                 if contexto_actual.contains(nombre):
                     raise NameError(
                         "No se puede usar el módulo "
                         f"'{nodo.modulo}': el símbolo '{nombre}' ya existe en el contexto actual"
                     )
-                simbolos_a_inyectar.append((nombre, simbolo))
 
+            # Definir en bloque solo si toda la validación anterior fue exitosa.
             for nombre, simbolo in simbolos_a_inyectar:
                 contexto_actual.define(nombre, simbolo)
         except Exception as exc:

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -220,6 +220,26 @@ def test_repl_usar_detecta_colision_de_simbolo_existente(monkeypatch):
         interp.ejecutar_nodo(NodoUsar('texto'))
 
 
+def test_repl_usar_colision_no_inyecta_ningun_simbolo(monkeypatch):
+    modulo = ModuleType("mi_modulo")
+    modulo.colisiona = lambda x: x
+    modulo.disponible = lambda x: x
+    modulo.__all__ = ["colisiona", "disponible"]
+
+    monkeypatch.setattr(
+        core_usar_loader,
+        "obtener_modulo",
+        lambda _nombre, **_kwargs: modulo,
+    )
+    interp = InterpretadorCobra()
+    interp.contextos[-1].define("colisiona", lambda x: x)
+
+    with pytest.raises(NameError, match=r"símbolo 'colisiona' ya existe"):
+        interp.ejecutar_nodo(NodoUsar("mi_modulo"))
+
+    assert "disponible" not in interp.variables
+
+
 def test_repl_usar_numpy_falla_sin_estado_parcial():
     interp = InterpretadorCobra()
     interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto"})


### PR DESCRIPTION
### Motivation
- Evitar inyecciones parciales al importar símbolos de un módulo mediante `usar` y garantizar que la operación sea atómica ante colisiones de nombres.
- Mantener el comportamiento esperado del filtro de exportables (ignorar nombres que empiezan por `_`, solo callables, no sobrescribir variables existentes).

### Description
- Cambia `InterpretadorCobra.ejecutar_usar` para aplicar una estrategia en dos fases: primera fase de recolección/validación de símbolos exportables y segunda fase de verificación de colisiones antes de definir.
- Si se detecta cualquier colisión contra el `contexto_actual`, se aborta la importación sin definir ningún símbolo del módulo.
- Mantiene los filtros existentes: se ignoran nombres que empiezan por `_`, se importan solo objetos `callable` y no se sobrescriben nombres ya definidos.
- Añade la prueba de regresión `test_repl_usar_colision_no_inyecta_ningun_simbolo` en `tests/unit/test_usar.py` y adapta el `monkeypatch` de ese caso para aceptar argumentos por palabra clave a `obtener_modulo`.

### Testing
- Ejecutado `pytest -q tests/unit/test_usar.py` que mostró fallos (5 fallos, 9 éxitos) debidos a `monkeypatch` en otros tests que usan lambdas sin aceptar el argumento `permitir_instalacion`, problema no introducido por este cambio.
- Ejecutado específicamente `pytest -q tests/unit/test_usar.py -k colision_no_inyecta` y el nuevo test de regresión pasó correctamente (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5de32c53883279309bf6ff1553a24)