### PR TITLE
Refuerza ruta de sugerencias GUI y contrato para nuevas palabras clave del Lexer

### DIFF
--- a/docs/tareas_implementacion_libro_cobra.md
+++ b/docs/tareas_implementacion_libro_cobra.md
@@ -17,6 +17,20 @@ Implementar de forma incremental, verificable y mantenible la adopción del nuev
 
 ---
 
+## Contrato obligatorio para nuevas palabras clave del Lexer
+
+Cuando una tarea añada una nueva palabra clave al Lexer de Cobra, esa misma tarea debe cerrar el cambio de lenguaje de extremo a extremo. No se acepta incorporar solo el token léxico.
+
+Checklist obligatorio de la misma tarea:
+
+- [ ] Actualizar el Parser para aceptar o rechazar explícitamente la nueva palabra clave en su contexto sintáctico.
+- [ ] Actualizar el AST si corresponde representar un nodo nuevo o ampliar uno existente.
+- [ ] Actualizar los transpiladores oficiales (`python`, `javascript`, `rust`) o documentar una incompatibilidad explícita si la característica no aplica.
+- [ ] Actualizar la documentación del Libro con la sintaxis, ejemplos válidos y contraejemplos inválidos.
+- [ ] Añadir o actualizar pruebas de contrato Lexer/Parser que cubran tokenización, parseo y errores esperados.
+
+---
+
 ## A) Tickets de creación/actualización del libro
 
 ### Ticket F0-T1 · Inventario documental base

--- a/tests/test_lexer_parser_contract.py
+++ b/tests/test_lexer_parser_contract.py
@@ -139,3 +139,109 @@ def test_humo_lexer_parser_acepta_ejemplos_del_libro_programacion() -> None:
         tokens = Lexer(codigo).tokenizar()
         ast_resultado = ClassicParser(tokens).parsear()
         assert ast_resultado
