### PR TITLE
Centralizar metadata de `usar`: construir una vez y propagarla

### DIFF
--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -167,7 +167,7 @@ def validar_ast_seguro(
         for nombre, metadata in metadata_usar.items():
             if not isinstance(metadata, dict):
                 continue
-            modulo = metadata.get("module") or metadata.get("canonical_module") or metadata.get("origin_module")
+            modulo = metadata.get("module")
             if not isinstance(modulo, str):
                 continue
             for validador_registrable in validadores_registrables:

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -916,7 +916,7 @@ class InterpretadorCobra:
         for nombre, metadata in (self._usar_symbol_metadata or {}).items():
             if not isinstance(metadata, dict):
                 continue
-            modulo = metadata.get("module") or metadata.get("canonical_module") or metadata.get("origin_module")
+            modulo = metadata.get("module")
             if isinstance(modulo, str):
                 for validador_registrable in validadores_registrables:
                     validador_registrable.registrar_simbolo_publico_usar(nombre, modulo, metadata=dict(metadata))
@@ -2091,8 +2091,17 @@ class InterpretadorCobra:
                 raise ImportError(mensaje_usuario)
 
             # Fase A: detectar colisiones de forma completa antes de definir.
+            metadata_por_simbolo = {
+                nombre: make_usar_symbol_metadata(
+                    module_name=nodo.modulo,
+                    symbol_name=nombre,
+                    callable_obj=simbolo,
+                )
+                for nombre, simbolo in simbolos_saneados
+            }
             conflictos = self._detectar_conflictos_usar_en_contexto(
-                simbolos_saneados, nodo.modulo
+                simbolos_saneados,
+                metadata_por_simbolo=metadata_por_simbolo,
             )
             if conflictos:
                 for simbolo_conflictivo in conflictos:
@@ -2170,7 +2179,7 @@ class InterpretadorCobra:
             # Fase B: inyectar de forma atómica y sin sobreescritura silenciosa.
             self._inyectar_simbolos_usar_en_contexto(
                 simbolos_saneados,
-                modulo=nodo.modulo,
+                metadata_por_simbolo=metadata_por_simbolo,
             )
         except Exception as exc:
             if _usar_detalle_habilitado():
@@ -2192,7 +2201,10 @@ class InterpretadorCobra:
             raise
 
     def _detectar_conflictos_usar_en_contexto(
-        self, simbolos_saneados: list[tuple[str, object]], modulo: str
+        self,
+        simbolos_saneados: list[tuple[str, object]],
+        *,
+        metadata_por_simbolo: Mapping[str, dict[str, object]],
     ) -> list[str]:
         """Devuelve símbolos en conflicto real (ignora reimport idempotente por metadatos)."""
         contexto_actual = self.contextos[-1]
@@ -2201,11 +2213,9 @@ class InterpretadorCobra:
             if not contexto_actual.contains(nombre):
                 continue
             previo = self._usar_symbol_metadata.get(nombre)
-            metadata_actual = make_usar_symbol_metadata(
-                module_name=modulo,
-                symbol_name=nombre,
-                callable_obj=simbolo,
-            )
+            metadata_actual = metadata_por_simbolo.get(nombre)
+            if metadata_actual is None:
+                continue
             if previo and previo == metadata_actual:
                 # Reimport idempotente: mismo símbolo, mismo módulo origen y misma identidad.
                 continue
@@ -2213,7 +2223,7 @@ class InterpretadorCobra:
         if conflictos:
             self._trace_debug(
                 "[USAR_COLLISION][PREFLIGHT] "
-                f"módulo={modulo} conflictos={','.join(conflictos)}"
+                f"módulo={metadata_por_simbolo[conflictos[0]].get('module')} conflictos={','.join(conflictos)}"
             )
         return conflictos
 
@@ -2221,7 +2231,7 @@ class InterpretadorCobra:
         self,
         simbolos_saneados: list[tuple[str, object]],
         *,
-        modulo: str,
+        metadata_por_simbolo: Mapping[str, dict[str, object]],
         permitir_sobrescritura: bool = False,
     ) -> None:
         """Inyecta símbolos saneados en el entorno activo centralizando el binding."""
@@ -2229,14 +2239,13 @@ class InterpretadorCobra:
         for nombre, simbolo in simbolos_saneados:
             if contexto_actual.contains(nombre) and not permitir_sobrescritura:
                 previo = self._usar_symbol_metadata.get(nombre)
-                metadata_actual = make_usar_symbol_metadata(
-                    module_name=modulo,
-                    symbol_name=nombre,
-                    callable_obj=simbolo,
-                )
+                metadata_actual = metadata_por_simbolo.get(nombre)
+                if metadata_actual is None:
+                    continue
                 if previo and previo == metadata_actual:
                     # No-op idempotente: evita warning/ruido al reimportar lo mismo.
                     continue
+                modulo = str(metadata_actual.get("module"))
                 detalle = {
                     "module": modulo,
                     "symbol": nombre,
@@ -2251,20 +2260,18 @@ class InterpretadorCobra:
                 )
                 raise NameError(
                     "No se puede usar el módulo "
-                    f"'{modulo}': {USAR_SYMBOL_CONFLICT_ERROR} colisión estructurada={detalle}"
+                    f"'{metadata_actual.get('module')}': {USAR_SYMBOL_CONFLICT_ERROR} colisión estructurada={detalle}"
                 )
