### PR TITLE
Agregar tests y soporte para resolución de módulos Cobra de proyecto en usar

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2281,11 +2281,19 @@ class InterpretadorCobra:
         self._project_root = descubrir_raiz_proyecto(
             current_file or self._project_root, self._main_file
         )
-        ruta_modulo = resolver_modulo_cobra_proyecto(
-            nombre_modulo,
-            project_root=self._project_root,
-            current_file=current_file,
-        ).resolve()
+        try:
+            ruta_modulo = resolver_modulo_cobra_proyecto(
+                nombre_modulo,
+                project_root=self._project_root,
+                current_file=current_file,
+            ).resolve()
+        except FileNotFoundError as exc:
+            ruta_buscada = self._project_root.joinpath(
+                *str(nombre_modulo).split(".")
+            ).with_suffix(".co")
+            raise FileNotFoundError(
+                f"Módulo no encontrado: {nombre_modulo}. Ruta buscada: {ruta_buscada}"
+            ) from exc
 
         if ruta_modulo in self._usar_module_cache:
             self._inyectar_exports_modulo_proyecto(self._usar_module_cache[ruta_modulo])
@@ -2305,7 +2313,12 @@ class InterpretadorCobra:
         except PermissionError as exc:
             raise PrimitivaPeligrosaError(str(exc)) from exc
         except FileNotFoundError as exc:
-            raise FileNotFoundError(f"Módulo no encontrado: {nombre_modulo}") from exc
+            ruta_buscada = self._project_root.joinpath(
+                *str(nombre_modulo).split(".")
+            ).with_suffix(".co")
+            raise FileNotFoundError(
+                f"Módulo no encontrado: {nombre_modulo}. Ruta buscada: {ruta_buscada}"
+            ) from exc
 
         self._usar_loading_stack.append(ruta_modulo)
         self._current_module_stack.append(ruta_modulo)
@@ -2467,8 +2480,20 @@ class InterpretadorCobra:
 
         try:
             nombre_modulo = nodo.modulo
