### PR TITLE
test: relax usar external module diagnostics

### DIFF
--- a/tests/integration/test_usar_public_contract_regression.py
+++ b/tests/integration/test_usar_public_contract_regression.py
@@ -11,6 +11,9 @@ from pcobra.cobra.core.runtime import InterpretadorCobra
 from pcobra.cobra.usar_policy import REPL_COBRA_MODULE_MAP, USAR_RUNTIME_EXPORT_OVERRIDES
 from pcobra.core import usar_loader as core_usar_loader
 
+USAR_RECHAZO_EXTERNO_MATCH = r"usar_error|no permitid[ao]|externo|fuera|no can[oó]nico|cat[aá]logo|m[oó]dulo"
+
+
 from tests.integration.test_repl_usar_entrypoints_contract import (
     _assert_contrato_simbolos_saneados,
     _modulo_holobit_publico_stub,
@@ -170,7 +173,7 @@ def test_rechaza_usar_numpy(factory, executor, get_interp, monkeypatch):
     interp = get_interp(cmd)
     estado_pre = dict(interp.contextos[-1].values)
 
-    with pytest.raises(PermissionError, match=r"no permitid[ao]|externo|fuera") as excinfo:
+    with pytest.raises(PermissionError, match=USAR_RECHAZO_EXTERNO_MATCH) as excinfo:
         executor(cmd, 'usar "numpy"')
 
     mensaje = str(excinfo.value).lower()
@@ -178,6 +181,8 @@ def test_rechaza_usar_numpy(factory, executor, get_interp, monkeypatch):
     assert "no permitid" in mensaje or "externo" in mensaje or "fuera" in mensaje
     assert "traceback" not in mensaje
     assert interp.contextos[-1].values == estado_pre
+    assert "numpy" not in interp.contextos[-1].values
+    assert "np" not in interp.contextos[-1].values
 
 
 def test_holobit_sdk_internals_no_son_importables(monkeypatch):
@@ -188,8 +193,18 @@ def test_holobit_sdk_internals_no_son_importables(monkeypatch):
 
     cmd = InteractiveCommand(InterpretadorCobra())
     cmd.interpretador.configurar_restriccion_usar_repl(alias_map)
-    with pytest.raises(PermissionError, match=r"Importación no permitida|usar_error\[(modulo_fuera_catalogo_publico|modulo_no_canonico)\]|módulo externo no permitido"):
+    estado_pre = dict(cmd.interpretador.contextos[-1].values)
+
+    with pytest.raises(PermissionError, match=USAR_RECHAZO_EXTERNO_MATCH) as excinfo:
         cmd.ejecutar_codigo('usar "holobit_sdk"')
+
+    mensaje = str(excinfo.value).lower()
+    assert "traceback" not in mensaje
+    assert cmd.interpretador.contextos[-1].values == estado_pre
+    simbolos = cmd.interpretador.contextos[-1].values
+    assert "holobit_sdk" not in simbolos
+    assert "crear_holobit" not in simbolos
+    assert "validar_holobit" not in simbolos
 
 
 def test_usar_holobit_expone_solo_api_cobra_facing(monkeypatch):

--- a/tests/unit/test_usar_public_contract.py
+++ b/tests/unit/test_usar_public_contract.py
@@ -23,6 +23,9 @@ from tests.integration.test_repl_usar_entrypoints_contract import (
 from tests.unit.test_backend_bootstrap_contract import _run_python_isolated
 
 
+USAR_RECHAZO_EXTERNO_MATCH = r"usar_error|no permitid[ao]|externo|fuera|no can[oó]nico|cat[aá]logo|m[oó]dulo"
+
+
 def _modulo_datos_publico_stub() -> ModuleType:
     mod = ModuleType("datos")
     mod.__all__ = ["filtrar", "mapear", "reducir"]
@@ -88,8 +91,17 @@ def test_rechazo_usar_modulos_externos_y_no_canonicos(monkeypatch, nombre):
     monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda nombre: (_ for _ in ()).throw(ModuleNotFoundError(nombre)))
 
     cmd = InteractiveCommand(InterpretadorCobra())
-    with pytest.raises(PermissionError, match=r"Importación no permitida|usar_error\[(modulo_fuera_catalogo_publico|modulo_no_canonico)\]|módulo externo no permitido"):
+    estado_pre = dict(cmd.interpretador.contextos[-1].values)
+
+    with pytest.raises(PermissionError, match=USAR_RECHAZO_EXTERNO_MATCH) as excinfo:
         cmd.ejecutar_codigo(f'usar "{nombre}"')
+
+    mensaje = str(excinfo.value).lower()
+    assert "traceback" not in mensaje
+    assert cmd.interpretador.contextos[-1].values == estado_pre
+    simbolos = cmd.interpretador.contextos[-1].values
+    assert nombre not in simbolos
+    assert nombre.replace("-", "_") not in simbolos
 
 
 def test_rechazo_internals_holobit_sdk(monkeypatch):
@@ -97,8 +109,18 @@ def test_rechazo_internals_holobit_sdk(monkeypatch):
 
     cmd = InteractiveCommand(InterpretadorCobra())
     cmd.interpretador.configurar_restriccion_usar_repl({**REPL_COBRA_MODULE_MAP, "holobit": "holobit"})
-    with pytest.raises(PermissionError, match=r"Importación no permitida|usar_error\[(modulo_fuera_catalogo_publico|modulo_no_canonico)\]|módulo externo no permitido"):
+    estado_pre = dict(cmd.interpretador.contextos[-1].values)
+
+    with pytest.raises(PermissionError, match=USAR_RECHAZO_EXTERNO_MATCH) as excinfo:
         cmd.ejecutar_codigo('usar "holobit_sdk"')
+
+    mensaje = str(excinfo.value).lower()
+    assert "traceback" not in mensaje
+    assert cmd.interpretador.contextos[-1].values == estado_pre
+    simbolos = cmd.interpretador.contextos[-1].values
+    assert "holobit_sdk" not in simbolos
+    assert "crear_holobit" not in simbolos
+    assert "validar_holobit" not in simbolos
 
 
 def test_usar_holobit_solo_api_cobra(monkeypatch):
@@ -171,7 +193,7 @@ def test_usar_rechaza_modulo_fuera_allowlist_aun_si_alias_map_lo_declara():
     class _NodoUsar:
         modulo = "numpy"
 
-    with pytest.raises(PermissionError, match=r"^Importación no permitida|^usar_error\[modulo_no_canonico\]"):
+    with pytest.raises(PermissionError, match=USAR_RECHAZO_EXTERNO_MATCH):
         interp.ejecutar_usar(_NodoUsar())
 
 


### PR DESCRIPTION
### Motivation

- Los tests que comprobaban rechazos de `usar` eran frágiles por coincidencias literales en mensajes de error que han cambiado; es necesario un patrón estable que cubra las variantes actuales.
- Mantener las aserciones de intención sobre la política `usar` (se lanza `PermissionError`, el contexto REPL no cambia, no aparece `traceback`, y los símbolos del módulo rechazado no quedan disponibles) sin tocar la implementación del lenguaje Cobra.

### Description

- Añadí una constante compartida `USAR_RECHAZO_EXTERNO_MATCH` con una expresión regular más flexible en `tests/unit/test_usar_public_contract.py` y `tests/integration/test_usar_public_contract_regression.py`.
- Reemplacé las expectativas exactas de `match` por `USAR_RECHAZO_EXTERNO_MATCH` en los lugares relevantes y actualicé las llamadas a `pytest.raises` para usar la constante.
- Añadí captura del estado previo `estado_pre = dict(...contextos[-1].values)` y comprobaciones posteriores que verifican ausencia de `traceback`, que el contexto no cambió y que el módulo rechazado no quedó expuesto como símbolo.
- Limitado el cambio exclusivamente a los dos ficheros de tests solicitados sin modificar Lexer, Parser, gramática, tokens, AST, transpiladores ni sintaxis Cobra.

### Testing

- Ejecuté `pytest tests/unit/test_usar_public_contract.py tests/integration/test_usar_public_contract_regression.py` y los tests afectados pasaron correctamente (ejecución exitosa de pytest).
- Ejecuté `git diff --check` y no se detectaron problemas en el diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40ea0b7010832792698aa1238f5307)