### PR TITLE
Endurecer saneamiento 'usar' en módulos Cobra-facing y añadir pruebas

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -51,6 +51,12 @@ PREFIJOS_MODULOS_BACKEND_INTERNOS = (
 
 @dataclass(frozen=True)
 class PoliticaSaneamientoUsar:
+    """Configuración de saneamiento para ``usar``.
+
+    En módulos Cobra-facing puede habilitarse validación estricta para
+    rechazar cualquier nombre no canónico (en vez de permitirlo con warning).
+    """
+
     validar_nombre_canonico_espanol_en_cobra_facing: bool = False
 
 
@@ -145,14 +151,12 @@ def sanear_simbolo_para_usar(
         return _rechazar(nombre, simbolo, "non_callable_not_canonical_public_constant", "solo se permiten no-callables para constantes públicas explícitas y canónicas", metadata)
 
     if politica_efectiva.validar_nombre_canonico_espanol_en_cobra_facing and modulo_cobra_facing and not _parece_nombre_canonico_espanol(nombre):
-        return ResultadoSaneamientoSimboloUsar(
+        return _rechazar(
             nombre,
             simbolo,
-            False,
             "non_canonical_spanish_name",
-            "símbolo permitido por compatibilidad, pero no cumple nombre canónico español para módulo Cobra-facing",
-            warning=True,
-            metadata=metadata,
+            "modo estricto Cobra-facing: nombres no canónicos no se exportan",
+            metadata,
         )
 
     if not callable(simbolo):

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -1,6 +1,10 @@
 from types import ModuleType
 
-from pcobra.core.usar_symbol_policy import sanear_exportables_para_usar, sanear_simbolo_para_usar
+from pcobra.core.usar_symbol_policy import (
+    PoliticaSaneamientoUsar,
+    sanear_exportables_para_usar,
+    sanear_simbolo_para_usar,
+)
 
 
 def test_rechaza_nombres_prohibidos_explicitos():
@@ -56,7 +60,7 @@ def test_saneamiento_centralizado_aplica_todas_las_reglas():
     permitidos, rechazos, warnings = sanear_exportables_para_usar(simbolos)
 
     assert [nombre for nombre, _ in permitidos] == ["PI", "publica"]
-    assert {r.nombre for r in rechazos} == {"_interno", "append"}
+    assert {r.nombre for r in rechazos.rechazos_duros} == {"_interno", "append"}
     assert [w.nombre for w in warnings] == ["PI"]
 
 
@@ -77,11 +81,71 @@ def test_rechaza_no_callable_que_no_es_constante_publica_canonica():
     assert resultado_ok.warning is True
     assert resultado_ok.codigo == "public_constant"
 
-
-
 def test_rechaza_todos_los_alias_ingleses_prohibidos():
     prohibidos = ("self", "append", "map", "filter", "unwrap", "expect")
     for nombre in prohibidos:
         resultado = sanear_simbolo_para_usar(nombre, lambda: None)
         assert resultado.rechazado is True
         assert resultado.codigo == "explicit_forbidden_name"
+
+
+def test_modo_estricto_cobra_facing_rechaza_nombres_no_canonicos():
+    politica = PoliticaSaneamientoUsar(validar_nombre_canonico_espanol_en_cobra_facing=True)
+
+    resultado = sanear_simbolo_para_usar(
+        "procesar",
+        lambda: None,
+        politica=politica,
+        modulo_cobra_facing=True,
+    )
+
+    assert resultado.rechazado is True
+    assert resultado.codigo == "non_canonical_spanish_name"
+
+
+def test_modo_estricto_cobra_facing_permite_nombres_canonicos():
+    politica = PoliticaSaneamientoUsar(validar_nombre_canonico_espanol_en_cobra_facing=True)
+
+    resultado = sanear_simbolo_para_usar(
+        "procesar_datos",
+        lambda: None,
+        politica=politica,
+        modulo_cobra_facing=True,
+    )
+
+    assert resultado.rechazado is False
+    assert resultado.codigo == "ok"
+
+
+def test_constantes_publicas_canonicas_explicitas_se_permiten():
+    for nombre in ("PI", "E", "TAU", "INF", "NAN"):
+        resultado = sanear_simbolo_para_usar(nombre, 1.0)
+        assert resultado.rechazado is False
+        assert resultado.codigo == "public_constant"
+        assert resultado.warning is True
+
+
+def test_rechazo_estricto_alias_backend_hacia_cobra():
+    prohibidos = ("self", "append", "map", "filter", "unwrap", "expect", "keys", "values", "len", "lower", "upper")
+    for nombre in prohibidos:
+        resultado = sanear_simbolo_para_usar(nombre, lambda: None)
+        assert resultado.rechazado is True
+        assert resultado.codigo == "explicit_forbidden_name"
+
+
+def test_objetos_envueltos_sdk_y_wrapped_se_bloquean_siempre():
+    modulo_sdk = ModuleType("modulo_sdk")
+
+    class WrapperConWrapped:
+        __wrapped__ = modulo_sdk
+
+    class WrapperConSdk:
+        _sdk = modulo_sdk
+
+    r_wrapped = sanear_simbolo_para_usar("wrapper", WrapperConWrapped())
+    r_sdk = sanear_simbolo_para_usar("wrapper_sdk", WrapperConSdk())
+
+    assert r_wrapped.rechazado is True
+    assert r_wrapped.codigo == "backend_module_object"
+    assert r_sdk.rechazado is True
+    assert r_sdk.codigo == "backend_module_object"


### PR DESCRIPTION
### Motivation
- Hacer que en módulos Cobra-facing la superficie `usar` aplique un modo estricto que no permita nombres no canónicos en lugar de degradarlos a warning. 
- Garantizar que solo las constantes públicas canónicas explícitas (`PI`, `E`, `TAU`, `INF`, `NAN`) puedan ser exportadas como no-callables. 
- Bloquear de forma consistente objetos backend y wrappers de SDK para evitar fugas de implementación del backend a la API Cobra-facing.

### Description
- Se documentó y añadió la opción en `PoliticaSaneamientoUsar` (`validar_nombre_canonico_espanol_en_cobra_facing`) con docstring que explica el modo estricto para módulos Cobra-facing. 
- Se cambió la lógica en `sanear_simbolo_para_usar` para que, cuando la política estricta esté activada y `modulo_cobra_facing=True`, los nombres no canónicos se rechacen con el código `non_canonical_spanish_name` en lugar de emitir un `warning`. 
- Se conservaron las únicas constantes no-callable permitidas en `NOMBRES_CONSTANTES_PUBLICAS_CANONICAS` y su flujo sigue devolviendo `public_constant` con `warning=True`. 
- Se añadieron/ajustaron pruebas en `tests/unit/test_usar_symbol_policy.py` para cubrir el modo estricto Cobra-facing, el rechazo de aliases backend→Cobra (`self`, `append`, `map`, `filter`, `unwrap`, `expect`, `keys`, `values`, `len`, `lower`, `upper`), y el bloqueo de objetos envueltos (`__wrapped__`, `_sdk`), además de corregir la aserción que inspecciona `ClasificacionSaneamientoUsar`.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_symbol_policy.py` y todos los tests en ese archivo pasaron: `12 passed, 1 warning`.
- La suite de pruebas modificadas valida las nuevas reglas estrictas y la compatibilidad con las constantes públicas canónicas (todos los asserts relevantes pasan).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef9b1c8448327870e081ce94766ae)