### PR TITLE
test: reforzar cobertura de seguridad para archivo.existe

### DIFF
--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -809,6 +809,14 @@ def test_repl_archivo_existe_bloquea_ruta_absoluta_windows_con_error_controlado(
 
 
 
+
+
+def test_repl_archivo_invocacion_cruda_sin_usar_permanece_bloqueada():
+    cmd = ReplCommandV2()
+
+    with pytest.raises(Exception, match='Uso de primitiva peligrosa'):
+        cmd._ejecutar_en_modo_normal('imprimir(existe("README.md"))')
+
 def test_repl_archivo_invocacion_directa_permanece_bloqueada_sin_traceback(capsys):
     cmd = ReplCommandV2()
     cmd._ejecutar_en_modo_normal('usar "archivo"')
@@ -816,8 +824,9 @@ def test_repl_archivo_invocacion_directa_permanece_bloqueada_sin_traceback(capsy
     with pytest.raises(Exception, match='Uso de primitiva peligrosa'):
         cmd._ejecutar_en_modo_normal('imprimir(existe("README.md"))')
 
-    salida = capsys.readouterr().out
+    salida = capsys.readouterr().out.strip()
     assert 'traceback' not in salida.lower()
+    assert len(salida.splitlines()) <= 2
 
 
 def test_repl_archivo_hardening_no_expone_backend_crudo():


### PR DESCRIPTION
### Motivation
- Asegurar que la primitiva `existe` del módulo `archivo` no pueda ser eludida mediante una llamada cruda sin `usar "archivo"` y que el mensaje de error en modo normal sea corto y sin traceback.
- Reforzar la cobertura de los casos ya contemplados (uso correcto que devuelve booleano y bloqueos por rutas relativas/absolutas) para evitar regresiones de seguridad o de UX.

### Description
- Añadido el test `test_repl_archivo_invocacion_cruda_sin_usar_permanece_bloqueada` en `tests/integration/test_repl_usar_entrypoints_contract.py` que verifica que `imprimir(existe("README.md"))` sin `usar "archivo"` lanza la excepción de primitiva peligrosa.
- Modificado `test_repl_archivo_invocacion_directa_permanece_bloqueada_sin_traceback` para limpiar la salida con `strip()` y añadir una aserción que limita la salida de error a como máximo 2 líneas, además de comprobar la ausencia de la palabra `traceback`.
- No se tocaron los tests existentes que validan el caso positivo (`usar "archivo"` + `existe("README.md")` -> booleano) ni los negativos para rutas relativas/absolutas; se mantuvieron tal cual.

### Testing
- Ejecutado `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py -k 'archivo_existe or invocacion_cruda or invocacion_directa'` y la selección de pruebas pasó correctamente con `6 passed, 61 deselected, 1 warning`.
- Los tests añadidos y modificados pasaron en la ejecución localizada y no introducen fallos en las comprobaciones de bloqueo y mensajería de error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a021afb9ce88327842362ea000de6d6)