### PR TITLE
Propagate canonical file_path for Cobra project modules

### DIFF
--- a/src/pcobra/cobra/imports/resolver.py
+++ b/src/pcobra/cobra/imports/resolver.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import logging
+import os
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -55,6 +56,7 @@ class ResolutionResult:
     source: str
     resolved_name: str
     import_path: str | None = None
+    file_path: str | None = None
     backend: str | None = None
     backend_adapter: object | None = None
     precedence_reason: str | None = None
@@ -276,6 +278,7 @@ class CobraImportResolver:
             source=candidates[0].source,
             resolved_name=candidates[0].resolved_name,
             import_path=candidates[0].import_path,
+            file_path=candidates[0].file_path,
             backend=candidates[0].backend,
             backend_adapter=candidates[0].backend_adapter,
             precedence_reason=precedence_reason,
@@ -326,6 +329,8 @@ class CobraImportResolver:
             "conflict_candidates": list(resolution.conflict_candidates),
             "audit_debug": self.audit_debug,
         }
+        if resolution.file_path is not None:
+            metadata["file_path"] = resolution.file_path
         setattr(module, "__cobra_resolution_source__", resolution.source)
         setattr(module, "__cobra_backend_injected__", resolution.backend)
         setattr(module, "__cobra_resolution_metadata__", metadata)
@@ -340,6 +345,7 @@ class CobraImportResolver:
             source=resolution.source,
             resolved_name=resolution.resolved_name,
             import_path=resolution.import_path,
+            file_path=resolution.file_path,
             backend=effective_backend,
             backend_adapter=adapter,
             precedence_reason=resolution.precedence_reason,
@@ -378,13 +384,34 @@ class CobraImportResolver:
             relative / "__init__.cobra",
         )
         for pattern in local_patterns:
-            if (self.project_root / pattern).exists():
+            candidate_path = self.project_root / pattern
+            if candidate_path.exists():
+                file_path = candidate_path.resolve()
+                self._verify_path_inside_project_root(file_path)
                 return ResolutionResult(
                     request=name,
                     source="project",
                     resolved_name=name,
+                    import_path=None,
+                    file_path=str(file_path),
                 )
         return None
+
+    def _verify_path_inside_project_root(self, file_path: Path) -> None:
+        if self.project_root is None:
+            return
+        try:
+            common = os.path.commonpath((str(self.project_root), str(file_path)))
+        except ValueError as exc:
+            raise ImportResolutionError(
+                "Ruta de módulo de proyecto fuera de la raíz autorizada.",
+                code="IMP-PROJECT-PATH-001",
+            ) from exc
+        if common != str(self.project_root):
+            raise ImportResolutionError(
+                "Ruta de módulo de proyecto fuera de la raíz autorizada.",
+                code="IMP-PROJECT-PATH-001",
+            )
 
     def _resolve_stdlib_module(self, name: str) -> ResolutionResult | None:
         if name.startswith("cobra."):

--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import sys
 from typing import Any
 
