### PR TITLE
Refuerza saneamiento de símbolos para `usar` y amplía pruebas

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -89,6 +89,14 @@ def _mensaje_nombre_prohibido(nombre: str) -> str:
 
 def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamientoSimboloUsar:
     """Aplica la política de exportación de símbolos para ``usar``."""
+    if nombre in DUNDERS_BLOQUEADOS:
+        return _rechazar(
+            nombre,
+            simbolo,
+            "dunder_name",
+            "dunders Python conocidos no se permiten en usar",
+        )
+
     if nombre.startswith("_"):
         return _rechazar(
             nombre,
@@ -103,14 +111,6 @@ def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamien
             simbolo,
             "dunder_pattern",
             "nombres con '__' no se permiten en usar",
-        )
-
-    if nombre in DUNDERS_BLOQUEADOS:
-        return _rechazar(
-            nombre,
-            simbolo,
-            "dunder_name",
-            "dunders Python conocidos no se permiten en usar",
         )
 
     if _es_objeto_backend_no_exportable(simbolo):

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -4,9 +4,11 @@ from pcobra.core.usar_symbol_policy import sanear_exportables_para_usar, sanear_
 
 
 def test_rechaza_nombres_prohibidos_explicitos():
-    for nombre in ("self", "append", "map"):
+    for nombre in ("self", "append", "map", "filter", "unwrap", "expect"):
         resultado = sanear_simbolo_para_usar(nombre, lambda: None)
         assert resultado.rechazado is True
+        assert resultado.codigo == "explicit_forbidden_name"
+        assert "Usa el nombre Cobra canónico" in (resultado.mensaje or "")
 
 
 def test_rechaza_doble_guion_bajo_y_modulo_backend():
@@ -28,7 +30,7 @@ def test_reglas_de_saneamiento_por_caso_especifico():
 
     r_dunder_python = sanear_simbolo_para_usar("__name__", lambda: None)
     assert r_dunder_python.rechazado is True
-    assert r_dunder_python.codigo == "private_prefix"
+    assert r_dunder_python.codigo == "dunder_name"
 
     r_objeto_backend = sanear_simbolo_para_usar("backend", ModuleType("backend"))
     assert r_objeto_backend.rechazado is True
@@ -56,6 +58,24 @@ def test_saneamiento_centralizado_aplica_todas_las_reglas():
     assert [nombre for nombre, _ in permitidos] == ["PI", "publica"]
     assert {r.nombre for r in rechazos} == {"_interno", "append"}
     assert [w.nombre for w in warnings] == ["PI"]
+
+
+def test_acepta_equivalentes_canonicos_en_espanol():
+    for nombre in ("agregar", "mapear", "filtrar", "obtener_o_error", "esperar_valor"):
+        resultado = sanear_simbolo_para_usar(nombre, lambda: None)
+        assert resultado.rechazado is False
+        assert resultado.codigo == "ok"
+
+
+def test_rechaza_no_callable_que_no_es_constante_publica_canonica():
+    resultado = sanear_simbolo_para_usar("valor_interno", 123)
+    assert resultado.rechazado is True
+    assert resultado.codigo == "non_callable_not_canonical_public_constant"
+
+    resultado_ok = sanear_simbolo_para_usar("PI", 3.14159)
+    assert resultado_ok.rechazado is False
+    assert resultado_ok.warning is True
+    assert resultado_ok.codigo == "public_constant"
 
 
 


### PR DESCRIPTION
### Motivation
- Evitar sobreescrituras silenciosas y exponer rechazos claros al importar símbolos con `usar` mediante reglas explícitas de saneamiento.
- Reforzar la política para bloquear dunders Python conocidos, prefijos privados, alias en inglés prohibidos y objetos/módulos backend no exportables, permitiendo únicamente constantes públicas canónicas no-callables.

### Description
- Ajusta la prioridad de validación en `sanear_simbolo_para_usar` para comprobar `DUNDERS_BLOQUEADOS` primero y rechazar con el código `dunder_name` cuando corresponda (archivo `src/pcobra/core/usar_symbol_policy.py`).
- Mantiene el rechazo de prefijos privados (`_`), patrones con `__`, nombres prohibidos (p. ej. `self`, `append`, `map`, `filter`, `unwrap`, `expect`) y objetos módulo/backend no exportables; y rechaza no-callables salvo constantes canónicas (`PI`, `E`, etc.).
- Conserva la producción de conflictos estructurados en `sanitizar_exports_publicos` integrando los resultados de `sanear_exportables_para_usar` sin cambiar su flujo (archivo `src/pcobra/cobra/usar_loader.py`).
- Añade y amplía pruebas unitarias en `tests/unit/test_usar_symbol_policy.py` para cubrir aliases prohibidos en inglés, dunders con código específico, aceptación de equivalentes canónicos en español (`agregar`, `mapear`, `filtrar`, `obtener_o_error`, `esperar_valor`) y rechazo/aceptación de no-callables y constantes públicas.

### Testing
- Ejecutado `pytest -q tests/unit/test_usar_symbol_policy.py` y la suite pasó (`7 passed, 1 warning`).
- Las modificaciones se probaron únicamente con la suite de pruebas unitarias mencionada y no se cambiaron otras rutas de ejecución automáticas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd9d7e03b8832783825eb770b593e4)