### PR TITLE
Separar workspace_root y project_root en IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -1,5 +1,6 @@
 """IDLE gráfico principal para editar, ejecutar e inspeccionar código Cobra."""
 
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -14,7 +15,12 @@ def main(page: "ft.Page"):
     ft = runtime.require_flet()
 
     estado = runtime.GuiFileState()
-    directorio_actual = Path.cwd().resolve()
+    workspace_root = (
+        Path(os.environ.get("COBRA_PROJECTS_DIR") or Path.home() / "CobraProjects")
+        .expanduser()
+        .resolve(strict=False)
+    )
+    project_root = workspace_root
 
     entrada = runtime.crear_editor_codigo(ft)
     salida = runtime.crear_salida_seleccionable(ft)
@@ -24,7 +30,7 @@ def main(page: "ft.Page"):
     # como helper FilePicker para integraciones alternativas de Flet.
     ruta_input = runtime.flet_text_field(ft, label="Ruta", value="", expand=True)
     raiz_input = runtime.flet_text_field(
-        ft, label="Raíz del árbol", value=str(directorio_actual), expand=True
+        ft, label="Raíz del árbol", value=str(project_root), expand=True
     )
     arbol = runtime.flet_list_view(ft, expand=True, spacing=2, auto_scroll=False)
     lenguajes = list(runtime.gui_target_choices())
@@ -76,7 +82,6 @@ def main(page: "ft.Page"):
         return ruta
 
     def cargar_archivo(ruta: Path, *, desde_arbol: bool = False) -> None:
-        nonlocal directorio_actual
         try:
             if desde_arbol:
                 entrada.value, salida.value = runtime.cargar_archivo_desde_arbol(
@@ -96,7 +101,6 @@ def main(page: "ft.Page"):
             mostrar_error_archivo(exc)
             page.update()
             return
-        directorio_actual = estado.ruta.parent if estado.ruta else directorio_actual
         reconstruir_arbol()
         actualizar_pagina()
 
@@ -129,16 +133,16 @@ def main(page: "ft.Page"):
         cargar_archivo(Path(ruta), desde_arbol=True)
 
     def reconstruir_arbol() -> bool:
-        raiz_input.value = str(directorio_actual)
+        raiz_input.value = str(project_root)
         arbol.controls.clear()
         arbol.controls.append(
-            runtime.flet_text(ft, value=f"Directorio raíz: {directorio_actual}")
+            runtime.flet_text(ft, value=f"Directorio raíz: {project_root}")
         )
         try:
             arbol_canonico = runtime.crear_arbol_directorios(
                 ft,
                 on_click=cargar_archivo_desde_evento_arbol,
-                root_path=directorio_actual,
+                root_path=project_root,
             )
         except (FileNotFoundError, NotADirectoryError, PermissionError) as exc:
             mostrar_error_archivo(exc)
@@ -153,7 +157,7 @@ def main(page: "ft.Page"):
         return True
 
     def establecer_raiz_arbol_handler(_e):
-        nonlocal directorio_actual
+        nonlocal project_root
         if not raiz_input.value:
             salida.value = "Indica un directorio para usar como raíz del árbol."
             page.update()
@@ -173,11 +177,11 @@ def main(page: "ft.Page"):
             salida.value = f"La raíz del árbol debe ser un directorio: {nueva_raiz}"
             page.update()
             return
-        directorio_actual = nueva_raiz
+        project_root = nueva_raiz
         if not reconstruir_arbol():
             page.update()
             return
-        salida.value = f"Raíz del árbol actualizada: {directorio_actual}"
+        salida.value = f"Raíz del árbol actualizada: {project_root}"
         actualizar_pagina()
 
     def nuevo_handler(_e):
@@ -323,7 +327,6 @@ def main(page: "ft.Page"):
     )
 
     page.add(runtime.flet_row(ft, controls=[panel_lateral, editor], expand=True))
-
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -348,9 +348,12 @@ def test_main_selector_y_switch_sin_targets(monkeypatch):
     assert activar.disabled is True
 
 
-def test_main_inicializa_ruta_y_raiz_arbol_con_cwd(monkeypatch, tmp_path):
+def test_main_inicializa_workspace_root_desde_env_y_ruta_visible_vacia(
+    monkeypatch, tmp_path
+):
     ft = _fake_flet()
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COBRA_PROJECTS_DIR", str(tmp_path))
     monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
         idle.runtime, "detectar_motor_ia_sugerencias", _motor_disponible
@@ -397,7 +400,7 @@ def test_main_inicializa_ruta_y_raiz_arbol_con_cwd(monkeypatch, tmp_path):
         if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Raíz del árbol"
     )
 
-    assert ruta_input.value == str(tmp_path.resolve())
+    assert ruta_input.value == ""
     assert raiz_input.value == str(tmp_path.resolve())
 
 
