### PR TITLE
Add Cobra installer package skeleton

### DIFF
--- a/src/pcobra/cobra_installer/__init__.py
+++ b/src/pcobra/cobra_installer/__init__.py
@@ -1,0 +1,19 @@
+"""API pública para construir instaladores de proyectos Cobra.
+
+El paquete concentra la lógica de empaquetado fuera del IDLE. Las interfaces
+visuales deben limitarse a invocar :func:`package_current_project` o a usar el
+puente delgado de :mod:`pcobra.cobra_installer.idle_bridge`.
+"""
+
+from __future__ import annotations
+
+from .project import BuildOptions, BuildResult, CobraInstallerError
+from .runtime_builder import build_project, package_current_project
+
+__all__ = [
+    "BuildOptions",
+    "BuildResult",
+    "CobraInstallerError",
+    "build_project",
+    "package_current_project",
+]

--- a/src/pcobra/cobra_installer/cache.py
+++ b/src/pcobra/cobra_installer/cache.py
@@ -1,0 +1,9 @@
+"""Módulo inicial del instalador Cobra.
+
+Este archivo reserva una responsabilidad concreta del flujo de construcción para
+mantener la lógica fuera del IDLE a medida que el instalador evolucione.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/pcobra/cobra_installer/cli.py
+++ b/src/pcobra/cobra_installer/cli.py
@@ -1,0 +1,39 @@
+"""CLI mínima para el instalador Cobra."""
+
+from __future__ import annotations
+
+import argparse
+
+from .project import CobraInstallerError
+from .runtime_builder import package_current_project
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="cobra-installer")
+    parser.add_argument("project_root", nargs="?", default=".")
+    parser.add_argument("--entrypoint")
+    parser.add_argument("--output-dir")
+    parser.add_argument("--name")
+    parser.add_argument("--target", default="current")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = package_current_project(
+            args.project_root,
+            entrypoint=args.entrypoint,
+            output_dir=args.output_dir,
+            name=args.name,
+            target=args.target,
+        )
+    except CobraInstallerError as exc:
+        print(f"Error: {exc}")
+        return 1
+    print(result.artifact_path or result.output_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pcobra/cobra_installer/dependency_resolver.py
+++ b/src/pcobra/cobra_installer/dependency_resolver.py
@@ -1,0 +1,9 @@
+"""Módulo inicial del instalador Cobra.
+
+Este archivo reserva una responsabilidad concreta del flujo de construcción para
+mantener la lógica fuera del IDLE a medida que el instalador evolucione.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/pcobra/cobra_installer/hub_resolver.py
+++ b/src/pcobra/cobra_installer/hub_resolver.py
@@ -1,0 +1,9 @@
+"""Módulo inicial del instalador Cobra.
+
+Este archivo reserva una responsabilidad concreta del flujo de construcción para
+mantener la lógica fuera del IDLE a medida que el instalador evolucione.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/pcobra/cobra_installer/idle_bridge.py
+++ b/src/pcobra/cobra_installer/idle_bridge.py
@@ -1,0 +1,18 @@
+"""Puente delgado para que el IDLE delegue el empaquetado.
+
+No debe contener lógica de construcción: el IDLE y este módulo solo llaman a
+``package_current_project``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .project import BuildResult
+from .runtime_builder import package_current_project
+
+
+def package_from_idle(project_root: str | Path, **kwargs: object) -> BuildResult:
+    """Delegación explícita desde el IDLE hacia la API pública del instalador."""
+
+    return package_current_project(project_root, **kwargs)

