### PR TITLE
Agregar utilidades regex en corelibs

### DIFF
--- a/src/pcobra/corelibs/regex.py
+++ b/src/pcobra/corelibs/regex.py
@@ -1,0 +1,82 @@
+"""Funciones utilitarias para trabajar con expresiones regulares."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from typing import Any
+
+
+__all__ = [
+    "buscar",
+    "coincidir",
+    "reemplazar",
+    "dividir",
+    "encontrar_todos",
+]
+
+_Reemplazo = str | Callable[[re.Match[str]], str]
+
+
+def _error_patron(exc: re.error) -> ValueError:
+    """Convierte errores de ``re`` en mensajes claros para Cobra."""
+
+    return ValueError(f"patrón de expresión regular inválido: {exc}")
+
+
+def buscar(patron: str, texto: str, *, flags: int = 0) -> str | None:
+    """Busca ``patron`` en ``texto`` y devuelve el texto coincidente o ``None``."""
+
+    try:
+        coincidencia = re.search(patron, texto, flags)
+    except re.error as exc:
+        raise _error_patron(exc) from None
+    if coincidencia is None:
+        return None
+    return coincidencia.group(0)
+
+
+def coincidir(patron: str, texto: str, *, flags: int = 0) -> str | None:
+    """Comprueba si ``texto`` empieza con ``patron`` y devuelve la coincidencia."""
+
+    try:
+        coincidencia = re.match(patron, texto, flags)
+    except re.error as exc:
+        raise _error_patron(exc) from None
+    if coincidencia is None:
+        return None
+    return coincidencia.group(0)
+
+
+def reemplazar(
+    patron: str,
+    reemplazo: _Reemplazo,
+    texto: str,
+    *,
+    limite: int = 0,
+    flags: int = 0,
+) -> str:
+    """Reemplaza coincidencias de ``patron`` en ``texto`` respetando ``limite``."""
+
+    try:
+        return re.sub(patron, reemplazo, texto, count=limite, flags=flags)
+    except re.error as exc:
+        raise _error_patron(exc) from None
+
+
+def dividir(patron: str, texto: str, *, maximo: int = 0, flags: int = 0) -> list[str]:
+    """Divide ``texto`` usando ``patron`` como separador."""
+
+    try:
+        return re.split(patron, texto, maxsplit=maximo, flags=flags)
+    except re.error as exc:
+        raise _error_patron(exc) from None
+
+
+def encontrar_todos(patron: str, texto: str, *, flags: int = 0) -> list[Any]:
+    """Devuelve una lista con todas las coincidencias de ``patron`` en ``texto``."""
+
+    try:
+        return list(re.findall(patron, texto, flags))
+    except re.error as exc:
+        raise _error_patron(exc) from None

--- a/tests/unit/test_corelibs_regex.py
+++ b/tests/unit/test_corelibs_regex.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from pcobra.corelibs import regex
+
+
+def test_buscar_y_coincidir_devuelven_texto_o_none() -> None:
+    assert regex.buscar(r"\d+", "abc123") == "123"
+    assert regex.buscar(r"\d+", "abc") is None
+    assert regex.coincidir(r"abc", "abcdef") == "abc"
+    assert regex.coincidir(r"\d+", "abc123") is None
+
+
+def test_operaciones_regex_respetan_limites_flags_y_listas() -> None:
+    assert regex.reemplazar(r"a", "x", "banana", limite=2) == "bxnxna"
+    assert regex.dividir(r"\s+", "uno  dos\ttres", maximo=1) == ["uno", "dos\ttres"]
+    assert regex.encontrar_todos(r"[a-z]+", "A b C d", flags=re.IGNORECASE) == [
+        "A",
+        "b",
+        "C",
+        "d",
+    ]
+
+
+@pytest.mark.parametrize("funcion,args", [
+    (regex.buscar, ("[", "texto")),
+    (regex.coincidir, ("[", "texto")),
+    (regex.reemplazar, ("[", "x", "texto")),
+    (regex.dividir, ("[", "texto")),
+    (regex.encontrar_todos, ("[", "texto")),
+])
+def test_patrones_invalidos_generan_value_error_en_espanol(funcion, args) -> None:
+    with pytest.raises(ValueError, match="patrón de expresión regular inválido"):
+        funcion(*args)
+
+
+def test_all_solo_expone_api_publica_canonica() -> None:
+    assert regex.__all__ == [
+        "buscar",
+        "coincidir",
+        "reemplazar",
+        "dividir",
+        "encontrar_todos",
+    ]


### PR DESCRIPTION
### Motivation
- Añadir un módulo de utilidades de expresiones regulares en la colección de `corelibs` para complementar las funciones de texto existentes y ofrecer una API en español consistente.
- Evitar exponer objetos `re.Match` en la API pública y garantizar mensajes de error claros en español cuando el patrón sea inválido.

### Description
- Se creó `src/pcobra/corelibs/regex.py` y se definió `__all__` exponiendo `buscar`, `coincidir`, `reemplazar`, `dividir` y `encontrar_todos`.
- `buscar` usa `re.search` y `coincidir` usa `re.match`, ambas devuelven la subcadena coincidente o `None` evitando exponer `Match`.
- `reemplazar`, `dividir` y `encontrar_todos` son envoltorios sobre `re.sub`, `re.split` y `re.findall` que respetan `limite`/`maximo` y `flags` según corresponda.
- Errores de patrón (`re.error`) se convierten en `ValueError` con mensaje en español: `"patrón de expresión regular inválido: ..."`.
- Se añadieron pruebas unitarias en `tests/unit/test_corelibs_regex.py` para cubrir comportamiento nominal, flags/límites, manejo de patrones inválidos y la variable `__all__`.

### Testing
- Ejecuté `python -m pytest tests/unit/test_corelibs_regex.py` y los tests unitarios del nuevo módulo pasaron satisfactoriamente. (8 passed)
- Ejecuté `python -m compileall -q src/pcobra/corelibs/regex.py` y `python -m ruff check src/pcobra/corelibs/regex.py tests/unit/test_corelibs_regex.py`, ambos checks pasaron.
- Al ejecutar `python -m pytest tests/test_usar_public_exports_snapshot.py tests/unit/test_corelibs_regex.py` se detectó una falla no relacionada con `regex`: la prueba de snapshot público falla porque `texto.__all__` parece no exponer `dividir` (deriva previa en la superficie pública), por lo que el conjunto global de tests reportó fallos fuera del cambio realizado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48c2292a1c832792c4e41fef5046a3)