### PR TITLE
test: reforzar superficie pública y errores de dominio de holobit

### DIFF
--- a/tests/unit/test_holobit_corelib_domain_errors.py
+++ b/tests/unit/test_holobit_corelib_domain_errors.py
@@ -27,3 +27,50 @@ def test_adaptador_traduce_error_runtime_sdk_a_error_dominio(monkeypatch: pytest
 
     with pytest.raises(holobit_module.ErrorHolobit, match="runtime de Cobra"):
         holobit_module.serializar_holobit({"tipo": "holobit", "valores": [1, 2, 3]})
+
+
+@pytest.mark.parametrize(
+    "entrada",
+    [
+        None,
+        "abc",
+        123,
+        {"a": 1},
+        [1, "dos", 3],
+        [1, True, 3],
+    ],
+)
+def test_crear_holobit_rechaza_entradas_invalidas_y_tipos_mixtos(holobit_module, entrada) -> None:
+    with pytest.raises(TypeError):
+        holobit_module.crear_holobit(entrada)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "",
+        "{",
+        "{\"tipo\":\"holobit\"",
+        "{\"tipo\":\"holobit\",\"valores\":[1],}",
+        "{\"tipo\":\"otro\",\"valores\":[1]}",
+        "{\"tipo\":\"holobit\",\"valores\":\"1,2\"}",
+    ],
+)
+def test_deserializar_holobit_rechaza_payloads_corruptos_o_invalidos(holobit_module, payload) -> None:
+    with pytest.raises((TypeError, holobit_module.ErrorHolobit)):
+        holobit_module.deserializar_holobit(payload)
+
+
+def test_formato_canonico_dict_estable_en_roundtrip(holobit_module) -> None:
+    original = holobit_module.crear_holobit([1, 2.5, 3])
+    assert original == {"tipo": "holobit", "valores": [1.0, 2.5, 3.0]}
+
+    serializado = holobit_module.serializar_holobit(original)
+    restaurado = holobit_module.deserializar_holobit(serializado)
+
+    assert restaurado == {"tipo": "holobit", "valores": [1.0, 2.5, 3.0]}
+
+
+def test_errores_de_dominio_holobit_en_espanol(holobit_module) -> None:
+    with pytest.raises(holobit_module.ErrorHolobit, match="payload de holobit"):
+        holobit_module.deserializar_holobit("{json malo")

--- a/tests/unit/test_usar_runtime_policy.py
+++ b/tests/unit/test_usar_runtime_policy.py
@@ -124,6 +124,29 @@ def test_usar_runtime_holobit_no_expone_objetos_sdk_internos(monkeypatch):
         assert interno not in interp.variables
 
 
+def test_usar_holobit_regresion_no_expone_simbolos_internos_por_introspeccion(monkeypatch):
+    import pcobra.corelibs.holobit as modulo_holobit
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _n, **_k: modulo_holobit)
+    interp = _interp_con_alias({"holobit": "holobit"})
+    interp.ejecutar_nodo(NodoUsar("holobit"))
+
+    namespace = set(interp.variables)
+    assert set(modulo_holobit.__all__) == {
+        "crear_holobit",
+        "validar_holobit",
+        "serializar_holobit",
+        "deserializar_holobit",
+        "proyectar",
+        "transformar",
+        "graficar",
+        "combinar",
+        "medir",
+    }
+    for interno in ("_SDKHolobit", "_AdaptadorInternoHolobit", "EQUIVALENCIAS_SEMANTICAS_HOLOBIT"):
+        assert interno not in namespace
+
+
 def test_usar_runtime_allowlist_y_flags_mantienen_contrato_estricto():
     canonicos = tuple(REPL_COBRA_MODULE_MAP.keys())
     assert tuple(REPL_COBRA_MODULE_MAP.values()) == canonicos


### PR DESCRIPTION
### Motivation
- Asegurar que la superficie pública de `holobit` siga siendo únicamente la API canónica expuesta por `__all__` y que no se filtren símbolos internos del SDK o del runtime.
- Añadir pruebas de caja negra que cubran entradas inválidas, tipos mixtos y payloads JSON corruptos para las funciones de serialización/deserialización y creación de holobits.
- Verificar la estabilidad del formato canónico `{"tipo": "holobit", "valores": [...]}` en roundtrips y que los errores de dominio aparezcan en español.
- Introducir una regresión que impida que `usar "holobit"` exponga símbolos internos por introspección en el namespace del REPL.

### Description
- Añadidos tests en `tests/unit/test_holobit_corelib_domain_errors.py` que parametrizan entradas inválidas para `crear_holobit`, payloads JSON corruptos/estructuralmente inválidos para `deserializar_holobit`, comprobación de roundtrip `crear -> serializar -> deserializar` y verificación de mensajes de error de dominio en español.
- Añadida regresión en `tests/unit/test_usar_runtime_policy.py` que carga `pcobra.corelibs.holobit`, ejecuta `usar "holobit"` en un intérprete mock y comprueba que `__all__` coincide con la API pública canónica y que símbolos internos como `_SDKHolobit`, `_AdaptadorInternoHolobit` y `EQUIVALENCIAS_SEMANTICAS_HOLOBIT` no aparecen en el namespace del `usar`.
- Cambios limitados a pruebas; no se modificó la lógica de `src/pcobra/corelibs/holobit.py` ni runtime.

### Testing
- Ejecutado `pytest -q tests/unit/test_holobit_corelib_domain_errors.py` y pasó correctamente (`16 passed`).
- Ejecutado `pytest -q tests/unit/test_holobit_corelib_domain_errors.py tests/unit/test_usar_runtime_policy.py` y la colección falló por un error de importación ajeno a estos cambios: `NameError: LEGACY_INTERNAL_TARGETS` en `src/pcobra/cobra/transpilers/compatibility_matrix.py` (no relacionado con las pruebas añadidas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1fc4118c8327a125ae417558568d)