### PR TITLE
Compactar logging de conflictos en `usar` y agregar checklist pre-merge

### DIFF
--- a/docs/compatibility/pr_checklist_pre_merge_usar_2026-05-10.md
+++ b/docs/compatibility/pr_checklist_pre_merge_usar_2026-05-10.md
@@ -1,0 +1,23 @@
+# PR Checklist pre-merge: `usar` (2026-05-10)
+
+## Alcance revisado
+- Rango inspeccionado: `a665cd3..HEAD`.
+- Archivos modificados en el rango:
+  - `src/pcobra/core/interpreter.py`
+  - `tests/unit/test_usar.py`
+
+## Criterios de aceptación
+- [x] **Sin cambios en lexer/parser críticos**.
+  - Verificado que **no** aparecen en el diff:
+    - `src/pcobra/core/lexer.py`
+    - `src/pcobra/core/parser.py`
+    - `src/pcobra/cobra/core/lexer.py`
+    - `src/pcobra/cobra/core/parser.py`
+- [x] **No se introdujo sintaxis nueva**.
+  - El cambio funcional en código agrega solo un helper de logging (`_resumen_conflictos_usar`) y ajuste de mensajes `warning`; no hay edición de gramática, parser ni lexer.
+- [x] **No se relajó la sanitización global de `usar`**.
+  - Se mantiene el flujo de detección de conflictos de saneamiento; únicamente se compacta la salida de log a `count=<n>` en modo normal.
+- [x] **No se permitió import externo directo ni bypass de sandbox**.
+  - No hay cambios en rutas permitidas/import policy ni en validaciones de sandbox dentro del rango inspeccionado.
+- [x] **Checklist documentado**.
+  - Este documento deja trazabilidad explícita de la revisión pre-merge solicitada.


### PR DESCRIPTION
### Motivation
- Reducir la verbosidad de los logs de conflictos en el flujo `usar` manteniendo la lógica de saneamiento y trazabilidad compacta. 
- Documentar y dejar evidencia pre-merge de las verificaciones de seguridad solicitadas para evitar regresiones en lexer/parser, sintaxis y políticas de import.

### Description
- Se añadió el helper `_resumen_conflictos_usar` en `src/pcobra/core/interpreter.py` para producir un resumen compacto `count=<n>` de conflictos. 
- Se modificaron las llamadas a `logging.warning` relacionadas con `USAR` para usar el resumen compacto y añadir el `count` en eventos de colisión por símbolo en `src/pcobra/core/interpreter.py`.
- Se añadió el test `test_usar_warning_conflictos_saneamiento_formato_compacto` en `tests/unit/test_usar.py` que verifica el formato compacto del warning. 
- Se agregó el documento `docs/compatibility/pr_checklist_pre_merge_usar_2026-05-10.md` que registra la revisión pre-merge y confirma que no se tocaron los archivos críticos de lexer/parser, no se introdujo sintaxis nueva, no se relajó la sanitización global de `usar` y no se habilitó bypass de sandbox o import externo directo.

### Testing
- Intenté ejecutar `pytest -q tests/unit/test_usar.py -k compacto`, pero la ejecución falló durante la colección con `ImportError: attempted relative import beyond top-level package` y por tanto el test no pudo completarse.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00c575b9a48327a3372563af5cc24f)