### PR TITLE
Fortalece validación de identidad de paquetes

### DIFF
--- a/src/pcobra/cobra/cli/cobrahub_packages.py
+++ b/src/pcobra/cobra/cli/cobrahub_packages.py
@@ -66,7 +66,9 @@ class CobraHubPackages:
             return False
         try:
             if not es_paquete_cobra(ruta):
-                raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
+                raise ValueError(
+                    "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
+                )
             info = validar_paquete(ruta)
             self.repository.publish(ruta, dict(info.manifest), info.checksum)
             _mostrar_info(_("Paquete publicado correctamente"))
@@ -91,13 +93,29 @@ class CobraHubPackages:
         self, nombre: str, destino: str | None = None, version: str | None = None
     ) -> bool:
         """Descarga, cachea e instala un paquete desde CobraHub."""
-        from pcobra.cobra.packaging import es_paquete_cobra, extraer_paquete
+        from pcobra.cobra.packaging import (
+            es_paquete_cobra,
+            extraer_paquete,
+            normalizar_nombre_paquete,
+            validar_version_paquete,
+        )
 
         cache_path: Path | None = None
-        if not self.client._validar_nombre_modulo(nombre) or not self.client._validar_url():
+        try:
+            normalized_name = normalizar_nombre_paquete(nombre)
+            normalized_version = (
+                validar_version_paquete(version) if version is not None else None
+            )
+        except ValueError as e:
+            _mostrar_error(str(e))
+            return False
+        if (
+            not self.client._validar_nombre_modulo(normalized_name)
+            or not self.client._validar_url()
+        ):
             return False
         try:
-            downloaded = self.repository.download(nombre, version)
+            downloaded = self.repository.download(normalized_name, normalized_version)
             cache_path = downloaded.path
 
             if not es_paquete_cobra(cache_path):
@@ -105,7 +123,11 @@ class CobraHubPackages:
                 _mostrar_error(_("La descarga no es un paquete Cobra válido"))
                 return False
 
-            install_path = Path(destino).expanduser() if destino else install_dir() / nombre
+            install_path = (
+                Path(destino).expanduser()
+                if destino
+                else install_dir() / normalized_name
+            )
             extraer_paquete(cache_path, install_path)
             _mostrar_info(_("Paquete instalado en {dest}").format(dest=install_path))
             return True

--- a/src/pcobra/cobra/hub/repository.py
+++ b/src/pcobra/cobra/hub/repository.py
@@ -20,7 +20,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
 from pcobra.cobra.cli.i18n import _
