### PR TITLE
Allowlist contextual para `existe` usando metadata de `usar`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2221,6 +2221,8 @@ class InterpretadorCobra:
             "module": modulo,
             "canonical_module": modulo,
             "python_module": modulo_objeto,
+            "origen_modulo": modulo,
+            "origen_tipo": "public_wrapper",
             "exported_name": nombre_exportado,
             "is_public_export": True,
             "is_sanitized_wrapper": True,

--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -77,12 +77,15 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
         if ("archivo", nodo.nombre) not in self._simbolos_publicos_usar:
             return False
         metadata = self._metadata_simbolos_usar.get(nodo.nombre, {})
-        origen_modulo = metadata.get("module")
+        origen_modulo = metadata.get("origen_modulo", metadata.get("module"))
         origen_canonico = metadata.get("canonical_module")
         origen_backend = metadata.get("python_module")
+        origen_tipo = metadata.get("origen_tipo")
         es_publico = metadata.get("is_public_export") is True
         es_wrapper_sanitizado = metadata.get("is_sanitized_wrapper") is True
         if origen_modulo != "archivo" or origen_canonico != "archivo":
+            return False
+        if origen_tipo is not None and origen_tipo != "public_wrapper":
             return False
         if origen_backend not in self.WRAPPERS_PYTHON_MODULES_PERMITIDOS:
             return False


### PR DESCRIPTION
### Motivation
- Permitir la primitiva `existe` únicamente cuando proviene del wrapper público y saneado del módulo canónico `archivo` sin relajar bloqueos globales.
- Usar metadata del flujo `usar` para tomar una decisión contextual en el validador en lugar de basarse solo en el nombre de la primitiva.

### Description
- Agrega metadata explícita en `_construir_metadata_simbolo_usar`: `"origen_modulo": modulo` y `"origen_tipo": "public_wrapper"`.
- Ajusta `ValidadorPrimitivaPeligrosa._es_wrapper_publico_permitido` para priorizar `origen_modulo` (con fallback a `module`) y exigir `origen_tipo == "public_wrapper"` cuando la clave exista.
- Mantiene las comprobaciones previas: módulo canónico `archivo`, backend Python permitido en `WRAPPERS_PYTHON_MODULES_PERMITIDOS`, export público y wrapper saneado, y validación estricta de rutas relativas en `_ruta_permitida_en_wrapper` (sin absolutas, sin `..`, sin paths Windows/UNC indebidos).
- Cambio localizado al flujo `usar` y al validador de primitivas peligrosas sin relajar reglas globales ni exponer primitivas de backend.

### Testing
- Ejecuté `python -m pytest -q tests/core/test_usar_policy.py tests/core/test_semantic_validators.py` y falló por ausencia de esos archivos en el repo (error: archivo/directorio no encontrado).
- Ejecuté `python -m pytest -q tests/unit/test_usar.py tests/unit/test_semantic_validator.py tests/unit/test_fs_access_validator.py` y la colección de tests falló con `ImportError: attempted relative import beyond top-level package` durante la importación de `InterpretadorCobra`.
- No se observaron fallos relacionados con las nuevas condiciones lógicas añadidas en tiempo de ejecución debido a que la suite no pudo completarse por problemas de entorno de test; los cambios permanecen localizados y las validaciones de rutas no fueron modificadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a053b5cc832788dedf5d93bd37cc)