### PR TITLE
Mejora flujo de `usar`: errores diferenciados y validaciones

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -90,8 +90,13 @@ from .environment import Environment
 
 MODULES_PATH = _DEFAULT_MODULES_PATH
 REPL_USAR_EXTERNAL_MODULE_ERROR = (
-    "módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)"
+    "usar_error[modulo_no_permitido]: módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)"
 )
+USAR_NON_CANONICAL_MODULE_ERROR = (
+    "usar_error[modulo_no_canonico]: el módulo solicitado no es canónico; use el alias oficial Cobra"
+)
+USAR_INVALID_EXPORT_ERROR = "usar_error[export_invalido]"
+USAR_SYMBOL_CONFLICT_ERROR = "usar_error[conflicto_simbolo]"
 USAR_COLLISION_STRICT_ERROR = "strict_error"
 USAR_COLLISION_WARN_ALIAS_REQUIRED = "warn_alias_required"
 _USAR_COLLISION_POLICIES = frozenset({USAR_COLLISION_STRICT_ERROR, USAR_COLLISION_WARN_ALIAS_REQUIRED})
@@ -1884,6 +1889,8 @@ class InterpretadorCobra:
             es_modulo_oficial_cobra = modulo_canonico is not None
 
             if not es_modulo_oficial_cobra:
+                if nombre_modulo in mapa_repl.values():
+                    raise PermissionError(USAR_NON_CANONICAL_MODULE_ERROR)
                 raise PermissionError(REPL_USAR_EXTERNAL_MODULE_ERROR)
             if not USAR_COBRA_FACING_MODULE_FLAGS.get(modulo_canonico, False):
                 raise PermissionError(
@@ -1947,7 +1954,7 @@ class InterpretadorCobra:
 
             if not simbolos_saneados:
                 raise ImportError(
-                    "rechazos de saneamiento en usar "
+                    f"{USAR_INVALID_EXPORT_ERROR}: rechazos de saneamiento en usar "
                     f"'{nodo.modulo}': no quedaron símbolos exportables tras saneamiento. "
                     f"conflictos={conflictos_saneamiento}"
                 )
@@ -1980,7 +1987,7 @@ class InterpretadorCobra:
                     self._trace_debug(f"[USAR_COLLISION][WARN] {evento_colision}")
                     raise NameError(
                         "No se puede usar el módulo "
-                        f"'{nodo.modulo}': colisión estructurada={detalle}. "
+                        f"'{nodo.modulo}': {USAR_SYMBOL_CONFLICT_ERROR} colisión estructurada={detalle}. "
                         "Requiere alias explícito según la convención del runtime (usar importar ... como ...)."
                     )
                 evento_colision = {
@@ -1994,7 +2001,7 @@ class InterpretadorCobra:
                 logging.error("USAR collision event: %s", evento_colision)
                 raise NameError(
                     "No se puede usar el módulo "
-                    f"'{nodo.modulo}': colisión estructurada={detalle}"
+                    f"'{nodo.modulo}': {USAR_SYMBOL_CONFLICT_ERROR} colisión estructurada={detalle}"
                 )
 
             # Fase B: inyectar de forma atómica y sin sobreescritura silenciosa.
@@ -2014,7 +2021,7 @@ class InterpretadorCobra:
                     )
                     raise NameError(
                         "No se puede usar el módulo "
-                        f"'{nodo.modulo}': colisión estructurada={detalle}"
+                        f"'{nodo.modulo}': {USAR_SYMBOL_CONFLICT_ERROR} colisión estructurada={detalle}"
                     )
                 contexto_actual.define(nombre, simbolo)
         except Exception as exc:

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -701,3 +701,26 @@ def test_repl_usar_emite_evento_telemetria_colision_warn(monkeypatch, caplog):
 def test_usar_loader_rechaza_numpy_y_equivalentes_prohibidos(nombre):
     with pytest.raises(PermissionError, match=r"Importación no permitida en 'usar'"):
         usar_loader.obtener_modulo(nombre)
+
+
+def test_usar_rechaza_modulo_no_canonico_en_repl_estricto():
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"num": "numero"})
+
+    with pytest.raises(PermissionError, match=r"usar_error\[modulo_no_canonico\]"):
+        interp.ejecutar_nodo(NodoUsar("numero"))
+
+
+def test_usar_error_export_invalido_es_diferenciado(monkeypatch):
+    modulo = ModuleType("texto")
+    modulo.__all__ = ["NO_CALLABLE"]
+    modulo.NO_CALLABLE = "valor"
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/texto.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"texto": "texto"})
+
+    with pytest.raises(ImportError, match=r"usar_error\[export_invalido\]"):
+        interp.ejecutar_nodo(NodoUsar("texto"))


### PR DESCRIPTION
### Motivation
- Implementar en el runtime de `usar` la secuencia: resolver módulo -> verificar Cobra-facing -> sanitizar exports -> comparar con entorno actual -> inyectar, unificando comportamiento entre REPL y ejecución batch. 
- Evitar sobreescritura silenciosa en caso de colisiones y proporcionar mensajes de error diferenciados para facilitar el diagnóstico automatizado. 

### Description
- Añadidas constantes de error en `src/pcobra/core/interpreter.py`: `USAR_NON_CANONICAL_MODULE_ERROR`, `USAR_INVALID_EXPORT_ERROR`, `USAR_SYMBOL_CONFLICT_ERROR` y modificación de `REPL_USAR_EXTERNAL_MODULE_ERROR` para incluir `usar_error[modulo_no_permitido]`. 
- En la fase de resolución se distingue cuando el nombre recibido no es clave permitida pero coincide con un valor canónico y se emite `usar_error[modulo_no_canonico]` en lugar del mensaje genérico. 
- El fallo de saneamiento cuando no quedan exportables ahora se etiqueta como `usar_error[export_invalido]`. 
- Los mensajes de colisión (preflight y runtime recheck) se etiquetan con `usar_error[conflicto_simbolo]` y se mantiene la política de no inyectar/sobrescribir símbolos existentes; también se preservan los eventos estructurados de telemetría. 
- Se añadieron pruebas en `tests/unit/test_usar.py` para cubrir rechazo por módulo no canónico en REPL estricto y para validar que el error de export inválido esté diferenciado. 

### Testing
- Se ejecutó `python -m compileall -q src/pcobra/core/interpreter.py tests/unit/test_usar.py` y la compilación de los módulos modificados fue satisfactoria. 
- Intenté ejecutar `pytest -q tests/unit/test_usar.py -k 'no_canonico or export_invalido or colision_policy_warn_alias_required_no_overwrite or modulos_externos_rechazados_en_runtime_general'` pero la colección de pruebas falló por un error de importación no relacionado con estos cambios: `ImportError: cannot import name 'INTERNAL_BACKENDS' from 'pcobra.cobra.architecture.backend_policy'`, por lo que las pruebas unitarias no pudieron completarse en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc2f7b7e8832780ce797ee1f9036a)