### PR TITLE
Pin JupyterLab version for Binder

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,2 +1,4 @@
 -r ../requirements.txt
-jupyterlab
+# Dependencia exclusiva del entorno Binder: se fija aquí para evitar
+# que repo2docker resuelva una versión flotante distinta en cada build.
+jupyterlab==4.5.8


### PR DESCRIPTION
### Motivation
- Evitar que Binder/repo2docker resuelva una versión flotante de `jupyterlab` y garantizar una build reproducible; verifiqué en PyPI que la última versión estable compatible con Python `>=3.11` es `jupyterlab 4.5.8` y no se modificó Lexer/Parser ni reglas de sintaxis.

### Description
- Fijé `jupyterlab==4.5.8` en `binder/requirements.txt` y añadí un comentario explicando que la dependencia es exclusiva del entorno Binder; no se añadió un extra en `pyproject.toml` y no se tocaron otros archivos del proyecto.

### Testing
- Ejecuté una consulta automática a PyPI que confirmó `jupyterlab 4.5.8` como compatible con Python `>=3.11` (OK); ejecuté `python -m pip install -r binder/requirements.txt --dry-run` que mostró un conflicto preexistente en el lock raíz (`agix==1.9.0` vs `numpy==2.4.6`) por lo que la resolución completa falló (FAIL para la resolución global); ejecuté `python -m pip install 'jupyterlab==4.5.8' --dry-run` (OK); ejecuté un script de aserción que valida que `binder/requirements.txt` contiene `jupyterlab==4.5.8` y no la entrada flotante (OK); ejecuté `git diff --check` para validar no introducir errores en el diff (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a245adadb40832797e8481149a0c578)