### PR TITLE
test: reforzar contrato de exports en módulos oficiales REPL

### DIFF
--- a/tests/unit/test_repl_official_stdlib_exports_policy.py
+++ b/tests/unit/test_repl_official_stdlib_exports_policy.py
@@ -3,26 +3,37 @@ from __future__ import annotations
 import importlib
 
 from pcobra.cobra.stdlib_contract import CONTRACTS
+from pcobra.cobra.usar_loader import obtener_modulo_cobra_oficial
 from pcobra.cobra.usar_policy import REPL_COBRA_MODULE_MAP
 
 
 def test_modulos_oficiales_repl_requieren_all_y_callables() -> None:
     for alias, module_name in REPL_COBRA_MODULE_MAP.items():
-        modulo = importlib.import_module(f"pcobra.standard_library.{module_name}")
+        modulo = obtener_modulo_cobra_oficial(module_name)
         exports = getattr(modulo, "__all__", None)
-        assert exports is not None, f"El módulo oficial '{alias}' debe definir __all__"
+        assert exports is not None, (
+            f"[modulo={module_name} alias={alias}] debe definir __all__"
+        )
         assert isinstance(exports, list | tuple), (
-            f"El módulo oficial '{alias}' debe exponer __all__ como lista/tupla"
+            f"[modulo={module_name} alias={alias}] __all__ debe ser lista o tupla"
         )
         for symbol_name in exports:
             assert isinstance(symbol_name, str), (
-                f"El módulo oficial '{alias}' exporta símbolo no textual: {symbol_name!r}"
+                f"[modulo={module_name} alias={alias} simbolo={symbol_name!r}] "
+                "el nombre exportado debe ser str"
+            )
+            assert not symbol_name.startswith("_"), (
+                f"[modulo={module_name} alias={alias} simbolo={symbol_name}] "
+                "no se permiten símbolos privados en __all__"
             )
             assert hasattr(modulo, symbol_name), (
-                f"El módulo oficial '{alias}' exporta símbolo inexistente: {symbol_name}"
+                f"[modulo={module_name} alias={alias} simbolo={symbol_name}] "
+                "el símbolo exportado no existe en el módulo"
             )
-            assert callable(getattr(modulo, symbol_name)), (
-                f"El módulo oficial '{alias}' exporta símbolo no callable: {symbol_name}"
+            exported_symbol = getattr(modulo, symbol_name)
+            assert callable(exported_symbol), (
+                f"[modulo={module_name} alias={alias} simbolo={symbol_name}] "
+                "el símbolo exportado debe ser callable"
             )
 
 


### PR DESCRIPTION
### Motivation
- Asegurar que los módulos oficiales usados por el REPL cumplan un contrato claro de exports y se carguen desde la fuente oficial del proyecto.
- Facilitar el mantenimiento de la stdlib detectando símbolos ausentes, privados o no-callables con mensajes de fallo explícitos.

### Description
- Actualiza `tests/unit/test_repl_official_stdlib_exports_policy.py` para cargar cada módulo usando `obtener_modulo_cobra_oficial` en lugar de importar por ruta fija.
- Endurece las validaciones sobre `__all__` para verificar que `__all__` existe y es `list|tuple`, que cada entrada es `str` y que ninguna entrada comienza con `_`.
- Verifica que cada nombre listado en `__all__` existe en el módulo y que el objeto exportado es `callable`, y mejora los mensajes de aserción incluyendo `modulo`, `alias` y `simbolo` para diagnóstico inmediato.

### Testing
- Se ejecutó `pytest -q tests/unit/test_repl_official_stdlib_exports_policy.py` y la suite reportó `1 failed, 1 passed`.
- La falla ocurre en `test_modulos_oficiales_repl_requieren_all_y_callables` porque el módulo `archivo` no define `__all__`, que es el contrato que ahora la prueba exige.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60d2ba1688327950d0fa3d107011e)