### PR TITLE
Fix `usar` canonical module loading to use internal path map

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from pcobra.cobra.usar_policy import (
     CANONICAL_MODULE_SURFACE_CONTRACTS,
+    REPL_COBRA_MODULE_INTERNAL_PATH_MAP,
     USAR_BACKEND_BLOCKLIST,
     USAR_COBRA_PUBLIC_MODULES,
     USAR_RUNTIME_EXPORT_OVERRIDES,
@@ -145,31 +146,37 @@ def _cargar_modulo_local_desde_directorio(nombre: str, directorio: Path):
     return modulo
 
 
+def _cargar_modulo_local_desde_ruta(nombre: str, ruta: Path):
+    """Carga un módulo Python desde una ruta absoluta explícita."""
+
+    mod_spec = importlib.util.spec_from_file_location(nombre, ruta)
+    if mod_spec is None or mod_spec.loader is None:
+        raise ImportError(f"No se pudo crear spec para el módulo '{nombre}'")
+    modulo = importlib.util.module_from_spec(mod_spec)
+    sys.modules[nombre] = modulo
+    mod_spec.loader.exec_module(modulo)
+    return modulo
+
+
 def obtener_modulo_cobra_oficial(nombre: str):
-    """Carga módulos oficiales de Cobra solo desde ``corelibs`` o ``standard_library``."""
+    """Carga módulos oficiales de Cobra desde la ruta interna canónica declarada."""
 
     nombre = validar_nombre_modulo_usar(nombre, require_allowlist=True)
-    base = Path(__file__).resolve()
+    rel_path = REPL_COBRA_MODULE_INTERNAL_PATH_MAP.get(nombre)
+    if not rel_path:
+        raise ModuleNotFoundError(
+            f"Módulo oficial Cobra '{nombre}' permitido pero sin ruta interna canónica declarada."
+        )
 
-    for parent in base.parents:
-        corelibs = parent / "corelibs"
-        if corelibs.exists():
-            modulo = _cargar_modulo_local_desde_directorio(nombre, corelibs)
-            if modulo is not None:
-                return modulo
-            break
+    repo_root = Path(__file__).resolve().parents[3]
+    ruta_modulo = (repo_root / rel_path).resolve()
+    if not ruta_modulo.exists():
+        raise ModuleNotFoundError(
+            "Módulo oficial Cobra permitido no resoluble en runtime: "
+            f"alias='{nombre}' ruta='{rel_path}'."
+        )
 
-    for parent in base.parents:
-        stdlib = parent / "standard_library"
-        if stdlib.exists():
-            modulo = _cargar_modulo_local_desde_directorio(nombre, stdlib)
-            if modulo is not None:
-                return modulo
-            break
-
-    raise ModuleNotFoundError(
-        f"Módulo oficial Cobra '{nombre}' no encontrado en corelibs/standard_library"
-    )
+    return _cargar_modulo_local_desde_ruta(nombre, ruta_modulo)
 
 
 def obtener_modulo(nombre: str, *, permitir_instalacion: bool = True):


### PR DESCRIPTION
### Motivation

- Garantizar que módulos canónicos de `usar` se carguen exactamente desde la ruta interna oficial definida en la política y evitar la resolución ambigua por presencia en `corelibs`/`standard_library`.
- Evitar duplicación de lógica de carga por archivo y mantener las validaciones de seguridad ya existentes como gate previo a cualquier resolución.
- Proveer mensajes de error explícitos cuando un módulo permitido no sea resoluble en runtime por falta de mapeo o archivo.

### Description

- Importa y utiliza `REPL_COBRA_MODULE_INTERNAL_PATH_MAP` desde `pcobra.cobra.usar_policy` como fuente única de verdad para resolver alias `usar`.
- Reemplaza la búsqueda secuencial en `corelibs`/`standard_library` por resolución directa de la ruta relativa declarada y carga del archivo correspondiente con el mapa.
- Añade el helper reutilizable `_cargar_modulo_local_desde_ruta` que reutiliza `importlib.util.spec_from_file_location` y `exec_module` para no duplicar lógica de carga por ruta.
- Mantiene `validar_nombre_modulo_usar(...)` y el resto de validaciones (allowlist, bloqueo de nombres internos/backend, prevención de traversal) como puerta antes de resolver la ruta, y lanza errores claros cuando falta la ruta canónica o el archivo en runtime.

### Testing

- Ejecuté `python -m py_compile src/pcobra/cobra/usar_loader.py` y la compilación finalizó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003e8ce69483279f153ff24e2ec225)