### PR TITLE
Expandir utilidades estándar Cobra en corelibs y docs

### DIFF
--- a/docs/standard_library/archivo.md
+++ b/docs/standard_library/archivo.md
@@ -12,3 +12,8 @@ Documentación sincronizada automáticamente desde `src/pcobra/standard_library/
 | `existe` |
 | `leer` |
 <!-- END: AUTO-STDLIB-FUNCTIONS -->
+
+
+## Nuevas utilidades
+- `anexar(ruta, datos)`: agrega texto al final de un archivo seguro.
+- `leer_lineas(ruta, mantener_saltos=False)`: lee el archivo y separa por líneas.

--- a/docs/standard_library/asincrono.md
+++ b/docs/standard_library/asincrono.md
@@ -13,3 +13,5 @@ Documentación sincronizada automáticamente desde `src/pcobra/standard_library/
 | `proteger_tarea` |
 | `reintentar_async` |
 <!-- END: AUTO-STDLIB-FUNCTIONS -->
+
+- `dormir_async(segundos)` expone pausa cooperativa equivalente a `await sleep`.

--- a/docs/standard_library/datos.md
+++ b/docs/standard_library/datos.md
@@ -151,3 +151,6 @@ En el objetivo JavaScript se ofrece una implementación parcial que mantiene las
 | `tabla_cruzada` |
 | `unir_columnas` |
 <!-- END: AUTO-STDLIB-FUNCTIONS -->
+
+
+El módulo `datos` sigue funcionando como fachada canónica sobre `standard_library.datos`; no introduce backend paralelo y reexporta su API existente.

