### PR TITLE
test: add corelib coverage

### DIFF
--- a/tests/core/test_corelib_argumentos.py
+++ b/tests/core/test_corelib_argumentos.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+import pcobra.corelibs.argumentos as argumentos
+
+
+def test_import_directo_y_all_presente() -> None:
+    assert isinstance(argumentos.__all__, list)
+    assert "parsear_pares" in argumentos.__all__
+
+
+def test_parsear_pares_y_obtener_opcion_exitoso() -> None:
+    argv = ["--modo", "rapido", "-v", "--salida=archivo.txt", "posicional"]
+
+    assert argumentos.parsear_pares(argv) == {
+        "modo": "rapido",
+        "v": True,
+        "salida": "archivo.txt",
+    }
+    assert argumentos.obtener_opcion("modo", argv) == "rapido"
+    assert argumentos.contiene_flag("v", argv) is True
+
+
+def test_obtener_argumentos_rechaza_texto_plano() -> None:
+    with pytest.raises(TypeError):
+        argumentos.obtener_argumentos("--modo rapido")

--- a/tests/core/test_corelib_compresion.py
+++ b/tests/core/test_corelib_compresion.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from zipfile import ZipFile
+
+import pytest
+
+import pcobra.corelibs.compresion as compresion
+
+
+def test_import_directo_y_all_presente() -> None:
+    assert isinstance(compresion.__all__, list)
+    assert "crear_zip" in compresion.__all__
+
+
+def test_crear_listar_y_extraer_zip_con_tmp_path(tmp_path) -> None:
+    origen = tmp_path / "origen"
+    origen.mkdir()
+    archivo = origen / "datos.txt"
+    archivo.write_text("contenido", encoding="utf-8")
+    zip_path = tmp_path / "salida" / "datos.zip"
+
+    nombres = compresion.crear_zip(zip_path, archivo, base=origen)
+    destino = tmp_path / "extraido"
+    extraidas = compresion.extraer_zip(zip_path, destino)
+
+    assert nombres == ["datos.txt"]
+    assert compresion.listar_zip(zip_path) == ["datos.txt"]
+    assert (destino / "datos.txt").read_text(encoding="utf-8") == "contenido"
+    assert str(destino / "datos.txt") in extraidas
+
+
+def test_extraer_zip_rechaza_path_traversal(tmp_path) -> None:
+    zip_path = tmp_path / "inseguro.zip"
+    with ZipFile(zip_path, "w") as archivo_zip:
+        archivo_zip.writestr("../escape.txt", "no")
+
+    with pytest.raises(ValueError):
+        compresion.extraer_zip(zip_path, tmp_path / "destino")

