### PR TITLE
fix: alinear tests de `usar` con contrato real de holobit/holobit_sdk

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -673,7 +673,10 @@ def test_usar_numpy_rechazado_en_superficie_publica():
 
 
 def test_internals_holobit_sdk_no_importables_por_usar_loader():
-    for nombre in ("holobit_sdk", "holobit_sdk.core", "holobit_sdk.visualization"):
+    with pytest.raises(PermissionError):
+        usar_loader.obtener_modulo("holobit_sdk")
+
+    for nombre in ("holobit_sdk.core", "holobit_sdk.visualization"):
         with pytest.raises(ValueError):
             usar_loader.obtener_modulo(nombre)
 
@@ -686,7 +689,6 @@ def test_usar_holobit_expone_solo_api_publica(monkeypatch):
     interp.configurar_restriccion_usar_repl({"holobit": "holobit"})
     interp.ejecutar_nodo(NodoUsar("holobit"))
 
-    assert "holobit" in interp.variables
     assert "proyectar" in interp.variables
     assert "_require_holobit_sdk" not in interp.variables
 


### PR DESCRIPTION
### Motivation
- Alinear las expectativas de los tests con el contrato real del cargador `usar` y evitar falsos fallos por asunciones incorrectas sobre excepciones o símbolos exportados.

### Description
- En `tests/unit/test_usar.py` `test_internals_holobit_sdk_no_importables_por_usar_loader` ahora espera `PermissionError` para el módulo top-level `"holobit_sdk"` y sigue esperando `ValueError` para los nombres puntados como `"holobit_sdk.core"` y `"holobit_sdk.visualization"`.
- En `test_usar_holobit_expone_solo_api_publica` se eliminó la aserción que exigía que el nombre `"holobit"` se inyectara en `interp.variables`, manteniendo la comprobación de que la API pública exporta las llamadas esperadas (`"proyectar"`) y no expone internals (`"_require_holobit_sdk"`).

### Testing
- Se ejecutó `python -m py_compile tests/unit/test_usar.py` y la comprobación de sintaxis finalizó correctamente.
- Se intentó correr `pytest -q tests/unit/test_usar.py -k 'holobit_sdk_no_importables or holobit_expone_solo_api_publica'` pero la ejecución falló en la fase de colección por un problema de import-path preexistente (`ImportError: attempted relative import beyond top-level package`), por lo que no se pudieron completar las pruebas en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f884cd0f188327abb4eb9e7845bb77)