### PR TITLE
Document and test IDLE package actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,18 @@ El objetivo de pCobra es brindar a la comunidad hispanohablante una alternativa 
 2. [Manual de Cobra (referencia técnica canónica)](docs/MANUAL_COBRA.md).
 3. [Guía básica (resumen histórico)](docs/guia_basica.md) y [documentación histórica](docs/historico/README.md) como apoyo secundario.
 
+## Acciones IDLE para paquetes CobraHub
+
+El IDLE gráfico expone un flujo de empaquetado pensado para operar sobre el proyecto activo y sobre la ruta visible del campo **Ruta**. Las acciones disponibles son:
+
+- **Crear paquete**: inicializa el manifiesto `cobra.pkg.json` en el proyecto activo y prepara la estructura mínima del paquete. Si no hay proyecto activo, el IDLE muestra un mensaje indicando que primero debe abrirse o crearse uno.
+- **Abrir paquete**: extrae un paquete `.co` indicado en el campo **Ruta** hacia el proyecto activo o, si no hay proyecto activo, hacia la raíz de trabajo del IDLE.
+- **Validar paquete**: inspecciona el paquete `.co` indicado en **Ruta** y muestra si es válido; los errores estructurales del paquete se presentan como mensajes visibles de paquete inválido.
+- **Construir paquete**: genera el archivo `.co` del proyecto activo usando su manifiesto `cobra.pkg.json`. Si falta el manifiesto, la construcción se detiene para que el usuario lo cree explícitamente antes.
+- **Publicar CobraHub**: publica el paquete `.co` indicado en **Ruta** mediante el cliente de CobraHub y muestra un mensaje visible si la publicación falla.
+
+Estas acciones están conectadas desde `src/pcobra/gui/idle.py` exclusivamente a helpers de `src/pcobra/gui/runtime.py`, de modo que la interfaz no importa directamente la capa de empaquetado ni el cliente CobraHub.
+
 ## Ejemplos
 
 Proyectos de demostración disponibles en el [repositorio de ejemplos](https://github.com/Alphonsus411/pCobra/tree/HEAD/examples).

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -1631,16 +1631,25 @@ def idle_validar_paquete(paquete: str | Path):
 
 
 def idle_construir_paquete(project_root: str | Path, salida: str | Path | None = None) -> Path:
-    from pcobra.cobra.packaging import construir_paquete
+    from pcobra.cobra.packaging import MANIFEST_NAME, construir_paquete
 
     root = validar_project_root_idle(project_root)
+    manifest_path = root / MANIFEST_NAME
+    if not manifest_path.is_file():
+        raise FileNotFoundError(
+            f"No se encontró el manifiesto del paquete: {manifest_path}. "
+            "Usa 'Crear paquete' antes de construir."
+        )
     return construir_paquete(root, salida)
 
 
 def idle_abrir_paquete(paquete: str | Path, destino: str | Path) -> Path:
     from pcobra.cobra.packaging import extraer_paquete
 
-    return extraer_paquete(paquete, destino)
+    destino_path = Path(destino)
+    if not destino_path.is_dir():
+        raise FileNotFoundError(f"Destino de extracción inexistente: {destino_path}")
+    return extraer_paquete(paquete, destino_path)
 
 
 def idle_publicar_paquete(paquete: str | Path) -> bool:

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -1079,6 +1080,7 @@ def test_idle_abrir_paquete_extrae_proyecto_minimo(tmp_path: Path) -> None:
     runtime.idle_crear_paquete(project_root, "paquete-demo", version="1.0.0")
     paquete = runtime.idle_construir_paquete(project_root)
     destino = tmp_path / "extraido"
+    destino.mkdir()
 
     extraido = runtime.idle_abrir_paquete(paquete, destino)
 
@@ -1091,6 +1093,87 @@ def test_idle_abrir_paquete_extrae_proyecto_minimo(tmp_path: Path) -> None:
     assert (destino / "assets" / "recurso.txt").read_text(
         encoding="utf-8"
     ) == "recurso\n"
+
+
+def test_idle_validar_paquete_muestra_error_para_paquete_invalido(tmp_path: Path) -> None:
+    paquete = tmp_path / "invalido.co"
+    paquete.write_text("no es un zip cobra", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="paquete Cobra válido"):
+        runtime.idle_validar_paquete(paquete)
+
+
+def test_idle_abrir_paquete_falla_si_destino_no_existe(tmp_path: Path) -> None:
+    project_root = _crear_proyecto_cobra_minimo(tmp_path)
+    runtime.idle_crear_paquete(project_root, "paquete-demo", version="1.0.0")
+    paquete = runtime.idle_construir_paquete(project_root)
+    destino = tmp_path / "destino-inexistente"
+
+    with pytest.raises(FileNotFoundError, match="Destino de extracción inexistente"):
+        runtime.idle_abrir_paquete(paquete, destino)
+
+
+def test_idle_construir_paquete_falla_si_falta_manifest(tmp_path: Path) -> None:
+    project_root = _crear_proyecto_cobra_minimo(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="Usa 'Crear paquete' antes de construir"):
+        runtime.idle_construir_paquete(project_root)
+
+
+def test_idle_publicar_paquete_expone_fallo_de_publicacion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paquete = tmp_path / "paquete.co"
+    paquete.write_text("contenido", encoding="utf-8")
+
+    def publicar_mock(self, ruta: str) -> bool:
+        return False
+
+    monkeypatch.setattr(
+        "pcobra.cobra.cli.cobrahub_client.CobraHubClient.publicar_paquete",
+        publicar_mock,
+    )
+
+    assert runtime.idle_publicar_paquete(paquete) is False
+
+
+def test_botones_idle_de_paquetes_delegan_solo_en_helpers_runtime() -> None:
+    source = Path("src/pcobra/gui/idle.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    package_handlers = {
+        "crear_paquete_handler": "idle_crear_paquete",
+        "abrir_paquete_handler": "idle_abrir_paquete",
+        "validar_paquete_handler": "idle_validar_paquete",
+        "construir_paquete_handler": "idle_construir_paquete",
+        "publicar_paquete_handler": "idle_publicar_paquete",
+    }
+    handler_nodes = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name in package_handlers
+    }
+
+    assert set(handler_nodes) == set(package_handlers)
+    for handler_name, helper_name in package_handlers.items():
+        runtime_calls = [
+            call.func.attr
+            for call in ast.walk(handler_nodes[handler_name])
+            if isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id == "runtime"
+        ]
+        assert helper_name in runtime_calls
+
+    forbidden_imports = {
+        "pcobra.cobra.packaging",
+        "pcobra.cobra.cli.cobrahub_client",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            assert node.module not in forbidden_imports
+        elif isinstance(node, ast.Import):
+            assert all(alias.name not in forbidden_imports for alias in node.names)
 
 
 def test_idle_publicar_paquete_usa_cliente_mockeado_sin_red(
@@ -1120,6 +1203,7 @@ def test_helpers_idle_de_paquetes_no_importan_lexer_ni_parser_y_delegan_en_packa
     project_root = _crear_proyecto_cobra_minimo(tmp_path)
     paquete = tmp_path / "paquete.co"
     destino = tmp_path / "destino"
+    destino.mkdir()
     llamadas: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
 
     def fake_crear_paquete(*args, **kwargs):
@@ -1157,6 +1241,9 @@ def test_helpers_idle_de_paquetes_no_importan_lexer_ni_parser_y_delegan_en_packa
         return real_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr("builtins.__import__", fail_lexer_parser_import)
+
+    manifest = project_root / "cobra.pkg.json"
+    manifest.write_text("{}", encoding="utf-8")
 
     assert (
         runtime.idle_crear_paquete(project_root, "paquete-demo", version="2.0.0")


### PR DESCRIPTION
### Motivation

- Documentar las acciones de empaquetado visibles desde el IDLE para que los usuarios conozcan los flujos: crear, abrir, validar, construir y publicar paquetes CobraHub. 
- Asegurar que la interfaz del IDLE delega la lógica de empaquetado en helpers centrales y no importa capas de análisis como Lexer/Parser. 
- Hacer que los helpers del runtime expongan errores visibles en los casos comunes (manifiesto ausente, destino de extracción inexistente) para mejorar los mensajes en GUI.

### Description

- Añadida sección explicativa en `README.md` titulada "Acciones IDLE para paquetes CobraHub" que describe las acciones: Crear paquete, Abrir paquete, Validar paquete, Construir paquete y Publicar CobraHub. 
- En `src/pcobra/gui/runtime.py` se endurecen los helpers IDLE: `idle_construir_paquete` ahora comprueba que `cobra.pkg.json` exista y lanza `FileNotFoundError` con mensaje claro si falta, y `idle_abrir_paquete` valida que el `destino` exista antes de intentar extraer, lanzando `FileNotFoundError` si no. 
- Se añadieron/extendieron pruebas en `tests/unit/test_gui_runtime.py` para cubrir errores visibles: paquete inválido, fallo de publicación, destino de extracción inexistente y construcción con manifiesto ausente. 
- Se añadió una prueba que analiza el AST de `src/pcobra/gui/idle.py` para confirmar que los handlers de botones (`crear_paquete_handler`, `abrir_paquete_handler`, `validar_paquete_handler`, `construir_paquete_handler`, `publicar_paquete_handler`) llaman exclusivamente a helpers en `runtime` y que `idle.py` no importa directamente `pcobra.cobra.packaging` ni el cliente CobraHub.
- Conservada y adaptada la prueba que asegura que los helpers IDLE delegan en `pcobra.cobra.packaging` y no importan `Lexer` ni `Parser`.

### Testing

- Verificación de compilación: `python -m py_compile src/pcobra/gui/runtime.py tests/unit/test_gui_runtime.py` (éxito). 
- Ejecutados los tests enfocados en IDLE: `pytest tests/unit/test_gui_runtime.py -q -k 'idle_'` y la ejecución devolvió `12 passed` para el subconjunto IDLE. 
- Ejecutados los tests no-IDLE: `pytest tests/unit/test_gui_runtime.py -q -k 'not idle_'` y la ejecución devolvió `70 passed` para el subconjunto restante. 
- Nota sobre ejecución completa: una invocación única de `pytest` sobre todo el archivo alcanzó un `MemoryError` en este entorno tras ~49 pruebas, por lo que el archivo se verificó en dos subconjuntos complementarios y todas las pruebas añadidas y existentes pasaron en esas ejecuciones divididas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43d653328083279d97dd373bf0745f)