### PR TITLE
Cachear módulos de proyecto de `usar` por ruta canónica y detectar ciclos

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -55,6 +55,7 @@ from .ast_nodes import (
     NodoNoLocal,
     NodoWith,
     NodoImportDesde,
+    NodoExport,
     NodoAST,
     NodoRomper,
     NodoContinuar,
@@ -550,6 +551,8 @@ class InterpretadorCobra:
             self._main_file, self._main_file
         )
         self._current_module_stack: list[Path] = []
+        self._usar_module_cache: dict[Path, dict[str, object]] = {}
+        self._usar_loading_stack: list[Path] = []
         # Debe ejecutarse siempre después de crear _validador y _usar_symbol_metadata.
         self.asegurar_estado_runtime_inicial()
 
@@ -2268,7 +2271,7 @@ class InterpretadorCobra:
                 self._set_mode(modo_prev)
 
     def _ejecutar_usar_modulo_proyecto(self, nombre_modulo: str) -> None:
-        """Ejecuta un módulo Cobra de proyecto resuelto desde la raíz canonicalizada."""
+        """Ejecuta un módulo Cobra de proyecto resuelto por ruta canónica."""
 
         current_file = (
             self._current_module_stack[-1]
@@ -2282,9 +2285,17 @@ class InterpretadorCobra:
             nombre_modulo,
             project_root=self._project_root,
             current_file=current_file,
-        )
-        if ruta_modulo in self._current_module_stack:
-            raise ImportError(f"Importación circular detectada en usar: {nombre_modulo}")
+        ).resolve()
+
+        if ruta_modulo in self._usar_module_cache:
+            self._inyectar_exports_modulo_proyecto(self._usar_module_cache[ruta_modulo])
+            return
+
+        if ruta_modulo in self._usar_loading_stack:
+            ciclo = [*self._usar_loading_stack, ruta_modulo]
+            cadena = " -> ".join(ruta.name for ruta in ciclo[ciclo.index(ruta_modulo):])
+            raise ImportError(f"Ciclo de módulos detectado en usar: {cadena}")
+
         try:
             ast = cargar_ast_modulo(
                 str(ruta_modulo),
@@ -2296,12 +2307,53 @@ class InterpretadorCobra:
         except FileNotFoundError as exc:
             raise FileNotFoundError(f"Módulo no encontrado: {nombre_modulo}") from exc
 
+        self._usar_loading_stack.append(ruta_modulo)
         self._current_module_stack.append(ruta_modulo)
+        entorno_modulo = Environment(parent=self.contextos[-1])
+        self.contextos.append(entorno_modulo)
+        self.mem_contextos.append({})
         try:
             for subnodo in ast:
+                if isinstance(subnodo, NodoExport):
+                    continue
                 self.ejecutar_nodo(subnodo)
+            exports = self._extraer_exports_modulo_proyecto(ast, entorno_modulo)
+            self._usar_module_cache[ruta_modulo] = dict(exports)
         finally:
+            memoria_local = self.mem_contextos.pop()
+            for idx, tam in memoria_local.values():
+                self.liberar_memoria(idx, tam)
+            self.contextos.pop()
             self._current_module_stack.pop()
+            self._usar_loading_stack.pop()
+
+        self._inyectar_exports_modulo_proyecto(exports)
+
+    def _extraer_exports_modulo_proyecto(
+        self, ast: list[object], entorno_modulo: Environment
+    ) -> dict[str, object]:
+        """Obtiene los símbolos públicos de un módulo Cobra ejecutado por ``usar``."""
+
+        nombres_exportados = [
+            nodo.nombre for nodo in ast if isinstance(nodo, NodoExport)
+        ]
+        if not nombres_exportados:
+            nombres_exportados = [
+                nombre for nombre in entorno_modulo.values if not nombre.startswith("_")
+            ]
+
+        exports: dict[str, object] = {}
+        for nombre in nombres_exportados:
+            if nombre in entorno_modulo.values:
+                exports[nombre] = entorno_modulo.values[nombre]
+        return exports
+
+    def _inyectar_exports_modulo_proyecto(self, exports: Mapping[str, object]) -> None:
+        """Inyecta en el contexto activo los exports cacheados de un módulo de proyecto."""
+
+        contexto_actual = self.contextos[-1]
+        for nombre, valor in exports.items():
+            contexto_actual.define(nombre, valor)
 
     def ejecutar_usar(self, nodo):
         """Importa callables públicos al contexto actual usando la política de ``usar``.

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -71,3 +71,66 @@ def test_interpretador_usar_proyecto_resuelve_desde_cobra_toml(monkeypatch, tmp_
         )
     ]
     assert interp._project_root == proyecto.resolve()
+
+
+def test_interpretador_usar_proyecto_cachea_por_ruta_canonica(monkeypatch, tmp_path):
+    from pcobra.core.ast_nodes import NodoAsignacion, NodoValor
+
+    proyecto = tmp_path / "app"
+    (proyecto / "utilidades").mkdir(parents=True)
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "utilidades" / "fechas.co"
+    modulo.write_text("", encoding="utf-8")
+    cargas = []
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        cargas.append(Path(ruta))
+        return [NodoAsignacion("valor", NodoValor(len(cargas)), declaracion=True)]
+
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
+
+    interp = InterpretadorCobra(safe_mode=False, main_file=principal)
+    interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.fechas"))
+    interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.fechas"))
+
+    assert cargas == [modulo.resolve()]
+    assert interp.variables["valor"] == 1
+    assert list(interp._usar_module_cache) == [modulo.resolve()]
+
+
+def test_interpretador_usar_proyecto_detecta_ciclos_con_rutas_canonicas(monkeypatch, tmp_path):
+    from pcobra.core.ast_nodes import NodoUsar
+
+    proyecto = tmp_path / "app"
+    utilidades = proyecto / "utilidades"
+    utilidades.mkdir(parents=True)
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo_a = utilidades / "a.co"
+    modulo_b = utilidades / "b.co"
+    modulo_a.write_text("", encoding="utf-8")
+    modulo_b.write_text("", encoding="utf-8")
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        if Path(ruta).resolve() == modulo_a.resolve():
+            return [NodoUsar("utilidades.b")]
+        return [NodoUsar("utilidades.a")]
+
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
+
+    interp = InterpretadorCobra(safe_mode=False, main_file=principal)
+
+    try:
+        interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.a"))
+    except ImportError as exc:
+        assert str(exc) == "Ciclo de módulos detectado en usar: a.co -> b.co -> a.co"
+    else:
+        raise AssertionError("Se esperaba un ImportError por ciclo de módulos")
+    assert interp._usar_loading_stack == []


### PR DESCRIPTION
### Motivation
- Mejorar la semántica de `usar` para módulos de proyecto evitando recargas redundantes usando la ruta canonicalizada del archivo.
- Detectar ciclos de carga entre módulos de proyecto y reportar una cadena legible del ciclo.
- Ejecutar el módulo en un entorno aislado para capturar sus exports y luego reinyectar esos símbolos en el contexto activo para preservar la semántica pública de `usar`.

### Description
- Añadidos en `InterpretadorCobra.__init__` los campos `_usar_module_cache: dict[Path, dict[str, object]]` y `_usar_loading_stack: list[Path]` para cache y detección de ciclos. (archivo modificado: `src/pcobra/core/interpreter.py`).
- En `_ejecutar_usar_modulo_proyecto` se canonicaliza la ruta con `Path.resolve()`, se reutiliza el cache si existe y se detecta ciclo si la ruta ya está en `_usar_loading_stack`, lanzando `ImportError` con la cadena del ciclo (ej.: `a.co -> b.co -> a.co`).
- Para módulos nuevos se parsea con `cargar_ast_modulo`, se ejecuta el AST en un entorno de módulo aislado (`Environment` hijo), se extraen los símbolos públicos (respetando `NodoExport` o nombres públicos) y se cachean sus exports; se inyectan esos exports en el contexto activo al finalizar.
- Se añade limpieza con `try/finally` para asegurar que `_usar_loading_stack`, `_current_module_stack`, y la memoria local se limpien aún en caso de error, y se añaden los helpers `_extraer_exports_modulo_proyecto` y `_inyectar_exports_modulo_proyecto`.
- Mantengo intacto `ejecutar_import` para no alterar la semántica actual de `import` y añadí tests que cubren la reutilización por ruta canónica y la detección de ciclos (archivo modificado: `tests/unit/test_project_root_usar_resolution.py`).

### Testing
- Ejecutado `pytest -q tests/unit/test_project_root_usar_resolution.py` y todas las pruebas nuevas y existentes de ese archivo pasaron (`6 passed`, `1 warning`).
- Ejecutado `python -m py_compile src/pcobra/core/interpreter.py` y la compilación del módulo fue correcta.
- Intentado `pytest -q tests/unit/test_usar.py tests/unit/test_project_root_usar_resolution.py` la colección falló en `tests/unit/test_usar.py` por un `ImportError: attempted relative import beyond top-level package` que es un problema de importación existente en el entorno de ejecución y no está relacionado con los cambios introducidos en este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d1557736083279c188069a6f3c110)