### PR TITLE
Completa runtime selectivo para PyInstaller

### DIFF
--- a/src/pcobra/cobra_installer/runtime_builder.py
+++ b/src/pcobra/cobra_installer/runtime_builder.py
@@ -199,16 +199,19 @@ def _copy_pcobra_runtime(destination_root: Path) -> tuple[Path, ...]:
             destination = destination_root / filename
             _copy_path(source, destination)
             copied.append(destination)
-    for name in ("core", "corelibs", "standard_library"):
+    for name in ("_stubs", "core", "corelibs", "standard_library"):
         source = pcobra_root / name
         if source.exists():
             destination = destination_root / name
             _copy_path(source, destination)
             copied.append(destination)
+    source_layout = _create_runtime_source_layout(destination_root)
+    if source_layout is not None:
+        copied.append(source_layout)
     cobra_root = destination_root / "cobra"
     cobra_root.mkdir(parents=True, exist_ok=True)
     cobra_source = pcobra_root / "cobra"
-    for filename in ("__init__.py", "packaging.py", "usar_loader.py"):
+    for filename in ("__init__.py", "packaging.py", "usar_loader.py", "usar_policy.py"):
         source = cobra_source / filename
         if source.is_file():
             destination = cobra_root / filename
@@ -221,6 +224,25 @@ def _copy_pcobra_runtime(destination_root: Path) -> tuple[Path, ...]:
             _copy_path(source, destination)
             copied.append(destination)
     return tuple(copied)
+
+
+def _create_runtime_source_layout(destination_root: Path) -> Path | None:
+    """Crea la ruta ``src/pcobra`` esperada por contratos de arranque.
+
+    Algunos contratos internos validan rutas históricas ``src/pcobra/...`` en
+    tiempo de importación. En el árbol de PyInstaller el paquete vive bajo
+    ``runtime/pcobra``; por eso se crea una réplica mínima y filtrada solo de
+    las bibliotecas canónicas consultadas por esos contratos.
+    """
+
+    source_layout = destination_root.parent.parent / "src" / "pcobra"
+    copied = False
+    for name in ("corelibs", "standard_library"):
+        source = destination_root / name
+        if source.exists():
+            _copy_path(source, source_layout / name)
+            copied = True
+    return source_layout if copied else None
 
 
 def _copy_hub_packages(
@@ -318,10 +340,17 @@ def _pyinstaller_entrypoint_code(source_entrypoint: Path | None, build_dir: Path
 
 
 _RUNTIME_COBRA_SUBPACKAGES = (
+    # Importados por pcobra.__init__ y por las rutas de resolución/transpilación
+    # usadas por `pcobra.cobra.cli.cli ejecutar`.
+    "architecture",
+    "backends",
     "bindings",
+    "build",
     "cli",
+    "config",
     "core",
     "imports",
+    "macro",
     "semantico",
     "stdlib_contract",
     "transpilers",
@@ -344,4 +373,4 @@ _IGNORED_NAMES = {
     "tests",
     "venv",
 }
-_IGNORED_SUFFIXES = {".pyc", ".pyo"}
+_IGNORED_SUFFIXES = {".md", ".pyc", ".pyo"}


### PR DESCRIPTION
### Motivation

- Preparar un árbol mínimo y determinista que PyInstaller pueda empaquetar y que permita importar y ejecutar la CLI de Cobra sin arrastrar todo el repositorio.
- Satisfacer contratos de arranque que esperan rutas históricas (`src/pcobra/...`) y evitar incluir documentación o caches innecesarios en el build final.

### Description

- Extiende la copia selectiva en `src/pcobra/cobra_installer/runtime_builder.py` para incluir `_stubs`, `core`, `corelibs` y `standard_library` en el runtime preparado para PyInstaller.
- Amplía la lista de subpaquetes Cobra copiados (`architecture`, `backends`, `build`, `config`, `macro`, etc.) y añade la copia de `usar_policy.py` necesaria para arranque correcto.
- Añade la función `_create_runtime_source_layout` que crea una réplica mínima `src/pcobra` dentro del árbol de build para satisfacer rutas históricas usadas por validaciones internas y solo replica `corelibs` y `standard_library`.
- Evita copiar documentación pesada dentro de los paquetes ajustando `_IGNORED_SUFFIXES` para excluir archivos Markdown y mantiene el `pyinstaller_entrypoint.py` estable que ajusta `sys.path` antes de ejecutar el entrypoint.

### Testing

- Ejecuté los tests unitarios con `pytest -q tests/unit/test_cobra_installer_runtime_builder.py` y pasaron (`2 passed, 1 warning`).
- Realicé una verificación manual creando un runtime temporal con `prepare_runtime` e importando `pcobra.cobra.cli.cli` desde el árbol copiado para comprobar que la CLI se puede cargar correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45fc989f2c83279b5d6f825aa80fea)