### PR TITLE
test: agregar casos REPL para `elemento` en módulo `datos`

### DIFF
--- a/tests/integration/test_repl_list_literal_eval_contract.py
+++ b/tests/integration/test_repl_list_literal_eval_contract.py
@@ -11,6 +11,12 @@ from pcobra.cobra.core.parser import ParserError
 from pcobra.cobra.core.runtime import InterpretadorCobra
 
 
+def _assert_valores_numericos_salida(out: StringIO, esperados: list[str]) -> None:
+    lineas = [linea.strip() for linea in out.getvalue().splitlines() if linea.strip()]
+    valores = [linea for linea in lineas if linea.isdigit()]
+    assert valores[-len(esperados):] == esperados
+
+
 def _estado(factory, executor, getter, codigo: str):
     cmd = factory()
     executor(cmd, codigo)
@@ -77,9 +83,7 @@ def test_repl_interpreter_longitud_lista_literal_y_variable_desde_datos():
         repl.ejecutar_codigo('imprimir(longitud(xs))')
         repl.ejecutar_codigo('imprimir(longitud([1, 2, 3]))')
 
-    lineas = [linea.strip() for linea in out.getvalue().splitlines() if linea.strip()]
-    valores = [linea for linea in lineas if linea.isdigit()]
-    assert valores[-2:] == ["3", "3"]
+    _assert_valores_numericos_salida(out, ["3", "3"])
 
 
 def test_repl_interpreter_datos_longitud_lista_literal_directa():
@@ -163,11 +167,8 @@ def test_repl_interpreter_datos_elemento_regresion_variante_solicitada():
         repl.ejecutar_codigo('var ys = [10, 20, 30]')
         repl.ejecutar_codigo('imprimir(elemento(ys, 1))')
         repl.ejecutar_codigo('imprimir(elemento([1, 2, 3], 2))')
-        repl.ejecutar_codigo('imprimir(longitud([1, 2, 3]))')
 
-    lineas = [linea.strip() for linea in out.getvalue().splitlines() if linea.strip()]
-    valores = [linea for linea in lineas if linea.isdigit()]
-    assert valores[-4:] == ["10", "20", "3", "3"]
+    _assert_valores_numericos_salida(out, ["10", "20", "3"])
 
 
 def test_repl_interpreter_datos_elemento_errores_limpios():


### PR DESCRIPTION
### Motivation
- Añadir cobertura en la suite REPL/runtime para validar que `usar "datos"` expone `elemento` y que las llamadas a `elemento(...)` devuelven los valores esperados en distintos escenarios. 

### Description
- Se añadió un helper compartido `_assert_valores_numericos_salida(out, esperados)` en `tests/integration/test_repl_list_literal_eval_contract.py` para reutilizar la validación de valores numéricos en stdout. 
- Se reemplazaron las aserciones ad-hoc en la prueba de `longitud` para usar el helper. 
- Se ajustó la prueba de regresión de `elemento` para validar exactamente los casos solicitados: `elemento([10, 20, 30], 0) -> 10`, `var ys = [10, 20, 30]; elemento(ys, 1) -> 20` y `elemento([1, 2, 3], 2) -> 3`, usando el helper para verificar la salida numérica. 
- Los cambios quedan únicamente en el paquete de tests de stdlib/runtime (`tests/integration/test_repl_list_literal_eval_contract.py`) y no tocan pruebas del parser ni código de producción.

### Testing
- Ejecutado el comando `pytest -q tests/integration/test_repl_list_literal_eval_contract.py -k 'longitud_lista_literal_y_variable_desde_datos or usar_datos_expone_elemento or datos_elemento_regresion_variante_solicitada'` y obtuvo `3 passed, 11 deselected`.
- Las pruebas específicas afectadas pasaron correctamente en la ejecución dirigida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b23ec1648327aabaabc9b2c33701)