### PR TITLE
Normalizar metadata `usar` antes de pre-auditoría y añadir helper compartido

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -91,6 +91,7 @@ from .utils import validar_ast_estructural, ErrorEstructuraAST
 from .errors import CondicionNoBooleanaError
 from .usar_symbol_policy import (
     build_and_validate_usar_symbol_metadata,
+    normalizar_metadata_simbolo_usar,
     validate_usar_symbol_metadata,
 )
 from .environment import Environment
@@ -1043,7 +1044,21 @@ class InterpretadorCobra:
         """
         if not self.safe_mode or self._validador is None:
             return
+        if etapa == "pre-auditoría":
+            self._normalizar_metadata_usar_pre_auditoria()
         self._validar_metadata_usar_en_ejecucion(etapa=etapa)
+
+    def _normalizar_metadata_usar_pre_auditoria(self) -> None:
+        """Normaliza metadata `usar` de intérprete/validador antes de pre-auditoría."""
+        metadata_validador = getattr(self._validador, "_metadata_simbolos_usar", None)
+        if isinstance(self._usar_symbol_metadata, dict):
+            for nombre, metadata in list(self._usar_symbol_metadata.items()):
+                module_name = str(metadata.get("module")) if isinstance(metadata, dict) and metadata.get("module") is not None else ""
+                self._usar_symbol_metadata[nombre] = normalizar_metadata_simbolo_usar(metadata, module_name, nombre)
+        if isinstance(metadata_validador, dict):
+            for nombre, metadata in list(metadata_validador.items()):
+                module_name = str(metadata.get("module")) if isinstance(metadata, dict) and metadata.get("module") is not None else ""
+                metadata_validador[nombre] = normalizar_metadata_simbolo_usar(metadata, module_name, nombre)
 
     def _validar_metadata_usar_en_ejecucion(self, *, etapa: str | None = None) -> None:
         """Valida metadata de `usar` en etapa='pre-auditoría' de forma estricta.

--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -1,6 +1,7 @@
 """Política de saneamiento de símbolos para la instrucción ``usar``."""
 
 from dataclasses import dataclass, field
+import logging
 import os
 from types import ModuleType
 from typing import Any
