### PR TITLE
test: cover idle path guard helpers

### DIFF
--- a/tests/gui/test_idle_path_guards.py
+++ b/tests/gui/test_idle_path_guards.py
@@ -5,51 +5,68 @@ import pytest
 from pcobra.gui import idle
 
 
-def test_resolver_ruta_en_project_root_acepta_ruta_relativa_normal(tmp_path: Path):
-    project_root = tmp_path / "workspace" / "proyecto"
+@pytest.fixture
+def idle_roots(tmp_path: Path) -> tuple[Path, Path]:
+    workspace_root = tmp_path / "workspace"
+    project_root = workspace_root / "proyecto"
     project_root.mkdir(parents=True)
+    return workspace_root, project_root
+
+
+def test_resolver_ruta_en_project_root_acepta_ruta_relativa_normal(
+    idle_roots: tuple[Path, Path],
+):
+    _workspace_root, project_root = idle_roots
 
     assert idle.resolver_ruta_en_project_root("src/programa.co", project_root) == (
         project_root / "src" / "programa.co"
     ).resolve()
 
 
-def test_resolver_ruta_en_project_root_bloquea_parent_directory(tmp_path: Path):
-    project_root = tmp_path / "workspace" / "proyecto"
-    project_root.mkdir(parents=True)
+def test_resolver_ruta_en_project_root_bloquea_parent_directory(
+    idle_roots: tuple[Path, Path],
+):
+    _workspace_root, project_root = idle_roots
 
     with pytest.raises(ValueError, match="dentro del proyecto activo"):
         idle.resolver_ruta_en_project_root("../escape.co", project_root)
 
 
 def test_resolver_ruta_en_project_root_bloquea_absoluta_fuera_de_project_root(
-    tmp_path: Path,
+    tmp_path: Path, idle_roots: tuple[Path, Path]
 ):
-    project_root = tmp_path / "workspace" / "proyecto"
+    _workspace_root, project_root = idle_roots
     externo = tmp_path / "externo.co"
-    project_root.mkdir(parents=True)
 
     with pytest.raises(ValueError, match="dentro del proyecto activo"):
         idle.resolver_ruta_en_project_root(externo, project_root)
 
 
 def test_validar_ruta_carpeta_eliminable_idle_bloquea_punto_como_carpeta_normal(
-    tmp_path: Path,
+    idle_roots: tuple[Path, Path],
 ):
-    workspace_root = tmp_path / "workspace"
-    project_root = workspace_root / "proyecto"
-    project_root.mkdir(parents=True)
+    workspace_root, project_root = idle_roots
 
     with pytest.raises(ValueError, match="proyecto activo como carpeta normal"):
         idle.validar_ruta_carpeta_eliminable_idle(".", project_root, workspace_root)
 
 
-def test_validar_ruta_carpeta_eliminable_idle_bloquea_workspace_root(tmp_path: Path):
-    workspace_root = tmp_path / "workspace"
-    project_root = workspace_root / "proyecto"
-    project_root.mkdir(parents=True)
+def test_validar_ruta_carpeta_eliminable_idle_bloquea_workspace_root(
+    idle_roots: tuple[Path, Path],
+):
+    workspace_root, project_root = idle_roots
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="dentro del proyecto activo"):
         idle.validar_ruta_carpeta_eliminable_idle(
             workspace_root, project_root, workspace_root
         )
+
+
+def test_validar_project_root_eliminable_idle_exige_proyecto_activo_existente(
+    idle_roots: tuple[Path, Path],
+):
+    workspace_root, project_root = idle_roots
+    project_root.rmdir()
+
+    with pytest.raises(FileNotFoundError, match="No existe el proyecto"):
+        idle.validar_project_root_eliminable_idle(project_root, workspace_root)


### PR DESCRIPTION
### Motivation

- Añadir pruebas enfocadas en los helpers de resolución y validación de rutas del IDLE para evitar regressions en control de escapes y límites del workspace.
- Reutilizar `tmp_path` para crear `workspace_root` y `project_root` y centralizar la preparación de escenarios de prueba.

### Description

- Añadido el fixture `idle_roots` en `tests/gui/test_idle_path_guards.py` que crea `workspace_root` y `project_root` en `tmp_path` para los tests.
- Reorganizados los tests existentes para usar el fixture en lugar de repetir la creación de directorios temporales.
- Añadido un caso que cubre `validar_project_root_eliminable_idle` para asegurar que se lanza `FileNotFoundError` cuando el proyecto activo no existe.
- Ajustada la aserción en la prueba que verifica el bloqueo de la raíz del workspace para comprobar el mensaje de validación esperado de los guards.

### Testing

- Ejecutado `pytest tests/gui/test_idle_path_guards.py` y las pruebas pasaron con éxito; salida: `6 passed, 1 warning`.
- Las pruebas importan los helpers desde `src/pcobra/gui/idle.py` sin iniciar la GUI porque la inicialización de Flet está diferida en `main()`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a392998c39883279bfa1b89ca568f12)