### PR TITLE
Implement Cobra project discovery

### DIFF
--- a/src/pcobra/cobra_installer/__init__.py
+++ b/src/pcobra/cobra_installer/__init__.py
@@ -8,7 +8,16 @@ puente delgado de :mod:`pcobra.cobra_installer.idle_bridge`.
 from __future__ import annotations
 
 from .manifest import BuildManifest, DependencyInfo
-from .project import BuildOptions, BuildResult, CobraInstallerError, CobraProject
+from .project import (
+    BuildOptions,
+    BuildResult,
+    CobraInstallerError,
+    CobraProject,
+    ProjectResources,
+    collect_project_resources,
+    discover_project,
+    find_entrypoint,
+)
 from .targets import BuildMode, TargetOS
 from .runtime_builder import build_project, package_current_project
 
@@ -19,6 +28,10 @@ __all__ = [
     "BuildResult",
     "CobraProject",
     "CobraInstallerError",
+    "ProjectResources",
+    "collect_project_resources",
+    "discover_project",
+    "find_entrypoint",
     "DependencyInfo",
     "TargetOS",
     "build_project",

--- a/src/pcobra/cobra_installer/manifest.py
+++ b/src/pcobra/cobra_installer/manifest.py
@@ -52,6 +52,8 @@ class BuildManifest:
             "config": dict(project.config),
             "co_packages": [_stringify(path) for path in project.co_packages],
             "documentation": [_stringify(path) for path in project.documentation],
+            "config_dirs": [_stringify(path) for path in project.config_dirs],
+            "auxiliary_resources": [_stringify(path) for path in project.auxiliary_resources],
             "executable_name": self.executable_name,
             "target": _enum_value(self.target),
             "architecture": self.architecture,

--- a/src/pcobra/cobra_installer/project.py
+++ b/src/pcobra/cobra_installer/project.py
@@ -1,16 +1,45 @@
-"""Tipos compartidos para el instalador Cobra."""
+"""Tipos compartidos y detección de proyectos para el instalador Cobra."""
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Mapping, Sequence
+
+try:  # pragma: no cover - Python < 3.11 compatibility path
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    tomllib = None  # type: ignore[assignment]
 
 from .targets import BuildMode, TargetOS
 
 
 class CobraInstallerError(RuntimeError):
     """Error base para fallos controlados durante el empaquetado Cobra."""
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectResources:
+    """Recursos relevantes encontrados dentro de una raíz de proyecto Cobra."""
+
+    assets: Sequence[Path | str] = field(default_factory=tuple)
+    config_dirs: Sequence[Path | str] = field(default_factory=tuple)
+    co_packages: Sequence[Path | str] = field(default_factory=tuple)
+    documentation: Sequence[Path | str] = field(default_factory=tuple)
+    auxiliary_resources: Sequence[Path | str] = field(default_factory=tuple)
+
+    def normalized(self, project_root: Path | str) -> "ProjectResources":
+        """Devuelve una copia con rutas absolutas resueltas desde la raíz."""
+
+        root = Path(project_root).expanduser().resolve()
+        return ProjectResources(
+            assets=tuple(_normalize_path(path, root) for path in self.assets),
+            config_dirs=tuple(_normalize_path(path, root) for path in self.config_dirs),
+            co_packages=tuple(_normalize_path(path, root) for path in self.co_packages),
+            documentation=tuple(_normalize_path(path, root) for path in self.documentation),
+            auxiliary_resources=tuple(_normalize_path(path, root) for path in self.auxiliary_resources),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,6 +54,8 @@ class CobraProject:
     config: Mapping[str, object] = field(default_factory=dict)
     co_packages: Sequence[Path | str] = field(default_factory=tuple)
     documentation: Sequence[Path | str] = field(default_factory=tuple)
+    config_dirs: Sequence[Path | str] = field(default_factory=tuple)
+    auxiliary_resources: Sequence[Path | str] = field(default_factory=tuple)
 
     def normalized(self) -> "CobraProject":
         """Devuelve una copia con rutas absolutas resueltas desde la raíz."""
@@ -39,6 +70,8 @@ class CobraProject:
             config=dict(self.config),
             co_packages=tuple(_normalize_path(path, root) for path in self.co_packages),
             documentation=tuple(_normalize_path(path, root) for path in self.documentation),
+            config_dirs=tuple(_normalize_path(path, root) for path in self.config_dirs),
+            auxiliary_resources=tuple(_normalize_path(path, root) for path in self.auxiliary_resources),
         )
 
 
@@ -109,6 +142,151 @@ class BuildResult:
     logs: tuple[str, ...] = ()
 
 
+def discover_project(path: Path) -> CobraProject:
+    """Detecta y normaliza un proyecto Cobra a partir de un archivo o directorio."""
+
+    root = _discover_project_root(path)
+    resources = collect_project_resources(root)
+    entrypoint = find_entrypoint(root)
+    config = _read_cobra_toml(root / "cobra.toml")
+    return CobraProject(
+        project_root=root,
+        entrypoint=entrypoint,
+        cobra_toml=root / "cobra.toml" if (root / "cobra.toml").is_file() else None,
+        cobra_lock=root / "cobra.lock" if (root / "cobra.lock").is_file() else None,
+        assets=resources.assets,
+        config=config,
+        co_packages=resources.co_packages,
+        documentation=resources.documentation,
+        config_dirs=resources.config_dirs,
+        auxiliary_resources=resources.auxiliary_resources,
+    ).normalized()
+
+
+def find_entrypoint(project_root: Path) -> Path:
+    """Resuelve el entrypoint del proyecto priorizando ``main.cobra``."""
+
+    root = Path(project_root).expanduser().resolve()
+    main_cobra = root / "main.cobra"
+    if main_cobra.is_file():
+        return main_cobra
+
+    configured = _configured_entrypoints(root)
+    if len(configured) == 1:
+        return configured[0]
+    if len(configured) > 1:
+        formatted = ", ".join(str(path) for path in configured)
+        raise CobraInstallerError(
+            "No se pudo determinar un entrypoint único: cobra.toml contiene "
+            f"varias rutas candidatas ({formatted}). Define solo una o crea main.cobra."
+        )
+
+    candidates = sorted(root.glob("*.cobra"))
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1:
+        formatted = ", ".join(path.name for path in candidates)
+        raise CobraInstallerError(
+            "No se pudo determinar el entrypoint Cobra: no existe main.cobra y hay "
+            f"varios archivos .cobra en la raíz ({formatted}). Configura el entrypoint en cobra.toml."
+        )
+
+    raise CobraInstallerError(
+        f"No se encontró entrypoint Cobra en {root}. Crea main.cobra o configura el entrypoint en cobra.toml."
+    )
+
+
+def collect_project_resources(project_root: Path) -> ProjectResources:
+    """Recolecta recursos Cobra empaquetables bajo la raíz del proyecto."""
+
+    root = Path(project_root).expanduser().resolve()
+    if not root.is_dir():
+        raise CobraInstallerError(f"La raíz del proyecto no existe o no es un directorio: {root}")
+
+    assets: list[Path] = []
+    config_dirs: list[Path] = []
+    co_packages: list[Path] = []
+    documentation: list[Path] = []
+    auxiliary: list[Path] = []
+
+    for current_raw, dirs, files in os.walk(root):
+        current = Path(current_raw)
+        dirs[:] = [dirname for dirname in dirs if dirname not in _IGNORED_DIRS]
+        if current.name == "assets":
+            assets.append(current)
+        if current.name == "config":
+            config_dirs.append(current)
+        for filename in files:
+            path = current / filename
+            suffix = path.suffix.lower()
+            if suffix == ".co":
+                co_packages.append(path)
+            elif suffix in _DOCUMENTATION_SUFFIXES:
+                documentation.append(path)
+            elif path.name in _AUXILIARY_FILE_NAMES or suffix in _AUXILIARY_SUFFIXES:
+                auxiliary.append(path)
+
+    return ProjectResources(
+        assets=tuple(sorted(assets)),
+        config_dirs=tuple(sorted(config_dirs)),
+        co_packages=tuple(sorted(co_packages)),
+        documentation=tuple(sorted(documentation)),
+        auxiliary_resources=tuple(sorted(auxiliary)),
+    ).normalized(root)
+
+
+def _discover_project_root(path: Path) -> Path:
+    candidate = Path(path).expanduser().resolve()
+    start = candidate.parent if candidate.is_file() else candidate
+    if not start.exists():
+        raise CobraInstallerError(f"La ruta del proyecto no existe: {candidate}")
+
+    for current in (start, *start.parents):
+        if (current / "main.cobra").is_file() or (current / "cobra.toml").is_file() or (current / "cobra.lock").is_file():
+            return current
+    return start
+
+
+def _configured_entrypoints(root: Path) -> list[Path]:
+    config = _read_cobra_toml(root / "cobra.toml")
+    raw_values = _find_entrypoint_values(config)
+    resolved: list[Path] = []
+    seen: set[Path] = set()
+    for value in raw_values:
+        path = _normalize_path(value, root)
+        if path in seen:
+            continue
+        seen.add(path)
+        if not path.is_file():
+            raise CobraInstallerError(f"El entrypoint configurado en cobra.toml no existe: {path}")
+        resolved.append(path)
+    return resolved
+
+
+def _read_cobra_toml(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        return {}
+    if tomllib is None:
+        raise CobraInstallerError("No se puede leer cobra.toml: tomllib no está disponible en esta versión de Python.")
+    try:
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:  # type: ignore[union-attr]
+        raise CobraInstallerError(f"cobra.toml no es válido: {exc}") from exc
+
+
+def _find_entrypoint_values(config: Mapping[str, object]) -> list[str]:
+    values: list[str] = []
+    for key in ("entrypoint", "main", "source", "script"):
+        value = config.get(key)
+        if isinstance(value, str):
+            values.append(value)
+    for section_name in ("project", "package", "build", "app", "cobra"):
+        section = config.get(section_name)
+        if isinstance(section, Mapping):
+            values.extend(_find_entrypoint_values(section))
+    return values
+
+
 def _normalize_optional_path(path: Path | str | None, root: Path) -> Path | None:
     if path is None:
         return None
@@ -120,3 +298,22 @@ def _normalize_path(path: Path | str, root: Path) -> Path:
     if not raw_path.is_absolute():
         raw_path = root / raw_path
     return raw_path.resolve()
+
+
+_IGNORED_DIRS = {
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+}
+_DOCUMENTATION_SUFFIXES = {".md", ".rst", ".txt"}
+_AUXILIARY_SUFFIXES = {".json", ".yaml", ".yml", ".ini", ".cfg", ".env", ".ico", ".png", ".jpg", ".jpeg", ".svg"}
+_AUXILIARY_FILE_NAMES = {"cobra.toml", "cobra.lock", "pyproject.toml", "requirements.txt", "LICENSE", "NOTICE"}

--- a/tests/unit/test_cobra_installer_models.py
+++ b/tests/unit/test_cobra_installer_models.py
@@ -21,6 +21,8 @@ def test_cobra_project_normaliza_recursos_desde_raiz(tmp_path: Path) -> None:
         assets=("assets/logo.png",),
         co_packages=("paquetes/ui.co",),
         documentation=("docs/manual.md",),
+        config_dirs=("config",),
+        auxiliary_resources=("assets/logo.png",),
         config={"profile": "release"},
     ).normalized()
 
@@ -30,6 +32,8 @@ def test_cobra_project_normaliza_recursos_desde_raiz(tmp_path: Path) -> None:
     assert project.assets == (tmp_path / "assets/logo.png",)
     assert project.co_packages == (tmp_path / "paquetes/ui.co",)
     assert project.documentation == (tmp_path / "docs/manual.md",)
+    assert project.config_dirs == (tmp_path / "config",)
+    assert project.auxiliary_resources == (tmp_path / "assets/logo.png",)
     assert project.config == {"profile": "release"}
 
 
@@ -68,6 +72,8 @@ def test_build_manifest_serializa_campos_del_build(tmp_path: Path) -> None:
             config={"debug": False},
             co_packages=("pkg/app.co",),
             documentation=("README.md",),
+            config_dirs=("config",),
+            auxiliary_resources=("assets/logo.png",),
         ),
         executable_name="cobra-app",
         icon="assets/logo.png",
