### PR TITLE
Document GUI/IA suggestion contract and add regression tests

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -492,7 +492,26 @@ asincronico funcion main():
 
 **Compatibilidad por backend:** soporte async completo en backend Python; en otros targets revisar disponibilidad de event loop.
 
-### 3.9 Decorators
+### 3.9 Contrato para sugerencias automáticas en GUI/IA
+
+Las herramientas de GUI, asistentes de IA o acciones de corrección automática pueden sugerir cambios sobre código Cobra, pero **no pueden ampliar la sintaxis del lenguaje por su cuenta**. Toda recomendación debe cumplir este contrato antes de mostrarse como corrección aplicable:
+
+1. **Validación de entrada:** el código original se tokeniza con `Lexer` y se parsea con `Parser`. Si el fragmento de entrada no puede validarse, la herramienta debe informar el error en vez de inventar una corrección sintáctica.
+2. **Sintaxis existente:** la sugerencia no debe introducir tokens, palabras reservadas, operadores o construcciones ausentes del parser vigente. Si una forma no aparece en el índice de sintaxis ni es aceptada por `Parser`, queda fuera de las recomendaciones automáticas.
+3. **Trazabilidad al Libro:** cada recomendación debe mapearse a una regla concreta de este Libro, citando la sección aplicable (por ejemplo, `§3.3 Sentencias`, `§3.4 Funciones` o `§3.6 Módulos`).
+4. **Regresión obligatoria:** por cada recomendación nueva se añade un caso válido y uno inválido en `tests/gui/` o `tests/integration/`; además, el fragmento sugerido debe tener una prueba que confirme que `Parser` lo acepta.
+
+Recomendaciones autorizadas actualmente:
+
+| Recomendación | Regla del Libro | Fragmento sugerido que debe aceptar `Parser` | Forma inválida cubierta por regresión |
+|---|---|---|---|
+| Usar `retorno` dentro de funciones. | `§3.3 Sentencias` y `§3.4 Funciones`. | `func saludar(nombre): retorno nombre fin` | `retornar nombre` |
+| Usar `usar` sin alias `como` y con importación plana. | `§3.6 Módulos`. | `usar "numero"` seguido de `es_finito(10)` | `usar "numero" como numero` |
+| Declarar funciones con `func` o `definir`. | `§3.4 Funciones`. | `func calcular_total(a, b): retorno a + b fin` | `funcion calcular_total(a, b): ...` |
+
+> Nota editorial: si en el futuro el parser incorpora una construcción nueva, primero debe actualizarse el índice de sintaxis y la regla correspondiente del Libro; solo después puede añadirse una recomendación automática para esa construcción.
+
+### 3.10 Decorators
 
 **Definición corta:** anotaciones (`@`) para extender funciones/clases sin modificar su cuerpo.
 
@@ -523,7 +542,7 @@ funcion descargar(url):
 
 **Compatibilidad por backend:** decorators dependen de capacidades de metaprogramación del target; validar en `build` por backend.
 
-### 3.10 Macros
+### 3.11 Macros
 
 **Definición corta:** transformación de código antes o durante fases de compilación/transpilación.
 
@@ -548,7 +567,7 @@ traza(usuario_id)
 
 **Compatibilidad por backend:** comportamiento depende del pipeline de transpiler; mantener macros pequeñas y deterministas.
 
-### 3.11 Patrones avanzados
+### 3.12 Patrones avanzados
 
 **Definición corta:** combinaciones de constructos para resolver problemas complejos de forma mantenible.
 

