### PR TITLE
Agregar acción GUI "Corrección" y reporte tipográfico no destructivo

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -212,6 +212,9 @@ def main(page: "ft.Page"):
     sugerencias_handler = runtime.crear_handler_sugerencias(
         entrada=entrada, salida=salida, page=page
     )
+    correccion_handler = runtime.crear_handler_correccion_tipografica(
+        entrada=entrada, salida=salida, page=page
+    )
 
     reconstruir_arbol()
     sincronizar_estado_visual()
@@ -249,6 +252,7 @@ def main(page: "ft.Page"):
             runtime.flet_elevated_button(ft, "Tokens", on_click=tokens_handler),
             runtime.flet_elevated_button(ft, "AST", on_click=ast_handler),
             runtime.crear_boton_sugerencias_libro(ft, on_click=sugerencias_handler),
+            runtime.crear_boton_correccion(ft, on_click=correccion_handler),
         ],
         wrap=True,
     )

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -93,6 +93,9 @@ el equipo decide exponer todos los archivos en el árbol.
 SUGERENCIAS_BUTTON_TEXT = "Sugerencias del Libro"
 """Etiqueta homogénea para la acción de sugerencias trazables en las GUIs."""
 
+CORRECCION_BUTTON_TEXT = "Corrección"
+"""Etiqueta para solicitar un reporte de corrección tipográfica sin modificar el editor."""
+
 CANONICAL_SUGGESTION_ENGINE = "agix"
 """Motor opcional canónico para sugerencias de Cobra."""
 
@@ -392,17 +395,29 @@ def flet_elevated_button(ft: Any, *args: Any, **kwargs: Any) -> Any:
     return _flet_attr(ft, "ElevatedButton", "ElevatedButton")(*args, **kwargs)
 
 
-def crear_boton_sugerencias_libro(ft: Any, *, on_click: Any) -> Any:
-    """Crea el botón de sugerencias con estado visual según motor IA."""
+def _crear_boton_motor_ia(ft: Any, texto: str, *, on_click: Any) -> Any:
+    """Crea un botón dependiente del motor IA opcional de sugerencias."""
 
     motor = detectar_motor_ia_sugerencias()
     return flet_elevated_button(
         ft,
-        SUGERENCIAS_BUTTON_TEXT,
+        texto,
         on_click=on_click if motor.disponible else None,
         disabled=not motor.disponible,
         tooltip=motor.tooltip,
     )
+
+
+def crear_boton_sugerencias_libro(ft: Any, *, on_click: Any) -> Any:
+    """Crea el botón de sugerencias con estado visual según motor IA."""
+
+    return _crear_boton_motor_ia(ft, SUGERENCIAS_BUTTON_TEXT, on_click=on_click)
+
+
+def crear_boton_correccion(ft: Any, *, on_click: Any) -> Any:
+    """Crea el botón visible de corrección sin modificar automáticamente el editor."""
+
+    return _crear_boton_motor_ia(ft, CORRECCION_BUTTON_TEXT, on_click=on_click)
 
 
 def flet_text_button(ft: Any, *args: Any, **kwargs: Any) -> Any:
@@ -700,6 +715,123 @@ def _formatear_sugerencias_agrupadas(sugerencias: list[str]) -> str:
     return "\n".join(bloques)
 
 
