### PR TITLE
Añadir modelo PackageManifest para manifiestos de paquetes Cobra

### DIFF
--- a/src/pcobra/cobra/packaging.py
+++ b/src/pcobra/cobra/packaging.py
@@ -22,6 +22,103 @@ MAX_PACKAGE_SIZE = 50 * 1024 * 1024
 
 
 @dataclass(frozen=True)
+class PackageManifest:
+    """Modelo explícito del manifiesto de un paquete Cobra."""
+
+    format: str
+    name: str
+    version: str
+    files: list[str]
+    checksums: dict[str, str]
+    description: str | None = None
+    authors: list[str] | None = None
+    license: str | None = None
+    homepage: str | None = None
+    dependencies: dict[str, str] | None = None
+
+
+def manifest_from_dict(data: dict[str, Any]) -> PackageManifest:
+    """Convierte un diccionario JSON en un manifiesto Cobra validado.
+
+    Mantiene compatibilidad con manifiestos históricos que solo declaran
+    ``format``, ``name``, ``version``, ``files`` y ``checksums``.
+    """
+    package_format = data.get("format")
+    if package_format is None:
+        raise ValueError("El manifiesto no declara format")
+    if package_format != PACKAGE_FORMAT:
+        raise ValueError(f"Formato de paquete no soportado: {package_format}")
+
+    name = data.get("name")
+    if not name:
+        raise ValueError("El manifiesto no declara name")
+
+    version = data.get("version")
+    if not version:
+        raise ValueError("El manifiesto no declara version")
+
+    files = data.get("files", [])
+    checksums = data.get("checksums", {})
+    if not isinstance(files, list):
+        raise ValueError("El manifiesto debe declarar files como lista")
+    if not isinstance(checksums, dict):
+        raise ValueError("El manifiesto debe declarar checksums como objeto")
+
+    authors = data.get("authors")
+    if authors is not None and not isinstance(authors, list):
+        raise ValueError("El manifiesto debe declarar authors como lista")
+
+    dependencies = data.get("dependencies")
+    if dependencies is not None and not isinstance(dependencies, dict):
+        raise ValueError("El manifiesto debe declarar dependencies como objeto")
+
+    return PackageManifest(
+        format=str(package_format),
+        name=str(name),
+        version=str(version),
+        files=[str(file) for file in files],
+        checksums={str(name): checksum for name, checksum in checksums.items()},
+        description=(
+            None if data.get("description") is None else str(data.get("description"))
+        ),
+        authors=None if authors is None else [str(author) for author in authors],
+        license=None if data.get("license") is None else str(data.get("license")),
+        homepage=None if data.get("homepage") is None else str(data.get("homepage")),
+        dependencies=(
+            None
+            if dependencies is None
+            else {str(name): str(value) for name, value in dependencies.items()}
+        ),
+    )
+
+
+def manifest_to_dict(manifest: PackageManifest) -> dict[str, Any]:
+    """Convierte un ``PackageManifest`` en un diccionario JSON-compatible."""
+    data: dict[str, Any] = {
+        "format": manifest.format,
+        "name": manifest.name,
+        "version": manifest.version,
+        "files": list(manifest.files),
+        "checksums": dict(manifest.checksums),
+    }
+    optional_fields = {
+        "description": manifest.description,
+        "authors": manifest.authors,
+        "license": manifest.license,
+        "homepage": manifest.homepage,
+        "dependencies": manifest.dependencies,
+    }
+    for key, value in optional_fields.items():
+        if value is not None:
+            data[key] = (
+                list(value)
+                if isinstance(value, list)
+                else dict(value) if isinstance(value, dict) else value
+            )
+    return data
+
+
+@dataclass(frozen=True)
 class PackageSearchResult:
     """Metadatos normalizados para resultados remotos de CobraHub."""
 
@@ -88,45 +185,80 @@ def crear_paquete(source: str | Path, *, nombre: str, version: str = "0.1.0") ->
     root = Path(source)
     root.mkdir(parents=True, exist_ok=True)
     (root / "src").mkdir(exist_ok=True)
