### PR TITLE
test: cubrir helpers de runtime GUI y ajustar imports de contextlib

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -2,7 +2,7 @@
 
 import io
 import re
-from contextlib import redirect_stderr, redirect_stdout
+from contextlib import redirect_stdout, redirect_stderr
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path

--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -42,3 +42,78 @@ def test_escribir_archivo_texto_propaga_ruta_inexistente(tmp_path: Path):
         pass
     else:
         raise AssertionError("La escritura debe fallar si el directorio no existe")
+
+
+def test_parse_missing_target_detecta_modulo_faltante_con_accion_dependencia():
+    exc = ModuleNotFoundError("No module named 'flet'", name="flet")
+
+    missing_target, action = runtime._parse_missing_target(exc)
+
+    assert missing_target == "flet"
+    assert "instala la dependencia" in action
+    assert "flet" in action
+
+
+def test_parse_missing_target_detecta_simbolo_faltante_en_import_local():
+    exc = ImportError(
+        "cannot import name 'Lexer' from 'pcobra.cobra.gui.deps' "
+        "(/tmp/pcobra/cobra/gui/deps.py)"
+    )
+
+    missing_target, action = runtime._parse_missing_target(exc)
+
+    assert missing_target == "pcobra.cobra.gui.deps.Lexer"
+    assert "corrige el import local" in action
+    assert "pcobra.cobra.gui.deps.Lexer" in action
+
+
+def test_ejecutar_codigo_usa_dependencias_gui_y_captura_stdout_stderr(monkeypatch):
+    calls = []
+
+    class FakeLexer:
+        def __init__(self, codigo: str) -> None:
+            calls.append(("lexer_init", codigo))
+
+        def tokenizar(self) -> list[str]:
+            print("salida desde lexer")
+            calls.append(("tokenizar",))
+            return ["TOKEN"]
+
+    class FakeParser:
+        def __init__(self, tokens: list[str]) -> None:
+            calls.append(("parser_init", tokens))
+
+        def parsear(self) -> str:
+            calls.append(("parsear",))
+            return "AST"
+
+    class FakeInterpretadorCobra:
+        def ejecutar_ast(self, ast: str) -> None:
+            import sys
+
+            print(f"stdout ast={ast}")
+            print("stderr capturado", file=sys.stderr)
+            calls.append(("ejecutar_ast", ast))
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {
+            "Lexer": FakeLexer,
+            "Parser": FakeParser,
+            "InterpretadorCobra": FakeInterpretadorCobra,
+        },
+    )
+
+    salida = runtime.ejecutar_codigo("mostrar 1")
+
+    assert calls == [
+        ("lexer_init", "mostrar 1"),
+        ("tokenizar",),
+        ("parser_init", ["TOKEN"]),
+        ("parsear",),
+        ("ejecutar_ast", "AST"),
+    ]
+    assert "salida desde lexer" in salida
+    assert "stdout ast=AST" in salida
+    assert "stderr capturado" in salida


### PR DESCRIPTION
### Motivation

- Añadir cobertura de pruebas para los ayudantes de runtime de la GUI, en particular `_parse_missing_target()` y `ejecutar_codigo()`, para detectar regresiones en diagnóstico de importaciones y captura de salida.
- Evitar ejecutar código Cobra real en tests usando dobles/mocks para las dependencias del runtime.
- Asegurar que no quedan símbolos globales no definidos mediante la revisión estática configurada ( Ruff ).

### Description

- Se ajustó el orden del import de `contextlib` a `from contextlib import redirect_stdout, redirect_stderr` en `src/pcobra/gui/runtime.py` sin cambiar la lógica funcional.
- Se añadieron pruebas en `tests/gui/test_runtime_file_helpers.py` que cubren `_parse_missing_target()` para módulos faltantes y símbolos faltantes en imports locales.
- Se añadió una prueba que sustituye `require_gui_dependencies` por dobles (`FakeLexer`, `FakeParser`, `FakeInterpretadorCobra`) y verifica el orden de llamadas y la captura de `stdout`/`stderr` en `ejecutar_codigo()`.

### Testing

- Se ejecutó `python -m pytest tests/gui/test_runtime_file_helpers.py` y todas las pruebas relevantes pasaron (`7 passed`).
- Se ejecutó la revisión estática con `python -m ruff check src/pcobra/gui/runtime.py` y `ruff` no reportó errores (todas las comprobaciones pasaron).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f97be0b288327993d2d80594d0285)