### PR TITLE
Añadir helper de resolución de raíz de workspace para el IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -1,6 +1,5 @@
 """IDLE gráfico principal para editar, ejecutar e inspeccionar código Cobra."""
 
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,11 +14,7 @@ def main(page: "ft.Page"):
     ft = runtime.require_flet()
 
     estado = runtime.GuiFileState()
-    workspace_root = (
-        Path(os.environ.get("COBRA_PROJECTS_DIR") or Path.home() / "CobraProjects")
-        .expanduser()
-        .resolve(strict=False)
-    )
+    workspace_root = runtime.resolver_workspace_root_idle()
     project_root = workspace_root
 
     entrada = runtime.crear_editor_codigo(ft)

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -2,6 +2,7 @@
 
 import io
 import importlib.util
+import os
 import re
 import warnings
 from contextlib import redirect_stdout, redirect_stderr
@@ -98,6 +99,15 @@ CORRECCION_BUTTON_TEXT = "Corrección"
 
 CANONICAL_SUGGESTION_ENGINE = "agix"
 """Motor opcional canónico para sugerencias de Cobra."""
+
+
+def resolver_workspace_root_idle() -> Path:
+    """Resuelve la raíz de trabajo inicial del IDLE sin depender de ``Path.cwd()``."""
+
+    configured_root = os.environ.get("COBRA_PROJECTS_DIR")
+    if configured_root:
+        return Path(configured_root).expanduser().resolve()
+    return (Path.home() / "CobraProjects").expanduser().resolve()
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -13,6 +13,26 @@ def _ejecutar_en_tmp_path(monkeypatch, tmp_path: Path):
     monkeypatch.chdir(tmp_path)
 
 
+def test_resolver_workspace_root_idle_usa_cobra_projects_dir(
+    monkeypatch, tmp_path: Path
+):
+    workspace = tmp_path / "workspace personalizado"
+    monkeypatch.setenv("COBRA_PROJECTS_DIR", str(workspace))
+
+    assert runtime.resolver_workspace_root_idle() == workspace.resolve()
+
+
+def test_resolver_workspace_root_idle_usa_cobraprojects_en_home_sin_env(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.delenv("COBRA_PROJECTS_DIR", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert (
+        runtime.resolver_workspace_root_idle() == (tmp_path / "CobraProjects").resolve()
+    )
+
+
 def test_es_archivo_cobra_prioriza_extensiones_documentadas():
     assert runtime.es_archivo_cobra("programa.co")
     assert runtime.es_archivo_cobra("paquete.COBRA")


### PR DESCRIPTION
### Motivation

- Evitar el uso de `Path.cwd()` al determinar la raíz de proyectos del IDLE y centralizar la lógica de resolución en un helper reutilizable.
- Permitir que el IDLE use `COBRA_PROJECTS_DIR` si está presente y asegurar un fallback seguro a `~/CobraProjects` cuando no lo esté.

### Description

- Se añadió el helper `resolver_workspace_root_idle()` en `src/pcobra/gui/runtime.py` que lee `COBRA_PROJECTS_DIR` desde `os.environ` y devuelve la ruta expandida y resuelta, o `(Path.home() / "CobraProjects").expanduser().resolve()` si la variable no está definida.
- Se importó `os` en `src/pcobra/gui/runtime.py` para leer la variable de entorno.
- Se actualizó `src/pcobra/gui/idle.py` para usar `runtime.resolver_workspace_root_idle()` en lugar de construir la ruta inline.
- Se añadieron pruebas en `tests/gui/test_runtime_file_helpers.py` que cubren ambos escenarios: con `COBRA_PROJECTS_DIR` establecido y sin la variable (simulando `Path.home()` usando `monkeypatch`).

### Testing

- Se ejecutó `pytest tests/gui/test_runtime_file_helpers.py -q` y todas las pruebas relevantes pasaron (`12 passed, 1 warning`).
- Se ejecutó `ruff check src/pcobra/gui/runtime.py src/pcobra/gui/idle.py tests/gui/test_runtime_file_helpers.py` y no se reportaron errores.
- Se ejecutó `black --check --target-version py312 src/pcobra/gui/runtime.py src/pcobra/gui/idle.py tests/gui/test_runtime_file_helpers.py` y la verificación final pasó tras formateo automático del test afectado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c65ef0a48327a68678325f61c647)