### PR TITLE
Añadir resolución segura de módulos Cobra de proyecto

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -1,6 +1,7 @@
 import importlib
 import importlib.util
 import logging
+import os
 import re
 from pathlib import Path
 import sys
@@ -20,6 +21,11 @@ from pcobra.cobra.core.usar_symbol_policy import (
 
 # Regex estricta para mantener la sintaxis `usar "modulo"` acotada a identificadores simples.
 _VALID_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+# Segmentos seguros para módulos de proyecto: ruta lógica punteada, no ruta del sistema.
+_VALID_PROJECT_MODULE_SEGMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_PROJECT_MODULE_FORBIDDEN_CHARS = frozenset('/\\@$%*?"\'<>|;`!()[]{}=+,')
 
 # Patrones que deben bloquearse explícitamente para evitar imports de backend o rutas internas.
 _INTERNAL_HINTS = (
@@ -125,6 +131,91 @@ def validar_nombre_modulo_usar(nombre: str, *, require_allowlist: bool = True) -
         )
 
     return nombre
+
+
+
+def validar_nombre_modulo_cobra_proyecto(nombre: str) -> tuple[str, ...]:
+    """Valida una ruta lógica punteada de módulo Cobra de proyecto.
+
+    Esta validación es deliberadamente independiente de
+    :func:`validar_nombre_modulo_usar` para no relajar el contrato público de
+    módulos oficiales/corelibs.
+    """
+
+    if not isinstance(nombre, str):
+        raise ValueError("Nombre de módulo de proyecto inválido: se esperaba string.")
+
+    nombre_raw = nombre.strip()
+    if not nombre_raw:
+        raise ValueError("Nombre de módulo de proyecto vacío.")
+
+    if any(sep in nombre_raw for sep in ("/", "\\")):
+        raise ValueError(
+            f"Nombre de módulo de proyecto inválido: '{nombre_raw}' no debe contener separadores de ruta."
+        )
+
+    segmentos = nombre_raw.split(".")
+    for segmento in segmentos:
+        if segmento in {"", ".", ".."}:
+            raise ValueError(
+                f"Nombre de módulo de proyecto inválido: '{nombre_raw}' contiene segmentos vacíos/traversal."
+            )
+        if any(caracter in segmento for caracter in _PROJECT_MODULE_FORBIDDEN_CHARS):
+            raise ValueError(
+                f"Nombre de módulo de proyecto inválido: '{nombre_raw}' contiene caracteres no seguros."
+            )
+        if ":" in segmento:
+            raise ValueError(
+                f"Nombre de módulo de proyecto inválido: '{nombre_raw}' parece una unidad Windows."
+            )
+        if not _VALID_PROJECT_MODULE_SEGMENT_RE.fullmatch(segmento):
+            raise ValueError(
+                "Nombre de módulo de proyecto inválido: usa segmentos tipo identificador "
+                "separados por puntos (ej. 'utilidades.fechas')."
+            )
+
+    return tuple(segmentos)
+
+
+def _verificar_path_dentro_de_root(ruta: Path, root: Path) -> None:
+    """Verifica con rutas canónicas que ``ruta`` queda dentro de ``root``."""
+
+    try:
+        common = os.path.commonpath((str(root), str(ruta)))
+    except ValueError as exc:
+        raise ValueError("Ruta de módulo de proyecto fuera de la raíz autorizada.") from exc
+
+    if common != str(root):
+        raise ValueError("Ruta de módulo de proyecto fuera de la raíz autorizada.")
+
+
+def resolver_modulo_cobra_proyecto(
+    nombre: str,
+    *,
+    project_root: Path,
+    current_file: Path | None = None,
+) -> Path:
+    """Resuelve un módulo Cobra de proyecto a un archivo ``.co`` seguro.
+
+    ``nombre`` es una ruta lógica punteada (por ejemplo
+    ``utilidades.fechas``), que se transforma en
+    ``project_root / "utilidades" / "fechas.co"``. La función sólo devuelve
+    una ruta canónica; no carga ni importa el módulo para evitar introducir un
+    segundo sistema de imports.
+    """
+
+    segmentos = validar_nombre_modulo_cobra_proyecto(nombre)
+    root_resuelto = Path(project_root).resolve(strict=False)
+
+    if current_file is not None:
+        current_resuelto = Path(current_file).resolve(strict=False)
+        _verificar_path_dentro_de_root(current_resuelto, root_resuelto)
+
+    ruta_logica = root_resuelto.joinpath(*segmentos[:-1], f"{segmentos[-1]}.co")
+    ruta_resuelta = ruta_logica.resolve(strict=False)
+    _verificar_path_dentro_de_root(ruta_resuelta, root_resuelto)
+
+    return ruta_resuelta
 
 
 def _cargar_modulo_local_desde_directorio(nombre: str, directorio: Path):

--- a/src/pcobra/core/usar_loader.py
+++ b/src/pcobra/core/usar_loader.py
@@ -31,6 +31,12 @@ def obtener_modulo_cobra_oficial(*args, **kwargs):
     return _impl.obtener_modulo_cobra_oficial(*args, **kwargs)
 
 
+def resolver_modulo_cobra_proyecto(*args, **kwargs):
+    """Delega en la implementación canónica de `pcobra.cobra.usar_loader`."""
+
+    return _impl.resolver_modulo_cobra_proyecto(*args, **kwargs)
+
+
 def validar_nombre_modulo_usar(*args, **kwargs):
     """Delega en la implementación canónica de `pcobra.cobra.usar_loader`."""
 

--- a/tests/unit/test_core_usar_loader_delegation.py
+++ b/tests/unit/test_core_usar_loader_delegation.py
@@ -12,3 +12,23 @@ def test_core_usar_loader_delega_en_cobra_usar_loader(monkeypatch):
     monkeypatch.setattr(cobra_usar_loader, "obtener_modulo", _fake_obtener_modulo)
 
     assert core_usar_loader.obtener_modulo("numero") is token
+
+
+def test_core_usar_loader_expone_resolver_modulo_cobra_proyecto(monkeypatch, tmp_path):
+    token = tmp_path / "utilidades" / "fechas.co"
+
+    def _fake_resolver(nombre, *, project_root, current_file=None):
+        assert nombre == "utilidades.fechas"
+        assert project_root == tmp_path
+        assert current_file is None
+        return token
+
+    monkeypatch.setattr(cobra_usar_loader, "resolver_modulo_cobra_proyecto", _fake_resolver)
+
+    assert (
+        core_usar_loader.resolver_modulo_cobra_proyecto(
+            "utilidades.fechas",
+            project_root=tmp_path,
+        )
+        == token
+    )

--- a/tests/unit/test_usar_loader_validation.py
+++ b/tests/unit/test_usar_loader_validation.py
@@ -63,3 +63,63 @@ def test_modulo_no_publico_error_controlado_sin_traceback():
     mensaje = str(excinfo.value)
     assert "fuera del catálogo público" in mensaje or "módulo externo no permitido" in mensaje
     assert "Traceback" not in mensaje
+
+
+def test_resolver_modulo_cobra_proyecto_convierte_nombre_punteado_en_co(tmp_path):
+    from pcobra.cobra.usar_loader import resolver_modulo_cobra_proyecto
+
+    ruta = resolver_modulo_cobra_proyecto("utilidades.fechas", project_root=tmp_path)
+
+    assert ruta == (tmp_path / "utilidades" / "fechas.co").resolve(strict=False)
+
+
+@pytest.mark.parametrize(
+    "nombre",
+    [
+        "",
+        "utilidades..fechas",
+        ".utilidades",
+        "utilidades.",
+        "../secreto",
+        "utilidades/fechas",
+        r"utilidades\\fechas",
+        "C:secreto",
+        "utilidades.fecha$",
+        "utilidades.-fecha",
+    ],
+)
+def test_resolver_modulo_cobra_proyecto_rechaza_nombres_inseguros(tmp_path, nombre):
+    from pcobra.cobra.usar_loader import resolver_modulo_cobra_proyecto
+
+    with pytest.raises(ValueError):
+        resolver_modulo_cobra_proyecto(nombre, project_root=tmp_path)
+
+
+def test_resolver_modulo_cobra_proyecto_rechaza_traversal_por_symlink(tmp_path):
+    from pcobra.cobra.usar_loader import resolver_modulo_cobra_proyecto
+
+    destino_externo = tmp_path.parent / f"{tmp_path.name}_externo"
+    destino_externo.mkdir()
+    (tmp_path / "utilidades").symlink_to(destino_externo, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="fuera de la raíz autorizada"):
+        resolver_modulo_cobra_proyecto("utilidades.fechas", project_root=tmp_path)
+
+
+def test_resolver_modulo_cobra_proyecto_valida_current_file_dentro_de_root(tmp_path):
+    from pcobra.cobra.usar_loader import resolver_modulo_cobra_proyecto
+
+    externo = tmp_path.parent / f"{tmp_path.name}_archivo_externo.co"
+    externo.write_text("", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="fuera de la raíz autorizada"):
+        resolver_modulo_cobra_proyecto(
+            "utilidades.fechas",
+            project_root=tmp_path,
+            current_file=externo,
+        )
+
+
+def test_validacion_oficial_sigue_rechazando_nombres_punteados():
+    with pytest.raises(ValueError):
+        validar_nombre_modulo_usar("utilidades.fechas", require_allowlist=False)


### PR DESCRIPTION
### Motivation
- Permitir resolver módulos de proyecto nombrados con rutas lógicas punteadas (ej. `utilidades.fechas`) sin introducir un segundo sistema de imports ni relajar la política de módulos oficiales. 
- Asegurar que la resolución de módulos de proyecto sea segura frente a traversal, symlinks fuera de la raíz, separadores de ruta y caracteres peligrosos. 

### Description
- Añadida validación independiente `validar_nombre_modulo_cobra_proyecto(nombre: str) -> tuple[str, ...]` que acepta segmentos punteados y rechaza segmentos vacíos, `.`/`..`, separadores `/` y `\`, unidades Windows y caracteres no seguros; nueva lógica en `src/pcobra/cobra/usar_loader.py`. 
- Implementada `resolver_modulo_cobra_proyecto(nombre, *, project_root: Path, current_file: Path | None = None) -> Path` que convierte `utilidades.fechas` en `project_root / "utilidades" / "fechas.co"`, canonicaliza con `Path.resolve(strict=False)` y verifica que la ruta y `current_file` queden dentro de `project_root` usando `os.path.commonpath`; la función sólo devuelve la ruta y no realiza import dinámico. 
- Se añadieron constantes de validación internas (`_VALID_PROJECT_MODULE_SEGMENT_RE`, `_PROJECT_MODULE_FORBIDDEN_CHARS`) y helper `_verificar_path_dentro_de_root` en `src/pcobra/cobra/usar_loader.py`. 
- No se modificó `validar_nombre_modulo_usar` ni la resolución de módulos oficiales (`obtener_modulo_cobra_oficial`) para preservar el contrato público de corelibs. 
- Expuesta la nueva función desde `src/pcobra/core/usar_loader.py` mediante un wrapper delegado a la implementación canónica. 
- Añadidas pruebas unitarias que cubren la conversión `utilidades.fechas -> utilidades/fechas.co`, rechazo de nombres inseguros, symlink que apunta fuera de la raíz, validación de `current_file` y delegación del wrapper en `tests/unit/test_usar_loader_validation.py` y `tests/unit/test_core_usar_loader_delegation.py`. 

### Testing
- Ejecutado `pytest -q tests/unit/test_usar_loader_validation.py tests/unit/test_core_usar_loader_delegation.py` y los tests enfocados pasaron correctamente. 
- Ejecutado `ruff check` sobre los módulos modificados y no se reportaron errores. 
- Intenté ejecutar una ejecución más amplia que incluía `tests/unit/test_usar.py` y la ejecución falló durante la fase de colección con un `ImportError: attempted relative import beyond top-level package` que parece preexistente y no está causado por los cambios introducidos; por tanto la validación completa de la suite integrada no se pudo completar en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c58ffd17c8327a3506508de5f4124)