### PR TITLE
Centraliza resolución de usar_loader entre core y cobra

### DIFF
--- a/src/pcobra/core/usar_loader.py
+++ b/src/pcobra/core/usar_loader.py
@@ -1,5 +1,43 @@
-"""Punto de entrada para ``obtener_modulo`` en el espacio ``pcobra.core``."""
+"""Compat wrapper para `usar_loader` en `pcobra.core`.
 
-from pcobra.cobra.usar_loader import *  # noqa: F401,F403
+Este módulo delega en `pcobra.cobra.usar_loader` para mantener una sola
+fuente de verdad de la política canónica de resolución de `usar`.
+"""
 
-__all__ = list(globals().get("__all__", []))
+from __future__ import annotations
+
+from pcobra.cobra import usar_loader as _impl
+
+__all__ = list(getattr(_impl, "__all__", []))
+
+
+def __getattr__(name: str):
+    return getattr(_impl, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(dir(_impl)))
+
+
+def obtener_modulo(*args, **kwargs):
+    """Delega en la implementación canónica de `pcobra.cobra.usar_loader`."""
+
+    return _impl.obtener_modulo(*args, **kwargs)
+
+
+def obtener_modulo_cobra_oficial(*args, **kwargs):
+    """Delega en la implementación canónica de `pcobra.cobra.usar_loader`."""
+
+    return _impl.obtener_modulo_cobra_oficial(*args, **kwargs)
+
+
+def validar_nombre_modulo_usar(*args, **kwargs):
+    """Delega en la implementación canónica de `pcobra.cobra.usar_loader`."""
+
+    return _impl.validar_nombre_modulo_usar(*args, **kwargs)
+
+
+def sanitizar_exports_publicos(*args, **kwargs):
+    """Delega en la implementación canónica de `pcobra.cobra.usar_loader`."""
+
+    return _impl.sanitizar_exports_publicos(*args, **kwargs)

--- a/tests/unit/test_core_usar_loader_delegation.py
+++ b/tests/unit/test_core_usar_loader_delegation.py
@@ -1,0 +1,14 @@
+from pcobra.core import usar_loader as core_usar_loader
+from pcobra.cobra import usar_loader as cobra_usar_loader
+
+
+def test_core_usar_loader_delega_en_cobra_usar_loader(monkeypatch):
+    token = object()
+
+    def _fake_obtener_modulo(nombre, **_kwargs):
+        assert nombre == "numero"
+        return token
+
+    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo", _fake_obtener_modulo)
+
+    assert core_usar_loader.obtener_modulo("numero") is token


### PR DESCRIPTION
### Motivation

- El intérprete invoca `from .usar_loader import obtener_modulo, sanitizar_exports_publicos` en `InterpretadorCobra.ejecutar_usar`, por lo que el punto real de carga de `usar` es `pcobra.core.usar_loader.obtener_modulo`.
- Existía un wrapper que re-exportaba símbolos (via `import *`) y podía divergir del módulo canónico, creando puntos de parcheo inconsistentes en tests.
- La intención es unificar la política de resolución canónica y tener un único punto de extensión para que parches/tests sean deterministas.

### Description

- Sustituye el wrapper con `import *` en `src/pcobra/core/usar_loader.py` por un módulo de compatibilidad que delega explícitamente en `pcobra.cobra.usar_loader`.
- Añade `__getattr__` y `__dir__` para preservar compatibilidad dinámica y exponer la misma API que el implementador canónico.
- Proporciona delegaciones explícitas para `obtener_modulo`, `obtener_modulo_cobra_oficial`, `validar_nombre_modulo_usar` y `sanitizar_exports_publicos` para dejar un único punto de entrada.
- Añade el test `tests/unit/test_core_usar_loader_delegation.py` que verifica que parchear `pcobra.cobra.usar_loader.obtener_modulo` afecta a `pcobra.core.usar_loader.obtener_modulo` (single source of truth).

### Testing

- Ejecuté `pytest -q tests/unit/test_core_usar_loader_delegation.py tests/unit/test_usar_loader_stdlib.py` y todos los tests ejecutados pasaron (salida: `10 passed, 1 warning`).
- El nuevo test de delegación pasó y valida que el punto de extensión real está unificado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00426687548327ad36bcf92a6708d8)