### PR TITLE
Wrap ValueError from `usar` metadata canonicalization into `PrimitivaPeligrosaError`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1060,7 +1060,10 @@ class InterpretadorCobra:
         for nombre, metadata_interp in self._usar_symbol_metadata.items():
             if not isinstance(metadata_interp, dict):
                 continue
-            metadata_interp = self._canonicalizar_metadata_usar(nombre, metadata_interp)
+            try:
+                metadata_interp = self._canonicalizar_metadata_usar(nombre, metadata_interp)
+            except (PrimitivaPeligrosaError, ValueError):
+                continue
             self._usar_symbol_metadata[nombre] = dict(metadata_interp)
             metadata_val_actual = metadata_validador.get(nombre)
             if metadata_val_actual is None:
@@ -1068,7 +1071,10 @@ class InterpretadorCobra:
                 continue
             if not isinstance(metadata_val_actual, dict):
                 continue
-            metadata_val_actual = self._canonicalizar_metadata_usar(nombre, metadata_val_actual)
+            try:
+                metadata_val_actual = self._canonicalizar_metadata_usar(nombre, metadata_val_actual)
+            except (PrimitivaPeligrosaError, ValueError):
+                continue
             mismo_modulo = metadata_val_actual.get("module") == metadata_interp.get("module")
             payload_cambio = metadata_val_actual != metadata_interp
             if mismo_modulo and payload_cambio:
@@ -1095,10 +1101,27 @@ class InterpretadorCobra:
         metadata_validador = getattr(self._validador, "_metadata_simbolos_usar", None)
         if isinstance(self._usar_symbol_metadata, dict):
             for nombre, metadata in list(self._usar_symbol_metadata.items()):
-                self._usar_symbol_metadata[nombre] = self._canonicalizar_metadata_usar(nombre, metadata)
+                try:
+                    self._usar_symbol_metadata[nombre] = self._canonicalizar_metadata_usar(nombre, metadata)
+                except (PrimitivaPeligrosaError, ValueError) as exc:
+                    raise PrimitivaPeligrosaError(
+                        "Metadata de validador inválida para símbolos usar: "
+                        f"metadata de intérprete inválida para símbolo '{nombre}' "
+                        f"(clave_esperada='module|kind|public_api|sanitized', tipo='{type(metadata).__name__}', codigo_interno='invalid_symbol_metadata', troubleshooting='metadata_interprete_no_cumple_contrato', detalle=validation_reason='{exc}')."
+                        f"{self._detalle_debug_metadata_usar(symbol=nombre)}"
+                    ) from exc
         if isinstance(metadata_validador, dict):
             for nombre, metadata in list(metadata_validador.items()):
