### PR TITLE
Añadir comando CLI `cobra installer build`

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -165,6 +165,7 @@ class AppConfig:
         CommandClassRoute("pcobra.cobra.cli.commands_v2.build_cmd", "BuildCommandV2"),
         CommandClassRoute("pcobra.cobra.cli.commands_v2.test_cmd", "TestCommandV2"),
         CommandClassRoute("pcobra.cobra.cli.commands_v2.mod_cmd", "ModCommandV2"),
+        CommandClassRoute("pcobra.cobra.cli.commands_v2.installer_cmd", "InstallerCommandV2"),
         CommandClassRoute("pcobra.cobra.cli.commands.package_cmd", "PaqueteCommand"),
         CommandClassRoute("pcobra.cobra.cli.commands.hub_cmd", "HubCommand"),
         # `repl` forma parte del contrato público oficial de CLI v2 (no alias legacy).

--- a/src/pcobra/cobra/cli/commands_v2/installer_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/installer_cmd.py
@@ -1,0 +1,122 @@
+"""Comando público para construir instaladores Cobra."""
+
+from __future__ import annotations
+
+import argparse
+import warnings
+from pathlib import Path
+from typing import Any
+
+import pcobra.cobra_installer as cobra_installer
+from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra_installer import BuildOptions, CobraInstallerError
+
+
+class InstallerCommandV2(BaseCommand):
+    """Agrupa acciones de empaquetado instalable para proyectos Cobra."""
+
+    name = "installer"
+    capability = "codegen"
+
+    def register_subparser(self, subparsers: Any):
+        parser = subparsers.add_parser(
+            self.name,
+            help="Construye instaladores/autoejecutables de proyectos Cobra",
+        )
+        installer_subparsers = parser.add_subparsers(
+            dest="installer_action",
+            parser_class=argparse.ArgumentParser,
+            required=True,
+        )
+        build_parser = installer_subparsers.add_parser(
+            "build",
+            help="Construye un artefacto con PyInstaller",
+        )
+        build_parser.add_argument(
+            "project_path",
+            nargs="?",
+            default=".",
+            help="Ruta del proyecto Cobra a empaquetar",
+        )
+        build_parser.add_argument(
+            "--target", choices=("windows", "linux", "macos"), required=True
+        )
+        build_parser.add_argument(
+            "--mode", choices=("onefile", "onedir"), default="onedir"
+        )
+        build_parser.add_argument("--name", dest="name")
+        build_parser.add_argument("--icon", dest="icon", type=Path)
+        build_parser.add_argument(
+            "--builder",
+            choices=("local", "docker", "vm", "ci", "remote"),
+            default="local",
+        )
+        build_parser.add_argument(
+            "--install-pyinstaller",
+            action="store_true",
+            help="Permite instalar PyInstaller automáticamente si no está disponible",
+        )
+        build_parser.add_argument(
+            "--no-open-dist",
+            action="store_true",
+            help="No abre la carpeta dist al terminar (comportamiento por defecto en CLI)",
+        )
+        build_parser.set_defaults(cmd=self)
+        return parser
+
+    def run(self, args: Any) -> int:
+        if getattr(args, "installer_action", None) != "build":
+            raise CobraInstallerError(
+                "Acción de installer no soportada. Usa: cobra installer build ."
+            )
+
+        options = BuildOptions(
+            project_root=args.project_path,
+            target=args.target,
+            mode=args.mode,
+            name=args.name,
+            icon=args.icon,
+            builder=args.builder,
+            install_pyinstaller=bool(args.install_pyinstaller),
+            log_callback=print,
+        )
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always", RuntimeWarning)
+                result = cobra_installer.build_project(args.project_path, options)
+            for warning in caught:
+                print(f"Aviso: {_friendly_installer_error(str(warning.message))}")
+        except CobraInstallerError as exc:
+            print(f"Error: {_friendly_installer_error(str(exc))}")
+            return 1
+
+        artifact = result.artifact_path or result.output_dir or result.dist_dir
+        print(f"Build completado correctamente: {artifact}")
+        return 0
+
+
+def _friendly_installer_error(message: str) -> str:
+    """Normaliza fallos frecuentes a mensajes accionables para usuarios CLI."""
+
+    text = message.strip() or "fallo desconocido del instalador."
+    lowered = text.lower()
+    if (
+        "no es válida" in lowered
+        or "no es válido" in lowered
+        or "no se encontró entrypoint" in lowered
+    ):
+        return f"Proyecto inválido: {text}"
+    if "no existe" in lowered or "no es un directorio" in lowered or "no es una carpeta" in lowered:
+        return f"Dependencia o ruta inexistente: {text}"
+    if "hash" in lowered or "sha256" in lowered or "checksum" in lowered:
+        return f"Hash incorrecto: {text}"
+    if "conflicto de versiones" in lowered or "version conflict" in lowered:
+        return f"Conflicto de versiones: {text}"
+    if (
+        "pyinstaller no está instalado" in lowered
+        or "no está instalado o no es importable" in lowered
+    ):
+        return f"PyInstaller no disponible: {text}"
+    if "cross-compilation" in lowered or "cross compilation" in lowered:
+        return f"Cross-compilation solicitada: {text}"
+    return text

