### PR TITLE
Amplía pruebas de `usar` en REPL y valida carga de módulos oficiales Cobra

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -239,6 +239,7 @@ def test_repl_usar_colision_no_inyecta_ningun_simbolo(monkeypatch):
     with pytest.raises(NameError, match=r"símbolo 'colisiona' ya existe"):
         interp.ejecutar_nodo(NodoUsar("mi_modulo"))
 
+    assert interp.obtener_variable("colisiona") is not None
     assert "disponible" not in interp.variables
 
 
@@ -253,6 +254,48 @@ def test_repl_usar_numpy_falla_sin_estado_parcial():
 
     assert interp.variables == estado_inicial
     assert "numpy" not in interp.variables
+
+
+def test_obtener_modulo_alias_cobra_usa_origen_oficial(monkeypatch):
+    modulo_oficial = ModuleType("numero")
+    modulo_oficial.es_finito = lambda valor: True
+    monkeypatch.setitem(usar_loader.USAR_WHITELIST, "numero", "numero")
+
+    llamadas = {"oficial": 0, "importlib": 0}
+
+    def _resolver_fallido(*_args, **_kwargs):
+        from pcobra.cobra.imports.resolver import ImportResolutionError
+
+        raise ImportResolutionError("sin backend")
+
+    class FakeResolver:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        load_module = _resolver_fallido
+
+    def _import_module_controlado(nombre, *args, **kwargs):
+        if nombre == "numero":
+            llamadas["importlib"] += 1
+            raise ModuleNotFoundError(nombre)
+        return importlib_import_real(nombre, *args, **kwargs)
+
+    def _oficial_controlado(nombre):
+        llamadas["oficial"] += 1
+        assert nombre == "numero"
+        return modulo_oficial
+
+    importlib_import_real = usar_loader.importlib.import_module
+    from pcobra.cobra.imports import resolver as imports_resolver
+
+    monkeypatch.setattr(imports_resolver, "CobraImportResolver", FakeResolver)
+    monkeypatch.setattr(usar_loader.importlib, "import_module", _import_module_controlado)
+    monkeypatch.setattr(usar_loader, "obtener_modulo_cobra_oficial", _oficial_controlado)
+
+    modulo = usar_loader.obtener_modulo("numero")
+
+    assert modulo is modulo_oficial
+    assert llamadas == {"oficial": 1, "importlib": 1}
 
 
 def test_repl_no_habilita_acceso_por_punto_para_usar_numero(monkeypatch):


### PR DESCRIPTION
### Motivation

- Añadir cobertura de casos REPL para `usar` que verifiquen la inyección de símbolos expuestos por módulos oficiales (`numero`, `texto`) sin prefijo.
- Asegurar que una colisión de nombres preexistente provoca error y no deja símbolos parciales inyectados en el intérprete.
- Verificar que, para alias oficiales de Cobra, la ruta de carga prioriza el origen oficial (`obtener_modulo_cobra_oficial`) en lugar de un `importlib.import_module` directo.

### Description

- Se amplió `tests/unit/test_usar.py` añadiendo una aserción que confirma que el símbolo preexistente sigue disponible tras una colisión y que no se inyectan símbolos adicionales cuando falla `usar`.
- Se añadió el test `test_obtener_modulo_alias_cobra_usa_origen_oficial` que usa `monkeypatch` para simular un `CobraImportResolver` que falla, parchear `importlib.import_module` para forzar un `ModuleNotFoundError` y parchear `obtener_modulo_cobra_oficial` para comprobar que se llama y se devuelve el módulo oficial.
- Las pruebas mantienen la restricción de no tocar `Lexer`/`Parser` y validan el comportamiento en `evaluator/loader` mediante `InterpretadorCobra` y `usar_loader`.

### Testing

- Se ejecutó `pytest -q tests/unit/test_usar.py` y la ejecución falló en la fase de colección con `ImportError: attempted relative import beyond top-level package`, por una limitación de imports en el entorno de test actual; los nuevos tests no pudieron completarse por este error.
- No se ejecutaron otros tests automatizados adicionales en este cambio por la falla de colección anterior.
- Los cambios de test están añadidos en `tests/unit/test_usar.py` y listos para ejecutar una vez resuelta la configuración de importación del paquete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f7b45c6483278e66a57b31c8e9e8)