### PR TITLE
test: reforzar superficie pública de `usar` en tests unitarios

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -626,3 +626,101 @@ def test_repl_usar_colision_multiple_sin_inyeccion_parcial(monkeypatch):
         _ejecutar_codigo('usar "texto"', interp)
 
     assert "quitar_prefijo" not in interp.contextos[-1].values
+
+
+def test_usar_numero_exporta_solo_nombres_espanoles(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_numero)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero"})
+    interp.ejecutar_nodo(NodoUsar("numero"))
+
+    assert "es_finito" in interp.variables
+    assert "isfinite" not in interp.variables
+
+
+def test_usar_texto_exporta_solo_nombres_espanoles(monkeypatch):
+    import pcobra.corelibs.texto as modulo_texto
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_texto)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"texto": "texto"})
+    interp.ejecutar_nodo(NodoUsar("texto"))
+
+    assert "a_snake" in interp.variables
+    assert "to_snake_case" not in interp.variables
+
+
+def test_usar_datos_incluye_filtrar_mapear_reducir(monkeypatch):
+    import pcobra.standard_library.datos as modulo_datos
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_datos)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"datos": "datos"})
+    interp.ejecutar_nodo(NodoUsar("datos"))
+
+    for simbolo in ("filtrar", "mapear", "reducir"):
+        assert simbolo in interp.variables
+
+
+def test_usar_numpy_rechazado_en_superficie_publica():
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto", "datos": "datos"})
+
+    with pytest.raises(PermissionError, match=r"solo alias oficiales Cobra"):
+        interp.ejecutar_nodo(NodoUsar("numpy"))
+
+
+def test_internals_holobit_sdk_no_importables_por_usar_loader():
+    for nombre in ("holobit_sdk", "holobit_sdk.core", "holobit_sdk.visualization"):
+        with pytest.raises(ValueError):
+            usar_loader.obtener_modulo(nombre)
+
+
+def test_usar_holobit_expone_solo_api_publica(monkeypatch):
+    import pcobra.corelibs.holobit as modulo_holobit
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_holobit)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"holobit": "holobit"})
+    interp.ejecutar_nodo(NodoUsar("holobit"))
+
+    assert "holobit" in interp.variables
+    assert "proyectar" in interp.variables
+    assert "_require_holobit_sdk" not in interp.variables
+
+
+def test_simbolos_exportados_por_usar_no_contienen_doble_guion_bajo(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_numero)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero"})
+    interp.ejecutar_nodo(NodoUsar("numero"))
+
+    assert all("__" not in simbolo for simbolo in interp.variables)
+
+
+def test_usar_no_exporta_simbolos_bloqueados(monkeypatch):
+    import pcobra.standard_library.datos as modulo_datos
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_datos)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"datos": "datos"})
+    interp.ejecutar_nodo(NodoUsar("datos"))
+
+    for simbolo in ("self", "append", "map", "filter", "unwrap", "expect"):
+        assert simbolo not in interp.variables
+
+
+def test_backends_legados_no_cargan_en_startup_normal():
+    for nombre in ("go", "cpp", "java", "wasm", "asm"):
+        with pytest.raises(PermissionError):
+            usar_loader.obtener_modulo(nombre)
+
+
+def test_politica_publica_backend_es_python_javascript_rust():
+    from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+
+    assert PUBLIC_BACKENDS == ("python", "javascript", "rust")


### PR DESCRIPTION
### Motivation
- Asegurar que la instrucción `usar` expone únicamente la superficie pública esperada y bloquea accesos/exports no permitidos según las políticas del proyecto. 
- Evitar depender de detalles internos de implementación en las aserciones y reutilizar la infraestructura de pruebas existente. 
- Documentar contractualmente la política pública de backends observada por la API pública.

### Description
- Añade múltiples casos en `tests/unit/test_usar.py` que validan la superficie pública de `usar`, incluidos: `usar "numero"`, `usar "texto"`, `usar "datos"`, rechazo de `usar "numpy"`, bloqueo de imports de `holobit_sdk`, exposición pública de `holobit` sin internals, ausencia de símbolos con `__`, bloqueo de símbolos prohibidos (`self`, `append`, `map`, `filter`, `unwrap`, `expect`), no carga de backends legados en startup y comprobación de `PUBLIC_BACKENDS == ("python","javascript","rust")`. 
- Reutiliza fixtures/helpers e infraestructura del propio `test_usar.py` (`InterpretadorCobra`, `NodoUsar`, `monkeypatch`, etc.) para no duplicar bootstrap. 
- El cambio fue añadido y committeado en `tests/unit/test_usar.py` y se creó el PR con la descripción del cambio.

### Testing
- Se ejecutó `python -m py_compile tests/unit/test_usar.py` y la comprobación de sintaxis del nuevo archivo finalizó correctamente. 
- Intentos de ejecutar `pytest` sobre el archivo (`pytest -q tests/unit/test_usar.py` y `PYTHONPATH=src pytest -q tests/unit/test_usar.py`) fallaron en la fase de colección por un problema preexistente de import path relativo (`ImportError: attempted relative import beyond top-level package`) que no fue introducido por este cambio. 
- No se pudieron completar las ejecuciones completas de `pytest` en este entorno por la razón anterior; el archivo de tests compila y está listo para ejecución en un entorno con el `PYTHONPATH`/paquetes correctos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f70bf8ec008327a7290a69ac5b35d5)