### PR TITLE
test: asegurar resolución del workspace del IDLE

### DIFF
--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -17,11 +17,12 @@ def test_resolver_workspace_root_idle_crea_cobra_projects_dir_configurado(
     monkeypatch, tmp_path: Path
 ):
     workspace = tmp_path / "workspace personalizado"
+    workspace_resuelto = workspace.resolve()
     monkeypatch.setenv("COBRA_PROJECTS_DIR", str(workspace))
 
     assert not workspace.exists()
 
-    assert runtime.resolver_workspace_root_idle() == workspace.resolve()
+    assert runtime.resolver_workspace_root_idle() == workspace_resuelto
     assert workspace.is_dir()
 
 
@@ -32,9 +33,10 @@ def test_resolver_workspace_root_idle_crea_cobraprojects_en_home_sin_env(
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     workspace = tmp_path / "CobraProjects"
+    workspace_resuelto = workspace.resolve()
     assert not workspace.exists()
 
-    assert runtime.resolver_workspace_root_idle() == workspace.resolve()
+    assert runtime.resolver_workspace_root_idle() == workspace_resuelto
     assert workspace.is_dir()
 
 


### PR DESCRIPTION
### Motivation
- Asegurar que `resolver_workspace_root_idle()` crea la carpeta de trabajo y devuelve la ruta resuelta, y reforzar las pruebas para verificar ese comportamiento de forma explícita.

### Description
- Se actualizan las pruebas en `tests/gui/test_runtime_file_helpers.py` para resolver previamente la ruta esperada (`workspace_resuelto`) y comparar la salida de `resolver_workspace_root_idle()` contra esa ruta resuelta sin modificar la lógica de `src/pcobra/gui/runtime.py`.

### Testing
- Ejecutado `pytest tests/gui/test_runtime_file_helpers.py` y todas las pruebas relacionadas pasaron (25 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3796e70ad08327bb65749462ef6513)