### PR TITLE
test: ampliar cobertura de `usar` en REPL para datos/texto/numero

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -661,6 +661,65 @@ def test_usar_texto_exporta_solo_nombres_espanoles(monkeypatch):
     assert "to_snake_case" not in interp.variables
 
 
+
+
+def test_repl_usar_datos_imprimir_longitud_lista_produce_3(monkeypatch, capsys):
+    import pcobra.standard_library.datos as modulo_datos
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_datos)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"datos": "datos"})
+
+    _ejecutar_codigo('usar "datos"\nimprimir(longitud([1, 2, 3]))', interp)
+
+    assert capsys.readouterr().out.strip().splitlines()[-1] == "3"
+
+
+def test_usar_texto_expone_superficie_publica_clave(monkeypatch):
+    import pcobra.corelibs.texto as modulo_texto
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_texto)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"texto": "texto"})
+    interp.ejecutar_nodo(NodoUsar("texto"))
+
+    for simbolo in ("recortar", "repetir", "quitar_acentos", "prefijo_comun", "sufijo_comun"):
+        assert simbolo in interp.variables
+
+
+def test_usar_numero_conserva_es_finito_y_signo_operativos(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_numero)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero"})
+    interp.ejecutar_nodo(NodoUsar("numero"))
+
+    assert interp.obtener_variable("es_finito")(10) is True
+    assert interp.obtener_variable("signo")(-8) == -1
+
+
+def test_usar_datos_no_exporta_objetos_backend_sdk_wrappers(monkeypatch):
+    modulo = ModuleType("datos")
+    modulo.__all__ = ["longitud", "backend", "sdk", "wrapper", "modulo_externo"]
+    modulo.longitud = lambda xs: len(xs)
+    modulo.backend = ModuleType("backend")
+    modulo.sdk = ModuleType("sdk")
+    modulo.wrapper = ModuleType("wrapper")
+    modulo.modulo_externo = ModuleType("modulo_externo")
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/standard_library/datos.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"datos": "datos"})
+
+    with pytest.raises(ImportError, match=r"rechazos de saneamiento en usar"):
+        interp.ejecutar_nodo(NodoUsar("datos"))
+
+    assert "longitud" not in interp.variables
+    for simbolo in ("backend", "sdk", "wrapper", "modulo_externo"):
+        assert simbolo not in interp.variables
 def test_usar_datos_incluye_filtrar_mapear_reducir(monkeypatch):
     import pcobra.standard_library.datos as modulo_datos
 


### PR DESCRIPTION
### Motivation
- Reforzar el contrato público de la instrucción `usar` en el REPL para evitar regresiones en la inyección de símbolos y en la allowlist de módulos.
- Detectar y prevenir la exportación accidental de objetos de backend/SDK/wrappers desde `standard_library.datos` mediante tests atómicos de saneamiento.

### Description
- Añadidos tests en `tests/unit/test_usar.py` que validan casos REPL específicos: `test_repl_usar_datos_imprimir_longitud_lista_produce_3`, `test_usar_texto_expone_superficie_publica_clave`, `test_usar_numero_conserva_es_finito_y_signo_operativos` y `test_usar_datos_no_exporta_objetos_backend_sdk_wrappers`.
- Los tests comprueban que `usar "datos"` permite `imprimir(longitud([1,2,3]))` imprimiendo `3`, que `usar "texto"` expone `recortar`, `repetir`, `quitar_acentos`, `prefijo_comun` y `sufijo_comun`, y que `usar "numero"` mantiene `es_finito` y `signo` operativos.
- Se añadió un caso que simula un módulo `datos` que contiene objetos tipo módulo/SDK/wrapper y verifica que la sanitización de `usar` rechaza la importación (no permite inyección parcial) y no deja símbolos vulnerables en el contexto.
- No se introdujeron dependencias externas y los tests usan `monkeypatch`/mocks para mantenerlos acotados al comportamiento público.

### Testing
- Ejecuté un subset focalizado con `pytest -q tests/unit/test_usar.py -k "datos_imprimir_longitud_lista_produce_3 or texto_expone_superficie_publica_clave or numero_conserva_es_finito_y_signo_operativos or usar_numpy_rechazado_en_superficie_publica or datos_no_exporta_objetos_backend_sdk_wrappers"` para validar los casos añadidos.
- La ejecución falló en la fase de colección por un `ImportError: attempted relative import beyond top-level package` originado al importar `core.interpreter`, por lo que las pruebas nuevas no pudieron ejecutarse en este entorno de CI local.
- Los cambios están limitados a tests y no modifican código de producción; requieren ejecutar el conjunto completo en un entorno donde la importación de paquetes (paquetes `pcobra`/`core`) esté correctamente configurada para validar exitosamente las nuevas pruebas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00462feb3c83279c3b4cd33bd0e682)