### PR TITLE
Agregar helper resolver_ruta_en_project_root en IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -52,6 +52,23 @@ def main(page: "ft.Page"):
     def mostrar_error_archivo(exc: Exception) -> None:
         salida.value = runtime.formatear_error(exc)
 
+    def resolver_ruta_en_project_root(ruta: str | Path) -> Path:
+        project_root_resuelto = Path(project_root).expanduser().resolve()
+        ruta_expandida = Path(ruta).expanduser()
+        candidata = (
+            ruta_expandida
+            if ruta_expandida.is_absolute()
+            else project_root_resuelto / ruta_expandida
+        )
+        candidata = candidata.resolve()
+        try:
+            candidata.relative_to(project_root_resuelto)
+        except ValueError as exc:
+            raise ValueError(
+                f"La ruta debe estar dentro del proyecto activo: {project_root_resuelto}"
+            ) from exc
+        return candidata
+
     def resolver_ruta_archivo_idle(ruta: str | Path) -> Path | None:
         try:
             return runtime.resolver_ruta_archivo_en_project_root(ruta, project_root)


### PR DESCRIPTION
### Motivation
- Añadir un helper interno para normalizar y validar rutas relativas/absolutas contra el `project_root` activo sin mezclarlo con las validaciones específicas de archivos Cobra.

### Description
- Se añadió la función interna `resolver_ruta_en_project_root(ruta: str | Path) -> Path` dentro de `main(page)` para resolver `project_root` con `Path(project_root).expanduser().resolve()` y expandir la entrada con `Path(ruta).expanduser()`.
- Si la entrada es relativa se concatena con `project_root_resuelto`, si es absoluta se usa directamente, luego se aplica `.resolve()` a la candidata.
- Se valida que la `candidata.relative_to(project_root_resuelto)` y se lanza `ValueError` con el mensaje `La ruta debe estar dentro del proyecto activo: {project_root_resuelto}` si falla.
- No se añadió validación de extensión en este helper y se mantiene `resolver_ruta_archivo_idle()` sin cambios para las comprobaciones específicas de archivos Cobra.

### Testing
- `python -m compileall -q src/pcobra/gui/idle.py` se ejecutó correctamente sin errores de sintaxis.
- `git diff --check` se ejecutó como parte del flujo de verificación y no reportó problemas relacionados con este cambio.
- `pytest -q tests` falló durante la colección por errores de importación no relacionados con esta modificación, incluyendo la falta de `LEGACY_BACKEND_REMOVAL_CANDIDATES` y varios `ModuleNotFoundError` para `cobra.transpilers.transpiler.to_asm`, `to_go` y `to_wasm`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37ade188d883278963a55b81f0261e)