### PR TITLE
Emitir cuerpo de función directamente excepto cuando hay defer (ExitStack condicional)

### DIFF
--- a/src/pcobra/cobra/transpilers/transpiler/python_nodes/funcion.py
+++ b/src/pcobra/cobra/transpilers/transpiler/python_nodes/funcion.py
@@ -17,7 +17,27 @@ _ATRIBUTOS_AST_CON_DEFER = (
 )
 
 
+_COLECCIONES_AST = (list, tuple, set, frozenset)
+
+
+def _agregar_hijos_ast_con_defer(pendientes, nodo):
+    if isinstance(nodo, dict):
+        pendientes.extend(nodo.values())
+        return
+
+    if isinstance(nodo, _COLECCIONES_AST):
+        pendientes.extend(nodo)
+        return
+
+    for atributo in _ATRIBUTOS_AST_CON_DEFER:
+        if hasattr(nodo, atributo):
+            valor = getattr(nodo, atributo)
+            if valor is not None:
+                pendientes.append(valor)
+
+
 def _contiene_defer(nodo):
+    """Detecta ``NodoDefer`` en un cuerpo o en bloques de control anidados."""
     pendientes = [nodo]
     visitados = set()
 
@@ -26,7 +46,11 @@ def _contiene_defer(nodo):
         if actual is None:
             continue
 
-        if isinstance(actual, (list, tuple)):
+        if isinstance(actual, dict):
+            pendientes.extend(actual.values())
+            continue
+
+        if isinstance(actual, _COLECCIONES_AST):
             pendientes.extend(actual)
             continue
 
@@ -38,13 +62,18 @@ def _contiene_defer(nodo):
         if _es_nodo_defer(actual):
             return True
 
-        for atributo in _ATRIBUTOS_AST_CON_DEFER:
-            if hasattr(actual, atributo):
-                valor = getattr(actual, atributo)
-                if valor is not None:
-                    pendientes.append(valor)
+        _agregar_hijos_ast_con_defer(pendientes, actual)
 
     return False
+
+
+def _emitir_cuerpo_funcion(self, cuerpo):
+    if not cuerpo:
+        self.codigo += f"{self.obtener_indentacion()}pass\n"
+        return
+
+    for instruccion in cuerpo:
+        instruccion.aceptar(self)
 
 
 def visit_funcion(self, nodo):
@@ -64,11 +93,7 @@ def visit_funcion(self, nodo):
 
     usa_defer = _contiene_defer(nodo.cuerpo)
     if not usa_defer:
-        if not nodo.cuerpo:
-            self.codigo += f"{self.obtener_indentacion()}pass\n"
-        else:
-            for instruccion in nodo.cuerpo:
-                instruccion.aceptar(self)
+        _emitir_cuerpo_funcion(self, nodo.cuerpo)
         self.nivel_indentacion -= 1
         return
 
@@ -82,11 +107,7 @@ def visit_funcion(self, nodo):
         )
         self.nivel_indentacion += 1
         try:
-            if not nodo.cuerpo:
-                self.codigo += f"{self.obtener_indentacion()}pass\n"
-            else:
-                for instruccion in nodo.cuerpo:
-                    instruccion.aceptar(self)
+            _emitir_cuerpo_funcion(self, nodo.cuerpo)
         finally:
             self.nivel_indentacion -= 1
     finally:

--- a/tests/unit/test_to_python.py
+++ b/tests/unit/test_to_python.py
@@ -20,6 +20,7 @@ try:
         NodoWith,
         NodoDefer,
         NodoRetorno,
+        NodoTryCatch,
         NodoOperacionBinaria,
     )
     from pcobra.core.ast_nodes import NodoSwitch, NodoCase, NodoPattern, NodoGuard
@@ -43,6 +44,7 @@ except ImportError:  # pragma: no cover - compatibilidad
         NodoWith,
         NodoDefer,
         NodoRetorno,
