### PR TITLE
CLI: resolver versión desde env / metadata / pyproject y ocultar 'commit unknown'

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -77,24 +77,44 @@ from pcobra.cobra.cli.utils.autocomplete import (
 )
 
 # Metadata injected at build time, with package metadata fallback for editable installs.
+def _resolve_pyproject_version() -> Optional[str]:
+    pyproject_path = Path(__file__).resolve().parents[4] / "pyproject.toml"
+    try:
+        metadata = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+    version = metadata.get("project", {}).get("version")
+    return str(version) if version else None
+
+
 def _resolve_cli_version() -> str:
     env_version = environ.get("COBRA_CLI_VERSION")
     if env_version:
         return env_version
+
     try:
         return package_version("pcobra")
     except PackageNotFoundError:
-        pyproject_path = Path(__file__).resolve().parents[4] / "pyproject.toml"
-        try:
-            metadata = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
-            version = metadata.get("project", {}).get("version")
-        except (OSError, tomllib.TOMLDecodeError):
-            version = None
-        return str(version) if version else "dev"
+        pyproject_version = _resolve_pyproject_version()
+        return pyproject_version if pyproject_version else "dev"
+
+
+def _resolve_cli_commit() -> Optional[str]:
+    commit = environ.get("COBRA_CLI_COMMIT", "").strip()
+    if not commit or commit.lower() == "unknown":
+        return None
+    return commit
+
+
+def _format_cli_version() -> str:
+    commit = _resolve_cli_commit()
+    commit_suffix = f" (commit {commit})" if commit else ""
+    return f"%(prog)s {CLI_VERSION}{commit_suffix}"
 
 
 CLI_VERSION = _resolve_cli_version()
-CLI_COMMIT = environ.get("COBRA_CLI_COMMIT", "unknown")
+CLI_COMMIT = _resolve_cli_commit()
 COBRA_INTERNAL_ENABLE_CLI_V1_ENV = "COBRA_INTERNAL_ENABLE_CLI_V1"
 COBRA_ENABLE_LEGACY_CLI_ENV = "COBRA_INTERNAL_ENABLE_LEGACY_CLI"
 assert_public_targets_contract(tuple(PUBLIC_BACKENDS), source="cobra cli bootstrap")
