### PR TITLE
Reutilizar generar_sugerencias en el handler de sugerencias Agix

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+from pcobra.ia.analizador_agix import generar_sugerencias
 
 
 @lru_cache(maxsize=1)
@@ -401,27 +402,31 @@ def crear_handler_sugerencias_agix(
     """Crea el handler para generar sugerencias de código con Agix."""
 
     def sugerencias_agix_handler(_e: Any) -> None:
+        deps = require_gui_dependencies()
+        codigo = normalizar_codigo(entrada.value)
         try:
-            from agix.reasoning.basic import Reasoner
-            from agix.models.code_suggestion import CodeSuggestion
-            from agix.models.code_document import CodeDocument
-
-            codigo = normalizar_codigo(entrada.value)
-            documento = CodeDocument(code=codigo, language="cobra")
-            reasoner = Reasoner()
-            sugerencias: list[CodeSuggestion] = reasoner.suggest(documento)
-
+            # ``generar_sugerencias`` centraliza la validación con Lexer/Parser
+            # y evita depender de modelos internos de ``agix.models.*``.
+            sugerencias = generar_sugerencias(codigo)
+        except ImportError as exc:
+            salida.value = (
+                "Agix no está instalado o no está disponible. "
+                "Instálalo con 'pip install agix' para usar esta función. "
+                f"Detalle: {exc}"
+            )
+        except Exception as exc:
+            salida.value = formatear_error(
+                exc,
+                lexer_error_type=deps.get("LexerError"),
+                parser_error_type=deps.get("ParserError"),
+            )
+        else:
             if sugerencias:
                 salida.value = "Sugerencias de Agix:\n" + "\n".join(
-                    f"- {s.suggestion} (Precisión: {s.precision:.2f}, Interpretabilidad: {s.interpretability:.2f})"
-                    for s in sugerencias
+                    f"- {sugerencia}" for sugerencia in sugerencias
                 )
             else:
                 salida.value = "Agix no encontró sugerencias para el código actual."
-        except ModuleNotFoundError:
-            salida.value = "Agix no está instalado. Instálalo con 'pip install agix' para usar esta función."
-        except Exception as exc:
-            salida.value = f"Error al generar sugerencias con Agix: {exc}"
         finally:
             page.update()
 

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -227,3 +227,91 @@ def test_formatear_error_lexico_y_sintactico_sin_recargar_dependencias(monkeypat
         parser_error_type=FakeParserError,
     ) == "Error de sintaxis: faltó ')'"
     assert llamadas["count"] == 0
+
+
+def test_crear_handler_sugerencias_agix_exitosas(monkeypatch: pytest.MonkeyPatch) -> None:
+    entrada = SimpleNamespace(value="imprimir('Hola')")
+    salida = SimpleNamespace(value="")
+    page = SimpleNamespace(update=lambda: setattr(page, "updated", True))
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {"LexerError": Exception, "ParserError": Exception},
+    )
+    monkeypatch.setattr(
+        runtime,
+        "generar_sugerencias",
+        lambda codigo: [f"Sugerencia para {codigo}"],
+    )
+
+    handler = runtime.crear_handler_sugerencias_agix(
+        entrada=entrada, salida=salida, page=page
+    )
+    handler(None)
+
+    assert salida.value == "Sugerencias de Agix:\n- Sugerencia para imprimir('Hola')"
+    assert page.updated is True
+
+
+def test_crear_handler_sugerencias_agix_dependencia_ausente(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entrada = SimpleNamespace(value="imprimir('Hola')")
+    salida = SimpleNamespace(value="")
+    page = SimpleNamespace(update=lambda: setattr(page, "updated", True))
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {"LexerError": Exception, "ParserError": Exception},
+    )
+
+    def _generar_sugerencias(_codigo: str) -> list[str]:
+        raise ImportError("Instala el paquete agix")
+
+    monkeypatch.setattr(runtime, "generar_sugerencias", _generar_sugerencias)
+
+    handler = runtime.crear_handler_sugerencias_agix(
+        entrada=entrada, salida=salida, page=page
+    )
+    handler(None)
+
+    assert "Agix no está instalado o no está disponible" in salida.value
+    assert "pip install agix" in salida.value
+    assert "Instala el paquete agix" in salida.value
+    assert page.updated is True
+
+
+def test_crear_handler_sugerencias_agix_error_lexico_sintactico_claro(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeLexerError(Exception):
+        linea = 3
+        columna = 9
+
+    class FakeParserError(Exception):
+        pass
+
+    entrada = SimpleNamespace(value="@")
+    salida = SimpleNamespace(value="")
+    page = SimpleNamespace(update=lambda: setattr(page, "updated", True))
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {"LexerError": FakeLexerError, "ParserError": FakeParserError},
+    )
+
+    def _generar_sugerencias(_codigo: str) -> list[str]:
+        raise FakeLexerError("carácter inválido")
+
+    monkeypatch.setattr(runtime, "generar_sugerencias", _generar_sugerencias)
+
+    handler = runtime.crear_handler_sugerencias_agix(
+        entrada=entrada, salida=salida, page=page
+    )
+    handler(None)
+
+    assert salida.value == "Error léxico (línea 3, columna 9): carácter inválido"
+    assert page.updated is True


### PR DESCRIPTION
### Motivation
- Evitar importar clases internas de `agix.models.*` desde el runtime de la GUI y reducir el acoplamiento directo con la API interna de `agix`.
- Centralizar la validación léxica/sintáctica en un único punto (`generar_sugerencias`) para evitar duplicación de validaciones `Lexer`/`Parser` en el handler de la GUI.
- Unificar los mensajes de UI usando el nombre `Agix` y proporcionar retroalimentación clara cuando la dependencia falta o cuando hay errores léxicos/sintácticos.

### Description
- Importa y reutiliza `generar_sugerencias` desde `pcobra.ia.analizador_agix` en `src/pcobra/gui/runtime.py` y elimina el uso directo de `agix.models.*` dentro de `crear_handler_sugerencias_agix`.
- El handler `crear_handler_sugerencias_agix` ahora llama a `generar_sugerencias(codigo)`, captura `ImportError` para mostrar un mensaje accionable que recomienda `pip install agix`, y usa `formatear_error()` para mostrar errores léxicos/sintácticos con los tipos inyectados desde `require_gui_dependencies()`.
- Se actualizaron los textos que se muestran en la UI para usar consistentemente `Agix` y para presentar resultados, ausencia de sugerencias y errores de forma legible.
- Agregué pruebas unitarias en `tests/unit/test_gui_runtime.py` usando `monkeypatch` que verifican: sugerencias exitosas, dependencia ausente (lanza `ImportError`) y manejo claro de error léxico/sintáctico (mapea a mensaje de `LexerError`/`ParserError`).

### Testing
- Ejecuté `pytest -q tests/unit/test_gui_runtime.py` y todos los tests pasaron (`14 passed`).
- Ejecuté `python -m py_compile src/pcobra/gui/runtime.py tests/unit/test_gui_runtime.py` sin errores de sintaxis.
- Las pruebas añadidas cubren los casos de éxito, dependencia ausente y error léxico/sintáctico y fueron validadas con `monkeypatch` en los tests unitarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f9cf9b9948327b0b4447d270c0128)