### PR TITLE
Bloquea acciones Cobra para archivos no Cobra en IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -700,19 +700,54 @@ def main(page: "ft.Page"):
         salida.value = f"Carpeta eliminada: {ruta_resuelta}"
         actualizar_pagina()
 
-    ejecutar_handler = runtime.crear_handler_ejecucion(
+    def archivo_activo_permite_accion_cobra(accion: str) -> bool:
+        """Valida que el archivo activo permita una acción propia de Cobra."""
+
+        if estado.ruta is None:
+            return True
+
+        if runtime.archivo_permite_accion(estado.ruta, accion):
+            return True
+
+        salida.value = "Esta acción solo está disponible para archivos Cobra."
+        page.update()
+        return False
+
+    ejecutar_runtime_handler = runtime.crear_handler_ejecucion(
         entrada=entrada, salida=salida, selector=selector, activar=activar, page=page
     )
-    tokens_handler = runtime.crear_handler_tokens(
+    tokens_runtime_handler = runtime.crear_handler_tokens(
         entrada=entrada, salida=salida, page=page
     )
-    ast_handler = runtime.crear_handler_ast(entrada=entrada, salida=salida, page=page)
-    sugerencias_handler = runtime.crear_handler_sugerencias(
+    ast_runtime_handler = runtime.crear_handler_ast(
         entrada=entrada, salida=salida, page=page
     )
-    correccion_handler = runtime.crear_handler_correccion_tipografica(
+    sugerencias_runtime_handler = runtime.crear_handler_sugerencias(
         entrada=entrada, salida=salida, page=page
     )
+    correccion_runtime_handler = runtime.crear_handler_correccion_tipografica(
+        entrada=entrada, salida=salida, page=page
+    )
+
+    def ejecutar_handler(e):
+        if archivo_activo_permite_accion_cobra(runtime.ACCION_EJECUTAR):
+            ejecutar_runtime_handler(e)
+
+    def tokens_handler(e):
+        if archivo_activo_permite_accion_cobra(runtime.ACCION_TOKENS):
+            tokens_runtime_handler(e)
+
+    def ast_handler(e):
+        if archivo_activo_permite_accion_cobra(runtime.ACCION_AST):
+            ast_runtime_handler(e)
+
+    def sugerencias_handler(e):
+        if archivo_activo_permite_accion_cobra(runtime.ACCION_SUGERENCIAS):
+            sugerencias_runtime_handler(e)
+
+    def correccion_handler(e):
+        if archivo_activo_permite_accion_cobra(runtime.ACCION_CORRECCION):
+            correccion_runtime_handler(e)
 
     reconstruir_arbol()
     sincronizar_estado_visual()

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -401,6 +401,107 @@ def test_main_handlers_smoke(monkeypatch):
     assert page.update.call_count == 6
 
 
+def test_main_bloquea_acciones_cobra_en_archivos_no_cobra(monkeypatch, tmp_path):
+    ft = _fake_flet()
+    monkeypatch.setenv("COBRA_PROJECTS_DIR", str(tmp_path))
+    monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)
+    monkeypatch.setattr(
+        idle.runtime, "detectar_motor_ia_sugerencias", _motor_disponible
+    )
+    monkeypatch.setattr(idle.runtime, "gui_target_choices", lambda: ("python",))
+    monkeypatch.setattr(
+        idle.runtime,
+        "require_gui_dependencies",
+        lambda: {
+            "TRANSPILERS": {"python": object},
+            "LexerError": RuntimeError,
+            "ParserError": ValueError,
+            "Lexer": lambda _codigo: SimpleNamespace(tokenizar=lambda: []),
+            "Parser": lambda _tokens: SimpleNamespace(parsear=lambda: []),
+        },
+    )
+    monkeypatch.setattr(idle.runtime, "normalizar_codigo", lambda value: value or "")
+    ejecutar_mock = MagicMock(return_value="ejecutado")
+    tokens_mock = MagicMock(return_value="Token(X)")
+    ast_mock = MagicMock(return_value="[Nodo]")
+    sugerencias_mock = MagicMock(return_value="sugerencias")
+    correccion_mock = MagicMock(return_value="correccion")
+    monkeypatch.setattr(idle.runtime, "ejecutar_codigo", ejecutar_mock)
+    monkeypatch.setattr(idle.runtime, "mostrar_tokens", tokens_mock)
+    monkeypatch.setattr(idle.runtime, "mostrar_ast", ast_mock)
+    monkeypatch.setattr(idle.runtime, "generar_reporte_sugerencias", sugerencias_mock)
+    monkeypatch.setattr(
+        idle.runtime, "generar_reporte_correccion_tipografica", correccion_mock
+    )
+
+    archivos_no_cobra = [
+        "README.md",
+        "Dockerfile",
+        "config.json",
+        "config.yaml",
+        "config.toml",
+        "notas.txt",
+        ".gitignore",
+        ".env.example",
+    ]
+    for nombre in archivos_no_cobra:
+        (tmp_path / nombre).write_text("contenido", encoding="utf-8")
+
+    page = ft.Page()
+    idle.main(page)
+
+    ruta_input = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.TextField) and c.kwargs.get("label") == "Ruta"
+    )
+    salida = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.Text) and c.kwargs.get("selectable")
+    )
+    botones = {
+        c.text: c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton)
+        and c.text
+        in {
+            "Abrir",
+            "Ejecutar",
+            "Tokens",
+            "AST",
+            "Sugerencias del Libro",
+            "Corrección",
+        }
+    }
+
+    for nombre in archivos_no_cobra:
+        ruta_input.value = str(tmp_path / nombre)
+        botones["Abrir"].on_click(None)
+
+        ejecutar_mock.reset_mock()
+        tokens_mock.reset_mock()
+        ast_mock.reset_mock()
+        sugerencias_mock.reset_mock()
+        correccion_mock.reset_mock()
+
+        for accion in [
+            "Ejecutar",
+            "Tokens",
+            "AST",
+            "Sugerencias del Libro",
+            "Corrección",
+        ]:
+            botones[accion].on_click(None)
+            assert salida.value == "Esta acción solo está disponible para archivos Cobra."
+
+        ejecutar_mock.assert_not_called()
+        tokens_mock.assert_not_called()
+        ast_mock.assert_not_called()
+        sugerencias_mock.assert_not_called()
+        correccion_mock.assert_not_called()
+
+
 def test_main_selector_y_switch_sin_targets(monkeypatch):
     ft = _fake_flet()
     monkeypatch.setattr(idle.runtime, "require_flet", lambda: ft)


