### PR TITLE
Rechaza alias legacy `wrapper_safe` contradictorio

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -328,6 +328,10 @@ def _resolver_valor_canonico_desde_aliases(
         valores.append(metadata_dict[canonical_key])
     valores.extend(metadata_dict[k] for k in alias_keys)
     if len({repr(v) for v in valores}) > 1:
+        if canonical_key == "safe_wrapper":
+            raise ValueError(
+                f"Metadata inválida para símbolo usar: aliases inconsistentes para {canonical_key}"
+            )
         valor_seguro = USAR_METADATA_SECURE_DEFAULTS.get(canonical_key)
         if valor_seguro is not None and valor_seguro in valores:
             metadata_dict[canonical_key] = valor_seguro

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -316,6 +316,26 @@ def test_normaliza_wrapper_safe_legacy_hacia_safe_wrapper_canonico():
     }
 
 
+def test_rechaza_wrapper_safe_legacy_contradicendo_safe_wrapper_canonico():
+    raw = {
+        "origin_kind": "usar",
+        "module": "archivo",
+        "symbol": "existe",
+        "sanitized": True,
+        "safe_wrapper": False,
+        "wrapper_safe": True,
+        "public_api": True,
+        "backend_exposed": False,
+        "callable": True,
+    }
+
+    try:
+        validate_usar_symbol_metadata("existe", raw)
+    except ValueError as exc:
+        assert "aliases inconsistentes para safe_wrapper" in str(exc)
+    else:
+        raise AssertionError("Se esperaba ValueError por wrapper_safe contradictorio.")
+
 def test_regresion_runtime_usar_archivo_existe_no_aborta_por_safe_wrapper():
     metadata_runtime_real = {
         "introduced_by_usar": "usar",


### PR DESCRIPTION
### Motivation
- Evitar una vía fail-open donde un alias legacy (`wrapper_safe`) pudiera contradecir explícitamente `safe_wrapper` y hacer que el resolver acepte un valor inseguro por sustitución al default seguro.
- Mantener el contrato fail-closed de la metadata `usar` asegurando que conflictos semánticos en aliases se rechacen explícitamente.

### Description
- Modifica `_resolver_valor_canonico_desde_aliases` en `src/pcobra/core/usar_symbol_policy.py` para que, ante un conflicto explícito en la clave canónica `safe_wrapper`, se lance `ValueError` en lugar de resolver automáticamente al default seguro. 
- Limpia/normaliza aliases legacy como antes, pero impide que `wrapper_safe` anule o sea contradictorio con `safe_wrapper` en tiempo de normalización/validación.
- Añade el test `test_rechaza_wrapper_safe_legacy_contradicendo_safe_wrapper_canonico` en `tests/unit/test_usar_symbol_policy.py` que verifica que `validate_usar_symbol_metadata` rechaza la combinación `safe_wrapper=False` junto a `wrapper_safe=True`.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_symbol_policy.py` y todos los tests pasaron (`24 passed, 1 warning`).
- El nuevo test `test_rechaza_wrapper_safe_legacy_contradicendo_safe_wrapper_canonico` se ejecutó correctamente como parte del conjunto.
- Las pruebas confirman que el resolver ya no acepta payloads contradictorios para `safe_wrapper` y que la normalización/validación siguen manteniendo las invariantes de seguridad.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d3674bda083278aaa4b444ec6ff16)