### PR TITLE
Asegurar creación de la raíz de workspace del IDLE

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -102,7 +102,7 @@ CANONICAL_SUGGESTION_ENGINE = "agix"
 
 
 def resolver_workspace_root_idle() -> Path:
-    """Resuelve la raíz de trabajo inicial del IDLE sin depender de ``Path.cwd()``."""
+    """Resuelve y crea la raíz de trabajo inicial del IDLE sin usar ``Path.cwd()``."""
 
     configured_root = os.environ.get("COBRA_PROJECTS_DIR")
     if configured_root:

--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -13,7 +13,7 @@ def _ejecutar_en_tmp_path(monkeypatch, tmp_path: Path):
     monkeypatch.chdir(tmp_path)
 
 
-def test_resolver_workspace_root_idle_usa_cobra_projects_dir(
+def test_resolver_workspace_root_idle_crea_cobra_projects_dir_configurado(
     monkeypatch, tmp_path: Path
 ):
     workspace = tmp_path / "workspace personalizado"
@@ -25,7 +25,7 @@ def test_resolver_workspace_root_idle_usa_cobra_projects_dir(
     assert workspace.is_dir()
 
 
-def test_resolver_workspace_root_idle_usa_cobraprojects_en_home_sin_env(
+def test_resolver_workspace_root_idle_crea_cobraprojects_en_home_sin_env(
     monkeypatch, tmp_path: Path
 ):
     monkeypatch.delenv("COBRA_PROJECTS_DIR", raising=False)


### PR DESCRIPTION
### Motivation
- Garantizar que `resolver_workspace_root_idle()` resuelva y cree la carpeta de proyectos del IDLE antes de devolverla, tanto cuando se usa `COBRA_PROJECTS_DIR` como cuando se usa el valor por defecto `Path.home() / "CobraProjects"`.

### Description
- Aclaré el docstring de `resolver_workspace_root_idle()` para reflejar que la ruta se resuelve y se crea; la función mantiene la llamada a `workspace_root.mkdir(parents=True, exist_ok=True)` antes de devolver `workspace_root` en `src/pcobra/gui/runtime.py`.
- Renombré dos tests en `tests/gui/test_runtime_file_helpers.py` para documentar explícitamente que las pruebas verifican la creación de la carpeta configurada por `COBRA_PROJECTS_DIR` y la creación del directorio por defecto en `Path.home()`.
- Los archivos modificados son `src/pcobra/gui/runtime.py` y `tests/gui/test_runtime_file_helpers.py` y los cambios se han committeado con el mensaje `Clarify IDLE workspace root creation`.

### Testing
- Ejecuté `pytest tests/gui/test_runtime_file_helpers.py` y los tests pasaron exitosamente con salida `25 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37935b02a483278d1722a6237df4ac)