### PR TITLE
Propaga errores de contrato en get_mapped_path

### DIFF
--- a/src/pcobra/cobra/transpilers/module_map.py
+++ b/src/pcobra/cobra/transpilers/module_map.py
@@ -228,7 +228,7 @@ def _validate_public_backend_policy(data: Dict[str, Any]) -> None:
     if not isinstance(modulos, dict):
         return
 
-    invalid_by_module: dict[str, list[str]] = {}
+    invalid_by_module: dict[str, list[tuple[str, str]]] = {}
     for module_name, module_mapping in modulos.items():
         if not isinstance(module_mapping, dict):
             continue
@@ -287,11 +287,16 @@ def get_mapped_path(module: str, backend: str) -> str:
     Solo acepta nombres canónicos incluidos en ``OFFICIAL_TARGETS`` y resuelve
     exclusivamente desde ``cobra.toml`` usando la estructura
     ``[modulos."<module>"]``. Si no hay mapeo válido, devuelve ``module``.
+
+    Los backends solicitados que no pertenecen al conjunto oficial se tratan
+    como ausencia de mapeo, pero las violaciones del contrato del módulo que
+    detecta ``resolve_backend_for_module`` se dejan propagar para fallar rápido.
     """
-    try:
-        canonical_backend = resolve_backend_for_module(module, backend)
-    except ValueError:
+    canonical_request = normalize_target_name(backend)
+    if canonical_request not in OFFICIAL_TARGETS:
         return module
+
+    canonical_backend = resolve_backend_for_module(module, backend)
     if canonical_backend not in OFFICIAL_TARGETS:
         raise ValueError(
             "CONTRACT_ERROR: backend no oficial en get_mapped_path: "

--- a/tests/unit/test_module_map.py
+++ b/tests/unit/test_module_map.py
@@ -15,7 +15,7 @@ def test_module_map_rechaza_target_fuera_de_public_backends_en_cobra_toml(tmp_pa
     module_map.COBRA_TOML_PATH = str(toml_file)
     module_map._toml_cache = None
 
-    with pytest.raises(ValueError, match="PUBLIC_BACKENDS"):
+    with pytest.raises(ValueError, match="legacy_mapped_ok"):
         module_map.get_toml_map()
 
 
@@ -64,4 +64,5 @@ def test_module_map_resuelve_backend_por_contrato_stdlib(tmp_path, monkeypatch):
     module_map._stdlib_contract_cache = None
     module_map._toml_cache = None
 
-    assert module_map.get_mapped_path("cobra.web", "rust") == "cobra_web.js"
+    with pytest.raises(ValueError, match="backend no permitido por contrato"):
+        module_map.get_mapped_path("cobra.web", "rust")

--- a/tests/unit/test_module_map_errors.py
+++ b/tests/unit/test_module_map_errors.py
@@ -94,6 +94,25 @@ def test_get_mapped_path_devuelve_original_para_backend_fuera_del_set_canonico(m
     assert module_map.get_mapped_path("m", "fantasy") == "m"
 
 
+def test_get_mapped_path_propaga_backend_prohibido_por_contrato(monkeypatch):
+    monkeypatch.setattr(
+        module_map,
+        "get_stdlib_contract",
+        lambda module: {
+            "backend_preferido": "javascript",
+            "fallback_permitido": [],
+        },
+    )
+    monkeypatch.setattr(
+        module_map,
+        "get_toml_map",
+        lambda: {"modulos": {"m": {"python": "dist/m.py", "javascript": "dist/m.js"}}},
+    )
+
+    with pytest.raises(ValueError, match="backend no permitido por contrato"):
+        module_map.get_mapped_path("m", "python")
+
+
 def test_get_mapped_path_resuelve_desde_tabla_modulos_en_toml(monkeypatch):
     monkeypatch.setattr(
         module_map,


### PR DESCRIPTION
### Motivation
- Corregir un bug crítico donde `get_mapped_path` atrapaba cualquier `ValueError` de `resolve_backend_for_module` y ocultaba violaciones de contrato de módulo que deben fallar rápidamente.
- Mantener el comportamiento que trata como "sin mapeo" las solicitudes de backends que no pertenecen al conjunto canónico `OFFICIAL_TARGETS`.
- Alinear los tests y la validación para reflejar las nuevas categorías de error introducidas en la validación de `cobra.toml`.

### Description
- Modifica `get_mapped_path` para primero normalizar la petición (`canonical_request`) y devolver el módulo original solo si el backend solicitado no es oficial, y luego llamar a `resolve_backend_for_module` permitiendo que sus `ValueError` (violaciones de contrato) se propaguen en lugar de ser capturados.
- Corrige la anotación/estructura interna `invalid_by_module` para almacenar tuples `(key, category)` y utiliza esa información para construir errores categorizados con `_build_policy_error` durante la validación de `modulos`.
- Añade el test `test_get_mapped_path_propaga_backend_prohibido_por_contrato` y adapta `tests/unit/test_module_map.py`/`tests/unit/test_module_map_errors.py` para reflejar que las claves legacy se informan con la categoría nueva y que las violaciones de contrato fallan rápido.

### Testing
- Ejecutado `pytest -q tests/unit/test_module_map.py tests/unit/test_module_map_errors.py tests/unit/test_pcobra_module_map.py tests/unit/test_cobra_module_map.py` y la batería correspondiente pasó con `19 passed, 1 warning`.
- Ejecutado `pytest -q tests/unit/test_module_map_errors.py tests/unit/test_module_map.py tests/unit/test_lexer_errors_extra.py` y estas pruebas unitarias pasaron correctamente (`18+ passed` en la corrida intermedia).
- Intenté ejecutar la suite que incluye `tests/unit/test_smoke_transpilation_official_targets.py` pero la recolección falló en este checkout por falta del módulo `pcobra.cobra.transpilers.transpiler.to_asm`, por lo que esa colección quedó bloqueada por una limitación de entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d335ee79483278a3e7a1d0b49475d)