### PR TITLE
Fix premature block termination on assignment results

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1518,7 +1518,7 @@ class InterpretadorCobra:
             try:
                 for instr in nodo.cuerpo:
                     resultado = self.ejecutar_nodo(instr)
-                    if isinstance(instr, NodoAsignacion) and getattr(instr, "declaracion", False):
+                    if isinstance(instr, NodoAsignacion):
                         continue
                     if resultado is not None:
                         return resultado
@@ -1900,7 +1900,7 @@ class InterpretadorCobra:
         if condicion is True:
             for instruccion in bloque_si:
                 resultado = self.ejecutar_nodo(instruccion)
-                if isinstance(instruccion, NodoAsignacion) and getattr(instruccion, "declaracion", False):
+                if isinstance(instruccion, NodoAsignacion):
                     continue
                 if resultado is not None:
                     return resultado
@@ -1911,7 +1911,7 @@ class InterpretadorCobra:
             return None
         for instruccion in bloque_sino:
             resultado = self.ejecutar_nodo(instruccion)
-            if isinstance(instruccion, NodoAsignacion) and getattr(instruccion, "declaracion", False):
+            if isinstance(instruccion, NodoAsignacion):
                 continue
             if resultado is not None:
                 return resultado
@@ -1941,7 +1941,7 @@ class InterpretadorCobra:
         try:
             for instruccion in nodo.bloque_try:
                 resultado = self.ejecutar_nodo(instruccion)
-                if isinstance(instruccion, NodoAsignacion) and getattr(instruccion, "declaracion", False):
+                if isinstance(instruccion, NodoAsignacion):
                     continue
                 if resultado is not None:
                     return resultado
@@ -1954,14 +1954,14 @@ class InterpretadorCobra:
                     contexto_actual.define(nodo.nombre_excepcion, exc.valor)
             for instruccion in nodo.bloque_catch:
                 resultado = self.ejecutar_nodo(instruccion)
-                if isinstance(instruccion, NodoAsignacion) and getattr(instruccion, "declaracion", False):
+                if isinstance(instruccion, NodoAsignacion):
                     continue
                 if resultado is not None:
                     return resultado
         finally:
             for instruccion in nodo.bloque_finally:
                 resultado = self.ejecutar_nodo(instruccion)
-                if isinstance(instruccion, NodoAsignacion) and getattr(instruccion, "declaracion", False):
+                if isinstance(instruccion, NodoAsignacion):
                     continue
                 if resultado is not None:
                     return resultado


### PR DESCRIPTION
### Motivation
- Se detectó que en bloques secuenciales internos (por ejemplo `with`, `si/sino`, `try/catch/finally`, `mientras`) el resultado devuelto por una asignación podía tratarse como señal de corte de bloque cuando la asignación no estaba marcada como `declaracion`, causando finalización prematura de bloques en reasignaciones.
- El objetivo es aplicar el ajuste mínimo en runtime para que las asignaciones no interrumpan el flujo secuencial salvo las señales de control explícitas (`retorno`, `romper`, `continuar`, excepciones).

### Description
- Se cambió la lógica de los bucles secuenciales en `InterpretadorCobra` para ignorar el `resultado` de cualquier `NodoAsignacion` comprobando `isinstance(..., NodoAsignacion)` y haciendo `continue` en esas instrucciones; esto evita que reasignaciones sean interpretadas como corte del bloque.
- Los puntos modificados están en los bucles de ejecución de bloques dentro de `src/pcobra/core/interpreter.py` (bloques `with`, condicionales `si/sino`, `mientras`, y `try/catch/finally`).
- No se tocaron Lexer/Parser ni contratos públicos; el parche se limita al runtime y preserva el resto de la semántica de control-flow.
- El cambio es mínimo y local: las rutas de corte siguen siendo únicamente nodos de control explícito y excepciones.

### Testing
- Se ejecutó `pytest -q src/pcobra/core -k asignacion` sobre el código modificado y la ejecución no recolectó tests para ese filtro (no se ejecutaron casos; resultado: “no tests collected”, pytest exit code 5).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11817a60808327bb1bbe2b8ca23ecf)