### PR TITLE
test: ampliar cobertura de seguridad para `existe` en modo seguro

### DIFF
--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -78,6 +78,14 @@ def test_existe_publico_desde_usar_bloquea_rutas_fuera_de_politica(codigo):
         interp.ejecutar_ast(ast)
 
 
+
+def test_existe_publico_no_habilita_simbolos_backend_crudos_no_publicos():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"\nimprimir(leer_archivo("README.md"))')
+
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast)
+
 def test_cli_default_mantiene_modo_seguro_y_fallback_inseguro_deshabilitado():
     app = CliApplication()
     app.initialize()


### PR DESCRIPTION
### Motivation
- Asegurar que `usar "archivo"` no exponga primitivas peligrosas internas y que la API pública `existe` siga comportándose según la política de seguridad.

### Description
- Añadido test `test_existe_publico_no_habilita_simbolos_backend_crudos_no_publicos` en `tests/unit/test_safe_mode.py` que ejecuta `usar "archivo"\nimprimir(leer_archivo("README.md"))` y espera `PrimitivaPeligrosaError`.
- El cambio refuerza la cobertura sobre la frontera entre símbolos públicos permitidos y símbolos backend crudos/no públicos.
- Commit realizado: `test: ampliar cobertura de existe en modo seguro`.

### Testing
- Ejecuté `pytest -q tests/unit/test_safe_mode.py` y la colección falló por un `ImportError: attempted relative import beyond top-level package` originado en la resolución de imports del entorno, por lo que el test no llegó a ejecutarse.
- El archivo de test fue agregado y el commit fue exitoso (`git commit` tuvo éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a016c86aa488327b537ac215bfaab47)