### PR TITLE
[Follow-up] Restore runtime-safe canonical path for `numero` in `usar` policy

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -37,8 +37,8 @@ USAR_COBRA_FACING_MODULE_FLAGS: dict[str, bool] = {
 }
 
 _USAR_CANONICAL_INTERNAL_PATHS: dict[str, str] = {
-    # `numero` expone el contrato runtime de `usar` desde standard_library.
-    "numero": "src/pcobra/standard_library/numero.py",
+    # `numero` debe cargar desde corelibs para evitar ciclos de importación en runtime.
+    "numero": "src/pcobra/corelibs/numero.py",
     # `texto` y `datos` exponen su API pública real desde standard_library.
     "texto": "src/pcobra/standard_library/texto.py",
     "datos": "src/pcobra/standard_library/datos.py",


### PR DESCRIPTION
### Motivation
- Evitar un ciclo de importación en tiempo de ejecución que provocaba `ImportError` al cargar `usar numero` al apuntar `numero` a `src/pcobra/standard_library/numero.py` en lugar de la implementación segura en `corelibs`.

### Description
- Cambia la entrada `_USAR_CANONICAL_INTERNAL_PATHS['numero']` para resolver a `src/pcobra/corelibs/numero.py` y actualiza el comentario inline para documentar que esto evita ciclos de importación durante `obtener_modulo_cobra_oficial`.

### Testing
- Ejecuté un chequeo de humo en runtime con `from pcobra.cobra.usar_loader import obtener_modulo_cobra_oficial` y `obtener_modulo_cobra_oficial("numero")`, que cargó el módulo correctamente y confirmó la presencia de la función `absoluto`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0578cc26a08327888d2c89db7f8ad4)