### PR TITLE
fix: corregir test de rechazo por saneamiento en `test_usar.py`

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -659,8 +659,7 @@ def test_politica_publica_backend_es_python_javascript_rust():
 
 def test_repl_usar_emite_evento_telemetria_saneamiento_rechazado(monkeypatch, caplog):
     modulo = ModuleType("mod_ext")
-    modulo.__all__ = ["ok", "backend"]
-    modulo.ok = lambda valor: valor
+    modulo.__all__ = ["backend"]
     modulo.backend = ModuleType("backend_obj")
     modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/mod_ext.py"
 


### PR DESCRIPTION
### Motivation
- Corregir un fallo determinista en `test_repl_usar_emite_evento_telemetria_saneamiento_rechazado` donde el módulo simulado exportaba un símbolo invocable que impedía que el saneamiento dejara cero símbolos y por tanto no se producía el `ImportError` esperado.

### Description
- Se modificó `tests/unit/test_usar.py` para que en `test_repl_usar_emite_evento_telemetria_saneamiento_rechazado` el mock de módulo tenga `modulo.__all__ = ["backend"]` y se eliminó la definición de `modulo.ok`, de modo que solo se exportan símbolos rechazables y el saneamiento deja cero símbolos importables.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar.py -k saneamiento_rechazado`, pero la ejecución falló durante la colección con `ImportError: attempted relative import beyond top-level package` en `core.interpreter`, por lo que la aserción ajustada no pudo ejecutarse en este entorno; la corrección del test está aplicada y debería pasar cuando se ejecute en un entorno con los paquetes/paths configurados correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f70103488327803a38ef597dd2b3)