### PR TITLE
docs: añadir flujo recomendado en IDLE gráfico y enlazar desde README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ El objetivo de pCobra es brindar a la comunidad hispanohablante una alternativa 
 - Licencia
 - **Ruta recomendada de documentación (sin ambigüedad):**
   - [Libro de Programación Cobra — **Principal** (inicio a avanzado)](docs/LIBRO_PROGRAMACION_COBRA.md)
+    - [Flujo recomendado en el IDLE gráfico](docs/LIBRO_PROGRAMACION_COBRA.md#flujo-recomendado-en-el-idle-gráfico)
   - [Manual de Cobra (Markdown) — **Referencia técnica canónica**](docs/MANUAL_COBRA.md)
   - [Guía básica — **Histórico** (resumen rápido)](docs/guia_basica.md)
   - [Contenido histórico complementario](docs/historico/README.md)

--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -829,6 +829,21 @@ Cobra incluye módulos de soporte para flujos asíncronos y coordinación.
 
 El panel lateral funciona como árbol de directorios ligero: muestra carpetas y archivos Cobra con extensiones `.co` y `.cobra`, que son las extensiones documentadas para scripts y paquetes. Seleccionar un archivo carga su texto en el editor sin validar sintaxis. Guardar escribe exactamente el contenido normalizado visible en el editor y evita ejecutar lexer o parser, por lo que también puede persistir borradores incompletos o temporalmente inválidos.
 
+#### Flujo recomendado en el IDLE gráfico
+
+Para trabajar desde el entorno gráfico sin mezclar rutas internas, sigue este recorrido principal:
+
+1. **Crear o abrir archivo Cobra**: usa **Nuevo** para empezar un borrador o **Abrir** para cargar un archivo `.cobra`/`.co` desde el árbol lateral.
+2. **Editar código**: modifica el contenido en el editor y mantén visible el indicador de cambios sin guardar antes de ejecutar acciones destructivas o de recarga.
+3. **Validar tokens**: pulsa la acción de tokens para confirmar que el lexer reconoce correctamente palabras clave, literales, operadores e identificadores.
+4. **Revisar AST**: abre la vista de AST para comprobar que el parser interpreta la estructura esperada antes de ejecutar o generar artefactos.
+5. **Ejecutar**: usa la acción de ejecución del IDLE para probar el comportamiento del programa con el intérprete de Cobra.
+6. **Transpilar**: cuando necesites salida para otro entorno, elige únicamente uno de los targets públicos `python`, `javascript` o `rust`; esos son los destinos documentados para el recorrido principal.
+7. **Guardar cambios**: usa **Guardar** si el archivo ya tiene ruta activa o **Guardar como** para definir una nueva ubicación; guarda después de validar el resultado que quieres conservar.
+8. **Solicitar sugerencias AGIX**: pulsa **Sugerencias** solo después de tener tokens y AST válidos; si la dependencia opcional `agix` está disponible, el IDLE pedirá recomendaciones, y si no lo está mostrará el aviso correspondiente sin bloquear el resto del flujo.
+
+El recorrido principal evita mencionar targets internos o históricos. Si necesitas contexto de migración, consulta los [anexos legacy/internal](anexos_legacy_internal/README.md) fuera del onboarding diario.
+
 #### Acción de sugerencias en GUI/IDLE
 
 El botón **Sugerencias** del IDLE toma el texto actual del editor, lo normaliza igual que las acciones de ejecución y lo valida primero con el `Lexer` y el `Parser` oficiales de Cobra. Esta validación conserva la gramática existente: el Libro se usa como referencia pedagógica y documental para explicar buenas prácticas, no como parser alternativo ni como fuente de reglas sintácticas paralelas.


### PR DESCRIPTION
### Motivation

- Documentar el recorrido principal de uso del IDLE gráfico para orientar a usuarios en un flujo coherente de edición y ejecución.
- Garantizar que los ejemplos y recomendaciones del recorrido principal usen solo los targets públicos de transpilación (`python`, `javascript`, `rust`) y evitar mencionar targets legacy en el onboarding.

### Description

- Añadida la subsección `Flujo recomendado en el IDLE gráfico` en `docs/LIBRO_PROGRAMACION_COBRA.md` que describe paso a paso: crear/abrir archivo, editar, validar tokens, revisar AST, ejecutar, transpilar (a `python`, `javascript` o `rust`), guardar y solicitar sugerencias AGIX si la dependencia opcional está disponible.
- Actualizado `README.md` para incluir un enlace directo a la nueva sección del Libro (`docs/LIBRO_PROGRAMACION_COBRA.md#flujo-recomendado-en-el-idle-gráfico`) dentro del bloque principal de documentación.
- El texto evita exponer targets internos/legacy en el recorrido principal y remite a los anexos internos (`anexos_legacy/internal`) si se requiere contexto histórico.

### Testing

- Ejecutado un script de validación (`python - <<'PY' ... PY`) que comprobó la presencia del enlace en `README.md` y la inclusión de los targets públicos en la nueva sección, y la comprobación pasó correctamente.
- Ejecutado `git diff --check` para verificar que el diff no introduce errores de espacio en blanco, y la comprobación pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e8027f8148327bdadc65f666932c3)