### PR TITLE
Añadir detección/normalización/validación de targets y esqueleto de Builder en cobra_installer

### DIFF
--- a/src/pcobra/cobra_installer/__init__.py
+++ b/src/pcobra/cobra_installer/__init__.py
@@ -19,7 +19,17 @@ from .project import (
     discover_project,
     find_entrypoint,
 )
-from .targets import BuildMode, TargetOS
+from .targets import (
+    BuildMode,
+    Builder,
+    BuilderConfig,
+    ExpectedArtifact,
+    TargetOS,
+    detect_host_os,
+    expected_artifact_for,
+    normalize_target,
+    validate_target,
+)
 from .transpile import TranspileResult, transpile_project
 from .validator import ValidationErrorDetail, ValidationResult, validate_project
 from .runtime_builder import (
@@ -32,6 +42,8 @@ from .runtime_builder import (
 __all__ = [
     "BuildManifest",
     "BuildMode",
+    "Builder",
+    "BuilderConfig",
     "BuildOptions",
     "BuildResult",
     "CobraProject",
@@ -41,7 +53,11 @@ __all__ = [
     "discover_project",
     "find_entrypoint",
     "DependencyInfo",
+    "ExpectedArtifact",
     "TargetOS",
+    "detect_host_os",
+    "expected_artifact_for",
+    "normalize_target",
     "TranspileResult",
     "transpile_project",
     "ValidationErrorDetail",
@@ -50,6 +66,7 @@ __all__ = [
     "SpecBuildContext",
     "build_project",
     "validate_project",
+    "validate_target",
     "package_current_project",
     "prepare_runtime",
     "write_spec",

--- a/src/pcobra/cobra_installer/cli.py
+++ b/src/pcobra/cobra_installer/cli.py
@@ -15,6 +15,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--output-dir")
     parser.add_argument("--name")
     parser.add_argument("--target", default="current")
+    parser.add_argument(
+        "--builder",
+        choices=("local", "docker", "vm", "ci", "remote"),
+        default="local",
+        help="Builder futuro para aislar builds no nativos; solo local está implementado todavía.",
+    )
     return parser
 
 
@@ -27,6 +33,7 @@ def main(argv: list[str] | None = None) -> int:
             output_dir=args.output_dir,
             name=args.name,
             target=args.target,
+            builder=args.builder,
         )
     except CobraInstallerError as exc:
         print(f"Error: {exc}")

--- a/src/pcobra/cobra_installer/project.py
+++ b/src/pcobra/cobra_installer/project.py
@@ -12,7 +12,7 @@ try:  # pragma: no cover - Python < 3.11 compatibility path
 except ModuleNotFoundError:  # pragma: no cover
     tomllib = None  # type: ignore[assignment]
 
-from .targets import BuildMode, TargetOS
+from .targets import BuildMode, Builder, BuilderConfig, TargetOS, normalize_target
 
 
 class CobraInstallerError(RuntimeError):
@@ -37,8 +37,12 @@ class ProjectResources:
             assets=tuple(_normalize_path(path, root) for path in self.assets),
             config_dirs=tuple(_normalize_path(path, root) for path in self.config_dirs),
             co_packages=tuple(_normalize_path(path, root) for path in self.co_packages),
-            documentation=tuple(_normalize_path(path, root) for path in self.documentation),
-            auxiliary_resources=tuple(_normalize_path(path, root) for path in self.auxiliary_resources),
+            documentation=tuple(
+                _normalize_path(path, root) for path in self.documentation
+            ),
+            auxiliary_resources=tuple(
+                _normalize_path(path, root) for path in self.auxiliary_resources
+            ),
         )
 
 
@@ -64,14 +68,22 @@ class CobraProject:
         return CobraProject(
             project_root=root,
             entrypoint=_normalize_optional_path(self.entrypoint, root),
-            cobra_toml=_normalize_optional_path(self.cobra_toml or root / "cobra.toml", root),
-            cobra_lock=_normalize_optional_path(self.cobra_lock or root / "cobra.lock", root),
+            cobra_toml=_normalize_optional_path(
+                self.cobra_toml or root / "cobra.toml", root
+            ),
+            cobra_lock=_normalize_optional_path(
+                self.cobra_lock or root / "cobra.lock", root
+            ),
             assets=tuple(_normalize_path(path, root) for path in self.assets),
             config=dict(self.config),
             co_packages=tuple(_normalize_path(path, root) for path in self.co_packages),
-            documentation=tuple(_normalize_path(path, root) for path in self.documentation),
+            documentation=tuple(
+                _normalize_path(path, root) for path in self.documentation
+            ),
             config_dirs=tuple(_normalize_path(path, root) for path in self.config_dirs),
-            auxiliary_resources=tuple(_normalize_path(path, root) for path in self.auxiliary_resources),
+            auxiliary_resources=tuple(
+                _normalize_path(path, root) for path in self.auxiliary_resources
+            ),
         )
 
 
@@ -85,6 +97,8 @@ class BuildOptions:
     name: str | None = None
     target: str | TargetOS = "current"
     architecture: str = "native"
+    builder: Builder | str = Builder.LOCAL
+    builder_config: BuilderConfig | None = None
     mode: BuildMode | str = BuildMode.ONEDIR
     temp_dir: Path | str | None = None
     dist_dir: Path | str | None = None
@@ -100,15 +114,20 @@ class BuildOptions:
 
         root = Path(self.project_root).expanduser().resolve()
         entrypoint = _normalize_optional_path(self.entrypoint, root)
-        output_dir = _normalize_optional_path(self.output_dir or self.dist_dir or root / "dist", root)
+        output_dir = _normalize_optional_path(
+            self.output_dir or self.dist_dir or root / "dist", root
+        )
         temp_dir = _normalize_optional_path(self.temp_dir or root / "build", root)
         return BuildOptions(
             project_root=root,
             entrypoint=entrypoint,
             output_dir=output_dir,
             name=self.name,
-            target=self.target,
+            target=normalize_target(self.target),
             architecture=self.architecture,
+            builder=Builder.from_value(self.builder),
+            builder_config=self.builder_config
+            or BuilderConfig.from_value(self.builder),
             mode=BuildMode.from_value(self.mode),
             temp_dir=temp_dir,
             dist_dir=output_dir,
@@ -131,6 +150,8 @@ class BuildResult:
     output_dir: Path | None = None
     target: str | TargetOS = "current"
     architecture: str = "native"
+    builder: Builder | str = Builder.LOCAL
+    builder_config: BuilderConfig | None = None
     mode: BuildMode = BuildMode.ONEDIR
     executable_name: str | None = None
     temp_dir: Path | None = None
@@ -201,7 +222,9 @@ def collect_project_resources(project_root: Path) -> ProjectResources:
 
     root = Path(project_root).expanduser().resolve()
     if not root.is_dir():
-        raise CobraInstallerError(f"La raíz del proyecto no existe o no es un directorio: {root}")
+        raise CobraInstallerError(
+            f"La raíz del proyecto no existe o no es un directorio: {root}"
+        )
 
     assets: list[Path] = []
     config_dirs: list[Path] = []
@@ -242,7 +265,11 @@ def _discover_project_root(path: Path) -> Path:
         raise CobraInstallerError(f"La ruta del proyecto no existe: {candidate}")
 
     for current in (start, *start.parents):
-        if (current / "main.cobra").is_file() or (current / "cobra.toml").is_file() or (current / "cobra.lock").is_file():
+        if (
+            (current / "main.cobra").is_file()
+            or (current / "cobra.toml").is_file()
+            or (current / "cobra.lock").is_file()
+        ):
             return current
     return start
 
@@ -258,7 +285,9 @@ def _configured_entrypoints(root: Path) -> list[Path]:
             continue
         seen.add(path)
         if not path.is_file():
-            raise CobraInstallerError(f"El entrypoint configurado en cobra.toml no existe: {path}")
+            raise CobraInstallerError(
+                f"El entrypoint configurado en cobra.toml no existe: {path}"
+            )
         resolved.append(path)
     return resolved
 
@@ -267,7 +296,9 @@ def _read_cobra_toml(path: Path) -> dict[str, object]:
     if not path.is_file():
         return {}
     if tomllib is None:
-        raise CobraInstallerError("No se puede leer cobra.toml: tomllib no está disponible en esta versión de Python.")
+        raise CobraInstallerError(
+            "No se puede leer cobra.toml: tomllib no está disponible en esta versión de Python."
+        )
     try:
         return tomllib.loads(path.read_text(encoding="utf-8"))
     except tomllib.TOMLDecodeError as exc:  # type: ignore[union-attr]
@@ -315,5 +346,24 @@ _IGNORED_DIRS = {
     "venv",
 }
 _DOCUMENTATION_SUFFIXES = {".md", ".rst", ".txt"}
-_AUXILIARY_SUFFIXES = {".json", ".yaml", ".yml", ".ini", ".cfg", ".env", ".ico", ".png", ".jpg", ".jpeg", ".svg"}
-_AUXILIARY_FILE_NAMES = {"cobra.toml", "cobra.lock", "pyproject.toml", "requirements.txt", "LICENSE", "NOTICE"}
+_AUXILIARY_SUFFIXES = {
+    ".json",
+    ".yaml",
+    ".yml",
+    ".ini",
+    ".cfg",
+    ".env",
+    ".ico",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".svg",
+}
+_AUXILIARY_FILE_NAMES = {
+    "cobra.toml",
+    "cobra.lock",
+    "pyproject.toml",
+    "requirements.txt",
+    "LICENSE",
+    "NOTICE",
+}

--- a/src/pcobra/cobra_installer/runtime_builder.py
+++ b/src/pcobra/cobra_installer/runtime_builder.py
@@ -9,9 +9,18 @@ from typing import Mapping, Sequence
 
 import pcobra
 
-from .dependency_resolver import DependencyResolutionResult, resolve_project_dependencies
+from .dependency_resolver import (
+    DependencyResolutionResult,
+    resolve_project_dependencies,
+)
 from .manifest import create_manifest
-from .project import BuildOptions, BuildResult, CobraInstallerError, CobraProject, discover_project
+from .project import (
+    BuildOptions,
+    BuildResult,
+    CobraInstallerError,
+    CobraProject,
+    discover_project,
+)
 from .spec_writer import SpecBuildContext, write_spec
 from .validator import discover_entrypoint, validate_build_options
 
@@ -95,7 +104,9 @@ def prepare_runtime(
 
     copied_hub_packages = _copy_hub_packages(dependency_resolution, packages_dir)
     copied_explicit_packages = _copy_dependency_paths(dependencies, packages_dir, root)
-    copied_project_packages = _copy_many(normalized_project.co_packages, packages_dir, root)
+    copied_project_packages = _copy_many(
+        normalized_project.co_packages, packages_dir, root
+    )
     copied_assets = _copy_many(
         (*normalized_project.assets, *normalized_options.assets), assets_dir, root
     )
@@ -130,7 +141,11 @@ def prepare_runtime(
         entrypoint=entrypoint,
         copied_resources={
             "runtime": runtime_copies,
-            "packages": (*copied_hub_packages, *copied_explicit_packages, *copied_project_packages),
+            "packages": (
+                *copied_hub_packages,
+                *copied_explicit_packages,
+                *copied_project_packages,
+            ),
             "assets": copied_assets,
             "config": copied_config,
             "documentation": copied_docs,
@@ -145,7 +160,9 @@ def prepare_runtime(
     )
 
 
-def build_project(options: BuildOptions | None = None, **overrides: object) -> BuildResult:
+def build_project(
+    options: BuildOptions | None = None, **overrides: object
+) -> BuildResult:
     """Construye un proyecto Cobra usando una API programática estable.
 
     La implementación inicial prepara directorios, manifiesto y especificación
@@ -156,7 +173,9 @@ def build_project(options: BuildOptions | None = None, **overrides: object) -> B
     if overrides:
         base = replace(base, **overrides)
     normalized = validate_build_options(base)
-    entrypoint = normalized.entrypoint or discover_entrypoint(Path(normalized.project_root))
+    entrypoint = normalized.entrypoint or discover_entrypoint(
+        Path(normalized.project_root)
+    )
     if entrypoint is None:
         raise CobraInstallerError(
             f"No se encontró un punto de entrada Cobra en {normalized.project_root}"
@@ -201,16 +220,24 @@ def build_project(options: BuildOptions | None = None, **overrides: object) -> B
         output_dir=output_dir,
         target=normalized.target,
         architecture=normalized.architecture,
+        builder=normalized.builder,
+        builder_config=normalized.builder_config,
         mode=normalized.mode,
         executable_name=name,
         temp_dir=Path(normalized.temp_dir) if normalized.temp_dir is not None else None,
         dist_dir=output_dir,
-        metadata={"entrypoint": str(entrypoint), "manifest": str(manifest_path), "name": name},
+        metadata={
+            "entrypoint": str(entrypoint),
+            "manifest": str(manifest_path),
+            "name": name,
+        },
         logs=("Proyecto preparado para empaquetado.",),
     )
 
 
-def package_current_project(project_root: str | Path | None = None, **kwargs: object) -> BuildResult:
+def package_current_project(
+    project_root: str | Path | None = None, **kwargs: object
+) -> BuildResult:
     """Empaqueta el proyecto actual; punto único que debe llamar el IDLE."""
 
     options = BuildOptions(project_root=project_root or Path.cwd(), **kwargs)
@@ -341,7 +368,9 @@ def _existing_optional_paths(*paths: Path | str | None) -> tuple[Path | str, ...
     return tuple(path for path in paths if path is not None and Path(path).exists())
 
 
-def _pyinstaller_entrypoint_code(source_entrypoint: Path | None, build_dir: Path) -> str:
+def _pyinstaller_entrypoint_code(
+    source_entrypoint: Path | None, build_dir: Path
+) -> str:
     source_literal = str(source_entrypoint) if source_entrypoint is not None else ""
     return (
         '"""Entrypoint estable generado por cobra_installer para PyInstaller."""\n'

--- a/src/pcobra/cobra_installer/targets.py
+++ b/src/pcobra/cobra_installer/targets.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import platform
+import warnings
+from dataclasses import dataclass
 from enum import StrEnum
 
 
@@ -27,5 +30,161 @@ class TargetOS(StrEnum):
     LINUX = "linux"
     MACOS = "macos"
 
+    @classmethod
+    def from_value(cls, value: "TargetOS | str") -> "TargetOS":
+        """Normaliza aliases de usuario al sistema operativo canónico."""
 
-__all__ = ["BuildMode", "TargetOS"]
+        if isinstance(value, cls):
+            return value
+        normalized = str(value).strip().lower().replace("_", "-")
+        if normalized == "current":
+            return detect_host_os()
+        aliases = {
+            "win": cls.WINDOWS,
+            "win32": cls.WINDOWS,
+            "windows": cls.WINDOWS,
+            "linux": cls.LINUX,
+            "gnu-linux": cls.LINUX,
+            "darwin": cls.MACOS,
+            "mac": cls.MACOS,
+            "macos": cls.MACOS,
+            "mac-os": cls.MACOS,
+            "osx": cls.MACOS,
+            "os-x": cls.MACOS,
+        }
+        try:
+            return aliases[normalized]
+        except KeyError as exc:
+            supported = ", ".join((*VALID_TARGET_VALUES, "current"))
+            raise ValueError(
+                f"Target no soportado: {value!r}. Valores válidos: {supported}."
+            ) from exc
+
+    @property
+    def expected_artifact(self) -> "ExpectedArtifact":
+        """Describe el artefacto final esperado para este sistema operativo."""
+
+        return EXPECTED_ARTIFACTS[self]
+
+
+class Builder(StrEnum):
+    """Builders futuros para aislar builds no nativos."""
+
+    LOCAL = "local"
+    DOCKER = "docker"
+    VM = "vm"
+    CI = "ci"
+    REMOTE = "remote"
+
+    @classmethod
+    def from_value(cls, value: "Builder | str | None") -> "Builder":
+        """Normaliza la selección de builder sin activar implementaciones futuras."""
+
+        if value is None:
+            return cls.LOCAL
+        if isinstance(value, cls):
+            return value
+        return cls(str(value).strip().lower())
+
+
+@dataclass(frozen=True, slots=True)
+class BuilderConfig:
+    """Esqueleto de configuración para builders futuros."""
+
+    builder: Builder = Builder.LOCAL
+    image: str | None = None
+    vm_name: str | None = None
+    ci_runner: str | None = None
+    remote_url: str | None = None
+
+    @classmethod
+    def from_value(
+        cls, value: "BuilderConfig | Builder | str | None"
+    ) -> "BuilderConfig":
+        """Crea una configuración mínima desde un builder o cadena."""
+
+        if isinstance(value, cls):
+            return value
+        return cls(builder=Builder.from_value(value))
+
+
+@dataclass(frozen=True, slots=True)
+class ExpectedArtifact:
+    """Formato final esperado para el artefacto de PyInstaller."""
+
+    description: str
+    extension: str | None = None
+    bundle_extension: str | None = None
+
+
+VALID_TARGET_VALUES = tuple(target.value for target in TargetOS)
+EXPECTED_ARTIFACTS: dict[TargetOS, ExpectedArtifact] = {
+    TargetOS.WINDOWS: ExpectedArtifact(
+        description="ejecutable Windows", extension=".exe"
+    ),
+    TargetOS.LINUX: ExpectedArtifact(description="binario ELF", extension=None),
+    TargetOS.MACOS: ExpectedArtifact(
+        description="bundle .app o binario macOS", bundle_extension=".app"
+    ),
+}
+CROSS_COMPILATION_WARNING = (
+    "El target seleccionado ({target}) no coincide con el host actual ({host}). "
+    "PyInstaller no soporta cross-compilation de forma nativa. Para generar "
+    "artefactos de otro sistema operativo, usa Docker, una Máquina Virtual, "
+    "un runner CI/CD o un builder remoto."
+)
+
+
+def detect_host_os() -> TargetOS:
+    """Detecta el sistema operativo host y lo normaliza a TargetOS."""
+
+    system = platform.system().strip().lower()
+    if system == "windows":
+        return TargetOS.WINDOWS
+    if system == "linux":
+        return TargetOS.LINUX
+    if system == "darwin":
+        return TargetOS.MACOS
+    raise RuntimeError(f"Host no soportado para build Cobra: {platform.system()!r}.")
+
+
+def normalize_target(value: TargetOS | str) -> TargetOS:
+    """Normaliza targets admitiendo ``current`` como alias del host actual."""
+
+    return TargetOS.from_value(value)
+
+
+def validate_target(value: TargetOS | str, *, warn_on_cross: bool = True) -> TargetOS:
+    """Valida el target y advierte cuando no coincide con el host actual."""
+
+    target = normalize_target(value)
+    host = detect_host_os()
+    if warn_on_cross and target is not host:
+        warnings.warn(
+            CROSS_COMPILATION_WARNING.format(target=target.value, host=host.value),
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    return target
+
+
+def expected_artifact_for(target: TargetOS | str) -> ExpectedArtifact:
+    """Devuelve la extensión o formato final esperado para un target."""
+
+    return normalize_target(target).expected_artifact
+
+
+__all__ = [
+    "BuildMode",
+    "Builder",
+    "BuilderConfig",
+    "CROSS_COMPILATION_WARNING",
+    "EXPECTED_ARTIFACTS",
+    "ExpectedArtifact",
+    "TargetOS",
+    "VALID_TARGET_VALUES",
+    "detect_host_os",
+    "expected_artifact_for",
+    "normalize_target",
+    "validate_target",
+]

--- a/src/pcobra/cobra_installer/validator.py
+++ b/src/pcobra/cobra_installer/validator.py
@@ -13,6 +13,7 @@ from typing import Mapping, Sequence
 from pcobra.cobra.packaging import es_paquete_cobra
 
 from .project import BuildOptions, CobraInstallerError, CobraProject
+from .targets import validate_target
 
 COBRA_EXTENSIONS = (".cobra", ".co")
 _EXECUTABLE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
@@ -105,7 +106,9 @@ def validate_project(project: CobraProject) -> ValidationResult:
     _validate_resource_paths(normalized.assets, root, "assets", errors)
     _validate_resource_paths(normalized.config_dirs, root, "config_dirs", errors)
     _validate_resource_paths(normalized.documentation, root, "documentation", errors)
-    _validate_resource_paths(normalized.auxiliary_resources, root, "auxiliary_resources", errors)
+    _validate_resource_paths(
+        normalized.auxiliary_resources, root, "auxiliary_resources", errors
+    )
     _validate_resource_paths(normalized.co_packages, root, "co_packages", errors)
     _validate_configured_executable_names(normalized.config, errors)
     _validate_configured_icon(normalized.config, root, errors)
@@ -122,8 +125,13 @@ def validate_build_options(options: BuildOptions) -> BuildOptions:
     ``CobraInstallerError``.
     """
 
-    normalized = options.normalized()
-    entrypoint = normalized.entrypoint or discover_entrypoint(Path(normalized.project_root))
+    try:
+        normalized = options.normalized()
+    except (RuntimeError, ValueError) as exc:
+        raise CobraInstallerError(str(exc)) from exc
+    entrypoint = normalized.entrypoint or discover_entrypoint(
+        Path(normalized.project_root)
+    )
     project = CobraProject(
         project_root=normalized.project_root,
         entrypoint=entrypoint,
@@ -132,12 +140,30 @@ def validate_build_options(options: BuildOptions) -> BuildOptions:
     )
     result = validate_project(project)
     extra_errors = list(result.errors)
+    try:
+        validate_target(normalized.target)
+    except (RuntimeError, ValueError) as exc:
+        extra_errors.append(
+            ValidationErrorDetail(
+                code="target_invalid",
+                message=str(exc),
+                field="target",
+                hint="Usa windows, linux, macos o current.",
+            )
+        )
     if normalized.icon is not None:
-        _validate_icon_path(normalized.icon, Path(normalized.project_root), extra_errors, field_name="icon")
+        _validate_icon_path(
+            normalized.icon,
+            Path(normalized.project_root),
+            extra_errors,
+            field_name="icon",
+        )
     if normalized.name is not None:
         _validate_executable_name(normalized.name, extra_errors, field_name="name")
     if extra_errors:
-        ValidationResult(project=result.project, errors=tuple(extra_errors)).raise_for_errors()
+        ValidationResult(
+            project=result.project, errors=tuple(extra_errors)
+        ).raise_for_errors()
     return normalized
 
 
@@ -155,7 +181,9 @@ def discover_entrypoint(project_root: Path) -> Path | None:
     return None
 
 
-def _validate_entrypoint(project: CobraProject, root: Path, errors: list[ValidationErrorDetail]) -> None:
+def _validate_entrypoint(
+    project: CobraProject, root: Path, errors: list[ValidationErrorDetail]
+) -> None:
     entrypoint = project.entrypoint
     if entrypoint is None:
         errors.append(
@@ -169,10 +197,24 @@ def _validate_entrypoint(project: CobraProject, root: Path, errors: list[Validat
         )
         return
     if not entrypoint.is_file():
-        errors.append(ValidationErrorDetail("entrypoint_not_found", f"El punto de entrada no existe: {entrypoint}", entrypoint, "entrypoint"))
+        errors.append(
+            ValidationErrorDetail(
+                "entrypoint_not_found",
+                f"El punto de entrada no existe: {entrypoint}",
+                entrypoint,
+                "entrypoint",
+            )
+        )
         return
     if not _is_inside_project(entrypoint, root):
-        errors.append(ValidationErrorDetail("entrypoint_outside_project", f"El entrypoint está fuera del proyecto: {entrypoint}", entrypoint, "entrypoint"))
+        errors.append(
+            ValidationErrorDetail(
+                "entrypoint_outside_project",
+                f"El entrypoint está fuera del proyecto: {entrypoint}",
+                entrypoint,
+                "entrypoint",
+            )
+        )
     if entrypoint.suffix.lower() != ".cobra":
         errors.append(
             ValidationErrorDetail(
@@ -184,21 +226,51 @@ def _validate_entrypoint(project: CobraProject, root: Path, errors: list[Validat
         )
 
 
-def _validate_cobra_toml(project: CobraProject, root: Path, errors: list[ValidationErrorDetail]) -> None:
+def _validate_cobra_toml(
+    project: CobraProject, root: Path, errors: list[ValidationErrorDetail]
+) -> None:
     path = project.cobra_toml
     if path is None:
         return
     if path.name != "cobra.toml":
-        errors.append(ValidationErrorDetail("cobra_toml_name_invalid", f"El manifiesto debe llamarse cobra.toml: {path}", path, "cobra_toml"))
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_toml_name_invalid",
+                f"El manifiesto debe llamarse cobra.toml: {path}",
+                path,
+                "cobra_toml",
+            )
+        )
     if not _is_inside_project(path, root):
-        errors.append(ValidationErrorDetail("cobra_toml_outside_project", f"cobra.toml está fuera del proyecto: {path}", path, "cobra_toml"))
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_toml_outside_project",
+                f"cobra.toml está fuera del proyecto: {path}",
+                path,
+                "cobra_toml",
+            )
+        )
     if not path.exists():
         if path == root / "cobra.toml":
             return
-        errors.append(ValidationErrorDetail("cobra_toml_not_found", f"cobra.toml no existe: {path}", path, "cobra_toml"))
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_toml_not_found",
+                f"cobra.toml no existe: {path}",
+                path,
+                "cobra_toml",
+            )
+        )
         return
     if not path.is_file():
-        errors.append(ValidationErrorDetail("cobra_toml_not_file", f"cobra.toml no es un archivo: {path}", path, "cobra_toml"))
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_toml_not_file",
+                f"cobra.toml no es un archivo: {path}",
+                path,
+                "cobra_toml",
+            )
+        )
         return
     data = _read_toml_mapping(path, errors, "cobra_toml")
     if data is not None and not any(key in data for key in _REQUIRED_TOML_TOP_LEVEL):
@@ -212,95 +284,270 @@ def _validate_cobra_toml(project: CobraProject, root: Path, errors: list[Validat
         )
 
 
-def _validate_cobra_lock(project: CobraProject, root: Path, errors: list[ValidationErrorDetail]) -> None:
+def _validate_cobra_lock(
+    project: CobraProject, root: Path, errors: list[ValidationErrorDetail]
+) -> None:
     path = project.cobra_lock
     if path is None or not path.exists():
         return
     if path.name != "cobra.lock":
-        errors.append(ValidationErrorDetail("cobra_lock_name_invalid", f"El lockfile debe llamarse cobra.lock: {path}", path, "cobra_lock"))
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_lock_name_invalid",
+                f"El lockfile debe llamarse cobra.lock: {path}",
+                path,
+                "cobra_lock",
+            )
+        )
     if not _is_inside_project(path, root):
-        errors.append(ValidationErrorDetail("cobra_lock_outside_project", f"cobra.lock está fuera del proyecto: {path}", path, "cobra_lock"))
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_lock_outside_project",
+                f"cobra.lock está fuera del proyecto: {path}",
+                path,
+                "cobra_lock",
+            )
+        )
     if not path.is_file():
-        errors.append(ValidationErrorDetail("cobra_lock_not_file", f"cobra.lock no es un archivo: {path}", path, "cobra_lock"))
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_lock_not_file",
+                f"cobra.lock no es un archivo: {path}",
+                path,
+                "cobra_lock",
+            )
+        )
         return
     parsed = _read_lock_mapping(path, errors)
