### PR TITLE
Refactor runtime API matrix to resolve pcobra modules via package resources

### DIFF
--- a/src/pcobra/cobra/transpilers/runtime_api_matrix.py
+++ b/src/pcobra/cobra/transpilers/runtime_api_matrix.py
@@ -13,15 +13,15 @@ consumible desde ``compatibility_matrix.py`` y scripts de documentación.
 
 from dataclasses import dataclass
 import ast
+from importlib.resources import files
 import json
 from pathlib import Path
 from typing import Final
 
 from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
 
-REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[4]
-STANDARD_LIBRARY_INIT: Final[Path] = REPO_ROOT / "src/pcobra/standard_library/__init__.py"
-CORELIBS_INIT: Final[Path] = REPO_ROOT / "src/pcobra/corelibs/__init__.py"
+STANDARD_LIBRARY_INIT: Final[Path] = Path(str(files("pcobra.standard_library").joinpath("__init__.py")))
+CORELIBS_INIT: Final[Path] = Path(str(files("pcobra.corelibs").joinpath("__init__.py")))
 SNAPSHOT_PATH: Final[Path] = Path(__file__).resolve().with_name("runtime_api_parity_snapshot.json")
 
 


### PR DESCRIPTION
### Motivation
- Evitar rutas frágiles basadas en `Path(__file__)` + ascensos al root y en cadenas que asumen `src/pcobra`, resolviendo en su lugar los archivos de paquete para `pcobra.standard_library` y `pcobra.corelibs` sin alterar el comportamiento en instalación editable ni la lógica de paridad.

### Description
- Se importó `files` desde `importlib.resources` y se reemplazaron las construcciones que usaban `REPO_ROOT / "src/pcobra/..."` por `Path(str(files("pcobra.standard_library").joinpath("__init__.py")))` y equivalente para `pcobra.corelibs`, manteniendo `SNAPSHOT_PATH` y toda la lógica de lectura/validación sin cambios.

### Testing
- Se compiló el módulo con `python -m compileall src/pcobra/cobra/transpilers/runtime_api_matrix.py` y se ejecutó un smoke test con `from pcobra.cobra.transpilers.runtime_api_matrix import extract_runtime_export_sets` para verificar que la extracción de exports funciona; ambas acciones completaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1284c0241083279c1496a7fd7dc590)