### PR TITLE
Mostrar archivos desconocidos del IDLE como texto plano por defecto

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -152,13 +152,13 @@ ETIQUETAS_TIPO_ARCHIVO: dict[str, str] = {
 }
 """Etiquetas visibles por tipo de archivo detectado."""
 
-MOSTRAR_DESCONOCIDOS_COMO_TEXTO_IDLE = False
+MOSTRAR_DESCONOCIDOS_COMO_TEXTO_IDLE = True
 """Bandera interna para exponer archivos desconocidos como texto plano.
 
-El valor por defecto mantiene visible solo lo que la GUI clasifica como Cobra o
-texto/configuración auxiliar soportado por ``detectar_tipo_archivo()``. Puede
-activarse desde código o una configuración futura si el equipo decide permitir
-abrir archivos desconocidos como texto plano desde el árbol del IDLE.
+El valor por defecto muestra también los archivos no clasificados del proyecto
+activo para que puedan abrirse como texto plano desde el árbol del IDLE. Estas
+rutas conservan solo acciones base de archivo: nunca habilitan ejecución,
+tokens, AST, sugerencias ni corrección Cobra.
 """
 
 SUGERENCIAS_BUTTON_TEXT = "Sugerencias del Libro"
@@ -445,9 +445,7 @@ def resolver_ruta_texto_en_project_root(
     return ruta_resuelta
 
 
-TIPOS_ARCHIVO_TEXTO_IDLE: frozenset[str] = frozenset(CAPACIDADES_POR_TIPO) - frozenset(
-    {TIPO_ARCHIVO_DESCONOCIDO}
-)
+TIPOS_ARCHIVO_TEXTO_IDLE: frozenset[str] = frozenset(CAPACIDADES_POR_TIPO)
 """Tipos de archivo no directorio visibles y abribles como texto en el IDLE."""
 
 
@@ -461,8 +459,8 @@ def listar_directorio_idle(
     La política general muestra siempre directorios, archivos Cobra y archivos
     auxiliares de texto/configuración clasificados por ``detectar_tipo_archivo()``
     (por ejemplo Markdown, TXT, JSON/YAML/TOML, Dockerfile, ignore y
-    ``.env.example``). ``incluir_desconocidos`` permite exponer archivos no
-    clasificados si se decide abrirlos como texto plano.
+    ``.env.example``). ``incluir_desconocidos`` permite ocultar o exponer archivos
+    no clasificados, que se tratan únicamente como texto plano.
     """
 
     base = Path(root).expanduser()
@@ -473,9 +471,11 @@ def listar_directorio_idle(
             visibles.append(entry)
             continue
         tipo_archivo = detectar_tipo_archivo(entry)
-        if tipo_archivo in TIPOS_ARCHIVO_TEXTO_IDLE or (
-            incluir_desconocidos and tipo_archivo == TIPO_ARCHIVO_DESCONOCIDO
-        ):
+        if tipo_archivo == TIPO_ARCHIVO_DESCONOCIDO:
+            if incluir_desconocidos:
+                visibles.append(entry)
+            continue
+        if tipo_archivo in TIPOS_ARCHIVO_TEXTO_IDLE:
             visibles.append(entry)
 
     return sorted(visibles, key=lambda entry: (not entry.is_dir(), entry.name.lower()))

--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -59,6 +59,7 @@ def test_listar_directorio_idle_incluye_auxiliares_y_ordena(tmp_path: Path):
         "alfa.cobra",
         "beta.co",
         "config.yaml",
+        "ignorado.py",
         "README.md",
     ]
 
@@ -71,16 +72,15 @@ def test_listar_directorio_cobra_delega_en_politica_idle(tmp_path: Path):
     ]
 
 
-def test_listar_directorio_idle_permite_desconocidos_opcionalmente(tmp_path: Path):
+def test_listar_directorio_idle_muestra_desconocidos_por_defecto_y_permite_ocultarlos(tmp_path: Path):
     (tmp_path / "script.py").write_text("", encoding="utf-8")
 
-    assert runtime.listar_directorio_idle(tmp_path) == []
-    assert [
-        path.name
-        for path in runtime.listar_directorio_idle(
-            tmp_path, incluir_desconocidos=True
-        )
-    ] == ["script.py"]
+    assert [path.name for path in runtime.listar_directorio_idle(tmp_path)] == [
+        "script.py"
+    ]
+    assert runtime.listar_directorio_idle(
+        tmp_path, incluir_desconocidos=False
+    ) == []
 
 
 def test_construir_entradas_directorio_muestra_readme_markdown(tmp_path: Path):
@@ -333,6 +333,29 @@ def test_cargar_archivo_desde_arbol_reusa_apertura_y_valida_extension(tmp_path: 
     assert mensaje_txt == f"Archivo cargado: {archivo_no_cobra.resolve()}"
     assert estado.ruta == archivo_no_cobra.resolve()
     assert estado.contenido_cargado == "texto"
+
+
+def test_archivo_desconocido_se_abre_como_texto_sin_lexer_parser(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    desconocido = tmp_path / "script.py"
+    desconocido.write_text("print('texto plano')", encoding="utf-8")
+    estado = runtime.GuiFileState()
+
+    def fail_require_gui_dependencies():
+        raise AssertionError("No debe invocar Lexer/Parser para abrir texto plano")
+
+    monkeypatch.setattr(
+        runtime, "require_gui_dependencies", fail_require_gui_dependencies
+    )
+
+    contenido, mensaje = runtime.cargar_archivo_desde_arbol(desconocido, estado)
+
+    assert contenido == "print('texto plano')"
+    assert mensaje == f"Archivo cargado: {desconocido.resolve()}"
+    assert estado.ruta == desconocido.resolve()
+    assert estado.contenido_cargado == "print('texto plano')"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -199,6 +199,7 @@ def test_listar_directorio_cobra_modo_seguro_incluye_texto_auxiliar_clasificado(
         "zeta",
         "alfa.cobra",
         "beta.co",
+        "ignorado.py",
         "notas.txt",
         "README.md",
     ]
@@ -983,8 +984,18 @@ def test_accion_cargar_archivo_desde_arbol_filtra_extensiones(
     assert estado.contenido_cargado == "notas del proyecto"
     assert estado.cambios_sin_guardar is False
     assert mensaje == f"Archivo cargado: {archivo.resolve()}"
-    with pytest.raises(ValueError, match="archivo de texto del proyecto"):
-        runtime.cargar_archivo_desde_arbol(tmp_path / "imagen.png", estado)
+    desconocido = tmp_path / "imagen.png"
+    desconocido.write_bytes(b"texto plano compatible utf-8")
+
+    contenido_desconocido, mensaje_desconocido = runtime.cargar_archivo_desde_arbol(
+        desconocido, estado
+    )
+
+    assert runtime.detectar_tipo_archivo(desconocido) == runtime.TIPO_ARCHIVO_DESCONOCIDO
+    assert contenido_desconocido == "texto plano compatible utf-8"
+    assert estado.ruta == desconocido.resolve()
+    assert estado.contenido_cargado == "texto plano compatible utf-8"
+    assert mensaje_desconocido == f"Archivo cargado: {desconocido.resolve()}"
 
 
 def test_require_flet_error_accionable(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- La GUI del IDLE actualmente oculta archivos no clasificados; se quiere permitir abrirlos como texto plano desde el árbol del proyecto activo sin habilitar capacidades de Cobra.
- Mantener intactos Lexer, Parser, gramática, tokens, AST y transpiladores mientras se expone la opción de visualizar/editar archivos desconocidos.

### Description
- Cambio del flag por defecto `MOSTRAR_DESCONOCIDOS_COMO_TEXTO_IDLE` a `True` para mostrar archivos desconocidos dentro del proyecto activo por defecto.
- Inclusión de `TIPOS_ARCHIVO_TEXTO_IDLE` para permitir que los archivos desconocidos sean considerados abribles como texto y ajuste de la lógica de `listar_directorio_idle(...)` para que `incluir_desconocidos=False` siga pudiendo ocultarlos explícitamente.
- `cargar_archivo_desde_arbol(...)` sigue validando mediante `TIPOS_ARCHIVO_TEXTO_IDLE`, por lo que archivos desconocidos se abren como texto plano sin invocar `require_gui_dependencies` ni pasar por Lexer/Parser.
- No se modificaron `CAPACIDADES_POR_TIPO` para desconocidos, por lo que las acciones Cobra (`ejecutar`, `tokens`, `ast`, `sugerencias`, `correccion`) permanecen deshabilitadas para estos archivos.

### Testing
- Se añadieron/ajustaron tests en `tests/gui/test_runtime_file_helpers.py` y `tests/unit/test_gui_runtime.py` para cubrir visibilidad en árbol, apertura como texto sin Lexer/Parser y que los desconocidos solo tienen acciones base.
- Ejecutado: `python -m pytest tests/gui/test_runtime_file_helpers.py tests/unit/test_gui_runtime.py` y los tests relevantes pasaron exitosamente (total de tests ejecutados en la sesión: 102 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f9c8457c083278a078c713ee2dc8a)