### PR TITLE
[Follow-up] Fix REPL `usar` aliases blocked by package whitelist

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -150,7 +150,7 @@ def cargar_lista_blanca():
 cargar_lista_blanca()
 
 
-def obtener_modulo(nombre: str):
+def obtener_modulo(nombre: str, *, validar_whitelist: bool = True):
     """Importa y devuelve un módulo.
 
     Si el paquete no está instalado se intentará ejecutar ``pip install``
@@ -158,13 +158,15 @@ def obtener_modulo(nombre: str):
     De lo contrario se lanza :class:`RuntimeError`.
     """
     nombre = _validar_nombre(nombre)
-    if not USAR_WHITELIST:
-        raise PermissionError(
-            "La lista blanca de paquetes está vacía. No se puede usar 'usar'."
-        )
-    if nombre not in USAR_WHITELIST:
-        raise PermissionError(f"Paquete '{nombre}' no está permitido.")
-    spec = USAR_WHITELIST[nombre]
+    spec = nombre
+    if validar_whitelist:
+        if not USAR_WHITELIST:
+            raise PermissionError(
+                "La lista blanca de paquetes está vacía. No se puede usar 'usar'."
+            )
+        if nombre not in USAR_WHITELIST:
+            raise PermissionError(f"Paquete '{nombre}' no está permitido.")
+        spec = USAR_WHITELIST[nombre]
 
     base = Path(__file__).resolve()
     from pcobra.cobra.imports.resolver import CobraImportResolver, ImportResolutionError

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1815,7 +1815,11 @@ class InterpretadorCobra:
                     )
                 nombre_modulo = modulo_resuelto
 
-            modulo = obtener_modulo(nombre_modulo)
+            validar_whitelist = self._repl_usar_alias_map is None
+            modulo = obtener_modulo(
+                nombre_modulo,
+                validar_whitelist=validar_whitelist,
+            )
             exportables = getattr(modulo, "__all__", None)
             if exportables is None:
                 exportables = dir(modulo)


### PR DESCRIPTION
### Motivation
- A PR introduced REPL-only aliases that map short names (e.g. `numero`, `texto`) to internal `standard_library` modules, but the module loader still enforced `USAR_WHITELIST`, making those aliases rejected and `usar` unusable in REPL. 
- The intent is to let the REPL alias map control which internal standard-library modules are allowed while preserving the global whitelist for normal `usar` usage.

### Description
- Added a keyword-only parameter `validar_whitelist: bool = True` to `obtener_modulo` in `src/pcobra/cobra/usar_loader.py` so callers can opt out of global whitelist checks. 
- Kept the default behavior of `obtener_modulo` unchanged so existing callers still validate against `USAR_WHITELIST`. 
- Updated `InterpretadorCobra.ejecutar_usar` in `src/pcobra/core/interpreter.py` to pass `validar_whitelist=False` when the REPL alias map (`self._repl_usar_alias_map`) is active, and to keep validation enabled otherwise. 
- The change only bypasses the whitelist when the REPL already resolved the name via the approved alias map, preserving security for other flows.

### Testing
- Compiled the modified modules with `python -m py_compile src/pcobra/core/interpreter.py src/pcobra/cobra/usar_loader.py src/pcobra/cobra/cli/commands/interactive_cmd.py` and the command completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78a9fc1488327afce058344c795c5)