### PR TITLE
Fix runtime binding for `usar` imported callables in interpreter

### DIFF
--- a/informe_tecnico_binding_runtime_usar.md
+++ b/informe_tecnico_binding_runtime_usar.md
@@ -1,0 +1,33 @@
+# Informe técnico: binding runtime de `usar "numero"`
+
+## Resumen del problema
+Se verificó que `usar "numero"` resolvía e inyectaba símbolos saneados en runtime, pero al invocar funciones como `es_finito(10)` el intérprete caía en la rama de "Función no implementada" porque `ejecutar_llamada_funcion` solo ejecutaba funciones Cobra representadas como `dict` (`tipo == "funcion"`).
+
+## Causa raíz
+En `src/pcobra/core/interpreter.py`, `ejecutar_llamada_funcion` obtenía el símbolo por nombre y descartaba cualquier valor que no tuviera el descriptor interno de función Cobra. Los callables Python provenientes de `usar` (ya saneados e inyectados en contexto) no eran ejecutados.
+
+## Cambio aplicado
+1. Se mantuvo intacta la ruta de `usar` y su sanitización.
+2. Se añadió un bloque mínimo en `ejecutar_llamada_funcion` para soportar `callable(funcion)`:
+   - Evalúa argumentos con `self.evaluar_expresion`.
+   - Verifica cada argumento con `self._verificar_valor_contexto`.
+   - Ejecuta `funcion(*argumentos_resueltos)`.
+   - Verifica el resultado con `self._verificar_valor_contexto`.
+   - Retorna el resultado.
+3. La lógica existente para funciones Cobra definidas por usuario (`dict` con `tipo == "funcion"`) se mantiene sin cambios semánticos.
+
+## Seguridad y superficie pública
+- No se añadió import dinámico.
+- No se relajó sanitización de `usar`.
+- Solo se ejecutan callables ya presentes en el contexto del intérprete.
+- Se preserva el rechazo de módulos externos no canónicos en `usar`.
+
+## Cobertura añadida
+Se añadieron pruebas unitarias en `tests/unit/test_usar.py` para validar ejecución runtime de callables importados por `usar`:
+- `es_finito` ejecutable desde `ejecutar_llamada_funcion`.
+- `es_nan` ejecutable desde `ejecutar_llamada_funcion`.
+
+## Archivos modificados
+- `src/pcobra/core/interpreter.py`
+- `tests/unit/test_usar.py`
+- `informe_tecnico_binding_runtime_usar.md`

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1659,6 +1659,18 @@ class InterpretadorCobra:
                     print(valor)
         else:
             funcion = self.obtener_variable(nodo.nombre)
+
+            if callable(funcion):
+                argumentos_resueltos = []
+                for arg in nodo.argumentos:
+                    valor = self.evaluar_expresion(arg)
+                    self._verificar_valor_contexto(valor)
+                    argumentos_resueltos.append(valor)
+
+                resultado = funcion(*argumentos_resueltos)
+                self._verificar_valor_contexto(resultado)
+                return resultado
+
             if not isinstance(funcion, dict) or funcion.get("tipo") != "funcion":
                 if emitir_salida_llamada:
                     print(f"Funci\u00f3n '{nodo.nombre}' no implementada")

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -18,7 +18,7 @@ import pytest
 
 from core.interpreter import InterpretadorCobra
 from core.errors import InvalidTokenError
-from core.ast_nodes import NodoUsar
+from core.ast_nodes import NodoLlamadaFuncion, NodoUsar, NodoValor
 from core.environment import Environment
 from cobra.core import Lexer, Parser
 from cobra import usar_loader
@@ -238,6 +238,30 @@ def test_repl_usar_texto_permite_a_snake_sin_prefijo(monkeypatch):
     assert "a_snake" in interp.variables
     assert interp.obtener_variable("a_snake")("HolaMundo") == "hola_mundo"
 
+
+
+
+def test_repl_usar_numero_ejecuta_callable_runtime_es_finito(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_numero)
+    interp = _ejecutar_codigo('usar "numero"
+es_finito(10)')
+
+    llamada = NodoLlamadaFuncion("es_finito", [NodoValor(10)])
+    assert interp.ejecutar_llamada_funcion(llamada) is True
+
+
+def test_repl_usar_numero_ejecuta_callable_runtime_es_nan(monkeypatch):
+    import math
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_numero)
+    interp = _ejecutar_codigo('usar "numero"
+es_nan(10)')
+
+    llamada = NodoLlamadaFuncion("es_nan", [NodoValor(math.nan)])
+    assert interp.ejecutar_llamada_funcion(llamada) is True
 
 def test_repl_usar_detecta_colision_de_simbolo_existente(monkeypatch):
     import pcobra.corelibs.texto as modulo_texto


### PR DESCRIPTION
## Resumen
Corrige el fallo de runtime donde funciones saneadas e inyectadas por `usar "numero"` (por ejemplo `es_finito`) quedaban accesibles en contexto pero no ejecutables mediante llamadas del intérprete/REPL.

## Cambios principales
- `src/pcobra/core/interpreter.py`
  - En `ejecutar_llamada_funcion`, se añadió soporte explícito para `callable` Python ya presentes en el contexto:
    - evalúa argumentos con `evaluar_expresion`
    - valida argumentos y retorno con `_verificar_valor_contexto`
    - ejecuta `funcion(*argumentos_resueltos)` y retorna el resultado
  - Se mantiene intacto el flujo existente para funciones Cobra de usuario (descriptor `dict` con `tipo == "funcion"`).

- `tests/unit/test_usar.py`
  - Se agregaron pruebas para validar que, tras `usar "numero"`, el runtime ejecuta callables importados:
    - `es_finito`
    - `es_nan`

- `informe_tecnico_binding_runtime_usar.md`
  - Informe técnico con causa raíz, decisión de diseño, cambios y garantías de seguridad/superficie.

## Restricciones verificadas
- Sin cambios en lexer/parser ni sintaxis pública.
- Sin import dinámico adicional.
- Sin relajar sanitización de `usar`.
- Mantiene política canónica y compatibilidad con funciones Cobra de usuario.

## Archivos modificados
- `src/pcobra/core/interpreter.py`
- `tests/unit/test_usar.py`
- `informe_tecnico_binding_runtime_usar.md`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff61d966588327ac8424821db5abb1)