### PR TITLE
docs: aclarar manejo de archivos .co/.cobra en el IDLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,7 +1184,7 @@ La entrada recomendada para el entorno gráfico interactivo es `cobra gui`, que 
 
 El IDLE gráfico (`cobra gui`) incluye un editor con estado de archivo activo: muestra la ruta seleccionada, detecta cambios sin guardar con un asterisco y conserva el contenido cargado para comparar modificaciones. La barra de archivo expone las acciones **Nuevo**, **Abrir**, **Guardar**, **Guardar como** y **Recargar**.
 
-El panel lateral lista carpetas y archivos Cobra (`.co` para scripts y `.cobra` para paquetes) desde el directorio de trabajo actual. Al seleccionar un archivo del árbol, su contenido se carga directamente en el editor y se actualiza la ruta activa. Las operaciones de guardado escriben el texto normalizado del editor tal como está, sin pasar por el lexer ni por el parser. Los errores de permisos, rutas inexistentes o codificación se muestran con el formato homogéneo de errores de la GUI.
+El panel lateral lista carpetas y archivos Cobra desde el directorio de trabajo actual. Por compatibilidad histórica, tanto `.cobra` como `.co` pueden ser archivos fuente Cobra de texto y se tratan como código editable cuando no son paquetes. Un `.co` solo es paquete si es un ZIP legible con `cobra.pkg.json` en la raíz; en ese caso el IDLE debe tratarlo como artefacto de empaquetado y no como código fuente editable. Al seleccionar un archivo fuente del árbol, su contenido se carga directamente en el editor y se actualiza la ruta activa. Las operaciones de guardado escriben el texto normalizado del editor tal como está, sin pasar por el lexer ni por el parser. Los errores de permisos, rutas inexistentes o codificación se muestran con el formato homogéneo de errores de la GUI.
 
 ## Conversión desde otros lenguajes a Cobra
 


### PR DESCRIPTION
### Motivation
- Corregir la descripción del panel lateral del IDLE en `README.md` para reflejar la regla real sobre ` .co` y `.cobra`: ambos pueden ser fuentes de texto por compatibilidad histórica y un `.co` solo es paquete si es un ZIP legible con `cobra.pkg.json`, sin tocar Lexer ni Parser.

### Description
- Se actualizó la sección “IDLE gráfico” en `README.md` reemplazando la frase que decía “`.co` para scripts y `.cobra` para paquetes” por la explicación de compatibilidad histórica y la regla que trata los `.co` ZIP con `cobra.pkg.json` como artefactos de empaquetado; solo se modificó documentación.

### Testing
- Se ejecutaron comprobaciones de verificación con `rg -n "IDLE|\.co|\.cobra|panel lateral|scripts|paquetes" README.md`, `git diff -- README.md`, `git status --short && git diff --name-only` y `nl -ba README.md | sed -n '1181,1190p'`, y todas finalizaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44e4fd6d98832796fff2942e60707c)