### PR TITLE
Centraliza sanitización de símbolos exportados en `usar`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -70,7 +70,7 @@ from .cobra_config import (
     limite_cpu_segundos,
 )
 from ..cobra.usar_policy import REPL_COBRA_MODULE_MAP, USAR_RUNTIME_EXPORT_OVERRIDES
-from .usar_symbol_policy import sanear_simbolo_para_usar
+from .usar_symbol_policy import sanear_exportables_para_usar
 from .resource_limits import (
     limitar_memoria_mb as _lim_mem,
     limitar_cpu_segundos as _lim_cpu,
@@ -1864,7 +1864,7 @@ class InterpretadorCobra:
             simbolos = []
             vistos = set()
             for nombre in candidatos:
-                if not isinstance(nombre, str) or nombre.startswith("_") or nombre in vistos:
+                if not isinstance(nombre, str) or nombre in vistos:
                     continue
                 if not hasattr(modulo_obj, nombre):
                     continue
@@ -1921,23 +1921,33 @@ class InterpretadorCobra:
 
             contexto_actual = self.contextos[-1]
 
-            reporte_rechazos: list[dict[str, str]] = []
-            reporte_warnings: list[dict[str, str]] = []
-            simbolos_saneados: list[tuple[str, object]] = []
-            for nombre, simbolo in simbolos_a_inyectar:
-                resultado = sanear_simbolo_para_usar(nombre, simbolo)
-                if resultado.rechazado:
-                    reporte_rechazos.append(
-                        {"symbol": nombre, "code": resultado.codigo or "rejected", "message": resultado.mensaje or "símbolo rechazado"}
-                    )
-                    self._trace_debug(f"[USAR_SANITIZE][REJECT] {nombre}: {resultado.codigo}")
-                    continue
-                if resultado.warning:
-                    reporte_warnings.append(
-                        {"symbol": nombre, "code": resultado.codigo or "warning", "message": resultado.mensaje or "warning"}
-                    )
-                    self._trace_debug(f"[USAR_SANITIZE][WARN] {nombre}: {resultado.codigo}")
-                simbolos_saneados.append((nombre, simbolo))
+            simbolos_saneados, rechazos_saneamiento, warnings_saneamiento = sanear_exportables_para_usar(
+                simbolos_a_inyectar
+            )
+            reporte_rechazos: list[dict[str, str]] = [
+                {
+                    "symbol": resultado.nombre,
+                    "code": resultado.codigo or "rejected",
+                    "message": resultado.mensaje or "símbolo rechazado",
+                }
+                for resultado in rechazos_saneamiento
+            ]
+            reporte_warnings: list[dict[str, str]] = [
+                {
+                    "symbol": resultado.nombre,
+                    "code": resultado.codigo or "warning",
+                    "message": resultado.mensaje or "warning",
+                }
+                for resultado in warnings_saneamiento
+            ]
+            for resultado in rechazos_saneamiento:
+                self._trace_debug(
+                    f"[USAR_SANITIZE][REJECT] {resultado.nombre}: {resultado.codigo} - {resultado.mensaje}"
+                )
+            for resultado in warnings_saneamiento:
+                self._trace_debug(
+                    f"[USAR_SANITIZE][WARN] {resultado.nombre}: {resultado.codigo} - {resultado.mensaje}"
+                )
 
             if reporte_rechazos:
                 evento_rechazos = {
@@ -1945,6 +1955,7 @@ class InterpretadorCobra:
                     "severity": "warning",
                     "module": nodo.modulo,
                     "rejections": reporte_rechazos,
+                    "simbolos_rechazados": reporte_rechazos,
                 }
                 logging.warning("USAR sanitize reject event: %s", evento_rechazos)
                 self._trace_debug(f"[USAR_SANITIZE][REJECTS] {evento_rechazos}")

--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -156,3 +156,22 @@ def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamien
         )
 
     return ResultadoSaneamientoSimboloUsar(nombre, simbolo, False, "ok", "símbolo exportable")
+
+
+def sanear_exportables_para_usar(
+    simbolos: list[tuple[str, object]],
+) -> tuple[list[tuple[str, object]], list[ResultadoSaneamientoSimboloUsar], list[ResultadoSaneamientoSimboloUsar]]:
+    """Sanea una lista de símbolos candidatos para ``usar`` de forma uniforme."""
+
+    permitidos: list[tuple[str, object]] = []
+    rechazos: list[ResultadoSaneamientoSimboloUsar] = []
+    warnings: list[ResultadoSaneamientoSimboloUsar] = []
+    for nombre, simbolo in simbolos:
+        resultado = sanear_simbolo_para_usar(nombre, simbolo)
+        if resultado.rechazado:
+            rechazos.append(resultado)
+            continue
+        if resultado.warning:
+            warnings.append(resultado)
+        permitidos.append((nombre, simbolo))
+    return permitidos, rechazos, warnings

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -1,6 +1,6 @@
 from types import ModuleType
 
