### PR TITLE
Refuerza sincronización estricta y trazas de `usar` en runtime

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import hashlib
+import json
 from typing import Mapping, Optional
 
 from .lexer import (
@@ -913,6 +914,14 @@ class InterpretadorCobra:
                 validadores_registrables.append(cursor)
             cursor = getattr(cursor, "siguiente", None)
         self._asegurar_metadata_usar_sincronizada(etapa="pre-auditoría")
+        hash_interp = self._hash_estructural_metadata(self._usar_symbol_metadata)
+        hash_validador = self._hash_estructural_metadata(getattr(self._validador, "_metadata_simbolos_usar", {}))
+        if hash_interp != hash_validador:
+            raise PrimitivaPeligrosaError(
+                "Desincronización de metadata usar detectada antes de auditoría: "
+                f"hash intérprete='{hash_interp}' hash validador='{hash_validador}' "
+                "(codigo_interno='metadata_hash_mismatch', política='strict')."
+            )
         for nombre, metadata in (self._usar_symbol_metadata or {}).items():
             if not isinstance(metadata, dict):
                 continue
@@ -945,6 +954,14 @@ class InterpretadorCobra:
             "validator_type": "validate_usar_symbol_metadata",
         }
         return f" detalle_debug={payload}"
+
+    @staticmethod
+    def _hash_estructural_metadata(metadata: object) -> str:
+        """Calcula hash estable para detectar cambios estructurales de metadata."""
+        if not isinstance(metadata, dict):
+            return f"tipo-invalido:{type(metadata).__name__}"
+        serializado = json.dumps(metadata, sort_keys=True, ensure_ascii=False, default=repr)
+        return hashlib.sha256(serializado.encode("utf-8")).hexdigest()
 
     def _asegurar_metadata_usar_sincronizada(self, *, etapa: str | None = None) -> None:
         if not self.safe_mode or self._validador is None:
@@ -2293,11 +2310,25 @@ class InterpretadorCobra:
             contexto_actual.define(nombre, simbolo)
             self._usar_symbol_metadata[nombre] = dict(metadata_simbolo)
             if self.safe_mode and self._validador is not None and hasattr(self._validador, "registrar_simbolo_publico_usar"):
+                resumen = {
+                    "module": metadata_simbolo.get("module"),
+                    "symbol": metadata_simbolo.get("symbol"),
+                    "callable": metadata_simbolo.get("callable"),
+                    "public_api": metadata_simbolo.get("public_api"),
+                    "sanitized": metadata_simbolo.get("sanitized"),
+                }
+                self._trace_debug(f"[USAR_METADATA][PRE_REGISTRO] {resumen}")
                 self._validador.registrar_simbolo_publico_usar(
                     nombre,
                     str(metadata_simbolo["module"]),
                     metadata=dict(metadata_simbolo),
                 )
+                self._trace_debug(f"[USAR_METADATA][POST_REGISTRO] {resumen}")
+                if str(metadata_simbolo.get("module")) == "archivo" and nombre == "existe":
+                    self._trace_debug(
+                        "[USAR_TRACE][archivo.existe] confirmado wrapper sanitizado "
+                        f"(public_api={metadata_simbolo.get('public_api')}, sanitized={metadata_simbolo.get('sanitized')})"
+                    )
                 self._asegurar_metadata_usar_sincronizada(etapa="post-registro")
 
     def ejecutar_holobit(self, nodo):


### PR DESCRIPTION
### Motivation
- Aumentar la robustez del modo seguro detectando desincronizaciones estructurales entre la metadata registrada por el intérprete y la vista del validador antes de la auditoría en ejecución.
- Facilitar la depuración y asegurar que `archivo.existe` llega como wrapper sanitizado (y no como primitiva backend) mediante trazas detalladas por símbolo.

### Description
- Se añadió el helper `_hash_estructural_metadata` que serializa de forma estable la metadata y calcula un `sha256` para detectar cambios estructurales, y se importó `json` para la serialización.
- En `_auditar_en_ejecucion` se comparan los hashes de metadata del intérprete y del validador antes de re-registrar símbolos y se lanza `PrimitivaPeligrosaError` si hay desajuste (fallo explícito de desincronización, política estricta).
- En `_inyectar_simbolos_usar_en_contexto` se registran trazas `debug` con un resumen por símbolo (`module`, `symbol`, `callable`, `public_api`, `sanitized`) justo antes y después de llamar a `registrar_simbolo_publico_usar`.
- Se añadió una traza específica para `archivo.existe` que confirma explícitamente que el registro llegó como wrapper sanitizado mostrando `public_api` y `sanitized`.

### Testing
- Se verificó la sintaxis realizando `python -m py_compile src/pcobra/core/interpreter.py`, que completó correctamente.
- Intentos de ejecutar tests unitarios con `pytest` sobre `tests/unit/test_safe_mode.py` y `tests/unit/test_usar_runtime_policy.py` fallaron durante la colección por una limitación del entorno de pruebas (`ImportError: attempted relative import beyond top-level package`).
- Se reintentó `PYTHONPATH=src pytest` con la misma falla de colección por imports, por lo que las pruebas automáticas no pudieron completarse en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08185dd69c8327bdc151d10b9bc66d)