### PR TITLE
[Follow-up] Remove unresolved `holobit` from canonical `usar` allowlist

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -15,7 +15,6 @@ USAR_COBRA_ALLOWLIST: set[str] = {
     "archivo",
     "tiempo",
     "red",
-    "holobit",
 }
 
 # Regex estricta para mantener la sintaxis `usar "modulo"` acotada a identificadores simples.

--- a/tests/unit/test_usar_loader_validation.py
+++ b/tests/unit/test_usar_loader_validation.py
@@ -28,5 +28,4 @@ def test_allowlist_canonica_contiene_modulos_esperados():
         "archivo",
         "tiempo",
         "red",
-        "holobit",
     }


### PR DESCRIPTION
### Motivation
- Remove `holobit` from the runtime canonical `USAR_COBRA_ALLOWLIST` because it was advertised as permitted for `usar` but cannot be loaded by `obtener_modulo_cobra_oficial()` (no `holobit` module exists in `corelibs/` or `standard_library/`), causing deterministic `ImportError` at runtime. 

### Description
- Deleted `"holobit"` from `USAR_COBRA_ALLOWLIST` in `src/pcobra/cobra/usar_loader.py` and updated the expected canonical set in `tests/unit/test_usar_loader_validation.py` so runtime behavior matches the advertised allowlist. 

### Testing
- Ran `pytest -q tests/unit/test_usar_loader_validation.py` and the suite passed (`7 passed`, one DeprecationWarning reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79759e55c83279f69503b2382a925)