### PR TITLE
docs: document GUI / IDLE behavior

### DIFF
--- a/docs/gui_idle.md
+++ b/docs/gui_idle.md
@@ -1,6 +1,6 @@
-# Capacidades actuales del IDLE gráfico
+# GUI / IDLE
 
-El IDLE gráfico de pCobra vive en `src/pcobra/gui/idle.py` y reutiliza los helpers canónicos de `src/pcobra/gui/runtime.py` para mantener una sola implementación de la lógica de archivos, árbol, ejecución e inspección.
+El IDLE gráfico de pCobra vive en `src/pcobra/gui/idle.py` y reutiliza los helpers canónicos de `src/pcobra/gui/runtime.py` para mantener una sola implementación de la lógica de archivos, árbol, ejecución, transpilación, tokens, AST e inspección.
 
 ## Arranque
 
@@ -24,42 +24,48 @@ from pcobra.gui.app import main
 
 El alias `pcobra.gui.app.main` delega en el IDLE canónico y no debe introducir una segunda lógica de archivo ni handlers alternativos para las mismas acciones.
 
-## Edición y estado de archivo
+## Flujo de análisis y acciones
 
-El editor permite modificar código Cobra de forma interactiva. La cabecera muestra el archivo activo o `Archivo nuevo (sin guardar)`, y añade un asterisco cuando el contenido del editor difiere del contenido cargado desde disco. La comparación de cambios se centraliza en `runtime.marcar_cambios_editor`.
+El flujo funcional de la interfaz es:
 
-## Acciones de archivo
-
-La barra de archivo expone estas acciones:
-
-- **Nuevo:** reinicia el estado del editor con un archivo en memoria sin ruta activa mediante `runtime.crear_archivo_nuevo_en_editor`.
-- **Abrir:** carga la ruta indicada en el campo `Ruta` mediante `runtime.abrir_archivo_desde_ruta`.
-- **Guardar:** escribe el archivo activo con `runtime.guardar_archivo_activo`; si todavía no existe ruta activa, redirige al flujo de **Guardar como**.
-- **Guardar como:** escribe el contenido del editor en la ruta indicada mediante `runtime.guardar_archivo_como`.
-- **Recargar:** vuelve a leer desde disco el archivo activo mediante `runtime.recargar_archivo_activo`.
-
-Toda lectura, escritura y normalización de rutas se mantiene en `src/pcobra/gui/runtime.py`. `src/pcobra/gui/idle.py` solo coordina eventos Flet, estado visual y mensajes.
-
-## Árbol de directorios
-
-El panel lateral muestra un árbol de directorios construido con `runtime.crear_arbol_directorios`. La raíz inicial es el directorio de trabajo actual y puede cambiarse desde el campo `Raíz del árbol` con el botón **Establecer raíz**.
-
-El árbol carga subdirectorios bajo demanda al expandirlos. Al seleccionar un archivo Cobra visible, el IDLE llama a `runtime.cargar_archivo_desde_arbol`, que valida la extensión y reutiliza el mismo flujo de apertura de archivos.
-
-## Ejecución, transpilación, tokens, AST y sugerencias
+1. **Editor Cobra:** el usuario escribe o carga código Cobra en el editor principal.
+2. **Lexer:** antes de mostrar tokens, AST, sugerencias o ejecutar acciones que necesitan análisis, el contenido se tokeniza con el lexer del proyecto.
+3. **Parser:** los tokens pasan por el parser para construir la representación sintáctica que consumen las acciones posteriores.
+4. **Ejecución, transpilación o sugerencias:** con el código validado por el lexer y el parser, la GUI puede interpretar el programa, transpilarlo a un backend público o pedir sugerencias al motor IA opcional.
 
 La barra de ejecución permite:
 
 - **Ejecutar:** interpreta el código del editor con el runtime Cobra compartido.
-- **Transpilar:** al activar el switch `Transpilar`, genera código para el target seleccionado en el desplegable.
+- **Transpilar:** al activar el switch `Transpilar`, genera código únicamente para los backends públicos disponibles: `python`, `javascript` y `rust`.
 - **Tokens:** muestra la tokenización del código actual.
 - **AST:** muestra la representación del árbol sintáctico.
 - **Sugerencias del Libro:** valida primero errores léxicos/sintácticos con `runtime.analizar_codigo`, que ejecuta `Lexer` y `Parser` como punto único de tokenización/parseo para la GUI. Solo si ambos pasos terminan sin errores, `runtime.generar_reporte_sugerencias` consulta el motor IA opcional y muestra sugerencias.
 
 Estos flujos se crean desde helpers de `runtime.py`: `crear_handler_ejecucion`, `crear_handler_tokens`, `crear_handler_ast` y `crear_handler_sugerencias`. Las acciones nuevas que quieran proponer correcciones tipográficas o sugerencias automáticas deben reutilizar `generar_reporte_sugerencias` —o una fachada equivalente que conserve el mismo prechequeo con `Lexer` y `Parser`— en lugar de llamar directamente al motor IA.
 
-## Limitaciones actuales
+## Edición y estado de archivo
 
