### PR TITLE
Emit function-call warning via logging (avoid stdout)

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1604,7 +1604,7 @@ class InterpretadorCobra:
         """Ejecuta la invocación de una función, interna o del usuario."""
         emitir_salida_llamada = self.in_execution()
         if emitir_salida_llamada:
-            print(f"WARNING: Llamada a funcion: {nodo.nombre}")
+            logging.warning("Llamada a funcion: %s", nodo.nombre)
         if nodo.nombre == "imprimir":
             for arg in nodo.argumentos:
                 if isinstance(arg, Token) and arg.tipo == TipoToken.IDENTIFICADOR:


### PR DESCRIPTION
### Motivation
- Preserve the audit/logging channel and avoid polluting program stdout by emitting function-call warnings through the existing logger rather than `print` during runtime.

### Description
- Replace the `print(f"WARNING: Llamada a funcion: {nodo.nombre}")` in `InterpretadorCobra.ejecutar_llamada_funcion` with `logging.warning("Llamada a funcion: %s", nodo.nombre)` while keeping the `self.in_execution()` guard.

### Testing
- Verified with `rg "Llamada a funcion"` that the warning string is now emitted from the logger path and ran `pytest -q`, which still fails during collection due to pre-existing integration assertion errors in `tests/utils/targets.py` that are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7850b01388327842c968921afcd9a)