### PR TITLE
Añadir tablas de equivalencias semánticas y validación de superficie en corelibs

### DIFF
--- a/src/pcobra/corelibs/archivo.py
+++ b/src/pcobra/corelibs/archivo.py
@@ -5,6 +5,14 @@ from pathlib import Path
 from typing import Union
 
 PathLike = Union[str, os.PathLike[str]]
+EQUIVALENCIAS_SEMANTICAS_ARCHIVO: dict[str, str] = {
+    "open(...).read": "leer",
+    "open(...).write": "escribir",
+    "os.path.exists": "existe",
+    "os.remove": "eliminar",
+    "open(..., 'a')": "anexar",
+    "readlines": "leer_lineas",
+}
 
 
 def _resolver_ruta(ruta: PathLike) -> Path:

--- a/src/pcobra/corelibs/asincrono.py
+++ b/src/pcobra/corelibs/asincrono.py
@@ -19,6 +19,14 @@ from typing import (
 )
 
 T = TypeVar("T")
+EQUIVALENCIAS_SEMANTICAS_ASINCRONO: dict[str, str] = {
+    "gather": "recolectar",
+    "wait_for": "esperar_con_timeout",
+    "sleep": "dormir_async",
+    "as_completed": "iterar_completadas",
+    "shield": "proteger_tarea",
+    "to_thread": "ejecutar_en_hilo",
+}
 
 try:  # pragma: no cover - Python >= 3.11 lo define de forma nativa
     ExceptionGroup

--- a/src/pcobra/corelibs/datos.py
+++ b/src/pcobra/corelibs/datos.py
@@ -7,6 +7,17 @@ una whitelist explícita de símbolos Cobra.
 
 from pcobra.standard_library import datos as _datos
 
+EQUIVALENCIAS_SEMANTICAS_DATOS: dict[str, str] = {
+    "keys": "claves",
+    "values": "valores",
+    "len": "longitud",
+    "map": "mapear",
+    "filter": "filtrar",
+    "reduce": "reducir",
+    "merge": "combinar_tablas",
+    "pivot": "pivotar_tabla",
+}
+
 leer_csv = _datos.leer_csv
 leer_json = _datos.leer_json
 escribir_csv = _datos.escribir_csv

--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -12,6 +12,16 @@ from typing import Any
 from pcobra.core.holobits.graficar import graficar as _runtime_graficar
 from pcobra.core.holobits.holobit import Holobit as _RuntimeHolobit
 
+EQUIVALENCIAS_SEMANTICAS_HOLOBIT: dict[str, str] = {
+    "new Holobit": "crear_holobit",
+    "validate": "validar_holobit",
+    "serialize": "serializar_holobit",
+    "deserialize": "deserializar_holobit",
+    "project": "proyectar",
+    "transform": "transformar",
+    "render": "graficar",
+}
+
 # Alias interno para compatibilidad de pruebas de dominio (no exportado).
 _SDKHolobit = _RuntimeHolobit
 

--- a/src/pcobra/corelibs/logica.py
+++ b/src/pcobra/corelibs/logica.py
@@ -7,6 +7,14 @@ from itertools import product
 from typing import Callable, Iterable, TypeVar
 
 T = TypeVar("T")
+EQUIVALENCIAS_SEMANTICAS_LOGICA: dict[str, str] = {
+    "all": "todos",
+    "any": "alguno",
+    "not": "negacion",
+    "and": "conjuncion",
+    "or": "disyuncion",
+    "if_then": "entonces",
+}
 
 
 def _evaluar_resultado(resultado: T | Callable[[], T]) -> T:

--- a/src/pcobra/corelibs/numero.py
+++ b/src/pcobra/corelibs/numero.py
@@ -19,6 +19,22 @@ from statistics import (
 )
 
 _ALFABETO_DEFECTO = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+EQUIVALENCIAS_SEMANTICAS_NUMERO: dict[str, str] = {
+    "abs": "absoluto",
+    "round": "redondear",
+    "floor": "piso",
+    "ceil": "techo",
+    "gcd": "mcd",
+    "lcm": "mcm",
+    "isclose": "es_cercano",
+    "hypot": "hipotenusa",
+    "dist": "distancia_euclidiana",
+    "isfinite": "es_finito",
+    "isinf": "es_infinito",
+    "isnan": "es_nan",
+    "copysign": "copiar_signo",
+    "prod": "producto",
+}
 
 
 def absoluto(valor):

