### PR TITLE
test: cover Cobra installer dependency resolution

### DIFF
--- a/tests/unit/test_cobra_installer_dependency_resolver.py
+++ b/tests/unit/test_cobra_installer_dependency_resolver.py
@@ -73,6 +73,68 @@ def test_resuelve_desde_cache_y_genera_lock(tmp_path):
     assert len(lock["packages"][0]["sha256"]) == 64
 
 
+class _FakeCobraHubRepository:
+    def __init__(self, packages):
+        self.packages = packages
+        self.downloads = []
+
+    def download(self, name, version=None):
+        from pcobra.cobra.hub.repository import DownloadedPackage
+
+        self.downloads.append((name, version))
+        path = self.packages[(name, version)]
+        sha256 = CobraHubResolver._sha256_file(path)
+        return DownloadedPackage(path=path, name=name, version=version, checksum=sha256)
+
+
+def test_resuelve_multiples_dependencias_desde_cache_y_cobrahub_sin_red(tmp_path):
+    cached_package = _package(tmp_path, name="dep-cache", version="1.2.3")
+    remote_package = _package(tmp_path, name="dep-remota", version="2.0.0")
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    cached = cache / "dep-cache-1.2.3.co"
+    cached.write_bytes(cached_package.read_bytes())
+    remote = tmp_path / "remote" / "dep-remota-2.0.0.co"
+    remote.parent.mkdir()
+    remote.write_bytes(remote_package.read_bytes())
+    repo = _FakeCobraHubRepository({("dep-remota", "2.0.0"): remote})
+    (tmp_path / "cobra.toml").write_text(
+        '[dependencies]\ndep-cache = "1.2.3"\ndep-remota = "2.0.0"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "main.cobra").write_text(
+        "import 'dep-cache.modulo'\nimport 'dep-remota.api'\n", encoding="utf-8"
+    )
+
+    result = resolve_project_dependencies(
+        tmp_path, resolver=CobraHubResolver(repository=repo, cache_dir=cache)
+    )
+
+    assert result.used_imports == {"dep-cache", "dep-remota"}
+    assert set(result.declared) == {"dep-cache", "dep-remota"}
+    assert set(result.resolved) == {"dep-cache", "dep-remota"}
+    assert repo.downloads == [("dep-remota", "2.0.0")]
+    assert result.resolved["dep-cache"].name == "dep-cache"
+    assert result.resolved["dep-cache"].version == "1.2.3"
+    assert result.resolved["dep-cache"].path == cached
+    assert len(result.resolved["dep-cache"].sha256) == 64
+    assert result.resolved["dep-cache"].source == "installer-cache"
+    assert result.resolved["dep-remota"].name == "dep-remota"
+    assert result.resolved["dep-remota"].version == "2.0.0"
+    assert result.resolved["dep-remota"].path == remote
+    assert len(result.resolved["dep-remota"].sha256) == 64
+    assert result.resolved["dep-remota"].source == "cobrahub"
+    lock = json.loads((tmp_path / "cobra.lock").read_text(encoding="utf-8"))
+    assert [package["name"] for package in lock["packages"]] == [
+        "dep-cache",
+        "dep-remota",
+    ]
+    assert {package["source"] for package in lock["packages"]} == {
+        "installer-cache",
+        "cobrahub",
+    }
+
+
 def test_falla_si_import_no_esta_declarado(tmp_path):
     (tmp_path / "cobra.toml").write_text("", encoding="utf-8")
     (tmp_path / "main.cobra").write_text("usar dep.modulo\n", encoding="utf-8")

