### PR TITLE
Añadir reglas trazables del Libro y usarlas para generar sugerencias AGIX

### DIFF
--- a/src/pcobra/ia/analizador_agix.py
+++ b/src/pcobra/ia/analizador_agix.py
@@ -26,6 +26,7 @@ try:
         pass
 
     from agix.emotion.emotion_simulator import PADState
+
     # Alias similar para los módulos de simulación emocional.
     sys.modules["src.agix.emotion.emotion_simulator"] = agix.emotion.emotion_simulator
 
@@ -35,7 +36,7 @@ except ImportError:  # pragma: no cover - depende de agix instalado
     PADState = None
 from typing import List
 
-from pcobra.cobra.core import Lexer, Parser
+from pcobra.ia.reglas_libro_programacion import construir_candidatos_desde_reglas
 
 MENSAJE_DEPENDENCIA_AGIX = (
     "La dependencia opcional 'agix' no está instalada o no se pudo importar. "
@@ -62,29 +63,9 @@ def generar_sugerencias(
     if Reasoner is None:
         raise ImportError(MENSAJE_DEPENDENCIA_AGIX)
 
-    # Validar el código utilizando las herramientas de Cobra
-    tokens = Lexer(codigo).tokenizar()
-    Parser(tokens).parsear()
-
-    evaluaciones = []
-    if "imprimir(" not in codigo:
-        evaluaciones.append({
-            "name": "Agregar imprimir para depurar",
-            "accuracy": 0.9,
-            "interpretability": 0.8,
-        })
-    if "var " in codigo:
-        evaluaciones.append({
-            "name": "Usar nombres descriptivos para variables",
-            "accuracy": 0.8,
-            "interpretability": 0.7,
-        })
-    if not evaluaciones:
-        evaluaciones.append({
-            "name": "Código correcto",
-            "accuracy": 0.5,
-            "interpretability": 1.0,
-        })
+    # Las reglas internas validan primero la entrada con Lexer/Parser y solo
+    # producen candidatos respaldados por fragmentos que el Parser acepta.
+    evaluaciones = construir_candidatos_desde_reglas(codigo)
 
     if peso_precision is not None:
         for ev in evaluaciones:

--- a/src/pcobra/ia/reglas_libro_programacion.py
+++ b/src/pcobra/ia/reglas_libro_programacion.py
@@ -1,0 +1,123 @@
+"""Reglas trazables del Libro de Programación para sugerencias de IA.
+
+Este módulo no amplía la sintaxis de Cobra: cada fragmento sugerido se valida
+con el ``Lexer`` y el ``Parser`` vigentes antes de exponerse como candidato.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from pcobra.cobra.core import Lexer, Parser
+
+
+@dataclass(frozen=True)
+class ReglaLibroProgramacion:
+    """Regla interna derivada de ``docs/LIBRO_PROGRAMACION_COBRA.md``."""
+
+    id: str
+    seccion: str
+    descripcion: str
+    fragmento_valido: str
+    construir_mensaje: Callable[[str], str]
+    aplica: Callable[[str], bool]
+    accuracy: float
+    interpretability: float
+
+    def mensaje(self, codigo: str) -> str:
+        """Devuelve una sugerencia trazable a esta regla interna."""
+        return f"{self.construir_mensaje(codigo)} [regla: {self.id}; {self.seccion}]"
+
+
+def validar_con_parser(codigo: str) -> None:
+    """Valida ``codigo`` con el lexer y parser oficiales de Cobra."""
+    tokens = Lexer(codigo).tokenizar()
+    Parser(tokens).parsear()
+
+
+def _fragmento_soportado(fragmento: str) -> bool:
+    try:
+        validar_con_parser(fragmento)
+    except Exception:
+        return False
+    return True
+
+
+def _contiene_identificador_corto(codigo: str) -> bool:
+    tokens = Lexer(codigo).tokenizar()
+    return any(
+        token.tipo.name == "IDENTIFICADOR"
+        and isinstance(token.valor, str)
+        and len(token.valor) == 1
+        for token in tokens
+    )
+
+
+REGLAS_LIBRO_PROGRAMACION: tuple[ReglaLibroProgramacion, ...] = (
+    ReglaLibroProgramacion(
+        id="LP-3.1-NOMBRES-DESCRIPTIVOS",
+        seccion="§3.1 Léxico",
+        descripcion="Usar identificadores válidos y legibles para variables, funciones, clases y módulos.",
+        fragmento_valido="total = 10\nimprimir(total)",
+        construir_mensaje=lambda _codigo: "Usar nombres descriptivos para variables",
+        aplica=_contiene_identificador_corto,
+        accuracy=0.8,
+        interpretability=0.9,
+    ),
+    ReglaLibroProgramacion(
+        id="LP-3.3-IMPRESION-CANONICA",
+        seccion="§3.3 Sentencias",
+        descripcion="Preferir sentencias canónicas verificadas por el parser para acciones con efecto.",
+        fragmento_valido='imprimir("Hola, Cobra")',
+        construir_mensaje=lambda _codigo: "Agregar una sentencia imprimir solo si aporta observabilidad",
+        aplica=lambda codigo: "imprimir" not in codigo,
+        accuracy=0.55,
+        interpretability=0.75,
+    ),
+    ReglaLibroProgramacion(
+        id="LP-3.6-USAR-SIN-ALIAS",
+        seccion="§3.6 Módulos",
+        descripcion='Usar módulos con la forma aceptada por el parser: usar "modulo", sin alias como.',
+        fragmento_valido='usar "numero"\nes_finito(10)',
+        construir_mensaje=lambda _codigo: 'Usar módulos con `usar "modulo"` y llamadas planas, sin alias `como`',
+        aplica=lambda codigo: "usar" in codigo,
+        accuracy=0.65,
+        interpretability=0.85,
+    ),
+)
+
+
+def construir_candidatos_desde_reglas(codigo: str) -> list[dict[str, object]]:
+    """Construye candidatos aplicables desde reglas internas trazables.
+
+    La entrada y cada fragmento canónico asociado a las reglas se validan con
+    ``Lexer``/``Parser``. Si la entrada no parsea, la excepción se propaga para
+    impedir sugerencias aplicables sobre código inválido.
+    """
+    validar_con_parser(codigo)
+    candidatos: list[dict[str, object]] = []
+    for regla in REGLAS_LIBRO_PROGRAMACION:
+        if regla.aplica(codigo) and _fragmento_soportado(regla.fragmento_valido):
+            candidatos.append(
+                {
+                    "name": regla.mensaje(codigo),
+                    "reason": regla.mensaje(codigo),
+                    "accuracy": regla.accuracy,
+                    "interpretability": regla.interpretability,
+                    "rule_id": regla.id,
+                    "rule_section": regla.seccion,
+                }
+            )
+    if not candidatos:
+        candidatos.append(
+            {
+                "name": "Código correcto [regla: LP-3.9-CONTRATO-IA; §3.9 Contrato para sugerencias automáticas en GUI/IA]",
+                "reason": "Código correcto [regla: LP-3.9-CONTRATO-IA; §3.9 Contrato para sugerencias automáticas en GUI/IA]",
+                "accuracy": 0.5,
+                "interpretability": 1.0,
+                "rule_id": "LP-3.9-CONTRATO-IA",
+                "rule_section": "§3.9 Contrato para sugerencias automáticas en GUI/IA",
+            }
+        )
+    return candidatos

--- a/tests/unit/test_analizador_agix.py
+++ b/tests/unit/test_analizador_agix.py
@@ -5,7 +5,6 @@ import pytest
 from pcobra.ia import analizador_agix
 
 
-
 def test_generar_sugerencias_variable_descriptiva():
     """Verifica que se retorne la sugerencia adecuada."""
     instancia_falsa = MagicMock()
@@ -31,7 +30,9 @@ def test_generar_sugerencias_modulacion_emocional():
 
 def test_generar_sugerencias_sin_agix():
     with patch.object(analizador_agix, "Reasoner", None):
-        with pytest.raises(ImportError, match="dependencia opcional 'agix'.*pip install agix"):
+        with pytest.raises(
+            ImportError, match="dependencia opcional 'agix'.*pip install agix"
+        ):
             analizador_agix.generar_sugerencias("var x = 5")
 
 
@@ -52,19 +53,72 @@ def test_import_opcional_sin_agix_muestra_mensaje_claro(monkeypatch):
 
     try:
         assert recargado.Reasoner is None
-        with pytest.raises(ImportError, match="dependencia opcional 'agix'.*pip install agix"):
+        with pytest.raises(
+            ImportError, match="dependencia opcional 'agix'.*pip install agix"
+        ):
             recargado.generar_sugerencias("var x = 5")
     finally:
         monkeypatch.setattr(builtins, "__import__", import_original)
         importlib.reload(analizador_agix)
 
 
-@pytest.mark.parametrize("param, valor", [
-    ("placer", 2.0),
-    ("activacion", -1.5),
-    ("dominancia", 1.2),
-])
+@pytest.mark.parametrize(
+    "param, valor",
+    [
+        ("placer", 2.0),
+        ("activacion", -1.5),
+        ("dominancia", 1.2),
+    ],
+)
 def test_generar_sugerencias_valores_fuera_de_rango(param, valor):
     with patch.object(analizador_agix, "Reasoner", MagicMock()):
         with pytest.raises(ValueError, match=rf"{param} debe estar en el rango"):
             analizador_agix.generar_sugerencias("var x = 5", **{param: valor})
+
+
+def test_error_lexico_o_sintactico_impide_sugerencias_aplicables():
+    """No se invoca agix si Lexer/Parser rechazan el fragmento."""
+    razonador = MagicMock()
+    with patch.object(
+        analizador_agix, "Reasoner", return_value=razonador
+    ) as razonador_cls:
+        with pytest.raises(Exception):
+            analizador_agix.generar_sugerencias(
+                "funcion saludar(nombre): retornar nombre"
+            )
+    razonador_cls.assert_not_called()
+    razonador.select_best_model.assert_not_called()
+
+
+def test_sugerencias_no_inventan_construcciones_fuera_del_parser():
+    """Los candidatos salen de reglas validadas y evitan formas no aceptadas."""
+    instancia = MagicMock()
+
+    def seleccionar_primero(evaluaciones):
+        return evaluaciones[0]
+
+    instancia.select_best_model.side_effect = seleccionar_primero
+    with patch.object(analizador_agix, "Reasoner", return_value=instancia):
+        sugerencias = analizador_agix.generar_sugerencias("var x = 5")
+
+    texto = "\n".join(sugerencias)
+    assert "retornar" not in texto
+    assert "funcion " not in texto
+    evaluaciones = instancia.select_best_model.call_args.args[0]
+    assert all("rule_id" in evaluacion for evaluacion in evaluaciones)
+    assert all("rule_section" in evaluacion for evaluacion in evaluaciones)
+
+
+def test_sugerencia_principal_referencia_regla_interna_trazable():
+    instancia = MagicMock()
+
+    def seleccionar_primero(evaluaciones):
+        return evaluaciones[0]
+
+    instancia.select_best_model.side_effect = seleccionar_primero
+    with patch.object(analizador_agix, "Reasoner", return_value=instancia):
+        sugerencias = analizador_agix.generar_sugerencias("var x = 5")
+
+    assert len(sugerencias) == 1
+    assert "[regla: LP-" in sugerencias[0]
+    assert "§3." in sugerencias[0]


### PR DESCRIPTION
### Motivation
- Extraer reglas explícitas y verificables desde el `docs/LIBRO_PROGRAMACION_COBRA.md` para que las sugerencias no inventen sintaxis ni tokens fuera del `Parser`.
- Forzar validación previa con `Lexer` y `Parser` para impedir sugerencias aplicables sobre código léxico/sintácticamente inválido.
- Mantener a `agix.reasoning.basic.Reasoner` sólo como selector/priorizador de candidatos ya construidos y trazables.

### Description
- Se añadió el módulo `src/pcobra/ia/reglas_libro_programacion.py` que define `ReglaLibroProgramacion` y la función `construir_candidatos_desde_reglas(codigo)`; cada regla incluye `id`, `seccion`, `fragmento_valido`, `accuracy` e `interpretability` y construye candidatos trazables que incluyen `rule_id` y `rule_section`.
- La validación de entrada y de cada `fragmento_valido` se realiza con `Lexer(codigo).tokenizar()` y `Parser(tokens).parsear()` para garantizar que el parser acepta las formas sugeridas.
- Se modificó `src/pcobra/ia/analizador_agix.py::generar_sugerencias` para usar `construir_candidatos_desde_reglas(codigo)` como fuente de candidatos y dejar a `Reasoner` exclusivamente como selector/priorizador; los pesos y la modularización por `PADState` se mantienen.
- Se añadieron reglas iniciales derivadas del Libro (nombres descriptivos, impresión canónica, `usar` sin alias) y las pruebas que exponen trazabilidad y restricciones sintácticas.

### Testing
- Se ejecutó `pytest -q tests/unit/test_analizador_agix.py` y todos los tests unitarios pasaron: `10 passed`.
- Se comprobó que los módulos compilan con `python -m py_compile src/pcobra/ia/analizador_agix.py src/pcobra/ia/reglas_libro_programacion.py` sin errores.
- Se ejecutó el formateador `black` (se aplicaron cambios de formato) y se verificó `git diff --check` sin errores relevantes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3032805ff48327b89745f4ccf803e5)