### PR TITLE
Añadir tests de paridad run/repl acotados para continuidad tras declaración

### DIFF
--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -675,25 +675,54 @@ def test_sandbox_normaliza_safe_mode_y_validadores_igual_en_run_y_repl(monkeypat
     assert [getattr(v, "origen", None) for v in capturas[1][2]] == ["uno.py", "dos.py"]
 
 
+
+
 @pytest.mark.integration
-@pytest.mark.parametrize("declarador", ["var", "variable"])
-def test_run_no_corta_bloque_secuencial_tras_declaracion(tmp_path, declarador: str, monkeypatch):
+@pytest.mark.parametrize(
+    ("caso", "codigo", "estado_esperado"),
+    [
+        (
+            "var",
+            'imprimir("antes")\nvar x = 3\nimprimir("despues")',
+            {"x": 3},
+        ),
+        (
+            "variable",
+            'imprimir("antes")\nvariable y := 4\nimprimir("despues")',
+            {"y": 4},
+        ),
+    ],
+)
+def test_paridad_funcional_acotada_run_y_repl_en_declaraciones_secuenciales(
+    tmp_path, caso: str, codigo: str, estado_esperado: dict[str, int], monkeypatch
+):
     monkeypatch.setattr("pcobra.cobra.cli.services.run_service.limitar_cpu_segundos", lambda *_: None)
-    codigo = (
-        'imprimir("antes")\n'
-        f"{declarador} x {":=" if declarador == "variable" else "="} 3\n"
-        'imprimir("despues")\n'
-    )
-    archivo = tmp_path / "secuencial.co"
-    archivo.write_text(codigo, encoding="utf-8")
+    archivo = tmp_path / f"paridad_{caso}.co"
+    archivo.write_text(codigo + "\n", encoding="utf-8")
 
     out_run, err_run = StringIO(), StringIO()
     with redirect_stdout(out_run), redirect_stderr(err_run):
         rc_run = RunCommandV2().run(_run_args(str(archivo)))
 
+    repl = InteractiveCommand(InterpretadorCobra())
+    repl._seguro_repl = False
+    repl._extra_validators_repl = None
+    out_repl, err_repl = StringIO(), StringIO()
+    with redirect_stdout(out_repl), redirect_stderr(err_repl):
+        repl.ejecutar_codigo(codigo)
+
+    lineas_run = [ln.strip() for ln in out_run.getvalue().splitlines() if ln.strip()]
+    lineas_repl = [ln.strip() for ln in out_repl.getvalue().splitlines() if ln.strip()]
+    salida_run = out_run.getvalue() + err_run.getvalue()
+    salida_repl = out_repl.getvalue() + err_repl.getvalue()
+
     assert rc_run == 0
-    assert err_run.getvalue() == ""
-    assert [ln.strip() for ln in out_run.getvalue().splitlines() if ln.strip()] == ["antes", "despues"]
+    assert lineas_run == lineas_repl == ["antes", "despues"]
+    assert "Traceback" not in salida_run
+    assert "Traceback" not in salida_repl
+    assert err_run.getvalue() == err_repl.getvalue() == ""
+    for nombre, valor in estado_esperado.items():
+        assert repl.interpretador.contextos[-1].get(nombre) == valor
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Motivation
- Reproducir y prevenir una regresión donde una declaración (var/variable) podía interrumpir la secuencia en la ruta `run` pero comportarse distinto en `repl`.
- Verificar paridad funcional entre el harness de `run` y el REPL no interactivo en casos mínimos relacionados con declaraciones secuenciales.
- Mantener el alcance reducido al bug reportado sin reactivar suites legacy ni introducir refactors o cambios en backends.

### Description
- Se reemplaza el test run-only previo por un test parametrizado en `tests/integration/test_run_repl_equivalence.py` que cubre exactamente dos casos: `imprimir("antes"); var x = 3; imprimir("despues")` y `imprimir("antes"); variable y := 4; imprimir("despues")`.
- El test ejecuta cada caso por la ruta de `run` (`RunCommandV2().run(...)`) y por la ruta REPL no interactiva (`InteractiveCommand(...).ejecutar_codigo(...)`).
- Se validan tres criterios para cada caso: orden de salida (`antes`, `despues`), ausencia de `Traceback` en la salida y persistencia del estado en el REPL (valor de `x`/`y`).
- Solo se modificó el archivo de integración mencionado y no se tocaron otros tests ni infraestructuras legacy.

### Testing
- Ejecutado el test específico con `pytest -q tests/integration/test_run_repl_equivalence.py -k paridad_funcional_acotada_run_y_repl_en_declaraciones_secuenciales` y la suite focalizada pasó con `2 passed, 27 deselected`.
- Las aserciones verificaron que ambas rutas producen las mismas líneas de salida y que no aparece `Traceback` en ninguna ruta.
- No se ejecutaron ni reactivaron pruebas adicionales de la suite legacy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a118025facc83278f2fb2cf2d877a2a)