### PR TITLE
test: assert usar syntax error at parse time

### DIFF
--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -5,8 +5,7 @@ import pytest
 
 import pcobra  # garantiza rutas para submódulos
 from cobra.cli.cli import CliApplication
-from cobra.core import Lexer
-from cobra.core import Parser
+from cobra.core import Lexer, Parser, ParserError
 from core.ast_nodes import NodoLlamadaFuncion, NodoValor
 from core.interpreter import InterpretadorCobra
 from core.semantic_validators import PrimitivaPeligrosaError
@@ -103,11 +102,10 @@ def test_usar_archivo_existe_readme_no_falla_por_metadata():
 
 
 def test_sintaxis_usar_sin_cadena_rechaza_con_error_claro():
-    interp = InterpretadorCobra()
-    ast = generar_ast('usar archivo')
+    with pytest.raises(ParserError, match=r"(cadena|string|literal|comillas)"):
+        generar_ast('usar archivo')
 
-    with pytest.raises(Exception, match=r"(cadena|string|literal)"):
-        interp.ejecutar_ast(ast)
+
 def test_usar_datos_longitud_builtin_permanece_en_3():
     interp = InterpretadorCobra()
     ast = generar_ast('usar "datos"\nvar xs = [1, 2, 3]\nimprimir(longitud(xs))\nimprimir(longitud([1,2,3]))')


### PR DESCRIPTION
### Motivation
- Asegurar que la prueba que verifica la sintaxis inválida `usar archivo` capture el error en el momento de parseo y pueda afirmar el tipo y mensaje del error.

### Description
- En `tests/unit/test_safe_mode.py` se importó `ParserError` desde `cobra.core` y se movió la llamada a `generar_ast('usar archivo')` dentro de un `with pytest.raises(ParserError, match=...)` para capturar el `ParserError` de parseo y comprobar el mensaje (se amplió la expresión regular para incluir `comillas`).

### Testing
- Confirmé con un script Python que `Parser(Lexer('usar archivo').analizar_token()).parsear()` lanza `ParserError` cuyo mensaje contiene `comillas` (éxito), y la ejecución de `pytest` en este entorno no pudo recolectar la prueba debido a un preexistente `ImportError: attempted relative import beyond top-level package` al importar `InterpretadorCobra` (no se pudo ejecutar `pytest` aquí).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d31fb16448327bcf39f2d792ff579)