### PR TITLE
feat(ia): fachada estable para sugerencias automáticas (usa `agix`)

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -830,7 +830,7 @@ Funciones disponibles en la GUI:
     *   **Tokens:** Tokeniza el contenido actual del editor y muestra un token por línea.
     *   **AST:** Parsea el contenido actual del editor y muestra la representación del árbol sintáctico.
 *   **Sugerencias de código:**
-    *   **Sugerencias:** Valida primero errores léxicos/sintácticos y, si el código es válido, solicita sugerencias estilísticas mediante la integración opcional de Agix.
+    *   **Sugerencias:** Valida primero errores léxicos/sintácticos y, si el código es válido, solicita sugerencias estilísticas mediante la integración opcional de Agix. Antes de mostrarlas en la GUI, las sugerencias automáticas se construyen desde las reglas de `src/pcobra/ia/reglas_libro_programacion.py` y cada fragmento propuesto se valida con `Lexer(codigo).tokenizar()` y `Parser(tokens).parsear()`; si el Lexer o el Parser rechazan el código, no se presentan sugerencias.
 
 Para iniciar el IDLE recomendado, usa:
 

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
-from pcobra.ia.analizador_agix import generar_sugerencias
+from pcobra.ia.analizador_sugerencias import generar_sugerencias
 
 
 @lru_cache(maxsize=1)
@@ -590,7 +590,7 @@ def generar_reporte_sugerencias(codigo: str) -> str:
             "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
             "Sugerencias estilísticas:\n"
             f"- No se pudieron generar sugerencias: {exc}. "
-            "Instala la dependencia opcional 'agix' para activar esta acción."
+            "Instala la dependencia opcional real 'agix' para activar esta acción; 'agi-core' no está declarado en este proyecto."
         )
 
     if sugerencias:

--- a/src/pcobra/ia/analizador_sugerencias.py
+++ b/src/pcobra/ia/analizador_sugerencias.py
@@ -1,0 +1,41 @@
+"""Fachada estable para sugerencias automáticas de código Cobra.
+
+La dependencia AGI real declarada por el proyecto es ``agix``. No hay un
+paquete ``agi-core``/``agi_core`` declarado ni local en este repositorio, así
+que esta fachada delega en ``analizador_agix`` y mantiene un único punto de
+entrada público para GUI y otros consumidores.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from pcobra.ia.analizador_agix import generar_sugerencias as _generar_con_agix
+
+MOTOR_SUGERENCIAS = "agix"
+
+
+def generar_sugerencias(
+    codigo: str,
+    peso_precision: float | None = None,
+    peso_interpretabilidad: float | None = None,
+    placer: float | None = None,
+    activacion: float | None = None,
+    dominancia: float | None = None,
+) -> List[str]:
+    """Genera sugerencias usando el motor disponible y validado.
+
+    La implementación seleccionada conserva el contrato de validación de
+    ``analizador_agix``: primero se valida el código con ``Lexer``/``Parser`` y
+    después solo se exponen candidatos procedentes de
+    ``reglas_libro_programacion`` cuyos fragmentos también parsean.
+    """
+
+    return _generar_con_agix(
+        codigo,
+        peso_precision=peso_precision,
+        peso_interpretabilidad=peso_interpretabilidad,
+        placer=placer,
+        activacion=activacion,
+        dominancia=dominancia,
+    )

--- a/tests/unit/test_analizador_sugerencias.py
+++ b/tests/unit/test_analizador_sugerencias.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch
+
+from pcobra.ia import analizador_sugerencias
+
+
+def test_fachada_delega_en_agix_con_contrato_estable():
+    with patch.object(
+        analizador_sugerencias,
+        "_generar_con_agix",
+        return_value=["Usar nombres descriptivos"],
+    ) as generar:
+        resultado = analizador_sugerencias.generar_sugerencias(
+            "var x = 5",
+            peso_precision=0.8,
+            peso_interpretabilidad=0.9,
+            placer=0.1,
+            activacion=0.2,
+            dominancia=-0.3,
+        )
+
+    assert resultado == ["Usar nombres descriptivos"]
+    generar.assert_called_once_with(
+        "var x = 5",
+        peso_precision=0.8,
+        peso_interpretabilidad=0.9,
+        placer=0.1,
+        activacion=0.2,
+        dominancia=-0.3,
+    )
+    assert analizador_sugerencias.MOTOR_SUGERENCIAS == "agix"


### PR DESCRIPTION
### Motivation
- Detectar y reconciliar la dependencia real de IA: el proyecto declara y usa `agix` y no existe `agi-core`/`agi_core`/`agicore` en el repositorio ni en dependencias. 
- Proveer un punto de entrada estable para la GUI y para integraciones futuras sin eliminar la validación previa con `Lexer`/`Parser`. 
- Documentar claramente el contrato de generación de sugerencias para evitar ambigüedad sobre la dependencia requerida.

### Description
- Añadido el módulo fachada `src/pcobra/ia/analizador_sugerencias.py` que mantiene la función pública `generar_sugerencias(codigo, ...)` y delega en `analizador_agix` conservando el flujo de validación. 
- La fachada exporta `MOTOR_SUGERENCIAS = "agix"` para dejar explícito el motor real seleccionado. 
- Actualizado `src/pcobra/gui/runtime.py` para importar la nueva fachada en lugar de `analizador_agix` y se ajustó el mensaje de error para nombrar la dependencia real (`agix`) y aclarar que `agi-core` no está declarada. 
- Documentado en `docs/LIBRO_PROGRAMACION_COBRA.md` que las sugerencias automáticas se construyen desde `src/pcobra/ia/reglas_libro_programacion.py` y que cada fragmento propuesto pasa por `Lexer(codigo).tokenizar()` y `Parser(tokens).parsear()` antes de presentarse en la GUI, y añadida una prueba unitaria en `tests/unit/test_analizador_sugerencias.py` que verifica la delegación.

### Testing
- Se ejecutó `pytest -q tests/unit/test_analizador_agix.py tests/unit/test_analizador_sugerencias.py tests/unit/test_gui_runtime.py` y las pruebas relacionadas con el analizador, la fachada y la integración GUI pasaron correctamente. 
- El test aislado de CLI `pytest -q tests/unit/test_cli_agix.py::test_cli_agix_pad_values` falló debido a un `NameError` preexistente en el registro de comandos (`filter_legacy_commands_for_profile` no definido), lo que ocurre antes de alcanzar la ruta de sugerencias; este fallo es independiente de los cambios de esta PR. 
- Los cambios de código añadidos fueron validados por las pruebas unitarias mencionadas y la nueva prueba `tests/unit/test_analizador_sugerencias.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3122a476908327b33a5b72cc0eb150)