### PR TITLE
[PR #2506 follow-up] Permitir constantes públicas canónicas en modo estricto Cobra-facing

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -150,7 +150,12 @@ def sanear_simbolo_para_usar(
     if not callable(simbolo) and nombre not in NOMBRES_CONSTANTES_PUBLICAS_CANONICAS:
         return _rechazar(nombre, simbolo, "non_callable_not_canonical_public_constant", "solo se permiten no-callables para constantes públicas explícitas y canónicas", metadata)
 
-    if politica_efectiva.validar_nombre_canonico_espanol_en_cobra_facing and modulo_cobra_facing and not _parece_nombre_canonico_espanol(nombre):
+    if (
+        politica_efectiva.validar_nombre_canonico_espanol_en_cobra_facing
+        and modulo_cobra_facing
+        and nombre not in NOMBRES_CONSTANTES_PUBLICAS_CANONICAS
+        and not _parece_nombre_canonico_espanol(nombre)
+    ):
         return _rechazar(
             nombre,
             simbolo,

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -117,6 +117,22 @@ def test_modo_estricto_cobra_facing_permite_nombres_canonicos():
     assert resultado.codigo == "ok"
 
 
+def test_modo_estricto_cobra_facing_permite_constantes_publicas_canonicas():
+    politica = PoliticaSaneamientoUsar(validar_nombre_canonico_espanol_en_cobra_facing=True)
+
+    for nombre in ("PI", "E", "TAU", "INF", "NAN"):
+        resultado = sanear_simbolo_para_usar(
+            nombre,
+            1.0,
+            politica=politica,
+            modulo_cobra_facing=True,
+        )
+
+        assert resultado.rechazado is False
+        assert resultado.codigo == "public_constant"
+        assert resultado.warning is True
+
+
 def test_constantes_publicas_canonicas_explicitas_se_permiten():
     for nombre in ("PI", "E", "TAU", "INF", "NAN"):
         resultado = sanear_simbolo_para_usar(nombre, 1.0)


### PR DESCRIPTION
### Motivation
- Corregir una regresión P1 donde el modo estricto Cobra-facing (`validar_nombre_canonico_espanol_en_cobra_facing=True`) rechazaba las constantes públicas canónicas explícitas (`PI`, `E`, `TAU`, `INF`, `NAN`).
- Mantener la intención de la política de bloquear nombres no canónicos y objetos backend mientras se permiten expresamente esas constantes no-callable.

### Description
- Ajustada la condición en `sanear_simbolo_para_usar` para que la validación estricta en módulos Cobra-facing excluya los nombres en `NOMBRES_CONSTANTES_PUBLICAS_CANONICAS` antes de rechazar por `non_canonical_spanish_name`.
- Añadida la prueba `test_modo_estricto_cobra_facing_permite_constantes_publicas_canonicas` en `tests/unit/test_usar_symbol_policy.py` que verifica que las constantes canónicas siguen clasificándose como `public_constant` con `warning=True` en modo estricto.
- Cambios realizados en `src/pcobra/core/usar_symbol_policy.py` y `tests/unit/test_usar_symbol_policy.py` para implementar y cubrir la corrección.

### Testing
- Ejecutado `pytest -q tests/unit/test_usar_symbol_policy.py` y pasó con `13 passed, 1 warning`.
- Las pruebas nuevas y existentes validan que el modo estricto sigue rechazando nombres no canónicos mientras permite las constantes públicas canónicas (todos los asserts relevantes pasan).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0483803d708327ad58e71da56bb2a0)