### PR TITLE
Evita recursión infinita en _contiene_nodo_valor y añade test

### DIFF
--- a/src/pcobra/cobra/transpilers/transpiler/to_python.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_python.py
@@ -334,7 +334,16 @@ class TranspiladorPython(BaseTranspiler):
             codigo = "import asyncio\n" + codigo
         return codigo
 
-    def _contiene_nodo_valor(self, nodo):
+    def _contiene_nodo_valor(self, nodo, _visitados=None):
+        if _visitados is None:
+            _visitados = set()
+
+        if hasattr(nodo, "__dict__"):
+            identificador = id(nodo)
+            if identificador in _visitados:
+                return False
+            _visitados.add(identificador)
+
         if hasattr(nodo, "valor") and len(getattr(nodo, "__dict__", {})) == 1:
             return True
         for atributo in getattr(nodo, "__dict__", {}).values():
@@ -343,12 +352,16 @@ class TranspiladorPython(BaseTranspiler):
                     if isinstance(elem, (list, tuple)):
                         for sub in elem:
                             if hasattr(sub, "__dict__") and self._contiene_nodo_valor(
-                                sub
+                                sub, _visitados
                             ):
                                 return True
-                    elif hasattr(elem, "__dict__") and self._contiene_nodo_valor(elem):
+                    elif hasattr(elem, "__dict__") and self._contiene_nodo_valor(
+                        elem, _visitados
+                    ):
                         return True
-            elif hasattr(atributo, "__dict__") and self._contiene_nodo_valor(atributo):
+            elif hasattr(atributo, "__dict__") and self._contiene_nodo_valor(
+                atributo, _visitados
+            ):
                 return True
         return False
 

--- a/tests/unit/test_to_python4.py
+++ b/tests/unit/test_to_python4.py
@@ -121,3 +121,17 @@ def test_transpilar_metodo():
         + "def mi_metodo(a, b):\n    resultado = a + b\n"
     )
     assert result == expected, "Error en la transpilación de método"
+
+
+class NodoCiclicoArtificial:
+    def __init__(self):
+        self.hijos = []
+
+
+def test_contiene_nodo_valor_ignora_ciclos_sin_recursion_error():
+    nodo = NodoCiclicoArtificial()
+    nodo.hijos.append(nodo)
+
+    transpiler = TranspiladorPython()
+
+    assert transpiler._contiene_nodo_valor(nodo) is False


### PR DESCRIPTION
### Motivation
- `TranspiladorPython._contiene_nodo_valor` recorría recursivamente atributos sin registrar nodos visitados, lo que podía provocar `RecursionError` en presencia de nodos compartidos o ciclos por identidad.
- Mantener la firma pública del método y la detección actual de nodos valor mientras se corta la recursión infinita.

### Description
- Cambiado `_contiene_nodo_valor(self, nodo)` a `_contiene_nodo_valor(self, nodo, _visitados=None)` y se inicializa internamente `_visitados = set()` cuando es `None`.
- Antes de recorrer `nodo.__dict__` se comprueba `identificador = id(nodo)` en `_visitados`; si ya está presente se devuelve `False`, si no se añade y se continúa.
- Se propaga `_visitados` en las llamadas recursivas para listas/tuplas y atributos anidados sin alterar la lógica existente que detecta nodos con `valor`.
- Añadido test `test_contiene_nodo_valor_ignora_ciclos_sin_recursion_error` en `tests/unit/test_to_python4.py` que crea un nodo artificial cíclico y comprueba que la función no lanza `RecursionError` y devuelve `False`.

### Testing
- Ejecutado `python -m pytest tests/unit/test_to_python4.py::test_contiene_nodo_valor_ignora_ciclos_sin_recursion_error -q` y el test pasó correctamente.
- Ejecutado `git diff --check` para validar whitespace y no reportó problemas.
- Ejecutado `python -m pytest tests/unit/test_to_python4.py -q` y se observaron fallos en tests preexistentes no relacionados con este cambio debido a expectativas/estructuras AST antiguas; los fallos no están causados por la modificación introducida en este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ac44b88048327bdff8e6383ab4143)