### PR TITLE
test: cover build abort on cobra.lock hash mismatch

### DIFF
--- a/tests/unit/test_cobra_installer_transpile.py
+++ b/tests/unit/test_cobra_installer_transpile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import py_compile
 from pathlib import Path
 
@@ -183,4 +184,83 @@ def test_build_cancela_antes_de_transpilar_y_pyinstaller_si_dependencia_no_exist
     message = str(exc_info.value)
     assert "dep-fantasma" in message
     assert "9.9.9" in message
+    assert calls == {"resolve": 1, "transpile": 0, "pyinstaller": 0}
+
+
+def test_build_cancela_antes_de_transpilar_y_pyinstaller_si_hash_de_lock_no_coincide(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import pcobra.cobra_installer.runtime_builder as runtime_builder
+    from pcobra.cobra_installer import build_project
+    from pcobra.cobra_installer.dependency_resolver import CobraDependencyError
+    from pcobra.cobra_installer.project import CobraInstallerError
+
+    project_root = tmp_path / "app"
+    project_root.mkdir()
+    entrypoint = project_root / "main.cobra"
+    entrypoint.write_text(
+        "usar dep-integridad.modulo\nimprimir('no transpilar')\n",
+        encoding="utf-8",
+    )
+    (project_root / "cobra.toml").write_text(
+        '[project]\nname = "demo"\n\n[dependencies]\ndep-integridad = "1.2.3"\n',
+        encoding="utf-8",
+    )
+    expected_hash = "a" * 64
+    resolved_hash = "b" * 64
+    (project_root / "cobra.lock").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "packages": [
+                    {
+                        "name": "dep-integridad",
+                        "version": "1.2.3",
+                        "sha256": expected_hash,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    calls = {"resolve": 0, "transpile": 0, "pyinstaller": 0}
+
+    def fake_resolve_project_dependencies(root):
+        calls["resolve"] += 1
+        assert Path(root) == project_root
+        lock = json.loads((project_root / "cobra.lock").read_text(encoding="utf-8"))
+        assert lock["packages"][0]["sha256"] == expected_hash
+        raise CobraDependencyError(
+            "Hash inválido para dep-integridad==1.2.3: "
+            f"se esperaba {expected_hash}, se obtuvo {resolved_hash}."
+        )
+
+    def fail_transpile_project(*_args, **_kwargs):
+        calls["transpile"] += 1
+        raise AssertionError("no debe transpilar si falla la integridad del lock")
+
+    def fail_run_pyinstaller(*_args, **_kwargs):
+        calls["pyinstaller"] += 1
+        raise AssertionError(
+            "no debe ejecutar PyInstaller si falla la integridad del lock"
+        )
+
+    monkeypatch.setattr(
+        runtime_builder,
+        "resolve_project_dependencies",
+        fake_resolve_project_dependencies,
+    )
+    monkeypatch.setattr(runtime_builder, "transpile_project", fail_transpile_project)
+    monkeypatch.setattr(runtime_builder, "run_pyinstaller", fail_run_pyinstaller)
+
+    with pytest.raises(CobraInstallerError) as exc_info:
+        build_project(
+            project_root, BuildOptions(project_root=project_root, entrypoint=entrypoint)
+        )
+
+    message = str(exc_info.value)
+    assert "dep-integridad" in message
+    assert expected_hash in message
+    assert resolved_hash in message
     assert calls == {"resolve": 1, "transpile": 0, "pyinstaller": 0}


### PR DESCRIPTION
### Motivation

- Garantizar que el flujo de build detecte y aborte cuando `cobra.lock` contiene un SHA-256 esperado que no coincide con el artefacto resuelto.
- Evitar que, en ese caso, se proceda a la transpilación o a la ejecución de PyInstaller y asegurar que el mensaje de error sea informativo sobre la dependencia y los hashes.

### Description

- Añadido `import json` y un nuevo test `test_build_cancela_antes_de_transpilar_y_pyinstaller_si_hash_de_lock_no_coincide` en `tests/unit/test_cobra_installer_transpile.py` que crea un proyecto de prueba con `cobra.lock` y simula una discrepancia de hash.
- El test sustituye `resolve_project_dependencies` por un doble que lanza `CobraDependencyError` con mensaje indicando la dependencia, el hash esperado y el hash obtenido, y sustituye `transpile_project` y `run_pyinstaller` por dobles que fallan si se llaman.
- Se comprueba explícitamente que el build se cancela antes de la transpilación y de ejecutar PyInstaller verificando contadores y que el error contiene la dependencia afectada, el hash esperado y el hash resuelto.

### Testing

- Ejecutado `pytest -q tests/unit/test_cobra_installer_transpile.py -q` y la suite específica pasó correctamente (todos los tests verdes).
- Ejecutado `git diff --check` para verificar el estilo y no se detectaron problemas tras ajustar la EOF; los cambios se commitearon con el mensaje `test: cover build abort on lock hash mismatch`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46848bee50832795eb4c862716984e)