### PR TITLE
test: cover usar missing public module error

### DIFF
--- a/tests/unit/test_usar_public_contract.py
+++ b/tests/unit/test_usar_public_contract.py
@@ -104,6 +104,26 @@ def test_rechazo_usar_modulos_externos_y_no_canonicos(monkeypatch, nombre):
     assert nombre.replace("-", "_") not in simbolos
 
 
+def test_usar_modulo_inexistente_falla_con_diagnostico_publico(monkeypatch):
+    monkeypatch.setattr(
+        core_usar_loader,
+        "obtener_modulo_cobra_oficial",
+        lambda nombre: (_ for _ in ()).throw(ModuleNotFoundError(nombre)),
+    )
+
+    cmd = InteractiveCommand(InterpretadorCobra())
+    estado_pre = dict(cmd.interpretador.contextos[-1].values)
+
+    with pytest.raises(PermissionError, match=USAR_RECHAZO_EXTERNO_MATCH) as excinfo:
+        cmd.ejecutar_codigo('usar "modulo_inexistente"')
+
+    mensaje = str(excinfo.value).lower()
+    assert "modulo_fuera_catalogo_publico" in mensaje or "usar_error[" in mensaje
+    assert "traceback" not in mensaje
+    assert cmd.interpretador.contextos[-1].values == estado_pre
+    assert "modulo_inexistente" not in cmd.interpretador.contextos[-1].values
+
+
 def test_rechazo_internals_holobit_sdk(monkeypatch):
     monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda nombre: _modulo_holobit_publico_stub() if nombre == "holobit" else (_ for _ in ()).throw(ModuleNotFoundError(nombre)))
 


### PR DESCRIPTION
### Motivation
- Asegurar que `usar "modulo_inexistente"` falla con el diagnóstico público esperado y no altera el contexto del intérprete, manteniendo la consistencia con el contrato de errores públicos de `usar`.

### Description
- Se añadió el test `test_usar_modulo_inexistente_falla_con_diagnostico_publico` en `tests/unit/test_usar_public_contract.py` que simula `ModuleNotFoundError` desde `obtener_modulo_cobra_oficial` y verifica que se lanza `PermissionError` coincidente con `USAR_RECHAZO_EXTERNO_MATCH`, que el mensaje no contiene `traceback` y que el contexto del intérprete no cambia.

### Testing
- Ejecutado `pytest tests/unit/test_usar_public_contract.py tests/integration/test_core_data_filter_callback.py -q` y todos los tests pasaron (22 passed) con una advertencia relacionada con import deprecado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40f5ab00a48327a2fa4f6e32949c05)