--- a/tests/unit/test_cobra_installer_hub_resolver.py
+++ b/tests/unit/test_cobra_installer_hub_resolver.py
@@ -1,0 +1,79 @@
+import json
+
+from pcobra.cobra.hub.repository import DownloadedPackage
+from pcobra.cobra.packaging import construir_paquete
+from pcobra.cobra_installer.hub_resolver import CobraHubResolver
+
+
+def _package(tmp_path, name="dep", version="1.2.3", dependencies=None):
+    root = tmp_path / f"pkg-{name}"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "main.cobra").write_text("var x = 1\n", encoding="utf-8")
+    manifest = {
+        "format": "cobra-package-v1",
+        "name": name,
+        "version": version,
+        "files": [],
+        "checksums": {},
+    }
+    if dependencies:
+        manifest["dependencies"] = dependencies
+    (root / "cobra.pkg.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return construir_paquete(root)
+
+
+class FakeCobraHubRepository:
+    def __init__(self, packages):
+        self.packages = packages
+        self.downloads = []
+
+    def download(self, name, version=None):
+        self.downloads.append((name, version))
+        path = self.packages[(name, version)]
+        checksum = CobraHubResolver._sha256_file(path)
+        return DownloadedPackage(path=path, name=name, version=version, checksum=checksum)
+
+
+def test_hub_resolver_devuelve_paquete_cacheado_con_hash_ruta_y_origen(tmp_path):
+    package = _package(tmp_path, name="dep-cache", version="1.2.3")
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    cached = cache / "dep-cache-1.2.3.co"
+    cached.write_bytes(package.read_bytes())
+    expected_hash = CobraHubResolver._sha256_file(cached)
+
+    result = CobraHubResolver(cache_dir=cache).resolve(
+        "dep-cache", "1.2.3", expected_sha256=expected_hash
+    )
+
+    assert result.name == "dep-cache"
+    assert result.version == "1.2.3"
+    assert result.sha256 == expected_hash
+    assert result.path == cached
+    assert result.source == "installer-cache"
+
+
+def test_hub_resolver_descarga_desde_repositorio_mock_sin_red(tmp_path):
+    remote = _package(
+        tmp_path,
+        name="dep-remota",
+        version="2.0.0",
+        dependencies={"dep-cache": "1.2.3"},
+    )
+    remote_target = tmp_path / "remote" / "dep-remota-2.0.0.co"
+    remote_target.parent.mkdir()
+    remote_target.write_bytes(remote.read_bytes())
+    repo = FakeCobraHubRepository({("dep-remota", "2.0.0"): remote_target})
+    expected_hash = CobraHubResolver._sha256_file(remote_target)
+
+    result = CobraHubResolver(repository=repo, cache_dir=tmp_path / "cache").resolve(
+        "dep-remota", "2.0.0", expected_sha256=expected_hash
+    )
+
+    assert repo.downloads == [("dep-remota", "2.0.0")]
+    assert result.name == "dep-remota"
+    assert result.version == "2.0.0"
+    assert result.sha256 == expected_hash
+    assert result.path == remote_target
+    assert result.source == "cobrahub"
+    assert result.dependencies == {"dep-cache": "1.2.3"}


### PR DESCRIPTION
### Motivation
- Aumentar la cobertura de tests para la resolución de dependencias del instalador Cobra y asegurar que el flujo mezcla caché local y descargas (sin usar la red real). 
- Verificar que los resultados incluyen nombre, versión, hash SHA-256, ruta local y origen (cache vs remoto) para cada dependencia resuelta.

### Description
- Añadí un `FakeCobraHubRepository` en `tests/unit/test_cobra_installer_dependency_resolver.py` para simular descargas sin acceso a red y registrar llamadas a `download`.
- Añadí un test en `tests/unit/test_cobra_installer_dependency_resolver.py` que declara múltiples paquetes en `cobra.toml`, usa una mezcla de paquete en caché y otro servido por el mock, y valida nombre, versión, hash, ruta y origen en `DependencyResolutionResult` y en `cobra.lock`.
- Añadí `tests/unit/test_cobra_installer_hub_resolver.py` con tests unitarios de `CobraHubResolver` que generan paquetes `.co` válidos localmente y verifican resolución desde caché y desde repositorio mockeado, incluyendo dependencias transitivas.
- Todas las modificaciones son tests; no se cambió código productivo del instalador o del resolver.

### Testing
- Ejecuté `pytest -q tests/unit/test_cobra_installer_dependency_resolver.py tests/unit/test_cobra_installer_hub_resolver.py`, que pasó exitosamente con `9 passed, 1 warning`.
- Los tests validan específicamente: detección de imports, lectura de `cobra.toml`, resolución desde caché, descarga mockeada desde repositorio y generación/contendido de `cobra.lock` con fuentes (`installer-cache`/`cobrahub`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a467c6272948327abcdb32e780b67e3)