### PR TITLE
Harden `archivo.existe` path checks and expand traversal test coverage

### DIFF
--- a/src/pcobra/corelibs/archivo.py
+++ b/src/pcobra/corelibs/archivo.py
@@ -81,9 +81,10 @@ def existe(ruta: PathLike) -> bool:
         if not isinstance(ruta, str):
             return False
         destino = _resolver_ruta(ruta)
-    except ValueError:
+        return destino.is_file()
+    except Exception:
+        # Mantiene el error encapsulado para no exponer tracebacks en REPL.
         return False
-    return destino.is_file()
 
 
 def eliminar(ruta: PathLike) -> None:

--- a/src/pcobra/standard_library/archivo.py
+++ b/src/pcobra/standard_library/archivo.py
@@ -79,9 +79,10 @@ def existe(ruta: PathLike) -> bool:
         if not isinstance(ruta, str):
             return False
         ruta_segura = _resolver_ruta(ruta)
-    except ValueError:
+        return ruta_segura.is_file()
+    except Exception:
+        # Mantiene el error encapsulado para no exponer tracebacks en REPL.
         return False
-    return ruta_segura.is_file()
 
 
 PUBLIC_API_ARCHIVO: tuple[str, ...] = (

--- a/tests/unit/test_archivo.py
+++ b/tests/unit/test_archivo.py
@@ -46,13 +46,30 @@ def test_archivo_existe_relativa_valida(monkeypatch, tmp_path, ruta):
     assert archivo.existe(ruta) is True
 
 
-@pytest.mark.parametrize("ruta", ["/etc/passwd", "C:\\Windows\\System32\\drivers\\etc\\hosts", "\\\\server\\share\\file.txt"])
+@pytest.mark.parametrize(
+    "ruta",
+    [
+        "/etc/passwd",
+        "C:\\Windows\\System32\\drivers\\etc\\hosts",
+        "\\\\server\\share\\file.txt",
+        "//server/share/file.txt",
+        "D:/datos/secret.txt",
+    ],
+)
 def test_archivo_existe_bloquea_absolutas_y_windows_unc(monkeypatch, tmp_path, ruta):
     monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
     assert archivo.existe(ruta) is False
 
 
-@pytest.mark.parametrize("ruta", ["./../secreto.txt", "a/../../secreto.txt"])
+@pytest.mark.parametrize(
+    "ruta",
+    [
+        "./../secreto.txt",
+        "a/../../secreto.txt",
+        "carpeta/../..//secreto.txt",
+        "subdir/./.././../secreto.txt",
+    ],
+)
 def test_archivo_existe_bloquea_traversal(monkeypatch, tmp_path, ruta):
     monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
     assert archivo.existe(ruta) is False

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -693,13 +693,30 @@ def test_archivo_existe_relativa_valida(monkeypatch, tmp_path, ruta):
     assert core.existe(ruta) is True
 
 
-@pytest.mark.parametrize("ruta", ["/etc/passwd", "C:\\Windows\\System32\\drivers\\etc\\hosts", "\\\\server\\share\\file.txt"])
+@pytest.mark.parametrize(
+    "ruta",
+    [
+        "/etc/passwd",
+        "C:\\Windows\\System32\\drivers\\etc\\hosts",
+        "\\\\server\\share\\file.txt",
+        "//server/share/file.txt",
+        "D:/datos/secret.txt",
+    ],
+)
 def test_archivo_existe_bloquea_absolutas_y_windows_unc(monkeypatch, tmp_path, ruta):
     monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
     assert core.existe(ruta) is False
 
 
-@pytest.mark.parametrize("ruta", ["./../secreto.txt", "a/../../secreto.txt"])
+@pytest.mark.parametrize(
+    "ruta",
+    [
+        "./../secreto.txt",
+        "a/../../secreto.txt",
+        "carpeta/../..//secreto.txt",
+        "subdir/./.././../secreto.txt",
+    ],
+)
 def test_archivo_existe_bloquea_traversal(monkeypatch, tmp_path, ruta):
     monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
     assert core.existe(ruta) is False


### PR DESCRIPTION
### Motivation

- Unificar y endurecer el comportamiento de `existe` para que sea predecible y seguro frente a entradas no válidas y errores internos. 
- Evitar que errores internos propaguen tracebacks al REPL asegurando una API que siempre retorne `bool` y oculte detalles de excepciones.

### Description

- Se actualizó la implementación de `existe` en `src/pcobra/corelibs/archivo.py` y en `src/pcobra/standard_library/archivo.py` para que rechace entradas no `str`, encapsule cualquier excepción interna y siempre retorne `bool`.
- La lógica de resolución y sandboxing se mantiene en `_resolver_ruta`, que sigue bloqueando rutas absolutas/UNC/drive-letter y cualquier uso de `..` o salidas del directorio permitido tras `resolve`+`relative_to`.
- Se ampliaron las pruebas parametrizadas en `tests/unit/test_archivo.py` y `tests/unit/test_corelibs.py` para cubrir variantes adicionales de rutas Windows/UNC/Unix y formas normalizadas de traversal (`//server/share/...`, `D:/...`, `carpeta/../..//...`, `subdir/./.././../...`).
- Los cambios mantienen el comportamiento defensivo en REPL evitando exponer tracebacks y conservando la política de sandbox existente.

### Testing

- Ejecutado `pytest -q tests/unit/test_archivo.py tests/unit/test_corelibs.py -k "archivo_existe"` y todas las pruebas ejecutadas pasaron correctamente.
- Resultado del `pytest`: `25 passed, 53 deselected, 1 warning` (ejecución en ~2.5s), y no se detectaron fallos en las pruebas relacionadas con `existe`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ecbacaa08327bd1673cb75b03b7c)