### PR TITLE
test: enforce project bar row layout

### DIFF
--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -236,7 +236,7 @@ def test_panel_lateral_organiza_proyecto_en_columna(monkeypatch, tmp_path):
     assert raiz_input.kwargs.get("expand") is True
 
     barra_botones = barra_raiz_arbol.controls[1]
-    assert isinstance(barra_botones, (ft.Row, ft.Column))
+    assert isinstance(barra_botones, ft.Row)
     botones = barra_botones.controls
     assert [boton.text for boton in botones] == [
         "Crear proyecto",


### PR DESCRIPTION
### Motivation
- Asegurar que la barra de control de raíz del árbol (`barra_raiz_arbol`) use una fila para los botones y que el layout lateral mantenga el orden: texto, barra de raíz y árbol.

### Description
- Ajusté la prueba unitaria para exigir que `barra_botones` sea una `ft.Row` en lugar de aceptar también `ft.Column` en `tests/unit/test_gui_idle.py`.
- No fue necesario modificar `src/pcobra/gui/idle.py` porque ya construye `barra_raiz_arbol` como `runtime.flet_column(...)` con `raiz_input` primero y una `runtime.flet_row(...)` hija que contiene los botones `Crear proyecto` y `Abrir proyecto` y conserva los handlers `crear_proyecto_handler` y `establecer_raiz_arbol_handler`.
- El cambio se limita a endurecer la verificación del layout fake de Flet sin alterar la lógica del IDLE.

### Testing
- Ejecuté `pytest tests/unit/test_gui_idle.py -q` y todas las pruebas del archivo pasaron (24 passed).
- No se ejecutaron cambios en otros tests automáticos y no se observaron fallos tras la modificación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3797e7879883278af8f4d21a33d664)