### PR TITLE
[PR #2373 follow-up] Restore canonical strict REPL rejection message

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,7 +915,7 @@ En REPL incremental, `usar` aplica una política **estricta** y explícita:
 - **Semántica aplicada:** modelo oficial plano del libro (`usar numero`), sin acceso por prefijo de módulo (`numero.funcion(...)`).
 - **Inyección de símbolos:** solo se inyectan símbolos públicos **callables** exportados por `__all__`.
 - **Filtrado:** se ignoran símbolos privados (`_...`) y cualquier símbolo no callable.
-- **Módulos externos en REPL estricto:** deben fallar con error claro: `módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)`.
+- **Módulos externos en REPL estricto:** deben fallar con error claro: `módulos externos no soportados en REPL`.
 - Solo se aceptan módulos oficiales definidos en `REPL_COBRA_MODULE_MAP` y no hay fallback de instalación con `pip`.
 
 Ejemplos de comportamiento esperado en REPL:
@@ -928,7 +928,7 @@ usar "texto"
 imprimir(a_snake("HolaMundo"))  # ✅
 
 usar "numpy"
-imprimir(sqrt(4))  # ❌ módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)
+imprimir(sqrt(4))  # ❌ módulos externos no soportados en REPL
 ```
 
 > Nota: en Cobra REPL no hay dot-access para estos símbolos inyectados.

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1866,7 +1866,7 @@ class InterpretadorCobra:
             if es_modulo_oficial_cobra:
                 modulo = obtener_modulo_cobra_oficial(modulo_canonico)
             elif es_repl_estricto:
-                raise PermissionError("módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)")
+                raise PermissionError("módulos externos no soportados en REPL")
             else:
                 modulo = obtener_modulo(
                     nombre_modulo,
@@ -1884,7 +1884,7 @@ class InterpretadorCobra:
             if es_repl_estricto and es_modulo_oficial_cobra:
                 modulo_file = getattr(modulo, "__file__", None)
                 if not modulo_file:
-                    raise PermissionError("módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)")
+                    raise PermissionError("módulos externos no soportados en REPL")
 
                 ruta_modulo = Path(modulo_file).resolve()
                 raiz_pcobra = Path(__file__).resolve().parents[1]
@@ -1898,7 +1898,7 @@ class InterpretadorCobra:
                     for ruta_base in rutas_oficiales
                 )
                 if not es_oficial:
-                    raise PermissionError("módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)")
+                    raise PermissionError("módulos externos no soportados en REPL")
 
             # ``usar`` solo importa API pública explícita del módulo Cobra:
             # prioriza __all__, filtra privados/no-callables y evita fugas de

--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -108,7 +108,7 @@ def test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_numpy_restrin
     executor(cmd, 'usar "numero"')
     estado_pre_numpy = dict(interp.contextos[-1].values)
 
-    with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto \(solo alias oficiales Cobra\)"):
+    with pytest.raises(PermissionError, match=r"módulos externos no soportados en REPL"):
         executor(cmd, 'usar "numpy"')
 
     assert "numpy" not in interp.variables
@@ -181,7 +181,7 @@ def test_repl_rechazo_externo_no_inyecta_simbolos(factory, executor, get_interp,
     interp = get_interp(cmd)
     estado_pre = dict(interp.contextos[-1].values)
 
-    with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto \(solo alias oficiales Cobra\)"):
+    with pytest.raises(PermissionError, match=r"módulos externos no soportados en REPL"):
         executor(cmd, 'usar "requests"')
 
     assert estado_pre == interp.contextos[-1].values


### PR DESCRIPTION
### Motivation

- Reparar una regresión de contrato introducida por un cambio de redacción que rompía aserciones existentes sobre el mensaje de rechazo en REPL estricto. 
- Mantener compatibilidad con tests y consumidores que esperan el texto canónico de error para módulos externos en REPL. 
- Alinear la documentación pública (`README.md`) con el comportamiento en tiempo de ejecución para evitar confusiones. 

### Description

- Restaura el texto canónico del `PermissionError` en las rutas de rechazo de REPL estricto en `src/pcobra/core/interpreter.py` a `"módulos externos no soportados en REPL"`. 
- Actualiza las expectativas de los tests de integración en `tests/integration/test_repl_usar_entrypoints_contract.py` para usar la misma cadena canónica. 
- Ajusta el ejemplo de documentación en `README.md` para reflejar el mensaje de rechazo restaurado. 

### Testing

- Ejecuté `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py` y la suite pasó con `13 passed` (1 warning). 
- Intenté ejecutar `pytest -q tests/unit/test_usar.py tests/integration/test_repl_usar_entrypoints_contract.py` pero la ejecución falló en la colección por un problema de importación local (`attempted relative import beyond top-level package`). 
- Tras actualizar las expectativas en los tests de integración, volví a ejecutar solo la suite de integración y confirmé que todos los tests nuevos/modificados pasan (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f790827a048327880d91c709e7098f)