### PR TITLE
Follow-up: fix texto runtime callable coverage to use exported symbol

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -278,7 +278,7 @@ def test_repl_usar_texto_ejecuta_callables_runtime_basicos(monkeypatch):
     import pcobra.corelibs.texto as modulo_texto
 
     monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_texto)
-    interp = _ejecutar_codigo('usar "texto"\nrecortar("  cobra  ")')
+    interp = _ejecutar_codigo('usar "texto"\nprefijo_comun("cobra", "cobre")')
 
     assert interp.obtener_variable("recortar")("  cobra  ") == "cobra"
     assert interp.obtener_variable("repetir")("ja", 3) == "jajaja"


### PR DESCRIPTION
### Motivation
- Ensure the runtime coverage test for `usar "texto"` only invokes callables that the module actually exports via `__all__`, so `sanitizar_exports_publicos` injects the expected names and the test cannot fail deterministically.

### Description
- Updated the test in `tests/unit/test_usar.py` to use an exported bootstrap call: replaced `recortar("  cobra  ")` (non-exported) with `prefijo_comun("cobra", "cobre")` so the test exercises injected names that appear in `pcobra.corelibs.texto.__all__`.

### Testing
- Ran the focused test collection with `pytest -q tests/unit/test_usar.py -k "texto_ejecuta_callables_runtime_basicos"` and it failed during collection due to an existing import-path issue (`ImportError: attempted relative import beyond top-level package`), which is unrelated to this test change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05692894688327b34798323ce21c19)