### PR TITLE
test: actualizar contrato público de `filtrar` en stubs de `datos`

### DIFF
--- a/tests/integration/test_usar_public_contract_regression.py
+++ b/tests/integration/test_usar_public_contract_regression.py
@@ -111,7 +111,7 @@ def test_usar_texto_contrato_runtime_overrides_y_poc_funcional(factory, executor
 def _modulo_datos_publico_stub() -> ModuleType:
     mod = ModuleType("datos")
     mod.__all__ = ["filtrar", "mapear", "reducir"]
-    mod.filtrar = lambda valores, predicado=None: valores
+    mod.filtrar = lambda tabla, condicion: [fila for fila in tabla if condicion(fila)]
     mod.mapear = lambda valores, fn=None: valores
     mod.reducir = lambda valores, fn=None, inicial=None: inicial if inicial is not None else valores[0]
     mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/datos.py"
@@ -135,13 +135,14 @@ def test_usar_datos_incluye_filtrar_mapear_reducir(factory, executor, get_interp
     executor(cmd, 'usar "datos"')
 
     valores = [1, 2, 3]
+    tabla = [{"activo": True}, {"activo": False}]
     for simbolo in ("filtrar", "mapear", "reducir"):
         assert simbolo in interp.contextos[-1].values
         assert callable(interp.contextos[-1].get(simbolo))
 
-    assert interp.contextos[-1].get("filtrar")(valores) == valores
-    assert interp.contextos[-1].get("mapear")(valores) == valores
-    assert interp.contextos[-1].get("reducir")(valores) == 1
+    assert interp.contextos[-1].get("filtrar")(tabla, lambda fila: fila["activo"]) == [{"activo": True}]
+    assert interp.contextos[-1].get("mapear")(tabla, lambda fila: fila) == tabla
+    assert interp.contextos[-1].get("reducir")(tabla, lambda total, fila: total + int(fila["activo"]), 0) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_usar_public_contract.py
+++ b/tests/unit/test_usar_public_contract.py
@@ -22,7 +22,7 @@ from tests.unit.test_backend_bootstrap_contract import _run_python_isolated
 def _modulo_datos_publico_stub() -> ModuleType:
     mod = ModuleType("datos")
     mod.__all__ = ["filtrar", "mapear", "reducir"]
-    mod.filtrar = lambda valores, predicado=None: valores
+    mod.filtrar = lambda tabla, condicion: [fila for fila in tabla if condicion(fila)]
     mod.mapear = lambda valores, fn=None: valores
     mod.reducir = lambda valores, fn=None, inicial=None: inicial if inicial is not None else valores[0]
     mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/datos.py"
@@ -57,6 +57,9 @@ def test_usar_datos_expone_filtrar_mapear_reducir(monkeypatch):
 
     simbolos = interp.contextos[-1].values
     assert {"filtrar", "mapear", "reducir"}.issubset(simbolos)
+
+    tabla = [{"activo": True}, {"activo": False}]
+    assert simbolos["filtrar"](tabla, lambda fila: fila["activo"]) == [{"activo": True}]
 
 
 @pytest.mark.parametrize("nombre", ["numpy", "np", "node-fetch", "serde", "holobit_sdk"] )


### PR DESCRIPTION
### Motivation

- Actualizar los stubs usados en pruebas de contrato público para reflejar la firma real `filtrar(tabla, condicion)` y así verificar el comportamiento observable de `usar "datos"`.
- Evitar pruebas que asuman una firma antigua (por ejemplo `filtrar(valores)`) y en su lugar ejecutar `filtrar` con una condición sobre una tabla mínima.

### Description

- En `tests/unit/test_usar_public_contract.py` y `tests/integration/test_usar_public_contract_regression.py` se reemplazó el stub `mod.filtrar = lambda valores, predicado=None: valores` por `mod.filtrar = lambda tabla, condicion: [fila for fila in tabla if condicion(fila)]`.
- Se añadieron tablas mínimas `tabla = [{"activo": True}, {"activo": False}]` y aserciones que llaman `filtrar(tabla, condicion)` para comprobar que filtra según la condición.
- En el test de integración se ajustaron las invocaciones a `mapear` y `reducir` para usar las firmas actuales: `mapear(tabla, lambda fila: fila)` y `reducir(tabla, lambda total, fila: ..., 0)`.
- Los cambios se limitaron a tests y stubs; no se modificó `src/pcobra/standard_library/datos.py` ni `src/pcobra/corelibs/datos.py`.

### Testing

- Ejecutado: `pytest tests/unit/test_usar_public_contract.py::test_usar_datos_expone_filtrar_mapear_reducir tests/integration/test_usar_public_contract_regression.py::test_usar_datos_incluye_filtrar_mapear_reducir` y los tests modificados pasaron con éxito (`3 passed, 1 warning`).
- Ejecución previa: `pytest tests/unit/test_usar_public_contract.py tests/integration/test_usar_public_contract_regression.py` mostró fallos no relacionados inicialmente (expectativas de mensajes y símbolos en otros tests de `usar`) antes de completar el ajuste de llamadas a `mapear`/`reducir` en la regresión de integración.
- Las pruebas automatizadas específicas afectadas por este cambio ahora validan la firma y el comportamiento observable de `filtrar` correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40de67ddf4832789de815d6dcbddf8)