### PR TITLE
Add build backend abstraction for cobra_installer (BuilderKind / BuildBackend)

### DIFF
--- a/src/pcobra/cobra_installer/__init__.py
+++ b/src/pcobra/cobra_installer/__init__.py
@@ -7,6 +7,12 @@ puente delgado de :mod:`pcobra.cobra_installer.idle_bridge`.
 
 from __future__ import annotations
 
+from .builders import (
+    BuildBackend,
+    BuilderKind,
+    LocalPyInstallerBuilder,
+    resolve_build_backend,
+)
 from .logger import BuildLogger, ProgressEvent
 from .manifest import BuildManifest, DependencyInfo
 from .spec_writer import SpecBuildContext, write_spec
@@ -45,12 +51,15 @@ __all__ = [
     "BuildManifest",
     "BuildMode",
     "Builder",
+    "BuilderKind",
+    "BuildBackend",
     "BuilderConfig",
     "BuildOptions",
     "BuildResult",
     "CobraProject",
     "CobraInstallerError",
     "ProgressEvent",
+    "LocalPyInstallerBuilder",
     "ProjectResources",
     "collect_project_resources",
     "discover_project",
@@ -72,5 +81,6 @@ __all__ = [
     "validate_target",
     "package_current_project",
     "prepare_runtime",
+    "resolve_build_backend",
     "write_spec",
 ]

--- a/src/pcobra/cobra_installer/builders.py
+++ b/src/pcobra/cobra_installer/builders.py
@@ -1,0 +1,83 @@
+"""Abstracciones internas para builders de cobra_installer.
+
+La arquitectura separa la selección del entorno de build de la orquestación del
+proyecto. Por ahora solo el builder local ejecuta PyInstaller directamente en el
+host; docker/vm/ci/remote quedan reservados para implementaciones futuras.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Protocol, runtime_checkable
+
+from .logger import BuildLogger
+from .project import BuildOptions, CobraInstallerError
+from .pyinstaller_runner import PyInstallerRunResult, run_pyinstaller
+from .targets import BuilderKind
+
+_RESERVED_BUILDERS = {
+    BuilderKind.DOCKER: "Docker",
+    BuilderKind.VM: "máquina virtual",
+    BuilderKind.CI: "runner CI/CD",
+    BuilderKind.REMOTE: "builder remoto",
+}
+
+
+@runtime_checkable
+class BuildBackend(Protocol):
+    """Contrato mínimo para ejecutar el paso backend de un build Cobra."""
+
+    kind: BuilderKind
+
+    def run_pyinstaller(
+        self, spec_path: Path, options: BuildOptions, logger: BuildLogger
+    ) -> PyInstallerRunResult:
+        """Ejecuta PyInstaller o una estrategia equivalente para generar el artefacto."""
+
+
+@dataclass(frozen=True, slots=True)
+class LocalPyInstallerBuilder:
+    """Backend local que delega el empaquetado en PyInstaller sobre el host actual."""
+
+    kind: BuilderKind = BuilderKind.LOCAL
+    runner: Callable[[Path, BuildOptions, BuildLogger], PyInstallerRunResult] = (
+        run_pyinstaller
+    )
+
+    def run_pyinstaller(
+        self, spec_path: Path, options: BuildOptions, logger: BuildLogger
+    ) -> PyInstallerRunResult:
+        """Ejecuta PyInstaller localmente usando las opciones normalizadas."""
+
+        return self.runner(spec_path, options, logger)
+
+
+def resolve_build_backend(kind: BuilderKind | str | None) -> BuildBackend:
+    """Devuelve el backend implementado o falla con un mensaje explícito.
+
+    Los builders docker/vm/ci/remote se aceptan como valores reservados para que
+    la API pública ya refleje la arquitectura prevista, pero todavía no pueden
+    ejecutar builds.
+    """
+
+    builder_kind = BuilderKind.from_value(kind)
+    if builder_kind is BuilderKind.LOCAL:
+        return LocalPyInstallerBuilder()
+
+    planned = _RESERVED_BUILDERS[builder_kind]
+    reserved = ", ".join(item.value for item in BuilderKind)
+    raise CobraInstallerError(
+        "Builder no disponible todavía: "
+        f"{builder_kind.value!r}. La arquitectura de cobra_installer ya está "
+        f"preparada para builders ({reserved}), pero el builder basado en "
+        f"{planned} todavía no está implementado. Usa builder='local' por ahora."
+    )
+
+
+__all__ = [
+    "BuildBackend",
+    "BuilderKind",
+    "LocalPyInstallerBuilder",
+    "resolve_build_backend",
+]

--- a/src/pcobra/cobra_installer/runtime_builder.py
+++ b/src/pcobra/cobra_installer/runtime_builder.py
@@ -9,6 +9,7 @@ from typing import Mapping, Sequence
 
 import pcobra
 
+from .builders import LocalPyInstallerBuilder, resolve_build_backend
 from .logger import BuildLogger, emit_many
 from .dependency_resolver import (
     DependencyResolutionResult,
@@ -192,6 +193,9 @@ def build_project(
     if overrides:
         base = replace(base, **overrides)
     normalized = validate_build_options(base)
+    build_backend = resolve_build_backend(normalized.builder)
+    if isinstance(build_backend, LocalPyInstallerBuilder):
+        build_backend = LocalPyInstallerBuilder(runner=run_pyinstaller)
     logger = BuildLogger(legacy_callback=normalized.log_callback)
     logs: list[str] = []
 
@@ -275,7 +279,7 @@ def build_project(
     )
 
     step("ejecucion_pyinstaller", "Ejecutando PyInstaller...", 8)
-    pyinstaller = run_pyinstaller(spec_path, normalized, logger)
+    pyinstaller = build_backend.run_pyinstaller(spec_path, normalized, logger)
 
     step("escritura_manifiesto", "Escribiendo manifiesto de build...", 9)
     manifest_path = create_manifest(

--- a/src/pcobra/cobra_installer/targets.py
+++ b/src/pcobra/cobra_installer/targets.py
@@ -67,8 +67,8 @@ class TargetOS(StrEnum):
         return EXPECTED_ARTIFACTS[self]
 
 
-class Builder(StrEnum):
-    """Builders futuros para aislar builds no nativos."""
+class BuilderKind(StrEnum):
+    """Tipos de builder soportados o reservados para aislar builds."""
 
     LOCAL = "local"
     DOCKER = "docker"
@@ -77,7 +77,7 @@ class Builder(StrEnum):
     REMOTE = "remote"
 
     @classmethod
-    def from_value(cls, value: "Builder | str | None") -> "Builder":
+    def from_value(cls, value: "BuilderKind | str | None") -> "BuilderKind":
         """Normaliza la selección de builder sin activar implementaciones futuras."""
 
         if value is None:
@@ -87,11 +87,15 @@ class Builder(StrEnum):
         return cls(str(value).strip().lower())
 
 
+# Alias de compatibilidad: la API pública histórica exportaba ``Builder``.
+Builder = BuilderKind
+
+
 @dataclass(frozen=True, slots=True)
 class BuilderConfig:
     """Esqueleto de configuración para builders futuros."""
 
-    builder: Builder = Builder.LOCAL
+    builder: BuilderKind = BuilderKind.LOCAL
     image: str | None = None
     vm_name: str | None = None
     ci_runner: str | None = None
@@ -99,13 +103,13 @@ class BuilderConfig:
 
     @classmethod
     def from_value(
-        cls, value: "BuilderConfig | Builder | str | None"
+        cls, value: "BuilderConfig | BuilderKind | str | None"
     ) -> "BuilderConfig":
         """Crea una configuración mínima desde un builder o cadena."""
 
         if isinstance(value, cls):
             return value
-        return cls(builder=Builder.from_value(value))
+        return cls(builder=BuilderKind.from_value(value))
 
 
 @dataclass(frozen=True, slots=True)
@@ -177,6 +181,7 @@ def expected_artifact_for(target: TargetOS | str) -> ExpectedArtifact:
 __all__ = [
     "BuildMode",
     "Builder",
+    "BuilderKind",
     "BuilderConfig",
     "CROSS_COMPILATION_WARNING",
     "EXPECTED_ARTIFACTS",

--- a/tests/integration/test_cobra_installer_build.py
+++ b/tests/integration/test_cobra_installer_build.py
@@ -51,9 +51,11 @@ def test_installer_build_parametriza_modo_y_genera_manifest_sin_pyinstaller_real
     transpile_calls: list[tuple[Path, Path]] = []
     real_transpile_project = runtime_builder.transpile_project
 
-    def spy_transpile_project(project, build_dir, options):
+    def spy_transpile_project(project, build_dir, options, dependency_resolution=None):
         transpile_calls.append((Path(project.entrypoint), Path(build_dir)))
-        return real_transpile_project(project, build_dir, options)
+        return real_transpile_project(
+            project, build_dir, options, dependency_resolution
+        )
 
     pyinstaller_calls: list[Path] = []
 

--- a/tests/unit/test_cobra_installer_builders.py
+++ b/tests/unit/test_cobra_installer_builders.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from pcobra.cobra_installer import (
+    BuildBackend,
+    Builder,
+    BuilderKind,
+    CobraInstallerError,
+    LocalPyInstallerBuilder,
+    resolve_build_backend,
+)
+
+
+@pytest.mark.parametrize("reserved", ["docker", "vm", "ci", "remote"])
+def test_builders_reservados_devuelven_error_claro(reserved: str) -> None:
+    with pytest.raises(CobraInstallerError) as exc_info:
+        resolve_build_backend(reserved)
+
+    message = str(exc_info.value)
+    assert f"{reserved!r}" in message
+    assert "arquitectura" in message
+    assert "todavía no está implementado" in message
+    assert "builder='local'" in message
+
+
+def test_builder_local_resuelve_backend_pyinstaller() -> None:
+    backend = resolve_build_backend(BuilderKind.LOCAL)
+
+    assert isinstance(backend, LocalPyInstallerBuilder)
+    assert backend.kind is Builder.LOCAL
+    assert isinstance(backend, BuildBackend)


### PR DESCRIPTION
### Motivation

- Separar la selección del entorno de build de la orquestación para permitir futuros backends (docker/vm/ci/remote) sin romper la lógica actual.  
- Soportar de forma explícita `local` ahora y reservar las demás opciones mostrando un error claro cuando se seleccionen.  

### Description

- Se añadió `src/pcobra/cobra_installer/builders.py` con la abstracción `BuildBackend` (protocol), la implementación `LocalPyInstallerBuilder` y la función `resolve_build_backend` que resuelve o falla con mensaje explícito para builders reservados.  
- El enum público en `targets.py` fue renombrado internamente a `BuilderKind` y se mantiene `Builder = BuilderKind` como alias de compatibilidad, además se actualizó `BuilderConfig` para usar `BuilderKind`.  
- `runtime_builder.build_project` ahora resuelve el backend mediante `resolve_build_backend` y delega la ejecución de PyInstaller al backend resuelto, preservando la posibilidad de monkeypatch en pruebas para el builder local.  
- Se exportaron las nuevas piezas relevantes desde `pcobra.cobra_installer.__init__` y se añadieron pruebas en `tests/unit/test_cobra_installer_builders.py` junto a un ajuste menor en `tests/integration/test_cobra_installer_build.py` para acomodar el cambio de firma del spy de transpilación.  

### Testing

- Formateo con `python -m black ...` ejecutado con éxito sobre los módulos modificados.  
- Se ejecutaron `pytest` para `tests/unit/test_cobra_installer_builders.py` y `tests/integration/test_cobra_installer_build.py` y todos los tests pasaron (`7 passed`, `1 warning`).  
- Se verificó la compilación de bytecode con `python -m compileall -q` y terminó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a474df7950083278c956154ef0e1ff9)