### PR TITLE
Asegurar existencia del directorio de workspace en resolver_workspace_root_idle

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -106,8 +106,12 @@ def resolver_workspace_root_idle() -> Path:
 
     configured_root = os.environ.get("COBRA_PROJECTS_DIR")
     if configured_root:
-        return Path(configured_root).expanduser().resolve()
-    return (Path.home() / "CobraProjects").expanduser().resolve()
+        workspace_root = Path(configured_root).expanduser().resolve()
+    else:
+        workspace_root = (Path.home() / "CobraProjects").expanduser().resolve()
+
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    return workspace_root
 
 
 def resolver_repo_root_gui() -> Path:

--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -19,7 +19,10 @@ def test_resolver_workspace_root_idle_usa_cobra_projects_dir(
     workspace = tmp_path / "workspace personalizado"
     monkeypatch.setenv("COBRA_PROJECTS_DIR", str(workspace))
 
+    assert not workspace.exists()
+
     assert runtime.resolver_workspace_root_idle() == workspace.resolve()
+    assert workspace.is_dir()
 
 
 def test_resolver_workspace_root_idle_usa_cobraprojects_en_home_sin_env(
@@ -28,9 +31,11 @@ def test_resolver_workspace_root_idle_usa_cobraprojects_en_home_sin_env(
     monkeypatch.delenv("COBRA_PROJECTS_DIR", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-    assert (
-        runtime.resolver_workspace_root_idle() == (tmp_path / "CobraProjects").resolve()
-    )
+    workspace = tmp_path / "CobraProjects"
+    assert not workspace.exists()
+
+    assert runtime.resolver_workspace_root_idle() == workspace.resolve()
+    assert workspace.is_dir()
 
 
 def test_es_archivo_cobra_prioriza_extensiones_documentadas():


### PR DESCRIPTION
### Motivation

- Garantizar que la ruta resuelta para los proyectos del IDLE exista en disco antes de ser usada por la GUI.

### Description

- Mantiene la prioridad de `COBRA_PROJECTS_DIR` si está definida y, en caso contrario, usa `Path.home() / "CobraProjects"` sin introducir rutas hardcodeadas adicionales.
- Crea la carpeta resuelta con `workspace_root.mkdir(parents=True, exist_ok=True)` antes de devolverla y permite que cualquier `OSError` se propague sin silenciarlo.
- Actualiza las pruebas en `tests/gui/test_runtime_file_helpers.py` para comprobar que la función crea el directorio indicado tanto cuando `COBRA_PROJECTS_DIR` está presente como cuando se usa el valor por defecto en `Path.home()`.

### Testing

- Ejecutado `pytest tests/gui/test_runtime_file_helpers.py -q` y las pruebas relevantes pasaron (`25 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36e09df92c832788005e97efacdbe4)