### PR TITLE
test: reforzar no-exportación backend en usar "datos"

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -707,13 +707,16 @@ def test_usar_numero_conserva_es_finito_y_signo_operativos(monkeypatch):
 
 def test_usar_datos_no_exporta_objetos_backend_sdk_wrappers(monkeypatch):
     modulo = ModuleType("datos")
-    modulo.__all__ = ["longitud", "backend", "sdk", "wrapper", "modulo_externo", "module_object"]
+    modulo.__all__ = ["longitud", "backend", "sdk", "wrapper", "modulo_externo", "module_object", "backend_module_object", "USAR_RUNTIME_EXPORT_OVERRIDES", "REPL_COBRA_MODULE_INTERNAL_PATH_MAP"]
     modulo.longitud = lambda xs: len(xs)
     modulo.backend = ModuleType("backend")
     modulo.sdk = ModuleType("sdk")
     modulo.wrapper = ModuleType("wrapper")
     modulo.modulo_externo = ModuleType("modulo_externo")
     modulo.module_object = object()
+    modulo.backend_module_object = object()
+    modulo.USAR_RUNTIME_EXPORT_OVERRIDES = object()
+    modulo.REPL_COBRA_MODULE_INTERNAL_PATH_MAP = object()
     modulo.__file__ = "/workspace/pCobra/src/pcobra/standard_library/datos.py"
 
     monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
@@ -725,7 +728,16 @@ def test_usar_datos_no_exporta_objetos_backend_sdk_wrappers(monkeypatch):
         interp.ejecutar_nodo(NodoUsar("datos"))
 
     assert "longitud" not in interp.variables
-    for simbolo in ("backend", "sdk", "wrapper", "modulo_externo", "module_object"):
+    for simbolo in (
+        "backend",
+        "sdk",
+        "wrapper",
+        "modulo_externo",
+        "module_object",
+        "backend_module_object",
+        "USAR_RUNTIME_EXPORT_OVERRIDES",
+        "REPL_COBRA_MODULE_INTERNAL_PATH_MAP",
+    ):
         assert simbolo not in interp.variables
 def test_usar_datos_incluye_filtrar_mapear_reducir(monkeypatch):
     import pcobra.standard_library.datos as modulo_datos


### PR DESCRIPTION
### Motivation
- Evitar que la instrucción `usar` filtre internals de backend/SDK/wrappers en el namespace REPL cuando esos nombres aparezcan en `__all__` o en el módulo simulado.
- Asegurar que la superficie pública de `usar` se mantenga acotada y coherente con la política de allowlist y saneamiento.

### Description
- Se actualizó `tests/unit/test_usar.py` para ampliar el módulo simulado `datos` añadiendo nombres internos adicionales en `__all__` (`backend_module_object`, `USAR_RUNTIME_EXPORT_OVERRIDES`, `REPL_COBRA_MODULE_INTERNAL_PATH_MAP`).
- Se añadieron los atributos correspondientes al módulo simulado y se agregaron aserciones explícitas que comprueban que ninguno de esos símbolos queda inyectado en `interp.variables` tras `NodoUsar("datos")`.
- No se realizaron cambios en código productivo ni se introdujeron dependencias externas; el cambio es únicamente en pruebas unitarias.

### Testing
- Se intentó ejecutar un subconjunto de tests con `pytest` sobre `tests/unit/test_usar.py` para los casos relevantes y la ejecución de colección falló con `ImportError: attempted relative import beyond top-level package` y por tanto los tests no llegaron a ejecutarse.
- Reintentos con `PYTHONPATH=src pytest ...` reprodujeron el mismo error de colección, por lo que las nuevas aserciones no pudieron validarse en el entorno automatizado durante esta ejecución.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00518e77108327bf3ad6502874a042)