### PR TITLE
Fix projection mode behavior in holobit adapter (follow-up to #2384)

### DIFF
--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -64,10 +64,18 @@ def deserializar_holobit(payload: str) -> dict[str, Any]:
 
 
 def proyectar(hb: dict[str, Any], modo: str) -> dict[str, Any]:
-    _ = modo
     interno = _desde_estructura_cobra(hb)
+    modo_normalizado = str(modo).strip().lower()
     _to_sdk_holobit(interno)
-    return _a_estructura_cobra(interno)
+
+    if modo_normalizado == "3d":
+        proyectado = list(interno.valores)
+    elif modo_normalizado == "2d":
+        proyectado = list(interno.valores[:2])
+    else:
+        raise ValueError(f"Modo de proyección no soportado: {modo}")
+
+    return crear_holobit(proyectado)
 
 
 def transformar(hb: dict[str, Any], operacion: str, *parametros: Any) -> dict[str, Any]:

--- a/tests/unit/test_corelibs_holobit_adapter.py
+++ b/tests/unit/test_corelibs_holobit_adapter.py
@@ -41,3 +41,16 @@ def test_holobit_adapter_combinar_medir_y_transformar():
 def test_policy_rechaza_holobit_sdk_en_usar():
     with pytest.raises(PermissionError):
         usar_loader.obtener_modulo("holobit_sdk")
+
+
+def test_holobit_adapter_proyectar_respeta_modo_y_valida_errores():
+    hb = holobit.crear_holobit([1, 2, 3])
+
+    p2d = holobit.proyectar(hb, "2D")
+    assert p2d["valores"] == [1.0, 2.0]
+
+    p3d = holobit.proyectar(hb, "3D")
+    assert p3d["valores"] == [1.0, 2.0, 3.0]
+
+    with pytest.raises(ValueError):
+        holobit.proyectar(hb, "modo_invalido")


### PR DESCRIPTION
### Motivation
- `proyectar` was ignoring its `modo` parameter and always returning the original holobit, causing silent incorrect behavior for callers that expect mode-specific projections or explicit errors for unsupported modes. 
- The change ensures projection semantics are respected and invalid modes fail loudly to avoid corrupting downstream logic.

### Description
- Updated `src/pcobra/corelibs/holobit.py` so `proyectar` normalizes `modo`, uses `_to_sdk_holobit(interno)`, and returns a mode-specific projection. 
- `proyectar` now supports `"2d"` (returns the first two values) and `"3d"` (preserves all values) and raises `ValueError` for unsupported modes. 
- Replaced the previous no-op return with `crear_holobit(proyectado)` to produce a proper Cobra-serializable structure. 
- Added `test_holobit_adapter_proyectar_respeta_modo_y_valida_errores` to `tests/unit/test_corelibs_holobit_adapter.py` to cover 2D/3D behavior and invalid-mode errors.

### Testing
- Ran `pytest -q tests/unit/test_corelibs_holobit_adapter.py` and the test suite for the adapter passed. 
- Result: `4 passed`, with one existing deprecation warning; the new projection tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f880560f988327875a39b720aab5bf)