### PR TITLE
test: reforzar UX de errores `usar` y warnings de sanitización

### DIFF
--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -680,3 +680,18 @@ def test_no_regresion_seguridad_usar_numpy_fuera_catalogo_publico():
     cmd = ReplCommandV2()
     with pytest.raises(PermissionError, match=r'(modulo_fuera_catalogo_publico|módulo fuera del catálogo público)'):
         cmd._ejecutar_en_modo_normal('usar "numpy"')
+
+
+def test_repl_usar_numpy_error_explicito_corto_sin_traceback_en_modo_normal(capsys):
+    cmd = ReplCommandV2()
+    with pytest.raises(PermissionError) as excinfo:
+        cmd._ejecutar_en_modo_normal('usar "numpy"')
+
+    mensaje = str(excinfo.value)
+    assert "Traceback" not in mensaje
+    assert "detalle=" not in mensaje
+    assert len(mensaje) < 220
+
+    salida = capsys.readouterr().out
+    assert "Traceback" not in salida
+

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -1144,3 +1144,35 @@ def test_usar_warning_conflictos_saneamiento_formato_compacto(monkeypatch, caplo
     assert "count=2" in warning
     assert "conflicts=[" not in warning
     assert "{'symbol'" not in warning
+
+
+def test_usar_warning_conflictos_saneamiento_detalle_solo_debug(monkeypatch, caplog):
+    modulo = ModuleType("texto")
+    modulo.__all__ = ["A_snake", "a_snake"]
+    modulo.A_snake = lambda texto: texto
+    modulo.a_snake = lambda texto: texto
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/texto.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
+    monkeypatch.setenv("PCOBRA_DEBUG_RUNTIME", "1")
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"texto": "texto"})
+
+    with pytest.raises(ImportError):
+        interp.ejecutar_nodo(NodoUsar("texto"))
+
+    warnings_saneamiento = [
+        rec.message for rec in caplog.records if "USAR sanitize conflicts event module=texto" in rec.message
+    ]
+    assert warnings_saneamiento
+    warning = warnings_saneamiento[-1]
+    assert "count=2" in warning
+    assert "conflicts=[" not in warning
+
+    trazas_debug = [
+        rec.message for rec in caplog.records if "[USAR_SANITIZE][CONFLICTS]" in rec.message
+    ]
+    assert trazas_debug
+    assert "'conflicts':" in trazas_debug[-1]
+


### PR DESCRIPTION
### Motivation
- Evitar que `usar "numpy"` exponga tracebacks o detalles técnicos en modo REPL normal y mantener mensajes cortos y seguros para el usuario.
- Evitar volcados de diccionarios enormes en la salida normal al emitir warnings de sanitización y permitir un formato resumido para la UX.
- Asegurar que la información completa de conflictos permanezca disponible solo en trazas de debug/verbose internas cuando `PCOBRA_DEBUG_RUNTIME` esté activado.

### Description
- Añade un test explícito en `tests/integration/test_repl_usar_entrypoints_contract.py` que verifica que `usar "numpy"` genera un `PermissionError` con mensaje corto sin `detalle=` y sin `Traceback` en la salida estándar.
- Añade tests en `tests/unit/test_usar.py` que comprueban que el warning de sanitización visible es compacto (`USAR sanitize conflicts event module=... count=...`) y no contiene `conflicts=[` ni diccionarios impresos, y que el detalle completo aparece en trazas debug cuando `PCOBRA_DEBUG_RUNTIME=1`.
- Las pruebas ejercitan tanto la salida del REPL en modo normal como la emisión de trazas internas para validar la separación normal/debug.

### Testing
- Ejecutado `PYTHONPATH=src pytest -q tests/integration/test_repl_usar_entrypoints_contract.py -k "numpy_error_explicito or no_regresion_seguridad_usar_numpy_error_corto"` y las pruebas relevantes pasaron (`2 passed, 50 deselected`).
- Ejecutado `PYTHONPATH=src pytest -q tests/unit/test_usar.py -k "warning_conflictos_saneamiento or no_muestra_traceback_ni_detalle or muestra_detalle_extendido"` y la colección falló por un `ImportError` durante la importación del módulo de tests (`attempted relative import beyond top-level package`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a017ec03aec83279efa288e6ed37027)