### PR TITLE
test: reforzar cobertura de listas literales para longitud en REPL/runtime

### DIFF
--- a/tests/integration/test_repl_list_literal_eval_contract.py
+++ b/tests/integration/test_repl_list_literal_eval_contract.py
@@ -21,7 +21,9 @@ def test_repl_interpreter_evalua_lista_literal_en_asignacion_var():
         lambda cmd: cmd.interpretador,
         "var xs = [1, 2, 3]",
     )
-    assert interp.obtener_variable("xs") == [1, 2, 3]
+    xs = interp.obtener_variable("xs")
+    assert isinstance(xs, list)
+    assert xs == [1, 2, 3]
 
 
 def test_repl_interpreter_evalua_lista_con_expresiones_internas():
@@ -29,9 +31,11 @@ def test_repl_interpreter_evalua_lista_con_expresiones_internas():
         lambda: InteractiveCommand(InterpretadorCobra()),
         lambda cmd, code: cmd.ejecutar_codigo(code),
         lambda cmd: cmd.interpretador,
-        "var a = 10\nvar xs = [a, a + 1]",
+        "var a = 10\nvar xs = [a, a + 1, 3]",
     )
-    assert interp.obtener_variable("xs") == [10, 11]
+    xs = interp.obtener_variable("xs")
+    assert isinstance(xs, list)
+    assert xs == [10, 11, 3]
 
 
 def test_repl_v2_delega_mismo_tratamiento_de_lista_literal():
@@ -66,12 +70,12 @@ def test_repl_interpreter_longitud_lista_con_expresiones_y_repr_razonable():
     with redirect_stdout(out):
         repl.ejecutar_codigo('usar "datos"')
         repl.ejecutar_codigo('var a = 10')
-        repl.ejecutar_codigo('var xs = [a, a + 1]')
+        repl.ejecutar_codigo('var xs = [a, a + 1, 3]')
         repl.ejecutar_codigo('imprimir(longitud(xs))')
         repl.ejecutar_codigo('imprimir(xs)')
 
     lineas = [linea.strip() for linea in out.getvalue().splitlines() if linea.strip()]
-    assert lineas[-2] == "2"
+    assert lineas[-2] == "3"
     repr_lista = lineas[-1]
-    assert "10" in repr_lista and "11" in repr_lista
+    assert "10" in repr_lista and "11" in repr_lista and "3" in repr_lista
     assert repr_lista.startswith("[") and repr_lista.endswith("]")


### PR DESCRIPTION
### Motivation
- Asegurar que los literales de lista producidos por el intérprete son listas Python puras y que cada elemento pasa por evaluación, materialización y validaciones previas a ser usados por funciones runtime como `longitud`.
- Añadir casos de integración REPL/runtime que verifiquen comportamiento con listas literales, listas con expresiones y la interoperabilidad con la librería `datos` sin tocar sintaxis ni el parser.

### Description
- Revisé el bloque `isinstance(expresion, NodoLista)` en `evaluar_expresion` y confirmé que cada elemento pasa por `evaluar_expresion`, `_materializar_valor`, `_asegurar_resultado_no_ast` y `_verificar_valor_contexto` antes de añadirse a la lista resultante retornada como `list` Python.
- No fue necesario modificar `src/pcobra/core/interpreter.py` porque ya cumple el contrato requerido para listas literales.
- Actualicé `tests/integration/test_repl_list_literal_eval_contract.py` para añadir aserciones de tipo (`isinstance(..., list)`), verificar `longitud(xs)` e `imprimir(longitud([1, 2, 3]))`, y cubrir el caso `var a = 10; var xs = [a, a+1, 3]` comprobando contenido y representación.
- Confirmación explícita de que no se tocaron el Lexer/Parser ni la sintaxis pública del lenguaje.

### Testing
- Ejecuté `pytest -q tests/integration/test_repl_list_literal_eval_contract.py` y todos los tests de ese archivo pasaron exitosamente (5 passed).
- Las pruebas validan tanto la forma (tipo `list`) como el contenido y la salida de `imprimir(longitud(...))` en los escenarios solicitados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ca1884b08327910dd023fd802e21)