### PR TITLE
Refuerza prechequeo de sugerencias GUI

### DIFF
--- a/docs/gui_idle.md
+++ b/docs/gui_idle.md
@@ -54,9 +54,9 @@ La barra de ejecución permite:
 - **Transpilar:** al activar el switch `Transpilar`, genera código para el target seleccionado en el desplegable.
 - **Tokens:** muestra la tokenización del código actual.
 - **AST:** muestra la representación del árbol sintáctico.
-- **Sugerencias del Libro:** valida primero errores léxicos/sintácticos y, si el motor IA opcional está disponible, añade sugerencias.
+- **Sugerencias del Libro:** valida primero errores léxicos/sintácticos con `runtime.analizar_codigo`, que ejecuta `Lexer` y `Parser` como punto único de tokenización/parseo para la GUI. Solo si ambos pasos terminan sin errores, `runtime.generar_reporte_sugerencias` consulta el motor IA opcional y muestra sugerencias.
 
-Estos flujos se crean desde helpers de `runtime.py`: `crear_handler_ejecucion`, `crear_handler_tokens`, `crear_handler_ast` y `crear_handler_sugerencias`.
+Estos flujos se crean desde helpers de `runtime.py`: `crear_handler_ejecucion`, `crear_handler_tokens`, `crear_handler_ast` y `crear_handler_sugerencias`. Las acciones nuevas que quieran proponer correcciones tipográficas o sugerencias automáticas deben reutilizar `generar_reporte_sugerencias` —o una fachada equivalente que conserve el mismo prechequeo con `Lexer` y `Parser`— en lugar de llamar directamente al motor IA.
 
 ## Limitaciones actuales
 

--- a/tests/gui/test_auto_suggestion_parser_contract.py
+++ b/tests/gui/test_auto_suggestion_parser_contract.py
@@ -97,8 +97,29 @@ def test_recomendaciones_gui_cubren_ejemplos_invalidos_sin_ampliar_parser(
         _parsear(fragmento_invalido)
 
 
-def test_reporte_sugerencias_no_invoca_fachada_si_codigo_no_parsea(monkeypatch) -> None:
-    """La GUI debe cortar antes de llamar a la fachada IA si Parser falla."""
+@pytest.mark.parametrize(
+    ("codigo_invalido", "tipo_fallo"),
+    [
+        pytest.param(
+            'imprimir("hola)',
+            "Lexer",
+            id="corta-si-falla-lexer",
+        ),
+        pytest.param(
+            """
+funcion calcular_total(subtotal, impuesto):
+    retorno subtotal + impuesto
+fin
+""",
+            "Parser",
+            id="corta-si-falla-parser",
+        ),
+    ],
+)
+def test_reporte_sugerencias_no_invoca_motor_ia_si_lexer_o_parser_fallan(
+    monkeypatch, codigo_invalido: str, tipo_fallo: str
+) -> None:
+    """La GUI debe cortar antes de llamar al motor IA si Lexer o Parser fallan."""
 
     monkeypatch.setattr(
         runtime,
@@ -106,22 +127,12 @@ def test_reporte_sugerencias_no_invoca_fachada_si_codigo_no_parsea(monkeypatch) 
         lambda: runtime.MotorIASugerencias(disponible=True),
     )
 
-    codigo_invalido = """
-funcion calcular_total(subtotal, impuesto):
-    retorno subtotal + impuesto
-fin
-"""
+    def fallar_si_se_invoca_motor(_codigo: str) -> list[str]:
+        pytest.fail(f"generar_sugerencias no debe ejecutarse cuando falla {tipo_fallo}")
 
-    from pcobra.ia import analizador_sugerencias
+    monkeypatch.setattr(runtime, "generar_sugerencias", fallar_si_se_invoca_motor)
 
-    with pytest.MonkeyPatch.context() as contexto:
-        llamada_fachada = contexto.setattr(
-            analizador_sugerencias,
-            "generar_sugerencias",
-            pytest.fail,
-        )
-        assert llamada_fachada is None
-        reporte = runtime.generar_reporte_sugerencias(codigo_invalido)
+    reporte = runtime.generar_reporte_sugerencias(codigo_invalido)
 
     assert "Errores léxicos/sintácticos:" in reporte
     assert "Corrige primero los errores anteriores" in reporte


### PR DESCRIPTION
### Motivation

- Asegurar que la generación de sugerencias no invoque el motor IA cuando falla el `Lexer` o el `Parser`, preservando el contrato de validación previa del GUI. 
- Verificar que las reglas del `Libro de Programación` solo propongan fragmentos que realmente parsea el parser vigente. 
- Documentar que `runtime.analizar_codigo` es el punto único de tokenización/parseo en la GUI y que nuevas herramientas deben reutilizar el mismo prechequeo.

### Description

- Amplía `tests/gui/test_auto_suggestion_parser_contract.py` para parametrizar dos casos de fallo (fallo de `Lexer` y fallo de `Parser`) y parchea `runtime.generar_sugerencias` para garantizar que no se ejecute cuando el prechequeo falla. 
- Actualiza `docs/gui_idle.md` para declarar explícitamente que las "Sugerencias del Libro" pasan primero por `runtime.analizar_codigo` (que ejecuta `Lexer` y `Parser`) y que las correcciones tipográficas o nuevas sugerencias deben reutilizar `generar_reporte_sugerencias` o una fachada equivalente que mantenga el mismo prechequeo. 
- No se introdujeron rutas alternativas que llamen directamente al motor IA y se mantiene `runtime.analizar_codigo` como el punto único para tokenizar/parsear en la GUI.

### Testing

- Se ejecutó `pytest tests/gui/test_auto_suggestion_parser_contract.py` y todas las pruebas relevantes pasaron con éxito (resultado: `12 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a361e41a6208327a4f776304d3754ea)