### PR TITLE
Añadir eliminación de proyecto en el IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -263,6 +263,48 @@ def main(page: "ft.Page"):
         salida.value = f"Proyecto abierto: {project_root}"
         actualizar_pagina()
 
+    def eliminar_proyecto_handler(_e):
+        nonlocal project_root
+        if not hay_proyecto_activo():
+            salida.value = "No hay proyecto activo para eliminar."
+            page.update()
+            return
+
+        project_root_resuelto = project_root.resolve()
+        workspace_root_resuelto = workspace_root.resolve()
+
+        if project_root_resuelto == workspace_root_resuelto:
+            salida.value = "No se puede eliminar la raíz completa del workspace."
+            page.update()
+            return
+
+        try:
+            runtime.eliminar_proyecto_validado(
+                project_root_resuelto, workspace_root_resuelto
+            )
+        except (
+            FileNotFoundError,
+            NotADirectoryError,
+            PermissionError,
+            OSError,
+            ValueError,
+        ) as exc:
+            mostrar_error_archivo(exc)
+            page.update()
+            return
+
+        proyecto_eliminado = project_root_resuelto
+        project_root = workspace_root
+        estado.ruta = None
+        estado.contenido_cargado = ""
+        estado.cambios_sin_guardar = False
+        entrada.value = ""
+        ruta_input.value = ""
+        reconstruir_arbol()
+        raiz_input.value = str(project_root)
+        salida.value = f"Proyecto eliminado: {proyecto_eliminado}"
+        actualizar_pagina()
+
     def nuevo_handler(_e):
         entrada.value, salida.value = runtime.crear_archivo_nuevo_en_editor(estado)
         actualizar_pagina()
@@ -505,6 +547,9 @@ def main(page: "ft.Page"):
                     ),
                     runtime.flet_elevated_button(
                         ft, "Abrir proyecto", on_click=establecer_raiz_arbol_handler
+                    ),
+                    runtime.flet_elevated_button(
+                        ft, "Eliminar proyecto", on_click=eliminar_proyecto_handler
                     ),
                 ],
                 wrap=True,

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -241,9 +241,11 @@ def test_panel_lateral_organiza_proyecto_en_columna(monkeypatch, tmp_path):
     assert [boton.text for boton in botones] == [
         "Crear proyecto",
         "Abrir proyecto",
+        "Eliminar proyecto",
     ]
     assert botones[0].on_click.__name__ == "crear_proyecto_handler"
     assert botones[1].on_click.__name__ == "establecer_raiz_arbol_handler"
