### PR TITLE
Follow-up: preserve structured `usar` error codes in user-mode messages

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1976,9 +1976,12 @@ class InterpretadorCobra:
                     self._trace_debug(f"[USAR_SANITIZE][CONFLICTS] {evento_conflictos}")
 
             if not simbolos_saneados:
-                mensaje_usuario = formatear_error_usar_usuario("export_invalido", nodo.modulo)
+                mensaje_usuario = (
+                    f"{formatear_error_usar_usuario('export_invalido', nodo.modulo)} "
+                    f"({USAR_INVALID_EXPORT_ERROR})"
+                )
                 if self._debug_trazas_habilitadas() or _runtime_debug_enabled():
-                    mensaje_usuario = f"{mensaje_usuario} ({USAR_INVALID_EXPORT_ERROR}; conflictos={conflictos_saneamiento})"
+                    mensaje_usuario = f"{mensaje_usuario} conflictos={conflictos_saneamiento}"
                 raise ImportError(mensaje_usuario)
 
             # Fase A: detectar colisiones de forma completa antes de definir.
@@ -2057,9 +2060,7 @@ class InterpretadorCobra:
         except Exception as exc:
             logging.exception("Error al usar el módulo '%s': %s", nodo.modulo, exc)
             if isinstance(exc, PermissionError):
-                mensaje = formatear_error_usar_usuario("modulo_fuera_catalogo", nodo.modulo)
-                if self._debug_trazas_habilitadas() or _runtime_debug_enabled():
-                    mensaje = f"{mensaje} ({exc})"
+                mensaje = f"{formatear_error_usar_usuario('modulo_fuera_catalogo', nodo.modulo)} ({exc})"
                 raise PermissionError(mensaje) from exc
             raise
 


### PR DESCRIPTION
### Motivation
- Preserve machine-detectable `usar_error[...]` discriminators when `usar` fails so callers can reliably distinguish failure reasons even with debug flags off. 
- Keep user-facing messages brief while retaining structured payloads in error text for programmatic checks and diagnostics.

### Description
- Always include `USAR_INVALID_EXPORT_ERROR` in the raised `ImportError` when `not simbolos_saneados`, while debug/runtime modes still append detailed conflict information, by changing the `not simbolos_saneados` path to build a message that contains the structured marker (`USAR_INVALID_EXPORT_ERROR`).
- Preserve the original `PermissionError` payload when re-raising in `ejecutar_usar` by including the upstream exception text in the new `PermissionError` message so structured reasons like `modulo_no_canonico` or `backend_import_directo` remain available to callers.
- Changes are localized to `src/pcobra/core/interpreter.py` and maintain existing debug behavior guarded by `self._debug_trazas_habilitadas()` or `_runtime_debug_enabled()`.

### Testing
- Ran `python -m compileall src/pcobra/core/interpreter.py` and compilation succeeded.
- Attempted `PYTHONPATH=src pytest -q tests/unit/test_usar_runtime_policy.py -k "error_usuario or colision_warn_diagnostico"` but test collection failed with an import error (`attempted relative import beyond top-level package`) in this environment, so pytest assertions did not execute.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03fd6d4eb883278e02557b347d0f70)