### PR TITLE
test: ampliar regresión de `usar` para numero/texto/logica/tiempo/datos

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -342,6 +342,59 @@ def test_repl_usar_colision_en_ancestro_no_inyecta_exportables(monkeypatch):
 
 
 
+
+
+def test_repl_usar_numero_regresion_es_finito_y_signo(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_numero)
+    interp = _ejecutar_codigo('usar "numero"\nes_finito(10)\nsigno(0-5)')
+
+    assert interp.obtener_variable("es_finito")(10) is True
+    assert interp.obtener_variable("signo")(-5) == -1
+
+
+def test_repl_usar_texto_regresion_mayusculas_recortar_repetir_quitar_acentos(monkeypatch):
+    import pcobra.corelibs.texto as modulo_texto
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_texto)
+    interp = _ejecutar_codigo('usar "texto"\nmayusculas("cobra")\nrecortar("  cobra  ")\nrepetir("co", 2)\nquitar_acentos("canción")')
+
+    assert interp.obtener_variable("mayusculas")("cobra") == "COBRA"
+    assert interp.obtener_variable("recortar")("  cobra  ") == "cobra"
+    assert interp.obtener_variable("repetir")("co", 2) == "coco"
+    assert interp.obtener_variable("quitar_acentos")("canción") == "cancion"
+
+
+def test_repl_usar_logica_regresion_conjuncion_y_negacion(monkeypatch):
+    import pcobra.corelibs.logica as modulo_logica
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_logica)
+    interp = _ejecutar_codigo('usar "logica"\nconjuncion(verdadero, falso)\nnegacion(falso)')
+
+    assert interp.obtener_variable("conjuncion")(True, False) is False
+    assert interp.obtener_variable("negacion")(False) is True
+
+
+def test_repl_usar_tiempo_regresion_epoch_valida_tipo_y_rango(monkeypatch):
+    import pcobra.corelibs.tiempo as modulo_tiempo
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_tiempo)
+    interp = _ejecutar_codigo('usar "tiempo"\nepoch()')
+
+    valor_epoch = interp.obtener_variable("epoch")()
+    assert isinstance(valor_epoch, (int, float))
+    assert 0 <= valor_epoch < 4102444800
+
+
+def test_repl_usar_datos_regresion_longitud_cobra(monkeypatch):
+    import pcobra.corelibs.datos as modulo_datos
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_datos)
+    interp = _ejecutar_codigo('usar "datos"\nlongitud("cobra")')
+
+    assert interp.obtener_variable("longitud")("cobra") == 5
+
 def test_repl_usar_texto_colision_en_ancestro_es_atomico(monkeypatch):
     import pcobra.corelibs.texto as modulo_texto
 


### PR DESCRIPTION
### Motivation
- Aumentar la cobertura anti-regresión de la instrucción `usar` para validar que símbolos inyectados desde módulos canónicos se inyectan y ejecutan correctamente en runtime. 
- Detectar regresiones en el binding/ejecución de callables aportados por `usar` (p.ej. funciones que deberían ejecutarse como callables Python en el intérprete). 

### Description
- Se agregaron 5 tests en `tests/unit/test_usar.py` que ejercitan `usar "..."` y validan resultados por valor para las APIs solicitadas (`numero`, `texto`, `logica`, `tiempo`, `datos`).
- Casos añadidos: `test_repl_usar_numero_regresion_es_finito_y_signo`, `test_repl_usar_texto_regresion_mayusculas_recortar_repetir_quitar_acentos`, `test_repl_usar_logica_regresion_conjuncion_y_negacion`, `test_repl_usar_tiempo_regresion_epoch_valida_tipo_y_rango`, y `test_repl_usar_datos_regresion_longitud_cobra`.
- Las aserciones son por valor esperado en todos los casos salvo `epoch`, donde se valida `isinstance(..., (int, float))` y un rango razonable de Unix epoch (`0 <= epoch < 4102444800`).
- No se modificó código de runtime, loader ni del intérprete; los cambios son únicamente de pruebas y por tanto no alteran el contrato público de binding runtime de `usar`.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar.py -k 'regresion_es_finito_y_signo or regresion_mayusculas_recortar_repetir_quitar_acentos or regresion_conjuncion_y_negacion or regresion_epoch_valida_tipo_y_rango or regresion_longitud_cobra'`, que falló durante la colección con `ImportError: attempted relative import beyond top-level package`.
- Reintenté con `PYTHONPATH=src pytest -q tests/unit/test_usar.py -k 'regresion_es_finito_y_signo or regresion_mayusculas_recortar_repetir_quitar_acentos or regresion_conjuncion_y_negacion or regresion_epoch_valida_tipo_y_rango or regresion_longitud_cobra'`, y la colección volvió a fallar por la misma razón de import path.
- Resultado: los nuevos tests están añadidos y listos, pero no pudieron ejecutarse en este entorno por una configuración de import path/colección; la ejecución en CI o en un entorno con `PYTHONPATH`/paquete correcto debería correrlos normalmente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0174df4df48327a8b5238572cc38c0)