### PR TITLE
Centraliza detección de tipos y capacidades de archivos en la GUI

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -81,8 +81,64 @@ def _local_import_action(module_name: str, symbol_name: str) -> str:
     )
 
 
+TIPO_ARCHIVO_COBRA = "cobra"
+TIPO_ARCHIVO_MARKDOWN = "markdown"
+TIPO_ARCHIVO_TEXTO = "texto"
+TIPO_ARCHIVO_CONFIG = "config"
+TIPO_ARCHIVO_DOCKER = "docker"
+TIPO_ARCHIVO_IGNORE = "ignore"
+TIPO_ARCHIVO_ENV_EXAMPLE = "env_example"
+TIPO_ARCHIVO_DESCONOCIDO = "desconocido"
+
+ACCION_EDITAR = "editar"
+ACCION_GUARDAR = "guardar"
+ACCION_RECARGAR = "recargar"
+ACCION_BORRAR = "borrar"
+ACCION_EJECUTAR = "ejecutar"
+ACCION_TOKENS = "tokens"
+ACCION_AST = "ast"
+ACCION_SUGERENCIAS = "sugerencias"
+ACCION_CORRECCION = "correccion"
+
+ACCIONES_ARCHIVO_BASE: frozenset[str] = frozenset(
+    {ACCION_EDITAR, ACCION_GUARDAR, ACCION_RECARGAR, ACCION_BORRAR}
+)
+"""Acciones comunes para archivos manipulables desde la GUI."""
+
+ACCIONES_ARCHIVO_COBRA: frozenset[str] = ACCIONES_ARCHIVO_BASE | frozenset(
+    {
+        ACCION_EJECUTAR,
+        ACCION_TOKENS,
+        ACCION_AST,
+        ACCION_SUGERENCIAS,
+        ACCION_CORRECCION,
+    }
+)
+"""Acciones disponibles para archivos Cobra."""
+
 COBRA_FILE_EXTENSIONS: tuple[str, ...] = (".cobra", ".co")
 """Extensiones Cobra aceptadas y priorizadas para el explorador del IDLE."""
