### PR TITLE
Add Cobra installer build models

### DIFF
--- a/src/pcobra/cobra_installer/__init__.py
+++ b/src/pcobra/cobra_installer/__init__.py
@@ -7,13 +7,20 @@ puente delgado de :mod:`pcobra.cobra_installer.idle_bridge`.
 
 from __future__ import annotations
 
-from .project import BuildOptions, BuildResult, CobraInstallerError
+from .manifest import BuildManifest, DependencyInfo
+from .project import BuildOptions, BuildResult, CobraInstallerError, CobraProject
+from .targets import BuildMode, TargetOS
 from .runtime_builder import build_project, package_current_project
 
 __all__ = [
+    "BuildManifest",
+    "BuildMode",
     "BuildOptions",
     "BuildResult",
+    "CobraProject",
     "CobraInstallerError",
+    "DependencyInfo",
+    "TargetOS",
     "build_project",
     "package_current_project",
 ]

--- a/src/pcobra/cobra_installer/manifest.py
+++ b/src/pcobra/cobra_installer/manifest.py
@@ -3,21 +3,114 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Mapping, Sequence
 
-from .project import BuildOptions
+from .project import BuildOptions, CobraProject
+from .targets import BuildMode, TargetOS
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyInfo:
+    """Dependencia incluida o auditada durante el empaquetado."""
+
+    name: str
+    version: str | None = None
+    source: str | None = None
+    path: Path | str | None = None
+    hashes: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class BuildManifest:
+    """Manifiesto reproducible de un build Cobra."""
+
+    project: CobraProject
+    executable_name: str
+    target: str | TargetOS = "current"
+    architecture: str = "native"
+    mode: BuildMode | str = BuildMode.ONEDIR
+    temp_dir: Path | str | None = None
+    dist_dir: Path | str | None = None
+    icon: Path | str | None = None
+    hashes: Mapping[str, str] = field(default_factory=dict)
+    cobra_version: str | None = None
+    pyinstaller_version: str | None = None
+    dependencies: Sequence[DependencyInfo] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, object]:
+        """Convierte el manifiesto a una estructura serializable como JSON."""
+
+        project = self.project.normalized()
+        return {
+            "project_root": _stringify(project.project_root),
+            "entrypoint": _stringify(project.entrypoint),
+            "cobra_toml": _stringify(project.cobra_toml),
+            "cobra_lock": _stringify(project.cobra_lock),
+            "assets": [_stringify(path) for path in project.assets],
+            "config": dict(project.config),
+            "co_packages": [_stringify(path) for path in project.co_packages],
+            "documentation": [_stringify(path) for path in project.documentation],
+            "executable_name": self.executable_name,
+            "target": _enum_value(self.target),
+            "architecture": self.architecture,
+            "mode": BuildMode.from_value(self.mode).value,
+            "temp_dir": _stringify(self.temp_dir),
+            "dist_dir": _stringify(self.dist_dir),
+            "icon": _stringify(self.icon),
+            "hashes": dict(self.hashes),
+            "cobra_version": self.cobra_version,
+            "pyinstaller_version": self.pyinstaller_version,
+            "dependencies": [
+                {
+                    "name": dependency.name,
+                    "version": dependency.version,
+                    "source": dependency.source,
+                    "path": _stringify(dependency.path),
+                    "hashes": dict(dependency.hashes),
+                }
+                for dependency in self.dependencies
+            ],
+        }
 
 
 def create_manifest(options: BuildOptions, entrypoint: Path, output_dir: Path, name: str) -> Path:
-    """Crea un manifiesto JSON mínimo para el artefacto."""
+    """Crea un manifiesto JSON para el artefacto Cobra."""
 
     path = output_dir / "cobra-installer-manifest.json"
