### PR TITLE
fix(ci): restrict protected-file diff guard to pull_request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         run: python scripts/validate_targets_policy.py
 
       - name: Guard protected lexer/parser files unchanged in `usar` fix scope (blocking)
+        if: github.event_name == 'pull_request'
         shell: bash
         run: |
           git diff --name-only origin/${{ github.base_ref }}...HEAD | tee /tmp/changed_files.txt


### PR DESCRIPTION
### Motivation
- Prevent CI failures caused by running `git diff --name-only origin/${{ github.base_ref }}...HEAD` on non-PR events where `github.base_ref` is empty, which produced invalid revision errors and blocked the pipeline.

### Description
- Add a step-level guard `if: github.event_name == 'pull_request'` to the "Guard protected lexer/parser files unchanged in `usar` fix scope (blocking)" step in `.github/workflows/ci.yml` so the protected-file diff runs only for pull requests.

### Testing
- No automated tests were run for this YAML-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a056eec3a388327a900665616810eaa)