### PR TITLE
test: reforzar contrato público de usar y política de backends

### DIFF
--- a/tests/unit/test_usar_loader_public_api_contract.py
+++ b/tests/unit/test_usar_loader_public_api_contract.py
@@ -157,6 +157,55 @@ def test_backends_legacy_no_se_cargan_en_startup_normal() -> None:
     assert not (legacy & set(sys.modules))
 
 
+
+
+def test_superficie_usar_no_expone_aliases_ni_internals_prohibidos() -> None:
+    modulos = ("numero", "texto", "datos")
+    prohibidos_exactos = {"self", "append", "map", "filter", "unwrap", "expect"}
+
+    for nombre_modulo in modulos:
+        modulo = usar_loader.obtener_modulo(nombre_modulo)
+        simbolos = _simbolos_publicos(modulo)
+
+        for simbolo in simbolos:
+            assert "__" not in simbolo, f"{nombre_modulo} exporta símbolo dunder: {simbolo}"
+            assert simbolo not in prohibidos_exactos, (
+                f"{nombre_modulo} exporta símbolo no permitido: {simbolo}"
+            )
+
+
+def test_arranque_normal_import_pcobra_no_precarga_legacy() -> None:
+    import importlib
+    import sys
+
+    importlib.import_module("pcobra")
+
+    legacy = {
+        "pcobra.cobra.transpilers.transpiler.to_go",
+        "pcobra.cobra.transpilers.transpiler.to_cpp",
+        "pcobra.cobra.transpilers.transpiler.to_java",
+        "pcobra.cobra.transpilers.transpiler.to_wasm",
+        "pcobra.cobra.transpilers.transpiler.to_asm",
+    }
+    assert not (legacy & set(sys.modules))
+
+
+def test_contrato_publico_backends_y_configuracion_publica_sin_extras() -> None:
+    import re
+    from pathlib import Path
+
+    from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+
+    assert PUBLIC_BACKENDS == ("python", "javascript", "rust")
+
+    contenido_pcobra_toml = Path("pcobra.toml").read_text(encoding="utf-8")
+    requeridos = re.search(r'required_targets\s*=\s*\[(.*?)\]', contenido_pcobra_toml, re.DOTALL)
+    assert requeridos is not None
+    assert requeridos.group(1).replace('"', "").replace(" ", "") == "python,javascript,rust"
+
+    contenido_readme = Path("README.md").read_text(encoding="utf-8")
+    assert "Backends oficiales públicos para `cobra build`: `python`, `javascript`, `rust`." in contenido_readme
+
 def test_politica_publica_permanece_exactamente_python_javascript_rust() -> None:
     from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 


### PR DESCRIPTION
### Motivation
- Garantizar que la superficie pública expuesta por `usar "numero"`, `usar "texto"` y `usar "datos"` sea la canónica en español y no incluya aliases internos o dunder.
- Asegurar que importaciones bloqueadas como `numpy` y `holobit_sdk` fallen con el error contractual esperado.
- Evitar la carga eager de transpiladores legacy en arranques normales de la librería/CLI.
- Verificar que la política pública de backends permanece exactamente `("python","javascript","rust")` y que la configuración/documentación públicas no listan extras.

### Description
- Añadido/actualizado `tests/unit/test_usar_loader_public_api_contract.py` con una nueva prueba `test_superficie_usar_no_expone_aliases_ni_internals_prohibidos` que recorre las exportaciones de los módulos `numero`, `texto` y `datos` y falla si aparece `__` o cualquiera de los aliases prohibidos exactos (`self`, `append`, `map`, `filter`, `unwrap`, `expect`).
- Añadida la prueba `test_arranque_normal_import_pcobra_no_precarga_legacy` que importa `pcobra` y comprueba que los módulos legacy de transpilador (`to_go`, `to_cpp`, `to_java`, `to_wasm`, `to_asm`) no están precargados.
- Añadida la prueba `test_contrato_publico_backends_y_configuracion_publica_sin_extras` que valida `PUBLIC_BACKENDS == ("python","javascript","rust")`, comprueba `required_targets` en `pcobra.toml` y la presencia de la línea canónica en `README.md`.
- No se cambió la implementación productiva; se reforzaron y reorganizaron aserciones en tests existentes (se separó la comprobación de dunders de los aliases exactos) y se confirmaron las pruebas negativas existentes para `numpy` y `holobit_sdk`.

### Testing
- Ejecutado `pytest -q tests/unit/test_usar_loader_public_api_contract.py tests/unit/test_startup_no_legacy_eager_loading.py tests/unit/test_backend_public_contract.py` y tras ajustar una aserción inicial todos los tests pasaron: `34 passed, 1 warning`.
- Se verificó la reproducción del fallo inicial, se aplicó la corrección en el test y se volvió a ejecutar la batería de pruebas mencionada con éxito.
- Los tests adicionales son unitarios y no modifican comportamientos de producción; sólo validan contratos públicos y arranques.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fefd963e488327a96d943dd222a1c7)