### PR TITLE
Alinear runtime Docker oficial a python/javascript/rust

### DIFF
--- a/docs/compatibility/holobit-sdk.md
+++ b/docs/compatibility/holobit-sdk.md
@@ -33,9 +33,10 @@ Todos los targets oficiales mantienen hooks canónicos `cobra_*` para Holobit. E
 
 ### Categorías runtime oficiales (sin inflar compatibilidad)
 
-- **Runtime oficial verificable**: `python`, `rust`, `javascript`, `cpp`.
+- **Runtime oficial verificable (incluye Docker oficial)**: `python`, `rust`, `javascript`.
 - **Runtime best-effort no público**: `go`, `java`.
 - **Solo transpilación**: `wasm`, `asm`.
+- **Legacy/internal sin runtime oficial público**: `cpp`.
 - **SDK full**: solo `python` (el resto permanece en `partial` o capacidades puntuales `none` según feature).
 
 ---

--- a/docs/lenguajes_soportados.rst
+++ b/docs/lenguajes_soportados.rst
@@ -32,9 +32,10 @@ Capacidades públicas por backend
 Interpretación oficial:
 
 - ``python`` es el único backend con compatibilidad SDK completa y estado Holobit ``full``.
-- ``rust``, ``javascript`` y ``cpp`` tienen runtime oficial verificable y adaptador Holobit mantenido por el proyecto, pero siguen en estado contractual ``partial``.
-- ``go`` y ``java`` conservan runtime best-effort no público.
-- ``wasm`` y ``asm`` son backends oficiales de salida orientados a transpilación, no a runtime oficial público.
+- ``rust`` y ``javascript`` tienen runtime oficial verificable y adaptador Holobit mantenido por el proyecto, pero siguen en estado contractual ``partial``.
+- ``go`` y ``java`` conservan runtime best-effort no público (sin runtime Docker oficial).
+- ``wasm`` y ``asm`` son backends oficiales de salida orientados a transpilación, no a runtime oficial público ni Docker oficial.
+- ``cpp`` permanece como backend legacy/internal sin runtime Docker oficial público.
 
 Transpilación inversa (feature independiente)
 ---------------------------------------------

--- a/src/pcobra/core/sandbox.py
+++ b/src/pcobra/core/sandbox.py
@@ -51,10 +51,58 @@ MAX_CONTAINER_OUTPUT_BYTES = 8 * 1024
 CONTAINER_IMAGE_BY_BACKEND = {
     "python": "cobra-python-sandbox",
     "javascript": "cobra-js-sandbox",
-    "cpp": "cobra-cpp-sandbox",
     "rust": "cobra-rust-sandbox",
 }
 OFFICIAL_CONTAINER_BACKENDS = tuple(CONTAINER_IMAGE_BY_BACKEND)
