### PR TITLE
Clasifica errores de contrato como errores de usuario y oculta traceback en modo normal

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -293,6 +293,25 @@ class CommandRegistry:
 
         return self.commands
 
+def _is_expected_user_contract_error(exc: Exception) -> bool:
+    """Clasifica errores de contrato esperados que deben tratarse como error de usuario."""
+    mensaje = str(exc).strip().lower()
+    if not mensaje:
+        return False
+    marcadores = (
+        "usar_error[",
+        "conflicto",
+        "sanitize",
+        "sanitiz",
+        "modulo_fuera_catalogo",
+        "módulo fuera de catálogo",
+        "modulo_no_permitido",
+        "modulo_no_canonico",
+        "backend_import_directo",
+    )
+    return any(m in mensaje for m in marcadores)
+
+
 class CliApplication:
     """Aplicación principal de CLI con inicialización idempotente por instancia.
 
@@ -810,6 +829,7 @@ class CliApplication:
             getattr(exc, "error_ya_mostrado", False)
         )
         mensaje = str(exc).strip() or _("Ha ocurrido un error inesperado.")
+        error_usuario_esperado = _is_expected_user_contract_error(exc)
 
         if not error_ya_mostrado:
             messages.mostrar_error(mensaje, registrar_log=False)
@@ -817,6 +837,13 @@ class CliApplication:
         if debug_activo:
             logging.exception("Error in execution")
             logging.getLogger(__name__).debug(format_traceback(exc, language))
+        elif error_usuario_esperado:
+            logging.getLogger(__name__).debug(
+                "Error de contrato de usuario (sin traceback en modo normal): %s",
+                format_traceback(exc, language),
+            )
+        else:
+            logging.exception("Error interno inesperado en ejecución de comando")
         return 1
 
     @staticmethod
@@ -1105,13 +1132,18 @@ class CliApplication:
 
                 return self.execute_command(args, debug_activo=debug_activo)
             except Exception as e:
+                mensaje_error = str(e).strip() or _("Ha ocurrido un error inesperado.")
+                error_usuario_esperado = _is_expected_user_contract_error(e)
                 if debug_activo:
                     logging.exception("Fatal error in application")
-                mensaje_error = str(e).strip() or _("Ha ocurrido un error inesperado.")
-                messages.mostrar_error(
-                    _("Fatal error: {}").format(mensaje_error),
-                    registrar_log=False,
-                )
+                elif error_usuario_esperado:
+                    logging.getLogger(__name__).debug(
+                        "Fatal error clasificado como usuario (sin traceback visible): %s",
+                        format_traceback(e, AppConfig.DEFAULT_LANGUAGE),
+                    )
+                else:
+                    logging.exception("Fatal error interno inesperado en aplicación")
+                messages.mostrar_error(mensaje_error, registrar_log=False)
                 return 1
 
 

--- a/tests/unit/test_cli_execution_error_output.py
+++ b/tests/unit/test_cli_execution_error_output.py
@@ -19,7 +19,7 @@ def test_handle_execution_error_normal_hides_traceback_and_keeps_logging_excepti
     assert result == 1
     assert mock_error.call_count == 1
     assert mock_error.call_args[0][0] == "boom"
-    mock_logging_error.assert_called_once_with("Error in execution: %s", "boom")
+    mock_logging_error.assert_called_once_with("Error interno inesperado en ejecución de comando", exc_info=True)
     mock_print.assert_not_called()
     mock_format_traceback.assert_not_called()
 
@@ -36,7 +36,7 @@ def test_handle_execution_error_no_duplica_salida_si_ya_fue_mostrada():
 
     assert result == 1
     mock_error.assert_not_called()
-    mock_logging_error.assert_called_once_with("Error in execution: %s", "boom")
+    mock_logging_error.assert_called_once_with("Error interno inesperado en ejecución de comando", exc_info=True)
     mock_print.assert_not_called()
 
 
@@ -83,7 +83,7 @@ def test_handle_execution_error_con_root_logger_configurado_no_duplica_salida():
 
     assert result == 1
     mock_error.assert_called_once_with("boom", registrar_log=False)
-    mock_logging_error.assert_called_once_with("Error in execution: %s", "boom")
+    mock_logging_error.assert_called_once_with("Error interno inesperado en ejecución de comando", exc_info=True)
     mock_print.assert_not_called()
 
 
@@ -226,3 +226,40 @@ def test_enforce_runtime_safety_policy_audita_rama_critica_sin_fallback():
         reason="non_interactive_override_without_fallback",
         audit_id="SEC-RUNTIME-001",
     )
+
+
+def test_handle_execution_error_usuario_esperado_no_muestra_traceback_en_modo_normal():
+    app = CliApplication()
+    exc = RuntimeError("usar_error[conflicto_simbolo]: detalle técnico")
+
+    with patch("cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
+        "cobra.cli.cli.logging.getLogger"
+    ) as mock_get_logger, patch(
+        "cobra.cli.cli.format_traceback", return_value="Traceback técnico"
+    ) as mock_tb:
+        result = app._handle_execution_error(exc, "es", debug_activo=False)
+
+    assert result == 1
+    mock_error.assert_called_once_with("usar_error[conflicto_simbolo]: detalle técnico", registrar_log=False)
+    mock_tb.assert_called_once_with(exc, "es")
+    assert not any("Traceback" in str(c.args[0]) for c in mock_error.call_args_list)
+    assert any("sin traceback en modo normal" in str(c.args[0]) for c in mock_get_logger.return_value.debug.call_args_list)
+
+
+def test_handle_execution_error_debug_si_muestra_traceback_en_logs():
+    app = CliApplication()
+    exc = RuntimeError("usar_error[modulo_fuera_catalogo_publico]: numpy")
+
+    with patch("cobra.cli.cli.messages.mostrar_error") as mock_error, patch(
+        "cobra.cli.cli.logging.exception"
+    ) as mock_exception, patch(
+        "cobra.cli.cli.logging.getLogger"
+    ) as mock_get_logger, patch(
+        "cobra.cli.cli.format_traceback", return_value="Traceback detallado"
+    ):
+        result = app._handle_execution_error(exc, "es", debug_activo=True)
+
+    assert result == 1
+    mock_error.assert_called_once()
+    mock_exception.assert_called_once()
+    mock_get_logger.return_value.debug.assert_called_once_with("Traceback detallado")


### PR DESCRIPTION
### Motivation
- Evitar que errores esperados de contrato (p. ej. `usar_error[...]`, conflictos de símbolos, sanitización inválida, módulo fuera de catálogo/canónico) muestren tracebacks al usuario en modo normal y, al mismo tiempo, preservar el detalle técnico para debugging.
- Unificar la política de visibilidad de tracebacks en el manejador global del CLI/REPL para mejorar la experiencia de usuario y mantener observabilidad.

### Description
- Se añadió la función `_is_expected_user_contract_error(exc: Exception) -> bool` en `src/pcobra/cobra/cli/cli.py` para clasificar errores de contrato esperados por coincidencia de marcadores en el mensaje.
- Se modificó `_handle_execution_error(...)` para: mostrar un mensaje breve al usuario vía `messages.mostrar_error` en modo normal, registrar detalle técnico en logger debug cuando el error es de usuario esperado, y reservar `logging.exception`/traceback visible solo para `--debug` o fallos internos inesperados.
- Se ajustó el bloque `except` de `CliApplication.run(...)` para aplicar la misma clasificación en errores fatales y evitar exponer tracebacks de errores de contrato en modo normal.
- Se actualizó `tests/unit/test_cli_execution_error_output.py` añadiendo casos que verifican que los errores de contrato no muestran `Traceback` en modo normal y que sí se registran en logs en modo debug; también se adaptaron expectativas para el logging de errores internos.

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_execution_error_output.py tests/cli/test_repl_error_recovery_contract.py -q` y ambos sets de pruebas pasaron exitosamente (todos los tests ejecutados: OK).
- Las pruebas agregadas/completadas cubren: ausencia de `Traceback` en salida de usuario para errores de contrato en modo normal y presencia de traceback en logs cuando `debug` está activo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006c6dba408327af56148c038a4c34)