### PR TITLE
Silenciar avisos en rutas opcionales de sqliteplus

### DIFF
--- a/src/pcobra/core/database.py
+++ b/src/pcobra/core/database.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import inspect
 import json
 import logging
 import os
@@ -223,18 +224,36 @@ def _load_sqliteplus_class(*, silent_optional: bool = False):
     return _SQLITEPLUS_CLASS
 
 
+def _load_sqliteplus_class_silent_optional():
+    """Carga SQLitePlus sin avisos para rutas donde el fallback opcional es esperado."""
+
+    loader = _load_sqliteplus_class
+    try:
+        accepts_silent_optional = (
+            "silent_optional" in inspect.signature(loader).parameters
+        )
+    except (TypeError, ValueError):  # pragma: no cover - callables no introspectables
+        accepts_silent_optional = True
+
+    if accepts_silent_optional:
+        return loader(silent_optional=True)
+
+    # Compatibilidad con pruebas/adaptadores heredados que sustituyen el loader
+    # por callables sin el parámetro opcional. No se usa en el flujo normal de
+    # ``cobra build`` y el motivo queda limitado al log de depuración.
+    LOGGER.debug(
+        "Loader SQLitePlus sin parámetro silent_optional; se invoca sin avisos de usuario."
+    )
+    return loader()
+
+
 def is_sqliteplus_available() -> bool:
     """Indica si la dependencia opcional ``sqliteplus-enhanced`` está operativa."""
 
     global _SQLITEPLUS_AVAILABILITY
     if _SQLITEPLUS_AVAILABILITY is None:
         try:
