### PR TITLE
Refuerza validación y sincronización de metadata `usar` en safe mode

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -912,7 +912,7 @@ class InterpretadorCobra:
             if hasattr(cursor, "registrar_simbolo_publico_usar"):
                 validadores_registrables.append(cursor)
             cursor = getattr(cursor, "siguiente", None)
-        self._asegurar_metadata_usar_sincronizada()
+        self._asegurar_metadata_usar_sincronizada(etapa="pre-auditoría")
         for nombre, metadata in (self._usar_symbol_metadata or {}).items():
             if not isinstance(metadata, dict):
                 continue
@@ -929,13 +929,16 @@ class InterpretadorCobra:
         except ValueError as exc:
             raise PrimitivaPeligrosaError(str(exc)) from exc
 
-    def _asegurar_metadata_usar_sincronizada(self) -> None:
+    def _asegurar_metadata_usar_sincronizada(self, *, etapa: str | None = None) -> None:
         if not self.safe_mode or self._validador is None:
             return
         metadata_validador = getattr(self._validador, "_metadata_simbolos_usar", None)
         if not isinstance(metadata_validador, dict):
+            tipo_recibido = type(metadata_validador).__name__
+            detalle_etapa = f" etapa='{etapa}'" if etapa else ""
             raise PrimitivaPeligrosaError(
-                "Metadata de validador inválida para símbolos usar"
+                "Metadata de validador inválida para símbolos usar: "
+                f"se recibió tipo '{tipo_recibido}' en _metadata_simbolos_usar.{detalle_etapa}"
             )
         if set(metadata_validador.keys()) != set(self._usar_symbol_metadata.keys()):
             raise PrimitivaPeligrosaError(
@@ -2244,7 +2247,7 @@ class InterpretadorCobra:
                     modulo,
                     metadata=dict(metadata_simbolo),
                 )
-                self._asegurar_metadata_usar_sincronizada()
+                self._asegurar_metadata_usar_sincronizada(etapa="post-registro")
 
     def ejecutar_holobit(self, nodo):
         """Simula la ejecución de un holobit y devuelve sus valores."""

--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -256,6 +256,27 @@ USAR_SYMBOL_METADATA_LEGACY_KEYS = frozenset(
     }
 )
 
+USAR_SYMBOL_METADATA_OPTIONAL_KEYS = frozenset(
+    {
+        "python_module",
+        "origen_tipo",
+        "is_public_export",
+        "safe_wrapper",
+        "introduced_by",
+        "introduced_by_usar",
+        "callable_id",
+        "stable_signature",
+    }
+)
+
+# Claves inesperadas consideradas críticas: no forman parte del contrato
+# canónico ni de compatibilidad y deben bloquearse por fail-closed.
+USAR_SYMBOL_METADATA_ALLOWED_KEYS = (
+    USAR_SYMBOL_METADATA_REQUIRED_KEYS
+    | USAR_SYMBOL_METADATA_LEGACY_KEYS
+    | USAR_SYMBOL_METADATA_OPTIONAL_KEYS
+)
+
 
 def make_usar_symbol_metadata(
     module_name: str,
@@ -306,11 +327,22 @@ def make_usar_symbol_metadata(
 
 def validate_usar_symbol_metadata(nombre: str, metadata: object) -> dict[str, object]:
     """Valida esquema mínimo canónico para metadata `usar`."""
+    return _validar_metadata_simbolo_usar(nombre, metadata)
+
+
+def _validar_metadata_simbolo_usar(nombre: str, metadata: object) -> dict[str, object]:
+    """Valida esquema canónico de metadata `usar` con política fail-closed."""
     if not isinstance(metadata, dict):
         raise ValueError(f"Metadata inválida para símbolo usar '{nombre}': tipo no permitido")
     faltantes = USAR_SYMBOL_METADATA_REQUIRED_KEYS - set(metadata.keys())
     if faltantes:
         raise ValueError(f"Metadata inválida para símbolo usar '{nombre}': faltan claves {sorted(faltantes)}")
+    inesperadas_criticas = set(metadata.keys()) - USAR_SYMBOL_METADATA_ALLOWED_KEYS
+    if inesperadas_criticas:
+        raise ValueError(
+            "Metadata inválida para símbolo usar "
+            f"'{nombre}': claves inesperadas críticas {sorted(inesperadas_criticas)}"
+        )
     if metadata.get("origin_kind") != "usar":
         raise ValueError(f"Metadata inválida para símbolo usar '{nombre}': origin_kind inválido")
     module = metadata.get("module")


### PR DESCRIPTION
### Motivation
- Mejorar la trazabilidad y el diagnóstico cuando la metadata `usar` está desincronizada entre intérprete y validador. 
- Endurecer el contrato del esquema de metadata para aplicar un comportamiento fail-closed y evitar bypasses por claves inesperadas. 
- Evitar falsos positivos al aceptar la metadata canónica generada por el loader/sanitizer incluyendo claves opcionales compatibles.

### Description
- Amplía `_asegurar_metadata_usar_sincronizada` para aceptar un parámetro `etapa` y enriquecer el error cuando `_metadata_simbolos_usar` no es `dict`, incluyendo el `tipo recibido` y la `etapa` (`pre-auditoría` / `post-registro`). (modificado: `src/pcobra/core/interpreter.py`).
- Introduce `_validar_metadata_simbolo_usar` y hace que `validate_usar_symbol_metadata` delegue en ella para centralizar la validación del esquema. (modificado: `src/pcobra/core/usar_symbol_policy.py`).
- Añade un conjunto explícito de `OPTIONAL_KEYS` y un conjunto `ALLOWED_KEYS` (required + legacy + optional) y valida ahora claves faltantes y `claves inesperadas críticas` con enfoque fail-closed, rechazando metadata que contenga claves fuera del contrato. (modificado: `src/pcobra/core/usar_symbol_policy.py`).
- Asegura compatibilidad con la metadata generada por `make_usar_symbol_metadata` al incluir las claves opcionales esperadas para evitar falsos positivos.

### Testing
- Se compiló el código modificado con `python -m compileall src/pcobra/core/usar_symbol_policy.py src/pcobra/core/interpreter.py` y la compilación fue exitosa. 
- Se ejecutó `pytest -q tests/unit/test_safe_mode.py` durante verificación y la colección falló con `ImportError: attempted relative import beyond top-level package`, un problema de import-path del entorno de test que no parece originarse en la lógica introducida aquí (error en la fase de colección, no en las nuevas validaciones).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073bda60cc83278a02a84b5c28b5a6)