### PR TITLE
Normalizar BOM en frontera de `run` y agregar pruebas de cobertura

### DIFF
--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -105,6 +105,11 @@ def prevalidar_y_parsear_codigo(codigo: str) -> Any:
 
     if not isinstance(codigo, str):
         raise TypeError(_("El código fuente debe ser una cadena de texto"))
+    # Nota de compatibilidad:
+    # - El BOM de archivos (`\ufeff` al inicio) se normaliza en la frontera de
+    #   lectura de `run_service`.
+    # - Aquí sólo aplicamos saneamiento Unicode compatible para tokenización,
+    #   sin alterar reglas de Lexer/Parser.
     codigo_saneado = sanitize_source_for_tokenizer(codigo)
     tokens = Lexer(codigo_saneado).tokenizar()
     return Parser(tokens).parsear()

--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -38,6 +38,11 @@ except ModuleNotFoundError as canon_exc:  # pragma: no cover
 RUNTIME_MANAGER = RuntimeManager()
 
 def _normalizar_codigo_entrada(codigo: str) -> str:
+    """Normaliza la frontera de entrada de archivos de código.
+
+    Mantiene comportamiento no invasivo: únicamente remueve BOM UTF-8
+    (`\ufeff`) cuando aparece en la posición 0 del archivo.
+    """
     if codigo.startswith("\ufeff"):
         return codigo[1:]
     return codigo

--- a/tests/cli/test_run_service_input_normalization.py
+++ b/tests/cli/test_run_service_input_normalization.py
@@ -1,0 +1,12 @@
+from pcobra.cobra.cli.services.run_service import _normalizar_codigo_entrada
+
+
+def test_normalizar_codigo_entrada_remueve_solo_bom_inicial() -> None:
+    codigo = "\ufeffimprimir('ok')"
+    assert _normalizar_codigo_entrada(codigo) == "imprimir('ok')"
+
+
+def test_normalizar_codigo_entrada_no_toca_bom_no_inicial() -> None:
+    codigo = "imprimir('a')\n\ufeffimprimir('b')"
+    assert _normalizar_codigo_entrada(codigo) == codigo
+


### PR DESCRIPTION
### Motivation
- Evitar que un BOM UTF-8 inicial (`\ufeff`) en archivos de entrada rompa la tokenización/parsing al ejecutar `run` y mantener la política de saneamiento no invasiva del pipeline de análisis.
- Asegurar que la normalización de la frontera de entrada sea explícita y esté documentada para evitar duplicación o conflicto con el saneamiento Unicode del pipeline.
- Añadir pruebas específicas que verifiquen la eliminación únicamente del BOM inicial y la paridad funcional con/ sin BOM en `run`.

### Description
- Añadido docstring a `pcobra.cobra.cli.services.run_service._normalizar_codigo_entrada` que deja explícito que sólo elimina `\ufeff` en posición 0 y que el comportamiento es no invasivo.
- La normalización sigue realizándose inmediatamente después de `Path(...).read_text(encoding="utf-8")` en `RunService.run` (frontera de lectura de archivos) y se reforzó la intención en el código existente.
- Se añadió una nota de compatibilidad en `pcobra.cobra.cli.execution_pipeline.prevalidar_y_parsear_codigo` para documentar que el BOM se gestiona en la frontera de `run` y que aquí sólo se aplica el saneamiento Unicode para tokenización sin alterar reglas de `Lexer`/`Parser`.
- Se añadió la suite de pruebas `tests/cli/test_run_service_input_normalization.py` con dos tests que garantizan que `
ormalizar_codigo_entrada` elimina sólo el BOM inicial y no modifica BOM en posiciones no iniciales.

### Testing
- Ejecutado `pytest -q tests/cli/test_run_service_input_normalization.py tests/integration/test_run_repl_equivalence.py -k "bom or corto_sin_traceback_con_y_sin_bom"` y la ejecución devolvió `5 passed, 29 deselected`.
- Las pruebas verificaron la ejecución correcta con y sin BOM (salida `antes` / `despues`) y confirmaron que los errores léxicos siguen mostrando un mensaje corto sin `Traceback` en modo normal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e53e1ea883278f70821857f6a6fa)