### PR TITLE
Normalizar contenedores iniciales de metadata de `usar` en InterpretadorCobra

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -508,6 +508,18 @@ class InterpretadorCobra:
         # Metadatos de símbolos inyectados por `usar` para soportar reimport idempotente.
         # nombre_simbolo -> {"module": str, "exported_name": str, "callable_id": int}
         self._usar_symbol_metadata: dict[str, dict[str, object]] = {}
+        self._normalizar_contenedor_metadata_usar_inicial()
+
+    def _normalizar_contenedor_metadata_usar_inicial(self) -> None:
+        """Inicializa contenedores de metadata de `usar` solo en el arranque."""
+        if (not hasattr(self, "_usar_symbol_metadata")) or self._usar_symbol_metadata is None:
+            self._usar_symbol_metadata = {}
+
+        if hasattr(self, "_validador"):
+            if not hasattr(self._validador, "_metadata_simbolos_usar"):
+                self._validador._metadata_simbolos_usar = {}
+            elif self._validador._metadata_simbolos_usar is None:
+                self._validador._metadata_simbolos_usar = {}
 
     def configurar_restriccion_usar_repl(self, alias_map: dict[str, str] | None) -> None:
         """Configura whitelist explícita de módulos `usar` para flujo REPL.


### PR DESCRIPTION
### Motivation
- Inicializar de forma explícita y segura los contenedores de metadata usados por `usar` durante la construcción del intérprete, evitando correcciones silenciosas que puedan ocultar corrupción de datos y preservando los fallos posteriores cuando los tipos sean inválidos.

### Description
- Se añadió el método privado ` _normalizar_contenedor_metadata_usar_inicial()` y se invoca al final de `InterpretadorCobra.__init__`, implementando las reglas solicitadas: inicializar `self._usar_symbol_metadata` a `{}` solo si no existe o es `None`, no autocorregir si ya existe con tipo no-`dict`, y si existe `self._validador` crear `_metadata_simbolos_usar` cuando falte o convertirlo a `{}` únicamente si es `None`, sin tocar casos donde el validador tenga tipos inválidos; no se modificó `_asegurar_metadata_usar_sincronizada`.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/core/interpreter.py` y la compilación del archivo concluyó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08279837488327bc2e3b22935298db)