### PR TITLE
Agregar puente IDLE para empaquetado de proyectos Cobra

### DIFF
--- a/src/pcobra/cobra_installer/idle_bridge.py
+++ b/src/pcobra/cobra_installer/idle_bridge.py
@@ -6,13 +6,166 @@ No debe contener lógica de construcción: el IDLE y este módulo solo llaman a
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Callable, Mapping
 
-from .project import BuildResult
-from .runtime_builder import package_current_project
+from .project import BuildOptions, CobraInstallerError
+from .runtime_builder import build_project
+
+ProgressCallback = Callable[[str], None]
+ErrorCallback = Callable[[str], None]
 
 
-def package_from_idle(project_root: str | Path, **kwargs: object) -> BuildResult:
-    """Delegación explícita desde el IDLE hacia la API pública del instalador."""
+@dataclass(frozen=True, slots=True)
+class IdlePackageResult:
+    """Resultado mínimo que necesita mostrar el IDLE tras empaquetar."""
 
-    return package_current_project(project_root, **kwargs)
+    executable_path: Path | None
+    dist_dir: Path
+
+
+def package_current_project(
+    project_path: str | Path,
+    ui_options: Mapping[str, Any] | object | None = None,
+    progress_callback: ProgressCallback | None = None,
+    error_callback: ErrorCallback | None = None,
+) -> IdlePackageResult:
+    """Empaqueta el proyecto actual desde IDLE usando la API del instalador.
+
+    El IDLE entrega opciones propias de la interfaz (normalmente un ``dict`` o
+    un objeto simple) y este puente las convierte a :class:`BuildOptions`,
+    conecta el callback de progreso al ``log_callback`` del builder y traduce
+    errores controlados del instalador a mensajes orientados a usuario.
+    """
+
+    options = _build_options_from_idle(project_path, ui_options, progress_callback)
+    try:
+        if progress_callback is not None:
+            progress_callback("Iniciando empaquetado del proyecto Cobra...")
+        result = build_project(project_path, options)
+        dist_dir = Path(result.dist_dir or result.output_dir or result.artifact_path)
+        executable_path = _resolve_executable_path(result.executable_name, dist_dir)
+        if progress_callback is not None:
+            progress_callback(f"Empaquetado completado en {dist_dir}.")
+        return IdlePackageResult(executable_path=executable_path, dist_dir=dist_dir)
+    except CobraInstallerError as exc:
+        message = _user_message_from_installer_error(exc)
+        if error_callback is not None:
+            error_callback(message)
+        raise RuntimeError(message) from exc
+
+
+def package_from_idle(
+    project_root: str | Path,
+    ui_options: Mapping[str, Any] | object | None = None,
+    progress_callback: ProgressCallback | None = None,
+    error_callback: ErrorCallback | None = None,
+    **kwargs: object,
+) -> IdlePackageResult:
+    """Alias explícito para código existente del IDLE."""
+
+    merged_options = _merge_ui_options(ui_options, kwargs)
+    return package_current_project(
+        project_root,
+        merged_options,
+        progress_callback,
+        error_callback,
+    )
+
+
+def _build_options_from_idle(
+    project_path: str | Path,
+    ui_options: Mapping[str, Any] | object | None,
+    progress_callback: ProgressCallback | None,
+) -> BuildOptions:
+    values = _ui_options_to_dict(ui_options)
+    translated = {
+        option_name: values[ui_name]
+        for ui_name, option_name in _UI_OPTION_ALIASES.items()
+        if ui_name in values and values[ui_name] is not None
+    }
+    extra_args = translated.get("extra_args")
+    if isinstance(extra_args, str):
+        translated["extra_args"] = tuple(extra_args.split())
+    return BuildOptions(
+        project_root=project_path,
+        log_callback=progress_callback,
+        **translated,
+    )
+
+
+def _ui_options_to_dict(ui_options: Mapping[str, Any] | object | None) -> dict[str, Any]:
+    if ui_options is None:
+        return {}
+    if isinstance(ui_options, Mapping):
+        return dict(ui_options)
+    return {
+        name: getattr(ui_options, name)
+        for name in _UI_OPTION_ALIASES
+        if hasattr(ui_options, name)
+    }
+
+
+def _merge_ui_options(
+    ui_options: Mapping[str, Any] | object | None, kwargs: Mapping[str, object]
+) -> dict[str, Any]:
+    merged = _ui_options_to_dict(ui_options)
+    merged.update(kwargs)
+    return merged
+
+
+def _resolve_executable_path(executable_name: str | None, dist_dir: Path) -> Path | None:
+    if not executable_name:
+        return None
+    direct = dist_dir / executable_name
+    if direct.exists():
+        return direct
+    windows = dist_dir / f"{executable_name}.exe"
+    if windows.exists():
+        return windows
+    nested = dist_dir / executable_name / executable_name
+    if nested.exists():
+        return nested
+    nested_windows = dist_dir / executable_name / f"{executable_name}.exe"
+    if nested_windows.exists():
+        return nested_windows
+    return direct
+
+
+def _user_message_from_installer_error(exc: CobraInstallerError) -> str:
+    detail = str(exc).strip()
+    if not detail:
+        detail = "fallo desconocido del instalador"
+    return f"No se pudo empaquetar el proyecto Cobra: {detail}"
+
+
+_UI_OPTION_ALIASES = {
+    "entrypoint": "entrypoint",
+    "output_dir": "output_dir",
+    "dist_dir": "dist_dir",
+    "name": "name",
+    "target": "target",
+    "architecture": "architecture",
+    "builder": "builder",
+    "builder_config": "builder_config",
+    "mode": "mode",
+    "temp_dir": "temp_dir",
+    "icon": "icon",
+    "assets": "assets",
+    "config": "config",
+    "clean": "clean",
+    "include_dependencies": "include_dependencies",
+    "extra_args": "extra_args",
+    "install_pyinstaller": "install_pyinstaller",
+    # Nombres frecuentes de controles del IDLE.
+    "nombre": "name",
+    "salida": "output_dir",
+    "directorio_salida": "output_dir",
+    "objetivo": "target",
+    "arquitectura": "architecture",
+    "modo": "mode",
+    "limpiar": "clean",
+    "incluir_dependencias": "include_dependencies",
+    "instalar_pyinstaller": "install_pyinstaller",
+}

