### PR TITLE
[PR #2656 Follow-up] Export `normalizar_unicode` in `usar "texto"` runtime surface

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -295,6 +295,7 @@ USAR_RUNTIME_EXPORT_OVERRIDES: dict[str, tuple[str, ...]] = {
         "recortar",
         "repetir",
         "quitar_acentos",
+        "normalizar_unicode",
     ),
     "datos": (
         "leer_csv",

--- a/tests/integration/test_usar_runtime_contract.py
+++ b/tests/integration/test_usar_runtime_contract.py
@@ -98,7 +98,7 @@ def test_rechaza_numpy_en_repl_estricto_sin_inyeccion(monkeypatch):
     assert estado_pre == interp.contextos[-1].values
 
 
-def test_texto_simbolo_existente_fuera_de_override_falla_como_no_declarado(monkeypatch):
+def test_texto_simbolo_canonico_normalizar_unicode_se_exporta(monkeypatch):
     mod = ModuleType("texto")
     mod.__all__ = [*USAR_RUNTIME_EXPORT_OVERRIDES["texto"], "normalizar_unicode"]
     for name in USAR_RUNTIME_EXPORT_OVERRIDES["texto"]:
@@ -113,12 +113,11 @@ def test_texto_simbolo_existente_fuera_de_override_falla_como_no_declarado(monke
     interp.configurar_restriccion_usar_repl({"texto": "texto"})
     interp.ejecutar_usar(_nodo("texto"))
 
-    assert "normalizar_unicode" not in interp.contextos[-1].values
-    with pytest.raises(NameError, match=r"^Variable no declarada: normalizar_unicode$"):
-        interp.contextos[-1].get("normalizar_unicode")
+    assert "normalizar_unicode" in interp.contextos[-1].values
+    assert interp.contextos[-1].get("normalizar_unicode")("Árbol", "NFC") == "Árbol"
 
 
-def test_regresion_texto_detecta_mapeo_interno_incompleto_y_filtra_fuera_de_api_publica():
+def test_regresion_texto_no_reporta_fuera_de_api_publica_para_normalizar_unicode():
     mod = ModuleType("texto")
     mod.__all__ = [*USAR_RUNTIME_EXPORT_OVERRIDES["texto"], "normalizar_unicode"]
     for name in USAR_RUNTIME_EXPORT_OVERRIDES["texto"]:
@@ -129,8 +128,8 @@ def test_regresion_texto_detecta_mapeo_interno_incompleto_y_filtra_fuera_de_api_
 
     mapa_limpio, conflictos = sanitizar_exports_publicos(mod, "texto")
 
-    assert "normalizar_unicode" not in mapa_limpio
-    assert any(
+    assert "normalizar_unicode" in mapa_limpio
+    assert not any(
         conflicto.get("symbol") == "normalizar_unicode" and conflicto.get("code") == "outside_public_api"
         for conflicto in conflictos
     )


### PR DESCRIPTION
### Motivation
- `normalizar_unicode` was omitted from `USAR_RUNTIME_EXPORT_OVERRIDES["texto"]`, causing `usar "texto"` to drop that public API symbol and trigger user-facing `NameError` regressions.
- `sanitizar_exports_publicos` only preserves symbols present in the override allowlist, so the override must include canonical symbols declared in `pcobra.corelibs.texto`.
- Restore a contract-complete, circular-import-safe runtime surface for `texto` so existing programs and tests relying on the canonical API continue to work.

### Description
- Added `"normalizar_unicode"` to `USAR_RUNTIME_EXPORT_OVERRIDES["texto"]` in `src/pcobra/cobra/usar_policy.py`.
- Updated `tests/integration/test_usar_runtime_contract.py` to assert that `normalizar_unicode` is exported and callable from the `texto` import context and that `sanitizar_exports_publicos` no longer reports it as `outside_public_api`.
- Renamed/adjusted the affected test cases and assertions to reflect the corrected runtime behavior.

### Testing
- Ran `pytest -q tests/integration/test_usar_runtime_contract.py -k texto` before the change and observed failures related to the missing export (`2 failed, 2 passed, 7 deselected`).
- After applying the fix, ran `pytest -q tests/integration/test_usar_runtime_contract.py -k texto` and the relevant tests passed (`4 passed, 7 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d364885883278e1e889b466613e0)