-    manifest = {
-        "format": PACKAGE_FORMAT,
-        "name": _safe_name(nombre),
-        "version": version,
-        "files": [],
-        "checksums": {},
-    }
+    manifest = manifest_to_dict(
+        PackageManifest(
+            format=PACKAGE_FORMAT,
+            name=_safe_name(nombre),
+            version=version,
+            files=[],
+            checksums={},
+        )
+    )
     manifest_path = root / MANIFEST_NAME
     if not manifest_path.exists():
-        manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
     readme = root / "README.md"
     if not readme.exists():
         readme.write_text(f"# {nombre}\n\nPaquete Cobra.\n", encoding="utf-8")
     return manifest_path
 
 
-def construir_paquete(source: str | Path, output: str | Path | None = None, *, nombre: str | None = None, version: str | None = None) -> Path:
+def construir_paquete(
+    source: str | Path,
+    output: str | Path | None = None,
+    *,
+    nombre: str | None = None,
+    version: str | None = None,
+) -> Path:
     """Construye un archivo ``.co`` ZIP con manifiesto e integridad."""
     root = Path(source).resolve()
     if not root.is_dir():
         raise ValueError("La fuente del paquete debe ser un directorio")
     manifest_path = root / MANIFEST_NAME
-    manifest: dict[str, Any]
     if manifest_path.exists():
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest = manifest_from_dict(manifest_data)
     else:
-        manifest = {"format": PACKAGE_FORMAT, "name": nombre or root.name, "version": version or "0.1.0"}
-    manifest["format"] = PACKAGE_FORMAT
-    manifest["name"] = _safe_name(str(nombre or manifest.get("name") or root.name))
-    manifest["version"] = str(version or manifest.get("version") or "0.1.0")
+        manifest = PackageManifest(
+            format=PACKAGE_FORMAT,
+            name=str(nombre or root.name),
+            version=str(version or "0.1.0"),
+            files=[],
+            checksums={},
+        )
 
-    files = [p for p in _iter_package_files(root) if p.relative_to(root).as_posix() != MANIFEST_NAME]
+    files = [
+        p
+        for p in _iter_package_files(root)
+        if p.relative_to(root).as_posix() != MANIFEST_NAME
+    ]
     checksums = {p.relative_to(root).as_posix(): _sha256_file(p) for p in files}
