### PR TITLE
Fortalece validación canónica de `usar` y trazabilidad de rechazos

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -71,6 +71,8 @@ from .cobra_config import (
 )
 from ..cobra.usar_policy import (
     REPL_COBRA_MODULE_MAP,
+    USAR_COBRA_ALLOWLIST,
+    USAR_COBRA_PUBLIC_MODULES,
     USAR_COBRA_FACING_MODULE_FLAGS,
 )
 from .resource_limits import (
@@ -91,8 +93,17 @@ MODULES_PATH = _DEFAULT_MODULES_PATH
 REPL_USAR_EXTERNAL_MODULE_ERROR = (
     "usar_error[modulo_no_permitido]: módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)"
 )
+USAR_DIRECT_BACKEND_IMPORT_ERROR = (
+    "usar_error[backend_import_directo]: import directo de backend no permitido en usar"
+)
 USAR_NON_CANONICAL_MODULE_ERROR = (
     "usar_error[modulo_no_canonico]: el módulo solicitado no es canónico; use el alias oficial Cobra"
+)
+USAR_NON_PUBLIC_MODULE_ERROR = (
+    "usar_error[modulo_fuera_catalogo_publico]: el módulo solicitado está fuera de USAR_COBRA_PUBLIC_MODULES"
+)
+USAR_NON_FACING_MODULE_ERROR = (
+    "usar_error[modulo_no_cobra_facing]: el módulo solicitado no está marcado como Cobra-facing"
 )
 USAR_INVALID_EXPORT_ERROR = "usar_error[export_invalido]"
 USAR_SYMBOL_CONFLICT_ERROR = "usar_error[conflicto_simbolo]"
@@ -1852,25 +1863,34 @@ class InterpretadorCobra:
         from .usar_loader import obtener_modulo, sanitizar_exports_publicos
 
         def _resolver_carga_modulo_usar(nombre_modulo: str):
-            """Resuelve solo módulos canónicos Cobra; ``usar`` nunca hace import dinámico externo."""
+            """Resuelve módulos `usar` únicamente desde el catálogo canónico Cobra."""
             es_repl_estricto = self._repl_usar_alias_map is not None
             mapa_repl = self._repl_usar_alias_map or REPL_COBRA_MODULE_MAP
-            modulo_canonico = mapa_repl.get(nombre_modulo)
-            es_modulo_oficial_cobra = modulo_canonico is not None
 
-            if not es_modulo_oficial_cobra:
+            if nombre_modulo not in USAR_COBRA_ALLOWLIST:
+                # Trazabilidad explícita para intentos de importar módulos de backend directamente.
                 if nombre_modulo in mapa_repl.values():
                     raise PermissionError(USAR_NON_CANONICAL_MODULE_ERROR)
-                raise PermissionError(REPL_USAR_EXTERNAL_MODULE_ERROR)
+                if "." in nombre_modulo or nombre_modulo.startswith("pcobra"):
+                    raise PermissionError(USAR_DIRECT_BACKEND_IMPORT_ERROR)
+                raise PermissionError(USAR_NON_PUBLIC_MODULE_ERROR)
+
+            if nombre_modulo not in USAR_COBRA_PUBLIC_MODULES:
+                raise PermissionError(USAR_NON_PUBLIC_MODULE_ERROR)
+
+            modulo_canonico = mapa_repl.get(nombre_modulo)
+            if modulo_canonico is None:
+                raise PermissionError(USAR_NON_CANONICAL_MODULE_ERROR)
+
+            if modulo_canonico not in USAR_COBRA_ALLOWLIST:
+                raise PermissionError(USAR_NON_PUBLIC_MODULE_ERROR)
+
             if not USAR_COBRA_FACING_MODULE_FLAGS.get(modulo_canonico, False):
-                raise PermissionError(
-                    "Módulo no permitido en 'usar': "
-                    f"'{nombre_modulo}' no está marcado como Cobra-facing."
-                )
+                raise PermissionError(f"{USAR_NON_FACING_MODULE_ERROR}: '{nombre_modulo}'")
 
             modulo = obtener_modulo(modulo_canonico)
 
-            return modulo, es_repl_estricto, es_modulo_oficial_cobra
+            return modulo, es_repl_estricto, True
 
         try:
             nombre_modulo = nodo.modulo


### PR DESCRIPTION
### Motivation
- Asegurar que toda resolución de la instrucción `usar` pase por el catálogo canónico `USAR_COBRA_ALLOWLIST` para evitar import dinámico externo accidental.
- Rechazar explícitamente cualquier nombre fuera de `USAR_COBRA_PUBLIC_MODULES` aunque exista en `PYTHONPATH` o esté instalado como módulo de backend.
- Forzar la validación de que un módulo es “Cobra-facing” (`USAR_COBRA_FACING_MODULE_FLAGS`) antes de cargarlo e inyectar símbolos en el entorno.
- Mantener la política anti-colisión existente para evitar sobreescrituras silenciosas al inyectar símbolos.

### Description
- Se actualiza `src/pcobra/core/interpreter.py` para importar `USAR_COBRA_ALLOWLIST` y `USAR_COBRA_PUBLIC_MODULES` y se añaden constantes de error nuevas (`usar_error[...]`) para trazabilidad de rechazos.
- Se reemplaza la lógica de `_resolver_carga_modulo_usar` para validar en orden: pertenencia a `USAR_COBRA_ALLOWLIST`, pertenencia a `USAR_COBRA_PUBLIC_MODULES`, mapeo canónico en `REPL_COBRA_MODULE_MAP`, y marcado `USAR_COBRA_FACING_MODULE_FLAGS` antes de llamar a `obtener_modulo`.
- Se añade rechazo explícito y trazabilidad para intentos de import directo de backend (nombres con `.` o prefijo `pcobra`) y para módulos no públicos o no-canónicos, emitiendo códigos `usar_error[backend_import_directo]`, `usar_error[modulo_fuera_catalogo_publico]`, `usar_error[modulo_no_canonico]` y `usar_error[modulo_no_cobra_facing]`.
- No se modifica la lógica de detección/gestión de colisiones (`USAR_COLLISION_*`); la comprobación preflight y la inyección atómica sin sobreescritura silenciosa siguen igual en `ejecutar_usar`.

### Testing
- Ejecutado: `pytest -q tests/core/test_superficie_publica_canonica.py` y todos los tests pasaron (`40 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef7abe8a08327b0d1326c89c37f05)