### PR TITLE
Implement CobraInstaller build cache

### DIFF
--- a/src/pcobra/cobra_installer/cache.py
+++ b/src/pcobra/cobra_installer/cache.py
@@ -1,9 +1,254 @@
-"""Módulo inicial del instalador Cobra.
+"""Caché de artefactos de build para CobraInstaller.
 
-Este archivo reserva una responsabilidad concreta del flujo de construcción para
-mantener la lógica fuera del IDLE a medida que el instalador evolucione.
+La caché del instalador reutiliza la caché local de CobraHub como fuente
+principal para paquetes ``.co`` ya descargados, pero escribe artefactos propios en
+un subdirectorio separado. Así se evitan escrituras accidentales dentro del
+proyecto: el instalador solo debe tocar el árbol del usuario cuando genera de
+forma explícita ``cobra.lock``.
 """
 
 from __future__ import annotations
 
-__all__: list[str] = []
+import hashlib
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from pcobra.cobra.hub.repository import package_cache_dir
+from pcobra.cobra.packaging import normalizar_nombre_paquete, validar_version_paquete
+
+__all__ = [
+    "COBRA_INSTALLER_CACHE_DIR_ENV",
+    "CobraInstallerCache",
+    "CobraInstallerCacheEntry",
+    "installer_cache_dir",
+]
+
+COBRA_INSTALLER_CACHE_DIR_ENV = "COBRA_INSTALLER_CACHE_DIR"
+_INSTALLER_CACHE_SUBDIR = "cobra-installer"
+
+
+@dataclass(frozen=True)
+class CobraInstallerCacheEntry:
+    """Artefacto localizado en una de las capas de caché."""
+
+    name: str
+    version: str
+    path: Path
+    sha256: str
+    source: str
+
+
+class CobraInstallerCache:
+    """Caché en capas para artefactos de CobraInstaller.
+
+    Prioridad de lectura:
+    1. Caché existente de CobraHub, salvo que se configure explícitamente un
+       directorio de instalador mediante ``COBRA_INSTALLER_CACHE_DIR`` o
+       ``cache_dir``.
+    2. Subdirectorio propio de CobraInstaller para artefactos temporales.
+
+    Las escrituras de :meth:`put` siempre van a la capa propia del instalador y
+    nunca al directorio del proyecto.
+    """
+
+    def __init__(
+        self,
+        *,
+        cache_dir: str | Path | None = None,
+        hub_cache_dir: str | Path | None = None,
+    ) -> None:
+        env_cache_dir = os.environ.get(COBRA_INSTALLER_CACHE_DIR_ENV)
+        self._explicit_installer_cache = cache_dir is not None or bool(env_cache_dir)
+        self.hub_cache_dir = (
+            Path(hub_cache_dir).expanduser() if hub_cache_dir else package_cache_dir()
+        )
+        self.cache_dir = installer_cache_dir(cache_dir, hub_cache_dir=self.hub_cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def get(
+        self,
+        name: str,
+        version: str,
+        *,
+        expected_sha256: str | None = None,
+    ) -> CobraInstallerCacheEntry | None:
+        """Devuelve un artefacto válido o ``None`` si no está cacheado.
+
+        ``expected_sha256`` permite invalidar automáticamente copias obsoletas o
+        corruptas por hash. La versión forma parte del nombre canónico del
+        artefacto, por lo que pedir otra versión no reutiliza una entrada previa.
+        """
+
+        normalized_name, normalized_version = self._normalize_key(name, version)
+        expected_sha256 = self._normalize_hash(expected_sha256)
+        for candidate, source in self._candidates(normalized_name, normalized_version):
+            if not candidate.is_file():
+                continue
+            entry = self.validate(
+                candidate,
+                normalized_name,
+                normalized_version,
+                expected_sha256=expected_sha256,
+                source=source,
+            )
+            if entry is not None:
+                return entry
+            if source == "installer-cache":
+                candidate.unlink(missing_ok=True)
+        return None
+
+    def put(
+        self,
+        name: str,
+        version: str,
+        artifact: str | Path,
+        *,
+        expected_sha256: str | None = None,
+    ) -> CobraInstallerCacheEntry:
+        """Copia ``artifact`` a la caché propia del instalador y lo valida."""
+
+        normalized_name, normalized_version = self._normalize_key(name, version)
+        expected_sha256 = self._normalize_hash(expected_sha256)
+        source_path = Path(artifact).expanduser()
+        target = self.cache_dir / self._filename(normalized_name, normalized_version)
+        if source_path.resolve() != target.resolve():
+            shutil.copy2(source_path, target)
+        entry = self.validate(
+            target,
+            normalized_name,
+            normalized_version,
+            expected_sha256=expected_sha256,
+            source="installer-cache",
+        )
+        if entry is None:
+            target.unlink(missing_ok=True)
+            raise ValueError(
+                f"Artefacto inválido para {normalized_name}=={normalized_version}"
+            )
+        return entry
+
+    def validate(
+        self,
+        artifact: str | Path,
+        name: str,
+        version: str,
+        *,
+        expected_sha256: str | None = None,
+        source: str | None = None,
+    ) -> CobraInstallerCacheEntry | None:
+        """Valida ruta, versión y hash de un artefacto cacheado."""
+
+        normalized_name, normalized_version = self._normalize_key(name, version)
+        path = Path(artifact).expanduser()
+        if not path.is_file():
+            return None
+        if path.name not in {
+            self._filename(normalized_name, normalized_version),
+            f"{normalized_name}.co",
+        }:
+            return None
+        digest = self._sha256_file(path)
+        expected_sha256 = self._normalize_hash(expected_sha256)
+        if expected_sha256 and digest.lower() != expected_sha256.lower():
+            return None
+        return CobraInstallerCacheEntry(
+            name=normalized_name,
+            version=normalized_version,
+            path=path,
+            sha256=digest,
+            source=source or self._source_for(path),
+        )
+
+    def clear(self, name: str | None = None, version: str | None = None) -> int:
+        """Elimina artefactos de la caché propia del instalador.
+
+        No limpia la caché compartida de CobraHub para no borrar paquetes que
+        puedan estar siendo usados por otros comandos.
+        """
+
+        deleted = 0
+        for path in self.cache_dir.glob("*.co"):
+            if not self._matches(path, name=name, version=version):
+                continue
+            path.unlink(missing_ok=True)
+            deleted += 1
+        return deleted
+
+    def candidates(self, name: str, version: str) -> list[Path]:
+        """Lista rutas candidatas en orden de prioridad de lectura."""
+
+        normalized_name, normalized_version = self._normalize_key(name, version)
+        return [
+            path
+            for path, _source in self._candidates(normalized_name, normalized_version)
+        ]
+
+    def _candidates(self, name: str, version: str) -> list[tuple[Path, str]]:
+        installer_candidates = [
+            (self.cache_dir / self._filename(name, version), "installer-cache"),
+            (self.cache_dir / f"{name}.co", "installer-cache"),
+        ]
+        if self._explicit_installer_cache:
+            return installer_candidates
+        return [
+            (self.hub_cache_dir / self._filename(name, version), "cobrahub-cache"),
+            (self.hub_cache_dir / f"{name}.co", "cobrahub-cache"),
+            *installer_candidates,
+        ]
+
+    def _source_for(self, path: Path) -> str:
+        try:
+            if path.resolve().parent == self.hub_cache_dir.resolve():
+                return "cobrahub-cache"
+            if path.resolve().parent == self.cache_dir.resolve():
+                return "installer-cache"
+        except OSError:
+            pass
+        return str(path)
+
+    @staticmethod
+    def _filename(name: str, version: str) -> str:
+        return f"{name}-{version}.co"
+
+    @staticmethod
+    def _normalize_key(name: str, version: str) -> tuple[str, str]:
+        return normalizar_nombre_paquete(name), validar_version_paquete(version)
+
+    @staticmethod
+    def _normalize_hash(value: str | None) -> str | None:
+        return value.removeprefix("sha256:").lower() if value else None
+
+    @staticmethod
+    def _sha256_file(path: Path) -> str:
+        sha = hashlib.sha256()
+        with path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                sha.update(chunk)
+        return sha.hexdigest()
+
+    def _matches(self, path: Path, *, name: str | None, version: str | None) -> bool:
+        if name is None:
+            return True
+        normalized_name = normalizar_nombre_paquete(name)
+        if version is None:
+            return path.name == f"{normalized_name}.co" or path.name.startswith(
+                f"{normalized_name}-"
+            )
+        normalized_version = validar_version_paquete(version)
+        return path.name == self._filename(normalized_name, normalized_version)
+
+
+def installer_cache_dir(
+    cache_dir: str | Path | None = None,
+    *,
+    hub_cache_dir: str | Path | None = None,
+) -> Path:
+    """Devuelve el directorio de caché propio de CobraInstaller."""
+
+    configured = cache_dir or os.environ.get(COBRA_INSTALLER_CACHE_DIR_ENV)
+    if configured:
+        return Path(configured).expanduser()
+    hub_dir = Path(hub_cache_dir).expanduser() if hub_cache_dir else package_cache_dir()
+    return hub_dir / _INSTALLER_CACHE_SUBDIR

--- a/src/pcobra/cobra_installer/hub_resolver.py
+++ b/src/pcobra/cobra_installer/hub_resolver.py
@@ -11,7 +11,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from pcobra.cobra.hub.repository import PackageRepository, package_cache_dir
+from pcobra.cobra.hub.repository import PackageRepository
+from pcobra.cobra_installer.cache import CobraInstallerCache
 from pcobra.cobra.packaging import (
     es_paquete_cobra,
     inspeccionar_paquete,
@@ -49,10 +50,8 @@ class CobraHubResolver:
         cache_dir: str | Path | None = None,
     ) -> None:
         self.repository = repository
-        self.cache_dir = (
-            Path(cache_dir).expanduser() if cache_dir else package_cache_dir()
-        )
-        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.cache = CobraInstallerCache(cache_dir=cache_dir)
+        self.cache_dir = self.cache.cache_dir
 
     def resolve(
         self,
@@ -78,16 +77,15 @@ class CobraHubResolver:
 
         for candidate in candidates:
             if candidate.is_file():
+                cache_entry = self.cache.validate(
+                    candidate, normalized_name, normalized_version
+                )
                 return self._inspect_candidate(
                     candidate,
                     normalized_name,
                     normalized_version,
                     expected_sha256=expected_sha256,
-                    source=(
-                        "cache"
-                        if candidate.parent == self.cache_dir
-                        else str(candidate)
-                    ),
+                    source=cache_entry.source if cache_entry else str(candidate),
                 )
 
         if self.repository is None:
@@ -111,10 +109,7 @@ class CobraHubResolver:
         )
 
     def _cache_candidates(self, name: str, version: str) -> list[Path]:
-        return [
-            self.cache_dir / f"{name}-{version}.co",
-            self.cache_dir / f"{name}.co",
-        ]
+        return self.cache.candidates(name, version)
 
     def _inspect_candidate(
         self,

--- a/tests/unit/test_cobra_installer_cache.py
+++ b/tests/unit/test_cobra_installer_cache.py
@@ -1,0 +1,71 @@
+import hashlib
+
+from pcobra.cobra_installer.cache import CobraInstallerCache, installer_cache_dir
+
+
+def _write(path, content=b"artifact"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return hashlib.sha256(content).hexdigest()
+
+
+def test_installer_cache_dir_usa_subdirectorio_de_cobrahub(tmp_path):
+    hub_cache = tmp_path / "hub-cache"
+
+    assert installer_cache_dir(hub_cache_dir=hub_cache) == hub_cache / "cobra-installer"
+
+
+def test_get_prefiere_cache_cobrahub_cuando_no_hay_configuracion_explicita(tmp_path):
+    hub_cache = tmp_path / "hub"
+    installer_cache = hub_cache / "cobra-installer"
+    hub_hash = _write(hub_cache / "dep-1.2.3.co", b"hub")
+    _write(installer_cache / "dep-1.2.3.co", b"installer")
+
+    cache = CobraInstallerCache(hub_cache_dir=hub_cache)
+    entry = cache.get("dep", "1.2.3", expected_sha256=hub_hash)
+
+    assert entry is not None
+    assert entry.path == hub_cache / "dep-1.2.3.co"
+    assert entry.source == "cobrahub-cache"
+
+
+def test_put_escribe_en_cache_propia_y_clear_no_borra_cobrahub(tmp_path):
+    hub_cache = tmp_path / "hub"
+    source_hash = _write(tmp_path / "source.co", b"installer")
+    _write(hub_cache / "dep-1.2.3.co", b"hub")
+    cache = CobraInstallerCache(hub_cache_dir=hub_cache)
+
+    entry = cache.put("dep", "1.2.3", tmp_path / "source.co", expected_sha256=source_hash)
+    deleted = cache.clear("dep", "1.2.3")
+
+    assert entry.path == hub_cache / "cobra-installer" / "dep-1.2.3.co"
+    assert deleted == 1
+    assert (hub_cache / "dep-1.2.3.co").exists()
+    assert not entry.path.exists()
+
+
+def test_hash_invalida_artefacto_de_cache_propia(tmp_path):
+    hub_cache = tmp_path / "hub"
+    cache = CobraInstallerCache(hub_cache_dir=hub_cache)
+    artifact = cache.cache_dir / "dep-1.2.3.co"
+    _write(artifact, b"old")
+
+    entry = cache.get("dep", "1.2.3", expected_sha256="0" * 64)
+
+    assert entry is None
+    assert not artifact.exists()
+
+
+def test_variable_entorno_dirige_cache_instalador(monkeypatch, tmp_path):
+    configured = tmp_path / "configured-cache"
+    hub_cache = tmp_path / "hub"
+    hub_hash = _write(hub_cache / "dep-1.2.3.co", b"hub")
+    configured_hash = _write(configured / "dep-1.2.3.co", b"configured")
+    monkeypatch.setenv("COBRA_INSTALLER_CACHE_DIR", str(configured))
+
+    cache = CobraInstallerCache(hub_cache_dir=hub_cache)
+    entry = cache.get("dep", "1.2.3", expected_sha256=configured_hash)
+
+    assert entry is not None
+    assert entry.path == configured / "dep-1.2.3.co"
+    assert cache.get("dep", "1.2.3", expected_sha256=hub_hash) is None


### PR DESCRIPTION
### Motivation
- Añadir una capa de caché dedicada para artefactos de build que reutilice la caché existente de CobraHub cuando proceda y permita al instalador escribir artefactos temporales en su propio espacio.
- Evitar escrituras accidentales dentro del árbol del proyecto salvo cuando se genere explícitamente `cobra.lock`.
- Soportar invalidación por hash/versión y permitir configuración futura mediante la variable de entorno `COBRA_INSTALLER_CACHE_DIR`.

### Description
- Se creó `src/pcobra/cobra_installer/cache.py` con `CobraInstallerCache`, `CobraInstallerCacheEntry` y `installer_cache_dir`, e implementación de las operaciones públicas `get`, `put`, `validate` y `clear`.
- La caché es en capas: por defecto lee primero la caché de CobraHub y mantiene un subdirectorio propio (`cobra-installer`) para escrituras del instalador, y respeta `COBRA_INSTALLER_CACHE_DIR` si está configurada.
- Se añadieron validación por `sha256`, normalización de nombre/versión y comportamiento de invalidación (se borra el artefacto inválido de la capa del instalador cuando corresponde).
- Se integró la nueva caché en `CobraHubResolver` para resolver candidatos desde la capa correcta antes de descargar desde el repositorio, y se añadieron tests unitarios nuevos en `tests/unit/test_cobra_installer_cache.py`.

### Testing
- Se ejecutó `python -m ruff check src/pcobra/cobra_installer/cache.py src/pcobra/cobra_installer/hub_resolver.py tests/unit/test_cobra_installer_cache.py` y pasó sin errores.
- Se ejecutó `python -m pytest tests/unit/test_cobra_installer_cache.py tests/unit/test_cobra_installer_dependency_resolver.py` y todos los tests pasaron (`11 passed`, 1 warning).
- Las pruebas verifican prioridad de lectura entre CobraHub e instalador, escritura en subdirectorio propio, invalidación por hash y comportamiento de la variable de entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45553bd8308327851b9adc64ea91a2)