### PR TITLE
docs: documentar motor IA canónico agix

### DIFF
--- a/docs/ADR/002-motor-ia-sugerencias-agix.md
+++ b/docs/ADR/002-motor-ia-sugerencias-agix.md
@@ -1,0 +1,93 @@
+# ADR 002: Motor IA canónico para sugerencias Cobra
+
+## Estado
+
+Aceptada.
+
+## Contexto
+
+Durante la revisión de cambios potenciales del motor IA apareció el nombre
+`agi-core` como posible sustituto de `agix`. La comprobación de dependencias y
+código vigente muestra que Cobra no usa `agi-core` como dependencia declarada ni
+como API pública de integración:
+
+- `pyproject.toml` declara `agix>=1.9.0,<2` como dependencia del proyecto.
+- `src/pcobra/gui/runtime.py` define `CANONICAL_SUGGESTION_ENGINE = "agix"` y
+  usa ese nombre para la detección liviana del motor opcional.
+- `src/pcobra/ia/analizador_sugerencias.py` es la fachada pública estable y
+  delega en `src/pcobra/ia/analizador_agix.py`.
+- `src/pcobra/ia/analizador_agix.py` importa API pública de `agix`, en concreto
+  `agix.reasoning.basic.Reasoner` y `agix.emotion.emotion_simulator.PADState`.
+
+Existe un paquete externo publicado con el nombre `agi-core`, pero su mera
+existencia en el ecosistema Python no implica que sea compatible con Cobra ni
+que deba reemplazar la integración actual. No se ha identificado en Cobra una
+historia de usuario aprobada, contrato de API, pruebas de compatibilidad ni
+plan de migración que justifiquen sustituir `agix`.
+
+## Decisión
+
+El nombre canónico del motor IA de sugerencias en Cobra sigue siendo `agix`.
+La referencia `agi-core`, cuando aparezca en tareas o conversaciones sin un
+contrato técnico adicional, debe tratarse como una referencia informal o una
+incoherencia nominal, no como una instrucción de migración.
+
+No se debe cambiar `CANONICAL_SUGGESTION_ENGINE = "agix"` ni añadir detección,
+imports o dependencias de `agi-core` sin una ADR nueva que apruebe una migración
+o una integración paralela.
+
+## API pública usada por Cobra
+
+La integración vigente con `agix` usa esta superficie mínima:
+
+1. Paquete Python real: `agix`.
+2. Razonador: `agix.reasoning.basic.Reasoner`.
+3. Estado emocional opcional: `agix.emotion.emotion_simulator.PADState`.
+4. Método esperado del razonador: `select_best_model(evaluaciones)`.
+5. Modulación emocional opcional: `modular_por_emocion(pad)` cuando se reciben
+   valores completos de placer, activación y dominancia.
+
+La API pública estable para el resto de Cobra no es `agix` directamente, sino
+`pcobra.ia.analizador_sugerencias.generar_sugerencias()`. La GUI debe seguir
+usando esa fachada bajo demanda después de validar el código con `Lexer` y
+`Parser`.
+
+## Política de compatibilidad
+
+- `agix` es el único motor soportado para sugerencias mientras esta ADR esté
+  vigente.
+- `pcobra.ia.analizador_sugerencias` es la fachada estable para consumidores
+  internos y externos del paquete Cobra.
+- `pcobra.ia.analizador_agix` puede contener shims o alias técnicos necesarios
+  para compatibilidad con versiones de `agix`, pero esos detalles no forman
+  parte del contrato público de Cobra.
+- `agi-core` no tiene compatibilidad implícita con `agix`; cualquier soporte de
+  `agi-core` requiere una ADR separada con contrato de API, estrategia de
+  instalación, pruebas y plan de migración o coexistencia.
+
+## Cambios requeridos ante una futura migración
+
+Si una ADR futura decide sustituir o complementar `agix` con otro motor, deberá
+cubrir como mínimo:
+
+1. Actualización de dependencias en `pyproject.toml` y documentación de
+   instalación.
+2. Cambio explícito de la detección en `src/pcobra/gui/runtime.py`, incluyendo
+   el valor de `CANONICAL_SUGGESTION_ENGINE` si el motor canónico cambia.
+3. Adaptación de `pcobra.ia.analizador_sugerencias` para mantener una fachada
+   estable aunque cambie la implementación interna.
+4. Nuevo adaptador de motor o reemplazo controlado de `analizador_agix.py`.
+5. Pruebas que verifiquen disponibilidad, errores cuando falta la dependencia,
+   validación previa con `Lexer`/`Parser` y validación de fragmentos sugeridos.
+6. Actualización de `docs/LIBRO_PROGRAMACION_COBRA.md`,
+   `docs/gui_idle_especificacion.md` y cualquier guía de GUI o dependencias.
+
+## Consecuencias
+
+- Se evita introducir una dependencia externa no validada solo por similitud de
+  nombre.
+- La GUI conserva una detección liviana y coherente con la dependencia real.
+- Los usuarios reciben instrucciones consistentes: instalar `agix` para activar
+  sugerencias IA.
+- Cualquier cambio real de motor queda bloqueado hasta documentar su contrato,
+  compatibilidad y pruebas en una ADR dedicada.

