### PR TITLE
test: cubrir validación de sugerencias GUI y contrato de nuevas palabras clave

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -511,6 +511,8 @@ Recomendaciones autorizadas actualmente:
 
 > Nota editorial: si en el futuro el parser incorpora una construcción nueva, primero debe actualizarse el índice de sintaxis y la regla correspondiente del Libro; solo después puede añadirse una recomendación automática para esa construcción.
 
+> Nota de contrato para nuevas palabras clave: cualquier tarea que añada una palabra clave al `Lexer` debe incluir en el mismo cambio la actualización coherente de `Parser`, nodos de AST si corresponde, transpiladores oficiales (`python`, `javascript` y `rust`), documentación del Libro y pruebas de contrato Lexer/Parser con un caso válido y uno inválido.
+
 ### 3.10 Decorators
 
 **Definición corta:** anotaciones (`@`) para extender funciones/clases sin modificar su cuerpo.

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -12,9 +12,13 @@ from pcobra.gui import runtime
 
 @pytest.fixture(autouse=True)
 def _reset_cache():
-    runtime.require_gui_dependencies.cache_clear()
+    cache_clear = getattr(runtime.require_gui_dependencies, "cache_clear", None)
+    if cache_clear is not None:
+        cache_clear()
     yield
-    runtime.require_gui_dependencies.cache_clear()
+    cache_clear = getattr(runtime.require_gui_dependencies, "cache_clear", None)
+    if cache_clear is not None:
+        cache_clear()
 
 
 def test_normalizar_codigo_admite_none_y_texto() -> None:
@@ -73,6 +77,136 @@ def test_transpilar_codigo_usa_transpilador_python_registrado(
         == "codigo python registrado"
     )
     assert llamadas == {"transpiler_inits": 1, "ast": ["AST"]}
