### PR TITLE
test: reforzar contrato público de holobit

### DIFF
--- a/tests/unit/test_corelibs_holobit_adapter.py
+++ b/tests/unit/test_corelibs_holobit_adapter.py
@@ -48,6 +48,31 @@ def test_holobit_adapter_combinar_medir_y_transformar():
     assert t["tipo"] == "holobit"
 
 
+def test_holobit_adapter_normaliza_tipos_cobra_facing():
+    hb = holobit.crear_holobit((1, 2.5, 3))
+
+    proyectado = holobit.proyectar(hb, "2d")
+    transformado = holobit.transformar(hb, "rotar", "z", 90)
+    combinado = holobit.combinar(hb, holobit.crear_holobit([4]))
+    metricas = holobit.medir(hb)
+
+    assert isinstance(hb, dict)
+    assert isinstance(proyectado, dict)
+    assert isinstance(transformado, dict)
+    assert isinstance(combinado, dict)
+    assert isinstance(metricas, dict)
+    assert hb["tipo"] == "holobit"
+    assert all(isinstance(v, float) for v in hb["valores"])
+    assert isinstance(metricas["dimension"], int)
+    assert isinstance(metricas["magnitud"], float)
+
+
+@pytest.mark.parametrize("valor_invalido", [True, False])
+def test_crear_holobit_rechaza_booleanos(valor_invalido):
+    with pytest.raises(TypeError):
+        holobit.crear_holobit([valor_invalido, 1])
+
+
 def test_policy_rechaza_holobit_sdk_en_usar():
     with pytest.raises(PermissionError):
         usar_loader.obtener_modulo("holobit_sdk")

--- a/tests/unit/test_usar_loader_public_api_contract.py
+++ b/tests/unit/test_usar_loader_public_api_contract.py
@@ -80,6 +80,23 @@ def test_usar_holobit_expone_solo_api_cobra_sin_internals_sdk() -> None:
     assert all("__" not in nombre for nombre in simbolos)
 
 
+def test_stdlib_holobit_exporta_exactamente_api_permitida() -> None:
+    from pcobra.standard_library import holobit as stdlib_holobit
+
+    assert set(stdlib_holobit.__all__) == {
+        "crear_holobit",
+        "validar_holobit",
+        "serializar_holobit",
+        "deserializar_holobit",
+        "proyectar",
+        "transformar",
+        "graficar",
+        "combinar",
+        "medir",
+    }
+    assert all(callable(getattr(stdlib_holobit, nombre)) for nombre in stdlib_holobit.__all__)
+
+
 def test_internals_holobit_sdk_no_importables_directo_desde_usar_loader() -> None:
     with pytest.raises(PermissionError) as excinfo:
         usar_loader.obtener_modulo("holobit_sdk")


### PR DESCRIPTION
### Motivation
- Garantizar que el adaptador público de `holobit` cumple el contrato Cobra-facing (normaliza entradas/salidas a `dict`/listas/escalares y no expone internals/SDK). 
- Evitar comportamientos ambiguos en la API pública mediante pruebas que validen tipos y estructuras retornadas. 
- Reforzar validación de entrada para prevenir que valores booleanos se acepten como números en `crear_holobit`.

### Description
- Añadido `test_holobit_adapter_normaliza_tipos_cobra_facing` en `tests/unit/test_corelibs_holobit_adapter.py` para verificar que `crear_holobit`, `proyectar`, `transformar`, `combinar` y `medir` devuelven estructuras Cobra-facing (`dict`, listas y escalares tipados) y valores numéricos como `float`/`int`.
- Añadido `test_crear_holobit_rechaza_booleanos` en `tests/unit/test_corelibs_holobit_adapter.py` para asegurar que `crear_holobit` rechaza booleanos como entradas numéricas.
- Añadido `test_stdlib_holobit_exporta_exactamente_api_permitida` en `tests/unit/test_usar_loader_public_api_contract.py` para comprobar que `pcobra.standard_library.holobit.__all__` expone exactamente la API canónica y que cada símbolo es callable.

### Testing
- Ejecuté `pytest -q tests/unit/test_corelibs_holobit_adapter.py::test_holobit_adapter_normaliza_tipos_cobra_facing tests/unit/test_corelibs_holobit_adapter.py::test_crear_holobit_rechaza_booleanos tests/unit/test_usar_loader_public_api_contract.py::test_stdlib_holobit_exporta_exactamente_api_permitida` y las tres pruebas pasaron ✅.
- Ejecutar `pytest -q tests/unit/test_corelibs_holobit_adapter.py tests/unit/test_usar_loader_public_api_contract.py` mostró 5 fallos preexistentes en `test_politica_de_simbolos_prohibidos_devuelve_codigo_y_mensaje` debido a una discrepancia en `resultado.codigo` (`explicit_forbidden_name` vs `cobra_public_equivalent`), lo cual es un problema de política existente no introducido por estos cambios ⚠️.
- Nota: este PR sólo añade pruebas (no modifica la lógica de runtime); las fallas detectadas son regresiones/política existentes que requieren una corrección separada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb30495c308327bbadd3b19d760b40)