### PR TITLE
Eliminar docstring duplicado en `mostrar_tokens`

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -1017,7 +1017,6 @@ def transpilar_codigo(codigo: str, lang: str) -> str:
 
 
 def mostrar_tokens(codigo: str) -> str:
-    """Tokeniza código Cobra y devuelve una representación por línea."""
     deps = require_gui_dependencies()
     tokens, _ast = analizar_codigo(codigo)
     return "\n".join(str(token) for token in tokens)


### PR DESCRIPTION
### Motivation
- Eliminar un docstring redundante en la función responsable de mostrar tokens para mantener el código limpio sin alterar su comportamiento.

### Description
- Se eliminó el docstring duplicado en `mostrar_tokens(codigo: str) -> str` ubicado en `src/pcobra/gui/runtime.py` y no se modificó la lógica de tokenización ni la llamada a `analizar_codigo()`.

### Testing
- Se compiló el archivo modificado con `python -m compileall -q src/pcobra/gui/runtime.py` y la comprobación final pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36619014d48327820fc8ee550aae56)