### PR TITLE
Lazy-load GUI directory tree

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -366,31 +366,50 @@ def crear_salida_seleccionable(ft: Any, **kwargs: Any) -> Any:
 def crear_arbol_directorios(
     ft: Any, *, on_click: Any, root_path: Path | None = None
 ) -> Any:
-    """Crea un componente de árbol de directorios para la GUI."""
+    """Crea un árbol de directorios con carga diferida de subcarpetas."""
     if root_path is None:
         root_path = Path(".").resolve()
 
-    def _crear_nodo_directorio(path: Path) -> Any:
-        if path.is_dir():
-            children = []
-            for entry in listar_directorio_cobra(path):
-                children.append(_crear_nodo_directorio(entry))
-            return ft.ExpansionTile(
-                title=ft.Text(path.name),
-                leading=ft.Icon(ft.icons.FOLDER),
-                controls=children,
-            )
-        else:
-            return ft.ListTile(
-                title=ft.Text(path.name),
-                leading=ft.Icon(ft.icons.INSERT_DRIVE_FILE),
-                data=str(path),
-                on_click=on_click,
-            )
+    def _crear_nodo_archivo(path: Path) -> Any:
+        return ft.ListTile(
+            title=ft.Text(path.name),
+            leading=ft.Icon(ft.icons.INSERT_DRIVE_FILE),
+            data=str(path),
+            on_click=on_click,
+        )
 
-    elementos_arbol = []
-    for entrada in listar_directorio_cobra(root_path):
-        elementos_arbol.append(_crear_nodo_directorio(entrada))
+    def _crear_nodo_directorio(path: Path) -> Any:
+        tile = ft.ExpansionTile(
+            title=ft.Text(path.name),
+            leading=ft.Icon(ft.icons.FOLDER),
+            controls=[],
+        )
+        tile.data = {"path": path, "children_loaded": False}
+
+        def _cargar_hijos_al_expandir(_e: Any) -> None:
+            data = getattr(tile, "data", {})
+            if data.get("children_loaded"):
+                return
+            tile.controls = [
+                _crear_nodo(entrada) for entrada in listar_directorio_cobra(path)
+            ]
+            data["children_loaded"] = True
+            tile.data = data
+            update = getattr(tile, "update", None)
+            if callable(update):
+                update()
+
+        tile.on_change = _cargar_hijos_al_expandir
+        return tile
+
+    def _crear_nodo(path: Path) -> Any:
+        if path.is_dir():
+            return _crear_nodo_directorio(path)
+        return _crear_nodo_archivo(path)
+
+    elementos_arbol = [
+        _crear_nodo(entrada) for entrada in listar_directorio_cobra(root_path)
+    ]
 
     return ft.Column(elementos_arbol, scroll=ft.ScrollMode.ALWAYS)
 

--- a/tests/unit/test_gui_app.py
+++ b/tests/unit/test_gui_app.py
@@ -110,8 +110,12 @@ def test_main_renderiza_componentes_minimos(monkeypatch):
     )
     monkeypatch.setattr(app.runtime, "normalizar_codigo", lambda value: value or "")
     monkeypatch.setattr(app.runtime, "ejecutar_codigo", lambda _codigo: "ok")
-    monkeypatch.setattr(app.runtime, "transpilar_codigo", lambda _codigo, _lang: "transpilado")
-    monkeypatch.setattr(app.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}")
+    monkeypatch.setattr(
+        app.runtime, "transpilar_codigo", lambda _codigo, _lang: "transpilado"
+    )
+    monkeypatch.setattr(
+        app.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}"
+    )
 
     page = ft.Page()
     app.main(page)
@@ -146,7 +150,9 @@ def test_main_handler_actualiza_salida(monkeypatch):
     monkeypatch.setattr(app.runtime, "normalizar_codigo", lambda value: value or "")
     monkeypatch.setattr(app.runtime, "ejecutar_codigo", ejecutar_mock)
     monkeypatch.setattr(app.runtime, "transpilar_codigo", transpilar_mock)
-    monkeypatch.setattr(app.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}")
+    monkeypatch.setattr(
+        app.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}"
+    )
 
     page = ft.Page()
     app.main(page)
@@ -156,7 +162,9 @@ def test_main_handler_actualiza_salida(monkeypatch):
     activar = next(c for c in page.controls if isinstance(c, ft.Switch))
     salida = next(c for c in page.controls if isinstance(c, ft.Text))
     ejecutar_btn = next(
-        c for c in page.controls if isinstance(c, ft.ElevatedButton) and c.text == "Ejecutar"
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Ejecutar"
     )
 
     entrada.value = "imprimir('x')"
@@ -176,7 +184,9 @@ def test_main_handler_actualiza_salida(monkeypatch):
     assert page.update.call_count == 3
 
 
