### PR TITLE
Alinear `cobra run` safe-mode con REPL para `usar "archivo"` + `existe`

### DIFF
--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -329,9 +329,15 @@ def ejecutar_codigo_canonico(
 
     ast = analizar_codigo_fn(codigo)
     if seguro:
+        nodos_usar = [
+            nodo for nodo in ast if getattr(nodo, "__class__", type("", (), {})).__name__ == "NodoUsar"
+        ]
+        if nodos_usar:
+            ejecutar_ast(nodos_usar, interpretador)
         validar_ast_seguro(
             ast,
             validadores_extra=extra_validators,
+            interpretador=interpretador,
             construir_cadena_fn=construir_cadena_fn,
         )
     resultado = ejecutar_ast(ast, interpretador)

--- a/tests/unit/test_parity_contract_run_vs_repl.py
+++ b/tests/unit/test_parity_contract_run_vs_repl.py
@@ -35,6 +35,24 @@ def _ejecutar_modo_script(snippets: list[str]) -> dict[str, str | int]:
     }
 
 
+def _ejecutar_modo_script_seguro(snippets: list[str]) -> dict[str, str | int]:
+    codigo = "\n\n".join(snippets)
+    servicio = RunService()
+    out, err = StringIO(), StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        with patch.object(
+            InterpretadorCobra,
+            "_asegurar_no_autorreferencia_asignacion",
+            return_value=None,
+        ):
+            rc = servicio.ejecutar_normal(codigo, seguro=True, extra_validators=None)
+    return {
+        "rc": rc,
+        "stdout": _normalizar_salida(out.getvalue()),
+        "stderr": _normalizar_salida(err.getvalue()),
+    }
+
+
 def _ejecutar_modo_repl(snippets: list[str]) -> dict[str, str]:
     repl = InteractiveCommand(InterpretadorCobra())
     repl._seguro_repl = False
@@ -126,3 +144,29 @@ def test_parity_secuencia_run_vs_repl_con_declaraciones_equivalentes(declaracion
         "No debe existir salida de error en RUN ni REPL para esta secuencia"
     )
     assert resultado_script["stdout"] == resultado_repl["stdout"] == salida_esperada
+
+
+def test_run_seguro_permite_existe_solo_con_usar_archivo() -> None:
+    resultado = _ejecutar_modo_script_seguro(
+        [
+            'usar "archivo"',
+            'imprimir(existe("README.md"))',
+            'imprimir(existe("../README.md"))',
+        ]
+    )
+
+    assert resultado["rc"] == 0
+    assert resultado["stderr"] == ""
+    assert "verdadero" in resultado["stdout"]
+    assert resultado["stdout"].splitlines()[-1] == "falso"
+
+
+def test_run_seguro_bloquea_existe_sin_usar_archivo() -> None:
+    resultado = _ejecutar_modo_script_seguro(
+        [
+            'imprimir(existe("README.md"))',
+        ]
+    )
+
+    assert resultado["rc"] == 1
+    assert "Uso de primitiva peligrosa: 'existe'" in resultado["stdout"]


### PR DESCRIPTION
### Motivation

- Corregir la discrepancia entre la ruta `cobra run` y el REPL para el caso seguro donde `usar "archivo"` debe habilitar únicamente la primitiva `existe` desde la API pública `archivo` sin abrir bypass global. 

### Description

- En `execution_pipeline.ejecutar_codigo_canonico` se pre-ejecutan únicamente los nodos `NodoUsar` cuando `safe_mode=True` para propagar metadata canónica de `usar` al intérprete antes de validar primitivas peligrosas. 
- `validar_ast_seguro(...)` ahora se invoca con el `interpretador` activo para que los validadores registrables reciban la metadata sincronizada y puedan autorizar `archivo.existe` correctamente. 
- Se añadieron pruebas en `tests/unit/test_parity_contract_run_vs_repl.py` que cubren la ruta `run` en modo seguro y verifican: `usar "archivo"` + `existe("README.md")` => permitido, `usar "archivo"` + `existe("../README.md")` => denegado por ruta, y sin `usar "archivo"` + `existe("README.md")` => error controlado. 
- No se cambia la política de módulos públicos ni se permiten imports externos o bypasses; la validación sigue restringida a los contratos públicos existentes y a `PUBLIC_BACKENDS` tal como antes. 

### Testing

- Ejecuté las pruebas focalizadas para los escenarios añadidos (`pytest -q tests/unit/test_parity_contract_run_vs_repl.py -k "run_seguro"`) y ambas pruebas nuevas pasaron. 
- Se ejecutó una corrida más amplia del archivo de pruebas y el entorno mostró un `INTERNALERROR (MemoryError)` durante la fase de reporting; esto pareció ser un fallo del entorno de test/reporting y no una regresión funcional de los cambios aplicados. 
- Las aserciones verifican además que el mensaje de error cuando `existe` se usa sin `usar "archivo"` sea corto y controlado (`"Uso de primitiva peligrosa: 'existe'"`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1198b7407c8327b50a0367e8c33b6e)