### PR TITLE
Congelar política pública de backends en entrypoints y validadores

### DIFF
--- a/scripts/lint_policy_drift.py
+++ b/scripts/lint_policy_drift.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Detecta drift de policy canónica en rutas públicas (set oficial de 8 targets)."""
+"""Detecta drift de policy canónica en rutas públicas (set oficial de 3 backends públicos)."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ SRC_ROOT = ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
-from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS, assert_public_targets_contract
 
 SCAN_ROOTS = (
     ROOT / "README.md",
@@ -32,7 +32,8 @@ SKIP_FILES = {
     "scripts/audit_retired_targets.py",
     "scripts/targets_policy_common.py",
 }
-OFFICIAL = set(OFFICIAL_TARGETS)
+assert_public_targets_contract(tuple(PUBLIC_BACKENDS), source="scripts/lint_policy_drift.py")
+OFFICIAL = set(PUBLIC_BACKENDS)
 CONTEXT = re.compile(
     r"(?i)(targets?|backends?|destinos?|--tipo|--destino|--origen)"
 )

--- a/src/pcobra/__init__.py
+++ b/src/pcobra/__init__.py
@@ -8,6 +8,10 @@ import sys as _sys
 import warnings as _warnings
 from typing import Dict, Tuple
 
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS, assert_public_targets_contract
+
+assert_public_targets_contract(tuple(PUBLIC_BACKENDS), source="import pcobra")
+
 logger = logging.getLogger(__name__)
 
 _LEGACY_IMPORT_PHASE_ENV = "PCOBRA_LEGACY_IMPORT_PHASE"

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -20,7 +20,7 @@ from pcobra.cli import (
 )
 
 from pcobra.cobra.cli.commands.base import BaseCommand
-from pcobra.cobra.cli.target_policies import OFFICIAL_TRANSPILATION_TARGETS
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS, assert_public_targets_contract
 from pcobra.cobra.core.interpreter import InterpretadorCobra
 from pcobra.cobra.cli.i18n import _, format_traceback, setup_gettext
 
@@ -76,7 +76,8 @@ CLI_VERSION = environ.get("COBRA_CLI_VERSION", "dev")
 CLI_COMMIT = environ.get("COBRA_CLI_COMMIT", "unknown")
 COBRA_INTERNAL_ENABLE_CLI_V1_ENV = "COBRA_INTERNAL_ENABLE_CLI_V1"
 COBRA_ENABLE_LEGACY_CLI_ENV = "COBRA_INTERNAL_ENABLE_LEGACY_CLI"
-LANG_CHOICES = tuple(OFFICIAL_TRANSPILATION_TARGETS)
+assert_public_targets_contract(tuple(PUBLIC_BACKENDS), source="cobra cli bootstrap")
+LANG_CHOICES = tuple(PUBLIC_BACKENDS)
 LEGACY_COMMAND_MIGRATION_MAP: dict[str, dict[str, str]] = {
     "interactive": {
         "target": "repl",


### PR DESCRIPTION
### Motivation
- Asegurar que la lista canónica de backends públicos provenga únicamente de `src/pcobra/cobra/architecture/backend_policy.py` durante arranque/import público.
- Evitar que rutas de bootstrap o validadores utilicen listas derivadas o antiguas que puedan introducir drift o exponer backends legacy en flujos públicos.
- Forzar la comprobación temprana del contrato público (exactamente 3 backends) en los entrypoints sensibles al startup para detectar desalineaciones lo antes posible.

### Description
- Se añadió una aserción de contrato público usando `assert_public_targets_contract` en `src/pcobra/__init__.py` para validar `import pcobra` frente a `PUBLIC_BACKENDS`.
- Se actualizó el bootstrap de CLI en `src/pcobra/cobra/cli/cli.py` para derivar `LANG_CHOICES` directamente de `PUBLIC_BACKENDS` y ejecutar la misma aserción contractual durante el arranque de la CLI pública.
- Se modificó `scripts/lint_policy_drift.py` para consumir `PUBLIC_BACKENDS` desde `backend_policy` y para validar/expresar la regla de los 3 backends públicos canónicos.
- Auditoría ligera mostró que las rutas legacy de transpilers están centralizadas en `transpilers/legacy_registry.py` y no hay carga eager de módulos legacy en arranque público estándar, manteniendo la compatibilidad en rutas internas explícitas.

### Testing
- Ejecuté `pytest -q tests/test_cli_entrypoint_imports.py tests/test_backend_startup_policy.py tests/cli/test_runtime_imports_contract.py` y todos los casos objetivo pasaron con éxito; resultado: `25 passed, 1 warning`.
- Las pruebas verifican que `import pcobra` y los comandos públicos (`cobra repl/run/test`) no cargan transpilers legacy en el flujo de startup estándar y que la política pública queda alineada con `backend_policy`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff0c6ec16c832784ebd09081653a9f)