### PR TITLE
test: cubrir política runtime estricta para `usar`

### DIFF
--- a/tests/unit/test_usar_runtime_policy.py
+++ b/tests/unit/test_usar_runtime_policy.py
@@ -1,0 +1,138 @@
+from types import ModuleType
+
+import pytest
+
+from core.ast_nodes import NodoUsar
+from core.interpreter import InterpretadorCobra
+from pcobra.cobra import usar_loader
+from pcobra.cobra.usar_policy import (
+    REPL_COBRA_MODULE_MAP,
+    USAR_COBRA_ALLOWLIST,
+    USAR_COBRA_FACING_MODULE_FLAGS,
+)
+from core import usar_loader as core_usar_loader
+
+
+def _interp_con_alias(alias_map: dict[str, str]) -> InterpretadorCobra:
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl(alias_map)
+    return interp
+
+
+def test_usar_runtime_numero_expone_solo_api_espanola(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _n, **_k: modulo_numero)
+    interp = _interp_con_alias({"numero": "numero"})
+    interp.ejecutar_nodo(NodoUsar("numero"))
+
+    assert "es_finito" in interp.variables
+    assert "isfinite" not in interp.variables
+
+
+def test_usar_runtime_texto_expone_solo_api_espanola(monkeypatch):
+    import pcobra.corelibs.texto as modulo_texto
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _n, **_k: modulo_texto)
+    interp = _interp_con_alias({"texto": "texto"})
+    interp.ejecutar_nodo(NodoUsar("texto"))
+
+    assert "a_snake" in interp.variables
+    assert "to_snake_case" not in interp.variables
+
+
+def test_usar_runtime_datos_expone_filtrar_mapear_reducir(monkeypatch):
+    import pcobra.standard_library.datos as modulo_datos
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _n, **_k: modulo_datos)
+    interp = _interp_con_alias({"datos": "datos"})
+    interp.ejecutar_nodo(NodoUsar("datos"))
+
+    assert {"filtrar", "mapear", "reducir"}.issubset(interp.variables)
+
+
+@pytest.mark.parametrize("nombre", ["numpy", "pandas", "torch", "node-fetch", "serde"])
+def test_usar_runtime_rechaza_numpy_y_similares(nombre):
+    with pytest.raises(PermissionError, match=r"Importación no permitida en 'usar'"):
+        usar_loader.validar_nombre_modulo_usar(nombre)
+
+
+def test_usar_runtime_holobit_expone_solo_api_cobra_facing(monkeypatch):
+    import pcobra.corelibs.holobit as modulo_holobit
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _n, **_k: modulo_holobit)
+    interp = _interp_con_alias({"holobit": "holobit"})
+    interp.ejecutar_nodo(NodoUsar("holobit"))
+
+    assert "holobit" in interp.variables
+    assert "proyectar" in interp.variables
+    assert "_to_sdk_holobit" not in interp.variables
+    assert "_require_holobit_sdk" not in interp.variables
+    assert "Holobit" not in interp.variables
+
+
+def test_usar_runtime_no_exporta_simbolos_con_doble_guion_bajo(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _n, **_k: modulo_numero)
+    interp = _interp_con_alias({"numero": "numero"})
+    interp.ejecutar_nodo(NodoUsar("numero"))
+
+    assert all("__" not in nombre for nombre in interp.variables)
+
+
+def test_usar_runtime_no_exporta_simbolos_bloqueados(monkeypatch):
+    import pcobra.standard_library.datos as modulo_datos
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _n, **_k: modulo_datos)
+    interp = _interp_con_alias({"datos": "datos"})
+    interp.ejecutar_nodo(NodoUsar("datos"))
+
+    for prohibido in ("self", "append", "map", "filter", "unwrap", "expect"):
+        assert prohibido not in interp.variables
+
+
+def test_usar_runtime_colision_warn_diagnostico_y_sin_overwrite(monkeypatch, caplog):
+    modulo = ModuleType("texto")
+    modulo.__all__ = ["a_snake", "a_camel"]
+    modulo.a_snake = lambda txt: f"nuevo:{txt}"
+    modulo.a_camel = lambda txt: txt
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/texto.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _n: modulo)
+
+    interp = _interp_con_alias({"texto": "texto"})
+    interp.configurar_politica_colision_usar("warn_alias_required")
+    valor_prev = lambda txt: f"previo:{txt}"
+    interp.contextos[-1].define("a_snake", valor_prev)
+
+    with pytest.raises(NameError, match=r"Requiere alias explícito"):
+        interp.ejecutar_nodo(NodoUsar("texto"))
+
+    assert interp.contextos[-1].resolver("a_snake") is valor_prev
+    assert "usar_collision" in caplog.text
+
+
+def test_usar_runtime_holobit_no_expone_objetos_sdk_internos(monkeypatch):
+    import pcobra.corelibs.holobit as modulo_holobit
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _n, **_k: modulo_holobit)
+    interp = _interp_con_alias({"holobit": "holobit"})
+    interp.ejecutar_nodo(NodoUsar("holobit"))
+
+    for interno in ("holobit_sdk", "_SDKHolobit", "Holobit", "_to_sdk_holobit"):
+        assert interno not in interp.variables
+
+
+def test_usar_runtime_allowlist_y_flags_mantienen_contrato_estricto():
+    canonicos = tuple(REPL_COBRA_MODULE_MAP.keys())
+    assert tuple(REPL_COBRA_MODULE_MAP.values()) == canonicos
+    assert tuple(USAR_COBRA_FACING_MODULE_FLAGS.keys()) == canonicos
+    assert all(USAR_COBRA_FACING_MODULE_FLAGS.values())
+    assert set(canonicos) == set(USAR_COBRA_ALLOWLIST)
+
+
+def test_validar_nombre_modulo_usar_exige_allowlist_estricta():
+    assert usar_loader.validar_nombre_modulo_usar("numero") == "numero"
+    with pytest.raises(PermissionError):
+        usar_loader.validar_nombre_modulo_usar("mi_modulo_privado")


