### PR TITLE
tests: añadir regresiones REPL v2 para seguridad de `usar` y revalidar BUG-001

### DIFF
--- a/tests/integration/test_repl_list_literal_eval_contract.py
+++ b/tests/integration/test_repl_list_literal_eval_contract.py
@@ -238,3 +238,43 @@ def test_repl_v2_usar_fronteras_rechaza_numpy_y_sintaxis_invalida(capsys):
         cmd._ejecutar_en_modo_normal("imprimir(ys[0])")
     salida_indice = capsys.readouterr().out
     assert "Traceback" not in salida_indice
+
+
+def test_repl_v2_usar_bloquea_primitiva_peligrosa_sin_origen_permitido(capsys):
+    cmd = ReplCommandV2()
+
+    with pytest.raises(Exception, match=r"Uso de primitiva peligrosa: 'existe'") as excinfo:
+        cmd._ejecutar_en_modo_normal('imprimir(existe("/tmp"))')
+
+    assert "Traceback" not in capsys.readouterr().out
+    assert str(excinfo.value).startswith("Uso de primitiva peligrosa")
+
+
+def test_repl_v2_usar_no_expone_os_pathlib_sdk_ni_privados(capsys):
+    cmd = ReplCommandV2()
+    cmd._ejecutar_en_modo_normal('usar "datos"')
+
+    for simbolo in ("os", "pathlib", "holobit_sdk", "_privado"):
+        with pytest.raises(NameError):
+            cmd._ejecutar_en_modo_normal(f"imprimir({simbolo})")
+        salida = capsys.readouterr().out
+        assert "Traceback" not in salida
+
+
+def test_repl_v2_revalida_bug_001_var_global_funcion_y_reasignacion(capsys):
+    cmd = ReplCommandV2()
+    programa = """
+var g = 1
+func valor_local():
+    var interno = 2
+    retorno interno
+fin
+imprimir(g)
+imprimir(valor_local())
+var g = 9
+imprimir(g)
+""".strip()
+
+    cmd._ejecutar_en_modo_normal(programa)
+    salida = [ln.strip() for ln in capsys.readouterr().out.splitlines() if ln.strip().isdigit()]
+    assert salida[-3:] == ["1", "2", "9"]


### PR DESCRIPTION
### Motivation
- Añadir una batería de regresión que compruebe fronteras de seguridad en la operación `usar` (rechazo de módulos fuera del catálogo público y bloqueo de primitivas peligrosas sin origen permitido). 
- Asegurar que `usar` no exponga señales inseguras como `os`, `pathlib`, SDKs backend o símbolos privados. 
- Revalidar escenarios relacionados con BUG-001 (var global, var en función y reasignación) para evitar regresiones colaterales en el flujo de ejecución.

### Description
- Se añadió y registró el fichero de pruebas `tests/integration/test_repl_list_literal_eval_contract.py` con tres nuevos tests: `test_repl_v2_usar_bloquea_primitiva_peligrosa_sin_origen_permitido`, `test_repl_v2_usar_no_expone_os_pathlib_sdk_ni_privados` y `test_repl_v2_revalida_bug_001_var_global_funcion_y_reasignacion`. 
- Los tests verifican que los errores emitidos son concisos y no muestran `Traceback` en salida, y que las primitivas peligrosas solo funcionan si fueron registradas mediante `usar` válido. 
- No se modifica la gramática ni se introducen tokens nuevos ni cambios en código productivo; solo se amplía la suite de tests de integración para cubrir los contratos de seguridad y la regresión mencionada.

### Testing
- Ejecutado: `pytest -q tests/integration/test_repl_list_literal_eval_contract.py -k "usar_fronteras or bloquea_primitiva or no_expone_os or revalida_bug_001 or datos_elemento_errores"` y la selección de tests relevantes pasó correctamente. 
- Ejecutado: `pytest -q tests/test_lexer.py tests/test_parser.py tests/unit/test_cli_execution_pipeline_contract.py -k "BUG-001 or parser_global or token"` y los tests relevantes pasaron correctamente. 
- Todas las ejecuciones automáticas realizadas durante la verificación terminaron con éxito para las pruebas ejecutadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11c85792dc83279a60ac85667525f1)