### PR TITLE
Hacer idempotente `usar` en reimportaciones con metadatos de símbolo

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2107,13 +2107,12 @@ class InterpretadorCobra:
             if not contexto_actual.contains(nombre):
                 continue
             previo = self._usar_symbol_metadata.get(nombre)
-            identidad_actual = id(simbolo)
-            if (
-                previo
-                and previo.get("module") == modulo
-                and previo.get("exported_name") == nombre
-                and previo.get("callable_id") == identidad_actual
-            ):
+            metadata_actual = self._construir_metadata_simbolo_usar(
+                modulo=modulo,
+                nombre_exportado=nombre,
+                simbolo=simbolo,
+            )
+            if previo and previo == metadata_actual:
                 # Reimport idempotente: mismo símbolo, mismo módulo origen y misma identidad.
                 continue
             conflictos.append(nombre)
@@ -2136,13 +2135,12 @@ class InterpretadorCobra:
         for nombre, simbolo in simbolos_saneados:
             if contexto_actual.contains(nombre) and not permitir_sobrescritura:
                 previo = self._usar_symbol_metadata.get(nombre)
-                identidad_actual = id(simbolo)
-                if (
-                    previo
-                    and previo.get("module") == modulo
-                    and previo.get("exported_name") == nombre
-                    and previo.get("callable_id") == identidad_actual
-                ):
+                metadata_actual = self._construir_metadata_simbolo_usar(
+                    modulo=modulo,
+                    nombre_exportado=nombre,
+                    simbolo=simbolo,
+                )
+                if previo and previo == metadata_actual:
                     # No-op idempotente: evita warning/ruido al reimportar lo mismo.
                     continue
                 detalle = {
@@ -2162,13 +2160,36 @@ class InterpretadorCobra:
                     f"'{modulo}': {USAR_SYMBOL_CONFLICT_ERROR} colisión estructurada={detalle}"
                 )
             contexto_actual.define(nombre, simbolo)
-            self._usar_symbol_metadata[nombre] = {
-                "module": modulo,
-                "exported_name": nombre,
-                "callable_id": id(simbolo),
-            }
+            self._usar_symbol_metadata[nombre] = self._construir_metadata_simbolo_usar(
+                modulo=modulo,
+                nombre_exportado=nombre,
+                simbolo=simbolo,
+            )
             if self.safe_mode and self._validador is not None and hasattr(self._validador, "registrar_simbolo_publico_usar"):
                 self._validador.registrar_simbolo_publico_usar(nombre, modulo)
+
+    def _construir_metadata_simbolo_usar(
+        self,
+        *,
+        modulo: str,
+        nombre_exportado: str,
+        simbolo: object,
+    ) -> dict[str, object]:
+        """Construye metadatos de origen para detectar reimportaciones idempotentes."""
+        firma_estable = None
+        modulo_objeto = getattr(simbolo, "__module__", None)
+        qualname = getattr(simbolo, "__qualname__", None)
+        code = getattr(simbolo, "__code__", None)
+        if modulo_objeto and qualname:
+            firma_estable = f"{modulo_objeto}:{qualname}"
+            if code is not None:
+                firma_estable = f"{firma_estable}:{getattr(code, 'co_argcount', 'na')}:{getattr(code, 'co_kwonlyargcount', 'na')}"
+        return {
+            "module": modulo,
+            "exported_name": nombre_exportado,
+            "callable_id": id(simbolo),
+            "stable_signature": firma_estable,
+        }
 
     def ejecutar_holobit(self, nodo):
         """Simula la ejecución de un holobit y devuelve sus valores."""

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -661,6 +661,69 @@ def test_usar_texto_exporta_solo_nombres_espanoles(monkeypatch):
     assert "to_snake_case" not in interp.variables
 
 
