### PR TITLE
Asegura estructura aislada de proyectos en el IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -186,16 +186,19 @@ def main(page: "ft.Page"):
             raise ValueError(f"El proyecto debe estar dentro de: {workspace_canonico}")
         return runtime.validar_project_root_idle(candidata)
 
+    def inicializar_estructura_proyecto(ruta_proyecto: Path, nombre: str) -> None:
+        ruta_proyecto.mkdir(parents=True, exist_ok=True)
+        (ruta_proyecto / "src").mkdir(exist_ok=True)
+        readme = ruta_proyecto / "README.md"
+        if not readme.exists():
+            readme.write_text(f"# {nombre}\n", encoding="utf-8")
+
     def crear_proyecto_handler(_e):
         nonlocal project_root
         try:
             nombre = nombre_proyecto_seguro(raiz_input.value or "")
             nuevo_proyecto = (workspace_root / nombre).resolve()
-            nuevo_proyecto.mkdir(parents=True, exist_ok=True)
-            (nuevo_proyecto / "src").mkdir(exist_ok=True)
-            readme = nuevo_proyecto / "README.md"
-            if not readme.exists():
-                readme.write_text(f"# {nombre}\n", encoding="utf-8")
+            inicializar_estructura_proyecto(nuevo_proyecto, nombre)
         except (OSError, ValueError) as exc:
             mostrar_error_archivo(exc)
             page.update()
@@ -217,6 +220,12 @@ def main(page: "ft.Page"):
             return
         if not nueva_raiz.is_dir():
             salida.value = f"El proyecto activo debe ser un directorio: {nueva_raiz}"
+            page.update()
+            return
+        try:
+            inicializar_estructura_proyecto(nueva_raiz, nueva_raiz.name)
+        except OSError as exc:
+            mostrar_error_archivo(exc)
             page.update()
             return
         project_root = nueva_raiz


### PR DESCRIPTION
### Motivation
- Garantizar que cada proyecto creado o abierto en el IDLE tenga su propia estructura mínima (`src/` y `README.md`) y que la raíz activa del GUI (`project_root`) apunte al proyecto correcto.
- Evitar que archivos relativos terminen en la raíz de workspace, en otro proyecto o en el `src/` del repositorio, y mantener el árbol del explorador limitado al proyecto activo.

### Description
- Se extrajo e introdujo la función interna `inicializar_estructura_proyecto(ruta_proyecto: Path, nombre: str)` que crea `ruta_proyecto`, su subdirectorio `src/` y `README.md` si no existen. (modificación en `src/pcobra/gui/idle.py`).
- `crear_proyecto_handler` ahora usa `inicializar_estructura_proyecto` tras construir la ruta con `(workspace_root / nombre).resolve()` para crear el proyecto y luego asignar `project_root` al proyecto creado.
- `establecer_raiz_arbol_handler` llama a `inicializar_estructura_proyecto` al abrir un proyecto existente antes de asignar `project_root`, y propaga errores de sistema a la UI si la inicialización falla.
- No se cambió el comportamiento de `reconstruir_arbol()`: continúa llamando a `runtime.crear_arbol_directorios(..., root_path=project_root)` para listar el árbol anclado a la raíz del proyecto activo.

### Testing
- Ejecutado `pytest tests/unit/test_gui_idle.py`, todos los tests pasaron (24 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37955f324c832788434f08cf92ac04)