### PR TITLE
Añadir validadores de rutas del IDLE y tests

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -10,6 +10,47 @@ if TYPE_CHECKING:
     import flet as ft
 
 
+def resolver_ruta_en_project_root(ruta: str | Path, project_root: str | Path) -> Path:
+    """Resuelve ``ruta`` de forma canónica y exige que quede bajo ``project_root``."""
+
+    project_root_resuelto = Path(project_root).expanduser().resolve()
+    ruta_expandida = Path(ruta).expanduser()
+    candidata = (
+        ruta_expandida
+        if ruta_expandida.is_absolute()
+        else project_root_resuelto / ruta_expandida
+    )
+    candidata = candidata.resolve()
+    try:
+        candidata.relative_to(project_root_resuelto)
+    except ValueError as exc:
+        raise ValueError(
+            f"La ruta debe estar dentro del proyecto activo: {project_root_resuelto}"
+        ) from exc
+    return candidata
+
+
+def validar_ruta_carpeta_eliminable_idle(
+    ruta: str | Path, project_root: str | Path, workspace_root: str | Path
+) -> Path:
+    """Valida una carpeta visible antes de permitir su eliminación desde el IDLE."""
+
+    ruta_resuelta = resolver_ruta_en_project_root(ruta, project_root)
+    project_root_resuelto = Path(project_root).resolve()
+    workspace_root_resuelto = Path(workspace_root).resolve()
+
+    if ruta_resuelta == project_root_resuelto:
+        raise ValueError(
+            "No se puede eliminar el proyecto activo como carpeta normal. "
+            'Usa "Eliminar proyecto".'
+        )
+
+    if ruta_resuelta == workspace_root_resuelto:
+        raise ValueError("No se puede eliminar la raíz completa del workspace.")
+
+    return ruta_resuelta
+
+
 def main(page: "ft.Page"):
     """Interfaz principal del IDLE con archivos, árbol, ejecución, tokens, AST y sugerencias."""
     ft = runtime.require_flet()
@@ -104,23 +145,6 @@ def main(page: "ft.Page"):
 
     def mostrar_error_archivo(exc: Exception) -> None:
         salida.value = runtime.formatear_error(exc)
-
-    def resolver_ruta_en_project_root(ruta: str | Path) -> Path:
-        project_root_resuelto = Path(project_root).expanduser().resolve()
-        ruta_expandida = Path(ruta).expanduser()
-        candidata = (
-            ruta_expandida
-            if ruta_expandida.is_absolute()
-            else project_root_resuelto / ruta_expandida
-        )
-        candidata = candidata.resolve()
-        try:
-            candidata.relative_to(project_root_resuelto)
-        except ValueError as exc:
-            raise ValueError(
-                f"La ruta debe estar dentro del proyecto activo: {project_root_resuelto}"
-            ) from exc
-        return candidata
 
     def resolver_ruta_archivo_idle(ruta: str | Path) -> Path | None:
         try:
@@ -549,7 +573,9 @@ def main(page: "ft.Page"):
             return
 
         try:
-            ruta_resuelta = resolver_ruta_en_project_root(texto)
+            ruta_resuelta = validar_ruta_carpeta_eliminable_idle(
+                texto, project_root, workspace_root
+            )
         except (
             FileNotFoundError,
             NotADirectoryError,
@@ -561,21 +587,6 @@ def main(page: "ft.Page"):
             page.update()
             return
 
-        project_root_resuelto = project_root.resolve()
-        workspace_root_resuelto = workspace_root.resolve()
-
-        if ruta_resuelta == project_root_resuelto:
-            salida.value = (
-                "No se puede eliminar el proyecto activo como carpeta normal. "
-                'Usa "Eliminar proyecto".'
-            )
-            page.update()
-            return
-
-        if ruta_resuelta == workspace_root_resuelto:
-            salida.value = "No se puede eliminar la raíz completa del workspace."
-            page.update()
-            return
 
         if not ruta_resuelta.exists():
             salida.value = (

--- a/tests/gui/test_idle_path_guards.py
+++ b/tests/gui/test_idle_path_guards.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+
+from pcobra.gui import idle
+
+
+def test_resolver_ruta_en_project_root_acepta_ruta_relativa_normal(tmp_path: Path):
+    project_root = tmp_path / "workspace" / "proyecto"
+    project_root.mkdir(parents=True)
+
+    assert idle.resolver_ruta_en_project_root("src/programa.co", project_root) == (
+        project_root / "src" / "programa.co"
+    ).resolve()
+
+
+def test_resolver_ruta_en_project_root_bloquea_parent_directory(tmp_path: Path):
+    project_root = tmp_path / "workspace" / "proyecto"
+    project_root.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="dentro del proyecto activo"):
+        idle.resolver_ruta_en_project_root("../escape.co", project_root)
+
+
+def test_resolver_ruta_en_project_root_bloquea_absoluta_fuera_de_project_root(
+    tmp_path: Path,
+):
+    project_root = tmp_path / "workspace" / "proyecto"
+    externo = tmp_path / "externo.co"
+    project_root.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="dentro del proyecto activo"):
+        idle.resolver_ruta_en_project_root(externo, project_root)
+
+
+def test_validar_ruta_carpeta_eliminable_idle_bloquea_punto_como_carpeta_normal(
+    tmp_path: Path,
+):
+    workspace_root = tmp_path / "workspace"
+    project_root = workspace_root / "proyecto"
+    project_root.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="proyecto activo como carpeta normal"):
+        idle.validar_ruta_carpeta_eliminable_idle(".", project_root, workspace_root)
+
+
+def test_validar_ruta_carpeta_eliminable_idle_bloquea_workspace_root(tmp_path: Path):
+    workspace_root = tmp_path / "workspace"
+    project_root = workspace_root / "proyecto"
+    project_root.mkdir(parents=True)
+
+    with pytest.raises(ValueError):
+        idle.validar_ruta_carpeta_eliminable_idle(
+            workspace_root, project_root, workspace_root
+        )


### PR DESCRIPTION
### Motivation

- Evitar escapes de ruta y eliminaciones peligrosas desde la UI del IDLE mediante comprobaciones canónicas mínimas y puros helpers reutilizables.
- Mantener los cambios localizados y sin refactorizar la integración con Flet ni la lógica existente de runtime.

### Description

- Extrae `resolver_ruta_en_project_root(ruta, project_root)` para resolver y exigir que una ruta quede bajo `project_root` usando resolución canónica. (F: `src/pcobra/gui/idle.py`)
- Añade `validar_ruta_carpeta_eliminable_idle(ruta, project_root, workspace_root)` que valida y bloquea la eliminación de la carpeta del proyecto activo y de la raíz del workspace. (F: `src/pcobra/gui/idle.py`)
- Reutiliza el helper de validación en el handler de “Eliminar carpeta” del IDLE para mantener la lógica de presentación intacta pero delegando la validación pura al nuevo helper. (F: `src/pcobra/gui/idle.py`)
- Añade `tests/gui/test_idle_path_guards.py` con casos que cubren ruta relativa válida dentro del proyecto, `..` bloqueado, ruta absoluta externa bloqueada, `.` bloqueado como eliminación de carpeta y bloqueo de `workspace_root`. (F: `tests/gui/test_idle_path_guards.py`)

### Testing

- Ejecutado `pytest tests/gui -q` y todas las pruebas GUI pasaron; resultado: `59 passed, 1 warning`.
- Las nuevas pruebas específicas en `tests/gui/test_idle_path_guards.py` se ejecutaron como parte de la suite y pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a382aaf343483279357a0823979bdae)