### PR TITLE
Añadir contrato para reglas de sugerencias del Libro

### DIFF
--- a/docs/tareas_implementacion_libro_cobra.md
+++ b/docs/tareas_implementacion_libro_cobra.md
@@ -29,6 +29,18 @@ Checklist obligatorio de la misma tarea:
 - [ ] Actualizar la documentación del Libro con la sintaxis, ejemplos válidos y contraejemplos inválidos.
 - [ ] Añadir o actualizar pruebas de contrato Lexer/Parser que cubran tokenización, parseo y errores esperados.
 
+
+## Contrato obligatorio para nuevas reglas de sugerencias del Libro
+
+Toda regla nueva derivada del Libro y registrada en `REGLAS_LIBRO_PROGRAMACION` debe añadirse con prueba de contrato en `tests/gui/test_auto_suggestion_parser_contract.py` o `tests/unit/test_parser_sugerencias.py`. La regla debe declarar `id`, `seccion`, `descripcion` y `fragmento_valido`; además, cuando aplique, debe declarar `fragmento_no_recomendado` con un ejemplo no recomendado o inválido. El `fragmento_valido` tiene que pasar siempre por `Lexer(fragmento).tokenizar()` y `Parser(tokens).parsear()` para evitar sugerencias que amplíen la sintaxis sin soporte real del parser.
+
+Checklist obligatorio de la misma tarea:
+
+- [ ] Añadir o actualizar la entrada en `REGLAS_LIBRO_PROGRAMACION` con metadatos trazables al Libro.
+- [ ] Incluir `fragmento_valido` parseable por `Lexer` y `Parser`.
+- [ ] Incluir `fragmento_no_recomendado` cuando exista una forma desaconsejada o inválida relacionada.
+- [ ] Añadir o ampliar una prueba de contrato que itere todas las reglas y falle si faltan metadatos obligatorios o si el fragmento válido deja de parsear.
+
 ---
 
 ## A) Tickets de creación/actualización del libro

--- a/src/pcobra/ia/reglas_libro_programacion.py
+++ b/src/pcobra/ia/reglas_libro_programacion.py
@@ -20,6 +20,7 @@ class ReglaLibroProgramacion:
     seccion: str
     descripcion: str
     fragmento_valido: str
+    fragmento_no_recomendado: str | None
     categoria: str
     severidad: str
     aplicable_automaticamente: bool
