### PR TITLE
refactor(gui): centralizar helpers de runtime para GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1111,9 +1111,11 @@ cobra -v run programa.co
 Los archivos con extensión ``.cobra`` representan paquetes completos, mientras que los scripts individuales se guardan como ``.co``.
 
 El subcomando `docs` ejecuta `sphinx-apidoc` para generar la documentación de la API antes de compilar el HTML.
-El subcomando `gui` abre el iddle integrado y requiere tener instalado Flet.
+El subcomando `gui` abre el IDLE gráfico principal y requiere tener instalado Flet.
 
 ### IDLE gráfico
+
+La entrada recomendada para el entorno gráfico interactivo es `cobra gui`, que carga `src/pcobra/gui/idle.py`. Esa interfaz es la GUI principal: compone los componentes compartidos de `src/pcobra/gui/runtime.py` y ofrece edición de archivos, árbol de directorios, ejecución/transpilación, tokens, AST y sugerencias. `src/pcobra/gui/app.py` se conserva como versión mínima para usos embebidos o pruebas rápidas, pero debe reutilizar los mismos helpers de runtime y no mantener rutas alternativas de lógica.
 
 El IDLE gráfico (`cobra gui`) incluye un editor con estado de archivo activo: muestra la ruta seleccionada, detecta cambios sin guardar con un asterisco y conserva el contenido cargado para comparar modificaciones. La barra de archivo expone las acciones **Nuevo**, **Abrir**, **Guardar**, **Guardar como** y **Recargar**.
 

--- a/src/pcobra/gui/app.py
+++ b/src/pcobra/gui/app.py
@@ -1,6 +1,5 @@
 """Aplicación gráfica básica usando Flet para ejecutar código Cobra."""
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pcobra.gui import runtime
@@ -38,7 +37,7 @@ def main(page: "ft.Page"):
         activar=activar,
         page=page,
     )
