### PR TITLE
Corregir origen interno del módulo `numero` en política `usar`

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -37,8 +37,8 @@ USAR_COBRA_FACING_MODULE_FLAGS: dict[str, bool] = {
 }
 
 _USAR_CANONICAL_INTERNAL_PATHS: dict[str, str] = {
-    # `numero` expone el contrato runtime de `usar` desde standard_library.
-    "numero": "src/pcobra/standard_library/numero.py",
+    # `numero` expone el contrato runtime de `usar` desde corelibs.
+    "numero": "src/pcobra/corelibs/numero.py",
     # `texto` y `datos` exponen su API pública real desde standard_library.
     "texto": "src/pcobra/standard_library/texto.py",
     "datos": "src/pcobra/standard_library/datos.py",


### PR DESCRIPTION
### Motivation
- Corregir la resolución de `numero` para que cargue desde `src/pcobra/corelibs/numero.py` (la implementación real) en lugar de la ruta previa en `standard_library`.

### Description
- Actualicé `_USAR_CANONICAL_INTERNAL_PATHS` en `src/pcobra/cobra/usar_policy.py` para mapear el alias `"numero"` a `src/pcobra/corelibs/numero.py` manteniendo el resto del mapeo y la lógica local sin añadir helpers centrales ni modificar lexer/parser o validaciones de seguridad.

### Testing
- Verifiqué existencia y presencia de las funciones canónicas con un script AST que inspeccionó los archivos listados, confirmé en runtime con `from pcobra.cobra import usar_policy` que `REPL_COBRA_MODULE_INTERNAL_PATH_MAP['numero']` resuelve a `src/pcobra/corelibs/numero.py`, y confirmé el commit en git; todas las comprobaciones automatizadas pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0047f1212083279bc5c238663fac0f)