### PR TITLE
Permitir `str` en `root_path` de `crear_arbol_directorios`

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -483,7 +483,7 @@ def crear_salida_seleccionable(ft: Any, **kwargs: Any) -> Any:
 
 
 def crear_arbol_directorios(
-    ft: Any, *, on_click: Any, root_path: Path | None = None
+    ft: Any, *, on_click: Any, root_path: str | Path | None = None
 ) -> Any:
     """Crea un árbol de directorios con carga diferida de subcarpetas."""
     if root_path is None:


### PR DESCRIPTION
### Motivation
- Ampliar la anotación de `root_path` para aceptar `str` además de `Path` y `None` sin romper las llamadas existentes que pasan `Path` o `str`.

### Description
- Actualizada la firma de `crear_arbol_directorios` en `src/pcobra/gui/runtime.py` a `root_path: str | Path | None = None`, preservando la lógica de fallback `if root_path is None: root_path = Path('.').resolve()` y delegando la normalización a `listar_directorio_cobra` que ya usa `Path(root).expanduser()`.

### Testing
- Ejecutados `pytest tests/gui/test_runtime_file_helpers.py tests/unit/test_gui_runtime.py` y ambos conjuntos pasaron correctamente (`61 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a15943a883278ecefccd6e54c0e7)