### PR TITLE
Actualizar mapeo interno canónico de `usar` por módulo

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -36,12 +36,27 @@ USAR_COBRA_FACING_MODULE_FLAGS: dict[str, bool] = {
     modulo: True for modulo in USAR_COBRA_PUBLIC_MODULES
 }
 
+def _build_repl_cobra_module_internal_path_map() -> dict[str, str]:
+    """Construye el mapeo oficial `alias usar` -> ruta interna por módulo."""
+
+    return {
+        # Mantener `numero` en corelibs para no introducir regresión de resolución.
+        "numero": "src/pcobra/corelibs/numero.py",
+        # `texto` y `datos` exponen su API pública real desde standard_library.
+        "texto": "src/pcobra/standard_library/texto.py",
+        "datos": "src/pcobra/standard_library/datos.py",
+        "logica": "src/pcobra/corelibs/logica.py",
+        "asincrono": "src/pcobra/corelibs/asincrono.py",
+        "sistema": "src/pcobra/corelibs/sistema.py",
+        "archivo": "src/pcobra/corelibs/archivo.py",
+        "tiempo": "src/pcobra/corelibs/tiempo.py",
+        "red": "src/pcobra/corelibs/red.py",
+        "holobit": "src/pcobra/corelibs/holobit.py",
+    }
+
+
 # Fuente única de verdad: alias canónico `usar` -> ruta interna oficial.
-REPL_COBRA_MODULE_INTERNAL_PATH_MAP: dict[str, str] = {
-    modulo: f"src/pcobra/corelibs/{modulo}.py" for modulo in USAR_COBRA_PUBLIC_MODULES
-}
-# Regresión: `texto` debe resolver al módulo que implementa todo USAR_RUNTIME_EXPORT_OVERRIDES["texto"].
-REPL_COBRA_MODULE_INTERNAL_PATH_MAP["texto"] = "src/pcobra/standard_library/texto.py"
+REPL_COBRA_MODULE_INTERNAL_PATH_MAP: dict[str, str] = _build_repl_cobra_module_internal_path_map()
 
 
 


### PR DESCRIPTION
### Motivation
- Reemplazar el mapeo genérico por un mapeo explícito por módulo para garantizar que cada alias de `usar` resuelva a la ruta interna correcta según la auditoría de la Tarea 1. 
- Evitar regresiones manteniendo `numero` apuntando a su ruta actual en `corelibs`. 
- Asegurar que `texto` y `datos` apunten a los módulos donde vive su API funcional real (`standard_library`). 
- Centralizar la construcción del mapa en un único helper para evitar duplicación de lógica y facilitar futuros cambios.

### Description
- Se añadió la función helper `_build_repl_cobra_module_internal_path_map()` y se reemplazó la asignación genérica de `REPL_COBRA_MODULE_INTERNAL_PATH_MAP` por la llamada a este helper en `src/pcobra/cobra/usar_policy.py`.
- El mapeo explícito ahora contiene rutas por módulo, manteniendo `"numero": "src/pcobra/corelibs/numero.py"` y resolviendo `"texto"` y `"datos"` a `src/pcobra/standard_library/` según lo esperado.
- No se modificaron la sintaxis pública, el lexer/parser, las validaciones de sanitización global ni la protección de `backend_module_object`, y la validación de contrato (`validar_contrato_modulos_canonicos_usar`) permanece intacta.
- Cambio localizado en `src/pcobra/cobra/usar_policy.py` y la lógica de resolución queda centralizada para evitar duplicidad.

### Testing
- Ejecuté `python -m compileall src/pcobra/cobra/usar_policy.py` y la compilación está correcta y sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003a29dafc8327bc80a17872953b29)