### PR TITLE
Enruta warnings operativos del pipeline al canal de debug/verbose

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -230,7 +230,7 @@ class InterpretadorCobra:
             payload["hash_corto"] = hash_corto
         if fase:
             payload["fase"] = fase
-        logging.warning("Auditoria validador extra: %s", payload)
+        logging.debug("Auditoria validador extra: %s", payload)
 
     @staticmethod
     def _cargar_validadores(ruta):


### PR DESCRIPTION
### Motivation
- Reducir el ruido en modo normal moviendo mensajes operativos de auditoría internos a la capa de diagnóstico para que solo sean visibles con `--debug`/`-v` y conservar la visibilidad de errores relevantes para el usuario final.

### Description
- Cambia `logging.warning` a `logging.debug` en `InterpretadorCobra._registrar_auditoria_validador` (`src/pcobra/core/interpreter.py`) para que el evento de auditoría `validador_extra` se emita solo en modo debug/verbose.

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_logging_regression.py` y todos los tests automáticos relacionados pasaron (8 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11fcb9045c83279c02e447638c4b36)