### PR TITLE
Harden safe-mode `usar "archivo"` wrapper validation for `existe`

### DIFF
--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -1,4 +1,5 @@
 from pathlib import PurePosixPath
+import re
 
 from .base import ValidadorBase
 from ..ast_nodes import NodoLlamadaFuncion, NodoHilo, NodoLlamadaMetodo, NodoValor
@@ -12,6 +13,11 @@ class PrimitivaPeligrosaError(Exception):
 
 class ValidadorPrimitivaPeligrosa(ValidadorBase):
     """Validador que detecta llamadas a primitivas peligrosas."""
+
+    WRAPPERS_PYTHON_MODULES_PERMITIDOS = frozenset({
+        "pcobra.standard_library.archivo",
+        "cobra.standard_library.archivo",
+    })
 
     PRIMITIVAS_PELIGROSAS = {
         "leer_archivo",
@@ -54,6 +60,10 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
         ruta = primer_arg.valor.strip()
         if not ruta:
             return False
+        if re.match(r"^[a-zA-Z]:[\\/]", ruta):
+            return False
+        if ruta.startswith("\\"):
+            return False
         path = PurePosixPath(ruta)
         if path.is_absolute():
             return False
@@ -74,7 +84,7 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
         es_wrapper_sanitizado = metadata.get("is_sanitized_wrapper") is True
         if origen_modulo != "archivo" or origen_canonico != "archivo":
             return False
-        if origen_backend != "pcobra.standard_library.archivo":
+        if origen_backend not in self.WRAPPERS_PYTHON_MODULES_PERMITIDOS:
             return False
         if not es_publico or not es_wrapper_sanitizado:
             return False

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -63,11 +63,35 @@ def test_existe_publico_desde_usar_acepta_ruta_relativa():
     assert "verdadero" in salida or "falso" in salida
 
 
+def test_metadata_usar_archivo_existe_cadena_completa():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')
+
+    with patch("sys.stdout", new_callable=StringIO):
+        interp.ejecutar_ast(ast)
+
+    metadata = interp._usar_symbol_metadata["existe"]
+    assert metadata["module"] == "archivo"
+    assert metadata["canonical_module"] == "archivo"
+    assert metadata["is_public_export"] is True
+    assert metadata["is_sanitized_wrapper"] is True
+    assert metadata["python_module"] in {
+        "pcobra.standard_library.archivo",
+        "cobra.standard_library.archivo",
+    }
+
+    metadata_validador = interp._validador._metadata_simbolos_usar["existe"]
+    assert metadata_validador["module"] == "archivo"
+    assert metadata_validador["canonical_module"] == "archivo"
+
+
 @pytest.mark.parametrize(
     "codigo",
     [
         'usar "archivo"\nimprimir(existe("/etc/passwd"))',
         'usar "archivo"\nimprimir(existe("../secreto.txt"))',
+        'usar "archivo"\nimprimir(existe("C:/Windows/System32/drivers/etc/hosts"))',
+        'usar "archivo"\nimprimir(existe("\\\\servidor\\compartido\\secreto.txt"))',
     ],
 )
 def test_existe_publico_desde_usar_bloquea_rutas_fuera_de_politica(codigo):
@@ -107,4 +131,3 @@ def test_existe_publico_desde_usar_bloquea_traversal_normalizado(codigo):
 
     with pytest.raises(PrimitivaPeligrosaError):
         interp.ejecutar_ast(ast)
-


### PR DESCRIPTION
### Motivation
- Evitar falsos positivos/negativos al autorizar la primitiva `existe` desde `usar "archivo"` comprobando exhaustivamente la metadata registrada. 
- Impedir permitir wrappers backend crudos por error comparando `python_module` de forma explícita y segura. 
- Cerrar vectores de escape de ruta aceptando sólo rutas relativas limpias y rechazando rutas absolutas Windows/UNC. 

### Description
- Añadido un conjunto cerrado `WRAPPERS_PYTHON_MODULES_PERMITIDOS` y cambio de la comparación de `python_module` en `ValidadorPrimitivaPeligrosa` para permitir sólo wrappers canónicos (`pcobra.standard_library.archivo` y alias `cobra.standard_library.archivo`).
- Endurecida la función `_ruta_permitida_en_wrapper` para bloquear rutas absolutas estilo Windows (`C:/...` / `D:\...`) y rutas UNC (`\\servidor\...`) además de las verificaciones POSIX existentes (absolutas, `..`).
- Añadida la prueba `test_metadata_usar_archivo_existe_cadena_completa` que valida que la metadata construida por el intérprete para `usar "archivo"` contiene `module`, `canonical_module`, `is_public_export`, `is_sanitized_wrapper` y un `python_module` permitido, y que esa metadata es disponible para el validador.
- Extendidas las pruebas parametrizadas de rutas inseguras en `tests/unit/test_safe_mode.py` para incluir variantes Windows y UNC y mantener la verificación de bloqueo de primitivas backend crudas (`leer_archivo`).

### Testing
- Ejecuté `pytest -q tests/unit/test_safe_mode.py` en el entorno y la colección falló por `ImportError: attempted relative import beyond top-level package`, lo que impidió ejecutar las pruebas (error de descubrimiento/entorno, no de la lógica aplicada).
- También probé con `PYTHONPATH=src` y `PYTHONPATH=src/pcobra` y obtuve el mismo error de importación en la fase de colección, por lo que no hay resultados verdes/rojos de tests unitarios en este PR aún.
- Los cambios unitarios (nuevas aserciones y ampliaciones) fueron añadidos a `tests/unit/test_safe_mode.py` y el validador modificado en `src/pcobra/core/semantic_validators/primitiva_peligrosa.py` para su futura validación en un entorno de test con imports configurados correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0193b2b0c8832788c2b79872f65b9a)