### PR TITLE
test: reforzar contrato serializable y no-fuga de holobit

### DIFF
--- a/tests/unit/test_corelibs_holobit_adapter.py
+++ b/tests/unit/test_corelibs_holobit_adapter.py
@@ -85,6 +85,29 @@ def test_internals_no_se_exportan_en_public_api():
 
 
 @pytest.mark.parametrize(
+    "estructura_invalida",
+    [
+        {"tipo": "holobit"},
+        {"valores": [1, 2, 3]},
+        {"tipo": "holobit", "valores": [1, 2], "legacy": True},
+        {"tipo": "holobit_sdk", "valores": [1, 2]},
+        {"tipo": "holobit", "valores": [1, "Holobit"]},
+    ],
+)
+def test_validar_holobit_rechaza_payloads_fuera_del_contrato_serializable(estructura_invalida):
+    assert holobit.validar_holobit(estructura_invalida) is False
+
+
+def test_serializar_holobit_rechaza_objeto_sdk_o_clase_interna():
+    class LegacyHolobit:
+        tipo = "holobit"
+        valores = [1, 2, 3]
+
+    with pytest.raises(TypeError):
+        holobit.serializar_holobit(LegacyHolobit())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
     "payload",
     [
         "[1,2,3]",


### PR DESCRIPTION
### Motivation
- Asegurar que las fachadas públicas de Holobit solo expongan la API canónica serializable y que no filtren símbolos/objetos internos del SDK o clases legacy.
- Añadir pruebas que refuercen el contrato de `usar "holobit"` para rechazar estructuras fuera del esquema exacto (`tipo` + `valores`) y objetos no-serializables.

### Description
- Se añadió una parametrización de tests en `tests/unit/test_corelibs_holobit_adapter.py` que valida que `validar_holobit` rechaza payloads fuera del contrato público (claves faltantes, claves extra, tipos incorrectos y símbolos legacy).
- Se añadió un test que verifica que `serializar_holobit` rechaza objetos tipo SDK o clases internas (evitando fugas de internals en la superficie pública).
- Solo se modificó el archivo `tests/unit/test_corelibs_holobit_adapter.py`; no se cambiaron implementaciones de producción.

### Testing
- Ejecutado `pytest -q tests/unit/test_corelibs_holobit_adapter.py tests/unit/test_holobit_no_fuga_exports.py` y ambas pruebas unitarias pasaron (`26 passed`, `1 warning`).
- Ejecutado `pytest -q tests/unit/test_corelibs_holobit_adapter.py tests/unit/test_holobit_no_fuga_exports.py tests/unit/test_holobit_sdk_fallback_contract.py` produjo fallos preexistentes en la matriz de compatibilidad (KeyError: `wasm` y una expectativa `rust` marcada como `full`), los cuales son ajenos a este cambio.
- Ejecutado `pytest -q ... tests/unit/test_holobit_runtime_backends.py` falló en la colección por un importador ausente (`ModuleNotFoundError: pcobra.cobra.transpilers.transpiler.to_asm`), incidente preexistente fuera del alcance de este parche.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff1d0a78bc83278fccbf1c0c33cc8a)