### PR TITLE
Centraliza adaptadores Flet y compatibiliza la GUI con Flet 0.85

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "python-dotenv>=1.2.2,<2",
     "pexpect>=4.9,<5",
     "requests>=2.34.2,<3",
-    "flet>=0.28.3,<0.29",
+    "flet>=0.28.3,!=0.29.*,<0.86",
     "packaging>=26.2,<27",
     "pybind11>=3.0.4,<4",
     "tree-sitter>=0.25.2,<0.26",

--- a/src/pcobra/cobra/cli/commands/flet_cmd.py
+++ b/src/pcobra/cobra/cli/commands/flet_cmd.py
@@ -7,6 +7,7 @@ from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error
+from pcobra.gui import runtime as gui_runtime
 
 
 class FletCommand(BaseCommand):
@@ -66,9 +67,12 @@ class FletCommand(BaseCommand):
         gui_module = "pcobra.gui.idle" if ui_target == "idle" else "pcobra.gui.app"
 
         try:
-            import flet as flet_runtime
-        except (ImportError, ModuleNotFoundError) as exc:
-            self._report_import_error(exc, context="flet")
+            flet_runtime = gui_runtime.require_flet()
+        except RuntimeError:
+            self._report_import_error(
+                ModuleNotFoundError("No module named 'flet'", name="flet"),
+                context="flet",
+            )
             return 1
 
         try:
@@ -80,7 +84,7 @@ class FletCommand(BaseCommand):
             self._report_import_error(e, context=gui_module)
             return 1
         try:
-            flet_runtime.app(target=main)
+            gui_runtime.flet_app(main, ft=flet_runtime)
             return 0
         except Exception as e:
             mostrar_error(_("Error inesperado al ejecutar la aplicación: {0}").format(str(e)))

--- a/src/pcobra/gui/app.py
+++ b/src/pcobra/gui/app.py
@@ -12,16 +12,16 @@ def main(page: "ft.Page"):
     """Función principal para Flet."""
     ft = runtime.require_flet()
 
-    entrada = ft.TextField(multiline=True, expand=True)
-    salida = ft.Text(value="", selectable=True)
+    entrada = runtime.flet_text_field(ft, multiline=True, expand=True)
+    salida = runtime.flet_text(ft, value="", selectable=True)
     lenguajes = list(runtime.gui_target_choices())
-    selector = ft.Dropdown(
-        options=[runtime.flet_dropdown_option(ft, lang) for lang in lenguajes]
+    selector = runtime.flet_dropdown(
+        ft, options=[runtime.flet_dropdown_option(ft, lang) for lang in lenguajes]
     )
     if lenguajes:
         selector.value = lenguajes[0]
 
-    activar = ft.Switch(label="Transpilar", disabled=not lenguajes)
+    activar = runtime.flet_switch(ft, label="Transpilar", disabled=not lenguajes)
 
     def ejecutar_handler(_e):
         deps = runtime.require_gui_dependencies()
@@ -46,6 +46,6 @@ def main(page: "ft.Page"):
         entrada,
         selector,
         activar,
-        ft.ElevatedButton("Ejecutar", on_click=ejecutar_handler),
+        runtime.flet_elevated_button(ft, "Ejecutar", on_click=ejecutar_handler),
         salida,
     )

--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -12,16 +12,16 @@ def main(page: "ft.Page"):
     """Función principal para el entorno IDLE."""
     ft = runtime.require_flet()
 
-    entrada = ft.TextField(multiline=True, expand=True)
-    salida = ft.Text(value="", selectable=True)
+    entrada = runtime.flet_text_field(ft, multiline=True, expand=True)
+    salida = runtime.flet_text(ft, value="", selectable=True)
     lenguajes = list(runtime.gui_target_choices())
