### PR TITLE
Mantener colisión en `usar` si el binding del contexto fue sobrescrito

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1008,6 +1008,35 @@ class InterpretadorCobra:
         return previo_cmp == actual_cmp
 
     @staticmethod
+    def _binding_usar_preserva_identidad_previa(
+        valor_actual: object,
+        previo: dict[str, object] | None,
+    ) -> bool:
+        """Confirma que el binding vigente sigue siendo el símbolo importado previamente."""
+        if not isinstance(previo, dict):
+            return False
+        callable_id_previo = previo.get("callable_id")
+        if not isinstance(callable_id_previo, int):
+            return False
+        return id(valor_actual) == callable_id_previo
+
+    def _reimport_usar_es_idempotente_en_contexto(
+        self,
+        contexto_actual: Environment,
+        nombre: str,
+        previo: dict[str, object] | None,
+        actual: dict[str, object] | None,
+    ) -> bool:
+        """Valida reimport idempotente sin ocultar sobrescrituras del contexto."""
+        if not self._metadata_usar_equivalente_idempotente(previo, actual):
+            return False
+        try:
+            valor_actual = contexto_actual.get(nombre)
+        except NameError:
+            return False
+        return self._binding_usar_preserva_identidad_previa(valor_actual, previo)
+
+    @staticmethod
     def _detalle_debug_metadata_usar(
         *,
         symbol: str | None = None,
@@ -2384,7 +2413,7 @@ class InterpretadorCobra:
         *,
         metadata_por_simbolo: Mapping[str, dict[str, object]],
     ) -> list[str]:
-        """Devuelve símbolos en conflicto real (ignora reimport idempotente por metadatos)."""
+        """Devuelve conflictos reales; solo ignora reimport si metadata y binding siguen intactos."""
         contexto_actual = self.contextos[-1]
         conflictos: list[str] = []
         for nombre, simbolo in simbolos_saneados:
@@ -2394,8 +2423,8 @@ class InterpretadorCobra:
             metadata_actual = metadata_por_simbolo.get(nombre)
             if metadata_actual is None:
                 continue
-            if self._metadata_usar_equivalente_idempotente(previo, metadata_actual):
-                # Reimport idempotente: mismo símbolo, mismo módulo origen y misma identidad.
+            if self._reimport_usar_es_idempotente_en_contexto(contexto_actual, nombre, previo, metadata_actual):
+                # Reimport idempotente: metadata equivalente y binding vigente intacto.
                 continue
             conflictos.append(nombre)
         if conflictos:
@@ -2420,8 +2449,8 @@ class InterpretadorCobra:
                 metadata_actual = metadata_por_simbolo.get(nombre)
                 if metadata_actual is None:
                     continue
-                if self._metadata_usar_equivalente_idempotente(previo, metadata_actual):
-                    # No-op idempotente: evita warning/ruido al reimportar lo mismo.
+                if self._reimport_usar_es_idempotente_en_contexto(contexto_actual, nombre, previo, metadata_actual):
+                    # No-op idempotente: evita warning/ruido al reimportar lo mismo si el binding sigue intacto.
                     continue
                 modulo = str(metadata_actual.get("module"))
                 detalle = {

--- a/tests/integration/test_usar_canonical_surface_contract.py
+++ b/tests/integration/test_usar_canonical_surface_contract.py
@@ -195,3 +195,20 @@ def test_usar_reimportes_reinyecciones_metadata_canonica_e_idempotente(factory):
     for nombre, metadata in interp._usar_symbol_metadata.items():
         assert isinstance(metadata, dict), f"metadata de {nombre} debe ser dict"
         assert set(metadata).issubset(_USAR_METADATA_CANONICAL_KEYS)
+
+
+@pytest.mark.parametrize("factory", [lambda: InteractiveCommand(InterpretadorCobra(safe_mode=True)), ReplCommandV2])
+def test_usar_reimport_colisiona_si_binding_contexto_fue_sobrescrito(factory):
+    _cmd, ejecutar, interp = _crear_comando(factory)
+    if hasattr(_cmd, "_delegate"):
+        _cmd._delegate.interpretador.safe_mode = True
+
+    ejecutar('usar "archivo"')
+    metadata_original = dict(interp._usar_symbol_metadata["existe"])
+    interp.contextos[-1].define("existe", 1)
+
+    with pytest.raises(NameError, match="conflicto de símbolos|colisión"):
+        ejecutar('usar "archivo"')
+
+    assert interp.contextos[-1].values["existe"] == 1
+    assert interp._usar_symbol_metadata["existe"] == metadata_original


### PR DESCRIPTION
### Motivation
- Evitar que la detección de reimport idempotente en `usar` ignore cambios en el binding del contexto cuando solo se comparaba metadata (ignorando `callable_id`), lo que permitía reinyecciones silenciosas y rompía supuestos de safe-mode.
- Restaurar la conducta previa que considera una colisión real si un usuario sobrescribe un símbolo importado antes de volver a ejecutar `usar`.

### Description
- Añade `InterpretadorCobra._binding_usar_preserva_identidad_previa` para verificar que el binding actual mantiene la identidad del callable original (usa `callable_id`).
- Introduce `InterpretadorCobra._reimport_usar_es_idempotente_en_contexto` que combina la comparación de metadata y la comprobación del binding vivo para decidir si un reimport es no-op idempotente.
- Reemplaza las comprobaciones anteriores en `_detectar_conflictos_usar_en_contexto` y `_inyectar_simbolos_usar_en_contexto` para usar la nueva función y así preservar las colisiones cuando el binding fue sobrescrito.
- Añade el test de regresión `test_usar_reimport_colisiona_si_binding_contexto_fue_sobrescrito` en `tests/integration/test_usar_canonical_surface_contract.py` que confirma que sobrescribir `existe` provoca colisión en un reimport y que el binding sobrescrito y la metadata previa se preservan.

### Testing
- Ejecuté `pytest -q tests/integration/test_usar_canonical_surface_contract.py::test_usar_reimportes_reinyecciones_metadata_canonica_e_idempotente tests/integration/test_usar_canonical_surface_contract.py::test_usar_reimport_colisiona_si_binding_contexto_fue_sobrescrito` y los tests objetivo pasaron.
- Resultado de la ejecución integrada: `4 passed, 1 warning`, por lo que la conducta de reimport y la regresión cubierta están resueltas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d37f5065c8327b581c4441355b919)