### PR TITLE
Corregir auditoría en ejecución: omitir si el validador no implementa `auditar_operacion`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -822,9 +822,12 @@ class InterpretadorCobra:
         """Ejecuta la auditoría funcional únicamente durante la fase de ejecución."""
         if not self.in_execution() or not self.safe_mode or self._validador is None:
             return
+        auditar_operacion = getattr(self._validador, "auditar_operacion", None)
+        if not callable(auditar_operacion):
+            return
         # En ejecución auditamos solo la operación concreta para evitar
         # recorrer ramas de control de flujo que no se ejecutaron.
-        self._validador.auditar_operacion(nodo)
+        auditar_operacion(nodo)
 
     def _contiene_yield(self, nodo, visitados_ids: set[int] | None = None):
         if visitados_ids is None:


### PR DESCRIPTION
### Motivation
- Evitar un `AttributeError` en `safe_mode` durante la ejecución cuando la cabeza de la cadena de validadores no implementa auditoría. 
- Asegurar que la auditoría en ejecución solo se invoque si el validador actual soporta explícitamente la operación de auditoría para no recorrer subárboles del AST no ejecutados.

### Description
- Añadida una verificación en `Interpreter._auditar_en_ejecucion` (archivo `src/pcobra/core/interpreter.py`) que obtiene `auditar_operacion` con `getattr(self._validador, "auditar_operacion", None)` y retorna si no es `callable`.
- Si `auditar_operacion` existe y es invocable, se llama con el mismo `nodo` como antes, preservando el comportamiento de auditar únicamente la operación ejecutada.

### Testing
- Ejecutado: `pytest -q tests/unit/test_interpreter.py::test_validacion_llamada_funcion_no_duplica_warning_en_invocacion_simple tests/unit/test_auditoria_validator.py`.
- Resultado: `3 passed, 1 warning` (las pruebas seleccionadas pasaron; la advertencia es deprecación no relacionada con la corrección).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d8791638832784f495862254b0db)