### PR TITLE
Permitir cargar textos clasificados desde el árbol

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -749,11 +749,19 @@ def recargar_archivo_activo(estado: GuiFileState) -> tuple[str, str]:
 def cargar_archivo_desde_arbol(
     ruta: str | Path, estado: GuiFileState
 ) -> tuple[str, str]:
-    """Carga una entrada de árbol si es archivo Cobra y devuelve contenido/mensaje."""
+    """Carga una entrada de árbol si es un archivo de texto clasificado."""
 
-    if not es_archivo_cobra(ruta):
-        raise ValueError("Selecciona un archivo Cobra (.co o .cobra).")
-    return abrir_archivo_desde_ruta(ruta, estado)
+    origen = Path(ruta).expanduser().resolve()
+    if origen.exists() and origen.is_dir():
+        raise NotADirectoryError(
+            "La ruta indicada corresponde a un directorio; "
+            "indica un archivo de texto del proyecto."
+        )
+
+    if detectar_tipo_archivo(origen) not in TIPOS_ARCHIVO_TEXTO_IDLE:
+        raise ValueError("Selecciona un archivo de texto del proyecto.")
+
+    return abrir_archivo_desde_ruta_validada(origen, estado)
 
 
 def require_flet() -> Any:

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -940,16 +940,21 @@ def test_accion_cargar_archivo_desde_arbol_filtra_extensiones(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
-    archivo = tmp_path / "arbol.co"
-    archivo.write_text("imprimir('arbol')", encoding="utf-8")
+    archivo = tmp_path / "notas.txt"
+    archivo.write_text("notas del proyecto", encoding="utf-8")
     estado = runtime.GuiFileState()
 
     contenido, mensaje = runtime.cargar_archivo_desde_arbol(archivo, estado)
 
-    assert contenido == "imprimir('arbol')"
+    assert runtime.detectar_tipo_archivo(archivo) == runtime.TIPO_ARCHIVO_TEXTO
+    assert not runtime.es_archivo_cobra(archivo)
+    assert contenido == "notas del proyecto"
+    assert estado.ruta == archivo.resolve()
+    assert estado.contenido_cargado == "notas del proyecto"
+    assert estado.cambios_sin_guardar is False
     assert mensaje == f"Archivo cargado: {archivo.resolve()}"
-    with pytest.raises(ValueError, match="archivo Cobra"):
-        runtime.cargar_archivo_desde_arbol(tmp_path / "notas.txt", estado)
+    with pytest.raises(ValueError, match="archivo de texto del proyecto"):
+        runtime.cargar_archivo_desde_arbol(tmp_path / "imagen.png", estado)
 
 
 def test_require_flet_error_accionable(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation

- Permitir que el IDLE abra desde el árbol archivos de texto auxiliares (por ejemplo `.txt` o `README.md`) además de archivos Cobra; así el explorador no queda restringido solo a código .co/.cobra.
- Evitar que el runtime duplique la validación de pertenencia a `project_root` que ya realiza `idle.py` con su resolver seguro, manteniendo la responsabilidad de sandbox en el IDLE.
- Leer el contenido con el helper validado sin invocar `Lexer`/`Parser` para casos que no son código Cobra.

### Description

- Modifica `cargar_archivo_desde_arbol` en `src/pcobra/gui/runtime.py` para aceptar cualquier ruta clasificada por `detectar_tipo_archivo()` como parte de `TIPOS_ARCHIVO_TEXTO_IDLE` en lugar de exigir `es_archivo_cobra()`.
- Rechaza explícitamente directorios con un `NotADirectoryError` y rechaza entradas no clasificadas con `ValueError` cuyo texto es ahora "Selecciona un archivo de texto del proyecto.".
- Usa `abrir_archivo_desde_ruta_validada()` (helper validado) para abrir y cargar el archivo, evitando cualquier paso de Lexer/Parser dentro del runtime.
- Actualiza la prueba `tests/unit/test_gui_runtime.py::test_accion_cargar_archivo_desde_arbol_filtra_extensiones` para crear y cargar `notas.txt` y verificar que se clasifica como texto y no como Cobra.

### Testing

- Ejecuté `pytest tests/unit/test_gui_runtime.py::test_accion_cargar_archivo_desde_arbol_filtra_extensiones` y la prueba pasó correctamente.
- Ejecuté `pytest tests/unit/test_gui_runtime.py` y obtuve 3 fallos que parecen no estar relacionados con este cambio (atributo `MOSTRAR_TODOS_LOS_ARCHIVOS_IDLE` ausente, mensaje esperado distinto en el árbol y un mock de Flet sin `Column`).
- Commit creado con mensaje `Permitir cargar textos clasificados desde el árbol` y los archivos modificados fueron `src/pcobra/gui/runtime.py` y `tests/unit/test_gui_runtime.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f8f9840788327a74f7db66c85e6fa)