+from pcobra.cobra.imports.resolver import CobraImportResolver, ImportResolutionError
 from pcobra.cobra.usar_policy import (
     CANONICAL_MODULE_SURFACE_CONTRACTS,
     REPL_COBRA_MODULE_INTERNAL_PATH_MAP,
@@ -207,15 +208,27 @@ def resolver_modulo_cobra_proyecto(
     segundo sistema de imports.
     """
 
-    segmentos = validar_nombre_modulo_cobra_proyecto(nombre)
+    validar_nombre_modulo_cobra_proyecto(nombre)
     root_resuelto = Path(project_root).resolve(strict=False)
 
     if current_file is not None:
         current_resuelto = Path(current_file).resolve(strict=False)
         _verificar_path_dentro_de_root(current_resuelto, root_resuelto)
 
-    ruta_logica = root_resuelto.joinpath(*segmentos[:-1], f"{segmentos[-1]}.co")
-    ruta_resuelta = ruta_logica.resolve(strict=False)
+    try:
+        resolution = CobraImportResolver(
+            project_root=root_resuelto,
+            collision_policy="warn",
+        ).resolve(nombre)
+    except ImportResolutionError as exc:
+        if exc.code == "IMP-PROJECT-PATH-001":
+            raise ValueError("Ruta de módulo de proyecto fuera de la raíz autorizada.") from exc
+        raise FileNotFoundError(f"Módulo no encontrado: {nombre}") from exc
+
+    if resolution.source != "project" or not resolution.file_path:
+        raise FileNotFoundError(f"Módulo no encontrado: {nombre}")
+
+    ruta_resuelta = Path(resolution.file_path)
     _verificar_path_dentro_de_root(ruta_resuelta, root_resuelto)
 
     return ruta_resuelta

--- a/tests/unit/test_imports_resolver.py
+++ b/tests/unit/test_imports_resolver.py
@@ -130,6 +130,34 @@ def test_politica_colisiones_desde_config(monkeypatch, tmp_path):
         resolver.resolve("datos")
 
 
+
+def test_modulo_proyecto_expone_file_path_canonico(tmp_path):
+    modulo = tmp_path / "utilidades" / "fechas.co"
+    modulo.parent.mkdir()
+    modulo.write_text("", encoding="utf-8")
+
+    resolver = CobraImportResolver(project_root=tmp_path)
+    result = resolver.resolve("utilidades.fechas")
+
+    assert result.source == "project"
+    assert result.import_path is None
+    assert result.file_path == str(modulo.resolve())
+
+
+def test_modulo_proyecto_rechaza_file_path_canonico_fuera_de_root(tmp_path):
+    destino_externo = tmp_path.parent / f"{tmp_path.name}_externo_resolver"
+    destino_externo.mkdir()
+    (destino_externo / "fechas.co").write_text("", encoding="utf-8")
+    (tmp_path / "utilidades").symlink_to(destino_externo, target_is_directory=True)
+
+    resolver = CobraImportResolver(project_root=tmp_path)
+
+    with pytest.raises(ImportResolutionError) as excinfo:
+        resolver.resolve("utilidades.fechas")
+
+    assert excinfo.value.code == "IMP-PROJECT-PATH-001"
+
+
 def test_bridge_python_directo():
     resolver = CobraImportResolver()
 

--- a/tests/unit/test_usar_loader_validation.py
+++ b/tests/unit/test_usar_loader_validation.py
@@ -68,9 +68,13 @@ def test_modulo_no_publico_error_controlado_sin_traceback():
 def test_resolver_modulo_cobra_proyecto_convierte_nombre_punteado_en_co(tmp_path):
     from pcobra.cobra.usar_loader import resolver_modulo_cobra_proyecto
 
+    modulo = tmp_path / "utilidades" / "fechas.co"
+    modulo.parent.mkdir()
+    modulo.write_text("", encoding="utf-8")
+
     ruta = resolver_modulo_cobra_proyecto("utilidades.fechas", project_root=tmp_path)
 
-    assert ruta == (tmp_path / "utilidades" / "fechas.co").resolve(strict=False)
+    assert ruta == modulo.resolve()
 
 
 @pytest.mark.parametrize(
@@ -100,6 +104,7 @@ def test_resolver_modulo_cobra_proyecto_rechaza_traversal_por_symlink(tmp_path):
 
     destino_externo = tmp_path.parent / f"{tmp_path.name}_externo"
     destino_externo.mkdir()
+    (destino_externo / "fechas.co").write_text("", encoding="utf-8")
     (tmp_path / "utilidades").symlink_to(destino_externo, target_is_directory=True)
 
     with pytest.raises(ValueError, match="fuera de la raíz autorizada"):


### PR DESCRIPTION
### Motivation
- Evitar duplicar la lógica de resolución de módulos Cobra de proyecto y exponer la ruta física canonical cuando exista para que callers (por ejemplo `usar`) la reutilicen.
- Mantener compatibilidad con módulos Python/híbridos y preservar `import_path=None` para archivos `.co/.cobra` no importables por Python.

### Description
- Añadido `file_path: str | None = None` a `ResolutionResult` y propagado en la selección de candidatos y en el adaptador de backend cuando corresponde.
- `_resolve_local_file_module` ahora resuelve `project_root / pattern` con `Path.resolve()`, asigna `file_path` (y mantiene `import_path=None`) y verifica canonicidad dentro de `project_root` antes de devolver el resultado, lanzando `ImportResolutionError(code="IMP-PROJECT-PATH-001")` si no lo está.
- `_attach_module_metadata` incluye `file_path` en `__cobra_resolution_metadata__` únicamente cuando existe, evitando cambios en metadatos de módulos que no la tengan.
- `resolver_modulo_cobra_proyecto` (en `pcobra.cobra.usar_loader`) delega ahora en `CobraImportResolver.resolve()` y usa `file_path` retornado para devolver la ruta canonical en lugar de recomponer `relative.with_suffix('.co')` manualmente, manteniendo las comprobaciones de seguridad previas.
- Añadidas pruebas unitarias que verifican que los módulos de proyecto exponen `file_path` canonical, que `import_path is None` para `.co`, y que se rechazan rutas que canonicalizan fuera de `project_root`; además se ajustó una prueba ligera en `test_usar_loader_validation.py` para el caso de existencia del archivo.

### Testing
- Ejecutado `python -m pytest tests/unit/test_imports_resolver.py tests/unit/test_usar_loader_validation.py tests/unit/test_project_root_usar_resolution.py -q` y `python -m pytest tests/unit/test_imports_resolver.py tests/unit/test_usar_loader_validation.py tests/unit/test_project_root_usar_resolution.py tests/unit/test_core_usar_loader_delegation.py -q`, ambos completaron correctamente (todos los tests unitarios relevantes pasaron; salida final: 59 passed, 1 warning in local runs).
- Se añadieron y validaron las pruebas: `test_modulo_proyecto_expone_file_path_canonico` y `test_modulo_proyecto_rechaza_file_path_canonico_fuera_de_root` en `tests/unit/test_imports_resolver.py`, y la ligera adaptación en `tests/unit/test_usar_loader_validation.py` para comprobar resolución real del archivo `.co`.
- Se verificó que la nueva metadata sólo añade `file_path` cuando existe y que `usar`/`Interpretador._ejecutar_usar_modulo_proyecto` siguen resolviendo y cargando módulos de proyecto correctamente en los tests automáticos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d1ededbe483279c11f13f93780240)