### PR TITLE
Centralizar mapeo canónico de rutas internas para `usar`

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -36,23 +36,26 @@ USAR_COBRA_FACING_MODULE_FLAGS: dict[str, bool] = {
     modulo: True for modulo in USAR_COBRA_PUBLIC_MODULES
 }
 
+_USAR_CANONICAL_INTERNAL_PATHS: dict[str, str] = {
+    # Mantener `numero` en corelibs para no introducir regresión de resolución.
+    "numero": "src/pcobra/corelibs/numero.py",
+    # `texto` y `datos` exponen su API pública real desde standard_library.
+    "texto": "src/pcobra/standard_library/texto.py",
+    "datos": "src/pcobra/standard_library/datos.py",
+    "logica": "src/pcobra/corelibs/logica.py",
+    "asincrono": "src/pcobra/corelibs/asincrono.py",
+    "sistema": "src/pcobra/corelibs/sistema.py",
+    "archivo": "src/pcobra/corelibs/archivo.py",
+    "tiempo": "src/pcobra/corelibs/tiempo.py",
+    "red": "src/pcobra/corelibs/red.py",
+    "holobit": "src/pcobra/corelibs/holobit.py",
+}
+
+
 def _build_repl_cobra_module_internal_path_map() -> dict[str, str]:
     """Construye el mapeo oficial `alias usar` -> ruta interna por módulo."""
 
-    return {
-        # Mantener `numero` en corelibs para no introducir regresión de resolución.
-        "numero": "src/pcobra/corelibs/numero.py",
-        # `texto` y `datos` exponen su API pública real desde standard_library.
-        "texto": "src/pcobra/standard_library/texto.py",
-        "datos": "src/pcobra/standard_library/datos.py",
-        "logica": "src/pcobra/corelibs/logica.py",
-        "asincrono": "src/pcobra/corelibs/asincrono.py",
-        "sistema": "src/pcobra/corelibs/sistema.py",
-        "archivo": "src/pcobra/corelibs/archivo.py",
-        "tiempo": "src/pcobra/corelibs/tiempo.py",
-        "red": "src/pcobra/corelibs/red.py",
-        "holobit": "src/pcobra/corelibs/holobit.py",
-    }
+    return dict(_USAR_CANONICAL_INTERNAL_PATHS)
 
 
 # Fuente única de verdad: alias canónico `usar` -> ruta interna oficial.


### PR DESCRIPTION
### Motivation
- Evitar lógica derivada/inline para la resolución de alias `usar` y proporcionar una fuente única y explícita de rutas internas canónicas.
- Asegurar que los módulos `numero`, `texto` y `datos` apunten a las rutas reales de origen público sin cambiar la API pública ni reglas de sanitización.
- Facilitar reutilización y evitar duplicación en la construcción del mapa interno para futuras modificaciones.

### Description
- Añadido el diccionario `_USAR_CANONICAL_INTERNAL_PATHS` que contiene el mapeo canónico alias -> ruta interna real, incluyendo las entradas solicitadas: `numero -> src/pcobra/corelibs/numero.py`, `texto -> src/pcobra/standard_library/texto.py`, y `datos -> src/pcobra/standard_library/datos.py`.
- Modificada la función ` _build_repl_cobra_module_internal_path_map()` para devolver una copia de `_USAR_CANONICAL_INTERNAL_PATHS` en lugar de construir el dict inline.
- Conservadas todas las demás entradas apuntando a `src/pcobra/corelibs/*.py` cuando ese es el origen público efectivo, y sin tocar `USAR_COBRA_PUBLIC_MODULES`, la sintaxis pública ni las reglas de sanitización.

### Testing
- Ejecutado `validar_contrato_modulos_canonicos_usar()` por importación y ejecución en Python y completó sin errores (éxito).
- Verificada la resolución de rutas leyendo `REPL_COBRA_MODULE_INTERNAL_PATH_MAP` y comprobando que `numero`, `texto` y `datos` devuelven las rutas esperadas mediante un script Python (éxito).
- Las comprobaciones automáticas realizadas durante el commit local (importación/validación) terminaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0043abb1008327b6dc3c853ce8c4b3)