### PR TITLE
Add CobraHub package metadata and versioned cache

### DIFF
--- a/src/pcobra/cobra/cli/cobrahub_client.py
+++ b/src/pcobra/cobra/cli/cobrahub_client.py
@@ -382,11 +382,13 @@ class CobraHubClient:
 
         return CobraHubPackages(self).buscar_paquetes(consulta)
 
-    def instalar_paquete(self, nombre: str, destino: str | None = None) -> bool:
+    def instalar_paquete(
+        self, nombre: str, destino: str | None = None, version: str | None = None
+    ) -> bool:
         """Instala un paquete usando la API separada de paquetes."""
         from pcobra.cobra.cli.cobrahub_packages import CobraHubPackages
 
-        return CobraHubPackages(self).instalar_paquete(nombre, destino)
+        return CobraHubPackages(self).instalar_paquete(nombre, destino, version)
 
 
 # Funciones conveniencia para interacción sencilla con CobraHub.

--- a/src/pcobra/cobra/cli/cobrahub_packages.py
+++ b/src/pcobra/cobra/cli/cobrahub_packages.py
@@ -14,6 +14,7 @@ import logging
 import os
 import shutil
 import urllib.parse
+from email.message import Message
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -23,6 +24,65 @@ if TYPE_CHECKING:  # pragma: no cover - solo para tipado
     from pcobra.cobra.cli.cobrahub_client import CobraHubClient
 
 logger = logging.getLogger(__name__)
+
+
+def _normalizar_resultado_paquete(item: Any) -> dict[str, str]:
+    """Convierte respuestas variadas del servidor al modelo mínimo público."""
+    from pcobra.cobra.packaging import PackageSearchResult
+
+    if not isinstance(item, dict):
+        item = {"name": str(item)}
+
+    name = item.get("name") or item.get("nombre") or item.get("package")
+    if not name:
+        name = Path(str(item.get("filename") or item.get("archivo") or "paquete.co")).stem
+
+    result = PackageSearchResult(
+        name=str(name),
+        version=_optional_str(item.get("version")),
+        filename=_optional_str(item.get("filename") or item.get("archivo")),
+        checksum=_optional_str(
+            item.get("checksum")
+            or item.get("sha256")
+            or item.get("digest")
+            or item.get("content_checksum")
+        ),
+        download_url=_optional_str(
+            item.get("download_url") or item.get("url") or item.get("href")
+        ),
+        remote_id=_optional_str(item.get("remote_id") or item.get("id")),
+    )
+    return result.as_dict()
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    value = str(value)
+    return value or None
+
+
+def _cache_filename(nombre: str, version: str | None) -> str:
+    return f"{nombre}-{version}.co" if version else f"{nombre}.co"
+
+
+def _version_from_response(response: Any) -> str | None:
+    headers = getattr(response, "headers", {}) or {}
+    version = headers.get("X-Package-Version") or headers.get("X-Cobra-Package-Version")
+    if version:
+        return str(version)
+    content_disposition = headers.get("Content-Disposition")
+    if not content_disposition:
+        return None
+    msg = Message()
+    msg["Content-Disposition"] = content_disposition
+    filename = msg.get_filename()
+    if not filename:
+        return None
+    stem = Path(filename).stem
+    if "-" not in stem:
+        return None
+    return stem.rsplit("-", 1)[1] or None
 
 
 def _mostrar_error(mensaje: str) -> None:
@@ -91,29 +151,34 @@ class CobraHubPackages:
             ) as response:
                 response.raise_for_status()
                 data = response.json() if hasattr(response, "json") else []
-            if isinstance(data, dict):
-                return list(data.get("results", []))
-            return list(data)
+            items = data.get("results", []) if isinstance(data, dict) else data
+            return [_normalizar_resultado_paquete(item) for item in list(items)]
         except Exception as e:
             logger.error(f"Error buscando paquetes: {e}")
             _mostrar_error(_("Error buscando paquetes: {err}").format(err=str(e)))
             return []
 
-    def instalar_paquete(self, nombre: str, destino: str | None = None) -> bool:
+    def instalar_paquete(
+        self, nombre: str, destino: str | None = None, version: str | None = None
+    ) -> bool:
         """Descarga, cachea e instala un paquete desde CobraHub."""
         from pcobra.cobra.packaging import extraer_paquete
 
         if not self.client._validar_nombre_modulo(nombre) or not self.client._validar_url():
             return False
