### PR TITLE
Agregar lectura de configuración TOML e INI

### DIFF
--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -198,6 +198,12 @@ from .sistema import (
     obtener_env,
     listar_dir,
 )
+from .configuracion import (
+    leer_toml,
+    leer_ini,
+    toml_disponible,
+    leer_configuracion,
+)
 from .pruebas import (
     igual,
     verdadero,
@@ -419,6 +425,10 @@ __all__ = [
     "proteger_tarea",
     "ejecutar_en_hilo",
     "grupo_tareas",
+    "leer_toml",
+    "leer_ini",
+    "toml_disponible",
+    "leer_configuracion",
     "igual",
     "verdadero",
     "falso",

--- a/src/pcobra/corelibs/configuracion.py
+++ b/src/pcobra/corelibs/configuracion.py
@@ -1,0 +1,86 @@
+"""Lectura de archivos de configuración TOML e INI para las corelibs."""
+
+from __future__ import annotations
+
+import configparser
+import importlib
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+__all__ = [
+    "leer_toml",
+    "leer_ini",
+    "toml_disponible",
+    "leer_configuracion",
+]
+
+_TOML_NO_SOPORTADO = "TOML no está soportado en este entorno de Python: falta tomllib"
+_FORMATOS_SOPORTADOS = ".toml, .ini, .cfg"
+
+
+def toml_disponible() -> bool:
+    """Indica si el intérprete actual incluye soporte estándar para TOML."""
+
+    return importlib.util.find_spec("tomllib") is not None
+
+
+def leer_toml(ruta: str | Path) -> dict[str, Any]:
+    """Lee un archivo TOML desde ``ruta`` usando ``tomllib`` de la biblioteca estándar."""
+
+    ruta_configuracion = _validar_archivo_existente(ruta)
+    tomllib = _cargar_tomllib()
+
+    with ruta_configuracion.open("rb") as archivo:
+        return tomllib.load(archivo)
+
+
+def leer_ini(ruta: str | Path) -> dict[str, dict[str, str]]:
+    """Lee un archivo INI/CFG y devuelve sus secciones como diccionarios."""
+
+    ruta_configuracion = _validar_archivo_existente(ruta)
+    parser = configparser.ConfigParser()
+
+    with ruta_configuracion.open("r", encoding="utf-8") as archivo:
+        parser.read_file(archivo, source=str(ruta_configuracion))
+
+    configuracion: dict[str, dict[str, str]] = {}
+    if parser.defaults():
+        configuracion[parser.default_section] = dict(parser.defaults())
+
+    for seccion in parser.sections():
+        configuracion[seccion] = dict(parser[seccion])
+
+    return configuracion
+
+
+def leer_configuracion(ruta: str | Path) -> dict[str, Any] | dict[str, dict[str, str]]:
+    """Lee ``ruta`` eligiendo el parser por extensión: ``.toml``, ``.ini`` o ``.cfg``."""
+
+    ruta_configuracion = _validar_archivo_existente(ruta)
+    extension = ruta_configuracion.suffix.lower()
+
+    if extension == ".toml":
+        return leer_toml(ruta_configuracion)
+    if extension in {".ini", ".cfg"}:
+        return leer_ini(ruta_configuracion)
+
+    raise ValueError(
+        f"Formato de configuración no soportado para '{ruta_configuracion}'; "
+        f"extensiones soportadas: {_FORMATOS_SOPORTADOS}"
+    )
+
+
+def _validar_archivo_existente(ruta: str | Path) -> Path:
+    ruta_configuracion = Path(ruta)
+    if not ruta_configuracion.is_file():
+        raise FileNotFoundError(f"Archivo de configuración no encontrado: {ruta_configuracion}")
+    return ruta_configuracion
+
+
+def _cargar_tomllib() -> ModuleType:
+    if not toml_disponible():
+        raise RuntimeError(_TOML_NO_SOPORTADO)
+
+    return importlib.import_module("tomllib")

--- a/tests/unit/test_corelibs_configuracion.py
+++ b/tests/unit/test_corelibs_configuracion.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pcobra.corelibs import configuracion
+
+
+def test_leer_toml_y_leer_configuracion_toml(tmp_path: Path):
+    ruta = tmp_path / "app.toml"
+    ruta.write_text('[app]\nnombre = "Cobra"\nactivo = true\n', encoding="utf-8")
+
+    assert configuracion.toml_disponible() is True
+    assert configuracion.leer_toml(ruta) == {"app": {"nombre": "Cobra", "activo": True}}
+    assert configuracion.leer_configuracion(ruta) == {"app": {"nombre": "Cobra", "activo": True}}
+
+
+def test_leer_ini_y_cfg_por_extension(tmp_path: Path):
+    ruta = tmp_path / "app.cfg"
+    ruta.write_text('[DEFAULT]\nbase = cobra\n[servidor]\npuerto = 8080\n', encoding="utf-8")
+
+    assert configuracion.leer_ini(ruta) == {
+        "DEFAULT": {"base": "cobra"},
+        "servidor": {"base": "cobra", "puerto": "8080"},
+    }
+    assert configuracion.leer_configuracion(ruta)["servidor"]["puerto"] == "8080"
+
+
+def test_leer_toml_sin_tomllib_lanza_runtimeerror_claro(tmp_path: Path, monkeypatch):
+    ruta = tmp_path / "app.toml"
+    ruta.write_text("valor = 1\n", encoding="utf-8")
+    monkeypatch.setattr(configuracion, "toml_disponible", lambda: False)
+
+    with pytest.raises(RuntimeError, match="TOML no está soportado.*tomllib"):
+        configuracion.leer_toml(ruta)
+
+
+def test_errores_deterministas_para_ruta_inexistente_y_formato_no_soportado(tmp_path: Path):
+    inexistente = tmp_path / "no_existe.ini"
+    with pytest.raises(FileNotFoundError, match="Archivo de configuración no encontrado"):
+        configuracion.leer_configuracion(inexistente)
+
+    ruta = tmp_path / "app.json"
+    ruta.write_text("{}", encoding="utf-8")
+    with pytest.raises(ValueError, match="Formato de configuración no soportado"):
+        configuracion.leer_configuracion(ruta)
+
+
+def test_all_expone_solo_api_publica():
+    assert configuracion.__all__ == [
+        "leer_toml",
+        "leer_ini",
+        "toml_disponible",
+        "leer_configuracion",
+    ]


### PR DESCRIPTION
### Motivation

- Añadir utilidades para leer archivos de configuración en las corelibs y exponer una API consistente para TOML e INI/CFG.
- Usar `tomllib` cuando esté disponible y proporcionar una degradación predecible en entornos sin soporte estándar para TOML.
- Garantizar errores deterministas para rutas inexistentes y formatos no soportados y mantener una superficie pública controlada mediante `__all__`.

### Description

- Se crea `src/pcobra/corelibs/configuracion.py` con las funciones públicas `leer_toml`, `leer_ini`, `toml_disponible` y `leer_configuracion` y el `__all__` correspondiente.
- `toml_disponible()` detecta `tomllib` mediante `importlib.util.find_spec` y `leer_toml` carga TOML usando `tomllib`, lanzando un `RuntimeError` claro cuando no está disponible.
- `leer_ini()` usa `configparser` para devolver secciones como diccionarios (incluye `DEFAULT`), y `leer_configuracion()` elige el parser por extensión `.toml`, `.ini` o `.cfg` y rechaza otras extensiones con `ValueError`.
- Se reexporta la API desde `pcobra.corelibs.__init__.py` y se añaden pruebas unitarias en `tests/unit/test_corelibs_configuracion.py` que cubren lectura TOML/INI, ausencia de `tomllib`, errores deterministas y la validación de `__all__`.

### Testing

- Se ejecutó `python -m pytest tests/unit/test_corelibs_configuracion.py` y los tests locales añadidos pasaron (`5 passed`).
- Se ejecutó `python -m pytest tests/unit/test_corelibs_configuracion.py tests/unit/test_corelibs_surface_exports.py` y la integración con la superficie pública pasó (`15 passed, 1 warning`).
- Se ejecutó `python -m pytest tests/unit/test_corelibs_configuracion.py tests/unit/test_corelibs.py::test_texto_funcs` para validar que no rompe otras exportaciones y pasó (`6 passed`).
- No se añadieron dependencias externas y las salidas de error son deterministas para archivo inexistente y formato no soportado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48c545425083278e22138bcf74ffdf)