### PR TITLE
Corelibs: whitelist explícita de símbolos públicos Cobra

### DIFF
--- a/src/pcobra/corelibs/coleccion.py
+++ b/src/pcobra/corelibs/coleccion.py
@@ -287,3 +287,26 @@ def pares_consecutivos(lista: Iterable[T] | Sequence[T]) -> List[Tuple[T, T]]:
 
     elementos = _asegurar_iterable(lista)
     return list(zip(elementos, elementos[1:]))
+
+
+__all__ = [
+    "ordenar",
+    "maximo",
+    "minimo",
+    "sin_duplicados",
+    "mapear",
+    "mapear_aplanado",
+    "filtrar",
+    "reducir",
+    "encontrar",
+    "aplanar",
+    "agrupar_por",
+    "particionar",
+    "mezclar",
+    "zip_listas",
+    "tomar",
+    "tomar_mientras",
+    "descartar_mientras",
+    "scanear",
+    "pares_consecutivos",
+]

--- a/src/pcobra/corelibs/datos.py
+++ b/src/pcobra/corelibs/datos.py
@@ -1,8 +1,84 @@
 """Módulo canónico ``datos`` para `usar`.
 
 Este puente mantiene el nombre público en español (`usar "datos"`) y reexpone
-la implementación oficial ubicada en ``pcobra.standard_library.datos``.
+la implementación oficial ubicada en ``pcobra.standard_library.datos`` mediante
+una whitelist explícita de símbolos Cobra.
 """
 
-from pcobra.standard_library.datos import *  # noqa: F401,F403
-from pcobra.standard_library.datos import __all__  # noqa: F401
+from pcobra.standard_library import datos as _datos
+
+leer_csv = _datos.leer_csv
+leer_json = _datos.leer_json
+escribir_csv = _datos.escribir_csv
+escribir_json = _datos.escribir_json
+leer_excel = _datos.leer_excel
+escribir_excel = _datos.escribir_excel
+leer_parquet = _datos.leer_parquet
+escribir_parquet = _datos.escribir_parquet
+leer_feather = _datos.leer_feather
+escribir_feather = _datos.escribir_feather
+describir = _datos.describir
+correlacion_pearson = _datos.correlacion_pearson
+correlacion_spearman = _datos.correlacion_spearman
+matriz_covarianza = _datos.matriz_covarianza
+calcular_percentiles = _datos.calcular_percentiles
+resumen_rapido = _datos.resumen_rapido
+seleccionar_columnas = _datos.seleccionar_columnas
+filtrar = _datos.filtrar
+mutar_columna = _datos.mutar_columna
+separar_columna = _datos.separar_columna
+unir_columnas = _datos.unir_columnas
+agrupar_y_resumir = _datos.agrupar_y_resumir
+tabla_cruzada = _datos.tabla_cruzada
+pivotar_ancho = _datos.pivotar_ancho
+pivotar_largo = _datos.pivotar_largo
+ordenar_tabla = _datos.ordenar_tabla
+combinar_tablas = _datos.combinar_tablas
+rellenar_nulos = _datos.rellenar_nulos
+desplegar_tabla = _datos.desplegar_tabla
+pivotar_tabla = _datos.pivotar_tabla
+agregar = _datos.agregar
+mapear = _datos.mapear
+reducir = _datos.reducir
+claves = _datos.claves
+valores = _datos.valores
+longitud = _datos.longitud
+
+__all__ = [
+    "leer_csv",
+    "leer_json",
+    "escribir_csv",
+    "escribir_json",
+    "leer_excel",
+    "escribir_excel",
+    "leer_parquet",
+    "escribir_parquet",
+    "leer_feather",
+    "escribir_feather",
+    "describir",
+    "correlacion_pearson",
+    "correlacion_spearman",
+    "matriz_covarianza",
+    "calcular_percentiles",
+    "resumen_rapido",
+    "seleccionar_columnas",
+    "filtrar",
+    "mutar_columna",
+    "separar_columna",
+    "unir_columnas",
+    "agrupar_y_resumir",
+    "tabla_cruzada",
+    "pivotar_ancho",
+    "pivotar_largo",
+    "ordenar_tabla",
+    "combinar_tablas",
+    "rellenar_nulos",
+    "desplegar_tabla",
+    "pivotar_tabla",
+    "agregar",
+    "mapear",
+    "reducir",
+    "claves",
+    "valores",
+    "longitud",
+]

--- a/src/pcobra/corelibs/seguridad.py
+++ b/src/pcobra/corelibs/seguridad.py
@@ -2,7 +2,6 @@
 
 import hashlib
 import uuid
-import warnings
 
 
 def hash_sha256(texto: str) -> str:
@@ -10,11 +9,13 @@ def hash_sha256(texto: str) -> str:
     return hashlib.sha256(texto.encode("utf-8")).hexdigest()
 
 
-# MD5 es inseguro y se mantiene sólo como alias de ``hash_sha256`` para
-# compatibilidad con versiones anteriores.
-hash_md5 = hash_sha256
+# MD5 es inseguro y se mantiene solo como alias interno para compatibilidad.
+_hash_md5_legacy = hash_sha256
 
 
 def generar_uuid() -> str:
     """Genera un identificador único."""
     return str(uuid.uuid4())
+
+
+__all__ = ["hash_sha256", "generar_uuid"]


### PR DESCRIPTION
### Motivation

- Asegurar que los módulos Core publiquen sólo los símbolos Cobra previstos mediante listas blancas explícitas para evitar exportaciones implícitas o accidentales.
- Uniformizar la API pública usando identificadores en español y `snake_case` coherente con el estilo existente del repositorio.
- Evitar exponer alias en inglés o legados cuando ya existe un nombre oficial en español.

### Description

- `src/pcobra/corelibs/datos.py` reemplaza `from ... import *` por reexportaciones explícitas desde `pcobra.standard_library.datos` (asignadas a `leer_csv`, `mapear`, `filtrar`, `reducir`, `claves`, `valores`, `longitud`, etc.) y declara `__all__` con la whitelist pública en español.
- `src/pcobra/corelibs/coleccion.py` añade un `__all__` que fija el contrato público para las funciones de colección (`ordenar`, `mapear`, `filtrar`, `reducir`, `aplanar`, `agrupar_por`, `tomar`, etc.) evitando que utilidades internas se exporten por accidente.
- `src/pcobra/corelibs/seguridad.py` convierte el alias MD5 en una variable interna (`_hash_md5_legacy`) y expone únicamente la API pública deseada mediante `__all__ = ["hash_sha256", "generar_uuid"]`.

### Testing

- Se ejecutó `python -m pytest -q tests/unit/test_standard_library_datos.py tests/unit/test_corelibs_sistema.py tests/unit/test_corelibs_numero_estadistica.py` y la suite terminó sin errores.
- Resultado de las pruebas: `67 passed, 5 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3d5f756083278d058203561dca8e)