### PR TITLE
Refactor: cargar `texto` sin importar paquete agregador y añadir wrappers `usar`-facing

### DIFF
--- a/src/pcobra/corelibs/texto.py
+++ b/src/pcobra/corelibs/texto.py
@@ -1057,6 +1057,30 @@ def lineas_no_vacias(texto: str) -> list[str]:
 
     return [linea.strip() for linea in texto.splitlines() if linea.strip()]
 
+
+def recortar(texto: str) -> str:
+    """Recorta espacios al inicio y final usando la semántica de ``str.strip``."""
+
+    return quitar_espacios(texto)
+
+
+def repetir(texto: str, veces: int) -> str:
+    """Repite ``texto`` ``veces`` veces validando que ``veces`` no sea negativo."""
+
+    if veces < 0:
+        raise ValueError("veces debe ser >= 0")
+    return texto * veces
+
+
+def quitar_acentos(texto: str) -> str:
+    """Elimina diacríticos conservando caracteres base Unicode."""
+
+    descompuesto = unicodedata.normalize("NFD", texto)
+    sin_marcas = "".join(
+        caracter for caracter in descompuesto if unicodedata.category(caracter) != "Mn"
+    )
+    return unicodedata.normalize("NFC", sin_marcas)
+
 __all__ = [
     "mayusculas",
     "minusculas",
@@ -1122,6 +1146,9 @@ __all__ = [
     "es_titulo",
     "es_digito",
     "lineas_no_vacias",
+    "recortar",
+    "repetir",
+    "quitar_acentos",
 ]
 
 

--- a/src/pcobra/standard_library/texto.py
+++ b/src/pcobra/standard_library/texto.py
@@ -16,8 +16,20 @@ from typing import Any, TypeVar, overload
 
 import unicodedata
 
-from pcobra.corelibs import texto as _texto
 from pcobra.corelibs.texto import (
+    capitalizar as _capitalizar_texto,
+    titulo as _titulo_texto,
+    invertir as _invertir_texto,
+    concatenar as _concatenar_texto,
+    quitar_espacios as _quitar_espacios_texto,
+    dividir as _dividir_texto,
+    unir as _unir_texto,
+    empieza_con as _empieza_con_texto,
+    termina_con as _termina_con_texto,
+    rellenar_izquierda as _rellenar_izquierda_texto,
+    rellenar_derecha as _rellenar_derecha_texto,
+    normalizar_unicode as _normalizar_unicode_texto,
+    lineas_no_vacias as _lineas_no_vacias_texto,
     encontrar as _encontrar_texto,
     encontrar_derecha as _encontrar_derecha_texto,
     indice as _indice_texto,
@@ -26,41 +38,31 @@ from pcobra.corelibs.texto import (
     formatear_mapa as _formatear_mapa_texto,
     tabla_traduccion as _tabla_traduccion_texto,
     traducir as _traducir_texto,
-)
-from pcobra.corelibs import (
-    centrar_texto as _centrar_texto,
-    contar_subcadena as _contar_subcadena,
-    dividir,
     dividir_derecha as _dividir_derecha,
     dividir_lineas as _dividir_lineas,
     indentar_texto as _indentar_texto,
     desindentar_texto as _desindentar_texto,
     envolver_texto as _envolver_texto,
     acortar_texto as _acortar_texto,
-    invertir,
     intercambiar_mayusculas as _intercambiar_mayusculas,
     minusculas as _minusculas,
     mayusculas as _mayusculas,
     minusculas_casefold as _minusculas_casefold,
-    normalizar_unicode,
-    expandir_tabulaciones as _expandir_tabulaciones,
-    codificar_texto as _codificar_texto,
-    decodificar_texto as _decodificar_texto,
+    codificar as _codificar_texto,
+    decodificar as _decodificar_texto,
     prefijo_comun as _prefijo_comun,
-    quitar_espacios,
     quitar_prefijo as _quitar_prefijo,
     quitar_sufijo as _quitar_sufijo,
     a_snake as _a_snake,
     a_camel as _a_camel,
     quitar_envoltura as _quitar_envoltura,
     particionar_derecha as _particionar_derecha,
-    particionar_texto as _particionar,
+    particionar as _particionar,
     rellenar_ceros as _rellenar_ceros,
     subcadena_antes as _subcadena_antes,
     subcadena_despues as _subcadena_despues,
     subcadena_antes_ultima as _subcadena_antes_ultima,
     subcadena_despues_ultima as _subcadena_despues_ultima,
-    unir,
     sufijo_comun as _sufijo_comun,
     es_alfabetico as _es_alfabetico,
     es_alfa_numerico as _es_alfa_numerico,
@@ -76,6 +78,9 @@ from pcobra.corelibs import (
     es_espacio as _es_espacio,
     incluye as _incluye,
     reemplazar as _reemplazar,
+    centrar_texto as _centrar_texto,
+    contar_subcadena as _contar_subcadena,
+    expandir_tabulaciones as _expandir_tabulaciones,
 )
 
 _T = TypeVar("_T")
@@ -832,91 +837,91 @@ def traducir(texto: str, tabla: Mapping[int, str | None]) -> str:
 def capitalizar(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.capitalizar``."""
 
-    return _texto.capitalizar(*args, **kwargs)
+    return _capitalizar_texto(*args, **kwargs)
 
 
 def titulo(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.titulo``."""
 
-    return _texto.titulo(*args, **kwargs)
+    return _titulo_texto(*args, **kwargs)
 
 
 def invertir(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.invertir``."""
 
-    return _texto.invertir(*args, **kwargs)
+    return _invertir_texto(*args, **kwargs)
 
 
 def concatenar(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.concatenar``."""
 
-    return _texto.concatenar(*args, **kwargs)
+    return _concatenar_texto(*args, **kwargs)
 
 
 def quitar_espacios(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.quitar_espacios``."""
 
-    return _texto.quitar_espacios(*args, **kwargs)
+    return _quitar_espacios_texto(*args, **kwargs)
 
 
 def dividir(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.dividir``."""
 
-    return _texto.dividir(*args, **kwargs)
+    return _dividir_texto(*args, **kwargs)
 
 
 def unir(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.unir``."""
 
-    return _texto.unir(*args, **kwargs)
+    return _unir_texto(*args, **kwargs)
 
 
 def reemplazar(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.reemplazar``."""
 
-    return _texto.reemplazar(*args, **kwargs)
+    return _reemplazar(*args, **kwargs)
 
 
 def empieza_con(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.empieza_con``."""
 
-    return _texto.empieza_con(*args, **kwargs)
+    return _empieza_con_texto(*args, **kwargs)
 
 
 def termina_con(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.termina_con``."""
 
-    return _texto.termina_con(*args, **kwargs)
+    return _termina_con_texto(*args, **kwargs)
 
 
 def incluye(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.incluye``."""
 
-    return _texto.incluye(*args, **kwargs)
+    return _incluye(*args, **kwargs)
 
 
 def rellenar_izquierda(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.rellenar_izquierda``."""
 
-    return _texto.rellenar_izquierda(*args, **kwargs)
+    return _rellenar_izquierda_texto(*args, **kwargs)
 
 
 def rellenar_derecha(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.rellenar_derecha``."""
 
-    return _texto.rellenar_derecha(*args, **kwargs)
+    return _rellenar_derecha_texto(*args, **kwargs)
 
 
 def normalizar_unicode(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.normalizar_unicode``."""
 
-    return _texto.normalizar_unicode(*args, **kwargs)
+    return _normalizar_unicode_texto(*args, **kwargs)
 
 
 def lineas_no_vacias(*args, **kwargs):
     """Delega en ``pcobra.corelibs.texto.lineas_no_vacias``."""
 
-    return _texto.lineas_no_vacias(*args, **kwargs)
+    return _lineas_no_vacias_texto(*args, **kwargs)
 
 
 def recortar(texto: str) -> str:

--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -93,6 +93,26 @@ def test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_texto_sin_pre
         (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
     ],
 )
+def test_repl_usar_texto_end_to_end_superficie_publica_callables(factory, executor, get_interp):
+    cmd = factory()
+    interp = get_interp(cmd)
+
+    executor(cmd, 'usar "texto"')
+
+    assert interp.obtener_variable("recortar")("  Cobra  ") == "Cobra"
+    assert interp.obtener_variable("repetir")("ja", 3) == "jajaja"
+    assert interp.obtener_variable("quitar_acentos")("canción") == "cancion"
+    assert interp.obtener_variable("prefijo_comun")("cobra", "cobre") == "cobr"
+    assert interp.obtener_variable("sufijo_comun")("programacion", "nacion") == "acion"
+
+
+@pytest.mark.parametrize(
+    ("factory", "executor", "get_interp"),
+    [
+        (lambda: InteractiveCommand(InterpretadorCobra()), lambda cmd, code: cmd.ejecutar_codigo(code), lambda cmd: cmd.interpretador),
+        (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
+    ],
+)
 def test_repl_contract_sintaxis_usar_compat_parser_semantica_plana_numpy_restringido_atomico(factory, executor, get_interp, monkeypatch):
     mod_numero = _modulo_numero_stub()
 


### PR DESCRIPTION
### Motivation
- Evitar importaciones transversales que inicializan paquetes completos y pueden introducir ciclos o sobrecarga en el arranque al resolver `usar "texto"` en REPL.
- Garantizar que la superficie pública consumida por `usar` sea ligera, segura y exponga únicamente callables apropiados en español.

### Description
- Reemplacé el patrón `from pcobra.corelibs import ...` en `src/pcobra/standard_library/texto.py` por importaciones puntuales directas desde `pcobra.corelibs.texto`, evitando así cargar `corelibs.__init__` completo.
- Actualicé los delegadores Cobra-facing en `standard_library/texto.py` para que invoquen directamente los símbolos importados (por ejemplo `_capitalizar_texto`, `_dividir_texto`, etc.) en lugar de usar el objeto de paquete.
- Añadí wrappers seguros históricos en `src/pcobra/corelibs/texto.py` para `recortar`, `repetir` y `quitar_acentos`, incluyendo validación (p. ej. `repetir` valida `veces >= 0`) y los incorporé en `__all__`.
- Añadí una prueba de integración REPL/CLI en `tests/integration/test_repl_usar_entrypoints_contract.py` que ejecuta `usar "texto"` y verifica callables públicos (`recortar`, `repetir`, `quitar_acentos`, `prefijo_comun`, `sufijo_comun`).

### Testing
- Ejecuté `pytest -q tests/unit/test_standard_library_texto.py tests/integration/test_repl_usar_entrypoints_contract.py::test_repl_usar_texto_end_to_end_superficie_publica_callables` y obtuvo `20 passed` (test objetivo de integración y suite de texto pasan).
- Hubo una ejecución intermedia con `pytest -q tests/unit/test_standard_library_texto.py tests/unit/test_usar_runtime_policy.py::test_usar_runtime_texto_expone_solo_api_espanola tests/integration/...` que falló por un `ImportError: attempted relative import beyond top-level package` al cargar un test legacy fuera del alcance de este cambio, pero no está relacionado con la regresión introducida por los cambios en `texto`.
- Las modificaciones están committeadas en la rama actual y el PR fue creado con este resumen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a005026fd8083279c2b503264cca14c)