### PR TITLE
Implementar resolución de dependencias del instalador Cobra

### DIFF
--- a/src/pcobra/cobra_installer/dependency_resolver.py
+++ b/src/pcobra/cobra_installer/dependency_resolver.py
@@ -1,9 +1,388 @@
-"""Módulo inicial del instalador Cobra.
+"""Resolución de dependencias Cobra para proyectos instalables.
 
-Este archivo reserva una responsabilidad concreta del flujo de construcción para
-mantener la lógica fuera del IDLE a medida que el instalador evolucione.
+Este módulo lee ``cobra.toml`` y ``cobra.lock``, detecta imports Cobra usados por
+el proyecto y coordina la localización/descarga de paquetes vía CobraHub sin
+reinventar el formato ``.co`` ni la caché existente bajo ``pcobra.cobra``.
 """
 
 from __future__ import annotations
 
-__all__: list[str] = []
+import json
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from pcobra.cobra.packaging import normalizar_nombre_paquete, validar_version_paquete
+from pcobra.cobra_installer.hub_resolver import (
+    CobraHubResolution,
+    CobraHubResolver,
+    CobraInstallerError,
+)
+
+__all__ = [
+    "CobraDependencyError",
+    "DeclaredDependency",
+    "LockedDependency",
+    "DependencyResolutionResult",
+    "detect_cobra_imports",
+    "read_declared_dependencies",
+    "read_lockfile",
+    "resolve_project_dependencies",
+    "write_lockfile",
+]
+
+
+class CobraDependencyError(CobraInstallerError):
+    """Error controlado de dependencias apto para CLI e IDLE."""
+
+
+@dataclass(frozen=True)
+class DeclaredDependency:
+    """Dependencia declarada por el usuario en ``cobra.toml``."""
+
+    name: str
+    version: str
+
+
+@dataclass(frozen=True)
+class LockedDependency:
+    """Entrada normalizada procedente de ``cobra.lock``."""
+
+    name: str
+    version: str
+    sha256: str | None = None
+    source: str | None = None
+
+
+@dataclass(frozen=True)
+class DependencyResolutionResult:
+    """Resultado de resolver todas las dependencias de un proyecto."""
+
+    declared: dict[str, DeclaredDependency]
+    used_imports: set[str]
+    resolved: dict[str, CobraHubResolution]
+    lockfile_path: Path
+    lockfile_created: bool = False
+    conflicts: tuple[str, ...] = ()
+    missing_declarations: tuple[str, ...] = ()
+
+
+_IMPORT_RE = re.compile(
+    r"^\s*(?:usar\s+(?P<usar>\"[^\"]+\"|'[^']+'|[A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)+)|import\s+(?P<import>\"[^\"]+\"|'[^']+'))",
+    re.MULTILINE,
+)
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+_LOCK_VERSION = 1
+_IGNORED_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+}
+
+
+def resolve_project_dependencies(
+    project_root: str | Path,
+    *,
+    resolver: CobraHubResolver | None = None,
+    fail_on_unused_declared: bool = False,
+) -> DependencyResolutionResult:
+    """Resuelve y valida las dependencias Cobra de ``project_root``.
+
+    Valida que los imports usados estén declarados, que las versiones declaradas
+    coincidan con el lockfile cuando existe, que no haya conflictos transitivos y
+    que los hashes de los artefactos coincidan con ``cobra.lock``. Si no existe
+    lockfile, lo genera con las descargas/localizaciones resueltas.
+    """
+
+    root = Path(project_root).resolve()
+    declared = read_declared_dependencies(root / "cobra.toml")
+    used_imports = detect_cobra_imports(root)
+    missing = tuple(sorted(used_imports - set(declared)))
+    if missing:
+        raise CobraDependencyError(
+            "Dependencias Cobra no declaradas en cobra.toml: " + ", ".join(missing)
+        )
+
+    if fail_on_unused_declared:
+        unused = tuple(sorted(set(declared) - used_imports))
+        if unused:
+            raise CobraDependencyError(
+                "Dependencias Cobra declaradas pero no usadas: " + ", ".join(unused)
+            )
+
+    lock_path = root / "cobra.lock"
+    locked = read_lockfile(lock_path) if lock_path.exists() else {}
+    _validate_declared_against_lock(declared, locked)
+
+    hub = resolver or CobraHubResolver()
+    resolved: dict[str, CobraHubResolution] = {}
+    requested_versions = {name: dep.version for name, dep in declared.items()}
+
+    for name, dep in sorted(declared.items()):
+        lock_entry = locked.get(name)
+        resolution = hub.resolve(
+            name,
+            dep.version,
+            expected_sha256=lock_entry.sha256 if lock_entry else None,
+            source=lock_entry.source if lock_entry else None,
+        )
+        if resolution.version != dep.version:
+            raise CobraDependencyError(
+                f"Conflicto de versión para {name}: cobra.toml pide {dep.version}, "
+                f"pero CobraHub resolvió {resolution.version}."
+            )
+        resolved[name] = resolution
+
+        for transitive_name, transitive_version in resolution.dependencies.items():
+            if (
+                transitive_name in requested_versions
+                and requested_versions[transitive_name] != transitive_version
+            ):
+                raise CobraDependencyError(
+                    f"Conflicto de versiones: {name} requiere {transitive_name}=={transitive_version}, "
+                    f"pero el proyecto declara {transitive_name}=={requested_versions[transitive_name]}."
+                )
+
+    created = False
+    if not lock_path.exists():
+        write_lockfile(lock_path, resolved)
+        created = True
+
+    return DependencyResolutionResult(
+        declared=declared,
+        used_imports=used_imports,
+        resolved=resolved,
+        lockfile_path=lock_path,
+        lockfile_created=created,
+        missing_declarations=missing,
+    )
+
+
+def read_declared_dependencies(path: str | Path) -> dict[str, DeclaredDependency]:
+    """Lee dependencias Cobra declaradas en ``cobra.toml``.
+
+    Formatos soportados:
+    - ``[dependencies] paquete = "1.2.3"``
+    - ``[cobra.dependencies] paquete = "1.2.3"``
+    - ``[project] dependencies = ["paquete==1.2.3"]``
+    """
+
+    toml_path = Path(path)
+    if not toml_path.exists():
+        return {}
+    try:
+        data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise CobraDependencyError(f"No se pudo leer cobra.toml: {exc}") from exc
+
+    raw: dict[str, Any] = {}
+    for key_path in (("dependencies",), ("cobra", "dependencies")):
+        section = _get_mapping(data, key_path)
+        if section:
+            raw.update(section)
+    project_deps = _get_mapping(data, ("project",)).get("dependencies")
+    if isinstance(project_deps, list):
+        raw.update(_parse_dependency_list(project_deps))
+
+    declared: dict[str, DeclaredDependency] = {}
+    for raw_name, raw_version in raw.items():
+        name = _normalize_dependency_name(str(raw_name))
+        version = _normalize_version_spec(raw_version, name)
+        if name in declared and declared[name].version != version:
+            raise CobraDependencyError(
+                f"Conflicto de versiones declaradas para {name}: {declared[name].version} y {version}."
+            )
+        declared[name] = DeclaredDependency(name=name, version=version)
+    return declared
+
+
+def read_lockfile(path: str | Path) -> dict[str, LockedDependency]:
+    """Lee versiones y hashes desde ``cobra.lock`` JSON o TOML."""
+
+    lock_path = Path(path)
+    try:
+        text = lock_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CobraDependencyError(f"No se pudo leer cobra.lock: {exc}") from exc
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        try:
+            data = tomllib.loads(text)
+        except tomllib.TOMLDecodeError as exc:
+            raise CobraDependencyError(
+                f"cobra.lock no es JSON ni TOML válido: {exc}"
+            ) from exc
+
+    packages = data.get("packages") if isinstance(data, Mapping) else None
+    entries: Sequence[Any]
+    if isinstance(packages, list):
+        entries = packages
+    elif isinstance(packages, Mapping):
+        entries = [
+            (
+                {"name": name, **value}
+                if isinstance(value, Mapping)
+                else {"name": name, "version": value}
+            )
+            for name, value in packages.items()
+        ]
+    elif isinstance(data, list):
+        entries = data
+    else:
+        entries = []
+
+    locked: dict[str, LockedDependency] = {}
+    for entry in entries:
+        if (
+            not isinstance(entry, Mapping)
+            or "name" not in entry
+            or "version" not in entry
+        ):
+            raise CobraDependencyError(
+                "cobra.lock contiene una entrada de paquete inválida."
+            )
+        name = _normalize_dependency_name(str(entry["name"]))
+        version = validar_version_paquete(str(entry["version"]))
+        sha256 = entry.get("sha256") or entry.get("checksum") or entry.get("hash")
+        if isinstance(sha256, str):
+            sha256 = sha256.removeprefix("sha256:")
+            if not _SHA256_RE.fullmatch(sha256):
+                raise CobraDependencyError(
+                    f"Hash SHA-256 inválido en cobra.lock para {name}."
+                )
+        else:
+            sha256 = None
+        source = entry.get("source")
+        locked[name] = LockedDependency(
+            name=name,
+            version=version,
+            sha256=sha256,
+            source=str(source) if source else None,
+        )
+    return locked
+
+
+def write_lockfile(
+    path: str | Path, resolved: Mapping[str, CobraHubResolution]
+) -> None:
+    """Genera ``cobra.lock`` estable cuando no existe."""
+
+    lock_path = Path(path)
+    payload = {
+        "version": _LOCK_VERSION,
+        "packages": [
+            {
+                "name": item.name,
+                "version": item.version,
+                "sha256": item.sha256,
+                "source": item.source,
+            }
+            for item in sorted(resolved.values(), key=lambda value: value.name)
+        ],
+    }
+    lock_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def detect_cobra_imports(project_root: str | Path) -> set[str]:
+    """Detecta estáticamente imports Cobra usados por archivos ``.cobra``/``.co``."""
+
+    root = Path(project_root)
+    imports: set[str] = set()
+    for file in _iter_cobra_sources(root):
+        try:
+            text = file.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for match in _IMPORT_RE.finditer(text):
+            raw = match.group("usar") or match.group("import") or ""
+            module = raw.strip().strip("\"'")
+            if _is_local_import(module):
+                continue
+            package = module.split(".", 1)[0]
+            imports.add(_normalize_dependency_name(package))
+    return imports
+
+
+def _iter_cobra_sources(root: Path):
+    for path in root.rglob("*"):
+        if any(part in _IGNORED_DIRS for part in path.relative_to(root).parts):
+            continue
+        if path.is_file() and path.suffix in {".cobra", ".co"}:
+            yield path
+
+
+def _is_local_import(module: str) -> bool:
+    return (
+        module.startswith((".", "/"))
+        or module.endswith((".cobra", ".co"))
+        or "/" in module
+        or "\\" in module
+    )
+
+
+def _normalize_dependency_name(name: str) -> str:
+    try:
+        return normalizar_nombre_paquete(name)
+    except ValueError as exc:
+        raise CobraDependencyError(
+            f"Nombre de dependencia Cobra inválido: {name}"
+        ) from exc
+
+
+def _normalize_version_spec(value: Any, name: str) -> str:
+    if isinstance(value, Mapping):
+        value = value.get("version")
+    if not isinstance(value, str):
+        raise CobraDependencyError(
+            f"Versión inválida para {name}: debe ser una cadena SemVer exacta."
+        )
+    version = value.strip()
+    if version.startswith("=="):
+        version = version[2:].strip()
+    try:
+        return validar_version_paquete(version)
+    except ValueError as exc:
+        raise CobraDependencyError(
+            f"Versión inválida para {name}: use SemVer exacto MAJOR.MINOR.PATCH."
+        ) from exc
+
+
+def _parse_dependency_list(values: Sequence[Any]) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for value in values:
+        if not isinstance(value, str) or "==" not in value:
+            continue
+        name, version = value.split("==", 1)
+        parsed[name.strip()] = version.strip()
+    return parsed
+
+
+def _get_mapping(data: Mapping[str, Any], key_path: Sequence[str]) -> Mapping[str, Any]:
+    current: Any = data
+    for key in key_path:
+        if not isinstance(current, Mapping):
+            return {}
+        current = current.get(key, {})
+    return current if isinstance(current, Mapping) else {}
+
+
+def _validate_declared_against_lock(
+    declared: Mapping[str, DeclaredDependency], locked: Mapping[str, LockedDependency]
+) -> None:
+    for name, dep in declared.items():
+        lock = locked.get(name)
+        if lock and lock.version != dep.version:
+            raise CobraDependencyError(
+                f"Conflicto de versión para {name}: cobra.toml declara {dep.version}, "
+                f"pero cobra.lock fija {lock.version}."
+            )

--- a/src/pcobra/cobra_installer/hub_resolver.py
+++ b/src/pcobra/cobra_installer/hub_resolver.py
@@ -1,9 +1,200 @@
-"""Módulo inicial del instalador Cobra.
+"""Localización de paquetes CobraHub para el instalador Cobra.
 
-Este archivo reserva una responsabilidad concreta del flujo de construcción para
-mantener la lógica fuera del IDLE a medida que el instalador evolucione.
+Reutiliza ``pcobra.cobra.hub.repository`` y ``pcobra.cobra.packaging`` para
+buscar en caché, descargar, inspeccionar y validar artefactos ``.co``.
 """
 
 from __future__ import annotations
 
