### PR TITLE
Evitar que declaraciones `var/variable` corten ejecución en `run` (alinear con REPL)

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1518,6 +1518,8 @@ class InterpretadorCobra:
             try:
                 for instr in nodo.cuerpo:
                     resultado = self.ejecutar_nodo(instr)
+                    if isinstance(instr, NodoAsignacion) and getattr(instr, "declaracion", False):
+                        continue
                     if resultado is not None:
                         return resultado
             finally:
@@ -1895,6 +1897,8 @@ class InterpretadorCobra:
         if condicion is True:
             for instruccion in bloque_si:
                 resultado = self.ejecutar_nodo(instruccion)
+                if isinstance(instruccion, NodoAsignacion) and getattr(instruccion, "declaracion", False):
+                    continue
                 if resultado is not None:
                     return resultado
             return None
@@ -1904,6 +1908,8 @@ class InterpretadorCobra:
             return None
         for instruccion in bloque_sino:
             resultado = self.ejecutar_nodo(instruccion)
+            if isinstance(instruccion, NodoAsignacion) and getattr(instruccion, "declaracion", False):
+                continue
             if resultado is not None:
                 return resultado
 
@@ -1932,6 +1938,8 @@ class InterpretadorCobra:
         try:
             for instruccion in nodo.bloque_try:
                 resultado = self.ejecutar_nodo(instruccion)
+                if isinstance(instruccion, NodoAsignacion) and getattr(instruccion, "declaracion", False):
+                    continue
                 if resultado is not None:
                     return resultado
         except ExcepcionCobra as exc:
@@ -1943,11 +1951,15 @@ class InterpretadorCobra:
                     contexto_actual.define(nodo.nombre_excepcion, exc.valor)
             for instruccion in nodo.bloque_catch:
                 resultado = self.ejecutar_nodo(instruccion)
+                if isinstance(instruccion, NodoAsignacion) and getattr(instruccion, "declaracion", False):
+                    continue
                 if resultado is not None:
                     return resultado
         finally:
             for instruccion in nodo.bloque_finally:
                 resultado = self.ejecutar_nodo(instruccion)
+                if isinstance(instruccion, NodoAsignacion) and getattr(instruccion, "declaracion", False):
+                    continue
                 if resultado is not None:
                     return resultado
 

--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -673,3 +673,46 @@ def test_sandbox_normaliza_safe_mode_y_validadores_igual_en_run_y_repl(monkeypat
     assert capturas[0][1] is True and capturas[1][1] is True
     assert [getattr(v, "origen", None) for v in capturas[0][2]] == ["uno.py", "dos.py"]
     assert [getattr(v, "origen", None) for v in capturas[1][2]] == ["uno.py", "dos.py"]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("declarador", ["var", "variable"])
+def test_run_no_corta_bloque_secuencial_tras_declaracion(tmp_path, declarador: str, monkeypatch):
+    monkeypatch.setattr("pcobra.cobra.cli.services.run_service.limitar_cpu_segundos", lambda *_: None)
+    codigo = (
+        'imprimir("antes")\n'
+        f"{declarador} x {":=" if declarador == "variable" else "="} 3\n"
+        'imprimir("despues")\n'
+    )
+    archivo = tmp_path / "secuencial.co"
+    archivo.write_text(codigo, encoding="utf-8")
+
+    out_run, err_run = StringIO(), StringIO()
+    with redirect_stdout(out_run), redirect_stderr(err_run):
+        rc_run = RunCommandV2().run(_run_args(str(archivo)))
+
+    assert rc_run == 0
+    assert err_run.getvalue() == ""
+    assert [ln.strip() for ln in out_run.getvalue().splitlines() if ln.strip()] == ["antes", "despues"]
+
+
+@pytest.mark.integration
+def test_run_no_corta_sentencias_posteriores_en_bloque_si(tmp_path, monkeypatch):
+    monkeypatch.setattr("pcobra.cobra.cli.services.run_service.limitar_cpu_segundos", lambda *_: None)
+    codigo = (
+        "si verdadero:\n"
+        "    var x = 3\n"
+        '    imprimir("medio")\n'
+        "fin\n"
+        'imprimir("fin")\n'
+    )
+    archivo = tmp_path / "bloque_si.co"
+    archivo.write_text(codigo, encoding="utf-8")
+
+    out_run, err_run = StringIO(), StringIO()
+    with redirect_stdout(out_run), redirect_stderr(err_run):
+        rc_run = RunCommandV2().run(_run_args(str(archivo)))
+
+    assert rc_run == 0
+    assert err_run.getvalue() == ""
+    assert [ln.strip() for ln in out_run.getvalue().splitlines() if ln.strip()] == ["medio", "fin"]


### PR DESCRIPTION
### Motivation

- Corregir una divergencia entre la ejecución por lotes (`cobra run`) y el REPL donde una declaración (`var`/`variable`) podía comportarse como retorno temprano dentro de bloques, interrumpiendo sentencias posteriores.
- Mantener las políticas de seguridad y el catálogo público de `usar` sin cambios, limitando la corrección al flujo de control secuencial del intérprete.

### Description

- Ajusta el intérprete para que, al recorrer cuerpos secuenciales, las asignaciones que sean declaraciones (`NodoAsignacion` con `declaracion=True`) no se propaguen como resultado y simplemente se ignoren para el propósito de retorno temprano en los loops de `with`, `si/sino`, y `try/catch/finally`.
- Conserva la propagación normal de señales de control reales (`return`/`_ControlRomper`/`_ControlContinuar`) y no modifica la evaluación ni materialización de valores en el evaluador.
- No se tocaron las funciones relacionadas con sanitización de `usar`, import whitelist ni exposición de símbolos privados; el cambio es local a `src/pcobra/core/interpreter.py`.
- Añade pruebas integradas acotadas en `tests/integration/test_run_repl_equivalence.py` para los casos: `imprimir("antes"); var/variable x = 3; imprimir("despues")` y un bloque `si` con sentencias posteriores dentro y fuera del bloque.

### Testing

- Ejecuté los tests focalizados con `pytest -q tests/integration/test_run_repl_equivalence.py -k "no_corta_bloque_secuencial_tras_declaracion or no_corta_sentencias_posteriores_en_bloque_si"` y ambos casos pasaron correctamente.
- Ejecuté un conjunto ampliado de tests REPL/`usar` como comprobación de humo y se detectaron fallos preexistentes en contratos de `usar` (mensajes/metadata), que son independientes de esta corrección de control de flujo; no se introdujeron por este cambio.
- Los cambios modifican `src/pcobra/core/interpreter.py` y `tests/integration/test_run_repl_equivalence.py` y las pruebas añadidas confirman la paridad esperada entre `run` y REPL para el comportamiento de declaraciones.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a117a1ce0f08327b293525b98dcf626)