### PR TITLE
Mejora 'usar' para módulos Cobra de proyecto: detección de ciclos y saneamiento de exports

### DIFF
--- a/src/pcobra/cobra/transpilers/transpiler/python_nodes/usar.py
+++ b/src/pcobra/cobra/transpilers/transpiler/python_nodes/usar.py
@@ -7,5 +7,6 @@ def visit_usar(self, nodo):
     llamada = f"usar_modulo({', '.join(args)})"
     self.codigo += (
         f"{ind}from pcobra.cobra.usar_loader import usar_modulo\n"
-        f"{ind}globals().update({llamada})\n"
+        f"{ind}_usar_exports = {llamada}\n"
+        f"{ind}globals().update(dict(_usar_exports.get('simbolos', [])))\n"
     )

--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -530,7 +530,7 @@ def _cargar_exports_modulo_cobra_proyecto(
     from pcobra.core.environment import Environment
     from pcobra.core.import_utils import cargar_ast_modulo
     from pcobra.core.interpreter import InterpretadorCobra
-    from pcobra.core.ast_nodes import NodoExport
+    from pcobra.core.ast_nodes import NodoExport, NodoUsar
 
     ruta_modulo = resolver_ruta_canonica_modulo_cobra_proyecto(
         nombre,
@@ -556,6 +556,7 @@ def _cargar_exports_modulo_cobra_proyecto(
     except FileNotFoundError as exc:
         raise FileNotFoundError(f"Módulo no encontrado: {nombre}") from exc
 
+    _USAR_PROJECT_LOADING_STACK.append(ruta_modulo)
     interpretador = InterpretadorCobra(
         safe_mode=False, main_file=current_file or ruta_modulo
     )
@@ -566,11 +567,22 @@ def _cargar_exports_modulo_cobra_proyecto(
     interpretador._current_module_stack.append(ruta_modulo)
     interpretador.contextos.append(Environment(parent=interpretador.contextos[-1]))
     interpretador.mem_contextos.append({})
-    _USAR_PROJECT_LOADING_STACK.append(ruta_modulo)
     try:
         for subnodo in ast:
             if isinstance(subnodo, NodoExport):
                 continue
+            if isinstance(subnodo, NodoUsar) or subnodo.__class__.__name__ == "NodoUsar":
+                modulo_hijo = str(subnodo.modulo).strip().strip('\"\'')
+                ruta_hijo = resolver_ruta_canonica_modulo_cobra_proyecto(
+                    modulo_hijo,
+                    project_root=project_root,
+                    current_file=ruta_modulo,
+                )
+                if ruta_hijo in _USAR_PROJECT_LOADING_STACK:
+                    cadena = formatear_ciclo_modulos_cobra_proyecto(
+                        ruta_hijo, project_root=project_root
+                    )
+                    raise ImportError(f"Ciclo de módulos detectado en usar: {cadena}")
             interpretador.ejecutar_nodo(subnodo)
         exports = _extraer_exports_modulo_cobra_proyecto(
             ast,

--- a/tests/test_transpilers.py
+++ b/tests/test_transpilers.py
@@ -47,7 +47,8 @@ def test_transpilador_python_usar_invoca_api_canonica() -> None:
     codigo = transpiler.generate_code([nodo])
 
     assert "from pcobra.cobra.usar_loader import usar_modulo" in codigo
-    assert "globals().update(usar_modulo('texto'))" in codigo
+    assert "_usar_exports = usar_modulo('texto')" in codigo
+    assert "globals().update(dict(_usar_exports.get('simbolos', [])))" in codigo
     assert "obtener_modulo" not in codigo
 
 
@@ -58,7 +59,8 @@ def test_transpilador_python_usar_punteado_genera_usar_modulo_sin_parser() -> No
     codigo = TranspiladorPython().generate_code([nodo])
 
     assert "from pcobra.cobra.usar_loader import usar_modulo" in codigo
-    assert "globals().update(usar_modulo('utilidades.fechas'))" in codigo
+    assert "_usar_exports = usar_modulo('utilidades.fechas')" in codigo
+    assert "globals().update(dict(_usar_exports.get('simbolos', [])))" in codigo
     assert "obtener_modulo" not in codigo
 
 
@@ -208,9 +210,9 @@ def test_transpilador_python_usar_proyecto_incluye_contexto_estable(tmp_path, mo
 
     assert "from pcobra.cobra.usar_loader import usar_modulo" in codigo
     assert (
-        "globals().update(usar_modulo("
+        "_usar_exports = usar_modulo("
         f"'utilidades.fechas', project_root={str(proyecto.resolve())!r}, "
-        f"current_file={str(principal.resolve())!r}))"
+        f"current_file={str(principal.resolve())!r})"
     ) in codigo
     assert llamadas == [
         (
@@ -279,9 +281,9 @@ def test_python_adapter_usar_proyecto_propaga_contexto_estable(tmp_path) -> None
     )
 
     assert (
-        "globals().update(usar_modulo("
+        "_usar_exports = usar_modulo("
         f"'utilidades.fechas', project_root={str(proyecto.resolve())!r}, "
-        f"current_file={str(principal.resolve())!r}))"
+        f"current_file={str(principal.resolve())!r})"
     ) in codigo
 
 


### PR DESCRIPTION
### Motivation
- Evitar ciclos y estado parcial al cargar módulos Cobra de proyecto detectando rutas hijas antes de ejecutar nodos y manteniendo una pila de carga consistente. 
- Reducir la exposición de metadata interna en el código transpilado para el backend Python, inyectando únicamente los símbolos exportables en `globals()`.
- Asegurar que estos cambios no toquen archivos de lexer/parser/gramática ni la definición de tokens.

### Description
- En `src/pcobra/cobra/usar_loader.py` se añade el módulo actual a la pila de carga antes de ejecutar nodos y se resuelven las rutas canónicas de cada `NodoUsar` hijo para detectar y reportar ciclos de módulos antes de la ejecución. 
- En `src/pcobra/cobra/transpilers/transpiler/python_nodes/usar.py` el `visit_usar` ahora asigna `_usar_exports = usar_modulo(...)` y realiza `globals().update(dict(_usar_exports.get('simbolos', [])))` para inyectar solo símbolos exportables en el código Python generado. 
- Se actualizaron expectativas en `tests/test_transpilers.py` para reflejar el nuevo patrón de generación (`_usar_exports` + inyección de `simbolos`). 
- No se modificaron archivos de lexer, parser ni gramáticas; la revisión incluye una comprobación explícita para confirmar que no hay diffs en esos ficheros.

### Testing
- Ejecuté `pytest -q tests/integration/test_usar_project_modules.py` y la suite pasó (14 passed, 1 warning). 
- Ejecuté `pytest -q tests/test_transpilers.py` y la suite pasó (14 passed, 1 warning). 
- Ejecuté `pytest -q tests/unit/test_usar_loader_validation.py` y la suite pasó (34 passed, 1 warning). 
- Intenté ejecutar varias suites en un único comando, pero el intento combinado falló con `MemoryError`/`OSError: Cannot allocate memory` durante la limpieza de `/tmp/pytest-of-root`; por ello las suites relevantes fueron ejecutadas por separado y todas pasaron individualmente. 
- Verifiqué con `git diff --name-only -- src/pcobra/core/lexer.py src/pcobra/core/parser.py src/pcobra/cobra/core/parser.py ':(glob)**/*.lark' ':(glob)**/*.grammar' ':(glob)**/*.g4'` que no hay cambios en lexer/parser/gramáticas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e5470e5e883279fb31d9650c41c0d)