### PR TITLE
Restore official loader hook in `ejecutar_usar`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1844,7 +1844,7 @@ class InterpretadorCobra:
         from pathlib import Path
         from types import ModuleType
 
-        from .usar_loader import obtener_modulo
+        from .usar_loader import obtener_modulo_cobra_oficial
 
         def _resolver_exportables(modulo_obj, *, modulo_oficial: bool, nombre_modulo: str):
             """Resuelve exportables candidatos según política de ``usar``."""
@@ -1893,7 +1893,7 @@ class InterpretadorCobra:
             if not es_modulo_oficial_cobra:
                 raise PermissionError(REPL_USAR_EXTERNAL_MODULE_ERROR)
 
-            modulo = obtener_modulo(modulo_canonico)
+            modulo = obtener_modulo_cobra_oficial(modulo_canonico)
 
             return modulo, es_repl_estricto, es_modulo_oficial_cobra
 


### PR DESCRIPTION
### Motivation

- Ensure `InterpretadorCobra.ejecutar_usar` resolves canonical Cobra modules via the core official loader entrypoint so REPL/integration overrides at `pcobra.core.usar_loader.obtener_modulo_cobra_oficial` remain effective and deterministic.

### Description

- Replace the import and call of `obtener_modulo` with `obtener_modulo_cobra_oficial` in `src/pcobra/core/interpreter.py` so `usar` routes canonical module resolution through the core loader hook.

### Testing

- Ran `pytest -q tests/unit/test_usar_loader_stdlib.py tests/unit/test_usar_loader_site_packages.py` and the tests passed (`16 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02e7ffe370832797276666914c4c22)