### PR TITLE
Endurecer `usar_loader` para imports canónicos y bloqueo explícito

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -20,6 +20,14 @@ USAR_COBRA_PUBLIC_MODULES: tuple[str, ...] = (
 
 USAR_COBRA_ALLOWLIST: frozenset[str] = frozenset(USAR_COBRA_PUBLIC_MODULES)
 
+# Módulos no canónicos conocidos que deben rechazarse de forma explícita.
+_USAR_NON_CANONICAL_MODULES: frozenset[str] = frozenset({
+    "numpy",
+    "node-fetch",
+    "serde",
+    "holobit_sdk",
+})
+
 # Regex estricta para mantener la sintaxis `usar "modulo"` acotada a identificadores simples.
 _VALID_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
@@ -112,6 +120,13 @@ def obtener_modulo(nombre: str, *, permitir_instalacion: bool = True):
 
     _ = permitir_instalacion  # compat: ya no se usa instalación dinámica para `usar`.
     nombre = _validar_nombre(nombre)
+
+    if nombre in _USAR_NON_CANONICAL_MODULES:
+        raise PermissionError(
+            f"Importación no permitida en 'usar': '{nombre}'. "
+            "Es un módulo no canónico y no forma parte de la API pública. "
+            f"Módulos permitidos: {', '.join(sorted(USAR_COBRA_ALLOWLIST))}."
+        )
 
     if nombre not in USAR_COBRA_ALLOWLIST:
         raise PermissionError(


### PR DESCRIPTION
### Motivation
- Forzar que la superficie pública de `usar` solo permita los módulos canónicos listados en `USAR_COBRA_PUBLIC_MODULES` y evitar ambigüedades de resolución.
- Reforzar la seguridad y semántica mediante validación estricta de nombres y bloqueo de rutas/caracteres peligrosos y hints internos.
- Rechazar explícitamente módulos no canónicos y potencialmente peligrosos (`numpy`, `node-fetch`, `serde`, `holobit_sdk`) para evitar bypass desde `site-packages`.

### Description
- Se preserva `USAR_COBRA_PUBLIC_MODULES` como la fuente canónica de módulos para `usar` y se mantiene la allowlist en `USAR_COBRA_ALLOWLIST`.
- Se agregó `_USAR_NON_CANONICAL_MODULES` con `{"numpy", "node-fetch", "serde", "holobit_sdk"}` y una verificación temprana que lanza `PermissionError` con mensaje consistente cuando se intenta `usar` uno de ellos.
- Mantengo la validación estricta de nombre mediante la regex `_VALID_NAME_RE`, bloqueo de caracteres/rutas (`/`, `\\`, `.`, `-`, `:`, `@`) y bloqueo por hints internos (`pcobra`, `corelibs`, `standard_library`, etc.).
- La resolución de módulos oficiales sigue cargando únicamente desde `corelibs` y `standard_library` a través de `obtener_modulo_cobra_oficial` sin instalación dinámica.

### Testing
- Ejecutado `pytest -q tests/unit/test_usar_loader_validation.py tests/unit/test_usar_loader_site_packages.py` inicialmente y se reprodujeron fallos de contrato de mensaje que guiaron el ajuste del texto de error (5 fallos en la primera ejecución).
- Tras ajustar el mensaje y agregar la lista de módulos no canónicos la misma orden `pytest -q tests/unit/test_usar_loader_validation.py tests/unit/test_usar_loader_site_packages.py` pasó con `15 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f724392df48327856d2b074b568ba7)