@@ -413,6 +416,7 @@ def test_main_arbol_inicial_muestra_subdirectorios_y_archivos_cobra(
     subdirectorio.mkdir()
 
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COBRA_PROJECTS_DIR", str(tmp_path))
     monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
         idle.runtime, "detectar_motor_ia_sugerencias", _motor_disponible
@@ -473,6 +477,7 @@ def test_main_arbol_inicial_muestra_estado_vacio_en_tmp_path_vacio(
 ):
     ft = _fake_flet()
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COBRA_PROJECTS_DIR", str(tmp_path))
     monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
         idle.runtime, "detectar_motor_ia_sugerencias", _motor_disponible
@@ -534,6 +539,7 @@ def test_main_panel_lateral_conserva_ancho_contenido_y_arbol(monkeypatch, tmp_pa
     subdirectorio.mkdir()
 
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COBRA_PROJECTS_DIR", str(tmp_path))
     monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
         idle.runtime, "detectar_motor_ia_sugerencias", _motor_disponible
@@ -580,6 +586,7 @@ def test_main_panel_lateral_conserva_ancho_contenido_y_arbol(monkeypatch, tmp_pa
 def test_main_muestra_error_visible_si_falla_arbol_directorios(monkeypatch, tmp_path):
     ft = _fake_flet()
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COBRA_PROJECTS_DIR", str(tmp_path))
     monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
         idle.runtime, "detectar_motor_ia_sugerencias", _motor_disponible
@@ -633,6 +640,7 @@ def test_main_establecer_raiz_arbol_muestra_error_si_listado_falla(
 ):
     ft = _fake_flet()
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COBRA_PROJECTS_DIR", str(tmp_path))
     monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
         idle.runtime, "detectar_motor_ia_sugerencias", _motor_disponible
@@ -709,6 +717,7 @@ def test_main_establecer_raiz_arbol_muestra_error_si_listado_falla(
 def test_main_acciones_publicas_de_archivo(monkeypatch, tmp_path):
     ft = _fake_flet()
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COBRA_PROJECTS_DIR", str(tmp_path))
     monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
         idle.runtime, "detectar_motor_ia_sugerencias", _motor_disponible
@@ -736,7 +745,9 @@ def test_main_acciones_publicas_de_archivo(monkeypatch, tmp_path):
         idle.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}"
     )
 
-    archivo_abrir = tmp_path / "abrir.cobra"
+    subdir_abrir = tmp_path / "subdir_abrir"
+    subdir_abrir.mkdir()
+    archivo_abrir = subdir_abrir / "abrir.cobra"
     archivo_abrir.write_text("imprimir('abrir')", encoding="utf-8")
     archivo_arbol = tmp_path / "arbol.co"
     archivo_arbol.write_text("imprimir('arbol')", encoding="utf-8")
@@ -755,11 +766,19 @@ def test_main_acciones_publicas_de_archivo(monkeypatch, tmp_path):
         for c in page.controls
         if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Ruta"
     )
-    assert ruta_input.value == str(tmp_path.resolve())
+    assert ruta_input.value == ""
     salida = next(
         c
         for c in page.controls
         if isinstance(c, ft.Text) and c.kwargs.get("selectable")
+    )
+    arbol = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ListView)
+        and getattr(getattr(c, "controls", [None])[0], "value", "").startswith(
+            "Directorio raíz:"
+        )
     )
     estado_archivo = next(
         c
@@ -780,6 +799,8 @@ def test_main_acciones_publicas_de_archivo(monkeypatch, tmp_path):
     assert entrada.value == "imprimir('abrir')"
     assert salida.value == f"Archivo cargado: {archivo_abrir.resolve()}"
     assert estado_archivo.value == str(archivo_abrir.resolve())
+    assert ruta_input.value == str(archivo_abrir.resolve())
+    assert arbol.controls[0].value == f"Directorio raíz: {tmp_path.resolve()}"
 
     entrada.value = "imprimir('guardado')"
     botones["Guardar"].on_click(None)
@@ -811,6 +832,7 @@ def test_main_acciones_publicas_de_archivo(monkeypatch, tmp_path):
 def test_main_establecer_raiz_arbol_valida_directorios(monkeypatch, tmp_path):
     ft = _fake_flet()
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COBRA_PROJECTS_DIR", str(tmp_path))
     monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
         idle.runtime, "detectar_motor_ia_sugerencias", _motor_disponible


### PR DESCRIPTION
### Motivation

- Evitar usar `Path.cwd()` como raíz del árbol y clarificar dos roles distintos: la raíz del workspace y la raíz del proyecto que muestra el árbol lateral.
- Hacer que `estado.ruta` y `ruta_input` sigan representando únicamente el archivo activo y la ruta visible respectivamente, sin afectar la raíz del árbol.

### Description

- Reemplacé la variable `directorio_actual` por `workspace_root` (inicializada desde `COBRA_PROJECTS_DIR` o `Path.home() / "CobraProjects"`) y `project_root` (inicialmente igual a `workspace_root`) en `src/pcobra/gui/idle.py`.
- Modifiqué la inicialización de `raiz_input` y la reconstrucción del árbol para que usen únicamente `project_root` (texto visible y `root_path` en `runtime.crear_arbol_directorios`).
- Eliminé la lógica que cambiaba la raíz del árbol según `estado.ruta.parent` y ajusté el handler `establecer_raiz_arbol_handler` para actualizar solo `project_root` con `nonlocal project_root`.
- Mantengo la sincronización existente entre `estado.ruta` y `ruta_input` sin convertir la raíz del árbol en la ruta visible al abrir o guardar archivos, y añadí la importación de `os` requerida.
- Actualicé `tests/unit/test_gui_idle.py` para reflejar la nueva semántica (inicializar `COBRA_PROJECTS_DIR` en los tests y comprobar que `ruta_input` permanece vacío hasta abrir un archivo y que la raíz del árbol no cambia al abrir archivos en subdirectorios).

### Testing

- Ejecuté `pytest tests/unit/test_gui_idle.py -q` y todos los tests del fichero pasaron (`14 passed`).
- Verifiqué que `src/pcobra/gui/idle.py` compila con `python -m py_compile src/pcobra/gui/idle.py` sin errores.
- Formateé los archivos afectados con `black` y confirmé que no hay problemas de compilación tras los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c5092a908327ad8c7e7f7d923dbc)