### PR TITLE
test: reforzar contratos REPL/seguro para `usar` (`archivo`, `datos`, `numpy`)

### DIFF
--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -419,6 +419,46 @@ def test_repl_usar_datos_longitud_imprimir_lista_y_variable(factory, executor, g
         (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
     ],
 )
+def test_repl_aceptacion_positiva_usar_archivo_existe_readme(factory, executor, get_interp, capsys):
+    cmd = factory()
+    _ = get_interp(cmd)
+
+    executor(cmd, 'usar "archivo"')
+    executor(cmd, 'imprimir(existe("README.md"))')
+
+    salida = capsys.readouterr().out.strip().splitlines()
+    assert salida
+    assert salida[-1].strip() in {"verdadero", "falso"}
+    assert all("Uso de primitiva peligrosa" not in linea for linea in salida)
+
+
+@pytest.mark.parametrize(
+    ("factory", "executor", "get_interp"),
+    [
+        (lambda: InteractiveCommand(InterpretadorCobra()), lambda cmd, code: cmd.ejecutar_codigo(code), lambda cmd: cmd.interpretador),
+        (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
+    ],
+)
+def test_repl_numpy_rechazo_no_deja_estado_parcial(factory, executor, get_interp):
+    cmd = factory()
+    interp = get_interp(cmd)
+    estado_pre = dict(interp.contextos[-1].values)
+
+    with pytest.raises(PermissionError, match=r"(módulo fuera del catálogo público|modulo_fuera_catalogo_publico)"):
+        executor(cmd, 'usar "numpy"')
+
+    assert dict(interp.contextos[-1].values) == estado_pre
+    assert "numpy" not in interp.contextos[-1].values
+    assert "numpy" not in interp.variables
+
+
+@pytest.mark.parametrize(
+    ("factory", "executor", "get_interp"),
+    [
+        (lambda: InteractiveCommand(InterpretadorCobra()), lambda cmd, code: cmd.ejecutar_codigo(code), lambda cmd: cmd.interpretador),
+        (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
+    ],
+)
 def test_repl_usar_no_expone_simbolos_no_publicos(factory, executor, get_interp):
     cmd = factory()
     interp = get_interp(cmd)

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -63,6 +63,28 @@ def test_existe_publico_desde_usar_acepta_ruta_relativa():
     assert "verdadero" in salida or "falso" in salida
 
 
+def test_usar_archivo_existe_imprime_booleano_sin_primitiva_peligrosa():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        interp.ejecutar_ast(ast)
+
+    salida = out.getvalue().strip()
+    assert salida in {"verdadero", "falso"}
+
+
+def test_usar_datos_longitud_builtin_permanece_en_3():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "datos"\nvar xs = [1, 2, 3]\nimprimir(longitud(xs))\nimprimir(longitud([1,2,3]))')
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        interp.ejecutar_ast(ast)
+
+    lineas = [linea.strip() for linea in out.getvalue().splitlines() if linea.strip()]
+    assert lineas[-2:] == ["3", "3"]
+
+
 def test_existe_backend_crudo_sigue_bloqueado_aun_con_usar_archivo():
     interp = InterpretadorCobra()
     ast = generar_ast('usar "archivo"\nexiste = leer_archivo\nimprimir(existe("README.md"))')
@@ -342,6 +364,18 @@ def test_usar_numpy_rechaza_con_error_corto():
 
     with pytest.raises(PermissionError, match="No se puede usar 'numpy': módulo fuera del catálogo público"):
         interp.ejecutar_ast(ast)
+
+
+def test_usar_numpy_fallo_no_inyecta_estado_parcial_en_contexto():
+    interp = InterpretadorCobra()
+    estado_pre = dict(interp.contextos[-1].values)
+
+    with pytest.raises(PermissionError, match="No se puede usar 'numpy': módulo fuera del catálogo público"):
+        interp.ejecutar_ast(generar_ast('usar "numpy"'))
+
+    assert dict(interp.contextos[-1].values) == estado_pre
+    assert "numpy" not in interp.contextos[-1].values
+    assert "numpy" not in interp.variables
 
 
 def test_existe_rechaza_metadata_con_is_sanitized_wrapper_false():


### PR DESCRIPTION
### Motivation
- Asegurar que la operación `usar` expone únicamente APIs públicas y seguras en modo REPL y en el intérprete seguro. 
- Evitar regresiones en builtins como `longitud` tras importar `datos` y garantizar que `usar "numpy"` se rechaza sin dejar estado parcial. 

### Description
- Añadí pruebas en `tests/unit/test_safe_mode.py` para verificar que `usar "archivo"` + `imprimir(existe("README.md"))` imprime estrictamente `verdadero` o `falso`. 
- Añadí prueba en `tests/unit/test_safe_mode.py` que valida la no regresión del builtin `longitud` tras `usar "datos"` con `xs = [1,2,3]`. 
- Añadí prueba en `tests/unit/test_safe_mode.py` que comprueba que un fallo de `usar "numpy"` no deja estado parcial ni inyecta símbolos en el contexto/variables. 
- Añadí pruebas REPL equivalentes en `tests/integration/test_repl_usar_entrypoints_contract.py` para cubrir aceptación positiva de `archivo` y atomicidad / rechazo corto de `numpy` en ambos frontends REPL. 

### Testing
- Ejecuté `pytest -q tests/unit/test_safe_mode.py tests/integration/test_repl_usar_entrypoints_contract.py` y la colección falló con `ImportError: attempted relative import beyond top-level package` durante la importación de `tests/unit/test_safe_mode.py`. 
- Ejecuté `PYTHONPATH=src pytest -q tests/integration/test_repl_usar_entrypoints_contract.py -k 'aceptacion_positiva_usar_archivo_existe_readme or usar_datos_longitud_imprimir_lista_y_variable or numpy_rechazo_no_deja_estado_parcial'` y las pruebas fallaron por `PrimitivaPeligrosaError: Metadata de validador inválida para símbolos usar` en tiempo de ejecución. 
- Los cambios fueron staged y commiteados con el mensaje `test: reforzar contratos de usar para archivo/datos y rechazo numpy`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07121ec2748327b31e12017d0b063a)