### PR TITLE
Propaga contexto usar desde adaptador Python

### DIFF
--- a/src/pcobra/cobra/backends/python_adapter.py
+++ b/src/pcobra/cobra/backends/python_adapter.py
@@ -13,8 +13,9 @@ class PythonAdapter(BackendAdapter):
 
     def compile(self, ast: Any, options: Mapping[str, Any] | None = None) -> str:
         opts = options or {}
-        transpiler = TranspiladorPython(
+        transpiler = TranspiladorPython()
+        return transpiler.generate_code(
+            ast,
             source_file=opts.get("source_file"),
             project_root=opts.get("project_root"),
         )
-        return transpiler.generate_code(ast)


### PR DESCRIPTION
### Motivation
- Asegurar que el contexto estable de `source_file` y `project_root` se propague al transpilador Python para que las llamadas generadas a `usar_modulo` incluyan `project_root='...'` y `current_file='...'` sin duplicar lógica de resolución.

### Description
- Se modificó `PythonAdapter.compile` para instanciar `TranspiladorPython()` y llamar a `generate_code(ast, source_file=..., project_root=...)`, manteniendo la resolución de `usar` centralizada en `pcobra.cobra.usar_loader.usar_modulo` y sin tocar la lógica de `visit_usar` (que ya importa `usar_modulo`, genera la llamada con los kwargs del contexto y hace `globals().update(dict(_usar_exports.get('simbolos', [])))`).

### Testing
- Se ejecutaron los tests unitarios `tests/test_transpilers.py::test_transpilador_python_usar_proyecto_incluye_contexto_estable`, `tests/test_transpilers.py::test_transpilado_python_usar_proyecto_funciona_fuera_del_cwd` y `tests/test_transpilers.py::test_python_adapter_usar_proyecto_propaga_contexto_estable`, y todos pasaron (3 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e5d762ba88327b864b969d4480435)