-        cache_path = package_cache_dir() / f"{nombre}.co"
+        cache_path = package_cache_dir() / _cache_filename(nombre, version)
         try:
             with self.client.session.get(
                 f"{self.client.base_url}/paquetes/{urllib.parse.quote(nombre)}",
+                **({"params": {"version": version}} if version else {}),
                 timeout=(self.client.CONNECT_TIMEOUT, self.client.READ_TIMEOUT),
                 stream=True,
             ) as response:
                 response.raise_for_status()
                 checksum_servidor = response.headers.get("X-Content-Checksum")
+                version_servidor = _version_from_response(response)
+                if version_servidor and version_servidor != version:
+                    cache_path = package_cache_dir() / _cache_filename(nombre, version_servidor)
                 sha256 = hashlib.sha256()
                 tamaño_total = 0
 

--- a/src/pcobra/cobra/cli/commands/hub_cmd.py
+++ b/src/pcobra/cobra/cli/commands/hub_cmd.py
@@ -26,6 +26,7 @@ class HubCommand(BaseCommand):
         buscar.add_argument("consulta")
         inst = sub.add_parser("instalar", help=_("Instala un paquete"))
         inst.add_argument("nombre")
+        inst.add_argument("--version")
         inst.add_argument("--destino", type=Path)
         parser.set_defaults(cmd=self)
         return parser
@@ -42,6 +43,6 @@ class HubCommand(BaseCommand):
             return 0
         if args.accion == "instalar":
             destino = str(args.destino) if args.destino else None
-            return 0 if packages.instalar_paquete(args.nombre, destino) else 1
+            return 0 if packages.instalar_paquete(args.nombre, destino, args.version) else 1
         mostrar_error(_("Acción de hub no reconocida"))
         return 1

--- a/src/pcobra/cobra/packaging.py
+++ b/src/pcobra/cobra/packaging.py
@@ -23,6 +23,30 @@ MAX_PACKAGE_SIZE = 50 * 1024 * 1024
 
 
 @dataclass(frozen=True)
+class PackageSearchResult:
+    """Metadatos normalizados para resultados remotos de CobraHub."""
+
+    name: str
+    version: str | None = None
+    filename: str | None = None
+    checksum: str | None = None
+    download_url: str | None = None
+    remote_id: str | None = None
+
+    def as_dict(self) -> dict[str, str]:
+        """Devuelve solo los campos disponibles para mantener compatibilidad JSON."""
+        values = {
+            "name": self.name,
+            "version": self.version,
+            "filename": self.filename,
+            "checksum": self.checksum,
+            "download_url": self.download_url,
+            "remote_id": self.remote_id,
+        }
+        return {key: value for key, value in values.items() if value is not None}
+
+
+@dataclass(frozen=True)
 class PackageInspection:
     path: Path
     manifest: dict[str, Any]

--- a/tests/unit/test_cli_cobrahub.py
+++ b/tests/unit/test_cli_cobrahub.py
@@ -653,6 +653,99 @@ class _PackageStreamingResponse:
 def _sha256_bytes(data):
     return hashlib.sha256(data).hexdigest()
 
