### PR TITLE
docs: alinear contrato de integridad de paquetes Cobra

### DIFF
--- a/README.md
+++ b/README.md
@@ -1142,7 +1142,7 @@ El subcomando `gui` abre el IDLE gráfico principal y requiere tener instalado F
 
 ### Paquetes `.co` y CobraHub
 
-CobraHub funciona ahora como una capa de herramientas independiente para crear, construir, validar, inspeccionar, extraer, publicar, buscar e instalar paquetes `.co`. Un paquete `.co` es un ZIP con manifiesto `cobra.pkg.json`, checksums SHA-256 y estructura de carpetas conservada; puede contener archivos `.cobra`, documentación Markdown, texto, `Dockerfile` y recursos. Esta funcionalidad no cambia la sintaxis de Cobra ni requiere tocar Lexer o Parser. Consulta la guía actualizada de paquetes en [`docs/frontend/paquetes.rst`](docs/frontend/paquetes.rst) y el resumen de diseño en [`docs/cobrahub_paquetes.md`](docs/cobrahub_paquetes.md).
+CobraHub funciona ahora como una capa de herramientas independiente para crear, construir, validar, verificar, inspeccionar, extraer, publicar, buscar e instalar paquetes `.co`. Un paquete `.co` es un ZIP con manifiesto `cobra.pkg.json`, checksums SHA-256 y estructura de carpetas conservada; puede contener archivos `.cobra`, documentación Markdown, texto, `Dockerfile` y recursos. `validar` comprueba la estructura y el manifiesto del contenedor, `verificar` expresa de forma explícita la verificación de integridad SHA-256, e `integridad` se conserva como alias legacy. Esta funcionalidad no cambia la sintaxis de Cobra ni requiere tocar Lexer o Parser. Consulta la guía actualizada de paquetes en [`docs/frontend/paquetes.rst`](docs/frontend/paquetes.rst) y el resumen de diseño en [`docs/cobrahub_paquetes.md`](docs/cobrahub_paquetes.md).
 
 Comandos nuevos:
 

--- a/docs/cobrahub_paquetes.md
+++ b/docs/cobrahub_paquetes.md
@@ -132,6 +132,19 @@ La funcionalidad se implementa en `pcobra.cobra.packaging`, una capa independien
 6. Añadir acciones del IDLE que reutilizan la misma lógica de empaquetado.
 7. Añadir pruebas unitarias de construcción, validación, inspección y extracción.
 
+
+## Contrato de validación e integridad CLI
+
+- `cobra paquete validar <artefacto.co>` comprueba que el archivo sea un paquete
+  Cobra válido: ZIP legible con `cobra.pkg.json`, manifiesto completo, lista de
+  archivos coherente y checksums declarados para el contenido.
+- `cobra paquete verificar <artefacto.co>` es el alias explícito para integridad:
+  recalcula y compara los hashes SHA-256 de los archivos declarados en el
+  manifiesto antes de publicar, instalar o confiar en el artefacto.
+- `cobra paquete integridad <artefacto.co>` se conserva como alias legacy de
+  `verificar` para no romper scripts existentes; el código nuevo debe preferir
+  `verificar`.
+
 ## Regla de detección de paquetes `.co`
 
 Un archivo `.co` solo se considera paquete Cobra cuando cumple ambas condiciones estructurales:

--- a/docs/frontend/paquetes.rst
+++ b/docs/frontend/paquetes.rst
@@ -84,14 +84,19 @@ Construir el contenedor publicable ``.co``:
 
    cobra paquete construir mi_paquete dist/demo.co
 
-Validar checksums y manifiesto:
+Validar estructura y manifiesto del contenedor:
 
 .. code-block:: bash
 
    cobra paquete validar dist/demo.co
 
-Verificar explícitamente la integridad del paquete antes de publicarlo o
-instalarlo; el alias ``integridad`` es equivalente:
+Verificación de integridad
+--------------------------
+
+Antes de publicar o instalar un paquete, usa ``verificar`` para expresar de
+forma explícita la comprobación de integridad SHA-256 de los archivos declarados
+en ``cobra.pkg.json``. El comando ``integridad`` se mantiene como alias legacy
+para scripts existentes y es equivalente a ``verificar``.
 
 .. code-block:: bash
 

--- a/src/pcobra/cobra/cli/commands/package_cmd.py
+++ b/src/pcobra/cobra/cli/commands/package_cmd.py
@@ -57,6 +57,10 @@ class PaqueteCommand(BaseCommand):
             "verificar",
             aliases=["integridad"],
             help=_("Verifica la integridad de un paquete .co"),
+            description=_(
+                "Verifica la integridad SHA-256 de un paquete .co; "
+                "integridad es un alias legacy equivalente."
+            ),
         )
         verificar.add_argument("paquete", type=Path)
 

--- a/tests/integration/golden/cli_ui_v2_help_public.golden
+++ b/tests/integration/golden/cli_ui_v2_help_public.golden
@@ -4,18 +4,20 @@ usage: cobra [-h] [--version] [--ayuda] [--format] [--debug] [-v] [--no-safe]
              [--no-color] [--extra-validators EXTRA_VALIDATORS]
              [--legacy-imports] [--dev-ephemeral-key] [--plugins-safe-mode]
              [--plugins-unsafe-mode] [--plugins-allowlist PLUGINS_ALLOWLIST]