+        NodoTryCatch,
         NodoOperacionBinaria,
     )
     from core.ast_nodes import (  # type: ignore
@@ -198,6 +200,45 @@ def test_transpilador_funcion_sin_defer_retorna_identificador_basico():
     assert transpilador.codigo == "def identidad(n):\n" + "    return n\n"
     assert "ExitStack" not in transpilador.codigo
     assert transpilador.usa_contextlib is False
+
+
+def test_transpilador_funcion_vacia_sin_defer_emite_pass_sin_exitstack():
+    func = NodoFuncion("vacia", [], [])
+    transpilador = TranspiladorPython()
+
+    func.aceptar(transpilador)
+
+    assert transpilador.codigo == "def vacia():\n" + "    pass\n"
+    assert "ExitStack" not in transpilador.codigo
+    assert transpilador.usa_contextlib is False
+
+
+def test_transpilador_funcion_con_defer_en_try_anidado_emite_exitstack():
+    func = NodoFuncion(
+        "cerrar",
+        [],
+        [
+            NodoTryCatch(
+                [NodoDefer(NodoLlamadaFuncion("limpiar", []), linea=1, columna=1)],
+                bloque_catch=[NodoRetorno(NodoValor(0))],
+            ),
+            NodoRetorno(NodoValor(1)),
+        ],
+    )
+    transpilador = TranspiladorPython()
+
+    func.aceptar(transpilador)
+
+    assert (
+        "    with contextlib.ExitStack() as __cobra_defer_stack_0:\n"
+        in transpilador.codigo
+    )
+    assert (
+        "            __cobra_defer_stack_0.callback(lambda: limpiar())\n"
+        in transpilador.codigo
+    )
+    assert transpilador.usa_contextlib is True
+    assert transpilador._defer_stack == []
 
 
 def test_transpilador_funcion_con_defer_retorno_conserva_exitstack_solo_con_defer():


### PR DESCRIPTION
### Motivation
- Evitar envolver en `contextlib.ExitStack` funciones que no contienen `defer` y emitir su cuerpo de forma directa para generar código Python más claro y eficiente.
- Detectar `defer` aún cuando está anidado en bloques como `try/catch`, `if/else`, `instrucciones`, etc., sin cambiar lexer/parser/nodos AST.

### Description
- Refactoriza el detector local para `defer`: se introducen `_COLECCIONES_AST` y `_agregar_hijos_ast_con_defer` y se mejora `_contiene_defer(nodo)` para recorrer listas, tuplas, sets, diccionarios y atributos de bloques anidados. (modificado: `src/pcobra/cobra/transpilers/transpiler/python_nodes/funcion.py`)
- Añade `_emitir_cuerpo_funcion(self, cuerpo)` para centralizar la emisión del cuerpo y asegurar `pass` cuando está vacío. (modificado: `src/pcobra/cobra/transpilers/transpiler/python_nodes/funcion.py`)
- Cambia `visit_funcion` para usar `_contiene_defer(nodo.cuerpo)` y solo cuando devuelve `True` emitir `with contextlib.ExitStack() as __cobra_defer_stack_X:` junto con el push/pop de `self._defer_stack` y `self.usa_contextlib = True`; en el caso contrario se emite el cuerpo directamente o `pass`. (modificado: `src/pcobra/cobra/transpilers/transpiler/python_nodes/funcion.py`)
- Añade casos de prueba de regresión enfocados en la nueva lógica: función vacía sin `defer` y `defer` dentro de un `try` anidado. (modificado: `tests/unit/test_to_python.py`)
- No se tocaron el lexer, parser, la gramática ni los nodos AST y se mantiene la asignación externa `TranspiladorPython.visit_funcion = _visit_funcion` en `to_python.py`.

### Testing
- Ejecuté `pytest tests/unit/test_to_python.py -q -k 'funcion or defer'` y obtuvo `12 passed, 16 deselected` (foco en visitantes de función y defer: OK).
- Ejecuté `python -m py_compile src/pcobra/cobra/transpilers/transpiler/python_nodes/funcion.py tests/unit/test_to_python.py` y no hubo errores de compilación.
- Ejecuté `git diff --check` para verificar formato y `git commit` para registrar los cambios; commit `650f865` creado.
- Nota: `pytest tests/unit/test_to_python.py -q` completo aún falla en 4 tests no relacionados con este cambio (problemas previos en `constant_folder`, Holobit y `switch`/guard), por lo que la modificación propuesta no agravó la suite relacionada con `defer`/funciones.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aee6f12548327b851914ac4e08143)