--- a/tests/core/test_corelib_configuracion.py
+++ b/tests/core/test_corelib_configuracion.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+import pcobra.corelibs.configuracion as configuracion
+
+
+def test_import_directo_y_all_presente() -> None:
+    assert isinstance(configuracion.__all__, list)
+    assert "leer_configuracion" in configuracion.__all__
+
+
+def test_leer_ini_y_configuracion_con_tmp_path(tmp_path) -> None:
+    ruta_ini = tmp_path / "app.ini"
+    ruta_ini.write_text("[app]\nnombre = cobra\n", encoding="utf-8")
+
+    assert configuracion.leer_ini(ruta_ini) == {"app": {"nombre": "cobra"}}
+    assert configuracion.leer_configuracion(ruta_ini) == {"app": {"nombre": "cobra"}}
+
+
+def test_extension_no_soportada_lanza_value_error(tmp_path) -> None:
+    ruta = tmp_path / "app.txt"
+    ruta.write_text("x=1", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        configuracion.leer_configuracion(ruta)

--- a/tests/core/test_corelib_cripto.py
+++ b/tests/core/test_corelib_cripto.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+import pcobra.corelibs.cripto as cripto
+
+
+def test_import_directo_y_all_presente() -> None:
+    assert isinstance(cripto.__all__, list)
+    assert "sha256" in cripto.__all__
+
+
+def test_hash_y_token_hexadecimal_exitosos() -> None:
+    assert cripto.sha256("cobra") == cripto.sha256(b"cobra")
+    assert cripto.comparar_seguro("abc", "abc") is True
+    assert len(cripto.token_hexadecimal(4)) == 8
+
+
+def test_token_rechaza_tamano_no_positivo() -> None:
+    with pytest.raises(ValueError):
+        cripto.token_seguro(0)

--- a/tests/core/test_corelib_proceso.py
+++ b/tests/core/test_corelib_proceso.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import pcobra.corelibs.proceso as proceso
+
+
+def test_import_directo_y_all_presente() -> None:
+    assert isinstance(proceso.__all__, list)
+    assert "ejecutar" in proceso.__all__
+
+
+def test_ejecutar_python_portable_ok() -> None:
+    resultado = proceso.ejecutar(sys.executable, argumentos=["-c", "print('ok')"])
+
+    assert proceso.codigo_salida(resultado) == 0
+    assert proceso.salida(resultado).strip() == "ok"
+    assert proceso.errores(resultado) == ""
+
+
+def test_argumentos_texto_plano_lanza_type_error() -> None:
+    with pytest.raises(TypeError):
+        proceso.ejecutar(sys.executable, argumentos="-c print('ok')")

--- a/tests/core/test_corelib_pruebas.py
+++ b/tests/core/test_corelib_pruebas.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+import pcobra.corelibs.pruebas as pruebas
+
+
+def test_import_directo_y_all_presente() -> None:
+    assert isinstance(pruebas.__all__, list)
+    assert "igual" in pruebas.__all__
+
+
+def test_aserciones_principales_exitosas() -> None:
+    assert pruebas.igual(2 + 2, 4) is True
+    assert pruebas.verdadero("cobra") is True
+    assert pruebas.contiene(["a", "b"], "a") is True
+
+
+def test_igual_distinto_lanza_assertion_error() -> None:
+    with pytest.raises(AssertionError):
+        pruebas.igual("obtenido", "esperado")

--- a/tests/core/test_corelib_regex.py
+++ b/tests/core/test_corelib_regex.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+
+import pcobra.corelibs.regex as regex
+
+
+def test_import_directo_y_all_presente() -> None:
+    assert isinstance(regex.__all__, list)
+    assert "buscar" in regex.__all__
+
+
+def test_buscar_reemplazar_y_encontrar_todos_exitosos() -> None:
+    texto = "cobra 123 cobra 456"
+
+    assert regex.buscar(r"\d+", texto) == "123"
+    assert regex.reemplazar(r"cobra", "Cobra", texto, limite=1).startswith("Cobra")
+    assert regex.encontrar_todos(r"\d+", texto) == ["123", "456"]
+
+
+def test_patron_invalido_lanza_value_error() -> None:
+    with pytest.raises(ValueError):
+        regex.buscar("(", "texto")

--- a/tests/core/test_corelib_registro.py
+++ b/tests/core/test_corelib_registro.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import pcobra.corelibs.registro as registro
+
+
+def test_import_directo_y_all_presente() -> None:
+    assert isinstance(registro.__all__, list)
+    assert "configurar" in registro.__all__
+
+
+def test_configurar_registro_en_archivo_temporal(tmp_path) -> None:
+    destino = tmp_path / "cobra.log"
+    logger = registro.configurar(nivel="INFO", destino=destino)
+
+    registro.info("mensaje portable")
+    for handler in logger.handlers:
+        handler.flush()
+
+    assert logger.level == logging.INFO
+    assert "INFO:pcobra.registro:mensaje portable" in destino.read_text(encoding="utf-8")
+
+
+def test_configurar_nivel_invalido_lanza_value_error() -> None:
+    with pytest.raises(ValueError):
+        registro.configurar(nivel="NO_EXISTE")

--- a/tests/core/test_corelib_ruta.py
+++ b/tests/core/test_corelib_ruta.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+
+import pcobra.corelibs.ruta as ruta
+
+
+def test_import_directo_y_all_presente() -> None:
+    assert isinstance(ruta.__all__, list)
+    assert "unir" in ruta.__all__
+
+
+def test_unir_y_relativa_multiplataforma(tmp_path) -> None:
+    archivo = tmp_path / "datos" / "entrada.txt"
+    archivo.parent.mkdir()
+    archivo.write_text("ok", encoding="utf-8")
+
+    construida = ruta.unir(tmp_path, "datos", "entrada.txt")
+
+    assert ruta.existe(construida) is True
+    assert ruta.nombre(construida) == "entrada.txt"
+    assert ruta.extension(construida) == ".txt"
+    assert ruta.relativa(construida, tmp_path) == ruta.unir("datos", "entrada.txt")
+
+
+def test_unir_rechaza_partes_vacias() -> None:
+    with pytest.raises(ValueError):
+        ruta.unir()

--- a/tests/core/test_corelib_serializacion.py
+++ b/tests/core/test_corelib_serializacion.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+import pcobra.corelibs.serializacion as serializacion
+
+
+def test_import_directo_y_all_presente() -> None:
+    assert isinstance(serializacion.__all__, list)
+    assert "codificar_json" in serializacion.__all__
+
+
+def test_json_y_csv_exitosos_con_tmp_path(tmp_path) -> None:
+    ruta_json = tmp_path / "datos.json"
+    serializacion.escribir_json(ruta_json, {"b": 2, "a": 1}, indentar=None)
+    assert serializacion.leer_json(ruta_json) == {"a": 1, "b": 2}
+
+    ruta_csv = tmp_path / "datos.csv"
+    serializacion.escribir_csv(ruta_csv, [{"nombre": "Ada", "valor": 1}])
+    assert serializacion.leer_csv(ruta_csv) == [{"nombre": "Ada", "valor": "1"}]
+
+
+def test_decodificar_json_invalido_lanza_error() -> None:
+    with pytest.raises(ValueError):
+        serializacion.decodificar_json("{no-es-json")

--- a/tests/core/test_corelib_temporal.py
+++ b/tests/core/test_corelib_temporal.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import pcobra.corelibs.temporal as temporal
+
+
+def test_import_directo_y_all_presente() -> None:
+    assert isinstance(temporal.__all__, list)
+    assert "limpiar" in temporal.__all__
+
+
+def test_archivo_y_directorio_temporal_se_limpian() -> None:
+    archivo = Path(temporal.archivo_temporal(prefijo="pcobra-", sufijo=".tmp"))
+    directorio = Path(temporal.directorio_temporal(prefijo="pcobra-"))
+    try:
+        assert archivo.exists()
+        assert directorio.is_dir()
+    finally:
+        assert temporal.limpiar(archivo) is True
+        assert temporal.limpiar(directorio) is True
+
+    assert temporal.limpiar(archivo) is False
+
+
+def test_limpiar_rechaza_ruta_vacia() -> None:
+    with pytest.raises(ValueError):
+        temporal.limpiar("")


### PR DESCRIPTION
### Motivation

- Añadir cobertura de pruebas para varias corelibs en `src/pcobra/corelibs/` para verificar la superficie pública y comportamientos principales y de error.
- Garantizar que las funciones multiplataforma y las operaciones con sistema de archivos y procesos sean portables y seguras.

### Description

- Se añadieron 11 tests nuevos en `tests/core/` que importan los módulos directamente y comprueban la presencia de `__all__`: `test_corelib_ruta.py`, `test_corelib_serializacion.py`, `test_corelib_proceso.py`, `test_corelib_registro.py`, `test_corelib_argumentos.py`, `test_corelib_pruebas.py`, `test_corelib_temporal.py`, `test_corelib_cripto.py`, `test_corelib_regex.py`, `test_corelib_compresion.py` y `test_corelib_configuracion.py`.
- Cada archivo incluye una prueba de import directo y `__all__`, una prueba de caso principal exitoso y al menos una prueba de error esperado; las pruebas de sistema de archivos usan `tmp_path` para evitar rutas absolutas hardcodeadas.
- `proceso` usa invocación portable mediante `sys.executable` para ejecutar `-c "print('ok')"`, `compresion` crea/lista/extrae ZIP y valida rechazo de path traversal, y `temporal` crea y limpia recursos temporales de forma explícita.
- Las pruebas también verifican parsing de argumentos, serialización JSON/CSV, hashing/tokenización, utilidades de regex y la API de logging con destino a archivo temporal.

### Testing

- Se ejecutó `pytest tests/core/test_corelib_*.py -q` y todas las pruebas pasaron localmente con resultado `33 passed, 1 warning`.
- Las pruebas relevantes fueron diseñadas para ser deterministas y multiplataforma usando `tmp_path` y `sys.executable` cuando procede.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48c945f1d4832796cd9013402380ac)