### PR TITLE
Ajusta API pública española en módulos logica

### DIFF
--- a/src/pcobra/corelibs/logica.py
+++ b/src/pcobra/corelibs/logica.py
@@ -151,6 +151,12 @@ def coalesce(*valores: T, predicado: Callable[[T], bool] | None = None) -> T | N
     return None
 
 
+def coalescer(*valores: T, predicado: Callable[[T], bool] | None = None) -> T | None:
+    """Alias canónico en español para :func:`coalesce`."""
+
+    return coalesce(*valores, predicado=predicado)
+
+
 def condicional(
     *casos: tuple[bool | Callable[[], bool], T | Callable[[], T]],
     por_defecto: T | Callable[[], T] | None = None,
@@ -472,7 +478,7 @@ __all__ = [
     "entonces",
     "si_no",
     "condicional",
-    "coalesce",
+    "coalescer",
     "todas",
     "alguna",
     "ninguna",

--- a/src/pcobra/standard_library/logica.py
+++ b/src/pcobra/standard_library/logica.py
@@ -91,7 +91,7 @@ def si_no(valor: bool, resultado: T | Callable[[], T]) -> T | None:
     return _logica.si_no(valor, resultado)
 
 
-def coalesce(*valores: T, predicado: Callable[[T], bool] | None = None) -> T | None:
+def _coalesce_interno(*valores: T, predicado: Callable[[T], bool] | None = None) -> T | None:
     """Devuelve el primer valor que cumpla el predicado, como ``COALESCE`` en SQL."""
 
     return _logica.coalesce(*valores, predicado=predicado)
@@ -100,7 +100,7 @@ def coalesce(*valores: T, predicado: Callable[[T], bool] | None = None) -> T | N
 def coalescer(*valores: T, predicado: Callable[[T], bool] | None = None) -> T | None:
     """Alias canónico en español para ``coalesce``."""
 
-    return coalesce(*valores, predicado=predicado)
+    return _coalesce_interno(*valores, predicado=predicado)
 
 
 def condicional(

--- a/tests/unit/test_api_publica_logica_es.py
+++ b/tests/unit/test_api_publica_logica_es.py
@@ -1,0 +1,38 @@
+import ast
+from pathlib import Path
+
+
+def _leer_ast(relpath: str) -> ast.Module:
+    ruta = Path(__file__).resolve().parents[2] / relpath
+    return ast.parse(ruta.read_text(encoding="utf-8"))
+
+
+def _extraer_all(modulo: ast.Module) -> set[str]:
+    for nodo in modulo.body:
+        if isinstance(nodo, ast.Assign):
+            for target in nodo.targets:
+                if isinstance(target, ast.Name) and target.id == "__all__":
+                    if isinstance(nodo.value, (ast.List, ast.Tuple)):
+                        return {elt.value for elt in nodo.value.elts if isinstance(elt, ast.Constant)}
+    return set()
+
+
+def _nombres_funciones(modulo: ast.Module) -> set[str]:
+    return {n.name for n in modulo.body if isinstance(n, ast.FunctionDef)}
+
+
+def test_corelibs_logica_api_espanola_publica():
+    modulo = _leer_ast("src/pcobra/corelibs/logica.py")
+    exports = _extraer_all(modulo)
+    assert "coalescer" in exports
+    assert "coalesce" not in exports
+
+
+def test_standard_library_logica_api_espanola_publica():
+    modulo = _leer_ast("src/pcobra/standard_library/logica.py")
+    exports = _extraer_all(modulo)
+    funciones = _nombres_funciones(modulo)
+    assert "coalescer" in exports
+    assert "coalesce" not in exports
+    assert "_coalesce_interno" in funciones
+    assert "coalesce" not in funciones


### PR DESCRIPTION
### Motivation
- Unificar la superficie pública hacia nombres canónicos en español y evitar exponer aliases en inglés cuando existe un equivalente Cobra.
- Evitar rupturas en la API pública y facilitar la importación mediante `usar` exponiendo solo los símbolos públicos en español.

### Description
- En `src/pcobra/corelibs/logica.py` se añadió el alias público `coalescer` que reaprovecha la implementación existente `coalesce` y se ajustó `__all__` para exportar `coalescer` (eliminando `coalesce` de la exportación pública). 
- En `src/pcobra/standard_library/logica.py` la implementación auxiliar queda en un helper privado llamado `_coalesce_interno` y la API pública sigue siendo `coalescer` que delega en ese helper. 
- Se añadió una prueba `tests/unit/test_api_publica_logica_es.py` que valida por AST la presencia de la API española y la ausencia del alias inglés en los exports, y verifica que la implementación interna en `standard_library` es privada (`_coalesce_interno`).

### Testing
- Se ejecutó inicialmente `pytest` con una importación directa y falló la colección por un `ImportError` debido a una dependencia circular durante la importación del paquete, por lo que la prueba se adaptó a inspección por AST para evitar efectos de importación en tiempo de carga. 
- Se ejecutó `pytest -q tests/unit/test_api_publica_logica_es.py` y las pruebas finales pasaron (`2 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f71231d69083278dfb6607789fa9a3)