### PR TITLE
Formatear ciclos de módulos con rutas relativas a project_root

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -297,14 +297,40 @@ def obtener_cache_ast_import_co() -> dict[Path, list[Any]]:
     return _IMPORT_CO_AST_CACHE
 
 
-def formatear_ciclo_modulos_cobra_proyecto(ruta_modulo: Path) -> str:
-    """Construye una cadena clara del ciclo usando rutas canónicas en la pila."""
+def _formatear_ruta_ciclo_modulo(ruta: Path, project_root: Path | None) -> str:
+    """Formatea una ruta de ciclo de forma estable y legible."""
+
+    try:
+        ruta_canonica = canonicalizar_ruta_usar_proyecto(ruta)
+    except (OSError, RuntimeError, ValueError):
+        return ruta.name or str(ruta)
+
+    if project_root is not None:
+        try:
+            raiz_canonica = canonicalizar_ruta_usar_proyecto(project_root)
+            return ruta_canonica.relative_to(raiz_canonica).as_posix()
+        except (OSError, RuntimeError, ValueError):
+            pass
+
+    return str(ruta_canonica) if str(ruta_canonica) else (ruta.name or str(ruta))
+
+
+def formatear_ciclo_modulos_cobra_proyecto(
+    ruta_modulo: Path,
+    *,
+    project_root: Path | None = None,
+    loading_stack: list[Path] | None = None,
+) -> str:
+    """Construye una cadena clara del ciclo usando rutas relativas si es posible."""
 
     ruta_canonica = canonicalizar_ruta_usar_proyecto(ruta_modulo)
-    pila = [canonicalizar_ruta_usar_proyecto(ruta) for ruta in _USAR_PROJECT_LOADING_STACK]
+    pila_origen = loading_stack if loading_stack is not None else _USAR_PROJECT_LOADING_STACK
+    pila = [canonicalizar_ruta_usar_proyecto(ruta) for ruta in pila_origen]
     ciclo = [*pila, ruta_canonica]
     inicio = ciclo.index(ruta_canonica)
-    return " -> ".join(ruta.name for ruta in ciclo[inicio:])
+    return " -> ".join(
+        _formatear_ruta_ciclo_modulo(ruta, project_root) for ruta in ciclo[inicio:]
+    )
 
 
 def _ascender_hasta_cobra_toml(candidato: Path | None) -> Path | None:
