### PR TITLE
Harden public backend policy across CLI and GUI runtime

### DIFF
--- a/src/pcobra/cobra/cli/target_policies.py
+++ b/src/pcobra/cobra/cli/target_policies.py
@@ -55,6 +55,11 @@ def _internal_compat_bindings():
 ACCEPTED_TARGET_ALIASES: tuple[tuple[str, str], ...] = ()
 
 
+OFFICIAL_PUBLIC_BACKENDS = require_exact_official_targets(
+    PUBLIC_BACKENDS,
+    context="pcobra.cobra.cli.target_policies.OFFICIAL_PUBLIC_BACKENDS",
+)
+
 def accepted_target_aliases_examples_text() -> str:
     """No existen aliases aceptados en la superficie pública actual."""
     return "sin aliases públicos"
@@ -69,6 +74,10 @@ OFFICIAL_TRANSPILATION_TARGETS = require_exact_official_targets(
 # Targets oficiales con tooling oficial de ejecución en contenedor/sandbox Docker.
 OFFICIAL_RUNTIME_TARGETS = target_cli_choices(
     tuple(target for target in OFFICIAL_RUNTIME_BACKENDS if target in OFFICIAL_TRANSPILATION_TARGETS)
+)
+require_exact_official_targets(
+    OFFICIAL_RUNTIME_BACKENDS,
+    context="pcobra.cobra.cli.target_policies.OFFICIAL_RUNTIME_BACKENDS",
 )
 
 # Targets best-effort conservados fuera del contrato oficial de runtime.
@@ -196,10 +205,10 @@ _validate_runtime_categories_contract()
 
 def _validate_public_routes_contract() -> None:
     """Bloquea inicialización si las rutas públicas se salen de PUBLIC_BACKENDS."""
-    if OFFICIAL_TRANSPILATION_TARGETS != PUBLIC_BACKENDS:
+    if OFFICIAL_TRANSPILATION_TARGETS != OFFICIAL_PUBLIC_BACKENDS:
         raise RuntimeError(
             "OFFICIAL_TRANSPILATION_TARGETS debe ser exactamente PUBLIC_BACKENDS "
-            f"en rutas públicas. official={OFFICIAL_TRANSPILATION_TARGETS}; public={PUBLIC_BACKENDS}"
+            f"en rutas públicas. official={OFFICIAL_TRANSPILATION_TARGETS}; public={OFFICIAL_PUBLIC_BACKENDS}"
         )
 
     for route_name, route_targets in (
@@ -209,7 +218,7 @@ def _validate_public_routes_contract() -> None:
         ("SDK_COMPATIBLE_TARGETS", SDK_COMPATIBLE_TARGETS),
     ):
         out_of_contract = tuple(
-            target for target in route_targets if target not in PUBLIC_BACKENDS
+            target for target in route_targets if target not in OFFICIAL_PUBLIC_BACKENDS
         )
         if out_of_contract:
             raise RuntimeError(

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -8,6 +8,8 @@ from contextlib import redirect_stderr, redirect_stdout
 from functools import lru_cache
 from typing import Any
 
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+
 
 @lru_cache(maxsize=1)
 def require_gui_dependencies() -> dict[str, Any]:
@@ -140,8 +142,14 @@ def formatear_error(
 
 
 def gui_target_choices() -> tuple[str, ...]:
-    """Devuelve targets canónicos visibles en GUI preservando el orden oficial."""
+    """Devuelve targets públicos canónicos visibles en GUI preservando el orden oficial."""
     deps = require_gui_dependencies()
+    official_targets = tuple(deps["OFFICIAL_TARGETS"])
+    if official_targets != PUBLIC_BACKENDS:
+        raise RuntimeError(
+            "Contrato público inválido en GUI: OFFICIAL_TARGETS debe coincidir con PUBLIC_BACKENDS. "
+            f"official={official_targets}; public={PUBLIC_BACKENDS}"
+        )
     return deps["target_cli_choices"](
-        set(deps["OFFICIAL_TARGETS"]) & set(deps["TRANSPILERS"])
+        set(PUBLIC_BACKENDS) & set(deps["TRANSPILERS"])
     )


### PR DESCRIPTION
### Motivation
- Asegurar que la superficie pública (CLI/GUI) solo exponga los backends canónicos `python`, `javascript` y `rust` y evitar importación/visibilidad automática de implementaciones legacy.
- Evitar desincronías entre constantes como `PUBLIC_BACKENDS`, `OFFICIAL_TARGETS` y rutas públicas que puedan promocionar targets legacy por error.

### Description
- Añadido `OFFICIAL_PUBLIC_BACKENDS` y validación explícita con `require_exact_official_targets` en `src/pcobra/cobra/cli/target_policies.py` para anclar las rutas públicas al canon `PUBLIC_BACKENDS`.
- Añadida validación fuerte de `OFFICIAL_RUNTIME_BACKENDS` con `require_exact_official_targets` y actualizado `_validate_public_routes_contract` para comparar rutas públicas contra `OFFICIAL_PUBLIC_BACKENDS` en `target_policies.py`.
- En `src/pcobra/gui/runtime.py` se importa `PUBLIC_BACKENDS` y se añade una comprobación que falla pronto si `OFFICIAL_TARGETS` diverge de `PUBLIC_BACKENDS`, además la GUI ahora construye choices usando exclusivamente `PUBLIC_BACKENDS` intersectado con los transpilers disponibles.
- Mantengo la carga diferida y la ruta de compatibilidad legacy (módulos `internal_compat` / `transpilers.transpiler.legacy`) sin imports eager en superficies públicas para preservar compatibilidad interna sin promover legacy públicamente.

### Testing
- Ejecutado `python -m compileall -q src/pcobra/cobra/cli/target_policies.py src/pcobra/gui/runtime.py` y la compilación fue exitosa. 
- No se ejecutaron tests automatizados adicionales en este cambio; no se detectaron errores de importación estática tras las modificaciones.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef1b1a2108327b8752af91248dc87)