### PR TITLE
Agregar pruebas de startup y documentación: backends oficiales vs legacy

### DIFF
--- a/docs/architecture/backends_oficiales_vs_legacy.md
+++ b/docs/architecture/backends_oficiales_vs_legacy.md
@@ -1,0 +1,44 @@
+# Arquitectura: backends oficiales activos vs legacy opcional
+
+## Resumen ejecutivo
+
+`pcobra` mantiene un **contrato público activo** enfocado exclusivamente en tres backends:
+
+- `python`
+- `javascript`
+- `rust`
+
+Estos tres backends se consideran oficiales para startup normal, comandos base y cobertura contractual de integración.
+
+## Backends oficiales activos (ruta normal)
+
+En ruta normal de ejecución (por ejemplo `import pcobra`, `python -m pcobra` y bootstrap CLI),
+la arquitectura valida y expone solo el conjunto público oficial.
+
+Implicaciones:
+
+1. El contrato de producto y pruebas se centra en los tres backends oficiales.
+2. La política pública rechaza targets fuera de contrato en comandos públicos.
+3. El arranque evita cargar transpilers legacy para mantener startup predecible y mínimo.
+
+## Backends legacy opcionales (desactivados por defecto)
+
+Los transpilers legacy viven en:
+
+- `src/pcobra/cobra/transpilers/transpiler/legacy/*`
+
+Estos módulos existen para compatibilidad histórica y casos internos, pero:
+
+- **no forman parte del contrato público activo**, y
+- **no deben cargarse durante el startup normal**.
+
+Su uso es opcional/controlado y fuera del flujo principal soportado de cara a usuario final.
+
+## Relación con pruebas de contrato
+
+Las pruebas de contrato público en `tests/integration/transpilers/test_official_backends_contracts.py`
+permanecen intencionadamente acotadas a los 3 backends oficiales, para alinear:
+
+- política arquitectónica,
+- expectativas de soporte, y
+- matriz de compatibilidad publicada.

--- a/tests/test_backend_startup_policy.py
+++ b/tests/test_backend_startup_policy.py
@@ -8,11 +8,11 @@ import sys
 import pytest
 
 LEGACY_TRANSPILER_MODULES = (
-    "pcobra.cobra.transpilers.transpiler.to_go",
-    "pcobra.cobra.transpilers.transpiler.to_java",
-    "pcobra.cobra.transpilers.transpiler.to_cpp",
-    "pcobra.cobra.transpilers.transpiler.to_asm",
-    "pcobra.cobra.transpilers.transpiler.to_wasm",
+    "pcobra.cobra.transpilers.transpiler.legacy.to_go",
+    "pcobra.cobra.transpilers.transpiler.legacy.to_java",
+    "pcobra.cobra.transpilers.transpiler.legacy.to_cpp",
+    "pcobra.cobra.transpilers.transpiler.legacy.to_asm",
+    "pcobra.cobra.transpilers.transpiler.legacy.to_wasm",
 )
 
 EXPECTED_PUBLIC_TARGETS = ("python", "javascript", "rust")
@@ -52,6 +52,45 @@ def test_normal_boot_paths_do_not_import_legacy_transpilers(module_name: str) ->
     assert module_name not in loaded_during_boot, (
         f"{module_name} fue cargado durante boot normal, violando política pública"
     )
+
+
+@pytest.mark.parity_contract
+def test_import_pcobra_exposes_lazy_public_api_without_legacy_transpiler_modules() -> None:
+    before = set(sys.modules)
+
+    package = importlib.import_module("pcobra")
+    after = set(sys.modules)
+
+    assert "cobra" in package.__all__
+    assert "core" in package.__all__
+    assert "cli" in package.__all__
+    assert "ia" in package.__all__
+    assert "jupyter_kernel" in package.__all__
+    assert "gui" in package.__all__
+    assert "lsp" in package.__all__
+    assert "compiler" in package.__all__
+
+    loaded_during_import = after - before
+    for module_name in LEGACY_TRANSPILER_MODULES:
+        assert module_name not in after
+        assert module_name not in loaded_during_import
+
+
+@pytest.mark.parity_contract
+@pytest.mark.parametrize(
+    "base_module",
+    ("pcobra.__main__", "pcobra.cli", "pcobra.cobra.cli.bootstrap"),
+)
+def test_base_command_import_paths_do_not_load_legacy_transpilers(base_module: str) -> None:
+    before = set(sys.modules)
+
+    importlib.import_module(base_module)
+
+    after = set(sys.modules)
+    loaded_during_import = after - before
+    for module_name in LEGACY_TRANSPILER_MODULES:
+        assert module_name not in after
+        assert module_name not in loaded_during_import
 
 
 @pytest.mark.parity_contract


### PR DESCRIPTION
### Motivation
- Evitar que el arranque normal (`import pcobra` y comandos base) cargue módulos de transpilers legacy bajo `transpiler/legacy/*` para mantener el contrato público y un startup mínimo.
- Asegurar mediante pruebas que la API pública lazy expuesta por `pcobra` no provoca imports ansiosos de módulos legacy.
- Documentar la distinción arquitectónica entre los tres backends oficiales activos y los transpilers legacy opcionales desactivados por defecto.

### Description
- Actualiza la enumeración `LEGACY_TRANSPILER_MODULES` a las rutas reales bajo `pcobra.cobra.transpilers.transpiler.legacy.*` en `tests/test_backend_startup_policy.py`.
- Añade pruebas que verifican que `import pcobra` expone la API lazy pública sin cargar módulos legacy (`test_import_pcobra_exposes_lazy_public_api_without_legacy_transpiler_modules`) y que rutas base de comando (`pcobra.__main__`, `pcobra.cli`, `pcobra.cobra.cli.bootstrap`) no cargan los módulos legacy (`test_base_command_import_paths_do_not_load_legacy_transpilers`).
- Conserva las verificaciones contractuales limitadas a los 3 backends oficiales (`python`, `javascript`, `rust`) en las pruebas de integración existentes.
- Añade el documento `docs/architecture/backends_oficiales_vs_legacy.md` que describe la diferencia entre backends oficiales activos y legacy opcional desactivado por defecto.

### Testing
- Ejecutado `pytest -q tests/test_backend_startup_policy.py tests/integration/transpilers/test_official_backends_contracts.py` y la suite pasó correctamente con `39 passed, 1 warning`.
- Las pruebas de contrato sobre los 3 backends oficiales se ejecutaron y permanecen sin cambios funcionales en su alcance (todos los checks relevantes pasaron).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff4b339e9883279ab9e288b0b46c69)