### PR TITLE
Refuerza `usar` en runtime con política explícita de colisiones

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -89,6 +89,9 @@ MODULES_PATH = _DEFAULT_MODULES_PATH
 REPL_USAR_EXTERNAL_MODULE_ERROR = (
     "módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)"
 )
+USAR_COLLISION_STRICT_ERROR = "strict_error"
+USAR_COLLISION_WARN_ALIAS_REQUIRED = "warn_alias_required"
+_USAR_COLLISION_POLICIES = frozenset({USAR_COLLISION_STRICT_ERROR, USAR_COLLISION_WARN_ALIAS_REQUIRED})
 _NOMBRES_PUBLICOS_EQUIVALENTE_COBRA = frozenset(
     {"self", "append", "map", "filter", "unwrap", "expect"}
 )
@@ -459,6 +462,7 @@ class InterpretadorCobra:
         self.ultimo_ir: Optional[InternalIRModule] = None
         # Restricción opcional para `usar` en REPL/evaluador incremental.
         self._repl_usar_alias_map: dict[str, str] | None = None
+        self._usar_collision_policy = USAR_COLLISION_STRICT_ERROR
 
     def configurar_restriccion_usar_repl(self, alias_map: dict[str, str] | None) -> None:
         """Configura whitelist explícita de módulos `usar` para flujo REPL.
@@ -466,6 +470,12 @@ class InterpretadorCobra:
         Cuando ``alias_map`` es ``None``, no se aplica restricción adicional.
         """
         self._repl_usar_alias_map = alias_map.copy() if alias_map is not None else None
+
+    def configurar_politica_colision_usar(self, policy: str) -> None:
+        """Configura la política de colisión para ``usar`` en runtime."""
+        if policy not in _USAR_COLLISION_POLICIES:
+            raise ValueError(f"Política de colisión inválida: {policy}")
+        self._usar_collision_policy = policy
 
     def in_execution(self) -> bool:
         """Indica si el intérprete se encuentra en fase de ejecución."""
@@ -1987,15 +1997,28 @@ class InterpretadorCobra:
                     f"rechazos de saneamiento en usar '{nodo.modulo}': {reporte_rechazos}"
                 )
 
-            # Fase A: validar colisiones de forma completa antes de definir.
-            for nombre, _simbolo in simbolos_saneados:
-                if contexto_actual.contains(nombre):
+            # Fase A: detectar colisiones de forma completa antes de definir.
+            conflictos = [
+                nombre for nombre, _simbolo in simbolos_saneados if contexto_actual.contains(nombre)
+            ]
+            if conflictos:
+                conflicto = conflictos[0]
+                if self._usar_collision_policy == USAR_COLLISION_WARN_ALIAS_REQUIRED:
+                    self._trace_debug(
+                        "[USAR_COLLISION][WARN] "
+                        f"módulo={nodo.modulo} conflictos={conflictos} policy={self._usar_collision_policy}"
+                    )
                     raise NameError(
                         "No se puede usar el módulo "
-                        f"'{nodo.modulo}': colisión estructurada={{'symbol': '{nombre}', 'code': 'symbol_collision', 'message': 'símbolo ya existe en contexto actual'}}"
+                        f"'{nodo.modulo}': conflicto={conflictos}. "
+                        "Requiere alias explícito según la convención del runtime (usar importar ... como ...)."
                     )
+                raise NameError(
+                    "No se puede usar el módulo "
+                    f"'{nodo.modulo}': colisión estructurada={{'symbol': '{conflicto}', 'code': 'symbol_collision', 'message': 'símbolo ya existe en contexto actual'}}"
+                )
 