@@ -92,6 +98,8 @@ def test_build_manifest_serializa_campos_del_build(tmp_path: Path) -> None:
     assert payload["config"] == {"debug": False}
     assert payload["co_packages"] == [str(tmp_path / "pkg/app.co")]
     assert payload["documentation"] == [str(tmp_path / "README.md")]
+    assert payload["config_dirs"] == [str(tmp_path / "config")]
+    assert payload["auxiliary_resources"] == [str(tmp_path / "assets" / "logo.png")]
     assert payload["executable_name"] == "cobra-app"
     assert payload["icon"] == "assets/logo.png"
     assert payload["target"] == "macos"
@@ -138,3 +146,71 @@ def test_create_manifest_mantiene_compatibilidad_y_agrega_campos(tmp_path: Path)
     assert payload["mode"] == "onefile"
     assert payload["dist_dir"] == str(output_dir)
     assert payload["include_dependencies"] is False
+
+
+def test_discover_project_prefiere_main_cobra_y_recolecta_recursos(tmp_path: Path) -> None:
+    from pcobra.cobra_installer import discover_project
+
+    (tmp_path / "main.cobra").write_text("imprimir('hola')\n", encoding="utf-8")
+    (tmp_path / "cobra.toml").write_text('[project]\nentrypoint = "otro.cobra"\n', encoding="utf-8")
+    (tmp_path / "cobra.lock").write_text("# lock\n", encoding="utf-8")
+    (tmp_path / "assets").mkdir()
+    (tmp_path / "assets" / "logo.png").write_bytes(b"png")
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "app.yaml").write_text("debug: false\n", encoding="utf-8")
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "ui.co").write_text("paquete ui\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("# Demo\n", encoding="utf-8")
+
+    project = discover_project(tmp_path)
+
+    assert project.project_root == tmp_path.resolve()
+    assert project.entrypoint == tmp_path / "main.cobra"
+    assert project.cobra_toml == tmp_path / "cobra.toml"
+    assert project.cobra_lock == tmp_path / "cobra.lock"
+    assert project.assets == (tmp_path / "assets",)
+    assert project.config_dirs == (tmp_path / "config",)
+    assert project.co_packages == (tmp_path / "pkg" / "ui.co",)
+    assert project.documentation == (tmp_path / "README.md",)
+    assert tmp_path / "assets" / "logo.png" in project.auxiliary_resources
+    assert tmp_path / "config" / "app.yaml" in project.auxiliary_resources
+
+
+def test_find_entrypoint_usa_cobra_toml_si_no_hay_main(tmp_path: Path) -> None:
+    from pcobra.cobra_installer import find_entrypoint
+
+    src = tmp_path / "src"
+    src.mkdir()
+    entrypoint = src / "app.cobra"
+    entrypoint.write_text("imprimir('app')\n", encoding="utf-8")
+    (tmp_path / "cobra.toml").write_text('[build]\nentrypoint = "src/app.cobra"\n', encoding="utf-8")
+
+    assert find_entrypoint(tmp_path) == entrypoint
+
+
+def test_find_entrypoint_error_claro_si_hay_ambiguedad(tmp_path: Path) -> None:
+    import pytest
+
+    from pcobra.cobra_installer import CobraInstallerError, find_entrypoint
+
+    (tmp_path / "uno.cobra").write_text("", encoding="utf-8")
+    (tmp_path / "dos.cobra").write_text("", encoding="utf-8")
+
+    with pytest.raises(CobraInstallerError, match="varios archivos .cobra"):
+        find_entrypoint(tmp_path)
+
+
+def test_collect_project_resources_ignora_build_y_dist(tmp_path: Path) -> None:
+    from pcobra.cobra_installer import collect_project_resources
+
+    (tmp_path / "assets").mkdir()
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "omitido.co").write_text("", encoding="utf-8")
+    (tmp_path / "mod.co").write_text("", encoding="utf-8")
+    (tmp_path / "manual.rst").write_text("Manual\n", encoding="utf-8")
+
+    resources = collect_project_resources(tmp_path)
+
+    assert resources.assets == (tmp_path / "assets",)
+    assert resources.co_packages == (tmp_path / "mod.co",)
+    assert resources.documentation == (tmp_path / "manual.rst",)