--- a/docs/standard_library/holobit.md
+++ b/docs/standard_library/holobit.md
@@ -44,3 +44,5 @@ var r = transformar(d, "rotar", "z", 90)
 var p = proyectar(r, "2D")
 imprimir(p)
 ```
+
+- `escalar(hb, factor)` multiplica cada componente del holobit por un factor numérico.

--- a/docs/standard_library/logica.md
+++ b/docs/standard_library/logica.md
@@ -59,3 +59,5 @@ para facilitar la depuración.
 | `xor` |
 | `xor_multiple` |
 <!-- END: AUTO-STDLIB-FUNCTIONS -->
+
+- `si_condicional(condicion, cuando_verdadero, cuando_falso)` ofrece el ternario explícito en español.

--- a/docs/standard_library/numero.md
+++ b/docs/standard_library/numero.md
@@ -66,3 +66,5 @@ explícitos tanto en Python como en los demás backends soportados.
 | `varianza` |
 | `varianza_muestral` |
 <!-- END: AUTO-STDLIB-FUNCTIONS -->
+
+- `aleatorio_entero(minimo, maximo, semilla=None)` genera enteros inclusivos estilo `randint` con nombre Cobra.

--- a/docs/standard_library/red.md
+++ b/docs/standard_library/red.md
@@ -1,0 +1,4 @@
+# `standard_library.red`
+
+Utilidades seguras de red HTTPS con lista blanca de hosts (`COBRA_HOST_WHITELIST`).
+Incluye `obtener_url`, `enviar_post`, variantes async, `descargar_archivo` y `obtener_json`.

--- a/docs/standard_library/sistema.md
+++ b/docs/standard_library/sistema.md
@@ -1,0 +1,9 @@
+# `standard_library.sistema`
+
+Funciones de sistema seguras:
+- `obtener_os`
+- `ejecutar` / `ejecutar_async`
+- `ejecutar_stream`
+- `obtener_env`
+- `listar_dir`
+- `directorio_actual`

--- a/docs/standard_library/texto.md
+++ b/docs/standard_library/texto.md
@@ -156,3 +156,5 @@ Todas estas funciones respetan Unicode y aprovechan los normalizadores base disp
 | `tabla_traduccion` |
 | `traducir` |
 <!-- END: AUTO-STDLIB-FUNCTIONS -->
+
+- `lineas_no_vacias(texto)` devuelve solo líneas con contenido útil tras `strip`.

--- a/docs/standard_library/tiempo.md
+++ b/docs/standard_library/tiempo.md
@@ -1,0 +1,8 @@
+# `standard_library.tiempo`
+
+API temporal en español:
+- `ahora()`
+- `formatear(fecha, formato)`
+- `dormir(segundos)`
+- `epoch(fecha=None)`
+- `desde_epoch(segundos)`

--- a/src/pcobra/corelibs/archivo.py
+++ b/src/pcobra/corelibs/archivo.py
@@ -92,3 +92,19 @@ def eliminar(ruta: PathLike) -> None:
         # Compatibilidad con versiones de Python anteriores a 3.8.
         if ruta_segura.exists():
             ruta_segura.unlink()
+
+
+
+def anexar(ruta: PathLike, datos: str) -> None:
+    """Agrega ``datos`` al final del archivo respetando el sandbox de rutas."""
+
+    ruta_segura = _resolver_ruta(ruta)
+    with ruta_segura.open("a", encoding="utf-8") as f:
+        f.write(datos)
+
+
+def leer_lineas(ruta: PathLike, *, mantener_saltos: bool = False) -> list[str]:
+    """Lee un archivo y devuelve sus líneas."""
+
+    contenido = leer(ruta)
+    return contenido.splitlines(keepends=mantener_saltos)

--- a/src/pcobra/corelibs/asincrono.py
+++ b/src/pcobra/corelibs/asincrono.py
@@ -660,3 +660,10 @@ async def recolectar_resultados(
         raise
     finally:
         await asyncio.gather(*tareas, return_exceptions=True)
+
+
+
+async def dormir_async(segundos: float) -> None:
+    """Suspende la corrutina actual durante ``segundos``."""
+
+    await asyncio.sleep(segundos)

--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -124,6 +124,15 @@ def deserializar(payload: str) -> dict[str, Any]:
     return deserializar_holobit(payload)
 
 
+def escalar(hb: dict[str, Any], factor: float) -> dict[str, Any]:
+    """Multiplica cada componente del holobit por ``factor``."""
+
+    interno = _desde_estructura_cobra(hb)
+    if not _es_numero(factor):
+        raise TypeError("factor debe ser numérico")
+    return crear_holobit([valor * float(factor) for valor in interno.valores])
+
+
 __all__ = [
     "crear",
     "validar",
@@ -134,4 +143,5 @@ __all__ = [
     "graficar",
     "combinar",
     "medir",
+    "escalar",
 ]

--- a/src/pcobra/corelibs/logica.py
+++ b/src/pcobra/corelibs/logica.py
@@ -489,4 +489,12 @@ __all__ = [
     "exactamente_n",
     "tabla_verdad",
     "diferencia_simetrica",
+    "si_condicional",
 ]
+
+
+
+def si_condicional(condicion: bool, cuando_verdadero: T, cuando_falso: T) -> T:
+    """Retorna ``cuando_verdadero`` o ``cuando_falso`` según ``condicion``."""
+
+    return cuando_verdadero if _asegurar_booleano(condicion, "condicion") else cuando_falso

--- a/src/pcobra/corelibs/numero.py
+++ b/src/pcobra/corelibs/numero.py
@@ -802,3 +802,11 @@ def coeficiente_variacion(valores, *, muestral: bool = False) -> float:
     else:
         dispersion = pstdev(datos)
     return dispersion / abs(media)
+
+
+
+def aleatorio_entero(minimo: int, maximo: int, semilla: int | None = None) -> int:
+    """Devuelve un entero aleatorio inclusivo entre ``minimo`` y ``maximo``."""
+
+    generador = random.Random(semilla) if semilla is not None else random
+    return generador.randint(minimo, maximo)

--- a/src/pcobra/corelibs/red.py
+++ b/src/pcobra/corelibs/red.py
@@ -276,3 +276,16 @@ async def obtener_url_texto(url: str, permitir_redirecciones: bool = False) -> s
         return await obtener_url_async(url, permitir_redirecciones=permitir_redirecciones)
     except Exception as exc:
         raise _error_red("obtener_url_texto", exc) from None
+
+
+
+def obtener_json(url: str, permitir_redirecciones: bool = False) -> dict[str, Any] | list[Any]:
+    """Obtiene una URL HTTPS y la interpreta como JSON."""
+
+    import json
+
+    cuerpo = obtener_url(url, permitir_redirecciones=permitir_redirecciones)
+    datos = json.loads(cuerpo)
+    if not isinstance(datos, (dict, list)):
+        raise TypeError("La respuesta JSON debe ser un objeto o una lista")
+    return datos

--- a/src/pcobra/corelibs/sistema.py
+++ b/src/pcobra/corelibs/sistema.py
@@ -340,3 +340,10 @@ async def ejecutar_comando_async(
         return await ejecutar_async(comando, permitidos=permitidos, timeout=timeout)
     except Exception as exc:
         raise _error_sistema("ejecutar_comando_async", exc) from None
+
+
+
+def directorio_actual() -> str:
+    """Devuelve la ruta del directorio de trabajo actual."""
+
+    return os.getcwd()

--- a/src/pcobra/corelibs/texto.py
+++ b/src/pcobra/corelibs/texto.py
@@ -1033,3 +1033,10 @@ def es_digito(texto: str) -> bool:
     """Reproduce :meth:`str.isdigit` de Python aceptando dígitos Unicode."""
 
     return texto.isdigit()
+
+
+
+def lineas_no_vacias(texto: str) -> list[str]:
+    """Devuelve líneas no vacías tras recortar espacios extremos."""
+
+    return [linea.strip() for linea in texto.splitlines() if linea.strip()]

--- a/src/pcobra/corelibs/tiempo.py
+++ b/src/pcobra/corelibs/tiempo.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from pcobra.standard_library.fecha import formatear as _formatear_fecha
 from pcobra.standard_library.fecha import hoy as _hoy
 
-__all__ = ["ahora", "formatear", "dormir"]
+__all__ = ["ahora", "formatear", "dormir", "epoch", "desde_epoch"]
 
 
 def ahora() -> datetime:
@@ -31,3 +31,16 @@ def dormir(segundos: float) -> None:
     """Detiene la ejecución durante *segundos*."""
 
     time.sleep(segundos)
+
+
+
+def epoch(fecha: datetime | None = None) -> float:
+    """Convierte una fecha a timestamp Unix en segundos."""
+
+    return (fecha or ahora()).timestamp()
+
+
+def desde_epoch(segundos: float) -> datetime:
+    """Convierte segundos Unix a ``datetime`` local."""
+
+    return datetime.fromtimestamp(segundos)


### PR DESCRIPTION
### Motivation
- Auditar y completar las utilidades faltantes en los módulos de `src/pcobra/corelibs` para ofrecer APIs en español inspiradas en capacidades estándar sin introducir infraestructura paralela.
- Reusar los envoltorios existentes en `src/pcobra/standard_library/` y mantener la semántica runtime y el contrato CLI sin tocar Lexer/Parser.

### Description
- Añadidas utilidades en `corelibs`: `archivo.anexar`, `archivo.leer_lineas`, `tiempo.epoch`, `tiempo.desde_epoch` (y actualización de `__all__`), `sistema.directorio_actual`, `red.obtener_json`, `asincrono.dormir_async`, `logica.si_condicional`, `numero.aleatorio_entero`, `texto.lineas_no_vacias`, y `holobit.escalar`.
- `datos.py` se mantiene como fachada canónica que reexporta `pcobra.standard_library.datos` sin crear un backend paralelo.
- Actualizados y añadidos documentos en `docs/standard_library/*` para reflejar las nuevas APIs y se crearon páginas para `red`, `sistema` y `tiempo`.
- Cambios implementados preservan validaciones y tipos existentes y evitan modificaciones en lexer/parser/CLI.

### Testing
- Ejecutado `python -m py_compile src/pcobra/corelibs/{numero.py,texto.py,datos.py,logica.py,asincrono.py,sistema.py,archivo.py,tiempo.py,red.py,holobit.py}` y la comprobación de sintaxis completó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f719cf4e20832791e3bd7c80ea8ef1)