--- a/tests/unit/test_cobra_installer_idle_bridge.py
+++ b/tests/unit/test_cobra_installer_idle_bridge.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from pcobra.cobra_installer import idle_bridge
+from pcobra.cobra_installer.project import BuildOptions, BuildResult, CobraInstallerError
+
+
+def test_package_current_project_convierte_opciones_idle_e_invoca_builder(monkeypatch, tmp_path: Path) -> None:
+    calls = []
+    progress = []
+    dist_dir = tmp_path / "dist"
+    executable = dist_dir / "demo"
+    executable.parent.mkdir()
+    executable.write_text("bin", encoding="utf-8")
+
+    def fake_build_project(project_path, options):
+        calls.append((project_path, options))
+        options.log_callback("progreso del builder")
+        return BuildResult(
+            success=True,
+            executable_name="demo",
+            output_dir=dist_dir,
+            dist_dir=dist_dir,
+        )
+
+    monkeypatch.setattr(idle_bridge, "build_project", fake_build_project)
+
+    result = idle_bridge.package_current_project(
+        tmp_path,
+        {
+            "nombre": "demo",
+            "directorio_salida": "dist",
+            "objetivo": "linux",
+            "arquitectura": "x86_64",
+            "modo": "onefile",
+            "limpiar": True,
+            "incluir_dependencias": False,
+            "extra_args": "--noconfirm --clean",
+        },
+        progress.append,
+    )
+
+    assert result == idle_bridge.IdlePackageResult(executable, dist_dir)
+    assert len(calls) == 1
+    assert calls[0][0] == tmp_path
+    options = calls[0][1]
+    assert isinstance(options, BuildOptions)
+    assert options.project_root == tmp_path
+    assert options.name == "demo"
+    assert options.output_dir == "dist"
+    assert options.target == "linux"
+    assert options.architecture == "x86_64"
+    assert options.mode == "onefile"
+    assert options.clean is True
+    assert options.include_dependencies is False
+    assert options.extra_args == ("--noconfirm", "--clean")
+    assert progress == [
+        "Iniciando empaquetado del proyecto Cobra...",
+        "progreso del builder",
+        f"Empaquetado completado en {dist_dir}.",
+    ]
+
+
+def test_package_current_project_acepta_objeto_simple_de_opciones(monkeypatch, tmp_path: Path) -> None:
+    captured = []
+
+    def fake_build_project(_project_path, options):
+        captured.append(options)
+        return BuildResult(success=True, executable_name="app", dist_dir=tmp_path / "dist")
+
+    monkeypatch.setattr(idle_bridge, "build_project", fake_build_project)
+
+    result = idle_bridge.package_current_project(
+        tmp_path,
+        SimpleNamespace(nombre="app", objetivo="windows", instalar_pyinstaller=True),
+    )
+
+    assert result.executable_path == tmp_path / "dist" / "app"
+    assert result.dist_dir == tmp_path / "dist"
+    assert captured[0].name == "app"
+    assert captured[0].target == "windows"
+    assert captured[0].install_pyinstaller is True
+
+
+def test_package_current_project_traduce_error_controlado(monkeypatch, tmp_path: Path) -> None:
+    errors = []
+
+    def fake_build_project(_project_path, _options):
+        raise CobraInstallerError("no existe main.cobra")
+
+    monkeypatch.setattr(idle_bridge, "build_project", fake_build_project)
+
+    with pytest.raises(RuntimeError, match="No se pudo empaquetar"):
+        idle_bridge.package_current_project(tmp_path, {}, error_callback=errors.append)
+
+    assert errors == [
+        "No se pudo empaquetar el proyecto Cobra: no existe main.cobra"
+    ]
+
+
+def test_package_from_idle_es_alias_compatible_con_kwargs(monkeypatch, tmp_path: Path) -> None:
+    captured = []
+
+    def fake_package_current_project(project_root, ui_options, progress_callback, error_callback):
+        captured.append((project_root, ui_options, progress_callback, error_callback))
+        return idle_bridge.IdlePackageResult(tmp_path / "dist" / "demo", tmp_path / "dist")
+
+    monkeypatch.setattr(idle_bridge, "package_current_project", fake_package_current_project)
+
+    result = idle_bridge.package_from_idle(tmp_path, {"nombre": "demo"}, objetivo="linux")
+
+    assert result.dist_dir == tmp_path / "dist"
+    assert captured == [(tmp_path, {"nombre": "demo", "objetivo": "linux"}, None, None)]


