### PR TITLE
Fix manejo BOM en build/run, silencia fallback SQLite opcional y mejora UX de `usar` y versión CLI

### DIFF
--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -19,6 +19,7 @@ from pcobra.cobra.architecture.contracts import (
 )
 from pcobra.cobra.bindings.runtime_manager import RuntimeManager
 from pcobra.cobra.build.orchestrator import BackendResolution, BuildOrchestrator
+from pcobra.cobra.cli.utils.source import read_cobra_source
 from pcobra.cobra.core.ast_cache import obtener_ast
 
 ORCHESTRATOR = BuildOrchestrator()
@@ -165,7 +166,7 @@ def build(source: str, hints: dict[str, Any] | None = None) -> dict[str, Any]:
     source_path = Path(source)
     if source_path.exists() and source_path.is_file():
         source_file = str(source_path)
-        codigo = source_path.read_text(encoding="utf-8")
+        codigo = read_cobra_source(source_path)
     else:
         source_file = str(context.get("source_file", "<memory>"))
         codigo = source

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -2,6 +2,8 @@ import argparse
 import logging
 import os
 import sys
+import tomllib
+from importlib.metadata import PackageNotFoundError, version as package_version
 from os import environ
 from pathlib import Path
 from typing import List, Dict, Optional, Type, Any, ContextManager
@@ -74,8 +76,24 @@ from pcobra.cobra.cli.utils.autocomplete import (
     files_completer,
 )
 
-# Metadata injected at build time
-CLI_VERSION = environ.get("COBRA_CLI_VERSION", "dev")
+# Metadata injected at build time, with package metadata fallback for editable installs.
+def _resolve_cli_version() -> str:
+    env_version = environ.get("COBRA_CLI_VERSION")
+    if env_version:
+        return env_version
+    try:
+        return package_version("pcobra")
+    except PackageNotFoundError:
+        pyproject_path = Path(__file__).resolve().parents[4] / "pyproject.toml"
+        try:
+            metadata = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+            version = metadata.get("project", {}).get("version")
+        except (OSError, tomllib.TOMLDecodeError):
+            version = None
+        return str(version) if version else "dev"
+
+
+CLI_VERSION = _resolve_cli_version()
 CLI_COMMIT = environ.get("COBRA_CLI_COMMIT", "unknown")
 COBRA_INTERNAL_ENABLE_CLI_V1_ENV = "COBRA_INTERNAL_ENABLE_CLI_V1"
 COBRA_ENABLE_LEGACY_CLI_ENV = "COBRA_INTERNAL_ENABLE_LEGACY_CLI"