+def test_usar_logica_dos_veces_es_idempotente(monkeypatch):
+    import pcobra.corelibs.logica as modulo_logica
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_logica)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"logica": "logica"})
+
+    _ejecutar_codigo('usar "logica"\nusar "logica"', interp)
+
+    assert "es_verdadero" in interp.variables
+
+
+def test_usar_numero_dos_veces_es_idempotente(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_numero)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero"})
+
+    _ejecutar_codigo('usar "numero"\nusar "numero"', interp)
+
+    assert "es_finito" in interp.variables
+
+
+def test_usar_numero_conflicto_real_por_redefinicion_usuario(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_numero)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero"})
+    interp.contextos[-1].define("es_finito", 123)
+
+    with pytest.raises(NameError, match=r"conflicto"):
+        _ejecutar_codigo('usar "numero"', interp)
+
+
+def test_usar_conflicto_entre_modulos_distintos_mismo_nombre(monkeypatch):
+    modulo_numero = ModuleType("numero")
+    modulo_numero.__all__ = ["compartido"]
+    modulo_numero.compartido = lambda valor: valor
+    modulo_numero.__file__ = "/workspace/pCobra/src/pcobra/corelibs/numero.py"
+
+    modulo_logica = ModuleType("logica")
+    modulo_logica.__all__ = ["compartido"]
+    modulo_logica.compartido = lambda valor: not valor
+    modulo_logica.__file__ = "/workspace/pCobra/src/pcobra/corelibs/logica.py"
+
+    def _resolver(nombre, **_kwargs):
+        if nombre == "numero":
+            return modulo_numero
+        if nombre == "logica":
+            return modulo_logica
+        raise ModuleNotFoundError(nombre)
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", _resolver)
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero", "logica": "logica"})
+    _ejecutar_codigo('usar "numero"', interp)
+
+    with pytest.raises(NameError, match=r"conflicto"):
+        _ejecutar_codigo('usar "logica"', interp)
+
+
 
 
 def test_repl_usar_datos_imprimir_longitud_lista_produce_3(monkeypatch, capsys):


### PR DESCRIPTION
### Motivation
- Registrar metadatos de origen por símbolo importado (`módulo`, `nombre` público, `identidad` y una `firma estable`) para distinguir reimports idempotentes de conflictos reales.
- Hacer que una segunda llamada a `usar "modulo"` sea no-op cuando el símbolo proviene del mismo módulo y objeto, y seguir fallando si hay diferencias (redefinición de usuario, otro módulo u otro objeto).
- Evitar ruido de warnings por cada símbolo en escenarios idempotentes y permitir un único mensaje de debugging opcional.

### Description
- Se añadió la función ` _construir_metadata_simbolo_usar(...)` que normaliza y devuelve metadatos por símbolo (módulo origen, `exported_name`, `callable_id` e `stable_signature`).
- ` _detectar_conflictos_usar_en_contexto(...)` ahora compara los metadatos almacenados con los metadatos actuales y solo considera reimports verdaderamente idénticos como no-conflicto; cualquier diferencia sigue produciendo conflicto estricto.
- ` _inyectar_simbolos_usar_en_contexto(...)` aplica la misma comparación en tiempo de inyección, evita warnings/no-ops para reimports idempotentes y almacena los metadatos enriquecidos en `self._usar_symbol_metadata` al definir el símbolo.
- Se añadieron tests en `tests/unit/test_usar.py` para cubrir los casos solicitados: `test_usar_logica_dos_veces_es_idempotente`, `test_usar_numero_dos_veces_es_idempotente`, `test_usar_numero_conflicto_real_por_redefinicion_usuario` y `test_usar_conflicto_entre_modulos_distintos_mismo_nombre`.

### Testing
- Ejecuté pruebas focalizadas con `pytest` sobre el archivo modificado: `pytest -q tests/unit/test_usar.py -k 'idempotente or conflicto_real or modulos_distintos'` y variantes con `PYTHONPATH` para intentar resolver imports; la colección falló en este entorno por un error de import legacy: `ImportError: attempted relative import beyond top-level package`, por lo que los tests nuevos no llegaron a ejecutarse.
- Resultado de las ejecuciones automatizadas: la colección de tests falló (no se alcanzó la ejecución de las nuevas pruebas) debido al problema de importación descrito, por lo que no hay resultados de pas/fail de los tests añadidos en este entorno de CI local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0062ae1a9483278aebaf6152136fde)