### PR TITLE
test: enforce build CLI public args contract

### DIFF
--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -79,6 +79,7 @@ def test_cli_build_help_public_contract_no_expone_flags_backend():
     assert result.returncode == 0
     output = result.stdout.lower()
     assert "--backend" not in output
+    assert "--target" not in output
     assert "--tipo" not in output
     assert "--tipos" not in output
 

--- a/tests/unit/test_cli_v2_command_contract.py
+++ b/tests/unit/test_cli_v2_command_contract.py
@@ -164,7 +164,29 @@ def test_build_v2_help_no_expone_flags_backend():
 
     assert "--tipo" not in help_text
     assert "--backend" not in help_text
+    assert "--target" not in help_text
     assert "--tipos" not in help_text
+
+
+def test_build_v2_parser_publico_registra_solo_file_posicional():
+    subparsers = _build_subparsers()
+    command = BuildCommandV2()
+    command.register_subparser(subparsers)
+    parser = subparsers.choices[command.name]
+
+    public_actions = [
+        action
+        for action in parser._actions
+        if not any(option in ("-h", "--help") for option in action.option_strings)
+    ]
+
+    assert [(action.dest, tuple(action.option_strings)) for action in public_actions] == [
+        ("file", ()),
+    ]
+    assert parser.parse_args(["programa.co"]).file == "programa.co"
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["programa.co", "--target", "python"])
 
 
 def test_run_v2_valida_seguridad_por_ruta_binding(monkeypatch):


### PR DESCRIPTION
### Motivation
- Asegurar que el comando `build` (v2) solo exponga el argumento posicional público `file` y no publique opciones de selección de backend/target.
- Añadir cobertura de contrato CLI que prevenga regresiones que introduzcan `--target`/`--backend` u alias equivalentes en la superficie pública.

### Description
- Inspeccioné `BuildCommandV2.register_subparser` y verifiqué que el subparser solo añade el posicional `file` sin flags de backend/target; no se modificó la implementación del comando (`src/pcobra/cobra/cli/commands_v2/build_cmd.py`).
- Añadí assertions en tests unitarios para que `build --help` no incluya `--target` además de `--backend`, `--tipo` y `--tipos`, y un test que inspecciona las acciones públicas del parser comprobando que el único argumento es `file` (`tests/unit/test_cli_v2_command_contract.py`).
- Reforcé el test de integración que valida la ayuda pública de CLI para incluir la ausencia de `--target` en `cobra build --help` (`tests/integration/test_cli_public_help_contract.py`).
- No se añadieron flags nuevos al CLI y la resolución/selección de backend permanece dentro de la política interna y la ruta existente de `backend_pipeline` / `BuildService`.

### Testing
- Ejecutado con éxito el conjunto focalizado: `pytest tests/unit/test_cli_v2_command_contract.py::test_build_v2_help_no_expone_flags_backend tests/unit/test_cli_v2_command_contract.py::test_build_v2_parser_publico_registra_solo_file_posicional tests/integration/test_cli_public_help_contract.py::test_cli_build_help_public_contract_no_expone_flags_backend` (todos pasaron).
- Ejecución del fichero unitario completo `pytest tests/unit/test_cli_v2_command_contract.py` mostró fallos preexistentes no relacionados con estos cambios, concretamente import/monkeypatch sobre `cobra.cli.commands_v2.build_cmd.backend_pipeline` y accesos a atributos `_legacy` ausentes en otros comandos, por lo que no se tocaron para no ampliar el alcance de esta PR.
- Los cambios comprometidos son solo en tests y no alteran la política interna de selección de backend; los tests focales relevantes para el contrato CLI pasan correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a251b55961c83278846c5f9d08d46ec)