### PR TITLE
Adaptar descriptores de función Cobra como callbacks Python

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -2087,6 +2087,53 @@ class InterpretadorCobra:
         self.contextos[-1].define(nodo.nombre, funcion)
         return None
 
+    @staticmethod
+    def _es_descriptor_funcion_cobra(valor):
+        """Indica si ``valor`` es un descriptor runtime de función Cobra."""
+        return isinstance(valor, dict) and valor.get("tipo") == "funcion"
+
+    def _ejecutar_descriptor_funcion_cobra(self, funcion, argumentos):
+        """Ejecuta un descriptor de función Cobra con argumentos ya resueltos."""
+        parametros = funcion.get("parametros", funcion.get("params", []))
+        cuerpo = funcion.get("cuerpo", funcion.get("body", []))
+
+        if len(parametros) != len(argumentos):
+            raise TypeError(f"se esperaban {len(parametros)} argumentos")
+
+        entorno_capturado = funcion.get(
+            "scope_lexico", funcion.get("entorno", self.contextos[-1])
+        )
+        self.contextos.append(Environment(parent=entorno_capturado))
+        self.mem_contextos.append({})
+        try:
+            for nombre_param, valor in zip(parametros, argumentos):
+                indice = self.solicitar_memoria(1)
+                self.mem_contextos[-1][nombre_param] = (indice, 1)
+                self.contextos[-1].define(nombre_param, valor)
+
+            resultado = None
+            for instruccion in cuerpo:
+                resultado = self.ejecutar_nodo(instruccion)
+                if resultado is not None:
+                    break
+            return resultado
+        finally:
+            memoria_local = self.mem_contextos.pop()
+            for idx, tam in memoria_local.values():
+                self.liberar_memoria(idx, tam)
+            self.contextos.pop()
+
+    def _adaptar_callback_cobra(self, funcion):
+        """Convierte un descriptor de función Cobra en un callback Python mínimo."""
+
+        def callback(*argumentos):
+            return self._ejecutar_descriptor_funcion_cobra(funcion, list(argumentos))
+
+        nombre = funcion.get("nombre")
+        if nombre:
+            callback.__name__ = str(nombre)
+        return callback
+
     def ejecutar_llamada_funcion(self, nodo):
         """Ejecuta la invocación de una función, interna o del usuario."""
         emitir_salida_llamada = self.in_execution()
@@ -2111,6 +2158,8 @@ class InterpretadorCobra:
                 for arg in nodo.argumentos:
                     valor = self.evaluar_expresion(arg)
                     self._verificar_valor_contexto(valor)
+                    if self._es_descriptor_funcion_cobra(valor):
+                        valor = self._adaptar_callback_cobra(valor)
                     argumentos_resueltos.append(valor)
 
                 try:
@@ -2120,21 +2169,19 @@ class InterpretadorCobra:
                 self._verificar_valor_contexto(resultado)
                 return resultado
 
-            if not isinstance(funcion, dict) or funcion.get("tipo") != "funcion":
+            if not self._es_descriptor_funcion_cobra(funcion):
                 if emitir_salida_llamada:
                     print(f"Funci\u00f3n '{nodo.nombre}' no implementada")
                 return None
 
-            if len(funcion["parametros"]) != len(nodo.argumentos):
+            parametros = funcion.get("parametros", funcion.get("params", []))
+            if len(parametros) != len(nodo.argumentos):
                 if emitir_salida_llamada:
-                    print(
-                        f"Error: se esperaban {len(funcion['parametros'])} argumentos"
-                    )
+                    print(f"Error: se esperaban {len(parametros)} argumentos")
                 return None
 
-            contiene_yield = any(
-                self._contiene_yield(instr) for instr in funcion["cuerpo"]
-            )
+            cuerpo = funcion.get("cuerpo", funcion.get("body", []))
+            contiene_yield = any(self._contiene_yield(instr) for instr in cuerpo)
 
             def preparar_contexto():
                 # Los argumentos se evalúan en el contexto llamador antes de
@@ -2152,7 +2199,7 @@ class InterpretadorCobra:
                 )
                 self.contextos.append(Environment(parent=entorno_capturado))
                 self.mem_contextos.append({})
-                for nombre_param, valor in zip(funcion["parametros"], argumentos_resueltos):
+                for nombre_param, valor in zip(parametros, argumentos_resueltos):
                     indice = self.solicitar_memoria(1)
                     self.mem_contextos[-1][nombre_param] = (indice, 1)
                     self.contextos[-1].define(nombre_param, valor)
@@ -2169,7 +2216,7 @@ class InterpretadorCobra:
                 def generador():
                     preparar_contexto()
                     try:
-                        for instr in funcion["cuerpo"]:
+                        for instr in cuerpo:
                             if isinstance(instr, NodoYield):
                                 yield self.evaluar_expresion(instr.expresion)
                             else:
@@ -2184,7 +2231,7 @@ class InterpretadorCobra:
                 preparar_contexto()
                 try:
                     resultado = None
-                    for instruccion in funcion["cuerpo"]:
+                    for instruccion in cuerpo:
                         resultado = self.ejecutar_nodo(instruccion)
                         if resultado is not None:
                             break

