### PR TITLE
Restringe resolución runtime de `usar` a allowlist canónica de módulos Cobra

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -1,153 +1,63 @@
 import importlib
 import importlib.util
-import os
 import re
-import shlex
-import subprocess
 from pathlib import Path
 import sys
 
+# Allowlist canónica de módulos Cobra habilitados para `usar`.
+USAR_COBRA_ALLOWLIST: set[str] = {
+    "numero",
+    "texto",
+    "datos",
+    "logica",
+    "asincrono",
+    "sistema",
+    "archivo",
+    "tiempo",
+    "red",
+    "holobit",
+}
 
-# Intentamos cargar configuración dinámica desde cobra.toml
-try:
-    import tomli
-except ImportError:
-    tomli = None  # Tomli no es necesario en Python ≥ 3.11
+# Regex estricta para mantener la sintaxis `usar "modulo"` acotada a identificadores simples.
+_VALID_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
-USAR_WHITELIST: dict[str, str] = {}
-
-# Nombre de la variable de entorno que habilita la instalación automática
-USAR_INSTALL_ENV = "COBRA_USAR_INSTALL"
-
-# Variable para habilitar specs flexibles (menos seguras) de forma explícita
-USAR_INSTALL_UNSAFE_ENV = "COBRA_USAR_INSTALL_UNSAFE_SPECS"
-
-# Regex de validación para los nombres de paquetes
-_VALID_NAME_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
-_VALID_VERSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+\-]*$")
-_VALID_STRICT_SPEC_RE = re.compile(
-    r"^(?P<name>[A-Za-z0-9_\-]+)"
-    r"(?:(?:==(?P<pin>[A-Za-z0-9][A-Za-z0-9._+\-]*))"
-    r"|(?:>=(?P<min>[A-Za-z0-9][A-Za-z0-9._+\-]*),<(?P<max>[A-Za-z0-9][A-Za-z0-9._+\-]*)))?$"
+# Patrones que deben bloquearse explícitamente para evitar imports de backend o rutas internas.
+_INTERNAL_HINTS = (
+    "pcobra",
+    "cobra",
+    "core",
+    "corelibs",
+    "standard_library",
+    "backend",
+    "bindings",
+    "transpiler",
 )
-_URL_PREFIXES = ("http://", "https://", "git+", "file://")
-_unsafe_warning_printed = False
 
 
 def _validar_nombre(nombre: str) -> str:
-    """Valida el nombre del paquete y devuelve una versión saneada.
-
-    Se rechazan nombres con guiones iniciales, barras u otros caracteres
-    sospechosos. Solo se permiten letras, dígitos, guiones y guiones bajos.
-    """
+    """Valida que el nombre sea seguro para resolución runtime de `usar`."""
 
     nombre = nombre.strip()
+    if not nombre:
+        raise ValueError("Nombre de módulo vacío en 'usar'.")
+
     if not _VALID_NAME_RE.fullmatch(nombre):
         raise ValueError(
-            f"Nombre de paquete '{nombre}' contiene caracteres no permitidos"
+            "Nombre de módulo inválido en 'usar': solo se permiten "
+            "identificadores simples en minúsculas (ej. usar 'texto')."
         )
-    if nombre.startswith("-") or "/" in nombre or "\\" in nombre:
-        raise ValueError(f"Nombre de paquete '{nombre}' no es seguro")
+
+    if any(ch in nombre for ch in ("/", "\\", ".", "-", ":", "@")):
+        raise ValueError(f"Nombre de módulo '{nombre}' no es seguro para 'usar'.")
+
+    for hint in _INTERNAL_HINTS:
+        if hint in nombre:
+            raise ValueError(
+                f"Nombre de módulo '{nombre}' parece una ruta interna o de backend; "
+                "usa únicamente módulos Cobra canónicos."
+            )
+
     return nombre
-
-
-def _parsear_entrada(entrada: str) -> tuple[str, str]:
-    """Devuelve el nombre base y la especificación completa de la entrada."""
-
-    entrada = entrada.strip()
-    if not entrada:
-        raise ValueError("Entrada vacía en lista blanca")
-
-    if os.environ.get(USAR_INSTALL_UNSAFE_ENV):
-        global _unsafe_warning_printed
-        if not _unsafe_warning_printed:
-            print(
-                "ADVERTENCIA: modo inseguro de specs activado "
-                f"({USAR_INSTALL_UNSAFE_ENV}=1). "
-                "Se permiten argumentos avanzados de pip bajo tu propio riesgo."
-            )
-            _unsafe_warning_printed = True
-
-        match = re.match(r"([A-Za-z0-9_\-]+)", entrada)
-        if not match:
-            raise ValueError(f"Entrada de paquete '{entrada}' inválida")
-        nombre_base = _validar_nombre(match.group(1))
-        return nombre_base, entrada
-
-    tokens = [tok for tok in re.split(r"[\s,]+", entrada) if tok]
-    for token in tokens:
-        if token.startswith("-"):
-            raise ValueError(
-                f"Entrada de paquete '{entrada}' contiene flags no permitidos: '{token}'"
-            )
-        token_lower = token.lower()
-        if token_lower.startswith(_URL_PREFIXES):
-            raise ValueError(
-                f"Entrada de paquete '{entrada}' contiene una URL directa no permitida"
-            )
-
-    if "@" in entrada:
-        raise ValueError(f"Entrada de paquete '{entrada}' usa formato no permitido con '@'")
-    if "#" in entrada:
-        raise ValueError(f"Entrada de paquete '{entrada}' contiene hash no permitido")
-
-    match = _VALID_STRICT_SPEC_RE.fullmatch(entrada)
-    if not match:
-        raise ValueError(
-            f"Entrada de paquete '{entrada}' no cumple formato permitido: "
-            "nombre | nombre==x.y.z | nombre>=x,<y"
-        )
-
-    nombre_base = _validar_nombre(match.group("name"))
-    for version in (match.group("pin"), match.group("min"), match.group("max")):
-        if version is not None and not _VALID_VERSION_RE.fullmatch(version):
-            raise ValueError(f"Versión '{version}' no es válida en '{entrada}'")
-
-    return nombre_base, entrada
-
-
-def cargar_lista_blanca():
-    """Carga la lista blanca de paquetes permitidos desde cobra.toml si existe"""
-    global USAR_WHITELIST
-
-    # Por defecto incluye paquetes clave del proyecto
-    default_pkgs = [
-        "numpy",
-        "pandas",
-        "requests",
-        "matplotlib",
-        "holobit-sdk",
-        "agix",
-    ]
-
-    USAR_WHITELIST = {}
-    for item in default_pkgs:
-        nombre_base, spec = _parsear_entrada(item)
-        USAR_WHITELIST[nombre_base] = spec
-
-    # Cargar desde configuración si se encuentra en algún padre del archivo
-    config_path = None
-    for parent in Path(__file__).resolve().parents:
-        candidate = parent / "cobra.toml"
-        if candidate.exists():
-            config_path = candidate
-            break
-
-    if config_path and tomli:
-        try:
-            with open(config_path, "rb") as f:
-                config = tomli.load(f)
-            permitidos = config.get("usar", {}).get("permitidos", [])
-            if isinstance(permitidos, list):
-                for item in permitidos:
-                    nombre_base, spec = _parsear_entrada(item)
-                    USAR_WHITELIST[nombre_base] = spec
-        except Exception as e:
-            print(f"Advertencia: no se pudo leer cobra.toml: {e}")
-
-
-# Ejecutar al importar
-cargar_lista_blanca()
 
 
 def _cargar_modulo_local_desde_directorio(nombre: str, directorio: Path):
@@ -196,77 +106,20 @@ def obtener_modulo_cobra_oficial(nombre: str):
 
 
 def obtener_modulo(nombre: str, *, permitir_instalacion: bool = True):
-    """Importa y devuelve un módulo.
+    """Resuelve módulos de `usar` solo contra la allowlist canónica de Cobra."""
 
-    Si el paquete no está instalado se intentará ejecutar ``pip install``
-    siempre que la variable de entorno ``COBRA_USAR_INSTALL`` esté definida.
-    De lo contrario se lanza :class:`RuntimeError`.
-    """
+    _ = permitir_instalacion  # compat: ya no se usa instalación dinámica para `usar`.
     nombre = _validar_nombre(nombre)
-    # Política runtime general: whitelist + resolver + import local/stdlib + pip opcional.
-    if not USAR_WHITELIST:
+
+    if nombre not in USAR_COBRA_ALLOWLIST:
         raise PermissionError(
-            "La lista blanca de paquetes está vacía. No se puede usar 'usar'."
+            f"Importación no permitida en 'usar': '{nombre}'. "
+            f"Módulos permitidos: {', '.join(sorted(USAR_COBRA_ALLOWLIST))}."
         )
-    if nombre not in USAR_WHITELIST:
-        raise PermissionError(f"Paquete '{nombre}' no está permitido.")
-    spec = USAR_WHITELIST[nombre]
-
-    base = Path(__file__).resolve()
-    from pcobra.cobra.imports.resolver import CobraImportResolver, ImportResolutionError
-
-    resolver = CobraImportResolver(project_root=base.parents[3])
-    try:
-        _, module = resolver.load_module(nombre, fallback_backend="python")
-    except ImportResolutionError:
-        module = None
-    else:
-        if module is not None:
-            return module
 
     try:
-        return importlib.import_module(nombre)
-    except ModuleNotFoundError:
-        try:
-            return obtener_modulo_cobra_oficial(nombre)
-        except ModuleNotFoundError:
-            pass
-
-        # Si no se encontró, verificar si la instalación está permitida
-        if not permitir_instalacion or not os.environ.get(USAR_INSTALL_ENV):
-            raise RuntimeError(
-                "Instalación automática no permitida. "
-                f"Define {USAR_INSTALL_ENV}=1 para habilitarla."
-            )
-
-        print(f"Paquete '{spec}' no encontrado. Instalando con pip...")
-
-        try:
-            cmd = [
-                sys.executable,
-                "-m",
-                "pip",
-                "install",
-            ]
-
-            if os.environ.get(USAR_INSTALL_UNSAFE_ENV):
-                print(
-                    "ADVERTENCIA: instalación en modo inseguro; "
-                    "se aceptan argumentos avanzados de pip."
-                )
-                argumentos = shlex.split(spec)
-            else:
-                argumentos = [spec]
-
-            cmd += argumentos
-            subprocess.run(cmd, check=True)
-            print(f"Paquete instalado: {spec}")
-        except subprocess.CalledProcessError as exc:
-            raise RuntimeError(f"Fallo al instalar '{spec}': {exc}") from exc
-
-        try:
-            return importlib.import_module(nombre)
-        except ModuleNotFoundError as exc:
-            raise ImportError(
-                f"No se pudo importar el módulo '{nombre}' tras la instalación"
-            ) from exc
+        return obtener_modulo_cobra_oficial(nombre)
+    except ModuleNotFoundError as exc:
+        raise ImportError(
+            f"No se pudo resolver el módulo Cobra permitido '{nombre}' en runtime."
+        ) from exc

--- a/tests/unit/test_usar_loader_validation.py
+++ b/tests/unit/test_usar_loader_validation.py
@@ -3,40 +3,30 @@ import pytest
 from cobra import usar_loader
 
 
-@pytest.mark.parametrize("nombre", ["-malicious", "requests==2.0", "../etc/passwd"])
-def test_obtener_modulo_rechaza_nombres_invalidos(nombre):
+@pytest.mark.parametrize(
+    "nombre",
+    ["-malicious", "requests==2.0", "../etc/passwd", "pcobra", "corelibs_utils"],
+)
+def test_obtener_modulo_rechaza_nombres_invalidos_o_internos(nombre):
     with pytest.raises(ValueError):
         usar_loader.obtener_modulo(nombre)
 
 
-@pytest.mark.parametrize(
-    "entrada,esperado",
-    [
-        ("numpy", ("numpy", "numpy")),
-        ("numpy==1.26.4", ("numpy", "numpy==1.26.4")),
-        ("numpy>=1.26,<2", ("numpy", "numpy>=1.26,<2")),
-    ],
-)
-def test_parsear_entrada_permite_formato_estricto(monkeypatch, entrada, esperado):
-    monkeypatch.delenv("COBRA_USAR_INSTALL_UNSAFE_SPECS", raising=False)
-    assert usar_loader._parsear_entrada(entrada) == esperado
+def test_obtener_modulo_rechaza_modulos_fuera_allowlist():
+    with pytest.raises(PermissionError, match="Importación no permitida"):
+        usar_loader.obtener_modulo("numpy")
 
 
-@pytest.mark.parametrize(
-    "entrada",
-    [
-        "numpy --index-url https://evil.example/simple",
-        "numpy --find-links https://evil.example/wheels",
-        "numpy --trusted-host evil.example",
-        "https://evil.example/pkg.whl",
-        "git+https://evil.example/repo.git",
-        "file:///tmp/paquete.whl",
-        "numpy @ https://evil.example/pkg.whl",
-        "numpy==1.26 --hash=sha256:abc123",
-        "numpy #sha256=abc123",
-    ],
-)
-def test_parsear_entrada_rechaza_flags_urls_y_hashes(monkeypatch, entrada):
-    monkeypatch.delenv("COBRA_USAR_INSTALL_UNSAFE_SPECS", raising=False)
-    with pytest.raises(ValueError):
-        usar_loader._parsear_entrada(entrada)
+def test_allowlist_canonica_contiene_modulos_esperados():
+    assert usar_loader.USAR_COBRA_ALLOWLIST == {
+        "numero",
+        "texto",
+        "datos",
+        "logica",
+        "asincrono",
+        "sistema",
+        "archivo",
+        "tiempo",
+        "red",
+        "holobit",
+    }


### PR DESCRIPTION
### Motivation
- Identificar y endurecer el punto de resolución runtime donde `usar "modulo"` se traduce a carga real para evitar imports arbitrarios en ejecución. 
- Forzar una política segura y predecible para `usar` basada en un conjunto canónico de módulos Cobra y bloquear nombres que parezcan rutas internas o paquetes de backend. 
- Mantener sin cambios la sintaxis del parser (`usar "modulo"`) y aplicar la restricción únicamente en el binding runtime. 

### Description
- Se añadió una allowlist canónica `USAR_COBRA_ALLOWLIST` con los módulos: `numero`, `texto`, `datos`, `logica`, `asincrono`, `sistema`, `archivo`, `tiempo`, `red`, `holobit` en `src/pcobra/cobra/usar_loader.py`. 
- Se implementó validación reforzada de nombres con `_VALID_NAME_RE` (identificadores simples en minúsculas) y bloqueo de patrones internos vía `_INTERNAL_HINTS` para rechazar nombres que parezcan rutas o paquetes backend. 
- `obtener_modulo()` ahora verifica la allowlist y lanza `PermissionError` si el módulo no está permitido, y resuelve únicamente módulos oficiales Cobra mediante `obtener_modulo_cobra_oficial`; se eliminó la lógica de instalación dinámica y la whitelist configurable en tiempo de ejecución. 
- Se actualizaron las pruebas en `tests/unit/test_usar_loader_validation.py` para cubrir rechazo de nombres inválidos/internos, rechazo de módulos fuera de la allowlist y verificación del contenido de la allowlist. 

### Testing
- Ejecutado `pytest -q tests/unit/test_usar_loader_validation.py` y todos los tests pasaron (7 passed). 
- Las pruebas unitarias actualizadas verifican la validación de nombres, el rechazo de imports no permitidos y la existencia exacta de la allowlist canónica.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f702d14e108327830dc11d00283e61)