### PR TITLE
Alinea sandbox de archivos en GUI

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -818,10 +818,11 @@ Funciones disponibles en la GUI:
 *   **Editor de código:** Un área principal para escribir y editar código Cobra.
 *   **Salida seleccionable:** Un panel de resultados para copiar mensajes, salida de ejecución, tokens, AST, código transpilado o sugerencias.
 *   **Gestión de archivos:**
+    *   **Política de rutas:** El IDLE respeta la misma política de sandbox que la librería `archivo`: todas las operaciones de abrir, guardar y guardar como se normalizan con la resolución centralizada de `pcobra.corelibs.archivo` y quedan restringidas a `COBRA_IO_BASE_DIR` si está definida, o al directorio de trabajo actual en caso contrario. A diferencia de las primitivas Cobra de programa, la GUI acepta rutas absolutas devueltas por selectores de archivos solo cuando resuelven dentro de ese directorio permitido; cualquier ruta que escape del sandbox se rechaza antes de leer o escribir.
     *   **Nuevo:** Limpia el editor y crea un archivo en memoria sin ruta activa.
-    *   **Abrir:** Carga la ruta indicada en el campo `Ruta`.
-    *   **Guardar:** Guarda el archivo activo en su ubicación actual.
-    *   **Guardar como:** Guarda el contenido del editor en la ruta indicada.
+    *   **Abrir:** Carga la ruta indicada en el campo `Ruta` si permanece dentro del sandbox configurado.
+    *   **Guardar:** Guarda el archivo activo en su ubicación actual, volviendo a validar la ruta activa contra la política de sandbox.
+    *   **Guardar como:** Guarda el contenido del editor en la ruta indicada si la normalización no sale de `COBRA_IO_BASE_DIR` o del directorio de trabajo.
     *   **Recargar:** Vuelve a leer desde disco el archivo activo.
     *   **Árbol de directorios:** Usa la API canónica `pcobra.gui.runtime.crear_arbol_directorios`. El panel parte del directorio de trabajo actual, muestra primero las carpetas y después los archivos Cobra (`.co`/`.cobra`) en orden estable, y carga las subcarpetas bajo demanda al expandirlas. Solo los archivos Cobra visibles disparan la carga en el editor; el IDLE conecta el evento `on_click` con `cargar_archivo_desde_arbol`, que valida la extensión antes de leer el contenido y actualiza el estado del archivo activo.
 *   **Ejecución y transpilación:**

--- a/src/pcobra/corelibs/archivo.py
+++ b/src/pcobra/corelibs/archivo.py
@@ -25,22 +25,28 @@ def _es_ruta_absoluta_o_sensible_windows(ruta: PathLike) -> bool:
     return False
 
 
-def _resolver_ruta(ruta: PathLike) -> Path:
+def _resolver_ruta(
+    ruta: PathLike, *, permitir_absoluta_dentro_base: bool = False
+) -> Path:
     """Normaliza ``ruta`` dentro de un directorio permitido.
 
     Se utiliza ``COBRA_IO_BASE_DIR`` como directorio base si está definido;
     en caso contrario se emplea el directorio de trabajo actual. Si la ruta
     resultante se sale de este directorio controlado, se genera un
-    ``ValueError``.
+    ``ValueError``. Por defecto rechaza rutas absolutas para mantener la
+    política histórica de las corelibs; los clientes GUI pueden activar
+    ``permitir_absoluta_dentro_base`` para aceptar rutas absolutas que ya
+    resuelven dentro del mismo sandbox.
     """
 
     base = Path(os.environ.get("COBRA_IO_BASE_DIR") or Path.cwd()).resolve()
-    objetivo = Path(ruta)
-    if objetivo.is_absolute() or _es_ruta_absoluta_o_sensible_windows(ruta):
+    objetivo = Path(ruta).expanduser()
+    es_absoluta = objetivo.is_absolute() or _es_ruta_absoluta_o_sensible_windows(ruta)
+    if es_absoluta and not permitir_absoluta_dentro_base:
         raise ValueError("Las rutas absolutas no están permitidas")
     if ".." in objetivo.parts:
         raise ValueError("La ruta no puede contener '..'")
-    destino = (base / objetivo).resolve()
+    destino = objetivo.resolve() if es_absoluta else (base / objetivo).resolve()
     try:
         destino.relative_to(base)
     except ValueError as exc:

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+from pcobra.corelibs.archivo import _resolver_ruta as resolver_ruta_sandbox
 
 
 @lru_cache(maxsize=1)
@@ -172,10 +173,16 @@ def listar_directorio_cobra(root: str | Path) -> list[Path]:
     return sorted(visibles, key=lambda entry: (not entry.is_dir(), entry.name.lower()))
 
 
-def leer_archivo_texto(path: str | Path, *, encoding: str = "utf-8") -> str:
-    """Lee un archivo Cobra como texto UTF-8 sin interpretar su contenido."""
+def normalizar_ruta_archivo_gui(path: str | Path) -> Path:
+    """Normaliza rutas de la GUI según el sandbox Cobra compartido."""
 
