### PR TITLE
Preserve builtin semantics in `minimo`/`maximo` (fix single-iterable regression)

### DIFF
--- a/src/pcobra/corelibs/numero.py
+++ b/src/pcobra/corelibs/numero.py
@@ -76,25 +76,23 @@ def truncar(valor):
 
 
 def minimo(*valores):
-    """Retorna el menor valor recibido.
-
-    Se exige al menos un argumento para alinear mensajes con el runtime Cobra.
-    """
+    """Retorna el menor valor recibido preservando semántica de :func:`min`."""
 
     if not valores:
         raise TypeError("minimo requiere al menos un argumento")
-    return min(valores)
+    if len(valores) == 1:
+        return min(valores[0])
+    return min(*valores)
 
 
 def maximo(*valores):
-    """Retorna el mayor valor recibido.
-
-    Se exige al menos un argumento para alinear mensajes con el runtime Cobra.
-    """
+    """Retorna el mayor valor recibido preservando semántica de :func:`max`."""
 
     if not valores:
         raise TypeError("maximo requiere al menos un argumento")
-    return max(valores)
+    if len(valores) == 1:
+        return max(valores[0])
+    return max(*valores)
 
 
 def mcd(*valores: int) -> int:

--- a/tests/unit/test_standard_library_numero.py
+++ b/tests/unit/test_standard_library_numero.py
@@ -69,6 +69,20 @@ def test_signo_y_limitar():
         numero.limitar(0, 2, 1)
 
 
+
+
+def test_minimo_maximo_preservan_semantica_builtin():
+    datos = [3, 1, 2]
+    assert numero.minimo(datos) == 1
+    assert numero.maximo(datos) == 3
+    assert numero.minimo(3, 1, 2) == 1
+    assert numero.maximo(3, 1, 2) == 3
+
+    with pytest.raises(TypeError):
+        numero.minimo()
+    with pytest.raises(TypeError):
+        numero.maximo()
+
 def test_hipotenusa_y_distancia_euclidiana():
     assert numero.hipotenusa(3, 4) == pytest.approx(5.0)
     assert numero.hipotenusa([2, 3, 6]) == pytest.approx(math.sqrt(49.0))


### PR DESCRIPTION
### Motivation
- Mantener compatibilidad con las semánticas de `min`/`max` al exponer alias en español y evitar que `minimo(iterable)`/`maximo(iterable)` devuelvan el iterable en lugar de sus elementos.
- Corregir la regresión introducida por la implementación variádica que trataba el iterable único como un elemento único dentro de una tupla de argumentos.

### Description
- Modifiqué `src/pcobra/corelibs/numero.py` para que `minimo(*valores)` y `maximo(*valores)` preserven la semántica de los builtins: cuando reciben un solo argumento usan `min(valores[0])`/`max(valores[0])`, y en el caso variádico usan `min(*valores)`/`max(*valores)`.
- Conservé los mensajes de error explícitos para el caso de cero argumentos (`TypeError("minimo requiere al menos un argumento")` / `TypeError("maximo requiere al menos un argumento")`).
- Añadí pruebas de regresión en `tests/unit/test_standard_library_numero.py` que verifican la forma con un iterable, la forma variádica y la excepción ante cero argumentos.

### Testing
- Ejecuté `pytest -q tests/unit/test_standard_library_numero.py -k "minimo_maximo or signo_y_limitar"` y la ejecución falló durante la recolección por un problema de import circular en la inicialización del paquete que es independiente de este cambio.
- Validé la corrección cargando `src/pcobra/corelibs/numero.py` directamente con `importlib` y comprobando que `minimo([3,1,2]) == 1`, `maximo([3,1,2]) == 3`, `minimo(3,1,2) == 1`, `maximo(3,1,2) == 3`, y que la llamada sin argumentos lanza `TypeError`, todas las aserciones pasaron con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a035f619d54832798d3103ba2a88d97)