### PR TITLE
Restore missing `texto` runtime API in `corelibs.texto` (fix usar "texto" regressions)

### DIFF
--- a/src/pcobra/corelibs/texto.py
+++ b/src/pcobra/corelibs/texto.py
@@ -1058,6 +1058,46 @@ def lineas_no_vacias(texto: str) -> list[str]:
     return [linea.strip() for linea in texto.splitlines() if linea.strip()]
 
 
+
+
+def normalizar_espacios(texto: str) -> str:
+    """Colapsa espacios en blanco consecutivos y recorta extremos."""
+
+    partes = dividir(texto)
+    return unir(" ", partes) if partes else ""
+
+
+def es_palindromo(
+    texto: str,
+    *,
+    ignorar_espacios: bool = True,
+    ignorar_tildes: bool = True,
+    ignorar_mayusculas: bool = True,
+) -> bool:
+    """Indica si ``texto`` es un palíndromo bajo reglas de normalización básicas."""
+
+    procesado = texto
+    if ignorar_espacios:
+        procesado = "".join(dividir(procesado))
+    else:
+        procesado = quitar_espacios(procesado)
+    if ignorar_tildes:
+        procesado = quitar_acentos(procesado)
+    if ignorar_mayusculas:
+        procesado = minusculas(procesado)
+    return procesado == invertir(procesado)
+
+
+def es_anagrama(texto: str, otro: str, *, ignorar_espacios: bool = True) -> bool:
+    """Comprueba si dos cadenas son anagramas ignorando acentos y opcionalmente espacios."""
+
+    def preparar(valor: str) -> str:
+        resultado = quitar_acentos(valor)
+        if ignorar_espacios:
+            resultado = "".join(dividir(resultado))
+        return "".join(sorted(minusculas(resultado)))
+
+    return preparar(texto) == preparar(otro)
 def recortar(texto: str) -> str:
     """Recorta espacios al inicio y final usando la semántica de ``str.strip``."""
 
@@ -1149,6 +1189,9 @@ __all__ = [
     "recortar",
     "repetir",
     "quitar_acentos",
+    "normalizar_espacios",
+    "es_palindromo",
+    "es_anagrama",
 ]
 
 


### PR DESCRIPTION
### Motivation
- Fix a user-visible regression where `usar "texto"` resolved to `pcobra.corelibs.texto` but did not export historically expected symbols, causing `NameError` at runtime and breaking the declared capability contract.

### Description
- Added the missing Cobra-facing runtime functions `normalizar_espacios`, `es_palindromo`, and `es_anagrama` to `src/pcobra/corelibs/texto.py` so the module provides the full surface required by the runtime overrides. 
- Exported the new symbols by updating `__all__` in `src/pcobra/corelibs/texto.py` so capability-contract consumers and `usar` resolution observe them as public API. 
- Kept the intended `usar` routing to the `corelibs` implementation while restoring the documented callable surface to avoid user-facing regressions.

### Testing
- Ran focused automated tests: `tests/unit/test_usar_loader_public_api_contract.py::test_usar_texto_expone_solo_callables_en_espanol`, `tests/integration/test_usar_runtime_contract.py::test_usar_texto_expone_recortar_repetir_quitar_acentos`, and `tests/integration/test_repl_entrypoint_numero_callable_output.py::test_entrypoint_repl_texto_flujo_integral_callable_output`.
- Result: `3 passed, 1 warning` and no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04068933988327bef676874bbc40f6)