### PR TITLE
Valida rutas de Guardar como en IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -218,11 +218,20 @@ def main(page: "ft.Page"):
 
     def guardar_como_handler(_e):
         """Guarda usando el campo Ruta, flujo canónico del IDLE principal."""
-        ruta = obtener_ruta_archivo_desde_input()
+        texto = (ruta_input.value or "").strip()
+
+        if not texto:
+            salida.value = "Indica la ruta de un archivo Cobra."
+            page.update()
+            return
+
+        ruta = resolver_ruta_archivo_idle(texto)
         if ruta is None:
             return
 
-        guardar_en(ruta)
+        if guardar_en(ruta):
+            ruta_input.value = str(ruta)
+            page.update()
 
     def recargar_handler(_e):
         if estado.ruta is None:

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -204,6 +204,15 @@ def resolver_ruta_archivo_en_project_root(
         raise NotADirectoryError(f"La raíz del proyecto debe ser un directorio: {raiz}")
 
     ruta_original = Path(ruta).expanduser()
+    candidata_original = (
+        ruta_original if ruta_original.is_absolute() else raiz / ruta_original
+    )
+    ruta_original_resuelta = candidata_original.resolve()
+
+    if ruta_original_resuelta.exists() and ruta_original_resuelta.is_dir():
+        raise NotADirectoryError(
+            "La ruta indicada corresponde a un directorio; indica un archivo Cobra."
+        )
 
     if not ruta_original.suffix:
         ruta_original = ruta_original.with_suffix(".cobra")

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -915,3 +915,99 @@ def test_crear_arbol_directorios_muestra_estado_vacio_en_carpeta_sin_cobras(tmp_
     assert arbol.scroll == ft.ScrollMode.ALWAYS
     assert len(arbol.controls) == 1
     assert arbol.controls[0].value == "No hay archivos Cobra en esta carpeta"
+
+
+def _preparar_idle_archivos(monkeypatch, tmp_path):
+    ft = _fake_flet()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COBRA_PROJECTS_DIR", str(tmp_path))
+    monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
+    monkeypatch.setattr(
+        idle.runtime,
+        "detectar_motor_ia_sugerencias",
+        _motor_disponible,
+    )
+    monkeypatch.setattr(idle.runtime, "gui_target_choices", lambda: ("python",))
+    monkeypatch.setattr(
+        idle.runtime,
+        "require_gui_dependencies",
+        lambda: {
+            "TRANSPILERS": {"python": object},
+            "LexerError": RuntimeError,
+            "ParserError": ValueError,
+            "Lexer": lambda _codigo: SimpleNamespace(tokenizar=lambda: []),
+            "Parser": lambda _tokens: SimpleNamespace(parsear=lambda: []),
+        },
+    )
+    monkeypatch.setattr(idle.runtime, "normalizar_codigo", lambda value: value or "")
+    monkeypatch.setattr(idle.runtime, "ejecutar_codigo", lambda _codigo: "ok")
+    monkeypatch.setattr(
+        idle.runtime, "transpilar_codigo", lambda _codigo, _lang: "transpilado"
+    )
+    monkeypatch.setattr(idle.runtime, "mostrar_tokens", lambda _codigo: "Token(X)")
+    monkeypatch.setattr(idle.runtime, "mostrar_ast", lambda _codigo: "[Nodo]")
+    monkeypatch.setattr(
+        idle.runtime, "formatear_error", lambda exc, **_kwargs: f"error: {exc}"
+    )
+    page = ft.Page()
+    idle.main(page)
+    entrada = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("multiline")
+    )
+    ruta_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Ruta"
+    )
+    salida = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.Text) and c.kwargs.get("selectable")
+    )
+    guardar_como = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Guardar como"
+    )
+    return ft, page, entrada, ruta_input, salida, guardar_como
+
+
+def test_guardar_como_resuelve_ruta_relativa_con_extension_y_normaliza_input(
+    monkeypatch, tmp_path
+):
+    _ft, _page, entrada, ruta_input, salida, guardar_como = _preparar_idle_archivos(
+        monkeypatch, tmp_path
+    )
+    (tmp_path / "src").mkdir()
+    destino = (tmp_path / "src" / "main.cobra").resolve()
+
+    entrada.value = "imprimir('main')"
+    ruta_input.value = "src/main"
+    guardar_como.on_click(None)
+
+    assert destino.read_text(encoding="utf-8") == "imprimir('main')"
+    assert salida.value == f"Archivo guardado: {destino}"
+    assert ruta_input.value == str(destino)
+
+
+def test_guardar_como_rechaza_escape_relativo_absoluto_externo_y_directorio(
+    monkeypatch, tmp_path
+):
+    _ft, _page, entrada, ruta_input, salida, guardar_como = _preparar_idle_archivos(
+        monkeypatch, tmp_path
+    )
+    directorio = tmp_path / "existente"
+    directorio.mkdir()
+    absoluto_externo = (tmp_path.parent / "escape_idle_absoluto.cobra").resolve()
+    entrada.value = "imprimir('no guardar')"
+
+    for ruta in ("../escape.cobra", str(absoluto_externo), str(directorio)):
+        ruta_input.value = ruta
+        guardar_como.on_click(None)
+        assert salida.value.startswith("error: ")
+
+    assert not (tmp_path.parent / "escape.cobra").exists()
+    assert not absoluto_externo.exists()
+    assert directorio.is_dir()

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -1199,6 +1199,16 @@ def test_resolver_ruta_archivo_en_project_root_rechaza_directorios(
         runtime.resolver_ruta_archivo_en_project_root(directorio, tmp_path)
 
 
+def test_resolver_ruta_archivo_en_project_root_rechaza_directorio_sin_extension(
+    tmp_path: Path,
+) -> None:
+    directorio = tmp_path / "directorio"
+    directorio.mkdir()
+
+    with pytest.raises(NotADirectoryError):
+        runtime.resolver_ruta_archivo_en_project_root(directorio, tmp_path)
+
+
 def test_resolver_ruta_archivo_en_project_root_rechaza_symlink_externo(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### Motivation

- Evitar que el flujo de "Guardar como" acepte rutas no válidas (escapes fuera de la raíz, directorios o extensiones no permitidas) y dejar visible la ruta normalizada después de un guardado exitoso.

### Description

- Cambia `guardar_como_handler()` en `src/pcobra/gui/idle.py` para leer explícitamente `ruta_input.value`, validar/parsear la ruta con `resolver_ruta_archivo_idle()` y llamar a `guardar_en()` solo cuando la ruta ya está validada; además actualiza `ruta_input.value` con la ruta final tras guardar.
- Refuerza `resolver_ruta_archivo_en_project_root()` en `src/pcobra/gui/runtime.py` para rechazar directorios ya existentes antes de añadir la extensión por defecto y así bloquear escapes y casos de directorio vs archivo.
- Añade pruebas en `tests/unit/test_gui_idle.py` que verifican que `src/main` crea `src/main.cobra`, que el campo de ruta se normaliza tras guardar y que se rechazan `../escape.cobra`, una ruta absoluta externa y un directorio existente.
- Añade prueba en `tests/unit/test_gui_runtime.py` que cubre el rechazo de directorios existentes incluso si la ruta no tiene extensión.

### Testing

- Se ejecutó `pytest -q tests/unit/test_gui_runtime.py::test_resolver_ruta_archivo_en_project_root_rechaza_directorio_sin_extension tests/unit/test_gui_idle.py::test_guardar_como_resuelve_ruta_relativa_con_extension_y_normaliza_input tests/unit/test_gui_idle.py::test_guardar_como_rechaza_escape_relativo_absoluto_externo_y_directorio` y todos los tests focalizados pasaron.
- Se ejecutó `pytest -q tests/unit/test_gui_runtime.py tests/unit/test_gui_idle.py` y la suite combinada pasó (74 passed, 1 warning).
- `git diff --check` no reportó problemas en el diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c8f8208c8327991ef0a8dc266be0)