### PR TITLE
Alinear API pública canónica en módulos de biblioteca estándar

### DIFF
--- a/src/pcobra/standard_library/archivo.py
+++ b/src/pcobra/standard_library/archivo.py
@@ -71,10 +71,7 @@ def existe(ruta: PathLike) -> bool:
     return ruta_segura.is_file()
 
 
-__all__ = ["leer", "escribir", "adjuntar", "existe"
-    "eliminar",
-    "anexar",
-    "leer_lineas",]
+__all__ = ["leer", "escribir", "adjuntar", "existe"]
 
 
 def eliminar(*args, **kwargs):

--- a/src/pcobra/standard_library/asincrono.py
+++ b/src/pcobra/standard_library/asincrono.py
@@ -31,16 +31,7 @@ __all__ = [
     "proteger_tarea",
     "ejecutar_en_hilo",
     "reintentar_async",
-
-    "recolectar",
-    "carrera",
-    "primero_exitoso",
-    "esperar_timeout",
-    "crear_tarea",
-    "iterar_completadas",
-    "mapear_concurrencia",
-    "recolectar_resultados",
-    "dormir_async",]
+]
 
 
 def grupo_tareas() -> AsyncContextManager[Any]:

--- a/src/pcobra/standard_library/logica.py
+++ b/src/pcobra/standard_library/logica.py
@@ -38,9 +38,7 @@ __all__ = [
     "exactamente_n",
     "tabla_verdad",
     "diferencia_simetrica",
-
-    "coalesce",
-    "si_condicional",]
+]
 
 
 def es_verdadero(valor: bool) -> bool:

--- a/src/pcobra/standard_library/numero.py
+++ b/src/pcobra/standard_library/numero.py
@@ -35,35 +35,7 @@ __all__ = [
     "cuartiles",
     "rango_intercuartil",
     "coeficiente_variacion",
-
-    "absoluto",
-    "redondear",
-    "piso",
-    "techo",
-    "mcd",
-    "mcm",
-    "es_cercano",
-    "producto",
-    "entero_a_base",
-    "entero_desde_base",
-    "longitud_bits",
-    "contar_bits",
-    "rotar_bits_izquierda",
-    "rotar_bits_derecha",
-    "entero_a_bytes",
-    "entero_desde_bytes",
-    "raiz",
-    "potencia",
-    "clamp",
-    "aleatorio",
-    "mediana",
-    "moda",
-    "desviacion_estandar",
-    "es_par",
-    "es_primo",
-    "factorial",
-    "promedio",
-    "aleatorio_entero",]
+]
 
 
 def es_finito(valor: RealLike) -> bool:

--- a/src/pcobra/standard_library/red.py
+++ b/src/pcobra/standard_library/red.py
@@ -16,8 +16,7 @@ __all__ = [
     "enviar_post_async",
     "descargar_archivo",
     "obtener_json",
-
-    "obtener_url_texto",]
+]
 
 
 def obtener_url(*args, **kwargs):

--- a/src/pcobra/standard_library/sistema.py
+++ b/src/pcobra/standard_library/sistema.py
@@ -14,8 +14,7 @@ __all__ = [
     "obtener_env",
     "listar_dir",
     "directorio_actual",
-
-    "ejecutar_comando_async",]
+]
 
 
 def obtener_os() -> str:


### PR DESCRIPTION
### Motivation
- Evitar que símbolos internos o backends se expongan a la superficie pública `usar`/REPL ajustando `__all__` a la API canónica definida en `CAPACIDADES_POR_MODULO`.
- Corregir fugas accidentales de nombres causadas por concatenaciones o listas desalineadas en varios módulos de `standard_library`.
- Mantener la separación estricta entre la API pública Cobra y los detalles de implementación/backends sin reestructurar la arquitectura existente.

### Description
- Actualicé `__all__` en `src/pcobra/standard_library/archivo.py` para exponer solo `leer`, `escribir`, `adjuntar` y `existe` y corregir la concatenación que provocaba una fuga de símbolos.
- Recorté las exportaciones públicas en `src/pcobra/standard_library/asincrono.py` para exponer únicamente las primitivas canónicas (`grupo_tareas`, `limitar_tiempo`, `proteger_tarea`, `ejecutar_en_hilo`, `reintentar_async`).
- Elimé aliases/entradas no canónicas de la API pública en `src/pcobra/standard_library/logica.py` y `src/pcobra/standard_library/numero.py` dejando las implementaciones internas intactas pero no exportadas.
- Alineé las listas públicas en `src/pcobra/standard_library/red.py` y `src/pcobra/standard_library/sistema.py` con el contrato canónico; los helpers adicionales permanecen como funciones internas no exportadas.

### Testing
- Ejecuté `pytest -q tests/unit/standard_library/test_api_canonica_por_modulo.py` y verificé que todas las aserciones sobre `__all__` pasaran (20 passed).
- Durante la iteración ejecuté una batería más amplia con `pytest` que inicialmente falló por una importación circular detectada durante la recolección; el problema fue solucionado como parte de las modificaciones y las pruebas canónicas volvieron a pasar.
- No se introdujeron cambios en la lógica de las funciones delegadas; los ajustes afectan únicamente la superficie pública exportada (`__all__`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc54036b60832794aaefdf8fb636ca)