### PR TITLE
test: fijar contrato público de filtrar

### DIFF
--- a/tests/integration/test_usar_public_contract_regression.py
+++ b/tests/integration/test_usar_public_contract_regression.py
@@ -145,6 +145,24 @@ def test_usar_datos_incluye_filtrar_mapear_reducir(factory, executor, get_interp
         (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
     ],
 )
+def test_usar_datos_filtrar_contrato_publico_real(factory, executor, get_interp):
+    cmd = factory()
+    interp = get_interp(cmd)
+    executor(cmd, 'usar "datos"')
+
+    tabla = [{"activo": True}, {"activo": False}]
+    simbolos = interp.contextos[-1].values
+
+    assert simbolos["filtrar"](tabla, lambda fila: fila["activo"]) == [{"activo": True}]
+
+
+@pytest.mark.parametrize(
+    ("factory", "executor", "get_interp"),
+    [
+        (lambda: InteractiveCommand(InterpretadorCobra()), lambda cmd, code: cmd.ejecutar_codigo(code), lambda cmd: cmd.interpretador),
+        (ReplCommandV2, lambda cmd, code: cmd._ejecutar_en_modo_normal(code), lambda cmd: cmd._delegate.interpretador),
+    ],
+)
 def test_rechaza_usar_numpy(factory, executor, get_interp, monkeypatch):
     monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda nombre: (_ for _ in ()).throw(ModuleNotFoundError(nombre)))
 

--- a/tests/unit/test_usar_public_contract.py
+++ b/tests/unit/test_usar_public_contract.py
@@ -66,6 +66,23 @@ def test_usar_datos_expone_filtrar_mapear_reducir(monkeypatch):
     assert simbolos["filtrar"](tabla, lambda fila: fila["activo"]) == [{"activo": True}]
 
 
+def test_usar_datos_filtrar_contrato_publico_minimo(monkeypatch):
+    monkeypatch.setattr(core_usar_loader, "obtener_modulo", lambda _nombre: _modulo_datos_publico_stub())
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl(REPL_COBRA_MODULE_MAP)
+
+    class _NodoUsar:
+        modulo = "datos"
+
+    interp.ejecutar_usar(_NodoUsar())
+
+    tabla = [{"activo": True}, {"activo": False}]
+    simbolos = interp.contextos[-1].values
+
+    assert simbolos["filtrar"](tabla, lambda fila: fila["activo"]) == [{"activo": True}]
+
+
 @pytest.mark.parametrize("nombre", ["numpy", "np", "node-fetch", "serde", "holobit_sdk"] )
 def test_rechazo_usar_modulos_externos_y_no_canonicos(monkeypatch, nombre):
     monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda nombre: (_ for _ in ()).throw(ModuleNotFoundError(nombre)))


### PR DESCRIPTION
### Motivation
- Asegurar y documentar explícitamente el contrato público `filtrar(tabla, condicion)` para evitar regresiones en el binding de `usar "datos"` mediante una prueba mínima que refleja el ejemplo de uso esperado.

### Description
- Añade la prueba unitaria `tests/unit/test_usar_public_contract.py::test_usar_datos_filtrar_contrato_publico_minimo` que valida el comportamiento mínimo `filtrar(tabla, lambda fila: ...)` usando el stub público de `datos`.
- Añade la prueba de integración `tests/integration/test_usar_public_contract_regression.py::test_usar_datos_filtrar_contrato_publico_real` que ejecuta `usar "datos"` contra la implementación real y verifica el mismo contrato público sin tocar el código productivo.
- No se modificó `src/pcobra/standard_library/datos.py` ni `src/pcobra/corelibs/datos.py` porque la comprobación con la implementación real no mostró regresión productiva.

### Testing
- Ejecutado `python -m pytest tests/unit/test_usar_public_contract.py tests/integration/test_usar_public_contract_regression.py -q` y ambas colecciones pasaron (46 passed) con 1 warning de deprecación existente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40e900ca7483278b0dae50beb41a07)