### PR TITLE
Reforzar contrato de backends públicos (python, javascript, rust)

### DIFF
--- a/src/pcobra/cobra/gui/deps.py
+++ b/src/pcobra/cobra/gui/deps.py
@@ -10,11 +10,19 @@ Expone únicamente:
 
 from __future__ import annotations
 
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 from pcobra.cobra.core import Lexer, LexerError, Parser, ParserError
 from pcobra.cobra.transpilers.registry import get_transpilers
 from pcobra.cobra.transpilers.target_utils import target_cli_choices
 from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
 from pcobra.cobra.core.interpreter import InterpretadorCobra
+
+if tuple(OFFICIAL_TARGETS) != PUBLIC_BACKENDS:
+    raise RuntimeError(
+        "Contrato público inválido en GUI deps: OFFICIAL_TARGETS debe coincidir "
+        f"exactamente con PUBLIC_BACKENDS. official={tuple(OFFICIAL_TARGETS)}; "
+        f"public={PUBLIC_BACKENDS}"
+    )
 
 __all__ = [
     "Lexer",
@@ -26,4 +34,3 @@ __all__ = [
     "target_cli_choices",
     "OFFICIAL_TARGETS",
 ]
-

--- a/src/pcobra/cobra/transpilers/targets.py
+++ b/src/pcobra/cobra/transpilers/targets.py
@@ -36,3 +36,10 @@ if PUBLIC_BACKENDS != EXPECTED_CANONICAL_TARGETS:
         "PUBLIC_BACKENDS debe mantener exactamente los nombres públicos canónicos en orden. "
         + _canonical_diff_report(current=PUBLIC_BACKENDS)
     )
+
+
+if tuple(OFFICIAL_TARGETS) != PUBLIC_BACKENDS:
+    raise RuntimeError(
+        "OFFICIAL_TARGETS debe coincidir exactamente con PUBLIC_BACKENDS. "
+        + _canonical_diff_report(current=tuple(OFFICIAL_TARGETS))
+    )

--- a/tests/cli/test_public_v2_commands_contract.py
+++ b/tests/cli/test_public_v2_commands_contract.py
@@ -5,14 +5,12 @@ import argparse
 from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 from pcobra.cobra.cli.cli import AppConfig, CommandRegistry
 
