### PR TITLE
test: enforce public transpiler targets contract

### DIFF
--- a/tests/unit/test_cli_transpiler_registry_contract.py
+++ b/tests/unit/test_cli_transpiler_registry_contract.py
@@ -2,8 +2,24 @@ from __future__ import annotations
 
 import pytest
 
+from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+from pcobra.cobra.config.transpile_targets import OFFICIAL_TARGETS
+from pcobra.gui.runtime import gui_target_choices
 from pcobra.cobra.cli import transpiler_registry as cli_registry
 from pcobra.cobra.transpilers import registry as canonical_registry
+from pcobra.cobra.transpilers.registry import PUBLIC_TRANSPILER_CLASS_PATHS
+
+EXPECTED_PUBLIC_TARGETS = ("python", "javascript", "rust")
+LEGACY_OR_ALIAS_TARGETS = (
+    "js",
+    "py",
+    "node",
+    "nodejs",
+    "golang",
+    "go",
+    "java",
+    "jvm",
+)
 
 
 class DummyPluginTranspiler:
@@ -60,3 +76,18 @@ def test_cli_wrapper_carga_entrypoints_por_contrato_de_get_transpilers(monkeypat
     cli_registry.cli_transpilers()
 
     assert calls["ensure"] == 1
+
+
+def test_contrato_publico_transpiladores_conserva_solo_targets_oficiales_en_orden() -> None:
+    assert OFFICIAL_TARGETS == EXPECTED_PUBLIC_TARGETS
+    assert PUBLIC_BACKENDS == EXPECTED_PUBLIC_TARGETS
+    assert tuple(PUBLIC_TRANSPILER_CLASS_PATHS.keys()) == EXPECTED_PUBLIC_TARGETS
+
+
+def test_aliases_legacy_no_aparecen_en_registro_publico_ni_choices_gui() -> None:
+    public_registry_targets = tuple(PUBLIC_TRANSPILER_CLASS_PATHS.keys())
+    gui_choices = tuple(gui_target_choices())
+
+    assert gui_choices == EXPECTED_PUBLIC_TARGETS
+    assert not set(LEGACY_OR_ALIAS_TARGETS).intersection(public_registry_targets)
+    assert not set(LEGACY_OR_ALIAS_TARGETS).intersection(gui_choices)


### PR DESCRIPTION
### Motivation
- Asegurar que la superficie pública de transpiladores permanezca exactamente en los tres targets oficiales y en el orden canónico, y que aliases/targets legacy no se expongan en el registro público ni en las opciones visibles de la GUI.

### Description
- Añadidas constantes `EXPECTED_PUBLIC_TARGETS` y `LEGACY_OR_ALIAS_TARGETS` y dos pruebas nuevas en `tests/unit/test_cli_transpiler_registry_contract.py` para cubrir el contrato público de transpiladores.
- La primera prueba valida que `OFFICIAL_TARGETS`, `PUBLIC_BACKENDS` y `tuple(PUBLIC_TRANSPILER_CLASS_PATHS.keys())` sean exactamente `("python", "javascript", "rust")` y conserven el orden.
- La segunda prueba valida que `gui_target_choices()` devuelva los targets oficiales y que aliases como `js`, `py`, `node`, `golang`, `java` o `jvm` no aparezcan ni en `PUBLIC_TRANSPILER_CLASS_PATHS` ni en las choices de GUI.
- No se eliminan shims históricos ni se cambia comportamiento en código productivo; solo se añaden aserciones en tests para garantizar que dichos shims no formen parte de la superficie pública.

### Testing
- Ejecutado `pytest tests/unit/test_cli_transpiler_registry_contract.py` y las pruebas automatizadas pasaron correctamente con `6 passed` and no fallos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36670a90c48327a31631674b5d7f15)