### PR TITLE
Normaliza contrato público de holobit y aísla runtime interno

### DIFF
--- a/docs/standard_library/holobit.md
+++ b/docs/standard_library/holobit.md
@@ -31,13 +31,16 @@ El módulo `holobit` disponible vía `usar "holobit"` expone **solo** estas func
 ## Reglas del contrato
 
 - No se exportan clases ni namespaces internos de Python.
+- El orden de `__all__` es contractual y estable para `usar`:
+  `crear_holobit`, `validar_holobit`, `serializar_holobit`, `deserializar_holobit`,
+  `proyectar`, `transformar`, `graficar`, `combinar`, `medir`.
 - La estructura de intercambio es serializable y Cobra-compatible:
 
 ```json
 {"tipo":"holobit","valores":[1.0,2.0,3.0]}
 ```
 
-- El módulo no expone `holobit_sdk`, clases internas ni helpers privados; cualquier acceso directo a esos símbolos se considera fuga y debe fallar en pruebas.
+- El módulo no expone clases internas, helpers privados ni nombres de backend; cualquier acceso directo a esos símbolos se considera fuga y debe fallar en pruebas.
 - `usar "holobit_sdk"` está prohibido por política de `usar`.
 
 ## Ejemplos Cobra

--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -146,9 +146,19 @@ CANONICAL_MODULE_SURFACE_CONTRACTS: dict[str, CanonicalModuleSurfaceContract] = 
         forbidden_symbols=("requests", "httpx"),
     ),
     "holobit": CanonicalModuleSurfaceContract(
-        required_functions=("crear_holobit", "validar_holobit", "transformar", "graficar"),
+        required_functions=(
+            "crear_holobit",
+            "validar_holobit",
+            "serializar_holobit",
+            "deserializar_holobit",
+            "proyectar",
+            "transformar",
+            "graficar",
+            "combinar",
+            "medir",
+        ),
         allowed_aliases={},
-        forbidden_symbols=("_SDKHolobit",),
+        forbidden_symbols=("_SDKHolobit", "Holobit", "holobit_sdk"),
     ),
 }
 

