### PR TITLE
Unifica mensaje de rechazo para módulos externos en REPL estricto

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1820,8 +1820,7 @@ class InterpretadorCobra:
           - El módulo debe resolverse desde rutas oficiales de Cobra
             (``corelibs``/``standard_library``).
           - Cualquier módulo externo se rechaza explícitamente con
-            ``PermissionError: módulo externo no permitido en REPL estricto
-            (solo alias oficiales Cobra)``.
+            ``PermissionError: módulos externos no soportados en REPL``.
 
         - Fuera de REPL estricto:
           - Módulos oficiales: se cargan como oficiales y deben exponer
@@ -1866,7 +1865,7 @@ class InterpretadorCobra:
             if es_modulo_oficial_cobra:
                 modulo = obtener_modulo_cobra_oficial(modulo_canonico)
             elif es_repl_estricto:
-                raise PermissionError("módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)")
+                raise PermissionError("módulos externos no soportados en REPL")
             else:
                 modulo = obtener_modulo(
                     nombre_modulo,
@@ -1884,7 +1883,7 @@ class InterpretadorCobra:
             if es_repl_estricto and es_modulo_oficial_cobra:
                 modulo_file = getattr(modulo, "__file__", None)
                 if not modulo_file:
-                    raise PermissionError("módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)")
+                    raise PermissionError("módulos externos no soportados en REPL")
 
                 ruta_modulo = Path(modulo_file).resolve()
                 raiz_pcobra = Path(__file__).resolve().parents[1]
@@ -1898,7 +1897,7 @@ class InterpretadorCobra:
                     for ruta_base in rutas_oficiales
                 )
                 if not es_oficial:
-                    raise PermissionError("módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)")
+                    raise PermissionError("módulos externos no soportados en REPL")
 
             # ``usar`` solo importa API pública explícita del módulo Cobra:
             # prioriza __all__, filtra privados/no-callables y evita fugas de

--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -108,7 +108,7 @@ def test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_numpy_restrin
     executor(cmd, 'usar "numero"')
     estado_pre_numpy = dict(interp.contextos[-1].values)
 
-    with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto \(solo alias oficiales Cobra\)"):
+    with pytest.raises(PermissionError, match=r"módulos externos no soportados en REPL"):
         executor(cmd, 'usar "numpy"')
 
     assert "numpy" not in interp.variables
@@ -181,7 +181,7 @@ def test_repl_rechazo_externo_no_inyecta_simbolos(factory, executor, get_interp,
     interp = get_interp(cmd)
     estado_pre = dict(interp.contextos[-1].values)
 
-    with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto \(solo alias oficiales Cobra\)"):
+    with pytest.raises(PermissionError, match=r"módulos externos no soportados en REPL"):
         executor(cmd, 'usar "requests"')
 
     assert estado_pre == interp.contextos[-1].values


### PR DESCRIPTION
### Motivation
- Evitar inconsistencias en los textos de error cuando `usar` rechaza módulos externos en modo REPL estricto, usando un mensaje canónico estable.
- Facilitar el mantenimiento de las pruebas que verifican literales de excepción y prevenir fallos por mensajes distintos en distintos caminos de error.

### Description
- Reemplazados los tres `raise PermissionError(...)` en `InterpretadorCobra.ejecutar_usar` por el mensaje único exacto `módulos externos no soportados en REPL`.
- Actualizada la docstring de `ejecutar_usar` para documentar el nuevo mensaje canónico en la matriz de comportamiento de REPL estricto.
- Actualizadas las pruebas que comprobaban el literal anterior para usar el nuevo mensaje en `tests/integration/test_repl_usar_entrypoints_contract.py` y en las referencias pertinentes de `tests/unit/test_usar.py`.

### Testing
- Ejecutado `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py tests/unit/test_usar.py -k "repl_usar or externos"` y falló debido a errores no relacionados en este entorno (ImportError por `__all__` en stubs de módulos oficiales), por lo que no es indicativo del cambio de mensaje.
- Ejecutados tests dirigidos que cubren los caminos de rechazo y contrato REPL: `test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_numpy_restringido_atomico`, `test_repl_rechazo_externo_no_inyecta_simbolos`, `test_repl_usar_numpy_falla_sin_estado_parcial` y `test_repl_usar_rechazo_externo_emite_mensaje_canonico`, todos los cuales pasaron correctamente en ejecuciones focalizadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f5fa25c883278cb3f3cab89005a6)