### PR TITLE
Add GUI runtime execution scope regressions

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -1512,6 +1512,33 @@ def normalizar_codigo(codigo: str | None) -> str:
     return codigo or ""
 
 
+def _analizar_codigo_gui_con_declaraciones_implicitas(codigo: str) -> Any:
+    """Analiza código GUI permitiendo primeras asignaciones como declaraciones.
+
+    El editor/IDLE acepta fragmentos cortos como ``x = 1`` para facilitar la
+    ejecución interactiva. El parser conserva esas asignaciones como mutaciones;
+    aquí las marcamos como declaración solo cuando introducen un nombre nuevo en
+    el nivel superior, sin alterar el error de lectura de variables inexistentes.
+    """
+    from pcobra.cobra.cli.execution_pipeline import analizar_codigo
+
+    ast = analizar_codigo(codigo)
+    declarados: set[str] = set()
+    for nodo in ast if isinstance(ast, list) else []:
+        if type(nodo).__name__ != "NodoAsignacion":
+            continue
+        nombre = getattr(nodo, "identificador", getattr(nodo, "variable", None))
+        if not isinstance(nombre, str):
+            continue
+        if getattr(nodo, "declaracion", False) or getattr(nodo, "inferencia", False):
+            declarados.add(nombre)
+            continue
+        if nombre not in declarados:
+            setattr(nodo, "declaracion", True)
+            declarados.add(nombre)
+    return ast
+
+
 def ejecutar_codigo(codigo: str) -> str:
     """Ejecuta código Cobra y captura la salida impresa."""
     from pcobra.cobra.cli.execution_pipeline import (
@@ -1528,7 +1555,8 @@ def ejecutar_codigo(codigo: str) -> str:
                 interpretador_cls=deps["InterpretadorCobra"],
                 safe_mode=True,
                 extra_validators=None,
-            )
+            ),
+            analizar_codigo_fn=_analizar_codigo_gui_con_declaraciones_implicitas,
         )
     return buffer.getvalue()
 

--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -1,0 +1,26 @@
+import pytest
+
+from pcobra.gui import runtime
+
+
+def test_ejecutar_codigo_permite_asignacion_numerica_en_mismo_fragmento():
+    salida = runtime.ejecutar_codigo("x = 123\nimprimir(x)")
+
+    assert "123" in salida
+
+
+def test_ejecutar_codigo_permite_asignacion_texto_en_mismo_fragmento():
+    salida = runtime.ejecutar_codigo('x = "hola"\nimprimir(x)')
+
+    assert "hola" in salida
+
+
+def test_ejecutar_codigo_permite_asignacion_lista_en_mismo_fragmento():
+    salida = runtime.ejecutar_codigo("numeros = [1, 2, 3, 4]\nimprimir(numeros)")
+
+    assert "[1, 2, 3, 4]" in salida
+
+
+def test_ejecutar_codigo_variable_inexistente_sigue_fallando():
+    with pytest.raises(NameError, match="Variable no declarada"):
+        runtime.ejecutar_codigo("imprimir(no_existe)")

--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -214,52 +214,46 @@ def test_parse_missing_target_detecta_simbolo_faltante_en_import_local():
 def test_ejecutar_codigo_usa_dependencias_gui_y_captura_stdout_stderr(monkeypatch):
     calls = []
 
-    class FakeLexer:
-        def __init__(self, codigo: str) -> None:
-            calls.append(("lexer_init", codigo))
-
-        def tokenizar(self) -> list[str]:
-            print("salida desde lexer")
-            calls.append(("tokenizar",))
-            return ["TOKEN"]
-
-    class FakeParser:
-        def __init__(self, tokens: list[str]) -> None:
-            calls.append(("parser_init", tokens))
-
-        def parsear(self) -> str:
-            calls.append(("parsear",))
-            return "AST"
+    class FakeValidador:
+        _metadata_simbolos_usar = {}
 
     class FakeInterpretadorCobra:
