### PR TITLE
Refuerza contrato de seguridad para `existe` y agrega regresiones de modo seguro

### DIFF
--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -73,9 +73,11 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
             return False
 
         # Validación explícita de contrato canónico para `existe`.
-        if metadata.get("module") != "archivo":
+        module = metadata.get("module")
+        exported_name = metadata.get("exported_name")
+        if module != "archivo":
             return False
-        if metadata.get("exported_name") != "existe":
+        if exported_name != "existe":
             return False
         if metadata.get("is_sanitized_wrapper") is not True:
             return False

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -371,3 +371,27 @@ def test_hilo_con_primitiva_peligrosa_fuera_de_ruta_canonica_se_bloquea():
 
     with pytest.raises(PrimitivaPeligrosaError):
         interp.ejecutar_ast(ast)
+
+
+def test_regresion_redefinicion_local_existe_permanece_bloqueada_en_modo_seguro():
+    interp = InterpretadorCobra()
+    ast = generar_ast('func existe(ruta) { retorno verdadero }\nimprimir(existe("README.md"))')
+
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast)
+
+
+def test_regresion_alias_malicioso_post_usar_archivo_permanece_bloqueado():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"\nexiste = leer_archivo\nimprimir(existe("README.md"))')
+
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast)
+
+
+def test_regresion_imports_no_publicos_permanece_bloqueado_en_modo_seguro():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"\nimprimir(leer_archivo("README.md"))')
+
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast)


### PR DESCRIPTION
### Motivation
- Aumentar la seguridad de la primitiva `existe` validando explícitamente la metadata canónica introducida por `usar` para evitar bypass por alias o redefinición local.
- Rechazar por defecto llamadas cuando la metadata falta, no es `dict`, el `module` difiere o el `exported_name` no coincide para evitar accesos a wrappers backend no autorizados.

### Description
- En `ValidadorPrimitivaPeligrosa._es_wrapper_publico_permitido` se extraen y validan explícitamente `module` y `exported_name` desde la metadata antes de aprobar el wrapper público `existe` y se mantienen checks estrictos de `is_sanitized_wrapper is True` y `public_api is True`.
- Se conserva el rechazo por defecto cuando la metadata falta o no es `dict` y cuando los flags de wrapper sanitizado/API pública no son correctos.
- Se agregaron tres tests de regresión en `tests/unit/test_safe_mode.py` que verifican que siguen bloqueados: redefinición local `func existe(...)`, alias malicioso `existe = leer_archivo` tras `usar "archivo"`, y uso de imports no públicos (`leer_archivo`) tras `usar "archivo"`.

### Testing
- Ejecuté `pytest -q tests/unit/test_safe_mode.py` y la ejecución falló durante la recolección con `ImportError: attempted relative import beyond top-level package`.
- También intenté `PYTHONPATH=src pytest -q tests/unit/test_safe_mode.py` y obtuvo el mismo `ImportError` en la recolección, por lo que las nuevas pruebas no pudieron completarse en este entorno de CI local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a070a9aac188327bb52893f85f07b3b)