### PR TITLE
Aclarar “Sugerencias del Libro” en GUI, documentación y tests

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -830,7 +830,7 @@ Funciones disponibles en la GUI:
     *   **Tokens:** Tokeniza el contenido actual del editor y muestra un token por línea.
     *   **AST:** Parsea el contenido actual del editor y muestra la representación del árbol sintáctico.
 *   **Sugerencias de código:**
-    *   **Sugerencias:** Valida primero errores léxicos/sintácticos y, si el código es válido, solicita sugerencias estilísticas mediante la integración opcional de Agix. Antes de mostrarlas en la GUI, las sugerencias automáticas se construyen desde las reglas de `src/pcobra/ia/reglas_libro_programacion.py` y cada fragmento propuesto se valida con `Lexer(codigo).tokenizar()` y `Parser(tokens).parsear()`; si el Lexer o el Parser rechazan el código, no se presentan sugerencias.
+    *   **Sugerencias del Libro:** Herramienta de corrección tipográfica/estilística que valida primero el contenido del editor con `Lexer(codigo).tokenizar()` y `Parser(tokens).parsear()`. Si el código no supera esa validación léxica/sintáctica, informa el error y no inventa correcciones. Si el código es válido, solicita sugerencias mediante la integración opcional de Agix, pero los candidatos se construyen desde las reglas trazables del Libro definidas en `src/pcobra/ia/reglas_libro_programacion.py`; por eso cada detalle conserva metadatos como `rule_id` y `rule_section`, y cada fragmento propuesto vuelve a validarse con Lexer/Parser antes de mostrarse en la GUI.
 
 Para iniciar el IDLE recomendado, usa:
 

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -80,8 +80,8 @@ def _local_import_action(module_name: str, symbol_name: str) -> str:
 COBRA_FILE_EXTENSIONS: tuple[str, ...] = (".co", ".cobra")
 """Extensiones Cobra priorizadas para el explorador del IDLE."""
 
-SUGERENCIAS_BUTTON_TEXT = "Sugerencias"
-"""Etiqueta homogénea para la acción de sugerencias en las GUIs."""
+SUGERENCIAS_BUTTON_TEXT = "Sugerencias del Libro"
+"""Etiqueta homogénea para la acción de sugerencias trazables en las GUIs."""
 
 
 @dataclass(slots=True)
@@ -578,7 +578,7 @@ def generar_reporte_sugerencias(codigo: str) -> str:
         return (
             "Errores léxicos/sintácticos:\n"
             f"- {error}\n\n"
-            "Sugerencias estilísticas:\n"
+            "Sugerencias del Libro:\n"
             "- Corrige primero los errores anteriores para solicitar sugerencias."
         )
 
@@ -588,7 +588,7 @@ def generar_reporte_sugerencias(codigo: str) -> str:
         return (
             "Errores léxicos/sintácticos:\n"
             "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
-            "Sugerencias estilísticas:\n"
+            "Sugerencias del Libro:\n"
             f"- No se pudieron generar sugerencias: {exc}. "
             "Instala la dependencia opcional real 'agix' para activar esta acción; 'agi-core' no está declarado en este proyecto."
         )
@@ -602,7 +602,7 @@ def generar_reporte_sugerencias(codigo: str) -> str:
     return (
         "Errores léxicos/sintácticos:\n"
         "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
-        "Sugerencias estilísticas:\n"
+        "Sugerencias del Libro:\n"
         f"{sugerencias_legibles}"
     )
 

--- a/tests/unit/test_gui_app.py
+++ b/tests/unit/test_gui_app.py
@@ -146,7 +146,7 @@ def test_main_renderiza_componentes_minimos(monkeypatch):
             "Ejecutar",
             "Tokens",
             "AST",
-            "Sugerencias",
+            "Sugerencias del Libro",
         }
     ]
     assert [b.text for b in botones] == [
@@ -158,7 +158,7 @@ def test_main_renderiza_componentes_minimos(monkeypatch):
         "Ejecutar",
         "Tokens",
         "AST",
-        "Sugerencias",
+        "Sugerencias del Libro",
     ]
 
 

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -114,12 +114,12 @@ def test_main_renderiza_botones_esperados(monkeypatch):
     assert [
         b.text
         for b in botones
-        if b.text in {"Ejecutar", "Tokens", "AST", "Sugerencias"}
+        if b.text in {"Ejecutar", "Tokens", "AST", "Sugerencias del Libro"}
     ] == [
         "Ejecutar",
         "Tokens",
         "AST",
-        "Sugerencias",
+        "Sugerencias del Libro",
     ]
 
 