-    sugerencias_agix_handler = runtime.crear_handler_sugerencias_agix(
+    sugerencias_handler = runtime.crear_handler_sugerencias(
         entrada=entrada,
         salida=salida,
         page=page,
@@ -46,26 +45,30 @@ def main(page: "ft.Page"):
 
     def cargar_archivo_handler(e):
         if e.control.data and runtime.es_archivo_cobra(e.control.data):
-            ruta_archivo = e.control.data
-            entrada.value = runtime.leer_archivo_texto(ruta_archivo)
-            estado_archivo.ruta = ruta_archivo
-            estado_archivo.contenido_cargado = entrada.value
-            estado_archivo.cambios_sin_guardar = False
+            entrada.value = runtime.cargar_archivo_en_estado(
+                e.control.data, estado_archivo
+            )
             page.update()
 
-    arbol_directorios = runtime.crear_arbol_directorios(ft, on_click=cargar_archivo_handler, root_path=Path(".").resolve())
+    arbol_directorios = runtime.crear_arbol_directorios(
+        ft, on_click=cargar_archivo_handler
+    )
 
     page.add(
         runtime.flet_row(
             ft,
             [
                 runtime.flet_elevated_button(ft, "Guardar", on_click=guardar_handler),
-                runtime.flet_elevated_button(ft, "Guardar como", on_click=guardar_como_handler),
+                runtime.flet_elevated_button(
+                    ft, "Guardar como", on_click=guardar_como_handler
+                ),
                 selector,
                 activar,
                 runtime.flet_elevated_button(ft, "Ejecutar", on_click=ejecutar_handler),
-                runtime.flet_elevated_button(ft, "Sugerencias (Agix)", on_click=sugerencias_agix_handler),
-            ]
+                runtime.flet_elevated_button(
+                    ft, "Sugerencias", on_click=sugerencias_handler
+                ),
+            ],
         ),
         runtime.flet_row(
             ft,
@@ -76,6 +79,7 @@ def main(page: "ft.Page"):
             expand=True,
         ),
     )
+
 
 if __name__ == "__main__":
     runtime.flet_app(main)

--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -1,4 +1,4 @@
-"""Entorno interactivo para ejecutar código Cobra y explorar tokens y AST."""
+"""IDLE gráfico principal para editar, ejecutar e inspeccionar código Cobra."""
 
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -10,51 +10,42 @@ if TYPE_CHECKING:
 
 
 def main(page: "ft.Page"):
-    """Interfaz extendida del IDLE con tokens, AST, archivos, árbol y sugerencias."""
+    """Interfaz principal del IDLE con archivos, árbol, ejecución, tokens, AST y sugerencias."""
     ft = runtime.require_flet()
 
     estado = runtime.GuiFileState()
-    directorio_actual = Path.cwd()
+    directorio_actual = Path.cwd().resolve()
 
     entrada = runtime.crear_editor_codigo(ft)
     salida = runtime.crear_salida_seleccionable(ft)
-    estado_archivo = runtime.flet_text(ft, value="Archivo nuevo (sin guardar)")
+    estado_archivo = runtime.flet_text(ft, value=runtime.crear_titulo_archivo(estado))
     ruta_input = runtime.flet_text_field(ft, label="Ruta", value="", expand=True)
     arbol = runtime.flet_list_view(ft, expand=True, spacing=2, auto_scroll=False)
     lenguajes = list(runtime.gui_target_choices())
     selector = runtime.crear_selector_target(ft, lenguajes=lenguajes)
     activar = runtime.crear_switch_transpilacion(ft, lenguajes=lenguajes)
 
-    def ruta_mostrada() -> str:
-        """Devuelve el título específico del IDLE para el archivo activo."""
-        ruta = estado.ruta
-        nombre = str(ruta) if ruta is not None else "Archivo nuevo (sin guardar)"
-        return f"{nombre}{' *' if estado.cambios_sin_guardar else ''}"
-
     def sincronizar_estado_visual() -> None:
-        """Sincroniza controles específicos del IDLE con el estado de archivo."""
-        estado_archivo.value = ruta_mostrada()
+        estado_archivo.value = runtime.crear_titulo_archivo(estado)
         ruta_input.value = str(estado.ruta or "")
 
-    def marcar_cambios(_e=None) -> None:
-        """Marca cambios sin guardar; comportamiento exclusivo del IDLE."""
-        estado.cambios_sin_guardar = (
-            runtime.normalizar_codigo(entrada.value) != estado.contenido_cargado
-        )
+    def actualizar_pagina() -> None:
         sincronizar_estado_visual()
         page.update()
+
+    def marcar_cambios(_e=None) -> None:
+        runtime.marcar_cambios_editor(estado, entrada.value)
+        actualizar_pagina()
 
     entrada.on_change = marcar_cambios
 
     def mostrar_error_archivo(exc: Exception) -> None:
-        """Muestra errores de archivos en la salida extendida del IDLE."""
         salida.value = runtime.formatear_error(exc)
 
     def cargar_archivo(ruta: Path) -> None:
-        """Carga un archivo Cobra desde el árbol o ruta del IDLE."""
         nonlocal directorio_actual
         try:
-            contenido = runtime.leer_archivo_texto(ruta)
+            entrada.value = runtime.cargar_archivo_en_estado(ruta, estado)
         except (
             FileNotFoundError,
             NotADirectoryError,
@@ -64,20 +55,14 @@ def main(page: "ft.Page"):
             mostrar_error_archivo(exc)
             page.update()
             return
-        estado.ruta = ruta.expanduser().resolve()
-        estado.contenido_cargado = contenido
-        estado.cambios_sin_guardar = False
-        directorio_actual = estado.ruta.parent
-        entrada.value = contenido
+        directorio_actual = estado.ruta.parent if estado.ruta else directorio_actual
         salida.value = f"Archivo cargado: {estado.ruta}"
-        sincronizar_estado_visual()
         reconstruir_arbol()
-        page.update()
+        actualizar_pagina()
 
     def guardar_en(ruta: Path) -> bool:
-        """Guarda el editor en una ruta; acción específica del IDLE."""
         try:
-            contenido_guardado = runtime.escribir_archivo_texto(ruta, entrada.value)
+            runtime.guardar_archivo_en_estado(ruta, entrada.value, estado)
         except (
             FileNotFoundError,
             NotADirectoryError,
@@ -87,36 +72,30 @@ def main(page: "ft.Page"):
             mostrar_error_archivo(exc)
             page.update()
             return False
-        estado.ruta = ruta.expanduser().resolve()
-        estado.contenido_cargado = contenido_guardado
-        estado.cambios_sin_guardar = False
         salida.value = f"Archivo guardado: {estado.ruta}"
-        sincronizar_estado_visual()
         reconstruir_arbol()
-        page.update()
+        actualizar_pagina()
         return True
 
     def reconstruir_arbol() -> None:
-        """Reconstruye el árbol lateral de archivos Cobra del IDLE."""
         arbol.controls.clear()
         arbol.controls.append(
             runtime.flet_text(ft, value=f"Directorio: {directorio_actual}")
         )
-        if directorio_actual.parent != directorio_actual:
-            arbol.controls.append(
-                runtime.flet_text_button(
-                    ft,
-                    "📁 ..",
-                    on_click=lambda _e: cambiar_directorio(directorio_actual.parent),
-                )
-            )
         try:
-            entradas = runtime.listar_directorio_cobra(directorio_actual)
+            padre, entradas = runtime.construir_entradas_directorio(directorio_actual)
         except (FileNotFoundError, NotADirectoryError, PermissionError) as exc:
             mostrar_error_archivo(exc)
             entradas = []
-        for ruta in entradas:
-            if ruta.is_dir():
+            padre = None
+        if padre is not None:
+            arbol.controls.append(
+                runtime.flet_text_button(
+                    ft, "📁 ..", on_click=lambda _e: cambiar_directorio(padre)
+                )
+            )
+        for tipo, ruta in entradas:
+            if tipo == "dir":
                 arbol.controls.append(
                     runtime.flet_text_button(
                         ft,
@@ -134,24 +113,17 @@ def main(page: "ft.Page"):
                 )
 
     def cambiar_directorio(ruta: Path) -> None:
-        """Cambia el directorio explorado por el árbol lateral del IDLE."""
         nonlocal directorio_actual
         directorio_actual = ruta.expanduser().resolve()
         reconstruir_arbol()
         page.update()
 
     def nuevo_handler(_e):
-        """Crea un documento nuevo en memoria; acción específica del IDLE."""
-        estado.ruta = None
-        estado.contenido_cargado = ""
-        estado.cambios_sin_guardar = False
-        entrada.value = ""
+        entrada.value = runtime.nuevo_archivo(estado)
         salida.value = "Archivo nuevo creado en memoria."
-        sincronizar_estado_visual()
-        page.update()
+        actualizar_pagina()
 
     def abrir_handler(_e):
-        """Abre la ruta escrita en el campo Ruta del IDLE."""
         if not ruta_input.value:
             salida.value = (
                 "Indica una ruta para abrir o selecciona un archivo del árbol."
@@ -161,14 +133,12 @@ def main(page: "ft.Page"):
         cargar_archivo(Path(ruta_input.value))
 
     def guardar_handler(_e):
-        """Guarda el archivo activo del IDLE o delega en Guardar como."""
         if estado.ruta is None:
             guardar_como_handler(_e)
             return
         guardar_en(estado.ruta)
 
     def guardar_como_handler(_e):
-        """Guarda el documento del IDLE en la ruta indicada."""
         if not ruta_input.value:
             salida.value = "Indica una ruta de destino en el campo Ruta."
             page.update()
@@ -176,7 +146,6 @@ def main(page: "ft.Page"):
         guardar_en(Path(ruta_input.value))
 
     def recargar_handler(_e):
-        """Recarga desde disco el archivo activo del IDLE."""
         if estado.ruta is None:
             salida.value = "No hay archivo activo que recargar."
             page.update()
@@ -184,97 +153,15 @@ def main(page: "ft.Page"):
         cargar_archivo(estado.ruta)
 
     ejecutar_handler = runtime.crear_handler_ejecucion(
-        entrada=entrada,
-        salida=salida,
-        selector=selector,
-        activar=activar,
-        page=page,
+        entrada=entrada, salida=salida, selector=selector, activar=activar, page=page
     )
-
-    def tokens_handler(_e):
-        """Muestra tokens; herramienta extendida exclusiva del IDLE."""
-        deps = runtime.require_gui_dependencies()
-        codigo = runtime.normalizar_codigo(entrada.value)
-        try:
-            salida.value = runtime.mostrar_tokens(codigo)
-        except Exception as exc:
-            salida.value = runtime.formatear_error(
-                exc,
-                lexer_error_type=deps.get("LexerError"),
-                parser_error_type=deps.get("ParserError"),
-            )
-        finally:
-            page.update()
-
-    def ast_handler(_e):
-        """Muestra el AST; herramienta extendida exclusiva del IDLE."""
-        deps = runtime.require_gui_dependencies()
-        codigo = runtime.normalizar_codigo(entrada.value)
-        try:
-            salida.value = runtime.mostrar_ast(codigo)
-        except Exception as exc:
-            salida.value = runtime.formatear_error(
-                exc,
-                lexer_error_type=deps.get("LexerError"),
-                parser_error_type=deps.get("ParserError"),
-            )
-        finally:
-            page.update()
-
-    def sugerencias_handler(_e):
-        """Genera sugerencias estilísticas; herramienta extendida del IDLE."""
-        deps = runtime.require_gui_dependencies()
-        codigo = runtime.normalizar_codigo(entrada.value)
-        try:
-            deps["Parser"](deps["Lexer"](codigo).tokenizar()).parsear()
-        except Exception as exc:
-            error = runtime.formatear_error(
-                exc,
-                lexer_error_type=deps.get("LexerError"),
-                parser_error_type=deps.get("ParserError"),
-            )
-            salida.value = (
-                "Errores léxicos/sintácticos:\n"
-                f"- {error}\n\n"
-                "Sugerencias estilísticas:\n"
-                "- Corrige primero los errores anteriores para solicitar sugerencias."
-            )
-            page.update()
-            return
-
-        try:
-            from pcobra.ia.analizador_agix import generar_sugerencias
-
-            sugerencias = generar_sugerencias(codigo)
-        except ImportError as exc:
-            salida.value = (
-                "Errores léxicos/sintácticos:\n"
-                "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
-                "Sugerencias estilísticas:\n"
-                f"- No se pudieron generar sugerencias: {exc}. "
-                "Instala la dependencia opcional 'agix' para activar esta acción."
-            )
-        except Exception as exc:
-            salida.value = runtime.formatear_error(
-                exc,
-                lexer_error_type=deps.get("LexerError"),
-                parser_error_type=deps.get("ParserError"),
-            )
-        else:
-            if sugerencias:
-                sugerencias_legibles = "\n".join(
-                    f"- {sugerencia}" for sugerencia in sugerencias
-                )
-            else:
-                sugerencias_legibles = "- No se recibieron sugerencias."
-            salida.value = (
-                "Errores léxicos/sintácticos:\n"
-                "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
-                "Sugerencias estilísticas:\n"
-                f"{sugerencias_legibles}"
-            )
-        finally:
-            page.update()
+    tokens_handler = runtime.crear_handler_tokens(
+        entrada=entrada, salida=salida, page=page
+    )
+    ast_handler = runtime.crear_handler_ast(entrada=entrada, salida=salida, page=page)
+    sugerencias_handler = runtime.crear_handler_sugerencias(
+        entrada=entrada, salida=salida, page=page
+    )
 
     reconstruir_arbol()
     sincronizar_estado_visual()

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -17,7 +17,10 @@ def require_gui_dependencies() -> dict[str, Any]:
     """Importa dependencias de núcleo/transpiladores de forma diferida."""
     try:
         from pcobra.cobra.gui import deps as gui_deps
-    except (ImportError, ModuleNotFoundError) as exc:  # pragma: no cover - validado desde CLI
+    except (
+        ImportError,
+        ModuleNotFoundError,
+    ) as exc:  # pragma: no cover - validado desde CLI
         missing_target, action = _parse_missing_target(exc)
         detail = str(exc) or repr(exc)
         raise RuntimeError(
@@ -46,7 +49,9 @@ def _parse_missing_target(exc: ImportError) -> tuple[str, str]:
         missing_module = getattr(exc, "name", None) or "desconocido"
         return missing_module, _dependency_action(missing_module)
 
-    cannot_import_match = re.search(r"cannot import name '([^']+)' from '([^']+)'", detail)
+    cannot_import_match = re.search(
+        r"cannot import name '([^']+)' from '([^']+)'", detail
+    )
     if cannot_import_match:
         symbol_name, module_name = cannot_import_match.groups()
         target = f"{module_name}.{symbol_name}"
@@ -96,7 +101,9 @@ def listar_directorio_cobra(root: str | Path) -> list[Path]:
 
     base = Path(root).expanduser()
     entradas = list(base.iterdir())
-    visibles = [entry for entry in entradas if entry.is_dir() or es_archivo_cobra(entry)]
+    visibles = [
+        entry for entry in entradas if entry.is_dir() or es_archivo_cobra(entry)
+    ]
     return sorted(visibles, key=lambda entry: (not entry.is_dir(), entry.name.lower()))
 
 
@@ -117,12 +124,79 @@ def escribir_archivo_texto(
     return codigo
 
 
+def crear_titulo_archivo(estado: GuiFileState) -> str:
+    """Devuelve la etiqueta común del archivo activo en la GUI."""
+
+    nombre = (
+        str(estado.ruta) if estado.ruta is not None else "Archivo nuevo (sin guardar)"
+    )
+    return f"{nombre}{' *' if estado.cambios_sin_guardar else ''}"
+
+
+def marcar_cambios_editor(estado: GuiFileState, contenido: str | None) -> bool:
+    """Actualiza el estado sucio comparando editor y contenido cargado."""
+
+    estado.cambios_sin_guardar = (
+        normalizar_codigo(contenido) != estado.contenido_cargado
+    )
+    return estado.cambios_sin_guardar
+
+
+def nuevo_archivo(estado: GuiFileState) -> str:
+    """Reinicia el estado de archivo y devuelve contenido vacío para el editor."""
+
+    estado.ruta = None
+    estado.contenido_cargado = ""
+    estado.cambios_sin_guardar = False
+    return ""
+
+
+def cargar_archivo_en_estado(ruta: str | Path, estado: GuiFileState) -> str:
+    """Carga un archivo de texto, actualiza estado y devuelve su contenido."""
+
+    ruta_resuelta = Path(ruta).expanduser().resolve()
+    contenido = leer_archivo_texto(ruta_resuelta)
+    estado.ruta = ruta_resuelta
+    estado.contenido_cargado = contenido
+    estado.cambios_sin_guardar = False
+    return contenido
+
+
+def guardar_archivo_en_estado(
+    ruta: str | Path, contenido: str | None, estado: GuiFileState
+) -> str:
+    """Guarda contenido del editor, actualiza estado y devuelve el texto guardado."""
+
+    ruta_resuelta = Path(ruta).expanduser().resolve()
+    contenido_guardado = escribir_archivo_texto(ruta_resuelta, contenido)
+    estado.ruta = ruta_resuelta
+    estado.contenido_cargado = contenido_guardado
+    estado.cambios_sin_guardar = False
+    return contenido_guardado
+
+
+def construir_entradas_directorio(
+    directorio: str | Path,
+) -> tuple[Path | None, list[tuple[str, Path]]]:
+    """Devuelve padre opcional y entradas visibles para renderizar árboles GUI."""
+
+    actual = Path(directorio).expanduser().resolve()
+    padre = actual.parent if actual.parent != actual else None
+    entradas = [
+        ("dir" if ruta.is_dir() else "file", ruta)
+        for ruta in listar_directorio_cobra(actual)
+    ]
+    return padre, entradas
+
+
 def require_flet() -> Any:
     """Importa Flet de forma diferida para no romper imports de CLI."""
     try:
         import flet as ft
     except ModuleNotFoundError as exc:  # pragma: no cover - validado desde CLI
-        raise RuntimeError("Falta la dependencia 'flet'. Ejecuta: pip install flet.") from exc
+        raise RuntimeError(
+            "Falta la dependencia 'flet'. Ejecuta: pip install flet."
+        ) from exc
     return ft
 
 
@@ -235,7 +309,9 @@ def crear_salida_seleccionable(ft: Any, **kwargs: Any) -> Any:
     return flet_text(ft, **opciones)
 
 
-def crear_arbol_directorios(ft: Any, *, on_click: Any, root_path: Path | None = None) -> Any:
+def crear_arbol_directorios(
+    ft: Any, *, on_click: Any, root_path: Path | None = None
+) -> Any:
     """Crea un componente de árbol de directorios para la GUI."""
     if root_path is None:
         root_path = Path(".").resolve()
@@ -284,7 +360,9 @@ def crear_switch_transpilacion(ft: Any, *, lenguajes: list[str] | None = None) -
     return flet_switch(ft, label="Transpilar", disabled=not targets)
 
 
-def ejecutar_o_transpilar(codigo: str, *, transpilacion_activa: bool, target: str) -> str:
+def ejecutar_o_transpilar(
+    codigo: str, *, transpilacion_activa: bool, target: str
+) -> str:
     """Ejecuta o transpila código Cobra; lógica compartida por ambas GUIs."""
 
     deps = require_gui_dependencies()
@@ -326,22 +404,19 @@ def crear_handler_ejecucion(
     return ejecutar_handler
 
 
-def _guardar_archivo(page: Any, entrada: Any, estado_archivo: GuiFileState, ruta: Path) -> None:
+def _guardar_archivo(
+    page: Any, entrada: Any, estado_archivo: GuiFileState, ruta: Path
+) -> None:
     """Guarda el contenido del editor en la ruta especificada."""
     try:
-        contenido_guardado = escribir_archivo_texto(ruta, entrada.value)
-        estado_archivo.ruta = ruta
-        estado_archivo.contenido_cargado = contenido_guardado
-        estado_archivo.cambios_sin_guardar = False
+        guardar_archivo_en_estado(ruta, entrada.value, estado_archivo)
         page.snack_bar.open = True
         page.snack_bar.content = flet_text(
             require_flet(), f"Archivo guardado en {ruta}"
         )
     except Exception as exc:
         page.snack_bar.open = True
-        page.snack_bar.content = flet_text(
-            require_flet(), f"Error al guardar: {exc}"
-        )
+        page.snack_bar.content = flet_text(require_flet(), f"Error al guardar: {exc}")
     finally:
         page.update()
 
@@ -359,7 +434,9 @@ def crear_handler_guardar(
             _guardar_archivo(page, entrada, estado_archivo, estado_archivo.ruta)
         else:
             # Si no hay ruta, invocar "Guardar como"
-            crear_handler_guardar_como(entrada=entrada, estado_archivo=estado_archivo, page=page)(_e)
+            crear_handler_guardar_como(
+                entrada=entrada, estado_archivo=estado_archivo, page=page
+            )(_e)
 
     return guardar_handler
 
@@ -433,6 +510,116 @@ def crear_handler_sugerencias_agix(
     return sugerencias_agix_handler
 
 
+def analizar_codigo(codigo: str) -> tuple[list[Any], Any]:
+    """Ejecuta Lexer y Parser una vez y devuelve tokens y AST."""
+
+    deps = require_gui_dependencies()
+    tokens = deps["Lexer"](codigo).tokenizar()
+    ast = deps["Parser"](tokens).parsear()
+    return tokens, ast
+
+
+def generar_reporte_sugerencias(codigo: str) -> str:
+    """Valida código y genera reporte común de sugerencias estilísticas."""
+
+    deps = require_gui_dependencies()
+    try:
+        analizar_codigo(codigo)
+    except Exception as exc:
+        error = formatear_error(
+            exc,
+            lexer_error_type=deps.get("LexerError"),
+            parser_error_type=deps.get("ParserError"),
+        )
+        return (
+            "Errores léxicos/sintácticos:\n"
+            f"- {error}\n\n"
+            "Sugerencias estilísticas:\n"
+            "- Corrige primero los errores anteriores para solicitar sugerencias."
+        )
+
+    try:
+        sugerencias = generar_sugerencias(codigo)
+    except ImportError as exc:
+        return (
+            "Errores léxicos/sintácticos:\n"
+            "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
+            "Sugerencias estilísticas:\n"
+            f"- No se pudieron generar sugerencias: {exc}. "
+            "Instala la dependencia opcional 'agix' para activar esta acción."
+        )
+
+    if sugerencias:
+        sugerencias_legibles = "\n".join(
+            f"- {sugerencia}" for sugerencia in sugerencias
+        )
+    else:
+        sugerencias_legibles = "- No se recibieron sugerencias."
+    return (
+        "Errores léxicos/sintácticos:\n"
+        "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
+        "Sugerencias estilísticas:\n"
+        f"{sugerencias_legibles}"
+    )
+
+
+def crear_handler_tokens(*, entrada: Any, salida: Any, page: Any) -> Any:
+    """Crea handler compartido para mostrar tokens Cobra."""
+
+    def tokens_handler(_e: Any) -> None:
+        deps = require_gui_dependencies()
+        try:
+            salida.value = mostrar_tokens(normalizar_codigo(entrada.value))
+        except Exception as exc:
+            salida.value = formatear_error(
+                exc,
+                lexer_error_type=deps.get("LexerError"),
+                parser_error_type=deps.get("ParserError"),
+            )
+        finally:
+            page.update()
+
+    return tokens_handler
+
+
+def crear_handler_ast(*, entrada: Any, salida: Any, page: Any) -> Any:
+    """Crea handler compartido para mostrar el AST Cobra."""
+
+    def ast_handler(_e: Any) -> None:
+        deps = require_gui_dependencies()
+        try:
+            salida.value = mostrar_ast(normalizar_codigo(entrada.value))
+        except Exception as exc:
+            salida.value = formatear_error(
+                exc,
+                lexer_error_type=deps.get("LexerError"),
+                parser_error_type=deps.get("ParserError"),
+            )
+        finally:
+            page.update()
+
+    return ast_handler
+
+
+def crear_handler_sugerencias(*, entrada: Any, salida: Any, page: Any) -> Any:
+    """Crea handler compartido para sugerencias con validación léxica/sintáctica."""
+
+    def sugerencias_handler(_e: Any) -> None:
+        deps = require_gui_dependencies()
+        try:
+            salida.value = generar_reporte_sugerencias(normalizar_codigo(entrada.value))
+        except Exception as exc:
+            salida.value = formatear_error(
+                exc,
+                lexer_error_type=deps.get("LexerError"),
+                parser_error_type=deps.get("ParserError"),
+            )
+        finally:
+            page.update()
+
+    return sugerencias_handler
+
+
 def normalizar_codigo(codigo: str | None) -> str:
     """Normaliza la entrada para evitar valores ``None``."""
     return codigo or ""
@@ -443,8 +630,7 @@ def ejecutar_codigo(codigo: str) -> str:
     deps = require_gui_dependencies()
     buffer = io.StringIO()
     with redirect_stdout(buffer), redirect_stderr(buffer):
-        tokens = deps["Lexer"](codigo).tokenizar()
-        ast = deps["Parser"](tokens).parsear()
+        _tokens, ast = analizar_codigo(codigo)
         deps["InterpretadorCobra"]().ejecutar_ast(ast)
     return buffer.getvalue()
 
@@ -452,8 +638,7 @@ def ejecutar_codigo(codigo: str) -> str:
 def transpilar_codigo(codigo: str, lang: str) -> str:
     """Transpila código Cobra al lenguaje especificado."""
     deps = require_gui_dependencies()
-    tokens = deps["Lexer"](codigo).tokenizar()
-    ast = deps["Parser"](tokens).parsear()
+    _tokens, ast = analizar_codigo(codigo)
     transp = deps["TRANSPILERS"][lang]()
     return transp.generate_code(ast)
 
@@ -461,15 +646,14 @@ def transpilar_codigo(codigo: str, lang: str) -> str:
 def mostrar_tokens(codigo: str) -> str:
     """Tokeniza código Cobra y devuelve una representación por línea."""
     deps = require_gui_dependencies()
-    tokens = deps["Lexer"](codigo).tokenizar()
+    tokens, _ast = analizar_codigo(codigo)
     return "\n".join(str(token) for token in tokens)
 
 
 def mostrar_ast(codigo: str) -> str:
     """Parsea código Cobra y devuelve una representación serializada del AST."""
     deps = require_gui_dependencies()
-    tokens = deps["Lexer"](codigo).tokenizar()
-    ast = deps["Parser"](tokens).parsear()
+    _tokens, ast = analizar_codigo(codigo)
     return str(ast)
 
 
@@ -503,6 +687,4 @@ def gui_target_choices() -> tuple[str, ...]:
             "Contrato público inválido en GUI: OFFICIAL_TARGETS debe coincidir con PUBLIC_BACKENDS. "
             f"official={official_targets}; public={PUBLIC_BACKENDS}"
         )
-    return deps["target_cli_choices"](
-        set(PUBLIC_BACKENDS) & set(deps["TRANSPILERS"])
-    )
+    return deps["target_cli_choices"](set(PUBLIC_BACKENDS) & set(deps["TRANSPILERS"]))


### PR DESCRIPTION
### Motivation
- Evitar duplicación entre las entradas GUI y decidir que `src/pcobra/gui/idle.py` sea la GUI principal compuesta mientras `src/pcobra/gui/app.py` quede como versión mínima reutilizando los mismos helpers.
- Consolidar toda la lógica común (guardado/apertura, árbol de directorios, análisis Lexer/Parser, tokens, AST y sugerencias) en un único módulo `src/pcobra/gui/runtime.py` para facilitar mantenimiento y pruebas.

### Description
- Se movió y centralizó en `src/pcobra/gui/runtime.py` el estado de archivo (`GuiFileState`), helpers para título/estado de archivo, detección de cambios, creación/nuevo/carga/guardado de archivos y generación de entradas del árbol (`crear_titulo_archivo`, `marcar_cambios_editor`, `nuevo_archivo`, `cargar_archivo_en_estado`, `guardar_archivo_en_estado`, `construir_entradas_directorio`).
- Se añadieron utilidades de análisis y reporte reutilizables en `runtime.py`: `analizar_codigo`, `generar_reporte_sugerencias`, y handlers compartidos `crear_handler_ejecucion`, `crear_handler_tokens`, `crear_handler_ast`, `crear_handler_sugerencias`; las funciones de ejecución/transpilación/token/AST ahora usan `analizar_codigo`.
- `src/pcobra/gui/idle.py` fue refactorizado para ser la composición principal de componentes y usar únicamente los helpers de `runtime.py` (carga/guardado, árbol, ejecución, tokens, AST y sugerencias) sin duplicar la lógica.
- `src/pcobra/gui/app.py` se mantuvo como app mínima y se actualizó para reutilizar los mismos helpers (se sustituyó el uso explícito de la ruta Agix por el handler común de sugerencias), manteniendo la compatibilidad con la ruta heredada `crear_handler_sugerencias_agix` en `runtime.py`.
- Se documentó en `README.md` que la entrada recomendada es `cobra gui` (carga `src/pcobra/gui/idle.py`) y que `app.py` es la versión mínima; además se aplicó formato con `black` para consistencia de estilo.

### Testing
- Se compiló el módulo GUI con `python -m compileall -q src/pcobra/gui` y no produjo errores.
- Se ejecutaron los tests GUI: `PYTHONPATH=src pytest -q tests/gui/test_runtime_import_without_flet.py tests/gui/test_runtime_file_helpers.py tests/gui/test_app_import.py` y todos pasaron.
- Se ejecutaron los tests unitarios relevantes: `PYTHONPATH=src pytest -q tests/unit/test_gui_runtime.py` junto a los tests GUI anteriores y todos pasaron (suite combinada pasó completamente).
- Se verificó `git diff --check`, se creó el commit y no hay errores de chequeo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fadebdefc83279dd2eddf3316f0fb)