### PR TITLE
Añadir utilidades criptográficas en corelibs

### DIFF
--- a/src/pcobra/corelibs/cripto.py
+++ b/src/pcobra/corelibs/cripto.py
@@ -1,0 +1,75 @@
+"""Utilidades criptográficas básicas para hashing y generación de tokens."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import operator
+import secrets
+
+
+__all__ = [
+    "sha256",
+    "sha512",
+    "comparar_seguro",
+    "token_seguro",
+    "token_hexadecimal",
+]
+
+
+def _a_bytes(datos: str | bytes) -> bytes:
+    """Convierte cadenas a UTF-8 y conserva datos binarios sin cambios."""
+
+    if isinstance(datos, str):
+        return datos.encode("utf-8")
+    if isinstance(datos, bytes):
+        return datos
+    raise TypeError("datos debe ser str o bytes")
+
+
+def _tamano_token(bytes: int) -> int:
+    """Valida y normaliza el tamaño en bytes solicitado para un token."""
+
+    try:
+        longitud = operator.index(bytes)
+    except TypeError:
+        raise TypeError("bytes debe ser un entero") from None
+    if longitud <= 0:
+        raise ValueError("bytes debe ser positivo")
+    return longitud
+
+
+def sha256(datos: str | bytes) -> str:
+    """Calcula el resumen SHA-256 hexadecimal de ``datos``.
+
+    Las cadenas ``str`` se codifican como UTF-8 antes de aplicar el hash.
+    """
+
+    return hashlib.sha256(_a_bytes(datos)).hexdigest()
+
+
+def sha512(datos: str | bytes) -> str:
+    """Calcula el resumen SHA-512 hexadecimal de ``datos``.
+
+    Las cadenas ``str`` se codifican como UTF-8 antes de aplicar el hash.
+    """
+
+    return hashlib.sha512(_a_bytes(datos)).hexdigest()
+
+
+def comparar_seguro(a: str | bytes, b: str | bytes) -> bool:
+    """Compara dos valores con resistencia a ataques de temporización."""
+
+    return hmac.compare_digest(_a_bytes(a), _a_bytes(b))
+
+
+def token_seguro(bytes: int = 32) -> str:
+    """Genera un token URL-safe usando entropía del sistema."""
+
+    return secrets.token_urlsafe(_tamano_token(bytes))
+
+
+def token_hexadecimal(bytes: int = 32) -> str:
+    """Genera un token hexadecimal usando entropía del sistema."""
+
+    return secrets.token_hex(_tamano_token(bytes))


### PR DESCRIPTION
### Motivation
- Proveer funciones criptográficas básicas reutilizables en la biblioteca `pcobra.corelibs` para hashing y generación de tokens.
- Aceptar entradas tanto como `str` como `bytes` y garantizar codificación segura de `str` a UTF-8 antes de hash o comparación.
- Evitar almacenar secretos en estado global y usar solamente la biblioteca estándar (`hashlib`, `hmac`, `secrets`).

### Description
- Añadido el fichero `src/pcobra/corelibs/cripto.py` con la API pública listada en `__all__` que expone `sha256`, `sha512`, `comparar_seguro`, `token_seguro` y `token_hexadecimal`.
- Implementadas las utilidades internas `_a_bytes` para normalizar `str|bytes` y `_tamano_token` para validar que el tamaño de token sea un entero positivo y lanzando `TypeError`/`ValueError` apropiados.
- Implementadas `sha256` y `sha512` que devuelven hex digest usando `hashlib`, y `comparar_seguro` que usa `hmac.compare_digest` para evitar ataques por temporización.
- Implementadas `token_seguro` y `token_hexadecimal` usando `secrets.token_urlsafe` y `secrets.token_hex` respectivamente sin dependencias externas.

### Testing
- Compilación comprobada con `python -m compileall -q src/pcobra/corelibs/cripto.py` y la importación fue exitosa.
- Ejecutadas aserciones en un script que verificó equivalencia `str`/`bytes` en `sha256`, longitud de `sha512`, comportamiento de `comparar_seguro`, generación de tokens y rechazo de tamaños no positivos; todas las aserciones pasaron.
- No hay cambios pendientes en el índice tras el `commit` que añadió `src/pcobra/corelibs/cripto.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48c1190c2c8327ac486ad102ecfb55)