### PR TITLE
Alinear política estricta de `usar` en REPL y reforzar pruebas de rechazo de externos

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,7 +915,7 @@ En REPL incremental, `usar` aplica una política **estricta** y explícita:
 - **Semántica aplicada:** modelo oficial plano del libro (`usar numero`), sin acceso por prefijo de módulo (`numero.funcion(...)`).
 - **Inyección de símbolos:** solo se inyectan símbolos públicos **callables** exportados por `__all__`.
 - **Filtrado:** se ignoran símbolos privados (`_...`) y cualquier símbolo no callable.
-- **Módulos externos en REPL estricto:** deben fallar con error claro: `módulos externos no soportados en REPL`.
+- **Módulos externos en REPL estricto:** deben fallar con error claro: `módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)`.
 - Solo se aceptan módulos oficiales definidos en `REPL_COBRA_MODULE_MAP` y no hay fallback de instalación con `pip`.
 
 Ejemplos de comportamiento esperado en REPL:
@@ -928,7 +928,7 @@ usar "texto"
 imprimir(a_snake("HolaMundo"))  # ✅
 
 usar "numpy"
-imprimir(sqrt(4))  # ❌ módulos externos no soportados en REPL
+imprimir(sqrt(4))  # ❌ módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)
 ```
 
 > Nota: en Cobra REPL no hay dot-access para estos símbolos inyectados.

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -243,6 +243,12 @@ class InteractiveCommand(BaseCommand):
         self._configurar_restriccion_usar_repl()
 
     def _configurar_restriccion_usar_repl(self) -> None:
+        """Activa la política estricta de ``usar`` en REPL.
+
+        Política visible al usuario:
+        - Solo se permiten alias oficiales de ``REPL_COBRA_MODULE_MAP``.
+        - Cualquier módulo externo debe fallar con mensaje estable y explícito.
+        """
         if hasattr(self.interpretador, "configurar_restriccion_usar_repl"):
             self.interpretador.configurar_restriccion_usar_repl(self._USAR_ALIAS_REPL)
 

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1819,7 +1819,9 @@ class InterpretadorCobra:
             ``logica``, etc.) mapeados en el alias map activo.
           - El módulo debe resolverse desde rutas oficiales de Cobra
             (``corelibs``/``standard_library``).
-          - Cualquier módulo externo se rechaza con ``PermissionError``.
+          - Cualquier módulo externo se rechaza explícitamente con
+            ``PermissionError: módulo externo no permitido en REPL estricto
+            (solo alias oficiales Cobra)``.
 
         - Fuera de REPL estricto:
           - Módulos oficiales: se cargan como oficiales y deben exponer
@@ -1864,7 +1866,7 @@ class InterpretadorCobra:
             if es_modulo_oficial_cobra:
                 modulo = obtener_modulo_cobra_oficial(modulo_canonico)
             elif es_repl_estricto:
-                raise PermissionError("módulos externos no soportados en REPL")
+                raise PermissionError("módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)")
             else:
                 modulo = obtener_modulo(
                     nombre_modulo,
@@ -1882,7 +1884,7 @@ class InterpretadorCobra:
             if es_repl_estricto and es_modulo_oficial_cobra:
                 modulo_file = getattr(modulo, "__file__", None)
                 if not modulo_file:
-                    raise PermissionError("módulos externos no soportados en REPL")
+                    raise PermissionError("módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)")
 
                 ruta_modulo = Path(modulo_file).resolve()
                 raiz_pcobra = Path(__file__).resolve().parents[1]
@@ -1896,7 +1898,7 @@ class InterpretadorCobra:
                     for ruta_base in rutas_oficiales
                 )
                 if not es_oficial:
-                    raise PermissionError("módulos externos no soportados en REPL")
+                    raise PermissionError("módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)")
 
             # ``usar`` solo importa API pública explícita del módulo Cobra:
             # prioriza __all__, filtra privados/no-callables y evita fugas de
@@ -1906,7 +1908,7 @@ class InterpretadorCobra:
             )
             if not simbolos_a_inyectar and not es_modulo_oficial_cobra:
                 raise ImportError(
-                    "módulo externo no exportable para usar"
+                    "módulo externo no exportable para usar: requiere __all__ con callables públicos"
                 )
 
             contexto_actual = self.contextos[-1]

--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -108,7 +108,7 @@ def test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_numpy_restrin
     executor(cmd, 'usar "numero"')
     estado_pre_numpy = dict(interp.contextos[-1].values)
 
-    with pytest.raises(PermissionError, match="módulos externos no soportados en REPL"):
+    with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto \(solo alias oficiales Cobra\)"):
         executor(cmd, 'usar "numpy"')
 
     assert "numpy" not in interp.variables
@@ -158,3 +158,52 @@ def test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_colision_no_s
 
     assert interp.obtener_variable("es_finito")("x") == "ocupado"
     assert "es_par" not in interp.contextos[-1].values
+
+
+@pytest.mark.parametrize(
+    ("factory", "executor", "get_interp"),
+    [
+        (lambda: InteractiveCommand(InterpretadorCobra()), lambda cmd, code: cmd.ejecutar_codigo(code), lambda cmd: cmd.interpretador),
+        (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
+    ],
+)
+def test_repl_rechazo_externo_no_inyecta_simbolos(factory, executor, get_interp, monkeypatch):
+    mod_numero = _modulo_numero_stub()
+
+    def _resolver_modulo(nombre: str, **_kwargs):
+        if nombre == "numero":
+            return mod_numero
+        raise ModuleNotFoundError(nombre)
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda nombre: _resolver_modulo(nombre))
+
+    cmd = factory()
+    interp = get_interp(cmd)
+    estado_pre = dict(interp.contextos[-1].values)
+
+    with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto \(solo alias oficiales Cobra\)"):
+        executor(cmd, 'usar "requests"')
+
+    assert estado_pre == interp.contextos[-1].values
+    assert "requests" not in interp.contextos[-1].values
+
+
+def test_usar_externo_whitelist_sin_all_falla_claro_y_atomico(monkeypatch):
+    mod_externo = ModuleType("externo_sin_all")
+    mod_externo.__file__ = "/tmp/externo_sin_all.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda *_args, **_kwargs: mod_externo)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl(None)
+
+    class _NodoUsar:
+        modulo = "externo_sin_all"
+
+    estado_pre = dict(interp.contextos[-1].values)
+
+    with pytest.raises(ImportError, match="módulo externo no exportable para usar: requiere __all__ con callables públicos"):
+        interp.ejecutar_usar(_NodoUsar())
+
+    assert estado_pre == interp.contextos[-1].values
+    assert "externo_sin_all" not in interp.contextos[-1].values


### PR DESCRIPTION
### Motivation

- Forzar y documentar la política de `usar` en el REPL para aceptar únicamente alias oficiales y rechazar módulos externos de forma explícita.
- Evitar ambigüedad en los mensajes de error que el usuario ve al intentar `usar` módulos externos en rutas REPL o runtime.
- Garantizar atomicidad en la operación `usar` para que un fallo no deje símbolos parcialmente inyectados en el contexto REPL.
- Añadir una prueba de no-regresión que verifique que un módulo externo permitido por ruta general pero sin `__all__` utilizable falla de forma clara y sin efectos secundarios.

### Description

- Actualiza el comportamiento y docstring de `ejecutar_usar` en `src/pcobra/core/interpreter.py` para declarar la política REPL y unificar los mensajes de rechazo; ahora lanza `PermissionError("módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)")` en las rutas REPL estrictas y `ImportError("módulo externo no exportable para usar: requiere __all__ con callables públicos")` para externos sin `__all__` exportable.
- Añade documentación visible al usuario en el REPL (método `_configurar_restriccion_usar_repl`) en `src/pcobra/cobra/cli/commands/interactive_cmd.py` explicando la política aplicada en REPL.
- Actualiza el README para alinear el mensaje público de ejemplo con la política y el mensaje estable de error.
- Extiende `tests/integration/test_repl_usar_entrypoints_contract.py` con dos verificaciones: una que asegura que el rechazo de un externo en REPL no inyecta símbolos en el contexto, y otra de no-regresión que comprueba que un módulo externo sin `__all__` produce el `ImportError` esperado y no modifica el entorno.

### Testing

- Ejecuté `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py` y todos los tests pasaron (`13 passed`) con advertencias menores sobre escapes en cadenas; la suite completó correctamente.
- Las nuevas pruebas verifican explícitamente que tras un `PermissionError` por intento de `usar` externo no hay cambios en `interp.contextos[-1].values` y que el caso sin `__all__` lanza el `ImportError` esperado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f48732008327838514bb06cadf10)