### PR TITLE
Unificar pipeline de metadata de `usar` y añadir trazas USAR_METADATA_PIPELINE

### DIFF
--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -15,7 +15,11 @@ from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_source_for_tokenizer
 from pcobra.cobra.cli.utils.validators import normalizar_validadores_extra
 from pcobra.cobra.core.runtime import ValidadorBase, construir_cadena
-from pcobra.core.usar_symbol_policy import validate_usar_symbol_metadata
+from pcobra.core.usar_symbol_policy import (
+    normalizar_metadata_simbolo_usar,
+    validate_usar_symbol_metadata,
+)
+import logging
 
 
 @dataclass(frozen=True)
@@ -180,9 +184,22 @@ def validar_ast_seguro(
                 continue
             metadata_normalizada = dict(metadata)
             if validar_metadata_usar:
+                modulo_ctx = ""
+                if isinstance(metadata_normalizada.get("module"), str):
+                    modulo_ctx = str(metadata_normalizada["module"])
+                metadata_normalizada = normalizar_metadata_simbolo_usar(
+                    metadata_normalizada,
+                    modulo_ctx,
+                    nombre,
+                )
                 metadata_normalizada = validate_usar_symbol_metadata(
                     nombre,
                     metadata_normalizada,
+                )
+                logging.debug(
+                    "USAR_METADATA_PIPELINE route=legacy-normalized module=%s symbol=%s",
+                    metadata_normalizada.get("module"),
+                    nombre,
                 )
             modulo = metadata_normalizada.get("module")
             if not isinstance(modulo, str):

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -972,7 +972,8 @@ class InterpretadorCobra:
 
     def _validar_metadata_usar_o_fallar(self, nombre: str, metadata: object) -> None:
         try:
-            validate_usar_symbol_metadata(nombre, metadata)
+            metadata_normalizada = self._canonicalizar_metadata_usar(nombre, metadata)
+            validate_usar_symbol_metadata(nombre, metadata_normalizada)
         except ValueError as exc:
             # Preserva el motivo original para diagnóstico en REPL sin exponer internals sensibles.
             raise PrimitivaPeligrosaError(
@@ -993,7 +994,13 @@ class InterpretadorCobra:
             if isinstance(modulo_metadata, str):
                 modulo = modulo_metadata
         metadata_normalizada = normalizar_metadata_simbolo_usar(metadata, modulo, nombre)
-        return validate_usar_symbol_metadata(nombre, metadata_normalizada)
+        metadata_validada = validate_usar_symbol_metadata(nombre, metadata_normalizada)
+        logging.debug(
+            "USAR_METADATA_PIPELINE route=legacy-normalized module=%s symbol=%s",
+            metadata_validada.get("module"),
+            nombre,
+        )
+        return metadata_validada
 
     @staticmethod
     def _metadata_usar_equivalente_idempotente(
@@ -2273,10 +2280,12 @@ class InterpretadorCobra:
                     symbol_name=nombre,
                     callable_obj=simbolo,
                 )
-                metadata_por_simbolo[nombre] = validate_usar_symbol_metadata(
+                logging.debug(
+                    "USAR_METADATA_PIPELINE route=factory module=%s symbol=%s",
+                    nodo.modulo,
                     nombre,
-                    metadata_simbolo,
                 )
+                metadata_por_simbolo[nombre] = dict(metadata_simbolo)
             conflictos = self._detectar_conflictos_usar_en_contexto(
                 simbolos_saneados,
                 metadata_por_simbolo=metadata_por_simbolo,


### PR DESCRIPTION
### Motivation
- Evitar validaciones directas sobre payload `raw` y centralizar la normalización/validación de metadata `usar` en una única ruta para reducir discrepancias y fallos de sincronización entre intérprete y validador.
- Mantener compatibilidad legacy para metadata prearmada, pero forzar su normalización explícita antes de la validación final.
- Habilitar trazas diagnósticas claras para distinguir el origen de cada metadata (`factory` vs `legacy-normalized`) y facilitar debugging operativo.

### Description
- En `src/pcobra/core/interpreter.py` se cambió `_validar_metadata_usar_o_fallar` para canonicalizar primero usando `self._canonicalizar_metadata_usar(...)` y luego validar, evitando validar payloads raw directamente.
- En `src/pcobra/core/interpreter.py` `_canonicalizar_metadata_usar` ahora normaliza+valida y emite `logging.debug` con la cadena `USAR_METADATA_PIPELINE route=legacy-normalized` para trazar esa ruta.
- En la rama de construcción dentro de `ejecutar_usar` se usa exclusivamente `build_and_validate_usar_symbol_metadata(...)` como puerta para símbolos provenientes de objetos reales y se añadió traza `USAR_METADATA_PIPELINE route=factory`, además de almacenar la metadata ya validada.
- En `src/pcobra/cobra/cli/execution_pipeline.py` el flujo que rehidrata metadata prearmada ahora aplica explícitamente `normalizar_metadata_simbolo_usar(...)` antes de `validate_usar_symbol_metadata(...)` y emite la traza `USAR_METADATA_PIPELINE route=legacy-normalized`.

### Testing
- Se compiló el código modificado con `python -m compileall src/pcobra/core/interpreter.py src/pcobra/cobra/cli/execution_pipeline.py` y la compilación finalizó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0983342b608327ba7dc57b474bfd10)