### PR TITLE
Implementar PyInstaller runner

### DIFF
--- a/src/pcobra/cobra_installer/pyinstaller_runner.py
+++ b/src/pcobra/cobra_installer/pyinstaller_runner.py
@@ -1,9 +1,291 @@
-"""Módulo inicial del instalador Cobra.
+"""Ejecución controlada de PyInstaller para CobraInstaller.
 
-Este archivo reserva una responsabilidad concreta del flujo de construcción para
-mantener la lógica fuera del IDLE a medida que el instalador evolucione.
+El módulo encapsula toda la interacción con PyInstaller para que las capas de
+CLI/IDLE no tengan que pedir al usuario que invoque ``pyinstaller`` a mano.
+Todas las llamadas a procesos pasan por ``subprocess`` y aceptan fábricas
+inyectables, lo que permite mockearlas por completo en tests.
 """
 
 from __future__ import annotations
 
-__all__: list[str] = []
+import queue
+import shutil
+import subprocess
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
+
+from .project import CobraInstallerError
+
+__all__ = [
+    "PyInstallerInfo",
+    "PyInstallerRunResult",
+    "detect_pyinstaller",
+    "install_pyinstaller_if_allowed",
+    "run_pyinstaller",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PyInstallerInfo:
+    """Información detectada de PyInstaller."""
+
+    available: bool
+    version: str | None = None
+    executable: str | None = None
+    command: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class PyInstallerRunResult:
+    """Resultado de una ejecución de PyInstaller."""
+
+    success: bool
+    version: str
+    returncode: int
+    command: tuple[str, ...]
+    stdout: str = ""
+    stderr: str = ""
+
+
+def detect_pyinstaller(
+    *,
+    run_factory: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    which: Callable[[str], str | None] = shutil.which,
+) -> PyInstallerInfo:
+    """Comprueba si PyInstaller está disponible y devuelve su versión.
+
+    Primero intenta ejecutar ``python -m PyInstaller --version`` para no depender
+    de que el binario ``pyinstaller`` esté en ``PATH``. Si falla, prueba el
+    ejecutable localizado por ``shutil.which``. Los errores se convierten en un
+    resultado ``available=False`` para que el llamador decida si puede instalar.
+    """
+
+    commands: list[tuple[str, ...]] = [(sys.executable, "-m", "PyInstaller", "--version")]
+    executable = which("pyinstaller")
+    if executable:
+        commands.append((executable, "--version"))
+
+    for command in commands:
+        try:
+            completed = run_factory(
+                list(command),
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except (FileNotFoundError, OSError):
+            continue
+        if completed.returncode == 0:
+            version = _first_non_empty_line(completed.stdout, completed.stderr)
+            if version:
+                return PyInstallerInfo(
+                    available=True,
+                    version=version,
+                    executable=executable,
+                    command=command,
+                )
+    return PyInstallerInfo(available=False, executable=executable)
+
+
+def install_pyinstaller_if_allowed(
+    options: Any,
+    logger: Any | None = None,
+    *,
+    run_factory: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> PyInstallerInfo:
+    """Instala PyInstaller solo cuando las opciones lo permiten.
+
+    La instalación se habilita con cualquiera de estos atributos booleanos en
+    ``options``: ``install_pyinstaller``, ``allow_pyinstaller_install`` o
+    ``auto_install_pyinstaller``. Si PyInstaller ya existe no instala nada.
+    """
+
+    detected = detect_pyinstaller(run_factory=run_factory)
+    if detected.available:
+        return detected
+
+    if not _option_enabled(
+        options,
+        "install_pyinstaller",
+        "allow_pyinstaller_install",
+        "auto_install_pyinstaller",
+    ):
+        raise CobraInstallerError(
+            "PyInstaller no está instalado. Habilita la instalación automática "
+            "en las opciones del build o instala la dependencia en el entorno."
+        )
+
+    _log(logger, "info", "PyInstaller no está disponible; instalando con pip...")
+    command = [sys.executable, "-m", "pip", "install", "pyinstaller"]
+    try:
+        completed = run_factory(command, check=False, capture_output=True, text=True)
+    except (FileNotFoundError, OSError) as exc:
+        raise CobraInstallerError(
+            f"No se pudo ejecutar pip para instalar PyInstaller: {exc}"
+        ) from exc
+
+    if completed.returncode != 0:
+        detail = _translate_pyinstaller_error(completed.stderr or completed.stdout)
+        raise CobraInstallerError(f"No se pudo instalar PyInstaller: {detail}")
+
+    detected = detect_pyinstaller(run_factory=run_factory)
+    if not detected.available:
+        raise CobraInstallerError(
+            "PyInstaller se instaló, pero no se pudo verificar su versión."
+        )
+    return detected
+
+
+def run_pyinstaller(
+    spec_path: str | Path,
+    options: Any,
+    logger: Any,
+    *,
+    popen_factory: Callable[..., subprocess.Popen[str]] = subprocess.Popen,
+    run_factory: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> PyInstallerRunResult:
+    """Ejecuta PyInstaller sobre ``spec_path`` con salida en tiempo real."""
+
+    spec = Path(spec_path).expanduser().resolve()
+    if not spec.is_file():
+        raise CobraInstallerError(f"El archivo spec de PyInstaller no existe: {spec}")
+
+    info = install_pyinstaller_if_allowed(options, logger, run_factory=run_factory)
+    version = info.version or "desconocida"
+    command = [sys.executable, "-m", "PyInstaller", str(spec), *_extra_args(options)]
+    _log(logger, "info", f"Ejecutando PyInstaller {version}: {' '.join(command)}")
+
+    try:
+        process = popen_factory(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        raise CobraInstallerError(f"No se pudo iniciar PyInstaller: {exc}") from exc
+
+    stdout, stderr = _stream_process_output(process, logger)
+    returncode = process.wait()
+    if returncode != 0:
+        message = _translate_pyinstaller_error(stderr or stdout)
+        raise CobraInstallerError(f"PyInstaller falló con código {returncode}: {message}")
+
+    return PyInstallerRunResult(
+        success=True,
+        version=version,
+        returncode=returncode,
+        command=tuple(command),
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _stream_process_output(process: subprocess.Popen[str], logger: Any) -> tuple[str, str]:
+    events: queue.Queue[tuple[str, str]] = queue.Queue()
+
+    def reader(name: str, stream: Iterable[str] | None) -> None:
+        if stream is None:
+            return
+        for line in stream:
+            events.put((name, line))
+
+    threads = [
+        threading.Thread(target=reader, args=("stdout", process.stdout), daemon=True),
+        threading.Thread(target=reader, args=("stderr", process.stderr), daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+    while any(thread.is_alive() for thread in threads):
+        _drain_events(events, logger, stdout_parts, stderr_parts)
+    for thread in threads:
+        thread.join()
+    _drain_events(events, logger, stdout_parts, stderr_parts)
+    return "".join(stdout_parts), "".join(stderr_parts)
+
+
+def _drain_events(
+    events: queue.Queue[tuple[str, str]],
+    logger: Any,
+    stdout_parts: list[str],
+    stderr_parts: list[str],
+) -> None:
+    while True:
+        try:
+            name, line = events.get_nowait()
+        except queue.Empty:
+            return
+        if name == "stdout":
+            stdout_parts.append(line)
+            _log(logger, "info", line.rstrip("\n"))
+        else:
+            stderr_parts.append(line)
+            _log(logger, "error", line.rstrip("\n"))
+
+
+def _translate_pyinstaller_error(output: str) -> str:
+    text = output.strip()
+    lowered = text.lower()
+    if not text:
+        return "PyInstaller no devolvió detalles del error."
+    if "no module named pyinstaller" in lowered:
+        return "PyInstaller no está instalado o no es importable en este intérprete de Python."
+    if "permission denied" in lowered or "access is denied" in lowered:
+        return (
+            "Permiso denegado al leer/escribir archivos del build. "
+            "Revisa permisos y antivirus."
+        )
+    if "file not found" in lowered or "no such file or directory" in lowered:
+        return "Falta un archivo requerido por el spec o por los recursos del proyecto."
+    if "syntaxerror" in lowered:
+        return "PyInstaller encontró un error de sintaxis en el spec o en el código incluido."
+    if "recursion" in lowered and "maximum" in lowered:
+        return (
+            "PyInstaller agotó el límite de recursión; revisa imports circulares "
+            "o aumenta el límite en el spec."
+        )
+    if "failed to execute script" in lowered:
+        return (
+            "El ejecutable generado no pudo iniciar el script empaquetado. "
+            "Revisa imports y datos incluidos."
+        )
+    return text
+
+
+def _extra_args(options: Any) -> tuple[str, ...]:
+    raw = getattr(options, "extra_args", ()) if options is not None else ()
+    if isinstance(raw, str):
+        return (raw,)
+    return tuple(str(value) for value in raw)
+
+
+def _option_enabled(options: Any, *names: str) -> bool:
+    if options is None:
+        return False
+    if isinstance(options, Mapping):
+        return any(bool(options.get(name)) for name in names)
+    return any(bool(getattr(options, name, False)) for name in names)
+
+
+def _first_non_empty_line(*chunks: str | None) -> str | None:
+    for chunk in chunks:
+        for line in (chunk or "").splitlines():
+            stripped = line.strip()
+            if stripped:
+                return stripped
+    return None
+
+
+def _log(logger: Any | None, level: str, message: str) -> None:
+    if logger is None:
+        return
+    method = getattr(logger, level, None) or getattr(logger, "write", None)
+    if callable(method):
+        method(message)

--- a/tests/unit/test_pyinstaller_runner.py
+++ b/tests/unit/test_pyinstaller_runner.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from pcobra.cobra_installer.project import CobraInstallerError
+from pcobra.cobra_installer.pyinstaller_runner import (
+    detect_pyinstaller,
+    install_pyinstaller_if_allowed,
+    run_pyinstaller,
+)
+
+
+class Logger:
+    def __init__(self) -> None:
+        self.infos: list[str] = []
+        self.errors: list[str] = []
+
+    def info(self, message: str) -> None:
+        self.infos.append(message)
+
+    def error(self, message: str) -> None:
+        self.errors.append(message)
+
+
+class FakeProcess:
+    def __init__(self, returncode: int = 0) -> None:
+        self.stdout = iter(["paso 1\n", "paso 2\n"])
+        self.stderr = iter(["aviso\n"])
+        self._returncode = returncode
+
+    def wait(self) -> int:
+        return self._returncode
+
+
+def completed(args: list[str], returncode: int = 0, stdout: str = "6.14.0\n", stderr: str = ""):
+    return subprocess.CompletedProcess(args=args, returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_detect_pyinstaller_usa_python_module_y_devuelve_version() -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return completed(args, stdout="6.14.0\n")
+
+    info = detect_pyinstaller(run_factory=fake_run, which=lambda name: None)
+
+    assert info.available is True
+    assert info.version == "6.14.0"
+    assert calls == [[info.command[0], "-m", "PyInstaller", "--version"]]
+
+
+def test_install_pyinstaller_rechaza_instalacion_no_habilitada() -> None:
+    def fake_run(args, **kwargs):
+        return completed(args, returncode=1, stdout="", stderr="No module named PyInstaller")
+
+    with pytest.raises(CobraInstallerError, match="Habilita la instalación automática"):
+        install_pyinstaller_if_allowed(SimpleNamespace(), run_factory=fake_run)
+
+
+def test_install_pyinstaller_si_opcion_lo_permite() -> None:
+    calls: list[list[str]] = []
+    installed = False
+
+    def fake_run(args, **kwargs):
+        nonlocal installed
+        calls.append(args)
+        if args[1:3] == ["-m", "PyInstaller"] and not installed:
+            return completed(args, returncode=1, stdout="", stderr="No module named PyInstaller")
+        if args[1:4] == ["-m", "pip", "install"]:
+            installed = True
+            return completed(args, stdout="installed\n")
+        return completed(args, stdout="6.14.0\n")
+
+    info = install_pyinstaller_if_allowed(
+        SimpleNamespace(install_pyinstaller=True), run_factory=fake_run
+    )
+
+    assert info.available is True
+    assert info.version == "6.14.0"
+    assert any(call[1:4] == ["-m", "pip", "install"] for call in calls)
+
+
+def test_run_pyinstaller_streaming_y_resultado(tmp_path: Path) -> None:
+    spec = tmp_path / "app.spec"
+    spec.write_text("# spec", encoding="utf-8")
+    logger = Logger()
+
+    def fake_run(args, **kwargs):
+        return completed(args, stdout="6.14.0\n")
+
+    popen_calls: list[list[str]] = []
+
+    def fake_popen(args, **kwargs):
+        popen_calls.append(args)
+        assert kwargs["stdout"] == subprocess.PIPE
+        assert kwargs["stderr"] == subprocess.PIPE
+        return FakeProcess()
+
+    result = run_pyinstaller(
+        spec,
+        SimpleNamespace(extra_args=("--clean",)),
+        logger,
+        run_factory=fake_run,
+        popen_factory=fake_popen,
+    )
+
+    assert result.success is True
+    assert result.version == "6.14.0"
+    assert result.stdout == "paso 1\npaso 2\n"
+    assert result.stderr == "aviso\n"
+    assert popen_calls[0][-2:] == [str(spec.resolve()), "--clean"]
+    assert "paso 1" in logger.infos
+    assert "aviso" in logger.errors
+
+
+def test_run_pyinstaller_traduce_errores_comunes(tmp_path: Path) -> None:
+    spec = tmp_path / "app.spec"
+    spec.write_text("# spec", encoding="utf-8")
+
+    def fake_run(args, **kwargs):
+        return completed(args, stdout="6.14.0\n")
+
+    class FailingProcess(FakeProcess):
+        def __init__(self) -> None:
+            super().__init__(returncode=1)
+            self.stdout = iter([])
+            self.stderr = iter(["Permission denied: dist/app\n"])
+
+    with pytest.raises(CobraInstallerError, match="Permiso denegado"):
+        run_pyinstaller(
+            spec,
+            SimpleNamespace(),
+            Logger(),
+            run_factory=fake_run,
+            popen_factory=lambda args, **kwargs: FailingProcess(),
+        )


### PR DESCRIPTION
### Motivation

- Encapsular toda la interacción con PyInstaller para que la CLI/IDLE no exijan al usuario ejecutar `pyinstaller` manualmente. 
- Permitir instalación automática opcional de `pyinstaller` controlada por las opciones de build. 
- Proveer ejecución controlada que capture y emita `stdout`/`stderr` en tiempo real y traduzca errores comunes a mensajes comprensibles. 
- Hacer que las llamadas a procesos sean completamente mockeables en tests mediante fábricas inyectables. 

### Description

- Se implementaron las funciones públicas `detect_pyinstaller()`, `install_pyinstaller_if_allowed()` y `run_pyinstaller()` en `src/pcobra/cobra_installer/pyinstaller_runner.py`. 
- Se añadieron los dataclasses `PyInstallerInfo` y `PyInstallerRunResult` para describir disponibilidad, versión, comando ejecutado y salidas capturadas. 
- `detect_pyinstaller()` intenta `python -m PyInstaller --version` y hace fallback al ejecutable `pyinstaller`, usando un `run_factory` inyectable para permitir mocks. 
- `install_pyinstaller_if_allowed()` instala `pyinstaller` vía `pip` solo si las opciones habilitan atributos como `install_pyinstaller`, `allow_pyinstaller_install` o `auto_install_pyinstaller`, y vuelve a verificar la versión tras la instalación. 
- `run_pyinstaller()` valida el `.spec`, asegura/instala PyInstaller si procede, ejecuta PyInstaller mediante un `popen_factory` inyectable, streamea `stdout`/`stderr` en tiempo real a un `logger` y devuelve un `PyInstallerRunResult`; además traduce errores comunes (permiso denegado, archivo no encontrado, errores de sintaxis, módulo no importable, etc.). 
- La ejecución en tiempo real está implementada con hilos que leen `stdout`/`stderr` y usan colas para juntar y enviar las líneas al `logger`, conservando a la vez la salida completa para retornarla. 
- Se añadieron tests unitarios nuevos en `tests/unit/test_pyinstaller_runner.py` que mockean completamente `subprocess.run` y `subprocess.Popen` para verificar detección, instalación condicional, streaming y traducción de errores. 

### Testing

- Se verificó la compilación del módulo con `python -m py_compile src/pcobra/cobra_installer/pyinstaller_runner.py` y la verificación fue exitosa. 
- Se ejecutaron los tests unitarios `pytest -q tests/unit/test_pyinstaller_runner.py` y todos los tests pasaron (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4607b54b048327b0f8bc8bdc1919f7)