### PR TITLE
test(usar): reforzar no-regresión de numpy/numero tras ajuste de texto

### DIFF
--- a/tests/integration/test_usar_runtime_contract.py
+++ b/tests/integration/test_usar_runtime_contract.py
@@ -87,9 +87,10 @@ def test_rechaza_numpy_en_repl_estricto_sin_inyeccion(monkeypatch):
     interp.configurar_restriccion_usar_repl({"numero": "numero"})
     estado_pre = dict(interp.contextos[-1].values)
 
-    with pytest.raises(PermissionError, match="modulo_fuera_catalogo_publico|módulo externo no permitido en REPL estricto"):
+    with pytest.raises(PermissionError, match="modulo_fuera_catalogo_publico|módulo externo no permitido en REPL estricto") as exc:
         interp.ejecutar_usar(_nodo("numpy"))
 
+    assert "usar_error[modulo_fuera_catalogo_publico]" in str(exc.value)
     assert estado_pre == interp.contextos[-1].values
 
 

--- a/tests/unit/test_usar_runtime_policy.py
+++ b/tests/unit/test_usar_runtime_policy.py
@@ -19,7 +19,7 @@ def _interp_con_alias(alias_map: dict[str, str]) -> InterpretadorCobra:
     return interp
 
 
-def test_usar_runtime_numero_expone_solo_api_espanola(monkeypatch):
+def test_no_regresion_ajuste_texto_usar_runtime_numero_expone_solo_api_espanola(monkeypatch):
     import pcobra.corelibs.numero as modulo_numero
 
     monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _n, **_k: modulo_numero)
@@ -27,6 +27,7 @@ def test_usar_runtime_numero_expone_solo_api_espanola(monkeypatch):
     interp.ejecutar_nodo(NodoUsar("numero"))
 
     assert "es_finito" in interp.variables
+    assert "es_par" in interp.variables
     assert "isfinite" not in interp.variables
 
 


### PR DESCRIPTION
### Motivation

- Asegurar que `usar "numpy"` sigue siendo rechazado por la política de `usar` y que `usar "numero"` continúa exponiendo la API pública canónica tras ajustes en `texto`.
- Documentar explícitamente en el nombre del test unitario la cobertura de no-regresión relacionada con el ajuste de `texto`.
- Evitar cualquier cambio en listas de permitidos o políticas; los cambios son únicamente en las pruebas.

### Description

- Renombré el test unitario a `test_no_regresion_ajuste_texto_usar_runtime_numero_expone_solo_api_espanola` y añadí la aserción `assert "es_par" in interp.variables` para reforzar la superficie pública esperada en `numero` (archivo modificado: `tests/unit/test_usar_runtime_policy.py`).
- En el test de integración `test_rechaza_numpy_en_repl_estricto_sin_inyeccion` capturo la excepción y verifico explícitamente que el mensaje de error contenga `usar_error[modulo_fuera_catalogo_publico]` para dejar constancia del rechazo por política (archivo modificado: `tests/integration/test_usar_runtime_contract.py`).
- No se tocaron allowlists, flags ni código de runtime; los cambios se limitan a ajustes de aserciones y nombres de pruebas para cubrir no-regresión.

### Testing

- Ejecuté `pytest -q tests/integration/test_usar_runtime_contract.py` y los tests de integración relevantes pasaron (6 passed, 1 warning).
- Ejecuté `pytest -q tests/unit/test_usar_runtime_policy.py tests/integration/test_usar_runtime_contract.py` y la colección falló con un `ImportError` por un import path legacy/depredado en este entorno durante la recolección de tests unitarios; el fallo es de configuración de entorno y no de las aserciones añadidas.
- Las pruebas de integración confirmaron que `usar "numpy"` continúa rechazándose y que la inyección de símbolos no ocurre tras el error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff894631c483278e139fad9428a810)