### PR TITLE
fix(run): normalizar BOM UTF-8 en la frontera de entrada de `cobra run`

### DIFF
--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -37,6 +37,12 @@ except ModuleNotFoundError as canon_exc:  # pragma: no cover
 
 RUNTIME_MANAGER = RuntimeManager()
 
+def _normalizar_codigo_entrada(codigo: str) -> str:
+    if codigo.startswith("\ufeff"):
+        return codigo[1:]
+    return codigo
+
+
 
 def _importar_modulo_sandbox() -> Any:
     """Compatibilidad para tests/adaptadores legacy; evita import dinámico en run."""
@@ -111,6 +117,7 @@ class RunService:
 
         try:
             codigo = Path(archivo_resuelto).read_text(encoding="utf-8")
+            codigo = _normalizar_codigo_entrada(codigo)
         except (PermissionError, UnicodeDecodeError) as e:
             mostrar_error(f"Error al leer el archivo: {e}", registrar_log=False)
             return 1

--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -789,3 +789,41 @@ def test_run_conservar_control_break_y_continue_en_mientras(tmp_path, monkeypatc
     assert rc_run == 0
     assert err_run.getvalue() == ""
     assert [ln.strip() for ln in out_run.getvalue().splitlines() if ln.strip()] == ["1", "3", "4"]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("con_bom", [True, False])
+def test_run_acepta_utf8_bom_en_frontera_de_entrada(tmp_path, monkeypatch, con_bom: bool):
+    monkeypatch.setattr("pcobra.cobra.cli.services.run_service.limitar_cpu_segundos", lambda *_: None)
+    contenido = 'imprimir("antes")\nvar x = 3\nimprimir("despues")\n'
+    if con_bom:
+        contenido = "\ufeff" + contenido
+
+    archivo = tmp_path / ("programa_bom.co" if con_bom else "programa_sin_bom.co")
+    archivo.write_text(contenido, encoding="utf-8")
+
+    out_run, err_run = StringIO(), StringIO()
+    with redirect_stdout(out_run), redirect_stderr(err_run):
+        rc_run = RunCommandV2().run(_run_args(str(archivo)))
+
+    assert rc_run == 0
+    assert err_run.getvalue() == ""
+    assert [ln.strip() for ln in out_run.getvalue().splitlines() if ln.strip()] == ["antes", "despues"]
+
+
+@pytest.mark.integration
+def test_run_error_lexico_sigue_siendo_corto_sin_traceback_con_y_sin_bom(tmp_path, monkeypatch):
+    monkeypatch.setattr("pcobra.cobra.cli.services.run_service.limitar_cpu_segundos", lambda *_: None)
+
+    for prefijo in ("", "\ufeff"):
+        archivo = tmp_path / ("error_sin_bom.co" if not prefijo else "error_con_bom.co")
+        archivo.write_text(prefijo + 'imprimir("cadena sin cerrar)\n', encoding="utf-8")
+
+        out_run, err_run = StringIO(), StringIO()
+        with redirect_stdout(out_run), redirect_stderr(err_run):
+            rc_run = RunCommandV2().run(_run_args(str(archivo)))
+
+        assert rc_run != 0
+        salida = out_run.getvalue() + err_run.getvalue()
+        assert "Traceback" not in salida
+        assert salida.strip() != ""


### PR DESCRIPTION
### Motivation
- Evitar que un BOM UTF-8 inicial en archivos fuente cause problemas en el pipeline léxico sin alterar el contenido restante ni el comportamiento del lexer/parser.
- Aplicar la normalización solo en la frontera de entrada para no afectar otras vías de ingestión de código.

### Description
- Se localizó la lectura de fuente en `RunService.run` y se añadió la función `_normalizar_codigo_entrada(codigo: str)` que elimina únicamente el prefijo BOM (`\ufeff`) inicial si está presente.
- La normalización se aplica inmediatamente tras `Path(archivo_resuelto).read_text(encoding="utf-8")` y antes de cualquier prevalidación o envío al pipeline, sin tocar Lexer/Parser ni reglas/tokenización.
- Se agregaron pruebas de regresión de integración en `tests/integration/test_run_repl_equivalence.py` que verifican ejecución idéntica con y sin BOM y que los errores léxicos siguen mostrando mensajes cortos sin `Traceback`.
- Archivos modificados: `src/pcobra/cobra/cli/services/run_service.py` y `tests/integration/test_run_repl_equivalence.py`.

### Testing
- Ejecutado `pytest -q tests/integration/test_run_repl_equivalence.py -k 'bom or retorno_fuera_de_funcion'` y los tests relevantes pasaron (integración con BOM y sin BOM OK).
- Ejecutado `pytest -q tests/integration/test_run_repl_equivalence.py -k 'bom or siendo_corto'` y las pruebas que validan comportamiento en errores léxicos pasaron.
- No se cambiaron pruebas del lexer/parser y no se observaron regresiones en las ejecuciones automatizadas mencionadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11b0f9d8d88327ad1b9f7ff832fa53)