### PR TITLE
Aisla permisos `usar` entre sesiones REPL

### DIFF
--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -155,7 +155,16 @@ def validar_ast_seguro(
             raise TypeError(
                 _("Los validadores extra deben ser una lista de instancias de validadores")
             )
-    validador = construir_cadena_fn(validadores_extra)
+    # Cuando hay un intérprete de sesión, la hidratación con metadatos de
+    # ``usar`` debe quedar confinada a esa sesión.  ``construir_cadena``
+    # reutiliza un singleton cuando ``validadores_extra is None``; registrar
+    # símbolos sobre esa cadena compartida filtraría permisos entre REPLs vivos.
+    validadores_para_cadena = (
+        []
+        if interpretador is not None and validadores_extra is None
+        else validadores_extra
+    )
+    validador = construir_cadena_fn(validadores_para_cadena)
     if interpretador is not None:
         metadata_usar = getattr(interpretador, "_usar_symbol_metadata", {}) or {}
         validadores_registrables = []
@@ -167,11 +176,19 @@ def validar_ast_seguro(
         for nombre, metadata in metadata_usar.items():
             if not isinstance(metadata, dict):
                 continue
-            modulo = metadata.get("module") or metadata.get("canonical_module") or metadata.get("origin_module")
+            modulo = (
+                metadata.get("module")
+                or metadata.get("canonical_module")
+                or metadata.get("origin_module")
+            )
             if not isinstance(modulo, str):
                 continue
             for validador_registrable in validadores_registrables:
-                validador_registrable.registrar_simbolo_publico_usar(nombre, modulo, metadata=dict(metadata))
+                validador_registrable.registrar_simbolo_publico_usar(
+                    nombre,
+                    modulo,
+                    metadata=dict(metadata),
+                )
     for nodo in ast:
         nodo.aceptar(validador)
 

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -480,8 +480,14 @@ class InterpretadorCobra:
         # Regla de fases: analysis = sin efectos, execution = con efectos.
         # Por defecto iniciamos en ejecución para preservar compatibilidad fuera del REPL.
         self.mode = "execution"
+        # Cada intérprete mantiene estado propio de permisos introducidos por
+        # ``usar``. Evitamos el singleton de ``construir_cadena(None)`` para que
+        # un REPL no herede wrappers públicos registrados por otra sesión viva.
+        validadores_cadena = [] if extra is None else extra
         self._validador = (
-            construir_cadena(extra, emitir_side_effects=True) if safe_mode else None
+            construir_cadena(validadores_cadena, emitir_side_effects=True)
+            if safe_mode
+            else None
         )
         # Analizador semántico persistente para mantener contexto entre ejecuciones
         self.analizador = AnalizadorSemantico()

--- a/tests/integration/test_repl_usar_entrypoints_contract.py
+++ b/tests/integration/test_repl_usar_entrypoints_contract.py
@@ -864,6 +864,17 @@ def test_repl_archivo_invocacion_cruda_sin_usar_permanece_bloqueada():
     with pytest.raises(Exception, match='Uso de primitiva peligrosa'):
         cmd._ejecutar_en_modo_normal('imprimir(existe("README.md"))')
 
+
+def test_repl_archivo_permisos_usar_no_se_filtran_entre_sesiones():
+    cmd_con_usar = ReplCommandV2()
+    cmd_sin_usar = ReplCommandV2()
+
+    cmd_con_usar._ejecutar_en_modo_normal('usar "archivo"')
+
+    with pytest.raises(Exception, match='Uso de primitiva peligrosa'):
+        cmd_sin_usar._ejecutar_en_modo_normal('imprimir(existe("README.md"))')
+
+
 def test_repl_archivo_invocacion_directa_permitida_tras_usar_sin_traceback(capsys):
     cmd = ReplCommandV2()
     cmd._ejecutar_en_modo_normal('usar "archivo"')


### PR DESCRIPTION
### Motivation

- Evitar que metadatos introducidos por `usar` en una sesión REPL registren wrappers públicos sobre la cadena singleton de validadores y así filtrar permisos a otras sesiones vivas. 
- Mantener el contrato de seguridad por sesión: una sesión que no ejecutó `usar "archivo"` debe seguir bloqueando la primitiva `existe(...)` como peligrosa. 

### Description

- Ajusta `validar_ast_seguro` para construir la cadena de validadores con `validadores_para_cadena = []` cuando hay un `interpretador` de sesión y `validadores_extra is None`, evitando hidratar la cadena singleton compartida; la lógica de registro de `interpretador._usar_symbol_metadata` se mantiene pero sobre la cadena aislada (`src/pcobra/cobra/cli/execution_pipeline.py`).
- Cambia la inicialización de `InterpretadorCobra` para crear su propia cadena de ejecución cuando `extra` es `None` usando `validadores_cadena = [] if extra is None else extra`, de modo que registros de `usar` queden confinados a la instancia del intérprete (`src/pcobra/core/interpreter.py`).
- Añade una regresión que verifica que permisos `usar` no se filtran entre sesiones creando dos `ReplCommandV2` y comprobando que la sesión que no ejecutó `usar` sigue fallando en `imprimir(existe(...))` con `PrimitivaPeligrosa` (`tests/integration/test_repl_usar_entrypoints_contract.py`).

### Testing

- Ejecuté `python -m py_compile src/pcobra/cobra/cli/execution_pipeline.py src/pcobra/core/interpreter.py` y la verificación de bytecode pasó sin errores. 
- Ejecuté los tests seleccionados con `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py -k 'archivo_invocacion_cruda_sin_usar or archivo_permisos_usar_no_se_filtran or archivo_invocacion_directa_permitida_tras_usar'` y los casos relevantes pasaron (`3 passed`).
- Ejecuté la batería completa `pytest -q tests/integration/test_repl_usar_entrypoints_contract.py` y observé 5 fallos que no están relacionados con el aislamiento de `usar` (fallos sobre `tiempo.ahora` que devuelve un `datetime` en lugar del stub esperado, discrepancia en el texto de error de `holobit`, y expectativas sobre símbolos `api_publica` para `archivo`/`asincrono`), por lo que esos problemas requieren seguimiento independiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d2baf83b48327b44e1923b9a26547)