### PR TITLE
Fix app GUI smoke fake for suggestion button state kwargs

### DIFF
--- a/tests/unit/test_gui_app.py
+++ b/tests/unit/test_gui_app.py
@@ -30,9 +30,11 @@ def _fake_flet():
             self.disabled = kwargs.get("disabled", False)
 
     class ElevatedButton:
-        def __init__(self, text, on_click=None):
+        def __init__(self, text, on_click=None, **kwargs):
             self.text = text
             self.on_click = on_click
+            self.disabled = kwargs.get("disabled", False)
+            self.tooltip = kwargs.get("tooltip")
 
     class TextButton(ElevatedButton):
         pass


### PR DESCRIPTION
### Motivation
- The centralized suggestion button factory now passes `disabled` and `tooltip` kwargs to `ElevatedButton`, which caused the `pcobra.gui.app` smoke tests to raise a `TypeError` because the test Flet fake did not accept these new kwargs.

### Description
- Update the test Flet fake in `tests/unit/test_gui_app.py` so `ElevatedButton.__init__` accepts `**kwargs` and stores `disabled` and `tooltip` from the provided kwargs.

### Testing
- Ran `python -m pytest -q tests/unit/test_gui_runtime.py tests/unit/test_gui_idle.py tests/unit/test_gui_app.py` and `python -m ruff check tests/unit/test_gui_app.py`, and the tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e1c9642708327944fb2c519de97bf)