### PR TITLE
Add integration test for `usar` collision atomicity

### DIFF
--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -72,3 +72,43 @@ def test_repl_contract_usar_aliases_y_restriccion_numpy(factory, executor, get_i
 
     with pytest.raises(Exception, match=r"Token no reconocido: '\.'"):
         executor(cmd, "numero.es_finito(10)")
+
+
+def _modulo_numero_multi_export_stub() -> ModuleType:
+    mod = ModuleType("numero")
+    mod.__all__ = ["es_finito", "es_par"]
+    mod.es_finito = lambda valor: valor == valor and valor not in (float("inf"), float("-inf"))
+    mod.es_par = lambda valor: isinstance(valor, int) and valor % 2 == 0
+    mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/numero.py"
+    return mod
+
+
+@pytest.mark.parametrize(
+    ("factory", "executor", "get_interp"),
+    [
+        (lambda: InteractiveCommand(InterpretadorCobra()), lambda cmd, code: cmd.ejecutar_codigo(code), lambda cmd: cmd.interpretador),
+        (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
+    ],
+)
+def test_repl_contract_colision_usar_numero_falla_sin_estado_parcial(factory, executor, get_interp, monkeypatch):
+    mod_numero = _modulo_numero_multi_export_stub()
+    mod_texto = _modulo_texto_stub()
+
+    def _resolver_modulo(nombre: str, **_kwargs):
+        if nombre == "numero":
+            return mod_numero
+        if nombre == "texto":
+            return mod_texto
+        raise ModuleNotFoundError(nombre)
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda nombre: _resolver_modulo(nombre))
+
+    cmd = factory()
+    interp = get_interp(cmd)
+    interp.contextos[-1].define("es_finito", lambda _valor: "ocupado")
+
+    with pytest.raises(NameError, match=r"No se puede usar el módulo 'numero': el símbolo 'es_finito' ya existe"):
+        executor(cmd, 'usar "numero"')
+
+    assert interp.obtener_variable("es_finito")("x") == "ocupado"
+    assert "es_par" not in interp.contextos[-1].values


### PR DESCRIPTION
### Motivation
- Asegurar que la semántica de `usar` realiza la validación de colisiones en dos fases y no deja estado parcial si hay conflicto.
- Garantizar que el error es explícito y útil con el formato `No se puede usar el módulo '...': el símbolo '...' ya existe en el contexto actual`.
- Probar el caso práctico donde `es_finito` ya está definido y `usar "numero"` debe fallar atómicamente sin inyectar otras exportaciones.

### Description
- Se añadió un stub multi-export para `numero` (`_modulo_numero_multi_export_stub`) que exporta `es_finito` y `es_par` en `tests/integration/test_repl_usar_entrypoints_contract.py`.
- Se añadió la prueba parametrizada `test_repl_contract_colision_usar_numero_falla_sin_estado_parcial` que predefine `es_finito` en el contexto, ejecuta `usar "numero"` y verifica que se lanza `NameError` con el mensaje exacto y que `es_par` no queda inyectado.
- Se verificó que la implementación existente de `ejecutar_usar` ya aplica la Fase A (validación con `contexto_actual.contains`) y la Fase B (definición sólo tras validación) con el mensaje de error solicitado.

### Testing
- Ejecutado: `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py`.
- Resultado: todos los tests del archivo pasaron (`6 passed`) con `1 warning` y la nueva prueba de colisión pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6c534f9408327bd85c1630452b0a7)