### PR TITLE
Restore language-equivalence contract metadata

### DIFF
--- a/data/language_equivalence.yml
+++ b/data/language_equivalence.yml
@@ -1,67 +1,256 @@
 version: 1.0.0
+source_of_truth: src/pcobra/cobra/transpilers/compatibility_matrix.py
 backends:
 - python
 - javascript
 - rust
 features:
 - id: decoradores
+  cobra_syntax: "@traza\ndef saludar(nombre):\n    retornar f\"Hola {nombre}\"\n"
+  python_equivalent: "@traza\ndef saludar(nombre):\n    return f\"Hola {nombre}\"\n"
+  status_source:
+    matrix: AST_FEATURE_MINIMUM_CONTRACT
+    key: decoradores
   backend_equivalents:
     javascript:
+      equivalent: '@traza
+
+        function saludar(nombre) { return `Hola ${nombre}`; }
+
+        '
       status: full
+      limitations: []
+      expected_markers:
+      - const cobraJsCorelibs = Object.freeze({
+      - const mostrar = (...args) => cobraJsStandardLibrary.mostrar(...args);
     rust:
+      equivalent: 'fn saludar(nombre: &str) -> String { format!("Hola {}", nombre)
+        }
+
+        // decorador aplicado: saludar = traza(saludar)
+
+        '
       status: full
-
-
-
-
-
+      acceptance_criteria:
+      - Emite marcador de decorador y comentario de aplicación en codegen.
+      - La evidencia mínima queda fijada en `tests/integration/transpilers/golden_phase1/rust.decoradores.golden`.
+      limitations: []
+      expected_markers:
+      - // @decorador traza
+      - '// decorador aplicado: saludar = traza(saludar)'
+  decorator_support:
+    memoizar:
+      python: full
+      javascript: full
+      rust: full
+    orden_total:
+      python: full
+      javascript: full
+      rust: full
+    despachar_por_tipo:
+      python: full
+      javascript: full
+      rust: full
+    depreciado:
+      python: full
+      javascript: full
+      rust: full
+    sincronizar:
+      python: full
+      javascript: full
+      rust: full
+    reintentar:
+      python: full
+      javascript: full
+      rust: full
+    reintentar_async:
+      python: full
+      javascript: full
+      rust: full
+    dataclase:
+      python: full
+      javascript: full
+      rust: full
+    temporizar:
+      python: full
+      javascript: full
+      rust: full
+  python_expected_markers:
+  - from corelibs import *
+  - from standard_library import *
 - id: imports_corelibs
+  cobra_syntax: 'usar corelibs
+
+    usar standard_library
+
+    mostrar(longitud([1,2,3]))
+
+    '
+  python_equivalent: 'from corelibs import *
+
+    from standard_library import *
+
+    print(longitud([1, 2, 3]))
+
+    '
+  status_source:
+    matrix: BACKEND_COMPATIBILITY
+    key: corelibs
   backend_equivalents:
     javascript:
+      equivalent: 'import { longitud } from "cobraJsCorelibs";
+
+        import { mostrar } from "cobraJsStandardLibrary";
+
+        '
       status: partial
+      limitations:
+      - Cobertura parcial vía adaptadores del proyecto.
+      expected_markers:
+      - import * as io from
+      - longitud(3);
     rust:
+      equivalent: 'use crate::corelibs::*;
+
+        use crate::standard_library::*;
+
+        '
       status: full
-
-
-
-
-
+      acceptance_criteria:
+      - Incluye imports de `corelibs` y `standard_library` para ruta mínima contractual.
+      - La evidencia mínima queda fijada en `tests/integration/transpilers/golden_phase1/rust.imports_corelibs.golden`.
+      limitations: []
+      expected_markers:
+      - use crate::corelibs::*;
+      - use crate::standard_library::*;
+  python_expected_markers:
+  - from corelibs import *
+  - from standard_library import *
+  - longitud(3)
 - id: manejo_errores
+  cobra_syntax: "intentar:\n    transformar(h, \"operacion_no_soportada\")\ncapturar\
+    \ error:\n    mostrar(error)\n"
+  python_equivalent: "try:\n    transformar(h, \"operacion_no_soportada\")\nexcept\
+    \ Exception as error:\n    print(error)\n"
+  status_source:
+    matrix: BACKEND_COMPATIBILITY
+    key: holobit
   backend_equivalents:
     javascript:
+      equivalent: 'try { cobra_transformar(h, "x"); } catch (err) { console.error(err);
+        }
+
+        '
       status: partial
