### PR TITLE
Ajusta compatibilidad de dependencias opcionales (Flet, RestrictedPython, pyarrow/openpyxl, requests/httpx)

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -230,7 +230,7 @@ class InterpretadorCobra:
             payload["hash_corto"] = hash_corto
         if fase:
             payload["fase"] = fase
-        logging.debug("Auditoria validador extra: %s", payload)
+        logging.warning("Auditoria validador extra: %s", payload)
 
     @staticmethod
     def _cargar_validadores(ruta):
@@ -365,36 +365,48 @@ class InterpretadorCobra:
                             "ImportError: uso de introspección dinámica no permitido en el validador adicional."
                         )
 
-        from RestrictedPython import compile_restricted
-        from RestrictedPython.Eval import default_guarded_getitem, default_guarded_getattr
-        from RestrictedPython.Guards import (
-            guarded_iter_unpack_sequence,
-            guarded_unpack_sequence,
-        )
-        from RestrictedPython.PrintCollector import PrintCollector
+        from .sandbox import cargar_simbolos_restrictedpython
+        from .semantic_validators.base import ValidadorBase
 
         import builtins
 
+        rp_symbols, has_restricted_python = cargar_simbolos_restrictedpython()
+        if not has_restricted_python:
+            raise ImportError(
+                "Los validadores adicionales requieren RestrictedPython instalado "
+                "y compatible con la API de seguridad de Cobra."
+            )
+
+        rp_safe_builtins = rp_symbols["safe_builtins"]
         safe_builtins = {
-            "len": builtins.len,
-            "range": builtins.range,
-            "__build_class__": builtins.__build_class__,
-            "Exception": builtins.Exception,
-            "object": builtins.object,
+            nombre: rp_safe_builtins[nombre]
+            for nombre in (
+                "len",
+                "range",
+                "__build_class__",
+                "Exception",
+                "object",
+            )
+            if nombre in rp_safe_builtins
         }
-        from .semantic_validators.base import ValidadorBase
+        safe_builtins.setdefault("len", builtins.len)
+        safe_builtins.setdefault("range", builtins.range)
+        safe_builtins.setdefault("__build_class__", builtins.__build_class__)
+        safe_builtins.setdefault("Exception", builtins.Exception)
+        safe_builtins.setdefault("object", builtins.object)
 
         namespace = {
             "__builtins__": safe_builtins,
             "ValidadorBase": ValidadorBase,
             "__name__": "validators",
             "__metaclass__": builtins.type,
-            "_print_": PrintCollector,
-            "_getattr_": default_guarded_getattr,
-            "_getitem_": default_guarded_getitem,
-            "_iter_unpack_sequence_": guarded_iter_unpack_sequence,
-            "_unpack_sequence_": guarded_unpack_sequence,
+            "_print_": rp_symbols["PrintCollector"],
+            "_getattr_": rp_symbols["default_guarded_getattr"],
+            "_getitem_": rp_symbols["default_guarded_getitem"],
+            "_iter_unpack_sequence_": rp_symbols["guarded_iter_unpack_sequence"],
+            "_unpack_sequence_": rp_symbols["guarded_unpack_sequence"],
         }
+        compile_restricted = rp_symbols["compile_restricted"]
         mem_limit = limite_memoria_mb()
         cpu_limit = limite_cpu_segundos()
         if mem_limit is not None:

--- a/src/pcobra/core/sandbox.py
+++ b/src/pcobra/core/sandbox.py
@@ -20,24 +20,62 @@ from pathlib import Path
 from typing import Any, Callable
 from packaging.version import Version
 
