### PR TITLE
docs: confirm agix dependency for IA integration

### DIFF
--- a/docs/proposals/actualizacion_librerias_python_tareas.md
+++ b/docs/proposals/actualizacion_librerias_python_tareas.md
@@ -283,6 +283,15 @@ Antes de implementar cualquier ticket, leer y respetar estos puntos:
 
 **Trabajo esperado**
 
+- Mantener `agix` como paquete requerido para la integración de producto: el
+  proyecto declara `agix>=1.9.0,<2`, el módulo
+  `src/pcobra/ia/analizador_agix.py` importa la API pública de `agix` y no hay
+  una decisión técnica aprobada para migrar a `agi-core`.
+- No sustituir referencias nuevas de tareas o issues por `agi-core`; si aparece
+  esa mención, corregirla a `agix` salvo que antes se documente una propuesta
+  formal en `docs/proposals/` con el nombre exacto del paquete, la API pública
+  usada, su relación con `analizador_agix.py` y el plan de compatibilidad o
+  reemplazo.
 - Revisar rutas públicas de AGIX actuales frente a imports existentes.
 - Validar llamadas y tipos usados por `analizador_agix.py`.
 - Revisar API actual de `smooth-criminal` usada por `performance.py`.


### PR DESCRIPTION
### Motivation
- Aclarar que la integración de IA del producto debe seguir usando `agix` (no `agi-core`) y evitar reemplazos accidentales por `agi-core` sin una propuesta técnica formal, manteniendo `src/pcobra/ia/analizador_agix.py` sin cambios hasta confirmar la API real.

### Description
- Se actualizó `docs/proposals/actualizacion_librerias_python_tareas.md` para incluir reglas que mantienen `agix` como dependencia del producto y que requieren una propuesta documentada en `docs/proposals/` (nombre del paquete, API pública, relación con `analizador_agix.py` y plan de compatibilidad/reemplazo) antes de considerar migrar a `agi-core`, sin modificar `src/pcobra/ia/analizador_agix.py`.

### Testing
- Se ejecutaron `python -m pytest tests/unit/test_analizador_agix.py tests/unit/test_cli_agix_missing_dep.py` y los tests pasaron (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3023de45d88327b53c5bf65d70caf9)