-    return Path(path).expanduser().read_text(encoding=encoding)
+    return resolver_ruta_sandbox(path, permitir_absoluta_dentro_base=True)
+
+
+def leer_archivo_texto(path: str | Path, *, encoding: str = "utf-8") -> str:
+    """Lee un archivo Cobra como texto UTF-8 dentro del sandbox configurado."""
+
+    return normalizar_ruta_archivo_gui(path).read_text(encoding=encoding)
 
 
 def escribir_archivo_texto(
@@ -184,7 +191,7 @@ def escribir_archivo_texto(
     """Escribe exactamente el contenido normalizado del editor y lo devuelve."""
 
     codigo = normalizar_codigo(contenido)
-    destino = Path(path).expanduser()
+    destino = normalizar_ruta_archivo_gui(path)
     destino.write_text(codigo, encoding=encoding)
     return codigo
 
@@ -219,7 +226,7 @@ def nuevo_archivo(estado: GuiFileState) -> str:
 def cargar_archivo_en_estado(ruta: str | Path, estado: GuiFileState) -> str:
     """Carga un archivo de texto, actualiza estado y devuelve su contenido."""
 
-    ruta_resuelta = Path(ruta).expanduser().resolve()
+    ruta_resuelta = normalizar_ruta_archivo_gui(ruta)
     contenido = leer_archivo_texto(ruta_resuelta)
     estado.ruta = ruta_resuelta
     estado.contenido_cargado = contenido
@@ -232,7 +239,7 @@ def guardar_archivo_en_estado(
 ) -> str:
     """Guarda contenido del editor, actualiza estado y devuelve el texto guardado."""
 
-    ruta_resuelta = Path(ruta).expanduser().resolve()
+    ruta_resuelta = normalizar_ruta_archivo_gui(ruta)
     contenido_guardado = escribir_archivo_texto(ruta_resuelta, contenido)
     estado.ruta = ruta_resuelta
     estado.contenido_cargado = contenido_guardado

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -487,7 +487,10 @@ def test_accion_nuevo_archivo_reinicia_estado() -> None:
     assert estado == runtime.GuiFileState()
 
 
-def test_accion_abrir_archivo_desde_ruta(tmp_path: Path) -> None:
+def test_accion_abrir_archivo_desde_ruta(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
     archivo = tmp_path / "programa.cobra"
     archivo.write_text("imprimir('hola')", encoding="utf-8")
     estado = runtime.GuiFileState()
@@ -501,7 +504,10 @@ def test_accion_abrir_archivo_desde_ruta(tmp_path: Path) -> None:
     assert mensaje == f"Archivo cargado: {archivo.resolve()}"
 
 
-def test_accion_guardar_archivo_activo(tmp_path: Path) -> None:
+def test_accion_guardar_archivo_activo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
     archivo = tmp_path / "programa.cobra"
     archivo.write_text("imprimir('antes')", encoding="utf-8")
     estado = runtime.GuiFileState(
@@ -524,7 +530,10 @@ def test_accion_guardar_archivo_activo_sin_ruta_falla() -> None:
         runtime.guardar_archivo_activo("imprimir('x')", runtime.GuiFileState())
 
 
-def test_accion_guardar_archivo_como(tmp_path: Path) -> None:
+def test_accion_guardar_archivo_como(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
     destino = tmp_path / "nuevo.cobra"
     estado = runtime.GuiFileState()
 
@@ -540,7 +549,87 @@ def test_accion_guardar_archivo_como(tmp_path: Path) -> None:
     assert mensaje == f"Archivo guardado: {destino.resolve()}"
 
 
-def test_accion_recargar_archivo_activo(tmp_path: Path) -> None:
+def test_accion_abrir_archivo_respeta_sandbox_con_ruta_absoluta(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    archivo = tmp_path / "programa.cobra"
+    archivo.write_text("imprimir('sandbox')", encoding="utf-8")
+    estado = runtime.GuiFileState()
+
+    contenido, mensaje = runtime.abrir_archivo_desde_ruta(archivo.resolve(), estado)
+
+    assert contenido == "imprimir('sandbox')"
+    assert estado.ruta == archivo.resolve()
+    assert mensaje == f"Archivo cargado: {archivo.resolve()}"
+
+
+def test_accion_guardar_archivo_activo_respeta_sandbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    archivo = tmp_path / "programa.cobra"
+    archivo.write_text("imprimir('antes')", encoding="utf-8")
+    estado = runtime.GuiFileState(ruta=archivo.resolve(), cambios_sin_guardar=True)
+
+    contenido, mensaje = runtime.guardar_archivo_activo("imprimir('despues')", estado)
+
+    assert contenido == "imprimir('despues')"
+    assert archivo.read_text(encoding="utf-8") == "imprimir('despues')"
+    assert estado.ruta == archivo.resolve()
+    assert estado.cambios_sin_guardar is False
+    assert mensaje == f"Archivo guardado: {archivo.resolve()}"
+
+
+def test_accion_guardar_archivo_como_respeta_sandbox_con_ruta_relativa(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    estado = runtime.GuiFileState()
+
+    contenido, mensaje = runtime.guardar_archivo_como(
+        "nuevo.cobra", "imprimir('nuevo')", estado
+    )
+
+    destino = tmp_path / "nuevo.cobra"
+    assert contenido == "imprimir('nuevo')"
+    assert destino.read_text(encoding="utf-8") == "imprimir('nuevo')"
+    assert estado.ruta == destino.resolve()
+    assert mensaje == f"Archivo guardado: {destino.resolve()}"
+
+
+@pytest.mark.parametrize(
+    ("accion", "argumentos"),
+    [
+        ("abrir", lambda fuera: (fuera,)),
+        ("guardar", lambda fuera: (fuera, "imprimir('x')")),
+        ("guardar_como", lambda fuera: (fuera, "imprimir('x')")),
+    ],
+)
+def test_acciones_archivo_rechazan_rutas_fuera_del_sandbox(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    accion: str,
+    argumentos,
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    fuera = tmp_path.parent / "fuera.cobra"
+    fuera.write_text("imprimir('fuera')", encoding="utf-8")
+    estado = runtime.GuiFileState(ruta=fuera if accion == "guardar" else None)
+
+    with pytest.raises(ValueError, match="fuera del directorio permitido"):
+        if accion == "abrir":
+            runtime.abrir_archivo_desde_ruta(*argumentos(fuera), estado)
+        elif accion == "guardar":
+            runtime.guardar_archivo_activo(argumentos(fuera)[1], estado)
+        else:
+            runtime.guardar_archivo_como(*argumentos(fuera), estado)
+
+
+def test_accion_recargar_archivo_activo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
     archivo = tmp_path / "programa.cobra"
     archivo.write_text("imprimir('disco')", encoding="utf-8")
     estado = runtime.GuiFileState(
@@ -557,7 +646,10 @@ def test_accion_recargar_archivo_activo(tmp_path: Path) -> None:
     assert mensaje == f"Archivo cargado: {archivo.resolve()}"
 
 
-def test_accion_cargar_archivo_desde_arbol_filtra_extensiones(tmp_path: Path) -> None:
+def test_accion_cargar_archivo_desde_arbol_filtra_extensiones(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
     archivo = tmp_path / "arbol.co"
     archivo.write_text("imprimir('arbol')", encoding="utf-8")
     estado = runtime.GuiFileState()


### PR DESCRIPTION
### Motivation

- Evitar divergencias entre la GUI y las bibliotecas núcleo en la política de acceso a ficheros centralizando la normalización de rutas. 
- Hacer que el IDLE gráfico respete el mismo sandbox que `COBRA_IO_BASE_DIR` para proteger el entorno y mantener coherencia con la API `archivo`.

### Description

- Centraliza la resolución/normalización de rutas en `pcobra.corelibs.archivo._resolver_ruta` añadiendo el parámetro `permitir_absoluta_dentro_base` para permitir a clientes GUI aceptar rutas absolutas solo cuando resuelven dentro del sandbox. 
- Actualiza `pcobra.gui.runtime` para usar la normalización compartida mediante una nueva función `normalizar_ruta_archivo_gui`, y modifica `leer_archivo_texto`, `escribir_archivo_texto`, `cargar_archivo_en_estado` y `guardar_archivo_en_estado` para validar rutas antes de leer/escribir. 
- Documenta la decisión en la sección 10.1 de `docs/LIBRO_PROGRAMACION_COBRA.md`, explicitando que la GUI respeta `COBRA_IO_BASE_DIR` y acepta rutas absolutas únicamente si permanecen dentro del directorio permitido. 
- Añade pruebas unitarias en `tests/unit/test_gui_runtime.py` para cubrir: abrir con ruta absoluta dentro del sandbox, guardar (activo), guardar como (relativo), y rechazo de operaciones sobre rutas fuera del sandbox.

### Testing

- Se verificó la sintaxis con `python -m py_compile src/pcobra/corelibs/archivo.py src/pcobra/gui/runtime.py tests/unit/test_gui_runtime.py` y la comprobación pasó exitosamente. 
- Se ejecutaron las pruebas relevantes con `pytest -q tests/unit/test_gui_runtime.py tests/unit/test_corelibs.py::test_archivo_funcs tests/unit/test_corelibs.py::test_archivo_rechaza_rutas_invalidas tests/unit/test_archivo.py`, y todas ellas pasaron (`63 passed, 1 warning`). 
- Se intentó una ejecución más amplia (`pytest` sobre múltiples módulos core) que inicialmente mostró fallos en pruebas de transpilación no relacionadas con estos cambios (diferencias en quoting/expectativas de salida); esos fallos son ajenos a la lógica de sandbox aplicada en esta PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33cbeb73b88327884e7e8ea785a2e6)