### PR TITLE
Modernize paquete CLI tests for JSON package format

### DIFF
--- a/tests/unit/test_cli_paquete.py
+++ b/tests/unit/test_cli_paquete.py
@@ -1,33 +1,101 @@
+import json
 from io import StringIO
 import zipfile
-try:
-    import tomllib  # Python >= 3.11
-except ModuleNotFoundError:  # pragma: no cover
-    import tomli as tomllib
 from unittest.mock import patch
 
 from cobra.cli.cli import main
-from cobra.cli.commands import modules_cmd, package_cmd
+from cobra.cli.commands import modules_cmd
 
 
-def test_paquete_crear_instalar(tmp_path, monkeypatch):
+def _crear_fuente(tmp_path):
     src = tmp_path / "src"
     src.mkdir()
     modulo = src / "m.co"
-    modulo.write_text("var x = 1")
-    pkg = tmp_path / "demo.cobra"
+    modulo.write_text("var x = 1", encoding="utf-8")
+    return src, modulo
+
+
+def _leer_manifest(paquete):
+    with zipfile.ZipFile(paquete) as zf:
+        return json.loads(zf.read("cobra.pkg.json").decode("utf-8"))
+
+
+def test_paquete_crear_instalar_flujo_moderno_co(tmp_path, monkeypatch):
+    src, _modulo = _crear_fuente(tmp_path)
+    pkg = tmp_path / "demo.co"
 
     with patch("sys.stdout", new_callable=StringIO):
-        main(["paquete", "crear", str(src), str(pkg), "--nombre=demo", "--version=0.1"])
+        main(["paquete", "crear", str(src), str(pkg), "--nombre=demo"])
 
     assert pkg.exists()
-    with zipfile.ZipFile(pkg) as zf:
-        data = tomllib.loads(zf.read("cobra.pkg").decode("utf-8"))
-    assert data["paquete"]["nombre"] == "demo"
+    data = _leer_manifest(pkg)
+    assert data["format"] == "cobra-package-v1"
+    assert data["name"] == "demo"
+    assert data["version"] == "0.1.0"
+    assert data["files"] == ["README.md", "m.co"]
+    assert set(data["checksums"]) == {"README.md", "m.co"}
+    assert all(data["checksums"].values())
+
     mods_dir = tmp_path / "mods"
     monkeypatch.setattr(modules_cmd, "MODULES_PATH", mods_dir)
 
     with patch("sys.stdout", new_callable=StringIO):
-        main(["paquete", "instalar", str(pkg)])
+        main(["paquete", "instalar", str(pkg), "--destino", str(mods_dir)])
 
     assert (mods_dir / "m.co").exists()
+
+
+def test_paquete_crear_instalar_alias_legacy_cobra(tmp_path, monkeypatch):
+    src, _modulo = _crear_fuente(tmp_path)
+    pkg = tmp_path / "demo.cobra"
+
+    with patch("sys.stdout", new_callable=StringIO):
+        main(["paquete", "crear", str(src), str(pkg), "--nombre=demo"])
+
+    assert pkg.exists()
+    data = _leer_manifest(pkg)
+    assert data["format"] == "cobra-package-v1"
+    assert data["name"] == "demo"
+    assert data["version"] == "0.1.0"
+    assert data["files"] == ["README.md", "m.co"]
+    assert set(data["checksums"]) == {"README.md", "m.co"}
+
+    mods_dir = tmp_path / "mods-legacy"
+    monkeypatch.setattr(modules_cmd, "MODULES_PATH", mods_dir)
+
+    with patch("sys.stdout", new_callable=StringIO):
+        main(["paquete", "instalar", str(pkg), "--destino", str(mods_dir)])
+
+    assert (mods_dir / "m.co").exists()
+
+
+def test_paquete_validar_construir_inspeccionar_extraer_formato_moderno(tmp_path):
+    src, _modulo = _crear_fuente(tmp_path)
+    pkg = tmp_path / "demo.co"
+
+    with patch("sys.stdout", new_callable=StringIO):
+        main(["paquete", "construir", str(src), str(pkg), "--nombre=demo"])
+
+    data = _leer_manifest(pkg)
+    assert data["format"] == "cobra-package-v1"
+    assert data["name"] == "demo"
+    assert data["version"] == "0.1.0"
+    assert data["files"] == ["m.co"]
+    assert set(data["checksums"]) == {"m.co"}
+
+    with patch("sys.stdout", new_callable=StringIO) as stdout:
+        main(["paquete", "validar", str(pkg)])
+    assert "Paquete válido" in stdout.getvalue()
+
+    with patch("sys.stdout", new_callable=StringIO) as stdout:
+        main(["paquete", "inspeccionar", str(pkg)])
+    salida = stdout.getvalue()
+    assert "Paquete: demo 0.1.0" in salida
+    assert "- m.co" in salida
+    assert "SHA256:" in salida
+
+    destino = tmp_path / "extraido"
+    with patch("sys.stdout", new_callable=StringIO) as stdout:
+        main(["paquete", "extraer", str(pkg), str(destino)])
+    assert "Paquete extraído" in stdout.getvalue()
+    assert (destino / "m.co").read_text(encoding="utf-8") == "var x = 1"


### PR DESCRIPTION
### Motivation
- Actualizar la suite de pruebas para reflejar el formato moderno de paquetes (`cobra.pkg.json`) y añadir cobertura CLI completa para las operaciones de paquete.
- Separar claramente el flujo moderno `.co` del alias legacy `.cobra` para validar compatibilidad sin mezclar expectativas.

### Description
- Reemplacé la lectura legacy de `cobra.pkg` (TOML) por `json.loads` sobre `cobra.pkg.json` en `tests/unit/test_cli_paquete.py`.
- Cambié el flujo moderno de ejemplo para usar `demo.co` y añadí un caso separado `demo.cobra` para la compatibilidad legacy.
- Añadí validaciones en los tests para los campos del manifiesto `format`, `name`, `version`, `files` y `checksums`, y adapté las expectativas de versión por defecto a `0.1.0`.
- Añadí cobertura CLI para `paquete validar`, `paquete construir`, `paquete inspeccionar` y `paquete extraer`, y ajusté la invocación de instalación para pasar `--destino` al comando.

### Testing
- Se ejecutó `pytest -q tests/unit/test_cli_paquete.py` y todos los tests en ese archivo pasaron.
- Se ejecutó `pytest -q tests/unit/test_cli_paquete.py tests/unit/test_cobra_packaging.py` y ambas suites pasaron exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a436a35ace88327ae7926cb5aeb2374)