### PR TITLE
Centraliza política de módulos `usar` y alinea runtime/loader/docs

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -4,21 +4,7 @@ import re
 from pathlib import Path
 import sys
 
-# Allowlist canónica de módulos Cobra habilitados para `usar`.
-USAR_COBRA_PUBLIC_MODULES: tuple[str, ...] = (
-    "numero",
-    "texto",
-    "datos",
-    "logica",
-    "asincrono",
-    "sistema",
-    "archivo",
-    "tiempo",
-    "red",
-    "holobit",
-)
-
-USAR_COBRA_ALLOWLIST: frozenset[str] = frozenset(USAR_COBRA_PUBLIC_MODULES)
+from pcobra.cobra.usar_policy import USAR_COBRA_ALLOWLIST, USAR_COBRA_PUBLIC_MODULES
 
 # Módulos no canónicos conocidos que deben rechazarse de forma explícita.
 _USAR_NON_CANONICAL_MODULES: frozenset[str] = frozenset({

--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -6,7 +6,20 @@ import importlib
 from dataclasses import dataclass
 from pathlib import Path
 
-from pcobra.cobra.usar_loader import USAR_COBRA_PUBLIC_MODULES
+# Fuente única de verdad de módulos canónicos permitidos por `usar`.
+USAR_COBRA_PUBLIC_MODULES: tuple[str, ...] = (
+    "numero",
+    "texto",
+    "datos",
+    "logica",
+    "asincrono",
+    "sistema",
+    "archivo",
+    "tiempo",
+    "red",
+    "holobit",
+)
+USAR_COBRA_ALLOWLIST: frozenset[str] = frozenset(USAR_COBRA_PUBLIC_MODULES)
 
 REPL_COBRA_MODULE_MAP: dict[str, str] = {modulo: modulo for modulo in USAR_COBRA_PUBLIC_MODULES}
 
@@ -124,6 +137,21 @@ CANONICAL_MODULE_SURFACE_CONTRACTS: dict[str, CanonicalModuleSurfaceContract] = 
         allowed_aliases={},
         forbidden_symbols=("_SDKHolobit",),
     ),
+}
+
+# Excepciones de exportación pública por módulo para runtime `usar`.
+USAR_RUNTIME_EXPORT_OVERRIDES: dict[str, tuple[str, ...]] = {
+    "holobit": (
+        "crear_holobit",
+        "validar_holobit",
+        "serializar_holobit",
+        "deserializar_holobit",
+        "proyectar",
+        "transformar",
+        "graficar",
+        "combinar",
+        "medir",
+    )
 }
 
 

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -69,7 +69,7 @@ from .cobra_config import (
     limite_memoria_mb,
     limite_cpu_segundos,
 )
