### PR TITLE
Validar y normalizar dependencias en manifiestos Cobra

### DIFF
--- a/src/pcobra/cobra/packaging.py
+++ b/src/pcobra/cobra/packaging.py
@@ -59,7 +59,11 @@ def manifest_from_dict(data: dict[str, Any]) -> PackageManifest:
     """Convierte un diccionario JSON en un manifiesto Cobra validado.
 
     Mantiene compatibilidad con manifiestos históricos que solo declaran
-    ``format``, ``name``, ``version``, ``files`` y ``checksums``.
+    ``format``, ``name``, ``version``, ``files`` y ``checksums``. Las
+    dependencias se normalizan con la misma política que los nombres de
+    paquete y, por ahora, solo aceptan versiones exactas SemVer; los rangos
+    no están soportados hasta que exista una política de resolución
+    documentada.
     """
     package_format = data.get("format")
     if package_format is None:
@@ -90,6 +94,8 @@ def manifest_from_dict(data: dict[str, Any]) -> PackageManifest:
     if dependencies is not None and not isinstance(dependencies, dict):
         raise ValueError("El manifiesto debe declarar dependencies como objeto")
 
+    normalized_dependencies = _validar_dependencias_manifest(dependencies)
+
     return PackageManifest(
         format=str(package_format),
         name=normalizar_nombre_paquete(str(name)),
@@ -102,12 +108,36 @@ def manifest_from_dict(data: dict[str, Any]) -> PackageManifest:
         authors=None if authors is None else [str(author) for author in authors],
         license=None if data.get("license") is None else str(data.get("license")),
         homepage=None if data.get("homepage") is None else str(data.get("homepage")),
-        dependencies=(
-            None
-            if dependencies is None
-            else {str(name): str(value) for name, value in dependencies.items()}
-        ),
+        dependencies=normalized_dependencies,
     )
+
+
+def _validar_dependencias_manifest(
+    dependencies: dict[Any, Any] | None,
+) -> dict[str, str] | None:
+    """Normaliza y valida las dependencias declaradas en un manifiesto.
+
+    Cobra todavía no define semántica para resolver rangos de versiones, por
+    lo que cada dependencia debe apuntar a una versión exacta SemVer simple.
+    """
+    if dependencies is None:
+        return None
+
+    normalized_dependencies: dict[str, str] = {}
+    for raw_name, raw_version in dependencies.items():
+        name = normalizar_nombre_paquete(str(raw_name))
+        if name in normalized_dependencies:
+            raise ValueError(f"Dependencia duplicada tras normalizar: {name}")
+        try:
+            version = validar_version_paquete(str(raw_version))
+        except ValueError as exc:
+            raise ValueError(
+                f"Versión de dependencia inválida para {name}: "
+                "solo se aceptan versiones exactas SemVer"
+            ) from exc
+        normalized_dependencies[name] = version
+
+    return normalized_dependencies
 
 
 def manifest_to_dict(manifest: PackageManifest) -> dict[str, Any]:

--- a/tests/unit/test_cobra_packaging.py
+++ b/tests/unit/test_cobra_packaging.py
@@ -54,7 +54,7 @@ def test_package_manifest_acepta_campos_extra_permitidos():
         "authors": ["Equipo Cobra"],
         "license": "MIT",
         "homepage": "https://example.test/demo",
-        "dependencies": {"stdlib": ">=1.0"},
+        "dependencies": {"Std Lib": "1.2.3"},
     }
 
     manifest = manifest_from_dict(data)
@@ -63,8 +63,54 @@ def test_package_manifest_acepta_campos_extra_permitidos():
     assert manifest.authors == ["Equipo Cobra"]
     assert manifest.license == "MIT"
     assert manifest.homepage == "https://example.test/demo"
-    assert manifest.dependencies == {"stdlib": ">=1.0"}
-    assert manifest_to_dict(manifest) == data
+    assert manifest.dependencies == {"std-lib": "1.2.3"}
+    expected = {**data, "dependencies": {"std-lib": "1.2.3"}}
+    assert manifest_to_dict(manifest) == expected
+
+
+def test_package_manifest_normaliza_dependencias_validas():
+    manifest = manifest_from_dict(
+        {
+            "format": "cobra-package-v1",
+            "name": "demo",
+            "version": "1.0.0",
+            "files": [],
+            "checksums": {},
+            "dependencies": {
+                "  Paquete Demo ": " 1.2.3 ",
+                "util.core": "2.0.0-beta.1+build.5",
+            },
+        }
+    )
+
+    assert manifest.dependencies == {
+        "paquete-demo": "1.2.3",
+        "util.core": "2.0.0-beta.1+build.5",
+    }
+
+
+@pytest.mark.parametrize(
+    ("dependencies", "match"),
+    [
+        ({"demo/evil": "1.0.0"}, "Nombre de paquete inválido"),
+        ({"demo": ">=1.0.0"}, "solo se aceptan versiones exactas SemVer"),
+        ({"demo": "1.0"}, "solo se aceptan versiones exactas SemVer"),
+        ({"demo": "v1.0.0"}, "solo se aceptan versiones exactas SemVer"),
+        ([], "dependencies como objeto"),
+    ],
+)
+def test_package_manifest_rechaza_dependencias_invalidas(dependencies, match):
+    with pytest.raises(ValueError, match=match):
+        manifest_from_dict(
+            {
+                "format": "cobra-package-v1",
+                "name": "demo",
+                "version": "1.0.0",
+                "files": [],
+                "checksums": {},
+                "dependencies": dependencies,
+            }
+        )
 
 
 def test_package_manifest_rechaza_formato_no_soportado():


### PR DESCRIPTION
### Motivation
- Hacer que las dependencias declaradas en el manifiesto se normalicen y validen de forma consistente con la política de nombres de paquete de Cobra.
- Evitar ambigüedades al aceptar rangos de versión hasta definir la política de resolución, documentando la restricción actual.

### Description
- Documenta en `manifest_from_dict()` que las `dependencies` se normalizan como nombres de paquete y que por ahora solo se aceptan versiones SemVer exactas.
- Añade la función auxiliar `_validar_dependencias_manifest()` que normaliza cada clave con `normalizar_nombre_paquete()`, detecta duplicados tras normalización y valida cada versión con `validar_version_paquete()` rechazando rangos u otros formatos no SemVer.
- Integra la normalización en `manifest_from_dict()` para que `PackageManifest.dependencies` reciba dependencias normalizadas o `None`.
- Actualiza y añade pruebas en `tests/unit/test_cobra_packaging.py` para cubrir dependencias válidas (normalización y SemVer) y varios casos inválidos (nombres inseguros, rangos no soportados, versiones no SemVer y tipo incorrecto).

### Testing
- Ejecuté `pytest tests/unit/test_cobra_packaging.py -q` y los tests unitarios modificados pasaron (`49 passed` en la ejecución local de la batería de tests de archivo).
- Ejecuté la suite completa con `pytest -q -x` y falló en una prueba de contrato CLI no relacionada con estos cambios: `tests/cli/test_public_v2_commands_contract.py::test_public_v2_subcommands_match_contract_exactly`, que detectó comandos extra (`hub` y `paquete`) expuestos públicamente; este fallo parece ajeno a la validación de dependencias.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44eb8849508327b7e607f4cef2a3a8)