### PR TITLE
Implementar preparación de runtime Cobra para PyInstaller (prepare_runtime)

### DIFF
--- a/src/pcobra/cobra_installer/__init__.py
+++ b/src/pcobra/cobra_installer/__init__.py
@@ -21,7 +21,12 @@ from .project import (
 from .targets import BuildMode, TargetOS
 from .transpile import TranspileResult, transpile_project
 from .validator import ValidationErrorDetail, ValidationResult, validate_project
-from .runtime_builder import build_project, package_current_project
+from .runtime_builder import (
+    RuntimePreparationResult,
+    build_project,
+    package_current_project,
+    prepare_runtime,
+)
 
 __all__ = [
     "BuildManifest",
@@ -40,7 +45,9 @@ __all__ = [
     "transpile_project",
     "ValidationErrorDetail",
     "ValidationResult",
+    "RuntimePreparationResult",
     "build_project",
     "validate_project",
     "package_current_project",
+    "prepare_runtime",
 ]

--- a/src/pcobra/cobra_installer/runtime_builder.py
+++ b/src/pcobra/cobra_installer/runtime_builder.py
@@ -2,13 +2,147 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
+import shutil
+from dataclasses import dataclass, field, replace
 from pathlib import Path
+from typing import Mapping, Sequence
 
+import pcobra
+
+from .dependency_resolver import DependencyResolutionResult, resolve_project_dependencies
 from .manifest import create_manifest
-from .project import BuildOptions, BuildResult, CobraInstallerError
+from .project import BuildOptions, BuildResult, CobraInstallerError, CobraProject
 from .spec_writer import write_spec
 from .validator import discover_entrypoint, validate_build_options
+
+__all__ = [
+    "RuntimePreparationResult",
+    "build_project",
+    "package_current_project",
+    "prepare_runtime",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimePreparationResult:
+    """Resultado estable de preparar el runtime que consumirá PyInstaller."""
+
+    build_dir: Path
+    runtime_dir: Path
+    corelibs_dir: Path
+    standard_library_dir: Path
+    cobra_dir: Path
+    packages_dir: Path
+    assets_dir: Path
+    config_dir: Path
+    documentation_dir: Path
+    auxiliary_dir: Path
+    entrypoint: Path
+    copied_resources: Mapping[str, tuple[Path, ...]] = field(default_factory=dict)
+    dependency_resolution: DependencyResolutionResult | None = None
+    logs: tuple[str, ...] = ()
+
+
+def prepare_runtime(
+    build_dir: str | Path,
+    project: CobraProject,
+    dependencies: DependencyResolutionResult | Sequence[Path | str] | None,
+    options: BuildOptions,
+) -> RuntimePreparationResult:
+    """Prepara un árbol mínimo de runtime Cobra listo para PyInstaller.
+
+    Copia de forma selectiva las piezas necesarias para ejecutar código Cobra:
+    ``pcobra/core``, ``pcobra/corelibs``, ``pcobra/standard_library`` y una
+    superficie acotada de ``pcobra/cobra``. Además empaqueta recursos del
+    proyecto, paquetes ``.co`` locales o resueltos por CobraHub, y genera un
+    ``pyinstaller_entrypoint.py`` determinista que ajusta ``sys.path`` antes de
+    ejecutar el entrypoint Python generado o, si aún no existe, el entrypoint
+    Cobra mediante la CLI pública.
+    """
+
+    normalized_project = project.normalized()
+    normalized_options = options.normalized()
+    root = Path(normalized_project.project_root)
+    target = Path(build_dir).expanduser().resolve()
+    if normalized_options.clean and target.exists():
+        shutil.rmtree(target)
+    target.mkdir(parents=True, exist_ok=True)
+
+    runtime_root = target / "runtime"
+    pcobra_runtime = runtime_root / "pcobra"
+    packages_dir = target / "packages"
+    assets_dir = target / "assets"
+    config_dir = target / "config"
+    documentation_dir = target / "docs"
+    auxiliary_dir = target / "resources"
+    for directory in (
+        pcobra_runtime,
+        packages_dir,
+        assets_dir,
+        config_dir,
+        documentation_dir,
+        auxiliary_dir,
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    runtime_copies = _copy_pcobra_runtime(pcobra_runtime)
+
+    dependency_resolution: DependencyResolutionResult | None = None
+    if isinstance(dependencies, DependencyResolutionResult):
+        dependency_resolution = dependencies
+    elif dependencies is None and normalized_options.include_dependencies:
+        dependency_resolution = resolve_project_dependencies(root)
+
+    copied_hub_packages = _copy_hub_packages(dependency_resolution, packages_dir)
+    copied_explicit_packages = _copy_dependency_paths(dependencies, packages_dir, root)
+    copied_project_packages = _copy_many(normalized_project.co_packages, packages_dir, root)
+    copied_assets = _copy_many(
+        (*normalized_project.assets, *normalized_options.assets), assets_dir, root
+    )
+    copied_config = _copy_many(normalized_project.config_dirs, config_dir, root)
+    copied_docs = _copy_many(normalized_project.documentation, documentation_dir, root)
+    copied_auxiliary = _copy_many(
+        _existing_optional_paths(
+            normalized_project.cobra_toml,
+            normalized_project.cobra_lock,
+            *normalized_project.auxiliary_resources,
+        ),
+        auxiliary_dir,
+        root,
+    )
+    entrypoint = target / "pyinstaller_entrypoint.py"
+    source_entrypoint = normalized_project.entrypoint or normalized_options.entrypoint
+    entrypoint.write_text(
+        _pyinstaller_entrypoint_code(source_entrypoint, target), encoding="utf-8"
+    )
+
+    return RuntimePreparationResult(
+        build_dir=target,
+        runtime_dir=pcobra_runtime,
+        corelibs_dir=pcobra_runtime / "corelibs",
+        standard_library_dir=pcobra_runtime / "standard_library",
+        cobra_dir=pcobra_runtime / "cobra",
+        packages_dir=packages_dir,
+        assets_dir=assets_dir,
+        config_dir=config_dir,
+        documentation_dir=documentation_dir,
+        auxiliary_dir=auxiliary_dir,
+        entrypoint=entrypoint,
+        copied_resources={
+            "runtime": runtime_copies,
+            "packages": (*copied_hub_packages, *copied_explicit_packages, *copied_project_packages),
+            "assets": copied_assets,
+            "config": copied_config,
+            "documentation": copied_docs,
+            "auxiliary": copied_auxiliary,
+            "entrypoint": (entrypoint,),
+        },
+        dependency_resolution=dependency_resolution,
+        logs=(
+            f"Runtime Cobra copiado en {pcobra_runtime}.",
+            f"Entrypoint Python para PyInstaller creado en {entrypoint}.",
+        ),
+    )
 
 
 def build_project(options: BuildOptions | None = None, **overrides: object) -> BuildResult:
@@ -54,3 +188,160 @@ def package_current_project(project_root: str | Path | None = None, **kwargs: ob
 
     options = BuildOptions(project_root=project_root or Path.cwd(), **kwargs)
     return build_project(options)
+
+
+def _copy_pcobra_runtime(destination_root: Path) -> tuple[Path, ...]:
+    pcobra_root = Path(pcobra.__file__).resolve().parent
+    copied: list[Path] = []
+    for filename in ("__init__.py", "__main__.py", "cli.py"):
+        source = pcobra_root / filename
+        if source.is_file():
+            destination = destination_root / filename
+            _copy_path(source, destination)
+            copied.append(destination)
+    for name in ("core", "corelibs", "standard_library"):
+        source = pcobra_root / name
+        if source.exists():
+            destination = destination_root / name
+            _copy_path(source, destination)
+            copied.append(destination)
+    cobra_root = destination_root / "cobra"
+    cobra_root.mkdir(parents=True, exist_ok=True)
+    cobra_source = pcobra_root / "cobra"
+    for filename in ("__init__.py", "packaging.py", "usar_loader.py"):
+        source = cobra_source / filename
+        if source.is_file():
+            destination = cobra_root / filename
+            _copy_path(source, destination)
+            copied.append(destination)
+    for name in _RUNTIME_COBRA_SUBPACKAGES:
+        source = cobra_source / name
+        if source.exists():
+            destination = cobra_root / name
+            _copy_path(source, destination)
+            copied.append(destination)
+    return tuple(copied)
+
+
+def _copy_hub_packages(
+    resolution: DependencyResolutionResult | None, packages_dir: Path
+) -> tuple[Path, ...]:
+    if resolution is None:
+        return ()
+    copied: list[Path] = []
+    for package in resolution.resolved.values():
+        destination = packages_dir / package.path.name
+        _copy_path(package.path, destination)
+        copied.append(destination)
+    return tuple(copied)
+
+
+def _copy_dependency_paths(
+    dependencies: DependencyResolutionResult | Sequence[Path | str] | None,
+    packages_dir: Path,
+    project_root: Path,
+) -> tuple[Path, ...]:
+    if dependencies is None or isinstance(dependencies, DependencyResolutionResult):
+        return ()
+    return _copy_many(dependencies, packages_dir, project_root)
+
+
+def _copy_many(
+    paths: Sequence[Path | str], destination_root: Path, project_root: Path
+) -> tuple[Path, ...]:
+    copied: list[Path] = []
+    seen: set[Path] = set()
+    for raw in paths:
+        source = Path(raw).expanduser().resolve()
+        if source in seen or not source.exists():
+            continue
+        seen.add(source)
+        destination = destination_root / _relative_or_name(source, project_root)
+        _copy_path(source, destination)
+        copied.append(destination)
+    return tuple(copied)
+
+
+def _copy_path(source: Path, destination: Path) -> None:
+    if source.is_dir():
+        if destination.exists():
+            shutil.rmtree(destination)
+        shutil.copytree(source, destination, ignore=_ignore_runtime_noise)
+    else:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+
+def _ignore_runtime_noise(_directory: str, names: list[str]) -> set[str]:
+    ignored: set[str] = set()
+    for name in names:
+        path_name = Path(name)
+        if name in _IGNORED_NAMES or path_name.suffix in _IGNORED_SUFFIXES:
+            ignored.add(name)
+    return ignored
+
+
+def _relative_or_name(path: Path, root: Path) -> Path:
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        return Path(path.name)
+
+
+def _existing_optional_paths(*paths: Path | str | None) -> tuple[Path | str, ...]:
+    return tuple(path for path in paths if path is not None and Path(path).exists())
+
+
+def _pyinstaller_entrypoint_code(source_entrypoint: Path | None, build_dir: Path) -> str:
+    source_literal = str(source_entrypoint) if source_entrypoint is not None else ""
+    return (
+        '"""Entrypoint estable generado por cobra_installer para PyInstaller."""\n'
+        "from __future__ import annotations\n\n"
+        "import runpy\n"
+        "import sys\n"
+        "from pathlib import Path\n\n"
+        "BASE_DIR = Path(getattr(sys, '_MEIPASS', Path(__file__).resolve().parent))\n"
+        "for relative in ('runtime', 'packages', 'python'):\n"
+        "    candidate = BASE_DIR / relative\n"
+        "    if candidate.exists():\n"
+        "        sys.path.insert(0, str(candidate))\n\n"
+        "generated_main = BASE_DIR / 'python' / '__main__.py'\n"
+        "if generated_main.is_file():\n"
+        "    runpy.run_path(str(generated_main), run_name='__main__')\n"
+        "else:\n"
+        f"    source_entrypoint = Path({source_literal!r})\n"
+        "    if not source_entrypoint.is_file():\n"
+        "        raise SystemExit('No se encontró entrypoint Python generado ni fuente Cobra original.')\n"
+        "    from pcobra.cobra.cli.cli import main as cobra_main\n"
+        "    raise SystemExit(cobra_main(['ejecutar', str(source_entrypoint)]))\n"
+    )
+
+
+_RUNTIME_COBRA_SUBPACKAGES = (
+    "bindings",
+    "cli",
+    "core",
+    "imports",
+    "semantico",
+    "stdlib_contract",
+    "transpilers",
+)
+
+_IGNORED_NAMES = {
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "benchmarks",
+    "docs",
+    "documentation",
+    "examples",
+    "node_modules",
+    "tests",
+    "venv",
+}
+_IGNORED_SUFFIXES = {".pyc", ".pyo"}

--- a/tests/unit/test_cobra_installer_runtime_builder.py
+++ b/tests/unit/test_cobra_installer_runtime_builder.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import py_compile
+from pathlib import Path
+
+from pcobra.cobra_installer import (
+    BuildOptions,
+    CobraProject,
+    RuntimePreparationResult,
+    prepare_runtime,
+)
+from pcobra.cobra_installer.dependency_resolver import DependencyResolutionResult
+from pcobra.cobra_installer.hub_resolver import CobraHubResolution
+
+
+def test_prepare_runtime_copia_runtime_recursos_y_entrypoint_filtrados(tmp_path: Path) -> None:
+    project_root = tmp_path / "app"
+    project_root.mkdir()
+    entrypoint = project_root / "main.cobra"
+    entrypoint.write_text("imprimir('hola')\n", encoding="utf-8")
+    (project_root / "cobra.toml").write_text("name = 'demo'\n", encoding="utf-8")
+    (project_root / "cobra.lock").write_text('{"packages": []}\n', encoding="utf-8")
+    (project_root / "assets").mkdir()
+    (project_root / "assets" / "logo.txt").write_text("asset", encoding="utf-8")
+    (project_root / "config").mkdir()
+    (project_root / "config" / "settings.json").write_text("{}", encoding="utf-8")
+    (project_root / "README.md").write_text("# Demo", encoding="utf-8")
+    (project_root / "vendor.co").write_bytes(b"paquete-local")
+    resolved_package = tmp_path / "remoto-1.0.0.co"
+    resolved_package.write_bytes(b"paquete-remoto")
+    resolution = DependencyResolutionResult(
+        declared={},
+        used_imports=set(),
+        resolved={
+            "remoto": CobraHubResolution(
+                name="remoto",
+                version="1.0.0",
+                path=resolved_package,
+                sha256="0" * 64,
+                source="test",
+            )
+        },
+        lockfile_path=project_root / "cobra.lock",
+    )
+
+    result = prepare_runtime(
+        tmp_path / "build-runtime",
+        CobraProject(
+            project_root=project_root,
+            entrypoint=entrypoint,
+            cobra_toml=project_root / "cobra.toml",
+            cobra_lock=project_root / "cobra.lock",
+            assets=(project_root / "assets",),
+            config_dirs=(project_root / "config",),
+            documentation=(project_root / "README.md",),
+            co_packages=(project_root / "vendor.co",),
+        ),
+        resolution,
+        BuildOptions(project_root=project_root, entrypoint=entrypoint),
+    )
+
+    assert isinstance(result, RuntimePreparationResult)
+    py_compile.compile(str(result.entrypoint), doraise=True)
+    assert (result.runtime_dir / "__init__.py").is_file()
+    assert (result.runtime_dir / "core").is_dir()
+    assert result.corelibs_dir.is_dir()
+    assert result.standard_library_dir.is_dir()
+    assert (result.cobra_dir / "core" / "parser.py").is_file()
+    assert (result.cobra_dir / "cli" / "cli.py").is_file()
+    assert not (result.runtime_dir / "cobra" / "benchmarks").exists()
+    assert not any(result.runtime_dir.rglob("__pycache__"))
+    assert (result.packages_dir / "remoto-1.0.0.co").read_bytes() == b"paquete-remoto"
+    assert (result.packages_dir / "vendor.co").read_bytes() == b"paquete-local"
+    assert (result.assets_dir / "assets" / "logo.txt").read_text(encoding="utf-8") == "asset"
+    assert (result.config_dir / "config" / "settings.json").is_file()
+    assert (result.documentation_dir / "README.md").is_file()
+    assert (result.auxiliary_dir / "cobra.toml").is_file()
+    assert (result.auxiliary_dir / "cobra.lock").is_file()
+    assert "runtime" in result.copied_resources
+    assert result.dependency_resolution is resolution
+
+
+def test_prepare_runtime_acepta_dependencias_como_rutas_y_no_resuelve_si_se_omiten(tmp_path: Path) -> None:
+    project_root = tmp_path / "app"
+    project_root.mkdir()
+    entrypoint = project_root / "main.cobra"
+    entrypoint.write_text("imprimir('sin deps')\n", encoding="utf-8")
+    paquete = tmp_path / "manual.co"
+    paquete.write_bytes(b"manual")
+
+    result = prepare_runtime(
+        tmp_path / "build-runtime",
+        CobraProject(project_root=project_root, entrypoint=entrypoint),
+        (paquete,),
+        BuildOptions(
+            project_root=project_root,
+            entrypoint=entrypoint,
+            include_dependencies=False,
+        ),
+    )
+
+    assert (result.packages_dir / "manual.co").read_bytes() == b"manual"
+    assert result.dependency_resolution is None


### PR DESCRIPTION
### Motivation

- Proveer una API estable para preparar un árbol de runtime empaquetable por PyInstaller incluyendo sólo lo necesario del runtime Cobra. 
- Evitar arrastrar tests, caches, documentación interna pesada y bytecode al artefacto final para reducir tamaño y ruido. 
- Soportar paquetes `.co` locales y paquetes resueltos vía CobraHub y generar un entrypoint Python determinista para ejecución fuera del árbol de fuentes.

### Description

- Se añadió `RuntimePreparationResult` y la función pública `prepare_runtime(build_dir, project, dependencies, options)` que prepara un árbol mínimo con `runtime`, `packages`, `python`, `assets`, `config`, `docs` y `resources`. (archivo: `src/pcobra/cobra_installer/runtime_builder.py`).
- Implementación de copiado selectivo del runtime `pcobra` incluyendo `core`, `corelibs`, `standard_library` y una superficie acotada de `pcobra/cobra` (`bindings`, `cli`, `core`, `imports`, `semantico`, `stdlib_contract`, `transpilers`) con filtrado para ignorar caches, tests, benchmarks, entornos virtuales y bytecode. (funciones: `_copy_pcobra_runtime`, `_copy_path`, `_ignore_runtime_noise`).
- Soporte para copiar paquetes resueltos por CobraHub y paquetes declarados como rutas o locales (`_copy_hub_packages`, `_copy_dependency_paths`, `_copy_many`) y empaquetado de assets/config/documentación/auxiliares detectados en el proyecto.
- Generación de un entrypoint estable `pyinstaller_entrypoint.py` que ajusta `sys.path` (por `runtime`, `packages`, `python`), ejecuta `python/__main__.py` si existe y, como fallback, invoca la CLI pública de Cobra para ejecutar la fuente original; además se exporta la API desde `pcobra.cobra_installer` modificando `__init__.py`.
- Se añadieron pruebas unitarias en `tests/unit/test_cobra_installer_runtime_builder.py` que validan la copia del runtime y recursos, la exclusión de ruido y la inclusión de paquetes resueltos y locales.

### Testing

- Ejecutado: `python -m pytest tests/unit/test_cobra_installer_runtime_builder.py -q` y la suite del instalador `python -m pytest tests/unit/test_cobra_installer_transpile.py tests/unit/test_cobra_installer_models.py tests/unit/test_cobra_installer_runtime_builder.py -q`, con resultado: todas las pruebas unitarias relacionadas del instalador pasaron (`14 passed`, `1 warning`).
- Se verificó formato/linting con `python -m ruff check src/pcobra/cobra_installer/runtime_builder.py src/pcobra/cobra_installer/__init__.py tests/unit/test_cobra_installer_runtime_builder.py` y no se reportaron fallos.
- Se compiló con `python -m py_compile src/pcobra/cobra_installer/runtime_builder.py src/pcobra/cobra_installer/__init__.py tests/unit/test_cobra_installer_runtime_builder.py` sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45e599fa408327bd3695c0d694e58a)