### PR TITLE
Añadir eliminación de carpetas en IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -340,7 +340,9 @@ def main(page: "ft.Page"):
             return
         estado.ruta = ruta_resuelta
         try:
-            entrada.value, salida.value = runtime.recargar_archivo_activo_validado(estado)
+            entrada.value, salida.value = runtime.recargar_archivo_activo_validado(
+                estado
+            )
         except (
             FileNotFoundError,
             NotADirectoryError,
@@ -385,6 +387,93 @@ def main(page: "ft.Page"):
         ruta_input.value = ""
         reconstruir_arbol()
         salida.value = f"Archivo eliminado: {ruta_resuelta}"
+        actualizar_pagina()
+
+    def eliminar_carpeta_handler(_e):
+
+        if not requerir_proyecto_activo():
+            return
+
+        texto = (ruta_input.value or "").strip()
+
+        if not texto:
+            salida.value = "Indica la ruta de una carpeta."
+            page.update()
+            return
+
+        try:
+            ruta_resuelta = resolver_ruta_en_project_root(texto)
+        except (
+            FileNotFoundError,
+            NotADirectoryError,
+            PermissionError,
+            OSError,
+            ValueError,
+        ) as exc:
+            mostrar_error_archivo(exc)
+            page.update()
+            return
+
+        project_root_resuelto = project_root.resolve()
+        workspace_root_resuelto = workspace_root.resolve()
+
+        if ruta_resuelta == project_root_resuelto:
+            salida.value = (
+                "No se puede eliminar el proyecto activo como carpeta normal. "
+                'Usa "Eliminar proyecto".'
+            )
+            page.update()
+            return
+
+        if ruta_resuelta == workspace_root_resuelto:
+            salida.value = "No se puede eliminar la raíz completa del workspace."
+            page.update()
+            return
+
+        if not ruta_resuelta.exists():
+            salida.value = (
+                f"No existe la carpeta que se quiere eliminar: {ruta_resuelta}"
+            )
+            page.update()
+            return
+
+        if not ruta_resuelta.is_dir():
+            salida.value = f"La ruta indicada no es una carpeta: {ruta_resuelta}"
+            page.update()
+            return
+
+        archivo_activo_en_carpeta = False
+        if estado.ruta is not None:
+            try:
+                estado_ruta_resuelta = estado.ruta.resolve()
+                estado_ruta_resuelta.relative_to(ruta_resuelta)
+            except ValueError:
+                archivo_activo_en_carpeta = False
+            else:
+                archivo_activo_en_carpeta = True
+
+        try:
+            runtime.eliminar_directorio_validado(ruta_resuelta)
+        except (
+            FileNotFoundError,
+            NotADirectoryError,
+            PermissionError,
+            OSError,
+            ValueError,
+        ) as exc:
+            mostrar_error_archivo(exc)
+            page.update()
+            return
+
+        if archivo_activo_en_carpeta:
+            estado.ruta = None
+            estado.contenido_cargado = ""
+            estado.cambios_sin_guardar = False
+            entrada.value = ""
+            ruta_input.value = ""
+
+        reconstruir_arbol()
+        salida.value = f"Carpeta eliminada: {ruta_resuelta}"
         actualizar_pagina()
 
     ejecutar_handler = runtime.crear_handler_ejecucion(
@@ -435,6 +524,9 @@ def main(page: "ft.Page"):
             runtime.flet_elevated_button(ft, "Recargar", on_click=recargar_handler),
             runtime.flet_elevated_button(
                 ft, "Eliminar", on_click=eliminar_archivo_handler
+            ),
+            runtime.flet_elevated_button(
+                ft, "Eliminar carpeta", on_click=eliminar_carpeta_handler
             ),
         ],
         wrap=True,

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -1503,3 +1503,96 @@ def test_eliminar_archivo_activo_reinicia_editor_y_estado_visual(monkeypatch, tm
     assert ruta_input.value == ""
     assert salida.value == f"Archivo eliminado: {destino}"
     assert estado_archivo.value == "Archivo nuevo (sin guardar)"
+
+
+def test_eliminar_carpeta_reinicia_editor_si_archivo_activo_esta_dentro(
+    monkeypatch, tmp_path
+):
+    (
+        ft,
+        page,
+        entrada,
+        ruta_input,
+        salida,
+        _abrir,
+        guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    proyecto_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
+    )
+    crear_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Crear proyecto"
+    )
+    eliminar_carpeta = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Eliminar carpeta"
+    )
+    estado_archivo = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.Text) and c.value == "Archivo nuevo (sin guardar)"
+    )
+
+    proyecto_input.value = "proyecto"
+    crear_proyecto.on_click(None)
+    carpeta = (
+        idle.runtime.resolver_workspace_root_idle() / "proyecto" / "src"
+    ).resolve()
+    destino = (carpeta / "borrar.cobra").resolve()
+    entrada.value = "imprimir('borrar')"
+    ruta_input.value = "src/borrar"
+    guardar_como.on_click(None)
+
+    ruta_input.value = "src"
+    eliminar_carpeta.on_click(None)
+
+    assert not carpeta.exists()
+    assert not destino.exists()
+    assert entrada.value == ""
+    assert ruta_input.value == ""
+    assert salida.value == f"Carpeta eliminada: {carpeta}"
+    assert estado_archivo.value == "Archivo nuevo (sin guardar)"
+
+
+def test_eliminar_carpeta_bloquea_project_root_activo(monkeypatch, tmp_path):
+    (
+        ft,
+        page,
+        _entrada,
+        ruta_input,
+        salida,
+        _abrir,
+        _guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    proyecto_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
+    )
+    crear_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Crear proyecto"
+    )
+    eliminar_carpeta = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Eliminar carpeta"
+    )
+
+    proyecto_input.value = "proyecto"
+    crear_proyecto.on_click(None)
+    proyecto = (idle.runtime.resolver_workspace_root_idle() / "proyecto").resolve()
+
+    ruta_input.value = str(proyecto)
+    eliminar_carpeta.on_click(None)
+
+    assert proyecto.exists()
+    assert salida.value == (
+        'No se puede eliminar el proyecto activo como carpeta normal. Usa "Eliminar proyecto".'
+    )