--- a/docs/gui_idle_especificacion.md
+++ b/docs/gui_idle_especificacion.md
@@ -7,6 +7,7 @@ Esta especificación describe las acciones visibles soportadas por `src/pcobra/g
 - La interfaz principal se construye en `pcobra.gui.idle.main` y delega la lógica reusable en `pcobra.gui.runtime`.
 - Las acciones que analizan código Cobra deben ejecutar primero el flujo canónico `Lexer(codigo).tokenizar()` y después `Parser(tokens).parsear()` mediante `analizar_codigo()` antes de interpretar, transpilar, mostrar tokens, mostrar AST o solicitar sugerencias.
 - La acción **Sugerencias del Libro** debe pasar siempre primero por `Lexer` y `Parser`. Si alguno falla, el IDLE debe mostrar los errores léxicos/sintácticos y no debe invocar el motor opcional de sugerencias.
+- El motor IA canónico para sugerencias es `agix`; `agi-core` no debe usarse como sustituto ni dependencia paralela sin una ADR nueva. La decisión vigente está documentada en [`docs/ADR/002-motor-ia-sugerencias-agix.md`](ADR/002-motor-ia-sugerencias-agix.md).
 - El selector de transpilación del IDLE solo puede mostrar los targets públicos canónicos: `python`, `javascript` y `rust`. No debe exponer aliases, targets legacy ni backends experimentales.
 
 ## Acciones soportadas y funciones runtime


### PR DESCRIPTION
### Motivation

- Se detectaron referencias inconsistentes al nombre `agi-core` durante la revisión de la integración IA y es necesario fijar el nombre canónico del motor de sugerencias para evitar confusión. 
- El proyecto ya declara y utiliza `agix` en `pyproject.toml`, en la fachada `pcobra.ia.analizador_sugerencias` y en el runtime, por lo que conviene documentar la decisión arquitectónica.

### Description

- Añadida una ADR en `docs/ADR/002-motor-ia-sugerencias-agix.md` que fija `agix` como motor IA canónico, describe la API usada (`agix.reasoning.basic.Reasoner`, `agix.emotion.emotion_simulator.PADState`) y define la política de compatibilidad. 
- Actualizada la especificación del IDLE en `docs/gui_idle_especificacion.md` para enlazar la ADR y dejar explícito que `agi-core` no debe adoptarse sin una ADR de migración. 
- No se modificó la lógica de runtime ni las constantes; `CANONICAL_SUGGESTION_ENGINE = "agix"` y la dependencia `agix>=1.9.0,<2` en `pyproject.toml` permanecen sin cambios.

### Testing

- Ejecutado `python -m compileall src/pcobra/gui/runtime.py src/pcobra/ia/analizador_sugerencias.py src/pcobra/ia/analizador_agix.py` para verificar que los módulos relevantes compilan correctamente, y la comprobación fue satisfactoria. 
- Ejecutado `rg -n "agi-core|CANONICAL_SUGGESTION_ENGINE = \"agix\"|agix>=1\.9\.0,<2|Reasoner|PADState|002-motor-ia"` sobre los ficheros relevantes para validar referencias y la búsqueda devolvió los resultados esperados. 
- Ejecutado `git diff --check` para validar que no hay problemas de espacio/formatos en los diffs; la verificación pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36629069348327b5c301c8f5a8d2c3)