### PR TITLE
Restringe detalles técnicos en errores de usar

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -111,7 +111,12 @@ def _debug_assert_boundary_text_sanitized(text: str, *, context: str) -> None:
 
 
 def format_user_error(exc: Exception) -> str:
-    """Normaliza mensajes de error para salida limpia en la CLI."""
+    """Normaliza mensajes de error para salida limpia en la CLI.
+
+    La categoría del REPL se mantiene solo para logging interno; la salida de
+    usuario no debe recibir un segundo prefijo ``Error:`` ni ``Error general:``
+    cuando el intérprete ya entregó un mensaje accionable como ``usar``.
+    """
     msg = " ".join(str(exc).strip().split())
     prefijos_redundantes = re.compile(
         r"^(?:error\s+general|error\s+cr[ií]tico|error\s+de\s+sintaxis|error)\s*[:：\-–—]?\s*",

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2432,20 +2432,21 @@ class InterpretadorCobra:
                 metadata_por_simbolo=metadata_por_simbolo,
             )
         except Exception as exc:
-            if _usar_detalle_habilitado():
+            detalle_usar_habilitado = _usar_detalle_habilitado()
+            if detalle_usar_habilitado:
                 logging.exception("Error al usar el módulo '%s': %s", nodo.modulo, exc)
             elif _usar_error_esperado(exc):
-                logging.debug("Error esperado al usar el módulo '%s': %s", nodo.modulo, exc)
+                logging.debug("Error esperado al usar el módulo '%s'", nodo.modulo)
             else:
                 logging.error("Error al usar el módulo '%s': %s", nodo.modulo, exc)
             if isinstance(exc, PermissionError):
                 mensaje = formatear_error_usar_usuario("modulo_fuera_catalogo", nodo.modulo)
-                if _usar_detalle_habilitado():
+                if detalle_usar_habilitado:
                     mensaje = f"{mensaje} ({exc})"
                 raise PermissionError(mensaje) from exc
             if isinstance(exc, ModuleNotFoundError):
                 mensaje = formatear_error_usar_usuario("carga_modulo_error", nodo.modulo)
-                if _usar_detalle_habilitado():
+                if detalle_usar_habilitado:
                     mensaje = f"{mensaje} ({exc})"
                 raise ImportError(mensaje) from exc
             raise

--- a/tests/unit/test_interactive_cmd_logging.py
+++ b/tests/unit/test_interactive_cmd_logging.py
@@ -86,6 +86,24 @@ def test_format_user_error_elimina_prefijos_duplicados():
     assert format_user_error(Exception("Error general: Error: fallo")) == "fallo"
 
 
+def test_format_user_error_preserva_mensaje_usar_corto_sin_prefijo_extra():
+    mensaje = "No se puede usar 'numpy': módulo fuera del catálogo público."
+    assert format_user_error(PermissionError(f"Error general: Error: {mensaje}")) == mensaje
+
+
+def test_log_error_usar_no_antepone_categoria_repl():
+    cmd = InteractiveCommand(types.SimpleNamespace())
+    cmd._debug_mode = False
+    mock_mostrar_error = Mock()
+    globals_log_error = InteractiveCommand._log_error.__globals__
+    mensaje = "No se puede usar 'numpy': módulo fuera del catálogo público."
+
+    with patch.dict(globals_log_error, {"mostrar_error": mock_mostrar_error}):
+        cmd._log_error(_("Error general"), PermissionError(f"Error: {mensaje}"))
+
+    mock_mostrar_error.assert_called_once_with(mensaje, registrar_log=False)
+
+
 def test_log_error_no_debug_solo_imprime_error_limpio():
     cmd = InteractiveCommand(types.SimpleNamespace())
     cmd._debug_mode = False

