### PR TITLE
Alinear metadatos de Python: mantener runtime >=3.9

### DIFF
--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -170,7 +170,7 @@ If you prefer to automate the process, run:
 ./scripts/install.sh --dev      # install in editable mode
 ```
 
-3. Create a virtual environment and activate it (Python 3.10 or higher):
+3. Create a virtual environment and activate it (Python 3.9 or higher):
 
 ```bash
 python -m venv .venv
@@ -225,7 +225,7 @@ PYTHONPATH=$PWD/src python -c "from src.core.main import main; main()"
 
 ### Installation with pipx
 
-[pipx](https://pypa.github.io/pipx/) is a tool to install and run Python applications in isolation and requires Python 3.10 or higher. To install Cobra with pipx run:
+[pipx](https://pypa.github.io/pipx/) is a tool to install and run Python applications in isolation and requires Python 3.10 or higher; Cobra itself supports Python 3.9 or higher. To install Cobra with pipx run:
 
 ```bash
 pipx install pcobra

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -227,7 +227,7 @@ tabulate==0.10.0
     # via smooth-criminal
 tomli==2.4.0
     # via pcobra (pyproject.toml)
-tree-sitter==0.25.2
+tree-sitter==0.23.2
     # via pcobra (pyproject.toml)
 typing-extensions==4.15.0
     # via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 dependencies = [
@@ -37,7 +38,7 @@ dependencies = [
     "flet~=0.28",
     "packaging>=24,<26",
     "pybind11>=2.13,<3",
-    "tree-sitter~=0.25",
+    "tree-sitter~=0.23.2",
     "RestrictedPython==8.0",
     "prompt_toolkit~=3.0",
     "Pygments~=2.19",
@@ -131,7 +132,7 @@ cobra = "pcobra.cli:main"
 
 [tool.black]
 line-length = 88
-target-version = ["py39", "py310", "py311"]
+target-version = ["py39", "py310", "py311", "py312"]
 
 [tool.isort]
 profile = "black"
@@ -140,7 +141,7 @@ known_first_party = ["pcobra"]
 
 [tool.ruff]
 line-length = 88
-target-version = "py311"
+target-version = "py39"
 exclude = [
     "docs/frontend",
     "docs/build",
@@ -153,7 +154,7 @@ select = ["E9", "F63", "F7", "F82"]
 ignore = []
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.9"
 ignore_missing_imports = true
 exclude = "^(docs/build/|docs/frontend/|venv/|.venv/|tests/|build/|dist/|examples/|notebooks/)"
 warn_unused_ignores = true
@@ -177,7 +178,7 @@ exclude = [
 ignore = []
 reportMissingImports = false
 reportMissingTypeStubs = false
-pythonVersion = "3.11"
+pythonVersion = "3.9"
 typeCheckingMode = "basic"
 useLibraryCodeForTypes = true
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -293,7 +293,7 @@ traitlets==5.14.3
     #   jupyter-client
     #   jupyter-core
     #   matplotlib-inline
-tree-sitter==0.25.1
+tree-sitter==0.23.2
     # via
     #   pcobra (pyproject.toml)
     #   tree-sitter-languages

--- a/requirements.txt
+++ b/requirements.txt
@@ -166,7 +166,7 @@ tabulate==0.9.0
     # via smooth-criminal
 tomli==2.2.1
     # via pcobra (pyproject.toml)
-tree-sitter==0.25.1
+tree-sitter==0.23.2
     # via pcobra (pyproject.toml)
 typing-extensions==4.13.2
     # via


### PR DESCRIPTION
### Motivation

- Mantener el runtime público en `Python >=3.9` para evitar forzar actualizaciones de librerías científicas mayor-ruptura (p.ej. NumPy 2.x / Pandas 3.x). 
- Detecté que la dependencia `tree-sitter` en la serie `0.25.x` requiere Python >=3.10, lo que hace incompatible la resolución con `>=3.9`. 
- Evitar cambios en lexer/parser/gramáticas y, en su lugar, ajustar metadata y pines para mantener compatibilidad de instalación.

### Description

- Mantengo `requires-python = ">=3.9"` y añado el clasificador `Programming Language :: Python :: 3.12` para reflejar la matriz CI nocturna. 
- Alineo herramientas de desarrollo/analizadores: `tool.black.target-version` ahora incluye `py312`, `tool.ruff.target-version` se fija en `py39`, y `tool.mypy.python_version` y `tool.pyright.pythonVersion` se bajan a `3.9` en `pyproject.toml`.
- Fijo `tree-sitter~=0.23.2` en `pyproject.toml` y sincronizo el pin a `tree-sitter==0.23.2` en `requirements.txt`, `requirements-dev.txt` y `docs/requirements.txt` para que la resolución sea compatible con Python 3.9.
- Actualizo texto de instalación en `docs/README.en.md` para indicar que Cobra soporta Python 3.9+, preservando la nota de que `pipx` requiere Python 3.10+.

### Testing

- ✅ Validación de metadata: parseo de `pyproject.toml` y aserciones automáticas sobre `requires-python`, clasificadores y configuraciones de `ruff`/`mypy`/`pyright` pasaron correctamente. 
- ⚠️ Resolución de dependencias con `uv pip compile --python-version 3.9` resolvió un conjunto compatible tras bajar `tree-sitter` a `0.23.2`, pero mostró la advertencia de entorno local (no hay Python 3.9 instalado y se usó Python 3.12 para construir los paquetes). 
- ✅ Simulación de instalación editable con `python -m pip install --dry-run -e .` completada sin errores con los cambios (resolvería `tree-sitter-0.23.2`). 
- ✅ Búsquedas (`rg`) para patrones obsoletos y `git diff --check` ejecutadas y sin errores.


Cambios comprometidos en commit `9c4d2bf` con mensaje "Align Python runtime metadata".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23e6fd43bc83278587917ed1e699bb)