### PR TITLE
Ajustar ruta interna de `texto` en runtime de `usar` del REPL

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -40,6 +40,8 @@ USAR_COBRA_FACING_MODULE_FLAGS: dict[str, bool] = {
 REPL_COBRA_MODULE_INTERNAL_PATH_MAP: dict[str, str] = {
     modulo: f"src/pcobra/corelibs/{modulo}.py" for modulo in USAR_COBRA_PUBLIC_MODULES
 }
+# `texto` debe apuntar al módulo que cubre completo USAR_RUNTIME_EXPORT_OVERRIDES["texto"] para evitar regresiones.
+REPL_COBRA_MODULE_INTERNAL_PATH_MAP["texto"] = "src/pcobra/standard_library/texto.py"
 
 
 


### PR DESCRIPTION
### Motivation
- Ajustar la resolución interna del alias `texto` para que use el módulo que implementa completamente la API esperada por el runtime sin modificar la whitelist ni las políticas de seguridad.

### Description
- Cambié únicamente la entrada `REPL_COBRA_MODULE_INTERNAL_PATH_MAP["texto"]` en `src/pcobra/cobra/usar_policy.py` para que apunte a `src/pcobra/standard_library/texto.py` y añadí un comentario breve que explica por qué debe apuntar a ese módulo; las demás entradas y las listas/flags (p. ej. `USAR_COBRA_PUBLIC_MODULES`, `USAR_COBRA_ALLOWLIST`, `USAR_COBRA_FACING_MODULE_FLAGS`) permanecen intactas.

### Testing
- Se compiló el archivo modificado con `python -m py_compile src/pcobra/cobra/usar_policy.py` y la comprobación terminó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff81d9f9988327b969886b3346e90e)