### PR TITLE
Harden startup backend policy against legacy eager loading

### DIFF
--- a/src/pcobra/cobra/architecture/backend_policy.py
+++ b/src/pcobra/cobra/architecture/backend_policy.py
@@ -21,6 +21,8 @@ PUBLIC_BACKENDS: Final[tuple[str, ...]] = (
 PUBLIC_TARGET_LISTING_LIMIT: Final[int] = 3
 
 # Backends legacy mantenidos exclusivamente para compatibilidad interna.
+# Importante: no deben cargarse durante startup de rutas públicas
+# (`import pcobra`, `cobra repl`, `cobra run`, `cobra test`) salvo opt-in explícito.
 INTERNAL_BACKENDS: Final[tuple[str, ...]] = (
     "go",
     "cpp",

--- a/tests/test_cli_entrypoint_imports.py
+++ b/tests/test_cli_entrypoint_imports.py
@@ -106,6 +106,32 @@ def test_import_bench_cmd_no_depende_de_scripts_py_path() -> None:
     )
 
 
+
+
+def test_import_pcobra_no_carga_backends_legacy_en_startup() -> None:
+    """`import pcobra` no debe cargar transpilers/backends legacy por defecto."""
+
+    result = _run_python_isolated(
+        "import pcobra; "
+        "import sys; "
+        "legacy_markers = ("
+        "'pcobra.cobra.transpilers.transpiler.to_go',"
+        "'pcobra.cobra.transpilers.transpiler.to_cpp',"
+        "'pcobra.cobra.transpilers.transpiler.to_java',"
+        "'pcobra.cobra.transpilers.transpiler.to_wasm',"
+        "'pcobra.cobra.transpilers.transpiler.to_asm',"
+        "'pcobra.cobra.cli.internal_compat.legacy_targets',"
+        "'pcobra.cobra.internal_compat.legacy_contracts',"
+        "); "
+        "loaded = sorted(name for name in sys.modules if name in legacy_markers); "
+        "assert not loaded, f'import pcobra cargó módulos legacy: {loaded}'; "
+    )
+
+    assert result.returncode == 0, (
+        "`import pcobra` no debe activar rutas legacy en startup por defecto. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
 def test_cli_startup_preserva_utf8_en_literal_imprimir() -> None:
     """Contrato: startup de CLI debe preservar UTF-8 sin mojibake en salida."""
 

--- a/tests/test_unified_ecosystem_plan.py
+++ b/tests/test_unified_ecosystem_plan.py
@@ -31,3 +31,7 @@ def test_import_policy_resolution_order() -> None:
         "python_bridge",
         "hybrid",
     )
+
+
+def test_public_backends_contract_is_exact() -> None:
+    assert PUBLIC_BACKENDS == ("python", "javascript", "rust")


### PR DESCRIPTION
### Motivation
- Evitar que rutas públicas y el import principal carguen transpiladores/backends legacy por defecto para preservar el contrato público y reducir riesgo de regresiones al iniciar la CLI o el paquete.
- Hacer explícita la política de que solo `python`, `javascript` y `rust` son los backends públicos visibles y que los legados (`go`, `cpp`, `java`, `wasm`, `asm`) quedan fuera del startup por defecto.

### Description
- Añadido comentario explicativo en `src/pcobra/cobra/architecture/backend_policy.py` indicando que los `INTERNAL_BACKENDS` no deben cargarse durante el arranque público salvo opt‑in explícito. 
- Añadido test de auditoría `test_import_pcobra_no_carga_backends_legacy_en_startup` en `tests/test_cli_entrypoint_imports.py` que verifica que `import pcobra` no carga módulos legacy en `sys.modules` al iniciar.
- Añadida aserción explícita en `tests/test_unified_ecosystem_plan.py` para garantizar que `PUBLIC_BACKENDS` es exactamente `("python","javascript","rust")`.

### Testing
- Ejecutado `pytest -q tests/test_cli_entrypoint_imports.py::test_import_pcobra_no_carga_backends_legacy_en_startup tests/test_cli_entrypoint_imports.py::test_cli_public_commands_do_not_import_legacy_transpilers_on_startup tests/test_unified_ecosystem_plan.py tests/unit/test_runtime_manager.py tests/unit/test_backend_pipeline_runtime_manager.py` y la suite seleccionada pasó con `33 passed, 1 warning`.
- Se verificó que `BackendPipeline` y `RuntimeManager` mantienen su comportamiento de inicialización mediante las pruebas unitarias correspondientes, las cuales pasaron en la ejecución anterior.
- Hubo una colección fallida previa en `tests/unit/test_repl_no_backend_pipeline_temporaries.py` por un import relativo legacy preexistente que no fue introducido por estos cambios y que no forma parte de la validación final mostrada arriba.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6ad6dbb0832784b396e383727018)