### PR TITLE
Agregar botón 'Sugerencias' al IDLE y conectar analizador_agix

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -829,6 +829,12 @@ Cobra incluye módulos de soporte para flujos asíncronos y coordinación.
 
 El panel lateral funciona como árbol de directorios ligero: muestra carpetas y archivos Cobra con extensiones `.co` y `.cobra`, que son las extensiones documentadas para scripts y paquetes. Seleccionar un archivo carga su texto en el editor sin validar sintaxis. Guardar escribe exactamente el contenido normalizado visible en el editor y evita ejecutar lexer o parser, por lo que también puede persistir borradores incompletos o temporalmente inválidos.
 
+#### Acción de sugerencias en GUI/IDLE
+
+El botón **Sugerencias** del IDLE toma el texto actual del editor, lo normaliza igual que las acciones de ejecución y lo valida primero con el `Lexer` y el `Parser` oficiales de Cobra. Esta validación conserva la gramática existente: el Libro se usa como referencia pedagógica y documental para explicar buenas prácticas, no como parser alternativo ni como fuente de reglas sintácticas paralelas.
+
+Si el código contiene errores léxicos o sintácticos, la salida separa esos errores de las sugerencias estilísticas y pide corregirlos antes de consultar recomendaciones. Si la validación pasa, el IDLE llama a `pcobra.ia.analizador_agix.generar_sugerencias`, que depende de forma opcional del paquete `agix`. Cuando `agix` no está instalado, la interfaz muestra un mensaje claro indicando que la acción de sugerencias requiere instalar esa dependencia opcional; no se introduce ni se asume una librería `agi-core` sin una tarea previa de descubrimiento para confirmar el paquete o API canónicos.
+
 Flujo mínimo sugerido:
 
 ```bash

--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -55,7 +55,12 @@ def main(page: "ft.Page"):
         nonlocal directorio_actual
         try:
             contenido = runtime.leer_archivo_texto(ruta)
-        except (FileNotFoundError, NotADirectoryError, PermissionError, UnicodeError) as exc:
+        except (
+            FileNotFoundError,
+            NotADirectoryError,
+            PermissionError,
+            UnicodeError,
+        ) as exc:
             mostrar_error_archivo(exc)
             page.update()
             return
@@ -72,7 +77,12 @@ def main(page: "ft.Page"):
     def guardar_en(ruta: Path) -> bool:
         try:
             contenido_guardado = runtime.escribir_archivo_texto(ruta, entrada.value)
-        except (FileNotFoundError, NotADirectoryError, PermissionError, UnicodeError) as exc:
+        except (
+            FileNotFoundError,
+            NotADirectoryError,
+            PermissionError,
+            UnicodeError,
+        ) as exc:
             mostrar_error_archivo(exc)
             page.update()
             return False
@@ -87,7 +97,9 @@ def main(page: "ft.Page"):
 
     def reconstruir_arbol() -> None:
         arbol.controls.clear()
-        arbol.controls.append(runtime.flet_text(ft, value=f"Directorio: {directorio_actual}"))
+        arbol.controls.append(
+            runtime.flet_text(ft, value=f"Directorio: {directorio_actual}")
+        )
         if directorio_actual.parent != directorio_actual:
             arbol.controls.append(
                 runtime.flet_text_button(
@@ -136,7 +148,9 @@ def main(page: "ft.Page"):
 
     def abrir_handler(_e):
         if not ruta_input.value:
-            salida.value = "Indica una ruta para abrir o selecciona un archivo del árbol."
+            salida.value = (
+                "Indica una ruta para abrir o selecciona un archivo del árbol."
+            )
             page.update()
             return
         cargar_archivo(Path(ruta_input.value))
@@ -208,6 +222,60 @@ def main(page: "ft.Page"):
         finally:
             page.update()
 
+    def sugerencias_handler(_e):
+        deps = runtime.require_gui_dependencies()
+        codigo = runtime.normalizar_codigo(entrada.value)
+        try:
+            deps["Parser"](deps["Lexer"](codigo).tokenizar()).parsear()
+        except Exception as exc:
+            error = runtime.formatear_error(
+                exc,
+                lexer_error_type=deps.get("LexerError"),
+                parser_error_type=deps.get("ParserError"),
+            )
+            salida.value = (
+                "Errores léxicos/sintácticos:\n"
+                f"- {error}\n\n"
+                "Sugerencias estilísticas:\n"
+                "- Corrige primero los errores anteriores para solicitar sugerencias."
+            )
+            page.update()
+            return
+
+        try:
+            from pcobra.ia.analizador_agix import generar_sugerencias
+
+            sugerencias = generar_sugerencias(codigo)
+        except ImportError as exc:
+            salida.value = (
+                "Errores léxicos/sintácticos:\n"
+                "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
+                "Sugerencias estilísticas:\n"
+                f"- No se pudieron generar sugerencias: {exc}. "
+                "Instala la dependencia opcional 'agix' para activar esta acción."
+            )
+        except Exception as exc:
+            salida.value = runtime.formatear_error(
+                exc,
+                lexer_error_type=deps.get("LexerError"),
+                parser_error_type=deps.get("ParserError"),
+            )
+        else:
+            if sugerencias:
+                sugerencias_legibles = "\n".join(
+                    f"- {sugerencia}" for sugerencia in sugerencias
+                )
+            else:
+                sugerencias_legibles = "- No se recibieron sugerencias."
+            salida.value = (
+                "Errores léxicos/sintácticos:\n"
+                "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
+                "Sugerencias estilísticas:\n"
+                f"{sugerencias_legibles}"
+            )
+        finally:
+            page.update()
+
     reconstruir_arbol()
     sincronizar_estado_visual()
 
@@ -217,7 +285,9 @@ def main(page: "ft.Page"):
             runtime.flet_elevated_button(ft, "Nuevo", on_click=nuevo_handler),
             runtime.flet_elevated_button(ft, "Abrir", on_click=abrir_handler),
             runtime.flet_elevated_button(ft, "Guardar", on_click=guardar_handler),
-            runtime.flet_elevated_button(ft, "Guardar como", on_click=guardar_como_handler),
+            runtime.flet_elevated_button(
+                ft, "Guardar como", on_click=guardar_como_handler
+            ),
             runtime.flet_elevated_button(ft, "Recargar", on_click=recargar_handler),
         ],
         wrap=True,
@@ -230,12 +300,22 @@ def main(page: "ft.Page"):
             runtime.flet_elevated_button(ft, "Ejecutar", on_click=ejecutar_handler),
             runtime.flet_elevated_button(ft, "Tokens", on_click=tokens_handler),
             runtime.flet_elevated_button(ft, "AST", on_click=ast_handler),
+            runtime.flet_elevated_button(
+                ft, "Sugerencias", on_click=sugerencias_handler
+            ),
         ],
         wrap=True,
     )
     editor = runtime.flet_column(
         ft,
-        controls=[estado_archivo, ruta_input, barra_archivo, entrada, barra_ejecucion, salida],
+        controls=[
+            estado_archivo,
+            ruta_input,
+            barra_archivo,
+            entrada,
+            barra_ejecucion,
+            salida,
+        ],
         expand=True,
     )
     panel_lateral = runtime.flet_container(

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
 from pcobra.gui import idle
@@ -11,10 +12,12 @@ from pcobra.gui import idle
 def _fake_flet():
     class TextField:
         def __init__(self, **_kwargs):
+            self.kwargs = _kwargs
             self.value = ""
 
     class Text:
         def __init__(self, value="", **_kwargs):
+            self.kwargs = _kwargs
             self.value = value
 
     class Dropdown:
@@ -32,13 +35,33 @@ def _fake_flet():
             self.text = text
             self.on_click = on_click
 
+    class TextButton(ElevatedButton):
+        pass
+
+    class Layout:
+        def __init__(self, controls=None, **_kwargs):
+            self.controls = controls or []
+
+    class Container:
+        def __init__(self, content=None, **_kwargs):
+            self.content = content
+
     class Page:
         def __init__(self):
             self.controls = []
             self.update = MagicMock()
 
         def add(self, *args):
-            self.controls.extend(args)
+            def _flatten(control):
+                self.controls.append(control)
+                for child in getattr(control, "controls", []) or []:
+                    _flatten(child)
+                content = getattr(control, "content", None)
+                if content is not None:
+                    _flatten(content)
+
+            for arg in args:
+                _flatten(arg)
 
     return SimpleNamespace(
         TextField=TextField,
@@ -46,6 +69,11 @@ def _fake_flet():
         Dropdown=Dropdown,
         Switch=Switch,
         ElevatedButton=ElevatedButton,
+        TextButton=TextButton,
+        Row=Layout,
+        Column=Layout,
+        Container=Container,
+        ListView=Layout,
         Page=Page,
         dropdown=SimpleNamespace(Option=lambda v: v),
     )
@@ -62,20 +90,34 @@ def test_main_renderiza_botones_esperados(monkeypatch):
             "TRANSPILERS": {"python": object},
             "LexerError": RuntimeError,
             "ParserError": ValueError,
+            "Lexer": lambda _codigo: SimpleNamespace(tokenizar=lambda: []),
+            "Parser": lambda _tokens: SimpleNamespace(parsear=lambda: []),
         },
     )
     monkeypatch.setattr(idle.runtime, "normalizar_codigo", lambda value: value or "")
     monkeypatch.setattr(idle.runtime, "ejecutar_codigo", lambda _codigo: "ok")
-    monkeypatch.setattr(idle.runtime, "transpilar_codigo", lambda _codigo, _lang: "transpilado")
+    monkeypatch.setattr(
+        idle.runtime, "transpilar_codigo", lambda _codigo, _lang: "transpilado"
+    )
     monkeypatch.setattr(idle.runtime, "mostrar_tokens", lambda _codigo: "Token(X)")
     monkeypatch.setattr(idle.runtime, "mostrar_ast", lambda _codigo: "[Nodo]")
-    monkeypatch.setattr(idle.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}")
-
+    monkeypatch.setattr(
+        idle.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}"
+    )
     page = ft.Page()
     idle.main(page)
 
     botones = [c for c in page.controls if isinstance(c, ft.ElevatedButton)]
-    assert [b.text for b in botones] == ["Ejecutar", "Tokens", "AST"]
+    assert [
+        b.text
+        for b in botones
+        if b.text in {"Ejecutar", "Tokens", "AST", "Sugerencias"}
+    ] == [
+        "Ejecutar",
+        "Tokens",
+        "AST",
+        "Sugerencias",
+    ]
 
 
 def test_main_handlers_smoke(monkeypatch):
@@ -91,6 +133,8 @@ def test_main_handlers_smoke(monkeypatch):
             "TRANSPILERS": {"python": object},
             "LexerError": RuntimeError,
             "ParserError": ValueError,
+            "Lexer": lambda _codigo: SimpleNamespace(tokenizar=lambda: []),
+            "Parser": lambda _tokens: SimpleNamespace(parsear=lambda: []),
         },
     )
     monkeypatch.setattr(idle.runtime, "normalizar_codigo", lambda value: value or "")
@@ -98,17 +142,38 @@ def test_main_handlers_smoke(monkeypatch):
     monkeypatch.setattr(idle.runtime, "transpilar_codigo", transpilar_mock)
     monkeypatch.setattr(idle.runtime, "mostrar_tokens", lambda _codigo: "Token(X)")
     monkeypatch.setattr(idle.runtime, "mostrar_ast", lambda _codigo: "[Nodo]")
-    monkeypatch.setattr(idle.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}")
+    monkeypatch.setattr(
+        idle.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}"
+    )
+    analizador = ModuleType("pcobra.ia.analizador_agix")
+    analizador.generar_sugerencias = lambda _codigo: ["Usa nombres descriptivos"]
+    monkeypatch.setitem(sys.modules, "pcobra.ia.analizador_agix", analizador)
 
     page = ft.Page()
     idle.main(page)
 
-    entrada = next(c for c in page.controls if isinstance(c, ft.TextField))
+    entrada = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("multiline")
+    )
     selector = next(c for c in page.controls if isinstance(c, ft.Dropdown))
     activar = next(c for c in page.controls if isinstance(c, ft.Switch))
-    salida = next(c for c in page.controls if isinstance(c, ft.Text))
-    botones = [c for c in page.controls if isinstance(c, ft.ElevatedButton)]
-    ejecutar_btn, tokens_btn, ast_btn = botones
+    salida = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.Text) and c.kwargs.get("selectable")
+    )
+    botones = {
+        c.text: c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton)
+        and c.text in {"Ejecutar", "Tokens", "AST", "Sugerencias"}
+    }
+    ejecutar_btn = botones["Ejecutar"]
+    tokens_btn = botones["Tokens"]
+    ast_btn = botones["AST"]
+    sugerencias_btn = botones["Sugerencias"]
 
     entrada.value = "imprimir('x')"
     ejecutar_btn.on_click(None)
@@ -128,9 +193,14 @@ def test_main_handlers_smoke(monkeypatch):
 
     ast_btn.on_click(None)
     assert salida.value == "[Nodo]"
+
+    sugerencias_btn.on_click(None)
+    assert "Errores léxicos/sintácticos" in salida.value
+    assert "- No se detectaron errores" in salida.value
+    assert "- Usa nombres descriptivos" in salida.value
     ejecutar_mock.assert_called_once_with("imprimir('x')")
     transpilar_mock.assert_called_once_with("imprimir('x')", "python")
-    assert page.update.call_count == 5
+    assert page.update.call_count == 6
 
 
 def test_main_selector_y_switch_sin_targets(monkeypatch):
@@ -148,10 +218,14 @@ def test_main_selector_y_switch_sin_targets(monkeypatch):
     )
     monkeypatch.setattr(idle.runtime, "normalizar_codigo", lambda value: value or "")
     monkeypatch.setattr(idle.runtime, "ejecutar_codigo", lambda _codigo: "ejecutado")
-    monkeypatch.setattr(idle.runtime, "transpilar_codigo", lambda _codigo, _lang: "transpilado")
+    monkeypatch.setattr(
+        idle.runtime, "transpilar_codigo", lambda _codigo, _lang: "transpilado"
+    )
     monkeypatch.setattr(idle.runtime, "mostrar_tokens", lambda _codigo: "Token(X)")
     monkeypatch.setattr(idle.runtime, "mostrar_ast", lambda _codigo: "[Nodo]")
-    monkeypatch.setattr(idle.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}")
+    monkeypatch.setattr(
+        idle.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}"
+    )
 
     page = ft.Page()
     idle.main(page)


### PR DESCRIPTION
### Motivation

- Proveer en el IDLE una acción que ofrezca sugerencias estilísticas sobre el código usando el analizador existente basado en `agix` cuando esté disponible.
- Asegurar que las sugerencias solo se soliciten sobre código validado por el `Lexer` y `Parser` oficiales de Cobra, sin tocar la gramática.
- Evitar introducir o asumir una librería `agi-core` sin una tarea previa de descubrimiento; documentar la dependencia opcional `agix` y su comportamiento cuando falta.

### Description

- Añadido botón **Sugerencias** en la barra de ejecución del IDLE y nuevo handler `sugerencias_handler` en `src/pcobra/gui/idle.py` que normaliza `entrada.value` con `runtime.normalizar_codigo` y valida el código con las dependencias `Lexer`/`Parser` obtenidas vía `runtime.require_gui_dependencies()`.
- El handler captura errores léxicos/sintácticos y los muestra separados de las sugerencias estilísticas; si la validación pasa, importa `pcobra.ia.analizador_agix.generar_sugerencias` y muestra sus resultados en `salida.value` en formato legible.
- Se captura `ImportError` para mostrar un mensaje claro y accionable cuando `agix` no está instalado, sin asumir otras bibliotecas alternativas.
- Documentada la nueva acción en `docs/LIBRO_PROGRAMACION_COBRA.md` (sección GUI/IDLE) y actualizadas pruebas en `tests/unit/test_gui_idle.py` para cubrir el nuevo botón y el flujo con un mock de `pcobra.ia.analizador_agix`.

### Testing

- Ejecutados chequeos estáticos y formateo: `python -m compileall -q src/pcobra/gui/idle.py tests/unit/test_gui_idle.py`, `python -m ruff check src/pcobra/gui/idle.py tests/unit/test_gui_idle.py`, y `python -m black src/pcobra/gui/idle.py tests/unit/test_gui_idle.py` (Black mostró advertencia de entorno pero se aplicó el formateo); todos los linters/formatters pasaron tras el reformat.
- Pruebas unitarias ejecutadas con `pytest -q tests/unit/test_gui_idle.py tests/unit/test_analizador_agix.py` y resultaron exitosas (tests relevantes pasaron).
- Resultado final: pruebas ejecutadas para los módulos modificados: todas las pruebas ejecutadas en estas suites pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e7a026db48327a7f1accb27de1223)