### PR TITLE
test(usar): ampliar cobertura de telemetría, colisiones y módulos prohibidos

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -655,3 +655,49 @@ def test_politica_publica_backend_es_python_javascript_rust():
     from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 
     assert PUBLIC_BACKENDS == ("python", "javascript", "rust")
+
+
+def test_repl_usar_emite_evento_telemetria_saneamiento_rechazado(monkeypatch, caplog):
+    modulo = ModuleType("mod_ext")
+    modulo.__all__ = ["ok", "backend"]
+    modulo.ok = lambda valor: valor
+    modulo.backend = ModuleType("backend_obj")
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/mod_ext.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"mod_ext": "mod_ext"})
+
+    with pytest.raises(ImportError, match=r"rechazos de saneamiento en usar"):
+        interp.ejecutar_nodo(NodoUsar("mod_ext"))
+
+    assert "usar_sanitize_reject" in caplog.text
+    assert "simbolos_rechazados" in caplog.text
+
+
+def test_repl_usar_emite_evento_telemetria_colision_warn(monkeypatch, caplog):
+    modulo = ModuleType("texto")
+    modulo.__all__ = ["a_snake", "a_camel"]
+    modulo.a_snake = lambda texto: texto
+    modulo.a_camel = lambda texto: texto
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/texto.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"texto": "texto"})
+    interp.configurar_politica_colision_usar("warn_alias_required")
+    interp.contextos[-1].define("a_snake", lambda _texto: "ocupado")
+
+    with pytest.raises(NameError, match=r"Requiere alias explícito"):
+        interp.ejecutar_nodo(NodoUsar("texto"))
+
+    assert "usar_collision" in caplog.text
+    assert "warn_alias_required" in caplog.text
+
+
+@pytest.mark.parametrize("nombre", ["numpy", "node-fetch", "serde", "holobit_sdk"])
+def test_usar_loader_rechaza_numpy_y_equivalentes_prohibidos(nombre):
+    with pytest.raises(PermissionError, match=r"Importación no permitida en 'usar'"):
+        usar_loader.obtener_modulo(nombre)


### PR DESCRIPTION
### Motivation
- Añadir pruebas que verifiquen telemetría y mensajes estructurados durante saneamiento de `usar` y colisiones de símbolos.
- Garantizar que importaciones no-canónicas/ backend (ej. `numpy`, `node-fetch`, `serde`, `holobit_sdk`) sean rechazadas de forma consistente por `usar_loader`.
- Asegurar que las políticas de colisión (`warn_alias_required` / strict) no causen sobreescritura silenciosa y produzcan errores coherentes.

### Description
- Se añadieron tests en `tests/unit/test_usar.py` que comprueban que un módulo con símbolos rechazables emite el evento de telemetría `usar_sanitize_reject` y lanza `ImportError` al intentar `usar`lo.
- Se añadió un test que simula colisión bajo `warn_alias_required` y verifica que se lanza `NameError` y que se registra `usar_collision` en el log sin inyectar símbolos.
- Se añadió un test parametrizado que asegura que `usar_loader.obtener_modulo(...)` rechaza siempre módulos prohibidos como `numpy`, `node-fetch`, `serde` y `holobit_sdk` con `PermissionError`.
- Los cambios son únicamente pruebas (append a `tests/unit/test_usar.py`) y no modifican la implementación runtime de `usar`.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar.py -k "telemetria or equivalentes_prohibidos or warn_alias_required_no_overwrite or no_sobrescritura or colision or numpy"` para validar las pruebas añadidas, pero la ejecución falló durante la colección con un `ImportError: attempted relative import beyond top-level package` originado en la importación de `core.interpreter` y ajeno a las pruebas nuevas.
- Ninguno de los nuevos asserts fue ejecutado debido al fallo de colección, por lo que las nuevas pruebas están añadidas pero no pasadas en este entorno de ejecución.
- Se recomienda ejecutar la batería completa de `tests/unit/test_usar.py` en un entorno con el path/paquete `pcobra` correctamente configurado para validar los nuevos tests de telemetría y rechazo de módulos prohibidos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb79dd38088327bf23d4d26fdcc8d0)