### PR TITLE
Añade gestión de archivos al IDLE gráfico

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,6 +1112,12 @@ Los archivos con extensión ``.cobra`` representan paquetes completos, mientras 
 El subcomando `docs` ejecuta `sphinx-apidoc` para generar la documentación de la API antes de compilar el HTML.
 El subcomando `gui` abre el iddle integrado y requiere tener instalado Flet.
 
+### IDLE gráfico
+
+El IDLE gráfico (`cobra gui`) incluye un editor con estado de archivo activo: muestra la ruta seleccionada, detecta cambios sin guardar con un asterisco y conserva el contenido cargado para comparar modificaciones. La barra de archivo expone las acciones **Nuevo**, **Abrir**, **Guardar**, **Guardar como** y **Recargar**.
+
+El panel lateral lista carpetas y archivos Cobra (`.co` para scripts y `.cobra` para paquetes) desde el directorio de trabajo actual. Al seleccionar un archivo del árbol, su contenido se carga directamente en el editor y se actualiza la ruta activa. Las operaciones de guardado escriben el texto normalizado del editor tal como está, sin pasar por el lexer ni por el parser. Los errores de permisos, rutas inexistentes o codificación se muestran con el formato homogéneo de errores de la GUI.
+
 ## Conversión desde otros lenguajes a Cobra
 
 `cobra transpilar-inverso` documenta una capacidad distinta de la transpilación de salida normal. Aquí conviene separar dos listas para evitar ambigüedades:

--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -823,6 +823,12 @@ Cobra incluye módulos de soporte para flujos asíncronos y coordinación.
 | `verificar` | `codegen` | `VerifyCommand` | `src/pcobra/cobra/cli/commands/verify_cmd.py` |
 <!-- END: AUTO-CLI-TABLE -->
 
