### PR TITLE
Refina errores de `usar`: mensajes cortos para usuario y detalle en debug

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -118,11 +118,17 @@ def formatear_error_usar_usuario(codigo: str, modulo: str, contexto_minimo: str 
         "modulo_fuera_catalogo": f"No se puede usar '{modulo}': módulo fuera del catálogo público.",
         "conflicto_simbolo": f"No se puede usar '{modulo}': hay conflicto de símbolos en el contexto actual.",
         "export_invalido": f"No se puede usar '{modulo}': no hay símbolos exportables válidos.",
+        "carga_modulo_error": f"No se puede usar '{modulo}': error al cargar el módulo.",
     }
     base = mensajes.get(codigo, f"No se puede usar '{modulo}'.")
     if contexto_minimo:
         return f"{base} {contexto_minimo}"
     return base
+
+
+def _usar_error_esperado(exc: Exception) -> bool:
+    """Identifica errores esperados del contrato de `usar`."""
+    return isinstance(exc, (PermissionError, NameError, ImportError, ValueError))
 
 
 def _usar_detalle_habilitado() -> bool:
@@ -2075,13 +2081,20 @@ class InterpretadorCobra:
         except Exception as exc:
             if _usar_detalle_habilitado():
                 logging.exception("Error al usar el módulo '%s': %s", nodo.modulo, exc)
-            else:
+            elif _usar_error_esperado(exc):
                 logging.error("Error al usar el módulo '%s': %s", nodo.modulo, exc)
+            else:
+                logging.exception("Error al usar el módulo '%s': %s", nodo.modulo, exc)
             if isinstance(exc, PermissionError):
                 mensaje = formatear_error_usar_usuario("modulo_fuera_catalogo", nodo.modulo)
                 if _usar_detalle_habilitado():
                     mensaje = f"{mensaje} ({exc})"
                 raise PermissionError(mensaje) from exc
+            if isinstance(exc, ModuleNotFoundError):
+                mensaje = formatear_error_usar_usuario("carga_modulo_error", nodo.modulo)
+                if _usar_detalle_habilitado():
+                    mensaje = f"{mensaje} ({exc})"
+                raise ImportError(mensaje) from exc
             raise
 
     def _detectar_conflictos_usar_en_contexto(

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -961,3 +961,24 @@ def test_usar_muestra_detalle_extendido_en_debug(monkeypatch, caplog):
     texto_error = str(excinfo.value)
     assert "detalle=" in texto_error
     assert "Traceback" in caplog.text
+
+
+def test_usar_error_carga_modulo_mensaje_corto_en_modo_normal(monkeypatch, caplog):
+    monkeypatch.setattr(
+        core_usar_loader,
+        "obtener_modulo_cobra_oficial",
+        lambda _nombre: (_ for _ in ()).throw(ModuleNotFoundError("boom")),
+    )
+    monkeypatch.delenv("PCOBRA_DEBUG_RUNTIME", raising=False)
+    monkeypatch.delenv("PCOBRA_DEBUG_TRACES", raising=False)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"texto": "texto"})
+
+    with pytest.raises(ImportError) as excinfo:
+        interp.ejecutar_nodo(NodoUsar("texto"))
+
+    texto_error = str(excinfo.value)
+    assert "error al cargar el módulo" in texto_error
+    assert "boom" not in texto_error
+    assert "Traceback" not in caplog.text


### PR DESCRIPTION
### Motivation
- Evitar que la ruta `usar` imprima payload técnico o tracebacks en modo normal manteniendo trazas completas disponibles en debug/verbose.  
- Proveer mensajes breves y consistentes para errores esperados del contrato (`usar`) y mantener eventos/`logger` con payload íntegro para diagnóstico.  

### Description
- Añadido mensaje corto `carga_modulo_error` en `formatear_error_usar_usuario` para presentar al usuario fallos de carga de módulo de forma resumida.  
- Introducido helper `_usar_error_esperado` que identifica errores de contrato (`PermissionError`, `NameError`, `ImportError`, `ValueError`) y se usa para decidir si registrar con o sin traceback.  
- Ajustada la rama `except` en `InterpretadorCobra.ejecutar_usar` para usar `logging.error(...)` (sin traceback) para errores esperados en modo normal y `logging.exception(...)` (con traceback) solo en modo debug/verbose o para errores inesperados.  
- Convertido `ModuleNotFoundError` en `ImportError` que expone el mensaje corto al usuario en modo normal y el detalle original sólo si `PCOBRA_DEBUG_RUNTIME`/trazas está activo; añadido test que cubre presentación corta para error de carga.  

### Testing
- Ejecuté `pytest -q tests/unit/test_usar.py -k "no_muestra_traceback or muestra_detalle_extendido_en_debug or error_export_invalido_es_diferenciado or error_carga_modulo_mensaje_corto"`, la ejecución falló en la fase de colección por configuración de imports (`attempted relative import beyond top-level package`).  
- Ejecuté `PYTHONPATH=src pytest -q tests/unit/test_usar.py -k "no_muestra_traceback or muestra_detalle_extendido_en_debug or error_export_invalido_es_diferenciado or error_carga_modulo_mensaje_corto"`, y presentó la misma falla de colección por imports del entorno de prueba.  
- Se añadió la prueba `test_usar_error_carga_modulo_mensaje_corto_en_modo_normal` que valida ausencia de traceback y mensaje corto; la prueba no llegó a ejecutarse por el problema de colección anterior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a005e61d8ac8327ac0f95765854892d)