### PR TITLE
Normaliza metadata de `usar` y cubre regresión de `safe_wrapper` legacy

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -254,6 +254,7 @@ USAR_METADATA_LEGACY_ALIASES = {
     "origen_tipo": "origin_kind",
     "is_public_export": "public_api",
     "safe_wrapper": "safe_wrapper",
+    "wrapper_safe": "safe_wrapper",
 }
 USAR_METADATA_LEGACY_CONSISTENCY = {
     "origen_modulo": "module",
@@ -448,6 +449,14 @@ def normalizar_metadata_simbolo_usar(raw_metadata: object, module_name: str, sym
             alias_keys=alias_keys,
         )
 
+    for legacy_key, canonical_key in CANONICAL_USAR_METADATA_SCHEMA["legacy_consistency"].items():
+        if legacy_key in metadata_dict and canonical_key not in metadata_dict:
+            metadata_dict[canonical_key] = metadata_dict[legacy_key]
+
+    for legacy_key, canonical_key in CANONICAL_USAR_METADATA_SCHEMA["legacy_bool_true"].items():
+        if legacy_key in metadata_dict and canonical_key not in metadata_dict:
+            metadata_dict[canonical_key] = metadata_dict[legacy_key]
+
     if isinstance(module_name, str) and module_name.strip():
         if "module" in metadata_dict and metadata_dict["module"] != module_name:
             raise ValueError(
@@ -483,6 +492,16 @@ def normalizar_metadata_simbolo_usar(raw_metadata: object, module_name: str, sym
     if faltantes:
         raise ValueError(f"Metadata inválida para símbolo usar '{symbol_name}': faltan claves {sorted(faltantes)}")
 
+    claves_canonicas_y_opcionales = (
+        CANONICAL_USAR_METADATA_SCHEMA["required_keys"]
+        | USAR_SYMBOL_METADATA_OPTIONAL_KEYS
+    )
+    metadata_final = {
+        clave: metadata_dict[clave]
+        for clave in metadata_dict
+        if clave in claves_canonicas_y_opcionales
+    }
+
     inesperadas_criticas = set(metadata_dict.keys()) - CANONICAL_USAR_METADATA_SCHEMA["allowed_keys"]
     if inesperadas_criticas:
         raise ValueError(
@@ -490,7 +509,7 @@ def normalizar_metadata_simbolo_usar(raw_metadata: object, module_name: str, sym
             f"'{symbol_name}': claves inesperadas críticas {sorted(inesperadas_criticas)}"
         )
 
-    return metadata_dict
+    return metadata_final
 
 
 def validate_usar_symbol_metadata(nombre: str, metadata: object) -> dict[str, object]:

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -288,3 +288,52 @@ def test_normalizacion_acepta_y_canonicaliza_claves_legacy_compatibles_sin_criti
     assert "introduced_by_usar" not in normalizada
     assert "origen_tipo" not in normalizada
     assert "is_public_export" not in normalizada
+
+
+def test_normaliza_wrapper_safe_legacy_hacia_safe_wrapper_canonico():
+    raw = {
+        "origin_kind": "usar",
+        "module": "archivo",
+        "symbol": "existe",
+        "sanitized": True,
+        "wrapper_safe": True,
+        "public_api": True,
+        "backend_exposed": False,
+        "callable": True,
+    }
+    normalizada = normalizar_metadata_simbolo_usar(raw, "archivo", "existe")
+    assert normalizada["safe_wrapper"] is True
+    assert "wrapper_safe" not in normalizada
+    assert set(normalizada.keys()) == {
+        "origin_kind",
+        "module",
+        "symbol",
+        "sanitized",
+        "safe_wrapper",
+        "public_api",
+        "backend_exposed",
+        "callable",
+    }
+
+
+def test_regresion_runtime_usar_archivo_existe_no_aborta_por_safe_wrapper():
+    metadata_runtime_real = {
+        "introduced_by_usar": "usar",
+        "canonical_module": "archivo",
+        "exported_name": "existe",
+        "is_sanitized_wrapper": True,
+        "wrapper_safe": True,
+        "is_public_export": True,
+        "backend_exposed": False,
+        "callable": True,
+        "python_module": "pcobra.std.archivo",
+    }
+
+    normalizada = validate_usar_symbol_metadata("existe", metadata_runtime_real)
+
+    assert normalizada["module"] == "archivo"
+    assert normalizada["symbol"] == "existe"
+    assert normalizada["sanitized"] is True
+    assert normalizada["safe_wrapper"] is True
+    assert normalizada["safe_wrapper"] is normalizada["sanitized"]
+    assert normalizada["backend_exposed"] is False


### PR DESCRIPTION
### Motivation
- Evitar que payloads legacy contaminen el snapshot final de metadata y provocar rechazos inesperados al validar `usar`.
- Aceptar de forma segura variantes legacy de la bandera `safe_wrapper` (p.ej. `wrapper_safe`) que aparecen en metadata runtime real.
- Mantener el contrato fail-closed y las invariantes de seguridad para metadata de `usar`.

### Description
- Proyecta la salida de `normalizar_metadata_simbolo_usar(...)` a solo claves canónicas requeridas (`required_keys`) más las opcionales permitidas (`USAR_SYMBOL_METADATA_OPTIONAL_KEYS`) antes del retorno final en `src/pcobra/core/usar_symbol_policy.py`.
- Añade `"wrapper_safe"` como alias legacy mapeado a la clave canónica `safe_wrapper` y promueve claves legacy de consistencia (`canonical_module`, `exported_name`, etc.) y booleanos legacy (`is_sanitized_wrapper`) hacia sus canónicas cuando faltan estas últimas.
- Conserva la validación estricta en `validate_usar_symbol_metadata`: `sanitized is True`, `safe_wrapper is True`, `safe_wrapper == sanitized`, y `backend_exposed is False` sin relajar comprobaciones fail-closed para claves críticas inesperadas.
- Cambios realizados en `src/pcobra/core/usar_symbol_policy.py` y se añadieron tests en `tests/unit/test_usar_symbol_policy.py` que cubren canonicalización de `wrapper_safe` y una regresión realista de metadata runtime para `usar "archivo"` (`existe`).

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_symbol_policy.py` y todos los tests pasaron exitosamente (`23 passed, 1 warning`).
- Se añadieron y verificaron los tests `test_normaliza_wrapper_safe_legacy_hacia_safe_wrapper_canonico` y `test_regresion_runtime_usar_archivo_existe_no_aborta_por_safe_wrapper`, y ambos se ejecutaron correctamente como parte del conjunto.
- Las pruebas confirman que la normalización elimina claves legacy en la salida final y que las invariantes de seguridad siguen aplicándose.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a097b681dd48327aecc0ef763d204b5)