### PR TITLE
Fix import-time crash by re-exporting legacy backend constants in backend_policy

### DIFF
--- a/src/pcobra/cobra/architecture/backend_policy.py
+++ b/src/pcobra/cobra/architecture/backend_policy.py
@@ -7,6 +7,11 @@ from __future__ import annotations
 
 from typing import Final
 
+from pcobra.cobra.architecture.legacy_backend_lifecycle import (
+    INTERNAL_BACKENDS,
+    INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW,
+)
+
 # Cobra es la única interfaz pública soportada para usuarios e integraciones.
 PUBLIC_INTERFACE_NAME: Final[str] = "cobra"
 


### PR DESCRIPTION
### Motivation
- Restore the legacy import contract so modules that still import `INTERNAL_BACKENDS` and `INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW` from `pcobra.cobra.architecture.backend_policy` do not raise `ImportError` during startup. 

### Description
- Add a compatibility re-export in `src/pcobra/cobra/architecture/backend_policy.py` that imports and exposes `INTERNAL_BACKENDS` and `INTERNAL_COMPATIBILITY_RETIREMENT_WINDOW` from `pcobra.cobra.architecture.legacy_backend_lifecycle`. 

### Testing
- Verified that `from pcobra.cobra.config import transpile_targets` and `from pcobra.cobra.transpilers import registry` import successfully and ran `python -m compileall -q src/pcobra/cobra/architecture src/pcobra/cobra/internal_compat src/pcobra/cobra/config src/pcobra/cobra/transpilers` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0304c8c8c48327bda54300564959df)