### PR TITLE
docs: clarify `usar` behavior for REPL and non-REPL runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,26 +903,53 @@ imprimir(saludo)
 
 Al ejecutar `programa.co`, se procesará primero `modulo.co` y luego se imprimirá `Hola desde módulo`.
 
-## Instrucción `usar` para dependencias dinámicas
+## Instrucción `usar`: separación REPL vs runtime general
 
-La sentencia `usar "paquete"` intenta importar un módulo de Python. Si el
-paquete no está disponible, Cobra ejecutará `pip install paquete` para
-instalarlo y luego lo cargará en tiempo de ejecución. Cuando la entrada de la
-lista blanca incluye hashes (`--hash=`) se añade automáticamente la bandera
-`--require-hashes` para que `pip` verifique el contenido; de lo contrario se
-omite. El módulo queda registrado en el entorno bajo el mismo nombre para su
-uso posterior.
-Para restringir qué dependencias pueden instalarse se emplea la variable
-`USAR_WHITELIST` definida en `src/pcobra/cobra/usar_loader.py`. Basta con
-añadir o quitar nombres de paquetes en dicho conjunto para modificar la lista
-autorizada. Si la lista se deja vacía la función `obtener_modulo` lanzará
-`PermissionError`, por lo que es necesario poblarla antes de permitir
-instalaciones dinámicas.
+La semántica de `usar` depende del contexto de ejecución:
 
-Para habilitar la instalación automática define la variable de entorno
-`COBRA_USAR_INSTALL=1`. Cuando esta variable no esté establecida,
-`obtener_modulo()` rechazará instalar dependencias y lanzará un
-`RuntimeError` si el paquete no se encuentra.
+### REPL (modo interactivo)
+
+En REPL, `usar` es **estricto**:
+
+- Solo acepta módulos oficiales definidos en `REPL_COBRA_MODULE_MAP`.
+- **No** existe fallback de instalación con `pip`.
+- Si pides un módulo externo (por ejemplo `numpy`), se rechaza con error y sin
+  dejar estado parcial.
+- Los símbolos se inyectan de forma directa (sin namespace de objeto).
+
+Ejemplos canónicos en REPL:
+
+```cobra
+usar "numero"
+imprimir(es_finito(10))
+
+usar "texto"
+imprimir(a_snake("HolaMundo"))
+```
+
+Ejemplo de rechazo explícito en REPL:
+
+```cobra
+usar "numpy"   # rechazado: módulo externo no soportado en REPL
+```
+
+> Nota: en Cobra REPL no hay dot-access para estos módulos inyectados.
+> `numero.es_finito(10)` **no** está permitido; usa `es_finito(10)`.
+
+### Runtime fuera de REPL
+
+Fuera del REPL se aplica la política general de resolución de dependencias
+(whitelist y reglas de entorno/configuración del loader).
+
+La sentencia `usar "paquete"` intenta importar un módulo de Python y, según la
+configuración activa, puede habilitar instalación dinámica. Para restringir qué
+dependencias pueden instalarse se emplea la variable `USAR_WHITELIST` definida
+en `src/pcobra/cobra/usar_loader.py`.
+
+Si la política habilita instalación automática (por ejemplo con
+`COBRA_USAR_INSTALL=1`), el runtime podrá invocar `pip` cuando el paquete no
+esté disponible. Si no está habilitada, `obtener_modulo()` rechazará la
+instalación y lanzará error.
 
 ## Archivo de mapeo de módulos
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -559,9 +559,45 @@ imprimir(saludo)
 
 When running `programa.co`, `modulo.co` is processed first and then `Hola desde módulo` is printed.
 
-## `usar` statement for dynamic dependencies
+## `usar` statement: REPL vs general runtime
 
-The statement `usar "paquete"` tries to import a Python module. If the package is not available, Cobra will run `pip install paquete` to install it and then load it at runtime. The module is registered in the environment under the same name for later use. To restrict which dependencies can be installed use the variable `USAR_WHITELIST` defined in `src/pcobra/cobra/usar_loader.py`.
+`usar` has different semantics depending on execution context:
+
+### REPL (interactive mode)
+
+In REPL, `usar` is **strict**:
+
+- Only official Cobra modules listed in `REPL_COBRA_MODULE_MAP` are allowed.
+- There is **no** `pip` installation fallback.
+- External modules (for example `numpy`) are rejected with no partial state left in session context.
+- Symbols are injected directly (not as object namespace access).
+
+Canonical REPL examples:
+
+```cobra
+usar "numero"
+imprimir(es_finito(10))
+
+usar "texto"
+imprimir(a_snake("HolaMundo"))
+```
+
+Explicit REPL rejection example:
+
+```cobra
+usar "numpy"   # rejected: external modules are not supported in REPL
+```
+
+> Note: there is no dot-access for these injected symbols in Cobra REPL.
+> `numero.es_finito(10)` is **not** allowed; use `es_finito(10)`.
+
+### Runtime outside REPL
+
+Outside REPL, Cobra applies the general dependency policy (whitelist + resolver/loader configuration).
+
+The statement `usar "paquete"` attempts a Python import and then follows runtime policy. To restrict allowed dynamic dependencies use `USAR_WHITELIST` in `src/pcobra/cobra/usar_loader.py`.
+
+If auto-install is enabled by policy/configuration (for example `COBRA_USAR_INSTALL=1`), the runtime may invoke `pip` when the package is missing. If not enabled, `obtener_modulo()` rejects installation and raises an error.
 
 ## Module mapping file
 


### PR DESCRIPTION
### Motivation

- Evitar ambigüedad en la documentación sobre la instrucción `usar` y dejar explícita la diferencia de semántica entre REPL (interactivo) y runtime normal. 
- Alinear los README públicos con el contrato operativo del REPL descrito en `docs/SPEC_COBRA.md` para evitar expectativas de instalación dinámica en sesiones interactivas.

### Description

- Actualiza `README.md` y `docs/README.en.md` para separar explícitamente la semántica de `usar` en `REPL` versus `runtime` fuera del REPL. 
- Documenta que en REPL `usar` solo permite módulos oficiales listados en `REPL_COBRA_MODULE_MAP` y que nunca realiza fallback a `pip`, rechazando módulos externos como `numpy`. 
- Añade ejemplos canónicos en ambos READMEs: `usar "numero"` seguido de `es_finito(10)` y `usar "texto"` seguido de `a_snake("HolaMundo")`, y un ejemplo explícito de rechazo `usar "numpy"`. 
- Incluye una nota clara de que en Cobra REPL no hay dot-access para los símbolos inyectados (por ejemplo `numero.es_finito(10)` no está permitido) y referencia la configuración de control de dependencias en `src/pcobra/cobra/usar_loader.py` (`USAR_WHITELIST`).

### Testing

- Ejecuté búsquedas automáticas con `rg` para localizar menciones de `usar`/`REPL`/`pip` en la documentación y verifiqué que las secciones relevantes fueron actualizadas; la comprobación devolvió las rutas y líneas esperadas (éxito). 
- Previsualicé automáticamente los fragmentos editados con `sed`/`nl` para validar el texto insertado en `README.md` y `docs/README.en.md`; la inspección mostró los ejemplos y la nota de no dot-access correctamente insertados (éxito). 
- No se ejecutaron tests unitarios o de integración sobre el código modificado en esta modificación documental; se recomienda correr la suite con `pytest` en el CI o localmente para validaciones adicionales.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63da629c883278ddc41c24fcacab8)