### PR TITLE
test: añadir test unitario para transpilación de funciones con corelibs

### DIFF
--- a/tests/unit/test_to_python_funciones.py
+++ b/tests/unit/test_to_python_funciones.py
@@ -1,0 +1,28 @@
+from pcobra.cobra.core.lexer import Lexer
+from pcobra.cobra.core.parser import Parser
+from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
+
+
+def test_transpila_funcion_y_llamadas_a_corelibs_sin_contextlib():
+    codigo_fuente = '''usar "numero"
+usar "texto"
+
+func doble(n):
+    retorno n * 2
+fin
+
+imprimir(mayusculas("cobra"))
+imprimir(doble(5))
+'''
+
+    tokens = Lexer(codigo_fuente).analizar_token()
+    ast = Parser(tokens).parsear()
+    codigo_python = TranspiladorPython().generate_code(ast)
+
+    assert "mayusculas" in codigo_python
+    assert "texto = obtener_modulo('texto')" in codigo_python
+    assert "def doble(n):" in codigo_python
+    assert "return n * 2" in codigo_python
+    assert "print(mayusculas('cobra'))" in codigo_python
+    assert "print(doble(5))" in codigo_python
+    assert "contextlib" not in codigo_python


### PR DESCRIPTION
### Motivation
- Añadir una prueba ligera que cubra la transpilación de un script Cobra con `usar "numero"`, `usar "texto"`, la función `doble` y llamadas a `imprimir`, y verificar que no se introduce `contextlib` cuando no hay `defer`.

### Description
- Se añade `tests/unit/test_to_python_funciones.py` que tokeniza y parsea el script con `Lexer`/`Parser`, genera código con `TranspiladorPython` y comprueba la presencia de `mayusculas`, la asignación `texto = obtener_modulo('texto')`, la definición `def doble(n):`, `return n * 2`, las llamadas `print(mayusculas('cobra'))` y `print(doble(5))`, sin introducir `contextlib`; no se modifica la GUI Flet.

### Testing
- Ejecuté `pytest tests/unit/test_to_python_funciones.py` y la prueba pasó; ejecuté `pytest tests/unit/test_to_python.py tests/unit/test_to_python_funciones.py` y el nuevo test pasó pero 4 pruebas preexistentes fallaron: `test_transpilador_condicional`, `test_transpilador_mientras`, `test_transpilador_holobit` y `test_transpilador_switch_patron_guardia`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aa2be20a88327b6cc5aabeb5215fd)