### PR TITLE
Fix explicit_forbidden_name regression in usar symbol policy

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -34,6 +34,7 @@ EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS = {
 }
 
 NOMBRES_PROHIBIDOS_EXPLICITOS = frozenset(EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS)
+NOMBRES_CON_EQUIVALENTE_PUBLICO = frozenset({"Holobit", "holobit_sdk"})
 DUNDERS_BLOQUEADOS = frozenset(
     {"__builtins__", "__loader__", "__package__", "__spec__", "__name__"}
 )
@@ -147,7 +148,7 @@ def sanear_simbolo_para_usar(
         return _rechazar(nombre, simbolo, "backend_internal_name", "nombre interno del backend bloqueado", metadata)
 
     if nombre in NOMBRES_PROHIBIDOS_EXPLICITOS:
-        codigo = "cobra_public_equivalent" if nombre in EQUIVALENCIAS_PROHIBIDAS_A_CANONICAS else "explicit_forbidden_name"
+        codigo = "cobra_public_equivalent" if nombre in NOMBRES_CON_EQUIVALENTE_PUBLICO else "explicit_forbidden_name"
         return _rechazar(nombre, simbolo, codigo, _mensaje_nombre_prohibido(nombre), metadata)
 
     if not callable(simbolo) and nombre not in NOMBRES_CONSTANTES_PUBLICAS_CANONICAS:


### PR DESCRIPTION
### Motivation
- Restore the original rejection contract so explicit forbidden aliases (e.g., `self`, `append`, `map`) continue to emit `explicit_forbidden_name` while still returning `cobra_public_equivalent` for SDK-specific names that map to a public canonical symbol.

### Description
- Add `NOMBRES_CON_EQUIVALENTE_PUBLICO = frozenset({"Holobit", "holobit_sdk"})` and update the rejection branch in `sanear_simbolo_para_usar` to select `codigo` based on membership in that new set, preserving `explicit_forbidden_name` for other explicit forbiddens.

### Testing
- Ran `pytest -q tests/unit/test_usar_symbol_policy.py` and observed `12 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05638061508327a9b2009da2770622)