--- a/src/pcobra/cobra_installer/logger.py
+++ b/src/pcobra/cobra_installer/logger.py
@@ -1,0 +1,9 @@
+"""Módulo inicial del instalador Cobra.
+
+Este archivo reserva una responsabilidad concreta del flujo de construcción para
+mantener la lógica fuera del IDLE a medida que el instalador evolucione.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/pcobra/cobra_installer/manifest.py
+++ b/src/pcobra/cobra_installer/manifest.py
@@ -1,0 +1,23 @@
+"""Escritura de manifiestos del instalador Cobra."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .project import BuildOptions
+
+
+def create_manifest(options: BuildOptions, entrypoint: Path, output_dir: Path, name: str) -> Path:
+    """Crea un manifiesto JSON mínimo para el artefacto."""
+
+    path = output_dir / "cobra-installer-manifest.json"
+    payload = {
+        "name": name,
+        "project_root": str(options.project_root),
+        "entrypoint": str(entrypoint),
+        "target": options.target,
+        "include_dependencies": options.include_dependencies,
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path

--- a/src/pcobra/cobra_installer/project.py
+++ b/src/pcobra/cobra_installer/project.py
@@ -1,0 +1,61 @@
+"""Tipos compartidos para el instalador Cobra."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping, Sequence
+
+
+class CobraInstallerError(RuntimeError):
+    """Error base para fallos controlados durante el empaquetado Cobra."""
+
+
+@dataclass(frozen=True, slots=True)
+class BuildOptions:
+    """Opciones mínimas para construir un artefacto instalable."""
+
+    project_root: Path | str = Path.cwd()
+    entrypoint: Path | str | None = None
+    output_dir: Path | str | None = None
+    name: str | None = None
+    target: str = "current"
+    clean: bool = False
+    include_dependencies: bool = True
+    extra_args: Sequence[str] = field(default_factory=tuple)
+
+    def normalized(self) -> "BuildOptions":
+        """Devuelve una copia con rutas absolutas y valores derivados."""
+
+        root = Path(self.project_root).expanduser().resolve()
+        entrypoint = None
+        if self.entrypoint is not None:
+            raw_entrypoint = Path(self.entrypoint).expanduser()
+            entrypoint = raw_entrypoint if raw_entrypoint.is_absolute() else root / raw_entrypoint
+            entrypoint = entrypoint.resolve()
+        output_dir = Path(self.output_dir).expanduser() if self.output_dir is not None else root / "dist"
+        if not output_dir.is_absolute():
+            output_dir = root / output_dir
+        return BuildOptions(
+            project_root=root,
+            entrypoint=entrypoint,
+            output_dir=output_dir.resolve(),
+            name=self.name,
+            target=self.target,
+            clean=self.clean,
+            include_dependencies=self.include_dependencies,
+            extra_args=tuple(self.extra_args),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BuildResult:
+    """Resultado estable de un proceso de construcción."""
+
+    success: bool
+    artifact_path: Path | None = None
+    project_root: Path | None = None
+    output_dir: Path | None = None
+    target: str = "current"
+    metadata: Mapping[str, object] = field(default_factory=dict)
+    logs: tuple[str, ...] = ()

--- a/src/pcobra/cobra_installer/pyinstaller_runner.py
+++ b/src/pcobra/cobra_installer/pyinstaller_runner.py
@@ -1,0 +1,9 @@
+"""Módulo inicial del instalador Cobra.
+
+Este archivo reserva una responsabilidad concreta del flujo de construcción para
+mantener la lógica fuera del IDLE a medida que el instalador evolucione.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/pcobra/cobra_installer/runtime_builder.py
+++ b/src/pcobra/cobra_installer/runtime_builder.py
@@ -1,0 +1,51 @@
+"""Orquestación principal de construcción fuera del IDLE."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from .manifest import create_manifest
+from .project import BuildOptions, BuildResult, CobraInstallerError
+from .spec_writer import write_spec
+from .validator import discover_entrypoint, validate_project
+
+
+def build_project(options: BuildOptions | None = None, **overrides: object) -> BuildResult:
+    """Construye un proyecto Cobra usando una API programática estable.
+
+    La implementación inicial prepara directorios, manifiesto y especificación
+    mínima para que PyInstaller/CLI puedan integrarse sin acoplar lógica al IDLE.
+    """
+
+    base = options or BuildOptions()
+    if overrides:
+        base = replace(base, **overrides)
+    normalized = validate_project(base)
+    entrypoint = normalized.entrypoint or discover_entrypoint(Path(normalized.project_root))
+    if entrypoint is None:
+        raise CobraInstallerError(
+            f"No se encontró un punto de entrada Cobra en {normalized.project_root}"
+        )
+
+    output_dir = Path(normalized.output_dir or Path(normalized.project_root) / "dist")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    name = normalized.name or entrypoint.stem
+    manifest_path = create_manifest(normalized, entrypoint, output_dir, name)
+    spec_path = write_spec(normalized, entrypoint, output_dir, name)
+    return BuildResult(
+        success=True,
+        artifact_path=spec_path,
+        project_root=Path(normalized.project_root),
+        output_dir=output_dir,
+        target=normalized.target,
+        metadata={"entrypoint": str(entrypoint), "manifest": str(manifest_path), "name": name},
+        logs=("Proyecto preparado para empaquetado.",),
+    )
+
+
+def package_current_project(project_root: str | Path | None = None, **kwargs: object) -> BuildResult:
+    """Empaqueta el proyecto actual; punto único que debe llamar el IDLE."""
+
+    options = BuildOptions(project_root=project_root or Path.cwd(), **kwargs)
+    return build_project(options)

--- a/src/pcobra/cobra_installer/spec_writer.py
+++ b/src/pcobra/cobra_installer/spec_writer.py
@@ -1,0 +1,27 @@
+"""Generación de especificaciones de empaquetado."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .project import BuildOptions
+
+
+def write_spec(options: BuildOptions, entrypoint: Path, output_dir: Path, name: str) -> Path:
+    """Escribe una especificación inicial legible por humanos."""
+
+    path = output_dir / f"{name}.cobra-installer.toml"
+    path.write_text(
+        "\n".join(
+            [
+                f'name = "{name}"',
+                f'project_root = "{Path(options.project_root)}"',
+                f'entrypoint = "{entrypoint}"',
+                f'target = "{options.target}"',
+                f'include_dependencies = {str(options.include_dependencies).lower()}',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return path

--- a/src/pcobra/cobra_installer/targets.py
+++ b/src/pcobra/cobra_installer/targets.py
@@ -1,0 +1,9 @@
+"""Módulo inicial del instalador Cobra.
+
+Este archivo reserva una responsabilidad concreta del flujo de construcción para
+mantener la lógica fuera del IDLE a medida que el instalador evolucione.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/pcobra/cobra_installer/transpile.py
+++ b/src/pcobra/cobra_installer/transpile.py
@@ -1,0 +1,9 @@
+"""Módulo inicial del instalador Cobra.
+
+Este archivo reserva una responsabilidad concreta del flujo de construcción para
+mantener la lógica fuera del IDLE a medida que el instalador evolucione.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/pcobra/cobra_installer/validator.py
+++ b/src/pcobra/cobra_installer/validator.py
@@ -1,0 +1,35 @@
+"""Validación de proyectos para el instalador Cobra."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .project import BuildOptions, CobraInstallerError
+
+COBRA_EXTENSIONS = (".cobra", ".co")
+
+
+def validate_project(options: BuildOptions) -> BuildOptions:
+    """Valida opciones y devuelve una versión normalizada."""
+
+    normalized = options.normalized()
+    root = Path(normalized.project_root)
+    if not root.exists() or not root.is_dir():
+        raise CobraInstallerError(f"El proyecto no existe o no es una carpeta: {root}")
+    if normalized.entrypoint is not None and not normalized.entrypoint.exists():
+        raise CobraInstallerError(f"El punto de entrada no existe: {normalized.entrypoint}")
+    return normalized
+
+
+def discover_entrypoint(project_root: Path) -> Path | None:
+    """Busca un punto de entrada Cobra común dentro del proyecto."""
+
+    for name in ("main.cobra", "main.co", "app.cobra", "app.co"):
+        candidate = project_root / name
+        if candidate.exists() and candidate.is_file():
+            return candidate
+    for extension in COBRA_EXTENSIONS:
+        matches = sorted(project_root.glob(f"*{extension}"))
+        if matches:
+            return matches[0]
+    return None


### PR DESCRIPTION
### Motivation

- Separar la lógica de empaquetado del IDLE y proporcionar una API estable y reutilizable para construir/empacar proyectos Cobra.
- Proveer un punto de entrada mínimo para que la UI/IDLE pueda delegar sin incluir la lógica de construcción.

### Description

- Añadido el paquete `src/pcobra/cobra_installer/` con los módulos iniciales solicitados y placeholders para responsabilidades futuras (`dependency_resolver`, `hub_resolver`, `transpile`, `pyinstaller_runner`, `targets`, `cache`, `logger`).
- Expuesta API pública mínima en `src/pcobra/cobra_installer/__init__.py` incluyendo `BuildOptions`, `BuildResult`, `CobraInstallerError`, `build_project` y `package_current_project`.
- Implementado `BuildOptions`/`BuildResult` y validación/descubrimiento de entrypoint en `project.py` y `validator.py` con normalización de rutas mediante `BuildOptions.normalized()`.
- Implementada la orquestación inicial en `runtime_builder.py` que valida el proyecto, descubre el entrypoint, crea `dist/`, escribe un manifiesto JSON (`manifest.create_manifest`) y una especificación TOML legible (`spec_writer.write_spec`).
- Añadida una CLI mínima en `cli.py` que llama a `package_current_project(...)` y un puente fino para el IDLE en `idle_bridge.py` que solamente delega en `package_current_project(...)`.

### Testing

- Ejecutado `python -m compileall -q src/pcobra/cobra_installer` y la compilación de los módulos nuevos pasó correctamente.
- Ejecutado un smoke test en Python que importa la API pública y usa `package_current_project`/`build_project` sobre un proyecto temporal con `main.co`/`main.cobra`, verificando que se generan `dist/<name>.cobra-installer.toml` y `cobra-installer-manifest.json`, y dichos tests pasaron.
- Comprobación automática de la API del puente del IDLE (`idle_bridge.package_from_idle`) verificando que delega correctamente, y la prueba pasó.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4544e61c2c83278c1378ae41c7a020)