### PR TITLE
tests: cobertura para caché canónica de `usar` con `project_root` equivalentes

### DIFF
--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -10,6 +10,7 @@ from pcobra.cobra.usar_loader import (
     obtener_cache_modulos_cobra_proyecto,
     obtener_pila_carga_modulos_cobra_proyecto,
     resolver_modulo_cobra_proyecto,
+    resolver_ruta_canonica_modulo_cobra_proyecto,
     usar_modulo,
     validar_nombre_modulo_cobra_proyecto,
 )
@@ -535,6 +536,61 @@ def test_interpretador_usar_proyecto_cachea_referencias_equivalentes(monkeypatch
     assert cargas == [modulo.resolve()]
     assert interp.variables["valor"] == 1
 
+
+
+def test_resolver_ruta_canonica_modulo_cobra_proyecto_normaliza_project_root_equivalente(tmp_path):
+    proyecto = tmp_path / "app"
+    subdir = proyecto / "subdir"
+    modulo = proyecto / "utilidades" / "fechas.co"
+    subdir.mkdir(parents=True)
+    modulo.parent.mkdir(parents=True)
+    modulo.write_text("", encoding="utf-8")
+
+    ruta_desde_root = resolver_ruta_canonica_modulo_cobra_proyecto(
+        "utilidades.fechas", project_root=proyecto
+    )
+    ruta_desde_root_equivalente = resolver_ruta_canonica_modulo_cobra_proyecto(
+        "utilidades.fechas", project_root=subdir / ".."
+    )
+
+    assert ruta_desde_root == modulo.resolve()
+    assert ruta_desde_root_equivalente == modulo.resolve()
+    assert ruta_desde_root_equivalente == ruta_desde_root
+
+
+def test_usar_modulo_cachea_referencias_equivalentes_al_mismo_co(monkeypatch, tmp_path):
+    from pcobra.core.ast_nodes import NodoAsignacion, NodoValor
+
+    proyecto = tmp_path / "app"
+    subdir = proyecto / "subdir"
+    modulo = proyecto / "utilidades" / "fechas.co"
+    subdir.mkdir(parents=True)
+    modulo.parent.mkdir(parents=True)
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo.write_text("", encoding="utf-8")
+    cargas = []
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        cargas.append((Path(ruta).resolve(strict=False), kwargs["modules_path"]))
+        return [NodoAsignacion("hoy", NodoValor(len(cargas)), declaracion=True)]
+
+    monkeypatch.setattr(
+        "pcobra.core.import_utils.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
+
+    exports_root = usar_modulo(
+        "utilidades.fechas", project_root=proyecto, current_file=principal
+    )
+    exports_root_equivalente = usar_modulo(
+        "utilidades.fechas", project_root=subdir / "..", current_file=principal
+    )
+
+    assert exports_root["hoy"] == 1
+    assert exports_root_equivalente["hoy"] == 1
+    assert cargas == [(modulo.resolve(), str(proyecto.resolve()))]
+    assert list(obtener_cache_modulos_cobra_proyecto()) == [modulo.resolve()]
 
 def test_api_e_interpretador_comparten_cache_por_ruta_canonica(monkeypatch, tmp_path):
     from pcobra.core.ast_nodes import NodoAsignacion, NodoValor


### PR DESCRIPTION
### Motivation
- Asegurar que referencias equivalentes a la misma raíz de proyecto (por ejemplo `project_root` y `project_root / "subdir" / ".."`) se canonicalizan y comparten una única entrada de caché para módulos Cobra de proyecto.
- Verificar que la carga real de AST (`cargar_ast_modulo`) se realiza una sola vez para referencias equivalentes y que la semántica legacy de `import 'archivo.co'` permanece separada.

### Description
- Añadí dos tests unitarios en `tests/unit/test_project_root_usar_resolution.py`: uno para `resolver_ruta_canonica_modulo_cobra_proyecto` y otro para comprobar que `usar_modulo` cachea referencias equivalentes al mismo `.co` y que solo llama una vez a `cargar_ast_modulo`.
- Importé `resolver_ruta_canonica_modulo_cobra_proyecto` en el módulo de tests y añadí asserts que comparan rutas resueltas desde `project_root` y desde una ruta equivalente con `..`.
- Confirmé en la revisión del código que `_cargar_exports_modulo_cobra_proyecto` usa el resultado de `resolver_ruta_canonica_modulo_cobra_proyecto` como clave en `_USAR_PROJECT_MODULE_CACHE` para lectura y escritura, manteniendo la caché por `Path` canónico.
- No se cambiaron las rutas de ejecución ni la semántica de `import 'archivo.co'`, que sigue usando el loader/flujo legacy probado por la suite existente.

### Testing
- Ejecuté `pytest -q tests/unit/test_project_root_usar_resolution.py` y los tests unitarios añadidos y existentes pasaron correctamente.
- Intenté ejecutar `pytest -q tests/integration/test_usar_project_modules.py`, pero la ejecución no pudo completarse debido a limitación de entorno con `MemoryError` / `OSError: [Errno 12] Cannot allocate memory`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e3467b19c8327b453df33f3c0a523)