### PR TITLE
Ensure canonical `usar` metadata normalization on CLI reinjection

### DIFF
--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -183,19 +183,19 @@ def validar_ast_seguro(
             if not isinstance(metadata, dict):
                 continue
             metadata_normalizada = dict(metadata)
+            modulo_ctx = ""
+            if isinstance(metadata_normalizada.get("module"), str):
+                modulo_ctx = str(metadata_normalizada["module"])
+            metadata_normalizada = normalizar_metadata_simbolo_usar(
+                metadata_normalizada,
+                modulo_ctx,
+                nombre,
+            )
+            metadata_normalizada = validate_usar_symbol_metadata(
+                nombre,
+                metadata_normalizada,
+            )
             if validar_metadata_usar:
-                modulo_ctx = ""
-                if isinstance(metadata_normalizada.get("module"), str):
-                    modulo_ctx = str(metadata_normalizada["module"])
-                metadata_normalizada = normalizar_metadata_simbolo_usar(
-                    metadata_normalizada,
-                    modulo_ctx,
-                    nombre,
-                )
-                metadata_normalizada = validate_usar_symbol_metadata(
-                    nombre,
-                    metadata_normalizada,
-                )
                 logging.debug(
                     "USAR_METADATA_PIPELINE route=legacy-normalized module=%s symbol=%s",
                     metadata_normalizada.get("module"),


### PR DESCRIPTION
### Motivation
- Garantizar que la reinyección de metadata `usar` en la cadena de validadores del CLI pase siempre por la ruta canónica de normalización y validación para evitar registros ad-hoc que violen el contrato de metadata.
- Confirmar que la construcción de metadata nueva al importar módulos ya utiliza la fábrica canónica `build_and_validate_usar_symbol_metadata(...)` en la fase de carga para mantener consistencia de origen.

### Description
- Revisión del flujo de `usar` en `src/pcobra/core/interpreter.py` y verificación de que la creación de metadata nueva usa `build_and_validate_usar_symbol_metadata(...)` durante la importación de símbolos (pre-inyección). 
- Cambio en `src/pcobra/cobra/cli/execution_pipeline.py` dentro de `validar_ast_seguro` para que la reinyección de cada `metadata` haga siempre `normalizar_metadata_simbolo_usar(...)` seguido de `validate_usar_symbol_metadata(...)` antes de llamar a `registrar_simbolo_publico_usar(...)`.
- Mantener la visibilidad de depuración controlada por `validar_metadata_usar` dejando el `logging.debug(...)` sujeto a esa bandera para no alterar la verbosidad por defecto.

### Testing
- Ejecutado `pytest -q tests -k "usar and metadata"`, pero la ejecución falló en la fase de colección por errores preexistentes del repositorio (módulos de transpilers faltantes y un `ImportError` en `target_policies`), por lo que no se pudo validar con esos tests.
- Ejecutado `pytest -q tests/unit -k "execution_pipeline or usar_symbol or metadata" --maxfail=1`, y la ejecución falló en colección por el mismo `ImportError` en `test_cli_mode_policy`, por lo que no se obtuvieron tests unitarios verdes relacionados con el cambio.
- No se observaron errores introducidos por la modificación en `execution_pipeline.py` durante las invocaciones realizadas; los fallos reportados parecen independientes del cambio aplicado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09880c41d88327a0da0fb5a71ecbfe)