### PR DESCRIPTION
### Motivation

- Añadir detección automática de la raíz, entrypoint y recursos de un proyecto Cobra para soportar el empaquetado/instalador fuera del IDLE. 
- Priorizar `main.cobra` como entrypoint y permitir configuración desde `cobra.toml`, devolviendo errores claros en caso de ambigüedad.

### Description

- Se añadió el dataclass `ProjectResources` para agrupar `assets`, `config_dirs`, `co_packages`, `documentation` y `auxiliary_resources` y su normalización a rutas absolutas. 
- Se implementaron las funciones `discover_project(path: Path) -> CobraProject`, `find_entrypoint(project_root: Path) -> Path` y `collect_project_resources(project_root: Path) -> ProjectResources`, incluyendo detección de raíz, recorrido seguro del árbol (`os.walk`) e identificación de recursos relevantes. 
- Se extendió `CobraProject` para incluir `config_dirs` y `auxiliary_resources`, y se añadió lectura tolerante de `cobra.toml` (usa `tomllib` cuando está disponible) y resolución de entrypoint desde claves comunes (`entrypoint`, `main`, `source`, `script`) dentro de secciones habituales. 
- Se exportaron `ProjectResources`, `collect_project_resources`, `discover_project` y `find_entrypoint` en la API pública de `pcobra.cobra_installer` y se añadió la serialización de `config_dirs` y `auxiliary_resources` en el manifiesto de build.
- Compatibilidad: se evitó `Path.walk()` y se usa `os.walk()` para mantener compatibilidad con Python >=3.11.

### Testing

- Ejecutado `python -m pytest tests/unit/test_cobra_installer_models.py`, todas las pruebas unitarias pasaron (`8 passed, 1 warning`).
- Ejecutado `python -m ruff check src/pcobra/cobra_installer/project.py src/pcobra/cobra_installer/manifest.py src/pcobra/cobra_installer/__init__.py tests/unit/test_cobra_installer_models.py`, sin errores (`All checks passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a454a8179bc832793bff3b6ac1aadaa)