### PR TITLE
Agregar subcomando `hub cache` para gestionar caché de paquetes .co

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Versión 10.0.13
 - `corelibs.asincrono` incorpora `grupo_tareas` y `reintentar_async`, reexportados en la biblioteca estándar para coordinar corrutinas y reintentos con *backoff*.
 - `corelibs.texto`, `corelibs.numero` y `standard_library.datos` añaden validadores `es_*`, helpers como `prefijo_comun`/`sufijo_comun`, funciones `interpolar`/`envolver_modular` y lectura/escritura de Parquet y Feather.
 - `corelibs.sistema.ejecutar` mantiene la ejecución en modo seguro con listas blancas obligatorias tanto en Python como en los *bindings* nativos.
+- `cobra hub cache listar|limpiar|validar` permite inspeccionar, depurar y verificar la caché local de paquetes `.co` de CobraHub sin romper los comandos actuales de publicación, búsqueda e instalación.
 
 [English version available here](docs/README.en.md)
 
@@ -137,6 +138,19 @@ Fuente normativa de detalle: `docs/contrato_runtime_holobit.md` y `docs/matriz_t
 
 El objetivo de pCobra es brindar a la comunidad hispanohablante una alternativa cercana para aprender y construir software, reduciendo la barrera del idioma y fomentando la colaboración abierta. A medida que evoluciona, el proyecto busca ampliar su ecosistema, mejorar la transpilación y proveer herramientas que sirvan de puente entre la educación y el desarrollo profesional.
 
+
+### Caché local de CobraHub
+
+Los paquetes CobraHub descargados o publicados se guardan como artefactos `.co` en la caché local (`~/.cobra/hub/cache` por defecto, configurable con `COBRAHUB_CACHE_DIR`). La CLI incluye operaciones locales para administrarla:
+
+```bash
+cobra hub cache listar
+cobra hub cache limpiar
+cobra hub cache limpiar demo
+cobra hub cache validar
+```
+
+`listar` muestra los `.co` cacheados, `limpiar` elimina todos o los asociados a un nombre de paquete, y `validar` reutiliza los validadores de paquetes Cobra para comprobar estructura e integridad de cada entrada cacheada.
 
 ## Tabla de Contenidos
 

--- a/docs/frontend/cobrahub.rst
+++ b/docs/frontend/cobrahub.rst
@@ -72,9 +72,46 @@ contra CobraHub:
 
       cobra hub instalar demo
 
+10. Revisar, limpiar o validar la caché local de paquetes descargados o
+    publicados:
+
+   .. code-block:: bash
+
+      cobra hub cache listar
+      cobra hub cache limpiar
+      cobra hub cache validar
+
 Los comandos ``cobra paquete`` gestionan el ciclo de vida local del artefacto.
 Los comandos ``cobra hub`` usan ese artefacto para publicar, buscar e instalar
 paquetes mediante la API recomendada de CobraHub.
+
+
+Caché local de CobraHub
+-----------------------
+
+CobraHub mantiene una caché local de paquetes ``.co`` para reutilizar artefactos
+descargados o publicados sin contactar de nuevo con el servicio remoto. Por
+defecto se ubica en ``~/.cobra/hub/cache`` y puede redirigirse con la variable
+de entorno ``COBRAHUB_CACHE_DIR``.
+
+Las operaciones disponibles son locales y no rompen los comandos existentes de
+publicación, búsqueda o instalación:
+
+.. code-block:: bash
+
+   cobra hub cache listar
+   cobra hub cache limpiar
+   cobra hub cache limpiar demo
+   cobra hub cache validar
+
+``listar`` muestra los archivos ``.co`` cacheados. ``limpiar`` sin argumentos
+elimina todos los paquetes cacheados; con un nombre elimina ``<nombre>.co`` y
+sus variantes versionadas ``<nombre>-<version>.co``. ``validar`` recorre cada
+``.co`` de la caché y aplica las mismas comprobaciones estructurales y de
+integridad usadas para paquetes Cobra: primero ``es_paquete_cobra()`` y después
+``validar_paquete()``. El comando devuelve código ``0`` si todos los paquetes
+son válidos y ``1`` si al menos una entrada está corrupta o no es un paquete
+Cobra.
 
 Qué cuenta como paquete ``.co``
 ------------------------------

--- a/src/pcobra/cobra/cli/cobrahub_packages.py
+++ b/src/pcobra/cobra/cli/cobrahub_packages.py
@@ -27,6 +27,60 @@ if TYPE_CHECKING:  # pragma: no cover - solo para tipado
 logger = logging.getLogger(__name__)
 
 
+def listar_cache() -> list[Path]:
+    """Lista los paquetes ``.co`` presentes en la caché local de CobraHub."""
+    return sorted(
+        path
+        for path in package_cache_dir().iterdir()
+        if path.is_file() and path.suffix == ".co"
+    )
+
+
+def _coincide_nombre_cache(path: Path, nombre: str) -> bool:
+    """Indica si una entrada cacheada corresponde al nombre solicitado."""
+    from pcobra.cobra.packaging import normalizar_nombre_paquete
+
+    objetivo = nombre[:-3] if nombre.endswith(".co") else nombre
+    objetivo = normalizar_nombre_paquete(objetivo)
+    stem = path.stem
+    return stem == objetivo or stem.startswith(f"{objetivo}-")
+
+
+def limpiar_cache(nombre: str | None = None) -> int:
+    """Elimina paquetes de la caché y devuelve cuántos archivos se borraron.
+
+    Si ``nombre`` es ``None`` se eliminan todos los ``.co`` cacheados. Si se
+    indica un nombre, se borran tanto ``<nombre>.co`` como variantes
+    versionadas ``<nombre>-<version>.co``.
+    """
+    borrados = 0
+    for path in listar_cache():
+        if nombre is not None and not _coincide_nombre_cache(path, nombre):
+            continue
+        path.unlink()
+        borrados += 1
+    return borrados
+
+
+def validar_cache() -> list[tuple[Path, bool, str | None]]:
+    """Valida cada paquete ``.co`` cacheado con los validadores de empaquetado."""
+    from pcobra.cobra.packaging import es_paquete_cobra, validar_paquete
+
+    resultados: list[tuple[Path, bool, str | None]] = []
+    for path in listar_cache():
+        try:
+            if not es_paquete_cobra(path):
+                raise ValueError(
+                    "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
+                )
+            validar_paquete(path)
+        except Exception as exc:
+            resultados.append((path, False, str(exc)))
+        else:
+            resultados.append((path, True, None))
+    return resultados
+
+
 def _mostrar_error(mensaje: str) -> None:
     """Emite errores vía la fachada legacy para conservar mocks existentes."""
     from pcobra.cobra.cli import cobrahub_client
@@ -148,6 +202,9 @@ class CobraHubPackages:
 
 __all__ = [
     "CobraHubPackages",
+    "listar_cache",
+    "limpiar_cache",
+    "validar_cache",
     "install_dir",
     "json_dumps",
     "package_cache_dir",

--- a/src/pcobra/cobra/cli/commands/hub_cmd.py
+++ b/src/pcobra/cobra/cli/commands/hub_cmd.py
@@ -3,7 +3,12 @@ from pathlib import Path
 from typing import Any
 
 from pcobra.cobra.cli.cobrahub_client import CobraHubClient
-from pcobra.cobra.cli.cobrahub_packages import CobraHubPackages
+from pcobra.cobra.cli.cobrahub_packages import (
+    CobraHubPackages,
+    limpiar_cache,
+    listar_cache,
+    validar_cache,
+)
 from pcobra.cobra.cli.commands.base import BaseCommand
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.argument_parser import CustomArgumentParser
@@ -28,6 +33,12 @@ class HubCommand(BaseCommand):
         inst.add_argument("nombre")
         inst.add_argument("--version")
         inst.add_argument("--destino", type=Path)
+        cache = sub.add_parser("cache", help=_("Gestiona la caché local de paquetes"))
+        cache_sub = cache.add_subparsers(dest="cache_accion", required=True)
+        cache_sub.add_parser("listar", help=_("Lista paquetes cacheados"))
+        limpiar = cache_sub.add_parser("limpiar", help=_("Limpia paquetes cacheados"))
+        limpiar.add_argument("nombre", nargs="?")
+        cache_sub.add_parser("validar", help=_("Valida paquetes cacheados"))
         parser.set_defaults(cmd=self)
         return parser
 
@@ -43,6 +54,38 @@ class HubCommand(BaseCommand):
             return 0
         if args.accion == "instalar":
             destino = str(args.destino) if args.destino else None
-            return 0 if packages.instalar_paquete(args.nombre, destino, args.version) else 1
+            return (
+                0
+                if packages.instalar_paquete(args.nombre, destino, args.version)
+                else 1
+            )
+        if args.accion == "cache":
+            return self._run_cache(args)
         mostrar_error(_("Acción de hub no reconocida"))
+        return 1
+
+    def _run_cache(self, args: Namespace) -> int:
+        """Ejecuta las acciones locales de caché sin contactar con CobraHub."""
+        if args.cache_accion == "listar":
+            for path in listar_cache():
+                mostrar_info(str(path))
+            return 0
+        if args.cache_accion == "limpiar":
+            try:
+                borrados = limpiar_cache(args.nombre)
+            except ValueError as exc:
+                mostrar_error(str(exc))
+                return 1
+            mostrar_info(
+                _("Paquetes eliminados de caché: {total}").format(total=borrados)
+            )
+            return 0
+        if args.cache_accion == "validar":
+            resultados = validar_cache()
+            for path, ok, error in resultados:
+                estado = _("válido") if ok else _("inválido")
+                detalle = f": {error}" if error else ""
+                mostrar_info(f"{path} {estado}{detalle}")
+            return 0 if all(ok for _, ok, _ in resultados) else 1
+        mostrar_error(_("Acción de caché no reconocida"))
         return 1

--- a/tests/unit/test_cobrahub_cache.py
+++ b/tests/unit/test_cobrahub_cache.py
@@ -1,0 +1,81 @@
+from argparse import Namespace
+from pathlib import Path
+
+from pcobra.cobra.cli.cobrahub_packages import (
+    limpiar_cache,
+    listar_cache,
+    validar_cache,
+)
+from pcobra.cobra.cli.commands.hub_cmd import HubCommand
+from pcobra.cobra.packaging import construir_paquete, crear_paquete
+
+
+def _crear_paquete_valido(tmp_path: Path, nombre: str = "demo") -> Path:
+    proyecto = tmp_path / f"src-{nombre}"
+    crear_paquete(proyecto, nombre=nombre, version="1.0.0")
+    (proyecto / "src" / "main.cobra").write_text("imprimir('hola')\n", encoding="utf-8")
+    return construir_paquete(proyecto, tmp_path / f"{nombre}.co")
+
+
+def test_listar_cache_devuelve_solo_paquetes_co_ordenados(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(tmp_path))
+    (tmp_path / "b.co").write_text("no importa para listar", encoding="utf-8")
+    (tmp_path / "a.co").write_text("no importa para listar", encoding="utf-8")
+    (tmp_path / "nota.txt").write_text("ignorado", encoding="utf-8")
+
+    assert [path.name for path in listar_cache()] == ["a.co", "b.co"]
+
+
+def test_limpiar_cache_borra_todo_o_por_nombre(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(tmp_path))
+    for nombre in ["demo.co", "demo-1.0.0.co", "otro.co", "nota.txt"]:
+        (tmp_path / nombre).write_text("x", encoding="utf-8")
+
+    assert limpiar_cache("demo") == 2
+    assert not (tmp_path / "demo.co").exists()
+    assert not (tmp_path / "demo-1.0.0.co").exists()
+    assert (tmp_path / "otro.co").exists()
+    assert limpiar_cache() == 1
+    assert (tmp_path / "nota.txt").exists()
+
+
+def test_validar_cache_reutiliza_validadores_de_paquetes(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(tmp_path / "cache"))
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    paquete = _crear_paquete_valido(tmp_path, "demo")
+    paquete.replace(cache_dir / "demo.co")
+    (cache_dir / "roto.co").write_text("var x = 1", encoding="utf-8")
+
+    resultados = {path.name: (ok, error) for path, ok, error in validar_cache()}
+
+    assert resultados["demo.co"] == (True, None)
+    assert resultados["roto.co"][0] is False
+    assert "No es un paquete Cobra" in resultados["roto.co"][1]
+
+
+def test_cli_hub_cache_validar_devuelve_error_si_hay_invalidos(
+    tmp_path: Path, monkeypatch, capsys
+):
+    monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(tmp_path))
+    (tmp_path / "roto.co").write_text("var x = 1", encoding="utf-8")
+
+    codigo = HubCommand().run(Namespace(accion="cache", cache_accion="validar"))
+
+    salida = capsys.readouterr().out
+    assert codigo == 1
+    assert "roto.co" in salida
+    assert "inválido" in salida
+
+
+def test_cli_hub_cache_limpiar_informa_total(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(tmp_path))
+    (tmp_path / "demo.co").write_text("x", encoding="utf-8")
+
+    codigo = HubCommand().run(
+        Namespace(accion="cache", cache_accion="limpiar", nombre=None)
+    )
+
+    assert codigo == 0
+    assert "Paquetes eliminados de caché: 1" in capsys.readouterr().out
+    assert listar_cache() == []


### PR DESCRIPTION
### Motivation
- Proveer operaciones locales para inspeccionar, limpiar y validar la caché de paquetes descargados/publicados sin afectar los comandos existentes de `hub`.
- Facilitar depuración y mantenimiento de artefactos `.co` usando los validadores ya existentes de empaquetado para detectar corrupción o inconsistencias.
- Mantener compatibilidad con la API/UX actual de la CLI y reutilizar utilidades y mensajes ya presentes en el proyecto.

### Description
- Añadido el subcomando `cobra hub cache` con acciones `listar`, `limpiar` y `validar` en `src/pcobra/cobra/cli/commands/hub_cmd.py` y despacho en `_run_cache`.
- Implementadas las funciones `listar_cache()`, `limpiar_cache(nombre: str | None = None) -> int` y `validar_cache() -> list[tuple[Path, bool, str | None]]` en `src/pcobra/cobra/cli/cobrahub_packages.py`, y exportadas en `__all__`.
- La validación reutiliza `es_paquete_cobra()` y `validar_paquete()` de `pcobra.cobra.packaging`, y `limpiar_cache` soporta coincidencia por nombre incluyendo variantes versionadas (`<nombre>-<version>.co`).
- Actualizados `docs/frontend/cobrahub.rst` y `README.md` para documentar la caché y añadidos tests unitarios en `tests/unit/test_cobrahub_cache.py` que cubren listar, limpiar, validar y comportamiento CLI.

### Testing
- Ejecutado `python -m pytest tests/unit/test_cobrahub_cache.py -q` y los tests del nuevo fichero pasaron (`5 passed`).
- Ejecutado el suite combinado `python -m pytest tests/unit/test_cli_cobrahub.py tests/unit/test_cobrahub_cache.py -q` y todas las pruebas pasaron (`39 passed` en el run mostrado).
- Ejecutado el formateo/lint con `python -m ruff check` sobre los ficheros modificados y `ruff format` cuando se requirió, y las comprobaciones estáticas pasaron sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4409ce3b988327a5f05d31a55b98a3)