### PR TITLE
datos: ajustar validación de `elemento` para indexación segura

### DIFF
--- a/src/pcobra/standard_library/datos.py
+++ b/src/pcobra/standard_library/datos.py
@@ -607,13 +607,15 @@ def elemento(coleccion: Any, indice: int) -> Any:
     if not isinstance(indice, int) or isinstance(indice, bool):
         raise TypeError("índice debe ser entero")
 
-    if not isinstance(coleccion, list):
+    if not isinstance(coleccion, Sequence) or isinstance(coleccion, (str, bytes, bytearray)):
         raise TypeError("objeto no indexable")
 
     try:
         return coleccion[indice]
     except IndexError as exc:
         raise IndexError("índice fuera de rango") from exc
+    except TypeError as exc:
+        raise TypeError("objeto no indexable") from exc
 
 
 def seleccionar_columnas(tabla: Iterable[Registro], columnas: Sequence[str]) -> Tabla:


### PR DESCRIPTION
### Motivation
- Asegurar que la función Cobra-facing `elemento` valide el `indice` y la `coleccion` según la política runtime y produzca errores cortos y explícitos en lugar de `None` o tracebacks largos.

### Description
- En `src/pcobra/standard_library/datos.py` se actualiza `elemento(coleccion, indice)` para validar primero que `indice` sea entero (no `bool`), aceptar cualquier `Sequence` indexable pero rechazar `str`, `bytes` o `bytearray`, realizar el acceso protegido y remapear únicamente `IndexError`/`TypeError` a los mensajes Cobra limpios `índice fuera de rango` y `objeto no indexable` sin usos de `try/except` genérico.

### Testing
- Ejecuté `pytest -q tests/unit/test_datos_public_contract.py tests/unit/test_usar.py -k elemento` y la ejecución falló en la fase de collection por errores de import/circularidad del entorno (no atribuibles al cambio); esto se registró como error de colección.
- Ejecuté una validación directa por `python` importando `pcobra.standard_library.datos` y probando casos válidos y errores esperados, y los resultados fueron los esperados (acceso correcto y mensajes remapeados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ac38aabc8327a7593a86c0023afe)