### PR TITLE
Validar manifiestos de paquetes Cobra estrictamente

### DIFF
--- a/src/pcobra/cobra/packaging.py
+++ b/src/pcobra/cobra/packaging.py
@@ -123,19 +123,70 @@ def inspeccionar_paquete(package: str | Path) -> PackageInspection:
     return PackageInspection(pkg, manifest, names, _sha256_file(pkg))
 
 
+def _normalizar_ruta_paquete(name: str) -> str:
+    normalized = Path(str(name).replace("\\", "/"))
+    if normalized.is_absolute() or ".." in normalized.parts:
+        raise ValueError(f"Ruta insegura en paquete: {name}")
+    normalized_name = normalized.as_posix()
+    if not normalized_name or normalized_name == ".":
+        raise ValueError(f"Ruta inválida en paquete: {name}")
+    return normalized_name
+
+
+def _normalizar_lista_archivos(values: Any, *, field: str) -> set[str]:
+    if not isinstance(values, list):
+        raise ValueError(f"El manifiesto debe declarar {field} como lista")
+    return {_normalizar_ruta_paquete(str(value)) for value in values}
+
+
+def _normalizar_checksums(values: Any) -> dict[str, Any]:
+    if not isinstance(values, dict):
+        raise ValueError("El manifiesto debe declarar checksums como objeto")
+    return {_normalizar_ruta_paquete(str(name)): checksum for name, checksum in values.items()}
+
+
 def validar_paquete(package: str | Path) -> PackageInspection:
     inspection = inspeccionar_paquete(package)
-    checksums = inspection.manifest.get("checksums", {})
+    manifest = inspection.manifest
+    package_format = manifest.get("format")
+    if package_format is None:
+        raise ValueError("El manifiesto no declara format")
+    if package_format != PACKAGE_FORMAT:
+        raise ValueError(f"Formato de paquete no soportado: {package_format}")
+    if not manifest.get("name"):
+        raise ValueError("El manifiesto no declara name")
+    if not manifest.get("version"):
+        raise ValueError("El manifiesto no declara version")
+
+    declared_files = _normalizar_lista_archivos(manifest.get("files"), field="files")
+    checksums = _normalizar_checksums(manifest.get("checksums"))
+
     with zipfile.ZipFile(inspection.path) as zf:
-        for name in inspection.files:
-            path = Path(name)
-            if path.is_absolute() or ".." in path.parts:
-                raise ValueError(f"Ruta insegura en paquete: {name}")
-        for name, expected in checksums.items():
-            if name not in inspection.files:
-                raise ValueError(f"Archivo declarado ausente: {name}")
+        real_files = {
+            _normalizar_ruta_paquete(info.filename)
+            for info in zf.infolist()
+            if not info.is_dir() and info.filename != MANIFEST_NAME
+        }
+        extra_files = real_files - declared_files
+        if extra_files:
+            raise ValueError(f"Archivos no declarados en paquete: {', '.join(sorted(extra_files))}")
+
+        missing_files = declared_files - real_files
+        if missing_files:
+            raise ValueError(f"Archivos declarados ausentes: {', '.join(sorted(missing_files))}")
+
+        checksum_files = set(checksums)
+        undeclared_checksums = checksum_files - declared_files
+        if undeclared_checksums:
+            raise ValueError(f"Checksums para archivos no declarados: {', '.join(sorted(undeclared_checksums))}")
+
+        missing_checksums = declared_files - checksum_files
+        if missing_checksums:
+            raise ValueError(f"Faltan checksums para archivos declarados: {', '.join(sorted(missing_checksums))}")
+
+        for name in sorted(declared_files):
             actual = _sha256_bytes(zf.read(name))
-            if actual != expected:
+            if actual != checksums[name]:
                 raise ValueError(f"Integridad fallida para {name}")
     return inspection
 

--- a/tests/unit/test_cobra_packaging.py
+++ b/tests/unit/test_cobra_packaging.py
@@ -1,4 +1,9 @@
+import hashlib
+import json
+import zipfile
 from pathlib import Path
