### PR TITLE
Permitir usar_modulo para módulos Cobra simples de proyecto

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -483,19 +483,30 @@ def usar_modulo(
       misma resolución canónica por ruta y una cache global por archivo.
     """
 
-    if isinstance(nombre, str) and "." in nombre:
-        current = Path(current_file).expanduser() if current_file is not None else None
-        root = (
-            Path(project_root).expanduser().resolve(strict=False)
-            if project_root is not None
-            else descubrir_raiz_proyecto(current, current)
+    if isinstance(nombre, str):
+        nombre_limpio = nombre.strip()
+        es_modulo_oficial = (
+            normalizar_nombre_usar(nombre_limpio) in USAR_COBRA_PUBLIC_MODULES
         )
-        exports = _cargar_exports_modulo_cobra_proyecto(
-            nombre,
-            project_root=root,
-            current_file=current,
-        )
-        return dict(exports.get("simbolos", []))
+        if "." in nombre_limpio or not es_modulo_oficial:
+            current = (
+                Path(current_file).expanduser() if current_file is not None else None
+            )
+            root = (
+                Path(project_root).expanduser().resolve(strict=False)
+                if project_root is not None
+                else descubrir_raiz_proyecto(current, current)
+            )
+            try:
+                exports = _cargar_exports_modulo_cobra_proyecto(
+                    nombre_limpio,
+                    project_root=root,
+                    current_file=current,
+                )
+                return dict(exports.get("simbolos", []))
+            except (FileNotFoundError, ValueError):
+                if "." in nombre_limpio:
+                    raise
 
     modulo = obtener_modulo(nombre)
     mapa_limpio, conflictos = sanitizar_exports_publicos(

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from pcobra.cobra.usar_loader import (
     descubrir_raiz_proyecto,
     resolver_modulo_cobra_proyecto,
+    usar_modulo,
 )
 from pcobra.core.interpreter import InterpretadorCobra
 
@@ -198,7 +199,74 @@ def test_resolver_modulo_cobra_proyecto_resuelve_modulo_anidado(tmp_path):
     modulo.parent.mkdir(parents=True)
     modulo.write_text("", encoding="utf-8")
 
-    assert resolver_modulo_cobra_proyecto("a.b.c", project_root=proyecto) == modulo.resolve()
+    assert (
+        resolver_modulo_cobra_proyecto("a.b.c", project_root=proyecto) == modulo.resolve()
+    )
+
+
+def test_usar_modulo_api_resuelve_util_misma_carpeta(monkeypatch, tmp_path):
+    from pcobra.core.ast_nodes import NodoAsignacion, NodoValor
+
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "util.co"
+    modulo.write_text("", encoding="utf-8")
+    rutas_cargadas = []
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        rutas_cargadas.append((Path(ruta), kwargs["modules_path"]))
+        return [NodoAsignacion("valor_util", NodoValor(7), declaracion=True)]
+
+    monkeypatch.setattr(
+        "pcobra.core.import_utils.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
+
+    exports = usar_modulo("util", current_file=principal)
+
+    assert exports["valor_util"] == 7
+    assert rutas_cargadas == [(modulo.resolve(), str(proyecto.resolve()))]
+
+
+def test_usar_modulo_api_resuelve_utilidades_fechas(monkeypatch, tmp_path):
+    from pcobra.core.ast_nodes import NodoAsignacion, NodoValor
+
+    proyecto = tmp_path / "app"
+    (proyecto / "utilidades").mkdir(parents=True)
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "utilidades" / "fechas.co"
+    modulo.write_text("", encoding="utf-8")
+    rutas_cargadas = []
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        rutas_cargadas.append((Path(ruta), kwargs["modules_path"]))
+        return [NodoAsignacion("hoy", NodoValor("2026-06-13"), declaracion=True)]
+
+    monkeypatch.setattr(
+        "pcobra.core.import_utils.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
+
+    exports = usar_modulo("utilidades.fechas", current_file=principal)
+
+    assert exports["hoy"] == "2026-06-13"
+    assert rutas_cargadas == [(modulo.resolve(), str(proyecto.resolve()))]
+
+
+def test_usar_modulo_api_nombre_simple_inexistente_mantiene_error_publico(tmp_path):
+    import pytest
+
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="no canónico"):
+        usar_modulo("numpy", current_file=principal)
 
 
 def test_interpretador_usar_proyecto_misma_carpeta_con_nombre_simple(monkeypatch, tmp_path):
@@ -215,13 +283,68 @@ def test_interpretador_usar_proyecto_misma_carpeta_con_nombre_simple(monkeypatch
         rutas_cargadas.append(Path(ruta))
         return []
 
-    monkeypatch.setattr("pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo)
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
 
     interp = InterpretadorCobra(main_file=principal)
     interp.ejecutar_usar(SimpleNamespace(modulo="saludos"))
 
     assert rutas_cargadas == [modulo.resolve()]
 
+
+def test_interpretador_usar_proyecto_util_misma_carpeta(monkeypatch, tmp_path):
+    from pcobra.core.ast_nodes import NodoAsignacion, NodoValor
+
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "util.co"
+    modulo.write_text("", encoding="utf-8")
+    rutas_cargadas = []
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        rutas_cargadas.append((Path(ruta), kwargs["modules_path"]))
+        return [NodoAsignacion("valor_util", NodoValor(11), declaracion=True)]
+
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
+
+    interp = InterpretadorCobra(safe_mode=False, main_file=principal)
+    interp.ejecutar_usar(SimpleNamespace(modulo="util"))
+
+    assert interp.variables["valor_util"] == 11
+    assert rutas_cargadas == [(modulo.resolve(), str(proyecto.resolve()))]
+
+
+def test_interpretador_usar_proyecto_utilidades_fechas(monkeypatch, tmp_path):
+    from pcobra.core.ast_nodes import NodoAsignacion, NodoValor
+
+    proyecto = tmp_path / "app"
+    (proyecto / "utilidades").mkdir(parents=True)
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "utilidades" / "fechas.co"
+    modulo.write_text("", encoding="utf-8")
+    rutas_cargadas = []
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        rutas_cargadas.append((Path(ruta), kwargs["modules_path"]))
+        return [NodoAsignacion("hoy", NodoValor("2026-06-13"), declaracion=True)]
+
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
+
+    interp = InterpretadorCobra(safe_mode=False, main_file=principal)
+    interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.fechas"))
+
+    assert interp.variables["hoy"] == "2026-06-13"
+    assert rutas_cargadas == [(modulo.resolve(), str(proyecto.resolve()))]
 
 def test_interpretador_usar_proyecto_mantiene_raiz_al_cambiar_cwd(monkeypatch, tmp_path):
     proyecto = tmp_path / "app"
@@ -239,7 +362,9 @@ def test_interpretador_usar_proyecto_mantiene_raiz_al_cambiar_cwd(monkeypatch, t
         rutas_cargadas.append((Path(ruta), kwargs["modules_path"]))
         return []
 
-    monkeypatch.setattr("pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo)
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
     monkeypatch.chdir(externo)
 
     interp = InterpretadorCobra(main_file=principal)
@@ -265,7 +390,9 @@ def test_interpretador_usar_proyecto_cachea_referencias_equivalentes(monkeypatch
         cargas.append(Path(ruta).resolve())
         return [NodoAsignacion("valor", NodoValor(len(cargas)), declaracion=True)]
 
-    monkeypatch.setattr("pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo)
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
 
     interp = InterpretadorCobra(safe_mode=False, main_file=principal)
     interp.ejecutar_usar(SimpleNamespace(modulo="a.b.c"))
@@ -313,7 +440,9 @@ def test_interpretador_usar_proyecto_detecta_ciclo_indirecto(monkeypatch, tmp_pa
         siguiente = {"a.co": "b", "b.co": "c", "c.co": "a"}[Path(ruta).name]
         return [NodoUsar(siguiente)]
 
-    monkeypatch.setattr("pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo)
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
 
     interp = InterpretadorCobra(safe_mode=False, main_file=principal)
     with pytest.raises(ImportError, match=r"a\.co -> b\.co -> c\.co -> a\.co"):
@@ -350,7 +479,9 @@ def test_import_archivo_co_mantiene_ejecutar_import(monkeypatch, tmp_path):
         llamadas.append((ruta, kwargs["modules_path"]))
         return []
 
-    monkeypatch.setattr("pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo)
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
 
     interp = InterpretadorCobra(main_file=principal)
     interp.ejecutar_import(SimpleNamespace(ruta=str(modulo)))


### PR DESCRIPTION
### Motivation
- Hacer que la API pública `usar_modulo()` acepte nombres simples no oficiales resolviéndolos como módulos Cobra de proyecto cuando correspondan, sin romper la prioridad y la compatibilidad de módulos oficiales. 

### Description
- Modifica `usar_modulo()` en `src/pcobra/cobra/usar_loader.py` para, cuando `nombre` sea string, intentar resolución de proyecto si el nombre contiene `.` o no está en `USAR_COBRA_PUBLIC_MODULES`, manteniendo la prioridad de módulos oficiales. 
- Usa `descubrir_raiz_proyecto(current, current)` para determinar la raíz del proyecto y llama a `_cargar_exports_modulo_cobra_proyecto()` con la raíz y `current_file` descubiertos. 
- Si la resolución de proyecto falla para nombres puntuales que contienen `.` re-lanza la excepción, y para nombres simples no oficiales que no se encuentran, deja que el flujo existente produzca el mismo `PermissionError`/mensaje de módulo no canónico para mantener compatibilidad. 
- Añade tests en `tests/unit/test_project_root_usar_resolution.py` que cubren `util.co` en la misma carpeta y `utilidades/fechas.co` tanto mediante la API `usar_modulo()` como mediante `InterpretadorCobra.ejecutar_usar()`.

### Testing
- Se ejecutó `pytest -q tests/unit/test_project_root_usar_resolution.py -q` y todas las pruebas de ese archivo pasaron exitosamente. 
- Se comprobó la sintaxis con `python -m py_compile` sobre `src/pcobra/cobra/usar_loader.py` y el archivo de tests añadido y la verificación estática (`git diff --check`) no reportó problemas. 
- Intentos de ejecutar una batería más amplia (incluyendo `tests/unit/test_usar.py`) fallaron en este entorno de ejecución por import legacy en ese test (`ImportError: attempted relative import beyond top-level package`), por lo que no se incluyeron aquí cambios sobre ese conjunto de tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d25abc3e483279789daaa352e8f05)