### PR TITLE
test: reforzar contrato atómico de `usar` en REPL estricto

### DIFF
--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -107,13 +107,16 @@ def test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_numpy_restrin
     interp = get_interp(cmd)
     executor(cmd, 'usar "numero"')
     estado_pre_numpy = dict(interp.contextos[-1].values)
+    simbolos_pre = set(interp.contextos[-1].values.keys())
 
     with pytest.raises(PermissionError, match=r"módulos externos no soportados en REPL"):
         executor(cmd, 'usar "numpy"')
 
+    # Contrato de Cobra: `usar` es plano (sin `.`), no se expone namespace tipo `numero.*`.
     assert "numpy" not in interp.variables
     assert "numpy" not in interp.contextos[-1].values
     assert estado_pre_numpy == interp.contextos[-1].values
+    assert simbolos_pre == set(interp.contextos[-1].values.keys())
 
     with pytest.raises(Exception, match=r"Token no reconocido: '\.'"):
         executor(cmd, "numero.es_finito(10)")

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -156,6 +156,7 @@ def test_cargar_lista_blanca_sin_cobra_toml_mantiene_hardcoded(monkeypatch, tmp_
 def test_interpreter_usar_registra_modulo(monkeypatch):
     mod = ModuleType('math')
     mod.sumar = lambda a, b: a + b
+    mod.__all__ = ['sumar']
     monkeypatch.setattr(core_usar_loader, 'obtener_modulo', lambda _name, **_kwargs: mod)
     interp = InterpretadorCobra()
     interp.ejecutar_nodo(NodoUsar('math'))
@@ -411,12 +412,14 @@ def test_repl_usar_numpy_falla_sin_estado_parcial():
     interp = InterpretadorCobra()
     interp.contextos[-1].define("sentinela", 42)
     estado_inicial = dict(interp.variables)
+    simbolos_iniciales = set(interp.contextos[-1].values.keys())
     interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto"})
 
     with pytest.raises(PermissionError, match="módulos externos no soportados en REPL"):
         _ejecutar_codigo('usar "numpy"', interp)
 
     assert interp.variables == estado_inicial
+    assert simbolos_iniciales == set(interp.contextos[-1].values.keys())
     assert "numpy" not in interp.variables
 
 


### PR DESCRIPTION
### Motivation
- Asegurar que el intento de `usar "numpy"` en REPL estricto falle con un error claro y no deje cambios parciales en el entorno. 
- Evitar regresiones donde `usar` pudiera exponer un namespace con `.` en lugar de exportar símbolos planos.
- Hacer que los tests reflejen el contrato actual de módulos externos (requieren `__all__` para exportables).

### Description
- Amplía `tests/integration/test_repl_usar_entrypoints_contract.py` para comprobar la atomicidad comparando el conjunto de keys del contexto antes y después del fallo y añade un comentario de contrato que recuerda que `usar` es plano (sin `.`).
- Modifica `tests/unit/test_usar.py` para añadir la comprobación de atomicidad equivalente en el test de REPL y ajustar un stub (`mod`) añadiendo `__all__` para alinear el test con la política de exportables.
- No se introducen cambios en la lógica de producción; solo se fortalecen y corrigen las pruebas para el comportamiento esperado.

### Testing
- Ejecutado `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py tests/unit/test_usar.py` y la suite objetivo pasó localmente (todos los tests ejecutados pasaron).
- No se añadieron tests que fallen; las modificaciones son validaciones adicionales y una corrección del stub para evitar falsos negativos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f81fff208327873d26411e3636bc)