### PR TITLE
docs: aclarar contrato de metadata canónica en registrar_simbolo_publico_usar

### DIFF
--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -44,6 +44,12 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
         modulo: str,
         metadata: dict[str, object] | None = None,
     ) -> None:
+        """Registra un símbolo público de ``usar`` con metadata canónica validada.
+
+        Este método **solo** acepta metadata canónica ya validada por el contrato
+        de ``usar`` (normalmente construida con
+        :func:`pcobra.core.usar_symbol_policy.make_usar_symbol_metadata`).
+        """
         if metadata is None:
             raise ValueError(
                 "Metadata inválida para símbolo usar: se requiere metadata canónica preconstruida"


### PR DESCRIPTION
### Motivation
- Asegurar que la metadata asociada a símbolos importados por `usar` sea la canónica validada y evitar drift de contrato al propagar metadata entre intérprete y validadores.

### Description
- Se añadió una docstring a `registrar_simbolo_publico_usar` en `src/pcobra/core/semantic_validators/primitiva_peligrosa.py` que documenta explícitamente que el método solo acepta metadata canónica ya validada y referencia `pcobra.core.usar_symbol_policy.make_usar_symbol_metadata` como la forma de construirla.
- Revisé `src/pcobra/core/interpreter.py` y confirmé que `metadata_por_simbolo` se construye mediante `make_usar_symbol_metadata(...)` en el flujo de `usar`, y no se introdujeron construcciones manuales adicionales en runtime que deban reemplazarse. 

### Testing
- Ejecuté `pytest -q tests/unit/test_safe_mode.py` y la ejecución falló en la recolección por un error de importación del entorno (`ImportError: attempted relative import beyond top-level package`), que parece no estar relacionado con la documentación añadida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08176aab6c8327b72a546256429a00)