### PR TITLE
test: validar `elemento` en contrato de `usar "datos"`

### DIFF
--- a/tests/integration/test_usar_runtime_contract.py
+++ b/tests/integration/test_usar_runtime_contract.py
@@ -143,8 +143,9 @@ def test_usar_datos_expone_longitud_y_metadata_canonica(monkeypatch):
         lambda module_name, symbol_name, callable_obj: {"origin_kind": "usar", "module": module_name, "symbol": symbol_name, "sanitized": True, "public_api": True, "backend_exposed": False, "callable": True},
     )
     mod = ModuleType("datos")
-    mod.__all__ = ["longitud"]
+    mod.__all__ = ["longitud", "elemento"]
     mod.longitud = lambda valores: len(valores)
+    mod.elemento = lambda coleccion, indice: coleccion[indice]
     mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/datos.py"
 
     monkeypatch.setattr(cobra_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: mod)
@@ -156,6 +157,15 @@ def test_usar_datos_expone_longitud_y_metadata_canonica(monkeypatch):
 
     assert "longitud" in interp.contextos[-1].values
     assert interp.contextos[-1].get("longitud")([1, 2, 3]) == 3
+    assert interp.contextos[-1].get("elemento")([10, 20, 30], 1) == 20
+
+    metadata = interp._usar_symbol_metadata.get("elemento")
+    assert metadata is not None
+    assert metadata["symbol"] == "elemento"
+    assert metadata["module"] == "datos"
+    assert metadata["origin_kind"] == "usar"
+    assert metadata["public_api"] is True
+    assert metadata["backend_exposed"] is False
 
 
 


### PR DESCRIPTION
### Motivation
- Garantizar que `elemento(coleccion, indice)` forma parte de la superficie pública que expone `usar "datos"` y que su metadata canónica (nombre, módulo, procedencia y flags de visibilidad) se registra correctamente sin revelar objetos backend.

### Description
- Modifica `tests/integration/test_usar_runtime_contract.py` para añadir `elemento` al stub de `datos`, comprobar que es invocable tras `usar "datos"` y añadir aserciones sobre `interp._usar_symbol_metadata` verificando `symbol`, `module`, `origin_kind`, `public_api` y `backend_exposed`.

### Testing
- Ejecuté `pytest -q tests/integration/test_usar_runtime_contract.py -k "datos_expone_longitud_y_metadata_canonica or usar_modulos_validos_no_reporta_error_metadata"` y los tests afectados pasaron (`2 passed, 19 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099c48d48083278557520f6ebba22e)