### PR TITLE
Agregar import Path en GUI app y prueba de importación

### DIFF
--- a/src/pcobra/gui/app.py
+++ b/src/pcobra/gui/app.py
@@ -1,5 +1,6 @@
 """Aplicación gráfica básica usando Flet para ejecutar código Cobra."""
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pcobra.gui import runtime

--- a/tests/gui/test_app_import.py
+++ b/tests/gui/test_app_import.py
@@ -1,0 +1,5 @@
+from pcobra.gui import app
+
+
+def test_main_se_resuelve_sin_name_error():
+    assert callable(app.main)


### PR DESCRIPTION
### Motivation
- El árbol de directorios en la GUI usa `Path` en `root_path=Path(".").resolve()` pero `Path` no estaba importado, lo que puede provocar errores estáticos o `NameError` al importar el módulo.

### Description
- Añadido `from pathlib import Path` en `src/pcobra/gui/app.py` para resolver la referencia a `Path`.
- Añadida la prueba `tests/gui/test_app_import.py` que importa `pcobra.gui.app` y verifica que `main` se resuelve como callable para prevenir regresiones de importación.

### Testing
- Ejecutado `python -m pytest tests/gui/test_app_import.py tests/gui/test_runtime_file_helpers.py` y todas las pruebas pasaron (`5 passed`).
- Ejecutado `python -m py_compile src/pcobra/gui/app.py` y la compilación estática fue exitosa.
- Ejecutado `python -m ruff check src/pcobra/gui/app.py tests/gui/test_app_import.py` y no se reportaron errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ee735b5648327b824f0728ce0af90)