### PR TITLE
Endurecer `usar` para aceptar solo catálogo canónico Cobra

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1838,14 +1838,13 @@ class InterpretadorCobra:
           - Módulos oficiales: exportan callables públicos (no privados).
             ``__all__`` se usa como filtro preferente si existe, pero su
             ausencia no bloquea la carga de módulos oficiales.
-          - Módulos externos: se permiten solo si pueden exportarse de forma
-            completa según la política de ``usar`` (API pública explícita por
-            ``__all__`` y símbolos callables). Si no cumplen, se rechazan.
+          - Módulos externos: se rechazan siempre; ``usar`` solo acepta alias
+            canónicos del catálogo oficial Cobra.
         """
         from pathlib import Path
         from types import ModuleType
 
-        from .usar_loader import obtener_modulo, obtener_modulo_cobra_oficial
+        from .usar_loader import obtener_modulo_cobra_oficial
 
         def _resolver_exportables_callables(modulo_obj, *, modulo_oficial: bool, nombre_modulo: str):
             """Resuelve exportables callables según política de ``usar``."""
@@ -1864,14 +1863,11 @@ class InterpretadorCobra:
                 ]
 
             if exportables is None:
-                if modulo_oficial:
-                    candidatos = [
-                        nombre
-                        for nombre in dir(modulo_obj)
-                        if isinstance(nombre, str) and not nombre.startswith("_")
-                    ]
-                else:
-                    return []
+                candidatos = [
+                    nombre
+                    for nombre in dir(modulo_obj)
+                    if isinstance(nombre, str) and not nombre.startswith("_")
+                ]
             else:
                 candidatos = exportables
 
@@ -1898,15 +1894,10 @@ class InterpretadorCobra:
             modulo_canonico = mapa_repl.get(nombre_modulo)
             es_modulo_oficial_cobra = modulo_canonico is not None
 
-            if es_modulo_oficial_cobra:
-                modulo = obtener_modulo_cobra_oficial(modulo_canonico)
-            elif es_repl_estricto:
+            if not es_modulo_oficial_cobra:
                 raise PermissionError(REPL_USAR_EXTERNAL_MODULE_ERROR)
-            else:
-                modulo = obtener_modulo(
-                    nombre_modulo,
-                    permitir_instalacion=True,
-                )
+
+            modulo = obtener_modulo_cobra_oficial(modulo_canonico)
 
             return modulo, es_repl_estricto, es_modulo_oficial_cobra
 
@@ -1941,10 +1932,6 @@ class InterpretadorCobra:
             simbolos_a_inyectar = _resolver_exportables_callables(
                 modulo, modulo_oficial=es_modulo_oficial_cobra, nombre_modulo=nombre_modulo
             )
-            if not simbolos_a_inyectar and not es_modulo_oficial_cobra:
-                raise ImportError(
-                    "módulo externo no exportable para usar: requiere __all__ con callables públicos"
-                )
 
             contexto_actual = self.contextos[-1]
 

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -320,94 +320,25 @@ def test_repl_usar_texto_colision_en_ancestro_es_atomico(monkeypatch):
     interp.contextos.pop()
 
 
-def test_usar_modulo_externo_no_estricto_inyecta_exportables_completos(monkeypatch):
-    modulo = ModuleType("numpy")
-    modulo.sumar = lambda a, b: a + b
-    modulo.restar = lambda a, b: a - b
-    modulo.__all__ = ["sumar", "restar"]
-
-    monkeypatch.setattr(
-        core_usar_loader,
-        "obtener_modulo",
-        lambda _nombre, **_kwargs: modulo,
-    )
+@pytest.mark.parametrize("nombre", ["numpy", "node-fetch", "serde", "holobit_sdk"])
+def test_usar_modulos_externos_rechazados_en_runtime_general(nombre):
     interp = InterpretadorCobra()
 
-    interp.ejecutar_nodo(NodoUsar("numpy"))
+    with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto \(solo alias oficiales Cobra\)"):
+        interp.ejecutar_nodo(NodoUsar(nombre))
 
-    assert interp.obtener_variable("sumar")(2, 3) == 5
-    assert interp.obtener_variable("restar")(8, 2) == 6
 
-def test_usar_modulo_externo_sin_exportables_falla_sin_estado_parcial(monkeypatch):
-    modulo = ModuleType("numpy")
+def test_usar_modulo_externo_rechazado_sin_estado_parcial():
     interp = InterpretadorCobra()
     interp.contextos[-1].define("sentinela", 42)
     estado_inicial = dict(interp.variables)
 
-    monkeypatch.setattr(
-        core_usar_loader,
-        "obtener_modulo",
-        lambda _nombre, **_kwargs: modulo,
-    )
-
-    with pytest.raises(ImportError, match="módulo externo no exportable para usar"):
-        interp.ejecutar_nodo(NodoUsar("numpy"))
+    with pytest.raises(PermissionError, match=r"solo alias oficiales Cobra"):
+        _ejecutar_codigo('usar "numpy"', interp)
 
     assert interp.variables == estado_inicial
 
 
-
-def test_usar_modulo_externo_con_all_vacio_falla_atomico(monkeypatch):
-    modulo = ModuleType("externo_vacio")
-    modulo.__all__ = []
-
-    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo)
-
-    interp = InterpretadorCobra()
-    interp.contextos[-1].define("sentinela", 42)
-    estado_inicial = dict(interp.variables)
-
-    with pytest.raises(ImportError, match="módulo externo no exportable para usar"):
-        _ejecutar_codigo('usar "externo_vacio"', interp)
-
-    assert interp.variables == estado_inicial
-
-
-def test_usar_modulo_externo_all_mixto_inyecta_solo_callables_publicos(monkeypatch):
-    modulo = ModuleType("externo_mixto")
-    modulo.publica = lambda x: x
-    modulo._privada = lambda x: x
-    modulo.no_callable = 123
-    modulo.__all__ = ["publica", "_privada", "no_callable"]
-
-    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo)
-
-    interp = InterpretadorCobra()
-    _ejecutar_codigo('usar "externo_mixto"', interp)
-
-    assert "publica" in interp.variables
-    assert callable(interp.obtener_variable("publica"))
-    assert "_privada" not in interp.variables
-    assert "no_callable" not in interp.variables
-
-
-def test_usar_modulo_externo_all_mixto_colision_es_atomico(monkeypatch):
-    modulo = ModuleType("externo_colision")
-    modulo.colisiona = lambda x: x
-    modulo.disponible = lambda x: x
-    modulo.__all__ = ["colisiona", "disponible"]
-
-    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo)
-
-    interp = InterpretadorCobra()
-    interp.contextos[-1].define("colisiona", lambda x: f"ocupado:{x}")
-    estado_inicial = dict(interp.variables)
-
-    with pytest.raises(NameError, match=r"símbolo 'colisiona' ya existe"):
-        _ejecutar_codigo('usar "externo_colision"', interp)
-
-    assert interp.variables == estado_inicial
-    assert "disponible" not in interp.variables
 def test_repl_usar_numpy_falla_sin_estado_parcial():
     interp = InterpretadorCobra()
     interp.contextos[-1].define("sentinela", 42)


### PR DESCRIPTION
### Motivation
- Eliminar una ruta permisiva que permitía cargar módulos externos mediante `usar` y cerrar un vector de importación directa a backends/paquetes no oficiales.
- Forzar que la resolución de `usar` use únicamente el catálogo canónico/alias oficial de Cobra para evitar fugas de API o dependencias externas.
- Mantener compatibilidad sintáctica con la forma `usar "modulo"` sin cambiar la gramática del parser.

### Description
- Modifiqué `InterpretadorCobra.ejecutar_usar` para que `_resolver_carga_modulo_usar` siempre rechace módulos no canónicos y resuelva exclusivamente mediante `obtener_modulo_cobra_oficial` (archivo `src/pcobra/core/interpreter.py`).
- Eliminé la rama de fallback que llamaba a `obtener_modulo(..., permitir_instalacion=True)` y ajusté la lógica que construye la lista de `candidatos` para exportables sobre módulos oficiales.
- Actualicé la documentación inline en `ejecutar_usar` para indicar explícitamente que los módulos externos se rechazan y que solo se aceptan alias oficiales del catálogo Cobra.
- Reemplacé pruebas que asumían carga de módulos externos por pruebas de seguridad que esperan rechazos explícitos para `numpy`, `node-fetch`, `serde` y `holobit_sdk`, y añadí una prueba que verifica que no hay mutación de estado cuando se rechaza `usar "numpy"` (archivo `tests/unit/test_usar.py`).

### Testing
- Ejecuté `pytest -q tests/unit/test_usar.py -k 'usar_modulos_externos_rechazados_en_runtime_general or usar_modulo_externo_rechazado_sin_estado_parcial or repl_usar_rechazo_externo_emite_mensaje_canonico or usar_numpy_rechazado_en_superficie_publica'` contra los tests modificados.
- La ejecución falló en la fase de colección con `ImportError: attempted relative import beyond top-level package`, por un layout/import-path del entorno de pruebas, por lo que no se alcanzaron las aserciones nuevas.
- No se reportaron ejecuciones completas de pruebas que fallen por lógica del cambio porque la colección de tests impidió la ejecución; las pruebas añadidas esperan `PermissionError` al intentar `usar` módulos externos y están incluidas en el repositorio para su ejecución en un entorno de test con import paths correctos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7642945508327b54acf511efcefdf)