### PR TITLE
Confirmación por doble pulsación para "Eliminar carpeta" en GUI

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -36,6 +36,8 @@ def main(page: "ft.Page"):
     ruta_eliminacion_pendiente: Path | None = None
     ruta_estado_eliminacion_pendiente: Path | None = None
     ruta_visible_eliminacion_pendiente = ""
+    ruta_carpeta_eliminacion_pendiente: Path | None = None
+    ruta_visible_carpeta_eliminacion_pendiente = ""
 
     def cancelar_confirmacion_eliminacion_pendiente() -> None:
         nonlocal ruta_eliminacion_pendiente
@@ -45,6 +47,16 @@ def main(page: "ft.Page"):
         ruta_estado_eliminacion_pendiente = None
         ruta_visible_eliminacion_pendiente = ""
 
+    def cancelar_confirmacion_carpeta_eliminacion_pendiente() -> None:
+        nonlocal ruta_carpeta_eliminacion_pendiente
+        nonlocal ruta_visible_carpeta_eliminacion_pendiente
+        ruta_carpeta_eliminacion_pendiente = None
+        ruta_visible_carpeta_eliminacion_pendiente = ""
+
+    def cancelar_confirmaciones_eliminacion_pendientes() -> None:
+        cancelar_confirmacion_eliminacion_pendiente()
+        cancelar_confirmacion_carpeta_eliminacion_pendiente()
+
     def sincronizar_estado_visual() -> None:
         estado_archivo.value = runtime.crear_titulo_archivo(estado)
 
@@ -52,7 +64,7 @@ def main(page: "ft.Page"):
             ruta_input.value = str(estado.ruta)
 
     def limpiar_archivo_activo() -> None:
-        cancelar_confirmacion_eliminacion_pendiente()
+        cancelar_confirmaciones_eliminacion_pendientes()
         estado.ruta = None
         estado.contenido_cargado = ""
         estado.cambios_sin_guardar = False
@@ -72,8 +84,15 @@ def main(page: "ft.Page"):
         ):
             cancelar_confirmacion_eliminacion_pendiente()
 
+    def cancelar_confirmacion_carpeta_si_cambia_ruta_pendiente() -> None:
+        if ruta_carpeta_eliminacion_pendiente is None:
+            return
+        if (ruta_input.value or "") != ruta_visible_carpeta_eliminacion_pendiente:
+            cancelar_confirmacion_carpeta_eliminacion_pendiente()
+
     def ruta_visible_cambiada(_e=None) -> None:
         cancelar_confirmacion_si_cambia_ruta_pendiente()
+        cancelar_confirmacion_carpeta_si_cambia_ruta_pendiente()
 
     ruta_input.on_change = ruta_visible_cambiada
 
@@ -503,6 +522,10 @@ def main(page: "ft.Page"):
         actualizar_pagina()
 
     def eliminar_carpeta_handler(_e):
+        nonlocal ruta_carpeta_eliminacion_pendiente
+        nonlocal ruta_visible_carpeta_eliminacion_pendiente
+
+        cancelar_confirmacion_carpeta_si_cambia_ruta_pendiente()
 
         if not requerir_proyecto_activo():
             return
@@ -510,6 +533,7 @@ def main(page: "ft.Page"):
         texto = (ruta_input.value or "").strip()
 
         if not texto:
+            cancelar_confirmacion_carpeta_eliminacion_pendiente()
             salida.value = "Indica la ruta de una carpeta."
             page.update()
             return
@@ -555,6 +579,15 @@ def main(page: "ft.Page"):
             page.update()
             return
 
+        if ruta_carpeta_eliminacion_pendiente != ruta_resuelta:
+            ruta_carpeta_eliminacion_pendiente = ruta_resuelta
+            ruta_visible_carpeta_eliminacion_pendiente = ruta_input.value or ""
+            salida.value = (
+                "Pulsa de nuevo Eliminar carpeta para confirmar: " f"{ruta_resuelta}"
+            )
+            page.update()
+            return
+
         archivo_activo_en_carpeta = False
         if estado.ruta is not None:
             try:
@@ -577,6 +610,8 @@ def main(page: "ft.Page"):
             mostrar_error_archivo(exc)
             page.update()
             return
