### PR TITLE
test: añadir caso para colisión de `usar` en entorno ancestro (no inyecta exportables)

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -19,6 +19,7 @@ import pytest
 from core.interpreter import InterpretadorCobra
 from core.errors import InvalidTokenError
 from core.ast_nodes import NodoUsar
+from core.environment import Environment
 from cobra.core import Lexer, Parser
 from cobra import usar_loader
 from core import usar_loader as core_usar_loader
@@ -267,6 +268,30 @@ def test_repl_usar_colision_no_inyecta_ningun_simbolo(monkeypatch):
 
     assert interp.obtener_variable("colisiona") is not None
     assert "disponible" not in interp.variables
+
+
+def test_repl_usar_colision_en_ancestro_no_inyecta_exportables(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_numero)
+    interp = InterpretadorCobra()
+    contexto_padre = interp.contextos[-1]
+    contexto_hijo = Environment(parent=contexto_padre)
+    # Contrato: no sobrescribir en toda la cadena léxica.
+    contexto_padre.define("es_finito", lambda _valor: "ocupado")
+    interp.contextos.append(contexto_hijo)
+    interp.mem_contextos.append({})
+
+    with pytest.raises(NameError, match=r"símbolo 'es_finito' ya existe"):
+        interp.ejecutar_nodo(NodoUsar("numero"))
+
+    assert contexto_padre.get("es_finito")("x") == "ocupado"
+    assert "es_finito" not in contexto_hijo.values
+    assert "a_decimal" not in contexto_hijo.values
+    assert "es_entero" not in contexto_hijo.values
+
+    interp.mem_contextos.pop()
+    interp.contextos.pop()
 
 
 


### PR DESCRIPTION
### Motivation
- Asegurar que la operación `usar` respeta el contrato de no sobrescribir símbolos existentes en toda la cadena léxica cuando un símbolo exportado ya existe en un entorno ancestro. 
- Detectar y prevenir estados parciales de inyección cuando ocurre una colisión de nombres durante `usar`.

### Description
- Se añadió el import `from core.environment import Environment` para poder construir un contexto hijo enlazado explícitamente a su padre en la prueba. 
- Se creó el test `test_repl_usar_colision_en_ancestro_no_inyecta_exportables` en `tests/unit/test_usar.py` que define `es_finito` en el entorno padre, ejecuta `NodoUsar("numero")` desde el hijo y espera un `NameError` por colisión. 
- El test también verifica atomicidad comprobando que no se inyectan otros exportables del módulo (`a_decimal`, `es_entero`) en el contexto hijo y mantiene el valor original en el padre, e incluye el comentario del contrato `no sobrescribir en toda la cadena léxica`.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar.py -k "ancestro_no_inyecta_exportables or colision_no_inyecta_ningun_simbolo"`, que falló en la fase de colección con `ImportError: attempted relative import beyond top-level package` y por tanto las pruebas no llegaron a ejecutarse.
- No se detectaron fallos del nuevo test en tiempo de ejecución porque la ejecución quedó interrumpida durante la colección; la prueba añadida fue verificada sintácticamente en el archivo `tests/unit/test_usar.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6171d00248327a67b907ad0447099)