### PR TITLE
Estado explícito de confirmación para "Eliminar archivo" en el IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -74,19 +74,13 @@ def main(page: "ft.Page"):
     lenguajes = list(runtime.gui_target_choices())
     selector = runtime.crear_selector_target(ft, lenguajes=lenguajes)
     activar = runtime.crear_switch_transpilacion(ft, lenguajes=lenguajes)
-    ruta_eliminacion_pendiente: Path | None = None
-    ruta_estado_eliminacion_pendiente: Path | None = None
-    ruta_visible_eliminacion_pendiente = ""
+    confirmacion_eliminacion_archivo_pendiente: dict[str, object] | None = None
     ruta_carpeta_eliminacion_pendiente: Path | None = None
     ruta_visible_carpeta_eliminacion_pendiente = ""
 
     def cancelar_confirmacion_eliminacion_pendiente() -> None:
-        nonlocal ruta_eliminacion_pendiente
-        nonlocal ruta_estado_eliminacion_pendiente
-        nonlocal ruta_visible_eliminacion_pendiente
-        ruta_eliminacion_pendiente = None
-        ruta_estado_eliminacion_pendiente = None
-        ruta_visible_eliminacion_pendiente = ""
+        nonlocal confirmacion_eliminacion_archivo_pendiente
+        confirmacion_eliminacion_archivo_pendiente = None
 
     def cancelar_confirmacion_carpeta_eliminacion_pendiente() -> None:
         nonlocal ruta_carpeta_eliminacion_pendiente
@@ -117,11 +111,13 @@ def main(page: "ft.Page"):
         page.update()
 
     def cancelar_confirmacion_si_cambia_ruta_pendiente() -> None:
-        if ruta_eliminacion_pendiente is None:
+        if confirmacion_eliminacion_archivo_pendiente is None:
             return
         if (
-            estado.ruta != ruta_estado_eliminacion_pendiente
-            or (ruta_input.value or "") != ruta_visible_eliminacion_pendiente
+            estado.ruta
+            != confirmacion_eliminacion_archivo_pendiente["ruta_estado"]
+            or (ruta_input.value or "")
+            != confirmacion_eliminacion_archivo_pendiente["ruta_visible"]
         ):
             cancelar_confirmacion_eliminacion_pendiente()
 
@@ -513,9 +509,7 @@ def main(page: "ft.Page"):
         actualizar_pagina()
 
     def eliminar_archivo_handler(_e):
-        nonlocal ruta_eliminacion_pendiente
-        nonlocal ruta_estado_eliminacion_pendiente
-        nonlocal ruta_visible_eliminacion_pendiente
+        nonlocal confirmacion_eliminacion_archivo_pendiente
 
         cancelar_confirmacion_si_cambia_ruta_pendiente()
 
@@ -532,10 +526,17 @@ def main(page: "ft.Page"):
             cancelar_confirmacion_eliminacion_pendiente()
             return
 
-        if ruta_eliminacion_pendiente != ruta_resuelta:
-            ruta_eliminacion_pendiente = ruta_resuelta
-            ruta_estado_eliminacion_pendiente = estado.ruta
-            ruta_visible_eliminacion_pendiente = ruta_input.value or ""
+        if (
+            confirmacion_eliminacion_archivo_pendiente is None
+            or confirmacion_eliminacion_archivo_pendiente["tipo"] != "archivo"
+            or confirmacion_eliminacion_archivo_pendiente["ruta"] != ruta_resuelta
+        ):
+            confirmacion_eliminacion_archivo_pendiente = {
+                "tipo": "archivo",
+                "ruta": ruta_resuelta,
+                "ruta_estado": estado.ruta,
+                "ruta_visible": ruta_input.value or "",
+            }
             salida.value = (
                 "Pulsa de nuevo Eliminar archivo para confirmar: " f"{ruta_resuelta}"
             )


### PR DESCRIPTION
### Motivation
- Evitar borrados accidentales exigiendo una confirmación explícita por doble pulsación y mantener las validaciones previas al borrado. 
- Centralizar el estado de confirmación en una estructura que incluya el tipo de operación y la ruta candidata para simplificar la comprobación y la cancelación si cambia la ruta.

### Description
- Sustituye las variables dispersas de confirmación (`ruta_eliminacion_pendiente`, `ruta_estado_eliminacion_pendiente`, `ruta_visible_eliminacion_pendiente`) por un único estado local `confirmacion_eliminacion_archivo_pendiente` que es un `dict` con `"tipo"`, `"ruta"`, `"ruta_estado"` y `"ruta_visible"`.
- Actualiza `cancelar_confirmacion_eliminacion_pendiente` y la comprobación central `cancelar_confirmacion_si_cambia_ruta_pendiente` para usar el nuevo dict y cancelar la confirmación si `estado.ruta` o `ruta_input.value` cambian.
- Modifica `eliminar_archivo_handler` para mantener todas las validaciones actuales (proyecto activo, ruta dentro de `project_root`, bloqueo de `..`, que la ruta apunte a un archivo), guardar la ruta candidata en `confirmacion_eliminacion_archivo_pendiente` en la primera pulsación mostrando exactamente `Pulsa de nuevo Eliminar archivo para confirmar: <ruta>`, y solo ejecutar `runtime.eliminar_archivo_validado` en la segunda pulsación si la ruta recalculada coincide con la pendiente; en caso contrario se cancela la confirmación.
- Conserva el comportamiento posterior al borrado usando `limpiar_archivo_activo()` y `reconstruir_arbol()`, lo que deja `estado.ruta = None`, editor vacío, campo ruta vacío y árbol refrescado.

### Testing
- Ejecutado `python -m py_compile src/pcobra/gui/idle.py` y la compilación finalizó correctamente.
- Ejecutado `pytest tests/unit/test_gui_idle.py -k "eliminar_archivo"` y las pruebas seleccionadas pasaron (`3 passed`).
- Ejecutado `git diff --check` para verificar el diff y no se detectaron problemas de whitespace u otros errores automáticos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38f379873c83278294bfd253d8c4bb)