### PR TITLE
test: cubrir casos negativos de `usar` para módulos no canónicos y flags Cobra-facing

### DIFF
--- a/tests/unit/test_usar_public_contract.py
+++ b/tests/unit/test_usar_public_contract.py
@@ -137,3 +137,41 @@ def test_public_backends_contrato_exacto_en_backend_policy():
 def test_public_backends_inmutable_tipo_tuple():
     assert isinstance(PUBLIC_BACKENDS, tuple)
     assert PUBLIC_BACKENDS == tuple(PUBLIC_BACKENDS)
+
+
+def test_rechaza_usar_ruta_backend_no_canonica_con_error_consistente():
+    interp = InterpretadorCobra()
+
+    class _NodoUsar:
+        modulo = "pcobra.corelibs.numero"
+
+    with pytest.raises(PermissionError, match=r"^usar_error\[backend_import_directo\]"):
+        interp.ejecutar_usar(_NodoUsar())
+
+
+def test_usar_rechaza_modulo_fuera_allowlist_aun_si_alias_map_lo_declara():
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero", "numpy": "numpy"})
+
+    class _NodoUsar:
+        modulo = "numpy"
+
+    with pytest.raises(PermissionError, match=r"^usar_error\[modulo_no_canonico\]"):
+        interp.ejecutar_usar(_NodoUsar())
+
+
+def test_usar_rechaza_modulo_no_cobra_facing_si_flag_false(monkeypatch):
+    mod_numero = _modulo_numero_stub()
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre: mod_numero)
+    from pcobra.cobra import usar_policy
+
+    monkeypatch.setitem(usar_policy.USAR_COBRA_FACING_MODULE_FLAGS, "numero", False)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl(REPL_COBRA_MODULE_MAP)
+
+    class _NodoUsar:
+        modulo = "numero"
+
+    with pytest.raises(PermissionError, match=r"^usar_error\[modulo_no_cobra_facing\]"):
+        interp.ejecutar_usar(_NodoUsar())


### PR DESCRIPTION
### Motivation
- Añadir cobertura de tests negativos para la resolución de `usar` y asegurar que se rechacen imports de backends externos/no-canónicos.
- Verificar que la validación respeta `USAR_COBRA_ALLOWLIST`, `USAR_COBRA_PUBLIC_MODULES` y las banderas `USAR_COBRA_FACING_MODULE_FLAGS` expuestas en la política canónica.

### Description
- Se añadieron 3 tests en `tests/unit/test_usar_public_contract.py` que ejercitan `_resolver_carga_modulo_usar` vía `InterpretadorCobra.ejecutar_usar` para los casos solicitados.
- Test 1 valida rechazo con error consistente para rutas backend/no canónicas (ej. `pcobra.corelibs.numero`) y espera `usar_error[backend_import_directo]`.
- Test 2 valida que un alias no canónico forzado en el alias map (ej. `numpy`) sigue siendo rechazado y se espera `usar_error[modulo_no_canonico]`.
- Test 3 verifica que si `USAR_COBRA_FACING_MODULE_FLAGS["numero"]` se marca `False`, entonces `usar "numero"` falla con `usar_error[modulo_no_cobra_facing]`; para ello el test parchea `usar_policy.USAR_COBRA_FACING_MODULE_FLAGS`.

### Testing
- Ejecutado: `pytest -q tests/unit/test_usar_public_contract.py -k 'ruta_backend_no_canonica or fuera_allowlist or no_cobra_facing'` y la ejecución final pasó correctamente con `3 passed, 15 deselected, 1 warning`.
- Las aserciones nuevas verifican mensajes de `PermissionError` con patrones regex que garantizan errores estructurados y consistentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6b78de1c8327a3f26d994ae02cba)