### PR TITLE
Update optional dependency ranges

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,23 +57,23 @@ Documentation = "https://github.com/Alphonsus411/pCobra#readme"
 Source = "https://github.com/Alphonsus411/pCobra"
 
 [project.optional-dependencies]
-excel = ["openpyxl>=3.1,<4"]
-columnar = ["pyarrow>=17,<22"]
-io-binary = ["pyarrow>=17,<22"]
+excel = ["openpyxl>=3.1.5,<4"]
+columnar = ["pyarrow>=21,<22"]
+io-binary = ["pyarrow>=21,<22"]
 lsp = ["python-lsp-server~=1.13"]
 ml = [
-    "tensorflow>=2.13,<2.17",
-    "DEAP>=1.3.3,<1.5",
+    "tensorflow>=2.20,<2.21",
+    "DEAP>=1.4.4,<2",
 ]
-big-data = ["dask>=2024.6.2"]
+big-data = ["dask>=2024.8,<2024.9"]
 mutation = ["mutpy==0.6.1"]
 notebooks = [
-    "papermill~=2.6",
-    "nbconvert~=7.16",
-    "ipykernel~=6.29",
+    "papermill>=2.6,<2.7",
+    "nbconvert>=7.17,<8",
+    "ipykernel>=6.31,<7",
 ]
 docs = [
-    "sphinx~=7.2",
+    "sphinx>=7.4,<8",
     "sphinx-rtd-theme~=2.0",
     "myst-parser~=3.0",
     "sphinxcontrib-plantuml~=0.30",
@@ -81,15 +81,15 @@ docs = [
 dev = [
     "python-dotenv~=1.1",
     "python-lsp-server~=1.13",
-    "hypothesis~=6.138",
-    "ipykernel~=6.29",
+    "hypothesis>=6.141,<7",
+    "ipykernel>=6.31,<7",
     "tree-sitter-languages~=1.10",
-    "pytest~=8.4",
-    "pytest-cov~=6.2",
-    "pytest-timeout~=2.4",
-    "ruff~=0.12",
-    "mypy~=1.17",
-    "pip-tools~=7.4",
+    "pytest>=8.4,<9",
+    "pytest-cov>=7.1,<8",
+    "pytest-timeout>=2.4,<3",
+    "ruff>=0.15,<0.16",
+    "mypy>=1.19,<2",
+    "pip-tools>=7.5,<8",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
### Motivation
- Actualizar los extras en `pyproject.toml` a líneas más recientes y seguras manteniendo la política de compatibilidad con Python `>=3.9` del proyecto.
- Evitar rangos que requieren Python `>=3.10`/`>=3.12` cuando eso rompería la compatibilidad declarada, escogiendo la última línea compatible.
- Normalizar y modernizar las dependencias de desarrollo, notebooks y data/ML para reducir vulnerabilidades y facilitar reproducibilidad.

### Description
- Actualizado el extra `excel` a `openpyxl>=3.1.5,<4` para usar la última 3.1.x compatible con `>=3.9`.
- Actualizados `columnar` e `io-binary` a `pyarrow>=21,<22` (evitando `pyarrow 24` que requiere Python `>=3.10`).
- Actualizado `ml` a `tensorflow>=2.20,<2.21` y `DEAP>=1.4.4,<2` respetando compatibilidad con la política de Python.
- Actualizado `big-data` a `dask>=2024.8,<2024.9`, `notebooks` a `papermill>=2.6,<2.7`, `nbconvert>=7.17,<8`, `ipykernel>=6.31,<7`, `docs` a `sphinx>=7.4,<8`, y `dev` con `hypothesis>=6.141,<7`, `pytest>=8.4,<9`, `pytest-cov>=7.1,<8`, `pytest-timeout>=2.4,<3`, `ruff>=0.15,<0.16`, `mypy>=1.19,<2`, `pip-tools>=7.5,<8`.
- Conservado `mutation = ["mutpy==0.6.1"]` sin cambios y no se tocaron Lexer/Parser ni reglas de sintaxis.

### Testing
- Se consultaron versiones públicas con `pip index` y la metadata de PyPI (`requires_python`) para seleccionar las líneas más recientes compatibles; esas comprobaciones se realizaron por script HTTP a la API de PyPI y tuvieron éxito.
- Se ejecutó un script de validación que parsea `pyproject.toml` y aserta que los extras actualizados están presentes con los rangos esperados (`python - <<'PY' ... PY`), y el script devolvió validación satisfactoria.
- Se realizó una comprobación de diferencias/whitespace tras la edición y no se detectaron errores automáticos en la salida de verificación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23ea1edb748327acfe9c1f724f15d1)