### PR TITLE
Alinear módulo canónico `numero` con `USAR_RUNTIME_EXPORT_OVERRIDES`

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -37,8 +37,8 @@ USAR_COBRA_FACING_MODULE_FLAGS: dict[str, bool] = {
 }
 
 _USAR_CANONICAL_INTERNAL_PATHS: dict[str, str] = {
-    # Mantener `numero` en corelibs para no introducir regresión de resolución.
-    "numero": "src/pcobra/corelibs/numero.py",
+    # `numero` expone el contrato runtime de `usar` desde standard_library.
+    "numero": "src/pcobra/standard_library/numero.py",
     # `texto` y `datos` exponen su API pública real desde standard_library.
     "texto": "src/pcobra/standard_library/texto.py",
     "datos": "src/pcobra/standard_library/datos.py",


### PR DESCRIPTION
### Motivation
- Corregir una inconsistencia donde `USAR_RUNTIME_EXPORT_OVERRIDES['numero']` reclamaba `sumatoria` que existe en `src/pcobra/standard_library/numero.py` pero la ruta canónica apuntaba a `corelibs`, provocando resolución incorrecta en `usar`.

### Description
- Actualiza `_USAR_CANONICAL_INTERNAL_PATHS` para resolver el alias `numero` a `src/pcobra/standard_library/numero.py` sin modificar políticas de exportación ni relajar el bloqueo de objetos backend.

### Testing
- Verificado con un script AST que todos los símbolos listados en `USAR_RUNTIME_EXPORT_OVERRIDES` para `texto`, `datos` y `numero` existen en sus rutas canónicas resueltas (sin faltantes), con búsquedas `rg` para los símbolos requeridos y confirmación del commit; todas las comprobaciones automatizadas tuvieron éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00448fbed8832782d660d6442bf67d)