### PR TITLE
Validar checksums SHA-256 en manifiestos de paquete

### DIFF
--- a/src/pcobra/cobra/packaging.py
+++ b/src/pcobra/cobra/packaging.py
@@ -180,10 +180,24 @@ def _normalizar_lista_archivos(values: Any, *, field: str) -> set[str]:
     return {_normalizar_ruta_paquete(str(value)) for value in values}
 
 
-def _normalizar_checksums(values: Any) -> dict[str, Any]:
+def _validar_checksum_sha256(name: str, checksum: Any) -> str:
+    if not isinstance(checksum, str):
+        raise ValueError(f"Checksum inválido para {name}: debe ser una cadena")
+    if len(checksum) != 64:
+        raise ValueError(f"Checksum inválido para {name}: debe tener 64 caracteres")
+    if not all(char in "0123456789abcdefABCDEF" for char in checksum):
+        raise ValueError(f"Checksum inválido para {name}: debe contener solo caracteres hexadecimales")
+    return checksum
+
+
+def _normalizar_checksums(values: Any) -> dict[str, str]:
     if not isinstance(values, dict):
         raise ValueError("El manifiesto debe declarar checksums como objeto")
-    return {_normalizar_ruta_paquete(str(name)): checksum for name, checksum in values.items()}
+    return {
+        normalized_name: _validar_checksum_sha256(normalized_name, checksum)
+        for name, checksum in values.items()
+        for normalized_name in [_normalizar_ruta_paquete(str(name))]
+    }
 
 
 def validar_paquete(package: str | Path) -> PackageInspection:

--- a/tests/unit/test_cobra_packaging.py
+++ b/tests/unit/test_cobra_packaging.py
@@ -133,6 +133,82 @@ def test_validar_paquete_rechaza_checksum_ausente(tmp_path: Path):
         validar_paquete(paquete)
 
 
+def test_validar_paquete_rechaza_checksum_no_string(tmp_path: Path):
+    contenido = b"imprimir('hola')\n"
+    paquete = _crear_zip_con_manifest(
+        tmp_path,
+        {
+            "format": "cobra-package-v1",
+            "name": "demo",
+            "version": "1.0.0",
+            "files": ["src/main.cobra"],
+            "checksums": {"src/main.cobra": 123},
+        },
+        {"src/main.cobra": contenido},
+    )
+
+    with pytest.raises(ValueError, match="Checksum inválido para src/main\\.cobra: debe ser una cadena"):
+        validar_paquete(paquete)
+
+
+def test_validar_paquete_rechaza_checksum_demasiado_corto(tmp_path: Path):
+    contenido = b"imprimir('hola')\n"
+    paquete = _crear_zip_con_manifest(
+        tmp_path,
+        {
+            "format": "cobra-package-v1",
+            "name": "demo",
+            "version": "1.0.0",
+            "files": ["src/main.cobra"],
+            "checksums": {"src/main.cobra": "abc123"},
+        },
+        {"src/main.cobra": contenido},
+    )
+
+    with pytest.raises(ValueError, match="Checksum inválido para src/main\\.cobra: debe tener 64 caracteres"):
+        validar_paquete(paquete)
+
+
+def test_validar_paquete_rechaza_checksum_no_hexadecimal(tmp_path: Path):
+    contenido = b"imprimir('hola')\n"
+    paquete = _crear_zip_con_manifest(
+        tmp_path,
+        {
+            "format": "cobra-package-v1",
+            "name": "demo",
+            "version": "1.0.0",
+            "files": ["src/main.cobra"],
+            "checksums": {"src/main.cobra": "g" * 64},
+        },
+        {"src/main.cobra": contenido},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Checksum inválido para src/main\\.cobra: debe contener solo caracteres hexadecimales",
+    ):
+        validar_paquete(paquete)
+
+
+def test_validar_paquete_acepta_checksum_valido(tmp_path: Path):
+    contenido = b"imprimir('hola')\n"
+    paquete = _crear_zip_con_manifest(
+        tmp_path,
+        {
+            "format": "cobra-package-v1",
+            "name": "demo",
+            "version": "1.0.0",
+            "files": ["src/main.cobra"],
+            "checksums": {"src/main.cobra": _sha256(contenido)},
+        },
+        {"src/main.cobra": contenido},
+    )
+
+    info = validar_paquete(paquete)
+
+    assert info.manifest["checksums"]["src/main.cobra"] == _sha256(contenido)
+
+
 def test_validar_paquete_rechaza_formato_invalido(tmp_path: Path):
     contenido = b"imprimir('hola')\n"
     paquete = _crear_zip_con_manifest(


### PR DESCRIPTION
### Motivation
- Evitar que manifiestos de paquetes contengan checksums con tipo, longitud o formato inválidos que causen comprobaciones de integridad silenciosas o mensajes genéricos.

### Description
- Añadida la función privada ` _validar_checksum_sha256(name: str, checksum: Any) -> str` que verifica que el `checksum` sea `str`, tenga exactamente 64 caracteres y contenga solo caracteres hexadecimales.
- Integrada la validación dentro de ` _normalizar_checksums` para normalizar rutas y validar cada checksum por archivo, preservando un mensaje de error específico que indica el archivo afectado.
- Actualizados los mensajes de error para ser específicos por archivo cuando el checksum es inválido.
- Modificados los archivos `src/pcobra/cobra/packaging.py` y `tests/unit/test_cobra_packaging.py` para incluir la lógica y la cobertura de pruebas.

### Testing
- Ejecutado `pytest tests/unit/test_cobra_packaging.py` y todas las pruebas de ese módulo pasaron satisfactoriamente con resultado `15 passed, 1 warning`.
- Añadidas pruebas unitarias que cubren los casos de checksum no string, checksum demasiado corto, checksum con caracteres no hexadecimales y checksum válido, y todas pasaron en la ejecución anterior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43bd1013108327a88883299a8ef939)