-        def ejecutar_ast(self, ast: str) -> None:
+        def __init__(self, **kwargs) -> None:
+            calls.append(("interpreter_init", kwargs))
+            self._usar_symbol_metadata = {}
+            self._validador = FakeValidador()
+
+        def configurar_restriccion_usar_repl(self, alias_map):
+            calls.append(("configurar_restriccion_usar_repl", alias_map))
+
+        def asegurar_estado_runtime_inicial(self) -> None:
+            calls.append(("asegurar_estado_runtime_inicial",))
+
+        def ejecutar_ast(self, ast) -> None:
             import sys
 
-            print(f"stdout ast={ast}")
+            print(f"stdout ast_type={type(ast).__name__}")
             print("stderr capturado", file=sys.stderr)
-            calls.append(("ejecutar_ast", ast))
+            calls.append(("ejecutar_ast", type(ast).__name__))
 
     monkeypatch.setattr(
         runtime,
         "require_gui_dependencies",
         lambda: {
-            "Lexer": FakeLexer,
-            "Parser": FakeParser,
+            "Lexer": object,
+            "Parser": object,
             "InterpretadorCobra": FakeInterpretadorCobra,
         },
     )
 
-    salida = runtime.ejecutar_codigo("mostrar 1")
+    salida = runtime.ejecutar_codigo("imprimir(1)")
 
-    assert calls == [
-        ("lexer_init", "mostrar 1"),
-        ("tokenizar",),
-        ("parser_init", ["TOKEN"]),
-        ("parsear",),
-        ("ejecutar_ast", "AST"),
-    ]
-    assert "salida desde lexer" in salida
-    assert "stdout ast=AST" in salida
+    assert calls[0] == (
+        "interpreter_init",
+        {"safe_mode": True, "extra_validators": None, "main_file": None},
+    )
+    assert ("ejecutar_ast", "list") in calls
+    assert "stdout ast_type=list" in salida
     assert "stderr capturado" in salida
 
 


### PR DESCRIPTION
### Motivation
- Permitir que fragmentos cortos escritos desde la GUI/IDLE que contienen una asignación seguida de su uso (p. ej. `x = 123\nimprimir(x)`) se ejecuten correctamente sin cambiar el contrato existente sobre errores de variable no declarada.
- Añadir pruebas de regresión que verifiquen ejecuciones con números, strings, listas y que `imprimir(no_existe)` siga fallando con `NameError`.

### Description
- Añadida la función internal ` _analizar_codigo_gui_con_declaraciones_implicitas(codigo: str) -> Any` que marca la primera asignación top-level como `declaracion` en el AST para permitir ejecuciones interactivas desde la GUI.  
- `ejecutar_codigo` ahora pasa `analizar_codigo_fn=_analizar_codigo_gui_con_declaraciones_implicitas` al pipeline canónico para usar el análisis adaptado a snippets de editor.  
- Actualizada la prueba existente `test_ejecutar_codigo_usa_dependencias_gui_y_captura_stdout_stderr` para inyectar un `FakeInterpretadorCobra` compatible con la fábrica canónica del pipeline.  
- Añadido `tests/gui/test_gui_runtime_execution_scope.py` con cuatro pruebas reales (sin mocks de Lexer/Parser/Interpretador) que cubren números, strings, listas y el caso de variable inexistente.

### Testing
- Ejecutado `pytest -q tests/gui/test_gui_runtime_execution_scope.py tests/gui/test_runtime_file_helpers.py::test_ejecutar_codigo_usa_dependencias_gui_y_captura_stdout_stderr` y la suite objetivo pasó exitosamente.  
- Ejecutado `pytest -q tests/gui/test_runtime_file_helpers.py tests/gui/test_gui_runtime_execution_scope.py` y todos los tests relacionados pasaron (`36 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4125ba3200832784cfd21525d0974a)