### PR TITLE
Centralizar validación de `usar`, reforzar loader y añadir tests de rechazo

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -55,8 +55,8 @@ def _rechazar_modulo_no_canonico(nombre: str) -> None:
             f"Módulos permitidos: {', '.join(sorted(USAR_COBRA_ALLOWLIST))}."
         )
 
-def _validar_nombre(nombre: str) -> str:
-    """Valida que el nombre sea seguro para resolución runtime de `usar`."""
+def validar_nombre_modulo_usar(nombre: str, *, require_allowlist: bool = True) -> str:
+    """Valida nombre de `usar` y opcionalmente exige allowlist canónica."""
 
     _rechazar_modulo_no_canonico(nombre)
     nombre = nombre.strip()
@@ -78,6 +78,12 @@ def _validar_nombre(nombre: str) -> str:
                 f"Nombre de módulo '{nombre}' parece una ruta interna o de backend; "
                 "usa únicamente módulos Cobra canónicos."
             )
+
+    if require_allowlist and nombre not in USAR_COBRA_ALLOWLIST:
+        raise PermissionError(
+            f"Importación no permitida en 'usar': '{nombre}'. "
+            f"Módulos permitidos: {', '.join(sorted(USAR_COBRA_ALLOWLIST))}."
+        )
 
     return nombre
 
@@ -103,7 +109,7 @@ def _cargar_modulo_local_desde_directorio(nombre: str, directorio: Path):
 def obtener_modulo_cobra_oficial(nombre: str):
     """Carga módulos oficiales de Cobra solo desde ``corelibs`` o ``standard_library``."""
 
-    nombre = _validar_nombre(nombre)
+    nombre = validar_nombre_modulo_usar(nombre, require_allowlist=True)
     base = Path(__file__).resolve()
 
     for parent in base.parents:
@@ -131,13 +137,7 @@ def obtener_modulo(nombre: str, *, permitir_instalacion: bool = True):
     """Resuelve módulos de `usar` solo contra la allowlist canónica de Cobra."""
 
     _ = permitir_instalacion  # compat: ya no se usa instalación dinámica para `usar`.
-    nombre = _validar_nombre(nombre)
-
-    if nombre not in USAR_COBRA_ALLOWLIST:
-        raise PermissionError(
-            f"Importación no permitida en 'usar': '{nombre}'. "
-            f"Módulos permitidos: {', '.join(sorted(USAR_COBRA_ALLOWLIST))}."
-        )
+    nombre = validar_nombre_modulo_usar(nombre, require_allowlist=True)
 
     try:
         return obtener_modulo_cobra_oficial(nombre)

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1844,7 +1844,7 @@ class InterpretadorCobra:
         from pathlib import Path
         from types import ModuleType
 
-        from .usar_loader import obtener_modulo_cobra_oficial
+        from .usar_loader import obtener_modulo
 
         def _resolver_exportables(modulo_obj, *, modulo_oficial: bool, nombre_modulo: str):
             """Resuelve exportables candidatos según política de ``usar``."""
@@ -1893,7 +1893,7 @@ class InterpretadorCobra:
             if not es_modulo_oficial_cobra:
                 raise PermissionError(REPL_USAR_EXTERNAL_MODULE_ERROR)
 
-            modulo = obtener_modulo_cobra_oficial(modulo_canonico)
+            modulo = obtener_modulo(modulo_canonico)
 
             return modulo, es_repl_estricto, es_modulo_oficial_cobra
 

--- a/tests/unit/test_usar_loader_site_packages.py
+++ b/tests/unit/test_usar_loader_site_packages.py
@@ -3,7 +3,13 @@ import pytest
 from cobra import usar_loader
 
 
-@pytest.mark.parametrize("nombre", ["numpy", "serde", "holobit_sdk"])
-def test_site_packages_no_bypassea_politica_allowlist(nombre):
-    with pytest.raises(PermissionError, match="Módulos permitidos"):
+@pytest.mark.parametrize("nombre", ["numpy", "node-fetch", "serde", "holobit_sdk"])
+def test_rechazo_explicito_modulos_backend_no_canonicos(nombre):
+    with pytest.raises(PermissionError, match="backend/no canónico"):
         usar_loader.obtener_modulo(nombre)
