### PR TITLE
fix: rollback atomic injection in `usar` to avoid partial imports on runtime collision

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1997,22 +1997,32 @@ class InterpretadorCobra:
                 )
 
             # Fase B: inyectar de forma atómica y sin sobreescritura silenciosa.
-            for nombre, simbolo in simbolos_saneados:
-                if contexto_actual.contains(nombre):
-                    detalle = {
-                        "symbol": nombre,
-                        "code": "symbol_collision_runtime_recheck",
-                        "message": "símbolo ya existe en contexto actual",
-                    }
-                    self._trace_debug(
-                        "[USAR_COLLISION][ERROR] "
-                        f"módulo={nodo.modulo} símbolo={nombre} code=symbol_collision_runtime_recheck"
-                    )
-                    raise NameError(
-                        "No se puede usar el módulo "
-                        f"'{nodo.modulo}': colisión estructurada={detalle}"
-                    )
-                contexto_actual.define(nombre, simbolo)
+            simbolos_inyectados: list[tuple[str, object]] = []
+            try:
+                for nombre, simbolo in simbolos_saneados:
+                    if contexto_actual.contains(nombre):
+                        detalle = {
+                            "symbol": nombre,
+                            "code": "symbol_collision_runtime_recheck",
+                            "message": "símbolo ya existe en contexto actual",
+                        }
+                        self._trace_debug(
+                            "[USAR_COLLISION][ERROR] "
+                            f"módulo={nodo.modulo} símbolo={nombre} code=symbol_collision_runtime_recheck"
+                        )
+                        raise NameError(
+                            "No se puede usar el módulo "
+                            f"'{nodo.modulo}': colisión estructurada={detalle}"
+                        )
+                    contexto_actual.define(nombre, simbolo)
+                    simbolos_inyectados.append((nombre, simbolo))
+            except Exception:
+                # Rollback defensivo: evita estado parcial si falla durante Fase B.
+                for nombre, simbolo in reversed(simbolos_inyectados):
+                    valor_actual = contexto_actual.values.get(nombre)
+                    if valor_actual is simbolo:
+                        del contexto_actual.values[nombre]
+                raise
             if reporte_warnings:
                 self._trace_debug(f"[USAR_SANITIZE][WARNINGS] {reporte_warnings}")
         except Exception as exc:


### PR DESCRIPTION
### Motivation
- Corregir un fallo P1 en `ejecutar_usar` donde una colisión detectada en Fase B podía dejar símbolos parcialmente inyectados en `contexto_actual`, rompiendo la propiedad all-or-nothing del `usar`.
- Evitar corrupción de estado cuando otra entidad concurrente modifica el entorno entre la precomprobación (Fase A) y la inyección (Fase B).

### Description
- Modifica `src/pcobra/core/interpreter.py` para introducir `simbolos_inyectados` y registrar cada símbolo definido durante Fase B. 
- Envuelve la inyección en un bloque `try/except` que, ante cualquier excepción, realiza un rollback en orden inverso para eliminar únicamente los símbolos inyectados por esta operación. 
- El rollback es conservador y borra una entrada solo si el valor actual en `contexto_actual.values` es idéntico (`is`) al objeto que esta operación había insertado. 
- Conserva las comprobaciones y diagnósticos de colisión existentes (`symbol_collision_runtime_recheck`) y relanza la excepción original tras el deshacer.

### Testing
- Ejecutado `python -m py_compile src/pcobra/core/interpreter.py` y la compilación fue exitosa. 
- No se ejecutaron pruebas unitarias adicionales en este cambio; sólo se validó que el archivo modificado compila correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c69043a88327aa5f19e874a0e8b5)