### PR TITLE
Agregar descubrimiento de raíz de proyecto y resolución de módulos `usar` de proyecto

### DIFF
--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -41,6 +41,7 @@ class PipelineInput:
     safe_mode: bool
     extra_validators: Any = None
     interpretador: Any | None = None
+    main_file: Any | None = None
 
 
 @dataclass(frozen=True)
@@ -67,14 +68,16 @@ def construir_script_sandbox_canonico(
     safe_mode: bool | None = None,
     extra_validators: Any = None,
     imprimir_resultado: bool = False,
+    main_file: Any | None = None,
 ) -> str:
     """Genera un script sandbox con imports canónicos del runtime Cobra."""
 
     extra_repr = repr(extra_validators if extra_validators is not None else None)
+    main_file_fragment = "" if main_file is None else f", main_file={str(main_file)!r}"
     kwargs_fragment = (
         ""
         if safe_mode is None
-        else f", safe_mode={safe_mode!r}, extra_validators={extra_repr}"
+        else f", safe_mode={safe_mode!r}, extra_validators={extra_repr}{main_file_fragment}"
     )
     script = (
         "from pcobra.cobra.cli.execution_pipeline import prevalidar_y_parsear_codigo\n"
@@ -225,6 +228,7 @@ def construir_interprete_seguro_canonico(
     interpretador_cls: Any,
     safe_mode: bool,
     extra_validators: Any,
+    main_file: Any | None = None,
 ) -> Any:
     """Factory canónico de runtime para intérprete CLI.
 
@@ -237,6 +241,7 @@ def construir_interprete_seguro_canonico(
     interpretador = interpretador_cls(
         safe_mode=safe_mode,
         extra_validators=extra_validators,
+        main_file=main_file,
     )
     asegurar_estado_runtime = getattr(interpretador, "asegurar_estado_runtime_inicial", None)
     if callable(asegurar_estado_runtime):
@@ -288,6 +293,7 @@ def preparar_interpretador(
     interpretador_cls: Any,
     safe_mode: bool,
     extra_validators: Any,
+    main_file: Any | None = None,
 ) -> InterpreterSetup:
     """Centraliza normalización de validadores, flags de seguridad e intérprete."""
     opciones = normalizar_opciones_pipeline(
@@ -299,6 +305,7 @@ def preparar_interpretador(
         interpretador_cls=interpretador_cls,
         safe_mode=opciones.safe_mode,
         extra_validators=opciones.validadores_extra,
+        main_file=main_file,
     )
     return InterpreterSetup(
         interpretador_cls=interpretador_cls,
@@ -379,12 +386,16 @@ def ejecutar_pipeline_explicito(
         interpretador_cls=pipeline_input.interpretador_cls,
         safe_mode=pipeline_input.safe_mode,
         extra_validators=pipeline_input.extra_validators,
+        main_file=pipeline_input.main_file,
     )
     interpretador = (
         pipeline_input.interpretador
         if pipeline_input.interpretador is not None
         else setup.interpretador
     )
+    configurar_archivo = getattr(interpretador, "configurar_archivo_principal", None)
+    if pipeline_input.main_file is not None and callable(configurar_archivo):
+        configurar_archivo(pipeline_input.main_file)
     resultado = ejecutar_codigo_canonico(
         pipeline_input.codigo,
         interpretador=interpretador,

--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -118,10 +118,18 @@ class RunService:
 
         def ejecutar() -> int:
             if sandbox:
-                return self.ejecutar_en_sandbox(codigo, seguro, extra_validators, allow_insecure_fallback=allow_insecure_fallback)
+                return self.ejecutar_en_sandbox(
+                    codigo,
+                    seguro,
+                    extra_validators,
+                    main_file=archivo_resuelto,
+                    allow_insecure_fallback=allow_insecure_fallback,
+                )
             if contenedor:
                 return self.ejecutar_en_contenedor(codigo, contenedor)
-            return self.ejecutar_normal(codigo, seguro, extra_validators)
+            return self.ejecutar_normal(
+                codigo, seguro, extra_validators, main_file=archivo_resuelto
+            )
 
         try:
             return self.limitar_recursos(ejecutar)
@@ -154,6 +162,7 @@ class RunService:
         seguro: bool,
         extra_validators: Any,
         *,
+        main_file: Path | None = None,
         allow_insecure_fallback: bool = False,
     ) -> int:
         try:
@@ -167,6 +176,7 @@ class RunService:
                     interpretador_cls=interpretador_cls,
                     safe_mode=seguro,
                     extra_validators=extra_validators,
+                    main_file=main_file,
                 ),
                 analizar_codigo_fn=lambda _codigo: [],
             )
@@ -182,6 +192,7 @@ class RunService:
             codigo,
             safe_mode=setup.safe_mode,
             extra_validators=setup.validadores_extra,
+            main_file=main_file,
         )
 
         try:
@@ -219,7 +230,14 @@ class RunService:
             mostrar_error(f"Error ejecutando en contenedor Docker: {e}", registrar_log=False)
             return 1
 
-    def ejecutar_normal(self, codigo: str, seguro: bool, extra_validators: Any) -> int:
+    def ejecutar_normal(
+        self,
+        codigo: str,
+        seguro: bool,
+        extra_validators: Any,
+        *,
+        main_file: Path | None = None,
+    ) -> int:
         try:
             ejecutar_pipeline_explicito(
                 PipelineInput(
@@ -227,6 +245,7 @@ class RunService:
                     interpretador_cls=resolver_interpretador_cls(module_name=__name__, default_cls=InterpretadorCobra),
                     safe_mode=seguro,
                     extra_validators=extra_validators,
+                    main_file=main_file,
                 ),
                 construir_cadena_fn=construir_cadena,
                 analizar_codigo_fn=prevalidar_y_parsear_codigo,

--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -218,6 +218,43 @@ def resolver_modulo_cobra_proyecto(
     return ruta_resuelta
 
 
+def _ascender_hasta_cobra_toml(candidato: Path | None) -> Path | None:
+    """Busca ``cobra.toml`` ascendiendo desde un archivo o directorio."""
+
+    if candidato is None:
+        return None
+    ruta = Path(candidato).expanduser().resolve(strict=False)
+    if ruta.suffix or (ruta.exists() and ruta.is_file()):
+        ruta = ruta.parent
+    for directorio in (ruta, *ruta.parents):
+        if (directorio / "cobra.toml").is_file():
+            return directorio.resolve(strict=False)
+    return None
+
+
+def descubrir_raiz_proyecto(start: Path | None, main_file: Path | None = None) -> Path:
+    """Descubre y canonicaliza la raíz efectiva de un proyecto Cobra.
+
+    Prioridad:
+    1. Directorio que contiene un ``cobra.toml`` encontrado ascendiendo desde
+       ``start`` o desde ``main_file``.
+    2. Directorio canonicalizado de ``main_file`` cuando no hay ``cobra.toml``.
+    3. ``Path.cwd().resolve()`` para preservar el comportamiento legacy.
+    """
+
+    for candidato in (start, main_file):
+        raiz_configurada = _ascender_hasta_cobra_toml(candidato)
+        if raiz_configurada is not None:
+            return raiz_configurada
+
+    if main_file is not None:
+        principal = Path(main_file).expanduser().resolve(strict=False)
+        directorio = principal.parent if principal.suffix or principal.is_file() else principal
+        return directorio.resolve(strict=False)
+
+    return Path.cwd().resolve()
+
+
 def _cargar_modulo_local_desde_directorio(nombre: str, directorio: Path):
     """Carga un módulo Python desde un directorio local dado."""
 

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import hashlib
+from pathlib import Path
 from typing import Mapping, Optional
 
 from .lexer import (
@@ -94,7 +95,12 @@ from .usar_symbol_policy import (
     validate_usar_symbol_metadata,
 )
 from .environment import Environment
-from pcobra.cobra.usar_loader import obtener_modulo, sanitizar_exports_publicos
+from pcobra.cobra.usar_loader import (
+    descubrir_raiz_proyecto,
+    obtener_modulo,
+    resolver_modulo_cobra_proyecto,
+    sanitizar_exports_publicos,
+)
 
 MODULES_PATH = _DEFAULT_MODULES_PATH
 REPL_USAR_EXTERNAL_MODULE_ERROR = (
@@ -481,7 +487,12 @@ class InterpretadorCobra:
         )
         return namespace.get("VALIDADORES_EXTRA", [])
 
-    def __init__(self, safe_mode: bool = True, extra_validators=None):
+    def __init__(
+        self,
+        safe_mode: bool = True,
+        extra_validators=None,
+        main_file: Path | str | None = None,
+    ):
         """Crea un nuevo interpretador.
 
         Parameters
@@ -494,6 +505,9 @@ class InterpretadorCobra:
         extra_validators: list | str, optional
             Lista de instancias adicionales o ruta a un módulo que defina
             ``VALIDADORES_EXTRA``.
+        main_file: Path | str, optional
+            Archivo principal conocido por CLI/runtime para resolver módulos de
+            proyecto con ``usar`` desde la raíz canonicalizada.
         """
         extra = extra_validators
         if isinstance(extra, str):
@@ -527,6 +541,15 @@ class InterpretadorCobra:
         # Metadatos de símbolos inyectados por `usar` para soportar reimport idempotente.
         # nombre_simbolo -> {"module": str, "exported_name": str, "callable_id": int}
         self._usar_symbol_metadata: dict[str, dict[str, object]] = {}
+        self._main_file: Path | None = (
+            Path(main_file).expanduser().resolve(strict=False)
+            if main_file is not None
+            else None
+        )
+        self._project_root: Path = descubrir_raiz_proyecto(
+            self._main_file, self._main_file
+        )
+        self._current_module_stack: list[Path] = []
         # Debe ejecutarse siempre después de crear _validador y _usar_symbol_metadata.
         self.asegurar_estado_runtime_inicial()
 
@@ -1477,6 +1500,21 @@ class InterpretadorCobra:
 
         return build_internal_ir(ast)
 
+    def configurar_archivo_principal(self, main_file: Path | str | None) -> None:
+        """Configura el archivo principal y recalcula la raíz canonicalizada."""
+
+        self._main_file = (
+            Path(main_file).expanduser().resolve(strict=False)
+            if main_file is not None
+            else None
+        )
+        start = (
+            self._current_module_stack[-1]
+            if self._current_module_stack
+            else self._main_file
+        )
+        self._project_root = descubrir_raiz_proyecto(start, self._main_file)
+
     def ejecutar_nodo(self, nodo):
         self._trace_debug(f"[EXEC] node_type={type(nodo).__name__} node_id={id(nodo)}")
         # Contrato de control de flujo:
@@ -2229,6 +2267,42 @@ class InterpretadorCobra:
             finally:
                 self._set_mode(modo_prev)
 
+    def _ejecutar_usar_modulo_proyecto(self, nombre_modulo: str) -> None:
+        """Ejecuta un módulo Cobra de proyecto resuelto desde la raíz canonicalizada."""
+
+        current_file = (
+            self._current_module_stack[-1]
+            if self._current_module_stack
+            else self._main_file
+        )
+        self._project_root = descubrir_raiz_proyecto(
+            current_file or self._project_root, self._main_file
+        )
+        ruta_modulo = resolver_modulo_cobra_proyecto(
+            nombre_modulo,
+            project_root=self._project_root,
+            current_file=current_file,
+        )
+        if ruta_modulo in self._current_module_stack:
+            raise ImportError(f"Importación circular detectada en usar: {nombre_modulo}")
+        try:
+            ast = cargar_ast_modulo(
+                str(ruta_modulo),
+                modules_path=str(self._project_root),
+                whitelist={self._project_root},
+            )
+        except PermissionError as exc:
+            raise PrimitivaPeligrosaError(str(exc)) from exc
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(f"Módulo no encontrado: {nombre_modulo}") from exc
+
+        self._current_module_stack.append(ruta_modulo)
+        try:
+            for subnodo in ast:
+                self.ejecutar_nodo(subnodo)
+        finally:
+            self._current_module_stack.pop()
+
     def ejecutar_usar(self, nodo):
         """Importa callables públicos al contexto actual usando la política de ``usar``.
 
@@ -2289,6 +2363,8 @@ class InterpretadorCobra:
 
         try:
             nombre_modulo = nodo.modulo
+            if isinstance(nombre_modulo, str) and "." in nombre_modulo:
+                return self._ejecutar_usar_modulo_proyecto(nombre_modulo)
             modulo, es_repl_estricto, es_modulo_oficial_cobra = _resolver_carga_modulo_usar(
                 nombre_modulo
             )

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from pcobra.cobra.usar_loader import (
+    descubrir_raiz_proyecto,
+    resolver_modulo_cobra_proyecto,
+)
+from pcobra.core.interpreter import InterpretadorCobra
+
+
+def test_descubrir_raiz_proyecto_prefiere_cobra_toml_desde_archivo_principal(tmp_path):
+    proyecto = tmp_path / "app"
+    subdir = proyecto / "src"
+    subdir.mkdir(parents=True)
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = subdir / "main.co"
+    principal.write_text("", encoding="utf-8")
+
+    assert descubrir_raiz_proyecto(subdir, principal) == proyecto.resolve()
+
+
+def test_descubrir_raiz_proyecto_usa_directorio_principal_sin_cobra_toml(tmp_path):
+    principal = tmp_path / "programa.co"
+    principal.write_text("", encoding="utf-8")
+
+    assert descubrir_raiz_proyecto(None, principal) == tmp_path.resolve()
+
+
+def test_resolver_modulo_cobra_proyecto_usa_raiz_canonicalizada(tmp_path):
+    proyecto = tmp_path / "app"
+    modulo_dir = proyecto / "utilidades"
+    modulo_dir.mkdir(parents=True)
+    ruta = modulo_dir / "fechas.co"
+    ruta.write_text("", encoding="utf-8")
+
+    assert (
+        resolver_modulo_cobra_proyecto("utilidades.fechas", project_root=proyecto)
+        == ruta.resolve()
+    )
+
+
+def test_interpretador_usar_proyecto_resuelve_desde_cobra_toml(monkeypatch, tmp_path):
+    proyecto = tmp_path / "app"
+    (proyecto / "programas").mkdir(parents=True)
+    (proyecto / "utilidades").mkdir()
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "programas" / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "utilidades" / "fechas.co"
+    modulo.write_text("", encoding="utf-8")
+    rutas_cargadas = []
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        rutas_cargadas.append((Path(ruta), kwargs))
+        return []
+
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
+
+    interp = InterpretadorCobra(main_file=principal)
+    interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.fechas"))
+
+    assert rutas_cargadas == [
+        (
+            modulo.resolve(),
+            {
+                "modules_path": str(proyecto.resolve()),
+                "whitelist": {proyecto.resolve()},
+            },
+        )
+    ]
+    assert interp._project_root == proyecto.resolve()


### PR DESCRIPTION
### Motivation

- Permitir que `usar utilidades.fechas` se resuelva siempre desde la raíz canonicalizada del proyecto (p. ej. donde exista `cobra.toml`) y no dependiera solo de `cwd` o de rutas ad-hoc.
- Mantener estado mínimo en el intérprete para conocer el `main_file`/raíz efectiva y habilitar resolución segura de módulos de proyecto sin tocar Lexer/Parser/AST.

### Description

- Añadida función `descubrir_raiz_proyecto(start: Path | None, main_file: Path | None = None) -> Path` en `src/pcobra/cobra/usar_loader.py` que busca `cobra.toml` ascendiendo, cae al directorio del `main_file` o finalmente a `Path.cwd().resolve()`. (modificado: `usar_loader.py`).
- Extendido `InterpretadorCobra.__init__` para aceptar `main_file` y guardar `_main_file`, `_project_root` y `_current_module_stack` sin alterar el lexer/parser/AST; añadido `configurar_archivo_principal` y ajuste de inicialización. (modificado: `src/pcobra/core/interpreter.py`).
- Implementado soporte para módulos punteados de proyecto en `usar`: `_ejecutar_usar_modulo_proyecto` resuelve `utilidades.fechas` a `<raíz>/utilidades/fechas.co`, carga su AST con `cargar_ast_modulo` usando `modules_path`/`whitelist` desde la raíz canonicalizada, evita ciclos simples con una pila de módulos y ejecuta el AST. (modificado: `src/pcobra/core/interpreter.py`).
- Threaded `main_file` a través del pipeline de la CLI/runtime y del constructor de scripts para sandbox, para que el intérprete creado por la CLI conozca el archivo ejecutado; se actualizó `PipelineInput`, `construir_interprete_seguro_canonico`, `preparar_interpretador` y `RunService` para propagar `main_file`, y se añadió el fragmento al script sandbox. (modificados: `src/pcobra/cobra/cli/execution_pipeline.py`, `src/pcobra/cobra/cli/services/run_service.py`).
- Añadidos tests unitarios que cubren la detección de raíz por `cobra.toml`, fallback al directorio del principal y la resolución canonicalizada de `resolver_modulo_cobra_proyecto`, además de integración mínima que verifica que `InterpretadorCobra(main_file=...)` resuelve `usar utilidades.fechas` desde la raíz encontrada. (nuevo: `tests/unit/test_project_root_usar_resolution.py`).

### Testing

- Se compiló estáticamente el código modificado con `python -m py_compile src/pcobra/cobra/usar_loader.py src/pcobra/core/interpreter.py src/pcobra/cobra/cli/execution_pipeline.py src/pcobra/cobra/cli/services/run_service.py` y pasó correctamente.
- Se ejecutaron unit tests focalizados: `pytest -q tests/unit/test_project_root_usar_resolution.py tests/unit/test_usar_loader_validation.py::test_resolver_modulo_cobra_proyecto_convierte_nombre_punteado_en_co` y ambos pasaron (suites locales mostraron 5 passed, 1 warning).
- Durante una corrida más amplia se observó una regresión temporal en tests que hacen `monkeypatch` sobre `execute_cmd.analizar_codigo` (cuatro fallos), la cual se abordó ajustando el pipeline/propagación de `main_file` y la suite afectada volvió a pasar en las ejecuciones posteriores; los tests relevantes finales pasaron tras los ajustes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d0ee775e883278a739f6a3f88f72e)