### PR TITLE
Mantener raíz del árbol al abrir archivos

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -103,6 +103,9 @@ def main(page: "ft.Page"):
             mostrar_error_archivo(exc)
             page.update()
             return
+        # Abrir un archivo solo cambia el archivo activo (estado.ruta). La raíz
+        # visible del árbol permanece anclada a project_root para no contraer el
+        # explorador al directorio padre del archivo abierto.
         reconstruir_arbol()
         actualizar_pagina()
 

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -1054,6 +1054,42 @@ def test_abrir_valida_ruta_relativa_visible_dentro_del_proyecto(
     assert ruta_input.value == str(archivo)
 
 
+def test_abrir_archivo_en_subdirectorio_reconstruye_arbol_con_project_root(
+    monkeypatch, tmp_path
+):
+    llamadas_root_path = []
+    crear_arbol_real = idle.runtime.crear_arbol_directorios
+
+    def _crear_arbol_spy(*args, **kwargs):
+        llamadas_root_path.append(kwargs["root_path"])
+        return crear_arbol_real(*args, **kwargs)
+
+    monkeypatch.setattr(idle.runtime, "crear_arbol_directorios", _crear_arbol_spy)
+    (
+        _ft,
+        _page,
+        entrada,
+        ruta_input,
+        salida,
+        abrir,
+        _guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    project_root = tmp_path.resolve()
+    src = tmp_path / "src"
+    src.mkdir()
+    archivo = (src / "main.cobra").resolve()
+    archivo.write_text("imprimir('main')", encoding="utf-8")
+
+    ruta_input.value = "src/main.cobra"
+    abrir.on_click(None)
+
+    assert entrada.value == "imprimir('main')"
+    assert salida.value == f"Archivo cargado: {archivo}"
+    assert ruta_input.value == str(archivo)
+    assert llamadas_root_path[-1] == project_root
+    assert project_root / "src" not in llamadas_root_path
+
+
 def test_abrir_rechaza_ruta_visible_fuera_del_proyecto_antes_del_runtime(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
### Motivation
- Evitar que al abrir un archivo desde el IDLE la raíz visible del árbol cambie al padre del archivo abierto; la raíz debe permanecer anclada a `project_root` mientras que solo `estado.ruta` se actualiza.

### Description
- Añadido un comentario explicativo en `src/pcobra/gui/idle.py` junto al flujo de apertura para dejar explícito que abrir un archivo solo actualiza el archivo activo y no reassigna la raíz del árbol; la llamada a `reconstruir_arbol()` conserva `project_root`.
- Añadida una prueba de regresión en `tests/unit/test_gui_idle.py` que utiliza el flet falso y un spy sobre `crear_arbol_directorios()` para comprobar que al abrir `src/main.cobra` el `root_path` pasado a `crear_arbol_directorios()` es el `project_root` y no `project_root / "src"`.

### Testing
- Ejecutado `pytest tests/unit/test_gui_idle.py -q` y la suite del fichero pasó correctamente con `19 passed` (y 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36cb8ede308327a5d82257c71672df)