### PR TITLE
Clarificar matriz de `usar`, centralizar resolución y añadir tests para REPL/no estricto

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1805,10 +1805,21 @@ class InterpretadorCobra:
     def ejecutar_usar(self, nodo):
         """Importa callables públicos al contexto actual usando la política de ``usar``.
 
-        En modo REPL estricto (cuando existe ``_repl_usar_alias_map``), solo se
-        permiten módulos oficiales de Cobra cargados desde ``corelibs`` o
-        ``standard_library``. No hay fallback a módulos Python externos ni
-        instalación automática de paquetes.
+        Matriz de comportamiento:
+
+        - REPL estricto (``_repl_usar_alias_map`` definido):
+          - Se permiten únicamente módulos oficiales (``numero``, ``texto``,
+            ``logica``, etc.) mapeados en el alias map activo.
+          - El módulo debe resolverse desde rutas oficiales de Cobra
+            (``corelibs``/``standard_library``).
+          - Cualquier módulo externo se rechaza con ``PermissionError``.
+
+        - Fuera de REPL estricto:
+          - Módulos oficiales: se cargan como oficiales y deben exponer
+            ``__all__`` explícito.
+          - Módulos externos: se permiten solo si pueden exportarse de forma
+            completa según la política de ``usar`` (API pública explícita por
+            ``__all__`` y símbolos callables). Si no cumplen, se rechazan.
         """
         from pathlib import Path
 
@@ -1836,8 +1847,8 @@ class InterpretadorCobra:
                 simbolos.append((nombre, simbolo))
             return simbolos
 
-        try:
-            nombre_modulo = nodo.modulo
+        def _resolver_carga_modulo_usar(nombre_modulo: str):
+            """Aplica una única ruta de decisión para módulos de ``usar``."""
             es_repl_estricto = self._repl_usar_alias_map is not None
             mapa_repl = self._repl_usar_alias_map or REPL_COBRA_MODULE_MAP
             modulo_canonico = mapa_repl.get(nombre_modulo)
@@ -1845,15 +1856,21 @@ class InterpretadorCobra:
 
             if es_modulo_oficial_cobra:
                 modulo = obtener_modulo_cobra_oficial(modulo_canonico)
+            elif es_repl_estricto:
+                raise PermissionError("módulos externos no soportados en REPL")
             else:
-                if es_repl_estricto:
-                    raise PermissionError(
-                        "módulos externos no soportados en REPL"
-                    )
                 modulo = obtener_modulo(
                     nombre_modulo,
                     permitir_instalacion=True,
                 )
+
+            return modulo, es_repl_estricto, es_modulo_oficial_cobra
+
+        try:
+            nombre_modulo = nodo.modulo
+            modulo, es_repl_estricto, es_modulo_oficial_cobra = _resolver_carga_modulo_usar(
+                nombre_modulo
+            )
 
             if es_repl_estricto and es_modulo_oficial_cobra:
                 modulo_file = getattr(modulo, "__file__", None)

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -191,6 +191,32 @@ def _ejecutar_codigo(codigo: str, interp: InterpretadorCobra | None = None) -> I
     return interprete
 
 
+
+
+def test_repl_usar_numero_inyecta_funciones_globales(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_numero)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto"})
+
+    interp.ejecutar_nodo(NodoUsar("numero"))
+
+    assert "es_finito" in interp.variables
+    assert interp.obtener_variable("es_finito")(10) is True
+
+
+def test_repl_usar_texto_inyecta_funciones_globales(monkeypatch):
+    import pcobra.corelibs.texto as modulo_texto
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_texto)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto"})
+
+    interp.ejecutar_nodo(NodoUsar("texto"))
+
+    assert "a_snake" in interp.variables
+    assert interp.obtener_variable("a_snake")("HolaMundo") == "hola_mundo"
 def test_repl_usar_numero_permite_es_finito_sin_prefijo(monkeypatch):
     import pcobra.corelibs.numero as modulo_numero
 
@@ -244,6 +270,26 @@ def test_repl_usar_colision_no_inyecta_ningun_simbolo(monkeypatch):
 
 
 
+
+
+
+def test_usar_modulo_externo_no_estricto_inyecta_exportables_completos(monkeypatch):
+    modulo = ModuleType("numpy")
+    modulo.sumar = lambda a, b: a + b
+    modulo.restar = lambda a, b: a - b
+    modulo.__all__ = ["sumar", "restar"]
+
+    monkeypatch.setattr(
+        core_usar_loader,
+        "obtener_modulo",
+        lambda _nombre, **_kwargs: modulo,
+    )
+    interp = InterpretadorCobra()
+
+    interp.ejecutar_nodo(NodoUsar("numpy"))
+
+    assert interp.obtener_variable("sumar")(2, 3) == 5
+    assert interp.obtener_variable("restar")(8, 2) == 6
 
 def test_usar_modulo_externo_sin_exportables_falla_sin_estado_parcial(monkeypatch):
     modulo = ModuleType("numpy")


### PR DESCRIPTION
### Motivation

- Aclarar la política de `usar` diferenciando comportamiento en REPL estricto y en modo no estricto para evitar ambigüedades de seguridad y origen de módulos.
- Evitar rutas de decisión dispersas que podían llevar a comportamientos inconsistentes al cargar módulos externos u oficiales.
- Añadir pruebas explícitas que cubran las combinaciones importantes de REPL estricto vs no estricto y la inyección atómica de símbolos.

### Description

- Actualicé el docstring de `ejecutar_usar` para documentar la matriz de comportamiento en REPL estricto vs fuera de REPL estricto, incluyendo requisitos de `__all__` y origen oficial (`corelibs`/`standard_library`).
- Centralicé la lógica de decisión de carga en la nueva función interna `_resolver_carga_modulo_usar`, que devuelve el módulo y banderas (`es_repl_estricto`, `es_modulo_oficial_cobra`) y evita rutas ambigüas de resolución.
- Mantengo y uso el helper `_resolver_exportables_callables` para normalizar la extracción de símbolos públicos (filtra privados y no-callables y exige `__all__` para módulos oficiales).
- Añadí tests unitarios en `tests/unit/test_usar.py` para cubrir casos explícitos: `test_repl_usar_numero_inyecta_funciones_globales`, `test_repl_usar_texto_inyecta_funciones_globales` y `test_usar_modulo_externo_no_estricto_inyecta_exportables_completos`.

### Testing

- Ejecuté `pytest -q tests/unit/test_usar.py` y la ejecución falló en la fase de colección con `ImportError: attempted relative import beyond top-level package` originado por la configuración de imports del entorno de pruebas; la suite no llegó a ejecutar los tests nuevos.
- Reintenté con `PYTHONPATH=src pytest -q tests/unit/test_usar.py` y obtuve el mismo fallo de colección por la misma causa, por lo que no hubo ejecución de las pruebas añadidas.
- No se observaron fallos en el código modificado durante el formateo/commit local, pero las pruebas automatizadas en CI/local necesitan que la configuración de imports sea corregida para poder validar los nuevos casos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6029f9ac8832782e229a7386fb0aa)