+
+        cancelar_confirmacion_carpeta_eliminacion_pendiente()
 
         if archivo_activo_en_carpeta:
             limpiar_archivo_activo()

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -1681,12 +1681,71 @@ def test_eliminar_carpeta_reinicia_editor_si_archivo_activo_esta_dentro(
     ruta_input.value = "src"
     eliminar_carpeta.on_click(None)
 
+    assert carpeta.exists()
+    assert destino.exists()
+    assert salida.value == f"Pulsa de nuevo Eliminar carpeta para confirmar: {carpeta}"
+
+    eliminar_carpeta.on_click(None)
+
     assert not carpeta.exists()
     assert not destino.exists()
     assert entrada.value == ""
     assert ruta_input.value == ""
     assert salida.value == f"Carpeta eliminada: {carpeta}"
     assert estado_archivo.value == "Archivo nuevo (sin guardar)"
+
+
+def test_eliminar_carpeta_cancela_confirmacion_si_cambia_ruta_visible(
+    monkeypatch, tmp_path
+):
+    (
+        ft,
+        page,
+        _entrada,
+        ruta_input,
+        salida,
+        _abrir,
+        _guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    proyecto_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
+    )
+    crear_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Crear proyecto"
+    )
+    eliminar_carpeta = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Eliminar carpeta"
+    )
+
+    proyecto_input.value = "proyecto"
+    crear_proyecto.on_click(None)
+    proyecto = (idle.runtime.resolver_workspace_root_idle() / "proyecto").resolve()
+    carpeta = proyecto / "docs"
+    otra_carpeta = proyecto / "tmp"
+    carpeta.mkdir()
+    otra_carpeta.mkdir()
+
+    ruta_input.value = "docs"
+    eliminar_carpeta.on_click(None)
+    ruta_input.value = "tmp"
+    ruta_input.on_change(None)
+    eliminar_carpeta.on_click(None)
+
+    assert carpeta.exists()
+    assert otra_carpeta.exists()
+    assert salida.value == f"Pulsa de nuevo Eliminar carpeta para confirmar: {otra_carpeta}"
+
+    eliminar_carpeta.on_click(None)
+
+    assert carpeta.exists()
+    assert not otra_carpeta.exists()
+    assert salida.value == f"Carpeta eliminada: {otra_carpeta}"
 
 
 def test_eliminar_proyecto_activo_reinicia_estado_y_vuelve_al_workspace(
@@ -1897,4 +1956,53 @@ def test_eliminar_carpeta_bloquea_project_root_activo(monkeypatch, tmp_path):
     assert proyecto.exists()
     assert salida.value == (
         'No se puede eliminar el proyecto activo como carpeta normal. Usa "Eliminar proyecto".'
+    )
+
+
+def test_eliminar_carpeta_mantiene_bloqueos_de_workspace_y_escape(
+    monkeypatch, tmp_path
+):
+    (
+        ft,
+        page,
+        _entrada,
+        ruta_input,
+        salida,
+        _abrir,
+        _guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    proyecto_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
+    )
+    crear_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Crear proyecto"
+    )
+    eliminar_carpeta = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Eliminar carpeta"
+    )
+
+    proyecto_input.value = "proyecto"
+    crear_proyecto.on_click(None)
+    workspace = idle.runtime.resolver_workspace_root_idle().resolve()
+
+    ruta_input.value = str(workspace)
+    eliminar_carpeta.on_click(None)
+
+    assert workspace.exists()
+    assert salida.value == "error: La ruta debe estar dentro del proyecto activo: " + str(
+        workspace / "proyecto"
+    )
+
+    ruta_input.value = "../escape"
+    eliminar_carpeta.on_click(None)
+
+    assert workspace.exists()
+    assert salida.value == "error: La ruta debe estar dentro del proyecto activo: " + str(
+        workspace / "proyecto"
     )


### PR DESCRIPTION
### Motivation
- Evitar borrados accidentales al eliminar carpetas desde el IDLE añadiendo una confirmación explícita asociada a la ruta resuelta.
- Mantener todas las validaciones y bloqueos existentes (`project_root`, `workspace_root`, escapes `..`, existencia y tipo directorio) antes de permitir el borrado.

### Description
- Añadido estado pendiente específico para carpetas: `ruta_carpeta_eliminacion_pendiente` y `ruta_visible_carpeta_eliminacion_pendiente`, y helpers para cancelar estas confirmaciones. 
- `ruta_input.on_change` ahora cancela la confirmación pendiente de carpeta si cambia la ruta visible. 
- `eliminar_carpeta_handler` conserva todas las validaciones previas, y en la primera pulsación guarda la ruta resuelta y muestra exactamente: `Pulsa de nuevo Eliminar carpeta para confirmar: <ruta>` sin borrar; en la segunda pulsación vuelve a validar y borra solo si la ruta coincide con la pendiente. 
- Se cancelan las confirmaciones pendientes al reiniciar el archivo activo para mantener estado consistente. 
- Tests actualizados y nuevos tests añadidos para cubrir: primer click no borra, segundo click borra si la ruta no cambia, cancelación al cambiar `ruta_input.value`, y que `project_root`, `workspace_root` y escapes con `../` siguen bloqueados.

### Testing
- `python -m py_compile src/pcobra/gui/idle.py` ejecutado y sin errores. (OK)
- `pytest -q tests/unit/test_gui_idle.py -q` ejecutado y todos los tests de `test_gui_idle.py` pasaron correctamente. (OK)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37bfcf5bac83279234a4e0b156381e)