### PR TITLE
Compatibiliza instalación legacy de paquetes Cobra

### DIFF
--- a/src/pcobra/cobra/cli/commands/package_cmd.py
+++ b/src/pcobra/cobra/cli/commands/package_cmd.py
@@ -1,7 +1,11 @@
 from argparse import Namespace
+import shutil
+import stat
 from pathlib import Path
 from typing import Any
+import zipfile
 
+from pcobra.cobra.cli.commands import modules_cmd
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
@@ -29,7 +33,9 @@ class PaqueteCommand(BaseCommand):
 
         crear = sub.add_parser("crear", help=_("Crea la estructura de un paquete"))
         crear.add_argument("fuente", type=Path, help=_("Directorio del paquete"))
-        crear.add_argument("paquete", nargs="?", type=Path, help=_("Alias legacy: salida .co opcional"))
+        crear.add_argument(
+            "paquete", nargs="?", type=Path, help=_("Alias legacy: salida .co opcional")
+        )
         crear.add_argument("--nombre", default=None, help=_("Nombre del paquete"))
         crear.add_argument("--version", default="0.1.0", help=_("Versión"))
 
@@ -42,56 +48,162 @@ class PaqueteCommand(BaseCommand):
         construir.add_argument("--nombre", default=None)
         construir.add_argument("--version", default=None)
 
-        inspeccionar = sub.add_parser("inspeccionar", help=_("Inspecciona el contenido de un paquete"))
+        inspeccionar = sub.add_parser(
+            "inspeccionar", help=_("Inspecciona el contenido de un paquete")
+        )
         inspeccionar.add_argument("paquete", type=Path)
 
-        verificar = sub.add_parser("verificar", aliases=["integridad"], help=_("Verifica la integridad de un paquete .co"))
+        verificar = sub.add_parser(
+            "verificar",
+            aliases=["integridad"],
+            help=_("Verifica la integridad de un paquete .co"),
+        )
         verificar.add_argument("paquete", type=Path)
 
         extraer = sub.add_parser("extraer", help=_("Extrae un paquete .co"))
         extraer.add_argument("paquete", type=Path)
         extraer.add_argument("destino", type=Path)
 
-        inst = sub.add_parser("instalar", help=_("Alias legacy de extraer a ~/.cobra/packages"))
+        inst = sub.add_parser(
+            "instalar", help=_("Alias legacy de extraer a ~/.cobra/packages")
+        )
         inst.add_argument("paquete", type=Path)
         inst.add_argument("--destino", type=Path, default=DEFAULT_INSTALL_DIR)
 
         parser.set_defaults(cmd=self)
         return parser
 
