### PR TITLE
docs: aclarar flujos de paquetes y CobraHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1105,9 +1105,16 @@ cobra build noexiste.co
 cobra mod list
 cobra mod install ruta/al/modulo.co
 cobra mod remove modulo.co
-# Crear e instalar paquetes Cobra
-cobra paquete crear src demo.cobra
-cobra paquete instalar demo.cobra
+# Flujo local moderno de paquetes Cobra .co
+cobra paquete crear src --nombre demo --version 0.1.0
+cobra paquete construir src dist/demo.co
+cobra paquete validar dist/demo.co
+cobra paquete inspeccionar dist/demo.co
+cobra paquete extraer dist/demo.co ./vendor/demo
+# Flujo moderno de CobraHub
+cobra hub publicar dist/demo.co
+cobra hub buscar demo
+cobra hub instalar demo --destino ./vendor/demo
 # Generar documentación HTML y API
 cobra docs
 # Crear un ejecutable independiente
@@ -1142,9 +1149,11 @@ El subcomando `gui` abre el IDLE gráfico principal y requiere tener instalado F
 
 ### Paquetes `.co` y CobraHub
 
-CobraHub funciona ahora como una capa de herramientas independiente para crear, construir, validar, verificar, inspeccionar, extraer, publicar, buscar e instalar paquetes `.co`. Un paquete `.co` es un ZIP con manifiesto `cobra.pkg.json`, checksums SHA-256 y estructura de carpetas conservada; puede contener archivos `.cobra`, documentación Markdown, texto, `Dockerfile` y recursos. `validar` comprueba la estructura y el manifiesto del contenedor, `verificar` expresa de forma explícita la verificación de integridad SHA-256, e `integridad` se conserva como alias legacy. Esta funcionalidad no cambia la sintaxis de Cobra ni requiere tocar Lexer o Parser. Consulta la guía actualizada de paquetes en [`docs/frontend/paquetes.rst`](docs/frontend/paquetes.rst) y el resumen de diseño en [`docs/cobrahub_paquetes.md`](docs/cobrahub_paquetes.md).
+CobraHub funciona ahora como una capa de herramientas independiente para crear, construir, validar, verificar, inspeccionar, extraer, publicar, buscar e instalar paquetes `.co`. Un paquete `.co` es un ZIP con manifiesto `cobra.pkg.json`, checksums SHA-256 y estructura de carpetas conservada; puede contener archivos `.cobra`, documentación Markdown, texto, `Dockerfile` y recursos. `validar` comprueba la estructura y el manifiesto del contenedor, `verificar` expresa de forma explícita la verificación de integridad SHA-256, e `integridad` se conserva como alias legacy. Esta funcionalidad no cambia la sintaxis de Cobra ni requiere tocar Lexer o Parser: el paquete `.co` se detecta como un ZIP con `cobra.pkg.json`, no como sintaxis Cobra. Consulta la guía actualizada de paquetes en [`docs/frontend/paquetes.rst`](docs/frontend/paquetes.rst) y el resumen de diseño en [`docs/cobrahub_paquetes.md`](docs/cobrahub_paquetes.md).
 
