### PR TITLE
Allowlist public backend exposure auditor

### DIFF
--- a/scripts/ci/validate_targets.py
+++ b/scripts/ci/validate_targets.py
@@ -101,6 +101,7 @@ REPO_AUDIT_ALLOWED_FILE_PATHS = frozenset(
         "scripts/validate_targets_policy.py",
         "scripts/ci/validate_targets.py",
         "scripts/ci/audit_targets_contract.py",
+        "scripts/ci/audit_public_backend_exposure_terms.py",
         "scripts/audit_retired_targets.py",
         "scripts/ci/validate_workflow_target_matrix.py",
         "tests/unit/test_cli_target_aliases.py",


### PR DESCRIPTION
### Motivation
- The new auditor `scripts/ci/audit_public_backend_exposure_terms.py` intentionally contains literal legacy alias strings which the general target validator flags, so the auditor must be allowlisted to avoid CI failures while keeping the validator strict for the rest of the repo.  

### Description
- Added `scripts/ci/audit_public_backend_exposure_terms.py` to `REPO_AUDIT_ALLOWED_FILE_PATHS` in `scripts/ci/validate_targets.py` so the validator ignores the auditor's intentional legacy alias literals.  

### Testing
- Ran `python scripts/ci/validate_targets.py` and it completed with OK; ran `python scripts/ci/audit_public_backend_exposure_terms.py` and it reported OK; ran `python -m pytest tests/unit/test_ci_audit_public_backend_exposure_terms.py` and the unit tests passed (2 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e27c0959483279b0c0e53ec51ed31)