### PR TITLE
[Follow-up] Fix parser/lexer gate to catch rename-only diffs

### DIFF
--- a/scripts/ci/gate_no_parser_lexer_changes.py
+++ b/scripts/ci/gate_no_parser_lexer_changes.py
@@ -14,12 +14,36 @@ CANONICAL_SYNTAX_PATHS = (
 )
 
 
+def _parse_name_status(output: str) -> list[Path]:
+    changed: list[Path] = []
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+
+        status = parts[0]
+        paths = parts[1:]
+
+        if status.startswith(("R", "C")) and len(paths) >= 2:
+            changed.append(Path(paths[0]))
+            changed.append(Path(paths[1]))
+            continue
+
+        changed.append(Path(paths[0]))
+
+    return changed
+
+
 def _git_changed_files(base: str, head: str) -> list[Path]:
-    cmd = ["git", "diff", "--name-only", f"{base}...{head}"]
+    cmd = ["git", "diff", "--name-status", f"{base}...{head}"]
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or "git diff falló")
-    return [Path(line.strip()) for line in result.stdout.splitlines() if line.strip()]
+    return _parse_name_status(result.stdout)
 
 
 def _find_blocked_paths(changed: list[Path]) -> list[Path]:

--- a/tests/unit/test_gate_no_parser_lexer_changes.py
+++ b/tests/unit/test_gate_no_parser_lexer_changes.py
@@ -26,3 +26,28 @@ def test_gate_fails_when_parser_changes() -> None:
     )
     assert result.returncode == 1
     assert "bloqueados" in result.stdout
+
+
+from importlib import util
+
+
+def _load_gate_module():
+    spec = util.spec_from_file_location(
+        "gate_no_parser_lexer_changes",
+        "scripts/ci/gate_no_parser_lexer_changes.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_name_status_detects_rename_of_canonical_file() -> None:
+    gate = _load_gate_module()
+    changed = gate._parse_name_status(
+        "R100\tsrc/pcobra/cobra/core/parser.py\tsrc/pcobra/cobra/core/parser_v2.py\n"
+    )
+
+    blocked = gate._find_blocked_paths(changed)
+
+    assert blocked == [gate.Path("src/pcobra/cobra/core/parser.py")]


### PR DESCRIPTION
### Motivation

- Evitar que renombrados o copiados de archivos canónicos de sintaxis sorteen la comprobación de CI que usaba `git diff --name-only`.
- Asegurar que cualquier cambio/remoción de `src/pcobra/cobra/core/lexer.py` o `src/pcobra/cobra/core/parser.py` sea detectado y bloqueado por el gate.

### Description

- Cambiado el `git diff` usado en `scripts/ci/gate_no_parser_lexer_changes.py` de `--name-only` a `--name-status` para obtener estado y rutas pre/post-imagen.
- Añadida la función `_parse_name_status(output: str)` que extrae tanto la ruta antigua como la nueva para entradas de tipo `R*`/`C*` y devuelve la lista de `Path` afectadas.
- La lógica de detección `_find_blocked_paths` y el argumento `--changed-file` se mantienen, ahora alimentados con la salida parseada para cubrir renames.
- Añadido un test de regresión `tests/unit/test_gate_no_parser_lexer_changes.py::test_parse_name_status_detects_rename_of_canonical_file` que simula una línea `R100	old	new` y verifica que la ruta canónica queda bloqueada.

### Testing

- Ejecutado `pytest -q tests/unit/test_gate_no_parser_lexer_changes.py` y la ejecución resultó en `3 passed, 1 warning`.
- Las pruebas cubren los casos de solo cambios de runtime, cambios directos en `parser.py` y renombrado detectado, y todas pasaron correctamente.
- El gate sigue devolviendo los mismos códigos de salida para OK y detección bloqueada cuando se invoca con `--changed-file` o mediante `git diff`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032bf5000c8327b58df64e98a7e2c4)