### PR TITLE
Unifica mensaje canónico para rechazos de `usar` en REPL estricto

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -85,6 +85,9 @@ from .errors import CondicionNoBooleanaError
 from .environment import Environment
 
 MODULES_PATH = _DEFAULT_MODULES_PATH
+REPL_USAR_EXTERNAL_MODULE_ERROR = (
+    "módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)"
+)
 
 
 def _ruta_import_permitida(ruta: str) -> bool:
@@ -1820,7 +1823,7 @@ class InterpretadorCobra:
           - El módulo debe resolverse desde rutas oficiales de Cobra
             (``corelibs``/``standard_library``).
           - Cualquier módulo externo se rechaza explícitamente con
-            ``PermissionError: módulos externos no soportados en REPL``.
+            ``PermissionError: módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)``.
 
         - Fuera de REPL estricto:
           - Módulos oficiales: exportan callables públicos (no privados).
@@ -1874,7 +1877,7 @@ class InterpretadorCobra:
             if es_modulo_oficial_cobra:
                 modulo = obtener_modulo_cobra_oficial(modulo_canonico)
             elif es_repl_estricto:
-                raise PermissionError("módulos externos no soportados en REPL")
+                raise PermissionError(REPL_USAR_EXTERNAL_MODULE_ERROR)
             else:
                 modulo = obtener_modulo(
                     nombre_modulo,
@@ -1892,7 +1895,7 @@ class InterpretadorCobra:
             if es_repl_estricto and es_modulo_oficial_cobra:
                 modulo_file = getattr(modulo, "__file__", None)
                 if not modulo_file:
-                    raise PermissionError("módulos externos no soportados en REPL")
+                    raise PermissionError(REPL_USAR_EXTERNAL_MODULE_ERROR)
 
                 ruta_modulo = Path(modulo_file).resolve()
                 raiz_pcobra = Path(__file__).resolve().parents[1]
@@ -1906,7 +1909,7 @@ class InterpretadorCobra:
                     for ruta_base in rutas_oficiales
                 )
                 if not es_oficial:
-                    raise PermissionError("módulos externos no soportados en REPL")
+                    raise PermissionError(REPL_USAR_EXTERNAL_MODULE_ERROR)
 
             # ``usar`` solo importa API pública explícita del módulo Cobra:
             # prioriza __all__, filtra privados/no-callables y evita fugas de

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -415,7 +415,7 @@ def test_repl_usar_numpy_falla_sin_estado_parcial():
     simbolos_iniciales = set(interp.contextos[-1].values.keys())
     interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto"})
 
-    with pytest.raises(PermissionError, match="módulos externos no soportados en REPL"):
+    with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto \(solo alias oficiales Cobra\)"):
         _ejecutar_codigo('usar "numpy"', interp)
 
     assert interp.variables == estado_inicial
@@ -440,7 +440,7 @@ def test_repl_usar_rechazo_externo_emite_mensaje_canonico(monkeypatch, escenario
     interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto"})
 
     if escenario == "alias_no_permitido":
-        with pytest.raises(PermissionError, match="módulos externos no soportados en REPL"):
+        with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto \(solo alias oficiales Cobra\)"):
             interp.ejecutar_nodo(NodoUsar("numpy"))
         return
 
@@ -455,7 +455,7 @@ def test_repl_usar_rechazo_externo_emite_mensaje_canonico(monkeypatch, escenario
         lambda _nombre: modulo,
     )
 
-    with pytest.raises(PermissionError, match="módulos externos no soportados en REPL"):
+    with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto \(solo alias oficiales Cobra\)"):
         interp.ejecutar_nodo(NodoUsar("numero"))
 
 


### PR DESCRIPTION
### Motivation

- Asegurar un único mensaje canónico al rechazar módulos externos en el REPL estricto para evitar ambigüedad entre ramas de código y coincidir con la documentación. 
- Hacer que las pruebas verifiquen exactamente ese texto para prevenir regresiones de mensaje en futuras modificaciones.

### Description

- Se añadió la constante `REPL_USAR_EXTERNAL_MODULE_ERROR` en `src/pcobra/core/interpreter.py` con el literal canónico documentado. 
- Se reemplazaron todas las ramas de rechazo en `InterpretadorCobra.ejecutar_usar` para lanzar `PermissionError(REPL_USAR_EXTERNAL_MODULE_ERROR)` (alias no permitido, módulo sin `__file__` y ruta no ubicada en `corelibs`/`standard_library`). 
- Se actualizó la docstring de `ejecutar_usar` para describir el mensaje exacto y mantenerla alineada con `README.md`. 
- Se modificaron las expectativas en `tests/unit/test_usar.py` para validar el nuevo mensaje exacto usando literales raw regex (`r"..."`) y evitar `SyntaxWarning` por secuencias de escape.

### Testing

- Ejecuté `pytest -q tests/unit/test_usar.py -k "repl_usar_numpy_falla_sin_estado_parcial or repl_usar_rechazo_externo_emite_mensaje_canonico"` y la colección falló debido a `ImportError: attempted relative import beyond top-level package` en el entorno de ejecución. 
- Intenté `PYTHONPATH=src pytest -q tests/unit/test_usar.py -k ...` y obtuve la misma falla de colección por el problema de import path, por lo que las pruebas no llegaron a ejecutarse. 
- Corregí las cadenas de prueba a raw regex para eliminar `SyntaxWarning` y verifiqué que `README.md` ya contenía el mismo literal, quedando la documentación y el comportamiento alineados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f94e920c8327b5fde6d6a891f513)