-                metadata_validador[nombre] = self._canonicalizar_metadata_usar(nombre, metadata)
+                try:
+                    metadata_validador[nombre] = self._canonicalizar_metadata_usar(nombre, metadata)
+                except (PrimitivaPeligrosaError, ValueError) as exc:
+                    tipo_recibido = type(metadata).__name__
+                    raise PrimitivaPeligrosaError(
+                        "Metadata de validador inválida para símbolos usar: "
+                        f"metadata por símbolo inválida para '{nombre}' "
+                        f"(clave_esperada='module|kind|public_api|sanitized', tipo='{tipo_recibido}', codigo_interno='invalid_symbol_metadata', troubleshooting='metadata_validador_no_cumple_contrato', detalle=validation_reason='{exc}')."
+                        f"{self._detalle_debug_metadata_usar(symbol=nombre)}"
+                    ) from exc
 
     def _validar_metadata_usar_en_ejecucion(self, *, etapa: str | None = None) -> None:
         """Valida metadata de `usar` en etapa='pre-auditoría' de forma estricta.
@@ -1141,23 +1164,23 @@ class InterpretadorCobra:
             try:
                 metadata_interp_canonica = self._canonicalizar_metadata_usar(nombre, metadata_interp)
                 self._usar_symbol_metadata[nombre] = dict(metadata_interp_canonica)
-            except PrimitivaPeligrosaError as exc:
+            except (PrimitivaPeligrosaError, ValueError) as exc:
                 raise PrimitivaPeligrosaError(
                     "Metadata de validador inválida para símbolos usar: "
                     f"metadata de intérprete inválida para símbolo '{nombre}' "
-                    f"(clave_esperada='module|kind|public_api|sanitized', tipo='{type(metadata_interp).__name__}', codigo_interno='invalid_symbol_metadata', troubleshooting='metadata_interprete_no_cumple_contrato', detalle={exc})."
+                    f"(clave_esperada='module|kind|public_api|sanitized', tipo='{type(metadata_interp).__name__}', codigo_interno='invalid_symbol_metadata', troubleshooting='metadata_interprete_no_cumple_contrato', detalle=validation_reason='{exc}')."
                     f"{self._detalle_debug_metadata_usar(symbol=nombre)}{detalle_etapa}"
                 ) from exc
             metadata_val = metadata_validador.get(nombre)
             try:
                 metadata_val_canonica = self._canonicalizar_metadata_usar(nombre, metadata_val)
                 metadata_validador[nombre] = dict(metadata_val_canonica)
-            except PrimitivaPeligrosaError as exc:
+            except (PrimitivaPeligrosaError, ValueError) as exc:
                 tipo_recibido = type(metadata_val).__name__
                 raise PrimitivaPeligrosaError(
                     "Metadata de validador inválida para símbolos usar: "
                     f"metadata por símbolo inválida para '{nombre}' "
-                    f"(clave_esperada='module|kind|public_api|sanitized', tipo='{tipo_recibido}', codigo_interno='invalid_symbol_metadata', troubleshooting='metadata_validador_no_cumple_contrato', detalle={exc})."
+                    f"(clave_esperada='module|kind|public_api|sanitized', tipo='{tipo_recibido}', codigo_interno='invalid_symbol_metadata', troubleshooting='metadata_validador_no_cumple_contrato', detalle=validation_reason='{exc}')."
                     f"{self._detalle_debug_metadata_usar(symbol=nombre)}{detalle_etapa}"
                 ) from exc
             if metadata_interp_canonica != metadata_val_canonica:

--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -678,6 +678,32 @@ def test_metadata_usar_error_invalid_symbol_metadata_preserva_motivo_original():
     assert "troubleshooting='metadata_validador_no_cumple_contrato'" in mensaje
 
 
+
+def test_metadata_usar_valueerror_interprete_se_envuelve_como_primitiva_peligrosa():
+    interp = InterpretadorCobra()
+    metadata_valida = {
+        "origin_kind": "usar",
+        "module": "archivo",
+        "symbol": "existe",
+        "sanitized": True,
+        "safe_wrapper": True,
+        "public_api": True,
+        "backend_exposed": False,
+        "callable": True,
+    }
+    metadata_invalida = dict(metadata_valida)
+    metadata_invalida["public_api"] = False
+    interp._usar_symbol_metadata = {"existe": metadata_invalida}
+    interp._validador._metadata_simbolos_usar = {"existe": metadata_valida}
+
+    with pytest.raises(PrimitivaPeligrosaError) as err:
+        interp._validar_metadata_usar_en_ejecucion(etapa="pre-auditoría")
+
+    mensaje = str(err.value)
+    assert "codigo_interno='invalid_symbol_metadata'" in mensaje
+    assert "troubleshooting='metadata_interprete_no_cumple_contrato'" in mensaje
+    assert "public_api debe ser True" in mensaje
+
 def test_metadata_usar_error_missing_keys_incluye_troubleshooting():
     interp = InterpretadorCobra()
     with patch("sys.stdout", new_callable=StringIO):


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where `_canonicalizar_metadata_usar(...)` could raise `ValueError` that escaped the safe-mode pipeline instead of being translated to the domain-specific `PrimitivaPeligrosaError` (`invalid_symbol_metadata`).
- Preserve the safe-mode contract so malformed interpreter/validator metadata is reported as structured errors and pre-audit validation remains fail-closed.
- Avoid dropping or silently mutating runtime metadata containers during non-destructive sync while letting strict validation surface errors correctly.

### Description
- In `_sincronizar_metadata_usar_no_destructiva` added handling to catch `ValueError` (in addition to `PrimitivaPeligrosaError`) from `self._canonicalizar_metadata_usar(...)` and skip malformed per-symbol payloads during the non-destructive sync pass so they do not crash the sync early. (`src/pcobra/core/interpreter.py`)
- In `_normalizar_metadata_usar_pre_auditoria` and `_validar_metadata_usar_en_ejecucion` extended exception handling to catch `ValueError` as well and re-raise a `PrimitivaPeligrosaError` with `codigo_interno='invalid_symbol_metadata'`, embedding a `validation_reason` detail so the original validation message is preserved for diagnostics. (`src/pcobra/core/interpreter.py`)
- Updated error message formatting to include `validation_reason` where `ValueError` details were previously unwrapped. (`src/pcobra/core/interpreter.py`)
- Added a regression unit test `test_metadata_usar_valueerror_interprete_se_envuelve_como_primitiva_peligrosa` that verifies a `ValueError` produced by interpreter metadata validation is wrapped as a `PrimitivaPeligrosaError` with the expected `invalid_symbol_metadata` attributes. (`tests/unit/test_safe_mode.py`)

### Testing
- Compiled modified modules with `python -m py_compile src/pcobra/core/interpreter.py tests/unit/test_safe_mode.py` and compilation succeeded. 
- Ran an inline regression check using `PYTHONPATH=src python - <<'PY' ... PY` which confirmed the malformed interpreter metadata case raises and reports a structured `PrimitivaPeligrosaError` (printed `structured error ok`).
- Attempted to run the two related pytest cases with `PYTHONPATH=src python -m pytest -q tests/unit/test_safe_mode.py::test_metadata_usar_valueerror_interprete_se_envuelve_como_primitiva_peligrosa tests/unit/test_safe_mode.py::test_metadata_usar_error_invalid_symbol_metadata_preserva_motivo_original`, but collection failed in this environment due to an existing import layout issue (`ImportError: attempted relative import beyond top-level package`) unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d428bf4108327b53fb19af4629d1a)