### PR TITLE
test: cubrir targets del instalador Cobra (windows/linux/macos, cross-compilation y errores)

### DIFF
--- a/tests/unit/test_cobra_installer_targets.py
+++ b/tests/unit/test_cobra_installer_targets.py
@@ -39,16 +39,56 @@ def test_normalize_target_acepta_aliases(raw, expected):
     assert normalize_target(raw) is expected
 
 
-def test_expected_artifact_for_declara_formatos_finales():
-    assert expected_artifact_for("windows").extension == ".exe"
-    assert expected_artifact_for("linux").description == "binario ELF"
-    assert expected_artifact_for("macos").bundle_extension == ".app"
+@pytest.mark.parametrize(
+    ("target", "expected", "attribute", "value"),
+    [
+        ("windows", TargetOS.WINDOWS, "extension", ".exe"),
+        ("linux", TargetOS.LINUX, "description", "binario ELF"),
+        ("macos", TargetOS.MACOS, "bundle_extension", ".app"),
+    ],
+)
+def test_targets_principales_declaran_artefacto_esperado(
+    target, expected, attribute, value
+):
+    assert normalize_target(target) is expected
+    artifact = expected_artifact_for(target)
+    assert getattr(artifact, attribute) == value
 
 
-def test_validate_target_advierte_en_cross_compilation(monkeypatch):
-    monkeypatch.setattr(platform, "system", lambda: "Linux")
+@pytest.mark.parametrize(
+    ("host_system", "target", "expected"),
+    [
+        ("Windows", "windows", TargetOS.WINDOWS),
+        ("Linux", "linux", TargetOS.LINUX),
+        ("Darwin", "macos", TargetOS.MACOS),
+    ],
+)
+def test_validate_target_no_advierte_si_target_es_igual_al_host(
+    monkeypatch, host_system, target, expected
+):
+    monkeypatch.setattr(platform, "system", lambda: host_system)
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        assert validate_target(target) is expected
+    assert captured == []
+
+
+@pytest.mark.parametrize(
+    ("host_system", "target", "expected"),
+    [
+        ("Linux", "windows", TargetOS.WINDOWS),
+        ("Windows", "linux", TargetOS.LINUX),
+        ("Linux", "macos", TargetOS.MACOS),
+    ],
+)
+def test_validate_target_advierte_si_target_es_diferente_al_host(
+    monkeypatch, host_system, target, expected
+):
+    monkeypatch.setattr(platform, "system", lambda: host_system)
+
     with pytest.warns(RuntimeWarning) as captured:
-        assert validate_target("windows") is TargetOS.WINDOWS
+        assert validate_target(target) is expected
+
     message = str(captured[0].message)
     assert "PyInstaller no soporta cross-compilation de forma nativa" in message
     assert "Docker" in message
@@ -57,12 +97,14 @@ def test_validate_target_advierte_en_cross_compilation(monkeypatch):
     assert "builder remoto" in message
 
 
-def test_validate_target_no_advierte_en_host_actual(monkeypatch):
-    monkeypatch.setattr(platform, "system", lambda: "Linux")
-    with warnings.catch_warnings(record=True) as captured:
-        warnings.simplefilter("always")
-        assert validate_target("linux") is TargetOS.LINUX
-    assert captured == []
+@pytest.mark.parametrize("invalid_target", ["freebsd", "", "windows-arm64"])
+def test_normalize_target_rechaza_target_invalido(invalid_target):
+    with pytest.raises(ValueError) as excinfo:
+        normalize_target(invalid_target)
+
+    message = str(excinfo.value)
+    assert f"Target no soportado: {invalid_target!r}" in message
+    assert "windows, linux, macos, current" in message
 
 
 def test_builder_config_prepara_opciones_futuras():


### PR DESCRIPTION
### Motivation
- Asegurar que la normalización de targets y la información de artefactos funcionen para `windows`, `linux` y `macos`.
- Verificar el comportamiento de `validate_target` cuando el target coincide o difiere del host, y validar la advertencia sobre cross-compilation.
- Capturar casos de target inválido y ampliar la cobertura del `Builder`/`BuilderConfig` mínimo.

### Description
- Añadidos y parametrizados tests en `tests/unit/test_cobra_installer_targets.py` para comprobar la normalización de targets y aliases con `normalize_target`.
- Se añadió una prueba parametrizada que valida el `ExpectedArtifact` por target usando `expected_artifact_for` (extensión o `bundle_extension`).
- Se añadieron tests que comprueban que `validate_target` no emite advertencia cuando el target es igual al host y que emite `RuntimeWarning` cuando difiere, comprobando que el mensaje incluye las recomendaciones: `Docker`, `Máquina Virtual`, `runner CI/CD` y `builder remoto`.
- Se añadió cobertura para targets inválidos (por ejemplo `freebsd`, cadena vacía, `windows-arm64`) comprobando que `normalize_target` lanza `ValueError`; y se mantuvo la verificación mínima de `Builder.from_value` y `BuilderConfig.from_value`.

### Testing
- Ejecutado `pytest tests/unit/test_cobra_installer_targets.py` y la suite específica pasó completamente con `21 passed` y `1 warning` (advertencia deprecación existente), por lo que los nuevos tests son verdes.
- Las pruebas verifican explícitamente: detección de host con `detect_host_os`, normalización con `normalize_target`, formato de artefacto con `expected_artifact_for`, validación/advertencias con `validate_target`, y helpers de builder con `Builder.from_value` y `BuilderConfig.from_value`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46872dfe0c8327aa5a0707973768d6)