### PR TITLE
Restringe excepción de `existe` al wrapper seguro de `usar "archivo"`

### DIFF
--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -1,8 +1,5 @@
-from pathlib import PurePosixPath
-import re
-
 from .base import ValidadorBase
-from ..ast_nodes import NodoLlamadaFuncion, NodoHilo, NodoLlamadaMetodo, NodoValor
+from ..ast_nodes import NodoLlamadaFuncion, NodoHilo, NodoLlamadaMetodo
 
 
 class PrimitivaPeligrosaError(Exception):
@@ -50,27 +47,6 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
         if metadata:
             self._metadata_simbolos_usar[nombre] = dict(metadata)
 
-    @staticmethod
-    def _ruta_permitida_en_wrapper(argumentos) -> bool:
-        if not argumentos:
-            return False
-        primer_arg = argumentos[0]
-        if not isinstance(primer_arg, NodoValor) or not isinstance(primer_arg.valor, str):
-            return False
-        ruta = primer_arg.valor.strip()
-        if not ruta:
-            return False
-        if re.match(r"^[a-zA-Z]:[\\/]", ruta):
-            return False
-        if ruta.startswith("\\"):
-            return False
-        path = PurePosixPath(ruta)
-        if path.is_absolute():
-            return False
-        if ".." in path.parts:
-            return False
-        return True
-
     def _es_wrapper_publico_permitido(self, nodo: NodoLlamadaFuncion) -> bool:
         if nodo.nombre != "existe":
             return False
@@ -91,7 +67,7 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
             return False
         if not es_publico or not es_wrapper_sanitizado:
             return False
-        return self._ruta_permitida_en_wrapper(nodo.argumentos)
+        return metadata.get("exported_name") == "existe"
 
     def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
         if nodo.nombre in self.PRIMITIVAS_PELIGROSAS and not self._es_wrapper_publico_permitido(nodo):


### PR DESCRIPTION
### Motivation
- Evitar que la primitiva peligrosa `existe` quede permitida por nombre de forma global y permitirla únicamente cuando proviene de un `usar` legítimo que haya exportado un wrapper seguro del módulo canónico `archivo`.
- Evitar duplicar validaciones de rutas en el validador semántico y delegar la validación de paths sensibles a la capa de ejecución/sandbox del módulo `archivo`.

### Description
- Ajusta `ValidadorPrimitivaPeligrosa` para que la excepción que permite `existe` sea estricta y solo ocurra cuando el símbolo fue registrado por `usar` y su metadata cumple: `origen_modulo`/`canonical_module` == "archivo", `origen_tipo` == "public_wrapper", `python_module` dentro de la whitelist `WRAPPERS_PYTHON_MODULES_PERMITIDOS`, `is_public_export` y `is_sanitized_wrapper` a `True`, y `exported_name` == "existe" (archivo: `src/pcobra/core/semantic_validators/primitiva_peligrosa.py`).
- Elimina la validación local de rutas dentro del validador semántico para no duplicar lógicas; la comprobación segura de rutas (bloqueo de rutas absolutas, bloqueo de `..`, y restricción a `COBRA_IO_BASE_DIR`/workspace) permanece en los resolvers/implementaciones de `archivo` en `standard_library` y `corelibs` (archivos: `src/pcobra/standard_library/archivo.py` y `src/pcobra/corelibs/archivo.py`).
- Confirma que `InterpretadorCobra` ya construye y registra metadata mínima útil en `_construir_metadata_simbolo_usar` y que `ejecutar_usar` llama al validador vía `registrar_simbolo_publico_usar` cuando está en `safe_mode` para exponer esos metadatos al validador semántico (archivo: `src/pcobra/core/interpreter.py`).
- Mantengo explícita la política de seguridad: este cambio no habilita importaciones externas ni acceso arbitrario al filesystem fuera de las rutas permitidas por la política y los resolvers de `archivo`.

### Testing
- Ejecuté `python -m py_compile src/pcobra/core/semantic_validators/primitiva_peligrosa.py` y compiló correctamente.
- Ejecuté `pytest -q tests/unit/test_semantic_validator.py tests/unit/test_archivo.py`; `tests/unit/test_archivo.py` pasó pero `tests/unit/test_semantic_validator.py` falló por un `ImportError: attempted relative import beyond top-level package` en este entorno de ejecución (no relacionado con la lógica implementada en este cambio), por lo que una ejecución completa y limpia de la suite en CI es recomendada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020ffb02c083279eccfe0111c6215b)