### PR TITLE
Preserve Python function declarations during transpilation

### DIFF
--- a/src/pcobra/cobra/transpilers/transpiler/to_python.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_python.py
@@ -258,11 +258,17 @@ class TranspiladorPython(BaseTranspiler):
     def obtener_indentacion(self):
         return "    " * self.nivel_indentacion
 
+    def _contiene_funciones(self, nodos):
+        """Indica si el programa declara funciones de primer nivel."""
+        return any(isinstance(nodo, NodoFuncion) for nodo in nodos)
 
     def transpilar(self, nodos):
         nodos = normalize_to_cobra_ast(nodos)
         nodos = expandir_macros(nodos)
-        nodos = remove_dead_code(inline_functions(optimize_constants(nodos)))
+        nodos = optimize_constants(nodos)
+        if not self._contiene_funciones(nodos):
+            nodos = inline_functions(nodos)
+        nodos = remove_dead_code(nodos)
         usa_holobit = ast_requires_holobit_runtime(nodos)
         self.codigo = get_standard_imports("python")
         if usa_holobit:

--- a/tests/unit/test_to_python.py
+++ b/tests/unit/test_to_python.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 try:
     from pcobra.core.ast_nodes import (
         NodoAsignacion,
@@ -18,6 +20,7 @@ try:
         NodoWith,
         NodoDefer,
         NodoRetorno,
+        NodoOperacionBinaria,
     )
     from pcobra.core.ast_nodes import NodoSwitch, NodoCase, NodoPattern, NodoGuard
 except ImportError:  # pragma: no cover - compatibilidad
@@ -40,6 +43,7 @@ except ImportError:  # pragma: no cover - compatibilidad
         NodoWith,
         NodoDefer,
         NodoRetorno,
+        NodoOperacionBinaria,
     )
     from core.ast_nodes import (  # type: ignore
         NodoSwitch,
@@ -148,6 +152,29 @@ fin"""
     assert transpilador.codigo == "def doble(n):\n" + "    return n * 2\n"
     assert "ExitStack" not in transpilador.codigo
     assert transpilador.usa_contextlib is False
+
+
+def test_transpilar_python_conserva_funcion_simple_inlineable():
+    ast = [
+        NodoFuncion(
+            "doble",
+            ["n"],
+            [
+                NodoRetorno(
+                    NodoOperacionBinaria(
+                        NodoIdentificador("n"),
+                        SimpleNamespace(tipo=None, valor="*"),
+                        NodoValor(2),
+                    )
+                )
+            ],
+        )
+    ]
+
+    codigo = TranspiladorPython().generate_code(ast)
+
+    assert "def doble(n):\n" in codigo
+    assert "    return n * 2\n" in codigo
 
 
 def test_transpilador_funcion_sin_defer_retorna_identificador_basico():


### PR DESCRIPTION
### Motivation

- Evitar que el optimizador de inlining elimine declaraciones de función simples antes de generar código Python, lo que provocaba que `def doble(n):` desapareciera del output transpileado.
- Aplicar una corrección mínima y local al backend Python sin cambiar la interfaz pública del inliner ni el comportamiento del intérprete.

### Description

- En `src/pcobra/cobra/transpilers/transpiler/to_python.py` se añadió el método `_contiene_funciones(self, nodos)` para detectar `NodoFuncion` de primer nivel y, en `transpilar`, se reordenaron las optimizaciones para ejecutar `optimize_constants` primero, aplicar `inline_functions` solo si no hay funciones top-level y luego `remove_dead_code`.
- La solución es interna al transpiler (ninguna API pública del inliner fue modificada) y mantiene el inliner tal cual para el intérprete y otros backends.
- Se añadió un test de regresión `test_transpilar_python_conserva_funcion_simple_inlineable` en `tests/unit/test_to_python.py` que verifica que una función simple equivalente a `func doble(n): retorno n * 2 fin` produce `def doble(n):` y `return n * 2` en el código Python generado.
- Se hicieron ajustes menores en el propio test para poder construir el AST usado en la prueba (`NodoOperacionBinaria` y un `SimpleNamespace` para el token) sin afectar la lógica del runtime.

### Testing

- Ejecutado: `python -m pytest tests/unit/test_to_python.py::test_transpilar_python_conserva_funcion_simple_inlineable tests/unit/test_to_python.py::test_transpilador_funcion_sin_defer_retorna_operacion_basica tests/unit/test_optimizations.py -q`; resultado: todos los tests especificados pasaron (✅).
- Ejecutado: `python -m pytest tests/unit/test_optimizations.py -q`; resultado: pasó (✅).
- Ejecutado: `python -m pytest tests/unit/test_to_python.py -q`; resultado: fallo en 4 tests preexistentes del archivo no relacionados con la regresión añadida (fallos sobre optimizaciones/representación de strings y Holobit), por lo que la regresión cubierta por el nuevo test sí quedó resuelta mientras permanecen otras issues históricas en ese archivo (❌).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2530ad48648327957c14c0b1b3a8e6)