### PR TITLE
Fix `usar_loader` monkeypatch scope leak in regression tests

### DIFF
--- a/tests/integration/test_usar_runtime_contract.py
+++ b/tests/integration/test_usar_runtime_contract.py
@@ -9,7 +9,6 @@ import pytest
 from pcobra.cobra.core.runtime import InterpretadorCobra
 from pcobra.cobra.usar_policy import USAR_RUNTIME_EXPORT_OVERRIDES
 from pcobra.core import usar_symbol_policy
-from pcobra.cobra import usar_loader as cobra_usar_loader
 
 
 def _nodo(modulo: str):
@@ -29,8 +28,8 @@ def test_holobit_export_only_runtime_override(monkeypatch):
     mod._to_sdk_holobit = lambda *_: None
     mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/holobit.py"
 
-    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: mod)
-    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: mod)
+    monkeypatch.setattr("pcobra.core.usar_loader.obtener_modulo_cobra_oficial", lambda _nombre: mod)
+    monkeypatch.setattr("pcobra.core.usar_loader.obtener_modulo", lambda _nombre, **_kwargs: mod)
 
     interp = InterpretadorCobra()
     interp.configurar_restriccion_usar_repl({"holobit": "holobit"})
@@ -106,8 +105,8 @@ def test_texto_simbolo_existente_fuera_de_override_falla_como_no_declarado(monke
     mod.normalizar_unicode = lambda texto, forma="NFC": texto
     mod.__file__ = "/workspace/pCobra/src/pcobra/standard_library/texto.py"
 
-    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: mod)
-    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: mod)
+    monkeypatch.setattr("pcobra.core.usar_loader.obtener_modulo_cobra_oficial", lambda _nombre: mod)
+    monkeypatch.setattr("pcobra.core.usar_loader.obtener_modulo", lambda _nombre, **_kwargs: mod)
 
     interp = InterpretadorCobra()
     interp.configurar_restriccion_usar_repl({"texto": "texto"})
@@ -142,8 +141,8 @@ def test_usar_datos_expone_longitud(monkeypatch):
     mod.longitud = lambda valores: len(valores)
     mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/datos.py"
 
-    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: mod)
-    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: mod)
+    monkeypatch.setattr("pcobra.core.usar_loader.obtener_modulo_cobra_oficial", lambda _nombre: mod)
+    monkeypatch.setattr("pcobra.core.usar_loader.obtener_modulo", lambda _nombre, **_kwargs: mod)
 
     interp = InterpretadorCobra()
     interp.configurar_restriccion_usar_repl({"datos": "datos"})
@@ -161,8 +160,8 @@ def test_usar_texto_expone_recortar_repetir_quitar_acentos(monkeypatch):
     mod.quitar_acentos = lambda texto: str(texto).translate(str.maketrans("áéíóú", "aeiou"))
     mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/texto.py"
 
-    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: mod)
-    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: mod)
+    monkeypatch.setattr("pcobra.core.usar_loader.obtener_modulo_cobra_oficial", lambda _nombre: mod)
+    monkeypatch.setattr("pcobra.core.usar_loader.obtener_modulo", lambda _nombre, **_kwargs: mod)
 
     interp = InterpretadorCobra()
     interp.configurar_restriccion_usar_repl({"texto": "texto"})
@@ -179,8 +178,8 @@ def test_usar_numero_mantiene_es_finito_y_signo(monkeypatch):
     mod.signo = lambda valor: -1 if valor < 0 else (1 if valor > 0 else 0)
     mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/numero.py"
 
-    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: mod)
-    monkeypatch.setattr(cobra_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: mod)
+    monkeypatch.setattr("pcobra.core.usar_loader.obtener_modulo_cobra_oficial", lambda _nombre: mod)
+    monkeypatch.setattr("pcobra.core.usar_loader.obtener_modulo", lambda _nombre, **_kwargs: mod)
 
     interp = InterpretadorCobra()
     interp.configurar_restriccion_usar_repl({"numero": "numero"})


### PR DESCRIPTION
### Motivation

- Prevent order-dependent test leakage caused by monkeypatching the wrong `usar_loader` namespace which made tests capture a mocked function permanently when imports occurred with `from ... import *`. 
- Ensure the new `usar` runtime regression tests and the static lexer/parser integrity check do not introduce cross-test state breaks.

### Description

- Replaced module-object monkeypatch targets with string-based targets under `pcobra.core.usar_loader` for `obtener_modulo_cobra_oficial` and `obtener_modulo` so patches apply to the namespace actually used by `InterpretadorCobra.ejecutar_usar`. 
- Applied the new patching strategy consistently across all relevant tests in `tests/integration/test_usar_runtime_contract.py`. 
- Removed the now-unused import `from pcobra.cobra import usar_loader as cobra_usar_loader` from the test file.

### Testing

- Ran a targeted test selection with `python -m pytest -q tests/integration/test_usar_runtime_contract.py -k 'holobit_export_only_runtime_override or usar_datos_expone_longitud or usar_texto_expone_recortar_repetir_quitar_acentos or usar_numero_mantiene_es_finito_y_signo or rechaza_numpy_en_repl_estricto_sin_inyeccion or integridad_estatica'` and the selection completed successfully (`6 passed, 4 deselected`).
- Running the entire test file previously surfaced a preexisting unrelated failure (circular import in `pcobra.standard_library.texto`) which was not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a056fa1f6a48327bdbac8a7bdd635da)