### PR TITLE
docs: alinear targets públicos de transpilación

### DIFF
--- a/docs/arquitectura_parser_transpiladores.md
+++ b/docs/arquitectura_parser_transpiladores.md
@@ -11,7 +11,7 @@ Se encarga de leer el texto fuente y convertirlo en una secuencia de *tokens*. C
 Consume los tokens generados por el lexer y construye el \u00c1rbol de Sintaxis Abstracta (**AST**). El parser valida la estructura del programa y crea los nodos que representar\u00e1n instrucciones, expresiones y declaraciones.
 
 ### `transpilers`
-Una vez disponible el AST, los transpiladores recorren cada nodo mediante el patr\u00f3n *Visitor* para generar c\u00f3digo en otros lenguajes. Cobra expone como destinos oficiales los 8 nombres can\u00f3nicos `python`, `rust`, `javascript`, `wasm`, `go`, `cpp`, `java` y `asm`.
+Una vez disponible el AST, los transpiladores recorren cada nodo mediante el patr\u00f3n *Visitor* para generar c\u00f3digo en otros lenguajes. Cobra expone como destinos oficiales públicos únicamente `python`, `javascript` y `rust`, en el mismo orden contractual de `PUBLIC_BACKENDS` (`src/pcobra/cobra/architecture/backend_policy.py`). Los transpilers históricos `wasm`, `go`, `cpp`, `java` y `asm` quedan fuera de la superficie pública y solo pueden tratarse como rutas internas de migración o regresión.
 
 ## Interacci\u00f3n general
 El proceso habitual comienza con el lexer, sigue con el parser y finaliza en el int\u00e9rprete o en alguno de los transpiladores. La siguiente gr\u00e1fica resume dicho flujo.
@@ -33,7 +33,6 @@ AST --> "Interprete"
 AST --> Transpiladores
 Transpiladores --> python
 Transpiladores --> javascript
-Transpiladores --> asm
 Transpiladores --> rust
 @enduml
 ```

--- a/docs/especificacion_tecnica.md
+++ b/docs/especificacion_tecnica.md
@@ -6,7 +6,7 @@ Para ver ejemplos completos de compilación y transpilación, consulta la carpet
 
 ## Targets oficiales de transpilación
 
-En runtime oficial y para soporte de producción, Cobra define **únicamente** los targets de transpilación publicados por la política canónica. Esa lista se deriva de `src/pcobra/cobra/config/transpile_targets.py` (`OFFICIAL_TARGETS`) y del registro canónico en `src/pcobra/cobra/transpilers/registry.py`.
+En runtime oficial y para soporte de producción, Cobra define **únicamente** los targets de transpilación publicados por la política canónica. Esa lista se deriva de `src/pcobra/cobra/architecture/backend_policy.py` (`PUBLIC_BACKENDS`).
 
 Cualquier backend o flujo de implementación fuera de esa lista debe considerarse experimental y no forma
 parte del paquete instalable de producción.
@@ -14,7 +14,7 @@ parte del paquete instalable de producción.
 ## Matriz técnica de compatibilidad de librerías
 
 La matriz vigente de compatibilidad por librería (runtime, parser, serialización y red)
-para los 8 targets oficiales se publica en:
+para los 3 targets públicos oficiales (`python`, `javascript`, `rust`) se publica en:
 
 - [`docs/library_compatibility_matrix.md`](./library_compatibility_matrix.md)
 

--- a/docs/estructura_ast.md
+++ b/docs/estructura_ast.md
@@ -61,17 +61,12 @@ Parser --> AST
 AST --> Transpiladores
 Transpiladores --> Python
 Transpiladores --> javascript
-Transpiladores --> asm
 Transpiladores --> Rust
-Transpiladores --> cpp
-Transpiladores --> Go
-Transpiladores --> Java
-Transpiladores --> wasm
 @enduml
 ```
 
 
 ## Archivo histórico (no soportado)
 
