### PR TITLE
docs: añadir guía de Cobra Installer y actualizar empaquetado

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ cobra hub cache validar
 - Arquitectura del compilador
 - Architecture Overview
 - [Especificación del IDLE gráfico](docs/gui_idle_especificacion.md)
+- [Cobra Installer y empaquetado de ejecutables](docs/cobra_installer.md)
 - Ecosistema unificado Cobra
 - Anexos internos (NO PÚBLICO)
 - Instalación
@@ -519,21 +520,21 @@ más reciente y ejecútalo directamente.
 Crear un tag `vX.Y.Z` en GitHub desencadena la publicación automática del
 paquete en PyPI y la actualización de la imagen Docker.
 
-Si prefieres generar el ejecutable manualmente ejecuta desde la raíz del
-repositorio en tu sistema (Windows, macOS o Linux):
+Si prefieres generar un ejecutable de un proyecto Cobra manualmente, el flujo recomendado es Cobra Installer desde la raíz del proyecto:
 
 ```bash
-pip install pyinstaller
-cobra empaquetar --output dist
+cobra installer build .
+cobra build --installer .
+cobra installer build . --target windows
+cobra installer build . --target linux
+cobra installer build . --target macos
 ```
-El nombre del binario puede ajustarse con la opción `--name`. También puedes
-usar un archivo `.spec` propio o agregar datos adicionales mediante
-``--spec`` y ``--add-data``:
 
-```bash
-cobra empaquetar --spec build/cobra.spec \
-  --add-data "all-bytes.dat;all-bytes.dat" --output dist
-```
+El botón **Empaquetar** del IDLE gráfico (`cobra gui`) usa la misma capa de `pcobra.cobra_installer`: abre un proyecto, pulsa **Empaquetar**, elige `onedir` u `onefile` y revisa el progreso en el panel de salida. `onedir` genera una carpeta distribuible con ejecutable y recursos; `onefile` genera un único ejecutable que extrae recursos al arrancar. Consulta la guía completa en [`docs/cobra_installer.md`](docs/cobra_installer.md).
+
+PyInstaller no ofrece cross-compilation general entre sistemas operativos: para publicar binarios de Windows, Linux y macOS debes construir en cada sistema objetivo, o usar Docker/VM/CI/builder remoto según corresponda. Cada build genera `dist/cobra_build_manifest.json` con entrypoint, target, modo, versiones, hashes, rutas y recursos incluidos para auditoría.
+
+El comando histórico `cobra empaquetar --output dist` sigue documentado para empaquetar la CLI de Cobra, pero no es el flujo recomendado para empaquetar proyectos de usuario.
 
 ## Crear un ejecutable con PyInstaller
 
@@ -1117,8 +1118,12 @@ cobra hub buscar demo
 cobra hub instalar demo --destino ./vendor/demo
 # Generar documentación HTML y API
 cobra docs
-# Crear un ejecutable independiente
-cobra empaquetar --output dist
+# Crear un ejecutable/instalador de un proyecto Cobra
+cobra installer build .
+cobra build --installer .
+cobra installer build . --target windows
+cobra installer build . --target linux
+cobra installer build . --target macos
 # Perfilar un programa y guardar los resultados
 cobra profile programa.co --output salida.prof
 # O mostrar el perfil directamente en pantalla

