### PR TITLE
Separar validadores legacy de sintaxis

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ cobra validar-sintaxis --report-json reporte_sintaxis.json
 cobra validar-sintaxis --report-json
 ```
 
-El comando respeta el `--modo` global de la CLI y puede combinarse con `--modo mixto`, `--modo cobra` o `--modo transpilar`.
+El comando respeta el `--modo` global de la CLI y puede combinarse con `--modo mixto`, `--modo cobra` o `--modo transpilar`. La ruta pública de `validar-sintaxis` solo acepta los backends oficiales `python`, `javascript` y `rust`; los validadores históricos `go`, `cpp`, `java`, `wasm` y `asm` se conservan únicamente en `pcobra.cobra.qa.legacy_syntax_validation.LEGACY_INTERNAL_VALIDATORS` para regresión interna o migraciones documentadas, y no deben consumirse desde comandos públicos.
 
 **Contrato JSON versionado (`--report-json`)**
 
@@ -1507,7 +1507,7 @@ Las contribuciones son bienvenidas. Si deseas contribuir, sigue estos pasos:
 - Ejecuta primero el smoke de sintaxis con `python scripts/smoke_syntax.py`
   (delegación a `pcobra.cobra.qa.syntax_validation` con perfil `solo-cobra`).
 - Ejecuta `python scripts/smoke_transpilers_syntax.py` para transpilación + validación
-  sintáctica cruzada de los 8 targets oficiales; este script también delega en la misma API
+  sintáctica cruzada de los 3 targets oficiales públicos (`python`, `javascript`, `rust`); este script también delega en la misma API
   unificada (`pcobra.cobra.qa.syntax_validation`, perfil `transpiladores`).
 - Ejecuta `make secrets` para buscar credenciales expuestas usando *gitleaks*.
 - Para lanzar todas las validaciones en un solo paso ejecuta `python scripts/check.py`.

--- a/docs/tareas_validacion_sintaxis.md
+++ b/docs/tareas_validacion_sintaxis.md
@@ -159,7 +159,7 @@ Para separar pipelines rápidos y completos, `validar-sintaxis` y `scripts/check
 quedan alineados en tres perfiles:
 
 - `solo-cobra`: validación rápida (Python + parse Cobra).
-- `transpiladores`: valida exclusivamente sintaxis de backends.
+- `transpiladores`: valida exclusivamente sintaxis de los backends oficiales públicos (`python`, `javascript`, `rust`).
 - `completo`: ejecuta todo.
 
 Ejemplos recomendados:
@@ -180,6 +180,7 @@ python scripts/check.py --perfil completo
 
 Compatibilidad:
 - `--solo-cobra` se mantiene como alias deprecado de `--perfil solo-cobra`.
+- Los validadores `go`, `cpp`, `java`, `wasm` y `asm` quedan fuera de la ruta pública. Si se necesitan para regresión histórica, deben invocarse solo desde rutas internas/de migración usando `pcobra.cobra.qa.legacy_syntax_validation.LEGACY_INTERNAL_VALIDATORS`.
 
 
 ## 7) Contrato JSON de `validar-sintaxis --report-json` (versionado)