+
+
+def test_generar_reporte_sugerencias_valida_antes_de_sugerir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """La ruta común de sugerencias debe ejecutar Lexer/Parser antes de Agix."""
+
+    llamadas: list[str] = []
+
+    def analizar_primero(codigo: str):
+        llamadas.append(f"analizar:{codigo}")
+        return ["TOKEN"], ["AST"]
+
+    def sugerir_despues(codigo: str):
+        llamadas.append(f"sugerir:{codigo}")
+        return ["Usar nombres descriptivos para variables"]
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {"LexerError": Exception, "ParserError": Exception},
+    )
+    monkeypatch.setattr(runtime, "analizar_codigo", analizar_primero)
+    monkeypatch.setattr(runtime, "generar_sugerencias", sugerir_despues)
+
+    reporte = runtime.generar_reporte_sugerencias("var x = 5")
+
+    assert llamadas == ["analizar:var x = 5", "sugerir:var x = 5"]
+    assert "No se detectaron errores" in reporte
+    assert "- Usar nombres descriptivos para variables" in reporte
+
+
+def test_generar_reporte_sugerencias_devuelve_error_parser_sin_correcciones(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Si Parser falla, no se consulta Agix ni se proponen correcciones aplicables."""
+
+    class FakeLexerError(Exception):
+        pass
+
+    class FakeParserError(Exception):
+        pass
+
+    def analizar_con_error_parser(_codigo: str):
+        raise FakeParserError("Token inesperado en término: EOF")
+
+    def no_debe_llamarse(_codigo: str):
+        raise AssertionError("generar_sugerencias no debe ejecutarse tras ParserError")
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {"LexerError": FakeLexerError, "ParserError": FakeParserError},
+    )
+    monkeypatch.setattr(runtime, "analizar_codigo", analizar_con_error_parser)
+    monkeypatch.setattr(runtime, "generar_sugerencias", no_debe_llamarse)
+
+    reporte = runtime.generar_reporte_sugerencias("var x =")
+
+    assert reporte.startswith("Errores léxicos/sintácticos:")
+    assert "Error de sintaxis" in reporte
+    assert "Sugerencias estilísticas:" in reporte
+    assert "Corrige primero los errores anteriores" in reporte
+    assert "Usar nombres descriptivos" not in reporte
+
+
+def test_generar_reporte_sugerencias_devuelve_error_lexer_sin_correcciones(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Si Lexer falla, el reporte prioriza el error léxico y bloquea sugerencias."""
+
+    class FakeLexerError(Exception):
+        linea = 1
+        columna = 11
+
+    class FakeParserError(Exception):
+        pass
+
+    def analizar_con_error_lexer(_codigo: str):
+        raise FakeLexerError("Token no reconocido: '¿'")
+
+    def no_debe_llamarse(_codigo: str):
+        raise AssertionError("generar_sugerencias no debe ejecutarse tras LexerError")
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {"LexerError": FakeLexerError, "ParserError": FakeParserError},
+    )
+    monkeypatch.setattr(runtime, "analizar_codigo", analizar_con_error_lexer)
+    monkeypatch.setattr(runtime, "generar_sugerencias", no_debe_llamarse)
+
+    reporte = runtime.generar_reporte_sugerencias("var x = 5 ¿")
+
+    assert reporte.startswith("Errores léxicos/sintácticos:")
+    assert "Error léxico" in reporte
+    assert "Sugerencias estilísticas:" in reporte
+    assert "Corrige primero los errores anteriores" in reporte
+    assert "Usar nombres descriptivos" not in reporte
+
+
+def test_generar_reporte_sugerencias_codigo_cobra_valido_con_fixture_minimo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fixture mínimo con tokens y declaración soportados por Lexer/Parser."""
+
+    llamadas: list[str] = []
+
+    def analizar_fixture_minimo(codigo: str):
+        llamadas.append(codigo)
+        return ["VAR", "IDENTIFICADOR", "ASIGNAR", "ENTERO"], ["NodoAsignacion"]
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {"LexerError": Exception, "ParserError": Exception},
+    )
+    monkeypatch.setattr(runtime, "analizar_codigo", analizar_fixture_minimo)
+    monkeypatch.setattr(
+        runtime,
+        "generar_sugerencias",
+        lambda _codigo: ["Usar nombres descriptivos para variables"],
+    )
+
+    reporte = runtime.generar_reporte_sugerencias("var x = 5")
+
+    assert "No se detectaron errores con el Lexer y Parser de Cobra" in reporte
+    assert "- Usar nombres descriptivos para variables" in reporte
+    assert llamadas == ["var x = 5"]
+
 
 def test_formatear_error_lexico_y_sintaxis() -> None:
     class FakeLexerError(Exception):


### PR DESCRIPTION
### Motivation

- Garantizar que la ruta de sugerencias en la GUI valida el código con `Lexer`/`Parser` antes de invocar el razonador/agix y que prioriza errores léxicos/sintácticos sobre propuestas.
- Asegurar que no se propongan correcciones aplicables cuando el `Parser` falla y facilitar fixtures mínimos para probar la ruta de sugerencias sin depender del lexer/parser reales.
- Formalizar en el Libro el contrato requerido cuando se añadan nuevas palabras clave al `Lexer`.

### Description

- Añadidos tests en `tests/unit/test_gui_runtime.py` que verifican que `generar_reporte_sugerencias` ejecuta `analizar_codigo` antes de solicitar sugerencias, que devuelve errores léxicos/sintácticos antes de sugerencias y que no llama a `generar_sugerencias` cuando `Parser` falla. 
- Añadido caso con un fixture mínimo que simula tokens y AST para cubrir la ruta de sugerencias con código Cobra válido (`var x = 5`).
- Haciendo robusto el fixture de limpieza: el `@pytest.fixture` que limpia la caché de `require_gui_dependencies` ahora usa `getattr(..., "cache_clear", None)` para tolerar `monkeypatch` que sustituya `require_gui_dependencies` en las pruebas.
- Documentación actualizada en `docs/LIBRO_PROGRAMACION_COBRA.md` con una nota de contrato que exige que cualquier nueva palabra clave añadida al `Lexer` se implemente junto con las actualizaciones coherentes de `Parser`, nodos AST (si aplica), los transpiladores oficiales (`python`, `javascript`, `rust`), la documentación del Libro y pruebas de contrato (caso válido e inválido).

### Testing

- Ejecutado: `pytest tests/unit/test_gui_runtime.py tests/unit/test_analizador_agix.py -q`.
- Resultado: todos los tests ejecutados pasaron (`35 passed, 1 warning`) en la sesión de pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30f7c854988327abf76d4614fa9835)