### PR TITLE
test: detectar referencias legacy de Flet (ft.icons/ft.colors) en GUI

### DIFF
--- a/tests/unit/test_gui_app.py
+++ b/tests/unit/test_gui_app.py
@@ -332,15 +332,17 @@ def test_crear_arbol_directorios_carga_hijos_bajo_demanda_y_filtra(tmp_path):
     assert hijo.controls == []
 
 
-def test_gui_runtime_no_usa_ft_icons_legacy():
+def test_gui_runtime_no_usa_ft_icons_ni_ft_colors_legacy():
     gui_dir = Path(__file__).resolve().parents[2] / "src" / "pcobra" / "gui"
+    referencias_legacy = {}
 
-    referencias_legacy = {
-        path.relative_to(gui_dir): line_no
-        for path in gui_dir.rglob("*.py")
-        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
-        if "ft.icons" in line
-    }
+    for path in gui_dir.rglob("*.py"):
+        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for referencia in ("ft.icons", "ft.colors"):
+                if referencia in line:
+                    referencias_legacy.setdefault(path.relative_to(gui_dir), []).append(
+                        (line_no, referencia)
+                    )
 
     assert referencias_legacy == {}
 


### PR DESCRIPTION
### Motivation
- Asegurar que los módulos bajo `src/pcobra/gui/` no usan las referencias legacy `ft.icons` ni `ft.colors` y que se emplean las APIs públicas `ft.Icons` y `ft.Colors` cuando corresponda.

### Description
- Se amplió y renombró la prueba estática en `tests/unit/test_gui_app.py` para que escanee todos los `*.py` en `src/pcobra/gui/` buscando tanto `ft.icons` como `ft.colors` y falle si se encuentran referencias legacy.

### Testing
- Ejecuté `pytest tests/unit/test_gui_app.py tests/unit/test_gui_idle.py` y todas las pruebas unitarias pasaron (`32 passed, 1 warning`).
- Ejecuté la búsqueda estática `rg -n "ft\.(icons|colors)" src/pcobra/gui` y no se encontraron referencias legacy en el código fuente del GUI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36db04a9b883279586273afa72378b)