### PR TITLE
Clasificar errores de `elemento` como errores de usuario esperados

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -309,6 +309,9 @@ def _is_expected_user_contract_error(exc: Exception) -> bool:
         "modulo_no_permitido",
         "modulo_no_canonico",
         "backend_import_directo",
+        "error: índice fuera de rango",
+        "error: índice debe ser entero",
+        "error: objeto no indexable",
     )
     return any(m in mensaje for m in marcadores)
 

--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -122,17 +122,26 @@ def format_user_error(exc: Exception) -> str:
 def _es_error_usuario_repl(exc: Exception) -> bool:
     """Clasifica errores esperados de contrato `usar` como errores de usuario."""
     msg = str(exc)
+    msg_lower = msg.lower()
     if isinstance(exc, (PermissionError, ValueError, ImportError)):
         if "usar_error[" in msg:
             return True
-        if "catálogo público" in msg or "catalogo publico" in msg.lower():
+        if "catálogo público" in msg or "catalogo publico" in msg_lower:
             return True
-        if "conflicto de símbolos" in msg or "conflicto de simbolos" in msg.lower():
+        if "conflicto de símbolos" in msg or "conflicto de simbolos" in msg_lower:
             return True
-        if "referencia circular" in msg.lower() or "import circular" in msg.lower():
+        if "referencia circular" in msg_lower or "import circular" in msg_lower:
             return True
-        if "export_invalido" in msg or "sanitize" in msg.lower():
+        if "export_invalido" in msg or "sanitize" in msg_lower:
             return True
+
+    if isinstance(exc, (IndexError, TypeError)):
+        return msg_lower in {
+            "error: índice fuera de rango",
+            "error: índice debe ser entero",
+            "error: objeto no indexable",
+        }
+
     return False
 
 


### PR DESCRIPTION
### Motivation
- Asegurar que las excepciones generadas por la función pública `elemento` se muestren al usuario como errores cortos y en español (sin traceback) cuando correspondan al contrato de API pública. 
- Mantener intacto el comportamiento de reporting para errores internos no relacionados, limitando la excepción a un conjunto explícito de mensajes de `elemento`.

### Description
- Añadí las tres cadenas exactas emitidas por `elemento` a la clasificación global de errores esperados en `src/pcobra/cobra/cli/cli.py` para que la CLI reconozca `Error: índice fuera de rango`, `Error: índice debe ser entero` y `Error: objeto no indexable` como errores de contrato de usuario. 
- Ajusté el canal REPL en `src/pcobra/cobra/cli/commands/interactive_cmd.py` para que trate específicamente `IndexError`/`TypeError` con esos mensajes exactos (comparando la cadena en minúsculas) como errores de usuario y así evitar mostrar traceback en modo normal. 
- Los cambios son puntuales sobre la clasificación/lógica de presentación y no modifican la forma en que `elemento` genera las excepciones ni otros flujos de logging/reporting del runtime.

### Testing
- Ejecuté intentos focalizados de `pytest` contra los tests relevantes (`tests/integration/test_repl_list_literal_eval_contract.py::test_repl_v2_datos_elemento_errores_cortos_sin_traceback`, `tests/unit/test_usar.py::test_repl_runtime_usar_datos_elemento_y_regresiones_con_errores_limpios`, `tests/unit/test_datos_public_contract.py::test_import_datos_corelib_elemento_fuera_de_rango`) pero la colección falló por import errors en el entorno (import circular y relative import beyond top-level), por lo que las pruebas automatizadas no pudieron completarse. 
- Reintenté ejecutar un subconjunto de tests unitarios/integración y obtuve errores de colección idénticos relacionados con el estado del checkout (circular imports), indicando que las fallas no son originadas por la lógica de clasificación aplicada. 
- La verificación funcional fue completada por inspección del código modificado y por confirmar que las cadenas chequeadas coinciden exactamente con: `Error: índice fuera de rango`, `Error: índice debe ser entero` y `Error: objeto no indexable`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ad304ebc832786f6bff33718bb87)