### PR TITLE
test: separar contratos REPL de `usar` en casos explícitos

### DIFF
--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -41,15 +41,12 @@ def test_entrypoints_repl_configuran_restriccion_estricta(factory):
         (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
     ],
 )
-def test_repl_contract_usar_aliases_y_restriccion_numpy(factory, executor, get_interp, monkeypatch):
+def test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_numero_sin_prefijo(factory, executor, get_interp, monkeypatch):
     mod_numero = _modulo_numero_stub()
-    mod_texto = _modulo_texto_stub()
 
     def _resolver_modulo(nombre: str, **_kwargs):
         if nombre == "numero":
             return mod_numero
-        if nombre == "texto":
-            return mod_texto
         raise ModuleNotFoundError(nombre)
 
     monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda nombre: _resolver_modulo(nombre))
@@ -59,11 +56,56 @@ def test_repl_contract_usar_aliases_y_restriccion_numpy(factory, executor, get_i
 
     executor(cmd, 'usar "numero"')
     executor(cmd, "es_finito(10)")
+
     assert interp.obtener_variable("es_finito")(10) is True
+
+
+@pytest.mark.parametrize(
+    ("factory", "executor", "get_interp"),
+    [
+        (lambda: InteractiveCommand(InterpretadorCobra()), lambda cmd, code: cmd.ejecutar_codigo(code), lambda cmd: cmd.interpretador),
+        (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
+    ],
+)
+def test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_texto_sin_prefijo(factory, executor, get_interp, monkeypatch):
+    mod_texto = _modulo_texto_stub()
+
+    def _resolver_modulo(nombre: str, **_kwargs):
+        if nombre == "texto":
+            return mod_texto
+        raise ModuleNotFoundError(nombre)
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda nombre: _resolver_modulo(nombre))
+
+    cmd = factory()
+    interp = get_interp(cmd)
 
     executor(cmd, 'usar "texto"')
     executor(cmd, 'a_snake("HolaMundo")')
+
     assert interp.obtener_variable("a_snake")("HolaMundo") == "hola_mundo"
+
+
+@pytest.mark.parametrize(
+    ("factory", "executor", "get_interp"),
+    [
+        (lambda: InteractiveCommand(InterpretadorCobra()), lambda cmd, code: cmd.ejecutar_codigo(code), lambda cmd: cmd.interpretador),
+        (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
+    ],
+)
+def test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_numpy_restringido_atomico(factory, executor, get_interp, monkeypatch):
+    mod_numero = _modulo_numero_stub()
+
+    def _resolver_modulo(nombre: str, **_kwargs):
+        if nombre == "numero":
+            return mod_numero
+        raise ModuleNotFoundError(nombre)
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda nombre: _resolver_modulo(nombre))
+
+    cmd = factory()
+    interp = get_interp(cmd)
+    executor(cmd, 'usar "numero"')
     estado_pre_numpy = dict(interp.contextos[-1].values)
 
     with pytest.raises(PermissionError, match="módulos externos no soportados en REPL"):
@@ -75,6 +117,7 @@ def test_repl_contract_usar_aliases_y_restriccion_numpy(factory, executor, get_i
 
     with pytest.raises(Exception, match=r"Token no reconocido: '\.'"):
         executor(cmd, "numero.es_finito(10)")
+
 
 
 def _modulo_numero_multi_export_stub() -> ModuleType:
@@ -93,7 +136,7 @@ def _modulo_numero_multi_export_stub() -> ModuleType:
         (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
     ],
 )
-def test_repl_contract_colision_usar_numero_falla_sin_estado_parcial(factory, executor, get_interp, monkeypatch):
+def test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_colision_no_sobrescribe_usuario(factory, executor, get_interp, monkeypatch):
     mod_numero = _modulo_numero_multi_export_stub()
     mod_texto = _modulo_texto_stub()
 


### PR DESCRIPTION
### Motivation
- Aclarar y separar los contratos del REPL sobre la instrucción `usar` en escenarios explícitos para que cada comportamiento quede probado de forma independiente.
- Documentar en el nombre de cada test que la sintaxis del parser sigue siendo `usar "..."` por compatibilidad mientras la semántica es plana (modelo del libro).

### Description
- Se reorganizan y separan los casos del fichero `tests/integration/test_repl_usar_entrypoints_contract.py` en pruebas independientes para cada escenario (`numero`, `texto`, restricción `numpy` y colisión de nombres) y se renombran los tests para dejar explícita la compatibilidad de sintaxis y la semántica plana.
- Se añade un test que ejecuta `usar "numero"` y luego `es_finito(10)` en el mismo contexto verificando acceso directo sin prefijo de módulo.
- Se añade un test que ejecuta `usar "texto"` y luego `a_snake("HolaMundo")` verificando disponibilidad directa de la función.
- Se añade un test REPL estricto que intenta `usar "numpy"` y falla de forma atómica con `PermissionError` y mensaje canónico sobre módulos externos no soportados, además de comprobar que no hay estado parcial.

### Testing
- Se ejecutó `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py` y todos los tests del archivo pasaron: `10 passed`.
- No se informaron errores ni estados parciales tras las pruebas ejecutadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f365eb2c8327a15da6e690998683)