### PR TITLE
Fix safe-mode hilo test syntax

### DIFF
--- a/tests/unit/test_safe_mode.py
+++ b/tests/unit/test_safe_mode.py
@@ -304,7 +304,7 @@ def test_existe_como_metodo_sigue_bloqueado_en_modo_seguro():
 
 def test_hilo_con_primitiva_peligrosa_fuera_de_ruta_canonica_se_bloquea():
     interp = InterpretadorCobra()
-    ast = generar_ast('hilo(leer_archivo, "README.md")')
+    ast = generar_ast('hilo leer_archivo("README.md")')
 
     with pytest.raises(PrimitivaPeligrosaError):
         interp.ejecutar_ast(ast)


### PR DESCRIPTION
### Motivation
- Ensure the new safe-mode test actually reaches semantic validation by using the parser-supported `hilo <identificador>(...)` form because the previous `hilo(leer_archivo, "README.md")` string triggered a `ParserError` and never exercised `visit_hilo`.

### Description
- Update `tests/unit/test_safe_mode.py` to use `hilo leer_archivo("README.md")` instead of `hilo(leer_archivo, "README.md")` so the parser produces a `NodoHilo` and the semantic validator's `visit_hilo` is executed.

### Testing
- Performed a parser/interpreter smoke check with `python` that parsed `hilo leer_archivo("README.md")` into a `NodoHilo` and confirmed execution raises `PrimitivaPeligrosaError` as expected; this succeeded.
- Ran `pytest -q tests/unit/test_safe_mode.py` but collection still fails in this environment with `ImportError: attempted relative import beyond top-level package`, which matches the import-path limitation previously observed and is unrelated to the test fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e7a9780ac8327adf760bafb852bd5)