### PR TITLE
Refuerza normalización fail-closed de metadata `usar` y resolución determinista de aliases

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -348,23 +348,35 @@ def _resolver_valor_canonico_desde_aliases(
     metadata_dict: dict[str, object],
     canonical_key: str,
     alias_keys: list[str],
+    symbol_name: str,
 ) -> None:
     if not alias_keys:
         return
-    valores: list[object] = []
+
+    pares_valores: list[tuple[str, object]] = []
     if canonical_key in metadata_dict:
-        valores.append(metadata_dict[canonical_key])
-    valores.extend(metadata_dict[k] for k in alias_keys)
-    if len({repr(v) for v in valores}) > 1:
+        pares_valores.append((canonical_key, metadata_dict[canonical_key]))
+    pares_valores.extend((k, metadata_dict[k]) for k in alias_keys)
+
+    representaciones: dict[str, list[str]] = {}
+    for source_key, valor in pares_valores:
+        representaciones.setdefault(repr(valor), []).append(source_key)
+
+    if len(representaciones) > 1:
         valor_seguro = USAR_METADATA_SECURE_DEFAULTS.get(canonical_key)
-        if valor_seguro is not None and valor_seguro in valores:
-            metadata_dict[canonical_key] = valor_seguro
-        else:
+        if valor_seguro is None:
             raise ValueError(
-                f"Metadata inválida para símbolo usar: aliases inconsistentes para {canonical_key}"
+                f"Metadata inválida para símbolo usar '{symbol_name}': aliases inconsistentes para {canonical_key}"
             )
-    elif canonical_key not in metadata_dict:
-        metadata_dict[canonical_key] = valores[0]
+        if all(valor != valor_seguro for _, valor in pares_valores):
+            raise ValueError(
+                f"Metadata inválida para símbolo usar '{symbol_name}': aliases inconsistentes para {canonical_key} sin valor seguro"
+            )
+        metadata_dict[canonical_key] = valor_seguro
+        return
+
+    if canonical_key not in metadata_dict:
+        metadata_dict[canonical_key] = pares_valores[0][1]
 
 
 def make_usar_symbol_metadata(
@@ -481,6 +493,7 @@ def normalizar_metadata_simbolo_usar(raw_metadata: object, module_name: str, sym
             metadata_dict=metadata_dict,
             canonical_key=canonical_key,
             alias_keys=aliases_presentes,
+            symbol_name=symbol_name,
         )
 
     # Alias legacy adicional (`kind -> origin_kind`) mantenido por compatibilidad.
@@ -490,6 +503,7 @@ def normalizar_metadata_simbolo_usar(raw_metadata: object, module_name: str, sym
             metadata_dict=metadata_dict,
             canonical_key="origin_kind",
             alias_keys=["kind"],
+            symbol_name=symbol_name,
         )
 
     for legacy_key, canonical_key in USAR_SCHEMA_LEGACY_CONSISTENCY.items():
@@ -512,9 +526,8 @@ def normalizar_metadata_simbolo_usar(raw_metadata: object, module_name: str, sym
                 f"Metadata inválida para símbolo usar '{symbol_name}': inconsistencia semántica: symbol distinto del contexto"
             )
         metadata_dict.setdefault("symbol", symbol_name)
-    # 2) Aplicar defaults seguros sobre contrato canónico.
+    # 2) Aplicar defaults seguros solo cuando faltan claves canónicas.
     metadata_dict.setdefault("origin_kind", USAR_SCHEMA_VALUE_CONSTRAINTS["origin_kind"])
-    metadata_dict["origin_kind"] = USAR_SCHEMA_VALUE_CONSTRAINTS["origin_kind"]
     for key, default in USAR_METADATA_SECURE_BOOL_DEFAULTS.items():
         metadata_dict.setdefault(key, default)
 


### PR DESCRIPTION
### Motivation
- Evitar ambigüedades y silencios peligrosos en la normalización de metadata `usar` aplicando una política determinista y fail-closed para aliases legacy. 
- Asegurar que los mapeos legacy solicitados se mantengan y no sean sobreecritos de forma silenciosa por defaults inseguros. 
- Forzar coherencia con el contexto operativo (`module_name` / `symbol_name`) para evitar inyección o incongruencias semánticas.

### Description
- `_resolver_valor_canonico_desde_aliases(...)` ahora recibe `symbol_name`, agrupa pares `(clave_origen, valor)` y detecta contradicciones por representación, lanzando `ValueError` si los aliases son inconsistentes y no existe un `valor_seguro` aplicable; si existe el `valor_seguro` y está presente, se fija ese valor. 
- Se mantienen/aseguran los mapeos legacy: `introduced_by|introduced_by_usar|origen_tipo|kind -> origin_kind`, `is_public_export -> public_api` y `wrapper_safe -> safe_wrapper` durante la normalización. 
- Se completa `module` y `symbol` desde `module_name` / `symbol_name` y se aborta con error si el payload contradice esos valores de contexto; si faltan, se rellenan con `setdefault`. 
- Los defaults seguros (`sanitized=True`, `safe_wrapper=True`, `public_api=True`, `backend_exposed=False`) se aplican con `setdefault` (no se fuerzan sobre valores explícitos del payload) y ya no se sobrescribe incondicionalmente `origin_kind`. 
- Se eliminan las claves legacy absorbidas antes del chequeo final de `allowed_keys` para que la comprobación fail-closed detecte claves inesperadas correctamente.

### Testing
- Se compiló el módulo con `python -m compileall src/pcobra/core/usar_symbol_policy.py` y la compilación finalizó con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a098a1e5e8c8327ad5cf62d21a14b50)