### PR TITLE
Unify GUI entrypoint around IDLE

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -809,25 +809,36 @@ Para más detalles sobre cada comando, puedes usar ``cobra <comando> --help``.
 
 ### 10.1 IDLE gráfico con gestión de archivos
 
-Cobra incluye un entorno de desarrollo integrado (IDLE) gráfico basado en Flet, que permite escribir, ejecutar y transpilar código de forma interactiva. Este IDLE ha sido mejorado con las siguientes funcionalidades:
+Cobra incluye un entorno de desarrollo integrado (IDLE) gráfico basado en Flet, que permite escribir, ejecutar, inspeccionar y transpilar código de forma interactiva. La entrada pública recomendada es ``cobra gui``, que carga la implementación canónica ``pcobra.gui.idle.main``. El módulo ``pcobra.gui.app`` se mantiene como alias de compatibilidad y delega en el mismo IDLE para evitar layouts, botones o handlers duplicados.
 
-*   **Editor de código:** Un área principal para escribir y editar tu código Cobra.
+Funciones disponibles en la GUI:
+
+*   **Editor de código:** Un área principal para escribir y editar código Cobra.
+*   **Salida seleccionable:** Un panel de resultados para copiar mensajes, salida de ejecución, tokens, AST, código transpilado o sugerencias.
 *   **Gestión de archivos:**
-    *   **Guardar:** Guarda el archivo actual en su ubicación.
-    *   **Guardar como:** Permite guardar el contenido del editor en una nueva ubicación o con un nuevo nombre.
-    *   **Árbol de directorios:** Una vista lateral que muestra la estructura de archivos y carpetas de tu proyecto. Puedes hacer clic en los archivos `.co` o `.cobra` para cargarlos directamente en el editor.
+    *   **Nuevo:** Limpia el editor y crea un archivo en memoria sin ruta activa.
+    *   **Abrir:** Carga la ruta indicada en el campo `Ruta`.
+    *   **Guardar:** Guarda el archivo activo en su ubicación actual.
+    *   **Guardar como:** Guarda el contenido del editor en la ruta indicada.
+    *   **Recargar:** Vuelve a leer desde disco el archivo activo.
+    *   **Árbol de directorios:** Muestra carpetas y archivos `.co`/`.cobra`; al seleccionar un archivo Cobra, lo carga directamente en el editor.
 *   **Ejecución y transpilación:**
-    *   **Selector de target:** Elige el lenguaje de destino (Python, JavaScript, Rust) para la transpilación.
-    *   **Switch de transpilación:** Alterna entre ejecutar el código directamente o transpilarlo al lenguaje seleccionado.
-    *   **Botón "Ejecutar":** Ejecuta el código Cobra o lo transpila, mostrando la salida o el código generado en el área de resultados.
-*   **Sugerencias de código (Agix):**
-    *   **Botón "Sugerencias (Agix)":** Utiliza la librería opcional `agix` para analizar tu código y ofrecer sugerencias de mejora o corrección tipográfica, basándose en las mejores prácticas del "Libro de Programación principal". Las sugerencias se muestran en el área de salida.
+    *   **Selector de target:** Elige el lenguaje de destino disponible para transpilación.
+    *   **Switch de transpilación:** Alterna entre ejecutar el código directamente o transpilarlo al target seleccionado.
+    *   **Ejecutar:** Ejecuta el código Cobra o muestra el código generado por el transpilador.
+*   **Inspección del lenguaje:**
+    *   **Tokens:** Tokeniza el contenido actual del editor y muestra un token por línea.
+    *   **AST:** Parsea el contenido actual del editor y muestra la representación del árbol sintáctico.
+*   **Sugerencias de código:**
+    *   **Sugerencias:** Valida primero errores léxicos/sintácticos y, si el código es válido, solicita sugerencias estilísticas mediante la integración opcional de Agix.
 
-Para iniciar el IDLE, usa el comando ``cobra gui``.
+Para iniciar el IDLE recomendado, usa:
 
 .. code-block:: bash
 
    cobra gui
