### PR TITLE
Registrar símbolos `usar` a través de la cadena de validadores en modo seguro

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2122,8 +2122,17 @@ class InterpretadorCobra:
                     f"'{modulo}': {USAR_SYMBOL_CONFLICT_ERROR} colisión estructurada={detalle}"
                 )
             contexto_actual.define(nombre, simbolo)
-            if self.safe_mode and self._validador is not None and hasattr(self._validador, "registrar_simbolo_publico_usar"):
-                self._validador.registrar_simbolo_publico_usar(nombre)
+            if self.safe_mode and self._validador is not None:
+                self._registrar_simbolo_publico_usar_en_cadena(nombre)
+
+    def _registrar_simbolo_publico_usar_en_cadena(self, nombre: str) -> None:
+        """Registra un símbolo público de ``usar`` en toda la cadena de validación."""
+        actual = self._validador
+        while actual is not None:
+            registrar = getattr(actual, "registrar_simbolo_publico_usar", None)
+            if callable(registrar):
+                registrar(nombre)
+            actual = getattr(actual, "siguiente", None)
 
     def ejecutar_holobit(self, nodo):
         """Simula la ejecución de un holobit y devuelve sus valores."""

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -70,6 +70,40 @@ def test_existe_publico_desde_usar_bloquea_rutas_fuera_de_politica(codigo):
         interp.ejecutar_ast(ast)
 
 
+
+
+def test_registro_simbolo_usar_recorrer_cadena_validadores():
+    class ValidadorRaizSinRegistro:
+        def __init__(self, siguiente=None):
+            self.siguiente = siguiente
+
+    class ValidadorConRegistro:
+        def __init__(self):
+            self.siguiente = None
+            self.registrados = []
+
+        def registrar_simbolo_publico_usar(self, nombre):
+            self.registrados.append(nombre)
+
+    class ContextoFalso:
+        def contains(self, _nombre):
+            return False
+
+        def define(self, _nombre, _simbolo):
+            return None
+
+    validador_objetivo = ValidadorConRegistro()
+    raiz = ValidadorRaizSinRegistro(siguiente=validador_objetivo)
+
+    interp = InterpretadorCobra()
+    interp._validador = raiz
+    interp.contextos = [ContextoFalso()]
+
+    interp._inyectar_simbolos_usar_en_contexto([("existe", object())], modulo="archivo")
+
+    assert validador_objetivo.registrados == ["existe"]
+
+
 def test_cli_default_mantiene_modo_seguro_y_fallback_inseguro_deshabilitado():
     app = CliApplication()
     app.initialize()


### PR DESCRIPTION
### Motivation
- Arreglar una regresión en la que, con `auditoria.activa = true`, los símbolos inyectados por `usar` no llegaban a `ValidadorPrimitivaPeligrosa` porque solo se llamaba `registrar_simbolo_publico_usar` en la raíz de la cadena. 
- Permitir que el wrapper público `existe` proporcionado por `usar "archivo"` funcione en `safe_mode` cuando la ruta cumple la política, sin habilitar primitivas arbitrarias peligrosas.

### Description
- Añadido `_registrar_simbolo_publico_usar_en_cadena` en `src/pcobra/core/interpreter.py` para recorrer la cadena de validadores via `siguiente` y llamar `registrar_simbolo_publico_usar` en cualquier validador que lo implemente. 
- `_inyectar_simbolos_usar_en_contexto` ahora usa el nuevo helper cuando `safe_mode` está activo, en lugar de invocar el método únicamente en la raíz. 
- Añadido un test de regresión en `tests/unit/test_safe_mode.py` que simula un validador raíz sin registro seguido por uno que sí lo implementa y verifica que `existe` queda registrado en el validador downstream.

### Testing
- Ejecuté `pytest -q tests/unit/test_safe_mode.py -k "registro_simbolo_usar_recorrer_cadena_validadores or existe_publico_desde_usar_acepta_ruta_relativa"` y la recolección falló con `ImportError: attempted relative import beyond top-level package`. 
- Intentos adicionales para ejecutar con `PYTHONPATH=src pytest ...` en este entorno también fallaron por problemas de importación/colección, por lo que los tests añadidos no pudieron completarse aquí. 
- El cambio es limitado a `src/pcobra/core/interpreter.py` y `tests/unit/test_safe_mode.py` y requiere ejecutar la suite en un entorno con el layout de paquete correcto (por ejemplo `PYTHONPATH=src` o instalación del paquete) para validar los tests automáticamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a041aba80288327b1dec0a029e23491)