@@ -359,8 +360,13 @@ def build_and_validate_usar_symbol_metadata(
     return dict(metadata_validada)
 
 
-def _normalizar_metadata_simbolo_usar(nombre: str, metadata: object) -> dict[str, object]:
-    """Normaliza e inspecciona metadata `usar` sin relajar seguridad.
+def normalizar_metadata_simbolo_usar(raw_metadata: object, module_name: str, symbol_name: str) -> dict[str, object]:
+    """Normaliza metadata de `usar` y aplica compatibilidad legacy segura.
+
+    - Clona/sanitiza el input (`dict` obligatorio).
+    - Convierte aliases legacy conocidos a claves canónicas cuando corresponda.
+    - Completa campos derivados seguros (`module`, `symbol`, `sanitized`).
+    - Elimina únicamente claves no canónicas cuando son aliases legacy mapeados.
 
     Contrato canónico obligatorio (fail-closed):
     - ``origin_kind`` (str): marcador de procedencia; debe ser ``"usar"``.
@@ -377,24 +383,45 @@ def _normalizar_metadata_simbolo_usar(nombre: str, metadata: object) -> dict[str
     todo el ciclo (`usar` -> registro -> auditoría): el validador fail-closed
     exige igualdad estructural estricta y rechaza mutaciones inesperadas.
     """
-    if not isinstance(metadata, dict):
-        raise ValueError(f"Metadata inválida para símbolo usar '{nombre}': tipo no permitido")
+    if not isinstance(raw_metadata, dict):
+        raise ValueError(f"Metadata inválida para símbolo usar '{symbol_name}': tipo no permitido")
 
-    metadata_dict = dict(metadata)
+    metadata_dict = dict(raw_metadata)
     # Compatibilidad legacy estricta: aceptar `kind="usar"` como alias de
     # `origin_kind` solo cuando el campo canónico no existe.
+    aliases_normalizados: list[str] = []
     for legacy_key, canonical_key in CANONICAL_USAR_METADATA_SCHEMA["legacy_aliases"].items():
         if canonical_key not in metadata_dict and legacy_key in metadata_dict:
             metadata_dict[canonical_key] = metadata_dict[legacy_key]
+            aliases_normalizados.append(legacy_key)
+
+    if isinstance(module_name, str) and module_name.strip():
+        metadata_dict.setdefault("module", module_name)
+    if isinstance(symbol_name, str) and symbol_name.strip():
+        metadata_dict.setdefault("symbol", symbol_name)
+    metadata_dict.setdefault("sanitized", True)
+
+    for legacy_key in aliases_normalizados:
+        metadata_dict.pop(legacy_key, None)
+
+
+    if aliases_normalizados:
+        logging.info(
+            "USAR metadata legacy normalizada OK module=%s symbol=%s aliases=%s",
+            module_name,
+            symbol_name,
+            sorted(aliases_normalizados),
+        )
+
     faltantes = CANONICAL_USAR_METADATA_SCHEMA["required_keys"] - set(metadata_dict.keys())
     if faltantes:
-        raise ValueError(f"Metadata inválida para símbolo usar '{nombre}': faltan claves {sorted(faltantes)}")
+        raise ValueError(f"Metadata inválida para símbolo usar '{symbol_name}': faltan claves {sorted(faltantes)}")
 
     inesperadas_criticas = set(metadata_dict.keys()) - CANONICAL_USAR_METADATA_SCHEMA["allowed_keys"]
     if inesperadas_criticas:
         raise ValueError(
             "Metadata inválida para símbolo usar "
-            f"'{nombre}': claves inesperadas críticas {sorted(inesperadas_criticas)}"
+            f"'{symbol_name}': claves inesperadas críticas {sorted(inesperadas_criticas)}"
         )
 
     return metadata_dict
@@ -407,7 +434,16 @@ def validate_usar_symbol_metadata(nombre: str, metadata: object) -> dict[str, ob
     # Este validador es fail-closed y centraliza todo control de integridad
     # antes de sincronizar metadata con intérprete/validadores semánticos.
     """
-    metadata_dict = _normalizar_metadata_simbolo_usar(nombre, metadata)
+    module_name = str(metadata.get("module")) if isinstance(metadata, dict) and metadata.get("module") is not None else ""
+    try:
+        metadata_dict = normalizar_metadata_simbolo_usar(metadata, module_name, nombre)
+    except ValueError:
+        logging.error(
+            "USAR rechazo por metadata inválida tras normalizar module=%s symbol=%s",
+            module_name,
+            nombre,
+        )
+        raise
 
     if metadata_dict.get("origin_kind") != CANONICAL_USAR_METADATA_SCHEMA["value_constraints"]["origin_kind"]:
         raise ValueError(f"Metadata inválida para símbolo usar '{nombre}': origin_kind inválido")

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -2,6 +2,7 @@ from types import ModuleType
 
 from pcobra.core.usar_symbol_policy import (
     PoliticaSaneamientoUsar,
+    normalizar_metadata_simbolo_usar,
     sanear_exportables_para_usar,
     sanear_simbolo_para_usar,
 )
@@ -163,3 +164,18 @@ def test_rechaza_clase_interna_con_rastro_sdk_en_modulo():
     resultado = sanear_simbolo_para_usar("adaptador", ClaseInterna)
     assert resultado.rechazado is True
     assert resultado.codigo == "backend_module_object"
+
+
+def test_normalizar_metadata_simbolo_usar_convierte_alias_legacy_y_derivados():
+    raw = {
+        "kind": "usar",
+        "public_api": True,
+        "backend_exposed": False,
+        "callable": True,
+    }
+    normalizada = normalizar_metadata_simbolo_usar(raw, "texto", "formatear")
+    assert normalizada["origin_kind"] == "usar"
+    assert normalizada["module"] == "texto"
+    assert normalizada["symbol"] == "formatear"
+    assert normalizada["sanitized"] is True
+    assert "kind" not in normalizada


### PR DESCRIPTION
### Motivation
- Evitar que metadata legacy o sin transformar llegue al validador final y garantizar un contrato canónico `usar` en la fase de pre-auditoría. 

### Description
- Añade la función compartida `normalizar_metadata_simbolo_usar(raw_metadata, module_name, symbol_name)` en `src/pcobra/core/usar_symbol_policy.py` que clona/sanitiza el input, convierte aliases legacy a claves canónicas, completa campos derivados seguros (`module`, `symbol`, `sanitized`) y elimina únicamente aliases legacy reconocidos.
- Integra la normalización en el flujo de `Interpreter` llamando a `normalizar_metadata_simbolo_usar` justo antes de la fase de `pre-auditoría` mediante el nuevo método `_normalizar_metadata_usar_pre_auditoria()` y su invocación desde `_asegurar_metadata_usar_sincronizada` en `src/pcobra/core/interpreter.py` para asegurar que solo metadata normalizada llegue al validador.
- Refuerza el validador para capturar y registrar diagnósticos cuando la normalización falla, emitiendo logs distinguibles `USAR metadata legacy normalizada OK ...` y `USAR rechazo por metadata inválida tras normalizar ...` en `src/pcobra/core/usar_symbol_policy.py`.
- Ajusta `validate_usar_symbol_metadata` para emplear la normalización previa y propagar fallos (fail-closed) cuando la metadata no es válida después de normalizar.
- Añade una prueba unitaria `test_normalizar_metadata_simbolo_usar_convierte_alias_legacy_y_derivados` en `tests/unit/test_usar_symbol_policy.py` que verifica conversión de alias legacy y completado de campos derivados.

### Testing
- Ejecutado `pytest -q tests/unit/test_usar_symbol_policy.py` y todas las pruebas de ese módulo pasaron (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09710688e08327a933bb56bddaa52c)