### PR TITLE
Aclarar separación entre backends oficiales y legacy opcionales en registro

### DIFF
--- a/src/pcobra/cobra/transpilers/registry.py
+++ b/src/pcobra/cobra/transpilers/registry.py
@@ -1,4 +1,12 @@
-"""Registro canónico de transpiladores oficiales."""
+"""Registro canónico de backends/transpiladores.
+
+Activos oficiales (política pública y startup normal): ``python``,
+``javascript`` y ``rust``.
+
+Backends legacy opcionales: viven en ``legacy_registry`` y se cargan solo
+bajo rutas internas explícitas de compatibilidad (import lazy, nunca eager en
+el path público por defecto).
+"""
 
 from __future__ import annotations
 
@@ -60,7 +68,7 @@ _OFFICIAL_TARGETS_SET: Final[frozenset[str]] = frozenset(_ORDERED_OFFICIAL_TARGE
 
 
 def _legacy_registry_module():
-    """Import diferido del inventario legacy interno fuera del startup path principal."""
+    """Import diferido del inventario legacy interno (ruta opcional/no pública)."""
     return import_module("pcobra.cobra.transpilers.legacy_registry")
 
 


### PR DESCRIPTION
### Motivation
- Hacer explícito en el módulo de registro que la política pública y el flujo de arranque normales exponen exactamente `python`, `javascript` y `rust`, y que los backends legacy deben permanecer fuera del path público para evitar imports/initializations por defecto.

### Description
- Actualicé el docstring de `src/pcobra/cobra/transpilers/registry.py` para documentar que los activos oficiales son `python`, `javascript` y `rust`, y que los backends legacy viven en `legacy_registry` y se cargan solo por rutas internas explícitas y de forma lazy.
- Ajusté el docstring de la función `_legacy_registry_module` para reflejar que es una ruta opcional/no pública; no se realizaron cambios funcionales en la lógica de carga.

### Testing
- Ejecuté `python -m pytest -q tests/test_cli_entrypoint_imports.py::test_import_pcobra_no_carga_backends_legacy_en_startup tests/test_cli_entrypoint_imports.py::test_cli_public_commands_do_not_import_legacy_transpilers_on_startup` y ambos tests pasaron (4 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feff2261808327a2d3cc1b42d238c5)