### PR TITLE
Corregir limpieza de pila de carga y mensajes de ciclo en `usar` de proyecto

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -560,27 +560,28 @@ def _cargar_exports_modulo_cobra_proyecto(
         )
         raise ImportError(f"Ciclo de módulos detectado en usar: {cadena}")
 
-    try:
-        ast = cargar_ast_modulo(
-            str(ruta_modulo),
-            modules_path=str(root_canonico),
-            whitelist={root_canonico},
-        )
-    except FileNotFoundError as exc:
-        raise FileNotFoundError(f"Módulo no encontrado: {nombre}") from exc
-
     _USAR_PROJECT_LOADING_STACK.append(ruta_modulo)
-    interpretador = InterpretadorCobra(
-        safe_mode=False, main_file=current_canonico or ruta_modulo
-    )
-    interpretador._project_root = root_canonico
-    interpretador._main_file = (
-        current_canonico if current_canonico else ruta_modulo
-    )
-    interpretador._current_module_stack.append(ruta_modulo)
-    interpretador.contextos.append(Environment(parent=interpretador.contextos[-1]))
-    interpretador.mem_contextos.append({})
+    interpretador = None
     try:
+        try:
+            ast = cargar_ast_modulo(
+                str(ruta_modulo),
+                modules_path=str(root_canonico),
+                whitelist={root_canonico},
+            )
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(f"Módulo no encontrado: {nombre}") from exc
+
+        interpretador = InterpretadorCobra(
+            safe_mode=False, main_file=current_canonico or ruta_modulo
+        )
+        interpretador._project_root = root_canonico
+        interpretador._main_file = (
+            current_canonico if current_canonico else ruta_modulo
+        )
+        interpretador._current_module_stack.append(ruta_modulo)
+        interpretador.contextos.append(Environment(parent=interpretador.contextos[-1]))
+        interpretador.mem_contextos.append({})
         for subnodo in ast:
             if isinstance(subnodo, NodoExport):
                 continue
@@ -612,12 +613,16 @@ def _cargar_exports_modulo_cobra_proyecto(
         )
         return _USAR_PROJECT_MODULE_CACHE[ruta_modulo]
     finally:
