### PR TITLE
Añadir pruebas de regresión contractual para política de startup y targets públicos

### DIFF
--- a/tests/test_backend_startup_policy.py
+++ b/tests/test_backend_startup_policy.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Regresión contractual: política de startup y targets públicos."""
+
+import importlib
+import sys
+
+import pytest
+
+LEGACY_TRANSPILER_MODULES = (
+    "pcobra.cobra.transpilers.transpiler.to_go",
+    "pcobra.cobra.transpilers.transpiler.to_java",
+    "pcobra.cobra.transpilers.transpiler.to_cpp",
+    "pcobra.cobra.transpilers.transpiler.to_asm",
+    "pcobra.cobra.transpilers.transpiler.to_wasm",
+)
+
+EXPECTED_PUBLIC_TARGETS = ("python", "javascript", "rust")
+
+
+@pytest.mark.parity_contract
+@pytest.mark.parametrize("module_name", LEGACY_TRANSPILER_MODULES)
+def test_runtime_startup_policy_does_not_import_legacy_transpilers(module_name: str) -> None:
+    before = set(sys.modules)
+
+    # Startup normal de política contractual (sin resolver transpilers legacy).
+    importlib.import_module("pcobra.cobra.architecture.backend_policy")
+    importlib.import_module("pcobra.cobra.config.transpile_targets")
+
+    after = set(sys.modules)
+    loaded_during_startup = after - before
+
+    assert module_name not in after, f"{module_name} no debe quedar cargado tras startup"
+    assert module_name not in loaded_during_startup, (
+        f"{module_name} fue cargado durante startup/runtime, violando política pública"
+    )
+
+
+@pytest.mark.parity_contract
+def test_public_targets_contract_is_exact_in_config_and_architecture() -> None:
+    config_targets = importlib.import_module(
+        "pcobra.cobra.config.transpile_targets"
+    ).OFFICIAL_TARGETS
+    policy_targets = importlib.import_module(
+        "pcobra.cobra.architecture.backend_policy"
+    ).PUBLIC_BACKENDS
+
+    assert config_targets == EXPECTED_PUBLIC_TARGETS
+    assert policy_targets == EXPECTED_PUBLIC_TARGETS
+    assert config_targets == policy_targets
+
+
+@pytest.mark.parity_contract
+@pytest.mark.parametrize("invalid_target", ("go", "java", "cpp", "asm", "wasm", "brainfuck"))
+def test_non_official_target_fails_with_clear_policy_error(invalid_target: str) -> None:
+    assert_public_command_uses_only_public_backends = importlib.import_module(
+        "pcobra.cobra.architecture.backend_policy"
+    ).assert_public_command_uses_only_public_backends
+
+    with pytest.raises(RuntimeError) as excinfo:
+        assert_public_command_uses_only_public_backends(
+            command="cobra test-policy",
+            targets=(invalid_target,),
+        )
+
+    message = str(excinfo.value)
+    assert "PUBLIC CONTRACT" in message
+    assert "fuera de contrato" in message
+    assert "allowed=('python', 'javascript', 'rust')" in message


### PR DESCRIPTION
### Motivation

- Asegurar que la inicialización normal de la capa de política no importe transpilers legacy internos por accidente y evitar reintroducciones.
- Preservar de forma automatizada el contrato público de targets exactamente `("python", "javascript", "rust")` en la configuración y la política de arquitectura.
- Verificar que peticiones a targets no oficiales fallen con un error de política claro para evitar aceptación accidental de backends legacy.

### Description

- Añade el archivo de pruebas `tests/test_backend_startup_policy.py` con instrumentación de `sys.modules` antes/después de la importación de políticas para detectar imports inesperados.
- Comprueba explícitamente que los módulos legacy `pcobra.cobra.transpilers.transpiler.to_go`, `to_java`, `to_cpp`, `to_asm`, `to_wasm` no aparecen tras el startup al importar `pcobra.cobra.architecture.backend_policy` y `pcobra.cobra.config.transpile_targets`.
- Valida que el contrato público de targets coincide exactamente con `EXPECTED_PUBLIC_TARGETS = ("python", "javascript", "rust")` consultando `pcobra.cobra.config.transpile_targets.OFFICIAL_TARGETS` y `pcobra.cobra.architecture.backend_policy.PUBLIC_BACKENDS`.
- Añade casos negativos que invocan `assert_public_command_uses_only_public_backends` para targets no oficiales (`go`, `java`, `cpp`, `asm`, `wasm`, `brainfuck`) y esperan `RuntimeError` con mensajes que contienen `"PUBLIC CONTRACT"` y la lista `allowed=('python', 'javascript', 'rust')`, y marca las pruebas con `@pytest.mark.parity_contract` como regresión contractual.

### Testing

- Ejecutado `pytest -q tests/test_backend_startup_policy.py` y todas las pruebas de la nueva suite pasaron (`12 passed`).
- Las pruebas usan importación selectiva de los módulos de política (`backend_policy` y `transpile_targets`) para evitar activar validaciones/Lazy-loading más amplias del subsistema de transpilers durante la comprobación contractuales.
- Se observó una advertencia deprecatoria sobre el namespace `core` al ejecutar las pruebas, pero no afectó al resultado de la suite contractual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe08b7f2988327b366bad2316e4e41)