### PR TITLE
Reenviar warnings internos de runtime a logging DEBUG

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1976,8 +1976,8 @@ class InterpretadorCobra:
     def ejecutar_llamada_funcion(self, nodo):
         """Ejecuta la invocación de una función, interna o del usuario."""
         emitir_salida_llamada = self.in_execution()
-        if emitir_salida_llamada:
-            print(f"WARNING: Llamada a funcion: {nodo.nombre}")
+        if logging.getLogger().isEnabledFor(logging.DEBUG):
+            logging.debug("Llamada a función: %s", nodo.nombre)
         if nodo.nombre == "imprimir":
             for arg in nodo.argumentos:
                 if isinstance(arg, Token) and arg.tipo == TipoToken.IDENTIFICADOR:
@@ -2292,7 +2292,7 @@ class InterpretadorCobra:
                     "severity": "warning",
                     "module": nodo.modulo,
                 }
-                logging.warning(
+                logging.debug(
                     "USAR sanitize conflicts event module=%s %s",
                     nodo.modulo,
                     _resumen_conflictos_usar(conflictos_saneamiento),
@@ -2341,7 +2341,7 @@ class InterpretadorCobra:
                         "policy": self._usar_collision_policy,
                         "detail": detalle_por_simbolo,
                     }
-                    logging.warning(
+                    logging.debug(
                         "USAR collision symbol event module=%s symbol=%s policy=%s count=%s",
                         nodo.modulo,
                         simbolo_conflictivo,
@@ -2361,13 +2361,8 @@ class InterpretadorCobra:
                     "phase": "preflight",
                 }
                 if self._usar_collision_policy == USAR_COLLISION_WARN_ALIAS_REQUIRED:
-                    logging.warning(
-                        "WARNING: %s module=%s count=%s",
-                        formatear_error_usar_usuario(
-                            "conflicto_simbolo",
-                            nodo.modulo,
-                            "Use alias explícito para resolver la colisión.",
-                        ),
+                    logging.debug(
+                        "usar_conflicto_simbolo module=%s count=%s",
                         nodo.modulo,
                         len(conflictos),
                     )

--- a/tests/unit/test_repl_function_definition_contract.py
+++ b/tests/unit/test_repl_function_definition_contract.py
@@ -69,7 +69,7 @@ def _capturar_repl(cmd: InteractiveCommand, codigo: str) -> tuple[str, list[str]
         logger.setLevel(prev_level)
 
 
-def test_repl_warning_llamada_funcion_simple_conteo_unico_y_resultado_visible() -> None:
+def test_repl_modo_normal_no_muestra_warning_llamada_funcion_y_resultado_visible() -> None:
     cmd = InteractiveCommand(InterpretadorCobra())
     _capturar_repl(cmd, """
 func test(x):
@@ -78,12 +78,12 @@ fin
 """)
     salida_stdout, salida_logging = _capturar_repl(cmd, "test(1)")
 
-    assert salida_stdout.splitlines().count("WARNING: Llamada a funcion: test") == 1
+    assert "WARNING: Llamada a funcion: test" not in salida_stdout
     assert "1" in salida_stdout
-    assert not any("WARNING: Llamada a funcion: test" in ln for ln in salida_logging)
+    assert not any("Llamada a función: test" in ln for ln in salida_logging)
 
 
-def test_repl_warning_llamada_funcion_anidada_orden_cardinalidad_y_resultado() -> None:
+def test_repl_modo_normal_llamada_anidada_sin_warning_y_resultado() -> None:
     cmd = InteractiveCommand(InterpretadorCobra())
     salida_def, logs_def = _capturar_repl(cmd, """
 func doble(x):
@@ -98,21 +98,13 @@ fin
 
     salida_stdout, salida_logging = _capturar_repl(cmd, "triple(3)")
 
-    warnings = [
-        ln
-        for ln in salida_stdout.splitlines()
-        if ln.startswith("WARNING: Llamada a funcion:")
-    ]
-    assert warnings == [
-        "WARNING: Llamada a funcion: triple",
-        "WARNING: Llamada a funcion: doble",
-    ]
+    assert "WARNING: Llamada a funcion:" not in salida_stdout
     assert "9" in salida_stdout
-    assert not any("WARNING: Llamada a funcion: triple" in ln for ln in salida_logging)
-    assert not any("WARNING: Llamada a funcion: doble" in ln for ln in salida_logging)
+    assert not any("Llamada a función: triple" in ln for ln in salida_logging)
+    assert not any("Llamada a función: doble" in ln for ln in salida_logging)
 
 
-def test_no_regresion_llamadas_anidadas_triple_warning_unico_por_funcion() -> None:
+def test_repl_debug_muestra_traza_llamadas_anidadas_en_logging() -> None:
     cmd = InteractiveCommand(InterpretadorCobra())
     salida_def, _ = _capturar_repl(
         cmd,
@@ -127,11 +119,27 @@ fin
     )
     assert salida_def == ""
 
-    salida_stdout, _ = _capturar_repl(cmd, "triple(3)")
-    lineas = salida_stdout.splitlines()
-    assert lineas.count("WARNING: Llamada a funcion: triple") == 1
-    assert lineas.count("WARNING: Llamada a funcion: doble") == 1
-    assert lineas[-1] == "9"
+    import logging
+
+    logger = logging.getLogger()
+    prev_handlers = list(logger.handlers)
+    prev_level = logger.level
+    stream_logs = StringIO()
+    logger.handlers = [logging.StreamHandler(stream_logs)]
+    logger.setLevel(logging.DEBUG)
+    try:
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            cmd.ejecutar_codigo("triple(3)")
+        salida_stdout = out.getvalue()
+    finally:
+        logger.handlers = prev_handlers
+        logger.setLevel(prev_level)
+
+    lineas_logs = stream_logs.getvalue()
+    assert "Llamada a función: triple" in lineas_logs
+    assert "Llamada a función: doble" in lineas_logs
+    assert "WARNING: Llamada a funcion" not in salida_stdout
+    assert salida_stdout.splitlines()[-1] == "9"
 
 
 def test_regresion_repl_fase_analisis_y_ejecucion_para_func_test() -> None:
@@ -150,5 +158,5 @@ fin
 
     salida_call, _ = _capturar_repl(cmd, "test(1)")
     lineas = salida_call.splitlines()
-    assert lineas.count("WARNING: Llamada a funcion: test") == 1
+    assert "WARNING: Llamada a funcion: test" not in salida_call
     assert lineas[-1] == "1"


### PR DESCRIPTION
### Motivation

- Reducir el ruido en la salida del CLI/REPL evitando mensajes informativos/internos (trazas de llamada, eventos de saneamiento/colisiones) que hoy aparecían como `WARNING` o impresos en `stdout` y no son diagnósticos críticos para el usuario final.
- Mantener la trazabilidad técnica disponible bajo niveles verbosos (`--debug` / logging `DEBUG`) para depuración y telemetría interna.
- Preservar la semántica de ejecución y los errores funcionales visibles al usuario final (excepciones y mensajes de error públicos).

### Description

- Reemplacé el `print('WARNING: Llamada a funcion: ...')` en `ejecutar_llamada_funcion` por un `logging.debug("Llamada a función: %s", nodo.nombre)` protegido con `isEnabledFor(logging.DEBUG)` para que las trazas de llamada aparezcan solo en modo debug, sin alterar la salida normal de `imprimir` ni la lógica de ejecución.
- Reclasifiqué eventos internos del pipeline `usar` que antes usaban `logging.warning` por `logging.debug` para `USAR sanitize conflicts` y `USAR collision symbol` y cambié el mensaje de aviso-aliás a `logging.debug` manteniendo `logging.error` para el evento de colisión crítico que produce error, de modo que solo los errores reales sigan saliendo como `error`/excepción.
- Actualicé la prueba de contrato REPL en `tests/unit/test_repl_function_definition_contract.py` para verificar que en modo normal no aparecen estos warnings internos en `stdout` y que en modo `DEBUG` las trazas internas se registran en el logger.
- Archivos modificados: `src/pcobra/core/interpreter.py` y `tests/unit/test_repl_function_definition_contract.py`.

### Testing

- Ejecuté `pytest -q tests/unit/test_repl_function_definition_contract.py` y obtuvo `6 passed, 1 warning` (la suite modificada pasó y valida los escenarios normal vs debug).
- Intenté ejecutar pruebas específicas relacionadas con `usar` pero la colección falló por un error de import (`ImportError: attempted relative import beyond top-level package`) del entorno de test, por lo que no se pudo ejecutar `tests/unit/test_usar.py` en este entorno; el fallo fue de import path y no relacionado a los cambios aplicados.
- No se observaron cambios en la lógica de ejecución ni en el manejo de errores funcionales tras las modificaciones según las pruebas unitarias ejecutadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11b8b766a4832782a3d020c6fa3ef8)