### PR TITLE
test: add Python transpiler GUI regression

### DIFF
--- a/tests/unit/test_to_python_funciones.py
+++ b/tests/unit/test_to_python_funciones.py
@@ -141,3 +141,35 @@ imprimir(identidad(3))
     assert "print(identidad(3))" in codigo_python
     assert "contextlib.ExitStack" not in codigo_python
     assert "maximum recursion depth exceeded" not in codigo_python
+
+
+def test_transpila_script_gui_reducido_sin_exitstack_ni_recursion():
+    codigo_fuente = '''func doble(n):
+    retorno n * 2
+fin
+
+func resumen_numero(n):
+    si n > 0: imprimir("positivo") sino: imprimir("no positivo") fin
+    imprimir(doble(n))
+fin
+
+var x = 7
+resumen_numero(x)
+'''
+
+    try:
+        tokens = Lexer(codigo_fuente).analizar_token()
+        ast = Parser(tokens).parsear()
+        codigo_python = TranspiladorPython().generate_code(ast)
+    except RecursionError as exc:  # pragma: no cover - el fallo debe ser explícito
+        raise AssertionError("La transpilación no debe lanzar RecursionError") from exc
+
+    assert "def doble(n):" in codigo_python
+    assert "return n * 2" in codigo_python
+    assert "def resumen_numero(n):" in codigo_python
+    assert "if n > 0:" in codigo_python
+    assert "else:" in codigo_python
+    assert "print(doble(n))" in codigo_python
+    assert "x = 7" in codigo_python
+    assert "resumen_numero(x)" in codigo_python
+    assert "contextlib.ExitStack" not in codigo_python


### PR DESCRIPTION
### Motivation
- Evitar regresiones en la conversión a Python de un script estilo GUI reducido que incluye definiciones de función, `retorno`, `si/sino` inline, llamadas anidadas, y asignaciones.
- Comprobar que cuando no hay `defer` no se introduce `contextlib.ExitStack` en el código generado.
- Asegurar que la transpilación no lanza `RecursionError` para este caso concreto.

### Description
- Añadido el test `test_transpila_script_gui_reducido_sin_exitstack_ni_recursion` en `tests/unit/test_to_python_funciones.py` que contiene el script reducido y realiza la transpilación con `Lexer`, `Parser` y `TranspiladorPython`.
- El test envuelve la transpilación en un `try/except` que convierte cualquier `RecursionError` en un fallo explícito y comprueba la presencia de `def doble(n):`, `return n * 2`, `def resumen_numero(n):`, `if n > 0:`, `else:`, `print(doble(n))`, `x = 7` y `resumen_numero(x)` en la salida.
- El test también afirma que `contextlib.ExitStack` no aparece en el código generado cuando no hay `defer`.

### Testing
- Ejecutado `pytest tests/unit/test_to_python_funciones.py -q` y la suite correspondiente pasó exitosamente; resultado: `6 passed` con `1` advertencia de deprecación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b9d39b1c48327a48a6ff6da5a18df)