### PR TITLE
Fortalece contrato público serializable de Holobit

### DIFF
--- a/docs/contrato_runtime_holobit.md
+++ b/docs/contrato_runtime_holobit.md
@@ -32,6 +32,27 @@ contrato** Holobit multi-backend. Son helpers adicionales del runtime Python
 aparecer en la matriz contractual pública al mismo nivel que
 `proyectar`/`transformar`/`graficar`.
 
+## Contrato público serializable para `usar "holobit"`
+
+La fachada pública `pcobra.corelibs.holobit` (consumida por `usar "holobit"`) acepta y retorna **solo** una estructura serializable JSON con este esquema:
+
+- Tipo raíz: `object`/`dict`.
+- Claves permitidas (exactas): `tipo`, `valores`.
+- `tipo`: cadena exacta `"holobit"`.
+- `valores`: secuencia/lista de números (`int`/`float`, no `bool`).
+- No se permiten claves adicionales ni objetos/clases SDK en el contrato público.
+
+Ejemplo válido:
+
+```json
+{"tipo":"holobit","valores":[1.0,2.0,3.0]}
+```
+
+Serialización pública:
+
+- `serializar_holobit(hb)` produce JSON del objeto completo del contrato público.
+- `deserializar_holobit(payload)` exige ese mismo contrato y rechaza payloads legacy (por ejemplo arrays sueltos o claves extra).
+
 ## Semántica mínima
 
 ### Política oficial cuando falta `holobit_sdk`

--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -32,13 +32,28 @@ def _a_estructura_cobra(hb: _SDKHolobit) -> dict[str, Any]:
     return {"tipo": "holobit", "valores": [float(v) for v in hb.valores]}
 
 
+def _validar_estructura_holobit(hb: Any) -> dict[str, Any]:
+    if not isinstance(hb, dict):
+        raise TypeError("El holobit debe ser un objeto tipo dict")
+    claves = set(hb.keys())
+    if claves != {"tipo", "valores"}:
+        raise TypeError("Las claves permitidas del holobit son exactamente: tipo, valores")
+    if hb["tipo"] != "holobit":
+        raise TypeError("La clave 'tipo' debe ser la cadena 'holobit'")
+    valores = hb["valores"]
+    if not isinstance(valores, Sequence) or isinstance(valores, (str, bytes)):
+        raise TypeError("La clave 'valores' debe ser una lista o secuencia numérica")
+    return hb
+
+
 def _desde_estructura_cobra(hb: dict[str, Any]) -> _SDKHolobit:
-    if not isinstance(hb, dict) or hb.get("tipo") != "holobit":
-        raise TypeError("Se esperaba una estructura Cobra de holobit")
-    return _SDKHolobit(_normalizar_valores(hb.get("valores", [])))
+    estructura = _validar_estructura_holobit(hb)
+    return _SDKHolobit(_normalizar_valores(estructura["valores"]))
 
 
 def crear_holobit(valores: Iterable[Any]) -> dict[str, Any]:
+    if valores is None:
+        raise TypeError("'valores' no puede ser None")
     return _a_estructura_cobra(_SDKHolobit(_normalizar_valores(valores)))
 
 
@@ -51,20 +66,23 @@ def validar_holobit(hb: Any) -> bool:
 
 
 def serializar_holobit(hb: dict[str, Any]) -> str:
-    return json.dumps(_desde_estructura_cobra(hb).valores)
+    return json.dumps(_a_estructura_cobra(_desde_estructura_cobra(hb)), ensure_ascii=False)
 
 
 def deserializar_holobit(payload: str) -> dict[str, Any]:
+    if not isinstance(payload, str):
+        raise TypeError("El payload de holobit debe ser texto JSON")
     datos = json.loads(payload)
-    if not isinstance(datos, Sequence) or isinstance(datos, (str, bytes)):
-        raise TypeError("El payload de holobit debe representar una lista")
-    return crear_holobit(datos)
+    _validar_estructura_holobit(datos)
+    return crear_holobit(datos["valores"])
 
 
 def proyectar(hb: dict[str, Any], modo: str) -> dict[str, Any]:
+    if not isinstance(modo, str):
+        raise TypeError("'modo' debe ser texto")
     interno = _desde_estructura_cobra(hb)
     valores = list(interno.valores)
-    modo_norm = str(modo).strip().lower()
+    modo_norm = modo.strip().lower()
     if modo_norm == "2d":
         return crear_holobit(valores[:2])
     if modo_norm == "3d":
