### PR TITLE
Limit Python support for numeric dependency pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "10.1.1"
 description = "Un lenguaje de programación en español para simulaciones y más."
 authors = [ {name = "Adolfo González Hernández", email = "adolfogonzal@gmail.com"} ]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 license = { file = "LICENSE" }
 keywords = ["cobra", "lenguaje", "cli"]
 classifiers = [
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 
-# Política Python >=3.11: las dependencias se fijan al tramo más reciente
+# Política Python >=3.11,<3.14: las dependencias se fijan al tramo más reciente
 # publicado compatible con la superficie actual del proyecto.
 dependencies = [
     "numpy>=2.1.3,<2.2",


### PR DESCRIPTION
### Motivation
- Prevent Python 3.14 environments from resolving to NumPy/SciPy releases that do not provide cp314-compatible wheels by narrowing the advertised interpreter range.

### Description
- Change `requires-python` in `pyproject.toml` from `">=3.11"` to `">=3.11,<3.14"` and update the dependency policy comment to reflect the narrowed supported interpreter range.

### Testing
- Validated `pyproject.toml` metadata with `tomllib` using a `python - <<'PY' ... PY` check and ran `git diff --check`, both of which succeeded.
- Attempt to run `python -m piptools compile --output-file=/tmp/pcobra-req.txt --strip-extras pyproject.toml` could not be executed because `piptools` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d233add708327b5d062d42b36bf53)