### PR TITLE
Detectar y reportar conflictos entre dependencias transitivas de Cobra

### DIFF
--- a/src/pcobra/cobra_installer/dependency_resolver.py
+++ b/src/pcobra/cobra_installer/dependency_resolver.py
@@ -120,31 +120,51 @@ def resolve_project_dependencies(
     hub = resolver or CobraHubResolver()
     resolved: dict[str, CobraHubResolution] = {}
     requested_versions = {name: dep.version for name, dep in declared.items()}
+    dependency_chains = {
+        name: f"proyecto -> {name}=={dep.version}"
+        for name, dep in declared.items()
+    }
+    pending = sorted(requested_versions.items())
 
-    for name, dep in sorted(declared.items()):
+    while pending:
+        name, version = pending.pop(0)
+        if name in resolved:
+            continue
         lock_entry = locked.get(name)
         resolution = hub.resolve(
             name,
-            dep.version,
+            version,
             expected_sha256=lock_entry.sha256 if lock_entry else None,
             source=lock_entry.source if lock_entry else None,
         )
-        if resolution.version != dep.version:
+        if resolution.version != version:
             raise CobraDependencyError(
-                f"Conflicto de versión para {name}: cobra.toml pide {dep.version}, "
-                f"pero CobraHub resolvió {resolution.version}."
+                f"Conflicto de versión para {name}: se pidió {version}, "
+                f"pero CobraHub resolvió {resolution.version}. "
+                f"Cadena: {dependency_chains[name]}."
             )
         resolved[name] = resolution
 
-        for transitive_name, transitive_version in resolution.dependencies.items():
-            if (
-                transitive_name in requested_versions
-                and requested_versions[transitive_name] != transitive_version
-            ):
+        for transitive_name, transitive_version in sorted(
+            resolution.dependencies.items()
+        ):
+            chain = (
+                f"{dependency_chains[name]} -> "
+                f"{transitive_name}=={transitive_version}"
+            )
+            requested = requested_versions.get(transitive_name)
+            if requested is not None and requested != transitive_version:
+                previous_chain = dependency_chains[transitive_name]
                 raise CobraDependencyError(
-                    f"Conflicto de versiones: {name} requiere {transitive_name}=={transitive_version}, "
-                    f"pero el proyecto declara {transitive_name}=={requested_versions[transitive_name]}."
+                    f"Conflicto de versiones para {transitive_name}: "
+                    f"se requieren versiones incompatibles {requested} y {transitive_version}. "
+                    f"Cadena existente: {previous_chain}. "
+                    f"Cadena nueva: {chain}."
                 )
+            if requested is None:
+                requested_versions[transitive_name] = transitive_version
+                dependency_chains[transitive_name] = chain
+                pending.append((transitive_name, transitive_version))
 
     created = False
     if not lock_path.exists():

--- a/tests/unit/test_cli_installer_cmd.py
+++ b/tests/unit/test_cli_installer_cmd.py
@@ -137,7 +137,9 @@ def test_installer_build_mensajes_claros(
     monkeypatch.setattr(cobra_installer, "build_project", fake_build_project)
     command = InstallerCommandV2()
     parser = _registered_parser(command)
-    args = parser.parse_args(["installer", "build", str(tmp_path), "--target", "linux"])
+    args = parser.parse_args(
+        ["installer", "build", str(tmp_path), "--target", "linux"]
+    )
 
     assert command.run(args) == 1
     assert expected in capsys.readouterr().out
@@ -150,3 +152,31 @@ def _registered_parser(command):
     subparsers = root.add_subparsers(dest="command")
     command.register_subparser(subparsers)
     return root
+
+
+def test_installer_build_muestra_conflicto_transitivo_con_cadena(
+    monkeypatch, tmp_path, capsys
+):
+    import pcobra.cobra_installer as cobra_installer
+
+    def fake_build_project(project_path, options):
+        raise CobraInstallerError(
+            "Conflicto de versiones para compartida: se requieren versiones "
+            "incompatibles 1.0.0 y 2.0.0. Cadena existente: proyecto -> "
+            "dep-a==1.0.0 -> compartida==1.0.0. Cadena nueva: proyecto -> "
+            "dep-b==1.0.0 -> compartida==2.0.0."
+        )
+
+    monkeypatch.setattr(cobra_installer, "build_project", fake_build_project)
+    command = InstallerCommandV2()
+    parser = _registered_parser(command)
+    args = parser.parse_args(
+        ["installer", "build", str(tmp_path), "--target", "linux"]
+    )
+
+    assert command.run(args) == 1
+    output = capsys.readouterr().out
+    assert "Conflicto de versiones" in output
+    assert "compartida" in output
+    assert "Cadena existente" in output
+    assert "Cadena nueva" in output

--- a/tests/unit/test_cobra_installer_dependency_resolver.py
+++ b/tests/unit/test_cobra_installer_dependency_resolver.py
@@ -354,3 +354,47 @@ def test_dependencia_declarada_inexistente_en_cobrahub_falla_controlado(tmp_path
     assert "9.9.9" in message
     assert "CobraHub" in message
     assert repo.downloads == [("dep-fantasma", "9.9.9")]
+
+
+def test_detecta_conflicto_entre_dependencias_transitivas_y_explica_cadenas(tmp_path):
+    dep_a = _package(
+        tmp_path,
+        name="dep-a",
+        version="1.0.0",
+        dependencies={"compartida": "1.0.0"},
+    )
+    dep_b = _package(
+        tmp_path,
+        name="dep-b",
+        version="1.0.0",
+        dependencies={"compartida": "2.0.0"},
+    )
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    (cache / "dep-a-1.0.0.co").write_bytes(dep_a.read_bytes())
+    (cache / "dep-b-1.0.0.co").write_bytes(dep_b.read_bytes())
+    (tmp_path / "cobra.toml").write_text(
+        '[dependencies]\ndep-a = "1.0.0"\ndep-b = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "main.cobra").write_text(
+        "usar dep-a.api\nusar dep-b.api\n", encoding="utf-8"
+    )
+
+    with pytest.raises(CobraDependencyError) as exc_info:
+        resolve_project_dependencies(
+            tmp_path, resolver=CobraHubResolver(cache_dir=cache)
+        )
+
+    message = str(exc_info.value)
+    assert "Conflicto de versiones para compartida" in message
+    assert "versiones incompatibles 1.0.0 y 2.0.0" in message
+    assert (
+        "Cadena existente: proyecto -> dep-a==1.0.0 -> compartida==1.0.0"
+        in message
+    )
+    assert (
+        "Cadena nueva: proyecto -> dep-b==1.0.0 -> compartida==2.0.0"
+        in message
+    )
+    assert not (tmp_path / "cobra.lock").exists()

--- a/tests/unit/test_cobra_installer_idle_bridge.py
+++ b/tests/unit/test_cobra_installer_idle_bridge.py
@@ -95,7 +95,9 @@ def test_package_current_project_traduce_error_controlado(monkeypatch, tmp_path:
     monkeypatch.setattr(idle_bridge, "build_project", fake_build_project)
 
     with pytest.raises(RuntimeError, match="No se pudo empaquetar"):
-        idle_bridge.package_current_project(tmp_path, {}, error_callback=errors.append)
+        idle_bridge.package_current_project(
+            tmp_path, {}, error_callback=errors.append
+        )
 
     assert errors == [
         "No se pudo empaquetar el proyecto Cobra: no existe main.cobra"
@@ -114,4 +116,33 @@ def test_package_from_idle_es_alias_compatible_con_kwargs(monkeypatch, tmp_path:
     result = idle_bridge.package_from_idle(tmp_path, {"nombre": "demo"}, objetivo="linux")
 
     assert result.dist_dir == tmp_path / "dist"
-    assert captured == [(tmp_path, {"nombre": "demo", "objetivo": "linux"}, None, None)]
+    assert captured == [
+        (tmp_path, {"nombre": "demo", "objetivo": "linux"}, None, None)
+    ]
+
+
+def test_package_current_project_muestra_conflicto_transitivo_comprensible(
+    monkeypatch, tmp_path: Path
+) -> None:
+    errors = []
+
+    def fake_build_project(_project_path, _options):
+        raise CobraInstallerError(
+            "Conflicto de versiones para compartida: se requieren versiones "
+            "incompatibles 1.0.0 y 2.0.0. Cadena existente: proyecto -> "
+            "dep-a==1.0.0 -> compartida==1.0.0. Cadena nueva: proyecto -> "
+            "dep-b==1.0.0 -> compartida==2.0.0."
+        )
+
+    monkeypatch.setattr(idle_bridge, "build_project", fake_build_project)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        idle_bridge.package_current_project(
+            tmp_path, {}, error_callback=errors.append
+        )
+
+    message = str(exc_info.value)
+    assert "No se pudo empaquetar el proyecto Cobra" in message
+    assert "Conflicto de versiones para compartida" in message
+    assert "Cadena existente" in message
+    assert errors == [message]

--- a/tests/unit/test_cobra_installer_transpile.py
+++ b/tests/unit/test_cobra_installer_transpile.py
@@ -178,7 +178,8 @@ def test_build_cancela_antes_de_transpilar_y_pyinstaller_si_dependencia_no_exist
 
     with pytest.raises(CobraInstallerError) as exc_info:
         build_project(
-            project_root, BuildOptions(project_root=project_root, entrypoint=entrypoint)
+            project_root,
+            BuildOptions(project_root=project_root, entrypoint=entrypoint),
         )
 
     message = str(exc_info.value)
@@ -256,11 +257,70 @@ def test_build_cancela_antes_de_transpilar_y_pyinstaller_si_hash_de_lock_no_coin
 
     with pytest.raises(CobraInstallerError) as exc_info:
         build_project(
-            project_root, BuildOptions(project_root=project_root, entrypoint=entrypoint)
+            project_root,
+            BuildOptions(project_root=project_root, entrypoint=entrypoint),
         )
 
     message = str(exc_info.value)
     assert "dep-integridad" in message
     assert expected_hash in message
     assert resolved_hash in message
+    assert calls == {"resolve": 1, "transpile": 0, "pyinstaller": 0}
+
+
+def test_build_cancela_antes_de_transpilar_si_conflicto_transitivo_incompatible(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import pcobra.cobra_installer.runtime_builder as runtime_builder
+    from pcobra.cobra_installer import build_project
+    from pcobra.cobra_installer.dependency_resolver import CobraDependencyError
+    from pcobra.cobra_installer.project import CobraInstallerError
+
+    project_root = tmp_path / "app"
+    project_root.mkdir()
+    entrypoint = project_root / "main.cobra"
+    entrypoint.write_text("usar dep-a.api\nusar dep-b.api\n", encoding="utf-8")
+    (project_root / "cobra.toml").write_text(
+        '[project]\nname = "demo"\n\n'
+        '[dependencies]\ndep-a = "1.0.0"\ndep-b = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    calls = {"resolve": 0, "transpile": 0, "pyinstaller": 0}
+
+    def fake_resolve_project_dependencies(root):
+        calls["resolve"] += 1
+        assert Path(root) == project_root
+        raise CobraDependencyError(
+            "Conflicto de versiones para compartida: se requieren versiones "
+            "incompatibles 1.0.0 y 2.0.0. Cadena existente: proyecto -> "
+            "dep-a==1.0.0 -> compartida==1.0.0. Cadena nueva: proyecto -> "
+            "dep-b==1.0.0 -> compartida==2.0.0."
+        )
+
+    def fail_transpile_project(*_args, **_kwargs):
+        calls["transpile"] += 1
+        raise AssertionError("no debe transpilar si hay conflicto de dependencias")
+
+    def fail_run_pyinstaller(*_args, **_kwargs):
+        calls["pyinstaller"] += 1
+        raise AssertionError("no debe ejecutar PyInstaller si hay conflicto")
+
+    monkeypatch.setattr(
+        runtime_builder,
+        "resolve_project_dependencies",
+        fake_resolve_project_dependencies,
+    )
+    monkeypatch.setattr(runtime_builder, "transpile_project", fail_transpile_project)
+    monkeypatch.setattr(runtime_builder, "run_pyinstaller", fail_run_pyinstaller)
+
+    with pytest.raises(CobraInstallerError) as exc_info:
+        build_project(
+            project_root,
+            BuildOptions(project_root=project_root, entrypoint=entrypoint),
+        )
+
+    message = str(exc_info.value)
+    assert "Conflicto de versiones para compartida" in message
+    assert "Cadena existente" in message
+    assert "Cadena nueva" in message
     assert calls == {"resolve": 1, "transpile": 0, "pyinstaller": 0}


### PR DESCRIPTION
### Motivation
- Mejorar la detección y diagnóstico cuando dos dependencias directas requieren versiones incompatibles de la misma dependencia transitiva. 
- Proporcionar mensajes comprensibles para CLI e IDLE que incluyan la cadena de dependencias que provoca el conflicto. 

### Description
- Implementa resolución transitiva en `resolve_project_dependencies` y mantiene cadenas de dependencia (`proyecto -> paquete==versión -> ...`) para diagnosticar conflictos y lanzar `CobraDependencyError` con detalle de las cadenas. (modificado: `src/pcobra/cobra_installer/dependency_resolver.py`).
- Cuando se detecta un conflicto transitivo se muestra en el mensaje la cadena existente y la cadena nueva que causó la incompatibilidad; no se escribe `cobra.lock` en ese caso. (cambios en la lógica de resolución y control de `write_lockfile`).
- Añade pruebas unitarias que simulan dos paquetes directos (`dep-a`, `dep-b`) que requieren versiones incompatibles de `compartida` y validan que el error explique ambas cadenas y que no se genere `cobra.lock`. (tests añadidos: `tests/unit/test_cobra_installer_dependency_resolver.py`).
- Añade tests que verifican que el build se cancela antes de la transpilación y de PyInstaller ante este conflicto y que CLI e IDLE muestran/trasladan un mensaje comprensible con las cadenas de dependencia. (tests añadidos/actualizados: `tests/unit/test_cobra_installer_transpile.py`, `tests/unit/test_cobra_installer_idle_bridge.py`, `tests/unit/test_cli_installer_cmd.py`).

### Testing
- Ejecutado: `pytest -q tests/unit/test_cobra_installer_dependency_resolver.py tests/unit/test_cobra_installer_transpile.py tests/unit/test_cobra_installer_idle_bridge.py tests/unit/test_cli_installer_cmd.py` y las pruebas relevantes pasaron (todas las pruebas ejecutadas verdes con 32 passed, 1 warning en la sesión local de CI de la edición). 
- Se comprobó además que `git diff --check` no reporta problemas de formato en los ficheros modificados en este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4685a55d6883278142d6809bd47046)