### PR TITLE
Evitar efectos de módulos `usar` durante la prevalidación segura

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -41,6 +41,7 @@ except ModuleNotFoundError:  # pragma: no cover - entornos sin prompt_toolkit
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.execution_pipeline import (
     construir_script_sandbox_canonico,
+    ejecutar_usar_prevalidacion,
     prevalidar_y_parsear_codigo,
     resolver_interpretador_cls,
     validar_ast_seguro,
@@ -560,8 +561,7 @@ class InteractiveCommand(BaseCommand):
                 if getattr(nodo, "__class__", type("", (), {})).__name__ == "NodoUsar"
             ]
             if nodos_usar:
-                for nodo_usar in nodos_usar:
-                    self.interpretador.ejecutar_nodo(nodo_usar)
+                ejecutar_usar_prevalidacion(nodos_usar, self.interpretador)
             validar_ast_seguro(
                 ast,
                 validadores_extra=self._extra_validators_repl,

--- a/src/pcobra/cobra/cli/execution_pipeline.py
+++ b/src/pcobra/cobra/cli/execution_pipeline.py
@@ -128,6 +128,17 @@ def ejecutar_ast(ast: Any, interpreter: Any) -> Any:
     return interpreter.ejecutar_ast(ast)
 
 
+def ejecutar_usar_prevalidacion(nodos_usar: Any, interpreter: Any) -> Any:
+    """Ejecuta la prepasada segura de `usar` sin efectos en módulos de proyecto."""
+
+    previo = getattr(interpreter, "_usar_prepass_metadata_only", False)
+    setattr(interpreter, "_usar_prepass_metadata_only", True)
+    try:
+        return ejecutar_ast(nodos_usar, interpreter)
+    finally:
+        setattr(interpreter, "_usar_prepass_metadata_only", previo)
+
+
 def resolver_validadores_seguridad(
     extra_validators: Any,
     *,
@@ -352,7 +363,7 @@ def ejecutar_codigo_canonico(
             nodo for nodo in ast if getattr(nodo, "__class__", type("", (), {})).__name__ == "NodoUsar"
         ]
         if nodos_usar:
-            ejecutar_ast(nodos_usar, interpretador)
+            ejecutar_usar_prevalidacion(nodos_usar, interpretador)
         validar_ast_seguro(
             ast,
             validadores_extra=extra_validators,

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -550,6 +550,9 @@ class InterpretadorCobra:
             self._main_file, self._main_file
         )
         self._current_module_stack: list[Path] = []
+        # Prepasadas de modo seguro solo deben poblar/validar metadatos de `usar`
+        # sin ejecutar efectos de módulos Cobra de proyecto.
+        self._usar_prepass_metadata_only = False
         # Debe ejecutarse siempre después de crear _validador y _usar_symbol_metadata.
         self.asegurar_estado_runtime_inicial()
 
@@ -2298,6 +2301,15 @@ class InterpretadorCobra:
 
         self._current_module_stack.append(ruta_modulo)
         try:
+            if self._usar_prepass_metadata_only:
+                for subnodo in ast:
+                    modo_prev = self._set_mode("analysis")
+                    try:
+                        self._validar(subnodo)
+                    finally:
+                        self._set_mode(modo_prev)
+                return None
+
             for subnodo in ast:
                 self.ejecutar_nodo(subnodo)
         finally:

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -71,3 +71,70 @@ def test_interpretador_usar_proyecto_resuelve_desde_cobra_toml(monkeypatch, tmp_
         )
     ]
     assert interp._project_root == proyecto.resolve()
+
+
+def test_usar_proyecto_prepass_seguro_valida_sin_ejecutar(monkeypatch, tmp_path):
+    proyecto = tmp_path / "app"
+    (proyecto / "utilidades").mkdir(parents=True)
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "utilidades" / "fechas.co"
+    modulo.write_text("", encoding="utf-8")
+    eventos = []
+
+    class NodoEfecto:
+        def aceptar(self, validador):
+            eventos.append("validado")
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        return [NodoEfecto()]
+
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
+
+    interp = InterpretadorCobra(main_file=principal)
+    ejecutar_original = interp.ejecutar_nodo
+
+    def ejecutar_nodo_con_efecto(nodo):
+        eventos.append("ejecutado")
+        return ejecutar_original(nodo)
+
+    monkeypatch.setattr(interp, "ejecutar_nodo", ejecutar_nodo_con_efecto)
+    interp._usar_prepass_metadata_only = True
+
+    interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.fechas"))
+
+    assert eventos == ["validado"]
+
+
+def test_usar_proyecto_ejecucion_normal_ejecuta_modulo(monkeypatch, tmp_path):
+    proyecto = tmp_path / "app"
+    (proyecto / "utilidades").mkdir(parents=True)
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    modulo = proyecto / "utilidades" / "fechas.co"
+    modulo.write_text("", encoding="utf-8")
+    eventos = []
+
+    class NodoEfecto:
+        pass
+
+    def fake_cargar_ast_modulo(ruta, **kwargs):
+        return [NodoEfecto()]
+
+    monkeypatch.setattr(
+        "pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo
+    )
+    interp = InterpretadorCobra(main_file=principal)
+
+    def ejecutar_nodo_con_efecto(nodo):
+        eventos.append("ejecutado")
+
+    monkeypatch.setattr(interp, "ejecutar_nodo", ejecutar_nodo_con_efecto)
+
+    interp.ejecutar_usar(SimpleNamespace(modulo="utilidades.fechas"))
+
+    assert eventos == ["ejecutado"]


### PR DESCRIPTION
### Motivation

- El prepass en `safe_mode` estaba ejecutando los nodos de módulos de proyecto importados por `usar`, lo que provocaba efectos top-level (prints, asignaciones, I/O) antes de la validación y de la ejecución normal. 
- Es necesario que la prevalidación solo construya/valide metadata de `usar` (idempotente) sin ejecutar efectos, para mantener la semántica de `usar` y evitar doble ejecución.

### Description

- Añadido flag `_usar_prepass_metadata_only` en `InterpretadorCobra` para marcar prepasadas seguras que deben validar metadata sin ejecutar efectos. (modificado: `src/pcobra/core/interpreter.py`).
- Modificado `_ejecutar_usar_modulo_proyecto` para, cuando la prepass metadata-only esté activada, recorrer los nodos del AST en modo `analysis` y validar (`_validar`) en lugar de llamar a `ejecutar_nodo`. (modificado: `src/pcobra/core/interpreter.py`).
- Creado helper `ejecutar_usar_prevalidacion` en el pipeline que habilita temporalmente la prepass metadata-only, ejecuta la prevalidación y restaura el estado previo. (modificado: `src/pcobra/cobra/cli/execution_pipeline.py`).
- Actualizado el flujo del REPL y del pipeline CLI para usar el helper en la prevalidación segura en lugar de ejecutar directamente los `NodoUsar`, preservando la validación sin efectos. (modificado: `src/pcobra/cobra/cli/commands/interactive_cmd.py`, `src/pcobra/cobra/cli/execution_pipeline.py`).
- Añadidos tests de regresión que verifican que la prepass valida sin ejecutar efectos y que la ejecución normal sigue ejecutando el módulo importado. (nuevo: `tests/unit/test_project_root_usar_resolution.py`).

### Testing

- Verificado que los módulos modificados compilan estáticamente con `python -m py_compile src/pcobra/core/interpreter.py src/pcobra/cobra/cli/execution_pipeline.py src/pcobra/cobra/cli/commands/interactive_cmd.py` (éxito).
- Ejecutados los tests unitarios añadidos y relacionados con resolución/loader: `pytest -q tests/unit/test_project_root_usar_resolution.py` y `pytest -q tests/unit/test_project_root_usar_resolution.py tests/unit/test_usar_loader_validation.py::test_resolver_modulo_cobra_proyecto_convierte_nombre_punteado_en_co`, ambos pasaron (todos los tests relevantes pasaron; salida: 7 passed, 1 warning en la sesión local).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d6307e4d08327951601e0b6c66590)