### PR TITLE
tests: separar casos de es_nan en tests/unit/test_usar.py

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -251,15 +251,26 @@ def test_repl_usar_numero_ejecuta_callable_runtime_es_finito(monkeypatch):
     assert interp.ejecutar_llamada_funcion(llamada) is True
 
 
-def test_repl_usar_numero_ejecuta_callable_runtime_es_nan(monkeypatch):
+def test_repl_usar_numero_ejecuta_callable_runtime_es_nan_con_math_nan(monkeypatch):
     import math
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_numero)
+    # Caso explícito: validar es_nan(math.nan) en runtime.
+    interp = _ejecutar_codigo('usar \"numero\"\nes_nan(math.nan)')
+
+    llamada = NodoLlamadaFuncion("es_nan", [NodoValor(math.nan)])
+    assert interp.ejecutar_llamada_funcion(llamada) is True
+
+
+def test_repl_usar_numero_ejecuta_callable_runtime_es_nan_con_entero(monkeypatch):
     import pcobra.corelibs.numero as modulo_numero
 
     monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_numero)
     interp = _ejecutar_codigo('usar \"numero\"\nes_nan(10)')
 
-    llamada = NodoLlamadaFuncion("es_nan", [NodoValor(math.nan)])
-    assert interp.ejecutar_llamada_funcion(llamada) is True
+    llamada = NodoLlamadaFuncion("es_nan", [NodoValor(10)])
+    assert interp.ejecutar_llamada_funcion(llamada) is False
 
 def test_repl_usar_detecta_colision_de_simbolo_existente(monkeypatch):
     import pcobra.corelibs.texto as modulo_texto


### PR DESCRIPTION
### Motivation
- Aclarar intención y expectativa de la prueba que verifica `es_nan` separando el caso explícito con `math.nan` del caso con un entero, para facilitar el diagnóstico de fallos.
- Evitar mezclar ambos escenarios en una sola prueba y mantener nombre/setup/expectativa alineados con lo que se valida en runtime.

### Description
- Renombrada la prueba original a `test_repl_usar_numero_ejecuta_callable_runtime_es_nan_con_math_nan` y añadí un comentario que indica explícitamente que valida `es_nan(math.nan)`.
- Añadida una prueba independiente `test_repl_usar_numero_ejecuta_callable_runtime_es_nan_con_entero` que cubre `es_nan(10)` con resultado esperado `False`.
- Ajustados los invocados de runtime con `_ejecutar_codigo('usar \"numero\"\nes_nan(...)')` y las llamadas `NodoLlamadaFuncion`/`NodoValor` correspondientes para cada caso.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar.py -k 'es_nan_con_math_nan or es_nan_con_entero'` y la primera ejecución falló en colección por un `SyntaxError` en un literal multilínea, el cual fue corregido y el archivo actualizado.
- Tras la corrección volví a ejecutar el mismo filtro y la ejecución falló en la fase de importación con `ImportError: attempted relative import beyond top-level package`, un problema de entorno/imports no relacionado con la lógica de las pruebas nuevas.
- Resultado: las nuevas pruebas están incorporadas en el archivo y sintácticamente correctas, pero no llegaron a ejecutarse con éxito debido al error de importación del entorno durante la recolección de tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff7c636c488327877f8256a59abfe5)