### PR TITLE
Bloquear cambios en lexer/parser canónicos para contribuciones de runtime

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,27 @@ Fixtures de regresión para `validar-sintaxis`:
 - Cada feature nueva debe añadir `examples/features/<feature_id>/minimal.co`.
 - `validar-sintaxis` usa automáticamente esos fixtures para smoke de regresión.
 
+
+## Alcance de extensiones de módulos/core runtime
+
+Para contribuciones enfocadas en extensión de módulos o runtime (`src/pcobra/cobra/**`),
+**no se deben introducir cambios sintácticos** (lexer/parser) salvo que el issue/ADR
+especifique explícitamente una evolución del lenguaje.
+
+Rutas canónicas de sintaxis (protegidas por gate):
+
+- `src/pcobra/cobra/core/lexer.py`
+- `src/pcobra/cobra/core/parser.py`
+
+Gate recomendado en CI/local:
+
+```bash
+python scripts/ci/gate_no_parser_lexer_changes.py --base <sha_base> --head <sha_head>
+```
+
+Si este gate falla, el cambio queda fuera del alcance “runtime/core modules only” y
+debe moverse a una tarea de evolución sintáctica.
+
 ## Dependencias y versionado
 
 - Usa `pyproject.toml` (`[project].version`) como **única fuente visible de

--- a/scripts/ci/gate_no_parser_lexer_changes.py
+++ b/scripts/ci/gate_no_parser_lexer_changes.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Gate de CI: bloquea cambios en lexer/parser canónicos."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+CANONICAL_SYNTAX_PATHS = (
+    Path("src/pcobra/cobra/core/lexer.py"),
+    Path("src/pcobra/cobra/core/parser.py"),
+)
+
+
+def _git_changed_files(base: str, head: str) -> list[Path]:
+    cmd = ["git", "diff", "--name-only", f"{base}...{head}"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git diff falló")
+    return [Path(line.strip()) for line in result.stdout.splitlines() if line.strip()]
+
+
+def _find_blocked_paths(changed: list[Path]) -> list[Path]:
+    blocked = []
+    blocked_set = {p.as_posix() for p in CANONICAL_SYNTAX_PATHS}
+    for path in changed:
+        if path.as_posix() in blocked_set:
+            blocked.append(path)
+    return blocked
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Falla si se detectan cambios en lexer/parser canónicos "
+            "dentro del alcance del trabajo actual"
+        )
+    )
+    parser.add_argument("--base", help="SHA/rama base para diff", default=None)
+    parser.add_argument("--head", help="SHA/rama head para diff", default="HEAD")
+    parser.add_argument(
+        "--changed-file",
+        action="append",
+        default=[],
+        help="Archivo modificado (puede repetirse). Si se usa, omite git diff.",
+    )
+    args = parser.parse_args()
+
+    if args.changed_file:
+        changed_files = [Path(p) for p in args.changed_file]
+    else:
+        base = args.base or "HEAD~1"
+        try:
+            changed_files = _git_changed_files(base, args.head)
+        except RuntimeError as exc:
+            print(f"[gate-no-parser-lexer] error: {exc}", file=sys.stderr)
+            return 2
+
+    blocked = _find_blocked_paths(changed_files)
+    if blocked:
+        print("[gate-no-parser-lexer] Se detectaron cambios sintácticos bloqueados:")
+        for path in blocked:
+            print(f" - {path.as_posix()}")
+        print(
+            "Si necesitas extender módulos/core runtime, evita cambios de sintaxis "
+            "(lexer/parser) en este alcance."
+        )
+        return 1
+
+    print("[gate-no-parser-lexer] OK: sin cambios en lexer/parser canónicos.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_gate_no_parser_lexer_changes.py
+++ b/tests/unit/test_gate_no_parser_lexer_changes.py
@@ -1,0 +1,28 @@
+import subprocess
+import sys
+
+
+def _run_gate(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "scripts/ci/gate_no_parser_lexer_changes.py", *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_gate_passes_with_runtime_only_changes() -> None:
+    result = _run_gate(
+        "--changed-file",
+        "src/pcobra/cobra/runtime/executor.py",
+    )
+    assert result.returncode == 0
+
+
+def test_gate_fails_when_parser_changes() -> None:
+    result = _run_gate(
+        "--changed-file",
+        "src/pcobra/cobra/core/parser.py",
+    )
+    assert result.returncode == 1
+    assert "bloqueados" in result.stdout


### PR DESCRIPTION
### Motivation

- Evitar que cambios sintácticos accidentales (lexer/parser) se filtren en PRs que solo extienden módulos o el runtime. 
- Formalizar las rutas canónicas de sintaxis que deben protegerse durante trabajos de `src/pcobra/cobra/**`.
- Proveer un gate sencillo para CI/local que permita detectar y detener esos cambios antes de merge.

### Description

- Añadido script de gate `scripts/ci/gate_no_parser_lexer_changes.py` que falla si detecta modificaciones en `src/pcobra/cobra/core/lexer.py` o `src/pcobra/cobra/core/parser.py` usando `git diff` o `--changed-file` para pruebas/pipelines. 
- Actualizada la guía de contribución `CONTRIBUTING.md` con la sección `Alcance de extensiones de módulos/core runtime` y las rutas canónicas protegidas. 
- Añadidas pruebas unitarias `tests/unit/test_gate_no_parser_lexer_changes.py` que cubren el paso (cambios runtime permitidos) y el fallo (cambio en parser detectado). 

### Testing

- Ejecutado `pytest -q tests/unit/test_gate_no_parser_lexer_changes.py` y la suite pasó con `2 passed` y `1 warning`.
- Las pruebas llaman al gate con `--changed-file` para simular los casos `runtime` y `parser` sin depender de git en el entorno de CI. 
- El gate imprime resultados legibles y devuelve código de salida `0` en OK, `1` cuando detecta cambios bloqueados y `2` si `git diff` falla.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7b4ef948832797599d99843b321b)