### PR TITLE
Fix UTF-8 fixture reads in agix test

### DIFF
--- a/tests/unit/test_analizador_agix.py
+++ b/tests/unit/test_analizador_agix.py
@@ -182,10 +182,10 @@ def test_sugerencia_principal_referencia_regla_interna_trazable():
 def test_motor_canonico_es_agix_y_no_agi_core():
     """El contrato público mantiene agix como dependencia oficial y fachada GUI."""
 
-    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
     dependencias = pyproject["project"]["dependencies"]
-    requirements_docs = Path("docs/requirements.txt").read_text()
-    libro = Path("docs/LIBRO_PROGRAMACION_COBRA.md").read_text()
+    requirements_docs = Path("docs/requirements.txt").read_text(encoding="utf-8")
+    libro = Path("docs/LIBRO_PROGRAMACION_COBRA.md").read_text(encoding="utf-8")
 
     assert any(dep.startswith("agix") for dep in dependencias)
     assert not any(dep.startswith("agi-core") for dep in dependencias)


### PR DESCRIPTION
### Motivation
- Prevent `UnicodeDecodeError` on Windows CI by ensuring repository text fixtures are decoded as UTF-8 instead of relying on the locale-default `Path.read_text()`.

### Description
- Update `tests/unit/test_analizador_agix.py` to call `Path.read_text(encoding="utf-8")` when reading `pyproject.toml`, `docs/requirements.txt`, and `docs/LIBRO_PROGRAMACION_COBRA.md`.

### Testing
- Ran `pytest -q tests/unit/test_analizador_agix.py`, which completed with `15 passed, 1 warning`.
- Ran `ruff check tests/unit/test_analizador_agix.py`, which returned `All checks passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e5435590483278bdcfbec822d904e)