### PR TITLE
Gate project usar modules in strict REPL

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2453,6 +2453,9 @@ class InterpretadorCobra:
             es_repl_estricto = self._repl_usar_alias_map is not None
             mapa_repl = self._repl_usar_alias_map or REPL_COBRA_MODULE_MAP
 
+            if es_repl_estricto and nombre_modulo not in mapa_repl:
+                raise PermissionError(REPL_USAR_EXTERNAL_MODULE_ERROR)
+
             if nombre_modulo not in USAR_COBRA_ALLOWLIST:
                 # Trazabilidad explícita para intentos de importar módulos de backend directamente.
                 if nombre_modulo in mapa_repl.values():
@@ -2483,8 +2486,12 @@ class InterpretadorCobra:
             if isinstance(nombre_modulo, str):
                 nombre_modulo_limpio = nombre_modulo.strip()
                 if (
-                    "." in nombre_modulo_limpio
-                    or nombre_modulo_limpio not in USAR_COBRA_ALLOWLIST
+                    self._repl_usar_alias_map is None
+                    and not nombre_modulo_limpio.startswith("pcobra")
+                    and (
+                        "." in nombre_modulo_limpio
+                        or nombre_modulo_limpio not in USAR_COBRA_ALLOWLIST
+                    )
                 ):
                     try:
                         return self._ejecutar_usar_modulo_proyecto(nombre_modulo_limpio)
@@ -2645,6 +2652,8 @@ class InterpretadorCobra:
             else:
                 logging.error("Error al usar el módulo '%s': %s", nodo.modulo, exc)
             if isinstance(exc, PermissionError):
+                if str(exc) == REPL_USAR_EXTERNAL_MODULE_ERROR or str(exc).startswith("usar_error["):
+                    raise
                 mensaje = formatear_error_usar_usuario("modulo_fuera_catalogo", nodo.modulo)
                 if detalle_usar_habilitado:
                     mensaje = f"{mensaje} ({exc})"

--- a/tests/unit/test_project_root_usar_resolution.py
+++ b/tests/unit/test_project_root_usar_resolution.py
@@ -201,6 +201,28 @@ def test_resolver_modulo_cobra_proyecto_resuelve_modulo_anidado(tmp_path):
     assert resolver_modulo_cobra_proyecto("a.b.c", project_root=proyecto) == modulo.resolve()
 
 
+def test_interpretador_usar_proyecto_simple_se_bloquea_en_repl_estricto(monkeypatch, tmp_path):
+    import pytest
+
+    proyecto = tmp_path / "app"
+    proyecto.mkdir()
+    (proyecto / "cobra.toml").write_text("[proyecto]\n", encoding="utf-8")
+    principal = proyecto / "main.co"
+    principal.write_text("", encoding="utf-8")
+    (proyecto / "saludos.co").write_text("", encoding="utf-8")
+
+    def fake_cargar_ast_modulo(_ruta, **_kwargs):
+        raise AssertionError("REPL estricto no debe resolver módulos Cobra de proyecto")
+
+    monkeypatch.setattr("pcobra.core.interpreter.cargar_ast_modulo", fake_cargar_ast_modulo)
+
+    interp = InterpretadorCobra(main_file=principal)
+    interp.configurar_restriccion_usar_repl({"numero": "numero", "texto": "texto"})
+
+    with pytest.raises(PermissionError, match=r"módulo externo no permitido en REPL estricto"):
+        interp.ejecutar_usar(SimpleNamespace(modulo="saludos"))
+
+
 def test_interpretador_usar_proyecto_misma_carpeta_con_nombre_simple(monkeypatch, tmp_path):
     proyecto = tmp_path / "app"
     proyecto.mkdir()


### PR DESCRIPTION
### Motivation
- Prevent strict REPL `usar` from bypassing the official-alias restriction by resolving same-project `.co` files before validating the configured REPL alias map.
- Keep existing canonical `usar_error[...]` PermissionError messages intact so callers can rely on error codes and messages emitted by the policy checks.
- Add a regression test that demonstrates `usar saludos` is rejected in strict REPL even when `saludos.co` exists in the project root.

### Description
- In `src/pcobra/core/interpreter.py` gate canonical REPL checks early by raising `REPL_USAR_EXTERNAL_MODULE_ERROR` when `_repl_usar_alias_map` is set and the requested name is not in the alias map. 
- Restrict the project-module fallback so it only runs when no REPL alias restriction is active and avoid treating backend-style names (`pcobra.*`) as project modules. 
- Preserve canonical permission errors by re-raising `REPL_USAR_EXTERNAL_MODULE_ERROR` and errors that already start with `usar_error[...]` instead of wrapping them in a generic "módulo fuera del catálogo público" message. 
- Add `tests/unit/test_project_root_usar_resolution.py::test_interpretador_usar_proyecto_simple_se_bloquea_en_repl_estricto` to assert the strict-REPL rejection for simple project module names.

### Testing
- Ran the new and related unit tests: `pytest -q tests/unit/test_project_root_usar_resolution.py` and the suite passed (`23 passed, 1 warning`).
- Exercised related public-contract tests selectively with `pytest -q tests/unit/test_usar_public_contract.py::<tests>` and the targeted checks passed after the changes. 
- Noted an unrelated test-collection issue when attempting to run some legacy-importing tests (`tests/unit/test_usar.py`) in this environment which raised `ImportError: attempted relative import beyond top-level package`; this is an environment/collector quirk and not caused by the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d671d04ac832797ce43f7cafba890)