### PR TITLE
Refactoriza limpieza de archivo activo al borrar

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -39,6 +39,13 @@ def main(page: "ft.Page"):
         if estado.ruta is not None:
             ruta_input.value = str(estado.ruta)
 
+    def limpiar_archivo_activo() -> None:
+        estado.ruta = None
+        estado.contenido_cargado = ""
+        estado.cambios_sin_guardar = False
+        entrada.value = ""
+        ruta_input.value = ""
+
     def actualizar_pagina() -> None:
         sincronizar_estado_visual()
         page.update()
@@ -295,11 +302,7 @@ def main(page: "ft.Page"):
 
         proyecto_eliminado = project_root_resuelto
         project_root = workspace_root
-        estado.ruta = None
-        estado.contenido_cargado = ""
-        estado.cambios_sin_guardar = False
-        entrada.value = ""
-        ruta_input.value = ""
+        limpiar_archivo_activo()
         reconstruir_arbol()
         raiz_input.value = str(project_root)
         salida.value = f"Proyecto eliminado: {proyecto_eliminado}"
@@ -422,11 +425,7 @@ def main(page: "ft.Page"):
             mostrar_error_archivo(exc)
             page.update()
             return
-        estado.ruta = None
-        estado.contenido_cargado = ""
-        estado.cambios_sin_guardar = False
-        entrada.value = ""
-        ruta_input.value = ""
+        limpiar_archivo_activo()
         reconstruir_arbol()
         salida.value = f"Archivo eliminado: {ruta_resuelta}"
         actualizar_pagina()
@@ -508,11 +507,7 @@ def main(page: "ft.Page"):
             return
 
         if archivo_activo_en_carpeta:
-            estado.ruta = None
-            estado.contenido_cargado = ""
-            estado.cambios_sin_guardar = False
-            entrada.value = ""
-            ruta_input.value = ""
+            limpiar_archivo_activo()
 
         reconstruir_arbol()
         salida.value = f"Carpeta eliminada: {ruta_resuelta}"


### PR DESCRIPTION
### Motivation
- Evitar duplicación de código al reiniciar el estado y la UI del archivo activo tras operaciones de borrado. 
- Centralizar el reseteo del estado del editor para reducir riesgo de inconsistencias al eliminar archivos, carpetas o proyectos.
- Mantener el cambio localizado únicamente a flujos de borrado para no afectar la creación de nuevos archivos.

### Description
- Añadido un helper interno `limpiar_archivo_activo()` en `main(page)` junto a `sincronizar_estado_visual()` que pone `estado.ruta = None`, `estado.contenido_cargado = ""`, `estado.cambios_sin_guardar = False`, `entrada.value = ""` y `ruta_input.value = ""`.
- Reemplazada la lógica repetida por llamadas a `limpiar_archivo_activo()` en los handlers de borrado: `eliminar_proyecto_handler`, `eliminar_archivo_handler`, y `eliminar_carpeta_handler` (solo cuando el archivo activo esté dentro de la carpeta borrada).
- No se modifica `nuevo_handler`; el comportamiento de creación de archivos se mantiene intacto para mantener el parche localizado.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/gui/idle.py` y compiló correctamente.
- Se ejecutaron pruebas focalizadas: `pytest -q tests/unit/test_gui_idle.py::test_eliminar_archivo_activo_reinicia_editor_y_estado_visual tests/unit/test_gui_idle.py::test_eliminar_carpeta_reinicia_editor_si_archivo_activo_esta_dentro tests/unit/test_gui_idle.py::test_eliminar_proyecto_activo_reinicia_estado_y_vuelve_al_workspace` — 2 pruebas pasaron y 1 falló con `StopIteration` durante la búsqueda del botón porque la prueba espera un botón con texto `"Eliminar"` mientras la UI expone `"Eliminar archivo"` (fallo de localización del control, no de la limpieza centralizada).
- Ejecución completa `pytest -q` falló en la fase de colección por import errors no relacionados con este cambio (`LEGACY_BACKEND_REMOVAL_CANDIDATES`, módulos de transpilers `to_asm/to_go/to_wasm`), por lo que no se completó la suite global.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37b3dee7108327b0140edfd7d6e0a5)