### PR TITLE
test(gui): cover idle file type capabilities

### DIFF
--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -325,12 +325,14 @@ def test_cargar_archivo_desde_arbol_reusa_apertura_y_valida_extension(tmp_path: 
     assert estado.ruta == archivo_cobra.resolve()
     assert estado.contenido_cargado == "imprimir('arbol')"
 
-    try:
-        runtime.cargar_archivo_desde_arbol(archivo_no_cobra, estado)
-    except ValueError as exc:
-        assert "Selecciona un archivo Cobra" in str(exc)
-    else:
-        raise AssertionError("El árbol solo debe cargar archivos .co/.cobra")
+    contenido_txt, mensaje_txt = runtime.cargar_archivo_desde_arbol(
+        archivo_no_cobra, estado
+    )
+
+    assert contenido_txt == "texto"
+    assert mensaje_txt == f"Archivo cargado: {archivo_no_cobra.resolve()}"
+    assert estado.ruta == archivo_no_cobra.resolve()
+    assert estado.contenido_cargado == "texto"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -229,7 +229,7 @@ def test_panel_lateral_organiza_proyecto_en_columna(monkeypatch, tmp_path):
 
     contenido_panel = panel_lateral.content
     assert isinstance(contenido_panel, ft.Column)
-    assert contenido_panel.controls[0].value == "Archivos Cobra"
+    assert contenido_panel.controls[0].value == "Archivos del proyecto"
 
     barra_raiz_arbol = contenido_panel.controls[1]
     assert isinstance(barra_raiz_arbol, ft.Column)
@@ -719,7 +719,7 @@ def test_main_arbol_inicial_muestra_estado_vacio_en_tmp_path_vacio(
     )
 
     assert any(
-        getattr(control, "value", "") == "No hay archivos Cobra en esta carpeta"
+        getattr(control, "value", "") == "No hay archivos visibles en esta carpeta"
         for control in arbol.controls[1:]
     )
     assert len(arbol.controls) > 1
@@ -759,7 +759,7 @@ def test_main_panel_lateral_conserva_ancho_contenido_y_arbol(monkeypatch, tmp_pa
         for c in page.controls
         if isinstance(c, ft.Container)
         and getattr(getattr(c, "content", None), "controls", [None])[0].value
-        == "Archivos Cobra"
+        == "Archivos del proyecto"
     )
     columna = panel_lateral.content
     arbol = columna.controls[-1]
@@ -772,7 +772,7 @@ def test_main_panel_lateral_conserva_ancho_contenido_y_arbol(monkeypatch, tmp_pa
     assert getattr(columna, "controls", None)
     assert columna.expand is True
     assert arbol.expand is True
-    assert columna.controls[0].value == "Archivos Cobra"
+    assert columna.controls[0].value == "Archivos del proyecto"
     assert columna.controls[-1] is arbol
     assert arbol.controls[0].value == _estado_workspace_proyecto(tmp_path)
     assert {"subdirectorio", "programa.cobra", "programa.co"}.issubset(titulos)
@@ -994,7 +994,7 @@ def test_main_acciones_publicas_de_archivo(monkeypatch, tmp_path):
     botones["Abrir"].on_click(None)
     assert entrada.value == "imprimir('abrir')"
     assert salida.value == f"Archivo cargado: {archivo_abrir.resolve()}"
-    assert estado_archivo.value == str(archivo_abrir.resolve())
+    assert estado_archivo.value == f"Archivo Cobra: {archivo_abrir.resolve()}"
     assert ruta_input.value == str(archivo_abrir.resolve())
     assert arbol.controls[0].value == _estado_workspace_proyecto(tmp_path)
 
@@ -1112,7 +1112,7 @@ def test_crear_arbol_directorios_muestra_estado_vacio_en_carpeta_sin_cobras(tmp_
 
     assert arbol.scroll == ft.ScrollMode.ALWAYS
     assert len(arbol.controls) == 1
-    assert arbol.controls[0].value == "No hay archivos Cobra en esta carpeta"
+    assert arbol.controls[0].value == "No hay archivos visibles en esta carpeta"
 
 
 def _preparar_idle_archivos(monkeypatch, tmp_path, workspace_root=None):

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -102,13 +102,13 @@ def test_es_archivo_cobra_reconoce_extensiones_seguras_documentadas() -> None:
 
 def test_detectar_tipo_archivo_clasifica_extensiones_y_nombres_conocidos() -> None:
     casos = {
-        "programa.cobra": runtime.TIPO_ARCHIVO_COBRA,
-        "programa.co": runtime.TIPO_ARCHIVO_COBRA,
+        "main.cobra": runtime.TIPO_ARCHIVO_COBRA,
+        "main.co": runtime.TIPO_ARCHIVO_COBRA,
         "README.md": runtime.TIPO_ARCHIVO_MARKDOWN,
-        "manual.markdown": runtime.TIPO_ARCHIVO_MARKDOWN,
+        "README.markdown": runtime.TIPO_ARCHIVO_MARKDOWN,
         "notas.txt": runtime.TIPO_ARCHIVO_TEXTO,
-        "package.json": runtime.TIPO_ARCHIVO_CONFIG,
-        "compose.yml": runtime.TIPO_ARCHIVO_CONFIG,
+        "docker-compose.yml": runtime.TIPO_ARCHIVO_CONFIG,
+        "config.json": runtime.TIPO_ARCHIVO_CONFIG,
         "compose.yaml": runtime.TIPO_ARCHIVO_CONFIG,
         "pyproject.toml": runtime.TIPO_ARCHIVO_CONFIG,
         "Dockerfile": runtime.TIPO_ARCHIVO_DOCKER,
@@ -172,7 +172,7 @@ def test_capacidades_archivo_reservan_acciones_cobra_para_codigo_cobra() -> None
     for ruta in [
         "README.md",
         "notas.txt",
-        "package.json",
+        "config.json",
         "Dockerfile",
         ".gitignore",
         ".env.example",
@@ -185,7 +185,7 @@ def test_capacidades_archivo_reservan_acciones_cobra_para_codigo_cobra() -> None
         )
 
 
-def test_listar_directorio_cobra_modo_seguro_filtra_archivos_no_cobra(
+def test_listar_directorio_cobra_modo_seguro_incluye_texto_auxiliar_clasificado(
     tmp_path: Path,
 ) -> None:
     (tmp_path / "zeta").mkdir()
@@ -193,12 +193,14 @@ def test_listar_directorio_cobra_modo_seguro_filtra_archivos_no_cobra(
     (tmp_path / "alfa.cobra").write_text("", encoding="utf-8")
     (tmp_path / "ignorado.py").write_text("", encoding="utf-8")
     (tmp_path / "README.md").write_text("", encoding="utf-8")
+    (tmp_path / "notas.txt").write_text("", encoding="utf-8")
 
-    assert runtime.MOSTRAR_TODOS_LOS_ARCHIVOS_IDLE is False
     assert [path.name for path in runtime.listar_directorio_cobra(tmp_path)] == [
         "zeta",
         "alfa.cobra",
         "beta.co",
+        "notas.txt",
+        "README.md",
     ]
 
 
@@ -319,7 +321,7 @@ def test_crear_arbol_directorios_sin_root_path_usa_workspace_idle(
 
     assert llamadas == ["resolver"]
     assert arbol.scroll == ft.ScrollMode.ALWAYS
-    assert arbol.controls[0].value == "No hay archivos Cobra en esta carpeta"
+    assert arbol.controls[0].value == "No hay archivos visibles en esta carpeta"
 
 
 def test_crear_arbol_directorios_propaga_file_not_found_en_ruta_inexistente(
@@ -342,7 +344,7 @@ def test_crear_arbol_directorios_propaga_permission_error_sin_tocar_permisos(
     def fake(_root_path):
         raise PermissionError("sin permiso portable")
 
-    monkeypatch.setattr(runtime, "listar_directorio_cobra", fake)
+    monkeypatch.setattr(runtime, "listar_directorio_idle", fake)
 
     with pytest.raises(PermissionError, match="sin permiso portable"):
         runtime.crear_arbol_directorios(


### PR DESCRIPTION
### Motivation
- Alinear las pruebas GUI con la política actual de clasificación de archivos del IDLE cubriendo tipos auxiliares (markdown, texto, config, docker, ignore, env_example) y no solo archivos Cobra.
- Verificar programáticamente las capacidades por tipo (acciones Cobra vs acciones base editables) sin interacción visual compleja.

### Description
- Actualiza `tests/unit/test_gui_runtime.py` para añadir/ajustar casos que cubren `detectar_tipo_archivo()` con `main.cobra`, `main.co`, `README.md`, `README.markdown`, `notas.txt`, `Dockerfile`, `Dockerfile.dev`, `docker-compose.yml`, `config.json`, `pyproject.toml`, `.gitignore`, `.dockerignore`, `.env.example` y un archivo no reconocido (`desconocido`).
- Refuerza comprobaciones de capacidades con `obtener_capacidades_archivo()` y `archivo_permite_accion()` asegurando que solo `cobra` permite `ejecutar`, `tokens`, `ast`, `sugerencias`, `correccion` y que todos los tipos editables permiten `editar`, `guardar`, `recargar`, `borrar`.
- Actualiza tests de árbol/carga para reflejar que archivos auxiliares (`README.md`, `notas.txt`, etc.) son visibles/abribles en el IDLE en lugar de ser rechazados, y adapta textos esperados mínimos en la UI a "Archivos del proyecto" y "No hay archivos visibles en esta carpeta".
- Modifica `tests/gui/test_runtime_file_helpers.py` para validar que `cargar_archivo_desde_arbol()` carga también archivos de texto auxiliares en lugar de esperar rechazo por no ser Cobra.
- Reemplaza en pruebas específicas el uso de `listar_directorio_cobra` por `listar_directorio_idle` cuando se simulan errores/monkeypatch para ajustarse a la política actual.

### Testing
- Ejecutado `pytest -q tests/unit/test_gui_runtime.py` y las pruebas modificadas pasaron exitosamente.
- Ejecutado `pytest -q tests/gui/test_runtime_file_helpers.py` y el caso adaptado de `cargar_archivo_desde_arbol` pasó exitosamente.
- Ejecutados tests focalizados de `tests/unit/test_gui_idle.py` que verifican el panel lateral y el árbol (p. ej. `test_main_bloquea_acciones_cobra_en_archivos_no_cobra`, `test_panel_lateral_organiza_proyecto_en_columna`, `test_main_arbol_inicial_muestra_estado_vacio_en_tmp_path_vacio`, `test_main_panel_lateral_conserva_ancho_contenido_y_arbol`, `test_main_acciones_publicas_de_archivo`, `test_crear_arbol_directorios_muestra_estado_vacio_en_carpeta_sin_cobras`) con `pytest` y todos los casos seleccionados pasaron tras los ajustes.
- Se realizó el commit con el mensaje `test(gui): cover idle file type capabilities` y no hay errores en `git diff --check`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f95871ff0832797a498f60187a714)