### PR TITLE
Unifica resolución de `usar` en backend Python

### DIFF
--- a/src/pcobra/cobra/transpilers/transpiler/python_nodes/usar.py
+++ b/src/pcobra/cobra/transpilers/transpiler/python_nodes/usar.py
@@ -1,11 +1,8 @@
-from pcobra.cobra.usar_loader import obtener_modulo
-
-
 def visit_usar(self, nodo):
-    """Genera el código para la instrucción ``usar``."""
+    """Genera el código para la instrucción ``usar`` usando la API canónica."""
 
     ind = self.obtener_indentacion()
     self.codigo += (
-        f"{ind}from pcobra.cobra.usar_loader import obtener_modulo\n"
-        f"{ind}{nodo.modulo} = obtener_modulo('{nodo.modulo}')\n"
+        f"{ind}from pcobra.cobra.usar_loader import usar_modulo\n"
+        f"{ind}globals().update(usar_modulo('{nodo.modulo}'))\n"
     )

--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -15,6 +15,7 @@ from pcobra.cobra.usar_policy import (
     USAR_RUNTIME_EXPORT_OVERRIDES,
 )
 from pcobra.cobra.core.usar_symbol_policy import (
+    build_and_validate_usar_symbol_metadata,
     depuracion_saneamiento_usar_habilitada,
     sanear_exportables_para_usar,
 )
@@ -26,6 +27,8 @@ _VALID_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 # Segmentos seguros para módulos de proyecto: ruta lógica punteada, no ruta del sistema.
 _VALID_PROJECT_MODULE_SEGMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _PROJECT_MODULE_FORBIDDEN_CHARS = frozenset('/\\@$%*?"\'<>|;`!()[]{}=+,')
