### PR TITLE
Agregar tests: usar 'datos' imprimir longitudes, rechazo persistente de numpy y saneamiento de exports

### DIFF
--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -377,6 +377,42 @@ def test_repl_seguridad_numpy_rechazado_mensaje_corto_sin_traceback(factory, exe
 
 
 @pytest.mark.parametrize(
+    ("factory", "executor"),
+    [
+        (lambda: InteractiveCommand(InterpretadorCobra()), lambda cmd, code: cmd.ejecutar_codigo(code)),
+        (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code)),
+    ],
+)
+def test_repl_rechazo_numpy_es_persistente(factory, executor):
+    cmd = factory()
+    for _ in range(2):
+        with pytest.raises(PermissionError) as excinfo:
+            executor(cmd, 'usar "numpy"')
+        mensaje = str(excinfo.value)
+        assert "modulo_fuera_catalogo_publico" in mensaje or "módulo fuera del catálogo público" in mensaje
+
+
+@pytest.mark.parametrize(
+    ("factory", "executor", "get_interp"),
+    [
+        (lambda: InteractiveCommand(InterpretadorCobra()), lambda cmd, code: cmd.ejecutar_codigo(code), lambda cmd: cmd.interpretador),
+        (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
+    ],
+)
+def test_repl_usar_datos_longitud_imprimir_lista_y_variable(factory, executor, get_interp, capsys):
+    cmd = factory()
+    interp = get_interp(cmd)
+
+    executor(cmd, 'usar "datos"')
+    interp.contextos[-1].define("xs", [1, 2, 3])
+    executor(cmd, "imprimir(longitud(xs))")
+    executor(cmd, "imprimir(longitud([1,2,3]))")
+
+    salida = capsys.readouterr().out
+    assert salida.count("3") >= 2
+
+
+@pytest.mark.parametrize(
     ("factory", "executor", "get_interp"),
     [
         (lambda: InteractiveCommand(InterpretadorCobra()), lambda cmd, code: cmd.ejecutar_codigo(code), lambda cmd: cmd.interpretador),

--- a/tests/unit/test_usar_loader_public_api_contract.py
+++ b/tests/unit/test_usar_loader_public_api_contract.py
@@ -160,8 +160,9 @@ def test_backends_legacy_no_se_cargan_en_startup_normal() -> None:
 
 
 def test_superficie_usar_no_expone_aliases_ni_internals_prohibidos() -> None:
-    modulos = ("numero", "texto", "datos")
+    modulos = ("numero", "texto", "datos", "archivo")
     prohibidos_exactos = {"self", "append", "map", "filter", "unwrap", "expect"}
+    prohibidos_internals = {"_backend", "__all__", "os", "pathlib"}
 
     for nombre_modulo in modulos:
         modulo = usar_loader.obtener_modulo(nombre_modulo)
@@ -172,6 +173,23 @@ def test_superficie_usar_no_expone_aliases_ni_internals_prohibidos() -> None:
             assert simbolo not in prohibidos_exactos, (
                 f"{nombre_modulo} exporta símbolo no permitido: {simbolo}"
             )
+            assert simbolo not in prohibidos_internals, (
+                f"{nombre_modulo} exporta internals no permitidos: {simbolo}"
+            )
+
+
+def test_apertura_allowlist_archivo_existe_no_afecta_resolucion_publica() -> None:
+    modulo_archivo = usar_loader.obtener_modulo("archivo")
+    modulo_datos = usar_loader.obtener_modulo("datos")
+
+    simbolos_archivo = _simbolos_publicos(modulo_archivo)
+    simbolos_datos = _simbolos_publicos(modulo_datos)
+
+    assert "existe" in simbolos_archivo
+    assert "longitud" in simbolos_datos
+    assert "_backend" not in simbolos_datos
+    assert "__all__" not in simbolos_datos
+    assert "pathlib" not in simbolos_datos
 
 
 def test_arranque_normal_import_pcobra_no_precarga_legacy() -> None:


### PR DESCRIPTION
### Motivation
- Cubrir casos de uso y regresión del flujo `usar` verificando que `datos.longitud` funciona en valores y literales y que la salida de `imprimir` es la esperada.
- Asegurar que los rechazos por módulos fuera del catálogo público (p. ej. `numpy`) sean persistentes y que no se filtren símbolos privados/internals en la superficie pública.

### Description
- Añadí un test de integración `test_repl_usar_datos_longitud_imprimir_lista_y_variable` en `tests/integration/test_repl_usar_entrypoints_contract.py` que hace `usar "datos"`, define `xs=[1,2,3]` y ejecuta `imprimir(longitud(xs))` y `imprimir(longitud([1,2,3]))`, comprobando que la salida contiene `3` al menos dos veces.
- Añadí un test de integración `test_repl_rechazo_numpy_es_persistente` en el mismo archivo que intenta `usar "numpy"` dos veces y valida que ambas intentos lanzan `PermissionError` con el mensaje de catálogo público.
- Modifiqué `tests/unit/test_usar_loader_public_api_contract.py` para incluir el módulo `archivo` en la verificación de superficie pública y añadí comprobaciones que prohíben símbolos internos (`_backend`, `__all__`, `os`, `pathlib`) y un test `test_apertura_allowlist_archivo_existe_no_afecta_resolucion_publica` que verifica que habilitar `archivo.existe` no rompe la resolución pública de `datos`.
- Cambios limitados a tests: `tests/integration/test_repl_usar_entrypoints_contract.py` y `tests/unit/test_usar_loader_public_api_contract.py`.

### Testing
- Ejecuté `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py -k "rechazo_numpy_es_persistente or usar_datos_longitud_imprimir_lista_y_variable"` y las pruebas pasaron (`4 passed, 68 deselected`).
- Ejecuté `pytest -q tests/unit/test_usar_loader_public_api_contract.py -k "apertura_allowlist_archivo_existe_no_afecta_resolucion_publica or superficie_usar_no_expone_aliases_ni_internals_prohibidos"` y las pruebas unitarias pasaron (`2 passed, 24 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06f45ddf8c8327a719c8dbf447f836)