### PR TITLE
Evitar CWD implícito en el árbol GUI

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -592,9 +592,14 @@ def crear_salida_seleccionable(ft: Any, **kwargs: Any) -> Any:
 def crear_arbol_directorios(
     ft: Any, *, on_click: Any, root_path: str | Path | None = None
 ) -> Any:
-    """Crea un árbol de directorios con carga diferida de subcarpetas."""
+    """Crea un árbol de directorios con carga diferida de subcarpetas.
+
+    Si no se proporciona ``root_path``, usa la raíz de trabajo canónica del
+    IDLE como fallback explícito en lugar de depender del directorio actual del
+    proceso.
+    """
     if root_path is None:
-        root_path = Path(".").resolve()
+        root_path = resolver_workspace_root_idle()
 
     def _crear_nodo_archivo(path: Path) -> Any:
         return ft.ListTile(

--- a/tests/unit/test_gui_app.py
+++ b/tests/unit/test_gui_app.py
@@ -108,13 +108,16 @@ def _fake_flet():
     )
 
 
+def _fake_crear_arbol_directorios(ft, on_click, root_path=None):
+    assert root_path is not None
+    return ft.Column([])
+
+
 def test_main_renderiza_componentes_minimos(monkeypatch):
     ft = _fake_flet()
     monkeypatch.setattr(app.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
-        app.runtime,
-        "crear_arbol_directorios",
-        lambda _ft, on_click, root_path=None: _ft.Column([]),
+        app.runtime, "crear_arbol_directorios", _fake_crear_arbol_directorios
     )
     monkeypatch.setattr(app.runtime, "gui_target_choices", lambda: ("python",))
     monkeypatch.setattr(
@@ -172,9 +175,7 @@ def test_main_handler_actualiza_salida(monkeypatch):
     ft = _fake_flet()
     monkeypatch.setattr(app.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
-        app.runtime,
-        "crear_arbol_directorios",
-        lambda _ft, on_click, root_path=None: _ft.Column([]),
+        app.runtime, "crear_arbol_directorios", _fake_crear_arbol_directorios
     )
     monkeypatch.setattr(app.runtime, "gui_target_choices", lambda: ("python",))
     ejecutar_mock = MagicMock(return_value="ejecutado")
@@ -239,9 +240,7 @@ def test_main_configura_selector_por_defecto_y_switch_deshabilitado_si_no_hay_ta
     ft = _fake_flet()
     monkeypatch.setattr(app.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
-        app.runtime,
-        "crear_arbol_directorios",
-        lambda _ft, on_click, root_path=None: _ft.Column([]),
+        app.runtime, "crear_arbol_directorios", _fake_crear_arbol_directorios
     )
     monkeypatch.setattr(app.runtime, "gui_target_choices", lambda: ())
     monkeypatch.setattr(

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -201,6 +201,41 @@ def test_crear_arbol_directorios_acepta_root_path_path_y_str_con_entradas_reales
     )
 
 
+def test_crear_arbol_directorios_sin_root_path_usa_workspace_idle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class Text:
+        def __init__(self, value=None, **_kwargs):
+            self.value = value
+
+    class Column:
+        def __init__(self, controls=None, **kwargs):
+            self.controls = controls or []
+            self.scroll = kwargs.get("scroll")
+
+    ft = SimpleNamespace(
+        Text=Text,
+        Column=Column,
+        ScrollMode=SimpleNamespace(ALWAYS="always"),
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    llamadas = []
+
+    def fake_resolver_workspace_root_idle() -> Path:
+        llamadas.append("resolver")
+        return workspace
+
+    monkeypatch.setattr(
+        runtime, "resolver_workspace_root_idle", fake_resolver_workspace_root_idle
+    )
+
+    arbol = runtime.crear_arbol_directorios(ft, on_click=lambda _e: None)
+
+    assert llamadas == ["resolver"]
+    assert arbol.scroll == ft.ScrollMode.ALWAYS
+    assert arbol.controls[0].value == "No hay archivos Cobra en esta carpeta"
+
 def test_crear_arbol_directorios_propaga_file_not_found_en_ruta_inexistente(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Evitar que `crear_arbol_directorios()` dependa del directorio de trabajo del proceso cuando `root_path` es `None` para comportamiento determinista del IDLE. 
- Usar la raíz de workspace del IDLE como fallback explícito en lugar de `Path('.').resolve()`.
- Asegurar que el código y las pruebas reflejen el contrato de que los callers esperan o proporcionan una raíz explícita.

### Description
- Cambia `crear_arbol_directorios()` para usar `resolver_workspace_root_idle()` cuando `root_path` sea `None` y añade aclaración en la docstring (`src/pcobra/gui/runtime.py`).
- Refuerza los dobles en `tests/unit/test_gui_app.py` para comprobar que la app pasa siempre un `root_path` al invocar `crear_arbol_directorios()`.
- Añade la prueba `test_crear_arbol_directorios_sin_root_path_usa_workspace_idle` en `tests/unit/test_gui_runtime.py` que comprueba que el fallback llama a `resolver_workspace_root_idle()` y produce la vista vacía esperada.

### Testing
- Ejecutado: `pytest tests/unit/test_gui_app.py tests/unit/test_gui_runtime.py tests/unit/test_gui_idle.py`.
- Resultado: todos los tests pasaron (`89 passed`) con 1 warning de deprecación existente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d1d28b708327a9d11e242ee9fda1)