### PR TITLE
Validar tamaño y checksum al instalar paquetes de CobraHub

### DIFF
--- a/src/pcobra/cobra/cli/cobrahub_client.py
+++ b/src/pcobra/cobra/cli/cobrahub_client.py
@@ -412,9 +412,28 @@ class CobraHubClient:
                 stream=True,
             ) as response:
                 response.raise_for_status()
+                checksum_servidor = response.headers.get("X-Content-Checksum")
+                sha256 = hashlib.sha256()
+                tamaño_total = 0
+
                 with open(cache_path, "wb") as out:
                     for chunk in response.iter_content(chunk_size=self.CHUNK_SIZE):
+                        if not chunk:
+                            continue
+                        tamaño_total += len(chunk)
+                        if tamaño_total > self.MAX_FILE_SIZE:
+                            out.close()
+                            os.unlink(cache_path)
+                            mostrar_error(_("Archivo descargado demasiado grande"))
+                            return False
+                        sha256.update(chunk)
                         out.write(chunk)
+
+            if checksum_servidor and sha256.hexdigest() != checksum_servidor:
+                os.unlink(cache_path)
+                mostrar_error(_("Verificación de integridad fallida"))
+                return False
+
             install_path = (
                 Path(destino).expanduser() if destino else _install_dir() / nombre
             )
@@ -424,6 +443,11 @@ class CobraHubClient:
         except Exception as e:
             logger.error(f"Error instalando paquete: {e}")
             mostrar_error(_("Error instalando paquete: {err}").format(err=str(e)))
+            if cache_path.exists():
+                try:
+                    os.unlink(cache_path)
+                except Exception:
+                    pass
             return False
 
 

--- a/tests/unit/test_cli_cobrahub.py
+++ b/tests/unit/test_cli_cobrahub.py
@@ -621,3 +621,126 @@ def test_buscar_paquetes_usa_metodo_real_de_clase(monkeypatch):
     client = cobrahub_client.CobraHubClient()
 
     assert client.buscar_paquetes("demo") == [{"name": "demo", "version": "1.0.0"}]
+
+
+class _PackageStreamingResponse:
+    def __init__(self, client, chunks, checksum=None):
+        self.client = client
+        self.chunks = chunks
+        self.headers = {}
+        if checksum is not None:
+            self.headers["X-Content-Checksum"] = checksum
+        self.iter_calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    def iter_content(self, chunk_size):
+        self.iter_calls.append(chunk_size)
+        yield from self.chunks
+
+    @property
+    def content(self):  # pragma: no cover - asegura que se use streaming
+        raise AssertionError("La instalación debe descargar el paquete en streaming")
+
+
+def _sha256_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+@pytest.mark.timeout(5)
+def test_instalar_paquete_descarga_valida(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    install_dir = tmp_path / "instalados"
+    monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("COBRAHUB_INSTALL_DIR", str(install_dir))
+
+    client = cobrahub_client.CobraHubClient()
+    chunks = [b"paquete-", b"valido"]
+    contenido = b"".join(chunks)
+    response = _PackageStreamingResponse(client, chunks, _sha256_bytes(contenido))
+    client.session.get = MagicMock(return_value=response)
+
+    with patch("pcobra.cobra.packaging.extraer_paquete") as extraer:
+        ok = client.instalar_paquete("demo")
+
+    assert ok
+    cache_path = cache_dir / "demo.co"
+    assert cache_path.read_bytes() == contenido
+    extraer.assert_called_once_with(cache_path, install_dir / "demo")
+    client.session.get.assert_called_once()
+    assert client.session.get.call_args.kwargs["stream"] is True
+    assert response.iter_calls == [client.CHUNK_SIZE]
+
+
+@pytest.mark.timeout(5)
+def test_instalar_paquete_descarga_demasiado_grande(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(cache_dir))
+
+    client = cobrahub_client.CobraHubClient()
+    monkeypatch.setattr(client, "MAX_FILE_SIZE", 4)
+    response = _PackageStreamingResponse(client, [b"123", b"45"])
+    client.session.get = MagicMock(return_value=response)
+
+    with (
+        patch("pcobra.cobra.packaging.extraer_paquete") as extraer,
+        patch("cobra.cli.cobrahub_client.mostrar_error") as err,
+    ):
+        ok = client.instalar_paquete("demo")
+
+    assert not ok
+    assert not (cache_dir / "demo.co").exists()
+    extraer.assert_not_called()
+    err.assert_called_once()
+
+
+@pytest.mark.timeout(5)
+def test_instalar_paquete_checksum_incorrecto(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(cache_dir))
+
+    client = cobrahub_client.CobraHubClient()
+    response = _PackageStreamingResponse(client, [b"contenido"], "0" * 64)
+    client.session.get = MagicMock(return_value=response)
+
+    with (
+        patch("pcobra.cobra.packaging.extraer_paquete") as extraer,
+        patch("cobra.cli.cobrahub_client.mostrar_error") as err,
+    ):
+        ok = client.instalar_paquete("demo")
+
+    assert not ok
+    assert not (cache_dir / "demo.co").exists()
+    extraer.assert_not_called()
+    err.assert_called_once()
+
+
+@pytest.mark.timeout(5)
+def test_instalar_paquete_limpia_cache_parcial(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(cache_dir))
+
+    client = cobrahub_client.CobraHubClient()
+
+    class _ResponseConFallo(_PackageStreamingResponse):
+        def iter_content(self, chunk_size):
+            self.iter_calls.append(chunk_size)
+            yield b"parcial"
+            raise RuntimeError("conexión interrumpida")
+
+    response = _ResponseConFallo(client, [])
+    client.session.get = MagicMock(return_value=response)
+
+    with patch("pcobra.cobra.packaging.extraer_paquete") as extraer:
+        ok = client.instalar_paquete("demo")
+
+    assert not ok
+    assert not (cache_dir / "demo.co").exists()
+    extraer.assert_not_called()


### PR DESCRIPTION
### Motivation
- Evitar extraer paquetes corruptos o demasiado grandes al instalar desde CobraHub. 
- Reforzar la limpieza de artefactos parciales en caché cuando la descarga falla o no cumple integridad.

### Description
- En `CobraHubClient.instalar_paquete` se acumula el tamaño de los `chunk` durante `response.iter_content` y se aborta si supera `CobraHubClient.MAX_FILE_SIZE`, borrando el archivo parcial de caché y devolviendo `False`.
- Se lee la cabecera `X-Content-Checksum` y se calcula SHA-256 durante la descarga; si el checksum no coincide se borra la caché parcial y no se llama a `extraer_paquete`.
- Se ignoran `chunk` vacíos durante la iteración y se añade limpieza defensiva del archivo de caché en el bloque `except` en caso de errores.
- Se añadieron pruebas en `tests/unit/test_cli_cobrahub.py` que cubren descarga válida, descarga demasiado grande, checksum incorrecto y limpieza de caché parcial.

### Testing
- Se ejecutó `pytest -q tests/unit/test_cli_cobrahub.py` y los tests unitarios relevantes pasaron (`30 passed, 1 warning`).
- Se ejecutó la suite completa con `pytest -q -x`; los tests del paquete modificado pasan, pero la ejecución completa falló en `tests/cli/test_public_v2_commands_contract.py::test_public_v2_subcommands_match_contract_exactly` por la detección de subcomandos extra (`hub` y `paquete`), problema que no está relacionado con estas modificaciones.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a437eb7d8c883279e844008605a86fc)