-    if parsed is not None and parsed and not any(key in parsed for key in _LOCK_REQUIRED_KEYS):
-        errors.append(ValidationErrorDetail("cobra_lock_format_invalid", "cobra.lock no contiene claves reconocibles de lockfile.", path, "cobra_lock"))
+    if (
+        parsed is not None
+        and parsed
+        and not any(key in parsed for key in _LOCK_REQUIRED_KEYS)
+    ):
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_lock_format_invalid",
+                "cobra.lock no contiene claves reconocibles de lockfile.",
+                path,
+                "cobra_lock",
+            )
+        )
 
 
-def _validate_resource_paths(paths: Sequence[Path | str], root: Path, field_name: str, errors: list[ValidationErrorDetail]) -> None:
+def _validate_resource_paths(
+    paths: Sequence[Path | str],
+    root: Path,
+    field_name: str,
+    errors: list[ValidationErrorDetail],
+) -> None:
     for raw_path in paths:
         path = Path(raw_path)
         if not _is_inside_project(path, root):
-            errors.append(ValidationErrorDetail(f"{field_name}_outside_project", f"La ruta de {field_name} está fuera del proyecto: {path}", path, field_name))
+            errors.append(
+                ValidationErrorDetail(
+                    f"{field_name}_outside_project",
+                    f"La ruta de {field_name} está fuera del proyecto: {path}",
+                    path,
+                    field_name,
+                )
+            )
         if not path.exists():
