### PR TITLE
Preserva a_snake en contrato usar texto

### DIFF
--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -229,6 +229,7 @@ USAR_RUNTIME_EXPORT_OVERRIDES: dict[str, tuple[str, ...]] = {
         "producto",
     ),
     "texto": (
+        "a_snake",
         "mayusculas",
         "minusculas",
         "prefijo_comun",

--- a/src/pcobra/standard_library/texto.py
+++ b/src/pcobra/standard_library/texto.py
@@ -87,6 +87,7 @@ _T = TypeVar("_T")
 _SIN_VALOR = object()
 
 __all__ = [
+    "a_snake",
     "mayusculas",
     "minusculas",
     "prefijo_comun",


### PR DESCRIPTION
### Motivation
- Restaurar la presencia del símbolo público `a_snake` en la superficie consumida por `usar "texto"` para respetar el contrato público y las aserciones de los tests.

### Description
- Se añade `"a_snake"` a `USAR_RUNTIME_EXPORT_OVERRIDES["texto"]` y se expone `"a_snake"` en el `__all__` de `src/pcobra/standard_library/texto.py`, sin crear aliases como `snake_case` ni cambiar la implementación productiva.

### Testing
- Ejecutado: `pytest tests/integration/test_usar_public_contract_regression.py::test_usar_texto_solo_simbolos_espanoles tests/integration/test_usar_public_contract_regression.py::test_usar_texto_contrato_runtime_overrides_y_poc_funcional tests/unit/test_usar_public_contract.py::test_usar_numero_y_texto_solo_espanol tests/unit/test_usar_core_all_exports.py -q`, y estos tests focalizados pasaron;
- Ejecutado: `pytest tests/integration/test_usar_public_contract_regression.py -q`, donde la versión completa sigue mostrando 5 fallos no relacionados con `a_snake` (mensajes/estructura de error y firma esperada de saneamiento) que quedan fuera de este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40e1eebe9c8327b6df46ec09a56e9e)