--- a/tests/unit/test_usar_numpy_error_contract.py
+++ b/tests/unit/test_usar_numpy_error_contract.py
@@ -1,0 +1,46 @@
+import logging
+
+import pytest
+
+from pcobra.cobra.core import Lexer, Parser
+from pcobra.core.interpreter import InterpretadorCobra
+
+
+def generar_ast(codigo: str):
+    tokens = Lexer(codigo).analizar_token()
+    return Parser(tokens).parsear()
+
+
+def test_usar_numpy_rechaza_con_error_corto_sin_detalle_tecnico():
+    interp = InterpretadorCobra()
+
+    with pytest.raises(PermissionError) as excinfo:
+        interp.ejecutar_ast(generar_ast('usar "numpy"'))
+
+    assert str(excinfo.value) == "No se puede usar 'numpy': módulo fuera del catálogo público."
+    assert "usar_error[" not in str(excinfo.value)
+    assert "USAR_COBRA_PUBLIC_MODULES" not in str(excinfo.value)
+
+
+def test_usar_numpy_no_filtra_detalle_tecnico_en_log_normal(caplog):
+    interp = InterpretadorCobra()
+
+    with caplog.at_level(logging.DEBUG), pytest.raises(PermissionError):
+        interp.ejecutar_ast(generar_ast('usar "numpy"'))
+
+    mensajes = "\n".join(record.message for record in caplog.records)
+    assert "usar_error[" not in mensajes
+    assert "USAR_COBRA_PUBLIC_MODULES" not in mensajes
+
+
+def test_usar_numpy_incluye_detalle_tecnico_solo_con_debug(monkeypatch):
+    monkeypatch.setenv("PCOBRA_DEBUG_RUNTIME", "1")
+    interp = InterpretadorCobra()
+
+    with pytest.raises(PermissionError) as excinfo:
+        interp.ejecutar_ast(generar_ast('usar "numpy"'))
+
+    mensaje = str(excinfo.value)
+    assert mensaje.startswith("No se puede usar 'numpy': módulo fuera del catálogo público.")
+    assert "usar_error[modulo_fuera_catalogo_publico]" in mensaje
+    assert "USAR_COBRA_PUBLIC_MODULES" in mensaje


### PR DESCRIPTION
### Motivation
- Evitar que la UX del REPL/CLI muestre detalles técnicos innecesarios cuando el usuario ejecuta `usar "<modulo>"`, preservando un mensaje corto y legible para el caso común (p. ej. `usar "numpy"`).
- Permitir que la información técnica (`usar_error[...]`, `USAR_COBRA_PUBLIC_MODULES`, traceback) sólo se exponga cuando está explícitamente habilitado el diagnóstico runtime/verbose mediante `_usar_detalle_habilitado()`.

### Description
- En `src/pcobra/core/interpreter.py` se calcula una sola vez `detalle_usar_habilitado = _usar_detalle_habilitado()` en el bloque `except` de `ejecutar_usar` y se usa para controlar tanto el logging como la inclusión de detalles técnicos en el mensaje que se re-levanta; los mensajes de usuario cortos se mantienen (`No se puede usar 'numpy': módulo fuera del catálogo público.`). 
- Se revisó la lógica de logging para no duplicar información en logs normales (`logging.debug`/`logging.error`) y evitar añadir detalles técnicos cuando `detalle_usar_habilitado` es falso. 
- En `src/pcobra/cobra/cli/commands/interactive_cmd.py::format_user_error` se añadió documentación que aclara que la categoría técnica debe permanecer solo para logging y que la salida de usuario no debe recibir prefijos redundantes (p. ej. `Error:`). 
- Se añadieron pruebas unitarias aisladas en `tests/unit/test_usar_numpy_error_contract.py` y se extendió `tests/unit/test_interactive_cmd_logging.py` con casos para verificar que el mensaje corto de `usar "numpy"` se preserve y que `_log_error` no anteponga un prefijo redundante. 

### Testing
- Ejecuté los tests focalizados con `PYTHONPATH=src pytest tests/unit/test_usar_numpy_error_contract.py tests/unit/test_interactive_cmd_logging.py` y la batería relevante pasó (`12 passed`).
- Ejecuté `python -m py_compile` sobre los módulos tocados (`src/pcobra/core/interpreter.py`, `src/pcobra/cobra/cli/commands/interactive_cmd.py`) y los tests nuevos para comprobar sintaxis y compilación previa al commit, sin errores.
- Como verificación manual ejecuté el intérprete en modo normal y en modo debug (con `PCOBRA_DEBUG_RUNTIME=1`) comprobando que en modo normal solo aparece el mensaje corto y en debug se incluyen detalles técnicos en el mensaje y logs; esto se hizo con un stub mínimo de `requests` igual que en `tests/conftest.py`.
- Nota: una ejecución previa del conjunto más amplio de tests mostró fallos no relacionados (imports legados en `tests/unit/test_safe_mode.py`) que quedaron fuera del alcance de este cambio; las pruebas nuevas y las afectadas por la modificación pasan correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2514f4f7c08327bc0a88b2a412bf39)