### PR TITLE
Simplify visit_retorno and add tests for return/defer behavior

### DIFF
--- a/src/pcobra/cobra/transpilers/transpiler/python_nodes/retorno.py
+++ b/src/pcobra/cobra/transpilers/transpiler/python_nodes/retorno.py
@@ -1,3 +1,3 @@
 def visit_retorno(self, nodo):
-    valor = self.obtener_valor(getattr(nodo, "expresion", nodo.expresion))
+    valor = self.obtener_valor(nodo.expresion)
     self.codigo += f"{self.obtener_indentacion()}return {valor}\n"

--- a/tests/unit/test_to_python.py
+++ b/tests/unit/test_to_python.py
@@ -136,6 +136,58 @@ def test_transpilador_funcion_con_defer():
     assert resultado == esperado
 
 
+def test_transpilador_funcion_sin_defer_retorna_operacion_basica():
+    codigo_fuente = """func doble(n):
+    retorno n * 2
+fin"""
+    func = Parser(Lexer(codigo_fuente).analizar_token()).parsear()[0]
+    transpilador = TranspiladorPython()
+
+    func.aceptar(transpilador)
+
+    assert transpilador.codigo == "def doble(n):\n" + "    return n * 2\n"
+    assert "ExitStack" not in transpilador.codigo
+    assert transpilador.usa_contextlib is False
+
+
+def test_transpilador_funcion_sin_defer_retorna_identificador_basico():
+    func = NodoFuncion("identidad", ["n"], [NodoRetorno(NodoIdentificador("n"))])
+    transpilador = TranspiladorPython()
+
+    func.aceptar(transpilador)
+
+    assert transpilador.codigo == "def identidad(n):\n" + "    return n\n"
+    assert "ExitStack" not in transpilador.codigo
+    assert transpilador.usa_contextlib is False
+
+
+def test_transpilador_funcion_con_defer_retorno_conserva_exitstack_solo_con_defer():
+    con_defer = NodoFuncion(
+        "cerrar",
+        [],
+        [
+            NodoDefer(NodoLlamadaFuncion("limpiar", []), linea=1, columna=1),
+            NodoRetorno(NodoValor(1)),
+        ],
+    )
+    sin_defer = NodoFuncion("uno", [], [NodoRetorno(NodoValor(1))])
+    transpilador_con_defer = TranspiladorPython()
+    transpilador_sin_defer = TranspiladorPython()
+
+    con_defer.aceptar(transpilador_con_defer)
+    sin_defer.aceptar(transpilador_sin_defer)
+
+    assert (
+        "    with contextlib.ExitStack() as __cobra_defer_stack_0:\n"
+        in transpilador_con_defer.codigo
+    )
+    assert "        return 1\n" in transpilador_con_defer.codigo
+    assert transpilador_con_defer.usa_contextlib is True
+    assert transpilador_sin_defer.codigo == "def uno():\n" + "    return 1\n"
+    assert "ExitStack" not in transpilador_sin_defer.codigo
+    assert transpilador_sin_defer.usa_contextlib is False
+
+
 def test_detector_defer_por_nombre_en_bloques_anidados():
     from pcobra.cobra.transpilers.transpiler.python_nodes.funcion import _contiene_defer
 


### PR DESCRIPTION
### Motivation
- Mantener la salida de `NodoRetorno` estrictamente como `return {valor}` sin introducir manejo de `ExitStack` en el visitante de retorno.
- Asegurar que `obtener_valor(nodo.expresion)` no reingrese a `visit_retorno` ni a `visit_funcion` y añadir pruebas de regresión que cubran retornos simples y la interacción con `defer`.

### Description
- Simplificado `visit_retorno` para obtener la expresión directamente con `valor = self.obtener_valor(nodo.expresion)` y emitir `return {valor}` sin lógica adicional; archivo modificado: `src/pcobra/cobra/transpilers/transpiler/python_nodes/retorno.py`.
- No se añadió ninguna lógica de `ExitStack` en `visit_retorno`; la creación/uso de `ExitStack` sigue siendo responsabilidad de `visit_funcion` cuando `_contiene_defer` detecta `NodoDefer` (sin cambios en esa lógica).
- Se añadieron pruebas unitarias en `tests/unit/test_to_python.py` que cubren: función sin `defer` con `retorno n * 2`, función sin `defer` con `retorno n`, y función con `defer` y `retorno 1` verificando que `ExitStack` solo aparece en el caso con `defer`.

### Testing
- Ejecuté los tests focalizados: `pytest` sobre las pruebas añadidas y las relacionadas con `defer` (4 tests específicos), y todos pasaron (4 passed).
- Verifiqué la compilación estática con `python -m py_compile` sobre los archivos modificados y los tests añadidos, y la comprobación pasó sin errores.
- Ejecutar `pytest tests/unit/test_to_python.py -q` muestra fallos preexistentes no relacionados con este cambio en otras pruebas del archivo (`test_transpilador_condicional`, `test_transpilador_mientras`, `test_transpilador_holobit`, `test_transpilador_switch_patron_guardia`), por lo que las pruebas globales del archivo no fueron usadas como bloqueo para este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a252ef6a3a48327818f9b5bcf9fb873)