### PR TITLE
Saneamiento central en runtime para `usar` antes de inyección al contexto REPL/ejecución

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import hashlib
+from dataclasses import dataclass
 from typing import Mapping, Optional
 
 from .lexer import (
@@ -88,6 +89,25 @@ MODULES_PATH = _DEFAULT_MODULES_PATH
 REPL_USAR_EXTERNAL_MODULE_ERROR = (
     "módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)"
 )
+_NOMBRES_PUBLICOS_EQUIVALENTE_COBRA = frozenset(
+    {"self", "append", "map", "filter", "unwrap", "expect"}
+)
+_DUNDERS_BLOQUEADOS = frozenset(
+    {"__builtins__", "__loader__", "__package__", "__spec__", "__name__"}
+)
+_NOMBRES_BACKEND_INTERNOS = frozenset(
+    {"sys", "os", "importlib", "pcobra", "cobra", "core"}
+)
+
+
+@dataclass(frozen=True)
+class _ResultadoSaneamientoSimbolo:
+    nombre: str
+    simbolo: object
+    rechazado: bool
+    codigo: str | None = None
+    mensaje: str | None = None
+    warning: bool = False
 
 
 def _ruta_import_permitida(ruta: str) -> bool:
@@ -1834,6 +1854,7 @@ class InterpretadorCobra:
             ``__all__`` y símbolos callables). Si no cumplen, se rechazan.
         """
         from pathlib import Path
+        from types import ModuleType
 
         from .usar_loader import obtener_modulo, obtener_modulo_cobra_oficial
 
@@ -1862,10 +1883,29 @@ class InterpretadorCobra:
                     continue
                 simbolo = getattr(modulo_obj, nombre)
                 if not callable(simbolo):
+                    if modulo_oficial and nombre.isupper():
+                        simbolos.append((nombre, simbolo))
                     continue
                 vistos.add(nombre)
                 simbolos.append((nombre, simbolo))
             return simbolos
+
+        def _sanear_simbolo_para_usar(nombre: str, simbolo: object) -> _ResultadoSaneamientoSimbolo:
+            if nombre.startswith("_"):
+                return _ResultadoSaneamientoSimbolo(nombre, simbolo, True, "private_prefix", "símbolos que inicien con '_' no son exportables")
+            if "__" in nombre or nombre in _DUNDERS_BLOQUEADOS:
+                return _ResultadoSaneamientoSimbolo(nombre, simbolo, True, "dunder_name", "dunders Python no se permiten en usar")
+            if nombre in _NOMBRES_BACKEND_INTERNOS:
+                return _ResultadoSaneamientoSimbolo(nombre, simbolo, True, "backend_internal_name", "nombre interno del backend bloqueado")
+            if isinstance(simbolo, ModuleType):
+                return _ResultadoSaneamientoSimbolo(nombre, simbolo, True, "backend_module_object", "objetos módulo/paquete no son exportables")
+            if nombre in _NOMBRES_PUBLICOS_EQUIVALENTE_COBRA:
+                return _ResultadoSaneamientoSimbolo(nombre, simbolo, True, "cobra_public_equivalent", "nombre público reservado por equivalente Cobra")
+            if not callable(simbolo) and not nombre.isupper():
+                return _ResultadoSaneamientoSimbolo(nombre, simbolo, True, "non_callable_not_public_constant", "solo se permiten no-callables para constantes públicas explícitas")
+            if not callable(simbolo):
+                return _ResultadoSaneamientoSimbolo(nombre, simbolo, False, "public_constant", "constante pública explícita permitida", warning=True)
+            return _ResultadoSaneamientoSimbolo(nombre, simbolo, False)
 
         def _resolver_carga_modulo_usar(nombre_modulo: str):
             """Aplica una única ruta de decisión para módulos de ``usar``."""
@@ -1924,17 +1964,42 @@ class InterpretadorCobra:
 
             contexto_actual = self.contextos[-1]
 
+            reporte_rechazos: list[dict[str, str]] = []
+            reporte_warnings: list[dict[str, str]] = []
+            simbolos_saneados: list[tuple[str, object]] = []
+            for nombre, simbolo in simbolos_a_inyectar:
+                resultado = _sanear_simbolo_para_usar(nombre, simbolo)
+                if resultado.rechazado:
+                    reporte_rechazos.append(
+                        {"symbol": nombre, "code": resultado.codigo or "rejected", "message": resultado.mensaje or "símbolo rechazado"}
+                    )
+                    self._trace_debug(f"[USAR_SANITIZE][REJECT] {nombre}: {resultado.codigo}")
+                    continue
+                if resultado.warning:
+                    reporte_warnings.append(
+                        {"symbol": nombre, "code": resultado.codigo or "warning", "message": resultado.mensaje or "warning"}
+                    )
+                    self._trace_debug(f"[USAR_SANITIZE][WARN] {nombre}: {resultado.codigo}")
+                simbolos_saneados.append((nombre, simbolo))
+
+            if reporte_rechazos:
+                raise ImportError(
+                    f"rechazos de saneamiento en usar '{nodo.modulo}': {reporte_rechazos}"
+                )
+
             # Fase A: validar colisiones de forma completa antes de definir.
-            for nombre, _simbolo in simbolos_a_inyectar:
+            for nombre, _simbolo in simbolos_saneados:
                 if contexto_actual.contains(nombre):
                     raise NameError(
                         "No se puede usar el módulo "
-                        f"'{nodo.modulo}': el símbolo '{nombre}' ya existe en el contexto actual"
+                        f"'{nodo.modulo}': colisión estructurada={{'symbol': '{nombre}', 'code': 'symbol_collision', 'message': 'símbolo ya existe en contexto actual'}}"
                     )
 
             # Fase B (atómica): definir solo si toda la validación anterior fue exitosa.
-            for nombre, simbolo in simbolos_a_inyectar:
+            for nombre, simbolo in simbolos_saneados:
                 contexto_actual.define(nombre, simbolo)
+            if reporte_warnings:
+                self._trace_debug(f"[USAR_SANITIZE][WARNINGS] {reporte_warnings}")
         except Exception as exc:
             logging.exception(f"Error al usar el módulo '{nodo.modulo}': {exc}")
             raise


### PR DESCRIPTION
### Motivation
- Centralizar la política de saneamiento de símbolos importados por `usar` para evitar fugas de internals y colisiones cuando se inyectan nombres al contexto del REPL/ejecución. 
- Reforzar reglas mínimas de rechazo y advertencia (dunders, privados, módulos, nombres reservados, no-callables) y ofrecer reportes estructurados para diagnóstico.

### Description
- Añadido `_ResultadoSaneamientoSimbolo` (dataclass) y la función `_sanear_simbolo_para_usar(...)` que aplica las reglas de aceptación/rechazo por símbolo antes de la inyección. 
- Reglas implementadas: rechazo de símbolos que inician con `_`, que contienen `__` o pertenecen a dunders bloqueados, nombres internos de backend (`sys`, `os`, `importlib`, `pcobra`, `cobra`, `core`), objetos módulo/paquete, y nombres públicos prohibidos con equivalente Cobra (`self`, `append`, `map`, `filter`, `unwrap`, `expect`). 
- Permitidos los no-callables únicamente cuando son constantes públicas explícitas por convención (identificador en mayúsculas), marcando esos casos como `warning` técnico interno en lugar de rechazo. 
- La fase de `usar` ahora: (A) resolver exportables, (B) sanear todos los símbolos y acumular rechazos/warnings, (C) si hay rechazos se falla con `ImportError` que incluye un payload estructurado (`symbol`, `code`, `message`), (D) validar colisiones atomizadas y finalmente definir los símbolos saneados; las colisiones devuelven `NameError` con mensaje estructurado para diagnóstico. 
- Integradas trazas de depuración internas con `_trace_debug` para warnings/rechazos sin exponer estos internals en la salida de usuario normal.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar.py` y la ejecución falló en la fase de colección con `ImportError: attempted relative import beyond top-level package`, por un problema de import-path del entorno de test que impide la recolección; el fallo ocurrió durante importación de módulos y no fue causado directamente por la lógica de saneamiento introducida. 
- No se ejecutaron otros tests automatizados completos en este entorno debido al problema de recolección señalado y la ejecución abortó en la etapa inicial.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f703f9bb9c8327af0e2952bf809fe7)