### PR TITLE
docs(interpreter): aclarar contrato de control de flujo en ejecución de nodos

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1443,6 +1443,9 @@ class InterpretadorCobra:
 
     def ejecutar_nodo(self, nodo):
         self._trace_debug(f"[EXEC] node_type={type(nodo).__name__} node_id={id(nodo)}")
+        # Contrato de control de flujo:
+        # - Las declaraciones (`var`/`variable`) no emiten señal de corte.
+        # - Solo nodos de control (retorno/romper/continuar/errores) interrumpen bloques.
         if self.mode == "analysis":
             # En análisis no se ejecutan nodos: evita prints, mutaciones y efectos observables.
             return None
@@ -1546,6 +1549,8 @@ class InterpretadorCobra:
 
     def ejecutar_asignacion(self, nodo, visitados=None):
         """Evalúa una asignación de variable o atributo."""
+        # Contrato: una declaración (`var`/`variable`) solo muta contexto y nunca
+        # devuelve señal de control para cortar un bloque.
         visitados = set() if visitados is None else visitados
         nombre = getattr(nodo, "identificador", getattr(nodo, "variable", None))
         valor_nodo = getattr(nodo, "expresion", getattr(nodo, "valor", None))


### PR DESCRIPTION
### Motivation
- Hacer explícito en el código el contrato de control de flujo para ayudar a futuros mantenedores: las declaraciones no deben cortar bloques y solo los nodos de control (retorno/romper/continuar/errores) deben interrumpir la ejecución.

### Description
- Se añadieron comentarios contractuales breves en `ejecutar_nodo` y en `ejecutar_asignacion` que especifican que las declaraciones (`var`/`variable`) no emiten señal de corte y que solo nodos de control interrumpen bloques; no se cambió la semántica ni se añadieron APIs o cambios de sintaxis.

### Testing
- Se compiló el archivo modificado con `python -m compileall -q src/pcobra/core/interpreter.py` y la verificación de compilación succeedió.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a118fd5aefc8327bb97d35f51da6ecb)