### PR TITLE
Restringe `existe` a símbolo canónico importado por `usar "archivo"`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2181,7 +2181,11 @@ class InterpretadorCobra:
                 simbolo=simbolo,
             )
             if self.safe_mode and self._validador is not None and hasattr(self._validador, "registrar_simbolo_publico_usar"):
-                self._validador.registrar_simbolo_publico_usar(nombre, modulo)
+                self._validador.registrar_simbolo_publico_usar(
+                    nombre,
+                    modulo,
+                    metadata=self._usar_symbol_metadata[nombre],
+                )
 
     def _construir_metadata_simbolo_usar(
         self,
@@ -2201,6 +2205,8 @@ class InterpretadorCobra:
                 firma_estable = f"{firma_estable}:{getattr(code, 'co_argcount', 'na')}:{getattr(code, 'co_kwonlyargcount', 'na')}"
         return {
             "module": modulo,
+            "canonical_module": modulo,
+            "python_module": modulo_objeto,
             "exported_name": nombre_exportado,
             "callable_id": id(simbolo),
             "stable_signature": firma_estable,

--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -32,9 +32,17 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
     def __init__(self):
         super().__init__()
         self._simbolos_publicos_usar: set[tuple[str, str]] = set()
+        self._metadata_simbolos_usar: dict[str, dict[str, object]] = {}
 
-    def registrar_simbolo_publico_usar(self, nombre: str, modulo: str) -> None:
+    def registrar_simbolo_publico_usar(
+        self,
+        nombre: str,
+        modulo: str,
+        metadata: dict[str, object] | None = None,
+    ) -> None:
         self._simbolos_publicos_usar.add((modulo, nombre))
+        if metadata:
+            self._metadata_simbolos_usar[nombre] = dict(metadata)
 
     @staticmethod
     def _ruta_permitida_en_wrapper(argumentos) -> bool:
@@ -57,6 +65,14 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
         if nodo.nombre != "existe":
             return False
         if ("archivo", nodo.nombre) not in self._simbolos_publicos_usar:
+            return False
+        metadata = self._metadata_simbolos_usar.get(nodo.nombre, {})
+        origen_modulo = metadata.get("module")
+        origen_canonico = metadata.get("canonical_module")
+        origen_backend = metadata.get("python_module")
+        if origen_modulo != "archivo" or origen_canonico != "archivo":
+            return False
+        if origen_backend != "pcobra.standard_library.archivo":
             return False
         return self._ruta_permitida_en_wrapper(nodo.argumentos)
 

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -44,6 +44,14 @@ def test_codigo_seguro_se_ejecuta_en_modo_seguro():
     assert out.getvalue().strip() == "hola"
 
 
+def test_existe_no_se_habilita_solo_por_nombre_sin_usar_archivo():
+    interp = InterpretadorCobra()
+    ast = generar_ast('func existe(ruta) { retorno verdadero }\nimprimir(existe("README.md"))')
+
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast)
+
+
 def test_existe_publico_desde_usar_acepta_ruta_relativa():
     interp = InterpretadorCobra()
     ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')


### PR DESCRIPTION
### Motivation

- Evitar que la primitiva `existe` sea permitida por mera coincidencia nominal y asegurar que solo el wrapper público canónico exponga esa operación segura.
- Mantener la política de rutas seguras (sin absolutas ni path traversal) y no exponer primitivas backend crudas mediante el mecanismo `usar`.

### Description

- Añadí metadata mínima de origen al binding de `usar` (`canonical_module` y `python_module`) en `_construir_metadata_simbolo_usar` y se almacena en `_usar_symbol_metadata`.
- Propagué esa metadata al validador llamando a `registrar_simbolo_publico_usar(nombre, modulo, metadata=...)` durante la inyección de símbolos por `usar`.
- Extendí `ValidadorPrimitivaPeligrosa` para conservar `_metadata_simbolos_usar` y exigir que `existe` solo se considere permitido si la metadata indica origen `archivo` y backend `pcobra.standard_library.archivo`, además de pasar la comprobación de rutas vía `_ruta_permitida_en_wrapper`.
- Añadí un test que verifica que una función local `existe` no habilita la primitiva por nombre (`test_existe_no_se_habilita_solo_por_nombre_sin_usar_archivo`).

### Testing

- Ejecuté `pytest -q tests/unit/test_safe_mode.py` para validar cambios sobre el comportamiento de `existe`, pero la ejecución falló en la fase de colección con `ImportError: attempted relative import beyond top-level package` debido al entorno de import durante la prueba; la falla es de colección y no de las aserciones del cambio.
- Los tests relacionados existentes sobre `usar "archivo"` + `existe("README.md")` y casos inseguros de rutas siguen presentes y apuntan a cubrir la política de rutas (no se modificaron sus condiciones en esta PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ad5ab8388327975151e330e5bebc)