### PR TITLE
Usar factory canónico para crear intérprete y reforzar invariantes en CLI/REPL

### DIFF
--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -197,20 +197,6 @@ def validar_ast_seguro(
         nodo.aceptar(validador)
 
 
-def construir_interprete(
-    *,
-    interpretador_cls: Any,
-    safe_mode: bool,
-    extra_validators: Any,
-) -> Any:
-    """Construye una instancia del intérprete con la configuración común."""
-
-    return interpretador_cls(
-        safe_mode=safe_mode,
-        extra_validators=extra_validators,
-    )
-
-
 def construir_interprete_seguro_canonico(
     *,
     interpretador_cls: Any,
@@ -225,8 +211,7 @@ def construir_interprete_seguro_canonico(
     ``usar`` entre intérprete y validador.
     """
 
-    interpretador = construir_interprete(
-        interpretador_cls=interpretador_cls,
+    interpretador = interpretador_cls(
         safe_mode=safe_mode,
         extra_validators=extra_validators,
     )
@@ -243,7 +228,11 @@ def construir_interprete_seguro_canonico(
             "Invariante runtime violada: en safe_mode=True debe existir interpreter._validador."
         )
     validador = getattr(interpretador, "_validador", None)
-    if validador is not None and not isinstance(
+    if safe_mode and validador is None:
+        raise TypeError(
+            "Invariante runtime violada: en safe_mode=True debe existir interpreter._validador."
+        )
+    if safe_mode and not isinstance(
         getattr(validador, "_metadata_simbolos_usar", None), dict
     ):
         raise TypeError(


### PR DESCRIPTION
### Motivation
- Centralizar la creación de intérpretes en el pipeline canónico para evitar caminos alternativos de inicialización y garantizar paridad entre CLI/REPL/ejecución de archivos.
- Detectar temprano estados runtime inválidos en modo seguro para evitar ejecuciones con metadatos inconsistentes.

### Description
- Eliminé el helper `construir_interprete` en `src/pcobra/cobra/cli/execution_pipeline.py` y ahora la construcción del intérprete se hace directamente con `interpretador_cls(...)` dentro de `construir_interprete_seguro_canonico`.
- Añadí/fortalecí chequeos inmediatos de invariante en `construir_interprete_seguro_canonico` para asegurar que `interpreter._usar_symbol_metadata` sea `dict`.
- En `safe_mode=True` ahora se exige explícitamente que `interpreter._validador` exista y que `interpreter._validador._metadata_simbolos_usar` sea `dict`, y se lanza `TypeError` con mensajes claros cuando alguna invariante falla.
- Retorno del intérprete preservado y sin cambios funcionales en el resto del flujo del pipeline canónico.

### Testing
- Compile check con `python -m py_compile src/pcobra/cobra/cli/execution_pipeline.py` — resultado: OK.
- No se ejecutaron tests unitarios adicionales en esta modificación automatizada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a096154422c8327b357a0d822df4644)