### PR TITLE
[PR #2382 follow-up] Restaurar exportaciones públicas `a_listas` y `de_listas` en `datos`

### DIFF
--- a/src/pcobra/standard_library/datos.py
+++ b/src/pcobra/standard_library/datos.py
@@ -61,6 +61,8 @@ __all__ = [
     "rellenar_nulos",
     "desplegar_tabla",
     "pivotar_tabla",
+    "a_listas",
+    "de_listas",
     "agregar",
     "mapear",
     "reducir",


### PR DESCRIPTION
### Motivation
- Corregir una regresión introducida al estandarizar las exportaciones que dejó fuera `a_listas` y `de_listas` del contrato público de `cobra.datos`, lo que provoca una ruptura backward-incompatible en REPL y cargadores guiados por contrato.

### Description
- Se añadieron de nuevo `"a_listas"` y `"de_listas"` en la lista `__all__` del archivo `src/pcobra/standard_library/datos.py` para restaurar la superficie pública declarada.

### Testing
- Se compiló el módulo con `python -m compileall -q src/pcobra/standard_library/datos.py` y la compilación fue exitosa. 
- Se verificó mediante importación que ambas entradas están presentes con `from pcobra.standard_library import datos` y comprobación de `"a_listas" in datos.__all__` y `"de_listas" in datos.__all__`, que devolvieron `True`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8218d3cd48327b4ea60403bd94b6f)