### PR TITLE
Endurece validación y canonicalización de rutas para `usar` de proyecto

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -176,9 +176,20 @@ def validar_nombre_modulo_cobra_proyecto(nombre: str) -> tuple[str, ...]:
     if not nombre_raw:
         raise ValueError("Nombre de módulo de proyecto vacío.")
 
+    # `usar` de proyecto acepta únicamente rutas lógicas punteadas, nunca rutas
+    # del sistema. Bloqueamos separadores POSIX/Windows, traversal, rutas
+    # absolutas y cualquier forma de unidad Windows antes de resolver.
     if any(sep in nombre_raw for sep in ("/", "\\")):
         raise ValueError(
             f"Nombre de módulo de proyecto inválido: '{nombre_raw}' no debe contener separadores de ruta."
+        )
+    if ".." in nombre_raw:
+        raise ValueError(
+            f"Nombre de módulo de proyecto inválido: '{nombre_raw}' contiene traversal."
+        )
+    if os.path.isabs(nombre_raw) or re.match(r"^[A-Za-z]:", nombre_raw):
+        raise ValueError(
+            f"Nombre de módulo de proyecto inválido: '{nombre_raw}' parece una ruta absoluta o unidad Windows."
         )
 
     segmentos = nombre_raw.split(".")
@@ -207,12 +218,14 @@ def validar_nombre_modulo_cobra_proyecto(nombre: str) -> tuple[str, ...]:
 def _verificar_path_dentro_de_root(ruta: Path, root: Path) -> None:
     """Verifica con rutas canónicas que ``ruta`` queda dentro de ``root``."""
 
+    root_canonico = canonicalizar_ruta_usar_proyecto(root)
+    ruta_canonica = canonicalizar_ruta_usar_proyecto(ruta)
     try:
-        common = os.path.commonpath((str(root), str(ruta)))
+        common = os.path.commonpath((str(root_canonico), str(ruta_canonica)))
     except ValueError as exc:
         raise ValueError("Ruta de módulo de proyecto fuera de la raíz autorizada.") from exc
 
