### PR TITLE
Prioritize standard_library in official module loader for strict REPL

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -175,17 +175,17 @@ def obtener_modulo_cobra_oficial(nombre: str):
     base = Path(__file__).resolve()
 
     for parent in base.parents:
-        corelibs = parent / "corelibs"
-        if corelibs.exists():
-            modulo = _cargar_modulo_local_desde_directorio(nombre, corelibs)
+        stdlib = parent / "standard_library"
+        if stdlib.exists():
+            modulo = _cargar_modulo_local_desde_directorio(nombre, stdlib)
             if modulo is not None:
                 return modulo
             break
 
     for parent in base.parents:
-        stdlib = parent / "standard_library"
-        if stdlib.exists():
-            modulo = _cargar_modulo_local_desde_directorio(nombre, stdlib)
+        corelibs = parent / "corelibs"
+        if corelibs.exists():
+            modulo = _cargar_modulo_local_desde_directorio(nombre, corelibs)
             if modulo is not None:
                 return modulo
             break


### PR DESCRIPTION
### Motivation
- Corregir el fallo P1 donde `obtener_modulo_cobra_oficial` resolvía nombres duplicados desde `corelibs` antes que desde `standard_library`, lo que provocaba `ImportError` en REPL estricto al cargar módulos oficiales que requieren `__all__`.

### Description
- Reordené la búsqueda en `obtener_modulo_cobra_oficial` en `src/pcobra/cobra/usar_loader.py` para comprobar `standard_library` antes de `corelibs`, de modo que las implementaciones canónicas de la biblioteca oficial tengan precedencia.

### Testing
- Compilé el módulo modificado con `python -m compileall src/pcobra/cobra/usar_loader.py` y la compilación finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78c6cd7388327b659da8ccc9f9b95)