--- a/docs/cobra_installer.md
+++ b/docs/cobra_installer.md
@@ -1,0 +1,171 @@
+# Cobra Installer: empaquetado de proyectos Cobra
+
+`cobra installer` construye ejecutables o carpetas distribuibles de proyectos Cobra usando la capa `pcobra.cobra_installer` y PyInstaller. Es el flujo recomendado para convertir un proyecto con `main.cobra` o `cobra.toml` en un artefacto instalable.
+
+## Uso desde el IDLE gráfico
+
+1. Abre el IDLE con `cobra gui`.
+2. Crea o abre un proyecto Cobra.
+3. Comprueba que el proyecto tenga un `main.cobra` en la raíz o un `entrypoint`/`main`/`source`/`script` configurado en `cobra.toml`.
+4. Pulsa el botón **Empaquetar**.
+5. En el diálogo, elige el modo de salida:
+   - `onedir`: carpeta distribuible con el ejecutable y sus recursos.
+   - `onefile`: ejecutable único.
+6. Confirma con **Empaquetar** y revisa el progreso en el panel de salida.
+
+El IDLE usa un puente delgado hacia `pcobra.cobra_installer.idle_bridge`; la interfaz no duplica la lógica de PyInstaller ni del manifiesto. Si no hay proyecto o ruta activa, el IDLE debe mostrar un mensaje indicando que primero hay que abrir o indicar un proyecto.
+
+## Uso desde CLI
+
+Flujo básico desde la raíz del proyecto:
+
+```bash
+cobra installer build .
+```
+
+Alias integrado en `cobra build`:
+
+```bash
+cobra build --installer .
+```
+
+Seleccionar sistema operativo objetivo declarado:
+
+```bash
+cobra installer build . --target windows
+cobra installer build . --target linux
+cobra installer build . --target macos
+```
+
+Opciones útiles:
+
+```bash
+cobra installer build . --mode onedir
+cobra installer build . --mode onefile
+cobra installer build . --name mi_app
+cobra installer build . --icon assets/icon.ico
+cobra installer build . --install-pyinstaller
+cobra installer build . --builder docker
+cobra installer build . --builder vm
+cobra installer build . --builder ci
+cobra installer build . --builder remote
+```
+
+Valores principales:
+
+| Opción | Valores | Uso |
+|---|---|---|
+| `--target` | `current`, `windows`, `linux`, `macos` | Declara el sistema operativo objetivo. |
+| `--mode` | `onedir`, `onefile` | Controla si el resultado es carpeta o ejecutable único. |
+| `--builder` | `local`, `docker`, `vm`, `ci`, `remote` | Documenta la estrategia de construcción recomendada. |
+| `--name` | texto | Nombre del ejecutable. |
+| `--icon` | ruta | Icono del artefacto, si PyInstaller lo soporta para la plataforma. |
+| `--install-pyinstaller` | bandera | Permite instalar PyInstaller automáticamente si no está disponible. |
+
+## OneDir y OneFile
+
+### OneDir (`--mode onedir`)
+
+`onedir` crea una carpeta dentro de `dist/` con el ejecutable, bibliotecas, módulos Python y recursos necesarios. Es el modo predeterminado y suele ser el más transparente para depurar.
+
+Ventajas:
+
+- Arranque más rápido que `onefile` en muchos casos.
+- Errores de recursos faltantes más fáciles de diagnosticar.
+- Permite inspeccionar qué archivos quedaron incluidos.
+
+Costes:
+
+- Distribuyes una carpeta completa, no un único archivo.
+- Es más fácil que usuarios borren accidentalmente archivos necesarios.
+
+### OneFile (`--mode onefile`)
+
+`onefile` empaqueta el proyecto como un único ejecutable. PyInstaller extrae internamente los recursos en una ubicación temporal al iniciar.
+
+Ventajas:
+
+- Distribución sencilla: un archivo principal.
+- Útil para demos, herramientas pequeñas y entregas manuales.
+
+Costes:
+
+- Inicio más lento por la extracción temporal.
+- Diagnóstico más difícil si faltan datos o imports dinámicos.
+- Antivirus o políticas corporativas pueden bloquear la extracción temporal.
+
+## Limitaciones de cross-compilation con PyInstaller
+
+PyInstaller no ofrece cross-compilation general entre sistemas operativos. En la práctica, un ejecutable de Windows debe construirse en Windows, uno de Linux en Linux y uno de macOS en macOS. La opción `--target` documenta la intención del build y ayuda a nombrar/rutar el artefacto, pero no convierte automáticamente un host Linux en compilador nativo de Windows o macOS.
+
+Recomendación operativa:
+
+- Para Windows: construir en Windows, una VM Windows, un runner CI Windows o un builder remoto Windows.
+- Para Linux: construir en Linux, contenedor Docker Linux, runner CI Linux o builder remoto Linux.
+- Para macOS: construir en macOS o runner CI macOS; la firma/notarización de Apple requiere pasos adicionales fuera de Cobra Installer.
+
+## Docker, VM, CI y builder remoto
+
+Usa `--builder` para dejar explícita la estrategia de construcción:
+
+```bash
+cobra installer build . --target linux --builder docker
+cobra installer build . --target windows --builder vm
+cobra installer build . --target macos --builder ci
+cobra installer build . --target windows --builder remote
+```
+
+Recomendaciones:
+
+- **Docker**: ideal para builds Linux reproducibles y para fijar versiones de Python, PyInstaller y dependencias.
+- **VM**: útil para Windows/macOS cuando necesitas controlar una máquina completa o probar instaladores manualmente.
+- **CI**: recomendado para publicar artefactos por release usando matrices de `windows`, `linux` y `macos`.
+- **Builder remoto**: apropiado cuando el equipo local no tiene el sistema operativo objetivo, credenciales de firma o dependencias pesadas.
+
+Aunque el builder sea remoto, conserva el manifiesto generado en `dist/cobra_build_manifest.json` junto al artefacto para auditoría y soporte.
+
+## `cobra_build_manifest.json`
+
+Cada build genera `dist/cobra_build_manifest.json`. También se escribe el alias heredado `cobra-installer-manifest.json` para integraciones antiguas.
+
+El manifiesto registra información reproducible y de diagnóstico, incluyendo:
+
+- `project`, `project_root` y `entrypoint`.
+- `version`, `name` y `executable_name`.
+- `target`, `architecture`, `mode` y `build_mode`.
+- `cobra_version` y `pyinstaller_version`.
+- `dist_dir`, `temp_dir`, `executable_path` e `icon`.
+- `hashes` SHA-256 de entradas y artefactos disponibles.
+- `dependencies` y `cobrahub_dependencies`.
+- `assets`, `assets_included`, `co_packages`, `documentation`, `config_dirs` y `auxiliary_resources`.
+- `generated_at`, `build_duration_seconds`, `runtime_included`, `final_size_bytes` e `include_dependencies`.
+
+Usos recomendados:
+
+- Adjuntarlo a releases junto al ejecutable.
+- Comparar builds entre CI y entorno local.
+- Diagnosticar qué entrypoint, recursos y versiones participaron en la construcción.
+- Validar hashes antes de redistribuir binarios.
+
+## Errores comunes y solución
+
+| Error o síntoma | Causa habitual | Solución |
+|---|---|---|
+| `PyInstaller no disponible` | PyInstaller no está instalado o no es importable en el Python activo. | Ejecuta `pip install pyinstaller` o usa `cobra installer build . --install-pyinstaller`. |
+| `No se encontró entrypoint Cobra` | No existe `main.cobra` y `cobra.toml` no declara entrada. | Crea `main.cobra` o configura un único `entrypoint`/`main`/`source`/`script` en `cobra.toml`. |
+| `No se pudo determinar un entrypoint único` | Hay varios `.cobra` o varias entradas configuradas. | Deja solo una entrada explícita en `cobra.toml` o crea `main.cobra`. |
+| `La ruta del proyecto no existe` | Se pasó una ruta incorrecta. | Ejecuta el comando desde la raíz correcta o usa una ruta absoluta válida. |
+| `cobra.toml no es válido` | TOML mal formado. | Valida comillas, secciones y claves duplicadas antes de reconstruir. |
+| `Permiso denegado` | Carpeta `build/` o `dist/` bloqueada, antivirus o permisos insuficientes. | Cierra ejecutables previos, limpia `build/`/`dist/`, revisa permisos y exclusiones de antivirus. |
+| `Falta un archivo requerido` | Un recurso referenciado por el spec, icono o configuración no existe. | Corrige rutas y vuelve a ejecutar desde la raíz del proyecto. |
+| `failed to execute script` al abrir el binario | Imports dinámicos o datos no incluidos. | Prueba `--mode onedir`, revisa recursos incluidos y añade configuración/spec si procede. |
+| Build para otro SO no produce binario nativo | Limitación de cross-compilation de PyInstaller. | Construye en el mismo SO mediante Docker Linux, VM, CI o builder remoto. |
+| El ejecutable tarda en arrancar | Modo `onefile` extrae datos temporalmente. | Usa `--mode onedir` para distribución interna o depuración. |
+
+## Checklist rápido antes de publicar
+
+- Ejecuta el artefacto en una máquina limpia del mismo sistema operativo objetivo.
+- Conserva `cobra_build_manifest.json` con el binario.
+- Prefiere `onedir` para depurar y `onefile` solo cuando un único archivo sea prioritario.
+- Usa CI con matriz de SO para releases multiplataforma.
+- Si hay recursos externos, verifica que aparezcan en `assets_included` o en las secciones de recursos del manifiesto.

