### PR TITLE
fix: keep holobit dependency resolvable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pandas>=2.3.3,<3",
     "agix>=1.4,<1.5",
     "chardet>=5.2,<6",
-    "holobit-sdk>=1.2,<2; python_version >= '3.10'",
+    "holobit-sdk>=1.0.8,<1.2; python_version >= '3.10'",
     "smooth-criminal>=0.8,<1",
     "tomli>=2.4,<3",
     "PyYAML>=6.0.3,<7",


### PR DESCRIPTION
### Motivation
- The conditional `holobit-sdk` dependency range required `>=1.2` which could be unresolvable against published package versions for Python `>=3.10`, so the range must be constrained to published releases to avoid install failures.

### Description
- Updated `pyproject.toml` to change the conditional dependency from `"holobit-sdk>=1.2,<2; python_version >= '3.10'"` to `"holobit-sdk>=1.0.8,<1.2; python_version >= '3.10'"` so the resolver can find a published wheel.

### Testing
- Validated dependency syntax by parsing each requirement with `packaging.requirements.Requirement`, which completed successfully for all main dependencies.
- Confirmed the adjusted range resolves to an available distribution with `python -m pip download --no-deps --dest /tmp/pcobra-holobit-check 'holobit-sdk>=1.0.8,<1.2'`, which downloaded a wheel.
- Ran `git diff --check` to ensure no whitespace or formatting issues, and it returned no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cefa44b8c83278d1c6282f36aa18e)