### PR TITLE
Restore legacy transpiler compatibility shims and align target validator

### DIFF
--- a/scripts/ci/validate_targets.py
+++ b/scripts/ci/validate_targets.py
@@ -63,6 +63,10 @@ EXPECTED_TRANSPILER_MODULES = tuple(
     f"src/pcobra/cobra/transpilers/transpiler/{filename}"
     for filename in official_transpiler_module_filenames()
 )
+COMPAT_LEGACY_TRANSPILER_SHIMS = tuple(
+    f"src/pcobra/cobra/transpilers/transpiler/to_{target}.py"
+    for target in INTERNAL_LEGACY_TARGETS
+)
 EXPECTED_GOLDEN_FILES = tuple(
     f"tests/integration/transpilers/golden/{target}.golden"
     for target in FINAL_OFFICIAL_TARGETS
@@ -595,20 +599,26 @@ def validate_targeted_artifact_roots(
         if not (set(path.relative_to(ROOT).parts) & ignored_parts)
         and "legacy" not in path.relative_to(ROOT).parts
     }
-    expected_forward_paths = set(EXPECTED_TRANSPILER_MODULES) | {
-        "src/pcobra/cobra/transpilers/transpiler/to_js.py"
-    }
+    expected_forward_paths = (
+        set(EXPECTED_TRANSPILER_MODULES)
+        | set(COMPAT_LEGACY_TRANSPILER_SHIMS)
+        | {"src/pcobra/cobra/transpilers/transpiler/to_js.py"}
+    )
     for missing in sorted(expected_forward_paths - found_forward_paths):
         errors.append(
             f"{missing}: falta módulo oficial to_*.py para un backend canónico"
         )
     for extra in sorted(found_forward_paths - expected_forward_paths):
         errors.append(
-            f"{extra}: módulo to_*.py extra fuera de política (target retirado o alias interno expuesto)"
+            f"{extra}: módulo to_*.py extra fuera de política (target retirado o alias interno no controlado)"
         )
 
     found_forward = {path.name for path in TRANSPILER_DIR.glob("to_*.py")}
-    expected_forward = {Path(path).name for path in EXPECTED_TRANSPILER_MODULES} | {"to_js.py"}
+    expected_forward = (
+        {Path(path).name for path in EXPECTED_TRANSPILER_MODULES}
+        | {Path(path).name for path in COMPAT_LEGACY_TRANSPILER_SHIMS}
+        | {"to_js.py"}
+    )
     if found_forward != expected_forward:
         errors.append(
             f"{TRANSPILER_DIR.relative_to(ROOT).as_posix()}: directorio canónico desalineado -> "
@@ -617,7 +627,7 @@ def validate_targeted_artifact_roots(
     unexpected_forward = sorted(found_forward - expected_forward)
     if unexpected_forward:
         errors.append(
-            f"{TRANSPILER_DIR.relative_to(ROOT).as_posix()}: inventario to_*.py contiene módulos no permitidos -> "
+            f"{TRANSPILER_DIR.relative_to(ROOT).as_posix()}: inventario to_*.py contiene módulos no permitidos ni shims legacy controlados -> "
             f"{unexpected_forward}"
         )
     expected_registry_modules = {

--- a/src/pcobra/cobra/transpilers/common/utils.py
+++ b/src/pcobra/cobra/transpilers/common/utils.py
@@ -66,10 +66,17 @@ STANDARD_IMPORTS = {
         *build_javascript_standard_runtime_lines(),
     ],
     "rust": build_rust_standard_runtime_lines(),
+    # Entradas legacy internas: no forman parte de ACTIVE_RUNTIME_BACKENDS ni del
+    # contrato público, pero mantienen operativos los transpiladores históricos
+    # cuando se importan con PCOBRA_ENABLE_LEGACY_TRANSPILERS=1.
+    "go": [],
     "cpp": [
         "#include <iostream>",
         "#include <stdexcept>",
     ],
+    "java": [],
+    "wasm": [],
+    "asm": [],
 }
 
 HOOK_SIGNATURE_MARKERS = {
@@ -102,6 +109,13 @@ RUNTIME_ERROR_MESSAGE = {
 
 
 RUNTIME_HOOKS = {
+    # Hooks legacy internos: solo se consultan desde módulos bajo
+    # transpiler.legacy, ya protegidos por opt-in explícito.
+    "go": [],
+    "cpp": [],
+    "java": [],
+    "wasm": [],
+    "asm": [],
     "python": [
         "def _cobra_missing_holobit(feature):",
         "    raise ModuleNotFoundError(",

--- a/src/pcobra/cobra/transpilers/transpiler/to_asm.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_asm.py
@@ -1,0 +1,12 @@
+"""INTERNAL COMPATIBILITY ONLY. Shim histórico para la ruta legacy to_asm.
+
+La implementación legacy vive en el módulo legacy.to_asm. Este alias se
+conserva para importadores internos durante la migración y sigue requiriendo
+PCOBRA_ENABLE_LEGACY_TRANSPILERS=1 porque el módulo legacy canónico valida
+ese opt-in al importarse.
+"""
+# pcobra-compat: allow-legacy-transpiler-shim
+
+from pcobra.cobra.transpilers.transpiler.legacy.to_asm import TranspiladorASM
+
+__all__ = ["TranspiladorASM"]

--- a/src/pcobra/cobra/transpilers/transpiler/to_cpp.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_cpp.py
@@ -1,0 +1,12 @@
+"""INTERNAL COMPATIBILITY ONLY. Shim histórico para la ruta legacy to_cpp.
+
+La implementación legacy vive en el módulo legacy.to_cpp. Este alias se
+conserva para importadores internos durante la migración y sigue requiriendo
+PCOBRA_ENABLE_LEGACY_TRANSPILERS=1 porque el módulo legacy canónico valida
+ese opt-in al importarse.
+"""
+# pcobra-compat: allow-legacy-transpiler-shim
+
+from pcobra.cobra.transpilers.transpiler.legacy.to_cpp import TranspiladorCPP
+
+__all__ = ["TranspiladorCPP"]

--- a/src/pcobra/cobra/transpilers/transpiler/to_go.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_go.py
@@ -1,0 +1,12 @@
+"""INTERNAL COMPATIBILITY ONLY. Shim histórico para la ruta legacy to_go.
+
+La implementación legacy vive en el módulo legacy.to_go. Este alias se
+conserva para importadores internos durante la migración y sigue requiriendo
+PCOBRA_ENABLE_LEGACY_TRANSPILERS=1 porque el módulo legacy canónico valida
+ese opt-in al importarse.
+"""
+# pcobra-compat: allow-legacy-transpiler-shim
+
+from pcobra.cobra.transpilers.transpiler.legacy.to_go import TranspiladorGo
+
+__all__ = ["TranspiladorGo"]

--- a/src/pcobra/cobra/transpilers/transpiler/to_java.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_java.py
@@ -1,0 +1,12 @@
+"""INTERNAL COMPATIBILITY ONLY. Shim histórico para la ruta legacy to_java.
+
+La implementación legacy vive en el módulo legacy.to_java. Este alias se
+conserva para importadores internos durante la migración y sigue requiriendo
+PCOBRA_ENABLE_LEGACY_TRANSPILERS=1 porque el módulo legacy canónico valida
+ese opt-in al importarse.
+"""
+# pcobra-compat: allow-legacy-transpiler-shim
+
+from pcobra.cobra.transpilers.transpiler.legacy.to_java import TranspiladorJava
+
+__all__ = ["TranspiladorJava"]

--- a/src/pcobra/cobra/transpilers/transpiler/to_wasm.py
+++ b/src/pcobra/cobra/transpilers/transpiler/to_wasm.py
@@ -1,0 +1,12 @@
+"""INTERNAL COMPATIBILITY ONLY. Shim histórico para la ruta legacy to_wasm.
+
+La implementación legacy vive en el módulo legacy.to_wasm. Este alias se
+conserva para importadores internos durante la migración y sigue requiriendo
+PCOBRA_ENABLE_LEGACY_TRANSPILERS=1 porque el módulo legacy canónico valida
+ese opt-in al importarse.
+"""
+# pcobra-compat: allow-legacy-transpiler-shim
+
+from pcobra.cobra.transpilers.transpiler.legacy.to_wasm import TranspiladorWasm
+
+__all__ = ["TranspiladorWasm"]


### PR DESCRIPTION
### Motivation
- Preserve backward compatibility for in-tree importers that still reference legacy `to_*` modules while keeping the public backend contract limited to `python`, `javascript` and `rust`.
- Ensure legacy transpilers remain available only behind an explicit opt-in and do not leak into the official public registry or runtime contract.

### Description
- Reintroduced internal-only shim modules `src/pcobra/cobra/transpilers/transpiler/to_go.py`, `to_cpp.py`, `to_java.py`, `to_wasm.py`, and `to_asm.py` that re-export the guarded legacy implementations under `pcobra.cobra.transpilers.transpiler.legacy.*` and preserve the requirement of `PCOBRA_ENABLE_LEGACY_TRANSPILERS=1` for import-time opt-in.
- Restored minimal legacy entries in `STANDARD_IMPORTS` and `RUNTIME_HOOKS` inside `src/pcobra/cobra/transpilers/common/utils.py` so opt-in legacy transpilers can run without breaking tests while keeping those entries out of the active/public runtime backend set.
- Updated `scripts/ci/validate_targets.py` to recognize a controlled set of legacy shim files via a new `COMPAT_LEGACY_TRANSPILER_SHIMS` and to accept those exact shim paths while continuing to fail on any uncontrolled `to_*.py` extras.
- Kept the public contract unchanged by treating these modules as internal compatibility artifacts (opt-in only) rather than adding them to the official transpiler registry.

### Testing
- Ran `PYTHONPATH=src PCOBRA_ENABLE_LEGACY_TRANSPILERS=1 pytest -q tests/unit/test_to_go.py tests/integration/test_usar_legacy_compatibility.py` and observed all tests pass (`5 passed`).
- Executed `PYTHONPATH=src python scripts/ci/validate_targets.py` and received the CI validator OK message indicating target inventory alignment.
- Verified the opt-in guard by attempting to import a legacy shim without `PCOBRA_ENABLE_LEGACY_TRANSPILERS=1` and confirmed the expected runtime guard error mentioning `PCOBRA_ENABLE_LEGACY_TRANSPILERS`.
- Ran the integration legacy-compatibility test `PYTHONPATH=src pytest -q tests/integration/test_usar_legacy_compatibility.py` which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d6e8f45f08327bf0ae9ed12c3d02a)