### PR TITLE
Añade auditoría CI para reglas del Libro de Programación

### DIFF
--- a/docs/gui_idle_trazabilidad.md
+++ b/docs/gui_idle_trazabilidad.md
@@ -20,3 +20,30 @@ Esta matriz documenta únicamente comportamiento existente en el IDLE gráfico c
 ## Especificación normativa
 
 La especificación consolidada de acciones soportadas, funciones runtime, validación previa con `Lexer`/`Parser` y restricción del selector de transpilación a `python`, `javascript` y `rust` está en [`docs/gui_idle_especificacion.md`](gui_idle_especificacion.md).
+
+## Auditoría CI de reglas derivadas del Libro
+
+El flujo de trazabilidad de **Sugerencias del Libro** se protege con el script
+`scripts/ci/audit_reglas_libro_programacion.py`. Este script lee de forma
+estática `src/pcobra/ia/reglas_libro_programacion.py`, extrae los campos `id`,
+`seccion` y `fragmento_valido` de cada entrada de `REGLAS_LIBRO_PROGRAMACION` y
+falla si detecta cualquiera de estas condiciones:
+
+1. Una regla no declara un `id`, una `seccion` o un `fragmento_valido` literal y
+   no vacío.
+2. La `seccion` no usa el formato trazable `§N[.N] Título`.
+3. La sección referenciada no existe como encabezado en
+   `docs/LIBRO_PROGRAMACION_COBRA.md`, lo que evita reglas huérfanas respecto al
+   Libro.
+4. El `fragmento_valido` deja de parsear con el `Lexer` y el `Parser` oficiales
+   de Cobra.
+
+Para ejecutar la auditoría de forma aislada:
+
+```bash
+python scripts/ci/audit_reglas_libro_programacion.py
+```
+
+La prueba `tests/unit/test_audit_reglas_libro_programacion.py` invoca la misma
+función de auditoría para que el contrato también forme parte de la suite de
+`pytest`.

