### PR TITLE
Asegura inclusión de cobra_installer en distribuciones

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,5 +24,8 @@ recursive-include src/pcobra *.md
 recursive-include src/pcobra *.txt
 recursive-include src/pcobra *.html
 
+# Recursos no Python específicos de cobra_installer necesarios para runtime/spec/templates.
+recursive-include src/pcobra/cobra_installer *.toml *.yaml *.yml *.json *.ini *.cfg *.md *.txt *.html *.j2 *.template
+
 recursive-include notebooks *
 recursive-include docs/frontend *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,25 @@ include-package-data = true
 # de distribución/publicación en PyPI.
 package-dir = {"" = "src"}
 
+
+[tool.setuptools.package-data]
+# Recursos internos de cobra_installer usados en runtime/spec/templates.
+# Aunque hoy el paquete solo contiene Python, estos patrones aseguran que
+# futuros recursos no Python bajo src/pcobra/cobra_installer/ entren en wheels.
+"pcobra.cobra_installer" = [
+    "**/*.toml",
+    "**/*.yaml",
+    "**/*.yml",
+    "**/*.json",
+    "**/*.ini",
+    "**/*.cfg",
+    "**/*.md",
+    "**/*.txt",
+    "**/*.html",
+    "**/*.j2",
+    "**/*.template",
+]
+
 [tool.setuptools.exclude-package-data]
 "*" = [
     "docs/historico/*",

--- a/tests/unit/test_distribution_package_config.py
+++ b/tests/unit/test_distribution_package_config.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = ROOT / "pyproject.toml"
+MANIFEST = ROOT / "MANIFEST.in"
+
+_RESOURCE_PATTERNS = {
+    "**/*.toml",
+    "**/*.yaml",
+    "**/*.yml",
+    "**/*.json",
+    "**/*.ini",
+    "**/*.cfg",
+    "**/*.md",
+    "**/*.txt",
+    "**/*.html",
+    "**/*.j2",
+    "**/*.template",
+}
+
+
+def test_cobra_installer_se_descubre_como_paquete_distribuido() -> None:
+    """Evita regresiones que excluyan pcobra.cobra_installer del wheel."""
+
+    config = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    setuptools_config = config["tool"]["setuptools"]
+
+    assert setuptools_config["package-dir"] == {"": "src"}
+    assert setuptools_config["packages"]["find"]["where"] == ["src"]
+    assert "pcobra*" in setuptools_config["packages"]["find"]["include"]
+
+
+def test_cobra_installer_declara_recursos_no_python_en_wheel_y_sdist() -> None:
+    """Asegura recursos futuros de runtime/spec/templates en wheel y sdist."""
+
+    config = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    package_data = config["tool"]["setuptools"]["package-data"]
+
+    assert set(package_data["pcobra.cobra_installer"]) >= _RESOURCE_PATTERNS
+
+    manifest = MANIFEST.read_text(encoding="utf-8")
+    assert "recursive-include src/pcobra *.py" in manifest
+    assert "recursive-include src/pcobra/cobra_installer" in manifest
+    for suffix in ("*.toml", "*.yaml", "*.yml", "*.json", "*.j2", "*.template"):
+        assert suffix in manifest


### PR DESCRIPTION
### Motivation

- Evitar regresiones que excluyan `pcobra.cobra_installer` de paquetes publicados (wheel/sdist) y asegurar que futuros recursos no Python requeridos por `runtime/spec/templates` se empaqueten correctamente.
- Añadir una comprobación estática para detectar cambios accidentales en la configuración de empaquetado.

### Description

- Añade un bloque `[tool.setuptools.package-data]` en `pyproject.toml` declarando `pcobra.cobra_installer` y patrones para recursos no Python como `**/*.toml`, `**/*.yaml`, `**/*.json`, `**/*.j2`, `**/*.template`, etc.
- Refuerza `MANIFEST.in` con una línea `recursive-include src/pcobra/cobra_installer ...` para incluir recursos no Python en el `sdist` además de las inclusiones existentes bajo `src/pcobra`.
- Añade la prueba estática `tests/unit/test_distribution_package_config.py` que valida que el paquete se descubre desde `src`, que `package-data` contiene los patrones esperados y que `MANIFEST.in` incluye las entradas para `cobra_installer` y los sufijos relevantes.
- Mantiene la política actual de que hoy `cobra_installer` solo contiene `.py` pero deja explícitos los patrones para admitir archivos no Python en el futuro.

### Testing

- Ejecuté `python -m pytest tests/unit/test_distribution_package_config.py` y la prueba pasó correctamente.
- Intenté `python -m build --sdist --wheel` y al no estar disponible el módulo `build` se instaló con `pip` y la construcción de `sdist` y `wheel` se completó con éxito después de la instalación.
- Verifiqué programáticamente el contenido de `dist/*.whl` y `dist/*.tar.gz` y confirmé que `pcobra/cobra_installer/__init__.py` y `pcobra/cobra_installer/spec_writer.py` aparecen en ambos artefactos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47ae88bb1483279ab4185ce952ce8d)