--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -20,6 +20,7 @@ from pcobra.cobra.cli.services.contracts import RunRequest, normalize_run_reques
 from pcobra.cobra.cli.services.format_service import format_code_with_black
 from pcobra.cobra.cli.target_policies import resolve_docker_backend
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
+from pcobra.cobra.cli.utils.source import read_cobra_source
 from pcobra.cobra.cli.utils.validators import validar_archivo_existente
 from pcobra.cobra.core import LexerError, ParserError
 from pcobra.cobra.core.runtime import (
@@ -36,17 +37,6 @@ except ModuleNotFoundError as canon_exc:  # pragma: no cover
     sandbox_module = load_legacy_core_sandbox(canonical_error=canon_exc)
 
 RUNTIME_MANAGER = RuntimeManager()
-
-def _normalizar_codigo_entrada(codigo: str) -> str:
-    """Normaliza la frontera de entrada de archivos de código.
-
-    Mantiene comportamiento no invasivo: únicamente remueve BOM UTF-8
-    (`\ufeff`) cuando aparece en la posición 0 del archivo.
-    """
-    if codigo.startswith("\ufeff"):
-        return codigo[1:]
-    return codigo
-
 
 
 def _importar_modulo_sandbox() -> Any:
@@ -121,8 +111,7 @@ class RunService:
         self.logger.setLevel(logging.DEBUG if depurar else logging.INFO)
 
         try:
-            codigo = Path(archivo_resuelto).read_text(encoding="utf-8")
-            codigo = _normalizar_codigo_entrada(codigo)
+            codigo = read_cobra_source(archivo_resuelto)
         except (PermissionError, UnicodeDecodeError) as e:
             mostrar_error(f"Error al leer el archivo: {e}", registrar_log=False)
             return 1
@@ -246,7 +235,7 @@ class RunService:
         except (LexerError, ParserError) as e:
             mostrar_error(f"Error de análisis: {e}", registrar_log=False)
             return 1
-        except (TypeError, ValueError) as e:
+        except (TypeError, ValueError, PermissionError, NameError) as e:
             mostrar_error(str(e), registrar_log=False)
             return 1
         except PrimitivaPeligrosaError as pe:

--- a/src/pcobra/cobra/cli/utils/source.py
+++ b/src/pcobra/cobra/cli/utils/source.py
@@ -1,0 +1,24 @@
+"""Utilidades compartidas para leer fuente Cobra desde CLI/pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from os import PathLike
+
+
+def normalize_cobra_source(text: str) -> str:
+    """Normaliza fuente Cobra antes de tokenizar sin cambiar la gramática.
+
+    Solo elimina el BOM UTF-8 inicial cuando existe. Usar ``utf-8-sig`` en la
+    lectura ya lo consume, pero ``removeprefix`` conserva compatibilidad si el
+    texto llega desde otra frontera.
+    """
+
+    return text.removeprefix("\ufeff")
+
+
+def read_cobra_source(path: str | PathLike[str]) -> str:
+    """Lee un archivo Cobra aceptando UTF-8 con o sin BOM inicial."""
+
+    text = Path(path).read_text(encoding="utf-8-sig")
+    return normalize_cobra_source(text)

--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -148,6 +148,12 @@ def _cargar_modulo_local_desde_directorio(nombre: str, directorio: Path):
 def _cargar_modulo_local_desde_ruta(nombre: str, ruta: Path):
     """Carga un módulo Python desde una ruta absoluta explícita."""
 
+    modulo_existente = sys.modules.get(nombre)
+    if modulo_existente is not None:
+        modulo_file = getattr(modulo_existente, "__file__", None)
+        if modulo_file and Path(modulo_file).resolve() == ruta:
+            return modulo_existente
+
     mod_spec = importlib.util.spec_from_file_location(nombre, ruta)
     if mod_spec is None or mod_spec.loader is None:
         raise ImportError(f"No se pudo crear spec para el módulo '{nombre}'")
@@ -174,6 +180,26 @@ def obtener_modulo_cobra_oficial(nombre: str):
             "Módulo oficial Cobra permitido no resoluble en runtime: "
             f"alias='{nombre}' ruta='{rel_path}'."
         )
+
+    if rel_path.startswith("src/pcobra/corelibs/"):
+        nombre_import = f"pcobra.corelibs.{ruta_modulo.stem}"
+    elif rel_path.startswith("src/pcobra/standard_library/"):
+        nombre_import = f"pcobra.standard_library.{ruta_modulo.stem}"
+    else:
+        nombre_import = ""
+
+    if nombre_import:
+        modulo = importlib.import_module(nombre_import)
+        modulo_file = getattr(modulo, "__file__", None)
+        if modulo_file and Path(modulo_file).resolve() == ruta_modulo:
+            for export_name in getattr(modulo, "__all__", ()):  # Cobra-facing: alias público.
+                export = getattr(modulo, export_name, None)
+                if callable(export) and hasattr(export, "__module__"):
+                    try:
+                        export.__module__ = nombre
+                    except (AttributeError, TypeError):
+                        pass
+            return modulo
 
     return _cargar_modulo_local_desde_ruta(nombre, ruta_modulo)
 

--- a/src/pcobra/core/database.py
+++ b/src/pcobra/core/database.py
@@ -307,7 +307,12 @@ def _get_sqliteplus_instance():
     with _INIT_LOCK:
         if _SQLITEPLUS_INSTANCE is not None:
             return _SQLITEPLUS_INSTANCE
-        sqliteplus_cls = _load_sqliteplus_class()
+        try:
+            sqliteplus_cls = _load_sqliteplus_class(silent_optional=True)
+        except TypeError:
+            # Compatibilidad con pruebas/adaptadores que sustituyen el loader
+            # por callables sin el parámetro opcional.
+            sqliteplus_cls = _load_sqliteplus_class()
         db_path, cipher_key = _resolve_paths()
         _SQLITEPLUS_INSTANCE = sqliteplus_cls(db_path=str(db_path), cipher_key=cipher_key)
         return _SQLITEPLUS_INSTANCE

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import hashlib
-import json
 from typing import Mapping, Optional
 
 from .lexer import (
@@ -95,6 +94,7 @@ from .usar_symbol_policy import (
     validate_usar_symbol_metadata,
 )
 from .environment import Environment
+from pcobra.cobra.usar_loader import obtener_modulo, sanitizar_exports_publicos
 
 MODULES_PATH = _DEFAULT_MODULES_PATH
 REPL_USAR_EXTERNAL_MODULE_ERROR = (
@@ -1051,11 +1051,35 @@ class InterpretadorCobra:
 
     @staticmethod
     def _hash_estructural_metadata(metadata: object) -> str:
-        """Calcula hash estable para detectar cambios estructurales de metadata."""
+        """Calcula hash estable y acotado para metadata canónica de ``usar``.
+
+        La metadata esperada solo contiene escalares pequeños; aun así evitamos
+        serializar objetos arbitrarios con ``default=repr`` para no disparar
+        ``repr`` costosos de dependencias opcionales durante la auditoría.
+        """
         if not isinstance(metadata, dict):
             return f"tipo-invalido:{type(metadata).__name__}"
-        serializado = json.dumps(metadata, sort_keys=True, ensure_ascii=False, default=repr)
-        return hashlib.sha256(serializado.encode("utf-8")).hexdigest()
+
+        partes: list[str] = []
+        for nombre in sorted(str(clave) for clave in metadata):
+            valor = metadata.get(nombre)
+            if isinstance(valor, dict):
+                campos = []
+                for clave_meta in sorted(str(clave) for clave in valor):
+                    dato = valor.get(clave_meta)
+                    if isinstance(dato, (str, int, bool, type(None))):
+                        dato_seguro = dato
+                    else:
+                        dato_seguro = f"<{type(dato).__name__}>"
+                    campos.append(f"{clave_meta}={dato_seguro!r}")
+                partes.append(f"{nombre}:" + ";".join(campos))
+            else:
+                partes.append(f"{nombre}=<{type(valor).__name__}>")
+        digest = hashlib.sha256()
+        for parte in partes:
+            digest.update(parte.encode("utf-8", errors="replace"))
+            digest.update(b"\n")
+        return digest.hexdigest()
 
     def _sincronizar_metadata_usar_no_destructiva(self) -> None:
         """Sincroniza metadata de `usar` sin borrar contenedores existentes.
@@ -2233,8 +2257,6 @@ class InterpretadorCobra:
             canónicos del catálogo oficial Cobra.
         """
         from pathlib import Path
-        from .usar_loader import obtener_modulo, sanitizar_exports_publicos
-
         def _resolver_carga_modulo_usar(nombre_modulo: str):
             """Resuelve módulos `usar` únicamente desde el catálogo canónico Cobra."""
             es_repl_estricto = self._repl_usar_alias_map is not None
@@ -2413,7 +2435,7 @@ class InterpretadorCobra:
             if _usar_detalle_habilitado():
                 logging.exception("Error al usar el módulo '%s': %s", nodo.modulo, exc)
             elif _usar_error_esperado(exc):
-                logging.error("Error al usar el módulo '%s': %s", nodo.modulo, exc)
+                logging.debug("Error esperado al usar el módulo '%s': %s", nodo.modulo, exc)
             else:
                 logging.error("Error al usar el módulo '%s': %s", nodo.modulo, exc)
             if isinstance(exc, PermissionError):

--- a/tests/integration/test_run_repl_equivalence.py
+++ b/tests/integration/test_run_repl_equivalence.py
@@ -7,6 +7,7 @@ import pytest
 from unittest.mock import call, patch
 
 from pcobra.cobra.cli.commands_v2.run_cmd import RunCommandV2
+from pcobra.cobra.cli.services.build_service import BuildService
 from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
 from pcobra.cobra.cli.execution_pipeline import (
     PipelineInput,
@@ -836,6 +837,33 @@ def test_run_utf8_bom_y_sin_bom_producen_salida_identica(tmp_path, monkeypatch):
 
 
 @pytest.mark.integration
+def test_build_utf8_bom_y_sin_bom_compilan_sin_token_bom(tmp_path, monkeypatch):
+    monkeypatch.setenv("SQLITE_DB_KEY", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+    script = 'imprimir("hola")\n'
+
+    archivo_sin_bom = tmp_path / "build_sin_bom.co"
+    archivo_con_bom = tmp_path / "build_con_bom.co"
+    archivo_sin_bom.write_text(script, encoding="utf-8")
+    archivo_con_bom.write_text("\ufeff" + script, encoding="utf-8")
+
+    salidas = []
+    for archivo in (archivo_sin_bom, archivo_con_bom):
+        out_build, err_build = StringIO(), StringIO()
+        with redirect_stdout(out_build), redirect_stderr(err_build):
+            rc_build = BuildService().run(Namespace(file=str(archivo), debug=False))
+
+        salida = out_build.getvalue() + err_build.getvalue()
+        assert rc_build == 0, salida
+        assert "Token no reconocido" not in salida
+        assert "\ufeff" not in salida
+        assert "sqliteplus-enhanced" not in salida
+        salidas.append(out_build.getvalue())
+
+    assert "print('hola')" in salidas[0]
+    assert "print('hola')" in salidas[1]
+
+
+@pytest.mark.integration
 def test_run_error_lexico_sigue_siendo_corto_sin_traceback_con_y_sin_bom(tmp_path, monkeypatch):
     monkeypatch.setattr("pcobra.cobra.cli.services.run_service.limitar_cpu_segundos", lambda *_: None)
 
@@ -851,6 +879,24 @@ def test_run_error_lexico_sigue_siendo_corto_sin_traceback_con_y_sin_bom(tmp_pat
         salida = out_run.getvalue() + err_run.getvalue()
         assert "Traceback" not in salida
         assert salida.strip() != ""
+
+
+@pytest.mark.integration
+def test_run_usar_numpy_rechaza_sin_traceback_ni_error_duplicado(tmp_path, monkeypatch):
+    monkeypatch.setattr("pcobra.cobra.cli.services.run_service.limitar_cpu_segundos", lambda *_: None)
+    archivo = tmp_path / "numpy.co"
+    archivo.write_text('usar "numpy"\n', encoding="utf-8")
+
+    out_run, err_run = StringIO(), StringIO()
+    with redirect_stdout(out_run), redirect_stderr(err_run):
+        rc_run = RunCommandV2().run(_run_args(str(archivo)))
+
+    salida = out_run.getvalue() + err_run.getvalue()
+    assert rc_run == 1
+    assert "numpy" in salida
+    assert "catálogo público" in salida
+    assert "traceback" not in salida.lower()
+    assert salida.lower().count("error") == 1
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Motivation

- Resolver fallo en `cobra build` con archivos UTF-8 BOM centralizando la lectura de fuente para `run`/`build` y evitando que el Lexer reciba el carácter BOM.
- Reducir mensajes duplicados/ruidosos en `usar` para módulos externos (p. ej. `numpy`) sin relajar la política de seguridad.
- Evitar warning ruidoso sobre `sqliteplus-enhanced` en ejecución normal y proporcionar una resolución de versión más útil para `cobra --version` en entornos de desarrollo/editable.

### Description

- Añadida utilidad `read_cobra_source()` que lee con `encoding="utf-8-sig"` y elimina únicamente el BOM inicial si existe, en `src/pcobra/cobra/cli/utils/source.py` y usada desde `run` y `build` para unificar comportamiento de lectura de fuente. (`read_cobra_source`) 
- Reemplazada lectura directa `Path.read_text(encoding="utf-8")` por `read_cobra_source()` en `src/pcobra/cobra/cli/services/run_service.py` y `src/pcobra/cobra/build/backend_pipeline.py` para corregir `BUG-BUILD-001`.
- Mejorada captura de errores en `RunService.ejecutar_normal` para mostrar `PermissionError` y `NameError` como mensajes limpios sin traceback en modo normal, preservando mensajes como `Variable no declarada: ...`.
- Reducido ruido de logs en `usar` moviendo el log de errores esperados a `debug` (no se imprime dos veces ni con traceback en modo normal); cambios en `src/pcobra/core/interpreter.py` para evitar duplicación de errores (`UX-ERR-001`).
- Optimizado flujo de carga de módulos canónicos en `src/pcobra/cobra/usar_loader.py` para reutilizar imports `pcobra.corelibs.*` y `pcobra.standard_library.*` cuando sea posible, además de evitar recargas idénticas desde `sys.modules` (mejora de rendimiento y robustez en REPL).
- Sustituido hashing/serialización indiscriminada de metadata `usar` por una versión acotada y segura que evita llamar `repr`/serializar objetos arbitrarios durante auditoría en `src/pcobra/core/interpreter.py` (reduce riesgo de OOM/CPU por objetos grandes).
- Silenciado el warning/advertencia visible para el fallback de `sqliteplus-enhanced` usando `silent_optional=True` por defecto en `_get_sqliteplus_instance()` manteniendo compatibilidad con tests que sustituyan el loader (cobertura defensiva) en `src/pcobra/core/database.py`.
- `cobra --version` ahora intenta `importlib.metadata.version('pcobra')` y, en editable/dev, cae a leer `pyproject.toml` antes de devolver `dev` en `src/pcobra/cobra/cli/cli.py`.
- Añadidos tests de regresión en `tests/integration/test_run_repl_equivalence.py` para: (a) `cobra build` con/sin BOM y (b) rechazo de `usar "numpy"` sin duplicación ni traceback.

### Testing

- Ejecutados tests específicos de integración añadidos y relacionados:
  - `python -m pytest tests/integration/test_run_repl_equivalence.py::test_run_usar_numpy_rechaza_sin_traceback_ni_error_duplicado -q` — PASSED.
  - `python -m pytest tests/integration/test_run_repl_equivalence.py::test_build_utf8_bom_y_sin_bom_compilan_sin_token_bom -q` — PASSED.
  - `python -m pytest tests/integration/test_run_repl_equivalence.py::test_run_utf8_bom_y_sin_bom_producen_salida_identica tests/integration/test_run_repl_equivalence.py::test_run_existe_sin_usar_archivo_permanece_bloqueado -q` — PASSED.
- Verificado `cobra --version` devuelve versión desde `pyproject.toml` en entorno editable: `python -m cobra.cli.cli --version` — muestra `cobra 10.1.1 (commit unknown)` (OK).
- Ejecutado un caso real de `run` con el script de ejemplo de release; la salida coincide con lo esperado (salida funcional), y `build` con `SQLITE_DB_KEY` set produjo el artefacto sin mensajes de token BOM ni advertencias ruidosas (OK).
- Compilados los módulos cambiados con `python -m compileall -q <files>` para asegurarse de que no hay errores de sintaxis (OK).
- Nota sobre ejecución completa de suite: intentar ejecutar en una sola invocación un lote grande de tests provocó `MemoryError` en el entorno de ejecución (no un fallo del parche); los tests relevantes se ejecutaron en tandas y pasaron.

Cambios principales en archivos: `src/pcobra/cobra/cli/utils/source.py`, `src/pcobra/cobra/cli/services/run_service.py`, `src/pcobra/cobra/build/backend_pipeline.py`, `src/pcobra/core/database.py`, `src/pcobra/cobra/cli/cli.py`, `src/pcobra/core/interpreter.py`, `src/pcobra/cobra/usar_loader.py`, y `tests/integration/test_run_repl_equivalence.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24603c0efc83278009dfdcfd56eea8)