### PR TITLE
Fix strict USAR metadata sanitization validation

### DIFF
--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -627,9 +627,13 @@ def validate_usar_symbol_metadata(nombre: str, metadata: object) -> dict[str, ob
         raise ValueError(
             f"Metadata inválida para símbolo usar '{nombre}': backend_exposed debe ser False [troubleshooting: violación de seguridad]"
         )
-    if metadata_dict.get("safe_wrapper") is not metadata_dict.get("sanitized"):
+    if metadata_dict.get("sanitized") is not USAR_SCHEMA_VALUE_CONSTRAINTS["sanitized"]:
         raise ValueError(
-            f"Metadata inválida para símbolo usar '{nombre}': safe_wrapper contradice sanitized [troubleshooting: violación de seguridad]"
+            f"Metadata inválida para símbolo usar '{nombre}': sanitized debe ser True [troubleshooting: violación de seguridad]"
+        )
+    if metadata_dict.get("safe_wrapper") is not USAR_SCHEMA_VALUE_CONSTRAINTS["safe_wrapper"]:
+        raise ValueError(
+            f"Metadata inválida para símbolo usar '{nombre}': safe_wrapper debe ser True [troubleshooting: violación de seguridad]"
         )
     if not isinstance(metadata_dict.get("callable"), USAR_SCHEMA_VALUE_CONSTRAINTS["callable"]):
         raise ValueError(

--- a/tests/unit/test_usar_symbol_policy.py
+++ b/tests/unit/test_usar_symbol_policy.py
@@ -399,6 +399,26 @@ def test_rechaza_contradicciones_criticas_de_metadata_usar():
             "backend_exposed": False,
             "callable": True,
         },
+        {
+            "origin_kind": "usar",
+            "module": "archivo",
+            "symbol": "existe",
+            "sanitized": False,
+            "safe_wrapper": False,
+            "public_api": True,
+            "backend_exposed": False,
+            "callable": True,
+        },
+        {
+            "origin_kind": "usar",
+            "module": "archivo",
+            "symbol": "existe",
+            "sanitized": True,
+            "safe_wrapper": False,
+            "public_api": True,
+            "backend_exposed": False,
+            "callable": True,
+        },
     ]
 
     for metadata in casos_invalidos_normalizacion:


### PR DESCRIPTION
### Motivation

- Restore strict enforcement that canonical security flags in `usar` metadata are explicitly true so non-sanitized or unwrapped payloads cannot bypass the validator by having matching false values.

### Description

- Replace the equality check between `safe_wrapper` and `sanitized` in `validate_usar_symbol_metadata` with explicit checks that `metadata_dict.get("sanitized") is USAR_SCHEMA_VALUE_CONSTRAINTS["sanitized"]` and `metadata_dict.get("safe_wrapper") is USAR_SCHEMA_VALUE_CONSTRAINTS["safe_wrapper"]` so each flag must independently match the canonical constraint.
- Preserve the fixed sequence `normalizar -> validar constraints -> devolver payload canónico` and keep the existing troubleshooting suffixes in error messages while making the failing flag explicit in the raised `ValueError` messages.
- Add regression cases to `tests/unit/test_usar_symbol_policy.py` covering payloads with both flags `False` and with `safe_wrapper=False` to ensure the strict validator rejects those inputs.

### Testing

- Ran `pytest -q tests/unit/test_usar_symbol_policy.py` and the suite passed with `25 passed, 1 warning`.
- The modified unit tests include the new regression cases and succeeded under the run above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d39e99b108327b4dfa3f3e7037886)