### PR TITLE
Asegura metadata canónica de símbolos `usar` en intérprete y validador

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2400,7 +2400,7 @@ class InterpretadorCobra:
             metadata_simbolo = validate_usar_symbol_metadata(nombre, metadata_simbolo)
             contexto_actual.define(nombre, simbolo)
             self._usar_symbol_metadata[nombre] = dict(metadata_simbolo)
-            if self.safe_mode and self._validador is not None and hasattr(self._validador, "registrar_simbolo_publico_usar"):
+            if self._validador is not None and hasattr(self._validador, "registrar_simbolo_publico_usar"):
                 resumen = {
                     "module": metadata_simbolo.get("module"),
                     "symbol": metadata_simbolo.get("symbol"),

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -224,15 +224,19 @@ def test_usar_datos_longitud_metadata_completa_en_interprete_y_validador():
 
     interp.ejecutar_ast(ast)
 
+    assert "longitud" in interp._usar_symbol_metadata
+    assert "longitud" in interp._validador._metadata_simbolos_usar
+
     metadata = interp._usar_symbol_metadata["longitud"]
     metadata_validador = interp._validador._metadata_simbolos_usar["longitud"]
 
-    assert metadata["module"] == "datos"
-    assert metadata["origin_kind"] == "usar"
-    assert metadata["sanitized"] is True
-    assert metadata["public_api"] is True
-    assert metadata["symbol"] == "longitud"
-    assert isinstance(metadata["callable"], bool)
+    for payload in (metadata, metadata_validador):
+        assert payload["module"] == "datos"
+        assert payload["origin_kind"] == "usar"
+        assert payload["sanitized"] is True
+        assert payload["public_api"] is True
+        assert payload["symbol"] == "longitud"
+        assert isinstance(payload["callable"], bool)
 
     # El payload registrado en intérprete y validador debe ser idéntico.
     assert metadata_validador == metadata


### PR DESCRIPTION
### Motivation
- Garantizar que cada símbolo importado por `usar` guarde metadata válida tanto en `interpreter._usar_symbol_metadata` como en `interpreter._validador._metadata_simbolos_usar` para permitir reimports idempotentes y auditoría.
- Validar presencia y consistencia de campos clave (por ejemplo `module: 'datos'`, `origin_kind: 'usar'`, `sanitized: True`, `public_api: True`) en casos como la función `longitud` exportada por `datos`.
- Mantener la política de rechazo para módulos externos (`usar "numpy"` sigue bloqueado) sin relajar el validador ni la política de carga.

### Description
- Se modificó la condición en `_inyectar_simbolos_usar_en_contexto` para llamar a `registrar_simbolo_publico_usar` siempre que `self._validador` exista y exponga ese método, eliminando la dependencia explícita de `safe_mode` en ese punto (`src/pcobra/core/interpreter.py`).
- Se valida y almacena la metadata con `validate_usar_symbol_metadata` y se sincroniza no destructivamente con `_sincronizar_metadata_usar_no_destructiva` y `_asegurar_metadata_usar_sincronizada` tras el registro en el validador.
- Se actualizó la prueba `test_usar_datos_longitud_metadata_completa_en_interprete_y_validador` para comprobar la presencia de `"longitud"` en ambos contenedores, verificar los campos canónicos (`module`, `origin_kind`, `sanitized`, `public_api`, `symbol`, `callable`) y la igualdad estructural entre los payloads (`tests/unit/test_safe_mode.py`).
- No se tocaron los mecanismos de rechazo de módulos externos ni la lógica de `usar_loader`/políticas asociadas.

### Testing
- Ejecuté pruebas unitarias focalizadas con `pytest -q tests/unit/test_safe_mode.py -k "datos_longitud_metadata_completa_en_interprete_y_validador or usar_numpy_rechaza_con_error_corto"`, que fallaron en la fase de colección con un `ImportError: attempted relative import beyond top-level package` en este entorno de ejecución y no completaron las aserciones.
- Reintenté con `PYTHONPATH=src pytest -q tests/unit/test_safe_mode.py -k "datos_longitud_metadata_completa_en_interprete_y_validador or usar_numpy_rechaza_con_error_corto"`, obteniendo el mismo error de colección por empaquetado, por lo que no se pudieron ejecutar las pruebas dentro de esta sesión.
- El cambio fue comiteado localmente y se generó la PR metadata; las aserciones añadidas permanecen listas para validación en CI donde la configuración de ejecución permita la correcta importación del paquete.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09660ea4808327b89cb93679081d23)