### PR TITLE
Permitir wrapper seguro de `existe` desde `usar "archivo"` con política de rutas en modo seguro

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2122,6 +2122,8 @@ class InterpretadorCobra:
                     f"'{modulo}': {USAR_SYMBOL_CONFLICT_ERROR} colisión estructurada={detalle}"
                 )
             contexto_actual.define(nombre, simbolo)
+            if self.safe_mode and self._validador is not None and hasattr(self._validador, "registrar_simbolo_publico_usar"):
+                self._validador.registrar_simbolo_publico_usar(nombre)
 
     def ejecutar_holobit(self, nodo):
         """Simula la ejecución de un holobit y devuelve sus valores."""

--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -1,5 +1,7 @@
+from pathlib import PurePosixPath
+
 from .base import ValidadorBase
-from ..ast_nodes import NodoLlamadaFuncion, NodoHilo, NodoLlamadaMetodo
+from ..ast_nodes import NodoLlamadaFuncion, NodoHilo, NodoLlamadaMetodo, NodoValor
 
 
 class PrimitivaPeligrosaError(Exception):
@@ -25,8 +27,41 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
         "listar_dir",
     }
 
+
+
+    def __init__(self):
+        super().__init__()
+        self._simbolos_publicos_usar: set[str] = set()
+
+    def registrar_simbolo_publico_usar(self, nombre: str) -> None:
+        self._simbolos_publicos_usar.add(nombre)
+
+    @staticmethod
+    def _ruta_permitida_en_wrapper(argumentos) -> bool:
+        if not argumentos:
+            return False
+        primer_arg = argumentos[0]
+        if not isinstance(primer_arg, NodoValor) or not isinstance(primer_arg.valor, str):
+            return False
+        ruta = primer_arg.valor.strip()
+        if not ruta:
+            return False
+        path = PurePosixPath(ruta)
+        if path.is_absolute():
+            return False
+        if ".." in path.parts:
+            return False
+        return True
+
+    def _es_wrapper_publico_permitido(self, nodo: NodoLlamadaFuncion) -> bool:
+        if nodo.nombre != "existe":
+            return False
+        if nodo.nombre not in self._simbolos_publicos_usar:
+            return False
+        return self._ruta_permitida_en_wrapper(nodo.argumentos)
+
     def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
-        if nodo.nombre in self.PRIMITIVAS_PELIGROSAS:
+        if nodo.nombre in self.PRIMITIVAS_PELIGROSAS and not self._es_wrapper_publico_permitido(nodo):
             raise PrimitivaPeligrosaError(
                 f"Uso de primitiva peligrosa: '{nodo.nombre}'"
             )

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -24,7 +24,6 @@ def generar_ast(codigo: str):
         "obtener_url('ejemplo')",
         "leer('x.txt')",
         "escribir('x.txt', 'hola')",
-        "existe('x.txt')",
         "enviar_post('u', 'd')",
         "ejecutar(['ls'])",
         "listar_dir('.')",
@@ -43,6 +42,32 @@ def test_codigo_seguro_se_ejecuta_en_modo_seguro():
     with patch("sys.stdout", new_callable=StringIO) as out:
         interp.ejecutar_llamada_funcion(nodo)
     assert out.getvalue().strip() == "hola"
+
+
+def test_existe_publico_desde_usar_acepta_ruta_relativa():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        interp.ejecutar_ast(ast)
+
+    salida = out.getvalue()
+    assert "verdadero" in salida or "falso" in salida
+
+
+@pytest.mark.parametrize(
+    "codigo",
+    [
+        'usar "archivo"\nimprimir(existe("/etc/passwd"))',
+        'usar "archivo"\nimprimir(existe("../secreto.txt"))',
+    ],
+)
+def test_existe_publico_desde_usar_bloquea_rutas_fuera_de_politica(codigo):
+    interp = InterpretadorCobra()
+    ast = generar_ast(codigo)
+
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast)
 
 
 def test_cli_default_mantiene_modo_seguro_y_fallback_inseguro_deshabilitado():


### PR DESCRIPTION
### Motivation
- Permitir que el wrapper público `existe` proveniente de `usar "archivo"` pueda ejecutarse en modo seguro sin abrir la puerta a primitivas arbitrarias peligrosas.
- Diferenciar el origen de un símbolo (símbolo inyectado por `usar` y saneado vs símbolo arbitrario/no confiable) para aplicar reglas más finas de seguridad.
- Aplicar una política de rutas que permita solo rutas relativas seguras y bloquee absolutas o traversal (`..`).

### Description
- El validador `ValidadorPrimitivaPeligrosa` ahora mantiene un registro de símbolos públicos importados por `usar` y añade `registrar_simbolo_publico_usar` para marcarlos como confiables. 
- Se añadió la comprobación de política de ruta usando `PurePosixPath` y la función `_ruta_permitida_en_wrapper` que bloquea rutas absolutas y `..`, y solo acepta `existe` cuando el símbolo fue registrado y la ruta es válida. 
- En el intérprete, al inyectar símbolos saneados en `_inyectar_simbolos_usar_en_contexto` se notifica al validador (`registrar_simbolo_publico_usar`) cuando el intérprete está en `safe_mode` y el validador soporta el registro. 
- Se añadieron tests en `tests/unit/test_safe_mode.py` que verifican `usar "archivo"\nimprimir(existe("README.md"))` (permiso relativo) y rechazan rutas fuera de política (`/etc/passwd`, `../secreto.txt`), y se removió el caso directo `existe('x.txt')` de la lista global de primitivas rechazadas en ese test. 

### Testing
- Ejecuté `pytest -q tests/unit/test_safe_mode.py tests/unit/test_semantic_validator.py` y la ejecución falló en la recolección por un error de importación (`attempted relative import beyond top-level package`) en este entorno de test automatizado. 
- Intenté `PYTHONPATH=src pytest -q ...` para limitar el scope a los tests añadidos y otra vez no se completó la recolección (sin collectors para los tests explícitos) debido a la configuración del entorno de importación; por tanto los nuevos tests no pudieron ejecutarse con éxito aquí. 
- Los cambios han sido limitados a `src/pcobra/core/semantic_validators/primitiva_peligrosa.py`, `src/pcobra/core/interpreter.py` y `tests/unit/test_safe_mode.py` y requieren ejecutar la suite de tests en el layout de paquete estándar (por ejemplo con `PYTHONPATH=src` o instalando el paquete) para validar completamente los tests añadidos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0056cd5c388327a2730b754f04df02)