-            # Fase B (atómica): definir solo si toda la validación anterior fue exitosa.
+            # Fase B: inyectar de forma atómica y sin sobreescritura silenciosa.
             for nombre, simbolo in simbolos_saneados:
                 contexto_actual.define(nombre, simbolo)
             if reporte_warnings:

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -585,3 +585,44 @@ def test_repl_usar_modulo_oficial_con_all_mixto_filtra_callables_publicos(monkey
     assert "_privada" not in interp.variables
     assert "NO_CALLABLE" not in interp.variables
     assert "faltante" not in interp.variables
+
+def test_repl_usar_colision_policy_warn_alias_required_no_overwrite(monkeypatch):
+    modulo = ModuleType("texto")
+    modulo.__all__ = ["a_snake", "a_camel"]
+    modulo.a_snake = lambda texto: texto
+    modulo.a_camel = lambda texto: texto
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/texto.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"texto": "texto"})
+    interp.configurar_politica_colision_usar("warn_alias_required")
+    interp.contextos[-1].define("a_snake", lambda _texto: "ocupado")
+
+    with pytest.raises(NameError, match=r"Requiere alias explícito"):
+        _ejecutar_codigo('usar "texto"', interp)
+
+    assert interp.contextos[-1].get("a_snake")("x") == "ocupado"
+    assert "a_camel" not in interp.contextos[-1].values
+
+
+def test_repl_usar_colision_multiple_sin_inyeccion_parcial(monkeypatch):
+    modulo = ModuleType("texto")
+    modulo.__all__ = ["a_snake", "a_camel", "quitar_prefijo"]
+    modulo.a_snake = lambda texto: texto
+    modulo.a_camel = lambda texto: texto
+    modulo.quitar_prefijo = lambda texto, prefijo: texto.removeprefix(prefijo)
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/texto.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"texto": "texto"})
+    interp.contextos[-1].define("a_snake", lambda _texto: "ocupado")
+    interp.contextos[-1].define("a_camel", lambda _texto: "ocupado")
+
+    with pytest.raises(NameError, match=r"symbol_collision"):
+        _ejecutar_codigo('usar "texto"', interp)
+
+    assert "quitar_prefijo" not in interp.contextos[-1].values


### PR DESCRIPTION
### Motivation
- Implementar una secuencia runtime para `usar` que resuelva módulo, extraiga y sanee exportaciones, detecte colisiones contra el contexto actual y solo inyecte si toda la validación pasa.
- Evitar sobrescritura implícita de símbolos existentes en flows REPL/ejecución y forzar convenciones de alias cuando la política lo requiera.
- Exponer una política de colisiones configurable para permitir modos estrictos o de advertencia que exijan alias explícito.

### Description
- Añade constantes de política `USAR_COLLISION_STRICT_ERROR` y `USAR_COLLISION_WARN_ALIAS_REQUIRED` y el conjunto `_USAR_COLLISION_POLICIES` en `src/pcobra/core/interpreter.py`.
- Guarda la política en el estado del intérprete (`self._usar_collision_policy`) y expone el método `configurar_politica_colision_usar(policy: str)` para validarla y cambiarla en runtime.
- Refuerza `ejecutar_usar` para ejecutar las fases: resolver módulo, comprobar origen Cobra en REPL estricto, extraer `__all__`/candidatos, sanear símbolos, detectar colisiones completas antes de cualquier `define`, y realizar una inyección atómica sin sobreescritura silenciosa; en caso de conflicto aplica la política seleccionada.
- Añade pruebas unitarias en `tests/unit/test_usar.py` que verifican la política `warn_alias_required` y que múltiples colisiones impiden inyección parcial (`test_repl_usar_colision_policy_warn_alias_required_no_overwrite` y `test_repl_usar_colision_multiple_sin_inyeccion_parcial`).

### Testing
- Ejecuté pruebas focalizadas con `pytest -q tests/unit/test_usar.py -k 'colision_policy_warn_alias_required_no_overwrite or colision_multiple_sin_inyeccion_parcial or semantica_oficial_plana_libro_parser_legacy_colision_es_atomica'` y la ejecución no completó por un error de recolección de pytest (`ImportError: attempted relative import beyond top-level package`) que proviene del esquema legacy de imports de los tests en este entorno, por lo que las nuevas pruebas no pudieron ejecutarse satisfactoriamente aquí.
- Reintenté con `PYTHONPATH=src pytest -q ...` y obtuve el mismo `ImportError`, indicando que la falla está ligada al entorno de recolección y no a la lógica implementada en `ejecutar_usar`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f709aa5cb48327a2f076f497cda5dc)