@@ -73,12 +91,16 @@ def proyectar(hb: dict[str, Any], modo: str) -> dict[str, Any]:
 
 
 def transformar(hb: dict[str, Any], operacion: str, *parametros: Any) -> dict[str, Any]:
+    if not isinstance(operacion, str):
+        raise TypeError("'operacion' debe ser texto")
     valores = list(_desde_estructura_cobra(hb).valores)
-    op = str(operacion).strip().lower()
+    op = operacion.strip().lower()
     if op == "rotar":
         if len(parametros) < 2:
             raise ValueError("rotar requiere eje y ángulo")
         eje = str(parametros[0]).strip().lower()
+        if not _es_numero(parametros[1]):
+            raise TypeError("El ángulo de rotación debe ser numérico")
         angulo = float(parametros[1])
         if eje != "z" or len(valores) < 2:
             return crear_holobit(valores)
@@ -94,7 +116,10 @@ def transformar(hb: dict[str, Any], operacion: str, *parametros: Any) -> dict[st
 
 
 def graficar(hb: dict[str, Any]) -> str:
-    return _sdk_graficar(_desde_estructura_cobra(hb))
+    vista = _sdk_graficar(_desde_estructura_cobra(hb))
+    if not isinstance(vista, str):
+        raise TypeError("La salida de graficar debe ser texto")
+    return vista
 
 
 def combinar(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
@@ -107,8 +132,10 @@ def medir(hb: dict[str, Any]) -> dict[str, float | int]:
     interno = _desde_estructura_cobra(hb)
     valores = interno.valores
     magnitud = sum(v * v for v in valores) ** 0.5
-    return {"dimension": len(valores), "magnitud": float(magnitud)}
-
+    salida = {"dimension": len(valores), "magnitud": float(magnitud)}
+    if not isinstance(salida["dimension"], int) or not _es_numero(salida["magnitud"]):
+        raise TypeError("Salida inválida de medir")
+    return salida
 
 
 __all__ = [
@@ -123,4 +150,3 @@ __all__ = [
     "medir",
 ]
 
-del Any, Iterable, Sequence

--- a/tests/integration/test_usar_public_contract_regression.py
+++ b/tests/integration/test_usar_public_contract_regression.py
@@ -237,3 +237,37 @@ def test_usar_no_inyecta_simbolos_prohibidos_ni_objetos_backend(monkeypatch):
     assert "MAX_SIZE" in mensaje
     assert "OK" not in interp.contextos[-1].values
     assert interp.contextos[-1].values == estado_pre
+
+
+def test_usar_holobit_inyecta_solo_all_y_nombres_en_espanol(monkeypatch):
+    mod_holobit = _modulo_holobit_publico_stub()
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda nombre: mod_holobit if nombre == "holobit" else (_ for _ in ()).throw(ModuleNotFoundError(nombre)))
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({**REPL_COBRA_MODULE_MAP, "holobit": "holobit"})
+
+    class _NodoUsar:
+        modulo = "holobit"
+
+    interp.ejecutar_usar(_NodoUsar())
+    simbolos = set(interp.contextos[-1].values.keys())
+
+    assert set(mod_holobit.__all__).issubset(simbolos)
+    assert "Holobit" not in simbolos
+    assert "holobit_sdk" not in simbolos
+    assert "_to_sdk_holobit" not in simbolos
+    assert all("_" in nombre or nombre.islower() for nombre in mod_holobit.__all__)
+
+
+def test_holobit_corelib_deserializacion_invalida_regresion():
+    import importlib.util
+    from pathlib import Path
+
+    ruta = Path("src/pcobra/corelibs/holobit.py").resolve()
+    spec = importlib.util.spec_from_file_location("_holobit_corelib_regression", ruta)
+    holobit = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(holobit)
+
+    with pytest.raises((TypeError, ValueError, KeyError)):
+        holobit.deserializar_holobit('{"tipo":"holobit","valores":[1],"extra":true}')

--- a/tests/unit/test_corelibs_holobit_adapter.py
+++ b/tests/unit/test_corelibs_holobit_adapter.py
@@ -1,28 +1,38 @@
+import importlib.util
+from pathlib import Path
+
 import pytest
 
-from pcobra.corelibs import holobit
 from pcobra.cobra import usar_loader
+
+ruta = Path("src/pcobra/corelibs/holobit.py").resolve()
+spec = importlib.util.spec_from_file_location("_holobit_corelib_tests", ruta)
+holobit = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(holobit)
+
+EXPECTED_PUBLIC_API = {
+    "crear_holobit",
+    "validar_holobit",
+    "serializar_holobit",
+    "deserializar_holobit",
+    "proyectar",
+    "transformar",
+    "graficar",
+    "combinar",
+    "medir",
+}
 
 
 def test_holobit_adapter_public_contract_roundtrip():
     hb = holobit.crear_holobit([1, 2, 3])
-    assert set(holobit.__all__) == {
-        "crear_holobit",
-        "validar_holobit",
-        "serializar_holobit",
-        "deserializar_holobit",
-        "proyectar",
-        "transformar",
-        "graficar",
-        "combinar",
-        "medir",
-    }
-    assert hb["__cobra_tipo__"] == "holobit"
+    assert set(holobit.__all__) == EXPECTED_PUBLIC_API
+    assert hb == {"tipo": "holobit", "valores": [1.0, 2.0, 3.0]}
     assert holobit.validar_holobit(hb) is True
 
     payload = holobit.serializar_holobit(hb)
     hb2 = holobit.deserializar_holobit(payload)
-    assert hb2["valores"] == [1.0, 2.0, 3.0]
+    assert hb2 == hb
 
 
 def test_holobit_adapter_combinar_medir_y_transformar():
@@ -35,9 +45,29 @@ def test_holobit_adapter_combinar_medir_y_transformar():
     assert metricas["magnitud"] > 0
 
     t = holobit.transformar(c, "rotar", "x", 90)
-    assert t["__cobra_tipo__"] == "holobit"
+    assert t["tipo"] == "holobit"
 
 
 def test_policy_rechaza_holobit_sdk_en_usar():
     with pytest.raises(PermissionError):
         usar_loader.obtener_modulo("holobit_sdk")
+
+
+def test_internals_no_se_exportan_en_public_api():
+    exports = set(holobit.__all__)
+    for bloqueado in ("Holobit", "_SDKHolobit", "_validar_estructura_holobit", "holobit_sdk"):
+        assert bloqueado not in exports
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "[1,2,3]",
+        '{"tipo":"otro","valores":[1]}',
+        '{"tipo":"holobit","valores":"123"}',
+        '{"tipo":"holobit","valores":[1],"extra":true}',
+    ],
+)
+def test_deserializar_holobit_rechaza_payload_invalido(payload):
+    with pytest.raises((TypeError, ValueError, KeyError)):
+        holobit.deserializar_holobit(payload)


