### PR TITLE
Actualizar fakes de Flet en tests GUI para usar `ft.Icons` moderno

### DIFF
--- a/tests/unit/test_gui_app.py
+++ b/tests/unit/test_gui_app.py
@@ -101,7 +101,6 @@ def _fake_flet():
         ExpansionTile=ExpansionTile,
         ListTile=ListTile,
         Icon=Icon,
-        icons=SimpleNamespace(INSERT_DRIVE_FILE="file", FOLDER="folder"),
         Icons=SimpleNamespace(INSERT_DRIVE_FILE="file", FOLDER="folder"),
         ScrollMode=SimpleNamespace(ALWAYS="always"),
         Page=Page,
@@ -273,13 +272,11 @@ def test_main_configura_selector_por_defecto_y_switch_deshabilitado_si_no_hay_ta
     assert activar.disabled is True
 
 
-def test_fake_flet_expone_icons_moderno_y_legacy():
+def test_fake_flet_expone_icons_moderno():
     ft = _fake_flet()
 
     assert ft.Icons.INSERT_DRIVE_FILE == "file"
     assert ft.Icons.FOLDER == "folder"
-    assert ft.icons.INSERT_DRIVE_FILE == "file"
-    assert ft.icons.FOLDER == "folder"
 
 
 def _text_value(control):

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -116,7 +116,6 @@ def _fake_flet():
         ListTile=ListTile,
         ExpansionTile=ExpansionTile,
         Icon=Icon,
-        icons=SimpleNamespace(INSERT_DRIVE_FILE="file", FOLDER="folder"),
         Icons=SimpleNamespace(INSERT_DRIVE_FILE="file", FOLDER="folder"),
         ScrollMode=SimpleNamespace(ALWAYS="always"),
         Page=Page,
@@ -124,13 +123,11 @@ def _fake_flet():
     )
 
 
-def test_fake_flet_expone_icons_moderno_y_legacy():
+def test_fake_flet_expone_icons_moderno():
     ft = _fake_flet()
 
     assert ft.Icons.INSERT_DRIVE_FILE == "file"
     assert ft.Icons.FOLDER == "folder"
-    assert ft.icons.INSERT_DRIVE_FILE == "file"
-    assert ft.icons.FOLDER == "folder"
 
 
 def test_main_renderiza_botones_esperados(monkeypatch):


### PR DESCRIPTION
### Motivation
- Quitar el alias legacy `icons` del fake de Flet y actualizar los tests para reflejar la API moderna `ft.Icons`, además de asegurar que el runtime de la GUI no use `ft.icons`.

### Description
- Se eliminaron los atributos `icons=SimpleNamespace(...)` de `_fake_flet()` en `tests/unit/test_gui_idle.py` y `tests/unit/test_gui_app.py`, se renombraron los tests a `test_fake_flet_expone_icons_moderno` y se limitaron las aserciones para validar únicamente `ft.Icons.INSERT_DRIVE_FILE` y `ft.Icons.FOLDER`, sin modificar Lexer, Parser, gramática, AST ni CLI.

### Testing
- Ejecutado `pytest tests/unit/test_gui_idle.py tests/unit/test_gui_app.py` (los tests afectados pasaron, total ejecutado en ambos archivos: 21 tests) y verificado con `rg -n "ft\.icons" src/pcobra/gui/` que no hay coincidencias, ambos resultados OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a367d809adc8327897eca0fb0ea52a9)