### PR TITLE
Make `_validador_metadata_usar` annotation Python 3.9-compatible

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -977,7 +977,7 @@ class InterpretadorCobra:
             cursor = getattr(cursor, "siguiente", None)
         return validadores_registrables
 
-    def _validador_metadata_usar(self) -> object | None:
+    def _validador_metadata_usar(self) -> Optional[object]:
         """Localiza el validador dueño de ``_metadata_simbolos_usar`` en la cadena."""
         cursor = self._validador
         while cursor is not None:


### PR DESCRIPTION
### Motivation
- Avoid import-time `TypeError` on supported Python 3.9 runtimes caused by the PEP 604 annotation `object | None` in the usar-metadata lookup helper.

### Description
- Replace the return annotation on `_validador_metadata_usar` from `object | None` to `Optional[object]` in `src/pcobra/core/interpreter.py` and reuse the already-imported `Optional` from `typing` so the module is importable under Python 3.9.

### Testing
- Ran `python -m py_compile src/pcobra/core/interpreter.py` which succeeded.
- Verified the runtime annotation via `from pcobra.core.interpreter import InterpretadorCobra` and inspecting `InterpretadorCobra._validador_metadata_usar.__annotations__`, which shows `Optional[object]` as the return annotation.
- Executed `pytest` for the related integration files (`tests/integration/test_repl_usar_entrypoints_contract.py` and `tests/integration/test_usar_canonical_surface_contract.py`), which ran but stopped after 5 failing tests (29 passed, 5 failed); the failures appear unrelated to this annotation change (they reflect integration expectations about `tiempo.ahora`, holobit error-message wording, and exposed symbols for some modules).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a213ff69fdc8327922a9f4f5ff40765)