+
+
+def test_nueva_palabra_clave_del_lexer_exige_actualizaciones_de_contrato() -> None:
+    """Toda palabra clave nueva debe aterrizar en Parser y en el checklist público."""
+
+    tokens_declaracion_con_handler = set(ClassicParser([])._factories)
+    tokens_contextuales_soportados = {
+        TipoToken.CAPTURAR,
+        TipoToken.CASE,
+        TipoToken.COMO,
+        TipoToken.EN,
+        TipoToken.FIN,
+        TipoToken.FINALMENTE,
+        TipoToken.METODO,
+        TipoToken.ATRIBUTO,
+        TipoToken.RETORNO,
+        TipoToken.SINO,
+        TipoToken.SINO_SI,
+    }
+    tokens_expresion_soportados = {TipoToken.LAMBDA}
+    tokens_reservados_sin_declaracion_propia = (
+        tokens_declaracion_con_handler
+        | tokens_contextuales_soportados
+        | tokens_expresion_soportados
+    )
+
+    palabras_reservadas = {
+        token.tipo
+        for palabra in [
+            "var",
+            "variable",
+            "func",
+            "definir",
+            "metodo",
+            "atributo",
+            "si",
+            "sino",
+            "elseif",
+            "garantia",
+            "guard",
+            "mientras",
+            "para",
+            "import",
+            "usar",
+            "exportar",
+            "option",
+            "macro",
+            "hilo",
+            "asincronico",
+            "switch",
+            "segun",
+            "case",
+            "caso",
+            "clase",
+            "estructura",
+            "registro",
+            "enumeracion",
+            "interface",
+            "rasgo",
+            "en",
+            "holobit",
+            "proyectar",
+            "transformar",
+            "graficar",
+            "try",
+            "intentar",
+            "defer",
+            "aplazar",
+            "catch",
+            "capturar",
+            "throw",
+            "lanzar",
+            "imprimir",
+            "yield",
+            "esperar",
+            "romper",
+            "continuar",
+            "pasar",
+            "afirmar",
+            "eliminar",
+            "global",
+            "nolocal",
+            "lambda",
+            "con",
+            "finalmente",
+            "desde",
+            "como",
+            "fin",
+            "retorno",
+        ]
+        for token in [Lexer(palabra).tokenizar()[0]]
+    }
+
+    faltantes = palabras_reservadas - tokens_reservados_sin_declaracion_propia
+    assert {token.name for token in faltantes} == set()
+    checklist = (ROOT / "docs/tareas_implementacion_libro_cobra.md").read_text(
+        encoding="utf-8"
+    )
+    for requisito in [
+        "Parser",
+        "AST",
+        "transpiladores oficiales",
+        "documentación del Libro",
+        "pruebas de contrato Lexer/Parser",
+    ]:
+        assert requisito in checklist

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -242,7 +242,6 @@ def test_generar_reporte_sugerencias_codigo_valido_usa_lexer_parser_reales(
     assert "LP-3.1-NOMBRES-DESCRIPTIVOS" in reporte
     assert "- Usar nombres descriptivos para variables" in reporte
 
-
 @pytest.mark.parametrize(
     "codigo_invalido, tipo_error",
     [
@@ -304,7 +303,6 @@ def test_generar_reporte_sugerencias_no_ejecuta_ia_hasta_lexer_y_parser_reales(
     assert "No se detectaron errores con el Lexer y Parser de Cobra" in reporte
     assert "LP-3.1-NOMBRES-DESCRIPTIVOS" in reporte
 
-
 @pytest.mark.parametrize(
     ("codigo_invalido", "tipo_error"),
     [
@@ -336,6 +334,61 @@ def test_generar_reporte_sugerencias_gui_rechaza_invalidos_reales_sin_estilo_apl
     assert "LP-3.1-NOMBRES-DESCRIPTIVOS" not in reporte
     assert "Usar nombres descriptivos para variables" not in reporte
 
+
+@pytest.mark.parametrize(
+    ("codigo", "esperado"),
+    [
+        ("var x = 5", "Sugerencias estilísticas:"),
+        ("var x =", "Error de sintaxis"),
+        ("var x = 5 ¿", "Error léxico"),
+    ],
+)
+def test_ruta_sugerencias_cubre_fixtures_minimos_reales_de_cobra(
+    monkeypatch: pytest.MonkeyPatch, codigo: str, esperado: str
+) -> None:
+    """Fixtures mínimos reales: declaración válida y errores Lexer/Parser."""
+
+    monkeypatch.setattr(runtime, "require_gui_dependencies", _deps_lexer_parser_reales)
+    llamadas_sugerencias: list[str] = []
+
+    def sugerir_solo_si_parsea(codigo_validado: str) -> list[str]:
+        llamadas_sugerencias.append(codigo_validado)
+        return ["Usar nombres descriptivos para variables"]
+
+    monkeypatch.setattr(runtime, "generar_sugerencias", sugerir_solo_si_parsea)
+
+    reporte = runtime.generar_reporte_sugerencias(codigo)
+
+    assert esperado in reporte
+    if codigo == "var x = 5":
+        assert llamadas_sugerencias == [codigo]
+        assert "No se detectaron errores con el Lexer y Parser de Cobra" in reporte
+        assert "- Usar nombres descriptivos para variables" in reporte
+    else:
+        assert llamadas_sugerencias == []
+        assert "Corrige primero los errores anteriores" in reporte
+        assert "- Usar nombres descriptivos para variables" not in reporte
+
+
+def test_ruta_sugerencias_parser_fallido_no_expone_correccion_aplicable_real(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Un ParserError real corta la ruta antes de Agix y de reglas aplicables."""
+
+    monkeypatch.setattr(runtime, "require_gui_dependencies", _deps_lexer_parser_reales)
+
+    def no_sugerir(_codigo: str) -> list[str]:
+        raise AssertionError("No debe proponer correcciones si Parser falla")
+
+    monkeypatch.setattr(runtime, "generar_sugerencias", no_sugerir)
+
+    reporte = runtime.generar_reporte_sugerencias("var x =")
+
+    assert reporte.startswith("Errores léxicos/sintácticos:")
+    assert "Error de sintaxis" in reporte
+    assert "Corrige primero los errores anteriores" in reporte
+    assert "Sugerencias estilísticas:" in reporte
+    assert "Usar nombres descriptivos" not in reporte
 
 def test_formatear_error_lexico_y_sintaxis() -> None:
     class FakeLexerError(Exception):


### PR DESCRIPTION
### Motivation
- Asegurar que la ruta de generación de sugerencias valida primero con el Lexer/Parser, que prioriza errores léxicos/sintácticos y evita proponer correcciones aplicables cuando el Parser falla.
- Proteger el contrato del lenguaje ante la posible incorporación de nuevas palabras clave del Lexer obligando a cambios complementarios en Parser/AST/transpiladores/documentación y pruebas.

### Description
- Añade tests en `tests/unit/test_gui_runtime.py` que usan fixtures mínimos reales (`var x = 5`, `var x =`, `var x = 5 ¿`) para validar que `generar_reporte_sugerencias` ejecuta `analizar_codigo` antes de `generar_sugerencias` y no llama a IA cuando hay errores léxicos/sintácticos.
- Añade un test en `tests/test_lexer_parser_contract.py` que comprueba que las palabras reservadas tokenizadas están cubiertas por handlers del `Parser` o por categorías explícitas y que el checklist documental exige Parser/AST/transpiladores/Libro/pruebas.
- Actualiza `docs/tareas_implementacion_libro_cobra.md` con la sección "Contrato obligatorio para nuevas palabras clave del Lexer" que lista el checklist requerido (Parser, AST, transpiladores oficiales, documentación y pruebas).

### Testing
- Ejecuté `python -m pytest tests/unit/test_gui_runtime.py tests/unit/test_analizador_agix.py` y la suite de GUI + analizador AGIX pasó (47 passed, 1 warning).
- Ejecuté `python -m pytest tests/test_lexer_parser_contract.py` y las pruebas de contrato Lexer/Parser pasaron (5 passed, 1 warning).
- Intenté ejecutar todas las suites juntas en un único proceso (`pytest` sobre los tres archivos) y el entorno agotó memoria (`MemoryError`); al ejecutar los bloques separados las mismas pruebas pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3374dda4348327884f847951b89bd1)