### PR TITLE
Refuerza `existe()` con validación estricta de rutas en archivo/corelibs

### DIFF
--- a/src/pcobra/corelibs/archivo.py
+++ b/src/pcobra/corelibs/archivo.py
@@ -78,16 +78,12 @@ def existe(ruta: PathLike) -> bool:
     """Indica si el archivo existe dentro del directorio permitido."""
 
     try:
-        objetivo = Path(ruta)
-        if objetivo.is_absolute() or _es_ruta_absoluta_o_sensible_windows(ruta):
-            base = Path(os.environ.get("COBRA_IO_BASE_DIR") or Path.cwd()).resolve()
-            destino = objetivo.resolve()
-            destino.relative_to(base)
-        else:
-            destino = _resolver_ruta(objetivo)
+        if not isinstance(ruta, str):
+            return False
+        destino = _resolver_ruta(ruta)
     except ValueError:
         return False
-    return destino.exists()
+    return destino.is_file()
 
 
 def eliminar(ruta: PathLike) -> None:

--- a/src/pcobra/standard_library/archivo.py
+++ b/src/pcobra/standard_library/archivo.py
@@ -10,12 +10,23 @@ from typing import Union
 PathLike = Union[str, os.PathLike[str]]
 
 
+def _es_ruta_absoluta_o_sensible_windows(ruta: PathLike) -> bool:
+    texto = str(ruta).strip()
+    if not texto:
+        return False
+    if texto.startswith("\\\\"):
+        return True
+    if len(texto) >= 2 and texto[1] == ":" and texto[0].isalpha():
+        return True
+    return False
+
+
 def _resolver_ruta(ruta: PathLike) -> Path:
     """Normaliza ``ruta`` asegurando que permanezca en un directorio seguro."""
 
     base = Path(os.environ.get("COBRA_IO_BASE_DIR") or Path.cwd()).resolve()
     objetivo = Path(ruta)
-    if objetivo.is_absolute():
+    if objetivo.is_absolute() or _es_ruta_absoluta_o_sensible_windows(ruta):
         raise ValueError("Las rutas absolutas no están permitidas")
     if ".." in objetivo.parts:
         raise ValueError("La ruta no puede contener '..'")
@@ -65,6 +76,8 @@ def existe(ruta: PathLike) -> bool:
     """Indica si el archivo existe dentro del directorio permitido."""
 
     try:
+        if not isinstance(ruta, str):
+            return False
         ruta_segura = _resolver_ruta(ruta)
     except ValueError:
         return False

--- a/tests/unit/test_archivo.py
+++ b/tests/unit/test_archivo.py
@@ -37,3 +37,28 @@ def test_archivo_rechaza_rutas_invalidas(monkeypatch, tmp_path, func, ruta):
     with pytest.raises(ValueError):
         func(ruta(tmp_path))
 
+
+@pytest.mark.parametrize("ruta", ["README.md", "./README.md"])
+def test_archivo_existe_relativa_valida(monkeypatch, tmp_path, ruta):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    (tmp_path / "README.md").write_text("ok", encoding="utf-8")
+
+    assert archivo.existe(ruta) is True
+
+
+@pytest.mark.parametrize("ruta", ["/etc/passwd", "C:\\Windows\\System32\\drivers\\etc\\hosts", "\\\\server\\share\\file.txt"])
+def test_archivo_existe_bloquea_absolutas_y_windows_unc(monkeypatch, tmp_path, ruta):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    assert archivo.existe(ruta) is False
+
+
+@pytest.mark.parametrize("ruta", ["./../secreto.txt", "a/../../secreto.txt"])
+def test_archivo_existe_bloquea_traversal(monkeypatch, tmp_path, ruta):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    assert archivo.existe(ruta) is False
+
+
+def test_archivo_existe_solo_acepta_str(monkeypatch, tmp_path):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    (tmp_path / "README.md").write_text("ok", encoding="utf-8")
+    assert archivo.existe(Path("README.md")) is False

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -7,6 +7,7 @@ import statistics as stats
 import sys
 from collections import OrderedDict
 from datetime import datetime
