### PR TITLE
Refactor: extraer componentes GUI compartidos y handler en runtime

### DIFF
--- a/src/pcobra/gui/app.py
+++ b/src/pcobra/gui/app.py
@@ -9,38 +9,21 @@ if TYPE_CHECKING:
 
 
 def main(page: "ft.Page"):
-    """Función principal para Flet."""
+    """Interfaz mínima de Flet basada en componentes compartidos."""
     ft = runtime.require_flet()
 
-    entrada = runtime.flet_text_field(ft, multiline=True, expand=True)
-    salida = runtime.flet_text(ft, value="", selectable=True)
     lenguajes = list(runtime.gui_target_choices())
-    selector = runtime.flet_dropdown(
-        ft, options=[runtime.flet_dropdown_option(ft, lang) for lang in lenguajes]
+    entrada = runtime.crear_editor_codigo(ft)
+    salida = runtime.crear_salida_seleccionable(ft)
+    selector = runtime.crear_selector_target(ft, lenguajes=lenguajes)
+    activar = runtime.crear_switch_transpilacion(ft, lenguajes=lenguajes)
+    ejecutar_handler = runtime.crear_handler_ejecucion(
+        entrada=entrada,
+        salida=salida,
+        selector=selector,
+        activar=activar,
+        page=page,
     )
-    if lenguajes:
-        selector.value = lenguajes[0]
-
-    activar = runtime.flet_switch(ft, label="Transpilar", disabled=not lenguajes)
-
-    def ejecutar_handler(_e):
-        deps = runtime.require_gui_dependencies()
-        codigo = runtime.normalizar_codigo(entrada.value)
-        try:
-            if activar.value and selector.value not in deps["TRANSPILERS"]:
-                salida.value = "Selecciona un lenguaje destino para transpilar"
-            elif activar.value and selector.value in deps["TRANSPILERS"]:
-                salida.value = runtime.transpilar_codigo(codigo, selector.value)
-            else:
-                salida.value = runtime.ejecutar_codigo(codigo)
-        except Exception as exc:
-            salida.value = runtime.formatear_error(
-                exc,
-                lexer_error_type=deps.get("LexerError"),
-                parser_error_type=deps.get("ParserError"),
-            )
-        finally:
-            page.update()
 
     page.add(
         entrada,

--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -10,36 +10,34 @@ if TYPE_CHECKING:
 
 
 def main(page: "ft.Page"):
-    """Función principal para el entorno IDLE."""
+    """Interfaz extendida del IDLE con tokens, AST, archivos, árbol y sugerencias."""
     ft = runtime.require_flet()
 
     estado = runtime.GuiFileState()
     directorio_actual = Path.cwd()
 
-    entrada = runtime.flet_text_field(ft, multiline=True, expand=True)
-    salida = runtime.flet_text(ft, value="", selectable=True)
+    entrada = runtime.crear_editor_codigo(ft)
+    salida = runtime.crear_salida_seleccionable(ft)
     estado_archivo = runtime.flet_text(ft, value="Archivo nuevo (sin guardar)")
     ruta_input = runtime.flet_text_field(ft, label="Ruta", value="", expand=True)
     arbol = runtime.flet_list_view(ft, expand=True, spacing=2, auto_scroll=False)
     lenguajes = list(runtime.gui_target_choices())
-    selector = runtime.flet_dropdown(
-        ft, options=[runtime.flet_dropdown_option(ft, lang) for lang in lenguajes]
-    )
-    if lenguajes:
-        selector.value = lenguajes[0]
-
-    activar = runtime.flet_switch(ft, label="Transpilar", disabled=not lenguajes)
+    selector = runtime.crear_selector_target(ft, lenguajes=lenguajes)
+    activar = runtime.crear_switch_transpilacion(ft, lenguajes=lenguajes)
 
     def ruta_mostrada() -> str:
+        """Devuelve el título específico del IDLE para el archivo activo."""
         ruta = estado.ruta
         nombre = str(ruta) if ruta is not None else "Archivo nuevo (sin guardar)"
         return f"{nombre}{' *' if estado.cambios_sin_guardar else ''}"
 
     def sincronizar_estado_visual() -> None:
+        """Sincroniza controles específicos del IDLE con el estado de archivo."""
         estado_archivo.value = ruta_mostrada()
         ruta_input.value = str(estado.ruta or "")
 
     def marcar_cambios(_e=None) -> None:
+        """Marca cambios sin guardar; comportamiento exclusivo del IDLE."""
         estado.cambios_sin_guardar = (
             runtime.normalizar_codigo(entrada.value) != estado.contenido_cargado
         )
@@ -49,9 +47,11 @@ def main(page: "ft.Page"):
     entrada.on_change = marcar_cambios
 
     def mostrar_error_archivo(exc: Exception) -> None:
+        """Muestra errores de archivos en la salida extendida del IDLE."""
         salida.value = runtime.formatear_error(exc)
 
     def cargar_archivo(ruta: Path) -> None:
+        """Carga un archivo Cobra desde el árbol o ruta del IDLE."""
         nonlocal directorio_actual
         try:
             contenido = runtime.leer_archivo_texto(ruta)
@@ -75,6 +75,7 @@ def main(page: "ft.Page"):
         page.update()
 
     def guardar_en(ruta: Path) -> bool:
+        """Guarda el editor en una ruta; acción específica del IDLE."""
         try:
             contenido_guardado = runtime.escribir_archivo_texto(ruta, entrada.value)
         except (
@@ -96,6 +97,7 @@ def main(page: "ft.Page"):
         return True
 
     def reconstruir_arbol() -> None:
+        """Reconstruye el árbol lateral de archivos Cobra del IDLE."""
         arbol.controls.clear()
         arbol.controls.append(
             runtime.flet_text(ft, value=f"Directorio: {directorio_actual}")
@@ -132,12 +134,14 @@ def main(page: "ft.Page"):
                 )
 
     def cambiar_directorio(ruta: Path) -> None:
+        """Cambia el directorio explorado por el árbol lateral del IDLE."""
         nonlocal directorio_actual
         directorio_actual = ruta.expanduser().resolve()
         reconstruir_arbol()
         page.update()
 
     def nuevo_handler(_e):
+        """Crea un documento nuevo en memoria; acción específica del IDLE."""
         estado.ruta = None
         estado.contenido_cargado = ""
         estado.cambios_sin_guardar = False
@@ -147,6 +151,7 @@ def main(page: "ft.Page"):
         page.update()
 
     def abrir_handler(_e):
+        """Abre la ruta escrita en el campo Ruta del IDLE."""
         if not ruta_input.value:
             salida.value = (
                 "Indica una ruta para abrir o selecciona un archivo del árbol."
@@ -156,12 +161,14 @@ def main(page: "ft.Page"):
         cargar_archivo(Path(ruta_input.value))
 
     def guardar_handler(_e):
+        """Guarda el archivo activo del IDLE o delega en Guardar como."""
         if estado.ruta is None:
             guardar_como_handler(_e)
             return
         guardar_en(estado.ruta)
 
     def guardar_como_handler(_e):
+        """Guarda el documento del IDLE en la ruta indicada."""
         if not ruta_input.value:
             salida.value = "Indica una ruta de destino en el campo Ruta."
             page.update()
@@ -169,32 +176,23 @@ def main(page: "ft.Page"):
         guardar_en(Path(ruta_input.value))
 
     def recargar_handler(_e):
+        """Recarga desde disco el archivo activo del IDLE."""
         if estado.ruta is None:
             salida.value = "No hay archivo activo que recargar."
             page.update()
             return
         cargar_archivo(estado.ruta)
 
-    def ejecutar_handler(_e):
-        deps = runtime.require_gui_dependencies()
-        codigo = runtime.normalizar_codigo(entrada.value)
-        try:
-            if activar.value and selector.value not in deps["TRANSPILERS"]:
-                salida.value = "Selecciona un lenguaje destino para transpilar"
-            elif activar.value and selector.value in deps["TRANSPILERS"]:
-                salida.value = runtime.transpilar_codigo(codigo, selector.value)
-            else:
-                salida.value = runtime.ejecutar_codigo(codigo)
-        except Exception as exc:
-            salida.value = runtime.formatear_error(
-                exc,
-                lexer_error_type=deps.get("LexerError"),
-                parser_error_type=deps.get("ParserError"),
-            )
-        finally:
-            page.update()
+    ejecutar_handler = runtime.crear_handler_ejecucion(
+        entrada=entrada,
+        salida=salida,
+        selector=selector,
+        activar=activar,
+        page=page,
+    )
 
     def tokens_handler(_e):
+        """Muestra tokens; herramienta extendida exclusiva del IDLE."""
         deps = runtime.require_gui_dependencies()
         codigo = runtime.normalizar_codigo(entrada.value)
         try:
@@ -209,6 +207,7 @@ def main(page: "ft.Page"):
             page.update()
 
     def ast_handler(_e):
+        """Muestra el AST; herramienta extendida exclusiva del IDLE."""
         deps = runtime.require_gui_dependencies()
         codigo = runtime.normalizar_codigo(entrada.value)
         try:
@@ -223,6 +222,7 @@ def main(page: "ft.Page"):
             page.update()
 
     def sugerencias_handler(_e):
+        """Genera sugerencias estilísticas; herramienta extendida del IDLE."""
         deps = runtime.require_gui_dependencies()
         codigo = runtime.normalizar_codigo(entrada.value)
         try:

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -220,6 +220,83 @@ def flet_dropdown_option(ft: Any, value: str) -> Any:
     return option_factory(value)
 
 
+def crear_editor_codigo(ft: Any, **kwargs: Any) -> Any:
+    """Crea el editor de código compartido por la app mínima y el IDLE."""
+
+    opciones = {"multiline": True, "expand": True}
+    opciones.update(kwargs)
+    return flet_text_field(ft, **opciones)
+
+
+def crear_salida_seleccionable(ft: Any, **kwargs: Any) -> Any:
+    """Crea la salida seleccionable compartida por la app mínima y el IDLE."""
+
+    opciones = {"value": "", "selectable": True}
+    opciones.update(kwargs)
+    return flet_text(ft, **opciones)
+
+
+def crear_selector_target(ft: Any, *, lenguajes: list[str] | None = None) -> Any:
+    """Crea el selector de target compartido para transpilación en GUI."""
+
+    targets = list(gui_target_choices()) if lenguajes is None else lenguajes
+    selector = flet_dropdown(
+        ft, options=[flet_dropdown_option(ft, lang) for lang in targets]
+    )
+    if targets:
+        selector.value = targets[0]
+    return selector
+
+
+def crear_switch_transpilacion(ft: Any, *, lenguajes: list[str] | None = None) -> Any:
+    """Crea el switch compartido que alterna ejecución y transpilación."""
+
+    targets = list(gui_target_choices()) if lenguajes is None else lenguajes
+    return flet_switch(ft, label="Transpilar", disabled=not targets)
+
+
+def ejecutar_o_transpilar(codigo: str, *, transpilacion_activa: bool, target: str) -> str:
+    """Ejecuta o transpila código Cobra; lógica compartida por ambas GUIs."""
+
+    deps = require_gui_dependencies()
+    if transpilacion_activa and target not in deps["TRANSPILERS"]:
+        return "Selecciona un lenguaje destino para transpilar"
+    if transpilacion_activa:
+        return transpilar_codigo(codigo, target)
+    return ejecutar_codigo(codigo)
+
+
+def crear_handler_ejecucion(
+    *,
+    entrada: Any,
+    salida: Any,
+    selector: Any,
+    activar: Any,
+    page: Any,
+) -> Any:
+    """Crea el handler compartido de ejecutar/transpilar para app mínima e IDLE."""
+
+    def ejecutar_handler(_e: Any) -> None:
+        deps = require_gui_dependencies()
+        codigo = normalizar_codigo(entrada.value)
+        try:
+            salida.value = ejecutar_o_transpilar(
+                codigo,
+                transpilacion_activa=bool(activar.value),
+                target=str(selector.value or ""),
+            )
+        except Exception as exc:
+            salida.value = formatear_error(
+                exc,
+                lexer_error_type=deps.get("LexerError"),
+                parser_error_type=deps.get("ParserError"),
+            )
+        finally:
+            page.update()
+
+    return ejecutar_handler
+
+
 def normalizar_codigo(codigo: str | None) -> str:
     """Normaliza la entrada para evitar valores ``None``."""
     return codigo or ""


### PR DESCRIPTION
### Motivation
- Reducir duplicación entre los entrypoints GUI y centralizar la construcción de widgets y la lógica de ejecutar/transpilar. 
- Permitir que `app.py` permanezca como interfaz mínima y que `idle.py` mantenga la interfaz extendida mientras reutilizan código común.

### Description
- Añadidos helpers compartidos en `src/pcobra/gui/runtime.py`: `crear_editor_codigo`, `crear_salida_seleccionable`, `crear_selector_target`, `crear_switch_transpilacion`, `ejecutar_o_transpilar` y `crear_handler_ejecucion`, todos con docstrings que indican su carácter compartido. 
- `src/pcobra/gui/app.py` simplificado para componer la UI mínima usando los helpers y mantener `runtime.flet_app(main)` como entrypoint. 
- `src/pcobra/gui/idle.py` actualizado para reutilizar los mismos helpers mientras conserva las funcionalidades extendidas (gestión de archivos, árbol, tokens, AST y sugerencias) y se añadieron docstrings breves a funciones específicas del IDLE. 
- No se cambió la lógica funcional de ejecución/transpilación, sólo se extrajo a helpers compartidos y se redujo duplicación entre los entrypoints.

### Testing
- Ejecutado `python -m compileall src/pcobra/gui` y la compilación de los módulos GUI fue correcta. 
- Ejecutados tests focalizados de GUI: `python -m pytest -q tests/unit/test_gui_runtime.py tests/unit/test_gui_app.py tests/unit/test_gui_idle.py tests/gui/test_runtime_file_helpers.py`, todos pasaron (21 tests en el conjunto ejecutado). 
- Verificación de docstrings/exports con un script de importación (inspección de `app.main`, `idle.main` y helpers) completada con éxito. 
- Intento de `python -m pytest -q` a la suite completa falló en colección por imports faltantes de transpilers/backend (`cobra.transpilers.transpiler.to_cpp`, `to_go`, `to_asm`, e `INTERNAL_BACKENDS`), los cuales son preexistentes y no están relacionados con este refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e81117df88327b4929a189d56f3f7)