### PR TITLE
test: cubrir paridad de secuencia histórica entre REPL y RUN

### DIFF
--- a/tests/unit/test_parity_contract_run_vs_repl.py
+++ b/tests/unit/test_parity_contract_run_vs_repl.py
@@ -97,3 +97,24 @@ def test_parity_contract_run_service_vs_repl(caso: str, snippets: list[str], sal
     assert resultado_script["stdout"].endswith(salida_esperada), (
         f"{caso}: la salida final observable debe reflejar el estado esperado"
     )
+
+
+@pytest.mark.parametrize("declaracion", ["var x = 3", "variable x := 3"])
+def test_parity_secuencia_repl_vs_run_no_corta_flujo(declaracion: str) -> None:
+    # Cubre la divergencia histórica REPL vs RUN: en RUN no debe cortarse la secuencia.
+    snippets = [
+        'imprimir("antes")',
+        declaracion,
+        'imprimir("despues")',
+    ]
+    salida_esperada = "antes\ndespues"
+
+    resultado_script = _ejecutar_modo_script(snippets)
+    resultado_repl = _ejecutar_modo_repl(snippets)
+
+    assert resultado_script["rc"] == 0, "RunService debe completar la secuencia sin cortar flujo"
+    assert resultado_script["stderr"] == resultado_repl["stderr"] == "", (
+        "No debe existir salida de error en RUN ni REPL para esta secuencia"
+    )
+    assert resultado_script["stdout"] == salida_esperada
+    assert resultado_repl["stdout"] == salida_esperada


### PR DESCRIPTION
### Motivation
- Proteger una divergencia histórica entre REPL y RUN donde la ejecución en `RunService` podía cortar la secuencia observable que funciona en REPL.

### Description
- Añade una prueba parametrizada en `tests/unit/test_parity_contract_run_vs_repl.py` que ejecuta el mismo mini-programa en RUN usando `RunService.ejecutar_normal` y en REPL usando `InteractiveCommand.ejecutar_codigo`.
- La prueba usa la secuencia `imprimir("antes")` → declaración de variable → `imprimir("despues")` y verifica que la salida coincida y que no haya errores en ninguna ruta.
- Se incluyen dos variantes de declaración (`var x = 3` y la forma de inferencia `variable x := 3`) y se añadió un comentario corto que indica que el test cubre la divergencia histórica REPL vs RUN.
- La prueba se mantiene limitada al módulo afectado y no expande soporte a backends no soportados ni al resto del conjunto legacy.

### Testing
- Ejecuté `pytest -q tests/unit/test_parity_contract_run_vs_repl.py -k secuencia` y la primera ejecución falló porque la variante `variable x = 3` no era compatible con el parser (se esperaba `:=`).
- Ajusté la variante a `variable x := 3` y volví a ejecutar `pytest -q tests/unit/test_parity_contract_run_vs_repl.py -k secuencia`, con resultado: todas las pruebas seleccionadas pasaron exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a117b54509883279681194d274e6f92)