### PR TITLE
[PR #2481 follow-up] Preserve canonical runtime whitelist in usar exports

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -140,15 +140,31 @@ def sanitizar_exports_publicos(modulo: object, alias_modulo: str) -> tuple[dict[
     silenciosas.
     """
 
+    override_exports = USAR_RUNTIME_EXPORT_OVERRIDES.get(alias_modulo)
     exportables = getattr(modulo, "__all__", None)
-    if exportables is None:
-        candidatos = list(USAR_RUNTIME_EXPORT_OVERRIDES.get(alias_modulo, ()))
+
+    if override_exports is not None:
+        # Para módulos canónicos, la whitelist de runtime es la fuente de verdad.
+        # No se debe confiar en __all__ para evitar ampliaciones accidentales de API.
+        candidatos = list(override_exports)
+        conflictos = []
+        if exportables is None:
+            conflictos.append(
+                {
+                    "module": alias_modulo,
+                    "symbol": "__all__",
+                    "code": "missing___all__",
+                    "message": "módulo sin __all__; se aplica whitelist explícita por política",
+                }
+            )
+    elif exportables is None:
+        candidatos = []
         conflictos = [
             {
                 "module": alias_modulo,
                 "symbol": "__all__",
                 "code": "missing___all__",
-                "message": "módulo sin __all__; se aplica whitelist explícita por política",
+                "message": "módulo sin __all__ y sin whitelist canónica configurada",
             }
         ]
     else:


### PR DESCRIPTION
### Motivation
- Corregir la regresión que permitía que `module.__all__` sobreescribiera la whitelist canónica `USAR_RUNTIME_EXPORT_OVERRIDES`, lo que expandía exportaciones y generaba colisiones en `usar`.
- Centralizar la vía de saneamiento para que la política runtime sea la fuente de verdad y evitar bypasses que expongan símbolos no deseados.

### Description
- Modificado `sanitizar_exports_publicos` en `src/pcobra/cobra/usar_loader.py` para que, cuando exista `USAR_RUNTIME_EXPORT_OVERRIDES[alias_modulo]`, esa whitelist sea la fuente de verdad incluso si `__all__` está presente, y en ese caso se añade un conflicto `missing___all__` si el módulo no define `__all__`.
- Si no existe override ni `__all__`, los `candidatos` se dejan vacíos y se reporta explícitamente un conflicto `missing___all__` en lugar de confiar en reflexión amplia del módulo.
- Se preserva la validación posterior mediante `sanear_exportables_para_usar` y la construcción de `mapa_limpio` y la lista estructurada de `conflictos` para mantener la detección de colisiones y rechazos.

### Testing
- Ejecutado `python -m compileall -q src/pcobra/cobra/usar_loader.py src/pcobra/core/interpreter.py src/pcobra/cobra/usar_policy.py src/pcobra/core/usar_symbol_policy.py` y la compilación finalizó correctamente (OK).
- No se añadieron tests unitarios en esta cambio; solo se validó la compilación estática de los módulos afectados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03397d420c8327bef0a359c4c05d03)