-def test_main_configura_selector_por_defecto_y_switch_deshabilitado_si_no_hay_targets(monkeypatch):
+def test_main_configura_selector_por_defecto_y_switch_deshabilitado_si_no_hay_targets(
+    monkeypatch,
+):
     ft = _fake_flet()
     monkeypatch.setattr(app.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
@@ -194,8 +204,12 @@ def test_main_configura_selector_por_defecto_y_switch_deshabilitado_si_no_hay_ta
     )
     monkeypatch.setattr(app.runtime, "normalizar_codigo", lambda value: value or "")
     monkeypatch.setattr(app.runtime, "ejecutar_codigo", lambda _codigo: "ejecutado")
-    monkeypatch.setattr(app.runtime, "transpilar_codigo", lambda _codigo, _lang: "transpilado")
-    monkeypatch.setattr(app.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}")
+    monkeypatch.setattr(
+        app.runtime, "transpilar_codigo", lambda _codigo, _lang: "transpilado"
+    )
+    monkeypatch.setattr(
+        app.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}"
+    )
 
     page = ft.Page()
     app.main(page)
@@ -205,3 +219,53 @@ def test_main_configura_selector_por_defecto_y_switch_deshabilitado_si_no_hay_ta
 
     assert selector.value is None
     assert activar.disabled is True
+
+
+def _text_value(control):
+    return getattr(getattr(control, "title", None), "value", None)
+
+
+def test_crear_arbol_directorios_lista_solo_nivel_inicial(tmp_path):
+    from pcobra.gui import runtime
+
+    ft = _fake_flet()
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "subdir" / "anidado.cobra").write_text("imprimir('anidado')")
+    (tmp_path / "programa.co").write_text("imprimir('co')")
+    (tmp_path / "programa.cobra").write_text("imprimir('cobra')")
+    (tmp_path / "ignorado.txt").write_text("no cobra")
+
+    arbol = runtime.crear_arbol_directorios(
+        ft, on_click=lambda _e: None, root_path=tmp_path
+    )
+
+    nombres = [_text_value(control) for control in arbol.controls]
+    assert nombres == ["subdir", "programa.co", "programa.cobra"]
+    subdir = arbol.controls[0]
+    assert isinstance(subdir, ft.ExpansionTile)
+    assert subdir.controls == []
+
+
+def test_crear_arbol_directorios_carga_hijos_bajo_demanda_y_filtra(tmp_path):
+    from pcobra.gui import runtime
+
+    ft = _fake_flet()
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "subdir" / "hijo").mkdir()
+    (tmp_path / "subdir" / "codigo.co").write_text("imprimir('co')")
+    (tmp_path / "subdir" / "codigo.cobra").write_text("imprimir('cobra')")
+    (tmp_path / "subdir" / "notas.txt").write_text("no cobra")
+    (tmp_path / "raiz.cobra").write_text("imprimir('raiz')")
+
+    arbol = runtime.crear_arbol_directorios(
+        ft, on_click=lambda _e: None, root_path=tmp_path
+    )
+    subdir = arbol.controls[0]
+
+    subdir.on_change(SimpleNamespace(control=subdir))
+
+    nombres = [_text_value(control) for control in subdir.controls]
+    assert nombres == ["hijo", "codigo.co", "codigo.cobra"]
+    hijo = subdir.controls[0]
+    assert isinstance(hijo, ft.ExpansionTile)
+    assert hijo.controls == []


### PR DESCRIPTION
### Motivation
- Evitar la construcción recursiva del árbol de directorios al iniciar la GUI para mejorar rendimiento y evitar I/O innecesario en el arranque.
- Reutilizar el mismo enfoque no recursivo que usa `reconstruir_arbol` en el IDLE y mantener la experiencia actual de `ExpansionTile`.

### Description
- Cambiado `crear_arbol_directorios` en `src/pcobra/gui/runtime.py` para listar únicamente el nivel raíz inicial y no construir recursivamente todos los descendientes.
- Cada carpeta se representa con `ft.ExpansionTile` iniciando `controls=[]` y con un `data` que marca si sus hijos ya fueron cargados.
- Se añadió un manejador `on_change` que, al expandir la carpeta, llama a `listar_directorio_cobra()` para cargar bajo demanda solo los hijos directos (subdirectorios y archivos con extensiones `.co`/`.cobra`).
- Añadidas pruebas en `tests/unit/test_gui_app.py` que crean una estructura temporal y verifican que el árbol inicial contiene solo el primer nivel y que la expansión carga y filtra correctamente los hijos.

### Testing
- Se ejecutó el formateador con `python -m black src/pcobra/gui/runtime.py tests/unit/test_gui_app.py` y completó correctamente.
- Se ejecutaron las pruebas focalizadas con `pytest -q tests/unit/test_gui_app.py` y las nuevas pruebas pasaron exitosamente.
- Se compiló con `python -m compileall -q src/pcobra/gui/runtime.py tests/unit/test_gui_app.py` y no se reportaron errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a310d7ba9d4832793d41a59cb945cfb)