--- a/docs/frontend/empaquetar.rst
+++ b/docs/frontend/empaquetar.rst
@@ -1,48 +1,108 @@
-Empaquetar la CLI
-=================
+Empaquetar proyectos e instaladores
+===================================
 
-Este proyecto puede distribuirse como un ejecutable independiente usando
-`PyInstaller <https://pyinstaller.org>`_. Internamente PyInstaller se
-ejecutar\u00e1 sobre ``src/cli/cli.py``. De forma manual podr\u00edas ejecutar
-``pyinstaller --onefile src/cli/cli.py -n cobra``.
+Flujo recomendado: Cobra Installer
+----------------------------------
 
-Para generar el ejecutable ejecuta:
+Para empaquetar un proyecto Cobra como ejecutable o carpeta distribuible usa el
+subcomando público ``installer`` desde la raíz del proyecto:
+
+.. code-block:: bash
+
+   cobra installer build .
+   cobra build --installer .
+
+También puedes declarar el sistema operativo objetivo del artefacto:
+
+.. code-block:: bash
+
+   cobra installer build . --target windows
+   cobra installer build . --target linux
+   cobra installer build . --target macos
+
+El proyecto debe tener un ``main.cobra`` en la raíz o un entrypoint configurado
+en ``cobra.toml``. La guía completa está en :doc:`../cobra_installer`.
+
+Uso desde el IDLE gráfico
+-------------------------
+
+El IDLE gráfico expone el botón **Empaquetar** para el proyecto activo:
+
+1. Inicia ``cobra gui``.
+2. Abre o crea un proyecto Cobra.
+3. Pulsa **Empaquetar**.
+4. Elige ``onedir`` o ``onefile``.
+5. Confirma con **Empaquetar** y revisa el progreso en el panel de salida.
+
+Si no hay proyecto o ruta activa, la interfaz debe avisar antes de construir. El
+IDLE delega en ``pcobra.cobra_installer.idle_bridge`` y comparte la misma lógica
+que la CLI.
+
+OneDir y OneFile
+----------------
+
+``onedir`` es el modo predeterminado. Genera una carpeta en ``dist/`` con el
+ejecutable, bibliotecas y recursos. Es más fácil de inspeccionar y depurar.
+
+``onefile`` genera un único ejecutable. Es cómodo para distribución manual, pero
+puede tardar más en arrancar porque PyInstaller extrae recursos en una ubicación
+temporal.
+
+Limitaciones de plataforma
+--------------------------
+
+PyInstaller debe construir normalmente en el mismo sistema operativo donde se
+ejecutará el binario. La opción ``--target`` expresa la intención del build, pero
+no convierte automáticamente Linux en un compilador nativo de Windows o macOS.
+Para publicar artefactos multiplataforma usa:
+
+- Docker para builds Linux reproducibles.
+- VM Windows/macOS cuando necesites el sistema completo.
+- CI con matriz ``windows``, ``linux`` y ``macos`` para releases.
+- Builder remoto si el equipo local no tiene el SO, firma o dependencias.
+
+Manifiesto de build
+-------------------
+
+Cada ejecución genera ``dist/cobra_build_manifest.json`` y, por compatibilidad,
+``cobra-installer-manifest.json``. El manifiesto registra entrypoint, target,
+modo ``onedir``/``onefile``, versiones de Cobra y PyInstaller, hashes SHA-256,
+rutas de salida, recursos incluidos, dependencias y tamaño final. Adjunta este
+archivo a los releases para auditoría y diagnóstico.
+
+Errores comunes
+---------------
+
+- ``PyInstaller no disponible``: instala ``pyinstaller`` o ejecuta
+  ``cobra installer build . --install-pyinstaller``.
+- ``No se encontró entrypoint Cobra``: crea ``main.cobra`` o configura una única
+  entrada en ``cobra.toml``.
+- ``Permiso denegado``: cierra binarios previos, limpia ``build/`` y ``dist/`` y
+  revisa antivirus/permisos.
+- ``failed to execute script``: prueba ``--mode onedir`` y revisa imports o datos
+  no incluidos.
+- Build de otro sistema operativo: construye en ese SO mediante Docker, VM, CI o
+  builder remoto.
+
+Flujo histórico para empaquetar la CLI
+--------------------------------------
+
+El comando ``cobra empaquetar`` se mantiene para empaquetar la propia CLI de
+Cobra como ejecutable independiente. Internamente ejecuta PyInstaller sobre la
+CLI del proyecto.
 
 .. code-block:: bash
 
    cobra empaquetar --output dist
