### PR TITLE
Follow-up: fix es_nan(math.nan) test setup parsing in PR #2548

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -257,7 +257,7 @@ def test_repl_usar_numero_ejecuta_callable_runtime_es_nan_con_math_nan(monkeypat
 
     monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda nombre, **_kwargs: modulo_numero)
     # Caso explícito: validar es_nan(math.nan) en runtime.
-    interp = _ejecutar_codigo('usar \"numero\"\nes_nan(math.nan)')
+    interp = _ejecutar_codigo('usar \"numero\"\nes_nan(0)')
 
     llamada = NodoLlamadaFuncion("es_nan", [NodoValor(math.nan)])
     assert interp.ejecutar_llamada_funcion(llamada) is True


### PR DESCRIPTION
### Motivation
- Prevent the test from failing during lexing/parsing by avoiding dot access in the Cobra source snippet while preserving the intended runtime assertion for `es_nan`.

### Description
- Updated `tests/unit/test_usar.py` so the Cobra setup in `test_repl_usar_numero_ejecuta_callable_runtime_es_nan_con_math_nan` uses `es_nan(0)` instead of `es_nan(math.nan)`, and retained the runtime invocation `NodoValor(math.nan)` to validate the `es_nan` runtime behavior.

### Testing
- Ran `pytest -q tests/unit/test_usar.py -k 'es_nan_con_math_nan or es_nan_con_entero'`, but test collection aborted with `ImportError: attempted relative import beyond top-level package`, which is an environment/import issue unrelated to the change, so the updated test is committed and syntactically correct but could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0565a13cf48327ade6a2ed7da76ed4)