### PR TITLE
Propagar contexto de proyecto para resolver usar

### DIFF
--- a/src/pcobra/cobra/backends/python_adapter.py
+++ b/src/pcobra/cobra/backends/python_adapter.py
@@ -12,6 +12,9 @@ class PythonAdapter(BackendAdapter):
     """Wrapper sobre ``TranspiladorPython`` sin modificar su implementación."""
 
     def compile(self, ast: Any, options: Mapping[str, Any] | None = None) -> str:
-        _ = options or {}
-        transpiler = TranspiladorPython()
+        opts = options or {}
+        transpiler = TranspiladorPython(
+            source_file=opts.get("source_file"),
+            project_root=opts.get("project_root"),
+        )
         return transpiler.generate_code(ast)

--- a/src/pcobra/cobra/build/backend_pipeline.py
+++ b/src/pcobra/cobra/build/backend_pipeline.py
@@ -188,7 +188,12 @@ def build(source: str, hints: dict[str, Any] | None = None) -> dict[str, Any]:
 
     resolution, runtime_context = resolve_backend_runtime(source_file, context)
     ast = obtener_ast(codigo)
-    code = transpile(ast, resolution.backend, source_file=source_file)
+    code = transpile(
+        ast,
+        resolution.backend,
+        source_file=source_file,
+        project_root=context.get("project_root"),
+    )
     debug = bool(context.get("debug", False))
     if hasattr(resolution, "reason_for"):
         reason = resolution.reason_for(debug=debug)

