### PR TITLE
test: add cobra installer project build coverage

### DIFF
--- a/tests/integration/test_cobra_installer_build.py
+++ b/tests/integration/test_cobra_installer_build.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pcobra.cobra_installer import BuildOptions, build_project
+from pcobra.cobra_installer.pyinstaller_runner import PyInstallerRunResult
+
+
+def _create_minimal_cobra_project(root: Path) -> tuple[Path, Path]:
+    """Crea un proyecto Cobra mínimo con entrypoint y cobra.toml."""
+
+    entrypoint = root / "main.cobra"
+    manifest = root / "cobra.toml"
+    entrypoint.write_text("imprimir('build mock')\n", encoding="utf-8")
+    manifest.write_text(
+        '[project]\nname = "demo-build"\nversion = "1.0.0"\n'
+        '[build]\nentrypoint = "main.cobra"\nbackend = "python"\n',
+        encoding="utf-8",
+    )
+    return entrypoint, manifest
+
+
+def test_installer_build_transpila_y_genera_dist_manifest_sin_pyinstaller_real(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import pcobra.cobra_installer.runtime_builder as runtime_builder
+
+    entrypoint, _manifest = _create_minimal_cobra_project(tmp_path)
+    transpile_calls: list[tuple[Path, Path]] = []
+    real_transpile_project = runtime_builder.transpile_project
+
+    def spy_transpile_project(project, build_dir, options):
+        transpile_calls.append((Path(project.entrypoint), Path(build_dir)))
+        return real_transpile_project(project, build_dir, options)
+
+    pyinstaller_calls: list[Path] = []
+
+    def fake_run_pyinstaller(spec_path, options, logger):
+        pyinstaller_calls.append(Path(spec_path))
+        logger.info("PyInstaller mockeado: no se genera ejecutable real")
+        return PyInstallerRunResult(
+            success=True,
+            version="6.mock",
+            returncode=0,
+            command=("python", "-m", "PyInstaller", str(spec_path)),
+        )
+
+    monkeypatch.setattr(runtime_builder, "transpile_project", spy_transpile_project)
+    monkeypatch.setattr(runtime_builder, "run_pyinstaller", fake_run_pyinstaller)
+
+    result = build_project(
+        tmp_path,
+        BuildOptions(project_root=tmp_path, include_dependencies=False),
+    )
+
+    dist_dir = tmp_path / "dist"
+    manifest_path = dist_dir / "cobra_build_manifest.json"
+    manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert result.success is True
+    assert result.dist_dir == dist_dir
+    assert dist_dir.is_dir()
+    assert manifest_path.is_file()
+    assert transpile_calls == [(entrypoint, tmp_path / "build")]
+    assert pyinstaller_calls == [dist_dir / "main.spec"]
+    assert result.metadata["manifest"] == str(manifest_path)
+    assert result.pyinstaller_version == "6.mock"
+    assert manifest_payload["project"] == "demo-build"
+    assert manifest_payload["backend"] == "python"
+    assert manifest_payload["executable_path"] == str(dist_dir / "main" / "main")

--- a/tests/unit/test_cobra_installer_project.py
+++ b/tests/unit/test_cobra_installer_project.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pcobra.cobra_installer import discover_project, validate_project
+
+
+def _create_minimal_cobra_project(root: Path) -> tuple[Path, Path]:
+    """Crea un proyecto Cobra mínimo para pruebas del instalador."""
+
+    entrypoint = root / "main.cobra"
+    manifest = root / "cobra.toml"
+    entrypoint.write_text("imprimir('hola desde installer')\n", encoding="utf-8")
+    manifest.write_text(
+        '[project]\nname = "demo-installer"\nversion = "0.1.0"\n'
+        '[build]\nentrypoint = "main.cobra"\n',
+        encoding="utf-8",
+    )
+    return entrypoint, manifest
+
+
+def test_installer_detecta_y_valida_proyecto_cobra_minimo(tmp_path: Path) -> None:
+    entrypoint, manifest = _create_minimal_cobra_project(tmp_path)
+
+    project = discover_project(tmp_path)
+    validation = validate_project(project)
+
+    assert project.project_root == tmp_path.resolve()
+    assert project.entrypoint == entrypoint
+    assert project.cobra_toml == manifest
+    assert project.config["project"]["name"] == "demo-installer"
+    assert project.config["build"]["entrypoint"] == "main.cobra"
+    assert validation.is_valid
+    assert validation.errors == ()


### PR DESCRIPTION
### Motivation
- Añadir cobertura de tests para el flujo del instalador/build de Cobra cubriendo detección de proyecto, validación, transpilación y generación de `dist`/manifest.
- Proveer fixtures temporales para `main.cobra` y `cobra.toml` y evitar generar ejecutables reales al mockear PyInstaller.

### Description
- Se agregan dos tests: `tests/unit/test_cobra_installer_project.py` que crea un proyecto mínimo con `main.cobra` y `cobra.toml` y valida `discover_project` y `validate_project`.
- Se agrega `tests/integration/test_cobra_installer_build.py` que crea un proyecto temporal, espía la llamada a transpilación y mockea PyInstaller vía `pcobra.cobra_installer.runtime_builder.run_pyinstaller` para no producir ejecutables reales.
- El test de integración valida que se invoca la transpilación, que se genera la carpeta `dist`, que existe `cobra_build_manifest.json` y que el manifiesto contiene los metadatos esperados (proyecto, backend, `executable_path`, etc.).
- Ajustes menores en la expectativa del path `executable_path` dentro del test para alinear con la salida real del flujo de build.

### Testing
- Ejecutado: `pytest -q tests/unit/test_cobra_installer_project.py tests/integration/test_cobra_installer_build.py`, el comando pasó con éxito.
- Ejecutado: `pytest -q tests/unit/test_cobra_installer_project.py tests/unit/test_cobra_installer_models.py tests/unit/test_cobra_installer_transpile.py tests/unit/test_pyinstaller_runner.py tests/integration/test_cobra_installer_build.py`, resultado final: `22 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a467a4ab34c83279da16aee8ad486f4)