-__all__: list[str] = []
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pcobra.cobra.hub.repository import PackageRepository, package_cache_dir
+from pcobra.cobra.packaging import (
+    es_paquete_cobra,
+    inspeccionar_paquete,
+    normalizar_nombre_paquete,
+    validar_paquete,
+    validar_version_paquete,
+)
+
+__all__ = ["CobraInstallerError", "CobraHubResolution", "CobraHubResolver"]
+
+
+class CobraInstallerError(RuntimeError):
+    """Excepción controlada con mensaje claro para CLI e IDLE."""
+
+
+@dataclass(frozen=True)
+class CobraHubResolution:
+    """Paquete Cobra localizado y validado."""
+
+    name: str
+    version: str
+    path: Path
+    sha256: str
+    source: str
+    dependencies: dict[str, str] = field(default_factory=dict)
+
+
+class CobraHubResolver:
+    """Resuelve paquetes desde caché local, ruta explícita o repositorio CobraHub."""
+
+    def __init__(
+        self,
+        repository: PackageRepository | None = None,
+        *,
+        cache_dir: str | Path | None = None,
+    ) -> None:
+        self.repository = repository
+        self.cache_dir = (
+            Path(cache_dir).expanduser() if cache_dir else package_cache_dir()
+        )
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def resolve(
+        self,
+        name: str,
+        version: str,
+        *,
+        expected_sha256: str | None = None,
+        source: str | None = None,
+    ) -> CobraHubResolution:
+        """Localiza/descarga ``name`` y valida versión, formato e integridad."""
+
+        normalized_name = self._name(name)
+        normalized_version = self._version(version, normalized_name)
+        if expected_sha256:
+            expected_sha256 = expected_sha256.removeprefix("sha256:").lower()
+
+        candidates: list[Path] = []
+        if source:
+            source_path = Path(source).expanduser()
+            if source_path.exists():
+                candidates.append(source_path)
+        candidates.extend(self._cache_candidates(normalized_name, normalized_version))
+
+        for candidate in candidates:
+            if candidate.is_file():
+                return self._inspect_candidate(
+                    candidate,
+                    normalized_name,
+                    normalized_version,
+                    expected_sha256=expected_sha256,
+                    source=(
+                        "cache"
+                        if candidate.parent == self.cache_dir
+                        else str(candidate)
+                    ),
+                )
+
+        if self.repository is None:
+            raise CobraInstallerError(
+                f"Dependencia Cobra no encontrada en caché: {normalized_name}=={normalized_version}. "
+                "Configure CobraHub o precargue el paquete en la caché local."
+            )
+
+        try:
+            downloaded = self.repository.download(normalized_name, normalized_version)
+        except Exception as exc:  # noqa: BLE001 - se traduce a error controlado
+            raise CobraInstallerError(
+                f"No se pudo descargar {normalized_name}=={normalized_version} desde CobraHub: {exc}"
+            ) from exc
+        return self._inspect_candidate(
+            downloaded.path,
+            normalized_name,
+            normalized_version,
+            expected_sha256=expected_sha256 or downloaded.checksum,
+            source="cobrahub",
+        )
+
+    def _cache_candidates(self, name: str, version: str) -> list[Path]:
+        return [
+            self.cache_dir / f"{name}-{version}.co",
+            self.cache_dir / f"{name}.co",
+        ]
+
+    def _inspect_candidate(
+        self,
+        path: Path,
+        name: str,
+        version: str,
+        *,
+        expected_sha256: str | None,
+        source: str,
+    ) -> CobraHubResolution:
+        try:
+            if not es_paquete_cobra(path):
+                raise ValueError("el artefacto no es un paquete Cobra .co válido")
+            validation = validar_paquete(path)
+            inspection = inspeccionar_paquete(path)
+        except Exception as exc:  # noqa: BLE001 - se traduce a error controlado
+            raise CobraInstallerError(
+                f"Paquete Cobra inválido para {name}: {exc}"
+            ) from exc
+
+        manifest = validation.manifest
+        package_name = self._name(str(manifest.get("name", "")))
+        package_version = self._version(str(manifest.get("version", "")), package_name)
+        if package_name != name:
+            raise CobraInstallerError(
+                f"Paquete incorrecto: se esperaba {name}, pero el artefacto declara {package_name}."
+            )
+        if package_version != version:
+            raise CobraInstallerError(
+                f"Versión incorrecta para {name}: se esperaba {version}, pero el artefacto declara {package_version}."
+            )
+
+        digest = inspection.checksum or self._sha256_file(path)
+        if expected_sha256 and digest.lower() != expected_sha256.lower():
+            raise CobraInstallerError(
+                f"Hash inválido para {name}=={version}: se esperaba {expected_sha256}, se obtuvo {digest}."
+            )
+
+        raw_deps = manifest.get("dependencies") or {}
+        dependencies = (
+            {
+                self._name(str(dep_name)): self._version(
+                    str(dep_version), str(dep_name)
+                )
+                for dep_name, dep_version in raw_deps.items()
+            }
+            if isinstance(raw_deps, dict)
+            else {}
+        )
+        return CobraHubResolution(
+            name=package_name,
+            version=package_version,
+            path=Path(path),
+            sha256=digest,
+            source=source,
+            dependencies=dependencies,
+        )
+
+    @staticmethod
+    def _sha256_file(path: Path) -> str:
+        sha = hashlib.sha256()
+        with path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                sha.update(chunk)
+        return sha.hexdigest()
+
+    @staticmethod
+    def _name(name: str) -> str:
+        try:
+            return normalizar_nombre_paquete(name)
+        except ValueError as exc:
+            raise CobraInstallerError(
+                f"Nombre de paquete Cobra inválido: {name}"
+            ) from exc
+
+    @staticmethod
+    def _version(version: str, name: str) -> str:
+        try:
+            return validar_version_paquete(version)
+        except ValueError as exc:
+            raise CobraInstallerError(
+                f"Versión inválida para {name}: {version}"
+            ) from exc

