### PR TITLE
Documentar alias legacy de paquetes CobraHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,7 +1144,16 @@ cobra hub buscar demo
 cobra hub instalar demo --destino ./vendor/demo
 ```
 
-Los comandos legacy de `paquete crear` con salida posicional y `paquete instalar` se mantienen como alias compatibles. El IDLE (`cobra gui`) reutiliza la misma lógica de `pcobra.cobra.packaging` para las acciones **Crear paquete**, **Abrir paquete**, **Validar paquete**, **Construir paquete** y **Publicar CobraHub**.
+Los comandos legacy se mantienen por compatibilidad con scripts existentes y no deben eliminarse sin una política de deprecación explícita. La equivalencia actual entre comandos antiguos y recomendados es:
+
+| comando legacy | comando recomendado | estado | notas de compatibilidad |
+| --- | --- | --- | --- |
+| `cobra modulos publicar` | `cobra hub publicar` | Compatibilidad | `modulos` conserva el flujo histórico de módulos sueltos; `hub` publica paquetes `.co` validados. |
+| `cobra modulos buscar` | `cobra hub buscar` o `cobra hub instalar` | Compatibilidad | Usa `hub buscar` para descubrir paquetes y `hub instalar` para descargarlos e instalarlos. |
+| `cobra paquete instalar` | `cobra paquete extraer` | Alias legacy | Alias de extracción/instalación local hacia el destino indicado o `~/.cobra/packages` por defecto. |
+| `cobra paquete crear <fuente> <salida>` | `cobra paquete crear <fuente>` + `cobra paquete construir <fuente> <salida>` | Alias legacy | Mantiene la creación del manifiesto y la construcción del artefacto en una sola invocación. |
+
+El IDLE (`cobra gui`) reutiliza la misma lógica de `pcobra.cobra.packaging` para las acciones **Crear paquete**, **Abrir paquete**, **Validar paquete**, **Construir paquete** y **Publicar CobraHub**.
 
 ### IDLE gráfico
 

--- a/docs/frontend/cobrahub.rst
+++ b/docs/frontend/cobrahub.rst
@@ -94,12 +94,34 @@ Compatibilidad legacy de módulos
 --------------------------------
 
 Los comandos históricos de módulos se mantienen para no romper scripts ni flujos
-existentes que publican o buscan archivos sueltos:
+existentes que publican o buscan archivos sueltos. Estos comandos legacy se
+conservan por compatibilidad y no deben eliminarse sin una política de
+deprecación explícita.
 
-.. code-block:: bash
+.. list-table:: Alias legacy y comandos recomendados
+   :header-rows: 1
+   :widths: 24 24 16 36
 
-   cobra modulos publicar ruta/al/modulo.co
-   cobra modulos buscar nombre.co
+   * - comando legacy
+     - comando recomendado
+     - estado
+     - notas de compatibilidad
+   * - ``cobra modulos publicar``
+     - ``cobra hub publicar``
+     - Compatibilidad
+     - ``modulos`` publica módulos sueltos mediante el flujo histórico; ``hub`` publica paquetes ``.co`` con manifiesto.
+   * - ``cobra modulos buscar``
+     - ``cobra hub buscar`` o ``cobra hub instalar``
+     - Compatibilidad
+     - Para código nuevo, busca paquetes con ``hub buscar`` e instálalos con ``hub instalar``.
+   * - ``cobra paquete instalar``
+     - ``cobra paquete extraer``
+     - Alias legacy
+     - Alias de extracción/instalación local; útil para scripts antiguos que esperan un destino local.
+   * - ``cobra paquete crear <fuente> <salida>``
+     - ``cobra paquete crear <fuente>`` + ``cobra paquete construir <fuente> <salida>``
+     - Alias legacy
+     - Mantiene el flujo antiguo de creación + construcción en una sola invocación.
 
 Este flujo legacy usa el subcomando ``modulos`` y la configuración histórica de
 CobraHub, incluida la variable de entorno ``COBRAHUB_URL`` cuando aplique. Para

--- a/docs/frontend/paquetes.rst
+++ b/docs/frontend/paquetes.rst
@@ -113,10 +113,35 @@ Extraer el paquete en una carpeta local:
 Compatibilidad con comandos legacy
 ----------------------------------
 
-Los comandos legacy, como ``cobra paquete instalar`` y las variantes antiguas de
-``cobra paquete crear`` con salida posicional, se conservan como alias de
-compatibilidad. Para paquetes nuevos, el formato recomendado es el contenedor
-``.co`` con manifiesto ``cobra.pkg.json`` y checksums SHA-256.
+Los comandos legacy se mantienen por compatibilidad con scripts existentes y no
+deben eliminarse sin una política de deprecación explícita. Para paquetes
+nuevos, el formato recomendado es el contenedor ``.co`` con manifiesto
+``cobra.pkg.json`` y checksums SHA-256.
+
+.. list-table:: Alias legacy y comandos recomendados
+   :header-rows: 1
+   :widths: 24 24 16 36
+
+   * - comando legacy
+     - comando recomendado
+     - estado
+     - notas de compatibilidad
+   * - ``cobra modulos publicar``
+     - ``cobra hub publicar``
+     - Compatibilidad
+     - ``modulos`` conserva el flujo histórico de módulos sueltos; ``hub`` publica paquetes ``.co`` validados.
+   * - ``cobra modulos buscar``
+     - ``cobra hub buscar`` o ``cobra hub instalar``
+     - Compatibilidad
+     - Usa ``hub buscar`` para descubrimiento y ``hub instalar`` para descarga e instalación de paquetes CobraHub.
+   * - ``cobra paquete instalar``
+     - ``cobra paquete extraer``
+     - Alias legacy
+     - Alias de extracción/instalación local hacia el directorio indicado o ``~/.cobra/packages`` por defecto.
+   * - ``cobra paquete crear <fuente> <salida>``
+     - ``cobra paquete crear <fuente>`` + ``cobra paquete construir <fuente> <salida>``
+     - Alias legacy
+     - La forma posicional crea el manifiesto y construye el artefacto en un solo paso para compatibilidad.
 
 Véase también
 -------------

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -43,6 +43,7 @@ from pcobra.cobra.cli.public_command_policy import (
     PROFILE_PUBLIC,
     PUBLIC_COMMANDS_CONTRACT,
     filter_commands_for_profile,
+    filter_legacy_commands_for_profile,
     resolve_command_profile,
 )
 from pcobra.cobra.architecture.overview import USER_ROUTE_BACKEND_ENTRYPOINT

--- a/src/pcobra/cobra/cli/public_command_policy.py
+++ b/src/pcobra/cobra/cli/public_command_policy.py
@@ -67,7 +67,20 @@ def filter_commands_for_profile(command_names: Iterable[str], profile: str) -> s
     return names.intersection(allowed)
 
 
+def filter_legacy_commands_for_profile(command_names: Iterable[str], profile: str) -> set[str]:
+    """Devuelve comandos legacy visibles según perfil.
 
+    La superficie v1/legacy queda reservada para sesiones de desarrollo y
+    migración; el perfil público no debe exponer esos comandos.
+    """
+
+    normalized_profile = str(profile).strip().lower() or PROFILE_PUBLIC
+    names = {name.strip().lower() for name in command_names}
+
+    if normalized_profile == PROFILE_DEVELOPMENT:
+        return names
+
+    return set()
 
 
 __all__ = [
@@ -80,4 +93,5 @@ __all__ = [
     "COMMAND_PROFILES",
     "resolve_command_profile",
     "filter_commands_for_profile",
+    "filter_legacy_commands_for_profile",
 ]

--- a/tests/cli/test_cli_alias_registration.py
+++ b/tests/cli/test_cli_alias_registration.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+
+from pcobra.cobra.cli.cli import CommandRegistry
+from pcobra.cobra.cli.public_command_policy import PROFILE_DEVELOPMENT, PROFILE_PUBLIC
+from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
+
+
+def _subparser_action(parser: argparse.ArgumentParser) -> argparse._SubParsersAction:
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action
+    raise AssertionError(f"No se encontró acción de subparsers en {parser.prog!r}")
+
+
+def _command_parser(
+    *, ui: str = "v2", profile: str = PROFILE_PUBLIC
+) -> tuple[CustomArgumentParser, argparse._SubParsersAction]:
+    parser = CustomArgumentParser(prog="cobra")
+    subparsers = parser.add_subparsers(dest="command")
+    CommandRegistry().register_base_commands(subparsers, ui=ui, profile=profile)
+    return parser, subparsers
+
+
+def test_aliases_legacy_de_paquete_siguen_registrados_en_cli_publica() -> None:
+    _, comandos = _command_parser()
+
+    paquete = comandos.choices["paquete"]
+    acciones_paquete = _subparser_action(paquete)
+
+    assert "instalar" in acciones_paquete.choices
+    assert "extraer" in acciones_paquete.choices
+
+    crear = acciones_paquete.choices["crear"]
+    destinos_posicionales = [
+        action.dest
+        for action in crear._actions
+        if not action.option_strings and action.dest != "help"
+    ]
+    assert destinos_posicionales == ["fuente", "paquete"]
+
+
+def test_comandos_recomendados_de_hub_siguen_registrados_en_cli_publica() -> None:
+    _, comandos = _command_parser()
+
+    hub = comandos.choices["hub"]
+    acciones_hub = _subparser_action(hub)
+
+    assert {"publicar", "buscar", "instalar"}.issubset(acciones_hub.choices)
+
+
+def test_comandos_legacy_de_modulos_siguen_registrados_en_perfil_desarrollo_v1() -> None:
+    _, comandos = _command_parser(ui="v1", profile=PROFILE_DEVELOPMENT)
+
+    modulos = comandos.choices["modulos"]
+    acciones_modulos = _subparser_action(modulos)
+
+    assert {"publicar", "buscar"}.issubset(acciones_modulos.choices)

--- a/tests/unit/test_public_command_policy.py
+++ b/tests/unit/test_public_command_policy.py
@@ -3,15 +3,27 @@ from cobra.cli.public_command_policy import (
     PROFILE_PUBLIC,
     PUBLIC_COMMANDS_CONTRACT,
     filter_commands_for_profile,
+    filter_legacy_commands_for_profile,
 )
 
 
 def test_filter_commands_publico_permite_solo_superficie_v2_publica():
     visibles = filter_commands_for_profile(
-        ("run", "build", "test", "mod", "repl", "interactive", "legacy", "debug"),
+        (
+            "run",
+            "build",
+            "test",
+            "mod",
+            "repl",
+            "paquete",
+            "hub",
+            "interactive",
+            "legacy",
+            "debug",
+        ),
         PROFILE_PUBLIC,
     )
-    assert visibles == {"run", "build", "test", "mod", "repl"}
+    assert visibles == {"run", "build", "test", "mod", "repl", "paquete", "hub"}
 
 
 def test_filter_commands_development_permite_toda_superficie_v2():
@@ -21,7 +33,15 @@ def test_filter_commands_development_permite_toda_superficie_v2():
 
 
 def test_public_commands_contract_oficial_v2_no_incluye_alias_legacy():
-    assert PUBLIC_COMMANDS_CONTRACT == ("run", "build", "test", "mod", "repl")
+    assert PUBLIC_COMMANDS_CONTRACT == (
+        "run",
+        "build",
+        "test",
+        "mod",
+        "repl",
+        "paquete",
+        "hub",
+    )
     assert "interactive" not in PUBLIC_COMMANDS_CONTRACT
 
 


### PR DESCRIPTION
### Motivation

- Documentar en la guía y el README la equivalencia entre comandos legacy y los comandos recomendados para paquetes y CobraHub y dejar constancia de que los comandos legacy no deben eliminarse sin una política de deprecación. 
- Asegurar mediante pruebas que los alias/compatibilidades de la CLI (paquete/modulos/hub) permanezcan registrados y no se rompan durante migraciones de la interfaz.

### Description

- Se añadieron matrices de compatibilidad (tabla con `comando legacy`, `comando recomendado`, `estado`, `notas de compatibilidad`) en `README.md`, `docs/frontend/paquetes.rst` y `docs/frontend/cobrahub.rst`, incluyendo las entradas solicitadas (`cobra modulos publicar` ↔ `cobra hub publicar`, `cobra modulos buscar` ↔ `cobra hub buscar`/`hub instalar`, `cobra paquete instalar` ↔ `cobra paquete extraer`, `cobra paquete crear <fuente> <salida>` ↔ `crear` + `construir`).
- Se añadió la prueba de integración de registro de alias CLI en `tests/cli/test_cli_alias_registration.py` que verifica que `paquete.instalar`, el alias posicional de `paquete crear`, las acciones `hub publicar/buscar/instalar` y `modulos publicar/buscar` (en UI v1 perfil `development`) siguen registrados.
- Se añadió `filter_legacy_commands_for_profile` en `src/pcobra/cobra/cli/public_command_policy.py` y se importó en `src/pcobra/cobra/cli/cli.py` para habilitar el filtrado/registro correcto de rutas legacy v1 bajo el perfil de desarrollo.
- Se actualizó `tests/unit/test_public_command_policy.py` para reflejar el contrato público vigente (`paquete` y `hub` forman parte de `PUBLIC_COMMANDS_CONTRACT`) y se aplicaron pequeñas limpiezas de pruebas.

### Testing

- Ejecutadas las pruebas nuevas y relacionadas con política de comandos con `pytest tests/cli/test_cli_alias_registration.py -q` y `pytest tests/unit/test_public_command_policy.py tests/cli/test_cli_alias_registration.py -q`, ambas colecciones pasaron (todos los tests verdes).
- Se comprobó la ausencia de problemas de formato con `git diff --check`, sin errores reportados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43f0a9fc688327ac4ef8aeacb1f5e8)