### PR TITLE
test: cover undeclared filtrar callback

### DIFF
--- a/tests/integration/test_core_data_filter_callback.py
+++ b/tests/integration/test_core_data_filter_callback.py
@@ -35,3 +35,41 @@ imprimir(filtrar(registros, condicion))
     assert errores.getvalue() == ""
     assert "Variable no declarada: registros" not in evidencia
     assert "{'activo': True}" in salida.getvalue()
+
+
+@pytest.mark.integration
+def test_filtrar_callback_no_declarado_falla_antes_de_stdlib(monkeypatch) -> None:
+    def filtrar_no_debe_ejecutarse(*_args, **_kwargs):
+        raise AssertionError("filtrar de la stdlib no debe ejecutarse")
+
+    monkeypatch.setattr(
+        "pcobra.corelibs.datos.filtrar",
+        filtrar_no_debe_ejecutarse,
+    )
+    codigo = '''usar "datos"
+
+var tabla = [["activo", verdadero]]
+imprimir(filtrar(tabla, callback_no_declarado))
+'''
+    salida = StringIO()
+    errores = StringIO()
+
+    with (
+        redirect_stdout(salida),
+        redirect_stderr(errores),
+        pytest.raises(NameError) as exc_info,
+    ):
+        ejecutar_pipeline_explicito(
+            PipelineInput(
+                codigo=codigo,
+                interpretador_cls=InterpretadorCobra,
+                safe_mode=False,
+                extra_validators=None,
+            )
+        )
+
+    mensaje = str(exc_info.value)
+    evidencia = "\n".join([mensaje, salida.getvalue(), errores.getvalue()])
+    assert "Variable no declarada: callback_no_declarado" in mensaje
+    assert "Traceback" not in evidencia
+    assert "filtrar de la stdlib no debe ejecutarse" not in evidencia


### PR DESCRIPTION
### Motivation
- Asegurar que una llamada a `filtrar(tabla, callback_no_declarado)` falla con el diagnóstico público de variable no declarada y que ese fallo ocurre antes de que se invoque cualquier implementación de la stdlib.
- Evitar que se muestre un traceback crudo al usuario cuando el identificador callback no existe.

### Description
- Añadido el test `test_filtrar_callback_no_declarado_falla_antes_de_stdlib` en `tests/integration/test_core_data_filter_callback.py` que reproduce `usar "datos"` y la llamada `filtrar(tabla, callback_no_declarado)`.
- El test parchea `pcobra.corelibs.datos.filtrar` con un centinela que fallaría si se ejecuta, para garantizar que la detección del identificador se produce antes de entrar en la stdlib.
- Ejecuta el pipeline mediante `ejecutar_pipeline_explicito` con captura de `stdout`/`stderr` y comprueba que se lanza `NameError` con el mensaje público esperado y que no aparece `Traceback` en la salida.

### Testing
- Ejecutado `pytest tests/integration/test_core_data_filter_callback.py -q` y los tests relevantes pasaron (`2 passed`, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40f4708f5c8327bf6d880b61b759a1)