-from pcobra.cobra.packaging import PackageSearchResult
+from pcobra.cobra.packaging import (
+    PackageSearchResult,
+    normalizar_nombre_paquete,
+    validar_version_paquete,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - solo para tipado
     from pcobra.cobra.cli.cobrahub_client import CobraHubClient
@@ -41,7 +45,9 @@ class DownloadedPackage:
 class PackageRepository(Protocol):
     """Contrato independiente para repositorios de paquetes Cobra."""
 
-    def publish(self, package_path: str | Path, metadata: dict[str, Any], checksum: str) -> bool:
+    def publish(
+        self, package_path: str | Path, metadata: dict[str, Any], checksum: str
+    ) -> bool:
         """Publica un paquete ya validado con sus metadatos y checksum."""
         ...
 
@@ -64,7 +70,9 @@ class HttpCobraHubRepository:
     def __init__(self, client: "CobraHubClient") -> None:
         self.client = client
 
-    def publish(self, package_path: str | Path, metadata: dict[str, Any], checksum: str) -> bool:
+    def publish(
+        self, package_path: str | Path, metadata: dict[str, Any], checksum: str
+    ) -> bool:
         """Publica un paquete .co mediante la API HTTP de CobraHub."""
         ruta = Path(package_path)
         with ruta.open("rb") as f:
@@ -101,24 +109,40 @@ class HttpCobraHubRepository:
 
     def download(self, name: str, version: str | None = None) -> DownloadedPackage:
         """Descarga un paquete por nombre y versión opcional en la caché local."""
-        cache_path = package_cache_dir() / _cache_filename(name, version)
+        normalized_name = normalizar_nombre_paquete(name)
+        normalized_version = (
+            validar_version_paquete(version) if version is not None else None
+        )
+        cache_path = package_cache_dir() / _cache_filename(
+            normalized_name, normalized_version
+        )
         try:
             with self.client.session.get(
-                f"{self.client.base_url}/paquetes/{urllib.parse.quote(name)}",
-                **({"params": {"version": version}} if version else {}),
+                f"{self.client.base_url}/paquetes/{urllib.parse.quote(normalized_name)}",
+                **(
+                    {"params": {"version": normalized_version}}
+                    if normalized_version
+                    else {}
+                ),
                 timeout=(self.client.CONNECT_TIMEOUT, self.client.READ_TIMEOUT),
                 stream=True,
             ) as response:
                 response.raise_for_status()
                 checksum_servidor = response.headers.get("X-Content-Checksum")
                 version_servidor = _version_from_response(response)
-                if version_servidor and version_servidor != version:
-                    cache_path = package_cache_dir() / _cache_filename(name, version_servidor)
+                if version_servidor:
+                    version_servidor = validar_version_paquete(version_servidor)
+                if version_servidor and version_servidor != normalized_version:
+                    cache_path = package_cache_dir() / _cache_filename(
+                        normalized_name, version_servidor
+                    )
                 sha256 = hashlib.sha256()
                 tamaño_total = 0
 
                 with open(cache_path, "wb") as out:
-                    for chunk in response.iter_content(chunk_size=self.client.CHUNK_SIZE):
+                    for chunk in response.iter_content(
+                        chunk_size=self.client.CHUNK_SIZE
+                    ):
                         if not chunk:
                             continue
                         tamaño_total += len(chunk)
@@ -136,8 +160,8 @@ class HttpCobraHubRepository:
 
             return DownloadedPackage(
                 path=cache_path,
-                name=name,
-                version=version_servidor or version,
+                name=normalized_name,
+                version=version_servidor or normalized_version,
                 checksum=checksum_servidor or digest,
             )
         except Exception:
@@ -150,7 +174,9 @@ class HttpCobraHubRepository:
         from pcobra.cobra.packaging import es_paquete_cobra, validar_paquete
 
         if not es_paquete_cobra(package_path):
-            raise ValueError("No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json")
+            raise ValueError(
+                "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
+            )
         info = validar_paquete(package_path)
         return dict(info.manifest)
 
@@ -162,7 +188,9 @@ def _normalizar_resultado_paquete(item: Any) -> PackageSearchResult:
 
     name = item.get("name") or item.get("nombre") or item.get("package")
     if not name:
-        name = Path(str(item.get("filename") or item.get("archivo") or "paquete.co")).stem
+        name = Path(
+            str(item.get("filename") or item.get("archivo") or "paquete.co")
+        ).stem
 
     return PackageSearchResult(
         name=str(name),
@@ -174,7 +202,9 @@ def _normalizar_resultado_paquete(item: Any) -> PackageSearchResult:
             or item.get("digest")
             or item.get("content_checksum")
         ),
-        download_url=_optional_str(item.get("download_url") or item.get("url") or item.get("href")),
+        download_url=_optional_str(
+            item.get("download_url") or item.get("url") or item.get("href")
+        ),
         remote_id=_optional_str(item.get("remote_id") or item.get("id")),
     )
 
@@ -212,7 +242,9 @@ def _version_from_response(response: Any) -> str | None:
 def package_cache_dir() -> Path:
     """Devuelve el directorio de caché local para paquetes CobraHub."""
     cache = Path(
-        os.environ.get("COBRAHUB_CACHE_DIR", str(Path.home() / ".cobra" / "hub" / "cache"))
+        os.environ.get(
+            "COBRAHUB_CACHE_DIR", str(Path.home() / ".cobra" / "hub" / "cache")
+        )
     ).expanduser()
     cache.mkdir(parents=True, exist_ok=True)
     return cache

--- a/src/pcobra/cobra/packaging.py
+++ b/src/pcobra/cobra/packaging.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import shutil
 import zipfile
 from dataclasses import dataclass