-    if common != str(root):
+    if common != str(root_canonico):
         raise ValueError("Ruta de módulo de proyecto fuera de la raíz autorizada.")
 
 

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -712,6 +712,36 @@ def test_interpretador_usar_proyecto_modulo_inexistente_muestra_nombre_y_ruta(tm
     assert str(ruta_buscada) in mensaje
 
 
+def test_resolver_modulo_cobra_proyecto_rechaza_resultado_manipulado_fuera_de_root(
+    monkeypatch, tmp_path
+):
+    from pcobra.cobra import usar_loader
+    from pcobra.cobra.imports.resolver import ResolutionResult
+
+    proyecto = tmp_path / "app"
+    externo = tmp_path / "externo"
+    proyecto.mkdir()
+    externo.mkdir()
+    ruta_externa = externo / "fechas.co"
+    ruta_externa.write_text("", encoding="utf-8")
+
+    class FakeResolver:
+        def __init__(self, **_kwargs):
+            pass
+
+        def resolve(self, nombre):
+            return ResolutionResult(
+                request=nombre,
+                source="project",
+                resolved_name=nombre,
+                file_path=str(ruta_externa),
+            )
+
+    monkeypatch.setattr(usar_loader, "CobraImportResolver", FakeResolver)
+
+    with pytest.raises(ValueError, match="fuera de la raíz autorizada"):
+        resolver_modulo_cobra_proyecto("utilidades.fechas", project_root=proyecto)
+
 def test_import_archivo_co_mantiene_ejecutar_import(monkeypatch, tmp_path):
     principal = tmp_path / "main.co"
     principal.write_text("", encoding="utf-8")

--- a/tests/unit/test_usar_loader_validation.py
+++ b/tests/unit/test_usar_loader_validation.py
@@ -4,7 +4,11 @@ import importlib
 
 import pytest
 
-from pcobra.cobra.usar_loader import validar_nombre_modulo_usar
+from pcobra.cobra.usar_loader import (
+    _verificar_path_dentro_de_root,
+    validar_nombre_modulo_cobra_proyecto,
+    validar_nombre_modulo_usar,
+)
 from pcobra.cobra.usar_policy import REPL_COBRA_MODULE_MAP, USAR_COBRA_FACING_MODULE_FLAGS
 
 
@@ -85,6 +89,12 @@ def test_resolver_modulo_cobra_proyecto_convierte_nombre_punteado_en_co(tmp_path
         ".utilidades",
         "utilidades.",
         "../secreto",
+        "a/../b",
+        "/tmp/x",
+        r"C:\tmp\x",
+        "C:tmp",
+        r"a\b",
+        "a/b",
         "utilidades/fechas",
         r"utilidades\\fechas",
         "C:secreto",
@@ -124,6 +134,24 @@ def test_resolver_modulo_cobra_proyecto_valida_current_file_dentro_de_root(tmp_p
             current_file=externo,
         )
 
+
+
+@pytest.mark.parametrize(
+    "nombre",
+    ["../secreto", "a/../b", "/tmp/x", r"C:\tmp\x", "C:tmp", r"a\b", "a/b"],
+)
+def test_validar_nombre_modulo_cobra_proyecto_rechaza_rutas_manipuladas(nombre):
+    with pytest.raises(ValueError):
+        validar_nombre_modulo_cobra_proyecto(nombre)
+
+
+def test_verificar_path_dentro_de_root_canonicaliza_antes_de_commonpath(tmp_path):
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    ruta_manipulada = proyecto / "subdir" / ".." / ".." / "secreto.co"
+
+    with pytest.raises(ValueError, match="fuera de la raíz autorizada"):
+        _verificar_path_dentro_de_root(ruta_manipulada, proyecto)
 
 def test_validacion_oficial_sigue_rechazando_nombres_punteados():
     with pytest.raises(ValueError):


### PR DESCRIPTION
### Motivation
- Evitar que entradas de `usar` permitan rutas del sistema o traversal que puedan resolverse fuera de la raíz del proyecto.
- Asegurar que la comprobación de pertenencia al `project_root` compare rutas canonicalizadas para no ser burlada por symlinks o segmentos manipulados.

### Description
- Refuerza `validar_nombre_modulo_cobra_proyecto` para rechazar nombres que contengan `/`, `\`, `..`, rutas absolutas (`os.path.isabs`) o patrones de unidad Windows (`^[A-Za-z]:`).
- Ajusta `_verificar_path_dentro_de_root` para canonicalizar tanto `root` como `ruta` usando `canonicalizar_ruta_usar_proyecto` antes de comparar con `os.path.commonpath`.
- Añade pruebas parametrizadas que ejercitan nombres manipulados: `../secreto`, `a/../b`, `/tmp/x`, `C:\tmp\x`, `C:tmp`, `a\b` y `a/b`.
- Añade una prueba que simula un `CobraImportResolver` malicioso devolviendo una ruta externa y verifica que `resolver_modulo_cobra_proyecto` la rechaza; esto confirma que ninguna ruta de `usar` puede resolverse fuera de `project_root` incluso si el resolvedor devuelve una ruta manipulada.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar_loader_validation.py` y la suite relevante pasó (`34 passed`).
- Ejecuté la prueba aislada `tests/unit/test_project_root_usar_resolution.py::test_resolver_modulo_cobra_proyecto_rechaza_resultado_manipulado_fuera_de_root` y pasó (1 passed).
- Intenté ejecutar ambas colecciones juntas y en este entorno apareció un `MemoryError` al ejecutar pruebas más amplias que parsean contratos stdlib vía `ast.parse`, pero las pruebas nuevas y específicas añadidas por este cambio pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e446b1b0c8327a74926308e07160a)