### PR TITLE
test: document project usar resolution coverage

### DIFF
--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -339,6 +339,32 @@ def test_resolver_modulo_cobra_proyecto_resuelve_modulo_anidado(tmp_path):
     )
 
 
+def test_cobertura_explicita_usar_resuelve_util_subcarpeta_y_anidado(tmp_path):
+    """Documenta los tres casos nominales pedidos para `usar` de proyecto.
+
+    Mantiene la cobertura explícita sin tocar gramática, tokens, Lexer ni Parser:
+    - `usar util` -> `util.co` en la raíz del proyecto;
+    - `usar utilidades.fechas` -> subcarpeta;
+    - `usar a.b.c` -> módulo anidado.
+    """
+
+    proyecto = tmp_path / "app"
+    rutas_esperadas = {
+        "util": proyecto / "util.co",
+        "utilidades.fechas": proyecto / "utilidades" / "fechas.co",
+        "a.b.c": proyecto / "a" / "b" / "c.co",
+    }
+    for ruta in rutas_esperadas.values():
+        ruta.parent.mkdir(parents=True, exist_ok=True)
+        ruta.write_text("", encoding="utf-8")
+
+    for nombre_modulo, ruta_esperada in rutas_esperadas.items():
+        assert (
+            resolver_modulo_cobra_proyecto(nombre_modulo, project_root=proyecto)
+            == ruta_esperada.resolve()
+        )
+
+
 def test_usar_modulo_api_resuelve_util_misma_carpeta(monkeypatch, tmp_path):
     from pcobra.core.ast_nodes import NodoAsignacion, NodoValor
 


### PR DESCRIPTION
### Motivation
- Añadir una prueba explícita que documente y garantice la resolución de módulos de proyecto para los casos nominales `usar util`, `usar utilidades.fechas` y `usar a.b.c` sin modificar gramática, tokens, Lexer ni Parser.

### Description
- Se añadió la prueba `test_cobertura_explicita_usar_resuelve_util_subcarpeta_y_anidado` en `tests/unit/test_project_root_usar_resolution.py` que crea un proyecto temporal y verifica la resolución a `util.co`, `utilidades/fechas.co` y `a/b/c.co` usando `resolver_modulo_cobra_proyecto`.

### Testing
- Ejecutados tests focalizados: `python -m pytest tests/unit/test_project_root_usar_resolution.py::test_cobertura_explicita_usar_resuelve_util_subcarpeta_y_anidado tests/test_transpilers.py::test_transpilador_python_usar_proyecto_incluye_contexto_estable tests/test_transpilers.py::test_python_adapter_usar_proyecto_propaga_contexto_estable -q` — todos pasaron.
- Ejecutado el suite de transpilers: `python -m pytest tests/test_transpilers.py -q` — `14 passed, 1 warning`.
- Intento de ejecutar ambos archivos juntos encontró un `MemoryError` del entorno durante la captura/formateo de pytest, por lo que se usaron ejecuciones focalizadas para verificar la cobertura; las pruebas relevantes pasaron en las ejecuciones dirigidas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e5c2aec988327918e373dce48631b)