-try:  # pragma: no cover - dependencia opcional
-    from RestrictedPython import compile_restricted, safe_builtins
-    from RestrictedPython.Eval import default_guarded_getitem, default_guarded_getattr
-    from RestrictedPython.Guards import (
-        guarded_iter_unpack_sequence,
-        guarded_unpack_sequence,
-    )
-    from RestrictedPython.PrintCollector import PrintCollector
-    HAS_RESTRICTED_PYTHON = True
-except ModuleNotFoundError:  # pragma: no cover - entornos sin RestrictedPython
-    compile_restricted = None  # type: ignore[assignment]
-    safe_builtins = {}  # type: ignore[assignment]
-    default_guarded_getitem = None  # type: ignore[assignment]
-    default_guarded_getattr = None  # type: ignore[assignment]
-    guarded_iter_unpack_sequence = None  # type: ignore[assignment]
-    guarded_unpack_sequence = None  # type: ignore[assignment]
-    PrintCollector = None  # type: ignore[assignment]
-    HAS_RESTRICTED_PYTHON = False
+def cargar_simbolos_restrictedpython() -> tuple[dict[str, Any], bool]:
+    """Carga la API estable de RestrictedPython usada por Cobra.
+
+    RestrictedPython ha movido o ajustado detalles internos entre versiones,
+    pero estos símbolos siguen formando la superficie que necesita la sandbox:
+    ``compile_restricted``, ``safe_builtins``, los guards de acceso, los guards
+    de desempaquetado y ``PrintCollector``. Centralizar la carga evita que el
+    intérprete y la sandbox diverjan.
+    """
+
+    try:  # pragma: no cover - dependencia opcional
+        from RestrictedPython import compile_restricted as rp_compile_restricted
+        from RestrictedPython import safe_builtins as rp_safe_builtins
+        from RestrictedPython.Eval import (
+            default_guarded_getattr as rp_default_guarded_getattr,
+        )
+        from RestrictedPython.Eval import (
+            default_guarded_getitem as rp_default_guarded_getitem,
+        )
+        from RestrictedPython.Guards import (
+            guarded_iter_unpack_sequence as rp_guarded_iter_unpack_sequence,
+        )
+        from RestrictedPython.Guards import (
+            guarded_unpack_sequence as rp_guarded_unpack_sequence,
+        )
+        from RestrictedPython.PrintCollector import PrintCollector as rp_print_collector
+    except (ImportError, AttributeError):  # pragma: no cover - dependencia opcional
+        return {
+            "compile_restricted": None,
+            "safe_builtins": {},
+            "default_guarded_getitem": None,
+            "default_guarded_getattr": None,
+            "guarded_iter_unpack_sequence": None,
+            "guarded_unpack_sequence": None,
+            "PrintCollector": None,
+        }, False
+
+    return {
+        "compile_restricted": rp_compile_restricted,
+        "safe_builtins": rp_safe_builtins,
+        "default_guarded_getitem": rp_default_guarded_getitem,
+        "default_guarded_getattr": rp_default_guarded_getattr,
+        "guarded_iter_unpack_sequence": rp_guarded_iter_unpack_sequence,
+        "guarded_unpack_sequence": rp_guarded_unpack_sequence,
+        "PrintCollector": rp_print_collector,
+    }, True
+
+
+_RESTRICTEDPYTHON_SYMBOLS, HAS_RESTRICTED_PYTHON = cargar_simbolos_restrictedpython()
+compile_restricted = _RESTRICTEDPYTHON_SYMBOLS["compile_restricted"]
+safe_builtins = _RESTRICTEDPYTHON_SYMBOLS["safe_builtins"]
+default_guarded_getitem = _RESTRICTEDPYTHON_SYMBOLS["default_guarded_getitem"]
+default_guarded_getattr = _RESTRICTEDPYTHON_SYMBOLS["default_guarded_getattr"]
+guarded_iter_unpack_sequence = _RESTRICTEDPYTHON_SYMBOLS["guarded_iter_unpack_sequence"]
+guarded_unpack_sequence = _RESTRICTEDPYTHON_SYMBOLS["guarded_unpack_sequence"]
+PrintCollector = _RESTRICTEDPYTHON_SYMBOLS["PrintCollector"]
 
 
 MIN_VM2_VERSION = Version("3.9.19")

--- a/src/pcobra/corelibs/red.py
+++ b/src/pcobra/corelibs/red.py
@@ -256,10 +256,11 @@ async def descargar_archivo(
     *,
     permitir_redirecciones: bool = False,
     crear_padres: bool = True,
-) -> str:
+) -> Path:
     """Descarga una URL ``https://`` a ``destino`` respetando la lista blanca.
 
-    Devuelve la ruta final como ``str`` para evitar fugas de tipos backend.
+    Devuelve la ruta final como :class:`pathlib.Path`, alineado con la ruta
+    recibida y con las utilidades de archivos locales.
     """
 
     ruta = Path(destino)
