### PR TITLE
Reducir ruido en errores de `usar` y enrutar detalles a debug

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -125,6 +125,11 @@ def formatear_error_usar_usuario(codigo: str, modulo: str, contexto_minimo: str 
     return base
 
 
+def _usar_detalle_habilitado() -> bool:
+    """Determina si `usar` puede exponer detalles extendidos en salida de error."""
+    return _runtime_debug_enabled() or InterpretadorCobra._debug_trazas_habilitadas()
+
+
 def _runtime_debug_enabled() -> bool:
     """Habilita diagnóstico puntual de runtime vía entorno."""
     return os.getenv("PCOBRA_DEBUG_RUNTIME", "").strip() == "1"
@@ -1971,13 +1976,13 @@ class InterpretadorCobra:
                     "module": nodo.modulo,
                     "conflicts": conflictos_saneamiento,
                 }
-                logging.warning("USAR sanitize conflicts event: %s", evento_conflictos)
-                if self._debug_trazas_habilitadas() or _runtime_debug_enabled():
+                logging.warning("USAR sanitize conflicts event module=%s count=%s", nodo.modulo, len(conflictos_saneamiento))
+                if _usar_detalle_habilitado():
                     self._trace_debug(f"[USAR_SANITIZE][CONFLICTS] {evento_conflictos}")
 
             if not simbolos_saneados:
                 mensaje_usuario = formatear_error_usar_usuario("export_invalido", nodo.modulo)
-                if self._debug_trazas_habilitadas() or _runtime_debug_enabled():
+                if _usar_detalle_habilitado():
                     mensaje_usuario = f"{mensaje_usuario} ({USAR_INVALID_EXPORT_ERROR}; conflictos={conflictos_saneamiento})"
                 raise ImportError(mensaje_usuario)
 
@@ -2003,8 +2008,13 @@ class InterpretadorCobra:
                         "policy": self._usar_collision_policy,
                         "detail": detalle_por_simbolo,
                     }
-                    logging.warning("USAR collision symbol event: %s", evento_colision)
-                    if self._debug_trazas_habilitadas() or _runtime_debug_enabled():
+                    logging.warning(
+                        "USAR collision symbol event module=%s symbol=%s policy=%s",
+                        nodo.modulo,
+                        simbolo_conflictivo,
+                        self._usar_collision_policy,
+                    )
+                    if _usar_detalle_habilitado():
                         self._trace_debug(f"[USAR_COLLISION][SYMBOL] {evento_colision}")
 
                 conflicto = conflictos[0]
@@ -2032,7 +2042,7 @@ class InterpretadorCobra:
                         nodo.modulo,
                         "Requiere alias explícito.",
                     )
-                    if self._debug_trazas_habilitadas() or _runtime_debug_enabled():
+                    if _usar_detalle_habilitado():
                         mensaje_usuario = f"{mensaje_usuario} detalle={detalle}"
                     raise NameError(mensaje_usuario)
                 evento_colision = {
@@ -2043,9 +2053,14 @@ class InterpretadorCobra:
                     "policy": self._usar_collision_policy,
                     "detail": detalle,
                 }
-                logging.error("USAR collision event: %s", evento_colision)
+                logging.error(
+                    "USAR collision event module=%s policy=%s total_conflicts=%s",
+                    nodo.modulo,
+                    self._usar_collision_policy,
+                    len(conflictos),
+                )
                 mensaje_usuario = formatear_error_usar_usuario("conflicto_simbolo", nodo.modulo)
-                if self._debug_trazas_habilitadas() or _runtime_debug_enabled():
+                if _usar_detalle_habilitado():
                     mensaje_usuario = f"{mensaje_usuario} detalle={detalle}"
                 raise NameError(mensaje_usuario)
 
@@ -2055,10 +2070,13 @@ class InterpretadorCobra:
                 modulo=nodo.modulo,
             )
         except Exception as exc:
-            logging.exception("Error al usar el módulo '%s': %s", nodo.modulo, exc)
+            if _usar_detalle_habilitado():
+                logging.exception("Error al usar el módulo '%s': %s", nodo.modulo, exc)
+            else:
+                logging.error("Error al usar el módulo '%s': %s", nodo.modulo, exc)
             if isinstance(exc, PermissionError):
                 mensaje = formatear_error_usar_usuario("modulo_fuera_catalogo", nodo.modulo)
