### PR TITLE
Use importlib.resources to locate standard_library/corelibs __init__.py

### DIFF
--- a/src/pcobra/cobra/transpilers/runtime_api_matrix.py
+++ b/src/pcobra/cobra/transpilers/runtime_api_matrix.py
@@ -13,15 +13,14 @@ consumible desde ``compatibility_matrix.py`` y scripts de documentación.
 
 from dataclasses import dataclass
 import ast
+from importlib import resources
+from importlib.resources.abc import Traversable
 import json
 from pathlib import Path
 from typing import Final
 
 from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
 
-REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[4]
-STANDARD_LIBRARY_INIT: Final[Path] = REPO_ROOT / "src/pcobra/standard_library/__init__.py"
-CORELIBS_INIT: Final[Path] = REPO_ROOT / "src/pcobra/corelibs/__init__.py"
 SNAPSHOT_PATH: Final[Path] = Path(__file__).resolve().with_name("runtime_api_parity_snapshot.json")
 
 
@@ -35,7 +34,21 @@ class RuntimeApiExportSets:
         return tuple(sorted(set(self.standard_library) | set(self.corelibs)))
 
 
-def _read_all_exports(path: Path) -> tuple[str, ...]:
+def _resolve_package_init(package: str) -> Traversable:
+    init_path = resources.files(package).joinpath("__init__.py")
+    if not init_path.is_file():
+        raise RuntimeError(
+            f"No se pudo resolver {package}.__init__.py para matriz runtime: "
+            f"ruta obtenida '{init_path}' no es un archivo válido."
+        )
+    return init_path
+
+
+STANDARD_LIBRARY_INIT: Final[Traversable] = _resolve_package_init("pcobra.standard_library")
+CORELIBS_INIT: Final[Traversable] = _resolve_package_init("pcobra.corelibs")
+
+
+def _read_all_exports(path: Path | Traversable) -> tuple[str, ...]:
     source = path.read_text(encoding="utf-8")
     module = ast.parse(source, filename=str(path))
     for node in module.body:


### PR DESCRIPTION
### Motivation
- El código resolvía rutas hardcodeadas a `src/pcobra/...` para obtener los `__init__.py` de las librerías estándar y `corelibs`, lo que hace frágil la resolución de recursos cuando el paquete no está en la estructura de fuentes esperada. 
- Se desea una resolución basada en paquetes que falle explícitamente en lugar de ocultar errores reales de matriz.

### Description
- Reemplazado el cálculo hardcodeado de rutas por `importlib.resources.files(...).joinpath("__init__.py")` mediante la nueva función `_resolve_package_init(...)` que valida que el recurso sea un archivo real. 
- Declaradas `STANDARD_LIBRARY_INIT` y `CORELIBS_INIT` como `Traversable` resuelto por `_resolve_package_init(...)` usando `pcobra.standard_library` y `pcobra.corelibs`. 
- Adaptado `_read_all_exports(...)` para aceptar `Path | Traversable` sin cambiar su contrato público y conservando la lectura en `utf-8` tal como antes. 
- Se mantiene el comportamiento de parseo existente y se asegura que, ante fallo de resolución, se lance un `RuntimeError` con mensaje útil (sin fallback silencioso). 

### Testing
- Ejecuté la extracción directa con `from pcobra.cobra.transpilers.runtime_api_matrix import extract_runtime_export_sets` y la invocación de prueba imprimió conteos de símbolos, confirmando que la resolución y parseo funcionan (smoke test OK). 
- Corrí `pytest -q tests/integration/transpilers/test_library_compatibility_matrix.py` y se reportaron 3 fallos por discrepancia entre `LIBRARY_COMPATIBILITY` y `OFFICIAL_TARGETS`, que parecen previos y no relacionados con la resolución de recursos; esos tests fallaron. 
- No se silenciaron errores y la nueva validación produce errores explícitos si no se puede resolver `__init__.py` del paquete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a127a948a908327abc788e4dc39d205)