-            metadata_simbolo = make_usar_symbol_metadata(
-                module_name=modulo,
-                symbol_name=nombre,
-                callable_obj=simbolo,
-            )
+            metadata_simbolo = metadata_por_simbolo.get(nombre)
+            if metadata_simbolo is None:
+                continue
             self._validar_metadata_usar_o_fallar(nombre, metadata_simbolo)
             contexto_actual.define(nombre, simbolo)
             self._usar_symbol_metadata[nombre] = dict(metadata_simbolo)
             if self.safe_mode and self._validador is not None and hasattr(self._validador, "registrar_simbolo_publico_usar"):
                 self._validador.registrar_simbolo_publico_usar(
                     nombre,
-                    modulo,
+                    str(metadata_simbolo["module"]),
                     metadata=dict(metadata_simbolo),
                 )
                 self._asegurar_metadata_usar_sincronizada(etapa="post-registro")

--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -1,6 +1,6 @@
 from .base import ValidadorBase
 from ..ast_nodes import NodoLlamadaFuncion, NodoHilo, NodoLlamadaMetodo
-from ..usar_symbol_policy import make_usar_symbol_metadata, validate_usar_symbol_metadata
+from ..usar_symbol_policy import validate_usar_symbol_metadata
 
 
 class PrimitivaPeligrosaError(Exception):
@@ -44,16 +44,17 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
         modulo: str,
         metadata: dict[str, object] | None = None,
     ) -> None:
-        self._simbolos_publicos_usar.add((modulo, nombre))
-        metadata_base = metadata
-        if metadata_base is None:
-            metadata_base = make_usar_symbol_metadata(
-                module_name=modulo,
-                symbol_name=nombre,
-                callable_obj=object(),
+        if metadata is None:
+            raise ValueError(
+                "Metadata inválida para símbolo usar: se requiere metadata canónica preconstruida"
             )
-        metadata_validada = dict(validate_usar_symbol_metadata(nombre, metadata_base))
-        self._metadata_simbolos_usar[nombre] = metadata_validada
+        metadata_validada = validate_usar_symbol_metadata(nombre, metadata)
+        if metadata_validada.get("module") != modulo:
+            raise ValueError(
+                f"Metadata inválida para símbolo usar '{nombre}': module no coincide con registro"
+            )
+        self._simbolos_publicos_usar.add((modulo, nombre))
+        self._metadata_simbolos_usar[nombre] = dict(metadata_validada)
 
     def _es_wrapper_publico_permitido(self, nodo: NodoLlamadaFuncion) -> tuple[bool, str | None]:
         # Contrato de seguridad: No basta el nombre del símbolo.


### PR DESCRIPTION
### Motivation
- Evitar reconstrucciones laterales de metadata y garantizar sincronía 1:1 entre el intérprete y los validadores para símbolos importados por `usar`.
- Asegurar que la metadata de `usar` cumpla el contrato canónico (por ejemplo `origin_kind="usar"`, `sanitized=True`, `public_api=True`, `backend_exposed=False`, `callable` booleano) y se valide una única vez.

### Description
- Genero la metadata canónica una sola vez por símbolo usando `make_usar_symbol_metadata(module_name, symbol_name, callable_obj)` durante la fase de carga/runtime y la propago como `metadata_por_simbolo` en detección de colisiones e inyección; cambios en `src/pcobra/core/interpreter.py`.
- Modifiqué `_detectar_conflictos_usar_en_contexto` y `_inyectar_simbolos_usar_en_contexto` para recibir y reutilizar la metadata preconstruida en lugar de reconstruirla por símbolo; la metadata validada se persiste en `_usar_symbol_metadata`.
- Cambié `ValidadorPrimitivaPeligrosa.registrar_simbolo_publico_usar` para exigir metadata preconstruida, validarla con `validate_usar_symbol_metadata`, comprobar que `metadata["module"]` coincide con el registro y persistirla sin alterar campos canónicos; cambios en `src/pcobra/core/semantic_validators/primitiva_peligrosa.py`.
- Eliminé los fallbacks condicionales a claves legacy al propagar metadata a validadores e intérprete, usando siempre `metadata["module"]` para mantener sincronía con `_usar_symbol_metadata`; cambio en `src/pcobra/cobra/cli/execution_pipeline.py` y puntos de sincronización del intérprete.

### Testing
- Ejecuté intentos de pruebas unitarias focalizadas con `pytest` para `tests/unit/test_safe_mode.py::test_metadata_usar_archivo_existe_cadena_completa`, `tests/unit/test_safe_mode.py::test_usar_metadata_minima_y_consistente_entre_interprete_y_validador` y `tests/unit/test_usar_runtime_policy.py::test_usar_runtime_reimport_idempotente_numero_no_falla`, pero la colección falló por import error del entorno (`ImportError: attempted relative import beyond top-level package`) impidiendo validar automáticamente los casos.
- Intenté ejecutar `PYTHONPATH=src pytest -q tests/unit/test_usar_runtime_policy.py::test_usar_runtime_reimport_idempotente_numero_no_falla` y la colección igualmente falló por la misma limitación de layout/imports del entorno de ejecución.
- No se reportaron fallos lógicos durante el ajuste de código en esta sesión y los cambios quedaron versionados en un commit local; se recomienda ejecutar la batería de tests completa en el CI o en un entorno con `PYTHONPATH=src` correctamente configurado para confirmar comportamiento en todos los tests pertinentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0812b4c4b083278462ff1f60af5c67)