### PR TITLE
test(repl): cubrir export `elemento` en módulo `datos`

### DIFF
--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -221,8 +221,9 @@ def _modulo_tiempo_stub() -> ModuleType:
 
 def _modulo_datos_stub() -> ModuleType:
     mod = ModuleType("datos")
-    mod.__all__ = ["longitud"]
+    mod.__all__ = ["longitud", "elemento"]
     mod.longitud = lambda valores: len(valores)
+    mod.elemento = lambda valores, indice: valores[indice]
     mod._backend = object()
     mod.module_object = object()
     mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/datos.py"
@@ -474,12 +475,21 @@ def test_repl_usar_datos_longitud_imprimir_lista_y_variable(factory, executor, g
     interp = get_interp(cmd)
 
     executor(cmd, 'usar "datos"')
+
+    assert callable(interp.obtener_variable("elemento"))
+    assert interp.obtener_variable("elemento")([10, 20, 30], 0) == 10
+
+    interp.contextos[-1].define("ys", [10, 20, 30])
+    assert interp.obtener_variable("elemento")(interp.obtener_variable("ys"), 1) == 20
+    assert interp.obtener_variable("elemento")([1, 2, 3], 2) == 3
+
     interp.contextos[-1].define("xs", [1, 2, 3])
     executor(cmd, "imprimir(longitud(xs))")
     executor(cmd, "imprimir(longitud([1,2,3]))")
 
     salida = capsys.readouterr().out
     assert salida.count("3") >= 2
+    assert interp.obtener_variable("longitud")([1, 2, 3]) == 3
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation
- Garantizar que la superficie pública del módulo `datos` expone el nuevo símbolo `elemento` y validar su comportamiento de indexado desde el REPL, manteniendo la cobertura de `longitud` como no regresión.

### Description
- Extiende el stub `_modulo_datos_stub` para incluir `elemento(valores, indice)` y añadirlo a `__all__`.
- Amplía `test_repl_usar_datos_longitud_imprimir_lista_y_variable` para comprobar que `usar "datos"` expone `elemento`, validar `elemento([10, 20, 30], 0) == 10`, `elemento(ys, 1) == 20` usando la variable del intérprete y `elemento([1, 2, 3], 2) == 3`.
- Conserva el estilo y las utilidades de aserción ya existentes y añade una aserción de no regresión `longitud([1, 2, 3]) == 3` sin crear un harness paralelo.

### Testing
- Ejecuté `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py -k datos_longitud_imprimir_lista_y_variable` y la selección objetivo se completó correctamente con `2 passed, 81 deselected`.
- La prueba validó tanto las nuevas aserciones sobre `elemento` como la no regresión de `longitud` con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09a49d11188327aff9e9605521f516)