### PR TITLE
Endurecer allowlist de `usar` en runtime y reforzar tests de sanitización

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -121,8 +121,7 @@ def validar_nombre_modulo_usar(nombre: str, *, require_allowlist: bool = True) -
 
     if require_allowlist and nombre not in USAR_COBRA_PUBLIC_MODULES:
         raise PermissionError(
-            f"Importación no permitida en 'usar': '{nombre}'. "
-            f"Solo se aceptan nombres canónicos exactos: {', '.join(USAR_COBRA_PUBLIC_MODULES)}."
+            f"usar_error[modulo_fuera_catalogo_publico]: '{nombre}' está fuera del catálogo público."
         )
 
     return nombre

--- a/tests/unit/test_usar_runtime_policy.py
+++ b/tests/unit/test_usar_runtime_policy.py
@@ -228,6 +228,55 @@ def test_validar_nombre_modulo_usar_exige_allowlist_estricta():
         usar_loader.validar_nombre_modulo_usar("mi_modulo_privado")
 
 
+def test_validar_nombre_modulo_usar_numpy_devuelve_error_corto_fuera_catalogo_publico():
+    with pytest.raises(PermissionError) as exc:
+        usar_loader.validar_nombre_modulo_usar("numpy")
+    assert "modulo_fuera_catalogo_publico" in str(exc.value)
+
+
+def test_obtener_modulo_mantiene_allowlist_obligatoria_en_runtime_normal(monkeypatch):
+    parametros: dict[str, object] = {}
+
+    def _validador(nombre, *, require_allowlist=True):
+        parametros["nombre"] = nombre
+        parametros["require_allowlist"] = require_allowlist
+        return "numero"
+
+    monkeypatch.setattr(usar_loader, "validar_nombre_modulo_usar", _validador)
+    monkeypatch.setattr(usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: ModuleType("numero"))
+
+    usar_loader.obtener_modulo("numero")
+
+    assert parametros["nombre"] == "numero"
+    assert parametros["require_allowlist"] is True
+
+
+def test_sanitizar_exports_publicos_descarta_simbolos_fuera_del_contrato_canonico_y_backend():
+    modulo = ModuleType("numero")
+    modulo.__all__ = [
+        "es_par",
+        "sumar",
+        "pathlib",
+        "os",
+        "_interno_sdk",
+        "sdk_client",
+    ]
+    modulo.es_par = lambda n: n % 2 == 0
+    modulo.sumar = lambda a, b: a + b
+    modulo.pathlib = object()
+    modulo.os = object()
+    modulo._interno_sdk = object()
+    modulo.sdk_client = object()
+
+    mapa_limpio, conflictos = usar_loader.sanitizar_exports_publicos(modulo, "numero")
+
+    assert set(mapa_limpio) == {"es_par", "sumar"}
+    rechazados = {(c.get("symbol"), c.get("code")) for c in conflictos}
+    assert ("pathlib", "outside_public_api") in rechazados
+    assert ("os", "outside_public_api") in rechazados
+    assert ("_interno_sdk", "outside_public_api") in rechazados
+    assert ("sdk_client", "outside_public_api") in rechazados
+
 @pytest.mark.parametrize(
     "nombre_interno",
     (


### PR DESCRIPTION
### Motivation
- Garantizar que `validar_nombre_modulo_usar(..., require_allowlist=True)` siga siendo obligatorio en el flujo runtime/REPL normal para evitar relajaciones accidentales de la allowlist. 
- Asegurar que llamadas como `usar "numpy"` continúen produciendo un `PermissionError` con un mensaje corto y estable que identifique el módulo como fuera del catálogo público. 
- Mantener la política de `sanitizar_exports_publicos(...)` para descartar símbolos fuera de `CANONICAL_MODULE_SURFACE_CONTRACTS` y overrides permitidos, y añadir pruebas que verifiquen el comportamiento frente a símbolos backend/internos.

### Description
- Cambié el `PermissionError` en `src/pcobra/cobra/usar_loader.py` para que al rechazar nombres fuera de `USAR_COBRA_PUBLIC_MODULES` arroje un mensaje corto y estable: `usar_error[modulo_fuera_catalogo_publico]: '{nombre}' está fuera del catálogo público.`
- Añadí tests en `tests/unit/test_usar_runtime_policy.py` que comprueban: rechazo de `numpy` con el código corto `modulo_fuera_catalogo_publico`, que `obtener_modulo` siga llamando a `validar_nombre_modulo_usar` con `require_allowlist=True`, y que `sanitizar_exports_publicos` descarte símbolos backend/internos (`os`, `pathlib`, `_interno_sdk`, `sdk_client`) dejando sólo la API pública (p.ej. `es_par`, `sumar`).
- Mantengo la lógica existente de `sanitizar_exports_publicos` (filtrado por `__all__`, overrides y saneamiento adicional) y las métricas de rechazo; los cambios son limitados al texto de error y a las pruebas que validan el contrato.
- Los cambios fueron registrados en un commit y se preparó el PR (mensaje del PR generado automáticamente).

### Testing
- Agregué tres tests unitarios nuevos en `tests/unit/test_usar_runtime_policy.py` para `numpy`, la verificación de `require_allowlist` en `obtener_modulo`, y la prueba de descarte de símbolos no públicos en `sanitizar_exports_publicos`.
- Intenté ejecutar pruebas focalizadas con `pytest -q tests/unit/test_usar_runtime_policy.py -k 'allowlist or numpy or sanitizar_exports_publicos_descarta or validar_nombre_modulo_usar_exige_allowlist_estricta'`, pero la colección falló con `ImportError: attempted relative import beyond top-level package` en este entorno de ejecución. 
- Reintenté con `PYTHONPATH=src pytest -q tests/unit/test_usar_runtime_policy.py -k 'allowlist or numpy or sanitizar_exports_publicos_descarta or validar_nombre_modulo_usar_exige_allowlist_estricta'` y obtuve el mismo error de colección por el `ImportError`, por lo que no se pudo completar la ejecución automática aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06e03e10d48327a98af98df658b65d)