-    manifest["files"] = list(checksums)
-    manifest["checksums"] = checksums
-    dest = Path(output) if output else root.parent / f"{manifest['name']}-{manifest['version']}.co"
+    manifest = PackageManifest(
+        format=PACKAGE_FORMAT,
+        name=_safe_name(str(nombre or manifest.name or root.name)),
+        version=str(version or manifest.version or "0.1.0"),
+        files=list(checksums),
+        checksums=checksums,
+        description=manifest.description,
+        authors=manifest.authors,
+        license=manifest.license,
+        homepage=manifest.homepage,
+        dependencies=manifest.dependencies,
+    )
+    manifest_data = manifest_to_dict(manifest)
+    dest = (
+        Path(output)
+        if output
+        else root.parent / f"{manifest.name}-{manifest.version}.co"
+    )
     dest.parent.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr(MANIFEST_NAME, json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
+        zf.writestr(
+            MANIFEST_NAME,
+            json.dumps(manifest_data, indent=2, ensure_ascii=False) + "\n",
+        )
         for file in files:
             zf.write(file, file.relative_to(root).as_posix())
     return dest
@@ -156,11 +288,15 @@ def inspeccionar_paquete(package: str | Path) -> PackageInspection:
     if pkg.stat().st_size > MAX_PACKAGE_SIZE:
         raise ValueError("El paquete excede el tamaño máximo permitido")
     if not es_paquete_cobra(pkg):
-        raise ValueError("El paquete no es un paquete Cobra válido: debe ser ZIP y contener cobra.pkg.json")
+        raise ValueError(
+            "El paquete no es un paquete Cobra válido: debe ser ZIP y contener cobra.pkg.json"
+        )
     with zipfile.ZipFile(pkg) as zf:
         names = zf.namelist()
-        manifest = json.loads(zf.read(MANIFEST_NAME).decode("utf-8"))
-    return PackageInspection(pkg, manifest, names, _sha256_file(pkg))
+        manifest = manifest_from_dict(
+            json.loads(zf.read(MANIFEST_NAME).decode("utf-8"))
+        )
+    return PackageInspection(pkg, manifest_to_dict(manifest), names, _sha256_file(pkg))
 
 
 def _normalizar_ruta_paquete(name: str) -> str:
@@ -185,7 +321,9 @@ def _validar_checksum_sha256(name: str, checksum: Any) -> str:
     if len(checksum) != 64:
         raise ValueError(f"Checksum inválido para {name}: debe tener 64 caracteres")
     if not all(char in "0123456789abcdefABCDEF" for char in checksum):
-        raise ValueError(f"Checksum inválido para {name}: debe contener solo caracteres hexadecimales")
+        raise ValueError(
+            f"Checksum inválido para {name}: debe contener solo caracteres hexadecimales"
+        )
     return checksum
 
 
@@ -201,19 +339,10 @@ def _normalizar_checksums(values: Any) -> dict[str, str]:
 
 def validar_paquete(package: str | Path) -> PackageInspection:
     inspection = inspeccionar_paquete(package)
-    manifest = inspection.manifest
-    package_format = manifest.get("format")
-    if package_format is None:
-        raise ValueError("El manifiesto no declara format")
-    if package_format != PACKAGE_FORMAT:
-        raise ValueError(f"Formato de paquete no soportado: {package_format}")
-    if not manifest.get("name"):
-        raise ValueError("El manifiesto no declara name")
-    if not manifest.get("version"):
-        raise ValueError("El manifiesto no declara version")
+    manifest = manifest_from_dict(inspection.manifest)
 
-    declared_files = _normalizar_lista_archivos(manifest.get("files"), field="files")
-    checksums = _normalizar_checksums(manifest.get("checksums"))
+    declared_files = _normalizar_lista_archivos(manifest.files, field="files")
+    checksums = _normalizar_checksums(manifest.checksums)
 
     with zipfile.ZipFile(inspection.path) as zf:
         real_files = {
@@ -223,20 +352,28 @@ def validar_paquete(package: str | Path) -> PackageInspection:
         }
         extra_files = real_files - declared_files
         if extra_files:
-            raise ValueError(f"Archivos no declarados en paquete: {', '.join(sorted(extra_files))}")
+            raise ValueError(
+                f"Archivos no declarados en paquete: {', '.join(sorted(extra_files))}"
+            )
 
         missing_files = declared_files - real_files
         if missing_files:
-            raise ValueError(f"Archivos declarados ausentes: {', '.join(sorted(missing_files))}")
+            raise ValueError(
+                f"Archivos declarados ausentes: {', '.join(sorted(missing_files))}"
+            )
 
         checksum_files = set(checksums)
         undeclared_checksums = checksum_files - declared_files
         if undeclared_checksums:
-            raise ValueError(f"Checksums para archivos no declarados: {', '.join(sorted(undeclared_checksums))}")
+            raise ValueError(
+                f"Checksums para archivos no declarados: {', '.join(sorted(undeclared_checksums))}"
+            )
 
         missing_checksums = declared_files - checksum_files
         if missing_checksums:
-            raise ValueError(f"Faltan checksums para archivos declarados: {', '.join(sorted(missing_checksums))}")
+            raise ValueError(
+                f"Faltan checksums para archivos declarados: {', '.join(sorted(missing_checksums))}"
+            )
 
         for name in sorted(declared_files):
             actual = _sha256_bytes(zf.read(name))

--- a/tests/unit/test_cobra_packaging.py
+++ b/tests/unit/test_cobra_packaging.py
@@ -8,12 +8,73 @@ import pytest
 
 from pcobra.cobra.packaging import (
     MANIFEST_NAME,
+    PackageManifest,
     construir_paquete,
     crear_paquete,
     extraer_paquete,
     inspeccionar_paquete,
+    manifest_from_dict,
+    manifest_to_dict,
     validar_paquete,
 )
+
+
+def test_package_manifest_minimo_compatible():
+    data = {
+        "format": "cobra-package-v1",
+        "name": "demo",
+        "version": "1.0.0",
+        "files": [],
+        "checksums": {},
+    }
+
+    manifest = manifest_from_dict(data)
+
+    assert manifest == PackageManifest(
+        format="cobra-package-v1",
+        name="demo",
+        version="1.0.0",
+        files=[],
+        checksums={},
+    )
+    assert manifest_to_dict(manifest) == data
+
+
+def test_package_manifest_acepta_campos_extra_permitidos():
+    data = {
+        "format": "cobra-package-v1",
+        "name": "demo",
+        "version": "1.0.0",
+        "files": [],
+        "checksums": {},
+        "description": "Paquete de prueba",
+        "authors": ["Equipo Cobra"],
+        "license": "MIT",
+        "homepage": "https://example.test/demo",
+        "dependencies": {"stdlib": ">=1.0"},
+    }
+
+    manifest = manifest_from_dict(data)
+
+    assert manifest.description == "Paquete de prueba"
+    assert manifest.authors == ["Equipo Cobra"]
+    assert manifest.license == "MIT"
+    assert manifest.homepage == "https://example.test/demo"
+    assert manifest.dependencies == {"stdlib": ">=1.0"}
+    assert manifest_to_dict(manifest) == data
+
+
+def test_package_manifest_rechaza_formato_no_soportado():
+    with pytest.raises(ValueError, match="Formato de paquete no soportado"):
+        manifest_from_dict(
+            {
+                "format": "cobra-package-v0",
+                "name": "demo",
+                "version": "1.0.0",
+                "files": [],
+                "checksums": {},
+            }
+        )
 
 
 def test_packaging_no_importa_lexer_parser():
@@ -35,7 +96,8 @@ def test_packaging_no_importa_lexer_parser():
     forbidden_modules = {
         module
         for module in imported_modules
-        if module in {"pcobra.cobra.core", "pcobra.cobra.core.lexer", "pcobra.cobra.core.parser"}
+        if module
+        in {"pcobra.cobra.core", "pcobra.cobra.core.lexer", "pcobra.cobra.core.parser"}
         or module.endswith((".lexer", ".parser"))
     }
 
@@ -46,7 +108,9 @@ def test_paquete_cobra_conserva_estructura_y_recursos(tmp_path: Path):
     proyecto = tmp_path / "demo"
     crear_paquete(proyecto, nombre="demo", version="1.0.0")
     (proyecto / "src" / "main.cobra").write_text("imprimir('hola')\n", encoding="utf-8")
-    (proyecto / "src" / "helper.co").write_text("funcion ayuda() {}\n", encoding="utf-8")
+    (proyecto / "src" / "helper.co").write_text(
+        "funcion ayuda() {}\n", encoding="utf-8"
+    )
     (proyecto / "README.md").write_text("# Demo\n", encoding="utf-8")
     (proyecto / "docs").mkdir()
     (proyecto / "docs" / "guia.md").write_text("# Guía\n", encoding="utf-8")
@@ -73,12 +137,18 @@ def test_paquete_cobra_conserva_estructura_y_recursos(tmp_path: Path):
     assert inspeccion.checksum
 
     destino = extraer_paquete(paquete, tmp_path / "instalado")
-    assert (destino / "src" / "main.cobra").read_text(encoding="utf-8") == "imprimir('hola')\n"
-    assert (destino / "assets" / "imagenes" / "logo.bin").read_bytes() == b"\x89PNG recurso"
+    assert (destino / "src" / "main.cobra").read_text(
+        encoding="utf-8"
+    ) == "imprimir('hola')\n"
+    assert (
+        destino / "assets" / "imagenes" / "logo.bin"
+    ).read_bytes() == b"\x89PNG recurso"
     assert (destino / "resources" / "i18n" / "es.dat").read_bytes() == b"hola=recurso"
 
 
-def _crear_zip_con_manifest(tmp_path: Path, manifest: dict, files: dict[str, bytes] | None = None) -> Path:
+def _crear_zip_con_manifest(
+    tmp_path: Path, manifest: dict, files: dict[str, bytes] | None = None
+) -> Path:
     paquete = tmp_path / "manual.co"
     with zipfile.ZipFile(paquete, "w", zipfile.ZIP_DEFLATED) as zf:
         zf.writestr(MANIFEST_NAME, json.dumps(manifest, ensure_ascii=False))
@@ -158,7 +228,9 @@ def test_validar_paquete_rechaza_checksum_no_string(tmp_path: Path):
         {"src/main.cobra": contenido},
     )
 