-
 EXPECTED_PUBLIC_V2_COMMANDS = {"run", "build", "test", "mod", "repl"}
 
 
 def test_app_config_v2_routes_include_repl_command_v2() -> None:
     routes = {
-        (route.module_path, route.class_name)
-        for route in AppConfig.V2_COMMAND_ROUTES
+        (route.module_path, route.class_name) for route in AppConfig.V2_COMMAND_ROUTES
     }
 
     assert (
@@ -45,3 +43,24 @@ def test_public_v2_subcommands_match_contract_exactly() -> None:
 
 def test_cli_public_backend_policy_is_exact() -> None:
     assert PUBLIC_BACKENDS == ("python", "javascript", "rust")
+
+
+def test_public_backend_policy_excludes_retired_targets() -> None:
+    retired_targets = {"go", "java", "cpp", "asm", "wasm", "brainfuck"}
+
+    assert set(PUBLIC_BACKENDS).isdisjoint(retired_targets)
+
+
+def test_public_v2_commands_do_not_register_retired_backend_names() -> None:
+    registry = CommandRegistry()
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+
+    commands = registry.register_base_commands(
+        subparsers,
+        ui="v2",
+        profile="public",
+    )
+
+    retired_targets = {"go", "java", "cpp", "asm", "wasm", "brainfuck"}
+    assert retired_targets.isdisjoint(commands)

--- a/tests/test_backend_startup_policy.py
+++ b/tests/test_backend_startup_policy.py
@@ -21,7 +21,9 @@ EXPECTED_PUBLIC_TARGETS = ("python", "javascript", "rust")
 
 @pytest.mark.parity_contract
 @pytest.mark.parametrize("module_name", RETIRED_TRANSPILER_MODULES)
-def test_runtime_startup_policy_does_not_import_legacy_transpilers(module_name: str) -> None:
+def test_runtime_startup_policy_does_not_import_legacy_transpilers(
+    module_name: str,
+) -> None:
     before = set(sys.modules)
 
     # Startup normal de política contractual (sin resolver transpilers legacy).
@@ -31,10 +33,12 @@ def test_runtime_startup_policy_does_not_import_legacy_transpilers(module_name: 
     after = set(sys.modules)
     loaded_during_startup = after - before
 
-    assert module_name not in after, f"{module_name} no debe quedar cargado tras startup"
-    assert module_name not in loaded_during_startup, (
-        f"{module_name} fue cargado durante startup/runtime, violando política pública"
-    )
+    assert (
+        module_name not in after
+    ), f"{module_name} no debe quedar cargado tras startup"
+    assert (
+        module_name not in loaded_during_startup
+    ), f"{module_name} fue cargado durante startup/runtime, violando política pública"
 
 
 @pytest.mark.parity_contract
@@ -49,14 +53,18 @@ def test_normal_boot_paths_do_not_import_legacy_transpilers(module_name: str) ->
     after = set(sys.modules)
     loaded_during_boot = after - before
 
-    assert module_name not in after, f"{module_name} no debe quedar cargado tras boot normal"
-    assert module_name not in loaded_during_boot, (
-        f"{module_name} fue cargado durante boot normal, violando política pública"
-    )
+    assert (
+        module_name not in after
+    ), f"{module_name} no debe quedar cargado tras boot normal"
+    assert (
+        module_name not in loaded_during_boot
+    ), f"{module_name} fue cargado durante boot normal, violando política pública"
 
 
 @pytest.mark.parity_contract
-def test_import_pcobra_exposes_lazy_public_api_without_legacy_transpiler_modules() -> None:
+def test_import_pcobra_exposes_lazy_public_api_without_legacy_transpiler_modules() -> (
+    None
+):
     before = set(sys.modules)
 
     package = importlib.import_module("pcobra")
@@ -82,7 +90,9 @@ def test_import_pcobra_exposes_lazy_public_api_without_legacy_transpiler_modules
     "base_module",
     ("pcobra.__main__", "pcobra.cli", "pcobra.cobra.cli.bootstrap"),
 )
-def test_base_command_import_paths_do_not_load_legacy_transpilers(base_module: str) -> None:
+def test_base_command_import_paths_do_not_load_legacy_transpilers(
+    base_module: str,
+) -> None:
     before = set(sys.modules)
 
     importlib.import_module(base_module)
@@ -114,7 +124,9 @@ def test_public_targets_contract_is_exact_in_config_and_architecture() -> None:
 
 
 @pytest.mark.parity_contract
-@pytest.mark.parametrize("invalid_target", ("go", "java", "cpp", "asm", "wasm", "brainfuck"))
+@pytest.mark.parametrize(
+    "invalid_target", ("go", "java", "cpp", "asm", "wasm", "brainfuck")
+)
 def test_non_official_target_fails_with_clear_policy_error(invalid_target: str) -> None:
     assert_public_command_uses_only_public_backends = importlib.import_module(
         "pcobra.cobra.architecture.backend_policy"
@@ -180,3 +192,73 @@ def test_legacy_syntax_validators_are_not_imported_by_public_runtime_routes() ->
     importlib.import_module("pcobra.cobra.cli.commands.qa_validar_cmd")
 
     assert legacy_module not in sys.modules
+
+
+@pytest.mark.parity_contract
+def test_transpiler_and_gui_official_targets_match_public_backends_exactly() -> None:
+    public_backends = importlib.import_module(
+        "pcobra.cobra.architecture.backend_policy"
+    ).PUBLIC_BACKENDS
+    transpiler_targets = importlib.import_module(
+        "pcobra.cobra.transpilers.targets"
+    ).OFFICIAL_TARGETS
+    gui_deps_targets = importlib.import_module("pcobra.cobra.gui.deps").OFFICIAL_TARGETS
+
+    assert public_backends == EXPECTED_PUBLIC_TARGETS
+    assert tuple(transpiler_targets) == public_backends
+    assert tuple(gui_deps_targets) == public_backends
+
+
+@pytest.mark.parity_contract
+def test_gui_target_choices_ignores_retired_registered_transpilers() -> None:
+    gui_runtime = importlib.import_module("pcobra.gui.runtime")
+    public_backends = importlib.import_module(
+        "pcobra.cobra.architecture.backend_policy"
+    ).PUBLIC_BACKENDS
+    retired_targets = ("go", "java", "cpp", "asm", "wasm", "brainfuck")
+
+    gui_runtime.require_gui_dependencies.cache_clear()
+    original_require_gui_dependencies = gui_runtime.require_gui_dependencies
+    try:
+        gui_runtime.require_gui_dependencies = lambda: {
+            "OFFICIAL_TARGETS": public_backends,
+            "TRANSPILERS": {
+                **{target: object() for target in public_backends},
+                **{target: object() for target in retired_targets},
+            },
+            "target_cli_choices": lambda targets: tuple(
+                target for target in public_backends if target in targets
+            ),
+        }
+
+        assert gui_runtime.gui_target_choices() == public_backends
+    finally:
+        gui_runtime.require_gui_dependencies = original_require_gui_dependencies
+        importlib.reload(gui_runtime)
+
+
+@pytest.mark.parity_contract
+def test_gui_target_choices_rejects_official_targets_different_from_public_backends() -> (
+    None
+):
+    gui_runtime = importlib.import_module("pcobra.gui.runtime")
+    public_backends = importlib.import_module(
+        "pcobra.cobra.architecture.backend_policy"
+    ).PUBLIC_BACKENDS
+
+    gui_runtime.require_gui_dependencies.cache_clear()
+    original_require_gui_dependencies = gui_runtime.require_gui_dependencies
+    try:
+        gui_runtime.require_gui_dependencies = lambda: {
+            "OFFICIAL_TARGETS": public_backends + ("go",),
+            "TRANSPILERS": {target: object() for target in public_backends + ("go",)},
+            "target_cli_choices": lambda targets: tuple(targets),
+        }
+
+        with pytest.raises(
+            RuntimeError, match="OFFICIAL_TARGETS debe coincidir con PUBLIC_BACKENDS"
+        ):
+            gui_runtime.gui_target_choices()
+    finally:
+        gui_runtime.require_gui_dependencies = original_require_gui_dependencies
+        importlib.reload(gui_runtime)

--- a/tests/unit/test_gui_app.py
+++ b/tests/unit/test_gui_app.py
@@ -30,9 +30,11 @@ def _fake_flet():
             self.disabled = kwargs.get("disabled", False)
 
     class ElevatedButton:
-        def __init__(self, text, on_click=None):
+        def __init__(self, text, on_click=None, **kwargs):
             self.text = text
             self.on_click = on_click
+            self.disabled = kwargs.get("disabled", False)
+            self.tooltip = kwargs.get("tooltip")
 
     class TextButton(ElevatedButton):
         pass
@@ -316,3 +318,48 @@ def test_crear_arbol_directorios_carga_hijos_bajo_demanda_y_filtra(tmp_path):
     hijo = subdir.controls[0]
     assert isinstance(hijo, ft.ExpansionTile)
     assert hijo.controls == []
+
+
+def test_gui_runtime_target_choices_usa_public_backends_y_filtra_retirados(monkeypatch):
+    from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+    from pcobra.gui import runtime
+
+    retired_targets = ("go", "java", "cpp", "asm", "wasm", "brainfuck")
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {
+            "OFFICIAL_TARGETS": PUBLIC_BACKENDS,
+            "TRANSPILERS": {
+                **{target: object() for target in PUBLIC_BACKENDS},
+                **{target: object() for target in retired_targets},
+            },
+            "target_cli_choices": lambda targets: tuple(
+                target for target in PUBLIC_BACKENDS if target in targets
+            ),
+        },
+    )
+
+    assert runtime.gui_target_choices() == PUBLIC_BACKENDS
+
+
+def test_gui_runtime_target_choices_rechaza_official_targets_con_legacy(monkeypatch):
+    import pytest
+
+    from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+    from pcobra.gui import runtime
+
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {
+            "OFFICIAL_TARGETS": PUBLIC_BACKENDS + ("go",),
+            "TRANSPILERS": {target: object() for target in PUBLIC_BACKENDS + ("go",)},
+            "target_cli_choices": tuple,
+        },
+    )
+
+    with pytest.raises(
+        RuntimeError, match="OFFICIAL_TARGETS debe coincidir con PUBLIC_BACKENDS"
+    ):
+        runtime.gui_target_choices()


