### PR TITLE
Abstraer repositorio de paquetes CobraHub

### DIFF
--- a/src/pcobra/cobra/cli/cobrahub_packages.py
+++ b/src/pcobra/cobra/cli/cobrahub_packages.py
@@ -1,88 +1,30 @@
-"""API de paquetes CobraHub.
+"""Fachada compatible para paquetes CobraHub.
 
-Esta capa concentra la lógica específica de paquetes ``.co``: publicación,
-búsqueda, instalación, caché local y lectura de metadatos. Recibe un
-``CobraHubClient`` compatible para reutilizar la configuración HTTP, validación
-de URL y límites comunes sin mezclar el flujo legacy de módulos.
+La lógica de repositorio vive en ``pcobra.cobra.hub.repository``. Esta clase se
+mantiene como punto de entrada estable para CLI, IDLE y tests, traduciendo el
+contrato independiente a los mensajes y valores booleanos históricos.
 """
 
 from __future__ import annotations
 
-import hashlib
-import json
 import logging
 import os
-import shutil
-import urllib.parse
-from email.message import Message
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.hub.repository import (
+    HttpCobraHubRepository,
+    PackageRepository,
+    install_dir,
+    json_dumps,
+    package_cache_dir,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - solo para tipado
     from pcobra.cobra.cli.cobrahub_client import CobraHubClient
 
 logger = logging.getLogger(__name__)
-
-
-def _normalizar_resultado_paquete(item: Any) -> dict[str, str]:
-    """Convierte respuestas variadas del servidor al modelo mínimo público."""
-    from pcobra.cobra.packaging import PackageSearchResult
-
-    if not isinstance(item, dict):
-        item = {"name": str(item)}
-
-    name = item.get("name") or item.get("nombre") or item.get("package")
-    if not name:
-        name = Path(str(item.get("filename") or item.get("archivo") or "paquete.co")).stem
-
-    result = PackageSearchResult(
-        name=str(name),
-        version=_optional_str(item.get("version")),
-        filename=_optional_str(item.get("filename") or item.get("archivo")),
-        checksum=_optional_str(
-            item.get("checksum")
-            or item.get("sha256")
-            or item.get("digest")
-            or item.get("content_checksum")
-        ),
-        download_url=_optional_str(
-            item.get("download_url") or item.get("url") or item.get("href")
-        ),
-        remote_id=_optional_str(item.get("remote_id") or item.get("id")),
-    )
-    return result.as_dict()
-
-
-def _optional_str(value: Any) -> str | None:
-    if value is None:
-        return None
-    value = str(value)
-    return value or None
-
-
-def _cache_filename(nombre: str, version: str | None) -> str:
-    return f"{nombre}-{version}.co" if version else f"{nombre}.co"
-
-
-def _version_from_response(response: Any) -> str | None:
-    headers = getattr(response, "headers", {}) or {}
-    version = headers.get("X-Package-Version") or headers.get("X-Cobra-Package-Version")
-    if version:
-        return str(version)
-    content_disposition = headers.get("Content-Disposition")
-    if not content_disposition:
-        return None
-    msg = Message()
-    msg["Content-Disposition"] = content_disposition
-    filename = msg.get_filename()
-    if not filename:
-        return None
-    stem = Path(filename).stem
-    if "-" not in stem:
-        return None
-    return stem.rsplit("-", 1)[1] or None
 
 
 def _mostrar_error(mensaje: str) -> None:
@@ -100,10 +42,21 @@ def _mostrar_info(mensaje: str) -> None:
 
 
 class CobraHubPackages:
-    """Operaciones de paquetes publicables en CobraHub."""
+    """Operaciones de paquetes publicables en CobraHub.
 
