### PR TITLE
Añadir botón y acción “Cerrar proyecto” en GUI del IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -17,6 +17,7 @@ def main(page: "ft.Page"):
     estado = runtime.GuiFileState()
     workspace_root = runtime.resolver_workspace_root_idle()
     project_root = workspace_root
+    proyecto_cerrado = False
 
     entrada = runtime.crear_editor_codigo(ft)
     salida = runtime.crear_salida_seleccionable(ft)
@@ -212,7 +213,7 @@ def main(page: "ft.Page"):
         return runtime.validar_project_root_idle(candidata)
 
     def hay_proyecto_activo() -> bool:
-        return project_root.resolve() != workspace_root.resolve()
+        return not proyecto_cerrado
 
     def requerir_proyecto_activo() -> bool:
         if hay_proyecto_activo():
@@ -229,7 +230,7 @@ def main(page: "ft.Page"):
             readme.write_text(f"# {nombre}\n", encoding="utf-8")
 
     def crear_proyecto_handler(_e):
-        nonlocal project_root
+        nonlocal project_root, proyecto_cerrado
         try:
             nombre = nombre_proyecto_seguro(raiz_input.value or "")
             nuevo_proyecto = (workspace_root / nombre).resolve()
@@ -239,6 +240,7 @@ def main(page: "ft.Page"):
             page.update()
             return
         project_root = nuevo_proyecto
+        proyecto_cerrado = False
         if not reconstruir_arbol():
             page.update()
             return
@@ -246,7 +248,7 @@ def main(page: "ft.Page"):
         actualizar_pagina()
 
     def establecer_raiz_arbol_handler(_e):
-        nonlocal project_root
+        nonlocal project_root, proyecto_cerrado
         try:
             nueva_raiz = resolver_directorio_proyecto(raiz_input.value or "")
         except (OSError, ValueError) as exc:
@@ -264,24 +266,40 @@ def main(page: "ft.Page"):
             page.update()
             return
         project_root = nueva_raiz
+        proyecto_cerrado = False
         if not reconstruir_arbol():
             page.update()
             return
         salida.value = f"Proyecto abierto: {project_root}"
         actualizar_pagina()
 
-    def eliminar_proyecto_handler(_e):
-        nonlocal project_root
-        if not hay_proyecto_activo():
-            salida.value = "No hay proyecto activo para eliminar."
+    def cerrar_proyecto_handler(_e):
+        nonlocal project_root, proyecto_cerrado
+        if project_root.resolve() == workspace_root.resolve():
+            salida.value = "No hay proyecto activo para cerrar."
             page.update()
             return
 
+        project_root = workspace_root
+        proyecto_cerrado = True
+        limpiar_archivo_activo()
+        reconstruir_arbol()
+        raiz_input.value = str(project_root)
+        if arbol.controls:
+            arbol.controls[0].value = "Proyecto activo: ninguno"
+        salida.value = "Proyecto cerrado."
+        actualizar_pagina()
+
+    def eliminar_proyecto_handler(_e):
+        nonlocal project_root, proyecto_cerrado
         project_root_resuelto = project_root.resolve()
         workspace_root_resuelto = workspace_root.resolve()
 
-        if project_root_resuelto == workspace_root_resuelto:
-            salida.value = "No se puede eliminar la raíz completa del workspace."
+        if (
+            not hay_proyecto_activo()
+            or project_root_resuelto == workspace_root_resuelto
+        ):
+            salida.value = "No hay proyecto activo para eliminar."
             page.update()
             return
 
@@ -302,6 +320,7 @@ def main(page: "ft.Page"):
 
         proyecto_eliminado = project_root_resuelto
         project_root = workspace_root
+        proyecto_cerrado = True
         limpiar_archivo_activo()
         reconstruir_arbol()
         raiz_input.value = str(project_root)
