### PR TITLE
docs: actualizar formato de paquetes Cobra

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,7 +1116,7 @@ El subcomando `gui` abre el IDLE gráfico principal y requiere tener instalado F
 
 ### Paquetes `.co` y CobraHub
 
-CobraHub funciona ahora como una capa de herramientas independiente para crear, construir, validar, inspeccionar, extraer, publicar, buscar e instalar paquetes `.co`. Un paquete `.co` es un ZIP con manifiesto `cobra.pkg.json`, checksums SHA-256 y estructura de carpetas conservada; puede contener archivos `.cobra`, documentación Markdown, texto, `Dockerfile` y recursos. Esta funcionalidad no cambia la sintaxis de Cobra ni requiere tocar Lexer o Parser.
+CobraHub funciona ahora como una capa de herramientas independiente para crear, construir, validar, inspeccionar, extraer, publicar, buscar e instalar paquetes `.co`. Un paquete `.co` es un ZIP con manifiesto `cobra.pkg.json`, checksums SHA-256 y estructura de carpetas conservada; puede contener archivos `.cobra`, documentación Markdown, texto, `Dockerfile` y recursos. Esta funcionalidad no cambia la sintaxis de Cobra ni requiere tocar Lexer o Parser. Consulta la guía actualizada de paquetes en [`docs/frontend/paquetes.rst`](docs/frontend/paquetes.rst) y el resumen de diseño en [`docs/cobrahub_paquetes.md`](docs/cobrahub_paquetes.md).
 
 Comandos nuevos:
 

--- a/docs/cobrahub_paquetes.md
+++ b/docs/cobrahub_paquetes.md
@@ -1,5 +1,7 @@
 # CobraHub y paquetes `.co`
 
+La guía de uso actualizada para crear, construir, validar, inspeccionar y extraer paquetes está en [`docs/frontend/paquetes.rst`](frontend/paquetes.rst).
+
 ## Auditoría inicial
 
 - La implementación previa de CobraHub estaba en `src/pcobra/cobra/cli/cobrahub_client.py` y se centraba en publicar/descargar módulos sueltos `.co` mediante endpoints `/modulos`.

--- a/docs/frontend/paquetes.rst
+++ b/docs/frontend/paquetes.rst
@@ -1,36 +1,98 @@
 Paquetes Cobra
 ==============
 
-Un paquete Cobra es un archivo comprimido que agrupa varios módulos ``.co`` y un
-manifest llamado ``cobra.pkg``. Este manifest utiliza sintaxis TOML para
-especificar los metadatos del paquete.
+Un paquete Cobra publicable usa la extensión ``.co`` y se distribuye como un
+contenedor ZIP. El contenedor conserva la estructura de carpetas del proyecto,
+incluye un manifiesto ``cobra.pkg.json`` y registra checksums SHA-256 para los
+archivos empaquetados.
 
-Estructura de ``cobra.pkg``
----------------------------
+Este formato pertenece a la capa de herramientas de empaquetado y CobraHub: no
+modifica la sintaxis del lenguaje ni requiere cambios en el Lexer o el Parser.
+Los archivos fuente Cobra pueden seguir usando ``.cobra`` o ``.co``; cuando
+``.co`` se usa como paquete publicable, la CLI lo trata como un ZIP con
+metadatos.
 
-.. code-block:: toml
+Contenido soportado
+-------------------
 
-   [paquete]
-   nombre = "demo"
-   version = "0.1"
+Los paquetes ``.co`` pueden incluir:
 
-   [modulos]
-   archivos = ["main.co", "util.co"]
+* archivos fuente ``.cobra`` y ``.co``;
+* documentación ``.md``;
+* archivos de texto ``.txt``;
+* ``Dockerfile``;
+* recursos adicionales preservando sus rutas relativas.
 
-Creación e instalación
-----------------------
+Manifiesto ``cobra.pkg.json``
+-----------------------------
 
-Para crear un paquete desde una carpeta que contenga archivos ``.co`` ejecuta:
+El manifiesto ``cobra.pkg.json`` describe los metadatos del paquete y la lista de
+archivos incluidos. Cada entrada se acompaña de su checksum SHA-256 para que las
+operaciones de validación e inspección puedan detectar cambios o corrupción del
+contenedor.
+
+Ejemplo simplificado:
+
+.. code-block:: json
+
+   {
+     "nombre": "demo",
+     "version": "0.1.0",
+     "archivos": [
+       {
+         "ruta": "main.co",
+         "sha256": "..."
+       },
+       {
+         "ruta": "README.md",
+         "sha256": "..."
+       }
+     ]
+   }
+
+Flujo recomendado
+-----------------
+
+Crear la estructura inicial del paquete:
 
 .. code-block:: bash
 
