### PR TITLE
Implementar generador de .spec de PyInstaller para cobra_installer

### DIFF
--- a/src/pcobra/cobra_installer/__init__.py
+++ b/src/pcobra/cobra_installer/__init__.py
@@ -8,6 +8,7 @@ puente delgado de :mod:`pcobra.cobra_installer.idle_bridge`.
 from __future__ import annotations
 
 from .manifest import BuildManifest, DependencyInfo
+from .spec_writer import SpecBuildContext, write_spec
 from .project import (
     BuildOptions,
     BuildResult,
@@ -46,8 +47,10 @@ __all__ = [
     "ValidationErrorDetail",
     "ValidationResult",
     "RuntimePreparationResult",
+    "SpecBuildContext",
     "build_project",
     "validate_project",
     "package_current_project",
     "prepare_runtime",
+    "write_spec",
 ]

--- a/src/pcobra/cobra_installer/runtime_builder.py
+++ b/src/pcobra/cobra_installer/runtime_builder.py
@@ -11,8 +11,8 @@ import pcobra
 
 from .dependency_resolver import DependencyResolutionResult, resolve_project_dependencies
 from .manifest import create_manifest
-from .project import BuildOptions, BuildResult, CobraInstallerError, CobraProject
-from .spec_writer import write_spec
+from .project import BuildOptions, BuildResult, CobraInstallerError, CobraProject, discover_project
+from .spec_writer import SpecBuildContext, write_spec
 from .validator import discover_entrypoint, validate_build_options
 
 __all__ = [
@@ -166,7 +166,34 @@ def build_project(options: BuildOptions | None = None, **overrides: object) -> B
     output_dir.mkdir(parents=True, exist_ok=True)
     name = normalized.name or entrypoint.stem
     manifest_path = create_manifest(normalized, entrypoint, output_dir, name)
-    spec_path = write_spec(normalized, entrypoint, output_dir, name)
+    project = discover_project(Path(normalized.project_root))
+    if project.entrypoint != entrypoint:
+        project = CobraProject(
+            project_root=project.project_root,
+            entrypoint=entrypoint,
+            cobra_toml=project.cobra_toml,
+            cobra_lock=project.cobra_lock,
+            assets=project.assets,
+            config=project.config,
+            co_packages=project.co_packages,
+            documentation=project.documentation,
+            config_dirs=project.config_dirs,
+            auxiliary_resources=project.auxiliary_resources,
+        )
+    runtime = prepare_runtime(
+        Path(normalized.temp_dir or Path(normalized.project_root) / "build"),
+        project,
+        None,
+        normalized,
+    )
+    spec_path = write_spec(
+        SpecBuildContext(
+            options=normalized,
+            runtime=runtime,
+            output_dir=output_dir,
+            executable_name=name,
+        )
+    )
     return BuildResult(
         success=True,
         artifact_path=spec_path,

--- a/src/pcobra/cobra_installer/spec_writer.py
+++ b/src/pcobra/cobra_installer/spec_writer.py
@@ -1,27 +1,181 @@
-"""Generación de especificaciones de empaquetado."""
+"""Generación de especificaciones de empaquetado para PyInstaller."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING, Sequence
 
 from .project import BuildOptions
+from .targets import BuildMode
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .runtime_builder import RuntimePreparationResult
 
 
-def write_spec(options: BuildOptions, entrypoint: Path, output_dir: Path, name: str) -> Path:
-    """Escribe una especificación inicial legible por humanos."""
+@dataclass(frozen=True, slots=True)
+class SpecBuildContext:
+    """Contexto completo necesario para escribir un ``.spec`` de PyInstaller."""
 
-    path = output_dir / f"{name}.cobra-installer.toml"
-    path.write_text(
-        "\n".join(
-            [
-                f'name = "{name}"',
-                f'project_root = "{Path(options.project_root)}"',
-                f'entrypoint = "{entrypoint}"',
-                f'target = "{options.target}"',
-                f'include_dependencies = {str(options.include_dependencies).lower()}',
-                "",
-            ]
-        ),
-        encoding="utf-8",
+    options: BuildOptions
+    runtime: "RuntimePreparationResult"
+    output_dir: Path | str
+    executable_name: str
+    hidden_imports: Sequence[str] = field(default_factory=tuple)
+    additional_datas: Sequence[tuple[Path | str, str]] = field(default_factory=tuple)
+
+
+def write_spec(build_context: SpecBuildContext) -> Path:
+    """Escribe un archivo ``.spec`` de PyInstaller para un runtime Cobra preparado.
+
+    El spec referencia el entrypoint Python generado por ``prepare_runtime`` e
+    incluye automáticamente las carpetas de runtime Cobra, corelibs, paquetes
+    CobraHub/locales, assets, configuración, documentación y recursos auxiliares.
+    No ejecuta PyInstaller; solo produce el archivo de configuración.
+    """
+
+    context = build_context
+    options = context.options.normalized()
+    runtime = context.runtime
+    output_dir = Path(context.output_dir).expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    name = _python_literal(context.executable_name)
+    spec_path = output_dir / f"{context.executable_name}.spec"
+    mode = BuildMode.from_value(options.mode)
+
+    datas = _collect_datas(runtime, context.additional_datas)
+    hidden_imports = _collect_hidden_imports(context.hidden_imports)
+    icon_line = f"    icon={_python_literal(str(options.icon))},\n" if options.icon else ""
+
+    analysis = _analysis_block(runtime, options, datas, hidden_imports)
+    if mode is BuildMode.ONEFILE:
+        body = _onefile_body(analysis, name, icon_line)
+    else:
+        body = _onedir_body(analysis, name, icon_line)
+
+    spec_path.write_text(body, encoding="utf-8")
+    return spec_path
+
+
+def _analysis_block(
+    runtime: "RuntimePreparationResult",
+    options: BuildOptions,
+    datas: tuple[tuple[str, str], ...],
+    hidden_imports: tuple[str, ...],
+) -> str:
+    return (
+        "# -*- mode: python ; coding: utf-8 -*-\n"
+        "# Spec generado automáticamente por cobra_installer.\n\n"
+        f"block_cipher = None\n\n"
+        "a = Analysis(\n"
+        f"    [{_python_literal(str(runtime.entrypoint))}],\n"
+        f"    pathex={[str(runtime.build_dir), str(options.project_root)]!r},\n"
+        "    binaries=[],\n"
+        f"    datas={datas!r},\n"
+        f"    hiddenimports={hidden_imports!r},\n"
+        "    hookspath=[],\n"
+        "    hooksconfig={},\n"
+        "    runtime_hooks=[],\n"
+        "    excludes=[],\n"
+        "    win_no_prefer_redirects=False,\n"
+        "    win_private_assemblies=False,\n"
+        "    cipher=block_cipher,\n"
+        "    noarchive=False,\n"
+        ")\n"
+        "pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)\n"
     )
-    return path
+
+
+def _onefile_body(analysis: str, name: str, icon_line: str) -> str:
+    return analysis + (
+        "exe = EXE(\n"
+        "    pyz,\n"
+        "    a.scripts,\n"
+        "    a.binaries,\n"
+        "    a.zipfiles,\n"
+        "    a.datas,\n"
+        "    [],\n"
+        f"    name={name},\n"
+        "    debug=False,\n"
+        "    bootloader_ignore_signals=False,\n"
+        "    strip=False,\n"
+        "    upx=True,\n"
+        "    upx_exclude=[],\n"
+        "    runtime_tmpdir=None,\n"
+        "    console=True,\n"
+        f"{icon_line}"
+        ")\n"
+    )
+
+
+def _onedir_body(analysis: str, name: str, icon_line: str) -> str:
+    return analysis + (
+        "exe = EXE(\n"
+        "    pyz,\n"
+        "    a.scripts,\n"
+        "    [],\n"
+        f"    name={name},\n"
+        "    debug=False,\n"
+        "    bootloader_ignore_signals=False,\n"
+        "    strip=False,\n"
+        "    upx=True,\n"
+        "    console=True,\n"
+        "    exclude_binaries=True,\n"
+        f"{icon_line}"
+        ")\n"
+        "coll = COLLECT(\n"
+        "    exe,\n"
+        "    a.binaries,\n"
+        "    a.zipfiles,\n"
+        "    a.datas,\n"
+        "    strip=False,\n"
+        "    upx=True,\n"
+        f"    name={name},\n"
+        ")\n"
+    )
+
+
+def _collect_datas(
+    runtime: "RuntimePreparationResult",
+    additional_datas: Sequence[tuple[Path | str, str]],
+) -> tuple[tuple[str, str], ...]:
+    candidates: list[tuple[Path, str]] = [
+        (runtime.runtime_dir, "runtime/pcobra"),
+        (runtime.corelibs_dir, "runtime/pcobra/corelibs"),
+        (runtime.standard_library_dir, "runtime/pcobra/standard_library"),
+        (runtime.cobra_dir, "runtime/pcobra/cobra"),
+        (runtime.packages_dir, "packages"),
+        (runtime.assets_dir, "assets"),
+        (runtime.config_dir, "config"),
+        (runtime.documentation_dir, "docs"),
+        (runtime.auxiliary_dir, "resources"),
+    ]
+    candidates.extend((Path(source), destination) for source, destination in additional_datas)
+
+    datas: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for source, destination in candidates:
+        if not source.exists():
+            continue
+        item = (str(source), destination)
+        if item in seen:
+            continue
+        seen.add(item)
+        datas.append(item)
+    return tuple(datas)
+
+
+def _collect_hidden_imports(extra_hidden_imports: Sequence[str]) -> tuple[str, ...]:
+    defaults = (
+        "pcobra",
+        "pcobra.core",
+        "pcobra.corelibs",
+        "pcobra.standard_library",
+        "pcobra.cobra.cli.cli",
+        "pcobra.cobra.transpilers.transpiler.to_python",
+    )
+    return tuple(dict.fromkeys((*defaults, *extra_hidden_imports)))
+
+
+def _python_literal(value: str) -> str:
+    return repr(value)

--- a/tests/unit/test_cobra_installer_spec_writer.py
+++ b/tests/unit/test_cobra_installer_spec_writer.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pcobra.cobra_installer import BuildMode, BuildOptions
+from pcobra.cobra_installer.runtime_builder import RuntimePreparationResult
+from pcobra.cobra_installer.spec_writer import SpecBuildContext, write_spec
+
+
+def _runtime_tree(tmp_path: Path) -> RuntimePreparationResult:
+    build_dir = tmp_path / "build"
+    runtime_dir = build_dir / "runtime" / "pcobra"
+    corelibs_dir = runtime_dir / "corelibs"
+    standard_library_dir = runtime_dir / "standard_library"
+    cobra_dir = runtime_dir / "cobra"
+    packages_dir = build_dir / "packages"
+    assets_dir = build_dir / "assets"
+    config_dir = build_dir / "config"
+    documentation_dir = build_dir / "docs"
+    auxiliary_dir = build_dir / "resources"
+    entrypoint = build_dir / "pyinstaller_entrypoint.py"
+    for path in (
+        corelibs_dir,
+        standard_library_dir,
+        cobra_dir,
+        packages_dir,
+        assets_dir,
+        config_dir,
+        documentation_dir,
+        auxiliary_dir,
+    ):
+        path.mkdir(parents=True, exist_ok=True)
+    entrypoint.write_text("print('entrypoint')\n", encoding="utf-8")
+    return RuntimePreparationResult(
+        build_dir=build_dir,
+        runtime_dir=runtime_dir,
+        corelibs_dir=corelibs_dir,
+        standard_library_dir=standard_library_dir,
+        cobra_dir=cobra_dir,
+        packages_dir=packages_dir,
+        assets_dir=assets_dir,
+        config_dir=config_dir,
+        documentation_dir=documentation_dir,
+        auxiliary_dir=auxiliary_dir,
+        entrypoint=entrypoint,
+    )
+
+
+def test_write_spec_onedir_incluye_runtime_recursos_imports_y_nombre(tmp_path: Path) -> None:
+    runtime = _runtime_tree(tmp_path)
+    extra_data = tmp_path / "extra-data"
+    extra_data.mkdir()
+
+    spec_path = write_spec(
+        SpecBuildContext(
+            options=BuildOptions(project_root=tmp_path, mode=BuildMode.ONEDIR),
+            runtime=runtime,
+            output_dir=tmp_path / "dist",
+            executable_name="demo_app",
+            hidden_imports=("cobrahub.paquete",),
+            additional_datas=((extra_data, "extras"),),
+        )
+    )
+
+    content = spec_path.read_text(encoding="utf-8")
+    assert spec_path == tmp_path / "dist" / "demo_app.spec"
+    assert str(runtime.entrypoint) in content
+    assert "('" in content and "runtime/pcobra" in content
+    assert "runtime/pcobra/corelibs" in content
+    assert "packages" in content
+    assert "assets" in content
+    assert "config" in content
+    assert "docs" in content
+    assert "resources" in content
+    assert "extras" in content
+    assert "pcobra.cobra.cli.cli" in content
+    assert "cobrahub.paquete" in content
+    assert "exclude_binaries=True" in content
+    assert "coll = COLLECT" in content
+    assert "name='demo_app'" in content
+
+
+def test_write_spec_onefile_incluye_icono_y_sin_collect(tmp_path: Path) -> None:
+    runtime = _runtime_tree(tmp_path)
+    icon = tmp_path / "icon.ico"
+    icon.write_bytes(b"ico")
+
+    spec_path = write_spec(
+        SpecBuildContext(
+            options=BuildOptions(project_root=tmp_path, mode=BuildMode.ONEFILE, icon=icon),
+            runtime=runtime,
+            output_dir=tmp_path / "dist",
+            executable_name="demo_onefile",
+        )
+    )
+
+    content = spec_path.read_text(encoding="utf-8")
+    assert spec_path.name == "demo_onefile.spec"
+    assert "a.binaries" in content
+    assert "a.datas" in content
+    assert "coll = COLLECT" not in content
+    assert f"icon='{icon}'" in content
+    assert "name='demo_onefile'" in content


### PR DESCRIPTION
### Motivation
- Añadir la capacidad de generar un archivo `.spec` de PyInstaller a partir del runtime preparado por el instalador Cobra para permitir empaquetado reproducible sin ejecutar PyInstaller.
- Centralizar la información del build (entrypoint generado, runtime Cobra, paquetes, assets, configuración y metadatos) en un contexto que pueda validarse y probarse de forma unitaria.

### Description
- Se introduce la clase de contexto `SpecBuildContext` y la función `write_spec(build_context) -> Path` en `src/pcobra/cobra_installer/spec_writer.py`, que genera un `.spec` completo para PyInstaller incluyendo `Analysis`, `PYZ`, `EXE` y `COLLECT` según el modo (`onefile`/`onedir`).
- `write_spec` incluye automáticamente el entrypoint Python generado, runtime Cobra, `corelibs`, `standard_library`, paquetes (CobraHub/locales/locales), `assets`, `config`, `documentation`, recursos auxiliares, imports ocultos por defecto, entradas adicionales de `datas` y el `icon` opcional.
- Se modifica `build_project` en `src/pcobra/cobra_installer/runtime_builder.py` para preparar el runtime con `prepare_runtime(...)` y llamar a `write_spec(SpecBuildContext(...))` usando el runtime generado.
- Se exportan `SpecBuildContext` y `write_spec` en la API pública (`src/pcobra/cobra_installer/__init__.py`) y se añaden tests unitarios en `tests/unit/test_cobra_installer_spec_writer.py` que validan el contenido generado del `.spec` en modos `onedir` y `onefile` sin invocar PyInstaller.

### Testing
- Se ejecutó `python -m pytest tests/unit/test_cobra_installer_spec_writer.py` y los tests unitarios de la nueva suite pasaron (`2 passed`).
- Se ejecutó `python -m pytest tests/unit/test_cobra_installer_runtime_builder.py tests/unit/test_cobra_installer_models.py tests/unit/test_cobra_installer_spec_writer.py` y todas las pruebas relacionadas con el instalador pasaron (`27 passed` en `tests/unit/test_cobra_installer_*.py`).
- Se verificó la compilación estática con `python -m compileall` sobre los módulos afectados y no se detectaron errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4601e193a083279013f936c9b4ac81)