### PR TITLE
Use canonical secure interpreter factory in CLI and bench command

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -22,6 +22,7 @@ from pcobra.cli import (
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS, assert_public_targets_contract
 from pcobra.cobra.core.interpreter import InterpretadorCobra
+from pcobra.cobra.cli.execution_pipeline import construir_interprete_seguro_canonico
 from pcobra.cobra.cli.i18n import _, format_traceback, setup_gettext
 
 
@@ -347,7 +348,13 @@ class CliApplication:
         if self.parser and self.command_registry and self.interpreter:
             return
         setup_gettext()
-        self.interpreter = InterpretadorCobra()
+        # CONTRATO: este factory canónico es obligatorio para preservar
+        # `_metadata_simbolos_usar` como `dict` y validar invariantes runtime.
+        self.interpreter = construir_interprete_seguro_canonico(
+            interpretador_cls=InterpretadorCobra,
+            safe_mode=True,
+            extra_validators=None,
+        )
         self.command_registry = CommandRegistry(self.interpreter)
         self.parser = self._build_argument_parser()
 

--- a/src/pcobra/cobra/cli/commands/benchthreads_cmd.py
+++ b/src/pcobra/cobra/cli/commands/benchthreads_cmd.py
@@ -23,6 +23,7 @@ else:
 from pcobra.cobra.core import Lexer
 from pcobra.cobra.core import Parser
 from pcobra.cobra.core.interpreter import InterpretadorCobra
+from pcobra.cobra.cli.execution_pipeline import construir_interprete_seguro_canonico
 
 try:  # pragma: no cover - dependencia opcional
     from jupyter_kernel import CobraKernel
@@ -155,7 +156,13 @@ class BenchThreadsCommand(BaseCommand):
 
     def _run_sequential(self) -> None:
         """Ejecuta código de forma secuencial."""
-        interp = InterpretadorCobra()
+        # CONTRATO: este factory canónico es obligatorio para preservar
+        # `_metadata_simbolos_usar` como `dict` y validar invariantes runtime.
+        interp = construir_interprete_seguro_canonico(
+            interpretador_cls=InterpretadorCobra,
+            safe_mode=True,
+            extra_validators=None,
+        )
         tokens = Lexer(SEQUENTIAL_CODE.read_text()).tokenizar()
         ast = Parser(tokens).parsear()
         interp.ejecutar_ast(ast)


### PR DESCRIPTION
### Motivation
- Evitar creación directa de `InterpretadorCobra` en puntos de entrada interactivos para garantizar las invariantes runtime relacionadas con metadata de `usar`.
- Centralizar la construcción del intérprete para asegurar que `_metadata_simbolos_usar` y `_validador._metadata_simbolos_usar` sean `dict` y se verifiquen las condiciones de `safe_mode`.

### Description
- Reemplacé `InterpretadorCobra()` por `construir_interprete_seguro_canonico(...)` en `CliApplication.initialize()` de `src/pcobra/cobra/cli/cli.py` y en `BenchThreadsCommand._run_sequential()` de `src/pcobra/cobra/cli/commands/benchthreads_cmd.py`.
- Importé `construir_interprete_seguro_canonico` desde `pcobra.cobra.cli.execution_pipeline` en ambos módulos.
- Mantuve los flags efectivos previos usando `safe_mode=True` y `extra_validators=None` para preservar el comportamiento por defecto del constructor anterior.
- Añadí comentarios de contrato en cada entrypoint crítico indicando que este factory es obligatorio para preservar `_metadata_simbolos_usar` como `dict` y validar invariantes runtime.

### Testing
- Ejecuté `rg -n "InterpretadorCobra\(" src/pcobra` y confirmé que no quedan llamadas directas en rutas activas de CLI/REPL/interactivo; la comprobación fue satisfactoria.
- Ejecuté `python -m compileall -q src/pcobra/cobra/cli/cli.py src/pcobra/cobra/cli/commands/benchthreads_cmd.py` para validar la sintaxis de los archivos modificados y la compilación fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a18a0ae08327981fe8a78f8e5217)