### PR TITLE
docs: aclarar contrato de `usar` en REPL para módulos externos/no canónicos

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ En REPL incremental, `usar` aplica una política **estricta** y explícita:
 - **Semántica aplicada:** modelo oficial plano del libro (`usar numero`), sin acceso por prefijo de módulo (`numero.funcion(...)`).
 - **Inyección de símbolos:** solo se inyectan símbolos públicos **callables** exportados por `__all__`.
 - **Filtrado:** se ignoran símbolos privados (`_...`) y cualquier símbolo no callable.
-- **Módulos externos en REPL estricto:** deben fallar con error claro: `módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)`.
+- **Módulos externos/no canónicos en REPL estricto:** deben rechazarse de forma controlada. El diagnóstico debe indicar que el módulo está fuera del catálogo, no permitido, no canónico o externo; no debe exponer traceback crudo ni activar fallback a instalación dinámica o carga externa.
 - Solo se aceptan módulos oficiales definidos en `REPL_COBRA_MODULE_MAP` y no hay fallback de instalación con `pip`.
 
 Ejemplos de comportamiento esperado en REPL:
@@ -930,7 +930,7 @@ usar "texto"
 imprimir(a_snake("HolaMundo"))  # ✅
 
 usar "numpy"
-imprimir(sqrt(4))  # ❌ módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)
+imprimir(sqrt(4))  # ❌ rechazado de forma controlada: módulo fuera del catálogo/no permitido/no canónico/externo
 ```
 
 > Nota: en Cobra REPL no hay dot-access para estos símbolos inyectados.


### PR DESCRIPTION
### Motivation
- Evitar fijar un mensaje de error literal en la documentación y sustituirlo por una formulación estable basada en propiedades para el rechazo de módulos externos o no canónicos en el REPL.
- Mantener el ejemplo negativo `usar "numpy"` pero describiendo el comportamiento esperado (rechazo controlado) en lugar de una cadena concreta de diagnóstico.

### Description
- Actualicé `README.md` en la sección "Contrato de `usar` en REPL" para reemplazar la línea que contenía el diagnóstico literal por una descripción basada en propiedades que exige rechazo controlado, diagnóstico claro (fuera del catálogo/no permitido/no canónico/externo), sin traceback crudo y sin fallback a instalación dinámica o carga externa. (`README.md` línea ~920).
- Ajusté el comentario del ejemplo negativo `usar "numpy"` para reflejar que el módulo debe ser "rechazado de forma controlada" en lugar de mostrar una cadena de error literal. (`README.md` línea ~933).
- No se realizaron cambios en código fuente ni en las rutas de implementación referenciadas (por ejemplo `src/pcobra/core/interpreter.py` o `src/pcobra/cobra/usar_policy.py`), solo se clarificó la documentación.

### Testing
- Ejecuté `rg -n "módulo externo no permitido en REPL estricto|usar \"numpy\"|Módulos externos/no canónicos|rechazado de forma controlada" README.md` para comprobar la presencia del nuevo texto, y la búsqueda tuvo éxito.
- Ejecuté `git diff --check` para validar que no hay errores de espacio o formato en el diff generado, y la comprobación tuvo éxito.
- Verifiqué el estado del repositorio con `git status --short` para confirmar el fichero modificado, y la verificación tuvo éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40eb0a752c83279a75aef5683f936f)