### PR TITLE
Unifica ruta segura de `usar` para run/REPL y cubre `existe` en run

### DIFF
--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -15,6 +15,7 @@ from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_source_for_tokenizer
 from pcobra.cobra.cli.utils.validators import normalizar_validadores_extra
 from pcobra.cobra.core.runtime import ValidadorBase, construir_cadena
+from pcobra.cobra.usar_policy import REPL_COBRA_MODULE_MAP
 from pcobra.core.usar_symbol_policy import (
     normalizar_metadata_simbolo_usar,
     validate_usar_symbol_metadata,
@@ -260,6 +261,12 @@ def construir_interprete_seguro_canonico(
         raise TypeError(
             "Invariante runtime violada: interpreter._validador._metadata_simbolos_usar debe ser dict."
         )
+
+    # Ruta única de resolución segura para `usar` en CLI (run/repl):
+    # solo alias/módulos canónicos del catálogo público.
+    configurar_restriccion = getattr(interpretador, "configurar_restriccion_usar_repl", None)
+    if callable(configurar_restriccion):
+        configurar_restriccion(REPL_COBRA_MODULE_MAP)
     return interpretador
 
 

--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -827,3 +827,52 @@ def test_run_error_lexico_sigue_siendo_corto_sin_traceback_con_y_sin_bom(tmp_pat
         salida = out_run.getvalue() + err_run.getvalue()
         assert "Traceback" not in salida
         assert salida.strip() != ""
+
+
+@pytest.mark.integration
+def test_run_usar_archivo_habilita_existe_readme_local(tmp_path, monkeypatch):
+    monkeypatch.setattr("pcobra.cobra.cli.services.run_service.limitar_cpu_segundos", lambda *_: None)
+    codigo = 'usar "archivo"\nimprimir(existe("README.md"))\n'
+    archivo = tmp_path / "programa.co"
+    archivo.write_text(codigo, encoding="utf-8")
+
+    out_run, err_run = StringIO(), StringIO()
+    with redirect_stdout(out_run), redirect_stderr(err_run):
+        rc_run = RunCommandV2().run(_run_args(str(archivo)))
+
+    assert rc_run == 0
+    assert err_run.getvalue() == ""
+    assert out_run.getvalue().strip().endswith("verdadero")
+
+
+@pytest.mark.integration
+def test_run_usar_archivo_existe_parent_es_falso_por_wrapper_seguro(tmp_path, monkeypatch):
+    monkeypatch.setattr("pcobra.cobra.cli.services.run_service.limitar_cpu_segundos", lambda *_: None)
+    codigo = 'usar "archivo"\nimprimir(existe("../README.md"))\n'
+    archivo = tmp_path / "programa.co"
+    archivo.write_text(codigo, encoding="utf-8")
+
+    out_run, err_run = StringIO(), StringIO()
+    with redirect_stdout(out_run), redirect_stderr(err_run):
+        rc_run = RunCommandV2().run(_run_args(str(archivo)))
+
+    assert rc_run == 0
+    assert err_run.getvalue() == ""
+    assert out_run.getvalue().strip().endswith("falso")
+
+
+@pytest.mark.integration
+def test_run_existe_sin_usar_archivo_permanece_bloqueado(tmp_path, monkeypatch):
+    monkeypatch.setattr("pcobra.cobra.cli.services.run_service.limitar_cpu_segundos", lambda *_: None)
+    codigo = 'imprimir(existe("README.md"))\n'
+    archivo = tmp_path / "programa.co"
+    archivo.write_text(codigo, encoding="utf-8")
+
+    out_run, err_run = StringIO(), StringIO()
+    with redirect_stdout(out_run), redirect_stderr(err_run):
+        rc_run = RunCommandV2().run(_run_args(str(archivo)))
+
+    assert rc_run == 1
+    salida = out_run.getvalue() + err_run.getvalue()
+    assert "existe" in salida.lower()
+    assert "traceback" not in salida.lower()


### PR DESCRIPTION
### Motivation
- Evitar divergencias entre la inicialización de contexto en REPL y la ruta usada por `cobra run` para resolver permisos de `usar`, garantizando una única fuente de verdad para los módulos/símbolos públicos permitidos.
- Mantener la validación global de primitivas peligrosas activa, permitiendo `existe` únicamente cuando fue introducida por `usar "archivo"` con metadata válida.

### Description
- En `src/pcobra/cobra/cli/execution_pipeline.py` se importa `REPL_COBRA_MODULE_MAP` y el factory canónico `construir_interprete_seguro_canonico` invoca `interpretador.configurar_restriccion_usar_repl(REPL_COBRA_MODULE_MAP)` cuando la API está disponible, unificando la restricción para `usar` entre `run` y REPL.
- No se cambió la lógica de validación de primitivas peligrosas; la comprobación sigue centralizada en los validadores (`ValidadorPrimitivaPeligrosa`) y la habilitación de `existe` sigue condicionada a la metadata registrada por `usar`.
- Se añadieron pruebas de integración en `tests/integration/test_run_repl_equivalence.py` que cubren los tres casos solicitados: `usar "archivo"` + `existe("README.md")` (permitido), `usar "archivo"` + `existe("../README.md")` (permitido pero devuelve `falso` por el wrapper seguro), y `existe("README.md")` sin `usar` (bloqueado con mensaje corto, sin traceback).

### Testing
- Ejecutado: `pytest -q tests/cli/test_repl_script_parity_contract.py -k 'usar_archivo or sin_usar_archivo_no_habilita_existe'` — Resultado: 2 passed, 17 deselected.
- Ejecutado: `pytest -q tests/integration/test_run_repl_equivalence.py -k 'usar_archivo_habilita_existe_readme_local or existe_parent_es_falso or existe_sin_usar_archivo_permanece_bloqueado'` — Resultado: 3 passed, 32 deselected.
- Las pruebas focalizadas de integración relacionadas con `usar`/`existe` pasaron y la validación de primitivas peligrosas se mantiene intacta en los flujos `run` y REPL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f867da7083278ee1020627b12508)