### PR TITLE
Validar normalización de rutas del IDLE

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -249,6 +249,11 @@ def resolver_ruta_archivo_en_project_root(
         raise NotADirectoryError(f"La raíz del proyecto debe ser un directorio: {raiz}")
 
     ruta_original = Path(ruta).expanduser()
+    ruta_final = (
+        ruta_original.with_suffix(".cobra")
+        if not ruta_original.suffix
+        else ruta_original
+    )
     candidata_original = (
         ruta_original if ruta_original.is_absolute() else raiz / ruta_original
     )
@@ -259,14 +264,11 @@ def resolver_ruta_archivo_en_project_root(
             "La ruta indicada corresponde a un directorio; indica un archivo Cobra."
         )
 
-    if not ruta_original.suffix:
-        ruta_original = ruta_original.with_suffix(".cobra")
-
-    extension = ruta_original.suffix.lower()
+    extension = ruta_final.suffix.lower()
     if extension not in COBRA_FILE_EXTENSIONS:
         raise ValueError("El archivo debe usar la extensión .cobra o .co.")
 
-    candidata = ruta_original if ruta_original.is_absolute() else raiz / ruta_original
+    candidata = ruta_final if ruta_final.is_absolute() else raiz / ruta_final
     ruta_resuelta = candidata.resolve()
 
     try:

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -1053,6 +1053,27 @@ def test_abrir_valida_ruta_relativa_visible_dentro_del_proyecto(monkeypatch, tmp
     assert ruta_input.value == str(archivo)
 
 
+def test_abrir_ruta_sin_extension_normaliza_input_con_ruta_final(monkeypatch, tmp_path):
+    (
+        _ft,
+        _page,
+        entrada,
+        ruta_input,
+        salida,
+        abrir,
+        _guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    archivo = (tmp_path / "main.cobra").resolve()
+    archivo.write_text("imprimir('main')", encoding="utf-8")
+
+    ruta_input.value = "main"
+    abrir.on_click(None)
+
+    assert entrada.value == "imprimir('main')"
+    assert salida.value == f"Archivo cargado: {archivo}"
+    assert ruta_input.value == str(archivo)
+
+
 def test_abrir_archivo_en_subdirectorio_reconstruye_arbol_con_project_root(
     monkeypatch, tmp_path
 ):

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -236,6 +236,7 @@ def test_crear_arbol_directorios_sin_root_path_usa_workspace_idle(
     assert arbol.scroll == ft.ScrollMode.ALWAYS
     assert arbol.controls[0].value == "No hay archivos Cobra en esta carpeta"
 
+
 def test_crear_arbol_directorios_propaga_file_not_found_en_ruta_inexistente(
     tmp_path: Path,
 ) -> None:
@@ -1204,6 +1205,30 @@ def test_resolver_ruta_archivo_en_project_root_relativa_y_extension_por_defecto(
     destino = runtime.resolver_ruta_archivo_en_project_root("src/programa", tmp_path)
 
     assert destino == (tmp_path / "src" / "programa.cobra").resolve()
+
+
+@pytest.mark.parametrize(
+    ("ruta", "esperado"),
+    [
+        ("main", "main.cobra"),
+        ("src/main", "src/main.cobra"),
+        ("main.co", "main.co"),
+        ("main.cobra", "main.cobra"),
+    ],
+)
+def test_resolver_ruta_archivo_en_project_root_normaliza_extensiones_cobra(
+    tmp_path: Path, ruta: str, esperado: str
+) -> None:
+    destino = runtime.resolver_ruta_archivo_en_project_root(ruta, tmp_path)
+
+    assert destino == (tmp_path / esperado).resolve()
+
+
+def test_resolver_ruta_archivo_en_project_root_rechaza_extension_no_cobra(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="extensión .cobra o .co"):
+        runtime.resolver_ruta_archivo_en_project_root("main.txt", tmp_path)
 
 
 def test_resolver_ruta_archivo_en_project_root_acepta_absoluta_interna(


### PR DESCRIPTION
### Motivation

- Asegurar que la resolución de rutas usada por el IDLE normalice las extensiones de entrada según la política del proyecto y rechace extensiones no permitidas. 
- Añadir pruebas de regresión para entradas habituales (`main`, `src/main`, `main.co`, `main.cobra`) y para un caso inválido (`main.txt`).
- Garantizar que el flujo visible del IDLE deja el campo `ruta_input.value` con la ruta final resuelta tras abrir/guardar cuando procede.

### Description

- Se hizo explícita la ruta final dentro de `resolver_ruta_archivo_en_project_root()` calculando `ruta_final = ruta_original.with_suffix(".cobra")` cuando la entrada no tiene sufijo, y conservando el sufijo si ya existe, para luego validar que la extensión sea `.cobra` o `.co` y construir la candidata a partir de `ruta_final`.
- Se añadieron pruebas unitarias en `tests/unit/test_gui_runtime.py` que cubren `main`, `src/main`, `main.co`, `main.cobra` y el rechazo de `main.txt`.
- Se añadió una prueba de regresión en `tests/unit/test_gui_idle.py` que abre `main` y verifica que se carga `main.cobra` y que `ruta_input.value` queda actualizado con la ruta final resuelta.
- Se aplicó formato con `black --target-version py312` a los archivos modificados y se creó el commit con mensaje `test: cubrir normalización de rutas del IDLE`.

### Testing

- Ejecuté `pytest -q tests/unit/test_gui_runtime.py` y todos los tests pasaron (`64 passed, 1 warning`).
- Ejecuté `pytest -q tests/unit/test_gui_idle.py` y todos los tests pasaron (`22 passed, 1 warning`).
- Ejecuté combinaciones de tests puntuales que cubren los cambios añadidos y todas pasaron (varias ejecuciones con los tests nuevos y cercanos resultaron en `passed`).
- Se verificó formato con `python -m black --target-version py312 --check` y se aplicó el formateo; `git diff --check` no mostró errores; nota: un intento combinado de ejecutar ambos módulos juntos en un único paso terminó de forma anómala en el entorno por una limitación del proceso/memoria, pero las ejecuciones por separado que ejercitan los mismos archivos completaron correctamente y se usan como evidencia de éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d395bcf48327a330618522f1142b)