### PR TITLE
Agregar helpers de aserción deterministas en corelibs (pcobra.corelibs.pruebas)

### DIFF
--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -198,6 +198,13 @@ from .sistema import (
     obtener_env,
     listar_dir,
 )
+from .pruebas import (
+    igual,
+    verdadero,
+    falso,
+    contiene,
+    lanza_error,
+)
 from .asincrono import (
     recolectar,
     iterar_completadas,
@@ -412,6 +419,11 @@ __all__ = [
     "proteger_tarea",
     "ejecutar_en_hilo",
     "grupo_tareas",
+    "igual",
+    "verdadero",
+    "falso",
+    "contiene",
+    "lanza_error",
 ]
 
 quitar_prefijo.__doc__ = (

--- a/src/pcobra/corelibs/pruebas.py
+++ b/src/pcobra/corelibs/pruebas.py
@@ -1,0 +1,166 @@
+"""Utilidades mínimas de aserción para pruebas en Cobra.
+
+Convención de retorno:
+- Las aserciones exitosas devuelven ``True``.
+- ``lanza_error`` devuelve la instancia de error capturada cuando la función
+  lanza el tipo esperado, para permitir inspeccionar su mensaje o atributos.
+
+Todas las comprobaciones fallidas lanzan ``AssertionError`` con mensajes
+explícitos y deterministas. Este módulo no depende de frameworks externos.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+TError = TypeVar("TError", bound=BaseException)
+
+__all__ = [
+    "igual",
+    "verdadero",
+    "falso",
+    "contiene",
+    "lanza_error",
+]
+
+
+def _mensaje_personalizado(mensaje: str | None, predeterminado: str) -> str:
+    """Devuelve ``mensaje`` si existe; en caso contrario, ``predeterminado``."""
+
+    return predeterminado if mensaje is None else str(mensaje)
+
+
+def igual(obtenido: Any, esperado: Any, mensaje: str | None = None) -> bool:
+    """Afirma que ``obtenido`` y ``esperado`` son iguales.
+
+    Returns:
+        ``True`` cuando la aserción se cumple.
+
+    Raises:
+        AssertionError: si los valores son distintos.
+    """
+
+    if obtenido == esperado:
+        return True
+
+    predeterminado = f"Se esperaba {esperado!r}, pero se obtuvo {obtenido!r}"
+    raise AssertionError(_mensaje_personalizado(mensaje, predeterminado))
+
+
+def verdadero(valor: Any, mensaje: str | None = None) -> bool:
+    """Afirma que ``valor`` es verdadero según la semántica booleana de Python.
+
+    Returns:
+        ``True`` cuando la aserción se cumple.
+
+    Raises:
+        AssertionError: si ``bool(valor)`` es ``False``.
+    """
+
+    if bool(valor):
+        return True
+
+    predeterminado = f"Se esperaba un valor verdadero, pero se obtuvo {valor!r}"
+    raise AssertionError(_mensaje_personalizado(mensaje, predeterminado))
+
+
+def falso(valor: Any, mensaje: str | None = None) -> bool:
+    """Afirma que ``valor`` es falso según la semántica booleana de Python.
+
+    Returns:
+        ``True`` cuando la aserción se cumple.
+
+    Raises:
+        AssertionError: si ``bool(valor)`` es ``True``.
+    """
+
+    if not bool(valor):
+        return True
+
+    predeterminado = f"Se esperaba un valor falso, pero se obtuvo {valor!r}"
+    raise AssertionError(_mensaje_personalizado(mensaje, predeterminado))
+
+
+def contiene(contenedor: Any, elemento: Any, mensaje: str | None = None) -> bool:
+    """Afirma que ``elemento`` pertenece a ``contenedor``.
+
+    Returns:
+        ``True`` cuando la aserción se cumple.
+
+    Raises:
+        AssertionError: si ``elemento`` no está en ``contenedor`` o si el
+        contenedor no soporta la operación de pertenencia.
+    """
+
+    try:
+        encontrado = elemento in contenedor
+    except TypeError as exc:
+        predeterminado = (
+            f"No se pudo comprobar pertenencia de {elemento!r} "
+            f"en {contenedor!r}: {exc}"
+        )
+        raise AssertionError(_mensaje_personalizado(mensaje, predeterminado)) from exc
+
+    if encontrado:
+        return True
+
+    predeterminado = f"Se esperaba que {elemento!r} estuviera en {contenedor!r}"
+    raise AssertionError(_mensaje_personalizado(mensaje, predeterminado))
+
+
+def lanza_error(
+    funcion: Callable[..., Any],
+    tipo_error: type[TError] | tuple[type[BaseException], ...] = Exception,
+    *args: Any,
+    **kwargs: Any,
+) -> TError | BaseException:
+    """Afirma que ``funcion(*args, **kwargs)`` lanza ``tipo_error``.
+
+    Returns:
+        La instancia de error capturada cuando coincide con ``tipo_error``.
+
+    Raises:
+        TypeError: si ``funcion`` no es invocable o ``tipo_error`` no es una
+        clase/tupla de clases de excepción válida para ``except``.
+        AssertionError: si no se lanza ningún error o si se lanza otro tipo.
+    """
+
+    if not callable(funcion):
+        raise TypeError("funcion debe ser callable")
+    _validar_tipo_error(tipo_error)
+
+    try:
+        funcion(*args, **kwargs)
+    except tipo_error as exc:
+        return exc
+    except Exception as exc:
+        nombre_esperado = _nombre_tipo_error(tipo_error)
+        predeterminado = (
+            f"Se esperaba error {nombre_esperado}, "
+            f"pero se lanzó {type(exc).__name__}: {exc}"
+        )
+        raise AssertionError(predeterminado) from exc
+
+    nombre_esperado = _nombre_tipo_error(tipo_error)
+    raise AssertionError(f"Se esperaba error {nombre_esperado}, pero no se lanzó ninguno")
+
+
+def _validar_tipo_error(
+    tipo_error: type[BaseException] | tuple[type[BaseException], ...],
+) -> None:
+    """Valida que ``tipo_error`` sea compatible con una cláusula ``except``."""
+
+    tipos = tipo_error if isinstance(tipo_error, tuple) else (tipo_error,)
+    if not tipos:
+        raise TypeError("tipo_error debe incluir al menos una clase de excepción")
+    if not all(isinstance(tipo, type) and issubclass(tipo, BaseException) for tipo in tipos):
+        raise TypeError("tipo_error debe ser una clase de excepción o una tupla de ellas")
+
+
+def _nombre_tipo_error(tipo_error: type[BaseException] | tuple[type[BaseException], ...]) -> str:
+    """Representa de forma estable un tipo o tupla de tipos de excepción."""
+
+    if isinstance(tipo_error, tuple):
+        return "(" + ", ".join(tipo.__name__ for tipo in tipo_error) + ")"
+    return tipo_error.__name__

--- a/tests/unit/test_corelibs_pruebas.py
+++ b/tests/unit/test_corelibs_pruebas.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from pcobra.corelibs import pruebas
+
+
+def test_aserciones_exitosas_devuelven_true():
+    assert pruebas.igual({"a": 1}, {"a": 1}) is True
+    assert pruebas.verdadero([1]) is True
+    assert pruebas.falso([]) is True
+    assert pruebas.contiene("cobra", "ob") is True
+
+
+def test_aserciones_fallidas_usan_mensajes_deterministas():
+    with pytest.raises(AssertionError, match="Se esperaba 2, pero se obtuvo 1"):
+        pruebas.igual(1, 2)
+
+    with pytest.raises(AssertionError, match="Se esperaba un valor verdadero, pero se obtuvo 0"):
+        pruebas.verdadero(0)
+
+    with pytest.raises(AssertionError, match="Se esperaba un valor falso, pero se obtuvo 'texto'"):
+        pruebas.falso("texto")
+
+    with pytest.raises(AssertionError, match=r"Se esperaba que 4 estuviera en \[1, 2, 3\]"):
+        pruebas.contiene([1, 2, 3], 4)
+
+
+def test_mensaje_personalizado_sustituye_el_predeterminado():
+    with pytest.raises(AssertionError, match="mensaje propio"):
+        pruebas.igual("a", "b", "mensaje propio")
+
+
+def test_contiene_reporta_contenedor_no_iterable_como_assertion_error():
+    with pytest.raises(AssertionError, match="No se pudo comprobar pertenencia"):
+        pruebas.contiene(10, 1)
+
+
+def test_lanza_error_devuelve_error_capturado():
+    def falla(valor: str) -> None:
+        raise ValueError(f"valor inválido: {valor}")
+
+    error = pruebas.lanza_error(falla, ValueError, "x")
+
+    assert isinstance(error, ValueError)
+    assert str(error) == "valor inválido: x"
+
+
+def test_lanza_error_falla_si_no_hay_error_o_tipo_distinto():
+    with pytest.raises(AssertionError, match="Se esperaba error ValueError, pero no se lanzó ninguno"):
+        pruebas.lanza_error(lambda: None, ValueError)
+
+    with pytest.raises(AssertionError, match="Se esperaba error ValueError, pero se lanzó TypeError"):
+        pruebas.lanza_error(lambda: (_ for _ in ()).throw(TypeError("boom")), ValueError)
+
+
+def test_lanza_error_valida_callable_y_tipo_error():
+    with pytest.raises(TypeError, match="funcion debe ser callable"):
+        pruebas.lanza_error("no callable")
+
+    with pytest.raises(TypeError, match="tipo_error debe ser una clase de excepción"):
+        pruebas.lanza_error(lambda: None, object)
+
+
+def test_all_expone_solo_api_publica():
+    assert pruebas.__all__ == ["igual", "verdadero", "falso", "contiene", "lanza_error"]
+    for nombre in pruebas.__all__:
+        assert hasattr(pruebas, nombre)


### PR DESCRIPTION
### Motivation
- Proveer utilidades mínimas y deterministas de aserción para pruebas dentro de `pcobra.corelibs` sin añadir dependencias externas.
- Facilitar comprobaciones explícitas y mensajes reproducibles para igualdad, verdad, falsedad, pertenencia y comprobación de excepciones.
- Permitir inspeccionar la excepción capturada cuando se espera que una función lance un error.

### Description
- Añadido `src/pcobra/corelibs/pruebas.py` con funciones públicas `igual`, `verdadero`, `falso`, `contiene` y `lanza_error` y `__all__` explícito, documentando la convención de retorno (`True` en aserciones exitosas; `lanza_error` devuelve la excepción capturada).
- `lanza_error` valida que `funcion` sea `callable` y que `tipo_error` sea una clase de excepción o una tupla de ellas; los fallos generan `TypeError` o `AssertionError` con mensajes deterministas.
- Re-exportados los helpers desde el paquete agregándolos en `src/pcobra/corelibs/__init__.py` para que puedan importarse como `from pcobra.corelibs import pruebas` o por nombre desde `pcobra.corelibs`.
- Añadidos tests enfocados en `tests/unit/test_corelibs_pruebas.py` que cubren éxitos, mensajes de falla deterministas, mensajes personalizados, errores al comprobar pertenencia en no-iterables, retorno de la excepción capturada y validaciones de entrada.

### Testing
- Se compiló el nuevo módulo y la modificación del paquete con `python -m py_compile src/pcobra/corelibs/pruebas.py src/pcobra/corelibs/__init__.py` y no produjo errores.
- Se ejecutaron las pruebas relevantes con `pytest -q tests/unit/test_corelibs_pruebas.py tests/unit/test_corelibs_surface_exports.py` y el resultado fue: `18 passed` (apareció 1 warning deprecación preexistente que no fue introducida por este cambio).
- Los tests nuevos en `tests/unit/test_corelibs_pruebas.py` pasan y verifican la superficie pública (`__all__`) del módulo de pruebas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48be7a34b48327818b8b55f633034e)