### PR TITLE
test: cubrir regresiones de preauditoría y secuencias `usar` seguras

### DIFF
--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -567,6 +567,40 @@ def test_metadata_usar_error_debug_agrega_detalle_estructurado():
     assert "existe" in mensaje
 
 
+def test_preauditoria_sentencia_simple_con_lista_sin_usar_no_reporta_invalid_container_nonetype():
+    interp = InterpretadorCobra()
+
+    with patch("sys.stdout", new_callable=StringIO):
+        interp.ejecutar_ast(generar_ast('var xs = [1, 2, 3]'))
+
+    assert isinstance(interp._validador._metadata_simbolos_usar, dict)
+
+def test_aceptacion_repl_runtime_datos_numero_archivo_y_politica_numpy_en_modo_seguro():
+    interp = InterpretadorCobra()
+
+    with patch("sys.stdout", new_callable=StringIO) as salida:
+        interp.ejecutar_ast(
+            generar_ast(
+                'var xs = [1, 2, 3]\n'
+                'usar "datos"\n'
+                'imprimir(longitud(xs))\n'
+                'imprimir(longitud([1,2,3]))\n'
+                'usar "numero"\n'
+                'imprimir(es_finito(10))\n'
+                'usar "archivo"\n'
+                'imprimir(existe("README.md"))'
+            )
+        )
+
+    lineas = [linea.strip() for linea in salida.getvalue().splitlines() if linea.strip()]
+    assert lineas.count("3") >= 2
+    assert "verdadero" in lineas
+    assert lineas[-1] in {"verdadero", "falso"}
+
+    with pytest.raises(PermissionError, match=r"(modulo_fuera_catalogo_publico|módulo fuera del catálogo público)"):
+        interp.ejecutar_ast(generar_ast('usar "numpy"'))
+
+
 def test_metadata_usar_error_invalid_container_incluye_tipo_y_troubleshooting():
     interp = InterpretadorCobra()
     with patch("sys.stdout", new_callable=StringIO):


### PR DESCRIPTION
### Motivation
- Evitar regresiones donde la preauditoría de una sentencia simple con listas deje la metadata interna en un estado inesperado o produzca errores tipo `invalid_container` con `NoneType` al ejecutar código en un intérprete nuevo.
- Añadir cobertura que valide flujos REPL en modo seguro para las entradas comunes `datos`, `numero` y `archivo` y asegurar que la política negativa contra `usar "numpy"` se mantiene.

### Description
- Agrega `test_preauditoria_sentencia_simple_con_lista_sin_usar_no_reporta_invalid_container_nonetype` en `tests/unit/test_safe_mode.py` que ejecuta `var xs = [1, 2, 3]` y verifica que `interp._validador._metadata_simbolos_usar` sea un `dict`.
- Agrega `test_aceptacion_repl_runtime_datos_numero_archivo_y_politica_numpy_en_modo_seguro` en `tests/unit/test_safe_mode.py` que evalúa una secuencia segura completa en un `InterpretadorCobra` con `usar "datos"`, `usar "numero"` y `usar "archivo"` y verifica salidas esperadas para `longitud`, `es_finito` y `existe`, además de comprobar que `usar "numpy"` siga rechazado.
- No se modificó código de runtime; los cambios son exclusivamente de pruebas unitarias de seguridad/repl.

### Testing
- Se compiló el archivo con `python -m py_compile tests/unit/test_safe_mode.py` y la compilación fue exitosa.
- Ejecuciones puntuales de `pytest` contra combinaciones de tests arrojaron errores de entorno (import path / `attempted relative import beyond top-level package`) y una falla intermedia por metadata inesperada en un stub durante iteración de desarrollo, por lo que no se incluyó cambio de runtime para resolver esa situación.
- Las nuevas pruebas añadidas fueron validadas sintácticamente y el commit fue creado; las ejecuciones de `pytest` a nivel de integración requieren ajuste de entorno/monkeypatch adicionales y no fueron aprobadas en este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08412a5ac08327b483ce02a7743ab7)