### PR TITLE
Alinear metadata de `usar` entre intérprete y validador

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2189,17 +2189,18 @@ class InterpretadorCobra:
                     "No se puede usar el módulo "
                     f"'{modulo}': {USAR_SYMBOL_CONFLICT_ERROR} colisión estructurada={detalle}"
                 )
-            contexto_actual.define(nombre, simbolo)
-            self._usar_symbol_metadata[nombre] = self._construir_metadata_simbolo_usar(
+            metadata_simbolo = self._construir_metadata_simbolo_usar(
                 modulo=modulo,
                 nombre_exportado=nombre,
                 simbolo=simbolo,
             )
+            contexto_actual.define(nombre, simbolo)
+            self._usar_symbol_metadata[nombre] = metadata_simbolo
             if self.safe_mode and self._validador is not None and hasattr(self._validador, "registrar_simbolo_publico_usar"):
                 self._validador.registrar_simbolo_publico_usar(
                     nombre,
                     modulo,
-                    metadata=self._usar_symbol_metadata[nombre],
+                    metadata=metadata_simbolo,
                 )
 
     def _construir_metadata_simbolo_usar(

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -103,6 +103,49 @@ def test_metadata_usar_archivo_existe_cadena_completa():
     assert metadata_validador["introduced_by_usar"] is True
 
 
+def test_usar_metadata_minima_y_consistente_entre_interprete_y_validador():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"')
+
+    interp.ejecutar_ast(ast)
+
+    requeridos = {
+        "module",
+        "origen_modulo",
+        "exported_name",
+        "is_sanitized_wrapper",
+        "public_api",
+        "introduced_by_usar",
+    }
+
+    for nombre, metadata in interp._usar_symbol_metadata.items():
+        faltantes = requeridos - set(metadata.keys())
+        assert not faltantes, f"metadata incompleta para {nombre}: {sorted(faltantes)}"
+        assert metadata["module"] == "archivo"
+        assert metadata["origen_modulo"] == "archivo"
+        assert metadata["exported_name"] == nombre
+        assert metadata["is_sanitized_wrapper"] is True
+        assert metadata["public_api"] is True
+        assert metadata["introduced_by_usar"] is True
+
+        metadata_validador = interp._validador._metadata_simbolos_usar[nombre]
+        assert metadata_validador == metadata
+
+
+def test_usar_detecta_divergencia_metadata_interprete_y_validador():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')
+
+    with patch("sys.stdout", new_callable=StringIO):
+        interp.ejecutar_ast(ast)
+
+    interp._validador._metadata_simbolos_usar["existe"]["public_api"] = False
+    ast_llamada = generar_ast('imprimir(existe("README.md"))')
+
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast_llamada)
+
+
 def test_existe_rechaza_metadata_incompleta_aunque_simbolo_este_registrado():
     interp = InterpretadorCobra()
     ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')


### PR DESCRIPTION
### Motivation
- Garantizar que cada símbolo importado por `usar` tenga la metadata mínima canónica y evitar divergencias entre el intérprete y el validador que puedan permitir bypass de políticas de seguridad.

### Description
- Refactoricé `_inyectar_simbolos_usar_en_contexto` para construir la metadata una sola vez (`metadata_simbolo`) y reutilizar exactamente ese objeto tanto en `self._usar_symbol_metadata` como al llamar `registrar_simbolo_publico_usar(...)` del validador.
- Mantengo y verifico los campos canónicos generados por `_construir_metadata_simbolo_usar`, incluyendo `module`, `origen_modulo`, `exported_name`, `is_sanitized_wrapper`, `public_api` e `introduced_by_usar` (y campos relacionados de canonicalización).
- Añadí tests unitarios en `tests/unit/test_safe_mode.py` que comprueban la presencia de los campos mínimos, la igualdad exacta entre `interp._usar_symbol_metadata` y `interp._validador._metadata_simbolos_usar`, y la detección de divergencias en el validador que deben causar `PrimitivaPeligrosaError`.
- Archivos modificados: `src/pcobra/core/interpreter.py` y `tests/unit/test_safe_mode.py`.

### Testing
- Ejecuté `pytest -q tests/unit/test_safe_mode.py`, que falló en la fase de colección con `ImportError: attempted relative import beyond top-level package`.
- Ejecuté `PYTHONPATH=src pytest -q tests/unit/test_safe_mode.py -k "metadata"`, que también falló en colección con el mismo `ImportError`.
- Las nuevas pruebas están añadidas pero no pudieron completarse en este entorno de ejecución por un problema de imports/paths; una vez resuelto el entorno de testeo (rutas de paquete), las pruebas deben ejecutarse y validar la consistencia introducida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d9fb23248327ad7bbf580cfb9ebd)