### PR TITLE
Añade gestión de proyectos al IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -1,5 +1,6 @@
 """IDLE gráfico principal para editar, ejecutar e inspeccionar código Cobra."""
 
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -25,7 +26,7 @@ def main(page: "ft.Page"):
     # como helper FilePicker para integraciones alternativas de Flet.
     ruta_input = runtime.flet_text_field(ft, label="Ruta", value="", expand=True)
     raiz_input = runtime.flet_text_field(
-        ft, label="Raíz del árbol", value=str(project_root), expand=True
+        ft, label="Proyecto activo", value=str(project_root), expand=True
     )
     arbol = runtime.flet_list_view(ft, expand=True, spacing=2, auto_scroll=False)
     lenguajes = list(runtime.gui_target_choices())
@@ -144,7 +145,7 @@ def main(page: "ft.Page"):
         raiz_input.value = str(project_root)
         arbol.controls.clear()
         arbol.controls.append(
-            runtime.flet_text(ft, value=f"Directorio raíz: {project_root}")
+            runtime.flet_text(ft, value=f"Proyecto activo: {project_root}")
         )
         try:
             arbol_canonico = runtime.crear_arbol_directorios(
@@ -164,32 +165,65 @@ def main(page: "ft.Page"):
         arbol.controls.extend(getattr(arbol_canonico, "controls", [arbol_canonico]))
         return True
 
-    def establecer_raiz_arbol_handler(_e):
+    def nombre_proyecto_seguro(texto: str) -> str:
+        nombre = re.sub(r"[^A-Za-z0-9._-]+", "_", texto.strip()).strip("._-")
+        if not nombre:
+            raise ValueError("Indica un nombre de proyecto válido.")
+        return nombre
+
+    def resolver_directorio_proyecto(texto: str | Path) -> Path:
+        ruta_texto = str(texto).strip()
+        if not ruta_texto:
+            raise ValueError("Indica un directorio de proyecto.")
+        ruta = Path(ruta_texto)
+        candidata = ruta if ruta.is_absolute() else workspace_root / ruta
+        candidata = candidata.resolve()
+        workspace_canonico = workspace_root.resolve()
+        if (
+            candidata != workspace_canonico
+            and workspace_canonico not in candidata.parents
+        ):
+            raise ValueError(f"El proyecto debe estar dentro de: {workspace_canonico}")
+        return candidata
+
+    def crear_proyecto_handler(_e):
         nonlocal project_root
-        if not raiz_input.value:
-            salida.value = "Indica un directorio para usar como raíz del árbol."
+        try:
+            nombre = nombre_proyecto_seguro(raiz_input.value or "")
+            nuevo_proyecto = (workspace_root / nombre).resolve()
+            nuevo_proyecto.mkdir(parents=True, exist_ok=True)
+            (nuevo_proyecto / "src").mkdir(exist_ok=True)
+            readme = nuevo_proyecto / "README.md"
+            if not readme.exists():
+                readme.write_text(f"# {nombre}\n", encoding="utf-8")
+        except (OSError, ValueError) as exc:
+            mostrar_error_archivo(exc)
             page.update()
             return
+        project_root = nuevo_proyecto
+        if not reconstruir_arbol():
+            page.update()
+            return
+        salida.value = f"Proyecto creado: {project_root}"
+        actualizar_pagina()
+
+    def establecer_raiz_arbol_handler(_e):
+        nonlocal project_root
         try:
-            nueva_raiz = runtime.normalizar_ruta_archivo_gui(raiz_input.value)
-        except (
-            FileNotFoundError,
-            NotADirectoryError,
-            PermissionError,
-            ValueError,
-        ) as exc:
+            nueva_raiz = resolver_directorio_proyecto(raiz_input.value or "")
+        except (OSError, ValueError) as exc:
             mostrar_error_archivo(exc)
             page.update()
             return
         if not nueva_raiz.is_dir():
-            salida.value = f"La raíz del árbol debe ser un directorio: {nueva_raiz}"
+            salida.value = f"El proyecto activo debe ser un directorio: {nueva_raiz}"
             page.update()
             return
         project_root = nueva_raiz
         if not reconstruir_arbol():
             page.update()
             return
-        salida.value = f"Raíz del árbol actualizada: {project_root}"
+        salida.value = f"Proyecto abierto: {project_root}"
         actualizar_pagina()
 
     def nuevo_handler(_e):
@@ -291,7 +325,10 @@ def main(page: "ft.Page"):
         controls=[
             raiz_input,
             runtime.flet_elevated_button(
-                ft, "Establecer raíz", on_click=establecer_raiz_arbol_handler
+                ft, "Crear proyecto", on_click=crear_proyecto_handler
+            ),
+            runtime.flet_elevated_button(
+                ft, "Abrir proyecto", on_click=establecer_raiz_arbol_handler
             ),
         ],
         wrap=True,

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -397,7 +397,7 @@ def test_main_inicializa_workspace_root_desde_env_y_ruta_visible_vacia(
     raiz_input = next(
         c
         for c in page.controls
-        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Raíz del árbol"
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
     )
 
     assert ruta_input.value == ""
@@ -440,13 +440,13 @@ def test_main_arbol_inicial_muestra_subdirectorios_y_archivos_cobra(
         for c in page.controls
         if isinstance(c, ft.ListView)
         and getattr(getattr(c, "controls", [None])[0], "value", "").startswith(
-            "Directorio raíz:"
+            "Proyecto activo:"
         )
     )
     entradas = arbol.controls[1:]
     titulos = [getattr(control.title, "value", "") for control in entradas]
 
-    assert arbol.controls[0].value == f"Directorio raíz: {tmp_path.resolve()}"
+    assert arbol.controls[0].value == f"Proyecto activo: {tmp_path.resolve()}"
     assert "subdirectorio" in titulos
     assert "programa.cobra" in titulos
     assert "programa.co" in titulos
@@ -518,7 +518,7 @@ def test_main_arbol_inicial_muestra_estado_vacio_en_tmp_path_vacio(
         for c in page.controls
         if isinstance(c, ft.ListView)
         and getattr(getattr(c, "controls", [None])[0], "value", "").startswith(
-            "Directorio raíz:"
+            "Proyecto activo:"
         )
     )
 
@@ -578,7 +578,7 @@ def test_main_panel_lateral_conserva_ancho_contenido_y_arbol(monkeypatch, tmp_pa
     assert arbol.expand is True
     assert columna.controls[0].value == "Archivos Cobra"
     assert columna.controls[-1] is arbol
-    assert arbol.controls[0].value == f"Directorio raíz: {tmp_path.resolve()}"
+    assert arbol.controls[0].value == f"Proyecto activo: {tmp_path.resolve()}"
     assert {"subdirectorio", "programa.cobra", "programa.co"}.issubset(titulos)
     assert entradas
 
@@ -623,7 +623,7 @@ def test_main_muestra_error_visible_si_falla_arbol_directorios(monkeypatch, tmp_
         for c in page.controls
         if isinstance(c, ft.ListView)
         and getattr(getattr(c, "controls", [None])[0], "value", "").startswith(
-            "Directorio raíz:"
+            "Proyecto activo:"
         )
     )
 
@@ -680,12 +680,12 @@ def test_main_establecer_raiz_arbol_muestra_error_si_listado_falla(
     raiz_input = next(
         c
         for c in page.controls
-        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Raíz del árbol"
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
     )
     boton_raiz = next(
         c
         for c in page.controls
-        if isinstance(c, ft.ElevatedButton) and c.text == "Establecer raíz"
+        if isinstance(c, ft.ElevatedButton) and c.text == "Abrir proyecto"
     )
     salida = next(
         c
@@ -697,7 +697,7 @@ def test_main_establecer_raiz_arbol_muestra_error_si_listado_falla(
         for c in page.controls
         if isinstance(c, ft.ListView)
         and getattr(getattr(c, "controls", [None])[0], "value", "").startswith(
-            "Directorio raíz:"
+            "Proyecto activo:"
         )
     )
 
@@ -777,7 +777,7 @@ def test_main_acciones_publicas_de_archivo(monkeypatch, tmp_path):
         for c in page.controls
         if isinstance(c, ft.ListView)
         and getattr(getattr(c, "controls", [None])[0], "value", "").startswith(
-            "Directorio raíz:"
+            "Proyecto activo:"
         )
     )
     estado_archivo = next(
@@ -800,7 +800,7 @@ def test_main_acciones_publicas_de_archivo(monkeypatch, tmp_path):
     assert salida.value == f"Archivo cargado: {archivo_abrir.resolve()}"
     assert estado_archivo.value == str(archivo_abrir.resolve())
     assert ruta_input.value == str(archivo_abrir.resolve())
-    assert arbol.controls[0].value == f"Directorio raíz: {tmp_path.resolve()}"
+    assert arbol.controls[0].value == f"Proyecto activo: {tmp_path.resolve()}"
 
     entrada.value = "imprimir('guardado')"
     botones["Guardar"].on_click(None)
@@ -871,12 +871,12 @@ def test_main_establecer_raiz_arbol_valida_directorios(monkeypatch, tmp_path):
     boton_raiz = next(
         c
         for c in page.controls
-        if isinstance(c, ft.ElevatedButton) and c.text == "Establecer raíz"
+        if isinstance(c, ft.ElevatedButton) and c.text == "Abrir proyecto"
     )
     raiz_input = next(
         c
         for c in page.controls
-        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Raíz del árbol"
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
     )
     salida = next(
         c
@@ -888,21 +888,22 @@ def test_main_establecer_raiz_arbol_valida_directorios(monkeypatch, tmp_path):
         for c in page.controls
         if isinstance(c, ft.ListView)
         and getattr(getattr(c, "controls", [None])[0], "value", "").startswith(
-            "Directorio raíz:"
+            "Proyecto activo:"
         )
     )
 
     raiz_input.value = str(archivo)
     boton_raiz.on_click(None)
     assert (
-        salida.value == f"La raíz del árbol debe ser un directorio: {archivo.resolve()}"
+        salida.value
+        == f"El proyecto activo debe ser un directorio: {archivo.resolve()}"
     )
 
     raiz_input.value = str(subdir)
     boton_raiz.on_click(None)
-    assert salida.value == f"Raíz del árbol actualizada: {subdir.resolve()}"
+    assert salida.value == f"Proyecto abierto: {subdir.resolve()}"
     assert raiz_input.value == str(subdir.resolve())
-    assert arbol.controls[0].value == f"Directorio raíz: {subdir.resolve()}"
+    assert arbol.controls[0].value == f"Proyecto activo: {subdir.resolve()}"
 
 
 def test_crear_arbol_directorios_muestra_estado_vacio_en_carpeta_sin_cobras(tmp_path):
@@ -1030,9 +1031,7 @@ def test_guardar_como_rechaza_escape_relativo_absoluto_externo_y_directorio(
     assert directorio.is_dir()
 
 
-def test_abrir_valida_ruta_relativa_visible_dentro_del_proyecto(
-    monkeypatch, tmp_path
-):
+def test_abrir_valida_ruta_relativa_visible_dentro_del_proyecto(monkeypatch, tmp_path):
     (
         _ft,
         _page,
@@ -1123,3 +1122,79 @@ def test_abrir_rechaza_ruta_visible_fuera_del_proyecto_antes_del_runtime(
         assert "raíz del proyecto" in salida.value
     finally:
         externo.unlink(missing_ok=True)
+
+
+def test_crear_proyectos_separados_con_src_y_readme(monkeypatch, tmp_path):
+    (
+        ft,
+        _page,
+        _entrada,
+        _ruta_input,
+        salida,
+        _abrir,
+        _guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    page = _page
+    proyecto_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
+    )
+    crear_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Crear proyecto"
+    )
+    arbol = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ListView)
+        and getattr(getattr(c, "controls", [None])[0], "value", "").startswith(
+            "Proyecto activo:"
+        )
+    )
+
+    for nombre in ("proyecto_uno", "proyecto_dos"):
+        proyecto_input.value = nombre
+        crear_proyecto.on_click(None)
+        proyecto = (tmp_path / nombre).resolve()
+
+        assert proyecto.is_dir()
+        assert (proyecto / "src").is_dir()
+        assert (proyecto / "README.md").read_text(encoding="utf-8") == f"# {nombre}\n"
+        assert salida.value == f"Proyecto creado: {proyecto}"
+        assert proyecto_input.value == str(proyecto)
+        assert arbol.controls[0].value == f"Proyecto activo: {proyecto}"
+
+    assert (tmp_path / "proyecto_uno") != (tmp_path / "proyecto_dos")
+
+
+def test_crear_proyecto_normaliza_nombre_seguro(monkeypatch, tmp_path):
+    (
+        ft,
+        page,
+        _entrada,
+        _ruta_input,
+        salida,
+        _abrir,
+        _guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    proyecto_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
+    )
+    crear_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Crear proyecto"
+    )
+
+    proyecto_input.value = " proyecto uno! "
+    crear_proyecto.on_click(None)
+
+    proyecto = (tmp_path / "proyecto_uno").resolve()
+    assert proyecto.is_dir()
+    assert (proyecto / "src").is_dir()
+    assert (proyecto / "README.md").is_file()
+    assert salida.value == f"Proyecto creado: {proyecto}"


### PR DESCRIPTION
### Motivation
- El campo lateral debía representar el proyecto activo en lugar de una "raíz" arbitraria para alinear la UI con la noción de proyecto. 
- Se necesitaban acciones visibles para crear y abrir proyectos desde la interfaz sin salir del flujo del IDLE. 
- La creación y apertura de proyectos debe limitarse al `workspace_root` y garantizar la estructura mínima (`src/` y `README.md`) para evitar rutas fuera del área de trabajo. 

### Description
- Reetiquetado el campo y cabecera del árbol para mostrar "Proyecto activo" y usar `project_root` como raíz del árbol; se actualizó el texto mostrado en la UI. 
- Añadidas funciones `nombre_proyecto_seguro`, `resolver_directorio_proyecto` y `crear_proyecto_handler` en `src/pcobra/gui/idle.py` para normalizar nombres, resolver rutas contra `workspace_root`, crear la carpeta del proyecto, `src/` y `README.md`, y actualizar `project_root`. 
- Modificada la acción previa de establecer raíz para convertirse en "Abrir proyecto" con validación que exige directorios y que queden dentro de `workspace_root`. 
- Añadidos botones `Crear proyecto` y `Abrir proyecto` en la barra lateral y tests unitarios en `tests/unit/test_gui_idle.py` que verifican la creación de `proyecto_uno` y `proyecto_dos` (cada uno con `src/` y `README.md`) y la normalización segura del nombre. 

### Testing
- Formateado con `python -m black src/pcobra/gui/idle.py tests/unit/test_gui_idle.py` y verificado sin errores con `git diff --check`. 
- Ejecutados los tests relevantes con `pytest tests/gui/test_runtime_file_helpers.py tests/unit/test_gui_idle.py -q`, que concluyeron correctamente con todos los tests pasando (`33 passed, 1 warning`). 
- También se ejecutaron `pytest tests/unit/test_gui_idle.py -q` durante desarrollo y pasó (`21 passed` en una ejecución previa) y los cambios fueron commitados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36cc93d3b0832796d0196f3ab83e29)