### PR TITLE
Endurece pipeline `usar` para validar solo metadata normalizada y formaliza `safe_wrapper`

### DIFF
--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -1,6 +1,9 @@
 from .base import ValidadorBase
 from ..ast_nodes import NodoLlamadaFuncion, NodoHilo, NodoLlamadaMetodo
-from ..usar_symbol_policy import validate_usar_symbol_metadata
+from ..usar_symbol_policy import (
+    normalizar_metadata_simbolo_usar,
+    validate_usar_symbol_metadata_normalized,
+)
 
 
 class PrimitivaPeligrosaError(Exception):
@@ -56,7 +59,8 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
             raise ValueError(
                 "Metadata inválida para símbolo usar: se requiere metadata canónica preconstruida"
             )
-        metadata_validada = validate_usar_symbol_metadata(nombre, metadata)
+        metadata_normalizada = normalizar_metadata_simbolo_usar(metadata, modulo, nombre)
+        metadata_validada = validate_usar_symbol_metadata_normalized(nombre, metadata_normalizada)
         if metadata_validada.get("module") != modulo:
             raise ValueError(
                 f"Metadata inválida para símbolo usar '{nombre}': module no coincide con registro"
@@ -78,7 +82,7 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
 
         # Única puerta de validación del contrato canónico.
         try:
-            metadata_validada = validate_usar_symbol_metadata(nodo.nombre, metadata)
+            metadata_validada = validate_usar_symbol_metadata_normalized(nodo.nombre, metadata)
         except ValueError as exc:
             return False, str(exc)
 

--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -240,6 +240,7 @@ USAR_SYMBOL_METADATA_REQUIRED_KEYS = frozenset(
         "module",
         "symbol",
         "sanitized",
+        "safe_wrapper",
         "public_api",
         "backend_exposed",
         "callable",
@@ -280,6 +281,7 @@ CANONICAL_USAR_METADATA_SCHEMA = {
     "value_constraints": {
         "origin_kind": "usar",
         "sanitized": True,
+        "safe_wrapper": True,
         "public_api": True,
         "backend_exposed": False,
         "callable": bool,
@@ -290,7 +292,7 @@ CANONICAL_USAR_METADATA_SCHEMA = {
         "introduced_by_usar": "origin_kind",
         "origen_tipo": "origin_kind",
         "is_public_export": "public_api",
-        "safe_wrapper": "sanitized",
+        "safe_wrapper": "safe_wrapper",
     },
     "legacy_consistency": {
         "origen_modulo": "module",
@@ -303,6 +305,7 @@ CANONICAL_USAR_METADATA_SCHEMA = {
 
 USAR_METADATA_SECURE_BOOL_DEFAULTS: dict[str, bool] = {
     "sanitized": True,
+    "safe_wrapper": True,
     "public_api": True,
     "backend_exposed": False,
 }
@@ -363,6 +366,7 @@ def make_usar_symbol_metadata(
         "module": module_name,
         "symbol": symbol_name,
         "sanitized": True,
+        "safe_wrapper": True,
         "public_api": True,
         "backend_exposed": False,
         "callable": es_callable,
@@ -414,6 +418,8 @@ def normalizar_metadata_simbolo_usar(raw_metadata: object, module_name: str, sym
     - ``module`` (str): módulo Cobra-facing que exporta el símbolo.
     - ``symbol`` (str): nombre público exacto del símbolo (debe coincidir con ``nombre``).
     - ``sanitized`` (bool): confirma paso por saneamiento/envoltura segura.
+    - ``safe_wrapper`` (bool): confirma que la API fue envuelta por wrapper seguro explícito.
+      Para entradas de ``usar`` debe ser ``True``.
     - ``public_api`` (bool): confirma que el símbolo pertenece a la API pública permitida.
     - ``backend_exposed`` (bool): debe ser ``False`` para impedir exposición de backend.
     - ``callable`` (bool): indica explícitamente si el símbolo invocable es callable.
@@ -456,10 +462,12 @@ def normalizar_metadata_simbolo_usar(raw_metadata: object, module_name: str, sym
             )
         metadata_dict.setdefault("symbol", symbol_name)
     metadata_dict.setdefault("sanitized", True)
+    metadata_dict.setdefault("safe_wrapper", True)
     metadata_dict["origin_kind"] = "usar"
 
     for legacy_key in aliases_normalizados:
-        metadata_dict.pop(legacy_key, None)
+        if legacy_key != CANONICAL_USAR_METADATA_SCHEMA["legacy_aliases"][legacy_key]:
+            metadata_dict.pop(legacy_key, None)
     for optional_legacy_key in (
         "origen_modulo",
         "canonical_module",
@@ -523,6 +531,10 @@ def validate_usar_symbol_metadata(nombre: str, metadata: object) -> dict[str, ob
 
     if metadata_dict.get("sanitized") is not CANONICAL_USAR_METADATA_SCHEMA["value_constraints"]["sanitized"]:
         raise ValueError(f"Metadata inválida para símbolo usar '{nombre}': wrapper no sanitizado")
+    if metadata_dict.get("safe_wrapper") is not CANONICAL_USAR_METADATA_SCHEMA["value_constraints"]["safe_wrapper"]:
+        raise ValueError(f"Metadata inválida para símbolo usar '{nombre}': safe_wrapper inválido")
+    if metadata_dict.get("safe_wrapper") is not metadata_dict.get("sanitized"):
+        raise ValueError(f"Metadata inválida para símbolo usar '{nombre}': safe_wrapper contradice sanitized")
     if metadata_dict.get("public_api") is not CANONICAL_USAR_METADATA_SCHEMA["value_constraints"]["public_api"]:
         raise ValueError(f"Metadata inválida para símbolo usar '{nombre}': public_api inválida")
     if metadata_dict.get("backend_exposed") is not CANONICAL_USAR_METADATA_SCHEMA["value_constraints"]["backend_exposed"]:
@@ -543,4 +555,15 @@ def validate_usar_symbol_metadata(nombre: str, metadata: object) -> dict[str, ob
                 f"Metadata inválida para símbolo usar '{nombre}': {legacy_key} contradice {canonical_key}"
             )
 
+    return metadata_dict
+
+
+def validate_usar_symbol_metadata_normalized(nombre: str, metadata: object) -> dict[str, object]:
+    """Valida metadata `usar` exigiendo payload ya normalizado (sin claves legacy)."""
+    metadata_dict = validate_usar_symbol_metadata(nombre, metadata)
+    legacy_presentes = set(metadata_dict).intersection(USAR_SYMBOL_METADATA_LEGACY_KEYS)
+    if legacy_presentes:
+        raise ValueError(
+            f"Metadata inválida para símbolo usar '{nombre}': payload no normalizado, contiene claves legacy {sorted(legacy_presentes)}"
+        )
     return metadata_dict

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -202,6 +202,7 @@ def test_normaliza_aliases_explicitos_a_claves_canonicas_y_filtra_legacy():
         "module",
         "symbol",
         "sanitized",
+        "safe_wrapper",
         "public_api",
         "backend_exposed",
         "callable",


### PR DESCRIPTION
### Motivation
- Evitar aceptación silenciosa de metadata no normalizada y mantener un validador fail-closed para evitar inyección o bypass de seguridad en símbolos importados vía `usar`.
- Formalizar la semántica de wrappers seguros que algunos nativos requieren (por ejemplo `archivo.existe`) como parte del schema canónico en lugar de excepciones ad-hoc.

### Description
- Añadí la clave requerida `safe_wrapper` al contrato canónico de metadata `usar`, la incluí en valores por defecto seguros y en `make_usar_symbol_metadata` con semántica explícita (`True`).
- Extendí el esquema (`CANONICAL_USAR_METADATA_SCHEMA`) para imponer `safe_wrapper` en `value_constraints` y validé la coherencia entre `safe_wrapper` y `sanitized`.
- Introduje `validate_usar_symbol_metadata_normalized` que exige que el payload ya esté normalizado (sin claves legacy) y lo uso desde `ValidadorPrimitivaPeligrosa` para que el validador opere exclusivamente sobre metadata normalizada; además cambié el registro para normalizar antes de validar.
- Mantengo el comportamiento fail-closed para: claves faltantes, `origin_kind != "usar"`, `public_api != True`, inconsistencias `module`/`symbol`, `backend_exposed != False` y claves inesperadas fuera del schema canónico; también ajusté la limpieza de aliases legacy para no eliminar claves que mappeen a la misma canonical key.
- Actualicé pruebas unitarias (`tests/unit/test_usar_symbol_policy.py`) para reflejar `safe_wrapper` como parte del conjunto canónico esperado tras normalización.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_symbol_policy.py -q` y pasó correctamente (todos los tests del módulo fueron verdes).
- Intenté ejecutar `pytest -q tests/unit/test_usar_symbol_policy.py tests/unit/test_safe_mode.py -q`, pero la colección falló por un `ImportError: attempted relative import beyond top-level package` en `tests/unit/test_safe_mode.py` durante la importación, error de colección no relacionado directamente con los cambios de metadata.
- No se silenciaron excepciones: las rutas de normalización/validación lanzan `ValueError` con mensajes claros cuando la metadata está faltante, inconsistente o contiene claves inesperadas (se verificó con los tests actualizados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0973eef10c8327b10b28d1148905f3)