### PR TITLE
test: cover installer cache reuse

### DIFF
--- a/tests/unit/test_cobra_installer_cache.py
+++ b/tests/unit/test_cobra_installer_cache.py
@@ -69,3 +69,19 @@ def test_variable_entorno_dirige_cache_instalador(monkeypatch, tmp_path):
     assert entry is not None
     assert entry.path == configured / "dep-1.2.3.co"
     assert cache.get("dep", "1.2.3", expected_sha256=hub_hash) is None
+
+
+def test_get_reutiliza_paquete_cacheado_si_version_y_hash_coinciden(tmp_path):
+    hub_cache = tmp_path / "hub"
+    cache = CobraInstallerCache(hub_cache_dir=hub_cache)
+    artifact_hash = _write(cache.cache_dir / "dep-1.2.3.co", b"cached-package")
+
+    entry = cache.get("dep", "1.2.3", expected_sha256=f"sha256:{artifact_hash}")
+
+    assert entry is not None
+    assert entry.name == "dep"
+    assert entry.version == "1.2.3"
+    assert entry.sha256 == artifact_hash
+    assert entry.path == cache.cache_dir / "dep-1.2.3.co"
+    assert entry.source == "installer-cache"
+    assert cache.get("dep", "1.2.4", expected_sha256=artifact_hash) is None

--- a/tests/unit/test_cobra_installer_dependency_resolver.py
+++ b/tests/unit/test_cobra_installer_dependency_resolver.py
@@ -73,6 +73,39 @@ def test_resuelve_desde_cache_y_genera_lock(tmp_path):
     assert len(lock["packages"][0]["sha256"]) == 64
 
 
+def test_resuelve_dependencia_cacheada_sin_cliente_remoto_y_lock_indica_cache(tmp_path):
+    package = _package(tmp_path, name="dep-cache", version="1.2.3")
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    cached = cache / "dep-cache-1.2.3.co"
+    cached.write_bytes(package.read_bytes())
+    repo = _FakeCobraHubRepository({})
+    (tmp_path / "cobra.toml").write_text(
+        '[dependencies]\ndep-cache = "1.2.3"\n', encoding="utf-8"
+    )
+    (tmp_path / "main.cobra").write_text(
+        "usar dep-cache.modulo\n", encoding="utf-8"
+    )
+
+    result = resolve_project_dependencies(
+        tmp_path, resolver=CobraHubResolver(repository=repo, cache_dir=cache)
+    )
+
+    assert repo.downloads == []
+    assert result.resolved["dep-cache"].path == cached
+    assert result.resolved["dep-cache"].version == "1.2.3"
+    assert result.resolved["dep-cache"].source == "installer-cache"
+    lock = json.loads((tmp_path / "cobra.lock").read_text(encoding="utf-8"))
+    assert lock["packages"] == [
+        {
+            "name": "dep-cache",
+            "version": "1.2.3",
+            "sha256": result.resolved["dep-cache"].sha256,
+            "source": "installer-cache",
+        }
+    ]
+
+
 class _FakeCobraHubRepository:
     def __init__(self, packages):
         self.packages = packages

--- a/tests/unit/test_cobra_installer_hub_resolver.py
+++ b/tests/unit/test_cobra_installer_hub_resolver.py
@@ -160,3 +160,24 @@ def test_hub_resolver_resuelve_multiples_paquetes_cache_y_remoto_sin_red(
         },
     }
     assert remote_result.dependencies == {"dep-cache": "1.2.3"}
+
+
+def test_hub_resolver_reutiliza_cache_con_repo_configurado_sin_descargar(tmp_path):
+    package = _package(tmp_path, name="dep-cache", version="1.2.3")
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    cached = cache / "dep-cache-1.2.3.co"
+    cached.write_bytes(package.read_bytes())
+    expected_hash = CobraHubResolver._sha256_file(cached)
+    repo = FakeCobraHubRepository({})
+
+    result = CobraHubResolver(repository=repo, cache_dir=cache).resolve(
+        "dep-cache", "1.2.3", expected_sha256=f"sha256:{expected_hash}"
+    )
+
+    assert repo.downloads == []
+    assert result.name == "dep-cache"
+    assert result.version == "1.2.3"
+    assert result.sha256 == expected_hash
+    assert result.path == cached
+    assert result.source == "installer-cache"


### PR DESCRIPTION
### Motivation

- Asegurar que la lógica de caché del instalador reutiliza artefactos locales cuando nombre, versión y hash coinciden y no recurre al cliente remoto innecesariamente.
- Documentar mediante pruebas que `cobra.lock` refleja correctamente el origen `installer-cache` cuando procede.
- Capturar regresiones en la normalización del prefijo de hash (`sha256:`) y en la selección de candidatos de caché.

### Description

- Añadidos tests en `tests/unit/test_cobra_installer_cache.py` para validar que `CobraInstallerCache.get` reutiliza un artefacto presente en la caché propia cuando la versión y el `expected_sha256` coinciden y que no reutiliza otra versión. (F: tests/unit/test_cobra_installer_cache.py)
- Añadido test en `tests/unit/test_cobra_installer_hub_resolver.py` que crea un repositorio falso y comprueba que `CobraHubResolver.resolve` no llama a `download` cuando el paquete ya está cacheado y válido, y que la resolución reporta `source == "installer-cache"`. (F: tests/unit/test_cobra_installer_hub_resolver.py)
- Añadido test en `tests/unit/test_cobra_installer_dependency_resolver.py` que resuelve un proyecto con dependencia cacheada sin invocar al cliente remoto y verifica que `cobra.lock` contiene la entrada con `source: "installer-cache"`. (F: tests/unit/test_cobra_installer_dependency_resolver.py)

### Testing

- Ejecutado `pytest tests/unit/test_cobra_installer_cache.py tests/unit/test_cobra_installer_hub_resolver.py tests/unit/test_cobra_installer_dependency_resolver.py` y todos los tests del subconjunto pasaron (19 passed) con un único `DeprecationWarning` no relacionado con los cambios.
- Las pruebas verifican explícitamente la ausencia de llamadas a `download` en los repositorios falsos y la presencia del campo `source` en `cobra.lock` cuando corresponde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a467f10e4ec8327bc548a849342ea9a)