### PR TITLE
test: refuerza flujo IDLE con dos proyectos

### DIFF
--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -1312,6 +1312,8 @@ def test_guardar_relativo_usa_project_root_activo_tras_abrir_segundo_proyecto(
     crear_proyecto.on_click(None)
     workspace_root = idle.runtime.resolver_workspace_root_idle()
     proyecto_uno = (workspace_root / "proyecto_uno").resolve()
+    archivo_proyecto_uno = proyecto_uno / "src" / "solo_uno.cobra"
+    archivo_proyecto_uno.write_text("imprimir('solo proyecto uno')", encoding="utf-8")
 
     proyecto_input.value = "proyecto_dos"
     crear_proyecto.on_click(None)
@@ -1320,6 +1322,22 @@ def test_guardar_relativo_usa_project_root_activo_tras_abrir_segundo_proyecto(
     proyecto_input.value = "proyecto_dos"
     abrir_proyecto.on_click(None)
 
+    controles_arbol_activo = arbol.controls[1:]
+    titulos_arbol_activo = [
+        getattr(getattr(control, "title", None), "value", "")
+        for control in controles_arbol_activo
+    ]
+
+    assert workspace_root == (tmp_path / "CobraProjects").resolve()
+    assert arbol.controls[0].value == f"Proyecto activo: {proyecto_dos}"
+    assert "src" in titulos_arbol_activo
+    assert "proyecto_uno" not in titulos_arbol_activo
+    assert "solo_uno.cobra" not in titulos_arbol_activo
+    assert all(
+        not str(getattr(control, "data", "")).startswith(str(proyecto_uno))
+        for control in controles_arbol_activo
+    )
+
     entrada.value = "imprimir('desde proyecto dos')"
     ruta_input.value = "src/main"
     guardar_como.on_click(None)
@@ -1327,9 +1345,13 @@ def test_guardar_relativo_usa_project_root_activo_tras_abrir_segundo_proyecto(
     destino_activo = proyecto_dos / "src" / "main.cobra"
     destino_workspace = workspace_root / "src" / "main.cobra"
     destino_otro_proyecto = proyecto_uno / "src" / "main.cobra"
+    destino_repo = (
+        idle.runtime.resolver_repo_root_gui() / "src" / "main.cobra"
+    ).resolve()
 
     assert proyecto_uno.is_dir()
     assert proyecto_dos.is_dir()
+    assert archivo_proyecto_uno.is_file()
     assert salida.value == f"Archivo guardado: {destino_activo}"
     assert ruta_input.value == str(destino_activo)
     assert proyecto_input.value == str(proyecto_dos)
@@ -1339,6 +1361,7 @@ def test_guardar_relativo_usa_project_root_activo_tras_abrir_segundo_proyecto(
     )
     assert not destino_workspace.exists()
     assert not destino_otro_proyecto.exists()
+    assert not destino_repo.exists()
 
 
 def test_crear_proyecto_normaliza_nombre_seguro(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation

- Asegurar que el flujo del IDLE con múltiples proyectos mantiene la raíz de proyecto activa al reconstruir el árbol y al guardar rutas relativas, evitando exponer archivos de proyectos distintos ni escribir fuera del proyecto activo.

### Description

- Se añadió en `tests/unit/test_gui_idle.py` la creación de un archivo exclusivo en `proyecto_uno/src/solo_uno.cobra` para simular contenido que no debe verse desde `proyecto_dos`.
- Se añadieron comprobaciones del árbol renderizado para verificar que el encabezado es `Proyecto activo: <ruta de proyecto_dos>` y que las entradas visibles no incluyen `proyecto_uno` ni `solo_uno.cobra` ni rutas que apunten a `proyecto_uno`.
- Se añadieron aserciones que confirman que al guardar `src/main` se crea `CobraProjects/proyecto_dos/src/main.cobra` y que no aparecen ficheros equivalentes en el workspace raíz, en `proyecto_uno` ni en la raíz del repositorio.
- Los cambios se guardaron en un commit con mensaje `test: refuerza flujo IDLE con dos proyectos`.

### Testing

- Ejecuté `pytest tests/unit/test_gui_idle.py::test_guardar_relativo_usa_project_root_activo_tras_abrir_segundo_proyecto tests/unit/test_gui_idle.py::test_crear_proyectos_separados_con_src_y_readme -q` y ambos tests pasaron.
- Ejecuté `pytest tests/unit/test_gui_idle.py -q` y la batería completa de tests del archivo pasó (`24 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3791efdd3c832798948d0695087859)