### PR TITLE
Agregar checklist pre-merge y pruebas negativas para seguridad de `usar`

### DIFF
--- a/docs_checklist_pre_merge_bug001.md
+++ b/docs_checklist_pre_merge_bug001.md
@@ -1,0 +1,17 @@
+# Checklist de revisión previa a merge (foco seguridad `usar` + BUG-001)
+
+## Alcance
+- Revisar únicamente rutas de `cobra run` y carga de fuente (`usar`/resolución de módulos), evitando tocar pipeline ajeno al flujo estabilizado de BUG-001.
+
+## Controles obligatorios
+- [ ] **No se habilitan imports externos directos**: confirmar que `validar_nombre_modulo_usar` sigue rechazando alias externos (p.ej. `numpy`, `node-fetch`, `serde`, SDKs).
+- [ ] **No se exponen símbolos no públicos**: verificar que en la superficie `usar` no aparecen `os`, `pathlib`, SDKs backend ni símbolos privados (`_`/`__`).
+- [ ] **Se mantiene rechazo de módulos fuera del catálogo público**: validar error de permiso para módulos no mapeados en catálogo oficial.
+- [ ] **Se mantiene validación global de primitivas peligrosas**: confirmar que llamadas peligrosas sin habilitación explícita por `usar` siguen bloqueadas por el validador semántico.
+- [ ] **No hay traceback en errores de usuario**: validar que el mensaje final sea controlado (tipo `PermissionError`/mensaje de dominio) y no fuga stacktrace interno.
+
+## Evidencia mínima recomendada
+- [ ] Ejecutar pruebas negativas específicas:
+  - módulo no público vía `usar`;
+  - primitiva peligrosa sin `usar` autorizado.
+- [ ] Ejecutar pruebas de regresión acotadas a `cobra run`/carga de fuente para garantizar ausencia de efectos colaterales en BUG-001.

--- a/tests/unit/test_semantic_validator.py
+++ b/tests/unit/test_semantic_validator.py
@@ -40,3 +40,17 @@ def test_import_no_permitido():
     with pytest.raises(PrimitivaPeligrosaError):
         for nodo in ast:
             nodo.aceptar(validador)
+
+
+def test_primitiva_peligrosa_sin_usar_autorizado_rechazada():
+    codigo = "imprimir(leer_archivo('README.md'))"
+    ast = generar_ast(codigo)
+    validador = construir_cadena()
+
+    with pytest.raises(PrimitivaPeligrosaError) as excinfo:
+        for nodo in ast:
+            nodo.aceptar(validador)
+
+    mensaje = str(excinfo.value)
+    assert "Traceback" not in mensaje
+    assert "leer_archivo" in mensaje or "Primitiva peligrosa" in mensaje

--- a/tests/unit/test_usar_loader_validation.py
+++ b/tests/unit/test_usar_loader_validation.py
@@ -54,3 +54,12 @@ def test_fuera_de_catalogo_no_llega_a_resolucion_de_modulo(monkeypatch):
         usar_loader.obtener_modulo("numpy")
 
     assert "fuera del catálogo público" in str(excinfo.value) or "Importación no permitida" in str(excinfo.value)
+
+
+def test_modulo_no_publico_error_controlado_sin_traceback():
+    with pytest.raises(PermissionError) as excinfo:
+        validar_nombre_modulo_usar("modulo_interno_privado")
+
+    mensaje = str(excinfo.value)
+    assert "fuera del catálogo público" in mensaje or "módulo externo no permitido" in mensaje
+    assert "Traceback" not in mensaje


### PR DESCRIPTION
### Motivation
- Asegurar la política de carga `usar` frente a imports externos y primitivas peligrosas sin autorizar, y evitar regresiones en BUG-001 al validar cambios limitados a rutas de carga de fuente. 
- Evitar fugas de traceback y exposición de símbolos privados/backend en la superficie pública `usar` para mejorar mensajes al usuario.

### Description
- Añade `docs_checklist_pre_merge_bug001.md` con una checklist operativa para revisar imports externos, exposición de símbolos privados/backend, rechazo de módulos fuera del catálogo público, validación de primitivas peligrosas y ausencia de traceback visible. 
- Añade el test negativo `test_modulo_no_publico_error_controlado_sin_traceback` en `tests/unit/test_usar_loader_validation.py` para validar rechazo controlado de módulos no públicos y ausencia de `Traceback` en el mensaje. 
- Añade el test negativo `test_primitiva_peligrosa_sin_usar_autorizado_rechazada` en `tests/unit/test_semantic_validator.py` para validar bloqueo de primitivas peligrosas sin `usar` y ausencia de `Traceback` en el mensaje. 
- No se modificó código de runtime productivo; los cambios son documentación y tests centrados en la superficie de `usar` y la cadena de validadores semánticos.

### Testing
- Ejecutado `pytest -q tests/unit/test_usar_loader_validation.py` y obtuvo `6 passed` con 1 warning, lo que valida la nueva prueba de módulo no público. 
- Ejecutado `pytest -q tests/unit/test_usar_loader_validation.py tests/unit/test_semantic_validator.py tests/integration/test_usar_runtime_contract.py -k "modulo_fuera_catalogo or fuera_catalogo or primitiva_peligrosa or import_no_permitido"` y obtuvo `3 passed, 28 deselected` con 1 warning, lo que confirma las comprobaciones negativas relevantes. 
- Intento de ejecutar `pytest -q tests/unit/test_usar_loader_validation.py tests/unit/test_safe_mode.py` falló en la fase de colección por un `ImportError: attempted relative import beyond top-level package` en `tests/unit/test_safe_mode.py`, que es un fallo de importación preexistente no introducido por estos cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11fe811d088327ac46944a17c8df61)