### PR TITLE
Block deleting dirty IDLE buffers

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -366,6 +366,13 @@ def main(page: "ft.Page"):
         ruta_resuelta = resolver_ruta_archivo_idle(estado.ruta)
         if ruta_resuelta is None:
             return
+        if estado.cambios_sin_guardar:
+            salida.value = (
+                "Guarda o descarta los cambios sin guardar antes de eliminar "
+                f"el archivo: {ruta_resuelta}"
+            )
+            page.update()
+            return
         try:
             runtime.eliminar_archivo_validado(ruta_resuelta)
         except (

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -1503,3 +1503,54 @@ def test_eliminar_archivo_activo_reinicia_editor_y_estado_visual(monkeypatch, tm
     assert ruta_input.value == ""
     assert salida.value == f"Archivo eliminado: {destino}"
     assert estado_archivo.value == "Archivo nuevo (sin guardar)"
+
+
+def test_eliminar_archivo_activo_bloquea_cambios_sin_guardar(monkeypatch, tmp_path):
+    (
+        ft,
+        page,
+        entrada,
+        ruta_input,
+        salida,
+        _abrir,
+        guardar_como,
+    ) = _preparar_idle_archivos(monkeypatch, tmp_path)
+    proyecto_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Proyecto activo"
+    )
+    crear_proyecto = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Crear proyecto"
+    )
+    eliminar = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Eliminar"
+    )
+
+    proyecto_input.value = "proyecto"
+    crear_proyecto.on_click(None)
+    destino = (
+        idle.runtime.resolver_workspace_root_idle()
+        / "proyecto"
+        / "src"
+        / "con-cambios.cobra"
+    ).resolve()
+    entrada.value = "imprimir('original')"
+    ruta_input.value = "src/con-cambios"
+    guardar_como.on_click(None)
+
+    entrada.value = "imprimir('editado')"
+    entrada.on_change(None)
+    eliminar.on_click(None)
+
+    assert destino.exists()
+    assert entrada.value == "imprimir('editado')"
+    assert ruta_input.value == str(destino)
+    assert salida.value == (
+        "Guarda o descarta los cambios sin guardar antes de eliminar "
+        f"el archivo: {destino}"
+    )


### PR DESCRIPTION
### Motivation
- Prevent accidental loss of unsaved in-memory edits when the user clicks `Eliminar` on the active file in the IDLE UI by stopping deletion when the editor buffer is dirty.

### Description
- Add a guard in `eliminar_archivo_handler` (`src/pcobra/gui/idle.py`) that checks `estado.cambios_sin_guardar`, sets `salida.value` to a warning and returns without unlinking when true.
- Keep the existing deletion flow intact when no unsaved changes exist, preserving the previous reset of `estado` and UI fields after successful deletion.
- Add a regression test `test_eliminar_archivo_activo_bloquea_cambios_sin_guardar` in `tests/unit/test_gui_idle.py` that verifies a dirty buffer blocks deletion and preserves the edited buffer, file on disk, route field, and warning message.

### Testing
- Compiled the updated modules with `python -m py_compile src/pcobra/gui/idle.py tests/unit/test_gui_idle.py` and compilation succeeded.
- Ran the focused pytest commands `pytest -q tests/unit/test_gui_idle.py::test_eliminar_archivo_activo_reinicia_editor_y_estado_visual tests/unit/test_gui_idle.py::test_eliminar_archivo_activo_bloquea_cambios_sin_guardar` and both tests passed.
- Ran `git diff --check` and no formatting issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e5a09526c8327bff33705b08f1981)