### PR TITLE
Fix holobits.transformar to preserve transformed values (rotar/z)

### DIFF
--- a/src/pcobra/core/holobits/__init__.py
+++ b/src/pcobra/core/holobits/__init__.py
@@ -101,6 +101,21 @@ def proyectar(hb: dict[str, Any], modo: str) -> dict[str, Any]:
 def transformar(hb: dict[str, Any], operacion: str, *parametros: Any) -> dict[str, Any]:
     interno = _desde_estructura_cobra(hb)
     _transformar_sdk(interno, operacion, *parametros)
+
+    op = str(operacion).strip().lower()
+    if op == "rotar" and len(parametros) >= 2:
+        eje = str(parametros[0]).strip().lower()
+        angulo = float(parametros[1])
+        valores = list(interno.valores)
+        if eje == "z" and len(valores) >= 2:
+            import math
+
+            rad = math.radians(angulo)
+            x, y = valores[0], valores[1]
+            valores[0] = x * math.cos(rad) - y * math.sin(rad)
+            valores[1] = x * math.sin(rad) + y * math.cos(rad)
+            interno = _Holobit(valores)
+
     return _a_estructura_cobra(interno)
 
 


### PR DESCRIPTION
### Motivation

- Restore the original Cobra-facing behavior of `transformar` where the function returns the updated holobit values after a transformation, avoiding a regression that returned unmodified values when delegation went through the SDK. 
- Ensure `rotar` transformations (particularly around the `z` axis) produce a normalized Cobra payload that callers can consume without relying on SDK internals.

### Description

- Updated `src/pcobra/core/holobits/__init__.py` `transformar` to still delegate to `_transformar_sdk` but then inspect the operation and parameters; for `rotar` on the `z` axis it computes the rotated 2D coordinates, reconstructs the local `_Holobit` from the new values, and returns the Cobra-structure built from that updated object. 
- Kept the SDK delegation path intact so environments with `holobit_sdk` remain supported while ensuring the public JSON contract reflects any effective local rotation.

### Testing

- Ran `pytest -q tests/unit/test_corelibs_holobit_adapter.py tests/unit/test_holobit_no_fuga_exports.py` to validate adapter behavior and public API exports. 
- Result: `19 passed, 1 warning` (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d2554a6083279077b24bbe2ea64f)