### PR TITLE
test: ampliar cobertura de listas literales en REPL e intérprete

### DIFF
--- a/tests/integration/test_repl_list_literal_eval_contract.py
+++ b/tests/integration/test_repl_list_literal_eval_contract.py
@@ -26,6 +26,22 @@ def test_repl_interpreter_evalua_lista_literal_en_asignacion_var():
     assert xs == [1, 2, 3]
 
 
+def test_repl_interpreter_lista_literal_repr_y_uso_posterior():
+    repl = InteractiveCommand(InterpretadorCobra())
+    out = StringIO()
+
+    with redirect_stdout(out):
+        repl.ejecutar_codigo("var xs = [1, 2, 3]")
+        repl.ejecutar_codigo("imprimir(xs)")
+        repl.ejecutar_codigo('usar "datos"')
+        repl.ejecutar_codigo("imprimir(longitud(xs))")
+
+    lineas = [linea.strip() for linea in out.getvalue().splitlines() if linea.strip()]
+    assert "[1, 2, 3]" in lineas
+    valores = [linea for linea in lineas if linea.isdigit()]
+    assert valores[-1] == "3"
+
+
 def test_repl_interpreter_evalua_lista_con_expresiones_internas():
     interp = _estado(
         lambda: InteractiveCommand(InterpretadorCobra()),
@@ -61,6 +77,34 @@ def test_repl_interpreter_longitud_lista_literal_y_variable_desde_datos():
     lineas = [linea.strip() for linea in out.getvalue().splitlines() if linea.strip()]
     valores = [linea for linea in lineas if linea.isdigit()]
     assert valores[-2:] == ["3", "3"]
+
+
+def test_repl_interpreter_datos_longitud_lista_literal_directa():
+    repl = InteractiveCommand(InterpretadorCobra())
+    out = StringIO()
+
+    with redirect_stdout(out):
+        repl.ejecutar_codigo('usar "datos"')
+        repl.ejecutar_codigo('imprimir(longitud([1, 2, 3]))')
+
+    lineas = [linea.strip() for linea in out.getvalue().splitlines() if linea.strip()]
+    valores = [linea for linea in lineas if linea.isdigit()]
+    assert valores[-1] == "3"
+
+
+def test_repl_interpreter_lista_literal_con_variables_longitud_dos():
+    repl = InteractiveCommand(InterpretadorCobra())
+    out = StringIO()
+
+    with redirect_stdout(out):
+        repl.ejecutar_codigo('usar "datos"')
+        repl.ejecutar_codigo('var a = 10')
+        repl.ejecutar_codigo('var xs = [a, a + 1]')
+        repl.ejecutar_codigo('imprimir(longitud(xs))')
+
+    lineas = [linea.strip() for linea in out.getvalue().splitlines() if linea.strip()]
+    valores = [linea for linea in lineas if linea.isdigit()]
+    assert valores[-1] == "2"
 
 
 def test_repl_interpreter_longitud_lista_con_expresiones_y_repr_razonable():


### PR DESCRIPTION
### Motivation
- Añadir tests de integración para garantizar que el REPL/intérprete maneja correctamente listas literales en asignaciones, representación y uso posterior sin necesitar cambios en lexer/parser.
- Cobrir escenarios prácticos: representación por `imprimir(...)`, uso de `longitud(...)`, y listas construidas a partir de variables.

### Description
- Se extendió `tests/integration/test_repl_list_literal_eval_contract.py` con nuevos casos: `test_repl_interpreter_lista_literal_repr_y_uso_posterior`, `test_repl_interpreter_datos_longitud_lista_literal_directa` y `test_repl_interpreter_lista_literal_con_variables_longitud_dos`.
- Los tests usan captura de `stdout` y filtrado de líneas (mismo estilo de aserciones del archivo existente) para validar la salida de `imprimir(...)` y `longitud(...)` en el REPL.
- No se modificó la implementación del intérprete/lexer/parser; sólo se añadieron y ajustaron pruebas para evitar dependencias en cambios sintácticos.

### Testing
- Ejecutado: `pytest -q tests/integration/test_repl_list_literal_eval_contract.py tests/unit/test_gate_no_parser_lexer_changes.py` y la ejecución final reportó todos los tests verdes con una advertencia; resultado: `10 passed, 1 warning`.
- Durante la iteración inicial un caso que intentaba usar indexación directa produjo un `ParserError`, por lo que se ajustó el test para validar la representación y la longitud usando `usar "datos"` y `longitud(...)`, y la verificación se repitió con éxito.
- Se incluyó explícitamente la ejecución del gate `test_gate_no_parser_lexer_changes.py` para confirmar que las pruebas añadidas no requieren cambios en lexer/parser y dicho gate pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02131d83988327a9b6841a31fd6d23)