### PR DESCRIPTION
### Motivation
- Añadir cobertura automatizada para garantizar que la política runtime de `usar` cumple el contrato público y de seguridad (allowlist, surface API, saneamiento y manejo de colisiones). 

### Description
- Se crea `tests/unit/test_usar_runtime_policy.py` con 11 pruebas que verifican la superficie y restricciones runtime de `usar` (incluye casos para `numero`, `texto`, `datos`, `holobit`, bloqueos de backend y símbolos prohibidos). 
- Las pruebas validan rechazo de módulos backend/no-canónicos (`numpy`, `pandas`, `torch`, `node-fetch`, `serde`) y que no se expongan símbolos con `__` ni nombres bloqueados (`self`, `append`, `map`, `filter`, `unwrap`, `expect`).
- Se añade verificación de colisiones para que generen warning/diagnóstico y no provoquen overwrite silencioso, y comprobación de que `holobit` no exporte internos del SDK.
- El archivo nuevo se ha commiteado en `tests/unit/test_usar_runtime_policy.py` bajo el mensaje `test: cubrir política runtime estricta de usar`.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_runtime_policy.py` tras crear el archivo, pero la colección de tests falló por un error de importación en el árbol de código: `NameError: name 'LEGACY_INTERNAL_TARGETS' is not defined` en `pcobra.cobra.transpilers.compatibility_matrix.py`, que es un fallo de inicialización del entorno y no un error en las pruebas nuevas. 
- Reintenté mover y ejecutar el test en `tests/unit/` y ejecutar un test puntual de `tests/unit/test_usar.py`, y ambas ejecuciones mostraron el mismo error de colección por la variable faltante en `compatibility_matrix.py` durante el import; por tanto las pruebas nuevas no pudieron completarse en este entorno. 
- El cambio es sólo de pruebas (no se modificó código runtime) y quedó commiteado; las pruebas están listas para ejecutarse cuando el problema de importación global se resuelva mediante la corrección del entorno o del archivo `compatibility_matrix.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe12aead048327857a4de6ff3115a0)