### PR TITLE
Agregar corelib de rutas

### DIFF
--- a/src/pcobra/corelibs/ruta.py
+++ b/src/pcobra/corelibs/ruta.py
@@ -1,0 +1,100 @@
+"""Utilidades de rutas para la biblioteca estándar de Cobra."""
+
+import os
+from pathlib import Path
+from typing import Union
+
+PathLike = Union[str, os.PathLike[str]]
+
+__all__ = [
+    "unir",
+    "normalizar",
+    "nombre",
+    "extension",
+    "padre",
+    "existe",
+    "es_absoluta",
+    "absoluta",
+    "relativa",
+]
+
+
+def _validar_ruta(ruta: PathLike, nombre_argumento: str = "ruta") -> PathLike:
+    if not isinstance(ruta, (str, os.PathLike)):
+        raise TypeError(
+            f"{nombre_argumento} debe ser una ruta de texto o compatible con os.PathLike"
+        )
+    texto = os.fspath(ruta)
+    if not isinstance(texto, str):
+        raise TypeError(f"{nombre_argumento} debe representar una ruta de texto")
+    if texto == "":
+        raise ValueError(f"{nombre_argumento} no puede estar vacía")
+    return ruta
+
+
+def unir(*partes: PathLike) -> str:
+    """Une segmentos de ruta y devuelve la ruta resultante como texto."""
+
+    if not partes:
+        raise ValueError("partes debe contener al menos una ruta")
+    partes_validadas = tuple(
+        _validar_ruta(parte, f"partes[{indice}]") for indice, parte in enumerate(partes)
+    )
+    return str(Path(partes_validadas[0]).joinpath(*partes_validadas[1:]))
+
+
+def normalizar(ruta: PathLike) -> str:
+    """Normaliza separadores y componentes redundantes de una ruta."""
+
+    ruta_validada = _validar_ruta(ruta)
+    return os.path.normpath(os.fspath(ruta_validada))
+
+
+def nombre(ruta: PathLike) -> str:
+    """Devuelve el nombre final de una ruta."""
+
+    ruta_validada = _validar_ruta(ruta)
+    return Path(ruta_validada).name
+
+
+def extension(ruta: PathLike) -> str:
+    """Devuelve la extensión final de una ruta, incluyendo el punto si existe."""
+
+    ruta_validada = _validar_ruta(ruta)
+    return Path(ruta_validada).suffix
+
+
+def padre(ruta: PathLike) -> str:
+    """Devuelve el directorio padre de una ruta como texto."""
+
+    ruta_validada = _validar_ruta(ruta)
+    return str(Path(ruta_validada).parent)
+
+
+def existe(ruta: PathLike) -> bool:
+    """Indica si una ruta existe en el sistema de archivos."""
+
+    ruta_validada = _validar_ruta(ruta)
+    return Path(ruta_validada).exists()
+
+
+def es_absoluta(ruta: PathLike) -> bool:
+    """Indica si una ruta es absoluta."""
+
+    ruta_validada = _validar_ruta(ruta)
+    return Path(ruta_validada).is_absolute()
+
+
+def absoluta(ruta: PathLike) -> str:
+    """Devuelve la versión absoluta de una ruta sin exigir que exista."""
+
+    ruta_validada = _validar_ruta(ruta)
+    return str(Path(ruta_validada).absolute())
+
+
+def relativa(ruta: PathLike, base: PathLike = ".") -> str:
+    """Devuelve ``ruta`` relativa a ``base``."""
+
+    ruta_validada = _validar_ruta(ruta)
+    base_validada = _validar_ruta(base, "base")
+    return os.path.relpath(os.fspath(ruta_validada), os.fspath(base_validada))

--- a/tests/test_corelibs_ruta.py
+++ b/tests/test_corelibs_ruta.py
@@ -1,0 +1,57 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from pcobra.corelibs import ruta
+
+
+def test_superficie_publica_ruta() -> None:
+    assert ruta.__all__ == [
+        "unir",
+        "normalizar",
+        "nombre",
+        "extension",
+        "padre",
+        "existe",
+        "es_absoluta",
+        "absoluta",
+        "relativa",
+    ]
+
+
+def test_operaciones_basicas_de_ruta(tmp_path: Path) -> None:
+    archivo = tmp_path / "datos" / "entrada.txt"
+    archivo.parent.mkdir()
+    archivo.write_text("cobra", encoding="utf-8")
+
+    assert ruta.unir(tmp_path, "datos", "entrada.txt") == str(archivo)
+    assert ruta.normalizar(f"datos{os.sep}.{os.sep}entrada.txt") == os.path.join(
+        "datos", "entrada.txt"
+    )
+    assert ruta.nombre(archivo) == "entrada.txt"
+    assert ruta.extension(archivo) == ".txt"
+    assert ruta.padre(archivo) == str(archivo.parent)
+    assert ruta.existe(archivo) is True
+    assert ruta.es_absoluta(archivo) is True
+    assert ruta.absoluta(".") == str(Path(".").absolute())
+    assert ruta.relativa(archivo, tmp_path) == os.path.join("datos", "entrada.txt")
+
+
+def test_argumentos_invalidos_generan_mensajes_deterministas() -> None:
+    with pytest.raises(ValueError, match="partes debe contener al menos una ruta"):
+        ruta.unir()
+
+    with pytest.raises(ValueError, match=r"partes\[1\] no puede estar vacía"):
+        ruta.unir("base", "")
+
+    with pytest.raises(ValueError, match="ruta no puede estar vacía"):
+        ruta.normalizar("")
+
+    with pytest.raises(ValueError, match="base no puede estar vacía"):
+        ruta.relativa("archivo.txt", "")
+
+    with pytest.raises(
+        TypeError, match="ruta debe ser una ruta de texto o compatible con os.PathLike"
+    ):
+        ruta.nombre(123)


### PR DESCRIPTION
### Motivation

- Añadir utilidades de manejo de rutas a las corelibs de Cobra para exponer una API en español consistente con el resto de la biblioteca. 
- Proveer validaciones deterministas para argumentos inválidos (tipos y rutas vacías) con mensajes en español. 
- Implementar la funcionalidad sin efectos secundarios globales ni cambios en Lexer, Parser, AST o archivos de sintaxis.

### Description

- Se creó `src/pcobra/corelibs/ruta.py` que exporta la API pública `__all__ = ["unir","normalizar","nombre","extension","padre","existe","es_absoluta","absoluta","relativa"]`.
- Se implementaron las funciones `unir`, `normalizar`, `nombre`, `extension`, `padre`, `existe`, `es_absoluta`, `absoluta` y `relativa` usando `pathlib.Path` y `os.path` para la lógica de rutas.
- Se añadió validación central `_validar_ruta` que rechaza tipos no `str`/`os.PathLike` y rutas vacías lanzando `TypeError` o `ValueError` con mensajes deterministas en español.
- No se introdujeron efectos secundarios globales y la implementación respeta las convenciones de las corelibs existentes.

### Testing

- Se añadieron pruebas en `tests/test_corelibs_ruta.py` que verifican la superficie pública, las operaciones básicas y los mensajes de error; `pytest tests/test_corelibs_ruta.py` pasó con éxito (3 passed).
- Se ejecutó formateo con `black` y verificación estática con `ruff check` sobre el nuevo módulo y no se detectaron fallos.
- Se comprobó la compilación sintáctica con `python -m compileall -q src/pcobra/corelibs/ruta.py tests/test_corelibs_ruta.py` y fue satisfactoria.
- Los checks automatizados ejecutados en el entorno de desarrollo local completaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a480557244c8327bf9c8f2a51eb6f38)