### PR TITLE
test: clarify texto usar export path

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -1015,18 +1015,18 @@ def test_repl_usar_texto_simbolo_fuera_de_overrides_no_disponible(monkeypatch):
         _ejecutar_codigo('usar "texto"\ncapitalizar("hola")', interp)
 
 
-def test_usar_texto_mantiene_filtro_outside_public_api_para_capitalizar(monkeypatch):
+def test_usar_texto_inyecta_a_snake_desde_all_y_no_capitalizar(monkeypatch):
     modulo_texto = core_usar_loader.obtener_modulo_cobra_oficial("texto")
 
-    _, conflictos = core_usar_loader.sanitizar_exports_publicos(modulo_texto, "texto")
-    conflicto_capitalizar = next(
-        (c for c in conflictos if c.get("symbol") == "capitalizar"),
-        None,
-    )
+    assert "a_snake" in modulo_texto.__all__
+    assert "capitalizar" not in modulo_texto.__all__
 
-    assert conflicto_capitalizar is not None
-    assert conflicto_capitalizar["code"] == "outside_public_api"
-    assert conflicto_capitalizar["symbol"] == "capitalizar"
+    simbolos_saneados, _, conflictos = core_usar_loader.sanitizar_exports_publicos(modulo_texto, "texto")
+    simbolos = dict(simbolos_saneados)
+
+    assert "a_snake" in simbolos
+    assert "capitalizar" not in simbolos
+    assert not any(c.get("symbol") == "capitalizar" for c in conflictos)
 
     monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre, **_kwargs: modulo_texto)
     interp = InterpretadorCobra()
@@ -1035,6 +1035,7 @@ def test_usar_texto_mantiene_filtro_outside_public_api_para_capitalizar(monkeypa
     with pytest.raises(NameError, match=r"capitalizar"):
         _ejecutar_codigo('usar "texto"\ncapitalizar("hola")', interp)
 
+    assert "a_snake" in interp.variables
     assert "capitalizar" not in interp.variables
 
 


### PR DESCRIPTION
### Motivation
- Aclarar y fijar la regresión de prueba sobre la ruta de resolución de `usar "texto"` para reflejar la forma real de retorno de `sanitizar_exports_publicos` y documentar que `a_snake` proviene de `__all__` y no de una política externa.

### Description
- Actualicé la prueba para renombrarla a `test_usar_texto_inyecta_a_snake_desde_all_y_no_capitalizar` y para validar explícitamente que `a_snake` está en `modulo_texto.__all__` y que sobrevive al saneamiento (`sanitizar_exports_publicos`) mientras que `capitalizar` no está disponible.
- No se tocaron archivos de producción ni componentes de análisis/gramática/lexer/AST; solo se modificó el test en `tests/unit/test_usar.py` para reflejar la ruta real de exportación.

### Testing
- Ejecuté la batería objetivo con `pytest -q tests/unit/test_usar.py::test_usar_texto_inyecta_a_snake_desde_all_y_no_capitalizar tests/unit/test_usar.py::test_repl_usar_texto_permite_a_snake_sin_prefijo tests/unit/test_usar.py::test_repl_usar_texto_simbolo_fuera_de_overrides_no_disponible tests/unit/test_usar_core_all_exports.py` y los tests relacionados pasaron (`4 passed, 1 warning`).
- Verifiqué la compilación del test con `python -m compileall -q tests/unit/test_usar.py` sin errores y ejecuté una comprobación rápida de diferencias con `git diff --check` sin marcar problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40e5a375f883279b0404e683270d86)