### PR TITLE
test: cover Cobra installer dependency resolution

### DIFF
--- a/tests/unit/test_cobra_installer_dependency_resolver.py
+++ b/tests/unit/test_cobra_installer_dependency_resolver.py
@@ -190,3 +190,104 @@ def test_detecta_conflicto_transitivo(tmp_path):
         resolve_project_dependencies(
             tmp_path, resolver=CobraHubResolver(cache_dir=cache)
         )
+
+
+class MultiDependencyProjectFixture:
+    def __init__(self, tmp_path):
+        self.project_root = tmp_path / "project"
+        self.project_root.mkdir()
+        self.cache_dir = tmp_path / "cache"
+        self.cache_dir.mkdir()
+        self.remote_dir = tmp_path / "remote"
+        self.remote_dir.mkdir()
+
+        cached_package = _package(tmp_path, name="dep-cache", version="1.2.3")
+        remote_package = _package(tmp_path, name="dep-remota", version="2.0.0")
+        self.cached_path = self.cache_dir / "dep-cache-1.2.3.co"
+        self.cached_path.write_bytes(cached_package.read_bytes())
+        self.remote_path = self.remote_dir / "dep-remota-2.0.0.co"
+        self.remote_path.write_bytes(remote_package.read_bytes())
+        self.hashes = {
+            "dep-cache": CobraHubResolver._sha256_file(self.cached_path),
+            "dep-remota": CobraHubResolver._sha256_file(self.remote_path),
+        }
+        self.repository = _FakeCobraHubRepository(
+            {("dep-remota", "2.0.0"): self.remote_path}
+        )
+        (self.project_root / "cobra.toml").write_text(
+            '[dependencies]\ndep-cache = "1.2.3"\n\n'
+            '[cobra.dependencies]\ndep-remota = "2.0.0"\n',
+            encoding="utf-8",
+        )
+        (self.project_root / "main.cobra").write_text(
+            "import 'dep-cache.modulo'\nimport 'dep-remota.api'\n",
+            encoding="utf-8",
+        )
+
+    @property
+    def resolver(self):
+        return CobraHubResolver(repository=self.repository, cache_dir=self.cache_dir)
+
+
+@pytest.fixture
+def multi_dependency_project(tmp_path):
+    return MultiDependencyProjectFixture(tmp_path)
+
+
+def test_resuelve_proyecto_con_multiples_dependencias_hash_ruta_y_origen(
+    multi_dependency_project,
+):
+    fixture = multi_dependency_project
+
+    result = resolve_project_dependencies(
+        fixture.project_root, resolver=fixture.resolver
+    )
+
+    assert result.lockfile_created is True
+    assert result.used_imports == {"dep-cache", "dep-remota"}
+    assert set(result.declared) == {"dep-cache", "dep-remota"}
+    assert fixture.repository.downloads == [("dep-remota", "2.0.0")]
+    assert {
+        name: {
+            "name": resolution.name,
+            "version": resolution.version,
+            "hash": resolution.sha256,
+            "path": resolution.path,
+            "source": resolution.source,
+        }
+        for name, resolution in result.resolved.items()
+    } == {
+        "dep-cache": {
+            "name": "dep-cache",
+            "version": "1.2.3",
+            "hash": fixture.hashes["dep-cache"],
+            "path": fixture.cached_path,
+            "source": "installer-cache",
+        },
+        "dep-remota": {
+            "name": "dep-remota",
+            "version": "2.0.0",
+            "hash": fixture.hashes["dep-remota"],
+            "path": fixture.remote_path,
+            "source": "cobrahub",
+        },
+    }
+
+    lock = json.loads((fixture.project_root / "cobra.lock").read_text(encoding="utf-8"))
+    assert lock == {
+        "version": 1,
+        "packages": [
+            {
+                "name": "dep-cache",
+                "sha256": fixture.hashes["dep-cache"],
+                "source": "installer-cache",
+                "version": "1.2.3",
+            },
+            {
+                "name": "dep-remota",
+                "sha256": fixture.hashes["dep-remota"],
+                "source": "cobrahub",
+                "version": "2.0.0",
+            },
+        ],
+    }

--- a/tests/unit/test_cobra_installer_hub_resolver.py
+++ b/tests/unit/test_cobra_installer_hub_resolver.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from pcobra.cobra.hub.repository import DownloadedPackage
 from pcobra.cobra.packaging import construir_paquete
 from pcobra.cobra_installer.hub_resolver import CobraHubResolver
@@ -31,7 +33,9 @@ class FakeCobraHubRepository:
         self.downloads.append((name, version))
         path = self.packages[(name, version)]
         checksum = CobraHubResolver._sha256_file(path)
-        return DownloadedPackage(path=path, name=name, version=version, checksum=checksum)
+        return DownloadedPackage(
+            path=path, name=name, version=version, checksum=checksum
+        )
 
 
 def test_hub_resolver_devuelve_paquete_cacheado_con_hash_ruta_y_origen(tmp_path):
