### PR TITLE
Asegura entrypoints canónicos de `usar` para `datos` y `tiempo`

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -13,5 +13,6 @@ REPL_COBRA_MODULE_MAP: dict[str, str] = {
     "logica": "logica",
     "numero": "numero",
     "texto": "texto",
+    "tiempo": "tiempo",
     "util": "util",
 }

--- a/src/pcobra/corelibs/datos.py
+++ b/src/pcobra/corelibs/datos.py
@@ -1,0 +1,8 @@
+"""Módulo canónico ``datos`` para `usar`.
+
+Este puente mantiene el nombre público en español (`usar "datos"`) y reexpone
+la implementación oficial ubicada en ``pcobra.standard_library.datos``.
+"""
+
+from pcobra.standard_library.datos import *  # noqa: F401,F403
+from pcobra.standard_library.datos import __all__  # noqa: F401

--- a/src/pcobra/corelibs/tiempo.py
+++ b/src/pcobra/corelibs/tiempo.py
@@ -1,19 +1,33 @@
-"""Utilidades relacionadas con el tiempo."""
+"""Módulo canónico ``tiempo`` para `usar`.
+
+Mantiene la API pública histórica (`ahora`, `formatear`, `dormir`) y delega
+las operaciones de fecha/hora al backend oficial de ``standard_library.fecha``.
+"""
+
+from __future__ import annotations
 
 import time
 from datetime import datetime
 
+from pcobra.standard_library.fecha import formatear as _formatear_fecha
+from pcobra.standard_library.fecha import hoy as _hoy
+
+__all__ = ["ahora", "formatear", "dormir"]
+
 
 def ahora() -> datetime:
     """Devuelve la fecha y hora actual."""
-    return datetime.now()
+
+    return _hoy()
 
 
 def formatear(fecha: datetime, formato: str = "%Y-%m-%d %H:%M:%S") -> str:
     """Convierte *fecha* a texto según *formato*."""
-    return fecha.strftime(formato)
+
+    return _formatear_fecha(fecha, formato)
 
 
 def dormir(segundos: float) -> None:
     """Detiene la ejecución durante *segundos*."""
+
     time.sleep(segundos)

--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -123,6 +123,23 @@ def test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_numpy_restrin
 
 
 
+
+
+def _modulo_tiempo_stub() -> ModuleType:
+    mod = ModuleType("tiempo")
+    mod.__all__ = ["ahora"]
+    mod.ahora = lambda: "2026-05-03T00:00:00"
+    mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/tiempo.py"
+    return mod
+
+
+def _modulo_datos_stub() -> ModuleType:
+    mod = ModuleType("datos")
+    mod.__all__ = ["longitud"]
+    mod.longitud = lambda valores: len(valores)
+    mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/datos.py"
+    return mod
+
 def _modulo_numero_multi_export_stub() -> ModuleType:
     mod = ModuleType("numero")
     mod.__all__ = ["es_finito", "es_par"]
@@ -210,3 +227,33 @@ def test_usar_externo_whitelist_sin_all_falla_claro_y_atomico(monkeypatch):
 
     assert estado_pre == interp.contextos[-1].values
     assert "externo_sin_all" not in interp.contextos[-1].values
+
+
+@pytest.mark.parametrize(
+    ("factory", "executor", "get_interp"),
+    [
+        (lambda: InteractiveCommand(InterpretadorCobra()), lambda cmd, code: cmd.ejecutar_codigo(code), lambda cmd: cmd.interpretador),
+        (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
+    ],
+)
+def test_repl_contract_resuelve_usar_datos_y_tiempo(factory, executor, get_interp, monkeypatch):
+    mod_datos = _modulo_datos_stub()
+    mod_tiempo = _modulo_tiempo_stub()
+
+    def _resolver_modulo(nombre: str, **_kwargs):
+        if nombre == "datos":
+            return mod_datos
+        if nombre == "tiempo":
+            return mod_tiempo
+        raise ModuleNotFoundError(nombre)
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda nombre: _resolver_modulo(nombre))
+
+    cmd = factory()
+    interp = get_interp(cmd)
+
+    executor(cmd, 'usar "datos"')
+    executor(cmd, 'usar "tiempo"')
+
+    assert interp.obtener_variable("longitud")([1, 2, 3]) == 3
+    assert interp.obtener_variable("ahora")() == "2026-05-03T00:00:00"


### PR DESCRIPTION
### Motivation
- Garantizar que los nombres públicos en español usados por la instrucción `usar` (`datos`, `tiempo`) resuelvan contra implementaciones oficiales sin exponer aliases backend o nombres en inglés.
- Evitar que el REPL estricto rechace módulos oficiales por falta de un puente canónico o por ausencia en el mapa de alias de REPL.
- Mantener la sintaxis del parser y la API pública histórica (`ahora`, `formatear`, `dormir`) sin cambiar la experiencia del usuario.

### Description
- Se añadió un módulo puente canónico `src/pcobra/corelibs/datos.py` que reexpone `pcobra.standard_library.datos` para que `usar "datos"` se resuelva desde la ruta oficial.
- Se adaptó `src/pcobra/corelibs/tiempo.py` para mantener la API pública (`ahora`, `formatear`, `dormir`) y delegar internamente en `pcobra.standard_library.fecha` sin cambiar la sintaxis del parser.
- Se extendió el mapa de alias del REPL (`REPL_COBRA_MODULE_MAP`) para incluir explícitamente `"tiempo": "tiempo"` y así permitir resolución en modo REPL estricto.
- Se añadieron pruebas de contrato en `tests/integration/test_repl_usar_entrypoints_contract.py` que verifican la resolución positiva de `usar "datos"` y `usar "tiempo"` mediante stubs de módulo.

### Testing
- Ejecuté `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py -k 'datos_y_tiempo'` y las pruebas específicas para `datos`/`tiempo` pasaron ✅.
- Ejecuté la suite completa del archivo con `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py` y la ejecución final reportó `5 failed, 6 passed, 1 warning`, lo cual apunta a fallos de expectativas de mensajes en tests existentes no relacionados con los entrypoints añadidos ⚠️.
- Los cambios fueron comprometidos y verificados localmente; los tests nuevos/dirigidos pasan y los fallos restantes requieren ajuste de mensajes esperados en tests preexistentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f70ef5b2748327be392d57a90089ef)