### PR TITLE
Fix regression in `usar numero` runtime exports

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -181,6 +181,8 @@ USAR_RUNTIME_EXPORT_OVERRIDES: dict[str, tuple[str, ...]] = {
         "redondear",
         "piso",
         "techo",
+        "aleatorio",
+        "aleatorio_entero",
         "mcd",
         "mcm",
         "es_cercano",


### PR DESCRIPTION
### Motivation
- Prevent a high-priority runtime regression where `usar numero` would stop exporting random helpers required by existing Cobra programs by aligning runtime export overrides with the canonical `numero` surface.

### Description
- Updated `USAR_RUNTIME_EXPORT_OVERRIDES` in `src/pcobra/cobra/usar_policy.py` to re-add the missing runtime exports `aleatorio` and `aleatorio_entero` so `usar numero` continues to expose the expected symbols.

### Testing
- Ran `python -m compileall -q src/pcobra/cobra/usar_policy.py` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0581a7d22c8327a2bb74d1d96a8f41)