### PR TITLE
chore(ci): enforce `usar`-fix scope in PR checklist and CI guard

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,16 @@ Describe el alcance de los cambios y su impacto en el proyecto o en la cobertura
 código.
 
 
+## Alcance de este PR (obligatorio)
+
+- [ ] Este PR está acotado exclusivamente a política/resolución de `usar` + tests.
+- [ ] Confirmo explícitamente que **NO** se modifican estos archivos:
+  - `src/pcobra/core/lexer.py`
+  - `src/pcobra/core/parser.py`
+  - `src/pcobra/cobra/core/lexer.py`
+  - `src/pcobra/cobra/core/parser.py`
+
+
 ## Checklist corto (parseo de strings)
 
 - [ ] No hay `ParserError` para literales string en expresiones.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,27 @@ jobs:
       - name: Validate public targets policy (blocking)
         shell: bash
         run: python scripts/validate_targets_policy.py
+
+      - name: Guard protected lexer/parser files unchanged in `usar` fix scope (blocking)
+        shell: bash
+        run: |
+          git diff --name-only origin/${{ github.base_ref }}...HEAD | tee /tmp/changed_files.txt
+          protected_files=(
+            "src/pcobra/core/lexer.py"
+            "src/pcobra/core/parser.py"
+            "src/pcobra/cobra/core/lexer.py"
+            "src/pcobra/cobra/core/parser.py"
+          )
+
+          for f in "${protected_files[@]}"; do
+            if rg -n "^${f}$" /tmp/changed_files.txt > /dev/null; then
+              echo "❌ Archivo protegido modificado fuera de alcance de fix de 'usar': ${f}" >&2
+              exit 1
+            fi
+          done
+
+          echo "✅ Verificación de alcance superada: no hay cambios en lexer/parser protegidos."
+
       - name: Validate `usar` public contract (blocking)
         shell: bash
         run: pytest tests/integration/test_usar_public_contract_regression.py tests/integration/test_usar_core_contract_full.py


### PR DESCRIPTION
### Motivation
- Asegurar que los fixes relacionados con la política/resolución de `usar` queden explícitamente acotados y revisables en PRs. 
- Evitar cambios accidentales en los componentes del lenguaje (`lexer`/`parser`) durante un fix de alcance limitado. 

### Description
- Se añadió una sección obligatoria en la plantilla de PR `.github/PULL_REQUEST_TEMPLATE.md` que obliga a declarar que el PR está limitado a política/resolución de `usar` + tests y a confirmar que no se modifican los archivos protegidos. 
- Los archivos marcados como protegidos son `src/pcobra/core/lexer.py`, `src/pcobra/core/parser.py`, `src/pcobra/cobra/core/lexer.py` y `src/pcobra/cobra/core/parser.py`. 
- Se añadió un paso bloqueante en el workflow de CI `.github/workflows/ci.yml` que revisa el diff del PR y falla si cualquiera de esos cuatro archivos aparece en el cambio. 
- No se realizan cambios funcionales en `lexer`/`parser`; el alcance es exclusivamente de política/alcance de `usar` y pruebas asociadas. 

### Testing
- No se ejecutaron pruebas automatizadas localmente durante este cambio. 
- La nueva verificación en CI es bloqueante y se ejecutará antes de las validaciones de `usar`, y no permitirá continuar si aparecen modificaciones en los archivos protegidos. 
- El pipeline existente seguirá ejecutando los tests de contrato relevantes en CI, incluyendo `pytest tests/integration/test_usar_public_contract_regression.py` y `pytest tests/integration/test_usar_core_contract_full.py` cuando corresponda. 
- Verificaciones básicas de los archivos modificados fueron inspeccionadas (`.github/PULL_REQUEST_TEMPLATE.md` y `.github/workflows/ci.yml`) para confirmar la inserción del bloque de alcance y del gate de CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003cfe23e88327beca3ca47fa7179e)