### PR TITLE
Integra símbolos .co en la ruta central de usar

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2317,8 +2317,18 @@ class InterpretadorCobra:
                 if isinstance(subnodo, NodoExport):
                     continue
                 self.ejecutar_nodo(subnodo)
-            exports = self._extraer_exports_modulo_proyecto(ast, entorno_modulo)
-            self._usar_module_cache[ruta_modulo] = dict(exports)
+            exports = self._extraer_exports_modulo_proyecto(
+                ast,
+                entorno_modulo,
+                ruta_modulo=ruta_modulo,
+            )
+            self._usar_module_cache[ruta_modulo] = {
+                "simbolos": list(exports["simbolos"]),
+                "metadata": {
+                    nombre: dict(metadata)
+                    for nombre, metadata in exports["metadata"].items()
+                },
+            }
         finally:
             memoria_local = self.mem_contextos.pop()
             for idx, tam in memoria_local.values():
@@ -2330,7 +2340,11 @@ class InterpretadorCobra:
         self._inyectar_exports_modulo_proyecto(exports)
 
     def _extraer_exports_modulo_proyecto(
-        self, ast: list[object], entorno_modulo: Environment
+        self,
+        ast: list[object],
+        entorno_modulo: Environment,
+        *,
+        ruta_modulo: Path,
     ) -> dict[str, object]:
         """Obtiene los símbolos públicos de un módulo Cobra ejecutado por ``usar``."""
 
@@ -2342,18 +2356,56 @@ class InterpretadorCobra:
                 nombre for nombre in entorno_modulo.values if not nombre.startswith("_")
             ]
 
-        exports: dict[str, object] = {}
+        simbolos_saneados: list[tuple[str, object]] = []
+        metadata_por_simbolo: dict[str, dict[str, object]] = {}
+        modulo_canonico = str(ruta_modulo.resolve())
         for nombre in nombres_exportados:
             if nombre in entorno_modulo.values:
-                exports[nombre] = entorno_modulo.values[nombre]
-        return exports
+                simbolo = entorno_modulo.values[nombre]
+                simbolos_saneados.append((nombre, simbolo))
+                metadata_por_simbolo[nombre] = build_and_validate_usar_symbol_metadata(
+                    module_name=modulo_canonico,
+                    symbol_name=nombre,
+                    callable_obj=simbolo,
+                )
+                logging.debug(
+                    "USAR_METADATA_PIPELINE route=project-module module=%s symbol=%s",
+                    modulo_canonico,
+                    nombre,
+                )
+
+        return {
+            "simbolos": simbolos_saneados,
+            "metadata": metadata_por_simbolo,
+        }
 
     def _inyectar_exports_modulo_proyecto(self, exports: Mapping[str, object]) -> None:
         """Inyecta en el contexto activo los exports cacheados de un módulo de proyecto."""
 