-    selector = ft.Dropdown(
-        options=[runtime.flet_dropdown_option(ft, lang) for lang in lenguajes]
+    selector = runtime.flet_dropdown(
+        ft, options=[runtime.flet_dropdown_option(ft, lang) for lang in lenguajes]
     )
     if lenguajes:
         selector.value = lenguajes[0]
 
-    activar = ft.Switch(label="Transpilar", disabled=not lenguajes)
+    activar = runtime.flet_switch(ft, label="Transpilar", disabled=not lenguajes)
 
     def ejecutar_handler(_e):
         deps = runtime.require_gui_dependencies()
@@ -74,8 +74,8 @@ def main(page: "ft.Page"):
         entrada,
         selector,
         activar,
-        ft.ElevatedButton("Ejecutar", on_click=ejecutar_handler),
-        ft.ElevatedButton("Tokens", on_click=tokens_handler),
-        ft.ElevatedButton("AST", on_click=ast_handler),
+        runtime.flet_elevated_button(ft, "Ejecutar", on_click=ejecutar_handler),
+        runtime.flet_elevated_button(ft, "Tokens", on_click=tokens_handler),
+        runtime.flet_elevated_button(ft, "AST", on_click=ast_handler),
         salida,
     )

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -80,6 +80,53 @@ def require_flet() -> Any:
     return ft
 
 
