### PR TITLE
Refuerza contrato público de holobit y bloqueo de símbolos SDK en `usar`

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -29,6 +29,8 @@ EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS = {
     "replace": "reemplazar",
     "startswith": "inicia_con",
     "endswith": "termina_con",
+    "Holobit": "crear_holobit",
+    "holobit_sdk": "crear_holobit",
 }
 
 NOMBRES_PROHIBIDOS_EXPLICITOS = frozenset(EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS)
@@ -145,7 +147,8 @@ def sanear_simbolo_para_usar(
         return _rechazar(nombre, simbolo, "backend_internal_name", "nombre interno del backend bloqueado", metadata)
 
     if nombre in NOMBRES_PROHIBIDOS_EXPLICITOS:
-        return _rechazar(nombre, simbolo, "explicit_forbidden_name", _mensaje_nombre_prohibido(nombre), metadata)
+        codigo = "cobra_public_equivalent" if nombre in EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS else "explicit_forbidden_name"
+        return _rechazar(nombre, simbolo, codigo, _mensaje_nombre_prohibido(nombre), metadata)
 
     if not callable(simbolo) and nombre not in NOMBRES_CONSTANTES_PUBLICAS_CANONICAS:
         return _rechazar(nombre, simbolo, "non_callable_not_canonical_public_constant", "solo se permiten no-callables para constantes públicas explícitas y canónicas", metadata)

--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -10,7 +10,7 @@ from collections.abc import Iterable, Sequence
 from typing import Any
 
 from pcobra.core.holobits.graficar import graficar as _runtime_graficar
-from pcobra.core.holobits.holobit import Holobit as _RuntimeHolobit
+from pcobra.core.holobits.holobit import Holobit as _runtime_holobit_tipo
 
 EQUIVALENCIAS_SEMANTICAS_HOLOBIT: dict[str, str] = {
     "new Holobit": "crear_holobit",
@@ -22,8 +22,7 @@ EQUIVALENCIAS_SEMANTICAS_HOLOBIT: dict[str, str] = {
     "render": "graficar",
 }
 
-# Alias interno para compatibilidad de pruebas de dominio (no exportado).
-_SDKHolobit = _RuntimeHolobit
+_SIMBOLOS_SDK_BLOQUEADOS = frozenset({"_SDKHolobit", "Holobit", "holobit_sdk"})
 
 
 class ErrorHolobit(ValueError):
@@ -49,7 +48,7 @@ class _AdaptadorInternoHolobit:
 
     @staticmethod
     def crear_desde_valores(valores: list[float]) -> Any:
-        return _SDKHolobit(valores)
+        return _runtime_holobit_tipo(valores)
 
     @staticmethod
     def obtener_valores(hb: Any) -> list[float]:
@@ -79,7 +78,23 @@ def _a_estructura_cobra(hb: Any) -> dict[str, Any]:
     return {"tipo": "holobit", "valores": _AdaptadorInternoHolobit.obtener_valores(hb)}
 
 
+def _rechazar_simbolos_sdk_en_estructura(valor: Any) -> None:
+    if isinstance(valor, str):
+        if valor in _SIMBOLOS_SDK_BLOQUEADOS:
+            raise TypeError("Estructura de holobit contiene símbolos internos no permitidos")
+        return
+    if isinstance(valor, dict):
+        for clave, contenido in valor.items():
+            _rechazar_simbolos_sdk_en_estructura(clave)
+            _rechazar_simbolos_sdk_en_estructura(contenido)
+        return
+    if isinstance(valor, Sequence) and not isinstance(valor, (str, bytes)):
+        for item in valor:
+            _rechazar_simbolos_sdk_en_estructura(item)
+
+
 def _validar_estructura_holobit(hb: Any) -> dict[str, Any]:
+    _rechazar_simbolos_sdk_en_estructura(hb)
     if not isinstance(hb, dict):
         raise TypeError("El holobit debe ser un objeto tipo dict")
     claves = set(hb.keys())
@@ -123,7 +138,9 @@ def validar_holobit(hb: Any) -> bool:
 
 def serializar_holobit(hb: dict[str, Any]) -> str:
     try:
-        return json.dumps(_a_estructura_cobra(_desde_estructura_cobra(hb)), ensure_ascii=False)
+        estructura_cobra = _a_estructura_cobra(_desde_estructura_cobra(hb))
+        _rechazar_simbolos_sdk_en_estructura(estructura_cobra)
+        return json.dumps(estructura_cobra, ensure_ascii=False)
     except (TypeError, ValueError):
         raise
     except Exception as exc:  # pragma: no cover - defensivo frente al runtime interno

--- a/tests/unit/test_usar_loader_public_api_contract.py
+++ b/tests/unit/test_usar_loader_public_api_contract.py
@@ -128,6 +128,20 @@ def test_politica_de_simbolos_prohibidos_devuelve_codigo_y_mensaje(simbolo: str)
     assert resultado.mensaje.strip()
 
 
+@pytest.mark.parametrize("simbolo", ["_SDKHolobit", "Holobit", "holobit_sdk"])
+def test_politica_bloquea_simbolos_sdk_holobit_en_superficie_usar(simbolo: str) -> None:
+    resultado = sanear_simbolo_para_usar(simbolo, lambda: None)
+    assert resultado.rechazado is True
+    assert resultado.codigo in {"private_prefix", "cobra_public_equivalent"}
+
+
+@pytest.mark.parametrize("payload", ['{"tipo":"holobit","valores":[1,"Holobit"]}', '{"tipo":"holobit_sdk","valores":[1,2]}'])
+def test_holobit_deserializar_bloquea_referencias_sdk(payload: str) -> None:
+    modulo = usar_loader.obtener_modulo("holobit")
+    with pytest.raises(TypeError):
+        modulo.deserializar_holobit(payload)
+
+
 def test_backends_legacy_no_se_cargan_en_startup_normal() -> None:
     import sys
     from pcobra.cobra.bindings.runtime_manager import RuntimeManager


### PR DESCRIPTION
### Motivation
- Evitar la fuga de tipos/símbolos del runtime SDK en la API pública de `holobit` y asegurar que `usar "holobit"` solo exporte la interfaz canónica de Cobra. 
- Prevenir que representaciones serializadas/deserializadas contengan referencias a símbolos internos/SDK que puedan eludir las políticas de exportación. 
- Asegurar que la política de saneamiento de `usar` detecte y bloquee nombres relacionados con el SDK de holobit y guíe hacia los equivalentes públicos canónicos.

### Description
- Encapsulé el tipo runtime importado renombrándolo a `_runtime_holobit_tipo` y eliminé alias exportable, evitando exponer tipos SDK directamente. 
- Añadí `_SIMBOLOS_SDK_BLOQUEADOS` y la función recursiva `_rechazar_simbolos_sdk_en_estructura` para detectar y rechazar cadenas, claves o elementos que contengan `"_SDKHolobit"`, `"Holobit"` o `"holobit_sdk"`. 
- Invoco el saneamiento en `_validar_estructura_holobit` y antes de `serializar_holobit` para impedir serializar/deserializar estructuras contaminadas; `deserializar_holobit` ahora valida la estructura y falla si contiene internals. 
- Extendí `EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS` en `src/pcobra/core/usar_symbol_policy.py` con `"Holobit"` y `"holobit_sdk"` y ajusté el código de rechazo para devolver `cobra_public_equivalent` cuando existe una equivalencia canónica. 
- Agregué tests de frontera en `tests/unit/test_usar_loader_public_api_contract.py` para validar que símbolos SDK sean rechazados por la política de `usar` y que `deserializar_holobit` bloquee payloads contaminados.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_loader_public_api_contract.py` y el conjunto de pruebas relacionado pasó con `22 passed, 1 warning`.
- Las nuevas pruebas añadidas cubren rechazo de símbolos `"_SDKHolobit"`, `"Holobit"`, `"holobit_sdk"` y payloads JSON que contienen referencias SDK y confirman que se lanza `TypeError` en caso de contaminación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fefc7362ec8327a55e522ec61bf16c)