### PR TITLE
Parametrize installer build tests for ONEFILE and ONEDIR and set expected artifact path

### DIFF
--- a/src/pcobra/cobra_installer/manifest.py
+++ b/src/pcobra/cobra_installer/manifest.py
@@ -116,7 +116,7 @@ def create_manifest(
 
     output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / BUILD_MANIFEST_NAME
-    executable_path = _default_executable_path(output_dir, name, options)
+    executable_path = expected_artifact_path(output_dir, name, options)
     project = CobraProject(
         project_root=options.project_root,
         entrypoint=entrypoint,
@@ -196,9 +196,8 @@ def _sha256_path(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _default_executable_path(
-    output_dir: Path, name: str, options: BuildOptions
-) -> Path:
+def expected_artifact_path(output_dir: Path, name: str, options: BuildOptions) -> Path:
+    """Devuelve la ruta del artefacto final esperada para el modo de build."""
     suffix = ".exe" if _enum_value(options.target) == TargetOS.WINDOWS.value else ""
     executable = f"{name}{suffix}"
     if BuildMode.from_value(options.mode) is BuildMode.ONEDIR:
@@ -318,5 +317,6 @@ __all__ = [
     "BuildManifest",
     "DependencyInfo",
     "create_manifest",
+    "expected_artifact_path",
     "write_manifest_json",
 ]

--- a/src/pcobra/cobra_installer/runtime_builder.py
+++ b/src/pcobra/cobra_installer/runtime_builder.py
@@ -14,7 +14,7 @@ from .dependency_resolver import (
     DependencyResolutionResult,
     resolve_project_dependencies,
 )
-from .manifest import create_manifest
+from .manifest import create_manifest, expected_artifact_path
 from .project import (
     BuildOptions,
     BuildResult,
@@ -289,7 +289,7 @@ def build_project(
 
     return BuildResult(
         success=True,
-        artifact_path=output_dir,
+        artifact_path=expected_artifact_path(output_dir, name, normalized),
         project_root=Path(normalized.project_root),
         output_dir=output_dir,
         target=normalized.target,

--- a/tests/integration/test_cobra_installer_build.py
+++ b/tests/integration/test_cobra_installer_build.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from pcobra.cobra_installer import BuildOptions, build_project
+import pytest
+
+from pcobra.cobra_installer import BuildMode, BuildOptions, build_project
 from pcobra.cobra_installer.pyinstaller_runner import PyInstallerRunResult
 
 
@@ -21,8 +23,27 @@ def _create_minimal_cobra_project(root: Path) -> tuple[Path, Path]:
     return entrypoint, manifest
 
 
-def test_installer_build_transpila_y_genera_dist_manifest_sin_pyinstaller_real(
-    tmp_path: Path, monkeypatch
+@pytest.mark.parametrize(
+    ("mode", "expected_artifact", "spec_assertions"),
+    (
+        (
+            BuildMode.ONEDIR,
+            Path("dist/main/main"),
+            ("coll = COLLECT(", "exclude_binaries=True", "    a.binaries,"),
+        ),
+        (
+            BuildMode.ONEFILE,
+            Path("dist/main"),
+            ("    a.binaries,", "    a.zipfiles,", "    a.datas,"),
+        ),
+    ),
+)
+def test_installer_build_parametriza_modo_y_genera_manifest_sin_pyinstaller_real(
+    tmp_path: Path,
+    monkeypatch,
+    mode: BuildMode,
+    expected_artifact: Path,
+    spec_assertions: tuple[str, ...],
 ) -> None:
     import pcobra.cobra_installer.runtime_builder as runtime_builder
 
@@ -38,6 +59,9 @@ def test_installer_build_transpila_y_genera_dist_manifest_sin_pyinstaller_real(
 
     def fake_run_pyinstaller(spec_path, options, logger):
         pyinstaller_calls.append(Path(spec_path))
+        artifact = tmp_path / expected_artifact
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text("binario mock", encoding="utf-8")
         logger.info("PyInstaller mockeado: no se genera ejecutable real")
         return PyInstallerRunResult(
             success=True,
@@ -51,7 +75,7 @@ def test_installer_build_transpila_y_genera_dist_manifest_sin_pyinstaller_real(
 
     result = build_project(
         tmp_path,
-        BuildOptions(project_root=tmp_path, include_dependencies=False),
+        BuildOptions(project_root=tmp_path, include_dependencies=False, mode=mode),
     )
 
     dist_dir = tmp_path / "dist"
@@ -63,9 +87,21 @@ def test_installer_build_transpila_y_genera_dist_manifest_sin_pyinstaller_real(
     assert dist_dir.is_dir()
     assert manifest_path.is_file()
     assert transpile_calls == [(entrypoint, tmp_path / "build")]
-    assert pyinstaller_calls == [dist_dir / "main.spec"]
+    spec_path = dist_dir / "main.spec"
+    spec_text = spec_path.read_text(encoding="utf-8")
+
+    assert pyinstaller_calls == [spec_path]
     assert result.metadata["manifest"] == str(manifest_path)
+    assert result.metadata["spec"] == str(spec_path)
     assert result.pyinstaller_version == "6.mock"
+    assert result.mode is mode
+    assert result.artifact_path == tmp_path / expected_artifact
     assert manifest_payload["project"] == "demo-build"
     assert manifest_payload["backend"] == "python"
-    assert manifest_payload["executable_path"] == str(dist_dir / "main" / "main")
+    assert manifest_payload["mode"] == mode.value
+    assert manifest_payload["build_mode"] == mode.value
+    assert manifest_payload["executable_path"] == str(tmp_path / expected_artifact)
+    for assertion in spec_assertions:
+        assert assertion in spec_text
+    if mode is BuildMode.ONEFILE:
+        assert "coll = COLLECT(" not in spec_text


### PR DESCRIPTION
### Motivation
- Añadir cobertura que valide que `spec_writer.py` genera `.spec` diferentes según `BuildMode.ONEFILE` y `BuildMode.ONEDIR`.
- Asegurar que `pyinstaller_runner.py` recibe el `.spec` correcto y que el flujo puede validarse sin ejecutar PyInstaller real.
- Registrar en el manifiesto el modo seleccionado y que `BuildResult` apunte al artefacto final esperado por cada modo.

### Description
- Añadido un test parametrizado en `tests/integration/test_cobra_installer_build.py` que cubre `BuildMode.ONEDIR` y `BuildMode.ONEFILE`, comprueba el `.spec` generado, el `.spec` recibido por el runner mockeado, el `manifest` y el `BuildResult`.
- El mock de PyInstaller en el test ahora crea el artefacto de salida esperado para permitir que `create_manifest` y las comprobaciones posteriores funcionen sin PyInstaller real.
- Extraída y exportada la lógica de cálculo del artefacto esperado a `expected_artifact_path` en `src/pcobra/cobra_installer/manifest.py` y usada por `create_manifest`.
- `build_project` ahora establece `BuildResult.artifact_path` usando `expected_artifact_path` en vez de apuntar al directorio `dist`, y se expone `expected_artifact_path` en `__all__`.

### Testing
- Formateo aplicado con `python -m black src/pcobra/cobra_installer/runtime_builder.py src/pcobra/cobra_installer/manifest.py tests/integration/test_cobra_installer_build.py` (ok).
- Ejecutado `python -m pytest tests/integration/test_cobra_installer_build.py -q` y el test parametrizado pasó (2 tests) con éxito.
- Ejecutado `python -m ruff check src/pcobra/cobra_installer/runtime_builder.py src/pcobra/cobra_installer/manifest.py tests/integration/test_cobra_installer_build.py` sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4681a77da88327a65b245425ae5b40)