+
+import pytest
 
 from pcobra.cobra.packaging import (
     MANIFEST_NAME,
@@ -33,3 +38,87 @@ def test_paquete_cobra_conserva_estructura_y_recursos(tmp_path: Path):
 
     destino = extraer_paquete(paquete, tmp_path / "instalado")
     assert (destino / "src" / "main.cobra").read_text(encoding="utf-8") == "imprimir('hola')\n"
+
+
+def _crear_zip_con_manifest(tmp_path: Path, manifest: dict, files: dict[str, bytes] | None = None) -> Path:
+    paquete = tmp_path / "manual.co"
+    with zipfile.ZipFile(paquete, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(MANIFEST_NAME, json.dumps(manifest, ensure_ascii=False))
+        for name, content in (files or {}).items():
+            zf.writestr(name, content)
+    return paquete
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def test_validar_paquete_rechaza_manifest_incompleto(tmp_path: Path):
+    contenido = b"imprimir('hola')\n"
+    paquete = _crear_zip_con_manifest(
+        tmp_path,
+        {
+            "format": "cobra-package-v1",
+            "name": "demo",
+            "files": ["src/main.cobra"],
+            "checksums": {"src/main.cobra": _sha256(contenido)},
+        },
+        {"src/main.cobra": contenido},
+    )
+
+    with pytest.raises(ValueError, match="version"):
+        validar_paquete(paquete)
+
+
+def test_validar_paquete_rechaza_archivo_extra_no_declarado(tmp_path: Path):
+    contenido = b"imprimir('hola')\n"
+    paquete = _crear_zip_con_manifest(
+        tmp_path,
+        {
+            "format": "cobra-package-v1",
+            "name": "demo",
+            "version": "1.0.0",
+            "files": ["src/main.cobra"],
+            "checksums": {"src/main.cobra": _sha256(contenido)},
+        },
+        {"src/main.cobra": contenido, "extra.txt": b"sobrante"},
+    )
+
+    with pytest.raises(ValueError, match="Archivos no declarados"):
+        validar_paquete(paquete)
+
+
+def test_validar_paquete_rechaza_checksum_ausente(tmp_path: Path):
+    contenido = b"imprimir('hola')\n"
+    paquete = _crear_zip_con_manifest(
+        tmp_path,
+        {
+            "format": "cobra-package-v1",
+            "name": "demo",
+            "version": "1.0.0",
+            "files": ["src/main.cobra"],
+            "checksums": {},
+        },
+        {"src/main.cobra": contenido},
+    )
+
+    with pytest.raises(ValueError, match="Faltan checksums"):
+        validar_paquete(paquete)
+
+
+def test_validar_paquete_rechaza_formato_invalido(tmp_path: Path):
+    contenido = b"imprimir('hola')\n"
+    paquete = _crear_zip_con_manifest(
+        tmp_path,
+        {
+            "format": "cobra-package-v0",
+            "name": "demo",
+            "version": "1.0.0",
+            "files": ["src/main.cobra"],
+            "checksums": {"src/main.cobra": _sha256(contenido)},
+        },
+        {"src/main.cobra": contenido},
+    )
+
+    with pytest.raises(ValueError, match="Formato de paquete no soportado"):
+        validar_paquete(paquete)


### PR DESCRIPTION
### Motivation

- Evitar mezclas silenciosas entre formatos de manifiesto y asegurar integridad y consistencia de paquetes Cobra mediante validación explícita del manifiesto y del contenido del ZIP. 
- Normalizar rutas y claves antes de comparar archivos reales, entradas declaradas y checksums para prevenir bypasses por diferencias de separación de rutas o entradas de directorio.

### Description

- Añadidas funciones de normalización: `_normalizar_ruta_paquete`, `_normalizar_lista_archivos` y `_normalizar_checksums` para unificar rutas a POSIX y rechazar rutas inseguras o inválidas. (modificado: `src/pcobra/cobra/packaging.py`).
- Endurecida la función `validar_paquete` para exigir que el manifiesto declare `format`, `name` y `version`, aceptar únicamente `cobra-package-v1`, y comprobar que no haya archivos reales no declarados, archivos declarados ausentes, checksums para archivos no declarados ni checksums faltantes; además valida integridad por SHA256. (modificado: `src/pcobra/cobra/packaging.py`).
- No se habilitó compatibilidad implícita con formatos legacy; los paquetes con `format` distinto a `cobra-package-v1` son rechazados salvo que exista una ruta de migración explícita. (comportamiento de compatibilidad intencionalmente estricto).
- Añadidas pruebas unitarias y helpers para generar ZIPs de prueba con manifiestos controlados y checksums reproducibles, cubriendo manifiesto incompleto, archivo extra no declarado, checksum ausente y formato inválido. (modificado: `tests/unit/test_cobra_packaging.py`).

### Testing

- Ejecutado `pytest -q tests/unit/test_cobra_packaging.py` y todos los tests pasaron (`5 passed`) con una advertencia deprecatoria; no se reportaron fallos en las nuevas pruebas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4383799d208327a1e3ba27ec88bc8e)