### PR TITLE
Refuerza validación segura de `existe` importado por `usar "archivo"`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2168,7 +2168,7 @@ class InterpretadorCobra:
                 "callable_id": id(simbolo),
             }
             if self.safe_mode and self._validador is not None and hasattr(self._validador, "registrar_simbolo_publico_usar"):
-                self._validador.registrar_simbolo_publico_usar(nombre)
+                self._validador.registrar_simbolo_publico_usar(nombre, modulo)
 
     def ejecutar_holobit(self, nodo):
         """Simula la ejecución de un holobit y devuelve sus valores."""

--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -31,10 +31,10 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
 
     def __init__(self):
         super().__init__()
-        self._simbolos_publicos_usar: set[str] = set()
+        self._simbolos_publicos_usar: set[tuple[str, str]] = set()
 
-    def registrar_simbolo_publico_usar(self, nombre: str) -> None:
-        self._simbolos_publicos_usar.add(nombre)
+    def registrar_simbolo_publico_usar(self, nombre: str, modulo: str) -> None:
+        self._simbolos_publicos_usar.add((modulo, nombre))
 
     @staticmethod
     def _ruta_permitida_en_wrapper(argumentos) -> bool:
@@ -56,7 +56,7 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
     def _es_wrapper_publico_permitido(self, nodo: NodoLlamadaFuncion) -> bool:
         if nodo.nombre != "existe":
             return False
-        if nodo.nombre not in self._simbolos_publicos_usar:
+        if ("archivo", nodo.nombre) not in self._simbolos_publicos_usar:
             return False
         return self._ruta_permitida_en_wrapper(nodo.argumentos)
 

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -76,3 +76,19 @@ def test_cli_default_mantiene_modo_seguro_y_fallback_inseguro_deshabilitado():
     args = app._parse_arguments([])
     assert args.seguro is True
     assert args.allow_insecure_fallback is False
+
+
+@pytest.mark.parametrize(
+    "codigo",
+    [
+        'usar "archivo"\nimprimir(existe("./../secreto.txt"))',
+        'usar "archivo"\nimprimir(existe("carpeta/../../secreto.txt"))',
+    ],
+)
+def test_existe_publico_desde_usar_bloquea_traversal_normalizado(codigo):
+    interp = InterpretadorCobra()
+    ast = generar_ast(codigo)
+
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast)
+


### PR DESCRIPTION
### Motivation
- Evitar permisos por homonimia de símbolos importados con `usar` y asegurar que la excepción para `existe(...)` solo aplique cuando el callable viene explícitamente del módulo público Cobra `archivo`.
- Mantener la política de rutas seguras (relativa, no absoluta, sin `..`) para cualquier acceso a archivo exposado como callable Cobra-facing.

### Description
- Cambia `ValidadorPrimitivaPeligrosa` para registrar símbolos públicos de `usar` como pares `(modulo, nombre)` en lugar de solo `nombre` y adapta la comprobación para que la excepción de `existe` verifique el par `("archivo", nombre)`.
- Modifica la firma de `registrar_simbolo_publico_usar` para recibir `nombre` y `modulo`, y actualiza el intérprete para pasar `modulo` al registrar símbolos inyectados por `usar`.
- Conserva/fortalece las comprobaciones de ruta en `_ruta_permitida_en_wrapper`: la ruta debe ser no vacía, no absoluta y no contener `..` (esto cubre casos normalizados tipo `./../` y `carpeta/../../`).
- Añade tests negativos en `tests/unit/test_safe_mode.py` que validan traversal normalizado rechazado por la política de seguridad y preserva el test de aceptación (`usar "archivo"` + `existe("README.md")` devuelve booleano).

### Testing
- Ejecuté compilación rápida de los ficheros modificados con `python -m compileall -q ...` y la comprobación de bytecode fue exitosa.
- Intenté ejecutar `pytest -q tests/unit/test_safe_mode.py` pero la ejecución falló en la fase de recolección por un problema de importación del entorno (`ImportError: attempted relative import beyond top-level package`), por lo que los tests unitarios no se completaron en este entorno de ejecución.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00618a1e548327ad6427705f4254a5)