### PR TITLE
test(holobit): reforzar caja negra de API pública y sanitización `usar`

### DIFF
--- a/tests/integration/test_usar_public_contract_regression.py
+++ b/tests/integration/test_usar_public_contract_regression.py
@@ -274,6 +274,55 @@ def test_holobit_corelib_deserializacion_invalida_regresion():
         holobit.deserializar_holobit('{"tipo":"holobit","valores":[1],"extra":true}')
 
 
+def test_holobit_corelib_superficie_publica_canonica_blackbox():
+    import importlib.util
+    from pathlib import Path
+
+    ruta = Path("src/pcobra/corelibs/holobit.py").resolve()
+    spec = importlib.util.spec_from_file_location("_holobit_corelib_blackbox_api", ruta)
+    holobit = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(holobit)
+
+    assert tuple(holobit.__all__) == (
+        "crear_holobit",
+        "validar_holobit",
+        "serializar_holobit",
+        "deserializar_holobit",
+        "proyectar",
+        "transformar",
+        "graficar",
+        "combinar",
+        "medir",
+    )
+
+
+def test_holobit_corelib_error_runtime_solo_terminos_cobra(monkeypatch):
+    import importlib.util
+    from pathlib import Path
+
+    ruta = Path("src/pcobra/corelibs/holobit.py").resolve()
+    spec = importlib.util.spec_from_file_location("_holobit_corelib_blackbox_runtime", ruta)
+    holobit = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(holobit)
+
+    monkeypatch.setattr(
+        holobit._AdaptadorInternoHolobit,
+        "graficar",
+        lambda _hb: (_ for _ in ()).throw(ModuleNotFoundError("holobit_sdk.core.holobit")),
+    )
+
+    hb = holobit.crear_holobit([1, 2, 3])
+    with pytest.raises(holobit.ErrorHolobit) as excinfo:
+        holobit.graficar(hb)
+
+    mensaje = str(excinfo.value)
+    assert "Cobra" in mensaje
+    assert "holobit_sdk" not in mensaje
+    assert "SDKHolobit" not in mensaje
+
+
 def test_binding_usar_sin_dependencia_lexer_parser_para_datos(monkeypatch):
     mod_datos = _modulo_datos_publico_stub()
     monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: mod_datos)


### PR DESCRIPTION
### Motivation
- Garantizar que la fachada pública de Holobit separa claramente la API canónica de la implementación interna y no expone símbolos del SDK en `usar`.
- Asegurar que errores runtime se reporten en términos del dominio Cobra y no filtren nombres técnicos del SDK.

### Description
- Añade el test `test_holobit_corelib_superficie_publica_canonica_blackbox` que carga `src/pcobra/corelibs/holobit.py` con `importlib` y verifica que `__all__` sea exactamente la tupla `("crear_holobit", "validar_holobit", "serializar_holobit", "deserializar_holobit", "proyectar", "transformar", "graficar", "combinar", "medir")`.
- Añade el test `test_holobit_corelib_error_runtime_solo_terminos_cobra` que monkeypatchea `holobit._AdaptadorInternoHolobit.graficar` para simular un fallo del SDK y verifica que se eleve `ErrorHolobit` y que el mensaje no contenga identificadores internos como `holobit_sdk` o `SDKHolobit`.
- Los cambios son únicamente pruebas en `tests/integration/test_usar_public_contract_regression.py` y no alteran la lógica de runtime ni las exportaciones existentes.

### Testing
- Ejecutado: `pytest -q tests/integration/test_usar_public_contract_regression.py -k 'holobit_corelib_superficie_publica_canonica_blackbox or holobit_corelib_error_runtime_solo_terminos_cobra or usar_holobit_expone_solo_api_cobra_facing or holobit_sdk_internals_no_son_importables'`.
- Resultado: `4 passed, 17 deselected` con 1 advertencia; las pruebas añadidas pasaron satisfactoriamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee176e38c8327b04d4dfb7d7a57c9)