### PR TITLE
Evaluación robusta de literales `NodoLista` en `InterpretadorCobra`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1401,7 +1401,8 @@ class InterpretadorCobra:
                 return self.ejecutar_holobit(expresion)
             elif isinstance(expresion, NodoLista):
                 elementos = []
-                for elemento in expresion.elementos:
+                nodos_elementos = list(getattr(expresion, "elementos", []) or [])
+                for elemento in nodos_elementos:
                     valor_elemento = self.evaluar_expresion(elemento, visitados)
                     valor_elemento = self._materializar_valor(
                         valor_elemento,


### PR DESCRIPTION
### Motivation
- Mejorar la evaluación de literales de lista para que la colección de elementos sea accedida de forma robusta y cada elemento pase por el mismo pipeline de evaluación, materialización y validación ya existente (sin crear bypass).

### Description
- En `src/pcobra/core/interpreter.py` se ajustó la rama de `NodoLista` en `InterpretadorCobra.evaluar_expresion` para normalizar los elementos con `nodos_elementos = list(getattr(expresion, "elementos", []) or [])` y luego iterar evaluando cada elemento recursivamente, aplicando `self._materializar_valor`, `_asegurar_resultado_no_ast` y `_verificar_valor_contexto`, retornando finalmente una lista Python materializada.

### Testing
- Intenté ejecutar los tests relevantes con `pytest` (`cd /workspace/pCobra && pytest -q tests/unit/test_interpreter.py -k "lista or longitud"` y con `PYTHONPATH=src`), pero la colección falló por `ImportError: attempted relative import beyond top-level package` en este entorno de ejecución, por lo que no se pudo validar automáticamente aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a019da19f4883279d07a561cfb7708b)