### PR TITLE
Ocultar warnings diagnósticos salvo con `--debug` o `-v`

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -59,7 +59,7 @@ def configure_encoding() -> None:
     os.environ["PYTHONIOENCODING"] = "utf-8"
 
 
-def configure_logging(debug: bool) -> None:
+def configure_logging(debug: bool, verbose: int = 0) -> None:
     """Configura logging de CLI con un único handler efectivo de consola.
 
     Contrato de logging del proyecto:
@@ -69,7 +69,8 @@ def configure_logging(debug: bool) -> None:
       y propagar al root.
     """
 
-    level = logging.DEBUG if debug else logging.WARNING
+    modo_diagnostico = bool(debug) or int(verbose or 0) > 0
+    level = logging.DEBUG if modo_diagnostico else logging.ERROR
     formatter = logging.Formatter("%(levelname)s: %(message)s")
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
@@ -299,7 +300,17 @@ def main(argumentos: Optional[List[str]] = None) -> int:
     argv_entrada: Iterable[str] = argumentos if argumentos is not None else sys.argv[1:]
     argv = _preprocesar_argumentos_cli(argv_entrada)
     debug = bool(argv and "--debug" in argv)
-    configure_logging(debug=debug)
+    verbose = 0
+    if argv:
+        for arg in argv:
+            if arg == "-v" or arg == "--verbose":
+                verbose += 1
+            elif arg.startswith("--verbose="):
+                try:
+                    verbose += int(arg.split("=", 1)[1] or 0)
+                except ValueError:
+                    verbose += 1
+    configure_logging(debug=debug, verbose=verbose)
     if debug:
         os.environ["PCOBRA_DEBUG_TRACES"] = "1"
     else:

--- a/tests/unit/test_cli_configurar_entorno.py
+++ b/tests/unit/test_cli_configurar_entorno.py
@@ -140,7 +140,7 @@ def test_main_reconfigura_consola_antes_de_logging_y_cli(monkeypatch):
 
     monkeypatch.setattr(cli, "configure_encoding", lambda: orden.append("utf8"))
     monkeypatch.setattr(cli, "_bootstrap_dev_path_si_opt_in", lambda: orden.append("bootstrap"))
-    monkeypatch.setattr(cli, "configure_logging", lambda debug: orden.append("logging"))
+    monkeypatch.setattr(cli, "configure_logging", lambda debug, verbose=0: orden.append("logging"))
     monkeypatch.setattr(cli, "configurar_entorno", lambda: orden.append("entorno"))
 
     class _DummyApp:
@@ -158,7 +158,7 @@ def test_main_reconfigura_consola_antes_de_logging_y_cli(monkeypatch):
 def test_main_devuelve_exit_code_1_si_falla_configuracion_entorno(monkeypatch, caplog):
     monkeypatch.setattr(cli, "configure_encoding", lambda: None)
     monkeypatch.setattr(cli, "_bootstrap_dev_path_si_opt_in", lambda: None)
-    monkeypatch.setattr(cli, "configure_logging", lambda debug: None)
+    monkeypatch.setattr(cli, "configure_logging", lambda debug, verbose=0: None)
     monkeypatch.setattr(
         cli,
         "configurar_entorno",

--- a/tests/unit/test_cli_logging_regression.py
+++ b/tests/unit/test_cli_logging_regression.py
@@ -9,7 +9,7 @@ from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
 
 def _run_interactive_and_capture_debug_traces(debug: bool) -> str:
     configure_logging(debug=debug)
-    cmd = InteractiveCommand(SimpleNamespace(ejecutar_ast=lambda ast: None))
+    cmd = InteractiveCommand(SimpleNamespace(ejecutar_ast=lambda ast: None, ejecutar_nodo=lambda nodo: None))
     cmd.procesar_ast = lambda codigo, validador=None: []  # type: ignore[assignment]
     buffer = StringIO()
     root_logger = logging.getLogger()
@@ -95,3 +95,42 @@ def test_configure_logging_pcobra_sin_handlers_locales_y_con_propagacion():
 
     assert app_logger.handlers == []
     assert app_logger.propagate is True
+
+
+def _capturar_mensajes_diagnosticos(*, debug: bool, verbose: int = 0) -> str:
+    configure_logging(debug=debug, verbose=verbose)
+    buffer = StringIO()
+    root_logger = logging.getLogger()
+    handler = root_logger.handlers[0]
+    original_stream = getattr(handler, "stream", None)
+    if hasattr(handler, "setStream"):
+        handler.setStream(buffer)
+    try:
+        logging.warning("Llamada a funcion: demo")
+        logging.warning("Usar modulo: demo")
+        logging.warning("USAR sanitize conflicts event module=demo count=1")
+    finally:
+        if original_stream is not None and hasattr(handler, "setStream"):
+            handler.setStream(original_stream)
+    return buffer.getvalue()
+
+
+def test_modo_normal_oculta_warnings_diagnosticos():
+    salida = _capturar_mensajes_diagnosticos(debug=False, verbose=0)
+    assert "Llamada a funcion: demo" not in salida
+    assert "Usar modulo: demo" not in salida
+    assert "USAR sanitize conflicts event module=demo" not in salida
+
+
+def test_modo_debug_muestra_warnings_diagnosticos():
+    salida = _capturar_mensajes_diagnosticos(debug=True, verbose=0)
+    assert "Llamada a funcion: demo" in salida
+    assert "Usar modulo: demo" in salida
+    assert "USAR sanitize conflicts event module=demo" in salida
+
+
+def test_modo_verbose_muestra_warnings_diagnosticos():
+    salida = _capturar_mensajes_diagnosticos(debug=False, verbose=1)
+    assert "Llamada a funcion: demo" in salida
+    assert "Usar modulo: demo" in salida
+    assert "USAR sanitize conflicts event module=demo" in salida


### PR DESCRIPTION
### Motivation
- Ocultar emisiones de diagnóstico internas como `Llamada a funcion: ...`, `Usar modulo: ...` y `USAR sanitize conflicts ...` en ejecución normal para evitar confundir al usuario final. 
- Permitir que esas trazas sigan siendo visibles para desarrolladores/operadores cuando se solicite explícitamente con `--debug` o niveles de `-v/--verbose`.
- Mantener visibles solo los errores funcionales para el usuario final y no alterar validaciones de seguridad ni el flujo de resolución de módulos. 

### Description
- Cambia la firma de `pcobra.cli.configure_logging` a `configure_logging(debug: bool, verbose: int = 0)` y calcula `modo_diagnostico = debug or verbose>0` para decidir el nivel de logging. 
- Ajusta el nivel raíz por defecto a `ERROR` (oculta `WARNING`/diagnósticos internos) y lo pone en `DEBUG` cuando `modo_diagnostico` está activo. 
- Extiende `pcobra.cli.main` para parsear `-v`/`--verbose` (y `--verbose=N`) y pasar `verbose` a `configure_logging`, además de respetar `--debug`. 
- Añade pruebas que verifican la aparición/ocultación de los warnings diagnósticos y adapta tests existentes para la nueva firma de `configure_logging`. 

### Testing
- Ejecuté `pytest -q tests/unit/test_cli_logging_regression.py tests/unit/test_cli_configurar_entorno.py` y ambos archivos de pruebas pasaron correctamente. 
- Resultado final de la ejecución de las pruebas solicitadas: tests completados con éxito (todas las aserciones pasaron, con una advertencia deprecación no relacionada).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f707bb88832786daa54777ec062e)