### PR TITLE
Ajusta logging de `usar` para modo normal y agrega test de formato corto estable

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2115,7 +2115,7 @@ class InterpretadorCobra:
             elif _usar_error_esperado(exc):
                 logging.error("Error al usar el módulo '%s': %s", nodo.modulo, exc)
             else:
-                logging.exception("Error al usar el módulo '%s': %s", nodo.modulo, exc)
+                logging.error("Error al usar el módulo '%s': %s", nodo.modulo, exc)
             if isinstance(exc, PermissionError):
                 mensaje = formatear_error_usar_usuario("modulo_fuera_catalogo", nodo.modulo)
                 if _usar_detalle_habilitado():

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -1146,6 +1146,32 @@ def test_usar_warning_conflictos_saneamiento_formato_compacto(monkeypatch, caplo
     assert "{'symbol'" not in warning
 
 
+
+
+def test_usar_warning_conflictos_saneamiento_formato_texto_estable(monkeypatch, caplog):
+    modulo = ModuleType("numero")
+    modulo.__all__ = ["A_snake", "a_snake"]
+    modulo.A_snake = lambda n: n
+    modulo.a_snake = lambda n: n
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/numero.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
+    monkeypatch.delenv("PCOBRA_DEBUG_RUNTIME", raising=False)
+    monkeypatch.delenv("PCOBRA_DEBUG_TRACES", raising=False)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero"})
+
+    with pytest.raises(ImportError):
+        interp.ejecutar_nodo(NodoUsar("numero"))
+
+    warnings_saneamiento = [
+        rec.message for rec in caplog.records if "USAR sanitize conflicts event module=numero" in rec.message
+    ]
+    assert warnings_saneamiento
+    assert warnings_saneamiento[-1] == "USAR sanitize conflicts event module=numero count=2 sample=[A_snake->a_snake,a_snake]"
+
+
 def test_usar_warning_conflictos_saneamiento_detalle_solo_debug(monkeypatch, caplog):
     modulo = ModuleType("texto")
     modulo.__all__ = ["A_snake", "a_snake"]


### PR DESCRIPTION
### Motivation
- Evitar que la instrucción `usar` exponga diccionarios de conflicto o tracebacks completos cuando la ejecución está en modo normal. 
- Mantener la máxima visibilidad técnica solo bajo modos `debug/verbose` para preservar salida compacta en producción.

### Description
- En `src/pcobra/core/interpreter.py` se cambió la rama por defecto de `logging.exception(...)` a `logging.error(...)` en el bloque `except` de `ejecutar_usar`, de modo que solo se emita traza completa cuando `_usar_detalle_habilitado()` retorna `True`.
- Se preserva `logging.exception(...)` siempre que `_usar_detalle_habilitado()` esté activo, manteniendo el comportamiento detallado en debug/verbose.
- Se añadió la prueba `test_usar_warning_conflictos_saneamiento_formato_texto_estable` en `tests/unit/test_usar.py` que valida de forma textual y estable el warning compacto esperado: `USAR sanitize conflicts event module=numero count=2 sample=[A_snake->a_snake,a_snake]`.
- Se mantuvieron las pruebas que verifican que el detalle completo siga disponible en modo debug (no se cambiaron esas aserciones).

### Testing
- Ejecuté pruebas unitarias focalizadas con `pytest -q tests/unit/test_usar.py -k "saneamiento_formato_compacto or formato_texto_estable or mensaje_corto_en_modo_normal"`, pero la ejecución falló en la fase de recolección con `ImportError: attempted relative import beyond top-level package` en este entorno, por lo que no se llegaron a ejecutar las aserciones nuevas.
- Reintenté con `PYTHONPATH=src pytest -q tests/unit/test_usar.py -k "..."` y `PYTHONPATH=src/pcobra pytest -q tests/unit/test_usar.py -k "..."` y ambas invocaciones fallaron durante la colección por el mismo `ImportError` de path, por lo que no hay resultados de tests pasados/fallidos más allá del error de importación en este entorno de CI/local.
- Los cambios son localmente deterministas y las nuevas aserciones son unitarias; una ejecución de test completa en un entorno con `PYTHONPATH` y layout correctos debería ejecutar y validar la nueva prueba y las existentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02202dca908327be63162345809701)