### PR TITLE
Endurecer superficie pública de holobit y bloqueo de fugas SDK

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -39,7 +39,14 @@ NOMBRES_CONSTANTES_PUBLICAS_CANONICAS = frozenset({"PI", "E", "TAU", "INF", "NAN
 NOMBRES_BACKEND_INTERNOS = frozenset(
     {"sys", "os", "importlib", "pcobra", "cobra", "core"}
 )
-PREFIJOS_MODULOS_BACKEND_INTERNOS = ("sys", "os", "importlib", "pcobra", "cobra")
+PREFIJOS_MODULOS_BACKEND_INTERNOS = (
+    "sys",
+    "os",
+    "importlib",
+    "pcobra",
+    "cobra",
+    "holobit_sdk",
+)
 
 
 @dataclass(frozen=True)

--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -36,6 +36,14 @@ def _error_dominio(mensaje: str, *, causa: Exception | None = None) -> ErrorHolo
     return ErrorHolobit(mensaje)
 
 
+def _traducir_error_interno(operacion: str, exc: Exception) -> ErrorHolobit:
+    """Traduce errores internos/SDK a errores Cobra legibles sin fuga de internals."""
+    _ = exc
+    return _error_dominio(
+        f"No se pudo ejecutar la operación '{operacion}' de holobit en runtime Cobra"
+    )
+
+
 class _AdaptadorInternoHolobit:
     """Encapsula acceso al runtime interno de Holobit sin exponer backend."""
 
@@ -96,7 +104,13 @@ def _desde_estructura_cobra(hb: dict[str, Any]) -> Any:
 def crear_holobit(valores: Iterable[Any]) -> dict[str, Any]:
     if valores is None:
         raise TypeError("'valores' no puede ser None")
-    return _a_estructura_cobra(_AdaptadorInternoHolobit.crear_desde_valores(_normalizar_valores(valores)))
+    try:
+        interno = _AdaptadorInternoHolobit.crear_desde_valores(_normalizar_valores(valores))
+    except (TypeError, ValueError):
+        raise
+    except Exception as exc:  # pragma: no cover - defensivo frente al runtime interno
+        raise _traducir_error_interno("crear", exc) from None
+    return _a_estructura_cobra(interno)
 
 
 def validar_holobit(hb: Any) -> bool:
@@ -108,7 +122,12 @@ def validar_holobit(hb: Any) -> bool:
 
 
 def serializar_holobit(hb: dict[str, Any]) -> str:
-    return json.dumps(_a_estructura_cobra(_desde_estructura_cobra(hb)), ensure_ascii=False)
+    try:
+        return json.dumps(_a_estructura_cobra(_desde_estructura_cobra(hb)), ensure_ascii=False)
+    except (TypeError, ValueError):
+        raise
+    except Exception as exc:  # pragma: no cover - defensivo frente al runtime interno
+        raise _traducir_error_interno("serializar", exc) from None
 
 
 def deserializar_holobit(payload: str) -> dict[str, Any]:
@@ -125,7 +144,12 @@ def deserializar_holobit(payload: str) -> dict[str, Any]:
 def proyectar(hb: dict[str, Any], modo: str) -> dict[str, Any]:
     if not isinstance(modo, str):
         raise TypeError("'modo' debe ser texto")
-    interno = _desde_estructura_cobra(hb)
+    try:
+        interno = _desde_estructura_cobra(hb)
+    except (TypeError, ValueError):
+        raise
+    except Exception as exc:  # pragma: no cover - defensivo frente al runtime interno
+        raise _traducir_error_interno("proyectar", exc) from None
     valores = list(interno.valores)
     modo_norm = modo.strip().lower()
     if modo_norm == "2d":
@@ -138,7 +162,12 @@ def proyectar(hb: dict[str, Any], modo: str) -> dict[str, Any]:
 def transformar(hb: dict[str, Any], operacion: str, *parametros: Any) -> dict[str, Any]:
     if not isinstance(operacion, str):
         raise TypeError("'operacion' debe ser texto")
-    valores = list(_desde_estructura_cobra(hb).valores)
+    try:
+        valores = list(_desde_estructura_cobra(hb).valores)
+    except (TypeError, ValueError):
+        raise
+    except Exception as exc:  # pragma: no cover - defensivo frente al runtime interno
+        raise _traducir_error_interno("transformar", exc) from None
     op = operacion.strip().lower()
     if op == "rotar":
         if len(parametros) < 2:
@@ -169,13 +198,23 @@ def graficar(hb: dict[str, Any]) -> str:
 
 
 def combinar(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
-    ha = _desde_estructura_cobra(a)
-    hb = _desde_estructura_cobra(b)
+    try:
+        ha = _desde_estructura_cobra(a)
+        hb = _desde_estructura_cobra(b)
+    except (TypeError, ValueError):
+        raise
+    except Exception as exc:  # pragma: no cover - defensivo frente al runtime interno
+        raise _traducir_error_interno("combinar", exc) from None
     return crear_holobit([*ha.valores, *hb.valores])
 
 
 def medir(hb: dict[str, Any]) -> dict[str, float | int]:
-    interno = _desde_estructura_cobra(hb)
+    try:
+        interno = _desde_estructura_cobra(hb)
+    except (TypeError, ValueError):
+        raise
+    except Exception as exc:  # pragma: no cover - defensivo frente al runtime interno
+        raise _traducir_error_interno("medir", exc) from None
     valores = interno.valores
     magnitud = sum(v * v for v in valores) ** 0.5
     salida = {"dimension": len(valores), "magnitud": float(magnitud)}

--- a/tests/integration/test_usar_public_contract_regression.py
+++ b/tests/integration/test_usar_public_contract_regression.py
@@ -355,3 +355,45 @@ def test_binding_usar_holobit_no_expone_internals_directos(monkeypatch):
     assert "holobit_sdk" not in simbolos
     assert "_to_sdk_holobit" not in simbolos
     assert all("__" not in nombre for nombre in simbolos)
+
+
+def test_sanitizar_exports_publicos_rechaza_objeto_sdk_accidental_en_holobit():
+    mod_holobit = _modulo_holobit_publico_stub()
+
+    class _SDKObjetoAccidental:
+        __module__ = "holobit_sdk.core.holobit"
+
+    mod_holobit.__all__ = [*mod_holobit.__all__, "SDKHolobitAccidental"]
+    mod_holobit.SDKHolobitAccidental = _SDKObjetoAccidental
+
+    mapa, conflictos = core_usar_loader.sanitizar_exports_publicos(mod_holobit, "holobit")
+
+    assert "SDKHolobitAccidental" not in mapa
+    assert any(c["symbol"] == "SDKHolobitAccidental" for c in conflictos)
+    assert any(c["code"] == "backend_module_object" for c in conflictos if c["symbol"] == "SDKHolobitAccidental")
+
+
+def test_usar_holobit_no_filtra_nombres_sdk_accidentales_en_contexto(monkeypatch):
+    mod_holobit = _modulo_holobit_publico_stub()
+    alias_map = {**REPL_COBRA_MODULE_MAP, "holobit": "holobit"}
+
+    class _SDKObjetoAccidental:
+        __module__ = "holobit_sdk.core.holobit"
+
+    mod_holobit.__all__ = [*mod_holobit.__all__, "SDKHolobitAccidental"]
+    mod_holobit.SDKHolobitAccidental = _SDKObjetoAccidental
+
+    monkeypatch.setattr(
+        core_usar_loader,
+        "obtener_modulo_cobra_oficial",
+        lambda nombre: mod_holobit if nombre == "holobit" else (_ for _ in ()).throw(ModuleNotFoundError(nombre)),
+    )
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl(alias_map)
+
+    class _NodoUsar:
+        modulo = "holobit"
+
+    interp.ejecutar_usar(_NodoUsar())
+    assert "SDKHolobitAccidental" not in interp.contextos[-1].values


### PR DESCRIPTION
### Motivation
- Evitar que excepciones públicas o la superficie `usar "holobit"` filtren clases/rutas internas del SDK (`holobit_sdk`) y mantener la API pública canónica limpia.
- Traducir errores internos/SDK a errores de dominio Cobra legibles sin exponer internals.
- Garantizar que el saneamiento de exports rechace objetos backend/SDK accidentalmente exportados.

### Description
- Añadida la función `_traducir_error_interno` y aplicado manejo defensivo en `src/pcobra/corelibs/holobit.py` para traducir excepciones inesperadas en `crear_holobit`, `serializar_holobit`, `proyectar`, `transformar`, `combinar` y `medir` a `ErrorHolobit` con mensajes genéricos de dominio.
- Conservada la API pública canónica (`PUBLIC_API_HOLOBIT` / `__all__`) sin introducir símbolos públicos nuevos ni exponer tipos/funciones internas.
- Endurecida la política de saneamiento en `src/pcobra/core/usar_symbol_policy.py` añadiendo `holobit_sdk` a `PREFIJOS_MODULOS_BACKEND_INTERNOS` para que símbolos cuyo `__module__` pertenezca al SDK sean considerados no exportables.
- Añadidos tests en `tests/integration/test_usar_public_contract_regression.py` que verifican que `sanitizar_exports_publicos` rechaza objetos SDK accidentales y que `usar "holobit"` no inyecta esos nombres en el contexto de ejecución.

### Testing
- Ejecutado `pytest -q tests/integration/test_usar_public_contract_regression.py -k 'holobit and (sdk or sanitizar or runtime)'` tras los cambios y la suite relevante pasó; la primera ejecución falló hasta que se añadió `holobit_sdk` a los prefijos bloqueados, luego la re-ejecución fue verde.
- Resultado final sobre el subconjunto ejecutado: los tests relevantes completaron correctamente (`4 passed, 19 deselected` para la selección indicada).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feeff5bff48327a3afdca953bda2ed)