### PR TITLE
Actualiza etiqueta de workspace/proyecto en IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -246,12 +246,15 @@ def main(page: "ft.Page"):
             lineas.append(f"Ruta completa: {project_resuelto}")
         return "\n".join(lineas)
 
+    estado_workspace_proyecto = runtime.flet_text(
+        ft, value=formatear_estado_workspace_proyecto()
+    )
+
     def reconstruir_arbol() -> bool:
         raiz_input.value = str(project_root)
+        estado_workspace_proyecto.value = formatear_estado_workspace_proyecto()
         arbol.controls.clear()
-        arbol.controls.append(
-            runtime.flet_text(ft, value=formatear_estado_workspace_proyecto())
-        )
+        arbol.controls.append(estado_workspace_proyecto)
         try:
             arbol_canonico = runtime.crear_arbol_directorios(
                 ft,


### PR DESCRIPTION
### Motivation
- Mostrar de forma clara y compacta la información de workspace y proyecto activo en el panel lateral del IDLE sin alterar el layout existente.
- Asegurar que la visualización se actualice en los flujos que cambian el proyecto: inicio del IDLE, crear, abrir, cerrar y eliminar proyecto.

### Description
- Añadida una etiqueta persistente `estado_workspace_proyecto = runtime.flet_text(...)` que contiene el texto con las líneas `Workspace: <ruta>`, `Proyecto activo: ...` y opcionalmente `Ruta completa: ...` cuando hay proyecto activo. 
- `reconstruir_arbol()` ahora actualiza `estado_workspace_proyecto.value` y reutiliza el control en `arbol.controls` en lugar de crear un texto nuevo, manteniendo el layout prácticamente intacto.
- Cambios limitados a `src/pcobra/gui/idle.py` y aplicados de forma mínima para cubrir los flujos que reconstruyen el árbol.

### Testing
- Ejecutado `pytest tests/unit/test_gui_idle.py` con resultado: 36 pruebas pasaron y 1 fallo; el fallo es previo/no relacionado y se debe a un prefijo `error:` en el mensaje devuelto por el flujo frente al texto esperado por la prueba. 
- Ejecutado `pytest tests/unit/test_gui_idle.py -k 'workspace or proyecto'` y todas las pruebas seleccionadas pasaron (14/14). 
- Ejecutado `python -m py_compile src/pcobra/gui/idle.py` y la verificación de sintaxis pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38e7c031188327bdeaf35e27a45bc8)