### PR TITLE
Soporta evaluación segura de NodoLista en el intérprete

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1421,6 +1421,7 @@ class InterpretadorCobra:
                     )
                     self._verificar_valor_contexto(valor_elemento)
                     elementos.append(valor_elemento)
+                self._verificar_valor_contexto(elementos)
                 return _retorno_critico(elementos, operador="lista")
             elif isinstance(expresion, NodoOperacionBinaria):
                 tipo = expresion.operador.tipo

--- a/tests/unit/test_interpreter.py
+++ b/tests/unit/test_interpreter.py
@@ -684,16 +684,17 @@ def test_lista_literal_evalua_elementos_recursivos():
                         Token(TipoToken.SUMA, "+"),
                         NodoValor(1),
                     ),
+                    NodoValor(3),
                 ]
             ),
             declaracion=True,
         )
     )
 
-    assert inter.obtener_variable("xs") == [10, 11]
+    assert inter.obtener_variable("xs") == [10, 11, 3]
     assert inter.ejecutar_llamada_funcion(
         NodoLlamadaFuncion("longitud", [NodoIdentificador("xs")])
-    ) == 2
+    ) == 3
 
 def test_lista_literal_propaga_error_semantico_en_elemento_invalido():
     inter = InterpretadorCobra()


### PR DESCRIPTION
### Motivation

- Asegurar que los literales de lista (`NodoLista`) sean evaluados elemento a elemento de forma segura y que la lista materializada completa pase por el mismo pipeline de validación de contexto/seguridad que otras expresiones.

### Description

- Refuerza la rama de `NodoLista` en `evaluar_expresion` para validar la lista completa llamando a `self._verificar_valor_contexto(elementos)` luego de evaluar y materializar cada elemento.
- Mantiene la evaluación recursiva por elemento usando el evaluador actual y las llamadas existentes a `_materializar_valor` y `_asegurar_resultado_no_ast` por elemento.
- Actualiza la prueba `test_lista_literal_evalua_elementos_recursivos` para cubrir el caso `var xs = [a, a + 1, 3]` y validar además `longitud(xs) == 3`.

### Testing

- Ejecuté `pytest -q tests/unit/test_interpreter.py -k "lista_literal"` para validar los cambios y la ejecución falló en la fase de colección por un `ImportError: attempted relative import beyond top-level package` en el entorno, por lo que las pruebas automáticas no completaron correctamente.
- Reintenté con `PYTHONPATH=src pytest -q tests/unit/test_interpreter.py -k "lista_literal"` y se reprodujo el mismo fallo de importación, por lo que no se obtuvo un resultado exitoso de test automatizado en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020ab5d818832787a30dc2218b5fc3)