-Las referencias históricas a targets retirados se eliminaron de esta guía para
-mantenerla alineada con los 8 destinos oficiales actuales.
+Las referencias históricas a `wasm`, `go`, `cpp`, `java` y `asm` se eliminaron de esta guía para
+mantenerla alineada con los 3 destinos oficiales públicos actuales: `python`, `javascript` y `rust`.

--- a/docs/genericos.md
+++ b/docs/genericos.md
@@ -12,10 +12,9 @@ clase Caja<T>:
     fin
 ```
 
-Al transpilar a `python`, `rust` o `cpp` los parámetros se convierten en las
-construcciones genéricas propias de cada lenguaje. En lenguajes sin soporte
-de genéricos, como `javascript`, los parámetros de tipo se omiten y se utilizan
-tipos dinámicos.
+Al transpilar a los targets oficiales públicos `python`, `javascript` y `rust`, los parámetros se convierten en las
+construcciones genéricas propias de cada lenguaje cuando existen. En `javascript`, los parámetros de tipo se omiten y se utilizan
+tipos dinámicos. Las variantes históricas para `cpp` quedan fuera de la documentación pública.
 
 ```python
 from typing import TypeVar, Generic
@@ -34,14 +33,6 @@ fn identidad<T>(x: T) {
 
 struct Caja<T> {}
 impl<T> Caja<T> {}
-```
-
-```cpp
-template <typename T>
-void identidad(T x) {}
-
-template <typename T>
-class Caja {};
 ```
 
 ```javascript

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -32,5 +32,5 @@ clase Archivo(Printable, Comprimible):
 fin
 ```
 
-En los transpilers a `python`, `javascript`, `cpp` y `rust` se generan las construcciones equivalentes
-(`class` abstracta, clase vacía, `struct` con métodos virtuales y `trait`).
+En los transpilers oficiales públicos a `python`, `javascript` y `rust` se generan las construcciones equivalentes
+(`class` abstracta, clase vacía y `trait`). Los ejemplos de `cpp` pertenecen a rutas históricas internas y no forman parte de la superficie pública.

--- a/docs/language_equivalence_matrix.md
+++ b/docs/language_equivalence_matrix.md
@@ -9,7 +9,7 @@ La fuente estructurada se mantiene en `data/language_equivalence.yml` y se valid
 Cada feature documenta:
 - Sintaxis Cobra.
 - Equivalente Python.
-- Equivalentes por backend: `javascript`, `rust`, `go`, `cpp`, `java`, `wasm`, `asm`.
+- Equivalentes por backend público: `python`, `javascript`, `rust`. Las columnas históricas para `go`, `cpp`, `java`, `wasm` y `asm` se retiraron de la superficie pública.
 - Estado por backend (`full`, `partial`, `none`) y limitaciones.
 
 ## Features cubiertas
@@ -32,14 +32,14 @@ El orden anterior se refleja en `LANGUAGE_EQUIVALENCE_PRIORITY_PHASES` dentro de
 
 ## Resumen de estado por feature/backend
 
-| Feature | python | javascript | rust | go | cpp | java | wasm | asm |
-|---|---|---|---|---|---|---|---|---|
-| decoradores | full | full | partial | partial | partial | none | partial | partial |
-| imports_corelibs | full | partial | partial | partial | partial | partial | partial | partial |
-| manejo_errores | full | partial | partial | partial | partial | partial | partial | partial |
-| async | full | full | none | partial | none | none | none | partial |
-| tipos_compuestos | full | full | partial | partial | partial | partial | partial | partial |
-| hooks_runtime | full | full | full | full | full | full | full | full |
+| Feature | python | javascript | rust |
+|---|---|---|---|
+| decoradores | full | full | partial |
+| imports_corelibs | full | partial | partial |
+| manejo_errores | full | partial | partial |
+| async | full | full | none |
+| tipos_compuestos | full | full | partial |
+| hooks_runtime | full | full | full |
 
 ## Sincronización y backlog técnico
 

--- a/docs/lenguajes_soportados.rst
+++ b/docs/lenguajes_soportados.rst
@@ -1,7 +1,7 @@
 Estado de los lenguajes soportados
 =================================
 
-Esta guía mantiene una sola narrativa pública: pCobra transpila únicamente a **8 backends oficiales** y separa con claridad la lista de targets de salida, el estado de runtime y la compatibilidad contractual de Holobit/SDK.
+Esta guía mantiene una sola narrativa pública: pCobra transpila públicamente únicamente a **3 backends oficiales** (``python``, ``javascript`` y ``rust``) y separa con claridad la lista de targets de salida, el estado de runtime y la compatibilidad contractual de Holobit/SDK.
 
 Resumen normativo derivado automáticamente desde la política canónica:
 
@@ -9,7 +9,7 @@ Resumen normativo derivado automáticamente desde la política canónica:
 
 Fuentes normativas visibles:
 
-- ``src/pcobra/cobra/config/transpile_targets.py`` para la lista canónica y los tiers.
+- ``src/pcobra/cobra/architecture/backend_policy.py`` (``PUBLIC_BACKENDS``) para la lista pública canónica y el orden contractual.
 - ``src/pcobra/cobra/cli/target_policies.py`` para la separación entre transpilación, runtime oficial, runtime best-effort y compatibilidad SDK.
 - ``src/pcobra/cobra/transpilers/compatibility_matrix.py`` para el estado contractual de Holobit, ``corelibs`` y ``standard_library``.
 
@@ -21,8 +21,8 @@ Lista exacta de targets oficiales
 Resumen por tier
 ----------------
 
-- **Tier 1**: ``python``, ``rust``, ``javascript`` y ``wasm``.
-- **Tier 2**: ``go``, ``cpp``, ``java`` y ``asm``.
+- **Tier 1 público**: ``python``, ``javascript`` y ``rust``.
+- **Legacy interno/histórico**: ``wasm``, ``go``, ``cpp``, ``java`` y ``asm`` no forman parte de la superficie pública.
 
 Capacidades públicas por backend
 --------------------------------
@@ -33,14 +33,12 @@ Interpretación oficial:
 
 - ``python`` es el único backend con compatibilidad SDK completa y estado Holobit ``full``.
 - ``rust`` y ``javascript`` tienen runtime oficial verificable y adaptador Holobit mantenido por el proyecto, pero siguen en estado contractual ``partial``.
-- ``go`` y ``java`` conservan runtime best-effort no público (sin runtime Docker oficial).
-- ``wasm`` y ``asm`` son backends oficiales de salida orientados a transpilación, no a runtime oficial público ni Docker oficial.
-- ``cpp`` permanece como backend legacy/internal sin runtime Docker oficial público.
+- ``wasm``, ``go``, ``cpp``, ``java`` y ``asm`` permanecen como referencias históricas o rutas internas de migración/regresión, sin runtime Docker oficial público ni contrato de salida público.
 
 Transpilación inversa (feature independiente)
 ---------------------------------------------
 
-La transpilación inversa es una capacidad separada de los backends de salida. Los orígenes soportados hoy son ``python``, ``javascript`` y ``java``; el destino final debe ser uno de los 8 backends oficiales de salida.
+La transpilación inversa es una capacidad separada de los backends de salida. Los orígenes soportados hoy son ``python``, ``javascript`` y ``java``; el destino final público debe ser uno de ``python``, ``javascript`` o ``rust``.
 
 .. code-block:: bash
 

--- a/docs/migracion_targets_retirados.md
+++ b/docs/migracion_targets_retirados.md
@@ -4,10 +4,10 @@ Este documento describe cómo migrar proyectos que dependían de targets elimina
 
 ## Estado actual (canónico + deprecaciones activas)
 
-Los targets canónicos de salida registrados son:
+Los targets canónicos públicos de salida registrados por `PUBLIC_BACKENDS` son:
 
-- **Tier 1**: `python`, `rust`, `javascript`, `wasm` *(con `wasm` deprecado para superficie pública)*.
-- **Tier 2**: `go`, `cpp`, `java`, `asm` *(deprecados para superficie pública)*.
+- **Tier 1 público**: `python`, `javascript`, `rust`.
+- **Legacy interno/histórico**: `wasm`, `go`, `cpp`, `java`, `asm` quedan fuera de la superficie pública.
 
 ### Deprecación pública (2 fases)
 
@@ -20,18 +20,16 @@ Plan aplicado:
 1. **Fase 1 (actual por defecto)**: warning en CLI + telemetría de uso.
 2. **Fase 2**: ocultos del help público y disponibles solo en modo legacy (`--legacy-targets` o `COBRA_LEGACY_TARGETS_MODE=1`).
 
-Si tu flujo usa un target retirado, debes moverlo a uno de estos 8.
+Si tu flujo usa un target retirado, debes moverlo a uno de los 3 targets públicos: `python`, `javascript` o `rust`.
 
 ## Selección de destino recomendada
 
 Elige el target según objetivo de tu pipeline:
 
-1. **Necesitas runtime oficial verificable en CLI/sandbox/contenedor**  
-   Migra a: `python`, `rust`, `javascript` o `cpp`.
-2. **Necesitas salida oficial pero aceptas runtime best-effort**  
-   Migra a: `go` o `java`.
-3. **Solo necesitas artefacto de transpilación/inspección**  
-   Migra a: `wasm` o `asm`.
+1. **Necesitas runtime oficial verificable en CLI/sandbox/contenedor**
+   Migra a: `python`, `javascript` o `rust`.
+2. **Necesitas salida legacy o artefactos de inspección**
+   Mantén ese uso fuera de la CLI/documentación pública y trátalo como migración interna temporal.
 
 ## Migración de comandos CLI
 
@@ -44,15 +42,14 @@ Elige el target según objetivo de tu pipeline:
 ## Compatibilidad Holobit SDK y librerías tras migrar
 
 - **Compatibilidad SDK full**: solo `python`.
-- **Resto de targets oficiales**: compatibilidad `partial`.
-- **Soporte oficial de runtime para `corelibs`/`standard_library`**: `python`, `rust`, `javascript`, `cpp`.
-- `go`/`java`: runtime best-effort.
-- `wasm`/`asm`: solo transpilación.
+- **Resto de targets públicos oficiales**: `javascript` y `rust` mantienen compatibilidad `partial`.
+- **Soporte oficial de runtime para `corelibs`/`standard_library`**: `python`, `javascript`, `rust`.
+- `wasm`, `go`, `cpp`, `java` y `asm`: rutas legacy internas/históricas, sin contrato público.
 
 ## Checklist de salida
 
 - [ ] No quedan referencias a targets retirados en `README`, `docs/`, `examples/`, `scripts/`.
-- [ ] Todos los comandos y snippets usan únicamente los 8 targets canónicos.
+- [ ] Todos los comandos y snippets públicos usan únicamente `python`, `javascript` y `rust`.
 - [ ] Se validó documentación y política con:
 
 ```bash

--- a/docs/proposals/plan_nuevas_funcionalidades.md
+++ b/docs/proposals/plan_nuevas_funcionalidades.md
@@ -10,7 +10,7 @@
 
 - **Biblioteca estándar**: ampliar textos, colecciones, números y booleanos con APIs inspiradas en Python y compatibles con la arquitectura actual.
 - **Modelo de ejecución**: introducir asincronía idiomática, decoradores utilitarios y utilidades concurrentes sin cambiar la política pública de targets.
-- **Interoperabilidad multilenguaje**: priorizar mejoras que mantengan paridad semántica dentro de los 8 targets oficiales (`python`, `rust`, `javascript`, `wasm`, `go`, `cpp`, `java`, `asm`).
+- **Interoperabilidad multilenguaje**: priorizar mejoras que mantengan paridad semántica dentro de los 3 targets públicos oficiales (`python`, `javascript`, `rust`). Las referencias a `wasm`, `go`, `cpp`, `java` o `asm` quedan como investigación histórica/interna y no amplían la superficie pública.
 - **Documentación y adopción**: acompañar cada fase con manuales, notebooks, automatización de pruebas y seguimiento de indicadores.
 
 ## Objetivos generales
@@ -27,13 +27,8 @@
 Los únicos targets públicos de salida contemplados por esta propuesta son:
 
 - `python`
-- `rust`
 - `javascript`
-- `wasm`
-- `go`
-- `cpp`
-- `java`
-- `asm`
+- `rust`
 
 ### Referencias explícitamente fuera de alcance
 
@@ -231,4 +226,4 @@ El siguiente backlog descompone cada tarea macro en actividades implementables c
 | --- | --- | --- | --- | --- | --- |
 | F4.1.a | Actualizar manuales con nuevas APIs | Revisar `docs/MANUAL_COBRA.md`, `docs/guia_basica.md`, `docs/README.en.md` | Validación con la pipeline de docs y revisión ortográfica | Plantillas de snippets en `docs/standard_library/` | Depende de fases 1-3 |
 | F4.1.b | Crear tutorial guiado paso a paso | Notebook y ejemplo principal de novedades | Ejecución manual en CI y smoke tests | Entrada de blog o guía interna | Depende de F4.1.a |
-| F4.2.a | Añadir suites diferenciales en CI | Extender scripts/CI para verificar semántica en los 8 targets oficiales | Ejecución automatizada por matriz | Documentar criterios de cobertura | Depende de fases 1-3 |
+| F4.2.a | Añadir suites diferenciales en CI | Extender scripts/CI para verificar semántica en los 3 targets públicos oficiales | Ejecución automatizada por matriz | Documentar criterios de cobertura | Depende de fases 1-3 |

--- a/docs/proposals/recorte_targets_oficiales_tareas.md
+++ b/docs/proposals/recorte_targets_oficiales_tareas.md
@@ -6,10 +6,7 @@ Este documento es el **documento madre de implementación** para cerrar el traba
 
 > **Aclaración de alcance**
 >
-> El objetivo de esta propuesta **no es cambiar el set de 8 targets oficiales**. Ese recorte ya está resuelto y la fuente de verdad vigente ya fija estos destinos:
->
-> - Tier 1: `python`, `rust`, `javascript`, `wasm`
-> - Tier 2: `go`, `cpp`, `java`, `asm`
+> Esta propuesta queda como **nota histórica**: el alcance oficial público vigente ya no es el set de 8 targets citado originalmente, sino `python`, `javascript` y `rust` según `PUBLIC_BACKENDS` en `src/pcobra/cobra/architecture/backend_policy.py`. Las menciones a `wasm`, `go`, `cpp`, `java` y `asm` deben leerse como contexto legacy/interno de migración, no como superficie pública.
 >
 > El trabajo pendiente consiste en:
 >
@@ -93,7 +90,7 @@ Antes de tocar cualquier bloque, el implementador debe asumir esta trazabilidad 
 **Notas de implementación**
 
 - Este ticket se rige por `docs/targets_policy.md` para nombres canónicos y por la separación pública entre targets oficiales y aliases legacy solo internos.
-- No cambiar el set de 8 targets: solo blindar la fuente de verdad y sus consumidores.
+- No cambiar el set público de 3 targets: solo blindar la fuente de verdad y sus consumidores.
 
 ### Ticket A2 — Blindar el registro de backends oficiales
 
@@ -130,7 +127,7 @@ Antes de tocar cualquier bloque, el implementador debe asumir esta trazabilidad 
 | Archivos a revisar | `README.md`, `docs/lenguajes.rst`, `docs/lenguajes_soportados.rst`, `docs/targets_policy.md` |
 | Archivos normativos a vincular | `docs/matriz_transpiladores.md`, `docs/contrato_runtime_holobit.md` |
 | Validaciones reales | `python -m pytest tests/unit/test_public_docs_scope.py`; `python scripts/validate_targets_policy.py` |
-| Criterio de cierre verificable | La documentación principal solo enumera como destinos oficiales los 8 targets ya recortados, distingue transpilación vs runtime y no promociona targets retirados, aliases legacy ni compatibilidad Holobit inflada. |
+| Criterio de cierre verificable | La documentación principal solo enumera como destinos oficiales `python`, `javascript` y `rust`, distingue transpilación vs runtime y no promociona targets retirados, aliases legacy ni compatibilidad Holobit inflada. |
 
 **Trabajo esperado**
 
@@ -226,12 +223,12 @@ Antes de tocar cualquier bloque, el implementador debe asumir esta trazabilidad 
 | Archivos a revisar | `src/pcobra/cobra/cli/target_policies.py`, `src/pcobra/core/sandbox.py` |
 | Archivos relacionados | `docs/targets_policy.md`, `docs/matriz_transpiladores.md`, `docs/contrato_runtime_holobit.md` |
 | Validaciones reales | `python -m pytest tests/unit/test_official_targets_consistency.py`; `python -m pytest tests/unit/test_target_execution_policy.py`; `python scripts/validate_targets_policy.py` |
-| Criterio de cierre verificable | La política pública y la implementación distinguen con claridad targets oficiales de transpilación, runtime oficial, runtime best-effort y targets solo de generación; no se vende equivalencia de ejecución para los 8 backends. |
+| Criterio de cierre verificable | La política pública y la implementación distinguen con claridad targets oficiales de transpilación, runtime oficial, runtime best-effort y targets solo de generación; no se vende equivalencia de ejecución para backends legacy fuera de `python`, `javascript` y `rust`. |
 
 **Trabajo esperado**
 
 - Revisar las listas `OFFICIAL_TRANSPILATION_TARGETS`, `OFFICIAL_RUNTIME_TARGETS`, `TRANSPILATION_ONLY_TARGETS` y `VERIFICATION_EXECUTABLE_TARGETS`.
-- Confirmar que sandbox, CLI y documentación no presentan `wasm`, `asm`, `go` o `java` como si tuvieran el mismo runtime oficial que `python`, `rust`, `javascript` y `cpp`.
+- Confirmar que sandbox, CLI y documentación no presentan `wasm`, `asm`, `go`, `java` o `cpp` como si tuvieran el mismo contrato público que `python`, `javascript` y `rust`.
 - Alinear wording técnico con la separación ya definida en `docs/targets_policy.md`.
 
 **Notas de implementación**
@@ -332,13 +329,13 @@ Un ticket de esta propuesta solo debe marcarse como **cerrado** cuando se cumpla
 1. el diff toca los archivos concretos asociados al ticket o confirma explícitamente que no requieren cambios;
 2. los documentos normativos vinculados (`docs/targets_policy.md`, `docs/matriz_transpiladores.md`, `docs/contrato_runtime_holobit.md`) siguen alineados;
 3. las validaciones reales indicadas en el ticket se ejecutan y quedan en verde;
-4. no se altera el set oficial de 8 targets, salvo una decisión de producto separada y documentada fuera de esta propuesta.
+4. no se altera el set público oficial de 3 targets, salvo una decisión de producto separada y documentada fuera de esta propuesta.
 
 ## Resultado esperado
 
 Al cerrar esta batería:
 
-- pCobra mantiene formalmente el alcance ya recortado a **8 targets oficiales de salida**;
+- pCobra mantiene formalmente el alcance público recortado a **3 targets oficiales de salida**;
 - desaparecen restos productivos/documentales que puedan reabrir targets legacy o aliases públicos;
 - la CI blinda la reintroducción de divergencias entre código, CLI, tests y documentación;
 - el contrato Holobit/`corelibs`/`standard_library` queda mantenido sin sobredimensionar compatibilidad real ni runtime oficial.

--- a/docs/release.md
+++ b/docs/release.md
@@ -42,7 +42,7 @@ Consulta el [archivo del workflow](../.github/workflows/release.yml) para más d
 
 Antes de etiquetar una versión, confirma explícitamente:
 
-- [ ] No hay referencias activas en código, ejemplos o scripts a lenguajes fuera del set oficial de salida (`python`, `rust`, `javascript`, `wasm`, `go`, `cpp`, `java`, `asm`).
+- [ ] No hay referencias activas en código, ejemplos o scripts a lenguajes fuera del set oficial público de salida (`python`, `javascript`, `rust`), salvo notas legacy explícitas.
 - [ ] No hay referencias activas en reverse fuera del set oficial de entrada (`python`, `javascript`, `java`).
 - [ ] `examples/`, `extensions/`, `scripts/benchmarks/` y `docker/` están alineados con el alcance oficial.
 - [ ] Se ejecutó un barrido final de cadenas y rutas para detectar residuos antes de publicar.
@@ -52,7 +52,7 @@ Antes de etiquetar una versión, confirma explícitamente:
 
 Antes de publicar una versión con cambios de política de targets:
 
-- [ ] Confirmar que la narrativa pública mantiene exclusivamente los 8 targets canónicos de salida.
+- [ ] Confirmar que la narrativa pública mantiene exclusivamente los 3 targets canónicos públicos de salida (`python`, `javascript`, `rust`).
 - [ ] Incluir la nota de corrección: la CLI instalada ya no importa `scripts.benchmarks` en tiempo de ejecución (usa `pcobra.cobra.benchmarks`).
 - [ ] Adjuntar pasos de migración vigentes para CI/scripts (`--backend`, `--tipo`, `--tipos`).
 - [ ] Ejecutar `python scripts/audit_retired_targets.py <ruta_proyecto>` sobre repos de referencia del ecosistema.


### PR DESCRIPTION
### Motivation
- Alinear la documentación pública con la política canónica de backends en `src/pcobra/cobra/architecture/backend_policy.py::PUBLIC_BACKENDS` para evitar inconsistencia entre código, CI y docs. 
- Ocultar o mover de la superficie pública los backends históricos `wasm`, `go`, `cpp`, `java` y `asm` para que la narrativa pública muestre únicamente los targets oficiales reales. 

### Description
- Actualiza `docs/arquitectura_parser_transpiladores.md`, `docs/estructura_ast.md` y diagramas UML/Graphviz para declarar que los transpiladores públicos son únicamente `python`, `javascript` y `rust` y eliminar referencias visibles a `asm`/otros. 
- Cambia textos en `docs/interfaces.md`, `docs/genericos.md`, `docs/especificacion_tecnica.md`, `docs/lenguajes_soportados.rst`, `docs/language_equivalence_matrix.md` y múltiples propuestas/migración/release para reemplazar la narrativa de 8 targets por la superficie pública de 3 targets y relegar `wasm/go/cpp/java/asm` a notas históricas/legacy internas. 
- Ajusta `docs/proposals/*`, `docs/migracion_targets_retirados.md` y `docs/release.md` para que las guías de migración y checklists recomienden migrar a los 3 targets públicos y traten los demás como rutas internas históricas. 
- Se eliminaron fragmentos públicos de ejemplo para `cpp` y se armonizó la referencia canónica a `PUBLIC_BACKENDS` como fuente de verdad en los documentos actualizados. 

### Testing
- Ejecutado `git diff --check` para validar diffs y limpiar espacios en blanco; la comprobación se arregló antes del commit y quedó limpia. 
- Ejecutado `python -m pytest -q tests/test_backend_startup_policy.py tests/unit/test_target_execution_policy.py tests/cli/test_runtime_imports_contract.py`, resultando en `26 passed, 1 skipped` y sin fallos relacionados con la política de backends. 
- Ejecutado `rg` sobre la colección de `docs/` y `docs/proposals/` para buscar ocurrencias de patrones (`wasm|go|cpp|java|asm|8 nombres canónicos|legacy`) y verificar que las menciones remanentes son notas históricas o internas; el barrido dejó coincidencias solo en contextos de archivo histórico/nota interna.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa12c88c083279329bcc75120255b)