### PR TITLE
test: reforzar contratos de `usar` en runtime, política y sintaxis

### DIFF
--- a/tests/integration/test_usar_runtime_contract.py
+++ b/tests/integration/test_usar_runtime_contract.py
@@ -212,6 +212,23 @@ def test_usar_archivo_carga_existe_sin_error_metadata():
     assert isinstance(existe("README.md"), bool)
 
 
+def test_usar_modulos_validos_no_reporta_error_metadata():
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"datos": "datos", "numero": "numero", "texto": "texto", "archivo": "archivo"})
+
+    interp.ejecutar_usar(_nodo("datos"))
+    interp.ejecutar_usar(_nodo("numero"))
+    interp.ejecutar_usar(_nodo("texto"))
+    interp.ejecutar_usar(_nodo("archivo"))
+
+    simbolos = interp.contextos[-1].values
+    assert interp.contextos[-1].get("longitud")([1, 2, 3]) == 3
+    assert interp.contextos[-1].get("es_finito")(10) is True
+    assert callable(interp.contextos[-1].get("recortar"))
+    assert isinstance(interp.contextos[-1].get("existe")("README.md"), bool)
+    assert all("metadata" not in str(k).lower() for k in simbolos.keys())
+
+
 def test_usar_carga_modulos_publicos_datos_numero_texto():
     interp = InterpretadorCobra()
     interp.configurar_restriccion_usar_repl({"datos": "datos", "numero": "numero", "texto": "texto"})
@@ -237,6 +254,24 @@ def test_repl_funcional_minimo_datos_numero_archivo_via_runtime():
 
     interp.ejecutar_usar(_nodo("archivo"))
     assert isinstance(interp.contextos[-1].get("existe")("README.md"), bool)
+
+
+def test_sanear_exports_descarta_simbolo_fuera_api_publica_al_usar():
+    modulo = ModuleType("texto")
+    modulo.__all__ = [*USAR_RUNTIME_EXPORT_OVERRIDES["texto"], "normalizar_unicode"]
+    for nombre in USAR_RUNTIME_EXPORT_OVERRIDES["texto"]:
+        setattr(modulo, nombre, lambda *args, **kwargs: (args, kwargs))
+    modulo.normalizar_unicode = lambda texto, forma="NFC": texto
+
+    mapa_limpio, conflictos = cobra_usar_loader.sanitizar_exports_publicos(modulo, "texto")
+    permitidos, _clasificacion, _warnings = usar_symbol_policy.sanear_exportables_para_usar(list(mapa_limpio.items()))
+
+    nombres = {nombre for nombre, _ in permitidos}
+    assert "normalizar_unicode" not in nombres
+    assert any(
+        conflicto.get("symbol") == "normalizar_unicode" and conflicto.get("code") == "outside_public_api"
+        for conflicto in conflictos
+    )
 
 
 def test_integridad_estatica_lexer_y_parser_sin_diff_inesperado():

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -103,11 +103,9 @@ def test_usar_archivo_existe_readme_no_falla_por_metadata():
 
 
 def test_sintaxis_usar_sin_cadena_rechaza_con_error_claro():
-    interp = InterpretadorCobra()
-    ast = generar_ast('usar archivo')
+    with pytest.raises(Exception, match=r"Se esperaba una ruta de módulo entre comillas"):
+        generar_ast('usar archivo')
 
-    with pytest.raises(Exception, match=r"(cadena|string|literal)"):
-        interp.ejecutar_ast(ast)
 def test_usar_datos_longitud_builtin_permanece_en_3():
     interp = InterpretadorCobra()
     ast = generar_ast('usar "datos"\nvar xs = [1, 2, 3]\nimprimir(longitud(xs))\nimprimir(longitud([1,2,3]))')


### PR DESCRIPTION
### Motivation
- Asegurar que `usar` sobre módulos públicos (`datos`, `numero`, `texto`, `archivo`) expone la API pública útil y no introduce errores/huellas de metadata en flujos válidos.
- Verificar que símbolos fuera de la API pública son correctamente descartados tras el saneamiento (`sanitizar_exports_publicos` + `sanear_exportables_para_usar`).
- Endurecer la verificación de sintaxis para que `usar archivo` (sin comillas) falle con un mensaje claro y estable: `Se esperaba una ruta de módulo entre comillas`.

### Description
- Añade `test_usar_modulos_validos_no_reporta_error_metadata` en `tests/integration/test_usar_runtime_contract.py` que carga `datos`, `numero`, `texto` y `archivo` vía runtime y valida `longitud([1,2,3]) == 3`, `es_finito(10) is True`, un símbolo representativo de `texto` y que `existe("README.md")` devuelve booleano. 
- Añade `test_sanear_exports_descarta_simbolo_fuera_api_publica_al_usar` en `tests/integration/test_usar_runtime_contract.py` que comprueba que `normalizar_unicode` (fuera de la API pública) es descartado tras `sanitizar_exports_publicos` y `sanear_exportables_para_usar` y que se reporta el conflicto `outside_public_api`.
- Ajusta `test_sintaxis_usar_sin_cadena_rechaza_con_error_claro` en `tests/unit/test_safe_mode.py` para capturar el error en la fase de parsing y exigir el mensaje exacto `Se esperaba una ruta de módulo entre comillas`.

### Testing
- Ejecuté los tests focalizados con `pytest -q tests/integration/test_usar_runtime_contract.py::test_usar_modulos_validos_no_reporta_error_metadata tests/integration/test_usar_runtime_contract.py::test_sanear_exports_descarta_simbolo_fuera_api_publica_al_usar tests/unit/test_safe_mode.py::test_sintaxis_usar_sin_cadena_rechaza_con_error_claro` y los tres tests pasaron: `3 passed`.
- Durante verificación se probaron corridas más amplias y se observaron problemas de formato de selección y un `MemoryError` en una ejecución amplia de pytest, por lo que la verificación final se limitó a las pruebas relevantes y éstas resultaron exitosas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08215990e883278fda2cf01ccc3881)