### PR TITLE
Endurecer validación de paquetes .co (ZIP)

### DIFF
--- a/src/pcobra/cobra/packaging.py
+++ b/src/pcobra/cobra/packaging.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import re
 import shutil
+import stat
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -365,13 +366,39 @@ def inspeccionar_paquete(package: str | Path) -> PackageInspection:
 
 
 def _normalizar_ruta_paquete(name: str) -> str:
-    normalized = Path(str(name).replace("\\", "/"))
-    if normalized.is_absolute() or ".." in normalized.parts:
-        raise ValueError(f"Ruta insegura en paquete: {name}")
-    normalized_name = normalized.as_posix()
-    if not normalized_name or normalized_name == ".":
+    raw_name = str(name)
+    if not raw_name:
         raise ValueError(f"Ruta inválida en paquete: {name}")
-    return normalized_name
+    if "\\" in raw_name:
+        raise ValueError(f"Ruta insegura en paquete: {name}")
+    if raw_name.startswith("/") or re.match(r"^[A-Za-z]:", raw_name):
+        raise ValueError(f"Ruta insegura en paquete: {name}")
+
+    parts = raw_name.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError(f"Ruta insegura en paquete: {name}")
+    return "/".join(parts)
+
+
+def _zipinfo_es_symlink(info: zipfile.ZipInfo) -> bool:
+    return stat.S_ISLNK((info.external_attr >> 16) & 0o170000)
+
+
+def _validar_entrada_zip(info: zipfile.ZipInfo) -> str:
+    if _zipinfo_es_symlink(info):
+        raise ValueError(f"Symlink no permitido en paquete: {info.filename}")
+    filename = info.filename.rstrip("/") if info.is_dir() else info.filename
+    return _normalizar_ruta_paquete(filename)
+
+
+def _validar_entradas_zip(zf: zipfile.ZipFile) -> dict[str, zipfile.ZipInfo]:
+    entries: dict[str, zipfile.ZipInfo] = {}
+    for info in zf.infolist():
+        normalized_name = _validar_entrada_zip(info)
+        if normalized_name in entries:
+            raise ValueError(f"Entrada duplicada en paquete: {normalized_name}")
+        entries[normalized_name] = info
+    return entries
 
 
 def _normalizar_lista_archivos(values: Any, *, field: str) -> set[str]:
@@ -415,10 +442,11 @@ def validar_paquete(package: str | Path) -> PackageInspection:
     checksums = _normalizar_checksums(manifest.checksums)
 
     with zipfile.ZipFile(inspection.path) as zf:
+        entries = _validar_entradas_zip(zf)
         real_files = {
-            _normalizar_ruta_paquete(info.filename)
-            for info in zf.infolist()
-            if not info.is_dir() and info.filename != MANIFEST_NAME
+            name
+            for name, info in entries.items()
+            if not info.is_dir() and name != MANIFEST_NAME
         }
         extra_files = real_files - declared_files
         if extra_files:
@@ -446,7 +474,7 @@ def validar_paquete(package: str | Path) -> PackageInspection:
             )
 
         for name in sorted(declared_files):
-            actual = _sha256_bytes(zf.read(name))
+            actual = _sha256_bytes(zf.read(entries[name]))
             if actual != checksums[name]:
                 raise ValueError(f"Integridad fallida para {name}")
     return inspection
@@ -463,14 +491,15 @@ def extraer_paquete(package: str | Path, destination: str | Path) -> Path:
     dest = Path(destination).resolve()
     dest.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(inspection.path) as zf:
-        for name in inspection.files:
+        entries = _validar_entradas_zip(zf)
+        for name, info in entries.items():
             target = (dest / name).resolve()
             target.relative_to(dest)
-            if name.endswith("/"):
+            if info.is_dir():
                 target.mkdir(parents=True, exist_ok=True)
             else:
                 target.parent.mkdir(parents=True, exist_ok=True)
-                with zf.open(name) as src, target.open("wb") as out:
+                with zf.open(info) as src, target.open("wb") as out:
                     shutil.copyfileobj(src, out)
     return dest
 

--- a/tests/unit/test_cobra_packaging.py
+++ b/tests/unit/test_cobra_packaging.py
@@ -1,6 +1,7 @@
 import ast
 import hashlib
 import json
+import stat
 import zipfile
 from pathlib import Path
 
