### PR TITLE
[PR #2468 follow-up] Fix canonical target order in audit_targets_contract gate

### DIFF
--- a/scripts/ci/audit_targets_contract.py
+++ b/scripts/ci/audit_targets_contract.py
@@ -25,8 +25,8 @@ from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS  # noqa: E402
 
 EXPECTED_CANONICAL_TARGETS: tuple[str, ...] = (
     "python",
-    "rust",
     "javascript",
+    "rust",
 )
 
 FORBIDDEN_TERMS: tuple[tuple[re.Pattern[str], str], ...] = (


### PR DESCRIPTION
### Motivation

- Corregir un falso negativo en la auditoría CI causado porque `EXPECTED_CANONICAL_TARGETS` tenía un orden distinto al contrato canónico público, lo que hacía fallar a `validate_canonical_targets()` por comparación de tuplas sensible al orden.

### Description

- Actualiza `scripts/ci/audit_targets_contract.py` para establecer `EXPECTED_CANONICAL_TARGETS` como `("python", "javascript", "rust")` y así alinear el orden con `PUBLIC_BACKENDS` en `src/pcobra/cobra/architecture/backend_policy.py`.
- La modificación es mínima y sólo reordena la tupla esperada para evitar discrepancias de orden sin cambiar la lógica de validación existente.

### Testing

- Ejecutado `python -m py_compile scripts/ci/audit_targets_contract.py` y la verificación de sintaxis finalizó correctamente.
- No se introdujeron errores de sintaxis adicionales en el archivo modificado tras el cambio y la comprobación automática pasó.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0316d35c888327b2dce657e1d962d3)