### PR TITLE
[Follow-up] Fix monkeypatch target for `usar` canonical surface contract tests

### DIFF
--- a/tests/integration/test_usar_canonical_surface_contract.py
+++ b/tests/integration/test_usar_canonical_surface_contract.py
@@ -10,6 +10,7 @@ from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
 from pcobra.cobra.cli.commands_v2.repl_cmd import ReplCommandV2
 from pcobra.core import usar_loader as core_usar_loader
+from pcobra.cobra import usar_loader as cobra_usar_loader
 from pcobra.cobra.core.runtime import InterpretadorCobra
 
 
@@ -65,7 +66,7 @@ def _crear_comando(factory):
 def test_caso_1_numero_superficie_publica_espanol(factory, monkeypatch):
     mod_numero = _crear_numero()
     resolver = lambda nombre, **_kwargs: mod_numero if nombre == "numero" else (_ for _ in ()).throw(ModuleNotFoundError(nombre))
-    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", resolver)
+    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo_cobra_oficial", resolver)
 
     _cmd, ejecutar, interp = _crear_comando(factory)
     ejecutar('usar "numero"')
@@ -78,7 +79,7 @@ def test_caso_1_numero_superficie_publica_espanol(factory, monkeypatch):
 def test_caso_2_texto_superficie_publica_espanol(factory, monkeypatch):
     mod_texto = _crear_texto()
     resolver = lambda nombre, **_kwargs: mod_texto if nombre == "texto" else (_ for _ in ()).throw(ModuleNotFoundError(nombre))
-    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", resolver)
+    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo_cobra_oficial", resolver)
 
     _cmd, ejecutar, interp = _crear_comando(factory)
     ejecutar('usar "texto"')
@@ -101,7 +102,7 @@ def test_caso_3_datos_superficie_publica_espanol():
 def test_casos_4_a_7_rechaza_modulos_no_permitidos(modulo_externo, factory, monkeypatch):
     mod_numero = _crear_numero()
     resolver = lambda nombre, **_kwargs: mod_numero if nombre == "numero" else (_ for _ in ()).throw(ModuleNotFoundError(nombre))
-    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", resolver)
+    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo_cobra_oficial", resolver)
 
     _cmd, ejecutar, interp = _crear_comando(factory)
     ejecutar('usar "numero"')
@@ -131,7 +132,7 @@ def test_usar_modulos_canonicos_solo_exponen_superficie_espanol(modulo, factory,
         "holobit": _crear_holobit(),
     }
     resolver = lambda nombre, **_kwargs: stubs[nombre] if nombre in stubs else (_ for _ in ()).throw(ModuleNotFoundError(nombre))
-    monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", resolver)
+    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo_cobra_oficial", resolver)
 
     _cmd, ejecutar, interp = _crear_comando(factory)
     ejecutar(f'usar "{modulo}"')


### PR DESCRIPTION
### Motivation
- Ensure the integration tests for `usar` are hermetic by patching the actual module where `obtener_modulo` is resolved so stubs take effect and tests don't accidentally load real modules.

### Description
- Import `pcobra.cobra.usar_loader` as `cobra_usar_loader` in `tests/integration/test_usar_canonical_surface_contract.py` and switch all `monkeypatch.setattr` calls to target `cobra_usar_loader.obtener_modulo_cobra_oficial` instead of the re-export in `pcobra.core.usar_loader`.
- Updated all affected test cases (numero, texto, non-permitted modules, and the parametrized canonical-surface test) to use the new import/monkeypatch target.

### Testing
- Ran `pytest -q tests/integration/test_usar_canonical_surface_contract.py -q`; the change removed the prior hermeticity bug caused by patching the re-export, and the suite now fails only on an unrelated expectation mismatch for the non-public-module rejection message (5 failures due to regex mismatch), not on the resolver/stubbing behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0365618b5083279ae86b2cc863764e)