### PR TITLE
Agregar códigos de salida para `cobra installer` y su alias

### DIFF
--- a/docs/cobra_installer.md
+++ b/docs/cobra_installer.md
@@ -147,6 +147,22 @@ Usos recomendados:
 - Diagnosticar qué entrypoint, recursos y versiones participaron en la construcción.
 - Validar hashes antes de redistribuir binarios.
 
+
+## Códigos de salida CLI
+
+`cobra installer build` y el alias `cobra build --installer` comparten la misma implementación de la capa CLI, por lo que devuelven los mismos códigos de salida para los mismos fallos. Los códigos públicos son:
+
+| Código | Nombre | Significado |
+|---:|---|---|
+| `0` | éxito | El artefacto se generó correctamente. |
+| `10` | proyecto inválido | La estructura del proyecto, `cobra.toml` o el entrypoint no son válidos. |
+| `11` | dependencia inexistente | Falta una ruta, recurso, paquete CobraHub o dependencia requerida. |
+| `12` | conflicto de versiones | Versiones declaradas, transitivas o bloqueadas son incompatibles. |
+| `13` | hash incorrecto | Un hash, checksum o SHA-256 no coincide con el valor esperado. |
+| `14` | PyInstaller no disponible | PyInstaller no está instalado o no puede importarse en el Python activo. |
+| `15` | target inválido | El sistema operativo objetivo solicitado no es válido o no está soportado. |
+| `70` | error interno inesperado | Fallo no clasificado en la frontera CLI del instalador. |
+
 ## Errores comunes y solución
 
 | Error o síntoma | Causa habitual | Solución |

--- a/src/pcobra/cobra/cli/commands_v2/installer_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/installer_cmd.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pcobra.cobra_installer as cobra_installer
 from pcobra.cobra.cli.commands.base import BaseCommand
+from pcobra.cobra.cli.exit_codes import CobraExitCode
 from pcobra.cobra_installer import BuildOptions, CobraInstallerError
 
 
@@ -57,7 +58,9 @@ def register_installer_build_arguments(
             help="Ruta del proyecto Cobra a empaquetar",
         )
     parser.add_argument(
-        "--target", choices=("current", "windows", "linux", "macos"), default="current"
+        "--target",
+        default="current",
+        help="Sistema operativo objetivo: current, windows, linux o macos",
     )
     parser.add_argument("--mode", choices=("onefile", "onedir"), default="onedir")
     parser.add_argument("--name", dest="name")
@@ -99,12 +102,17 @@ def run_installer_build(args: Any) -> int:
         for warning in caught:
             print(f"Aviso: {_friendly_installer_error(str(warning.message))}")
     except CobraInstallerError as exc:
-        print(f"Error: {_friendly_installer_error(str(exc))}")
-        return 1
+        message = str(exc)
+        print(f"Error: {_friendly_installer_error(message)}")
+        return int(_installer_exit_code(message))
+    except Exception as exc:  # pragma: no cover - salvaguarda de frontera CLI
+        message = str(exc).strip() or "fallo interno inesperado del instalador."
+        print(f"Error: Error interno inesperado: {message}")
+        return int(CobraExitCode.UNEXPECTED_INTERNAL_ERROR)
 
     artifact = result.artifact_path or result.output_dir or result.dist_dir
     print(f"Build completado correctamente: {artifact}")
-    return 0
+    return int(CobraExitCode.SUCCESS)
 
 
 def _friendly_installer_error(message: str) -> str:
@@ -112,6 +120,8 @@ def _friendly_installer_error(message: str) -> str:
 
     text = message.strip() or "fallo desconocido del instalador."
     lowered = text.lower()
