### PR TITLE
Normalizar metadata de `usar` en inicialización y soportar validador opcional

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -508,6 +508,7 @@ class InterpretadorCobra:
         # Metadatos de símbolos inyectados por `usar` para soportar reimport idempotente.
         # nombre_simbolo -> {"module": str, "exported_name": str, "callable_id": int}
         self._usar_symbol_metadata: dict[str, dict[str, object]] = {}
+        # Debe ejecutarse siempre después de crear _validador y _usar_symbol_metadata.
         self.asegurar_estado_runtime_inicial()
 
     def asegurar_estado_runtime_inicial(self) -> None:
@@ -532,11 +533,12 @@ class InterpretadorCobra:
         if (not hasattr(self, "_usar_symbol_metadata")) or self._usar_symbol_metadata is None:
             self._usar_symbol_metadata = {}
 
-        if hasattr(self, "_validador"):
-            if not hasattr(self._validador, "_metadata_simbolos_usar"):
-                self._validador._metadata_simbolos_usar = {}
-            elif self._validador._metadata_simbolos_usar is None:
-                self._validador._metadata_simbolos_usar = {}
+        validador = getattr(self, "_validador", None)
+        if validador is not None:
+            if not hasattr(validador, "_metadata_simbolos_usar"):
+                validador._metadata_simbolos_usar = {}
+            elif validador._metadata_simbolos_usar is None:
+                validador._metadata_simbolos_usar = {}
 
     def configurar_restriccion_usar_repl(self, alias_map: dict[str, str] | None) -> None:
         """Configura whitelist explícita de módulos `usar` para flujo REPL.


### PR DESCRIPTION
### Motivation
- Garantizar que `InterpretadorCobra.__init__()` invoque `asegurar_estado_runtime_inicial()` después de crear `_validador` y `_usar_symbol_metadata`, y aplicar reglas explícitas de normalización sin corregir contenedores inválidos silenciosamente.

### Description
- Añadido comentario que enfatiza el orden de inicialización y modificado `_normalizar_metadata_usar_en_inicializacion()` para usar `getattr(self, "_validador", None)` y solo crear `{}` cuando `_usar_symbol_metadata` o el `_metadata_simbolos_usar` del validador estén ausentes o en `None`, sin sustituir valores no-`dict`.

### Testing
- Ejecutado `python -m pytest -q tests -k "interpreter or usar or metadata"`; la colección falló por errores de importación no relacionados (módulos de transpilers faltantes), por lo que la suite completa no pasó.
- Ejecutado un chequeo directo con `python -c "from pcobra.core.interpreter import InterpretadorCobra; it=InterpretadorCobra(safe_mode=False); it.asegurar_estado_runtime_inicial(); print('ok')"` y se verificó que `_usar_symbol_metadata` existe y la normalización es idempotente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a094910f2508327a37da8f2ca406fc7)