-from pcobra.core.usar_symbol_policy import sanear_simbolo_para_usar
+from pcobra.core.usar_symbol_policy import sanear_exportables_para_usar, sanear_simbolo_para_usar
 
 
 def test_rechaza_nombres_prohibidos_explicitos():
@@ -15,3 +15,44 @@ def test_rechaza_doble_guion_bajo_y_modulo_backend():
 
     r_modulo = sanear_simbolo_para_usar("sdk", ModuleType("sdk"))
     assert r_modulo.rechazado is True
+
+
+def test_reglas_de_saneamiento_por_caso_especifico():
+    r_prefijo_privado = sanear_simbolo_para_usar("_interno", lambda: None)
+    assert r_prefijo_privado.rechazado is True
+    assert r_prefijo_privado.codigo == "private_prefix"
+
+    r_doble_guion_bajo = sanear_simbolo_para_usar("a__b", lambda: None)
+    assert r_doble_guion_bajo.rechazado is True
+    assert r_doble_guion_bajo.codigo == "dunder_pattern"
+
+    r_dunder_python = sanear_simbolo_para_usar("__name__", lambda: None)
+    assert r_dunder_python.rechazado is True
+    assert r_dunder_python.codigo == "private_prefix"
+
+    r_objeto_backend = sanear_simbolo_para_usar("backend", ModuleType("backend"))
+    assert r_objeto_backend.rechazado is True
+    assert r_objeto_backend.codigo == "backend_module_object"
+
+    r_interno_no_publico = sanear_simbolo_para_usar("interno", 123)
+    assert r_interno_no_publico.rechazado is True
+    assert r_interno_no_publico.codigo == "non_callable_not_canonical_public_constant"
+
+    r_backend_ingles = sanear_simbolo_para_usar("append", lambda: None)
+    assert r_backend_ingles.rechazado is True
+    assert r_backend_ingles.codigo == "explicit_forbidden_name"
+
+
+def test_saneamiento_centralizado_aplica_todas_las_reglas():
+    simbolos = [
+        ("_interno", lambda: None),
+        ("append", lambda: None),
+        ("PI", 3.14159),
+        ("publica", lambda: "ok"),
+    ]
+
+    permitidos, rechazos, warnings = sanear_exportables_para_usar(simbolos)
+
+    assert [nombre for nombre, _ in permitidos] == ["PI", "publica"]
+    assert {r.nombre for r in rechazos} == {"_interno", "append"}
+    assert [w.nombre for w in warnings] == ["PI"]


### PR DESCRIPTION
### Motivation
- Unificar y centralizar la lógica de saneamiento de símbolos exportables para `usar` para evitar reglas duplicadas y comportamientos inconsistentes entre módulos.
- Aplicar las reglas de rechazo solicitadas (prefijo `_`, presencia de `__`, dunders Python, objetos módulo/backend, internos no-callback no públicos, y nombres backend en inglés con equivalente Cobra) de forma determinista para todos los módulos cargados por `usar`.
- Proveer mensajes de telemetría/registro legibles por símbolo cuando se descarte un export para facilitar auditoría y diagnóstico.

### Description
- Añade el helper `sanear_exportables_para_usar(simbolos)` en `src/pcobra/core/usar_symbol_policy.py` que aplica `sanear_simbolo_para_usar` a una lista de candidatos y devuelve `permitidos`, `rechazos` y `warnings`.
- Modifica `InterpretadorCobra.ejecutar_usar` en `src/pcobra/core/interpreter.py` para delegar el saneamiento a `sanear_exportables_para_usar`, eliminando el filtrado parcial previo (ahora todos los candidatos pasan por la política única).
- Mejora el logging/telemetría de descarte incluyendo `codigo` y `mensaje` por símbolo y añadiendo el campo `simbolos_rechazados` en el payload del evento `usar_sanitize_reject` para compatibilidad de auditoría.
- Añade/expande pruebas en `tests/unit/test_usar_symbol_policy.py` que verifican cada regla individual (prefijo `_`, `__`, dunders conocidos, objetos módulo/backend, no-callables no canónicos y nombres backend en inglés) y un test de saneamiento por lote que valida la salida agregada.

### Testing
- Ejecutado `pytest -q tests/unit/test_usar_symbol_policy.py` y todas las pruebas pasaron (`4 passed`).
- Intentado ejecutar un subconjunto de `tests/unit/test_usar.py` en este entorno, pero la colección falló por un error de importación del entorno de pruebas (`attempted relative import beyond top-level package`) independiente de la lógica nueva; las pruebas específicas de la política sí se verificaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5bfd2ca883278116fe4bcdfdf7cd)