### PR TITLE
[BLOCKER 10.1.1] Fix carga de snapshot de paridad runtime desde recursos de paquete

### DIFF
--- a/src/pcobra/cobra/transpilers/runtime_api_matrix.py
+++ b/src/pcobra/cobra/transpilers/runtime_api_matrix.py
@@ -22,7 +22,7 @@ from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
 
 STANDARD_LIBRARY_INIT: Final[Path] = Path(str(files("pcobra.standard_library").joinpath("__init__.py")))
 CORELIBS_INIT: Final[Path] = Path(str(files("pcobra.corelibs").joinpath("__init__.py")))
-SNAPSHOT_PATH: Final[Path] = Path(__file__).resolve().with_name("runtime_api_parity_snapshot.json")
+SNAPSHOT_PATH: Final[Path] = Path(str(files("pcobra.cobra.transpilers").joinpath("runtime_api_parity_snapshot.json")))
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
### Motivation
- Se detectó que en `src/pcobra/cobra/transpilers/runtime_api_matrix.py` la ruta del snapshot se resolvía con `__file__.resolve().with_name(...)`, lo cual depende del layout `src/...` y puede fallar en instalaciones como wheel; este PR es bloqueante de `10.1.1`.

### Description
- Se reemplazó la resolución de `SNAPSHOT_PATH` por `importlib.resources.files("pcobra.cobra.transpilers").joinpath("runtime_api_parity_snapshot.json")`, limitando el diff a `src/pcobra/cobra/transpilers/runtime_api_matrix.py` y sin modificar Lexer/Parser, la sintaxis pública, la política de seguridad de imports ni los validadores.

### Testing
- Se ejecutó la validación mínima con `python - <<'PY'\nfrom pcobra.cobra.transpilers.runtime_api_matrix import build_runtime_api_matrix\nm = build_runtime_api_matrix()\nprint(sorted(m.keys()))\nPY` y la llamada a `build_runtime_api_matrix()` devolvió la estructura esperada (`available_api_by_backend`, `global_api`, `missing_api_by_backend`), por lo que la prueba automatizada local pasó.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12a3573cd88327a0370c91adb17d88)