### PR TITLE
test: align IDLE project paths with workspace root

### DIFF
--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -920,7 +920,9 @@ def test_crear_arbol_directorios_muestra_estado_vacio_en_carpeta_sin_cobras(tmp_
 
 def _preparar_idle_archivos(monkeypatch, tmp_path, workspace_root=None):
     ft = _fake_flet()
-    workspace_root = tmp_path if workspace_root is None else workspace_root
+    workspace_root = (
+        tmp_path / "CobraProjects" if workspace_root is None else workspace_root
+    )
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("COBRA_PROJECTS_DIR", str(workspace_root))
     monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
@@ -993,8 +995,9 @@ def test_guardar_como_resuelve_src_programa_sin_extension_como_cobra(
         _abrir,
         guardar_como,
     ) = _preparar_idle_archivos(monkeypatch, tmp_path)
-    (tmp_path / "src").mkdir()
-    destino = (tmp_path / "src" / "programa.cobra").resolve()
+    workspace_root = idle.runtime.resolver_workspace_root_idle()
+    (workspace_root / "src").mkdir()
+    destino = (workspace_root / "src" / "programa.cobra").resolve()
 
     entrada.value = "imprimir('programa')"
     ruta_input.value = "src/programa"
@@ -1017,7 +1020,8 @@ def test_guardar_como_rechaza_escape_relativo_absoluto_externo_y_directorio(
         _abrir,
         guardar_como,
     ) = _preparar_idle_archivos(monkeypatch, tmp_path)
-    directorio = tmp_path / "existente"
+    workspace_root = idle.runtime.resolver_workspace_root_idle()
+    directorio = workspace_root / "existente"
     directorio.mkdir()
     absoluto_externo = (tmp_path.parent / "escape_idle_absoluto.cobra").resolve()
     entrada.value = "imprimir('no guardar')"
@@ -1042,8 +1046,9 @@ def test_abrir_valida_ruta_relativa_visible_dentro_del_proyecto(monkeypatch, tmp
         abrir,
         _guardar_como,
     ) = _preparar_idle_archivos(monkeypatch, tmp_path)
-    (tmp_path / "src").mkdir()
-    archivo = (tmp_path / "src" / "abrir.co").resolve()
+    workspace_root = idle.runtime.resolver_workspace_root_idle()
+    (workspace_root / "src").mkdir()
+    archivo = (workspace_root / "src" / "abrir.co").resolve()
     archivo.write_text("imprimir('ok')", encoding="utf-8")
 
     ruta_input.value = "src/abrir.co"
@@ -1064,7 +1069,8 @@ def test_abrir_ruta_sin_extension_normaliza_input_con_ruta_final(monkeypatch, tm
         abrir,
         _guardar_como,
     ) = _preparar_idle_archivos(monkeypatch, tmp_path)
-    archivo = (tmp_path / "main.cobra").resolve()
+    workspace_root = idle.runtime.resolver_workspace_root_idle()
+    archivo = (workspace_root / "main.cobra").resolve()
     archivo.write_text("imprimir('main')", encoding="utf-8")
 
     ruta_input.value = "main"
@@ -1095,8 +1101,8 @@ def test_abrir_archivo_en_subdirectorio_reconstruye_arbol_con_project_root(
         abrir,
         _guardar_como,
     ) = _preparar_idle_archivos(monkeypatch, tmp_path)
-    project_root = tmp_path.resolve()
-    src = tmp_path / "src"
+    project_root = idle.runtime.resolver_workspace_root_idle()
+    src = project_root / "src"
     src.mkdir()
     archivo = (src / "main.cobra").resolve()
     archivo.write_text("imprimir('main')", encoding="utf-8")
@@ -1197,7 +1203,8 @@ def test_crear_proyectos_separados_con_src_y_readme(monkeypatch, tmp_path):
         assert proyecto_input.value == str(proyecto)
         assert arbol.controls[0].value == f"Proyecto activo: {proyecto}"
 
-    assert (tmp_path / "proyecto_uno") != (tmp_path / "proyecto_dos")
+    assert not (tmp_path / "proyecto_uno").exists()
+    assert not (tmp_path / "proyecto_dos").exists()
 
 
 def test_guardar_relativo_usa_project_root_activo_tras_abrir_segundo_proyecto(
@@ -1238,11 +1245,12 @@ def test_guardar_relativo_usa_project_root_activo_tras_abrir_segundo_proyecto(
 
     proyecto_input.value = "proyecto_uno"
     crear_proyecto.on_click(None)
-    proyecto_uno = (tmp_path / "proyecto_uno").resolve()
+    workspace_root = idle.runtime.resolver_workspace_root_idle()
+    proyecto_uno = (workspace_root / "proyecto_uno").resolve()
 
     proyecto_input.value = "proyecto_dos"
     crear_proyecto.on_click(None)
-    proyecto_dos = (tmp_path / "proyecto_dos").resolve()
+    proyecto_dos = (workspace_root / "proyecto_dos").resolve()
 
     proyecto_input.value = "proyecto_dos"
     abrir_proyecto.on_click(None)
@@ -1252,7 +1260,7 @@ def test_guardar_relativo_usa_project_root_activo_tras_abrir_segundo_proyecto(
     guardar_como.on_click(None)
 
     destino_activo = proyecto_dos / "src" / "main.cobra"
-    destino_workspace = tmp_path / "src" / "main.cobra"
+    destino_workspace = workspace_root / "src" / "main.cobra"
     destino_otro_proyecto = proyecto_uno / "src" / "main.cobra"
 
     assert proyecto_uno.is_dir()
@@ -1292,7 +1300,8 @@ def test_crear_proyecto_normaliza_nombre_seguro(monkeypatch, tmp_path):
     proyecto_input.value = " proyecto uno! "
     crear_proyecto.on_click(None)
 
-    proyecto = (tmp_path / "proyecto_uno").resolve()
+    workspace_root = idle.runtime.resolver_workspace_root_idle()
+    proyecto = (workspace_root / "proyecto_uno").resolve()
     assert proyecto.is_dir()
     assert (proyecto / "src").is_dir()
     assert (proyecto / "README.md").is_file()


### PR DESCRIPTION
### Motivation

- Evitar que las pruebas creen o comprueben proyectos bajo la raíz temporal `tmp_path` en lugar del workspace real del IDLE, y garantizar que los proyectos se creen siempre en `CobraProjects/<nombre>` o en la raíz retornada por el resolver del runtime.
- Prevenir fugas de archivos dentro del repositorio o dentro de `src/` y asegurar aislamiento entre proyectos en las pruebas.

### Description

- Cambiado el helper `_preparar_idle_archivos` para que el workspace mockeado por defecto sea `tmp_path / "CobraProjects"` cuando no se pasa `workspace_root` explícito.
- Actualizadas las expectativas en múltiples pruebas para construir rutas esperadas a partir de `idle.runtime.resolver_workspace_root_idle()` en los casos por defecto.
- Modificados tests concretos relacionados con crear/abrir/guardar (`guardar_como`, `abrir`, `abrir_archivo_en_subdirectorio`, `crear_proyectos_separados`, `guardar_relativo_usa_project_root_activo`, `crear_proyecto_normaliza_nombre_seguro`) para usar la raíz de workspace real y así no asumir `tmp_path` como raíz de proyecto.
- Añadidas comprobaciones explícitas de que no se crean carpetas `proyecto_uno`/`proyecto_dos` directamente bajo `tmp_path` cuando se usa `CobraProjects`.
- Archivo modificado: `tests/unit/test_gui_idle.py`.

### Testing

- Ejecutado `pytest tests/unit/test_gui_idle.py -q` y la suite completó con éxito; `23 passed, 1 warning`.
- Las pruebas del fichero afectado se ejecutaron localmente y pasaron sin fallos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36e3be7a008327aabbe2b67295428b)