### PR TITLE
Implementa validación Cobra-facing para `datos.elemento` y añade pruebas de contrato

### DIFF
--- a/src/pcobra/standard_library/datos.py
+++ b/src/pcobra/standard_library/datos.py
@@ -605,15 +605,15 @@ def elemento(coleccion: Any, indice: int) -> Any:
     """Devuelve ``coleccion[indice]`` con validaciones Cobra-facing."""
 
     if not isinstance(indice, int) or isinstance(indice, bool):
-        raise TypeError("Error: índice debe ser entero")
+        raise TypeError("índice debe ser entero")
 
     if not isinstance(coleccion, list):
-        raise TypeError("Error: objeto no indexable")
+        raise TypeError("objeto no indexable")
 
     try:
         return coleccion[indice]
     except IndexError as exc:
-        raise IndexError("Error: índice fuera de rango") from exc
+        raise IndexError("índice fuera de rango") from exc
 
 
 def seleccionar_columnas(tabla: Iterable[Registro], columnas: Sequence[str]) -> Tabla:

--- a/tests/unit/test_datos_public_contract.py
+++ b/tests/unit/test_datos_public_contract.py
@@ -24,3 +24,18 @@ def test_rechazo_continuo_backend_real_en_saneamiento():
 
 def test_import_datos_corelib_elemento_resuelve_indice():
     assert core_datos.elemento([10, 20, 30], 1) == 20
+
+
+def test_import_datos_corelib_elemento_valida_indice_entero():
+    with pytest.raises(TypeError, match="^índice debe ser entero$"):
+        core_datos.elemento([10, 20, 30], 1.5)
+
+
+def test_import_datos_corelib_elemento_rechaza_no_indexable():
+    with pytest.raises(TypeError, match="^objeto no indexable$"):
+        core_datos.elemento({"a": 1}, 0)
+
+
+def test_import_datos_corelib_elemento_fuera_de_rango():
+    with pytest.raises(IndexError, match="^índice fuera de rango$"):
+        core_datos.elemento([10], 2)


### PR DESCRIPTION
### Motivation
- Alinear la función pública `elemento(coleccion, indice)` de la stdlib con mensajes de error cortos y exactos esperados por la superficie Cobra-facing. 
- Garantizar que `usar "datos"` importe `elemento` desde la misma ruta canónica donde está `longitud` sin exponer tipos backend internos. 

### Description
- Se modificó `src/pcobra/standard_library/datos.py` implementando `elemento(coleccion, indice)` con validaciones que lanzan exactamente los mensajes `índice debe ser entero`, `objeto no indexable` e `índice fuera de rango` y devuelven el elemento cuando es válido. 
- Se añadieron pruebas en `tests/unit/test_datos_public_contract.py` que cubren índice no entero, objeto no indexable y índice fuera de rango, además del caso exitoso existente. 
- Verifiqué que `elemento` ya se reexpone en `src/pcobra/corelibs/datos.py` y que `PUBLIC_API_DATOS` / `__all__` mantienen la entrada `elemento` en la misma ruta canónica que `longitud`, sin alterar la policy de `usar`. 
- No se cambiaron el Lexer, Parser, reglas gramaticales, ni se relajó la política de imports o el catálogo público. 

### Testing
- Ejecuté una invocación directa con `python` llamando a `pcobra.standard_library.datos.elemento(...)` que devolvió el resultado esperado y produjo las tres excepciones con mensajes exactos según lo especificado (éxito). 
- Ejecuté `pytest -q tests/unit/test_datos_public_contract.py` y la ejecución falló en la fase de colección por un ciclo de importación preexistente entre módulos (`ImportError`), por lo que las nuevas pruebas no llegaron a ejecutarse en ese entorno (error de colección, no causado por este cambio). 
- Intenté `pytest -q tests/unit/test_standard_library_datos.py -k elemento` y no se ejecutaron tests relevantes en ese contexto (deselección), sin cambios funcionales en la implementación probada por la invocación directa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09a85962888327bc365a1c9b50eac7)