### PR TITLE
Aplazar carga eager de transpiladores y reforzar contrato de backends en startup

### DIFF
--- a/docs/targets_policy.md
+++ b/docs/targets_policy.md
@@ -47,3 +47,9 @@ Cualquier cambio que amplíe o reduzca la API pública estable (comandos, backen
 1. actualización de esta política,
 2. actualización de ADR de arquitectura aplicable,
 3. comunicación explícita en notas de versión.
+
+## Contrato de arranque (startup)
+
+- En rutas de arranque públicas (`import pcobra`, `cobra repl`, `cobra run`, `cobra test`) **solo** se pueden inicializar por defecto los backends `python`, `javascript`, `rust`.
+- Los backends legacy (`go`, `cpp`, `java`, `wasm`, `asm`) quedan restringidos a rutas lazy/opt-in de compatibilidad interna.
+- Cualquier regresión de carga eager de backends legacy en arranque debe fallar por guardas de test/CI.

--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -41,7 +41,15 @@ def _load_official_transpilers() -> dict[str, type]:
     return build_official_transpilers()
 
 
-TRANSPILERS: dict[str, type] = _load_official_transpilers()
+_TRANSPILERS_CACHE: dict[str, type] | None = None
+
+
+def _official_transpilers() -> dict[str, type]:
+    """Carga diferida + memoizada de transpiladores oficiales (sin eager loading en import)."""
+    global _TRANSPILERS_CACHE
+    if _TRANSPILERS_CACHE is None:
+        _TRANSPILERS_CACHE = _load_official_transpilers()
+    return _TRANSPILERS_CACHE
 
 
 def _public_route_backend_matrix() -> dict[str, tuple[str, ...]]:
@@ -140,9 +148,10 @@ def resolve_backend_runtime(
 
 def transpile(ast: Any, backend: str) -> str:
     """Transpila un AST al backend indicado usando el registro oficial."""
-    if backend not in TRANSPILERS:
+    transpilers = _official_transpilers()
+    if backend not in transpilers:
         raise ValueError(f"Transpilador no soportado: {backend}")
-    transpiler = TRANSPILERS[backend]()
+    transpiler = transpilers[backend]()
     return transpiler.generate_code(ast)
 
 

--- a/tests/unit/test_backend_pipeline_runtime_manager.py
+++ b/tests/unit/test_backend_pipeline_runtime_manager.py
@@ -23,7 +23,7 @@ def test_backend_pipeline_build_expone_contexto_runtime(monkeypatch):
         ),
     )
     monkeypatch.setattr(backend_pipeline, "obtener_ast", lambda _codigo: ["ast"])
-    monkeypatch.setattr(backend_pipeline, "TRANSPILERS", {"python": _DummyTranspiler})
+    monkeypatch.setattr(backend_pipeline, "_official_transpilers", lambda: {"python": _DummyTranspiler})
 
     result = backend_pipeline.build("imprimir(1)", hints={"preferred_backend": "python"})
 
@@ -50,7 +50,7 @@ def test_backend_pipeline_build_expone_reason_solo_en_debug(monkeypatch):
         ),
     )
     monkeypatch.setattr(backend_pipeline, "obtener_ast", lambda _codigo: ["ast"])
-    monkeypatch.setattr(backend_pipeline, "TRANSPILERS", {"python": _DummyTranspiler})
+    monkeypatch.setattr(backend_pipeline, "_official_transpilers", lambda: {"python": _DummyTranspiler})
 
     result = backend_pipeline.build("imprimir(1)", hints={"preferred_backend": "python", "debug": True})
 

--- a/tests/unit/test_startup_no_legacy_eager_loading.py
+++ b/tests/unit/test_startup_no_legacy_eager_loading.py
@@ -1,0 +1,39 @@
+import importlib
+import sys
+
+LEGACY_TRANSPILER_MODULES = (
+    "pcobra.cobra.transpilers.transpiler.to_go",
+    "pcobra.cobra.transpilers.transpiler.to_cpp",
+    "pcobra.cobra.transpilers.transpiler.to_java",
+    "pcobra.cobra.transpilers.transpiler.to_wasm",
+    "pcobra.cobra.transpilers.transpiler.to_asm",
+)
+
+
+def _purge_modules(prefixes: tuple[str, ...]) -> None:
+    for name in list(sys.modules):
+        if name.startswith(prefixes):
+            sys.modules.pop(name, None)
+
+
+def test_import_pcobra_no_precarga_transpiladores_legacy():
+    _purge_modules(("pcobra", "cobra", "core"))
+
+    importlib.import_module("pcobra")
+
+    for module_name in LEGACY_TRANSPILER_MODULES:
+        assert module_name not in sys.modules
+
+
+def test_import_backend_pipeline_no_precarga_legacy():
+    _purge_modules(("pcobra",))
+
+    importlib.import_module("pcobra.cobra.build.backend_pipeline")
+
+    for module_name in LEGACY_TRANSPILER_MODULES:
+        assert module_name not in sys.modules
+
+
+def test_public_backends_permancen_exactamente_tres():
+    policy = importlib.import_module("pcobra.cobra.architecture.backend_policy")
+    assert policy.PUBLIC_BACKENDS == ("python", "javascript", "rust")


### PR DESCRIPTION
### Motivation
- Evitar que imports/arranque públicos precarguen transpiladores legacy y romper el contrato UX/CLI de backends públicos. 
- Garantizar que las rutas de arranque (`import pcobra`, `cobra repl`, `cobra run`, `cobra test`) solo inicialicen por defecto `python`, `javascript` y `rust`. 
- Mover soporte legacy a rutas lazy/opt-in para reducir superficie de regresión en startup. 
- Añadir guardas automáticas en tests/CI que detecten reintroducción de eager loading de transpiladores legacy. 

### Description
- Reemplacé el diccionario global eager `TRANSPILERS` por un cargador diferido y memoizado `_official_transpilers()` en `src/pcobra/cobra/build/backend_pipeline.py` y actualicé `transpile()` para usarlo. 
- Ajusté tests existentes para inyectar/mokear el punto de carga nuevo (`_official_transpilers`) en `tests/unit/test_backend_pipeline_runtime_manager.py`. 
- Añadí `tests/unit/test_startup_no_legacy_eager_loading.py` que verifica que `import pcobra` y `import pcobra.cobra.build.backend_pipeline` no precarguen módulos legacy (`to_go`, `to_cpp`, `to_java`, `to_wasm`, `to_asm`) y que `PUBLIC_BACKENDS` siga siendo exactamente `("python","javascript","rust")`. 
- Actualicé documentación `docs/targets_policy.md` agregando una sección `Contrato de arranque (startup)` que explícita la restricción lazy/opt-in para backends legacy. 

### Testing
- Ejecuté `pytest -q tests/unit/test_backend_pipeline_runtime_manager.py tests/unit/test_startup_no_legacy_eager_loading.py` y todos los tests pasaron (`6 passed, 1 warning`). 
- Los tests añadidos ejercitan la ausencia de módulos legacy en `sys.modules` tras imports de inicio y validan la lista pública de backends; ambos checks pasan en CI local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f70acbe93c8327a1d4bb11fe904498)