+
+
+@pytest.mark.parametrize("nombre", ["requests", "pandas", "django"])
+def test_rechaza_cualquier_modulo_fuera_allowlist(nombre):
+    with pytest.raises(PermissionError, match="Módulos permitidos"):
+        usar_loader.validar_nombre_modulo_usar(nombre)

--- a/tests/unit/test_usar_loader_stdlib.py
+++ b/tests/unit/test_usar_loader_stdlib.py
@@ -1,20 +1,31 @@
-import types
-from datetime import datetime
-import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT))
+import pytest
 
 from cobra import usar_loader
-import standard_library.fecha as fecha
 
 
-def test_obtener_modulo_standard_library(monkeypatch):
-    usar_loader.USAR_WHITELIST.add("fecha")
-    mod = usar_loader.obtener_modulo("fecha")
-    usar_loader.USAR_WHITELIST.remove("fecha")
-    assert isinstance(mod, types.ModuleType)
-    assert hasattr(mod, "formatear")
-    assert mod.formatear(datetime(2020, 1, 1)) == fecha.formatear(datetime(2020, 1, 1))
+@pytest.mark.parametrize("nombre", ["numero", "texto", "datos", "holobit"])
+def test_entrypoint_obtener_modulo_delega_en_obtener_modulo_cobra_oficial(monkeypatch, nombre):
+    llamado = {"nombre": None}
 
+    def _fake_oficial(n):
+        llamado["nombre"] = n
+        return object()
+
+    monkeypatch.setattr(usar_loader, "obtener_modulo_cobra_oficial", _fake_oficial)
+    assert usar_loader.obtener_modulo(nombre) is not None
+    assert llamado["nombre"] == nombre
+
+
+@pytest.mark.parametrize(
+    "nombre",
+    [
+        "pcobra.core.database",
+        "cobra.usar_loader",
+        "corelibs.numero",
+        "standard_library.texto",
+        "backend_python",
+    ],
+)
+def test_rechaza_rutas_internas_y_backend(nombre):
+    with pytest.raises((ValueError, PermissionError), match="(usar|backend|interna|permitida)"):
+        usar_loader.validar_nombre_modulo_usar(nombre)


### PR DESCRIPTION
### Motivation

- Evitar divergencias entre las capas `core` y `cobra` en la política de resolución de la instrucción `usar` concentrando la validación y allowlist en un único punto reutilizable.
- Asegurar que todos los entrypoints de `usar` deleguen en la misma lógica de resolución y no realicen imports backend directos o bypass de la política.
- Mantener rechazos explícitos para nombres no-canónicos y rutas internas/backend solicitados por la política de seguridad.

### Description

- Centralicé la validación en `validar_nombre_modulo_usar(...)` en `src/pcobra/cobra/usar_loader.py`, que aplica validación de formato, bloqueo de hints internos, rechazo explícito de módulos no canónicos y (opcionalmente) la comprobación contra `USAR_COBRA_ALLOWLIST`.
- Actualicé `obtener_modulo(...)` y `obtener_modulo_cobra_oficial(...)` para delegar en la nueva función `validar_nombre_modulo_usar(...)` y evitar duplicación de lógica.
- Cambié el flujo en `src/pcobra/core/interpreter.py` (`InterpretadorCobra.ejecutar_usar`) para resolver módulos mediante `obtener_modulo(...)` en lugar de invocar otro cargador directo, garantizando aplicación uniforme de la política.
- Añadí/ajusté pruebas en `tests/unit/test_usar_loader_stdlib.py` y `tests/unit/test_usar_loader_site_packages.py` para verificar delegación de entrypoints, rechazo de rutas internas/backend, rechazo explícito de `numpy`, `node-fetch`, `serde`, `holobit_sdk` y rechazo de cualquier módulo fuera de la allowlist.
- Se mantuvo el uso de `importlib.util` para la carga interna desde `corelibs`/`standard_library` y no se introdujeron `importlib.import_module` directos en el flujo de `usar`.

### Testing

- Ejecuté `pytest -q tests/unit/test_usar_loader_stdlib.py tests/unit/test_usar_loader_site_packages.py` y las pruebas unitarias pasaron (16 passed, 1 warning).
- Las nuevas aserciones comprueban que `obtener_modulo` delega en `obtener_modulo_cobra_oficial` y que los nombres/rutas no permitidos son rechazados con `ValueError`/`PermissionError` según corresponda.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2bd11f508327b75381318a86db02)