### PR TITLE
Refuerza saneamiento y manejo de colisiones para `usar`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1982,6 +1982,12 @@ class InterpretadorCobra:
 
             # Fase B: inyectar de forma atómica y sin sobreescritura silenciosa.
             for nombre, simbolo in simbolos_saneados:
+                if contexto_actual.contains(nombre):
+                    self._trace_debug(
+                        "[USAR_COLLISION][WARN] "
+                        f"módulo={nodo.modulo} símbolo={nombre} code=symbol_collision_runtime_recheck"
+                    )
+                    continue
                 contexto_actual.define(nombre, simbolo)
             if reporte_warnings:
                 self._trace_debug(f"[USAR_SANITIZE][WARNINGS] {reporte_warnings}")

--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -4,7 +4,17 @@ from dataclasses import dataclass
 from types import ModuleType
 
 NOMBRES_PUBLICOS_EQUIVALENTE_COBRA = frozenset(
-    {"self", "append", "map", "filter", "unwrap", "expect"}
+    {
+        "self",
+        "append",
+        "map",
+        "filter",
+        "unwrap",
+        "expect",
+        "keys",
+        "values",
+        "len",
+    }
 )
 DUNDERS_BLOQUEADOS = frozenset(
     {"__builtins__", "__loader__", "__package__", "__spec__", "__name__"}
@@ -26,13 +36,13 @@ class ResultadoSaneamientoSimboloUsar:
 
 def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamientoSimboloUsar:
     """Aplica la política de exportación de símbolos para ``usar``."""
-    if nombre.startswith("_"):
+    if isinstance(simbolo, ModuleType):
         return ResultadoSaneamientoSimboloUsar(
             nombre,
             simbolo,
             True,
-            "private_prefix",
-            "símbolos que inicien con '_' no son exportables",
+            "backend_module_object",
+            "objetos módulo/paquete no son exportables",
         )
     if "__" in nombre or nombre in DUNDERS_BLOQUEADOS:
         return ResultadoSaneamientoSimboloUsar(
@@ -42,6 +52,14 @@ def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamien
             "dunder_name",
             "dunders Python no se permiten en usar",
         )
+    if nombre.startswith("_"):
+        return ResultadoSaneamientoSimboloUsar(
+            nombre,
+            simbolo,
+            True,
+            "private_prefix",
+            "símbolos que inicien con '_' no son exportables",
+        )
     if nombre in NOMBRES_BACKEND_INTERNOS:
         return ResultadoSaneamientoSimboloUsar(
             nombre,
@@ -49,14 +67,6 @@ def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamien
             True,
             "backend_internal_name",
             "nombre interno del backend bloqueado",
-        )
-    if isinstance(simbolo, ModuleType):
-        return ResultadoSaneamientoSimboloUsar(
-            nombre,
-            simbolo,
-            True,
-            "backend_module_object",
-            "objetos módulo/paquete no son exportables",
         )
     if nombre in NOMBRES_PUBLICOS_EQUIVALENTE_COBRA:
         return ResultadoSaneamientoSimboloUsar(

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -3,16 +3,33 @@ import math
 from pcobra.core.usar_symbol_policy import sanear_simbolo_para_usar
 
 
+def _callable_dummy():
+    return None
+
+
 def test_rechaza_nombres_prohibidos_backend():
     resultado = sanear_simbolo_para_usar("sys", lambda: None)
     assert resultado.rechazado is True
     assert resultado.codigo == "backend_internal_name"
 
 
+def test_rechaza_privado():
+    resultado = sanear_simbolo_para_usar("_privado", _callable_dummy)
+    assert resultado.rechazado is True
+    assert resultado.codigo == "private_prefix"
+
+
 def test_rechaza_dunders():
     resultado = sanear_simbolo_para_usar("__algo__", lambda: None)
     assert resultado.rechazado is True
-    assert resultado.codigo == "private_prefix"
+    assert resultado.codigo == "dunder_name"
+
+
+def test_rechaza_aliases_publicos_reservados():
+    for nombre in ("append", "map", "filter", "unwrap", "expect", "self", "keys", "values", "len"):
+        resultado = sanear_simbolo_para_usar(nombre, _callable_dummy)
+        assert resultado.rechazado is True
+        assert resultado.codigo == "cobra_public_equivalent"
 
 
 def test_rechaza_objetos_modulo():
@@ -26,3 +43,9 @@ def test_permite_constante_publica_explicita_como_warning():
     assert resultado.rechazado is False
     assert resultado.warning is True
     assert resultado.codigo == "public_constant"
+
+
+def test_rechaza_constante_no_mayuscula():
+    resultado = sanear_simbolo_para_usar("pi", 3.14)
+    assert resultado.rechazado is True
+    assert resultado.codigo == "non_callable_not_public_constant"


### PR DESCRIPTION
### Motivation

- Endurecer la política de exportación de símbolos de la instrucción `usar` para evitar alias problemáticos del backend, fugas de módulos/paquetes y dunders, y prevenir sobreescrituras silenciosas en tiempo de inyección.  

### Description

- Actualiza `src/pcobra/core/usar_symbol_policy.py` para ampliar `NOMBRES_PUBLICOS_EQUIVALENTE_COBRA` con `keys`, `values` y `len`, y para comprobar explícitamente objetos `ModuleType` y nombres que contengan `__`, devolviendo códigos de rechazo adecuados (`cobra_public_equivalent`, `backend_module_object`, `dunder_name`, `private_prefix`, `backend_internal_name`, `non_callable_not_public_constant`, `public_constant`).
- Reordena las comprobaciones en la función `sanear_simbolo_para_usar` para asegurar que los módulos se rechacen antes de otras reglas y mantiene la regla que acepta únicamente callables públicos o constantes en MAYÚSCULAS (estas últimas como `warning`).
- Modifica `src/pcobra/core/interpreter.py` en la fase de inyección para re-verificar colisiones por símbolo antes de `define`: emite una traza de advertencia y omite la definición conflictiva para evitar sobreescritura silenciosa en runtime.  
- Añade/actualiza `tests/unit/test_usar_symbol_policy.py` con casos nuevos que cubren `_privado`, `__dunder__`, aliases reservados (incluyendo `keys/values/len`), objetos módulo, constantes válidas (MAYÚSCULAS) y constantes inválidas (no MAYÚSCULAS).

### Testing

- Ejecuté `pytest -q tests/unit/test_usar_symbol_policy.py`; el primer ciclo falló por una expectativa previa sobre el código de rechazo de dunders, se corrigió la orden de comprobaciones y se re-ejecutó.  
- Resultado final: `pytest -q tests/unit/test_usar_symbol_policy.py` pasó correctamente (7 tests passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f718bee2608327ac56d07537f66139)