-   cobra paquete crear src demo.cobra --nombre=demo --version=0.1
+   cobra paquete crear mi_paquete --nombre demo --version 0.1.0
 
-El archivo resultante ``demo.cobra`` puede instalarse en el directorio de
-módulos predeterminado con:
+Construir el contenedor publicable ``.co``:
 
 .. code-block:: bash
 
-   cobra paquete instalar demo.cobra
+   cobra paquete construir mi_paquete dist/demo.co
 
-Los módulos incluidos estarán disponibles para ser importados con ``import``.
+Validar checksums y manifiesto:
+
+.. code-block:: bash
+
+   cobra paquete validar dist/demo.co
+
+Inspeccionar los metadatos y archivos incluidos:
+
+.. code-block:: bash
+
+   cobra paquete inspeccionar dist/demo.co
+
+Extraer el paquete en una carpeta local:
+
+.. code-block:: bash
+
+   cobra paquete extraer dist/demo.co ./vendor/demo
+
+Compatibilidad con comandos legacy
+----------------------------------
+
+Los comandos legacy, como ``cobra paquete instalar`` y las variantes antiguas de
+``cobra paquete crear`` con salida posicional, se conservan como alias de
+compatibilidad. Para paquetes nuevos, el formato recomendado es el contenedor
+``.co`` con manifiesto ``cobra.pkg.json`` y checksums SHA-256.
+
+Véase también
+-------------
+
+* :doc:`../cobrahub_paquetes`
+* La sección "Paquetes ``.co`` y CobraHub" del ``README.md`` del repositorio.


### PR DESCRIPTION
### Motivation

- Actualizar la documentación para reflejar el nuevo formato de paquetes publicables: contenedor ZIP con extensión `.co`, manifiesto `cobra.pkg.json` y checksums SHA-256 en lugar del antiguo `cobra.pkg` en TOML y extensión `.cobra`.
- Normalizar los ejemplos de uso de la CLI al flujo actual de empaquetado y operaciones: crear, construir, validar, inspeccionar y extraer.
- Mantener compatibilidad documental indicando que comandos legacy como `cobra paquete instalar` se conservan como alias, pero que el formato recomendado es `.co` con `cobra.pkg.json`.

### Description

- Reescrito `docs/frontend/paquetes.rst` para describir el formato `.co` como ZIP con `cobra.pkg.json`, checksums SHA-256, y los tipos de fichero soportados (`.cobra`, `.co`, `.md`, `.txt`, `Dockerfile` y recursos). 
- Sustituido el bloque de ejemplo y la estructura antigua por el nuevo flujo CLI con los comandos `cobra paquete crear mi_paquete --nombre demo --version 0.1.0`, `cobra paquete construir mi_paquete dist/demo.co`, `cobra paquete validar dist/demo.co`, `cobra paquete inspeccionar dist/demo.co` y `cobra paquete extraer dist/demo.co ./vendor/demo`.
- Añadida la nota de compatibilidad explicando la conservación de alias legacy como `cobra paquete instalar` y la recomendación del nuevo formato `.co`.
- Actualizados los cruces de referencia en `README.md` y en `docs/cobrahub_paquetes.md` para apuntar a la nueva guía en `docs/frontend/paquetes.rst` y al resumen de diseño de CobraHub.

### Testing

- Ejecutado `git diff --check` para comprobar problemas de espacio/formatos y no se detectaron errores.
- Generado el doctree con `docutils.publish_doctree` sobre `docs/frontend/paquetes.rst`, lo que produjo la estructura válida del documento (se registró una advertencia por el rol interpretado desconocido `doc`).
- Intentado construir la documentación con `python -m sphinx -b html docs/frontend /tmp/pcobra-docs-frontend -W --keep-going`, que falló por una dependencia ausente (`PlantUML`) requerida por `docs/frontend/conf.py` y por tanto no se completó la generación HTML en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a436757c2b4832792e6a868a4f28676)