-             {run,build,test,mod,repl} ...
+             {run,build,test,mod,paquete,hub,repl} ...
 
 CLI de Cobra para ejecutar e interpretar scripts, transpilar código a otros
 lenguajes o usar ambos flujos según --modo (cobra, transpilar, mixto). Modo
 cobra = solo programar/interpretar Cobra sin codegen.
 
 positional arguments:
-  {run,build,test,mod,repl}
+  {run,build,test,mod,paquete,hub,repl}
     run                 Run a Cobra file
     build               Build/transpile a Cobra file
     test                Validate project output across runtimes
     mod                 Manage Cobra modules
+    paquete             Gestiona paquetes Cobra .co
+    hub                 Gestiona paquetes en CobraHub
     repl                Start Cobra REPL
 
 options:

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -26,7 +26,7 @@ def _public_env() -> dict[str, str]:
 
 
 def test_cli_public_commands_contract_is_stable():
-    assert PUBLIC_COMMANDS == ("run", "build", "test", "mod", "repl")
+    assert PUBLIC_COMMANDS == ("run", "build", "test", "mod", "repl", "paquete", "hub")
 
 
 def test_cli_public_commands_contract_keeps_repl_as_official_command():
@@ -67,7 +67,7 @@ def test_cli_help_public_contract_snapshot():
     )
     expected_snapshot = _leer_snapshot_texto(expected_snapshot)
     assert " ".join(result.stdout.lower().split()) == " ".join(expected_snapshot.lower().split())
-    for command in ("run", "build", "test", "mod", "repl"):
+    for command in ("run", "build", "test", "mod", "repl", "paquete", "hub"):
         assert f" {command} " in f" {result.stdout.lower()} "
     assert "\n  menu " not in result.stdout.lower()
     assert "\n  legacy " not in result.stdout.lower()
@@ -113,4 +113,4 @@ def test_cli_help_public_contract_muestra_warning_migracion_en_comando_legacy():
     assert result.returncode != 0
     lower_output = result.stderr.lower() + result.stdout.lower()
     assert "invalid choice: 'compilar'" in lower_output
-    assert "choose from 'run', 'build', 'test', 'mod', 'repl'" in lower_output
+    assert "choose from run, build, test, mod, paquete, hub, repl" in lower_output

--- a/tests/unit/test_cli_paquete.py
+++ b/tests/unit/test_cli_paquete.py
@@ -99,3 +99,24 @@ def test_paquete_validar_construir_inspeccionar_extraer_formato_moderno(tmp_path
         main(["paquete", "extraer", str(pkg), str(destino)])
     assert "Paquete extraído" in stdout.getvalue()
     assert (destino / "m.co").read_text(encoding="utf-8") == "var x = 1"
+
+
+def test_paquete_help_documenta_verificar_e_integridad_legacy(capsys):
+    with patch("sys.stdout", new_callable=StringIO) as stdout:
+        codigo = main(["paquete", "--help"])
+
+    assert codigo == 0
+    salida = stdout.getvalue()
+    assert "verificar" in salida
+    assert "integridad" in salida
+
+
+def test_paquete_verificar_help_expone_alias_integridad(capsys):
+    with patch("sys.stdout", new_callable=StringIO) as stdout:
+        codigo = main(["paquete", "verificar", "--help"])
+
+    assert codigo == 0
+    salida = stdout.getvalue()
+    assert "verificar" in salida
+    assert "integridad" in salida
+    assert "paquete" in salida


### PR DESCRIPTION
### Motivation
- Aclarar en la documentación la diferencia entre `validar` (estructura/manifiesto) y `verificar` (verificación explícita de integridad SHA-256) para paquetes `.co` y mantener `integridad` como alias legacy.
- Asegurar que la ayuda pública de la CLI y los snapshots/tests reflejen la superficie real de comandos expuestos (`paquete`, `hub`) y muestren los alias legacy donde corresponde.

### Description
- Actualiza `README.md` para documentar que `validar` comprueba estructura/manifiesto, `verificar` realiza la verificación SHA-256 y `integridad` se conserva como alias legacy.
- Añade la sección "Verificación de integridad" en `docs/frontend/paquetes.rst` separando validación de estructura y verificación de checksums.
- Inserta un contrato CLI en `docs/cobrahub_paquetes.md` describiendo el comportamiento de `validar`, `verificar` e `integridad`.
- Ajusta la ayuda del subcomando en `src/pcobra/cobra/cli/commands/package_cmd.py` para que `cobra paquete verificar --help` incluya una `description` que menciona el alias legacy `integridad`.
- Añade tests de ayuda en `tests/unit/test_cli_paquete.py` y actualiza el snapshot y el test de ayuda pública en `tests/integration/*` para incluir `paquete` y `hub` en la superficie pública.

### Testing
- Ejecutado: `pytest -q tests/unit/test_cli_paquete.py tests/integration/test_cli_public_help_contract.py` y ambos archivos de tests relacionados pasaron correctamente (total combinado: 11 passed, 1 warning).
- También se ejecutaron las pruebas unitarias del archivo modificado `tests/unit/test_cli_paquete.py` de forma aislada y pasaron (5 passed, 1 warning en una ejecución intermedia antes del ajuste de ayuda).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a440bcdbb748327bf6ca1f15bb86be0)