-            errors.append(ValidationErrorDetail(f"{field_name}_not_found", f"La ruta de {field_name} no existe: {path}", path, field_name))
+            errors.append(
+                ValidationErrorDetail(
+                    f"{field_name}_not_found",
+                    f"La ruta de {field_name} no existe: {path}",
+                    path,
+                    field_name,
+                )
+            )
 
 
-def _validate_configured_executable_names(config: Mapping[str, object], errors: list[ValidationErrorDetail]) -> None:
+def _validate_configured_executable_names(
+    config: Mapping[str, object], errors: list[ValidationErrorDetail]
+) -> None:
     for field_name, value in _iter_config_values(config, _EXECUTABLE_NAME_KEYS):
         if isinstance(value, str):
             _validate_executable_name(value, errors, field_name=field_name)
         elif value is not None:
-            errors.append(ValidationErrorDetail("executable_name_type_invalid", f"El nombre de ejecutable en {field_name} debe ser texto.", field=field_name))
+            errors.append(
+                ValidationErrorDetail(
+                    "executable_name_type_invalid",
+                    f"El nombre de ejecutable en {field_name} debe ser texto.",
+                    field=field_name,
+                )
+            )
 
 
-def _validate_executable_name(name: str, errors: list[ValidationErrorDetail], *, field_name: str) -> None:
-    if not name or not _EXECUTABLE_NAME_RE.fullmatch(name) or name.endswith(".") or name.endswith(" "):
-        errors.append(ValidationErrorDetail("executable_name_invalid", f"Nombre de ejecutable inválido: {name!r}", field=field_name, hint="Usa letras, números, guion, guion bajo o punto, empezando por un carácter alfanumérico."))
+def _validate_executable_name(
+    name: str, errors: list[ValidationErrorDetail], *, field_name: str
+) -> None:
+    if (
+        not name
+        or not _EXECUTABLE_NAME_RE.fullmatch(name)
+        or name.endswith(".")
+        or name.endswith(" ")
+    ):
+        errors.append(
+            ValidationErrorDetail(
+                "executable_name_invalid",
+                f"Nombre de ejecutable inválido: {name!r}",
+                field=field_name,
+                hint="Usa letras, números, guion, guion bajo o punto, empezando por un carácter alfanumérico.",
+            )
+        )
         return
     if name.split(".", 1)[0].upper() in _RESERVED_EXECUTABLE_NAMES:
