### PR TITLE
test: ampliar contrato de seguridad de `usar` en REPL

### DIFF
--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -109,7 +109,7 @@ def test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_numpy_restrin
     estado_pre_numpy = dict(interp.contextos[-1].values)
     simbolos_pre = set(interp.contextos[-1].values.keys())
 
-    with pytest.raises(PermissionError, match=r"módulos externos no soportados en REPL"):
+    with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto"):
         executor(cmd, 'usar "numpy"')
 
     # Contrato de Cobra: `usar` es plano (sin `.`), no se expone namespace tipo `numero.*`.
@@ -149,6 +149,36 @@ def _modulo_numero_multi_export_stub() -> ModuleType:
     return mod
 
 
+def _assert_contrato_simbolos_saneados(simbolos: set[str]) -> None:
+    bloqueados_explicitos = {"self", "append", "map", "filter", "unwrap", "expect"}
+    for simbolo in simbolos:
+        assert "__" not in simbolo
+        assert not simbolo.startswith("_")
+        assert simbolo not in bloqueados_explicitos
+
+
+def _modulo_holobit_publico_stub() -> ModuleType:
+    mod = ModuleType("holobit")
+    mod.__all__ = [
+        "crear_holobit",
+        "validar_holobit",
+        "serializar_holobit",
+        "deserializar_holobit",
+        "proyectar",
+        "transformar",
+        "graficar",
+        "combinar",
+        "medir",
+    ]
+    for nombre in mod.__all__:
+        setattr(mod, nombre, lambda *args, _nombre=nombre, **kwargs: {"ok": _nombre, "args": args, "kwargs": kwargs})
+    mod.Holobit = object
+    mod._to_sdk_holobit = lambda *_args, **_kwargs: None
+    mod.holobit_sdk = object()
+    mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/holobit.py"
+    return mod
+
+
 @pytest.mark.parametrize(
     ("factory", "executor", "get_interp"),
     [
@@ -173,7 +203,7 @@ def test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_colision_no_s
     interp = get_interp(cmd)
     interp.contextos[-1].define("es_finito", lambda _valor: "ocupado")
 
-    with pytest.raises(NameError, match=r"No se puede usar el módulo 'numero': el símbolo 'es_finito' ya existe"):
+    with pytest.raises(NameError, match=r"No se puede usar el módulo 'numero': colisión estructurada="):
         executor(cmd, 'usar "numero"')
 
     assert interp.obtener_variable("es_finito")("x") == "ocupado"
@@ -201,7 +231,7 @@ def test_repl_rechazo_externo_no_inyecta_simbolos(factory, executor, get_interp,
     interp = get_interp(cmd)
     estado_pre = dict(interp.contextos[-1].values)
 
-    with pytest.raises(PermissionError, match=r"módulos externos no soportados en REPL"):
+    with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto"):
         executor(cmd, 'usar "requests"')
 
     assert estado_pre == interp.contextos[-1].values
@@ -257,3 +287,84 @@ def test_repl_contract_resuelve_usar_datos_y_tiempo(factory, executor, get_inter
 
     assert interp.obtener_variable("longitud")([1, 2, 3]) == 3
     assert interp.obtener_variable("ahora")() == "2026-05-03T00:00:00"
+
+
+def test_repl_contract_seguridad_usar_holobit_restringe_internals_y_saneamiento(monkeypatch):
+    mod_holobit = _modulo_holobit_publico_stub()
+
+    alias_map = {**REPL_COBRA_MODULE_MAP, "holobit": "holobit"}
+
+    def _resolver_modulo(nombre: str, **_kwargs):
+        if nombre == "holobit":
+            return mod_holobit
+        raise ModuleNotFoundError(nombre)
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda nombre: _resolver_modulo(nombre))
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl(alias_map)
+    interp._repl_usar_alias_map = alias_map
+
+    class _NodoUsar:
+        modulo = "holobit"
+
+    interp.ejecutar_usar(_NodoUsar())
+    simbolos_holobit = set(mod_holobit.__all__)
+
+    for simbolo in simbolos_holobit:
+        assert simbolo in interp.contextos[-1].values
+
+    _assert_contrato_simbolos_saneados(simbolos_holobit)
+
+    assert "Holobit" not in interp.contextos[-1].values
+    assert "_to_sdk_holobit" not in interp.contextos[-1].values
+    assert "holobit_sdk" not in interp.contextos[-1].values
+
+    cmd = InteractiveCommand(InterpretadorCobra())
+    cmd.interpretador.configurar_restriccion_usar_repl(alias_map)
+    estado_pre = dict(cmd.interpretador.contextos[-1].values)
+    with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto"):
+        cmd.ejecutar_codigo('usar "holobit_sdk"')
+
+    assert estado_pre == cmd.interpretador.contextos[-1].values
+
+
+def test_repl_contract_seguridad_usar_atomico_holobit_y_datos_sin_overwrite(monkeypatch):
+    mod_holobit = _modulo_holobit_publico_stub()
+    mod_datos = _modulo_datos_stub()
+    alias_map = {**REPL_COBRA_MODULE_MAP, "holobit": "holobit"}
+
+    def _resolver_modulo(nombre: str, **_kwargs):
+        if nombre == "holobit":
+            return mod_holobit
+        if nombre == "datos":
+            return mod_datos
+        raise ModuleNotFoundError(nombre)
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda nombre: _resolver_modulo(nombre))
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl(alias_map)
+    interp._repl_usar_alias_map = alias_map
+
+    interp.contextos[-1].define("graficar", lambda _hb: "ocupado")
+    estado_pre_holobit = dict(interp.contextos[-1].values)
+    with pytest.raises(NameError, match=r"No se puede usar el módulo 'holobit':"):
+        class _NodoUsarHolobit:
+            modulo = "holobit"
+
+        interp.ejecutar_usar(_NodoUsarHolobit())
+    assert estado_pre_holobit == interp.contextos[-1].values
+
+    assert interp.obtener_variable("graficar")({}) == "ocupado"
+
+    interp.contextos[-1].define("longitud", lambda _v: -1)
+    estado_pre_datos = dict(interp.contextos[-1].values)
+    with pytest.raises(NameError, match=r"No se puede usar el módulo 'datos':"):
+        class _NodoUsarDatos:
+            modulo = "datos"
+
+        interp.ejecutar_usar(_NodoUsarDatos())
+    assert estado_pre_datos == interp.contextos[-1].values
+
+    assert interp.obtener_variable("longitud")([]) == -1


### PR DESCRIPTION
### Motivation
- Consolidar la suite de tests de `usar` como un contrato de seguridad para evitar regresiones en el REPL.
- Añadir cobertura explícita para rechazos y restricciones (p. ej. `usar "numpy"`, no exponer internals de `holobit`) y garantizar que la inyección de símbolos sea atómica y sin sobreescritura silenciosa.
- Asegurar saneamiento de nombres exportados para bloquear dunders, privados y nombres inseguros (por ejemplo `self`, `append`, `map`, `filter`, `unwrap`, `expect`).

### Description
- Extendí `tests/integration/test_repl_usar_entrypoints_contract.py` con helpers y stubs: ` _assert_contrato_simbolos_saneados` y `_modulo_holobit_publico_stub` para pruebas controladas de la API pública de `holobit`.
- Agregué tests nuevos que verifican el rechazo de `usar "numpy"` y `usar "holobit_sdk"` en REPL estricto, que `usar "holobit"` solo inyecta la API esperada y que las inyecciones son atómicas frente a colisiones (`holobit` y `datos`).
- Ajusté expectativas de mensajes de error en pruebas para alinearlas con el formato actual del runtime (mensajes estructurados de colisión y rechazo externo) y cambié algunos flujos de test para invocar `InterpretadorCobra.ejecutar_usar` cuando corresponde.
- El cambio es localizado al archivo de pruebas (`tests/integration/test_repl_usar_entrypoints_contract.py`) y no modifica código de producción.

### Testing
- Ejecuté `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py` y la suite resultante pasó: `17 passed, 1 warning`.
- Durante la iteración se ejecutaron corridas dirigidas para aislar fallos y validar las correcciones hasta obtener la ejecución completa y satisfactoria con `pytest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f710643aa483278f3a146365259feb)