+
+def _extraer_metadatos_sugerencia(sugerencia: str) -> tuple[str, str]:
+    """Extrae regla y sección del Libro si el motor las incluye en el texto."""
+
+    regla = "regla no especificada"
+    seccion = "sección no especificada"
+    match = re.search(r"\[regla:\s*([^;\]]+)(?:;\s*([^\]]+))?\]", sugerencia)
+    if match:
+        regla = match.group(1).strip()
+        if match.group(2):
+            seccion = match.group(2).strip()
+    else:
+        seccion_match = re.search(r"(§\s*\d+(?:\.\d+)?[^:;\]]*)", sugerencia)
+        if seccion_match:
+            seccion = seccion_match.group(1).strip()
+    return regla, seccion
+
+
+def _ubicacion_aproximada_sugerencia(codigo: str, sugerencia: str) -> str:
+    """Calcula una ubicación aproximada sin alterar el editor."""
+
+    texto = sugerencia.lower()
+    pistas = (
+        ("retorno", ("retornar", "retorno")),
+        ("función", ("funcion ", "func ", "definir ")),
+        ("módulo", ("usar ",)),
+        ("impresión", ("imprimir",)),
+        ("nombre", ("var ", "=",)),
+    )
+    for _nombre, patrones in pistas:
+        if any(patron.strip() in texto for patron in patrones):
+            for numero, linea in enumerate(codigo.splitlines(), start=1):
+                linea_normalizada = linea.lower()
+                if any(patron in linea_normalizada for patron in patrones):
+                    return f"línea {numero}"
+    return "ubicación no disponible"
+
+
+def _limpiar_explicacion_sugerencia(sugerencia: str) -> str:
+    """Elimina metadatos compactos para dejar una explicación legible."""
+
+    return re.sub(r"\s*\[regla:[^\]]+\]\s*$", "", sugerencia).strip() or sugerencia
+
+
+def _formatear_sugerencias_detalladas(codigo: str, sugerencias: list[str]) -> str:
+    """Devuelve una lista agrupada con regla, sección, ubicación y explicación."""
+
+    agrupadas = {clave: [] for clave, _titulo in _CATEGORIAS_SUGERENCIAS}
+    for sugerencia in sugerencias:
+        regla, seccion = _extraer_metadatos_sugerencia(sugerencia)
+        ubicacion = _ubicacion_aproximada_sugerencia(codigo, sugerencia)
+        explicacion = _limpiar_explicacion_sugerencia(sugerencia)
+        item = (
+            f"  - Regla: {regla} | Sección: {seccion} | "
+            f"Ubicación: {ubicacion} | Explicación: {explicacion}"
+        )
+        agrupadas[_categoria_sugerencia(sugerencia)].append(item)
+
+    bloques: list[str] = []
+    for clave, titulo in _CATEGORIAS_SUGERENCIAS:
+        items = agrupadas[clave]
+        cuerpo = "\n".join(items) if items else "  - Sin sugerencias."
+        bloques.append(f"- {titulo}:\n{cuerpo}")
+    return "\n".join(bloques)
+
+def generar_reporte_correccion_tipografica(codigo: str) -> str:
+    """Valida código y genera un reporte de corrección sin editar automáticamente."""
+
+    deps = require_gui_dependencies()
+    try:
+        analizar_codigo(codigo)
+    except Exception as exc:
+        error = formatear_error(
+            exc,
+            lexer_error_type=deps.get("LexerError"),
+            parser_error_type=deps.get("ParserError"),
+        )
+        return (
+            "Errores léxicos/sintácticos:\n"
+            f"- {error}\n\n"
+            "Corrección tipográfica del Libro:\n"
+            "- Corrige primero los errores anteriores para solicitar sugerencias."
+        )
+
+    motor = detectar_motor_ia_sugerencias()
+    if not motor.disponible:
+        return (
+            "Errores léxicos/sintácticos:\n"
+            "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
+            "Corrección tipográfica del Libro:\n"
+            f"- {motor.tooltip}"
+        )
+
+    try:
+        sugerencias = generar_sugerencias(codigo)
+    except ImportError as exc:
+        return (
+            "Errores léxicos/sintácticos:\n"
+            "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
+            "Corrección tipográfica del Libro:\n"
+            f"- No se pudieron generar sugerencias: {exc}. "
+            "Instala la dependencia opcional de sugerencias para activar esta acción."
+        )
+
+    if sugerencias:
+        sugerencias_legibles = _formatear_sugerencias_detalladas(codigo, sugerencias)
+    else:
+        sugerencias_legibles = "- No se recibieron sugerencias."
+    return (
+        "Errores léxicos/sintácticos:\n"
+        "- No se detectaron errores con el Lexer y Parser de Cobra.\n\n"
+        "Corrección tipográfica del Libro:\n"
+        f"{sugerencias_legibles}\n\n"
+        "Nota: el editor no se modifica automáticamente."
+    )
+
+
 def generar_reporte_sugerencias(codigo: str) -> str:
     """Valida código y genera reporte común de sugerencias estilísticas."""
 
