### PR TITLE
Endure resolver_modulo_cobra_proyecto: rutas canónicas y validación estricta

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -258,6 +258,11 @@ def resolver_modulo_cobra_proyecto(
         ruta_directa = canonicalizar_ruta_usar_proyecto(ruta_directa)
         _verificar_path_dentro_de_root(ruta_directa, root_resuelto)
         return ruta_directa
+
+    # Compatibilidad legacy: el resolver histórico sólo puede actuar como
+    # fallback cuando haya sido sustituido explícitamente por un caller/test.
+    # La ruta principal y estable para `usar utilidades.fechas` es siempre:
+    # `project_root / "utilidades" / "fechas.co"`.
     if getattr(CobraImportResolver, "__module__", "") == "pcobra.cobra.imports.resolver":
         raise FileNotFoundError(f"Módulo no encontrado: {nombre}")
 
@@ -274,7 +279,7 @@ def resolver_modulo_cobra_proyecto(
     if resolution.source != "project" or not resolution.file_path:
         raise FileNotFoundError(f"Módulo no encontrado: {nombre}")
 
-    ruta_resuelta = Path(resolution.file_path)
+    ruta_resuelta = canonicalizar_ruta_usar_proyecto(resolution.file_path)
     _verificar_path_dentro_de_root(ruta_resuelta, root_resuelto)
 
     return ruta_resuelta
@@ -532,37 +537,45 @@ def _cargar_exports_modulo_cobra_proyecto(
     from pcobra.core.interpreter import InterpretadorCobra
     from pcobra.core.ast_nodes import NodoExport, NodoUsar
 
+    root_canonico = canonicalizar_ruta_usar_proyecto(project_root)
+    current_canonico = (
+        canonicalizar_ruta_usar_proyecto(current_file) if current_file else None
+    )
+    if current_canonico is not None:
+        _verificar_path_dentro_de_root(current_canonico, root_canonico)
+
     ruta_modulo = resolver_ruta_canonica_modulo_cobra_proyecto(
         nombre,
-        project_root=project_root,
-        current_file=current_file,
+        project_root=root_canonico,
+        current_file=current_canonico,
     )
+    _verificar_path_dentro_de_root(ruta_modulo, root_canonico)
 
     if ruta_modulo in _USAR_PROJECT_MODULE_CACHE:
         return _USAR_PROJECT_MODULE_CACHE[ruta_modulo]
 
     if ruta_modulo in _USAR_PROJECT_LOADING_STACK:
         cadena = formatear_ciclo_modulos_cobra_proyecto(
-            ruta_modulo, project_root=project_root
+            ruta_modulo, project_root=root_canonico
         )
         raise ImportError(f"Ciclo de módulos detectado en usar: {cadena}")
 
     try:
         ast = cargar_ast_modulo(
             str(ruta_modulo),
-            modules_path=str(project_root),
-            whitelist={project_root},
+            modules_path=str(root_canonico),
+            whitelist={root_canonico},
         )
     except FileNotFoundError as exc:
         raise FileNotFoundError(f"Módulo no encontrado: {nombre}") from exc
 
     _USAR_PROJECT_LOADING_STACK.append(ruta_modulo)
     interpretador = InterpretadorCobra(
-        safe_mode=False, main_file=current_file or ruta_modulo
+        safe_mode=False, main_file=current_canonico or ruta_modulo
     )
-    interpretador._project_root = canonicalizar_ruta_usar_proyecto(project_root)
+    interpretador._project_root = root_canonico
     interpretador._main_file = (
-        canonicalizar_ruta_usar_proyecto(current_file) if current_file else ruta_modulo
+        current_canonico if current_canonico else ruta_modulo
     )
     interpretador._current_module_stack.append(ruta_modulo)
     interpretador.contextos.append(Environment(parent=interpretador.contextos[-1]))
@@ -575,12 +588,13 @@ def _cargar_exports_modulo_cobra_proyecto(
                 modulo_hijo = str(subnodo.modulo).strip().strip('\"\'')
                 ruta_hijo = resolver_ruta_canonica_modulo_cobra_proyecto(
                     modulo_hijo,
-                    project_root=project_root,
+                    project_root=root_canonico,
                     current_file=ruta_modulo,
                 )
+                _verificar_path_dentro_de_root(ruta_hijo, root_canonico)
                 if ruta_hijo in _USAR_PROJECT_LOADING_STACK:
                     cadena = formatear_ciclo_modulos_cobra_proyecto(
-                        ruta_hijo, project_root=project_root
+                        ruta_hijo, project_root=root_canonico
                     )
                     raise ImportError(f"Ciclo de módulos detectado en usar: {cadena}")
             interpretador.ejecutar_nodo(subnodo)

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -742,6 +742,43 @@ def test_resolver_modulo_cobra_proyecto_rechaza_resultado_manipulado_fuera_de_ro
     with pytest.raises(ValueError, match="fuera de la raíz autorizada"):
         resolver_modulo_cobra_proyecto("utilidades.fechas", project_root=proyecto)
 
+
+def test_resolver_modulo_cobra_proyecto_fallback_devuelve_ruta_canonica(
+    monkeypatch, tmp_path
+):
+    from pcobra.cobra import usar_loader
+    from pcobra.cobra.imports.resolver import ResolutionResult
+
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    ruta_modulo = proyecto / "utilidades" / "fechas.co"
+    ruta_modulo.parent.mkdir()
+    ruta_modulo.write_text("", encoding="utf-8")
+
+    class FakeResolver:
+        def __init__(self, **_kwargs):
+            pass
+
+        def resolve(self, nombre):
+            ruta_legacy = (
+                proyecto / "." / "utilidades" / ".." / "utilidades" / "fechas.co"
+            )
+            return ResolutionResult(
+                request=nombre,
+                source="project",
+                resolved_name=nombre,
+                file_path=str(ruta_legacy),
+            )
+
+    ruta_modulo.unlink()
+    monkeypatch.setattr(usar_loader, "CobraImportResolver", FakeResolver)
+
+    assert (
+        resolver_modulo_cobra_proyecto("utilidades.fechas", project_root=proyecto)
+        == ruta_modulo.resolve(strict=False)
+    )
+
+
 def test_import_archivo_co_mantiene_ejecutar_import(monkeypatch, tmp_path):
     principal = tmp_path / "main.co"
     principal.write_text("", encoding="utf-8")


### PR DESCRIPTION
### Motivation

- Evitar rutas inesperadas o no canónicas al resolver módulos de proyecto y asegurar que la ruta principal para `usar utilidades.fechas` sea siempre `project_root / "utilidades" / "fechas.co"`.
- Limitar el uso de `CobraImportResolver` como fallback legacy solo cuando sea necesario y garantizar que cualquier ruta devuelta por él se canonicalice y se valide.
- Forzar que todas las rutas usadas internamente pasen por `canonicalizar_ruta_usar_proyecto` y por `_verificar_path_dentro_de_root` para evitar escapes fuera de la raíz del proyecto.

### Description

- Reforzado `resolver_modulo_cobra_proyecto` para preferir la ruta directa `project_root / <segmentos> / <archivo>.co` y documentar que el resolver histórico (`CobraImportResolver`) actúa solo como fallback; cualquier resultado de fallback ahora se canonicaliza mediante `canonicalizar_ruta_usar_proyecto` y se valida con `_verificar_path_dentro_de_root` antes de devolverse.
- En `_cargar_exports_modulo_cobra_proyecto` canonicalizo `project_root` y `current_file` al inicio, verifico que `current_file` esté dentro de `project_root`, paso las rutas canónicas a `cargar_ast_modulo` (modules_path y whitelist) y revalido las rutas hijas (`ruta_hijo`) antes de ejecutar nodos y formar mensajes de ciclo.
- Añadida prueba de regresión `test_resolver_modulo_cobra_proyecto_fallback_devuelve_ruta_canonica` que simula un fallback legacy que devuelve una ruta no normalizada y verifica que la función devuelve la ruta canónica final.
- No se cambiaron Lexer, Parser, gramática ni tokens.

### Testing

- Ejecutados tests focalizados: `pytest tests/unit/test_usar_loader_validation.py tests/unit/test_project_root_usar_resolution.py tests/integration/test_usar_project_modules.py -q` y la ejecución focal pasó (116 tests ok, 1 warning en la ejecución parcial observada).
- Ejecutada la suite completa sin el proveedor de caché con `pytest -q -p no:cacheprovider`; fallos reportados por `MemoryError` en pruebas no relacionadas (`tests/core/test_superficie_publica_canonica.py`) debidos a limitación del entorno y no a regresión en el código modificado.
- Commit creado: `Endure project usar module resolution` (hash: `39b159b`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e576a4bfc8327b6defa64344c73ef)