### PR TITLE
Fix follow-up: align legacy warning path with CLI compatibility gate

### DIFF
--- a/src/pcobra/cobra/architecture/legacy_backend_lifecycle.py
+++ b/src/pcobra/cobra/architecture/legacy_backend_lifecycle.py
@@ -132,7 +132,10 @@ def lifecycle_status_for_backend(target: str) -> LegacyLifecycleStatus:
 
 def legacy_backend_warning_message(*, target: str, route: str) -> str:
     """Mensaje único para advertencias de uso por rutas no públicas."""
-    metadata = get_legacy_backend_lifecycle()[target]
+    # Esta ruta se invoca tras pasar el gate de compatibilidad de CLI
+    # (COBRA_INTERNAL_LEGACY_TARGETS), por lo que no debe exigir un segundo
+    # opt-in diferente para poder construir la advertencia.
+    metadata = get_legacy_backend_lifecycle(require_opt_in=False)[target]
     return (
         f"[INTERNAL LEGACY BACKEND] '{target}' usado vía ruta no pública ({route}). "
         f"estado={metadata.status}; fase={metadata.phase}; ventana={metadata.retirement_window}; "


### PR DESCRIPTION
### Motivation
- Fix a high-priority regression where emitting the legacy backend warning could raise a `RuntimeError` unless the unrelated opt-in flag `PCOBRA_ENABLE_INTERNAL_LEGACY_BACKENDS` was set, which broke the existing CLI compatibility gate flow (`COBRA_INTERNAL_LEGACY_TARGETS`).

### Description
- Updated `legacy_backend_warning_message()` in `src/pcobra/cobra/architecture/legacy_backend_lifecycle.py` to call `get_legacy_backend_lifecycle(require_opt_in=False)` and added an explanatory comment so the warning path does not require the separate opt-in once the CLI gate has already allowed the legacy target.

### Testing
- Ran `pytest -q tests/unit/test_legacy_backend_lifecycle.py` and all tests in that module passed (9 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8bcee25b48327849ad3dd50be8830)