### PR TITLE
Restore LEGACY_INTERNAL_TARGETS import in compatibility matrix

### DIFF
--- a/src/pcobra/cobra/transpilers/compatibility_matrix.py
+++ b/src/pcobra/cobra/transpilers/compatibility_matrix.py
@@ -21,6 +21,7 @@ from typing import Final
 from pcobra.cobra.transpilers.target_utils import normalize_target_name
 from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 from pcobra.cobra.transpilers.runtime_api_matrix import build_runtime_api_matrix
+from pcobra.cobra.config.transpile_targets import LEGACY_INTERNAL_TARGETS
 from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS, TIER1_TARGETS
 
 CONTRACT_FEATURES: Final[tuple[str, ...]] = (


### PR DESCRIPTION
### Motivation
- Restore the missing `LEGACY_INTERNAL_TARGETS` import in `src/pcobra/cobra/transpilers/compatibility_matrix.py` to prevent a `NameError` at module import time and unblock transpiler initialization.

### Description
- Re-added `from pcobra.cobra.config.transpile_targets import LEGACY_INTERNAL_TARGETS` to `compatibility_matrix.py` so `_validate_contract_shape` and related validators can reference the legacy inventory symbol.

### Testing
- Ran `python -m compileall -q src/pcobra/cobra/transpilers/compatibility_matrix.py` and performed an import smoke test with `import pcobra.cobra.transpilers.compatibility_matrix`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033e6056a483278a018049cbef78c7)