--- a/tests/integration/test_usar_callback_cobra.py
+++ b/tests/integration/test_usar_callback_cobra.py
@@ -1,0 +1,102 @@
+from pcobra.core import interpreter as interpreter_module
+from pcobra.core.ast_nodes import (
+    NodoFuncion,
+    NodoIdentificador,
+    NodoLista,
+    NodoLlamadaFuncion,
+    NodoOperacionBinaria,
+    NodoRetorno,
+    NodoUsar,
+    NodoValor,
+)
+from pcobra.core.interpreter import InterpretadorCobra
+from pcobra.core.lexer import TipoToken, Token
+from pcobra.corelibs.coleccion import filtrar
+
+
+def _exports_filtrar():
+    return {
+        "simbolos": [("filtrar", filtrar)],
+        "metadata": {
+            "filtrar": {
+                "module": "coleccion_prueba",
+                "symbol": "filtrar",
+                "callable": True,
+                "public_api": True,
+                "sanitized": True,
+            }
+        },
+    }
+
+
+def test_usar_filtrar_acepta_funcion_cobra_como_callback(monkeypatch):
+    monkeypatch.setattr(interpreter_module, "usar_modulo", lambda *_args, **_kwargs: _exports_filtrar())
+    interp = InterpretadorCobra()
+
+    interp.ejecutar_nodo(NodoUsar("coleccion_prueba"))
+    interp.ejecutar_nodo(
+        NodoFuncion(
+            "es_par",
+            ["x"],
+            [
+                NodoRetorno(
+                    NodoOperacionBinaria(
+                        NodoOperacionBinaria(
+                            NodoIdentificador("x"),
+                            Token(TipoToken.MOD, "%"),
+                            NodoValor(2),
+                        ),
+                        Token(TipoToken.IGUAL, "=="),
+                        NodoValor(0),
+                    )
+                )
+            ],
+        )
+    )
+
+    resultado = interp.ejecutar_nodo(
+        NodoLlamadaFuncion(
+            "filtrar",
+            [
+                NodoLista([NodoValor(1), NodoValor(2), NodoValor(3), NodoValor(4)]),
+                NodoIdentificador("es_par"),
+            ],
+        )
+    )
+
+    assert resultado == [2, 4]
+
+
+def test_usar_filtrar_callback_cobra_respeta_scope_lexico(monkeypatch):
+    monkeypatch.setattr(interpreter_module, "usar_modulo", lambda *_args, **_kwargs: _exports_filtrar())
+    interp = InterpretadorCobra()
+
+    interp.ejecutar_nodo(NodoUsar("coleccion_prueba"))
+    interp.contextos[-1].define("limite", 2)
+    interp.ejecutar_nodo(
+        NodoFuncion(
+            "mayor_que_limite",
+            ["x"],
+            [
+                NodoRetorno(
+                    NodoOperacionBinaria(
+                        NodoIdentificador("x"),
+                        Token(TipoToken.MAYORQUE, ">"),
+                        NodoIdentificador("limite"),
+                    )
+                )
+            ],
+        )
+    )
+
+    resultado = interp.ejecutar_nodo(
+        NodoLlamadaFuncion(
+            "filtrar",
+            [
+                NodoLista([NodoValor(1), NodoValor(2), NodoValor(3), NodoValor(4)]),
+                NodoIdentificador("mayor_que_limite"),
+            ],
+        )
+    )
+
+    assert resultado == [3, 4]


### PR DESCRIPTION
### Motivation
- Permitir que los descriptores runtime de función Cobra (dict con `tipo == "funcion"`) se pasen como callbacks a funciones Python importadas vía `usar` sin cambiar Lexer/Parser/AST. 

### Description
- Añadido `InterpretadorCobra._es_descriptor_funcion_cobra` para identificar descriptores de función Cobra. 
- Añadidas las rutinas `_ejecutar_descriptor_funcion_cobra` y `_adaptar_callback_cobra` que reutilizan la semántica de llamadas Cobra (validación de aridad, captura del `scope_lexico`/`entorno`, creación/restauración de contexto local y liberación de memoria). 
- Integrada la adaptación en `ejecutar_llamada_funcion` para envolver valores-argumento que sean descriptores Cobra cuando el objetivo es `callable(funcion)`, manteniendo el comportamiento actual para argumentos no-descriptores. 
- Añadido soporte de compatibilidad para claves alternativas en descriptores (`params`/`body`) y para obtener `parametros`/`cuerpo` en la lógica existente. 
- Añadidos tests de integración en `tests/integration/test_usar_callback_cobra.py` que verifican pasar una función Cobra a `filtrar` y la captura de entorno léxico.

### Testing
- Compilación de módulo verificada con `python -m py_compile src/pcobra/core/interpreter.py` y pasó sin errores. 
- Ejecutado `pytest -q tests/integration/test_usar_callback_cobra.py` y todos los tests de ese archivo pasaron (`2 passed`). 
- Durante pruebas exploratorias combinando varios tests se observó un `INTERNALERROR` de pytest por `MemoryError` al formatear salida de fallo en una ejecución concreta, pero las comprobaciones específicas del cambio (compilación y los tests de integración añadidos) completaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40f02ed58c832788725f86b728429e)