### PR TITLE
Permitir usar módulos oficiales sin __all__ y filtrar solo callables públicos

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1823,8 +1823,9 @@ class InterpretadorCobra:
             ``PermissionError: módulos externos no soportados en REPL``.
 
         - Fuera de REPL estricto:
-          - Módulos oficiales: se cargan como oficiales y deben exponer
-            ``__all__`` explícito.
+          - Módulos oficiales: exportan callables públicos (no privados).
+            ``__all__`` se usa como filtro preferente si existe, pero su
+            ausencia no bloquea la carga de módulos oficiales.
           - Módulos externos: se permiten solo si pueden exportarse de forma
             completa según la política de ``usar`` (API pública explícita por
             ``__all__`` y símbolos callables). Si no cumplen, se rechazan.
@@ -1834,24 +1835,32 @@ class InterpretadorCobra:
         from .usar_loader import obtener_modulo, obtener_modulo_cobra_oficial
 
         def _resolver_exportables_callables(modulo_obj, *, modulo_oficial: bool):
-            """Resuelve exportables con una política única para ``usar``."""
+            """Resuelve exportables callables según política de ``usar``."""
             exportables = getattr(modulo_obj, "__all__", None)
+
             if exportables is None:
                 if modulo_oficial:
-                    raise ImportError(
-                        f"El módulo oficial '{nodo.modulo}' debe definir __all__ explícito"
-                    )
-                return []
+                    candidatos = [
+                        nombre
+                        for nombre in dir(modulo_obj)
+                        if isinstance(nombre, str) and not nombre.startswith("_")
+                    ]
+                else:
+                    return []
+            else:
+                candidatos = exportables
 
             simbolos = []
-            for nombre in exportables:
-                if not isinstance(nombre, str) or nombre.startswith("_"):
+            vistos = set()
+            for nombre in candidatos:
+                if not isinstance(nombre, str) or nombre.startswith("_") or nombre in vistos:
                     continue
                 if not hasattr(modulo_obj, nombre):
                     continue
                 simbolo = getattr(modulo_obj, nombre)
                 if not callable(simbolo):
                     continue
+                vistos.add(nombre)
                 simbolos.append((nombre, simbolo))
             return simbolos
 

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -504,3 +504,44 @@ def test_repl_no_habilita_acceso_por_punto_para_usar_numero(monkeypatch):
     monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_numero)
     with pytest.raises(InvalidTokenError, match=r"Token no reconocido: '\.'"):
         _ejecutar_codigo('usar "numero"\nnumero.es_finito(10)')
+
+
+def test_repl_usar_modulo_oficial_sin_all_inyecta_callables_publicos(monkeypatch):
+    modulo = ModuleType("numero")
+    modulo.es_finito = lambda valor: valor == valor
+    modulo.a_decimal = lambda valor: float(valor)
+    modulo._interna = lambda valor: valor
+    modulo.CONSTANTE = 7
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/numero.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto", "logica": "logica"})
+    _ejecutar_codigo('usar "numero"\nes_finito(10)', interp)
+
+    assert "es_finito" in interp.variables
+    assert "a_decimal" in interp.variables
+    assert "_interna" not in interp.variables
+    assert "CONSTANTE" not in interp.variables
+
+
+def test_repl_usar_modulo_oficial_con_all_mixto_filtra_callables_publicos(monkeypatch):
+    modulo = ModuleType("texto")
+    modulo.__all__ = ["a_snake", "_privada", "NO_CALLABLE", "faltante"]
+    modulo.a_snake = lambda texto: "hola_mundo" if texto == "HolaMundo" else str(texto)
+    modulo._privada = lambda texto: texto
+    modulo.NO_CALLABLE = "valor"
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/texto.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto", "logica": "logica"})
+    _ejecutar_codigo('usar "texto"\na_snake("HolaMundo")', interp)
+
+    assert "a_snake" in interp.variables
+    assert interp.obtener_variable("a_snake")("HolaMundo") == "hola_mundo"
+    assert "_privada" not in interp.variables
+    assert "NO_CALLABLE" not in interp.variables
+    assert "faltante" not in interp.variables


### PR DESCRIPTION
### Motivation

- Hacer que la política de `usar` sea más flexible para módulos oficiales de Cobra permitiendo que funcionen aunque no definan `__all__` explícito, mientras se evita exponer símbolos privados o no invocables. 
- Mantener la inyección segura y atómica de símbolos sin permitir sobrescrituras accidentales en el contexto de ejecución.

### Description

- Se modificó `_resolver_exportables_callables` en `InterpretadorCobra.ejecutar_usar` para que, cuando `__all__` esté ausente en un módulo oficial, se infieran candidatos a partir de los atributos públicos de `dir(modulo)` y se use `__all__` como filtro preferente si existe. 
- Se añadió filtrado estricto para incluir únicamente símbolos públicos y `callable`, excluyendo privados (nombres que empiezan por `_`), faltantes y constantes no llamables. 
- Se preservó la verificación previa de colisiones (`contexto_actual.contains(nombre)`) y la inyección atómica solo si no hay conflictos. 
- Se actualizó la documentación inline en `ejecutar_usar` y se añadieron dos pruebas unitarias en `tests/unit/test_usar.py` que cubren módulos oficiales sin `__all__` y módulos oficiales con `__all__` mixto (privados/no-callables/faltantes). 

### Testing

- Se ejecutaron los tests de integración relevantes con `PYTHONPATH=src pytest -q tests/integration/test_repl_usar_entrypoints_contract.py` y todos los casos pasaron (`13 passed`).
- Se ejecutaron combinaciones de `pytest` que incluían `tests/unit/test_usar.py` y la colección falló por un error de importación del entorno de pruebas (`ImportError: attempted relative import beyond top-level package`) durante la recolección; este fallo está relacionado con la invocación del runner en este entorno y no con la lógica introducida. 
- Se ejecutó un intento de correr selectivamente las nuevas pruebas unitarias con `PYTHONPATH=src/pcobra pytest -q tests/unit/test_usar.py -k "..."` y la colección igualmente falló por el mismo error de importación en este entorno de ejecución.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f6f993408327909d9679ef67ddf9)