### PR TITLE
test: cubrir callables de `usar "texto"` en runtime

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -272,6 +272,19 @@ def test_repl_usar_numero_ejecuta_callable_runtime_es_nan_con_entero(monkeypatch
     llamada = NodoLlamadaFuncion("es_nan", [NodoValor(10)])
     assert interp.ejecutar_llamada_funcion(llamada) is False
 
+
+
+def test_repl_usar_texto_ejecuta_callables_runtime_basicos(monkeypatch):
+    import pcobra.corelibs.texto as modulo_texto
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_texto)
+    interp = _ejecutar_codigo('usar "texto"\nrecortar("  cobra  ")')
+
+    assert interp.obtener_variable("recortar")("  cobra  ") == "cobra"
+    assert interp.obtener_variable("repetir")("ja", 3) == "jajaja"
+    assert interp.obtener_variable("quitar_acentos")("canción") == "cancion"
+    assert interp.obtener_variable("prefijo_comun")("cobra", "cobre") == "cobr"
+    assert interp.obtener_variable("sufijo_comun")("programacion", "nacion") == "acion"
 def test_repl_usar_detecta_colision_de_simbolo_existente(monkeypatch):
     import pcobra.corelibs.texto as modulo_texto
 


### PR DESCRIPTION
### Motivation
- Añadir cobertura para los bindings runtime del módulo `texto`, validando que `usar "texto"` inyecta y ejecuta correctamente funciones de utilidad (recorte, repetición, eliminación de acentos y búsqueda de prefijo/sufijo común).

### Description
- Se agregó el test `test_repl_usar_texto_ejecuta_callables_runtime_basicos` en `tests/unit/test_usar.py` siguiendo el mismo patrón de fixtures existente (`monkeypatch` sobre `core_usar_loader.obtener_modulo` y uso de `_ejecutar_codigo`).
- El test verifica exactamente las llamadas: `recortar("  cobra  ") -> "cobra"`, `repetir("ja", 3) -> "jajaja"`, `quitar_acentos("canción") -> "cancion"`, `prefijo_comun("cobra","cobre") -> "cobr"` y `sufijo_comun("programacion","nacion") -> "acion"`.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar.py -k "texto_ejecuta_callables_runtime_basicos or usar_texto_permite_a_snake"` y la colección de tests falló con `ImportError: attempted relative import beyond top-level package` durante la importación del módulo de pruebas; por tanto la nueva prueba fue añadida pero no completó ejecución en este entorno automatizado debido al problema de import paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8567fb508327b4405cb6c361a95a)