### PR TITLE
Consolida reglas de rechazo de `usar` y refuerza cobertura de pruebas

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1846,8 +1846,8 @@ class InterpretadorCobra:
 
         from .usar_loader import obtener_modulo_cobra_oficial
 
-        def _resolver_exportables_callables(modulo_obj, *, modulo_oficial: bool, nombre_modulo: str):
-            """Resuelve exportables callables según política de ``usar``."""
+        def _resolver_exportables(modulo_obj, *, modulo_oficial: bool, nombre_modulo: str):
+            """Resuelve exportables candidatos según política de ``usar``."""
             exportables = getattr(modulo_obj, "__all__", None)
             if modulo_oficial and nombre_modulo == "holobit":
                 exportables = [
@@ -1879,10 +1879,6 @@ class InterpretadorCobra:
                 if not hasattr(modulo_obj, nombre):
                     continue
                 simbolo = getattr(modulo_obj, nombre)
-                if not callable(simbolo):
-                    if modulo_oficial and nombre.isupper():
-                        simbolos.append((nombre, simbolo))
-                    continue
                 vistos.add(nombre)
                 simbolos.append((nombre, simbolo))
             return simbolos
@@ -1929,7 +1925,7 @@ class InterpretadorCobra:
             # ``usar`` solo importa API pública explícita del módulo Cobra:
             # prioriza __all__, filtra privados/no-callables y evita fugas de
             # símbolos internos o reexportados de forma implícita.
-            simbolos_a_inyectar = _resolver_exportables_callables(
+            simbolos_a_inyectar = _resolver_exportables(
                 modulo, modulo_oficial=es_modulo_oficial_cobra, nombre_modulo=nombre_modulo
             )
 

--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from types import ModuleType
 from typing import Any
 
-NOMBRES_PUBLICOS_EQUIVALENTE_COBRA = frozenset(
+NOMBRES_PROHIBIDOS_EXPLICITOS = frozenset(
     {
         "self",
         "append",
@@ -19,6 +19,15 @@ NOMBRES_PUBLICOS_EQUIVALENTE_COBRA = frozenset(
 )
 DUNDERS_BLOQUEADOS = frozenset(
     {"__builtins__", "__loader__", "__package__", "__spec__", "__name__"}
+)
+NOMBRES_CONSTANTES_PUBLICAS_CANONICAS = frozenset(
+    {
+        "PI",
+        "E",
+        "TAU",
+        "INF",
+        "NAN",
+    }
 )
 NOMBRES_BACKEND_INTERNOS = frozenset(
     {"sys", "os", "importlib", "pcobra", "cobra", "core"}
@@ -110,20 +119,20 @@ def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamien
             "nombre interno del backend bloqueado",
         )
 
-    if nombre in NOMBRES_PUBLICOS_EQUIVALENTE_COBRA:
+    if nombre in NOMBRES_PROHIBIDOS_EXPLICITOS:
         return _rechazar(
             nombre,
             simbolo,
-            "cobra_public_equivalent",
-            "nombre público reservado por equivalente Cobra",
+            "explicit_forbidden_name",
+            "nombre prohibido por política explícita de usar",
         )
 
-    if not callable(simbolo) and not nombre.isupper():
+    if not callable(simbolo) and nombre not in NOMBRES_CONSTANTES_PUBLICAS_CANONICAS:
         return _rechazar(
             nombre,
             simbolo,
-            "non_callable_not_public_constant",
-            "solo se permiten no-callables para constantes públicas explícitas",
+            "non_callable_not_canonical_public_constant",
+            "solo se permiten no-callables para constantes públicas canónicas",
         )
 
     if not callable(simbolo):

--- a/tests/integration/test_usar_public_contract_regression.py
+++ b/tests/integration/test_usar_public_contract_regression.py
@@ -207,10 +207,14 @@ def test_conflicto_no_overwrite_silencioso_reporta_error_estructurado(monkeypatc
 
 def test_usar_no_inyecta_simbolos_prohibidos_ni_objetos_backend(monkeypatch):
     mod = ModuleType("externo")
-    mod.__all__ = ["OK", "self", "SDK"]
+    mod.__all__ = ["OK", "self", "append", "map", "SDK", "MAX_SIZE", "__danger__"]
     mod.OK = lambda: "ok"
     mod.self = lambda: "reservado"
+    mod.append = lambda *_args: "append"
+    mod.map = lambda *_args: "map"
     mod.SDK = ModuleType("sdk")
+    mod.MAX_SIZE = 1024
+    mod.__danger__ = lambda: "boom"
     mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/mod_ext.py"
 
     monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: mod)
@@ -227,5 +231,9 @@ def test_usar_no_inyecta_simbolos_prohibidos_ni_objetos_backend(monkeypatch):
 
     mensaje = str(excinfo.value)
     assert "self" in mensaje
+    assert "append" in mensaje
+    assert "map" in mensaje
+    assert "SDK" in mensaje
+    assert "MAX_SIZE" in mensaje
     assert "OK" not in interp.contextos[-1].values
     assert interp.contextos[-1].values == estado_pre

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -10,9 +10,10 @@ def _callable_dummy():
 
 
 def test_rechaza_nombres_prohibidos_backend():
-    resultado = sanear_simbolo_para_usar("sys", lambda: None)
-    assert resultado.rechazado is True
-    assert resultado.codigo == "backend_internal_name"
+    for nombre in ("sys", "os", "importlib", "pcobra", "cobra", "core"):
+        resultado = sanear_simbolo_para_usar(nombre, lambda: None)
+        assert resultado.rechazado is True
+        assert resultado.codigo == "backend_internal_name"
 
 
 def test_rechaza_privado():
@@ -24,14 +25,20 @@ def test_rechaza_privado():
 def test_rechaza_dunders():
     resultado = sanear_simbolo_para_usar("__algo__", lambda: None)
     assert resultado.rechazado is True
-    assert resultado.codigo in {"dunder_name", "private_prefix"}
+    assert resultado.codigo in {"dunder_pattern", "private_prefix"}
+
+
+def test_rechaza_dunders_python_conocidos():
+    resultado = sanear_simbolo_para_usar("__name__", lambda: None)
+    assert resultado.rechazado is True
+    assert resultado.codigo == "private_prefix"
 
 
 def test_rechaza_aliases_publicos_reservados():
     for nombre in ("append", "map", "filter", "unwrap", "expect", "self", "keys", "values", "len"):
         resultado = sanear_simbolo_para_usar(nombre, _callable_dummy)
         assert resultado.rechazado is True
-        assert resultado.codigo == "cobra_public_equivalent"
+        assert resultado.codigo == "explicit_forbidden_name"
 
 
 def test_rechaza_objetos_modulo():
@@ -71,4 +78,10 @@ def test_permite_constante_publica_explicita_como_warning():
 def test_rechaza_constante_no_mayuscula():
     resultado = sanear_simbolo_para_usar("pi", 3.14)
     assert resultado.rechazado is True
-    assert resultado.codigo == "non_callable_not_public_constant"
+    assert resultado.codigo == "non_callable_not_canonical_public_constant"
+
+
+def test_rechaza_constante_mayuscula_no_canonica():
+    resultado = sanear_simbolo_para_usar("MAX_SIZE", 128)
+    assert resultado.rechazado is True
+    assert resultado.codigo == "non_callable_not_canonical_public_constant"


### PR DESCRIPTION
### Motivation
- Centralizar y endurecer la política de saneamiento para la instrucción `usar` evitando rutas alternas que permitieran filtrado inconsistente de símbolos. 
- Evitar fugas de objetos backend, dunders y nombres reservados que puedan colisionar o exponer internals.

### Description
- Reescribí la política en `sanear_simbolo_para_usar` para aplicar rechazos explícitos por prefijo `_`, patrón `__`, dunders conocidos, objetos módulo/backend, prefijos/nombres internos del backend y una tabla explícita de nombres prohibidos (`self`, `append`, `map`, `filter`, `unwrap`, `expect`, `keys`, `values`, `len`, etc.).
- Añadí la lista canónica `NOMBRES_CONSTANTES_PUBLICAS_CANONICAS` (`PI`, `E`, `TAU`, `INF`, `NAN`) y cambié la regla de no-callables para permitir solo constantes públicas canónicas; el resto de no-callables se rechazan.
- Unifiqué el flujo en `InterpretadorCobra.ejecutar_usar` para que `_resolver_exportables` solo reúna candidatos y delegue toda la aceptación/rechazo a `sanear_simbolo_para_usar`, eliminando el prefiltrado alterno por `callable`/mayúsculas.
- Actualicé y amplié pruebas unitarias e integración en `tests/unit/test_usar_symbol_policy.py` y `tests/integration/test_usar_public_contract_regression.py` para cubrir los nuevos rechazos obligatorios (nombres backend, dunders/patrón `__`, nombres explícitos prohibidos y constantes no canónicas).

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_symbol_policy.py tests/integration/test_usar_public_contract_regression.py` y todos los tests pasaron: `27 passed`.
- Las pruebas de integración confirman que `ejecutar_usar` no inyecta símbolos cuando hay rechazos de saneamiento y que el estado del contexto permanece intacto en caso de error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa14ddd9e4832785c06b171830faab)