### PR TITLE
test: agregar pruebas de arranque para evitar carga legacy y validar política pública de backends

### DIFF
--- a/tests/unit/test_backend_bootstrap_contract.py
+++ b/tests/unit/test_backend_bootstrap_contract.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+
+
+def _run_python_isolated(code: str) -> subprocess.CompletedProcess[str]:
+    bootstrap = (
+        "import os, sys; "
+        "assert 'PYTHONPATH' not in os.environ; "
+        f"sys.path.insert(0, {str(SRC_ROOT)!r}); "
+    )
+    return subprocess.run(
+        [sys.executable, "-I", "-c", bootstrap + code],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_bootstrap_runtime_manager_no_carga_modulos_legacy() -> None:
+    result = _run_python_isolated(
+        "from pcobra.cobra.bindings.runtime_manager import RuntimeManager; "
+        "RuntimeManager(); "
+        "import sys; "
+        "legacy_prefixes = ('core', 'bindings', 'scripts', 'cobra.core', 'core.'); "
+        "assert not any(name == 'core' or name == 'bindings' or name.startswith(legacy_prefixes) for name in sys.modules), "
+        "'RuntimeManager cargó imports legacy durante bootstrap';"
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_bootstrap_backend_pipeline_no_carga_backends_legado() -> None:
+    result = _run_python_isolated(
+        "import pcobra.cobra.build.backend_pipeline as bp; "
+        "bp.resolve_backend_runtime('app.co', {'preferred_backend': 'python'}); "
+        "import sys; "
+        "legacy_modules = ('pcobra.cobra.transpilers.transpiler.to_go', 'pcobra.cobra.transpilers.transpiler.to_cpp', 'pcobra.cobra.transpilers.transpiler.to_java', 'pcobra.cobra.transpilers.transpiler.to_wasm', 'pcobra.cobra.transpilers.transpiler.to_asm'); "
+        "assert not any(name in sys.modules for name in legacy_modules), "
+        "'BackendPipeline cargó transpiladores legacy en flujo estándar';"
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_politica_publica_exacta_en_todos_los_contratos() -> None:
+    from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+    from pcobra.cobra.bindings.contract import OFFICIAL_PUBLIC_LANGUAGES
+    from pcobra.cobra.bindings.contract import OFFICIAL_PUBLIC_ROUTE_MATRIX
+
+    expected = ("python", "javascript", "rust")
+    assert PUBLIC_BACKENDS == expected
+    assert OFFICIAL_PUBLIC_LANGUAGES == expected
+    assert tuple(OFFICIAL_PUBLIC_ROUTE_MATRIX.keys()) == expected


### PR DESCRIPTION
### Motivation
- Auditar puntos de entrada de carga en CLI/runtime para evitar que imports de compatibilidad legacy se ejecuten durante el bootstrap normal.
- Verificar y ejercer el contrato público de backends para asegurar que la política pública sea exactamente `python`, `javascript`, `rust` en todas las superficies relevantes.
- Proteger el flujo de `BackendPipeline/RuntimeManager` frente a regresiones que carguen transpiladores o módulos legacy innecesarios.

### Description
- Agrega el archivo de pruebas `tests/unit/test_backend_bootstrap_contract.py` con tres tests que ejercitan arranques aislados de Python (`-I`) para inspeccionar `sys.modules` tras bootstrap.
- Añade `test_bootstrap_runtime_manager_no_carga_modulos_legacy` que instancia `RuntimeManager()` y asegura que no se hayan cargado módulos legacy (`core`, `bindings`, `scripts`, `cobra.core`, `core.`) en tiempo de import.
- Añade `test_bootstrap_backend_pipeline_no_carga_backends_legado` que importa `pcobra.cobra.build.backend_pipeline` y llama `resolve_backend_runtime(...)` para verificar que los transpiladores legacy (`to_go`, `to_cpp`, `to_java`, `to_wasm`, `to_asm`) no se carguen en el flujo estándar.
- Añade `test_politica_publica_exacta_en_todos_los_contratos` que comprueba de forma estricta que `PUBLIC_BACKENDS`, `OFFICIAL_PUBLIC_LANGUAGES` y las llaves de `OFFICIAL_PUBLIC_ROUTE_MATRIX` sean exactamente `("python", "javascript", "rust")`.
- No se modificó código productivo; sólo se añadió cobertura de pruebas y validaciones de arranque.

### Testing
- Ejecuté `pytest -q tests/unit/test_backend_bootstrap_contract.py` y las 3 pruebas pasaron (3 passed) con una advertencia deprecatoria sobre `core` (DeprecationWarning), y todos los asserts de arranque aislado fueron correctos.
- Ejecuté una corrida combinada que incluyó `tests/unit/test_usar.py` y esa ejecución falló por un `ImportError: attempted relative import beyond top-level package` en `tests/unit/test_usar.py`, fallo independiente de las pruebas añadidas aquí.
- Las pruebas nuevas fueron diseñadas para ejecutarse en un intérprete aislado (`python -I`) con `src/` insertado en `sys.path` para evitar dependencias externas durante el chequeo de bootstrap.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f715837c888327819001bba2013f3f)