### PR TITLE
tests: agregar casos para `usar` con módulos externos y atomicidad de colisiones

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -354,6 +354,59 @@ def test_usar_modulo_externo_sin_exportables_falla_sin_estado_parcial(monkeypatc
 
     assert interp.variables == estado_inicial
 
+
+
+def test_usar_modulo_externo_con_all_vacio_falla_atomico(monkeypatch):
+    modulo = ModuleType("externo_vacio")
+    modulo.__all__ = []
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo)
+
+    interp = InterpretadorCobra()
+    interp.contextos[-1].define("sentinela", 42)
+    estado_inicial = dict(interp.variables)
+
+    with pytest.raises(ImportError, match="módulo externo no exportable para usar"):
+        _ejecutar_codigo('usar "externo_vacio"', interp)
+
+    assert interp.variables == estado_inicial
+
+
+def test_usar_modulo_externo_all_mixto_inyecta_solo_callables_publicos(monkeypatch):
+    modulo = ModuleType("externo_mixto")
+    modulo.publica = lambda x: x
+    modulo._privada = lambda x: x
+    modulo.no_callable = 123
+    modulo.__all__ = ["publica", "_privada", "no_callable"]
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo)
+
+    interp = InterpretadorCobra()
+    _ejecutar_codigo('usar "externo_mixto"', interp)
+
+    assert "publica" in interp.variables
+    assert callable(interp.obtener_variable("publica"))
+    assert "_privada" not in interp.variables
+    assert "no_callable" not in interp.variables
+
+
+def test_usar_modulo_externo_all_mixto_colision_es_atomico(monkeypatch):
+    modulo = ModuleType("externo_colision")
+    modulo.colisiona = lambda x: x
+    modulo.disponible = lambda x: x
+    modulo.__all__ = ["colisiona", "disponible"]
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo)
+
+    interp = InterpretadorCobra()
+    interp.contextos[-1].define("colisiona", lambda x: f"ocupado:{x}")
+    estado_inicial = dict(interp.variables)
+
+    with pytest.raises(NameError, match=r"símbolo 'colisiona' ya existe"):
+        _ejecutar_codigo('usar "externo_colision"', interp)
+
+    assert interp.variables == estado_inicial
+    assert "disponible" not in interp.variables
 def test_repl_usar_numpy_falla_sin_estado_parcial():
     interp = InterpretadorCobra()
     interp.contextos[-1].define("sentinela", 42)


### PR DESCRIPTION
### Motivation
- Aumentar la cobertura de `usar` sobre módulos externos simulados para garantizar filtrado de exportables y evitar estados parciales ante errores o colisiones.
- Verificar la política de REPL estricto emitiendo un `PermissionError` claro cuando corresponda.

### Description
- Se añadieron tres pruebas en `tests/unit/test_usar.py` que usan `monkeypatch` sobre `core_usar_loader.obtener_modulo`: (1) módulo con `__all__` vacío falla con `ImportError` sin mutar el entorno, (2) módulo con `__all__` mixto inyecta solo callables públicos, y (3) si hay colisión en un símbolo, la importación es atómica y no inyecta nada.
- Las pruebas usan la forma existente `usar "..."` vía la utilidad `_ejecutar_codigo` para no tocar lexer/parser/gramática y mantienen la integración con el mecanismo de `Environment` del intérprete.
- Los nuevos tests se insertaron en el bloque de pruebas existentes alrededor de las líneas relevantes en `tests/unit/test_usar.py` y emplean `ModuleType` para módulos falsos.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar.py` para validar los casos añadidos, pero la ejecución falló en la fase de colección con un `ImportError: attempted relative import beyond top-level package` originado en `src/pcobra/core/interpreter.py`.
- El fallo de colección parece ser un problema de configuración del entorno/import-path y no por las aserciones de las pruebas nuevas, por lo que las nuevas pruebas no llegaron a ejecutarse por completo en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f20989608327b56fdcfaeb562da8)