### PR TITLE
fix: capturar traza debug de sanitización desde stdout en tests de `usar`

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -1084,6 +1084,7 @@ def test_usar_muestra_detalle_extendido_en_debug(monkeypatch, caplog):
 
     monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
     monkeypatch.setenv("PCOBRA_DEBUG_RUNTIME", "1")
+    monkeypatch.setenv("PCOBRA_DEBUG_TRACES", "1")
 
     interp = InterpretadorCobra()
     interp.configurar_restriccion_usar_repl({"texto": "texto"})
@@ -1146,7 +1147,7 @@ def test_usar_warning_conflictos_saneamiento_formato_compacto(monkeypatch, caplo
     assert "{'symbol'" not in warning
 
 
-def test_usar_warning_conflictos_saneamiento_detalle_solo_debug(monkeypatch, caplog):
+def test_usar_warning_conflictos_saneamiento_detalle_solo_debug(monkeypatch, caplog, capsys):
     modulo = ModuleType("texto")
     modulo.__all__ = ["A_snake", "a_snake"]
     modulo.A_snake = lambda texto: texto
@@ -1155,6 +1156,7 @@ def test_usar_warning_conflictos_saneamiento_detalle_solo_debug(monkeypatch, cap
 
     monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
     monkeypatch.setenv("PCOBRA_DEBUG_RUNTIME", "1")
+    monkeypatch.setenv("PCOBRA_DEBUG_TRACES", "1")
 
     interp = InterpretadorCobra()
     interp.configurar_restriccion_usar_repl({"texto": "texto"})
@@ -1170,9 +1172,7 @@ def test_usar_warning_conflictos_saneamiento_detalle_solo_debug(monkeypatch, cap
     assert "count=2" in warning
     assert "conflicts=[" not in warning
 
-    trazas_debug = [
-        rec.message for rec in caplog.records if "[USAR_SANITIZE][CONFLICTS]" in rec.message
-    ]
-    assert trazas_debug
-    assert "'conflicts':" in trazas_debug[-1]
+    salida_debug = capsys.readouterr().out
+    assert "[USAR_SANITIZE][CONFLICTS]" in salida_debug
+    assert "'conflicts':" in salida_debug
 


### PR DESCRIPTION
### Motivation
- Corregir una aserción errónea en los tests que intentaba hallar la traza debug emitida por `InterpretadorCobra._trace_debug()` en `caplog`, cuando dicha traza se imprime por `print` y sólo está activa con `PCOBRA_DEBUG_TRACES`.

### Description
- Actualiza `tests/unit/test_usar.py` cambiando la firma del test `test_usar_warning_conflictos_saneamiento_detalle_solo_debug` para aceptar `capsys`, activa `PCOBRA_DEBUG_TRACES=1` en el test y reemplaza la búsqueda de la traza en `caplog` por `capsys.readouterr().out` para capturar la salida estándar donde se emite la traza debug.

### Testing
- Ejecutado `PYTHONPATH=src pytest -q tests/unit/test_usar.py -k "warning_conflictos_saneamiento_detalle_solo_debug"` y la colección de pytest falló en este entorno por un `ImportError: attempted relative import beyond top-level package`, por lo que la verificación del test modificado no pudo completarse aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06cbc1459883278a74855dc3a5c96f)