-    def __init__(self, client: "CobraHubClient") -> None:
+    Conserva la API histórica mientras delega publicación, búsqueda, descarga y
+    lectura de metadatos en ``PackageRepository``. Esta separación permite sumar
+    repositorios indexados, mirrors, autenticación y resolución de versiones sin
+    tocar Lexer/Parser ni los comandos existentes.
+    """
+
+    def __init__(
+        self,
+        client: "CobraHubClient",
+        repository: PackageRepository | None = None,
+    ) -> None:
         self.client = client
+        self.repository = repository or HttpCobraHubRepository(client)
 
     def publicar_paquete(self, ruta: str) -> bool:
         """Publica un paquete .co en CobraHub y lo guarda en caché local."""
@@ -115,25 +68,7 @@ class CobraHubPackages:
             if not es_paquete_cobra(ruta):
                 raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
             info = validar_paquete(ruta)
-            checksum = info.checksum
-            with open(ruta, "rb") as f:
-                with self.client.session.post(
-                    f"{self.client.base_url}/paquetes",
-                    files={"file": f},
-                    data={"metadata": json_dumps(info.manifest)},
-                    headers={
-                        "X-Content-Checksum": checksum,
-                        "Idempotency-Key": checksum,
-                    },
-                    timeout=(
-                        self.client.CONNECT_TIMEOUT,
-                        self.client.READ_TIMEOUT,
-                    ),
-                ) as response:
-                    response.raise_for_status()
-            cache_path = package_cache_dir() / Path(ruta).name
-            if Path(ruta).resolve() != cache_path.resolve():
-                shutil.copy2(ruta, cache_path)
+            self.repository.publish(ruta, dict(info.manifest), info.checksum)
             _mostrar_info(_("Paquete publicado correctamente"))
             return True
         except Exception as e:
@@ -146,15 +81,7 @@ class CobraHubPackages:
         if not self.client._validar_url():
             return []
         try:
-            with self.client.session.get(
-                f"{self.client.base_url}/paquetes",
-                params={"q": consulta},
-                timeout=(self.client.CONNECT_TIMEOUT, self.client.READ_TIMEOUT),
-            ) as response:
-                response.raise_for_status()
-                data = response.json() if hasattr(response, "json") else []
-            items = data.get("results", []) if isinstance(data, dict) else data
-            return [_normalizar_resultado_paquete(item) for item in list(items)]
+            return [result.as_dict() for result in self.repository.search(consulta)]
         except Exception as e:
             logger.error(f"Error buscando paquetes: {e}")
             _mostrar_error(_("Error buscando paquetes: {err}").format(err=str(e)))
@@ -166,41 +93,12 @@ class CobraHubPackages:
         """Descarga, cachea e instala un paquete desde CobraHub."""
         from pcobra.cobra.packaging import es_paquete_cobra, extraer_paquete
 
+        cache_path: Path | None = None
         if not self.client._validar_nombre_modulo(nombre) or not self.client._validar_url():
             return False
-        cache_path = package_cache_dir() / _cache_filename(nombre, version)
         try:
-            with self.client.session.get(
-                f"{self.client.base_url}/paquetes/{urllib.parse.quote(nombre)}",
-                **({"params": {"version": version}} if version else {}),
-                timeout=(self.client.CONNECT_TIMEOUT, self.client.READ_TIMEOUT),
-                stream=True,
-            ) as response:
-                response.raise_for_status()
-                checksum_servidor = response.headers.get("X-Content-Checksum")
-                version_servidor = _version_from_response(response)
-                if version_servidor and version_servidor != version:
-                    cache_path = package_cache_dir() / _cache_filename(nombre, version_servidor)
-                sha256 = hashlib.sha256()
-                tamaño_total = 0
-
-                with open(cache_path, "wb") as out:
-                    for chunk in response.iter_content(chunk_size=self.client.CHUNK_SIZE):
-                        if not chunk:
-                            continue
-                        tamaño_total += len(chunk)
-                        if tamaño_total > self.client.MAX_FILE_SIZE:
-                            out.close()
-                            os.unlink(cache_path)
-                            _mostrar_error(_("Archivo descargado demasiado grande"))
-                            return False
-                        sha256.update(chunk)
-                        out.write(chunk)
-
-            if checksum_servidor and sha256.hexdigest() != checksum_servidor:
-                os.unlink(cache_path)
-                _mostrar_error(_("Verificación de integridad fallida"))
-                return False
+            downloaded = self.repository.download(nombre, version)
+            cache_path = downloaded.path
 
             if not es_paquete_cobra(cache_path):
                 os.unlink(cache_path)
@@ -214,7 +112,7 @@ class CobraHubPackages:
         except Exception as e:
             logger.error(f"Error instalando paquete: {e}")
             _mostrar_error(_("Error instalando paquete: {err}").format(err=str(e)))
-            if cache_path.exists():
+            if cache_path is not None and cache_path.exists():
                 try:
                     os.unlink(cache_path)
                 except Exception:
@@ -223,37 +121,7 @@ class CobraHubPackages:
 
     def leer_metadatos(self, ruta: str | Path) -> dict[str, Any]:
         """Lee y devuelve el manifiesto/metadatos de un paquete local ``.co``."""
-        from pcobra.cobra.packaging import es_paquete_cobra, validar_paquete
-
-        if not es_paquete_cobra(ruta):
-            raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
-        info = validar_paquete(ruta)
-        return dict(info.manifest)
-
-
-def package_cache_dir() -> Path:
-    """Devuelve el directorio de caché local para paquetes CobraHub."""
-    cache = Path(
-        os.environ.get(
-            "COBRAHUB_CACHE_DIR", str(Path.home() / ".cobra" / "hub" / "cache")
-        )
-    ).expanduser()
-    cache.mkdir(parents=True, exist_ok=True)
-    return cache
-
-
-def install_dir() -> Path:
-    """Devuelve el directorio de instalación por defecto para paquetes."""
-    dest = Path(
-        os.environ.get("COBRAHUB_INSTALL_DIR", str(Path.home() / ".cobra" / "packages"))
-    ).expanduser()
-    dest.mkdir(parents=True, exist_ok=True)
-    return dest
-
-
-def json_dumps(value: Any) -> str:
-    """Serializa metadatos de paquete de forma estable."""
-    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+        return self.repository.read_metadata(ruta)
 
 
 __all__ = [

--- a/src/pcobra/cobra/hub/__init__.py
+++ b/src/pcobra/cobra/hub/__init__.py
@@ -1,0 +1,13 @@
+"""Infraestructura de repositorios CobraHub."""
+
+from pcobra.cobra.hub.repository import (
+    DownloadedPackage,
+    HttpCobraHubRepository,
+    PackageRepository,
+)
+
+__all__ = [
+    "DownloadedPackage",
+    "HttpCobraHubRepository",
+    "PackageRepository",
+]

--- a/src/pcobra/cobra/hub/repository.py
+++ b/src/pcobra/cobra/hub/repository.py
@@ -1,0 +1,242 @@
+"""Abstracción de repositorios de paquetes Cobra.
+
+Esta capa encapsula la publicación, búsqueda, descarga y lectura de metadatos
+sin acoplar esas operaciones al Lexer ni al Parser. En el futuro permitirá
+incorporar repositorios indexados, mirrors, autenticación y resolución de
+versiones sin tocar las fases de análisis del lenguaje.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import urllib.parse
+from dataclasses import dataclass
+from email.message import Message
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.packaging import PackageSearchResult
+
+if TYPE_CHECKING:  # pragma: no cover - solo para tipado
+    from pcobra.cobra.cli.cobrahub_client import CobraHubClient
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DownloadedPackage:
+    """Resultado de una descarga de paquete desde un repositorio."""
+
+    path: Path
+    name: str
+    version: str | None = None
+    checksum: str | None = None
+
+
+class PackageRepository(Protocol):
+    """Contrato independiente para repositorios de paquetes Cobra."""
+
+    def publish(self, package_path: str | Path, metadata: dict[str, Any], checksum: str) -> bool:
+        """Publica un paquete ya validado con sus metadatos y checksum."""
+        ...
+
+    def search(self, query: str) -> list[PackageSearchResult]:
+        """Busca paquetes por consulta textual."""
+        ...
+
+    def download(self, name: str, version: str | None = None) -> DownloadedPackage:
+        """Descarga un paquete y devuelve su ubicación local/cacheada."""
+        ...
+
+    def read_metadata(self, package_path: str | Path) -> dict[str, Any]:
+        """Lee los metadatos de un paquete local."""
+        ...
+
+
+class HttpCobraHubRepository:
+    """Repositorio CobraHub respaldado por HTTP usando un ``CobraHubClient``."""
+
+    def __init__(self, client: "CobraHubClient") -> None:
+        self.client = client
+
+    def publish(self, package_path: str | Path, metadata: dict[str, Any], checksum: str) -> bool:
+        """Publica un paquete .co mediante la API HTTP de CobraHub."""
+        ruta = Path(package_path)
+        with ruta.open("rb") as f:
+            with self.client.session.post(
+                f"{self.client.base_url}/paquetes",
+                files={"file": f},
+                data={"metadata": json_dumps(metadata)},
+                headers={
+                    "X-Content-Checksum": checksum,
+                    "Idempotency-Key": checksum,
+                },
+                timeout=(
+                    self.client.CONNECT_TIMEOUT,
+                    self.client.READ_TIMEOUT,
+                ),
+            ) as response:
+                response.raise_for_status()
+        cache_path = package_cache_dir() / ruta.name
+        if ruta.resolve() != cache_path.resolve():
+            shutil.copy2(ruta, cache_path)
+        return True
+
+    def search(self, query: str) -> list[PackageSearchResult]:
+        """Busca paquetes mediante la API HTTP de CobraHub."""
+        with self.client.session.get(
+            f"{self.client.base_url}/paquetes",
+            params={"q": query},
+            timeout=(self.client.CONNECT_TIMEOUT, self.client.READ_TIMEOUT),
+        ) as response:
+            response.raise_for_status()
+            data = response.json() if hasattr(response, "json") else []
+        items = data.get("results", []) if isinstance(data, dict) else data
+        return [_normalizar_resultado_paquete(item) for item in list(items)]
+
+    def download(self, name: str, version: str | None = None) -> DownloadedPackage:
+        """Descarga un paquete por nombre y versión opcional en la caché local."""
+        cache_path = package_cache_dir() / _cache_filename(name, version)
+        try:
+            with self.client.session.get(
+                f"{self.client.base_url}/paquetes/{urllib.parse.quote(name)}",
+                **({"params": {"version": version}} if version else {}),
+                timeout=(self.client.CONNECT_TIMEOUT, self.client.READ_TIMEOUT),
+                stream=True,
+            ) as response:
+                response.raise_for_status()
+                checksum_servidor = response.headers.get("X-Content-Checksum")
+                version_servidor = _version_from_response(response)
+                if version_servidor and version_servidor != version:
+                    cache_path = package_cache_dir() / _cache_filename(name, version_servidor)
+                sha256 = hashlib.sha256()
+                tamaño_total = 0
+
+                with open(cache_path, "wb") as out:
+                    for chunk in response.iter_content(chunk_size=self.client.CHUNK_SIZE):
+                        if not chunk:
+                            continue
+                        tamaño_total += len(chunk)
+                        if tamaño_total > self.client.MAX_FILE_SIZE:
+                            out.close()
+                            os.unlink(cache_path)
+                            raise ValueError(_("Archivo descargado demasiado grande"))
+                        sha256.update(chunk)
+                        out.write(chunk)
+
+            digest = sha256.hexdigest()
+            if checksum_servidor and digest != checksum_servidor:
+                os.unlink(cache_path)
+                raise ValueError(_("Verificación de integridad fallida"))
+
+            return DownloadedPackage(
+                path=cache_path,
+                name=name,
+                version=version_servidor or version,
+                checksum=checksum_servidor or digest,
+            )
+        except Exception:
+            if cache_path.exists():
+                os.unlink(cache_path)
+            raise
+
+    def read_metadata(self, package_path: str | Path) -> dict[str, Any]:
+        """Lee metadatos de un paquete local usando el validador de paquetes Cobra."""
+        from pcobra.cobra.packaging import es_paquete_cobra, validar_paquete
+
+        if not es_paquete_cobra(package_path):
+            raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
+        info = validar_paquete(package_path)
+        return dict(info.manifest)
+
+
+def _normalizar_resultado_paquete(item: Any) -> PackageSearchResult:
+    """Convierte respuestas variadas del servidor al modelo mínimo público."""
+    if not isinstance(item, dict):
+        item = {"name": str(item)}
+
+    name = item.get("name") or item.get("nombre") or item.get("package")
+    if not name:
+        name = Path(str(item.get("filename") or item.get("archivo") or "paquete.co")).stem
+
+    return PackageSearchResult(
+        name=str(name),
+        version=_optional_str(item.get("version")),
+        filename=_optional_str(item.get("filename") or item.get("archivo")),
+        checksum=_optional_str(
+            item.get("checksum")
+            or item.get("sha256")
+            or item.get("digest")
+            or item.get("content_checksum")
+        ),
+        download_url=_optional_str(item.get("download_url") or item.get("url") or item.get("href")),
+        remote_id=_optional_str(item.get("remote_id") or item.get("id")),
+    )
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    value = str(value)
+    return value or None
+
+
+def _cache_filename(nombre: str, version: str | None) -> str:
+    return f"{nombre}-{version}.co" if version else f"{nombre}.co"
+
+
+def _version_from_response(response: Any) -> str | None:
+    headers = getattr(response, "headers", {}) or {}
+    version = headers.get("X-Package-Version") or headers.get("X-Cobra-Package-Version")
+    if version:
+        return str(version)
+    content_disposition = headers.get("Content-Disposition")
+    if not content_disposition:
+        return None
+    msg = Message()
+    msg["Content-Disposition"] = content_disposition
+    filename = msg.get_filename()
+    if not filename:
+        return None
+    stem = Path(filename).stem
+    if "-" not in stem:
+        return None
+    return stem.rsplit("-", 1)[1] or None
+
+
+def package_cache_dir() -> Path:
+    """Devuelve el directorio de caché local para paquetes CobraHub."""
+    cache = Path(
+        os.environ.get("COBRAHUB_CACHE_DIR", str(Path.home() / ".cobra" / "hub" / "cache"))
+    ).expanduser()
+    cache.mkdir(parents=True, exist_ok=True)
+    return cache
+
+
+def install_dir() -> Path:
+    """Devuelve el directorio de instalación por defecto para paquetes."""
+    dest = Path(
+        os.environ.get("COBRAHUB_INSTALL_DIR", str(Path.home() / ".cobra" / "packages"))
+    ).expanduser()
+    dest.mkdir(parents=True, exist_ok=True)
+    return dest
+
+
+def json_dumps(value: Any) -> str:
+    """Serializa metadatos de paquete de forma estable."""
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+__all__ = [
+    "DownloadedPackage",
+    "HttpCobraHubRepository",
+    "PackageRepository",
+    "install_dir",
+    "json_dumps",
+    "package_cache_dir",
+]


