### PR TITLE
Agregar utilidades corelibs para parseo sencillo de argumentos CLI

### DIFF
--- a/src/pcobra/corelibs/argumentos.py
+++ b/src/pcobra/corelibs/argumentos.py
@@ -1,0 +1,155 @@
+"""Utilidades simples para consultar argumentos de línea de comandos.
+
+El módulo no captura ``sys.argv`` al importarse. Las funciones leen los
+argumentos reales únicamente cuando se invocan con ``argv=None``.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from typing import Any
+
+__all__ = [
+    "obtener_argumentos",
+    "contiene_flag",
+    "obtener_opcion",
+    "parsear_pares",
+]
+
+
+def obtener_argumentos(argv: Sequence[object] | None = None) -> list[str]:
+    """Devuelve una copia normalizada de los argumentos de usuario.
+
+    Cuando ``argv`` es ``None`` se usa ``sys.argv[1:]`` en el momento de la
+    llamada. Si se entrega una secuencia explícita, se copia completa sin
+    eliminar el primer elemento para facilitar pruebas y usos embebidos.
+    """
+
+    if argv is None:
+        return list(sys.argv[1:])
+    if isinstance(argv, (str, bytes, bytearray)):
+        raise TypeError("argv debe ser una secuencia de argumentos, no texto plano")
+    return [str(argumento) for argumento in argv]
+
+
+def _normalizar_nombre(nombre: str) -> str:
+    nombre = str(nombre).strip()
+    if not nombre:
+        raise ValueError("el nombre de la opción no puede estar vacío")
+
+    if nombre.startswith("--"):
+        nombre = nombre[2:]
+    elif nombre.startswith("-"):
+        nombre = nombre[1:]
+
+    if not nombre:
+        raise ValueError("el nombre de la opción no puede estar vacío")
+    return nombre
+
+
+def _tokens_opcion(nombre: str) -> tuple[str, str | None]:
+    nombre = _normalizar_nombre(nombre)
+    largo = f"--{nombre}"
+    corto = f"-{nombre}" if len(nombre) == 1 else None
+    return largo, corto
+
+
+def _es_opcion(argumento: str) -> bool:
+    if not argumento.startswith("-") or argumento == "-":
+        return False
+    try:
+        float(argumento)
+    except ValueError:
+        return True
+    return False
+
+
+def contiene_flag(nombre: str, argv: Sequence[object] | None = None) -> bool:
+    """Indica si ``argv`` contiene un flag largo o corto simple.
+
+    Reconoce ``--flag`` y, para nombres de un solo carácter, ``-v``. Las formas
+    con valor (``--clave=valor`` o ``--clave valor``) no cuentan como flag.
+    """
+
+    largo, corto = _tokens_opcion(nombre)
+    for argumento in obtener_argumentos(argv):
+        if argumento == largo or (corto is not None and argumento == corto):
+            return True
+    return False
+
+
+def obtener_opcion(
+    nombre: str,
+    argv: Sequence[object] | None = None,
+    por_defecto: Any = None,
+) -> str | Any:
+    """Obtiene el valor asociado a una opción o ``por_defecto`` si no existe.
+
+    Soporta ``--clave=valor``, ``--clave valor`` y opciones cortas simples como
+    ``-v valor`` cuando ``nombre`` tiene un solo carácter.
+    """
+
+    largo, corto = _tokens_opcion(nombre)
+    argumentos = obtener_argumentos(argv)
+
+    for indice, argumento in enumerate(argumentos):
+        if argumento.startswith(f"{largo}="):
+            return argumento.split("=", 1)[1]
+        if corto is not None and argumento.startswith(f"{corto}="):
+            return argumento.split("=", 1)[1]
+        if argumento == largo or (corto is not None and argumento == corto):
+            siguiente = indice + 1
+            if siguiente < len(argumentos) and not _es_opcion(argumentos[siguiente]):
+                return argumentos[siguiente]
+            return por_defecto
+
+    return por_defecto
+
+
+def parsear_pares(argv: Sequence[object] | None = None) -> dict[str, str | bool]:
+    """Parsea argumentos básicos en un diccionario de opciones.
+
+    ``--flag`` y flags cortos como ``-v`` se guardan con valor ``True``.
+    ``--clave valor``, ``--clave=valor`` y ``-v valor`` guardan el valor como
+    texto. Los argumentos posicionales se ignoran.
+    """
+
+    argumentos = obtener_argumentos(argv)
+    pares: dict[str, str | bool] = {}
+    indice = 0
+
+    while indice < len(argumentos):
+        argumento = argumentos[indice]
+
+        if argumento.startswith("--") and len(argumento) > 2:
+            nombre_valor = argumento[2:]
+            if "=" in nombre_valor:
+                nombre, valor = nombre_valor.split("=", 1)
+                if not nombre:
+                    raise ValueError("el nombre de la opción no puede estar vacío")
+                pares[nombre] = valor
+            else:
+                nombre = _normalizar_nombre(nombre_valor)
+                siguiente = indice + 1
+                if siguiente < len(argumentos) and not _es_opcion(argumentos[siguiente]):
+                    pares[nombre] = argumentos[siguiente]
+                    indice += 1
+                else:
+                    pares[nombre] = True
+        elif _es_opcion(argumento) and len(argumento) == 2:
+            nombre = _normalizar_nombre(argumento)
+            siguiente = indice + 1
+            if siguiente < len(argumentos) and not _es_opcion(argumentos[siguiente]):
+                pares[nombre] = argumentos[siguiente]
+                indice += 1
+            else:
+                pares[nombre] = True
+        elif _es_opcion(argumento) and len(argumento) > 2 and "=" in argumento:
+            nombre, valor = argumento[1:].split("=", 1)
+            if len(nombre) == 1:
+                pares[_normalizar_nombre(nombre)] = valor
+
+        indice += 1
+
+    return pares

--- a/tests/test_corelibs_argumentos.py
+++ b/tests/test_corelibs_argumentos.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from pcobra.corelibs.argumentos import (
+    contiene_flag,
+    obtener_argumentos,
+    obtener_opcion,
+    parsear_pares,
+)
+
+
+def test_obtener_argumentos_usa_sys_argv_solo_al_llamar(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["cobra", "--modo", "dev"])
+    assert obtener_argumentos() == ["--modo", "dev"]
+
+    monkeypatch.setattr(sys, "argv", ["cobra", "--modo", "prod"])
+    assert obtener_argumentos() == ["--modo", "prod"]
+
+
+def test_obtener_argumentos_copia_argv_explicito_completo():
+    assert obtener_argumentos(["programa", "--flag", 3]) == ["programa", "--flag", "3"]
+
+
+@pytest.mark.parametrize("nombre", ["", "-", "--", "   "])
+def test_nombres_vacios_lanzan_value_error(nombre):
+    with pytest.raises(ValueError):
+        contiene_flag(nombre, [])
+    with pytest.raises(ValueError):
+        obtener_opcion(nombre, [])
+
+
+def test_contiene_flag_soporta_largos_y_cortos_simples():
+    argv = ["--debug", "--modo=dev", "-v", "--salida", "archivo"]
+
+    assert contiene_flag("debug", argv) is True
+    assert contiene_flag("--debug", argv) is True
+    assert contiene_flag("v", argv) is True
+    assert contiene_flag("-v", argv) is True
+    assert contiene_flag("modo", argv) is False
+    assert contiene_flag("ausente", argv) is False
+
+
+def test_obtener_opcion_soporta_igual_separado_corto_y_defecto():
+    argv = ["--modo=dev", "--salida", "archivo.txt", "-n", "10", "--debug"]
+
+    assert obtener_opcion("modo", argv) == "dev"
+    assert obtener_opcion("salida", argv) == "archivo.txt"
+    assert obtener_opcion("n", argv) == "10"
+    assert obtener_opcion("debug", argv, por_defecto="no") == "no"
+    assert obtener_opcion("ausente", argv, por_defecto="x") == "x"
+
+
+def test_parsear_pares_parsea_patrones_basicos_e_ignora_posicionales():
+    argv = [
+        "entrada.cobra",
+        "--debug",
+        "--modo=dev",
+        "--salida",
+        "archivo.txt",
+        "-v",
+        "-n",
+        "10",
+        "--sin-valor",
+        "--negativo",
+        "-1",
+    ]
+
+    assert parsear_pares(argv) == {
+        "debug": True,
+        "modo": "dev",
+        "salida": "archivo.txt",
+        "v": True,
+        "n": "10",
+        "sin-valor": True,
+        "negativo": "-1",
+    }


### PR DESCRIPTION
### Motivation
- Proveer un módulo ligero en `pcobra.corelibs` para consultar argumentos de línea de comandos sin capturar `sys.argv` al importar.
- Soportar patrones comunes de CLI (`--flag`, `--clave valor`, `--clave=valor`, `-v`) y evitar que tokens numéricos negativos (ej. `-1`) se interpreten como flags.

### Description
- Se añadió `src/pcobra/corelibs/argumentos.py` con las funciones públicas `obtener_argumentos`, `contiene_flag`, `obtener_opcion` y `parsear_pares` y se exportan en `__all__`.
- `obtener_argumentos(argv=None)` usa `sys.argv[1:]` únicamente cuando `argv is None`, evitando capturas globales al importar; acepta secuencias explícitas y normaliza a `str`.
- Se implementó validación de nombres vacíos lanzando `ValueError` y normalización de nombres que pueden incluir prefijos `-` o `--` con las funciones internas `_normalizar_nombre` y `_tokens_opcion`.
- Se añadió lógica en `_es_opcion` para considerar como no-opciones tokens numéricos con guion (por ejemplo `-1`) de modo que números negativos se traten como valores posicionales y no como flags.
- `parsear_pares` produce un `dict[str, str | bool]` con flags como `True` y opciones con valor como `str`, cubriendo `--clave=valor`, `--clave valor`, `-v valor` y formas cortas simples.
- Se agregó `tests/test_corelibs_argumentos.py` que cubre lectura diferida de `sys.argv`, copiado de `argv` explícito, validación de nombres vacíos, detección de flags largos/cortos, `obtener_opcion` y `parsear_pares` (incluyendo caso de número negativo como valor).

### Testing
- Ejecutado `pytest -q tests/test_corelibs_argumentos.py` y todos los tests añadidos pasaron (`9 passed`).
- Verificado que el módulo compila con `python -m py_compile src/pcobra/corelibs/argumentos.py` (sin errores).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48bc48c704832781ae5555ed641b10)