### PR TITLE
test: add Python transpilation function regression

### DIFF
--- a/tests/unit/test_to_python_funciones.py
+++ b/tests/unit/test_to_python_funciones.py
@@ -74,3 +74,25 @@ imprimir(resumen)
     assert "def resumen_numero(n):" in codigo_python
     assert "y = doble(5)" in codigo_python
     assert "print(y)" in codigo_python
+
+
+def test_transpila_funcion_doble_asignacion_e_imprimir_sin_exitstack_ni_recursion():
+    codigo_fuente = """func doble(n):
+    retorno n * 2
+fin
+var x = doble(5)
+imprimir(x)
+"""
+
+    try:
+        tokens = Lexer(codigo_fuente).analizar_token()
+        ast = Parser(tokens).parsear()
+        codigo_python = TranspiladorPython().generate_code(ast)
+    except RecursionError as exc:  # pragma: no cover - el fallo debe ser explícito
+        raise AssertionError("La transpilación no debe lanzar RecursionError") from exc
+
+    assert "def doble(n):" in codigo_python
+    assert "return n * 2" in codigo_python
+    assert "x = doble(5)" in codigo_python
+    assert "print(x)" in codigo_python
+    assert "contextlib.ExitStack" not in codigo_python


### PR DESCRIPTION
### Motivation
- Añadir una prueba que garantice la transpilación correcta de una función simple (`doble`) con asignación y `imprimir`, y que confirme que sin `defer` no se introduce `contextlib.ExitStack` ni se produce `RecursionError`.

### Description
- Se amplió `tests/unit/test_to_python_funciones.py` con `test_transpila_funcion_doble_asignacion_e_imprimir_sin_exitstack_ni_recursion`, que parsea el código Cobra de ejemplo, transpila con `TranspiladorPython` y verifica la presencia de `def doble(n):`, `return n * 2`, `x = doble(5)` y `print(x)`, además de la ausencia de `contextlib.ExitStack` y de `RecursionError`.

### Testing
- Se ejecutó `pytest tests/unit/test_to_python_funciones.py::test_transpila_funcion_doble_asignacion_e_imprimir_sin_exitstack_ni_recursion` (pasó), `pytest tests/unit/test_to_python_funciones.py` (pasó), y `pytest tests/unit/test_to_python*.py` (falla en tests preexistentes no relacionados: `test_transpilador_condicional`, `test_transpilador_mientras`, `test_transpilador_holobit`, `test_transpilador_switch_patron_guardia`, `test_transpilar_asignacion`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2afa0106f083278b081d03f86dcdba)