### PR TITLE
Fortalecer API pública de holobit y encapsular errores del SDK

### DIFF
--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -13,6 +13,16 @@ from pcobra.core.holobits.graficar import graficar as _sdk_graficar
 from pcobra.core.holobits.holobit import Holobit as _SDKHolobit
 
 
+class ErrorHolobit(ValueError):
+    """Error de dominio Cobra para operaciones de Holobit."""
+
+
+def _error_dominio(mensaje: str, *, causa: Exception | None = None) -> ErrorHolobit:
+    if causa is None:
+        return ErrorHolobit(mensaje)
+    return ErrorHolobit(mensaje)
+
+
 def _es_numero(valor: Any) -> bool:
     return isinstance(valor, (int, float)) and not isinstance(valor, bool)
 
@@ -48,7 +58,10 @@ def _validar_estructura_holobit(hb: Any) -> dict[str, Any]:
 
 def _desde_estructura_cobra(hb: dict[str, Any]) -> _SDKHolobit:
     estructura = _validar_estructura_holobit(hb)
-    return _SDKHolobit(_normalizar_valores(estructura["valores"]))
+    try:
+        return _SDKHolobit(_normalizar_valores(estructura["valores"]))
+    except Exception as exc:  # pragma: no cover - defensivo frente al SDK
+        raise _error_dominio("No se pudo adaptar el holobit al runtime de Cobra", causa=exc) from None
 
 
 def crear_holobit(valores: Iterable[Any]) -> dict[str, Any]:
@@ -72,7 +85,10 @@ def serializar_holobit(hb: dict[str, Any]) -> str:
 def deserializar_holobit(payload: str) -> dict[str, Any]:
     if not isinstance(payload, str):
         raise TypeError("El payload de holobit debe ser texto JSON")
-    datos = json.loads(payload)
+    try:
+        datos = json.loads(payload)
+    except json.JSONDecodeError:
+        raise _error_dominio("El payload de holobit no es JSON válido") from None
     _validar_estructura_holobit(datos)
     return crear_holobit(datos["valores"])
 
@@ -116,7 +132,10 @@ def transformar(hb: dict[str, Any], operacion: str, *parametros: Any) -> dict[st
 
 
 def graficar(hb: dict[str, Any]) -> str:
-    vista = _sdk_graficar(_desde_estructura_cobra(hb))
+    try:
+        vista = _sdk_graficar(_desde_estructura_cobra(hb))
+    except Exception as exc:  # pragma: no cover - defensivo frente al SDK
+        raise _error_dominio("No se pudo graficar el holobit en el runtime de Cobra", causa=exc) from None
     if not isinstance(vista, str):
         raise TypeError("La salida de graficar debe ser texto")
     return vista

--- a/tests/unit/test_holobit_corelib_domain_errors.py
+++ b/tests/unit/test_holobit_corelib_domain_errors.py
@@ -1,0 +1,29 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def holobit_module():
+    ruta = Path("src/pcobra/corelibs/holobit.py").resolve()
+    spec = importlib.util.spec_from_file_location("_holobit_corelib_domain", ruta)
+    modulo = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(modulo)
+    return modulo
+
+
+def test_deserializar_holobit_retorna_error_dominio_en_json_invalido(holobit_module) -> None:
+    with pytest.raises(holobit_module.ErrorHolobit, match="JSON válido"):
+        holobit_module.deserializar_holobit("{json_invalido")
+
+
+def test_adaptador_traduce_error_runtime_sdk_a_error_dominio(monkeypatch: pytest.MonkeyPatch, holobit_module) -> None:
+    class _Boom(Exception):
+        pass
+
+    monkeypatch.setattr(holobit_module, "_SDKHolobit", lambda *_args, **_kwargs: (_ for _ in ()).throw(_Boom("sdk raw")))
+
+    with pytest.raises(holobit_module.ErrorHolobit, match="runtime de Cobra"):
+        holobit_module.serializar_holobit({"tipo": "holobit", "valores": [1, 2, 3]})


### PR DESCRIPTION
### Motivation
- Mantener la API pública de Holobit en español con funciones serializables y sin exponer clases/tipos internos del SDK. 
- Evitar la fuga de excepciones crudas del SDK/runtime hacia códigos de usuario y proporcionar mensajes de dominio coherentes para Cobra.

### Description
- Añadido `ErrorHolobit` y helper `_error_dominio` para representar errores de dominio Cobra en `src/pcobra/corelibs/holobit.py`.
- El adaptador `_desde_estructura_cobra` ahora captura excepciones del SDK y las traduce a `ErrorHolobit` con un mensaje estable de dominio. 
- `deserializar_holobit` convierte `JSONDecodeError` en `ErrorHolobit` para mantener el contrato de serialización/deserialización y evitar fugas de representación interna. 
- `graficar` envuelve llamadas al runtime/SDK en un `try/except` que traduce fallos internos a `ErrorHolobit` y se añadió la prueba de regresión en `tests/unit/test_holobit_corelib_domain_errors.py`.

### Testing
- Ejecutado `pytest -q tests/unit/test_holobit_corelib_domain_errors.py tests/integration/test_usar_public_contract_regression.py::test_holobit_corelib_deserializacion_invalida_regresion` y la batería relevante pasó; los tests añadidos reportaron `3 passed`.
- Se validó que la API pública sigue exponiendo únicamente los símbolos canónicos (`crear_holobit`, `validar_holobit`, `serializar_holobit`, `deserializar_holobit`, `proyectar`, `transformar`, `graficar`, `combinar`, `medir`) y que no se exponen internals del SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc57a909988327aa77483e4b404251)