-        errors.append(ValidationErrorDetail("executable_name_reserved", f"Nombre de ejecutable reservado por Windows: {name!r}", field=field_name))
+        errors.append(
+            ValidationErrorDetail(
+                "executable_name_reserved",
+                f"Nombre de ejecutable reservado por Windows: {name!r}",
+                field=field_name,
+            )
+        )
 
 
-def _validate_configured_icon(config: Mapping[str, object], root: Path, errors: list[ValidationErrorDetail]) -> None:
+def _validate_configured_icon(
+    config: Mapping[str, object], root: Path, errors: list[ValidationErrorDetail]
+) -> None:
     for field_name, value in _iter_config_values(config, _CONFIG_PATH_KEYS):
         if isinstance(value, str) and value:
-            _validate_icon_path(Path(value) if Path(value).is_absolute() else root / value, root, errors, field_name=field_name)
+            _validate_icon_path(
+                Path(value) if Path(value).is_absolute() else root / value,
+                root,
+                errors,
+                field_name=field_name,
+            )
         elif value is not None:
-            errors.append(ValidationErrorDetail("icon_type_invalid", f"El icono opcional en {field_name} debe ser una ruta de texto.", field=field_name))
+            errors.append(
+                ValidationErrorDetail(
+                    "icon_type_invalid",
+                    f"El icono opcional en {field_name} debe ser una ruta de texto.",
+                    field=field_name,
+                )
+            )
 
 
-def _validate_icon_path(path: Path, root: Path, errors: list[ValidationErrorDetail], *, field_name: str) -> None:
+def _validate_icon_path(
+    path: Path, root: Path, errors: list[ValidationErrorDetail], *, field_name: str
+) -> None:
     path = path.expanduser().resolve()
     if not _is_inside_project(path, root):
