### PR TITLE
Mejora diagnóstico fail-closed de metadata `usar` y cobertura de errores internos

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -939,7 +939,10 @@ class InterpretadorCobra:
         try:
             validate_usar_symbol_metadata(nombre, metadata)
         except ValueError as exc:
-            raise PrimitivaPeligrosaError(str(exc)) from exc
+            # Preserva el motivo original para diagnóstico en REPL sin exponer internals sensibles.
+            raise PrimitivaPeligrosaError(
+                f"validation_reason='{exc}'"
+            ) from exc
 
     @staticmethod
     def _detalle_debug_metadata_usar(
@@ -975,7 +978,7 @@ class InterpretadorCobra:
             tipo_recibido = type(metadata_validador).__name__
             raise PrimitivaPeligrosaError(
                 "Metadata de validador inválida para símbolos usar: "
-                f"tipo inválido en _metadata_simbolos_usar (tipo='{tipo_recibido}', codigo_interno='invalid_container')."
+                f"tipo inválido en _metadata_simbolos_usar (tipo='{tipo_recibido}', codigo_interno='invalid_container', troubleshooting='container_metadata_debe_ser_dict')."
                 f"{self._detalle_debug_metadata_usar(received_keys=set())}{detalle_etapa}"
             )
         claves_interp = set(self._usar_symbol_metadata.keys())
@@ -986,7 +989,7 @@ class InterpretadorCobra:
             raise PrimitivaPeligrosaError(
                 "Divergencia de metadata usar entre intérprete y validador"
                 f": claves divergentes (faltantes_en_validador={faltantes_en_validador}, "
-                f"extras_en_validador={extras_en_validador}, codigo_interno='missing_keys')."
+                f"extras_en_validador={extras_en_validador}, codigo_interno='missing_keys', troubleshooting='claves_de_metadata_desincronizadas')."
                 f"{self._detalle_debug_metadata_usar(expected_keys=claves_interp, received_keys=claves_validador)}{detalle_etapa}"
             )
         for nombre, metadata_interp in self._usar_symbol_metadata.items():
@@ -996,7 +999,7 @@ class InterpretadorCobra:
                 raise PrimitivaPeligrosaError(
                     "Metadata de validador inválida para símbolos usar: "
                     f"metadata de intérprete inválida para símbolo '{nombre}' "
-                    f"(codigo_interno='invalid_symbol_metadata', detalle={exc})."
+                    f"(clave_esperada='module|kind|public_api|sanitized', tipo='{type(metadata_interp).__name__}', codigo_interno='invalid_symbol_metadata', troubleshooting='metadata_interprete_no_cumple_contrato', detalle={exc})."
                     f"{self._detalle_debug_metadata_usar(symbol=nombre)}{detalle_etapa}"
                 ) from exc
             metadata_val = metadata_validador.get(nombre)
@@ -1007,13 +1010,13 @@ class InterpretadorCobra:
                 raise PrimitivaPeligrosaError(
                     "Metadata de validador inválida para símbolos usar: "
                     f"metadata por símbolo inválida para '{nombre}' "
-                    f"(tipo='{tipo_recibido}', codigo_interno='invalid_symbol_metadata', detalle={exc})."
+                    f"(clave_esperada='module|kind|public_api|sanitized', tipo='{tipo_recibido}', codigo_interno='invalid_symbol_metadata', troubleshooting='metadata_validador_no_cumple_contrato', detalle={exc})."
                     f"{self._detalle_debug_metadata_usar(symbol=nombre)}{detalle_etapa}"
                 ) from exc
             if metadata_interp != metadata_val:
                 raise PrimitivaPeligrosaError(
                     "Divergencia de metadata usar entre intérprete y validador"
-                    f": metadata por símbolo no coincide (símbolo='{nombre}', codigo_interno='mismatch_payload')."
+                    f": metadata por símbolo no coincide (símbolo='{nombre}', clave_esperada='module|kind|public_api|sanitized', tipo='{type(metadata_val).__name__}', codigo_interno='mismatch_payload', troubleshooting='payload_de_metadata_difiere')."
                     f"{self._detalle_debug_metadata_usar(symbol=nombre, expected_keys=set(metadata_interp.keys()), received_keys=set(metadata_val.keys()))}{detalle_etapa}"
                 )
 

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -496,3 +496,58 @@ def test_metadata_usar_error_debug_agrega_detalle_estructurado():
     assert "validate_usar_symbol_metadata" in mensaje
     assert "symbol" in mensaje
     assert "existe" in mensaje
+
+
+def test_metadata_usar_error_invalid_container_incluye_tipo_y_troubleshooting():
+    interp = InterpretadorCobra()
+    with patch("sys.stdout", new_callable=StringIO):
+        interp.ejecutar_ast(generar_ast('usar "archivo"\nimprimir(existe("README.md"))'))
+    interp._validador._metadata_simbolos_usar = []
+    with pytest.raises(PrimitivaPeligrosaError) as err:
+        interp.ejecutar_ast(generar_ast('imprimir(existe("README.md"))'))
+    mensaje = str(err.value)
+    assert "codigo_interno='invalid_container'" in mensaje
+    assert "tipo='list'" in mensaje
+    assert "troubleshooting='container_metadata_debe_ser_dict'" in mensaje
+
+
+def test_metadata_usar_error_invalid_symbol_metadata_preserva_motivo_original():
+    interp = InterpretadorCobra()
+    with patch("sys.stdout", new_callable=StringIO):
+        interp.ejecutar_ast(generar_ast('usar "archivo"\nimprimir(existe("README.md"))'))
+    interp._validador._metadata_simbolos_usar["existe"] = {"module": "archivo", "kind": "callable", "public_api": False, "sanitized": True}
+    with pytest.raises(PrimitivaPeligrosaError) as err:
+        interp.ejecutar_ast(generar_ast('imprimir(existe("README.md"))'))
+    mensaje = str(err.value)
+    assert "codigo_interno='invalid_symbol_metadata'" in mensaje
+    assert "símbolo 'existe'" in mensaje
+    assert "validation_reason='" in mensaje
+    assert "troubleshooting='metadata_validador_no_cumple_contrato'" in mensaje
+
+
+def test_metadata_usar_error_missing_keys_incluye_troubleshooting():
+    interp = InterpretadorCobra()
+    with patch("sys.stdout", new_callable=StringIO):
+        interp.ejecutar_ast(generar_ast('usar "archivo"\nimprimir(existe("README.md"))'))
+    interp._validador._metadata_simbolos_usar.pop("existe", None)
+    with pytest.raises(PrimitivaPeligrosaError) as err:
+        interp.ejecutar_ast(generar_ast('imprimir(existe("README.md"))'))
+    mensaje = str(err.value)
+    assert "codigo_interno='missing_keys'" in mensaje
+    assert "troubleshooting='claves_de_metadata_desincronizadas'" in mensaje
+
+
+def test_metadata_usar_error_mismatch_payload_incluye_detalle_simbolo_tipo_y_clave():
+    interp = InterpretadorCobra()
+    with patch("sys.stdout", new_callable=StringIO):
+        interp.ejecutar_ast(generar_ast('usar "archivo"\nimprimir(existe("README.md"))'))
+    interp._validador._metadata_simbolos_usar["existe"] = dict(interp._validador._metadata_simbolos_usar["existe"])
+    interp._validador._metadata_simbolos_usar["existe"]["module"] = "otro_modulo"
+    with pytest.raises(PrimitivaPeligrosaError) as err:
+        interp.ejecutar_ast(generar_ast('imprimir(existe("README.md"))'))
+    mensaje = str(err.value)
+    assert "codigo_interno='mismatch_payload'" in mensaje
+    assert "símbolo='existe'" in mensaje
+    assert "clave_esperada='module|kind|public_api|sanitized'" in mensaje
+    assert "tipo='dict'" in mensaje
+    assert "troubleshooting='payload_de_metadata_difiere'" in mensaje


### PR DESCRIPTION
### Motivation
- Aumentar la capacidad de diagnóstico cuando la metadata de `usar` está desincronizada manteniendo el comportamiento fail-closed.
- Conservar los `codigo_interno` existentes (`invalid_container`, `invalid_symbol_metadata`, `missing_keys`, `mismatch_payload`) y añadir un campo textual de troubleshooting para facilitar investigación sin exponer internals sensibles.
- Preservar el motivo original de validación para permitir diagnóstico en REPL sin filtrar detalles del backend.

### Description
- En `src/pcobra/core/interpreter.py` se cambió `_validar_metadata_usar_o_fallar` para que capture la razón original de `validate_usar_symbol_metadata` y la incluya en el `PrimitivaPeligrosaError` como `validation_reason='...'` sin publicar internals del validador.
- En `_asegurar_metadata_usar_sincronizada` se amplió el texto de los errores fail-closed para incluir el símbolo afectado cuando aplica, la(s) clave(s) esperada(s), el tipo recibido y un nuevo campo `troubleshooting='...'` consistente por categoría, manteniendo los `codigo_interno` actuales.
- Se añadieron cuatro pruebas unitarias en `tests/unit/test_safe_mode.py` que cubren y asertan fragmentos de mensaje para cada `codigo_interno`: `invalid_container`, `invalid_symbol_metadata`, `missing_keys` y `mismatch_payload`.

### Testing
- Se ejecutó `pytest -q tests/unit/test_safe_mode.py -k "metadata_usar_error"` para validar las nuevas pruebas, pero la ejecución falló en la fase de colección por un error de import relativo (`attempted relative import beyond top-level package`).
- Se reintentó con `PYTHONPATH=src pytest -q tests/unit/test_safe_mode.py -k "metadata_usar_error"` y el fallo de imports se mantuvo, por lo que las pruebas no pudieron completarse en este entorno automático.
- Las pruebas nuevas están en el repo y verifican la presencia de `codigo_interno` y los fragmentos `troubleshooting`, `validation_reason`, `símbolo` y `tipo` en los mensajes de error; su ejecución debería pasar en un entorno de test con imports correctamente configurados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08204b5b8c8327901c5121b9d7cf6f)