### PR TITLE
Fix language equivalence contract metadata review findings

### DIFF
--- a/data/language_equivalence.yml
+++ b/data/language_equivalence.yml
@@ -39,45 +39,45 @@ features:
       - // @decorador traza
       - '// decorador aplicado: saludar = traza(saludar)'
   decorator_support:
-    memoizar:
-      python: full
-      javascript: full
-      rust: full
-    orden_total:
-      python: full
-      javascript: full
-      rust: full
-    despachar_por_tipo:
-      python: full
-      javascript: full
-      rust: full
-    depreciado:
-      python: full
-      javascript: full
-      rust: full
-    sincronizar:
-      python: full
-      javascript: full
-      rust: full
-    reintentar:
-      python: full
-      javascript: full
-      rust: full
-    reintentar_async:
-      python: full
-      javascript: full
-      rust: full
-    dataclase:
-      python: full
-      javascript: full
-      rust: full
-    temporizar:
-      python: full
-      javascript: full
-      rust: full
+      memoizar:
+        python: full
+        javascript: full
+        rust: full
+      orden_total:
+        python: full
+        javascript: full
+        rust: full
+      despachar_por_tipo:
+        python: full
+        javascript: full
+        rust: full
+      depreciado:
+        python: full
+        javascript: full
+        rust: full
+      sincronizar:
+        python: full
+        javascript: full
+        rust: full
+      reintentar:
+        python: full
+        javascript: full
+        rust: full
+      reintentar_async:
+        python: full
+        javascript: full
+        rust: full
+      dataclase:
+        python: full
+        javascript: full
+        rust: full
+      temporizar:
+        python: full
+        javascript: full
+        rust: full
   python_expected_markers:
-  - from corelibs import *
-  - from standard_library import *
+  - import pcobra.corelibs as _pcobra_corelibs
+  - import pcobra.standard_library as _pcobra_standard_library
 - id: imports_corelibs
   cobra_syntax: 'usar corelibs
 
@@ -124,8 +124,8 @@ features:
       - use crate::corelibs::*;
       - use crate::standard_library::*;
   python_expected_markers:
-  - from corelibs import *
-  - from standard_library import *
+  - import pcobra.corelibs as _pcobra_corelibs
+  - import pcobra.standard_library as _pcobra_standard_library
   - longitud(3)
 - id: manejo_errores
   cobra_syntax: "intentar:\n    transformar(h, \"operacion_no_soportada\")\ncapturar\


### PR DESCRIPTION
### Motivation
- Repair contract metadata so the language-equivalence contract tests can locate decorator support and Python marker strings that the transpilers actually emit. 
- Address three high-priority issues: incorrect indentation for `decorator_support`, and Python marker strings that referred to legacy `from corelibs import *`/`from standard_library import *` instead of the current generated `pcobra.*` alias imports. 

### Description
- Rewrote the `decorator_support` block in `data/language_equivalence.yml` to restore the expected indentation level so tests that search the raw YAML find six-space decorator entries and eight-space backend status lines. 
- Replaced Python expected markers for `decoradores` with the runtime alias imports actually emitted by the Python transpiler: `import pcobra.corelibs as _pcobra_corelibs` and `import pcobra.standard_library as _pcobra_standard_library`. 
- Updated the `imports_corelibs` `python_expected_markers` similarly while preserving the executable marker `longitud(3)`.
- All edits were confined to `data/language_equivalence.yml` and preserve the public `backends`/contract wiring used by the validator. 

### Testing
- Parsed the modified YAML with `yaml.safe_load` and verified the `decorator_support` mapping contains the expected decorator entries. 
- Ran `python -m pytest tests/integration/transpilers/test_decoradores_contract.py -q` and it passed (`64 passed, 1 warning`). 
- Ran `python -m pytest tests/integration/transpilers/test_language_equivalence_contract.py::test_language_equivalence_contract_minimum_markers -q` and it passed (relevant markers checks: `12 passed, 1 warning`). 
- Ran the broader contract suite `python -m pytest tests/integration/transpilers/test_decoradores_contract.py tests/integration/transpilers/test_language_equivalence_contract.py -q` and observed remaining unrelated Python syntax/snapshot failures (5 failures) that are outside the three metadata issues fixed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e6db6ea0c8327b7a5d9d902357ff2)