-    with pytest.raises(ValueError, match="Checksum inválido para src/main\\.cobra: debe ser una cadena"):
+    with pytest.raises(
+        ValueError, match="Checksum inválido para src/main\\.cobra: debe ser una cadena"
+    ):
         validar_paquete(paquete)
 
 
@@ -176,7 +248,10 @@ def test_validar_paquete_rechaza_checksum_demasiado_corto(tmp_path: Path):
         {"src/main.cobra": contenido},
     )
 
-    with pytest.raises(ValueError, match="Checksum inválido para src/main\\.cobra: debe tener 64 caracteres"):
+    with pytest.raises(
+        ValueError,
+        match="Checksum inválido para src/main\\.cobra: debe tener 64 caracteres",
+    ):
         validar_paquete(paquete)
 
 
@@ -271,7 +346,10 @@ def test_es_paquete_cobra_acepta_zip_con_manifest(tmp_path: Path):
 def _corromper_contenido_paquete(paquete: Path, nombre: str, contenido: bytes) -> None:
     original = paquete.with_suffix(".tmp.co")
     paquete.rename(original)
-    with zipfile.ZipFile(original) as src, zipfile.ZipFile(paquete, "w", zipfile.ZIP_DEFLATED) as dst:
+    with (
+        zipfile.ZipFile(original) as src,
+        zipfile.ZipFile(paquete, "w", zipfile.ZIP_DEFLATED) as dst,
+    ):
         for item in src.infolist():
             data = src.read(item.filename)
             if item.filename == nombre:
