### PR TITLE
test: añadir cobertura para `usar "datos"` (agregar/mapear/filtrar)

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -751,6 +751,24 @@ def test_usar_datos_incluye_filtrar_mapear_reducir(monkeypatch):
         assert simbolo in interp.variables
 
 
+
+def test_usar_datos_operaciones_basicas_agregar_mapear_filtrar(monkeypatch):
+    import pcobra.standard_library.datos as modulo_datos
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_datos)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"datos": "datos"})
+    interp.ejecutar_nodo(NodoUsar("datos"))
+
+    tabla = [{"valor": 1}, {"valor": 2}]
+
+    assert interp.obtener_variable("agregar")(tabla, {"valor": 3})[-1]["valor"] == 3
+    assert interp.obtener_variable("mapear")(tabla, lambda fila: {**fila, "valor": fila["valor"] * 2}) == [
+        {"valor": 2},
+        {"valor": 4},
+    ]
+    assert interp.obtener_variable("filtrar")(tabla, lambda fila: fila["valor"] % 2 == 0) == [{"valor": 2}]
+
 def test_usar_numpy_rechazado_en_superficie_publica():
     interp = InterpretadorCobra()
     interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto", "datos": "datos"})


### PR DESCRIPTION
### Motivation
- Asegurar que la superficie Cobra-facing de `datos` expone callables reales para operaciones básicas (`longitud`, `filtrar`, `mapear`, `agregar`) y que `usar "datos"` sigue permitido mientras `usar "numpy"` permanece rechazado.

### Description
- Añadí el test `test_usar_datos_operaciones_basicas_agregar_mapear_filtrar` en `tests/unit/test_usar.py` que valida, tras `usar "datos"`, que `agregar`, `mapear` y `filtrar` son callables operativos; no se hicieron cambios a `src/pcobra/corelibs/datos.py` ni a la regla global `backend_module_object` en `src/pcobra/core/usar_symbol_policy.py`.

### Testing
- Ejecuté pruebas focalizadas con `pytest` sobre los casos relacionados con `usar "datos"` y `usar "numpy"`, pero la ejecución se interrumpió en la fase de colección por errores de importación (`ImportError` por import circular en `pcobra.corelibs` y `ImportError: attempted relative import beyond top-level package`), por lo que los tests añadidos no llegaron a ejecutarse.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00609bdc988327ba74453654bbbc89)