### PR TITLE
Silenciar warnings de auditoría en modo normal y conservar diagnóstico en debug

### DIFF
--- a/src/pcobra/core/semantic_validators/auditoria.py
+++ b/src/pcobra/core/semantic_validators/auditoria.py
@@ -29,7 +29,7 @@ class ValidadorAuditoria(ValidadorBase):
         # Fuente de verdad centralizada para side effects de auditoría.
         if not self.in_execution():
             return
-        logging.warning(mensaje)
+        logging.getLogger(__name__).debug(mensaje)
 
     def in_execution(self) -> bool:
         """Indica si la auditoría debe emitir side effects en fase de ejecución."""

--- a/tests/unit/test_auditoria_validator.py
+++ b/tests/unit/test_auditoria_validator.py
@@ -1,10 +1,10 @@
 import logging
 import pcobra  # garantiza rutas para submódulos
 import pytest
-from core.interpreter import InterpretadorCobra
-from core.ast_nodes import NodoLlamadaFuncion, NodoValor
-from core.semantic_validators import PrimitivaPeligrosaError
-from core.semantic_validators.auditoria import ValidadorAuditoria
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.ast_nodes import NodoLlamadaFuncion, NodoUsar, NodoValor
+from pcobra.core.semantic_validators import PrimitivaPeligrosaError
+from pcobra.core.semantic_validators.auditoria import ValidadorAuditoria
 
 
 def test_auditoria_no_emite_en_analysis_durante_semantica(caplog):
@@ -16,16 +16,25 @@ def test_auditoria_no_emite_en_analysis_durante_semantica(caplog):
     assert not caplog.records
 
 
-def test_validador_auditoria_emite_solo_en_execution(caplog):
-    nodo = NodoLlamadaFuncion("funcion_demo", [])
-
-    validador_analysis = ValidadorAuditoria(emitir_side_effects=False)
-    with caplog.at_level(logging.WARNING):
-        validador_analysis.visit_llamada_funcion(nodo)
-    assert not caplog.records
+def test_validador_auditoria_diagnostico_solo_en_debug(caplog):
+    validador = ValidadorAuditoria(emitir_side_effects=True)
 
     caplog.clear()
-    validador_execution = ValidadorAuditoria(emitir_side_effects=True)
-    with caplog.at_level(logging.WARNING):
-        validador_execution.visit_llamada_funcion(nodo)
-    assert any("funcion_demo" in rec.message for rec in caplog.records)
+    with caplog.at_level(logging.INFO):
+        validador.visit_llamada_funcion(NodoLlamadaFuncion("main", []))
+        validador.visit_usar(NodoUsar("archivo"))
+    assert not [r for r in caplog.records if "Llamada a funcion" in r.message or "Usar modulo" in r.message]
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        validador.visit_llamada_funcion(NodoLlamadaFuncion("main", []))
+        validador.visit_usar(NodoUsar("archivo"))
+    mensajes = [r.message for r in caplog.records]
+    assert "Usar modulo: archivo" in mensajes
+
+
+def test_validador_auditoria_no_emite_side_effects_en_analysis(caplog):
+    validador_analysis = ValidadorAuditoria(emitir_side_effects=False)
+    with caplog.at_level(logging.DEBUG):
+        validador_analysis.visit_usar(NodoUsar("archivo"))
+    assert not caplog.records


### PR DESCRIPTION
### Motivation
- Reducir el ruido visible al usuario causado por mensajes de auditoría (p.ej. “Usar modulo: ...”, “Llamada a metodo/función”) sin alterar la semántica de seguridad ni validación.
- Mantener la trazabilidad y diagnóstico disponible cuando el usuario habilita debug/verbose mediante el nivel de logging.

### Description
- Cambiado `ValidadorAuditoria._log` para emitir con `logging.getLogger(__name__).debug(...)` en lugar de `logging.warning(...)`, de modo que los diagnósticos solo aparezcan en modo debug.
- Actualizada la prueba `tests/unit/test_auditoria_validator.py` para validar que en nivel `INFO` no aparecen los mensajes ruidosos, que en `DEBUG` sí aparecen los diagnósticos, y que en modo `analysis` no se emiten side effects.
- No se modifica ninguna política de seguridad, validación ni flujo de ejecución (`in_execution`, `emitir_side_effects` y comportamiento del validador se mantienen intactos).

### Testing
- Ejecutado `pytest -q tests/unit/test_auditoria_validator.py` y la suite de pruebas del archivo pasó correctamente (`3 passed`).
- Se intentó ejecutar una ejecución más amplia (`pytest -q tests/unit/test_auditoria_validator.py tests/unit/test_usar.py`) y falló durante la colección por un error de imports/entorno no relacionado con los cambios de logging (error en importación relativa durante la colección).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f435684c83279e6d3e22b138c0f2)