### PR TITLE
test: cover Python return expression transpilation

### DIFF
--- a/tests/test_transpilers.py
+++ b/tests/test_transpilers.py
@@ -17,7 +17,9 @@ from pcobra.core.ast_nodes import (
     NodoIdentificador,
     NodoGarantia,
     NodoRetorno,
+    NodoLlamadaFuncion,
 )
+from pcobra.core.lexer import TipoToken, Token
 import pcobra.cobra.core as cobra_core
 
 # Registrar nodos adicionales en el módulo ``cobra.core`` para evitar errores de importación
@@ -60,6 +62,49 @@ def test_transpilador_python_garantia() -> None:
     codigo = transpiler.generate_code([nodo])
     assert "if not ok:" in codigo
     assert "return 0" in codigo
+
+
+def test_transpilador_python_retorno_usa_expresion_y_obtener_valor() -> None:
+    class TranspiladorPythonRastreador(TranspiladorPython):
+        def __init__(self):
+            super().__init__()
+            self.tipos_visitados = []
+
+        def obtener_valor(self, nodo):
+            self.tipos_visitados.append(type(nodo).__name__)
+            return super().obtener_valor(nodo)
+
+    casos = [
+        (
+            NodoOperacionBinaria(
+                NodoIdentificador("n"),
+                Token(TipoToken.MULT, "*"),
+                NodoValor(2),
+            ),
+            "return n * 2",
+            "NodoOperacionBinaria",
+        ),
+        (NodoIdentificador("n"), "return n", "NodoIdentificador"),
+        (
+            NodoLlamadaFuncion("doble", [NodoValor(5)]),
+            "return doble(5)",
+            "NodoLlamadaFuncion",
+        ),
+        (
+            NodoLlamadaFuncion("identidad", [NodoValor(3)]),
+            "return identidad(3)",
+            "NodoLlamadaFuncion",
+        ),
+        (NodoValor(3), "return 3", "NodoValor"),
+    ]
+
+    for expresion, salida_esperada, tipo_esperado in casos:
+        transpiler = TranspiladorPythonRastreador()
+        transpiler.visit_retorno(NodoRetorno(expresion))
+
+        assert transpiler.codigo.strip() == salida_esperada
+        assert transpiler.tipos_visitados[0] == tipo_esperado
+        assert all(tipo != "NodoRetorno" for tipo in transpiler.tipos_visitados)
 
 
 def test_transpilador_js_garantia() -> None:


### PR DESCRIPTION
### Motivation
- Asegurar que `visit_retorno` solo utiliza `nodo.expresion` y que la generación del texto del valor se delega en `TranspiladorPython.obtener_valor` para expresiones comunes (operación binaria, identificador, llamada a función y literal). 

### Description
- Añadida una prueba en `tests/test_transpilers.py` que instrumenta `TranspiladorPython.obtener_valor` para registrar el primer tipo de nodo recibido al transpilarel `NodoRetorno` y comprueba la salida textual esperada.
- La prueba cubre los casos `n * 2`, `n`, `doble(5)`, `identidad(3)` y un literal, comprobando que entran por las ramas `NodoOperacionBinaria`, `NodoIdentificador`, `NodoLlamadaFuncion` y `NodoValor`, y que `NodoRetorno` no se pasa recursivamente a `obtener_valor`.
- No se realizaron cambios al código de producción en `src/pcobra/cobra/transpilers/transpiler/python_nodes/retorno.py` ni a `to_python.py`; la verificación se limita a la nueva prueba.

### Testing
- Ejecutado `pytest tests/test_transpilers.py::test_transpilador_python_retorno_usa_expresion_y_obtener_valor -q` y la nueva prueba pasó correctamente.
- Ejecutado `pytest tests/test_transpilers.py -q`; la suite completa mostró dos fallos preexistentes en pruebas de `garantia` para los transpilers JS/CPP que no están relacionados con este cambio, por lo que la regresión introducida es solo la prueba adicionada que pasa.
- Inspección del código confirmó que `visit_retorno` implementa `valor = self.obtener_valor(nodo.expresion)` y genera `return {valor}` sin visitar `NodoRetorno` internamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2af1ecb9e883279e1f5d8df3093f1b)