### PR TITLE
Refuerza metadata canónica de `usar` y añade prueba para `datos.longitud`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2188,14 +2188,23 @@ class InterpretadorCobra:
                 raise ImportError(mensaje_usuario)
 
             # Fase A: detectar colisiones de forma completa antes de definir.
-            metadata_por_simbolo = {
-                nombre: build_and_validate_usar_symbol_metadata(
+            metadata_por_simbolo = {}
+            for nombre, simbolo in simbolos_saneados:
+                metadata_simbolo = build_and_validate_usar_symbol_metadata(
                     module_name=nodo.modulo,
                     symbol_name=nombre,
                     callable_obj=simbolo,
                 )
-                for nombre, simbolo in simbolos_saneados
-            }
+                # Refuerza explícitamente el contrato canónico durante la fase
+                # de preflight para evitar mutaciones parciales aguas abajo.
+                metadata_simbolo["module"] = nodo.modulo
+                metadata_simbolo["origin_kind"] = "usar"
+                metadata_simbolo["sanitized"] = True
+                metadata_simbolo["public_api"] = True
+                metadata_por_simbolo[nombre] = validate_usar_symbol_metadata(
+                    nombre,
+                    metadata_simbolo,
+                )
             conflictos = self._detectar_conflictos_usar_en_contexto(
                 simbolos_saneados,
                 metadata_por_simbolo=metadata_por_simbolo,

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -218,6 +218,30 @@ def test_usar_metadata_minima_y_consistente_entre_interprete_y_validador():
         assert metadata_validador == metadata
 
 
+def test_usar_datos_longitud_metadata_completa_en_interprete_y_validador():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "datos"')
+
+    interp.ejecutar_ast(ast)
+
+    metadata_interp = interp._usar_symbol_metadata["longitud"]
+    assert metadata_interp["module"] == "datos"
+    assert metadata_interp["origin_kind"] == "usar"
+    assert metadata_interp["sanitized"] is True
+    assert metadata_interp["public_api"] is True
+    assert metadata_interp["symbol"] == "longitud"
+    assert isinstance(metadata_interp["callable"], bool)
+
+    metadata_validador = interp._validador._metadata_simbolos_usar["longitud"]
+    assert metadata_validador["module"] == "datos"
+    assert metadata_validador["origin_kind"] == "usar"
+    assert metadata_validador["sanitized"] is True
+    assert metadata_validador["public_api"] is True
+    assert metadata_validador["symbol"] == "longitud"
+    assert isinstance(metadata_validador["callable"], bool)
+    assert metadata_validador == metadata_interp
+
+
 def test_roundtrip_metadata_usar_registro_y_sincronizacion_sin_mutaciones():
     interp = InterpretadorCobra()
     ast = generar_ast('usar "archivo"')


### PR DESCRIPTION
### Motivation
- Asegurar que la metadata construida durante `usar` incluya y confirme los campos canónicos requeridos (`module`, `origin_kind`, `sanitized`, `public_api`) para evitar desincronizaciones o mutaciones parciales antes del registro y auditoría.
- Mantener el contrato fail-closed de validación de metadata y garantizar que los validadores reciban el payload completo y consistente.
- Añadir cobertura específica para el símbolo `longitud` del módulo `datos` para verificar la sincronización de metadata entre intérprete y validador.

### Description
- En `InterpretadorCobra.ejecutar_usar` se reemplaza la construcción en línea de `metadata_por_simbolo` por un bucle que llama a `build_and_validate_usar_symbol_metadata`, fuerza explícitamente `module`, `origin_kind`, `sanitized` y `public_api` en cada entrada y revalida con `validate_usar_symbol_metadata` antes de seguir el flujo de colisiones e inyección en contexto.
- Se mantiene la propagación completa del payload hacia el validador usando `metadata=dict(metadata_simbolo)` al invocar `registrar_simbolo_publico_usar`, sin recortes del objeto metadata.
- Se incorpora una prueba unitaria nueva `test_usar_datos_longitud_metadata_completa_en_interprete_y_validador` en `tests/unit/test_safe_mode.py` que ejecuta `usar "datos"` y verifica la metadata completa de `longitud` en `interp._usar_symbol_metadata["longitud"]` y `interp._validador._metadata_simbolos_usar["longitud"]`.
- Archivos modificados: `src/pcobra/core/interpreter.py` y `tests/unit/test_safe_mode.py`.

### Testing
- `python -m py_compile src/pcobra/core/interpreter.py tests/unit/test_safe_mode.py` — Éxito (sin errores de sintaxis).
- `pytest -q tests/unit/test_safe_mode.py -k 'usar_datos_longitud_metadata_completa or metadata_minima_y_consistente'` — Falló durante la colección por error de importación en el entorno de ejecución: `attempted relative import beyond top-level package`.
- Reintentos con `PYTHONPATH=src` y `PYTHONPATH=src/pcobra` para ejecutar los tests focalizados — Ambos fallaron con el mismo error de importación durante la colección.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083a08fa5883278c0c7cc1955eb5a5)