-        errors.append(ValidationErrorDetail("icon_outside_project", f"El icono está fuera del proyecto: {path}", path, field_name))
+        errors.append(
+            ValidationErrorDetail(
+                "icon_outside_project",
+                f"El icono está fuera del proyecto: {path}",
+                path,
+                field_name,
+            )
+        )
     if not path.is_file():
-        errors.append(ValidationErrorDetail("icon_not_found", f"El icono configurado no existe: {path}", path, field_name))
+        errors.append(
+            ValidationErrorDetail(
+                "icon_not_found",
+                f"El icono configurado no existe: {path}",
+                path,
+                field_name,
+            )
+        )
     if path.suffix.lower() not in _ICON_SUFFIXES:
-        errors.append(ValidationErrorDetail("icon_extension_invalid", f"El icono debe usar una extensión compatible ({', '.join(sorted(_ICON_SUFFIXES))}): {path}", path, field_name))
+        errors.append(
+            ValidationErrorDetail(
+                "icon_extension_invalid",
+                f"El icono debe usar una extensión compatible ({', '.join(sorted(_ICON_SUFFIXES))}): {path}",
+                path,
+                field_name,
+            )
+        )
 
 
-def _validate_co_package_distinction(project: CobraProject, errors: list[ValidationErrorDetail]) -> None:
+def _validate_co_package_distinction(
+    project: CobraProject, errors: list[ValidationErrorDetail]
+) -> None:
     entrypoint = project.entrypoint
