### PR TITLE
Documentar contrato PackageRepository

### DIFF
--- a/docs/cobrahub_paquetes.md
+++ b/docs/cobrahub_paquetes.md
@@ -13,6 +13,28 @@ La guía de uso actualizada para crear, construir, validar, inspeccionar y extra
 - **Ruta recomendada para paquetes:** `src/pcobra/cobra/cli/cobrahub_packages.py` concentra la API de paquetes publicables `.co`: publicación, búsqueda, instalación, caché local y lectura de metadatos. El comando `cobra hub publicar|buscar|instalar` usa esta capa.
 - **Compatibilidad:** los métodos `publicar_paquete`, `buscar_paquetes` e `instalar_paquete` siguen disponibles en `CobraHubClient`, pero delegan en `CobraHubPackages`. El código nuevo debería importar `CobraHubPackages` directamente.
 
+
+## Contrato `PackageRepository`
+
+`PackageRepository` es el contrato interno que desacopla las operaciones de repositorio de paquetes del transporte concreto y del resto del lenguaje. La capa de comandos de CobraHub delega en esta interfaz para publicar, buscar, descargar y leer metadatos de paquetes `.co`, mientras Lexer y Parser permanecen ajenos al formato de distribución.
+
+La interfaz actual expone cuatro operaciones:
+
+- `publish(package_path, metadata, checksum)`: publica un paquete local ya validado. `package_path` apunta al artefacto `.co`, `metadata` contiene los metadatos normalizados que se indexarán y `checksum` identifica el contenido esperado para verificar integridad durante la publicación.
+- `search(query)`: busca paquetes a partir de una consulta textual y devuelve resultados normalizados para que la CLI pueda mostrarlos o usarlos en flujos posteriores.
+- `download(name, version=None)`: descarga un paquete por nombre canónico. `version` es opcional; si no se proporciona, el repositorio puede resolver la versión por defecto o más reciente según su política actual.
+- `read_metadata(package_path)`: lee y normaliza los metadatos de un paquete `.co` local, validando que sea un paquete Cobra antes de exponer su manifiesto.
+
+La implementación HTTP actual (`HttpCobraHubRepository`) usa endpoints provisionales mientras el servicio evoluciona:
+
+- `POST /paquetes` para `publish(package_path, metadata, checksum)`.
+- `GET /paquetes?q=...` para `search(query)`.
+- `GET /paquetes/{nombre}` para `download(name, version=None)`, con `version` como parámetro opcional cuando se quiere una versión concreta.
+
+`read_metadata(package_path)` es una operación local: reutiliza la validación del paquete `.co` y no requiere endpoint HTTP.
+
+Quedan fuera de alcance por ahora la resolución transitiva de dependencias, la autenticación compleja, las firmas criptográficas, un índice global completo, el yanking o deprecación de versiones y los mirrors. Esas capacidades podrán incorporarse detrás de nuevas implementaciones de `PackageRepository` o de extensiones compatibles del contrato, sin cambiar el Lexer ni el Parser. Esta separación permite evolucionar CobraHub hacia un repositorio tipo PyPI manteniendo estable la sintaxis del lenguaje y aislando el formato de distribución en la capa de empaquetado/repositorio.
+
 ## Contrato HTTP mínimo
 
 Esta especificación define el contrato HTTP mínimo que debe implementar un

--- a/docs/frontend/cobrahub.rst
+++ b/docs/frontend/cobrahub.rst
@@ -9,6 +9,42 @@ las notas de diseño consulta :doc:`paquetes` y el documento
 mínimo provisional para ``POST /paquetes``, ``GET /paquetes?q=consulta`` y
 ``GET /paquetes/{nombre}``, compatible con una futura infraestructura tipo PyPI.
 
+
+Contrato ``PackageRepository``
+-----------------------------
+
+La CLI de CobraHub no acopla la publicación, búsqueda, descarga ni lectura de
+metadatos a una implementación concreta. Esas operaciones se expresan mediante
+el contrato ``PackageRepository``:
+
+* ``publish(package_path, metadata, checksum)``: publica un paquete ``.co``
+  local ya validado, enviando los metadatos normalizados y el checksum esperado
+  del artefacto.
+* ``search(query)``: busca paquetes a partir de una consulta textual y devuelve
+  resultados normalizados.
+* ``download(name, version=None)``: descarga un paquete por nombre; ``version``
+  es opcional y, si se omite, el repositorio puede resolver la versión por
+  defecto o más reciente según su política.
+* ``read_metadata(package_path)``: lee metadatos de un paquete local tras
+  comprobar que el archivo es un paquete Cobra válido.
+
+La implementación HTTP actual usa endpoints provisionales:
+
+* ``POST /paquetes`` para publicar paquetes.
+* ``GET /paquetes?q=...`` para buscar paquetes.
+* ``GET /paquetes/{nombre}`` para descargar paquetes, con ``version`` como
+  parámetro opcional cuando se necesita una versión concreta.
+
+``read_metadata(package_path)`` no usa la red: opera sobre el archivo local y
+reutiliza la validación del paquete.
+
+Por ahora quedan fuera de alcance la resolución transitiva de dependencias, la
+autenticación compleja, las firmas criptográficas, un índice global completo, el
+yanking o deprecación de versiones y los mirrors. Mantener este contrato separado
+permite evolucionar CobraHub hacia un repositorio tipo PyPI sin tocar Lexer ni
+Parser, porque el empaquetado y el transporte siguen viviendo en capas externas
+a la sintaxis del lenguaje.
+
 Flujo recomendado de paquetes
 -----------------------------
 


### PR DESCRIPTION
### Motivation

- Dejar explícito en la documentación el contrato que separa las operaciones de repositorio de paquetes del transporte concreto y del resto del lenguaje. 
- Facilitar que futuras implementaciones (índices, mirrors, autenticación, resolución de versiones) evolucionen sin tocar Lexer/Parser ni la capa de empaquetado.

### Description

- Añadí una sección "Contrato `PackageRepository`" en `docs/cobrahub_paquetes.md` y `docs/frontend/cobrahub.rst` que enumera las cuatro operaciones públicas: `publish(package_path, metadata, checksum)`, `search(query)`, `download(name, version=None)` y `read_metadata(package_path)`.
- Indiqué que la implementación HTTP actual (`HttpCobraHubRepository`) usa endpoints provisionales: `POST /paquetes`, `GET /paquetes?q=...` y `GET /paquetes/{nombre}` y aclaré que `read_metadata(package_path)` es una operación local sin endpoint HTTP.
- Listé las capacidades que quedan fuera de alcance por ahora: resolución transitiva de dependencias, autenticación compleja, firmas criptográficas, índice global completo, yanking/deprecación de versiones y mirrors, y expliqué que dichas capacidades podrán implementarse detrás del contrato sin cambiar Lexer/Parser.

### Testing

- Compilé los módulos afectados con `python -m compileall -q src/pcobra/cobra/hub/repository.py src/pcobra/cobra/cli/cobrahub_packages.py` y la comprobación fue satisfactoria. 
- Verifiqué que no quedan problemas de formato con `git diff --check` y no se reportaron errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44ea489658832787f7db6bf6a561ef)