### PR TITLE
Documentar IDLE gráfico y ampliar tests de helpers de archivo

### DIFF
--- a/docs/gui_idle.md
+++ b/docs/gui_idle.md
@@ -1,0 +1,65 @@
+# Capacidades actuales del IDLE gráfico
+
+El IDLE gráfico de pCobra vive en `src/pcobra/gui/idle.py` y reutiliza los helpers canónicos de `src/pcobra/gui/runtime.py` para mantener una sola implementación de la lógica de archivos, árbol, ejecución e inspección.
+
+## Arranque
+
+La forma recomendada para abrirlo desde la CLI es:
+
+```bash
+cobra gui
+```
+
+Para integraciones Flet o lanzamientos desde Python, usa el entrypoint canónico:
+
+```python
+from pcobra.gui.idle import main
+```
+
+También se mantiene el alias de compatibilidad:
+
+```python
+from pcobra.gui.app import main
+```
+
+El alias `pcobra.gui.app.main` delega en el IDLE canónico y no debe introducir una segunda lógica de archivo ni handlers alternativos para las mismas acciones.
+
+## Edición y estado de archivo
+
+El editor permite modificar código Cobra de forma interactiva. La cabecera muestra el archivo activo o `Archivo nuevo (sin guardar)`, y añade un asterisco cuando el contenido del editor difiere del contenido cargado desde disco. La comparación de cambios se centraliza en `runtime.marcar_cambios_editor`.
+
+## Acciones de archivo
+
+La barra de archivo expone estas acciones:
+
+- **Nuevo:** reinicia el estado del editor con un archivo en memoria sin ruta activa mediante `runtime.crear_archivo_nuevo_en_editor`.
+- **Abrir:** carga la ruta indicada en el campo `Ruta` mediante `runtime.abrir_archivo_desde_ruta`.
+- **Guardar:** escribe el archivo activo con `runtime.guardar_archivo_activo`; si todavía no existe ruta activa, redirige al flujo de **Guardar como**.
+- **Guardar como:** escribe el contenido del editor en la ruta indicada mediante `runtime.guardar_archivo_como`.
+- **Recargar:** vuelve a leer desde disco el archivo activo mediante `runtime.recargar_archivo_activo`.
+
+Toda lectura, escritura y normalización de rutas se mantiene en `src/pcobra/gui/runtime.py`. `src/pcobra/gui/idle.py` solo coordina eventos Flet, estado visual y mensajes.
+
+## Árbol de directorios
+
+El panel lateral muestra un árbol de directorios construido con `runtime.crear_arbol_directorios`. La raíz inicial es el directorio de trabajo actual y puede cambiarse desde el campo `Raíz del árbol` con el botón **Establecer raíz**.
+
+El árbol carga subdirectorios bajo demanda al expandirlos. Al seleccionar un archivo Cobra visible, el IDLE llama a `runtime.cargar_archivo_desde_arbol`, que valida la extensión y reutiliza el mismo flujo de apertura de archivos.
+
+## Ejecución, transpilación, tokens, AST y sugerencias
+
+La barra de ejecución permite:
+
+- **Ejecutar:** interpreta el código del editor con el runtime Cobra compartido.
+- **Transpilar:** al activar el switch `Transpilar`, genera código para el target seleccionado en el desplegable.
+- **Tokens:** muestra la tokenización del código actual.
+- **AST:** muestra la representación del árbol sintáctico.
+- **Sugerencias del Libro:** valida primero errores léxicos/sintácticos y, si el motor IA opcional está disponible, añade sugerencias.
+
+Estos flujos se crean desde helpers de `runtime.py`: `crear_handler_ejecucion`, `crear_handler_tokens`, `crear_handler_ast` y `crear_handler_sugerencias`.
+
+## Limitaciones actuales
+
+- El árbol de directorios muestra directorios y archivos Cobra con extensión `.co` o `.cobra` por defecto; otros archivos quedan ocultos salvo que se active una configuración interna futura para mostrar todo.
+- Flet es una dependencia opcional de la GUI. Importar módulos CLI no debe requerir Flet; abrir el IDLE sí requiere instalarlo.
+- Las sugerencias dependen del motor IA declarado por el proyecto (`agix`). Si la dependencia opcional no está disponible, el botón aparece deshabilitado o informa el motivo.

--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -1,6 +1,15 @@
 from pathlib import Path
 
+import pytest
+
 from pcobra.gui import runtime
+
+
+@pytest.fixture(autouse=True)
+def _ejecutar_en_tmp_path(monkeypatch, tmp_path: Path):
+    """Alinea los helpers GUI con la política de sandbox de rutas Cobra."""
+
+    monkeypatch.chdir(tmp_path)
 
 
 def test_es_archivo_cobra_prioriza_extensiones_documentadas():
