### PR TITLE
Añadir regresión de `usar "texto"` para símbolo fuera de API pública

### DIFF
--- a/tests/integration/test_usar_runtime_contract.py
+++ b/tests/integration/test_usar_runtime_contract.py
@@ -91,3 +91,40 @@ def test_rechaza_numpy_en_repl_estricto_sin_inyeccion(monkeypatch):
         interp.ejecutar_usar(_nodo("numpy"))
 
     assert estado_pre == interp.contextos[-1].values
+
+
+def test_texto_simbolo_existente_fuera_de_override_falla_como_no_declarado(monkeypatch):
+    mod = ModuleType("texto")
+    mod.__all__ = [*USAR_RUNTIME_EXPORT_OVERRIDES["texto"], "normalizar_unicode"]
+    for name in USAR_RUNTIME_EXPORT_OVERRIDES["texto"]:
+        setattr(mod, name, lambda *args, **kwargs: (args, kwargs))
+    mod.normalizar_unicode = lambda texto, forma="NFC": texto
+    mod.__file__ = "/workspace/pCobra/src/pcobra/standard_library/texto.py"
+
+    monkeypatch.setattr("pcobra.core.usar_loader.obtener_modulo_cobra_oficial", lambda _nombre: mod)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"texto": "texto"})
+    interp.ejecutar_usar(_nodo("texto"))
+
+    assert "normalizar_unicode" not in interp.contextos[-1].values
+    with pytest.raises(NameError, match=r"^Variable no declarada: normalizar_unicode$"):
+        interp.contextos[-1].get("normalizar_unicode")
+
+
+def test_texto_mantiene_filtro_outside_public_api_en_mapeo_interno():
+    mod = ModuleType("texto")
+    mod.__all__ = [*USAR_RUNTIME_EXPORT_OVERRIDES["texto"], "normalizar_unicode"]
+    for name in USAR_RUNTIME_EXPORT_OVERRIDES["texto"]:
+        setattr(mod, name, lambda *args, **kwargs: (args, kwargs))
+    mod.normalizar_unicode = lambda texto, forma="NFC": texto
+
+    from pcobra.core.usar_loader import sanitizar_exports_publicos
+
+    mapa_limpio, conflictos = sanitizar_exports_publicos(mod, "texto")
+
+    assert "normalizar_unicode" not in mapa_limpio
+    assert any(
+        conflicto.get("symbol") == "normalizar_unicode" and conflicto.get("code") == "outside_public_api"
+        for conflicto in conflictos
+    )


### PR DESCRIPTION
### Motivation

- Asegurar que `usar "texto"` no inyecte símbolos presentes en el módulo fuente que no pertenezcan a la API pública canónica definida en `USAR_RUNTIME_EXPORT_OVERRIDES["texto"]`.

### Description

- Se añadió el identificador real `normalizar_unicode` (presente en `src/pcobra/standard_library/texto.py` y no listado en `USAR_RUNTIME_EXPORT_OVERRIDES["texto"]`) como caso de prueba.
- Se agregó la prueba de integración `test_texto_simbolo_existente_fuera_de_override_falla_como_no_declarado` en `tests/integration/test_usar_runtime_contract.py` que hace `interp.ejecutar_usar(_nodo("texto"))`, verifica que `normalizar_unicode` no esté en el contexto y que su acceso se comporte como `NameError` canonico (`Variable no declarada`).
- Se añadió la prueba `test_texto_mantiene_filtro_outside_public_api_en_mapeo_interno` que invoca `sanitizar_exports_publicos(mod, "texto")` y verifica que `normalizar_unicode` sea excluido del `mapa_limpio` y aparezca en `conflictos` con `code == "outside_public_api"`.
- Las pruebas usan `monkeypatch` para reemplazar la carga del módulo y simular un `__all__` que incluye el símbolo no permitido.

### Testing

- Ejecuté `pytest -q tests/integration/test_usar_runtime_contract.py` y todas las pruebas del archivo pasaron (`6 passed`) con una advertencia deprecatoria; el nuevo test pasó correctamente.
- No se introdujeron tests fallidos ni regresiones en este paquete de pruebas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff82db7f5c8327b70a31bf2cab7298)