### PR DESCRIPTION
### Motivation
- Añadir la capacidad de eliminar carpetas desde la UI del IDLE, con las mismas validaciones y protecciones que existen para archivos y proyectos.
- Evitar que el usuario borre accidentalmente la raíz del proyecto activo o la raíz del workspace desde el handler de eliminación de carpeta.

### Description
- Se añadió el handler `eliminar_carpeta_handler` dentro de `main(page)` que exige `requerir_proyecto_activo()`, lee `texto = (ruta_input.value or "").strip()` y valida/resuelve la ruta con `resolver_ruta_en_project_root(texto)` manejando las excepciones esperadas con `mostrar_error_archivo(exc)`.
- El handler compara `ruta_resuelta` con `project_root.resolve()` y `workspace_root.resolve()` para bloquear la eliminación del proyecto activo y de la raíz del workspace, valida `exists()` y `is_dir()`, detecta si el archivo activo pertenece a la carpeta con `estado.ruta.resolve().relative_to(ruta_resuelta)` y limpia el estado/editor cuando procede antes de llamar a `runtime.eliminar_directorio_validado(ruta_resuelta)`.
- Se añadió el botón `Eliminar carpeta` en la barra de archivo que invoca `eliminar_carpeta_handler` y se reconstruye el árbol con `reconstruir_arbol()` y se actualiza la UI con `actualizar_pagina()` mostrando mensajes claros en `salida.value`.
- Se agregaron dos pruebas unitarias a `tests/unit/test_gui_idle.py`: `test_eliminar_carpeta_reinicia_editor_si_archivo_activo_esta_dentro` y `test_eliminar_carpeta_bloquea_project_root_activo` que verifican el comportamiento de borrado y las protecciones correspondientes.

### Testing
- Se compiló el código con `python -m py_compile src/pcobra/gui/idle.py tests/unit/test_gui_idle.py` y la compilación fue satisfactoria.
- Se ejecutaron los nuevos tests específicos con `python -m pytest tests/unit/test_gui_idle.py::test_eliminar_carpeta_reinicia_editor_si_archivo_activo_esta_dentro tests/unit/test_gui_idle.py::test_eliminar_carpeta_bloquea_project_root_activo -q` y ambos pasaron.
- El conjunto completo de pruebas de `tests/unit/test_gui_idle.py` presenta fallos preexistentes (5 tests fallidos) que no están relacionados con las nuevas pruebas de carpeta; estos fallos permanecen y deben investigarse por separado.
- Se aplicó formato con `black` al archivo modificado antes de las pruebas exitosas de los nuevos casos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37b053d90083278f9b899a0f2894eb)