### PR TITLE
Instalación segura de PyInstaller y confirmación en IDLE

### DIFF
--- a/src/pcobra/cobra_installer/pyinstaller_runner.py
+++ b/src/pcobra/cobra_installer/pyinstaller_runner.py
@@ -63,7 +63,9 @@ def detect_pyinstaller(
     resultado ``available=False`` para que el llamador decida si puede instalar.
     """
 
-    commands: list[tuple[str, ...]] = [(sys.executable, "-m", "PyInstaller", "--version")]
+    commands: list[tuple[str, ...]] = [
+        (sys.executable, "-m", "PyInstaller", "--version")
+    ]
     executable = which("pyinstaller")
     if executable:
         commands.append((executable, "--version"))
@@ -114,8 +116,9 @@ def install_pyinstaller_if_allowed(
         "auto_install_pyinstaller",
     ):
         raise CobraInstallerError(
-            "PyInstaller no está instalado. Habilita la instalación automática "
-            "en las opciones del build o instala la dependencia en el entorno."
+            "PyInstaller no está instalado. Instala la dependencia con "
+            "'python -m pip install pyinstaller' o vuelve a ejecutar el build "
+            "con '--install-pyinstaller' para permitir la instalación automática."
         )
 
     _log(logger, "info", "PyInstaller no está disponible; instalando con pip...")
@@ -136,6 +139,11 @@ def install_pyinstaller_if_allowed(
         raise CobraInstallerError(
             "PyInstaller se instaló, pero no se pudo verificar su versión."
         )
+    _log(
+        logger,
+        "info",
+        f"PyInstaller instalado correctamente (versión {detected.version or 'desconocida'}).",
+    )
     return detected
 
 
@@ -173,7 +181,9 @@ def run_pyinstaller(
     returncode = process.wait()
     if returncode != 0:
         message = _translate_pyinstaller_error(stderr or stdout)
-        raise CobraInstallerError(f"PyInstaller falló con código {returncode}: {message}")
+        raise CobraInstallerError(
+            f"PyInstaller falló con código {returncode}: {message}"
+        )
 
     return PyInstallerRunResult(
         success=True,
@@ -185,7 +195,9 @@ def run_pyinstaller(
     )
 
 
-def _stream_process_output(process: subprocess.Popen[str], logger: Any) -> tuple[str, str]:
+def _stream_process_output(
+    process: subprocess.Popen[str], logger: Any
+) -> tuple[str, str]:
     events: queue.Queue[tuple[str, str]] = queue.Queue()
 
     def reader(name: str, stream: Iterable[str] | None) -> None:

--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -898,6 +898,11 @@ def main(page: "ft.Page"):
         icono_input = runtime.flet_text_field(
             ft, label="Icono opcional (.ico/.icns/.png)", value=""
         )
+        instalar_pyinstaller_switch = runtime.flet_switch(
+            ft,
+            label="Instalar PyInstaller si falta",
+            value=False,
+        )
         progreso = runtime.flet_text(
             ft, value=f"Proyecto detectado: {proyecto_detectado}"
         )
@@ -906,7 +911,15 @@ def main(page: "ft.Page"):
             dialog.open = False
             page.update()
 
-        def ejecutar_empaquetado(_ev=None) -> None:
+        def ejecutar_empaquetado(
+            _ev=None, *, instalacion_confirmada: bool = False
+        ) -> None:
+            install_pyinstaller = bool(
+                getattr(instalar_pyinstaller_switch, "value", False)
+            )
+            if install_pyinstaller and not instalacion_confirmada:
+                pedir_confirmacion_instalacion_pyinstaller()
+                return
             nombre = (nombre_input.value or "").strip() or proyecto_detectado.name
             icono = (icono_input.value or "").strip() or None
             target = selector_so.value or "current"
@@ -933,6 +946,7 @@ def main(page: "ft.Page"):
                             "target": target,
                             "mode": mode,
                             "icon": icono,
+                            "install_pyinstaller": install_pyinstaller,
                         },
                         progress_callback=log_callback,
                     )
@@ -953,6 +967,39 @@ def main(page: "ft.Page"):
 
             threading.Thread(target=worker, daemon=True).start()
 
+        def pedir_confirmacion_instalacion_pyinstaller() -> None:
+            confirm_dialog = dialog_factory(
+                modal=True,
+                title=runtime.flet_text(ft, value="Confirmar instalación"),
+                content=runtime.flet_text(
+                    ft,
+                    value=(
+                        "PyInstaller no se instalará sin confirmación. "
+                        "Si falta, Cobra ejecutará pip para instalarlo en este entorno."
+                    ),
+                ),
+                actions=[
+                    runtime.flet_text_button(
+                        ft,
+                        "Cancelar",
+                        on_click=lambda _ev=None: (
+                            setattr(page.dialog, "open", False),
+                            page.update(),
+                        ),
+                    ),
+                    runtime.flet_elevated_button(
+                        ft,
+                        "Instalar PyInstaller y empaquetar",
+                        on_click=lambda _ev=None: ejecutar_empaquetado(
+                            _ev, instalacion_confirmada=True
+                        ),
+                    ),
+                ],
+            )
+            page.dialog = confirm_dialog
+            confirm_dialog.open = True
+            page.update()
+
         dialog_factory = getattr(ft, "AlertDialog", None)
         if dialog_factory is None:
             salida.value = (
@@ -972,6 +1019,7 @@ def main(page: "ft.Page"):
                     selector_modo,
                     nombre_input,
                     icono_input,
+                    instalar_pyinstaller_switch,
                 ],
                 tight=True,
             ),

--- a/tests/gui/test_idle_packaging.py
+++ b/tests/gui/test_idle_packaging.py
@@ -163,6 +163,7 @@ def test_boton_empaquetar_detecta_proyecto_pide_opciones_y_muestra_progreso(
         "target": "current",
         "mode": "onefile",
         "icon": None,
+        "install_pyinstaller": False,
     }
     assert callable(progress_callback)
     assert (
@@ -181,6 +182,61 @@ def test_boton_empaquetar_detecta_proyecto_pide_opciones_y_muestra_progreso(
         in salida.value
     )
     assert page.launched_urls == [(project / "dist").resolve().as_uri()]
+
+
+def test_idle_pide_confirmacion_antes_de_instalar_pyinstaller(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    project = workspace / "proyecto_activo"
+    project.mkdir(parents=True)
+    active_file = project / "programa.cobra"
+    active_file.write_text("imprimir('hola')", encoding="utf-8")
+
+    package_calls = []
+
+    def fake_package_current_project(project_path, ui_options, progress_callback=None):
+        package_calls.append((Path(project_path), dict(ui_options), progress_callback))
+        dist_dir = Path(project_path) / "dist"
+        return SimpleNamespace(dist_dir=dist_dir, artifact_path=dist_dir / "demo")
+
+    monkeypatch.setattr(runtime, "require_flet", lambda: FakeFlet)
+    monkeypatch.setattr(runtime, "resolver_workspace_root_idle", lambda: workspace)
+    monkeypatch.setattr(runtime, "listar_directorio_idle", lambda _root: [])
+    monkeypatch.setattr(threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(
+        idle_bridge, "package_current_project", fake_package_current_project
+    )
+
+    page = FakePage()
+    idle.main(page)
+    root = SimpleNamespace(controls=page.controls)
+    ruta_input = next(
+        control
+        for control in walk_controls(root)
+        if getattr(control, "label", None) == "Ruta"
+    )
+    ruta_input.value = str(active_file)
+
+    find_button(root, "Empaquetar").on_click(None)
+    opciones_dialog = page.dialog
+    instalar_switch = next(
+        control
+        for control in walk_controls(opciones_dialog)
+        if getattr(control, "label", None) == "Instalar PyInstaller si falta"
+    )
+    instalar_switch.value = True
+
+    find_button(opciones_dialog, "Empaquetar").on_click(None)
+
+    assert package_calls == []
+    confirm_dialog = page.dialog
+    assert confirm_dialog is not opciones_dialog
+    assert confirm_dialog.open is True
+    assert "Confirmar instalación" in confirm_dialog.title.value
+
+    find_button(confirm_dialog, "Instalar PyInstaller y empaquetar").on_click(None)
+
+    assert len(package_calls) == 1
+    assert package_calls[0][1]["install_pyinstaller"] is True
 
 
 def test_idle_no_importa_modulos_internos_de_cobra_installer():

--- a/tests/unit/test_pyinstaller_runner.py
+++ b/tests/unit/test_pyinstaller_runner.py
@@ -36,8 +36,12 @@ class FakeProcess:
         return self._returncode
 
 
-def completed(args: list[str], returncode: int = 0, stdout: str = "6.14.0\n", stderr: str = ""):
-    return subprocess.CompletedProcess(args=args, returncode=returncode, stdout=stdout, stderr=stderr)
+def completed(
+    args: list[str], returncode: int = 0, stdout: str = "6.14.0\n", stderr: str = ""
+):
+    return subprocess.CompletedProcess(
+        args=args, returncode=returncode, stdout=stdout, stderr=stderr
+    )
 
 
 def test_detect_pyinstaller_usa_python_module_y_devuelve_version() -> None:
@@ -55,11 +59,21 @@ def test_detect_pyinstaller_usa_python_module_y_devuelve_version() -> None:
 
 
 def test_install_pyinstaller_rechaza_instalacion_no_habilitada() -> None:
-    def fake_run(args, **kwargs):
-        return completed(args, returncode=1, stdout="", stderr="No module named PyInstaller")
+    calls: list[list[str]] = []
 
-    with pytest.raises(CobraInstallerError, match="Habilita la instalación automática"):
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return completed(
+            args, returncode=1, stdout="", stderr="No module named PyInstaller"
+        )
+
+    with pytest.raises(CobraInstallerError) as exc_info:
         install_pyinstaller_if_allowed(SimpleNamespace(), run_factory=fake_run)
+
+    message = str(exc_info.value)
+    assert "python -m pip install pyinstaller" in message
+    assert "--install-pyinstaller" in message
+    assert not any(call[1:4] == ["-m", "pip", "install"] for call in calls)
 
 
 def test_install_pyinstaller_si_opcion_lo_permite() -> None:
@@ -70,19 +84,24 @@ def test_install_pyinstaller_si_opcion_lo_permite() -> None:
         nonlocal installed
         calls.append(args)
         if args[1:3] == ["-m", "PyInstaller"] and not installed:
-            return completed(args, returncode=1, stdout="", stderr="No module named PyInstaller")
+            return completed(
+                args, returncode=1, stdout="", stderr="No module named PyInstaller"
+            )
         if args[1:4] == ["-m", "pip", "install"]:
             installed = True
             return completed(args, stdout="installed\n")
         return completed(args, stdout="6.14.0\n")
 
+    logger = Logger()
+
     info = install_pyinstaller_if_allowed(
-        SimpleNamespace(install_pyinstaller=True), run_factory=fake_run
+        SimpleNamespace(install_pyinstaller=True), logger=logger, run_factory=fake_run
     )
 
     assert info.available is True
     assert info.version == "6.14.0"
     assert any(call[1:4] == ["-m", "pip", "install"] for call in calls)
+    assert any("PyInstaller instalado correctamente" in item for item in logger.infos)
 
 
 def test_run_pyinstaller_streaming_y_resultado(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Evitar intentos implícitos de instalación de PyInstaller sin permiso ni instrucciones claras cuando falta la dependencia.  
- Permitir la instalación automática solo mediante la opción explícita de build/IDLE y registrar en logs cuando la instalación se realiza.  
- En el IDLE gráfico, exigir confirmación interactiva antes de ejecutar una instalación automática para respetar entornos y políticas del usuario.

### Description

- Cambia el mensaje de error en `install_pyinstaller_if_allowed` para indicar de forma accionable `python -m pip install pyinstaller` o reintentar con `--install-pyinstaller` cuando PyInstaller no está presente (archivo modificado: `src/pcobra/cobra_installer/pyinstaller_runner.py`).
- Si se instala PyInstaller automáticamente, se añade un `logger.info` que registra la versión detectada tras la instalación (en `pyinstaller_runner.py`).
- En el IDLE se añade un switch `Instalar PyInstaller si falta` y un diálogo de confirmación; marcar la opción no instala automáticamente hasta que el usuario confirme en el diálogo de confirmación, y solo entonces se pasa `install_pyinstaller=True` al puente de empaquetado (archivo modificado: `src/pcobra/gui/idle.py`).
- Añade/actualiza tests con mocks que cubren: ausencia de PyInstaller sin permiso (se rechaza y no invoca `pip`), ausencia con permiso (se intenta instalar y se registra en logs) y flujo IDLE que exige confirmación antes de permitir la instalación (archivos modificados: `tests/unit/test_pyinstaller_runner.py`, `tests/gui/test_idle_packaging.py`).

### Testing

- Se ejecutaron tests focalizados con `pytest -q tests/unit/test_pyinstaller_runner.py tests/gui/test_idle_packaging.py tests/unit/test_cli_installer_cmd.py` y todos los casos ejecutados pasaron (resultado observado: tests focalizados completaron correctamente; salida mostrada: `18 passed, 1 warning`).
- Se verificó la sintaxis compilando con `python -m py_compile src/pcobra/cobra_installer/pyinstaller_runner.py src/pcobra/gui/idle.py tests/unit/test_pyinstaller_runner.py tests/gui/test_idle_packaging.py` y la compilación fue satisfactoria.
- Se corrieron las pruebas unitarias específicas de runner e IDLE que simulan `pip`/PyInstaller con `run_factory`/mocks y verifican los logs y el paso de la opción `install_pyinstaller`; todas las aserciones pasaron en los entornos de prueba ejecutados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47662009c48327b23c941b8c084857)