### PR TITLE
Centraliza acciones de archivo GUI

### DIFF
--- a/src/pcobra/gui/app.py
+++ b/src/pcobra/gui/app.py
@@ -44,8 +44,8 @@ def main(page: "ft.Page"):
     )
 
     def cargar_archivo_handler(e):
-        if e.control.data and runtime.es_archivo_cobra(e.control.data):
-            entrada.value = runtime.cargar_archivo_en_estado(
+        if e.control.data:
+            entrada.value, _mensaje = runtime.cargar_archivo_desde_arbol(
                 e.control.data, estado_archivo
             )
             page.update()

--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -45,34 +45,38 @@ def main(page: "ft.Page"):
     def cargar_archivo(ruta: Path) -> None:
         nonlocal directorio_actual
         try:
-            entrada.value = runtime.cargar_archivo_en_estado(ruta, estado)
+            entrada.value, salida.value = runtime.abrir_archivo_desde_ruta(
+                ruta, estado
+            )
         except (
             FileNotFoundError,
             NotADirectoryError,
             PermissionError,
             UnicodeError,
+            ValueError,
         ) as exc:
             mostrar_error_archivo(exc)
             page.update()
             return
         directorio_actual = estado.ruta.parent if estado.ruta else directorio_actual
-        salida.value = f"Archivo cargado: {estado.ruta}"
         reconstruir_arbol()
         actualizar_pagina()
 
     def guardar_en(ruta: Path) -> bool:
         try:
-            runtime.guardar_archivo_en_estado(ruta, entrada.value, estado)
+            _contenido, salida.value = runtime.guardar_archivo_como(
+                ruta, entrada.value, estado
+            )
         except (
             FileNotFoundError,
             NotADirectoryError,
             PermissionError,
             UnicodeError,
+            ValueError,
         ) as exc:
             mostrar_error_archivo(exc)
             page.update()
             return False
-        salida.value = f"Archivo guardado: {estado.ruta}"
         reconstruir_arbol()
         actualizar_pagina()
         return True
@@ -119,8 +123,7 @@ def main(page: "ft.Page"):
         page.update()
 
     def nuevo_handler(_e):
-        entrada.value = runtime.nuevo_archivo(estado)
-        salida.value = "Archivo nuevo creado en memoria."
+        entrada.value, salida.value = runtime.crear_archivo_nuevo_en_editor(estado)
         actualizar_pagina()
 
     def abrir_handler(_e):
@@ -136,7 +139,22 @@ def main(page: "ft.Page"):
         if estado.ruta is None:
             guardar_como_handler(_e)
             return
-        guardar_en(estado.ruta)
+        try:
+            _contenido, salida.value = runtime.guardar_archivo_activo(
+                entrada.value, estado
+            )
+        except (
+            FileNotFoundError,
+            NotADirectoryError,
+            PermissionError,
+            UnicodeError,
+            ValueError,
+        ) as exc:
+            mostrar_error_archivo(exc)
+            page.update()
+            return
+        reconstruir_arbol()
+        actualizar_pagina()
 
     def guardar_como_handler(_e):
         if not ruta_input.value:
@@ -150,7 +168,20 @@ def main(page: "ft.Page"):
             salida.value = "No hay archivo activo que recargar."
             page.update()
             return
-        cargar_archivo(estado.ruta)
+        try:
+            entrada.value, salida.value = runtime.recargar_archivo_activo(estado)
+        except (
+            FileNotFoundError,
+            NotADirectoryError,
+            PermissionError,
+            UnicodeError,
+            ValueError,
+        ) as exc:
+            mostrar_error_archivo(exc)
+            page.update()
+            return
+        reconstruir_arbol()
+        actualizar_pagina()
 
     ejecutar_handler = runtime.crear_handler_ejecucion(
         entrada=entrada, salida=salida, selector=selector, activar=activar, page=page

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -189,6 +189,57 @@ def construir_entradas_directorio(
     return padre, entradas
 
 
+def crear_archivo_nuevo_en_editor(estado: GuiFileState) -> tuple[str, str]:
+    """Prepara un archivo nuevo y devuelve contenido/mensaje para la GUI."""
+
+    return nuevo_archivo(estado), "Archivo nuevo creado en memoria."
+
+
+def abrir_archivo_desde_ruta(ruta: str | Path, estado: GuiFileState) -> tuple[str, str]:
+    """Abre una ruta de archivo, actualiza estado y devuelve contenido/mensaje."""
+
+    contenido = cargar_archivo_en_estado(ruta, estado)
+    return contenido, f"Archivo cargado: {estado.ruta}"
+
+
+def guardar_archivo_activo(
+    contenido: str | None, estado: GuiFileState
+) -> tuple[str, str]:
+    """Guarda el archivo activo y devuelve contenido normalizado/mensaje."""
+
+    if estado.ruta is None:
+        raise ValueError("No hay archivo activo que guardar.")
+    contenido_guardado = guardar_archivo_en_estado(estado.ruta, contenido, estado)
+    return contenido_guardado, f"Archivo guardado: {estado.ruta}"
+
+
+def guardar_archivo_como(
+    ruta: str | Path, contenido: str | None, estado: GuiFileState
+) -> tuple[str, str]:
+    """Guarda el editor en una ruta nueva y devuelve contenido/mensaje."""
+
+    contenido_guardado = guardar_archivo_en_estado(ruta, contenido, estado)
+    return contenido_guardado, f"Archivo guardado: {estado.ruta}"
+
+
+def recargar_archivo_activo(estado: GuiFileState) -> tuple[str, str]:
+    """Recarga el archivo activo desde disco y devuelve contenido/mensaje."""
+
+    if estado.ruta is None:
+        raise ValueError("No hay archivo activo que recargar.")
+    return abrir_archivo_desde_ruta(estado.ruta, estado)
+
+
+def cargar_archivo_desde_arbol(
+    ruta: str | Path, estado: GuiFileState
+) -> tuple[str, str]:
+    """Carga una entrada de árbol si es archivo Cobra y devuelve contenido/mensaje."""
+
+    if not es_archivo_cobra(ruta):
+        raise ValueError("Selecciona un archivo Cobra (.co o .cobra).")
+    return abrir_archivo_desde_ruta(ruta, estado)
+
+
 def require_flet() -> Any:
     """Importa Flet de forma diferida para no romper imports de CLI."""
     try:

--- a/tests/unit/test_gui_app.py
+++ b/tests/unit/test_gui_app.py
@@ -32,13 +32,47 @@ def _fake_flet():
             self.text = text
             self.on_click = on_click
 
+    class Layout:
+        def __init__(self, controls=None, *args, **_kwargs):
+            if controls is None and args:
+                controls = args[0]
+            self.controls = controls or []
+
+    class ExpansionTile:
+        def __init__(self, title=None, leading=None, controls=None):
+            self.title = title
+            self.leading = leading
+            self.controls = controls or []
+
+    class ListTile:
+        def __init__(self, title=None, leading=None, data=None, on_click=None):
+            self.title = title
+            self.leading = leading
+            self.data = data
+            self.on_click = on_click
+
+    class Icon:
+        def __init__(self, name):
+            self.name = name
+
     class Page:
         def __init__(self):
             self.controls = []
             self.update = MagicMock()
+            self.overlay = []
+            self.snack_bar = SimpleNamespace(open=False, content=None)
 
         def add(self, *args):
-            self.controls.extend(args)
+            def _flatten(control):
+                self.controls.append(control)
+                for child in getattr(control, "controls", []) or []:
+                    _flatten(child)
+                content = getattr(control, "content", None)
+                if content is not None:
+                    _flatten(content)
+
+            for arg in args:
+                _flatten(arg)
 
     return SimpleNamespace(
         TextField=TextField,
@@ -46,6 +80,13 @@ def _fake_flet():
         Dropdown=Dropdown,
         Switch=Switch,
         ElevatedButton=ElevatedButton,
+        Row=Layout,
+        Column=Layout,
+        ExpansionTile=ExpansionTile,
+        ListTile=ListTile,
+        Icon=Icon,
+        icons=SimpleNamespace(FOLDER="folder", INSERT_DRIVE_FILE="file"),
+        ScrollMode=SimpleNamespace(ALWAYS="always"),
         Page=Page,
         dropdown=SimpleNamespace(Option=lambda v: v),
     )
@@ -54,6 +95,9 @@ def _fake_flet():
 def test_main_renderiza_componentes_minimos(monkeypatch):
     ft = _fake_flet()
     monkeypatch.setattr(app.runtime, "require_flet", lambda: ft)
+    monkeypatch.setattr(
+        app.runtime, "crear_arbol_directorios", lambda _ft, on_click: _ft.Column([])
+    )
     monkeypatch.setattr(app.runtime, "gui_target_choices", lambda: ("python",))
     monkeypatch.setattr(
         app.runtime,
@@ -73,12 +117,20 @@ def test_main_renderiza_componentes_minimos(monkeypatch):
     app.main(page)
 
     botones = [c for c in page.controls if isinstance(c, ft.ElevatedButton)]
-    assert [b.text for b in botones] == ["Ejecutar"]
+    assert [b.text for b in botones] == [
+        "Guardar",
+        "Guardar como",
+        "Ejecutar",
+        "Sugerencias",
+    ]
 
 
 def test_main_handler_actualiza_salida(monkeypatch):
     ft = _fake_flet()
     monkeypatch.setattr(app.runtime, "require_flet", lambda: ft)
+    monkeypatch.setattr(
+        app.runtime, "crear_arbol_directorios", lambda _ft, on_click: _ft.Column([])
+    )
     monkeypatch.setattr(app.runtime, "gui_target_choices", lambda: ("python",))
     ejecutar_mock = MagicMock(return_value="ejecutado")
     transpilar_mock = MagicMock(return_value="transpilado")
@@ -127,6 +179,9 @@ def test_main_handler_actualiza_salida(monkeypatch):
 def test_main_configura_selector_por_defecto_y_switch_deshabilitado_si_no_hay_targets(monkeypatch):
     ft = _fake_flet()
     monkeypatch.setattr(app.runtime, "require_flet", lambda: ft)
+    monkeypatch.setattr(
+        app.runtime, "crear_arbol_directorios", lambda _ft, on_click: _ft.Column([])
+    )
     monkeypatch.setattr(app.runtime, "gui_target_choices", lambda: ())
     monkeypatch.setattr(
         app.runtime,

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -13,7 +13,7 @@ def _fake_flet():
     class TextField:
         def __init__(self, **_kwargs):
             self.kwargs = _kwargs
-            self.value = ""
+            self.value = _kwargs.get("value", "")
 
     class Text:
         def __init__(self, value="", **_kwargs):
@@ -102,6 +102,9 @@ def test_main_renderiza_botones_esperados(monkeypatch):
     monkeypatch.setattr(idle.runtime, "mostrar_tokens", lambda _codigo: "Token(X)")
     monkeypatch.setattr(idle.runtime, "mostrar_ast", lambda _codigo: "[Nodo]")
     monkeypatch.setattr(
+        idle.runtime, "generar_sugerencias", lambda _codigo: ["Usa nombres descriptivos"]
+    )
+    monkeypatch.setattr(
         idle.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}"
     )
     page = ft.Page()
@@ -142,6 +145,9 @@ def test_main_handlers_smoke(monkeypatch):
     monkeypatch.setattr(idle.runtime, "transpilar_codigo", transpilar_mock)
     monkeypatch.setattr(idle.runtime, "mostrar_tokens", lambda _codigo: "Token(X)")
     monkeypatch.setattr(idle.runtime, "mostrar_ast", lambda _codigo: "[Nodo]")
+    monkeypatch.setattr(
+        idle.runtime, "generar_sugerencias", lambda _codigo: ["Usa nombres descriptivos"]
+    )
     monkeypatch.setattr(
         idle.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}"
     )
@@ -224,6 +230,9 @@ def test_main_selector_y_switch_sin_targets(monkeypatch):
     monkeypatch.setattr(idle.runtime, "mostrar_tokens", lambda _codigo: "Token(X)")
     monkeypatch.setattr(idle.runtime, "mostrar_ast", lambda _codigo: "[Nodo]")
     monkeypatch.setattr(
+        idle.runtime, "generar_sugerencias", lambda _codigo: ["Usa nombres descriptivos"]
+    )
+    monkeypatch.setattr(
         idle.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}"
     )
 
@@ -235,3 +244,102 @@ def test_main_selector_y_switch_sin_targets(monkeypatch):
 
     assert selector.value is None
     assert activar.disabled is True
+
+
+def test_main_acciones_publicas_de_archivo(monkeypatch, tmp_path):
+    ft = _fake_flet()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
+    monkeypatch.setattr(idle.runtime, "gui_target_choices", lambda: ("python",))
+    monkeypatch.setattr(
+        idle.runtime,
+        "require_gui_dependencies",
+        lambda: {
+            "TRANSPILERS": {"python": object},
+            "LexerError": RuntimeError,
+            "ParserError": ValueError,
+            "Lexer": lambda _codigo: SimpleNamespace(tokenizar=lambda: []),
+            "Parser": lambda _tokens: SimpleNamespace(parsear=lambda: []),
+        },
+    )
+    monkeypatch.setattr(idle.runtime, "normalizar_codigo", lambda value: value or "")
+    monkeypatch.setattr(idle.runtime, "ejecutar_codigo", lambda _codigo: "ok")
+    monkeypatch.setattr(
+        idle.runtime, "transpilar_codigo", lambda _codigo, _lang: "transpilado"
+    )
+    monkeypatch.setattr(idle.runtime, "mostrar_tokens", lambda _codigo: "Token(X)")
+    monkeypatch.setattr(idle.runtime, "mostrar_ast", lambda _codigo: "[Nodo]")
+    monkeypatch.setattr(
+        idle.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}"
+    )
+
+    archivo_abrir = tmp_path / "abrir.cobra"
+    archivo_abrir.write_text("imprimir('abrir')", encoding="utf-8")
+    archivo_arbol = tmp_path / "arbol.co"
+    archivo_arbol.write_text("imprimir('arbol')", encoding="utf-8")
+    destino_guardar_como = tmp_path / "guardar_como.cobra"
+
+    page = ft.Page()
+    idle.main(page)
+
+    entrada = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("multiline")
+    )
+    ruta_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Ruta"
+    )
+    salida = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.Text) and c.kwargs.get("selectable")
+    )
+    estado_archivo = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.Text) and not c.kwargs.get("selectable")
+        and "Archivo nuevo" in c.value
+    )
+    botones = {
+        c.text: c for c in page.controls if isinstance(c, ft.ElevatedButton)
+    }
+
+    botones["Nuevo"].on_click(None)
+    assert entrada.value == ""
+    assert salida.value == "Archivo nuevo creado en memoria."
+    assert "Archivo nuevo (sin guardar)" in estado_archivo.value
+
+    ruta_input.value = str(archivo_abrir)
+    botones["Abrir"].on_click(None)
+    assert entrada.value == "imprimir('abrir')"
+    assert salida.value == f"Archivo cargado: {archivo_abrir.resolve()}"
+    assert estado_archivo.value == str(archivo_abrir.resolve())
+
+    entrada.value = "imprimir('guardado')"
+    botones["Guardar"].on_click(None)
+    assert archivo_abrir.read_text(encoding="utf-8") == "imprimir('guardado')"
+    assert salida.value == f"Archivo guardado: {archivo_abrir.resolve()}"
+
+    ruta_input.value = str(destino_guardar_como)
+    entrada.value = "imprimir('como')"
+    botones["Guardar como"].on_click(None)
+    assert destino_guardar_como.read_text(encoding="utf-8") == "imprimir('como')"
+    assert salida.value == f"Archivo guardado: {destino_guardar_como.resolve()}"
+
+    destino_guardar_como.write_text("imprimir('recargado')", encoding="utf-8")
+    entrada.value = "imprimir('memoria')"
+    botones["Recargar"].on_click(None)
+    assert entrada.value == "imprimir('recargado')"
+    assert salida.value == f"Archivo cargado: {destino_guardar_como.resolve()}"
+
+    boton_arbol = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextButton) and c.text == f"📄 {archivo_arbol.name}"
+    )
+    boton_arbol.on_click(None)
+    assert entrada.value == "imprimir('arbol')"
+    assert salida.value == f"Archivo cargado: {archivo_arbol.resolve()}"

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -105,6 +106,103 @@ def test_gui_target_choices_filtra_targets_no_oficiales(monkeypatch: pytest.Monk
     )
 
     assert runtime.gui_target_choices() == ("python", "rust")
