### PR TITLE
Endurece `ejecutar_usar` en REPL estricto para aceptar solo módulos oficiales

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1802,7 +1802,15 @@ class InterpretadorCobra:
                 self._set_mode(modo_prev)
 
     def ejecutar_usar(self, nodo):
-        """Importa callables públicos de un módulo Python al contexto actual."""
+        """Importa callables públicos al contexto actual usando la política de ``usar``.
+
+        En modo REPL estricto (cuando existe ``_repl_usar_alias_map``), solo se
+        permiten módulos oficiales de Cobra cargados desde ``corelibs`` o
+        ``standard_library``. No hay fallback a módulos Python externos ni
+        instalación automática de paquetes.
+        """
+        from pathlib import Path
+
         from .usar_loader import obtener_modulo, obtener_modulo_cobra_oficial
 
         try:
@@ -1825,6 +1833,31 @@ class InterpretadorCobra:
                     nombre_modulo,
                     permitir_instalacion=not es_repl_estricto,
                 )
+
+            if es_repl_estricto and modulo_canonico is not None:
+                modulo_file = getattr(modulo, "__file__", None)
+                if not modulo_file:
+                    raise PermissionError(
+                        "REPL estricto: módulo externo no soportado; no se pudo validar origen oficial"
+                    )
+
+                ruta_modulo = Path(modulo_file).resolve()
+                base = Path(__file__).resolve()
+                rutas_oficiales = []
+                for parent in base.parents:
+                    for carpeta in ("corelibs", "standard_library"):
+                        candidato = parent / carpeta
+                        if candidato.exists():
+                            rutas_oficiales.append(candidato.resolve())
+
+                es_oficial = any(
+                    ruta_modulo == ruta_base or ruta_base in ruta_modulo.parents
+                    for ruta_base in rutas_oficiales
+                )
+                if not es_oficial:
+                    raise PermissionError(
+                        "REPL estricto: módulo externo no soportado; use solo módulos oficiales de Cobra"
+                    )
 
             exportables = getattr(modulo, "__all__", None)
             if exportables is None:


### PR DESCRIPTION
### Motivation
- Evitar que el REPL estricto cargue o use módulos Python externos por fallback o instalación automática; solo deben permitirse artefactos oficiales del proyecto ubicados en `corelibs` o `standard_library`.
- Asegurar que la inspección de `__all__` y la inyección de símbolos solo ocurran cuando se haya verificado el origen interno del módulo para reducir riesgos de seguridad e inconsistencia.

### Description
- Actualicé el docstring de `ejecutar_usar` en `src/pcobra/core/interpreter.py` para documentar el contrato de REPL estricto: sin fallback a módulos externos ni instalación automática. 
- Tras resolver alias de REPL y cargar el módulo, ahora se valida que `modulo.__file__` exista y que la ruta real del módulo pertenezca a alguna carpeta `corelibs` o `standard_library` del árbol del proyecto antes de inspeccionar `__all__`, y se lanza `PermissionError` si no es un módulo oficial. 
- Se añadió la importación de `Path` y la búsqueda de las rutas oficiales recorriendo los padres de `__file__` del intérprete; la verificación compara igualdad o pertenencia en padres de la ruta del módulo. 
- Se mantiene el patrón de inyección existente: se ignoran nombres privados que empiezan por `_`, se inyectan solo objetos `callable` y se validan colisiones previas con `contexto_actual.contains(nombre)` antes de definir símbolos.

### Testing
- Se compiló el archivo modificado con `python -m py_compile src/pcobra/core/interpreter.py` y la compilación finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e308a9a883278420011254c32c17)