### PR TITLE
Parametrizar pruebas de alcance de ejecución del runtime GUI

### DIFF
--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -3,22 +3,20 @@ import pytest
 from pcobra.gui import runtime
 
 
-def test_ejecutar_codigo_permite_asignacion_numerica_en_mismo_fragmento():
-    salida = runtime.ejecutar_codigo("x = 123\nimprimir(x)")
+@pytest.mark.parametrize(
+    ("codigo", "salida_esperada"),
+    [
+        ("x = 123\nimprimir(x)", "123"),
+        ('x = "hola"\nimprimir(x)', "hola"),
+        ("numeros = [1, 2, 3, 4]\nimprimir(numeros)", "[1, 2, 3, 4]"),
+    ],
+)
+def test_ejecutar_codigo_permite_asignaciones_en_mismo_fragmento(
+    codigo, salida_esperada
+):
+    salida = runtime.ejecutar_codigo(codigo)
 
-    assert "123" in salida
-
-
-def test_ejecutar_codigo_permite_asignacion_texto_en_mismo_fragmento():
-    salida = runtime.ejecutar_codigo('x = "hola"\nimprimir(x)')
-
-    assert "hola" in salida
-
-
-def test_ejecutar_codigo_permite_asignacion_lista_en_mismo_fragmento():
-    salida = runtime.ejecutar_codigo("numeros = [1, 2, 3, 4]\nimprimir(numeros)")
-
-    assert "[1, 2, 3, 4]" in salida
+    assert salida_esperada in salida
 
 
 def test_ejecutar_codigo_variable_inexistente_sigue_fallando():


### PR DESCRIPTION
### Motivation
- Hacer las pruebas de regresión sobre el scope de ejecución del runtime más concisas y explícitas para cubrir asignaciones de número, texto y lista y conservar la comprobación de variable inexistente.

### Description
- Reemplacé tres tests individuales por un test parametrizado en `tests/gui/test_gui_runtime_execution_scope.py` que verifica `"x = 123\nimprimir(x)"` -> `123`, `"x = "hola"\nimprimir(x)"` -> `hola` y `"numeros = [1, 2, 3, 4]\nimprimir(numeros)"` -> `[1, 2, 3, 4]`.
- Mantengo el test separado que asegura que `runtime.ejecutar_codigo("imprimir(no_existe)")` lanza `NameError` con el texto `Variable no declarada`.
- No se realizaron cambios en la implementación del runtime, solo en la organización del test.

### Testing
- Ejecuté `python -m pytest tests/gui/test_gui_runtime_execution_scope.py -q` y todas las pruebas pasaron con éxito.
- Resultado de la ejecución: `4 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4165f66dbc832791b37c1d9de5fa6d)