-from ..cobra.usar_policy import REPL_COBRA_MODULE_MAP
+from ..cobra.usar_policy import REPL_COBRA_MODULE_MAP, USAR_RUNTIME_EXPORT_OVERRIDES
 from .usar_symbol_policy import sanear_simbolo_para_usar
 from .resource_limits import (
     limitar_memoria_mb as _lim_mem,
@@ -1849,18 +1849,8 @@ class InterpretadorCobra:
         def _resolver_exportables(modulo_obj, *, modulo_oficial: bool, nombre_modulo: str):
             """Resuelve exportables candidatos según política de ``usar``."""
             exportables = getattr(modulo_obj, "__all__", None)
-            if modulo_oficial and nombre_modulo == "holobit":
-                exportables = [
-                    "crear_holobit",
-                    "validar_holobit",
-                    "serializar_holobit",
-                    "deserializar_holobit",
-                    "proyectar",
-                    "transformar",
-                    "graficar",
-                    "combinar",
-                    "medir",
-                ]
+            if modulo_oficial:
+                exportables = USAR_RUNTIME_EXPORT_OVERRIDES.get(nombre_modulo, exportables)
 
             if exportables is None:
                 candidatos = [

--- a/tests/unit/test_usar_policy_contract.py
+++ b/tests/unit/test_usar_policy_contract.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pcobra.cobra.usar_loader import USAR_COBRA_PUBLIC_MODULES, obtener_modulo_cobra_oficial
+from pcobra.cobra.usar_loader import obtener_modulo_cobra_oficial
 from pcobra.cobra.usar_policy import (
     CANONICAL_MODULE_SURFACE_CONTRACTS,
     REPL_COBRA_MODULE_INTERNAL_PATH_MAP,
     REPL_COBRA_MODULE_MAP,
+    USAR_COBRA_PUBLIC_MODULES,
+    USAR_RUNTIME_EXPORT_OVERRIDES,
     validar_paridad_superficie_publica_modulos_canonicos,
 )
 
@@ -39,3 +41,17 @@ def test_contrato_superficie_publica_cubre_modulos_canonicos() -> None:
 
 def test_validacion_paridad_superficie_publica_ejecutable() -> None:
     validar_paridad_superficie_publica_modulos_canonicos()
+
+
+def test_consistencia_runtime_loader_docs_modulos_canonicos() -> None:
+    canonicos = tuple(USAR_COBRA_PUBLIC_MODULES)
+
+    assert tuple(REPL_COBRA_MODULE_MAP.keys()) == canonicos
+    assert tuple(REPL_COBRA_MODULE_MAP.values()) == canonicos
+    assert set(CANONICAL_MODULE_SURFACE_CONTRACTS) == set(canonicos)
+    assert set(USAR_RUNTIME_EXPORT_OVERRIDES).issubset(set(canonicos))
+
+    repo_root = Path(__file__).resolve().parents[2]
+    for modulo in canonicos:
+        doc_path = repo_root / "docs" / "standard_library" / f"{modulo}.md"
+        assert doc_path.exists(), f"Falta doc pública para módulo canónico: {modulo}"


### PR DESCRIPTION
### Motivation
- Eliminar listas duplicadas y puntos de decisión dispersos sobre qué módulos `usar` está permitido para evitar desalineos entre runtime, loader y documentación.
- Hacer que el cargador y el intérprete consuman una única fuente de verdad para reducir la probabilidad de regresiones por drift.
- Mantener compatibilidad con la sintaxis actual del parser (`usar "modulo"`) sin introducir nueva sintaxis.

### Description
- Se creó la política canónica en `src/pcobra/cobra/usar_policy.py` que define `USAR_COBRA_PUBLIC_MODULES`, `USAR_COBRA_ALLOWLIST`, `REPL_COBRA_MODULE_MAP` y `USAR_RUNTIME_EXPORT_OVERRIDES` (excepciones de exportación runtime como `holobit`).
- `src/pcobra/cobra/usar_loader.py` ahora consume la allowlist/catálogo central importando `USAR_COBRA_PUBLIC_MODULES` y `USAR_COBRA_ALLOWLIST` desde `usar_policy.py`, eliminando la duplicación local.
- `src/pcobra/core/interpreter.py` dejó la lista embebida de exportables para `holobit` y ahora usa `USAR_RUNTIME_EXPORT_OVERRIDES` desde la política central para resolver exportables en `ejecutar_usar`.
- Se añadió un test de consistencia `test_consistencia_runtime_loader_docs_modulos_canonicos` en `tests/unit/test_usar_policy_contract.py` que valida paridad entre runtime, loader, contratos y la existencia de la documentación en `docs/standard_library/*.md`.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_policy_contract.py tests/unit/test_repl_official_stdlib_exports_policy.py` como smoke/regresión de la política centralizada.
- Resultado: las pruebas pasaron (`9 passed`) con una advertencia deprecation; no hubo fallos en las aserciones de contrato/consistencia.
- Los cambios afectan únicamente a la resolución/validación de módulos `usar` y a tests relacionados; no se introdujeron cambios en la gramática del parser ni en la API pública de `usar`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb512699e48327b346d0145f8e82fe)