@@ -787,6 +919,27 @@ def crear_handler_ast(*, entrada: Any, salida: Any, page: Any) -> Any:
             page.update()
 
     return ast_handler
+
+
+def crear_handler_correccion_tipografica(*, entrada: Any, salida: Any, page: Any) -> Any:
+    """Crea handler para corrección tipográfica validada y no destructiva."""
+
+    def correccion_handler(_e: Any) -> None:
+        deps = require_gui_dependencies()
+        try:
+            salida.value = generar_reporte_correccion_tipografica(
+                normalizar_codigo(entrada.value)
+            )
+        except Exception as exc:
+            salida.value = formatear_error(
+                exc,
+                lexer_error_type=deps.get("LexerError"),
+                parser_error_type=deps.get("ParserError"),
+            )
+        finally:
+            page.update()
+
+    return correccion_handler
 
 
 def crear_handler_sugerencias(*, entrada: Any, salida: Any, page: Any) -> Any:

--- a/tests/gui/test_runtime_correccion_tipografica.py
+++ b/tests/gui/test_runtime_correccion_tipografica.py
@@ -1,0 +1,98 @@
+"""Pruebas del reporte GUI de corrección tipográfica no destructiva."""
+
+from __future__ import annotations
+
+import pytest
+
+from pcobra.gui import runtime
+
+
+@pytest.fixture(autouse=True)
+def _motor_disponible(monkeypatch):
+    monkeypatch.setattr(
+        runtime,
+        "detectar_motor_ia_sugerencias",
+        lambda: runtime.MotorIASugerencias(disponible=True),
+    )
+
+
+def test_correccion_codigo_valido_muestra_sugerencias_detalladas(monkeypatch):
+    monkeypatch.setattr(
+        runtime,
+        "generar_sugerencias",
+        lambda _codigo: [
+            "Usar nombres descriptivos para variables [regla: LP-3.1-NOMBRES-DESCRIPTIVOS; §3.1 Léxico]",
+        ],
+    )
+
+    reporte = runtime.generar_reporte_correccion_tipografica("x = 1\nimprimir(x)")
+
+    assert "- No se detectaron errores con el Lexer y Parser de Cobra." in reporte
+    assert "Corrección tipográfica del Libro:" in reporte
+    assert "Regla: LP-3.1-NOMBRES-DESCRIPTIVOS" in reporte
+    assert "Sección: §3.1 Léxico" in reporte
+    assert "Ubicación: línea 1" in reporte
+    assert "Explicación: Usar nombres descriptivos para variables" in reporte
+    assert "Nota: el editor no se modifica automáticamente." in reporte
+
+
+def test_correccion_codigo_invalido_bloquea_motor_por_parser(monkeypatch):
+    def fallar_si_invoca_motor(_codigo: str) -> list[str]:
+        pytest.fail("No debe invocar el motor IA con código inválido")
+
+    monkeypatch.setattr(runtime, "generar_sugerencias", fallar_si_invoca_motor)
+
+    reporte = runtime.generar_reporte_correccion_tipografica(
+        """
+funcion calcular_total(subtotal, impuesto):
+    retorno subtotal + impuesto
+fin
+"""
+    )
+
+    assert "Errores léxicos/sintácticos:" in reporte
+    assert "Corrige primero los errores anteriores" in reporte
+    assert "Corrección tipográfica del Libro:" in reporte
+
+
+def test_correccion_motor_ia_no_disponible(monkeypatch):
+    monkeypatch.setattr(
+        runtime,
+        "detectar_motor_ia_sugerencias",
+        lambda: runtime.MotorIASugerencias(
+            disponible=False,
+            detalle="Motor IA de pruebas no disponible.",
+        ),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "generar_sugerencias",
+        lambda _codigo: pytest.fail("No debe invocar motor no disponible"),
+    )
+
+    reporte = runtime.generar_reporte_correccion_tipografica("total = 10")
+
+    assert "- No se detectaron errores con el Lexer y Parser de Cobra." in reporte
+    assert "Motor IA de pruebas no disponible." in reporte
+
+
+def test_correccion_formato_de_salida_agrupado(monkeypatch):
+    monkeypatch.setattr(
+        runtime,
+        "generar_sugerencias",
+        lambda _codigo: [
+            "Usar `retorno` como sentencia de salida en funciones [regla: LP-3.3-RETORNO-CANONICO; §3.3 Sentencias]",
+            "Usar módulos con `usar \"modulo\"` y llamadas planas [regla: LP-3.6-USAR-SIN-ALIAS; §3.6 Módulos]",
+        ],
+    )
+
+    reporte = runtime.generar_reporte_correccion_tipografica(
+        'usar "numero"\nfunc saludar(nombre):\n    retorno nombre\nfin\n'
+    )
+
+    assert "- Estilo:" in reporte
+    assert "- Forma canónica:" in reporte
+    assert "Regla: LP-3.6-USAR-SIN-ALIAS" in reporte
+    assert "Ubicación: línea 1" in reporte
+    assert "Regla: LP-3.3-RETORNO-CANONICO" in reporte
+    assert "Ubicación: línea 3" in reporte