### PR DESCRIPTION
### Motivation
- El IDLE necesita un puente delgado que invoque la API pública del instalador sin acoplar lógica de build en la interfaz gráfica. 
- Convertir las opciones propias de la UI a `BuildOptions`, reportar progreso y devolver solo lo necesario (ruta ejecutable y `dist`) simplifica la integración del IDLE.

### Description
- Se implementa `IdlePackageResult` y `package_current_project(project_path, ui_options, progress_callback, error_callback)` en `src/pcobra/cobra_installer/idle_bridge.py`, que traduce opciones UI a `BuildOptions`, llama a `build_project(...)`, propaga mensajes de progreso y devuelve un resultado mínimo con `executable_path` y `dist_dir`.
- Se añade `package_from_idle(...)` como alias compatible que mezcla `ui_options` y `kwargs` para compatibilidad con llamadas existentes desde el IDLE.
- Se introducen mapeos de nombres de opción del IDLE (incluyendo variantes en español como `nombre`, `directorio_salida`, `objetivo`, `limpiar`, `incluir_dependencias`) hacia los campos de `BuildOptions` y normalización básica de `extra_args`.
- Se añade manejo que traduce `CobraInstallerError` a mensajes legibles por usuario y una resolución tolerante de la ruta del ejecutable resultante (soporta `.exe`, layouts `onedir`, rutas directas).

### Testing
- Se añadieron tests unitarios en `tests/unit/test_cobra_installer_idle_bridge.py` que usan mocks para validar que el IDLE solo necesita llamar al puente y comprobaron conversiones de opciones, callbacks de progreso y traducción de errores; se ejecutó `python -m pytest tests/unit/test_cobra_installer_idle_bridge.py -q` y resultó en `4 passed`.
- Se ejecutó una comprobación adicional contra partes relacionadas del instalador con `python -m pytest tests/unit/test_cobra_installer_runtime_builder.py tests/unit/test_cobra_installer_models.py tests/unit/test_cobra_installer_idle_bridge.py -q` y todos los tests ejecutados pasaron (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4677108be08327821df53b9e2a9c55)