### PR TITLE
Mostrar estado vacío en árbol de archivos Cobra

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -526,9 +526,14 @@ def crear_arbol_directorios(
             return _crear_nodo_directorio(path)
         return _crear_nodo_archivo(path)
 
-    elementos_arbol = [
-        _crear_nodo(entrada) for entrada in listar_directorio_cobra(root_path)
-    ]
+    entradas = listar_directorio_cobra(root_path)
+    if not entradas:
+        return ft.Column(
+            [flet_text(ft, value="No hay archivos Cobra en esta carpeta")],
+            scroll=ft.ScrollMode.ALWAYS,
+        )
+
+    elementos_arbol = [_crear_nodo(entrada) for entrada in entradas]
 
     return ft.Column(elementos_arbol, scroll=ft.ScrollMode.ALWAYS)
 

--- a/tests/unit/test_gui_app.py
+++ b/tests/unit/test_gui_app.py
@@ -44,6 +44,7 @@ def _fake_flet():
             if controls is None and args:
                 controls = args[0]
             self.controls = controls or []
+            self.scroll = _kwargs.get("scroll")
 
     class Container:
         def __init__(self, content=None, **_kwargs):
@@ -100,6 +101,7 @@ def _fake_flet():
         ListTile=ListTile,
         Icon=Icon,
         icons=SimpleNamespace(FOLDER="folder", INSERT_DRIVE_FILE="file"),
+        Icons=SimpleNamespace(FOLDER="folder", INSERT_DRIVE_FILE="file"),
         ScrollMode=SimpleNamespace(ALWAYS="always"),
         Page=Page,
         dropdown=SimpleNamespace(Option=lambda v: v),

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -50,6 +50,7 @@ def _fake_flet():
             self.data = _kwargs.get("data")
             self.on_click = _kwargs.get("on_click")
             self.on_change = _kwargs.get("on_change")
+            self.scroll = _kwargs.get("scroll")
 
     class Container:
         def __init__(self, content=None, **_kwargs):
@@ -509,3 +510,15 @@ def test_main_establecer_raiz_arbol_valida_directorios(monkeypatch, tmp_path):
     assert salida.value == f"Raíz del árbol actualizada: {subdir.resolve()}"
     assert raiz_input.value == str(subdir.resolve())
     assert arbol.controls[0].value == f"Directorio raíz: {subdir.resolve()}"
+
+
+def test_crear_arbol_directorios_muestra_estado_vacio_en_carpeta_sin_cobras(tmp_path):
+    ft = _fake_flet()
+
+    arbol = idle.runtime.crear_arbol_directorios(
+        ft, on_click=lambda _e: None, root_path=tmp_path
+    )
+
+    assert arbol.scroll == ft.ScrollMode.ALWAYS
+    assert len(arbol.controls) == 1
+    assert arbol.controls[0].value == "No hay archivos Cobra en esta carpeta"


### PR DESCRIPTION
### Motivation
- Mostrar un estado vacío claro cuando no hay archivos Cobra en la carpeta en lugar de insertar nodos ficticios en el árbol. 
- Mantener el comportamiento de scroll del `Column` para que la UI conserve la misma experiencia visual aún con estado vacío. 
- Añadir una prueba que valide el comportamiento en una ruta temporal vacía. 

### Description
- En `crear_arbol_directorios()` se reutiliza el resultado de `listar_directorio_cobra(root_path)` y si la lista está vacía se devuelve un `ft.Column` con un `flet_text(ft, value="No hay archivos Cobra en esta carpeta")` y `scroll=ft.ScrollMode.ALWAYS` sin crear nodos ficticios (`src/pcobra/gui/runtime.py`).
- Se añadió la prueba `test_crear_arbol_directorios_muestra_estado_vacio_en_carpeta_sin_cobras` en `tests/unit/test_gui_idle.py` que usa `tmp_path` y comprueba que el `Column` contiene el texto esperado y mantiene `scroll`.
- Se ajustaron los fakes de Flet en `tests/unit/test_gui_idle.py` y `tests/unit/test_gui_app.py` para exponer el atributo `scroll` y el namespace `Icons` que requiere el runtime durante las pruebas. 

### Testing
- Ejecuté `pytest tests/unit/test_gui_idle.py tests/unit/test_gui_app.py` y todas las pruebas pasaron (`14 passed`).
- También verifiqué integridad con `git diff --check` (sin errores) antes de commitear los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a366ee5b3f88327819c43a027dec45c)