### PR TITLE
Endurecer exportaciones de stdlib oficial en REPL

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1822,6 +1822,10 @@ class InterpretadorCobra:
             )
             exportables = getattr(modulo, "__all__", None)
             if exportables is None:
+                if es_repl_estricto and nombre_modulo in self._repl_usar_alias_map:
+                    raise ImportError(
+                        f"El módulo oficial '{nodo.modulo}' debe definir __all__ explícito"
+                    )
                 exportables = dir(modulo)
 
             simbolos_a_inyectar = []

--- a/src/pcobra/standard_library/archivo.py
+++ b/src/pcobra/standard_library/archivo.py
@@ -69,3 +69,5 @@ def existe(ruta: PathLike) -> bool:
         return False
     return ruta_segura.is_file()
 
+
+__all__ = ["leer", "escribir", "adjuntar", "existe"]

--- a/src/pcobra/standard_library/fecha.py
+++ b/src/pcobra/standard_library/fecha.py
@@ -19,3 +19,5 @@ def sumar_dias(fecha: datetime, dias: int) -> datetime:
     """Devuelve una nueva fecha tras sumar ``dias`` a ``fecha``."""
     return fecha + timedelta(days=dias)
 
+
+__all__ = ["hoy", "formatear", "sumar_dias"]

--- a/src/pcobra/standard_library/util.py
+++ b/src/pcobra/standard_library/util.py
@@ -150,3 +150,5 @@ def rel(
         if aplicar:
             restaurar()
 
+
+__all__ = ["es_nulo", "es_vacio", "repetir", "rel"]

--- a/tests/unit/test_repl_official_stdlib_exports_policy.py
+++ b/tests/unit/test_repl_official_stdlib_exports_policy.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib
+
+from pcobra.cobra.stdlib_contract import CONTRACTS
+from pcobra.cobra.usar_policy import REPL_COBRA_MODULE_MAP
+
+
+def test_modulos_oficiales_repl_requieren_all_y_callables() -> None:
+    for alias, module_name in REPL_COBRA_MODULE_MAP.items():
+        modulo = importlib.import_module(f"pcobra.standard_library.{module_name}")
+        exports = getattr(modulo, "__all__", None)
+        assert exports is not None, f"El módulo oficial '{alias}' debe definir __all__"
+        assert isinstance(exports, list | tuple), (
+            f"El módulo oficial '{alias}' debe exponer __all__ como lista/tupla"
+        )
+        for symbol_name in exports:
+            assert isinstance(symbol_name, str), (
+                f"El módulo oficial '{alias}' exporta símbolo no textual: {symbol_name!r}"
+            )
+            assert hasattr(modulo, symbol_name), (
+                f"El módulo oficial '{alias}' exporta símbolo inexistente: {symbol_name}"
+            )
+            assert callable(getattr(modulo, symbol_name)), (
+                f"El módulo oficial '{alias}' exporta símbolo no callable: {symbol_name}"
+            )
+
+
+def test_exports_de_contrato_stdlib_estan_alineados() -> None:
+    for contract in CONTRACTS:
+        for exported in contract.public_exports:
+            path = exported.source_path
+            if "standard_library/" not in path:
+                continue
+            module_path = path.replace("src/", "").replace("/", ".").removesuffix(".py")
+            modulo = importlib.import_module(module_path)
+            exports = getattr(modulo, "__all__", None)
+            assert exports is not None, f"{module_path} debe definir __all__"
+            assert exported.python_symbol in exports, (
+                f"{module_path} debe exportar '{exported.python_symbol}' en __all__"
+            )


### PR DESCRIPTION
### Motivation
- Evitar que la instrucción `usar` en REPL indiscriminadamente exponga símbolos internos mediante `dir()` y asegurar que los módulos oficiales publiquen explícitamente su API.
- Forzar coherencia entre los contratos declarativos en `cobra/stdlib_contract` y lo que efectivamente se inyecta en el REPL.

### Description
- En `src/pcobra/core/interpreter.py` se modifica `ejecutar_usar` para que, cuando el REPL está en modo estricto (alias map configurado) y se trate de un módulo oficial, se exija que el módulo defina `__all__` y no haga fallback a `dir()`. (evita exposición por introspección amplia).
- Se añaden `__all__` explícitos en `src/pcobra/standard_library/archivo.py`, `src/pcobra/standard_library/fecha.py` y `src/pcobra/standard_library/util.py` para declarar las funciones públicas que el REPL debe inyectar.
- Se agrega la prueba `tests/unit/test_repl_official_stdlib_exports_policy.py` que comprueba que todos los módulos oficiales listados en `REPL_COBRA_MODULE_MAP` definen `__all__`, que los nombres son strings, que existen en el módulo y que son `callable`, y además valida la alineación entre `cobra.stdlib_contract.CONTRACTS` y los `__all__` de los módulos de `standard_library` referenciados por `public_exports`.

### Testing
- Ejecutado `pytest -q tests/unit/test_repl_official_stdlib_exports_policy.py` y el conjunto pasó (2 tests pasaron, 1 advertencia deprecación).
- Ejecutado `pytest -q tests/unit/test_usar.py::test_repl_usar_colision_no_inyecta_ningun_simbolo` y pasó (1 test pasado, 1 advertencia).
- Se intentó ejecutar una combinación más amplia (`pytest` sobre varios tests relacionados) y la ejecución terminó con un `INTERNALERROR (MemoryError)` en PyTest durante formateo de tracebacks; esto es un error de infraestructura de test runner y no indica fallo de las pruebas unitarias añadidas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5df2d72a48327b1303fc9b18ffd57)