### PR TITLE
Conserva declaraciones de función en el backend Python

### DIFF
--- a/src/pcobra/cobra/transpilers/transpiler/to_python.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_python.py
@@ -1,6 +1,7 @@
 """Transpilador que convierte código Cobra en código Python."""
 
 from pcobra.cobra.core.ast_nodes import (
+    NodoAST,
     NodoAsignacion,
     NodoCondicional,
     NodoGarantia,
@@ -259,8 +260,34 @@ class TranspiladorPython(BaseTranspiler):
         return "    " * self.nivel_indentacion
 
     def _contiene_funciones(self, nodos):
-        """Indica si el programa declara funciones de primer nivel."""
-        return any(isinstance(nodo, NodoFuncion) for nodo in nodos)
+        """Indica si el AST declara alguna función.
+
+        El backend Python conserva las declaraciones ``def`` tal como aparecen en
+        el programa fuente; por eso no debe ejecutar el inliner cuando haya
+        funciones en el árbol.
+        """
+        pendientes = list(nodos)
+        visitados = set()
+
+        while pendientes:
+            actual = pendientes.pop()
+            if actual is None:
+                continue
+            if isinstance(actual, NodoFuncion):
+                return True
+            if isinstance(actual, (list, tuple)):
+                pendientes.extend(actual)
+                continue
+
+            identificador = id(actual)
+            if identificador in visitados:
+                continue
+            visitados.add(identificador)
+
+            if isinstance(actual, NodoAST):
+                pendientes.extend(vars(actual).values())
+
+        return False
 
     def transpilar(self, nodos):
         nodos = normalize_to_cobra_ast(nodos)

--- a/tests/unit/test_inlining_transpilers.py
+++ b/tests/unit/test_inlining_transpilers.py
@@ -14,18 +14,15 @@ def _ast_inline():
     ]
 
 
-def test_inline_python_transpiler():
+def test_python_transpiler_preserves_inlineable_function_declarations():
     codigo = TranspiladorPython().generate_code(_ast_inline())
-    assert codigo == IMPORTS + "x = 1\n"
+
+    assert codigo == IMPORTS + "def uno():\n    return 1\nx = uno()\n"
+    assert "def uno():" in codigo
 
 
 def test_inline_js_transpiler():
     codigo = TranspiladorJavaScript().generate_code(_ast_inline())
-    esperado = (
-        "import * as io from './nativos/io.js';\n"
-        + "import * as net from './nativos/io.js';\n"
-        + "import * as matematicas from './nativos/matematicas.js';\n"
-        + "import { Pila, Cola } from './nativos/estructuras.js';\n"
-        + "let x = 1;"
-    )
-    assert codigo == esperado
+    assert codigo.startswith("\n".join(get_standard_imports("javascript")) + "\n")
+    assert codigo.endswith("let x = 1;")
+    assert "function uno" not in codigo


### PR DESCRIPTION
### Motivation
- Evitar que el inliner elimine/inlinee declaraciones `func`/`NodoFuncion` cuando se transpila a Python, para que el backend genere `def nombre(...)` para funciones definidas por el usuario.
- Hacer la corrección mínima en el transpiler Python sin cambiar la interfaz pública del inliner ni el comportamiento global del intérprete.

### Description
- Añade una detección profunda de `NodoFuncion` en `TranspiladorPython._contiene_funciones` y evita llamar a `inline_functions` si el AST contiene cualquier `NodoFuncion` (recorrido seguro basado en `NodoAST`).
- Importa `NodoAST` en el transpiler y limita la exploración de atributos a instancias de `NodoAST` para evitar procesar valores auxiliares no AST.
- Actualiza la prueba de inlining Python (`tests/unit/test_inlining_transpilers.py`) para requerir que la declaración `def uno():` permanezca en el código generado y que la llamada siga siendo `x = uno()`.
- Mantiene el inliner sin cambios para otros backends (p. ej. JavaScript) y modifica ligeramente la aserción JS del test para no depender de una lista concreta de imports.

### Testing
- Ejecutado `pytest -q tests/unit/test_inlining_transpilers.py tests/unit/test_to_python.py::test_transpilar_python_conserva_funcion_simple_inlineable` y la prueba pasó.
- Ejecutado `pytest -q tests/unit/test_inlining_transpilers.py tests/unit/test_to_python.py` (conjunto de pruebas objetivo) con resultados `3 passed, 1 warning` tras los cambios.
- Ejecutado `python -m py_compile src/pcobra/cobra/transpilers/transpiler/to_python.py tests/unit/test_inlining_transpilers.py` para verificar sintaxis compilable y pasó.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a3d5534e483278d941cccc90bad67)