@@ -542,6 +561,9 @@ def main(page: "ft.Page"):
                     ),
                     runtime.flet_elevated_button(
                         ft, "Abrir proyecto", on_click=establecer_raiz_arbol_handler
+                    ),
+                    runtime.flet_elevated_button(
+                        ft, "Cerrar proyecto", on_click=cerrar_proyecto_handler
                     ),
                     runtime.flet_elevated_button(
                         ft, "Eliminar proyecto", on_click=eliminar_proyecto_handler

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -241,11 +241,13 @@ def test_panel_lateral_organiza_proyecto_en_columna(monkeypatch, tmp_path):
     assert [boton.text for boton in botones] == [
         "Crear proyecto",
         "Abrir proyecto",
+        "Cerrar proyecto",
         "Eliminar proyecto",
     ]
     assert botones[0].on_click.__name__ == "crear_proyecto_handler"
     assert botones[1].on_click.__name__ == "establecer_raiz_arbol_handler"
-    assert botones[2].on_click.__name__ == "eliminar_proyecto_handler"
+    assert botones[2].on_click.__name__ == "cerrar_proyecto_handler"
+    assert botones[3].on_click.__name__ == "eliminar_proyecto_handler"
 
     filas_con_textfield_expand_y_botones = [
         control
@@ -1478,7 +1480,7 @@ def test_eliminar_archivo_activo_reinicia_editor_y_estado_visual(monkeypatch, tm
     eliminar = next(
         c
         for c in page.controls
-        if isinstance(c, ft.ElevatedButton) and c.text == "Eliminar"
+        if isinstance(c, ft.ElevatedButton) and c.text == "Eliminar archivo"
     )
     estado_archivo = next(
         c
@@ -1620,6 +1622,95 @@ def test_eliminar_proyecto_activo_reinicia_estado_y_vuelve_al_workspace(
     assert arbol.controls[0].value == f"Proyecto activo: {workspace_root}"
     assert salida.value == f"Proyecto eliminado: {proyecto}"
     assert estado_archivo.value == "Archivo nuevo (sin guardar)"
+
+
+def test_cerrar_proyecto_reinicia_al_workspace_y_bloquea_archivos(
+    monkeypatch, tmp_path
+):
+    (
+        ft,
+        page,
+        entrada,
+        ruta_input,
+        salida,
+        _abrir,
+        _guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    workspace_root = idle.runtime.resolver_workspace_root_idle()
+    proyecto_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
+    )
+    crear_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Crear proyecto"
+    )
+    cerrar_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Cerrar proyecto"
+    )
+    eliminar_archivo = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Eliminar archivo"
+    )
+    estado_archivo = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.Text) and c.value == "Archivo nuevo (sin guardar)"
+    )
+    arbol = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ListView)
+        and getattr(getattr(c, "controls", [None])[0], "value", "").startswith(
+            "Proyecto activo:"
+        )
+    )
+
+    proyecto_input.value = "proyecto_beta"
+    crear_proyecto.on_click(None)
+    proyecto = (workspace_root / "proyecto_beta").resolve()
+    entrada.value = "imprimir('beta')"
+    ruta_input.value = "src/main.cobra"
+
+    cerrar_proyecto.on_click(None)
+
+    assert proyecto.exists()
+    assert proyecto_input.value == str(workspace_root)
+    assert entrada.value == ""
+    assert ruta_input.value == ""
+    assert estado_archivo.value == "Archivo nuevo (sin guardar)"
+    assert arbol.controls[0].value == "Proyecto activo: ninguno"
+    assert salida.value == "Proyecto cerrado."
+
+    eliminar_archivo.on_click(None)
+
+    assert salida.value == "Crea o abre un proyecto antes de trabajar con archivos."
+
+
+def test_cerrar_proyecto_bloquea_si_no_hay_proyecto_activo(monkeypatch, tmp_path):
+    (
+        ft,
+        page,
+        _entrada,
+        _ruta_input,
+        salida,
+        _abrir,
+        _guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    cerrar_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Cerrar proyecto"
+    )
+
+    cerrar_proyecto.on_click(None)
+
+    assert salida.value == "No hay proyecto activo para cerrar."
 
 
 def test_eliminar_proyecto_bloquea_si_no_hay_proyecto_activo(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Hacer visible y accesible la acción de cerrar un proyecto desde la barra de gestión de proyectos sin borrar archivos del disco.  
- Al cerrar, restablecer la UI y el estado interno al workspace para dejar el IDE en estado sin proyecto activo.  
- Evitar que posteriores acciones de archivo funcionen hasta crear/abrir un proyecto de nuevo, mostrando el mensaje apropiado.

### Description
- Añadido el botón visible `Cerrar proyecto` junto a `Crear proyecto`, `Abrir proyecto` y `Eliminar proyecto` en la columna de gestión de proyectos (`src/pcobra/gui/idle.py`).  
- Implementado `cerrar_proyecto_handler` que verifica si `project_root == workspace_root` para mostrar exactamente `No hay proyecto activo para cerrar.`; si hay proyecto activo, asigna `project_root = workspace_root`, marca internamente `proyecto_cerrado = True`, llama a `limpiar_archivo_activo()` (que hace `estado.ruta = None`, `entrada.value = ""`, `ruta_input.value = ""`), actualiza la etiqueta del árbol a `Proyecto activo: ninguno`, reconstruye el árbol y muestra exactamente `Proyecto cerrado.` sin borrar ficheros ni carpetas.  
- Introducida la marca interna `proyecto_cerrado` y ajustadas `hay_proyecto_activo()` / `requerir_proyecto_activo()` para bloquear operaciones de archivo tras un cierre/elim. explícito mostrando `Crea o abre un proyecto antes de trabajar con archivos.`.  
- Actualizadas pruebas unitarias en `tests/unit/test_gui_idle.py` para verificar la presencia del nuevo botón, el flujo con `proyecto_beta`, el retorno al workspace y el bloqueo posterior de acciones de archivo; también se corrigieron expectativas sobre el botón `Eliminar archivo` en pruebas existentes.

### Testing
- Ejecutado `pytest tests/unit/test_gui_idle.py -q` y la colección pasó correctamente.  
- Ejecutado `pytest tests/unit/test_gui_idle.py tests/gui/test_runtime_file_helpers.py -q` y ambas colecciones pasaron correctamente (pruebas automatizadas exitosas; se observó un warning no crítico sobre deprecación).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37ba5d912c8327b90414559695a502)