-            try:
-                _load_sqliteplus_class(silent_optional=True)
-            except TypeError:
-                # Compatibilidad con pruebas que sustituyen el loader por una
-                # lambda sin parámetros.
-                _load_sqliteplus_class()
+            _load_sqliteplus_class_silent_optional()
         except Exception as exc:  # pragma: no cover - ruta defensiva opcional
             LOGGER.debug(
                 "No se pudo validar sqliteplus-enhanced; se asume indisponible: %s",
@@ -307,14 +326,11 @@ def _get_sqliteplus_instance():
     with _INIT_LOCK:
         if _SQLITEPLUS_INSTANCE is not None:
             return _SQLITEPLUS_INSTANCE
-        try:
-            sqliteplus_cls = _load_sqliteplus_class(silent_optional=True)
-        except TypeError:
-            # Compatibilidad con pruebas/adaptadores que sustituyen el loader
-            # por callables sin el parámetro opcional.
-            sqliteplus_cls = _load_sqliteplus_class()
+        sqliteplus_cls = _load_sqliteplus_class_silent_optional()
         db_path, cipher_key = _resolve_paths()
-        _SQLITEPLUS_INSTANCE = sqliteplus_cls(db_path=str(db_path), cipher_key=cipher_key)
+        _SQLITEPLUS_INSTANCE = sqliteplus_cls(
+            db_path=str(db_path), cipher_key=cipher_key
+        )
         return _SQLITEPLUS_INSTANCE
 
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,6 +1,12 @@
+import importlib
+
 import pytest
 
 from pcobra.core import database
+
+
+def _fresh_database_module():
+    return importlib.import_module("pcobra.core.database")
 
 
 @pytest.fixture(autouse=True)
@@ -11,9 +17,13 @@ def _reset_database_state(monkeypatch):
     monkeypatch.delenv(database.COBRA_DB_PATH_ENV, raising=False)
     database._SQLITEPLUS_INSTANCE = None  # type: ignore[attr-defined]
     database._TABLES_READY = False  # type: ignore[attr-defined]
+    database._SQLITEPLUS_CLASS = None  # type: ignore[attr-defined]
+    database._SQLITEPLUS_AVAILABILITY = None  # type: ignore[attr-defined]
     yield
     database._SQLITEPLUS_INSTANCE = None  # type: ignore[attr-defined]
     database._TABLES_READY = False  # type: ignore[attr-defined]
+    database._SQLITEPLUS_CLASS = None  # type: ignore[attr-defined]
+    database._SQLITEPLUS_AVAILABILITY = None  # type: ignore[attr-defined]
 
 
 def test_resolve_paths_keeps_cipher_key_with_slash(monkeypatch, tmp_path):
@@ -54,3 +64,45 @@ def test_resolve_paths_accepts_explicit_path_prefix(monkeypatch, tmp_path):
     assert db_path == explicit_path
     assert cipher_key is None
     assert explicit_path.parent.exists()
+
+
+def test_get_connection_uses_optional_sqliteplus_fallback_silently(
+    monkeypatch, tmp_path, recwarn
+):
+    """Las rutas operativas esperadas no deben avisar si falta sqliteplus."""
+
+    db = importlib.reload(_fresh_database_module())
+    db_path = tmp_path / "fallback.db"
+    monkeypatch.setenv(db.SQLITE_DB_KEY_ENV, f"path:{db_path}")
+    monkeypatch.setattr(
+        db,
+        "distribution",
+        lambda _name: (_ for _ in ()).throw(db.PackageNotFoundError),
+    )
+    db._SQLITEPLUS_CLASS = None  # type: ignore[attr-defined]
+    db._SQLITEPLUS_AVAILABILITY = None  # type: ignore[attr-defined]
+
+    with db.get_connection() as conn:
+        conn.execute("SELECT 1")
+
+    assert not [warning for warning in recwarn if warning.category is RuntimeWarning]
+    assert db._SQLITEPLUS_AVAILABILITY is False  # type: ignore[attr-defined]
+
+
+def test_explicit_sqliteplus_load_warns_when_dependency_is_missing(monkeypatch):
+    """La carga explícita mantiene el aviso solicitado por el usuario."""
+
+    db = importlib.reload(_fresh_database_module())
+    monkeypatch.setattr(
+        db,
+        "distribution",
+        lambda _name: (_ for _ in ()).throw(db.PackageNotFoundError),
+    )
+    db._SQLITEPLUS_CLASS = None  # type: ignore[attr-defined]
+    db._SQLITEPLUS_AVAILABILITY = None  # type: ignore[attr-defined]
+
+    with pytest.warns(RuntimeWarning, match="sqliteplus-enhanced"):
+        fallback_cls = db._load_sqliteplus_class()
+
+    assert fallback_cls is db._SQLITEPLUS_CLASS  # type: ignore[attr-defined]
+    assert db._SQLITEPLUS_AVAILABILITY is False  # type: ignore[attr-defined]


### PR DESCRIPTION
### Motivation

- Evitar avisos interactivos cuando la ausencia de `sqliteplus-enhanced` es esperable (p. ej. rutas explícitas con `path:`) y mantener el fallback sin imponer la dependencia.
- Centralizar el comportamiento silencioso para las verificaciones internas y la inicialización de la conexión.
- Conservar `warnings.warn(...)` únicamente en rutas donde el llamador explícitamente solicita la notificación al usuario.

### Description

- Añade el helper interno `_load_sqliteplus_class_silent_optional()` que intenta invocar `_load_sqliteplus_class(silent_optional=True)` y, para adaptadores heredados, limita la compatibilidad a un `LOGGER.debug` en vez de emitir `warnings`. (`src/pcobra/core/database.py`).
- Cambia `is_sqliteplus_available()` y `_get_sqliteplus_instance()` para usar el helper silencioso en lugar de llamar directamente a `_load_sqliteplus_class()`, de modo que las rutas no interactivas no emitan `RuntimeWarning` por defecto. (`src/pcobra/core/database.py`).
- Mantiene intacto `_build_sqliteplus_fallback()` y la semántica original de `_load_sqliteplus_class()` para llamadas explícitas que sí deben advertir al usuario. (`src/pcobra/core/database.py`).
- Añade pruebas unitarias y ajustes en `tests/unit/test_database.py` para cubrir el comportamiento silencioso del fallback en rutas esperadas y la emisión de advertencia en la carga explícita de la dependencia opcional.

### Testing

- Ejecutado `pytest tests/core/test_database.py tests/unit/test_database.py -q` y las pruebas relevantes pasaron correctamente (todos los tests ejecutados pasaron; advertencia no bloqueante presente en el entorno). 
- Ejecutado `python -m ruff check src/pcobra/core/database.py tests/unit/test_database.py` y las comprobaciones de estilo/lint pasaron. 
- Intento de ejecutar `cobra build` con `SQLITE_DB_KEY=path:/tmp/pcobra-build-test.db` quedó bloqueado por una dependencia del entorno (`requests` ausente) antes de alcanzar la fase de build; la verificación de comportamiento de fallback en runtime ya quedó cubierta por las pruebas unitarias.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25183cafa08327ac678d47b485427c)