+
+También se puede invocar desde Python usando ``pcobra.gui.idle.main`` como destino Flet. Las integraciones antiguas que importan ``pcobra.gui.app.main`` siguen funcionando porque esa entrada delega en ``pcobra.gui.idle.main``.
 
 Flujo mínimo sugerido:
 

--- a/src/pcobra/gui/app.py
+++ b/src/pcobra/gui/app.py
@@ -1,84 +1,15 @@
-"""Aplicación gráfica básica usando Flet para ejecutar código Cobra."""
+"""Compatibilidad para la entrada GUI pública de Cobra.
 
-from typing import TYPE_CHECKING
+La implementación canónica de la interfaz gráfica vive en
+``pcobra.gui.idle.main``. Este módulo conserva ``pcobra.gui.app.main`` como
+alias público para integraciones históricas, evitando duplicar layout, botones
+y handlers.
+"""
 
 from pcobra.gui import runtime
+from pcobra.gui.idle import main
 
-if TYPE_CHECKING:
-    import flet as ft
-
-
-def main(page: "ft.Page"):
-    """Interfaz mínima de Flet basada en componentes compartidos."""
-    ft = runtime.require_flet()
-
-    lenguajes = list(runtime.gui_target_choices())
-    estado_archivo = runtime.GuiFileState()
-
-    entrada = runtime.crear_editor_codigo(ft)
-    salida = runtime.crear_salida_seleccionable(ft)
-    selector = runtime.crear_selector_target(ft, lenguajes=lenguajes)
-    activar = runtime.crear_switch_transpilacion(ft, lenguajes=lenguajes)
-
-    guardar_handler = runtime.crear_handler_guardar(
-        entrada=entrada,
-        estado_archivo=estado_archivo,
-        page=page,
-    )
-    guardar_como_handler = runtime.crear_handler_guardar_como(
-        entrada=entrada,
-        estado_archivo=estado_archivo,
-        page=page,
-    )
-    ejecutar_handler = runtime.crear_handler_ejecucion(
-        entrada=entrada,
-        salida=salida,
-        selector=selector,
-        activar=activar,
-        page=page,
-    )
-    sugerencias_handler = runtime.crear_handler_sugerencias(
-        entrada=entrada,
-        salida=salida,
-        page=page,
-    )
-
-    def cargar_archivo_handler(e):
-        if e.control.data:
-            entrada.value, _mensaje = runtime.cargar_archivo_desde_arbol(
-                e.control.data, estado_archivo
-            )
-            page.update()
-
-    arbol_directorios = runtime.crear_arbol_directorios(
-        ft, on_click=cargar_archivo_handler
-    )
-
-    page.add(
-        runtime.flet_row(
-            ft,
-            [
-                runtime.flet_elevated_button(ft, "Guardar", on_click=guardar_handler),
-                runtime.flet_elevated_button(
-                    ft, "Guardar como", on_click=guardar_como_handler
-                ),
-                selector,
-                activar,
-                runtime.flet_elevated_button(ft, "Ejecutar", on_click=ejecutar_handler),
-                runtime.flet_elevated_button(
-                    ft, runtime.SUGERENCIAS_BUTTON_TEXT, on_click=sugerencias_handler
-                ),
-            ],
-        ),
-        runtime.flet_row(
-            ft,
-            [
-                runtime.flet_column(ft, [arbol_directorios], expand=1),
-                runtime.flet_column(ft, [entrada, salida], expand=4),
-            ],
-            expand=True,
-        ),
-    )
+__all__ = ["main", "runtime"]
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_gui_app.py
+++ b/tests/unit/test_gui_app.py
@@ -11,10 +11,12 @@ from pcobra.gui import app
 def _fake_flet():
     class TextField:
         def __init__(self, **_kwargs):
-            self.value = ""
+            self.kwargs = _kwargs
+            self.value = _kwargs.get("value", "")
 
     class Text:
         def __init__(self, value="", **_kwargs):
