### PR TITLE
Agregar corelib de serialización (JSON y CSV)

### DIFF
--- a/src/pcobra/corelibs/serializacion.py
+++ b/src/pcobra/corelibs/serializacion.py
@@ -1,0 +1,148 @@
+"""Utilidades de serialización JSON y CSV para las corelibs de Cobra."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+__all__ = [
+    "codificar_json",
+    "decodificar_json",
+    "leer_json",
+    "escribir_json",
+    "leer_csv",
+    "escribir_csv",
+]
+
+
+def codificar_json(objeto: Any, *, ordenar: bool = False, indentar: int | None = None) -> str:
+    """Convierte ``objeto`` a texto JSON UTF-8 amigable.
+
+    ``ordenar`` controla el orden alfabético de claves y ``indentar`` permite
+    producir una salida legible cuando se proporciona un entero.
+    """
+
+    return json.dumps(objeto, ensure_ascii=False, sort_keys=ordenar, indent=indentar)
+
+
+def decodificar_json(texto: str) -> Any:
+    """Convierte un texto JSON en su valor Python equivalente."""
+
+    return json.loads(texto)
+
+
+def leer_json(ruta: str | Path) -> Any:
+    """Lee y decodifica un archivo JSON desde ``ruta``."""
+
+    return decodificar_json(Path(ruta).read_text(encoding="utf-8"))
+
+
+def escribir_json(ruta: str | Path, objeto: Any, *, indentar: int | None = 2) -> None:
+    """Codifica ``objeto`` como JSON y lo escribe en ``ruta``."""
+
+    Path(ruta).write_text(
+        codificar_json(objeto, indentar=indentar) + "\n",
+        encoding="utf-8",
+    )
+
+
+def leer_csv(ruta: str | Path, *, delimitador: str = ",") -> list[dict[str, str]]:
+    """Lee un CSV básico y devuelve una lista de diccionarios.
+
+    La primera fila del archivo se interpreta como cabecera. Se rechazan
+    archivos sin cabecera, cabeceras vacías y filas con columnas sobrantes o
+    faltantes para ofrecer errores claros ante datos no homogéneos.
+    """
+
+    with Path(ruta).open("r", encoding="utf-8", newline="") as archivo:
+        lector = csv.DictReader(archivo, delimiter=delimitador)
+        if lector.fieldnames is None:
+            raise ValueError("El CSV debe incluir una fila de cabecera")
+
+        campos = list(lector.fieldnames)
+        _validar_cabecera_csv(campos)
+
+        filas: list[dict[str, str]] = []
+        for numero_fila, fila in enumerate(lector, start=2):
+            if None in fila:
+                raise ValueError(
+                    f"La fila {numero_fila} tiene columnas sobrantes; "
+                    "todas las filas deben compartir la misma cabecera"
+                )
+
+            faltantes = [campo for campo, valor in fila.items() if valor is None]
+            if faltantes:
+                campos_faltantes = ", ".join(faltantes)
+                raise ValueError(
+                    f"La fila {numero_fila} no contiene valores para: {campos_faltantes}"
+                )
+
+            filas.append(dict(fila))
+
+    return filas
+
+
+def escribir_csv(
+    ruta: str | Path,
+    filas: Iterable[Mapping[str, Any]],
+    *,
+    delimitador: str = ",",
+) -> None:
+    """Escribe ``filas`` como CSV usando una lista de diccionarios homogénea.
+
+    Todas las filas deben tener las mismas claves que la primera fila. Se
+    rechazan colecciones vacías, filas vacías y filas no homogéneas.
+    """
+
+    filas_normalizadas = _normalizar_filas_csv(filas)
+    campos = list(filas_normalizadas[0].keys())
+
+    with Path(ruta).open("w", encoding="utf-8", newline="") as archivo:
+        escritor = csv.DictWriter(archivo, fieldnames=campos, delimiter=delimitador)
+        escritor.writeheader()
+        escritor.writerows(filas_normalizadas)
+
+
+def _validar_cabecera_csv(campos: list[str]) -> None:
+    if not campos or all(campo == "" for campo in campos):
+        raise ValueError("El CSV debe incluir una cabecera no vacía")
+
+    vacios = [indice + 1 for indice, campo in enumerate(campos) if campo == ""]
+    if vacios:
+        posiciones = ", ".join(str(posicion) for posicion in vacios)
+        raise ValueError(f"La cabecera CSV contiene columnas sin nombre: {posiciones}")
+
+    if len(set(campos)) != len(campos):
+        raise ValueError("La cabecera CSV contiene nombres de columna duplicados")
+
+
+def _normalizar_filas_csv(filas: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    filas_normalizadas = list(filas)
+    if not filas_normalizadas:
+        raise ValueError("No se puede escribir CSV sin filas")
+
+    primera = filas_normalizadas[0]
+    if not isinstance(primera, Mapping):
+        raise TypeError("Cada fila CSV debe ser un diccionario")
+    if not primera:
+        raise ValueError("Las filas CSV no pueden estar vacías")
+
+    campos = tuple(primera.keys())
+    resultado: list[dict[str, Any]] = []
+    for numero_fila, fila in enumerate(filas_normalizadas, start=1):
+        if not isinstance(fila, Mapping):
+            raise TypeError(f"La fila {numero_fila} debe ser un diccionario")
+        if not fila:
+            raise ValueError(f"La fila {numero_fila} está vacía")
+        if tuple(fila.keys()) != campos:
+            esperadas = ", ".join(str(campo) for campo in campos)
+            recibidas = ", ".join(str(campo) for campo in fila.keys())
+            raise ValueError(
+                f"La fila {numero_fila} no es homogénea; "
+                f"claves esperadas: {esperadas}; claves recibidas: {recibidas}"
+            )
+        resultado.append(dict(fila))
+
+    return resultado


### PR DESCRIPTION
### Motivation
- Proveer utilidades de serialización JSON y CSV reutilizables dentro de las corelibs de Cobra sin añadir dependencias externas. 
- Ofrecer validaciones claras para CSV (cabecera ausente/vacía, filas no homogéneas, filas vacías) para evitar errores silenciosos al procesar datos tabulares. 
- Mantener el uso de la biblioteca estándar (`json`, `csv`, `pathlib`) y no tocar los módulos de Parser/Lexer/AST.

### Description
- Se añadió el archivo `src/pcobra/corelibs/serializacion.py` que expone en `__all__` las funciones `codificar_json`, `decodificar_json`, `leer_json`, `escribir_json`, `leer_csv` y `escribir_csv`.
- Las funciones JSON usan `json` y `pathlib` y soportan ordenamiento de claves y `indent` mediante `codificar_json` y lectura/escritura UTF-8 con `leer_json`/`escribir_json`.
- La lectura CSV (`leer_csv`) usa `csv.DictReader` para devolver `list[dict[str,str]]` y valida cabeceras ausentes, cabeceras vacías/duplicadas y filas con columnas sobrantes o faltantes, lanzando `ValueError` con mensajes claros.
- La escritura CSV (`escribir_csv`) acepta un iterable de diccionarios homogéneos y valida ausencia de filas, filas vacías, tipos incorrectos y claves no homogéneas antes de escribir con `csv.DictWriter`.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/corelibs/serializacion.py` y la compilación fue satisfactoria. 
- Se ejecutó un script focalizado que realiza roundtrip JSON (`codificar_json`/`decodificar_json`, `escribir_json`/`leer_json`) y roundtrip CSV (`escribir_csv`/`leer_csv`) con datos de ejemplo y comprobación de tipos; todas las aserciones pasaron correctamente. 
- Se verificó que la validación de CSV no homogéneo lanza `ValueError` como se esperaba durante las pruebas automáticas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48b82661908327be88338fd15277ff)