### PR TITLE
Aclarar mensajes y pruebas para la dependencia opcional `agix`

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -819,7 +819,7 @@ Cobra incluye un entorno de desarrollo integrado (IDLE) gráfico basado en Flet,
     *   **Switch de transpilación:** Alterna entre ejecutar el código directamente o transpilarlo al lenguaje seleccionado.
     *   **Botón "Ejecutar":** Ejecuta el código Cobra o lo transpila, mostrando la salida o el código generado en el área de resultados.
 *   **Sugerencias de código (Agix):**
-    *   **Botón "Sugerencias (Agix)":** Utiliza la librería `Agix` para analizar tu código y ofrecer sugerencias de mejora o corrección tipográfica, basándose en las mejores prácticas del "Libro de Programación principal". Las sugerencias se muestran en el área de salida.
+    *   **Botón "Sugerencias (Agix)":** Utiliza la librería opcional `agix` para analizar tu código y ofrecer sugerencias de mejora o corrección tipográfica, basándose en las mejores prácticas del "Libro de Programación principal". Las sugerencias se muestran en el área de salida.
 
 Para iniciar el IDLE, usa el comando ``cobra gui``.
 

--- a/docs/casos_reales.md
+++ b/docs/casos_reales.md
@@ -41,7 +41,7 @@ cobra run ia.co
 También puedes ejecutar el cuaderno `notebooks/casos_reales/inteligencia_artificial.ipynb` para una versión interactiva.
 
 
-Necesitarás `scikit-learn` y opcionalmente `analizador_agix`.
+Necesitarás `scikit-learn`; para las sugerencias del plugin `analizador_agix`, instala también la dependencia opcional `agix`.
 
 El plugin `analizador_agix` soporta modulación emocional mediante los
 parámetros `placer`, `activacion` y `dominancia`, cada uno en el rango

--- a/src/pcobra/cobra/cli/commands/agix_cmd.py
+++ b/src/pcobra/cobra/cli/commands/agix_cmd.py
@@ -9,7 +9,7 @@ from pcobra.cobra.cli.utils.validators import validar_archivo_existente
 from pcobra.ia.analizador_agix import generar_sugerencias
 
 class AgixCommand(BaseCommand):