-            if isinstance(nombre_modulo, str) and "." in nombre_modulo:
-                return self._ejecutar_usar_modulo_proyecto(nombre_modulo)
+            if isinstance(nombre_modulo, str):
+                nombre_modulo_limpio = nombre_modulo.strip()
+                if (
+                    "." in nombre_modulo_limpio
+                    or nombre_modulo_limpio not in USAR_COBRA_ALLOWLIST
+                ):
+                    try:
+                        return self._ejecutar_usar_modulo_proyecto(nombre_modulo_limpio)
+                    except FileNotFoundError:
+                        if "." in nombre_modulo_limpio:
+                            raise
+                    except ValueError:
+                        if "." in nombre_modulo_limpio:
+                            raise
             modulo, es_repl_estricto, es_modulo_oficial_cobra = _resolver_carga_modulo_usar(
                 nombre_modulo
             )

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -172,3 +172,208 @@ def test_interpretador_usar_proyecto_respeta_export_y_detecta_conflicto(monkeypa
     interp_conflicto.contextos[-1].define("publico", 99)
     with pytest.raises(NameError, match="conflicto de símbolos"):
         interp_conflicto.ejecutar_usar(SimpleNamespace(modulo="utilidades.fechas"))
+
+
+def test_resolver_modulo_cobra_proyecto_resuelve_modulo_misma_carpeta(tmp_path):
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    modulo = proyecto / "saludos.co"
+    modulo.write_text("", encoding="utf-8")
+
+    assert resolver_modulo_cobra_proyecto("saludos", project_root=proyecto) == modulo.resolve()
+
+
+def test_resolver_modulo_cobra_proyecto_resuelve_subcarpeta_con_puntos(tmp_path):
+    proyecto = tmp_path / "app"
+    modulo = proyecto / "utilidades" / "fechas.co"
+    modulo.parent.mkdir(parents=True)
+    modulo.write_text("", encoding="utf-8")
+
+    assert resolver_modulo_cobra_proyecto("utilidades.fechas", project_root=proyecto) == modulo.resolve()
+
+
+def test_resolver_modulo_cobra_proyecto_resuelve_modulo_anidado(tmp_path):
+    proyecto = tmp_path / "app"
+    modulo = proyecto / "a" / "b" / "c.co"
+    modulo.parent.mkdir(parents=True)
+    modulo.write_text("", encoding="utf-8")
+
+    assert resolver_modulo_cobra_proyecto("a.b.c", project_root=proyecto) == modulo.resolve()
+
+
+def test_interpretador_usar_proyecto_misma_carpeta_con_nombre_simple(monkeypatch, tmp_path):
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "saludos.co"
+    modulo.write_text("", encoding="utf-8")
+    rutas_cargadas = []
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        rutas_cargadas.append(Path(ruta))
+        return []
+
+    monkeypatch.setattr("pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo)
+
+    interp = InterpretadorCobra(main_file=principal)
+    interp.ejecutar_usar(SimpleNamespace(modulo="saludos"))
+
+    assert rutas_cargadas == [modulo.resolve()]
+
+
+def test_interpretador_usar_proyecto_mantiene_raiz_al_cambiar_cwd(monkeypatch, tmp_path):
+    proyecto = tmp_path / "app"
+    externo = tmp_path / "otro-cwd"
+    externo.mkdir()
+    (proyecto / "utilidades").mkdir(parents=True)
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "utilidades" / "fechas.co"
+    modulo.write_text("", encoding="utf-8")
+    rutas_cargadas = []
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        rutas_cargadas.append((Path(ruta), kwargs["modules_path"]))
+        return []
+
+    monkeypatch.setattr("pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo)
+    monkeypatch.chdir(externo)
+
+    interp = InterpretadorCobra(main_file=principal)
+    interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.fechas"))
+
+    assert rutas_cargadas == [(modulo.resolve(), str(proyecto.resolve()))]
+    assert interp._project_root == proyecto.resolve()
+
+
+def test_interpretador_usar_proyecto_cachea_referencias_equivalentes(monkeypatch, tmp_path):
+    from pcobra.core.ast_nodes import NodoAsignacion, NodoValor
+
+    proyecto = tmp_path / "app"
+    (proyecto / "a" / "b").mkdir(parents=True)
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "a" / "b" / "c.co"
+    modulo.write_text("", encoding="utf-8")
+    cargas = []
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        cargas.append(Path(ruta).resolve())
+        return [NodoAsignacion("valor", NodoValor(len(cargas)), declaracion=True)]
+
+    monkeypatch.setattr("pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo)
+
+    interp = InterpretadorCobra(safe_mode=False, main_file=principal)
+    interp.ejecutar_usar(SimpleNamespace(modulo="a.b.c"))
+    interp.ejecutar_usar(SimpleNamespace(modulo="a.b.c"))
+
+    assert cargas == [modulo.resolve()]
+    assert interp.variables["valor"] == 1
+
+
+def test_interpretador_usar_proyecto_detecta_ciclo_directo_self(monkeypatch, tmp_path):
+    from pcobra.core.ast_nodes import NodoUsar
+    import pytest
+
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "a.co"
+    modulo.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo",
+        lambda _ruta, **_kwargs: [NodoUsar("a")],
+    )
+
+    interp = InterpretadorCobra(safe_mode=False, main_file=principal)
+    with pytest.raises(ImportError, match=r"Ciclo de módulos detectado en usar: a\.co -> a\.co"):
+        interp.ejecutar_usar(SimpleNamespace(modulo="a"))
+
+
+def test_interpretador_usar_proyecto_detecta_ciclo_indirecto(monkeypatch, tmp_path):
+    from pcobra.core.ast_nodes import NodoUsar
+    import pytest
+
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    for nombre in ("a", "b", "c"):
+        (proyecto / f"{nombre}.co").write_text("", encoding="utf-8")
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        siguiente = {"a.co": "b", "b.co": "c", "c.co": "a"}[Path(ruta).name]
+        return [NodoUsar(siguiente)]
+
+    monkeypatch.setattr("pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo)
+
+    interp = InterpretadorCobra(safe_mode=False, main_file=principal)
+    with pytest.raises(ImportError, match=r"a\.co -> b\.co -> c\.co -> a\.co"):
+        interp.ejecutar_usar(SimpleNamespace(modulo="a"))
+
+
+def test_interpretador_usar_proyecto_modulo_inexistente_muestra_nombre_y_ruta(tmp_path):
+    import pytest
+
+    proyecto = tmp_path / "app"
+    (proyecto / "utilidades").mkdir(parents=True)
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    ruta_buscada = proyecto / "utilidades" / "faltante.co"
+
+    interp = InterpretadorCobra(main_file=principal)
+    with pytest.raises(FileNotFoundError) as excinfo:
+        interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.faltante"))
+
+    mensaje = str(excinfo.value)
+    assert "utilidades.faltante" in mensaje
+    assert str(ruta_buscada) in mensaje
+
+
+def test_import_archivo_co_mantiene_ejecutar_import(monkeypatch, tmp_path):
+    principal = tmp_path / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = tmp_path / "archivo.co"
+    modulo.write_text("", encoding="utf-8")
+    llamadas = []
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        llamadas.append((ruta, kwargs["modules_path"]))
+        return []
+
+    monkeypatch.setattr("pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo)
+
+    interp = InterpretadorCobra(main_file=principal)
+    interp.ejecutar_import(SimpleNamespace(ruta=str(modulo)))
+
+    assert llamadas == [(str(modulo), Path.home() / ".cobra" / "modules")]
+
+
+def test_validacion_modulo_proyecto_acepta_puntos_y_rechaza_rutas_windows_posix():
+    import pytest
+    from pcobra.cobra.usar_loader import validar_nombre_modulo_cobra_proyecto
+
+    assert validar_nombre_modulo_cobra_proyecto("utilidades.fechas") == ("utilidades", "fechas")
+
+    for nombre in ("..", "a/../b", "../b", r"C:\\x", "a\\b"):
+        with pytest.raises(ValueError):
+            validar_nombre_modulo_cobra_proyecto(nombre)
+
+
+def test_resolver_modulo_cobra_proyecto_bloquea_traversal_estable(tmp_path):
+    import pytest
+
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+
+    with pytest.raises(ValueError, match="traversal"):
+        resolver_modulo_cobra_proyecto("..", project_root=proyecto)


### PR DESCRIPTION
### Motivation
- Añadir una batería de pruebas que cubran la resolución de módulos Cobra de proyecto (misma carpeta, subcarpetas con puntos, anidamiento, cambios de `cwd`, caché, ciclos directos/indirectos, módulo inexistente, validación de rutas y compatibilidad con `ejecutar_import`).
- Permitir que `usar` resuelva nombres simples no canónicos como módulos de proyecto cuando exista un `.co` correspondiente, para cubrir casos como `NodoUsar("saludos")` sin afectar la superficie oficial de módulos Cobra.
- Mejorar la trazabilidad de errores al incluir la ruta `.co` buscada cuando no se encuentra un módulo de proyecto.

### Description
- Se añadieron múltiples pruebas en `tests/unit/test_project_root_usar_resolution.py` para cubrir: módulo en la misma carpeta, subcarpeta con puntos, módulo anidado, ejecución desde otro `cwd`, carga única/caché por ruta, ciclo directo, ciclo indirecto, módulo inexistente con mensaje enriquecido, compatibilidad de `ejecutar_import`, validación de rutas Windows/POSIX y bloqueo de `..` traversal.
- Se actualizó `src/pcobra/core/interpreter.py` para intentar resolver nombres simples de `NodoUsar` como módulos de proyecto (llamando a la resolución canónica de proyecto) cuando proceda, manteniendo intacta la política para módulos oficiales y REPL.
- Se mejoró el mensaje de `FileNotFoundError` al resolver módulos de proyecto para incluir la ruta `.co` buscada; no se realizaron cambios en `lexer.py`, `parser.py` ni `docs/gramatica.ebnf`.

### Testing
- Ejecuté `pytest -q tests/unit/test_project_root_usar_resolution.py` y todas las pruebas añadidas y existentes en ese fichero pasaron (19 passed, 1 warning).
- Ejecuté `pytest -q tests/unit/test_usar.py tests/unit/test_project_root_usar_resolution.py` y la ejecución falló en la colección de `tests/unit/test_usar.py` debido a un import legacy (`core.interpreter`) que provoca `ImportError: attempted relative import beyond top-level package` antes de ejecutar las pruebas; el fallo es de colección del entorno de tests, no relacionado con los cambios de `usar` añadidos.
- Ejecuté `git diff --check` y una verificación de que no se modificaron `src/pcobra/cobra/core/lexer.py`, `src/pcobra/cobra/core/parser.py` ni `docs/gramatica.ebnf`; ambas verificaciones pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d2179ca988327bd5f8e4f2c35981b)