### PR DESCRIPTION
### Motivation
- Evitar que acciones específicas de Cobra (ejecución, tokens, AST, sugerencias y corrección) se apliquen a archivos que no son código Cobra y así prevenir llamadas inapropiadas a los analizadores/transpiladores.

### Description
- Añadido el helper local `archivo_activo_permite_accion_cobra(accion: str)` en `src/pcobra/gui/idle.py` que consulta `estado.ruta` y `runtime.archivo_permite_accion(estado.ruta, accion)` y, si la acción no está permitida, escribe `"Esta acción solo está disponible para archivos Cobra."` en la salida y llama a `page.update()`.
- Envolví los handlers expuestos en el IDLE (`Ejecutar`, `Tokens`, `AST`, `Sugerencias del Libro`, `Corrección`) para que primero validen la capacidad con el helper y sólo deleguen a los handlers runtime originales si la validación permite la acción.
- Con este cambio se asegura que tipos como Markdown, `Dockerfile`, JSON, YAML, TOML, TXT, archivos `ignore` y `.env.example` no lleguen a `mostrar_tokens()`, `mostrar_ast()`, `generar_reporte_sugerencias()` ni `generar_reporte_correccion_tipografica()` ya que la validación de `runtime.archivo_permite_accion` bloquea esas rutas.
- Se añadió una prueba de regresión en `tests/unit/test_gui_idle.py` que crea ejemplos de esos archivos no-Cobra y verifica que las acciones Cobra queden bloqueadas y que no se invoquen los mocks de los analizadores.

### Testing
- `pytest -q tests/unit/test_gui_idle.py::test_main_handlers_smoke tests/unit/test_gui_idle.py::test_main_bloquea_acciones_cobra_en_archivos_no_cobra` — passed.
- `python -m ruff check src/pcobra/gui/idle.py tests/unit/test_gui_idle.py` — passed (sin advertencias de estilo).
- `pytest -q tests/unit/test_gui_idle.py tests/unit/test_gui_runtime.py` — failed with 5 failures that appear pre-existing and unrelated a este cambio (expectativas sobre textos/layout del árbol y comportamiento de `guardar como`); los tests que validan el bloqueo de acciones Cobra pasan correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f90ab6f508327a39a31c3bc28e0a0)