### PR TITLE
Sanear frontera pública de Holobit y reforzar pruebas de no fuga

### DIFF
--- a/docs/contrato_runtime_holobit.md
+++ b/docs/contrato_runtime_holobit.md
@@ -53,6 +53,23 @@ Serialización pública:
 - `serializar_holobit(hb)` produce JSON del objeto completo del contrato público.
 - `deserializar_holobit(payload)` exige ese mismo contrato y rechaza payloads legacy (por ejemplo arrays sueltos o claves extra).
 
+
+## Frontera estricta de exportación
+
+Para `usar "holobit"` (fachadas `pcobra.corelibs.holobit`, `pcobra.standard_library.holobit` y superficie de `pcobra.core.holobits`) la API pública permitida es **solo**:
+
+- `crear_holobit`
+- `validar_holobit`
+- `serializar_holobit`
+- `deserializar_holobit`
+- `proyectar`
+- `transformar`
+- `graficar`
+- `combinar`
+- `medir`
+
+No se deben exportar `holobit_sdk`, la clase interna `Holobit` ni helpers privados.
+
 ## Semántica mínima
 
 ### Política oficial cuando falta `holobit_sdk`

--- a/docs/standard_library/holobit.md
+++ b/docs/standard_library/holobit.md
@@ -34,10 +34,10 @@ El módulo `holobit` disponible vía `usar "holobit"` expone **solo** estas func
 - La estructura de intercambio es serializable y Cobra-compatible:
 
 ```json
-{"__cobra_tipo__": "holobit", "valores": [1.0, 2.0, 3.0]}
+{"tipo":"holobit","valores":[1.0,2.0,3.0]}
 ```
 
-- Si `holobit_sdk` está instalado, el adaptador puede usarlo internamente para validar compatibilidad, sin exponer sus símbolos.
+- El módulo no expone `holobit_sdk`, clases internas ni helpers privados; cualquier acceso directo a esos símbolos se considera fuga y debe fallar en pruebas.
 - `usar "holobit_sdk"` está prohibido por política de `usar`.
 
 ## Ejemplos Cobra

