### PR TITLE
test: asegurar independencia de packaging

### DIFF
--- a/tests/unit/test_cobra_packaging.py
+++ b/tests/unit/test_cobra_packaging.py
@@ -1,3 +1,4 @@
+import ast
 import hashlib
 import json
 import zipfile
@@ -13,6 +14,32 @@ from pcobra.cobra.packaging import (
     inspeccionar_paquete,
     validar_paquete,
 )
+
+
+def test_packaging_no_importa_lexer_parser():
+    import pcobra.cobra.packaging as packaging
+
+    tree = ast.parse(Path(packaging.__file__).read_text(encoding="utf-8"))
+    imported_modules = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported_modules.update(
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    )
+
+    forbidden_modules = {
+        module
+        for module in imported_modules
+        if module in {"pcobra.cobra.core", "pcobra.cobra.core.lexer", "pcobra.cobra.core.parser"}
+        or module.endswith((".lexer", ".parser"))
+    }
+
+    assert forbidden_modules == set()
 
 
 def test_paquete_cobra_conserva_estructura_y_recursos(tmp_path: Path):


### PR DESCRIPTION
### Motivation
- Garantizar que el módulo de herramientas de empaquetado `pcobra.cobra.packaging` no dependa de los componentes de análisis léxico/parseo para mantener la separación de capas y evitar cargas innecesarias.

### Description
- Añade el test `test_packaging_no_importa_lexer_parser` en `tests/unit/test_cobra_packaging.py` que importa `pcobra.cobra.packaging`, analiza su código fuente con `ast` para recopilar imports y falla si detecta referencias a `pcobra.cobra.core`, `*.lexer` o `*.parser`.

### Testing
- Se ejecutó `pytest tests/unit/test_cobra_packaging.py -q` y la suite pasó (todos los tests de ese archivo se ejecutaron correctamente).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a439c6a31f08327a676a0c0b583c173)