### PR TITLE
Refuerza validación y confirmación para eliminar proyectos

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -51,6 +51,35 @@ def validar_ruta_carpeta_eliminable_idle(
     return ruta_resuelta
 
 
+def validar_project_root_eliminable_idle(
+    project_root: str | Path, workspace_root: str | Path
+) -> Path:
+    """Valida el proyecto activo antes de permitir su eliminación desde el IDLE."""
+
+    project_root_resuelto = Path(project_root).resolve()
+    workspace_root_resuelto = Path(workspace_root).resolve()
+
+    if project_root_resuelto == workspace_root_resuelto:
+        raise ValueError("No se puede eliminar la raíz completa del workspace.")
+
+    if project_root_resuelto.parent != workspace_root_resuelto:
+        raise ValueError(
+            "La raíz del proyecto debe ser hija directa de la raíz del workspace."
+        )
+
+    if not project_root_resuelto.exists():
+        raise FileNotFoundError(
+            f"No existe el proyecto que se quiere eliminar: {project_root_resuelto}"
+        )
+
+    if not project_root_resuelto.is_dir():
+        raise NotADirectoryError(
+            f"La ruta del proyecto no es un directorio: {project_root_resuelto}"
+        )
+
+    return project_root_resuelto
+
+
 def main(page: "ft.Page"):
     """Interfaz principal del IDLE con archivos, árbol, ejecución, tokens, AST y sugerencias."""
     ft = runtime.require_flet()
@@ -111,8 +140,7 @@ def main(page: "ft.Page"):
         if confirmacion_eliminacion_archivo_pendiente is None:
             return
         if (
-            estado.ruta
-            != confirmacion_eliminacion_archivo_pendiente["ruta_estado"]
+            estado.ruta != confirmacion_eliminacion_archivo_pendiente["ruta_estado"]
             or (ruta_input.value or "")
             != confirmacion_eliminacion_archivo_pendiente["ruta_visible"]
         ):
@@ -371,14 +399,28 @@ def main(page: "ft.Page"):
 
     def eliminar_proyecto_handler(_e):
         nonlocal project_root, proyecto_cerrado
-        project_root_resuelto = project_root.resolve()
         workspace_root_resuelto = workspace_root.resolve()
 
-        if (
-            not hay_proyecto_activo()
-            or project_root_resuelto == workspace_root_resuelto
-        ):
+        if not hay_proyecto_activo():
             salida.value = "No hay proyecto activo para eliminar."
+            page.update()
+            return
+
+        try:
+            project_root_resuelto = validar_project_root_eliminable_idle(
+                project_root, workspace_root
+            )
+        except (
+            FileNotFoundError,
+            NotADirectoryError,
+            PermissionError,
+            OSError,
+            ValueError,
+        ) as exc:
+            if project_root.resolve() == workspace_root_resuelto:
+                salida.value = "No hay proyecto activo para eliminar."
+            else:
+                mostrar_error_archivo(exc)
             page.update()
             return
 


### PR DESCRIPTION
### Motivation

- Evitar borrados accidentales reforzando las comprobaciones que se ejecutan antes de eliminar un proyecto desde el IDLE. 
- Forzar una confirmación mediante el nombre exacto del proyecto usando el campo visible `ruta_input` para integrarse con el flujo existente.

### Description

- Añadida la función `validar_project_root_eliminable_idle(project_root, workspace_root)` en `src/pcobra/gui/idle.py` que valida que el proyecto no sea la raíz del workspace, que sea hijo directo de `workspace_root`, que exista y que sea un directorio.
- Actualizado `eliminar_proyecto_handler` para invocar la nueva validación antes de solicitar la confirmación por nombre y antes de delegar en `runtime.eliminar_proyecto_validado()`.
- Conservada la confirmación por nombre exacto usando `ruta_input` y el mensaje preciso requerido: `Para eliminar este proyecto escribe su nombre exacto: <nombre>` cuando no coincide.
- Tras la eliminación se restablece el estado visual y lógico: `project_root` vuelve a `workspace_root`, `estado.ruta` se limpia, el editor y la ruta visible se vacían, se reconstruye el árbol lateral y se llama a `page.update()` mediante `actualizar_pagina()`.

### Testing

- Ejecutado formateo y comprobación estática con `python -m black src/pcobra/gui/idle.py` y `python -m ruff check src/pcobra/gui/idle.py`, ambos sin errores.
- Ejecutado `python -m compileall -q src/pcobra/gui/idle.py` sin errores.
- Ejecutadas pruebas focalizadas con pytest: `tests/unit/test_gui_idle.py::test_eliminar_proyecto_activo_reinicia_estado_y_vuelve_al_workspace`, `tests/unit/test_gui_idle.py::test_eliminar_proyecto_exige_nombre_exacto`, `tests/unit/test_gui_idle.py::test_eliminar_proyecto_bloquea_si_no_hay_proyecto_activo` y `tests/gui/test_runtime_delete_safe.py`, todas pasaron (14 tests totales en la sesión, 1 advertencia deprecación).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3908011f288327b6cf5f6a8e705106)