### PR TITLE
Añade etiquetas visibles al título de archivo GUI

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -140,6 +140,18 @@ CAPACIDADES_POR_TIPO: dict[str, frozenset[str]] = {
 }
 """Acciones permitidas por tipo de archivo detectado."""
 
+ETIQUETAS_TIPO_ARCHIVO: dict[str, str] = {
+    TIPO_ARCHIVO_COBRA: "Archivo Cobra",
+    TIPO_ARCHIVO_MARKDOWN: "Archivo Markdown",
+    TIPO_ARCHIVO_TEXTO: "Archivo de texto",
+    TIPO_ARCHIVO_CONFIG: "Archivo de configuración",
+    TIPO_ARCHIVO_DOCKER: "Archivo Docker",
+    TIPO_ARCHIVO_IGNORE: "Archivo ignore",
+    TIPO_ARCHIVO_ENV_EXAMPLE: "Archivo de entorno de ejemplo",
+    TIPO_ARCHIVO_DESCONOCIDO: "Archivo de texto",
+}
+"""Etiquetas visibles por tipo de archivo detectado."""
+
 MOSTRAR_DESCONOCIDOS_COMO_TEXTO_IDLE = False
 """Bandera interna para exponer archivos desconocidos como texto plano.
 
@@ -311,6 +323,15 @@ def detectar_tipo_archivo(path: str | Path) -> str:
     if nombre_lower in ENV_EXAMPLE_FILE_NAMES:
         return TIPO_ARCHIVO_ENV_EXAMPLE
     return TIPO_ARCHIVO_DESCONOCIDO
+
+
+def etiqueta_tipo_archivo(path: str | Path) -> str:
+    """Devuelve la etiqueta visible para el tipo detectado de una ruta."""
+
+    tipo_archivo = detectar_tipo_archivo(path)
+    return ETIQUETAS_TIPO_ARCHIVO.get(
+        tipo_archivo, ETIQUETAS_TIPO_ARCHIVO[TIPO_ARCHIVO_DESCONOCIDO]
+    )
 
 
 def obtener_capacidades_archivo(path: str | Path) -> frozenset[str]:
@@ -502,9 +523,10 @@ def escribir_archivo_texto(
 def crear_titulo_archivo(estado: GuiFileState) -> str:
     """Devuelve la etiqueta común del archivo activo en la GUI."""
 
-    nombre = (
-        str(estado.ruta) if estado.ruta is not None else "Archivo nuevo (sin guardar)"
-    )
+    if estado.ruta is None:
+        nombre = "Archivo nuevo (sin guardar)"
+    else:
+        nombre = f"{etiqueta_tipo_archivo(estado.ruta)}: {estado.ruta}"
     return f"{nombre}{' *' if estado.cambios_sin_guardar else ''}"
 
 

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -123,6 +123,34 @@ def test_detectar_tipo_archivo_clasifica_extensiones_y_nombres_conocidos() -> No
         assert runtime.detectar_tipo_archivo(ruta) == tipo_esperado
 
 
+def test_etiqueta_tipo_archivo_devuelve_textos_visibles() -> None:
+    casos = {
+        "programa.cobra": "Archivo Cobra",
+        "README.md": "Archivo Markdown",
+        "notas.txt": "Archivo de texto",
+        "pyproject.toml": "Archivo de configuración",
+        "Dockerfile": "Archivo Docker",
+        ".gitignore": "Archivo ignore",
+        ".env.example": "Archivo de entorno de ejemplo",
+        "imagen.png": "Archivo de texto",
+    }
+
+    for ruta, etiqueta_esperada in casos.items():
+        assert runtime.etiqueta_tipo_archivo(ruta) == etiqueta_esperada
+
+
+def test_crear_titulo_archivo_antepone_etiqueta_y_conserva_asterisco() -> None:
+    estado = runtime.GuiFileState(ruta=Path("README.md"), cambios_sin_guardar=True)
+
+    assert runtime.crear_titulo_archivo(estado) == "Archivo Markdown: README.md *"
+
+
+def test_crear_titulo_archivo_sin_ruta_mantiene_texto_de_archivo_nuevo() -> None:
+    estado = runtime.GuiFileState(cambios_sin_guardar=True)
+
+    assert runtime.crear_titulo_archivo(estado) == "Archivo nuevo (sin guardar) *"
+
+
 def test_capacidades_archivo_reservan_acciones_cobra_para_codigo_cobra() -> None:
     acciones_cobra = {
         runtime.ACCION_EJECUTAR,


### PR DESCRIPTION
### Motivation
- Mejorar la UX del IDLE mostrando una etiqueta legible del tipo de archivo antes de la ruta en el título del editor, y conservar el asterisco `*` para indicar cambios sin guardar mientras se mantiene el texto actual para archivos nuevos no guardados.

### Description
- Se añade el mapeo `ETIQUETAS_TIPO_ARCHIVO` con las etiquetas solicitadas para `cobra`, `markdown`, `texto`, `config`, `docker`, `ignore`, `env_example` y `desconocido` en `src/pcobra/gui/runtime.py`.
- Se incorpora el helper público `etiqueta_tipo_archivo(path)` que reutiliza `detectar_tipo_archivo(path)` y devuelve la etiqueta visible correspondiente.
- Se actualiza `crear_titulo_archivo(estado)` para anteponer la etiqueta cuando `estado.ruta` no es `None`, manteniendo `"Archivo nuevo (sin guardar)"` cuando no hay ruta y conservando el asterisco `*` para cambios sin guardar.
- Se añaden pruebas unitarias en `tests/unit/test_gui_runtime.py` que verifican las etiquetas por tipo y el formato del título con y sin ruta.

### Testing
- Se ejecutaron las pruebas añadidas y relacionadas con el cambio: `test_etiqueta_tipo_archivo_devuelve_textos_visibles`, `test_crear_titulo_archivo_antepone_etiqueta_y_conserva_asterisco` y `test_crear_titulo_archivo_sin_ruta_mantiene_texto_de_archivo_nuevo`, las cuales pasaron correctamente.
- Se verificó la compilación con `python -m compileall` sobre los archivos modificados y no arrojó errores.
- La ejecución de la suite completa `python -m pytest tests/unit/test_gui_runtime.py -q` muestra 3 fallos existentes que no están relacionados con estos cambios: falta la constante esperada `MOSTRAR_TODOS_LOS_ARCHIVOS_IDLE`, una expectativa de texto antiguo para árbol vacío, y un fake de Flet que carece de `Column` en los tests; dichos fallos quedan fuera del alcance de esta PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f91f4cfa883278d570e0abbb09ea5)