### PR TITLE
test: prevenir carga eager de transpilers legacy en startup y fijar política pública de backends

### DIFF
--- a/tests/integration/transpilers/test_official_backends_contracts.py
+++ b/tests/integration/transpilers/test_official_backends_contracts.py
@@ -54,6 +54,13 @@ RUNTIME_ADAPTER_MARKERS = {
     ),
 }
 
+
+
+def test_public_backend_policy_exact_set_is_enforced() -> None:
+    """Política pública exacta: solo python/javascript/rust."""
+
+    assert PUBLIC_BACKENDS == ("python", "javascript", "rust")
+
 def _generate(language: str, nodes: list[object]) -> str:
     module_name, class_name = TRANSPILERS[language]
     transpiler = getattr(importlib.import_module(module_name), class_name)()

--- a/tests/test_cli_entrypoint_imports.py
+++ b/tests/test_cli_entrypoint_imports.py
@@ -150,3 +150,29 @@ def test_cli_bootstrap_no_monkey_patchea_lexer() -> None:
         "El bootstrap CLI debe preservar el método original del lexer. "
         f"stdout={result.stdout!r} stderr={result.stderr!r}"
     )
+
+
+@pytest.mark.parametrize("command,argv", [("repl", ["repl", "-h"]), ("run", ["run", "-h"]), ("test", ["test", "-h"])])
+def test_cli_public_commands_do_not_import_legacy_transpilers_on_startup(command: str, argv: list[str]) -> None:
+    """`repl`/`ejecutar`/`test` no deben cargar módulos legacy en import/startup."""
+
+    result = _run_python_isolated(
+        f"from pcobra.cli import main; rc = main({argv!r}); "
+        "import sys; "
+        "legacy_markers = ("
+        "'pcobra.cobra.transpilers.transpiler.to_go',"
+        "'pcobra.cobra.transpilers.transpiler.to_cpp',"
+        "'pcobra.cobra.transpilers.transpiler.to_java',"
+        "'pcobra.cobra.transpilers.transpiler.to_wasm',"
+        "'pcobra.cobra.transpilers.transpiler.to_asm',"
+        "'pcobra.cobra.internal_compat.legacy_contracts',"
+        "); "
+        "loaded = sorted(name for name in sys.modules if name in legacy_markers); "
+        "assert rc == 0; "
+        "assert not loaded, f'Startup cargó módulos legacy: {loaded}'; ",
+    )
+
+    assert result.returncode == 0, (
+        "Las rutas públicas no deben cargar transpilers legacy en startup. "
+        f"command={command!r} stdout={result.stdout!r} stderr={result.stderr!r}"
+    )


### PR DESCRIPTION
### Motivation
- Evitar que rutas públicas normales de la CLI (`repl`, `run`, `test`) carguen de forma eager módulos/transpilers legacy/Internal-Compat durante el arranque o la petición de `--ayuda`.
- Asegurar por contrato que la política pública de backends permanezca exactamente en el conjunto permitido sin extras (`python`, `javascript`, `rust`).

### Description
- Añadida prueba de regresión en `tests/test_cli_entrypoint_imports.py` que ejecuta `pcobra.cli.main` en entorno aislado y verifica que las rutas públicas no importen módulos legacy/internal-compat en startup. 
- Añadida prueba en `tests/integration/transpilers/test_official_backends_contracts.py` que valida `PUBLIC_BACKENDS == ("python", "javascript", "rust")` exactamente. 
- Ajustada la invocación de los casos de prueba para usar `-h`/help en subcomandos y evitar falsos positivos por argumentos faltantes en las ejecuciones aisladas. 
- No se modificó la lógica de carga de transpilers en runtime; la solución protege el comportamiento deseado mediante tests de regresión.

### Testing
- Ejecutado `pytest -q tests/test_cli_entrypoint_imports.py tests/integration/transpilers/test_official_backends_contracts.py` inicialmente, lo que señaló 3 fallos que se debían a la forma de invocar los subcomandos en el test. 
- Tras corregir los casos de prueba, se re-ejecutó `pytest -q tests/test_cli_entrypoint_imports.py tests/integration/transpilers/test_official_backends_contracts.py` y todos los tests relevantes pasaron (`27 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae31a97f083278c6a09178a5781c0)