### PR TITLE
Unifica la fuente canónica de módulos `usar` y actualiza contrato

### DIFF
--- a/docs/inventario_usar_modulos.md
+++ b/docs/inventario_usar_modulos.md
@@ -2,115 +2,44 @@
 
 Fecha de actualización: 2026-05-03.
 
-## 1) Lista canónica permitida para `usar` (contrato público)
+## 1) Contrato público Cobra-facing
 
-La lista **canónica y permitida** para `usar` en REPL estricto se define en `REPL_COBRA_MODULE_MAP`.
-Cualquier módulo fuera de esta lista se rechaza como import externo no soportado.
+`usar` **solo** resuelve módulos Cobra-facing canónicos. La fuente única del contrato es:
 
-Módulos permitidos:
+- `USAR_COBRA_PUBLIC_MODULES` en `src/pcobra/cobra/usar_loader.py`.
 
-- `archivo`
-- `asincrono`
-- `datos`
-- `decoradores`
-- `fecha`
-- `interfaz`
-- `lista`
-- `logica`
-- `numero`
-- `texto`
-- `util`
+La política de REPL (`REPL_COBRA_MODULE_MAP`) se deriva de esa misma constante en `src/pcobra/cobra/usar_policy.py`, evitando listas divergentes.
 
-## 2) Fuente runtime de resolución de `usar "modulo"`
+Módulos canónicos permitidos (orden contractual exacto):
 
-La resolución en runtime de `usar` ocurre en dos capas:
+1. `numero`
+2. `texto`
+3. `datos`
+4. `logica`
+5. `asincrono`
+6. `sistema`
+7. `archivo`
+8. `tiempo`
+9. `red`
+10. `holobit`
 
-1. **Ruta principal de ejecución**: `InterpretadorCobra.ejecutar_usar` en `src/pcobra/core/interpreter.py`.
-   - Distingue entre REPL estricto y modo normal.
-   - En REPL estricto, sólo acepta alias oficiales definidos en `REPL_COBRA_MODULE_MAP`.
-   - Si el alias existe, carga con `obtener_modulo_cobra_oficial`; si no, rechaza módulo externo.
+## 2) Resolución runtime
 
-2. **Loader de módulos**: `src/pcobra/cobra/usar_loader.py`.
-   - `obtener_modulo_cobra_oficial(nombre)`: intenta resolver desde `corelibs/` y luego `standard_library/`.
-   - `obtener_modulo(nombre, permitir_instalacion=True)`: aplica whitelist, resolver de imports y fallback de import/instalación.
+- `obtener_modulo(nombre, ...)` valida nombre seguro y permite únicamente módulos incluidos en la constante canónica.
+- `obtener_modulo_cobra_oficial(nombre)` resuelve desde `corelibs/` o `standard_library/`.
+- En REPL estricto, cualquier módulo externo se rechaza.
 
-3. **Mapa de alias públicos Cobra (REPL estricto)**:
-   - `src/pcobra/cobra/usar_policy.py` define `REPL_COBRA_MODULE_MAP`.
+## 3) Verificación de consistencia
 
-## 3) Tabla de nombres canónicos (español) y equivalencias internas no expuestas
+- `scripts/validate_runtime_contract.py` valida que la constante canónica mantiene exactamente el contrato esperado.
+- `tests/integration/test_repl_usar_entrypoints_contract.py` verifica que los entrypoints REPL usan la política canónica y que el comportamiento de `usar` mantiene seguridad y atomicidad.
 
-> Política: la **API pública** de `usar` se expresa con nombres canónicos en español.
-> Las rutas internas de implementación (Python/JS/Rust/Holobit SDK) son detalles de sustrato y **no son API pública**.
+## 4) Alcance de API
 
-| Nombre canónico público (`usar`) | Equivalencia interna actual (no expuesta) | Observación |
-|---|---|---|
-| `archivo` | `standard_library/archivo.py` | Exporta `__all__` público.
-| `asincrono` | `standard_library/asincrono.py` | Exporta `__all__` público.
-| `datos` | `standard_library/datos.py` | Exporta `__all__` público.
-| `decoradores` | `standard_library/decoradores.py` | Exporta `__all__` público.
-| `fecha` | `standard_library/fecha.py` | Exporta `__all__` público.
-| `interfaz` | `standard_library/interfaz.py` | Exporta `__all__` público.
-| `lista` | `standard_library/lista.py` | Exporta `__all__` público.
-| `logica` | `standard_library/logica.py` | Exporta `__all__` público.
-| `numero` | `standard_library/numero.py` | Exporta `__all__` público.
-| `texto` | `standard_library/texto.py` | Exporta `__all__` público.
-| `util` | `standard_library/util.py` | Exporta `__all__` público.
+No son API pública de `usar`:
 
