### PR TITLE
docs(datos): documentar `elemento(coleccion, indice)` y ejemplos mínimos

### DIFF
--- a/docs/standard_library/datos.md
+++ b/docs/standard_library/datos.md
@@ -48,6 +48,24 @@ El módulo `standard_library.datos` encapsula operaciones comunes sobre datos ta
 - **`a_listas(datos)`**: transforma la tabla a un diccionario columna → lista.
 - **`de_listas(columnas)`**: genera una lista de diccionarios a partir de un mapeo de columnas.
 
+- **`elemento(coleccion, indice)`**: obtiene el valor por índice con validaciones Cobra-facing. Esta API **reemplaza temporalmente** la indexación con corchetes (`coleccion[indice]`) mientras no exista soporte sintáctico formal para esa forma en Cobra.
+
+
+### Ejemplos mínimos de `elemento`
+
+```cobra
+usar "datos"
+
+elemento([10, 20, 30], 0)
+# -> 10
+
+elemento([10, 20, 30], "0")
+# -> Error: índice debe ser entero
+
+elemento([10, 20, 30], 10)
+# -> Error: índice fuera de rango
+```
+
 ### Dependencias para trabajar con Excel
 
 Las operaciones con libros de Excel delegan en motores opcionales de `pandas`. Para archivos modernos (`.xlsx`) se recomienda instalar `openpyxl`::
@@ -147,6 +165,7 @@ En el objetivo JavaScript se ofrece una implementación parcial que mantiene las
 | `de_listas` |
 | `describir` |
 | `desplegar_tabla` |
+| `elemento` |
 | `escribir_csv` |
 | `escribir_excel` |
 | `escribir_feather` |


### PR DESCRIPTION
### Motivation
- Documentar la nueva API `elemento(coleccion, indice)` en el módulo `standard_library.datos` para exponer su uso como reemplazo temporal de la indexación con corchetes hasta que exista soporte sintáctico formal.

### Description
- Se actualizó `docs/standard_library/datos.md` para añadir la entrada `elemento(coleccion, indice)` en la lista de funciones y en la tabla `API pública sincronizada`, se añadió la aclaración explícita de que esta API reemplaza temporalmente la indexación con corchetes y se incorporó una sección de ejemplos mínimos que muestran `elemento([10, 20, 30], 0) -> 10`, el error por índice no entero y el error por índice fuera de rango.

### Testing
- No se ejecutaron tests automatizados; el cambio es exclusivamente de documentación y fue verificado localmente mediante inspección del archivo editado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09a755fe6c83278f4f5e1cfb4daf5b)