### PR TITLE
Agregar corelib determinista para ejecutar procesos

### DIFF
--- a/src/pcobra/corelibs/proceso.py
+++ b/src/pcobra/corelibs/proceso.py
@@ -1,0 +1,164 @@
+"""Utilidades deterministas para ejecutar procesos externos.
+
+El modo predeterminado evita el shell del sistema.  Activar ``shell=True`` es
+riesgoso porque delega el análisis del comando al intérprete de órdenes y puede
+habilitar expansión de variables, comodines, tuberías o inyección de comandos si
+la entrada no es confiable.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from collections.abc import Sequence
+from typing import Any
+
+ResultadoProceso = dict[str, int | str]
+
+__all__ = [
+    "ejecutar",
+    "capturar",
+    "codigo_salida",
+    "salida",
+    "errores",
+]
+
+
+def _normalizar_argumentos(argumentos: Sequence[object] | None) -> list[str]:
+    if argumentos is None:
+        return []
+    if isinstance(argumentos, (str, bytes)):
+        raise TypeError("argumentos debe ser una secuencia explícita, no texto plano")
+    return [str(argumento) for argumento in argumentos]
+
+
+def _preparar_comando(
+    comando: str | Sequence[object],
+    *,
+    argumentos: Sequence[object] | None,
+    shell: bool,
+) -> str | list[str]:
+    args = _normalizar_argumentos(argumentos)
+
+    if shell:
+        if not isinstance(comando, str):
+            raise TypeError("con shell=True, comando debe ser texto explícito")
+        if args:
+            argumentos_escapados = " ".join(
+                shlex.quote(argumento) for argumento in args
+            )
+            return f"{comando} {argumentos_escapados}"
+        return comando
+
+    if isinstance(comando, str):
+        if not comando:
+            raise ValueError("comando no puede estar vacío")
+        return [comando, *args]
+
+    if isinstance(comando, (bytes, bytearray)):
+        raise TypeError("comando debe ser str o una lista explícita de argumentos")
+
+    lista = [str(parte) for parte in comando]
+    if not lista:
+        raise ValueError("comando no puede estar vacío")
+    if args:
+        raise ValueError(
+            "argumentos solo puede usarse cuando comando es str con shell=False"
+        )
+    return lista
+
+
+def _resultado(codigo: int, stdout: str = "", stderr: str = "") -> ResultadoProceso:
+    return {"codigo": codigo, "salida": stdout, "error": stderr}
+
+
+def ejecutar(
+    comando: str | Sequence[object],
+    *,
+    argumentos: Sequence[object] | None = None,
+    shell: bool = False,
+    cwd: str | None = None,
+    entorno: dict[str, str] | None = None,
+    timeout: int | float | None = None,
+) -> ResultadoProceso:
+    """Ejecuta un proceso y devuelve ``codigo``, ``salida`` y ``error``.
+
+    Por defecto usa ``shell=False`` y pasa una lista explícita a
+    :func:`subprocess.run`, sin expansión de shell.  En ese modo ``comando``
+    puede ser una ruta/nombre de ejecutable como ``str`` acompañado de
+    ``argumentos`` explícitos, o una secuencia completa como
+    ``["python", "--version"]``.
+
+    ``shell=True`` debe solicitarse de forma explícita.  Es riesgoso: permite
+    que el shell interprete metacaracteres, expansión de variables, tuberías y
+    redirecciones, por lo que no debe usarse con entradas no confiables.
+
+    Los comandos inexistentes y los timeouts no lanzan excepciones de
+    ``subprocess``: se transforman en resultados deterministas con códigos
+    ``127`` y ``124`` respectivamente.
+    """
+
+    comando_preparado = _preparar_comando(comando, argumentos=argumentos, shell=shell)
+    try:
+        completado = subprocess.run(
+            comando_preparado,
+            shell=shell,
+            cwd=cwd,
+            env=entorno,
+            timeout=timeout,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return _resultado(
+            124,
+            stdout=(exc.stdout or ""),
+            stderr=(exc.stderr or "Tiempo de espera agotado"),
+        )
+    except FileNotFoundError as exc:
+        return _resultado(127, stderr=f"Comando no encontrado: {exc.filename}")
+    except OSError as exc:
+        return _resultado(126, stderr=str(exc))
+
+    return _resultado(completado.returncode, completado.stdout, completado.stderr)
+
+
+def capturar(
+    comando: str | Sequence[object],
+    *,
+    argumentos: Sequence[object] | None = None,
+    shell: bool = False,
+    cwd: str | None = None,
+    entorno: dict[str, str] | None = None,
+    timeout: int | float | None = None,
+) -> ResultadoProceso:
+    """Alias explícito de :func:`ejecutar` para capturar salida y errores."""
+
+    return ejecutar(
+        comando,
+        argumentos=argumentos,
+        shell=shell,
+        cwd=cwd,
+        entorno=entorno,
+        timeout=timeout,
+    )
+
+
+def codigo_salida(resultado: dict[str, Any]) -> int:
+    """Devuelve el código de salida de una estructura de resultado."""
+
+    return int(resultado.get("codigo", 0))
+
+
+def salida(resultado: dict[str, Any]) -> str:
+    """Devuelve la salida estándar de una estructura de resultado."""
+
+    return str(resultado.get("salida", ""))
+
+
+def errores(resultado: dict[str, Any]) -> str:
+    """Devuelve la salida de error de una estructura de resultado."""
+
+    return str(resultado.get("error", ""))

--- a/tests/test_corelibs_proceso.py
+++ b/tests/test_corelibs_proceso.py
@@ -1,0 +1,62 @@
+import sys
+
+import pytest
+
+from pcobra.corelibs import proceso
+
+
+def test_superficie_publica_proceso() -> None:
+    assert proceso.__all__ == [
+        "ejecutar",
+        "capturar",
+        "codigo_salida",
+        "salida",
+        "errores",
+    ]
+
+
+def test_captura_salida_con_argumentos_explicitos() -> None:
+    resultado = proceso.capturar(
+        sys.executable,
+        argumentos=["-c", "print('cobra')"],
+    )
+
+    assert proceso.codigo_salida(resultado) == 0
+    assert proceso.salida(resultado) == "cobra\n"
+    assert proceso.errores(resultado) == ""
+
+
+def test_shell_false_no_expande_metacaracteres() -> None:
+    resultado = proceso.ejecutar(
+        sys.executable,
+        argumentos=["-c", "import sys; print(sys.argv[1])", "$NO_EXPANDIR"],
+    )
+
+    assert resultado == {"codigo": 0, "salida": "$NO_EXPANDIR\n", "error": ""}
+
+
+def test_comando_inexistente_devuelve_error_determinista() -> None:
+    resultado = proceso.ejecutar("comando-pcobra-inexistente-para-prueba")
+
+    assert proceso.codigo_salida(resultado) == 127
+    assert proceso.salida(resultado) == ""
+    assert proceso.errores(resultado).startswith("Comando no encontrado:")
+
+
+def test_timeout_devuelve_error_determinista() -> None:
+    resultado = proceso.ejecutar(
+        sys.executable,
+        argumentos=["-c", "import time; time.sleep(1)"],
+        timeout=0.01,
+    )
+
+    assert resultado == {
+        "codigo": 124,
+        "salida": "",
+        "error": "Tiempo de espera agotado",
+    }
+
+
+def test_rechaza_argumentos_texto_plano() -> None:
+    with pytest.raises(TypeError, match="argumentos debe ser una secuencia explícita"):
+        proceso.ejecutar(sys.executable, argumentos="--version")


### PR DESCRIPTION
### Motivation
- Proveer utilidades deterministas para ejecutar y capturar procesos externos desde la biblioteca estándar de Cobra respetando la política de evitar expansión de shell por defecto. 
- Evitar excepciones de bajo nivel de `subprocess` en errores comunes y devolver una estructura simple y consistente (`dict` con `codigo`, `salida`, `error`).

### Description
- Añade `src/pcobra/corelibs/proceso.py` con las funciones públicas `ejecutar`, `capturar`, `codigo_salida`, `salida` y `errores`, y define `__all__` exportando la API.
- Implementa validación de argumentos para `shell=False` (acepta `str` con `argumentos` explícitos o una secuencia segura) y requiere `shell=True` de forma explícita documentada como riesgosa; usa `subprocess.run` para la ejecución.
- Normaliza la salida en un `dict` determinista y maneja errores comunes transformándolos en códigos estables: `127` para comando inexistente, `124` para timeout y `126` para errores OS.
- Añade pruebas `tests/test_corelibs_proceso.py` que comprueban la superficie pública, captura de salida, ausencia de expansión con `shell=False`, manejo de comando inexistente, timeout y validación de argumentos.

### Testing
- Formateo y linters ejecutados con `python -m black` y `python -m ruff` sobre los archivos añadidos y completaron correctamente.
- Compilación comprobada con `python -m compileall -q` y sin errores.
- Tests ejecutados con `python -m pytest tests/test_corelibs_proceso.py tests/unit/test_gate_no_parser_lexer_changes.py` y todos pasaron (`8 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48b9c39a688327a15b4d0c460ecd9b)