### PR TITLE
Follow-up: importar alias de corelibs en wrappers de stdlib para evitar NameError

### DIFF
--- a/src/pcobra/standard_library/holobit.py
+++ b/src/pcobra/standard_library/holobit.py
@@ -1,5 +1,6 @@
 """Fachada pública Holobit para `usar \"holobit\"`."""
 
+import pcobra.corelibs.holobit as _holobit
 from pcobra.corelibs.holobit import (
     crear_holobit,
     validar_holobit,

--- a/src/pcobra/standard_library/red.py
+++ b/src/pcobra/standard_library/red.py
@@ -1,5 +1,6 @@
 """Fachada de red segura con API canónica en español."""
 
+import pcobra.corelibs.red as _red
 from pcobra.corelibs.red import (
     obtener_url,
     enviar_post,

--- a/src/pcobra/standard_library/texto.py
+++ b/src/pcobra/standard_library/texto.py
@@ -36,6 +36,7 @@ from typing import Any, TypeVar, overload
 
 import unicodedata
 
+from pcobra.corelibs import texto as _texto
 from pcobra.corelibs.texto import (
     encontrar as _encontrar_texto,
     encontrar_derecha as _encontrar_derecha_texto,

--- a/src/pcobra/standard_library/tiempo.py
+++ b/src/pcobra/standard_library/tiempo.py
@@ -1,5 +1,6 @@
 """Fachada temporal en español para `usar \"tiempo\"`."""
 
+import pcobra.corelibs.tiempo as _tiempo
 from pcobra.corelibs.tiempo import ahora, formatear, dormir, epoch, desde_epoch
 
 __all__ = ["ahora", "formatear", "dormir", "epoch", "desde_epoch"]


### PR DESCRIPTION
### Motivation
- Corregir regresiones en tiempo de ejecución donde los wrappers de `standard_library` delegaban en aliases como `_red`, `_tiempo`, `_holobit` y `_texto` que no estaban importados tras los cambios de paridad realizados en la PR original (#2453). 

### Description
- `src/pcobra/standard_library/red.py`: añadida la línea `import pcobra.corelibs.red as _red` para que las funciones (`obtener_url`, `enviar_post`, `descargar_archivo`, `obtener_json`, etc.) deleguen correctamente. 
- `src/pcobra/standard_library/tiempo.py`: añadida la línea `import pcobra.corelibs.tiempo as _tiempo` para restaurar las delegaciones de `ahora`, `formatear`, `dormir`, `epoch` y `desde_epoch`. 
- `src/pcobra/standard_library/holobit.py`: añadida la línea `import pcobra.corelibs.holobit as _holobit` para que las API públicas de holobit (`crear_holobit`, `validar_holobit`, `medir`, etc.) funcionen. 
- `src/pcobra/standard_library/texto.py`: añadida la línea `from pcobra.corelibs import texto as _texto` para que las nuevas funciones-delegadas (`capitalizar`, `titulo`, `invertir`, `dividir`, `unir`, etc.) resuelvan al módulo subyacente.

### Testing
- Ejecutado `python -m compileall -q src/pcobra/standard_library/red.py src/pcobra/standard_library/tiempo.py src/pcobra/standard_library/holobit.py src/pcobra/standard_library/texto.py` y la compilación de los módulos afectados finalizó con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02ebe0c0d88327b69a95c4bf0fc2ef)