-
-El nombre del ejecutable puede cambiarse con ``--name``. Por ejemplo:
-
-.. code-block:: bash
-
    cobra empaquetar --name cobra --output dist
 
 También puedes pasar un archivo ``.spec`` personalizado o incluir archivos
-adicionales en el paquete utilizando ``--spec`` y ``--add-data``:
+adicionales con ``--spec`` y ``--add-data``:
 
 .. code-block:: bash
 
    cobra empaquetar --spec build/cobra.spec \
        --add-data "all-bytes.dat;all-bytes.dat" --output dist
 
-Esto creará un archivo ``cobra`` (o ``cobra.exe`` en Windows) en el directorio
-``dist``. Se necesita tener ``pyinstaller`` instalado previamente. Puedes
-instalarlo con ``pip install pyinstaller``.
-
-Requisitos de plataforma
-------------------------
-
-PyInstaller está disponible para Windows, macOS y Linux. El ejecutable sólo
-funciona en el mismo sistema operativo donde se creó. Si deseas distribuir para
-varias plataformas, debes empaquetar el proyecto en cada una de ellas.
-
-Los pasos para generar el binario son idénticos en los tres sistemas operativos:
-
-.. code-block:: bash
-
-   pip install pyinstaller
-   cobra empaquetar --output dist
-
-En caso de necesitar archivos adicionales o un ``.spec`` propio, utiliza las
-opciones ``--add-data`` y ``--spec`` mostradas anteriormente.
+Se necesita tener ``pyinstaller`` instalado previamente si no usas los flujos que
+lo instalan explícitamente.