@@ -63,6 +64,7 @@ REGLAS_LIBRO_PROGRAMACION: tuple[ReglaLibroProgramacion, ...] = (
         seccion="§3.1 Léxico",
         descripcion="Usar identificadores válidos y legibles para variables, funciones, clases y módulos.",
         fragmento_valido="total = 10\nimprimir(total)",
+        fragmento_no_recomendado="x = 10\nimprimir(x)",
         categoria="nombres",
         severidad="baja",
         aplicable_automaticamente=True,
@@ -76,6 +78,7 @@ REGLAS_LIBRO_PROGRAMACION: tuple[ReglaLibroProgramacion, ...] = (
         seccion="§3.3 Sentencias",
         descripcion="Preferir sentencias canónicas verificadas por el parser para acciones con efecto.",
         fragmento_valido='imprimir("Hola, Cobra")',
+        fragmento_no_recomendado=None,
         categoria="observabilidad",
         severidad="informativa",
         aplicable_automaticamente=False,
@@ -89,6 +92,7 @@ REGLAS_LIBRO_PROGRAMACION: tuple[ReglaLibroProgramacion, ...] = (
         seccion="§3.3 Sentencias",
         descripcion="Usar la sentencia de retorno implementada por el parser vigente: retorno.",
         fragmento_valido="func saludar(nombre):\n    retorno nombre\nfin",
+        fragmento_no_recomendado="func saludar(nombre):\n    retornar nombre\nfin",
         categoria="forma canónica",
         severidad="media",
         aplicable_automaticamente=True,
@@ -102,6 +106,7 @@ REGLAS_LIBRO_PROGRAMACION: tuple[ReglaLibroProgramacion, ...] = (
         seccion="§3.9 Contrato para sugerencias automáticas en GUI/IA",
         descripcion="Declarar funciones con las formas aceptadas por el parser y autorizadas por el contrato de sugerencias: func o definir.",
         fragmento_valido="func calcular_total(subtotal, impuesto):\n    retorno subtotal + impuesto\nfin",
+        fragmento_no_recomendado="funcion calcular_total(subtotal, impuesto):\n    retorno subtotal + impuesto\nfin",
         categoria="léxico/sintaxis",
         severidad="alta",
         aplicable_automaticamente=True,
@@ -115,6 +120,7 @@ REGLAS_LIBRO_PROGRAMACION: tuple[ReglaLibroProgramacion, ...] = (
         seccion="§3.6 Módulos",
         descripcion='Usar módulos con la forma aceptada por el parser: usar "modulo", sin alias como.',
         fragmento_valido='usar "numero"\nes_finito(10)',
+        fragmento_no_recomendado='usar "numero" como numero\nnumero.es_finito(10)',
         categoria="estilo",
         severidad="media",
         aplicable_automaticamente=True,

--- a/tests/gui/test_auto_suggestion_parser_contract.py
+++ b/tests/gui/test_auto_suggestion_parser_contract.py
@@ -96,16 +96,27 @@ def test_recomendaciones_gui_cubren_ejemplos_invalidos_sin_ampliar_parser(
 
 
 def test_reglas_libro_programacion_declaran_fragmentos_soportados_por_parser() -> None:
-    """Cada regla interna debe exponer un fragmento canónico parseable."""
+    """Cada regla interna debe exponer metadatos mínimos y un fragmento parseable."""
     from pcobra.ia.reglas_libro_programacion import REGLAS_LIBRO_PROGRAMACION
 
     ids = {regla.id for regla in REGLAS_LIBRO_PROGRAMACION}
     assert "LP-3.3-RETORNO-CANONICO" in ids
     assert "LP-3.9-FUNCIONES-CON-FUNC" in ids
 
+    campos_obligatorios = ("id", "seccion", "descripcion", "fragmento_valido")
+
     for regla in REGLAS_LIBRO_PROGRAMACION:
+        for campo in campos_obligatorios:
+            valor = getattr(regla, campo, None)
+            assert isinstance(valor, str) and valor.strip(), (regla, campo)
+
         ast = _parsear(regla.fragmento_valido)
         assert ast, regla.id
+
+        if regla.fragmento_no_recomendado is not None:
+            assert regla.fragmento_no_recomendado.strip(), regla.id
+            assert regla.fragmento_no_recomendado.strip() != regla.fragmento_valido.strip()
+
         assert regla.categoria in {
             "léxico/sintaxis",
             "estilo",
@@ -157,6 +168,8 @@ def test_reglas_libro_programacion_nuevas_cubren_casos_validos_e_invalidos(
 
     regla = next(regla for regla in REGLAS_LIBRO_PROGRAMACION if regla.id == rule_id)
     assert regla.fragmento_valido.strip() == fragmento_valido.strip()
+    assert regla.fragmento_no_recomendado is not None
+    assert regla.fragmento_no_recomendado.strip() == fragmento_invalido.strip()
     assert _parsear(fragmento_valido)
     with pytest.raises(ParserError):
-        _parsear(fragmento_invalido)
+        _parsear(regla.fragmento_no_recomendado)


### PR DESCRIPTION
### Motivation

- Evitar que las reglas de sugerencias propongan fragmentos que no estén realmente soportados por el lexer/parser y forzar metadatos mínimos para trazabilidad.
- Documentar la convención y exigir pruebas que verifiquen ejemplos válidos e inválidos por cada regla.

### Description

- Añadido el campo `fragmento_no_recomendado: str | None` a `ReglaLibroProgramacion` y actualizado `REGLAS_LIBRO_PROGRAMACION` para declarar un contraejemplo cuando aplique (archivo `src/pcobra/ia/reglas_libro_programacion.py`).
- Ampliadas las pruebas en `tests/gui/test_auto_suggestion_parser_contract.py` para iterar todas las reglas, exigir los campos `id`, `seccion`, `descripcion`, `fragmento_valido`, validar que `fragmento_valido` parsea con `Lexer`/`Parser` y comprobar `fragmento_no_recomendado` cuando exista; los casos parametrizados ahora se comparan con el campo de la regla en lugar de repetir el ejemplo inválido.
- Añadida la sección de contrato en `docs/tareas_implementacion_libro_cobra.md` que obliga a incluir prueba de contrato y checklist para nuevas reglas en `REGLAS_LIBRO_PROGRAMACION`.

### Testing

- Ejecutado `pytest tests/gui/test_auto_suggestion_parser_contract.py`, todas las pruebas (9) pasaron satisfactoriamente.
- No se ejecutaron otras suites automáticas en este cambio; la prueba mostró una advertencia de deprecación existente al importar `core` pero no afectó al paso de los tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a341961fd708327b42d5b85f5bd4e06)