### PR TITLE
docs: añadir evidencia de verificación de wheel (2026-05-24)

### DIFF
--- a/reports/release_evidence_2026-05-24.md
+++ b/reports/release_evidence_2026-05-24.md
@@ -1,0 +1,13 @@
+# Evidencia de verificación de wheel (2026-05-24)
+
+## Comandos ejecutados
+1. `python -m build --wheel`
+2. `python -m venv .venv-release-test`
+3. `pip install dist/pcobra-10.1.1-py3-none-any.whl`
+4. `cobra --version`
+5. `python -c "from pcobra.cobra.transpilers.runtime_api_matrix import build_runtime_api_matrix; print(type(build_runtime_api_matrix()).__name__)"`
+
+## Resultados clave
+- Wheel construida: `dist/pcobra-10.1.1-py3-none-any.whl`.
+- `cobra --version`: **falló** con `RuntimeError` de contrato startup (módulo canónico `numero` faltante en ruta `src/pcobra/corelibs/numero.py`).
+- `build_runtime_api_matrix()`: salida `dict`.


### PR DESCRIPTION
### Motivation
- Capturar evidencia reproducible de la verificación de la release local (construcción de wheel, instalación en venv limpio y comprobaciones de inicio/runtime) para adjuntar al PR.

### Description
- Añade `reports/release_evidence_2026-05-24.md` con los comandos ejecutados y los resultados clave; también se construyó `dist/pcobra-10.1.1-py3-none-any.whl` y el archivo fue commiteado.

### Testing
- Se ejecutaron automáticamente `python -m build --wheel` (wheel construida: `dist/pcobra-10.1.1-py3-none-any.whl`), creación de venv e instalación del wheel (ok), `cobra --version` (falló con `RuntimeError` por falta de módulo canónico `numero` en `src/pcobra/corelibs/numero.py`), y `python -c "from pcobra.cobra.transpilers.runtime_api_matrix import build_runtime_api_matrix; print(type(build_runtime_api_matrix()).__name__)"` (salida: `dict`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1295ee12ec8327816aa26a4b3d2dcb)