### PR DESCRIPTION
### Motivation
- Proveer una acción explícita en la UI para solicitar un reporte de corrección tipográfica sin modificar el editor automáticamente. 
- Reutilizar la validación existente con `analizar_codigo` antes de invocar el motor de sugerencias IA y mantener la fachada `pcobra.ia.analizador_sugerencias` como único punto de entrada IA desde la GUI. 
- Mostrar sugerencias agrupadas con metadatos útiles (regla/sección del Libro, ubicación aproximada y explicación) para facilitar revisión manual.

### Description
- Añadido botón visible `Corrección` en la barra de ejecución del IDLE y handler asociado en `src/pcobra/gui/idle.py` que usa `crear_handler_correccion_tipografica` del runtime. 
- Implementado `generar_reporte_correccion_tipografica(codigo: str)` en `src/pcobra/gui/runtime.py` que valida con `analizar_codigo`, consulta `detectar_motor_ia_sugerencias`, invoca la fachada `generar_sugerencias` y formatea una salida detallada agrupada sin aplicar cambios al editor. 
- Añadidos helpers internos en `src/pcobra/gui/runtime.py` para extraer metadatos (`_extraer_metadatos_sugerencia`), estimar ubicación (`_ubicacion_aproximada_sugerencia`) y formatear explicaciones (`_formatear_sugerencias_detalladas`), y construido `crear_boton_correccion` reutilizando la comprobación de disponibilidad del motor IA. 
- Nueva suite de pruebas `tests/gui/test_runtime_correccion_tipografica.py` que cubre código válido con sugerencias, código inválido bloqueado por el parser, motor IA no disponible y formato de salida agrupado.

### Testing
- Ejecutado `pytest -q tests/gui` y todas las pruebas GUI pasaron localmente (`27 passed, 1 warning`). 
- Ejecutado `pytest -q tests/gui/test_runtime_correccion_tipografica.py tests/gui/test_auto_suggestion_parser_contract.py` durante el desarrollo y los tests relevantes pasaron. 
- Ejecutado `python -m ruff check src/pcobra/gui/idle.py src/pcobra/gui/runtime.py tests/gui/test_runtime_correccion_tipografica.py` sin advertencias ni errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3652665ac08327b73597db2befcd8a)