@@ -117,3 +126,73 @@ def test_ejecutar_codigo_usa_dependencias_gui_y_captura_stdout_stderr(monkeypatc
     assert "salida desde lexer" in salida
     assert "stdout ast=AST" in salida
     assert "stderr capturado" in salida
+
+
+def test_helpers_archivo_cubren_nuevo_abrir_guardar_como_guardar_y_recargar(
+    tmp_path: Path,
+):
+    estado = runtime.GuiFileState()
+    origen = tmp_path / "origen.co"
+    destino = tmp_path / "destino.cobra"
+    origen.write_text("imprimir('origen')", encoding="utf-8")
+
+    contenido, mensaje = runtime.crear_archivo_nuevo_en_editor(estado)
+    assert contenido == ""
+    assert mensaje == "Archivo nuevo creado en memoria."
+    assert estado.ruta is None
+    assert estado.contenido_cargado == ""
+    assert estado.cambios_sin_guardar is False
+
+    contenido, mensaje = runtime.abrir_archivo_desde_ruta(origen, estado)
+    assert contenido == "imprimir('origen')"
+    assert mensaje == f"Archivo cargado: {origen.resolve()}"
+    assert estado.ruta == origen.resolve()
+    assert estado.contenido_cargado == "imprimir('origen')"
+    assert estado.cambios_sin_guardar is False
+
+    contenido, mensaje = runtime.guardar_archivo_como(
+        destino, "imprimir('guardar como')", estado
+    )
+    assert contenido == "imprimir('guardar como')"
+    assert mensaje == f"Archivo guardado: {destino.resolve()}"
+    assert destino.read_text(encoding="utf-8") == "imprimir('guardar como')"
+    assert estado.ruta == destino.resolve()
+    assert estado.contenido_cargado == "imprimir('guardar como')"
+    assert estado.cambios_sin_guardar is False
+
+    contenido, mensaje = runtime.guardar_archivo_activo(
+        "imprimir('guardar activo')", estado
+    )
+    assert contenido == "imprimir('guardar activo')"
+    assert mensaje == f"Archivo guardado: {destino.resolve()}"
+    assert destino.read_text(encoding="utf-8") == "imprimir('guardar activo')"
+    assert estado.contenido_cargado == "imprimir('guardar activo')"
+
+    destino.write_text("imprimir('recargado')", encoding="utf-8")
+    contenido, mensaje = runtime.recargar_archivo_activo(estado)
+    assert contenido == "imprimir('recargado')"
+    assert mensaje == f"Archivo cargado: {destino.resolve()}"
+    assert estado.contenido_cargado == "imprimir('recargado')"
+    assert estado.cambios_sin_guardar is False
+
+
+def test_cargar_archivo_desde_arbol_reusa_apertura_y_valida_extension(tmp_path: Path):
+    estado = runtime.GuiFileState()
+    archivo_cobra = tmp_path / "desde_arbol.cobra"
+    archivo_cobra.write_text("imprimir('arbol')", encoding="utf-8")
+    archivo_no_cobra = tmp_path / "nota.txt"
+    archivo_no_cobra.write_text("texto", encoding="utf-8")
+
+    contenido, mensaje = runtime.cargar_archivo_desde_arbol(archivo_cobra, estado)
+
+    assert contenido == "imprimir('arbol')"
+    assert mensaje == f"Archivo cargado: {archivo_cobra.resolve()}"
+    assert estado.ruta == archivo_cobra.resolve()
+    assert estado.contenido_cargado == "imprimir('arbol')"
+
+    try:
+        runtime.cargar_archivo_desde_arbol(archivo_no_cobra, estado)
+    except ValueError as exc:
+        assert "Selecciona un archivo Cobra" in str(exc)
+    else:
+        raise AssertionError("El árbol solo debe cargar archivos .co/.cobra")


### PR DESCRIPTION
### Motivation
- Aclarar y documentar las capacidades actuales del IDLE gráfico (edición, archivo, árbol, ejecución/transpilación, tokens, AST y sugerencias) y cómo arrancarlo desde el entrypoint canónico. 
- Asegurar que la lógica de lectura/escritura de archivos permanezca centralizada en `src/pcobra/gui/runtime.py` y reforzar pruebas que validen los flujos de archivo expuestos por esos helpers.

### Description
- Añadido `docs/gui_idle.md` que documenta arranque (`pcobra.gui.idle.main` / alias `pcobra.gui.app.main`), edición, acciones de archivo (Nuevo, Abrir, Guardar, Guardar como, Recargar), árbol de directorios, ejecución/transpilación, tokens, AST, sugerencias y limitaciones actuales. 
- Modificado `tests/gui/test_runtime_file_helpers.py` para ejecutar los tests dentro de `tmp_path` (fixture autouse) y añadidos casos que cubren explícitamente `Nuevo`, `Abrir`, `Guardar como`, `Guardar`, `Recargar` y carga desde árbol usando los helpers de `src/pcobra/gui/runtime.py`. 
- No se duplicó la lógica de I/O en `src/pcobra/gui/idle.py`; `idle.py` sigue delegando en los helpers de `runtime.py` para lectura/escritura y normalización.

### Testing
- Ejecutado `pytest -q tests/gui/test_runtime_file_helpers.py tests/unit/test_gui_idle.py` después de ajustar los tests; resultado final: las pruebas focalizadas pasaron (`15 passed, 1 warning`).
- Durante la primera ejecución local hubo fallos causados por el sandbox de rutas (tests usando `tmp_path` fuera de la raíz del repo), los tests se ajustaron para correr en `tmp_path` y luego pasaron correctamente.
- Ejecutado `git diff --check` para validar cambios del parche y no se detectaron problemas de diff-check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3586611d70832791f72ee69d210031)