### PR TITLE
Unify GUI directory tree implementation

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -823,7 +823,7 @@ Funciones disponibles en la GUI:
     *   **Guardar:** Guarda el archivo activo en su ubicación actual.
     *   **Guardar como:** Guarda el contenido del editor en la ruta indicada.
     *   **Recargar:** Vuelve a leer desde disco el archivo activo.
-    *   **Árbol de directorios:** Muestra carpetas y archivos `.co`/`.cobra`; al seleccionar un archivo Cobra, lo carga directamente en el editor.
+    *   **Árbol de directorios:** Usa la API canónica `pcobra.gui.runtime.crear_arbol_directorios`. El panel parte del directorio de trabajo actual, muestra primero las carpetas y después los archivos Cobra (`.co`/`.cobra`) en orden estable, y carga las subcarpetas bajo demanda al expandirlas. Solo los archivos Cobra visibles disparan la carga en el editor; el IDLE conecta el evento `on_click` con `cargar_archivo_desde_arbol`, que valida la extensión antes de leer el contenido y actualiza el estado del archivo activo.
 *   **Ejecución y transpilación:**
     *   **Selector de target:** Elige el lenguaje de destino disponible para transpilación.
     *   **Switch de transpilación:** Alterna entre ejecutar el código directamente o transpilarlo al target seleccionado.

--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -42,12 +42,17 @@ def main(page: "ft.Page"):
     def mostrar_error_archivo(exc: Exception) -> None:
         salida.value = runtime.formatear_error(exc)
 
-    def cargar_archivo(ruta: Path) -> None:
+    def cargar_archivo(ruta: Path, *, desde_arbol: bool = False) -> None:
         nonlocal directorio_actual
         try:
