### PR TITLE
Auditoría en ejecución: auditar solo la operación ejecutada

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -822,8 +822,9 @@ class InterpretadorCobra:
         """Ejecuta la auditoría funcional únicamente durante la fase de ejecución."""
         if not self.in_execution() or not self.safe_mode or self._validador is None:
             return
-        # En ejecución permitimos side effects de auditoría visibles al usuario.
-        nodo.aceptar(self._validador)
+        # En ejecución auditamos solo la operación concreta para evitar
+        # recorrer ramas de control de flujo que no se ejecutaron.
+        self._validador.auditar_operacion(nodo)
 
     def _contiene_yield(self, nodo, visitados_ids: set[int] | None = None):
         if visitados_ids is None:

--- a/src/pcobra/core/semantic_validators/auditoria.py
+++ b/src/pcobra/core/semantic_validators/auditoria.py
@@ -2,6 +2,7 @@ import logging
 
 from .base import ValidadorBase
 from ..ast_nodes import (
+    NodoAST,
     NodoLlamadaFuncion,
     NodoLlamadaMetodo,
     NodoHilo,
@@ -34,6 +35,20 @@ class ValidadorAuditoria(ValidadorBase):
     def in_execution(self) -> bool:
         """Indica si la auditoría debe emitir side effects en fase de ejecución."""
         return self.emitir_side_effects and self.mode == "execution"
+
+
+    def auditar_operacion(self, nodo: NodoAST) -> None:
+        """Audita solo la operación concreta ejecutada, sin recorrer subárboles."""
+        if isinstance(nodo, NodoLlamadaFuncion):
+            self._log(f"Llamada a funcion: {nodo.nombre}")
+        elif isinstance(nodo, NodoLlamadaMetodo):
+            self._log(f"Llamada a metodo: {nodo.nombre_metodo}")
+        elif isinstance(nodo, NodoImport):
+            self._log(f"Import de modulo: {nodo.ruta}")
+        elif isinstance(nodo, NodoUsar):
+            self._log(f"Usar modulo: {nodo.modulo}")
+        elif isinstance(nodo, NodoImportDesde):
+            self._log(f"Importar desde: {nodo.modulo}")
 
     def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
         """Contrato: este visitor nunca debe emitir side effects fuera de ejecución.


### PR DESCRIPTION
### Motivation
- Evitar que la auditoría en tiempo de ejecución recorra subárboles del AST que no se ejecutaron y produzca `warnings` engañosos. 
- Asegurar que los efectos secundarios de auditoría (logs/warnings) se emitan únicamente en la fase de ejecución y solo para operaciones concretas. 
- Alinear el comportamiento del validador de auditoría con el modo del intérprete para prevenir fugas de fase.

### Description
- Modificado `_auditar_en_ejecucion` en `src/pcobra/core/interpreter.py` para llamar a `self._validador.auditar_operacion(nodo)` en lugar de `nodo.aceptar(self._validador)`, de modo que la auditoría en ejecución no haga una visita recursiva del subtree. 
- Añadido `auditar_operacion(self, nodo: NodoAST)` en `src/pcobra/core/semantic_validators/auditoria.py` (y agregado el import de `NodoAST`) para emitir logs solo para operaciones primitivas (`NodoLlamadaFuncion`, `NodoLlamadaMetodo`, `NodoImport`, `NodoUsar`, `NodoImportDesde`) sin descender en el AST. 
- Conservada la implementación de los `visit_*` para la fase de análisis y centralizado el control de emisión via `_log` para que los efectos de auditoría respeten `in_execution()`.

### Testing
- Ejecutado: `pytest -q tests/unit/test_interpreter.py::test_validacion_llamada_funcion_no_duplica_warning_en_invocacion_simple tests/unit/test_auditoria_validator.py tests/unit/test_repl_warning_dedup.py::test_regresion_warning_test_1_se_emite_una_sola_vez`.
- Resultado: las pruebas automatizadas seleccionadas pasaron correctamente (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f783416a408327a6710d5d77f83b87)