### PR TITLE
test: reforzar contrato runtime de exports `usar` y colisiones de símbolos

### DIFF
--- a/tests/integration/test_usar_public_contract_regression.py
+++ b/tests/integration/test_usar_public_contract_regression.py
@@ -46,6 +46,7 @@ def test_usar_numero_solo_simbolos_espanoles(factory, executor, get_interp, monk
     simbolos = set(interp.contextos[-1].values.keys())
     assert "es_finito" in simbolos
     assert "isfinite" not in simbolos
+    assert interp.contextos[-1].get("es_finito")(3.14) is True
 
 
 @pytest.mark.parametrize(
@@ -67,6 +68,7 @@ def test_usar_texto_solo_simbolos_espanoles(factory, executor, get_interp, monke
     simbolos = set(interp.contextos[-1].values.keys())
     assert "a_snake" in simbolos
     assert "snake_case" not in simbolos
+    assert interp.contextos[-1].get("a_snake")("Hola Mundo") == "hola_mundo"
 
 
 def _modulo_datos_publico_stub() -> ModuleType:
@@ -95,8 +97,14 @@ def test_usar_datos_incluye_filtrar_mapear_reducir(factory, executor, get_interp
     interp = get_interp(cmd)
     executor(cmd, 'usar "datos"')
 
+    valores = [1, 2, 3]
     for simbolo in ("filtrar", "mapear", "reducir"):
         assert simbolo in interp.contextos[-1].values
+        assert callable(interp.contextos[-1].get(simbolo))
+
+    assert interp.contextos[-1].get("filtrar")(valores) == valores
+    assert interp.contextos[-1].get("mapear")(valores) == valores
+    assert interp.contextos[-1].get("reducir")(valores) == 1
 
 
 @pytest.mark.parametrize(
@@ -145,10 +153,15 @@ def test_usar_holobit_expone_solo_api_cobra_facing(monkeypatch):
 
     interp.ejecutar_usar(_NodoUsar())
 
-    simbolos = set(mod_holobit.__all__)
+    simbolos = {
+        simbolo
+        for simbolo in ("crear_holobit", "validar_holobit", "serializar_holobit", "deserializar_holobit", "proyectar", "transformar", "graficar", "combinar", "medir")
+        if simbolo in interp.contextos[-1].values
+    }
     assert simbolos == {"crear_holobit", "validar_holobit", "serializar_holobit", "deserializar_holobit", "proyectar", "transformar", "graficar", "combinar", "medir"}
     assert "holobit_sdk" not in interp.contextos[-1].values
     assert "_to_sdk_holobit" not in interp.contextos[-1].values
+    assert callable(interp.contextos[-1].get("crear_holobit"))
 
 
 def test_simbolos_exportados_sin_doble_guion_bajo_y_sin_prohibidos():
@@ -210,6 +223,7 @@ def test_conflictos_emiten_warning_estructurado_por_simbolo(monkeypatch, caplog)
     assert any("'symbol': 'mapear'" in mensaje for mensaje in mensajes)
     assert interp.contextos[-1].get("filtrar")() == "ocupado"
     assert interp.contextos[-1].get("mapear")() == "ocupado"
+    assert "reducir" not in interp.contextos[-1].values
 
 
 def test_usar_no_inyecta_simbolos_prohibidos_ni_objetos_backend(monkeypatch):


### PR DESCRIPTION
### Motivation
- Asegurar que las pruebas de `usar` validan exports efectivos en runtime y no sólo listas estáticas, cubrir casos de colisión y evitar overwrite silencioso.
- Añadir aserciones que ejecuten los símbolos exportados para detectar problemas en la integración real del intérprete.

### Description
- Actualiza `tests/integration/test_usar_public_contract_regression.py` para ejecutar y validar en runtime `es_finito` exportado por `usar "numero"` y `a_snake` exportado por `usar "texto"`.
- Añade comprobaciones de callable y resultados reales para `filtrar`, `mapear`, `reducir` tras `usar "datos"`.
- Cambia la verificación de `holobit` para inspeccionar símbolos realmente inyectados en el contexto runtime y añade una aserción que el export `crear_holobit` es callable.
- Refuerza pruebas de colisión para validar que símbolos en conflicto no se sobrescriben y que símbolos no conflictivos (p.ej. `reducir`) no se inyectan cuando hay colisiones preflight.

### Testing
- Ejecutado `pytest -q tests/integration/test_usar_public_contract_regression.py -k 'numero_solo_simbolos_espanoles or texto_solo_simbolos_espanoles or datos_incluye_filtrar_mapear_reducir or usar_holobit_expone_solo_api_cobra_facing or conflictos_emiten_warning_estructurado_por_simbolo'` y pasó con salida: 8 passed.
- Ejecutado `pytest -q tests/integration/test_usar_public_contract_regression.py tests/test_backend_startup_policy.py` y se detectaron fallos no introducidos por este cambio; hubo 5 failures en tests preexistentes (incluyendo `test_rechaza_usar_numpy`, `test_holobit_sdk_internals_no_son_importables`, `test_usar_no_inyecta_simbolos_prohibidos_ni_objetos_backend` y un caso de sanitización de exports), por lo que la batería completa falló en el entorno actual.
- Cambios committeados y PR creado; los tests relevantes añadidos pasan en la ejecución focalizada indicada arriba.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff08dc6b888327a53adb0072d494eb)