### PR TITLE
Use explicit `elementos` dispatch for `NodoLista` in expression evaluator

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1406,7 +1406,7 @@ class InterpretadorCobra:
                 return self.ejecutar_holobit(expresion)
             elif isinstance(expresion, NodoLista):
                 elementos = []
-                nodos_elementos = list(getattr(expresion, "elementos", []) or [])
+                nodos_elementos = list(expresion.elementos)
                 for elemento in nodos_elementos:
                     valor_elemento = self.evaluar_expresion(elemento, visitados)
                     valor_elemento = self._materializar_valor(


### PR DESCRIPTION
### Motivation
- Evitar ambigüedad en la iteración de literales de lista usando la propiedad real del nodo en vez de un acceso defensivo con `getattr`, manteniendo la semántica de evaluación recursiva y las validaciones ya presentes.

### Description
- Sustituí `getattr(expresion, "elementos", []) or []` por `expresion.elementos` en `InterpretadorCobra.evaluar_expresion` dentro de la rama `NodoLista` para iterar explícitamente los elementos; no se cambiaron las llamadas a `self.evaluar_expresion`, la materialización, la guardia anti-AST ni las validaciones de contexto, y `lexer.py`/`parser.py` no fueron modificados.

### Testing
- Intenté ejecutar los tests relevantes con `pytest` pero la colección falló por configuración de import (`ImportError: attempted relative import beyond top-level package`) y no se pudieron ejecutar automáticamente; sin embargo, realicé pruebas manuales con `PYTHONPATH=src` que construyen ASTs para `xs = [1,2,3]`, `longitud([1,2,3])` y `[a, a+1]` y devolvieron `ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01fc96f54c83278c7c3f18914078db)