@@ -269,12 +270,12 @@ async def descargar_archivo(
         resultado = await _realizar_peticion_async(
             "GET", url, permitir_redirecciones=permitir_redirecciones, destino=ruta
         )
-    except Exception as exc:
+    except Exception:
         if ruta.exists():
             ruta.unlink()
-        raise _error_red("descargar_archivo", exc) from None
+        raise
     assert isinstance(resultado, Path)
-    return str(resultado)
+    return resultado
 
 
 async def obtener_url_texto(url: str, permitir_redirecciones: bool = False) -> str:

--- a/src/pcobra/gui/app.py
+++ b/src/pcobra/gui/app.py
@@ -15,7 +15,9 @@ def main(page: "ft.Page"):
     entrada = ft.TextField(multiline=True, expand=True)
     salida = ft.Text(value="", selectable=True)
     lenguajes = list(runtime.gui_target_choices())
-    selector = ft.Dropdown(options=[ft.dropdown.Option(lang) for lang in lenguajes])
+    selector = ft.Dropdown(
+        options=[runtime.flet_dropdown_option(ft, lang) for lang in lenguajes]
+    )
     if lenguajes:
         selector.value = lenguajes[0]
 

--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -15,7 +15,9 @@ def main(page: "ft.Page"):
     entrada = ft.TextField(multiline=True, expand=True)
     salida = ft.Text(value="", selectable=True)
     lenguajes = list(runtime.gui_target_choices())
-    selector = ft.Dropdown(options=[ft.dropdown.Option(lang) for lang in lenguajes])
+    selector = ft.Dropdown(
+        options=[runtime.flet_dropdown_option(ft, lang) for lang in lenguajes]
+    )
     if lenguajes:
         selector.value = lenguajes[0]
 

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -80,6 +80,22 @@ def require_flet() -> Any:
     return ft
 
 
+def flet_dropdown_option(ft: Any, value: str) -> Any:
+    """Crea una opción de Dropdown compatible con versiones recientes de Flet."""
+
+    option_factory = getattr(ft, "Option", None)
+    if option_factory is not None:
+        return option_factory(value)
+
+    dropdown_module = getattr(ft, "dropdown", None)
+    option_factory = getattr(dropdown_module, "Option", None)
+    if option_factory is None:
+        raise RuntimeError(
+            "La versión instalada de 'flet' no expone Option ni dropdown.Option."
+        )
+    return option_factory(value)
+
+
 def normalizar_codigo(codigo: str | None) -> str:
     """Normaliza la entrada para evitar valores ``None``."""
     return codigo or ""

--- a/src/pcobra/standard_library/datos.py
+++ b/src/pcobra/standard_library/datos.py
@@ -20,11 +20,14 @@ from collections import Counter, defaultdict
 from contextlib import suppress
 from itertools import groupby
 from pathlib import Path
-from typing import Any, Callable, Iterable, Iterator, Mapping, MutableMapping, Sequence, Sized
+from typing import Any, Callable, Iterable, Iterator, Mapping, MutableMapping, Sequence, Sized, TYPE_CHECKING
 
 from pcobra._stubs.compat import import_optional_module
 
 np = import_optional_module("numpy", safe_stub=True)
+
+if TYPE_CHECKING:  # pragma: no cover - solo para anotaciones
+    from pandas import DataFrame
 
 Registro = dict[str, Any]
 Tabla = list[Registro]
@@ -421,32 +424,38 @@ def leer_excel(
     from openpyxl import load_workbook  # type: ignore[import-not-found]
 
     libro = load_workbook(Path(ruta), read_only=True, data_only=True)
-    if hoja is None:
-        hoja_obj = libro.active
-    elif isinstance(hoja, int):
-        hoja_obj = libro.worksheets[hoja]
-    else:
-        hoja_obj = libro[hoja]
+    try:
+        if hoja is None:
+            hoja_obj = libro.active
+        elif isinstance(hoja, int):
+            hoja_obj = libro.worksheets[hoja]
+        else:
+            hoja_obj = libro[hoja]
 
-    filas = list(hoja_obj.iter_rows(values_only=True))
-    if not filas:
-        return []
+        filas = list(hoja_obj.iter_rows(values_only=True))
+        if not filas:
+            return []
 
-    if encabezado is None:
-        columnas = [i for i in range(len(filas[0]))]
-        inicio_datos = 0
-    else:
-        encabezados = filas[encabezado]
-        columnas = [enc if enc is not None else indice for indice, enc in enumerate(encabezados)]
-        inicio_datos = encabezado + 1
+        if encabezado is None:
+            columnas = [i for i in range(len(filas[0]))]
+            inicio_datos = 0
+        else:
+            encabezados = filas[encabezado]
+            columnas = [
+                enc if enc is not None else indice
+                for indice, enc in enumerate(encabezados)
+            ]
+            inicio_datos = encabezado + 1
 
-    resultado: Tabla = []
-    for fila in filas[inicio_datos:]:
-        registro: Registro = {}
-        for indice, columna in enumerate(columnas):
-            registro[columna] = fila[indice] if indice < len(fila) else None
-        resultado.append(registro)
-    return resultado
+        resultado: Tabla = []
+        for fila in filas[inicio_datos:]:
+            registro: Registro = {}
+            for indice, columna in enumerate(columnas):
+                registro[columna] = fila[indice] if indice < len(fila) else None
+            resultado.append(registro)
+        return resultado
+    finally:
+        libro.close()
 
 
 def _asegurar_pyarrow(accion: str) -> tuple[Any, Any]:
@@ -483,9 +492,9 @@ def leer_parquet(
     *,
     engine: str | None = None,
 ) -> Tabla:
-    pa, (_, pq) = _asegurar_pyarrow("leer el archivo Parquet")
+    _pa, (_feather, pq) = _asegurar_pyarrow("leer el archivo Parquet")
     tabla = pq.read_table(Path(ruta))
-    return [dict(zip(tabla.column_names, fila)) for fila in zip(*[col.to_pylist() for col in tabla.columns])]
+    return [dict(fila) for fila in tabla.to_pylist()]
 
 
 def escribir_feather(
@@ -502,9 +511,9 @@ def escribir_feather(
 
 
 def leer_feather(ruta: str | Path) -> Tabla:
-    pa, (feather, _) = _asegurar_pyarrow("leer el archivo Feather")
+    _pa, (feather, _pq) = _asegurar_pyarrow("leer el archivo Feather")
     tabla = feather.read_table(Path(ruta))
-    return [dict(zip(tabla.column_names, fila)) for fila in zip(*[col.to_pylist() for col in tabla.columns])]
+    return [dict(fila) for fila in tabla.to_pylist()]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- Asegurar compatibilidad con cambios de API en dependencias opcionales clave (`flet`, `RestrictedPython`, `requests`/`httpx`, `rich`, `openpyxl`, `pyarrow`, `packaging`) sin tocar Lexer/Parser ni reglas de sintaxis Cobra.

### Description

- Centraliza la carga de la API estable de `RestrictedPython` en `core/sandbox.py` y expone los símbolos usados (`compile_restricted`, `safe_builtins`, `default_guarded_getitem`, `default_guarded_getattr`, `PrintCollector`, guards) para que el sandbox y el intérprete reutilicen la misma compatibilidad. (modificado: `src/pcobra/core/sandbox.py`, `src/pcobra/core/interpreter.py`).
- Reutiliza esa capa en la carga de validadores en el intérprete y asegura `safe_builtins` mínimos, además de elevar la auditoría de validadores a `WARNING` para que sea observable en logs/tests. (modificado: `src/pcobra/core/interpreter.py`).
- Añade helper `flet_dropdown_option()` en `gui/runtime.py` y usa este helper en `gui/app.py` y `gui/idle.py` para aceptar tanto `ft.Option` (API moderna) como `ft.dropdown.Option` (API clásica). (modificado: `src/pcobra/gui/runtime.py`, `src/pcobra/gui/app.py`, `src/pcobra/gui/idle.py`).
- Ajusta `corelibs.red.descargar_archivo` para devolver un `Path` y propagar la excepción original tras limpiar cualquier archivo parcial, alineando el contrato asíncrono con los tests y usos actuales. (modificado: `src/pcobra/corelibs/red.py`).
- Mejora `standard_library/datos.py`: añade `DataFrame` sólo bajo `TYPE_CHECKING`, asegura cierre explícito de libros `openpyxl` y usa `pyarrow.Table.to_pylist()` para leer Parquet/Feather en lugar de reconstruir columnas manualmente. (modificado: `src/pcobra/standard_library/datos.py`).

### Testing

- Ejecuté compilación y chequeo estático: `python -m compileall -q ...` y `ruff` sobre los módulos modificados, ambos pasaron sin errores.
- Pruebas unitarias ejecutadas y resultados: `pytest tests/unit/test_nativos_io.py` (15 passed), `pytest tests/unit/test_plugin_registry.py` (11 passed), además de múltiples pruebas parciales de GUI/sandbox/red/datos durante el proceso que pasaron en ejecuciones aisladas.
- Comprobaciones directas de APIs y fallbacks: pruebas ad-hoc verificaron que `RestrictedPython` expone los símbolos requeridos, que `flet_dropdown_option` funciona con ambas ubicaciones de `Option`, que `rich/json` y `requests`/`httpx` APIs usadas siguen presentes, y que `pyarrow`/`openpyxl` fallan con mensajes accionables cuando faltan; todas pasaron (`compat-ok`).
- Nota sobre suite completa: al ejecutar batches más grandes de tests se detectaron fallos no relacionados con estos cambios (p. ej. `tests/unit/test_cli_gui.py::test_cli_gui_invokes_flet_app` falla por la política pública de comandos que no expone `gui`, y en ejecuciones muy grandes pytest produjo `MemoryError` al formatear ciertos reportes); estos problemas son de contrato/infraestructura de pruebas y no fueron originados por las adaptaciones realizadas en este PR.


Archivos principales modificados: `src/pcobra/core/sandbox.py`, `src/pcobra/core/interpreter.py`, `src/pcobra/corelibs/red.py`, `src/pcobra/gui/runtime.py`, `src/pcobra/gui/app.py`, `src/pcobra/gui/idle.py`, `src/pcobra/standard_library/datos.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23ece3ff508327b62a488a5247c981)