+    assert botones[2].on_click.__name__ == "eliminar_proyecto_handler"
 
     filas_con_textfield_expand_y_botones = [
         control
@@ -1558,6 +1560,89 @@ def test_eliminar_carpeta_reinicia_editor_si_archivo_activo_esta_dentro(
     assert salida.value == f"Carpeta eliminada: {carpeta}"
     assert estado_archivo.value == "Archivo nuevo (sin guardar)"
 
+
+
+def test_eliminar_proyecto_activo_reinicia_estado_y_vuelve_al_workspace(
+    monkeypatch, tmp_path
+):
+    (
+        ft,
+        page,
+        entrada,
+        ruta_input,
+        salida,
+        _abrir,
+        guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    proyecto_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
+    )
+    crear_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Crear proyecto"
+    )
+    eliminar_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Eliminar proyecto"
+    )
+    estado_archivo = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.Text) and c.value == "Archivo nuevo (sin guardar)"
+    )
+    arbol = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ListView)
+        and getattr(getattr(c, "controls", [None])[0], "value", "").startswith(
+            "Proyecto activo:"
+        )
+    )
+
+    proyecto_input.value = "proyecto"
+    crear_proyecto.on_click(None)
+    workspace_root = idle.runtime.resolver_workspace_root_idle()
+    proyecto = (workspace_root / "proyecto").resolve()
+    entrada.value = "imprimir('borrar proyecto')"
+    ruta_input.value = "src/main"
+    guardar_como.on_click(None)
+
+    eliminar_proyecto.on_click(None)
+
+    assert not proyecto.exists()
+    assert entrada.value == ""
+    assert ruta_input.value == ""
+    assert proyecto_input.value == str(workspace_root)
+    assert arbol.controls[0].value == f"Proyecto activo: {workspace_root}"
+    assert salida.value == f"Proyecto eliminado: {proyecto}"
+    assert estado_archivo.value == "Archivo nuevo (sin guardar)"
+
+
+def test_eliminar_proyecto_bloquea_si_no_hay_proyecto_activo(monkeypatch, tmp_path):
+    (
+        ft,
+        page,
+        _entrada,
+        _ruta_input,
+        salida,
+        _abrir,
+        _guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    workspace_root = idle.runtime.resolver_workspace_root_idle()
+    eliminar_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Eliminar proyecto"
+    )
+
+    eliminar_proyecto.on_click(None)
+
+    assert workspace_root.exists()
+    assert salida.value == "No hay proyecto activo para eliminar."
 
 def test_eliminar_carpeta_bloquea_project_root_activo(monkeypatch, tmp_path):
     (


### PR DESCRIPTION
### Motivation
- Permitir eliminar el proyecto activo desde la interfaz del IDLE con las mismas validaciones del runtime y evitar la eliminación de la raíz del workspace.
- Mantener la consistencia del estado visual y del editor tras una eliminación exitosa (volver al workspace, limpiar ruta/entrada/estado).
- Proveer feedback de error para fallos comunes de archivo/directorio al eliminar proyectos.

### Description
- Añade `eliminar_proyecto_handler(_e)` dentro de `main(page)` con `nonlocal project_root`, validación de proyecto activo usando `hay_proyecto_activo()`, y resolución de `project_root.resolve()` y `workspace_root.resolve()`.
- Bloquea la eliminación si la raíz del proyecto coincide con la raíz del workspace y llama a `runtime.eliminar_proyecto_validado(project_root_resuelto, workspace_root_resuelto)` dentro de un `try/except` que captura `FileNotFoundError`, `NotADirectoryError`, `PermissionError`, `OSError` y `ValueError` y muestra el error con `mostrar_error_archivo(exc)`.
- Tras eliminar con éxito, guarda la ruta eliminada para mensaje, restablece `project_root = workspace_root`, limpia `estado` (`ruta`, `contenido_cargado`, `cambios_sin_guardar`), limpia `entrada.value` y `ruta_input.value`, llama a `reconstruir_arbol()`, actualiza `raiz_input.value` y muestra `Proyecto eliminado: {proyecto_eliminado}` y actualiza la página.
- Añade el botón `Eliminar proyecto` junto a `Crear proyecto` y `Abrir proyecto` en la barra de proyectos y añade tests unitarios que comprueban la presencia del botón, la eliminación correcta y el bloqueo cuando no hay proyecto activo.

### Testing
- Ejecuté `pytest` focalizado: `pytest tests/unit/test_gui_idle.py::test_panel_lateral_organiza_proyecto_en_columna tests/unit/test_gui_idle.py::test_eliminar_proyecto_activo_reinicia_estado_y_vuelve_al_workspace tests/unit/test_gui_idle.py::test_eliminar_proyecto_bloquea_si_no_hay_proyecto_activo -q` y estos tests pasaron correctamente.
- Ejecuté `python3 -m compileall src/pcobra/gui/idle.py` y la compilación fue correcta.
- Ejecuté la suite completa del archivo `tests/unit/test_gui_idle.py` con `pytest tests/unit/test_gui_idle.py -q` y hubo fallos preexistentes no relacionados con la funcionalidad añadida (5 fallos en tests de acciones de archivo/abrir/guardar); los tests añadidos por este cambio pasan.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37b1ca126483278a0ad3789634a3b7)