### PR TITLE
Permitir destino opcional al construir paquete desde IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -888,8 +888,18 @@ def main(page: "ft.Page"):
             if project_root is None:
                 salida.value = "Abre o crea un proyecto antes de construir un paquete."
             else:
-                paquete = runtime.idle_construir_paquete(project_root)
-                salida.value = f"Paquete construido: {paquete}"
+                destino_paquete: Path | None = None
+                ruta_visible = (ruta_input.value or "").strip()
+                if ruta_visible:
+                    ruta_destino = Path(ruta_visible).expanduser()
+                    if ruta_destino.suffix.lower() == ".co":
+                        destino_paquete = (
+                            ruta_destino
+                            if ruta_destino.is_absolute()
+                            else Path(project_root) / ruta_destino
+                        )
+                paquete = runtime.idle_construir_paquete(project_root, destino_paquete)
+                salida.value = f"Paquete construido: {paquete.resolve()}"
         except Exception as exc:
             salida.value = f"Error construyendo paquete: {exc}"
         actualizar_pagina()

--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -1667,9 +1667,14 @@ def idle_validar_paquete(paquete: str | Path):
 
 
 def idle_construir_paquete(project_root: str | Path, salida: str | Path | None = None) -> Path:
-    from pcobra.cobra.packaging import construir_paquete
+    from pcobra.cobra.packaging import MANIFEST_NAME, construir_paquete
 
     root = validar_project_root_idle(project_root)
+    manifest = root / MANIFEST_NAME
+    if not manifest.is_file():
+        raise FileNotFoundError(
+            "Usa 'Crear paquete' antes de construir: falta cobra.pkg.json"
+        )
     return construir_paquete(root, salida)
 
 

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -1129,6 +1129,17 @@ def test_idle_construir_y_validar_paquete_incluye_archivos_del_proyecto_minimo(
     assert "assets/recurso.txt" in inspection.files
 
 
+def test_idle_construir_paquete_respeta_salida_indicada(tmp_path: Path) -> None:
+    project_root = _crear_proyecto_cobra_minimo(tmp_path)
+    runtime.idle_crear_paquete(project_root, "paquete-demo", version="1.0.0")
+    salida = tmp_path / "artefactos" / "destino-personalizado.co"
+
+    paquete = runtime.idle_construir_paquete(project_root, salida)
+
+    assert paquete == salida
+    assert paquete.is_file()
+
+
 def test_idle_abrir_paquete_extrae_proyecto_minimo(tmp_path: Path) -> None:
     project_root = _crear_proyecto_cobra_minimo(tmp_path)
     runtime.idle_crear_paquete(project_root, "paquete-demo", version="1.0.0")
@@ -1172,6 +1183,25 @@ def test_idle_construir_paquete_falla_si_falta_manifest(tmp_path: Path) -> None:
 
     with pytest.raises(FileNotFoundError, match="Usa 'Crear paquete' antes de construir"):
         runtime.idle_construir_paquete(project_root)
+
+
+def test_idle_construir_paquete_exige_cobra_pkg_json_antes_de_delegar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project_root = _crear_proyecto_cobra_minimo(tmp_path)
+    salida = tmp_path / "no-debe-crearse.co"
+
+    def construir_paquete_mock(*_args, **_kwargs):
+        raise AssertionError("No debe construir sin cobra.pkg.json")
+
+    monkeypatch.setattr(
+        "pcobra.cobra.packaging.construir_paquete", construir_paquete_mock
+    )
+
+    with pytest.raises(FileNotFoundError, match="falta cobra\\.pkg\\.json"):
+        runtime.idle_construir_paquete(project_root, salida)
+
+    assert not salida.exists()
 
 
 def test_idle_publicar_paquete_expone_fallo_de_publicacion(


### PR DESCRIPTION
### Motivation
- Permitir que el handler de construcción del IDLE use el contenido de `ruta_input.value` como destino cuando el usuario apunta a un archivo `.co` para facilitar generar paquetes en ubicaciones personalizadas.
- Mantener `idle_construir_paquete(project_root, salida=None)` como el helper común para CLI/IDLE y garantizar que no delegue en la creación del paquete si falta el manifiesto `cobra.pkg.json`.
- Mostrar en la UI la ruta absoluta del paquete construido para mayor claridad del usuario.

### Description
- Actualiza `construir_paquete_handler()` en `src/pcobra/gui/idle.py` para interpretar `ruta_input.value` y, cuando apunta a un `.co`, construir una `Path` absoluta (resolviendo relativo a `project_root` si hace falta) y pasarla como `salida` a `runtime.idle_construir_paquete()`.
- Cambia la salida mostrada en `salida.value` para usar la ruta absoluta del paquete construido con `paquete.resolve()`.
- Añade en `src/pcobra/gui/runtime.py` una validación previa en `idle_construir_paquete()` que comprueba la existencia de `cobra.pkg.json` (`MANIFEST_NAME`) y lanza `FileNotFoundError` con mensaje claro si falta.
- Añade pruebas en `tests/unit/test_gui_runtime.py` que verifican que `idle_construir_paquete(project_root, salida)` respeta el destino indicado y que exige `cobra.pkg.json` antes de delegar en `pcobra.cobra.packaging.construir_paquete`.

### Testing
- Se ejecutaron las pruebas focalizadas con `pytest` para las nuevas y las relacionadas: cuatro tests pasaron (`test_idle_construir_y_validar_paquete_incluye_archivos_del_proyecto_minimo`, `test_idle_construir_paquete_respeta_salida_indicada`, `test_idle_construir_paquete_falla_si_falta_manifest`, `test_idle_construir_paquete_exige_cobra_pkg_json_antes_de_delegar`) y todas pasaron.
- Se comprobó la sintaxis con `python -m py_compile` sobre `src/pcobra/gui/idle.py`, `src/pcobra/gui/runtime.py` y `tests/unit/test_gui_runtime.py` y la comprobación fue satisfactoria.
- La ejecución completa de `python -m pytest tests/unit/test_gui_runtime.py -q` alcanzó 53 pruebas pasadas pero terminó con un `MemoryError` en Pytest durante la captura/limpieza del entorno, por lo que se validaron las pruebas relevantes de forma focalizada con resultados exitosos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44eda7b3788327ad18c78f2ff534e0)