### PR TITLE
Depurar exportaciones públicas de stdlib (archivo/texto) y regenerar matriz contractual

### DIFF
--- a/docs/_generated/stdlib_contract_matrix.json
+++ b/docs/_generated/stdlib_contract_matrix.json
@@ -215,7 +215,8 @@
       "public_api": [
         "cobra.web.obtener_url",
         "cobra.web.enviar_post",
-        "cobra.web.descargar_archivo"
+        "cobra.web.descargar_archivo",
+        "cobra.web.obtener_url_texto"
       ],
       "public_exports": [
         {
@@ -232,6 +233,11 @@
           "alias": "cobra.web.descargar_archivo",
           "source_path": "src/pcobra/corelibs/red.py",
           "python_symbol": "descargar_archivo"
+        },
+        {
+          "alias": "cobra.web.obtener_url_texto",
+          "source_path": "src/pcobra/corelibs/red.py",
+          "python_symbol": "obtener_url_texto"
         }
       ],
       "coverage": [
@@ -262,6 +268,16 @@
         },
         {
           "function": "cobra.web.descargar_archivo",
+          "backend": "python",
+          "level": "full"
+        },
+        {
+          "function": "cobra.web.obtener_url_texto",
+          "backend": "javascript",
+          "level": "partial"
+        },
+        {
+          "function": "cobra.web.obtener_url_texto",
           "backend": "python",
           "level": "full"
         }