+### 10.1 IDLE gráfico con gestión de archivos
+
+`cobra gui` abre el IDLE basado en Flet. Además de ejecutar código, mostrar tokens y mostrar AST, la interfaz integra una barra de archivo con **Nuevo**, **Abrir**, **Guardar**, **Guardar como** y **Recargar**. El editor mantiene la ruta activa, el contenido cargado originalmente y una bandera de cambios sin guardar.
+
+El panel lateral funciona como árbol de directorios ligero: muestra carpetas y archivos Cobra con extensiones `.co` y `.cobra`, que son las extensiones documentadas para scripts y paquetes. Seleccionar un archivo carga su texto en el editor sin validar sintaxis. Guardar escribe exactamente el contenido normalizado visible en el editor y evita ejecutar lexer o parser, por lo que también puede persistir borradores incompletos o temporalmente inválidos.
+
 Flujo mínimo sugerido:
 
 ```bash

--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -1,5 +1,6 @@
 """Entorno interactivo para ejecutar código Cobra y explorar tokens y AST."""
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pcobra.gui import runtime
@@ -12,8 +13,14 @@ def main(page: "ft.Page"):
     """Función principal para el entorno IDLE."""
     ft = runtime.require_flet()
 
+    estado = runtime.GuiFileState()
+    directorio_actual = Path.cwd()
+
     entrada = runtime.flet_text_field(ft, multiline=True, expand=True)
     salida = runtime.flet_text(ft, value="", selectable=True)
+    estado_archivo = runtime.flet_text(ft, value="Archivo nuevo (sin guardar)")
+    ruta_input = runtime.flet_text_field(ft, label="Ruta", value="", expand=True)
+    arbol = runtime.flet_list_view(ft, expand=True, spacing=2, auto_scroll=False)
     lenguajes = list(runtime.gui_target_choices())
     selector = runtime.flet_dropdown(
         ft, options=[runtime.flet_dropdown_option(ft, lang) for lang in lenguajes]
@@ -22,6 +29,137 @@ def main(page: "ft.Page"):
         selector.value = lenguajes[0]
 
     activar = runtime.flet_switch(ft, label="Transpilar", disabled=not lenguajes)
+
+    def ruta_mostrada() -> str:
+        ruta = estado.ruta
+        nombre = str(ruta) if ruta is not None else "Archivo nuevo (sin guardar)"
+        return f"{nombre}{' *' if estado.cambios_sin_guardar else ''}"
+
+    def sincronizar_estado_visual() -> None:
+        estado_archivo.value = ruta_mostrada()
+        ruta_input.value = str(estado.ruta or "")
+
+    def marcar_cambios(_e=None) -> None:
+        estado.cambios_sin_guardar = (
+            runtime.normalizar_codigo(entrada.value) != estado.contenido_cargado
+        )
+        sincronizar_estado_visual()
+        page.update()
+
+    entrada.on_change = marcar_cambios
+
+    def mostrar_error_archivo(exc: Exception) -> None:
+        salida.value = runtime.formatear_error(exc)
+
+    def cargar_archivo(ruta: Path) -> None:
+        nonlocal directorio_actual
+        try:
+            contenido = runtime.leer_archivo_texto(ruta)
+        except (FileNotFoundError, NotADirectoryError, PermissionError, UnicodeError) as exc:
+            mostrar_error_archivo(exc)
+            page.update()
+            return
+        estado.ruta = ruta.expanduser().resolve()
+        estado.contenido_cargado = contenido
+        estado.cambios_sin_guardar = False
+        directorio_actual = estado.ruta.parent
+        entrada.value = contenido
+        salida.value = f"Archivo cargado: {estado.ruta}"
+        sincronizar_estado_visual()
+        reconstruir_arbol()
+        page.update()
+
+    def guardar_en(ruta: Path) -> bool:
+        try:
+            contenido_guardado = runtime.escribir_archivo_texto(ruta, entrada.value)
+        except (FileNotFoundError, NotADirectoryError, PermissionError, UnicodeError) as exc:
+            mostrar_error_archivo(exc)
+            page.update()
+            return False
+        estado.ruta = ruta.expanduser().resolve()
+        estado.contenido_cargado = contenido_guardado
+        estado.cambios_sin_guardar = False
+        salida.value = f"Archivo guardado: {estado.ruta}"
+        sincronizar_estado_visual()
+        reconstruir_arbol()
+        page.update()
+        return True
+
+    def reconstruir_arbol() -> None:
+        arbol.controls.clear()
+        arbol.controls.append(runtime.flet_text(ft, value=f"Directorio: {directorio_actual}"))
+        if directorio_actual.parent != directorio_actual:
+            arbol.controls.append(
+                runtime.flet_text_button(
+                    ft,
+                    "📁 ..",
+                    on_click=lambda _e: cambiar_directorio(directorio_actual.parent),
+                )
+            )
+        try:
+            entradas = runtime.listar_directorio_cobra(directorio_actual)
+        except (FileNotFoundError, NotADirectoryError, PermissionError) as exc:
+            mostrar_error_archivo(exc)
+            entradas = []
+        for ruta in entradas:
+            if ruta.is_dir():
+                arbol.controls.append(
+                    runtime.flet_text_button(
+                        ft,
+                        f"📁 {ruta.name}",
+                        on_click=lambda _e, r=ruta: cambiar_directorio(r),
+                    )
+                )
+            else:
+                arbol.controls.append(
+                    runtime.flet_text_button(
+                        ft,
+                        f"📄 {ruta.name}",
+                        on_click=lambda _e, r=ruta: cargar_archivo(r),
+                    )
+                )
+
+    def cambiar_directorio(ruta: Path) -> None:
+        nonlocal directorio_actual
+        directorio_actual = ruta.expanduser().resolve()
+        reconstruir_arbol()
+        page.update()
+
+    def nuevo_handler(_e):
+        estado.ruta = None
+        estado.contenido_cargado = ""
+        estado.cambios_sin_guardar = False
+        entrada.value = ""
+        salida.value = "Archivo nuevo creado en memoria."
+        sincronizar_estado_visual()
+        page.update()
+
+    def abrir_handler(_e):
+        if not ruta_input.value:
+            salida.value = "Indica una ruta para abrir o selecciona un archivo del árbol."
+            page.update()
+            return
+        cargar_archivo(Path(ruta_input.value))
+
+    def guardar_handler(_e):
+        if estado.ruta is None:
+            guardar_como_handler(_e)
+            return
+        guardar_en(estado.ruta)
+
+    def guardar_como_handler(_e):
+        if not ruta_input.value:
+            salida.value = "Indica una ruta de destino en el campo Ruta."
+            page.update()
+            return
+        guardar_en(Path(ruta_input.value))
+
+    def recargar_handler(_e):
+        if estado.ruta is None:
+            salida.value = "No hay archivo activo que recargar."
+            page.update()
+            return
+        cargar_archivo(estado.ruta)
 
     def ejecutar_handler(_e):
         deps = runtime.require_gui_dependencies()
@@ -70,15 +208,48 @@ def main(page: "ft.Page"):
         finally:
             page.update()
 
-    page.add(
-        entrada,
-        selector,
-        activar,
-        runtime.flet_elevated_button(ft, "Ejecutar", on_click=ejecutar_handler),
-        runtime.flet_elevated_button(ft, "Tokens", on_click=tokens_handler),
-        runtime.flet_elevated_button(ft, "AST", on_click=ast_handler),
-        salida,
+    reconstruir_arbol()
+    sincronizar_estado_visual()
+
+    barra_archivo = runtime.flet_row(
+        ft,
+        controls=[
+            runtime.flet_elevated_button(ft, "Nuevo", on_click=nuevo_handler),
+            runtime.flet_elevated_button(ft, "Abrir", on_click=abrir_handler),
+            runtime.flet_elevated_button(ft, "Guardar", on_click=guardar_handler),
+            runtime.flet_elevated_button(ft, "Guardar como", on_click=guardar_como_handler),
+            runtime.flet_elevated_button(ft, "Recargar", on_click=recargar_handler),
+        ],
+        wrap=True,
     )
+    barra_ejecucion = runtime.flet_row(
+        ft,
+        controls=[
+            selector,
+            activar,
+            runtime.flet_elevated_button(ft, "Ejecutar", on_click=ejecutar_handler),
+            runtime.flet_elevated_button(ft, "Tokens", on_click=tokens_handler),
+            runtime.flet_elevated_button(ft, "AST", on_click=ast_handler),
+        ],
+        wrap=True,
+    )
+    editor = runtime.flet_column(
+        ft,
+        controls=[estado_archivo, ruta_input, barra_archivo, entrada, barra_ejecucion, salida],
+        expand=True,
+    )
+    panel_lateral = runtime.flet_container(
+        ft,
+        content=runtime.flet_column(
+            ft,
+            controls=[runtime.flet_text(ft, value="Archivos Cobra"), arbol],
+            expand=True,
+        ),
+        width=280,
+    )
+
+    page.add(runtime.flet_row(ft, controls=[panel_lateral, editor], expand=True))
+
 
 if __name__ == "__main__":
     runtime.flet_app(main)

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import io
 import re
+from dataclasses import dataclass
+from pathlib import Path
 from contextlib import redirect_stderr, redirect_stdout
 from functools import lru_cache
 from typing import Any
@@ -71,6 +73,51 @@ def _local_import_action(module_name: str, symbol_name: str) -> str:
     )
 
 
+COBRA_FILE_EXTENSIONS: tuple[str, ...] = (".co", ".cobra")
+"""Extensiones Cobra priorizadas para el explorador del IDLE."""
+
+
+@dataclass(slots=True)
+class GuiFileState:
+    """Estado mínimo del archivo editado en la GUI."""
+
+    ruta: Path | None = None
+    contenido_cargado: str = ""
+    cambios_sin_guardar: bool = False
+
+
+def es_archivo_cobra(path: str | Path) -> bool:
+    """Indica si una ruta parece contener código Cobra editable."""
+
+    return Path(path).suffix.lower() in COBRA_FILE_EXTENSIONS
+
+
+def listar_directorio_cobra(root: str | Path) -> list[Path]:
+    """Lista carpetas y archivos Cobra de un directorio, con orden estable."""
+
+    base = Path(root).expanduser()
+    entradas = list(base.iterdir())
+    visibles = [entry for entry in entradas if entry.is_dir() or es_archivo_cobra(entry)]
+    return sorted(visibles, key=lambda entry: (not entry.is_dir(), entry.name.lower()))
+
+
+def leer_archivo_texto(path: str | Path, *, encoding: str = "utf-8") -> str:
+    """Lee un archivo Cobra como texto UTF-8 sin interpretar su contenido."""
+
+    return Path(path).expanduser().read_text(encoding=encoding)
+
+
+def escribir_archivo_texto(
+    path: str | Path, contenido: str | None, *, encoding: str = "utf-8"
+) -> str:
+    """Escribe exactamente el contenido normalizado del editor y lo devuelve."""
+
+    codigo = normalizar_codigo(contenido)
+    destino = Path(path).expanduser()
+    destino.write_text(codigo, encoding=encoding)
+    return codigo
+
+
 def require_flet() -> Any:
     """Importa Flet de forma diferida para no romper imports de CLI."""
     try:
@@ -125,6 +172,36 @@ def flet_elevated_button(ft: Any, *args: Any, **kwargs: Any) -> Any:
     """Crea ``ft.ElevatedButton`` validando la API desde el runtime central."""
 
     return _flet_attr(ft, "ElevatedButton", "ElevatedButton")(*args, **kwargs)
+
+
+def flet_text_button(ft: Any, *args: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.TextButton`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "TextButton", "TextButton")(*args, **kwargs)
+
+
+def flet_row(ft: Any, *args: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.Row`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "Row", "Row")(*args, **kwargs)
+
+
+def flet_column(ft: Any, *args: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.Column`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "Column", "Column")(*args, **kwargs)
+
+
+def flet_container(ft: Any, *args: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.Container`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "Container", "Container")(*args, **kwargs)
+
+
+def flet_list_view(ft: Any, *args: Any, **kwargs: Any) -> Any:
+    """Crea ``ft.ListView`` validando la API desde el runtime central."""
+
+    return _flet_attr(ft, "ListView", "ListView")(*args, **kwargs)
 
 
 def flet_dropdown_option(ft: Any, value: str) -> Any:

--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from pcobra.gui import runtime
+
+
+def test_es_archivo_cobra_prioriza_extensiones_documentadas():
+    assert runtime.es_archivo_cobra("programa.co")
+    assert runtime.es_archivo_cobra("paquete.COBRA")
+    assert not runtime.es_archivo_cobra("README.md")
+
+
+def test_listar_directorio_cobra_filtra_y_ordena(tmp_path: Path):
+    (tmp_path / "zeta").mkdir()
+    (tmp_path / "beta.co").write_text("", encoding="utf-8")
+    (tmp_path / "alfa.cobra").write_text("", encoding="utf-8")
+    (tmp_path / "ignorado.py").write_text("", encoding="utf-8")
+
+    assert [path.name for path in runtime.listar_directorio_cobra(tmp_path)] == [
+        "zeta",
+        "alfa.cobra",
+        "beta.co",
+    ]
+
+
+def test_escribir_archivo_texto_no_parsea_ni_modifica_contenido(tmp_path: Path):
+    (tmp_path / "sub").mkdir()
+    destino = tmp_path / "sub" / "codigo.co"
+    codigo = "var x = 1\ntexto inválido para parser ???\n"
+
+    escrito = runtime.escribir_archivo_texto(destino, codigo)
+
+    assert escrito == codigo
+    assert destino.read_text(encoding="utf-8") == codigo
+
+
+def test_escribir_archivo_texto_propaga_ruta_inexistente(tmp_path: Path):
+    destino = tmp_path / "no_existe" / "codigo.co"
+
+    try:
+        runtime.escribir_archivo_texto(destino, "contenido")
+    except FileNotFoundError:
+        pass
+    else:
+        raise AssertionError("La escritura debe fallar si el directorio no existe")


### PR DESCRIPTION
### Motivation
- Proveer un IDLE gráfico (Flet) con gestión básica de archivos para crear/abrir/guardar/recargar scripts Cobra sin pasar por lexer/parser y mostrar errores formateados homogéneamente.
- Reutilizar y exponer helpers comunes de I/O y componentes Flet en `runtime` para compartir lógica entre `idle.py` y otras UIs.

### Description
- Añade estado de archivo activo `GuiFileState` y helpers de rutas/archivo en `src/pcobra/gui/runtime.py`: `COBRA_FILE_EXTENSIONS`, `es_archivo_cobra`, `listar_directorio_cobra`, `leer_archivo_texto` y `escribir_archivo_texto` que escribe el contenido normalizado tal cual.
- Amplía `runtime` con wrappers Flet coherentes: `flet_text_button`, `flet_row`, `flet_column`, `flet_container` y `flet_list_view` para usar en la GUI.
- Implementa en `src/pcobra/gui/idle.py` el panel lateral de árbol de directorios que lista carpetas y archivos Cobra (`.co`, `.cobra`) y acciones visibles en la barra de archivo: `Nuevo`, `Abrir`, `Guardar`, `Guardar como` y `Recargar`, cargando el contenido seleccionado en `entrada.value` y actualizando la ruta activa y la bandera de cambios sin guardar.
- Integra manejo de errores de permisos/rutas/codificación con `runtime.formatear_error` para mensajes uniformes en la GUI y deja claro que el guardado escribe el texto normalizado del editor sin pasar por Lexer/Parser.
- Documenta la funcionalidad añadida en `README.md` y en `docs/LIBRO_PROGRAMACION_COBRA.md` y agrega pruebas unitarias en `tests/gui/test_runtime_file_helpers.py` para la lógica de rutas y escritura.

### Testing
- Ejecuté `python -m pytest tests/gui/test_runtime_file_helpers.py`, que resultó en `4 passed` (tests que verifican detección de extensiones, orden/filtrado del árbol, escritura exacta y propagación de error cuando el directorio no existe).
- Ejecuté `python -m ruff check src/pcobra/gui/idle.py src/pcobra/gui/runtime.py tests/gui/test_runtime_file_helpers.py`, que pasó sin problemas.
- Verifiqué compilación estática con `python -m py_compile src/pcobra/gui/idle.py src/pcobra/gui/runtime.py`, que completó correctamente.
- Ejecuté `git diff --check` para comprobar problemas básicos y no se encontraron errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e784299ac83279fbdc3641fb65eb7)