### PR TITLE
Refuerza la carga oficial de módulos Cobra en `usar` para REPL estricto

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -150,6 +150,51 @@ def cargar_lista_blanca():
 cargar_lista_blanca()
 
 
+def _cargar_modulo_local_desde_directorio(nombre: str, directorio: Path):
+    """Carga un módulo Python desde un directorio local dado."""
+
+    mod_path = directorio / f"{nombre}.py"
+    pkg_path = directorio / nombre / "__init__.py"
+    if not (mod_path.exists() or pkg_path.exists()):
+        return None
+
+    ruta = mod_path if mod_path.exists() else pkg_path
+    mod_spec = importlib.util.spec_from_file_location(nombre, ruta)
+    if mod_spec is None or mod_spec.loader is None:
+        raise ImportError(f"No se pudo crear spec para el módulo '{nombre}'")
+    modulo = importlib.util.module_from_spec(mod_spec)
+    sys.modules[nombre] = modulo
+    mod_spec.loader.exec_module(modulo)
+    return modulo
+
+
+def obtener_modulo_cobra_oficial(nombre: str):
+    """Carga módulos oficiales de Cobra solo desde ``corelibs`` o ``standard_library``."""
+
+    nombre = _validar_nombre(nombre)
+    base = Path(__file__).resolve()
+
+    for parent in base.parents:
+        corelibs = parent / "corelibs"
+        if corelibs.exists():
+            modulo = _cargar_modulo_local_desde_directorio(nombre, corelibs)
+            if modulo is not None:
+                return modulo
+            break
+
+    for parent in base.parents:
+        stdlib = parent / "standard_library"
+        if stdlib.exists():
+            modulo = _cargar_modulo_local_desde_directorio(nombre, stdlib)
+            if modulo is not None:
+                return modulo
+            break
+
+    raise ModuleNotFoundError(
+        f"Módulo oficial Cobra '{nombre}' no encontrado en corelibs/standard_library"
+    )
+
+
 def obtener_modulo(nombre: str, *, permitir_instalacion: bool = True):
     """Importa y devuelve un módulo.
 
@@ -182,35 +227,10 @@ def obtener_modulo(nombre: str, *, permitir_instalacion: bool = True):
     try:
         return importlib.import_module(nombre)
     except ModuleNotFoundError:
-        # Buscar primero en corelibs
-        for parent in base.parents:
-            corelibs = parent / "corelibs"
-            if corelibs.exists():
-                mod_path = corelibs / f"{nombre}.py"
-                pkg_path = corelibs / nombre / "__init__.py"
-                if mod_path.exists() or pkg_path.exists():
-                    ruta = mod_path if mod_path.exists() else pkg_path
-                    mod_spec = importlib.util.spec_from_file_location(nombre, ruta)
-                    modulo = importlib.util.module_from_spec(mod_spec)
-                    sys.modules[nombre] = modulo
-                    mod_spec.loader.exec_module(modulo)
-                    return modulo
-                break
-
-        # Buscar también en standard_library
-        for parent in base.parents:
-            stdlib = parent / "standard_library"
-            if stdlib.exists():
-                mod_path = stdlib / f"{nombre}.py"
-                pkg_path = stdlib / nombre / "__init__.py"
-                if mod_path.exists() or pkg_path.exists():
-                    ruta = mod_path if mod_path.exists() else pkg_path
-                    mod_spec = importlib.util.spec_from_file_location(nombre, ruta)
-                    modulo = importlib.util.module_from_spec(mod_spec)
-                    sys.modules[nombre] = modulo
-                    mod_spec.loader.exec_module(modulo)
-                    return modulo
-                break
+        try:
+            return obtener_modulo_cobra_oficial(nombre)
+        except ModuleNotFoundError:
+            pass
 
         # Si no se encontró, verificar si la instalación está permitida
         if not permitir_instalacion or not os.environ.get(USAR_INSTALL_ENV):

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1803,26 +1803,32 @@ class InterpretadorCobra:
 
     def ejecutar_usar(self, nodo):
         """Importa callables públicos de un módulo Python al contexto actual."""
-        from .usar_loader import obtener_modulo
+        from .usar_loader import obtener_modulo, obtener_modulo_cobra_oficial
 
         try:
             nombre_modulo = nodo.modulo
-            if self._repl_usar_alias_map is not None:
-                modulo_resuelto = self._repl_usar_alias_map.get(nombre_modulo)
-                if modulo_resuelto is None:
+            es_repl_estricto = self._repl_usar_alias_map is not None
+            modulo_canonico = None
+
+            if es_repl_estricto:
+                modulo_canonico = self._repl_usar_alias_map.get(nombre_modulo)
+                if modulo_canonico is None:
                     raise PermissionError(
                         "módulos externos no soportados en REPL"
                     )
-                nombre_modulo = modulo_resuelto
+                nombre_modulo = modulo_canonico
 
-            es_repl_estricto = self._repl_usar_alias_map is not None
-            modulo = obtener_modulo(
-                nombre_modulo,
-                permitir_instalacion=not es_repl_estricto,
-            )
+            if es_repl_estricto and modulo_canonico is not None:
+                modulo = obtener_modulo_cobra_oficial(nombre_modulo)
+            else:
+                modulo = obtener_modulo(
+                    nombre_modulo,
+                    permitir_instalacion=not es_repl_estricto,
+                )
+
             exportables = getattr(modulo, "__all__", None)
             if exportables is None:
-                if es_repl_estricto and nombre_modulo in self._repl_usar_alias_map:
+                if es_repl_estricto and modulo_canonico is not None:
                     raise ImportError(
                         f"El módulo oficial '{nodo.modulo}' debe definir __all__ explícito"
                     )


### PR DESCRIPTION
### Motivation
- Evitar que en modo REPL estricto se permitan cargas de módulos externos fuera del mapa canónico y garantizar que los aliases autorizados sigan siendo la fuente de verdad (`self._repl_usar_alias_map`).
- Proveer una ruta explícita y segura para cargar módulos oficiales de Cobra desde los directorios del proyecto (`corelibs` / `standard_library`) sin depender de la whitelist general de `usar`.
- Mantener la política de error clara cuando se intenta usar módulos no permitidos en REPL estricto. 

### Description
- En `src/pcobra/core/interpreter.py` se actualizó `ejecutar_usar` para usar `self._repl_usar_alias_map` como fuente de verdad y para dirigir la carga a `obtener_modulo_cobra_oficial` cuando `es_repl_estricto` y el alias canónico existe, conservando la excepción `PermissionError("módulos externos no soportados en REPL")` para nombres fuera del mapa. 
- En `src/pcobra/cobra/usar_loader.py` se añadió la función `obtener_modulo_cobra_oficial(nombre)` que valida el nombre y busca exclusivamente en `corelibs` y `standard_library`, sin utilizar `USAR_WHITELIST` ni el flujo de instalación automática. 
- Se añadió la helper `_cargar_modulo_local_desde_directorio` para centralizar la lógica de carga desde archivos `.py` o paquetes locales y evitar duplicación. 
- `obtener_modulo` ahora reutiliza `obtener_modulo_cobra_oficial` como intento local antes de proceder con la instalación/flujo general, preservando la política de whitelist e instalación cuando no se está en REPL estricto. 

### Testing
- Se compiló el código modificado con `python -m compileall src/pcobra/core/interpreter.py src/pcobra/cobra/usar_loader.py` y la compilación finalizó correctamente. 
- No se ejecutaron pruebas unitarias adicionales; los cambios se limitaron a runtime/loader sin tocar lexer/ parser/gramática.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e1f4080c832785e3d3c8cf5c0a47)