### PR TITLE
Rechazar project roots internos del repositorio en IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -184,7 +184,7 @@ def main(page: "ft.Page"):
             and workspace_canonico not in candidata.parents
         ):
             raise ValueError(f"El proyecto debe estar dentro de: {workspace_canonico}")
-        return candidata
+        return runtime.validar_project_root_idle(candidata)
 
     def crear_proyecto_handler(_e):
         nonlocal project_root

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -110,6 +110,51 @@ def resolver_workspace_root_idle() -> Path:
     return (Path.home() / "CobraProjects").expanduser().resolve()
 
 
+def resolver_repo_root_gui() -> Path:
+    """Resuelve la raíz del repositorio de Cobra relativa a este módulo GUI."""
+
+    return Path(__file__).resolve().parents[3]
+
+
+def _es_misma_ruta(candidata: Path, prohibida: Path) -> bool:
+    """Compara rutas canónicas usando ``Path.relative_to()`` de forma portable."""
+
+    try:
+        relativa = candidata.relative_to(prohibida)
+    except ValueError:
+        return False
+    return relativa == Path(".")
+
+
+def validar_project_root_idle(project_root: str | Path) -> Path:
+    """Valida que la raíz de proyecto del IDLE no sea una ruta interna del repo.
+
+    El IDLE debe abrir proyectos de usuario, no la raíz del repositorio ni las
+    carpetas de código fuente de la propia aplicación. La comparación usa rutas
+    resueltas y ``Path.relative_to()`` para conservar compatibilidad con Windows.
+    """
+
+    candidata = Path(project_root).expanduser().resolve()
+    repo_root = resolver_repo_root_gui()
+    rutas_prohibidas = {
+        repo_root: "la raíz del repositorio",
+        repo_root / "src": "src/",
+        repo_root / "src" / "pcobra": "src/pcobra/",
+        repo_root / "src" / "pcobra" / "gui": "src/pcobra/gui/",
+    }
+
+    for ruta_prohibida, descripcion in rutas_prohibidas.items():
+        ruta_prohibida_resuelta = ruta_prohibida.resolve()
+        if _es_misma_ruta(candidata, ruta_prohibida_resuelta):
+            raise ValueError(
+                "No se puede abrir como proyecto del IDLE "
+                f"{descripcion}: {ruta_prohibida_resuelta}. "
+                "Elige una carpeta de proyecto fuera del código fuente de Cobra."
+            )
+
+    return candidata
+
+
 @dataclass(frozen=True, slots=True)
 class MotorIASugerencias:
     """Resultado liviano de disponibilidad del motor IA para sugerencias."""