+    @staticmethod
+    def _normalizar_nombre_legacy(nombre: str) -> Path:
+        ruta = Path(nombre.replace("\\", "/"))
+        if ruta.is_absolute() or ".." in ruta.parts or not ruta.parts:
+            raise ValueError(_("Ruta insegura en paquete: {ruta}").format(ruta=nombre))
+        if ruta.as_posix() in {"", "."}:
+            raise ValueError(_("Ruta inválida en paquete: {ruta}").format(ruta=nombre))
+        return ruta
+
+    @staticmethod
+    def _rechazar_symlinks_existentes(destino: Path, objetivo: Path) -> None:
+        relativo = objetivo.relative_to(destino)
+        candidatos = [destino]
+        candidatos.extend(
+            destino / parte for parte in relativo.parents if parte != Path(".")
+        )
+        candidatos.append(objetivo)
+        for candidato in candidatos:
+            if candidato.is_symlink():
+                raise ValueError(
+                    _(
+                        "No se permite escribir sobre symlinks existentes: {ruta}"
+                    ).format(ruta=candidato)
+                )
+
+    @staticmethod
+    def _instalar(paquete: Path) -> int:
+        """Instala paquetes Cobra modernos o ZIP legacy en el directorio de módulos.
+
+        Este adaptador conserva el flujo histórico usado por tests y llamadas
+        directas: instala siempre en ``modules_cmd.MODULES_PATH`` y devuelve un
+        código de salida en vez de propagar excepciones.
+        """
+        try:
+            destino = Path(modules_cmd.MODULES_PATH).resolve()
+            if es_paquete_cobra(paquete):
+                extraer_paquete(paquete, destino)
+                mostrar_info(_("Paquete instalado en {dest}").format(dest=destino))
+                return 0
+
+            if not zipfile.is_zipfile(paquete):
+                raise ValueError(
+                    _("No es un paquete Cobra ni un ZIP legacy válido: {pkg}").format(
+                        pkg=paquete
+                    )
+                )
+
+            destino.mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(paquete) as zf:
+                for info in zf.infolist():
+                    nombre = info.filename
+                    relativo = PaqueteCommand._normalizar_nombre_legacy(nombre)
+                    objetivo_sin_resolver = destino / relativo
+                    PaqueteCommand._rechazar_symlinks_existentes(
+                        destino, objetivo_sin_resolver
+                    )
+                    objetivo = objetivo_sin_resolver.resolve()
+                    objetivo.relative_to(destino)
+                    modo = info.external_attr >> 16
+                    if stat.S_IFMT(modo) == stat.S_IFLNK:
+                        raise ValueError(
+                            _(
+                                "No se permite extraer symlinks desde paquetes legacy: {ruta}"
+                            ).format(ruta=nombre)
+                        )
+                    if info.is_dir():
+                        objetivo.mkdir(parents=True, exist_ok=True)
+                    else:
+                        objetivo.parent.mkdir(parents=True, exist_ok=True)
+                        with zf.open(info) as src, objetivo.open("wb") as out:
+                            shutil.copyfileobj(src, out)
+            mostrar_info(_("Paquete instalado en {dest}").format(dest=destino))
+            return 0
+        except Exception as exc:
+            mostrar_error(_("Error instalando paquete: {error}").format(error=str(exc)))
+            return 1
+
     def run(self, args: Namespace) -> int:
         try:
             if args.accion == "crear":
                 nombre = args.nombre or args.fuente.name
-                manifest = crear_paquete(args.fuente, nombre=nombre, version=args.version)
+                manifest = crear_paquete(
+                    args.fuente, nombre=nombre, version=args.version
+                )
                 if args.paquete:
-                    destino = construir_paquete(args.fuente, args.paquete, nombre=nombre, version=args.version)
+                    destino = construir_paquete(
+                        args.fuente, args.paquete, nombre=nombre, version=args.version
+                    )
                     mostrar_info(_("Paquete creado en {dest}").format(dest=destino))
                 else:
-                    mostrar_info(_("Estructura de paquete creada: {manifest}").format(manifest=manifest))
+                    mostrar_info(
+                        _("Estructura de paquete creada: {manifest}").format(
+                            manifest=manifest
+                        )
+                    )
                 return 0
             if args.accion == "validar":
                 if not es_paquete_cobra(args.paquete):
-                    raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
+                    raise ValueError(
+                        "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
+                    )
                 validar_paquete(args.paquete)
                 mostrar_info(_("Paquete válido: {pkg}").format(pkg=args.paquete))
                 return 0
             if args.accion == "construir":
-                destino = construir_paquete(args.fuente, args.salida, nombre=args.nombre, version=args.version)
+                destino = construir_paquete(
+                    args.fuente, args.salida, nombre=args.nombre, version=args.version
+                )
                 mostrar_info(_("Paquete construido en {dest}").format(dest=destino))
                 return 0
             if args.accion == "inspeccionar":
                 if not es_paquete_cobra(args.paquete):
-                    raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
+                    raise ValueError(
+                        "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
+                    )
                 info = inspeccionar_paquete(args.paquete)
-                mostrar_info(_("Paquete: {name} {version}").format(name=info.manifest.get("name"), version=info.manifest.get("version")))
+                mostrar_info(
+                    _("Paquete: {name} {version}").format(
+                        name=info.manifest.get("name"),
+                        version=info.manifest.get("version"),
+                    )
+                )
                 for file in info.files:
                     mostrar_info(f" - {file}")
                 mostrar_info(_("SHA256: {checksum}").format(checksum=info.checksum))
                 return 0
             if args.accion in {"verificar", "integridad"}:
                 if not es_paquete_cobra(args.paquete):
