### PR TITLE
test(usar): cubrir acceso a símbolo de texto fuera de API pública

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -789,6 +789,33 @@ def test_usar_rechaza_modulo_no_canonico_en_repl_estricto():
         interp.ejecutar_nodo(NodoUsar("numero"))
 
 
+
+
+def test_repl_usar_texto_simbolo_fuera_de_overrides_no_disponible(monkeypatch):
+    import pcobra.corelibs.texto as modulo_texto
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_texto)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"texto": "texto"})
+
+    with pytest.raises(NameError, match=r"capitalizar"):
+        _ejecutar_codigo('usar "texto"\ncapitalizar("hola")', interp)
+
+
+def test_usar_texto_mantiene_filtro_outside_public_api_para_capitalizar():
+    import pcobra.corelibs.texto as modulo_texto
+
+    _, conflictos = core_usar_loader.sanitizar_exports_publicos(modulo_texto, "texto")
+    conflicto_capitalizar = next(
+        (c for c in conflictos if c.get("symbol") == "capitalizar"),
+        None,
+    )
+
+    assert conflicto_capitalizar is not None
+    assert conflicto_capitalizar["code"] == "outside_public_api"
+
+
 def test_usar_error_export_invalido_es_diferenciado(monkeypatch):
     modulo = ModuleType("texto")
     modulo.__all__ = ["NO_CALLABLE"]


### PR DESCRIPTION
### Motivation

- Evitar regresiones en el contrato de superficie de `usar` asegurando que símbolos presentes en el backend de `texto` pero fuera de `USAR_RUNTIME_EXPORT_OVERRIDES["texto"]` no queden disponibles en runtime.
- Comprobar explícita y programáticamente que el filtro `outside_public_api` sigue activo para símbolos no públicos como `capitalizar`.

### Description

- Añadí dos pruebas en `tests/unit/test_usar.py`: `test_repl_usar_texto_simbolo_fuera_de_overrides_no_disponible` que ejecuta `usar "texto"` e intenta invocar `capitalizar("hola")` y `test_usar_texto_mantiene_filtro_outside_public_api_para_capitalizar` que inspecciona el resultado de `sanitizar_exports_publicos(..., "texto")`.
- Las pruebas usan `monkeypatch` para forzar que `obtener_modulo` devuelva `pcobra.corelibs.texto`, configuran el REPL con `interp.configurar_restriccion_usar_repl({"texto":"texto"})` y asertan el `NameError` y la clasificación `outside_public_api` respectivamente.
- Cambios aplicados únicamente en `tests/unit/test_usar.py` (se insertaron ~27 líneas de tests adicionales). 

### Testing

- Ejecuté `pytest -q tests/unit/test_usar.py -k "capitalizar or export_invalido"` y la ejecución de colección falló con `ImportError: attempted relative import beyond top-level package` impidiendo que las nuevas aserciones se ejecutaran.
- Reintenté con `PYTHONPATH=src pytest -q tests/unit/test_usar.py -k "capitalizar or export_invalido"` y obtuve la misma falla de colección, por lo que las pruebas nuevas no pudieron completarse en este entorno automatizado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff868e0b308327934e87b9424b114a)