### PR TITLE
test: reforzar contrato de `usar` para REPL y metadata legacy/fail-closed

### DIFF
--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -1189,3 +1189,23 @@ def test_regresion_metadata_usar_none_pre_auditoria(factory, executor, get_inter
 
     with pytest.raises(PermissionError, match=r"(módulo fuera del catálogo público|modulo_fuera_catalogo_publico)"):
         executor(cmd, 'usar "numpy"')
+
+
+def test_repl_usar_datos_numero_archivo_contrato_basico_sin_errores_metadata(capsys):
+    cmd = ReplCommandV2()
+
+    cmd._ejecutar_en_modo_normal('usar "datos"')
+    cmd._ejecutar_en_modo_normal('var xs = [1, 2, 3]')
+    cmd._ejecutar_en_modo_normal('imprimir(longitud(xs))')
+
+    cmd._ejecutar_en_modo_normal('usar "numero"')
+    cmd._ejecutar_en_modo_normal('imprimir(es_finito(10))')
+
+    cmd._ejecutar_en_modo_normal('usar "archivo"')
+    cmd._ejecutar_en_modo_normal('imprimir(existe("README.md"))')
+
+    salida = capsys.readouterr().out
+    assert 'Traceback' not in salida
+    assert 'metadata' not in salida.lower()
+    assert '3' in salida
+    assert 'verdadero' in salida or 'falso' in salida

--- a/tests/integration/test_usar_runtime_contract.py
+++ b/tests/integration/test_usar_runtime_contract.py
@@ -299,3 +299,45 @@ def test_integridad_estatica_lexer_y_parser_sin_diff_inesperado():
     for ruta, hash_esperado in hashes_esperados.items():
         contenido = Path(ruta).read_bytes()
         assert hashlib.sha256(contenido).hexdigest() == hash_esperado, f"Hash inesperado en {ruta}"
+
+
+def test_runtime_metadata_legacy_aliases_se_normalizan_a_canonico():
+    raw = {
+        "introduced_by": "usar",
+        "introduced_by_usar": "usar",
+        "origen_tipo": "usar",
+        "is_public_export": True,
+        "module": "numero",
+        "symbol": "es_finito",
+        "sanitized": True,
+        "safe_wrapper": True,
+        "backend_exposed": False,
+        "callable": True,
+    }
+
+    normalizada = usar_symbol_policy.normalizar_metadata_simbolo_usar(raw, "numero", "es_finito")
+    validada = usar_symbol_policy.validate_usar_symbol_metadata("es_finito", normalizada)
+
+    assert validada["origin_kind"] == "usar"
+    assert validada["public_api"] is True
+    assert "introduced_by" not in validada
+    assert "introduced_by_usar" not in validada
+    assert "origen_tipo" not in validada
+    assert "is_public_export" not in validada
+
+
+def test_runtime_metadata_clave_desconocida_maliciosa_rechazada_fail_closed():
+    raw = {
+        "origin_kind": "usar",
+        "module": "numero",
+        "symbol": "es_finito",
+        "sanitized": True,
+        "safe_wrapper": True,
+        "public_api": True,
+        "backend_exposed": False,
+        "callable": True,
+        "__backend_hook__": "pwn",
+    }
+
+    with pytest.raises(ValueError, match=r"unexpected_keys|claves inesperadas"):
+        usar_symbol_policy.validate_usar_symbol_metadata("es_finito", raw)


### PR DESCRIPTION
### Motivation
- Asegurar el comportamiento seguro y esperado de la sentencia `usar` en el REPL y validar que la normalización/validación de metadata `usar` soporte aliases legacy y sea fail-closed ante claves inesperadas.

### Description
- Añadí un test REPL end-to-end en `tests/integration/test_repl_usar_entrypoints_contract.py` que ejecuta `usar "datos"` + `var xs = [1, 2, 3]` y verifica `longitud(xs)`, luego `usar "numero"` y `es_finito(10)`, y finalmente `usar "archivo"` y `existe("README.md")`, comprobando que no haya `Traceback` ni mensajes de metadata visibles en la salida.
- Añadí dos tests runtime en `tests/integration/test_usar_runtime_contract.py`: uno que valida la normalización segura de aliases legacy (`introduced_by`, `introduced_by_usar`, `origen_tipo`, `is_public_export`) hacia la metadata canónica, y otro que verifica el rechazo fail-closed frente a una clave realmente desconocida/maliciosa (`__backend_hook__`).
- Todos los cambios son pruebas de integración/contrato y no modifican el código de producción.

### Testing
- Ejecuté `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py -k "usar_datos_numero_archivo_contrato_basico or usar_archivo_requiere_cadena_entre_comillas or no_regresion_seguridad_usar_numpy"` y los tests seleccionados pasaron (`4 passed, 76 deselected`).
- Ejecuté `pytest -q tests/integration/test_usar_runtime_contract.py -k "usar_datos_expone_longitud_ymetadata_canonica or usar_numero_mantiene_es_finito_y_signo or usar_archivo_carga_existe_sin_error_metadata or metadata_legacy_aliases_se_normalizan_a_canonico or metadata_clave_desconocida_maliciosa_rechazada_fail_closed"` y los tests seleccionados pasaron (`4 passed, 14 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a097ddac8588327b7649c29ebac0c62)