### PR DESCRIPTION
### Motivation
- Asegurar un contrato público estable y serializable para Holobit que pueda consumirse desde `usar "holobit"` sin filtrar clases o objetos internos del SDK.
- Evitar que internals del SDK (por ejemplo `Holobit`, `holobit_sdk`, `_to_sdk_holobit`) sean exportados o importables desde la fachada pública.
- Añadir validaciones robustas de entrada/salida para las primitivas públicas del adaptador Holobit y capturar regresiones de serialización/uso de `usar`.

### Description
- Refuerzo de la fachada pública en `src/pcobra/corelibs/holobit.py` añadiendo `_validar_estructura_holobit`, validaciones de tipos para `crear_holobit`, `validar_holobit`, `serializar_holobit`, `deserializar_holobit`, `proyectar`, `transformar`, `graficar`, `combinar` y `medir`; la representación pública queda estrictamente como `{"tipo": "holobit", "valores": [...]}`.
- Mantención del uso interno del SDK (`pcobra.core.holobits.*`) sin exponer sus símbolos en `__all__`, y chequeos que previenen la fuga de internals en la API pública.
- Documentación actualizada en `docs/contrato_runtime_holobit.md` con la definición explícita del contrato público serializable y las reglas de serialización/deserialización.
- Tests actualizados/añadidos: `tests/unit/test_corelibs_holobit_adapter.py` ahora carga el módulo directamente para evitar dependencias circulares y verifica roundtrip, combinaciones, métricas, rechazo de payloads inválidos y ausencia de internals en `__all__`; `tests/integration/test_usar_public_contract_regression.py` añade pruebas que aseguran que `usar "holobit"` inyecta solo los símbolos declarados y que la deserialización rechaza payloads con claves adicionales.

### Testing
- Se ejecutó `pytest -q tests/unit/test_corelibs_holobit_adapter.py tests/integration/test_usar_public_contract_regression.py -k 'holobit'` y las pruebas relevantes finalizaron correctamente con `12 passed, 13 deselected`.
- Las pruebas incluyen casos negativos de importabilidad de internals y de serialización/deserialización inválida y todos los casos añadidos pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fadf59999c83279e5c7f0a5863349d)