### PR TITLE
Actualizar tests de funciones Python con defer

### DIFF
--- a/tests/unit/test_to_python.py
+++ b/tests/unit/test_to_python.py
@@ -107,13 +107,23 @@ def test_transpilador_funcion():
         NodoFuncion(
             "miFuncion",
             ["a", "b"],
-            [NodoAsignacion("x", NodoValor("a + b"))],
+            [
+                NodoAsignacion(
+                    "x",
+                    NodoOperacionBinaria(
+                        NodoIdentificador("a"),
+                        SimpleNamespace(tipo=None, valor="+"),
+                        NodoIdentificador("b"),
+                    ),
+                )
+            ],
         )
     ]
     transpilador = TranspiladorPython()
     resultado = transpilador.generate_code(ast)
-    esperado = IMPORTS + "def miFuncion(a, b):\n" + "    x = 'a + b'\n"
+    esperado = IMPORTS + "def miFuncion(a, b):\n" + "    x = a + b\n"
     assert resultado == esperado
+    assert "contextlib.ExitStack" not in resultado
 
 
 def test_transpilador_funcion_con_defer():
@@ -138,6 +148,8 @@ def test_transpilador_funcion_con_defer():
         + "        return 1\n"
     )
     assert resultado == esperado
+    assert "contextlib.ExitStack" in resultado
+    assert transpilador._defer_stack == []
 
 
 def test_transpilador_funcion_sin_defer_retorna_operacion_basica():


### PR DESCRIPTION
### Motivation
- Alinear los tests con la semántica del transpilador: las expresiones deben generarse como operaciones (`a + b`) y no como literales de cadena.
- Verificar explícitamente el uso de `contextlib.ExitStack` solo cuando hay `defer` en el cuerpo de la función.
- Asegurar que la pila interna de defer (`_defer_stack`) quede vacía después de generar código que usa `defer`.

### Description
- Se reemplaza en `test_transpilador_funcion` el uso de `NodoValor("a + b")` por un `NodoOperacionBinaria` que une `NodoIdentificador("a")` y `NodoIdentificador("b")` con operador `+`, y se actualiza la expectativa a `x = a + b` en lugar de `'a + b'`.
- Se añade en `test_transpilador_funcion` la aserción explícita `assert "contextlib.ExitStack" not in resultado` para funciones sin `defer`.
- Se mantienen las expectativas de `test_transpilador_funcion_con_defer` sobre `import contextlib`, el `with contextlib.ExitStack() as __cobra_defer_stack_0:`, el `callback` y `return 1`, y se añaden las aserciones `assert "contextlib.ExitStack" in resultado` y `assert transpilador._defer_stack == []`.
- Los cambios se aplicaron únicamente en `tests/unit/test_to_python.py` (actualización del AST y aserciones añadidas en los tests mencionados).

### Testing
- Ejecutado `python -m pytest tests/unit/test_to_python.py -k 'test_transpilador_funcion or test_transpilador_funcion_con_defer'` y ambas pruebas pasaron ✅.
- Ejecutado `python -m pytest tests/unit/test_to_python.py` y el archivo completo muestra fallos no relacionados con este cambio en `test_transpilador_condicional`, `test_transpilador_mientras`, `test_transpilador_holobit` y `test_transpilador_switch_patron_guardia`, por lo que el conjunto completo no está verde ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a8e1ac0748327a8bd1ef5e881d0db)