--- a/scripts/ci/audit_reglas_libro_programacion.py
+++ b/scripts/ci/audit_reglas_libro_programacion.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Audita la trazabilidad de reglas IA contra el Libro de Programación Cobra.
+
+El script lee ``src/pcobra/ia/reglas_libro_programacion.py`` con ``ast`` para
+extraer los metadatos declarados en ``REGLAS_LIBRO_PROGRAMACION`` sin ejecutar
+el módulo, comprueba que cada sección exista en el Libro y valida cada
+``fragmento_valido`` con el ``Lexer`` y ``Parser`` oficiales.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+REGLAS_PATH = ROOT / "src" / "pcobra" / "ia" / "reglas_libro_programacion.py"
+LIBRO_PATH = ROOT / "docs" / "LIBRO_PROGRAMACION_COBRA.md"
+SRC_PATH = ROOT / "src"
+
+
+@dataclass(frozen=True)
+class ReglaAuditada:
+    """Campos estáticos requeridos para auditar una regla del Libro."""
+
+    id: str
+    seccion: str
+    fragmento_valido: str
+
+
+def _literal_str(node: ast.AST, *, campo: str, regla: str) -> str:
+    """Devuelve un literal de cadena o falla con un mensaje accionable."""
+    try:
+        valor = ast.literal_eval(node)
+    except (SyntaxError, ValueError) as exc:
+        raise ValueError(f"{regla}: el campo {campo!r} debe ser literal") from exc
+    if not isinstance(valor, str) or not valor.strip():
+        raise ValueError(f"{regla}: el campo {campo!r} debe ser una cadena no vacía")
+    return valor
+
+
+def _extraer_reglas(reglas_path: Path = REGLAS_PATH) -> list[ReglaAuditada]:
+    """Extrae ``id``, ``seccion`` y ``fragmento_valido`` desde el AST del módulo."""
+    tree = ast.parse(reglas_path.read_text(encoding="utf-8"), filename=str(reglas_path))
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "REGLAS_LIBRO_PROGRAMACION"
+            for target in node.targets
+        ):
+            return _extraer_reglas_desde_tuple(node.value)
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.target.id == "REGLAS_LIBRO_PROGRAMACION" and node.value is not None:
+                return _extraer_reglas_desde_tuple(node.value)
+    raise ValueError(f"No se encontró REGLAS_LIBRO_PROGRAMACION en {reglas_path}")
+
+
+def _extraer_reglas_desde_tuple(node: ast.AST) -> list[ReglaAuditada]:
+    if not isinstance(node, ast.Tuple):
+        raise ValueError("REGLAS_LIBRO_PROGRAMACION debe declararse como una tupla literal")
+
+    reglas: list[ReglaAuditada] = []
+    for index, element in enumerate(node.elts, start=1):
+        if not isinstance(element, ast.Call):
+            raise ValueError(f"Regla #{index}: se esperaba una llamada a ReglaLibroProgramacion")
+        kwargs = {keyword.arg: keyword.value for keyword in element.keywords if keyword.arg}
+        regla_id = _literal_str(
+            kwargs.get("id", ast.Constant(value="")), campo="id", regla=f"Regla #{index}"
+        )
+        seccion = _literal_str(
+            kwargs.get("seccion", ast.Constant(value="")), campo="seccion", regla=regla_id
+        )
+        fragmento_valido = _literal_str(
+            kwargs.get("fragmento_valido", ast.Constant(value="")),
+            campo="fragmento_valido",
+            regla=regla_id,
+        )
+        reglas.append(ReglaAuditada(regla_id, seccion, fragmento_valido))
+    if not reglas:
+        raise ValueError("REGLAS_LIBRO_PROGRAMACION no puede estar vacía")
+    return reglas
+
+
+def _normalizar_seccion(seccion: str) -> tuple[str, str]:
+    match = re.fullmatch(r"§(?P<num>\d+(?:\.\d+)*)\s+(?P<title>.+)", seccion.strip())
+    if not match:
+        raise ValueError(
+            f"Sección inválida {seccion!r}: usa el formato '§N[.N] Título'"
+        )
+    return match.group("num"), " ".join(match.group("title").split()).casefold()
+
+
+def _extraer_secciones_libro(libro_path: Path = LIBRO_PATH) -> set[tuple[str, str]]:
+    contenido = libro_path.read_text(encoding="utf-8")
+    secciones: set[tuple[str, str]] = set()
+    for line in contenido.splitlines():
+        match = re.match(r"^#{2,6}\s+(?P<num>\d+(?:\.\d+)*)(?:\)|\.)?\s+(?P<title>.+?)\s*$", line)
+        if match:
+            secciones.add(
+                (match.group("num"), " ".join(match.group("title").split()).casefold())
+            )
+    return secciones
+
+
+def _validar_fragmento_parseable(regla: ReglaAuditada) -> None:
+    if str(SRC_PATH) not in sys.path:
+        sys.path.insert(0, str(SRC_PATH))
+    from pcobra.cobra.core import Lexer, Parser
+
+    tokens = Lexer(regla.fragmento_valido).tokenizar()
+    Parser(tokens).parsear()
+
+
+def auditar() -> list[str]:
+    """Ejecuta la auditoría y devuelve una lista de errores encontrados."""
+    errores: list[str] = []
+    try:
+        reglas = _extraer_reglas()
+    except Exception as exc:  # pragma: no cover - ruta defensiva para CI
+        return [f"No se pudieron extraer las reglas: {exc}"]
+
+    secciones_libro = _extraer_secciones_libro()
+    ids_vistos: set[str] = set()
+    for regla in reglas:
+        if regla.id in ids_vistos:
+            errores.append(f"{regla.id}: id duplicado")
+        ids_vistos.add(regla.id)
+
+        try:
+            seccion = _normalizar_seccion(regla.seccion)
+        except ValueError as exc:
+            errores.append(f"{regla.id}: {exc}")
+        else:
+            if seccion not in secciones_libro:
+                errores.append(
+                    f"{regla.id}: sección huérfana {regla.seccion!r}; no existe en {LIBRO_PATH}"
+                )
+
+        try:
+            _validar_fragmento_parseable(regla)
+        except Exception as exc:
+            errores.append(
+                f"{regla.id}: fragmento_valido no parsea con Lexer/Parser: {exc}"
+            )
+    return errores
+
+
+def main() -> int:
+    errores = auditar()
+    if errores:
+        print("Auditoría de reglas del Libro: ERROR", file=sys.stderr)
+        for error in errores:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("Auditoría de reglas del Libro: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_audit_reglas_libro_programacion.py
+++ b/tests/unit/test_audit_reglas_libro_programacion.py
@@ -1,0 +1,10 @@
+"""Contrato CI para que las reglas IA no queden huérfanas respecto al Libro."""
+
+from __future__ import annotations
+
+from scripts.ci.audit_reglas_libro_programacion import auditar
+
+
+def test_reglas_libro_programacion_no_quedan_huerfanas() -> None:
+    """Falla si una regla referencia una sección ausente o un fragmento no parseable."""
+    assert auditar() == []


### PR DESCRIPTION
### Motivation

- Evitar reglas internas que queden huérfanas respecto al `docs/LIBRO_PROGRAMACION_COBRA.md` y detectar desalineos entre reglas y el Libro de referencia. 
- Asegurar que los `fragmento_valido` declarados en `REGLAS_LIBRO_PROGRAMACION` siguen siendo parseables con el `Lexer` y el `Parser` oficiales. 
- Integrar la comprobación en CI/suite de pruebas para que el repositorio falle temprano ante cambios que rompan trazabilidad o el contrato del parser.

### Description

- Añade `scripts/ci/audit_reglas_libro_programacion.py`, un script que analiza con `ast` `src/pcobra/ia/reglas_libro_programacion.py` para extraer `id`, `seccion` y `fragmento_valido` sin ejecutar el módulo. 
- Valida que cada `seccion` use el formato trazable `§N[.N] Título`, normaliza y comprueba que exista entre los encabezados de `docs/LIBRO_PROGRAMACION_COBRA.md`. 
- Verifica que cada `fragmento_valido` tokenice y parsee usando `Lexer`/`Parser`, y expone la función `auditar()` que devuelve la lista de errores para uso en CI. 
- Añade la prueba `tests/unit/test_audit_reglas_libro_programacion.py` que invoca `auditar()` y documenta el flujo en `docs/gui_idle_trazabilidad.md` con instrucciones de uso (`python scripts/ci/audit_reglas_libro_programacion.py`).

### Testing

- Ejecuté `python scripts/ci/audit_reglas_libro_programacion.py` y el script devolvió estado OK indicando que no se detectaron errores en las reglas. 
- Ejecuté `pytest -q tests/unit/test_audit_reglas_libro_programacion.py tests/gui/test_auto_suggestion_parser_contract.py` y ambas pruebas pasaron correctamente (tests automatizados exitosos).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a352e7050d48327878e28de3263db02)