### PR TITLE
Agregar test de integración del REPL (entrypoint) para callables de "numero"

### DIFF
--- a/tests/integration/test_repl_entrypoint_numero_callable_output.py
+++ b/tests/integration/test_repl_entrypoint_numero_callable_output.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from types import ModuleType
+
+from pcobra.core import usar_loader as core_usar_loader
+from pcobra.cobra.cli.commands_v2.repl_cmd import ReplCommandV2
+
+
+def _modulo_numero_stub() -> ModuleType:
+    mod = ModuleType("numero")
+    mod.__all__ = ["es_finito", "es_nan"]
+    mod.es_finito = lambda valor: valor == valor and valor not in (float("inf"), float("-inf"))
+    mod.es_nan = lambda valor: valor != valor
+    mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/numero.py"
+    return mod
+
+
+def test_entrypoint_repl_real_usar_numero_callable_es_finito_y_es_nan(monkeypatch, capsys):
+    mod_numero = _modulo_numero_stub()
+
+    monkeypatch.setattr(
+        core_usar_loader,
+        "obtener_modulo_cobra_oficial",
+        lambda nombre: mod_numero if nombre == "numero" else (_ for _ in ()).throw(ModuleNotFoundError(nombre)),
+    )
+
+    cmd = ReplCommandV2()
+
+    cmd._ejecutar_en_modo_normal('usar "numero"')
+    cmd._ejecutar_en_modo_normal("imprimir(es_finito(10))")
+    cmd._ejecutar_en_modo_normal("imprimir(es_nan(10))")
+
+    salida = capsys.readouterr().out
+    assert "verdadero" in salida
+    assert "falso" in salida


### PR DESCRIPTION
### Motivation
- Confirmar el flujo exacto del REPL público `repl` y asegurar que `usar "numero"` + `es_finito(10)` termina en el mismo intérprete canónico y en su método `ejecutar_llamada_funcion`.
- Validar en integración el comportamiento observable (salida) cuando el entrypoint real del REPL inyecta callables runtime desde el módulo `numero`.
- Evitar cambios en la lógica del intérprete cuando el patrón `callable(funcion)` ya aplica y `_verificar_valor_contexto` se usa correctamente.

### Description
- Se añadió un nuevo test de integración `tests/integration/test_repl_entrypoint_numero_callable_output.py` que monkeypatcha `obtener_modulo_cobra_oficial` para exponer un stub de `numero` con `es_finito` y `es_nan` y ejecuta el flujo real del REPL vía `ReplCommandV2._ejecutar_en_modo_normal`.
- El test ejecuta en orden `cmd._ejecutar_en_modo_normal('usar "numero"')`, `cmd._ejecutar_en_modo_normal('imprimir(es_finito(10))')` y `cmd._ejecutar_en_modo_normal('imprimir(es_nan(10))')` y comprueba la salida textual `verdadero`/`falso`.
- No se modificó la implementación del intérprete; la inspección confirmó que `ReplCommandV2` delega en `InteractiveCommand` usando la misma instancia de `InterpretadorCobra` y que las llamadas terminan en `InterpretadorCobra.ejecutar_llamada_funcion` donde ya se usa `callable(funcion)` y `_verificar_valor_contexto`.

### Testing
- Ejecuté `pytest -q tests/integration/test_repl_entrypoint_numero_callable_output.py` y el test pasó (`1 passed`).
- El cambio fue añadido y confirmado con un commit que introduce únicamente el archivo de test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff64b079f4832793722c629489adb6)