### PR TITLE
Fortalece validación canónica de módulos en `usar_loader`

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -24,16 +24,47 @@ _INTERNAL_HINTS = (
     "corelibs",
     "standard_library",
     "backend",
+    "sdk",
+    "holobit_sdk",
     "bindings",
+    "runtime",
+    "transpilers",
     "transpiler",
 )
+
+_BACKEND_PREFIXES = (
+    "backend",
+    "pcobra",
+    "cobra",
+    "core",
+    "corelibs",
+    "runtime",
+)
+
+
+def normalizar_nombre_usar(nombre: str) -> str:
+    """Normaliza nombre de módulo para validaciones canónicas de `usar`."""
+
+    return (nombre or "").strip().lower().replace("-", "_")
 
 
 def _rechazar_modulo_no_canonico(nombre: str) -> None:
     """Rechaza módulos backend/no-canónicos con error explícito para `usar`."""
 
-    nombre_normalizado = (nombre or "").strip().lower()
-    if nombre_normalizado in USAR_BACKEND_BLOCKLIST:
+    nombre_normalizado = normalizar_nombre_usar(nombre)
+    blocklist_normalizada = {normalizar_nombre_usar(item) for item in USAR_BACKEND_BLOCKLIST}
+
+    if nombre_normalizado in blocklist_normalizada:
+        raise PermissionError(
+            f"Importación no permitida en 'usar': '{nombre}'. "
+            "Es un módulo backend/no canónico y no forma parte de la API pública. "
+            f"Módulos permitidos: {', '.join(sorted(USAR_COBRA_ALLOWLIST))}."
+        )
+
+    if any(
+        nombre_normalizado == prefijo or nombre_normalizado.startswith(f"{prefijo}_")
+        for prefijo in _BACKEND_PREFIXES
+    ):
         raise PermissionError(
             f"Importación no permitida en 'usar': '{nombre}'. "
             "Es un módulo backend/no canónico y no forma parte de la API pública. "
@@ -44,7 +75,7 @@ def validar_nombre_modulo_usar(nombre: str, *, require_allowlist: bool = True) -
     """Valida nombre de `usar` y opcionalmente exige allowlist canónica."""
 
     _rechazar_modulo_no_canonico(nombre)
-    nombre = nombre.strip()
+    nombre = normalizar_nombre_usar(nombre)
     if not nombre:
         raise ValueError("Nombre de módulo vacío en 'usar'.")
 


### PR DESCRIPTION
### Motivation
- Evitar que variantes no canónicas de nombres de módulo (mayúsculas/minúsculas, guiones vs underscores) eludan las restricciones de `usar` y prevenir imports de backends o rutas internas.
- Detectar y bloquear módulos que usen prefijos internos conocidos (`backend`, `pcobra`, `cobra`, `core`, `corelibs`, `runtime`) para reducir surface de ataque y confusión de API.
- Añadir patrones adicionales de hints internos (SDK/runtime/transpilers) para reforzar las comprobaciones de seguridad y claridad de errores.

### Description
- Añadida la función `normalizar_nombre_usar` que aplica `strip()`, `lower()` y convierte `-` en `_` para canonizar entradas antes de validar.
- Ampliado `_INTERNAL_HINTS` con `sdk`, `holobit_sdk`, `runtime` y `transpilers`, y añadido `_BACKEND_PREFIXES` para bloqueo por prefijo.
- Reforzado `_rechazar_modulo_no_canonico` para comparar contra una `USAR_BACKEND_BLOCKLIST` normalizada y bloquear nombres que coincidan o comiencen con prefijos internos conocidos.
- Aplicada la normalización canónica en `validar_nombre_modulo_usar` antes de las demás comprobaciones, manteniendo intacto el contrato `usar "modulo"` y conservando mensajes de error en español con la lista de módulos permitidos (`USAR_COBRA_ALLOWLIST`).

### Testing
- `python -m py_compile src/pcobra/cobra/usar_loader.py` se ejecutó y finalizó correctamente sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee93397f08327afb90de3150c6bac)