### PR TITLE
Evita import eager de Flet en runtime GUI

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -1,10 +1,12 @@
 """Runtime compartido para las interfaces GUI de Cobra."""
 
-from typing import Any
-import flet as ft
-from pathlib import Path
-from functools import lru_cache
+import io
+import re
+from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
 
 from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 
@@ -331,10 +333,14 @@ def _guardar_archivo(page: Any, entrada: Any, estado_archivo: GuiFileState, ruta
         estado_archivo.contenido_cargado = contenido_guardado
         estado_archivo.cambios_sin_guardar = False
         page.snack_bar.open = True
-        page.snack_bar.content = ft.Text(f"Archivo guardado en {ruta}")
+        page.snack_bar.content = flet_text(
+            require_flet(), f"Archivo guardado en {ruta}"
+        )
     except Exception as exc:
         page.snack_bar.open = True
-        page.snack_bar.content = ft.Text(f"Error al guardar: {exc}")
+        page.snack_bar.content = flet_text(
+            require_flet(), f"Error al guardar: {exc}"
+        )
     finally:
         page.update()
 
@@ -366,11 +372,15 @@ def crear_handler_guardar_como(
     """Crea el handler para guardar el archivo con un nuevo nombre/ruta."""
 
     def guardar_como_handler(_e: Any) -> None:
-        def on_file_dialog_result(e: ft.FilePickerResultEvent):
+        flet_runtime = require_flet()
+
+        def on_file_dialog_result(e: Any) -> None:
             if e.path:
                 _guardar_archivo(page, entrada, estado_archivo, Path(e.path))
 
-        file_picker = ft.FilePicker(on_result=on_file_dialog_result)
+        file_picker = _flet_attr(flet_runtime, "FilePicker", "FilePicker")(
+            on_result=on_file_dialog_result
+        )
         page.overlay.append(file_picker)
         page.update()
         file_picker.save_file(

--- a/tests/gui/test_runtime_import_without_flet.py
+++ b/tests/gui/test_runtime_import_without_flet.py
@@ -1,0 +1,22 @@
+import builtins
+import importlib
+import sys
+
+
+def test_runtime_import_no_requiere_flet(monkeypatch):
+    """El runtime GUI debe importarse aunque Flet no esté instalado."""
+
+    sys.modules.pop("pcobra.gui.runtime", None)
+    sys.modules.pop("flet", None)
+    real_import = builtins.__import__
+
+    def import_without_flet(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "flet" or name.startswith("flet."):
+            raise ModuleNotFoundError("No module named 'flet'", name="flet")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_flet)
+
+    runtime = importlib.import_module("pcobra.gui.runtime")
+
+    assert callable(runtime.require_flet)


### PR DESCRIPTION
### Motivation
- Evitar que `import pcobra.gui.runtime` requiera que la dependencia `flet` esté instalada para usos no-GUI, manteniendo la CLI y las pruebas ligeras.
- Centralizar la carga de Flet en un único punto (`require_flet()`) y eliminar dependencias globales sobre el símbolo `ft` en tiempo de importación.

### Description
- Elimina el `import flet as ft` en el nivel superior de `src/pcobra/gui/runtime.py` y mantiene `require_flet()` como único punto de carga diferida de Flet.
- Sustituye anotaciones/uso que dependían de `ft` en el import time por `Any`, por ejemplo el callback `on_file_dialog_result(e: Any)` en lugar de `ft.FilePickerResultEvent`.
- Evita el uso del símbolo global `ft` en funciones internas, usando `require_flet()` y los adaptadores `flet_text` / `_flet_attr(..., "FilePicker", ...)` para crear componentes y textos de Flet.
- Añade la prueba `tests/gui/test_runtime_import_without_flet.py` que simula la ausencia de `flet` y verifica que `pcobra.gui.runtime` se importa y expone `require_flet` correctamente.
- Archivos modificados: `src/pcobra/gui/runtime.py` y `tests/gui/test_runtime_import_without_flet.py`.

### Testing
- Ejecutado: `python -m pytest tests/gui/test_runtime_import_without_flet.py tests/gui/test_runtime_file_helpers.py tests/gui/test_app_import.py` y todos los tests pasaron (`6 passed`).
- Ejecutado: `python -m ruff check src/pcobra/gui/runtime.py tests/gui/test_runtime_import_without_flet.py` y el linter no reportó fallos.
- Se comprobó que no hay problemas de diff/check con `git diff --check` (sin errores automáticos detectados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2efd2f3f8483278241925a507cd221)