### PR TITLE
Documentar semántica legacy de NodoImport

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2233,7 +2233,14 @@ class InterpretadorCobra:
             self.contextos.pop()
 
     def ejecutar_import(self, nodo: NodoImport) -> None:
-        """Ejecuta una declaración de importación de módulo."""
+        """Ejecuta una declaración de importación de módulo legacy.
+
+        ``NodoImport`` mantiene la semántica histórica de ``import``: carga el
+        AST del archivo con ``cargar_ast_modulo`` y ejecuta todos sus nodos en el
+        contexto actual. La caché de AST sólo evita parseos repetidos; no debe
+        delegar en ``usar_modulo`` ni aplicar la semántica pública/exportada de
+        ``usar``.
+        """
         ruta = Path(nodo.ruta).expanduser()
         ruta_import_legacy = str(ruta)
         if not ruta.is_absolute():


### PR DESCRIPTION
### Motivation
- Asegurar explícitamente que `NodoImport` conserva el flujo legacy: debe cargar `.co` vía `cargar_ast_modulo`, no delegar en `usar_modulo`, y usar la caché AST sólo para evitar parseos repetidos, preservando el comportamiento de símbolos privados.

### Description
- Se añadió una docstring aclaratoria en `src/pcobra/core/interpreter.py` en el método `ejecutar_import` que especifica que `NodoImport` usa `cargar_ast_modulo`, ejecuta el AST en el contexto actual y no aplica la semántica pública de `usar` (cambio puramente documental sin alterar la lógica existente).

### Testing
- Ejecuté `pytest -q tests/unit/test_project_root_usar_resolution.py::test_import_archivo_co_via_nodo_import_usa_flujo_legacy_y_whitelist tests/unit/test_project_root_usar_resolution.py::test_usar_loader_no_altera_semantica_de_nodo_import` y ambos tests pasaron (2 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e5b3658108327984b7462712e07f8)