### PR TITLE
Permitir `existe()` tras `usar "archivo"` y propagar metadatos de `usar` a validadores REPL

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -512,6 +512,7 @@ class InteractiveCommand(BaseCommand):
             validar_ast_seguro(
                 ast,
                 validadores_extra=self._extra_validators_repl,
+                interpretador=self.interpretador,
             )
         resultado = None
         # Evitamos validar dos veces en ejecución para no duplicar side effects

--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -143,6 +143,7 @@ def validar_ast_seguro(
     ast: Any,
     *,
     validadores_extra: Any,
+    interpretador: Any | None = None,
     construir_cadena_fn: Callable[[Any], Any] = construir_cadena,
 ) -> None:
     """Aplica la cadena de validadores de seguridad sobre el AST."""
@@ -155,6 +156,22 @@ def validar_ast_seguro(
                 _("Los validadores extra deben ser una lista de instancias de validadores")
             )
     validador = construir_cadena_fn(validadores_extra)
+    if interpretador is not None:
+        metadata_usar = getattr(interpretador, "_usar_symbol_metadata", {}) or {}
+        validadores_registrables = []
+        cursor = validador
+        while cursor is not None:
+            if hasattr(cursor, "registrar_simbolo_publico_usar"):
+                validadores_registrables.append(cursor)
+            cursor = getattr(cursor, "siguiente", None)
+        for nombre, metadata in metadata_usar.items():
+            if not isinstance(metadata, dict):
+                continue
+            modulo = metadata.get("module") or metadata.get("canonical_module") or metadata.get("origin_module")
+            if not isinstance(modulo, str):
+                continue
+            for validador_registrable in validadores_registrables:
+                validador_registrable.registrar_simbolo_publico_usar(nombre, modulo, metadata=dict(metadata))
     for nodo in ast:
         nodo.aceptar(validador)
 

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -906,6 +906,19 @@ class InterpretadorCobra:
         """Ejecuta la auditoría funcional únicamente durante la fase de ejecución."""
         if not self.in_execution() or not self.safe_mode or self._validador is None:
             return
+        validadores_registrables = []
+        cursor = self._validador
+        while cursor is not None:
+            if hasattr(cursor, "registrar_simbolo_publico_usar"):
+                validadores_registrables.append(cursor)
+            cursor = getattr(cursor, "siguiente", None)
+        for nombre, metadata in (self._usar_symbol_metadata or {}).items():
+            if not isinstance(metadata, dict):
+                continue
+            modulo = metadata.get("module") or metadata.get("canonical_module") or metadata.get("origin_module")
+            if isinstance(modulo, str):
+                for validador_registrable in validadores_registrables:
+                    validador_registrable.registrar_simbolo_publico_usar(nombre, modulo, metadata=dict(metadata))
         # En ejecución permitimos side effects de auditoría visibles al usuario.
         nodo.aceptar(self._validador)
 

--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -864,16 +864,17 @@ def test_repl_archivo_invocacion_cruda_sin_usar_permanece_bloqueada():
     with pytest.raises(Exception, match='Uso de primitiva peligrosa'):
         cmd._ejecutar_en_modo_normal('imprimir(existe("README.md"))')
 
-def test_repl_archivo_invocacion_directa_permanece_bloqueada_sin_traceback(capsys):
+def test_repl_archivo_invocacion_directa_permitida_tras_usar_sin_traceback(capsys):
     cmd = ReplCommandV2()
     cmd._ejecutar_en_modo_normal('usar "archivo"')
 
-    with pytest.raises(Exception, match='Uso de primitiva peligrosa'):
-        cmd._ejecutar_en_modo_normal('imprimir(existe("README.md"))')
+    cmd._ejecutar_en_modo_normal('imprimir(existe("README.md"))')
 
     salida = capsys.readouterr().out.strip()
-    assert 'traceback' not in salida.lower()
-    assert len(salida.splitlines()) <= 2
+    lineas = [linea.strip() for linea in salida.splitlines() if linea.strip()]
+    assert 'Traceback' not in salida
+    assert lineas[-1] in {'verdadero', 'falso'}
+    assert len(lineas) <= 2
 
 
 def test_repl_archivo_hardening_no_expone_backend_crudo():


### PR DESCRIPTION
### Motivation

- Separar el caso prohibido (invocar `existe` sin `usar "archivo"`) del caso permitido (invocar `existe` después de `usar "archivo"`) para cumplir el contrato REPL y UX deseada. 
- Evitar que la validación de primitivas peligrosas bloquee wrappers públicos legítimos introducidos por `usar` en el flujo incremental del REPL.

### Description

- Añade un parámetro `interpretador` a `validar_ast_seguro` y, si está presente, hidrata la cadena de validadores con metadatos de `_usar_symbol_metadata` para que los validadores con `registrar_simbolo_publico_usar` conozcan los wrappers públicos importados por `usar` (`src/pcobra/cobra/cli/execution_pipeline.py`).
- Pasa el intérprete activo desde el REPL incremental a `validar_ast_seguro` para activar la hidratación previa a la validación silenciosa del AST (`src/pcobra/cobra/cli/commands/interactive_cmd.py`).
- Durante la auditoría en fase de ejecución se registra igualmente la metadata de símbolos `usar` en toda la cadena de validadores antes de auditar cada nodo, asegurando que la validación en ejecución reconozca los wrappers ya inyectados (`src/pcobra/core/interpreter.py`).
- Actualiza el test de integración para dividir semanticamente el caso: mantiene la prohibición sin `usar` y valida que tras `usar "archivo"` la salida impresa sea `verdadero` o `falso` con salida corta y sin traceback (`tests/integration/test_repl_usar_entrypoints_contract.py`).

### Testing

- Ejecuté `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py -k 'archivo_invocacion_cruda_sin_usar or archivo_invocacion_directa_permitida_tras_usar or seguridad_usar_numpy_error_corto_sin_traceback'` y los tests seleccionados pasaron: `4 passed`.
- Verifiqué que el rechazo de `usar "numpy"` sigue produciendo `PermissionError` sin traceback mediante las mismas pruebas de integración relacionadas con seguridad y salida corta.
- Durante la iteración inicial las pruebas fallaron hasta propagar correctamente los metadatos a los validadores, y tras los cambios se resolvieron los fallos relevantes y la suite seleccionada quedó verde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06f23b15a483279a2d148ca9809ccb)