### PR TITLE
test: reforzar asserts contra 'invalid_container' y 'NoneType' en usar (safe mode & REPL)

### DIFF
--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -1166,6 +1166,9 @@ def test_regresion_metadata_usar_none_pre_auditoria(factory, executor, get_inter
     assert callable(interp.obtener_variable("es_finito"))
     executor(cmd, "imprimir(es_finito(10))")
     salida_numero = capsys.readouterr()
+    combinado_numero = f"{salida_numero.out}\n{salida_numero.err}"
+    assert "invalid_container" not in combinado_numero
+    assert "NoneType" not in combinado_numero
     lineas_numero = [linea.strip() for linea in salida_numero.out.splitlines() if linea.strip()]
     assert lineas_numero and lineas_numero[-1] == "verdadero"
 
@@ -1173,6 +1176,7 @@ def test_regresion_metadata_usar_none_pre_auditoria(factory, executor, get_inter
     executor(cmd, 'imprimir(existe("README.md"))')
     salida_archivo = capsys.readouterr()
     combinado_archivo = f"{salida_archivo.out}\n{salida_archivo.err}"
+    assert "invalid_container" not in combinado_archivo
     assert "_metadata_simbolos_usar" not in combinado_archivo
     assert "NoneType" not in combinado_archivo
 
@@ -1182,3 +1186,6 @@ def test_regresion_metadata_usar_none_pre_auditoria(factory, executor, get_inter
         ultimo in {"verdadero", "falso"}
         or "Uso de primitiva peligrosa" in combinado_archivo
     )
+
+    with pytest.raises(PermissionError, match=r"(módulo fuera del catálogo público|modulo_fuera_catalogo_publico)"):
+        executor(cmd, 'usar "numpy"')

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -73,6 +73,8 @@ def test_usar_archivo_existe_imprime_booleano_sin_primitiva_peligrosa():
 
     salida = out.getvalue().strip()
     assert salida in {"verdadero", "falso"}
+    assert "invalid_container" not in salida
+    assert "NoneType" not in salida
 
 
 
@@ -84,9 +86,12 @@ def test_usar_numero_es_finito_true_y_texto_carga_ok_en_modo_seguro():
     with patch("sys.stdout", new_callable=StringIO) as out:
         interp.ejecutar_ast(ast)
 
-    lineas = [linea.strip() for linea in out.getvalue().splitlines() if linea.strip()]
+    salida = out.getvalue()
+    lineas = [linea.strip() for linea in salida.splitlines() if linea.strip()]
     assert "verdadero" in lineas
     assert "OK" in lineas
+    assert "invalid_container" not in salida
+    assert "NoneType" not in salida
 
 
 def test_usar_archivo_existe_readme_no_falla_por_metadata():
@@ -96,9 +101,12 @@ def test_usar_archivo_existe_readme_no_falla_por_metadata():
     with patch("sys.stdout", new_callable=StringIO) as out:
         interp.ejecutar_ast(ast)
 
-    salida = out.getvalue().strip().splitlines()
-    assert salida
-    assert salida[-1].strip() in {"verdadero", "falso"}
+    salida = out.getvalue()
+    lineas = salida.strip().splitlines()
+    assert lineas
+    assert lineas[-1].strip() in {"verdadero", "falso"}
+    assert "invalid_container" not in salida
+    assert "NoneType" not in salida
     assert "existe" in interp._usar_symbol_metadata
     assert "existe" in interp._validador._metadata_simbolos_usar
 
@@ -114,8 +122,24 @@ def test_usar_datos_longitud_builtin_permanece_en_3():
     with patch("sys.stdout", new_callable=StringIO) as out:
         interp.ejecutar_ast(ast)
 
-    lineas = [linea.strip() for linea in out.getvalue().splitlines() if linea.strip()]
+    salida = out.getvalue()
+    lineas = [linea.strip() for linea in salida.splitlines() if linea.strip()]
     assert lineas[-2:] == ["3", "3"]
+    assert "invalid_container" not in salida
+    assert "NoneType" not in salida
+
+
+def test_regresion_var_xs_lista_no_dispara_invalid_container_ni_nonetype():
+    interp = InterpretadorCobra()
+    ast = generar_ast("var xs = [1,2,3]")
+
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        interp.ejecutar_ast(ast)
+
+    salida = out.getvalue()
+    assert "invalid_container" not in salida
+    assert "NoneType" not in salida
+    assert interp.obtener_variable("xs") == [1, 2, 3]
 
 
 def test_existe_backend_crudo_sigue_bloqueado_aun_con_usar_archivo():


### PR DESCRIPTION
### Motivation
- Evitar regresiones donde mensajes internos como `invalid_container` o `NoneType` aparezcan en salidas válidas tras usar módulos con `usar` en modo seguro o REPL. 
- Asegurar que la superficie pública rechazará módulos fuera del catálogo (p. ej. `numpy`) y que no se filtre metadata `None` en la salida.

### Description
- Se actualizan tests en `tests/unit/test_safe_mode.py` para añadir assertions que garanticen que no aparece `invalid_container` ni `NoneType` en salidas válidas de `usar "archivo"`, `usar "numero"` y `usar "datos"`.
- Se añade un test mínimo `test_regresion_var_xs_lista_no_dispara_invalid_container_ni_nonetype` que ejecuta `var xs = [1,2,3]` en el intérprete y valida ausencia de los mensajes y persistencia de la variable.
- Se fortalece `test_regresion_metadata_usar_none_pre_auditoria` en `tests/integration/test_repl_usar_entrypoints_contract.py` para comprobar explícitamente ausencia de `invalid_container`/`NoneType` en las salidas de `numero` y `archivo` y se añade una aserción que `usar "numpy"` lanza `PermissionError`.
- Cambios puramente en suite de tests, sin cambios en código de producción ni en APIs.

### Testing
- Se ejecutó `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py -k "regresion_metadata_usar_none_pre_auditoria"` y la prueba pasó (`2 passed, 77 deselected`).
- Se intentó ejecutar una selección de unit tests con `pytest -q tests/unit/test_safe_mode.py -k "usar_datos_longitud_builtin_permanece_en_3 or regresion_var_xs_lista_no_dispara or usar_numero_es_finito_true or usar_archivo_existe_readme_no_falla_por_metadata or usar_archivo_existe_imprime_booleano"` y falló la recolección por un error de importación en el entorno (`ImportError: attempted relative import beyond top-level package`), lo que parece un problema de configuración de ejecución y no de las aserciones añadidas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a096780624883278b56280f8d8ea717)