--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -5,10 +5,11 @@ No re-exporta clases ni símbolos internos del runtime de Holobit.
 """
 
 import json
+import math
 from collections.abc import Iterable, Sequence
 from typing import Any
 
-from pcobra.core.holobits.graficar import graficar as _sdk_graficar
+from pcobra.core.holobits.graficar import graficar as _runtime_graficar
 from pcobra.core.holobits.holobit import Holobit as _RuntimeHolobit
 
 
@@ -20,6 +21,22 @@ def _error_dominio(mensaje: str, *, causa: Exception | None = None) -> ErrorHolo
     if causa is None:
         return ErrorHolobit(mensaje)
     return ErrorHolobit(mensaje)
+
+
+class _AdaptadorInternoHolobit:
+    """Encapsula acceso al runtime interno de Holobit sin exponer backend."""
+
+    @staticmethod
+    def crear_desde_valores(valores: list[float]) -> Any:
+        return _RuntimeHolobit(valores)
+
+    @staticmethod
+    def obtener_valores(hb: Any) -> list[float]:
+        return [float(v) for v in hb.valores]
+
+    @staticmethod
+    def graficar(hb: Any) -> str:
+        return _runtime_graficar(hb)
 
 
 def _es_numero(valor: Any) -> bool:
@@ -38,7 +55,7 @@ def _normalizar_valores(valores: Iterable[Any]) -> list[float]:
 
 
 def _a_estructura_cobra(hb: Any) -> dict[str, Any]:
-    return {"tipo": "holobit", "valores": [float(v) for v in hb.valores]}
+    return {"tipo": "holobit", "valores": _AdaptadorInternoHolobit.obtener_valores(hb)}
 
 
 def _validar_estructura_holobit(hb: Any) -> dict[str, Any]:
@@ -58,7 +75,7 @@ def _validar_estructura_holobit(hb: Any) -> dict[str, Any]:
 def _desde_estructura_cobra(hb: dict[str, Any]) -> Any:
     estructura = _validar_estructura_holobit(hb)
     try:
-        return _RuntimeHolobit(_normalizar_valores(estructura["valores"]))
+        return _AdaptadorInternoHolobit.crear_desde_valores(_normalizar_valores(estructura["valores"]))
     except Exception as exc:  # pragma: no cover - defensivo frente al SDK
         raise _error_dominio("No se pudo adaptar el holobit al runtime de Cobra", causa=exc) from None
 
@@ -66,7 +83,7 @@ def _desde_estructura_cobra(hb: dict[str, Any]) -> Any:
 def crear_holobit(valores: Iterable[Any]) -> dict[str, Any]:
     if valores is None:
         raise TypeError("'valores' no puede ser None")
-    return _a_estructura_cobra(_RuntimeHolobit(_normalizar_valores(valores)))
+    return _a_estructura_cobra(_AdaptadorInternoHolobit.crear_desde_valores(_normalizar_valores(valores)))
 
 
 def validar_holobit(hb: Any) -> bool:
@@ -119,8 +136,6 @@ def transformar(hb: dict[str, Any], operacion: str, *parametros: Any) -> dict[st
         angulo = float(parametros[1])
         if eje != "z" or len(valores) < 2:
             return crear_holobit(valores)
-        import math
-
         rad = math.radians(angulo)
         x, y = valores[0], valores[1]
         valores[0] = x * math.cos(rad) - y * math.sin(rad)
@@ -132,7 +147,7 @@ def transformar(hb: dict[str, Any], operacion: str, *parametros: Any) -> dict[st
 
 def graficar(hb: dict[str, Any]) -> str:
     try:
-        vista = _sdk_graficar(_desde_estructura_cobra(hb))
+        vista = _AdaptadorInternoHolobit.graficar(_desde_estructura_cobra(hb))
     except Exception as exc:  # pragma: no cover - defensivo frente al SDK
         raise _error_dominio("No se pudo graficar el holobit en el runtime de Cobra", causa=exc) from None
     if not isinstance(vista, str):
@@ -181,4 +196,3 @@ __all__ = list(PUBLIC_API_HOLOBIT)
 
 
 _validar_superficie_publica_holobit()
-


### PR DESCRIPTION
### Motivation
- Normalizar la fachada pública de `holobit` para que exponga únicamente la API canónica en español y en un orden contractual estable.
- Evitar la fuga de símbolos/backend (clases SDK, nombres internos) hacia la superficie pública de `usar "holobit"`. 
- Actualizar la política de `usar` y la documentación para reflejar el contrato público y el rechazo explícito de backends no-canónicos.

### Description
- En `src/pcobra/corelibs/holobit.py` se introdujo la clase privada `_AdaptadorInternoHolobit` que encapsula el acceso al runtime interno y se redirigieron las operaciones (creación, obtención de valores y `graficar`) a ese adaptador para no exponer clases/imports internos. 
- Se normalizó la API pública manteniendo exactamente los símbolos `crear_holobit`, `validar_holobit`, `serializar_holobit`, `deserializar_holobit`, `proyectar`, `transformar`, `graficar`, `combinar`, `medir` y se asegura el orden contractual vía la comprobación de `__all__`. 
- En `src/pcobra/cobra/usar_policy.py` se amplió el contrato canónico de `holobit` para requerir las 9 funciones canónicas y se añadieron símbolos prohibidos (`Holobit`, `holobit_sdk`, `_SDKHolobit`) al `forbidden_symbols`. 
- Se actualizó la documentación en `docs/standard_library/holobit.md` para reflejar el orden estable de `__all__` y la regla de no exponer nombres/backend internos.

### Testing
- Ejecutado `pytest -q tests/unit/test_corelibs_holobit_adapter.py tests/unit/test_holobit_no_fuga_exports.py tests/unit/test_usar_loader_validation.py` y la suite devolvió `23 passed, 1 warning` (advertencia deprecación preexistente en `importlib/core`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda6b222088327aa9f585220dc7264)