### PR TITLE
Documentar `agix` como motor oficial de sugerencias

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -501,6 +501,8 @@ Las herramientas de GUI, asistentes de IA o acciones de corrección automática 
 3. **Trazabilidad al Libro:** cada recomendación debe mapearse a una regla concreta de este Libro, citando la sección aplicable (por ejemplo, `§3.3 Sentencias`, `§3.4 Funciones` o `§3.6 Módulos`).
 4. **Regresión obligatoria:** por cada recomendación nueva se añade un caso válido y uno inválido en `tests/gui/` o `tests/integration/`; además, el fragmento sugerido debe tener una prueba que confirme que `Parser` lo acepta.
 
+Motor real de sugerencias: Cobra mantiene `agix` como dependencia oficial para esta integración. La fachada pública estable es `pcobra.ia.analizador_sugerencias`, que delega en `pcobra.ia.analizador_agix` y conserva el contrato de validación previa y posterior con `Lexer(codigo).tokenizar()` y `Parser(tokens).parsear()` antes de exponer sugerencias aplicables.
+
 Recomendaciones autorizadas actualmente:
 
 | Recomendación | Regla del Libro | Fragmento sugerido que debe aceptar `Parser` | Forma inválida cubierta por regresión |
@@ -830,7 +832,7 @@ Funciones disponibles en la GUI:
     *   **Tokens:** Tokeniza el contenido actual del editor y muestra un token por línea.
     *   **AST:** Parsea el contenido actual del editor y muestra la representación del árbol sintáctico.
 *   **Sugerencias de código:**
-    *   **Sugerencias del Libro:** Herramienta de corrección tipográfica/estilística que valida primero el contenido del editor con `Lexer(codigo).tokenizar()` y `Parser(tokens).parsear()`. Si el código no supera esa validación léxica/sintáctica, informa el error y no inventa correcciones. Si el código es válido, solicita sugerencias mediante la integración opcional de Agix, pero los candidatos se construyen desde las reglas trazables del Libro definidas en `src/pcobra/ia/reglas_libro_programacion.py`; por eso cada detalle conserva metadatos como `rule_id` y `rule_section`, y cada fragmento propuesto vuelve a validarse con Lexer/Parser antes de mostrarse en la GUI.
+    *   **Sugerencias del Libro:** Herramienta de corrección tipográfica/estilística que valida primero el contenido del editor con `Lexer(codigo).tokenizar()` y `Parser(tokens).parsear()`. Si el código no supera esa validación léxica/sintáctica, informa el error y no inventa correcciones. Si el código es válido, solicita sugerencias mediante la integración opcional de `agix`, pero los candidatos se construyen desde las reglas trazables del Libro definidas en `src/pcobra/ia/reglas_libro_programacion.py`; por eso cada detalle conserva metadatos como `rule_id` y `rule_section`, y cada fragmento propuesto vuelve a validarse con Lexer/Parser antes de mostrarse en la GUI.
 
 Para iniciar el IDLE recomendado, usa:
 

--- a/docs/proposals/actualizacion_librerias_python_tareas.md
+++ b/docs/proposals/actualizacion_librerias_python_tareas.md
@@ -39,7 +39,7 @@ Antes de implementar cualquier ticket, leer y respetar estos puntos:
 - `src/pcobra/standard_library/datos.py`: integración de datos, Excel y
   formatos columnares.
 - `src/pcobra/gui/`: integración GUI basada en Flet.
-- `src/pcobra/ia/analizador_agix.py`: integración con AGIX.
+- `src/pcobra/ia/analizador_agix.py`: integración con agix.
 - `src/pcobra/core/interpreter.py`: uso de `RestrictedPython`.
 - `src/pcobra/core/pybind_bridge.py`: uso de `pybind11`.
 - `src/pcobra/cobra/transpilers/reverse/`: integración con `tree-sitter` en
@@ -270,7 +270,7 @@ Antes de implementar cualquier ticket, leer y respetar estos puntos:
 - Si hay cambios visuales perceptibles en una app runnable, capturar evidencia
   visual cuando el entorno lo permita.
 
-### Ticket C3 — Validar integraciones AGIX, Holobit y Smooth Criminal
+### Ticket C3 — Validar integraciones agix, Holobit y Smooth Criminal
 
 | Campo | Detalle |
 |---|---|
@@ -284,15 +284,13 @@ Antes de implementar cualquier ticket, leer y respetar estos puntos:
 **Trabajo esperado**
 
 - Mantener `agix` como paquete requerido para la integración de producto: el
