### PR TITLE
test: cubrir PermissionError en crear_arbol_directorios

### DIFF
--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -213,6 +213,22 @@ def test_crear_arbol_directorios_propaga_file_not_found_en_ruta_inexistente(
         )
 
 
+def test_crear_arbol_directorios_propaga_permission_error_sin_tocar_permisos(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ft = SimpleNamespace()
+
+    def fake(_root_path):
+        raise PermissionError("sin permiso portable")
+
+    monkeypatch.setattr(runtime, "listar_directorio_cobra", fake)
+
+    with pytest.raises(PermissionError, match="sin permiso portable"):
+        runtime.crear_arbol_directorios(
+            ft, on_click=lambda _e: None, root_path=tmp_path
+        )
+
+
 def test_normalizar_codigo_admite_none_y_texto() -> None:
     assert runtime.normalizar_codigo(None) == ""
     assert runtime.normalizar_codigo("imprimir('x')") == "imprimir('x')"


### PR DESCRIPTION
### Motivation
- Añadir una prueba portátil que verifique que `crear_arbol_directorios` propaga un `PermissionError` sin cambiar permisos reales del filesystem para mantener compatibilidad con Windows.

### Description
- Se agrega `tests/unit/test_gui_runtime.py::test_crear_arbol_directorios_propaga_permission_error_sin_tocar_permisos` que crea un `ft` mínimo, monkeypatchea `runtime.listar_directorio_cobra` con una función que lanza `PermissionError("sin permiso portable")` y comprueba la propagación con `pytest.raises`.

### Testing
- Ejecutado `pytest tests/unit/test_gui_runtime.py -q` y la suite pasó con éxito (`51 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a369ce398c48327ac3ec72e9f61caed)