### PR TITLE
test: add Python transpiler recursion regression

### DIFF
--- a/tests/unit/test_to_python_funciones.py
+++ b/tests/unit/test_to_python_funciones.py
@@ -26,3 +26,51 @@ imprimir(doble(5))
     assert "print(mayusculas('cobra'))" in codigo_python
     assert "print(doble(5))" in codigo_python
     assert "contextlib" not in codigo_python
+
+
+def test_transpila_script_complejo_con_usar_funciones_retorno_y_llamadas():
+    codigo_fuente = '''usar "numero"
+usar "texto"
+usar "datos"
+
+func doble(n):
+    retorno n * 2
+fin
+
+func cuadrado(n):
+    retorno n * n
+fin
+
+func resumen_numero(n):
+    si n > 10:
+        retorno a_texto(n)
+    sino:
+        retorno "pequeno"
+    fin
+fin
+
+y = doble(5)
+z = cuadrado(y)
+resumen = resumen_numero(z)
+imprimir(y)
+imprimir(resumen)
+'''
+
+    try:
+        tokens = Lexer(codigo_fuente).analizar_token()
+        ast = Parser(tokens).parsear()
+        codigo_python = TranspiladorPython().generate_code(ast)
+    except RecursionError as exc:  # pragma: no cover - el fallo debe ser explícito
+        raise AssertionError("La transpilación no debe lanzar RecursionError") from exc
+    except Exception as exc:
+        if "maximum recursion depth exceeded" in str(exc):
+            raise AssertionError(
+                "La transpilación no debe superar la profundidad máxima de recursión"
+            ) from exc
+        raise
+
+    assert "def doble(n):" in codigo_python
+    assert "def cuadrado(n):" in codigo_python
+    assert "def resumen_numero(n):" in codigo_python
+    assert "y = doble(5)" in codigo_python
+    assert "print(y)" in codigo_python


### PR DESCRIPTION
### Motivation
- Añadir una prueba de regresión para prevenir que la ruta de transpiler Python entre en una recursión infinita al procesar scripts con varios `usar` y llamadas entre funciones.
- Reproducir de forma controlada el caso complejo del reporte con `usar "numero"`, `usar "texto"`, `usar "datos"`, múltiples funciones con `retorno`, una rama `si/sino`, asignaciones desde llamadas y `imprimir`.
- Asegurar que la vía pública mínima `Lexer` → `Parser` → `TranspiladorPython` se valide sin ejecutar la GUI. 

### Description
- Se añadió un test `test_transpila_script_complejo_con_usar_funciones_retorno_y_llamadas` en `tests/unit/test_to_python_funciones.py` que contiene el script Cobra reducido solicitado y las aserciones sobre el código generado.
- La prueba transpila usando la secuencia `Lexer(...).analizar_token()` → `Parser(...).parsear()` → `TranspiladorPython().generate_code(ast)` y no arranca la interfaz GUI. 
- El test falla explícitamente si la transpilación lanza `RecursionError` o si la excepción contiene `maximum recursion depth exceeded` para detectar regresiones de recursión. 
- Se verifican fragmentos clave del Python generado con afirmaciones que buscan `def doble(n):`, `def cuadrado(n):`, `def resumen_numero(n):`, `y = doble(5)` y `print(y)`. 

### Testing
- Se ejecutó `pytest -q tests/unit/test_to_python_funciones.py` y la suite focalizada pasó con `2 passed`.
- Se comprobó la sintaxis con `python -m py_compile tests/unit/test_to_python_funciones.py` y no reportó errores.
- Se ejecutó `git diff --check` y no se encontraron problemas en el diff generado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aaf14aec08327a0190ba1358bbd47)