### PR TITLE
Detectar paquetes Cobra (.co ZIP) en runtime GUI

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -820,6 +820,29 @@ def main(page: "ft.Page"):
         if archivo_activo_permite_accion_cobra(runtime.ACCION_CORRECCION):
             correccion_runtime_handler(e)
 
+    def archivo_visible_permite_accion_paquete(accion: str) -> bool:
+        """Valida que la ruta visible apunte a un paquete Cobra para acciones de paquete."""
+
+        texto = (ruta_input.value or "").strip()
+        ruta = Path(texto) if texto else estado.ruta
+        if ruta is None:
+            salida.value = "Indica la ruta del paquete .co en el campo de ruta."
+            page.update()
+            return False
+
+        tipo_archivo = runtime.detectar_tipo_archivo(ruta)
+        if tipo_archivo != runtime.TIPO_ARCHIVO_PAQUETE_COBRA:
+            salida.value = "Esta acción solo está disponible para paquetes Cobra .co."
+            page.update()
+            return False
+
+        if runtime.archivo_permite_accion(ruta, accion):
+            return True
+
+        salida.value = "Esta acción no está disponible para este paquete Cobra."
+        page.update()
+        return False
+
 
     def crear_paquete_handler(e):
         if project_root is None:
@@ -831,21 +854,26 @@ def main(page: "ft.Page"):
         actualizar_pagina()
 
     def abrir_paquete_handler(e):
+        if not archivo_visible_permite_accion_paquete(runtime.ACCION_ABRIR_PAQUETE):
+            return
         try:
-            if ruta_input.value:
+            paquete = Path(ruta_input.value) if ruta_input.value else estado.ruta
+            if paquete is None:
+                salida.value = "Indica la ruta del paquete .co en el campo de ruta."
+            else:
                 destino = project_root or runtime.resolver_workspace_root_idle()
-                runtime.idle_abrir_paquete(Path(ruta_input.value), destino)
+                runtime.idle_abrir_paquete(paquete, destino)
                 salida.value = f"Paquete abierto en: {destino}"
                 reconstruir_arbol()
-            else:
-                salida.value = "Indica la ruta del paquete .co en el campo de ruta."
         except Exception as exc:
             salida.value = f"Error abriendo paquete: {exc}"
         actualizar_pagina()
 
     def validar_paquete_handler(e):
+        if not archivo_visible_permite_accion_paquete(runtime.ACCION_VALIDAR_PAQUETE):
+            return
         try:
-            paquete = Path(ruta_input.value) if ruta_input.value else None
+            paquete = Path(ruta_input.value) if ruta_input.value else estado.ruta
             if paquete is None:
                 salida.value = "Indica la ruta del paquete .co en el campo de ruta."
             else:
@@ -867,8 +895,10 @@ def main(page: "ft.Page"):
         actualizar_pagina()
 
     def publicar_paquete_handler(e):
+        if not archivo_visible_permite_accion_paquete(runtime.ACCION_PUBLICAR_PAQUETE):
+            return
         try:
-            paquete = Path(ruta_input.value) if ruta_input.value else None
+            paquete = Path(ruta_input.value) if ruta_input.value else estado.ruta
             if paquete is None:
                 salida.value = "Indica la ruta del paquete .co en el campo de ruta."
             else:

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
+from pcobra.cobra.packaging import es_paquete_cobra
 from pcobra.corelibs.archivo import _resolver_ruta as resolver_ruta_sandbox
 
 
@@ -82,6 +83,7 @@ def _local_import_action(module_name: str, symbol_name: str) -> str:
 
 
 TIPO_ARCHIVO_COBRA = "cobra"
+TIPO_ARCHIVO_PAQUETE_COBRA = "paquete_cobra"
 TIPO_ARCHIVO_MARKDOWN = "markdown"
 TIPO_ARCHIVO_TEXTO = "texto"
 TIPO_ARCHIVO_CONFIG = "config"
@@ -99,6 +101,10 @@ ACCION_TOKENS = "tokens"
 ACCION_AST = "ast"
 ACCION_SUGERENCIAS = "sugerencias"
 ACCION_CORRECCION = "correccion"
