### PR TITLE
Añade detección estructural de paquetes Cobra

### DIFF
--- a/README.md
+++ b/README.md
@@ -1109,7 +1109,7 @@ Por defecto el nivel de registro es `INFO`; con `-v` o más se cambia a `DEBUG`:
 cobra -v run programa.co
 ```
 
-Los archivos fuente Cobra pueden usar ``.cobra`` o ``.co`` según el flujo histórico del proyecto. Los paquetes publicables de CobraHub también usan extensión ``.co`` como contenedor ZIP con manifiesto ``cobra.pkg.json``; la distinción se realiza en la capa de herramientas, no en el Lexer ni en el Parser.
+Los archivos fuente Cobra pueden usar ``.cobra`` o ``.co`` según el flujo histórico del proyecto. Los paquetes publicables de CobraHub también usan extensión ``.co`` como contenedor ZIP con manifiesto ``cobra.pkg.json``; la distinción se realiza en la capa de herramientas, no en el Lexer ni en el Parser. Regla exacta: un ``.co`` es paquete solo si es un ZIP legible y contiene ``cobra.pkg.json`` en la raíz; un ``.co`` de texto es fuente, y un ZIP sin manifiesto no es paquete Cobra válido.
 
 El subcomando `docs` ejecuta `sphinx-apidoc` para generar la documentación de la API antes de compilar el HTML.
 El subcomando `gui` abre el IDLE gráfico principal y requiere tener instalado Flet.

--- a/docs/cobrahub_paquetes.md
+++ b/docs/cobrahub_paquetes.md
@@ -34,6 +34,15 @@ La funcionalidad se implementa en `pcobra.cobra.packaging`, una capa independien
 6. Añadir acciones del IDLE que reutilizan la misma lógica de empaquetado.
 7. Añadir pruebas unitarias de construcción, validación, inspección y extracción.
 
+## Regla de detección de paquetes `.co`
+
+Un archivo `.co` solo se considera paquete Cobra cuando cumple ambas condiciones estructurales:
+
+1. El archivo es un ZIP legible.
+2. El ZIP contiene `cobra.pkg.json` en la raíz.
+
+La extensión `.co` por sí sola no basta: un `.co` de texto sigue siendo fuente Cobra, y un ZIP `.co` sin `cobra.pkg.json` no es un paquete Cobra válido. Esta comprobación vive en `pcobra.cobra.packaging.es_paquete_cobra()` y no invoca Lexer ni Parser. Los comandos de empaquetado y CobraHub usan esta regla antes de validar, publicar, instalar o leer metadatos de paquetes.
+
 ## Por qué no se toca Lexer ni Parser
 
 El cambio opera exclusivamente sobre archivos, ZIPs, manifiestos y transporte CobraHub. No añade tokens, reglas gramaticales ni sintaxis Cobra. Los archivos fuente incluidos se tratan como bytes hasta que el usuario decida ejecutarlos con los comandos existentes.

--- a/src/pcobra/cobra/cli/cobrahub_packages.py
+++ b/src/pcobra/cobra/cli/cobrahub_packages.py
@@ -107,11 +107,13 @@ class CobraHubPackages:
 
     def publicar_paquete(self, ruta: str) -> bool:
         """Publica un paquete .co en CobraHub y lo guarda en caché local."""
-        from pcobra.cobra.packaging import validar_paquete
+        from pcobra.cobra.packaging import es_paquete_cobra, validar_paquete
 
         if not self.client._validar_url():
             return False
         try:
+            if not es_paquete_cobra(ruta):
+                raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
             info = validar_paquete(ruta)
             checksum = info.checksum
             with open(ruta, "rb") as f:
@@ -162,7 +164,7 @@ class CobraHubPackages:
         self, nombre: str, destino: str | None = None, version: str | None = None
     ) -> bool:
         """Descarga, cachea e instala un paquete desde CobraHub."""
-        from pcobra.cobra.packaging import extraer_paquete
+        from pcobra.cobra.packaging import es_paquete_cobra, extraer_paquete
 
         if not self.client._validar_nombre_modulo(nombre) or not self.client._validar_url():
             return False
@@ -200,6 +202,11 @@ class CobraHubPackages:
                 _mostrar_error(_("Verificación de integridad fallida"))
                 return False
 
+            if not es_paquete_cobra(cache_path):
+                os.unlink(cache_path)
+                _mostrar_error(_("La descarga no es un paquete Cobra válido"))
+                return False
+
             install_path = Path(destino).expanduser() if destino else install_dir() / nombre
             extraer_paquete(cache_path, install_path)
             _mostrar_info(_("Paquete instalado en {dest}").format(dest=install_path))
@@ -216,8 +223,10 @@ class CobraHubPackages:
 
     def leer_metadatos(self, ruta: str | Path) -> dict[str, Any]:
         """Lee y devuelve el manifiesto/metadatos de un paquete local ``.co``."""
-        from pcobra.cobra.packaging import validar_paquete
+        from pcobra.cobra.packaging import es_paquete_cobra, validar_paquete
 
+        if not es_paquete_cobra(ruta):
+            raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
         info = validar_paquete(ruta)
         return dict(info.manifest)
 

--- a/src/pcobra/cobra/cli/commands/compile_cmd.py
+++ b/src/pcobra/cobra/cli/commands/compile_cmd.py
@@ -32,6 +32,7 @@ from pcobra.cobra.cli.deprecation_policy import (
 )
 from pcobra.cobra.cli.utils.messages import mostrar_advertencia, mostrar_error, mostrar_info
 from pcobra.cobra.cli.utils.validators import validar_archivo_existente
+from pcobra.cobra.packaging import es_paquete_cobra
 from pcobra.cobra.cli.utils.autocomplete import files_completer
 from pcobra.cobra.core import ParserError
 from pcobra.cobra.core.cobra_config import tiempo_max_transpilacion
@@ -86,6 +87,11 @@ def validate_file(filepath: str) -> bool:
         raise ValueError(f"No hay permisos de lectura para '{filepath}'")
     if os.path.getsize(path) > MAX_FILE_SIZE:
         raise ValueError(f"El archivo excede el tamaño máximo permitido ({MAX_FILE_SIZE} bytes)")
+    if es_paquete_cobra(path):
+        raise ValueError(
+            "El archivo es un paquete Cobra .co, no una fuente transpirable. "
+            "Instálalo o extráelo con el comando paquete antes de compilar."
+        )
     return True
 
 def validar_dependencias_con_alias(backend: str, mod_info: dict) -> None:

--- a/src/pcobra/cobra/cli/commands/package_cmd.py
+++ b/src/pcobra/cobra/cli/commands/package_cmd.py
@@ -10,6 +10,7 @@ from pcobra.cobra.packaging import (
     DEFAULT_INSTALL_DIR,
     construir_paquete,
     crear_paquete,
+    es_paquete_cobra,
     extraer_paquete,
     inspeccionar_paquete,
     validar_paquete,
@@ -66,6 +67,8 @@ class PaqueteCommand(BaseCommand):
                     mostrar_info(_("Estructura de paquete creada: {manifest}").format(manifest=manifest))
                 return 0
             if args.accion == "validar":
+                if not es_paquete_cobra(args.paquete):
+                    raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
                 validar_paquete(args.paquete)
                 mostrar_info(_("Paquete válido: {pkg}").format(pkg=args.paquete))
                 return 0
@@ -74,6 +77,8 @@ class PaqueteCommand(BaseCommand):
                 mostrar_info(_("Paquete construido en {dest}").format(dest=destino))
                 return 0
             if args.accion == "inspeccionar":
+                if not es_paquete_cobra(args.paquete):
+                    raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
                 info = inspeccionar_paquete(args.paquete)
                 mostrar_info(_("Paquete: {name} {version}").format(name=info.manifest.get("name"), version=info.manifest.get("version")))
                 for file in info.files:
@@ -81,10 +86,14 @@ class PaqueteCommand(BaseCommand):
                 mostrar_info(_("SHA256: {checksum}").format(checksum=info.checksum))
                 return 0
             if args.accion == "extraer":
+                if not es_paquete_cobra(args.paquete):
+                    raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
                 destino = extraer_paquete(args.paquete, args.destino)
                 mostrar_info(_("Paquete extraído en {dest}").format(dest=destino))
                 return 0
             if args.accion == "instalar":
+                if not es_paquete_cobra(args.paquete):
+                    raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
                 destino = extraer_paquete(args.paquete, args.destino)
                 mostrar_info(_("Paquete instalado en {dest}").format(dest=destino))
                 return 0

--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -19,6 +19,7 @@ from pcobra.cobra.cli.target_policies import resolve_docker_backend
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
 from pcobra.cobra.cli.utils.source import read_cobra_source
 from pcobra.cobra.cli.utils.validators import validar_archivo_existente
+from pcobra.cobra.packaging import es_paquete_cobra
 from pcobra.cobra.core import LexerError, ParserError
 from pcobra.cobra.core.runtime import (
     InterpretadorCobra,
@@ -125,6 +126,11 @@ class RunService:
             ) from error
         if resolved_path.stat().st_size > self.max_file_size:
             raise ValueError(f"El archivo excede el tamaño máximo permitido ({self.max_file_size} bytes)")
+        if es_paquete_cobra(resolved_path):
+            raise ValueError(
+                "El archivo es un paquete Cobra .co, no una fuente ejecutable. "
+                "Instálalo o extráelo con el comando paquete antes de ejecutar."
+            )
         return resolved_path
 
     def limitar_recursos(self, funcion: Any) -> int:

--- a/src/pcobra/cobra/packaging.py
+++ b/src/pcobra/cobra/packaging.py
@@ -133,16 +133,33 @@ def construir_paquete(source: str | Path, output: str | Path | None = None, *, n
     return dest
 
 
+def es_paquete_cobra(path: str | Path) -> bool:
+    """Indica si ``path`` es un paquete Cobra ``.co`` ZIP con manifiesto.
+
+    La detección es deliberadamente estructural y barata: no usa Lexer ni Parser,
+    solo comprueba que el archivo sea un ZIP legible y que contenga
+    ``cobra.pkg.json`` en la raíz del archivo.
+    """
+    candidate = Path(path)
+    if not candidate.is_file() or not zipfile.is_zipfile(candidate):
+        return False
+    try:
+        with zipfile.ZipFile(candidate) as zf:
+            return MANIFEST_NAME in zf.namelist()
+    except (OSError, zipfile.BadZipFile):
+        return False
+
+
 def inspeccionar_paquete(package: str | Path) -> PackageInspection:
     pkg = Path(package)
     if not pkg.exists():
         raise FileNotFoundError(f"Paquete no encontrado: {pkg}")
     if pkg.stat().st_size > MAX_PACKAGE_SIZE:
         raise ValueError("El paquete excede el tamaño máximo permitido")
+    if not es_paquete_cobra(pkg):
+        raise ValueError("El paquete no es un paquete Cobra válido: debe ser ZIP y contener cobra.pkg.json")
     with zipfile.ZipFile(pkg) as zf:
         names = zf.namelist()
-        if MANIFEST_NAME not in names:
-            raise ValueError("El paquete no contiene manifiesto cobra.pkg.json")
         manifest = json.loads(zf.read(MANIFEST_NAME).decode("utf-8"))
     return PackageInspection(pkg, manifest, names, _sha256_file(pkg))
 

--- a/tests/unit/test_cli_cobrahub.py
+++ b/tests/unit/test_cli_cobrahub.py
@@ -1,9 +1,11 @@
-from io import StringIO
+from io import BytesIO, StringIO
 from unittest.mock import patch, MagicMock
 import os
 import sys
 from types import ModuleType
 import hashlib
+import json
+import zipfile
 import pytest
 import requests
 
@@ -650,6 +652,24 @@ class _PackageStreamingResponse:
         raise AssertionError("La instalación debe descargar el paquete en streaming")
 
 
+
+
+def _paquete_cobra_bytes(label: str = "demo") -> bytes:
+    payload = f"imprimir('{label}')\n".encode("utf-8")
+    checksum = hashlib.sha256(payload).hexdigest()
+    manifest = {
+        "format": "cobra-package-v1",
+        "name": label,
+        "version": "1.0.0",
+        "files": ["src/main.cobra"],
+        "checksums": {"src/main.cobra": checksum},
+    }
+    buffer = BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("cobra.pkg.json", json.dumps(manifest, ensure_ascii=False))
+        zf.writestr("src/main.cobra", payload)
+    return buffer.getvalue()
+
 def _sha256_bytes(data):
     return hashlib.sha256(data).hexdigest()
 
@@ -711,7 +731,7 @@ def test_instalar_paquete_cache_versionada_si_servidor_entrega_version(tmp_path,
     monkeypatch.setenv("COBRAHUB_INSTALL_DIR", str(install_dir))
 
     client = cobrahub_client.CobraHubClient()
-    contenido = b"paquete-versionado"
+    contenido = _paquete_cobra_bytes("paquete-versionado")
     response = _PackageStreamingResponse(client, [contenido], _sha256_bytes(contenido))
     response.headers["X-Package-Version"] = "2.1.0"
     client.session.get = MagicMock(return_value=response)
@@ -734,7 +754,7 @@ def test_instalar_paquete_cache_legacy_si_servidor_no_entrega_version(tmp_path, 
     monkeypatch.setenv("COBRAHUB_INSTALL_DIR", str(install_dir))
 
     client = cobrahub_client.CobraHubClient()
-    contenido = b"paquete-legacy"
+    contenido = _paquete_cobra_bytes("paquete-legacy")
     response = _PackageStreamingResponse(client, [contenido], _sha256_bytes(contenido))
     client.session.get = MagicMock(return_value=response)
 
@@ -755,8 +775,9 @@ def test_instalar_paquete_descarga_valida(tmp_path, monkeypatch):
     monkeypatch.setenv("COBRAHUB_INSTALL_DIR", str(install_dir))
 
     client = cobrahub_client.CobraHubClient()
-    chunks = [b"paquete-", b"valido"]
-    contenido = b"".join(chunks)
+    contenido = _paquete_cobra_bytes("paquete-valido")
+    midpoint = len(contenido) // 2
+    chunks = [contenido[:midpoint], contenido[midpoint:]]
     response = _PackageStreamingResponse(client, chunks, _sha256_bytes(contenido))
     client.session.get = MagicMock(return_value=response)
 

--- a/tests/unit/test_cobra_packaging.py
+++ b/tests/unit/test_cobra_packaging.py
@@ -149,3 +149,33 @@ def test_validar_paquete_rechaza_formato_invalido(tmp_path: Path):
 
     with pytest.raises(ValueError, match="Formato de paquete no soportado"):
         validar_paquete(paquete)
+
+
+def test_es_paquete_cobra_rechaza_co_fuente_texto(tmp_path: Path):
+    fuente = tmp_path / "programa.co"
+    fuente.write_text("imprimir('hola')\n", encoding="utf-8")
+
+    from pcobra.cobra.packaging import es_paquete_cobra
+
+    assert es_paquete_cobra(fuente) is False
+
+
+def test_es_paquete_cobra_rechaza_zip_sin_manifest(tmp_path: Path):
+    paquete = tmp_path / "sin-manifest.co"
+    with zipfile.ZipFile(paquete, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("src/main.cobra", "imprimir('hola')\n")
+
+    from pcobra.cobra.packaging import es_paquete_cobra
+
+    assert es_paquete_cobra(paquete) is False
+
+
+def test_es_paquete_cobra_acepta_zip_con_manifest(tmp_path: Path):
+    paquete = tmp_path / "con-manifest.co"
+    with zipfile.ZipFile(paquete, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(MANIFEST_NAME, json.dumps({"format": "cobra-package-v1"}))
+        zf.writestr("src/main.cobra", "imprimir('hola')\n")
+
+    from pcobra.cobra.packaging import es_paquete_cobra
+
+    assert es_paquete_cobra(paquete) is True


### PR DESCRIPTION
### Motivation
- Detectar de forma clara y barata cuándo un `.co` es un paquete Cobra (contenedor ZIP con `cobra.pkg.json`) sin tocar Lexer ni Parser.
- Evitar que comandos de empaquetado/CobraHub operen sobre archivos que no sean paquetes válidos y dar mensajes no ambiguos si se intenta ejecutar/transpilar un paquete `.co` como si fuera fuente.
- Alinear pruebas y fixtures de CobraHub con la regla estructural para que las descargas simuladas reflejen paquetes válidos.

### Description
- Añade la función pública `es_paquete_cobra(path: str | Path) -> bool` en `pcobra.cobra.packaging` que detecta si un archivo es un ZIP legible que contiene `cobra.pkg.json` en la raíz y la reutiliza desde `inspeccionar_paquete` para errores estructurales claros.
- Integra la comprobación en el subcomando `paquete` (`crear/validar/inspeccionar/extraer/instalar`) y en la capa CobraHub (`publicar_paquete`, `instalar_paquete`, `leer_metadatos`) para validar previamente antes de delegar en `validar_paquete`/`extraer_paquete`.
- Añade protecciones en runtime/compilación para rechazar un `.co` que resulte ser paquete (mensajes explicativos) en `RunService.validar_archivo` y en `validate_file` de `compile_cmd` para evitar ambigüedad futura.
- Actualiza tests y fixtures: añade pruebas unitarias para `es_paquete_cobra` (fuente texto, ZIP sin manifiesto, ZIP con `cobra.pkg.json`) y modifica fixtures de CobraHub para generar descargas streaming que sean ZIPs válidos con manifiesto; además se documenta la regla en `docs/cobrahub_paquetes.md` y en `README.md`.

### Testing
- Ejecutadas las pruebas relevantes con `python -m pytest tests/unit/test_cobra_packaging.py tests/unit/test_cli_paquete.py tests/unit/test_cli_cobrahub.py tests/unit/test_cobrahub_retry.py tests/unit/test_cobrahub_close.py -q` y todas pasaron: "48 passed, 1 warning".
- Se verificó estilo/errores con `git diff --check` y se compiló el código modificado con `python -m py_compile` para `packaging.py`, `package_cmd.py`, `cobrahub_packages.py`, `run_service.py` y `compile_cmd.py`, sin errores. 
- Las pruebas unitarias nuevas y ajustadas cubren: detección estructural de paquetes, flujo de empaquetado/inspección/extraer/instalar y escenarios de descarga/cache de CobraHub en streaming, y todas las aserciones automáticas relacionadas pasaron en la ejecución descrita.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43b13284a08327b746645337978588)