+_USAR_PROJECT_MODULE_CACHE: dict[Path, dict[str, Any]] = {}
+_USAR_PROJECT_LOADING_STACK: list[Path] = []
 
 # Patrones que deben bloquearse explícitamente para evitar imports de backend o rutas internas.
 _INTERNAL_HINTS = (
@@ -344,6 +347,157 @@ def obtener_modulo(nombre: str, *, permitir_instalacion: bool = True):
         raise ImportError(
             f"No se pudo resolver el módulo Cobra permitido '{nombre}' en runtime."
         ) from exc
+
+
+def _extraer_exports_modulo_cobra_proyecto(
+    ast: list[object],
+    entorno_modulo: object,
+    *,
+    ruta_modulo: Path,
+) -> dict[str, Any]:
+    """Extrae exports saneados de un módulo ``.co`` ya ejecutado."""
+
+    from pcobra.core.ast_nodes import NodoExport
+
+    valores_entorno = getattr(entorno_modulo, "values", {})
+    nombres_exportados = [
+        nodo.nombre for nodo in ast if isinstance(nodo, NodoExport)
+    ] or [nombre for nombre in valores_entorno if not nombre.startswith("_")]
+
+    simbolos_saneados: list[tuple[str, object]] = []
+    metadata_por_simbolo: dict[str, dict[str, object]] = {}
+    modulo_canonico = str(ruta_modulo.resolve(strict=False))
+    for nombre in nombres_exportados:
+        if nombre not in valores_entorno:
+            continue
+        simbolo = valores_entorno[nombre]
+        simbolos_saneados.append((nombre, simbolo))
+        metadata_por_simbolo[nombre] = build_and_validate_usar_symbol_metadata(
+            module_name=modulo_canonico,
+            symbol_name=nombre,
+            callable_obj=simbolo,
+        )
+
+    return {
+        "simbolos": simbolos_saneados,
+        "metadata": metadata_por_simbolo,
+    }
+
+
+def _cargar_exports_modulo_cobra_proyecto(
+    nombre: str,
+    *,
+    project_root: Path,
+    current_file: Path | None = None,
+) -> dict[str, Any]:
+    """Carga un módulo Cobra de proyecto usando resolución canónica y cache."""
+
+    from pcobra.core.environment import Environment
+    from pcobra.core.import_utils import cargar_ast_modulo
+    from pcobra.core.interpreter import InterpretadorCobra
+    from pcobra.core.ast_nodes import NodoExport
+
+    ruta_modulo = resolver_modulo_cobra_proyecto(
+        nombre,
+        project_root=project_root,
+        current_file=current_file,
+    ).resolve(strict=False)
+
+    if ruta_modulo in _USAR_PROJECT_MODULE_CACHE:
+        return _USAR_PROJECT_MODULE_CACHE[ruta_modulo]
+
+    if ruta_modulo in _USAR_PROJECT_LOADING_STACK:
+        ciclo = [*_USAR_PROJECT_LOADING_STACK, ruta_modulo]
+        cadena = " -> ".join(ruta.name for ruta in ciclo[ciclo.index(ruta_modulo):])
+        raise ImportError(f"Ciclo de módulos detectado en usar: {cadena}")
+
+    try:
+        ast = cargar_ast_modulo(
+            str(ruta_modulo),
+            modules_path=str(project_root),
+            whitelist={project_root},
+        )
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"Módulo no encontrado: {nombre}") from exc
+
+    interpretador = InterpretadorCobra()
+    interpretador._project_root = Path(project_root).resolve(strict=False)
+    interpretador._main_file = (
+        Path(current_file).resolve(strict=False) if current_file else ruta_modulo
+    )
+    interpretador._current_module_stack.append(ruta_modulo)
+    interpretador.contextos.append(Environment(parent=interpretador.contextos[-1]))
+    interpretador.mem_contextos.append({})
+    _USAR_PROJECT_LOADING_STACK.append(ruta_modulo)
+    try:
+        for subnodo in ast:
+            if isinstance(subnodo, NodoExport):
+                continue
+            interpretador.ejecutar_nodo(subnodo)
+        exports = _extraer_exports_modulo_cobra_proyecto(
+            ast,
+            interpretador.contextos[-1],
+            ruta_modulo=ruta_modulo,
+        )
+        _USAR_PROJECT_MODULE_CACHE[ruta_modulo] = {
+            "simbolos": list(exports["simbolos"]),
+            "metadata": {
+                nombre: dict(metadata)
+                for nombre, metadata in exports["metadata"].items()
+            },
+        }
+        return _USAR_PROJECT_MODULE_CACHE[ruta_modulo]
+    finally:
+        memoria_local = interpretador.mem_contextos.pop()
+        for idx, tam in memoria_local.values():
+            interpretador.liberar_memoria(idx, tam)
+        interpretador.contextos.pop()
+        interpretador._current_module_stack.pop()
+        _USAR_PROJECT_LOADING_STACK.pop()
+
+
+def usar_modulo(
+    nombre: str,
+    *,
+    project_root: str | Path | None = None,
+    current_file: str | Path | None = None,
+) -> dict[str, Any]:
+    """API única para resolver ``usar`` en runtime y transpilación Python.
+
+    - Los módulos oficiales preservan ``obtener_modulo`` y devuelven sus
+      símbolos públicos saneados.
+    - Los módulos Cobra de proyecto (``foo.bar`` -> ``foo/bar.co``) usan la
+      misma resolución canónica por ruta y una cache global por archivo.
+    """
+
+    if isinstance(nombre, str) and "." in nombre:
+        current = Path(current_file).expanduser() if current_file is not None else None
+        root = (
+            Path(project_root).expanduser().resolve(strict=False)
+            if project_root is not None
+            else descubrir_raiz_proyecto(current, current)
+        )
+        exports = _cargar_exports_modulo_cobra_proyecto(
+            nombre,
+            project_root=root,
+            current_file=current,
+        )
+        return dict(exports.get("simbolos", []))
+
+    modulo = obtener_modulo(nombre)
+    mapa_limpio, conflictos = sanitizar_exports_publicos(
+        modulo,
+        normalizar_nombre_usar(nombre),
+    )
+    if conflictos:
+        logging.debug(
+            "USAR sanitize conflicts en API única module=%s conflicts=%s",
+            nombre,
+            conflictos,
+        )
+    if not mapa_limpio:
+        raise ImportError(f"No se encontraron símbolos exportables para usar '{nombre}'.")
+    return mapa_limpio
 
 
 def sanitizar_exports_publicos(modulo: object, alias_modulo: str) -> tuple[dict[str, Any], list[dict[str, str]]]:

--- a/src/pcobra/core/usar_loader.py
+++ b/src/pcobra/core/usar_loader.py
@@ -25,6 +25,12 @@ def obtener_modulo(*args, **kwargs):
     return _impl.obtener_modulo(*args, **kwargs)
 
 
+def usar_modulo(*args, **kwargs):
+    """Delega en la implementación canónica de `pcobra.cobra.usar_loader`."""
+
+    return _impl.usar_modulo(*args, **kwargs)
+
+
 def obtener_modulo_cobra_oficial(*args, **kwargs):
     """Delega en la implementación canónica de `pcobra.cobra.usar_loader`."""
 

--- a/tests/test_transpilers.py
+++ b/tests/test_transpilers.py
@@ -18,6 +18,8 @@ from pcobra.core.ast_nodes import (
     NodoGarantia,
     NodoRetorno,
     NodoLlamadaFuncion,
+    NodoExport,
+    NodoUsar,
 )
 from pcobra.core.lexer import TipoToken, Token
 import pcobra.cobra.core as cobra_core
@@ -36,6 +38,53 @@ def test_generate_code_asignacion_simple() -> None:
     codigo = transpiler.generate_code([nodo])
     assert "x = 1" in codigo
     assert transpiler.codigo == codigo
