### PR TITLE
Resolver aliases canónicos de `usar` en el evaluador

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -69,6 +69,7 @@ from .cobra_config import (
     limite_memoria_mb,
     limite_cpu_segundos,
 )
+from ..cobra.usar_policy import REPL_COBRA_MODULE_MAP
 from .resource_limits import (
     limitar_memoria_mb as _lim_mem,
     limitar_cpu_segundos as _lim_cpu,
@@ -1816,22 +1817,19 @@ class InterpretadorCobra:
         try:
             nombre_modulo = nodo.modulo
             es_repl_estricto = self._repl_usar_alias_map is not None
-            modulo_canonico = None
+            mapa_repl = self._repl_usar_alias_map or REPL_COBRA_MODULE_MAP
+            modulo_canonico = mapa_repl.get(nombre_modulo)
 
-            if es_repl_estricto:
-                modulo_canonico = self._repl_usar_alias_map.get(nombre_modulo)
-                if modulo_canonico is None:
+            if modulo_canonico is not None:
+                modulo = obtener_modulo_cobra_oficial(modulo_canonico)
+            else:
+                if es_repl_estricto:
                     raise PermissionError(
                         "módulos externos no soportados en REPL"
                     )
-                nombre_modulo = modulo_canonico
-
-            if es_repl_estricto and modulo_canonico is not None:
-                modulo = obtener_modulo_cobra_oficial(nombre_modulo)
-            else:
                 modulo = obtener_modulo(
                     nombre_modulo,
-                    permitir_instalacion=not es_repl_estricto,
+                    permitir_instalacion=True,
                 )
 
             if es_repl_estricto and modulo_canonico is not None:


### PR DESCRIPTION
### Motivation
- Asegurar que aliases canónicos (`numero`, `texto`, `logica` y los declarados en `REPL_COBRA_MODULE_MAP`) siempre se resuelvan a módulos oficiales de Cobra desde el evaluador, independientemente del modo REPL.
- Mantener la sintaxis y el parser existentes (`usar "..."`) sin cambios, actuando únicamente sobre la resolución semántica en `ejecutar_usar`.
- Conservar la política de rechazo en REPL estricto para módulos no canónicos y evitar dejar el contexto en un estado parcial si la carga/validación falla.

### Description
- Añadido `from ..cobra.usar_policy import REPL_COBRA_MODULE_MAP` a `src/pcobra/core/interpreter.py`.
- En `def ejecutar_usar(self, nodo):` se introduce `mapa_repl = self._repl_usar_alias_map or REPL_COBRA_MODULE_MAP` y se consulta `modulo_canonico = mapa_repl.get(nombre_modulo)` para una rama temprana.
- Si existe `modulo_canonico` el código siempre usa `obtener_modulo_cobra_oficial(modulo_canonico)`; si no existe y el intérprete está en REPL estricto se lanza `PermissionError("módulos externos no soportados en REPL")` y fuera de REPL estricto se llama a `obtener_modulo(..., permitir_instalacion=True)`.
- Se mantiene la validación posterior (comprobación de `__file__` y que el módulo provenga de `corelibs`/`standard_library`) para REPL estricto, y se conserva la inyección en dos fases (recolectar/validar antes de definir) evitando estado parcial en el contexto si ocurre un error.

### Testing
- Ejecutado `python -m py_compile src/pcobra/core/interpreter.py` y la comprobación de compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e45bc1e08327aee25b8f8f3c6086)