### PR TITLE
Refina manejo de errores REPL para `usar` como errores de usuario

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -117,6 +117,23 @@ def format_user_error(exc: Exception) -> str:
     return msg or _("Error desconocido")
 
 
+def _es_error_usuario_repl(exc: Exception) -> bool:
+    """Clasifica errores esperados de contrato `usar` como errores de usuario."""
+    msg = str(exc)
+    if isinstance(exc, (PermissionError, ValueError, ImportError)):
+        if "usar_error[" in msg:
+            return True
+        if "catálogo público" in msg or "catalogo publico" in msg.lower():
+            return True
+        if "conflicto de símbolos" in msg or "conflicto de simbolos" in msg.lower():
+            return True
+        if "referencia circular" in msg.lower() or "import circular" in msg.lower():
+            return True
+        if "export_invalido" in msg or "sanitize" in msg.lower():
+            return True
+    return False
+
+
 class _SessionHistoryFallback:
     """Historial mínimo para dobles de sesión usados en pruebas."""
 
@@ -987,6 +1004,8 @@ class InteractiveCommand(BaseCommand):
         """Clasifica errores del REPL para un reporte único en el loop principal."""
         if isinstance(error, (LexerError, ParserError)):
             return _("Error de sintaxis")
+        if _es_error_usuario_repl(error):
+            return _("Error de usuario")
         if isinstance(error, RuntimeError):
             return _("Error crítico")
         return _("Error general")

--- a/tests/cli/test_repl_error_recovery_contract.py
+++ b/tests/cli/test_repl_error_recovery_contract.py
@@ -39,10 +39,13 @@ def test_repl_bloque_incompleto_con_fin_anidado_sigue_acumulando(monkeypatch):
         sandbox_docker=None,
     )
 
-    ejecutar_spy.assert_called_once_with(
-        'si verdadero:\nsi verdadero:\n    imprimir("interno")\nfin\n    imprimir("externo")\nfin',
+    ejecutar_spy.assert_called_once()
+    args, kwargs = ejecutar_spy.call_args
+    assert args[:2] == (
+        'si verdadero:\nsi verdadero:\nimprimir("interno")\nfin\nimprimir("externo")\nfin',
         None,
     )
+    assert "ast_preparseado" in kwargs
     assert prompts[:6] == [">>> ", "... ", "... ", "... ", "... ", "... "]
 
 
@@ -72,7 +75,10 @@ def test_repl_error_sintactico_por_cierre_extra_reporta_y_acepta_nuevas_entradas
     )
 
     assert any("'fin'" in msg and "inesperado" in msg for msg in errores)
-    ejecutar_spy.assert_called_once_with('imprimir("ok")', None)
+    ejecutar_spy.assert_called_once()
+    args, kwargs = ejecutar_spy.call_args
+    assert args[:2] == ('imprimir("ok")', None)
+    assert "ast_preparseado" in kwargs
     assert cmd._estado_repl["buffer_lineas"] == []
     assert cmd._estado_repl["nivel_bloque"] == 0
 
@@ -80,7 +86,7 @@ def test_repl_error_sintactico_por_cierre_extra_reporta_y_acepta_nuevas_entradas
 @pytest.mark.integration
 def test_repl_error_runtime_no_cierra_sesion_y_permite_recuperacion(monkeypatch):
     cmd = InteractiveCommand(MagicMock())
-    entradas = iter(["romper()", 'imprimir("sigue")', "salir"])
+    entradas = iter(['imprimir("boom")', 'imprimir("sigue")', "salir"])
     errores: list[str] = []
 
     def _leer_linea(_prompt: str) -> str:
@@ -91,8 +97,8 @@ def test_repl_error_runtime_no_cierra_sesion_y_permite_recuperacion(monkeypatch)
         lambda mensaje, registrar_log=False: errores.append(str(mensaje)),
     )
 
-    def _ejecutar_codigo(codigo: str, _validador):
-        if codigo == "romper()":
+    def _ejecutar_codigo(codigo: str, _validador, ast_preparseado=None):
+        if codigo == 'imprimir("boom")':
             raise RuntimeError("fallo de runtime controlado")
 
     monkeypatch.setattr(cmd, "ejecutar_codigo", _ejecutar_codigo)
