### PR TITLE
Documentar ruta canónica de ejecución y añadir test de paridad de `usar`

### DIFF
--- a/docs/architecture/execution-canonical-route.md
+++ b/docs/architecture/execution-canonical-route.md
@@ -1,0 +1,59 @@
+# Ruta canónica de ejecución y shims de compatibilidad
+
+## Resumen ejecutivo
+
+La **ruta canónica de ejecución** del proyecto se mantiene en `pcobra.core.*` (implementación real), mientras que la CLI pública y el ecosistema moderno consumen `pcobra.cobra.*` como **fachada estable**.
+
+En términos prácticos:
+
+- Implementación de referencia: `pcobra.core`.
+- Entrypoints preferidos para CLI: `pcobra.cobra`.
+- Compatibilidad retro: módulos shim explícitos que reexportan desde la implementación canónica.
+
+## Inventario de módulos críticos duplicados
+
+### 1) Interpreter
+
+- Canónico: `src/pcobra/core/interpreter.py`
+- Shim/adapter: `src/pcobra/cobra/core/interpreter.py`
+- Estado: **compatibilidad explícita** (sin lógica propia en el shim).
+
+### 2) Parser
+
+- Canónico de importación pública CLI: `src/pcobra/cobra/core/parser.py`
+- Shim/adapter: `src/pcobra/core/parser.py`
+- Estado: **compatibilidad explícita**.
+
+### 3) Lexer
+
+- Canónico de importación pública CLI: `src/pcobra/cobra/core/lexer.py`
+- Shim/adapter: `src/pcobra/core/lexer.py`
+- Estado: **compatibilidad explícita**.
+
+### 4) Runtime
+
+- Entrypoint canónico CLI: `src/pcobra/cobra/core/runtime.py`
+- Implementación efectiva: `InterpretadorCobra` en `src/pcobra/core/interpreter.py`.
+- Estado: **fachada canónica para CLI** + implementación central reutilizada.
+
+### 5) Import utils
+
+- Canónico de implementación: `src/pcobra/core/import_utils.py`
+- Shim/adapter: `src/pcobra/cobra/core/import_utils.py`
+- Estado: **compatibilidad explícita**.
+
+## Política oficial
+
+1. Las nuevas integraciones de CLI deben importar desde `pcobra.cobra.*`.
+2. Las implementaciones de bajo nivel (núcleo semántico/ejecución) residen en `pcobra.core.*` cuando ya son la fuente de verdad.
+3. Todo módulo de compatibilidad debe ser un shim explícito sin lógica de negocio adicional.
+4. Cualquier divergencia de comportamiento entre entrypoints (`pcobra.core.*` vs `pcobra.cobra.*`) se considera regresión.
+
+## Contrato mínimo de paridad
+
+Se valida una paridad mínima de:
+
+- Sintaxis/semántica de `usar` entre entrypoints equivalentes.
+- Política de exportación (`__all__`) y rechazo de símbolos privados en módulos oficiales.
+
+Esta paridad se prueba en tests de integración para evitar deriva silenciosa entre rutas canónicas y de compatibilidad.

--- a/tests/integration/test_entrypoint_usar_export_policy_parity.py
+++ b/tests/integration/test_entrypoint_usar_export_policy_parity.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+
+from pcobra.core.interpreter import InterpretadorCobra as CoreInterpretador
+from pcobra.cobra.core.interpreter import InterpretadorCobra as CobraInterpretador
+from pcobra.core import usar_loader as core_usar_loader
+
+
+@pytest.mark.parametrize("interp_cls", [CoreInterpretador, CobraInterpretador])
+def test_usar_export_policy_rechaza_simbolos_privados(interp_cls, monkeypatch):
+    mod = ModuleType("numero")
+    mod.__all__ = ["es_finito", "_interno", "__oculto__"]
+    mod.es_finito = lambda valor: valor == valor
+    mod._interno = lambda: "no"
+    mod.__oculto__ = lambda: "no"
+    mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/numero.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: mod)
+
+    from pcobra.core.lexer import Lexer
+    from pcobra.core.parser import Parser
+
+    interp = interp_cls()
+    ast = Parser(Lexer('usar "numero"').tokenizar()).parsear()
+    interp.ejecutar_ast(ast)
+
+    assert callable(interp.obtener_variable("es_finito"))
+    with pytest.raises(NameError):
+        interp.obtener_variable("_interno")
+    with pytest.raises(NameError):
+        interp.obtener_variable("__oculto__")
+
+
+def test_entrypoints_interpreter_comparten_clase_canonica():
+    assert CoreInterpretador is CobraInterpretador


### PR DESCRIPTION
### Motivation
- Evitar deriva entre namespaces duplicados (`pcobra.core.*` vs `pcobra.cobra.*`) y dejar explícita cuál ruta es la fuente de verdad y cuál es shim de compatibilidad.
- Asegurar mínima paridad entre entrypoints para la semántica de `usar` y la política de exportación de módulos oficiales.

### Description
- Añade `docs/architecture/execution-canonical-route.md` que inventaría y describe los módulos críticos duplicados (`interpreter`, `parser`, `lexer`, `runtime`, `import_utils`) y la política de uso de rutas canónicas y shims.
- Incorpora `tests/integration/test_entrypoint_usar_export_policy_parity.py` que verifica que tanto `pcobra.core.interpreter.InterpretadorCobra` como `pcobra.cobra.core.interpreter.InterpretadorCobra` comparten la misma clase canónica y que `usar` respeta `__all__` y rechaza símbolos privados.
- La prueba construye el AST usando `pcobra.core.lexer.Lexer` y `pcobra.core.parser.Parser` y ejecuta el AST con `ejecutar_ast` para validar el comportamiento sin depender de métodos de conveniencia no compartidos entre entrypoints.

### Testing
- Ejecutado `pytest -q tests/integration/test_entrypoint_usar_export_policy_parity.py` y la suite pasó correctamente (`3 passed`).
- No se modificó la implementación del intérprete o shims; las comprobaciones validan paridad desde los entrypoints existentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf36163b88327b6bb31ac993c804c)