+UNOFFICIAL_BEST_EFFORT_BACKENDS = ("go", "java")
+UNOFFICIAL_TRANSPILATION_ONLY_BACKENDS = ("wasm", "asm")
+
+
+def _validate_container_runtime_policy_contract() -> None:
+    """Valida consistencia entre la política Docker y las constantes de CLI/runtime."""
+
+    from pcobra.cobra.cli.target_policies import OFFICIAL_RUNTIME_TARGETS
+    from pcobra.cobra.transpilers.compatibility_matrix import (
+        BEST_EFFORT_RUNTIME_BACKENDS,
+        OFFICIAL_RUNTIME_BACKENDS,
+        TRANSPILATION_ONLY_BACKENDS,
+    )
+
+    expected_official = tuple(OFFICIAL_RUNTIME_TARGETS)
+    if tuple(OFFICIAL_RUNTIME_BACKENDS) != expected_official:
+        raise RuntimeError(
+            "Desalineación de política runtime: "
+            f"OFFICIAL_RUNTIME_BACKENDS={tuple(OFFICIAL_RUNTIME_BACKENDS)} "
+            f"!= OFFICIAL_RUNTIME_TARGETS={expected_official}"
+        )
+
+    if OFFICIAL_CONTAINER_BACKENDS != expected_official:
+        raise RuntimeError(
+            "Desalineación de política Docker: "
+            f"CONTAINER_IMAGE_BY_BACKEND={OFFICIAL_CONTAINER_BACKENDS} "
+            f"!= OFFICIAL_RUNTIME_TARGETS={expected_official}"
+        )
+
+    matrix_best_effort = tuple(BEST_EFFORT_RUNTIME_BACKENDS)
+    if matrix_best_effort and matrix_best_effort != UNOFFICIAL_BEST_EFFORT_BACKENDS:
+        raise RuntimeError(
+            "Desalineación de best-effort runtime: "
+            f"matrix={matrix_best_effort} != sandbox={UNOFFICIAL_BEST_EFFORT_BACKENDS}"
+        )
+
+    matrix_transpilation_only = tuple(TRANSPILATION_ONLY_BACKENDS)
+    if (
+        matrix_transpilation_only
+        and matrix_transpilation_only != UNOFFICIAL_TRANSPILATION_ONLY_BACKENDS
+    ):
+        raise RuntimeError(
+            "Desalineación de targets solo transpilación: "
+            f"matrix={matrix_transpilation_only} "
+            f"!= sandbox={UNOFFICIAL_TRANSPILATION_ONLY_BACKENDS}"
+        )
+
+
+_validate_container_runtime_policy_contract()
 
 _ORIGINAL_IMPORT = builtins.__import__
 _SANDBOX_IMPORT_ALLOWLIST = {
@@ -800,12 +848,11 @@ def ejecutar_en_contenedor(
 ) -> str:
     """Ejecuta ``codigo`` dentro de un contenedor Docker según ``backend``.
 
-    Los backends soportados son ``python``, ``javascript``, ``cpp`` y ``rust``.
-    Son los mismos backends que hoy forman la matriz pública de runtime oficial
-    verificable. ``go`` y ``java`` siguen siendo targets oficiales de salida
-    con runtime best-effort, pero quedan fuera del runtime Docker oficial.
-    ``wasm`` y ``asm`` son targets oficiales solo de transpilación y tampoco
-    tienen runtime Docker oficial. Cada backend utiliza una imagen específica
+    Los runtimes Docker oficiales soportados son ``python``, ``javascript`` y ``rust``.
+    ``go`` y ``java`` se mantienen como targets no oficiales de runtime
+    best-effort (sin soporte Docker oficial). ``wasm`` y ``asm`` se mantienen
+    como targets no oficiales solo de transpilación (sin soporte Docker oficial).
+    Cada backend oficial utiliza una imagen específica
     que debe estar construida previamente. ``timeout`` define el límite de
     tiempo en segundos para la ejecución del contenedor o ``None`` para
     desactivar el límite.
@@ -818,14 +865,14 @@ def ejecutar_en_contenedor(
     """
 
     if backend not in CONTAINER_IMAGE_BY_BACKEND:
-        if backend in {"go", "java"}:
+        if backend in set(UNOFFICIAL_BEST_EFFORT_BACKENDS):
             raise ValueError(
                 "Backend con runtime best-effort pero sin runtime Docker oficial: "
                 f"{backend}. pCobra puede generar código para ese target y conservarlo "
                 "como backend best-effort, pero no lo expone como ejecución real oficial "
                 f"en contenedor. Runtimes Docker oficiales: {', '.join(OFFICIAL_CONTAINER_BACKENDS)}."
             )
-        if backend in {"wasm", "asm"}:
+        if backend in set(UNOFFICIAL_TRANSPILATION_ONLY_BACKENDS):
             raise ValueError(
                 "Backend oficial solo de transpilación, sin runtime Docker oficial: "
                 f"{backend}. pCobra puede generar código para ese target, "

--- a/tests/unit/test_target_execution_policy.py
+++ b/tests/unit/test_target_execution_policy.py
@@ -32,7 +32,7 @@ def test_resolve_docker_backend_rechaza_targets_oficiales_solo_transpilacion(tar
 
 def test_verify_runtime_es_subconjunto_explicito_del_runtime_oficial():
     assert set(VERIFICATION_EXECUTABLE_TARGETS).issubset(set(DOCKER_EXECUTABLE_TARGETS))
-    assert VERIFICATION_EXECUTABLE_TARGETS == ("python", "rust", "javascript", "cpp")
+    assert VERIFICATION_EXECUTABLE_TARGETS == ("python", "javascript", "rust")
 
 
 def test_mensaje_publico_de_runtime_no_promete_sdk_completo_fuera_de_python():


### PR DESCRIPTION
### Motivation
- Corregir docstrings y mensajes de error para que la política oficial de runtime Docker quede explícita y limitada a `python`, `javascript` y `rust`.
- Mantener manejo explícito y no ambiguo de `go`/`java` como runtimes best-effort y de `wasm`/`asm` como backends solo de transpilación.
- Detectar y prevenir desalineaciones entre la configuración local de imágenes Docker y las constantes canónicas usadas por la CLI/matriz de compatibilidad.

### Description
- Modifiqué `CONTAINER_IMAGE_BY_BACKEND` en `src/pcobra/core/sandbox.py` para exponer solo `python`, `javascript` y `rust` como `OFFICIAL_CONTAINER_BACKENDS` y eliminé la entrada `cpp` de las imágenes oficiales.
- Añadí `UNOFFICIAL_BEST_EFFORT_BACKENDS` y `UNOFFICIAL_TRANSPILATION_ONLY_BACKENDS` y reescribí los mensajes/docstring de `ejecutar_en_contenedor` para referirse explícitamente a esos grupos cuando corresponda.
- Implementé `_validate_container_runtime_policy_contract()` en `sandbox.py` y la ejecuto al importar el módulo para validar consistencia contra `OFFICIAL_RUNTIME_TARGETS`, `OFFICIAL_RUNTIME_BACKENDS`, `BEST_EFFORT_RUNTIME_BACKENDS` y `TRANSPILATION_ONLY_BACKENDS` provenientes de la lógica central de targets.
- Actualicé documentación en `docs/lenguajes_soportados.rst` y `docs/compatibility/holobit-sdk.md` para reflejar que Docker oficial es solo `python/javascript/rust` y que `cpp` se clasifica como legacy/internal sin runtime Docker público; además ajusté el test afectado en `tests/unit/test_target_execution_policy.py`.

### Testing
- Ejecuté el test modificado con `python -m pytest -q tests/unit/test_target_execution_policy.py`, que pasó con resultado `3 passed, 1 skipped`.
- No se ejecutó la batería completa de tests en este parche; la validación fue focalizada en la política de ejecución y en la coherencia de mensajes/constantes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef2dd25b88327a7eb14c6b9a382df)