### PR TITLE
Refuerza validaciones del wrapper `existe` y añade tests negativos para metadata

### DIFF
--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -146,28 +146,43 @@ def test_usar_detecta_divergencia_metadata_interprete_y_validador():
         interp.ejecutar_ast(ast_llamada)
 
 
-def test_existe_rechaza_metadata_incompleta_aunque_simbolo_este_registrado():
+def test_existe_rechaza_metadata_ausente_sin_fallback_permisivo():
     interp = InterpretadorCobra()
     ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')
 
     with patch("sys.stdout", new_callable=StringIO):
         interp.ejecutar_ast(ast)
 
-    # Simula bypass: símbolo registrado pero metadata incompleta/no canónica.
-    interp._validador._metadata_simbolos_usar["existe"].pop("origen_modulo", None)
+    # Simula bypass: símbolo registrado pero metadata ausente.
+    interp._validador._metadata_simbolos_usar.pop("existe", None)
     ast_llamada = generar_ast('imprimir(existe("README.md"))')
     with pytest.raises(PrimitivaPeligrosaError):
         interp.ejecutar_ast(ast_llamada)
 
 
-def test_existe_rechaza_metadata_con_modulo_distinto():
+
+
+def test_existe_rechaza_metadata_no_dict_sin_fallback_permisivo():
     interp = InterpretadorCobra()
     ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')
 
     with patch("sys.stdout", new_callable=StringIO):
         interp.ejecutar_ast(ast)
 
-    interp._validador._metadata_simbolos_usar["existe"]["module"] = "io"
+    interp._validador._metadata_simbolos_usar["existe"] = []
+    ast_llamada = generar_ast('imprimir(existe("README.md"))')
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast_llamada)
+
+@pytest.mark.parametrize("modulo", ["io", "numpy"])
+def test_existe_rechaza_metadata_con_modulo_distinto(modulo):
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')
+
+    with patch("sys.stdout", new_callable=StringIO):
+        interp.ejecutar_ast(ast)
+
+    interp._validador._metadata_simbolos_usar["existe"]["module"] = modulo
     ast_llamada = generar_ast('imprimir(existe("README.md"))')
     with pytest.raises(PrimitivaPeligrosaError):
         interp.ejecutar_ast(ast_llamada)
@@ -264,3 +279,16 @@ def test_usar_numpy_rechaza_con_error_corto():
 
     with pytest.raises(PermissionError, match="No se puede usar 'numpy': módulo fuera del catálogo público"):
         interp.ejecutar_ast(ast)
+
+
+def test_existe_rechaza_metadata_con_is_sanitized_wrapper_false():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')
+
+    with patch("sys.stdout", new_callable=StringIO):
+        interp.ejecutar_ast(ast)
+
+    interp._validador._metadata_simbolos_usar["existe"]["is_sanitized_wrapper"] = False
+    ast_llamada = generar_ast('imprimir(existe("README.md"))')
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast_llamada)


### PR DESCRIPTION
### Motivation
- Asegurar que la excepción al usar la primitiva peligrosa `existe` solo se permita vía el wrapper público y canónico con metadata estricta. 
- Rechazar cualquier metadata ausente o que no sea `dict` sin permitir un fallback permisivo. 
- Añadir tests negativos que cubran módulos no permitidos, nombres exportados distintos, `public_api=False`, `is_sanitized_wrapper=False` y el aliasing de backend crudo.

### Description
- Se actualiza `tests/unit/test_safe_mode.py` para reforzar y ampliar los casos de prueba relacionados con el wrapper `existe` en modo seguro. 
- Renombrado el test de metadata incompleta a `test_existe_rechaza_metadata_ausente_sin_fallback_permisivo` y ahora simula la ausencia total de metadata para `existe`. 
- Se añadió `test_existe_rechaza_metadata_no_dict_sin_fallback_permisivo` para validar que metadata no-dict (ej. lista) es rechazada. 
- Se parametrizó el test de módulo distinto para cubrir `io` y `numpy`, se mantiene el test para `exported_name` distinto y se añadió `test_existe_rechaza_metadata_con_is_sanitized_wrapper_false` para cubrir `is_sanitized_wrapper=False`.

### Testing
- Intenté ejecutar los tests específicos modificados con `pytest`, pero la recolección falló por un error de importación (`attempted relative import beyond top-level package`) en `core.interpreter`, por lo que los tests no pudieron completarse. 
- Reintenté con `PYTHONPATH=src` y obtuve el mismo error de importación durante la colección, por lo que no hay resultados de ejecución verdes/rojos. 
- Las modificaciones se limitaron a la suite de tests y no cambian la implementación del validador que ya realiza las comprobaciones estrictas (`module == "archivo"`, `exported_name == "existe"`, `is_sanitized_wrapper is True`, `public_api is True`, y rechazo de metadata ausente/no-dict).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ea72e970832798af3843f2d9d1a2)