### PR TITLE
Asegura inicialización idempotente de metadata `usar` en intérprete y rutas CLI

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -257,6 +257,9 @@ class InteractiveCommand(BaseCommand):
         """
         super().__init__()
         self.interpretador = interpretador
+        asegurar_estado_runtime = getattr(self.interpretador, "asegurar_estado_runtime_inicial", None)
+        if callable(asegurar_estado_runtime):
+            asegurar_estado_runtime()
         self._allow_insecure_fallback = False
         # Contrato de logging: no agregar handlers por comando; la emisión se
         # centraliza en root configurado desde ``pcobra.cli.configure_logging``.
@@ -996,10 +999,13 @@ class InteractiveCommand(BaseCommand):
         if self._interpretador_sesion is None:
             self._interpretador_sesion = self.interpretador
             self._configurar_restriccion_usar_repl()
-            return
-        if self.interpretador is not self._interpretador_sesion:
+        elif self.interpretador is not self._interpretador_sesion:
             self.interpretador = self._interpretador_sesion
             self._configurar_restriccion_usar_repl()
+
+        asegurar_estado_runtime = getattr(self.interpretador, "asegurar_estado_runtime_inicial", None)
+        if callable(asegurar_estado_runtime):
+            asegurar_estado_runtime()
 
     def _clasificar_error_repl(self, error: Exception) -> str:
         """Clasifica errores del REPL para un reporte único en el loop principal."""

--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -108,6 +108,9 @@ def prevalidar_y_parsear_codigo(codigo: str) -> Any:
 def ejecutar_ast(ast: Any, interpreter: Any) -> Any:
     """Ejecuta un AST usando una instancia explícita de intérprete."""
 
+    asegurar_estado_runtime = getattr(interpreter, "asegurar_estado_runtime_inicial", None)
+    if callable(asegurar_estado_runtime):
+        asegurar_estado_runtime()
     return interpreter.ejecutar_ast(ast)
 
 
@@ -232,6 +235,9 @@ def preparar_interpretador(
         safe_mode=opciones.safe_mode,
         extra_validators=opciones.validadores_extra,
     )
+    asegurar_estado_runtime = getattr(interpretador, "asegurar_estado_runtime_inicial", None)
+    if callable(asegurar_estado_runtime):
+        asegurar_estado_runtime()
     return InterpreterSetup(
         interpretador_cls=interpretador_cls,
         safe_mode=opciones.safe_mode,

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -508,6 +508,14 @@ class InterpretadorCobra:
         # Metadatos de símbolos inyectados por `usar` para soportar reimport idempotente.
         # nombre_simbolo -> {"module": str, "exported_name": str, "callable_id": int}
         self._usar_symbol_metadata: dict[str, dict[str, object]] = {}
+        self.asegurar_estado_runtime_inicial()
+
+    def asegurar_estado_runtime_inicial(self) -> None:
+        """Garantiza estado mínimo de runtime para metadata de `usar`.
+
+        Este método es idempotente: solo crea contenedores cuando faltan o
+        cuando están en ``None``, sin reescribir diccionarios ya poblados.
+        """
         self._normalizar_contenedor_metadata_usar_inicial()
 
     def _normalizar_contenedor_metadata_usar_inicial(self) -> None:


### PR DESCRIPTION
### Motivation
- Evitar regresiones donde `_metadata_simbolos_usar` quede en `None` cuando se construye o se reusa un `InterpretadorCobra` fuera del camino directo de `__init__`.
- Garantizar que la normalización de metadata de `usar` sea idempotente y no reescriba diccionarios ya poblados entre sentencias REPL.
- Cubrir los puntos de entrada CLI/REPL donde se construye o se reaprovecha el intérprete para asegurar consistencia del runtime.

### Description
- Añade el método público `asegurar_estado_runtime_inicial()` en `InterpretadorCobra` que delega en el normalizador interno sin sobreescribir contenedores ya existentes. 
- Llama a `asegurar_estado_runtime_inicial()` desde `InterpretadorCobra.__init__` para centralizar la inicialización mínima del runtime.
- Invoca la rutina al construir/reusar intérprete en el pipeline y CLI: en `execution_pipeline.preparar_interpretador`, en `execution_pipeline.ejecutar_ast` y en `InteractiveCommand` (`__init__` y `_sincronizar_interpretador_sesion`).
- Conserva la lógica previa de normalización que solo crea contenedores si faltan o están en `None`, preservando diccionarios con datos.

### Testing
- Compilación sintáctica ejecutada sobre los archivos modificados con `python -m compileall -q src/pcobra/core/interpreter.py src/pcobra/cobra/cli/execution_pipeline.py src/pcobra/cobra/cli/commands/interactive_cmd.py` y salida `OK` (éxito).
- Búsqueda estática con `rg` para verificar ubicaciones relacionadas con `_metadata_simbolos_usar` y la presencia de las invocaciones añadidas, la cual produjo los hallazgos esperados (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a082fb79c9c8327aa2a91a6f3592001)