### PR TITLE
Asegura estado runtime idempotente antes de pre-auditoría

### DIFF
--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -154,6 +154,11 @@ def validar_ast_seguro(
 ) -> None:
     """Aplica la cadena de validadores de seguridad sobre el AST."""
 
+    if interpretador is not None:
+        asegurar_estado_runtime = getattr(interpretador, "asegurar_estado_runtime_inicial", None)
+        if callable(asegurar_estado_runtime):
+            asegurar_estado_runtime()
+
     if validadores_extra is not None:
         if not isinstance(validadores_extra, list) or not all(
             isinstance(validador, ValidadorBase) for validador in validadores_extra

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -610,6 +610,22 @@ def test_metadata_usar_error_invalid_container_incluye_tipo_y_troubleshooting():
     assert "troubleshooting='container_metadata_debe_ser_dict'" in mensaje
 
 
+def test_regresion_metadata_none_se_normaliza_y_tipo_invalido_se_mantiene_en_invalid_container():
+    interp = InterpretadorCobra()
+    interp._validador._metadata_simbolos_usar = None
+
+    interp.asegurar_estado_runtime_inicial()
+
+    assert interp._validador._metadata_simbolos_usar == {}
+
+    interp._validador._metadata_simbolos_usar = []
+    with pytest.raises(PrimitivaPeligrosaError) as err:
+        interp.ejecutar_ast(generar_ast('imprimir("ok")'))
+    mensaje = str(err.value)
+    assert "codigo_interno='invalid_container'" in mensaje
+    assert "tipo='list'" in mensaje
+
+
 def test_metadata_usar_error_invalid_symbol_metadata_preserva_motivo_original():
     interp = InterpretadorCobra()
     with patch("sys.stdout", new_callable=StringIO):


### PR DESCRIPTION
### Motivation
- Evitar fallos en flujos que rehidratan contexto (REPL incremental y ejecución con contexto compartido) cuando `_metadata_simbolos_usar` fue inyectado como `None` antes de la primera pre-auditoría.
- Mantener la invariante de runtime entre intérprete y validador sin silenciar tipos inválidos ya presentes.

### Description
- Se agrega una invocación a `asegurar_estado_runtime_inicial()` al inicio de `validar_ast_seguro(...)` cuando se recibe un `interpretador`, para garantizar la normalización mínima antes de preparar la pre-auditoría de seguridad.
- Se preserva la idempotencia de la rutina de inicialización: solo crea contenedores faltantes o `None` y no reescribe contenedores válidos ni convierte tipos inválidos.
- Se añade un test de regresión `test_regresion_metadata_none_se_normaliza_y_tipo_invalido_se_mantiene_en_invalid_container` en `tests/unit/test_safe_mode.py` que verifica la normalización de `None` a `{}` y que un tipo inválido (`[]`) sigue fallando con `codigo_interno='invalid_container'`.
- No se modifica la llamada existente en `InterpretadorCobra.__init__`, que ya invocaba `asegurar_estado_runtime_inicial()` inmediatamente después de construir `_validador` y `_usar_symbol_metadata`.

### Testing
- Ejecuté `pytest -q tests/unit/test_safe_mode.py -k "regresion_metadata_none_se_normaliza or invalid_container_incluye_tipo"` y la colección falló con `ImportError: attempted relative import beyond top-level package` en la importación de `core.interpreter`, por lo que los tests no se llegaron a ejecutar.
- Reintenté con `PYTHONPATH=src pytest -q tests/unit/test_safe_mode.py -k "regresion_metadata_none_se_normaliza or invalid_container_incluye_tipo"` y obtuve el mismo error de colección por import-path en este entorno; no hay fallos de test relacionados con la lógica cambiada porque la suite no pudo ejecutarse completamente.
- Los cambios están concentrados en `src/pcobra/cobra/cli/execution_pipeline.py` y el test agregado en `tests/unit/test_safe_mode.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a429ad24832788a26b478347a62e)