--- a/tests/gui/test_auto_suggestion_parser_contract.py
+++ b/tests/gui/test_auto_suggestion_parser_contract.py
@@ -1,0 +1,96 @@
+"""Regresión del contrato de sugerencias automáticas para GUI/IA.
+
+Cada recomendación documentada debe partir de código validado por ``Lexer`` y
+``Parser`` y debe proponer solo construcciones ya aceptadas por el parser.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pcobra.cobra.core import Lexer, Parser, ParserError
+
+
+RECOMENDACIONES_GUI = [
+    pytest.param(
+        "retorno_en_funciones",
+        """
+func saludar(nombre):
+    retorno nombre
+fin
+""",
+        """
+func saludar(nombre):
+    retornar nombre
+fin
+""",
+        "Libro §3.3 Sentencias y §3.4 Funciones: usar `retorno`, no `retornar`.",
+        id="retorno-en-funciones",
+    ),
+    pytest.param(
+        "usar_importacion_con_cadena",
+        """
+usar "numero"
+imprimir(es_finito(10))
+""",
+        """
+usar "numero" como numero
+imprimir(numero.es_finito(10))
+""",
+        "Libro §3.6 Módulos: `usar` no acepta alias `como`; usar importación plana.",
+        id="usar-sin-alias-como",
+    ),
+    pytest.param(
+        "funciones_con_func",
+        """
+func calcular_total(subtotal, impuesto):
+    retorno subtotal + impuesto
+fin
+""",
+        """
+funcion calcular_total(subtotal, impuesto):
+    retorno subtotal + impuesto
+fin
+""",
+        "Libro §3.4 Funciones: el parser implementa `func`/`definir`.",
+        id="func-no-funcion",
+    ),
+]
+
+
+def _parsear(codigo: str):
+    tokens = Lexer(codigo).tokenizar()
+    return Parser(tokens).parsear()
+
+
+@pytest.mark.parametrize(
+    ("nombre", "fragmento_sugerido", "fragmento_invalido", "regla_libro"),
+    RECOMENDACIONES_GUI,
+)
+def test_recomendaciones_gui_solo_proponen_fragmentos_aceptados_por_parser(
+    nombre: str,
+    fragmento_sugerido: str,
+    fragmento_invalido: str,
+    regla_libro: str,
+) -> None:
+    assert nombre
+    assert regla_libro.startswith("Libro §3")
+    ast = _parsear(fragmento_sugerido)
+    assert ast
+
+
+@pytest.mark.parametrize(
+    ("nombre", "fragmento_sugerido", "fragmento_invalido", "regla_libro"),
+    RECOMENDACIONES_GUI,
+)
+def test_recomendaciones_gui_cubren_ejemplos_invalidos_sin_ampliar_parser(
+    nombre: str,
+    fragmento_sugerido: str,
+    fragmento_invalido: str,
+    regla_libro: str,
+) -> None:
+    assert nombre
+    assert fragmento_sugerido != fragmento_invalido
+    assert regla_libro
+    with pytest.raises(ParserError):
+        _parsear(fragmento_invalido)


### PR DESCRIPTION
### Motivation

- Formalizar en el Libro de Programación Cobra un contrato que limite las sugerencias automáticas de la GUI/IA para evitar que amplíen la sintaxis del lenguaje sin pasar por el parser. 
- Garantizar trazabilidad entre cada recomendación automática y las secciones del Libro, y forzar cobertura regresiva para evitar rupturas en el parser.

### Description

- Añadida la sección `3.9 Contrato para sugerencias automáticas en GUI/IA` en `docs/LIBRO_PROGRAMACION_COBRA.md` que exige validar el código original con `Lexer` y `Parser`, prohibe introducir construcciones no soportadas y obliga a mapear cada recomendación a una regla del Libro.
- Documentadas las recomendaciones autorizadas actuales (uso de `retorno`, `usar` con cadena sin alias `como`, y declarar funciones con `func`/`definir`).
- Añadido el test de regresión `tests/gui/test_auto_suggestion_parser_contract.py` que parametriza fragmentos sugeridos (válidos) y fragmentos inválidos y comprueba que `Parser` acepta los fragmentos sugeridos y rechaza las formas inválidas.
- Ajustada la numeración de secciones siguientes en `docs/LIBRO_PROGRAMACION_COBRA.md` para evitar duplicar el encabezado `3.9`.

### Testing

- Ejecutado `pytest -q tests/gui/test_auto_suggestion_parser_contract.py` y la suite del test agregado pasó: `6 passed, 1 warning`.
- Las pruebas confirman que cada fragmento sugerido es aceptado por `Parser` y que los contraejemplos inválidos elevan `ParserError` según lo esperado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fbcff38c48327a4eb23920cc8c3cd)