@@ -297,7 +375,9 @@ def test_cli_paquete_verificar_integridad_exitosa(tmp_path: Path, capsys):
     assert "Integridad válida" in salida
 
 
-def test_cli_paquete_verificar_integridad_falla_por_checksum_alterado(tmp_path: Path, capsys):
+def test_cli_paquete_verificar_integridad_falla_por_checksum_alterado(
+    tmp_path: Path, capsys
+):
     from argparse import Namespace
 
     from pcobra.cobra.cli.commands.package_cmd import PaqueteCommand


### PR DESCRIPTION
### Motivation
- Introducir un modelo explícito y validado para el manifiesto de paquetes para facilitar validación y soportar metadatos futuros como `description`, `authors`, `license`, `homepage` y `dependencies`.
- Reutilizar la lógica de conversión/validación en las rutas de creación, construcción, inspección y validación de paquetes para reducir manipulación ad-hoc de diccionarios.

### Description
- Añadido `@dataclass(frozen=True) PackageManifest` con campos obligatorios `format`, `name`, `version`, `files`, `checksums` y campos opcionales futuros `description`, `authors`, `license`, `homepage`, `dependencies` en `src/pcobra/cobra/packaging.py`.
- Añadidas las funciones `manifest_from_dict(data: dict[str, Any]) -> PackageManifest` y `manifest_to_dict(manifest: PackageManifest) -> dict[str, Any]` para convertir y validar manifiestos manteniendo compatibilidad con manifiestos mínimos existentes.
- Reemplazada la manipulación directa de dicts por el modelo y las funciones en `crear_paquete`, `construir_paquete`, `inspeccionar_paquete` y `validar_paquete`, preservando campos opcionales al reconstruir el manifiesto y serializarlo al ZIP.
- Añadidos tests en `tests/unit/test_cobra_packaging.py` que cubren el manifiesto mínimo compatible, aceptación de campos extra permitidos y el rechazo de formatos no soportados.

### Testing
- Ejecutado `pytest -q tests/unit/test_cobra_packaging.py` y los tests unitarios pasaron (`18 passed`, `1 warning`).
- Formateado con `python -m black src/pcobra/cobra/packaging.py tests/unit/test_cobra_packaging.py` y analizado con `python -m ruff check src/pcobra/cobra/packaging.py tests/unit/test_cobra_packaging.py`, ambos sin errores.
- Se comprobó `git diff --check` para asegurar que no quedan problemas de formato o whitespace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4401cdc34483278015da2c2477988e)