### PR TITLE
Ajusta fachada holobit para mantener adaptación interna y errores Cobra saneados

### DIFF
--- a/src/pcobra/corelibs/holobit.py
+++ b/src/pcobra/corelibs/holobit.py
@@ -12,6 +12,9 @@ from typing import Any
 from pcobra.core.holobits.graficar import graficar as _runtime_graficar
 from pcobra.core.holobits.holobit import Holobit as _runtime_holobit_tipo
 
+# Alias interno para compatibilidad de pruebas sin exponer SDK en la API pública.
+_SDKHolobit = _runtime_holobit_tipo
+
 EQUIVALENCIAS_SEMANTICAS_HOLOBIT: dict[str, str] = {
     "new Holobit": "crear_holobit",
     "validate": "validar_holobit",
@@ -48,7 +51,7 @@ class _AdaptadorInternoHolobit:
 
     @staticmethod
     def crear_desde_valores(valores: list[float]) -> Any:
-        return _runtime_holobit_tipo(valores)
+        return _SDKHolobit(valores)
 
     @staticmethod
     def obtener_valores(hb: Any) -> list[float]:


### PR DESCRIPTION
### Motivation
- Asegurar que el módulo `holobit` exponga únicamente la API pública canónica de Cobra y que el adaptador interno al runtime preserve encapsulación, normalice entradas/salidas a estructuras Cobra y traduzca errores del SDK a `ErrorHolobit` sin filtrar internals.

### Description
- Añade un alias interno `_SDKHolobit` y cambia `_AdaptadorInternoHolobit.crear_desde_valores` para instanciar mediante ese alias, manteniendo la API pública sin exponer tipos/imports del SDK (archivo modificado: `src/pcobra/corelibs/holobit.py`).

### Testing
- Ejecuté `pytest -q tests/unit/test_holobit_corelib_domain_errors.py tests/unit/test_holobit_no_fuga_exports.py tests/unit/test_usar_loader_public_api_contract.py -q`; las pruebas fallaron inicialmente por falta de `_SDKHolobit` y tras el ajuste todas las pruebas mencionadas pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff07c8383883279fde969ace1f06f7)