### PR TITLE
Expone aliases explícitos sin colisiones en corelibs

### DIFF
--- a/src/pcobra/corelibs/__init__.py
+++ b/src/pcobra/corelibs/__init__.py
@@ -198,6 +198,10 @@ from .sistema import (
     obtener_env,
     listar_dir,
 )
+from .ruta import unir as unir_ruta
+from .serializacion import leer_json as leer_json_serializacion
+from .proceso import ejecutar as ejecutar_proceso
+from .registro import info as info_registro
 from .configuracion import (
     leer_toml,
     leer_ini,
@@ -412,6 +416,10 @@ __all__ = [
     "ejecutar_stream",
     "obtener_env",
     "listar_dir",
+    "unir_ruta",
+    "leer_json_serializacion",
+    "ejecutar_proceso",
+    "info_registro",
     "recolectar",
     "iterar_completadas",
     "recolectar_resultados",


### PR DESCRIPTION
### Motivation

- Evitar colisiones en la superficie pública de `pcobra.corelibs` y ofrecer accesos canónicos descriptivos reexportando funciones concretas con alias.

### Description

- Añade imports alias en `src/pcobra/corelibs/__init__.py` para `ruta.unir as unir_ruta`, `serializacion.leer_json as leer_json_serializacion`, `proceso.ejecutar as ejecutar_proceso` y `registro.info as info_registro`, y publica esos nombres en `__all__` sin sobrescribir nombres existentes.

### Testing

- Ejecuté un script de comprobación de aliases y `pytest -q tests/test_corelibs_ruta.py tests/test_corelibs_proceso.py tests/unit/test_corelibs.py`, y las pruebas ejecutadas pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48c83ec08883278087f9850f84be85)