@@ -440,7 +460,7 @@ class CliApplication:
         parser.add_argument(
             "--version",
             action="version",
-            version=f"%(prog)s {CLI_VERSION} (commit {CLI_COMMIT})",
+            version=_format_cli_version(),
             help=_("Show version information and exit"),
         )
         parser.add_argument("--ayuda", action="help",

--- a/tests/unit/test_cli_version_resolution.py
+++ b/tests/unit/test_cli_version_resolution.py
@@ -1,0 +1,110 @@
+import ast
+import tomllib
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+from typing import Optional
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CLI_PATH = ROOT / "src" / "pcobra" / "cobra" / "cli" / "cli.py"
+
+
+def _load_version_helpers(tmp_path: Path, env: dict[str, str], package_version):
+    source = CLI_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    wanted = {
+        "_resolve_pyproject_version",
+        "_resolve_cli_version",
+        "_resolve_cli_commit",
+        "_format_cli_version",
+    }
+    helper_source = "\n\n".join(
+        ast.get_source_segment(source, node)
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in wanted
+    )
+    fake_cli = tmp_path / "src" / "pcobra" / "cobra" / "cli" / "cli.py"
+    fake_cli.parent.mkdir(parents=True)
+    fake_cli.write_text("", encoding="utf-8")
+    namespace = {
+        "__file__": str(fake_cli),
+        "environ": env,
+        "PackageNotFoundError": PackageNotFoundError,
+        "package_version": package_version,
+        "Path": Path,
+        "tomllib": tomllib,
+        "Optional": Optional,
+    }
+    exec(helper_source, namespace)
+    return namespace
+
+
+def test_pyproject_declara_version_10_1_1():
+    metadata = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert metadata["project"]["version"] == "10.1.1"
+
+
+def test_resolve_cli_version_prioriza_variable_de_entorno(tmp_path):
+    def fail_if_called(_name: str) -> str:  # pragma: no cover - should not run
+        raise AssertionError("package metadata should not be consulted")
+
+    helpers = _load_version_helpers(
+        tmp_path,
+        {"COBRA_CLI_VERSION": "env-1"},
+        fail_if_called,
+    )
+
+    assert helpers["_resolve_cli_version"]() == "env-1"
+
+
+def test_resolve_cli_version_usa_metadata_antes_de_pyproject(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nversion = "10.1.1"\n', encoding="utf-8")
+
+    helpers = _load_version_helpers(tmp_path, {}, lambda _name: "dist-2")
+
+    assert helpers["_resolve_cli_version"]() == "dist-2"
+
+
+def test_resolve_cli_version_usa_pyproject_sin_metadata_de_distribucion(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nversion = "10.1.1"\n', encoding="utf-8")
+
+    def missing_distribution(_name: str) -> str:
+        raise PackageNotFoundError
+
+    helpers = _load_version_helpers(tmp_path, {}, missing_distribution)
+
+    assert helpers["_resolve_cli_version"]() == "10.1.1"
+
+
+def test_resolve_cli_version_fallback_dev_si_no_hay_metadata_ni_pyproject(tmp_path):
+    def missing_distribution(_name: str) -> str:
+        raise PackageNotFoundError
+
+    helpers = _load_version_helpers(tmp_path, {}, missing_distribution)
+
+    assert helpers["_resolve_cli_version"]() == "dev"
+
+
+def test_format_cli_version_oculta_commit_unknown(tmp_path):
+    helpers = _load_version_helpers(
+        tmp_path,
+        {"COBRA_CLI_COMMIT": "unknown"},
+        lambda _name: "dist-2",
+    )
+    helpers["CLI_VERSION"] = "10.1.1"
+
+    assert helpers["_format_cli_version"]() == "%(prog)s 10.1.1"
+
+
+def test_format_cli_version_muestra_commit_informativo(tmp_path):
+    helpers = _load_version_helpers(
+        tmp_path,
+        {"COBRA_CLI_COMMIT": "abc123"},
+        lambda _name: "dist-2",
+    )
+    helpers["CLI_VERSION"] = "10.1.1"
+
+    assert helpers["_format_cli_version"]() == "%(prog)s 10.1.1 (commit abc123)"


### PR DESCRIPTION
### Motivation
- Asegurar que la resolución de la versión del CLI respete la prioridad solicitada: variable `COBRA_CLI_VERSION`, metadata de distribución, `pyproject.toml` y finalmente `dev` como fallback.
- Evitar que la ausencia de metadata de distribución en un checkout editable haga fallar el comando y mejorar la legibilidad de la salida `--version` ocultando el sufijo `commit unknown` cuando no aporta información.

### Description
- Añadido helper `_resolve_pyproject_version()` para leer de `pyproject.toml` de forma segura y usada como fallback cuando falta la metadata de distribución en `package_version("pcobra")` en `src/pcobra/cobra/cli/cli.py`.
- Ajustado `_resolve_cli_version()` para mantener la prioridad: `COBRA_CLI_VERSION` → `package_version("pcobra")` → `pyproject.toml` → `dev`.
- Añadidos helpers `_resolve_cli_commit()` y `_format_cli_version()` para ocultar `commit unknown` y solo mostrar el sufijo `(commit ...)` cuando `COBRA_CLI_COMMIT` aporta un valor real, y usado en el argumento `--version`.
- Añadido test unitario `tests/unit/test_cli_version_resolution.py` que verifica la prioridad de resolución, el fallback a `pyproject.toml`, el fallback final a `dev`, y el formato de commit.
- Verificado que `pyproject.toml` declara `version = "10.1.1"`.

### Testing
- Ejecuté `python -m pytest tests/unit/test_cli_version_resolution.py -q` y todos los tests unitarios pasaron (`7 passed`).
- Ejecuté `python -m py_compile src/pcobra/cobra/cli/cli.py tests/unit/test_cli_version_resolution.py` y la compilación de bytecode fue exitosa.
- Ejecuté `python -m ruff check src/pcobra/cobra/cli/cli.py tests/unit/test_cli_version_resolution.py` y no se reportaron problemas de estilo.
- Ejecuté `python -m pytest tests/integration/test_cli_ayuda.py::test_cobra_version_funciona_sin_sqlite_db_key -q`, que falla en este entorno por una dependencia ausente (`requests`) y por tanto el fallo es ambiental y no causado por los cambios realizados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2519ff4db48327979492cf14cde48c)