-    payload = {
-        "name": name,
-        "project_root": str(options.project_root),
-        "entrypoint": str(entrypoint),
-        "target": options.target,
-        "include_dependencies": options.include_dependencies,
-    }
+    manifest = BuildManifest(
+        project=CobraProject(
+            project_root=options.project_root,
+            entrypoint=entrypoint,
+            cobra_toml=Path(options.project_root) / "cobra.toml",
+            cobra_lock=Path(options.project_root) / "cobra.lock",
+            assets=options.assets,
+            config=options.config,
+        ),
+        executable_name=name,
+        target=options.target,
+        architecture=options.architecture,
+        mode=options.mode,
+        temp_dir=options.temp_dir,
+        dist_dir=output_dir,
+        icon=options.icon,
+    )
+    payload = manifest.to_dict()
+    payload["name"] = name
+    payload["include_dependencies"] = options.include_dependencies
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return path
+
+
+def _stringify(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _enum_value(value: object) -> object:
+    return value.value if hasattr(value, "value") else value
+
+
+__all__ = ["BuildManifest", "DependencyInfo", "create_manifest"]

--- a/src/pcobra/cobra_installer/project.py
+++ b/src/pcobra/cobra_installer/project.py
@@ -6,20 +6,58 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Mapping, Sequence
 
+from .targets import BuildMode, TargetOS
+
 
 class CobraInstallerError(RuntimeError):
     """Error base para fallos controlados durante el empaquetado Cobra."""
 
 
 @dataclass(frozen=True, slots=True)
+class CobraProject:
+    """Descripción normalizada de los recursos detectados en un proyecto Cobra."""
+
+    project_root: Path | str = Path.cwd()
+    entrypoint: Path | str | None = None
+    cobra_toml: Path | str | None = None
+    cobra_lock: Path | str | None = None
+    assets: Sequence[Path | str] = field(default_factory=tuple)
+    config: Mapping[str, object] = field(default_factory=dict)
+    co_packages: Sequence[Path | str] = field(default_factory=tuple)
+    documentation: Sequence[Path | str] = field(default_factory=tuple)
+
+    def normalized(self) -> "CobraProject":
+        """Devuelve una copia con rutas absolutas resueltas desde la raíz."""
+
+        root = Path(self.project_root).expanduser().resolve()
+        return CobraProject(
+            project_root=root,
+            entrypoint=_normalize_optional_path(self.entrypoint, root),
+            cobra_toml=_normalize_optional_path(self.cobra_toml or root / "cobra.toml", root),
+            cobra_lock=_normalize_optional_path(self.cobra_lock or root / "cobra.lock", root),
+            assets=tuple(_normalize_path(path, root) for path in self.assets),
+            config=dict(self.config),
+            co_packages=tuple(_normalize_path(path, root) for path in self.co_packages),
+            documentation=tuple(_normalize_path(path, root) for path in self.documentation),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class BuildOptions:
-    """Opciones mínimas para construir un artefacto instalable."""
+    """Opciones para construir un artefacto instalable de un proyecto Cobra."""
 
     project_root: Path | str = Path.cwd()
     entrypoint: Path | str | None = None
     output_dir: Path | str | None = None
     name: str | None = None
-    target: str = "current"
+    target: str | TargetOS = "current"
+    architecture: str = "native"
+    mode: BuildMode | str = BuildMode.ONEDIR
+    temp_dir: Path | str | None = None
+    dist_dir: Path | str | None = None
+    icon: Path | str | None = None
+    assets: Sequence[Path | str] = field(default_factory=tuple)
+    config: Mapping[str, object] = field(default_factory=dict)
     clean: bool = False
     include_dependencies: bool = True
     extra_args: Sequence[str] = field(default_factory=tuple)
@@ -28,20 +66,22 @@ class BuildOptions:
         """Devuelve una copia con rutas absolutas y valores derivados."""
 
         root = Path(self.project_root).expanduser().resolve()
-        entrypoint = None
-        if self.entrypoint is not None:
-            raw_entrypoint = Path(self.entrypoint).expanduser()
-            entrypoint = raw_entrypoint if raw_entrypoint.is_absolute() else root / raw_entrypoint
-            entrypoint = entrypoint.resolve()
-        output_dir = Path(self.output_dir).expanduser() if self.output_dir is not None else root / "dist"
-        if not output_dir.is_absolute():
-            output_dir = root / output_dir
+        entrypoint = _normalize_optional_path(self.entrypoint, root)
+        output_dir = _normalize_optional_path(self.output_dir or self.dist_dir or root / "dist", root)
+        temp_dir = _normalize_optional_path(self.temp_dir or root / "build", root)
         return BuildOptions(
             project_root=root,
             entrypoint=entrypoint,
-            output_dir=output_dir.resolve(),
+            output_dir=output_dir,
             name=self.name,
             target=self.target,
+            architecture=self.architecture,
+            mode=BuildMode.from_value(self.mode),
+            temp_dir=temp_dir,
+            dist_dir=output_dir,
+            icon=_normalize_optional_path(self.icon, root),
+            assets=tuple(_normalize_path(path, root) for path in self.assets),
+            config=dict(self.config),
             clean=self.clean,
             include_dependencies=self.include_dependencies,
             extra_args=tuple(self.extra_args),
@@ -56,6 +96,27 @@ class BuildResult:
     artifact_path: Path | None = None
     project_root: Path | None = None
     output_dir: Path | None = None
-    target: str = "current"
+    target: str | TargetOS = "current"
+    architecture: str = "native"
+    mode: BuildMode = BuildMode.ONEDIR
+    executable_name: str | None = None
+    temp_dir: Path | None = None
+    dist_dir: Path | None = None
+    hashes: Mapping[str, str] = field(default_factory=dict)
+    cobra_version: str | None = None
+    pyinstaller_version: str | None = None
     metadata: Mapping[str, object] = field(default_factory=dict)
     logs: tuple[str, ...] = ()
+
+
+def _normalize_optional_path(path: Path | str | None, root: Path) -> Path | None:
+    if path is None:
+        return None
+    return _normalize_path(path, root)
+
+
+def _normalize_path(path: Path | str, root: Path) -> Path:
+    raw_path = Path(path).expanduser()
+    if not raw_path.is_absolute():
+        raw_path = root / raw_path
+    return raw_path.resolve()

--- a/src/pcobra/cobra_installer/runtime_builder.py
+++ b/src/pcobra/cobra_installer/runtime_builder.py
@@ -39,6 +39,11 @@ def build_project(options: BuildOptions | None = None, **overrides: object) -> B
         project_root=Path(normalized.project_root),
         output_dir=output_dir,
         target=normalized.target,
+        architecture=normalized.architecture,
+        mode=normalized.mode,
+        executable_name=name,
+        temp_dir=Path(normalized.temp_dir) if normalized.temp_dir is not None else None,
+        dist_dir=output_dir,
         metadata={"entrypoint": str(entrypoint), "manifest": str(manifest_path), "name": name},
         logs=("Proyecto preparado para empaquetado.",),
     )

--- a/src/pcobra/cobra_installer/targets.py
+++ b/src/pcobra/cobra_installer/targets.py
@@ -1,9 +1,31 @@
-"""Módulo inicial del instalador Cobra.
-
-Este archivo reserva una responsabilidad concreta del flujo de construcción para
-mantener la lógica fuera del IDLE a medida que el instalador evolucione.
-"""
+"""Tipos de destino soportados por el instalador Cobra."""
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from enum import StrEnum
+
+
+class BuildMode(StrEnum):
+    """Modos de empaquetado compatibles con PyInstaller."""
+
+    ONEFILE = "onefile"
+    ONEDIR = "onedir"
+
+    @classmethod
+    def from_value(cls, value: "BuildMode | str") -> "BuildMode":
+        """Normaliza cadenas o instancias de enum al modo de build canónico."""
+
+        if isinstance(value, cls):
+            return value
+        return cls(str(value))
+
+
+class TargetOS(StrEnum):
+    """Sistemas operativos objetivo para un build Cobra."""
+
+    WINDOWS = "windows"
+    LINUX = "linux"
+    MACOS = "macos"
+
+
+__all__ = ["BuildMode", "TargetOS"]

--- a/tests/unit/test_cobra_installer_models.py
+++ b/tests/unit/test_cobra_installer_models.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pcobra.cobra_installer import (
+    BuildManifest,
+    BuildMode,
+    BuildOptions,
+    CobraProject,
+    DependencyInfo,
+    TargetOS,
+)
+from pcobra.cobra_installer.manifest import create_manifest
+
+
+def test_cobra_project_normaliza_recursos_desde_raiz(tmp_path: Path) -> None:
+    project = CobraProject(
+        project_root=tmp_path,
+        entrypoint="src/main.co",
+        assets=("assets/logo.png",),
+        co_packages=("paquetes/ui.co",),
+        documentation=("docs/manual.md",),
+        config={"profile": "release"},
+    ).normalized()
+
+    assert project.entrypoint == tmp_path / "src/main.co"
+    assert project.cobra_toml == tmp_path / "cobra.toml"
+    assert project.cobra_lock == tmp_path / "cobra.lock"
+    assert project.assets == (tmp_path / "assets/logo.png",)
+    assert project.co_packages == (tmp_path / "paquetes/ui.co",)
+    assert project.documentation == (tmp_path / "docs/manual.md",)
+    assert project.config == {"profile": "release"}
+
+
+def test_build_options_normaliza_modo_dist_temp_icono_y_assets(tmp_path: Path) -> None:
+    options = BuildOptions(
+        project_root=tmp_path,
+        entrypoint="main.co",
+        dist_dir="salida",
+        temp_dir="tmp-build",
+        icon="assets/app.ico",
+        assets=("assets/app.ico",),
+        target=TargetOS.LINUX,
+        architecture="x86_64",
+        mode="onefile",
+    ).normalized()
+
+    assert options.entrypoint == tmp_path / "main.co"
+    assert options.output_dir == tmp_path / "salida"
+    assert options.dist_dir == tmp_path / "salida"
+    assert options.temp_dir == tmp_path / "tmp-build"
+    assert options.icon == tmp_path / "assets/app.ico"
+    assert options.assets == (tmp_path / "assets/app.ico",)
+    assert options.target == TargetOS.LINUX
+    assert options.architecture == "x86_64"
+    assert options.mode == BuildMode.ONEFILE
+
+
+def test_build_manifest_serializa_campos_del_build(tmp_path: Path) -> None:
+    manifest = BuildManifest(
+        project=CobraProject(
+            project_root=tmp_path,
+            entrypoint="main.co",
+            cobra_toml="cobra.toml",
+            cobra_lock="cobra.lock",
+            assets=("assets/logo.png",),
+            config={"debug": False},
+            co_packages=("pkg/app.co",),
+            documentation=("README.md",),
+        ),
+        executable_name="cobra-app",
+        icon="assets/logo.png",
+        target=TargetOS.MACOS,
+        architecture="arm64",
+        mode=BuildMode.ONEDIR,
+        temp_dir="build/tmp",
+        dist_dir="dist/macos",
+        hashes={"main.co": "sha256:abc"},
+        cobra_version="1.2.3",
+        pyinstaller_version="6.0.0",
+        dependencies=(DependencyInfo(name="pyinstaller", version="6.0.0", hashes={"wheel": "sha256:def"}),),
+    )
+
+    payload = manifest.to_dict()
+
+    assert payload["project_root"] == str(tmp_path)
+    assert payload["entrypoint"] == str(tmp_path / "main.co")
+    assert payload["cobra_toml"] == str(tmp_path / "cobra.toml")
+    assert payload["cobra_lock"] == str(tmp_path / "cobra.lock")
+    assert payload["assets"] == [str(tmp_path / "assets/logo.png")]
+    assert payload["config"] == {"debug": False}
+    assert payload["co_packages"] == [str(tmp_path / "pkg/app.co")]
+    assert payload["documentation"] == [str(tmp_path / "README.md")]
+    assert payload["executable_name"] == "cobra-app"
+    assert payload["icon"] == "assets/logo.png"
+    assert payload["target"] == "macos"
+    assert payload["architecture"] == "arm64"
+    assert payload["mode"] == "onedir"
+    assert payload["temp_dir"] == "build/tmp"
+    assert payload["dist_dir"] == "dist/macos"
+    assert payload["hashes"] == {"main.co": "sha256:abc"}
+    assert payload["cobra_version"] == "1.2.3"
+    assert payload["pyinstaller_version"] == "6.0.0"
+    assert payload["dependencies"] == [
+        {
+            "name": "pyinstaller",
+            "version": "6.0.0",
+            "source": None,
+            "path": None,
+            "hashes": {"wheel": "sha256:def"},
+        }
+    ]
+
+
+def test_create_manifest_mantiene_compatibilidad_y_agrega_campos(tmp_path: Path) -> None:
+    output_dir = tmp_path / "dist"
+    output_dir.mkdir()
+    options = BuildOptions(
+        project_root=tmp_path,
+        target=TargetOS.WINDOWS,
+        architecture="x86_64",
+        mode=BuildMode.ONEFILE,
+        temp_dir=tmp_path / "build",
+        icon="app.ico",
+        assets=("assets",),
+        config={"env": "prod"},
+        include_dependencies=False,
+    ).normalized()
+
+    manifest_path = create_manifest(options, tmp_path / "main.co", output_dir, "demo")
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert payload["name"] == "demo"
+    assert payload["executable_name"] == "demo"
+    assert payload["target"] == "windows"
+    assert payload["architecture"] == "x86_64"
+    assert payload["mode"] == "onefile"
+    assert payload["dist_dir"] == str(output_dir)
+    assert payload["include_dependencies"] is False


### PR DESCRIPTION
### Motivation

- Proveer modelos y tipos explícitos para el flujo de empaquetado del instalador Cobra y facilitar la serialización del manifiesto de build.
- Normalizar rutas y parámetros de build (entrypoint real, assets, cobra.toml/lock, config, paquetes .co, docs, target/arquitectura/modo) para evitar lógica dispersa en el runtime.

### Description

- Se añadió `CobraProject` con normalización de rutas y campos para raíz, entrypoint, `cobra.toml`, `cobra.lock`, assets, config, paquetes `.co` y documentación (archivo: `src/pcobra/cobra_installer/project.py`).
- Se amplió `BuildOptions` para incluir `target`, `architecture`, `mode`, `temp_dir`, `dist_dir`, `icon`, `assets` y `config`, y se añadió lógica de normalización reutilizable (archivo: `src/pcobra/cobra_installer/project.py`).
- Se amplió `BuildResult` con `executable_name`, `architecture`, `mode`, `temp_dir`, `dist_dir`, `hashes`, `cobra_version` y `pyinstaller_version`; el builder rellena estos campos (archivo: `src/pcobra/cobra_installer/runtime_builder.py`).
- Se introdujeron `BuildMode` (`onefile`/`onedir`) y `TargetOS` (`windows`/`linux`/`macos`) como `StrEnum` (archivo: `src/pcobra/cobra_installer/targets.py`).
- Se añadieron `DependencyInfo` y `BuildManifest` con `to_dict()` para producir manifiestos JSON reproducibles (archivo: `src/pcobra/cobra_installer/manifest.py`), y `create_manifest` ahora emite el manifiesto enriquecido manteniendo compatibilidad con campos previos como `name` e `include_dependencies`.
- Se exportaron los nuevos modelos y enums desde la API pública del paquete (`src/pcobra/cobra_installer/__init__.py`).
- Se añadieron helpers para normalizar rutas y una suite de pruebas unitarias para cubrir normalización y serialización (`tests/unit/test_cobra_installer_models.py`).

### Testing

- Se ejecutó `pytest tests/unit/test_cobra_installer_models.py` y la suite de pruebas añadida pasó: 4 tests, 1 warning, todos exitosos.
- Se verificó la sintaxis de los módulos modificados con `python -m py_compile` y compilación estática de los ficheros modificados, lo cual fue exitoso.
- Se intentó ejecutar pruebas más amplias (`pytest tests/unit/test_build_orchestrator.py tests/unit/test_cobra_packaging.py`) y esas fallaron por un error preexistente no relacionado (`NameError: INTERNAL_BACKENDS` en `src/pcobra/cobra/architecture/contracts.py`), por lo que las pruebas de packaging quedaron interrumpidas por ese problema externo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45475724e483279c9345409e656129)