### PR TITLE
Exigir confirmación por nombre al eliminar proyectos

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -357,6 +357,16 @@ def main(page: "ft.Page"):
             page.update()
             return
 
+        nombre_proyecto = project_root_resuelto.name
+        confirmacion = ruta_input.value or ""
+        if confirmacion != nombre_proyecto:
+            salida.value = (
+                "Para eliminar este proyecto escribe su nombre exacto: "
+                f"{nombre_proyecto}"
+            )
+            page.update()
+            return
+
         try:
             runtime.eliminar_proyecto_validado(
                 project_root_resuelto, workspace_root_resuelto

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -1797,6 +1797,7 @@ def test_eliminar_proyecto_activo_reinicia_estado_y_vuelve_al_workspace(
     ruta_input.value = "src/main"
     guardar_como.on_click(None)
 
+    ruta_input.value = "proyecto"
     eliminar_proyecto.on_click(None)
 
     assert not proyecto.exists()
@@ -1806,6 +1807,51 @@ def test_eliminar_proyecto_activo_reinicia_estado_y_vuelve_al_workspace(
     assert arbol.controls[0].value == _estado_workspace_proyecto(workspace_root)
     assert salida.value == f"Proyecto eliminado: {proyecto}"
     assert estado_archivo.value == "Archivo nuevo (sin guardar)"
+
+
+def test_eliminar_proyecto_exige_nombre_exacto(monkeypatch, tmp_path):
+    (
+        ft,
+        page,
+        _entrada,
+        ruta_input,
+        salida,
+        _abrir,
+        _guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    proyecto_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
+    )
+    crear_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Crear proyecto"
+    )
+    eliminar_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Eliminar proyecto"
+    )
+
+    proyecto_input.value = "proyecto"
+    crear_proyecto.on_click(None)
+    proyecto = (idle.runtime.resolver_workspace_root_idle() / "proyecto").resolve()
+
+    ruta_input.value = "Proyecto"
+    eliminar_proyecto.on_click(None)
+
+    assert proyecto.exists()
+    assert salida.value == (
+        "Para eliminar este proyecto escribe su nombre exacto: proyecto"
+    )
+
+    ruta_input.value = "proyecto"
+    eliminar_proyecto.on_click(None)
+
+    assert not proyecto.exists()
+    assert salida.value == f"Proyecto eliminado: {proyecto}"
 
 
 def test_cerrar_proyecto_reinicia_al_workspace_y_bloquea_archivos(


### PR DESCRIPTION
### Motivation
- Evitar borrados accidentales requiriendo una confirmación por el nombre exacto del proyecto usando el campo visible `ruta_input`; mantener las validaciones de seguridad existentes al eliminar proyectos.

### Description
- Añade en `eliminar_proyecto_handler` la comprobación de que `ruta_input.value` coincide exactamente con `project_root.name` y, si no, muestra: `Para eliminar este proyecto escribe su nombre exacto: <nombre>` y no procede a borrar.
- Conserva la llamada a `runtime.eliminar_proyecto_validado(...)` para delegar todas las validaciones de fichero/directorio, inclusión en workspace y permisos.
- Tras un borrado exitoso se restablece `project_root` a `workspace_root`, se marca el proyecto como cerrado, se limpia el editor/ruta/estado, se reconstruye el árbol lateral y se llama a `actualizar_pagina()` para refrescar la UI.
- Ajusta la prueba existente para setear `ruta_input` antes de eliminar y añade `test_eliminar_proyecto_exige_nombre_exacto` para cubrir el caso de nombre incorrecto y el caso de coincidencia exacta.

### Testing
- Ejecutado `python -m pytest tests/unit/test_gui_idle.py -k 'eliminar_proyecto'` y las pruebas relacionadas pasaron. 
- Ejecutado `python -m pytest tests/unit/test_gui_idle.py` y la suite completa de tests de ese archivo pasó.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a380be54b1c832786123f2ed0c3e97a)