### PR TITLE
test: refuerza validación previa a sugerencias

### DIFF
--- a/tests/unit/test_analizador_agix.py
+++ b/tests/unit/test_analizador_agix.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pcobra.ia import analizador_agix
+from pcobra.ia.reglas_libro_programacion import construir_candidatos_desde_reglas
 
 
 def test_generar_sugerencias_variable_descriptiva():
@@ -88,6 +89,57 @@ def test_error_lexico_o_sintactico_impide_sugerencias_aplicables():
             )
     razonador_cls.assert_not_called()
     razonador.select_best_model.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "codigo_invalido",
+    [
+        "var x = 5 ¿",
+        "var x =",
+    ],
+)
+def test_generar_sugerencias_rechaza_codigo_invalido_antes_de_agix(codigo_invalido):
+    """Lexer/Parser deben bloquear Agix tanto para errores léxicos como sintácticos."""
+
+    razonador = MagicMock()
+    with patch.object(
+        analizador_agix, "Reasoner", return_value=razonador
+    ) as razonador_cls:
+        with pytest.raises(Exception):
+            analizador_agix.generar_sugerencias(codigo_invalido)
+
+    razonador_cls.assert_not_called()
+    razonador.select_best_model.assert_not_called()
+
+
+def test_generar_sugerencias_codigo_valido_expone_regla_nombres_descriptivos():
+    """Un programa Cobra válido puede activar LP-3.1 tras pasar Lexer/Parser."""
+
+    instancia = MagicMock()
+    instancia.select_best_model.side_effect = lambda evaluaciones: next(
+        ev
+        for ev in evaluaciones
+        if ev["rule_id"] == "LP-3.1-NOMBRES-DESCRIPTIVOS"
+    )
+
+    with patch.object(analizador_agix, "Reasoner", return_value=instancia):
+        sugerencias = analizador_agix.generar_sugerencias("var x = 5")
+
+    assert sugerencias == [
+        "Usar nombres descriptivos para variables "
+        "[regla: LP-3.1-NOMBRES-DESCRIPTIVOS; §3.1 Léxico]"
+    ]
+    evaluaciones = instancia.select_best_model.call_args.args[0]
+    assert any(
+        ev["rule_id"] == "LP-3.1-NOMBRES-DESCRIPTIVOS" for ev in evaluaciones
+    )
+
+
+def test_reglas_libro_programacion_validan_entrada_antes_de_candidatos():
+    """Las reglas internas no producen candidatos si falla el Parser."""
+
+    with pytest.raises(Exception):
+        construir_candidatos_desde_reglas("var x =")
 
 
 def test_sugerencias_no_inventan_construcciones_fuera_del_parser():

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -208,6 +208,56 @@ def test_generar_reporte_sugerencias_codigo_cobra_valido_con_fixture_minimo(
     assert llamadas == ["var x = 5"]
 
 
+def test_generar_reporte_sugerencias_codigo_valido_usa_lexer_parser_reales(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Con código Cobra válido, la GUI solo sugiere después del Lexer/Parser real."""
+
+    llamadas: list[str] = []
+
+    def sugerir_tras_validacion(codigo: str) -> list[str]:
+        llamadas.append(codigo)
+        return [
+            "Usar nombres descriptivos para variables "
+            "[regla: LP-3.1-NOMBRES-DESCRIPTIVOS; §3.1 Léxico]"
+        ]
+
+    monkeypatch.setattr(runtime, "generar_sugerencias", sugerir_tras_validacion)
+
+    reporte = runtime.generar_reporte_sugerencias("var x = 5")
+
+    assert llamadas == ["var x = 5"]
+    assert "No se detectaron errores con el Lexer y Parser de Cobra" in reporte
+    assert "LP-3.1-NOMBRES-DESCRIPTIVOS" in reporte
+    assert "- Usar nombres descriptivos para variables" in reporte
+
+
+@pytest.mark.parametrize(
+    "codigo_invalido, tipo_error",
+    [
+        ("var x = 5 ¿", "Error léxico"),
+        ("var x =", "Error de sintaxis"),
+    ],
+)
+def test_generar_reporte_sugerencias_codigo_invalido_real_bloquea_estilo(
+    monkeypatch: pytest.MonkeyPatch, codigo_invalido: str, tipo_error: str
+) -> None:
+    """La GUI muestra el error real y no genera sugerencias estilísticas aplicables."""
+
+    def no_debe_sugerir(_codigo: str) -> list[str]:
+        raise AssertionError("No se deben sugerir estilos con código inválido")
+
+    monkeypatch.setattr(runtime, "generar_sugerencias", no_debe_sugerir)
+
+    reporte = runtime.generar_reporte_sugerencias(codigo_invalido)
+
+    assert reporte.startswith("Errores léxicos/sintácticos:")
+    assert tipo_error in reporte
+    assert "Corrige primero los errores anteriores" in reporte
+    assert "LP-3.1-NOMBRES-DESCRIPTIVOS" not in reporte
+    assert "Usar nombres descriptivos para variables" not in reporte
+
+
 def test_formatear_error_lexico_y_sintaxis() -> None:
     class FakeLexerError(Exception):
         linea = 2


### PR DESCRIPTION
### Motivation

- Asegurar que la generación de sugerencias estilísticas solo se invoca cuando el código pasa por el `Lexer` y `Parser` de Cobra.  
- Evitar que el motor de IA (agix/Reasoner) se instancie o reciba entradas cuando existen errores léxicos o sintácticos.  
- Cubrir al menos una regla trazable de `REGLAS_LIBRO_PROGRAMACION`, en concreto `LP-3.1-NOMBRES-DESCRIPTIVOS`.

### Description

- Añadidos tests en `tests/unit/test_analizador_agix.py` que verifican que `generar_sugerencias()` rechaza código inválido léxico y sintáctico antes de llamar a `Reasoner` y que un fragmento válido activa la regla `LP-3.1-NOMBRES-DESCRIPTIVOS` en las evaluaciones.  
- Añadido test que asegura que `construir_candidatos_desde_reglas()` propaga la excepción del `Parser` y no construye candidatos si la entrada no parsea.  
- Añadidos tests en `tests/unit/test_gui_runtime.py` que ejercitan `generar_reporte_sugerencias()` con el flujo real de `Lexer`/`Parser`: uno confirma comportamiento exitoso con sugerencias trazables y otro parametrizado confirma que errores léxicos/sintácticos se muestran en la GUI y bloquean sugerencias estilísticas.  
- No se modificó la implementación de `Lexer`, `Parser`, reglas productivas o la sintaxis del lenguaje, ni se introdujeron palabras clave nuevas; solo se añadieron pruebas.

### Testing

- Ejecutado `pytest -q tests/unit/test_analizador_agix.py tests/unit/test_gui_runtime.py` y los tests relevantes pasaron con resultado `40 passed, 1 warning` (duración total ~3s).  
- Las nuevas pruebas verifican tanto rutas de éxito (sugerencias tras validación) como rutas de fallo (errores léxicos/sintácticos que impiden sugerencias) y todas las aserciones automatizadas resultaron exitosas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a316e297c9c83278ac98f2593e52015)