+ACCION_ABRIR_PAQUETE = "abrir_paquete"
+ACCION_VALIDAR_PAQUETE = "validar_paquete"
+ACCION_CONSTRUIR_PAQUETE = "construir_paquete"
+ACCION_PUBLICAR_PAQUETE = "publicar_paquete"
 
 ACCIONES_ARCHIVO_BASE: frozenset[str] = frozenset(
     {ACCION_EDITAR, ACCION_GUARDAR, ACCION_RECARGAR, ACCION_BORRAR}
@@ -116,6 +122,16 @@ ACCIONES_ARCHIVO_COBRA: frozenset[str] = ACCIONES_ARCHIVO_BASE | frozenset(
 )
 """Acciones disponibles para archivos Cobra."""
 
+ACCIONES_PAQUETE_COBRA: frozenset[str] = frozenset(
+    {
+        ACCION_ABRIR_PAQUETE,
+        ACCION_VALIDAR_PAQUETE,
+        ACCION_CONSTRUIR_PAQUETE,
+        ACCION_PUBLICAR_PAQUETE,
+    }
+)
+"""Acciones disponibles para paquetes Cobra ``.co``."""
+
 COBRA_FILE_EXTENSIONS: tuple[str, ...] = (".cobra", ".co")
 """Extensiones Cobra aceptadas y priorizadas para el explorador del IDLE."""
 
@@ -130,6 +146,7 @@ ENV_EXAMPLE_FILE_NAMES: frozenset[str] = frozenset({".env.example"})
 
 CAPACIDADES_POR_TIPO: dict[str, frozenset[str]] = {
     TIPO_ARCHIVO_COBRA: ACCIONES_ARCHIVO_COBRA,
+    TIPO_ARCHIVO_PAQUETE_COBRA: ACCIONES_PAQUETE_COBRA,
     TIPO_ARCHIVO_MARKDOWN: ACCIONES_ARCHIVO_BASE,
     TIPO_ARCHIVO_TEXTO: ACCIONES_ARCHIVO_BASE,
     TIPO_ARCHIVO_CONFIG: ACCIONES_ARCHIVO_BASE,
@@ -142,6 +159,7 @@ CAPACIDADES_POR_TIPO: dict[str, frozenset[str]] = {
 
 ETIQUETAS_TIPO_ARCHIVO: dict[str, str] = {
     TIPO_ARCHIVO_COBRA: "Archivo Cobra",
+    TIPO_ARCHIVO_PAQUETE_COBRA: "Paquete Cobra",
     TIPO_ARCHIVO_MARKDOWN: "Archivo Markdown",
     TIPO_ARCHIVO_TEXTO: "Archivo de texto",
     TIPO_ARCHIVO_CONFIG: "Archivo de configuración",
@@ -310,6 +328,8 @@ def detectar_tipo_archivo(path: str | Path) -> str:
 
     if nombre == "Dockerfile" or nombre.startswith("Dockerfile.") or nombre == "docker-compose.yml":
         return TIPO_ARCHIVO_DOCKER
+    if extension == ".co" and es_paquete_cobra(ruta):
+        return TIPO_ARCHIVO_PAQUETE_COBRA
     if extension in COBRA_FILE_EXTENSIONS:
         return TIPO_ARCHIVO_COBRA
     if extension in MARKDOWN_FILE_EXTENSIONS:
@@ -351,6 +371,12 @@ def es_archivo_cobra(path: str | Path) -> bool:
     """Indica si una ruta parece contener código Cobra editable."""
 
     return detectar_tipo_archivo(path) == TIPO_ARCHIVO_COBRA
+
+
+def es_paquete_cobra_gui(path: str | Path) -> bool:
+    """Indica si una ruta es un paquete Cobra ``.co`` no editable como texto."""
+
+    return detectar_tipo_archivo(path) == TIPO_ARCHIVO_PAQUETE_COBRA
 
 
 def resolver_ruta_archivo_en_project_root(
@@ -819,7 +845,17 @@ def cargar_archivo_desde_arbol(
             "indica un archivo de texto del proyecto."
         )
 
-    if detectar_tipo_archivo(origen) not in TIPOS_ARCHIVO_TEXTO_IDLE:
+    tipo_archivo = detectar_tipo_archivo(origen)
+    if tipo_archivo == TIPO_ARCHIVO_PAQUETE_COBRA:
+        estado.ruta = origen
+        estado.contenido_cargado = ""
+        estado.cambios_sin_guardar = False
+        return "", (
+            f"Paquete Cobra seleccionado: {origen}. "
+            "Usa Abrir paquete, Validar paquete o Publicar CobraHub."
+        )
+
+    if tipo_archivo not in TIPOS_ARCHIVO_TEXTO_IDLE:
         raise ValueError("Selecciona un archivo de texto del proyecto.")
 
     return abrir_archivo_desde_ruta_validada(origen, estado)

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import zipfile
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -99,6 +100,59 @@ def test_es_archivo_cobra_reconoce_extensiones_seguras_documentadas() -> None:
     assert runtime.es_archivo_cobra("programa.co")
     assert runtime.es_archivo_cobra("modulo.COBRA")
     assert not runtime.es_archivo_cobra("notas.txt")
+
+
+def test_detectar_tipo_archivo_co_de_texto_sigue_siendo_archivo_cobra(
+    tmp_path: Path,
+) -> None:
+    archivo = tmp_path / "programa.co"
+    archivo.write_text("imprimir('hola')\n", encoding="utf-8")
+
+    assert runtime.detectar_tipo_archivo(archivo) == runtime.TIPO_ARCHIVO_COBRA
+    assert runtime.es_archivo_cobra(archivo)
+
+
+def test_detectar_tipo_archivo_co_zip_con_manifest_es_paquete_cobra(
+    tmp_path: Path,
+) -> None:
+    paquete = tmp_path / "paquete.co"
+    with zipfile.ZipFile(paquete, "w") as zf:
+        zf.writestr("cobra.pkg.json", '{"name":"demo","version":"1.0.0"}')
+        zf.writestr("main.co", "imprimir('hola')\n")
+
+    assert runtime.detectar_tipo_archivo(paquete) == runtime.TIPO_ARCHIVO_PAQUETE_COBRA
+    assert runtime.es_paquete_cobra_gui(paquete)
+    assert not runtime.es_archivo_cobra(paquete)
+
+
+def test_detectar_tipo_archivo_co_zip_sin_manifest_no_es_paquete_cobra_valido(
+    tmp_path: Path,
+) -> None:
+    archivo = tmp_path / "archivo.co"
+    with zipfile.ZipFile(archivo, "w") as zf:
+        zf.writestr("main.co", "imprimir('hola')\n")
+
+    assert runtime.detectar_tipo_archivo(archivo) == runtime.TIPO_ARCHIVO_COBRA
+    assert not runtime.es_paquete_cobra_gui(archivo)
+    assert runtime.es_archivo_cobra(archivo)
+
+
+def test_cargar_archivo_desde_arbol_no_lee_paquete_cobra_zip_como_texto(
+    tmp_path: Path,
+) -> None:
+    paquete = tmp_path / "paquete.co"
+    with zipfile.ZipFile(paquete, "w") as zf:
+        zf.writestr("cobra.pkg.json", '{"name":"demo","version":"1.0.0"}')
+        zf.writestr("main.co", "imprimir('hola')\n")
+    estado = runtime.GuiFileState()
+
+    contenido, mensaje = runtime.cargar_archivo_desde_arbol(paquete, estado)
+
+    assert contenido == ""
+    assert "Paquete Cobra seleccionado" in mensaje
+    assert estado.ruta == paquete.resolve()
+    assert estado.contenido_cargado == ""
+    assert not estado.cambios_sin_guardar
 
 
 def test_detectar_tipo_archivo_clasifica_extensiones_y_nombres_conocidos() -> None:


### PR DESCRIPTION
### Motivation
- Evitar que archivos `.co` que son ZIP con `cobra.pkg.json` se traten como código editable y permitir acciones de paquete específicas en la GUI del IDLE.
- Hacer la detección estructural barata usando la función existente `pcobra.cobra.packaging.es_paquete_cobra()` para distinguir paquetes Cobra de archivos `.co` de texto.

### Description
- Añadido `TIPO_ARCHIVO_PAQUETE_COBRA`, nuevos `ACCION_*` relacionados con paquetes y la colección `ACCIONES_PAQUETE_COBRA`, y registrados en `CAPACIDADES_POR_TIPO` y `ETIQUETAS_TIPO_ARCHIVO` en `src/pcobra/gui/runtime.py`.
- Importado y usado `es_paquete_cobra()` en `detectar_tipo_archivo()` para detectar primero `.co` ZIP con `cobra.pkg.json` y exponer el helper `es_paquete_cobra_gui()`.
- Modificado `cargar_archivo_desde_arbol()` para no intentar leer paquetes ZIP `.co` como texto: deja el paquete seleccionado en `GuiFileState` y devuelve un mensaje que indica usar las acciones de paquete.
- En `src/pcobra/gui/idle.py` añadido `archivo_visible_permite_accion_paquete()` y conectado los handlers `abrir_paquete_handler`, `validar_paquete_handler` y `publicar_paquete_handler` para validar la ruta visible o `estado.ruta` antes de delegar en los helpers de `runtime`.
- Añadidas pruebas en `tests/unit/test_gui_runtime.py` que cubren: `.co` de texto sigue siendo archivo Cobra, `.co` ZIP con `cobra.pkg.json` se clasifica como paquete, `.co` ZIP sin manifiesto no se considera paquete Cobra válido, y que el árbol no lee un paquete ZIP como texto.

### Testing
- Las pruebas nuevas específicas pasaron: `test_detectar_tipo_archivo_co_de_texto_sigue_siendo_archivo_cobra`, `test_detectar_tipo_archivo_co_zip_con_manifest_es_paquete_cobra`, `test_detectar_tipo_archivo_co_zip_sin_manifest_no_es_paquete_cobra_valido` y `test_cargar_archivo_desde_arbol_no_lee_paquete_cobra_zip_como_texto` (ejecuciones aisladas exitosas).
- Subconjunto integrado que incluye los handlers de `idle` también pasó en este entorno (`tests/unit/test_gui_runtime.py::test_botones_idle_de_paquetes_delegan_solo_en_helpers_runtime` y `tests/unit/test_gui_idle.py` cuando se ejecutaron juntos).
- `python -m py_compile` sobre `src/pcobra/gui/runtime.py`, `src/pcobra/gui/idle.py` y el fichero de tests compiló correctamente.
- Intento de ejecutar el archivo completo `tests/unit/test_gui_runtime.py` terminó con `MemoryError` durante la fase de captura/teardown de pytest en este entorno y no por una aserción de código; esto parece una limitación del entorno de ejecución, no un fallo de la lógica introducida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44baef0dd4832781f3b812bf77365c)