### PR TITLE
Refuerza política de símbolos `usar` con clasificación y trazabilidad

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -222,16 +222,20 @@ def sanitizar_exports_publicos(modulo: object, alias_modulo: str) -> tuple[dict[
         vistos.add(nombre)
         simbolos_brutos.append((nombre, getattr(modulo, nombre)))
 
-    simbolos_saneados, rechazos, warnings = sanear_exportables_para_usar(simbolos_brutos)
+    simbolos_saneados, clasificacion, warnings = sanear_exportables_para_usar(
+        simbolos_brutos,
+        modulo_origen=alias_modulo,
+    )
     mapa_limpio = {nombre: simbolo for nombre, simbolo in simbolos_saneados}
 
-    for resultado in [*rechazos, *warnings]:
+    for resultado in [*clasificacion.rechazos_duros, *warnings]:
         conflictos.append(
             {
                 "module": alias_modulo,
                 "symbol": resultado.nombre,
                 "code": resultado.codigo or ("warning" if resultado.warning else "rejected"),
                 "message": resultado.mensaje or ("warning de saneamiento" if resultado.warning else "símbolo rechazado"),
+                "source_module": resultado.metadata.get("modulo_origen"),
             }
         )
 

--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -1,6 +1,6 @@
 """Política de saneamiento de símbolos para la instrucción ``usar``."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import ModuleType
 from typing import Any
 
@@ -14,31 +14,54 @@ EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS = {
     "keys": "claves",
     "values": "valores",
     "len": "longitud",
+    "lower": "minusculas",
+    "upper": "mayusculas",
+    "items": "elementos",
+    "get": "obtener",
+    "setdefault": "definir_por_defecto",
+    "update": "actualizar",
+    "pop": "extraer",
+    "clear": "limpiar",
+    "copy": "copiar",
+    "split": "separar",
+    "join": "unir",
+    "strip": "recortar",
+    "replace": "reemplazar",
+    "startswith": "inicia_con",
+    "endswith": "termina_con",
 }
 
 NOMBRES_PROHIBIDOS_EXPLICITOS = frozenset(EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS)
 DUNDERS_BLOQUEADOS = frozenset(
     {"__builtins__", "__loader__", "__package__", "__spec__", "__name__"}
 )
-NOMBRES_CONSTANTES_PUBLICAS_CANONICAS = frozenset(
-    {
-        "PI",
-        "E",
-        "TAU",
-        "INF",
-        "NAN",
-    }
-)
+NOMBRES_CONSTANTES_PUBLICAS_CANONICAS = frozenset({"PI", "E", "TAU", "INF", "NAN"})
 NOMBRES_BACKEND_INTERNOS = frozenset(
     {"sys", "os", "importlib", "pcobra", "cobra", "core"}
 )
-PREFIJOS_MODULOS_BACKEND_INTERNOS = (
-    "sys",
-    "os",
-    "importlib",
-    "pcobra",
-    "cobra",
-)
+PREFIJOS_MODULOS_BACKEND_INTERNOS = ("sys", "os", "importlib", "pcobra", "cobra")
+
+
+@dataclass(frozen=True)
+class PoliticaSaneamientoUsar:
+    validar_nombre_canonico_espanol_en_cobra_facing: bool = False
+
+
+@dataclass(frozen=True)
+class ResultadoSaneamientoSimboloUsar:
+    nombre: str
+    simbolo: object
+    rechazado: bool
+    codigo: str | None = None
+    mensaje: str | None = None
+    warning: bool = False
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ClasificacionSaneamientoUsar:
+    rechazos_duros: list[ResultadoSaneamientoSimboloUsar]
+    warnings_transicion: list[ResultadoSaneamientoSimboloUsar]
 
 
 def _es_objeto_backend_no_exportable(simbolo: Any) -> bool:
@@ -63,18 +86,8 @@ def _es_objeto_backend_no_exportable(simbolo: Any) -> bool:
     return False
 
 
-@dataclass(frozen=True)
-class ResultadoSaneamientoSimboloUsar:
-    nombre: str
-    simbolo: object
-    rechazado: bool
-    codigo: str | None = None
-    mensaje: str | None = None
-    warning: bool = False
-
-
-def _rechazar(nombre: str, simbolo: object, codigo: str, mensaje: str) -> ResultadoSaneamientoSimboloUsar:
-    return ResultadoSaneamientoSimboloUsar(nombre, simbolo, True, codigo, mensaje)
+def _rechazar(nombre: str, simbolo: object, codigo: str, mensaje: str, metadata: dict[str, object]) -> ResultadoSaneamientoSimboloUsar:
+    return ResultadoSaneamientoSimboloUsar(nombre, simbolo, True, codigo, mensaje, metadata=metadata)
 
 
 def _mensaje_nombre_prohibido(nombre: str) -> str:
@@ -87,62 +100,52 @@ def _mensaje_nombre_prohibido(nombre: str) -> str:
     return "nombre prohibido por política explícita de usar"
 
 
-def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamientoSimboloUsar:
+def _parece_nombre_canonico_espanol(nombre: str) -> bool:
+    return nombre.isidentifier() and nombre.lower() == nombre and "_" in nombre
+
+
+def sanear_simbolo_para_usar(
+    nombre: str,
+    simbolo: object,
+    *,
+    politica: PoliticaSaneamientoUsar | None = None,
+    modulo_origen: str | None = None,
+    modulo_cobra_facing: bool = False,
+) -> ResultadoSaneamientoSimboloUsar:
     """Aplica la política de exportación de símbolos para ``usar``."""
+    politica_efectiva = politica or PoliticaSaneamientoUsar()
+    metadata = {"modulo_origen": modulo_origen, "modulo_cobra_facing": modulo_cobra_facing}
+
     if nombre in DUNDERS_BLOQUEADOS:
-        return _rechazar(
-            nombre,
-            simbolo,
-            "dunder_name",
-            "dunders Python conocidos no se permiten en usar",
-        )
+        return _rechazar(nombre, simbolo, "dunder_name", "dunders Python conocidos no se permiten en usar", metadata)
 
     if nombre.startswith("_"):
-        return _rechazar(
-            nombre,
-            simbolo,
-            "private_prefix",
-            "símbolos que inicien con '_' no son exportables",
-        )
+        return _rechazar(nombre, simbolo, "private_prefix", "símbolos que inicien con '_' no son exportables", metadata)
 
     if "__" in nombre:
-        return _rechazar(
-            nombre,
-            simbolo,
-            "dunder_pattern",
-            "nombres con '__' no se permiten en usar",
-        )
+        return _rechazar(nombre, simbolo, "dunder_pattern", "nombres con '__' no se permiten en usar", metadata)
 
     if _es_objeto_backend_no_exportable(simbolo):
-        return _rechazar(
-            nombre,
-            simbolo,
-            "backend_module_object",
-            "objetos módulo/backend (incluye wrappers SDK e indirectos) no son exportables",
-        )
+        return _rechazar(nombre, simbolo, "backend_module_object", "objetos módulo/backend (incluye wrappers SDK e indirectos) no son exportables", metadata)
 
     if nombre in NOMBRES_BACKEND_INTERNOS:
-        return _rechazar(
-            nombre,
-            simbolo,
-            "backend_internal_name",
-            "nombre interno del backend bloqueado",
-        )
+        return _rechazar(nombre, simbolo, "backend_internal_name", "nombre interno del backend bloqueado", metadata)
 
     if nombre in NOMBRES_PROHIBIDOS_EXPLICITOS:
-        return _rechazar(
-            nombre,
-            simbolo,
-            "explicit_forbidden_name",
-            _mensaje_nombre_prohibido(nombre),
-        )
+        return _rechazar(nombre, simbolo, "explicit_forbidden_name", _mensaje_nombre_prohibido(nombre), metadata)
 
     if not callable(simbolo) and nombre not in NOMBRES_CONSTANTES_PUBLICAS_CANONICAS:
-        return _rechazar(
+        return _rechazar(nombre, simbolo, "non_callable_not_canonical_public_constant", "solo se permiten no-callables para constantes públicas explícitas y canónicas", metadata)
+
+    if politica_efectiva.validar_nombre_canonico_espanol_en_cobra_facing and modulo_cobra_facing and not _parece_nombre_canonico_espanol(nombre):
+        return ResultadoSaneamientoSimboloUsar(
             nombre,
             simbolo,
-            "non_callable_not_canonical_public_constant",
-            "solo se permiten no-callables para constantes públicas explícitas y canónicas",
+            False,
+            "non_canonical_spanish_name",
+            "símbolo permitido por compatibilidad, pero no cumple nombre canónico español para módulo Cobra-facing",
+            warning=True,
+            metadata=metadata,
         )
 
     if not callable(simbolo):
@@ -153,25 +156,38 @@ def sanear_simbolo_para_usar(nombre: str, simbolo: object) -> ResultadoSaneamien
             "public_constant",
             "constante pública explícita permitida",
             warning=True,
+            metadata=metadata,
         )
 
-    return ResultadoSaneamientoSimboloUsar(nombre, simbolo, False, "ok", "símbolo exportable")
+    return ResultadoSaneamientoSimboloUsar(nombre, simbolo, False, "ok", "símbolo exportable", metadata=metadata)
 
 
 def sanear_exportables_para_usar(
     simbolos: list[tuple[str, object]],
-) -> tuple[list[tuple[str, object]], list[ResultadoSaneamientoSimboloUsar], list[ResultadoSaneamientoSimboloUsar]]:
+    *,
+    politica: PoliticaSaneamientoUsar | None = None,
+    modulo_origen: str | None = None,
+    modulo_cobra_facing: bool = False,
+) -> tuple[list[tuple[str, object]], ClasificacionSaneamientoUsar, list[ResultadoSaneamientoSimboloUsar]]:
     """Sanea una lista de símbolos candidatos para ``usar`` de forma uniforme."""
 
     permitidos: list[tuple[str, object]] = []
-    rechazos: list[ResultadoSaneamientoSimboloUsar] = []
-    warnings: list[ResultadoSaneamientoSimboloUsar] = []
+    rechazos_duros: list[ResultadoSaneamientoSimboloUsar] = []
+    warnings_transicion: list[ResultadoSaneamientoSimboloUsar] = []
     for nombre, simbolo in simbolos:
-        resultado = sanear_simbolo_para_usar(nombre, simbolo)
+        resultado = sanear_simbolo_para_usar(
+            nombre,
+            simbolo,
+            politica=politica,
+            modulo_origen=modulo_origen,
+            modulo_cobra_facing=modulo_cobra_facing,
+        )
         if resultado.rechazado:
-            rechazos.append(resultado)
+            rechazos_duros.append(resultado)
             continue
         if resultado.warning:
-            warnings.append(resultado)
+            warnings_transicion.append(resultado)
         permitidos.append((nombre, simbolo))
-    return permitidos, rechazos, warnings
+
+    clasificacion = ClasificacionSaneamientoUsar(rechazos_duros=rechazos_duros, warnings_transicion=warnings_transicion)
+    return permitidos, clasificacion, warnings_transicion


### PR DESCRIPTION
### Motivation
- Separar explícitamente los rechazos duros de los warnings de transición para clarificar el comportamiento de saneamiento y facilitar decisiones operativas sobre compatibilidad.
- Endurecer la política de nombres prohibidos incorporando términos comunes de stdlib/backend para evitar colisiones y nombres no canónicos.
- Añadir trazabilidad de origen de módulo y una verificación opcional de nombre canónico en español para módulos marcados como Cobra-facing sin romper compatibilidad inmediata.
- Garantizar que no se exporten símbolos no callable salvo constantes públicas explícitas y canónicas para mantener invariantes de la API.

### Description
- Se amplió `EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS` con múltiples términos comunes (`lower`, `upper`, `items`, `get`, `setdefault`, `update`, `pop`, `clear`, `copy`, `split`, `join`, `strip`, `replace`, `startswith`, `endswith`, etc.).
- Se añadieron las estructuras `PoliticaSaneamientoUsar`, `ClasificacionSaneamientoUsar` y se extendió `ResultadoSaneamientoSimboloUsar` con `metadata` para incluir `modulo_origen` y `modulo_cobra_facing` en los resultados.
- `sanear_simbolo_para_usar` ahora acepta `politica`, `modulo_origen` y `modulo_cobra_facing`, devuelve warnings de transición (no disruptivos) cuando aplica la validación opcional de nombre canónico español, y siempre añade metadata para trazabilidad.
- `sanear_exportables_para_usar` ahora devuelve una `ClasificacionSaneamientoUsar` que separa `rechazos_duros` y `warnings_transicion`, y `usar_loader` pasa `modulo_origen` al saneamiento y añade `source_module` en los registros de conflicto.

### Testing
- Se compiló el código modificado con `python -m compileall src/pcobra/core/usar_symbol_policy.py src/pcobra/cobra/usar_loader.py` y la compilación finalizó correctamente.
- No se añadieron tests automatizados nuevos en esta PR; los cambios se diseñaron para ser compatibles por defecto y la validación opcional de nombres en español está desactivada por defecto.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feeb35c03483279e96470005665716)