+    if _is_invalid_target_error(lowered):
+        return f"Target inválido: {text}"
     if (
         "no es válida" in lowered
         or "no es válido" in lowered
@@ -126,7 +136,7 @@ def _friendly_installer_error(message: str) -> str:
         return f"Dependencia o ruta inexistente: {text}"
     if "hash" in lowered or "sha256" in lowered or "checksum" in lowered:
         return f"Hash incorrecto: {text}"
-    if "conflicto de versiones" in lowered or "version conflict" in lowered:
+    if _is_version_conflict_error(lowered):
         return f"Conflicto de versiones: {text}"
     if (
         "pyinstaller no está instalado" in lowered
@@ -136,3 +146,69 @@ def _friendly_installer_error(message: str) -> str:
     if "cross-compilation" in lowered or "cross compilation" in lowered:
         return f"Cross-compilation solicitada: {text}"
     return text
+
+
+def _installer_exit_code(message: str) -> CobraExitCode:
+    """Clasifica errores controlados del instalador en códigos de salida estables."""
+
+    lowered = (message or "").strip().lower()
+    if _is_invalid_target_error(lowered):
+        return CobraExitCode.INVALID_TARGET
+    if _is_pyinstaller_unavailable_error(lowered):
+        return CobraExitCode.PYINSTALLER_UNAVAILABLE
+    if _is_hash_mismatch_error(lowered):
+        return CobraExitCode.HASH_MISMATCH
+    if _is_version_conflict_error(lowered):
+        return CobraExitCode.VERSION_CONFLICT
+    if _is_missing_dependency_error(lowered):
+        return CobraExitCode.MISSING_DEPENDENCY
+    if _is_invalid_project_error(lowered):
+        return CobraExitCode.INVALID_PROJECT
+    return CobraExitCode.UNEXPECTED_INTERNAL_ERROR
+
+
+def _is_invalid_project_error(lowered: str) -> bool:
+    return (
+        "no es válida" in lowered
+        or "no es válido" in lowered
+        or "no se encontró entrypoint" in lowered
+    )
+
+
+def _is_missing_dependency_error(lowered: str) -> bool:
+    return (
+        "dependencia cobra no encontrada" in lowered
+        or "no existe" in lowered
+        or "no es un directorio" in lowered
+        or "no es una carpeta" in lowered
+    )
+
+
+def _is_hash_mismatch_error(lowered: str) -> bool:
+    return "hash" in lowered or "sha256" in lowered or "checksum" in lowered
+
+
+def _is_version_conflict_error(lowered: str) -> bool:
+    return (
+        "conflicto de versiones" in lowered
+        or "conflicto de versión" in lowered
+        or "version conflict" in lowered
+        or "versión incorrecta" in lowered
+    )
+
+
+def _is_pyinstaller_unavailable_error(lowered: str) -> bool:
+    return (
+        "pyinstaller no está instalado" in lowered
+        or "no está instalado o no es importable" in lowered
+    )
+
+
+def _is_invalid_target_error(lowered: str) -> bool:
+    return (
+        "target inválido" in lowered
+        or "target invalid" in lowered
+        or "target seleccionado" in lowered
+        or "target" in lowered and "no soport" in lowered
+        or "invalid target" in lowered
+    )

--- a/src/pcobra/cobra/cli/exit_codes.py
+++ b/src/pcobra/cobra/cli/exit_codes.py
@@ -1,0 +1,21 @@
+"""Códigos de salida públicos para la CLI de Cobra."""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class CobraExitCode(IntEnum):
+    """Códigos de salida estables usados por comandos CLI públicos."""
+
+    SUCCESS = 0
+    INVALID_PROJECT = 10
+    MISSING_DEPENDENCY = 11
+    VERSION_CONFLICT = 12
+    HASH_MISMATCH = 13
+    PYINSTALLER_UNAVAILABLE = 14
+    INVALID_TARGET = 15
+    UNEXPECTED_INTERNAL_ERROR = 70
+
+
+__all__ = ["CobraExitCode"]

--- a/tests/unit/test_cli_installer_cmd.py
+++ b/tests/unit/test_cli_installer_cmd.py
@@ -4,6 +4,7 @@ import pytest
 
 from pcobra.cobra.cli.commands_v2.build_cmd import BuildCommandV2
 from pcobra.cobra.cli.commands_v2.installer_cmd import InstallerCommandV2
+from pcobra.cobra.cli.exit_codes import CobraExitCode
 from pcobra.cobra_installer import BuildMode, Builder, CobraInstallerError, TargetOS
 from pcobra.cobra_installer.project import BuildResult
 
@@ -105,29 +106,47 @@ def test_build_installer_alias_equivale_en_error(monkeypatch, tmp_path, capsys):
     alias_status = build_command.run(alias_args)
     alias_output = capsys.readouterr().out
 
-    assert installer_status == alias_status == 1
+    assert installer_status == alias_status == int(CobraExitCode.MISSING_DEPENDENCY)
     assert installer_output == alias_output
 
 
 @pytest.mark.parametrize(
-    ("message", "expected"),
+    ("message", "expected", "exit_code"),
     [
         (
             "La estructura del proyecto no es válida: falta main.cobra",
             "Proyecto inválido",
+            CobraExitCode.INVALID_PROJECT,
         ),
-        ("La ruta del proyecto no existe: demo", "Dependencia o ruta inexistente"),
-        ("sha256 esperado no coincide", "Hash incorrecto"),
-        ("Conflicto de versiones para dep", "Conflicto de versiones"),
-        ("PyInstaller no está instalado", "PyInstaller no disponible"),
         (
-            "PyInstaller no soporta cross-compilation de forma nativa",
-            "Cross-compilation solicitada",
+            "La ruta del proyecto no existe: demo",
+            "Dependencia o ruta inexistente",
+            CobraExitCode.MISSING_DEPENDENCY,
+        ),
+        (
+            "sha256 esperado no coincide",
+            "Hash incorrecto",
+            CobraExitCode.HASH_MISMATCH,
+        ),
+        (
+            "Conflicto de versiones para dep",
+            "Conflicto de versiones",
+            CobraExitCode.VERSION_CONFLICT,
+        ),
+        (
+            "PyInstaller no está instalado",
+            "PyInstaller no disponible",
+            CobraExitCode.PYINSTALLER_UNAVAILABLE,
+        ),
+        (
+            "Target inválido: solaris",
+            "Target inválido",
+            CobraExitCode.INVALID_TARGET,
         ),
     ],
 )
 def test_installer_build_mensajes_claros(
-    monkeypatch, tmp_path, capsys, message, expected
+    monkeypatch, tmp_path, capsys, message, expected, exit_code
 ):
     import pcobra.cobra_installer as cobra_installer
 
@@ -141,7 +160,7 @@ def test_installer_build_mensajes_claros(
         ["installer", "build", str(tmp_path), "--target", "linux"]
     )
 
-    assert command.run(args) == 1
+    assert command.run(args) == int(exit_code)
     assert expected in capsys.readouterr().out
 
 
@@ -174,7 +193,7 @@ def test_installer_build_muestra_conflicto_transitivo_con_cadena(
         ["installer", "build", str(tmp_path), "--target", "linux"]
     )
 
-    assert command.run(args) == 1
+    assert command.run(args) == int(CobraExitCode.VERSION_CONFLICT)
     output = capsys.readouterr().out
     assert "Conflicto de versiones" in output
     assert "compartida" in output


### PR DESCRIPTION
### Motivation

- Establecer códigos de salida públicos y estables para la capa CLI del instalador para permitir a scripts y CI distinguir clases de fallos. 

### Description

- Añadí la enumeración pública `CobraExitCode` con los códigos solicitados en `src/pcobra/cobra/cli/exit_codes.py`. 
- Actualicé el runner CLI del instalador en `src/pcobra/cobra/cli/commands_v2/installer_cmd.py` para mapear errores controlados a esos códigos y devolver `UNEXPECTED_INTERNAL_ERROR` en errores inesperados. 
- Centralicé la clasificación de errores (`_installer_exit_code` y predicados `_is_*`) para distinguir: proyecto inválido, dependencia inexistente, conflicto de versiones, hash incorrecto, PyInstaller no disponible y target inválido. 
- Documenté la tabla de códigos de salida en `docs/cobra_installer.md` y ajusté tests en `tests/unit/test_cli_installer_cmd.py` para verificar paridad entre `cobra installer build` y `cobra build --installer` y la correspondencia de códigos. 

### Testing

- Ejecuté `pytest -q tests/unit/test_cli_installer_cmd.py` y las pruebas unitarias pasaron. 
- Ejecuté `pytest -q tests/unit/test_cli_installer_cmd.py tests/integration/test_cobra_installer_build.py` y tanto las pruebas unitarias como las de integración pasaron (`12 passed`). 
- Ejecuté `ruff check` sobre los ficheros modificados y no se detectaron problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4763c9b55c832788fe7e6825a14dc6)