### PR DESCRIPTION
### Motivation
- Desacoplar la lógica de red y caché de paquetes del resto del código para permitir en el futuro mirrors, repositorios indexados, autenticación y resolución de versiones sin tocar Lexer/Parser. 
- Hacer la lógica de paquetes intercambiable mediante un contrato, facilitando pruebas y sustituciones (p. ej. implementar un mirror local o un backend autenticado). 
- Mantener la API histórica usada por CLI/IDLE/tests para no romper integraciones existentes.

### Description
- Añadido `src/pcobra/cobra/hub/repository.py` que define el protocolo `PackageRepository`, el resultado `DownloadedPackage` y la implementación HTTP `HttpCobraHubRepository` con la lógica de publicación, búsqueda, descarga en streaming, validación de checksum/tamaño y limpieza de descargas parciales. 
- `CobraHubPackages` (en `src/pcobra/cobra/cli/cobrahub_packages.py`) convertido en fachada compatible que delega en un `PackageRepository` y preserva la API pública histórica; por defecto usa `HttpCobraHubRepository`. 
- Exportes añadidos en `src/pcobra/cobra/hub/__init__.py` para reexportar `DownloadedPackage`, `HttpCobraHubRepository` y `PackageRepository`. 
- Utilidades de caché/instalación y serialización (`package_cache_dir`, `install_dir`, `json_dumps`) se usan desde la nueva capa para conservar comportamiento y compatibilidad.

### Testing
- Ejecutado `python -m pytest tests/unit/test_cobra_packaging.py tests/unit/test_cli_cobrahub.py -q` y todas las pruebas unitarias relevantes pasaron (`48 passed, 1 warning`). 
- Ejecutado `python -m pytest tests/unit/test_cli_cobrahub.py -q` y las pruebas de CobraHub pasaron (todos los casos de instalación/búsqueda/publicación). 
- Ejecutado `python -m compileall -q src/pcobra/cobra/cli/cobrahub_packages.py src/pcobra/cobra/hub` y los módulos compilaron sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43ff8857708327b02256b147a82437)