### PR TITLE
Añade API numérica en español: `truncar`, `minimo`, `maximo`

### DIFF
--- a/src/pcobra/corelibs/numero.py
+++ b/src/pcobra/corelibs/numero.py
@@ -34,6 +34,9 @@ EQUIVALENCIAS_SEMANTICAS_NUMERO: dict[str, str] = {
     "isnan": "es_nan",
     "copysign": "copiar_signo",
     "prod": "producto",
+    "trunc": "truncar",
+    "min": "minimo",
+    "max": "maximo",
 }
 
 
@@ -64,6 +67,34 @@ def techo(valor):
     """Equivalente a ``math.ceil``."""
 
     return math.ceil(valor)
+
+
+def truncar(valor):
+    """Trunca ``valor`` hacia cero como :func:`math.trunc`."""
+
+    return math.trunc(valor)
+
+
+def minimo(*valores):
+    """Retorna el menor valor recibido.
+
+    Se exige al menos un argumento para alinear mensajes con el runtime Cobra.
+    """
+
+    if not valores:
+        raise TypeError("minimo requiere al menos un argumento")
+    return min(valores)
+
+
+def maximo(*valores):
+    """Retorna el mayor valor recibido.
+
+    Se exige al menos un argumento para alinear mensajes con el runtime Cobra.
+    """
+
+    if not valores:
+        raise TypeError("maximo requiere al menos un argumento")
+    return max(valores)
 
 
 def mcd(*valores: int) -> int:

--- a/src/pcobra/standard_library/numero.py
+++ b/src/pcobra/standard_library/numero.py
@@ -39,6 +39,9 @@ __all__ = [
     "redondear",
     "piso",
     "techo",
+    "truncar",
+    "minimo",
+    "maximo",
     "mcd",
     "mcm",
     "es_cercano",
@@ -215,6 +218,24 @@ def techo(*args, **kwargs):
     """Delega en ``pcobra.corelibs.numero.techo``."""
 
     return _numero.techo(*args, **kwargs)
+
+
+def truncar(*args, **kwargs):
+    """Delega en ``pcobra.corelibs.numero.truncar``."""
+
+    return _numero.truncar(*args, **kwargs)
+
+
+def minimo(*args, **kwargs):
+    """Delega en ``pcobra.corelibs.numero.minimo``."""
+
+    return _numero.minimo(*args, **kwargs)
+
+
+def maximo(*args, **kwargs):
+    """Delega en ``pcobra.corelibs.numero.maximo``."""
+
+    return _numero.maximo(*args, **kwargs)
 
 
 def mcd(*args, **kwargs):


### PR DESCRIPTION
### Motivation
- Unificar y ampliar la API pública en español para operaciones numéricas brindando nombres coherentes con la semántica existente (p. ej. `redondear`, `absoluto`).
- Proveer alias semánticos para backend/compatibilidad que mapeen funciones comunes (`trunc`, `min`, `max`) a sus nombres en español.

### Description
- Añadidos en `src/pcobra/corelibs/numero.py` las funciones `truncar`, `minimo` y `maximo` que implementan `math.trunc`, `min` y `max` respectivamente y lanzan errores con mensajes alineados al runtime Cobra cuando corresponde (por ejemplo `minimo requiere al menos un argumento`).
- Actualizado el diccionario `EQUIVALENCIAS_SEMANTICAS_NUMERO` para mapear `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff0283ee78832795ce149d31cee03d)