+from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
@@ -652,11 +653,10 @@ def test_archivo_funcs(tmp_path, monkeypatch):
     monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
     nombre = "f.txt"
     core.escribir(nombre, "data")
-    ruta = tmp_path / nombre
-    assert core.existe(ruta)
+    assert core.existe(nombre)
     assert core.leer(nombre) == "data"
-    core.eliminar(ruta)
-    assert not core.existe(ruta)
+    core.eliminar(nombre)
+    assert not core.existe(nombre)
 
 
 @pytest.mark.parametrize(
@@ -683,6 +683,32 @@ def test_archivo_existe_rechaza_fuera_del_sandbox(monkeypatch, tmp_path):
 
     assert not core.existe(str(archivo_forzado))
     assert not core.existe("../fuera.txt")
+
+
+@pytest.mark.parametrize("ruta", ["README.md", "./README.md"])
+def test_archivo_existe_relativa_valida(monkeypatch, tmp_path, ruta):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    (tmp_path / "README.md").write_text("ok", encoding="utf-8")
+
+    assert core.existe(ruta) is True
+
+
+@pytest.mark.parametrize("ruta", ["/etc/passwd", "C:\\Windows\\System32\\drivers\\etc\\hosts", "\\\\server\\share\\file.txt"])
+def test_archivo_existe_bloquea_absolutas_y_windows_unc(monkeypatch, tmp_path, ruta):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    assert core.existe(ruta) is False
+
+
+@pytest.mark.parametrize("ruta", ["./../secreto.txt", "a/../../secreto.txt"])
+def test_archivo_existe_bloquea_traversal(monkeypatch, tmp_path, ruta):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    assert core.existe(ruta) is False
+
+
+def test_archivo_existe_solo_acepta_str(monkeypatch, tmp_path):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    (tmp_path / "README.md").write_text("ok", encoding="utf-8")
+    assert core.existe(Path("README.md")) is False
 
 
 def test_archivo_eliminar_inexistente_no_falla(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Unificar y endurecer la política de validación de rutas para las APIs de archivo asegurando que `existe(ruta)` sea segura y predecible dentro del sandbox de I/O. 
- Evitar que `existe` acepte tipos inesperados o siga enlaces/rutas que salgan del directorio permitido, y mantener retorno booleano puro compatible con la impresión Cobra.

### Description
- Añadido helper `_es_ruta_absoluta_o_sensible_windows` y verificación en `_resolver_ruta` de `standard_library/archivo.py` para bloquear rutas absolutas, letras de unidad Windows y UNC.
- En `standard_library/archivo.py` y `corelibs/archivo.py` se reforzó `existe(ruta)` para aceptar únicamente `str` (devolver `False` para otros tipos) y validar/normalizar la ruta mediante `_resolver_ruta`.
- `corelibs/archivo.py` simplificó la lógica de `existe` para delegar en `_resolver_ruta` y usar `is_file()` como criterio de existencia de archivo regular.
- Añadidas pruebas en `tests/unit/test_archivo.py` y `tests/unit/test_corelibs.py` que cubren: ruta relativa válida (`README.md` y `./README.md`), bloqueo de absolutas y Windows/UNC, bloqueo de traversal directo/indirecto (`./../`, `a/../../`) y rechazo de tipos no-`str` para `existe`.
- Ajustes menores en tests existentes para usar rutas relativas en las comprobaciones coherentes con la nueva política.

### Testing
- Ejecutado el conjunto focalizado con `pytest -q tests/unit/test_archivo.py tests/unit/test_corelibs.py -k "archivo_existe or archivo_rechaza_rutas_invalidas or test_archivo_funcs or test_archivo"` y la batería final pasó con éxito (todos los tests seleccionados pasaron).
- Durante la integración inicial se detectaron 2 fallos en tests relacionados con asunciones sobre rutas absolutas y uso de `Path`; se corrigieron los tests y las implementaciones, y las re-ejecuciones automatizadas pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ddb214cc832788bce6820a7d766a)