### PR TITLE
Evita escritura duplicada en runtime GUI

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -213,7 +213,7 @@ def leer_archivo_texto(path: str | Path, *, encoding: str = "utf-8") -> str:
 def escribir_archivo_texto(
     path: str | Path, contenido: str | None, *, encoding: str = "utf-8"
 ) -> str:
-    """Escribe exactamente el contenido normalizado del editor y lo devuelve."""
+    """Escribe una sola vez el contenido normalizado del editor y lo devuelve."""
 
     codigo = normalizar_codigo(contenido)
     destino = normalizar_ruta_archivo_gui(path)

--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -40,6 +41,19 @@ def test_escribir_archivo_texto_no_parsea_ni_modifica_contenido(tmp_path: Path):
 
     assert escrito == codigo
     assert destino.read_text(encoding="utf-8") == codigo
+
+
+def test_escribir_archivo_texto_escribe_una_sola_vez(tmp_path: Path):
+    destino = tmp_path / "codigo.co"
+    codigo = "imprimir('una vez')"
+
+    with patch.object(
+        Path, "write_text", autospec=True, return_value=len(codigo)
+    ) as write_text:
+        escrito = runtime.escribir_archivo_texto(destino, codigo)
+
+    assert escrito == codigo
+    write_text.assert_called_once_with(destino.resolve(), codigo, encoding="utf-8")
 
 
 def test_escribir_archivo_texto_propaga_ruta_inexistente(tmp_path: Path):


### PR DESCRIPTION
### Motivation
- Asegurar que la función encargada de escribir archivos en la GUI realice exactamente una sola operación de escritura tras normalizar el código y resolver la ruta, evitando duplicaciones accidentales.
- Añadir una prueba de regresión que prevenga la reintroducción de una segunda llamada a `Path.write_text` en el futuro.
- Mantener sin cambios los contratos y la semántica de los helpers de guardado (`guardar_archivo_en_estado`, `guardar_archivo_activo`, `guardar_archivo_como`).

### Description
- Actualiza la documentación interna de `escribir_archivo_texto` en `src/pcobra/gui/runtime.py` para dejar explícito que escribe una sola vez el contenido normalizado antes de devolverlo.
- Agrega la prueba `test_escribir_archivo_texto_escribe_una_sola_vez` en `tests/gui/test_runtime_file_helpers.py` que parchea `Path.write_text` y comprueba que se invoque exactamente una vez con la ruta resuelta y `encoding="utf-8"`, y que la función devuelva el código normalizado.
- No se introdujeron cambios en la lógica de `guardar_archivo_en_estado`, `guardar_archivo_activo` ni `guardar_archivo_como`, que siguen delegando en `escribir_archivo_texto` y actualizando el estado.

### Testing
- Ejecuté `pytest tests/gui/test_runtime_file_helpers.py tests/unit/test_gui_runtime.py -q` y todos los tests pasaron: `58 passed, 1 warning`.
- La prueba de regresión añadida confirma que `escribir_archivo_texto` realiza una única invocación a `Path.write_text` y devuelve el contenido esperado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3660450e048327911376fe04d3f36f)