@@ -77,3 +81,82 @@ def test_hub_resolver_descarga_desde_repositorio_mock_sin_red(tmp_path):
     assert result.path == remote_target
     assert result.source == "cobrahub"
     assert result.dependencies == {"dep-cache": "1.2.3"}
+
+
+class MultiPackageCobraHubFixture:
+    def __init__(self, tmp_path):
+        self.cache_dir = tmp_path / "cache"
+        self.cache_dir.mkdir()
+        self.remote_dir = tmp_path / "remote"
+        self.remote_dir.mkdir()
+
+        cache_package = _package(tmp_path, name="dep-cache", version="1.2.3")
+        remote_package = _package(
+            tmp_path,
+            name="dep-remota",
+            version="2.0.0",
+            dependencies={"dep-cache": "1.2.3"},
+        )
+        self.cached_path = self.cache_dir / "dep-cache-1.2.3.co"
+        self.cached_path.write_bytes(cache_package.read_bytes())
+        self.remote_path = self.remote_dir / "dep-remota-2.0.0.co"
+        self.remote_path.write_bytes(remote_package.read_bytes())
+        self.hashes = {
+            "dep-cache": CobraHubResolver._sha256_file(self.cached_path),
+            "dep-remota": CobraHubResolver._sha256_file(self.remote_path),
+        }
+        self.repository = FakeCobraHubRepository(
+            {("dep-remota", "2.0.0"): self.remote_path}
+        )
+
+
+@pytest.fixture
+def multi_package_hub_fixture(tmp_path):
+    return MultiPackageCobraHubFixture(tmp_path)
+
+
+def test_hub_resolver_resuelve_multiples_paquetes_cache_y_remoto_sin_red(
+    multi_package_hub_fixture,
+):
+    fixture = multi_package_hub_fixture
+    resolver = CobraHubResolver(
+        repository=fixture.repository,
+        cache_dir=fixture.cache_dir,
+    )
+
+    cached_result = resolver.resolve(
+        "dep-cache", "1.2.3", expected_sha256=fixture.hashes["dep-cache"]
+    )
+    remote_result = resolver.resolve(
+        "dep-remota", "2.0.0", expected_sha256=fixture.hashes["dep-remota"]
+    )
+
+    assert fixture.repository.downloads == [("dep-remota", "2.0.0")]
+    assert {
+        cached_result.name: {
+            "version": cached_result.version,
+            "hash": cached_result.sha256,
+            "path": cached_result.path,
+            "source": cached_result.source,
+        },
+        remote_result.name: {
+            "version": remote_result.version,
+            "hash": remote_result.sha256,
+            "path": remote_result.path,
+            "source": remote_result.source,
+        },
+    } == {
+        "dep-cache": {
+            "version": "1.2.3",
+            "hash": fixture.hashes["dep-cache"],
+            "path": fixture.cached_path,
+            "source": "installer-cache",
+        },
+        "dep-remota": {
+            "version": "2.0.0",
+            "hash": fixture.hashes["dep-remota"],
+            "path": fixture.remote_path,
+            "source": "cobrahub",
+        },
+    }
+    assert remote_result.dependencies == {"dep-cache": "1.2.3"}


### PR DESCRIPTION
### Motivation

- Añadir pruebas que cubran escenarios multi-paquete para el instalador Cobra, incluyendo paquetes cacheados y paquetes remotos sin acceder a la red.
- Simular paquetes reales `.co` con hashes SHA-256 válidos y dependencias transitivas para validar la lógica de resolución y bloqueo.
- Evitar llamadas de red reales mockeando el repositorio CobraHub y validar que la salida contiene `name`, `version`, `sha256`, `path` y `source`.

### Description

- Se añadieron fixtures y un test en `tests/unit/test_cobra_installer_dependency_resolver.py` (clase `MultiDependencyProjectFixture`) que crea un proyecto con `cobra.toml`, paquetes `.co` en caché/remoto y verifica `resolve_project_dependencies` y el `cobra.lock` generado.
- Se añadieron fixtures y un test en `tests/unit/test_cobra_installer_hub_resolver.py` (clase `MultiPackageCobraHubFixture`) que prueba que `CobraHubResolver` resuelve paquetes desde caché y desde un repositorio remoto mockeado, incluyendo dependencias del paquete remoto.
- Ambos tests reutilizan los helpers existentes (`_package`, `FakeCobraHubRepository`/`_FakeCobraHubRepository`) y calculan hashes reales con `CobraHubResolver._sha256_file`.
- Los tests comprueban explícitamente que las resoluciones contienen `name`, `version`, `sha256`, `path` y `source` con orígenes `installer-cache` o `cobrahub` según corresponda.

### Testing

- Formateo con `python -m black tests/unit/test_cobra_installer_dependency_resolver.py tests/unit/test_cobra_installer_hub_resolver.py` ejecutado sin errores.
- Ejecutado `python -m pytest tests/unit/test_cobra_installer_dependency_resolver.py tests/unit/test_cobra_installer_hub_resolver.py` y todos los tests relevantes pasaron (`11 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a467d7ddf748327954327436bbc2310)