### PR TITLE
test: validate idle project sidebar layout

### DIFF
--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -213,11 +213,22 @@ def test_panel_lateral_organiza_proyecto_en_columna(monkeypatch, tmp_path):
     panel_lateral = next(
         c for c in page.controls if isinstance(c, ft.Container) and c.width == 280
     )
+    assert panel_lateral.width == 280
+
     contenido_panel = panel_lateral.content
     assert isinstance(contenido_panel, ft.Column)
+    assert contenido_panel.controls[0].value == "Archivos Cobra"
 
     barra_raiz_arbol = contenido_panel.controls[1]
     assert isinstance(barra_raiz_arbol, ft.Column)
+
+    arbol = contenido_panel.controls[2]
+    assert isinstance(arbol, ft.ListView)
+    assert contenido_panel.controls == [
+        contenido_panel.controls[0],
+        barra_raiz_arbol,
+        arbol,
+    ]
 
     raiz_input = barra_raiz_arbol.controls[0]
     assert isinstance(raiz_input, ft.TextField)
@@ -226,10 +237,13 @@ def test_panel_lateral_organiza_proyecto_en_columna(monkeypatch, tmp_path):
 
     barra_botones = barra_raiz_arbol.controls[1]
     assert isinstance(barra_botones, (ft.Row, ft.Column))
-    assert [boton.text for boton in barra_botones.controls] == [
+    botones = barra_botones.controls
+    assert [boton.text for boton in botones] == [
         "Crear proyecto",
         "Abrir proyecto",
     ]
+    assert botones[0].on_click.__name__ == "crear_proyecto_handler"
+    assert botones[1].on_click.__name__ == "establecer_raiz_arbol_handler"
 
     filas_con_textfield_expand_y_botones = [
         control


### PR DESCRIPTION
### Motivation
- Asegurar que la barra de proyecto en el panel lateral del IDLE presenta la estructura esperada y que los botones están correctamente enlazados para evitar regresiones en la UI.

### Description
- Se reforzó la prueba `test_panel_lateral_organiza_proyecto_en_columna` en `tests/unit/test_gui_idle.py` para verificar el ancho del panel lateral (`280`), que su contenido es una columna y que los controles aparecen en el orden `"Archivos Cobra"`, la barra de proyecto y el árbol.
- La prueba ahora valida que `raiz_input` tiene la etiqueta `"Proyecto activo"` y `expand=True`, que los botones son `"Crear proyecto"` y `"Abrir proyecto"`, y que sus `on_click` apuntan a `crear_proyecto_handler` y `establecer_raiz_arbol_handler` respectivamente.
- Se mantiene la comprobación de que un campo `expand` no comparte una misma fila con botones para evitar problemas de renderizado.

### Testing
- Ejecutado `pytest tests/unit/test_gui_idle.py -q` y la suite de pruebas del archivo pasó correctamente con `24 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a379450e22c8327a12419d9e430253b)