### PR TITLE
test: cover filtrar with var-declared registros

### DIFF
--- a/tests/integration/test_core_data_filter_callback.py
+++ b/tests/integration/test_core_data_filter_callback.py
@@ -1,0 +1,37 @@
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+
+import pytest
+
+from pcobra.cobra.cli.execution_pipeline import PipelineInput, ejecutar_pipeline_explicito
+from pcobra.cobra.core.runtime import InterpretadorCobra
+
+
+@pytest.mark.integration
+def test_filtrar_acepta_tabla_declarada_con_var_antes_del_callback() -> None:
+    codigo = '''usar "datos"
+
+var registros = [[["activo", verdadero]], [["activo", falso]]]
+func condicion(fila):
+    retorno fila[0][1]
+fin
+
+imprimir(filtrar(registros, condicion))
+'''
+    salida = StringIO()
+    errores = StringIO()
+
+    with redirect_stdout(salida), redirect_stderr(errores):
+        ejecutar_pipeline_explicito(
+            PipelineInput(
+                codigo=codigo,
+                interpretador_cls=InterpretadorCobra,
+                safe_mode=False,
+                extra_validators=None,
+            )
+        )
+
+    evidencia = salida.getvalue() + errores.getvalue()
+    assert errores.getvalue() == ""
+    assert "Variable no declarada: registros" not in evidencia
+    assert "{'activo': True}" in salida.getvalue()


### PR DESCRIPTION
### Motivation
- Añadir una prueba de integración/runtime que verifique que declarar la tabla con `var registros = ...` antes de pasar una función callback a `filtrar` no produzca el error `Variable no declarada: registros`.

### Description
- Se añadió `tests/integration/test_core_data_filter_callback.py` con un caso que ejecuta código Cobra real vía `ejecutar_pipeline_explicito`, declara `registros` usando `var`, define `func condicion(fila): ...` y llama a `imprimir(filtrar(registros, condicion))`, comprobando que no aparece el mensaje de variable no declarada y que la salida contiene `{'activo': True}`.

### Testing
- Se ejecutó `pytest -q tests/integration/test_core_data_filter_callback.py` y pasó correctamente.
- Se ejecutó `pytest -q tests/integration/test_run_repl_equivalence.py::test_error_semantico_y_runtime_equivalen_en_tipo_y_mensaje --maxfail=1` para validar que el contrato de asignación simple no se ve afectado y también pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40f323540083278736a5284e88d4ce)