### PR TITLE
Unifica reporte de sugerencias GUI y centraliza etiqueta "Sugerencias"

### DIFF
--- a/src/pcobra/gui/app.py
+++ b/src/pcobra/gui/app.py
@@ -66,7 +66,7 @@ def main(page: "ft.Page"):
                 activar,
                 runtime.flet_elevated_button(ft, "Ejecutar", on_click=ejecutar_handler),
                 runtime.flet_elevated_button(
-                    ft, "Sugerencias", on_click=sugerencias_handler
+                    ft, runtime.SUGERENCIAS_BUTTON_TEXT, on_click=sugerencias_handler
                 ),
             ],
         ),

--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -219,7 +219,7 @@ def main(page: "ft.Page"):
             runtime.flet_elevated_button(ft, "Tokens", on_click=tokens_handler),
             runtime.flet_elevated_button(ft, "AST", on_click=ast_handler),
             runtime.flet_elevated_button(
-                ft, "Sugerencias", on_click=sugerencias_handler
+                ft, runtime.SUGERENCIAS_BUTTON_TEXT, on_click=sugerencias_handler
             ),
         ],
         wrap=True,

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -80,6 +80,9 @@ def _local_import_action(module_name: str, symbol_name: str) -> str:
 COBRA_FILE_EXTENSIONS: tuple[str, ...] = (".co", ".cobra")
 """Extensiones Cobra priorizadas para el explorador del IDLE."""
 
+SUGERENCIAS_BUTTON_TEXT = "Sugerencias"
+"""Etiqueta homogénea para la acción de sugerencias en las GUIs."""
+
 
 @dataclass(slots=True)
 class GuiFileState:
@@ -527,38 +530,9 @@ def crear_handler_sugerencias_agix(
     salida: Any,
     page: Any,
 ) -> Any:
-    """Crea el handler para generar sugerencias de código con Agix."""
+    """Wrapper legacy interno para sugerencias; delega en el handler común."""
 