-    if entrypoint is not None and entrypoint.suffix.lower() == ".co" and entrypoint.exists() and es_paquete_cobra(entrypoint):
-        errors.append(ValidationErrorDetail("entrypoint_co_is_package", f"El entrypoint .co parece ser un paquete binario Cobra, no una fuente editable: {entrypoint}", entrypoint, "entrypoint"))
+    if (
+        entrypoint is not None
+        and entrypoint.suffix.lower() == ".co"
+        and entrypoint.exists()
+        and es_paquete_cobra(entrypoint)
+    ):
+        errors.append(
+            ValidationErrorDetail(
+                "entrypoint_co_is_package",
+                f"El entrypoint .co parece ser un paquete binario Cobra, no una fuente editable: {entrypoint}",
+                entrypoint,
+                "entrypoint",
+            )
+        )
     for raw_path in project.co_packages:
         path = Path(raw_path)
-        if path.suffix.lower() == ".co" and path.exists() and not es_paquete_cobra(path) and not zipfile.is_zipfile(path):
-            errors.append(ValidationErrorDetail("co_package_is_text_source", f"El paquete .co declarado parece una fuente de texto; muévelo a fuentes o conviértelo en paquete Cobra: {path}", path, "co_packages"))
+        if (
+            path.suffix.lower() == ".co"
+            and path.exists()
+            and not es_paquete_cobra(path)
+            and not zipfile.is_zipfile(path)
+        ):
+            errors.append(
+                ValidationErrorDetail(
+                    "co_package_is_text_source",
+                    f"El paquete .co declarado parece una fuente de texto; muévelo a fuentes o conviértelo en paquete Cobra: {path}",
+                    path,
+                    "co_packages",
+                )
+            )
 
 
-def _read_toml_mapping(path: Path, errors: list[ValidationErrorDetail], field_name: str) -> dict[str, object] | None:
+def _read_toml_mapping(
+    path: Path, errors: list[ValidationErrorDetail], field_name: str
+) -> dict[str, object] | None:
     try:
         data = tomllib.loads(path.read_text(encoding="utf-8"))
     except tomllib.TOMLDecodeError as exc:  # type: ignore[union-attr]