--- a/src/pcobra/corelibs/red.py
+++ b/src/pcobra/corelibs/red.py
@@ -23,6 +23,13 @@ if TYPE_CHECKING:  # pragma: no cover - solo para chequeo de tipos
 
 _MAX_RESP_SIZE = 1024 * 1024
 _MAX_REDIRECTS = 5
+EQUIVALENCIAS_SEMANTICAS_RED: dict[str, str] = {
+    "requests.get": "obtener_url",
+    "requests.post": "enviar_post",
+    "httpx.AsyncClient.get": "obtener_url_async",
+    "httpx.AsyncClient.post": "enviar_post_async",
+    "download": "descargar_archivo",
+}
 
 
 def _require_httpx() -> "_httpx":

--- a/src/pcobra/corelibs/sistema.py
+++ b/src/pcobra/corelibs/sistema.py
@@ -17,6 +17,14 @@ WHITELIST_ENV = "COBRA_EJECUTAR_PERMITIDOS"
 # tiempo de ejecución.
 _lista_env = os.getenv(WHITELIST_ENV)
 PERMITIDOS_FIJOS = tuple(_lista_env.split(os.pathsep)) if _lista_env else ()
+EQUIVALENCIAS_SEMANTICAS_SISTEMA: dict[str, str] = {
+    "getcwd": "directorio_actual",
+    "getenv": "obtener_entorno",
+    "setenv": "definir_entorno",
+    "platform.system": "nombre_sistema",
+    "platform.machine": "arquitectura",
+    "subprocess.run": "ejecutar",
+}
 
 
 def _normalizar_rutas(rutas: Iterable[str]) -> set[str]:

--- a/src/pcobra/corelibs/texto.py
+++ b/src/pcobra/corelibs/texto.py
@@ -17,6 +17,22 @@ _SIN_VALOR = object()
 
 _PATRON_TRANSICION_CASO = re.compile(r"(?<=[^\W_])(?=[^\W_])", re.UNICODE)
 _PATRON_SEPARADORES = re.compile(r"[\W_]+", re.UNICODE)
+EQUIVALENCIAS_SEMANTICAS_TEXTO: dict[str, str] = {
+    "upper": "mayusculas",
+    "lower": "minusculas",
+    "capitalize": "capitalizar",
+    "title": "titulo",
+    "swapcase": "intercambiar_mayusculas",
+    "strip": "recortar",
+    "lstrip": "recortar_izquierda",
+    "rstrip": "recortar_derecha",
+    "split": "dividir",
+    "join": "unir",
+    "replace": "reemplazar",
+    "startswith": "empieza_con",
+    "endswith": "termina_con",
+    "zfill": "rellenar_ceros",
+}
 
 
 def _insertar_espacio_transicion(match: re.Match[str]) -> str:

--- a/src/pcobra/corelibs/tiempo.py
+++ b/src/pcobra/corelibs/tiempo.py
@@ -12,6 +12,14 @@ from datetime import datetime
 from pcobra.standard_library.fecha import formatear as _formatear_fecha
 from pcobra.standard_library.fecha import hoy as _hoy
 
