### PR TITLE
test: reforzar validación de errores de `elemento` sin traceback

### DIFF
--- a/tests/integration/test_repl_list_literal_eval_contract.py
+++ b/tests/integration/test_repl_list_literal_eval_contract.py
@@ -176,12 +176,23 @@ def test_repl_interpreter_datos_elemento_errores_limpios():
     repl.ejecutar_codigo('usar "datos"')
     repl.ejecutar_codigo('var ys = [10, 20, 30]')
 
-    with pytest.raises(IndexError, match="índice fuera de rango"):
-        repl.ejecutar_codigo('imprimir(elemento(ys, 99))')
-    with pytest.raises(TypeError, match="índice debe ser entero"):
-        repl.ejecutar_codigo('imprimir(elemento(ys, "0"))')
-    with pytest.raises(TypeError, match="objeto no indexable"):
-        repl.ejecutar_codigo('imprimir(elemento(10, 0))')
+    with pytest.raises(IndexError, match=r"^Error: índice fuera de rango$") as err_indice:
+        repl.ejecutar_codigo("elemento(ys, 99)")
+    assert "Traceback" not in str(err_indice.value)
+    assert "File " not in str(err_indice.value)
+    assert "line " not in str(err_indice.value)
+
+    with pytest.raises(TypeError, match=r"^Error: índice debe ser entero$") as err_tipo_indice:
+        repl.ejecutar_codigo('elemento(ys, "0")')
+    assert "Traceback" not in str(err_tipo_indice.value)
+    assert "File " not in str(err_tipo_indice.value)
+    assert "line " not in str(err_tipo_indice.value)
+
+    with pytest.raises(TypeError, match=r"^Error: objeto no indexable$") as err_objeto:
+        repl.ejecutar_codigo("elemento(10, 0)")
+    assert "Traceback" not in str(err_objeto.value)
+    assert "File " not in str(err_objeto.value)
+    assert "line " not in str(err_objeto.value)
 
 
 def test_repl_v2_datos_elemento_errores_cortos_sin_traceback(capsys):


### PR DESCRIPTION
### Motivation
- Asegurar que las llamadas a la función pública `elemento` desde el REPL produzcan mensajes cortos y amigables en los errores y no expongan trazas técnicas.
- Evitar regresiones donde vuelvan a aparecer marcas típicas de traceback o detalles de archivo/linea en los mensajes de excepción.

### Description
- Actualiza `tests/integration/test_repl_list_literal_eval_contract.py` para reforzar `test_repl_interpreter_datos_elemento_errores_limpios` y cubrir explícitamente los tres casos solicitados: `elemento(ys, 99)`, `elemento(ys, "0")` y `elemento(10, 0)`.
- Exige ahora el prefijo exacto en el mensaje con anclas regex (`^Error: ...$`) para cada excepción levantada.
- Añade aserciones explícitas que verifiquen la ausencia de marcas de traceback en el mensaje de la excepción comprobando que no contienen `Traceback`, `File ` ni `line `.

### Testing
- Ejecutado `pytest -q tests/integration/test_repl_list_literal_eval_contract.py -k "errores_limpios or errores_cortos"` y la selección de pruebas indicó `2 passed, 12 deselected` con éxito.
- Las nuevas aserciones verifican tanto el contenido del mensaje (`Error: ...`) como la ausencia de fragmentos típicos de traceback y pasaron correctamente en la ejecución automatizada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b60e7c708327be48a8e6255e1a75)