### PR TITLE
Fix REPL parity tests: add missing `seguro` param and correct undeclared-identifier assertions

### DIFF
--- a/tests/cli/test_repl_script_parity_contract.py
+++ b/tests/cli/test_repl_script_parity_contract.py
@@ -119,7 +119,7 @@ def _ejecutar_por_ruta_repl(
 
 
 def _ejecutar_snippets_secuenciales_script(
-    snippets: list[str], *, variables_estado: tuple[str, ...]
+    snippets: list[str], *, variables_estado: tuple[str, ...], seguro: bool = False
 ) -> dict[str, object]:
     interpretador_cls = resolver_interpretador_cls(
         module_name="pcobra.cobra.cli.services.run_service",
@@ -272,8 +272,10 @@ def test_paridad_error_identificador_no_declarado_en_script_y_repl() -> None:
 
     mensaje_script = str(err_script.value).lower()
     mensaje_repl = str(err_repl.value).lower()
-    assert "existe" in mensaje_script
-    assert "existe" in mensaje_repl
+    assert "variable no declarada" in mensaje_script
+    assert "variable no declarada" in mensaje_repl
+    assert "no_declarado" in mensaje_script
+    assert "no_declarado" in mensaje_repl
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Motivation
- Prevent a `NameError` in the sequential-script test helper where `safe_mode=seguro` was used but `seguro` was not in scope.  
- Ensure the parity test for an undeclared identifier asserts the actual runtime error text instead of an unrelated string so the test verifies the intended behavior.

### Description
- Added the missing `seguro: bool = False` parameter to `_ejecutar_snippets_secuenciales_script` so `safe_mode=seguro` is valid in the helper.  
- Updated undeclared-identifier assertions in `tests/cli/test_repl_script_parity_contract.py` to check for the real error text `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d9160b8ec8327a9ff5131614f6612)