### PR TITLE
Aclara apertura de paquetes en IDLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ cobra hub cache validar
 El IDLE gráfico expone un flujo de empaquetado pensado para operar sobre el proyecto activo y sobre la ruta visible del campo **Ruta**. Las acciones disponibles son:
 
 - **Crear paquete**: inicializa el manifiesto `cobra.pkg.json` en el proyecto activo y prepara la estructura mínima del paquete. Si no hay proyecto activo, el IDLE muestra un mensaje indicando que primero debe abrirse o crearse uno.
-- **Abrir paquete**: extrae un paquete `.co` indicado en el campo **Ruta** hacia el proyecto activo o, si no hay proyecto activo, hacia la raíz de trabajo del IDLE.
+- **Abrir paquete**: extrae el contenido completo de un paquete `.co` indicado en el campo **Ruta** dentro del proyecto activo; si no hay proyecto activo, lo extrae en la raíz de trabajo o workspace del IDLE. No abre el `.co` como texto editable.
 - **Validar paquete**: inspecciona el paquete `.co` indicado en **Ruta** y muestra si es válido; los errores estructurales del paquete se presentan como mensajes visibles de paquete inválido.
 - **Construir paquete**: genera el archivo `.co` del proyecto activo usando su manifiesto `cobra.pkg.json`. Si falta el manifiesto, la construcción se detiene para que el usuario lo cree explícitamente antes.
 - **Publicar CobraHub**: publica el paquete `.co` indicado en **Ruta** mediante el cliente de CobraHub y muestra un mensaje visible si la publicación falla.

--- a/docs/frontend/cobrahub.rst
+++ b/docs/frontend/cobrahub.rst
@@ -90,6 +90,11 @@ contra CobraHub:
 
       cobra paquete extraer dist/demo.co salida/demo
 
+   En el IDLE gráfico, la acción **Abrir paquete** aplica esta misma operación
+   sobre el ``.co`` indicado en el campo **Ruta**: extrae su contenido en el
+   proyecto activo y, si no hay proyecto activo, en la raíz del workspace. No
+   carga el contenedor ``.co`` como fuente editable.
+
 7. Publicar el paquete en CobraHub:
 
    .. code-block:: bash

--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -863,7 +863,7 @@ def main(page: "ft.Page"):
             else:
                 destino = project_root or runtime.resolver_workspace_root_idle()
                 runtime.idle_abrir_paquete(paquete, destino)
-                salida.value = f"Paquete abierto en: {destino}"
+                salida.value = f"Paquete extraído/abierto en: {destino}"
                 reconstruir_arbol()
         except Exception as exc:
             salida.value = f"Error abriendo paquete: {exc}"

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -1168,6 +1168,24 @@ def test_idle_validar_paquete_muestra_error_para_paquete_invalido(tmp_path: Path
         runtime.idle_validar_paquete(paquete)
 
 
+def test_idle_abrir_paquete_delega_en_extraer_paquete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paquete = tmp_path / "paquete.co"
+    paquete.write_bytes(b"contenido de prueba")
+    destino = tmp_path / "destino"
+    destino.mkdir()
+    llamadas: list[tuple[Path, Path]] = []
+
+    def fake_extraer_paquete(paquete_arg, destino_arg):
+        llamadas.append((paquete_arg, destino_arg))
+        return Path(destino_arg)
+
+    monkeypatch.setattr("pcobra.cobra.packaging.extraer_paquete", fake_extraer_paquete)
+
+    assert runtime.idle_abrir_paquete(paquete, destino) == destino
+    assert llamadas == [(paquete, destino)]
+
 def test_idle_abrir_paquete_falla_si_destino_no_existe(tmp_path: Path) -> None:
     project_root = _crear_proyecto_cobra_minimo(tmp_path)
     runtime.idle_crear_paquete(project_root, "paquete-demo", version="1.0.0")


### PR DESCRIPTION
### Motivation
- Aclarar en la documentación y en la GUI que la acción **Abrir paquete** del IDLE extrae el contenido del `.co` en el proyecto activo o, si no hay proyecto activo, en la raíz del workspace, y no lo abre como fuente editable.
- Hacer el mensaje de éxito del IDLE más explícito para reflejar la operación real realizada por la acción.
- Añadir una prueba que garantice que el helper `idle_abrir_paquete()` delega en `extraer_paquete()` de `pcobra.cobra.packaging`.

### Description
- Actualiza `README.md` para describir que **Abrir paquete** extrae el contenido completo del `.co` dentro del proyecto activo o en la raíz del workspace y que no abre el `.co` como texto editable.  
- Añade una aclaración equivalente en `docs/frontend/cobrahub.rst` vinculando la acción del IDLE con la operación de extracción (`extraer`).
- Cambia el mensaje de éxito en `src/pcobra/gui/idle.py` de `Paquete abierto en: ...` a `Paquete extraído/abierto en: ...` tras llamar a `runtime.idle_abrir_paquete(...)`.
- Añade la prueba `test_idle_abrir_paquete_delega_en_extraer_paquete` en `tests/unit/test_gui_runtime.py` que parchea `pcobra.cobra.packaging.extraer_paquete` y verifica que `runtime.idle_abrir_paquete()` llama con los argumentos esperados.

### Testing
- Ejecutado `pytest tests/unit/test_gui_runtime.py::test_idle_abrir_paquete_delega_en_extraer_paquete -q` y la prueba pasó (1 passed, 1 warning).  
- Ejecutadas las pruebas relacionadas: `test_idle_abrir_paquete_extrae_proyecto_minimo`, `test_idle_abrir_paquete_delega_en_extraer_paquete`, `test_helpers_idle_de_paquetes_no_importan_lexer_ni_parser_y_delegan_en_packaging` y todas pasaron (3 passed, 1 warning).  
- `python -m py_compile src/pcobra/gui/idle.py src/pcobra/gui/runtime.py tests/unit/test_gui_runtime.py` se ejecutó correctamente sin errores de compilación.  
- `git diff --check` no mostró problemas.  
- Nota: la ejecución completa `pytest tests/unit/test_gui_runtime.py -q` terminó previamente con un `INTERNALERROR`/`MemoryError` de pytest después de reportar `53 passed`; por esa razón se ejecutaron y validaron las pruebas específicas relacionadas con este cambio y las comprobaciones de compilación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44fa06c31c8327b76e5d97b4c830c6)