### PR TITLE
Compactar warnings de `usar` y añadir test de formato

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1,7 +1,6 @@
 """Implementación del intérprete del lenguaje Cobra."""
 
 import logging
-import warnings
 import os
 import hashlib
 from typing import Mapping, Optional
@@ -2068,14 +2067,15 @@ class InterpretadorCobra:
                     "phase": "preflight",
                 }
                 if self._usar_collision_policy == USAR_COLLISION_WARN_ALIAS_REQUIRED:
-                    warnings.warn(
+                    logging.warning(
+                        "WARNING: %s module=%s count=%s",
                         formatear_error_usar_usuario(
                             "conflicto_simbolo",
                             nodo.modulo,
                             "Use alias explícito para resolver la colisión.",
                         ),
-                        RuntimeWarning,
-                        stacklevel=2,
+                        nodo.modulo,
+                        len(conflictos),
                     )
                     mensaje_usuario = formatear_error_usar_usuario(
                         "conflicto_simbolo",

--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -1202,3 +1202,34 @@ def test_usar_warning_conflictos_saneamiento_detalle_solo_debug(monkeypatch, cap
     assert trazas_debug
     assert "'conflicts':" in trazas_debug[-1]
 
+
+
+def test_usar_warning_colision_alias_formato_compacto(monkeypatch, caplog):
+    modulo = ModuleType("numero")
+    modulo.__all__ = ["sumar"]
+    modulo.sumar = lambda a, b: a + b
+    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/numero.py"
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
+    monkeypatch.delenv("PCOBRA_DEBUG_RUNTIME", raising=False)
+    monkeypatch.delenv("PCOBRA_DEBUG_TRACES", raising=False)
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"numero": "numero"})
+    interp.configurar_politica_colision_usar("warn_alias_required")
+    interp.contextos[-1].define("sumar", lambda a, b: a - b)
+
+    with pytest.raises(NameError):
+        interp.ejecutar_nodo(NodoUsar("numero"))
+
+    warnings_colision = [
+        rec.message for rec in caplog.records if rec.message.startswith("WARNING: No se puede usar 'numero'")
+    ]
+    assert warnings_colision
+    warning = warnings_colision[-1]
+    assert warning == (
+        "WARNING: No se puede usar 'numero': hay conflicto de símbolos en el contexto actual. "
+        "Use alias explícito para resolver la colisión. module=numero count=1"
+    )
+    assert "{" not in warning
+    assert "detalle=" not in warning


### PR DESCRIPTION
### Motivation
- Reducir el ruido en salida normal del CLI/REPL haciendo que los warnings de `usar` sean compactos y predecibles. 
- Evitar imprimir diccionarios internos de conflictos en la salida de usuario para no exponer estructuras técnicas.
- Mantener trazas/tracebacks completos solo cuando esté activado el modo debug/verbose para diagnósticos internos.

### Description
- Reemplacé el uso de `warnings.warn(...)` por `logging.warning(...)` en `InterpretadorCobra.ejecutar_usar` para emitir un warning compacto con el formato fijo `"WARNING: %s module=%s count=%s"` cuando la política es `warn_alias_required` (archivo `src/pcobra/core/interpreter.py`).
- Eliminé la importación ahora no usada de `warnings` en `src/pcobra/core/interpreter.py` y mantuve la rama de detalle técnico bajo `_usar_detalle_habilitado()` y `_trace_debug` para que la información completa solo aparezca en modo debug.
- Añadí un test de regresión `test_usar_warning_colision_alias_formato_compacto` en `tests/unit/test_usar.py` que comprueba que el warning en modo normal incluye `module=` y `count=`, y que no contiene diccionarios ni `detalle=` en la línea de warning.

### Testing
- Intenté ejecutar los tests focalizados con `pytest -q tests/unit/test_usar.py -k "warning_conflictos_saneamiento or warning_colision_alias_formato_compacto or no_muestra_traceback"`, pero la ejecución falló en la fase de colección por un error preexistente de imports (`ImportError: attempted relative import beyond top-level package`).
- Reintenté con `PYTHONPATH=src pytest -q tests/unit/test_usar.py ...` y obtuve el mismo fallo de colección por el problema de import relativo, por lo que el nuevo test fue añadido pero no pudo ser ejecutado en este entorno de CI local.
- Los cambios son locales y la intención del test es bloquear regresiones de formato; la edición fue committeada con mensaje `Ajusta formato de warnings de usar y añade test de regresión`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02d5718fa483278ef8e178ce2f09f1)