### PR TITLE
Lazy-load internal legacy transpiler registry to avoid import-time side effects

### DIFF
--- a/src/pcobra/cobra/transpilers/registry.py
+++ b/src/pcobra/cobra/transpilers/registry.py
@@ -152,10 +152,17 @@ def _validate_internal_legacy_registry_contract() -> tuple[str, ...]:
 
 _ORDERED_ALL_TARGETS: Final[tuple[str, ...]] = _validate_complete_registry_contract()
 _ORDERED_OFFICIAL_TARGETS: Final[tuple[str, ...]] = _validate_public_registry_contract()
-_ORDERED_INTERNAL_LEGACY_TARGETS: Final[tuple[str, ...]] = (
-    _validate_internal_legacy_registry_contract()
-)
+_ORDERED_INTERNAL_LEGACY_TARGETS_CACHE: tuple[str, ...] | None = None
 _OFFICIAL_TARGETS_SET: Final[frozenset[str]] = frozenset(_ORDERED_OFFICIAL_TARGETS)
+
+
+def _ordered_internal_legacy_targets() -> tuple[str, ...]:
+    """Resuelve y cachea el orden de backends legacy internos de forma lazy."""
+    global _ORDERED_INTERNAL_LEGACY_TARGETS_CACHE
+    if _ORDERED_INTERNAL_LEGACY_TARGETS_CACHE is None:
+        _ORDERED_INTERNAL_LEGACY_TARGETS_CACHE = _validate_internal_legacy_registry_contract()
+    return _ORDERED_INTERNAL_LEGACY_TARGETS_CACHE
+
 _PLUGIN_TRANSPILERS: dict[str, type] = {}
 _ENTRYPOINTS_LOADED = False
 
@@ -172,7 +179,7 @@ def ordered_internal_legacy_transpiler_paths() -> tuple[tuple[str, tuple[str, st
     """Devuelve el inventario legacy interno en orden contractual."""
     return tuple(
         (target, INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS[target])
-        for target in _ORDERED_INTERNAL_LEGACY_TARGETS
+        for target in _ordered_internal_legacy_targets()
     )
 
 
@@ -186,7 +193,7 @@ def ordered_internal_legacy_transpiler_entries() -> tuple[tuple[str, tuple[str, 
             INTERNAL_LEGACY_TRANSPILER_CLASS_PATHS[target],
             lifecycle_status_for_backend(target),
         )
-        for target in _ORDERED_INTERNAL_LEGACY_TARGETS
+        for target in _ordered_internal_legacy_targets()
     )
 
 

--- a/tests/unit/test_usar_public_contract.py
+++ b/tests/unit/test_usar_public_contract.py
@@ -108,8 +108,16 @@ def test_no_aparecen_simbolos_prohibidos_en_exports():
 def test_runtime_startup_no_carga_legacy_backends():
     result = _run_python_isolated(
         "import pcobra; import sys; "
-        "legacy = ('pcobra.cobra.transpilers.transpiler.to_go','pcobra.cobra.transpilers.transpiler.to_cpp','pcobra.cobra.transpilers.transpiler.to_java','pcobra.cobra.transpilers.transpiler.to_wasm','pcobra.cobra.transpilers.transpiler.to_asm'); "
-        "assert not any(name in sys.modules for name in legacy), 'startup cargó backends legacy';"
+        "legacy = ("
+        "'pcobra.cobra.transpilers.transpiler.to_go',"
+        "'pcobra.cobra.transpilers.transpiler.to_cpp',"
+        "'pcobra.cobra.transpilers.transpiler.to_java',"
+        "'pcobra.cobra.transpilers.transpiler.to_wasm',"
+        "'pcobra.cobra.transpilers.transpiler.to_asm',"
+        "'pcobra.cobra.internal_compat.legacy_contracts',"
+        "'pcobra.cobra.cli.internal_compat.legacy_targets',"
+        "); "
+        "assert not any(name in sys.modules for name in legacy), 'startup cargó módulos legacy';"
     )
     assert result.returncode == 0, result.stderr
 


### PR DESCRIPTION
### Motivation
- Evitar efectos secundarios por imports eager al resolver contratos/metadata de transpiladores legacy internos durante el arranque público.
- Mantener la superficie pública y el contrato de backends públicos (`python`, `javascript`, `rust`) sin alterar su comportamiento ni la API CLI.

### Description
- Reemplacé la evaluación eager de `_validate_internal_legacy_registry_contract()` por un caché lazy `_ORDERED_INTERNAL_LEGACY_TARGETS_CACHE` y un resolver diferido `_ordered_internal_legacy_targets()` en `src/pcobra/cobra/transpilers/registry.py`.
- Actualicé `ordered_internal_legacy_transpiler_paths()` y `ordered_internal_legacy_transpiler_entries()` para consumir los targets legacy a través del resolver lazy en vez de una constante evaluada en import-time.
- No se cambió el registro público ni la carga de backends públicos; `ordered_official_transpiler_paths()` y la lógica pública de `get_transpilers()` permanecen intactas.
- Fortalecí la aserción en `tests/unit/test_usar_public_contract.py` para verificar que módulos legacy adicionales (`pcobra.cobra.internal_compat.legacy_contracts`, `pcobra.cobra.cli.internal_compat.legacy_targets`) no se carguen en startup.

### Testing
- Ejecutado: `pytest -q tests/unit/test_usar_public_contract.py::test_runtime_startup_no_carga_legacy_backends tests/test_cli_entrypoint_imports.py::test_cli_public_commands_do_not_import_legacy_transpilers_on_startup tests/unit/test_registry_contract_guardrail.py`.
- Resultado: las pruebas focalizadas pasaron (todos los tests ejecutados completaron correctamente, salida del runner: `8 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb41d3822c832788b386720e0e4f3e)