### PR TITLE
Mostrar directorio actual en el campo Ruta del IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -33,7 +33,7 @@ def main(page: "ft.Page"):
 
     def sincronizar_estado_visual() -> None:
         estado_archivo.value = runtime.crear_titulo_archivo(estado)
-        ruta_input.value = str(estado.ruta or "")
+        ruta_input.value = str(estado.ruta or directorio_actual)
 
     def actualizar_pagina() -> None:
         sincronizar_estado_visual()

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -109,6 +109,7 @@ def _fake_flet():
         ExpansionTile=ExpansionTile,
         Icon=Icon,
         icons=SimpleNamespace(INSERT_DRIVE_FILE="file", FOLDER="folder"),
+        Icons=SimpleNamespace(INSERT_DRIVE_FILE="file", FOLDER="folder"),
         ScrollMode=SimpleNamespace(ALWAYS="always"),
         Page=Page,
         dropdown=SimpleNamespace(Option=lambda v: v),
@@ -382,6 +383,7 @@ def test_main_acciones_publicas_de_archivo(monkeypatch, tmp_path):
         for c in page.controls
         if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Ruta"
     )
+    assert ruta_input.value == str(tmp_path.resolve())
     salida = next(
         c
         for c in page.controls


### PR DESCRIPTION
### Motivation
- Al iniciar el IDLE sin archivo activo, el campo `Ruta` quedaba vacío y debe mostrar el `directorio_actual` para facilitar abrir/guardar desde el contexto correcto.
- Cuando hay un archivo activo, la `ruta` del estado debe seguir teniendo prioridad para no cambiar el contrato de los botones `Abrir`, `Guardar`, `Guardar como` ni `Recargar`.
- Añadir una comprobación en las pruebas para evitar regresiones en el comportamiento tras cambiar el directorio de trabajo.

### Description
- Se actualiza `sincronizar_estado_visual()` en `src/pcobra/gui/idle.py` para asignar `ruta_input.value = str(estado.ruta or directorio_actual)` en lugar de la cadena vacía cuando `estado.ruta` es `None`.
- Se añade una aserción en `tests/unit/test_gui_idle.py` que verifica que, tras `monkeypatch.chdir(tmp_path)` y llamar a `idle.main(page)`, el `TextField` con `label == "Ruta"` contiene `str(tmp_path.resolve())`.
- Se ajusta el doble de Flet en `tests/unit/test_gui_idle.py` para exponer `ft.Icons` (además de `ft.icons`) porque `runtime.crear_arbol_directorios()` usa `ft.Icons` al construir el árbol de archivos.

### Testing
- Se ejecutó `pytest tests/unit/test_gui_idle.py` y todas las pruebas del módulo GUI afectado pasaron; resultó en `6 passed`.
- No se modificó el comportamiento público de los controladores de archivo (`Abrir`, `Guardar`, `Guardar como`, `Recargar`) y las pruebas relacionadas con esos flujos siguen pasando exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a366de04f308327ba72be54d637e05e)