### PR TITLE
test: cubrir evaluación de NodoLista en `longitud` con expresiones

### DIFF
--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -691,6 +691,9 @@ def test_lista_literal_evalua_elementos_recursivos():
     )
 
     assert inter.obtener_variable("xs") == [10, 11]
+    assert inter.ejecutar_llamada_funcion(
+        NodoLlamadaFuncion("longitud", [NodoIdentificador("xs")])
+    ) == 2
 
 def test_lista_literal_propaga_error_semantico_en_elemento_invalido():
     inter = InterpretadorCobra()


### PR DESCRIPTION
### Motivation
- Asegurar que la evaluación de `NodoLista` produce valores materializados y que puede usarse como argumento en funciones como `longitud`, incluyendo elementos que son identificadores o expresiones.

### Description
- Añadí una aserción en `tests/unit/test_interpreter.py` (en `test_lista_literal_evalua_elementos_recursivos`) que verifica que, tras `var a = 10; var xs = [a, a + 1]`, la llamada `longitud(xs)` devuelve `2`, y confirmé que `InterpretadorCobra.evaluar_expresion` ya contiene la rama para `NodoLista` que evalúa recursivamente, materializa y valida cada elemento; no se modificaron `lexer.py` ni `parser.py`.

### Testing
- Intenté ejecutar los tests focalizados con `pytest -q tests/unit/test_interpreter.py -k "lista_literal or longitud_recibe_lista_literal"` y con `PYTHONPATH=src pytest ...`, pero la recolección falló con `ImportError: attempted relative import beyond top-level package`, por lo que no fue posible completar la ejecución automatizada en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01eaefd7a0832798fbe259eb5bff1b)