+
+
+def test_transpilador_python_usar_invoca_api_canonica() -> None:
+    nodo = NodoUsar("texto")
+    transpiler = TranspiladorPython()
+    codigo = transpiler.generate_code([nodo])
+
+    assert "from pcobra.cobra.usar_loader import usar_modulo" in codigo
+    assert "globals().update(usar_modulo('texto'))" in codigo
+    assert "obtener_modulo" not in codigo
+
+
+def test_usar_modulo_oficial_devuelve_exports_saneados() -> None:
+    from pcobra.cobra.usar_loader import usar_modulo
+
+    simbolos = usar_modulo("texto")
+
+    assert "recortar" in simbolos
+    assert callable(simbolos["recortar"])
+    assert "strip" not in simbolos
+
+
+def test_usar_modulo_proyecto_reusa_resolucion_y_cache(tmp_path, monkeypatch) -> None:
+    from pcobra.cobra.usar_loader import usar_modulo
+    from pcobra.core import import_utils
+
+    modulo = tmp_path / "utilidades" / "saludos.co"
+    modulo.parent.mkdir()
+    modulo.write_text("exportar saludo\n", encoding="utf-8")
+    llamadas = []
+
+    def cargar_ast_falso(ruta, *, modules_path, whitelist):
+        llamadas.append((Path(ruta).resolve(), Path(modules_path).resolve(), whitelist))
+        return [
+            NodoAsignacion("saludo", NodoValor("hola"), declaracion=True),
+            NodoExport("saludo"),
+        ]
+
+    monkeypatch.setattr(import_utils, "cargar_ast_modulo", cargar_ast_falso)
+
+    primera_carga = usar_modulo("utilidades.saludos", project_root=tmp_path)
+    segunda_carga = usar_modulo("utilidades.saludos", project_root=tmp_path)
+
+    assert primera_carga == {"saludo": "hola"}
+    assert segunda_carga == {"saludo": "hola"}
+    assert len(llamadas) == 1
+    assert llamadas[0][0] == modulo.resolve()
 
 
 def test_save_file(tmp_path: pytest.TempPathFactory) -> None:


### PR DESCRIPTION
### Motivation
- Evitar que el transpiler Python implemente una segunda resolución de `usar` duplicando la lógica runtime y crear una API única que sirva tanto a ejecución como a transpilación.
- Preservar el contrato y comportamiento de los módulos oficiales de Cobra mientras se comparte la resolución/caché de módulos `.co` de proyecto con el runtime principal.
- Limitar los cambios a backend Python y no tocar backends legacy salvo compatibilidad mínima para el wrapper.

### Description
- Añade `usar_modulo(nombre, *, project_root=None, current_file=None)` en `src/pcobra/cobra/usar_loader.py` que unifica la resolución de `usar`, devuelve un mapa de símbolos exportables y soporta módulos oficiales y módulos `.co` de proyecto con caché y detección de ciclos.
- Para módulos `.co` de proyecto, la nueva implementación reutiliza la resolución canónica (`resolver_modulo_cobra_proyecto`), ejecuta el AST a través de `InterpretadorCobra` para extraer exports y almacena resultados en la caché `_USAR_PROJECT_MODULE_CACHE` por ruta canónica.
- Preserva `obtener_modulo` para módulos oficiales y aplica `sanitizar_exports_publicos(...)` antes de devolver la superficie pública desde `usar_modulo`.
- Actualiza el nodo Python `visit_usar` (`src/pcobra/cobra/transpilers/transpiler/python_nodes/usar.py`) para importar y llamar a `usar_modulo` y hacer `globals().update(usar_modulo(...))` en lugar de generar llamadas directas a `obtener_modulo`.
- Añade delegación `usar_modulo` en el wrapper legacy `src/pcobra/core/usar_loader.py` y pruebas específicas en `tests/test_transpilers.py` para la generación de código, exports oficiales saneados y resolución/caché de módulos `.co`.

### Testing
- Se ejecutaron los tests de unidad relevantes con `python -m pytest tests/test_transpilers.py::test_transpilador_python_usar_invoca_api_canonica tests/test_transpilers.py::test_usar_modulo_oficial_devuelve_exports_saneados tests/test_transpilers.py::test_usar_modulo_proyecto_reusa_resolucion_y_cache -q` y los tres tests pasaron.
- Se verificó la sintaxis/compilación con `python -m py_compile src/pcobra/cobra/usar_loader.py src/pcobra/core/usar_loader.py src/pcobra/cobra/transpilers/transpiler/python_nodes/usar.py` y la compilación fue exitosa.
- Ejecutar el archivo completo `python -m pytest tests/test_transpilers.py -q` mostró dos fallos preexistentes en pruebas legacy no modificadas: `test_transpilador_js_garantia` (TypeError por concatenación de `NodoBloque`) y `test_transpilador_cpp_garantia` (ValueError por `STANDARD_IMPORTS` faltante para `cpp`), los cuales están fuera del alcance de esta modificación al backend Python.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d1cfc63708327b03d053440d702d8)