--- a/docs/frontend/index.rst
+++ b/docs/frontend/index.rst
@@ -44,6 +44,7 @@ Cobra es un lenguaje de programación experimental completamente en español. Su
    ../standard_library/numero
    validador
    modo_seguro
+   ../cobra_installer
    empaquetar
    contenedores
    paquetes

--- a/docs/gui_idle.md
+++ b/docs/gui_idle.md
@@ -71,3 +71,9 @@ Al seleccionar un archivo visible, el IDLE llama a `runtime.cargar_archivo_desde
 
 - **Flet:** Flet es una dependencia opcional de la GUI. Importar módulos CLI no debe requerir Flet; abrir el IDLE sí requiere instalarlo. Si Flet no está disponible, la aplicación CLI debe poder seguir funcionando y el intento de iniciar la GUI debe informar la dependencia faltante en lugar de romper flujos no gráficos.
 - **Motor IA de sugerencias:** las sugerencias dependen del motor IA declarado por el proyecto (`agix`). Si la dependencia opcional no está disponible, el botón de sugerencias aparece deshabilitado o muestra el motivo por el que no se pueden generar recomendaciones. La ejecución, los tokens, el AST, la transpilación y las acciones de archivo no deben depender de ese motor IA.
+
+## Empaquetar proyectos desde el IDLE
+
+El botón **Empaquetar** construye un artefacto instalable del proyecto activo usando la misma capa que `cobra installer build .`. El usuario debe abrir o crear un proyecto, pulsar **Empaquetar**, seleccionar `onedir` o `onefile` y confirmar. `onedir` genera una carpeta distribuible; `onefile` genera un ejecutable único con extracción temporal al arrancar.
+
+Si no hay proyecto o ruta activa, el IDLE muestra un aviso antes de invocar el build. Para detalles de CLI, cross-compilation, Docker/VM/CI, manifiesto `cobra_build_manifest.json` y solución de errores, consulta [`docs/cobra_installer.md`](cobra_installer.md).


### PR DESCRIPTION
### Motivation

- Centralizar y documentar el flujo recomendado para generar instaladores/ejecutables de proyectos Cobra usando la nueva capa `pcobra.cobra_installer` y PyInstaller. 
- Aclarar el uso desde el IDLE (botón **Empaquetar**), la CLI (`cobra installer build` / `cobra build --installer`) y los modos `onefile`/`onedir` junto con limitaciones de cross-compilation. 

### Description

- Añade `docs/cobra_installer.md` con guía completa: uso desde IDLE, ejemplos CLI (`cobra installer build .`, `cobra build --installer .`, `--target windows|linux|macos`), explicación `OneFile`/`OneDir`, limitaciones de PyInstaller, recomendaciones Docker/VM/CI/builder remoto, descripción de `cobra_build_manifest.json` y errores comunes con soluciones. 
- Actualiza `README.md` para enlazar la nueva guía y sustituir la recomendación de `cobra empaquetar` por los flujos `cobra installer build` / `cobra build --installer` (manteniendo `cobra empaquetar` como flujo histórico para empaquetar la CLI). 
- Reescribe `docs/frontend/empaquetar.rst` para documentar el empaquetado de proyectos e instaladores y mantener el apartado histórico de empaquetar la propia CLI. 
- Registra la nueva guía en el índice Sphinx `docs/frontend/index.rst` y agrega una nota explicativa sobre el botón **Empaquetar** en `docs/gui_idle.md`. 
- Todos los archivos modificados fueron añadidos y comiteados (`docs/cobra_installer.md`, `README.md`, `docs/frontend/empaquetar.rst`, `docs/frontend/index.rst`, `docs/gui_idle.md`).

### Testing

- Ejecuté `git diff --check` y `python -m compileall src/pcobra/cobra_installer src/pcobra/cobra/cli/commands_v2`, ambos OK. 
- Intenté generar la documentación con Sphinx: `python -m sphinx -b html docs/frontend docs/frontend/_build/html` pero falló por ausencia de PlantUML en el entorno (`RuntimeError: PlantUML no está instalado en el sistema`). 
- Ejecuté tests seleccionados: `pytest tests/unit/test_cobra_installer_models.py tests/unit/test_cobra_installer_spec_writer.py tests/unit/test_pyinstaller_runner.py tests/integration/test_cobra_installer_build.py`; las pruebas unitarias pasaron (20 tests) y hay 2 fallos en `tests/integration/test_cobra_installer_build.py` por una incompatibilidad en la firma del `spy_transpile_project` usado en el test (el stub acepta 3 argumentos mientras que `build_project` lo invoca con 4).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46896bd69883278a84ca417e693390)