-            entrada.value, salida.value = runtime.abrir_archivo_desde_ruta(
-                ruta, estado
-            )
+            if desde_arbol:
+                entrada.value, salida.value = runtime.cargar_archivo_desde_arbol(
+                    ruta, estado
+                )
+            else:
+                entrada.value, salida.value = runtime.abrir_archivo_desde_ruta(
+                    ruta, estado
+                )
         except (
             FileNotFoundError,
             NotADirectoryError,
@@ -81,46 +86,30 @@ def main(page: "ft.Page"):
         actualizar_pagina()
         return True
 
+    def cargar_archivo_desde_evento_arbol(e) -> None:
+        control = getattr(e, "control", None)
+        ruta = getattr(control, "data", None)
+        if ruta is None:
+            salida.value = "No se pudo determinar la ruta seleccionada en el árbol."
+            page.update()
+            return
+        cargar_archivo(Path(ruta), desde_arbol=True)
+
     def reconstruir_arbol() -> None:
         arbol.controls.clear()
         arbol.controls.append(
-            runtime.flet_text(ft, value=f"Directorio: {directorio_actual}")
+            runtime.flet_text(ft, value=f"Directorio raíz: {directorio_actual}")
         )
         try:
-            padre, entradas = runtime.construir_entradas_directorio(directorio_actual)
+            arbol_canonico = runtime.crear_arbol_directorios(
+                ft,
+                on_click=cargar_archivo_desde_evento_arbol,
+                root_path=directorio_actual,
+            )
         except (FileNotFoundError, NotADirectoryError, PermissionError) as exc:
             mostrar_error_archivo(exc)
-            entradas = []
-            padre = None
-        if padre is not None:
-            arbol.controls.append(
-                runtime.flet_text_button(
-                    ft, "📁 ..", on_click=lambda _e: cambiar_directorio(padre)
-                )
-            )
-        for tipo, ruta in entradas:
-            if tipo == "dir":
-                arbol.controls.append(
-                    runtime.flet_text_button(
-                        ft,
-                        f"📁 {ruta.name}",
-                        on_click=lambda _e, r=ruta: cambiar_directorio(r),
-                    )
-                )
-            else:
-                arbol.controls.append(
-                    runtime.flet_text_button(
-                        ft,
-                        f"📄 {ruta.name}",
-                        on_click=lambda _e, r=ruta: cargar_archivo(r),
-                    )
-                )
-
-    def cambiar_directorio(ruta: Path) -> None:
-        nonlocal directorio_actual
-        directorio_actual = ruta.expanduser().resolve()
-        reconstruir_arbol()
-        page.update()
+            return
+        arbol.controls.extend(getattr(arbol_canonico, "controls", [arbol_canonico]))
 
     def nuevo_handler(_e):
         entrada.value, salida.value = runtime.crear_archivo_nuevo_en_editor(estado)

--- a/tests/unit/test_gui_app.py
+++ b/tests/unit/test_gui_app.py
@@ -108,7 +108,9 @@ def test_main_renderiza_componentes_minimos(monkeypatch):
     ft = _fake_flet()
     monkeypatch.setattr(app.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
-        app.runtime, "crear_arbol_directorios", lambda _ft, on_click: _ft.Column([])
+        app.runtime,
+        "crear_arbol_directorios",
+        lambda _ft, on_click, root_path=None: _ft.Column([]),
     )
     monkeypatch.setattr(app.runtime, "gui_target_choices", lambda: ("python",))
     monkeypatch.setattr(
@@ -166,7 +168,9 @@ def test_main_handler_actualiza_salida(monkeypatch):
     ft = _fake_flet()
     monkeypatch.setattr(app.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
-        app.runtime, "crear_arbol_directorios", lambda _ft, on_click: _ft.Column([])
+        app.runtime,
+        "crear_arbol_directorios",
+        lambda _ft, on_click, root_path=None: _ft.Column([]),
     )
     monkeypatch.setattr(app.runtime, "gui_target_choices", lambda: ("python",))
     ejecutar_mock = MagicMock(return_value="ejecutado")
@@ -231,7 +235,9 @@ def test_main_configura_selector_por_defecto_y_switch_deshabilitado_si_no_hay_ta
     ft = _fake_flet()
     monkeypatch.setattr(app.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
-        app.runtime, "crear_arbol_directorios", lambda _ft, on_click: _ft.Column([])
+        app.runtime,
+        "crear_arbol_directorios",
+        lambda _ft, on_click, root_path=None: _ft.Column([]),
     )
     monkeypatch.setattr(app.runtime, "gui_target_choices", lambda: ())
     monkeypatch.setattr(


### PR DESCRIPTION
### Motivation

- Evitar dos implementaciones distintas del árbol de directorios en la GUI que causen comportamientos diferentes y duplicación de lógica.
- Centralizar el comportamiento del explorador en una API canónica para poder validar y filtrar la carga de archivos Cobra de forma coherente.
- Asegurar que los clicks en el árbol carguen solo archivos seguros (`.co`/`.cobra`) mediante la lógica ya existente en `runtime`.

### Description

- Se eligió `pcobra.gui.runtime.crear_arbol_directorios` como la implementación canónica y `src/pcobra/gui/idle.py` ahora delega la reconstrucción del árbol en esa función pasando `root_path=directorio_actual`.
- Se añadió en `idle.py` el handler `cargar_archivo_desde_evento_arbol` que obtiene la ruta desde `event.control.data` y llama a `runtime.cargar_archivo_desde_arbol` para una carga segura de archivos Cobra.
- Se eliminó la construcción manual previa de botones/entradas de archivo en `idle.py` y se adaptó el texto del panel a `Directorio raíz: {directorio_actual}` para reflejar el cambio.
- Se actualizó `docs/LIBRO_PROGRAMACION_COBRA.md` (sección `10.1`) para describir la API canónica `pcobra.gui.runtime.crear_arbol_directorios`, el orden estable, la carga diferida de subcarpetas y la validación de extensiones; y se ajustaron los tests (mocks) en `tests/unit/test_gui_app.py` para aceptar el parámetro `root_path`.

### Testing

- Formateo y lint con `python -m ruff format src/pcobra/gui/idle.py tests/unit/test_gui_app.py` y `python -m ruff check src/pcobra/gui/idle.py tests/unit/test_gui_app.py` se ejecutaron correctamente.
- Se ejecutaron los tests relevantes con `python -m pytest tests/unit/test_gui_app.py tests/unit/test_gui_runtime.py` y todos pasaron (`38 passed, 1 warning`).
- Las pruebas unitarias verifican específicamente la carga filtrada de extensiones (`cargar_archivo_desde_arbol`), la carga diferida de subcarpetas en `crear_arbol_directorios` y el correcto renderizado/handlers del IDLE.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33ab7300c08327960ebb57cb65f11e)