### PR TITLE
Centralizar sanitización de exports públicos para `usar` en runtime/REPL

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -3,8 +3,10 @@ import importlib.util
 import re
 from pathlib import Path
 import sys
+from typing import Any
 
 from pcobra.cobra.usar_policy import USAR_COBRA_ALLOWLIST, USAR_COBRA_PUBLIC_MODULES
+from pcobra.core.usar_symbol_policy import sanear_exportables_para_usar
 
 # Módulos no canónicos conocidos que deben rechazarse de forma explícita.
 _USAR_NON_CANONICAL_MODULES: frozenset[str] = frozenset({
@@ -131,3 +133,72 @@ def obtener_modulo(nombre: str, *, permitir_instalacion: bool = True):
         raise ImportError(
             f"No se pudo resolver el módulo Cobra permitido '{nombre}' en runtime."
         ) from exc
+
+
+def sanitizar_exports_publicos(modulo: object, alias_modulo: str) -> tuple[dict[str, Any], list[dict[str, str]]]:
+    """Filtra exports públicos válidos para ``usar`` y reporta conflictos/rechazos.
+
+    Devuelve un mapa limpio ``nombre -> símbolo`` y una lista estructurada de
+    conflictos para que el caller pueda advertir y evitar sobreescrituras
+    silenciosas.
+    """
+
+    exportables = getattr(modulo, "__all__", None)
+    if exportables is None:
+        candidatos = [
+            nombre for nombre in dir(modulo) if isinstance(nombre, str) and not nombre.startswith("_")
+        ]
+    else:
+        candidatos = exportables
+
+    simbolos_brutos: list[tuple[str, object]] = []
+    conflictos: list[dict[str, str]] = []
+    vistos: set[str] = set()
+    for nombre in candidatos:
+        if not isinstance(nombre, str):
+            conflictos.append(
+                {
+                    "module": alias_modulo,
+                    "symbol": repr(nombre),
+                    "code": "invalid_export_name_type",
+                    "message": "nombre de export no es string",
+                }
+            )
+            continue
+        if nombre in vistos:
+            conflictos.append(
+                {
+                    "module": alias_modulo,
+                    "symbol": nombre,
+                    "code": "duplicate_export_name",
+                    "message": "nombre exportado repetido en __all__/candidatos",
+                }
+            )
+            continue
+        if not hasattr(modulo, nombre):
+            conflictos.append(
+                {
+                    "module": alias_modulo,
+                    "symbol": nombre,
+                    "code": "missing_export_attr",
+                    "message": "el nombre exportado no existe en el módulo",
+                }
+            )
+            continue
+        vistos.add(nombre)
+        simbolos_brutos.append((nombre, getattr(modulo, nombre)))
+
+    simbolos_saneados, rechazos, warnings = sanear_exportables_para_usar(simbolos_brutos)
+    mapa_limpio = {nombre: simbolo for nombre, simbolo in simbolos_saneados}
+
+    for resultado in [*rechazos, *warnings]:
+        conflictos.append(
+            {
+                "module": alias_modulo,
+                "symbol": resultado.nombre,
+                "code": resultado.codigo or ("warning" if resultado.warning else "rejected"),
+                "message": resultado.mensaje or ("warning de saneamiento" if resultado.warning else "símbolo rechazado"),
+            }
+        )
+
+    return mapa_limpio, conflictos

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -74,7 +74,6 @@ from ..cobra.usar_policy import (
     USAR_COBRA_FACING_MODULE_FLAGS,
     USAR_RUNTIME_EXPORT_OVERRIDES,
 )
-from .usar_symbol_policy import sanear_exportables_para_usar
 from .resource_limits import (
     limitar_memoria_mb as _lim_mem,
     limitar_cpu_segundos as _lim_cpu,
@@ -1848,7 +1847,7 @@ class InterpretadorCobra:
         from pathlib import Path
         from types import ModuleType
 
-        from .usar_loader import obtener_modulo
+        from .usar_loader import obtener_modulo, sanitizar_exports_publicos
 
         def _resolver_exportables(modulo_obj, *, modulo_oficial: bool, nombre_modulo: str):
             """Resuelve exportables candidatos según política de ``usar``."""
@@ -1929,51 +1928,28 @@ class InterpretadorCobra:
             )
 
             contexto_actual = self.contextos[-1]
+            modulo_proxy = type("_UsarExportsProxy", (), {})()
+            for nombre, simbolo in simbolos_a_inyectar:
+                setattr(modulo_proxy, nombre, simbolo)
+            setattr(modulo_proxy, "__all__", [nombre for nombre, _ in simbolos_a_inyectar])
 
-            simbolos_saneados, rechazos_saneamiento, warnings_saneamiento = sanear_exportables_para_usar(
-                simbolos_a_inyectar
-            )
-            reporte_rechazos: list[dict[str, str]] = [
-                {
-                    "symbol": resultado.nombre,
-                    "code": resultado.codigo or "rejected",
-                    "message": resultado.mensaje or "símbolo rechazado",
-                }
-                for resultado in rechazos_saneamiento
-            ]
-            reporte_warnings: list[dict[str, str]] = [
-                {
-                    "symbol": resultado.nombre,
-                    "code": resultado.codigo or "warning",
-                    "message": resultado.mensaje or "warning",
-                }
-                for resultado in warnings_saneamiento
-            ]
-            for resultado in rechazos_saneamiento:
-                self._trace_debug(
-                    f"[USAR_SANITIZE][REJECT] {resultado.nombre}: {resultado.codigo} - {resultado.mensaje}"
-                )
-            for resultado in warnings_saneamiento:
-                self._trace_debug(
-                    f"[USAR_SANITIZE][WARN] {resultado.nombre}: {resultado.codigo} - {resultado.mensaje}"
-                )
-
-            if reporte_rechazos:
-                evento_rechazos = {
-                    "evento": "usar_sanitize_reject",
+            mapa_limpio, conflictos_saneamiento = sanitizar_exports_publicos(modulo_proxy, nodo.modulo)
+            simbolos_saneados = list(mapa_limpio.items())
+            if conflictos_saneamiento:
+                evento_conflictos = {
+                    "evento": "usar_sanitize_conflicts",
                     "severity": "warning",
                     "module": nodo.modulo,
-                    "rejections": reporte_rechazos,
-                    "simbolos_rechazados": reporte_rechazos,
+                    "conflicts": conflictos_saneamiento,
                 }
-                logging.warning("USAR sanitize reject event: %s", evento_rechazos)
-                self._trace_debug(f"[USAR_SANITIZE][REJECTS] {evento_rechazos}")
+                logging.warning("USAR sanitize conflicts event: %s", evento_conflictos)
+                self._trace_debug(f"[USAR_SANITIZE][CONFLICTS] {evento_conflictos}")
 
             if not simbolos_saneados:
                 raise ImportError(
                     "rechazos de saneamiento en usar "
                     f"'{nodo.modulo}': no quedaron símbolos exportables tras saneamiento. "
-                    f"rechazos={reporte_rechazos}"
+                    f"conflictos={conflictos_saneamiento}"
                 )
 
             # Fase A: detectar colisiones de forma completa antes de definir.
@@ -2041,15 +2017,6 @@ class InterpretadorCobra:
                         f"'{nodo.modulo}': colisión estructurada={detalle}"
                     )
                 contexto_actual.define(nombre, simbolo)
-            if reporte_warnings:
-                evento_warnings = {
-                    "evento": "usar_sanitize_warning",
-                    "severity": "warning",
-                    "module": nodo.modulo,
-                    "warnings": reporte_warnings,
-                }
-                logging.warning("USAR sanitize warning event: %s", evento_warnings)
-                self._trace_debug(f"[USAR_SANITIZE][WARNINGS] {reporte_warnings}")
         except Exception as exc:
             logging.exception(f"Error al usar el módulo '{nodo.modulo}': {exc}")
             raise


### PR DESCRIPTION
### Motivation
- Unificar y endurecer el punto de inyección de exports en runtime/REPL para `usar` y evitar sobreescrituras silenciosas al importar módulos Cobra.
- Aplicar de forma central las reglas de rechazo solicitadas (prefijos `_`, patrones `__`, dunders, nombres explícitamente prohibidos, objetos módulo/backend y permitir no-callables solo si están en la lista de constantes públicas canónicas).

### Description
- Se añadió la función `sanitizar_exports_publicos(modulo, alias_modulo)` en `src/pcobra/cobra/usar_loader.py` que construye candidatos, delega en `sanear_exportables_para_usar` y devuelve un `mapa_limpio` (`nombre -> símbolo`) y una lista estructurada de `conflictos` (incluye nombres no-string, duplicados y atributos faltantes además de rechazos/warnings de saneamiento).
- `InterpretadorCobra.ejecutar_usar` en `src/pcobra/core/interpreter.py` ahora crea un proxy de exports, llama a `sanitizar_exports_publicos(...)`, registra eventos de conflicto (`usar_sanitize_conflicts`) y consume el `mapa_limpio` para la inyección atómica, manteniendo la detección de colisiones y la política anti-overwrite existente.
- La implementación reusa la política existente `sanear_exportables_para_usar` en `src/pcobra/core/usar_symbol_policy.py` para no duplicar reglas y conservar la lista canonical de constantes públicas y nombres prohibidos.

### Testing
- Se compiló por bytecode con `python -m py_compile src/pcobra/cobra/usar_loader.py src/pcobra/core/interpreter.py` y la comprobación final fue exitosa.
- No se modificaron pruebas unitarias automatizadas; el cambio pasa la verificación de sintaxis y limpieza de imports en los módulos afectados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb5cde09883278af12744943a9a4c)