-                    raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
+                    raise ValueError(
+                        "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
+                    )
                 if verificar_integridad(args.paquete):
                     mostrar_info(_("Integridad válida: {pkg}").format(pkg=args.paquete))
                     return 0
@@ -99,18 +211,24 @@ class PaqueteCommand(BaseCommand):
                 return 1
             if args.accion == "extraer":
                 if not es_paquete_cobra(args.paquete):
-                    raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
+                    raise ValueError(
+                        "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
+                    )
                 destino = extraer_paquete(args.paquete, args.destino)
                 mostrar_info(_("Paquete extraído en {dest}").format(dest=destino))
                 return 0
             if args.accion == "instalar":
                 if not es_paquete_cobra(args.paquete):
-                    raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
+                    raise ValueError(
+                        "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
+                    )
                 destino = extraer_paquete(args.paquete, args.destino)
                 mostrar_info(_("Paquete instalado en {dest}").format(dest=destino))
                 return 0
             mostrar_error(_("Acción de paquete no reconocida"))
             return 1
         except Exception as exc:
-            mostrar_error(_("Error gestionando paquete: {error}").format(error=str(exc)))
+            mostrar_error(
+                _("Error gestionando paquete: {error}").format(error=str(exc))
+            )
             return 1

--- a/tests/unit/test_cli_paquete_symlink.py
+++ b/tests/unit/test_cli_paquete_symlink.py
@@ -57,3 +57,20 @@ def test_instalar_paquete_con_ruta_maliciosa(tmp_path, monkeypatch):
     assert ret == 1
     err.assert_called_once()
     assert not any(mods_dir.rglob("malo.co"))
+
+
+@pytest.mark.timeout(5)
+def test_instalar_paquete_con_cobra_pkg_json_moderno(tmp_path, monkeypatch):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "moderno.co").write_text("var y = 2", encoding="utf-8")
+    pkg = tmp_path / "moderno.co"
+    package_cmd.construir_paquete(src, pkg, nombre="moderno")
+    mods_dir = tmp_path / "mods"
+    monkeypatch.setattr(modules_cmd, "MODULES_PATH", mods_dir)
+    monkeypatch.setattr(package_cmd.modules_cmd, "MODULES_PATH", mods_dir)
+
+    ret = package_cmd.PaqueteCommand._instalar(pkg)
+
+    assert ret == 0
+    assert (mods_dir / "moderno.co").read_text(encoding="utf-8") == "var y = 2"


### PR DESCRIPTION
### Motivation
- Mantener compatibilidad con flujos legacy que llaman a una operación de instalación que devuelve códigos de salida en vez de lanzar excepciones. 
- Soportar tanto paquetes Cobra modernos (ZIP con `cobra.pkg.json`) como ZIP legacy, preservando la seguridad al extraer contenidos.

### Description
- Añade el método estático `PaqueteCommand._instalar(paquete: Path) -> int` que instala en `modules_cmd.MODULES_PATH`, delega paquetes modernos a `extraer_paquete` y devuelve 0/1 según el resultado. 
- Introduce helpers `PaqueteCommand._normalizar_nombre_legacy` y `PaqueteCommand._rechazar_symlinks_existentes` para validar rutas dentro del ZIP y rechazar escritura sobre symlinks existentes. 
- Implementa extracción segura de ZIP legacy verificando rutas relativas, rechazando rutas absolutas o con `..`, confinando destinos dentro de `MODULES_PATH` y prohibiendo la extracción de symlinks empaquetados. 
- Añade un test que cubre la instalación de un paquete `.co` moderno vía el adaptador legacy y modifica `tests/unit/test_cli_paquete_symlink.py` para incluirlo.

### Testing
- Se ejecutó `python -m black src/pcobra/cobra/cli/commands/package_cmd.py tests/unit/test_cli_paquete_symlink.py` y se aplicó formato sin incidencias. 
- Se ejecutó `python -m ruff check src/pcobra/cobra/cli/commands/package_cmd.py` y no se reportaron errores. 
- Se ejecutó `pytest -q tests/unit/test_cli_paquete_symlink.py tests/unit/test_cli_paquete.py` y todos los tests pasaron (`7 passed`, `1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43f93ae8648327b1c1e7d6323a0749)