### PR TITLE
Encapsula backends legacy y refuerza contrato público de backends

### DIFF
--- a/src/pcobra/cobra/architecture/backend_policy.py
+++ b/src/pcobra/cobra/architecture/backend_policy.py
@@ -20,31 +20,6 @@ PUBLIC_BACKENDS: Final[tuple[str, ...]] = (
 # Criterio de salida: toda API pública o doc de usuario solo puede listar 3 targets.
 PUBLIC_TARGET_LISTING_LIMIT: Final[int] = 3
 
-# Backends legacy mantenidos exclusivamente para compatibilidad interna.
-# Importante: no deben cargarse durante startup de rutas públicas
-# (`import pcobra`, `cobra repl`, `cobra run`, `cobra test`) salvo opt-in explícito.
-INTERNAL_BACKENDS: Final[tuple[str, ...]] = (
-    "go",
-    "cpp",
-    "java",
-    "wasm",
-    "asm",
-)
-
-# Ventana de retiro contractual para compatibilidad interna no pública.
-INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW: Final[dict[str, str]] = {
-    "go": "Q4 2026",
-    "cpp": "Q4 2026",
-    "java": "Q1 2027",
-    "wasm": "Q2 2027",
-    "asm": "Q3 2026",
-}
-
-# Fecha de corte global para retirar la compatibilidad legacy internal-only.
-INTERNAL_LEGACY_RETIREMENT_DATE: Final[str] = "2027-06-30"
-
-ALL_BACKENDS: Final[tuple[str, ...]] = PUBLIC_BACKENDS + INTERNAL_BACKENDS
-
 
 def assert_public_targets_contract(targets: tuple[str, ...], *, source: str) -> None:
     """Valida que una superficie pública cumpla el contrato oficial de 3 targets."""
@@ -58,4 +33,14 @@ def assert_public_targets_contract(targets: tuple[str, ...], *, source: str) -> 
         raise RuntimeError(
             "[PUBLIC CONTRACT] La superficie pública debe usar exactamente PUBLIC_BACKENDS. "
             f"source={source}; current={targets}; expected={PUBLIC_BACKENDS}"
+        )
+
+
+def assert_public_command_uses_only_public_backends(*, command: str, targets: tuple[str, ...]) -> None:
+    """Falla si un comando público consume cualquier backend fuera de PUBLIC_BACKENDS."""
+    legacy_targets = tuple(target for target in targets if target not in PUBLIC_BACKENDS)
+    if legacy_targets:
+        raise RuntimeError(
+            "[PUBLIC CONTRACT] Comando público fuera de contrato: "
+            f"command={command}; legacy={legacy_targets}; allowed={PUBLIC_BACKENDS}"
         )

--- a/src/pcobra/cobra/architecture/contracts.py
+++ b/src/pcobra/cobra/architecture/contracts.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
-from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS, PUBLIC_BACKENDS
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+from pcobra.cobra.architecture.legacy_backend_lifecycle import INTERNAL_BACKENDS
 from pcobra.cobra.bindings.contract import BindingRoute
 
 

--- a/src/pcobra/cobra/architecture/legacy_backend_lifecycle.py
+++ b/src/pcobra/cobra/architecture/legacy_backend_lifecycle.py
@@ -10,12 +10,33 @@ from dataclasses import dataclass
 import os
 from typing import Final, Literal
 
-from pcobra.cobra.architecture.backend_policy import (
-    INTERNAL_BACKENDS,
-    INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW,
-)
 
 LegacyLifecycleStatus = Literal["active-migration", "frozen", "removal-candidate"]
+
+INTERNAL_BACKENDS: Final[tuple[str, ...]] = (
+    "go",
+    "cpp",
+    "java",
+    "wasm",
+    "asm",
+)
+
+INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW: Final[dict[str, str]] = {
+    "go": "Q4 2026",
+    "cpp": "Q4 2026",
+    "java": "Q1 2027",
+    "wasm": "Q2 2027",
+    "asm": "Q3 2026",
+}
+
+INTERNAL_LEGACY_RETIREMENT_DATE: Final[str] = "2027-06-30"
+ALL_BACKENDS: Final[tuple[str, ...]] = (
+    "python",
+    "javascript",
+    "rust",
+    *INTERNAL_BACKENDS,
+)
+
 LegacyLifecyclePhase = Literal[
     "phase-1-hide-public-ux",
     "phase-2-development-profile-only",

--- a/src/pcobra/cobra/architecture/unified_ecosystem.py
+++ b/src/pcobra/cobra/architecture/unified_ecosystem.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
-from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS, PUBLIC_BACKENDS
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+from pcobra.cobra.architecture.legacy_backend_lifecycle import INTERNAL_BACKENDS
 
 
 OFFICIAL_USER_LANGUAGE: Final[str] = "cobra"

--- a/src/pcobra/cobra/benchmarks/targets_policy.py
+++ b/src/pcobra/cobra/benchmarks/targets_policy.py
@@ -13,7 +13,8 @@ except ModuleNotFoundError:
 from pathlib import Path
 from typing import Final, Mapping
 
-from pcobra.cobra.architecture.backend_policy import ALL_BACKENDS, PUBLIC_BACKENDS
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+from pcobra.cobra.architecture.legacy_backend_lifecycle import ALL_BACKENDS
 from pcobra.cobra.cli.target_policies import (
     BEST_EFFORT_RUNTIME_TARGETS,
     NO_RUNTIME_TARGETS,

--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from pcobra.cobra.architecture.backend_policy import assert_public_command_uses_only_public_backends
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.commands.interactive_cmd import (
     InteractiveCommand,
@@ -152,6 +153,8 @@ class ReplCommandV2(BaseCommand):
         self._extra_validators_repl = getattr(args, "extra_validators", None)
         sandbox = bool(getattr(args, "sandbox", False))
         sandbox_docker = getattr(args, "sandbox_docker", None)
+        if sandbox_docker:
+            assert_public_command_uses_only_public_backends(command="repl", targets=(sandbox_docker,))
 
         while True:
             try:

--- a/src/pcobra/cobra/cli/commands_v2/run_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/run_cmd.py
@@ -2,7 +2,10 @@ from argparse import SUPPRESS
 from typing import Any
 
 from pcobra.cobra.build import backend_pipeline
-from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+from pcobra.cobra.architecture.backend_policy import (
+    PUBLIC_BACKENDS,
+    assert_public_command_uses_only_public_backends,
+)
 from pcobra.cobra.architecture.contracts import assert_backend_allowed_for_scope
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
@@ -44,6 +47,7 @@ class RunCommandV2(BaseCommand):
         sandbox = bool(getattr(args, "sandbox", False))
         container = getattr(args, "container", None)
         binding_language = container or "python"
+        assert_public_command_uses_only_public_backends(command="run", targets=(binding_language,))
         assert_backend_allowed_for_scope(backend=binding_language, scope="public")
         try:
             self._runtime_manager.validate_command_runtime(

--- a/src/pcobra/cobra/cli/commands_v2/test_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/test_cmd.py
@@ -2,6 +2,7 @@ from argparse import SUPPRESS
 from typing import Any
 
 from pcobra.cobra.build import backend_pipeline
+from pcobra.cobra.architecture.backend_policy import assert_public_command_uses_only_public_backends
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.architecture.contracts import assert_backend_allowed_for_scope
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
@@ -53,6 +54,7 @@ class TestCommandV2(BaseCommand):
             )
         else:
             langs = list(raw_langs)
+        assert_public_command_uses_only_public_backends(command="test", targets=tuple(langs))
         for lang in langs:
             assert_backend_allowed_for_scope(backend=lang, scope="public")
             try:

--- a/src/pcobra/cobra/transpilers/registry.py
+++ b/src/pcobra/cobra/transpilers/registry.py
@@ -10,10 +10,10 @@ from types import MappingProxyType
 from typing import Final
 
 from pcobra.cobra.architecture.backend_policy import (
-    ALL_BACKENDS,
     PUBLIC_BACKENDS,
     assert_public_targets_contract,
 )
+from pcobra.cobra.architecture.legacy_backend_lifecycle import ALL_BACKENDS
 from pcobra.cobra.config.transpile_targets import OFFICIAL_TARGETS
 
 TRANSPILER_CLASS_PATHS: Final[dict[str, tuple[str, str]]] = {


### PR DESCRIPTION
### Motivation
- Asegurar que la superficie pública de ejecución quede limitada a `PUBLIC_BACKENDS = ("python", "javascript", "rust")` y evitar la carga accidental de inventarios legacy en startup público. 
- Encapsular el inventario y las ventanas de retiro legacy en un módulo interno para que solo rutas opt-in las consuman.

### Description
- Mantiene `PUBLIC_BACKENDS` como la única lista pública activa en `pcobra.cobra.architecture.backend_policy` y añade la función de guardia `assert_public_command_uses_only_public_backends` para validar usos por comando. 
- Mueve `INTERNAL_BACKENDS`, `INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW`, `INTERNAL_LEGACY_RETIREMENT_DATE` y `ALL_BACKENDS` al módulo interno `pcobra.cobra.architecture.legacy_backend_lifecycle` y adapta el código que necesita ese inventario a importar desde allí. 
- Actualiza imports en módulos relevantes (`transpilers/registry.py`, `benchmarks/targets_policy.py`, `architecture/contracts.py`, `architecture/unified_ecosystem.py`, y otros) para separar claramente la superficie pública de la compatibilidad interna. 
- Agrega comprobaciones en comandos públicos para fallar si consumen backends legacy: `RunCommandV2` valida el backend efectivo, `TestCommandV2` valida la lista de lenguajes solicitados, y `ReplCommandV2` valida `--sandbox-docker` cuando aplica. 

### Testing
- Se compiló en modo silencioso el árbol afectado con `python -m compileall -q src/pcobra/cobra/architecture src/pcobra/cobra/cli/commands_v2 src/pcobra/cobra/transpilers src/pcobra/cobra/benchmarks src/pcobra/cobra/config src/pcobra/cobra/internal_compat` y la verificación de byte-compilación finalizó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc95bc4550832790017b873ea66249)