@@ -215,6 +216,106 @@ def _crear_zip_con_manifest(
 
 def _sha256(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
+
+
+def _crear_zip_moderno_con_infos(
+    tmp_path: Path, entries: list[tuple[zipfile.ZipInfo | str, bytes]]
+) -> Path:
+    paquete = tmp_path / "manual-infos.co"
+    with zipfile.ZipFile(paquete, "w", zipfile.ZIP_DEFLATED) as zf:
+        for info_or_name, content in entries:
+            zf.writestr(info_or_name, content)
+    return paquete
+
+
+def _manifest_moderno(files: list[str], payloads: dict[str, bytes]) -> dict:
+    return {
+        "format": "cobra-package-v1",
+        "name": "demo",
+        "version": "1.0.0",
+        "files": files,
+        "checksums": {name: _sha256(payloads[name]) for name in files},
+    }
+
+
+def test_validar_paquete_moderno_rechaza_entrada_duplicada(tmp_path: Path):
+    contenido = b"imprimir('hola')\n"
+    manifest = _manifest_moderno(["src/main.cobra"], {"src/main.cobra": contenido})
+    paquete = _crear_zip_moderno_con_infos(
+        tmp_path,
+        [
+            (MANIFEST_NAME, json.dumps(manifest, ensure_ascii=False).encode()),
+            ("src/main.cobra", contenido),
+            ("src/main.cobra", contenido),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Entrada duplicada"):
+        validar_paquete(paquete)
+
+
+def test_validar_paquete_moderno_rechaza_symlink_por_external_attr(tmp_path: Path):
+    link = zipfile.ZipInfo("src/link.co")
+    link.external_attr = (stat.S_IFLNK | 0o777) << 16
+    contenido = b"destino.co"
+    manifest = _manifest_moderno(["src/link.co"], {"src/link.co": contenido})
+    paquete = _crear_zip_moderno_con_infos(
+        tmp_path,
+        [
+            (MANIFEST_NAME, json.dumps(manifest, ensure_ascii=False).encode()),
+            (link, contenido),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Symlink no permitido"):
+        validar_paquete(paquete)
+
+
+def test_validar_paquete_moderno_rechaza_ruta_parent_traversal(tmp_path: Path):
+    contenido = b"pwn"
+    manifest = _manifest_moderno(["../evil.co"], {"../evil.co": contenido})
+    paquete = _crear_zip_moderno_con_infos(
+        tmp_path,
+        [
+            (MANIFEST_NAME, json.dumps(manifest, ensure_ascii=False).encode()),
+            ("../evil.co", contenido),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Ruta insegura"):
+        validar_paquete(paquete)
+
+
+def test_validar_paquete_moderno_rechaza_ruta_absoluta(tmp_path: Path):
+    contenido = b"pwn"
+    manifest = _manifest_moderno(["/tmp/evil.co"], {"/tmp/evil.co": contenido})
+    paquete = _crear_zip_moderno_con_infos(
+        tmp_path,
+        [
+            (MANIFEST_NAME, json.dumps(manifest, ensure_ascii=False).encode()),
+            ("/tmp/evil.co", contenido),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Ruta insegura"):
+        validar_paquete(paquete)
+
+
+def test_extraer_paquete_moderno_rechaza_ruta_windows_con_traversal(tmp_path: Path):
+    contenido = b"pwn"
+    ruta = r"src\..\evil.co"
+    manifest = _manifest_moderno([ruta], {ruta: contenido})
+    paquete = _crear_zip_moderno_con_infos(
+        tmp_path,
+        [
+            (MANIFEST_NAME, json.dumps(manifest, ensure_ascii=False).encode()),
+            (ruta, contenido),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Ruta insegura"):
+        extraer_paquete(paquete, tmp_path / "destino")
+    assert not (tmp_path / "evil.co").exists()
 
 
 def test_validar_paquete_rechaza_manifest_incompleto(tmp_path: Path):


### PR DESCRIPTION
### Motivation
- Evitar vectores de traversals y symlinks en paquetes `.co` modernos rechazando entradas ZIP inseguras antes de extraer o verificar integridad. 

### Description
- Se endurece `_normalizar_ruta_paquete()` para rechazar nombres vacíos, separadores Windows (`\`), rutas absolutas POSIX (`/`) y rutas con prefijo de unidad Windows (`C:`), y segmentos vacíos, `.` o `..`.
- Se añaden funciones `_zipinfo_es_symlink()`, `_validar_entrada_zip()` y `_validar_entradas_zip()` para detectar symlinks vía `ZipInfo.external_attr` y entradas duplicadas ya en su forma normalizada.
- `validar_paquete()` ahora reutiliza las entradas validadas del ZIP para construir la lista de `real_files` y para leer los bytes usados en la comprobación de checksums.
- `extraer_paquete()` extrae solo a partir de las entradas revalidadas y comprueba que cada destino resuelto quede dentro del directorio destino antes de escribir el archivo.
- Cambios realizados en `src/pcobra/cobra/packaging.py` y pruebas añadidas en `tests/unit/test_cobra_packaging.py` para cubrir casos modernos (duplicado, symlink por external_attr, `../evil.co`, ruta absoluta y ruta Windows con traversal) manteniendo la suite legacy `tests/unit/test_cli_paquete_symlink.py` intacta.

### Testing
- Ejecutado `pytest -q tests/unit/test_cobra_packaging.py tests/unit/test_cli_paquete_symlink.py` y todas las pruebas automáticas relevantes pasaron (46 passed) con advertencias esperadas deprecación y la advertencia de duplicado usada en la prueba; no hubo fallos en las suites modernas ni legacy.
- También se ejecutaron individualmente `pytest -q tests/unit/test_cobra_packaging.py` y `pytest -q tests/unit/test_cli_paquete_symlink.py` y ambas pasaron exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44b69d56948327ac1763165edd8aff)