--- a/src/pcobra/cobra/cli/public_command_policy.py
+++ b/src/pcobra/cobra/cli/public_command_policy.py
@@ -6,12 +6,12 @@ from os import environ
 from typing import Iterable
 
 # `repl` es comando público oficial en UI v2; no debe tratarse como alias legacy.
-PUBLIC_COMMANDS_CONTRACT: tuple[str, ...] = ("run", "build", "test", "mod", "repl", "paquete", "hub")
+PUBLIC_COMMANDS_CONTRACT: tuple[str, ...] = ("run", "build", "test", "mod", "installer", "repl", "paquete", "hub")
 PUBLIC_COMMANDS: tuple[str, ...] = PUBLIC_COMMANDS_CONTRACT
 if PUBLIC_COMMANDS != PUBLIC_COMMANDS_CONTRACT:
     raise RuntimeError(
         "Contrato público inválido: PUBLIC_COMMANDS debe mantenerse en "
-        "('run', 'build', 'test', 'mod', 'repl', 'paquete', 'hub')."
+        "('run', 'build', 'test', 'mod', 'installer', 'repl', 'paquete', 'hub')."
     )
 INTERNAL_COMMANDS: tuple[str, ...] = (
     "legacy",
@@ -23,7 +23,7 @@ INTERNAL_COMMANDS: tuple[str, ...] = (
 
 COMMAND_VISIBILITY_MATRIX_MARKDOWN = """| Clase | Comandos |
 |---|---|
-| Públicos (UI v2) | run, build, test, mod, repl, paquete, hub |
+| Públicos (UI v2) | run, build, test, mod, installer, repl, paquete, hub |
 | Internos (UI v2 / development) | legacy, debug, devops |
 | Legacy públicos (UI v1) | *(ninguno; reservado a `development`)* |
 | Legacy internos (UI v1) | *(ninguno)* |

--- a/src/pcobra/cobra_installer/project.py
+++ b/src/pcobra/cobra_installer/project.py
@@ -109,6 +109,7 @@ class BuildOptions:
     include_dependencies: bool = True
     extra_args: Sequence[str] = field(default_factory=tuple)
     log_callback: Callable[[str], None] | None = None
+    install_pyinstaller: bool = False
 
     def normalized(self) -> "BuildOptions":
         """Devuelve una copia con rutas absolutas y valores derivados."""
@@ -139,6 +140,7 @@ class BuildOptions:
             include_dependencies=self.include_dependencies,
             extra_args=tuple(self.extra_args),
             log_callback=self.log_callback,
+            install_pyinstaller=self.install_pyinstaller,
         )
 
 

--- a/tests/integration/golden/cli_ui_v2_help_public.golden
+++ b/tests/integration/golden/cli_ui_v2_help_public.golden
@@ -4,18 +4,20 @@ usage: cobra [-h] [--version] [--ayuda] [--format] [--debug] [-v] [--no-safe]
              [--no-color] [--extra-validators EXTRA_VALIDATORS]
              [--legacy-imports] [--dev-ephemeral-key] [--plugins-safe-mode]
              [--plugins-unsafe-mode] [--plugins-allowlist PLUGINS_ALLOWLIST]
-             {run,build,test,mod,paquete,hub,repl} ...
+             {run,build,test,mod,installer,paquete,hub,repl} ...
 
 CLI de Cobra para ejecutar e interpretar scripts, transpilar código a otros
 lenguajes o usar ambos flujos según --modo (cobra, transpilar, mixto). Modo
 cobra = solo programar/interpretar Cobra sin codegen.
 
 positional arguments:
-  {run,build,test,mod,paquete,hub,repl}
+  {run,build,test,mod,installer,paquete,hub,repl}
     run                 Run a Cobra file
     build               Build/transpile a Cobra file
     test                Validate project output across runtimes
     mod                 Manage Cobra modules
+    installer           Construye instaladores/autoejecutables de proyectos
+                        Cobra
     paquete             Gestiona paquetes Cobra .co
     hub                 Gestiona paquetes en CobraHub
     repl                Start Cobra REPL

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -26,7 +26,7 @@ def _public_env() -> dict[str, str]:
 
 
 def test_cli_public_commands_contract_is_stable():
-    assert PUBLIC_COMMANDS == ("run", "build", "test", "mod", "repl", "paquete", "hub")
+    assert PUBLIC_COMMANDS == ("run", "build", "test", "mod", "installer", "repl", "paquete", "hub")
 
 
 def test_cli_public_commands_contract_keeps_repl_as_official_command():
@@ -67,7 +67,7 @@ def test_cli_help_public_contract_snapshot():
     )
     expected_snapshot = _leer_snapshot_texto(expected_snapshot)
     assert " ".join(result.stdout.lower().split()) == " ".join(expected_snapshot.lower().split())
-    for command in ("run", "build", "test", "mod", "repl", "paquete", "hub"):
+    for command in ("run", "build", "test", "mod", "installer", "repl", "paquete", "hub"):
         assert f" {command} " in f" {result.stdout.lower()} "
     assert "\n  menu " not in result.stdout.lower()
     assert "\n  legacy " not in result.stdout.lower()
@@ -113,4 +113,4 @@ def test_cli_help_public_contract_muestra_warning_migracion_en_comando_legacy():
     assert result.returncode != 0
     lower_output = result.stderr.lower() + result.stdout.lower()
     assert "invalid choice: 'compilar'" in lower_output
-    assert "choose from run, build, test, mod, paquete, hub, repl" in lower_output
+    assert "choose from run, build, test, mod, installer, paquete, hub, repl" in lower_output

--- a/tests/unit/test_cli_installer_cmd.py
+++ b/tests/unit/test_cli_installer_cmd.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+import pytest
+
+from pcobra.cobra.cli.commands_v2.installer_cmd import InstallerCommandV2
+from pcobra.cobra_installer import BuildMode, Builder, CobraInstallerError, TargetOS
+from pcobra.cobra_installer.project import BuildResult
+
+
+def test_installer_build_invoca_build_project(monkeypatch, tmp_path, capsys):
+    import pcobra.cobra_installer as cobra_installer
+
+    captured = {}
+
+    def fake_build_project(project_path, options):
+        captured["project_path"] = project_path
+        captured["options"] = options
+        return BuildResult(success=True, artifact_path=tmp_path / "dist")
+
+    monkeypatch.setattr(cobra_installer, "build_project", fake_build_project)
+    command = InstallerCommandV2()
+    parser = _registered_parser(command)
+    args = parser.parse_args(
+        [
+            "installer",
+            "build",
+            str(tmp_path),
+            "--target",
+            "linux",
+            "--mode",
+            "onefile",
+            "--name",
+            "demo",
+            "--icon",
+            "icon.png",
+            "--builder",
+            "local",
+            "--install-pyinstaller",
+            "--no-open-dist",
+        ]
+    )
+
+    assert command.run(args) == 0
+
+    options = captured["options"].normalized()
+    assert captured["project_path"] == str(tmp_path)
+    assert options.target is TargetOS.LINUX
+    assert options.mode is BuildMode.ONEFILE
+    assert options.name == "demo"
+    assert options.icon == tmp_path / "icon.png"
+    assert options.builder is Builder.LOCAL
+    assert options.install_pyinstaller is True
+    assert "Build completado correctamente" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("La estructura del proyecto no es válida: falta main.cobra", "Proyecto inválido"),
+        ("La ruta del proyecto no existe: demo", "Dependencia o ruta inexistente"),
+        ("sha256 esperado no coincide", "Hash incorrecto"),
+        ("Conflicto de versiones para dep", "Conflicto de versiones"),
+        ("PyInstaller no está instalado", "PyInstaller no disponible"),
+        ("PyInstaller no soporta cross-compilation de forma nativa", "Cross-compilation solicitada"),
+    ],
+)
+def test_installer_build_mensajes_claros(monkeypatch, tmp_path, capsys, message, expected):
+    import pcobra.cobra_installer as cobra_installer
+
+    def fake_build_project(project_path, options):
+        raise CobraInstallerError(message)
+
+    monkeypatch.setattr(cobra_installer, "build_project", fake_build_project)
+    command = InstallerCommandV2()
+    parser = _registered_parser(command)
+    args = parser.parse_args(["installer", "build", str(tmp_path), "--target", "linux"])
+
+    assert command.run(args) == 1
+    assert expected in capsys.readouterr().out
+
+
+def _registered_parser(command):
+    import argparse
+
+    root = argparse.ArgumentParser()
+    subparsers = root.add_subparsers(dest="command")
+    command.register_subparser(subparsers)
+    return root

--- a/tests/unit/test_public_command_policy.py
+++ b/tests/unit/test_public_command_policy.py
@@ -38,6 +38,7 @@ def test_public_commands_contract_oficial_v2_no_incluye_alias_legacy():
         "build",
         "test",
         "mod",
+        "installer",
         "repl",
         "paquete",
         "hub",


### PR DESCRIPTION
### Motivation
- Proveer un subcomando público para generar instaladores/autoejecutables de proyectos Cobra desde la CLI v2 y exponer opciones mínimas para controlar target, modo, nombre, icono, builder y comportamiento de PyInstaller.

### Description
- Añadido el nuevo comando público `installer` con la acción `build` en `src/pcobra/cobra/cli/commands_v2/installer_cmd.py` que acepta `--target`, `--mode`, `--name`, `--icon`, `--builder`, `--install-pyinstaller` y `--no-open-dist`.
- El comando construye un `BuildOptions` y delega exclusivamente en `pcobra.cobra_installer.build_project(...)` para realizar el proceso de empaquetado y emitir el resultado.
- Se añadieron mensajes amigables para los casos de: proyecto inválido, dependencia/ruta inexistente, hash incorrecto, conflicto de versiones, PyInstaller no disponible y cross-compilation solicitada mediante la función interna `_friendly_installer_error`.
- Se extendió `BuildOptions` en `src/pcobra/cobra_installer/project.py` para conservar la opción `install_pyinstaller` durante la normalización y se registró `installer` en el contrato público de comandos (`src/pcobra/cobra/cli/public_command_policy.py`) y en las rutas v2 (`src/pcobra/cobra/cli/cli.py`).
- Se añadieron tests unitarios en `tests/unit/test_cli_installer_cmd.py` y se actualizaron snapshots/tests de ayuda pública para incluir `installer`.

### Testing
- Se compiló el nuevo módulo y la modificación de modelos con `python -m compileall -q src/pcobra/cobra/cli/commands_v2/installer_cmd.py src/pcobra/cobra_installer/project.py` y no hubo errores.
- Se verificó la ayuda del nuevo subcomando con `python -m pcobra.cobra.cli.cli installer build --help` y la salida coincide con las expectativas.
- Se ejecutaron los tests relevantes con `pytest -q tests/unit/test_cli_installer_cmd.py tests/unit/test_pyinstaller_runner.py tests/unit/test_public_command_policy.py tests/integration/test_cli_public_help_contract.py` y todos los tests de ese conjunto pasaron (`23 passed`, `1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a463e25cc408327a1b8164e7f0a16f8)