### PR TITLE
Abrir carpeta dist tras empaquetar desde IDLE

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -14,6 +14,18 @@ if TYPE_CHECKING:
     import flet as ft
 
 
+def abrir_carpeta_dist(dist_dir: str | Path) -> None:
+    """Abre la carpeta ``dist`` con la herramienta nativa del sistema operativo."""
+
+    ruta_dist = Path(dist_dir)
+    if sys.platform.startswith("win"):
+        os.startfile(str(ruta_dist))  # type: ignore[attr-defined]
+    elif sys.platform == "darwin":
+        subprocess.Popen(["open", str(ruta_dist)])
+    else:
+        subprocess.Popen(["xdg-open", str(ruta_dist)])
+
+
 def resolver_ruta_en_project_root(ruta: str | Path, project_root: str | Path) -> Path:
     """Resuelve ``ruta`` de forma canónica y exige que quede bajo ``project_root``."""
 
@@ -848,23 +860,6 @@ def main(page: "ft.Page"):
         page.update()
         return None
 
-    def abrir_carpeta_dist(dist_dir: Path) -> None:
-        """Abre la carpeta dist de forma tolerante entre plataformas."""
-
-        try:
-            if hasattr(page, "launch_url"):
-                page.launch_url(dist_dir.resolve().as_uri())
-                return
-            if sys.platform.startswith("win"):
-                os.startfile(dist_dir)  # type: ignore[attr-defined]
-            elif sys.platform == "darwin":
-                subprocess.Popen(["open", str(dist_dir)])
-            else:
-                subprocess.Popen(["xdg-open", str(dist_dir)])
-        except Exception as exc:  # pragma: no cover - depende del escritorio local
-            salida.value += f"\nNo se pudo abrir automáticamente dist: {exc}"
-            page.update()
-
     def empaquetar_handler(_e):
         """Abre el diálogo permanente de empaquetado para el proyecto actual."""
 
@@ -963,7 +958,16 @@ def main(page: "ft.Page"):
                 progreso.value = f"Empaquetado finalizado: {artifact}"
                 salida.value += f"\nEmpaquetado finalizado: {artifact}"
                 page.update()
-                abrir_carpeta_dist(dist_dir)
+                try:
+                    abrir_carpeta_dist(dist_dir)
+                except (
+                    Exception
+                ) as exc:  # pragma: no cover - depende del escritorio local
+                    salida.value += (
+                        "\nAdvertencia: no se pudo abrir automáticamente "
+                        f"la carpeta dist ({dist_dir}): {exc}"
+                    )
+                    page.update()
 
             threading.Thread(target=worker, daemon=True).start()
 

--- a/tests/gui/test_idle_packaging.py
+++ b/tests/gui/test_idle_packaging.py
@@ -122,6 +122,9 @@ def test_boton_empaquetar_detecta_proyecto_pide_opciones_y_muestra_progreso(
         idle_bridge, "package_current_project", fake_package_current_project
     )
 
+    opened_dist_dirs = []
+    monkeypatch.setattr(idle, "abrir_carpeta_dist", opened_dist_dirs.append)
+
     page = FakePage()
     idle.main(page)
 
@@ -181,7 +184,82 @@ def test_boton_empaquetar_detecta_proyecto_pide_opciones_y_muestra_progreso(
         f"Empaquetado finalizado: {project / 'dist' / 'proyecto_activo'}"
         in salida.value
     )