-    """Genera sugerencias para código Cobra usando agix."""
+    """Genera sugerencias para código Cobra usando la dependencia opcional agix."""
     name = "agix"
 
     def register_subparser(self, subparsers: Any) -> CustomArgumentParser:

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -487,8 +487,8 @@ def crear_handler_sugerencias_agix(
             sugerencias = generar_sugerencias(codigo)
         except ImportError as exc:
             salida.value = (
-                "Agix no está instalado o no está disponible. "
-                "Instálalo con 'pip install agix' para usar esta función. "
+                "La dependencia opcional agix no está instalada o no está disponible. "
+                "Instálala con 'pip install agix' para usar esta función. "
                 f"Detalle: {exc}"
             )
         except Exception as exc:

--- a/src/pcobra/ia/analizador_agix.py
+++ b/src/pcobra/ia/analizador_agix.py
@@ -37,6 +37,11 @@ from typing import List
 
 from pcobra.cobra.core import Lexer, Parser
 
+MENSAJE_DEPENDENCIA_AGIX = (
+    "La dependencia opcional 'agix' no está instalada o no se pudo importar. "
+    "Instálala con 'pip install agix' para activar las sugerencias de IA."
+)
+
 
 def generar_sugerencias(
     codigo: str,
@@ -55,7 +60,7 @@ def generar_sugerencias(
     proporcionan, usando valores en el rango ``[-1.0, 1.0]``.
     """
     if Reasoner is None:
-        raise ImportError("Instala el paquete agix")
+        raise ImportError(MENSAJE_DEPENDENCIA_AGIX)
 
     # Validar el código utilizando las herramientas de Cobra
     tokens = Lexer(codigo).tokenizar()

--- a/tests/unit/test_analizador_agix.py
+++ b/tests/unit/test_analizador_agix.py
@@ -31,8 +31,32 @@ def test_generar_sugerencias_modulacion_emocional():
 
 def test_generar_sugerencias_sin_agix():
     with patch.object(analizador_agix, "Reasoner", None):
-        with pytest.raises(ImportError, match="Instala el paquete agix"):
+        with pytest.raises(ImportError, match="dependencia opcional 'agix'.*pip install agix"):
             analizador_agix.generar_sugerencias("var x = 5")
+
+
+def test_import_opcional_sin_agix_muestra_mensaje_claro(monkeypatch):
+    """Verifica que importar el analizador sin agix no rompa y falle con ayuda clara."""
+    import builtins
+    import importlib
+
+    import_original = builtins.__import__
+
+    def bloquear_agix(nombre, *args, **kwargs):
+        if nombre == "agix" or nombre.startswith("agix."):
+            raise ImportError("agix bloqueado para la prueba")
+        return import_original(nombre, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", bloquear_agix)
+    recargado = importlib.reload(analizador_agix)
+
+    try:
+        assert recargado.Reasoner is None
+        with pytest.raises(ImportError, match="dependencia opcional 'agix'.*pip install agix"):
+            recargado.generar_sugerencias("var x = 5")
+    finally:
+        monkeypatch.setattr(builtins, "__import__", import_original)
+        importlib.reload(analizador_agix)
 
 
 @pytest.mark.parametrize("param, valor", [

--- a/tests/unit/test_cli_agix_missing_dep.py
+++ b/tests/unit/test_cli_agix_missing_dep.py
@@ -20,4 +20,5 @@ def test_cli_agix_sin_agix(tmp_path, capsys):
         exit_code = cmd.run(args)
     salida = capsys.readouterr().out
     assert exit_code == 1
-    assert "Instala el paquete agix" in salida
+    assert "dependencia opcional 'agix'" in salida
+    assert "pip install agix" in salida

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -268,7 +268,7 @@ def test_crear_handler_sugerencias_agix_dependencia_ausente(
     )
 
     def _generar_sugerencias(_codigo: str) -> list[str]:
-        raise ImportError("Instala el paquete agix")
+        raise ImportError("La dependencia opcional 'agix' no está instalada")
 
     monkeypatch.setattr(runtime, "generar_sugerencias", _generar_sugerencias)
 
@@ -277,9 +277,9 @@ def test_crear_handler_sugerencias_agix_dependencia_ausente(
     )
     handler(None)
 
-    assert "Agix no está instalado o no está disponible" in salida.value
+    assert "dependencia opcional agix no está instalada" in salida.value
     assert "pip install agix" in salida.value
-    assert "Instala el paquete agix" in salida.value
+    assert "dependencia opcional 'agix'" in salida.value
     assert page.updated is True
 
 


### PR DESCRIPTION
### Motivation

- El proyecto declara `agix>=1.9.0,<2` en `pyproject.toml` y en `docs/requirements.txt`, por lo que la integración actual debe seguir usando `agix` y no migrar a `agi-core`.
- Mejorar los mensajes y las pruebas para que la ausencia de la dependencia opcional `agix` produzca una guía clara de instalación al usuario.

### Description

- Confirmado que la dependencia oficial usada es `agix` y no se realiza migración a `agi-core`; se mantuvo `agix` en `pyproject.toml`.
- Centralizado y estandarizado el mensaje de falta de dependencia en `src/pcobra/ia/analizador_agix.py` añadiendo `MENSAJE_DEPENDENCIA_AGIX` y usando este texto al lanzar el `ImportError` en `generar_sugerencias`.
- Actualizados textos y mensajes de usuario para reflejar que `agix` es una dependencia opcional en `src/pcobra/cobra/cli/commands/agix_cmd.py` y `src/pcobra/gui/runtime.py`.
- Documentación actualizada para evitar nombres mezclados en `docs/LIBRO_PROGRAMACION_COBRA.md` y `docs/casos_reales.md` indicando que `agix` es opcional.
- Añadida una prueba que simula la ausencia real del paquete (`test_import_opcional_sin_agix_muestra_mensaje_claro`) y ajustadas pruebas existentes en `tests/unit/test_analizador_agix.py`, `tests/unit/test_cli_agix_missing_dep.py` y `tests/unit/test_gui_runtime.py` para esperar el nuevo mensaje guiado.

### Testing

- Ejecuté `python -m pytest tests/unit/test_analizador_agix.py tests/unit/test_cli_agix_missing_dep.py tests/unit/test_gui_runtime.py -q` y todos los tests ejecutados pasaron (`22 passed`).
- Verifiqué disponibilidad de paquetes con `python -m pip index versions agix` y `python -m pip index versions agi-core` para evaluar opciones de migración.
- Ejecuté `ruff` sobre los ficheros modificados con `python -m ruff check ...` y no se reportaron problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2feb6604c08327a94e7deae9732672)