### PR TITLE
Endurecer `usar` para módulos externos sin exportables

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1886,6 +1886,11 @@ class InterpretadorCobra:
             simbolos_a_inyectar = _resolver_exportables_callables(
                 modulo, modulo_oficial=es_modulo_oficial_cobra
             )
+            if not simbolos_a_inyectar and not es_modulo_oficial_cobra:
+                raise ImportError(
+                    "módulo externo no exportable para usar"
+                )
+
             contexto_actual = self.contextos[-1]
 
             # Fase A: validar colisiones de forma completa antes de definir.

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -243,6 +243,25 @@ def test_repl_usar_colision_no_inyecta_ningun_simbolo(monkeypatch):
     assert "disponible" not in interp.variables
 
 
+
+
+def test_usar_modulo_externo_sin_exportables_falla_sin_estado_parcial(monkeypatch):
+    modulo = ModuleType("numpy")
+    interp = InterpretadorCobra()
+    interp.contextos[-1].define("sentinela", 42)
+    estado_inicial = dict(interp.variables)
+
+    monkeypatch.setattr(
+        core_usar_loader,
+        "obtener_modulo",
+        lambda _nombre, **_kwargs: modulo,
+    )
+
+    with pytest.raises(ImportError, match="módulo externo no exportable para usar"):
+        interp.ejecutar_nodo(NodoUsar("numpy"))
+
+    assert interp.variables == estado_inicial
+
 def test_repl_usar_numpy_falla_sin_estado_parcial():
     interp = InterpretadorCobra()
     interp.contextos[-1].define("sentinela", 42)


### PR DESCRIPTION
### Motivation
- Evitar que `usar` deje al intérprete en un estado parcial cuando se intenta importar un módulo externo que no expone exportables seguros. 
- Mantener el comportamiento estricto del REPL y la atomicidad de la operación de inyección de símbolos.

### Description
- En `InterpretadorCobra.ejecutar_usar` se añadió una validación que lanza `ImportError("módulo externo no exportable para usar")` cuando `simbolos_a_inyectar` queda vacío y `es_modulo_oficial_cobra` es `False`.
- Se preservó la lógica atómica existente: primero se valida la ausencia de colisiones y solo si todas las comprobaciones pasan se inyectan los símbolos en el contexto.
- Se añadió la prueba unitaria `test_usar_modulo_externo_sin_exportables_falla_sin_estado_parcial` en `tests/unit/test_usar.py` que simula `usar "numpy"` sin exportables y verifica que falla con mensaje claro y sin modificar el estado del intérprete.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar.py` y la ejecución falló en la fase de recolección con `ImportError: attempted relative import beyond top-level package` debido a la configuración de imports en el entorno de ejecución.
- Probé `PYTHONPATH=src pytest -q tests/unit/test_usar.py` y `PYTHONPATH=src/pcobra pytest -q tests/unit/test_usar.py`, y ambos intentos dieron el mismo error de recolección por imports, por lo que las pruebas no llegaron a ejecutarse completamente.
- La nueva prueba fue añadida al suite y está lista para correr en un entorno de CI con `PYTHONPATH` correctamente configurado; localmente requiere ajustar la carga de paquetes para permitir la importación relativa de `pcobra`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5fef0d13c8327917f0d233218d0c7)