-    assert page.launched_urls == [(project / "dist").resolve().as_uri()]
+    assert opened_dist_dirs == [project / "dist"]
+
+
+def test_abrir_carpeta_dist_usa_lanzador_del_sistema(monkeypatch, tmp_path):
+    dist_dir = tmp_path / "dist"
+
+    calls = []
+
+    monkeypatch.setattr(idle.sys, "platform", "win32")
+    monkeypatch.setattr(
+        idle.os, "startfile", lambda path: calls.append(path), raising=False
+    )
+    idle.abrir_carpeta_dist(dist_dir)
+    assert calls == [str(dist_dir)]
+
+    calls.clear()
+    monkeypatch.setattr(idle.sys, "platform", "darwin")
+    monkeypatch.setattr(idle.subprocess, "Popen", lambda args: calls.append(args))
+    idle.abrir_carpeta_dist(dist_dir)
+    assert calls == [["open", str(dist_dir)]]
+
+    calls.clear()
+    monkeypatch.setattr(idle.sys, "platform", "linux")
+    idle.abrir_carpeta_dist(dist_dir)
+    assert calls == [["xdg-open", str(dist_dir)]]
+
+
+def test_idle_advierte_si_no_puede_abrir_dist(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    project = workspace / "proyecto_activo"
+    project.mkdir(parents=True)
+    active_file = project / "programa.cobra"
+    active_file.write_text("imprimir('hola')", encoding="utf-8")
+
+    def fake_package_current_project(project_path, ui_options, progress_callback=None):
+        dist_dir = Path(project_path) / "dist"
+        return SimpleNamespace(
+            dist_dir=dist_dir, output_dir=None, artifact_path=dist_dir / "demo"
+        )
+
+    def fake_abrir_carpeta_dist(_dist_dir):
+        raise OSError("sin entorno gráfico")
+
+    monkeypatch.setattr(runtime, "require_flet", lambda: FakeFlet)
+    monkeypatch.setattr(runtime, "resolver_workspace_root_idle", lambda: workspace)
+    monkeypatch.setattr(runtime, "listar_directorio_idle", lambda _root: [])
+    monkeypatch.setattr(threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(
+        idle_bridge, "package_current_project", fake_package_current_project
+    )
+    monkeypatch.setattr(idle, "abrir_carpeta_dist", fake_abrir_carpeta_dist)
+
+    page = FakePage()
+    idle.main(page)
+    root = SimpleNamespace(controls=page.controls)
+    ruta_input = next(
+        control
+        for control in walk_controls(root)
+        if getattr(control, "label", None) == "Ruta"
+    )
+    ruta_input.value = str(active_file)
+
+    find_button(root, "Empaquetar").on_click(None)
+    find_button(page.dialog, "Empaquetar").on_click(None)
+
+    salida = next(
+        control
+        for control in walk_controls(root)
+        if getattr(control, "selectable", None) is True
+    )
+    assert "Empaquetado finalizado" in salida.value
+    assert (
+        f"Advertencia: no se pudo abrir automáticamente la carpeta dist ({project / 'dist'})"
+        in salida.value
+    )
+    assert "sin entorno gráfico" in salida.value
 
 
 def test_idle_pide_confirmacion_antes_de_instalar_pyinstaller(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Tras completar con éxito `package_current_project(...)` el flujo de empaquetado del IDLE debe abrir la carpeta `dist` para facilitar el acceso al artefacto.
- La apertura debe usar el lanzador nativo del sistema (Windows/macOS/Linux) y estar aislada para facilitar el mocking en tests.
- Si la apertura falla no debe romper la UI, sino mostrar una advertencia no fatal con la ruta de `dist`.

### Description
- Se añadió el helper de módulo `abrir_carpeta_dist(dist_dir: str | Path) -> None` que usa `os.startfile` en Windows, `open` en macOS o `xdg-open` en Linux. (F: `src/pcobra/gui/idle.py`)
- El handler de empaquetado llama a `abrir_carpeta_dist(dist_dir)` tras un empaquetado exitoso y captura excepciones para mostrar una advertencia no fatal en la salida del IDLE. (F: `src/pcobra/gui/idle.py`)
- Se eliminó la implementación anidada previa y se dejó la versión de módulo para poder mockearla fácilmente en tests. (F: `src/pcobra/gui/idle.py`)
- Se actualizaron y añadieron pruebas en `tests/gui/test_idle_packaging.py` para verificar la invocación mockeable, el comportamiento multiplataforma del helper y el mensaje de advertencia cuando la apertura falla. (F: `tests/gui/test_idle_packaging.py`)

### Testing
- Formateo: `python -m black src/pcobra/gui/idle.py tests/gui/test_idle_packaging.py` (Black se ejecutó; se mostró una advertencia del entorno de ejecución de Black relacionada con la versión de Python, pero el formateo se aplicó).
- Pruebas: `pytest tests/gui/test_idle_packaging.py` — todos los tests del archivo pasaron (`5 passed`).
- Se verificó que la nueva lógica de apertura y el manejo de errores estén cubiertos por los tests añadidos y modificados; las pruebas completaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47692bdd84832791454d39072ff9b4)