### PR TITLE
[PR #2578 follow-up] Fix `usar` idempotency when symbol was reassigned

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2084,6 +2084,34 @@ class InterpretadorCobra:
                 raise PermissionError(mensaje) from exc
             raise
 
+    def _es_reimport_idempotente_usar(
+        self,
+        *,
+        contexto_actual: Environment,
+        modulo: str,
+        nombre: str,
+        simbolo: object,
+    ) -> bool:
+        """Valida si un símbolo ya enlazado corresponde al mismo import previo de ``usar``."""
+        previo = self._usar_symbol_metadata.get(nombre)
+        if not previo:
+            return False
+
+        if (
+            previo.get("module") != modulo
+            or previo.get("exported_name") != nombre
+            or previo.get("callable_id") != id(simbolo)
+        ):
+            return False
+
+        try:
+            valor_actual = contexto_actual.get(nombre)
+        except NameError:
+            return False
+
+        # Evita falsos no-op cuando el usuario reasignó el símbolo en runtime.
+        return valor_actual is simbolo
+
     def _detectar_conflictos_usar_en_contexto(
         self, simbolos_saneados: list[tuple[str, object]], modulo: str
     ) -> list[str]:
@@ -2093,15 +2121,13 @@ class InterpretadorCobra:
         for nombre, simbolo in simbolos_saneados:
             if not contexto_actual.contains(nombre):
                 continue
-            previo = self._usar_symbol_metadata.get(nombre)
-            identidad_actual = id(simbolo)
-            if (
-                previo
-                and previo.get("module") == modulo
-                and previo.get("exported_name") == nombre
-                and previo.get("callable_id") == identidad_actual
+            if self._es_reimport_idempotente_usar(
+                contexto_actual=contexto_actual,
+                modulo=modulo,
+                nombre=nombre,
+                simbolo=simbolo,
             ):
-                # Reimport idempotente: mismo símbolo, mismo módulo origen y misma identidad.
+                # Reimport idempotente: mismo símbolo, mismo módulo origen y mismo binding activo.
                 continue
             conflictos.append(nombre)
         if conflictos:
@@ -2122,13 +2148,11 @@ class InterpretadorCobra:
         contexto_actual = self.contextos[-1]
         for nombre, simbolo in simbolos_saneados:
             if contexto_actual.contains(nombre) and not permitir_sobrescritura:
-                previo = self._usar_symbol_metadata.get(nombre)
-                identidad_actual = id(simbolo)
-                if (
-                    previo
-                    and previo.get("module") == modulo
-                    and previo.get("exported_name") == nombre
-                    and previo.get("callable_id") == identidad_actual
+                if self._es_reimport_idempotente_usar(
+                    contexto_actual=contexto_actual,
+                    modulo=modulo,
+                    nombre=nombre,
+                    simbolo=simbolo,
                 ):
                     # No-op idempotente: evita warning/ruido al reimportar lo mismo.
                     continue

--- a/tests/unit/test_usar_runtime_policy.py
+++ b/tests/unit/test_usar_runtime_policy.py
@@ -169,6 +169,21 @@ def test_usar_runtime_reimport_idempotente_numero_no_falla(monkeypatch):
     assert "es_finito" in interp.variables
 
 
+
+
+def test_usar_runtime_reimport_detecta_reasignacion_usuario_como_colision(monkeypatch):
+    import pcobra.corelibs.numero as modulo_numero
+
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _n, **_k: modulo_numero)
+    interp = _interp_con_alias({"numero": "numero"})
+
+    interp.ejecutar_nodo(NodoUsar("numero"))
+    interp.contextos[-1].define("es_finito", "valor_usuario")
+
+    with pytest.raises(NameError, match="conflicto de símbolos"):
+        interp.ejecutar_nodo(NodoUsar("numero"))
+
+
 def test_usar_runtime_colision_variable_usuario_sigue_fallando(monkeypatch):
     import pcobra.corelibs.numero as modulo_numero
 


### PR DESCRIPTION
### Motivation
- Prevent stale `usar` metadata from causing false idempotent no-ops when a user has reassigned a previously imported symbol. 
- Preserve the strict collision policy so genuine user-defined bindings still raise collisions. 
- Centralize and harden the idempotency check to avoid future regressions around `usar` reimports.

### Description
- Added helper `InterpretadorCobra._es_reimport_idempotente_usar(...)` that verifies both stored metadata (`module`, `exported_name`, `callable_id`) and that the active context binding still points to the same callable (`contexto_actual.get(nombre) is simbolo`).
- Updated preflight conflict detection `InterpretadorCobra._detectar_conflictos_usar_en_contexto` to use the new helper so reimports are ignored only when the active binding truly matches the prior import.
- Updated runtime injection `InterpretadorCobra._inyectar_simbolos_usar_en_contexto` to use the new helper, preserving the collision error when the symbol was reassigned by user code.
- Added regression test `test_usar_runtime_reimport_detecta_reasignacion_usuario_como_colision` in `tests/unit/test_usar_runtime_policy.py` that imports `numero`, reassigns `es_finito` in the context, and asserts a subsequent `usar

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a057c79fa048327bed9b9a77b5a26c5)