### PR TITLE
Verificar que la GUI use el transpilador Python registrado

### DIFF
--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -128,8 +128,8 @@ def test_main_handlers_smoke(monkeypatch):
 
     ast_btn.on_click(None)
     assert salida.value == "[Nodo]"
-    assert ejecutar_mock.call_count == 1
-    assert transpilar_mock.call_count == 1
+    ejecutar_mock.assert_called_once_with("imprimir('x')")
+    transpilar_mock.assert_called_once_with("imprimir('x')", "python")
     assert page.update.call_count == 5
 
 

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -29,6 +29,50 @@ def test_ejecutar_transpilar_tokens_y_ast() -> None:
     assert "NodoImprimir" in runtime.mostrar_ast(codigo)
 
 
+def test_transpilar_codigo_usa_transpilador_python_registrado(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llamadas = {"transpiler_inits": 0, "ast": None}
+
+    class FakeLexer:
+        def __init__(self, codigo: str):
+            self.codigo = codigo
+
+        def tokenizar(self):
+            assert self.codigo == "imprimir('Hola')"
+            return ["TOKEN"]
+
+    class FakeParser:
+        def __init__(self, tokens):
+            assert tokens == ["TOKEN"]
+
+        def parsear(self):
+            return ["AST"]
+
+    class TranspiladorPythonRegistrado:
+        def __init__(self):
+            llamadas["transpiler_inits"] += 1
+
+        def generate_code(self, ast):
+            llamadas["ast"] = ast
+            return "codigo python registrado"
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {
+            "Lexer": FakeLexer,
+            "Parser": FakeParser,
+            "TRANSPILERS": {"python": TranspiladorPythonRegistrado},
+        },
+    )
+
+    assert (
+        runtime.transpilar_codigo("imprimir('Hola')", "python")
+        == "codigo python registrado"
+    )
+    assert llamadas == {"transpiler_inits": 1, "ast": ["AST"]}
+
 def test_formatear_error_lexico_y_sintaxis() -> None:
     class FakeLexerError(Exception):
         linea = 2


### PR DESCRIPTION
### Motivation
- Asegurar que con la opción "Transpilar" activada y target `python`, la GUI delega al transpilador registrado en el runtime y no intenta ninguna lógica ad-hoc en la capa de presentación.
- Tener una prueba automatizada que confirme la instanciación y llamada al `TranspiladorPython` registrado desde `TRANSPILERS`.
- Aumentar la precisión del smoke test del entorno IDLE para verificar que el handler pasa el código y el target correctos a la función runtime.

### Description
- Añadida la prueba `test_transpilar_codigo_usa_transpilador_python_registrado` en `tests/unit/test_gui_runtime.py` que simula `Lexer`/`Parser` y verifica que `runtime.transpilar_codigo(..., "python")` instancia y llama al transpiler registrado.
- Reforzado `tests/unit/test_gui_idle.py::test_main_handlers_smoke` para asertar que, al activar `Transpilar` y seleccionar `python`, se llama a `runtime.transpilar_codigo` con los argumentos esperados.
- No se modificó código de la GUI ni se introdujo lógica específica para funciones Cobra; los cambios son únicamente en pruebas y preservan la interfaz pública del runtime.

### Testing
- Ejecuté `pytest tests/unit/test_gui_runtime.py tests/unit/test_gui_idle.py tests/test_transpilers.py::test_transpilador_python_retorno_usa_expresion_y_obtener_valor` y la suite objetivo pasó (`15 passed`).
- En una ejecución anterior que incluía `tests/unit/test_to_python3.py::test_transpilar_funcion` apareció un fallo en ese test heredado que espera una salida concreta de `NodoValor("a + b")`, ese fallo es independiente de la verificación GUI y no fue cambiado por este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c18547fe88327bf9834d41ba95ec3)