### PR TITLE
docs: expand feature rollout checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,12 @@ Plantilla reutilizable:
 
 - `docs/templates/feature_rollout_checklist.md`
 
+La plantilla exige documentar el resumen de archivos modificados, las pruebas
+añadidas, el resultado de comandos ejecutados, las POCs manuales pendientes,
+las validaciones manuales no ejecutadas y las confirmaciones explícitas de
+alcance cuando no se tocaron lexer, parser, gramática, tokens, AST,
+transpiladores, sintaxis Cobra ni dependencias.
+
 Gates de CI relacionados:
 
 - `python scripts/ci/audit_feature_rollout.py --base <sha_base> --head <sha_head>`

--- a/docs/templates/feature_rollout_checklist.md
+++ b/docs/templates/feature_rollout_checklist.md
@@ -7,6 +7,36 @@ Usa esta plantilla para cualquier feature nueva (`<feature_id>`).
 - Feature ID: `<feature_id>`
 - PR/RFC: `<enlace>`
 
+## Resumen de archivos modificados
+
+- `<ruta>`: `<motivo del cambio>`
+
+## Resumen de pruebas añadidas
+
+- `<ruta_test>`: `<caso cubierto>`
+- Si no se añadieron pruebas, justificar por qué no aplica:
+
+## Resultado de comandos ejecutados
+
+- `<comando>`: `<resultado>`
+- Indicar cualquier comando que no pudo ejecutarse y el motivo:
+
+## POCs que deben repetirse manualmente
+
+- `<POC/manual>`: `<pasos esperados>`
+- Si no hay POCs manuales pendientes, indicar: `No aplica`.
+
+## Confirmaciones explícitas de alcance
+
+- [ ] No se tocó Lexer.
+- [ ] No se tocó Parser.
+- [ ] No se tocó gramática.
+- [ ] No se tocaron tokens.
+- [ ] No se tocaron nodos AST.
+- [ ] No se tocaron transpiladores.
+- [ ] No se cambió sintaxis Cobra.
+- [ ] No se añadieron dependencias.
+
 ## Cobertura técnica
 
 - [ ] gramática/parser/AST
@@ -22,6 +52,11 @@ Usa esta plantilla para cualquier feature nueva (`<feature_id>`).
 - [ ] docs y ejemplos
   - Documentación:
   - Ejemplo mínimo en `examples/features/<feature_id>/minimal.co`:
+
+## Validaciones manuales no ejecutadas
+
+- `<validación>`: `<motivo>`
+- Si todas las validaciones manuales aplicables se ejecutaron, indicar: `No aplica`.
 
 ## Verificación rápida
 


### PR DESCRIPTION
### Motivation
- Mejorar la plantilla de rollout para que las PR de features documenten explícitamente archivos modificados, pruebas añadidas, comandos ejecutados, POCs manuales y validaciones, y para forzar confirmaciones de no afectación a componentes sintácticos y dependencias.

### Description
- Añade múltiples secciones a `docs/templates/feature_rollout_checklist.md`: `Resumen de archivos modificados`, `Resumen de pruebas añadidas`, `Resultado de comandos ejecutados`, `POCs que deben repetirse manualmente`, `Confirmaciones explícitas de alcance` y `Validaciones manuales no ejecutadas`.
- Actualiza `CONTRIBUTING.md` para indicar que la plantilla reutilizable exige documentar esas secciones y confirmaciones de alcance.
- Resumen de archivos modificados: `docs/templates/feature_rollout_checklist.md` y `CONTRIBUTING.md` (solo cambios documentales).
- Confirmaciones explícitas: no se tocó Lexer, no se tocó Parser, no se tocó gramática, no se tocaron tokens, no se tocaron nodos AST, no se tocaron transpiladores, no se cambió sintaxis Cobra y no se añadieron dependencias.

### Testing
- Ejecuté `git diff --check` y `git diff --name-only` y ambos mostraron un diff limpio y que solo se modificaron `CONTRIBUTING.md` y `docs/templates/feature_rollout_checklist.md` (OK).
- Ejecuté un pequeño script Python que confirmó que no se tocaron archivos protegidos (`src/pcobra/cobra/core/lexer.py`, `src/pcobra/cobra/core/parser.py`, ni archivos de dependencias) y devolvió `protected_touched: none` (OK).
- Ejecuté `python scripts/ci/audit_feature_rollout.py --feature-id placeholder` que falló de forma esperada porque `placeholder` no corresponde a una feature real con artefactos completos; este fallo es esperado y no indica regresión del cambio documental (esperado/fallo).
- Realicé el commit (`git commit`) satisfactoriamente produciendo el commit `d1c30ed` con las dos modificaciones documentales; no se añadieron pruebas automatizadas porque el cambio es exclusivamente documental.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3965ad75288327989a2995ef4ae428)