### PR TITLE
Aclarar contenido de paquetes Cobra y eliminar ALLOWED_TEXT_SUFFIXES

### DIFF
--- a/docs/frontend/paquetes.rst
+++ b/docs/frontend/paquetes.rst
@@ -12,16 +12,30 @@ Los archivos fuente Cobra pueden seguir usando ``.cobra`` o ``.co``; cuando
 ``.co`` se usa como paquete publicable, la CLI lo trata como un ZIP con
 metadatos.
 
-Contenido soportado
--------------------
+Contenido incluido
+------------------
 
-Los paquetes ``.co`` pueden incluir:
+La construcción del paquete no aplica una allowlist por extensión. En concreto,
+``cobra paquete construir`` recorre la carpeta fuente, preserva rutas relativas
+y añade todos los archivos regulares encontrados, con estas reglas:
 
-* archivos fuente ``.cobra`` y ``.co``;
-* documentación ``.md``;
-* archivos de texto ``.txt``;
-* ``Dockerfile``;
-* recursos adicionales preservando sus rutas relativas.
+* el manifiesto ``cobra.pkg.json`` se regenera en la raíz del ZIP y no se copia
+  como archivo de contenido normal;
+* se omiten las carpetas de trabajo ``.git``, ``__pycache__`` y
+  ``.pytest_cache``;
+* se incluyen archivos fuente ``.cobra``;
+* se incluyen archivos ``.co`` de texto usados como fuente Cobra;
+* se incluye documentación como ``README.md``, archivos ``.md`` bajo
+  ``docs/`` y archivos ``.txt``;
+* se incluye ``Dockerfile`` cuando existe en el proyecto;
+* se incluyen recursos arbitrarios, también binarios o con extensiones no
+  conocidas, bajo carpetas como ``resources/``, ``assets/`` o ``docs/``;
+* se conservan las carpetas anidadas porque cada entrada se guarda con su ruta
+  relativa dentro del proyecto.
+
+Por tanto, el límite de seguridad del formato no es la extensión del archivo,
+sino el manifiesto y la integridad: cada archivo incluido debe estar declarado
+en ``files`` y tener su checksum correspondiente en ``checksums``.
 
 Manifiesto ``cobra.pkg.json``
 -----------------------------
@@ -36,18 +50,23 @@ Ejemplo simplificado:
 .. code-block:: json
 
    {
-     "nombre": "demo",
+     "format": "cobra-package-v1",
+     "name": "demo",
      "version": "0.1.0",
-     "archivos": [
-       {
-         "ruta": "main.co",
-         "sha256": "..."
-       },
-       {
-         "ruta": "README.md",
-         "sha256": "..."
-       }
-     ]
+     "files": [
+       "src/main.co",
+       "README.md",
+       "Dockerfile",
+       "assets/imagenes/logo.bin",
+       "resources/i18n/es.dat"
+     ],
+     "checksums": {
+       "src/main.co": "...",
+       "README.md": "...",
+       "Dockerfile": "...",
+       "assets/imagenes/logo.bin": "...",
+       "resources/i18n/es.dat": "..."
+     }
    }
 
 Flujo recomendado

--- a/src/pcobra/cobra/packaging.py
+++ b/src/pcobra/cobra/packaging.py
@@ -18,7 +18,6 @@ LEGACY_MANIFEST_NAME = "cobra.pkg"
 PACKAGE_FORMAT = "cobra-package-v1"
 DEFAULT_CACHE_DIR = Path.home() / ".cobra" / "hub" / "cache"
 DEFAULT_INSTALL_DIR = Path.home() / ".cobra" / "packages"
-ALLOWED_TEXT_SUFFIXES = {".cobra", ".co", ".md", ".markdown", ".txt", ".json", ".toml", ".yaml", ".yml"}
 MAX_PACKAGE_SIZE = 50 * 1024 * 1024
 
 

