### PR TITLE
Restore RuntimeWarning contract for `usar` alias collisions

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import hashlib
+import warnings
 from typing import Mapping, Optional
 
 from .lexer import (
@@ -2067,15 +2068,19 @@ class InterpretadorCobra:
                     "phase": "preflight",
                 }
                 if self._usar_collision_policy == USAR_COLLISION_WARN_ALIAS_REQUIRED:
-                    logging.warning(
-                        "WARNING: %s module=%s count=%s",
-                        formatear_error_usar_usuario(
-                            "conflicto_simbolo",
+                    warnings.warn(
+                        "WARNING: %s module=%s count=%s"
+                        % (
+                            formatear_error_usar_usuario(
+                                "conflicto_simbolo",
+                                nodo.modulo,
+                                "Use alias explícito para resolver la colisión.",
+                            ),
                             nodo.modulo,
-                            "Use alias explícito para resolver la colisión.",
+                            len(conflictos),
                         ),
-                        nodo.modulo,
-                        len(conflictos),
+                        RuntimeWarning,
+                        stacklevel=2,
                     )
                     mensaje_usuario = formatear_error_usar_usuario(
                         "conflicto_simbolo",


### PR DESCRIPTION
### Motivation
- Restore the public warning contract broken by switching from `warnings.warn(..., RuntimeWarning)` to `logging.warning(...)` for `warn_alias_required` in `InterpretadorCobra.ejecutar_usar`, because callers must be able to catch/suppress the event via Python warnings.
- Preserve the compact, predictable warning format for CLI/REPL output while reinstating compatibility with `pytest.warns(...)` and user warning filters.

### Description
- Reintroduced `import warnings` and replaced the `logging.warning` call with `warnings.warn(..., RuntimeWarning, stacklevel=2)` in `src/pcobra/core/interpreter.py` for the `USAR_COLLISION_WARN_ALIAS_REQUIRED` branch.
- Built a single-line compact warning string that includes `module=` and `count=` so output remains predictable for users and tools.
- Kept the existing `logging.error` paths and `_usar_detalle_habilitado()` debug trace behavior unchanged.
- The related regression test `test_usar_warning_colision_alias_formato_compacto` was added in the original change to assert format and emission as a `RuntimeWarning`.

### Testing
- Ran `pytest -q tests/unit/test_usar.py -k "warning_colision_alias_formato_compacto or warning_conflictos_saneamiento or no_muestra_traceback"`, but test collection failed with `ImportError: attempted relative import beyond top-level package`, so the new test could not be executed in this environment.
- No further automated tests were run in this follow-up; the change is small and focused on restoring the warning emission behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d12a317483278b72e58719d9c3d2)