### PR TITLE
Fix REPL fallback validation state and legacy override compatibility

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -478,12 +478,12 @@ class InteractiveCommand(BaseCommand):
         try:
             ast = ast_preparseado if ast_preparseado is not None else prevalidar_y_parsear_codigo(codigo)
             validacion_no_silenciosa_realizada = False
-            ast, resultado = self._ejecutar_ast_en_repl(
+            validacion_no_silenciosa_realizada = True
+            ast, resultado = self._ejecutar_ast_en_repl_con_politica_validacion(
                 ast,
                 validador,
                 validar_no_silencioso=True,
             )
-            validacion_no_silenciosa_realizada = True
         except Exception as err_original:
             if not self._debe_intentar_fallback_expresion_top_level(
                 codigo, err_original
@@ -493,7 +493,7 @@ class InteractiveCommand(BaseCommand):
             codigo_fallback = f"imprimir({codigo.strip()})"
             try:
                 ast_fallback = prevalidar_y_parsear_codigo(codigo_fallback)
-                ast, resultado = self._ejecutar_ast_en_repl(
+                ast, resultado = self._ejecutar_ast_en_repl_con_politica_validacion(
                     ast_fallback,
                     validador,
                     validar_no_silencioso=not validacion_no_silenciosa_realizada,
@@ -507,6 +507,30 @@ class InteractiveCommand(BaseCommand):
         self.logger.debug("[EXEC] Ejecutando AST en intérprete")
         self.logger.debug("[EVAL] Resultado de evaluación: %r", resultado)
         self._imprimir_resultado_repl(ast, resultado)
+
+    def _ejecutar_ast_en_repl_con_politica_validacion(
+        self,
+        ast: list[Any],
+        validador: Optional[Any],
+        *,
+        validar_no_silencioso: bool,
+    ) -> tuple[list[Any], Any]:
+        """Invoca `_ejecutar_ast_en_repl` preservando compatibilidad hacia atrás.
+
+        Algunos tests/extensiones pueden sobreescribir `_ejecutar_ast_en_repl`
+        con la firma histórica de dos argumentos `(ast, validador)`.
+        """
+
+        try:
+            return self._ejecutar_ast_en_repl(
+                ast,
+                validador,
+                validar_no_silencioso=validar_no_silencioso,
+            )
+        except TypeError as err:
+            if "unexpected keyword argument 'validar_no_silencioso'" not in str(err):
+                raise
+            return self._ejecutar_ast_en_repl(ast, validador)
 
     def parsear_y_ejecutar_codigo_repl(
         self,


### PR DESCRIPTION
### Motivation
- Evitar que la validación no silenciosa se ejecute dos veces en la ruta de fallback del REPL cuando la ejecución falla tras haberse validado; la marca de estado debe reflejar que la validación ya se realizó antes de entrar en la ejecución. 
- Preservar compatibilidad con overrides/mocks existentes que implementan la firma histórica de `_ejecutar_ast_en_repl(ast, validador)` y evitar regresiones por el nuevo argumento keyword `validar_no_silencioso`.

### Description
- Se adelanta la marca `validacion_no_silenciosa_realizada` antes de invocar la ejecución inicial para evitar duplicar validaciones en la rama de fallback en `ejecutar_codigo`.
- Se añade el wrapper ` _ejecutar_ast_en_repl_con_politica_validacion(...)` que intenta llamar a `self._ejecutar_ast_en_repl(..., validar_no_silencioso=...)` y, ante un `TypeError` por argumento inesperado, vuelve a llamar la forma histórica `self._ejecutar_ast_en_repl(ast, validador)` para mantener compatibilidad.
- Se actualizan las invocaciones primarias y de fallback en `ejecutar_codigo` para usar el nuevo wrapper sin cambiar la semántica de las validaciones más allá de la corrección de estado.

### Testing
- Se compiló el módulo con `python -m py_compile src/pcobra/cobra/cli/commands/interactive_cmd.py` y la compilación fue exitosa.
- Se ejecutaron los tests en `tests/unit/test_interactive_cmd_repl_state_persistence.py` con `pytest -q`, resultando en 4 pruebas pasadas y 2 fallidas: `test_fallback_imprimir_top_level_aplica_solo_en_expresiones` y `test_fallback_no_modifica_statements_normales`.
- Los fallos ocurren porque los stubs/mocks del test esperan recibir snippets en forma de `str`, mientras que el flujo actualizado pasa nodos AST preparseados a los callbacks, por lo que las pruebas deben ajustarse para aceptar los AST cuando corresponda.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7790fd5408327a39920c4acd40cb9)