### PR TITLE
test: ampliar cobertura de contratos `usar` y política pública

### DIFF
--- a/tests/unit/test_usar_public_contract.py
+++ b/tests/unit/test_usar_public_contract.py
@@ -59,12 +59,13 @@ def test_usar_datos_expone_filtrar_mapear_reducir(monkeypatch):
     assert {"filtrar", "mapear", "reducir"}.issubset(simbolos)
 
 
-def test_rechazo_usar_numpy(monkeypatch):
+@pytest.mark.parametrize("nombre", ["numpy", "np", "node-fetch", "serde", "holobit_sdk"] )
+def test_rechazo_usar_modulos_externos_y_no_canonicos(monkeypatch, nombre):
     monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda nombre: (_ for _ in ()).throw(ModuleNotFoundError(nombre)))
 
     cmd = InteractiveCommand(InterpretadorCobra())
     with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto"):
-        cmd.ejecutar_codigo('usar "numpy"')
+        cmd.ejecutar_codigo(f'usar "{nombre}"')
 
 
 def test_rechazo_internals_holobit_sdk(monkeypatch):
@@ -121,6 +122,12 @@ def test_runtime_startup_no_carga_legacy_backends():
     )
     assert result.returncode == 0, result.stderr
 
+
+
+
+def test_usar_policy_publica_exacta_modulos_canonicos():
+    assert tuple(REPL_COBRA_MODULE_MAP.keys()) == ("numero", "texto", "datos")
+    assert tuple(REPL_COBRA_MODULE_MAP.values()) == ("numero", "texto", "datos")
 
 def test_public_backends_contrato_exacto_en_backend_policy():
     assert PUBLIC_BACKENDS == ("python", "javascript", "rust")


### PR DESCRIPTION
### Motivation
- Reforzar la superficie pública y las reglas de seguridad del comando `usar` y asegurar que la política pública de módulos canónicos permanezca exacta para evitar regresiones.

### Description
- Actualicé `tests/unit/test_usar_public_contract.py` para parametrizar el rechazo de módulos externos y equivalentes no canónicos (`"numpy"`, `"np"`, `"node-fetch"`, `"serde"`, `"holobit_sdk"`) y añadí `test_usar_policy_publica_exacta_modulos_canonicos` que verifica que `REPL_COBRA_MODULE_MAP` tenga exactamente las claves y valores `("numero", "texto", "datos")`.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_public_contract.py tests/unit/test_usar_loader_public_api_contract.py tests/unit/test_startup_no_legacy_eager_loading.py` y la colección falló por un `ImportError` al intentar importar `INTERNAL_BACKENDS` desde `pcobra.cobra.architecture.backend_policy`, error ajeno a este cambio; los tests nuevos no llegaron a ejecutarse.
- Ejecuté `pytest -q tests/unit/test_usar_loader_public_api_contract.py tests/unit/test_startup_no_legacy_eager_loading.py` y hubo 5 fallos en `tests/unit/test_usar_loader_public_api_contract.py` donde `sanear_simbolo_para_usar` devuelve `codigo == 'explicit_forbidden_name'` en lugar de `cobra_public_equivalent`, lo que indica una discrepancia de política previa y no fue introducido por este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7828d2e083279b1320a38d5ed24f)