### PR TITLE
Añadir test de regresión y evitar recursión al detectar tipos de nodo en el AST

### DIFF
--- a/src/pcobra/cobra/transpilers/common/utils.py
+++ b/src/pcobra/cobra/transpilers/common/utils.py
@@ -303,16 +303,42 @@ def validate_minimal_runtime_routes() -> None:
 validate_runtime_contracts()
 
 
-def ast_contains_node_types(tree, node_type_names: tuple[str, ...]) -> bool:
-    """Indica si ``tree`` contiene algún nodo cuyo nombre de clase esté en ``node_type_names``."""
+def ast_contains_node_types(
+    tree, node_type_names: tuple[str, ...], _visited: set[int] | None = None
+) -> bool:
+    """Indica si ``tree`` contiene algún nodo de los tipos indicados.
+
+    Algunos nodos conservan referencias a objetos auxiliares compartidos (por
+    ejemplo tokens) que pueden formar ciclos. El recorrido usa identidades ya
+    visitadas para evitar recursión infinita mientras inspecciona el AST.
+    """
     if tree is None:
         return False
+
+    if _visited is None:
+        _visited = set()
+
+    if isinstance(tree, (list, tuple, set, dict)) or hasattr(tree, "__dict__"):
+        identifier = id(tree)
+        if identifier in _visited:
+            return False
+        _visited.add(identifier)
+
+    if isinstance(tree, dict):
+        return any(
+            ast_contains_node_types(item, node_type_names, _visited)
+            for pair in tree.items()
+            for item in pair
+        )
+
     if isinstance(tree, (list, tuple, set)):
-        return any(ast_contains_node_types(item, node_type_names) for item in tree)
+        return any(
+            ast_contains_node_types(item, node_type_names, _visited) for item in tree
+        )
     if tree.__class__.__name__ in node_type_names:
         return True
     for value in getattr(tree, "__dict__", {}).values():
-        if ast_contains_node_types(value, node_type_names):
+        if ast_contains_node_types(value, node_type_names, _visited):
             return True
     return False
 

--- a/tests/unit/test_to_python.py
+++ b/tests/unit/test_to_python.py
@@ -485,3 +485,32 @@ def test_transpilador_clase_generica():
         + "            pass\n"
     )
     assert codigo == esperado
+
+
+def test_transpilador_python_funcion_condicional_parser_sin_recursion_ni_defer():
+    codigo_fuente = """func resumen_numero(n):
+    si n > 0:
+        imprimir("positivo")
+    sino:
+        imprimir("no positivo")
+    fin
+
+    retorno n
+fin
+
+var x = resumen_numero(3)
+imprimir(x)
+"""
+
+    tokens = Lexer(codigo_fuente).analizar_token()
+    ast = Parser(tokens).parsear()
+    codigo = TranspiladorPython().generate_code(ast)
+
+    assert "def resumen_numero(n):" in codigo
+    assert "if n > 0:" in codigo
+    assert "else:" in codigo
+    assert ("print('positivo')" in codigo) or ('print("positivo")' in codigo)
+    assert "return n" in codigo
+    assert "x = resumen_numero(3)" in codigo
+    assert "maximum recursion depth exceeded" not in codigo
+    assert "contextlib.ExitStack" not in codigo


### PR DESCRIPTION
### Motivation
- Evitar que la detección de tipos de nodo en el AST provoque recursión infinita en árboles producidos por el `Parser` al recorrer objetos con referencias cíclicas. 
- Añadir un test de regresión que valide el caso reducido de una `func` con `si`/`sino`, `retorno`, `imprimir` y la llamada asignada para impedir reaparición del problema.

### Description
- Se modifica `ast_contains_node_types` en `src/pcobra/cobra/transpilers/common/utils.py` para aceptar un parámetro `_visited` y evitar recorrer objetos ya visitados, protegiendo listas, tuplas, sets, dicts y objetos con `__dict__` contra ciclos. 
- La función ahora propaga `_visited` en llamadas recursivas y maneja `dict` explícitamente para inspeccionar sus elementos sin entrar en bucles infinitos. 
- Se añade el test `test_transpilador_python_funcion_condicional_parser_sin_recursion_ni_defer` en `tests/unit/test_to_python.py` que transpila el script Cobra reducido mediante `Lexer`, `Parser` y `TranspiladorPython` y verifica la presencia de `def resumen_numero(n):`, `if n > 0:`, `else:`, `print('positivo')` (o equivalente), `return n`, `x = resumen_numero(3)`, y la ausencia de `maximum recursion depth exceeded` y de `contextlib.ExitStack` cuando no hay `defer`.

### Testing
- Se ejecutó `python -m pytest tests/unit/test_to_python.py::test_transpilador_python_funcion_condicional_parser_sin_recursion_ni_defer` y el test pasó correctamente. 
- Se ejecutó `python -m pytest tests/unit/test_to_python.py` y el archivo completo mostró `22 passed, 4 failed`, siendo los fallos preexistentes en expectativas no relacionadas con este cambio (p. ej. manejo de condiciones como `str`, hooks Holobit y representación de guard en `switch`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a780562508327b371cd75383fe378)