### PR TITLE
Agregar test de colisión de `usar` en ancestro con atomicidad

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -295,7 +295,28 @@ def test_repl_usar_colision_en_ancestro_no_inyecta_exportables(monkeypatch):
 
 
 
+def test_repl_usar_texto_colision_en_ancestro_es_atomico(monkeypatch):
+    import pcobra.corelibs.texto as modulo_texto
 
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_texto)
+    interp = InterpretadorCobra()
+    contexto_padre = interp.contextos[-1]
+    contexto_hijo = Environment(parent=contexto_padre)
+    # Contrato: no sobrescribir en toda la cadena léxica.
+    contexto_padre.define("a_snake", lambda _valor: "ocupado")
+    interp.contextos.append(contexto_hijo)
+    interp.mem_contextos.append({})
+
+    with pytest.raises(NameError, match=r"símbolo 'a_snake' ya existe"):
+        interp.ejecutar_nodo(NodoUsar("texto"))
+
+    assert contexto_padre.get("a_snake")("Hola") == "ocupado"
+    assert "a_snake" not in contexto_hijo.values
+    assert "a_kebab" not in contexto_hijo.values
+    assert "capitalizar" not in contexto_hijo.values
+
+    interp.mem_contextos.pop()
+    interp.contextos.pop()
 
 
 def test_usar_modulo_externo_no_estricto_inyecta_exportables_completos(monkeypatch):


### PR DESCRIPTION
### Motivation
- Añadir cobertura para el contrato de `usar` que impide sobrescribir símbolos en toda la cadena léxica cuando hay colisiones con exportables oficiales.

### Description
- Se añadió el test `test_repl_usar_texto_colision_en_ancestro_es_atomico` en `tests/unit/test_usar.py` que crea dos contextos enlazados con `Environment(parent=...)`, define `a_snake` en el contexto padre y ejecuta `NodoUsar("texto")` en el hijo verificando que se lanza `NameError` por colisión.
- El test comprueba la atomicidad asegurando que no se inyectan otros exportables del módulo (`a_kebab`, `capitalizar`) cuando ocurre la colisión y documenta el contrato con el comentario `no sobrescribir en toda la cadena léxica`.

### Testing
- Intenté ejecutar `pytest -q tests/unit/test_usar.py -k 'ancestro and usar'` y `PYTHONPATH=src pytest -q tests/unit/test_usar.py -k 'texto_colision_en_ancestro_es_atomico'`, pero ambos fallaron en la colección con `ImportError: attempted relative import beyond top-level package`.
- No se ejecutaron tests unitarios que llegaran a correr el nuevo caso debido al error de importación en el entorno de prueba actual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f638f41a008327906aa78926fa1e15)