### PR TITLE
Preserve source order for `usar` metadata in safe-mode (fix archivo.existe bypass)

### DIFF
--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -328,18 +328,12 @@ def ejecutar_codigo_canonico(
     """Función canónica para analizar+validar+ejecutar código Cobra."""
 
     ast = analizar_codigo_fn(codigo)
-    if seguro:
-        nodos_usar = [
-            nodo for nodo in ast if getattr(nodo, "__class__", type("", (), {})).__name__ == "NodoUsar"
-        ]
-        if nodos_usar:
-            ejecutar_ast(nodos_usar, interpretador)
-        validar_ast_seguro(
-            ast,
-            validadores_extra=extra_validators,
-            interpretador=interpretador,
-            construir_cadena_fn=construir_cadena_fn,
-        )
+    # En modo seguro, la validación con estado dependiente de ``usar`` debe
+    # ocurrir durante la ejecución ordenada del intérprete.  Pre-ejecutar o
+    # pre-registrar todos los ``NodoUsar`` del script adelanta metadata que aún
+    # no existe en el punto real de ejecución y puede autorizar primitivas sobre
+    # bindings sombreados.  ``ejecutar_ast`` ya valida/audita cada nodo con el
+    # ``interpretador`` seguro preservando el orden fuente.
     resultado = ejecutar_ast(ast, interpretador)
     return PipelineResult(
         ast=ast,

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -941,6 +941,7 @@ class InterpretadorCobra:
         if self.mode != "analysis":
             return
         if self.safe_mode and id(nodo) not in self._validados:
+            self._sincronizar_metadata_usar_no_destructiva()
             nodo.aceptar(self._validador)
             self._validados.add(id(nodo))
 
@@ -1045,6 +1046,14 @@ class InterpretadorCobra:
         serializado = json.dumps(metadata, sort_keys=True, ensure_ascii=False, default=repr)
         return hashlib.sha256(serializado.encode("utf-8")).hexdigest()
 
+    def _iter_validadores_registrables_usar(self):
+        """Itera validadores de la cadena que aceptan metadata pública de ``usar``."""
+        cursor = self._validador
+        while cursor is not None:
+            if hasattr(cursor, "registrar_simbolo_publico_usar"):
+                yield cursor
+            cursor = getattr(cursor, "siguiente", None)
+
     def _sincronizar_metadata_usar_no_destructiva(self) -> None:
         """Sincroniza metadata de `usar` sin borrar contenedores existentes.
 
@@ -1071,14 +1080,20 @@ class InterpretadorCobra:
             metadata_val_actual = metadata_validador.get(nombre)
             if metadata_val_actual is None:
                 metadata_validador[nombre] = dict(metadata_interp)
-                continue
-            if not isinstance(metadata_val_actual, dict):
-                continue
-            metadata_val_actual = self._canonicalizar_metadata_usar(nombre, metadata_val_actual)
-            mismo_modulo = metadata_val_actual.get("module") == metadata_interp.get("module")
-            payload_cambio = metadata_val_actual != metadata_interp
-            if mismo_modulo and payload_cambio:
-                metadata_validador[nombre] = dict(metadata_interp)
+            elif isinstance(metadata_val_actual, dict):
+                metadata_val_actual = self._canonicalizar_metadata_usar(nombre, metadata_val_actual)
+                mismo_modulo = metadata_val_actual.get("module") == metadata_interp.get("module")
+                payload_cambio = metadata_val_actual != metadata_interp
+                if mismo_modulo and payload_cambio:
+                    metadata_validador[nombre] = dict(metadata_interp)
+            modulo = metadata_interp.get("module")
+            if isinstance(modulo, str):
+                for validador_registrable in self._iter_validadores_registrables_usar():
+                    validador_registrable.registrar_simbolo_publico_usar(
+                        nombre,
+                        modulo,
+                        metadata=dict(metadata_interp),
+                    )
 
     def _asegurar_metadata_usar_sincronizada(self, *, etapa: str | None = None) -> None:
         """Valida sincronización estricta para etapa='pre-auditoría'.
@@ -2489,7 +2504,7 @@ class InterpretadorCobra:
             metadata_simbolo = self._canonicalizar_metadata_usar(nombre, metadata_simbolo)
             contexto_actual.define(nombre, simbolo)
             self._usar_symbol_metadata[nombre] = dict(metadata_simbolo)
-            if self._validador is not None and hasattr(self._validador, "registrar_simbolo_publico_usar"):
+            if self._validador is not None:
                 resumen = {
                     "module": metadata_simbolo.get("module"),
                     "symbol": metadata_simbolo.get("symbol"),
@@ -2498,11 +2513,12 @@ class InterpretadorCobra:
                     "sanitized": metadata_simbolo.get("sanitized"),
                 }
                 self._trace_debug(f"[USAR_METADATA][PRE_REGISTRO] {resumen}")
-                self._validador.registrar_simbolo_publico_usar(
-                    nombre,
-                    str(metadata_simbolo["module"]),
-                    metadata=dict(metadata_simbolo),
-                )
+                for validador_registrable in self._iter_validadores_registrables_usar():
+                    validador_registrable.registrar_simbolo_publico_usar(
+                        nombre,
+                        str(metadata_simbolo["module"]),
+                        metadata=dict(metadata_simbolo),
+                    )
                 self._sincronizar_metadata_usar_no_destructiva()
                 self._trace_debug(f"[USAR_METADATA][POST_REGISTRO] {resumen}")
                 if str(metadata_simbolo.get("module")) == "archivo" and nombre == "existe":

--- a/src/pcobra/core/semantic_validators/__init__.py
+++ b/src/pcobra/core/semantic_validators/__init__.py
@@ -24,8 +24,8 @@ _CACHE_INFO: tuple[FunctionType, bool, bool] | None = None
 def construir_cadena(extra_validators=None, *, emitir_side_effects: bool = False):
     """Devuelve la cadena de validadores por defecto.
 
-    Si no se proporcionan validadores extra, la cadena se crea una única vez y
-    se reutiliza en llamadas sucesivas.
+    Si no se proporcionan validadores extra y no se piden efectos de ejecución,
+    la cadena se crea una única vez y se reutiliza en llamadas sucesivas.
     """
     global _CADENA_DEFECTO, _CACHE_INFO
 
@@ -33,6 +33,7 @@ def construir_cadena(extra_validators=None, *, emitir_side_effects: bool = False
 
     if (
         extra_validators is None
+        and not emitir_side_effects
         and _CADENA_DEFECTO is not None
         and _CACHE_INFO == (ValidadorPrimitivaPeligrosa.__init__, auditoria, emitir_side_effects)
     ):
@@ -52,7 +53,7 @@ def construir_cadena(extra_validators=None, *, emitir_side_effects: bool = False
         for val in extra_validators:
             actual = actual.set_siguiente(val)
 
-    if extra_validators is None:
+    if extra_validators is None and not emitir_side_effects:
         _CADENA_DEFECTO = primero
         _CACHE_INFO = (ValidadorPrimitivaPeligrosa.__init__, auditoria, emitir_side_effects)
 

--- a/tests/unit/test_parity_contract_run_vs_repl.py
+++ b/tests/unit/test_parity_contract_run_vs_repl.py
@@ -170,3 +170,17 @@ def test_run_seguro_bloquea_existe_sin_usar_archivo() -> None:
 
     assert resultado["rc"] == 1
     assert "Uso de primitiva peligrosa: 'existe'" in resultado["stdout"]
+
+
+def test_run_seguro_respeta_orden_usar_al_validar_existe_sombreado() -> None:
+    resultado = _ejecutar_modo_script_seguro(
+        [
+            "var existe = 1",
+            'usar "archivo"',
+            'imprimir(existe("README.md"))',
+        ]
+    )
+
+    assert resultado["rc"] == 1
+    assert "conflicto de símbolos" in resultado["stdout"]
+    assert "Función 'existe' no implementada" not in resultado["stdout"]


### PR DESCRIPTION
### Motivation

- Prevent a regression where `cobra run` pre-seeding `NodoUsar` metadata could authorize dangerous primitives out of source order (e.g., `existe` becoming allowed before the real `usar "archivo"` runs).
- Ensure `run` behavior matches the REPL contract that validation and any stateful `usar` synchronization happen in source order. 
- Avoid leaking or reusing side-effecting validator state across interpreter instances which can cause cross-run metadata leakage.

### Description

- Removed the safe-mode pre-pass that executed all `NodoUsar` nodes prior to normal execution in `ejecutar_codigo_canonico`, and now rely on the interpreter ordered execution to perform validation/auditing. 
- In `InterpretadorCobra`, call `_sincronizar_metadata_usar_no_destructiva()` before per-node analysis validation and register `usar` metadata into every validator that supports `registrar_simbolo_publico_usar` via a new `_iter_validadores_registrables_usar()` helper. 
- Change `usar` injection to register metadata across the full validator chain (not only the chain head) so `archivo.existe` is authorized only when the actual `usar` happened in source order. 
- Avoid caching/reusing validator chains that emit side effects by only using the cached default chain when `emitir_side_effects=False`, preventing side-effecting state from leaking between runs. 
- Added a regression unit test `test_run_seguro_respeta_orden_usar_al_validar_existe_sombreado` to assert a shadowed `existe` binding followed by `usar "archivo"` fails instead of incorrectly authorizing `existe`.

### Testing

- Ran focused safe-mode tests with `pytest -q tests/unit/test_parity_contract_run_vs_repl.py -k "run_seguro"` and they passed (3 passed). 
- Compiled modified modules with `python -m py_compile src/pcobra/cobra/cli/execution_pipeline.py src/pcobra/core/interpreter.py src/pcobra/core/semantic_validators/__init__.py` and compilation succeeded. 
- Ran the full parity test file `pytest -q tests/unit/test_parity_contract_run_vs_repl.py`; two unrelated parity assertions outside the safe-mode scope remain failing and are pre-existing; they are not regressions introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d8be4d6e48327a2567d59856172b2)