### PR DESCRIPTION
### Motivation
- Garantizar que la superficie pública solo exponga los tres backends oficiales `("python", "javascript", "rust")` y evitar filtrado accidental de targets retirados.
- Evitar que listas duplicadas o configuraciones internas desalineadas (p. ej. `OFFICIAL_TARGETS`) deriven en una GUI o CLI que muestre backends legacy como `go`, `java`, `cpp`, `asm`, `wasm` u otros.
- Añadir pruebas que bloqueen regresiones en la política de inicio y en las rutas públicas/GUI para mantener el contrato estable.

### Description
- Se añadió una comprobación en `src/pcobra/cobra/transpilers/targets.py` que falla el import si `OFFICIAL_TARGETS` no coincide exactamente con `PUBLIC_BACKENDS`.
- Se añadió la misma validación en `src/pcobra/cobra/gui/deps.py` para asegurar que las dependencias de la GUI no expongan una lista oficial distinta de `PUBLIC_BACKENDS`.
- Se añadieron y reforzaron pruebas en `tests/test_backend_startup_policy.py`, `tests/cli/test_public_v2_commands_contract.py` y `tests/unit/test_gui_app.py` para verificar que `PUBLIC_BACKENDS` es exactamente `("python", "javascript", "rust")`, que `gui_target_choices()` obtiene targets desde `PUBLIC_BACKENDS` y filtra targets retirados, y que comandos públicos v2 no registran nombres retirados.
- Se actualizó el doble de `flet` en `tests/unit/test_gui_app.py` para aceptar los kwargs (`disabled`, `tooltip`) usados por el runtime y así permitir las pruebas GUI sin romper la señalización de disponibilidad del motor IA.

### Testing
- Se ejecutaron las pruebas afectadas con `python -m pytest tests/test_backend_startup_policy.py tests/cli/test_public_v2_commands_contract.py tests/unit/test_gui_app.py` y todas las pruebas pasaron (40 passed, 1 warning).
- Se ejecutó `git diff --check` y se arregló el formato/EOF para pasar la verificación, y se ejecutó `black` sobre los archivos modificados (Black completó con una advertencia de entorno sobre la comprobación AST pero reformateó correctamente).
- Se validó que los cambios introducen los errores de contrato esperados al desalinear `OFFICIAL_TARGETS` en entornos de prueba (las nuevas pruebas cubren estas rutas y fallarán si se rompe el contrato).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3655f38ddc8327b5026415eeaccf04)