### PR TITLE
Añade diagnóstico REPL controlado por PCOBRA_DEBUG_RUNTIME

### DIFF
--- a/docs/diagnostico_runtime_repl.md
+++ b/docs/diagnostico_runtime_repl.md
@@ -1,0 +1,33 @@
+# Diagnóstico de runtime REPL (`PCOBRA_DEBUG_RUNTIME`)
+
+Este diagnóstico está **desactivado por defecto**.
+
+## Activación
+
+En Linux/macOS:
+
+```bash
+PCOBRA_DEBUG_RUNTIME=1 cobra repl
+```
+
+En Windows (PowerShell):
+
+```powershell
+$env:PCOBRA_DEBUG_RUNTIME = "1"
+cobra repl
+```
+
+## Qué registra
+
+Cuando `PCOBRA_DEBUG_RUNTIME=1`:
+
+1. En el entrypoint del REPL se registra:
+   - la ruta del archivo Python (`__file__`) de la clase concreta del intérprete activo,
+   - la clase concreta que ejecuta la evaluación de llamadas de función.
+2. En `ejecutar_usar` se registra la lista de símbolos inyectados **solo por nombre** luego de sanitización.
+
+## Privacidad y alcance
+
+- No se exponen objetos internos ni contenido privado de backend.
+- El log de `usar` incluye únicamente nombres sanitizados de exportación pública.
+- Si el flag no está activo, no se emiten estos logs adicionales.

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -216,6 +216,22 @@ class InteractiveCommand(BaseCommand):
 
     _USAR_ALIAS_REPL = REPL_COBRA_MODULE_MAP
 
+    @staticmethod
+    def _runtime_debug_enabled() -> bool:
+        return os.getenv("PCOBRA_DEBUG_RUNTIME", "").strip() == "1"
+
+    def _log_runtime_diagnostics(self) -> None:
+        if not self._runtime_debug_enabled():
+            return
+        runtime_file = inspect.getfile(self.interpretador.__class__)
+        evaluador_llamadas = getattr(self.interpretador, "ejecutar_llamada_funcion", None)
+        evaluador_clase = type(evaluador_llamadas.__self__).__name__ if evaluador_llamadas else "desconocido"
+        self.logger.info(
+            "[PCOBRA_DEBUG_RUNTIME] interpreter_file=%s call_evaluator_class=%s",
+            runtime_file,
+            evaluador_clase,
+        )
+
     def __init__(self, interpretador: InterpretadorCobra) -> None:
         """Inicializa el comando interactivo.
 
@@ -241,6 +257,7 @@ class InteractiveCommand(BaseCommand):
         self._allowed_modes = frozenset({"analysis", "execution"})
         self.mode = "analysis"
         self._configurar_restriccion_usar_repl()
+        self._log_runtime_diagnostics()
 
     def _configurar_restriccion_usar_repl(self) -> None:
         """Activa la política estricta de ``usar`` en REPL.

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -111,6 +111,13 @@ USAR_SYMBOL_CONFLICT_ERROR = "usar_error[conflicto_simbolo]"
 USAR_COLLISION_STRICT_ERROR = "strict_error"
 USAR_COLLISION_WARN_ALIAS_REQUIRED = "warn_alias_required"
 _USAR_COLLISION_POLICIES = frozenset({USAR_COLLISION_STRICT_ERROR, USAR_COLLISION_WARN_ALIAS_REQUIRED})
+
+
+def _runtime_debug_enabled() -> bool:
+    """Habilita diagnóstico puntual de runtime vía entorno."""
+    return os.getenv("PCOBRA_DEBUG_RUNTIME", "").strip() == "1"
+
+
 def _ruta_import_permitida(ruta: str) -> bool:
     """Indica si una ruta está autorizada para importarse."""
 
@@ -1932,6 +1939,12 @@ class InterpretadorCobra:
 
             mapa_limpio, conflictos_saneamiento = sanitizar_exports_publicos(modulo, nombre_modulo)
             simbolos_saneados = list(mapa_limpio.items())
+            if _runtime_debug_enabled():
+                logging.info(
+                    "[PCOBRA_DEBUG_RUNTIME] usar=%s simbolos_inyectados=%s",
+                    nodo.modulo,
+                    sorted(mapa_limpio.keys()),
+                )
             if conflictos_saneamiento:
                 evento_conflictos = {
                     "evento": "usar_sanitize_conflicts",


### PR DESCRIPTION
### Motivation
- Facilitar diagnóstico de qué runtime/interpreter está activo en REPL para reportes de usuario sin exponer datos privados del backend.

### Description
- Añade chequeo de flag de entorno `PCOBRA_DEBUG_RUNTIME` y helper `_runtime_debug_enabled()` en `src/pcobra/core/interpreter.py` y `src/pcobra/cobra/cli/commands/interactive_cmd.py`.
- En el entrypoint del REPL se registra, cuando el flag está activo, la ruta del archivo Python de la clase concreta del intérprete activo y el nombre de la clase que evalúa llamadas de función.
- En `InterpretadorCobra.ejecutar_usar` se registra, bajo el mismo flag, únicamente los nombres sanitizados de los símbolos inyectados (`sorted(mapa_limpio.keys())`), evitando loggear objetos internos.
- Añade documentación en `docs/diagnostico_runtime_repl.md` que explica cómo activar el diagnóstico y las garantías de privacidad (logs desactivados por defecto y solo nombres publicados).

### Testing
- `python -m py_compile src/pcobra/core/interpreter.py src/pcobra/cobra/cli/commands/interactive_cmd.py` se ejecutó correctamente. (éxito)
- `python -m pytest -q tests/unit/test_usar.py tests/unit/test_repl_command_v2.py` falló en la colección debido a un `SyntaxError` preexistente en `tests/unit/test_usar.py:248` (error de entorno de pruebas, no introducido por este cambio).
- `python -m pytest -q tests/unit/test_repl_command_v2.py` mostró 5 fallos en tests del REPL v2 en este entorno (las pruebas fallaron al ejecutarse; ver salida para detalles de aserciones y firmas esperadas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff66905a8483278e193691e55fb17d)