--- a/tests/unit/test_cobra_installer_dependency_resolver.py
+++ b/tests/unit/test_cobra_installer_dependency_resolver.py
@@ -1,0 +1,130 @@
+import json
+
+import pytest
+
+from pcobra.cobra.packaging import construir_paquete
+from pcobra.cobra_installer.dependency_resolver import (
+    CobraDependencyError,
+    detect_cobra_imports,
+    read_declared_dependencies,
+    resolve_project_dependencies,
+)
+from pcobra.cobra_installer.hub_resolver import CobraHubResolver, CobraInstallerError
+
+
+def _package(tmp_path, name="dep", version="1.2.3", dependencies=None):
+    root = tmp_path / f"pkg-{name}"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "main.cobra").write_text("var x = 1\n", encoding="utf-8")
+    manifest = {
+        "format": "cobra-package-v1",
+        "name": name,
+        "version": version,
+        "files": [],
+        "checksums": {},
+    }
+    if dependencies:
+        manifest["dependencies"] = dependencies
+    (root / "cobra.pkg.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return construir_paquete(root)
+
+
+def test_detecta_imports_cobra_estaticos(tmp_path):
+    (tmp_path / "main.cobra").write_text(
+        'usar dep.modulo\nimport "otra.sub"\nusar "./local.cobra"\n',
+        encoding="utf-8",
+    )
+
+    assert detect_cobra_imports(tmp_path) == {"dep", "otra"}
+
+
+def test_lee_dependencias_de_cobra_toml(tmp_path):
+    (tmp_path / "cobra.toml").write_text(
+        '[dependencies]\nDep = "1.2.3"\n[project]\ndependencies = ["otra==2.0.0"]\n',
+        encoding="utf-8",
+    )
+
+    deps = read_declared_dependencies(tmp_path / "cobra.toml")
+
+    assert deps["dep"].version == "1.2.3"
+    assert deps["otra"].version == "2.0.0"
+
+
+def test_resuelve_desde_cache_y_genera_lock(tmp_path):
+    package = _package(tmp_path, name="dep", version="1.2.3")
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    cached = cache / "dep-1.2.3.co"
+    cached.write_bytes(package.read_bytes())
+    (tmp_path / "cobra.toml").write_text(
+        '[dependencies]\ndep = "1.2.3"\n', encoding="utf-8"
+    )
+    (tmp_path / "main.cobra").write_text("usar dep.modulo\n", encoding="utf-8")
+
+    result = resolve_project_dependencies(
+        tmp_path, resolver=CobraHubResolver(cache_dir=cache)
+    )
+
+    assert result.lockfile_created is True
+    assert result.resolved["dep"].path == cached
+    lock = json.loads((tmp_path / "cobra.lock").read_text(encoding="utf-8"))
+    assert lock["packages"][0]["name"] == "dep"
+    assert lock["packages"][0]["version"] == "1.2.3"
+    assert len(lock["packages"][0]["sha256"]) == 64
+
+
+def test_falla_si_import_no_esta_declarado(tmp_path):
+    (tmp_path / "cobra.toml").write_text("", encoding="utf-8")
+    (tmp_path / "main.cobra").write_text("usar dep.modulo\n", encoding="utf-8")
+
+    with pytest.raises(CobraDependencyError, match="no declaradas"):
+        resolve_project_dependencies(
+            tmp_path, resolver=CobraHubResolver(cache_dir=tmp_path / "cache")
+        )
+
+
+def test_falla_hash_de_lock(tmp_path):
+    package = _package(tmp_path, name="dep", version="1.2.3")
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    (cache / "dep-1.2.3.co").write_bytes(package.read_bytes())
+    (tmp_path / "cobra.toml").write_text(
+        '[dependencies]\ndep = "1.2.3"\n', encoding="utf-8"
+    )
+    (tmp_path / "main.cobra").write_text("usar dep.modulo\n", encoding="utf-8")
+    (tmp_path / "cobra.lock").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "packages": [{"name": "dep", "version": "1.2.3", "sha256": "0" * 64}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CobraInstallerError, match="Hash inválido"):
+        resolve_project_dependencies(
+            tmp_path, resolver=CobraHubResolver(cache_dir=cache)
+        )
+
+
+def test_detecta_conflicto_transitivo(tmp_path):
+    package = _package(
+        tmp_path, name="dep", version="1.2.3", dependencies={"otra": "2.0.0"}
+    )
+    package2 = _package(tmp_path, name="otra", version="1.0.0")
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    (cache / "dep-1.2.3.co").write_bytes(package.read_bytes())
+    (cache / "otra-1.0.0.co").write_bytes(package2.read_bytes())
+    (tmp_path / "cobra.toml").write_text(
+        '[dependencies]\ndep = "1.2.3"\notra = "1.0.0"\n', encoding="utf-8"
+    )
+    (tmp_path / "main.cobra").write_text(
+        "usar dep.modulo\nusar otra.mod\n", encoding="utf-8"
+    )
+
+    with pytest.raises(CobraDependencyError, match="Conflicto de versiones"):
+        resolve_project_dependencies(
+            tmp_path, resolver=CobraHubResolver(cache_dir=cache)
+        )


### PR DESCRIPTION
### Motivation
- Añadir la lógica que permite al instalador gestionar dependencias Cobra declaradas en `cobra.toml` y fijadas/validables en `cobra.lock` para soportar instalaciones reproducibles.
- Reutilizar la lógica existente de empaquetado y repositorio bajo `pcobra.cobra` para evitar duplicar protocolos/formatos y aprovechar la caché/contratos actuales.

### Description
- Se implementó el resolvedor de dependencias en `src/pcobra/cobra_installer/dependency_resolver.py` con lectura de `cobra.toml`, lectura/validación de `cobra.lock`, detección estática de imports Cobra en fuentes `.cobra`/`.co`, comparación entre imports usados y dependencias declaradas, y generación de `cobra.lock` cuando falta.
- Se añadió `src/pcobra/cobra_installer/hub_resolver.py` que reutiliza `pcobra.cobra.hub.repository` y `pcobra.cobra.packaging` para localizar/usar la caché local, validar paquetes `.co`, descargar desde CobraHub y verificar versiones y hashes.
- Se incorporaron comprobaciones de integridad y compatibilidad: validación de versiones SemVer, verificación SHA-256 contra `cobra.lock`, detección de conflictos de versión (incluyendo conflictos transitivos) y errores controlados con mensajes aptos para CLI/IDLE (`CobraDependencyError` / `CobraInstallerError`).
- Se añadieron pruebas unitarias en `tests/unit/test_cobra_installer_dependency_resolver.py` cubriendo detección de imports, parsing de `cobra.toml`, resolución desde caché con generación de lock, dependencia no declarada, fallo por hash inválido y conflicto transitivo.

### Testing
- Ejecutado `pytest -q tests/unit/test_cobra_installer_dependency_resolver.py` y todas las pruebas del nuevo archivo pasaron (`6 passed`).
- Se verificó que los módulos compilaban con `python -m py_compile src/pcobra/cobra_installer/dependency_resolver.py src/pcobra/cobra_installer/hub_resolver.py` sin errores.
- Los cambios fueron formateados con `black` y se creó un commit con los ficheros modificados y las pruebas añadidas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a454f2e077483278de885637d37fb89)