### PR TITLE
Permitir `existe` solo vía wrapper público `archivo`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2221,6 +2221,8 @@ class InterpretadorCobra:
             "canonical_module": modulo,
             "python_module": modulo_objeto,
             "exported_name": nombre_exportado,
+            "is_public_export": True,
+            "is_sanitized_wrapper": True,
             "callable_id": id(simbolo),
             "stable_signature": firma_estable,
         }

--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -70,9 +70,13 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
         origen_modulo = metadata.get("module")
         origen_canonico = metadata.get("canonical_module")
         origen_backend = metadata.get("python_module")
+        es_publico = metadata.get("is_public_export") is True
+        es_wrapper_sanitizado = metadata.get("is_sanitized_wrapper") is True
         if origen_modulo != "archivo" or origen_canonico != "archivo":
             return False
         if origen_backend != "pcobra.standard_library.archivo":
+            return False
+        if not es_publico or not es_wrapper_sanitizado:
             return False
         return self._ruta_permitida_en_wrapper(nodo.argumentos)
 


### PR DESCRIPTION
### Motivation
- Evitar que la primitiva peligrosa `existe` sea llamada directamente al backend y solo permitirla cuando provenga del wrapper público canónico `archivo` inyectado por `usar` con metadata segura.
- Añadir metadata mínima en el registro de símbolos de `usar` para distinguir exports públicos/saneados del backend directo sin cambiar la política global de sanitización ni permitir imports externos.

### Description
- Actualiza el validador `ValidadorPrimitivaPeligrosa` para que la excepción sobre `existe` permita la llamada únicamente si el símbolo fue importado desde el módulo canónico `archivo`, su backend es `pcobra.standard_library.archivo` y la metadata indica `is_public_export=True` y `is_sanitized_wrapper=True` (archivo: `src/pcobra/core/semantic_validators/primitiva_peligrosa.py`).
- Añade las claves `is_public_export` e `is_sanitized_wrapper` en `_construir_metadata_simbolo_usar` para registrar esa metadata mínima cuando `usar` inyecta símbolos en el contexto (archivo: `src/pcobra/core/interpreter.py`).
- No se modificó la sanitización global de `usar`, ni se relajan las restricciones de import; la comprobación de rutas seguras para `archivo.existe` sigue delegada al wrapper público y a `corelibs/archivo` (prohibición de rutas absolutas, `..`, y salida del directorio permitido).

### Testing
- Se compiló el código modificado con `python -m py_compile src/pcobra/core/interpreter.py src/pcobra/core/semantic_validators/primitiva_peligrosa.py` y la compilación fue exitosa.
- Se verificó manualmente en lectura de código que las validaciones de rutas en `src/pcobra/standard_library/archivo.py` y `src/pcobra/corelibs/archivo.py` mantienen la protección contra rutas absolutas, `..` y salida del directorio base.»

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ce810cc08327919fa69d518f3c47)