### PR TITLE
Ajusta validaciones y mensajes de error en `elemento`

### DIFF
--- a/src/pcobra/standard_library/datos.py
+++ b/src/pcobra/standard_library/datos.py
@@ -605,18 +605,15 @@ def elemento(coleccion: Any, indice: int) -> Any:
     """Devuelve ``coleccion[indice]`` con validaciones Cobra-facing."""
 
     if not isinstance(indice, int) or isinstance(indice, bool):
-        raise TypeError("índice debe ser entero")
+        raise TypeError("Error: índice debe ser entero")
 
-    getitem = getattr(coleccion, "__getitem__", None)
-    if not callable(getitem):
-        raise TypeError("objeto no indexable")
+    if not isinstance(coleccion, list):
+        raise TypeError("Error: objeto no indexable")
 
     try:
         return coleccion[indice]
-    except TypeError as exc:
-        raise TypeError("objeto no indexable") from exc
-    except (IndexError, KeyError) as exc:
-        raise IndexError("índice fuera de rango") from exc
+    except IndexError as exc:
+        raise IndexError("Error: índice fuera de rango") from exc
 
 
 def seleccionar_columnas(tabla: Iterable[Registro], columnas: Sequence[str]) -> Tabla:


### PR DESCRIPTION
### Motivation
- Implementar validaciones Cobra-facing en `elemento` para comprobar primero que `indice` sea un entero (no `bool`) y que `coleccion` sea un tipo indexable permitido por la API pública, y mapear errores a mensajes cortos de usuario.

### Description
- Valida que `indice` sea instancia de `int` (excluyendo `bool`) y lanza `TypeError("Error: índice debe ser entero")` si no lo es.
- Restringe `coleccion` a `list` y lanza `TypeError("Error: objeto no indexable")` cuando no cumple esa condición.
- Realiza el acceso por índice y captura únicamente `IndexError` para volver a lanzar `IndexError("Error: índice fuera de rango")`, evitando `try/except` genérico.
- Actualiza los mensajes de error para que sean cortos y compatibles con el flujo de errores esperado en REPL.

### Testing
- Se ejecutó `pytest` sobre un conjunto de pruebas orientadas a `elemento` y la suite objetivo con `pytest -q tests/unit/test_usar.py::test_repl_usar_datos_elemento_basico_y_errores tests/integration/test_repl_list_literal_eval_contract.py::test_repl_interpreter_datos_elemento_errores_limpios tests/integration/test_repl_list_literal_eval_contract.py::test_repl_v2_datos_elemento_errores_cortos_sin_traceback tests/unit/test_datos_public_contract.py::test_import_datos_corelib_elemento_resuelve_indice` y la ejecución falló por errores de importación/carga de entorno (coleccionadores no encontrados y errores de importación circular), no por la lógica de `elemento`.
- No se ejecutaron otras pruebas automatizadas adicionales en esta sesión debido a los problemas de entorno detectados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099d68fc148327afb31f2ad0e5426d)