### PR TITLE
test: cubrir longitud y salida de listas en REPL

### DIFF
--- a/tests/integration/test_repl_list_literal_eval_contract.py
+++ b/tests/integration/test_repl_list_literal_eval_contract.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from contextlib import redirect_stdout
+from io import StringIO
+
 from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
 from pcobra.cobra.cli.commands_v2.repl_cmd import ReplCommandV2
 from pcobra.cobra.core.runtime import InterpretadorCobra
@@ -39,3 +42,36 @@ def test_repl_v2_delega_mismo_tratamiento_de_lista_literal():
         "var a = 5\nvar xs = [a, a + 1]",
     )
     assert interp.obtener_variable("xs") == [5, 6]
+
+
+def test_repl_interpreter_longitud_lista_literal_y_variable_desde_datos():
+    repl = InteractiveCommand(InterpretadorCobra())
+    out = StringIO()
+
+    with redirect_stdout(out):
+        repl.ejecutar_codigo('usar "datos"')
+        repl.ejecutar_codigo('var xs = [1, 2, 3]')
+        repl.ejecutar_codigo('imprimir(longitud(xs))')
+        repl.ejecutar_codigo('imprimir(longitud([1, 2, 3]))')
+
+    lineas = [linea.strip() for linea in out.getvalue().splitlines() if linea.strip()]
+    valores = [linea for linea in lineas if linea.isdigit()]
+    assert valores[-2:] == ["3", "3"]
+
+
+def test_repl_interpreter_longitud_lista_con_expresiones_y_repr_razonable():
+    repl = InteractiveCommand(InterpretadorCobra())
+    out = StringIO()
+
+    with redirect_stdout(out):
+        repl.ejecutar_codigo('usar "datos"')
+        repl.ejecutar_codigo('var a = 10')
+        repl.ejecutar_codigo('var xs = [a, a + 1]')
+        repl.ejecutar_codigo('imprimir(longitud(xs))')
+        repl.ejecutar_codigo('imprimir(xs)')
+
+    lineas = [linea.strip() for linea in out.getvalue().splitlines() if linea.strip()]
+    assert lineas[-2] == "2"
+    repr_lista = lineas[-1]
+    assert "10" in repr_lista and "11" in repr_lista
+    assert repr_lista.startswith("[") and repr_lista.endswith("]")


### PR DESCRIPTION
### Motivation
- Añadir cobertura de comportamiento de listas en el REPL para asegurar que la evaluación de literales y listas con expresiones internas funcionan en modo interactivo.
- Verificar que las funciones de la biblioteca estándar usadas en REPL como `longitud` estén disponibles tras `usar "datos"` y que la salida por `imprimir` sea razonable y robusta frente a mensajes no numéricos.

### Description
- Se extendió `tests/integration/test_repl_list_literal_eval_contract.py` añadiendo dos pruebas de integración que ejecutan código real en el REPL usando `InteractiveCommand` y capturan `stdout` con `redirect_stdout` + `StringIO`.
- Se añadió el caso `test_repl_interpreter_longitud_lista_literal_y_variable_desde_datos` que hace `usar "datos"`, define `var xs = [1, 2, 3]` y verifica que `imprimir(longitud(xs))` y `imprimir(longitud([1, 2, 3]))` producen `3` (filtrando líneas no numéricas del runtime).
- Se añadió el caso `test_repl_interpreter_longitud_lista_con_expresiones_y_repr_razonable` que define `var a = 10; var xs = [a, a + 1]`, comprueba `imprimir(longitud(xs)) == 2` y valida una representación razonable de `imprimir(xs)` comprobando presencia de valores y delimitadores de lista en la última línea.

### Testing
- Ejecuté `pytest -q tests/integration/test_repl_list_literal_eval_contract.py` y todas las pruebas añadidas pasaron (5 passed, 1 warning).
- Las pruebas preservan el mismo estilo de harness existente (ejecución de REPL real, captura de `stdout` y asserts sobre líneas de salida) y filtrado para evitar fragilidad por warnings en la salida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ac6ca5f883279df71da7e1068292)