### PR TITLE
test: reforzar contrato REPL de `usar` y documentarlo

### DIFF
--- a/docs/SPEC_COBRA.md
+++ b/docs/SPEC_COBRA.md
@@ -236,5 +236,6 @@ En REPL, `usar` aplica una política **estricta** y distinta del runtime general
 - Si el módulo solicitado no está en ese mapa, se aborta antes de cualquier import externo o instalación con `PermissionError("módulos externos no soportados en REPL")`.
 - En REPL no se permite fallback de instalación con `pip` bajo ninguna condición.
 - La inyección de símbolos es atómica: si falla la validación/carga, no queda estado parcial en el contexto interactivo.
+- Pruebas de contrato asociadas: `tests/unit/test_usar.py` valida `usar "numero"` + `es_finito(10)` sin prefijo, `usar "texto"` + `a_snake("HolaMundo")` sin prefijo, rechazo de `usar "numpy"` sin estado parcial y bloqueo de acceso por punto (`numero.es_finito(10)`).
 
 Fuera del REPL, el runtime general mantiene su política de whitelist y sus mecanismos de resolución/instalación configurables.

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -155,7 +155,7 @@ def test_cargar_lista_blanca_sin_cobra_toml_mantiene_hardcoded(monkeypatch, tmp_
 def test_interpreter_usar_registra_modulo(monkeypatch):
     mod = ModuleType('math')
     mod.sumar = lambda a, b: a + b
-    monkeypatch.setattr(core_usar_loader, 'obtener_modulo', lambda _name: mod)
+    monkeypatch.setattr(core_usar_loader, 'obtener_modulo', lambda _name, **_kwargs: mod)
     interp = InterpretadorCobra()
     interp.ejecutar_nodo(NodoUsar('math'))
     assert interp.obtener_variable('sumar')(1, 2) == 3
@@ -191,28 +191,30 @@ def _ejecutar_codigo(codigo: str, interp: InterpretadorCobra | None = None) -> I
     return interprete
 
 
-def test_repl_usar_numero_expone_es_finito_sin_variable_no_declarada(monkeypatch):
+def test_repl_usar_numero_permite_es_finito_sin_prefijo(monkeypatch):
     import pcobra.corelibs.numero as modulo_numero
 
-    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre: modulo_numero)
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_numero)
     interp = _ejecutar_codigo('usar "numero"\nes_finito(10)')
 
     assert "es_finito" in interp.variables
+    assert interp.obtener_variable("es_finito")(10) is True
 
 
-def test_repl_usar_texto_expone_a_snake(monkeypatch):
+def test_repl_usar_texto_permite_a_snake_sin_prefijo(monkeypatch):
     import pcobra.corelibs.texto as modulo_texto
 
-    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre: modulo_texto)
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_texto)
     interp = _ejecutar_codigo('usar "texto"\na_snake("HolaMundo")')
 
     assert "a_snake" in interp.variables
+    assert interp.obtener_variable("a_snake")("HolaMundo") == "hola_mundo"
 
 
 def test_repl_usar_detecta_colision_de_simbolo_existente(monkeypatch):
     import pcobra.corelibs.texto as modulo_texto
 
-    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre: modulo_texto)
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_texto)
     interp = InterpretadorCobra()
     interp.contextos[-1].define("a_snake", lambda x: x)
 
@@ -242,17 +244,20 @@ def test_repl_usar_colision_no_inyecta_ningun_simbolo(monkeypatch):
 
 def test_repl_usar_numpy_falla_sin_estado_parcial():
     interp = InterpretadorCobra()
+    interp.contextos[-1].define("sentinela", 42)
+    estado_inicial = dict(interp.variables)
     interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto"})
 
     with pytest.raises(PermissionError, match="módulos externos no soportados en REPL"):
         _ejecutar_codigo('usar "numpy"', interp)
 
+    assert interp.variables == estado_inicial
     assert "numpy" not in interp.variables
 
 
 def test_repl_no_habilita_acceso_por_punto_para_usar_numero(monkeypatch):
     import pcobra.corelibs.numero as modulo_numero
 
-    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre: modulo_numero)
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_numero)
     with pytest.raises(InvalidTokenError, match=r"Token no reconocido: '\.'"):
         _ejecutar_codigo('usar "numero"\nnumero.es_finito(10)')


### PR DESCRIPTION
### Motivation

- Asegurar que el contrato de `usar` en REPL permita el uso directo de las APIs de módulos core (sin prefijo) y que rechace módulos externos sin dejar estado parcial. 
- Documentar explícitamente las pruebas que validan este comportamiento en la especificación técnica.

### Description

- Actualiza `tests/unit/test_usar.py` para validar que `usar "numero"` expone `es_finito` y que `es_finito(10)` funciona sin prefijo mediante una aserción funcional. 
- Actualiza `tests/unit/test_usar.py` para validar que `usar "texto"` expone `a_snake` y que `a_snake("HolaMundo")` devuelve `"hola_mundo"` sin prefijo. 
- Refuerza la prueba de rechazo de `usar "numpy"` en REPL para comprobar que no se produce estado parcial guardando un `estado_inicial` y comprobando `interp.variables == estado_inicial` tras el fallo. 
- Ajusta los `monkeypatch` que simulan `obtener_modulo` para aceptar `**_kwargs` (compatibilidad con la firma real que pasa `permitir_instalacion`) y añade en `docs/SPEC_COBRA.md` un enlace que indica que `tests/unit/test_usar.py` valida el contrato REPL de `usar`.

### Testing

- Ejecuté `pytest -q tests/unit/test_usar.py` y los tests del archivo pasaron correctamente con resultado `16 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e0632f948327ae7035cf382867bc)