### PR TITLE
docs: agregar reporte de validación de pruebas solicitadas

### DIFF
--- a/reports/qa_validacion_2026-05-11.md
+++ b/reports/qa_validacion_2026-05-11.md
@@ -1,0 +1,27 @@
+# Validación solicitada (2026-05-11)
+
+## Alcance
+- Coberturas objetivo: `NodoLista`, `archivo.existe`, seguridad/sandbox y regresiones de módulos.
+- Regresión de intérprete/REPL relevante.
+
+## Comandos ejecutados
+1. `pytest -q tests/unit/test_corelibs.py -k "archivo_existe or sandbox"`
+2. `pytest -q tests/unit/test_transpiler_feature_parity.py -k "NodoLista"`
+3. `pytest -q tests/unit/test_cli_entrypoint_imports.py tests/unit/test_interpreter_identifier_comparisons.py -k "regresion or regresión"`
+4. `pytest -q tests/unit/test_cli_interactive_cmd.py -k "sandbox or repl"`
+5. `PYTHONPATH=src pytest -q tests/test_cli_entrypoint_imports.py tests/unit/test_interpreter_identifier_comparisons.py -k "regresion or regresión"`
+6. `PYTHONPATH=src pytest -q tests/unit/test_cli_interactive_cmd.py -k "repl or sandbox"`
+7. `PYTHONPATH=src pytest -q tests/unit/test_transpiler_feature_parity.py -k "NodoLista"`
+8. `PYTHONPATH=src pytest -q tests/unit/test_corelibs.py -k "archivo_existe_rechaza_fuera_del_sandbox"`
+
+## Resultado resumido
+- Los comandos de cobertura/regresión quedaron bloqueados por **errores de colección** del entorno/proyecto actual:
+  - `ImportError: attempted relative import beyond top-level package` en tests que importan `core.interpreter`.
+  - `ImportError` por importación circular parcial entre `pcobra.corelibs` y `pcobra.standard_library.asincrono`.
+  - Ruta inexistente usada en un intento inicial: `tests/unit/test_cli_entrypoint_imports.py` (el archivo real está en `tests/test_cli_entrypoint_imports.py`).
+
+## Verificaciones adicionales solicitadas
+- No se introdujo sintaxis nueva (no se modificó código fuente del runtime/parser/lexer).
+- No se relajó globalmente la sandbox.
+- No se añadieron imports externos directos.
+


### PR DESCRIPTION
### Motivation
- Registrar en el repositorio la ejecución y resultados de las pruebas solicitadas (coberturas `NodoLista`, `archivo.existe`, seguridad/sandbox y regresiones de módulos / REPL) para dejar evidencia reproducible del estado actual del proyecto.

### Description
- Se agrega el archivo `reports/qa_validacion_2026-05-11.md` que contiene la lista de comandos ejecutados y un resumen de los errores de colección observados; no se modificó ningún código fuente del intérprete, lexer o parser y el único cambio en el diff es la adición de ese archivo.

### Testing
- Ejecutados (comandos y resultado resumido): `pytest -q tests/unit/test_corelibs.py -k "archivo_existe or sandbox"` (ERROR: fallo en collection por importación circular `pcobra.corelibs` ↔ `pcobra.standard_library.asincrono`).
- `pytest -q tests/unit/test_transpiler_feature_parity.py -k "NodoLista"` (EXITOSO: comando completó pero no hubo tests seleccionados / deselects).
- `pytest -q tests/unit/test_cli_entrypoint_imports.py tests/unit/test_interpreter_identifier_comparisons.py -k "regresion or regresión"` (ERROR o ruta inicial mal resuelta; reintentos con `PYTHONPATH=src` también fallaron por `attempted relative import beyond top-level package`).
- `PYTHONPATH=src pytest -q tests/unit/test_cli_interactive_cmd.py -k "repl or sandbox"` (ERROR: fallo de colección por import relativo más allá del top-level en `core.interpreter`).
- Verificaciones pedidas: confirmo que NO hubo cambios en `src/pcobra/core/lexer.py`, `src/pcobra/core/parser.py`, `src/pcobra/cobra/core/lexer.py` ni `src/pcobra/cobra/core/parser.py`; además no se introdujo sintaxis nueva, no se relajó la sandbox global y no se añadieron imports externos directos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0186ee404c832792da750c0585d350)