-    def sugerencias_agix_handler(_e: Any) -> None:
-        deps = require_gui_dependencies()
-        codigo = normalizar_codigo(entrada.value)
-        try:
-            # ``generar_sugerencias`` centraliza la validación con Lexer/Parser
-            # y evita depender de modelos internos de ``agix.models.*``.
-            sugerencias = generar_sugerencias(codigo)
-        except ImportError as exc:
-            salida.value = (
-                "La dependencia opcional agix no está instalada o no está disponible. "
-                "Instálala con 'pip install agix' para usar esta función. "
-                f"Detalle: {exc}"
-            )
-        except Exception as exc:
-            salida.value = formatear_error(
-                exc,
-                lexer_error_type=deps.get("LexerError"),
-                parser_error_type=deps.get("ParserError"),
-            )
-        else:
-            if sugerencias:
-                salida.value = "Sugerencias de Agix:\n" + "\n".join(
-                    f"- {sugerencia}" for sugerencia in sugerencias
-                )
-            else:
-                salida.value = "Agix no encontró sugerencias para el código actual."
-        finally:
-            page.update()
-
-    return sugerencias_agix_handler
+    return crear_handler_sugerencias(entrada=entrada, salida=salida, page=page)
 
 
 def analizar_codigo(codigo: str) -> tuple[list[Any], Any]:

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -461,89 +461,30 @@ def test_formatear_error_lexico_y_sintactico_sin_recargar_dependencias(monkeypat
     assert llamadas["count"] == 0
 
 
-def test_crear_handler_sugerencias_agix_exitosas(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_crear_handler_sugerencias_agix_delega_en_handler_comun(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     entrada = SimpleNamespace(value="imprimir('Hola')")
     salida = SimpleNamespace(value="")
     page = SimpleNamespace(update=lambda: setattr(page, "updated", True))
+    llamadas = []
+
+    def _reporte(codigo: str) -> str:
+        llamadas.append(codigo)
+        return "reporte común"
 
     monkeypatch.setattr(
         runtime,
         "require_gui_dependencies",
         lambda: {"LexerError": Exception, "ParserError": Exception},
     )
-    monkeypatch.setattr(
-        runtime,
-        "generar_sugerencias",
-        lambda codigo: [f"Sugerencia para {codigo}"],
-    )
+    monkeypatch.setattr(runtime, "generar_reporte_sugerencias", _reporte)
 
     handler = runtime.crear_handler_sugerencias_agix(
         entrada=entrada, salida=salida, page=page
     )
     handler(None)
 
-    assert salida.value == "Sugerencias de Agix:\n- Sugerencia para imprimir('Hola')"
-    assert page.updated is True
-
-
-def test_crear_handler_sugerencias_agix_dependencia_ausente(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    entrada = SimpleNamespace(value="imprimir('Hola')")
-    salida = SimpleNamespace(value="")
-    page = SimpleNamespace(update=lambda: setattr(page, "updated", True))
-
-    monkeypatch.setattr(
-        runtime,
-        "require_gui_dependencies",
-        lambda: {"LexerError": Exception, "ParserError": Exception},
-    )
-
-    def _generar_sugerencias(_codigo: str) -> list[str]:
-        raise ImportError("La dependencia opcional 'agix' no está instalada")
-
-    monkeypatch.setattr(runtime, "generar_sugerencias", _generar_sugerencias)
-
-    handler = runtime.crear_handler_sugerencias_agix(
-        entrada=entrada, salida=salida, page=page
-    )
-    handler(None)
-
-    assert "dependencia opcional agix no está instalada" in salida.value
-    assert "pip install agix" in salida.value
-    assert "dependencia opcional 'agix'" in salida.value
-    assert page.updated is True
-
-
-def test_crear_handler_sugerencias_agix_error_lexico_sintactico_claro(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class FakeLexerError(Exception):
-        linea = 3
-        columna = 9
-
-    class FakeParserError(Exception):
-        pass
-
-    entrada = SimpleNamespace(value="@")
-    salida = SimpleNamespace(value="")
-    page = SimpleNamespace(update=lambda: setattr(page, "updated", True))
-
-    monkeypatch.setattr(
-        runtime,
-        "require_gui_dependencies",
-        lambda: {"LexerError": FakeLexerError, "ParserError": FakeParserError},
-    )
-
-    def _generar_sugerencias(_codigo: str) -> list[str]:
-        raise FakeLexerError("carácter inválido")
-
-    monkeypatch.setattr(runtime, "generar_sugerencias", _generar_sugerencias)
-
-    handler = runtime.crear_handler_sugerencias_agix(
-        entrada=entrada, salida=salida, page=page
-    )
-    handler(None)
-
-    assert salida.value == "Error léxico (línea 3, columna 9): carácter inválido"
+    assert llamadas == ["imprimir('Hola')"]
+    assert salida.value == "reporte común"
     assert page.updated is True


### PR DESCRIPTION
### Motivation
- Unificar la política de errores y comportamiento de sugerencias para evitar lógica duplicada entre el handler legacy de Agix y el flujo común de sugerencias.
- Mantener una sola fuente de verdad para: error de `Lexer`, error de `Parser`, ausencia opcional de la dependencia `agix` y el caso de no recibir sugerencias.
- Homogeneizar el texto del botón de sugerencias en las GUIs para evitar etiquetas dispersas y facilitar internacionalización.

### Description
- Introduce la constante `SUGERENCIAS_BUTTON_TEXT = "Sugerencias"` en `src/pcobra/gui/runtime.py` y actualiza `src/pcobra/gui/app.py` y `src/pcobra/gui/idle.py` para usarla en los botones de sugerencias.
- Convierte `crear_handler_sugerencias_agix` en un wrapper legacy que delega completamente a `crear_handler_sugerencias` para que toda la lógica de validación y errores pase por `generar_reporte_sugerencias` (manteniendo el punto único de formateo de errores).
- Simplifica las pruebas en `tests/unit/test_gui_runtime.py` reemplazando las expectativas fragmentadas del handler Agix por una prueba que verifica que el wrapper delega en `generar_reporte_sugerencias` y evitando comprobaciones incompatibles entre formatos antiguos y nuevos.
- Limpieza menor en código y mensajes para consolidar la ruta común de sugerencias sin eliminar la compatibilidad del wrapper legacy.

### Testing
- Ejecuté `python -m pytest tests/unit/test_gui_runtime.py` y todos los tests del archivo pasaron (`23 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a310a3262048327bd69c53e5b81324a)