### PR TITLE
Registrar excepciones de callables en ejecutar_llamada_funcion

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1674,7 +1674,14 @@ class InterpretadorCobra:
                     self._verificar_valor_contexto(valor)
                     argumentos_resueltos.append(valor)
 
-                resultado = funcion(*argumentos_resueltos)
+                try:
+                    resultado = funcion(*argumentos_resueltos)
+                except Exception:
+                    logging.exception(
+                        "Error en callable '%s' durante ejecutar_llamada_funcion",
+                        nodo.nombre,
+                    )
+                    raise
                 self._verificar_valor_contexto(resultado)
                 return resultado
 


### PR DESCRIPTION
### Motivation
- Evitar errores silenciosos al invocar callables nativos y garantizar trazabilidad homogénea sin cambiar la semántica de propagación.

### Description
- En `src/pcobra/core/interpreter.py` alrededor del bloque `if callable(funcion):` se envolvió la llamada `funcion(*argumentos_resueltos)` en `try/except Exception`, se añadió `logging.exception("Error en callable '%s' durante ejecutar_llamada_funcion", nodo.nombre)` y se vuelve a lanzar la excepción con `raise`.

### Testing
- Ejecuté `pytest -q`, que falló por errores de importación previos en la suite (módulos `to_cpp`, `to_go` y símbolo `enabled_internal_legacy_targets` faltantes), y los fallos no están relacionados con este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6c85f850832780d049fb4d7dc50e)