### PR TITLE
Restringe la política pública de targets a python/javascript/rust

### DIFF
--- a/src/pcobra/cobra/transpilers/module_map.py
+++ b/src/pcobra/cobra/transpilers/module_map.py
@@ -14,6 +14,13 @@ from pcobra.cobra.stdlib_contract import get_contract_manifests
 
 logger = logging.getLogger(__name__)
 
+
+if OFFICIAL_TARGETS != PUBLIC_BACKENDS:
+    raise RuntimeError(
+        "OFFICIAL_TARGETS y PUBLIC_BACKENDS deben coincidir en module_map para evitar rutas legacy. "
+        f"official={OFFICIAL_TARGETS}; public={PUBLIC_BACKENDS}"
+    )
+
 MODULE_MAP_PATH = os.environ.get(
     'COBRA_MODULE_MAP',
     os.path.abspath(

--- a/src/pcobra/cobra/transpilers/target_utils.py
+++ b/src/pcobra/cobra/transpilers/target_utils.py
@@ -37,31 +37,17 @@ LEGACY_OR_AMBIGUOUS_TARGETS: Final[tuple[str, ...]] = (
 
 # Recomendación canónica por cada nombre retirado.
 RETIRED_TARGET_REPLACEMENTS: Final[dict[str, str]] = {
-    "assembly": "asm",
     "js": "javascript",
-    "c": "cpp",
-    "cxx": "cpp",
-    "cpp11": "cpp",
-    "cpp17": "cpp",
-    "asm64": "asm",
-    "assembler": "asm",
     "node": "javascript",
     "nodejs": "javascript",
     "py": "python",
     "python3": "python",
-    "golang": "go",
-    "jvm": "java",
 }
 
 TARGET_FRIENDLY_LABELS: Final[dict[str, str]] = {
     "python": "Python",
     "rust": "Rust",
     "javascript": "JavaScript",
-    "wasm": "WebAssembly",
-    "go": "Go",
-    "cpp": "cpp",
-    "java": "Java",
-    "asm": "asm",
 }
 
 

--- a/tests/unit/test_target_validation_contract.py
+++ b/tests/unit/test_target_validation_contract.py
@@ -5,8 +5,9 @@ from unittest.mock import patch
 import pytest
 
 from cobra.cli.cli import main
-from pcobra.cobra.cli.target_policies import parse_target
+from pcobra.cobra.cli.target_policies import OFFICIAL_TRANSPILATION_TARGETS, parse_target
 from pcobra.cobra.semantico import mod_validator
+from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
 
 
 def test_api_parse_target_valido_canonico() -> None:
@@ -23,7 +24,9 @@ def test_api_parse_target_invalido_muestra_lista_exacta_con_tiers() -> None:
         parse_target("fantasy")
     mensaje = str(exc.value)
     assert "python=tier1" in mensaje
-    assert "asm=tier2" in mensaje
+    assert "javascript=tier1" in mensaje
+    assert "rust=tier1" in mensaje
+    assert "asm=tier2" not in mensaje
 
 
 def test_cli_compilar_target_invalido_muestra_lista_exacta_con_tiers(tmp_path) -> None:
@@ -36,7 +39,9 @@ def test_cli_compilar_target_invalido_muestra_lista_exacta_con_tiers(tmp_path) -
     assert exc.value.code == 2
     salida = out.getvalue()
     assert "python=tier1" in salida
-    assert "asm=tier2" in salida
+    assert "javascript=tier1" in salida
+    assert "rust=tier1" in salida
+    assert "asm=tier2" not in salida
 
 
 def test_mod_validator_rechaza_required_targets_fuera_de_lista(monkeypatch) -> None:
@@ -50,4 +55,14 @@ def test_mod_validator_rechaza_required_targets_fuera_de_lista(monkeypatch) -> N
     mensaje = str(exc.value)
     assert "target no permitido" in mensaje
     assert "python=tier1" in mensaje
-    assert "asm=tier2" in mensaje
+    assert "javascript=tier1" in mensaje
+    assert "rust=tier1" in mensaje
+    assert "asm=tier2" not in mensaje
+
+
+def test_startup_targets_contract_exige_solo_tres_targets_publicos() -> None:
+    assert OFFICIAL_TARGETS == ("python", "javascript", "rust")
+
+
+def test_cli_targets_contract_exige_solo_tres_targets_publicos() -> None:
+    assert OFFICIAL_TRANSPILATION_TARGETS == ("python", "javascript", "rust")


### PR DESCRIPTION
### Motivation
- Forzar que la superficie pública de targets (CLI, documentación y resoluciones de módulos) solo exponga los tres backends oficiales: `python`, `javascript` y `rust`.
- Evitar que recomendaciones de migración o etiquetas amigables vuelvan a reactivar rutas legacy (por ejemplo `js`, `golang`, `jvm`, `asm`) en la inicialización/compilación.
- Bloquear cualquier divergencia entre la lista oficial de targets y la política pública para impedir mappings ejecutables a backends retirados.

### Description
- En `src/pcobra/cobra/transpilers/target_utils.py` se redujeron `RETIRED_TARGET_REPLACEMENTS` y `TARGET_FRIENDLY_LABELS` para exponer únicamente el universo público (`python`, `javascript`, `rust`) mientras se mantienen listados y rechazo explícito de nombres legacy en `LEGACY_OR_AMBIGUOUS_TARGETS`.
- En `src/pcobra/cobra/transpilers/module_map.py` se añadió una comprobación temprana que falla si `OFFICIAL_TARGETS` no coincide exactamente con `PUBLIC_BACKENDS`, impidiendo que mappings públicos resuelvan a backends legacy.
- En `tests/unit/test_target_validation_contract.py` se actualizaron los asserts que muestran los tiers y se añadieron pruebas que aseguran que tanto `OFFICIAL_TARGETS` como `OFFICIAL_TRANSPILATION_TARGETS` sean exactamente `("python", "javascript", "rust")`.

### Testing
- Ejecutado: `pytest -q tests/unit/test_target_validation_contract.py tests/unit/test_smoke_transpilation_official_targets.py::test_module_map_resuelve_targets_publicos_solo_desde_cobra_toml tests/unit/test_smoke_transpilation_official_targets.py::test_module_map_falla_si_toml_declara_target_no_publico` y falló la colección con un `ImportError` por un problema preexistente al intentar importar `INTERNAL_BACKENDS` desde `pcobra.cobra.architecture.backend_policy`.
- Ejecutado: `pytest -q tests/unit/test_target_validation_contract.py` y la ejecución también falló en la fase de colección por el mismo `ImportError: cannot import name 'INTERNAL_BACKENDS' from 'pcobra.cobra.architecture.backend_policy'`.
- Nota: Las pruebas modificadas validan explícitamente la política pública y fallarán si aparece cualquier backend fuera de `python/javascript/rust` en startup/CLI; la falla observada es una dependencia de importación ajena a estos cambios y debe resolverse para completar el pipeline de tests automatizados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd84d053c08327adb66e9d39cc3b7c)