### PR TITLE
Refuerza aislamiento de proyectos en IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -179,16 +179,17 @@ def main(page: "ft.Page"):
         candidata = ruta if ruta.is_absolute() else workspace_root / ruta
         candidata = candidata.resolve()
         workspace_canonico = workspace_root.resolve()
-        if (
-            candidata != workspace_canonico
-            and workspace_canonico not in candidata.parents
-        ):
-            raise ValueError(f"El proyecto debe estar dentro de: {workspace_canonico}")
+        try:
+            candidata.relative_to(workspace_canonico)
+        except ValueError as exc:
+            raise ValueError(
+                f"El proyecto debe estar dentro de: {workspace_canonico}"
+            ) from exc
         return runtime.validar_project_root_idle(candidata)
 
     def inicializar_estructura_proyecto(ruta_proyecto: Path, nombre: str) -> None:
         ruta_proyecto.mkdir(parents=True, exist_ok=True)
-        (ruta_proyecto / "src").mkdir(exist_ok=True)
+        (ruta_proyecto / "src").mkdir(parents=True, exist_ok=True)
         readme = ruta_proyecto / "README.md"
         if not readme.exists():
             readme.write_text(f"# {nombre}\n", encoding="utf-8")

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -1378,6 +1378,49 @@ def test_guardar_relativo_usa_project_root_activo_tras_abrir_segundo_proyecto(
     assert not destino_repo.exists()
 
 
+def test_abrir_proyecto_rechaza_ruta_fuera_de_workspace(monkeypatch, tmp_path):
+    (
+        ft,
+        page,
+        _entrada,
+        _ruta_input,
+        salida,
+        _abrir,
+        _guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    workspace_root = idle.runtime.resolver_workspace_root_idle()
+    externo = tmp_path / "proyecto_externo"
+    externo.mkdir()
+    (externo / "src").mkdir()
+
+    proyecto_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
+    )
+    abrir_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Abrir proyecto"
+    )
+    arbol = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ListView)
+        and getattr(getattr(c, "controls", [None])[0], "value", "").startswith(
+            "Proyecto activo:"
+        )
+    )
+
+    proyecto_input.value = str(externo)
+    abrir_proyecto.on_click(None)
+
+    assert salida.value.startswith("error: ")
+    assert f"El proyecto debe estar dentro de: {workspace_root}" in salida.value
+    assert proyecto_input.value == str(externo)
+    assert arbol.controls[0].value == f"Proyecto activo: {workspace_root}"
+
+
 def test_crear_proyecto_normaliza_nombre_seguro(monkeypatch, tmp_path):
     (
         ft,


### PR DESCRIPTION
### Motivation

- Evitar que el IDLE abra o escriba proyectos fuera del directorio de trabajo del usuario y mantener el árbol de archivos anclado al proyecto activo para prevenir fugas hacia el repositorio o rutas globales. 
- Garantizar la creación mínima y predecible de la estructura de un proyecto (carpeta del proyecto, `src/`, `README.md`) bajo `workspace_root` cuando el usuario crea un proyecto nuevo. 
- Hacer la validación de rutas más robusta y portable usando comparaciones canónicas para bloquear escapes con `..` o symlinks.

### Description

- `resolver_directorio_proyecto` ahora valida pertenencia a `workspace_root` usando `Path.relative_to()` y rechaza rutas externas con un `ValueError`. (src/pcobra/gui/idle.py)
- `inicializar_estructura_proyecto` crea de forma idempotente la carpeta del proyecto, `src/` (con `parents=True`) y `README.md` si no existe. (src/pcobra/gui/idle.py)
- `crear_proyecto_handler` continúa creando proyectos únicamente en `workspace_root / nombre` y actualiza `project_root` al proyecto activo creado. (src/pcobra/gui/idle.py)
- `reconstruir_arbol()` mantiene la llamada a `runtime.crear_arbol_directorios(..., root_path=project_root)` para renderizar siempre desde el proyecto activo; las rutas relativas del flujo Guardar/Guardar como se resuelven contra `project_root` a través de las funciones de `runtime`. (src/pcobra/gui/idle.py y runtime)
- Se añadió la prueba `test_abrir_proyecto_rechaza_ruta_fuera_de_workspace` para verificar que intentar abrir un proyecto fuera de `workspace_root` sea rechazado y que el árbol activo no cambie. (tests/unit/test_gui_idle.py)

### Testing

- Ejecutado `pytest -q tests/unit/test_gui_idle.py`, todos los tests relevantes pasaron: `25 passed, 1 warning`.
- Las pruebas existentes que verifican creación de proyectos independientes, existencia de `src/` y `README.md`, aislamiento del árbol entre proyectos, y que guardar rutas relativas resuelve contra el proyecto activo se mantienen y pasan exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3798db50e083278d712972e8715fc5)