### PR TITLE
Pin FastAPI for Python 3.9 compatibility

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -44,8 +44,10 @@ docutils==0.20.1
     #   myst-parser
     #   sphinx
     #   sphinx-rtd-theme
-fastapi==0.136.3
-    # via agix
+fastapi==0.128.8
+    # via
+    #   agix
+    #   pcobra (pyproject.toml)
 flet==0.28.3
     # via
     #   agix
@@ -215,7 +217,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-starlette==1.2.1
+starlette==0.52.1
     # via fastapi
 sympy==1.14.0
     # via pcobra (pyproject.toml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ dependencies = [
     "pexpect>=4.9,<5",
     "requests>=2.32.5,<2.33",
     "flet>=0.28.3,<0.29",
+    # agix pulls FastAPI transitively; keep it on the newest Python 3.9-compatible line.
+    "fastapi>=0.128.8,<0.129",
     "packaging>=26,<27",
     "pybind11>=3.0,<4",
     "tree-sitter>=0.23.2,<0.24",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -56,8 +56,10 @@ docstring-to-markdown==0.17
     # via python-lsp-server
 executing==2.2.1
     # via stack-data
-fastapi==0.136.3
-    # via agix
+fastapi==0.128.8
+    # via
+    #   agix
+    #   pcobra (pyproject.toml)
 flet==0.28.3
     # via
     #   agix
@@ -280,7 +282,7 @@ sortedcontainers==2.4.0
     # via hypothesis
 stack-data==0.6.3
     # via ipython
-starlette==1.2.1
+starlette==0.52.1
     # via fastapi
 sympy==1.14.0
     # via pcobra (pyproject.toml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,8 +35,10 @@ contourpy==1.3.3
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fastapi==0.136.3
-    # via agix
+fastapi==0.128.8
+    # via
+    #   agix
+    #   pcobra (pyproject.toml)
 flet==0.28.3
     # via
     #   agix
@@ -158,7 +160,7 @@ six==1.17.0
     #   repath
 smooth-criminal==0.8.0
     # via pcobra (pyproject.toml)
-starlette==1.2.1
+starlette==0.52.1
     # via fastapi
 sympy==1.14.0
     # via pcobra (pyproject.toml)


### PR DESCRIPTION
### Motivation
- The compiled requirements in this PR currently pin `fastapi==0.136.3`, whose PyPI metadata declares `Requires-Python: >=3.10`, which breaks `pip install -r requirements.txt` for the project policy of `requires-python = ">=3.9"`.
- Ensure the compiled dependency graph remains installable on Python 3.9 by constraining FastAPI to a 3.9-compatible release line.

### Description
- Add an explicit FastAPI constraint to `pyproject.toml`: `fastapi>=0.128.8,<0.129` to keep the graph on the newest Python 3.9-compatible FastAPI line.
- Recompiled the three compiled requirement files with `pip-compile` producing `requirements.txt`, `requirements-dev.txt`, and `docs/requirements.txt` that pin `fastapi==0.128.8` and the compatible `starlette==0.52.1` and update a small set of transitive/dev pins.
- The changes are limited to `pyproject.toml`, `requirements.txt`, `requirements-dev.txt`, and `docs/requirements.txt` and do not modify source code.

### Testing
- Ran `pip-compile` via `bash scripts/sync_requirements.sh --upgrade`, observed an initial resolution failure caused by the unguarded FastAPI pin, then added the constraint and re-ran compilation successfully. (final: success)
- Verified no whitespace/diff issues with `git diff --check` and `bash scripts/check_requirements_drift.sh`. (success)
- Confirmed PyPI metadata for the selected FastAPI release with a small check (`python` script) showing `fastapi 0.128.8 Requires-Python: >=3.9`. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cfd6c722c8327b8c7646cdedd51bb)