### PR TITLE
[PR #2623 follow-up] Fix Windows drive traversal bypass in archivo.existe

### DIFF
--- a/src/pcobra/corelibs/archivo.py
+++ b/src/pcobra/corelibs/archivo.py
@@ -80,6 +80,8 @@ def existe(ruta: PathLike) -> bool:
     try:
         objetivo = Path(ruta)
         if objetivo.is_absolute() or _es_ruta_absoluta_o_sensible_windows(ruta):
+            if ".." in objetivo.parts:
+                raise ValueError("La ruta no puede contener '..'")
             base = Path(os.environ.get("COBRA_IO_BASE_DIR") or Path.cwd()).resolve()
             destino = objetivo.resolve()
             destino.relative_to(base)

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -685,6 +685,14 @@ def test_archivo_existe_rechaza_fuera_del_sandbox(monkeypatch, tmp_path):
     assert not core.existe("../fuera.txt")
 
 
+
+
+def test_archivo_existe_rechaza_drive_windows_con_traversal(monkeypatch, tmp_path):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    (tmp_path / "secret").write_text("x", encoding="utf-8")
+
+    assert not core.existe("C:/../secret")
+
 def test_archivo_eliminar_inexistente_no_falla(monkeypatch, tmp_path):
     monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
     core.eliminar("no-existe.txt")


### PR DESCRIPTION
### Motivation

- Evitar un bypass de la política de rutas cuando `existe()` recibe rutas con formato Windows (por ejemplo `"C:/../secret"`) que eran normalizadas por `resolve()` y eludían la denegación previa de segmentos `..`.

### Description

- En `src/pcobra/corelibs/archivo.py` se añade una comprobación que rechaza explícitamente `".."` en `Path.parts` para la rama de rutas absolutas / estilo Windows de `existe()`, y se añade el test de regresión `test_archivo_existe_rechaza_drive_windows_con_traversal` en `tests/unit/test_corelibs.py` para asegurar que `core.existe("C:/../secret")` devuelve `False`.

### Testing

- Ejecuté `PYTHONPATH=src pytest -q tests/unit/test_archivo.py` y los tests relevantes pasaron (`5 passed`).
- Intenté ejecutar `PYTHONPATH=src pytest -q tests/unit/test_corelibs.py -k "archivo_existe_rechaza_fuera_del_sandbox or archivo_existe_rechaza_drive_windows_con_traversal"` pero la recolección falló por un problema de importación circular preexistente (`ImportError: cannot import name 'grupo_tareas' from partially initialized module 'pcobra.corelibs'`), que no está introducido por este cambio; la nueva prueba de regresión fue añadida y está localizada para cuando la colección de tests funcione en el entorno de CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06cffdb8688327a6042c2d2dbff2c7)