### PR TITLE
test: ampliar cobertura de reglas del libro

### DIFF
--- a/src/pcobra/ia/reglas_libro_programacion.py
+++ b/src/pcobra/ia/reglas_libro_programacion.py
@@ -33,6 +33,16 @@ class ReglaLibroProgramacion:
         """Devuelve una sugerencia trazable a esta regla interna."""
         return f"{self.construir_mensaje(codigo)} [regla: {self.id}; {self.seccion}]"
 
+    def metadatos(self) -> dict[str, object]:
+        """Devuelve los metadatos públicos que trazan la regla en IA/GUI."""
+        return {
+            "rule_id": self.id,
+            "rule_section": self.seccion,
+            "category": self.categoria,
+            "severity": self.severidad,
+            "automatic": self.aplicable_automaticamente,
+        }
+
 
 def validar_con_parser(codigo: str) -> None:
     """Valida ``codigo`` con el lexer y parser oficiales de Cobra."""
@@ -149,11 +159,7 @@ def construir_candidatos_desde_reglas(codigo: str) -> list[dict[str, object]]:
                     "reason": regla.mensaje(codigo),
                     "accuracy": regla.accuracy,
                     "interpretability": regla.interpretability,
-                    "rule_id": regla.id,
-                    "rule_section": regla.seccion,
-                    "category": regla.categoria,
-                    "severity": regla.severidad,
-                    "automatic": regla.aplicable_automaticamente,
+                    **regla.metadatos(),
                 }
             )
     if not candidatos:

--- a/tests/gui/test_auto_suggestion_parser_contract.py
+++ b/tests/gui/test_auto_suggestion_parser_contract.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pytest
 
 from pcobra.cobra.core import Lexer, Parser, ParserError
+from pcobra.core.errors import LexerError
 from pcobra.gui import runtime
 
 
@@ -182,6 +183,13 @@ def test_reglas_libro_programacion_declaran_fragmentos_soportados_por_parser() -
     assert "LP-3.9-FUNCIONES-CON-FUNC" in ids
 
     campos_obligatorios = ("id", "seccion", "descripcion", "fragmento_valido")
+    claves_metadatos = {
+        "rule_id",
+        "rule_section",
+        "category",
+        "severity",
+        "automatic",
+    }
 
     for regla in REGLAS_LIBRO_PROGRAMACION:
         for campo in campos_obligatorios:
@@ -190,10 +198,24 @@ def test_reglas_libro_programacion_declaran_fragmentos_soportados_por_parser() -
 
         ast = _parsear(regla.fragmento_valido)
         assert ast, regla.id
+        assert regla.metadatos() == {
+            "rule_id": regla.id,
+            "rule_section": regla.seccion,
+            "category": regla.categoria,
+            "severity": regla.severidad,
+            "automatic": regla.aplicable_automaticamente,
+        }
+        assert set(regla.metadatos()) == claves_metadatos
 
         if regla.fragmento_no_recomendado is not None:
             assert regla.fragmento_no_recomendado.strip(), regla.id
             assert regla.fragmento_no_recomendado.strip() != regla.fragmento_valido.strip()
+            try:
+                ast_no_recomendado = _parsear(regla.fragmento_no_recomendado)
+            except (LexerError, ParserError) as exc:
+                assert str(exc), regla.id
+            else:
+                assert ast_no_recomendado, regla.id
 
         assert regla.categoria in {
             "léxico/sintaxis",


### PR DESCRIPTION
### Motivation
- Centralizar y fijar el contrato público de metadatos que expone cada regla del Libro para los flujos IA/GUI. 
- Asegurar que las reglas declaran fragmentos válidos que parsea el `Lexer`/`Parser` y que los fragmentos no recomendados se cubren como parseables o producen diagnóstico léxico/sintáctico conocido.

### Description
- Se añadió `ReglaLibroProgramacion.metadatos()` que devuelve un dict con `rule_id`, `rule_section`, `category`, `severity` y `automatic` y se reutiliza al construir candidatos en `construir_candidatos_desde_reglas()` (`**regla.metadatos()`).
- Se reforzaron las pruebas en `tests/gui/test_auto_suggestion_parser_contract.py` para comprobar los metadatos en todas las reglas, validar `fragmento_valido` con `Lexer`/`Parser` y verificar cada `fragmento_no_recomendado` como parseable o como error reconocido de `Lexer`/`Parser`.
- Se añadió una importación de `LexerError` en la prueba para distinguir fallos léxicos y se mejoró la lógica de aserción para dejar claro el comportamiento esperado en ambos casos.

### Testing
- Ejecutadas las pruebas GUI con `pytest tests/gui/test_auto_suggestion_parser_contract.py tests/gui/test_runtime_correccion_tipografica.py -q` y todas pasaron (`16 passed` en la primera ejecución, luego `16 passed` tras ajustes).
- Ejecutadas pruebas unitarias relevantes con `pytest tests/unit/test_analizador_agix.py tests/unit/test_gui_runtime.py -q` y todas pasaron (`63 passed` en la ejecución final); la batería completa de pruebas relacionadas reportó éxito y sin errores de formato (`git diff --check`).
- Las pruebas utilizan `monkeypatch`/dobles para `detectar_motor_ia_sugerencias` y `generar_sugerencias` para evitar depender de una instalación real de `agix` y esos flujos se comprobaron mediante mocks en los tests, con resultados exitosos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3663b31a7083279829eabb4170c41f)