### PR TITLE
test: validar filtrado de exports no públicos en `usar "numero"`

### DIFF
--- a/tests/unit/test_usar_runtime_policy.py
+++ b/tests/unit/test_usar_runtime_policy.py
@@ -96,6 +96,33 @@ def test_usar_runtime_no_exporta_simbolos_bloqueados(monkeypatch):
         assert prohibido not in interp.variables
 
 
+def test_usar_runtime_numero_filtra_simbolo_fuera_de_api_publica_y_no_lo_inyecta(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    mapa_limpio, _conflictos = usar_loader.sanitizar_exports_publicos(modulo_numero, "numero")
+    assert "desviacion_estandar" not in mapa_limpio
+
+    simbolos_inyectados: list[str] = []
+    inyeccion_real = InterpretadorCobra._inyectar_simbolos_usar_en_contexto
+
+    def _inyectar_con_espia(self, simbolos_saneados, *, modulo, permitir_sobrescritura=False):
+        simbolos_inyectados.extend(nombre for nombre, _ in simbolos_saneados)
+        return inyeccion_real(
+            self,
+            simbolos_saneados,
+            modulo=modulo,
+            permitir_sobrescritura=permitir_sobrescritura,
+        )
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _n, **_k: modulo_numero)
+    monkeypatch.setattr(InterpretadorCobra, "_inyectar_simbolos_usar_en_contexto", _inyectar_con_espia)
+
+    interp = _interp_con_alias({"numero": "numero"})
+    interp.ejecutar_nodo(NodoUsar("numero"))
+
+    assert "desviacion_estandar" not in simbolos_inyectados
+
+
 def test_usar_runtime_colision_warn_diagnostico_y_sin_overwrite(monkeypatch, caplog):
     modulo = ModuleType("texto")
     modulo.__all__ = ["a_snake", "a_camel"]


### PR DESCRIPTION
### Motivation
- Asegurar que símbolos fuera de la API pública canónica (ej. `desviacion_estandar`) sean filtrados por `sanitizar_exports_publicos` y no lleguen a la fase de inyección de `usar` en el intérprete.

### Description
- Agrega un test en `tests/unit/test_usar_runtime_policy.py` que importa `pcobra.corelibs.numero` y verifica que `sanitizar_exports_publicos` excluye `desviacion_estandar`.
- El test instrumenta `InterpretadorCobra._inyectar_simbolos_usar_en_contexto` con un espía para recopilar los símbolos realmente entregados a la inyección y comprueba que `desviacion_estandar` no esté presente.
- El test reutiliza la resolución vía `core_usar_loader.obtener_modulo` mediante `monkeypatch` y ejecuta el flujo completo con `ejecutar_nodo(NodoUsar("numero"))`.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_runtime_policy.py -k "filtra_simbolo_fuera_de_api_publica"` y la ejecución falló en la fase de colección con ImportError (`attempted relative import beyond top-level package`).
- Ejecuté `PYTHONPATH=src pytest -q tests/unit/test_usar_runtime_policy.py -k "filtra_simbolo_fuera_de_api_publica"` y volvió a fallar en colección por el mismo error de importación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6a46c1f88327b918868df7df7f1f)