### PR TITLE
Restaurar validación de procedencia canónica para `archivo.existe`

### DIFF
--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -12,6 +12,8 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
     """Validador que detecta llamadas a primitivas peligrosas."""
 
     WRAPPERS_PYTHON_MODULES_PERMITIDOS = frozenset({
+        "archivo",
+        "pcobra.corelibs.archivo",
         "pcobra.standard_library.archivo",
         "cobra.standard_library.archivo",
     })
@@ -49,7 +51,7 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
 
     def _es_wrapper_publico_permitido(self, nodo: NodoLlamadaFuncion) -> bool:
         # Único escape permitido para primitivas peligrosas:
-        # usar archivo.existe con metadata de sanitización de API pública.
+        # usar archivo.existe con metadata canónica de sanitización de API pública.
         if nodo.nombre != "existe":
             return False
         if ("archivo", "existe") not in self._simbolos_publicos_usar:
@@ -60,11 +62,29 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
 
         if metadata.get("module") != "archivo":
             return False
+        if metadata.get("origen_modulo") != "archivo":
+            return False
+        if metadata.get("origin_module") != "archivo":
+            return False
+        if metadata.get("canonical_module") != "archivo":
+            return False
+        if metadata.get("python_module") not in self.WRAPPERS_PYTHON_MODULES_PERMITIDOS:
+            return False
+        if metadata.get("origen_tipo") != "public_wrapper":
+            return False
         if metadata.get("exported_name") != "existe":
+            return False
+        if metadata.get("introduced_by") != "usar":
+            return False
+        if metadata.get("introduced_by_usar") is not True:
+            return False
+        if metadata.get("is_public_export") is not True:
+            return False
+        if metadata.get("public_api") is not True:
             return False
         if metadata.get("is_sanitized_wrapper") is not True:
             return False
-        if metadata.get("public_api") is not True:
+        if metadata.get("safe_wrapper") is not True:
             return False
         return True
 

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -91,6 +91,8 @@ def test_metadata_usar_archivo_existe_cadena_completa():
     assert metadata["introduced_by"] == "usar"
     assert metadata["introduced_by_usar"] is True
     assert metadata["python_module"] in {
+        "archivo",
+        "pcobra.corelibs.archivo",
         "pcobra.standard_library.archivo",
         "cobra.standard_library.archivo",
     }
@@ -155,6 +157,58 @@ def test_existe_rechaza_metadata_incompleta_aunque_simbolo_este_registrado():
 
     # Simula bypass: símbolo registrado pero metadata incompleta/no canónica.
     interp._validador._metadata_simbolos_usar["existe"].pop("origen_modulo", None)
+    ast_llamada = generar_ast('imprimir(existe("README.md"))')
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast_llamada)
+
+
+def test_existe_rechaza_metadata_sin_introduced_by_usar():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')
+
+    with patch("sys.stdout", new_callable=StringIO):
+        interp.ejecutar_ast(ast)
+
+    interp._validador._metadata_simbolos_usar["existe"].pop("introduced_by_usar", None)
+    ast_llamada = generar_ast('imprimir(existe("README.md"))')
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast_llamada)
+
+
+def test_existe_rechaza_metadata_con_origen_tipo_distinto():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')
+
+    with patch("sys.stdout", new_callable=StringIO):
+        interp.ejecutar_ast(ast)
+
+    interp._validador._metadata_simbolos_usar["existe"]["origen_tipo"] = "backend"
+    ast_llamada = generar_ast('imprimir(existe("README.md"))')
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast_llamada)
+
+
+def test_existe_rechaza_metadata_con_canonical_module_distinto():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')
+
+    with patch("sys.stdout", new_callable=StringIO):
+        interp.ejecutar_ast(ast)
+
+    interp._validador._metadata_simbolos_usar["existe"]["canonical_module"] = "io"
+    ast_llamada = generar_ast('imprimir(existe("README.md"))')
+    with pytest.raises(PrimitivaPeligrosaError):
+        interp.ejecutar_ast(ast_llamada)
+
+
+def test_existe_rechaza_metadata_con_python_module_no_permitido():
+    interp = InterpretadorCobra()
+    ast = generar_ast('usar "archivo"\nimprimir(existe("README.md"))')
+
+    with patch("sys.stdout", new_callable=StringIO):
+        interp.ejecutar_ast(ast)
+
+    interp._validador._metadata_simbolos_usar["existe"]["python_module"] = "modulo.no.permitido"
     ast_llamada = generar_ast('imprimir(existe("README.md"))')
     with pytest.raises(PrimitivaPeligrosaError):
         interp.ejecutar_ast(ast_llamada)


### PR DESCRIPTION
### Motivation
- Evitar que metadata parcial o forjada permita tratar una función como el wrapper público seguro `archivo.existe`, preservando la política de safe-mode para primitivas peligrosas. 
- Reforzar las comprobaciones de procedencia y backend para que solo el wrapper público canónico sea aceptado.

### Description
- Reintroduce comprobaciones estrictas en `_es_wrapper_publico_permitido` en `src/pcobra/core/semantic_validators/primitiva_peligrosa.py` para exigir explícitamente `module == "archivo"`, `origen_modulo == "archivo"`, `origin_module == "archivo"`, `canonical_module == "archivo"`, `origen_tipo == "public_wrapper"`, `exported_name == "existe"`, `introduced_by == "usar"`, `introduced_by_usar is True`, `is_public_export is True`, `public_api is True`, `is_sanitized_wrapper is True` y `safe_wrapper is True` antes de autorizar la llamada. 
- Amplía la lista `WRAPPERS_PYTHON_MODULES_PERMITIDOS` para incluir los nombres de módulo runtime relevantes (`"archivo"`, `"pcobra.corelibs.archivo"`, además de las entradas previas) y valida `python_module` contra esa lista. 
- Añade pruebas de regresión en `tests/unit/test_safe_mode.py` que verifican que modificaciones en la metadata (`introduced_by_usar`, `origen_tipo`, `canonical_module`, `python_module`, entre otras) impiden la autorización del wrapper.

### Testing
- Ejecuté `python -m py_compile src/pcobra/core/semantic_validators/primitiva_peligrosa.py tests/unit/test_safe_mode.py` y la compilación estática de los archivos modificados fue satisfactoria. 
- Ejecuté un script de comprobación manual del validador que registra un símbolo con metadata canónica y verifica que `ValidadorPrimitivaPeligrosa._es_wrapper_publico_permitido` acepta la metadata canónica y rechaza variantes con `introduced_by_usar`, `origen_tipo`, `canonical_module` o `python_module` alterados, y ese script pasó. 
- Añadí tests unitarios nuevos en `tests/unit/test_safe_mode.py`; al intentar ejecutar `pytest -q tests/unit/test_safe_mode.py` la colección falló por un problema de entorno/import (`ImportError: attempted relative import beyond top-level package`) que ya existía fuera de estos cambios y evita la ejecución automática de las nuevas pruebas en este entorno CI local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d25fefa00832783c4720866b2693a)