--- a/src/pcobra/core/holobits/__init__.py
+++ b/src/pcobra/core/holobits/__init__.py
@@ -1,22 +1,23 @@
-"""API pública del runtime Python para objetos ``Holobit``.
+"""Superficie pública saneada para Holobit en runtime Python."""
 
-El contrato Holobit transversal multi-backend incluye únicamente
-``holobit``, ``proyectar``, ``transformar`` y ``graficar``. Los helpers
-``escalar`` y ``mover`` se exportan aquí como capacidades adicionales del
-runtime Python y no deben leerse como parte de la matriz contractual
-multi-backend.
-"""
-
-from .holobit import Holobit
-from .graficar import graficar
-from .proyeccion import proyectar
-from .transformacion import transformar, escalar, mover
+from importlib import import_module
+from typing import Any
 
 __all__ = [
-    "Holobit",
-    "graficar",
+    "crear_holobit",
+    "validar_holobit",
+    "serializar_holobit",
+    "deserializar_holobit",
     "proyectar",
     "transformar",
-    "escalar",
-    "mover",
+    "graficar",
+    "combinar",
+    "medir",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    modulo = import_module("pcobra.corelibs.holobit")
+    return getattr(modulo, name)

--- a/src/pcobra/standard_library/holobit.py
+++ b/src/pcobra/standard_library/holobit.py
@@ -1,15 +1,15 @@
 """Fachada pública Holobit para `usar \"holobit\"`."""
 
 from pcobra.corelibs.holobit import (
-    crear_holobit,
-    validar_holobit,
-    serializar_holobit,
-    deserializar_holobit,
-    proyectar,
-    transformar,
-    graficar,
     combinar,
+    crear_holobit,
+    deserializar_holobit,
+    graficar,
     medir,
+    proyectar,
+    serializar_holobit,
+    transformar,
+    validar_holobit,
 )
 
 __all__ = [
@@ -23,57 +23,3 @@ __all__ = [
     "combinar",
     "medir",
 ]
-
-
-def crear_holobit(*args, **kwargs):
-    """Delega en ``pcobra.corelibs.holobit.crear_holobit``."""
-
-    return _holobit.crear_holobit(*args, **kwargs)
-
-
-def validar_holobit(*args, **kwargs):
-    """Delega en ``pcobra.corelibs.holobit.validar_holobit``."""
-
-    return _holobit.validar_holobit(*args, **kwargs)
-
-
-def serializar_holobit(*args, **kwargs):
-    """Delega en ``pcobra.corelibs.holobit.serializar_holobit``."""
-
-    return _holobit.serializar_holobit(*args, **kwargs)
-
-
-def deserializar_holobit(*args, **kwargs):
-    """Delega en ``pcobra.corelibs.holobit.deserializar_holobit``."""
-
-    return _holobit.deserializar_holobit(*args, **kwargs)
-
-
-def proyectar(*args, **kwargs):
-    """Delega en ``pcobra.corelibs.holobit.proyectar``."""
-
-    return _holobit.proyectar(*args, **kwargs)
-
-
-def transformar(*args, **kwargs):
-    """Delega en ``pcobra.corelibs.holobit.transformar``."""
-
-    return _holobit.transformar(*args, **kwargs)
-
-
-def graficar(*args, **kwargs):
-    """Delega en ``pcobra.corelibs.holobit.graficar``."""
-
-    return _holobit.graficar(*args, **kwargs)
-
-
-def combinar(*args, **kwargs):
-    """Delega en ``pcobra.corelibs.holobit.combinar``."""
-
-    return _holobit.combinar(*args, **kwargs)
-
-
-def medir(*args, **kwargs):
-    """Delega en ``pcobra.corelibs.holobit.medir``."""
-
-    return _holobit.medir(*args, **kwargs)

--- a/tests/unit/test_holobit_no_fuga_exports.py
+++ b/tests/unit/test_holobit_no_fuga_exports.py
@@ -1,0 +1,62 @@
+import importlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+EXPECTED_API = {
+    "crear_holobit",
+    "validar_holobit",
+    "serializar_holobit",
+    "deserializar_holobit",
+    "proyectar",
+    "transformar",
+    "graficar",
+    "combinar",
+    "medir",
+}
+
+
+def _load_corelib_module():
+    ruta = Path("src/pcobra/corelibs/holobit.py").resolve()
+    spec = importlib.util.spec_from_file_location("_holobit_corelib_no_fuga", ruta)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.parametrize(
+    "mod_name",
+    ["pcobra.standard_library.holobit", "pcobra.core.holobits"],
+)
+def test_superficies_holobit_solo_exportan_api_canonica(mod_name):
+    mod = importlib.import_module(mod_name)
+    assert set(mod.__all__) == EXPECTED_API
+
+
+def test_corelibs_holobit_solo_exporta_api_canonica():
+    mod = _load_corelib_module()
+    assert set(mod.__all__) == EXPECTED_API
+
+
+@pytest.mark.parametrize(
+    "mod_name,symbol",
+    [
+        ("pcobra.standard_library.holobit", "holobit_sdk"),
+        ("pcobra.standard_library.holobit", "Holobit"),
+        ("pcobra.core.holobits", "holobit_sdk"),
+        ("pcobra.core.holobits", "Holobit"),
+    ],
+)
+def test_no_fuga_de_sdk_ni_clases_internas(mod_name, symbol):
+    mod = importlib.import_module(mod_name)
+    with pytest.raises(AttributeError):
+        getattr(mod, symbol)
+
+
+def test_no_fuga_en_corelibs_por_getattr():
+    mod = _load_corelib_module()
+    for symbol in ("holobit_sdk", "Holobit"):
+        with pytest.raises(AttributeError):
+            getattr(mod, symbol)


### PR DESCRIPTION
### Motivation

- Asegurar que las superficies públicas de Holobit exporten únicamente la API canónica: `crear_holobit`, `validar_holobit`, `serializar_holobit`, `deserializar_holobit`, `proyectar`, `transformar`, `graficar`, `combinar`, `medir`.
- Evitar fugas de símbolos internos y del SDK (`holobit_sdk`, `Holobit`) desde `corelibs`, `standard_library` y `core.holobits` hacia usuarios de `usar "holobit"`.
- Garantizar que la serialización/deserialización use el contrato público Cobra estable (objeto con claves `tipo` y `valores`) y documentar la frontera de exportación.
- Añadir pruebas que verifiquen explícitamente que no es posible acceder a símbolos internos desde las fachadas públicas.

### Description

- Saneé `src/pcobra/standard_library/holobit.py` para importar explícitamente solo las funciones canónicas y exponerlas mediante `__all__` sin wrappers redundantes. 
- Reescribí `src/pcobra/core/holobits/__init__.py` para exponer un `__all__` fijo y una resolución perezosa mediante `__getattr__` que solo permite resolver los nombres canónicos y rechaza cualquier otro símbolo.
- Actualicé la documentación en `docs/contrato_runtime_holobit.md` y `docs/standard_library/holobit.md` para reflejar el contrato estable (`{"tipo":"holobit","valores":[...]}`) y la frontera estricta que prohíbe exponer `holobit_sdk` y clases internas.
- Añadí pruebas nuevas en `tests/unit/test_holobit_no_fuga_exports.py` que cargan `pcobra.corelibs.holobit` de forma aislada y verifican que las superficies públicas exporten exactamente la API canónica y que el acceso a `holobit_sdk`/`Holobit` falle.

### Testing

- Ejecuté `pytest -q tests/unit/test_corelibs_holobit_adapter.py tests/unit/test_holobit_no_fuga_exports.py` y todos los tests automatizados relacionados pasaron exitosamente. 
- Los tests nuevos verifican la igualdad exacta de `__all__` en las superficies públicas y que `getattr(...)` sobre `holobit_sdk` y `Holobit` lanza `AttributeError` en las fachadas públicas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb77601f888327b39eb3c8cbfc3cea)