### PR TITLE
Validar creación de proyectos en CobraProjects

### DIFF
--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -918,10 +918,11 @@ def test_crear_arbol_directorios_muestra_estado_vacio_en_carpeta_sin_cobras(tmp_
     assert arbol.controls[0].value == "No hay archivos Cobra en esta carpeta"
 
 
-def _preparar_idle_archivos(monkeypatch, tmp_path):
+def _preparar_idle_archivos(monkeypatch, tmp_path, workspace_root=None):
     ft = _fake_flet()
+    workspace_root = tmp_path if workspace_root is None else workspace_root
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("COBRA_PROJECTS_DIR", str(tmp_path))
+    monkeypatch.setenv("COBRA_PROJECTS_DIR", str(workspace_root))
     monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
     monkeypatch.setattr(
         idle.runtime,
@@ -1161,7 +1162,9 @@ def test_crear_proyectos_separados_con_src_y_readme(monkeypatch, tmp_path):
         salida,
         _abrir,
         _guardar_como,
-    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    ) = _preparar_idle_archivos(
+        monkeypatch, tmp_path, workspace_root=tmp_path / "CobraProjects"
+    )
     page = _page
     proyecto_input = next(
         c
@@ -1185,7 +1188,7 @@ def test_crear_proyectos_separados_con_src_y_readme(monkeypatch, tmp_path):
     for nombre in ("proyecto_uno", "proyecto_dos"):
         proyecto_input.value = nombre
         crear_proyecto.on_click(None)
-        proyecto = (tmp_path / nombre).resolve()
+        proyecto = (tmp_path / "CobraProjects" / nombre).resolve()
 
         assert proyecto.is_dir()
         assert (proyecto / "src").is_dir()


### PR DESCRIPTION
### Motivation
- Asegurar que la prueba verifica explícitamente la creación de proyectos bajo la raíz de workspace esperada (`CobraProjects`) y no solo bajo `tmp_path` genérico.
- Permitir que una prueba controle la raíz de workspace sin afectar el resto de tests que usan la configuración por defecto.
- Confirmar que el flujo de `crear_proyecto_handler` (normalizar nombre, resolver destino, crear carpeta, crear `src/`, crear `README.md`, actualizar `project_root`, reconstruir árbol) se mantiene intacto.

### Description
- Cambia la firma de `_preparar_idle_archivos` a aceptar un parámetro opcional `workspace_root` y usa su valor para exportar `COBRA_PROJECTS_DIR` cuando se proporciona.
- Actualiza `test_crear_proyectos_separados_con_src_y_readme` para invocar el helper con `workspace_root=tmp_path / "CobraProjects"` y para comprobar que los proyectos se crean en `CobraProjects/proyecto_uno` y `CobraProjects/proyecto_dos`, incluyendo `src/` y `README.md`.
- No se modificó `src/pcobra/gui/idle.py`; el `crear_proyecto_handler` ya implementaba el flujo requerido y permanece sin cambios.
- Archivo modificado: `tests/unit/test_gui_idle.py`.

### Testing
- Ejecuté `pytest tests/unit/test_gui_idle.py::test_crear_proyectos_separados_con_src_y_readme -q` y la prueba pasó (`1 passed, 1 warning`).
- Ejecuté `pytest tests/unit/test_gui_idle.py -q` y todo el conjunto del archivo pasó (`23 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d7bdbc18832787d7bf5f7b93f1aa)