### PR TITLE
test: validar módulos públicos de `usar` desde fuente canónica

### DIFF
--- a/tests/unit/test_usar_public_contract.py
+++ b/tests/unit/test_usar_public_contract.py
@@ -7,7 +7,7 @@ import pytest
 from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 from pcobra.cobra.cli.commands.interactive_cmd import InteractiveCommand
 from pcobra.cobra.core.runtime import InterpretadorCobra
-from pcobra.cobra.usar_policy import REPL_COBRA_MODULE_MAP
+from pcobra.cobra.usar_policy import REPL_COBRA_MODULE_MAP, USAR_COBRA_PUBLIC_MODULES
 from pcobra.core import usar_loader as core_usar_loader
 
 from tests.integration.test_repl_usar_entrypoints_contract import (
@@ -118,8 +118,8 @@ def test_runtime_startup_no_carga_legacy_backends():
 
 
 def test_usar_policy_publica_exacta_modulos_canonicos():
-    assert tuple(REPL_COBRA_MODULE_MAP.keys()) == ("numero", "texto", "datos")
-    assert tuple(REPL_COBRA_MODULE_MAP.values()) == ("numero", "texto", "datos")
+    assert tuple(REPL_COBRA_MODULE_MAP.keys()) == USAR_COBRA_PUBLIC_MODULES
+    assert tuple(REPL_COBRA_MODULE_MAP.values()) == USAR_COBRA_PUBLIC_MODULES
 
 def test_public_backends_contrato_exacto_en_backend_policy():
     assert PUBLIC_BACKENDS == ("python", "javascript", "rust")


### PR DESCRIPTION
### Motivation
- Actualizar la prueba que verificaba la lista canónica de módulos permitidos por `usar` para que compare contra la fuente única de verdad en vez de una tupla legacy hardcodeada de tres módulos.

### Description
- Importé `USAR_COBRA_PUBLIC_MODULES` desde `pcobra.cobra.usar_policy` junto a `REPL_COBRA_MODULE_MAP` en `tests/unit/test_usar_public_contract.py`.
- Reemplacé las aserciones hardcodeadas por comparaciones que usan `USAR_COBRA_PUBLIC_MODULES` para las claves y valores de `REPL_COBRA_MODULE_MAP`.
- No se modificó `src/pcobra/cobra/usar_policy.py` ni otras partes del parser/lexer/AST/transpiladores.

### Testing
- Ejecuté `pytest tests/unit/test_usar_public_contract.py::test_usar_policy_publica_exacta_modulos_canonicos -q` y la prueba pasó correctamente.
- Ejecuté `pytest tests/unit/test_usar_public_contract.py -q` y el archivo de tests completo mostró fallos existentes no relacionados con este cambio (5 fallos, 1 éxito) debido a expectativas sobre símbolos/exportaciones y mensajes de error en otras pruebas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40db51821083278927e3052ebb0dbf)