### PR TITLE
docs: aclarar adaptación obligatoria de `usar` en `ejecutar_usar`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1805,6 +1805,13 @@ class InterpretadorCobra:
     def ejecutar_usar(self, nodo):
         """Importa callables públicos al contexto actual usando la política de ``usar``.
 
+        Nota de compatibilidad obligatoria:
+
+        - En pCobra se acepta la forma ``usar "numero"`` por compatibilidad del
+          parser, pero esta entrada SIEMPRE se normaliza y ejecuta con la
+          semántica oficial del libro: ``usar numero`` (modelo plano sin
+          namespace de módulo).
+
         Matriz de comportamiento:
 
         - REPL estricto (``_repl_usar_alias_map`` definido):


### PR DESCRIPTION
### Motivation
- Documentar explícitamente en `ejecutar_usar` que la forma aceptada por el parser `usar "numero"` se normaliza y ejecuta siempre con la semántica oficial `usar numero` (modelo plano sin namespace de módulo). 

### Description
- Se añadió una nota de compatibilidad en el docstring de `ejecutar_usar` explicando la adaptación obligatoria de entrada y recordando el modelo plano de inyección de símbolos (sin exponer el objeto módulo). 

### Testing
- No se ejecutaron pruebas automatizadas para este cambio de documentación; se verificó localmente que el archivo fue modificado y committeado correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f641353f848327a0aab51f37faacc2)