+            self.kwargs = _kwargs
             self.value = value
 
     class Dropdown:
@@ -32,11 +34,18 @@ def _fake_flet():
             self.text = text
             self.on_click = on_click
 
+    class TextButton(ElevatedButton):
+        pass
+
     class Layout:
         def __init__(self, controls=None, *args, **_kwargs):
             if controls is None and args:
                 controls = args[0]
             self.controls = controls or []
+
+    class Container:
+        def __init__(self, content=None, **_kwargs):
+            self.content = content
 
     class ExpansionTile:
         def __init__(self, title=None, leading=None, controls=None):
@@ -80,8 +89,11 @@ def _fake_flet():
         Dropdown=Dropdown,
         Switch=Switch,
         ElevatedButton=ElevatedButton,
+        TextButton=TextButton,
         Row=Layout,
         Column=Layout,
+        Container=Container,
+        ListView=Layout,
         ExpansionTile=ExpansionTile,
         ListTile=ListTile,
         Icon=Icon,
@@ -120,11 +132,32 @@ def test_main_renderiza_componentes_minimos(monkeypatch):
     page = ft.Page()
     app.main(page)
 
-    botones = [c for c in page.controls if isinstance(c, ft.ElevatedButton)]
+    botones = [
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton)
+        and c.text
+        in {
+            "Nuevo",
+            "Abrir",
+            "Guardar",
+            "Guardar como",
+            "Recargar",
+            "Ejecutar",
+            "Tokens",
+            "AST",
+            "Sugerencias",
+        }
+    ]
     assert [b.text for b in botones] == [
+        "Nuevo",
+        "Abrir",
         "Guardar",
         "Guardar como",
+        "Recargar",
         "Ejecutar",
+        "Tokens",
+        "AST",
         "Sugerencias",
     ]
 
@@ -157,10 +190,18 @@ def test_main_handler_actualiza_salida(monkeypatch):
     page = ft.Page()
     app.main(page)
 
-    entrada = next(c for c in page.controls if isinstance(c, ft.TextField))
+    entrada = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("multiline")
+    )
     selector = next(c for c in page.controls if isinstance(c, ft.Dropdown))
     activar = next(c for c in page.controls if isinstance(c, ft.Switch))
