### PR TITLE
InterpretadorCobra: no retornar temprano en `ejecutar_ast`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1417,6 +1417,7 @@ class InterpretadorCobra:
             self._trace_debug(self._resumir_ast(ast))
         self._asegurar_ast_tipado(ast, "post_optimizacion")
         self.ultimo_ir = None
+        ultimo_resultado = None
         self._trace_debug("[RUN] antes de iterar AST")
         for index, nodo in enumerate(ast):
             self._trace_debug(
@@ -1429,10 +1430,10 @@ class InterpretadorCobra:
                 self._trace_debug("[RUN] antes de ejecutar_nodo")
                 resultado = self.ejecutar_nodo(nodo)
                 if resultado is not None:
-                    return resultado
+                    ultimo_resultado = resultado
             finally:
                 self._set_mode(modo_prev)
-        return None
+        return ultimo_resultado
 
     # -- Generación de IR ----------------------------------------------------
     def generar_internal_ir(self, ast) -> InternalIRModule:


### PR DESCRIPTION
### Motivation
- Evitar que la ejecución del AST se interrumpa al primer `resultado` no nulo de una asignación para asegurar que todo el script se ejecute secuencialmente y sólo se exponga el último resultado observable.

### Description
- Se modificó `src/pcobra/core/interpreter.py::InterpretadorCobra.ejecutar_ast` para introducir `ultimo_resultado = None`, acumular cualquier `resultado` no nulo en `ultimo_resultado` dentro del bucle `for index, nodo in enumerate(ast):` y devolver `ultimo_resultado` al final del bucle en lugar de hacer `return` inmediato.

### Testing
- Se compiló el archivo modificado con `python -m compileall src/pcobra/core/interpreter.py` y la compilación finalizó correctamente sin errores de sintaxis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1177335ecc8327aebceec566eaa008)