### PR TITLE
Delegar publicación de paquetes del IDLE a CobraHubPackages

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -1684,5 +1684,6 @@ def idle_abrir_paquete(paquete: str | Path, destino: str | Path) -> Path:
 
 def idle_publicar_paquete(paquete: str | Path) -> bool:
     from pcobra.cobra.cli.cobrahub_client import CobraHubClient
+    from pcobra.cobra.cli.cobrahub_packages import CobraHubPackages
 
-    return CobraHubClient().publicar_paquete(str(paquete))
+    return CobraHubPackages(CobraHubClient()).publicar_paquete(str(paquete))

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -1184,7 +1184,7 @@ def test_idle_publicar_paquete_expone_fallo_de_publicacion(
         return False
 
     monkeypatch.setattr(
-        "pcobra.cobra.cli.cobrahub_client.CobraHubClient.publicar_paquete",
+        "pcobra.cobra.cli.cobrahub_packages.CobraHubPackages.publicar_paquete",
         publicar_mock,
     )
 
@@ -1230,7 +1230,7 @@ def test_botones_idle_de_paquetes_delegan_solo_en_helpers_runtime() -> None:
             assert all(alias.name not in forbidden_imports for alias in node.names)
 
 
-def test_idle_publicar_paquete_usa_cliente_mockeado_sin_red(
+def test_idle_publicar_paquete_delega_en_cobrahub_packages_sin_red(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     project_root = _crear_proyecto_cobra_minimo(tmp_path)
@@ -1243,13 +1243,41 @@ def test_idle_publicar_paquete_usa_cliente_mockeado_sin_red(
         return True
 
     monkeypatch.setattr(
-        "pcobra.cobra.cli.cobrahub_client.CobraHubClient.publicar_paquete",
+        "pcobra.cobra.cli.cobrahub_packages.CobraHubPackages.publicar_paquete",
         publicar_mock,
     )
 
     assert runtime.idle_publicar_paquete(paquete) is True
     assert llamadas == [str(paquete)]
 
+
+def test_idle_publicar_paquete_no_delega_en_metodo_legacy_del_cliente(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paquete = tmp_path / "paquete.co"
+    paquete.write_text("contenido", encoding="utf-8")
+    llamadas: list[str] = []
+
+    def publicar_packages_mock(self, ruta: str) -> bool:
+        llamadas.append(ruta)
+        return True
+
+    def publicar_cliente_legacy_mock(self, ruta: str) -> bool:
+        raise AssertionError(
+            "El IDLE no debe publicar mediante CobraHubClient.publicar_paquete"
+        )
+
+    monkeypatch.setattr(
+        "pcobra.cobra.cli.cobrahub_packages.CobraHubPackages.publicar_paquete",
+        publicar_packages_mock,
+    )
+    monkeypatch.setattr(
+        "pcobra.cobra.cli.cobrahub_client.CobraHubClient.publicar_paquete",
+        publicar_cliente_legacy_mock,
+    )
+
+    assert runtime.idle_publicar_paquete(paquete) is True
+    assert llamadas == [str(paquete)]
 
 def test_helpers_idle_de_paquetes_no_importan_lexer_ni_parser_y_delegan_en_packaging(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
### Motivation
- Evitar duplicar validación, caché o lógica interna del cliente en el IDLE moviendo la responsabilidad de publicar paquetes a la fachada `CobraHubPackages`.

### Description
- Cambiado `idle_publicar_paquete()` en `src/pcobra/gui/runtime.py` para importar `CobraHubClient` y `CobraHubPackages` y devolver `CobraHubPackages(CobraHubClient()).publicar_paquete(str(paquete))` en lugar de llamar directamente al método legacy del cliente.
- Actualizada la suite de pruebas en `tests/unit/test_gui_runtime.py` para parchear `pcobra.cobra.cli.cobrahub_packages.CobraHubPackages.publicar_paquete` en los tests existentes que verifican la delegación.
- Añadida una prueba de regresión que parchea `CobraHubPackages.publicar_paquete` y parchea `CobraHubClient.publicar_paquete` para asegurar que `idle_publicar_paquete()` no publique usando el método legacy del cliente.

### Testing
- Ejecutados los tres tests relevantes con `pytest` y pasaron: `test_idle_publicar_paquete_expone_fallo_de_publicacion`, `test_idle_publicar_paquete_delega_en_cobrahub_packages_sin_red`, y `test_idle_publicar_paquete_no_delega_en_metodo_legacy_del_cliente` (3 passed, 1 warning).
- Se compiló con `python -m py_compile src/pcobra/gui/runtime.py tests/unit/test_gui_runtime.py` sin errores.
- Se intentó ejecutar todo `tests/unit/test_gui_runtime.py -q`, pero el entorno alcanzó un `MemoryError` después de reportar 53 tests pasados; los tests específicos modificados fueron verificados y pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44c4fc13c8832791c733eb216ed51a)