### PR TITLE
Add REPL tests for `usar "numero"` callable invocation and boolean output

### DIFF
--- a/tests/integration/test_repl_entrypoint_numero_callable_output.py
+++ b/tests/integration/test_repl_entrypoint_numero_callable_output.py
@@ -19,7 +19,7 @@ def _modulo_numero_stub() -> ModuleType:
     return mod
 
 
-def test_entrypoint_repl_real_numero_stdout_canonico_y_sin_error_no_implementada(monkeypatch, capsys):
+def test_entrypoint_repl_real_numero_callable_y_stdout_canonico_sin_error_no_implementada(monkeypatch, capsys):
     mod_numero = _modulo_numero_stub()
 
     monkeypatch.setattr(
@@ -37,6 +37,26 @@ def test_entrypoint_repl_real_numero_stdout_canonico_y_sin_error_no_implementada
     assert "verdadero" in salida
     assert "falso" in salida
     assert "Función 'es_finito' no implementada" not in salida
+    assert "Función 'es_nan' no implementada" not in salida
+
+
+def test_entrypoint_repl_real_numero_callable_directo_sin_no_implementada(monkeypatch, capsys):
+    mod_numero = _modulo_numero_stub()
+
+    monkeypatch.setattr(
+        core_usar_loader,
+        "obtener_modulo_cobra_oficial",
+        lambda nombre: mod_numero if nombre == "numero" else (_ for _ in ()).throw(ModuleNotFoundError(nombre)),
+    )
+
+    cmd = ReplCommandV2()
+    cmd._ejecutar_en_modo_normal('usar "numero"')
+    cmd._ejecutar_en_modo_normal("es_finito(10)")
+    cmd._ejecutar_en_modo_normal("es_nan(10)")
+
+    salida = capsys.readouterr().out
+    assert "Función 'es_finito' no implementada" not in salida
+    assert "Función 'es_nan' no implementada" not in salida
 
 
 def test_entrypoint_repl_real_rechaza_simbolo_no_exportado_por_superficie_publica(monkeypatch):


### PR DESCRIPTION
### Motivation
- Asegurar que `usar "numero"` inyecta funciones como `es_finito`/`es_nan` como callables Python vinculados y que invocaciones directas no caen en el fallback de "Función no implementada". 
- Verificar que la salida canónica para booleanos sea `verdadero`/`falso` al usar `imprimir(...)` en REPL. 
- Comprobar que la ruta de funciones definidas por usuario (descriptor `dict` con `tipo == "funcion"`) permanece operativa tras ejecutar `usar`.

### Description
- Actualiza el test existente `test_entrypoint_repl_real_numero_stdout_canonico_y_sin_error_no_implementada` renombrándolo a `test_entrypoint_repl_real_numero_callable_y_stdout_canonico_sin_error_no_implementada` y añade la aserción que verifica que no aparece el mensaje de fallback para `es_nan`. 
- Añade el test `test_entrypoint_repl_real_numero_callable_directo_sin_no_implementada` que ejecuta `es_finito(10)` y `es_nan(10)` directamente en `ReplCommandV2` tras `usar "numero"` y valida que no se emite el mensaje `Función '...' no implementada`. 
- Archivo modificado: `tests/integration/test_repl_entrypoint_numero_callable_output.py`; cambio limpiamente test-only sin modificar runtime.

### Testing
- Ejecutado `pytest -q tests/integration/test_repl_entrypoint_numero_callable_output.py` y los tests pasaron (`5 passed`) con una advertencia deprecación registrada; no hubo fallos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff683728e883278f53df8a19e7c610)