@@ -19,6 +20,12 @@ PACKAGE_FORMAT = "cobra-package-v1"
 DEFAULT_CACHE_DIR = Path.home() / ".cobra" / "hub" / "cache"
 DEFAULT_INSTALL_DIR = Path.home() / ".cobra" / "packages"
 MAX_PACKAGE_SIZE = 50 * 1024 * 1024
+_PACKAGE_NAME_RE = re.compile(r"^[a-z0-9_.-]+$")
+_SIMPLE_SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
 
 
 @dataclass(frozen=True)
@@ -74,8 +81,8 @@ def manifest_from_dict(data: dict[str, Any]) -> PackageManifest:
 
     return PackageManifest(
         format=str(package_format),
-        name=str(name),
-        version=str(version),
+        name=normalizar_nombre_paquete(str(name)),
+        version=validar_version_paquete(str(version)),
         files=[str(file) for file in files],
         checksums={str(name): checksum for name, checksum in checksums.items()},
         description=(
@@ -150,11 +157,43 @@ class PackageInspection:
     checksum: str
 
 
-def _safe_name(name: str) -> str:
-    normalized = name.strip().replace(" ", "-")
-    if not normalized or any(part in {"..", ""} for part in normalized.split("/")):
+def normalizar_nombre_paquete(nombre: str) -> str:
+    """Normaliza y valida la identidad pública de un paquete Cobra.
+
+    Política de nombres:
+    - se recortan espacios externos y se convierten espacios internos a ``-``;
+    - el resultado siempre se guarda en minúsculas;
+    - solo se admiten letras ASCII, números, ``_``, ``-`` y ``.``;
+    - no se admiten separadores de ruta, segmentos vacíos separados por ``.`` ni
+      segmentos ``..`` para evitar ambigüedad o traversal en cachés/instalación.
+    """
+    normalized = str(nombre).strip().lower().replace(" ", "-")
+    if not normalized:
+        raise ValueError("Nombre de paquete inválido")
+    if "/" in normalized or "\\" in normalized:
+        raise ValueError("Nombre de paquete inválido")
+    if not _PACKAGE_NAME_RE.fullmatch(normalized):
+        raise ValueError("Nombre de paquete inválido")
+    if any(part in {"", ".."} for part in normalized.split(".")):
         raise ValueError("Nombre de paquete inválido")
     return normalized
+
+
+def validar_version_paquete(version: str) -> str:
+    """Valida y devuelve una versión SemVer simple para paquetes Cobra.
+
+    La versión debe seguir ``MAJOR.MINOR.PATCH`` con enteros no negativos sin
+    ceros a la izquierda, y puede incluir sufijo prerelease ``-...`` y metadatos
+    de build ``+...`` compatibles con SemVer.
+    """
+    normalized = str(version).strip()
+    if not normalized or not _SIMPLE_SEMVER_RE.fullmatch(normalized):
+        raise ValueError("Versión de paquete inválida")
+    return normalized
+
+
+def _safe_name(name: str) -> str:
+    return normalizar_nombre_paquete(name)
 
 
 def _sha256_file(path: Path) -> str:
@@ -188,8 +227,8 @@ def crear_paquete(source: str | Path, *, nombre: str, version: str = "0.1.0") ->
     manifest = manifest_to_dict(
         PackageManifest(
             format=PACKAGE_FORMAT,
-            name=_safe_name(nombre),
-            version=version,
+            name=normalizar_nombre_paquete(nombre),
+            version=validar_version_paquete(version),
             files=[],
             checksums={},
         )
@@ -224,7 +263,7 @@ def construir_paquete(
         manifest = PackageManifest(
             format=PACKAGE_FORMAT,
             name=str(nombre or root.name),
-            version=str(version or "0.1.0"),
+            version=validar_version_paquete(str(version or "0.1.0")),
             files=[],
             checksums={},
         )
@@ -237,8 +276,8 @@ def construir_paquete(
     checksums = {p.relative_to(root).as_posix(): _sha256_file(p) for p in files}
     manifest = PackageManifest(
         format=PACKAGE_FORMAT,
-        name=_safe_name(str(nombre or manifest.name or root.name)),
-        version=str(version or manifest.version or "0.1.0"),
+        name=normalizar_nombre_paquete(str(nombre or manifest.name or root.name)),
+        version=validar_version_paquete(str(version or manifest.version or "0.1.0")),
         files=list(checksums),
         checksums=checksums,
         description=manifest.description,

--- a/tests/unit/test_cli_cobrahub.py
+++ b/tests/unit/test_cli_cobrahub.py
@@ -652,8 +652,6 @@ class _PackageStreamingResponse:
         raise AssertionError("La instalación debe descargar el paquete en streaming")
 
 
-
-
 def _paquete_cobra_bytes(label: str = "demo") -> bytes:
     payload = f"imprimir('{label}')\n".encode("utf-8")
     checksum = hashlib.sha256(payload).hexdigest()
@@ -670,8 +668,10 @@ def _paquete_cobra_bytes(label: str = "demo") -> bytes:
         zf.writestr("src/main.cobra", payload)
     return buffer.getvalue()
 
+
 def _sha256_bytes(data):
     return hashlib.sha256(data).hexdigest()
+
 
 @pytest.mark.timeout(5)
 def test_buscar_paquetes_normaliza_metadatos_disponibles(monkeypatch):
@@ -724,7 +724,9 @@ def test_buscar_paquetes_normaliza_metadatos_disponibles(monkeypatch):
 
 
 @pytest.mark.timeout(5)
-def test_instalar_paquete_cache_versionada_si_servidor_entrega_version(tmp_path, monkeypatch):
+def test_instalar_paquete_cache_versionada_si_servidor_entrega_version(
+    tmp_path, monkeypatch
+):
     cache_dir = tmp_path / "cache"
     install_dir = tmp_path / "instalados"
     monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(cache_dir))
@@ -747,7 +749,34 @@ def test_instalar_paquete_cache_versionada_si_servidor_entrega_version(tmp_path,
 
 
 @pytest.mark.timeout(5)
-def test_instalar_paquete_cache_legacy_si_servidor_no_entrega_version(tmp_path, monkeypatch):
+def test_instalar_paquete_normaliza_nombre_y_version_para_cache_e_instalacion(
+    tmp_path, monkeypatch
+):
+    cache_dir = tmp_path / "cache"
+    install_dir = tmp_path / "instalados"
+    monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("COBRAHUB_INSTALL_DIR", str(install_dir))
+
+    client = cobrahub_client.CobraHubClient()
+    contenido = _paquete_cobra_bytes("paquete-normalizado")
+    response = _PackageStreamingResponse(client, [contenido], _sha256_bytes(contenido))
+    client.session.get = MagicMock(return_value=response)
+
+    with patch("pcobra.cobra.packaging.extraer_paquete") as extraer:
+        ok = client.instalar_paquete("Demo Package", version=" 1.2.3 ")
+
+    assert ok
+    cache_path = cache_dir / "demo-package-1.2.3.co"
+    assert cache_path.read_bytes() == contenido
+    client.session.get.assert_called_once()
+    assert client.session.get.call_args.args[0].endswith("/paquetes/demo-package")
+    assert client.session.get.call_args.kwargs["params"] == {"version": "1.2.3"}
+    extraer.assert_called_once_with(cache_path, install_dir / "demo-package")
+
+
+def test_instalar_paquete_cache_legacy_si_servidor_no_entrega_version(
+    tmp_path, monkeypatch
+):
     cache_dir = tmp_path / "cache"
     install_dir = tmp_path / "instalados"
     monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(cache_dir))

--- a/tests/unit/test_cobra_packaging.py
+++ b/tests/unit/test_cobra_packaging.py
@@ -15,7 +15,9 @@ from pcobra.cobra.packaging import (
     inspeccionar_paquete,
     manifest_from_dict,
     manifest_to_dict,
+    normalizar_nombre_paquete,
     validar_paquete,
+    validar_version_paquete,
 )
 
 
@@ -75,6 +77,60 @@ def test_package_manifest_rechaza_formato_no_soportado():
                 "checksums": {},
             }
         )
+
+
+def test_normalizar_nombre_paquete_aplica_politica_documentada():
+    assert (
+        normalizar_nombre_paquete("  Paquete Demo_1.Modulo  ")
+        == "paquete-demo_1.modulo"
+    )
+
+
+@pytest.mark.parametrize(
+    "nombre",
+    [
+        "",
+        "   ",
+        "demo/evil",
+        r"demo\evil",
+        "demo..evil",
+        ".demo",
+        "demo.",
+        "demo@evil",
+        "démø",
+    ],
+)
+def test_normalizar_nombre_paquete_rechaza_nombres_invalidos(nombre):
+    with pytest.raises(ValueError, match="Nombre de paquete inválido"):
+        normalizar_nombre_paquete(nombre)
+
+
+def test_validar_version_paquete_acepta_semver_simple():
+    assert validar_version_paquete(" 1.2.3 ") == "1.2.3"
+    assert validar_version_paquete("1.2.3-beta.1+build.5") == "1.2.3-beta.1+build.5"
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["", "1", "1.2", "01.2.3", "1.2.3.4", "v1.2.3", "1.2.3 beta"],
+)
+def test_validar_version_paquete_rechaza_versiones_invalidas(version):
+    with pytest.raises(ValueError, match="Versión de paquete inválida"):
+        validar_version_paquete(version)
+
+
+def test_crear_y_construir_paquete_normalizan_identidad_consistentemente(
+    tmp_path: Path,
+):
+    proyecto = tmp_path / "demo"
+
+    crear_paquete(proyecto, nombre="Paquete Demo", version="1.0.0")
+    paquete = construir_paquete(proyecto, version="2.0.0")
+
+    manifest = inspeccionar_paquete(paquete).manifest
+    assert manifest["name"] == "paquete-demo"
+    assert manifest["version"] == "2.0.0"
+    assert paquete.name == "paquete-demo-2.0.0.co"
 
 
 def test_packaging_no_importa_lexer_parser():


### PR DESCRIPTION
### Motivation
- Evitar inconsistencias y rutas inseguras al identificar paquetes y al cache/instalación en CobraHub mediante una política pública de nombres y validación de versiones. 
- Documentar y aplicar una norma única para nombre/versión en la creación, lectura y descarga de paquetes para reducir errores y ataques por path traversal.

### Description
- Añade funciones públicas en `src/pcobra/cobra/packaging.py`: `normalizar_nombre_paquete(nombre: str) -> str` y `validar_version_paquete(version: str) -> str` con la política documentada (nombres en minúsculas, espacios -> `-`, solo `a-z0-9_.-`, sin separadores de ruta ni segmentos vacíos/`..`; versiones SemVer simple). 
- Sustituye el uso interno de `_safe_name()` y versiones libres por las nuevas funciones en `manifest_from_dict`, `crear_paquete` y `construir_paquete` para garantizar normalización consistente en manifiestos y artefactos `.co`.
- Actualiza `HttpCobraHubRepository.download()` en `src/pcobra/cobra/hub/repository.py` para normalizar nombre y versión antes de formar la URL, parámetros y nombre de caché, y para validar la versión enviada por el servidor.
- Actualiza `CobraHubPackages.instalar_paquete()` en `src/pcobra/cobra/cli/cobrahub_packages.py` para normalizar/validar nombre y versión antes de descargar e instalar y para usar el nombre normalizado en la ruta de instalación por defecto.
- Añade tests que cubren normalización de nombres, rechazo de nombres inválidos, validación de versiones válidas/ inválidas, consistencia entre `crear_paquete`/`construir_paquete` y normalización en flujo de descarga/ cache/instalación (`tests/unit/test_cobra_packaging.py` y `tests/unit/test_cli_cobrahub.py`).

### Testing
- Formateo con `black` aplicado a los archivos modificados usando: `python -m black src/pcobra/cobra/packaging.py src/pcobra/cobra/hub/repository.py src/pcobra/cobra/cli/cobrahub_packages.py tests/unit/test_cobra_packaging.py tests/unit/test_cli_cobrahub.py` and then run unit tests.
- Ejecutado: `python -m pytest tests/unit/test_cobra_packaging.py tests/unit/test_cli_cobrahub.py -q` and todos los tests añadidos/afectados pasaron (suite reportó los tests como exitosos, con advertencia irrelevante deprecación de `core`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4404c8843c8327a886a5861511fb94)