### PR TITLE
Actualizar rangos de NumPy/SciPy y fijar percentiles lineales en datos

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -106,7 +106,7 @@ myst-parser==5.1.0
     # via pcobra (pyproject.toml)
 networkx==3.6.1
     # via agix
-numpy==2.1.3
+numpy==2.4.6
     # via
     #   agix
     #   contourpy
@@ -180,7 +180,7 @@ rpds-py==2026.5.1
     # via
     #   jsonschema
     #   referencing
-scipy==1.14.1
+scipy==1.17.1
     # via
     #   agix
     #   pcobra (pyproject.toml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ classifiers = [
 # Política Python >=3.11: las dependencias se fijan al tramo más reciente
 # publicado compatible con la superficie actual del proyecto.
 dependencies = [
-    "numpy>=2.1.3,<2.2",
-    "scipy>=1.14.1,<1.15",
+    "numpy>=2.4.6,<2.5",
+    "scipy>=1.17.1,<1.18",
     "matplotlib>=3.10.9,<4",
     "pandas>=3.0.3,<4",
     "agix>=1.9.0,<2",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -141,7 +141,7 @@ nest-asyncio==1.6.0
     # via ipykernel
 networkx==3.6.1
     # via agix
-numpy==2.1.3
+numpy==2.4.6
     # via
     #   agix
     #   contourpy
@@ -269,7 +269,7 @@ rpds-py==2026.5.1
     #   referencing
 ruff==0.15.16
     # via pcobra (pyproject.toml)
-scipy==1.14.1
+scipy==1.17.1
     # via
     #   agix
     #   pcobra (pyproject.toml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,7 @@ mpmath==1.3.0
     # via sympy
 networkx==3.6.1
     # via agix
-numpy==2.1.3
+numpy==2.4.6
     # via
     #   agix
     #   contourpy
@@ -149,7 +149,7 @@ rpds-py==2026.5.1
     # via
     #   jsonschema
     #   referencing
-scipy==1.14.1
+scipy==1.17.1
     # via
     #   agix
     #   pcobra (pyproject.toml)

--- a/src/pcobra/standard_library/datos.py
+++ b/src/pcobra/standard_library/datos.py
@@ -191,6 +191,12 @@ def _valores_numericos(tabla: Tabla, columna: str) -> list[float]:
     return [float(valor) for valor in _valores_columna(tabla, columna, solo_numeros=True)]
 
 
+def _percentil_lineal(valores: Sequence[float], percentil: float) -> float:
+    """Calcula percentiles con interpolación lineal estable entre NumPy 2.x."""
+
+    return float(np.percentile(valores, percentil, method="linear"))
+
+
 def _valores_numericos_alineados(tabla: Tabla, columnas: Sequence[str]) -> list[list[float]]:
     alineados: list[list[float]] = []
     for fila in tabla:
@@ -1086,9 +1092,9 @@ def describir(datos: Iterable[Registro]) -> dict[str, dict[str, float]]:
             "mean": media,
             "std": desviacion,
             "min": min(valores),
-            "25%": float(np.percentile(valores, 25)),
-            "50%": float(np.percentile(valores, 50)),
-            "75%": float(np.percentile(valores, 75)),
+            "25%": _percentil_lineal(valores, 25),
+            "50%": _percentil_lineal(valores, 50),
+            "75%": _percentil_lineal(valores, 75),
             "max": max(valores),
         }
     return resultado
@@ -1218,7 +1224,7 @@ def calcular_percentiles(
             continue
         resultado[columna] = {}
         for percentil in percentiles:
-            resultado[columna][f"p{percentil}"] = float(np.percentile(valores, percentil))
+            resultado[columna][f"p{percentil}"] = _percentil_lineal(valores, percentil)
     return resultado
 
 


### PR DESCRIPTION
### Motivation

- Alinear los rangos de `numpy` y `scipy` con las versiones resueltas en el entorno de ejecución para evitar incoherencias entre metadata y entorno real. 
- Evitar dependencia del valor por defecto de `np.percentile` frente a cambios en NumPy 2.x especificando explícitamente el método de interpolación.

### Description

- Actualiza los requerimientos en `pyproject.toml` a `"numpy>=2.4.6,<2.5"` y `"scipy>=1.17.1,<1.18"` y sincroniza los pines en `requirements.txt`, `requirements-dev.txt` y `docs/requirements.txt` a `numpy==2.4.6` y `scipy==1.17.1`.
- Añade un helper `_percentil_lineal(valores, percentil)` en `src/pcobra/standard_library/datos.py` que llama a `np.percentile(..., method="linear")` para fijar el comportamiento de percentiles.
- Reemplaza las llamadas directas a `np.percentile` en `describir` y `calcular_percentiles` por el helper `_percentil_lineal` para los percentiles `25`, `50`, `75` y para percentiles configurables.
- No se modificó la sintaxis ni componentes de transpile/lexer/parser; los cambios se limitan a la capa de biblioteca estándar y metadata de dependencias.

### Testing

- Instalación validada con `python -m pip install 'numpy>=2.4.6,<2.5' 'scipy>=1.17.1,<1.18'` y `python -m pip check` sin problemas detectados.
- `python -m pytest tests/unit/test_standard_library_numero.py` pasó completamente (`30 passed`).
- `python -m pytest tests/unit/test_standard_library_datos.py` pasó (`39 passed, 4 skipped`).
- `python -m pytest tests/unit/test_corelibs.py` falló en 5 pruebas relacionadas con el transpile (casos de emisión de literales con comillas adicionales: `test_transpile_texto`, `test_transpile_texto_busquedas`, `test_transpile_numero`, `test_transpile_archivo`, `test_transpile_tiempo`), las cuales no se tocaron porque afectarían Lexer/Parser/Transpiler fuera del alcance de este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2458a1e13c83278e6732a317d20ce8)