### PR TITLE
Refuerza validación de rutas de archivos GUI

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -237,38 +237,38 @@ def resolver_ruta_archivo_en_project_root(
 ) -> Path:
     """Resuelve una ruta de archivo Cobra dentro de la raíz del proyecto IDLE.
 
-    Las rutas relativas se interpretan desde ``project_root``. Las absolutas se
-    aceptan únicamente si su ruta canónica queda dentro de ``project_root``. La
-    resolución con ``Path.resolve()`` y la comprobación con
-    ``Path.relative_to(project_root)`` bloquean escapes mediante ``..`` y
-    enlaces simbólicos externos.
+    Las rutas relativas se interpretan desde ``project_root`` y las absolutas
+    se aceptan únicamente si su ruta canónica queda dentro de esa raíz. La
+    resolución con ``Path.resolve()`` y la validación con ``Path.relative_to()``
+    bloquean escapes mediante ``..`` y enlaces simbólicos externos.
     """
 
     raiz = Path(project_root).expanduser().resolve()
     if raiz.exists() and not raiz.is_dir():
         raise NotADirectoryError(f"La raíz del proyecto debe ser un directorio: {raiz}")
 
-    ruta_original = Path(ruta).expanduser()
-    ruta_final = (
-        ruta_original.with_suffix(".cobra")
-        if not ruta_original.suffix
-        else ruta_original
+    ruta_expandida = Path(ruta).expanduser()
+    ruta_con_extension = (
+        ruta_expandida.with_suffix(".cobra")
+        if not ruta_expandida.suffix
+        else ruta_expandida
     )
-    candidata_original = (
-        ruta_original if ruta_original.is_absolute() else raiz / ruta_original
-    )
-    ruta_original_resuelta = candidata_original.resolve()
+    if ruta_con_extension.suffix.lower() not in COBRA_FILE_EXTENSIONS:
+        raise ValueError("El archivo debe usar la extensión .cobra o .co.")
 
-    if ruta_original_resuelta.exists() and ruta_original_resuelta.is_dir():
+    candidata_original = (
+        ruta_expandida if ruta_expandida.is_absolute() else raiz / ruta_expandida
+    ).resolve()
+    if candidata_original.exists() and candidata_original.is_dir():
         raise NotADirectoryError(
             "La ruta indicada corresponde a un directorio; indica un archivo Cobra."
         )
 
-    extension = ruta_final.suffix.lower()
-    if extension not in COBRA_FILE_EXTENSIONS:
-        raise ValueError("El archivo debe usar la extensión .cobra o .co.")
-
-    candidata = ruta_final if ruta_final.is_absolute() else raiz / ruta_final
+    candidata = (
+        ruta_con_extension
+        if ruta_con_extension.is_absolute()
+        else raiz / ruta_con_extension
+    )
     ruta_resuelta = candidata.resolve()
 
     try:

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -1241,6 +1241,19 @@ def test_resolver_ruta_archivo_en_project_root_acepta_absoluta_interna(
     assert destino == archivo.resolve()
 
 
+def test_resolver_ruta_archivo_en_project_root_rechaza_absoluta_externa(
+    tmp_path: Path,
+) -> None:
+    archivo_externo = tmp_path.parent / "externo_idle_helper.cobra"
+    archivo_externo.write_text("imprimir('externo')", encoding="utf-8")
+
+    try:
+        with pytest.raises(ValueError, match="dentro de la raíz del proyecto"):
+            runtime.resolver_ruta_archivo_en_project_root(archivo_externo, tmp_path)
+    finally:
+        archivo_externo.unlink(missing_ok=True)
+
+
 @pytest.mark.parametrize("ruta", ["../escape.cobra", "programa.txt"])
 def test_resolver_ruta_archivo_en_project_root_rechaza_rutas_invalidas(
     tmp_path: Path, ruta: str


### PR DESCRIPTION
### Motivation

- Asegurar que la GUI resuelva rutas de archivos de forma segura y portable, evitando escapes fuera de la raíz del proyecto o enlaces simbólicos que apunten fuera.

### Description

- Normaliza `project_root` con `Path.resolve()` y trata rutas relativas desde esa raíz; rutas absolutas solo se aceptan si su canónica queda dentro de `project_root` usando `Path.relative_to()`.
- Aplica por defecto la extensión `.cobra` cuando falta y valida explícitamente que la extensión sea `.co` o `.cobra` antes de aceptar la ruta.
- Rechaza destinos que sean directorios reales (con o sin extensión) antes y después de la resolución canónica.
- Añadí una prueba que verifica que una ruta absoluta externa (fuera de `project_root`) sea rechazada; se preservaron las pruebas existentes para escapes con `..` y symlinks externos.

### Testing

- Ejecuté la suite de pruebas relevante con `pytest tests/unit/test_gui_runtime.py -q` y la ejecución resultó en `65 passed, 1 warning`.
- Las pruebas cubren ruta relativa válida, ruta absoluta interna, `../escape.cobra`, ruta absoluta externa, directorio con `.cobra`, directorio sin extensión y symlink externo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d8b5a1f083279df80abd4fa6c541)