### PR TITLE
Eliminar carpeta: confirmación explícita por doble pulsación

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -75,18 +75,15 @@ def main(page: "ft.Page"):
     selector = runtime.crear_selector_target(ft, lenguajes=lenguajes)
     activar = runtime.crear_switch_transpilacion(ft, lenguajes=lenguajes)
     confirmacion_eliminacion_archivo_pendiente: dict[str, object] | None = None
-    ruta_carpeta_eliminacion_pendiente: Path | None = None
-    ruta_visible_carpeta_eliminacion_pendiente = ""
+    confirmacion_eliminacion_carpeta_pendiente: dict[str, object] | None = None
 
     def cancelar_confirmacion_eliminacion_pendiente() -> None:
         nonlocal confirmacion_eliminacion_archivo_pendiente
         confirmacion_eliminacion_archivo_pendiente = None
 
     def cancelar_confirmacion_carpeta_eliminacion_pendiente() -> None:
-        nonlocal ruta_carpeta_eliminacion_pendiente
-        nonlocal ruta_visible_carpeta_eliminacion_pendiente
-        ruta_carpeta_eliminacion_pendiente = None
-        ruta_visible_carpeta_eliminacion_pendiente = ""
+        nonlocal confirmacion_eliminacion_carpeta_pendiente
+        confirmacion_eliminacion_carpeta_pendiente = None
 
     def cancelar_confirmaciones_eliminacion_pendientes() -> None:
         cancelar_confirmacion_eliminacion_pendiente()
@@ -122,9 +119,13 @@ def main(page: "ft.Page"):
             cancelar_confirmacion_eliminacion_pendiente()
 
     def cancelar_confirmacion_carpeta_si_cambia_ruta_pendiente() -> None:
-        if ruta_carpeta_eliminacion_pendiente is None:
+        if confirmacion_eliminacion_carpeta_pendiente is None:
             return
-        if (ruta_input.value or "") != ruta_visible_carpeta_eliminacion_pendiente:
+        if (
+            confirmacion_eliminacion_carpeta_pendiente["tipo"] != "carpeta"
+            or (ruta_input.value or "")
+            != confirmacion_eliminacion_carpeta_pendiente["ruta_visible"]
+        ):
             cancelar_confirmacion_carpeta_eliminacion_pendiente()
 
     def ruta_visible_cambiada(_e=None) -> None:
@@ -561,8 +562,7 @@ def main(page: "ft.Page"):
         actualizar_pagina()
 
     def eliminar_carpeta_handler(_e):
-        nonlocal ruta_carpeta_eliminacion_pendiente
-        nonlocal ruta_visible_carpeta_eliminacion_pendiente
+        nonlocal confirmacion_eliminacion_carpeta_pendiente
 
         cancelar_confirmacion_carpeta_si_cambia_ruta_pendiente()
 
@@ -588,10 +588,14 @@ def main(page: "ft.Page"):
             OSError,
             ValueError,
         ) as exc:
-            mostrar_error_archivo(exc)
+            if str(exc).startswith(
+                "No se puede eliminar el proyecto activo como carpeta normal."
+            ):
+                salida.value = str(exc)
+            else:
+                mostrar_error_archivo(exc)
             page.update()
             return
-
 
         if not ruta_resuelta.exists():
             salida.value = (
@@ -605,9 +609,17 @@ def main(page: "ft.Page"):
             page.update()
             return
 
-        if ruta_carpeta_eliminacion_pendiente != ruta_resuelta:
-            ruta_carpeta_eliminacion_pendiente = ruta_resuelta
-            ruta_visible_carpeta_eliminacion_pendiente = ruta_input.value or ""
+        if (
+            confirmacion_eliminacion_carpeta_pendiente is None
+            or confirmacion_eliminacion_carpeta_pendiente["tipo"] != "carpeta"
+            or confirmacion_eliminacion_carpeta_pendiente["ruta"] != ruta_resuelta
+        ):
+            cancelar_confirmacion_carpeta_eliminacion_pendiente()
+            confirmacion_eliminacion_carpeta_pendiente = {
+                "tipo": "carpeta",
+                "ruta": ruta_resuelta,
+                "ruta_visible": ruta_input.value or "",
+            }
             salida.value = (
                 "Pulsa de nuevo Eliminar carpeta para confirmar: " f"{ruta_resuelta}"
             )


### PR DESCRIPTION
### Motivation
- Evitar eliminaciones accidentales al requerir una confirmación explícita y específica para la operación de eliminar carpeta.
- Mantener todas las validaciones previas a la confirmación (proyecto activo, ruta dentro de `project_root`, bloqueo de `../`, bloqueo de `project_root` y `workspace_root`, existencia y que sea directorio).
- Asegurar que el mensaje mostrado y el flujo de doble pulsación coincidan con las expectativas de la UI y tests existentes.

### Description
- Reemplacé el estado de confirmación de carpeta por un objeto de confirmación con `"tipo": "carpeta"`, `"ruta"` y `"ruta_visible"` para distinguir operaciones y guardar la ruta pendiente. (archivo modificado: `src/pcobra/gui/idle.py`).
- Mantengo todas las validaciones anteriores a la confirmación y, en la primera pulsación válida, guardo la ruta canónica y muestro exactamente: `Pulsa de nuevo Eliminar carpeta para confirmar: <ruta>` sin borrar nada; en la segunda pulsación se recalcula la ruta y se borra solo si coincide con la pendiente usando el borrado seguro ya existente.
- Ajusté el manejo de la excepción específica que indica que no se puede eliminar el `project_root` para mostrar el mensaje sin el prefijo de formateo (para cumplir con las aserciones de tests); el resto de excepciones sigue pasando por `mostrar_error_archivo`.
- Tras el borrado se cancela la confirmación pendiente, se limpia el archivo activo si estaba dentro de la carpeta, se reconstruye el árbol lateral y se actualiza la página.

### Testing
- Ejecuté `pytest tests/unit/test_gui_idle.py::test_eliminar_carpeta_reinicia_editor_si_archivo_activo_esta_dentro tests/unit/test_gui_idle.py::test_eliminar_carpeta_cancela_confirmacion_si_cambia_ruta_visible tests/unit/test_gui_idle.py::test_eliminar_carpeta_bloquea_project_root_activo tests/unit/test_gui_idle.py::test_eliminar_carpeta_mantiene_bloqueos_de_workspace_y_escape tests/gui/test_idle_path_guards.py`.
- Resultado: todos los tests ejecutados pasaron (9 passed) con 1 warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38f747a87883278151da77a1b8f4c1)