### PR TITLE
datos: endurecer validaciones de elemento()

### DIFF
--- a/src/pcobra/standard_library/datos.py
+++ b/src/pcobra/standard_library/datos.py
@@ -606,11 +606,16 @@ def elemento(coleccion: Any, indice: int) -> Any:
 
     if not isinstance(indice, int) or isinstance(indice, bool):
         raise TypeError("índice debe ser entero")
+
+    getitem = getattr(coleccion, "__getitem__", None)
+    if not callable(getitem):
+        raise TypeError("objeto no indexable")
+
     try:
         return coleccion[indice]
     except TypeError as exc:
         raise TypeError("objeto no indexable") from exc
-    except IndexError as exc:
+    except (IndexError, KeyError) as exc:
         raise IndexError("índice fuera de rango") from exc
 
 


### PR DESCRIPTION
### Motivation
- Mejorar la robustez y la consistencia de los mensajes de error expuestos a usuarios al acceder por índice en el runtime/stdlib del módulo `datos`.
- Evitar trazas técnicas en REPL y prevenir la filtración de estructuras internas o excepciones inesperadas al usuario.

### Description
- Se actualizó `elemento(coleccion, indice)` en `src/pcobra/standard_library/datos.py` para validar explícitamente que `indice` sea un entero y excluir `bool` como entero válido.
- Se añadió una comprobación previa de que `coleccion` tenga `__getitem__` callable y, en caso contrario, se lanza `TypeError` con el mensaje `objeto no indexable`.
- Se mapean y traducen errores esperados a mensajes de usuario cortos y controlados: `TypeError` → `objeto no indexable` y `IndexError`/`KeyError` → `índice fuera de rango`.
- Se evitó el uso de `try/except` genéricos silenciosos, capturando sólo las excepciones previstas para no exponer detalles del backend.

### Testing
- Se ejecutó el script de comprobación en Python `python - <<'PY' ... PY` que prueba un caso válido y varios casos erróneos para `elemento`, y los resultados mostraron la devolución correcta y los mensajes de error esperados.
- La ejecución del script devolvió la salida esperada para cada caso y no se detectaron fallos automáticos en las comprobaciones realizadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099876e5e08327b2b65d5901ab40c8)