### PR TITLE
Asegura validación estricta de metadata `usar` en pre-auditoría

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1041,7 +1041,13 @@ class InterpretadorCobra:
         self._validar_metadata_usar_en_ejecucion(etapa=etapa)
 
     def _validar_metadata_usar_en_ejecucion(self, *, etapa: str | None = None) -> None:
-        """Valida metadata de `usar` en etapa='pre-auditoría' de forma estricta."""
+        """Valida metadata de `usar` en etapa='pre-auditoría' de forma estricta.
+
+        Nota de contrato:
+        - En esta fase no se realizan coerciones ni normalizaciones de contenedor.
+        - Solo se acepta ``dict`` como contenedor de ``_metadata_simbolos_usar``.
+        - La validación por símbolo se delega en ``validate_usar_symbol_metadata``.
+        """
         metadata_validador = getattr(self._validador, "_metadata_simbolos_usar", None)
         detalle_etapa = f" etapa='{etapa}'" if etapa else ""
         if not isinstance(metadata_validador, dict):
@@ -1062,6 +1068,7 @@ class InterpretadorCobra:
                 f"extras_en_validador={extras_en_validador}, codigo_interno='missing_keys', troubleshooting='claves_de_metadata_desincronizadas')."
                 f"{self._detalle_debug_metadata_usar(expected_keys=claves_interp, received_keys=claves_validador)}{detalle_etapa}"
             )
+        # Fail-closed: no conversiones implícitas de payloads en pre-auditoría.
         for nombre, metadata_interp in self._usar_symbol_metadata.items():
             try:
                 self._validar_metadata_usar_o_fallar(nombre, metadata_interp)


### PR DESCRIPTION
### Motivation

- Reforzar el contrato de validación de metadata en la fase de `pre-auditoría` para evitar coerciones/normalizaciones implícitas que puedan ocultar discrepancias peligrosas.
- Preservar el comportamiento fail-closed cuando el contenedor `_metadata_simbolos_usar` no es un `dict` y mantener los códigos de error diagnósticos existentes.

### Description

- Actualiza el docstring de `InterpretadorCobra._validar_metadata_usar_en_ejecucion` para declarar explícitamente que en `pre-auditoría` no se aplican coerciones ni normalizaciones y que solo se acepta `dict` como contenedor.
- Añade un comentario de política (`Fail-closed`) para dejar claro que no deben introducirse conversiones implícitas de payloads en esta fase y conserva la validación por símbolo delegada a `validate_usar_symbol_metadata`.
- No se cambia la lógica de errores: se sigue lanzando `PrimitivaPeligrosaError` con `codigo_interno='invalid_container'` y `troubleshooting='container_metadata_debe_ser_dict'` cuando corresponde, y se mantienen los casos `missing_keys`, `invalid_symbol_metadata` y `mismatch_payload`.

### Testing

- Se compiló el archivo modificado con `python -m compileall src/pcobra/core/interpreter.py` y la compilación finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0963931f9483278425738da107329a)