### PR TITLE
Reforzar tests de seguridad para imports de proyecto

### DIFF
--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -10,6 +10,7 @@ from pcobra.cobra.usar_loader import (
     obtener_pila_carga_modulos_cobra_proyecto,
     resolver_modulo_cobra_proyecto,
     usar_modulo,
+    validar_nombre_modulo_cobra_proyecto,
 )
 from pcobra.core.interpreter import InterpretadorCobra
 
@@ -610,22 +611,86 @@ def test_import_archivo_co_mantiene_ejecutar_import(monkeypatch, tmp_path):
     assert llamadas == [(str(modulo), str(Path.home() / ".cobra" / "modules"))]
 
 
-def test_validacion_modulo_proyecto_acepta_puntos_y_rechaza_rutas_windows_posix():
-    import pytest
-    from pcobra.cobra.usar_loader import validar_nombre_modulo_cobra_proyecto
-
+def test_validacion_modulo_proyecto_acepta_puntos():
     assert validar_nombre_modulo_cobra_proyecto("utilidades.fechas") == ("utilidades", "fechas")
 
-    for nombre in ("..", "a/../b", "../b", r"C:\\x", "a\\b"):
-        with pytest.raises(ValueError):
-            validar_nombre_modulo_cobra_proyecto(nombre)
+
+@pytest.mark.parametrize(
+    "nombre",
+    [
+        "..",
+        "../externo",
+        "../externo.co",
+        "a/../b",
+        "a..b",
+        "utilidades..fechas",
+        ".oculto",
+        "utilidades.",
+        "/tmp/externo",
+        r"C:\\tmp\\externo",
+        "C:externo",
+        "a\\b",
+        "a/b",
+        "externo-co",
+        "externo@red",
+        "externo$",
+        "externo*",
+        "externo?",
+        "externo<privado>",
+        "externo|privado",
+        "externo;privado",
+        "externo`privado",
+        "externo privado",
+    ],
+)
+def test_validacion_modulo_proyecto_rechaza_traversal_rutas_y_caracteres_prohibidos(nombre):
+    with pytest.raises(ValueError):
+        validar_nombre_modulo_cobra_proyecto(nombre)
 
 
-def test_resolver_modulo_cobra_proyecto_bloquea_traversal_estable(tmp_path):
-    import pytest
+@pytest.mark.parametrize(
+    "nombre",
+    [
+        "..",
+        "../externo",
+        "../externo.co",
+        "a/../b",
+        "utilidades..fechas",
+    ],
+)
+def test_resolver_modulo_cobra_proyecto_rechaza_intentos_posix_de_escape(tmp_path, nombre):
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    externo = tmp_path / "externo.co"
+    externo.write_text("var secreto = 1\n", encoding="utf-8")
 
+    with pytest.raises(ValueError):
+        resolver_modulo_cobra_proyecto(nombre, project_root=proyecto)
+
+
+@pytest.mark.parametrize(
+    "nombre",
+    [
+        r"C:\\tmp\\externo",
+        "C:externo",
+        "a\\b",
+    ],
+)
+def test_resolver_modulo_cobra_proyecto_rechaza_rutas_windows_sin_depender_de_windows(tmp_path, nombre):
     proyecto = tmp_path / "app"
     proyecto.mkdir()
 
-    with pytest.raises(ValueError, match="traversal"):
-        resolver_modulo_cobra_proyecto("..", project_root=proyecto)
+    with pytest.raises(ValueError):
+        resolver_modulo_cobra_proyecto(nombre, project_root=proyecto)
+
+
+def test_resolver_modulo_cobra_proyecto_no_devuelve_symlink_fuera_de_project_root(tmp_path):
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    externo = tmp_path / "externo.co"
+    externo.write_text("var secreto = 1\n", encoding="utf-8")
+    enlace = proyecto / "escape.co"
+    enlace.symlink_to(externo)
+
+    with pytest.raises(ValueError, match="fuera de la raíz autorizada"):
+        resolver_modulo_cobra_proyecto("escape", project_root=proyecto)


### PR DESCRIPTION
### Motivation
- Aumentar la cobertura de validación y resolución de nombres de módulos de proyecto para prevenir path traversal y usos que parezcan rutas del sistema.
- Asegurar que la resolución canónica no devuelva rutas fuera de `project_root`, incluso si existen archivos/symlinks externos.

### Description
- Añadidos casos parametrizados en `tests/unit/test_project_root_usar_resolution.py` para nombres de módulo que contienen `../`, `..`, `/`, `\\`, `C:`, segmentos vacíos y caracteres prohibidos, validando el rechazo temprano por `validar_nombre_modulo_cobra_proyecto()`.
- Añadida prueba POSIX que crea un archivo externo (`externo.co`) y verifica que intentos como `../externo.co` son rechazados por `resolver_modulo_cobra_proyecto()`.
- Añadida prueba Windows-style (strings con `\\` y `C:`) que valida el rechazo sin depender de un sistema Windows real.
- Añadida prueba que crea un symlink dentro del proyecto apuntando a un `.co` externo y verifica que `resolver_modulo_cobra_proyecto()` no devuelve rutas fuera de `project_root`.

### Testing
- Ejecutado `pytest tests/unit/test_project_root_usar_resolution.py -q`, todos los tests añadidos y existentes pasaron ✅.
- Ejecutado `git diff --check` para validar formato y whitespace, sin problemas detectados ✅.
- Intentos de ejecutar una batería más amplia mostraron fallos preexistentes no introducidos por este cambio: `pytest tests/unit/test_usar_runtime_policy.py` falló en colección por imports legacy (`ImportError: attempted relative import beyond top-level package`) y `pytest tests/unit/test_usar_loader_public_api_contract.py` mostró un fallo no relacionado (`ValueError: too many values to unpack`); ambos errores quedaron documentados para inspección posterior ❌.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d60de27708327ba59224c73984b67)