### PR TITLE
test: reforzar seguridad y contratos de archivo.existe

### DIFF
--- a/tests/unit/test_archivo.py
+++ b/tests/unit/test_archivo.py
@@ -45,6 +45,8 @@ def test_archivo_existe_relativa_valida(monkeypatch, tmp_path, ruta):
 
     assert archivo.existe(ruta) is True
 
+    assert archivo.existe("NO_EXISTE.md") is False
+
 
 @pytest.mark.parametrize(
     "ruta",
@@ -64,6 +66,7 @@ def test_archivo_existe_bloquea_absolutas_y_windows_unc(monkeypatch, tmp_path, r
 @pytest.mark.parametrize(
     "ruta",
     [
+        "../secreto.txt",
         "./../secreto.txt",
         "a/../../secreto.txt",
         "carpeta/../..//secreto.txt",

--- a/tests/unit/test_corelibs.py
+++ b/tests/unit/test_corelibs.py
@@ -692,6 +692,8 @@ def test_archivo_existe_relativa_valida(monkeypatch, tmp_path, ruta):
 
     assert core.existe(ruta) is True
 
+    assert core.existe("NO_EXISTE.md") is False
+
 
 @pytest.mark.parametrize(
     "ruta",
@@ -711,6 +713,7 @@ def test_archivo_existe_bloquea_absolutas_y_windows_unc(monkeypatch, tmp_path, r
 @pytest.mark.parametrize(
     "ruta",
     [
+        "../secreto.txt",
         "./../secreto.txt",
         "a/../../secreto.txt",
         "carpeta/../..//secreto.txt",


### PR DESCRIPTION
### Motivation
- Asegurar y dejar explícito el contrato de `archivo.existe(...)` respecto a rutas relativas, absolutas y traversal para los módulos `pcobra.corelibs.archivo` y `pcobra.standard_library.archivo`.

### Description
- Se actualizaron los tests en `tests/unit/test_archivo.py` y `tests/unit/test_corelibs.py` para añadir una aserción explícita de que una ruta relativa válida inexistente (`"NO_EXISTE.md"`) devuelve `False` y para incluir el caso `"../secreto.txt"` entre los vectores de traversal rechazados.
- No fue necesario cambiar la implementación en `src/pcobra/corelibs/archivo.py` ni en `src/pcobra/standard_library/archivo.py` porque ya cumplen los requisitos de aceptar solo `str` en `existe`, normalizar vía `_resolver_ruta`, rechazar absolutas/`..` y devolver `False` ante errores.

### Testing
- Ejecutado `pytest -q tests/unit/test_archivo.py`, resultado: `18 passed` (éxito).
- Intento de ejecutar `pytest -q tests/unit/test_corelibs.py -k "archivo_existe" && pytest -q tests/unit/test_archivo.py` falló en la fase de colección por un `ImportError` causado por una importación circular preexistente en la suite (`pcobra.corelibs`), y no por los cambios en los tests.
- Los cambios en tests fueron committeados y están listos para revisión; la prueba específica de `archivo` pasa completamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a070c2b93dc8327b5d78839156e569b)