### PR TITLE
Agregar eliminación de archivo activo en IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -354,6 +354,39 @@ def main(page: "ft.Page"):
         reconstruir_arbol()
         actualizar_pagina()
 
+    def eliminar_archivo_handler(_e):
+
+        if not requerir_proyecto_activo():
+            return
+
+        if estado.ruta is None:
+            salida.value = "No hay archivo activo para eliminar."
+            page.update()
+            return
+        ruta_resuelta = resolver_ruta_archivo_idle(estado.ruta)
+        if ruta_resuelta is None:
+            return
+        try:
+            runtime.eliminar_archivo_validado(ruta_resuelta)
+        except (
+            FileNotFoundError,
+            NotADirectoryError,
+            PermissionError,
+            OSError,
+            ValueError,
+        ) as exc:
+            mostrar_error_archivo(exc)
+            page.update()
+            return
+        estado.ruta = None
+        estado.contenido_cargado = ""
+        estado.cambios_sin_guardar = False
+        entrada.value = ""
+        ruta_input.value = ""
+        reconstruir_arbol()
+        salida.value = f"Archivo eliminado: {ruta_resuelta}"
+        actualizar_pagina()
+
     ejecutar_handler = runtime.crear_handler_ejecucion(
         entrada=entrada, salida=salida, selector=selector, activar=activar, page=page
     )
@@ -400,6 +433,9 @@ def main(page: "ft.Page"):
                 ft, "Guardar como", on_click=guardar_como_handler
             ),
             runtime.flet_elevated_button(ft, "Recargar", on_click=recargar_handler),
+            runtime.flet_elevated_button(
+                ft, "Eliminar", on_click=eliminar_archivo_handler
+            ),
         ],
         wrap=True,
     )

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -1451,3 +1451,55 @@ def test_crear_proyecto_normaliza_nombre_seguro(monkeypatch, tmp_path):
     assert (proyecto / "src").is_dir()
     assert (proyecto / "README.md").is_file()
     assert salida.value == f"Proyecto creado: {proyecto}"
+
+
+def test_eliminar_archivo_activo_reinicia_editor_y_estado_visual(monkeypatch, tmp_path):
+    (
+        ft,
+        page,
+        entrada,
+        ruta_input,
+        salida,
+        _abrir,
+        guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    proyecto_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
+    )
+    crear_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Crear proyecto"
+    )
+    eliminar = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Eliminar"
+    )
+    estado_archivo = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.Text) and c.value == "Archivo nuevo (sin guardar)"
+    )
+
+    proyecto_input.value = "proyecto"
+    crear_proyecto.on_click(None)
+    destino = (
+        idle.runtime.resolver_workspace_root_idle()
+        / "proyecto"
+        / "src"
+        / "borrar.cobra"
+    ).resolve()
+    entrada.value = "imprimir('borrar')"
+    ruta_input.value = "src/borrar"
+    guardar_como.on_click(None)
+
+    eliminar.on_click(None)
+
+    assert not destino.exists()
+    assert entrada.value == ""
+    assert ruta_input.value == ""
+    assert salida.value == f"Archivo eliminado: {destino}"
+    assert estado_archivo.value == "Archivo nuevo (sin guardar)"


### PR DESCRIPTION
### Motivation
- Permitir al usuario eliminar el archivo actualmente activo desde la UI del IDLE y restablecer el estado del editor al archivo nuevo/sin guardar tras una eliminación exitosa.

### Description
- Añadido el handler `eliminar_archivo_handler(_e)` que valida proyecto activo con `requerir_proyecto_activo()`, comprueba `estado.ruta`, resuelve la ruta con `resolver_ruta_archivo_idle` y llama a `runtime.eliminar_archivo_validado(ruta_resuelta)` manejando las excepciones solicitadas con `mostrar_error_archivo(exc)`.
- Tras eliminar con éxito se reinician `estado.ruta`, `estado.contenido_cargado`, `estado.cambios_sin_guardar`, `entrada.value` y `ruta_input.value`, se llama a `reconstruir_arbol()` y a `actualizar_pagina()` y se asigna `salida.value = f"Archivo eliminado: {ruta_resuelta}"`.
- Se agregó el botón `Eliminar` en la barra de archivo que invoca `eliminar_archivo_handler` y una prueba unitaria que crea un proyecto, guarda un archivo y verifica el borrado y la visualización del estado `Archivo nuevo (sin guardar)`.
- Confirmado que `actualizar_pagina()` llama a `sincronizar_estado_visual()` que usa `runtime.crear_titulo_archivo(estado)` para mostrar el estado de archivo nuevo/sin guardar.

### Testing
- Se compiló el código comprobando `python -m py_compile src/pcobra/gui/idle.py tests/unit/test_gui_idle.py` y la compilación fue exitosa.
- La prueba añadida `tests/unit/test_gui_idle.py::test_eliminar_archivo_activo_reinicia_editor_y_estado_visual` pasó al ejecutarla con `pytest -q` y verificó la eliminación y el restablecimiento del estado.
- Se ejecutó `git diff --check` y no se detectaron problemas de formato.
- Al ejecutar `pytest -q tests/unit/test_gui_idle.py` la ejecución mostró 5 fallos preexistentes en pruebas relacionadas con abrir/guardar y proyecto activo (`test_main_acciones_publicas_de_archivo`, `test_guardar_como_resuelve_src_programa_sin_extension_como_cobra`, `test_guardar_como_rechaza_escape_relativo_absoluto_y_directorio`, `test_abrir_valida_ruta_relativa_visible_dentro_del_proyecto`, `test_abrir_ruta_sin_extension_normaliza_input_con_ruta_final`), mientras que la prueba nueva pasa; estos fallos parecen no ser introducidos por este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37af1e21f88327b33bc40a5ce1fd5c)