@@ -279,7 +295,8 @@
           "src/pcobra/standard_library/archivo.py"
         ],
         "corelibs": [
-          "src/pcobra/corelibs/sistema.py"
+          "src/pcobra/corelibs/sistema.py",
+          "src/pcobra/corelibs/tiempo.py"
         ],
         "core_nativos": [
           "src/pcobra/core/nativos/sistema.js"
@@ -288,8 +305,15 @@
       "public_api": [
         "cobra.system.leer",
         "cobra.system.escribir",
+        "cobra.system.adjuntar",
+        "cobra.system.existe",
         "cobra.system.ejecutar",
-        "cobra.system.obtener_env"
+        "cobra.system.ejecutar_comando_async",
+        "cobra.system.obtener_env",
+        "cobra.system.listar_dir",
+        "cobra.system.ahora",
+        "cobra.system.formatear",
+        "cobra.system.dormir"
       ],
       "public_exports": [
         {
@@ -303,14 +327,49 @@
           "python_symbol": "escribir"
         },
         {
+          "alias": "cobra.system.adjuntar",
+          "source_path": "src/pcobra/standard_library/archivo.py",
+          "python_symbol": "adjuntar"
+        },
+        {
+          "alias": "cobra.system.existe",
+          "source_path": "src/pcobra/standard_library/archivo.py",
+          "python_symbol": "existe"
+        },
+        {
           "alias": "cobra.system.ejecutar",
           "source_path": "src/pcobra/corelibs/sistema.py",
           "python_symbol": "ejecutar"
         },
         {
+          "alias": "cobra.system.ejecutar_comando_async",
+          "source_path": "src/pcobra/corelibs/sistema.py",
+          "python_symbol": "ejecutar_comando_async"
+        },
+        {
           "alias": "cobra.system.obtener_env",
           "source_path": "src/pcobra/corelibs/sistema.py",
           "python_symbol": "obtener_env"
+        },
+        {
+          "alias": "cobra.system.listar_dir",
+          "source_path": "src/pcobra/corelibs/sistema.py",
+          "python_symbol": "listar_dir"
+        },
+        {
+          "alias": "cobra.system.ahora",
+          "source_path": "src/pcobra/corelibs/tiempo.py",
+          "python_symbol": "ahora"
+        },
+        {
+          "alias": "cobra.system.formatear",
+          "source_path": "src/pcobra/corelibs/tiempo.py",
+          "python_symbol": "formatear"
+        },
+        {
+          "alias": "cobra.system.dormir",
+          "source_path": "src/pcobra/corelibs/tiempo.py",
+          "python_symbol": "dormir"
         }
       ],
       "coverage": [
@@ -345,6 +404,36 @@
           "level": "partial"
         },
         {
+          "function": "cobra.system.adjuntar",
+          "backend": "python",
+          "level": "full"
+        },
+        {
+          "function": "cobra.system.adjuntar",
+          "backend": "rust",
+          "level": "partial"
+        },
+        {
+          "function": "cobra.system.adjuntar",
+          "backend": "javascript",
+          "level": "partial"
+        },
+        {
+          "function": "cobra.system.existe",
+          "backend": "python",
+          "level": "full"
+        },
+        {
+          "function": "cobra.system.existe",
+          "backend": "rust",
+          "level": "partial"
+        },
+        {
+          "function": "cobra.system.existe",
+          "backend": "javascript",
+          "level": "partial"
+        },
+        {
           "function": "cobra.system.ejecutar",
           "backend": "python",
           "level": "full"
@@ -360,6 +449,21 @@
           "level": "partial"
         },
         {
+          "function": "cobra.system.ejecutar_comando_async",
+          "backend": "python",
+          "level": "full"
+        },
+        {
+          "function": "cobra.system.ejecutar_comando_async",
+          "backend": "rust",
+          "level": "partial"
+        },
+        {
+          "function": "cobra.system.ejecutar_comando_async",
+          "backend": "javascript",
+          "level": "partial"
+        },
+        {
           "function": "cobra.system.obtener_env",
           "backend": "python",
           "level": "full"
@@ -371,6 +475,66 @@
         },
         {
           "function": "cobra.system.obtener_env",
+          "backend": "javascript",
+          "level": "partial"
+        },
+        {
+          "function": "cobra.system.listar_dir",
+          "backend": "python",
+          "level": "full"
+        },
+        {
+          "function": "cobra.system.listar_dir",
+          "backend": "rust",
+          "level": "partial"
+        },
+        {
+          "function": "cobra.system.listar_dir",
+          "backend": "javascript",
+          "level": "partial"
+        },
+        {
+          "function": "cobra.system.ahora",
+          "backend": "python",
+          "level": "full"
+        },
+        {
+          "function": "cobra.system.ahora",
+          "backend": "rust",
+          "level": "partial"
+        },
+        {
+          "function": "cobra.system.ahora",
+          "backend": "javascript",
+          "level": "partial"
+        },
+        {
+          "function": "cobra.system.formatear",
+          "backend": "python",
+          "level": "full"
+        },
+        {
+          "function": "cobra.system.formatear",
+          "backend": "rust",
+          "level": "partial"
+        },
+        {
+          "function": "cobra.system.formatear",
+          "backend": "javascript",
+          "level": "partial"
+        },
+        {
+          "function": "cobra.system.dormir",
+          "backend": "python",
+          "level": "full"
+        },
+        {
+          "function": "cobra.system.dormir",
+          "backend": "rust",
+          "level": "partial"
+        },
+        {
+          "function": "cobra.system.dormir",
           "backend": "javascript",
           "level": "partial"
         }

--- a/docs/_generated/stdlib_contract_matrix.md
+++ b/docs/_generated/stdlib_contract_matrix.md
@@ -8,8 +8,8 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 |---|---|---|---|---|
 | `cobra.core` | 4 | `python` | `rust, javascript` | es_finito:rust, es_finito:javascript, es_infinito:rust, es_infinito:javascript, copiar_signo:rust, copiar_signo:javascript, signo:rust, signo:javascript |
 | `cobra.datos` | 4 | `python` | `javascript` | filtrar:javascript, seleccionar_columnas:javascript, a_listas:javascript, de_listas:javascript |
-| `cobra.web` | 3 | `javascript` | `python` | obtener_url:javascript, enviar_post:javascript, descargar_archivo:javascript |
-| `cobra.system` | 4 | `python` | `rust, javascript` | leer:rust, leer:javascript, escribir:rust, escribir:javascript, ejecutar:rust, ejecutar:javascript, obtener_env:rust, obtener_env:javascript |
+| `cobra.web` | 4 | `javascript` | `python` | obtener_url:javascript, enviar_post:javascript, descargar_archivo:javascript, obtener_url_texto:javascript |
+| `cobra.system` | 11 | `python` | `rust, javascript` | leer:rust, leer:javascript, escribir:rust, escribir:javascript, adjuntar:rust, adjuntar:javascript, existe:rust, existe:javascript, ejecutar:rust, ejecutar:javascript, ejecutar_comando_async:rust, ejecutar_comando_async:javascript, obtener_env:rust, obtener_env:javascript, listar_dir:rust, listar_dir:javascript, ahora:rust, ahora:javascript, formatear:rust, formatear:javascript, dormir:rust, dormir:javascript |
 
 ## `cobra.core`
 
@@ -102,6 +102,7 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 - `cobra.web.obtener_url`
 - `cobra.web.enviar_post`
 - `cobra.web.descargar_archivo`
+- `cobra.web.obtener_url_texto`
 
 ### Exportaciones públicas (alias Cobra estables)
 
@@ -110,6 +111,7 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 | `cobra.web.obtener_url` | `src/pcobra/corelibs/red.py` |
 | `cobra.web.enviar_post` | `src/pcobra/corelibs/red.py` |
 | `cobra.web.descargar_archivo` | `src/pcobra/corelibs/red.py` |
+| `cobra.web.obtener_url_texto` | `src/pcobra/corelibs/red.py` |
 
 ### Cobertura por función
 
@@ -121,21 +123,30 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 | `cobra.web.enviar_post` | `python` | `full` |
 | `cobra.web.descargar_archivo` | `javascript` | `partial` |
 | `cobra.web.descargar_archivo` | `python` | `full` |
+| `cobra.web.obtener_url_texto` | `javascript` | `partial` |
+| `cobra.web.obtener_url_texto` | `python` | `full` |
 
 ## `cobra.system`
 
 - **Backend primario:** `python`
 - **Fallback permitido:** `rust, javascript`
 - **Mapeo `standard_library`:** `src/pcobra/standard_library/archivo.py`
-- **Mapeo `corelibs`:** `src/pcobra/corelibs/sistema.py`
+- **Mapeo `corelibs`:** `src/pcobra/corelibs/sistema.py`, `src/pcobra/corelibs/tiempo.py`
 - **Mapeo `core/nativos`:** `src/pcobra/core/nativos/sistema.js`
 
 ### API pública
 
 - `cobra.system.leer`
 - `cobra.system.escribir`
+- `cobra.system.adjuntar`
+- `cobra.system.existe`
 - `cobra.system.ejecutar`
+- `cobra.system.ejecutar_comando_async`
 - `cobra.system.obtener_env`
+- `cobra.system.listar_dir`
+- `cobra.system.ahora`
+- `cobra.system.formatear`
+- `cobra.system.dormir`
 
 ### Exportaciones públicas (alias Cobra estables)
 
@@ -143,8 +154,15 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 |---|---|
 | `cobra.system.leer` | `src/pcobra/standard_library/archivo.py` |
 | `cobra.system.escribir` | `src/pcobra/standard_library/archivo.py` |
+| `cobra.system.adjuntar` | `src/pcobra/standard_library/archivo.py` |
+| `cobra.system.existe` | `src/pcobra/standard_library/archivo.py` |
 | `cobra.system.ejecutar` | `src/pcobra/corelibs/sistema.py` |
+| `cobra.system.ejecutar_comando_async` | `src/pcobra/corelibs/sistema.py` |
 | `cobra.system.obtener_env` | `src/pcobra/corelibs/sistema.py` |
+| `cobra.system.listar_dir` | `src/pcobra/corelibs/sistema.py` |
+| `cobra.system.ahora` | `src/pcobra/corelibs/tiempo.py` |
+| `cobra.system.formatear` | `src/pcobra/corelibs/tiempo.py` |
+| `cobra.system.dormir` | `src/pcobra/corelibs/tiempo.py` |
 
 ### Cobertura por función
 
@@ -156,9 +174,30 @@ Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 | `cobra.system.escribir` | `python` | `full` |
 | `cobra.system.escribir` | `rust` | `partial` |
 | `cobra.system.escribir` | `javascript` | `partial` |
+| `cobra.system.adjuntar` | `python` | `full` |
+| `cobra.system.adjuntar` | `rust` | `partial` |
+| `cobra.system.adjuntar` | `javascript` | `partial` |
+| `cobra.system.existe` | `python` | `full` |
+| `cobra.system.existe` | `rust` | `partial` |
+| `cobra.system.existe` | `javascript` | `partial` |
 | `cobra.system.ejecutar` | `python` | `full` |
 | `cobra.system.ejecutar` | `rust` | `partial` |
 | `cobra.system.ejecutar` | `javascript` | `partial` |
+| `cobra.system.ejecutar_comando_async` | `python` | `full` |
+| `cobra.system.ejecutar_comando_async` | `rust` | `partial` |
+| `cobra.system.ejecutar_comando_async` | `javascript` | `partial` |
 | `cobra.system.obtener_env` | `python` | `full` |
 | `cobra.system.obtener_env` | `rust` | `partial` |
 | `cobra.system.obtener_env` | `javascript` | `partial` |
+| `cobra.system.listar_dir` | `python` | `full` |
+| `cobra.system.listar_dir` | `rust` | `partial` |
+| `cobra.system.listar_dir` | `javascript` | `partial` |
+| `cobra.system.ahora` | `python` | `full` |
+| `cobra.system.ahora` | `rust` | `partial` |
+| `cobra.system.ahora` | `javascript` | `partial` |
+| `cobra.system.formatear` | `python` | `full` |
+| `cobra.system.formatear` | `rust` | `partial` |
+| `cobra.system.formatear` | `javascript` | `partial` |
+| `cobra.system.dormir` | `python` | `full` |
+| `cobra.system.dormir` | `rust` | `partial` |
+| `cobra.system.dormir` | `javascript` | `partial` |

--- a/docs/standard_library/matriz_stdlib_unificada.md
+++ b/docs/standard_library/matriz_stdlib_unificada.md
@@ -1,40 +1,203 @@
-# Matriz unificada de stdlib (inventario + propuestas)
+# Matriz única de stdlib Cobra (autogenerado)
 
-Este documento usa `__all__` como fuente pública para cada módulo.
+Este documento se genera desde `src/pcobra/cobra/stdlib_contract/*.py`.
 
-## Inventario actual por módulo
-- `src/pcobra/corelibs/numero.py`: absoluto, redondear, piso, techo, mcd, mcm, es_cercano, hipotenusa, distancia_euclidiana, es_finito, es_infinito, es_nan, copiar_signo, signo, producto, entero_a_base, entero_desde_base, longitud_bits, contar_bits, rotar_bits_izquierda, rotar_bits_derecha, entero_a_bytes, entero_desde_bytes, raiz, raiz_entera, potencia, limitar, interpolar, envolver_modular, aleatorio, aleatorio_entero, mediana, moda, desviacion_estandar, es_par, es_primo, factorial, promedio, combinaciones, permutaciones, suma_precisa, varianza, varianza_muestral, media_geometrica, media_armonica, percentil, cuartiles, rango_intercuartil, coeficiente_variacion
-- `src/pcobra/standard_library/numero.py`: es_finito, es_infinito, es_nan, copiar_signo, signo, limitar, hipotenusa, distancia_euclidiana, raiz_entera, combinaciones, permutaciones, suma_precisa, interpolar, envolver_modular, varianza, varianza_muestral, media_geometrica, media_armonica, percentil, cuartiles, rango_intercuartil, coeficiente_variacion, absoluto, redondear, piso, techo, mcd, mcm, es_cercano, raiz, potencia, mediana, moda, es_par, es_primo, factorial, promedio, sumatoria, producto
-- `src/pcobra/corelibs/texto.py`: mayusculas, minusculas, capitalizar, titulo, intercambiar_mayusculas, invertir, concatenar, codificar, decodificar, quitar_espacios, dividir, dividir_derecha, encontrar, encontrar_derecha, indice, indice_derecha, subcadena_antes, subcadena_despues, subcadena_antes_ultima, subcadena_despues_ultima, unir, formatear, formatear_mapa, tabla_traduccion, traducir, reemplazar, empieza_con, termina_con, incluye, quitar_prefijo, quitar_sufijo, a_snake, a_camel, quitar_envoltura, prefijo_comun, sufijo_comun, rellenar_izquierda, particionar, particionar_derecha, rellenar_derecha, normalizar_unicode, dividir_lineas, expandir_tabulaciones, contar_subcadena, indentar_texto, desindentar_texto, envolver_texto, acortar_texto, centrar_texto, rellenar_ceros, minusculas_casefold, es_alfabetico, es_alfa_numerico, es_decimal, es_numerico, es_identificador, es_imprimible, es_ascii, es_mayusculas, es_minusculas, es_espacio, es_titulo, es_digito, lineas_no_vacias
-- `src/pcobra/standard_library/texto.py`: quitar_acentos, normalizar_espacios, es_palindromo, es_anagrama, codificar, decodificar, es_alfabetico, es_alfa_numerico, es_decimal, es_numerico, es_identificador, es_imprimible, es_ascii, es_mayusculas, es_minusculas, es_titulo, es_digito, es_espacio, quitar_prefijo, quitar_sufijo, a_snake, a_camel, quitar_envoltura, prefijo_comun, sufijo_comun, dividir_lineas, dividir_derecha, encontrar, encontrar_derecha, subcadena_antes, subcadena_despues, subcadena_antes_ultima, subcadena_despues_ultima, indice, indice_derecha, contar_subcadena, centrar_texto, rellenar_ceros, minusculas, mayusculas, minusculas_casefold, intercambiar_mayusculas, expandir_tabulaciones, particionar, particionar_derecha, indentar_texto, desindentar_texto, envolver_texto, acortar_texto, formatear, formatear_mapa, tabla_traduccion, traducir, recortar, repetir
-- `src/pcobra/corelibs/datos.py`: leer_csv, leer_json, escribir_csv, escribir_json, leer_excel, escribir_excel, leer_parquet, escribir_parquet, leer_feather, escribir_feather, describir, correlacion_pearson, correlacion_spearman, matriz_covarianza, calcular_percentiles, resumen_rapido, seleccionar_columnas, filtrar, mutar_columna, separar_columna, unir_columnas, agrupar_y_resumir, tabla_cruzada, pivotar_ancho, pivotar_largo, ordenar_tabla, combinar_tablas, rellenar_nulos, desplegar_tabla, pivotar_tabla, agregar, mapear, reducir, claves, valores, longitud
-- `src/pcobra/standard_library/datos.py`: leer_csv, leer_json, escribir_csv, escribir_json, leer_excel, escribir_excel, leer_parquet, escribir_parquet, leer_feather, escribir_feather, describir, correlacion_pearson, correlacion_spearman, matriz_covarianza, calcular_percentiles, resumen_rapido, seleccionar_columnas, filtrar, mutar_columna, separar_columna, unir_columnas, agrupar_y_resumir, tabla_cruzada, pivotar_ancho, pivotar_largo, ordenar_tabla, combinar_tablas, rellenar_nulos, desplegar_tabla, pivotar_tabla, agregar, mapear, reducir, claves, valores, longitud, invertir_tabla, tomar
-- `src/pcobra/corelibs/logica.py`: es_verdadero, es_falso, conjuncion, disyuncion, negacion, xor, nand, nor, implica, equivale, xor_multiple, entonces, si_no, condicional, coalescer, todas, alguna, ninguna, solo_uno, conteo_verdaderos, paridad, mayoria, exactamente_n, tabla_verdad, diferencia_simetrica, si_condicional
-- `src/pcobra/standard_library/logica.py`: es_verdadero, es_falso, conjuncion, disyuncion, negacion, entonces, si_no, coalescer, condicional, xor, nand, nor, implica, equivale, xor_multiple, todas, alguna, ninguna, solo_uno, conteo_verdaderos, paridad, mayoria, exactamente_n, tabla_verdad, diferencia_simetrica
-- `src/pcobra/corelibs/asincrono.py`: proteger_tarea, limitar_tiempo, ejecutar_en_hilo, recolectar, carrera, primero_exitoso, esperar_timeout, reintentar_async, grupo_tareas, crear_tarea, iterar_completadas, mapear_concurrencia, recolectar_resultados, dormir_async
-- `src/pcobra/standard_library/asincrono.py`: grupo_tareas, limitar_tiempo, proteger_tarea, ejecutar_en_hilo, reintentar_async, recolectar
-- `src/pcobra/corelibs/sistema.py`: obtener_os, ejecutar, ejecutar_async, ejecutar_stream, obtener_env, listar_dir, ejecutar_comando_async, directorio_actual
-- `src/pcobra/standard_library/sistema.py`: obtener_os, ejecutar, ejecutar_async, ejecutar_stream, obtener_env, listar_dir, directorio_actual
-- `src/pcobra/corelibs/archivo.py`: leer, escribir, existe, eliminar, anexar, leer_lineas
-- `src/pcobra/standard_library/archivo.py`: leer, escribir, adjuntar, existe
-- `src/pcobra/corelibs/tiempo.py`: ahora, formatear, dormir, epoch, desde_epoch
-- `src/pcobra/standard_library/tiempo.py`: ahora, formatear, dormir, epoch, desde_epoch
-- `src/pcobra/corelibs/red.py`: obtener_url, enviar_post, obtener_url_async, enviar_post_async, descargar_archivo, obtener_url_texto, obtener_json
-- `src/pcobra/standard_library/red.py`: obtener_url, enviar_post, obtener_url_async, enviar_post_async, descargar_archivo, obtener_json, obtener_url_texto
-- `src/pcobra/corelibs/holobit.py`: (dinámico)
-- `src/pcobra/standard_library/holobit.py`: crear_holobit, validar_holobit, serializar_holobit, deserializar_holobit, proyectar, transformar, graficar, combinar, medir
+## Tabla de garantías por módulo
 
-## Tabla canónica permitida (Cobra-facing) y equivalencia semántica
+| Módulo | API pública | Backend primario | Fallback | Límites |
+|---|---|---|---|---|
+| `cobra.core` | 4 | `python` | `rust, javascript` | es_finito:rust, es_finito:javascript, es_infinito:rust, es_infinito:javascript, copiar_signo:rust, copiar_signo:javascript, signo:rust, signo:javascript |
+| `cobra.datos` | 4 | `python` | `javascript` | filtrar:javascript, seleccionar_columnas:javascript, a_listas:javascript, de_listas:javascript |
+| `cobra.web` | 4 | `javascript` | `python` | obtener_url:javascript, enviar_post:javascript, descargar_archivo:javascript, obtener_url_texto:javascript |
+| `cobra.system` | 11 | `python` | `rust, javascript` | leer:rust, leer:javascript, escribir:rust, escribir:javascript, adjuntar:rust, adjuntar:javascript, existe:rust, existe:javascript, ejecutar:rust, ejecutar:javascript, ejecutar_comando_async:rust, ejecutar_comando_async:javascript, obtener_env:rust, obtener_env:javascript, listar_dir:rust, listar_dir:javascript, ahora:rust, ahora:javascript, formatear:rust, formatear:javascript, dormir:rust, dormir:javascript |
 
-| Módulo | Funciones canónicas permitidas | Equivalente semántico |
+## `cobra.core`
+
+- **Backend primario:** `python`
+- **Fallback permitido:** `rust, javascript`
+- **Mapeo `standard_library`:** `src/pcobra/standard_library/numero.py`
+- **Mapeo `corelibs`:** `src/pcobra/corelibs/numero.py`
+- **Mapeo `core/nativos`:** `src/pcobra/core/nativos/numero.js`
+
+### API pública
+
+- `cobra.core.es_finito`
+- `cobra.core.es_infinito`
+- `cobra.core.copiar_signo`
+- `cobra.core.signo`
+
+### Exportaciones públicas (alias Cobra estables)
+
+| Alias Cobra | Módulo runtime trazable |
+|---|---|
+| `cobra.core.es_finito` | `src/pcobra/standard_library/numero.py` |
+| `cobra.core.es_infinito` | `src/pcobra/standard_library/numero.py` |
+| `cobra.core.copiar_signo` | `src/pcobra/standard_library/numero.py` |
+| `cobra.core.signo` | `src/pcobra/standard_library/numero.py` |
+
+### Cobertura por función
+
+| Función | Backend | Nivel |
 |---|---|---|
-| `numero` | `absoluto`, `redondear`, `piso`, `techo`, `mcd`, `mcm`, `es_cercano`, `hipotenusa`, `distancia_euclidiana`, `es_finito`, `es_infinito`, `es_nan`, `copiar_signo`, `signo`, `producto`, `entero_a_base`, `entero_desde_base`, `longitud_bits`, `contar_bits`, `rotar_bits_izquierda`, `rotar_bits_derecha`, `entero_a_bytes`, `entero_desde_bytes`, `raiz`, `raiz_entera`, `potencia`, `limitar`, `interpolar`, `envolver_modular`, `aleatorio`, `aleatorio_entero`, `mediana`, `moda`, `desviacion_estandar`, `es_par`, `es_primo`, `factorial`, `promedio`, `combinaciones`, `permutaciones`, `suma_precisa`, `varianza`, `varianza_muestral`, `media_geometrica`, `media_armonica`, `percentil`, `cuartiles`, `rango_intercuartil`, `coeficiente_variacion` | Funciones matemáticas y estadísticas de Python (`math`, `random`, `statistics`) con contrato Cobra en español. |
-| `texto` | API de `src/pcobra/corelibs/texto.py` exportada en `__all__` (p.ej. `minusculas`, `mayusculas`, `dividir`, `reemplazar`, `a_snake`, `a_camel`, validadores `es_*`). | Transformaciones y validaciones sobre `str` Unicode (métodos nativos de `str`, `re`, `unicodedata`, `textwrap`). |
-| `datos` | `leer_csv`, `leer_json`, `escribir_csv`, `escribir_json`, `leer_excel`, `escribir_excel`, `leer_parquet`, `escribir_parquet`, `leer_feather`, `escribir_feather`, `describir`, `correlacion_pearson`, `correlacion_spearman`, `matriz_covarianza`, `calcular_percentiles`, `resumen_rapido`, `seleccionar_columnas`, `filtrar`, `mutar_columna`, `separar_columna`, `unir_columnas`, `agrupar_y_resumir`, `tabla_cruzada`, `pivotar_ancho`, `pivotar_largo`, `ordenar_tabla`, `combinar_tablas`, `rellenar_nulos`, `desplegar_tabla`, `pivotar_tabla`, `agregar`, `mapear`, `reducir`, `claves`, `valores`, `longitud`. | Operaciones tabulares/colecciones compatibles con backend de `standard_library.datos` sin exponer detalles internos. |
-| `logica` | API de `src/pcobra/corelibs/logica.py` exportada en `__all__` (p.ej. `conjuncion`, `disyuncion`, `negacion`, `xor`, `implica`, `coalescer`, `tabla_verdad`). | Álgebra booleana y utilidades de control con validación estricta de booleanos. |
-| `asincrono` | `proteger_tarea`, `limitar_tiempo`, `ejecutar_en_hilo`, `recolectar`, `carrera`, `primero_exitoso`, `esperar_timeout`, `reintentar_async`, `grupo_tareas`, `crear_tarea`, `iterar_completadas`, `mapear_concurrencia`, `recolectar_resultados`, `dormir_async`. | Primitivas de concurrencia basadas en `asyncio` con nombres Cobra. |
-| `sistema` | `obtener_os`, `ejecutar`, `ejecutar_async`, `ejecutar_stream`, `obtener_env`, `listar_dir`, `ejecutar_comando_async`, `directorio_actual`. | Abstracciones seguras de `os` + subprocesos para automatización del entorno. |
-| `archivo` | `leer`, `escribir`, `adjuntar`, `anexar`, `existe`, `eliminar`, `leer_lineas`. | Operaciones de E/S de texto con sandbox de rutas (`COBRA_IO_BASE_DIR`). |
-| `tiempo` | `ahora`, `formatear`, `dormir`, `epoch`, `desde_epoch`. | Adaptadores sobre `datetime`/`time` y `standard_library.fecha`. |
-| `red` | `obtener_url`, `enviar_post`, `obtener_url_async`, `enviar_post_async`, `descargar_archivo`, `obtener_url_texto`, `obtener_json`. | Cliente HTTP(S) seguro (lista blanca de hosts, límites de tamaño y redirecciones). |
-| `holobit` | `crear_holobit`, `validar_holobit`, `serializar_holobit`, `deserializar_holobit`, `proyectar`, `transformar`, `graficar`, `combinar`, `medir`. | Adaptador Cobra sobre runtime Holobit sin fuga de clases internas. |
+| `cobra.core.es_finito` | `python` | `full` |
+| `cobra.core.es_finito` | `rust` | `partial` |
+| `cobra.core.es_finito` | `javascript` | `partial` |
+| `cobra.core.es_infinito` | `python` | `full` |
+| `cobra.core.es_infinito` | `rust` | `partial` |
+| `cobra.core.es_infinito` | `javascript` | `partial` |
+| `cobra.core.copiar_signo` | `python` | `full` |
+| `cobra.core.copiar_signo` | `rust` | `partial` |
+| `cobra.core.copiar_signo` | `javascript` | `partial` |
+| `cobra.core.signo` | `python` | `full` |
+| `cobra.core.signo` | `rust` | `partial` |
+| `cobra.core.signo` | `javascript` | `partial` |
+
+## `cobra.datos`
+
+- **Backend primario:** `python`
+- **Fallback permitido:** `javascript`
+- **Mapeo `standard_library`:** `src/pcobra/standard_library/datos.py`
+- **Mapeo `corelibs`:** `src/pcobra/corelibs/coleccion.py`
+- **Mapeo `core/nativos`:** `src/pcobra/core/nativos/datos.js`
+
+### API pública
+
+- `cobra.datos.filtrar`
+- `cobra.datos.seleccionar_columnas`
+- `cobra.datos.a_listas`
+- `cobra.datos.de_listas`
+
+### Exportaciones públicas (alias Cobra estables)
+
+| Alias Cobra | Módulo runtime trazable |
+|---|---|
+| `cobra.datos.filtrar` | `src/pcobra/standard_library/datos.py` |
+| `cobra.datos.seleccionar_columnas` | `src/pcobra/standard_library/datos.py` |
+| `cobra.datos.a_listas` | `src/pcobra/standard_library/datos.py` |
+| `cobra.datos.de_listas` | `src/pcobra/standard_library/datos.py` |
+
+### Cobertura por función
+
+| Función | Backend | Nivel |
+|---|---|---|
+| `cobra.datos.filtrar` | `python` | `full` |
+| `cobra.datos.filtrar` | `javascript` | `partial` |
+| `cobra.datos.seleccionar_columnas` | `python` | `full` |
+| `cobra.datos.seleccionar_columnas` | `javascript` | `partial` |
+| `cobra.datos.a_listas` | `python` | `full` |
+| `cobra.datos.a_listas` | `javascript` | `partial` |
+| `cobra.datos.de_listas` | `python` | `full` |
+| `cobra.datos.de_listas` | `javascript` | `partial` |
+
+## `cobra.web`
+
+- **Backend primario:** `javascript`
+- **Fallback permitido:** `python`
+- **Mapeo `standard_library`:** -
+- **Mapeo `corelibs`:** `src/pcobra/corelibs/red.py`
+- **Mapeo `core/nativos`:** `src/pcobra/core/nativos/red.js`
+
+### API pública
+
+- `cobra.web.obtener_url`
+- `cobra.web.enviar_post`
+- `cobra.web.descargar_archivo`
+- `cobra.web.obtener_url_texto`
+
+### Exportaciones públicas (alias Cobra estables)
+
+| Alias Cobra | Módulo runtime trazable |
+|---|---|
+| `cobra.web.obtener_url` | `src/pcobra/corelibs/red.py` |
+| `cobra.web.enviar_post` | `src/pcobra/corelibs/red.py` |
+| `cobra.web.descargar_archivo` | `src/pcobra/corelibs/red.py` |
+| `cobra.web.obtener_url_texto` | `src/pcobra/corelibs/red.py` |
+
+### Cobertura por función
+
+| Función | Backend | Nivel |
+|---|---|---|
+| `cobra.web.obtener_url` | `javascript` | `partial` |
+| `cobra.web.obtener_url` | `python` | `full` |
+| `cobra.web.enviar_post` | `javascript` | `partial` |
+| `cobra.web.enviar_post` | `python` | `full` |
+| `cobra.web.descargar_archivo` | `javascript` | `partial` |
+| `cobra.web.descargar_archivo` | `python` | `full` |
+| `cobra.web.obtener_url_texto` | `javascript` | `partial` |
+| `cobra.web.obtener_url_texto` | `python` | `full` |
+
+## `cobra.system`
+
+- **Backend primario:** `python`
+- **Fallback permitido:** `rust, javascript`
+- **Mapeo `standard_library`:** `src/pcobra/standard_library/archivo.py`
+- **Mapeo `corelibs`:** `src/pcobra/corelibs/sistema.py`, `src/pcobra/corelibs/tiempo.py`
+- **Mapeo `core/nativos`:** `src/pcobra/core/nativos/sistema.js`
+
+### API pública
+
+- `cobra.system.leer`
+- `cobra.system.escribir`
+- `cobra.system.adjuntar`
+- `cobra.system.existe`
+- `cobra.system.ejecutar`
+- `cobra.system.ejecutar_comando_async`
+- `cobra.system.obtener_env`
+- `cobra.system.listar_dir`
+- `cobra.system.ahora`
+- `cobra.system.formatear`
+- `cobra.system.dormir`
+
+### Exportaciones públicas (alias Cobra estables)
+
+| Alias Cobra | Módulo runtime trazable |
+|---|---|
+| `cobra.system.leer` | `src/pcobra/standard_library/archivo.py` |
+| `cobra.system.escribir` | `src/pcobra/standard_library/archivo.py` |
+| `cobra.system.adjuntar` | `src/pcobra/standard_library/archivo.py` |
+| `cobra.system.existe` | `src/pcobra/standard_library/archivo.py` |
+| `cobra.system.ejecutar` | `src/pcobra/corelibs/sistema.py` |
+| `cobra.system.ejecutar_comando_async` | `src/pcobra/corelibs/sistema.py` |
+| `cobra.system.obtener_env` | `src/pcobra/corelibs/sistema.py` |
+| `cobra.system.listar_dir` | `src/pcobra/corelibs/sistema.py` |
+| `cobra.system.ahora` | `src/pcobra/corelibs/tiempo.py` |
+| `cobra.system.formatear` | `src/pcobra/corelibs/tiempo.py` |
+| `cobra.system.dormir` | `src/pcobra/corelibs/tiempo.py` |
+
+### Cobertura por función
+
+| Función | Backend | Nivel |
+|---|---|---|
+| `cobra.system.leer` | `python` | `full` |
+| `cobra.system.leer` | `rust` | `partial` |
+| `cobra.system.leer` | `javascript` | `partial` |
+| `cobra.system.escribir` | `python` | `full` |
+| `cobra.system.escribir` | `rust` | `partial` |
+| `cobra.system.escribir` | `javascript` | `partial` |
+| `cobra.system.adjuntar` | `python` | `full` |
+| `cobra.system.adjuntar` | `rust` | `partial` |
+| `cobra.system.adjuntar` | `javascript` | `partial` |
+| `cobra.system.existe` | `python` | `full` |
+| `cobra.system.existe` | `rust` | `partial` |
+| `cobra.system.existe` | `javascript` | `partial` |
+| `cobra.system.ejecutar` | `python` | `full` |
+| `cobra.system.ejecutar` | `rust` | `partial` |
+| `cobra.system.ejecutar` | `javascript` | `partial` |
+| `cobra.system.ejecutar_comando_async` | `python` | `full` |
+| `cobra.system.ejecutar_comando_async` | `rust` | `partial` |
+| `cobra.system.ejecutar_comando_async` | `javascript` | `partial` |
+| `cobra.system.obtener_env` | `python` | `full` |
+| `cobra.system.obtener_env` | `rust` | `partial` |
+| `cobra.system.obtener_env` | `javascript` | `partial` |
+| `cobra.system.listar_dir` | `python` | `full` |
+| `cobra.system.listar_dir` | `rust` | `partial` |
+| `cobra.system.listar_dir` | `javascript` | `partial` |
+| `cobra.system.ahora` | `python` | `full` |
+| `cobra.system.ahora` | `rust` | `partial` |
+| `cobra.system.ahora` | `javascript` | `partial` |
+| `cobra.system.formatear` | `python` | `full` |
+| `cobra.system.formatear` | `rust` | `partial` |
+| `cobra.system.formatear` | `javascript` | `partial` |
+| `cobra.system.dormir` | `python` | `full` |
+| `cobra.system.dormir` | `rust` | `partial` |
+| `cobra.system.dormir` | `javascript` | `partial` |

--- a/src/pcobra/standard_library/archivo.py
+++ b/src/pcobra/standard_library/archivo.py
@@ -75,7 +75,6 @@ PUBLIC_API_ARCHIVO: tuple[str, ...] = (
     "leer",
     "escribir",
     "adjuntar",
-    "anexar",
     "existe",
     "eliminar",
     "leer_lineas",

--- a/src/pcobra/standard_library/texto.py
+++ b/src/pcobra/standard_library/texto.py
@@ -1,32 +1,12 @@
 """Funciones de texto de alto nivel basadas en ``pcobra.corelibs.texto``.
 
 Contrato de exportación: ``usar`` en REPL consume ``__all__`` como lista
-de API pública invocable de este módulo.
+pública invocable de este módulo.
 
 Ejemplo rápido::
 
     import standard_library.texto as texto
-
     texto.quitar_prefijo("🧪Prueba", "🧪")  # -> "Prueba"
-    texto.centrar_texto("cobra", 10, "-")    # -> "---cobra--"
-    texto.dividir_lineas("uno\r\ndos\n", conservar_delimitadores=True)
-    # -> ["uno\r\n", "dos\n"
-    "capitalizar",
-    "titulo",
-    "invertir",
-    "concatenar",
-    "quitar_espacios",
-    "dividir",
-    "unir",
-    "reemplazar",
-    "empieza_con",
-    "termina_con",
-    "incluye",
-    "rellenar_izquierda",
-    "rellenar_derecha",
-    "normalizar_unicode",
-    "lineas_no_vacias",]
-    texto.subcadena_despues("ruta/archivo.txt", "/")  # -> "archivo.txt"
 """
 
 from __future__ import annotations


### PR DESCRIPTION
### Motivation
- Alinear la superficie pública de la stdlib con los nombres canónicos Cobra y eliminar alias/backends expuestos por error en `archivo.py`.
- Normalizar la cabecera/documentación de `texto.py` para mantener consistencia en español y evitar texto residual no contractual.
- Actualizar la representación documental del contrato público (`docs/_generated/*`, `docs/standard_library/*`) para que refleje el estado real del código.

### Description
- Eliminé el alias público no canónico `anexar` de `src/pcobra/standard_library/archivo.py::__all__` dejando el nombre Cobra canónico `adjuntar` como la única exportación pública relacionada; la implementación backend sigue accesible internamente mediante la función delegada.
- Limpié y normalicé la cabecera/docstring de `src/pcobra/standard_library/texto.py` para que el ejemplo y la descripción estén consistentes y en español.
- Regeneré la matriz contractual y la documentación asociada ejecutando el generador de contrato para actualizar `docs/_generated/stdlib_contract_matrix.{md,json}` y `docs/standard_library/matriz_stdlib_unificada.md` según la superficie pública actual.

### Testing
- Ejecuté `python -m py_compile` sobre los módulos objetivos de `src/pcobra/standard_library/` y la comprobación de byte-compile pasó correctamente.
- Ejecuté `python scripts/generar_contrato_stdlib.py` para regenerar la matriz contractual y la generación completó sin error.
- Ejecuté `python scripts/ci/validate_stdlib_function_coverage.py` y falló por un problema de contrato preexistente no introducido por este cambio: `cobra.web.obtener_url_texto.python: marcado full pero no aparece en runtime_api_matrix.available_api_by_backend.global`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feed9571588327a523b5fcdefa139e)