### PR TITLE
Add REPL integration tests for list literal evaluation

### DIFF
--- a/tests/integration/test_repl_list_literal_eval_contract.py
+++ b/tests/integration/test_repl_list_literal_eval_contract.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+from pcobra.cobra.cli.commands_v2.repl_cmd import ReplCommandV2
+from pcobra.cobra.core.runtime import InterpretadorCobra
+
+
+def _estado(factory, executor, getter, codigo: str):
+    cmd = factory()
+    executor(cmd, codigo)
+    return getter(cmd)
+
+
+def test_repl_interpreter_evalua_lista_literal_en_asignacion_var():
+    interp = _estado(
+        lambda: InteractiveCommand(InterpretadorCobra()),
+        lambda cmd, code: cmd.ejecutar_codigo(code),
+        lambda cmd: cmd.interpretador,
+        "var xs = [1, 2, 3]",
+    )
+    assert interp.obtener_variable("xs") == [1, 2, 3]
+
+
+def test_repl_interpreter_evalua_lista_con_expresiones_internas():
+    interp = _estado(
+        lambda: InteractiveCommand(InterpretadorCobra()),
+        lambda cmd, code: cmd.ejecutar_codigo(code),
+        lambda cmd: cmd.interpretador,
+        "var a = 10\nvar xs = [a, a + 1]",
+    )
+    assert interp.obtener_variable("xs") == [10, 11]
+
+
+def test_repl_v2_delega_mismo_tratamiento_de_lista_literal():
+    interp = _estado(
+        ReplCommandV2,
+        lambda cmd, code: cmd._ejecutar_en_modo_normal(code),
+        lambda cmd: cmd._delegate.interpretador,
+        "var a = 5\nvar xs = [a, a + 1]",
+    )
+    assert interp.obtener_variable("xs") == [5, 6]


### PR DESCRIPTION
### Motivation
- Asegurar que la evaluación de `NodoLista` se comporte igual en los flujos REPL/CLI que en el intérprete central y añadir cobertura de integración sin tocar lexer/parser.

### Description
- Añadí `tests/integration/test_repl_list_literal_eval_contract.py` con tres pruebas que ejercitan la evaluación de literales de lista en asignación, listas con expresiones internas y la ruta REPL v2 que delega al mismo intérprete; no se modificó la lógica del intérprete (la implementación de `NodoLista` ya existe en `src/pcobra/core/interpreter.py`).

### Testing
- Ejecuté `pytest -q tests/integration/test_repl_list_literal_eval_contract.py` que pasó (3 tests aprobados, 1 warning); una ejecución combinada con `tests/unit/test_interpreter.py` falló en la fase de colección por un `ImportError` del entorno de pruebas pero ese error es de importación/entorno y no afecta la semántica de evaluación de listas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a018af462a483279d66e3f3e11e1422)