### PR TITLE
Fortalizar binding de `usar` y mejorar diagnósticos de colisiones y saneamiento

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1892,7 +1892,7 @@ class InterpretadorCobra:
             return simbolos
 
         def _resolver_carga_modulo_usar(nombre_modulo: str):
-            """Aplica una única ruta de decisión para módulos de ``usar``."""
+            """Aplica una única ruta de decisión para módulos de ``usar`` usando ``obtener_modulo`` permitido."""
             es_repl_estricto = self._repl_usar_alias_map is not None
             mapa_repl = self._repl_usar_alias_map or REPL_COBRA_MODULE_MAP
             modulo_canonico = mapa_repl.get(nombre_modulo)
@@ -1967,8 +1967,10 @@ class InterpretadorCobra:
                 simbolos_saneados.append((nombre, simbolo))
 
             if reporte_rechazos:
+                simbolos_rechazados = [item["symbol"] for item in reporte_rechazos]
                 raise ImportError(
-                    f"rechazos de saneamiento en usar '{nodo.modulo}': {reporte_rechazos}"
+                    "rechazos de saneamiento en usar "
+                    f"'{nodo.modulo}' para símbolos {simbolos_rechazados}: {reporte_rechazos}"
                 )
 
             # Fase A: detectar colisiones de forma completa antes de definir.
@@ -1978,10 +1980,12 @@ class InterpretadorCobra:
             if conflictos:
                 conflicto = conflictos[0]
                 if self._usar_collision_policy == USAR_COLLISION_WARN_ALIAS_REQUIRED:
-                    self._trace_debug(
-                        "[USAR_COLLISION][WARN] "
+                    diagnostico = (
+                        "[USAR_COLLISION][WARN_ALIAS_REQUIRED] "
                         f"módulo={nodo.modulo} conflictos={conflictos} policy={self._usar_collision_policy}"
                     )
+                    logging.warning(diagnostico)
+                    self._trace_debug(diagnostico)
                     raise NameError(
                         "No se puede usar el módulo "
                         f"'{nodo.modulo}': conflicto={conflictos}. "
@@ -1995,11 +1999,19 @@ class InterpretadorCobra:
             # Fase B: inyectar de forma atómica y sin sobreescritura silenciosa.
             for nombre, simbolo in simbolos_saneados:
                 if contexto_actual.contains(nombre):
+                    detalle = {
+                        "symbol": nombre,
+                        "code": "symbol_collision_runtime_recheck",
+                        "message": "símbolo ya existe en contexto actual",
+                    }
                     self._trace_debug(
-                        "[USAR_COLLISION][WARN] "
+                        "[USAR_COLLISION][ERROR] "
                         f"módulo={nodo.modulo} símbolo={nombre} code=symbol_collision_runtime_recheck"
                     )
-                    continue
+                    raise NameError(
+                        "No se puede usar el módulo "
+                        f"'{nodo.modulo}': colisión estructurada={detalle}"
+                    )
                 contexto_actual.define(nombre, simbolo)
             if reporte_warnings:
                 self._trace_debug(f"[USAR_SANITIZE][WARNINGS] {reporte_warnings}")


### PR DESCRIPTION
### Motivation
- Asegurar que `ejecutar_usar` siga el pipeline requerido: resolver módulo permitido (`obtener_modulo`/oficial), determinar exportables públicos (`__all__` cuando aplique), sanear cada símbolo con `sanear_simbolo_para_usar` e inyectar solo símbolos aprobados. 
- Evitar sobreescritura silenciosa de símbolos en tiempo de ejecución y proporcionar diagnósticos claros cuando la política de colisiones exija alias o cuando ocurra rechazo en el saneamiento. 
- Hacer los errores de rechazo de saneamiento explicativos y útiles para depuración mostrando la lista de símbolos rechazados. 
- Restringir cambios únicamente al runtime binding en `src/pcobra/core/interpreter.py` sin tocar el Parser/Lexer.

### Description
- Actualiza el helper de carga para `usar` para dejar explícita la decisión de resolución de módulo usando `obtener_modulo`/`obtener_modulo_cobra_oficial`. 
- Al recopilar rechazos de `sanear_simbolo_para_usar`, se construye `simbolos_rechazados` y la excepción `ImportError` ahora incluye la lista de símbolos rechazados además del detalle estructurado. 
- Mantiene la política estricta por defecto y, para la política `USAR_COLLISION_WARN_ALIAS_REQUIRED`, añade un `logging.warning(...)` y traza debug antes de lanzar `NameError` explicativo que solicita alias explícito. 
- Elimina la ruta de sobreescritura silenciosa en la revalidación runtime convirtiendo la comprobación de carrera en `Fase B` en un fallo explícito con `NameError` (antes se hacía `continue`).

### Testing
- Se ejecutó `python -m py_compile src/pcobra/core/interpreter.py` y compiló correctamente. 
- Se creó el commit con los cambios aplicados para revisión automática (sin pruebas unitarias adicionales ejecutadas en este PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f723577b008327bfb5bff67628099e)