--- a/src/pcobra/cobra/qa/legacy_syntax_validation.py
+++ b/src/pcobra/cobra/qa/legacy_syntax_validation.py
@@ -1,0 +1,170 @@
+"""Validadores internos legacy para regresión histórica.
+
+Este módulo no forma parte de la API pública de validación de sintaxis.
+Los comandos públicos deben consumir ``pcobra.cobra.qa.syntax_validation.VALIDATORS``,
+que contiene exclusivamente los backends oficiales: python, javascript y rust.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Callable
+
+from pcobra.cobra.qa.syntax_validation import (
+    SYNTAX_TOOL_TIMEOUT_SECONDS,
+    ValidationResult,
+    run_external_command,
+)
+
+
+def _validate_go(code: str) -> ValidationResult:
+    go = shutil.which("go")
+    if not go:
+        return ValidationResult("skipped", "go no está disponible")
+    gofmt = shutil.which("gofmt")
+    with tempfile.TemporaryDirectory(prefix="pcobra_go_") as tmp:
+        file_path = Path(tmp) / "main.go"
+        output_file = Path(tmp) / "main.bin"
+        file_path.write_text(code, encoding="utf-8")
+        try:
+            ok, output = run_external_command(
+                [go, "build", "-o", str(output_file), str(file_path)],
+                timeout_seconds=SYNTAX_TOOL_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return ValidationResult(
+                "fail",
+                f"go build excedió el timeout de {SYNTAX_TOOL_TIMEOUT_SECONDS}s para target go",
+            )
+        if not ok:
+            return ValidationResult("fail", output)
+
+        if not gofmt:
+            return ValidationResult(
+                "ok", "go build correcto (sin diagnóstico de gofmt)"
+            )
+
+        gofmt_result = subprocess.run(
+            [gofmt, "-l", str(file_path)],
+            text=True,
+            capture_output=True,
+        )
+        if gofmt_result.returncode != 0:
+            message = (gofmt_result.stderr or gofmt_result.stdout).strip()
+            return ValidationResult("fail", message or "gofmt -l falló")
+
+        style_output = gofmt_result.stdout.strip()
+        if style_output:
+            return ValidationResult(
+                "ok", "go build correcto; gofmt -l detectó diferencias de formato"
+            )
+
+    return ValidationResult("ok", "go build correcto; gofmt -l correcto")
+
+
+def _validate_cpp(code: str) -> ValidationResult:
+    clangpp = shutil.which("clang++")
+    if not clangpp:
+        return ValidationResult("skipped", "clang++ no está disponible")
+    normalized = "\n".join(
+        line
+        for line in code.splitlines()
+        if not line.strip().startswith("#include <pcobra/")
+    )
+    with tempfile.TemporaryDirectory(prefix="pcobra_cpp_") as tmp:
+        file_path = Path(tmp) / "main.cpp"
+        file_path.write_text(normalized, encoding="utf-8")
+        try:
+            ok, output = run_external_command(
+                [clangpp, "-fsyntax-only", str(file_path)],
+                timeout_seconds=SYNTAX_TOOL_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return ValidationResult(
+                "fail",
+                f"clang++ excedió el timeout de {SYNTAX_TOOL_TIMEOUT_SECONDS}s para target cpp",
+            )
+    return (
+        ValidationResult("ok", "clang++ -fsyntax-only correcto")
+        if ok
+        else ValidationResult("fail", output)
+    )
+
+
+def _validate_java(code: str) -> ValidationResult:
+    javac = shutil.which("javac")
+    if not javac:
+        return ValidationResult("skipped", "javac no está disponible")
+    normalized = "\n".join(
+        line
+        for line in code.splitlines()
+        if not line.strip().startswith("import pcobra.")
+    )
+    with tempfile.TemporaryDirectory(prefix="pcobra_java_") as tmp:
+        file_path = Path(tmp) / "Main.java"
+        file_path.write_text(normalized, encoding="utf-8")
+        try:
+            ok, output = run_external_command(
+                [javac, str(file_path)],
+                cwd=Path(tmp),
+                timeout_seconds=SYNTAX_TOOL_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return ValidationResult(
+                "fail",
+                f"javac excedió el timeout de {SYNTAX_TOOL_TIMEOUT_SECONDS}s para target java",
+            )
+    return (
+        ValidationResult("ok", "javac correcto")
+        if ok
+        else ValidationResult("fail", output)
+    )
+
+
+def _validate_wasm(code: str) -> ValidationResult:
+    wat2wasm = shutil.which("wat2wasm")
+    if not wat2wasm:
+        return ValidationResult("skipped", "wat2wasm no está disponible")
+    with tempfile.TemporaryDirectory(prefix="pcobra_wasm_") as tmp:
+        file_path = Path(tmp) / "main.wat"
+        output_file = Path(tmp) / "main.wasm"
+        file_path.write_text(code, encoding="utf-8")
+        try:
+            ok, output = run_external_command(
+                [wat2wasm, str(file_path), "-o", str(output_file)],
+                timeout_seconds=SYNTAX_TOOL_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return ValidationResult(
+                "fail",
+                f"wat2wasm excedió el timeout de {SYNTAX_TOOL_TIMEOUT_SECONDS}s para target wasm",
+            )
+    return (
+        ValidationResult("ok", "wat2wasm correcto")
+        if ok
+        else ValidationResult("fail", output)
+    )
+
+
+def _validate_asm(code: str) -> ValidationResult:
+    lines = [line.strip() for line in code.splitlines() if line.strip()]
+    if not lines:
+        return ValidationResult("fail", "salida ASM vacía")
+    unresolved = [line for line in lines if line.startswith("<") and line.endswith(">")]
+    if unresolved:
+        return ValidationResult("fail", f"tokens ASM no resueltos: {unresolved[:3]}")
+    return ValidationResult("ok", "validador interno ASM correcto")
+
+
+LEGACY_INTERNAL_VALIDATORS: dict[str, Callable[[str], ValidationResult]] = {
+    "go": _validate_go,
+    "cpp": _validate_cpp,
+    "java": _validate_java,
+    "wasm": _validate_wasm,
+    "asm": _validate_asm,
+}
+
+__all__ = ["LEGACY_INTERNAL_VALIDATORS"]

--- a/src/pcobra/cobra/qa/syntax_validation.py
+++ b/src/pcobra/cobra/qa/syntax_validation.py
@@ -16,6 +16,7 @@ from typing import Any, Callable
 
 from pcobra.cobra.transpilers.registry import official_transpiler_targets
 
+
 @dataclass
 class ValidationResult:
     status: str
@@ -39,7 +40,11 @@ class SyntaxReport:
 
 
 SUPPORTED_VALIDATOR_TARGETS: tuple[str, ...] = official_transpiler_targets()
-SUPPORTED_VALIDATION_PROFILES: tuple[str, ...] = ("solo-cobra", "transpiladores", "completo")
+SUPPORTED_VALIDATION_PROFILES: tuple[str, ...] = (
+    "solo-cobra",
+    "transpiladores",
+    "completo",
+)
 SYNTAX_REPORT_SCHEMA_VERSION = "1.0.0"
 # Tiempo máximo (en segundos) para herramientas externas de validación de sintaxis.
 # Ajustar este valor si el entorno de CI o la máquina local son más lentos.
@@ -55,8 +60,16 @@ def _resolve_project_root() -> Path | None:
 
 
 PROJECT_ROOT = _resolve_project_root()
-SRC_DIR = (PROJECT_ROOT / "src") if PROJECT_ROOT else Path(__file__).resolve().parents[5] / "src"
-TESTS_DIR = (PROJECT_ROOT / "tests") if PROJECT_ROOT else Path(__file__).resolve().parents[5] / "tests"
+SRC_DIR = (
+    (PROJECT_ROOT / "src")
+    if PROJECT_ROOT
+    else Path(__file__).resolve().parents[5] / "src"
+)
+TESTS_DIR = (
+    (PROJECT_ROOT / "tests")
+    if PROJECT_ROOT
+    else Path(__file__).resolve().parents[5] / "tests"
+)
 COBRA_FIXTURES = [
     SRC_DIR.parent / "scripts" / "benchmarks" / "programs" / "small.co",
     SRC_DIR.parent / "scripts" / "benchmarks" / "programs" / "factorial.co",
@@ -115,7 +128,9 @@ def load_ast_for_fixture(fixture: Path):
 
 
 def run_external_command(
-    command: list[str], cwd: Path | None = None, timeout_seconds: int | float | None = None
+    command: list[str],
+    cwd: Path | None = None,
+    timeout_seconds: int | float | None = None,
 ) -> tuple[bool, str]:
     result = subprocess.run(
         command,
@@ -131,11 +146,21 @@ def run_external_command(
 
 def validate_python_syntax() -> ValidationResult:
     src_ok = compileall.compile_dir(str(SRC_DIR), quiet=1, force=False)
-    excluded_dirs = {".venv", "__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "tmp", "temp"}
+    excluded_dirs = {
+        ".venv",
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        "tmp",
+        "temp",
+    }
     test_candidates = [
         file_path
         for file_path in TESTS_DIR.rglob("*.py")
-        if all(part not in excluded_dirs for part in file_path.relative_to(TESTS_DIR).parts)
+        if all(
+            part not in excluded_dirs for part in file_path.relative_to(TESTS_DIR).parts
+        )
     ]
 
     tests_ok = True
@@ -239,7 +264,11 @@ def _validate_javascript(code: str) -> ValidationResult:
                 "fail",
                 f"node --check excedió el timeout de {SYNTAX_TOOL_TIMEOUT_SECONDS}s para target javascript",
             )
-    return ValidationResult("ok", "node --check correcto") if ok else ValidationResult("fail", output)
+    return (
+        ValidationResult("ok", "node --check correcto")
+        if ok
+        else ValidationResult("fail", output)
+    )
 
 
 def _validate_rust(code: str) -> ValidationResult:
@@ -249,10 +278,13 @@ def _validate_rust(code: str) -> ValidationResult:
     normalized = "\n".join(
         line
         for line in code.splitlines()
-        if line.strip() not in {"use crate::corelibs::*;", "use crate::standard_library::*;"}
+        if line.strip()
+        not in {"use crate::corelibs::*;", "use crate::standard_library::*;"}
     )
     if "fn main(" not in normalized:
-        body = "\n".join(f"    {line}" for line in normalized.splitlines() if line.strip())
+        body = "\n".join(
+            f"    {line}" for line in normalized.splitlines() if line.strip()
+        )
         normalized = f"fn main() {{\n{body}\n}}"
     with tempfile.TemporaryDirectory(prefix="pcobra_rust_") as tmp:
         file_path = Path(tmp) / "main.rs"
@@ -260,7 +292,14 @@ def _validate_rust(code: str) -> ValidationResult:
         file_path.write_text(normalized, encoding="utf-8")
         try:
             ok, output = run_external_command(
-                [rustc, "--emit=metadata", "--edition=2021", str(file_path), "-o", str(output_file)],
+                [
+                    rustc,
+                    "--emit=metadata",
+                    "--edition=2021",
+                    str(file_path),
+                    "-o",
+                    str(output_file),
+                ],
                 timeout_seconds=SYNTAX_TOOL_TIMEOUT_SECONDS,
             )
         except subprocess.TimeoutExpired:
@@ -268,136 +307,25 @@ def _validate_rust(code: str) -> ValidationResult:
                 "fail",
                 f"rustc excedió el timeout de {SYNTAX_TOOL_TIMEOUT_SECONDS}s para target rust",
             )
-    return ValidationResult("ok", "rustc --emit=metadata correcto") if ok else ValidationResult("fail", output)
-
-
-def _validate_go(code: str) -> ValidationResult:
-    go = shutil.which("go")
-    if not go:
-        return ValidationResult("skipped", "go no está disponible")
-    gofmt = shutil.which("gofmt")
-    with tempfile.TemporaryDirectory(prefix="pcobra_go_") as tmp:
-        file_path = Path(tmp) / "main.go"
-        output_file = Path(tmp) / "main.bin"
-        file_path.write_text(code, encoding="utf-8")
-        try:
-            ok, output = run_external_command(
-                [go, "build", "-o", str(output_file), str(file_path)],
-                timeout_seconds=SYNTAX_TOOL_TIMEOUT_SECONDS,
-            )
-        except subprocess.TimeoutExpired:
-            return ValidationResult(
-                "fail",
-                f"go build excedió el timeout de {SYNTAX_TOOL_TIMEOUT_SECONDS}s para target go",
-            )
-        if not ok:
-            return ValidationResult("fail", output)
-
-        if not gofmt:
-            return ValidationResult("ok", "go build correcto (sin diagnóstico de gofmt)")
-
-        gofmt_result = subprocess.run(
-            [gofmt, "-l", str(file_path)],
-            text=True,
-            capture_output=True,
-        )
-        if gofmt_result.returncode != 0:
-            message = (gofmt_result.stderr or gofmt_result.stdout).strip()
-            return ValidationResult("fail", message or "gofmt -l falló")
-
-        style_output = gofmt_result.stdout.strip()
-        if style_output:
-            return ValidationResult("ok", "go build correcto; gofmt -l detectó diferencias de formato")
-
-    return ValidationResult("ok", "go build correcto; gofmt -l correcto")
-
-
-def _validate_cpp(code: str) -> ValidationResult:
-    clangpp = shutil.which("clang++")
-    if not clangpp:
-        return ValidationResult("skipped", "clang++ no está disponible")
-    normalized = "\n".join(
-        line for line in code.splitlines() if not line.strip().startswith("#include <pcobra/")
+    return (
+        ValidationResult("ok", "rustc --emit=metadata correcto")
+        if ok
+        else ValidationResult("fail", output)
     )
-    with tempfile.TemporaryDirectory(prefix="pcobra_cpp_") as tmp:
-        file_path = Path(tmp) / "main.cpp"
-        file_path.write_text(normalized, encoding="utf-8")
-        try:
-            ok, output = run_external_command(
-                [clangpp, "-fsyntax-only", str(file_path)],
-                timeout_seconds=SYNTAX_TOOL_TIMEOUT_SECONDS,
-            )
-        except subprocess.TimeoutExpired:
-            return ValidationResult(
-                "fail",
-                f"clang++ excedió el timeout de {SYNTAX_TOOL_TIMEOUT_SECONDS}s para target cpp",
-            )
-    return ValidationResult("ok", "clang++ -fsyntax-only correcto") if ok else ValidationResult("fail", output)
-
-
-def _validate_java(code: str) -> ValidationResult:
-    javac = shutil.which("javac")
-    if not javac:
-        return ValidationResult("skipped", "javac no está disponible")
-    normalized = "\n".join(line for line in code.splitlines() if not line.strip().startswith("import pcobra."))
-    with tempfile.TemporaryDirectory(prefix="pcobra_java_") as tmp:
-        file_path = Path(tmp) / "Main.java"
-        file_path.write_text(normalized, encoding="utf-8")
-        try:
-            ok, output = run_external_command(
-                [javac, str(file_path)],
-                cwd=Path(tmp),
-                timeout_seconds=SYNTAX_TOOL_TIMEOUT_SECONDS,
-            )
-        except subprocess.TimeoutExpired:
-            return ValidationResult(
-                "fail",
-                f"javac excedió el timeout de {SYNTAX_TOOL_TIMEOUT_SECONDS}s para target java",
-            )
-    return ValidationResult("ok", "javac correcto") if ok else ValidationResult("fail", output)
-
-
-def _validate_wasm(code: str) -> ValidationResult:
-    wat2wasm = shutil.which("wat2wasm")
-    if not wat2wasm:
-        return ValidationResult("skipped", "wat2wasm no está disponible")
-    with tempfile.TemporaryDirectory(prefix="pcobra_wasm_") as tmp:
-        file_path = Path(tmp) / "main.wat"
-        output_file = Path(tmp) / "main.wasm"
-        file_path.write_text(code, encoding="utf-8")
-        try:
-            ok, output = run_external_command(
-                [wat2wasm, str(file_path), "-o", str(output_file)],
-                timeout_seconds=SYNTAX_TOOL_TIMEOUT_SECONDS,
-            )
-        except subprocess.TimeoutExpired:
-            return ValidationResult(
-                "fail",
-                f"wat2wasm excedió el timeout de {SYNTAX_TOOL_TIMEOUT_SECONDS}s para target wasm",
-            )
-    return ValidationResult("ok", "wat2wasm correcto") if ok else ValidationResult("fail", output)
-
-
-def _validate_asm(code: str) -> ValidationResult:
-    lines = [line.strip() for line in code.splitlines() if line.strip()]
-    if not lines:
-        return ValidationResult("fail", "salida ASM vacía")
-    unresolved = [line for line in lines if line.startswith("<") and line.endswith(">")]
-    if unresolved:
-        return ValidationResult("fail", f"tokens ASM no resueltos: {unresolved[:3]}")
-    return ValidationResult("ok", "validador interno ASM correcto")
 
 
 VALIDATORS: dict[str, Callable[[str], ValidationResult]] = {
     "python": _validate_python,
     "javascript": _validate_javascript,
     "rust": _validate_rust,
-    "go": _validate_go,
-    "cpp": _validate_cpp,
-    "java": _validate_java,
-    "wasm": _validate_wasm,
-    "asm": _validate_asm,
 }
+
+
+def legacy_internal_validators() -> dict[str, Callable[[str], ValidationResult]]:
+    """Devuelve validadores legacy solo para rutas internas/de migración documentadas."""
+    from pcobra.cobra.qa.legacy_syntax_validation import LEGACY_INTERNAL_VALIDATORS
+
+    return dict(LEGACY_INTERNAL_VALIDATORS)
 
 
 def run_transpiler_syntax_validation(
@@ -407,7 +335,9 @@ def run_transpiler_syntax_validation(
     transpilers: dict[str, type],
     strict: bool = False,
 ) -> tuple[SyntaxReport, list[dict[str, str]], bool]:
-    summaries: dict[str, TargetSummary] = {target: TargetSummary() for target in targets}
+    summaries: dict[str, TargetSummary] = {
+        target: TargetSummary() for target in targets
+    }
     errors_by_target: dict[str, list[str]] = {target: [] for target in targets}
     events: list[dict[str, str]] = []
     has_failures = False
@@ -418,7 +348,9 @@ def run_transpiler_syntax_validation(
         except Exception as exc:  # noqa: BLE001
             for target in targets:
                 summaries[target].fail += 1
-                message = f"parse/transpilación previa falló: {type(exc).__name__}: {exc}"
+                message = (
+                    f"parse/transpilación previa falló: {type(exc).__name__}: {exc}"
+                )
                 events.append(
                     {
                         "fixture": str(fixture),
@@ -488,7 +420,9 @@ def run_transpiler_syntax_validation(
         cobra=ValidationResult("skipped", "Validación Cobra no ejecutada"),
         targets=summaries,
         strict=strict,
-        errors_by_target={target: msgs for target, msgs in errors_by_target.items() if msgs},
+        errors_by_target={
+            target: msgs for target, msgs in errors_by_target.items() if msgs
+        },
     )
     return report, events, has_failures
 
@@ -510,7 +444,9 @@ def execute_syntax_validation(
     py_result = (
         validate_python_syntax()
         if run_python_cobra
-        else ValidationResult("skipped", "Perfil transpiladores: validación Python omitida")
+        else ValidationResult(
+            "skipped", "Perfil transpiladores: validación Python omitida"
+        )
     )
     cobra_result = (
         validate_cobra_parse()
@@ -518,9 +454,8 @@ def execute_syntax_validation(
         else ValidationResult("skipped", "Perfil transpiladores: parse Cobra omitido")
     )
 
-    has_failures = (
-        (run_python_cobra and py_result.status != "ok")
-        or (run_python_cobra and cobra_result.status != "ok")
+    has_failures = (run_python_cobra and py_result.status != "ok") or (
+        run_python_cobra and cobra_result.status != "ok"
     )
 
     targets_requested: list[str] = []
@@ -531,7 +466,9 @@ def execute_syntax_validation(
         targets_requested = _parse_targets_csv(targets_raw)
         fixtures = [fixture for fixture in TRANSPILER_FIXTURES if fixture.exists()]
         if not fixtures:
-            raise FileNotFoundError("No hay fixtures disponibles para validar transpiladores.")
+            raise FileNotFoundError(
+                "No hay fixtures disponibles para validar transpiladores."
+            )
 
         transpilers_report, _, transpilers_failed = run_transpiler_syntax_validation(
             fixtures=fixtures,

--- a/tests/unit/qa/test_syntax_validation.py
+++ b/tests/unit/qa/test_syntax_validation.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from pcobra.cobra.qa import syntax_validation as sv
+from pcobra.cobra.qa import legacy_syntax_validation as legacy_sv
 
 
 class _LexerTokenizar:
@@ -13,6 +14,22 @@ class _LexerTokenizar:
 class _LexerAnalizar:
     def analizar_token(self):
         return ["ok2"]
+
+
+def test_validators_publicos_solo_incluyen_backends_oficiales():
+    assert tuple(sv.VALIDATORS) == ("python", "javascript", "rust")
+    assert set(legacy_sv.LEGACY_INTERNAL_VALIDATORS) == {
+        "go",
+        "cpp",
+        "java",
+        "wasm",
+        "asm",
+    }
+
+
+def test_parse_targets_csv_rechaza_legacy_en_ruta_publica():
+    with pytest.raises(ValueError, match="Targets no soportados"):
+        sv._parse_targets_csv("python,go")
 
 
 def test_tokenize_usa_tokenizar_si_esta_disponible():
@@ -35,7 +52,9 @@ def test_run_external_command_ok():
 
 
 def test_run_external_command_fail():
-    ok, output = sv.run_external_command(["python", "-c", "import sys; sys.stderr.write('boom'); sys.exit(2)"])
+    ok, output = sv.run_external_command(
+        ["python", "-c", "import sys; sys.stderr.write('boom'); sys.exit(2)"]
+    )
     assert ok is False
     assert "boom" in output
 
@@ -67,19 +86,49 @@ def test_run_external_command_pasa_timeout_a_subprocess(monkeypatch):
     [
         (sv._validate_javascript, "node", "console.log('ok')\n", "javascript"),
         (sv._validate_rust, "rustc", "fn main() {}\n", "rust"),
-        (sv._validate_go, "go", "package main\nfunc main(){}\n", "go"),
-        (sv._validate_cpp, "clang++", "int main() { return 0; }\n", "cpp"),
-        (sv._validate_java, "javac", "class Main { public static void main(String[] args) {} }\n", "java"),
-        (sv._validate_wasm, "wat2wasm", "(module)\n", "wasm"),
+        (
+            legacy_sv.LEGACY_INTERNAL_VALIDATORS["go"],
+            "go",
+            "package main\nfunc main(){}\n",
+            "go",
+        ),
+        (
+            legacy_sv.LEGACY_INTERNAL_VALIDATORS["cpp"],
+            "clang++",
+            "int main() { return 0; }\n",
+            "cpp",
+        ),
+        (
+            legacy_sv.LEGACY_INTERNAL_VALIDATORS["java"],
+            "javac",
+            "class Main { public static void main(String[] args) {} }\n",
+            "java",
+        ),
+        (
+            legacy_sv.LEGACY_INTERNAL_VALIDATORS["wasm"],
+            "wat2wasm",
+            "(module)\n",
+            "wasm",
+        ),
     ],
 )
-def test_validadores_externos_retornan_fail_en_timeout(monkeypatch, validator, tool_name, code, expected_target):
-    monkeypatch.setattr(sv.shutil, "which", lambda cmd: f"/usr/bin/{cmd}" if cmd == tool_name else None)
+def test_validadores_externos_retornan_fail_en_timeout(
+    monkeypatch, validator, tool_name, code, expected_target
+):
+    monkeypatch.setattr(
+        sv.shutil, "which", lambda cmd: f"/usr/bin/{cmd}" if cmd == tool_name else None
+    )
+    monkeypatch.setattr(
+        legacy_sv.shutil,
+        "which",
+        lambda cmd: f"/usr/bin/{cmd}" if cmd == tool_name else None,
+    )
 
     def fake_run_external_command(_command, cwd=None, timeout_seconds=None):
         raise sv.subprocess.TimeoutExpired(cmd=_command, timeout=timeout_seconds or 1)
 
     monkeypatch.setattr(sv, "run_external_command", fake_run_external_command)
+    monkeypatch.setattr(legacy_sv, "run_external_command", fake_run_external_command)
 
     result = validator(code)
 
@@ -89,13 +138,17 @@ def test_validadores_externos_retornan_fail_en_timeout(monkeypatch, validator, t
 
 
 def test_validator_asm_detecta_tokens_no_resueltos():
-    result = sv.VALIDATORS["asm"]("<pendiente>\nMOV R1, 3")
+    result = legacy_sv.LEGACY_INTERNAL_VALIDATORS["asm"]("<pendiente>\nMOV R1, 3")
     assert result.status == "fail"
     assert "no resueltos" in result.message
 
 
 def test_validate_go_falla_si_build_falla_aunque_gofmt_exista(monkeypatch):
-    monkeypatch.setattr(sv.shutil, "which", lambda cmd: f"/usr/bin/{cmd}" if cmd in {"go", "gofmt"} else None)
+    monkeypatch.setattr(
+        legacy_sv.shutil,
+        "which",
+        lambda cmd: f"/usr/bin/{cmd}" if cmd in {"go", "gofmt"} else None,
+    )
 
     def fake_run_external_command(command, cwd=None, timeout_seconds=None):
         if command[0].endswith("go") and command[1] == "build":
@@ -103,34 +156,53 @@ def test_validate_go_falla_si_build_falla_aunque_gofmt_exista(monkeypatch):
         raise AssertionError(f"comando inesperado: {command}")
 
     monkeypatch.setattr(sv, "run_external_command", fake_run_external_command)
+    monkeypatch.setattr(legacy_sv, "run_external_command", fake_run_external_command)
 
-    result = sv._validate_go("package main\nfunc main(){ variableInexistente() }\n")
+    result = legacy_sv.LEGACY_INTERNAL_VALIDATORS["go"](
+        "package main\nfunc main(){ variableInexistente() }\n"
+    )
     assert result.status == "fail"
     assert "undefined" in result.message
 
 
 def test_validate_go_ok_con_build_y_gofmt_opcional(monkeypatch):
-    monkeypatch.setattr(sv.shutil, "which", lambda cmd: "/usr/bin/go" if cmd == "go" else None)
-    monkeypatch.setattr(sv, "run_external_command", lambda _command, cwd=None, timeout_seconds=None: (True, ""))
+    monkeypatch.setattr(
+        legacy_sv.shutil, "which", lambda cmd: "/usr/bin/go" if cmd == "go" else None
+    )
+    monkeypatch.setattr(
+        legacy_sv,
+        "run_external_command",
+        lambda _command, cwd=None, timeout_seconds=None: (True, ""),
+    )
 
-    result = sv._validate_go("package main\nfunc main(){}\n")
+    result = legacy_sv.LEGACY_INTERNAL_VALIDATORS["go"]("package main\nfunc main(){}\n")
     assert result.status == "ok"
     assert "go build correcto" in result.message
     assert "sin diagnóstico de gofmt" in result.message
 
 
 def test_validate_go_ok_con_estilo_pendiente_en_gofmt(monkeypatch):
-    monkeypatch.setattr(sv.shutil, "which", lambda cmd: f"/usr/bin/{cmd}" if cmd in {"go", "gofmt"} else None)
-    monkeypatch.setattr(sv, "run_external_command", lambda _command, cwd=None, timeout_seconds=None: (True, ""))
+    monkeypatch.setattr(
+        legacy_sv.shutil,
+        "which",
+        lambda cmd: f"/usr/bin/{cmd}" if cmd in {"go", "gofmt"} else None,
+    )
+    monkeypatch.setattr(
+        legacy_sv,
+        "run_external_command",
+        lambda _command, cwd=None, timeout_seconds=None: (True, ""),
+    )
 
     class _CompletedProcess:
         returncode = 0
         stdout = "main.go\n"
         stderr = ""
 
-    monkeypatch.setattr(sv.subprocess, "run", lambda *args, **kwargs: _CompletedProcess())
+    monkeypatch.setattr(
+        legacy_sv.subprocess, "run", lambda *args, **kwargs: _CompletedProcess()
+    )
 
-    result = sv._validate_go("package main\nfunc main(){}\n")
+    result = legacy_sv.LEGACY_INTERNAL_VALIDATORS["go"]("package main\nfunc main(){}\n")
     assert result.status == "ok"
     assert "detectó diferencias de formato" in result.message
 
@@ -200,27 +272,33 @@ def test_run_transpiler_syntax_validation_resumen_ok_y_fail(monkeypatch):
 
     transpilers = {
         "python": OkTranspiler,
-        "asm": OkTranspiler,
+        "javascript": OkTranspiler,
         "rust": FailTranspiler,
     }
 
     report, events, has_failures = sv.run_transpiler_syntax_validation(
         fixtures=[Path("fixture.co")],
-        targets=["python", "asm", "rust"],
+        targets=["python", "javascript", "rust"],
         transpilers=transpilers,
         strict=False,
     )
 
     assert report.targets["python"].ok == 1
-    assert report.targets["asm"].ok == 1
+    assert report.targets["javascript"].ok == 1
     assert report.targets["rust"].fail == 1
     assert has_failures is True
-    assert any(event["target"] == "rust" and event["status"] == "fail" for event in events)
+    assert any(
+        event["target"] == "rust" and event["status"] == "fail" for event in events
+    )
 
 
 def test_run_transpiler_syntax_validation_strict_con_skipped(monkeypatch):
     monkeypatch.setattr(sv, "load_ast_for_fixture", lambda _fixture: ["ast"])
-    monkeypatch.setitem(sv.VALIDATORS, "custom", lambda _code: sv.ValidationResult("skipped", "tool ausente"))
+    monkeypatch.setitem(
+        sv.VALIDATORS,
+        "custom",
+        lambda _code: sv.ValidationResult("skipped", "tool ausente"),
+    )
 
     class CustomTranspiler:
         def generate_code(self, _ast):


### PR DESCRIPTION
### Motivation
- Limitar la superficie pública de validación a los backends oficiales para evitar que comandos públicos consuman validadores obsoletos.
- Mantener los validadores históricos disponibles solo para regresión o migración interna sin exponerlos en la API pública.
- Aclarar documentación y pruebas para reflejar la distinción entre backends oficiales y validadores legacy.

### Description
- Reducido `VALIDATORS` en `pcobra.cobra.qa.syntax_validation` para contener únicamente `"python"`, `"javascript"` y `"rust"` y añadido el helper `legacy_internal_validators()` que carga validadores legacy bajo demanda.
- Extraído los validadores `go`, `cpp`, `java`, `wasm` y `asm` a `src/pcobra/cobra/qa/legacy_syntax_validation.py` y expuestos como `LEGACY_INTERNAL_VALIDATORS` con documentación que indica que no forman parte de la API pública.
- Actualizadas las pruebas en `tests/unit/qa/test_syntax_validation.py` para usar `legacy_syntax_validation.LEGACY_INTERNAL_VALIDATORS` para los validadores históricos y añadir aserciones que verifican que la ruta pública sólo incluye los tres backends oficiales.
- Actualizada la documentación (`README.md` y `docs/tareas_validacion_sintaxis.md`) para declarar explícitamente que la ruta pública `validar-sintaxis` acepta sólo `python`, `javascript` y `rust`, y que los validadores legacy quedan en `pcobra.cobra.qa.legacy_syntax_validation.LEGACY_INTERNAL_VALIDATORS` para uso interno/migración.

### Testing
- Ejecutado `python -m pytest tests/unit/qa/test_syntax_validation.py -q` y todos los tests unitarios pasaron (`22 passed, 1 warning`).
- Ejecutado el smoke de transpiladores `python scripts/smoke_transpilers_syntax.py` y completó correctamente sin fallos en los targets oficiales (`python`, `javascript`, `rust`).
- Ejecutado `python -m ruff check` y `python -m compileall` sobre los módulos modificados y no se detectaron errores de lint/compilación; `black` se ejecutó para formateo automático.
- Ejecutado `python -m pytest tests/unit/qa/test_syntax_validation.py tests/integration/test_cli_validar_sintaxis.py -q` y los tests de integración fallaron (3 fails) debido a que el parser CLI cargado en este entorno de ejecución no registra el comando `validar-sintaxis` (esta es una limitación del entorno de pruebas, no de los cambios en los validadores).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30457a1aec8327b52bf49115338d97)