### PR TITLE
[PR #2469 follow-up] Fix `usar` sanitization crash when exports include unwritable dunder names

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -135,7 +135,13 @@ def obtener_modulo(nombre: str, *, permitir_instalacion: bool = True):
         ) from exc
 
 
-def sanitizar_exports_publicos(modulo: object, alias_modulo: str) -> tuple[dict[str, Any], list[dict[str, str]]]:
+def sanitizar_exports_publicos(
+    modulo: object,
+    alias_modulo: str,
+    *,
+    simbolos_pre_resueltos: list[tuple[str, object]] | None = None,
+    candidatos_override: list[object] | None = None,
+) -> tuple[dict[str, Any], list[dict[str, str]]]:
     """Filtra exports públicos válidos para ``usar`` y reporta conflictos/rechazos.
 
     Devuelve un mapa limpio ``nombre -> símbolo`` y una lista estructurada de
@@ -143,7 +149,7 @@ def sanitizar_exports_publicos(modulo: object, alias_modulo: str) -> tuple[dict[
     silenciosas.
     """
 
-    exportables = getattr(modulo, "__all__", None)
+    exportables = candidatos_override if candidatos_override is not None else getattr(modulo, "__all__", None)
     if exportables is None:
         candidatos = [
             nombre for nombre in dir(modulo) if isinstance(nombre, str) and not nombre.startswith("_")
@@ -154,39 +160,64 @@ def sanitizar_exports_publicos(modulo: object, alias_modulo: str) -> tuple[dict[
     simbolos_brutos: list[tuple[str, object]] = []
     conflictos: list[dict[str, str]] = []
     vistos: set[str] = set()
-    for nombre in candidatos:
-        if not isinstance(nombre, str):
-            conflictos.append(
-                {
-                    "module": alias_modulo,
-                    "symbol": repr(nombre),
-                    "code": "invalid_export_name_type",
-                    "message": "nombre de export no es string",
-                }
-            )
-            continue
-        if nombre in vistos:
-            conflictos.append(
-                {
-                    "module": alias_modulo,
-                    "symbol": nombre,
-                    "code": "duplicate_export_name",
-                    "message": "nombre exportado repetido en __all__/candidatos",
-                }
-            )
-            continue
-        if not hasattr(modulo, nombre):
-            conflictos.append(
-                {
-                    "module": alias_modulo,
-                    "symbol": nombre,
-                    "code": "missing_export_attr",
-                    "message": "el nombre exportado no existe en el módulo",
-                }
-            )
-            continue
-        vistos.add(nombre)
-        simbolos_brutos.append((nombre, getattr(modulo, nombre)))
+    if simbolos_pre_resueltos is not None:
+        for nombre, simbolo in simbolos_pre_resueltos:
+            if not isinstance(nombre, str):
+                conflictos.append(
+                    {
+                        "module": alias_modulo,
+                        "symbol": repr(nombre),
+                        "code": "invalid_export_name_type",
+                        "message": "nombre de export no es string",
+                    }
+                )
+                continue
+            if nombre in vistos:
+                conflictos.append(
+                    {
+                        "module": alias_modulo,
+                        "symbol": nombre,
+                        "code": "duplicate_export_name",
+                        "message": "nombre exportado repetido en __all__/candidatos",
+                    }
+                )
+                continue
+            vistos.add(nombre)
+            simbolos_brutos.append((nombre, simbolo))
+    else:
+        for nombre in candidatos:
+            if not isinstance(nombre, str):
+                conflictos.append(
+                    {
+                        "module": alias_modulo,
+                        "symbol": repr(nombre),
+                        "code": "invalid_export_name_type",
+                        "message": "nombre de export no es string",
+                    }
+                )
+                continue
+            if nombre in vistos:
+                conflictos.append(
+                    {
+                        "module": alias_modulo,
+                        "symbol": nombre,
+                        "code": "duplicate_export_name",
+                        "message": "nombre exportado repetido en __all__/candidatos",
+                    }
+                )
+                continue
+            if not hasattr(modulo, nombre):
+                conflictos.append(
+                    {
+                        "module": alias_modulo,
+                        "symbol": nombre,
+                        "code": "missing_export_attr",
+                        "message": "el nombre exportado no existe en el módulo",
+                    }
+                )
+                continue
+            vistos.add(nombre)
+            simbolos_brutos.append((nombre, getattr(modulo, nombre)))
 
     simbolos_saneados, rechazos, warnings = sanear_exportables_para_usar(simbolos_brutos)
     mapa_limpio = {nombre: simbolo for nombre, simbolo in simbolos_saneados}

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1928,12 +1928,12 @@ class InterpretadorCobra:
             )
 
             contexto_actual = self.contextos[-1]
-            modulo_proxy = type("_UsarExportsProxy", (), {})()
-            for nombre, simbolo in simbolos_a_inyectar:
-                setattr(modulo_proxy, nombre, simbolo)
-            setattr(modulo_proxy, "__all__", [nombre for nombre, _ in simbolos_a_inyectar])
-
-            mapa_limpio, conflictos_saneamiento = sanitizar_exports_publicos(modulo_proxy, nodo.modulo)
+            mapa_limpio, conflictos_saneamiento = sanitizar_exports_publicos(
+                modulo,
+                nodo.modulo,
+                simbolos_pre_resueltos=simbolos_a_inyectar,
+                candidatos_override=[nombre for nombre, _ in simbolos_a_inyectar],
+            )
             simbolos_saneados = list(mapa_limpio.items())
             if conflictos_saneamiento:
                 evento_conflictos = {


### PR DESCRIPTION
### Motivation
- Evitar que `usar` intente asignar todos los nombres de export mediante `setattr` en un proxy antes del saneamiento, lo que provocaba `TypeError`/`AttributeError` para nombres legales pero no escribibles (p.ej. `__class__`, `__weakref__`) y hacía fallar la importación antes de que se aplicaran las reglas de saneamiento.
- Mantener la centralización de las reglas de aceptación/rechazo de exports para `usar` sin introducir pasos frágiles de proxying que puedan romper la carga de módulos Cobra en runtime/REPL.

### Description
- Eliminado el paso de crear un `modulo_proxy` y de llamar a `setattr` para cada candidato en `InterpretadorCobra.ejecutar_usar`; ahora se llama directamente a `sanitizar_exports_publicos(...)` con los símbolos ya resueltos desde `_resolver_exportables` usando `simbolos_pre_resueltos` y `candidatos_override`.
- Extendida la firma de `sanitizar_exports_publicos` en `src/pcobra/cobra/usar_loader.py` para aceptar los parámetros opcionales `simbolos_pre_resueltos` y `candidatos_override` y procesar correctamente pares `(nombre, símbolo)` sin requerir atributos dinámicos en un objeto proxy.
- La función sigue delegando en la política existente `sanear_exportables_para_usar` para aplicar rechazos/warnings y construye el `mapa_limpio` (`nombre -> símbolo`) y la lista estructurada de `conflictos` tal como antes.

### Testing
- Compilación por bytecode ejecutada con `python -m py_compile src/pcobra/cobra/usar_loader.py src/pcobra/core/interpreter.py` y completada con éxito (sin errores de sintaxis).
- No se añadieron ni modificaron pruebas unitarias automáticas en este cambio; la verificación automática disponible (compilación) pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0319457d0c8327bd6d30a55b7a0673)