-        memoria_local = interpretador.mem_contextos.pop()
-        for idx, tam in memoria_local.values():
-            interpretador.liberar_memoria(idx, tam)
-        interpretador.contextos.pop()
-        interpretador._current_module_stack.pop()
-        _USAR_PROJECT_LOADING_STACK.pop()
+        if interpretador is not None:
+            memoria_local = interpretador.mem_contextos.pop()
+            for idx, tam in memoria_local.values():
+                interpretador.liberar_memoria(idx, tam)
+            interpretador.contextos.pop()
+            interpretador._current_module_stack.pop()
+        if _USAR_PROJECT_LOADING_STACK and _USAR_PROJECT_LOADING_STACK[-1] == ruta_modulo:
+            _USAR_PROJECT_LOADING_STACK.pop()
+        elif ruta_modulo in _USAR_PROJECT_LOADING_STACK:
+            _USAR_PROJECT_LOADING_STACK.remove(ruta_modulo)
 
 
 def usar_modulo(

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -693,6 +693,91 @@ def test_interpretador_usar_proyecto_detecta_ciclo_indirecto(monkeypatch, tmp_pa
         interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.internas.a"))
 
 
+
+
+def test_interpretador_usar_proyecto_detecta_ciclo_directo_en_root_con_mensaje_exacto(
+    monkeypatch, tmp_path
+):
+    from pcobra.core.ast_nodes import NodoUsar
+
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "a.co"
+    modulo.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "pcobra.core.import_utils.cargar_ast_modulo",
+        lambda _ruta, **_kwargs: [NodoUsar("a")],
+    )
+
+    interp = InterpretadorCobra(safe_mode=False, main_file=principal)
+    with pytest.raises(ImportError) as excinfo:
+        interp.ejecutar_usar(SimpleNamespace(modulo="a"))
+
+    assert str(excinfo.value) == "Ciclo de módulos detectado en usar: a.co -> a.co"
+    assert obtener_pila_carga_modulos_cobra_proyecto() == []
+
+
+def test_interpretador_usar_proyecto_detecta_ciclo_indirecto_en_root_con_cadena_completa(
+    monkeypatch, tmp_path
+):
+    from pcobra.core.ast_nodes import NodoUsar
+
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    for nombre in ("a", "b", "c"):
+        (proyecto / f"{nombre}.co").write_text("", encoding="utf-8")
+
+    def fake_cargar_ast_modulo(ruta, **_kwargs):
+        siguiente = {
+            "a.co": "b",
+            "b.co": "c",
+            "c.co": "a",
+        }[Path(ruta).name]
+        return [NodoUsar(siguiente)]
+
+    monkeypatch.setattr(
+        "pcobra.core.import_utils.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
+
+    interp = InterpretadorCobra(safe_mode=False, main_file=principal)
+    with pytest.raises(ImportError) as excinfo:
+        interp.ejecutar_usar(SimpleNamespace(modulo="a"))
+
+    assert str(excinfo.value) == (
+        "Ciclo de módulos detectado en usar: a.co -> b.co -> c.co -> a.co"
+    )
+    assert obtener_pila_carga_modulos_cobra_proyecto() == []
+
+
+def test_usar_proyecto_limpia_pila_si_falla_cargar_ast_modulo(monkeypatch, tmp_path):
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "a.co"
+    modulo.write_text("", encoding="utf-8")
+
+    def fake_cargar_ast_modulo(_ruta, **_kwargs):
+        assert obtener_pila_carga_modulos_cobra_proyecto() == [modulo.resolve()]
+        raise RuntimeError("fallo sintético de carga")
+
+    monkeypatch.setattr(
+        "pcobra.core.import_utils.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
+
+    with pytest.raises(RuntimeError, match="fallo sintético de carga"):
+        usar_modulo("a", project_root=proyecto, current_file=principal)
+
+    assert obtener_pila_carga_modulos_cobra_proyecto() == []
+
 def test_interpretador_usar_proyecto_modulo_inexistente_muestra_nombre_y_ruta(tmp_path):
     import pytest
 


### PR DESCRIPTION
### Motivation
- Evitar que fallos durante la lectura/parsing de un módulo de proyecto dejen residuos en la pila global de carga y garantizar que los ciclos se detecten y formateen correctamente. 
- Asegurar que ciclos directos e indirectos muestren la cadena completa y que las rutas dentro del `project_root` se presenten relativas.

### Description
- Se añade `ruta_modulo` a la pila global `_USAR_PROJECT_LOADING_STACK` antes de llamar a `cargar_ast_modulo` para que cualquier fallo posterior quede cubierto por la limpieza en `finally`.
- La carga y la inicialización del `InterpretadorCobra` quedan envueltas para permitir una limpieza defensiva: el `finally` borra recursos del intérprete si se llegó a crear y elimina `ruta_modulo` de la pila incluso cuando la excepción ocurre antes de la creación del intérprete.
- Se preserva la lógica de formateo de ciclos mediante `formatear_ciclo_modulos_cobra_proyecto`, que muestra rutas relativas a `project_root` cuando procede (cumpliendo los formatos esperados como `a.co -> a.co` y cadenas indirectas completas).
- Se añaden tests unitarios a `tests/unit/test_project_root_usar_resolution.py` que cubren el ciclo directo exacto, el ciclo indirecto con cadena completa y la limpieza de la pila cuando `cargar_ast_modulo` falla.

### Testing
- Se ejecutó `python -m pytest tests/unit/test_project_root_usar_resolution.py -q` y la suite relevante pasó en ejecución completa (tests añadidos incluidos).
- Se ejecutaron pruebas dirigidas: `::test_interpretador_usar_proyecto_detecta_ciclo_directo_en_root_con_mensaje_exacto`, `::test_interpretador_usar_proyecto_detecta_ciclo_indirecto_en_root_con_cadena_completa` y `::test_usar_proyecto_limpia_pila_si_falla_cargar_ast_modulo`, las cuales pasaron (`3 passed`).
- Se realizaron comprobaciones adicionales de estilo/compilación (`git diff --check` y `python -m py_compile ...`) que fueron exitosas; hubo una corrida posterior de `pytest` que reportó un `MemoryError` en la infraestructura durante el teardown de pytest (problema del entorno de ejecución, no un fallo en los tests añadidos), por lo que se recomienda ejecutar la suite en CI para validación final.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e59f534388327a2e0ec87b67b147e)