### PR TITLE
Refina mensajes de `usar` para modo usuario y modo debug

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -112,6 +112,18 @@ USAR_COLLISION_STRICT_ERROR = "strict_error"
 USAR_COLLISION_WARN_ALIAS_REQUIRED = "warn_alias_required"
 _USAR_COLLISION_POLICIES = frozenset({USAR_COLLISION_STRICT_ERROR, USAR_COLLISION_WARN_ALIAS_REQUIRED})
 
+def formatear_error_usar_usuario(codigo: str, modulo: str, contexto_minimo: str | None = None) -> str:
+    """Devuelve errores cortos y legibles para la salida de usuario en `usar`."""
+    mensajes = {
+        "modulo_fuera_catalogo": f"No se puede usar '{modulo}': módulo fuera del catálogo público.",
+        "conflicto_simbolo": f"No se puede usar '{modulo}': hay conflicto de símbolos en el contexto actual.",
+        "export_invalido": f"No se puede usar '{modulo}': no hay símbolos exportables válidos.",
+    }
+    base = mensajes.get(codigo, f"No se puede usar '{modulo}'.")
+    if contexto_minimo:
+        return f"{base} {contexto_minimo}"
+    return base
+
 
 def _runtime_debug_enabled() -> bool:
     """Habilita diagnóstico puntual de runtime vía entorno."""
@@ -1960,14 +1972,14 @@ class InterpretadorCobra:
                     "conflicts": conflictos_saneamiento,
                 }
                 logging.warning("USAR sanitize conflicts event: %s", evento_conflictos)
-                self._trace_debug(f"[USAR_SANITIZE][CONFLICTS] {evento_conflictos}")
+                if self._debug_trazas_habilitadas() or _runtime_debug_enabled():
+                    self._trace_debug(f"[USAR_SANITIZE][CONFLICTS] {evento_conflictos}")
 
             if not simbolos_saneados:
-                raise ImportError(
-                    f"{USAR_INVALID_EXPORT_ERROR}: rechazos de saneamiento en usar "
-                    f"'{nodo.modulo}': no quedaron símbolos exportables tras saneamiento. "
-                    f"conflictos={conflictos_saneamiento}"
-                )
+                mensaje_usuario = formatear_error_usar_usuario("export_invalido", nodo.modulo)
+                if self._debug_trazas_habilitadas() or _runtime_debug_enabled():
+                    mensaje_usuario = f"{mensaje_usuario} ({USAR_INVALID_EXPORT_ERROR}; conflictos={conflictos_saneamiento})"
+                raise ImportError(mensaje_usuario)
 
             # Fase A: detectar colisiones de forma completa antes de definir.
             conflictos = self._detectar_conflictos_usar_en_contexto(
@@ -1992,7 +2004,8 @@ class InterpretadorCobra:
                         "detail": detalle_por_simbolo,
                     }
                     logging.warning("USAR collision symbol event: %s", evento_colision)
-                    self._trace_debug(f"[USAR_COLLISION][SYMBOL] {evento_colision}")
+                    if self._debug_trazas_habilitadas() or _runtime_debug_enabled():
+                        self._trace_debug(f"[USAR_COLLISION][SYMBOL] {evento_colision}")
 
                 conflicto = conflictos[0]
                 detalle = {
@@ -2006,17 +2019,22 @@ class InterpretadorCobra:
                 }
                 if self._usar_collision_policy == USAR_COLLISION_WARN_ALIAS_REQUIRED:
                     warnings.warn(
-                        "Conflicto de nombres en `usar`: "
-                        f"módulo={nodo.modulo} símbolos={conflictos}. "
-                        "No se inyectó ningún símbolo; use alias explícito.",
+                        formatear_error_usar_usuario(
+                            "conflicto_simbolo",
+                            nodo.modulo,
+                            "Use alias explícito para resolver la colisión.",
+                        ),
                         RuntimeWarning,
                         stacklevel=2,
                     )
