### PR TITLE
Endurecer carga de `usar` para módulos Cobra oficiales

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -22,6 +22,9 @@ USAR_COBRA_PUBLIC_MODULES: tuple[str, ...] = (
 USAR_COBRA_ALLOWLIST: frozenset[str] = frozenset(USAR_COBRA_PUBLIC_MODULES)
 
 REPL_COBRA_MODULE_MAP: dict[str, str] = {modulo: modulo for modulo in USAR_COBRA_PUBLIC_MODULES}
+USAR_COBRA_FACING_MODULE_FLAGS: dict[str, bool] = {
+    modulo: True for modulo in USAR_COBRA_PUBLIC_MODULES
+}
 
 # Fuente única de verdad: alias canónico `usar` -> ruta interna oficial.
 REPL_COBRA_MODULE_INTERNAL_PATH_MAP: dict[str, str] = {
@@ -51,6 +54,16 @@ def validar_contrato_modulos_canonicos_usar() -> None:
         raise RuntimeError(
             "[STARTUP CONTRACT] REPL_COBRA_MODULE_MAP debe resolver cada alias "
             "canónico a su módulo Cobra-facing oficial."
+        )
+    if tuple(USAR_COBRA_FACING_MODULE_FLAGS.keys()) != canonicos:
+        raise RuntimeError(
+            "[STARTUP CONTRACT] USAR_COBRA_FACING_MODULE_FLAGS debe declarar "
+            "todos los módulos canónicos y en el orden oficial."
+        )
+    if not all(USAR_COBRA_FACING_MODULE_FLAGS.values()):
+        raise RuntimeError(
+            "[STARTUP CONTRACT] Todos los módulos canónicos de `usar` deben "
+            "estar marcados como Cobra-facing."
         )
 
     faltantes = [m for m in canonicos if m not in REPL_COBRA_MODULE_INTERNAL_PATH_MAP]

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -69,7 +69,11 @@ from .cobra_config import (
     limite_memoria_mb,
     limite_cpu_segundos,
 )
-from ..cobra.usar_policy import REPL_COBRA_MODULE_MAP, USAR_RUNTIME_EXPORT_OVERRIDES
+from ..cobra.usar_policy import (
+    REPL_COBRA_MODULE_MAP,
+    USAR_COBRA_FACING_MODULE_FLAGS,
+    USAR_RUNTIME_EXPORT_OVERRIDES,
+)
 from .usar_symbol_policy import sanear_exportables_para_usar
 from .resource_limits import (
     limitar_memoria_mb as _lim_mem,
@@ -1882,6 +1886,11 @@ class InterpretadorCobra:
 
             if not es_modulo_oficial_cobra:
                 raise PermissionError(REPL_USAR_EXTERNAL_MODULE_ERROR)
+            if not USAR_COBRA_FACING_MODULE_FLAGS.get(modulo_canonico, False):
+                raise PermissionError(
+                    "Módulo no permitido en 'usar': "
+                    f"'{nombre_modulo}' no está marcado como Cobra-facing."
+                )
 
             modulo = obtener_modulo(modulo_canonico)
 

--- a/tests/unit/test_usar_loader_validation.py
+++ b/tests/unit/test_usar_loader_validation.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import importlib
 
-from pcobra.cobra.usar_policy import REPL_COBRA_MODULE_MAP
+import pytest
+
+from pcobra.cobra.usar_loader import validar_nombre_modulo_usar
+from pcobra.cobra.usar_policy import REPL_COBRA_MODULE_MAP, USAR_COBRA_FACING_MODULE_FLAGS
 
 
 def test_repl_alias_map_contiene_modulos_base_numero_texto_datos():
@@ -26,3 +29,14 @@ def test_import_pcobra_no_hace_eager_load_de_backends_legacy():
 
     for nombre in legacy:
         assert nombre not in sys.modules
+
+
+def test_rechaza_imports_directos_backend_en_usar():
+    for modulo in ("numpy", "node-fetch", "serde", "holobit_sdk"):
+        with pytest.raises(PermissionError):
+            validar_nombre_modulo_usar(modulo)
+
+
+def test_flags_cobra_facing_cubren_modulos_repl():
+    assert tuple(USAR_COBRA_FACING_MODULE_FLAGS.keys()) == tuple(REPL_COBRA_MODULE_MAP.keys())
+    assert all(USAR_COBRA_FACING_MODULE_FLAGS.values())


### PR DESCRIPTION
### Motivation
- Asegurar que la instrucción `usar` solo resuelva módulos desde el catálogo oficial Cobra y que éstos estén explícitamente marcados como Cobra-facing antes de exponer exports al entorno.
- Evitar imports dinámicos arbitrarios y rechazar imports directos de módulos backend/externos que no deben ser accesibles desde `usar`.

### Description
- Se añade el metadato central `USAR_COBRA_FACING_MODULE_FLAGS` en `src/pcobra/cobra/usar_policy.py` y se valida su cobertura y activación en el arranque del proceso.
- Se refuerza la resolución de `usar` en `src/pcobra/core/interpreter.py` para rechazar antes de cargar cualquier alias canónico que no esté marcado como Cobra-facing.
- Se agregan pruebas en `tests/unit/test_usar_loader_validation.py` para rechazar imports explícitos de backends (`numpy`, `node-fetch`, `serde`, `holobit_sdk`) y para verificar que los flags Cobra-facing cubren el mapa REPL oficial.
- No se cambia la sanitización ni la política de colisiones existentes; la comprobación Cobra-facing se realiza antes de `obtener_modulo(...)` y antes de inyectar símbolos.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_loader_validation.py tests/unit/test_usar_symbol_policy.py` y ambos archivos pasaron con éxito.
- Resultado de la ejecución de pruebas: `8 passed` y sin fallos en las aserciones relacionadas con las nuevas validaciones.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc648cc28c8327a926331c76b0bf49)