+
+MARKDOWN_FILE_EXTENSIONS: frozenset[str] = frozenset({".md", ".markdown"})
+TEXT_FILE_EXTENSIONS: frozenset[str] = frozenset({".txt"})
+CONFIG_FILE_EXTENSIONS: frozenset[str] = frozenset(
+    {".json", ".yml", ".yaml", ".toml"}
+)
+IGNORE_FILE_NAMES: frozenset[str] = frozenset({".gitignore", ".dockerignore"})
+ENV_EXAMPLE_FILE_NAMES: frozenset[str] = frozenset({".env.example"})
+"""Nombres especiales de archivos de entorno de ejemplo."""
+
+CAPACIDADES_POR_TIPO: dict[str, frozenset[str]] = {
+    TIPO_ARCHIVO_COBRA: ACCIONES_ARCHIVO_COBRA,
+    TIPO_ARCHIVO_MARKDOWN: ACCIONES_ARCHIVO_BASE,
+    TIPO_ARCHIVO_TEXTO: ACCIONES_ARCHIVO_BASE,
+    TIPO_ARCHIVO_CONFIG: ACCIONES_ARCHIVO_BASE,
+    TIPO_ARCHIVO_DOCKER: ACCIONES_ARCHIVO_BASE,
+    TIPO_ARCHIVO_IGNORE: ACCIONES_ARCHIVO_BASE,
+    TIPO_ARCHIVO_ENV_EXAMPLE: ACCIONES_ARCHIVO_BASE,
+    TIPO_ARCHIVO_DESCONOCIDO: ACCIONES_ARCHIVO_BASE,
+}
+"""Acciones permitidas por tipo de archivo detectado."""
 
 MOSTRAR_TODOS_LOS_ARCHIVOS_IDLE = False
 """Bandera interna para una futura configuración de visibilidad completa.
@@ -231,10 +287,48 @@ def generar_sugerencias(codigo: str) -> list[str]:
     return _generar(codigo)
 
 
+def detectar_tipo_archivo(path: str | Path) -> str:
+    """Clasifica una ruta según los tipos de archivo conocidos por la GUI."""
+
+    ruta = Path(path)
+    nombre = ruta.name
+    nombre_lower = nombre.lower()
+    extension = ruta.suffix.lower()
+
+    if extension in COBRA_FILE_EXTENSIONS:
+        return TIPO_ARCHIVO_COBRA
+    if extension in MARKDOWN_FILE_EXTENSIONS:
+        return TIPO_ARCHIVO_MARKDOWN
+    if extension in TEXT_FILE_EXTENSIONS:
+        return TIPO_ARCHIVO_TEXTO
+    if extension in CONFIG_FILE_EXTENSIONS:
+        return TIPO_ARCHIVO_CONFIG
+    if nombre == "Dockerfile" or nombre.startswith("Dockerfile."):
+        return TIPO_ARCHIVO_DOCKER
+    if nombre_lower in IGNORE_FILE_NAMES:
+        return TIPO_ARCHIVO_IGNORE
+    if nombre_lower in ENV_EXAMPLE_FILE_NAMES:
+        return TIPO_ARCHIVO_ENV_EXAMPLE
+    return TIPO_ARCHIVO_DESCONOCIDO
+
+
+def obtener_capacidades_archivo(path: str | Path) -> frozenset[str]:
+    """Devuelve las acciones permitidas para el tipo detectado de una ruta."""
+
+    tipo_archivo = detectar_tipo_archivo(path)
+    return CAPACIDADES_POR_TIPO.get(tipo_archivo, ACCIONES_ARCHIVO_BASE)
+
+
+def archivo_permite_accion(path: str | Path, accion: str) -> bool:
+    """Indica si una ruta permite ejecutar una acción concreta en la GUI."""
+
+    return accion in obtener_capacidades_archivo(path)
+
+
 def es_archivo_cobra(path: str | Path) -> bool:
     """Indica si una ruta parece contener código Cobra editable."""
 
-    return Path(path).suffix.lower() in COBRA_FILE_EXTENSIONS
+    return detectar_tipo_archivo(path) == TIPO_ARCHIVO_COBRA
 
 
 def resolver_ruta_archivo_en_project_root(

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -100,6 +100,63 @@ def test_es_archivo_cobra_reconoce_extensiones_seguras_documentadas() -> None:
     assert not runtime.es_archivo_cobra("notas.txt")
 
 
+def test_detectar_tipo_archivo_clasifica_extensiones_y_nombres_conocidos() -> None:
+    casos = {
+        "programa.cobra": runtime.TIPO_ARCHIVO_COBRA,
+        "programa.co": runtime.TIPO_ARCHIVO_COBRA,
+        "README.md": runtime.TIPO_ARCHIVO_MARKDOWN,
+        "manual.markdown": runtime.TIPO_ARCHIVO_MARKDOWN,
+        "notas.txt": runtime.TIPO_ARCHIVO_TEXTO,
+        "package.json": runtime.TIPO_ARCHIVO_CONFIG,
+        "compose.yml": runtime.TIPO_ARCHIVO_CONFIG,
+        "compose.yaml": runtime.TIPO_ARCHIVO_CONFIG,
+        "pyproject.toml": runtime.TIPO_ARCHIVO_CONFIG,
+        "Dockerfile": runtime.TIPO_ARCHIVO_DOCKER,
+        "Dockerfile.dev": runtime.TIPO_ARCHIVO_DOCKER,
+        ".gitignore": runtime.TIPO_ARCHIVO_IGNORE,
+        ".dockerignore": runtime.TIPO_ARCHIVO_IGNORE,
+        ".env.example": runtime.TIPO_ARCHIVO_ENV_EXAMPLE,
+        "imagen.png": runtime.TIPO_ARCHIVO_DESCONOCIDO,
+    }
+
+    for ruta, tipo_esperado in casos.items():
+        assert runtime.detectar_tipo_archivo(ruta) == tipo_esperado
+
+
+def test_capacidades_archivo_reservan_acciones_cobra_para_codigo_cobra() -> None:
+    acciones_cobra = {
+        runtime.ACCION_EJECUTAR,
+        runtime.ACCION_TOKENS,
+        runtime.ACCION_AST,
+        runtime.ACCION_SUGERENCIAS,
+        runtime.ACCION_CORRECCION,
+    }
+    acciones_base = {
+        runtime.ACCION_EDITAR,
+        runtime.ACCION_GUARDAR,
+        runtime.ACCION_RECARGAR,
+        runtime.ACCION_BORRAR,
+    }
+
+    assert acciones_cobra <= runtime.obtener_capacidades_archivo("programa.cobra")
+    assert acciones_base <= runtime.obtener_capacidades_archivo("programa.cobra")
+
+    for ruta in [
+        "README.md",
+        "notas.txt",
+        "package.json",
+        "Dockerfile",
+        ".gitignore",
+        ".env.example",
+        "imagen.png",
+    ]:
+        capacidades = runtime.obtener_capacidades_archivo(ruta)
+        assert capacidades == acciones_base
+        assert not any(
+            runtime.archivo_permite_accion(ruta, accion) for accion in acciones_cobra
+        )
+
+
 def test_listar_directorio_cobra_modo_seguro_filtra_archivos_no_cobra(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Evitar lógica duplicada para identificar archivos Cobra y centralizar reglas de clasificación y permisos por tipo para la interfaz GUI.
- Permitir consultas uniformes sobre qué acciones son válidas para un archivo desde la GUI (editar, ejecutar, sugerencias, etc.).

### Description
- Añade constantes de tipo y acción (`TIPO_ARCHIVO_*`, `ACCION_*`), conjuntos de extensiones/nombres conocidos y el mapa `CAPACIDADES_POR_TIPO` en `src/pcobra/gui/runtime.py`.
- Implementa `detectar_tipo_archivo(path: str | Path) -> str`, `obtener_capacidades_archivo(path)` y `archivo_permite_accion(path, accion)` y reimplementa `es_archivo_cobra()` para delegar en la detección centralizada.
- Define que solo el tipo `cobra` permite las acciones Cobra (`ejecutar`, `tokens`, `ast`, `sugerencias`, `correccion`) y que los demás tipos conocidos permiten las acciones base (`editar`, `guardar`, `recargar`, `borrar`).
- Añade extensiones/nombres conocidos para `markdown`, `texto`, `config`, `docker`, `ignore`, `.env.example` y el fallback `desconocido`, y actualiza pruebas en `tests/unit/test_gui_runtime.py` para validar clasificación y capacidades.

### Testing
- Ejecuté `pytest tests/unit/test_gui_runtime.py tests/gui/test_runtime_file_helpers.py` y la ejecución principal pasó con `95 passed, 1 warning`.
- Ejecuté un subconjunto específico con `pytest -s` para las nuevas pruebas de detección y capacidades y pasó con `4 passed, 1 warning`.
- Una repetición completa falló por un `MemoryError` en el entorno durante el cierre de captura de `pytest`, que fue un problema de entorno y no una aserción del código modificado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f8d068b2483278646a8a4d92eabab)