-                    raise NameError(
-                        "No se puede usar el módulo "
-                        f"'{nodo.modulo}': {USAR_SYMBOL_CONFLICT_ERROR} colisión estructurada={detalle}. "
-                        "Requiere alias explícito según la convención del runtime (usar importar ... como ...)."
+                    mensaje_usuario = formatear_error_usar_usuario(
+                        "conflicto_simbolo",
+                        nodo.modulo,
+                        "Requiere alias explícito.",
                     )
+                    if self._debug_trazas_habilitadas() or _runtime_debug_enabled():
+                        mensaje_usuario = f"{mensaje_usuario} detalle={detalle}"
+                    raise NameError(mensaje_usuario)
                 evento_colision = {
                     "evento": "usar_collision",
                     "severity": "error",
@@ -2026,10 +2044,10 @@ class InterpretadorCobra:
                     "detail": detalle,
                 }
                 logging.error("USAR collision event: %s", evento_colision)
-                raise NameError(
-                    "No se puede usar el módulo "
-                    f"'{nodo.modulo}': {USAR_SYMBOL_CONFLICT_ERROR} colisión estructurada={detalle}"
-                )
+                mensaje_usuario = formatear_error_usar_usuario("conflicto_simbolo", nodo.modulo)
+                if self._debug_trazas_habilitadas() or _runtime_debug_enabled():
+                    mensaje_usuario = f"{mensaje_usuario} detalle={detalle}"
+                raise NameError(mensaje_usuario)
 
             # Fase B: inyectar de forma atómica y sin sobreescritura silenciosa.
             self._inyectar_simbolos_usar_en_contexto(
@@ -2037,7 +2055,12 @@ class InterpretadorCobra:
                 modulo=nodo.modulo,
             )
         except Exception as exc:
-            logging.exception(f"Error al usar el módulo '{nodo.modulo}': {exc}")
+            logging.exception("Error al usar el módulo '%s': %s", nodo.modulo, exc)
+            if isinstance(exc, PermissionError):
+                mensaje = formatear_error_usar_usuario("modulo_fuera_catalogo", nodo.modulo)
+                if self._debug_trazas_habilitadas() or _runtime_debug_enabled():
+                    mensaje = f"{mensaje} ({exc})"
+                raise PermissionError(mensaje) from exc
             raise
 
     def _detectar_conflictos_usar_en_contexto(

--- a/tests/unit/test_usar_runtime_policy.py
+++ b/tests/unit/test_usar_runtime_policy.py
@@ -209,3 +209,43 @@ def test_usar_runtime_rechaza_import_directo_de_internals_holobit(nombre_interno
     assert "Importación no permitida en 'usar'" in mensaje
     assert nombre_interno in mensaje
     assert "backend_" not in mensaje
+
+
+def test_usar_runtime_error_usuario_sin_detalle_en_modo_normal(monkeypatch):
+    modulo = ModuleType("texto")
+    modulo.__all__ = ["a_snake"]
+    modulo.a_snake = lambda txt: txt
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/texto.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _n: modulo)
+
+    interp = _interp_con_alias({"texto": "texto"})
+    interp.contextos[-1].define("a_snake", lambda txt: f"previo:{txt}")
+
+    with pytest.raises(NameError) as exc:
+        interp.ejecutar_nodo(NodoUsar("texto"))
+
+    mensaje = str(exc.value)
+    assert "conflicto de símbolos" in mensaje
+    assert "detalle=" not in mensaje
+    assert "[" not in mensaje
+
+
+def test_usar_runtime_error_usuario_con_detalle_en_debug(monkeypatch):
+    modulo = ModuleType("texto")
+    modulo.__all__ = ["a_snake"]
+    modulo.a_snake = lambda txt: txt
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/texto.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _n: modulo)
+    monkeypatch.setenv("PCOBRA_DEBUG_TRACES", "1")
+
+    interp = _interp_con_alias({"texto": "texto"})
+    interp.contextos[-1].define("a_snake", lambda txt: f"previo:{txt}")
+
+    with pytest.raises(NameError) as exc:
+        interp.ejecutar_nodo(NodoUsar("texto"))
+
+    mensaje = str(exc.value)
+    assert "conflicto de símbolos" in mensaje
+    assert "detalle=" in mensaje


### PR DESCRIPTION
### Motivation
- Evitar que la salida normal del REPL muestre diccionarios/listas completas o tracebacks al usar `usar` y proporcionar mensajes breves y amigables para el usuario.
- Mantener la telemetría y payloads completos disponibles en `logging` y trazas internas para depuración sin exponerlos en la salida estándar.
- Permitir que las banderas existentes de debug/verbose (`PCOBRA_DEBUG_TRACES`, `PCOBRA_DEBUG_RUNTIME`) activen la información extendida cuando sea necesario.

### Description
- Añadido el helper `formatear_error_usar_usuario(codigo, modulo, contexto_minimo)` que centraliza mensajes cortos y legibles para errores de `usar` (`modulo_fuera_catalogo`, `conflicto_simbolo`, `export_invalido`).
- En `ejecutar_usar` se reemplazaron mensajes con volcado de estructuras por mensajes breves para el usuario y se condicionó la emisión de detalles extendidos a `PCOBRA_DEBUG_TRACES` o `PCOBRA_DEBUG_RUNTIME`.
- Conservé los `evento_*` completos en `logging.warning/error/exception` para auditoría, mientras que las excepciones lanzadas al usuario quedan resumidas salvo en modo debug donde se añade `detalle=...`.
- Añadidas dos pruebas de regresión en `tests/unit/test_usar_runtime_policy.py` que verifican salida sin detalle en modo normal y con `detalle=` cuando `PCOBRA_DEBUG_TRACES` está habilitado.

### Testing
- Se ejecutó `python -m compileall src/pcobra/core/interpreter.py tests/unit/test_usar_runtime_policy.py` y la compilación fue satisfactoria.
- Intenté ejecutar `PYTHONPATH=src pytest -q tests/unit/test_usar_runtime_policy.py -k "error_usuario or colision_warn_diagnostico"`, la ejecución falló en la fase de colección por un conflicto de imports legacy (`core` vs `pcobra`) en este entorno, por lo que las aserciones de pytest no llegaron a correr completamente.
- Los cambios están en `src/pcobra/core/interpreter.py` y en `tests/unit/test_usar_runtime_policy.py` y fueron comprometidos en el repositorio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a004f05f28c8327b49d8f77a2a33f8d)