### PR TITLE
Agregar POC: callback Cobra para `datos.filtrar`

### DIFF
--- a/src/poc_data_filter_callback.cobra
+++ b/src/poc_data_filter_callback.cobra
@@ -1,0 +1,12 @@
+usar "datos"
+
+var tabla = [[["nombre", "Ada"], ["activo", verdadero]]]
+
+func esta_activo(fila):
+    retorno fila[1][1]
+fin
+
+imprimir(filtrar(tabla, esta_activo))
+
+# Salida esperada:
+# [{'nombre': 'Ada', 'activo': True}]


### PR DESCRIPTION
### Motivation
- Proveer un ejemplo mínimo que demuestre cómo pasar una función Cobra declarada como callback a la función `filtrar(tabla, condicion)` del módulo `datos`.
- Asegurar que el ejemplo respete el contrato tabular de `standard_library.datos.filtrar`, mostrando una fila convertible a `Registro` mediante pares clave/valor.

### Description
- Se añadió el archivo `src/poc_data_filter_callback.cobra` que importa el módulo con `usar "datos"`.
- Se crea una variable `tabla` con filas como listas de pares clave/valor para ser materializables por la stdlib. 
- Se declara la función Cobra `func esta_activo(fila): ... fin` y se pasa como callback a `filtrar` con la llamada `imprimir(filtrar(tabla, esta_activo))`.
- Se documenta la salida esperada como comentario en el propio archivo usando el formato permitido por el repositorio.

### Testing
- Se ejecutó `PYTHONPATH=$PWD python -m pcobra run src/poc_data_filter_callback.cobra` y el programa se ejecutó correctamente produciendo la salida esperada; la prueba automática local pasó.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40f6a0adb08327b1b8a1b1becfaf8c)