### PR TITLE
test: cover HubCommand package flows

### DIFF
--- a/tests/unit/test_cobrahub_cache.py
+++ b/tests/unit/test_cobrahub_cache.py
@@ -1,4 +1,6 @@
 from argparse import Namespace
+from unittest.mock import patch
+import re
 from pathlib import Path
 
 from pcobra.cobra.cli.cobrahub_packages import (
@@ -79,3 +81,107 @@ def test_cli_hub_cache_limpiar_informa_total(tmp_path: Path, monkeypatch, capsys
     assert codigo == 0
     assert "Paquetes eliminados de caché: 1" in capsys.readouterr().out
     assert listar_cache() == []
+
+
+def test_cli_hub_publicar_delega_en_cobrahub_packages_sin_red():
+    args = Namespace(accion="publicar", paquete=Path("dist/demo.co"))
+
+    with patch(
+        "pcobra.cobra.cli.commands.hub_cmd.CobraHubPackages.publicar_paquete",
+        return_value=True,
+    ) as publicar:
+        codigo = HubCommand().run(args)
+
+    assert codigo == 0
+    publicar.assert_called_once_with("dist/demo.co")
+
+
+def test_cli_hub_buscar_imprime_resultados_normalizados(capsys):
+    args = Namespace(accion="buscar", consulta="demo")
+    resultados = [
+        {"name": "demo", "version": "1.2.3"},
+        {"nombre": "ejemplo", "version": "2.0.0"},
+        {"version": "0.1.0"},
+    ]
+
+    with patch(
+        "pcobra.cobra.cli.commands.hub_cmd.CobraHubPackages.buscar_paquetes",
+        return_value=resultados,
+    ) as buscar:
+        codigo = HubCommand().run(args)
+
+    salida = capsys.readouterr().out
+    assert codigo == 0
+    buscar.assert_called_once_with("demo")
+    assert "demo 1.2.3" in salida
+    assert "ejemplo 2.0.0" in salida
+    assert "paquete 0.1.0" in salida
+
+
+def test_cli_hub_instalar_delega_en_cobrahub_packages_sin_red():
+    args = Namespace(
+        accion="instalar",
+        nombre="demo",
+        version="1.2.3",
+        destino=Path("ruta"),
+    )
+
+    with patch(
+        "pcobra.cobra.cli.commands.hub_cmd.CobraHubPackages.instalar_paquete",
+        return_value=True,
+    ) as instalar:
+        codigo = HubCommand().run(args)
+
+    assert codigo == 0
+    instalar.assert_called_once_with("demo", "ruta", "1.2.3")
+
+
+def test_cli_hub_publicar_e_instalar_devuelven_error_si_falla_operacion():
+    with patch(
+        "pcobra.cobra.cli.commands.hub_cmd.CobraHubPackages.publicar_paquete",
+        return_value=False,
+    ):
+        codigo_publicar = HubCommand().run(
+            Namespace(accion="publicar", paquete=Path("dist/demo.co"))
+        )
+
+    with patch(
+        "pcobra.cobra.cli.commands.hub_cmd.CobraHubPackages.instalar_paquete",
+        return_value=False,
+    ):
+        codigo_instalar = HubCommand().run(
+            Namespace(accion="instalar", nombre="demo", version=None, destino=None)
+        )
+
+    assert codigo_publicar != 0
+    assert codigo_instalar != 0
+
+
+def test_cli_hub_cache_listar_conserva_salida_ordenada(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(tmp_path))
+    (tmp_path / "b.co").write_text("x", encoding="utf-8")
+    (tmp_path / "a.co").write_text("x", encoding="utf-8")
+    (tmp_path / "nota.txt").write_text("x", encoding="utf-8")
+
+    codigo = HubCommand().run(Namespace(accion="cache", cache_accion="listar"))
+
+    lineas = [
+        re.sub(r"\x1b\[[0-9;]*m", "", line.strip())
+        for line in capsys.readouterr().out.splitlines()
+        if line.strip()
+    ]
+    assert codigo == 0
+    assert lineas == [str(tmp_path / "a.co"), str(tmp_path / "b.co")]
+
+
+def test_main_cobra_cli_hub_publicar_delega_sin_red():
+    from cobra.cli.cli import main
+
+    with patch(
+        "pcobra.cobra.cli.commands.hub_cmd.CobraHubPackages.publicar_paquete",
+        return_value=True,
+    ) as publicar:
+        codigo = main(["hub", "publicar", "dist/demo.co"])
+
+    assert codigo == 0
+    publicar.assert_called_once_with("dist/demo.co")


### PR DESCRIPTION
### Motivation
- Aumentar la cobertura de unidad del comando `hub` y del entrypoint legacy para asegurar que las rutas de publicación, búsqueda, instalación y gestión de caché delegan correctamente en la capa de paquetes y manejan errores sin realizar llamadas de red reales.

### Description
- Añadí múltiples pruebas en `tests/unit/test_cobrahub_cache.py` que comprueban que `HubCommand` delega en `CobraHubPackages.publicar_paquete` y `CobraHubPackages.instalar_paquete`, que la búsqueda imprime resultados normalizados y que publicación/instalación fallidas devuelven código distinto de cero.
- Añadí una prueba que invoca `main()` del shim legacy (`cobra.cli.cli`) para validar que `cobra hub publicar dist/demo.co` delega en `CobraHubPackages.publicar_paquete` sin red.
- Conservé y amplié pruebas de caché (`cache listar|limpiar|validar`), incluyendo limpieza de secuencia ordenada y saneamiento de códigos de color en la salida para hacer las aserciones robustas.
- Todas las pruebas usan `unittest.mock.patch` para sustituir los métodos de `CobraHubPackages` y evitar tráfico de red real.

### Testing
- Ejecutado: `pytest -q tests/unit/test_cobrahub_cache.py` and `pytest -q tests/unit/test_cli_cobrahub.py tests/unit/test_cobrahub_cache.py`.
- Resultado: las pruebas afectadas pasaron correctamente; en la ejecución final todos los tests invocados pasaron (`45 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44d6179bf88327a9330d5f03f2cef3)