### PR TITLE
Aclarar contrato de mapeo interno de `texto` y marcar test de regresión

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -40,7 +40,7 @@ USAR_COBRA_FACING_MODULE_FLAGS: dict[str, bool] = {
 REPL_COBRA_MODULE_INTERNAL_PATH_MAP: dict[str, str] = {
     modulo: f"src/pcobra/corelibs/{modulo}.py" for modulo in USAR_COBRA_PUBLIC_MODULES
 }
-# `texto` debe apuntar al módulo que cubre completo USAR_RUNTIME_EXPORT_OVERRIDES["texto"] para evitar regresiones.
+# Regresión: `texto` debe resolver al módulo que implementa todo USAR_RUNTIME_EXPORT_OVERRIDES["texto"].
 REPL_COBRA_MODULE_INTERNAL_PATH_MAP["texto"] = "src/pcobra/standard_library/texto.py"
 
 

--- a/tests/integration/test_usar_runtime_contract.py
+++ b/tests/integration/test_usar_runtime_contract.py
@@ -112,7 +112,7 @@ def test_texto_simbolo_existente_fuera_de_override_falla_como_no_declarado(monke
         interp.contextos[-1].get("normalizar_unicode")
 
 
-def test_texto_mantiene_filtro_outside_public_api_en_mapeo_interno():
+def test_regresion_texto_detecta_mapeo_interno_incompleto_y_filtra_fuera_de_api_publica():
     mod = ModuleType("texto")
     mod.__all__ = [*USAR_RUNTIME_EXPORT_OVERRIDES["texto"], "normalizar_unicode"]
     for name in USAR_RUNTIME_EXPORT_OVERRIDES["texto"]:


### PR DESCRIPTION
### Motivation
- Evitar regresiones donde el alias `texto` sea mapeado a una implementación incompleta, dejando explícito que `texto` debe resolver al módulo que implementa todo lo declarado en `USAR_RUNTIME_EXPORT_OVERRIDES["texto"]` y hacer más clara la intención del test asociado.

### Description
- Actualiza el comentario junto a `REPL_COBRA_MODULE_INTERNAL_PATH_MAP` para advertir explícitamente que `texto` debe resolver al módulo que implementa completamente `USAR_RUNTIME_EXPORT_OVERRIDES["texto"]`.
- Renombra el test de integración relacionado de `test_texto_mantiene_filtro_outside_public_api_en_mapeo_interno` a `test_regresion_texto_detecta_mapeo_interno_incompleto_y_filtra_fuera_de_api_publica` para indicar que es una comprobación de regresión.

### Testing
- Ejecuté `pytest -q tests/integration/test_usar_runtime_contract.py -k texto` y las pruebas relacionadas pasaron (`2 passed, 4 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff83e3bba083279f32396eb43b5bd3)