### PR TITLE
docs: aclarar contrato de `usar` en REPL y alinear ejemplos ES/EN

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,6 +911,8 @@ La semántica de `usar` depende del contexto de ejecución:
 
 En REPL, `usar` es **estricto**:
 
+- **Sintaxis implementada actual (restricción del parser, sin cambiar lexer/parser):** `usar "numero"` (siempre con cadena).
+- **Semántica objetivo oficial:** importación plana de funciones del módulo Cobra (`es_finito(...)` sin prefijo).
 - Solo acepta módulos oficiales definidos en `REPL_COBRA_MODULE_MAP`.
 - **No** existe fallback de instalación con `pip`.
 - Si pides un módulo externo (por ejemplo `numpy`), se rechaza con error y sin
@@ -930,7 +932,8 @@ imprimir(a_snake("HolaMundo"))
 Ejemplo de rechazo explícito en REPL:
 
 ```cobra
-usar "numpy"   # rechazado: módulo externo no soportado en REPL
+usar "numpy"
+# módulos externos no soportados en REPL
 ```
 
 > Nota: en Cobra REPL no hay dot-access para estos módulos inyectados.

--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -405,21 +405,41 @@ clase Usuario:
 
 **Definición corta:** unidades de organización y reutilización de código.
 
+**Contrato vigente de `usar` (sin cambiar lexer/parser):**
+
+- **Sintaxis implementada actual (restricción del parser):** `usar "numero"` (siempre con cadena).
+- **Semántica objetivo oficial:** importación plana de funciones del módulo Cobra cargado, por ejemplo `es_finito(...)` **sin prefijo**.
+
 **Sintaxis formal simplificada:**
 
 ```text
-importacion := "usar" IDENTIFICADOR
+usar_stmt := "usar" CADENA  # sintaxis implementada actualmente por parser
 ```
 
 **Ejemplos:**
 
 ```cobra
-usar texto
-usar numero
+usar "texto"
+usar "numero"
 ```
 
 ```cobra
-usar mi_modulo.utilidades
+usar "mi_modulo.utilidades"
+```
+
+Ejemplo canónico de adaptación (actual):
+
+```cobra
+# entrada (válida por parser actual)
+usar "numero"
+# uso plano esperado
+imprimir(es_finito(10))
+```
+
+Ejemplo de rechazo de módulo externo en REPL:
+
+```cobra
+usar "numpy"  # módulos externos no soportados en REPL
 ```
 
 **Anti-ejemplo frecuente:** dependencia circular entre módulos hermanos.
@@ -701,8 +721,8 @@ pares = numeros.filtrar(funcion(x): retornar x % 2 == 0)
 ### 7.1 Importar módulos
 
 ```cobra
-usar texto
-usar numero
+usar "texto"
+usar "numero"
 ```
 
 ### 7.2 Estructura recomendada

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -567,6 +567,8 @@ When running `programa.co`, `modulo.co` is processed first and then `Hola desde 
 
 In REPL, `usar` is **strict**:
 
+- **Current implemented syntax (parser restriction; do not change lexer/parser):** `usar "numero"` (string form).
+- **Official target semantics:** flat symbol import from the loaded Cobra module (`es_finito(...)` without prefix).
 - Only official Cobra modules listed in `REPL_COBRA_MODULE_MAP` are allowed.
 - There is **no** `pip` installation fallback.
 - External modules (for example `numpy`) are rejected with no partial state left in session context.
@@ -585,7 +587,8 @@ imprimir(a_snake("HolaMundo"))
 Explicit REPL rejection example:
 
 ```cobra
-usar "numpy"   # rejected: external modules are not supported in REPL
+usar "numpy"
+# external modules are not supported in REPL
 ```
 
 > Note: there is no dot-access for these injected symbols in Cobra REPL.

--- a/docs/SPEC_COBRA.md
+++ b/docs/SPEC_COBRA.md
@@ -232,10 +232,14 @@ datos.escribir_json(registros, 'salida/ventas.jsonl', lineas=True, aniadir=True)
 
 En REPL, `usar` aplica una política **estricta** y distinta del runtime general:
 
+- **Sintaxis implementada actual (restricción del parser, sin cambios de lexer/parser):** `usar "numero"` (forma con cadena).
+- **Semántica objetivo oficial:** importación plana de funciones del módulo Cobra (por ejemplo `es_finito(...)` sin prefijo).
 - Solo se aceptan módulos oficiales Cobra definidos en el mapa canónico `REPL_COBRA_MODULE_MAP` (por ejemplo `numero`, `texto`, `logica`, etc.).
 - Si el módulo solicitado no está en ese mapa, se aborta antes de cualquier import externo o instalación con `PermissionError("módulos externos no soportados en REPL")`.
 - En REPL no se permite fallback de instalación con `pip` bajo ninguna condición.
 - La inyección de símbolos es atómica: si falla la validación/carga, no queda estado parcial en el contexto interactivo.
+- Ejemplo canónico de adaptación: entrada `usar "numero"`; uso `imprimir(es_finito(10))`.
+- Ejemplo de rechazo de externo en REPL: `usar "numpy"` -> `módulos externos no soportados en REPL`.
 - Pruebas de contrato asociadas: `tests/unit/test_usar.py` valida `usar "numero"` + `es_finito(10)` sin prefijo, `usar "texto"` + `a_snake("HolaMundo")` sin prefijo, rechazo de `usar "numpy"` sin estado parcial y bloqueo de acceso por punto (`numero.es_finito(10)`).
 
 Fuera del REPL, el runtime general mantiene su política de whitelist y sus mecanismos de resolución/instalación configurables.


### PR DESCRIPTION
### Motivation

- Evitar ambigüedades entre la sintaxis actualmente aceptada por el parser y la semántica objetivo de la instrucción `usar` en el REPL. 
- Hacer explícito que la forma actual implementada por el parser es `usar "modulo"` (cadena) y que la semántica objetivo es la importación plana de símbolos (`es_finito(...)` sin prefijo). 
- Unificar la documentación en español e inglés y añadir ejemplos canónicos y de rechazo para orientar a usuarios y pruebas de contrato.

### Description

- Actualiza `README.md`, `docs/SPEC_COBRA.md`, `docs/LIBRO_PROGRAMACION_COBRA.md` y `docs/README.en.md` para explicitar el contrato REPL de `usar` (sintaxis implementada y semántica objetivo). 
- Cambia ejemplos en el libro y README para usar la forma con cadena (`usar "texto"`, `usar "numero"`), añade el ejemplo canónico `usar "numero"` + `imprimir(es_finito(10))` y el ejemplo de rechazo `usar "numpy"` -> `módulos externos no soportados en REPL`. 
- No se modificó lexer/parser ni runtime; los cambios son puramente documentales y se añadió un commit que incorpora las ediciones.

### Testing

- No se ejecutaron tests automáticos sobre código: este PR es de documentación y no incluye ejecución de suites unitarias automáticas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6ef3cc4708327b941a6e09572fd71)