### PR TITLE
Ajusta `usar` para tolerar rechazos parciales de símbolos

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1950,10 +1950,20 @@ class InterpretadorCobra:
                 simbolos_saneados.append((nombre, simbolo))
 
             if reporte_rechazos:
-                simbolos_rechazados = [item["symbol"] for item in reporte_rechazos]
+                evento_rechazos = {
+                    "evento": "usar_sanitize_reject",
+                    "severity": "warning",
+                    "module": nodo.modulo,
+                    "rejections": reporte_rechazos,
+                }
+                logging.warning("USAR sanitize reject event: %s", evento_rechazos)
+                self._trace_debug(f"[USAR_SANITIZE][REJECTS] {evento_rechazos}")
+
+            if not simbolos_saneados:
                 raise ImportError(
                     "rechazos de saneamiento en usar "
-                    f"'{nodo.modulo}' para símbolos {simbolos_rechazados}: {reporte_rechazos}"
+                    f"'{nodo.modulo}': no quedaron símbolos exportables tras saneamiento. "
+                    f"rechazos={reporte_rechazos}"
                 )
 
             # Fase A: detectar colisiones de forma completa antes de definir.
@@ -2022,6 +2032,13 @@ class InterpretadorCobra:
                     )
                 contexto_actual.define(nombre, simbolo)
             if reporte_warnings:
+                evento_warnings = {
+                    "evento": "usar_sanitize_warning",
+                    "severity": "warning",
+                    "module": nodo.modulo,
+                    "warnings": reporte_warnings,
+                }
+                logging.warning("USAR sanitize warning event: %s", evento_warnings)
                 self._trace_debug(f"[USAR_SANITIZE][WARNINGS] {reporte_warnings}")
         except Exception as exc:
             logging.exception(f"Error al usar el módulo '{nodo.modulo}': {exc}")

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -2,6 +2,10 @@ import importlib
 import math
 from types import ModuleType
 
+import pytest
+
+from pcobra.core.ast_nodes import NodoUsar
+from pcobra.core.interpreter import InterpretadorCobra
 from pcobra.core.usar_symbol_policy import sanear_simbolo_para_usar
 
 
@@ -85,3 +89,43 @@ def test_rechaza_constante_mayuscula_no_canonica():
     resultado = sanear_simbolo_para_usar("MAX_SIZE", 128)
     assert resultado.rechazado is True
     assert resultado.codigo == "non_callable_not_canonical_public_constant"
+
+
+def test_usar_modulo_mixto_importa_solo_simbolos_validos(monkeypatch):
+    modulo = ModuleType("fake_numero")
+    modulo.__all__ = ["es_finito", "_interno", "MAX_SIZE", "PI"]
+    modulo.es_finito = _callable_dummy
+    modulo._interno = _callable_dummy
+    modulo.MAX_SIZE = 128
+    modulo.PI = 3.14
+    modulo.__file__ = __file__
+
+    monkeypatch.setattr(
+        "pcobra.core.usar_loader.obtener_modulo_cobra_oficial",
+        lambda _canonico: modulo,
+    )
+
+    interp = InterpretadorCobra(safe_mode=False)
+    interp.ejecutar_usar(NodoUsar("numero"))
+
+    assert interp.variables["es_finito"] is _callable_dummy
+    assert interp.variables["PI"] == 3.14
+    assert "_interno" not in interp.variables
+    assert "MAX_SIZE" not in interp.variables
+
+
+def test_usar_modulo_totalmente_invalido_falla(monkeypatch):
+    modulo = ModuleType("fake_numero_invalido")
+    modulo.__all__ = ["_interno", "MAX_SIZE"]
+    modulo._interno = _callable_dummy
+    modulo.MAX_SIZE = 128
+    modulo.__file__ = __file__
+
+    monkeypatch.setattr(
+        "pcobra.core.usar_loader.obtener_modulo_cobra_oficial",
+        lambda _canonico: modulo,
+    )
+
+    interp = InterpretadorCobra(safe_mode=False)
+    with pytest.raises(ImportError, match="no quedaron símbolos exportables"):
+        interp.ejecutar_usar(NodoUsar("numero"))


### PR DESCRIPTION
### Motivation
- Permitir que `usar` importe los símbolos válidos de un módulo aun cuando algunos símbolos sean rechazados por la política de saneamiento en lugar de abortar la operación completa.
- Mantener el rechazo estricto cuando, tras el saneamiento, no queda ningún símbolo exportable que inyectar.
- Registrar eventos estructurados con los códigos de rechazo/advertencia emitidos por `sanear_simbolo_para_usar` para facilitar auditoría y trazas.
- Conservar las restricciones estrictas sobre símbolos prohibidos (prefijos `_`, `__`, módulos backend y nombres explícitamente prohibidos) y la lógica de detección de colisiones existente.

### Description
- Modifica `ejecutar_usar` en `src/pcobra/core/interpreter.py` para registrar un evento estructurado `usar_sanitize_reject` cuando existan rechazos y continuar inyectando los `simbolos_saneados` válidos en lugar de lanzar inmediatamente un error.
- Introduce un `ImportError` solo si `simbolos_saneados` queda vacío tras el saneamiento, con mensaje detallado de los rechazos observados.
- Añade logging estructurado `usar_sanitize_warning` al final del flujo para agrupar advertencias reportadas por `sanear_simbolo_para_usar` y mantiene las trazas debug existentes (`_trace_debug`).
- Agrega dos pruebas de regresión en `tests/unit/test_usar_symbol_policy.py` que simulan módulos con mezcla de símbolos válidos/ inválidos y un módulo totalmente inválido, usando `monkeypatch` sobre `obtener_modulo_cobra_oficial`.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_symbol_policy.py` y todos los casos pasaron correctamente (14 passed, 0 failed).
- Las pruebas verifican específicamente que un módulo mixto importa solo los símbolos válidos y que un módulo sin símbolos válidos produce `ImportError` por ausencia de exportables tras saneamiento.
- No se realizaron cambios en la política de bloqueo de símbolos privados ni en la detección de colisiones, por lo que las pruebas existentes que cubren esas rutas siguen comportándose igual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb186bc42c832791d29e684c23c303)