### PR TITLE
Unificar flujos de "Guardar como" en la GUI

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -19,6 +19,9 @@ def main(page: "ft.Page"):
     entrada = runtime.crear_editor_codigo(ft)
     salida = runtime.crear_salida_seleccionable(ft)
     estado_archivo = runtime.flet_text(ft, value=runtime.crear_titulo_archivo(estado))
+    # Flujo canónico del IDLE: el campo Ruta es la fuente visible para abrir y
+    # para Guardar como. ``runtime.crear_handler_guardar_como`` queda reservado
+    # como helper FilePicker para integraciones alternativas de Flet.
     ruta_input = runtime.flet_text_field(ft, label="Ruta", value="", expand=True)
     raiz_input = runtime.flet_text_field(
         ft, label="Raíz del árbol", value=str(directorio_actual), expand=True
@@ -176,6 +179,7 @@ def main(page: "ft.Page"):
         actualizar_pagina()
 
     def guardar_como_handler(_e):
+        """Guarda usando el campo Ruta, flujo canónico del IDLE principal."""
         if not ruta_input.value:
             salida.value = "Indica una ruta de destino en el campo Ruta."
             page.update()

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -599,16 +599,15 @@ def crear_handler_ejecucion(
 def _guardar_archivo(
     page: Any, entrada: Any, estado_archivo: GuiFileState, ruta: Path
 ) -> None:
-    """Guarda el contenido del editor en la ruta especificada."""
+    """Guarda el editor usando la misma lógica y mensajes de ``Guardar como``."""
+    flet_runtime = require_flet()
     try:
-        guardar_archivo_en_estado(ruta, entrada.value, estado_archivo)
+        _contenido, mensaje = guardar_archivo_como(ruta, entrada.value, estado_archivo)
         page.snack_bar.open = True
-        page.snack_bar.content = flet_text(
-            require_flet(), f"Archivo guardado en {ruta}"
-        )
+        page.snack_bar.content = flet_text(flet_runtime, mensaje)
     except Exception as exc:
         page.snack_bar.open = True
-        page.snack_bar.content = flet_text(require_flet(), f"Error al guardar: {exc}")
+        page.snack_bar.content = flet_text(flet_runtime, f"Error al guardar: {exc}")
     finally:
         page.update()
 
@@ -639,7 +638,13 @@ def crear_handler_guardar_como(
     estado_archivo: GuiFileState,
     page: Any,
 ) -> Any:
-    """Crea el handler para guardar el archivo con un nuevo nombre/ruta."""
+    """Crea un helper de ``Guardar como`` basado en ``FilePicker``.
+
+    El flujo canónico del IDLE principal conserva el campo ``Ruta`` para que
+    abrir, guardar como y la ruta activa compartan una única entrada visible.
+    Este helper queda disponible para integraciones GUI alternativas que
+    prefieran delegar la selección de destino al diálogo nativo de Flet.
+    """
 
     def guardar_como_handler(_e: Any) -> None:
         flet_runtime = require_flet()
@@ -715,7 +720,6 @@ def _formatear_sugerencias_agrupadas(sugerencias: list[str]) -> str:
     return "\n".join(bloques)
 
 
-
 def _extraer_metadatos_sugerencia(sugerencia: str) -> tuple[str, str]:
     """Extrae regla y sección del Libro si el motor las incluye en el texto."""
 
@@ -742,7 +746,13 @@ def _ubicacion_aproximada_sugerencia(codigo: str, sugerencia: str) -> str:
         ("función", ("funcion ", "func ", "definir ")),
         ("módulo", ("usar ",)),
         ("impresión", ("imprimir",)),
-        ("nombre", ("var ", "=",)),
+        (
+            "nombre",
+            (
+                "var ",
+                "=",
+            ),
+        ),
     )
     for _nombre, patrones in pistas:
         if any(patron.strip() in texto for patron in patrones):
@@ -779,6 +789,7 @@ def _formatear_sugerencias_detalladas(codigo: str, sugerencias: list[str]) -> st
         cuerpo = "\n".join(items) if items else "  - Sin sugerencias."
         bloques.append(f"- {titulo}:\n{cuerpo}")
     return "\n".join(bloques)
+
 
 def generar_reporte_correccion_tipografica(codigo: str) -> str:
     """Valida código y genera un reporte de corrección sin editar automáticamente."""
@@ -921,7 +932,9 @@ def crear_handler_ast(*, entrada: Any, salida: Any, page: Any) -> Any:
     return ast_handler
 
 
-def crear_handler_correccion_tipografica(*, entrada: Any, salida: Any, page: Any) -> Any:
+def crear_handler_correccion_tipografica(
+    *, entrada: Any, salida: Any, page: Any
+) -> Any:
     """Crea handler para corrección tipográfica validada y no destructiva."""
 
     def correccion_handler(_e: Any) -> None:

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -137,6 +137,7 @@ def test_listar_directorio_cobra_opcion_interna_muestra_todos_los_archivos(
         "script.py",
     ]
 
+
 def test_normalizar_codigo_admite_none_y_texto() -> None:
     assert runtime.normalizar_codigo(None) == ""
     assert runtime.normalizar_codigo("imprimir('x')") == "imprimir('x')"
@@ -960,3 +961,112 @@ def test_crear_handler_sugerencias_agix_es_alias_deprecado_interno(
     assert llamadas == [(entrada, salida, page, None)]
     assert salida.value == "reporte común"
     assert page.updated is True
+
+
+def test_guardar_como_por_ruta_y_filepicker_actualizan_estado_igual(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    destino_ruta = tmp_path / "desde_ruta.cobra"
+    destino_picker = tmp_path / "desde_picker.cobra"
+    codigo = "imprimir('mismo')"
+
+    estado_ruta = runtime.GuiFileState(cambios_sin_guardar=True)
+    contenido, mensaje = runtime.guardar_archivo_como(destino_ruta, codigo, estado_ruta)
+
+    picker_creados = []
+
+    class Text:
+        def __init__(self, value="", **_kwargs):
+            self.value = value
+
+    class FilePicker:
+        def __init__(self, on_result=None):
+            self.on_result = on_result
+            self.save_file_args = None
+            picker_creados.append(self)
+
+        def save_file(self, **kwargs):
+            self.save_file_args = kwargs
+
+    flet_runtime = SimpleNamespace(Text=Text, FilePicker=FilePicker)
+    monkeypatch.setattr(runtime, "require_flet", lambda: flet_runtime)
+
+    estado_picker = runtime.GuiFileState(cambios_sin_guardar=True)
+    entrada = SimpleNamespace(value=codigo)
+    page = SimpleNamespace(
+        overlay=[],
+        snack_bar=SimpleNamespace(open=False, content=None),
+        update=lambda: None,
+    )
+
+    handler = runtime.crear_handler_guardar_como(
+        entrada=entrada, estado_archivo=estado_picker, page=page
+    )
+    handler(None)
+    assert page.overlay == picker_creados
+    picker_creados[0].on_result(SimpleNamespace(path=str(destino_picker)))
+
+    assert contenido == codigo
+    assert destino_ruta.read_text(encoding="utf-8") == codigo
+    assert destino_picker.read_text(encoding="utf-8") == codigo
+    assert estado_ruta.ruta == destino_ruta.resolve()
+    assert estado_picker.ruta == destino_picker.resolve()
+    assert estado_ruta.contenido_cargado == estado_picker.contenido_cargado == codigo
+    assert estado_ruta.cambios_sin_guardar is estado_picker.cambios_sin_guardar is False
+    assert mensaje == f"Archivo guardado: {destino_ruta.resolve()}"
+    assert page.snack_bar.open is True
+    assert (
+        page.snack_bar.content.value == f"Archivo guardado: {destino_picker.resolve()}"
+    )
+
+
+def test_guardar_como_filepicker_usa_mensaje_de_exito_compartido(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    destino = tmp_path / "mensaje.cobra"
+
+    class Text:
+        def __init__(self, value="", **_kwargs):
+            self.value = value
+
+    class FilePicker:
+        def __init__(self, on_result=None):
+            self.on_result = on_result
+
+        def save_file(self, **_kwargs):
+            pass
+
+    picker = None
+
+    class CapturingFilePicker(FilePicker):
+        def __init__(self, on_result=None):
+            nonlocal picker
+            super().__init__(on_result=on_result)
+            picker = self
+
+    monkeypatch.setattr(
+        runtime,
+        "require_flet",
+        lambda: SimpleNamespace(Text=Text, FilePicker=CapturingFilePicker),
+    )
+    page = SimpleNamespace(
+        overlay=[],
+        snack_bar=SimpleNamespace(open=False, content=None),
+        update=lambda: None,
+    )
+    estado = runtime.GuiFileState()
+    handler = runtime.crear_handler_guardar_como(
+        entrada=SimpleNamespace(value="imprimir('ok')"),
+        estado_archivo=estado,
+        page=page,
+    )
+
+    handler(None)
+    picker.on_result(SimpleNamespace(path=str(destino)))
+
+    assert page.snack_bar.content.value == f"Archivo guardado: {destino.resolve()}"
+    assert estado.ruta == destino.resolve()
+    assert estado.contenido_cargado == "imprimir('ok')"
+    assert estado.cambios_sin_guardar is False


### PR DESCRIPTION
### Motivation
- Evitar inconsistencias entre el campo visible `Ruta` del IDLE y el `FilePicker` nativo para la acción `Guardar como` y asegurar un único comportamiento y mensajes de éxito/errores.

### Description
- Conservo el campo `Ruta` como flujo canónico del IDLE y documento su intención junto al control en `src/pcobra/gui/idle.py`.
- Marco `crear_handler_guardar_como` en `src/pcobra/gui/runtime.py` como un helper basado en `FilePicker` para integraciones alternativas y actualizo su docstring para aclararlo.
- Centralizo el guardado del helper `FilePicker` para reutilizar `guardar_archivo_como`, de modo que el `GuiFileState` y los mensajes (`"Archivo guardado: ..."` / errores) sean coherentes entre ambos caminos; cambios en `src/pcobra/gui/runtime.py` (`_guardar_archivo` y `crear_handler_guardar_como`).
- Añadí docstring al handler `guardar_como_handler` del IDLE para explicitar que usa el campo `Ruta` como flujo principal (`src/pcobra/gui/idle.py`).
- Incluyo dos pruebas unitarias nuevas que verifican que el flujo por `Ruta` y el flujo por `FilePicker` actualizan `GuiFileState.ruta`, `contenido_cargado` y `cambios_sin_guardar` de forma idéntica y que el `FilePicker` muestra el mensaje de éxito compartido (`tests/unit/test_gui_runtime.py`).

### Testing
- Ejecución de las pruebas añadidas: `pytest -q tests/unit/test_gui_runtime.py::test_guardar_como_por_ruta_y_filepicker_actualizan_estado_igual tests/unit/test_gui_runtime.py::test_guardar_como_filepicker_usa_mensaje_de_exito_compartido` — resultado: `2 passed`.
- Ejecución de los conjuntos relevantes: `pytest -q tests/unit/test_gui_runtime.py tests/unit/test_gui_idle.py` — resultado: `54 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a365dd3392883278057a79536cc7d6d)