@@ -1052,8 +1097,7 @@ def crear_handler_sugerencias_agix(
     """Alias interno de compatibilidad; usar ``crear_handler_sugerencias``."""
 
     warnings.warn(
-        "crear_handler_sugerencias_agix está deprecado; "
-        "usa crear_handler_sugerencias.",
+        "crear_handler_sugerencias_agix está deprecado; usa crear_handler_sugerencias.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from pcobra.gui import runtime
+from pcobra.gui import idle, runtime
 
 
 @pytest.fixture(autouse=True)
@@ -230,3 +230,160 @@ def test_cargar_archivo_desde_arbol_reusa_apertura_y_valida_extension(tmp_path: 
         assert "Selecciona un archivo Cobra" in str(exc)
     else:
         raise AssertionError("El árbol solo debe cargar archivos .co/.cobra")
+
+
+@pytest.mark.parametrize(
+    "ruta_relativa, descripcion",
+    [
+        (Path("."), "la raíz del repositorio"),
+        (Path("src"), "src/"),
+        (Path("src/pcobra"), "src/pcobra/"),
+        (Path("src/pcobra/gui"), "src/pcobra/gui/"),
+    ],
+)
+def test_validar_project_root_idle_rechaza_carpetas_internas_del_repo(
+    ruta_relativa: Path, descripcion: str
+):
+    repo_root = runtime.resolver_repo_root_gui()
+    carpeta_prohibida = repo_root / ruta_relativa
+
+    with pytest.raises(ValueError) as exc_info:
+        runtime.validar_project_root_idle(carpeta_prohibida)
+
+    mensaje = str(exc_info.value)
+    assert "No se puede abrir como proyecto del IDLE" in mensaje
+    assert descripcion in mensaje
+    assert "fuera del código fuente de Cobra" in mensaje
+
+
+def test_validar_project_root_idle_acepta_carpeta_de_proyecto_externa(tmp_path: Path):
+    proyecto = tmp_path / "mi_proyecto"
+    proyecto.mkdir()
+
+    assert runtime.validar_project_root_idle(proyecto) == proyecto.resolve()
+
+
+class _FakeControl:
+    def __init__(self, *args, **kwargs):
+        if args:
+            self.controls = args[0]
+        self.value = kwargs.get(
+            "value", args[0] if args and isinstance(args[0], str) else ""
+        )
+        self.label = kwargs.get("label")
+        self.text = args[0] if args and isinstance(args[0], str) else kwargs.get("text")
+        self.on_click = kwargs.get("on_click")
+        self.controls = kwargs.get("controls", getattr(self, "controls", []))
+        self.data = kwargs.get("data")
+        self.title = kwargs.get("title")
+        self.leading = kwargs.get("leading")
+        self.disabled = kwargs.get("disabled", False)
+        self.tooltip = kwargs.get("tooltip", "")
+        self.expand = kwargs.get("expand")
+        self.spacing = kwargs.get("spacing")
+        self.auto_scroll = kwargs.get("auto_scroll")
+
+    def update(self):
+        return None
+
+
+class _FakePage:
+    def __init__(self):
+        self.controls = []
+        self.update_calls = 0
+
+    def add(self, *controls):
+        self.controls.extend(controls)
+
+    def update(self):
+        self.update_calls += 1
+
+
+def _fake_flet_idle():
+    botones = []
+    campos = []
+    textos = []
+
+    class Text(_FakeControl):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            textos.append(self)
+
+    class TextField(_FakeControl):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            campos.append(self)
+
+    class ElevatedButton(_FakeControl):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            botones.append(self)
+
+    class Option(_FakeControl):
+        pass
+
+    ft = type(
+        "FakeFlet",
+        (),
+        {
+            "TextField": TextField,
+            "Text": Text,
+            "Dropdown": _FakeControl,
+            "Switch": _FakeControl,
+            "ElevatedButton": ElevatedButton,
+            "TextButton": _FakeControl,
+            "Row": _FakeControl,
+            "Column": _FakeControl,
+            "Container": _FakeControl,
+            "ListView": _FakeControl,
+            "ListTile": _FakeControl,
+            "ExpansionTile": _FakeControl,
+            "Icon": _FakeControl,
+            "Option": Option,
+            "Icons": type(
+                "Icons", (), {"INSERT_DRIVE_FILE": "file", "FOLDER": "folder"}
+            )(),
+            "ScrollMode": type("ScrollMode", (), {"ALWAYS": "always"})(),
+        },
+    )()
+    return ft, campos, botones, textos
+
+
+@pytest.mark.parametrize(
+    "ruta_relativa, descripcion",
+    [
+        (Path("."), "la raíz del repositorio"),
+        (Path("src"), "src/"),
+        (Path("src/pcobra"), "src/pcobra/"),
+        (Path("src/pcobra/gui"), "src/pcobra/gui/"),
+    ],
+)
+def test_idle_abrir_proyecto_rechaza_carpetas_internas_del_repo(
+    monkeypatch: pytest.MonkeyPatch, ruta_relativa: Path, descripcion: str
+):
+    repo_root = runtime.resolver_repo_root_gui()
+    monkeypatch.setenv("COBRA_PROJECTS_DIR", str(repo_root.parent))
+    monkeypatch.setattr(runtime, "require_flet", lambda: ft)
+    monkeypatch.setattr(
+        runtime,
+        "require_gui_dependencies",
+        lambda: {
+            "OFFICIAL_TARGETS": runtime.PUBLIC_BACKENDS,
+            "TRANSPILERS": {target: object for target in runtime.PUBLIC_BACKENDS},
+            "target_cli_choices": lambda targets: tuple(sorted(targets)),
+        },
+    )
+    ft, campos, botones, textos = _fake_flet_idle()
+    page = _FakePage()
+
+    idle.main(page)
+    raiz_input = next(campo for campo in campos if campo.label == "Proyecto activo")
+    abrir_proyecto = next(boton for boton in botones if boton.text == "Abrir proyecto")
+
+    raiz_input.value = str((repo_root / ruta_relativa).resolve())
+    abrir_proyecto.on_click(None)
+
+    salida = next(texto for texto in textos if "No se puede abrir" in texto.value)
+    assert "No se puede abrir como proyecto del IDLE" in salida.value
+    assert descripcion in salida.value
+    assert "fuera del código fuente de Cobra" in salida.value


### PR DESCRIPTION
### Motivation
- Evitar que el IDLE abra como proyecto carpetas del propio código fuente de la aplicación (raíz del repo, `src/`, `src/pcobra/`, `src/pcobra/gui/`) por razones de seguridad y usabilidad. 

### Description
- Añade en `src/pcobra/gui/runtime.py` las funciones `resolver_repo_root_gui()`, `_es_misma_ruta()` y `validar_project_root_idle()` que usan `pathlib.Path`, `resolve()` y `relative_to()` para comparar rutas de forma portable y compatible con Windows. 
- Conecta la validación al flujo de apertura de proyecto en `src/pcobra/gui/idle.py` para impedir seleccionar raíces internas tras la comprobación del workspace. 
- Añade pruebas en `tests/gui/test_runtime_file_helpers.py` que comprueban directamente el validador para las cuatro rutas prohibidas, una prueba positiva para una carpeta externa y una prueba de interacción que inicializa el IDLE con un Flet falso y verifica el mensaje claro de rechazo. 

### Testing
- Ejecutado `pytest tests/gui/test_runtime_file_helpers.py -q` y todos los tests del archivo pasaron (`21 passed`).
- Ejecutado `pytest tests/unit/test_gui_runtime.py -q` y todos los tests del archivo pasaron (`58 passed`).
- Verificado con `git diff --check` que no quedan problemas de formato ni whitespace (comprobación automatizada realizada durante el flujo de pruebas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36cdbb63788327901115f54c2489cd)