### PR TITLE
test: add GUI reduced Python transpilation regression

### DIFF
--- a/tests/unit/test_to_python_funciones.py
+++ b/tests/unit/test_to_python_funciones.py
@@ -173,3 +173,40 @@ resumen_numero(x)
     assert "x = 7" in codigo_python
     assert "resumen_numero(x)" in codigo_python
     assert "contextlib.ExitStack" not in codigo_python
+
+
+def test_regresion_transpila_gui_reducida_con_funciones_if_inline_sin_exitstack():
+    codigo_fuente = '''func doble(n):
+    retorno n * 2
+fin
+
+func resumen_numero(n):
+    si n > 0: imprimir("positivo") sino: imprimir("no positivo") fin
+    imprimir(doble(n))
+fin
+
+var x = 7
+resumen_numero(x)
+'''
+
+    try:
+        tokens = Lexer(codigo_fuente).analizar_token()
+        ast = Parser(tokens).parsear()
+        codigo_python = TranspiladorPython().generate_code(ast)
+    except RecursionError as exc:  # pragma: no cover - el fallo debe ser explícito
+        raise AssertionError("La transpilación no debe lanzar RecursionError") from exc
+
+    fragmentos_esperados = (
+        "def doble(n):",
+        "return n * 2",
+        "def resumen_numero(n):",
+        "if n > 0:",
+        "else:",
+        "print(doble(n))",
+        "x = 7",
+        "resumen_numero(x)",
+    )
+
+    for fragmento in fragmentos_esperados:
+        assert fragmento in codigo_python
+    assert "contextlib.ExitStack" not in codigo_python


### PR DESCRIPTION
### Motivation

- Prevent a regression in the Python transpiler when handling a reduced GUI-style script with inline `si/sino`, function definitions, assignment and a final function call.

### Description

- Added `test_regresion_transpila_gui_reducida_con_funciones_if_inline_sin_exitstack` to `tests/unit/test_to_python_funciones.py` which transpiles a small GUI script using `TranspiladorPython` and examines the generated Python.
- The test asserts the presence of the expected Python fragments (`def doble(n):`, `return n * 2`, `def resumen_numero(n):`, `if n > 0:`, `else:`, `print(doble(n))`, `x = 7`, `resumen_numero(x)`).
- The test also asserts that `contextlib.ExitStack` is not emitted when there is no `defer`, and converts any `RecursionError` into an explicit test failure.

### Testing

- Ran `pytest tests/unit/test_to_python_funciones.py -q` and the suite passed with `7 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c0ecf18a08327915f30b12a5bfb4c)