### PR TITLE
Add temporal corelib utilities

### DIFF
--- a/src/pcobra/corelibs/temporal.py
+++ b/src/pcobra/corelibs/temporal.py
@@ -1,0 +1,81 @@
+"""Utilidades para crear y limpiar rutas temporales en Cobra."""
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Optional, Union
+
+PathLike = Union[str, os.PathLike[str]]
+
+__all__ = ["archivo_temporal", "directorio_temporal", "limpiar"]
+
+
+def _validar_texto_opcional(valor: Optional[str], nombre_argumento: str) -> Optional[str]:
+    if valor is None:
+        return None
+    if not isinstance(valor, str):
+        raise TypeError(f"{nombre_argumento} debe ser texto o None")
+    return valor
+
+
+def _validar_ruta(ruta: PathLike) -> PathLike:
+    if not isinstance(ruta, (str, os.PathLike)):
+        raise TypeError("ruta debe ser una ruta de texto o compatible con os.PathLike")
+    texto = os.fspath(ruta)
+    if not isinstance(texto, str):
+        raise TypeError("ruta debe representar una ruta de texto")
+    if texto == "":
+        raise ValueError("ruta no puede estar vacía")
+    return ruta
+
+
+def archivo_temporal(
+    *, prefijo: Optional[str] = None, sufijo: Optional[str] = None, texto: bool = True
+) -> str:
+    """Crea un archivo temporal vacío y devuelve su ruta como texto.
+
+    El descriptor creado por :func:`tempfile.mkstemp` se cierra inmediatamente para
+    evitar fugas de recursos. ``texto`` selecciona si el archivo se abre en modo de
+    texto o binario durante la creación, siguiendo la semántica de ``mkstemp``.
+    """
+
+    prefijo_validado = _validar_texto_opcional(prefijo, "prefijo")
+    sufijo_validado = _validar_texto_opcional(sufijo, "sufijo")
+    if not isinstance(texto, bool):
+        raise TypeError("texto debe ser booleano")
+
+    descriptor, ruta = tempfile.mkstemp(
+        prefix=prefijo_validado, suffix=sufijo_validado, text=texto
+    )
+    os.close(descriptor)
+    return str(Path(ruta))
+
+
+def directorio_temporal(*, prefijo: Optional[str] = None) -> str:
+    """Crea un directorio temporal y devuelve su ruta como texto."""
+
+    prefijo_validado = _validar_texto_opcional(prefijo, "prefijo")
+    return str(Path(tempfile.mkdtemp(prefix=prefijo_validado)))
+
+
+def limpiar(ruta: PathLike) -> bool:
+    """Elimina un archivo o directorio temporal de forma segura.
+
+    Devuelve ``True`` cuando elimina una ruta existente. Si ``ruta`` no existe,
+    devuelve ``False`` de manera determinista y no crea errores.
+    """
+
+    ruta_validada = _validar_ruta(ruta)
+    objetivo = Path(ruta_validada)
+
+    if not objetivo.exists():
+        return False
+    try:
+        if objetivo.is_dir() and not objetivo.is_symlink():
+            shutil.rmtree(objetivo)
+        else:
+            objetivo.unlink()
+    except FileNotFoundError:
+        return False
+    return True

--- a/tests/test_corelibs_temporal.py
+++ b/tests/test_corelibs_temporal.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import pytest
+
+from pcobra.corelibs import temporal
+
+
+def test_superficie_publica_temporal() -> None:
+    assert temporal.__all__ == ["archivo_temporal", "directorio_temporal", "limpiar"]
+
+
+def test_archivo_temporal_devuelve_str_y_cierra_descriptor() -> None:
+    ruta = temporal.archivo_temporal(prefijo="cobra-", sufijo=".txt", texto=True)
+
+    try:
+        assert isinstance(ruta, str)
+        archivo = Path(ruta)
+        assert archivo.exists()
+        assert archivo.name.startswith("cobra-")
+        assert archivo.suffix == ".txt"
+        archivo.write_text("ok", encoding="utf-8")
+        assert archivo.read_text(encoding="utf-8") == "ok"
+    finally:
+        temporal.limpiar(ruta)
+
+
+def test_directorio_temporal_y_limpieza_recursiva() -> None:
+    ruta = temporal.directorio_temporal(prefijo="cobra-dir-")
+    directorio = Path(ruta)
+    archivo = directorio / "datos.txt"
+    archivo.write_text("cobra", encoding="utf-8")
+
+    assert isinstance(ruta, str)
+    assert directorio.exists()
+    assert directorio.name.startswith("cobra-dir-")
+    assert temporal.limpiar(ruta) is True
+    assert not directorio.exists()
+
+
+def test_limpiar_archivo_existente_y_ruta_inexistente(tmp_path: Path) -> None:
+    archivo = tmp_path / "temporal.txt"
+    archivo.write_text("cobra", encoding="utf-8")
+
+    assert temporal.limpiar(archivo) is True
+    assert temporal.limpiar(archivo) is False
+
+
+def test_argumentos_invalidos_generan_mensajes_deterministas() -> None:
+    with pytest.raises(TypeError, match="prefijo debe ser texto o None"):
+        temporal.archivo_temporal(prefijo=123)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="sufijo debe ser texto o None"):
+        temporal.archivo_temporal(sufijo=123)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="texto debe ser booleano"):
+        temporal.archivo_temporal(texto="si")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="ruta no puede estar vacía"):
+        temporal.limpiar("")


### PR DESCRIPTION
### Motivation
- Proveer utilidades sencillas y seguras para crear y limpiar archivos y directorios temporales usadas por Cobra, con comportamiento determinista ante entradas inválidas o rutas inexistentes.

### Description
- Añadido `src/pcobra/corelibs/temporal.py` que exporta `archivo_temporal`, `directorio_temporal` y `limpiar` en `__all__` y no mantiene registros globales de temporales.
- `archivo_temporal` usa `tempfile.mkstemp`, cierra el descriptor con `os.close` y devuelve la ruta como `str`, admitiendo `prefijo`, `sufijo` y el flag booleano `texto` con validación explícita.
- `directorio_temporal` usa `tempfile.mkdtemp` y devuelve la ruta como `str` con validación opcional de `prefijo`.
- `limpiar` valida la ruta, elimina recursivamente directorios con `shutil.rmtree` y archivos con `Path.unlink`, y devuelve `False` de forma determinista si la ruta no existe.

### Testing
- Se añadieron pruebas en `tests/test_corelibs_temporal.py` que ejercitan la superficie pública, cierre de descriptor, limpieza recursiva y errores deterministas; se ejecutó con `pytest -q tests/test_corelibs_temporal.py` y obtuvo `5 passed`.
- Se ejecutó un conjunto ampliado con `pytest -q tests/test_corelibs_ruta.py tests/test_corelibs_proceso.py tests/test_corelibs_temporal.py` y obtuvo `14 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48bff6f7d48327b50882f213c21a03)