-        contexto_actual = self.contextos[-1]
-        for nombre, valor in exports.items():
-            contexto_actual.define(nombre, valor)
+        simbolos_saneados = list(exports.get("simbolos", []))
+        metadata_por_simbolo = {
+            nombre: dict(metadata)
+            for nombre, metadata in dict(exports.get("metadata", {})).items()
+        }
+        conflictos = self._detectar_conflictos_usar_en_contexto(
+            simbolos_saneados,
+            metadata_por_simbolo=metadata_por_simbolo,
+        )
+        if conflictos:
+            modulo = str(
+                metadata_por_simbolo.get(conflictos[0], {}).get("module", "módulo Cobra")
+            )
+            raise NameError(
+                formatear_error_usar_usuario(
+                    "conflicto_simbolo",
+                    modulo,
+                    f"Símbolo conflictivo: {conflictos[0]}.",
+                )
+            )
+        self._inyectar_simbolos_usar_en_contexto(
+            simbolos_saneados,
+            metadata_por_simbolo=metadata_por_simbolo,
+        )
 
     def ejecutar_usar(self, nodo):
         """Importa callables públicos al contexto actual usando la política de ``usar``.

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -134,3 +134,41 @@ def test_interpretador_usar_proyecto_detecta_ciclos_con_rutas_canonicas(monkeypa
     else:
         raise AssertionError("Se esperaba un ImportError por ciclo de módulos")
     assert interp._usar_loading_stack == []
+
+
+def test_interpretador_usar_proyecto_respeta_export_y_detecta_conflicto(monkeypatch, tmp_path):
+    import pytest
+    from pcobra.core.ast_nodes import NodoAsignacion, NodoExport, NodoValor
+
+    proyecto = tmp_path / "app"
+    (proyecto / "utilidades").mkdir(parents=True)
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "utilidades" / "fechas.co"
+    modulo.write_text("", encoding="utf-8")
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        return [
+            NodoExport("publico"),
+            NodoAsignacion("publico", NodoValor(1), declaracion=True),
+            NodoAsignacion("privado", NodoValor(2), declaracion=True),
+        ]
+
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
+
+    interp = InterpretadorCobra(safe_mode=False, main_file=principal)
+    interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.fechas"))
+
+    assert interp.variables["publico"] == 1
+    assert "privado" not in interp.variables
+    assert interp._usar_symbol_metadata["publico"]["module"] == str(modulo.resolve())
+
+    interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.fechas"))
+
+    interp_conflicto = InterpretadorCobra(safe_mode=False, main_file=principal)
+    interp_conflicto.contextos[-1].define("publico", 99)
+    with pytest.raises(NameError, match="conflicto de símbolos"):
+        interp_conflicto.ejecutar_usar(SimpleNamespace(modulo="utilidades.fechas"))


### PR DESCRIPTION
### Motivation
- Permitir que los módulos Cobra del proyecto (`.co`) participen de la misma canalización de `usar` que los módulos oficiales, preservando detección de colisiones, metadata y reimport idempotente.
- Respetar `NodoExport` y la semántica actual de exponer símbolos públicos cuando no hay exports explícitos, evitando `define` directo sin metadata.

### Description
- Cambia `_extraer_exports_modulo_proyecto` para recolectar pares `(nombre, valor)` y construir metadata canónica usando `build_and_validate_usar_symbol_metadata` con la ruta canónica del `.co` como `module` de origen. (`src/pcobra/core/interpreter.py`)
- Almacena en cache módulos de proyecto como dict con `"simbolos"` y `"metadata"` para que reimportes por rutas equivalentes sean idempotentes. (`src/pcobra/core/interpreter.py`)
- Antes de definir en el contexto, pasa los exports por `_detectar_conflictos_usar_en_contexto` y usa `_inyectar_simbolos_usar_en_contexto` para inyección atómica y consistente, lanzando errores de colisión cuando corresponda. (`src/pcobra/core/interpreter.py`)
- Añade una prueba que verifica que `NodoExport` se respeta, que los símbolos privados no se exponen, que la metadata usa la ruta canónica y que un conflicto real produce `NameError`. (`tests/unit/test_project_root_usar_resolution.py`)

### Testing
- Ejecuté `python -m py_compile src/pcobra/core/interpreter.py` y la comprobación de bytecode fue satisfactoria. (éxito)
- Ejecuté `pytest -q tests/unit/test_project_root_usar_resolution.py` y todos los tests de ese módulo pasaron. (éxito)
- Intenté ejecutar la suite más amplia con `pytest -q tests/unit/test_usar.py tests/unit/test_safe_mode.py tests/unit/test_project_root_usar_resolution.py` pero la ejecución de colección falló por un `ImportError: attempted relative import beyond top-level package` relacionado con imports legacy `core.*` en este entorno; este error no está causado por los cambios funcionales introducidos. (colección fallida)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d16b7cab08327a8afd81b2c585fb7)