### PR TITLE
Preserve official `usar` imports in project modules (skip allowlist precheck)

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -573,16 +573,17 @@ def _cargar_exports_modulo_cobra_proyecto(
                 continue
             if isinstance(subnodo, NodoUsar) or subnodo.__class__.__name__ == "NodoUsar":
                 modulo_hijo = str(subnodo.modulo).strip().strip('\"\'')
-                ruta_hijo = resolver_ruta_canonica_modulo_cobra_proyecto(
-                    modulo_hijo,
-                    project_root=project_root,
-                    current_file=ruta_modulo,
-                )
-                if ruta_hijo in _USAR_PROJECT_LOADING_STACK:
-                    cadena = formatear_ciclo_modulos_cobra_proyecto(
-                        ruta_hijo, project_root=project_root
+                if normalizar_nombre_usar(modulo_hijo) not in USAR_COBRA_PUBLIC_MODULES:
+                    ruta_hijo = resolver_ruta_canonica_modulo_cobra_proyecto(
+                        modulo_hijo,
+                        project_root=project_root,
+                        current_file=ruta_modulo,
                     )
-                    raise ImportError(f"Ciclo de módulos detectado en usar: {cadena}")
+                    if ruta_hijo in _USAR_PROJECT_LOADING_STACK:
+                        cadena = formatear_ciclo_modulos_cobra_proyecto(
+                            ruta_hijo, project_root=project_root
+                        )
+                        raise ImportError(f"Ciclo de módulos detectado en usar: {cadena}")
             interpretador.ejecutar_nodo(subnodo)
         exports = _extraer_exports_modulo_cobra_proyecto(
             ast,

--- a/tests/integration/test_usar_project_modules.py
+++ b/tests/integration/test_usar_project_modules.py
@@ -125,6 +125,20 @@ def test_usar_carga_una_sola_vez_con_cache_y_monkeypatch(crear_modulo_cobra, mon
     assert llamadas.count("util.co") == 1
 
 
+def test_usar_modulo_proyecto_preserva_usar_oficial_texto(crear_modulo_cobra):
+    crear_modulo_cobra(
+        "util.co",
+        """
+        usar texto
+        variable saludo_mayusculas := mayusculas("hola")
+        """,
+    )
+    main = crear_modulo_cobra("main.co", "usar util")
+
+    interprete = ejecutar_archivo(main)
+
+    assert interprete.obtener_variable("saludo_mayusculas") == "HOLA"
+
 def test_usar_detecta_ciclo_directo(crear_modulo_cobra):
     crear_modulo_cobra("a.co", """
         usar a


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where project-module prechecks resolved allowlisted official modules (e.g. `texto`) as project `.co` files, causing `FileNotFoundError` when the project did not shadow the official module. 
- Ensure official Cobra modules continue to be resolved via the canonical/official path and not as project files during cycle detection. 
- Add a regression to prevent reintroducing the failure and to verify normal official-module usage inside project modules.

### Description
- Update `_cargar_exports_modulo_cobra_proyecto` to skip canonical resolution for child `NodoUsar` entries whose normalized name is in `USAR_COBRA_PUBLIC_MODULES`, by checking `normalizar_nombre_usar(modulo_hijo) not in USAR_COBRA_PUBLIC_MODULES` before resolving `ruta_hijo` and detecting cycles. 
- Preserve the existing cycle-detection behavior for non-official (project) modules so project cycles are still detected. 
- Add integration test `test_usar_modulo_proyecto_preserva_usar_oficial_texto` in `tests/integration/test_usar_project_modules.py` that asserts a project module can execute `usar texto` and call `mayusculas` without requiring a local `texto.co` shadow file.

### Testing
- Ran `pytest -q tests/integration/test_usar_project_modules.py` and the suite passed (`15 passed, 1 warning`). 
- Ran `pytest -q tests/unit/test_usar_loader_validation.py` and the suite passed (`34 passed, 1 warning`). 
- The added integration regression demonstrates that official `usar` imports inside project modules continue to resolve to the official module path rather than a missing project file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e443519088327932b9a7ba394d656)