### PR TITLE
Evita imports eager de backends legacy en startup y añade pruebas no-regresión

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -22,11 +22,19 @@ from pcobra.cli import (
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.target_policies import OFFICIAL_TRANSPILATION_TARGETS
 from pcobra.cobra.core.interpreter import InterpretadorCobra
-from pcobra.cobra.cli.internal_compat.legacy_targets import (
-    LEGACY_BACKENDS_FEATURE_FLAG,
-    is_internal_legacy_targets_enabled,
-)
 from pcobra.cobra.cli.i18n import _, format_traceback, setup_gettext
+
+
+def _internal_legacy_targets_runtime_flags() -> tuple[str, bool]:
+    """Carga diferida de flags legacy internas para evitar imports eager en startup."""
+
+    from pcobra.cobra.cli.internal_compat.legacy_targets import (
+        LEGACY_BACKENDS_FEATURE_FLAG,
+        is_internal_legacy_targets_enabled,
+    )
+
+    return LEGACY_BACKENDS_FEATURE_FLAG, is_internal_legacy_targets_enabled()
+
 from pcobra.cobra.cli.mode_policy import (
     CLI_MODOS_PERMITIDOS,
     MODO_POR_DEFECTO,
@@ -683,8 +691,9 @@ class CliApplication:
         blocked_routes: list[str] = []
         if self.command_registry and self.command_registry._is_legacy_cli_enabled():
             blocked_routes.append(f"legacy command group ({COBRA_ENABLE_LEGACY_CLI_ENV}=1)")
-        if is_internal_legacy_targets_enabled():
-            blocked_routes.append(f"legacy targets ({LEGACY_BACKENDS_FEATURE_FLAG}=1)")
+        legacy_flag_name, legacy_enabled = _internal_legacy_targets_runtime_flags()
+        if legacy_enabled:
+            blocked_routes.append(f"legacy targets ({legacy_flag_name}=1)")
 
         if not blocked_routes:
             return

--- a/tests/unit/test_startup_no_legacy_eager_loading.py
+++ b/tests/unit/test_startup_no_legacy_eager_loading.py
@@ -1,5 +1,7 @@
 import importlib
+import subprocess
 import sys
+from pathlib import Path
 
 LEGACY_TRANSPILER_MODULES = (
     "pcobra.cobra.transpilers.transpiler.to_go",
@@ -9,11 +11,42 @@ LEGACY_TRANSPILER_MODULES = (
     "pcobra.cobra.transpilers.transpiler.to_asm",
 )
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+
 
 def _purge_modules(prefixes: tuple[str, ...]) -> None:
     for name in list(sys.modules):
         if name.startswith(prefixes):
             sys.modules.pop(name, None)
+
+
+def _run_python_isolated(code: str) -> subprocess.CompletedProcess[str]:
+    bootstrap = (
+        "import os, sys; "
+        "assert 'PYTHONPATH' not in os.environ; "
+        f"sys.path.insert(0, {str(SRC_ROOT)!r}); "
+    )
+    return subprocess.run(
+        [sys.executable, "-I", "-c", bootstrap + code],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _legacy_assertion_snippet() -> str:
+    return (
+        "import sys; "
+        "legacy_modules = ("
+        "'pcobra.cobra.transpilers.transpiler.to_go',"
+        "'pcobra.cobra.transpilers.transpiler.to_cpp',"
+        "'pcobra.cobra.transpilers.transpiler.to_java',"
+        "'pcobra.cobra.transpilers.transpiler.to_wasm',"
+        "'pcobra.cobra.transpilers.transpiler.to_asm'"
+        "); "
+        "assert not any(name in sys.modules for name in legacy_modules), "
+        "'startup cargó backends legacy eager';"
+    )
 
 
 def test_import_pcobra_no_precarga_transpiladores_legacy():
@@ -34,6 +67,27 @@ def test_import_backend_pipeline_no_precarga_legacy():
         assert module_name not in sys.modules
 
 
+def test_import_cli_no_precarga_transpiladores_legacy():
+    result = _run_python_isolated(
+        "import pcobra.cobra.cli.cli; " + _legacy_assertion_snippet()
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_import_comandos_run_repl_test_no_precarga_transpiladores_legacy():
+    result = _run_python_isolated(
+        "import pcobra.cobra.cli.commands_v2.run_cmd; "
+        "import pcobra.cobra.cli.commands_v2.repl_cmd; "
+        "import pcobra.cobra.cli.commands_v2.test_cmd; "
+        + _legacy_assertion_snippet()
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_public_backends_permancen_exactamente_tres():
     policy = importlib.import_module("pcobra.cobra.architecture.backend_policy")
+    contracts = importlib.import_module("pcobra.cobra.architecture.contracts")
     assert policy.PUBLIC_BACKENDS == ("python", "javascript", "rust")
+    assert contracts.PUBLIC_BACKENDS == ("python", "javascript", "rust")


### PR DESCRIPTION
### Motivation
- Evitar que la inicialización/import-time de la CLI cargue código legacy (backends `go/cpp/java/wasm/asm`) que debe permanecer internal/opt-in y no formar parte del arranque público.
- Garantizar que la política pública de backends permanezca exactamente `("python", "javascript", "rust")` y que esto sea comprobado entre los módulos contractuales.

### Description
- Reemplacé el import eager de `pcobra.cobra.cli.internal_compat.legacy_targets` en `src/pcobra/cobra/cli/cli.py` por una carga diferida mediante la nueva función `_internal_legacy_targets_runtime_flags()` que importa y evalúa los flags solo en tiempo de ejecución del guard público.
- Cambié `_enforce_public_startup_guard` para usar `_internal_legacy_targets_runtime_flags()` y así evitar imports en el momento de importación del módulo CLI.
- Añadí/extendí tests en `tests/unit/test_startup_no_legacy_eager_loading.py` para validar en proceso aislado que `import pcobra`, `import pcobra.cobra.cli.cli` y la importación de `pcobra.cobra.cli.commands_v2.run_cmd/repl_cmd/test_cmd` no precargan los transpiladores legacy (`to_go/to_cpp/to_java/to_wasm/to_asm`).
- Añadí comprobación explícita de contrato público exacto contra ambos módulos canónicos importando `pcobra.cobra.architecture.backend_policy` y `pcobra.cobra.architecture.contracts` en el test.

### Testing
- Ejecuté `pytest -q tests/unit/test_startup_no_legacy_eager_loading.py tests/unit/test_backend_bootstrap_contract.py` y la suite relevante pasó: `8 passed, 1 warning`.
- Los tests cubren import aislado de `pcobra`, import de la CLI y rutas de comandos v2 para asegurar ausencia de carga eager de módulos legacy y la consistencia del contrato público.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f774e9dfd48327830130ece4aad304)