### PR TITLE
Refuerza saneamiento de símbolos `usar` con equivalencias canónicas

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -4,19 +4,19 @@ from dataclasses import dataclass
 from types import ModuleType
 from typing import Any
 
-NOMBRES_PROHIBIDOS_EXPLICITOS = frozenset(
-    {
-        "self",
-        "append",
-        "map",
-        "filter",
-        "unwrap",
-        "expect",
-        "keys",
-        "values",
-        "len",
-    }
-)
+EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS = {
+    "self": "instancia",
+    "append": "agregar",
+    "map": "mapear",
+    "filter": "filtrar",
+    "unwrap": "obtener_o_error",
+    "expect": "obtener_o_error",
+    "keys": "claves",
+    "values": "valores",
+    "len": "longitud",
+}
+
+NOMBRES_PROHIBIDOS_EXPLICITOS = frozenset(EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS)
 DUNDERS_BLOQUEADOS = frozenset(
     {"__builtins__", "__loader__", "__package__", "__spec__", "__name__"}
 )
@@ -77,6 +77,16 @@ def _rechazar(nombre: str, simbolo: object, codigo: str, mensaje: str) -> Result
     return ResultadoSaneamientoSimboloUsar(nombre, simbolo, True, codigo, mensaje)
 
 
+def _mensaje_nombre_prohibido(nombre: str) -> str:
+    recomendado = EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS.get(nombre)
+    if recomendado:
+        return (
+            f"nombre '{nombre}' no permitido por política de usar. "
+            f"Usa el nombre Cobra canónico '{recomendado}'."
+        )
+    return "nombre prohibido por política explícita de usar"
+
+
 def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamientoSimboloUsar:
     """Aplica la política de exportación de símbolos para ``usar``."""
     if nombre.startswith("_"):
@@ -124,7 +134,7 @@ def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamien
             nombre,
             simbolo,
             "explicit_forbidden_name",
-            "nombre prohibido por política explícita de usar",
+            _mensaje_nombre_prohibido(nombre),
         )
 
     if not callable(simbolo) and nombre not in NOMBRES_CONSTANTES_PUBLICAS_CANONICAS:
@@ -132,7 +142,7 @@ def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamien
             nombre,
             simbolo,
             "non_callable_not_canonical_public_constant",
-            "solo se permiten no-callables para constantes públicas canónicas",
+            "solo se permiten no-callables para constantes públicas explícitas y canónicas",
         )
 
     if not callable(simbolo):

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -38,11 +38,23 @@ def test_rechaza_dunders_python_conocidos():
     assert resultado.codigo == "private_prefix"
 
 
-def test_rechaza_aliases_publicos_reservados():
-    for nombre in ("append", "map", "filter", "unwrap", "expect", "self", "keys", "values", "len"):
+def test_rechaza_aliases_publicos_reservados_con_nombre_recomendado():
+    esperados = {
+        "append": "agregar",
+        "map": "mapear",
+        "filter": "filtrar",
+        "unwrap": "obtener_o_error",
+        "expect": "obtener_o_error",
+        "self": "instancia",
+        "keys": "claves",
+        "values": "valores",
+        "len": "longitud",
+    }
+    for nombre, recomendado in esperados.items():
         resultado = sanear_simbolo_para_usar(nombre, _callable_dummy)
         assert resultado.rechazado is True
         assert resultado.codigo == "explicit_forbidden_name"
+        assert recomendado in (resultado.mensaje or "")
 
 
 def test_rechaza_objetos_modulo():
@@ -129,3 +141,10 @@ def test_usar_modulo_totalmente_invalido_falla(monkeypatch):
     interp = InterpretadorCobra(safe_mode=False)
     with pytest.raises(ImportError, match="no quedaron símbolos exportables"):
         interp.ejecutar_usar(NodoUsar("numero"))
+
+
+def test_rechaza_nombres_con_dunder_en_cualquier_posicion():
+    for nombre in ("mi__simbolo", "__x", "x__", "normal__otro"):
+        resultado = sanear_simbolo_para_usar(nombre, _callable_dummy)
+        assert resultado.rechazado is True
+        assert resultado.codigo in {"dunder_pattern", "private_prefix"}


### PR DESCRIPTION
### Motivation
- Evitar que nombres en inglés o alias reservados (por ejemplo `append`, `map`, `filter`, `unwrap`, `expect`, `self`) sean exportados por `usar` sin señalar la forma canónica en Cobra.
- Proveer mensajes de error accionables que indiquen la alternativa canónica para facilitar migraciones y uso correcto de nombres.
- Aclarar y reforzar la política que solo permite constantes no-callables si son explícitas y canónicas.

### Description
- Agrega `EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS` en `src/pcobra/core/usar_symbol_policy.py` con el mapa `prohibido -> canónico` (por ejemplo `append: agregar`, `map: mapear`, `unwrap/expect: obtener_o_error`, `self: instancia`).
- Deriva `NOMBRES_PROHIBIDOS_EXPLICITOS` de ese mapa para evitar duplicidad y divergencias.
- Implementa `_mensaje_nombre_prohibido(nombre)` que devuelve un mensaje accionable sugiriendo el nombre Cobra canónico cuando exista equivalencia, y lo usa al rechazar nombres explícitos prohibidos.
- Ajusta el texto de política para constantes no-callables a "constantes públicas explícitas y canónicas".
- Añade/actualiza pruebas en `tests/unit/test_usar_symbol_policy.py` para validar que se rechazan los alias reservados con la recomendación canónica y que se rechazan nombres que contengan `__` en cualquier posición.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_symbol_policy.py -k 'aliases_publicos_reservados_con_nombre_recomendado or rechaza_nombres_con_dunder_en_cualquier_posicion or rechaza_dunders or rechaza_aliases'` y pasó exitosamente. 
- Ejecuté `pytest -q tests/unit/test_usar_symbol_policy.py` y el conjunto completo de tests del archivo mostró 2 fallos (en `test_usar_modulo_mixto_importa_solo_simbolos_validos` y `test_usar_modulo_totalmente_invalido_falla`) en este entorno; las pruebas nuevas específicas relacionadas con las equivalencias y patrones `__` pasan correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb611d565083278ad9e5bb207f83a6)