### PR TITLE
Endurecer validación de `usar`: centralizar saneamiento, bloquear backends y evitar bypasses

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -5,16 +5,13 @@ from pathlib import Path
 import sys
 from typing import Any
 
-from pcobra.cobra.usar_policy import USAR_COBRA_ALLOWLIST, USAR_COBRA_PUBLIC_MODULES
+from pcobra.cobra.usar_policy import (
+    USAR_BACKEND_BLOCKLIST,
+    USAR_COBRA_ALLOWLIST,
+    USAR_COBRA_PUBLIC_MODULES,
+    USAR_RUNTIME_EXPORT_OVERRIDES,
+)
 from pcobra.core.usar_symbol_policy import sanear_exportables_para_usar
-
-# Módulos no canónicos conocidos que deben rechazarse de forma explícita.
-_USAR_NON_CANONICAL_MODULES: frozenset[str] = frozenset({
-    "numpy",
-    "node-fetch",
-    "serde",
-    "holobit_sdk",
-})
 
 # Regex estricta para mantener la sintaxis `usar "modulo"` acotada a identificadores simples.
 _VALID_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
@@ -36,7 +33,7 @@ def _rechazar_modulo_no_canonico(nombre: str) -> None:
     """Rechaza módulos backend/no-canónicos con error explícito para `usar`."""
 
     nombre_normalizado = (nombre or "").strip().lower()