--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -73,11 +73,11 @@ def construir_script_sandbox_canonico(
     """Genera un script sandbox con imports canónicos del runtime Cobra."""
 
     extra_repr = repr(extra_validators if extra_validators is not None else None)
+    safe_mode_repr = True if safe_mode is None else safe_mode
     main_file_fragment = "" if main_file is None else f", main_file={str(main_file)!r}"
     kwargs_fragment = (
-        ""
-        if safe_mode is None
-        else f", safe_mode={safe_mode!r}, extra_validators={extra_repr}{main_file_fragment}"
+        f", safe_mode={safe_mode_repr!r}, "
+        f"extra_validators={extra_repr}{main_file_fragment}"
     )
     script = (
         "from pcobra.cobra.cli.execution_pipeline import prevalidar_y_parsear_codigo\n"

--- a/tests/test_transpilers.py
+++ b/tests/test_transpilers.py
@@ -9,6 +9,7 @@ sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
 from pcobra.cobra.transpilers.transpiler.to_python import TranspiladorPython
 from pcobra.cobra.transpilers.transpiler.to_js import TranspiladorJavaScript
 from pcobra.cobra.transpilers.transpiler.to_cpp import TranspiladorCPP
+from pcobra.cobra.backends.python_adapter import PythonAdapter
 from pcobra.core.ast_nodes import (
     NodoValor,
     NodoAsignacion,
@@ -209,6 +210,25 @@ def test_transpilador_python_usar_proyecto_incluye_contexto_estable(tmp_path, mo
             },
         )
     ]
+
+
+def test_python_adapter_usar_proyecto_propaga_contexto_estable(tmp_path) -> None:
+    proyecto = tmp_path / "proyecto"
+    principal = proyecto / "src" / "main.co"
+    principal.parent.mkdir(parents=True)
+    (proyecto / "cobra.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
+    principal.write_text('usar "utilidades.fechas"\n', encoding="utf-8")
+
+    codigo = PythonAdapter().compile(
+        [NodoUsar("utilidades.fechas")],
+        options={"source_file": principal},
+    )
+
+    assert (
+        "globals().update(usar_modulo("
+        f"'utilidades.fechas', project_root={str(proyecto.resolve())!r}, "
+        f"current_file={str(principal.resolve())!r}))"
+    ) in codigo
 
 
 def test_transpilador_python_usar_oficial_acepta_contexto(tmp_path) -> None:

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from pcobra.cobra.cli.execution_pipeline import PipelineInput, ejecutar_pipeline_explicito
 from pcobra.cobra.usar_loader import (
     descubrir_raiz_proyecto,
     obtener_cache_modulos_cobra_proyecto,
@@ -40,6 +41,46 @@ def test_descubrir_raiz_proyecto_usa_directorio_principal_sin_cobra_toml(tmp_pat
     principal.write_text("", encoding="utf-8")
 
     assert descubrir_raiz_proyecto(None, principal) == tmp_path.resolve()
+
+
+def test_ejecucion_desde_cwd_externo_resuelve_usar_con_main_file(
+    monkeypatch, tmp_path
+):
+    from pcobra.core.ast_nodes import NodoAsignacion, NodoValor
+
+    proyecto = tmp_path / "app"
+    externo = tmp_path / "externo"
+    (proyecto / "utilidades").mkdir(parents=True)
+    externo.mkdir()
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "programas" / "main.co"
+    principal.parent.mkdir()
+    principal.write_text('usar "utilidades.fechas"\n', encoding="utf-8")
+    modulo = proyecto / "utilidades" / "fechas.co"
+    modulo.write_text("variable hoy = 13\n", encoding="utf-8")
+    rutas_cargadas = []
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        rutas_cargadas.append((Path(ruta), kwargs["modules_path"]))
+        return [NodoAsignacion("hoy", NodoValor(13), declaracion=True)]
+
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
+    monkeypatch.chdir(externo)
+
+    setup, _resultado = ejecutar_pipeline_explicito(
+        PipelineInput(
+            codigo=principal.read_text(encoding="utf-8"),
+            interpretador_cls=InterpretadorCobra,
+            safe_mode=False,
+            main_file=principal,
+        )
+    )
+
+    assert rutas_cargadas == [(modulo.resolve(), str(proyecto.resolve()))]
+    assert setup.interpretador.variables["hoy"] == 13
+    assert setup.interpretador._project_root == proyecto.resolve()
 
 
 def test_resolver_modulo_cobra_proyecto_usa_raiz_canonicalizada(tmp_path):


### PR DESCRIPTION
### Motivation
- Asegurar que la resolución de módulos de proyecto con `usar` funcione cuando la CLI/runtime generan código o ejecutan scripts desde un `cwd` distinto al proyecto. 
- Mantener la prioridad existente de resolución (`cobra.toml` ascendiendo → directorio del `main_file` → `cwd`) y reforzar la propagación de contexto donde faltaba. 

### Description
- Modifica el script sandbox canónico para siempre serializar `safe_mode` y `extra_validators` y adjuntar `main_file` cuando esté presente en `construir_script_sandbox_canonico` (`src/pcobra/cobra/cli/execution_pipeline.py`).
- Hace que `PythonAdapter` pase `source_file` y `project_root` al `TranspiladorPython` para que el código generado incluya `project_root`/`current_file` en llamadas a `usar_modulo()` (`src/pcobra/cobra/backends/python_adapter.py`).
- Propaga `project_root` desde `hints` en `backend_pipeline.build()` hacia `transpile()` para que pipelines que llaman al backend mantengan el contexto de proyecto (`src/pcobra/cobra/build/backend_pipeline.py`).
- Añade pruebas: una que ejecuta el pipeline desde un `cwd` externo verificando que `usar "utilidades.fechas"` se resuelve en la raíz del proyecto, y otra que valida que `PythonAdapter` genera código con `project_root`/`current_file` (`tests/unit/test_project_root_usar_resolution.py` y `tests/test_transpilers.py`).

### Testing
- Ejecuté `pytest -q tests/unit/test_project_root_usar_resolution.py tests/test_transpilers.py::test_transpilador_python_usar_proyecto_incluye_contexto_estable tests/test_transpilers.py::test_python_adapter_usar_proyecto_propaga_contexto_estable` y todas las pruebas enfocadas pasaron (`27-28 passed` según alcance local).
- Verifiqué compilación sintáctica con `python -m py_compile` sobre los módulos modificados y no se detectaron errores.
- Los cambios se agruparon en un commit con mensaje `Propaga contexto de proyecto para usar` y se creó este PR que contiene los archivos modificados listados arriba.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d2888b36883279803810c844ceed9)