+
+
+def test_accion_nuevo_archivo_reinicia_estado() -> None:
+    estado = runtime.GuiFileState(
+        ruta=Path("programa.cobra"),
+        contenido_cargado="imprimir('x')",
+        cambios_sin_guardar=True,
+    )
+
+    contenido, mensaje = runtime.crear_archivo_nuevo_en_editor(estado)
+
+    assert contenido == ""
+    assert mensaje == "Archivo nuevo creado en memoria."
+    assert estado == runtime.GuiFileState()
+
+
+def test_accion_abrir_archivo_desde_ruta(tmp_path: Path) -> None:
+    archivo = tmp_path / "programa.cobra"
+    archivo.write_text("imprimir('hola')", encoding="utf-8")
+    estado = runtime.GuiFileState()
+
+    contenido, mensaje = runtime.abrir_archivo_desde_ruta(archivo, estado)
+
+    assert contenido == "imprimir('hola')"
+    assert estado.ruta == archivo.resolve()
+    assert estado.contenido_cargado == "imprimir('hola')"
+    assert estado.cambios_sin_guardar is False
+    assert mensaje == f"Archivo cargado: {archivo.resolve()}"
+
+
+def test_accion_guardar_archivo_activo(tmp_path: Path) -> None:
+    archivo = tmp_path / "programa.cobra"
+    archivo.write_text("imprimir('antes')", encoding="utf-8")
+    estado = runtime.GuiFileState(
+        ruta=archivo.resolve(),
+        contenido_cargado="imprimir('antes')",
+        cambios_sin_guardar=True,
+    )
+
+    contenido, mensaje = runtime.guardar_archivo_activo("imprimir('despues')", estado)
+
+    assert contenido == "imprimir('despues')"
+    assert archivo.read_text(encoding="utf-8") == "imprimir('despues')"
+    assert estado.contenido_cargado == "imprimir('despues')"
+    assert estado.cambios_sin_guardar is False
+    assert mensaje == f"Archivo guardado: {archivo.resolve()}"
+
+
+def test_accion_guardar_archivo_activo_sin_ruta_falla() -> None:
+    with pytest.raises(ValueError, match="No hay archivo activo"):
+        runtime.guardar_archivo_activo("imprimir('x')", runtime.GuiFileState())
+
+
+def test_accion_guardar_archivo_como(tmp_path: Path) -> None:
+    destino = tmp_path / "nuevo.cobra"
+    estado = runtime.GuiFileState()
+
+    contenido, mensaje = runtime.guardar_archivo_como(
+        destino, "imprimir('nuevo')", estado
+    )
+
+    assert contenido == "imprimir('nuevo')"
+    assert destino.read_text(encoding="utf-8") == "imprimir('nuevo')"
+    assert estado.ruta == destino.resolve()
+    assert estado.contenido_cargado == "imprimir('nuevo')"
+    assert estado.cambios_sin_guardar is False
+    assert mensaje == f"Archivo guardado: {destino.resolve()}"
+
+
+def test_accion_recargar_archivo_activo(tmp_path: Path) -> None:
+    archivo = tmp_path / "programa.cobra"
+    archivo.write_text("imprimir('disco')", encoding="utf-8")
+    estado = runtime.GuiFileState(
+        ruta=archivo.resolve(),
+        contenido_cargado="imprimir('memoria')",
+        cambios_sin_guardar=True,
+    )
+
+    contenido, mensaje = runtime.recargar_archivo_activo(estado)
+
+    assert contenido == "imprimir('disco')"
+    assert estado.contenido_cargado == "imprimir('disco')"
+    assert estado.cambios_sin_guardar is False
+    assert mensaje == f"Archivo cargado: {archivo.resolve()}"
+
+
+def test_accion_cargar_archivo_desde_arbol_filtra_extensiones(tmp_path: Path) -> None:
+    archivo = tmp_path / "arbol.co"
+    archivo.write_text("imprimir('arbol')", encoding="utf-8")
+    estado = runtime.GuiFileState()
+
+    contenido, mensaje = runtime.cargar_archivo_desde_arbol(archivo, estado)
+
+    assert contenido == "imprimir('arbol')"
+    assert mensaje == f"Archivo cargado: {archivo.resolve()}"
+    with pytest.raises(ValueError, match="archivo Cobra"):
+        runtime.cargar_archivo_desde_arbol(tmp_path / "notas.txt", estado)
 
 
 def test_require_flet_error_accionable(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- Evitar duplicación de lógica de gestión de archivos en las UIs y exponer las acciones públicas de archivo desde un único punto reutilizable.
- Mantener `pcobra.gui.app` como una interfaz mínima que reutiliza los helpers de `pcobra.gui.runtime` en lugar de implementar su propia lógica de archivo.
- Asegurar que los flujos de archivo (nuevo, abrir, guardar, guardar como, recargar, carga desde árbol) estén cubiertos por pruebas unitarias.

### Description
- Se añadieron helpers públicos en `src/pcobra/gui/runtime.py`: `crear_archivo_nuevo_en_editor`, `abrir_archivo_desde_ruta`, `guardar_archivo_activo`, `guardar_archivo_como`, `recargar_archivo_activo` y `cargar_archivo_desde_arbol` para centralizar la lógica de archivos.
- `src/pcobra/gui/idle.py` delega ahora todas las acciones de archivo a los helpers de `runtime.py` y unifica el manejo de errores/resultados para la UI del IDLE.
- `src/pcobra/gui/app.py` fue actualizado para usar `cargar_archivo_desde_arbol` al cargar desde el árbol, manteniendo la app como capa mínima que reutiliza `runtime`.
- Se añadieron y actualizaron pruebas en `tests/unit/test_gui_runtime.py`, `tests/unit/test_gui_idle.py` y `tests/unit/test_gui_app.py` para cubrir: crear nuevo archivo, abrir por ruta, guardar activo, guardar como, recargar activo y carga desde árbol; además se ajustaron los dobles de `flet` usados en los tests smoke.

### Testing
- Ejecutado: `pytest tests/unit/test_gui_idle.py tests/unit/test_gui_runtime.py tests/unit/test_gui_app.py`.
- Resultado: las pruebas unitarias automatizadas pasaron exitosamente (`28 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3007c5b2088327b57664934e89ad21)