+EQUIVALENCIAS_SEMANTICAS_TIEMPO: dict[str, str] = {
+    "datetime.now": "ahora",
+    "strftime": "formatear",
+    "sleep": "dormir",
+    "timestamp": "epoch",
+    "fromtimestamp": "desde_epoch",
+}
+
 PUBLIC_API_TIEMPO: tuple[str, ...] = (
     "ahora",
     "formatear",

--- a/tests/unit/test_corelibs_surface_exports.py
+++ b/tests/unit/test_corelibs_surface_exports.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+CORELIBS = ROOT / "src" / "pcobra" / "corelibs"
+
+MODULOS = {
+    "numero": "EQUIVALENCIAS_SEMANTICAS_NUMERO",
+    "texto": "EQUIVALENCIAS_SEMANTICAS_TEXTO",
+    "datos": "EQUIVALENCIAS_SEMANTICAS_DATOS",
+    "logica": "EQUIVALENCIAS_SEMANTICAS_LOGICA",
+    "asincrono": "EQUIVALENCIAS_SEMANTICAS_ASINCRONO",
+    "sistema": "EQUIVALENCIAS_SEMANTICAS_SISTEMA",
+    "archivo": "EQUIVALENCIAS_SEMANTICAS_ARCHIVO",
+    "tiempo": "EQUIVALENCIAS_SEMANTICAS_TIEMPO",
+    "red": "EQUIVALENCIAS_SEMANTICAS_RED",
+    "holobit": "EQUIVALENCIAS_SEMANTICAS_HOLOBIT",
+}
+
+RESERVADOS = {"__dict__", "__class__", "__getattribute__", "eval", "exec"}
+
+
+def _cargar_modulo(nombre: str):
+    ruta = CORELIBS / f"{nombre}.py"
+    spec = importlib.util.spec_from_file_location(f"_corelib_{nombre}_tests", ruta)
+    assert spec and spec.loader
+    modulo = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(modulo)
+    return modulo
+
+
+@pytest.mark.parametrize("nombre,tabla", MODULOS.items())
+def test_tabla_equivalencias_y_superficie_publica(nombre: str, tabla: str):
+    modulo = _cargar_modulo(nombre)
+
+    equivalencias = getattr(modulo, tabla)
+    assert isinstance(equivalencias, dict)
+    assert equivalencias
+    assert all(isinstance(k, str) and isinstance(v, str) for k, v in equivalencias.items())
+
+    assert isinstance(modulo.__all__, list)
+    assert modulo.__all__
+    assert len(modulo.__all__) == len(set(modulo.__all__))
+
+    for simbolo in modulo.__all__:
+        assert simbolo.isidentifier()
+        assert not simbolo.startswith("_")
+        assert simbolo not in RESERVADOS
+        assert hasattr(modulo, simbolo)


### PR DESCRIPTION
### Motivation

- Proveer por módulo una tabla de equivalencias semánticas (inspiradas en Python/JS/Rust) hacia nombres Cobra en español sin introducir nuevas primitivas ni tocar Lexer/Parser.  
- Reforzar la higiene de la superficie pública garantizando `__all__` explícito y validadores de exportación canónica para evitar fugas de símbolos backend.

### Description

- Se añadieron tablas `EQUIVALENCIAS_SEMANTICAS_*` en los módulos `numero`, `texto`, `datos`, `logica`, `asincrono`, `sistema`, `archivo`, `tiempo`, `red` y `holobit` con mapeos de nombres (por ejemplo `abs -> absoluto`, `upper -> mayusculas`, `keys -> claves`).
- Se añadió la prueba parametrizada `tests/unit/test_corelibs_surface_exports.py` que verifica la presencia y formato de las tablas, la validez de `__all__` y que los símbolos exportados existen y no son privados ni reservados.
- Se mantuvo intacta la semántica de runtime y los validadores de superficie pública existentes (`__all__` y funciones `_validar_superficie_*`) sin modificar el lexer/parser ni la sintaxis del lenguaje.
- Los cambios afectan solo a definiciones auxiliares (tablas) y pruebas; no se introducen nuevas APIs ejecutables ni se reexportan símbolos adicionales.

### Testing

- Se ejecutó `pytest -q tests/unit/test_corelibs_surface_exports.py tests/unit/test_corelibs_holobit_adapter.py` y ambas pruebas pasaron (ejecución local mostrada como exitosa con tests unitarios verdes).
- Al ejecutar un conjunto mayor incluyendo `tests/unit/test_corelibs_async.py` y `tests/unit/test_corelibs_sistema.py` se produjo un `ImportError` por una importación circular durante la colección de pruebas; este error parece preexistente en el entorno de prueba y no fue provocado por las tablas añadidas.
- Las nuevas pruebas unitarias introducidas (`test_corelibs_surface_exports.py`) completaron correctamente y validaron las tablas y la superficie pública canónica.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe187c44308327a35ff74ae70f2cf8)