### PR TITLE
fix(holobit): preservar alias interno _SDKHolobit manteniendo API pública

### DIFF
--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -12,6 +12,9 @@ from typing import Any
 from pcobra.core.holobits.graficar import graficar as _runtime_graficar
 from pcobra.core.holobits.holobit import Holobit as _RuntimeHolobit
 
+# Alias interno para compatibilidad de pruebas de dominio (no exportado).
+_SDKHolobit = _RuntimeHolobit
+
 
 class ErrorHolobit(ValueError):
     """Error de dominio Cobra para operaciones de Holobit."""
@@ -28,7 +31,7 @@ class _AdaptadorInternoHolobit:
 
     @staticmethod
     def crear_desde_valores(valores: list[float]) -> Any:
-        return _RuntimeHolobit(valores)
+        return _SDKHolobit(valores)
 
     @staticmethod
     def obtener_valores(hb: Any) -> list[float]:


### PR DESCRIPTION
### Motivation
- Restaurar la compatibilidad con pruebas que inyectan fallos en el runtime para verificar traducción de errores de runtime a `ErrorHolobit` sin exponer internals en la API pública.

### Description
- Añadido alias interno `_SDKHolobit = _RuntimeHolobit` en `src/pcobra/corelibs/holobit.py` para permitir monkeypatch en tests sin exportarlo.
- Actualizado `_AdaptadorInternoHolobit.crear_desde_valores` para instanciar mediante `_SDKHolobit` en vez de usar `_RuntimeHolobit` directamente.
- No se modificó `__all__`; la superficie pública permanece restringida a los nueve símbolos canónicos (`crear_holobit`, `validar_holobit`, `serializar_holobit`, `deserializar_holobit`, `proyectar`, `transformar`, `graficar`, `combinar`, `medir`).

### Testing
- Ejecuté `pytest -q tests/unit/test_holobit_no_fuga_exports.py tests/unit/test_holobit_corelib_domain_errors.py tests/unit/test_usar_loader_public_api_contract.py::test_internals_holobit_sdk_no_importables_directo_desde_usar_loader tests/integration/test_usar_public_contract_regression.py::test_holobit_corelib_deserializacion_invalida_regresion` y obtuve 1 fallo debido a la ausencia del alias `_SDKHolobit` para monkeypatch en la regresión.
- Tras introducir el alias, ejecuté `pytest -q tests/unit/test_holobit_corelib_domain_errors.py tests/unit/test_holobit_no_fuga_exports.py tests/integration/test_usar_public_contract_regression.py::test_holobit_corelib_deserializacion_invalida_regresion` y obtuve `11 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc2dd354883279b35d6408c588c6e)