### PR TITLE
docs: alinear ADR '3 backends' con `targets_policy` y añadir nota de migración

### DIFF
--- a/docs/architecture/adr-unified-3-backends.md
+++ b/docs/architecture/adr-unified-3-backends.md
@@ -3,7 +3,7 @@
 ## Contrato unificado (aplica a toda esta ADR)
 
 - Cobra es el **único lenguaje/interfaz pública**.
-- Solo existen **3 backends internos oficiales**: `python`, `javascript`, `rust`.
+- El **BackEnd oficial** de Cobra está compuesto exclusivamente por 3 targets: `python`, `javascript`, `rust`.
 - La decisión de backend es **interna** (no configurable por usuario final), salvo hints internos controlados.
 
 - **Estado:** Aprobado
@@ -14,12 +14,16 @@
 ## Decisión
 
 1. **Cobra es la única interfaz pública** para usuarios e integraciones externas.
-2. Los **backends oficiales públicos** son exclusivamente: `python`, `javascript`, `rust`.
-3. Los transpiladores legacy (`go`, `cpp`, `java`, `wasm`, `asm`) se retiran de la ruta de BackEnd: no son configurables, no aparecen en comandos públicos y cualquier referencia restante debe vivir solo en documentación histórica/no-backend.
+2. El **BackEnd oficial** coincide con `docs/targets_policy.md` y está compuesto exclusivamente por: `python`, `javascript`, `rust`.
+3. Los transpiladores legacy (`go`, `cpp`, `java`, `wasm`, `asm`) se retiran del BackEnd oficial: no son configurables, no aparecen en comandos públicos y se conservan solo como histórico si aplica.
 
 ## Zona histórica (no BackEnd)
 
-Las referencias heredadas a `go`, `cpp`, `java`, `wasm` y `asm` se tratan como inventario histórico o material de migración cerrado. No deben importarse desde `src/pcobra/cobra/transpilers/transpiler/legacy/` ni anunciarse como BackEnd.
+Las referencias heredadas a `go`, `cpp`, `java`, `wasm` y `asm` se tratan como inventario histórico o material de migración cerrado. No deben importarse desde `src/pcobra/cobra/transpilers/transpiler/legacy/` ni anunciarse como BackEnd oficial.
+
+## Nota de migración para referencias antiguas
+
+Si un usuario encuentra referencias antiguas a Go, C++, Java, WASM o ASM, debe interpretarlas como documentación histórica o como material de migración, no como targets disponibles del BackEnd oficial. La migración debe hacerse hacia uno de los tres targets oficiales (`python`, `javascript`, `rust`) o hacia la interfaz pública Cobra cuando el target concreto no sea relevante para el usuario final.
 
 ## Criterio de salida
 


### PR DESCRIPTION
### Motivation

- Alinear la terminología de la ADR con la política normativa de backends para evitar ambigüedades sobre qué es el BackEnd oficial. 
- Dejar explícito que los transpilers legacy se retiran del BackEnd oficial y que las referencias antiguas son históricas/migración. 
- Proveer una nota de migración para usuarios que encuentren referencias antiguas a Go, C++, Java, WASM o ASM. 

### Description

- Actualicé `docs/architecture/adr-unified-3-backends.md` para usar la terminología `BackEnd oficial` y referenciar `docs/targets_policy.md` como la fuente normativa. 
- Reemplacé la frase sobre “3 backends internos oficiales” por una declaración explícita de que los targets oficiales son `python`, `javascript` y `rust`. 
- Cambié la decisión sobre legacy para declarar que `go`, `cpp`, `java`, `wasm` y `asm` se retiran del BackEnd oficial y se conservan solo como histórico si aplica, y añadí la aclaración de que no deben anunciarse como BackEnd oficial. 
- Añadí una nueva sección `Nota de migración para referencias antiguas` con instrucciones de migración hacia los targets oficiales o la interfaz pública Cobra, y verifiqué que `docs/LIBRO_PROGRAMACION_COBRA.md` no requiere cambios porque ya está alineado. 

### Testing

- Ejecuté un script Python (`python - <<'PY' ... PY`) que comprobó la presencia de los targets ``python``, ``javascript`` y ``rust`` en la ADR y en el Libro y verificó la presencia de la nota de migración, y la verificación pasó. 
- Busqué menciones relevantes con `rg` para confirmar que la terminología en `docs/LIBRO_PROGRAMACION_COBRA.md`, `docs/architecture/adr-unified-3-backends.md` y `docs/targets_policy.md` está alineada, y la búsqueda confirmó la coherencia. 
- Ejecuté `git diff --check` para validar el diff y no se detectaron errores de formato/whitespace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a315288512c8327ba52a359f9e1317b)