-- El árbol de directorios muestra directorios y archivos Cobra con extensión `.co` o `.cobra` por defecto; otros archivos quedan ocultos salvo que se active una configuración interna futura para mostrar todo.
-- Flet es una dependencia opcional de la GUI. Importar módulos CLI no debe requerir Flet; abrir el IDLE sí requiere instalarlo.
-- Las sugerencias dependen del motor IA declarado por el proyecto (`agix`). Si la dependencia opcional no está disponible, el botón aparece deshabilitado o informa el motivo.
+El editor permite modificar código Cobra de forma interactiva. La cabecera muestra el archivo activo o `Archivo nuevo (sin guardar)`, y añade un asterisco cuando el contenido del editor difiere del contenido cargado desde disco. La comparación de cambios se centraliza en `runtime.marcar_cambios_editor` para reflejar el estado de cambios sin guardar de manera consistente.
+
+## Acciones de archivo y guardado
+
+La barra de archivo expone estas acciones:
+
+- **Nuevo:** reinicia el estado del editor con un archivo en memoria sin ruta activa mediante `runtime.crear_archivo_nuevo_en_editor`.
+- **Abrir:** carga la ruta indicada en el campo `Ruta` mediante `runtime.abrir_archivo_desde_ruta`.
+- **Guardar:** escribe el contenido del editor sobre el archivo activo con `runtime.guardar_archivo_activo`; si todavía no existe ruta activa, redirige al flujo de **Guardar como**.
+- **Guardar como:** escribe el contenido del editor en la ruta indicada mediante `runtime.guardar_archivo_como` y actualiza esa ruta como archivo activo.
+- **Recargar:** vuelve a leer desde disco el archivo activo mediante `runtime.recargar_archivo_activo`.
+
+Todas las lecturas y escrituras de archivos de texto Cobra se tratan como UTF-8. Si hay cambios sin guardar, la interfaz conserva el indicador visual hasta que el contenido del editor coincide de nuevo con el contenido persistido. Toda lectura, escritura y normalización de rutas se mantiene en `src/pcobra/gui/runtime.py`; `src/pcobra/gui/idle.py` solo coordina eventos Flet, estado visual y mensajes.
+
+## Árbol de directorios
+
+El panel lateral muestra un árbol de directorios construido con `runtime.crear_arbol_directorios`. La raíz inicial es el directorio de trabajo actual y puede cambiarse desde el campo `Raíz del árbol` con el botón **Establecer raíz**; por tanto, la raíz es editable desde la propia GUI.
+
+El árbol lista carpetas y archivos Cobra con extensión `.co` o `.cobra`. Los subdirectorios se cargan bajo demanda al expandirlos, y los archivos no Cobra quedan ocultos salvo que se active una configuración interna futura para mostrar todo. Al seleccionar un archivo Cobra visible, el IDLE llama a `runtime.cargar_archivo_desde_arbol`, valida la extensión y reutiliza el mismo flujo de apertura de archivos para cargar su contenido en el editor.
+
+## Dependencias opcionales y degradación
+
+- **Flet:** Flet es una dependencia opcional de la GUI. Importar módulos CLI no debe requerir Flet; abrir el IDLE sí requiere instalarlo. Si Flet no está disponible, la aplicación CLI debe poder seguir funcionando y el intento de iniciar la GUI debe informar la dependencia faltante en lugar de romper flujos no gráficos.
+- **Motor IA de sugerencias:** las sugerencias dependen del motor IA declarado por el proyecto (`agix`). Si la dependencia opcional no está disponible, el botón de sugerencias aparece deshabilitado o muestra el motivo por el que no se pueden generar recomendaciones. La ejecución, los tokens, el AST, la transpilación y las acciones de archivo no deben depender de ese motor IA.


### PR DESCRIPTION
### Motivation

- Documentar de forma explícita el flujo funcional de la GUI/IDLE desde el editor Cobra hasta el `Lexer`, `Parser` y las acciones posteriores. 
- Aclarar los límites de la transpilación desde la GUI y el comportamiento del árbol, guardado y estado de cambios sin guardar. 
- Explicar la degradación cuando faltan dependencias opcionales como `Flet` o el motor IA de sugerencias.

### Description

- Actualicé `docs/gui_idle.md` y lo reorganicé como sección `GUI / IDLE` describiendo el arranque desde CLI (`cobra gui`) y el entrypoint `from pcobra.gui.idle import main`.
- Añadí la sección `Flujo de análisis y acciones` que detalla el recorrido: `Editor Cobra` → `Lexer` → `Parser` → `Ejecución/Transpilación/Sugerencias`, e indiqué los handlers relevantes como `runtime.analizar_codigo`, `runtime.generar_reporte_sugerencias`, `crear_handler_ejecucion`, `crear_handler_tokens`, `crear_handler_ast` y `crear_handler_sugerencias`.
- Documenté que la transpilación desde la GUI solo genera código para los backends públicos `python`, `javascript` y `rust` y que el árbol lista carpetas y archivos con extensiones `.co` y `.cobra` mediante `runtime.crear_arbol_directorios`.
- Añadí detalles sobre edición y guardado: indicadores de archivo activo y cambios sin guardar mediante `runtime.marcar_cambios_editor`, flujo de `Guardar`/`Guardar como`, y que todas las lecturas/escrituras de archivos Cobra usan codificación `UTF-8`.
- Especificado el comportamiento cuando faltan dependencias opcionales: `Flet` (degradación informativa al intentar abrir la GUI) y el motor IA `agix` (botón de sugerencias deshabilitado con mensaje explicativo).

### Testing

- Ejecuté `git diff --check` para validar el diff y no se reportaron errores, prueba concluida con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a365b091e808327874cc8b24c2a9d59)