### PR TITLE
Refina salida de errores de `usar` y añade snapshot de mensajes

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -144,7 +144,12 @@ def _runtime_debug_enabled() -> bool:
 
 def _resumen_conflictos_usar(conflictos: list[object]) -> str:
     """Devuelve un resumen compacto de conflictos para logs no verbosos."""
-    return f"count={len(conflictos)}"
+    if not conflictos:
+        return "count=0"
+    muestra = ",".join(str(conflicto) for conflicto in conflictos[:3])
+    resto = len(conflictos) - 3
+    sufijo = f",+{resto}" if resto > 0 else ""
+    return f"count={len(conflictos)} sample=[{muestra}{sufijo}]"
 
 
 def _ruta_import_permitida(ruta: str) -> bool:
@@ -2007,7 +2012,6 @@ class InterpretadorCobra:
                     "evento": "usar_sanitize_conflicts",
                     "severity": "warning",
                     "module": nodo.modulo,
-                    "conflicts": conflictos_saneamiento,
                 }
                 logging.warning(
                     "USAR sanitize conflicts event module=%s %s",
@@ -2032,8 +2036,7 @@ class InterpretadorCobra:
                     detalle_por_simbolo = {
                         "module": nodo.modulo,
                         "symbol": simbolo_conflictivo,
-                        "conflicts": conflictos,
-                        "code": "symbol_collision",
+                            "code": "symbol_collision",
                         "message": "símbolo ya existe en contexto actual",
                         "policy": self._usar_collision_policy,
                         "phase": "preflight",
@@ -2059,7 +2062,6 @@ class InterpretadorCobra:
                 detalle = {
                     "module": nodo.modulo,
                     "symbol": conflicto,
-                    "conflicts": conflictos,
                     "code": "symbol_collision",
                     "message": "símbolo ya existe en contexto actual",
                     "policy": self._usar_collision_policy,
@@ -2081,13 +2083,12 @@ class InterpretadorCobra:
                         "Requiere alias explícito.",
                     )
                     if _usar_detalle_habilitado():
-                        mensaje_usuario = f"{mensaje_usuario} detalle={detalle}"
+                        mensaje_usuario = f"{mensaje_usuario} ({USAR_SYMBOL_CONFLICT_ERROR}; detalle={detalle})"
                     raise NameError(mensaje_usuario)
                 evento_colision = {
                     "evento": "usar_collision",
                     "severity": "error",
                     "module": nodo.modulo,
-                    "conflicts": conflictos,
                     "policy": self._usar_collision_policy,
                     "detail": detalle,
                 }
@@ -2099,7 +2100,7 @@ class InterpretadorCobra:
                 )
                 mensaje_usuario = formatear_error_usar_usuario("conflicto_simbolo", nodo.modulo)
                 if _usar_detalle_habilitado():
-                    mensaje_usuario = f"{mensaje_usuario} detalle={detalle}"
+                    mensaje_usuario = f"{mensaje_usuario} ({USAR_SYMBOL_CONFLICT_ERROR}; detalle={detalle})"
                 raise NameError(mensaje_usuario)
 
             # Fase B: inyectar de forma atómica y sin sobreescritura silenciosa.

--- a/tests/data/usar_error_messages_snapshot.json
+++ b/tests/data/usar_error_messages_snapshot.json
@@ -1,0 +1,8 @@
+{
+  "modulo_fuera_catalogo": "No se puede usar 'datos': módulo fuera del catálogo público.",
+  "conflicto_simbolo": "No se puede usar 'datos': hay conflicto de símbolos en el contexto actual.",
+  "export_invalido": "No se puede usar 'datos': no hay símbolos exportables válidos.",
+  "carga_modulo_error": "No se puede usar 'datos': error al cargar el módulo.",
+  "fallback": "No se puede usar 'datos'.",
+  "contexto_minimo": "No se puede usar 'datos': hay conflicto de símbolos en el contexto actual. Requiere alias explícito."
+}

--- a/tests/unit/test_usar_error_messages_snapshot.py
+++ b/tests/unit/test_usar_error_messages_snapshot.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pcobra.core.interpreter import formatear_error_usar_usuario
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SNAPSHOT_PATH = REPO_ROOT / "tests" / "data" / "usar_error_messages_snapshot.json"
+
+
+def _snapshot_actual() -> dict[str, str]:
+    modulo = "datos"
+    return {
+        "modulo_fuera_catalogo": formatear_error_usar_usuario("modulo_fuera_catalogo", modulo),
+        "conflicto_simbolo": formatear_error_usar_usuario("conflicto_simbolo", modulo),
+        "export_invalido": formatear_error_usar_usuario("export_invalido", modulo),
+        "carga_modulo_error": formatear_error_usar_usuario("carga_modulo_error", modulo),
+        "fallback": formatear_error_usar_usuario("desconocido", modulo),
+        "contexto_minimo": formatear_error_usar_usuario(
+            "conflicto_simbolo", modulo, "Requiere alias explícito."
+        ),
+    }
+
+
+def test_snapshot_mensajes_error_usar_compactos() -> None:
+    expected = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    actual = _snapshot_actual()
+    assert actual == expected


### PR DESCRIPTION
### Motivation
- Evitar volcar estructuras grandes en logs y mensajes a usuario cuando se ejecuta `usar`, mostrando solo resúmenes compactos en modo normal.
- Reservar información técnica detallada (payloads completos, `detalle=...`) para entornos de depuración o trazas internas.
- Asegurar que el formato breve de los mensajes no cambie accidentalmente mediante una prueba de snapshot.

### Description
- Modifica `_resumen_conflictos_usar` para devolver un resumen compacto con `count` y una `sample` acotada (máx. 3 elementos) en lugar del volcado completo.
- Ajusta los puntos de logging en la ruta de `usar`/saneamiento y colisiones para no exponer listas completas en logs normales y usar `_trace_debug` cuando se habilita detalle.
- Mantiene los mensajes de usuario cortos vía `formatear_error_usar_usuario`, y añade detalles técnicos solo si `_usar_detalle_habilitado()` está activo, incluyendo la etiqueta `USAR_SYMBOL_CONFLICT_ERROR` en esos casos.
- Añade `tests/unit/test_usar_error_messages_snapshot.py` y el snapshot `tests/data/usar_error_messages_snapshot.json` para fijar el contrato de formato de los mensajes visibles al usuario.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_error_messages_snapshot.py tests/integration/test_repl_usar_entrypoints_contract.py -k "logs_usar_conflictos_formato_resumido or snapshot_mensajes_error_usar_compactos"` y tras corregir una importación en la prueba se obtuvieron `2 passed, 65 deselected, 1 warning`.
- La nueva prueba de snapshot valida que `formatear_error_usar_usuario` produce los mensajes compactos esperados y pasó correctamente.
- La prueba de integración que verifica logs resumidos de conflictos (`test_logs_usar_conflictos_formato_resumido_sin_diccionario_gigante`) también pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e00d8c088327b566f2da2cf76da7)