### PR TITLE
test: reforzar smoke parity run vs repl para `usar "datos"`

### DIFF
--- a/tests/unit/test_parity_contract_run_vs_repl.py
+++ b/tests/unit/test_parity_contract_run_vs_repl.py
@@ -58,6 +58,15 @@ def _ejecutar_modo_repl(snippets: list[str]) -> dict[str, str]:
     ("caso", "snippets", "salida_esperada"),
     [
         (
+            "usar_datos_y_longitud_lista",
+            [
+                'usar "datos"',
+                "var xs = [1,2,3]",
+                "imprimir(longitud(xs))",
+            ],
+            "3",
+        ),
+        (
             "declaracion_externa_mutacion_en_mientras_y_lectura_posterior",
             [
                 "var contador = 0\nmientras contador < 3:\n    contador = contador + 1\nfin",


### PR DESCRIPTION
### Motivation

- Añadir una prueba de humo que verifique la paridad entre `RunService.ejecutar_normal` y el REPL para el flujo `usar "datos"` + `var xs = [1,2,3]` + `imprimir(longitud(xs))`, cubriendo una regresión histórica de divergencia entre rutas.

### Description

- Se añadió un caso parametrizado `usar_datos_y_longitud_lista` en `tests/unit/test_parity_contract_run_vs_repl.py` que ejecuta los snippets `usar "datos"`, `var xs = [1,2,3]` e `imprimir(longitud(xs))` y espera la salida `3`.
- El cambio es de test-only y no modifica la lógica de sanitización ni las políticas de `usar`; no se permiten módulos fuera de la whitelist ni se exponen símbolos privados/backend SDK al namespace del usuario.

### Testing

- Ejecutadas pruebas focalizadas con `pytest -q tests/unit/test_parity_contract_run_vs_repl.py -k usar_datos_y_longitud_lista`, y el caso objetivo pasó (`1 passed`).
- Intentos de ejecutar conjuntos más amplios (`pytest` sobre múltiples archivos) encontraron un `INTERNALERROR MemoryError` en el runner durante el formateo/reporting de fallos del entorno, por lo que la verificación global no pudo completarse; la verificación focalizada del nuevo test sí concluyó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1183cc30d88327ab3b1e3df4ab2105)