-### No API pública (solo sustrato interno)
+- rutas internas de backends,
+- símbolos internos de SDK,
+- aliases legacy fuera del set canónico.
 
-- Backends internos: Python, JavaScript y Rust.
-- Runtime/SDK interno de Holobit (incluyendo `holobit_sdk` interno por backend).
-- Módulos de compatibilidad legacy y rutas de transpilers internos.
-
-Nada de lo anterior debe consumirse como contrato estable desde programas de usuario Cobra; el único contrato de `usar` en REPL estricto es la lista canónica anterior.
-
-## 4) Seguridad de exportaciones y rechazo de imports directos a backend
-
-Para seguridad y estabilidad contractual:
-
-1. **Exportaciones controladas**:
-   - El módulo cargado por `usar` debe exponer `__all__` y símbolos públicos invocables.
-   - Si un módulo externo no define `__all__` adecuado, se rechaza con error explícito.
-
-2. **Rechazo de imports directos backend en REPL estricto**:
-   - `usar "numpy"`, `usar "requests"` y análogos externos son rechazados.
-   - No se permite acceder por namespace tipo `numero.es_finito(...)`; `usar` inyecta símbolos planos.
-
-3. **Carga atómica**:
-   - Ante error de importación/exportación, el contexto de variables no debe contaminarse con símbolos parciales.
-
-## 5) Verificación de consistencia (docs, tests, runtime real)
-
-Estado verificado en esta actualización:
-
-- **Docs**: este inventario alinea el contrato público con la lista canónica de `REPL_COBRA_MODULE_MAP`.
-- **Runtime**: la política efectiva de aliases en REPL estricto depende de `src/pcobra/cobra/usar_policy.py` y la ejecución en `InterpretadorCobra.ejecutar_usar`.
-- **Tests de contrato**: `tests/integration/test_repl_usar_entrypoints_contract.py` cubre:
-  - aceptación de módulos canónicos (`numero`, `texto`),
-  - rechazo de externos (`numpy`, `requests`),
-  - exigencia de `__all__` para exportabilidad,
-  - inmutabilidad/atomicidad del contexto si falla `usar`.
-
-## 6) Matriz por módulo objetivo
-
-Módulos objetivo tomados del mapa oficial `REPL_COBRA_MODULE_MAP`:
-`archivo`, `asincrono`, `datos`, `decoradores`, `fecha`, `interfaz`, `lista`, `logica`, `numero`, `texto`, `util`.
-
-> Criterio de estado:
-> - **implementado**: módulo resoluble y con exportaciones públicas (`__all__`).
-> - **parcial**: resoluble pero con señales de API no canónica relevante.
-> - **ausente**: no resoluble por las rutas oficiales.
-
-| Módulo Cobra público | Backend interno (archivo Python) | Exportaciones públicas actuales | Estado |
-|---|---|---|---|
-| `archivo` | `standard_library/archivo.py` | `leer`, `escribir`, `adjuntar`, `existe` | implementado |
-| `asincrono` | `standard_library/asincrono.py` | `grupo_tareas`, `limitar_tiempo`, `proteger_tarea`, `ejecutar_en_hilo`, `reintentar_async` | parcial |
-| `datos` | `standard_library/datos.py` | `leer_csv`, `leer_json`, `escribir_csv`, `escribir_json`, `leer_excel`, `escribir_excel`, `leer_parquet`, `escribir_parquet`, `leer_feather`, `escribir_feather`, `describir`, `correlacion_pearson`, `correlacion_spearman`, `matriz_covarianza`, `calcular_percentiles`, `resumen_rapido`, `seleccionar_columnas`, `filtrar`, `mutar_columna`, `separar_columna`, `unir_columnas`, `agrupar_y_resumir`, `tabla_cruzada`, `pivotar_ancho`, `pivotar_largo`, `ordenar_tabla`, `combinar_tablas`, `rellenar_nulos`, `desplegar_tabla`, `pivotar_tabla`, `a_listas`, `de_listas` | parcial |
-| `decoradores` | `standard_library/decoradores.py` | `memoizar`, `dataclase`, `temporizar`, `depreciado`, `sincronizar`, `reintentar`, `reintentar_async`, `orden_total`, `despachar_por_tipo` | parcial |
-| `fecha` | `standard_library/fecha.py` | `hoy`, `formatear`, `sumar_dias` | implementado |
-| `interfaz` | `standard_library/interfaz.py` | `mostrar_codigo`, `mostrar_markdown`, `mostrar_json`, `mostrar_arbol`, `preguntar_confirmacion`, `preguntar_password`, `mostrar_tabla`, `mostrar_tabla_paginada`, `mostrar_columnas`, `mostrar_panel`, `grupo_consola`, `estado_temporal`, `barra_progreso`, `limpiar_consola`, `imprimir_aviso`, `iniciar_gui`, `iniciar_gui_idle`, `preguntar_opciones_multiple` | parcial |
-| `lista` | `standard_library/lista.py` | `cabeza`, `cola`, `longitud`, `combinar`, `mapear_seguro`, `mapear_aplanado`, `ventanas`, `chunk`, `tomar_mientras`, `descartar_mientras`, `scanear`, `pares_consecutivos` | parcial |
-| `logica` | `standard_library/logica.py` | `es_verdadero`, `es_falso`, `conjuncion`, `disyuncion`, `negacion`, `entonces`, `si_no`, `coalesce`, `condicional`, `xor`, `nand`, `nor`, `implica`, `equivale`, `xor_multiple`, `todas`, `alguna`, `ninguna`, `solo_uno`, `conteo_verdaderos`, `paridad`, `mayoria`, `exactamente_n`, `tabla_verdad`, `diferencia_simetrica` | parcial |
-| `numero` | `standard_library/numero.py` | `es_finito`, `es_infinito`, `es_nan`, `copiar_signo`, `signo`, `limitar`, `hipotenusa`, `distancia_euclidiana`, `raiz_entera`, `combinaciones`, `permutaciones`, `suma_precisa`, `interpolar`, `envolver_modular`, `varianza`, `varianza_muestral`, `media_geometrica`, `media_armonica`, `percentil`, `cuartiles`, `rango_intercuartil`, `coeficiente_variacion` | parcial |
-| `texto` | `standard_library/texto.py` | `quitar_acentos`, `normalizar_espacios`, `es_palindromo`, `es_anagrama`, `codificar`, `decodificar`, `es_alfabetico`, `es_alfa_numerico`, `es_decimal`, `es_numerico`, `es_identificador`, `es_imprimible`, `es_ascii`, `es_mayusculas`, `es_minusculas`, `es_titulo`, `es_digito`, `es_espacio`, `quitar_prefijo`, `quitar_sufijo`, `a_snake`, `a_camel`, `quitar_envoltura`, `prefijo_comun`, `sufijo_comun`, `dividir_lineas`, `dividir_derecha`, `encontrar`, `encontrar_derecha`, `subcadena_antes`, `subcadena_despues`, `subcadena_antes_ultima`, `subcadena_despues_ultima`, `indice`, `indice_derecha`, `contar_subcadena`, `centrar_texto`, `rellenar_ceros`, `minusculas_casefold`, `intercambiar_mayusculas`, `expandir_tabulaciones`, `particionar`, `particionar_derecha`, `indentar_texto`, `desindentar_texto`, `envolver_texto`, `acortar_texto`, `formatear`, `formatear_mapa`, `tabla_traduccion`, `traducir` | parcial |
-| `util` | `standard_library/util.py` | `es_nulo`, `es_vacio`, `repetir`, `rel` | parcial |
+El contrato estable para usuario final es únicamente la lista canónica Cobra-facing indicada arriba.

