### PR TITLE
Exclude canonical required keys from USAR_SYMBOL_METADATA_LEGACY_KEYS (fix safe_wrapper regression)

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -263,11 +263,16 @@ USAR_METADATA_LEGACY_CONSISTENCY = {
 }
 USAR_METADATA_LEGACY_BOOL_TRUE = {"is_sanitized_wrapper": "sanitized"}
 
-# Claves legacy mantenidas solo por compatibilidad histórica.
+# Claves legacy mantenidas solo por compatibilidad histórica. Los aliases
+# canónicos idempotentes (por ejemplo ``safe_wrapper``) no deben tratarse como
+# legacy porque también forman parte del contrato normalizado obligatorio.
 USAR_SYMBOL_METADATA_LEGACY_KEYS = frozenset(
-    set(USAR_METADATA_LEGACY_ALIASES)
-    | set(USAR_METADATA_LEGACY_CONSISTENCY)
-    | set(USAR_METADATA_LEGACY_BOOL_TRUE)
+    (
+        set(USAR_METADATA_LEGACY_ALIASES)
+        | set(USAR_METADATA_LEGACY_CONSISTENCY)
+        | set(USAR_METADATA_LEGACY_BOOL_TRUE)
+    )
+    - USAR_SYMBOL_METADATA_REQUIRED_KEYS
 )
 
 USAR_SYMBOL_METADATA_OPTIONAL_KEYS = frozenset(

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -4,10 +4,12 @@ from pcobra.core.usar_symbol_policy import (
     CANONICAL_USAR_METADATA_SCHEMA,
     PoliticaSaneamientoUsar,
     USAR_SYMBOL_METADATA_ALLOWED_KEYS,
+    USAR_SYMBOL_METADATA_LEGACY_KEYS,
     normalizar_metadata_simbolo_usar,
     sanear_exportables_para_usar,
     sanear_simbolo_para_usar,
     validate_usar_symbol_metadata,
+    validate_usar_symbol_metadata_normalized,
 )
 
 
@@ -263,6 +265,28 @@ def test_rechaza_metadata_con_contradiccion_backend_exposed_true_en_validacion_e
         assert "backend_exposed inválido" in str(exc)
     else:
         raise AssertionError("Se esperaba ValueError por contradicción maliciosa de metadata.")
+
+
+def test_claves_legacy_no_incluyen_safe_wrapper_canonico():
+    assert "safe_wrapper" in USAR_SYMBOL_METADATA_ALLOWED_KEYS
+    assert "safe_wrapper" not in USAR_SYMBOL_METADATA_LEGACY_KEYS
+
+
+def test_validacion_normalizada_acepta_payload_canonico_con_safe_wrapper():
+    metadata = {
+        "origin_kind": "usar",
+        "module": "archivo",
+        "symbol": "existe",
+        "sanitized": True,
+        "safe_wrapper": True,
+        "public_api": True,
+        "backend_exposed": False,
+        "callable": True,
+    }
+
+    validada = validate_usar_symbol_metadata_normalized("existe", metadata)
+
+    assert validada == metadata
 
 
 def test_claves_legacy_compatibles_forman_parte_del_set_permitido():


### PR DESCRIPTION
### Motivation

- Fix a regression where `safe_wrapper` (a required canonical field) was included in the legacy-key set and caused `validate_usar_symbol_metadata_normalized` to reject valid canonical payloads. 
- Preserve the intent of centralizing legacy alias definitions while keeping canonical required fields treated as canonical, not legacy.

### Description

- Change `USAR_SYMBOL_METADATA_LEGACY_KEYS` to exclude canonical required keys by subtracting `USAR_SYMBOL_METADATA_REQUIRED_KEYS` from the union of legacy alias/consistency/bool maps in `src/pcobra/core/usar_symbol_policy.py`. 
- Add tests and imports in `tests/unit/test_usar_symbol_policy.py` to assert that `safe_wrapper` remains in `USAR_SYMBOL_METADATA_ALLOWED_KEYS` but is not present in `USAR_SYMBOL_METADATA_LEGACY_KEYS`. 
- Add a regression test that `validate_usar_symbol_metadata_normalized` accepts a canonical payload that includes `safe_wrapper`. 
- Keep `safe_wrapper` allowed and validated as part of the canonical schema while preventing it from being treated as legacy during normalized-validation.

### Testing

- Ran `pytest -q tests/unit/test_usar_symbol_policy.py` and it passed (`23 passed, 1 warning`).
- Ran `pytest -q tests/unit/test_usar_loader_public_api_contract.py tests/unit/test_usar_symbol_policy.py` and it passed (`51 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d34ff22188327b83fd27839bca42e)