### PR TITLE
Cerrar superficie pública de holobit y reforzar validaciones de `usar`

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -240,6 +240,12 @@ def validar_paridad_superficie_publica_modulos_canonicos() -> None:
         if not exports:
             raise RuntimeError(f"[STARTUP CONTRACT] {module_name} debe declarar __all__")
 
+        expected_exports = USAR_RUNTIME_EXPORT_OVERRIDES.get(module_name)
+        if expected_exports is not None and tuple(exports) != tuple(expected_exports):
+            raise RuntimeError(
+                f"[STARTUP CONTRACT] {module_name} debe exportar exactamente {expected_exports} y en ese orden"
+            )
+
         missing_required = [name for name in contract.required_functions if name not in exports]
         if missing_required:
             raise RuntimeError(
@@ -256,6 +262,22 @@ def validar_paridad_superficie_publica_modulos_canonicos() -> None:
         if leaked_forbidden:
             raise RuntimeError(
                 f"[STARTUP CONTRACT] {module_name} exporta símbolos prohibidos: {leaked_forbidden}"
+            )
+
+        leaked_internal = [
+            name
+            for name in exports
+            if name.startswith("_") or "sdk" in name.lower() or "internal" in name.lower()
+        ]
+        if leaked_internal:
+            raise RuntimeError(
+                f"[STARTUP CONTRACT] {module_name} filtra símbolos internos en __all__: {leaked_internal}"
+            )
+
+        leaked_class_like = [name for name in exports if isinstance(name, str) and name[:1].isupper()]
+        if leaked_class_like:
+            raise RuntimeError(
+                f"[STARTUP CONTRACT] {module_name} no debe exportar clases en __all__: {leaked_class_like}"
             )
 
         stdlib_path = Path(__file__).resolve().parents[1] / "standard_library" / f"{module_name}.py"

--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -1,8 +1,7 @@
 """Adaptador público de Holobit para `usar "holobit"`.
 
 Este módulo expone únicamente funciones serializables y compatibles con Cobra.
-No re-exporta clases ni símbolos internos de `pcobra.core.holobits` ni de
-`holobit_sdk`.
+No re-exporta clases ni símbolos internos del runtime de Holobit.
 """
 
 import json
@@ -10,7 +9,7 @@ from collections.abc import Iterable, Sequence
 from typing import Any
 
 from pcobra.core.holobits.graficar import graficar as _sdk_graficar
-from pcobra.core.holobits.holobit import Holobit as _SDKHolobit
+from pcobra.core.holobits.holobit import Holobit as _RuntimeHolobit
 
 
 class ErrorHolobit(ValueError):
@@ -38,7 +37,7 @@ def _normalizar_valores(valores: Iterable[Any]) -> list[float]:
     return salida
 
 
-def _a_estructura_cobra(hb: _SDKHolobit) -> dict[str, Any]:
+def _a_estructura_cobra(hb: Any) -> dict[str, Any]:
     return {"tipo": "holobit", "valores": [float(v) for v in hb.valores]}
 
 
@@ -56,10 +55,10 @@ def _validar_estructura_holobit(hb: Any) -> dict[str, Any]:
     return hb
 
 
-def _desde_estructura_cobra(hb: dict[str, Any]) -> _SDKHolobit:
+def _desde_estructura_cobra(hb: dict[str, Any]) -> Any:
     estructura = _validar_estructura_holobit(hb)
     try:
-        return _SDKHolobit(_normalizar_valores(estructura["valores"]))
+        return _RuntimeHolobit(_normalizar_valores(estructura["valores"]))
     except Exception as exc:  # pragma: no cover - defensivo frente al SDK
         raise _error_dominio("No se pudo adaptar el holobit al runtime de Cobra", causa=exc) from None
 
@@ -67,7 +66,7 @@ def _desde_estructura_cobra(hb: dict[str, Any]) -> _SDKHolobit:
 def crear_holobit(valores: Iterable[Any]) -> dict[str, Any]:
     if valores is None:
         raise TypeError("'valores' no puede ser None")
-    return _a_estructura_cobra(_SDKHolobit(_normalizar_valores(valores)))
+    return _a_estructura_cobra(_RuntimeHolobit(_normalizar_valores(valores)))
 
 
 def validar_holobit(hb: Any) -> bool:
@@ -157,7 +156,7 @@ def medir(hb: dict[str, Any]) -> dict[str, float | int]:
     return salida
 
 
-__all__ = [
+PUBLIC_API_HOLOBIT: tuple[str, ...] = (
     "crear_holobit",
     "validar_holobit",
     "serializar_holobit",
@@ -167,5 +166,19 @@ __all__ = [
     "graficar",
     "combinar",
     "medir",
-]
+)
+
+
+def _validar_superficie_publica_holobit() -> None:
+    exportados = tuple(__all__)
+    if exportados != PUBLIC_API_HOLOBIT:
+        raise RuntimeError(
+            "[STARTUP CONTRACT] holobit.__all__ debe exponer únicamente la API pública canónica de Cobra."
+        )
+
+
+__all__ = list(PUBLIC_API_HOLOBIT)
+
+
+_validar_superficie_publica_holobit()
 


### PR DESCRIPTION
### Motivation
- Garantizar que el módulo `holobit` sólo exporte la API pública canónica de Cobra y eliminar cualquier referencia a tipos/clases internas en las anotaciones públicas.
- Detectar en arranque fugas de símbolos internos o clases en `__all__` desde la política central de `usar` para evitar exposure accidental del runtime.

### Description
- En `src/pcobra/corelibs/holobit.py` se introduce `PUBLIC_API_HOLOBIT` con las 9 funciones públicas permitidas y `__all__` ahora se deriva de dicha tupla, además se añade `_validar_superficie_publica_holobit()` que se ejecuta en import para fallar si `__all__` contiene símbolos no permitidos. 
- En `holobit.py` se eliminan referencias de tipado público a clases internas y se usa `Any` o `_RuntimeHolobit` internamente para evitar filtrar nombres de runtime en las anotaciones visibles. 
- En `src/pcobra/cobra/usar_policy.py` se añade una comprobación que exige paridad exacta con `USAR_RUNTIME_EXPORT_OVERRIDES` para módulos con override (incluido `holobit`) y se introducen validaciones que fallan en startup si `__all__` filtra símbolos internos/privados (prefijo `_`, ocurrencia de `sdk`/`internal`) o nombres con forma de clase (inicial mayúscula). 
- Los cambios refuerzan el contrato canónico de superficie para `usar` y centralizan las comprobaciones en arranque para detección temprana.

### Testing
- Se compiló a bytecode con `python -m py_compile src/pcobra/corelibs/holobit.py src/pcobra/cobra/usar_policy.py` y la compilación completó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6f7934648327b357bbc95c756e26)