### PR TITLE
Evitar TypeError al ordenar claves heterogéneas en diagnóstico de metadata `usar`

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -930,18 +930,27 @@ class InterpretadorCobra:
             raise PrimitivaPeligrosaError(str(exc)) from exc
 
     @staticmethod
+    def _ordenar_claves_metadata_usar(keys: set[object]) -> list[object]:
+        """Ordena claves de metadata heterogéneas sin comparar tipos incompatibles."""
+        return sorted(keys, key=lambda key: (type(key).__name__, repr(key)))
+
+    @staticmethod
     def _detalle_debug_metadata_usar(
         *,
         symbol: str | None = None,
-        expected_keys: set[str] | None = None,
-        received_keys: set[str] | None = None,
+        expected_keys: set[object] | None = None,
+        received_keys: set[object] | None = None,
     ) -> str:
         if not _usar_detalle_habilitado():
             return ""
         payload = {
             "symbol": symbol,
-            "expected_keys": sorted(expected_keys) if expected_keys is not None else None,
-            "received_keys": sorted(received_keys) if received_keys is not None else None,
+            "expected_keys": InterpretadorCobra._ordenar_claves_metadata_usar(expected_keys)
+            if expected_keys is not None
+            else None,
+            "received_keys": InterpretadorCobra._ordenar_claves_metadata_usar(received_keys)
+            if received_keys is not None
+            else None,
             "validator_type": "validate_usar_symbol_metadata",
         }
         return f" detalle_debug={payload}"
@@ -961,8 +970,12 @@ class InterpretadorCobra:
         claves_interp = set(self._usar_symbol_metadata.keys())
         claves_validador = set(metadata_validador.keys())
         if claves_validador != claves_interp:
-            faltantes_en_validador = sorted(claves_interp - claves_validador)
-            extras_en_validador = sorted(claves_validador - claves_interp)
+            faltantes_en_validador = self._ordenar_claves_metadata_usar(
+                claves_interp - claves_validador
+            )
+            extras_en_validador = self._ordenar_claves_metadata_usar(
+                claves_validador - claves_interp
+            )
             raise PrimitivaPeligrosaError(
                 "Divergencia de metadata usar entre intérprete y validador"
                 f": claves divergentes (faltantes_en_validador={faltantes_en_validador}, "

--- a/src/pcobra/core/usar_symbol_policy.py
+++ b/src/pcobra/core/usar_symbol_policy.py
@@ -278,6 +278,11 @@ USAR_SYMBOL_METADATA_ALLOWED_KEYS = (
 )
 
 
+def _ordenar_claves_metadata(keys: set[object]) -> list[object]:
+    """Ordena claves de metadata heterogéneas sin comparar tipos incompatibles."""
+    return sorted(keys, key=lambda key: (type(key).__name__, repr(key)))
+
+
 def make_usar_symbol_metadata(
     module_name: str,
     symbol_name: str,
@@ -346,13 +351,16 @@ def _normalizar_metadata_simbolo_usar(nombre: str, metadata: object) -> dict[str
     metadata_dict = dict(metadata)
     faltantes = USAR_SYMBOL_METADATA_REQUIRED_KEYS - set(metadata_dict.keys())
     if faltantes:
-        raise ValueError(f"Metadata inválida para símbolo usar '{nombre}': faltan claves {sorted(faltantes)}")
+        raise ValueError(
+            "Metadata inválida para símbolo usar "
+            f"'{nombre}': faltan claves {_ordenar_claves_metadata(faltantes)}"
+        )
 
     inesperadas_criticas = set(metadata_dict.keys()) - USAR_SYMBOL_METADATA_ALLOWED_KEYS
     if inesperadas_criticas:
         raise ValueError(
             "Metadata inválida para símbolo usar "
-            f"'{nombre}': claves inesperadas críticas {sorted(inesperadas_criticas)}"
+            f"'{nombre}': claves inesperadas críticas {_ordenar_claves_metadata(inesperadas_criticas)}"
         )
 
     return metadata_dict

--- a/tests/unit/test_usar_metadata_debug.py
+++ b/tests/unit/test_usar_metadata_debug.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.semantic_validators import PrimitivaPeligrosaError
+from pcobra.core.usar_symbol_policy import validate_usar_symbol_metadata
+
+
+def test_metadata_usar_debug_tolera_claves_heterogeneas_en_metadata_corrupta():
+    interp = InterpretadorCobra()
+    interp._usar_symbol_metadata = {"existe": {}}
+    interp._validador = SimpleNamespace(_metadata_simbolos_usar={"existe": {}, 1: {}})
+
+    with patch("pcobra.core.interpreter._usar_detalle_habilitado", return_value=True):
+        with pytest.raises(PrimitivaPeligrosaError) as err:
+            interp._asegurar_metadata_usar_sincronizada(etapa="test")
+
+    mensaje = str(err.value)
+    assert "codigo_interno='missing_keys'" in mensaje
+    assert "detalle_debug=" in mensaje
+    assert "received_keys" in mensaje
+    assert "validate_usar_symbol_metadata" in mensaje
+
+
+def test_metadata_usar_debug_helper_ordena_claves_anidadas_heterogeneas():
+    with patch("pcobra.core.interpreter._usar_detalle_habilitado", return_value=True):
+        detalle = InterpretadorCobra._detalle_debug_metadata_usar(
+            symbol="existe",
+            expected_keys={"module", 1},
+            received_keys={"module", 2},
+        )
+
+    assert "detalle_debug=" in detalle
+    assert "expected_keys" in detalle
+    assert "received_keys" in detalle
+    assert "validate_usar_symbol_metadata" in detalle
+
+
+def test_validador_metadata_usar_rechaza_claves_heterogeneas_sin_typeerror():
+    metadata = {
+        "origin_kind": "usar",
+        "module": "archivo",
+        "symbol": "existe",
+        "sanitized": True,
+        "public_api": True,
+        "backend_exposed": False,
+        "callable": True,
+        1: "clave-corrupta",
+    }
+
+    with pytest.raises(ValueError, match="claves inesperadas críticas"):
+        validate_usar_symbol_metadata("existe", metadata)


### PR DESCRIPTION
### Motivation
- Evitar que la ruta de diagnóstico (_detalle_debug_) lance un `TypeError` cuando el metadata del validador contiene claves de tipos heterogéneos (por ejemplo `int` y `str`).
- Mantener el flujo controlado de errores (`PrimitivaPeligrosaError` / `ValueError`) y que el modo debug aporte detalle estructurado sin romper la validación segura.

### Description
- Añadida función de ordenación tolerante para claves heterogéneas en `InterpretadorCobra` como `InterpretadorCobra._ordenar_claves_metadata_usar` y usada en `_detalle_debug_metadata_usar` para producir listas ordenadas sin comparar tipos incompatibles.
- Reemplazado el uso directo de `sorted(...)` por la ordenación segura en los puntos donde se generan listas de claves faltantes/extra en `_asegurar_metadata_usar_sincronizada`.
- Añadida función auxiliar `_ordenar_claves_metadata` en `src/pcobra/core/usar_symbol_policy.py` y usada en `_normalizar_metadata_simbolo_usar` para que los mensajes de `ValueError` serialicen claves heterogéneas sin error.
- Añadidos tests de regresión en `tests/unit/test_usar_metadata_debug.py` que cubren: diagnóstico en modo debug con claves heterogéneas, helper de detalle debug y rechazo del validador ante claves heterogéneas sin provocar `TypeError`.

### Testing
- Compilación estática por archivo: `PYTHONPATH=src python -m py_compile src/pcobra/core/interpreter.py src/pcobra/core/usar_symbol_policy.py tests/unit/test_usar_metadata_debug.py` se ejecutó correctamente.
- Tests nuevos: `PYTHONPATH=src python -m pytest -q tests/unit/test_usar_metadata_debug.py` pasó (3 tests OK).
- Intento de ejecutar un subconjunto de `tests/unit/test_safe_mode.py` con `PYTHONPATH=src` falló en fase de colección por `ImportError: attempted relative import beyond top-level package` debido al alias/deprecatión de imports (`core.interpreter`) en el entorno de pruebas actual, por lo que esos tests no se pudieron ejecutar aquí; el cambio es localmente verificable y unit-testable una vez resuelto el `PYTHONPATH`/resolución de imports en el entorno de CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e942969b883279505b333cf99fadd)