### PR TITLE
Refactor: extraer política de saneamiento de símbolos para `usar`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import hashlib
-from dataclasses import dataclass
 from typing import Mapping, Optional
 
 from .lexer import (
@@ -71,6 +70,7 @@ from .cobra_config import (
     limite_cpu_segundos,
 )
 from ..cobra.usar_policy import REPL_COBRA_MODULE_MAP
+from .usar_symbol_policy import sanear_simbolo_para_usar
 from .resource_limits import (
     limitar_memoria_mb as _lim_mem,
     limitar_cpu_segundos as _lim_cpu,
@@ -92,27 +92,6 @@ REPL_USAR_EXTERNAL_MODULE_ERROR = (
 USAR_COLLISION_STRICT_ERROR = "strict_error"
 USAR_COLLISION_WARN_ALIAS_REQUIRED = "warn_alias_required"
 _USAR_COLLISION_POLICIES = frozenset({USAR_COLLISION_STRICT_ERROR, USAR_COLLISION_WARN_ALIAS_REQUIRED})
-_NOMBRES_PUBLICOS_EQUIVALENTE_COBRA = frozenset(
-    {"self", "append", "map", "filter", "unwrap", "expect"}
-)
-_DUNDERS_BLOQUEADOS = frozenset(
-    {"__builtins__", "__loader__", "__package__", "__spec__", "__name__"}
-)
-_NOMBRES_BACKEND_INTERNOS = frozenset(
-    {"sys", "os", "importlib", "pcobra", "cobra", "core"}
-)
-
-
-@dataclass(frozen=True)
-class _ResultadoSaneamientoSimbolo:
-    nombre: str
-    simbolo: object
-    rechazado: bool
-    codigo: str | None = None
-    mensaje: str | None = None
-    warning: bool = False
-
-
 def _ruta_import_permitida(ruta: str) -> bool:
     """Indica si una ruta está autorizada para importarse."""
 
@@ -1900,23 +1879,6 @@ class InterpretadorCobra:
                 simbolos.append((nombre, simbolo))
             return simbolos
 
-        def _sanear_simbolo_para_usar(nombre: str, simbolo: object) -> _ResultadoSaneamientoSimbolo:
-            if nombre.startswith("_"):
-                return _ResultadoSaneamientoSimbolo(nombre, simbolo, True, "private_prefix", "símbolos que inicien con '_' no son exportables")
-            if "__" in nombre or nombre in _DUNDERS_BLOQUEADOS:
-                return _ResultadoSaneamientoSimbolo(nombre, simbolo, True, "dunder_name", "dunders Python no se permiten en usar")
-            if nombre in _NOMBRES_BACKEND_INTERNOS:
-                return _ResultadoSaneamientoSimbolo(nombre, simbolo, True, "backend_internal_name", "nombre interno del backend bloqueado")
-            if isinstance(simbolo, ModuleType):
-                return _ResultadoSaneamientoSimbolo(nombre, simbolo, True, "backend_module_object", "objetos módulo/paquete no son exportables")
-            if nombre in _NOMBRES_PUBLICOS_EQUIVALENTE_COBRA:
-                return _ResultadoSaneamientoSimbolo(nombre, simbolo, True, "cobra_public_equivalent", "nombre público reservado por equivalente Cobra")
-            if not callable(simbolo) and not nombre.isupper():
-                return _ResultadoSaneamientoSimbolo(nombre, simbolo, True, "non_callable_not_public_constant", "solo se permiten no-callables para constantes públicas explícitas")
-            if not callable(simbolo):
-                return _ResultadoSaneamientoSimbolo(nombre, simbolo, False, "public_constant", "constante pública explícita permitida", warning=True)
-            return _ResultadoSaneamientoSimbolo(nombre, simbolo, False)
-
         def _resolver_carga_modulo_usar(nombre_modulo: str):
             """Aplica una única ruta de decisión para módulos de ``usar``."""
             es_repl_estricto = self._repl_usar_alias_map is not None
@@ -1978,7 +1940,7 @@ class InterpretadorCobra:
             reporte_warnings: list[dict[str, str]] = []
             simbolos_saneados: list[tuple[str, object]] = []
             for nombre, simbolo in simbolos_a_inyectar:
-                resultado = _sanear_simbolo_para_usar(nombre, simbolo)
+                resultado = sanear_simbolo_para_usar(nombre, simbolo)
                 if resultado.rechazado:
                     reporte_rechazos.append(
                         {"symbol": nombre, "code": resultado.codigo or "rejected", "message": resultado.mensaje or "símbolo rechazado"}

--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -1,0 +1,86 @@
+"""Política de saneamiento de símbolos para la instrucción ``usar``."""
+
+from dataclasses import dataclass
+from types import ModuleType
+
+NOMBRES_PUBLICOS_EQUIVALENTE_COBRA = frozenset(
+    {"self", "append", "map", "filter", "unwrap", "expect"}
+)
+DUNDERS_BLOQUEADOS = frozenset(
+    {"__builtins__", "__loader__", "__package__", "__spec__", "__name__"}
+)
+NOMBRES_BACKEND_INTERNOS = frozenset(
+    {"sys", "os", "importlib", "pcobra", "cobra", "core"}
+)
+
+
+@dataclass(frozen=True)
+class ResultadoSaneamientoSimboloUsar:
+    nombre: str
+    simbolo: object
+    rechazado: bool
+    codigo: str | None = None
+    mensaje: str | None = None
+    warning: bool = False
+
+
+def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamientoSimboloUsar:
+    """Aplica la política de exportación de símbolos para ``usar``."""
+    if nombre.startswith("_"):
+        return ResultadoSaneamientoSimboloUsar(
+            nombre,
+            simbolo,
+            True,
+            "private_prefix",
+            "símbolos que inicien con '_' no son exportables",
+        )
+    if "__" in nombre or nombre in DUNDERS_BLOQUEADOS:
+        return ResultadoSaneamientoSimboloUsar(
+            nombre,
+            simbolo,
+            True,
+            "dunder_name",
+            "dunders Python no se permiten en usar",
+        )
+    if nombre in NOMBRES_BACKEND_INTERNOS:
+        return ResultadoSaneamientoSimboloUsar(
+            nombre,
+            simbolo,
+            True,
+            "backend_internal_name",
+            "nombre interno del backend bloqueado",
+        )
+    if isinstance(simbolo, ModuleType):
+        return ResultadoSaneamientoSimboloUsar(
+            nombre,
+            simbolo,
+            True,
+            "backend_module_object",
+            "objetos módulo/paquete no son exportables",
+        )
+    if nombre in NOMBRES_PUBLICOS_EQUIVALENTE_COBRA:
+        return ResultadoSaneamientoSimboloUsar(
+            nombre,
+            simbolo,
+            True,
+            "cobra_public_equivalent",
+            "nombre público reservado por equivalente Cobra",
+        )
+    if not callable(simbolo) and not nombre.isupper():
+        return ResultadoSaneamientoSimboloUsar(
+            nombre,
+            simbolo,
+            True,
+            "non_callable_not_public_constant",
+            "solo se permiten no-callables para constantes públicas explícitas",
+        )
+    if not callable(simbolo):
+        return ResultadoSaneamientoSimboloUsar(
+            nombre,
+            simbolo,
+            False,
+            "public_constant",
+            "constante pública explícita permitida",
+            warning=True,
+        )
+    return ResultadoSaneamientoSimboloUsar(nombre, simbolo, False)

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -1,0 +1,28 @@
+import math
+
+from pcobra.core.usar_symbol_policy import sanear_simbolo_para_usar
+
+
+def test_rechaza_nombres_prohibidos_backend():
+    resultado = sanear_simbolo_para_usar("sys", lambda: None)
+    assert resultado.rechazado is True
+    assert resultado.codigo == "backend_internal_name"
+
+
+def test_rechaza_dunders():
+    resultado = sanear_simbolo_para_usar("__algo__", lambda: None)
+    assert resultado.rechazado is True
+    assert resultado.codigo == "private_prefix"
+
+
+def test_rechaza_objetos_modulo():
+    resultado = sanear_simbolo_para_usar("modulo", math)
+    assert resultado.rechazado is True
+    assert resultado.codigo == "backend_module_object"
+
+
+def test_permite_constante_publica_explicita_como_warning():
+    resultado = sanear_simbolo_para_usar("PI", 3.14)
+    assert resultado.rechazado is False
+    assert resultado.warning is True
+    assert resultado.codigo == "public_constant"


### PR DESCRIPTION
### Motivation
- Centralizar la lógica de validación/saneamiento de símbolos usados por la instrucción `usar` para facilitar el mantenimiento y las pruebas.
- Mantener exactamente el comportamiento observable (mismos códigos y mensajes de rechazo/advertencia y misma atomicidad de inyección) mientras se permite reutilizar la política desde diferentes puntos.

### Description
- Se creó `src/pcobra/core/usar_symbol_policy.py` y se movió allí la política de saneamiento como `sanear_simbolo_para_usar` y su dataclass de resultado; se conservaron los códigos y mensajes originales.
- Se eliminaron las constantes y la función interna correspondiente de `InterpretadorCobra.ejecutar_usar` y se importó/llamó `sanear_simbolo_para_usar` desde `src/pcobra/core/interpreter.py` sin alterar la semántica de `ejecutar_usar` (filtrado, detección de colisiones y inyección atómica permanecen igual).
- Se agregaron pruebas unitarias directas en `tests/unit/test_usar_symbol_policy.py` que cubren nombres prohibidos, dunders, objetos módulo y constantes públicas explícitas.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_symbol_policy.py` y todas las pruebas pasaron exitosamente.
- Ejecuté `pytest -q tests/unit/test_usar_symbol_policy.py tests/unit/test_usar_loader_stdlib.py` y apareció un fallo externo no introducido por este cambio: `AttributeError` por ausencia de `USAR_WHITELIST` en `pcobra.cobra.usar_loader`, por lo que la falla no se atribuye a la refactorización.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7137c3cec8327aca81eb52e97f93f)