### PR TITLE
Mantener raíz de proyecto estable en usar

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -1498,19 +1498,20 @@ class InterpretadorCobra:
         return build_internal_ir(ast)
 
     def configurar_archivo_principal(self, main_file: Path | str | None) -> None:
-        """Configura el archivo principal y recalcula la raíz canonicalizada."""
+        """Configura el archivo principal y recalcula la raíz canonicalizada.
+
+        La raíz autorizada de ``usar`` pertenece siempre al programa principal:
+        ``current_file`` y la pila de módulos sólo aportan contexto de carga y
+        detección de ciclos, pero no pueden ampliar ni desplazar ``_project_root``
+        hacia un módulo anidado con su propio ``cobra.toml``.
+        """
 
         self._main_file = (
             Path(main_file).expanduser().resolve(strict=False)
             if main_file is not None
             else None
         )
-        start = (
-            self._current_module_stack[-1]
-            if self._current_module_stack
-            else self._main_file
-        )
-        self._project_root = descubrir_raiz_proyecto(start, self._main_file)
+        self._project_root = descubrir_raiz_proyecto(self._main_file, self._main_file)
 
     def ejecutar_nodo(self, nodo):
         self._trace_debug(f"[EXEC] node_type={type(nodo).__name__} node_id={id(nodo)}")
@@ -2283,9 +2284,6 @@ class InterpretadorCobra:
             self._current_module_stack[-1]
             if self._current_module_stack
             else self._main_file
-        )
-        self._project_root = descubrir_raiz_proyecto(
-            current_file or self._project_root, self._main_file
         )
         exports = usar_modulo(
             nombre_modulo,


### PR DESCRIPTION
### Motivation
- Evitar que la raíz autorizada de `usar` se re-calcule desde módulos anidados y que un `cobra.toml` dentro de un subdirectorio desplace la raíz del proyecto principal.
- Asegurar que `current_file` y la pila de módulos solo sirvan como contexto de carga/ciclos y no amplíen la raíz autorizada.
- Mantener la cobertura del caso anidado ya existente (`test_usar_anidado_mantiene_raiz_autorizada_estable_con_current_file`) sin tocar Parser/Lexer.

### Description
- `configurar_archivo_principal` ahora recalcula `_project_root` exclusivamente a partir de `main_file` llamando a `descubrir_raiz_proyecto(self._main_file, self._main_file)` y documenta la intención en la docstring.
- Se eliminó el redescubrimiento de `_project_root` en `_ejecutar_usar_modulo_proyecto`, de modo que ese método pasa la raíz ya fijada a `usar_modulo` y usa `current_file` únicamente como contexto de carga/ciclos.
- No se realizaron cambios en Parser/Lexer ni en la lógica de resolución central implementada en `pcobra.cobra.usar_loader`.

### Testing
- `tests/unit/test_project_root_usar_resolution.py::test_usar_anidado_mantiene_raiz_autorizada_estable_con_current_file` se ejecutó y pasó correctamente.
- `tests/unit/test_project_root_usar_resolution.py::test_resolver_modulo_cobra_proyecto_rechaza_resultado_manipulado_fuera_de_root` se ejecutó y pasó correctamente.
- Ejecutar la suite completa `pytest tests/unit/test_project_root_usar_resolution.py` en este entorno falló por un `MemoryError` en el proceso de `pytest` tras iniciar la ejecución de la suite completa, por lo que solo los tests individuales anteriores pudieron confirmarse como verdes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e58d39dcc8327ab5033f84a1ad53f)