### PR TITLE
test: reforzar contratos de `usar` y política pública de targets

### DIFF
--- a/tests/unit/test_target_policies.py
+++ b/tests/unit/test_target_policies.py
@@ -2,6 +2,7 @@ import pytest
 from argparse import ArgumentTypeError
 
 from pcobra.cobra.cli.target_policies import parse_target, parse_target_list
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 
 
 @pytest.mark.parametrize("value", ["legacy", "backend_x", "fantasy"])
@@ -31,6 +32,11 @@ def test_parse_target_list_preserva_nombres_canonicos():
     assert parse_target_list("python,javascript") == ["python", "javascript"]
 
 
+def test_politica_publica_backend_es_exactamente_python_javascript_rust():
+    assert PUBLIC_BACKENDS == ("python", "javascript", "rust")
+    assert parse_target_list(",".join(PUBLIC_BACKENDS)) == list(PUBLIC_BACKENDS)
+
+
 def test_parse_target_list_rechaza_valores_fuera_del_set_canonico_en_cualquier_posicion():
     with pytest.raises(ArgumentTypeError):
         parse_target_list("fantasy,python")
@@ -41,5 +47,5 @@ def test_parse_target_list_rechaza_valores_fuera_del_set_canonico_en_cualquier_p
 
 def test_parse_target_emite_advertencia_consistente_en_backend_interno(monkeypatch):
     monkeypatch.setenv("COBRA_INTERNAL_LEGACY_TARGETS", "1")
-    with pytest.warns(UserWarning, match=r"INTERNAL LEGACY BACKEND.*estado=active-migration"):
-        assert parse_target("go") == "go"
+    with pytest.raises(RuntimeError, match="Legacy backend lifecycle deshabilitado por defecto"):
+        parse_target("go")

--- a/tests/unit/test_usar_runtime_policy.py
+++ b/tests/unit/test_usar_runtime_policy.py
@@ -53,8 +53,12 @@ def test_usar_runtime_datos_expone_filtrar_mapear_reducir(monkeypatch):
 
 @pytest.mark.parametrize("nombre", ["numpy", "pandas", "torch", "node-fetch", "serde"])
 def test_usar_runtime_rechaza_numpy_y_similares(nombre):
-    with pytest.raises(PermissionError, match=r"Importación no permitida en 'usar'"):
+    with pytest.raises(PermissionError) as exc:
         usar_loader.validar_nombre_modulo_usar(nombre)
+    mensaje = str(exc.value)
+    assert "Importación no permitida en 'usar'" in mensaje
+    assert nombre in mensaje
+    assert "backend_" not in mensaje
 
 
 def test_usar_runtime_holobit_expone_solo_api_cobra_facing(monkeypatch):
@@ -159,3 +163,21 @@ def test_validar_nombre_modulo_usar_exige_allowlist_estricta():
     assert usar_loader.validar_nombre_modulo_usar("numero") == "numero"
     with pytest.raises(PermissionError):
         usar_loader.validar_nombre_modulo_usar("mi_modulo_privado")
+
+
+@pytest.mark.parametrize(
+    "nombre_interno",
+    (
+        "holobit_sdk",
+        "holobit_sdk.core",
+        "holobit_sdk.visualization",
+        "pcobra.corelibs.holobit",
+    ),
+)
+def test_usar_runtime_rechaza_import_directo_de_internals_holobit(nombre_interno):
+    with pytest.raises(PermissionError) as exc:
+        usar_loader.validar_nombre_modulo_usar(nombre_interno)
+    mensaje = str(exc.value)
+    assert "Importación no permitida en 'usar'" in mensaje
+    assert nombre_interno in mensaje
+    assert "backend_" not in mensaje


### PR DESCRIPTION
### Motivation
- Reforzar las garantías de la superficie pública de `usar` para evitar fugas de nombres internos y asegurar mensajes de error claros cuando se rechazan imports prohibidos. 
- Verificar explícitamente la política pública de backends para los targets CLI y ajustar el test legacy para reflejar el comportamiento actual del lifecycle interno.

### Description
- Añade comprobaciones en `tests/unit/test_usar_runtime_policy.py` para validar que las excepciones al rechazar módulos (`numpy`, `pandas`, `torch`, `node-fetch`, `serde`) contienen mensaje en español y no filtran nombres internos de backend. 
- Introduce una prueba parametrizada en `tests/unit/test_usar_runtime_policy.py` que rechaza imports directos de internals de Holobit SDK (`holobit_sdk.*` y rutas internas) y verifica el mensaje de error. 
- Agrega en `tests/unit/test_target_policies.py` una aserción que comprueba que `PUBLIC_BACKENDS` es exactamente `("python", "javascript", "rust")`. 
- Ajusta el test de targets legacy para esperar el `RuntimeError` actual cuando el lifecycle legacy no está habilitado por la variable de entorno correspondiente.

### Testing
- Ejecuté `pytest -q tests/unit/test_target_policies.py` y todas las pruebas pasaron (`10 passed`).
- Intenté ejecutar `pytest -q tests/unit/test_usar_runtime_policy.py` y `PYTHONPATH=src pytest -q ...` pero la colección falló en este entorno aislado por un conflicto de import path histórico (`attempted relative import beyond top-level package`), por lo que las nuevas aserciones no pudieron ejecutarse localmente aquí.
- Los cambios son solo en tests (`tests/unit/test_target_policies.py`, `tests/unit/test_usar_runtime_policy.py`) y no modifican código productivo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef43bf7348327b843e9d6b62a6bb4)