@@ -174,12 +174,12 @@ def test_main_handlers_smoke(monkeypatch):
         c.text: c
         for c in page.controls
         if isinstance(c, ft.ElevatedButton)
-        and c.text in {"Ejecutar", "Tokens", "AST", "Sugerencias"}
+        and c.text in {"Ejecutar", "Tokens", "AST", "Sugerencias del Libro"}
     }
     ejecutar_btn = botones["Ejecutar"]
     tokens_btn = botones["Tokens"]
     ast_btn = botones["AST"]
-    sugerencias_btn = botones["Sugerencias"]
+    sugerencias_btn = botones["Sugerencias del Libro"]
 
     entrada.value = "imprimir('x')"
     ejecutar_btn.on_click(None)

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -148,7 +148,7 @@ def test_generar_reporte_sugerencias_devuelve_error_parser_sin_correcciones(
 
     assert reporte.startswith("Errores léxicos/sintácticos:")
     assert "Error de sintaxis" in reporte
-    assert "Sugerencias estilísticas:" in reporte
+    assert "Sugerencias del Libro:" in reporte
     assert "Corrige primero los errores anteriores" in reporte
     assert "Usar nombres descriptivos" not in reporte
 
@@ -183,7 +183,7 @@ def test_generar_reporte_sugerencias_devuelve_error_lexer_sin_correcciones(
 
     assert reporte.startswith("Errores léxicos/sintácticos:")
     assert "Error léxico" in reporte
-    assert "Sugerencias estilísticas:" in reporte
+    assert "Sugerencias del Libro:" in reporte
     assert "Corrige primero los errores anteriores" in reporte
     assert "Usar nombres descriptivos" not in reporte
 
@@ -338,7 +338,7 @@ def test_generar_reporte_sugerencias_gui_rechaza_invalidos_reales_sin_estilo_apl
 @pytest.mark.parametrize(
     ("codigo", "esperado"),
     [
-        ("var x = 5", "Sugerencias estilísticas:"),
+        ("var x = 5", "Sugerencias del Libro:"),
         ("var x =", "Error de sintaxis"),
         ("var x = 5 ¿", "Error léxico"),
     ],
@@ -387,7 +387,7 @@ def test_ruta_sugerencias_parser_fallido_no_expone_correccion_aplicable_real(
     assert reporte.startswith("Errores léxicos/sintácticos:")
     assert "Error de sintaxis" in reporte
     assert "Corrige primero los errores anteriores" in reporte
-    assert "Sugerencias estilísticas:" in reporte
+    assert "Sugerencias del Libro:" in reporte
     assert "Usar nombres descriptivos" not in reporte
 
 def test_formatear_error_lexico_y_sintaxis() -> None:


### PR DESCRIPTION
### Motivation
- Dejar explícito en la GUI y la documentación que la acción de sugerencias proviene de reglas trazables del Libro de Programación y no son correcciones sintácticas inventadas por la IA. 
- Preservar la trazabilidad de cada candidato (metadatos como `rule_id` y `rule_section`) y dejar claro el contrato de validación con `Lexer`/`Parser` antes de exponer sugerencias.

### Description
- Renombré la etiqueta compartida `SUGERENCIAS_BUTTON_TEXT` a `"Sugerencias del Libro"` en `src/pcobra/gui/runtime.py` y actualicé su docstring. 
- Cambié las cabeceras del reporte en `generar_reporte_sugerencias` para usar la frase `Sugerencias del Libro:` en lugar de la antigua `Sugerencias estilísticas:`. 
- Actualicé la sección GUI en `docs/LIBRO_PROGRAMACION_COBRA.md` para describir que la corrección tipográfica/estilística valida con `Lexer(codigo).tokenizar()` y `Parser(tokens).parsear()`, y que los candidatos se construyen desde `src/pcobra/ia/reglas_libro_programacion.py` manteniendo `rule_id` y `rule_section` y revalidando fragmentos. 
- Ajusté las aserciones en las pruebas unitarias de GUI (`tests/unit/test_gui_runtime.py`, `tests/unit/test_gui_app.py`, `tests/unit/test_gui_idle.py`) para reflejar la nueva etiqueta/cabecera. 
- No se modificaron las reglas en `src/pcobra/ia/reglas_libro_programacion.py`; sus metadatos (`rule_id`, `rule_section`) y la lógica de validación con `Lexer`/`Parser` se mantienen sin cambios.

### Testing
- Ejecuté `pytest tests/unit/test_gui_runtime.py tests/unit/test_gui_app.py tests/unit/test_gui_idle.py -q`. 
- Resultado: las pruebas ejecutadas pasaron correctamente (`42 passed`) y apareció una advertencia deprecatoria existente; no hubo fallos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3391a551608327b658b0678422144a)