### PR TITLE
Usar pipeline canónico para ejecución en GUI

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -1514,11 +1514,22 @@ def normalizar_codigo(codigo: str | None) -> str:
 
 def ejecutar_codigo(codigo: str) -> str:
     """Ejecuta código Cobra y captura la salida impresa."""
+    from pcobra.cobra.cli.execution_pipeline import (
+        PipelineInput,
+        ejecutar_pipeline_explicito,
+    )
+
     deps = require_gui_dependencies()
     buffer = io.StringIO()
     with redirect_stdout(buffer), redirect_stderr(buffer):
-        _tokens, ast = analizar_codigo(codigo)
-        deps["InterpretadorCobra"]().ejecutar_ast(ast)
+        ejecutar_pipeline_explicito(
+            PipelineInput(
+                codigo=codigo,
+                interpretador_cls=deps["InterpretadorCobra"],
+                safe_mode=True,
+                extra_validators=None,
+            )
+        )
     return buffer.getvalue()
 
 


### PR DESCRIPTION
### Motivation
- Evitar que el IDLE gráfico ejecute el AST por una ruta manual y con posible estado divergente respecto a la CLI. 
- Unificar el comportamiento de asignaciones top-level y entorno de ejecución para que la GUI reutilice el pipeline canónico compartido por la CLI.

### Description
- En `ejecutar_codigo()` se importan localmente `PipelineInput` y `ejecutar_pipeline_explicito` desde `pcobra.cobra.cli.execution_pipeline` y se reemplaza la secuencia `analizar_codigo(...)` + `InterpretadorCobra().ejecutar_ast(ast)` por una llamada a `ejecutar_pipeline_explicito(PipelineInput(...))` con `safe_mode=True` y `extra_validators=None` manteniendo la captura de `stdout`/`stderr` con `redirect_stdout`/`redirect_stderr`.
- No se modificó la lógica de `ejecutar_o_transpilar(...)`, `transpilar_codigo`, ni los helpers de tokens/AST, ni se tocaron Lexer/Parser/AST/transpiladores; la gestión de errores continúa pasando por `formatear_error(...)`.

### Testing
- Ejecuté `pytest -q tests/unit/test_gui_runtime.py::test_ejecutar_transpilar_tokens_y_ast` y la prueba pasó.
- Ejecuté `pytest -q tests/unit/test_gui_runtime.py::test_formatear_error_lexico_y_sintaxis tests/unit/test_gui_runtime.py::test_formatear_error_no_masking_si_fallan_dependencias tests/unit/test_gui_runtime.py::test_formatear_error_lexico_y_sintactico_sin_recargar_dependencias` y las pruebas pasaron.
- Ejecuté `pytest -q tests/unit/test_gui_runtime.py` y todo el módulo pasó (`72 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a411f2fc0008327806b2bb28df0b1f8)