### PR TITLE
Harden dangerous primitive wrapper validation for archivo.existe

### DIFF
--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -48,11 +48,15 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
             self._metadata_simbolos_usar[nombre] = dict(metadata)
 
     def _es_wrapper_publico_permitido(self, nodo: NodoLlamadaFuncion) -> bool:
+        # Único escape permitido para primitivas peligrosas:
+        # usar archivo.existe con metadata de sanitización de API pública.
         if nodo.nombre != "existe":
             return False
         if ("archivo", nodo.nombre) not in self._simbolos_publicos_usar:
             return False
-        metadata = self._metadata_simbolos_usar.get(nodo.nombre, {})
+        metadata = self._metadata_simbolos_usar.get(nodo.nombre)
+        if not isinstance(metadata, dict) or not metadata:
+            return False
         origen_modulo = metadata.get("origen_modulo") or metadata.get("origin_module")
         origen_canonico = metadata.get("canonical_module")
         origen_backend = metadata.get("python_module")


### PR DESCRIPTION
### Motivation
- Evitar un bypass de las primitivas peligrosas permitiendo únicamente el wrapper público `archivo.existe` cuando exista metadata válida que confirme sanitización y marca de API pública.

### Description
- Se endureció `_es_wrapper_publico_permitido`: ahora exige que la `metadata` exista y sea un `dict` no vacío (devuelve `False` si falta o no es un `dict`), se añadió un comentario aclaratorio y se mantuvieron sin cambios `PRIMITIVAS_PELIGROSAS` y la lógica de `visit_llamada_funcion`.

### Testing
- Ejecuté `python -m pytest -q`; la corrida falló por errores preexistentes de imports/módulos en tests de integración y performance, por lo que no se detectaron fallos atribuibles a este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d905479883278899b38e66116cf9)