+def _flet_attr(ft: Any, attr_name: str, api_name: str) -> Any:
+    """Devuelve una API raíz de Flet o falla con un mensaje homogéneo."""
+
+    attr = getattr(ft, attr_name, None)
+    if attr is None:
+        raise RuntimeError(f"La versión instalada de 'flet' no expone {api_name}.")
+    return attr
+
+
+def flet_app(target: Any, *args: Any, ft: Any | None = None, **kwargs: Any) -> Any:
+    """Lanza ``ft.app`` desde un único adaptador compatible."""
+
+    flet_runtime = ft if ft is not None else require_flet()
+    app_factory = _flet_attr(flet_runtime, "app", "app")
+    return app_factory(*args, target=target, **kwargs)
+
+
+def flet_text_field(ft: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.TextField`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "TextField", "TextField")(**kwargs)
+
+
+def flet_text(ft: Any, *args: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.Text`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "Text", "Text")(*args, **kwargs)
+
+
+def flet_dropdown(ft: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.Dropdown`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "Dropdown", "Dropdown")(**kwargs)
+
+
+def flet_switch(ft: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.Switch`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "Switch", "Switch")(**kwargs)
+
+
+def flet_elevated_button(ft: Any, *args: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.ElevatedButton`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "ElevatedButton", "ElevatedButton")(*args, **kwargs)
+
+
 def flet_dropdown_option(ft: Any, value: str) -> Any:
     """Crea una opción de Dropdown compatible con versiones recientes de Flet."""
 

--- a/src/pcobra/standard_library/interfaz.py
+++ b/src/pcobra/standard_library/interfaz.py
@@ -796,31 +796,25 @@ GuiTarget = Callable[[Any], None]
 def iniciar_gui(*, destino: GuiTarget | None = None, **kwargs: Any) -> None:
     """Inicia la aplicación gráfica principal basada en Flet."""
 
-    try:
-        import flet as ft
-    except ModuleNotFoundError as exc:  # pragma: no cover - rama dependiente del entorno
-        raise RuntimeError("Flet no está instalado. Ejecuta 'pip install flet'.") from exc
+    from pcobra.gui import runtime
 
     target = destino
     if target is None:
         from pcobra.gui.app import main as target  # type: ignore[assignment]
 
-    ft.app(target=target, **kwargs)
+    runtime.flet_app(target, **kwargs)
 
 
 def iniciar_gui_idle(*, destino: GuiTarget | None = None, **kwargs: Any) -> None:
     """Abre el entorno interactivo (IDLE) de Cobra usando Flet."""
 
-    try:
-        import flet as ft
-    except ModuleNotFoundError as exc:  # pragma: no cover - rama dependiente del entorno
-        raise RuntimeError("Flet no está instalado. Ejecuta 'pip install flet'.") from exc
+    from pcobra.gui import runtime
 
     target = destino
     if target is None:
         from pcobra.gui.idle import main as target  # type: ignore[assignment]
 
-    ft.app(target=target, **kwargs)
+    runtime.flet_app(target, **kwargs)
 
 
 __all__ = [

--- a/tests/unit/test_cli_gui_without_flet.py
+++ b/tests/unit/test_cli_gui_without_flet.py
@@ -11,16 +11,17 @@ def _args(ui: str = "idle") -> SimpleNamespace:
     return SimpleNamespace(ui=ui)
 
 
-def _default_module(name: str) -> SimpleNamespace:
-    if name == "pcobra.cobra.cli.commands.compile_cmd":
-        return SimpleNamespace(TRANSPILERS={})
-    if name == "pcobra.cobra.core":
-        return SimpleNamespace(Lexer=object, Parser=object)
-    if name == "pcobra.cobra.transpilers.target_utils":
-        return SimpleNamespace(target_cli_choices=lambda _targets: ())
-    if name == "pcobra.core.interpreter":
-        return SimpleNamespace(InterpretadorCobra=object)
-    return SimpleNamespace()
+def _deps_module(**overrides):
+    attrs = {
+        "Lexer": object,
+        "Parser": object,
+        "InterpretadorCobra": object,
+        "get_transpilers": lambda: {},
+        "target_cli_choices": lambda _targets: (),
+        "OFFICIAL_TARGETS": ("python", "javascript", "rust"),
+    }
+    attrs.update(overrides)
+    return SimpleNamespace(**attrs)
 
 
 def test_cli_gui_reporta_falta_de_flet(monkeypatch):
@@ -44,17 +45,17 @@ def test_cli_gui_reporta_falta_de_flet(monkeypatch):
     assert "pip install flet" in mensajes[0]
 
 
-def test_cli_gui_reporta_falta_de_modulo_core_en_preflight(monkeypatch):
+def test_cli_gui_reporta_falta_de_modulo_deps_en_preflight(monkeypatch):
     mensajes: list[str] = []
     cmd = FletCommand()
     fake_flet = SimpleNamespace(app=lambda **_kwargs: None)
 
     def _import_module(name: str):
-        if name == "pcobra.cobra.core":
-            raise ModuleNotFoundError("No module named 'pcobra.cobra.core'", name=name)
+        if name == "pcobra.cobra.gui.deps":
+            raise ModuleNotFoundError("No module named 'pcobra.cobra.gui.deps'", name=name)
         if name == "pcobra.gui.idle":
             return SimpleNamespace(main=lambda _page: None)
-        return _default_module(name)
+        return _deps_module()
 
     monkeypatch.setattr("pcobra.cobra.cli.commands.flet_cmd.mostrar_error", mensajes.append)
     monkeypatch.setattr("pcobra.cobra.cli.commands.flet_cmd.importlib.import_module", _import_module)
@@ -64,50 +65,23 @@ def test_cli_gui_reporta_falta_de_modulo_core_en_preflight(monkeypatch):
 
     assert result == 1
     assert "Error de importación GUI" in mensajes[0]
-    assert "pcobra.cobra.core" in mensajes[0]
+    assert "pcobra.cobra.gui.deps" in mensajes[0]
     assert "pip install -e ." in mensajes[0]
 
 
-def test_cli_gui_reporta_falta_de_modulo_transpiler_en_preflight(monkeypatch):
+def test_cli_gui_idle_reporta_simbolo_faltante_con_contexto_accionable(monkeypatch):
     mensajes: list[str] = []
     cmd = FletCommand()
     fake_flet = SimpleNamespace(app=lambda **_kwargs: None)
 
     def _import_module(name: str):
-        if name == "pcobra.cobra.transpilers.targets":
-            raise ModuleNotFoundError("No module named 'pcobra.cobra.transpilers.targets'", name=name)
+        if name == "pcobra.cobra.gui.deps":
+            deps = _deps_module()
+            delattr(deps, "InterpretadorCobra")
+            return deps
         if name == "pcobra.gui.idle":
             return SimpleNamespace(main=lambda _page: None)
-        return _default_module(name)
-
-    monkeypatch.setattr("pcobra.cobra.cli.commands.flet_cmd.mostrar_error", mensajes.append)
-    monkeypatch.setattr("pcobra.cobra.cli.commands.flet_cmd.importlib.import_module", _import_module)
-    monkeypatch.setitem(sys.modules, "flet", fake_flet)
-
-    result = cmd.run(_args())
-
-    assert result == 1
-    assert "Error de importación GUI" in mensajes[0]
-    assert "pcobra.cobra.transpilers.targets" in mensajes[0]
-    assert "pip install -e ." in mensajes[0]
-
-
-def test_cli_gui_idle_reporta_modulo_faltante_con_contexto_accionable(monkeypatch):
-    mensajes: list[str] = []
-    cmd = FletCommand()
-    fake_flet = SimpleNamespace(app=lambda **_kwargs: None)
-
-    def _import_module(name: str):
-        if name == "pcobra.core.interpreter":
-            raise ModuleNotFoundError("No module named 'pcobra.core.interpreter'", name=name)
-        if name == "pcobra.gui.idle":
-            return SimpleNamespace(main=lambda _page: None)
-        return SimpleNamespace(
-            Lexer=object,
-            Parser=object,
-            TRANSPILERS={},
-            target_cli_choices=lambda _targets: (),
-        )
+        return _deps_module()
 
     monkeypatch.setattr("pcobra.cobra.cli.commands.flet_cmd.mostrar_error", mensajes.append)
     monkeypatch.setattr("pcobra.cobra.cli.commands.flet_cmd.importlib.import_module", _import_module)
@@ -116,28 +90,23 @@ def test_cli_gui_idle_reporta_modulo_faltante_con_contexto_accionable(monkeypatc
     result = cmd.run(_args("idle"))
 
     assert result == 1
-    assert "pcobra.core.interpreter" in mensajes[0]
-    assert "pip install -e ." in mensajes[0]
+    assert "pcobra.cobra.gui.deps.InterpretadorCobra" in mensajes[0]
+    assert "corrige el import local" in mensajes[0]
 
 
-def test_cli_gui_app_reporta_modulo_faltante_con_contexto_accionable(monkeypatch):
+def test_cli_gui_app_reporta_simbolo_faltante_con_contexto_accionable(monkeypatch):
     mensajes: list[str] = []
     cmd = FletCommand()
     fake_flet = SimpleNamespace(app=lambda **_kwargs: None)
 
     def _import_module(name: str):
-        if name == "pcobra.cobra.cli.commands.compile_cmd":
-            raise ModuleNotFoundError(
-                "No module named 'pcobra.cobra.cli.commands.compile_cmd'", name=name
-            )
+        if name == "pcobra.cobra.gui.deps":
+            deps = _deps_module()
+            delattr(deps, "get_transpilers")
+            return deps
         if name == "pcobra.gui.app":
             return SimpleNamespace(main=lambda _page: None)
-        return SimpleNamespace(
-            Lexer=object,
-            Parser=object,
-            InterpretadorCobra=object,
-            target_cli_choices=lambda _targets: (),
-        )
+        return _deps_module()
 
     monkeypatch.setattr("pcobra.cobra.cli.commands.flet_cmd.mostrar_error", mensajes.append)
     monkeypatch.setattr("pcobra.cobra.cli.commands.flet_cmd.importlib.import_module", _import_module)
@@ -146,8 +115,8 @@ def test_cli_gui_app_reporta_modulo_faltante_con_contexto_accionable(monkeypatch
     result = cmd.run(_args("app"))
 
     assert result == 1
-    assert "pcobra.cobra.cli.commands.compile_cmd" in mensajes[0]
-    assert "pip install -e ." in mensajes[0]
+    assert "pcobra.cobra.gui.deps.get_transpilers" in mensajes[0]
+    assert "corrige el import local" in mensajes[0]
 
 
 def test_cli_gui_reporta_error_interno_de_import(monkeypatch):
@@ -158,7 +127,7 @@ def test_cli_gui_reporta_error_interno_de_import(monkeypatch):
     def _import_module(name: str):
         if name == "pcobra.gui.idle":
             raise ImportError("cannot import name 'main' from partially initialized module")
-        return _default_module(name)
+        return _deps_module()
 
     monkeypatch.setattr("pcobra.cobra.cli.commands.flet_cmd.mostrar_error", mensajes.append)
     monkeypatch.setattr("pcobra.cobra.cli.commands.flet_cmd.importlib.import_module", _import_module)
@@ -177,15 +146,17 @@ def test_cli_gui_reporta_simbolo_faltante_en_preflight(monkeypatch):
     fake_flet = SimpleNamespace(app=lambda **_kwargs: None)
 
     def _import_module(name: str):
-        if name == "pcobra.cobra.core":
-            return SimpleNamespace(Lexer=object)
+        if name == "pcobra.cobra.gui.deps":
+            return SimpleNamespace(
+                Lexer=object,
+                InterpretadorCobra=object,
+                get_transpilers=lambda: {},
+                target_cli_choices=lambda _targets: (),
+                OFFICIAL_TARGETS=("python", "javascript", "rust"),
+            )
         if name == "pcobra.gui.idle":
             return SimpleNamespace(main=lambda _page: None)
-        return SimpleNamespace(
-            TRANSPILERS={},
-            target_cli_choices=lambda _targets: (),
-            InterpretadorCobra=object,
-        )
+        return _deps_module()
 
     monkeypatch.setattr("pcobra.cobra.cli.commands.flet_cmd.mostrar_error", mensajes.append)
     monkeypatch.setattr("pcobra.cobra.cli.commands.flet_cmd.importlib.import_module", _import_module)
@@ -194,8 +165,7 @@ def test_cli_gui_reporta_simbolo_faltante_en_preflight(monkeypatch):
     result = cmd.run(_args("idle"))
 
     assert result == 1
-    assert "pcobra.cobra.core.Parser" in mensajes[0]
-    assert "pcobra.cobra.core" in mensajes[0]
+    assert "pcobra.cobra.gui.deps.Parser" in mensajes[0]
 
 
 def test_cli_gui_importerror_sin_name_extrae_modulo_desde_mensaje(monkeypatch):
@@ -208,7 +178,7 @@ def test_cli_gui_importerror_sin_name_extrae_modulo_desde_mensaje(monkeypatch):
             err = ImportError("No module named 'rich'")
             err.name = None
             raise err
-        return _default_module(name)
+        return _deps_module()
 
     monkeypatch.setattr("pcobra.cobra.cli.commands.flet_cmd.mostrar_error", mensajes.append)
     monkeypatch.setattr("pcobra.cobra.cli.commands.flet_cmd.importlib.import_module", _import_module)

--- a/tests/unit/test_gui_menu.py
+++ b/tests/unit/test_gui_menu.py
@@ -1,74 +1,79 @@
 import importlib
-import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 
-def _fake_flet():
-    class TextField:
-        def __init__(self, **kwargs):
-            self.value = ""
+class FakeTextField:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.value = ""
 
-    class Text:
-        def __init__(self, value="", **kwargs):
-            self.value = value
 
-    class Dropdown:
-        def __init__(self, options=None, **kwargs):
-            self.options = options or []
-            self.value = None
+class FakeText:
+    def __init__(self, value="", **kwargs):
+        self.kwargs = kwargs
+        self.value = value
 
-    class Switch:
-        def __init__(self, **kwargs):
-            self.value = False
 
-    class ElevatedButton:
-        def __init__(self, text, on_click=None):
-            self.text = text
-            self.on_click = on_click
+class FakeDropdown:
+    def __init__(self, options=None, **kwargs):
+        self.kwargs = kwargs
+        self.options = options or []
+        self.value = None
 
-    class Page:
-        def __init__(self):
-            self.controls = []
 
-        def add(self, *args):
-            self.controls.extend(args)
+class FakeSwitch:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.value = False
 
-        def update(self):
-            pass
 
-    return SimpleNamespace(
-        TextField=TextField,
-        Text=Text,
-        Dropdown=Dropdown,
-        Switch=Switch,
-        ElevatedButton=ElevatedButton,
-        Page=Page,
-        dropdown=SimpleNamespace(Option=lambda v: v),
-    )
+class FakeElevatedButton:
+    def __init__(self, text, on_click=None):
+        self.text = text
+        self.on_click = on_click
+
+
+class FakePage:
+    def __init__(self):
+        self.controls = []
+        self.updated = 0
+
+    def add(self, *args):
+        self.controls.extend(args)
+
+    def update(self):
+        self.updated += 1
+
+
+def _fake_flet(*, root_option=None, dropdown_option=None, app=None):
+    attrs = {
+        "TextField": FakeTextField,
+        "Text": FakeText,
+        "Dropdown": FakeDropdown,
+        "Switch": FakeSwitch,
+        "ElevatedButton": FakeElevatedButton,
+        "Page": FakePage,
+        "dropdown": SimpleNamespace(Option=dropdown_option or (lambda value: f"dropdown:{value}")),
+        "app": app or (lambda **kwargs: kwargs),
+    }
+    if root_option is not None:
+        attrs["Option"] = root_option
+    return SimpleNamespace(**attrs)
 
 
 def _prepare_module(monkeypatch, module_name):
     fake_ft = _fake_flet()
-    dummy_compile = SimpleNamespace(TRANSPILERS={"py": object()})
-    monkeypatch.setitem(sys.modules, "flet", fake_ft)
-    monkeypatch.setitem(sys.modules, "cobra.cli.commands.compile_cmd", dummy_compile)
     module = importlib.import_module(module_name)
     importlib.reload(module)
+    monkeypatch.setattr(module.runtime, "require_flet", lambda: fake_ft)
+    monkeypatch.setattr(module.runtime, "gui_target_choices", lambda: ("py",))
+    monkeypatch.setattr(
+        module.runtime,
+        "require_gui_dependencies",
+        lambda: {"TRANSPILERS": {"py": object()}, "LexerError": None, "ParserError": None},
+    )
     return module, fake_ft
-
-
-def _prepare_transpiler(monkeypatch, module):
-    inst = MagicMock()
-    cls = MagicMock(return_value=inst)
-    monkeypatch.setattr(module, "TRANSPILERS", {"py": cls})
-    lexer_inst = MagicMock()
-    parser_inst = MagicMock()
-    lexer_inst.tokenizar.return_value = "TOK"
-    parser_inst.parsear.return_value = "AST"
-    monkeypatch.setattr(module, "Lexer", MagicMock(return_value=lexer_inst))
-    monkeypatch.setattr(module, "Parser", MagicMock(return_value=parser_inst))
-    return cls, inst
 
 
 def _run_handler(ft, page, text):
@@ -87,18 +92,55 @@ def _run_handler(ft, page, text):
 
 
 def test_app_transpiler_invocado(monkeypatch):
-    module, ft = _prepare_module(monkeypatch, "gui.app")
-    _, inst = _prepare_transpiler(monkeypatch, module)
+    module, ft = _prepare_module(monkeypatch, "pcobra.gui.app")
+    transpilar = MagicMock(return_value="codigo python")
+    monkeypatch.setattr(module.runtime, "transpilar_codigo", transpilar)
+
     page = ft.Page()
     module.main(page)
     _run_handler(ft, page, "print(1)")
-    inst.generate_code.assert_called_once_with("AST")
+
+    transpilar.assert_called_once_with("print(1)", "py")
+    assert next(c for c in page.controls if isinstance(c, ft.Text)).value == "codigo python"
+    assert page.updated == 1
 
 
 def test_idle_transpiler_invocado(monkeypatch):
-    module, ft = _prepare_module(monkeypatch, "gui.idle")
-    _, inst = _prepare_transpiler(monkeypatch, module)
+    module, ft = _prepare_module(monkeypatch, "pcobra.gui.idle")
+    transpilar = MagicMock(return_value="codigo python")
+    monkeypatch.setattr(module.runtime, "transpilar_codigo", transpilar)
+
     page = ft.Page()
     module.main(page)
     _run_handler(ft, page, "print(1)")
-    inst.generate_code.assert_called_once_with("AST")
+
+    transpilar.assert_called_once_with("print(1)", "py")
+    assert next(c for c in page.controls if isinstance(c, ft.Text)).value == "codigo python"
+    assert page.updated == 1
+
+
+def test_dropdown_option_prefiere_api_raiz_si_existe():
+    from pcobra.gui import runtime
+
+    ft = _fake_flet(root_option=lambda value: f"root:{value}")
+
+    assert runtime.flet_dropdown_option(ft, "py") == "root:py"
+
+
+def test_dropdown_option_usa_dropdown_option_en_flet_0852():
+    from pcobra.gui import runtime
+
+    ft = _fake_flet(dropdown_option=lambda value: f"dropdown:{value}")
+
+    assert runtime.flet_dropdown_option(ft, "py") == "dropdown:py"
+
+
+def test_flet_app_centraliza_lanzamiento():
+    from pcobra.gui import runtime
+
+    app = MagicMock(return_value="ok")
+    target = object()
+    ft = _fake_flet(app=app)
+
+    assert runtime.flet_app(target, ft=ft, view="web_browser") == "ok"
+    app.assert_called_once_with(target=target, view="web_browser")

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -30,32 +30,23 @@ def test_ejecutar_transpilar_tokens_y_ast() -> None:
 
 
 def test_formatear_error_lexico_y_sintaxis() -> None:
-    deps = runtime.require_gui_dependencies()
+    class FakeLexerError(Exception):
+        linea = 2
+        columna = 4
 
-    try:
-        deps["Lexer"]("\x00").tokenizar()
-    except Exception as exc:
-        mensaje = runtime.formatear_error(
-            exc,
-            lexer_error_type=deps["LexerError"],
-            parser_error_type=deps["ParserError"],
-        )
-        assert mensaje.startswith("Error léxico")
-    else:  # pragma: no cover
-        pytest.fail("Se esperaba error léxico")
+    class FakeParserError(Exception):
+        pass
 
-    try:
-        tokens = deps["Lexer"]("imprimir('x'").tokenizar()
-        deps["Parser"](tokens).parsear()
-    except Exception as exc:
-        mensaje = runtime.formatear_error(
-            exc,
-            lexer_error_type=deps["LexerError"],
-            parser_error_type=deps["ParserError"],
-        )
-        assert mensaje.startswith("Error de sintaxis")
-    else:  # pragma: no cover
-        pytest.fail("Se esperaba error de sintaxis")
+    assert runtime.formatear_error(
+        FakeLexerError("carácter inválido"),
+        lexer_error_type=FakeLexerError,
+        parser_error_type=FakeParserError,
+    ).startswith("Error léxico")
+    assert runtime.formatear_error(
+        FakeParserError("faltó cierre"),
+        lexer_error_type=FakeLexerError,
+        parser_error_type=FakeParserError,
+    ).startswith("Error de sintaxis")
 
 
 def test_gui_target_choices_filtra_targets_no_oficiales(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -64,12 +55,12 @@ def test_gui_target_choices_filtra_targets_no_oficiales(monkeypatch: pytest.Monk
         "require_gui_dependencies",
         lambda: {
             "target_cli_choices": lambda targets: tuple(sorted(targets)),
-            "OFFICIAL_TARGETS": ("python", "java", "asm"),
-            "TRANSPILERS": {"python": object, "backend_x": object, "asm": object},
+            "OFFICIAL_TARGETS": ("python", "javascript", "rust"),
+            "TRANSPILERS": {"python": object, "backend_x": object, "rust": object},
         },
     )
 
-    assert runtime.gui_target_choices() == ("asm", "python")
+    assert runtime.gui_target_choices() == ("python", "rust")
 
 
 def test_require_flet_error_accionable(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -92,7 +83,7 @@ def test_require_gui_dependencies_error_accionable_modulo_ausente(
     real_import = __import__
 
     def _import_fail_core(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == "pcobra.core.interpreter":
+        if name == "pcobra.cobra.gui" and fromlist:
             raise ModuleNotFoundError(
                 "No module named 'pcobra.core.interpreter'", name="pcobra.core.interpreter"
             )
@@ -111,7 +102,7 @@ def test_require_gui_dependencies_error_accionable_simbolo_ausente(
     real_import = __import__
 
     def _import_fail_symbol(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == "pcobra.cobra.core" and fromlist:
+        if name == "pcobra.cobra.gui" and fromlist:
             raise ImportError("cannot import name 'Lexer' from 'pcobra.cobra.core'")
         return real_import(name, globals, locals, fromlist, level)
 
@@ -122,10 +113,33 @@ def test_require_gui_dependencies_error_accionable_simbolo_ausente(
     assert "corrige el import local de 'pcobra.cobra.core.Lexer'" in str(excinfo.value)
 
 
-def test_require_gui_dependencies_cachea_resultado() -> None:
+def test_require_gui_dependencies_cachea_resultado(monkeypatch: pytest.MonkeyPatch) -> None:
+    llamadas = {"count": 0}
+    fake_deps = SimpleNamespace(
+        Lexer=object,
+        LexerError=Exception,
+        Parser=object,
+        ParserError=Exception,
+        target_cli_choices=lambda _targets: (),
+        OFFICIAL_TARGETS=("python", "javascript", "rust"),
+        InterpretadorCobra=object,
+        get_transpilers=lambda: {"python": object},
+    )
+    real_import = __import__
+
+    def _import_fake_gui(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "pcobra.cobra.gui" and fromlist:
+            llamadas["count"] += 1
+            return SimpleNamespace(deps=fake_deps)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", _import_fake_gui)
+
     deps_a = runtime.require_gui_dependencies()
     deps_b = runtime.require_gui_dependencies()
+
     assert deps_a is deps_b
+    assert llamadas["count"] == 1
 
 
 def test_formatear_error_no_masking_si_fallan_dependencias() -> None:

--- a/tests/unit/test_gui_target_choices.py
+++ b/tests/unit/test_gui_target_choices.py
@@ -7,14 +7,14 @@ def test_gui_runtime_filtra_targets_fuera_del_conjunto_canonico(monkeypatch):
         "require_gui_dependencies",
         lambda: {
             "target_cli_choices": lambda targets: tuple(sorted(targets, reverse=True)),
-            "OFFICIAL_TARGETS": ("python", "java", "asm"),
+            "OFFICIAL_TARGETS": ("python", "javascript", "rust"),
             "TRANSPILERS": {
-                "java": object,
+                "javascript": object,
                 "python": object,
                 "backend_x": object,
-                "asm": object,
+                "rust": object,
             },
         },
     )
 
-    assert runtime.gui_target_choices() == ("python", "java", "asm")
+    assert runtime.gui_target_choices() == ("rust", "python", "javascript")


### PR DESCRIPTION
### Motivation
- Evitar duplicación y rupturas con las APIs cambiantes de Flet centralizando adaptadores y lanzadores en una única capa runtime. 
- Soportar la versión moderna `flet` (probada con `0.85.2`) donde `Option` ya no está en la raíz y existe como `dropdown.Option`.
- Mantener mensajes de preflight y errores accionables desde el comando CLI `gui` sin reimplementar lógica de compatibilidad en cada módulo.

### Description
- Se centralizan adaptadores y un lanzador compatible en `src/pcobra/gui/runtime.py`: `flet_app`, `flet_text_field`, `flet_text`, `flet_dropdown`, `flet_switch`, `flet_elevated_button` y `flet_dropdown_option` con fallback a `ft.dropdown.Option` cuando sea necesario.
- Se actualizan `src/pcobra/gui/app.py` y `src/pcobra/gui/idle.py` para usar los adaptadores de `runtime` en lugar de acceder a los símbolos de `ft` directamente.
- Se modifica `src/pcobra/standard_library/interfaz.py` para iniciar la UI mediante `runtime.flet_app` y así evitar duplicar la resolución de `flet` en la stdlib.
- Se adapta el comando CLI en `src/pcobra/cobra/cli/commands/flet_cmd.py` para resolver `flet` con `runtime.require_flet()` y lanzar la app con `runtime.flet_app(...)`, conservando las comprobaciones de preflight y los mensajes accionables.
- Se amplía la restricción de dependencia en `pyproject.toml` para admitir `flet` hasta la serie `0.85.x` (`"flet>=0.28.3,!=0.29.*,<0.86"`).
- Se actualizan/añaden pruebas unitarias en `tests/unit/` para usar dobles/stubs de Flet y cubrir las nuevas adaptaciones y los mensajes de error accionables sin abrir una UI real.

### Testing
- Se verificó localmente la compatibilidad práctica instalando `flet==0.85.2` y comprobando que existen `app`, `TextField`, `Text`, `Dropdown`, `Switch` y `ElevatedButton`, y que `Option` se encuentra como `dropdown.Option` (comprobación manual con `PYTHONPATH` apuntando a un target con `flet==0.85.2`).
- Se ejecutaron los tests unitarios relevantes: `tests/unit/test_gui_menu.py`, `tests/unit/test_cli_gui.py`, `tests/unit/test_cli_gui_without_flet.py`, `tests/unit/test_gui_runtime.py`, `tests/unit/test_gui_target_choices.py` y `tests/unit/test_standard_library_interfaz.py`, y todos pasaron (con una advertencia deprecación no bloqueante sobre `pcobra.core` durante las ejecuciones).
- Se compiló el nuevo código con `python -m py_compile` sobre `src/pcobra/gui/runtime.py`, `src/pcobra/gui/app.py`, `src/pcobra/gui/idle.py`, `src/pcobra/standard_library/interfaz.py` y `src/pcobra/cobra/cli/commands/flet_cmd.py` sin errores.
- Commit final: `e8e1225 Compatibiliza GUI con Flet 0.85`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2455f4580c8327bf74cf0aa0e75fcd)