### PR TITLE
docs: documentar trazabilidad y contrato de metadata en `usar`

### DIFF
--- a/informe_tecnico_binding_runtime_usar.md
+++ b/informe_tecnico_binding_runtime_usar.md
@@ -31,3 +31,70 @@ Se añadieron pruebas unitarias en `tests/unit/test_usar.py` para validar ejecuc
 - `src/pcobra/core/interpreter.py`
 - `tests/unit/test_usar.py`
 - `informe_tecnico_binding_runtime_usar.md`
+
+---
+
+## Trazabilidad solicitada (flujo `usar` y productor de metadata)
+
+### 1) Punto de entrada Cobra-facing en runtime/interprete
+- **Entrada principal**: `Interpretador.ejecutar_usar(self, nodo)` en `src/pcobra/core/interpreter.py`.
+- Desde esta función se resuelve el módulo canónico permitido, se sanean exports y se prepara la inyección en el contexto activo.
+
+### 2) Flujo hasta la creación de metadata por símbolo
+Secuencia observada:
+1. `ejecutar_usar` llama a `sanitizar_exports_publicos(modulo, nombre_modulo)` (vía `pcobra.core.usar_loader`) para obtener `mapa_limpio`.
+2. Se itera `simbolos_saneados = list(mapa_limpio.items())`.
+3. Para cada `(nombre, simbolo)` se construye metadata con:
+   - `build_and_validate_usar_symbol_metadata(module_name=nodo.modulo, symbol_name=nombre, callable_obj=simbolo)`.
+4. El resultado se valida de nuevo con:
+   - `validate_usar_symbol_metadata(nombre, metadata_simbolo)`.
+5. La colección resultante queda en `metadata_por_simbolo` y viaja a:
+   - `_detectar_conflictos_usar_en_contexto(..., metadata_por_simbolo=...)`.
+   - `_inyectar_simbolos_usar_en_contexto(..., metadata_por_simbolo=...)`.
+6. En inyección se vuelve a validar (`validate_usar_symbol_metadata`) antes de registrar en:
+   - `self._usar_symbol_metadata[nombre]`.
+   - `self._validador.registrar_simbolo_publico_usar(..., metadata=dict(metadata_simbolo))` cuando aplica.
+
+### 3) ¿Hay múltiples productores hoy?
+Sí, hay **más de un productor/transformador** en la cadena:
+- **Productor primario (canónico)**:
+  - `build_usar_symbol_metadata(...)` / `build_and_validate_usar_symbol_metadata(...)` en `src/pcobra/core/usar_symbol_policy.py`.
+- **Normalizador/validador estricto**:
+  - `_normalizar_metadata_simbolo_usar(...)` y `validate_usar_symbol_metadata(...)` en `src/pcobra/core/usar_symbol_policy.py`.
+- **Productor/transportista de candidatos de símbolo**:
+  - `sanitizar_exports_publicos(...)` y `sanear_exportables_para_usar(...)` (pipeline de saneamiento de exports antes de metadata).
+- **Registro secundario en validador runtime**:
+  - `registrar_simbolo_publico_usar` (consume metadata ya validada y la replica en `_metadata_simbolos_usar` del validador).
+
+> Conclusión: la **fábrica canónica de metadata** vive en `usar_symbol_policy.py`, pero el pipeline incluye saneamiento previo y validaciones/replicación posteriores.
+
+### 4) Contrato actual observado (claves, tipos, casos especiales)
+Contrato canónico impuesto por `validate_usar_symbol_metadata` + `_normalizar_metadata_simbolo_usar`:
+- Claves obligatorias:
+  - `origin_kind: str` (debe ser `"usar"`; compat legacy: `kind="usar"` se normaliza).
+  - `module: str` (módulo Cobra-facing canónico).
+  - `symbol: str` (nombre exportado).
+  - `callable: bool`.
+  - `public_api: bool`.
+  - `sanitized: bool`.
+  - `backend_exposed: bool`.
+- Claves frecuentes adicionales (derivadas por la fábrica canónica):
+  - `origin_module`, `canonical_module` (consistencia con `module`).
+  - `exported_name` (consistencia con `symbol`).
+  - `is_sanitized_wrapper` (consistencia con `sanitized`).
+  - `is_public_export`, `introduced_by`, `symbol_name`.
+- Tipos esperados:
+  - Contenedor metadata: `dict[str, object]` (fail-closed si no es dict).
+  - Banderas lógicas (`callable`, `public_api`, `sanitized`, `backend_exposed`): `bool` estricto.
+- Casos especiales observados:
+  - `archivo.existe`: en `_inyectar_simbolos_usar_en_contexto` hay traza explícita confirmando wrapper sanitizado cuando `module=="archivo"` y `nombre=="existe"`.
+  - Wrappers seguros/sanitizados: el contrato exige coherencia entre `sanitized` e `is_sanitized_wrapper` (si está presente).
+  - Si metadata falta o contradice claves canónicas, se rechaza con `ValueError` (fail-closed).
+
+### 5) Marcado de fuente upstream para futura normalización canónica
+Se deja marcado explícitamente como **fuente upstream** de metadata por símbolo:
+- **`build_and_validate_usar_symbol_metadata(...)` en `src/pcobra/core/usar_symbol_policy.py`**.
+
+Justificación:
+- Es el primer punto donde se crea metadata estructurada por símbolo en la ruta runtime de `usar`.
+- Ya aplica validación canónica inmediata y permite encadenar normalización estricta sin romper invariantes de seguridad.


### PR DESCRIPTION
### Motivation
- Documentar la trazabilidad runtime de la instrucción `usar` y exponer el contrato actual de metadata por símbolo para facilitar la futura normalización canónica y auditoría de seguridad.

### Description
- Se añadió una sección en `informe_tecnico_binding_runtime_usar.md` que describe el punto de entrada `Interpretador.ejecutar_usar`, el flujo hasta la construcción de `metadata_por_simbolo`, los productores/transformadores involucrados (p. ej. `sanitizar_exports_publicos`, la fábrica canónica en `usar_symbol_policy.py`, el validador y el registro runtime) y los casos especiales observados como `archivo.existe`.
- El documento marca explícitamente a `build_and_validate_usar_symbol_metadata(...)` en `src/pcobra/core/usar_symbol_policy.py` como la fuente upstream recomendada para conectar la normalización canónica, y confirma que no se modificó la lógica de runtime en el cambio.

### Testing
- No se ejecutaron pruebas automáticas sobre código; el cambio es puramente documental y no altera la ejecución del runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a096e830de88327bf2f822405a5d06d)