### PR TITLE
Refactoriza metadata de `usar` por etapa de ciclo de vida

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -516,10 +516,19 @@ class InterpretadorCobra:
         Este método es idempotente: solo crea contenedores cuando faltan o
         cuando están en ``None``, sin reescribir diccionarios ya poblados.
         """
-        self._normalizar_contenedor_metadata_usar_inicial()
+        self._normalizar_metadata_usar_en_inicializacion()
 
-    def _normalizar_contenedor_metadata_usar_inicial(self) -> None:
-        """Inicializa contenedores de metadata de `usar` solo en el arranque."""
+    def _normalizar_metadata_usar_en_inicializacion(self) -> None:
+        """Normaliza contenedores mínimos de metadata para etapa='inicialización'.
+
+        Reglas:
+        - Si falta ``_usar_symbol_metadata`` o está en ``None``, crear ``{}``.
+        - Si falta ``_metadata_simbolos_usar`` en validador o está en ``None``,
+          crear ``{}``.
+        - Si ``_metadata_simbolos_usar`` existe y no es ``dict``, no corregir de
+          forma silenciosa aquí; la validación estricta en etapa='pre-auditoría'
+          debe fallar con ``invalid_container``.
+        """
         if (not hasattr(self, "_usar_symbol_metadata")) or self._usar_symbol_metadata is None:
             self._usar_symbol_metadata = {}
 
@@ -1020,8 +1029,17 @@ class InterpretadorCobra:
                 metadata_validador[nombre] = dict(metadata_interp)
 
     def _asegurar_metadata_usar_sincronizada(self, *, etapa: str | None = None) -> None:
+        """Valida sincronización estricta para etapa='pre-auditoría'.
+
+        Política fail-closed: cualquier tipo inválido de contenedor dispara
+        ``invalid_container`` y aborta la ejecución segura.
+        """
         if not self.safe_mode or self._validador is None:
             return
+        self._validar_metadata_usar_en_ejecucion(etapa=etapa)
+
+    def _validar_metadata_usar_en_ejecucion(self, *, etapa: str | None = None) -> None:
+        """Valida metadata de `usar` en etapa='pre-auditoría' de forma estricta."""
         metadata_validador = getattr(self._validador, "_metadata_simbolos_usar", None)
         detalle_etapa = f" etapa='{etapa}'" if etapa else ""
         if not isinstance(metadata_validador, dict):


### PR DESCRIPTION
### Motivation
- Hacer explícita y determinista la semántica de normalización y validación de la metadata asociada a `usar` separando la lógica por etapas del ciclo de vida (`inicialización` vs `pre-auditoría`).
- Evitar correcciones silenciosas de contenedores inválidos durante la inicialización y garantizar una política fail-closed durante la comprobación previa a auditoría usando el código interno `invalid_container`.

### Description
- Se extrajo el helper de inicialización ` _normalizar_metadata_usar_en_inicializacion()` y se invoca desde `asegurar_estado_runtime_inicial()` para aplicar las reglas de `etapa='inicialización'` con docstring explicativo. 
- En la inicialización se crean `{}` cuando falta o es `None` `self._usar_symbol_metadata` y `self._validador._metadata_simbolos_usar`, pero no se corrigen silenciosamente los casos en que `_metadata_simbolos_usar` existe y no es `dict`.
- Se separó la validación estricta en `_validar_metadata_usar_en_ejecucion()` y `_asegurar_metadata_usar_sincronizada()` ahora delega en él; la validación lleva la semántica de `etapa='pre-auditoría'` y conserva la política fail-closed con `invalid_container` para tipos inválidos. 
- Se añadieron docstrings que usan explícitamente los términos solicitados: `etapa='inicialización'`, `etapa='pre-auditoría'` y `invalid_container` para dejar la intención inequívoca.

### Testing
- Ejecuté `python -m pytest -q tests/unit/test_usar_symbol_policy.py` y todos los tests unitarios relacionados pasaron (`14 passed`).
- Intenté ejecutar `python -m pytest -q tests/pcobra/core/test_interpreter_usar.py` pero la ruta no existe en el repositorio, por lo que ese comando falló (archivo faltante).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08543ba2d083278cd9f1516fe51a7b)