### PR TITLE
Estructura y refuerza política de símbolos exportables para `usar`

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -34,56 +34,68 @@ class ResultadoSaneamientoSimboloUsar:
     warning: bool = False
 
 
+def _rechazar(nombre: str, simbolo: object, codigo: str, mensaje: str) -> ResultadoSaneamientoSimboloUsar:
+    return ResultadoSaneamientoSimboloUsar(nombre, simbolo, True, codigo, mensaje)
+
+
 def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamientoSimboloUsar:
     """Aplica la política de exportación de símbolos para ``usar``."""
-    if isinstance(simbolo, ModuleType):
-        return ResultadoSaneamientoSimboloUsar(
-            nombre,
-            simbolo,
-            True,
-            "backend_module_object",
-            "objetos módulo/paquete no son exportables",
-        )
-    if "__" in nombre or nombre in DUNDERS_BLOQUEADOS:
-        return ResultadoSaneamientoSimboloUsar(
-            nombre,
-            simbolo,
-            True,
-            "dunder_name",
-            "dunders Python no se permiten en usar",
-        )
     if nombre.startswith("_"):
-        return ResultadoSaneamientoSimboloUsar(
+        return _rechazar(
             nombre,
             simbolo,
-            True,
             "private_prefix",
             "símbolos que inicien con '_' no son exportables",
         )
-    if nombre in NOMBRES_BACKEND_INTERNOS:
-        return ResultadoSaneamientoSimboloUsar(
+
+    if "__" in nombre:
+        return _rechazar(
             nombre,
             simbolo,
-            True,
+            "dunder_pattern",
+            "nombres con '__' no se permiten en usar",
+        )
+
+    if nombre in DUNDERS_BLOQUEADOS:
+        return _rechazar(
+            nombre,
+            simbolo,
+            "dunder_name",
+            "dunders Python conocidos no se permiten en usar",
+        )
+
+    if isinstance(simbolo, ModuleType):
+        return _rechazar(
+            nombre,
+            simbolo,
+            "backend_module_object",
+            "objetos módulo/paquete no son exportables",
+        )
+
+    if nombre in NOMBRES_BACKEND_INTERNOS:
+        return _rechazar(
+            nombre,
+            simbolo,
             "backend_internal_name",
             "nombre interno del backend bloqueado",
         )
+
     if nombre in NOMBRES_PUBLICOS_EQUIVALENTE_COBRA:
-        return ResultadoSaneamientoSimboloUsar(
+        return _rechazar(
             nombre,
             simbolo,
-            True,
             "cobra_public_equivalent",
             "nombre público reservado por equivalente Cobra",
         )
+
     if not callable(simbolo) and not nombre.isupper():
-        return ResultadoSaneamientoSimboloUsar(
+        return _rechazar(
             nombre,
             simbolo,
-            True,
             "non_callable_not_public_constant",
             "solo se permiten no-callables para constantes públicas explícitas",
         )
+
     if not callable(simbolo):
         return ResultadoSaneamientoSimboloUsar(
             nombre,
@@ -93,4 +105,5 @@ def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamien
             "constante pública explícita permitida",
             warning=True,
         )
-    return ResultadoSaneamientoSimboloUsar(nombre, simbolo, False)
+
+    return ResultadoSaneamientoSimboloUsar(nombre, simbolo, False, "ok", "símbolo exportable")


### PR DESCRIPTION
### Motivation
- Unificar y hacer explícita la política de qué símbolos pueden exportarse desde la instrucción `usar` para evitar exposiciones accidentales del backend y nombres problemáticos.
- Permitir al runtime reportar rechazos con contexto uniforme mediante un resultado estructurado (`codigo` + `mensaje`).

### Description
- Añadí el helper `_rechazar(...)` y consolidé todas las validaciones en `sanear_simbolo_para_usar` para devolver resultados estructurados coherentes. 
- Se aplican rechazos explícitos y ordenados para: nombres que empiecen por `_`, nombres que contengan `__`, dunders Python conocidos, objetos tipo `ModuleType`, nombres internos del backend (`sys`, `os`, `importlib`, `pcobra`, `cobra`, `core`) y aliases públicos prohibidos (`self`, `append`, `map`, `filter`, `unwrap`, `expect`, `keys`, `values`, `len`).
- Mantengo la regla de que los objetos no-callables solo se permiten si el nombre es una constante pública explícita (`nombre.isupper()`), devolviendo `warning=True` y `codigo="public_constant"` en ese caso. 
- Normalicé los casos permitidos para incluir también `codigo` y `mensaje` (por ejemplo `"ok"` / `"símbolo exportable"`) para que el runtime pueda agregar contexto de módulo de forma uniforme.

### Testing
- Ejecuté `python -m compileall src/pcobra/core/usar_symbol_policy.py` y la compilación fue satisfactoria. 
- Verifiqué los cambios en el fichero y el diff para asegurar que la lógica fue reintegrada en un único flujo de validación y que no se introdujeron nuevos nombres de sintaxis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f722250dc483279e2dbf422859f738)