### PR TITLE
Fix var declaration control flow in script execution

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1573,6 +1573,9 @@ class InterpretadorCobra:
                 indice = self.solicitar_memoria(1)
                 self.mem_contextos[indice_contexto][nombre] = (indice, 1)
                 self.contextos[-1].define(nombre, valor)
+                # Contrato de flujo: una declaración no emite señal de control
+                # ni valor de corte; el bloque secuencial debe continuar.
+                return None
             else:
                 indice_contexto = self._indice_entorno_variable(nombre)
                 if indice_contexto is None:

--- a/tests/unit/test_cli_execution_pipeline_contract.py
+++ b/tests/unit/test_cli_execution_pipeline_contract.py
@@ -386,6 +386,21 @@ def test_contrato_resultado_igual_entre_modo_archivo_y_interactivo():
     assert out_file.getvalue() == out_repl.getvalue()
 
 
+def test_execute_archivo_no_corta_bloque_principal_en_declaracion_var():
+    codigo = 'imprimir("antes")\nvar x = 3\nimprimir("despues")'
+
+    cmd_execute = ExecuteCommand()
+    out_file, err_file = StringIO(), StringIO()
+    with redirect_stdout(out_file), redirect_stderr(err_file):
+        result_file = cmd_execute._service.ejecutar_normal(
+            codigo, seguro=False, extra_validators=None
+        )
+
+    assert result_file == 0
+    assert err_file.getvalue() == ""
+    assert out_file.getvalue().splitlines() == ["antes", "despues"]
+
+
 @pytest.mark.parametrize(
     ("caso", "codigo"),
     [


### PR DESCRIPTION
### Motivation
- El bucle secuencial que ejecuta un archivo interpretado trataba una asignación de tipo `var` como si devolviera un valor de corte, interrumpiendo la ejecución posterior del bloque principal.

### Description
- En la rama de asignación del intérprete (`ejecutar_asignacion`) se devolvió explícitamente `None` tras definir una variable cuando `nodo.declaracion` o `nodo.inferencia` es `True`, asegurando que una declaración no termine el bloque secuencial (`src/pcobra/core/interpreter.py`).
- Se añadió una prueba de regresión en la capa de ejecución por archivo para el caso mínimo con `imprimir("antes")`, `var x = 3`, `imprimir("despues")` (`tests/unit/test_cli_execution_pipeline_contract.py`).
- El cambio es localizado al flujo de ejecución del runtime y no modifica semánticas reales de control (`retornar`, `romper`, `continuar`), ni toca Lexer/Parser ni la sanitización de `usar` o el catálogo público de módulos.

### Testing
- Ejecuté los tests focalizados con `pytest -q tests/unit/test_cli_execution_pipeline_contract.py -k "no_corta_bloque_principal_en_declaracion_var or contrato_resultado_igual_entre_modo_archivo_y_interactivo"` y ambas pruebas dirigidas pasaron.
- Al correr el conjunto filtrado se observaron `2 passed, 23 deselected` y no hubo errores ni regressiones en la capa verificada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a117c839b308327be88afe0788d253a)