-        errors.append(ValidationErrorDetail(f"{field_name}_syntax_invalid", f"{path.name} no es TOML válido: {exc}", path, field_name))
+        errors.append(
+            ValidationErrorDetail(
+                f"{field_name}_syntax_invalid",
+                f"{path.name} no es TOML válido: {exc}",
+                path,
+                field_name,
+            )
+        )
         return None
     except UnicodeDecodeError as exc:
-        errors.append(ValidationErrorDetail(f"{field_name}_encoding_invalid", f"{path.name} debe poder leerse como UTF-8: {exc}", path, field_name))
+        errors.append(
+            ValidationErrorDetail(
+                f"{field_name}_encoding_invalid",
+                f"{path.name} debe poder leerse como UTF-8: {exc}",
+                path,
+                field_name,
+            )
+        )
         return None
     if not isinstance(data, dict):
-        errors.append(ValidationErrorDetail(f"{field_name}_format_invalid", f"{path.name} debe contener un documento TOML de tablas/clave-valor.", path, field_name))
+        errors.append(
+            ValidationErrorDetail(
+                f"{field_name}_format_invalid",
+                f"{path.name} debe contener un documento TOML de tablas/clave-valor.",
+                path,
+                field_name,
+            )
+        )
         return None
     return data
 
 
-def _read_lock_mapping(path: Path, errors: list[ValidationErrorDetail]) -> Mapping[str, object] | None:
+def _read_lock_mapping(
+    path: Path, errors: list[ValidationErrorDetail]
+) -> Mapping[str, object] | None:
     try:
         text = path.read_text(encoding="utf-8")
     except UnicodeDecodeError as exc:
-        errors.append(ValidationErrorDetail("cobra_lock_encoding_invalid", f"cobra.lock debe poder leerse como UTF-8: {exc}", path, "cobra_lock"))
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_lock_encoding_invalid",
+                f"cobra.lock debe poder leerse como UTF-8: {exc}",
+                path,
+                "cobra_lock",
+            )
+        )
         return None
     stripped = text.strip()
     if not stripped:
@@ -309,18 +556,34 @@ def _read_lock_mapping(path: Path, errors: list[ValidationErrorDetail]) -> Mappi
         try:
             data = json.loads(stripped)
         except json.JSONDecodeError as exc:
-            errors.append(ValidationErrorDetail("cobra_lock_syntax_invalid", f"cobra.lock no es JSON válido: {exc}", path, "cobra_lock"))
+            errors.append(
+                ValidationErrorDetail(
+                    "cobra_lock_syntax_invalid",
+                    f"cobra.lock no es JSON válido: {exc}",
+                    path,
+                    "cobra_lock",
+                )
+            )
             return None
         if isinstance(data, Mapping):
             return data
         if isinstance(data, list):
             return {"packages": data}
-        errors.append(ValidationErrorDetail("cobra_lock_format_invalid", "cobra.lock JSON debe ser un objeto o lista.", path, "cobra_lock"))
+        errors.append(
+            ValidationErrorDetail(
+                "cobra_lock_format_invalid",
+                "cobra.lock JSON debe ser un objeto o lista.",
+                path,
+                "cobra_lock",
+            )
+        )
         return None
     return _read_toml_mapping(path, errors, "cobra_lock")
 
 
