### PR TITLE
test: verify cobra repl/run/test startup avoids eager legacy backend imports

### DIFF
--- a/tests/unit/test_startup_no_legacy_eager_loading.py
+++ b/tests/unit/test_startup_no_legacy_eager_loading.py
@@ -86,6 +86,38 @@ def test_import_comandos_run_repl_test_no_precarga_transpiladores_legacy():
     assert result.returncode == 0, result.stderr
 
 
+
+def _run_cli_parse_isolated(subcommand: str) -> subprocess.CompletedProcess[str]:
+    argv = [subcommand]
+    if subcommand in {"run", "test"}:
+        argv.append("dummy.co")
+    code = (
+        "from pcobra.cobra.cli.cli import CliApplication; "
+        "app = CliApplication(); "
+        "app.initialize(); "
+        "app._ensure_command_structure(); "
+        f"argv = {argv!r}; "
+        "app.parser.parse_args(argv); "
+        + _legacy_assertion_snippet()
+    )
+    return _run_python_isolated(code)
+
+
+def test_cobra_repl_no_precarga_transpiladores_legacy():
+    result = _run_cli_parse_isolated('repl')
+    assert result.returncode == 0, result.stderr
+
+
+def test_cobra_run_no_precarga_transpiladores_legacy():
+    result = _run_cli_parse_isolated('run')
+    assert result.returncode == 0, result.stderr
+
+
+def test_cobra_test_no_precarga_transpiladores_legacy():
+    result = _run_cli_parse_isolated('test')
+    assert result.returncode == 0, result.stderr
+
+
 def test_public_backends_permancen_exactamente_tres():
     policy = importlib.import_module("pcobra.cobra.architecture.backend_policy")
     contracts = importlib.import_module("pcobra.cobra.architecture.contracts")


### PR DESCRIPTION
### Motivation
- Asegurar que las rutas de inicio de la CLI (`repl`, `run`, `test`) no provoquen carga temprana de backends legacy (`go`, `cpp`, `java`, `wasm`, `asm`) durante el parseo/inicialización de comandos en tiempo de arranque.
- Extender la cobertura de auditoría de imports desde la mera importación de módulos hasta los caminos de inicio de comando para mantener `PUBLIC_BACKENDS` como el único contrato público.

### Description
- Añadido helper `
_run_cli_parse_isolated` en `tests/unit/test_startup_no_legacy_eager_loading.py` que instancia `CliApplication`, fuerza la estructura de comandos y parsea argv representativos antes de verificar ausencia de modules legacy.
- Añadidas tres pruebas nuevas que verifican que `cobra repl`, `cobra run` y `cobra test` no cargan eager los transpilers legacy durante el bootstrap de CLI.
- Mantuvimos la comprobación existente de contrato público `PUBLIC_BACKENDS == ('python','javascript','rust')` sin cambios.

### Testing
- Ejecutado `pytest -q tests/unit/test_startup_no_legacy_eager_loading.py` y la suite objetivo finalizó correctamente con `8 passed, 1 warning`.
- Las pruebas ejercitan import aislado vía subproceso para validar que ninguno de los módulos legacy (`pcobra.cobra.transpilers.transpiler.to_go`, `to_cpp`, `to_java`, `to_wasm`, `to_asm`) aparece en `sys.modules` durante los caminos de arranque verificados.
- Cambios realizados únicamente en `tests/unit/test_startup_no_legacy_eager_loading.py` y no requieren modificaciones en la API pública ni en los contratos de backends.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb82a7ac9c83279a59d8edf473beba)