--- a/scripts/ci/validate_public_backend_literals.py
+++ b/scripts/ci/validate_public_backend_literals.py
@@ -18,6 +18,9 @@ ALLOWED_FILES = {
 }
 PUBLIC_BACKENDS = ("python", "javascript", "rust")
 
+# Nota: el contrato de `usar` se valida contra su fuente canónica en
+# `scripts/validate_runtime_contract.py` usando `USAR_COBRA_PUBLIC_MODULES`.
+
 
 def _is_allowed_module(rel_path: Path) -> bool:
     if rel_path in ALLOWED_FILES:

--- a/scripts/validate_runtime_contract.py
+++ b/scripts/validate_runtime_contract.py
@@ -24,6 +24,8 @@ from pcobra.cobra.cli.target_policies import (
 from pcobra.cobra.stdlib_contract.validator import validate_contracts
 from pcobra.cobra.stdlib_contract.validator import validate_contracts_against_runtime_matrix
 from pcobra.cobra.stdlib_contract.validator import validate_generated_stdlib_contract_matrix
+from pcobra.cobra.usar_loader import USAR_COBRA_PUBLIC_MODULES
+
 from pcobra.cobra.transpilers.compatibility_matrix import (
     BACKEND_COMPATIBILITY,
     BACKEND_FEATURE_GAPS,
@@ -31,8 +33,28 @@ from pcobra.cobra.transpilers.compatibility_matrix import (
 )
 
 
+
+USAR_COBRA_PUBLIC_MODULES_EXPECTED: tuple[str, ...] = (
+    "numero",
+    "texto",
+    "datos",
+    "logica",
+    "asincrono",
+    "sistema",
+    "archivo",
+    "tiempo",
+    "red",
+    "holobit",
+)
+
 def main() -> int:
     validate_runtime_support_contract()
+
+    if tuple(USAR_COBRA_PUBLIC_MODULES) != USAR_COBRA_PUBLIC_MODULES_EXPECTED:
+        raise RuntimeError(
+            "Contrato usar canónico desalineado: "
+            f"actual={USAR_COBRA_PUBLIC_MODULES} esperado={USAR_COBRA_PUBLIC_MODULES_EXPECTED}"
+        )
     validate_contracts()
     validate_contracts_against_runtime_matrix()
     validate_generated_stdlib_contract_matrix()

--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import sys
 
 # Allowlist canónica de módulos Cobra habilitados para `usar`.
-USAR_COBRA_ALLOWLIST: set[str] = {
+USAR_COBRA_PUBLIC_MODULES: tuple[str, ...] = (
     "numero",
     "texto",
     "datos",
@@ -16,7 +16,9 @@ USAR_COBRA_ALLOWLIST: set[str] = {
     "tiempo",
     "red",
     "holobit",
-}
+)
+
+USAR_COBRA_ALLOWLIST: frozenset[str] = frozenset(USAR_COBRA_PUBLIC_MODULES)
 
 # Regex estricta para mantener la sintaxis `usar "modulo"` acotada a identificadores simples.
 _VALID_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")

--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -2,17 +2,8 @@
 
 from __future__ import annotations
 
+from pcobra.cobra.usar_loader import USAR_COBRA_PUBLIC_MODULES
+
 REPL_COBRA_MODULE_MAP: dict[str, str] = {
-    "archivo": "archivo",
-    "asincrono": "asincrono",
-    "datos": "datos",
-    "decoradores": "decoradores",
-    "fecha": "fecha",
-    "interfaz": "interfaz",
-    "lista": "lista",
-    "logica": "logica",
-    "numero": "numero",
-    "texto": "texto",
-    "tiempo": "tiempo",
-    "util": "util",
+    modulo: modulo for modulo in USAR_COBRA_PUBLIC_MODULES
 }


### PR DESCRIPTION
### Motivation

- Evitar listas duplicadas y divergentes entre el loader y la política REPL para la instrucción `usar` y tener una única fuente de verdad. 
- Asegurar que el contrato público de `usar` incluya exactamente los módulos requeridos en el orden especificado: `numero`, `texto`, `datos`, `logica`, `asincrono`, `sistema`, `archivo`, `tiempo`, `red`, `holobit`.
- Hacer que los scripts de validación consuman la misma fuente canónica para detectar desalineos tempranos.

### Description

- Introduje `USAR_COBRA_PUBLIC_MODULES: tuple[str, ...]` en `src/pcobra/cobra/usar_loader.py` y derivé `USAR_COBRA_ALLOWLIST: frozenset[str]` desde esa constante para uso interno.  
- Cambié `src/pcobra/cobra/usar_policy.py` para construir `REPL_COBRA_MODULE_MAP` a partir de `USAR_COBRA_PUBLIC_MODULES`, eliminando la lista literal duplicada.  
- Añadí una comprobación en `scripts/validate_runtime_contract.py` que importa `USAR_COBRA_PUBLIC_MODULES` y valida que coincida exactamente con el contrato esperado (tupla con los 10 módulos en el orden contractual).  
- Añadí una nota en `scripts/ci/validate_public_backend_literals.py` indicando que el contrato `usar` se valida desde `scripts/validate_runtime_contract.py`.  
- Actualicé `docs/inventario_usar_modulos.md` para documentar que la única fuente canónica es `USAR_COBRA_PUBLIC_MODULES` y listé los módulos exactos en orden contractual.

### Testing

- Ejecuté `python -m pytest -q tests/integration/test_repl_usar_entrypoints_contract.py tests/unit/test_usar_loader_validation.py tests/unit/test_ci_validate_public_backend_literals.py` y los tests seleccionados pasaron (27 passed, 1 warning).  
- Ejecuté `python scripts/validate_runtime_contract.py` y el script falló por una inconsistencia preexistente en la matriz stdlib/runtime (`cobra.web.obtener_url_texto.python`), la cual no fue introducida por este cambio; la nueva comprobación reportó el desalineo al comparar la constante canónica con la matriz esperada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f71756c16883279dfbaaacf6ff14f5)