-def _iter_config_values(config: Mapping[str, object], keys: Sequence[str]) -> list[tuple[str, object]]:
+def _iter_config_values(
+    config: Mapping[str, object], keys: Sequence[str]
+) -> list[tuple[str, object]]:
     values: list[tuple[str, object]] = []
     for key, value in config.items():
         if key in keys:

--- a/tests/unit/test_cobra_installer_targets.py
+++ b/tests/unit/test_cobra_installer_targets.py
@@ -1,0 +1,73 @@
+import platform
+import warnings
+
+import pytest
+
+from pcobra.cobra_installer.targets import (
+    Builder,
+    BuilderConfig,
+    TargetOS,
+    detect_host_os,
+    expected_artifact_for,
+    normalize_target,
+    validate_target,
+)
+
+
+def test_detect_host_os_normaliza_platforms(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    assert detect_host_os() is TargetOS.WINDOWS
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    assert detect_host_os() is TargetOS.LINUX
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    assert detect_host_os() is TargetOS.MACOS
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("windows", TargetOS.WINDOWS),
+        ("win32", TargetOS.WINDOWS),
+        ("linux", TargetOS.LINUX),
+        ("gnu_linux", TargetOS.LINUX),
+        ("macos", TargetOS.MACOS),
+        ("darwin", TargetOS.MACOS),
+        ("osx", TargetOS.MACOS),
+    ],
+)
+def test_normalize_target_acepta_aliases(raw, expected):
+    assert normalize_target(raw) is expected
+
+
+def test_expected_artifact_for_declara_formatos_finales():
+    assert expected_artifact_for("windows").extension == ".exe"
+    assert expected_artifact_for("linux").description == "binario ELF"
+    assert expected_artifact_for("macos").bundle_extension == ".app"
+
+
+def test_validate_target_advierte_en_cross_compilation(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    with pytest.warns(RuntimeWarning) as captured:
+        assert validate_target("windows") is TargetOS.WINDOWS
+    message = str(captured[0].message)
+    assert "PyInstaller no soporta cross-compilation de forma nativa" in message
+    assert "Docker" in message
+    assert "Máquina Virtual" in message
+    assert "runner CI/CD" in message
+    assert "builder remoto" in message
+
+
+def test_validate_target_no_advierte_en_host_actual(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        assert validate_target("linux") is TargetOS.LINUX
+    assert captured == []
+
+
+def test_builder_config_prepara_opciones_futuras():
+    assert Builder.from_value("docker") is Builder.DOCKER
+    assert Builder.from_value("vm") is Builder.VM
+    assert Builder.from_value("ci") is Builder.CI
+    assert Builder.from_value("remote") is Builder.REMOTE
+    assert BuilderConfig.from_value("remote") == BuilderConfig(builder=Builder.REMOTE)


### PR DESCRIPTION
### Motivation

- Mejorar la experiencia de empaquetado detectando el OS host y normalizando los targets para evitar errores de usuario al usar `--target`.
- Señalar explícitamente que PyInstaller no soporta cross-compilation de forma nativa y ofrecer alternativas prácticas para producir artefactos de otro SO.
- Preparar la base para builders remotos/aislados (`docker`, `vm`, `ci`, `remote`) sin implementar su lógica aún, permitiendo opciones futuras en la CLI.

### Description

- Se introdujeron utilidades en `src/pcobra/cobra_installer/targets.py`: detección del host con `detect_host_os()`, normalización con `TargetOS.from_value()` / `normalize_target()`, validación con `validate_target()`, metadatos de artefacto esperado `ExpectedArtifact` y el aviso `CROSS_COMPILATION_WARNING`, además de los nuevos `Builder` y `BuilderConfig` como esqueleto para builders futuros.
- Se propagaron y normalizaron las opciones en `BuildOptions` y `BuildResult` añadiendo `builder` y `builder_config`, y haciendo que `target` se normalice a `TargetOS` durante `normalized()` en `src/pcobra/cobra_installer/project.py`.
- Se conectó la validación de `target` al flujo de validación en `src/pcobra/cobra_installer/validator.py` para acumular errores controlados y advertencias en vez de lanzar excepciones crudas.
- Se añadió la opción `--builder` en la CLI (`src/pcobra/cobra_installer/cli.py`) con las elecciones `local|docker|vm|ci|remote` y se propagó el valor hacia `package_current_project`, y se actualizó `runtime_builder` para incluir `builder`/`builder_config` en los resultados.
- Se añadieron pruebas unitarias en `tests/unit/test_cobra_installer_targets.py` que cubren detección de host, aliases de targets, artefactos esperados, advertencias de cross-compilation y el `Builder`/`BuilderConfig` básico.

### Testing

- Ejecuté `pytest tests/unit/test_cobra_installer_targets.py -q` y las pruebas del nuevo módulo pasaron correctamente.
- Ejecuté `pytest` sobre los tests del instalador focales con `pytest tests/unit/test_cobra_installer_models.py tests/unit/test_cobra_installer_runtime_builder.py tests/unit/test_cobra_installer_spec_writer.py -q` y no hubo regresiones en esas suites.
- Ejecuté la suite completa de tests unitarios del instalador con `pytest tests/unit/test_cobra_installer_*.py tests/unit/test_pyinstaller_runner.py -q` y todas las pruebas unitarias del instalador pasaron.
- Ejecuté `python -m ruff check src/pcobra/cobra_installer tests/unit/test_cobra_installer_targets.py` y `git diff --check` para verificar estilo y errores, y ambos checks completaron sin problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a460bf516e08327bc75e3f8a2e4bb71)