### PR TITLE
tests: ampliar contrato runtime de `usar` y añadir casos REPL y de sintaxis

### DIFF
--- a/tests/integration/test_usar_runtime_contract.py
+++ b/tests/integration/test_usar_runtime_contract.py
@@ -301,6 +301,39 @@ def test_integridad_estatica_lexer_y_parser_sin_diff_inesperado():
         assert hashlib.sha256(contenido).hexdigest() == hash_esperado, f"Hash inesperado en {ruta}"
 
 
+
+def test_repl_incremental_usar_datos_preserva_estado_y_longitud(capsys):
+    from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+
+    cmd = InteractiveCommand(InterpretadorCobra())
+    cmd.ejecutar_codigo("var xs=[1,2,3]")
+    cmd.ejecutar_codigo('usar "datos"')
+    cmd.ejecutar_codigo("imprimir(longitud(xs))")
+    cmd.ejecutar_codigo("imprimir(longitud([1,2,3]))")
+
+    salida = capsys.readouterr().out
+    assert salida.count("3") >= 2
+
+
+def test_sintaxis_usar_sin_comillas_falla_como_hoy():
+    from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+
+    cmd = InteractiveCommand(InterpretadorCobra())
+    from pcobra.cobra.core.parser import ParserError
+
+    with pytest.raises(ParserError, match="comillas"):
+        cmd.ejecutar_codigo("usar archivo")
+
+
+def test_sintaxis_usar_cadena_sin_cerrar_falla_como_hoy():
+    from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
+
+    cmd = InteractiveCommand(InterpretadorCobra())
+    from pcobra.core.errors import UnclosedStringError
+
+    with pytest.raises(UnclosedStringError, match="Cadena sin cerrar"):
+        cmd.ejecutar_codigo('usar "datos2')
+
 def test_runtime_metadata_legacy_aliases_se_normalizan_a_canonico():
     raw = {
         "introduced_by": "usar",
@@ -336,8 +369,8 @@ def test_runtime_metadata_clave_desconocida_maliciosa_rechazada_fail_closed():
         "public_api": True,
         "backend_exposed": False,
         "callable": True,
-        "__backend_hook__": "pwn",
+        "__inject_backend__": "pwn",
     }
 
-    with pytest.raises(ValueError, match=r"unexpected_keys|claves inesperadas"):
+    with pytest.raises(ValueError, match=r"claves desconocidas|unexpected_keys|claves inesperadas"):
         usar_symbol_policy.validate_usar_symbol_metadata("es_finito", raw)


### PR DESCRIPTION
### Motivation

- Ampliar la cobertura sobre el comportamiento de `usar` en el runtime y validar que la metadata legacy se normaliza y que claves desconocidas se rechazan en modo fail-closed. 
- Verificar el comportamiento incremental estilo REPL para que `usar` preserve estado entre sentencias y las llamadas a `longitud` funcionen tanto sobre variables como sobre literales.

### Description

- Se modificó `tests/integration/test_usar_runtime_contract.py` para añadir un test incremental REPL `test_repl_incremental_usar_datos_preserva_estado_y_longitud` que ejecuta secuencialmente `var xs=[1,2,3]`, `usar "datos"` y comprueba las dos salidas de `imprimir(longitud(...))` usando `InteractiveCommand` y `InterpretadorCobra`.
- Se añadieron tests negativos de sintaxis que ejercitan la API pública REPL y validan que `usar archivo` (sin comillas) falla con `ParserError` y que `usar "datos2` (cadena sin cerrar) falla con `UnclosedStringError`.
- Se ajustó la prueba de hard-fail contra metadata maliciosa para usar la clave `__inject_backend__` y se amplió el patrón esperado en el `pytest.raises` para cubrir el mensaje real (`claves desconocidas|unexpected_keys|claves inesperadas`).
- Se evitó depender de `generar_ast` en los nuevos tests y se usó la vía de alto nivel `InteractiveCommand.ejecutar_codigo` para reflejar el flujo REPL real.

### Testing

- Se ejecutó `pytest -q tests/integration/test_usar_runtime_contract.py` y todos los tests del archivo pasaron exitosamente (`21 passed, 1 warning`).
- Las modificaciones fueron validadas mediante ejecuciones iterativas de los tests hasta que los casos añadidos se estabilizaron y los errores esperados coincidieron con las excepciones reales del parser/lexer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a098bff8bec8327ba69d4efc36699d7)