### PR TITLE
holobit: exponer solo símbolos públicos canónicos en español

### DIFF
--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -108,11 +108,27 @@ def medir(hb: dict[str, Any]) -> dict[str, float | int]:
     return {"dimension": len(valores), "magnitud": float(magnitud)}
 
 
+def crear(valores: Iterable[Any]) -> dict[str, Any]:
+    return crear_holobit(valores)
+
+
+def validar(hb: Any) -> bool:
+    return validar_holobit(hb)
+
+
+def serializar(hb: dict[str, Any]) -> str:
+    return serializar_holobit(hb)
+
+
+def deserializar(payload: str) -> dict[str, Any]:
+    return deserializar_holobit(payload)
+
+
 __all__ = [
-    "crear_holobit",
-    "validar_holobit",
-    "serializar_holobit",
-    "deserializar_holobit",
+    "crear",
+    "validar",
+    "serializar",
+    "deserializar",
     "proyectar",
     "transformar",
     "graficar",

--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -160,10 +160,10 @@ def _assert_contrato_simbolos_saneados(simbolos: set[str]) -> None:
 def _modulo_holobit_publico_stub() -> ModuleType:
     mod = ModuleType("holobit")
     mod.__all__ = [
-        "crear_holobit",
-        "validar_holobit",
-        "serializar_holobit",
-        "deserializar_holobit",
+        "crear",
+        "validar",
+        "serializar",
+        "deserializar",
         "proyectar",
         "transformar",
         "graficar",
@@ -315,8 +315,10 @@ def test_repl_contract_seguridad_usar_holobit_restringe_internals_y_saneamiento(
         assert simbolo in interp.contextos[-1].values
 
     _assert_contrato_simbolos_saneados(simbolos_holobit)
+    assert simbolos_holobit == {"crear", "validar", "serializar", "deserializar", "proyectar", "transformar", "graficar", "combinar", "medir"}
 
     assert "Holobit" not in interp.contextos[-1].values
+    assert "crear_holobit" not in interp.contextos[-1].values
     assert "_to_sdk_holobit" not in interp.contextos[-1].values
     assert "holobit_sdk" not in interp.contextos[-1].values
 
@@ -368,3 +370,32 @@ def test_repl_contract_seguridad_usar_atomico_holobit_y_datos_sin_overwrite(monk
     assert estado_pre_datos == interp.contextos[-1].values
 
     assert interp.obtener_variable("longitud")([]) == -1
+
+
+def test_holobit_corelib_exporta_solo_simbolos_canonicos_publicos():
+    import importlib.util
+    from pathlib import Path
+
+    ruta = Path("src/pcobra/corelibs/holobit.py").resolve()
+    spec = importlib.util.spec_from_file_location("_holobit_corelib_blackbox", ruta)
+    assert spec is not None and spec.loader is not None
+    holobit_corelib = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(holobit_corelib)
+
+    assert set(holobit_corelib.__all__) == {
+        "crear",
+        "validar",
+        "serializar",
+        "deserializar",
+        "proyectar",
+        "transformar",
+        "graficar",
+        "combinar",
+        "medir",
+    }
+    for simbolo in holobit_corelib.__all__:
+        assert callable(getattr(holobit_corelib, simbolo))
+
+    assert not hasattr(holobit_corelib, "__all__") or "Holobit" not in holobit_corelib.__all__
+    assert "holobit_sdk" not in holobit_corelib.__all__
+    assert "_to_sdk_holobit" not in holobit_corelib.__all__


### PR DESCRIPTION
### Motivation
- Alinear el adaptador público de Holobit con el contrato de `usar "holobit"` exponiendo únicamente funciones serializables y amigables para Cobra en español. 
- Evitar la fuga de clases internas, helpers privados o símbolos del SDK/backend en la superficie pública del corelib. 
- Añadir pruebas de caja negra que verifiquen que la carga atómica de `holobit` solo presenta los símbolos canónicos esperados.

### Description
- Modifica `src/pcobra/corelibs/holobit.py` para reemplazar las exportaciones no canónicas por envoltorios en español y actualizar `__all__` a `{"crear","validar","serializar","deserializar","proyectar","transformar","graficar","combinar","medir"}`. 
- Implementa `crear`, `validar`, `serializar` y `deserializar` como wrappers que delegan en las implementaciones internas existentes (`crear_holobit`, `validar_holobit`, `serializar_holobit`, `deserializar_holobit`) sin exportar esos nombres. 
- Asegura que no se exporten clases u objetos de módulo del backend/SDK (`Holobit`, `_to_sdk_holobit`, `holobit_sdk`, etc.) y actualiza los stubs de prueba para reflejar la interfaz pública esperada. 
- Añade una prueba de caja negra en `tests/integration/test_repl_usar_entrypoints_contract.py` que carga el archivo `src/pcobra/corelibs/holobit.py` directamente y verifica la lista exacta de símbolos públicos y que todos son callables.

### Testing
- Ejecuté `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py` para el conjunto afectado. 
- La primera ejecución señaló un problema de importación circular al importar todo el paquete, por lo que la prueba de caja negra carga el archivo del corelib mediante `importlib.util.spec_from_file_location` para comprobar la superficie pública de forma aislada. 
- Resultado final: todas las pruebas del archivo pasaron (`18 passed, 1 warning`) con la verificación de la nueva superficie pública exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7146ce9f083278c320c4b3483dd6d)