### PR TITLE
Endurecer validación runtime de `usar` y avisar colisiones de símbolos

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -41,6 +41,14 @@ _BACKEND_PREFIXES = (
     "runtime",
 )
 
+_BACKEND_EQUIVALENTS = {
+    "nodefetch",
+    "node_fetch",
+    "serde",
+    "holobitsdk",
+    "holobit_sdk",
+}
+
 
 def normalizar_nombre_usar(nombre: str) -> str:
     """Normaliza nombre de módulo para validaciones canónicas de `usar`."""
@@ -53,8 +61,9 @@ def _rechazar_modulo_no_canonico(nombre: str) -> None:
 
     nombre_normalizado = normalizar_nombre_usar(nombre)
     blocklist_normalizada = {normalizar_nombre_usar(item) for item in USAR_BACKEND_BLOCKLIST}
+    equivalentes_normalizados = {normalizar_nombre_usar(item) for item in _BACKEND_EQUIVALENTS}
 
-    if nombre_normalizado in blocklist_normalizada:
+    if nombre_normalizado in blocklist_normalizada or nombre_normalizado in equivalentes_normalizados:
         raise PermissionError(
             f"Importación no permitida en 'usar': '{nombre}'. "
             "Es un módulo backend/no canónico y no forma parte de la API pública. "

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1,6 +1,7 @@
 """Implementación del intérprete del lenguaje Cobra."""
 
 import logging
+import warnings
 import os
 import hashlib
 from typing import Mapping, Optional
@@ -1973,6 +1974,13 @@ class InterpretadorCobra:
                     "phase": "preflight",
                 }
                 if self._usar_collision_policy == USAR_COLLISION_WARN_ALIAS_REQUIRED:
+                    warnings.warn(
+                        "Conflicto de nombres en `usar`: "
+                        f"módulo={nodo.modulo} símbolos={conflictos}. "
+                        "No se inyectó ningún símbolo; use alias explícito.",
+                        RuntimeWarning,
+                        stacklevel=2,
+                    )
                     raise NameError(
                         "No se puede usar el módulo "
                         f"'{nodo.modulo}': {USAR_SYMBOL_CONFLICT_ERROR} colisión estructurada={detalle}. "


### PR DESCRIPTION
### Motivation
- Evitar bypasss de la política `usar` mediante variantes de nombres de paquetes backend y mejorar trazabilidad cuando la inyección de símbolos colisiona con el contexto actual.
- Mantener la sintaxis del parser (`usar "..."`) intacta y hacer todo el control en runtime.

### Description
- Añadido `_BACKEND_EQUIVALENTS` y validación adicional en `_rechazar_modulo_no_canonico` para bloquear variantes normalizadas (por ejemplo `node-fetch`/`node_fetch`/`nodefetch`, `serde`, `holobit_sdk`) en `src/pcobra/cobra/usar_loader.py`.
- La normalización usa `normalizar_nombre_usar` y se compara contra la `USAR_BACKEND_BLOCKLIST` y los equivalentes nuevos para impedir bypasss de nombres equivalentes.
- En `src/pcobra/core/interpreter.py` se importó `warnings` y, en `InterpretadorCobra.ejecutar_usar`, se emite `warnings.warn(..., RuntimeWarning)` con detalle de módulo/símbolos cuando la política de colisión es `USAR_COLLISION_WARN_ALIAS_REQUIRED` antes de lanzar `NameError` para rechazar la inyección.
- No se modificó la gramática ni el parser; todo el control se realiza en runtime y la política de no sobreescritura silenciosa continúa vigente.

### Testing
- Ejecutado `pytest -q tests/unit/test_usar_loader_validation.py` y pasó con éxito (4 tests, 1 warning).
- Ejecutado `pytest -q tests/unit/test_usar_runtime_policy.py` durante la verificación y la colección falló con `ImportError: attempted relative import beyond top-level package` (error de import path/entorno de pruebas, no de la lógica añadida).
- Se validaron localmente las modificaciones de archivos y se dejó trazabilidad de los eventos de colisión mediante `logging` y `warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff002530e88327a48b7291e0e0aadd)