-    if nombre_normalizado in _USAR_NON_CANONICAL_MODULES:
+    if nombre_normalizado in USAR_BACKEND_BLOCKLIST:
         raise PermissionError(
             f"Importación no permitida en 'usar': '{nombre}'. "
             "Es un módulo backend/no canónico y no forma parte de la API pública. "
@@ -145,14 +142,20 @@ def sanitizar_exports_publicos(modulo: object, alias_modulo: str) -> tuple[dict[
 
     exportables = getattr(modulo, "__all__", None)
     if exportables is None:
-        candidatos = [
-            nombre for nombre in dir(modulo) if isinstance(nombre, str) and not nombre.startswith("_")
+        candidatos = list(USAR_RUNTIME_EXPORT_OVERRIDES.get(alias_modulo, ()))
+        conflictos = [
+            {
+                "module": alias_modulo,
+                "symbol": "__all__",
+                "code": "missing___all__",
+                "message": "módulo sin __all__; se aplica whitelist explícita por política",
+            }
         ]
     else:
         candidatos = exportables
+        conflictos = []
 
     simbolos_brutos: list[tuple[str, object]] = []
-    conflictos: list[dict[str, str]] = []
     vistos: set[str] = set()
     for nombre in candidatos:
         if not isinstance(nombre, str):

--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -20,6 +20,16 @@ USAR_COBRA_PUBLIC_MODULES: tuple[str, ...] = (
     "holobit",
 )
 USAR_COBRA_ALLOWLIST: frozenset[str] = frozenset(USAR_COBRA_PUBLIC_MODULES)
+USAR_BACKEND_BLOCKLIST: frozenset[str] = frozenset(
+    {
+        "numpy",
+        "node-fetch",
+        "serde",
+        "holobit_sdk",
+        "pandas",
+        "torch",
+    }
+)
 
 REPL_COBRA_MODULE_MAP: dict[str, str] = {modulo: modulo for modulo in USAR_COBRA_PUBLIC_MODULES}
 USAR_COBRA_FACING_MODULE_FLAGS: dict[str, bool] = {

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -72,7 +72,6 @@ from .cobra_config import (
 from ..cobra.usar_policy import (
     REPL_COBRA_MODULE_MAP,
     USAR_COBRA_FACING_MODULE_FLAGS,
-    USAR_RUNTIME_EXPORT_OVERRIDES,
 )
 from .resource_limits import (
     limitar_memoria_mb as _lim_mem,
@@ -1850,36 +1849,7 @@ class InterpretadorCobra:
             canónicos del catálogo oficial Cobra.
         """
         from pathlib import Path
-        from types import ModuleType
-
         from .usar_loader import obtener_modulo, sanitizar_exports_publicos
-
-        def _resolver_exportables(modulo_obj, *, modulo_oficial: bool, nombre_modulo: str):
-            """Resuelve exportables candidatos según política de ``usar``."""
-            exportables = getattr(modulo_obj, "__all__", None)
-            if modulo_oficial:
-                exportables = USAR_RUNTIME_EXPORT_OVERRIDES.get(nombre_modulo, exportables)
-
-            if exportables is None:
-                candidatos = [
-                    nombre
-                    for nombre in dir(modulo_obj)
-                    if isinstance(nombre, str) and not nombre.startswith("_")
-                ]
-            else:
-                candidatos = exportables
-
-            simbolos = []
-            vistos = set()
-            for nombre in candidatos:
-                if not isinstance(nombre, str) or nombre in vistos:
-                    continue
-                if not hasattr(modulo_obj, nombre):
-                    continue
-                simbolo = getattr(modulo_obj, nombre)
-                vistos.add(nombre)
-                simbolos.append((nombre, simbolo))
-            return simbolos
 
         def _resolver_carga_modulo_usar(nombre_modulo: str):
             """Resuelve solo módulos canónicos Cobra; ``usar`` nunca hace import dinámico externo."""
@@ -1927,20 +1897,8 @@ class InterpretadorCobra:
                 if not es_oficial:
                     raise PermissionError(REPL_USAR_EXTERNAL_MODULE_ERROR)
 
-            # ``usar`` solo importa API pública explícita del módulo Cobra:
-            # prioriza __all__, filtra privados/no-callables y evita fugas de
-            # símbolos internos o reexportados de forma implícita.
-            simbolos_a_inyectar = _resolver_exportables(
-                modulo, modulo_oficial=es_modulo_oficial_cobra, nombre_modulo=nombre_modulo
-            )
-
             contexto_actual = self.contextos[-1]
-            modulo_proxy = type("_UsarExportsProxy", (), {})()
-            for nombre, simbolo in simbolos_a_inyectar:
-                setattr(modulo_proxy, nombre, simbolo)
-            setattr(modulo_proxy, "__all__", [nombre for nombre, _ in simbolos_a_inyectar])
-
-            mapa_limpio, conflictos_saneamiento = sanitizar_exports_publicos(modulo_proxy, nodo.modulo)
+            mapa_limpio, conflictos_saneamiento = sanitizar_exports_publicos(modulo, nombre_modulo)
             simbolos_saneados = list(mapa_limpio.items())
             if conflictos_saneamiento:
                 evento_conflictos = {


### PR DESCRIPTION
### Motivation
- Evitar rutas alternativas que permitan exportar símbolos sin pasar por la política central de `usar`. 
- Bloquear explícitamente módulos backend/no-canónicos y prevenir sobreescritura silenciosa en el entorno. 
- Asegurar que `__all__` solo se use si existe y, si no, aplicar una whitelist por política en lugar de exponer toda la reflexión.

### Description
- `src/pcobra/cobra/usar_loader.py`: `sanitizar_exports_publicos` ahora solo usa `__all__` cuando existe y, si falta, aplica la whitelist `USAR_RUNTIME_EXPORT_OVERRIDES` por módulo y añade un conflicto estructurado `missing___all__`; además consume la política de backend `USAR_BACKEND_BLOCKLIST` y delega en `sanear_exportables_para_usar` para la validación final. 
- `src/pcobra/core/interpreter.py`: eliminada la ruta alternativa que construía `modulo_proxy` y `_resolver_exportables`; `ejecutar_usar` delega directamente en `sanitizar_exports_publicos` para evitar bypasses y mantener una única vía de saneamiento. 
- `src/pcobra/cobra/usar_policy.py`: añadida la fuente canónica `USAR_BACKEND_BLOCKLIST` (ej. `numpy`, `node-fetch`, `serde`, `holobit_sdk`, `pandas`, `torch`) para bloqueo explícito consumido por el loader. 
- Se preserva la detección estructurada de colisiones (preflight y runtime recheck) y la política de no-overwrite al inyectar símbolos en el contexto.

### Testing
- Ejecutado `python -m compileall -q` sobre los módulos modificados (`src/pcobra/core/interpreter.py`, `src/pcobra/cobra/usar_loader.py`, `src/pcobra/cobra/usar_policy.py`, `src/pcobra/core/usar_symbol_policy.py`), y la compilación finalizó correctamente (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb56c4da88327a62254d22e6d5a36)