### PR TITLE
test: cubrir generación Python para `defer` (contextlib/ExitStack)

### DIFF
--- a/tests/unit/test_to_python.py
+++ b/tests/unit/test_to_python.py
@@ -241,6 +241,32 @@ def test_transpilador_funcion_con_defer_en_try_anidado_emite_exitstack():
     assert transpilador._defer_stack == []
 
 
+def test_transpilador_python_parser_funcion_con_defer_importa_contextlib_y_exitstack():
+    codigo_fuente = """func cerrar():
+    defer limpiar()
+    retorno 1
+fin"""
+    ast = Parser(Lexer(codigo_fuente).analizar_token()).parsear()
+
+    codigo = TranspiladorPython().generate_code(ast)
+
+    assert "import contextlib\n" in codigo
+    assert "with contextlib.ExitStack() as __cobra_defer_stack_" in codigo
+    assert ".callback(lambda:" in codigo
+
+
+def test_transpilador_python_parser_funcion_sin_defer_no_importa_contextlib():
+    codigo_fuente = """func identidad(n):
+    retorno n
+fin"""
+    ast = Parser(Lexer(codigo_fuente).analizar_token()).parsear()
+
+    codigo = TranspiladorPython().generate_code(ast)
+
+    assert "import contextlib" not in codigo
+    assert "contextlib.ExitStack" not in codigo
+
+
 def test_transpilador_funcion_con_defer_retorno_conserva_exitstack_solo_con_defer():
     con_defer = NodoFuncion(
         "cerrar",


### PR DESCRIPTION
### Motivation
- Añadir cobertura que verifique que al transpilar desde código Cobra las funciones con `defer` generan `import contextlib`, `with contextlib.ExitStack() as __cobra_defer_stack_` y llamadas `.callback(lambda:`, y que funciones sin `defer` no introducen `contextlib`.

### Description
- Añadí dos tests en `tests/unit/test_to_python.py`: uno que parsea fuente Cobra con `defer` y aserta la presencia de `import contextlib\n`, `with contextlib.ExitStack() as __cobra_defer_stack_` y `.callback(lambda:`, y otro que parsea una función sin `defer` y aserta que `contextlib` y `ExitStack` no aparecen; no se modifica la sintaxis Cobra ni ningún contrato público.

### Testing
- Ejecuté los tests específicos con `pytest tests/unit/test_to_python.py::test_transpilador_python_parser_funcion_con_defer_importa_contextlib_y_exitstack tests/unit/test_to_python.py::test_transpilador_python_parser_funcion_sin_defer_no_importa_contextlib -q` y ambos pasaron, y ejecuté la suite filtrada `-k 'defer or contextlib'` que también pasó; ejecutar el módulo completo `tests/unit/test_to_python.py` mostró fallos preexistentes no relacionados con este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c055503cc8327891c7673fba3416b)