### PR TITLE
test: validate `cobra run` BOM/no-BOM output parity

### DIFF
--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -812,6 +812,30 @@ def test_run_acepta_utf8_bom_en_frontera_de_entrada(tmp_path, monkeypatch, con_b
 
 
 @pytest.mark.integration
+def test_run_utf8_bom_y_sin_bom_producen_salida_identica(tmp_path, monkeypatch):
+    monkeypatch.setattr("pcobra.cobra.cli.services.run_service.limitar_cpu_segundos", lambda *_: None)
+    script = 'imprimir("antes")\nvar x = 3\nimprimir("despues")\n'
+
+    archivo_sin_bom = tmp_path / "script_sin_bom.co"
+    archivo_con_bom = tmp_path / "script_con_bom.co"
+    archivo_sin_bom.write_text(script, encoding="utf-8")
+    archivo_con_bom.write_text("\ufeff" + script, encoding="utf-8")
+
+    salidas = []
+    for archivo in (archivo_sin_bom, archivo_con_bom):
+        out_run, err_run = StringIO(), StringIO()
+        with redirect_stdout(out_run), redirect_stderr(err_run):
+            rc_run = RunCommandV2().run(_run_args(str(archivo)))
+
+        assert rc_run == 0
+        assert err_run.getvalue() == ""
+        salidas.append(out_run.getvalue())
+
+    assert salidas[0] == salidas[1]
+    assert [ln.strip() for ln in salidas[0].splitlines() if ln.strip()] == ["antes", "despues"]
+
+
+@pytest.mark.integration
 def test_run_error_lexico_sigue_siendo_corto_sin_traceback_con_y_sin_bom(tmp_path, monkeypatch):
     monkeypatch.setattr("pcobra.cobra.cli.services.run_service.limitar_cpu_segundos", lambda *_: None)
 


### PR DESCRIPTION
### Motivation
- Asegurar que la normalización mínima de entrada (remover BOM UTF-8 inicial) se aplica en la capa de lectura antes de tokenizar/analizar, y que `cobra run` produce exactamente la misma salida para scripts equivalentes con y sin BOM.

### Description
- Añade una prueba de integración `test_run_utf8_bom_y_sin_bom_producen_salida_identica` en `tests/integration/test_run_repl_equivalence.py` que crea dos archivos (uno con BOM y otro sin BOM) y valida que la salida es idéntica y contiene las líneas esperadas `antes` y `despues`.
- Ubicación verificada de la normalización: en `RunService.run` el archivo se lee con `Path(...).read_text(encoding="utf-8")` y se pasa por `_normalizar_codigo_entrada`, que sólo elimina un `\ufeff` si está en la posición 0, sin tocar el lexer/parser/sintaxis pública.
- No se modificaron reglas del lexer, tokens ni parser en este cambio; el PR introduce cobertura de prueba para el comportamiento existente.

### Testing
- Ejecuté `pytest -q tests/cli/test_run_service_input_normalization.py tests/integration/test_run_repl_equivalence.py -k 'bom or traceback'` y la suite devolvió `8 passed, 32 deselected, 1 warning`, por lo que la nueva prueba y las pruebas de normalización existentes pasan correctamente.
- También ejecuté las pruebas unitarias de normalización en `tests/cli/test_run_service_input_normalization.py` y todas pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11fba69c6c8327958486c78547aa1d)