### PR TITLE
Unifica la fuente de verdad de aliases legacy en usar_symbol_policy

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -247,16 +247,27 @@ USAR_SYMBOL_METADATA_REQUIRED_KEYS = frozenset(
     }
 )
 
+USAR_METADATA_LEGACY_ALIASES = {
+    "kind": "origin_kind",
+    "introduced_by": "origin_kind",
+    "introduced_by_usar": "origin_kind",
+    "origen_tipo": "origin_kind",
+    "is_public_export": "public_api",
+    "safe_wrapper": "safe_wrapper",
+}
+USAR_METADATA_LEGACY_CONSISTENCY = {
+    "origen_modulo": "module",
+    "canonical_module": "module",
+    "origin_module": "module",
+    "exported_name": "symbol",
+}
+USAR_METADATA_LEGACY_BOOL_TRUE = {"is_sanitized_wrapper": "sanitized"}
+
 # Claves legacy mantenidas solo por compatibilidad histórica.
 USAR_SYMBOL_METADATA_LEGACY_KEYS = frozenset(
-    {
-        "kind",
-        "origen_modulo",
-        "canonical_module",
-        "origin_module",
-        "exported_name",
-        "is_sanitized_wrapper",
-    }
+    set(USAR_METADATA_LEGACY_ALIASES)
+    | set(USAR_METADATA_LEGACY_CONSISTENCY)
+    | set(USAR_METADATA_LEGACY_BOOL_TRUE)
 )
 
 USAR_SYMBOL_METADATA_OPTIONAL_KEYS = frozenset(
@@ -286,21 +297,9 @@ CANONICAL_USAR_METADATA_SCHEMA = {
         "backend_exposed": False,
         "callable": bool,
     },
-    "legacy_aliases": {
-        "kind": "origin_kind",
-        "introduced_by": "origin_kind",
-        "introduced_by_usar": "origin_kind",
-        "origen_tipo": "origin_kind",
-        "is_public_export": "public_api",
-        "safe_wrapper": "safe_wrapper",
-    },
-    "legacy_consistency": {
-        "origen_modulo": "module",
-        "canonical_module": "module",
-        "origin_module": "module",
-        "exported_name": "symbol",
-    },
-    "legacy_bool_true": {"is_sanitized_wrapper": "sanitized"},
+    "legacy_aliases": USAR_METADATA_LEGACY_ALIASES,
+    "legacy_consistency": USAR_METADATA_LEGACY_CONSISTENCY,
+    "legacy_bool_true": USAR_METADATA_LEGACY_BOOL_TRUE,
 }
 
 USAR_METADATA_SECURE_BOOL_DEFAULTS: dict[str, bool] = {
@@ -468,13 +467,7 @@ def normalizar_metadata_simbolo_usar(raw_metadata: object, module_name: str, sym
     for legacy_key in aliases_normalizados:
         if legacy_key != CANONICAL_USAR_METADATA_SCHEMA["legacy_aliases"][legacy_key]:
             metadata_dict.pop(legacy_key, None)
-    for optional_legacy_key in (
-        "origen_modulo",
-        "canonical_module",
-        "origin_module",
-        "exported_name",
-        "is_sanitized_wrapper",
-    ):
+    for optional_legacy_key in set(USAR_METADATA_LEGACY_CONSISTENCY) | set(USAR_METADATA_LEGACY_BOOL_TRUE):
         metadata_dict.pop(optional_legacy_key, None)
 
 

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -1,7 +1,9 @@
 from types import ModuleType
 
 from pcobra.core.usar_symbol_policy import (
+    CANONICAL_USAR_METADATA_SCHEMA,
     PoliticaSaneamientoUsar,
+    USAR_SYMBOL_METADATA_ALLOWED_KEYS,
     normalizar_metadata_simbolo_usar,
     sanear_exportables_para_usar,
     sanear_simbolo_para_usar,
@@ -261,3 +263,28 @@ def test_rechaza_metadata_con_contradiccion_backend_exposed_true_en_validacion_e
         assert "backend_exposed inválido" in str(exc)
     else:
         raise AssertionError("Se esperaba ValueError por contradicción maliciosa de metadata.")
+
+
+def test_claves_legacy_compatibles_forman_parte_del_set_permitido():
+    legacy_compatibles = {"introduced_by", "introduced_by_usar", "origen_tipo", "is_public_export"}
+    assert legacy_compatibles.issubset(USAR_SYMBOL_METADATA_ALLOWED_KEYS)
+    assert legacy_compatibles.issubset(set(CANONICAL_USAR_METADATA_SCHEMA["legacy_aliases"]))
+
+
+def test_normalizacion_acepta_y_canonicaliza_claves_legacy_compatibles_sin_criticas():
+    raw = {
+        "introduced_by": "usar",
+        "introduced_by_usar": "usar",
+        "origen_tipo": "usar",
+        "is_public_export": True,
+        "safe_wrapper": True,
+        "backend_exposed": False,
+        "callable": True,
+    }
+    normalizada = normalizar_metadata_simbolo_usar(raw, "archivo", "existe")
+    assert normalizada["origin_kind"] == "usar"
+    assert normalizada["public_api"] is True
+    assert "introduced_by" not in normalizada
+    assert "introduced_by_usar" not in normalizada
+    assert "origen_tipo" not in normalizada
+    assert "is_public_export" not in normalizada


### PR DESCRIPTION
### Motivation

- Evitar listas divergentes de claves legacy y centralizar la definición de aliases para la metadata del contrato `usar` con una única fuente de verdad. 
- Asegurar que claves legacy de compatibilidad (`introduced_by`, `introduced_by_usar`, `origen_tipo`, `is_public_export`) sean aceptadas y canonicalizadas durante la normalización sin abrir vectores de claves inesperadas.
- Mantener la política fail-closed para claves realmente desconocidas y conservar las garantías de seguridad del validador.

### Description

- Se introducen los mapas `USAR_METADATA_LEGACY_ALIASES`, `USAR_METADATA_LEGACY_CONSISTENCY` y `USAR_METADATA_LEGACY_BOOL_TRUE` y se deriva `USAR_SYMBOL_METADATA_LEGACY_KEYS` a partir de la unión de sus claves. 
- `CANONICAL_USAR_METADATA_SCHEMA` ahora referencia los mapas legacy (`legacy_aliases`, `legacy_consistency`, `legacy_bool_true`) en lugar de duplicar listas literales. 
- La normalización borra las claves legacy opcionales basándose en `USAR_METADATA_LEGACY_CONSISTENCY | USAR_METADATA_LEGACY_BOOL_TRUE` para evitar otra lista hardcodeada y se mantiene la eliminación de aliases normalizados tras canonicalizar. 
- Se añadieron/ajustaron tests en `tests/unit/test_usar_symbol_policy.py` y se actualizaron imports para comprobar que las claves legacy de compatibilidad están en el set permitido y se canonicalizan sin dejar claves inesperadas críticas.

### Testing

- Se ejecutaron los tests unitarios con `pytest -q tests/unit/test_usar_symbol_policy.py` y todos pasaron (`21 passed, 1 warning`).
- Las nuevas pruebas verifican que las claves legacy compatibles forman parte de `USAR_SYMBOL_METADATA_ALLOWED_KEYS` y que la normalización convierte y elimina las claves legacy comprobadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a097a6caec48327b593cc585c31146f)