### PR TITLE
docs: update CobraHub package workflow

### DIFF
--- a/docs/frontend/cobrahub.rst
+++ b/docs/frontend/cobrahub.rst
@@ -1,47 +1,124 @@
 CobraHub
 ========
 
-CobraHub es un repositorio centralizado donde se pueden compartir módulos Cobra.
-La CLI integra dos acciones para interactuar con este servicio: ``publicar`` y
-``buscar`` dentro del subcomando ``modulos``.
+CobraHub es el punto de publicación, búsqueda e instalación de artefactos Cobra.
+El flujo recomendado trabaja con paquetes ``.co`` construidos por la capa de
+empaquetado ``pcobra.cobra.packaging``. Para el formato completo de paquetes y
+las notas de diseño consulta :doc:`paquetes` y el documento
+``../cobrahub_paquetes.md``.
 
-Publicar un módulo
-------------------
+Flujo recomendado de paquetes
+-----------------------------
 
-Para subir un archivo ``.co`` a CobraHub ejecuta:
+El flujo principal separa la preparación local del paquete de las operaciones
+contra CobraHub:
+
+1. Crear una estructura inicial de paquete:
+
+   .. code-block:: bash
+
+      cobra paquete crear mi_paquete --nombre demo --version 0.1.0
+
+2. Construir el contenedor publicable ``.co``:
+
+   .. code-block:: bash
+
+      cobra paquete construir mi_paquete dist/demo.co
+
+3. Validar que el contenedor sea legible, tenga manifiesto y conserve los
+   checksums esperados:
+
+   .. code-block:: bash
+
+      cobra paquete validar dist/demo.co
+
+4. Inspeccionar metadatos y archivos incluidos antes de publicar o instalar:
+
+   .. code-block:: bash
+
+      cobra paquete inspeccionar dist/demo.co
+
+5. Extraer el contenido en una carpeta local cuando necesites auditarlo o
+   reutilizarlo:
+
+   .. code-block:: bash
+
+      cobra paquete extraer dist/demo.co salida/demo
+
+6. Publicar el paquete en CobraHub:
+
+   .. code-block:: bash
+
+      cobra hub publicar dist/demo.co
+
+7. Buscar paquetes disponibles:
+
+   .. code-block:: bash
+
+      cobra hub buscar demo
+
+8. Instalar un paquete desde CobraHub:
+
+   .. code-block:: bash
+
+      cobra hub instalar demo
+
+Los comandos ``cobra paquete`` gestionan el ciclo de vida local del artefacto.
+Los comandos ``cobra hub`` usan ese artefacto para publicar, buscar e instalar
+paquetes mediante la API recomendada de CobraHub.
+
+Qué cuenta como paquete ``.co``
+------------------------------
+
+La extensión ``.co`` no basta para identificar un paquete publicable. Un archivo
+``.co`` solo se considera paquete Cobra cuando cumple estas dos condiciones:
+
+* es un ZIP legible;
+* contiene ``cobra.pkg.json`` en la raíz del ZIP.
+
+Por tanto, un archivo ``.co`` de texto puede seguir siendo código fuente Cobra,
+y un ZIP con extensión ``.co`` pero sin ``cobra.pkg.json`` no es un paquete Cobra
+válido. La detección y validación de este formato vive en
+``pcobra.cobra.packaging``.
+
+Compatibilidad legacy de módulos
+--------------------------------
+
+Los comandos históricos de módulos se mantienen para no romper scripts ni flujos
+existentes que publican o buscan archivos sueltos:
 
 .. code-block:: bash
 
    cobra modulos publicar ruta/al/modulo.co
-
-Si la operación es exitosa se mostrará un mensaje indicando que el módulo fue
-publicado correctamente.
-
-Buscar un módulo
-----------------
-
-Los módulos disponibles pueden descargarse con:
-
-.. code-block:: bash
-
    cobra modulos buscar nombre.co
 
-El archivo se guardará en el directorio de módulos configurado. Puedes cambiar
-la URL del servicio estableciendo la variable de entorno ``COBRAHUB_URL``.
+Este flujo legacy usa el subcomando ``modulos`` y la configuración histórica de
+CobraHub, incluida la variable de entorno ``COBRAHUB_URL`` cuando aplique. Para
+código nuevo se recomienda usar el flujo de paquetes con ``cobra paquete`` y
+``cobra hub``.
 
 Diálogo asistido desde la terminal
 ---------------------------------
 
-Cuando la CLI requiere más contexto (por ejemplo, credenciales o etiquetas del
-módulo) utiliza las utilidades de ``standard_library.interfaz`` para guiar el
-proceso. En pantalla verás algo similar a lo siguiente:
+Cuando la CLI requiere más contexto (por ejemplo, credenciales, nombre del
+paquete o etiquetas) utiliza las utilidades de ``standard_library.interfaz``
+para guiar el proceso. En pantalla verás algo similar a lo siguiente:
 
 .. code-block:: text
 
-   ¿Nombre para publicar en CobraHub? [demo_modulo]:
+   ¿Nombre para publicar en CobraHub? [demo]:
    ¿Elige la visibilidad? (privado/público) [público]: público
    ¿Cuántas etiquetas vas a registrar? 3
 
 Los campos se validan automáticamente y se muestran las opciones disponibles en
 colores, lo que facilita publicar en CobraHub desde entornos como Codespaces o
 Replit sin necesidad de interfaces gráficas adicionales.
+
+Relación con Lexer y Parser
+---------------------------
+
+Lexer y Parser no se modifican para soportar paquetes ``.co`` porque el
+empaquetado no forma parte de la sintaxis del lenguaje. La construcción,
+validación, inspección, extracción, publicación e instalación de paquetes viven
+en ``pcobra.cobra.packaging`` y tratan los archivos fuente como contenido del ZIP
+hasta que el usuario decida ejecutarlos con los comandos habituales.


### PR DESCRIPTION
### Motivation

- Centralizar la documentación en el flujo recomendado de paquetes `.co` y enlazar a la especificación de empaquetado para reducir confusión entre fuentes y paquetes publicables.
- Mantener compatibilidad con el flujo legacy de módulos para no romper scripts existentes.
- Aclarar que el empaquetado es una capa de herramientas independiente y que no modifica el Lexer ni el Parser.

### Description

- Actualiza `docs/frontend/cobrahub.rst` para presentar el flujo recomendado de paquetes y enlaza a `:doc:paquetes` y al documento `docs/cobrahub_paquetes.md`.
- Añade la lista recomendada de comandos de paquete: `cobra paquete crear`, `cobra paquete construir`, `cobra paquete validar`, `cobra paquete inspeccionar`, `cobra paquete extraer`, y los comandos de Hub: `cobra hub publicar`, `cobra hub buscar`, `cobra hub instalar`.
- Documenta la regla de detección de paquetes `.co` indicando que un `.co` es paquete solo si es un ZIP legible y contiene `cobra.pkg.json` en la raíz, y señala que la validación y detección vive en `pcobra.cobra.packaging`.
- Conserva una sección corta de compatibilidad legacy con `cobra modulos publicar` y `cobra modulos buscar` y aclara que para código nuevo se recomiendan `cobra paquete` y `cobra hub`.
- Añade la aclaración explícita de que Lexer y Parser no se tocan porque el empaquetado vive en `pcobra.cobra.packaging`.

### Testing

- Ejecuté un chequeo de contenido con el script `python - <<'PY' ... PY` que valida la presencia de las cadenas requeridas en `docs/frontend/cobrahub.rst`, y la comprobación finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43b4d9e7208327bf2eaae0ac65d74c)