### PR TITLE
Add runtime evaluation branch for NodoLista

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -39,6 +39,7 @@ from .ast_nodes import (
     NodoIdentificador,
     NodoValor,
     NodoImprimir,
+    NodoLista,
     NodoRetorno,
     NodoYield,
     NodoEsperar,
@@ -1393,6 +1394,20 @@ class InterpretadorCobra:
                 return _retorno_critico(valor_resuelto, operador="atributo")
             elif isinstance(expresion, NodoHolobit):
                 return self.ejecutar_holobit(expresion)
+            elif isinstance(expresion, NodoLista):
+                elementos = [
+                    self._asegurar_resultado_no_ast(
+                        self._materializar_valor(
+                            self.evaluar_expresion(elemento, visitados),
+                            visitados,
+                            origen="lista",
+                        ),
+                        nodo_origen=elemento,
+                        operador="lista:elemento",
+                    )
+                    for elemento in expresion.elementos
+                ]
+                return _retorno_critico(elementos, operador="lista")
             elif isinstance(expresion, NodoOperacionBinaria):
                 tipo = expresion.operador.tipo
                 self._trace_debug(

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -13,6 +13,7 @@ from core.ast_nodes import (
     NodoImprimir,
     NodoImport,
     NodoLlamadaFuncion,
+    NodoLista,
     NodoOperacionBinaria,
     NodoRetorno,
     NodoValor,
@@ -642,3 +643,51 @@ def test_mode_se_restaura_en_import_si_falla_ejecucion(monkeypatch):
 
     assert inter.mode == modo_inicial
     assert inter._validador.emitir_side_effects is True
+
+
+def test_lista_literal_en_asignacion_var():
+    inter = InterpretadorCobra()
+
+    inter.ejecutar_nodo(
+        NodoAsignacion(
+            "xs",
+            NodoLista([NodoValor(1), NodoValor(2), NodoValor(3)]),
+            declaracion=True,
+        )
+    )
+
+    assert inter.obtener_variable("xs") == [1, 2, 3]
+
+
+def test_longitud_recibe_lista_literal_como_argumento():
+    inter = InterpretadorCobra()
+
+    resultado = inter.ejecutar_llamada_funcion(
+        NodoLlamadaFuncion("longitud", [NodoLista([NodoValor(1), NodoValor(2), NodoValor(3)])])
+    )
+
+    assert resultado == 3
+
+
+def test_lista_literal_evalua_elementos_recursivos():
+    inter = InterpretadorCobra()
+    inter.ejecutar_nodo(NodoAsignacion("a", NodoValor(10), declaracion=True))
+
+    inter.ejecutar_nodo(
+        NodoAsignacion(
+            "xs",
+            NodoLista(
+                [
+                    NodoIdentificador("a"),
+                    NodoOperacionBinaria(
+                        NodoIdentificador("a"),
+                        Token(TipoToken.SUMA, "+"),
+                        NodoValor(1),
+                    ),
+                ]
+            ),
+            declaracion=True,
+        )
+    )
+
+    assert inter.obtener_variable("xs") == [10, 11]


### PR DESCRIPTION
### Motivation
- Soportar literales de lista en tiempo de ejecución para que expresiones como `var xs = [1, 2, 3]` y llamadas como `longitud([1,2,3])` funcionen sin cambios en el parser. 
- Garantizar que cada elemento de la lista se evalúe recursivamente y pase por las mismas comprobaciones de materialización y seguridad que otras subexpresiones.

### Description
- Importa `NodoLista` en `src/pcobra/core/interpreter.py` y añade una rama `elif isinstance(expresion, NodoLista):` dentro de `InterpretadorCobra.evaluar_expresion`.
- Cada elemento de `expresion.elementos` se evalúa recursivamente con `evaluar_expresion`, se materializa con `_materializar_valor` y se valida con `_asegurar_resultado_no_ast` antes de agregarse a la `list` de Python retornada.
- No se introducen cambios en el parser ni nueva sintaxis; esto añade únicamente soporte runtime para el nodo ya emitido por el parser.
- Añadidos/actualizados tests en `tests/unit/test_interpreter.py` que cubren: asignación de lista literal, pasar lista literal a `longitud(...)` y evaluación recursiva de elementos con identificadores y operaciones.

### Testing
- Ejecuté el commit con `git commit` para incluir cambios en `src/pcobra/core/interpreter.py` y `tests/unit/test_interpreter.py` (commit creado correctamente).
- Intenté ejecutar los tests localmente con `pytest -q tests/unit/test_interpreter.py -k "lista_literal_en_asignacion_var or longitud_recibe_lista_literal_como_argumento or lista_literal_evalua_elementos_recursivos"`, pero la colección falló con `ImportError: attempted relative import beyond top-level package` en este entorno de pruebas, por lo que las pruebas añadidas no pudieron completarse aquí.
- También intenté `PYTHONPATH=src pytest -q ...` y obtuve el mismo `ImportError`, indicando un problema de layout/entorno de importación que no está relacionado con la lógica de evaluación implementada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a007f85dcf883278fd7e2d149112d4b)