### PR TITLE
test: añadir test de transpilación Python para función identidad

### DIFF
--- a/tests/unit/test_to_python_funciones.py
+++ b/tests/unit/test_to_python_funciones.py
@@ -115,3 +115,29 @@ imprimir("ok")
     assert "pass" in codigo_python
     assert "print('ok')" in codigo_python
     assert "contextlib.ExitStack" not in codigo_python
+
+
+def test_transpila_funcion_identidad_e_imprimir_sin_exitstack_ni_recursion():
+    codigo_fuente = """func identidad(n):
+    retorno n
+fin
+imprimir(identidad(3))
+"""
+
+    try:
+        tokens = Lexer(codigo_fuente).analizar_token()
+        ast = Parser(tokens).parsear()
+        codigo_python = TranspiladorPython().generate_code(ast)
+    except RecursionError as exc:  # pragma: no cover - el fallo debe ser explícito
+        raise AssertionError(
+            "La transpilación no debe producir maximum recursion depth exceeded"
+        ) from exc
+    except Exception as exc:
+        assert "maximum recursion depth exceeded" not in str(exc)
+        raise
+
+    assert "def identidad(n):" in codigo_python
+    assert "return n" in codigo_python
+    assert "print(identidad(3))" in codigo_python
+    assert "contextlib.ExitStack" not in codigo_python
+    assert "maximum recursion depth exceeded" not in codigo_python


### PR DESCRIPTION
### Motivation
- Añadir cobertura que valide la transpilación de una función simple Cobra `identidad(n)` y la llamada `imprimir(identidad(3))`, asegurando que el transpiler genera la firma, `return` y `print` sin introducir `contextlib.ExitStack` ni errores de recursión.

### Description
- Se añadió un test `test_transpila_funcion_identidad_e_imprimir_sin_exitstack_ni_recursion` en `tests/unit/test_to_python_funciones.py` que usa `Lexer`, `Parser` y `TranspiladorPython` y realiza las aserciones solicitadas.

### Testing
- Ejecutados `pytest tests/unit/test_to_python_funciones.py::test_transpila_funcion_identidad_e_imprimir_sin_exitstack_ni_recursion -q` y `pytest tests/unit/test_to_python_funciones.py -q`, ambos devolvieron éxito (todos los tests pasan).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b011967d083279c78ac368bae0d90)