### PR TITLE
test: alinear regresiones REPL `usar` con casos requeridos

### DIFF
--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -265,11 +265,11 @@ def test_interprete_corelibs_superficie_minima_requerida():
     interp = InterpretadorCobra()
     interp.ejecutar_nodo(NodoUsar("numero"))
     assert interp.obtener_variable("es_finito")(10) is True
-    assert interp.obtener_variable("signo")(-7) == -1
+    assert interp.obtener_variable("signo")(0 - 5) == -1
 
     interp.ejecutar_nodo(NodoUsar("texto"))
     assert interp.obtener_variable("mayusculas")("cobra") == "COBRA"
-    assert interp.obtener_variable("recortar")("  cobra  ") == "cobra"
+    assert interp.obtener_variable("recortar")(" cobra ") == "cobra"
     assert interp.obtener_variable("repetir")("co", 2) == "coco"
     assert interp.obtener_variable("quitar_acentos")("canción") == "cancion"
 


### PR DESCRIPTION
### Motivation

- Alinear las pruebas de regresión del REPL `usar` con los casos concretos requeridos para `numero` y `texto` y garantizar que la cobertura existente de seguridad y UX sigue intacta.

### Description

- Modifica `tests/integration/test_repl_usar_entrypoints_contract.py` para validar `signo(0 - 5)` en lugar de `signo(-7)`.
- Modifica `tests/integration/test_repl_usar_entrypoints_contract.py` para validar `recortar(" cobra ")` en lugar de la variante con dobles espacios.
- No se realizan cambios en el código de runtime; solo se ajustan expectativas en las pruebas para evitar falsos negativos.

### Testing

- Se ejecutó `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py -k 'corelibs_superficie_minima_requerida or seguridad_usar_numpy_error_corto_sin_traceback_modo_normal or logs_usar_conflictos_formato_resumido_sin_diccionario_gigante or repl_ux_error_salida_corta_vs_debug'` y la ejecución final informó `4 passed, 56 deselected`.
- Durante la iteración se introdujo y posteriormente eliminó una prueba temporal que falló, y la validación final indicada arriba pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b3369078832790b471525a571744)