### PR TITLE
Unifica mensaje de rechazo de módulos externos en REPL y parametriza pruebas

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1875,9 +1875,7 @@ class InterpretadorCobra:
             if es_repl_estricto and es_modulo_oficial_cobra:
                 modulo_file = getattr(modulo, "__file__", None)
                 if not modulo_file:
-                    raise PermissionError(
-                        "REPL estricto: módulo externo no soportado; no se pudo validar origen oficial"
-                    )
+                    raise PermissionError("módulos externos no soportados en REPL")
 
                 ruta_modulo = Path(modulo_file).resolve()
                 base = Path(__file__).resolve()
@@ -1893,9 +1891,7 @@ class InterpretadorCobra:
                     for ruta_base in rutas_oficiales
                 )
                 if not es_oficial:
-                    raise PermissionError(
-                        "REPL estricto: módulo externo no soportado; use solo módulos oficiales de Cobra"
-                    )
+                    raise PermissionError("módulos externos no soportados en REPL")
 
             # ``usar`` solo importa API pública explícita del módulo Cobra:
             # prioriza __all__, filtra privados/no-callables y evita fugas de

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -346,6 +346,42 @@ def test_repl_usar_numpy_falla_sin_estado_parcial():
     assert "numpy" not in interp.variables
 
 
+@pytest.mark.parametrize(
+    "escenario",
+    [
+        "alias_no_permitido",
+        "modulo_sin___file__",
+        "ruta_no_oficial",
+    ],
+)
+def test_repl_usar_rechazo_externo_emite_mensaje_canonico(monkeypatch, escenario):
+    modulo = ModuleType("numero")
+    modulo.__all__ = ["es_finito"]
+    modulo.es_finito = lambda valor: True
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto"})
+
+    if escenario == "alias_no_permitido":
+        with pytest.raises(PermissionError, match="módulos externos no soportados en REPL"):
+            interp.ejecutar_nodo(NodoUsar("numpy"))
+        return
+
+    if escenario == "modulo_sin___file__":
+        monkeypatch.delattr(modulo, "__file__", raising=False)
+    else:
+        modulo.__file__ = "/tmp/externo/numero.py"
+
+    monkeypatch.setattr(
+        core_usar_loader,
+        "obtener_modulo_cobra_oficial",
+        lambda _nombre: modulo,
+    )
+
+    with pytest.raises(PermissionError, match="módulos externos no soportados en REPL"):
+        interp.ejecutar_nodo(NodoUsar("numero"))
+
+
 def test_obtener_modulo_alias_cobra_usa_origen_oficial(monkeypatch):
     modulo_oficial = ModuleType("numero")
     modulo_oficial.es_finito = lambda valor: True


### PR DESCRIPTION
### Motivation
- Homogenizar las rutas de rechazo de `ejecutar_usar` en modo REPL estricto para que todas las ramas que deniegan módulos externos emitan el mismo mensaje canónico. 
- Mantener la lógica de validación de origen oficial (`corelibs`/`standard_library`) intacta y solo cambiar el texto de los `PermissionError`. 
- Asegurar que las pruebas verifiquen de forma consistente el mensaje de error en los distintos escenarios de rechazo externo.

### Description
- Se actualizó `src/pcobra/core/interpreter.py` dentro de `ejecutar_usar` para reemplazar los dos `PermissionError` diferentes por el mensaje único: `módulos externos no soportados en REPL` sin alterar la validación de origen oficial. 
- Se agregó una prueba parametrizada `test_repl_usar_rechazo_externo_emite_mensaje_canonico` en `tests/unit/test_usar.py` que cubre tres escenarios: `alias_no_permitido`, `modulo_sin___file__` y `ruta_no_oficial`, esperando el mismo mensaje canónico. 
- Se ajustó una llamada a `monkeypatch.setattr` en la nueva prueba para usar el objeto correcto (`core_usar_loader`) al simular `obtener_modulo_cobra_oficial`.

### Testing
- Ejecuté un subconjunto de pruebas con `pytest -q tests/unit/test_usar.py -k 'repl_usar_rechazo_externo_emite_mensaje_canonico or repl_usar_numpy_falla_sin_estado_parcial'`, pero la colección falló con un error de importación: `ImportError: attempted relative import beyond top-level package` antes de ejecutar los tests. 
- Los cambios en el código y las pruebas fueron aplicados y confirmados en el árbol de trabajo, pero la ejecución automatizada quedó interrumpida por el problema de entorno/imports descrito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6299aa4b0832790cdccd7042f51de)