### PR TITLE
Mock del pipeline canónico en test GUI para evitar acoplamiento frágil

### DIFF
--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -214,46 +214,35 @@ def test_parse_missing_target_detecta_simbolo_faltante_en_import_local():
 def test_ejecutar_codigo_usa_dependencias_gui_y_captura_stdout_stderr(monkeypatch):
     calls = []
 
-    class FakeValidador:
-        _metadata_simbolos_usar = {}
-
     class FakeInterpretadorCobra:
-        def __init__(self, **kwargs) -> None:
-            calls.append(("interpreter_init", kwargs))
-            self._usar_symbol_metadata = {}
-            self._validador = FakeValidador()
+        pass
 
-        def configurar_restriccion_usar_repl(self, alias_map):
-            calls.append(("configurar_restriccion_usar_repl", alias_map))
+    def fake_ejecutar_pipeline_explicito(pipeline_input, **kwargs):
+        import sys
 
-        def asegurar_estado_runtime_inicial(self) -> None:
-            calls.append(("asegurar_estado_runtime_inicial",))
-
-        def ejecutar_ast(self, ast) -> None:
-            import sys
-
-            print(f"stdout ast_type={type(ast).__name__}")
-            print("stderr capturado", file=sys.stderr)
-            calls.append(("ejecutar_ast", type(ast).__name__))
+        calls.append(("pipeline_codigo", pipeline_input.codigo))
+        print("stdout capturado")
+        print("stderr capturado", file=sys.stderr)
+        return None, None
 
     monkeypatch.setattr(
         runtime,
         "require_gui_dependencies",
-        lambda: {
-            "Lexer": object,
-            "Parser": object,
-            "InterpretadorCobra": FakeInterpretadorCobra,
-        },
+        lambda: {"InterpretadorCobra": FakeInterpretadorCobra},
     )
 
-    salida = runtime.ejecutar_codigo("imprimir(1)")
+    from pcobra.cobra.cli import execution_pipeline
 
-    assert calls[0] == (
-        "interpreter_init",
-        {"safe_mode": True, "extra_validators": None, "main_file": None},
+    monkeypatch.setattr(
+        execution_pipeline,
+        "ejecutar_pipeline_explicito",
+        fake_ejecutar_pipeline_explicito,
     )
-    assert ("ejecutar_ast", "list") in calls
-    assert "stdout ast_type=list" in salida
+
+    salida = runtime.ejecutar_codigo("mostrar 1")
+
+    assert calls == [("pipeline_codigo", "mostrar 1")]
+    assert "stdout capturado" in salida
     assert "stderr capturado" in salida
 
 


### PR DESCRIPTION
### Motivation
- Evitar que la prueba dependa de detalles internos obsoletos del flujo `Lexer -> Parser -> ejecutar_ast` que podían bloquear correcciones futuras.
- Mantener la cobertura que verifica que `ejecutar_codigo()` captura la salida combinada de `stdout` y `stderr`.

### Description
- Reemplacé el mock acoplado al intérprete y expectativas internas por un `FakeInterpretadorCobra` mínimo para satisfacer dependencias de GUI.
- Mockeé el punto de entrada canónico importado por `ejecutar_codigo()` usando `execution_pipeline.ejecutar_pipeline_explicito` y lo hice imprimir en `stdout` y `stderr` desde el mock.
- Cambié la llamada del test a `runtime.ejecutar_codigo("mostrar 1")` y añadí una aserción mínima que verifica que el pipeline recibió exactamente el código fuente `"mostrar 1"`.
- Eliminé las aserciones sobre inicialización interna del intérprete y el tipo de AST para reducir fragilidad del test.

### Testing
- Ejecuté `pytest tests/gui/test_runtime_file_helpers.py::test_ejecutar_codigo_usa_dependencias_gui_y_captura_stdout_stderr -q` y la prueba pasó.
- Ejecuté `pytest tests/gui/test_runtime_file_helpers.py -q` y todo el archivo de tests pasó (`32 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a412ba95f8c832789e3d0505bffc428)