### PR TITLE
feat(cli): factory canónico para construcción segura de intérprete

### DIFF
--- a/src/pcobra/cobra/cli/commands/profile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/profile_cmd.py
@@ -19,6 +19,7 @@ from pcobra.cobra.core.interpreter import InterpretadorCobra
 from pcobra.cobra.core.sandbox import validar_dependencias
 from pcobra.cobra.core.semantic_validators import PrimitivaPeligrosaError, construir_cadena
 from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.cli.execution_pipeline import construir_interprete_seguro_canonico
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.services.format_service import format_code_with_black
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
@@ -153,8 +154,10 @@ class ProfileCommand(BaseCommand):
 
         try:
             profiler.enable()
-            InterpretadorCobra(
-                safe_mode=seguro, extra_validators=extra_validators
+            construir_interprete_seguro_canonico(
+                interpretador_cls=InterpretadorCobra,
+                safe_mode=seguro,
+                extra_validators=extra_validators,
             ).ejecutar_ast(ast)
             profiler.disable()
             

--- a/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/repl_cmd.py
@@ -7,6 +7,7 @@ from pcobra.cobra.cli.commands.interactive_cmd import (
     SANDBOX_DOCKER_CHOICES,
 )
 from pcobra.cobra.cli.execution_pipeline import (
+    construir_interprete_seguro_canonico,
     prevalidar_y_parsear_codigo,
 )
 from pcobra.cobra.cli.i18n import _
@@ -32,7 +33,13 @@ class ReplCommandV2(BaseCommand):
     capability = "execute"
     def __init__(self) -> None:
         super().__init__()
-        self._delegate = InteractiveCommand(InterpretadorCobra())
+        self._delegate = InteractiveCommand(
+            construir_interprete_seguro_canonico(
+                interpretador_cls=InterpretadorCobra,
+                safe_mode=True,
+                extra_validators=None,
+            )
+        )
         self._delegate.name = self.name
         # Mantener una única instancia viva para todo el ciclo de la sesión.
         self._interpretador_persistente: Any | None = self._delegate.interpretador

--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -66,16 +66,17 @@ def construir_script_sandbox_canonico(
     """Genera un script sandbox con imports canónicos del runtime Cobra."""
 
     extra_repr = repr(extra_validators if extra_validators is not None else None)
-    safe_mode_fragment = (
+    kwargs_fragment = (
         ""
         if safe_mode is None
         else f", safe_mode={safe_mode!r}, extra_validators={extra_repr}"
     )
     script = (
         "from pcobra.cobra.cli.execution_pipeline import prevalidar_y_parsear_codigo\n"
+        "from pcobra.cobra.cli.execution_pipeline import construir_interprete_seguro_canonico\n"
         "from pcobra.cobra.core.runtime import InterpretadorCobra\n"
         f"_ast = prevalidar_y_parsear_codigo({codigo!r})\n"
-        f"_interp = InterpretadorCobra({safe_mode_fragment.lstrip(', ')})\n"
+        f"_interp = construir_interprete_seguro_canonico(interpretador_cls=InterpretadorCobra{kwargs_fragment})\n"
         "_resultado = _interp.ejecutar_ast(_ast)\n"
     )
     if imprimir_resultado:
@@ -205,6 +206,47 @@ def construir_interprete(
     )
 
 
+def construir_interprete_seguro_canonico(
+    *,
+    interpretador_cls: Any,
+    safe_mode: bool,
+    extra_validators: Any,
+) -> Any:
+    """Factory canónico de runtime para intérprete CLI.
+
+    CONTRATO_RUNTIME_METADATA_USAR_INICIAL:
+    Toda creación/rehidratación de intérprete debe pasar por este factory para
+    garantizar inicialización mínima del runtime y consistencia de metadata
+    ``usar`` entre intérprete y validador.
+    """
+
+    interpretador = construir_interprete(
+        interpretador_cls=interpretador_cls,
+        safe_mode=safe_mode,
+        extra_validators=extra_validators,
+    )
+    asegurar_estado_runtime = getattr(interpretador, "asegurar_estado_runtime_inicial", None)
+    if callable(asegurar_estado_runtime):
+        asegurar_estado_runtime()
+
+    if not isinstance(getattr(interpretador, "_usar_symbol_metadata", None), dict):
+        raise TypeError(
+            "Invariante runtime violada: interpreter._usar_symbol_metadata debe ser dict."
+        )
+    if safe_mode and not hasattr(interpretador, "_validador"):
+        raise TypeError(
+            "Invariante runtime violada: en safe_mode=True debe existir interpreter._validador."
+        )
+    validador = getattr(interpretador, "_validador", None)
+    if validador is not None and not isinstance(
+        getattr(validador, "_metadata_simbolos_usar", None), dict
+    ):
+        raise TypeError(
+            "Invariante runtime violada: interpreter._validador._metadata_simbolos_usar debe ser dict."
+        )
+    return interpretador
+
+
 def resolver_interpretador_cls(
     *,
     module_name: str,
@@ -230,14 +272,11 @@ def preparar_interpretador(
         extra_validators=extra_validators,
         interpretador_cls=interpretador_cls,
     )
-    interpretador = construir_interprete(
+    interpretador = construir_interprete_seguro_canonico(
         interpretador_cls=interpretador_cls,
         safe_mode=opciones.safe_mode,
         extra_validators=opciones.validadores_extra,
     )
-    asegurar_estado_runtime = getattr(interpretador, "asegurar_estado_runtime_inicial", None)
-    if callable(asegurar_estado_runtime):
-        asegurar_estado_runtime()
     return InterpreterSetup(
         interpretador_cls=interpretador_cls,
         safe_mode=opciones.safe_mode,

--- a/src/pcobra/cobra/cli/services/test_service.py
+++ b/src/pcobra/cobra/cli/services/test_service.py
@@ -9,6 +9,7 @@ from pcobra.cobra.core.interpreter import InterpretadorCobra
 from pcobra.cobra.core.sandbox import ejecutar_en_contenedor, ejecutar_en_sandbox, ejecutar_en_sandbox_js
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.execution_pipeline import construir_interprete_seguro_canonico
 from pcobra.cobra.cli.mode_policy import validar_politica_modo
 from pcobra.cobra.cli.services.contracts import TestRequest, normalize_test_request
 from pcobra.cobra.cli.target_policies import (
@@ -32,7 +33,11 @@ class TestService:
     SUPPORTED_LANGUAGES = target_cli_choices(VERIFICATION_EXECUTABLE_TARGETS)
 
     def __init__(self) -> None:
-        self._interprete = InterpretadorCobra()
+        self._interprete = construir_interprete_seguro_canonico(
+            interpretador_cls=InterpretadorCobra,
+            safe_mode=True,
+            extra_validators=None,
+        )
         self._logger = logging.getLogger(__name__)
 
     def run(self, request: TestRequest) -> int:

--- a/src/pcobra/cobra/cli/services/verification_service.py
+++ b/src/pcobra/cobra/cli/services/verification_service.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from pcobra.cobra.build import backend_pipeline
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.execution_pipeline import construir_interprete_seguro_canonico
 from pcobra.cobra.cli.target_policies import VERIFICATION_EXECUTABLE_TARGETS
 from pcobra.cobra.core import Lexer, Parser
 from pcobra.cobra.core.interpreter import InterpretadorCobra
@@ -84,7 +85,11 @@ def execute_runtime_verification(archivo: str, lenguajes: list[str]) -> int:
     ast = Parser(tokens).parsear()
 
     with patch("sys.stdout", new_callable=StringIO) as out:
-        InterpretadorCobra().ejecutar_ast(ast)
+        construir_interprete_seguro_canonico(
+            interpretador_cls=InterpretadorCobra,
+            safe_mode=True,
+            extra_validators=None,
+        ).ejecutar_ast(ast)
     expected = out.getvalue().replace("\r\n", "\n")
 
     for language in lenguajes:


### PR DESCRIPTION
### Motivation
- Centralizar la construcción/rehidratación del `InterpretadorCobra` en un único punto para asegurar inicialización consistente del runtime. 
- Garantizar que tras construir el intérprete siempre se invoque `asegurar_estado_runtime_inicial()` y se verifiquen invariantes mínimas de metadata/validador.
- Evitar instanciaciones dispersas que puedan dejar el runtime en estados inválidos y detectar esas condiciones temprano.

### Description
- Añadido `construir_interprete_seguro_canonico(*, interpretador_cls, safe_mode, extra_validators)` en `pcobra.cobra.cli.execution_pipeline` con comentario de contrato `CONTRATO_RUNTIME_METADATA_USAR_INICIAL` que documenta el requisito.
- El factory realiza: 1) construcción del intérprete; 2) llamada a `asegurar_estado_runtime_inicial()` si existe; 3) comprobación de las invariantes: `isinstance(interpreter._usar_symbol_metadata, dict)`, existencia de `_validador` cuando `safe_mode=True`, y `isinstance(interpreter._validador._metadata_simbolos_usar, dict)` si hay validador.
- `preparar_interpretador` ahora usa exclusivamente `construir_interprete_seguro_canonico` en lugar de instanciación directa y llamada ad-hoc a `asegurar_estado_runtime_inicial()`.
- Actualizado el `script` sandbox canónico para crear el intérprete vía el factory (evita instanciación directa dentro del script generado).
- Migrados callsites que creaban intérpretes directamente para usar el factory: `ReplCommandV2`, `ProfileCommand`, `TestService` y `verification_service.execute_runtime_verification`.

### Testing
- Ejecutado: `python -m pytest -q tests/unit/test_cli_interactive_cmd.py -k "repl or sandbox" tests/unit/test_cli_execution_pipeline_contract.py -k "paridad or contrato"`; esta ejecución falló en fase de collection por un `ImportError` relacionado con rutas de import (no se pasó `PYTHONPATH=src`).
- Ejecutado con `PYTHONPATH=src`: `pytest -q tests/unit/test_repl_command_v2.py tests/unit/test_cli_execution_pipeline_contract.py -k "repl or pipeline"` y el resultado fue parcial: `5 failed, 30 passed` (las 5 fallas están en tests de REPL v2 y apuntan a dobles/mocks que esperan una firma distinta — p.ej. `unexpected keyword argument 'ast_preparseado'`).
- Conclución de pruebas automatizadas: los cambios se ejecutan pero hay 5 fallos en el conjunto REPL v2 que requieren ajustar los dobles/pruebas que dependen de firmas internas del flujo REPL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08496d44e88327a98c7b11f205acd9)