### PR TITLE
Follow-up: restore `usar` export compatibility and preserve `numero.producto` API

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -222,6 +222,7 @@ USAR_RUNTIME_EXPORT_OVERRIDES: dict[str, tuple[str, ...]] = {
         "prefijo_comun",
         "sufijo_comun",
         "dividir_lineas",
+        "dividir",
         "dividir_derecha",
         "encontrar",
         "encontrar_derecha",
@@ -249,6 +250,7 @@ USAR_RUNTIME_EXPORT_OVERRIDES: dict[str, tuple[str, ...]] = {
         "formatear_mapa",
         "tabla_traduccion",
         "traducir",
+        "reemplazar",
         "recortar",
         "repetir",
     ),
@@ -334,6 +336,7 @@ USAR_RUNTIME_EXPORT_OVERRIDES: dict[str, tuple[str, ...]] = {
         "ejecutar_stream",
         "obtener_env",
         "listar_dir",
+        "ejecutar_comando_async",
         "directorio_actual",
     ),
     "archivo": (
@@ -341,6 +344,9 @@ USAR_RUNTIME_EXPORT_OVERRIDES: dict[str, tuple[str, ...]] = {
         "escribir",
         "adjuntar",
         "existe",
+        "eliminar",
+        "anexar",
+        "leer_lineas",
     ),
     "tiempo": (
         "ahora",

--- a/src/pcobra/standard_library/numero.py
+++ b/src/pcobra/standard_library/numero.py
@@ -415,10 +415,7 @@ def sumatoria(valores):
     return suma_precisa(valores)
 
 
-def producto(valores):
-    """Multiplica los elementos numéricos de ``valores`` al estilo ``math.prod``."""
+def producto(*args, **kwargs):
+    """Delega en ``pcobra.corelibs.numero.producto``."""
 
-    acumulado = 1
-    for valor in valores:
-        acumulado *= float(valor)
-    return acumulado
+    return _numero.producto(*args, **kwargs)


### PR DESCRIPTION
### Motivation
- Restore runtime compatibility for `usar` so symbols expected by existing scripts are not dropped when modules are resolved from `corelibs` first. 
- Preserve the original `numero.producto` API/semantics (including `inicio` support and integer-preserving behavior) to avoid regressions.

### Description
- Updated `USAR_RUNTIME_EXPORT_OVERRIDES` in `src/pcobra/cobra/usar_policy.py` to reintroduce legacy symbols expected by runtime resolution, notably adding `dividir` and `reemplazar` to `texto`, `eliminar`, `anexar`, and `leer_lineas` to `archivo`, and `ejecutar_comando_async` to `sistema` to match `corelibs` exports. 
- Replaced the semantics-changing `producto` implementation in `src/pcobra/standard_library/numero.py` with a delegation to the core library by changing `producto` to `return _numero.producto(*args, **kwargs)`, preserving existing parameters and behavior. 
- Kept changes minimal and localized to `src/pcobra/cobra/usar_policy.py` and `src/pcobra/standard_library/numero.py` to avoid wider surface modifications. 

### Testing
- Ran `python -m compileall src/pcobra/cobra/usar_policy.py src/pcobra/standard_library/numero.py` and compilation completed successfully. 
- Executed automated runtime smoke checks that verified `numero.producto([2,3,4]) == 24` and `numero.producto([2,3], inicio=5) == 30`, and confirmed restored override entries are present in `USAR_RUNTIME_EXPORT_OVERRIDES`; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0333f7c37c8327812d17f1b1aa9682)