### PR TITLE
Hacer idempotente reimport de `usar` con metadatos de símbolo

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -485,6 +485,9 @@ class InterpretadorCobra:
         # Restricción opcional para `usar` en REPL/evaluador incremental.
         self._repl_usar_alias_map: dict[str, str] | None = None
         self._usar_collision_policy = USAR_COLLISION_STRICT_ERROR
+        # Metadatos de símbolos inyectados por `usar` para soportar reimport idempotente.
+        # nombre_simbolo -> {"module": str, "exported_name": str, "callable_id": int}
+        self._usar_symbol_metadata: dict[str, dict[str, object]] = {}
 
     def configurar_restriccion_usar_repl(self, alias_map: dict[str, str] | None) -> None:
         """Configura whitelist explícita de módulos `usar` para flujo REPL.
@@ -2084,9 +2087,23 @@ class InterpretadorCobra:
     def _detectar_conflictos_usar_en_contexto(
         self, simbolos_saneados: list[tuple[str, object]], modulo: str
     ) -> list[str]:
-        """Devuelve los símbolos que ya existen en el contexto activo."""
+        """Devuelve símbolos en conflicto real (ignora reimport idempotente por metadatos)."""
         contexto_actual = self.contextos[-1]
-        conflictos = [nombre for nombre, _ in simbolos_saneados if contexto_actual.contains(nombre)]
+        conflictos: list[str] = []
+        for nombre, simbolo in simbolos_saneados:
+            if not contexto_actual.contains(nombre):
+                continue
+            previo = self._usar_symbol_metadata.get(nombre)
+            identidad_actual = id(simbolo)
+            if (
+                previo
+                and previo.get("module") == modulo
+                and previo.get("exported_name") == nombre
+                and previo.get("callable_id") == identidad_actual
+            ):
+                # Reimport idempotente: mismo símbolo, mismo módulo origen y misma identidad.
+                continue
+            conflictos.append(nombre)
         if conflictos:
             self._trace_debug(
                 "[USAR_COLLISION][PREFLIGHT] "
@@ -2105,6 +2122,16 @@ class InterpretadorCobra:
         contexto_actual = self.contextos[-1]
         for nombre, simbolo in simbolos_saneados:
             if contexto_actual.contains(nombre) and not permitir_sobrescritura:
+                previo = self._usar_symbol_metadata.get(nombre)
+                identidad_actual = id(simbolo)
+                if (
+                    previo
+                    and previo.get("module") == modulo
+                    and previo.get("exported_name") == nombre
+                    and previo.get("callable_id") == identidad_actual
+                ):
+                    # No-op idempotente: evita warning/ruido al reimportar lo mismo.
+                    continue
                 detalle = {
                     "module": modulo,
                     "symbol": nombre,
@@ -2122,6 +2149,11 @@ class InterpretadorCobra:
                     f"'{modulo}': {USAR_SYMBOL_CONFLICT_ERROR} colisión estructurada={detalle}"
                 )
             contexto_actual.define(nombre, simbolo)
+            self._usar_symbol_metadata[nombre] = {
+                "module": modulo,
+                "exported_name": nombre,
+                "callable_id": id(simbolo),
+            }
             if self.safe_mode and self._validador is not None and hasattr(self._validador, "registrar_simbolo_publico_usar"):
                 self._validador.registrar_simbolo_publico_usar(nombre)
 

--- a/tests/unit/test_usar_runtime_policy.py
+++ b/tests/unit/test_usar_runtime_policy.py
@@ -145,6 +145,41 @@ def test_usar_runtime_colision_warn_diagnostico_y_sin_overwrite(monkeypatch, cap
     assert "usar_collision" in caplog.text
 
 
+def test_usar_runtime_reimport_idempotente_logica_no_falla(monkeypatch):
+    import pcobra.corelibs.logica as modulo_logica
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _n, **_k: modulo_logica)
+    interp = _interp_con_alias({"logica": "logica"})
+
+    interp.ejecutar_nodo(NodoUsar("logica"))
+    interp.ejecutar_nodo(NodoUsar("logica"))
+
+    assert "y_logico" in interp.variables
+
+
+def test_usar_runtime_reimport_idempotente_numero_no_falla(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _n, **_k: modulo_numero)
+    interp = _interp_con_alias({"numero": "numero"})
+
+    interp.ejecutar_nodo(NodoUsar("numero"))
+    interp.ejecutar_nodo(NodoUsar("numero"))
+
+    assert "es_finito" in interp.variables
+
+
+def test_usar_runtime_colision_variable_usuario_sigue_fallando(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _n, **_k: modulo_numero)
+    interp = _interp_con_alias({"numero": "numero"})
+    interp.contextos[-1].define("es_finito", "soy_usuario")
+
+    with pytest.raises(NameError, match="conflicto de símbolos"):
+        interp.ejecutar_nodo(NodoUsar("numero"))
+
+
 def test_usar_runtime_holobit_no_expone_objetos_sdk_internos(monkeypatch):
     import pcobra.corelibs.holobit as modulo_holobit
 


### PR DESCRIPTION
### Motivation
- Evitar ruido y warnings cuando un módulo oficial se vuelve a `usar` sin cambios efectivos al contexto (reimport idempotente). 
- Poder distinguir reimports idempotentes de colisiones reales por usuario u otros módulos usando metadatos del símbolo. 
- Mantener la política estricta de colisiones para casos genuinos (variable de usuario, módulo distinto o identidad distinta). 

### Description
- Añadido almacenamiento de metadatos en runtime `InterpretadorCobra._usar_symbol_metadata` para cada símbolo inyectado por `usar` con campos `module`, `exported_name` y `callable_id` (identidad del objeto). (modificado: `src/pcobra/core/interpreter.py`).
- Cambiada la detección de conflictos en `_detectar_conflictos_usar_en_contexto` para ignorar como conflicto los símbolos que ya existen pero cuya metadata indica mismo módulo origen, mismo nombre exportado y misma identidad del callable (tratar como no-op idempotente). (modificado: `src/pcobra/core/interpreter.py`).
- En `_inyectar_simbolos_usar_en_contexto` se reconoce y se salta la reimportación idempotente durante la inyección atómica y se persisten/actualizan los metadatos cuando se define un símbolo nuevo. (modificado: `src/pcobra/core/interpreter.py`).
- Añadidas pruebas unitarias en `tests/unit/test_usar_runtime_policy.py` para cubrir: reimport idempotente de `logica`, reimport idempotente de `numero`, y que una colisión con variable definida por el usuario sigue produciendo error. (modificado: `tests/unit/test_usar_runtime_policy.py`).

### Testing
- Ejecutado `pytest -q tests/unit/test_usar_runtime_policy.py -k 'reimport_idempotente or variable_usuario or colision_warn_diagnostico'` sin `PYTHONPATH` y falló en la fase de colección con `ImportError: attempted relative import beyond top-level package` (no se ejecutaron los tests añadidos). 
- Ejecutado `PYTHONPATH=src pytest -q tests/unit/test_usar_runtime_policy.py -k 'reimport_idempotente or variable_usuario or colision_warn_diagnostico'` para intentar corregir el path, y volvió a fallar en colección con el mismo `ImportError` (los nuevos tests no llegaron a ejecutarse). 
- Nota: las pruebas nuevas están incluidas en el árbol y están diseñadas para validar que: `usar "logica"` y `usar "numero"` son idempotentes y que una variable de usuario en el contexto sigue causando colisión; en el entorno de CI habitual (donde la resolución de paquetes es la esperada) deberían ejecutarse exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a005811bb5883279999669b336db89e)