### PR TITLE
test: ampliar cobertura de `usar` y hardening de metadata

### DIFF
--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -111,6 +111,16 @@ def test_usar_archivo_existe_readme_no_falla_por_metadata():
     assert "existe" in interp._validador._metadata_simbolos_usar
 
 
+def test_carga_basica_modulos_publicos_datos_numero_texto_archivo():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "datos"\nusar "numero"\nusar "texto"\nusar "archivo"')
+
+    with patch("sys.stdout", new_callable=StringIO):
+        interp.ejecutar_ast(ast)
+
+    for simbolo in ("longitud", "es_finito", "mayusculas", "existe"):
+        assert simbolo in interp.variables
+
 def test_sintaxis_usar_sin_cadena_rechaza_con_error_claro():
     with pytest.raises(Exception, match=r"Se esperaba una ruta de módulo entre comillas"):
         generar_ast('usar archivo')

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -5,6 +5,7 @@ from pcobra.core.usar_symbol_policy import (
     normalizar_metadata_simbolo_usar,
     sanear_exportables_para_usar,
     sanear_simbolo_para_usar,
+    validate_usar_symbol_metadata,
 )
 
 
@@ -223,3 +224,40 @@ def test_rechaza_conflicto_semantico_en_aliases_no_resoluble():
         assert "aliases inconsistentes para origin_kind" in str(exc)
     else:
         raise AssertionError("Se esperaba ValueError por conflicto semántico en aliases.")
+
+def test_rechaza_metadata_con_clave_desconocida_maliciosa():
+    raw = {
+        "origin_kind": "usar",
+        "module": "archivo",
+        "symbol": "existe",
+        "public_api": True,
+        "sanitized": True,
+        "callable": True,
+        "backend_exposed": False,
+        "__proto_payload_inyectado__": "boom",
+    }
+    try:
+        normalizar_metadata_simbolo_usar(raw, "archivo", "existe")
+    except ValueError as exc:
+        assert "claves inesperadas críticas" in str(exc)
+    else:
+        raise AssertionError("Se esperaba ValueError por clave desconocida.")
+
+
+def test_rechaza_metadata_con_contradiccion_backend_exposed_true_en_validacion_estricta():
+    raw = {
+        "origin_kind": "backend_privado",
+        "module": "archivo",
+        "symbol": "existe",
+        "public_api": True,
+        "sanitized": True,
+        "safe_wrapper": True,
+        "backend_exposed": True,
+        "callable": True,
+    }
+    try:
+        validate_usar_symbol_metadata("existe", raw)
+    except ValueError as exc:
+        assert "backend_exposed inválido" in str(exc)
+    else:
+        raise AssertionError("Se esperaba ValueError por contradicción maliciosa de metadata.")


### PR DESCRIPTION
### Motivation

- Reforzar la cobertura de pruebas sobre la semántica REPL/`usar` para garantizar que módulos públicos (`datos`, `numero`, `texto`, `archivo`) se cargan e inyectan símbolos esperados. 
- Asegurar validación fail-closed de la metadata de `usar` para detectar payloads maliciosos y contradicciones políticas (p.ej. `backend_exposed`).

### Description

- Añade `test_carga_basica_modulos_publicos_datos_numero_texto_archivo` en `tests/unit/test_safe_mode.py` que ejecuta `usar "datos"`, `usar "numero"`, `usar "texto"` y `usar "archivo"` y comprueba la presencia de `longitud`, `es_finito`, `mayusculas` y `existe` en el contexto runtime. 
- Importa `validate_usar_symbol_metadata` en `tests/unit/test_usar_symbol_policy.py` y añade dos pruebas nuevas que cubren rechazo de metadata maliciosa: una que detecta claves críticas inesperadas y otra que valida la contradicción `backend_exposed=true`. 
- Ajusta mensajes/expectativas de aserción en tests para reflejar los mensajes de error reales emitidos por el validador (p.ej. "claves inesperadas críticas").

### Testing

- Ejecuté `pytest -q tests/unit/test_usar_symbol_policy.py::test_rechaza_metadata_con_clave_desconocida_maliciosa tests/unit/test_usar_symbol_policy.py::test_rechaza_metadata_con_contradiccion_backend_exposed_true_en_validacion_estricta` y ambas pruebas pasaron (2 passed, 1 warning). 
- Intenté ejecutar varios tests de `tests/unit/test_safe_mode.py` en este entorno, pero la colección falló con un `ImportError` por resolución de paquete relativo (`core` vs `pcobra.core`), por lo que esos tests no pudieron correrse aquí y se documenta como limitación del entorno de ejecución actual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a097652e054832796f662898ca5e659)