### PR TITLE
Forzar política pública de backends y aislar compatibilidad legacy interna

### DIFF
--- a/src/pcobra/cobra/build/orchestrator.py
+++ b/src/pcobra/cobra/build/orchestrator.py
@@ -13,7 +13,7 @@ from pcobra.cobra.architecture.contracts import (
     assert_backend_allowed_for_scope,
     validate_capabilities_contract,
 )
-from pcobra.cobra.architecture.backend_policy import INTERNAL_BACKENDS
+from pcobra.cobra.internal_compat.legacy_contracts import INTERNAL_BACKENDS
 from pcobra.cobra.config.transpile_targets import target_metadata
 from pcobra.cobra.transpilers.module_map import get_toml_map
 from pcobra.cobra.transpilers.target_utils import normalize_target_name

--- a/src/pcobra/cobra/internal_compat/legacy_contracts.py
+++ b/src/pcobra/cobra/internal_compat/legacy_contracts.py
@@ -6,11 +6,9 @@ legacy del dominio principal; usar este namespace `internal_compat`.
 
 from __future__ import annotations
 
-from pcobra.cobra.architecture.backend_policy import (
+from pcobra.cobra.architecture.legacy_backend_lifecycle import (
     INTERNAL_BACKENDS,
     INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW,
-)
-from pcobra.cobra.architecture.legacy_backend_lifecycle import (
     lifecycle_status_for_backend,
     legacy_backend_warning_message,
 )

--- a/src/pcobra/cobra/transpilers/targets.py
+++ b/src/pcobra/cobra/transpilers/targets.py
@@ -33,6 +33,6 @@ if tuple(TARGETS_BY_TIER) != ("tier_1", "tier_2"):
 
 if OFFICIAL_TARGETS != EXPECTED_CANONICAL_TARGETS:
     raise RuntimeError(
-        "OFFICIAL_TARGETS debe mantener exactamente los 8 nombres canónicos en orden. "
+        "OFFICIAL_TARGETS debe mantener exactamente los nombres públicos canónicos en orden. "
         + _canonical_diff_report(current=OFFICIAL_TARGETS)
     )

--- a/tests/cli/test_public_v2_commands_contract.py
+++ b/tests/cli/test_public_v2_commands_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 from pcobra.cobra.cli.cli import AppConfig, CommandRegistry
 
 
@@ -40,3 +41,7 @@ def test_public_v2_subcommands_match_contract_exactly() -> None:
     )
 
     assert set(commands) == EXPECTED_PUBLIC_V2_COMMANDS
+
+
+def test_cli_public_backend_policy_is_exact() -> None:
+    assert PUBLIC_BACKENDS == ("python", "javascript", "rust")

--- a/tests/unit/test_runtime_api_matrix_contract.py
+++ b/tests/unit/test_runtime_api_matrix_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 from pcobra.cobra.transpilers.runtime_api_matrix import (
     build_runtime_api_matrix,
     validate_runtime_api_parity_snapshot,
@@ -27,3 +28,7 @@ def test_runtime_api_matrix_has_all_official_backends_and_python_full() -> None:
     for backend in OFFICIAL_TARGETS:
         assert isinstance(available[backend]["global"], list)
         assert isinstance(missing[backend]["global"], list)
+
+
+def test_runtime_public_backend_policy_is_exact() -> None:
+    assert PUBLIC_BACKENDS == ("python", "javascript", "rust")

--- a/tests/utils/targets.py
+++ b/tests/utils/targets.py
@@ -16,7 +16,7 @@ from pcobra.cobra.transpilers.compatibility_matrix import BACKEND_COMPATIBILITY
 from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS, TIER1_TARGETS, TIER2_TARGETS
 
 TierName = Literal["tier1", "tier2"]
-EXPECTED_CANONICAL_TARGETS = ("python", "rust", "javascript", "wasm", "go", "cpp", "java", "asm")
+EXPECTED_CANONICAL_TARGETS = ("python", "javascript", "rust")
 
 SUPPORTED_TARGETS = OFFICIAL_TARGETS
 OFFICIAL_TRANSPILATION_TARGETS_IN_TESTS = OFFICIAL_TRANSPILATION_TARGETS
@@ -84,7 +84,7 @@ def assert_official_targets_partition(
     compatibility_matrix: dict[str, dict[str, str]] = BACKEND_COMPATIBILITY,
     transpilers: Iterable[str] | None = None,
 ) -> dict[TierName, tuple[str, ...]]:
-    """Valida que los 8 backends oficiales queden particionados exactamente por tiers."""
+    """Valida que los backends públicos oficiales queden particionados exactamente por tiers."""
     partition = {
         tier: assert_tier_targets_match_policy(
             tier,


### PR DESCRIPTION
### Motivation
- Asegurar que la superficie pública de CLI/runtime sólo exponga los backends oficiales `("python","javascript","rust")` y que la inicialización por defecto no registre backends legacy (`go/cpp/java/wasm/asm`).
- Mover la lógica/inventario legacy a rutas internas de compatibilidad para evitar importaciones públicas accidentales y permitir opt-in controlado para migraciones.
- Hacer que los snapshots/golden y contratos públicos reflejen únicamente los backends activos y añadir aserciones que verifiquen la política exacta.

### Description
- Reubicación de imports de inventario legacy para consumirlos desde `pcobra.cobra.internal_compat.legacy_contracts` en lugar de rutas públicas, y corrección de `legacy_contracts` para importar desde `architecture.legacy_backend_lifecycle` (archivos cambiados: `src/pcobra/cobra/internal_compat/legacy_contracts.py`, `src/pcobra/cobra/build/orchestrator.py`).
- Actualización de las expectativas de tests a la política pública de 3 backends: `tests/utils/targets.py` ahora usa `EXPECTED_CANONICAL_TARGETS = ("python","javascript","rust")` y se ajustó la documentación asociada.
- Añadidas pruebas que afirman la política pública exacta en CLI y runtime: `test_cli_public_backend_policy_is_exact` y `test_runtime_public_backend_policy_is_exact` en `tests/cli/test_public_v2_commands_contract.py` y `tests/unit/test_runtime_api_matrix_contract.py` respectivamente.
- Ajuste de mensaje contractual en `src/pcobra/cobra/transpilers/targets.py` para eliminar la referencia histórica a “8 nombres canónicos” y reflejar la superficie pública vigente.

### Testing
- Ejecutado `pytest -q tests/cli/test_public_v2_commands_contract.py tests/unit/test_runtime_api_matrix_contract.py tests/utils/targets.py` como verificación automatizada del cambio.
- Resultado: la validación de contratos públicos y las nuevas aserciones añadidas pasan correctamente, aunque existen 2 fallos en pruebas de paridad/snapshot de runtime (`test_runtime_api_snapshot_contract_is_up_to_date` y `test_runtime_api_matrix_has_all_official_backends_and_python_full`) por desalineación del snapshot/API Python (símbolo removido `coalesce` y elementos faltantes `mapear`, `reducir`), por lo que la suite reportó 2 fallos y 5 éxitos.
- Acción recomendada: actualizar el snapshot/paridad de runtime Python o reconciliar los cambios API para resolver los fallos de paridad antes de liberar.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb79143cc8327b453b543384745e4)