### PR TITLE
Añade reglas trazables del Libro para sugerencias IA

### DIFF
--- a/src/pcobra/ia/reglas_libro_programacion.py
+++ b/src/pcobra/ia/reglas_libro_programacion.py
@@ -75,6 +75,27 @@ REGLAS_LIBRO_PROGRAMACION: tuple[ReglaLibroProgramacion, ...] = (
         accuracy=0.55,
         interpretability=0.75,
     ),
+
+    ReglaLibroProgramacion(
+        id="LP-3.3-RETORNO-CANONICO",
+        seccion="§3.3 Sentencias",
+        descripcion="Usar la sentencia de retorno implementada por el parser vigente: retorno.",
+        fragmento_valido='func saludar(nombre):\n    retorno nombre\nfin',
+        construir_mensaje=lambda _codigo: "Usar `retorno` como sentencia de salida en funciones",
+        aplica=lambda codigo: "retornar" in codigo,
+        accuracy=0.7,
+        interpretability=0.9,
+    ),
+    ReglaLibroProgramacion(
+        id="LP-3.9-FUNCIONES-CON-FUNC",
+        seccion="§3.9 Contrato para sugerencias automáticas en GUI/IA",
+        descripcion="Declarar funciones con las formas aceptadas por el parser y autorizadas por el contrato de sugerencias: func o definir.",
+        fragmento_valido='func calcular_total(subtotal, impuesto):\n    retorno subtotal + impuesto\nfin',
+        construir_mensaje=lambda _codigo: "Declarar funciones con `func` o `definir`, no con `funcion`",
+        aplica=lambda codigo: "funcion " in codigo,
+        accuracy=0.75,
+        interpretability=0.9,
+    ),
     ReglaLibroProgramacion(
         id="LP-3.6-USAR-SIN-ALIAS",
         seccion="§3.6 Módulos",

--- a/tests/gui/test_auto_suggestion_parser_contract.py
+++ b/tests/gui/test_auto_suggestion_parser_contract.py
@@ -94,3 +94,61 @@ def test_recomendaciones_gui_cubren_ejemplos_invalidos_sin_ampliar_parser(
     assert regla_libro
     with pytest.raises(ParserError):
         _parsear(fragmento_invalido)
+
+
+def test_reglas_libro_programacion_declaran_fragmentos_soportados_por_parser() -> None:
+    """Cada regla interna debe exponer un fragmento canónico parseable."""
+    from pcobra.ia.reglas_libro_programacion import REGLAS_LIBRO_PROGRAMACION
+
+    ids = {regla.id for regla in REGLAS_LIBRO_PROGRAMACION}
+    assert "LP-3.3-RETORNO-CANONICO" in ids
+    assert "LP-3.9-FUNCIONES-CON-FUNC" in ids
+
+    for regla in REGLAS_LIBRO_PROGRAMACION:
+        ast = _parsear(regla.fragmento_valido)
+        assert ast, regla.id
+
+
+@pytest.mark.parametrize(
+    ("rule_id", "fragmento_valido", "fragmento_invalido"),
+    [
+        pytest.param(
+            "LP-3.3-RETORNO-CANONICO",
+            """
+func saludar(nombre):
+    retorno nombre
+fin
+""",
+            """
+func saludar(nombre):
+    retornar nombre
+fin
+""",
+            id="regla-retorno-no-retornar",
+        ),
+        pytest.param(
+            "LP-3.9-FUNCIONES-CON-FUNC",
+            """
+func calcular_total(subtotal, impuesto):
+    retorno subtotal + impuesto
+fin
+""",
+            """
+funcion calcular_total(subtotal, impuesto):
+    retorno subtotal + impuesto
+fin
+""",
+            id="regla-func-no-funcion",
+        ),
+    ],
+)
+def test_reglas_libro_programacion_nuevas_cubren_casos_validos_e_invalidos(
+    rule_id: str, fragmento_valido: str, fragmento_invalido: str
+) -> None:
+    from pcobra.ia.reglas_libro_programacion import REGLAS_LIBRO_PROGRAMACION
+
+    regla = next(regla for regla in REGLAS_LIBRO_PROGRAMACION if regla.id == rule_id)
+    assert regla.fragmento_valido.strip() == fragmento_valido.strip()
+    assert _parsear(fragmento_valido)
+    with pytest.raises(ParserError):
+        _parsear(fragmento_invalido)


### PR DESCRIPTION
### Motivation
- Trazar recomendaciones del Libro de Programación a reglas internas para que las sugerencias automáticas cumplan el contrato de validación con `Lexer`/`Parser` (no ampliar sintaxis). 
- Añadir reglas para patrones ya documentados en el Libro: uso de `retorno` en funciones y declaraciones con `func`/`definir` frente a `funcion`.

### Description
- Añadidas dos entradas en `REGLAS_LIBRO_PROGRAMACION` en `src/pcobra/ia/reglas_libro_programacion.py`: `LP-3.3-RETORNO-CANONICO` y `LP-3.9-FUNCIONES-CON-FUNC`, cada una con `id`, `seccion`, `descripcion`, `fragmento_valido`, `construir_mensaje`, `aplica`, `accuracy` e `interpretability`.
- Los `fragmento_valido` mantienen la compatibilidad con el parser y se verifican mediante `validar_con_parser` / `_fragmento_soportado` antes de exponer la sugerencia; no se modificó `Lexer` ni `Parser` ni se introdujo sintaxis nueva.
- Se añadieron pruebas en `tests/gui/test_auto_suggestion_parser_contract.py` que: recorren todas las reglas y aseguran que `fragmento_valido` parsea, y añaden casos válidos/invalidos (regresión) para las nuevas reglas (`retorno` vs `retornar`, `func` vs `funcion`).

### Testing
- Se ejecutó `pytest -q tests/gui/test_auto_suggestion_parser_contract.py tests/unit/test_analizador_agix.py` y todos los tests pasaron (`23 passed`, `1 warning`).
- Se ejecutó `python -m ruff check src/pcobra/ia/reglas_libro_programacion.py tests/gui/test_auto_suggestion_parser_contract.py` y pasó sin incidencias.
- Las nuevas pruebas añadidas en `tests/gui/test_auto_suggestion_parser_contract.py` pasan correctamente y confirman que los fragmentos sugeridos son aceptados por el parser y que las formas inválidas fallan con `ParserError`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33caa34e148327b71eb90522fbbd4c)