### PR TITLE
Bloquea bypass de `existe` en llamadas de método

### DIFF
--- a/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
+++ b/src/pcobra/core/semantic_validators/primitiva_peligrosa.py
@@ -47,9 +47,15 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
         if metadata:
             self._metadata_simbolos_usar[nombre] = dict(metadata)
 
-    def _es_wrapper_publico_permitido(self, nodo: NodoLlamadaFuncion) -> bool:
+    def _es_wrapper_publico_permitido(
+        self, nodo: NodoLlamadaFuncion | NodoLlamadaMetodo
+    ) -> bool:
         # Único escape permitido para primitivas peligrosas:
         # usar archivo.existe con metadata de sanitización de API pública.
+        # Las llamadas de método no son la ruta canónica de `usar` y deben
+        # fallar esta compuerta aunque el método se llame `existe`.
+        if not isinstance(nodo, NodoLlamadaFuncion):
+            return False
         if nodo.nombre != "existe":
             return False
         if ("archivo", "existe") not in self._simbolos_publicos_usar:
@@ -70,7 +76,10 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
 
     def visit_llamada_funcion(self, nodo: NodoLlamadaFuncion):
         # Contrato: permitido solo si metadata canónica de usar+sanitización API pública.
-        if nodo.nombre in self.PRIMITIVAS_PELIGROSAS and not self._es_wrapper_publico_permitido(nodo):
+        if (
+            nodo.nombre in self.PRIMITIVAS_PELIGROSAS
+            and not self._es_wrapper_publico_permitido(nodo)
+        ):
             raise PrimitivaPeligrosaError(
                 f"Uso de primitiva peligrosa: '{nodo.nombre}'"
             )
@@ -87,7 +96,10 @@ class ValidadorPrimitivaPeligrosa(ValidadorBase):
         nodo.llamada.aceptar(self)
 
     def visit_llamada_metodo(self, nodo: NodoLlamadaMetodo):
-        if nodo.nombre_metodo in self.PRIMITIVAS_PELIGROSAS and nodo.nombre_metodo != "existe":
+        if (
+            nodo.nombre_metodo in self.PRIMITIVAS_PELIGROSAS
+            and not self._es_wrapper_publico_permitido(nodo)
+        ):
             raise PrimitivaPeligrosaError(
                 f"Uso de primitiva peligrosa: '{nodo.nombre_metodo}'"
             )

--- a/tests/unit/test_primitiva_peligrosa_validator.py
+++ b/tests/unit/test_primitiva_peligrosa_validator.py
@@ -1,0 +1,29 @@
+import pytest
+
+from pcobra.core.ast_nodes import NodoIdentificador, NodoLlamadaMetodo, NodoValor
+from pcobra.core.semantic_validators import (
+    PrimitivaPeligrosaError,
+    ValidadorPrimitivaPeligrosa,
+)
+
+
+def test_existe_como_llamada_metodo_no_usa_escape_de_wrapper_publico():
+    validador = ValidadorPrimitivaPeligrosa()
+    validador.registrar_simbolo_publico_usar(
+        "existe",
+        "archivo",
+        metadata={
+            "module": "archivo",
+            "exported_name": "existe",
+            "is_sanitized_wrapper": True,
+            "public_api": True,
+        },
+    )
+    llamada = NodoLlamadaMetodo(
+        NodoIdentificador("archivo"),
+        "existe",
+        [NodoValor("README.md")],
+    )
+
+    with pytest.raises(PrimitivaPeligrosaError):
+        llamada.aceptar(validador)


### PR DESCRIPTION
### Motivation
- Evitar bypass donde `obj.existe(...)` (nodo `NodoLlamadaMetodo`) elude la comprobación de wrapper público saneado y permite el uso de la primitiva `existe` fuera de la ruta canónica `usar "archivo"`.
- Asegurar que solo la llamada de función canónica validada por metadata de `usar` (`is_sanitized_wrapper` / `public_api`) quede exenta.

### Description
- Cambia la firma de `_es_wrapper_publico_permitido` para aceptar `NodoLlamadaFuncion | NodoLlamadaMetodo` y hace que devuelva `False` para nodos que no sean `NodoLlamadaFuncion`, de modo que llamadas de método no puedan satisfacer la compuerta.
- Ajusta `visit_llamada_metodo` para aplicar la misma verificación de wrapper y deja de tratar `existe` como una excepción especial por la vía de método; el mensaje de error sigue siendo `Uso de primitiva peligrosa: '<nombre>'`.
- Añade un test de regresión `tests/unit/test_primitiva_peligrosa_validator.py` que registra metadata legítima de `usar "archivo"` y verifica que un `NodoLlamadaMetodo(..., "existe", ...)` siga siendo bloqueado.

### Testing
- Ejecutado `pytest -q tests/unit/test_primitiva_peligrosa_validator.py`, que pasó (1 test, 1 passed).
- Verificado con `python -m py_compile src/pcobra/core/semantic_validators/primitiva_peligrosa.py tests/unit/test_primitiva_peligrosa_validator.py` sin errores de sintaxis.
- Intentos de ejecutar la batería más amplia (`tests/unit/test_safe_mode.py` / suite completa) quedaron interrumpidos por un error de importación en el entorno de colección (`attempted relative import beyond top-level package`), ajeno a esta corrección.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d29b7a4d08327bf2b6e95f794c801)