-                if self._debug_trazas_habilitadas() or _runtime_debug_enabled():
+                if _usar_detalle_habilitado():
                     mensaje = f"{mensaje} ({exc})"
                 raise PermissionError(mensaje) from exc
             raise

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -915,5 +915,49 @@ def test_usar_error_export_invalido_es_diferenciado(monkeypatch):
     interp = InterpretadorCobra()
     interp.configurar_restriccion_usar_repl({"texto": "texto"})
 
-    with pytest.raises(ImportError, match=r"usar_error\[export_invalido\]"):
+    with pytest.raises(ImportError, match=r"no hay símbolos exportables válidos"):
         interp.ejecutar_nodo(NodoUsar("texto"))
+
+
+def test_usar_no_muestra_traceback_ni_detalle_en_modo_normal(monkeypatch, caplog):
+    modulo = ModuleType("texto")
+    modulo.__all__ = ["a_snake"]
+    modulo.a_snake = lambda texto: texto
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/texto.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
+    monkeypatch.delenv("PCOBRA_DEBUG_RUNTIME", raising=False)
+    monkeypatch.delenv("PCOBRA_DEBUG_TRACES", raising=False)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"texto": "texto"})
+    interp.contextos[-1].define("a_snake", lambda _texto: "ocupado")
+
+    with pytest.raises(NameError) as excinfo:
+        interp.ejecutar_nodo(NodoUsar("texto"))
+
+    texto_error = str(excinfo.value)
+    assert "conflicto de símbolos" in texto_error
+    assert "detalle=" not in texto_error
+    assert "Traceback" not in caplog.text
+
+
+def test_usar_muestra_detalle_extendido_en_debug(monkeypatch, caplog):
+    modulo = ModuleType("texto")
+    modulo.__all__ = ["a_snake"]
+    modulo.a_snake = lambda texto: texto
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/texto.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
+    monkeypatch.setenv("PCOBRA_DEBUG_RUNTIME", "1")
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"texto": "texto"})
+    interp.contextos[-1].define("a_snake", lambda _texto: "ocupado")
+
+    with pytest.raises(NameError) as excinfo:
+        interp.ejecutar_nodo(NodoUsar("texto"))
+
+    texto_error = str(excinfo.value)
+    assert "detalle=" in texto_error
+    assert "Traceback" in caplog.text


### PR DESCRIPTION
### Motivation
- Evitar que la ruta `usar` imprima payloads estructurados completos o tracebacks en la salida normal del REPL. 
- Mantener disponibilidad de información completa solo para logging/diagnóstico y trazas debug/verbose. 
- Proporcionar mensajes cortos y legibles al usuario mediante un formateador dedicado. 

### Description
- Añade `formatear_error_usar_usuario(...)` (existente) y un nuevo helper `_usar_detalle_habilitado()` que centraliza si mostrar detalle extendido según `PCOBRA_DEBUG_RUNTIME` o trazas activadas. 
- Resume `logging.warning`/`logging.error` en `ejecutar_usar` para evitar volcar diccionarios completos y pasa el payload estructurado solo a `_trace_debug(...)` cuando el detalle está habilitado. 
- Cambia el manejo global de excepciones en `ejecutar_usar` para usar `logging.error(...)` en modo normal y `logging.exception(...)` solo cuando `_usar_detalle_habilitado()` es `True`, y proporciona mensajes usuario-amigables mediante `formatear_error_usar_usuario`. 
- Actualiza y añade pruebas en `tests/unit/test_usar.py` para validar el nuevo mensaje user-facing y las diferencias entre modo normal y debug. 

### Testing
- Se agregaron pruebas unitarias que comprueban que en modo normal no aparece `detalle=` ni traceback y que en debug sí aparecen los detalles extendidos. 
- Se ejecutó `pytest` focalizado sobre las pruebas modificadas pero la ejecución falló en la fase de colección debido a resolución de imports del entorno de tests (import relativo/top-level package), por lo que las aserciones lógicas no llegaron a ejecutarse. 
- Las pruebas nuevas/ajustadas están incluidas en el repositorio y deben pasar una vez que el entorno de test use `PYTHONPATH=src` o se ejecute desde el paquete top-level correctamente configurado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00534ee2c08327bf577145f53dda4e)