-Comandos nuevos:
+Flujo recomendado: `cobra paquete crear|construir|validar|inspeccionar|extraer` cubre el ciclo local moderno; `cobra paquete instalar` queda como alias legacy de extracción/instalación local; y `cobra hub publicar|buscar|instalar` es el flujo moderno de CobraHub. No uses `cobra paquete` → `cobra mod publish` para paquetes `.co` con manifiesto; `cobra modulos publicar|buscar` queda solo como compatibilidad histórica de módulos sueltos.
+
+Comandos recomendados:
 
 ```bash
 cobra paquete crear mi_paquete --nombre demo --version 0.1.0
@@ -1162,8 +1171,8 @@ Los comandos legacy se mantienen por compatibilidad con scripts existentes y no 
 
 | comando legacy | comando recomendado | estado | notas de compatibilidad |
 | --- | --- | --- | --- |
-| `cobra modulos publicar` | `cobra hub publicar` | Compatibilidad | `modulos` conserva el flujo histórico de módulos sueltos; `hub` publica paquetes `.co` validados. |
-| `cobra modulos buscar` | `cobra hub buscar` o `cobra hub instalar` | Compatibilidad | Usa `hub buscar` para descubrir paquetes y `hub instalar` para descargarlos e instalarlos. |
+| `cobra modulos publicar` | `cobra hub publicar` para paquetes `.co` con manifiesto | Compatibilidad | `modulos` conserva el flujo histórico de módulos sueltos; no lo uses como destino de paquetes `.co` con `cobra.pkg.json`. |
+| `cobra modulos buscar` | `cobra hub buscar` o `cobra hub instalar` | Compatibilidad | Usa `hub buscar` para descubrir paquetes CobraHub y `hub instalar` para descargarlos e instalarlos; `modulos buscar` queda para módulos sueltos históricos. |
 | `cobra paquete instalar` | `cobra paquete extraer` | Alias legacy | Alias de extracción/instalación local hacia el destino indicado o `~/.cobra/packages` por defecto. |
 | `cobra paquete crear <fuente> <salida>` | `cobra paquete crear <fuente>` + `cobra paquete construir <fuente> <salida>` | Alias legacy | Mantiene la creación del manifiesto y la construcción del artefacto en una sola invocación. |
 

--- a/docs/frontend/cobrahub.rst
+++ b/docs/frontend/cobrahub.rst
@@ -81,9 +81,14 @@ contra CobraHub:
       cobra hub cache limpiar
       cobra hub cache validar
 
-Los comandos ``cobra paquete`` gestionan el ciclo de vida local del artefacto.
-Los comandos ``cobra hub`` usan ese artefacto para publicar, buscar e instalar
-paquetes mediante la API recomendada de CobraHub.
+Los comandos ``cobra paquete crear|construir|validar|inspeccionar|extraer``
+gestionan el ciclo de vida local moderno del artefacto. ``cobra paquete
+instalar`` se conserva como alias legacy de extracción/instalación local. Los
+comandos ``cobra hub publicar|buscar|instalar`` usan ese artefacto para publicar,
+buscar e instalar paquetes mediante la API recomendada de CobraHub. No se
+recomienda enviar paquetes ``.co`` con ``cobra.pkg.json`` al flujo
+``cobra paquete`` → ``cobra mod publish``; ``cobra modulos publicar|buscar`` se
+mantiene solo como compatibilidad histórica de módulos sueltos.
 
 
 Caché local de CobraHub
@@ -144,13 +149,13 @@ deprecación explícita.
      - estado
      - notas de compatibilidad
    * - ``cobra modulos publicar``
-     - ``cobra hub publicar``
+     - ``cobra hub publicar`` para paquetes ``.co`` con manifiesto
      - Compatibilidad
-     - ``modulos`` publica módulos sueltos mediante el flujo histórico; ``hub`` publica paquetes ``.co`` con manifiesto.
+     - ``modulos`` publica módulos sueltos mediante el flujo histórico; no debe usarse como destino recomendado de paquetes ``.co`` con ``cobra.pkg.json``.
    * - ``cobra modulos buscar``
      - ``cobra hub buscar`` o ``cobra hub instalar``
      - Compatibilidad
-     - Para código nuevo, busca paquetes con ``hub buscar`` e instálalos con ``hub instalar``.
+     - Para código nuevo, busca paquetes con ``hub buscar`` e instálalos con ``hub instalar``; ``modulos buscar`` queda para módulos sueltos históricos.
    * - ``cobra paquete instalar``
      - ``cobra paquete extraer``
      - Alias legacy
@@ -162,8 +167,9 @@ deprecación explícita.
 
 Este flujo legacy usa el subcomando ``modulos`` y la configuración histórica de
 CobraHub, incluida la variable de entorno ``COBRAHUB_URL`` cuando aplique. Para
-código nuevo se recomienda usar el flujo de paquetes con ``cobra paquete`` y
-``cobra hub``.
+código nuevo se recomienda usar el flujo local de paquetes con ``cobra paquete
+crear|construir|validar|inspeccionar|extraer`` y el flujo remoto con ``cobra hub
+publicar|buscar|instalar``.
 
 Diálogo asistido desde la terminal
 ---------------------------------
@@ -186,7 +192,9 @@ Relación con Lexer y Parser
 ---------------------------
 
 Lexer y Parser no se modifican para soportar paquetes ``.co`` porque el
-empaquetado no forma parte de la sintaxis del lenguaje. La construcción,
+empaquetado no forma parte de la sintaxis del lenguaje: un paquete ``.co`` se
+detecta como un ZIP legible con ``cobra.pkg.json`` en la raíz, no como sintaxis
+Cobra. La construcción,
 validación, inspección, extracción, publicación e instalación de paquetes viven
 en ``pcobra.cobra.packaging`` y tratan los archivos fuente como contenido del ZIP
 hasta que el usuario decida ejecutarlos con los comandos habituales.

--- a/docs/frontend/paquetes.rst
+++ b/docs/frontend/paquetes.rst
@@ -9,8 +9,8 @@ archivos empaquetados.
 Este formato pertenece a la capa de herramientas de empaquetado y CobraHub: no
 modifica la sintaxis del lenguaje ni requiere cambios en el Lexer o el Parser.
 Los archivos fuente Cobra pueden seguir usando ``.cobra`` o ``.co``; cuando
-``.co`` se usa como paquete publicable, la CLI lo trata como un ZIP con
-metadatos.
+``.co`` se usa como paquete publicable, la CLI lo detecta como un ZIP legible
+con ``cobra.pkg.json`` en la raíz, no como sintaxis Cobra.
 
 Fuente de verdad pública
 ------------------------
@@ -126,6 +126,14 @@ Extraer el paquete en una carpeta local:
 
    cobra paquete extraer dist/demo.co ./vendor/demo
 
+Este es el flujo local moderno: ``cobra paquete crear|construir|validar|
+inspeccionar|extraer``. Para interactuar con CobraHub, usa el flujo remoto
+moderno ``cobra hub publicar|buscar|instalar``. ``cobra paquete instalar`` se
+conserva solo como alias legacy de extracción/instalación local, y
+``cobra modulos publicar|buscar`` queda reservado a compatibilidad histórica de
+módulos sueltos. No se recomienda migrar paquetes ``.co`` con manifiesto a
+``cobra mod publish`` ni al flujo histórico de ``modulos``.
+
 Compatibilidad con comandos legacy
 ----------------------------------
 
@@ -143,13 +151,13 @@ nuevos, el formato recomendado es el contenedor ``.co`` con manifiesto
      - estado
      - notas de compatibilidad
    * - ``cobra modulos publicar``
-     - ``cobra hub publicar``
+     - ``cobra hub publicar`` para paquetes ``.co`` con manifiesto
      - Compatibilidad
-     - ``modulos`` conserva el flujo histórico de módulos sueltos; ``hub`` publica paquetes ``.co`` validados.
+     - ``modulos`` conserva el flujo histórico de módulos sueltos; no es el destino recomendado para paquetes ``.co`` con ``cobra.pkg.json``.
    * - ``cobra modulos buscar``
      - ``cobra hub buscar`` o ``cobra hub instalar``
      - Compatibilidad
-     - Usa ``hub buscar`` para descubrimiento y ``hub instalar`` para descarga e instalación de paquetes CobraHub.
+     - Usa ``hub buscar`` para descubrimiento y ``hub instalar`` para descarga e instalación de paquetes CobraHub; ``modulos buscar`` queda para módulos sueltos históricos.
    * - ``cobra paquete instalar``
      - ``cobra paquete extraer``
      - Alias legacy

--- a/docs/migracion_cli_unificada.md
+++ b/docs/migracion_cli_unificada.md
@@ -10,6 +10,8 @@ Adoptar el modelo unificado:
 - `cobra build`
 - `cobra test`
 - `cobra mod`
+- `cobra paquete` para empaquetado local de artefactos `.co`
+- `cobra hub` para publicación, búsqueda e instalación en CobraHub
 
 Con backends públicos oficiales:
 
@@ -26,9 +28,9 @@ Con backends públicos oficiales:
 
 | Clase | Comandos |
 |---|---|
-| **Públicos (UI v2)** | `run`, `build`, `test`, `mod` |
+| **Públicos (UI v2)** | `run`, `build`, `test`, `mod`, `paquete`, `hub` |
 | **Internos (UI v2 / development)** | `legacy`, `debug`, `devops` |
-| **Legacy públicos (UI v1, migración)** | `interactive`, `compilar`, `ejecutar`, `modulos`, `verificar`, `docs`, `plugins`, `init`, `crear`, `paquete` |
+| **Legacy públicos (UI v1, migración)** | `interactive`, `compilar`, `ejecutar`, `modulos`, `verificar`, `docs`, `plugins`, `init`, `crear` |
 | **Legacy internos (UI v1)** | `cache`, `contenedor`, `gui`, `jupyter`, `qualia`, `agix` |
 | **Legacy obsoletos (UI v1)** | `dependencias`, `empaquetar`, `bench`, `benchmarks`, `benchmarks2`, `benchtranspilers`, `benchthreads`, `profile`, `transpilar-inverso`, `validar-sintaxis`, `qa-validar` |
 
@@ -45,14 +47,24 @@ Con backends públicos oficiales:
 | `cobra modulos listar` | `cobra mod list` |
 | `cobra modulos instalar ruta/al/modulo.co` | `cobra mod install ruta/al/modulo.co` |
 | `cobra modulos remover modulo.co` | `cobra mod remove modulo.co` |
-| `cobra modulos buscar nombre` | `cobra mod search nombre` |
-| `cobra modulos publicar ruta/al/modulo.co` | `cobra mod publish ruta/al/modulo.co` |
+| `cobra modulos buscar nombre` | `cobra mod search nombre` para módulos sueltos históricos; `cobra hub buscar nombre` para paquetes CobraHub |
+| `cobra modulos publicar ruta/al/modulo.co` | Compatibilidad histórica de módulos sueltos; usa `cobra hub publicar dist/paquete.co` para paquetes `.co` con `cobra.pkg.json` |
 | `cobra interactive archivo.co` | `cobra run archivo.co` |
 | `cobra init` | `cobra mod init` |
 | `cobra crear` | `cobra mod init` |
-| `cobra paquete` | `cobra mod publish` |
+| `cobra paquete crear <dir>` | Flujo local moderno de paquetes: crea `cobra.pkg.json` |
+| `cobra paquete construir <dir> <salida.co>` | Flujo local moderno de paquetes: construye el ZIP `.co` con manifiesto |
+| `cobra paquete validar <salida.co>` | Flujo local moderno de paquetes: valida estructura y manifiesto |
+| `cobra paquete inspeccionar <salida.co>` | Flujo local moderno de paquetes: muestra metadatos y contenido |
+| `cobra paquete extraer <salida.co> <destino>` | Flujo local moderno de paquetes: extracción local explícita |
+| `cobra paquete instalar <salida.co> [destino]` | Alias legacy de `cobra paquete extraer` para extracción/instalación local |
+| `cobra hub publicar <salida.co>` | Flujo moderno de CobraHub para paquetes `.co` con manifiesto |
+| `cobra hub buscar <nombre>` | Flujo moderno de CobraHub para descubrir paquetes |
+| `cobra hub instalar <nombre>` | Flujo moderno de CobraHub para descargar e instalar paquetes |
 
+### Nota sobre paquetes `.co` y Lexer/Parser
 
+No se toca el Lexer ni el Parser para soportar paquetes `.co`: un paquete publicable se detecta en la capa de herramientas como un ZIP legible que contiene `cobra.pkg.json` en la raíz, no como una nueva sintaxis Cobra. Por eso, no migres paquetes `.co` con manifiesto hacia `cobra mod publish`; usa `cobra paquete crear|construir|validar|inspeccionar|extraer` para el ciclo local y `cobra hub publicar|buscar|instalar` para CobraHub. `cobra modulos publicar|buscar` queda reservado a compatibilidad histórica de módulos sueltos.
 
 ## Plan de migración recomendado (paso a paso)
 


### PR DESCRIPTION
### Motivation
- Alinear la documentación para dejar inequívoco el flujo moderno de paquetes locales (`cobra paquete crear|construir|validar|inspeccionar|extraer`), el flujo de publicación/descubrimiento/instalación en CobraHub (`cobra hub publicar|buscar|instalar`) y la compatibilidad histórica de `cobra modulos`.
- Evitar la ambigüedad que sugería migrar paquetes `.co` con `cobra.pkg.json` hacia `cobra mod publish` y dejar claro que `cobra paquete instalar` se mantiene solo como alias legacy de extracción local.
- Aclarar explícitamente que no se modifica el Lexer/Parser porque un `.co` publicable se detecta como ZIP con `cobra.pkg.json` en la capa de herramientas, no como nueva sintaxis del lenguaje.

### Description
- Actualiza `docs/migracion_cli_unificada.md` para incluir `cobra paquete` y `cobra hub` en la superficie pública y detallar el mapeo de comandos modernos y legacy. 
- Modifica `README.md` para mostrar el flujo local moderno de paquetes (`crear|construir|validar|inspeccionar|extraer`), el flujo CobraHub (`hub publicar|buscar|instalar`) y marcar `cobra paquete instalar` como alias legacy local. 
- Ajusta `docs/frontend/paquetes.rst` y `docs/frontend/cobrahub.rst` para reforzar que `.co` publicable es un ZIP con `cobra.pkg.json`, separar el ciclo local y el remoto, y indicar que `modulos publicar|buscar` es compatibilidad histórica. 
- Añade una nota explícita en la documentación indicando que no se toca Lexer/Parser y que no se debe migrar paquetes `.co` con manifiesto hacia `cobra mod publish`.

### Testing
- Ejecutado `git diff --check` para comprobar inconsistencias de diff y formateo, y no se reportaron errores. (éxito)
- Búsqueda con `rg` sobre los ficheros modificados para validar la presencia de los términos claves (`cobra paquete crear|construir|validar|inspeccionar|extraer`, `cobra hub publicar|buscar|instalar`, `cobra.pkg.json`, etc.), y todas las ocurrencias esperadas fueron encontradas. (éxito)
- Script Python de verificación que comprueba la presencia de las menciones clave en los documentos (`cobra.pkg.json` y los flujos recomendados) y lanza aserciones; el script completó sin errores. (éxito)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44da81498483279490840c120b8746)