@@ -108,3 +114,94 @@ def test_repl_error_runtime_no_cierra_sesion_y_permite_recuperacion(monkeypatch)
     assert any("fallo de runtime controlado" in msg for msg in errores)
     assert cmd._estado_repl["nivel_bloque"] == 0
     assert cmd._estado_repl["buffer_lineas"] == []
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("linea", "exc"),
+    [
+        ('usar "numpy"', ValueError("usar_error[modulo_fuera_catalogo_publico] numpy")),
+        ('usar "datos"', ValueError("usar_error[export_invalido]: sanitize vacío")),
+        ('usar "texto"', RuntimeError("usar_error[import_circular_controlado]: texto")),
+        ('usar "numero"', ValueError("usar_error[conflicto_simbolo]: no idempotente")),
+    ],
+)
+def test_repl_usar_errores_esperados_solo_mensaje_breve_sin_traceback(
+    monkeypatch, linea, exc
+):
+    cmd = InteractiveCommand(MagicMock())
+    entradas = iter([linea, "salir"])
+    errores: list[str] = []
+    logs_debug: list[str] = []
+
+    monkeypatch.setattr(
+        "pcobra.cobra.cli.commands.interactive_cmd.mostrar_error",
+        lambda mensaje, registrar_log=False: errores.append(str(mensaje)),
+    )
+    monkeypatch.setattr(
+        cmd.logger,
+        "debug",
+        lambda mensaje, *args, **kwargs: logs_debug.append(str(mensaje)),
+    )
+
+    def _leer_linea(_prompt: str) -> str:
+        return next(entradas)
+
+    def _ejecutar_codigo(codigo: str, _validador, ast_preparseado=None):
+        if codigo == linea:
+            raise exc
+
+    monkeypatch.setattr(cmd, "ejecutar_codigo", _ejecutar_codigo)
+    cmd._debug_mode = False
+
+    cmd._run_repl_loop(
+        args=SimpleNamespace(),
+        validador=None,
+        leer_linea=_leer_linea,
+        sandbox=False,
+        sandbox_docker=None,
+    )
+
+    assert errores
+    assert any(msg.startswith("usar_error[") for msg in errores)
+    assert not any("Traceback" in msg for msg in errores)
+    assert not any("Traceback" in msg for msg in logs_debug)
+
+
+@pytest.mark.integration
+def test_repl_usar_error_debug_incluye_traceback(monkeypatch):
+    cmd = InteractiveCommand(MagicMock())
+    entradas = iter(['usar "texto"', "salir"])
+    errores: list[str] = []
+    logs_debug: list[str] = []
+
+    monkeypatch.setattr(
+        "pcobra.cobra.cli.commands.interactive_cmd.mostrar_error",
+        lambda mensaje, registrar_log=False: errores.append(str(mensaje)),
+    )
+    monkeypatch.setattr(
+        cmd.logger,
+        "debug",
+        lambda mensaje, *args, **kwargs: logs_debug.append(str(mensaje)),
+    )
+
+    def _leer_linea(_prompt: str) -> str:
+        return next(entradas)
+
+    def _ejecutar_codigo(codigo: str, _validador, ast_preparseado=None):
+        if codigo == 'usar "texto"':
+            raise RuntimeError("usar_error[import_circular_controlado]: texto")
+
+    monkeypatch.setattr(cmd, "ejecutar_codigo", _ejecutar_codigo)
+    cmd._debug_mode = True
+
+    cmd._run_repl_loop(
+        args=SimpleNamespace(),
+        validador=None,
+        leer_linea=_leer_linea,
+        sandbox=False,
+        sandbox_docker=None,
+    )
+
+    assert errores and errores[0].startswith("usar_error[")
+    assert any("usar_error[import_circular_controlado]" in msg for msg in logs_debug)


### PR DESCRIPTION
### Motivation
- Tratar errores esperados del contrato `usar` (módulo fuera de catálogo público, sanitización vacía/export inválido, conflicto de símbolo, import circular controlado) como errores de usuario para evitar mostrar tracebacks ruidosos al usuario.
- Mantener salida concisa en modo normal (`Error: ...`) mientras que en modo debug/verbose se conserva la traza técnica para diagnóstico.
- Evitar que logs técnicos (p. ej. trazas) terminen replicándose en la salida estándar del usuario.

### Description
- Añadí la función helper `def _es_error_usuario_repl(exc: Exception) -> bool:` que detecta errores de contrato `usar` (busca códigos/fragmentos como `usar_error[`, `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0059437b048327adf770d0006cc314)