### PR TITLE
test: cubrir fronteras `usar` y comportamiento de parser en REPL v2

### DIFF
--- a/tests/integration/test_repl_list_literal_eval_contract.py
+++ b/tests/integration/test_repl_list_literal_eval_contract.py
@@ -207,14 +207,22 @@ def test_repl_v2_datos_elemento_errores_cortos_sin_traceback(capsys):
 
 
 def test_repl_v2_usar_fronteras_rechaza_numpy_y_sintaxis_invalida(capsys):
+    """Fase actual: validar fronteras de `usar` sin tocar gramática/tokenización."""
     cmd = ReplCommandV2()
 
-    with pytest.raises(PermissionError):
+    with pytest.raises(PermissionError, match=r"(módulo fuera del catálogo público|modulo_fuera_catalogo_publico)"):
         cmd._ejecutar_en_modo_normal('usar "numpy"')
     salida_numpy = capsys.readouterr().out
     assert "Traceback" not in salida_numpy
 
-    with pytest.raises(ParserError):
+    with pytest.raises(ParserError, match=r"comillas"):
         cmd._ejecutar_en_modo_normal("usar archivo")
     salida_archivo = capsys.readouterr().out
     assert "Traceback" not in salida_archivo
+
+    cmd._ejecutar_en_modo_normal('usar "datos"')
+    cmd._ejecutar_en_modo_normal("var ys = [10, 20, 30]")
+    with pytest.raises(ParserError):
+        cmd._ejecutar_en_modo_normal("imprimir(ys[0])")
+    salida_indice = capsys.readouterr().out
+    assert "Traceback" not in salida_indice


### PR DESCRIPTION
### Motivation
- Reforzar la cobertura de contrato para `usar` en REPL v2 validando mensajes concretos de rechazo y dejar constancia de que esta fase no modifica la gramática/tokenización.

### Description
- Actualiza `tests/integration/test_repl_list_literal_eval_contract.py::test_repl_v2_usar_fronteras_rechaza_numpy_y_sintaxis_invalida` para exigir que `usar "numpy"` falle con `PermissionError` indicando "módulo fuera del catálogo público", que `usar archivo` (sin comillas) falle con `ParserError` relacionado con comillas faltantes, y añade una regresión que confirma que `imprimir(ys[0])` sigue fallando por parser sin emitir traceback.

### Testing
- Ejecutado `pytest -q tests/integration/test_repl_list_literal_eval_contract.py -k usar_fronteras_rechaza_numpy_y_sintaxis_invalida` y la prueba seleccionada pasó correctamente (`1 passed, 13 deselected`, con 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09a66686cc8327b68ff97e3b4ba83d)