### PR TITLE
test: add dependency import smoke coverage

### DIFF
--- a/tests/unit/test_dependency_import_smoke.py
+++ b/tests/unit/test_dependency_import_smoke.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import importlib
+import io
+import sys
+
+import pytest
+
+
+def _purge_modules(monkeypatch: pytest.MonkeyPatch, *module_roots: str) -> None:
+    """Elimina stubs ya cargados para importar la dependencia real."""
+
+    for name in list(sys.modules):
+        if any(name == root or name.startswith(f"{root}.") for root in module_roots):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def test_flet_import_and_basic_control_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    _purge_modules(monkeypatch, "flet")
+
+    flet = importlib.import_module("flet")
+
+    text = flet.Text("cobra")
+    assert text.value == "cobra"
+
+
+def test_restrictedpython_import_and_restricted_exec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _purge_modules(monkeypatch, "RestrictedPython")
+
+    restricted = importlib.import_module("RestrictedPython")
+
+    code = restricted.compile_restricted("resultado = 2 + 3", "<smoke>", "exec")
+    namespace = {"__builtins__": restricted.safe_builtins.copy()}
+    exec(code, namespace)
+    assert namespace["resultado"] == 5
+
+
+def test_requests_import_and_basic_prepared_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _purge_modules(monkeypatch, "requests")
+
+    requests = importlib.import_module("requests")
+
+    prepared = requests.Request(
+        "GET", "https://example.com/recurso", params={"q": "cobra"}
+    ).prepare()
+    assert prepared.method == "GET"
+    assert prepared.url == "https://example.com/recurso?q=cobra"
+
+
+def test_httpx_import_and_basic_response_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    _purge_modules(monkeypatch, "httpx")
+
+    httpx = importlib.import_module("httpx")
+
+    response = httpx.Response(204)
+    assert response.status_code == 204
+    assert response.is_success
+
+
+def test_rich_import_and_basic_console_render(monkeypatch: pytest.MonkeyPatch) -> None:
+    _purge_modules(monkeypatch, "rich")
+
+    console_module = importlib.import_module("rich.console")
+    table_module = importlib.import_module("rich.table")
+
+    output = io.StringIO()
+    console = console_module.Console(file=output, width=40, force_terminal=False)
+    table = table_module.Table()
+    table.add_column("libreria")
+    table.add_row("rich")
+    console.print(table)
+
+    assert "rich" in output.getvalue()
+
+
+def test_openpyxl_optional_extra_import_and_workbook_usage() -> None:
+    openpyxl = pytest.importorskip("openpyxl")
+
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet["A1"] = "cobra"
+
+    assert sheet["A1"].value == "cobra"
+
+
+def test_pyarrow_optional_extra_import_and_table_usage() -> None:
+    pyarrow = pytest.importorskip("pyarrow")
+
+    table = pyarrow.table({"lenguaje": ["cobra"]})
+
+    assert table.num_rows == 1
+    assert table.column("lenguaje").to_pylist() == ["cobra"]
+
+
+def test_packaging_import_and_basic_version_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    _purge_modules(monkeypatch, "packaging")
+
+    version_module = importlib.import_module("packaging.version")
+
+    assert version_module.Version("1.2.3") < version_module.Version("2")
+
+
+def test_tree_sitter_import_and_basic_parser_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _purge_modules(monkeypatch, "tree_sitter")
+
+    tree_sitter = importlib.import_module("tree_sitter")
+
+    parser = tree_sitter.Parser()
+    assert parser is not None

--- a/tests/unit/test_syntax_fixture_guard.py
+++ b/tests/unit/test_syntax_fixture_guard.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+EXPECTED_SYNTAX_FIXTURES_SHA256 = (
+    "f346d7efd9cab701aacb5563bd61fec24b597940a359c018f757ee1b792cb7d1"
+)
+
+
+def test_existing_syntax_fixtures_were_not_modified() -> None:
+    fixtures_root = Path(__file__).resolve().parents[1] / "fixtures"
+    fixture_files = sorted(fixtures_root.rglob("*.cobra"))
+
+    digest = hashlib.sha256()
+    for fixture_file in fixture_files:
+        digest.update(fixture_file.relative_to(fixtures_root.parent).as_posix().encode())
+        digest.update(b"\0")
+        digest.update(fixture_file.read_bytes())
+        digest.update(b"\0")
+
+    assert len(fixture_files) == 9
+    assert digest.hexdigest() == EXPECTED_SYNTAX_FIXTURES_SHA256


### PR DESCRIPTION
### Motivation

- Añadir pruebas que verifiquen la capacidad de importar y usar dependencias de runtime relevantes y extras opcionales sin introducir falsos positivos por los stubs de pruebas.
- Asegurar que los extras opcionales (`openpyxl`, `pyarrow`) se prueban solo cuando están instalados y no provocan fallos en entornos mínimos.
- Proteger los fixtures sintácticos existentes verificando por checksum que no se han modificado accidentalmente.

### Description

- Se añadió `tests/unit/test_dependency_import_smoke.py` con smoke tests de importación y uso básico para `flet`, `RestrictedPython`, `requests`, `httpx`, `rich`, `packaging` y `tree_sitter`, y con limpieza de `sys.modules` previa para evitar stubs cargados por `conftest.py`.
- En el mismo archivo se usan `pytest.importorskip` para `openpyxl` y `pyarrow` de modo que las pruebas de extras se salten cuando no están instaladas.
- Se añadió `tests/unit/test_syntax_fixture_guard.py` que calcula un `sha256` sobre los `.cobra` en `tests/fixtures` y lo compara contra un valor esperado para garantizar que los fixtures sintácticos no cambian.
- No se introdujeron cambios en la lógica del Lexer, Parser ni en fixtures; solo se añadieron pruebas adicionales y la comprobación de integridad de fixtures.

### Testing

- Se comprobó la sintaxis compilando con `python -m py_compile tests/unit/test_dependency_import_smoke.py tests/unit/test_syntax_fixture_guard.py` y la compilación fue correcta.
- Se ejecutaron los nuevos tests con `python -m pytest tests/unit/test_dependency_import_smoke.py tests/unit/test_syntax_fixture_guard.py` y el resultado fue `8 passed, 2 skipped` (los skips corresponden a `openpyxl` y `pyarrow` no instalados).
- Se ejecutaron los nuevos tests junto con `tests/unit/test_nativos_io.py` con `python -m pytest tests/unit/test_dependency_import_smoke.py tests/unit/test_syntax_fixture_guard.py tests/unit/test_nativos_io.py` y el resultado fue `23 passed, 2 skipped`.
- Se verificaron también pruebas de transpiladores inversos; esas pruebas de integración fallaron en este entorno por ausencia de las gramáticas opcionales `tree_sitter_javascript` / `tree_sitter_java`, lo cual es una limitación del entorno y no un efecto de los cambios introducidos aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23f57c8c6083279f94f287967bb32d)