### PR TITLE
test: cover idle initial cwd fields

### DIFF
--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -348,6 +348,59 @@ def test_main_selector_y_switch_sin_targets(monkeypatch):
     assert activar.disabled is True
 
 
+def test_main_inicializa_ruta_y_raiz_arbol_con_cwd(monkeypatch, tmp_path):
+    ft = _fake_flet()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
+    monkeypatch.setattr(
+        idle.runtime, "detectar_motor_ia_sugerencias", _motor_disponible
+    )
+    monkeypatch.setattr(idle.runtime, "gui_target_choices", lambda: ("python",))
+    monkeypatch.setattr(
+        idle.runtime,
+        "require_gui_dependencies",
+        lambda: {
+            "TRANSPILERS": {"python": object},
+            "LexerError": RuntimeError,
+            "ParserError": ValueError,
+            "Lexer": lambda _codigo: SimpleNamespace(tokenizar=lambda: []),
+            "Parser": lambda _tokens: SimpleNamespace(parsear=lambda: []),
+        },
+    )
+    monkeypatch.setattr(idle.runtime, "normalizar_codigo", lambda value: value or "")
+    monkeypatch.setattr(idle.runtime, "ejecutar_codigo", lambda _codigo: "ok")
+    monkeypatch.setattr(
+        idle.runtime, "transpilar_codigo", lambda _codigo, _lang: "transpilado"
+    )
+    monkeypatch.setattr(idle.runtime, "mostrar_tokens", lambda _codigo: "Token(X)")
+    monkeypatch.setattr(idle.runtime, "mostrar_ast", lambda _codigo: "[Nodo]")
+    monkeypatch.setattr(
+        idle.runtime,
+        "generar_sugerencias",
+        lambda _codigo: ["Usa nombres descriptivos"],
+    )
+    monkeypatch.setattr(
+        idle.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}"
+    )
+
+    page = ft.Page()
+    idle.main(page)
+
+    ruta_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Ruta"
+    )
+    raiz_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Raíz del árbol"
+    )
+
+    assert ruta_input.value == str(tmp_path.resolve())
+    assert raiz_input.value == str(tmp_path.resolve())
+
+
 def test_main_arbol_inicial_muestra_subdirectorios_y_archivos_cobra(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
### Motivation
- Asegurar que la interfaz `pcobra.gui.idle.main` inicializa correctamente los campos de ruta visibles con el directorio de trabajo actual para evitar regresiones en el manejo de la raíz del árbol y la ruta de archivos.

### Description
- Se añadió la prueba `test_main_inicializa_ruta_y_raiz_arbol_con_cwd` en `tests/unit/test_gui_idle.py` que verifica la inicialización de los campos `Ruta` y `Raíz del árbol` con `tmp_path.resolve()`.
- La prueba reutiliza el `ft` simulado generado por `_fake_flet()`, ejecuta `monkeypatch.chdir(tmp_path)` y mockea las mismas dependencias que los tests existentes de `idle.main` antes de llamar a `idle.main(page)`.
- La prueba localiza los `TextField` por su `label` (`"Ruta"` y `"Raíz del árbol"`) y afirma que sus `value` coinciden con `str(tmp_path.resolve())`.
- Los cambios fueron confirmados en un commit local con el mensaje `test: cover idle initial cwd fields`.

### Testing
- Se ejecutó `pytest -q tests/unit/test_gui_idle.py -q` y todos los tests del archivo pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a367e97df548327abef3183ff00ab71)