### PR TITLE
Mostrar errores de reconstrucción del árbol en el IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -115,6 +115,12 @@ def main(page: "ft.Page"):
             )
         except (FileNotFoundError, NotADirectoryError, PermissionError) as exc:
             mostrar_error_archivo(exc)
+            arbol.controls.append(
+                runtime.flet_text(
+                    ft,
+                    value=f"No se pudo listar la ruta: {runtime.formatear_error(exc)}",
+                )
+            )
             return
         arbol.controls.extend(getattr(arbol_canonico, "controls", [arbol_canonico]))
 

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -335,6 +335,57 @@ def test_main_selector_y_switch_sin_targets(monkeypatch):
     assert activar.disabled is True
 
 
+def test_main_muestra_error_visible_si_falla_arbol_directorios(monkeypatch, tmp_path):
+    ft = _fake_flet()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
+    monkeypatch.setattr(
+        idle.runtime, "detectar_motor_ia_sugerencias", _motor_disponible
+    )
+    monkeypatch.setattr(idle.runtime, "gui_target_choices", lambda: ("python",))
+    monkeypatch.setattr(
+        idle.runtime,
+        "require_gui_dependencies",
+        lambda: {
+            "TRANSPILERS": {"python": object},
+            "LexerError": RuntimeError,
+            "ParserError": ValueError,
+        },
+    )
+    monkeypatch.setattr(
+        idle.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}"
+    )
+
+    def _crear_arbol_falla(*_args, **_kwargs):
+        raise FileNotFoundError("directorio inaccesible")
+
+    monkeypatch.setattr(idle.runtime, "crear_arbol_directorios", _crear_arbol_falla)
+
+    page = ft.Page()
+    idle.main(page)
+
+    salida = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.Text) and c.kwargs.get("selectable")
+    )
+    arbol = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ListView)
+        and getattr(getattr(c, "controls", [None])[0], "value", "").startswith(
+            "Directorio raíz:"
+        )
+    )
+
+    assert salida.value == "error: directorio inaccesible"
+    assert any(
+        getattr(control, "value", "")
+        == "No se pudo listar la ruta: error: directorio inaccesible"
+        for control in arbol.controls
+    )
+
+
 def test_main_acciones_publicas_de_archivo(monkeypatch, tmp_path):
     ft = _fake_flet()
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
### Motivation
- Mostrar diagnósticos de errores de listado de directorios en el panel lateral del IDLE para que no queden ocultos y seguir mostrando el diagnóstico en la salida principal.
- Evitar silenciar excepciones relacionadas con rutas/permiso y hacerlas visibles para el usuario.

### Description
- En `src/pcobra/gui/idle.py` se actualizó `reconstruir_arbol()` para que, al capturar `FileNotFoundError`, `NotADirectoryError` o `PermissionError`, además de llamar a `mostrar_error_archivo(exc)` se añada a `arbol.controls` un `Text` con el mensaje formateado `No se pudo listar la ruta: ...` y luego se retorne.
- Se añadió la prueba `test_main_muestra_error_visible_si_falla_arbol_directorios` en `tests/unit/test_gui_idle.py` que simula que `crear_arbol_directorios` lanza `FileNotFoundError` y verifica que `salida.value` contiene el error formateado y que el `ListView` del árbol incluye el mensaje visible.
- Archivos modificados: `src/pcobra/gui/idle.py` y `tests/unit/test_gui_idle.py`.

### Testing
- Ejecuté `pytest -q tests/unit/test_gui_idle.py` y la suite relevante pasó correctamente (todos los tests pasaron).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36700da0a0832790e44f73a8732688)