-  proyecto declara `agix>=1.9.0,<2`, el módulo
-  `src/pcobra/ia/analizador_agix.py` importa la API pública de `agix` y no hay
-  una decisión técnica aprobada para migrar a `agi-core`.
-- No sustituir referencias nuevas de tareas o issues por `agi-core`; si aparece
-  esa mención, corregirla a `agix` salvo que antes se documente una propuesta
-  formal en `docs/proposals/` con el nombre exacto del paquete, la API pública
-  usada, su relación con `analizador_agix.py` y el plan de compatibilidad o
-  reemplazo.
-- Revisar rutas públicas de AGIX actuales frente a imports existentes.
+  proyecto declara `agix>=1.9.0,<2` y el módulo
+  `src/pcobra/ia/analizador_agix.py` importa la API pública de `agix`.
+- Normalizar referencias nuevas de tareas o issues al motor oficial `agix` y
+  exigir una propuesta formal en `docs/proposals/` antes de cambiar el nombre
+  exacto del paquete, la API pública usada, su relación con
+  `analizador_agix.py` y el plan de compatibilidad o reemplazo.
+- Revisar rutas públicas de agix actuales frente a imports existentes.
 - Validar llamadas y tipos usados por `analizador_agix.py`.
 - Revisar API actual de `smooth-criminal` usada por `performance.py`.
 - Confirmar mensajes de error si la dependencia no está instalada.

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -590,7 +590,7 @@ def generar_reporte_sugerencias(codigo: str) -> str:
             "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
             "Sugerencias del Libro:\n"
             f"- No se pudieron generar sugerencias: {exc}. "
-            "Instala la dependencia opcional real 'agix' para activar esta acción; 'agi-core' no está declarado en este proyecto."
+            "Instala la dependencia opcional real 'agix' para activar esta acción."
         )
 
     if sugerencias:

--- a/src/pcobra/ia/analizador_sugerencias.py
+++ b/src/pcobra/ia/analizador_sugerencias.py
@@ -1,9 +1,8 @@
 """Fachada estable para sugerencias automáticas de código Cobra.
 
-La dependencia AGI real declarada por el proyecto es ``agix``. No hay un
-paquete ``agi-core``/``agi_core`` declarado ni local en este repositorio, así
-que esta fachada delega en ``analizador_agix`` y mantiene un único punto de
-entrada público para GUI y otros consumidores.
+La dependencia AGI real declarada por el proyecto es ``agix``. Esta fachada
+delega en ``analizador_agix`` y mantiene un único punto de entrada público
+para GUI y otros consumidores.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
### Motivation

- Alinear la documentación y mensajes de usuario con la dependencia real usada por el proyecto para sugerencias automáticas, evitando referencias a una distribución no declarada como `agi-core`.
- Mantener una fachada estable pública `pcobra.ia.analizador_sugerencias` que delega en la implementación concreta y conserva el contrato de validación previa/posterior con `Lexer`/`Parser`.

### Description

- Actualiza `docs/LIBRO_PROGRAMACION_COBRA.md` (sección 3.9 y 10.1) para dejar claro que el motor real de sugerencias es `agix` y que se valida antes y después con `Lexer(codigo).tokenizar()` y `Parser(tokens).parsear()`.
- Cambia `docs/proposals/actualizacion_librerias_python_tareas.md` para normalizar referencias a `agix` y exigir una propuesta formal antes de cualquier migración de distribución/API.
- Limpia el mensaje en `src/pcobra/gui/runtime.py` para que solo recomiende instalar la dependencia opcional `agix` sin mencionar alternativas no declaradas.
- Ajusta la docstring de la fachada en `src/pcobra/ia/analizador_sugerencias.py` para reflejar que delega en `analizador_agix` y mantiene el punto de entrada público estable.
- No se cambiaron dependencias en `pyproject.toml`, `requirements*.txt` ni se añadió un nuevo adaptador: se decidió mantener `agix` como la dependencia oficial y conservar la fachada y el contrato existente.

### Testing

- Ejecutados: `pytest tests/unit/test_analizador_sugerencias.py tests/unit/test_analizador_agix.py tests/unit/test_gui_runtime.py -q`, todos los tests pasaron (48 passed).
- Verificación textual: búsqueda con `rg -n "agi-core|agi_core|Agix|AGIX" ...` para confirmar normalización de referencias a `agix`, sin hallazgos problemáticos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33a49186248327a2f3a445ea417d04)