### PR TITLE
Restaurar validación en modo seguro para llamadas directas a `ejecutar_nodo`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1080,6 +1080,15 @@ class InterpretadorCobra:
         return build_internal_ir(ast)
 
     def ejecutar_nodo(self, nodo):
+        if self.safe_mode and id(nodo) not in self._validados:
+            modo_prev = self.mode
+            if modo_prev != "analysis":
+                self.mode = "analysis"
+            try:
+                self._validar(nodo)
+            finally:
+                self.mode = modo_prev
+
         self._trace_debug(f"[EXEC] node_type={type(nodo).__name__} node_id={id(nodo)}")
         if isinstance(nodo, NodoAsignacion):
             return self.ejecutar_asignacion(nodo)


### PR DESCRIPTION
### Motivation
- Corregir la regresión introducida al separar las fases `analysis`/`execution` donde `_validar` quedó limitado a `analysis` pero `ejecutar_nodo` dejó de invocarlo, permitiendo que ejecuciones directas en `execution` eviten comprobaciones de `safe_mode`.

### Description
- Añadí un guard al inicio de `def ejecutar_nodo(self, nodo)` que, cuando `self.safe_mode` y `id(nodo)` no está en `self._validados`, cambia temporalmente `self.mode` a `"analysis"`, llama a `_validar(nodo)` y restaura el modo previo, manteniendo la desduplicación a través de `self._validados` y limitando el cambio de modo al mínimo necesario; el archivo modificado es `src/pcobra/core/interpreter.py`.

### Testing
- Ejecuté la verificación de sintaxis compilando el archivo con `python -m py_compile src/pcobra/core/interpreter.py` y la comprobación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78151e3588327999a14d2ce8b2af7)