### PR TITLE
Follow-up: fix function descriptor fixture keys in REPL usar test

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -539,8 +539,8 @@ def test_repl_usar_numero_callables_policy_funcion_usuario_e_imprimir(monkeypatc
 
     funcion_usuario = {
         "tipo": "funcion",
-        "params": ["x"],
-        "body": ["retornar x + 1"],
+        "parametros": ["x"],
+        "cuerpo": ["retornar x + 1"],
     }
     interp.contextos[-1].define("incrementar", funcion_usuario)
     llamada_usuario = NodoLlamadaFuncion("incrementar", [NodoValor(41)])


### PR DESCRIPTION
### Motivation

- Fix a high-priority test-fixture mismatch in `tests/unit/test_usar.py` where a user-defined function descriptor used non-canonical keys that would raise a `KeyError` in `InterpretadorCobra.ejecutar_llamada_funcion` and prevent the test from exercising the intended execution path.

### Description

- Updated the user-function fixture in `tests/unit/test_usar.py` to use the canonical descriptor keys expected by the interpreter by changing `"params"` -> `"parametros"` and `"body"` -> `"cuerpo"`, so `tipo == "funcion"` descriptors are handled correctly at runtime.

### Testing

- Ran `python -m pytest -q tests/unit/test_usar.py -k repl_usar_numero_callables_policy_funcion_usuario_e_imprimir` which still fails during collection due to an environment import error (`ImportError: attempted relative import beyond top-level package`), and the KeyError the fixture would have triggered is eliminated by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0485c470288327857b7b027cff4a40)