### PR TITLE
Usar lectura compartida para fuentes Cobra

### DIFF
--- a/src/pcobra/cobra/cli/services/test_service.py
+++ b/src/pcobra/cobra/cli/services/test_service.py
@@ -17,6 +17,7 @@ from pcobra.cobra.cli.target_policies import (
     VERIFICATION_EXECUTABLE_TARGETS,
 )
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
+from pcobra.cobra.cli.utils.source import read_cobra_source
 from pcobra.cobra.cli.utils.validators import validar_archivo_existente
 from pcobra.cobra.core import Lexer, Parser
 
@@ -110,7 +111,7 @@ class TestService:
         self.validate_file(file_path)
 
         try:
-            return Path(file_path).read_text(encoding="utf-8")
+            return read_cobra_source(file_path)
         except PermissionError:
             raise PermissionError(_("No hay permisos para leer el archivo '{}'").format(file_path))
         except UnicodeDecodeError as e:

--- a/tests/unit/test_cobra_source_reading.py
+++ b/tests/unit/test_cobra_source_reading.py
@@ -1,0 +1,66 @@
+import logging
+
+from pcobra.cobra.build import backend_pipeline
+from pcobra.cobra.cli.services import test_service
+from pcobra.cobra.cli.utils.source import read_cobra_source
+
+
+class _DummyTranspiler:
+    def generate_code(self, ast):
+        return "generated"
+
+
+def test_read_cobra_source_normaliza_bom_inicial(tmp_path):
+    source = tmp_path / "bom.cobra"
+    source.write_text("\ufeffimprimir(1)", encoding="utf-8")
+
+    assert read_cobra_source(source) == "imprimir(1)"
+
+
+def test_backend_pipeline_build_lee_archivo_antes_de_obtener_ast(monkeypatch, tmp_path):
+    source = tmp_path / "main.cobra"
+    source.write_text("\ufeffimprimir(1)", encoding="utf-8")
+    calls = []
+
+    def fake_read_cobra_source(path):
+        calls.append(("read", path))
+        return "imprimir(1)"
+
+    def fake_obtener_ast(codigo):
+        calls.append(("ast", codigo))
+        assert codigo == "imprimir(1)"
+        return ["ast"]
+
+    monkeypatch.setattr(backend_pipeline, "read_cobra_source", fake_read_cobra_source)
+    monkeypatch.setattr(backend_pipeline, "obtener_ast", fake_obtener_ast)
+    monkeypatch.setattr(
+        backend_pipeline,
+        "resolve_backend_runtime",
+        lambda source_file, hints=None: (
+            type("Resolution", (), {"backend": "python", "reason": None})(),
+            {},
+        ),
+    )
+    monkeypatch.setattr(backend_pipeline, "_official_transpilers", lambda: {"python": _DummyTranspiler})
+
+    result = backend_pipeline.build(str(source), hints={"preferred_backend": "python"})
+
+    assert result["code"] == "generated"
+    assert calls == [("read", source), ("ast", "imprimir(1)")]
+
+
+def test_test_service_read_source_file_usa_read_cobra_source(monkeypatch, tmp_path):
+    source = tmp_path / "main.cobra"
+    source.write_text("imprimir(1)", encoding="utf-8")
+    service = test_service.TestService.__new__(test_service.TestService)
+    service._logger = logging.getLogger(__name__)
+    calls = []
+
+    def fake_read_cobra_source(path):
+        calls.append(path)
+        return "imprimir(1)"
+
+    monkeypatch.setattr(test_service, "read_cobra_source", fake_read_cobra_source)
+
+    assert service.read_source_file(str(source)) == "imprimir(1)"
+    assert calls == [str(source)]


### PR DESCRIPTION
### Motivation
- Centralizar la lectura de archivos fuente Cobra para normalizar el BOM UTF-8 en la frontera de lectura y evitar que el BOM llegue al lexer como token.
- Asegurar que el pipeline de construcción lea el archivo con la utilidad compartida antes de invocar la construcción del AST.
- Evitar cambios en la gramática o en `Lexer`/`Parser` y mantener la compatibilidad funcional de las rutas `run`/`test`.

### Description
- Actualiza `TestService.read_source_file` para importar y usar `read_cobra_source(file_path)` en lugar de `Path(file_path).read_text(encoding="utf-8")` en `src/pcobra/cobra/cli/services/test_service.py`.
- Confirma que `src/pcobra/cobra/build/backend_pipeline.py` ya emplea `read_cobra_source(source_path)` antes de llamar a `obtener_ast(codigo)` y que `src/pcobra/cobra/cli/services/run_service.py` ya usa `read_cobra_source`.
- No se modificaron `Lexer` ni `Parser`, y no se añadió ningún token de BOM al lexer; la normalización se realiza en `src/pcobra/cobra/cli/utils/source.py` mediante `utf-8-sig` y `normalize_cobra_source`.
- Añade pruebas en `tests/unit/test_cobra_source_reading.py` que verifican la normalización del BOM, que `backend_pipeline.build` lee el archivo antes de `obtener_ast`, y que `TestService.read_source_file` delega en `read_cobra_source`.

### Testing
- Ejecutado `git diff --check` y no se reportaron errores.
- Ejecutado `pytest -q tests/unit/test_cobra_source_reading.py` y las pruebas pasaron.
- Ejecutado `pytest -q tests/unit/test_backend_pipeline_runtime_manager.py tests/unit/test_cobra_source_reading.py` y ambos archivos de pruebas pasaron (todos los tests exitosos, con advertencia no bloqueante sobre deprecación).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25131653b48327bc85cbcf6b08d952)