### PR TITLE
Conservar metadatos opcionales de paquetes CobraHub

### DIFF
--- a/src/pcobra/cobra/hub/repository.py
+++ b/src/pcobra/cobra/hub/repository.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING, Any, Protocol
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.packaging import (
     PackageSearchResult,
+    manifest_from_dict,
+    manifest_to_dict,
     normalizar_nombre_paquete,
     validar_version_paquete,
 )
@@ -75,6 +77,7 @@ class HttpCobraHubRepository:
     ) -> bool:
         """Publica un paquete .co mediante la API HTTP de CobraHub."""
         ruta = Path(package_path)
+        metadata = _normalizar_metadatos_paquete(metadata)
         with ruta.open("rb") as f:
             with self.client.session.post(
                 f"{self.client.base_url}/paquetes",
@@ -178,7 +181,28 @@ class HttpCobraHubRepository:
                 "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
             )
         info = validar_paquete(package_path)
-        return dict(info.manifest)
+        return _normalizar_metadatos_paquete(info.manifest)
+
+
+def _normalizar_metadatos_paquete(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Devuelve metadatos canónicos preservando campos opcionales soportados."""
+    return manifest_to_dict(manifest_from_dict(dict(metadata)))
+
+
+def _normalizar_lista_str(value: Any) -> list[str] | None:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    return [str(value)]
+
+
+def _normalizar_dependencias(value: Any) -> dict[str, str] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        return None
+    return {str(name): str(version) for name, version in value.items()}
 
 
 def _normalizar_resultado_paquete(item: Any) -> PackageSearchResult:
@@ -206,6 +230,17 @@ def _normalizar_resultado_paquete(item: Any) -> PackageSearchResult:
             item.get("download_url") or item.get("url") or item.get("href")
         ),
         remote_id=_optional_str(item.get("remote_id") or item.get("id")),
+        description=_optional_str(item.get("description") or item.get("descripcion")),
+        authors=_normalizar_lista_str(
+            item["authors"] if "authors" in item else item.get("autores")
+        ),
+        license=_optional_str(item.get("license") or item.get("licencia")),
+        homepage=_optional_str(
+            item.get("homepage") or item.get("home_page") or item.get("project_url")
+        ),
+        dependencies=_normalizar_dependencias(
+            item["dependencies"] if "dependencies" in item else item.get("dependencias")
+        ),
     )
 
 

--- a/src/pcobra/cobra/packaging.py
+++ b/src/pcobra/cobra/packaging.py
@@ -146,8 +146,13 @@ class PackageSearchResult:
     checksum: str | None = None
     download_url: str | None = None
     remote_id: str | None = None
+    description: str | None = None
+    authors: list[str] | None = None
+    license: str | None = None
+    homepage: str | None = None
+    dependencies: dict[str, str] | None = None
 
-    def as_dict(self) -> dict[str, str]:
+    def as_dict(self) -> dict[str, Any]:
         """Devuelve solo los campos disponibles para mantener compatibilidad JSON."""
         values = {
             "name": self.name,
@@ -156,6 +161,11 @@ class PackageSearchResult:
             "checksum": self.checksum,
             "download_url": self.download_url,
             "remote_id": self.remote_id,
+            "description": self.description,
+            "authors": self.authors,
+            "license": self.license,
+            "homepage": self.homepage,
+            "dependencies": self.dependencies,
         }
         return {key: value for key, value in values.items() if value is not None}
 

--- a/tests/unit/test_cli_cobrahub.py
+++ b/tests/unit/test_cli_cobrahub.py
@@ -652,7 +652,7 @@ class _PackageStreamingResponse:
         raise AssertionError("La instalación debe descargar el paquete en streaming")
 
 
-def _paquete_cobra_bytes(label: str = "demo") -> bytes:
+def _paquete_cobra_bytes(label: str = "demo", extra_manifest=None) -> bytes:
     payload = f"imprimir('{label}')\n".encode("utf-8")
     checksum = hashlib.sha256(payload).hexdigest()
     manifest = {
@@ -662,6 +662,8 @@ def _paquete_cobra_bytes(label: str = "demo") -> bytes:
         "files": ["src/main.cobra"],
         "checksums": {"src/main.cobra": checksum},
     }
+    if extra_manifest:
+        manifest.update(extra_manifest)
     buffer = BytesIO()
     with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("cobra.pkg.json", json.dumps(manifest, ensure_ascii=False))
@@ -695,6 +697,11 @@ def test_buscar_paquetes_normaliza_metadatos_disponibles(monkeypatch):
                         "sha256": "abc123",
                         "url": "https://example.test/demo-2.0.0.co",
                         "id": "pkg-1",
+                        "description": "Descripción corta",
+                        "authors": ["Ada", 7],
+                        "license": "Apache-2.0",
+                        "homepage": "https://example.test/demo",
+                        "dependencies": {"cobra-core": "^1.0.0", "util": 2},
                     }
                 ]
             }
@@ -719,8 +726,60 @@ def test_buscar_paquetes_normaliza_metadatos_disponibles(monkeypatch):
             "checksum": "abc123",
             "download_url": "https://example.test/demo-2.0.0.co",
             "remote_id": "pkg-1",
+            "description": "Descripción corta",
+            "authors": ["Ada", "7"],
+            "license": "Apache-2.0",
+            "homepage": "https://example.test/demo",
+            "dependencies": {"cobra-core": "^1.0.0", "util": "2"},
         }
     ]
+
+
+@pytest.mark.timeout(5)
+def test_publicar_paquete_preserva_manifiesto_enriquecido(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("COBRAHUB_CACHE_DIR", str(cache_dir))
+
+    manifest_extra = {
+        "name": "Demo Enriquecido",
+        "description": "Paquete de ejemplo con metadatos opcionales",
+        "authors": ["Ada Lovelace", 42],
+        "license": "MIT",
+        "homepage": "https://example.test/demo",
+        "dependencies": {"cobra-core": "^1.0.0", "util": 2},
+    }
+    paquete = tmp_path / "demo-enriquecido.co"
+    contenido = _paquete_cobra_bytes("demo-enriquecido", manifest_extra)
+    paquete.write_bytes(contenido)
+
+    client = cobrahub_client.CobraHubClient()
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    response.raise_for_status.return_value = None
+    client.session.post = MagicMock(return_value=response)
+
+    assert client.publicar_paquete(str(paquete))
+
+    client.session.post.assert_called_once()
+    metadata = json.loads(client.session.post.call_args.kwargs["data"]["metadata"])
+    assert metadata == {
+        "format": "cobra-package-v1",
+        "name": "demo-enriquecido",
+        "version": "1.0.0",
+        "files": ["src/main.cobra"],
+        "checksums": metadata["checksums"],
+        "description": "Paquete de ejemplo con metadatos opcionales",
+        "authors": ["Ada Lovelace", "42"],
+        "license": "MIT",
+        "homepage": "https://example.test/demo",
+        "dependencies": {"cobra-core": "^1.0.0", "util": "2"},
+    }
+    assert (cache_dir / paquete.name).read_bytes() == contenido
+
+    from pcobra.cobra.cli.cobrahub_packages import CobraHubPackages
+
+    assert CobraHubPackages(client).leer_metadatos(paquete) == metadata
 
 
 @pytest.mark.timeout(5)


### PR DESCRIPTION
### Motivation

- Asegurar que los campos opcionales del manifiesto (`description`, `authors`, `license`, `homepage`, `dependencies`) se preserven y se normalicen al publicar, leer y listar paquetes desde CobraHub.

### Description

- Normaliza los metadatos antes de enviarlos en `HttpCobraHubRepository.publish()` para garantizar una representación canónica y segura de los campos opcionales. (archivo: `src/pcobra/cobra/hub/repository.py`)
- `read_metadata()` ahora devuelve el manifiesto validado y normalizado usando el modelo de empaquetado canónico, vía `_normalizar_metadatos_paquete()`. (archivo: `src/pcobra/cobra/hub/repository.py`)
- Amplía la normalización de resultados remotos para incluir `description`, `authors`, `license`, `homepage` y `dependencies`, con helpers que convierten tipos heterogéneos a cadenas/listas/dict seguros. (archivo: `src/pcobra/cobra/hub/repository.py`)
- Añade campos opcionales a `PackageSearchResult` y actualiza `as_dict()` para seguir siendo compatible y omitir valores `None`. (archivo: `src/pcobra/cobra/packaging.py`)
- Añade pruebas unitarias que cubren la publicación con un manifiesto enriquecido y la búsqueda que devuelve metadatos opcionales. (archivo: `tests/unit/test_cli_cobrahub.py`)

### Testing

- Se ejecutó el formateo con `python -m black src/pcobra/cobra/hub/repository.py src/pcobra/cobra/packaging.py tests/unit/test_cli_cobrahub.py` y se aplicó a los tests modificados.
- Se ejecutaron las pruebas relevantes con `pytest -q tests/unit/test_cli_cobrahub.py tests/unit/test_cobra_packaging.py` y todas pasaron: `78 passed` con `2 warnings`.
- Se verificó la nueva cobertura para publicación/lectura de manifiesto enriquecido y búsqueda con metadatos opcionales; los tests añadidos pasan en la suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44e865f8748327834c344668dac581)