### PR TITLE
Reforzar contrato canónico de módulos `usar` en REPL

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -2,8 +2,63 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from pcobra.cobra.usar_loader import USAR_COBRA_PUBLIC_MODULES
 
-REPL_COBRA_MODULE_MAP: dict[str, str] = {
-    modulo: modulo for modulo in USAR_COBRA_PUBLIC_MODULES
+REPL_COBRA_MODULE_MAP: dict[str, str] = {modulo: modulo for modulo in USAR_COBRA_PUBLIC_MODULES}
+
+# Fuente única de verdad: alias canónico `usar` -> ruta interna oficial.
+REPL_COBRA_MODULE_INTERNAL_PATH_MAP: dict[str, str] = {
+    "numero": "src/pcobra/corelibs/numero.py",
+    "texto": "src/pcobra/corelibs/texto.py",
+    "datos": "src/pcobra/corelibs/datos.py",
+    "logica": "src/pcobra/corelibs/logica.py",
+    "asincrono": "src/pcobra/corelibs/asincrono.py",
+    "sistema": "src/pcobra/corelibs/sistema.py",
+    "archivo": "src/pcobra/corelibs/archivo.py",
+    "tiempo": "src/pcobra/corelibs/tiempo.py",
+    "red": "src/pcobra/corelibs/red.py",
+    "holobit": "src/pcobra/corelibs/holobit.py",
 }
+
+
+def validar_contrato_modulos_canonicos_usar() -> None:
+    """Valida en arranque el contrato canónico de módulos para `usar` en REPL."""
+
+    canonicos = tuple(USAR_COBRA_PUBLIC_MODULES)
+    if tuple(REPL_COBRA_MODULE_MAP.keys()) != canonicos:
+        raise RuntimeError(
+            "[STARTUP CONTRACT] REPL_COBRA_MODULE_MAP debe incluir exactamente "
+            f"los módulos canónicos soportados y en el orden oficial: {canonicos}."
+        )
+    if tuple(REPL_COBRA_MODULE_MAP.values()) != canonicos:
+        raise RuntimeError(
+            "[STARTUP CONTRACT] REPL_COBRA_MODULE_MAP debe resolver cada alias "
+            "canónico a su módulo Cobra-facing oficial."
+        )
+
+    faltantes = [m for m in canonicos if m not in REPL_COBRA_MODULE_INTERNAL_PATH_MAP]
+    sobrantes = [m for m in REPL_COBRA_MODULE_INTERNAL_PATH_MAP if m not in canonicos]
+    if faltantes or sobrantes:
+        raise RuntimeError(
+            "[STARTUP CONTRACT] REPL_COBRA_MODULE_INTERNAL_PATH_MAP fuera de contrato. "
+            f"faltantes={faltantes} sobrantes={sobrantes}."
+        )
+
+    repo_root = Path(__file__).resolve().parents[3]
+    for alias, rel_path in REPL_COBRA_MODULE_INTERNAL_PATH_MAP.items():
+        if not rel_path.startswith(("src/pcobra/corelibs/", "src/pcobra/standard_library/")):
+            raise RuntimeError(
+                "[STARTUP CONTRACT] Las rutas internas oficiales de `usar` deben "
+                f"estar en corelibs/standard_library; alias={alias} ruta={rel_path}."
+            )
+        path = repo_root / rel_path
+        if not path.exists():
+            raise RuntimeError(
+                "[STARTUP CONTRACT] Falta módulo canónico obligatorio de `usar`: "
+                f"alias={alias} ruta={rel_path}."
+            )
+
+
+validar_contrato_modulos_canonicos_usar()

--- a/tests/unit/test_usar_policy_contract.py
+++ b/tests/unit/test_usar_policy_contract.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pcobra.cobra.usar_loader import USAR_COBRA_PUBLIC_MODULES, obtener_modulo_cobra_oficial
+from pcobra.cobra.usar_policy import (
+    REPL_COBRA_MODULE_INTERNAL_PATH_MAP,
+    REPL_COBRA_MODULE_MAP,
+)
+
+
+def test_repl_module_map_contiene_exactamente_modulos_canonicos() -> None:
+    canonicos = tuple(USAR_COBRA_PUBLIC_MODULES)
+    assert tuple(REPL_COBRA_MODULE_MAP.keys()) == canonicos
+    assert tuple(REPL_COBRA_MODULE_MAP.values()) == canonicos
+    assert set(REPL_COBRA_MODULE_INTERNAL_PATH_MAP) == set(canonicos)
+
+
+def test_modulos_oficiales_se_resuelven_a_rutas_internas() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    for alias, canonical in REPL_COBRA_MODULE_MAP.items():
+        modulo = obtener_modulo_cobra_oficial(canonical)
+        modulo_path = Path(modulo.__file__).resolve()
+
+        expected_rel_path = REPL_COBRA_MODULE_INTERNAL_PATH_MAP[alias]
+        expected_path = (repo_root / expected_rel_path).resolve()
+        assert modulo_path == expected_path, (
+            f"alias={alias} canonical={canonical} debe resolver a {expected_rel_path}, "
+            f"obtuvo {modulo_path}"
+        )
+


### PR DESCRIPTION
### Motivation
- Asegurar que la instrucción `usar` solo resuelva a módulos Cobra-facing oficiales y que exista una fuente única de verdad que documente qué alias canónico apunta a qué módulo interno.
- Detectar en arranque cualquier deriva o fallo en el mapa de módulos canónicos para evitar que REPL permita módulos externos o rutas internas equivocadas.

### Description
- Añadí `REPL_COBRA_MODULE_INTERNAL_PATH_MAP` en `src/pcobra/cobra/usar_policy.py` que documenta explícitamente el alias canónico -> ruta interna (`corelibs`/`standard_library`).
- Implementé `validar_contrato_modulos_canonicos_usar()` y la ejecuto en import-time para que falle el arranque si el mapa canónico o las rutas internas no cumplen el contrato.
- Mantengo `REPL_COBRA_MODULE_MAP` alineado con `USAR_COBRA_PUBLIC_MODULES` y valido que las claves/valores coincidan exactamente con los módulos soportados.
- Añadí test de contrato `tests/unit/test_usar_policy_contract.py` que verifica la exactitud del mapa y que cada módulo oficial se resuelva a la ruta interna esperada.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_policy_contract.py` y el test añadido pasó correctamente.
- Ejecuté `pytest -q tests/unit/test_usar_policy_contract.py tests/unit/test_repl_official_stdlib_exports_policy.py` y la ejecución inicial mostró fallos en un test preexistente (`test_exports_de_contrato_stdlib_estan_alineados`) relacionado con `pcobra.standard_library.datos`, independiente de esta modificación.
- Después de alinear las rutas internas hacia `corelibs` corregí la expectativa y volví a ejecutar `pytest` sobre el test nuevo, confirmando que las comprobaciones de contrato de `usar` pasan (tests nuevos verdes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f732ca95c0832798c502bf63301e16)