### PR TITLE
Alinear validadores de targets al contrato canónico de 3 backends

### DIFF
--- a/scripts/ci/audit_targets_contract.py
+++ b/scripts/ci/audit_targets_contract.py
@@ -27,11 +27,6 @@ EXPECTED_CANONICAL_TARGETS: tuple[str, ...] = (
     "python",
     "rust",
     "javascript",
-    "wasm",
-    "go",
-    "cpp",
-    "java",
-    "asm",
 )
 
 FORBIDDEN_TERMS: tuple[tuple[re.Pattern[str], str], ...] = (

--- a/scripts/ci/generate_internal_only_inventory.py
+++ b/scripts/ci/generate_internal_only_inventory.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Genera inventario de referencias a backends internal-only fuera de rutas internas.
+"""Genera inventario histórico/diagnóstico de referencias legacy fuera de rutas internas.
 
 Estrategia:
 1) Búsqueda por path (rutas/documentos públicos vigilados).
@@ -30,7 +30,7 @@ TEXT_EXTENSIONS = {
     ".sh",
 }
 
-# Rutas con scope interno/histórico permitido para conservar compatibilidad temporal.
+# Rutas con scope histórico/diagnóstico permitido (sin soporte vigente).
 INTERNAL_ALLOWED_PREFIXES = (
     "src/pcobra/cobra/cli/internal_compat/",
     "docs/compatibility/",
@@ -101,7 +101,7 @@ def _render(findings: list[Finding]) -> str:
     sample = sorted(findings, key=lambda item: (item.rel_path, item.line_number))[:80]
 
     lines = [
-        "# Inventario de referencias internal-only (go/cpp/java/wasm/asm)",
+        "# Inventario histórico de referencias legacy (go/cpp/java/wasm/asm)",
         "",
         "Este reporte se genera con `scripts/ci/generate_internal_only_inventory.py`.",
         "",
@@ -145,7 +145,7 @@ def _render(findings: list[Finding]) -> str:
             "",
             "## Nota de uso",
             "",
-            "Este inventario es de diagnóstico. La eliminación se ejecuta por fases según `docs/compatibility/internal_only_backend_removal_checklist.md`.",
+            "Este inventario es exclusivamente histórico/diagnóstico. No implica soporte vigente para estos targets retirados.",
             "",
         ]
     )

--- a/scripts/ci/validate_targets.py
+++ b/scripts/ci/validate_targets.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validaciones CI estrictas para el contrato final de 8 backends."""
+"""Validaciones CI estrictas para el contrato canónico de 3 backends."""
 
 from __future__ import annotations
 
@@ -353,7 +353,7 @@ def validate_registry_tables() -> list[str]:
     expected = FINAL_OFFICIAL_TARGETS
     if tuple(OFFICIAL_TARGETS) != expected:
         errors.append(
-            "src/pcobra/cobra/transpilers/targets.py: OFFICIAL_TARGETS no coincide con el contrato final de 8 backends -> "
+            "src/pcobra/cobra/transpilers/targets.py: OFFICIAL_TARGETS no coincide con el contrato canónico de 3 backends -> "
             f"official={tuple(OFFICIAL_TARGETS)}, expected={expected}"
         )
     if tuple(TIER1_TARGETS + TIER2_TARGETS) != expected:
@@ -384,7 +384,7 @@ def validate_registry_tables() -> list[str]:
         )
     if official_transpiler_registry_literal() != EXPECTED_TRANSPILER_REGISTRY:
         errors.append(
-            "src/pcobra/cobra/transpilers/registry.py: el registro oficial no coincide exactamente con los 8 backends esperados -> "
+            "src/pcobra/cobra/transpilers/registry.py: el registro oficial no coincide exactamente con los 3 backends canónicos esperados -> "
             f"registry={official_transpiler_registry_literal()}, expected={EXPECTED_TRANSPILER_REGISTRY}"
         )
     return errors
@@ -584,7 +584,7 @@ def validate_targeted_artifact_roots(
         )
     for extra in sorted(found_forward_paths - expected_forward_paths):
         errors.append(
-            f"{extra}: módulo to_*.py extra fuera de política (posible backend 9 o alias interno expuesto)"
+            f"{extra}: módulo to_*.py extra fuera de política (target retirado o alias interno expuesto)"
         )
 
     found_forward = {path.name for path in TRANSPILER_DIR.glob("to_*.py")}
@@ -632,7 +632,7 @@ def validate_targeted_artifact_roots(
         errors.append(f"{missing}: falta golden file oficial para un backend canónico")
     for extra in sorted(found_golden_paths - expected_golden_paths):
         errors.append(
-            f"{extra}: golden file extra fuera de política (posible backend 9 no controlado)"
+            f"{extra}: golden file extra fuera de política (target retirado/no canónico detectado)"
         )
 
     found_golden = {path.name for path in GOLDEN_DIR.glob("*.golden")}
@@ -910,7 +910,7 @@ def validate_python_policy_literals(
         )
     if tuple(policy["official_targets"]) != expected:
         errors.append(
-            "scripts/targets_policy_common.py: read_target_policy()['official_targets'] no coincide con los 8 oficiales -> "
+            "scripts/targets_policy_common.py: read_target_policy()['official_targets'] no coincide con los 3 oficiales canónicos -> "
             f"policy={tuple(policy['official_targets'])}, expected={expected}"
         )
     if tuple(policy["tier1_targets"]) + tuple(policy["tier2_targets"]) != expected:


### PR DESCRIPTION
### Motivation

- Actualizar los validadores CI y reportes para reflejar el contrato canónico vigente de 3 targets (`python`, `javascript`, `rust`) en lugar del antiguo framing de 8 backends. 
- Tratar referencias a targets retirados únicamente como histórico/diagnóstico y evitar que los mensajes de validación promocionen soporte activo de targets legacy.

### Description

- Modifica `scripts/ci/validate_targets.py` para reemplazar mensajes y validaciones que mencionaban el "contrato final de 8 backends" por el framing de "contrato canónico de 3 backends" y ajustar textos que detectaban módulos/goldens extras para referirse a "targets retirado/no canónico". 
- Ajusta `scripts/ci/audit_targets_contract.py` reemplazando `EXPECTED_CANONICAL_TARGETS` por la tupla `("python", "rust", "javascript")` para alinear la auditoría con el contrato canónico. 
- Cambia `scripts/ci/generate_internal_only_inventory.py` para dejar explícito que el inventario es histórico/diagnóstico (sin implicar soporte vigente) y actualiza comentarios/encabezados y prefijos de rutas permitidas en consecuencia. 
- Conserva la lógica que deriva `to_*.py` y otros artefactos a partir del conjunto oficial canónico para evitar chequear nombres explícitos como `to_go`, `to_cpp`, `to_java`, `to_wasm` o `to_asm` como requisitos vigentes.

### Testing

- Se ejecutó `python -m py_compile scripts/ci/validate_targets.py scripts/ci/audit_targets_contract.py scripts/ci/validate_workflow_target_matrix.py scripts/ci/generate_internal_only_inventory.py` y la compilación sintáctica fue exitosa. 
- Se realizaron búsquedas con `rg` para verificar la eliminación de mensajes literales de 8 backends y la ausencia de checks que exijan módulos forward/reverse explícitos por target retirado, y no se detectaron referencias problemáticas en los archivos modificados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc988c98dc83279f9d32a13c9e1a2a)