### PR TITLE
Imponer contrato público de backends: solo python, javascript y rust

### DIFF
--- a/scripts/ci/audit_public_backend_exposure_terms.py
+++ b/scripts/ci/audit_public_backend_exposure_terms.py
@@ -15,9 +15,16 @@ from dataclasses import dataclass
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-FORBIDDEN_PUBLIC_TERMS = ("go", "cpp", "java", "wasm", "asm", "py", "js", "node", "golang", "jvm")
+BLOCKED_PUBLIC_BACKENDS = ("go", "cpp", "java", "wasm", "asm")
+BLOCKED_LEGACY_ALIASES = ("py", "js", "node", "nodejs", "python3", "golang", "jvm")
+FORBIDDEN_PUBLIC_TERMS = BLOCKED_PUBLIC_BACKENDS + BLOCKED_LEGACY_ALIASES
 OFFICIAL_PUBLIC_BACKENDS = ("python", "javascript", "rust")
-_TERM_RE = re.compile(r"(?<![\w.+/-])(" + "|".join(map(re.escape, FORBIDDEN_PUBLIC_TERMS)) + r")(?![\w.+/-])", re.IGNORECASE)
+_TERM_RE = re.compile(
+    r"(?<![\w.+/-])("
+    + "|".join(map(re.escape, FORBIDDEN_PUBLIC_TERMS))
+    + r")(?![\w.+/-])",
+    re.IGNORECASE,
+)
 
 PUBLIC_REGISTRY_FILES = (
     Path("src/pcobra/cobra/transpilers/registry.py"),
@@ -180,7 +187,8 @@ def main() -> int:
         for violation in violations:
             print(f"  - {violation.format()}", file=sys.stderr)
         print(
-            "Regla: go/cpp/java/wasm/asm/py/js/node/golang/jvm solo pueden aparecer "
+            "Regla: go/cpp/java/wasm/asm y aliases legacy "
+            "py/js/node/nodejs/python3/golang/jvm solo pueden aparecer "
             "en documentos históricos explícitos, pruebas de rechazo o shims legacy autorizados.",
             file=sys.stderr,
         )

--- a/tests/unit/test_backend_public_contract.py
+++ b/tests/unit/test_backend_public_contract.py
@@ -1,5 +1,22 @@
 from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+from pcobra.cobra.config.transpile_targets import ALLOWED_TARGETS
+from pcobra.cobra.transpilers.registry import (
+    PUBLIC_TRANSPILER_CLASS_PATHS,
+    official_transpiler_registry_literal,
+    official_transpiler_targets,
+)
 
 
 def test_politica_publica_exacta_tres_backends():
     assert PUBLIC_BACKENDS == ("python", "javascript", "rust")
+
+
+def test_allowed_targets_deriva_de_public_backends():
+    assert ALLOWED_TARGETS is PUBLIC_BACKENDS
+    assert ALLOWED_TARGETS == ("python", "javascript", "rust")
+
+
+def test_registro_publico_transpiladores_expone_exactamente_public_backends():
+    assert tuple(PUBLIC_TRANSPILER_CLASS_PATHS) == PUBLIC_BACKENDS
+    assert official_transpiler_targets() == PUBLIC_BACKENDS
+    assert tuple(official_transpiler_registry_literal()) == PUBLIC_BACKENDS

--- a/tests/unit/test_gui_target_choices.py
+++ b/tests/unit/test_gui_target_choices.py
@@ -1,3 +1,4 @@
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 from pcobra.gui import runtime
 
 
@@ -28,3 +29,19 @@ def test_gui_motor_sugerencias_usa_nombre_canonico_agix():
     assert runtime.CANONICAL_SUGGESTION_ENGINE == "agix"
     assert motor.nombre == "agix"
     assert "agi-core" not in motor.tooltip
+
+
+def test_gui_runtime_choices_coinciden_con_public_backends(monkeypatch):
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {
+            "target_cli_choices": lambda targets: tuple(
+                target for target in PUBLIC_BACKENDS if target in targets
+            ),
+            "OFFICIAL_TARGETS": PUBLIC_BACKENDS,
+            "TRANSPILERS": {target: object for target in PUBLIC_BACKENDS},
+        },
+    )
+
+    assert runtime.gui_target_choices() == PUBLIC_BACKENDS


### PR DESCRIPTION
### Motivation
- Garantizar que ninguna superficie pública (CLI/GUI/documentación) vuelva a exponer backends fuera del contrato oficial de tres targets.
- Evitar la reintroducción accidental de nombres legacy/aliases en choices, registros públicos o snapshots de runtime.
- Proveer pruebas y auditoría para detectar regresiones y documentar explícitamente los aliases bloqueados.

### Description
- Añadí tests en `tests/unit/test_backend_public_contract.py` que verifican que `PUBLIC_BACKENDS == ("python", "javascript", "rust")`, que `ALLOWED_TARGETS` deriva de `PUBLIC_BACKENDS` y que el registro público de transpiladores expone exactamente esos tres targets.
- Añadí un test en `tests/unit/test_gui_target_choices.py` que valida que las opciones visibles en la GUI coinciden con `PUBLIC_BACKENDS` y mantuve la prueba que filtra targets no canónicos.
- Fortalicé el script de auditoría `scripts/ci/audit_public_backend_exposure_terms.py` separando `BLOCKED_PUBLIC_BACKENDS` de `BLOCKED_LEGACY_ALIASES`, agregando aliases como `nodejs` y `python3`, y ajustando el patrón regex y el mensaje de error para mayor claridad.
- No fueron necesarios cambios en `src/pcobra/cobra/architecture/backend_policy.py`, `src/pcobra/cobra/config/transpile_targets.py` y `src/pcobra/cobra/transpilers/registry.py` porque ya mantienen el contrato (`PUBLIC_BACKENDS` y el registro canonico contienen solo `python`, `javascript`, `rust`).

### Testing
- Ejecuté `python -m pytest tests/unit/test_backend_public_contract.py tests/unit/test_gui_target_choices.py` y ambos tests pasaron (`6 passed, 1 warning`).
- Ejecuté `python scripts/ci/audit_public_backend_exposure_terms.py` y la auditoría devolvió `OK` sin violaciones.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a357f03f8048327a8001dc5a3ea5883)