### PR TITLE
test: cubrir función vacia en transpilador Python

### DIFF
--- a/tests/unit/test_to_python_funciones.py
+++ b/tests/unit/test_to_python_funciones.py
@@ -96,3 +96,22 @@ imprimir(x)
     assert "x = doble(5)" in codigo_python
     assert "print(x)" in codigo_python
     assert "contextlib.ExitStack" not in codigo_python
+
+
+def test_transpila_funcion_vacia_e_imprimir_sin_exitstack_ni_recursion():
+    codigo_fuente = '''func vacia(n):
+fin
+imprimir("ok")
+'''
+
+    try:
+        tokens = Lexer(codigo_fuente).analizar_token()
+        ast = Parser(tokens).parsear()
+        codigo_python = TranspiladorPython().generate_code(ast)
+    except RecursionError as exc:  # pragma: no cover - el fallo debe ser explícito
+        raise AssertionError("La transpilación no debe lanzar RecursionError") from exc
+
+    assert "def vacia(n):" in codigo_python
+    assert "pass" in codigo_python
+    assert "print('ok')" in codigo_python
+    assert "contextlib.ExitStack" not in codigo_python


### PR DESCRIPTION
### Motivation
- Añadir una prueba que garantice que una función Cobra vacía seguida de `imprimir("ok")` se transpila correctamente a Python sin introducir `contextlib.ExitStack` ni provocar `RecursionError`.

### Description
- Se añade `test_transpila_funcion_vacia_e_imprimir_sin_exitstack_ni_recursion` en `tests/unit/test_to_python_funciones.py` que usa `Lexer`, `Parser` y `TranspiladorPython` sobre el código Cobra `func vacia(n):\nfin\nimprimir("ok")` y comprueba que el código generado contiene `def vacia(n):`, `pass` y `print('ok')` y que no contiene `contextlib.ExitStack`.

### Testing
- Se ejecutó `pytest tests/unit/test_to_python_funciones.py::test_transpila_funcion_vacia_e_imprimir_sin_exitstack_ni_recursion` (pasó) y `pytest tests/unit/test_to_python_funciones.py` (todos los tests del archivo pasaron).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2afe6de57c8327a16ca99d434252cb)