--- a/tests/unit/test_cobra_packaging.py
+++ b/tests/unit/test_cobra_packaging.py
@@ -46,10 +46,15 @@ def test_paquete_cobra_conserva_estructura_y_recursos(tmp_path: Path):
     proyecto = tmp_path / "demo"
     crear_paquete(proyecto, nombre="demo", version="1.0.0")
     (proyecto / "src" / "main.cobra").write_text("imprimir('hola')\n", encoding="utf-8")
+    (proyecto / "src" / "helper.co").write_text("funcion ayuda() {}\n", encoding="utf-8")
     (proyecto / "README.md").write_text("# Demo\n", encoding="utf-8")
+    (proyecto / "docs").mkdir()
+    (proyecto / "docs" / "guia.md").write_text("# Guía\n", encoding="utf-8")
     (proyecto / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
-    (proyecto / "assets").mkdir()
-    (proyecto / "assets" / "dato.txt").write_text("recurso", encoding="utf-8")
+    (proyecto / "assets" / "imagenes").mkdir(parents=True)
+    (proyecto / "assets" / "imagenes" / "logo.bin").write_bytes(b"\x89PNG recurso")
+    (proyecto / "resources" / "i18n").mkdir(parents=True)
+    (proyecto / "resources" / "i18n" / "es.dat").write_bytes(b"hola=recurso")
 
     paquete = construir_paquete(proyecto, tmp_path / "demo.co")
 
@@ -57,14 +62,20 @@ def test_paquete_cobra_conserva_estructura_y_recursos(tmp_path: Path):
     assert info.manifest["format"] == "cobra-package-v1"
     assert MANIFEST_NAME in info.files
     assert "src/main.cobra" in info.files
+    assert "src/helper.co" in info.files
+    assert "README.md" in info.files
+    assert "docs/guia.md" in info.files
     assert "Dockerfile" in info.files
-    assert "assets/dato.txt" in info.files
+    assert "assets/imagenes/logo.bin" in info.files
+    assert "resources/i18n/es.dat" in info.files
 
     inspeccion = inspeccionar_paquete(paquete)
     assert inspeccion.checksum
 
     destino = extraer_paquete(paquete, tmp_path / "instalado")
     assert (destino / "src" / "main.cobra").read_text(encoding="utf-8") == "imprimir('hola')\n"
+    assert (destino / "assets" / "imagenes" / "logo.bin").read_bytes() == b"\x89PNG recurso"
+    assert (destino / "resources" / "i18n" / "es.dat").read_bytes() == b"hola=recurso"
 
 
 def _crear_zip_con_manifest(tmp_path: Path, manifest: dict, files: dict[str, bytes] | None = None) -> Path:


### PR DESCRIPTION
### Motivation

* La constante `ALLOWED_TEXT_SUFFIXES` estaba presente pero no se usaba para validar archivos, lo que inducía a pensar que existía una allowlist por extensión implícita. 
* El empaquetador preserva recursos arbitrarios por ruta relativa, así que es preferible documentar la política real y evitar una lista de sufijos engañosa.

### Description

* Eliminé la constante `ALLOWED_TEXT_SUFFIXES` de `src/pcobra/cobra/packaging.py` para no documentar una allowlist inexistente. 
* Actualicé `docs/frontend/paquetes.rst` para explicar que `cobra paquete construir` incluye todos los archivos regulares (omitiendo `.git`, `__pycache__` y `.pytest_cache`), que el manifiesto se regenera, y que se aceptan fuentes `.cobra`/`.co`, `Dockerfile`, documentación y recursos arbitrarios bajo carpetas como `resources/`, `assets/` o `docs/` con rutas anidadas conservadas. 
* Corregí el ejemplo del manifiesto para usar las claves reales (`format`, `name`, `version`, `files`, `checksums`). 
* Amplié `tests/unit/test_cobra_packaging.py` para cubrir `.co` fuente de texto, `README.md`, `docs/` anidados, `Dockerfile`, recursos binarios/arbitrarios en `assets/` y `resources/`, y comprobaciones de extracción del contenido binario y de texto.

### Testing

* Ejecuté `pytest tests/unit/test_cobra_packaging.py` y pasó: 15 tests passed (se mostró una advertencia deprecación existente sobre `core`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43c8af37208327ab2cc400351b02e0)