### PR TITLE
Fix IDLE project field flex layout

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -26,7 +26,7 @@ def main(page: "ft.Page"):
     # como helper FilePicker para integraciones alternativas de Flet.
     ruta_input = runtime.flet_text_field(ft, label="Ruta", value="", expand=True)
     raiz_input = runtime.flet_text_field(
-        ft, label="Proyecto activo", value=str(project_root), expand=True
+        ft, label="Proyecto activo", value=str(project_root)
     )
     arbol = runtime.flet_list_view(ft, expand=True, spacing=2, auto_scroll=False)
     lenguajes = list(runtime.gui_target_choices())

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -222,7 +222,7 @@ def test_panel_lateral_organiza_proyecto_en_columna(monkeypatch, tmp_path):
     raiz_input = barra_raiz_arbol.controls[0]
     assert isinstance(raiz_input, ft.TextField)
     assert raiz_input.kwargs.get("label") == "Proyecto activo"
-    assert raiz_input.kwargs.get("expand") is True
+    assert raiz_input.kwargs.get("expand") is not True
 
     barra_botones = barra_raiz_arbol.controls[1]
     assert isinstance(barra_botones, (ft.Row, ft.Column))


### PR DESCRIPTION
### Motivation

- Evitar que el `TextField` del campo "Proyecto activo" intente expandirse verticalmente dentro de una `Column` anidada en la barra lateral, lo que puede causar fallos de layout en Flet/Flutter.

### Description

- Se elimina `expand=True` del `raiz_input` en `src/pcobra/gui/idle.py` para que el campo `Proyecto activo` no crezca verticalmente dentro del `panel_lateral`.

### Testing

- Ejecutado `pytest tests/unit/test_gui_idle.py -q` y la suite pasó con `24 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e586b40108327bf91aed4f43e25d5)