### PR TITLE
Añade tests de REPL para listas y llamadas `longitud` con argumentos inline

### DIFF
--- a/tests/integration/test_repl_entrypoint_numero_callable_output.py
+++ b/tests/integration/test_repl_entrypoint_numero_callable_output.py
@@ -168,3 +168,33 @@ def test_entrypoint_repl_texto_flujo_integral_callable_output(capsys):
     assert "Cobra" in salida
     assert "jajaja" in salida
     assert "cancion" in salida
+
+
+def test_entrypoint_repl_asignacion_lista_no_reporta_nodolista(capsys):
+    cmd = ReplCommandV2()
+    cmd._ejecutar_en_modo_normal("var xs = [1, 2, 3]")
+    cmd._ejecutar_en_modo_normal("imprimir(xs)")
+
+    salida = capsys.readouterr().out
+    assert "[1, 2, 3]" in salida
+    assert "Expresión no soportada: tipo=NodoLista" not in salida
+
+
+def test_entrypoint_repl_usar_datos_longitud_argumento_inline(capsys):
+    cmd = ReplCommandV2()
+    cmd._ejecutar_en_modo_normal('usar "datos"')
+    cmd._ejecutar_en_modo_normal("imprimir(longitud([1, 2, 3]))")
+
+    salida = [linea.strip() for linea in capsys.readouterr().out.splitlines() if linea.strip()]
+    assert "3" in salida
+
+
+def test_entrypoint_repl_lista_con_expresiones_y_longitud(capsys):
+    cmd = ReplCommandV2()
+    cmd._ejecutar_en_modo_normal('usar "datos"')
+    cmd._ejecutar_en_modo_normal("var a = 10")
+    cmd._ejecutar_en_modo_normal("var xs = [a, a + 1]")
+    cmd._ejecutar_en_modo_normal("imprimir(longitud(xs))")
+
+    salida = [linea.strip() for linea in capsys.readouterr().out.splitlines() if linea.strip()]
+    assert "2" in salida


### PR DESCRIPTION
### Motivation
- Añadir tests de regresión para cubrir casos REPL donde listas y llamadas a `longitud` con argumentos inline o expresiones previamente fallaban o producían el mensaje `Expresión no soportada: tipo=NodoLista`.

### Description
- Se añadieron tres tests en `tests/integration/test_repl_entrypoint_numero_callable_output.py`: `test_entrypoint_repl_asignacion_lista_no_reporta_nodolista`, `test_entrypoint_repl_usar_datos_longitud_argumento_inline` y `test_entrypoint_repl_lista_con_expresiones_y_longitud`.
- Los tests ejercitan la asignación e impresión de listas, el uso de `usar "datos"` con `imprimir(longitud([1, 2, 3]))` y listas que contienen expresiones (`a`, `a + 1`), respetando el contrato de formato de salida del REPL.

### Testing
- Ejecutado `pytest -q tests/integration/test_repl_entrypoint_numero_callable_output.py -k "asignacion_lista or argumento_inline or lista_con_expresiones"` y las tres pruebas pasaron (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0158b983d883278204ea6b5692caec)