### PR TITLE
Refuerza metadata canónica de `usar` en intérprete, validadores y pipeline CLI

### DIFF
--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -15,6 +15,7 @@ from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_source_for_tokenizer
 from pcobra.cobra.cli.utils.validators import normalizar_validadores_extra
 from pcobra.cobra.core.runtime import ValidadorBase, construir_cadena
+from pcobra.core.usar_symbol_policy import validate_usar_symbol_metadata
 
 
 @dataclass(frozen=True)
@@ -144,6 +145,7 @@ def validar_ast_seguro(
     *,
     validadores_extra: Any,
     interpretador: Any | None = None,
+    validar_metadata_usar: bool = True,
     construir_cadena_fn: Callable[[Any], Any] = construir_cadena,
 ) -> None:
     """Aplica la cadena de validadores de seguridad sobre el AST."""
@@ -167,11 +169,21 @@ def validar_ast_seguro(
         for nombre, metadata in metadata_usar.items():
             if not isinstance(metadata, dict):
                 continue
-            modulo = metadata.get("module")
+            metadata_normalizada = dict(metadata)
+            if validar_metadata_usar:
+                metadata_normalizada = validate_usar_symbol_metadata(
+                    nombre,
+                    metadata_normalizada,
+                )
+            modulo = metadata_normalizada.get("module")
             if not isinstance(modulo, str):
                 continue
             for validador_registrable in validadores_registrables:
-                validador_registrable.registrar_simbolo_publico_usar(nombre, modulo, metadata=dict(metadata))
+                validador_registrable.registrar_simbolo_publico_usar(
+                    nombre,
+                    modulo,
+                    metadata=dict(metadata_normalizada),
+                )
     for nodo in ast:
         nodo.aceptar(validador)
 

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -89,7 +89,10 @@ from .import_utils import (
 )
 from .utils import validar_ast_estructural, ErrorEstructuraAST
 from .errors import CondicionNoBooleanaError
-from .usar_symbol_policy import make_usar_symbol_metadata, validate_usar_symbol_metadata
+from .usar_symbol_policy import (
+    build_and_validate_usar_symbol_metadata,
+    validate_usar_symbol_metadata,
+)
 from .environment import Environment
 
 MODULES_PATH = _DEFAULT_MODULES_PATH
@@ -2133,7 +2136,7 @@ class InterpretadorCobra:
 
             # Fase A: detectar colisiones de forma completa antes de definir.
             metadata_por_simbolo = {
-                nombre: make_usar_symbol_metadata(
+                nombre: build_and_validate_usar_symbol_metadata(
                     module_name=nodo.modulo,
                     symbol_name=nombre,
                     callable_obj=simbolo,
@@ -2306,7 +2309,7 @@ class InterpretadorCobra:
             metadata_simbolo = metadata_por_simbolo.get(nombre)
             if metadata_simbolo is None:
                 continue
-            self._validar_metadata_usar_o_fallar(nombre, metadata_simbolo)
+            metadata_simbolo = validate_usar_symbol_metadata(nombre, metadata_simbolo)
             contexto_actual.define(nombre, simbolo)
             self._usar_symbol_metadata[nombre] = dict(metadata_simbolo)
             if self.safe_mode and self._validador is not None and hasattr(self._validador, "registrar_simbolo_publico_usar"):

--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -49,6 +49,8 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
         Este método **solo** acepta metadata canónica ya validada por el contrato
         de ``usar`` (normalmente construida con
         :func:`pcobra.core.usar_symbol_policy.make_usar_symbol_metadata`).
+        Política fail-closed: si la metadata no respeta el contrato canónico, se
+        rechaza. Este método no reescribe ni corrige claves/valores.
         """
         if metadata is None:
             raise ValueError(

--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -325,6 +325,29 @@ def make_usar_symbol_metadata(
     }
 
 
+def build_and_validate_usar_symbol_metadata(
+    *,
+    module_name: str,
+    symbol_name: str,
+    callable_obj: object,
+) -> dict[str, object]:
+    """Fábrica canónica + validación final para metadata de ``usar``.
+
+    Este helper es la única ruta recomendada para construir metadata desde un
+    símbolo en memoria: crea la estructura con
+    :func:`make_usar_symbol_metadata`, valida con
+    :func:`validate_usar_symbol_metadata` y devuelve una copia normalizada para
+    almacenamiento/reinyección segura.
+    """
+    metadata = make_usar_symbol_metadata(
+        module_name=module_name,
+        symbol_name=symbol_name,
+        callable_obj=callable_obj,
+    )
+    metadata_validada = validate_usar_symbol_metadata(symbol_name, metadata)
+    return dict(metadata_validada)
+
+
 def _normalizar_metadata_simbolo_usar(nombre: str, metadata: object) -> dict[str, object]:
     """Normaliza e inspecciona metadata `usar` sin relajar seguridad.
 


### PR DESCRIPTION
### Motivation
- Evitar contenedores degradados y divergencias del contrato de metadata `usar` entre intérprete, validadores semánticos y pipeline CLI.
- Centralizar la ruta segura para crear y validar metadata de símbolos importados por `usar` y mantener política fail-closed.

### Description
- Añade `build_and_validate_usar_symbol_metadata(*, module_name, symbol_name, callable_obj)` en `src/pcobra/core/usar_symbol_policy.py` como fábrica canónica que construye con `make_usar_symbol_metadata`, valida con `validate_usar_symbol_metadata` y devuelve una copia normalizada para almacenamiento.
- Reemplaza la construcción directa de metadata en `InterpretadorCobra.ejecutar_usar` para usar `build_and_validate_usar_symbol_metadata` en `src/pcobra/core/interpreter.py` y refuerza la validación final con `validate_usar_symbol_metadata` justo antes de persistir/registrar la metadata al inyectar símbolos.
- Documenta explícitamente en `ValidadorPrimitivaPeligrosa.registrar_simbolo_publico_usar` (en `src/pcobra/core/semantic_validators/primitiva_peligrosa.py`) que solo acepta metadata canónica validada y que opera en modo fail-closed sin reescribir claves/valores.
- En `src/pcobra/cobra/cli/execution_pipeline.py` añade la validación previa opcional (`validar_metadata_usar=True`) al reinyectar metadata en validadores y hace la validación canónica antes de llamar a `registrar_simbolo_publico_usar` para prevenir contenedores degradados.

### Testing
- Compilé los módulos modificados con `python -m compileall src/pcobra/core/usar_symbol_policy.py src/pcobra/core/interpreter.py src/pcobra/core/semantic_validators/primitiva_peligrosa.py src/pcobra/cobra/cli/execution_pipeline.py` y la compilación finalizó sin errores.
- No se ejecutaron tests de unidad adicionales en este cambio; solo verificación de compilación automática que resultó exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a081b196bf08327ac7c0ab610e20d97)