### PR TITLE
Corrige creación de proyectos IDLE con symlinks

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -190,7 +190,16 @@ def main(page: "ft.Page"):
         nonlocal project_root
         try:
             nombre = nombre_proyecto_seguro(raiz_input.value or "")
-            nuevo_proyecto = (workspace_root / nombre).resolve()
+            workspace_canonico = workspace_root.resolve()
+            ruta_proyecto = workspace_root / nombre
+            nuevo_proyecto = ruta_proyecto.resolve()
+            if ruta_proyecto.is_symlink() or (
+                nuevo_proyecto != workspace_canonico
+                and workspace_canonico not in nuevo_proyecto.parents
+            ):
+                raise ValueError(
+                    f"El proyecto debe crearse dentro de: {workspace_canonico}"
+                )
             nuevo_proyecto.mkdir(parents=True, exist_ok=True)
             (nuevo_proyecto / "src").mkdir(exist_ok=True)
             readme = nuevo_proyecto / "README.md"

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -6,6 +6,8 @@ import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from pcobra.gui import idle
 
 
@@ -1198,3 +1200,41 @@ def test_crear_proyecto_normaliza_nombre_seguro(monkeypatch, tmp_path):
     assert (proyecto / "src").is_dir()
     assert (proyecto / "README.md").is_file()
     assert salida.value == f"Proyecto creado: {proyecto}"
+
+
+def test_crear_proyecto_rechaza_nombre_symlink_fuera_workspace(monkeypatch, tmp_path):
+    (
+        ft,
+        page,
+        _entrada,
+        _ruta_input,
+        salida,
+        _abrir,
+        _guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    externo = tmp_path.parent / f"{tmp_path.name}_externo"
+    externo.mkdir()
+    symlink = tmp_path / "proyecto_symlink"
+    try:
+        symlink.symlink_to(externo, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"No se pueden crear symlinks en este entorno: {exc}")
+
+    proyecto_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
+    )
+    crear_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Crear proyecto"
+    )
+
+    proyecto_input.value = "proyecto_symlink"
+    crear_proyecto.on_click(None)
+
+    assert not (externo / "src").exists()
+    assert not (externo / "README.md").exists()
+    assert salida.value.startswith("error: ")
+    assert "debe crearse dentro" in salida.value


### PR DESCRIPTION
### Motivation
- A bug allowed creating a project name that is a symlink inside `workspace_root` to cause `resolve()` to follow the symlink and write `src/` and `README.md` outside the workspace. 
- The change enforces that new projects are created only inside the canonical workspace and rejects symlinked project names to preserve the workspace containment invariant.

### Description
- Added a containment and symlink check in `crear_proyecto_handler` in `src/pcobra/gui/idle.py` that computes `ruta_proyecto = workspace_root / nombre`, calls `ruta_proyecto.resolve()`, rejects the request if `ruta_proyecto.is_symlink()` or the resolved path is outside `workspace_root.resolve()`, and raises `ValueError` instead of writing outside the workspace. 
- The check uses the canonical `workspace_root.resolve()` for containment verification. 
- Added a regression test `test_crear_proyecto_rechaza_nombre_symlink_fuera_workspace` to `tests/unit/test_gui_idle.py` that creates a symlink pointing outside the workspace and asserts no `src/` or `README.md` are written and an error is reported. 
- Added `import pytest` to the test file to support skipping when symlink creation is not available in the environment.

### Testing
- Ran `pytest tests/unit/test_gui_idle.py -q` and the tests passed. 
- Ran `pytest tests/gui/test_runtime_file_helpers.py tests/unit/test_gui_idle.py -q` and the combined run completed successfully with `34 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e56821a708327b71c33174f557b94)