### PR TITLE
test: preserve project root when opening subdirectory files

### DIFF
--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -1086,8 +1086,8 @@ def test_abrir_archivo_en_subdirectorio_reconstruye_arbol_con_project_root(
 
     monkeypatch.setattr(idle.runtime, "crear_arbol_directorios", _crear_arbol_spy)
     (
-        _ft,
-        _page,
+        ft,
+        page,
         entrada,
         ruta_input,
         salida,
@@ -1103,9 +1103,16 @@ def test_abrir_archivo_en_subdirectorio_reconstruye_arbol_con_project_root(
     ruta_input.value = "src/main.cobra"
     abrir.on_click(None)
 
+    raiz_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
+    )
+
     assert entrada.value == "imprimir('main')"
     assert salida.value == f"Archivo cargado: {archivo}"
     assert ruta_input.value == str(archivo)
+    assert raiz_input.value == str(project_root)
     assert llamadas_root_path[-1] == project_root
     assert project_root / "src" not in llamadas_root_path
 


### PR DESCRIPTION
### Motivation
- Asegurar que la UI del IDLE mantiene la raíz del proyecto visible y que la reconstrucción del árbol siempre se hace desde `project_root` al abrir archivos en subdirectorios.

### Description
- Refuerzo de la prueba `test_abrir_archivo_en_subdirectorio_reconstruye_arbol_con_project_root` en `tests/unit/test_gui_idle.py` para comprobar que `raiz_input.value` es `str(project_root)` tras abrir `src/main.cobra` y que `runtime.crear_arbol_directorios()` se invoca con `root_path=project_root`.

### Testing
- Ejecutado `pytest tests/unit/test_gui_idle.py -q`; la primera ejecución falló por un error de la prueba introducido durante la edición, se corrigió y la re-ejecución pasó con éxito: `22 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d57fad048327afb3b25fdda61061)