### PR TITLE
test: cubrir contrato usar de nuevas corelibs

### DIFF
--- a/tests/core/test_usar_policy_nuevas_corelibs.py
+++ b/tests/core/test_usar_policy_nuevas_corelibs.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from pcobra.cobra.usar_policy import (
+    REPL_COBRA_MODULE_INTERNAL_PATH_MAP,
+    USAR_COBRA_PUBLIC_MODULES,
+    validar_contrato_modulos_canonicos_usar,
+)
+from pcobra.core.ast_nodes import NodoUsar
+from pcobra.core.interpreter import InterpretadorCobra
+
+RAIZ_REPO = Path(__file__).resolve().parents[2]
+
+ALIASES_NUEVAS_CORELIBS = (
+    "ruta",
+    "serializacion",
+    "proceso",
+    "registro",
+    "argumentos",
+    "pruebas",
+    "temporal",
+    "cripto",
+    "regex",
+    "compresion",
+    "configuracion",
+)
+
+
+def _nombre_import_desde_ruta_interna(ruta_relativa: str) -> str:
+    """Convierte una ruta canónica interna en su nombre importable Python."""
+
+    if ruta_relativa.startswith("src/pcobra/corelibs/"):
+        return f"pcobra.corelibs.{Path(ruta_relativa).stem}"
+    if ruta_relativa.startswith("src/pcobra/standard_library/"):
+        return f"pcobra.standard_library.{Path(ruta_relativa).stem}"
+    raise AssertionError(f"Ruta interna no soportada por el contrato: {ruta_relativa}")
+
+
+@pytest.mark.parametrize("alias", ALIASES_NUEVAS_CORELIBS)
+def test_alias_nueva_corelib_cumple_contrato_publico_y_modulo_importable(alias: str) -> None:
+    validar_contrato_modulos_canonicos_usar()
+
+    assert alias in USAR_COBRA_PUBLIC_MODULES
+    assert alias in REPL_COBRA_MODULE_INTERNAL_PATH_MAP
+
+    ruta_relativa = REPL_COBRA_MODULE_INTERNAL_PATH_MAP[alias]
+    ruta_interna = RAIZ_REPO / ruta_relativa
+    assert ruta_interna.exists(), f"No existe la ruta interna para usar {alias}: {ruta_relativa}"
+
+    modulo = importlib.import_module(_nombre_import_desde_ruta_interna(ruta_relativa))
+    exportes = getattr(modulo, "__all__", None)
+    assert exportes, f"El módulo {alias} debe definir __all__ no vacío"
+
+
+@pytest.mark.parametrize("alias", ALIASES_NUEVAS_CORELIBS)
+def test_repl_resuelve_nueva_corelib_con_nodo_usar_sin_parser_lexer(alias: str) -> None:
+    interprete = InterpretadorCobra()
+    interprete.configurar_restriccion_usar_repl({alias: alias})
+
+    interprete.ejecutar_nodo(NodoUsar(alias))
+
+    ruta_relativa = REPL_COBRA_MODULE_INTERNAL_PATH_MAP[alias]
+    modulo = importlib.import_module(_nombre_import_desde_ruta_interna(ruta_relativa))
+    exportes = tuple(getattr(modulo, "__all__", ()))
+    assert exportes
+    assert any(nombre in interprete.variables for nombre in exportes)


### PR DESCRIPTION
### Motivation

- Garantizar que los nuevos alias de corelibs obligatorios para `usar` estén declarados, sean importables y expongan símbolos públicos válidos según el contrato canónico.

### Description

- Añade `tests/core/test_usar_policy_nuevas_corelibs.py` que importa `USAR_COBRA_PUBLIC_MODULES`, `REPL_COBRA_MODULE_INTERNAL_PATH_MAP` y `validar_contrato_modulos_canonicos_usar` desde `pcobra.cobra.usar_policy`.
- Añade una prueba parametrizada que para cada alias verifica que está en `USAR_COBRA_PUBLIC_MODULES`, en `REPL_COBRA_MODULE_INTERNAL_PATH_MAP`, que la ruta interna existe y que el módulo se puede importar con `importlib` y define `__all__` no vacío.
- Añade una prueba parametrizada que usa la infraestructura del intérprete creando un `InterpretadorCobra`, configurando la restricción REPL con `{alias: alias}` y ejecutando `NodoUsar(alias)` para comprobar que al menos un símbolo del `__all__` queda disponible en `interprete.variables` sin tocar Parser/Lexer.

### Testing

- Ejecutado `pytest -q tests/core/test_usar_policy_nuevas_corelibs.py` y la suite del archivo devolvió resultados exitosos (pasó).
- Ejecutado `pytest -q tests/core/test_superficie_publica_canonica.py tests/core/test_usar_policy_nuevas_corelibs.py` y ambas pruebas pasaron correctamente (suite combinada pasó; 1 warning deprecación documentado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48cad0b3ec8327aa21499e104a15b8)