### PR TITLE
Add validated GUI delete helpers (GUI-DELETE-SAFE-001 phase 1)

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -4,6 +4,7 @@ import io
 import importlib.util
 import os
 import re
+import shutil
 import warnings
 from contextlib import redirect_stdout, redirect_stderr
 from dataclasses import dataclass
@@ -481,6 +482,54 @@ def guardar_archivo_activo_validado(
     estado.contenido_cargado = codigo
     estado.cambios_sin_guardar = False
     return codigo, f"Archivo guardado: {destino}"
+
+
+def eliminar_archivo_validado(ruta: Path) -> None:
+    """Elimina un archivo cuya ruta ya fue validada por el IDLE principal."""
+
+    destino = Path(ruta).resolve()
+    if not destino.exists():
+        raise FileNotFoundError(
+            f"No existe el archivo que se quiere eliminar: {destino}"
+        )
+    if not destino.is_file():
+        raise ValueError(f"La ruta indicada no es un archivo: {destino}")
+    destino.unlink()
+
+
+def eliminar_directorio_validado(ruta: Path) -> None:
+    """Elimina un directorio cuya ruta ya fue validada por el IDLE principal."""
+
+    destino = Path(ruta).resolve()
+    if not destino.exists():
+        raise FileNotFoundError(
+            f"No existe el directorio que se quiere eliminar: {destino}"
+        )
+    if not destino.is_dir():
+        raise NotADirectoryError(f"La ruta indicada no es un directorio: {destino}")
+    shutil.rmtree(destino)
+
+
+def eliminar_proyecto_validado(project_root: Path, workspace_root: Path) -> None:
+    """Elimina un proyecto cuya raíz ya fue validada por el IDLE principal."""
+
+    proyecto = Path(project_root).resolve()
+    workspace = Path(workspace_root).resolve()
+    if proyecto == workspace:
+        raise ValueError("No se puede eliminar la raíz completa del workspace.")
+    if proyecto.parent != workspace:
+        raise ValueError(
+            "La raíz del proyecto debe ser hija directa de la raíz del workspace."
+        )
+    if not proyecto.exists():
+        raise FileNotFoundError(
+            f"No existe el proyecto que se quiere eliminar: {proyecto}"
+        )
+    if not proyecto.is_dir():
+        raise NotADirectoryError(
+            f"La ruta del proyecto no es un directorio: {proyecto}"
+        )
+    shutil.rmtree(proyecto)
 
 
 def leer_archivo_texto_validado(


### PR DESCRIPTION
### Motivation
- Añadir funciones de borrado seguro en el runtime de la GUI para rutas que ya fueron validadas por el IDLE, implementando la fase 1 de GUI-DELETE-SAFE-001.
- Mantener la validación de pertenencia al proyecto en el IDLE y evitar reintroducir la validación del sandbox global en estas funciones.

### Description
- Modificado únicamente `src/pcobra/gui/runtime.py` y añadido `import shutil` para soporte de borrado recursivo de directorios. 
- Añadida la función `eliminar_archivo_validado(ruta: Path) -> None` que resuelve la ruta, lanza `FileNotFoundError` si no existe, lanza `ValueError` si no es archivo y elimina con `unlink()`.
- Añadida la función `eliminar_directorio_validado(ruta: Path) -> None` que resuelve la ruta, lanza `FileNotFoundError` si no existe, lanza `NotADirectoryError` si no es directorio y elimina con `shutil.rmtree()`.
- Añadida la función `eliminar_proyecto_validado(project_root: Path, workspace_root: Path) -> None` que resuelve ambos paths, bloquea la eliminación si `project_root == workspace_root` o si `project_root.parent != workspace_root`, valida existencia y tipo directorio, y elimina con `shutil.rmtree()`.

### Testing
- Ejecutado `python -m compileall -q src/pcobra/gui/runtime.py` y la compilación pasó correctamente.
- Ejecutado un snippet funcional que crea un archivo, un directorio y un proyecto temporales dentro del repo y verifica que `eliminar_archivo_validado`, `eliminar_directorio_validado` y `eliminar_proyecto_validado` eliminan los recursos esperados, y la prueba pasó correctamente.
- Ejecutado `git diff --check` y no se encontraron problemas en el diff generado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37a982b0288327b38d133e1524ddc0)