### PR TITLE
Endurece la política REPL de `usar` y garantiza estado inalterado tras rechazo de `numpy`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1885,13 +1885,11 @@ class InterpretadorCobra:
                     raise PermissionError("módulos externos no soportados en REPL")
 
                 ruta_modulo = Path(modulo_file).resolve()
-                base = Path(__file__).resolve()
-                rutas_oficiales = []
-                for parent in base.parents:
-                    for carpeta in ("corelibs", "standard_library"):
-                        candidato = parent / carpeta
-                        if candidato.exists():
-                            rutas_oficiales.append(candidato.resolve())
+                raiz_pcobra = Path(__file__).resolve().parents[1]
+                rutas_oficiales = [
+                    (raiz_pcobra / "corelibs").resolve(),
+                    (raiz_pcobra / "standard_library").resolve(),
+                ]
 
                 es_oficial = any(
                     ruta_modulo == ruta_base or ruta_base in ruta_modulo.parents

--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -64,11 +64,14 @@ def test_repl_contract_usar_aliases_y_restriccion_numpy(factory, executor, get_i
     executor(cmd, 'usar "texto"')
     executor(cmd, 'a_snake("HolaMundo")')
     assert interp.obtener_variable("a_snake")("HolaMundo") == "hola_mundo"
+    estado_pre_numpy = dict(interp.contextos[-1].values)
 
     with pytest.raises(PermissionError, match="módulos externos no soportados en REPL"):
         executor(cmd, 'usar "numpy"')
 
     assert "numpy" not in interp.variables
+    assert "numpy" not in interp.contextos[-1].values
+    assert estado_pre_numpy == interp.contextos[-1].values
 
     with pytest.raises(Exception, match=r"Token no reconocido: '\.'"):
         executor(cmd, "numero.es_finito(10)")


### PR DESCRIPTION
### Motivation
- Asegurar que la rama REPL estricta de `usar` siga rechazando cualquier módulo externo con un `PermissionError` claro.
- Evitar que módulos externos con nombres o rutas coincidentes se acepten accidentalmente por una búsqueda de ancestros demasiado amplia. 
- Garantizar que el rechazo de un `usar` sea atómico y no deje el contexto en un estado parcialmente mutado.

### Description
- En `src/pcobra/core/interpreter.py` se mantiene la rama REPL estricta que lanza `PermissionError("módulos externos no soportados en REPL")` para módulos fuera del alias map y se refuerza la comprobación de ruta usando explícitamente las raíces `corelibs` y `standard_library` derivadas de `raiz_pcobra` en lugar de iterar todos los ancestros. 
- Se preserva la fase de validación previa a la inyección de símbolos (colisiones) y la fase atómica de definición, de forma que un fallo ocurre antes de cualquier mutación del contexto. 
- En `tests/integration/test_repl_usar_entrypoints_contract.py` se añadió una captura del estado del contexto (`estado_pre_numpy`) antes de intentar `usar "numpy"` y se añadieron aserciones que comprueban que `numpy` no aparece en `interp.variables`, no aparece en `interp.contextos[-1].values` y que el contexto permanece idéntico al snapshot tras el rechazo.

### Testing
- Se ejecutó `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py` y todos los tests del archivo pasaron (`6 passed`) con una advertencia deprecatoria. 
- Las nuevas aserciones verifican que `usar "numpy"` lanza `PermissionError` y no provoca cambios parciales en el contexto (prueba automatizada aprobada).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6d8d81fb08327b37c92d3e34e041b)