### PR TITLE
CobraHub: add .co packaging layer, CLI commands and IDLE integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1109,10 +1109,29 @@ Por defecto el nivel de registro es `INFO`; con `-v` o más se cambia a `DEBUG`:
 cobra -v run programa.co
 ```
 
-Los archivos con extensión ``.cobra`` representan paquetes completos, mientras que los scripts individuales se guardan como ``.co``.
+Los archivos fuente Cobra pueden usar ``.cobra`` o ``.co`` según el flujo histórico del proyecto. Los paquetes publicables de CobraHub también usan extensión ``.co`` como contenedor ZIP con manifiesto ``cobra.pkg.json``; la distinción se realiza en la capa de herramientas, no en el Lexer ni en el Parser.
 
 El subcomando `docs` ejecuta `sphinx-apidoc` para generar la documentación de la API antes de compilar el HTML.
 El subcomando `gui` abre el IDLE gráfico principal y requiere tener instalado Flet.
+
+### Paquetes `.co` y CobraHub
+
+CobraHub funciona ahora como una capa de herramientas independiente para crear, construir, validar, inspeccionar, extraer, publicar, buscar e instalar paquetes `.co`. Un paquete `.co` es un ZIP con manifiesto `cobra.pkg.json`, checksums SHA-256 y estructura de carpetas conservada; puede contener archivos `.cobra`, documentación Markdown, texto, `Dockerfile` y recursos. Esta funcionalidad no cambia la sintaxis de Cobra ni requiere tocar Lexer o Parser.
+
+Comandos nuevos:
+
+```bash
+cobra paquete crear mi_paquete --nombre demo --version 0.1.0
+cobra paquete construir mi_paquete dist/demo.co
+cobra paquete validar dist/demo.co
+cobra paquete inspeccionar dist/demo.co
+cobra paquete extraer dist/demo.co ./vendor/demo
+cobra hub publicar dist/demo.co
+cobra hub buscar demo
+cobra hub instalar demo --destino ./vendor/demo
+```
+
+Los comandos legacy de `paquete crear` con salida posicional y `paquete instalar` se mantienen como alias compatibles. El IDLE (`cobra gui`) reutiliza la misma lógica de `pcobra.cobra.packaging` para las acciones **Crear paquete**, **Abrir paquete**, **Validar paquete**, **Construir paquete** y **Publicar CobraHub**.
 
 ### IDLE gráfico
 

--- a/docs/cobrahub_paquetes.md
+++ b/docs/cobrahub_paquetes.md
@@ -1,0 +1,30 @@
+# CobraHub y paquetes `.co`
+
+## Auditoría inicial
+
+- La implementación previa de CobraHub estaba en `src/pcobra/cobra/cli/cobrahub_client.py` y se centraba en publicar/descargar módulos sueltos `.co` mediante endpoints `/modulos`.
+- La integración del IDLE está en `src/pcobra/gui/idle.py`, con lógica compartida en `src/pcobra/gui/runtime.py`.
+- Antes de esta evolución, `src/pcobra/cobra/cli/commands/package_cmd.py` creaba ZIPs simples con `cobra.pkg`, solo aceptaba `.co` y no preservaba documentación, Dockerfile ni recursos arbitrarios.
+- La documentación contenía una inconsistencia: indicaba que `.cobra` representaba paquetes completos y `.co` scripts individuales, mientras otras secciones, tests y ejemplos usan ambos como fuentes Cobra. Ahora los paquetes publicables `.co` se gestionan como contenedores en la capa de herramientas.
+
+## Diseño
+
+La funcionalidad se implementa en `pcobra.cobra.packaging`, una capa independiente que no importa ni ejecuta Lexer/Parser. El paquete `.co` es un archivo ZIP con:
+
+- `cobra.pkg.json` como manifiesto.
+- Lista de archivos conservando carpetas.
+- Checksums SHA-256 por archivo.
+- Soporte para `.cobra`, `.co`, `.md`, `.txt`, `Dockerfile` y recursos.
+
+## Tareas implementadas
+
+1. Crear módulo independiente de empaquetado.
+2. Sustituir el comando `cobra paquete` por acciones crear/validar/construir/inspeccionar/extraer e instalar como alias legacy.
+3. Añadir `cobra hub publicar|buscar|instalar` para paquetes.
+4. Ampliar el cliente CobraHub con publicación, búsqueda, instalación y caché local.
+5. Añadir acciones del IDLE que reutilizan la misma lógica de empaquetado.
+6. Añadir pruebas unitarias de construcción, validación, inspección y extracción.
+
+## Por qué no se toca Lexer ni Parser
+
+El cambio opera exclusivamente sobre archivos, ZIPs, manifiestos y transporte CobraHub. No añade tokens, reglas gramaticales ni sintaxis Cobra. Los archivos fuente incluidos se tratan como bytes hasta que el usuario decida ejecutarlos con los comandos existentes.

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -137,6 +137,7 @@ class AppConfig:
         CommandClassRoute("pcobra.cobra.cli.commands.docs_cmd", "DocsCommand"),
         CommandClassRoute("pcobra.cobra.cli.commands.empaquetar_cmd", "EmpaquetarCommand"),
         CommandClassRoute("pcobra.cobra.cli.commands.package_cmd", "PaqueteCommand"),
+        CommandClassRoute("pcobra.cobra.cli.commands.hub_cmd", "HubCommand"),
         CommandClassRoute("pcobra.cobra.cli.commands.crear_cmd", "CrearCommand"),
         CommandClassRoute("pcobra.cobra.cli.commands.init_cmd", "InitCommand"),
         CommandClassRoute("pcobra.cobra.cli.commands.jupyter_cmd", "JupyterCommand"),
@@ -163,6 +164,8 @@ class AppConfig:
         CommandClassRoute("pcobra.cobra.cli.commands_v2.build_cmd", "BuildCommandV2"),
         CommandClassRoute("pcobra.cobra.cli.commands_v2.test_cmd", "TestCommandV2"),
         CommandClassRoute("pcobra.cobra.cli.commands_v2.mod_cmd", "ModCommandV2"),
+        CommandClassRoute("pcobra.cobra.cli.commands.package_cmd", "PaqueteCommand"),
+        CommandClassRoute("pcobra.cobra.cli.commands.hub_cmd", "HubCommand"),
         # `repl` forma parte del contrato público oficial de CLI v2 (no alias legacy).
         CommandClassRoute("pcobra.cobra.cli.commands_v2.repl_cmd", "ReplCommandV2"),
     ]

--- a/src/pcobra/cobra/cli/cobrahub_client.py
+++ b/src/pcobra/cobra/cli/cobrahub_client.py
@@ -356,3 +356,101 @@ def descargar_modulo(
 
 __all__ = ["CobraHubClient", "publicar_modulo", "descargar_modulo"]
 
+
+# Extensiones de CobraHub para paquetes .co. Se mantienen junto al cliente legacy
+# para conservar compatibilidad con publicar/descargar módulos individuales.
+def _package_cache_dir() -> Path:
+    cache = Path(os.environ.get("COBRAHUB_CACHE_DIR", str(Path.home() / ".cobra" / "hub" / "cache"))).expanduser()
+    cache.mkdir(parents=True, exist_ok=True)
+    return cache
+
+
+def _install_dir() -> Path:
+    dest = Path(os.environ.get("COBRAHUB_INSTALL_DIR", str(Path.home() / ".cobra" / "packages"))).expanduser()
+    dest.mkdir(parents=True, exist_ok=True)
+    return dest
+
+
+def _publicar_paquete(self: CobraHubClient, ruta: str) -> bool:
+    from pcobra.cobra.packaging import validar_paquete
+
+    if not self._validar_url():
+        return False
+    try:
+        info = validar_paquete(ruta)
+        checksum = info.checksum
+        with open(ruta, "rb") as f:
+            with self.session.post(
+                f"{self.base_url}/paquetes",
+                files={"file": f},
+                data={"metadata": json_dumps(info.manifest)},
+                headers={"X-Content-Checksum": checksum, "Idempotency-Key": checksum},
+                timeout=(self.CONNECT_TIMEOUT, self.READ_TIMEOUT),
+            ) as response:
+                response.raise_for_status()
+        cache_path = _package_cache_dir() / Path(ruta).name
+        if Path(ruta).resolve() != cache_path.resolve():
+            import shutil
+            shutil.copy2(ruta, cache_path)
+        mostrar_info(_("Paquete publicado correctamente"))
+        return True
+    except Exception as e:
+        logger.error(f"Error publicando paquete: {e}")
+        mostrar_error(_("Error publicando paquete: {err}").format(err=str(e)))
+        return False
+
+
+def json_dumps(value):
+    import json
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _buscar_paquetes(self: CobraHubClient, consulta: str) -> list[dict]:
+    if not self._validar_url():
+        return []
+    try:
+        with self.session.get(
+            f"{self.base_url}/paquetes",
+            params={"q": consulta},
+            timeout=(self.CONNECT_TIMEOUT, self.READ_TIMEOUT),
+        ) as response:
+            response.raise_for_status()
+            data = response.json() if hasattr(response, "json") else []
+        if isinstance(data, dict):
+            return list(data.get("results", []))
+        return list(data)
+    except Exception as e:
+        logger.error(f"Error buscando paquetes: {e}")
+        mostrar_error(_("Error buscando paquetes: {err}").format(err=str(e)))
+        return []
+
+
+def _instalar_paquete(self: CobraHubClient, nombre: str, destino: str | None = None) -> bool:
+    from pcobra.cobra.packaging import extraer_paquete
+
+    if not self._validar_nombre_modulo(nombre) or not self._validar_url():
+        return False
+    cache_path = _package_cache_dir() / f"{nombre}.co"
+    try:
+        with self.session.get(
+            f"{self.base_url}/paquetes/{urllib.parse.quote(nombre)}",
+            timeout=(self.CONNECT_TIMEOUT, self.READ_TIMEOUT),
+            stream=True,
+        ) as response:
+            response.raise_for_status()
+            with open(cache_path, "wb") as out:
+                for chunk in response.iter_content(chunk_size=self.CHUNK_SIZE):
+                    out.write(chunk)
+        install_path = Path(destino).expanduser() if destino else _install_dir() / nombre
+        extraer_paquete(cache_path, install_path)
+        mostrar_info(_("Paquete instalado en {dest}").format(dest=install_path))
+        return True
+    except Exception as e:
+        logger.error(f"Error instalando paquete: {e}")
+        mostrar_error(_("Error instalando paquete: {err}").format(err=str(e)))
+        return False
+
+
+CobraHubClient.publicar_paquete = _publicar_paquete  # type: ignore[attr-defined]
+CobraHubClient.buscar_paquetes = _buscar_paquetes  # type: ignore[attr-defined]
+CobraHubClient.instalar_paquete = _instalar_paquete  # type: ignore[attr-defined]

--- a/src/pcobra/cobra/cli/commands/hub_cmd.py
+++ b/src/pcobra/cobra/cli/commands/hub_cmd.py
@@ -1,0 +1,42 @@
+from argparse import Namespace
+from pathlib import Path
+from typing import Any
+
+from pcobra.cobra.cli.cobrahub_client import CobraHubClient
+from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
+from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
+
+
+class HubCommand(BaseCommand):
+    """Publica, busca e instala paquetes en CobraHub."""
+
+    name = "hub"
+
+    def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
+        parser = subparsers.add_parser(self.name, help=_("Gestiona paquetes en CobraHub"))
+        sub = parser.add_subparsers(dest="accion", required=True)
+        pub = sub.add_parser("publicar", help=_("Publica un paquete .co"))
+        pub.add_argument("paquete", type=Path)
+        buscar = sub.add_parser("buscar", help=_("Busca paquetes"))
+        buscar.add_argument("consulta")
+        inst = sub.add_parser("instalar", help=_("Instala un paquete"))
+        inst.add_argument("nombre")
+        inst.add_argument("--destino", type=Path)
+        parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args: Namespace) -> int:
+        client = CobraHubClient()
+        if args.accion == "publicar":
+            return 0 if client.publicar_paquete(str(args.paquete)) else 1
+        if args.accion == "buscar":
+            results = client.buscar_paquetes(args.consulta)
+            for item in results:
+                mostrar_info(f"{item.get('name', item.get('nombre', 'paquete'))} {item.get('version', '')}".strip())
+            return 0
+        if args.accion == "instalar":
+            return 0 if client.instalar_paquete(args.nombre, str(args.destino) if args.destino else None) else 1
+        mostrar_error(_("Acción de hub no reconocida"))
+        return 1

--- a/src/pcobra/cobra/cli/commands/package_cmd.py
+++ b/src/pcobra/cobra/cli/commands/package_cmd.py
@@ -1,208 +1,95 @@
-import logging
-import zipfile
-from argparse import ArgumentParser, Namespace
+from argparse import Namespace
 from pathlib import Path
-from typing import List, Any
+from typing import Any
 
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
+from pcobra.cobra.packaging import (
+    DEFAULT_INSTALL_DIR,
+    construir_paquete,
+    crear_paquete,
+    extraer_paquete,
+    inspeccionar_paquete,
+    validar_paquete,
+)
 
-# Constantes
-MAX_ZIP_SIZE = 1024 * 1024 * 50  # 50MB
-MAX_FILES = 100
-ALLOWED_EXTENSIONS = {".co"}
-MODULES_PATH = Path.home() / ".cobra" / "modules"
 
 class PaqueteCommand(BaseCommand):
-    """Crea e instala paquetes Cobra."""
+    """Gestiona paquetes Cobra .co sin modificar la sintaxis del lenguaje."""
+
     name = "paquete"
 
     def register_subparser(self, subparsers: Any) -> CustomArgumentParser:
-        """Registra los argumentos del subcomando.
-        
-        Args:
-            subparsers: Objeto para registrar subcomandos
-            
-        Returns:
-            CustomArgumentParser: Parser configurado para este subcomando
-        """
-        parser = subparsers.add_parser(self.name, help=_("Gestiona paquetes Cobra"))
+        parser = subparsers.add_parser(self.name, help=_("Gestiona paquetes Cobra .co"))
         sub = parser.add_subparsers(dest="accion", required=True)
-        
-        crear = sub.add_parser("crear", help=_("Crea un paquete"))
-        crear.add_argument("fuente", help=_("Carpeta con archivos .co"), type=Path)
-        crear.add_argument("paquete", help=_("Archivo de paquete"), type=Path)
-        crear.add_argument("--nombre", default="paquete", help=_("Nombre"))
-        crear.add_argument("--version", default="0.1", help=_("Version"))
-        
-        inst = sub.add_parser("instalar", help=_("Instala un paquete"))
-        inst.add_argument("paquete", help=_("Archivo de paquete"), type=Path)
-        
+
+        crear = sub.add_parser("crear", help=_("Crea la estructura de un paquete"))
+        crear.add_argument("fuente", type=Path, help=_("Directorio del paquete"))
+        crear.add_argument("paquete", nargs="?", type=Path, help=_("Alias legacy: salida .co opcional"))
+        crear.add_argument("--nombre", default=None, help=_("Nombre del paquete"))
+        crear.add_argument("--version", default="0.1.0", help=_("Versión"))
+
+        validar = sub.add_parser("validar", help=_("Valida un paquete .co"))
+        validar.add_argument("paquete", type=Path)
+
+        construir = sub.add_parser("construir", help=_("Construye un paquete .co"))
+        construir.add_argument("fuente", type=Path)
+        construir.add_argument("salida", nargs="?", type=Path)
+        construir.add_argument("--nombre", default=None)
+        construir.add_argument("--version", default=None)
+
+        inspeccionar = sub.add_parser("inspeccionar", help=_("Inspecciona el contenido de un paquete"))
+        inspeccionar.add_argument("paquete", type=Path)
+
+        extraer = sub.add_parser("extraer", help=_("Extrae un paquete .co"))
+        extraer.add_argument("paquete", type=Path)
+        extraer.add_argument("destino", type=Path)
+
+        inst = sub.add_parser("instalar", help=_("Alias legacy de extraer a ~/.cobra/packages"))
+        inst.add_argument("paquete", type=Path)
+        inst.add_argument("--destino", type=Path, default=DEFAULT_INSTALL_DIR)
+
         parser.set_defaults(cmd=self)
         return parser
 
     def run(self, args: Namespace) -> int:
-        """Ejecuta la lógica del comando.
-        
-        Args:
-            args: Argumentos parseados del comando
-            
-        Returns:
-            int: 0 si exitoso, 1 si hay error
-        """
         try:
             if args.accion == "crear":
-                return self._crear(args.fuente, args.paquete, args.nombre, args.version)
-            elif args.accion == "instalar":
-                return self._instalar(args.paquete)
-            else:
-                mostrar_error(_("Acción de paquete no reconocida"))
-                return 1
-        except Exception as e:
-            logging.error(f"Error no manejado: {str(e)}", exc_info=True)
-            mostrar_error(_("Error inesperado: {error}").format(error=str(e)))
+                nombre = args.nombre or args.fuente.name
+                manifest = crear_paquete(args.fuente, nombre=nombre, version=args.version)
+                if args.paquete:
+                    destino = construir_paquete(args.fuente, args.paquete, nombre=nombre, version=args.version)
+                    mostrar_info(_("Paquete creado en {dest}").format(dest=destino))
+                else:
+                    mostrar_info(_("Estructura de paquete creada: {manifest}").format(manifest=manifest))
+                return 0
+            if args.accion == "validar":
+                validar_paquete(args.paquete)
+                mostrar_info(_("Paquete válido: {pkg}").format(pkg=args.paquete))
+                return 0
+            if args.accion == "construir":
+                destino = construir_paquete(args.fuente, args.salida, nombre=args.nombre, version=args.version)
+                mostrar_info(_("Paquete construido en {dest}").format(dest=destino))
+                return 0
+            if args.accion == "inspeccionar":
+                info = inspeccionar_paquete(args.paquete)
+                mostrar_info(_("Paquete: {name} {version}").format(name=info.manifest.get("name"), version=info.manifest.get("version")))
+                for file in info.files:
+                    mostrar_info(f" - {file}")
+                mostrar_info(_("SHA256: {checksum}").format(checksum=info.checksum))
+                return 0
+            if args.accion == "extraer":
+                destino = extraer_paquete(args.paquete, args.destino)
+                mostrar_info(_("Paquete extraído en {dest}").format(dest=destino))
+                return 0
+            if args.accion == "instalar":
+                destino = extraer_paquete(args.paquete, args.destino)
+                mostrar_info(_("Paquete instalado en {dest}").format(dest=destino))
+                return 0
+            mostrar_error(_("Acción de paquete no reconocida"))
             return 1
-
-    @staticmethod
-    def _validar_zip(path: Path) -> None:
-        """Valida el tamaño y contenido del archivo ZIP.
-        
-        Args:
-            path: Ruta al archivo ZIP
-            
-        Raises:
-            ValueError: Si el archivo excede los límites permitidos
-        """
-        if path.stat().st_size > MAX_ZIP_SIZE:
-            raise ValueError(_("El archivo excede el tamaño máximo permitido ({size} MB)").format(
-                size=MAX_ZIP_SIZE//1024//1024))
-
-    @staticmethod
-    def _validar_modulos(mods: List[Path]) -> List[Path]:
-        """Valida la lista de módulos y garantiza que sean rutas.
-
-        Args:
-            mods: Lista de rutas (o cadenas) a módulos
-
-        Returns:
-            List[Path]: Lista normalizada de rutas a módulos
-
-        Raises:
-            ValueError: Si no hay módulos o hay demasiados
-        """
-        paths = [m if isinstance(m, Path) else Path(m) for m in mods]
-        if len(paths) > MAX_FILES:
-            raise ValueError(_("Demasiados archivos en el paquete (máximo {max})").format(max=MAX_FILES))
-        if not paths:
-            raise ValueError(_("No se encontraron módulos"))
-        return paths
-
-    @staticmethod
-    def _crear(src: Path, pkg: Path, nombre: str, version: str) -> int:
-        """Crea un nuevo paquete.
-        
-        Args:
-            src: Ruta a la carpeta fuente
-            pkg: Ruta al archivo de paquete a crear
-            nombre: Nombre del paquete
-            version: Versión del paquete
-            
-        Returns:
-            int: 0 si exitoso, 1 si hay error
-        """
-        try:
-            if not src.is_dir():
-                mostrar_error(_("Directorio inválido"))
-                return 1
-
-            if pkg.exists():
-                mostrar_error(_("El archivo de paquete ya existe"))
-                return 1
-
-            mods = [f for f in src.iterdir() if f.suffix in ALLOWED_EXTENSIONS]
-            mods = PaqueteCommand._validar_modulos(mods)
-
-            mod_list = ", ".join(f'"{m.name}"' for m in mods)
-            contenido = (
-                f'[paquete]\nnombre = "{nombre}"\nversion = "{version}"\n\n'
-                f"[modulos]\narchivos = [{mod_list}]\n"
-            )
-
-            with zipfile.ZipFile(pkg, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-                for m in mods:
-                    zf.write(m, arcname=m.name)
-                zf.writestr("cobra.pkg", contenido)
-
-            mostrar_info(_("Paquete creado en {dest}").format(dest=pkg))
-            return 0
-
-        except ValueError as e:
-            mostrar_error(str(e))
-            return 1
-        except OSError as e:
-            mostrar_error(_("Error de E/S al crear paquete: {error}").format(error=str(e)))
-            return 1
-        except zipfile.BadZipFile as e:
-            mostrar_error(_("Error en archivo ZIP: {error}").format(error=str(e)))
-            return 1
-
-    @staticmethod
-    def _instalar(pkg: Path) -> int:
-        """Instala un paquete.
-        
-        Args:
-            pkg: Ruta al archivo de paquete
-            
-        Returns:
-            int: 0 si exitoso, 1 si hay error
-        """
-        try:
-            if not pkg.exists():
-                mostrar_error(_("Paquete no encontrado"))
-                return 1
-
-            PaqueteCommand._validar_zip(pkg)
-            modules_dir = Path(MODULES_PATH).resolve()
-            modules_dir.mkdir(parents=True, exist_ok=True)
-
-            with zipfile.ZipFile(pkg) as zf:
-                file_list = [name for name in zf.namelist() if name.endswith(".co")]
-                module_paths = [Path(name) for name in file_list]
-                module_paths = PaqueteCommand._validar_modulos(module_paths)
-
-                for name, rel_path in zip(file_list, module_paths):
-                    # Validar y normalizar ruta
-                    try:
-                        candidate = (modules_dir / rel_path).resolve()
-                        candidate.relative_to(modules_dir)
-                    except (ValueError, RuntimeError):
-                        mostrar_error(_("Nombre de archivo no válido en el paquete"))
-                        return 1
-
-                    dest = candidate
-                    if dest.exists() and dest.is_symlink():
-                        mostrar_error(
-                            _("El destino {dest} es un enlace simbólico").format(dest=dest)
-                        )
-                        return 1
-
-                    dest.parent.mkdir(parents=True, exist_ok=True)
-                    with zf.open(name) as src, open(dest, "wb") as out:
-                        out.write(src.read())
-
-            mostrar_info(
-                _("Paquete instalado en {dest}").format(dest=MODULES_PATH)
-            )
-            return 0
-
-        except ValueError as e:
-            mostrar_error(str(e))
-            return 1
-        except OSError as e:
-            mostrar_error(_("Error de E/S al instalar paquete: {error}").format(error=str(e)))
-            return 1
-        except zipfile.BadZipFile as e:
-            mostrar_error(_("Error en archivo ZIP: {error}").format(error=str(e)))
+        except Exception as exc:
+            mostrar_error(_("Error gestionando paquete: {error}").format(error=str(exc)))
             return 1

--- a/src/pcobra/cobra/cli/public_command_policy.py
+++ b/src/pcobra/cobra/cli/public_command_policy.py
@@ -6,12 +6,12 @@ from os import environ
 from typing import Iterable
 
 # `repl` es comando público oficial en UI v2; no debe tratarse como alias legacy.
-PUBLIC_COMMANDS_CONTRACT: tuple[str, ...] = ("run", "build", "test", "mod", "repl")
+PUBLIC_COMMANDS_CONTRACT: tuple[str, ...] = ("run", "build", "test", "mod", "repl", "paquete", "hub")
 PUBLIC_COMMANDS: tuple[str, ...] = PUBLIC_COMMANDS_CONTRACT
 if PUBLIC_COMMANDS != PUBLIC_COMMANDS_CONTRACT:
     raise RuntimeError(
         "Contrato público inválido: PUBLIC_COMMANDS debe mantenerse en "
-        "('run', 'build', 'test', 'mod', 'repl')."
+        "('run', 'build', 'test', 'mod', 'repl', 'paquete', 'hub')."
     )
 INTERNAL_COMMANDS: tuple[str, ...] = (
     "legacy",
@@ -23,7 +23,7 @@ INTERNAL_COMMANDS: tuple[str, ...] = (
 
 COMMAND_VISIBILITY_MATRIX_MARKDOWN = """| Clase | Comandos |
 |---|---|
-| Públicos (UI v2) | run, build, test, mod, repl |
+| Públicos (UI v2) | run, build, test, mod, repl, paquete, hub |
 | Internos (UI v2 / development) | legacy, debug, devops |
 | Legacy públicos (UI v1) | *(ninguno; reservado a `development`)* |
 | Legacy internos (UI v1) | *(ninguno)* |

--- a/src/pcobra/cobra/packaging.py
+++ b/src/pcobra/cobra/packaging.py
@@ -1,0 +1,162 @@
+"""Herramientas independientes para paquetes Cobra ``.co``.
+
+Este módulo no participa en Lexer ni Parser: opera sobre archivos y metadatos.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MANIFEST_NAME = "cobra.pkg.json"
+LEGACY_MANIFEST_NAME = "cobra.pkg"
+PACKAGE_FORMAT = "cobra-package-v1"
+DEFAULT_CACHE_DIR = Path.home() / ".cobra" / "hub" / "cache"
+DEFAULT_INSTALL_DIR = Path.home() / ".cobra" / "packages"
+ALLOWED_TEXT_SUFFIXES = {".cobra", ".co", ".md", ".markdown", ".txt", ".json", ".toml", ".yaml", ".yml"}
+MAX_PACKAGE_SIZE = 50 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class PackageInspection:
+    path: Path
+    manifest: dict[str, Any]
+    files: list[str]
+    checksum: str
+
+
+def _safe_name(name: str) -> str:
+    normalized = name.strip().replace(" ", "-")
+    if not normalized or any(part in {"..", ""} for part in normalized.split("/")):
+        raise ValueError("Nombre de paquete inválido")
+    return normalized
+
+
+def _sha256_file(path: Path) -> str:
+    sha = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            sha.update(chunk)
+    return sha.hexdigest()
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _iter_package_files(source: Path) -> list[Path]:
+    ignored = {".git", "__pycache__", ".pytest_cache"}
+    files: list[Path] = []
+    for path in source.rglob("*"):
+        if any(part in ignored for part in path.relative_to(source).parts):
+            continue
+        if path.is_file():
+            files.append(path)
+    return sorted(files, key=lambda p: p.relative_to(source).as_posix())
+
+
+def crear_paquete(source: str | Path, *, nombre: str, version: str = "0.1.0") -> Path:
+    """Crea una estructura base de paquete Cobra en ``source``."""
+    root = Path(source)
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "src").mkdir(exist_ok=True)
+    manifest = {
+        "format": PACKAGE_FORMAT,
+        "name": _safe_name(nombre),
+        "version": version,
+        "files": [],
+        "checksums": {},
+    }
+    manifest_path = root / MANIFEST_NAME
+    if not manifest_path.exists():
+        manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    readme = root / "README.md"
+    if not readme.exists():
+        readme.write_text(f"# {nombre}\n\nPaquete Cobra.\n", encoding="utf-8")
+    return manifest_path
+
+
+def construir_paquete(source: str | Path, output: str | Path | None = None, *, nombre: str | None = None, version: str | None = None) -> Path:
+    """Construye un archivo ``.co`` ZIP con manifiesto e integridad."""
+    root = Path(source).resolve()
+    if not root.is_dir():
+        raise ValueError("La fuente del paquete debe ser un directorio")
+    manifest_path = root / MANIFEST_NAME
+    manifest: dict[str, Any]
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    else:
+        manifest = {"format": PACKAGE_FORMAT, "name": nombre or root.name, "version": version or "0.1.0"}
+    manifest["format"] = PACKAGE_FORMAT
+    manifest["name"] = _safe_name(str(nombre or manifest.get("name") or root.name))
+    manifest["version"] = str(version or manifest.get("version") or "0.1.0")
+
+    files = [p for p in _iter_package_files(root) if p.relative_to(root).as_posix() != MANIFEST_NAME]
+    checksums = {p.relative_to(root).as_posix(): _sha256_file(p) for p in files}
+    manifest["files"] = list(checksums)
+    manifest["checksums"] = checksums
+    dest = Path(output) if output else root.parent / f"{manifest['name']}-{manifest['version']}.co"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(MANIFEST_NAME, json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
+        for file in files:
+            zf.write(file, file.relative_to(root).as_posix())
+    return dest
+
+
+def inspeccionar_paquete(package: str | Path) -> PackageInspection:
+    pkg = Path(package)
+    if not pkg.exists():
+        raise FileNotFoundError(f"Paquete no encontrado: {pkg}")
+    if pkg.stat().st_size > MAX_PACKAGE_SIZE:
+        raise ValueError("El paquete excede el tamaño máximo permitido")
+    with zipfile.ZipFile(pkg) as zf:
+        names = zf.namelist()
+        if MANIFEST_NAME not in names:
+            raise ValueError("El paquete no contiene manifiesto cobra.pkg.json")
+        manifest = json.loads(zf.read(MANIFEST_NAME).decode("utf-8"))
+    return PackageInspection(pkg, manifest, names, _sha256_file(pkg))
+
+
+def validar_paquete(package: str | Path) -> PackageInspection:
+    inspection = inspeccionar_paquete(package)
+    checksums = inspection.manifest.get("checksums", {})
+    with zipfile.ZipFile(inspection.path) as zf:
+        for name in inspection.files:
+            path = Path(name)
+            if path.is_absolute() or ".." in path.parts:
+                raise ValueError(f"Ruta insegura en paquete: {name}")
+        for name, expected in checksums.items():
+            if name not in inspection.files:
+                raise ValueError(f"Archivo declarado ausente: {name}")
+            actual = _sha256_bytes(zf.read(name))
+            if actual != expected:
+                raise ValueError(f"Integridad fallida para {name}")
+    return inspection
+
+
+def extraer_paquete(package: str | Path, destination: str | Path) -> Path:
+    inspection = validar_paquete(package)
+    dest = Path(destination).resolve()
+    dest.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(inspection.path) as zf:
+        for name in inspection.files:
+            target = (dest / name).resolve()
+            target.relative_to(dest)
+            if name.endswith("/"):
+                target.mkdir(parents=True, exist_ok=True)
+            else:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(name) as src, target.open("wb") as out:
+                    shutil.copyfileobj(src, out)
+    return dest
+
+
+def verificar_integridad(package: str | Path) -> bool:
+    validar_paquete(package)
+    return True

--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -820,6 +820,64 @@ def main(page: "ft.Page"):
         if archivo_activo_permite_accion_cobra(runtime.ACCION_CORRECCION):
             correccion_runtime_handler(e)
 
+
+    def crear_paquete_handler(e):
+        if project_root is None:
+            salida.value = "Abre o crea un proyecto antes de crear un paquete."
+        else:
+            manifest = runtime.idle_crear_paquete(project_root, project_root.name)
+            salida.value = f"Paquete inicializado: {manifest}"
+            reconstruir_arbol()
+        actualizar_pagina()
+
+    def abrir_paquete_handler(e):
+        try:
+            if ruta_input.value:
+                destino = project_root or runtime.resolver_workspace_root_idle()
+                runtime.idle_abrir_paquete(Path(ruta_input.value), destino)
+                salida.value = f"Paquete abierto en: {destino}"
+                reconstruir_arbol()
+            else:
+                salida.value = "Indica la ruta del paquete .co en el campo de ruta."
+        except Exception as exc:
+            salida.value = f"Error abriendo paquete: {exc}"
+        actualizar_pagina()
+
+    def validar_paquete_handler(e):
+        try:
+            paquete = Path(ruta_input.value) if ruta_input.value else None
+            if paquete is None:
+                salida.value = "Indica la ruta del paquete .co en el campo de ruta."
+            else:
+                runtime.idle_validar_paquete(paquete)
+                salida.value = f"Paquete válido: {paquete}"
+        except Exception as exc:
+            salida.value = f"Paquete inválido: {exc}"
+        actualizar_pagina()
+
+    def construir_paquete_handler(e):
+        try:
+            if project_root is None:
+                salida.value = "Abre o crea un proyecto antes de construir un paquete."
+            else:
+                paquete = runtime.idle_construir_paquete(project_root)
+                salida.value = f"Paquete construido: {paquete}"
+        except Exception as exc:
+            salida.value = f"Error construyendo paquete: {exc}"
+        actualizar_pagina()
+
+    def publicar_paquete_handler(e):
+        try:
+            paquete = Path(ruta_input.value) if ruta_input.value else None
+            if paquete is None:
+                salida.value = "Indica la ruta del paquete .co en el campo de ruta."
+            else:
+                ok = runtime.idle_publicar_paquete(paquete)
+                salida.value = "Paquete publicado en CobraHub." if ok else "No se pudo publicar el paquete."
+        except Exception as exc:
+            salida.value = f"Error publicando paquete: {exc}"
+        actualizar_pagina()
+
     reconstruir_arbol()
     sincronizar_estado_visual()
 
@@ -867,6 +925,11 @@ def main(page: "ft.Page"):
             runtime.flet_elevated_button(
                 ft, "Crear carpeta", on_click=crear_carpeta_handler
             ),
+            runtime.flet_elevated_button(ft, "Crear paquete", on_click=crear_paquete_handler),
+            runtime.flet_elevated_button(ft, "Abrir paquete", on_click=abrir_paquete_handler),
+            runtime.flet_elevated_button(ft, "Validar paquete", on_click=validar_paquete_handler),
+            runtime.flet_elevated_button(ft, "Construir paquete", on_click=construir_paquete_handler),
+            runtime.flet_elevated_button(ft, "Publicar CobraHub", on_click=publicar_paquete_handler),
             runtime.flet_elevated_button(
                 ft, "Eliminar proyecto", on_click=eliminar_proyecto_handler
             ),

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -1614,3 +1614,36 @@ def gui_target_choices() -> tuple[str, ...]:
             f"official={official_targets}; public={PUBLIC_BACKENDS}"
         )
     return deps["target_cli_choices"](set(PUBLIC_BACKENDS) & set(deps["TRANSPILERS"]))
+
+# Acciones de empaquetado CobraHub reutilizadas por CLI e IDLE. Estas funciones
+# son una capa de herramientas sobre archivos, no invocan Lexer ni Parser.
+def idle_crear_paquete(project_root: str | Path, nombre: str, version: str = "0.1.0") -> Path:
+    from pcobra.cobra.packaging import crear_paquete
+
+    root = validar_project_root_idle(project_root)
+    return crear_paquete(root, nombre=nombre, version=version)
+
+
+def idle_validar_paquete(paquete: str | Path):
+    from pcobra.cobra.packaging import validar_paquete
+
+    return validar_paquete(paquete)
+
+
+def idle_construir_paquete(project_root: str | Path, salida: str | Path | None = None) -> Path:
+    from pcobra.cobra.packaging import construir_paquete
+
+    root = validar_project_root_idle(project_root)
+    return construir_paquete(root, salida)
+
+
+def idle_abrir_paquete(paquete: str | Path, destino: str | Path) -> Path:
+    from pcobra.cobra.packaging import extraer_paquete
+
+    return extraer_paquete(paquete, destino)
+
+
+def idle_publicar_paquete(paquete: str | Path) -> bool:
+    from pcobra.cobra.cli.cobrahub_client import CobraHubClient
+
+    return CobraHubClient().publicar_paquete(str(paquete))

--- a/tests/unit/test_cobra_packaging.py
+++ b/tests/unit/test_cobra_packaging.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from pcobra.cobra.packaging import (
+    MANIFEST_NAME,
+    construir_paquete,
+    crear_paquete,
+    extraer_paquete,
+    inspeccionar_paquete,
+    validar_paquete,
+)
+
+
+def test_paquete_cobra_conserva_estructura_y_recursos(tmp_path: Path):
+    proyecto = tmp_path / "demo"
+    crear_paquete(proyecto, nombre="demo", version="1.0.0")
+    (proyecto / "src" / "main.cobra").write_text("imprimir('hola')\n", encoding="utf-8")
+    (proyecto / "README.md").write_text("# Demo\n", encoding="utf-8")
+    (proyecto / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    (proyecto / "assets").mkdir()
+    (proyecto / "assets" / "dato.txt").write_text("recurso", encoding="utf-8")
+
+    paquete = construir_paquete(proyecto, tmp_path / "demo.co")
+
+    info = validar_paquete(paquete)
+    assert info.manifest["format"] == "cobra-package-v1"
+    assert MANIFEST_NAME in info.files
+    assert "src/main.cobra" in info.files
+    assert "Dockerfile" in info.files
+    assert "assets/dato.txt" in info.files
+
+    inspeccion = inspeccionar_paquete(paquete)
+    assert inspeccion.checksum
+
+    destino = extraer_paquete(paquete, tmp_path / "instalado")
+    assert (destino / "src" / "main.cobra").read_text(encoding="utf-8") == "imprimir('hola')\n"


### PR DESCRIPTION
### Motivation

- Proveer un sistema de empaquetado `.co` capaz de contener código Cobra, documentación, Dockerfile y recursos sin tocar la sintaxis del lenguaje.  
- Mantener el Lexer y el Parser intactos y ofrecer la nueva funcionalidad como una capa de herramientas independiente.  
- Integrar la misma lógica de empaquetado entre la CLI y el IDLE y ampliar CobraHub para publicar/buscar/instalar paquetes.

### Description

- Añade un módulo independiente `pcobra.cobra.packaging` que implementa `crear_paquete`, `construir_paquete`, `inspeccionar_paquete`, `validar_paquete`, `extraer_paquete` y `verificar_integridad` con manifiesto `cobra.pkg.json` y checksums SHA-256 (archivo añadido: `src/pcobra/cobra/packaging.py`).  
- Extiende la CLI con subcomandos modernos en `cobra paquete` (`crear`, `validar`, `construir`, `inspeccionar`, `extraer`, `instalar` alias legacy) y añade `cobra hub publicar|buscar|instalar` (archivos añadidos/modificados: `src/pcobra/cobra/cli/commands/package_cmd.py`, `src/pcobra/cobra/cli/commands/hub_cmd.py`, `src/pcobra/cobra/cli/cobrahub_client.py`, y cambios de registro en `src/pcobra/cobra/cli/cli.py` y `src/pcobra/cobra/cli/public_command_policy.py`).  
- Amplía el cliente CobraHub para manejar paquetes `.co` (publicación, búsqueda, instalación y caché local) sin eliminar la compatibilidad con las operaciones de módulos existentes.  
- Integra acciones en el IDLE que reutilizan la misma capa `pcobra.cobra.packaging` (`idle_crear_paquete`, `idle_validar_paquete`, `idle_construir_paquete`, `idle_abrir_paquete`, `idle_publicar_paquete`) y añade botones/handlers en la GUI (`src/pcobra/gui/runtime.py`, `src/pcobra/gui/idle.py`).  
- Documentación y pruebas: documentación técnica añadida (`docs/cobrahub_paquetes.md`), README actualizado con instrucciones de uso y una prueba unitaria que cubre construcción/validación/inspección/extracción (`tests/unit/test_cobra_packaging.py`).

### Testing

- Ejecutado `pytest tests/unit/test_cobra_packaging.py` y la prueba unitaria pasó (`1 passed`).  
- Ejecutado `pytest tests/unit/test_cobra_packaging.py tests/cli/test_cli_imports.py tests/gui/test_runtime_file_helpers.py` y la batería integrada pasó (`37 passed, 1 warning`).  
- Validación estática/byte-compile de los nuevos módulos realizada con `compileall` y sin errores de importación en las rutas afectadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a435d53f1208327bd3edb13c47401f6)