### PR TITLE
Preserve security warnings while hiding diagnostic CLI traces

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -21,6 +21,11 @@ except ModuleNotFoundError:  # pragma: no cover - rama dependiente del entorno
     load_dotenv = None
 
 logger = logging.getLogger(__name__)
+_DIAGNOSTIC_WARNING_PREFIXES = (
+    "Llamada a funcion:",
+    "Usar modulo:",
+    "USAR sanitize conflicts event",
+)
 _CLI_BOOTSTRAP_PATH_ENV = "PCOBRA_CLI_BOOTSTRAP_PATH"
 _CLI_BOOTSTRAP_PATH_ENV_ALIAS = "COBRA_CLI_BOOTSTRAP_PATH"
 _DEFAULT_DB_PATH = str(Path("~/.cobra/sqliteplus/core.db").expanduser())
@@ -59,6 +64,16 @@ def configure_encoding() -> None:
     os.environ["PYTHONIOENCODING"] = "utf-8"
 
 
+class _FiltroWarningsDiagnosticos(logging.Filter):
+    """Oculta warnings internos de diagnóstico sin silenciar avisos de seguridad."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno != logging.WARNING:
+            return True
+        mensaje = record.getMessage()
+        return not mensaje.startswith(_DIAGNOSTIC_WARNING_PREFIXES)
+
+
 def configure_logging(debug: bool, verbose: int = 0) -> None:
     """Configura logging de CLI con un único handler efectivo de consola.
 
@@ -67,13 +82,17 @@ def configure_logging(debug: bool, verbose: int = 0) -> None:
     - Los módulos (incluido ``pcobra`` y sus submódulos) **no** deben adjuntar
       handlers locales; sólo deben obtener su logger con ``getLogger(__name__)``
       y propagar al root.
+    - En modo normal se filtran únicamente warnings diagnósticos internos; los
+      warnings funcionales y de seguridad siguen visibles para el usuario.
     """
 
     modo_diagnostico = bool(debug) or int(verbose or 0) > 0
-    level = logging.DEBUG if modo_diagnostico else logging.ERROR
+    level = logging.DEBUG if modo_diagnostico else logging.WARNING
     formatter = logging.Formatter("%(levelname)s: %(message)s")
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
+    if not modo_diagnostico:
+        handler.addFilter(_FiltroWarningsDiagnosticos())
 
     root_logger = logging.getLogger()
     for existing_handler in list(root_logger.handlers):

--- a/tests/unit/test_cli_logging_regression.py
+++ b/tests/unit/test_cli_logging_regression.py
@@ -3,7 +3,7 @@ from contextlib import redirect_stderr
 from io import StringIO
 from types import SimpleNamespace
 
-from pcobra.cli import configure_logging
+from pcobra.cli import configure_logging, ensure_sqlite_db_key_for_command
 from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
 
 
@@ -134,3 +134,49 @@ def test_modo_verbose_muestra_warnings_diagnosticos():
     assert "Llamada a funcion: demo" in salida
     assert "Usar modulo: demo" in salida
     assert "USAR sanitize conflicts event module=demo" in salida
+
+
+def _capturar_warning_seguridad(*, debug: bool, verbose: int = 0) -> str:
+    configure_logging(debug=debug, verbose=verbose)
+    buffer = StringIO()
+    root_logger = logging.getLogger()
+    handler = root_logger.handlers[0]
+    original_stream = getattr(handler, "stream", None)
+    if hasattr(handler, "setStream"):
+        handler.setStream(buffer)
+    try:
+        ensure_sqlite_db_key_for_command(
+            command_name="cache",
+            dev_ephemeral_cli_confirmation=True,
+        )
+    finally:
+        if original_stream is not None and hasattr(handler, "setStream"):
+            handler.setStream(original_stream)
+    return buffer.getvalue()
+
+
+def test_modo_normal_preserva_warnings_seguridad_runtime(monkeypatch):
+    monkeypatch.delenv("SQLITE_DB_KEY", raising=False)
+    monkeypatch.setenv("COBRA_DEV_MODE", "1")
+    monkeypatch.setenv("COBRA_DEV_ALLOW_EPHEMERAL_KEY", "1")
+
+    salida = _capturar_warning_seguridad(debug=False, verbose=0)
+    assert "Modo desarrollo confirmado" in salida
+    assert "SQLITE_DB_KEY" in salida
+
+
+def test_modo_normal_preserva_warnings_funcionales_no_diagnosticos():
+    configure_logging(debug=False, verbose=0)
+    buffer = StringIO()
+    root_logger = logging.getLogger()
+    handler = root_logger.handlers[0]
+    original_stream = getattr(handler, "stream", None)
+    if hasattr(handler, "setStream"):
+        handler.setStream(buffer)
+    try:
+        logging.getLogger("pcobra.test").warning("Aviso funcional importante")
+    finally:
+        if original_stream is not None and hasattr(handler, "setStream"):
+            handler.setStream(original_stream)
+
+    assert "Aviso funcional importante" in buffer.getvalue()


### PR DESCRIPTION
### Motivation
- The CLI previously set the root logger to `ERROR` in normal mode which suppressed all `WARNING` messages, hiding important runtime security notices such as the ephemeral `SQLITE_DB_KEY` warning. 
- We want to keep internal diagnostic traces hidden by default while ensuring functional and security warnings remain visible to users. 

### Description
- Change default root logging level in normal mode from `ERROR` to `WARNING` and keep `DEBUG` for diagnostic mode (`--debug` or `-v`).
- Add `_DIAGNOSTIC_WARNING_PREFIXES` and a `_FiltroWarningsDiagnosticos` logging filter that, in normal mode, suppresses only warnings whose messages start with known diagnostic prefixes. 
- Apply the filter to the console `StreamHandler` when not in diagnostic mode and preserve the `pcobra` logger propagation contract. 
- Extend regression tests in `tests/unit/test_cli_logging_regression.py` to assert that diagnostic traces stay hidden while dev-ephemeral `SQLITE_DB_KEY` warnings and other functional warnings are preserved.

### Testing
- Ran `pytest -q tests/unit/test_cli_logging_regression.py tests/unit/test_cli_sqlite_db_key.py` and both passed (all tests green).
- Ran `pytest -q tests/unit/test_cli_configurar_entorno.py` and all tests in that file passed.
- A combined run of the three files (`tests/unit/test_cli_logging_regression.py`, `tests/unit/test_cli_configurar_entorno.py`, `tests/unit/test_cli_sqlite_db_key.py`) initially exposed an import-order-sensitive failure in `test_main_reconfigura_consola_antes_de_logging_y_cli`, but each affected file passes when run independently as shown above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e7453f35c8327bb64926c1580f916)