### PR TITLE
test: reforzar chequeo estructural de exportes runtime en texto

### DIFF
--- a/tests/core/test_superficie_publica_canonica.py
+++ b/tests/core/test_superficie_publica_canonica.py
@@ -99,3 +99,20 @@ def test_aliases_controlados_por_contrato(modulo: str, aliases: dict[str, str]):
 def test_override_runtime_sin_simbolos_prohibidos(modulo: str, exportes: tuple[str, ...]):
     assert all("__" not in nombre for nombre in exportes)
     assert PROHIBIDOS.isdisjoint(exportes)
+
+
+def test_texto_override_runtime_expuesto_por_modulo_mapeado() -> None:
+    ruta_relativa = REPL_COBRA_MODULE_INTERNAL_PATH_MAP["texto"]
+    ruta_modulo = RAIZ_REPO / ruta_relativa
+
+    publicos = set(_nombres_publicos(ruta_modulo))
+    exportes_runtime_texto = set(USAR_RUNTIME_EXPORT_OVERRIDES["texto"])
+
+    faltantes = sorted(exportes_runtime_texto - publicos)
+    assert not faltantes, (
+        "El módulo mapeado para 'texto' debe exponer todos los símbolos de "
+        f"USAR_RUNTIME_EXPORT_OVERRIDES['texto']; faltan: {faltantes}"
+    )
+
+    for nombre in ("recortar", "repetir", "quitar_acentos", "prefijo_comun", "sufijo_comun"):
+        assert nombre in publicos, f"texto debe exportar obligatoriamente {nombre}"


### PR DESCRIPTION
### Motivation
- Añadir un guardrail estructural para detectar regresiones tempranas en las exportaciones esperadas del módulo `texto` sin ejecutar REPL real. 
- Evitar que cambios en el mapeo de rutas o en `__all__` de `texto` pasen desapercibidos respecto a `USAR_RUNTIME_EXPORT_OVERRIDES["texto"]`.

### Description
- Se añadió el test `test_texto_override_runtime_expuesto_por_modulo_mapeado` en `tests/core/test_superficie_publica_canonica.py` que carga el archivo mapeado por `REPL_COBRA_MODULE_INTERNAL_PATH_MAP["texto"]` y analiza su `__all__` por AST. 
- El test verifica que el conjunto de nombres declarado en `__all__` incluya todos los símbolos de `USAR_RUNTIME_EXPORT_OVERRIDES["texto"]`. 
- Además exige explícitamente que existan los símbolos `recortar`, `repetir`, `quitar_acentos`, `prefijo_comun` y `sufijo_comun` en las exportaciones públicas.

### Testing
- Ejecutado: `pytest -q tests/unit/test_usar_policy_contract.py tests/core/test_superficie_publica_canonica.py`.
- Resultado: los tests nuevos se agregaron correctamente pero la ejecución mostró fallos preexistentes que no son introducidos por este cambio: la resolución de `texto` apunta actualmente a `src/pcobra/corelibs/texto.py` cuando se esperaba `src/pcobra/standard_library/texto.py`, la validación de paridad de superficie pública falla por desalineación/orden de exportes en `numero`, y `texto` no exporta `dividir` en `__all__` según el contrato; en total `3 failed, 43 passed, 1 warning`.
- El test agregado es puramente estructural (AST de `__all__`) y no importa ni ejecuta REPL, por lo que actúa como chequeo temprano de regresiones en la superficie pública.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8a39994883279930763e91f7edf3)