@@ -493,7 +519,9 @@ def _cargar_exports_modulo_cobra_proyecto(
         return _USAR_PROJECT_MODULE_CACHE[ruta_modulo]
 
     if ruta_modulo in _USAR_PROJECT_LOADING_STACK:
-        cadena = formatear_ciclo_modulos_cobra_proyecto(ruta_modulo)
+        cadena = formatear_ciclo_modulos_cobra_proyecto(
+            ruta_modulo, project_root=project_root
+        )
         raise ImportError(f"Ciclo de módulos detectado en usar: {cadena}")
 
     try:

--- a/src/pcobra/core/import_utils.py
+++ b/src/pcobra/core/import_utils.py
@@ -109,7 +109,11 @@ def cargar_ast_modulo(
 
     if loading_stack is not None:
         if ruta_real_path in loading_stack:
-            cadena = formatear_ciclo_modulos_cobra_proyecto(ruta_real_path)
+            cadena = formatear_ciclo_modulos_cobra_proyecto(
+                ruta_real_path,
+                project_root=Path(modules_path) if modules_path is not None else None,
+                loading_stack=loading_stack,
+            )
             raise ImportError(f"Ciclo de módulos detectado en import: {cadena}")
         loading_stack.append(ruta_real_path)
 

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -6,6 +6,7 @@ import pytest
 from pcobra.cobra.cli.execution_pipeline import PipelineInput, ejecutar_pipeline_explicito
 from pcobra.cobra.usar_loader import (
     descubrir_raiz_proyecto,
+    formatear_ciclo_modulos_cobra_proyecto,
     obtener_cache_modulos_cobra_proyecto,
     obtener_pila_carga_modulos_cobra_proyecto,
     resolver_modulo_cobra_proyecto,
@@ -32,6 +33,41 @@ def limpiar_estado_usar_proyecto_compartido():
     obtener_cache_modulos_cobra_proyecto().clear()
     obtener_pila_carga_modulos_cobra_proyecto().clear()
 
+
+def test_formatear_ciclo_modulos_usa_rutas_relativas_en_subcarpetas(tmp_path):
+    proyecto = tmp_path / "app"
+    anidados = proyecto / "utilidades" / "internas"
+    anidados.mkdir(parents=True)
+    modulo_a = anidados / "a.co"
+    modulo_b = anidados / "b.co"
+    modulo_a.write_text("", encoding="utf-8")
+    modulo_b.write_text("", encoding="utf-8")
+
+    cadena = formatear_ciclo_modulos_cobra_proyecto(
+        modulo_a,
+        project_root=proyecto,
+        loading_stack=[modulo_a, modulo_b],
+    )
+
+    assert (
+        cadena
+        == "utilidades/internas/a.co -> utilidades/internas/b.co -> "
+        "utilidades/internas/a.co"
+    )
+
+def test_formatear_ciclo_modulos_fallback_canonico_fuera_de_project_root(tmp_path):
+    proyecto = tmp_path / "app"
+    externo = tmp_path / "externo"
+    proyecto.mkdir()
+    externo.mkdir()
+    modulo = externo / "a.co"
+    modulo.write_text("", encoding="utf-8")
+
+    cadena = formatear_ciclo_modulos_cobra_proyecto(
+        modulo, project_root=proyecto, loading_stack=[modulo]
+    )
+
+    assert cadena == f"{modulo.resolve()} -> {modulo.resolve()}"
 
 def test_descubrir_raiz_proyecto_prefiere_cobra_toml_desde_archivo_principal(tmp_path):
     proyecto = tmp_path / "app"
@@ -226,7 +262,10 @@ def test_interpretador_usar_proyecto_detecta_ciclos_con_rutas_canonicas(monkeypa
     try:
         interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.a"))
     except ImportError as exc:
-        assert str(exc) == "Ciclo de módulos detectado en usar: a.co -> b.co -> a.co"
+        assert str(exc) == (
+            "Ciclo de módulos detectado en usar: "
+            "utilidades/a.co -> utilidades/b.co -> utilidades/a.co"
+        )
     else:
         raise AssertionError("Se esperaba un ImportError por ciclo de módulos")
     assert interp._usar_loading_stack == []
@@ -303,7 +342,7 @@ def test_usar_modulo_api_resuelve_util_misma_carpeta(monkeypatch, tmp_path):
     from pcobra.core.ast_nodes import NodoAsignacion, NodoValor
 
     proyecto = tmp_path / "app"
-    proyecto.mkdir()
+    (proyecto / "utilidades" / "internas").mkdir(parents=True)
     (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
     principal = proyecto / "main.co"
     principal.write_text("", encoding="utf-8")
@@ -540,17 +579,25 @@ def test_interpretador_usar_proyecto_detecta_ciclo_directo_self(monkeypatch, tmp
     (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
     principal = proyecto / "main.co"
     principal.write_text("", encoding="utf-8")
-    modulo = proyecto / "a.co"
+    anidados = proyecto / "utilidades" / "internas"
+    anidados.mkdir(parents=True)
+    modulo = anidados / "a.co"
     modulo.write_text("", encoding="utf-8")
 
     monkeypatch.setattr(
         "pcobra.core.import_utils.cargar_ast_modulo",
-        lambda _ruta, **_kwargs: [NodoUsar("a")],
+        lambda _ruta, **_kwargs: [NodoUsar("utilidades.internas.a")],
     )
 
     interp = InterpretadorCobra(safe_mode=False, main_file=principal)
-    with pytest.raises(ImportError, match=r"Ciclo de módulos detectado en usar: a\.co -> a\.co"):
-        interp.ejecutar_usar(SimpleNamespace(modulo="a"))
+    with pytest.raises(
+        ImportError,
+        match=(
+            r"Ciclo de módulos detectado en usar: "
+            r"utilidades/internas/a\.co -> utilidades/internas/a\.co"
+        ),
+    ):
+        interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.internas.a"))
 
 
 def test_interpretador_usar_proyecto_detecta_ciclo_indirecto(monkeypatch, tmp_path):
@@ -558,15 +605,21 @@ def test_interpretador_usar_proyecto_detecta_ciclo_indirecto(monkeypatch, tmp_pa
     import pytest
 
     proyecto = tmp_path / "app"
-    proyecto.mkdir()
+    (proyecto / "utilidades" / "internas").mkdir(parents=True)
     (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
     principal = proyecto / "main.co"
     principal.write_text("", encoding="utf-8")
     for nombre in ("a", "b", "c"):
-        (proyecto / f"{nombre}.co").write_text("", encoding="utf-8")
+        (proyecto / "utilidades" / "internas" / f"{nombre}.co").write_text(
+            "", encoding="utf-8"
+        )
 
     def fake_cargar_ast_modulo(ruta, **kwargs):
-        siguiente = {"a.co": "b", "b.co": "c", "c.co": "a"}[Path(ruta).name]
+        siguiente = {
+            "a.co": "utilidades.internas.b",
+            "b.co": "utilidades.internas.c",
+            "c.co": "utilidades.internas.a",
+        }[Path(ruta).name]
         return [NodoUsar(siguiente)]
 
     monkeypatch.setattr(
@@ -574,8 +627,14 @@ def test_interpretador_usar_proyecto_detecta_ciclo_indirecto(monkeypatch, tmp_pa
     )
 
     interp = InterpretadorCobra(safe_mode=False, main_file=principal)
-    with pytest.raises(ImportError, match=r"a\.co -> b\.co -> c\.co -> a\.co"):
-        interp.ejecutar_usar(SimpleNamespace(modulo="a"))
+    with pytest.raises(
+        ImportError,
+        match=(
+            r"utilidades/internas/a\.co -> utilidades/internas/b\.co -> "
+            r"utilidades/internas/c\.co -> utilidades/internas/a\.co"
+        ),
+    ):
+        interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.internas.a"))
 
 
 def test_interpretador_usar_proyecto_modulo_inexistente_muestra_nombre_y_ruta(tmp_path):


### PR DESCRIPTION
### Motivation
- Hacer los mensajes de detección de ciclos más legibles usando rutas relativas a `project_root` siempre que sea posible. 
- Mantener un fallback seguro a ruta canónica o nombre de archivo si `relative_to()` o la canonicalización fallan, y unificar el formato entre runtime y backend Python.

### Description
- Añadido `_formatear_ruta_ciclo_modulo` para formatear de forma estable cada ruta del ciclo y devolver la ruta relativa a `project_root` con `.relative_to(...).as_posix()` cuando aplica, y fallback a ruta canónica o `ruta.name` en caso de error. (`src/pcobra/cobra/usar_loader.py`).
- Extendida `formatear_ciclo_modulos_cobra_proyecto` para aceptar `project_root` y `loading_stack` opcionales y usar el nuevo formateador en la construcción de la cadena de ciclo; soporta tanto la pila global como una pila explícita pasada por callers. (`src/pcobra/cobra/usar_loader.py`).
- Actualizado el runtime de `usar` para pasar `project_root` cuando se construye el mensaje de ciclo, garantizando el mismo formato en tiempo de ejecución. (`src/pcobra/cobra/usar_loader.py`).
- Reutilizado el formateador desde el backend de carga Python en `cargar_ast_modulo`, pasando `modules_path` como `project_root` y la `loading_stack` explícita para que los errores de import muestren el mismo formato. (`src/pcobra/core/import_utils.py`).
- Añadidos y adaptados tests unitarios en `tests/unit/test_project_root_usar_resolution.py` para cubrir ciclos directos e indirectos en subcarpetas anidadas y verificar el fallback cuando el módulo está fuera de `project_root`.

### Testing
- Ejecutado `pytest -q tests/unit/test_project_root_usar_resolution.py` y las pruebas unitarias relacionadas pasaron exitosamente (`63 passed, 1 warning`).
- Se ejecutaron pruebas de integración focales inicialmente y se detectaron fallos (2 tests fallaron) antes de ajustar los tests y la integración del formateador; tras los ajustes los tests unitarios añadidos y existentes pasaron.
- Verificado `git diff --check` sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d896882b48327ba24bbdd886c11db)