+@pytest.mark.timeout(5)
+def test_buscar_paquetes_normaliza_metadatos_disponibles(monkeypatch):
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "results": [
+                    {
+                        "nombre": "demo",
+                        "version": "2.0.0",
+                        "archivo": "demo-2.0.0.co",
+                        "sha256": "abc123",
+                        "url": "https://example.test/demo-2.0.0.co",
+                        "id": "pkg-1",
+                    }
+                ]
+            }
+
+    class Session:
+        def get(self, url, params, timeout):
+            return Response()
+
+    monkeypatch.setattr(
+        cobrahub_client.CobraHubClient,
+        "_configurar_sesion",
+        lambda self: Session(),
+    )
+
+    client = cobrahub_client.CobraHubClient()
+
+    assert client.buscar_paquetes("demo") == [
+        {
+            "name": "demo",
+            "version": "2.0.0",
+            "filename": "demo-2.0.0.co",
+            "checksum": "abc123",
+            "download_url": "https://example.test/demo-2.0.0.co",
+            "remote_id": "pkg-1",
+        }
+    ]
+
+
+@pytest.mark.timeout(5)
+def test_instalar_paquete_cache_versionada_si_servidor_entrega_version(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    install_dir = tmp_path / "instalados"
+    monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("COBRAHUB_INSTALL_DIR", str(install_dir))
+
+    client = cobrahub_client.CobraHubClient()
+    contenido = b"paquete-versionado"
+    response = _PackageStreamingResponse(client, [contenido], _sha256_bytes(contenido))
+    response.headers["X-Package-Version"] = "2.1.0"
+    client.session.get = MagicMock(return_value=response)
+
+    with patch("pcobra.cobra.packaging.extraer_paquete") as extraer:
+        ok = client.instalar_paquete("demo")
+
+    assert ok
+    cache_path = cache_dir / "demo-2.1.0.co"
+    assert cache_path.read_bytes() == contenido
+    assert not (cache_dir / "demo.co").exists()
+    extraer.assert_called_once_with(cache_path, install_dir / "demo")
+
+
+@pytest.mark.timeout(5)
+def test_instalar_paquete_cache_legacy_si_servidor_no_entrega_version(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    install_dir = tmp_path / "instalados"
+    monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("COBRAHUB_INSTALL_DIR", str(install_dir))
+
+    client = cobrahub_client.CobraHubClient()
+    contenido = b"paquete-legacy"
+    response = _PackageStreamingResponse(client, [contenido], _sha256_bytes(contenido))
+    client.session.get = MagicMock(return_value=response)
+
+    with patch("pcobra.cobra.packaging.extraer_paquete") as extraer:
+        ok = client.instalar_paquete("demo")
+
+    assert ok
+    cache_path = cache_dir / "demo.co"
+    assert cache_path.read_bytes() == contenido
+    extraer.assert_called_once_with(cache_path, install_dir / "demo")
+
 
 @pytest.mark.timeout(5)
 def test_instalar_paquete_descarga_valida(tmp_path, monkeypatch):


### PR DESCRIPTION
### Motivation
- Proveer un modelo mínimo y estable de metadatos para resultados de búsqueda/instalación (`name`, `version`, `filename`, `checksum`, `download_url`/identificador remoto) para facilitar integraciones con CobraHub.
- Permitir que la instalación acepte opcionalmente una `version` sin romper el flujo legacy y guardar en caché paquetes con nombre versionado cuando el servidor lo entregue.

### Description
- Añadido el dataclass `PackageSearchResult` con los campos solicitados y método `as_dict()` en `src/pcobra/cobra/packaging.py`.
- Implementadas funciones de normalización en `src/pcobra/cobra/cli/cobrahub_packages.py` que convierten respuestas del servidor (incluyendo campos legacy como `nombre`, `archivo`, `sha256`, `url`, `id`) al modelo mínimo público y devuelven solo los campos disponibles.
- Modificado `instalar_paquete` para aceptar `version: str | None` y para: enviar `params={"version": version}` si se pasa; detectar versión provista por el servidor desde headers (`X-Package-Version`, `X-Cobra-Package-Version`) o `Content-Disposition`; y escribir la caché como `{name}-{version}.co` cuando la versión esté disponible, manteniendo el fallback legacy `{name}.co` si no lo está.
- Propagada la firma `version` en la fachada `CobraHubClient` y añadido el argumento CLI `--version` en `cobra hub instalar` para compatibilidad con el nuevo flujo.
- Añadidos tests unitarios en `tests/unit/test_cli_cobrahub.py` que cubren normalización de metadatos, caché versionada y fallback legacy.

### Testing
- Ejecutado `python -m pytest tests/unit/test_cli_cobrahub.py -q` y la colección modificada pasó sin fallos (tests focales para búsqueda e instalación de paquetes). ✅
- Ejecutado `python -m pytest tests/unit/test_cli_cobrahub.py tests/unit/test_cobrahub_close.py tests/unit/test_cobrahub_retry.py -q` y pasaron sin fallos. ✅
- Ejecutado `python -m ruff check src/pcobra/cobra/packaging.py src/pcobra/cobra/cli/cobrahub_packages.py src/pcobra/cobra/cli/cobrahub_client.py src/pcobra/cobra/cli/commands/hub_cmd.py tests/unit/test_cli_cobrahub.py` y `ruff` no reportó problemas. ✅
- Ejecutada la suite completa `python -m pytest tests/unit -q`; hay fallos preexistentes/no relacionados que aparecen al correr toda la suite: `test_snapshot_api_publica[texto]`, `test_bench_transpilers_generates_results`, `test_benchmarks2_generates_json`, `test_benchmarks2_without_resource` y `test_benchmarks_generates_data_for_all_backends`; estos fallos parecen ser de snapshots/benchmarks ajenos a los cambios introducidos. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43abb15aac832793fc8ebba1b9e401)