+      limitations:
+      - Errores contractuales explícitos, semántica avanzada no cubierta.
+      expected_markers:
+      - try {
+      - catch (error)
     rust:
+      equivalent: "match cobra_transformar(&h, \"x\", &args) {\n    Ok(v) => v,\n\
+        \    Err(err) => eprintln!(\"{}\", err),\n}\n"
       status: partial
-
-
-
-
-
+      limitations:
+      - Basado en `Result`, no en excepciones.
+      expected_markers:
+      - match resultado {
+      - Err(e) => {
+  python_expected_markers:
+  - 'try:'
+  - 'except Exception as error:'
 - id: async
+  cobra_syntax: "async def obtener_datos():\n    retornar esperar cliente.fetch()\n"
+  python_equivalent: "async def obtener_datos():\n    return await client.fetch()\n"
+  status_source:
+    matrix: AST_FEATURE_MINIMUM_CONTRACT
+    key: async
   backend_equivalents:
     javascript:
+      equivalent: 'async function obtenerDatos() { return await client.fetch(); }
+
+        '
       status: full
+      limitations: []
+      expected_markers:
+      - async function obtener_datos()
+      - return await fetch();
     rust:
+      equivalent: 'async fn obtener_datos() { return fetch().await; }
+
+        '
       status: full
-
-
-
-
-
+      acceptance_criteria:
+      - Emite `async fn` y `.await` para la ruta mínima contractual.
+      - La evidencia mínima queda fijada en `tests/integration/transpilers/golden_phase1/rust.async.golden`.
+      limitations: []
+      expected_markers:
+      - async fn obtener_datos() {
+      - return fetch().await;
+  python_expected_markers:
+  - 'async def obtener_datos():'
+  - return await fetch()
 - id: tipos_compuestos
+  cobra_syntax: 'datos = {"nombres": ["Ana", "Luis"], "meta": {"activo": verdadero}}
+
+    '
+  python_equivalent: 'datos = {"nombres": ["Ana", "Luis"], "meta": {"activo": True}}
+
+    '
+  status_source:
+    matrix: AST_FEATURE_MINIMUM_CONTRACT
+    key: colecciones
   backend_equivalents:
     javascript:
+      equivalent: 'const datos = { nombres: ["Ana", "Luis"], meta: { activo: true
+        } };
+
+        '
       status: full
+      limitations: []
     rust:
+      equivalent: '// Vec<HashMap<String, Value>> / structs según estrategia del backend.
+
+        '
       status: partial
-
-
-
-
-
+      limitations:
+      - Conversión dinámica limitada frente a Python.
 - id: hooks_runtime
+  cobra_syntax: 'h = holobit("abc")
+
+    proyectar(h, "2d")
+
+    transformar(h, "escalar", 2)
+
+    graficar(h)
+
+    '
+  python_equivalent: 'h = cobra_holobit("abc")
+
+    cobra_proyectar(h, "2d")
+
+    cobra_transformar(h, "escalar", 2)
+
+    cobra_graficar(h)
+
+    '
+  status_source:
+    matrix: BACKEND_HOLOBIT_SDK_CAPABILITIES
+    key: import_hooks
   backend_equivalents:
     javascript:
+      equivalent: 'const h = cobra_holobit("abc");
+
+        cobra_proyectar(h, "2d");
+
+        '
       status: full
+      limitations: []
     rust:
+      equivalent: 'let h = cobra_holobit("abc");
+
+        let _ = cobra_proyectar(&h, "2d");
+
+        '
       status: full
+      limitations: []


### PR DESCRIPTION
### Motivation
- The CI validator `scripts/ci/validate_language_equivalence_matrix.py` started failing because per-feature contract metadata (`status_source`, `cobra_syntax`, `python_equivalent`, etc.) was removed when pruning legacy backend entries.  
- The language-equivalence contract must retain the canonical metadata so the validator can compare the YAML against the executable matrices and run the contract test suite.  
- Restore the minimal, official-surface metadata while keeping the public backend list limited to `python`, `javascript`, and `rust` so public policy changes remain intact.

### Description
- Rebuilt `data/language_equivalence.yml` entries to re-add `source_of_truth`, per-feature `cobra_syntax` and `python_equivalent`, and `status_source` (matrix/key) metadata for all features.  
- Restored backend-evidence fields scoped to official targets only (`javascript` and `rust` in `backend_equivalents`) including `equivalent`, `status`, `limitations`, `expected_markers`, and `acceptance_criteria`, and pruned legacy backend sections from the public contract.  
- Kept `backends` set to the three public targets (`python`, `javascript`, `rust`) so public-facing policies remain aligned with the transpiler-surface changes.  
- Limited decorator support and python_expected_markers to the remaining official targets and preserved contract wiring so the validator can reconcile YAML with `pcobra.cobra.transpilers.compatibility_matrix`.

### Testing
- Ran `python scripts/ci/validate_targets.py` and it passed confirming `OFFICIAL_TARGETS` remains `python, javascript, rust`.  
- Ran `python scripts/ci/validate_language_equivalence_matrix.py`; the script now passes the missing-metadata checks but the embedded executable contract test suite failed with 5 failures (21 passed, 1 warning), all related to Python transpiler output/snapshot mismatches and syntax/marker expectations for features like `decoradores`, `imports_corelibs` and `manejo_errores`.  
- Ran formatting/integrity checks with `git diff --check` which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d731dd73c8327819c8328e39bfe61)