-    salida = next(c for c in page.controls if isinstance(c, ft.Text))
+    salida = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.Text) and c.kwargs.get("selectable")
+    )
     ejecutar_btn = next(
         c
         for c in page.controls

--- a/tests/unit/test_gui_menu.py
+++ b/tests/unit/test_gui_menu.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 class FakeTextField:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
-        self.value = ""
+        self.value = kwargs.get("value", "")
 
 
 class FakeText:
@@ -34,13 +34,40 @@ class FakeElevatedButton:
         self.on_click = on_click
 
 
+class FakeTextButton(FakeElevatedButton):
+    pass
+
+
+class FakeLayout:
+    def __init__(self, controls=None, *args, **kwargs):
+        if controls is None and args:
+            controls = args[0]
+        self.controls = controls or []
+        self.kwargs = kwargs
+
+
+class FakeContainer:
+    def __init__(self, content=None, **kwargs):
+        self.content = content
+        self.kwargs = kwargs
+
+
 class FakePage:
     def __init__(self):
         self.controls = []
         self.updated = 0
 
     def add(self, *args):
-        self.controls.extend(args)
+        def _flatten(control):
+            self.controls.append(control)
+            for child in getattr(control, "controls", []) or []:
+                _flatten(child)
+            content = getattr(control, "content", None)
+            if content is not None:
+                _flatten(content)
+
+        for arg in args:
+            _flatten(arg)
 
     def update(self):
         self.updated += 1
@@ -53,6 +80,11 @@ def _fake_flet(*, root_option=None, dropdown_option=None, app=None):
         "Dropdown": FakeDropdown,
         "Switch": FakeSwitch,
         "ElevatedButton": FakeElevatedButton,
+        "TextButton": FakeTextButton,
+        "Row": FakeLayout,
+        "Column": FakeLayout,
+        "Container": FakeContainer,
+        "ListView": FakeLayout,
         "Page": FakePage,
         "dropdown": SimpleNamespace(Option=dropdown_option or (lambda value: f"dropdown:{value}")),
         "app": app or (lambda **kwargs: kwargs),
@@ -77,7 +109,11 @@ def _prepare_module(monkeypatch, module_name):
 
 
 def _run_handler(ft, page, text):
-    entrada = next(c for c in page.controls if isinstance(c, ft.TextField))
+    entrada = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("multiline")
+    )
     selector = next(c for c in page.controls if isinstance(c, ft.Dropdown))
     switch = next(c for c in page.controls if isinstance(c, ft.Switch))
     boton = next(
@@ -101,7 +137,14 @@ def test_app_transpiler_invocado(monkeypatch):
     _run_handler(ft, page, "print(1)")
 
     transpilar.assert_called_once_with("print(1)", "py")
-    assert next(c for c in page.controls if isinstance(c, ft.Text)).value == "codigo python"
+    assert (
+        next(
+            c
+            for c in page.controls
+            if isinstance(c, ft.Text) and c.kwargs.get("selectable")
+        ).value
+        == "codigo python"
+    )
     assert page.updated == 1
 
 
@@ -115,7 +158,14 @@ def test_idle_transpiler_invocado(monkeypatch):
     _run_handler(ft, page, "print(1)")
 
     transpilar.assert_called_once_with("print(1)", "py")
-    assert next(c for c in page.controls if isinstance(c, ft.Text)).value == "codigo python"
+    assert (
+        next(
+            c
+            for c in page.controls
+            if isinstance(c, ft.Text) and c.kwargs.get("selectable")
+        ).value
+        == "codigo python"
+    )
     assert page.updated == 1
 
 


### PR DESCRIPTION
### Motivation

- Evitar duplicación de layout, botones y handlers entre entradas GUI; centralizar la implementación canónica en `pcobra.gui.idle.main`.
- Mantener compatibilidad con integraciones existentes que importan `pcobra.gui.app` sin duplicar lógica.

### Description

- Reemplacé la implementación de `src/pcobra/gui/app.py` por un alias que importa y exporta `main` desde `pcobra.gui.idle` y mantiene `runtime` expuesto para compatibilidad, de modo que `pcobra.gui.app.main` delega en `pcobra.gui.idle.main` y no vuelve a construir la UI. (`src/pcobra/gui/app.py`).
- No fue necesario mover helpers: `src/pcobra/gui/runtime.py` ya contiene los helpers compartidos para editor, salida, selector de target, guardar, árbol, tokens, AST y sugerencias y se sigue reutilizando desde `idle` y `app`.
- Actualicé la documentación en `docs/LIBRO_PROGRAMACION_COBRA.md` para recomendar la entrada pública `cobra gui` / `pcobra.gui.idle.main` y enumerar las funciones disponibles en la GUI.
- Ajusté tests/simulacros para la capa Flet y actualicé los tests de smoke para que `pcobra.gui.app` y `pcobra.gui.idle` validen la misma superficie del IDLE (modificaciones en `tests/unit/test_gui_app.py` y `tests/unit/test_gui_menu.py`).

### Testing

- Se ejecutaron los tests unitarios relevantes con `pytest tests/unit/test_gui_app.py tests/unit/test_gui_idle.py tests/unit/test_gui_menu.py -q` y todos pasaron (tests de GUI en verde, con una advertencia deprecación sin impacto funcional).
- Se verificó la compilación estática de los módulos modificados con `python -m compileall -q src/pcobra/gui tests/unit/test_gui_app.py tests/unit/test_gui_idle.py tests/unit/test_gui_menu.py` y no arrojó errores.
- Se revisaron los cambios en documentación y tests para asegurar que las interfaces públicas recomendadas y los dobles de prueba reflejan la nueva delegación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a311961c5c88327a4f1a3d858ed3597)