### PR TITLE
test: reforzar cobertura de `usar "archivo"` para `existe` y política de `usar`

### DIFF
--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -63,6 +63,14 @@ def test_existe_publico_desde_usar_acepta_ruta_relativa():
     assert "verdadero" in salida or "falso" in salida
 
 
+def test_existe_backend_crudo_sigue_bloqueado_aun_con_usar_archivo():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"\nexiste = leer_archivo\nimprimir(existe("README.md"))')
+
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast)
+
+
 def test_metadata_usar_archivo_existe_cadena_completa():
     interp = InterpretadorCobra()
     ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')
@@ -148,4 +156,12 @@ def test_existe_publico_desde_usar_bloquea_traversal_normalizado(codigo):
     ast = generar_ast(codigo)
 
     with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast)
+
+
+def test_usar_numpy_rechaza_con_error_corto():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "numpy"')
+
+    with pytest.raises(PermissionError, match="No se puede usar 'numpy': módulo fuera del catálogo público"):
         interp.ejecutar_ast(ast)


### PR DESCRIPTION
### Motivation
- Asegurar el contrato de seguridad donde la primitiva `existe` solo se habilita vía el wrapper público expuesto por `usar "archivo"` y no por rebinding/aliasing a primitivas backend crudas, y verificar que `usar "numpy"` sigue rechazado por política.

### Description
- Añade dos pruebas en `tests/unit/test_safe_mode.py`: `test_existe_backend_crudo_sigue_bloqueado_aun_con_usar_archivo` y `test_usar_numpy_rechaza_con_error_corto`, además de pequeñas reubicaciones de espacio en el archivo de pruebas.

### Testing
- Ejecuté `pytest -q tests/unit/test_safe_mode.py` y la colección falló con `ImportError: attempted relative import beyond top-level package` durante la importación del intérprete; la prueba no llegó a ejecutarse. 
- Ejecuté `PYTHONPATH=src pytest -q tests/unit/test_safe_mode.py` con el mismo error de colección, por lo que las pruebas añadidas no pudieron validarse en este entorno de CI local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0203313734832791dcdd7cdd172f7b)