### PR TITLE
Fix `usar "datos"` callable exports and add safety regression tests

### DIFF
--- a/src/pcobra/corelibs/datos.py
+++ b/src/pcobra/corelibs/datos.py
@@ -48,12 +48,29 @@ combinar_tablas = _datos.combinar_tablas
 rellenar_nulos = _datos.rellenar_nulos
 desplegar_tabla = _datos.desplegar_tabla
 pivotar_tabla = _datos.pivotar_tabla
-agregar = _datos.agregar
-mapear = _datos.mapear
+def agregar(tabla, fila):
+    """Wrapper público seguro hacia :mod:`pcobra.standard_library.datos`."""
+    return _datos.agregar(tabla, fila)
+
+
+def mapear(tabla, transformacion):
+    """Wrapper público seguro hacia :mod:`pcobra.standard_library.datos`."""
+    return _datos.mapear(tabla, transformacion)
+
+
+def longitud(valor):
+    """Wrapper público seguro hacia :mod:`pcobra.standard_library.datos`."""
+    return _datos.longitud(valor)
+
+
+def filtrar(tabla, condicion):
+    """Wrapper público seguro hacia :mod:`pcobra.standard_library.datos`."""
+    return _datos.filtrar(tabla, condicion)
+
+
 reducir = _datos.reducir
 claves = _datos.claves
 valores = _datos.valores
-longitud = _datos.longitud
 
 PUBLIC_API_DATOS: tuple[str, ...] = (
     "leer_csv",

--- a/tests/unit/test_datos_public_contract.py
+++ b/tests/unit/test_datos_public_contract.py
@@ -1,0 +1,22 @@
+from types import ModuleType
+
+import pytest
+
+import pcobra.corelibs.datos as core_datos
+from pcobra.core.usar_symbol_policy import sanear_simbolo_para_usar
+
+
+def test_import_datos_corelib_expone_callables_directos():
+    for simbolo in ("longitud", "filtrar", "mapear", "agregar"):
+        assert callable(getattr(core_datos, simbolo))
+
+
+def test_import_datos_corelib_longitud_resuelve_lista():
+    assert core_datos.longitud([1, 2, 3]) == 3
+
+
+def test_rechazo_continuo_backend_real_en_saneamiento():
+    resultado = sanear_simbolo_para_usar("backend_real", ModuleType("os"))
+
+    assert resultado.rechazado is True
+    assert resultado.codigo == "backend_module_object"


### PR DESCRIPTION
### Motivation
- Asegurar que el puente público `corelibs/datos` exponga funciones Python callables directas para operaciones clave y no proxies ambiguos que puedan confundir la política `usar`.
- Garantizar que la superficie pública mantenga nombres canónicos y que `longitud([1,2,3])` se resuelva correctamente al importar `datos`.
- Verificar que la política de saneamiento siga bloqueando objetos backend reales (módulos / SDK wrappers) y no haya falsos positivos sobre funciones seguras.

### Description
- Reemplacé alias directos por wrappers explícitos en `src/pcobra/corelibs/datos.py` para `agregar`, `mapear`, `longitud` y `filtrar`, delegando internamente en `pcobra.standard_library.datos`.
- Dejé como alias directo las exportaciones no problemáticas (`reducir`, `claves`, `valores`) y mantuve intacta la comprobación `PUBLIC_API_DATOS` y `_validar_superficie_publica_datos()`.
- Añadí pruebas en `tests/unit/test_datos_public_contract.py` que comprueban la importación de callables, que `longitud([1,2,3]) == 3` y que la política de `sanear_simbolo_para_usar` rechaza objetos backend reales.
- No se modificó `src/pcobra/core/usar_symbol_policy.py`; la política de bloqueo de backend queda sin cambios.

### Testing
- Verificación directa por script Python usando `importlib.util.spec_from_file_location(...)` confirmó que `longitud`, `filtrar`, `mapear` y `agregar` son `callable` y que `longitud([1,2,3])` devuelve `3` (éxito).
- `pytest -q tests/unit/test_usar.py -k 'datos_corelib or backend_real_os or repl_usar_datos_imprimir_longitud_lista_produce_3 or usar_datos_no_exporta_objetos_backend_sdk_wrappers'` falló durante la colección por un `ImportError` de importación relativa/circularidad preexistente en el entorno de pruebas y no por los cambios en `datos` (fallido por problema de entorno).
- `pytest -q tests/unit/test_datos_public_contract.py tests/unit/test_standard_library_datos.py -k 'longitud or datos_corelib or rechazo_continuo'` también falló por errores de importación/circularidad del paquete en este entorno de ejecución y no por las nuevas pruebas en sí (fallido por problema de entorno).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a005588453c8327bee57ec65b41b84d)