### PR TITLE
Fijar backends públicos canónicos y evitar carga eager de transpilers legacy en startup

### DIFF
--- a/src/pcobra/cobra/architecture/backend_policy.py
+++ b/src/pcobra/cobra/architecture/backend_policy.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import Final
 
+from pcobra.cobra.architecture.legacy_backend_lifecycle import INTERNAL_BACKENDS
+
 # Cobra es la única interfaz pública soportada para usuarios e integraciones.
 PUBLIC_INTERFACE_NAME: Final[str] = "cobra"
 

--- a/tests/test_backend_startup_policy.py
+++ b/tests/test_backend_startup_policy.py
@@ -37,17 +37,40 @@ def test_runtime_startup_policy_does_not_import_legacy_transpilers(module_name: 
 
 
 @pytest.mark.parity_contract
+@pytest.mark.parametrize("module_name", LEGACY_TRANSPILER_MODULES)
+def test_normal_boot_paths_do_not_import_legacy_transpilers(module_name: str) -> None:
+    before = set(sys.modules)
+
+    # Rutas normales de arranque: import raíz y bootstrap CLI.
+    importlib.import_module("pcobra")
+    importlib.import_module("pcobra.cobra.cli.bootstrap")
+
+    after = set(sys.modules)
+    loaded_during_boot = after - before
+
+    assert module_name not in after, f"{module_name} no debe quedar cargado tras boot normal"
+    assert module_name not in loaded_during_boot, (
+        f"{module_name} fue cargado durante boot normal, violando política pública"
+    )
+
+
+@pytest.mark.parity_contract
 def test_public_targets_contract_is_exact_in_config_and_architecture() -> None:
     config_targets = importlib.import_module(
         "pcobra.cobra.config.transpile_targets"
     ).OFFICIAL_TARGETS
+    public_config_targets = importlib.import_module(
+        "pcobra.cobra.config.transpile_targets"
+    ).ALLOWED_TARGETS
     policy_targets = importlib.import_module(
         "pcobra.cobra.architecture.backend_policy"
     ).PUBLIC_BACKENDS
 
     assert config_targets == EXPECTED_PUBLIC_TARGETS
+    assert public_config_targets == EXPECTED_PUBLIC_TARGETS
     assert policy_targets == EXPECTED_PUBLIC_TARGETS
     assert config_targets == policy_targets
+    assert public_config_targets == policy_targets
 
 
 @pytest.mark.parity_contract


### PR DESCRIPTION
### Motivation
- Garantizar que la política pública de backends sea la fuente única de verdad y que las rutas de arranque públicas no importen de forma eager transpilers legacy.
- Alinear la configuración de targets públicos usada por rutas públicas con la política de arquitectura para evitar discrepancias contractuales.

### Description
- Mantengo `PUBLIC_BACKENDS` exactamente como `("python", "javascript", "rust")` y empalmo `INTERNAL_BACKENDS` desde el inventario legacy en `src/pcobra/cobra/architecture/backend_policy.py` mediante la importación de `legacy_backend_lifecycle.INTERNAL_BACKENDS` para que el módulo tenga acceso al listado interno sin exponerlo como público.
- Alineé `src/pcobra/cobra/config/transpile_targets.py` indirectamente (ya consumía `PUBLIC_BACKENDS`) y reforcé las aserciones en tests para exigir paridad exacta entre `ALLOWED_TARGETS`/`OFFICIAL_TARGETS` y `PUBLIC_BACKENDS`.
- Fortalecí `tests/test_backend_startup_policy.py` añadiendo `test_normal_boot_paths_do_not_import_legacy_transpilers` que verifica que en rutas normales de arranque (`import pcobra` y `pcobra.cobra.cli.bootstrap`) no se cargan los módulos legacy `to_go`, `to_cpp`, `to_java`, `to_wasm`, `to_asm`, y amplié las aserciones para comprobar `ALLOWED_TARGETS` además de `OFFICIAL_TARGETS` versus `PUBLIC_BACKENDS`.
- No fueron necesarias modificaciones semánticas en `docs/targets_policy.md` porque el documento ya especifica la misma política pública/legacy y la regla de no-carga eager en startup.

### Testing
- Ejecuté `pytest -q tests/test_backend_startup_policy.py` y los tests pasaron exitosamente: `17 passed, 1 warning`.
- Las nuevas assertions comprueban que `PUBLIC_BACKENDS == ("python", "javascript", "rust")` y que ningún transpiler legacy queda en `sys.modules` tras los escenarios de arranque probados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff12f5ed6c8327bbc99d7015d35cf6)