### PR TITLE
Endurecer validación en corelibs estándar

### DIFF
--- a/src/pcobra/corelibs/compresion.py
+++ b/src/pcobra/corelibs/compresion.py
@@ -10,7 +10,7 @@ import os
 from pathlib import Path, PurePosixPath
 from zipfile import ZipFile
 
-PathLike = str | Path
+PathLike = str | os.PathLike[str]
 
 __all__ = ["crear_zip", "extraer_zip", "listar_zip"]
 
@@ -34,7 +34,7 @@ def crear_zip(
             raise FileNotFoundError(f"La ruta a comprimir no existe: {ruta}")
 
     base_resuelta = _resolver_base(rutas_normalizadas, base)
-    destino_zip = Path(destino)
+    destino_zip = _validar_ruta(destino, "destino")
     destino_zip.parent.mkdir(parents=True, exist_ok=True)
 
     nombres: list[str] = []
@@ -55,11 +55,11 @@ def extraer_zip(origen: PathLike, destino: PathLike) -> list[str]:
     contra el directorio destino y se rechaza si queda fuera de él.
     """
 
-    origen_zip = Path(origen)
+    origen_zip = _validar_ruta(origen, "origen")
     if not origen_zip.exists():
         raise FileNotFoundError(f"El ZIP de origen no existe: {origen_zip}")
 
-    destino_base = Path(destino).resolve()
+    destino_base = _validar_ruta(destino, "destino").resolve()
     destino_base.mkdir(parents=True, exist_ok=True)
     rutas_extraidas: list[str] = []
 
@@ -83,7 +83,7 @@ def extraer_zip(origen: PathLike, destino: PathLike) -> list[str]:
 def listar_zip(origen: PathLike) -> list[str]:
     """Devuelve la lista simple de nombres incluidos en ``origen``."""
 
-    origen_zip = Path(origen)
+    origen_zip = _validar_ruta(origen, "origen")
     if not origen_zip.exists():
         raise FileNotFoundError(f"El ZIP de origen no existe: {origen_zip}")
 
@@ -91,10 +91,29 @@ def listar_zip(origen: PathLike) -> list[str]:
         return archivo_zip.namelist()
 
 
-def _normalizar_rutas(rutas: PathLike | list[PathLike] | tuple[PathLike, ...]) -> list[Path]:
-    if isinstance(rutas, (str, Path)):
-        return [Path(rutas)]
-    return [Path(ruta) for ruta in rutas]
+def _normalizar_rutas(
+    rutas: PathLike | list[PathLike] | tuple[PathLike, ...],
+) -> list[Path]:
+    if isinstance(rutas, (str, os.PathLike)):
+        return [_validar_ruta(rutas, "rutas")]
+    if not isinstance(rutas, (list, tuple)):
+        raise TypeError("rutas debe ser una ruta o una lista/tupla de rutas")
+    return [
+        _validar_ruta(ruta, f"rutas[{indice}]") for indice, ruta in enumerate(rutas)
+    ]
+
+
+def _validar_ruta(ruta: PathLike, nombre_argumento: str) -> Path:
+    if not isinstance(ruta, (str, os.PathLike)):
+        raise TypeError(
+            f"{nombre_argumento} debe ser una ruta de texto o compatible con os.PathLike"
+        )
+    texto = os.fspath(ruta)
+    if not isinstance(texto, str):
+        raise TypeError(f"{nombre_argumento} debe representar una ruta de texto")
+    if texto == "":
+        raise ValueError(f"{nombre_argumento} no puede estar vacía")
+    return Path(texto)
 
 
 def _resolver_base(rutas: list[Path], base: PathLike | None) -> Path:
@@ -102,7 +121,7 @@ def _resolver_base(rutas: list[Path], base: PathLike | None) -> Path:
         raise ValueError("Debe indicarse al menos una ruta para comprimir")
 
     if base is not None:
-        base_resuelta = Path(base).resolve()
+        base_resuelta = _validar_ruta(base, "base").resolve()
         if not base_resuelta.exists():
             raise FileNotFoundError(f"La base no existe: {base_resuelta}")
         if not base_resuelta.is_dir():

--- a/src/pcobra/corelibs/configuracion.py
+++ b/src/pcobra/corelibs/configuracion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import configparser
 import importlib
 import importlib.util
+import os
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -18,6 +19,7 @@ __all__ = [
 
 _TOML_NO_SOPORTADO = "TOML no está soportado en este entorno de Python: falta tomllib"
 _FORMATOS_SOPORTADOS = ".toml, .ini, .cfg"
+PathLike = str | os.PathLike[str]
 
 
 def toml_disponible() -> bool:
@@ -26,7 +28,7 @@ def toml_disponible() -> bool:
     return importlib.util.find_spec("tomllib") is not None
 
 
-def leer_toml(ruta: str | Path) -> dict[str, Any]:
+def leer_toml(ruta: PathLike) -> dict[str, Any]:
     """Lee un archivo TOML desde ``ruta`` usando ``tomllib`` de la biblioteca estándar."""
 
     ruta_configuracion = _validar_archivo_existente(ruta)
@@ -36,7 +38,7 @@ def leer_toml(ruta: str | Path) -> dict[str, Any]:
         return tomllib.load(archivo)
 
 
-def leer_ini(ruta: str | Path) -> dict[str, dict[str, str]]:
+def leer_ini(ruta: PathLike) -> dict[str, dict[str, str]]:
     """Lee un archivo INI/CFG y devuelve sus secciones como diccionarios."""
 
     ruta_configuracion = _validar_archivo_existente(ruta)
@@ -55,7 +57,7 @@ def leer_ini(ruta: str | Path) -> dict[str, dict[str, str]]:
     return configuracion
 
 
-def leer_configuracion(ruta: str | Path) -> dict[str, Any] | dict[str, dict[str, str]]:
+def leer_configuracion(ruta: PathLike) -> dict[str, Any] | dict[str, dict[str, str]]:
     """Lee ``ruta`` eligiendo el parser por extensión: ``.toml``, ``.ini`` o ``.cfg``."""
 
     ruta_configuracion = _validar_archivo_existente(ruta)
@@ -72,10 +74,19 @@ def leer_configuracion(ruta: str | Path) -> dict[str, Any] | dict[str, dict[str,
     )
 
 
-def _validar_archivo_existente(ruta: str | Path) -> Path:
-    ruta_configuracion = Path(ruta)
+def _validar_archivo_existente(ruta: PathLike) -> Path:
+    if not isinstance(ruta, (str, os.PathLike)):
+        raise TypeError("ruta debe ser una ruta de texto o compatible con os.PathLike")
+    texto = os.fspath(ruta)
+    if not isinstance(texto, str):
+        raise TypeError("ruta debe representar una ruta de texto")
+    if texto == "":
+        raise ValueError("ruta no puede estar vacía")
+    ruta_configuracion = Path(texto)
     if not ruta_configuracion.is_file():
-        raise FileNotFoundError(f"Archivo de configuración no encontrado: {ruta_configuracion}")
+        raise FileNotFoundError(
+            f"Archivo de configuración no encontrado: {ruta_configuracion}"
+        )
     return ruta_configuracion
 
 

--- a/src/pcobra/corelibs/regex.py
+++ b/src/pcobra/corelibs/regex.py
@@ -6,7 +6,6 @@ import re
 from collections.abc import Callable
 from typing import Any
 
-
 __all__ = [
     "buscar",
     "coincidir",
@@ -16,6 +15,12 @@ __all__ = [
 ]
 
 _Reemplazo = str | Callable[[re.Match[str]], str]
+
+
+def _validar_texto(valor: str, nombre_argumento: str) -> str:
+    if not isinstance(valor, str):
+        raise TypeError(f"{nombre_argumento} debe ser texto")
+    return valor
 
 
 def _error_patron(exc: re.error) -> ValueError:
@@ -28,7 +33,9 @@ def buscar(patron: str, texto: str, *, flags: int = 0) -> str | None:
     """Busca ``patron`` en ``texto`` y devuelve el texto coincidente o ``None``."""
 
     try:
-        coincidencia = re.search(patron, texto, flags)
+        coincidencia = re.search(
+            _validar_texto(patron, "patron"), _validar_texto(texto, "texto"), flags
+        )
     except re.error as exc:
         raise _error_patron(exc) from None
     if coincidencia is None:
@@ -40,7 +47,9 @@ def coincidir(patron: str, texto: str, *, flags: int = 0) -> str | None:
     """Comprueba si ``texto`` empieza con ``patron`` y devuelve la coincidencia."""
 
     try:
-        coincidencia = re.match(patron, texto, flags)
+        coincidencia = re.match(
+            _validar_texto(patron, "patron"), _validar_texto(texto, "texto"), flags
+        )
     except re.error as exc:
         raise _error_patron(exc) from None
     if coincidencia is None:
@@ -59,7 +68,13 @@ def reemplazar(
     """Reemplaza coincidencias de ``patron`` en ``texto`` respetando ``limite``."""
 
     try:
-        return re.sub(patron, reemplazo, texto, count=limite, flags=flags)
+        return re.sub(
+            _validar_texto(patron, "patron"),
+            reemplazo,
+            _validar_texto(texto, "texto"),
+            count=limite,
+            flags=flags,
+        )
     except re.error as exc:
         raise _error_patron(exc) from None
 
@@ -68,7 +83,12 @@ def dividir(patron: str, texto: str, *, maximo: int = 0, flags: int = 0) -> list
     """Divide ``texto`` usando ``patron`` como separador."""
 
     try:
-        return re.split(patron, texto, maxsplit=maximo, flags=flags)
+        return re.split(
+            _validar_texto(patron, "patron"),
+            _validar_texto(texto, "texto"),
+            maxsplit=maximo,
+            flags=flags,
+        )
     except re.error as exc:
         raise _error_patron(exc) from None
 
@@ -77,6 +97,10 @@ def encontrar_todos(patron: str, texto: str, *, flags: int = 0) -> list[Any]:
     """Devuelve una lista con todas las coincidencias de ``patron`` en ``texto``."""
 
     try:
-        return list(re.findall(patron, texto, flags))
+        return list(
+            re.findall(
+                _validar_texto(patron, "patron"), _validar_texto(texto, "texto"), flags
+            )
+        )
     except re.error as exc:
         raise _error_patron(exc) from None

--- a/src/pcobra/corelibs/serializacion.py
+++ b/src/pcobra/corelibs/serializacion.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
+import os
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
@@ -16,39 +17,76 @@ __all__ = [
     "escribir_csv",
 ]
 
+PathLike = str | os.PathLike[str]
 
-def codificar_json(objeto: Any, *, ordenar: bool = False, indentar: int | None = None) -> str:
+
+def _validar_ruta(ruta: PathLike, nombre_argumento: str = "ruta") -> Path:
+    if not isinstance(ruta, (str, os.PathLike)):
+        raise TypeError(
+            f"{nombre_argumento} debe ser una ruta de texto o compatible con os.PathLike"
+        )
+    texto = os.fspath(ruta)
+    if not isinstance(texto, str):
+        raise TypeError(f"{nombre_argumento} debe representar una ruta de texto")
+    if texto == "":
+        raise ValueError(f"{nombre_argumento} no puede estar vacía")
+    return Path(texto)
+
+
+def _validar_delimitador(delimitador: str) -> str:
+    if not isinstance(delimitador, str):
+        raise TypeError("delimitador debe ser texto")
+    if len(delimitador) != 1:
+        raise ValueError("delimitador debe contener exactamente un carácter")
+    return delimitador
+
+
+def codificar_json(
+    objeto: Any, *, ordenar: bool = False, indentar: int | None = None
+) -> str:
     """Convierte ``objeto`` a texto JSON UTF-8 amigable.
 
     ``ordenar`` controla el orden alfabético de claves y ``indentar`` permite
     producir una salida legible cuando se proporciona un entero.
     """
 
-    return json.dumps(objeto, ensure_ascii=False, sort_keys=ordenar, indent=indentar)
+    try:
+        return json.dumps(
+            objeto, ensure_ascii=False, sort_keys=ordenar, indent=indentar
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"No se pudo codificar JSON: {exc}") from exc
 
 
 def decodificar_json(texto: str) -> Any:
     """Convierte un texto JSON en su valor Python equivalente."""
 
-    return json.loads(texto)
+    if not isinstance(texto, str):
+        raise TypeError("texto debe ser una cadena JSON")
+    try:
+        return json.loads(texto)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"JSON inválido en línea {exc.lineno}, columna {exc.colno}: {exc.msg}"
+        ) from None
 
 
-def leer_json(ruta: str | Path) -> Any:
+def leer_json(ruta: PathLike) -> Any:
     """Lee y decodifica un archivo JSON desde ``ruta``."""
 
-    return decodificar_json(Path(ruta).read_text(encoding="utf-8"))
+    return decodificar_json(_validar_ruta(ruta).read_text(encoding="utf-8"))
 
 
-def escribir_json(ruta: str | Path, objeto: Any, *, indentar: int | None = 2) -> None:
+def escribir_json(ruta: PathLike, objeto: Any, *, indentar: int | None = 2) -> None:
     """Codifica ``objeto`` como JSON y lo escribe en ``ruta``."""
 
-    Path(ruta).write_text(
+    _validar_ruta(ruta).write_text(
         codificar_json(objeto, indentar=indentar) + "\n",
         encoding="utf-8",
     )
 
 
-def leer_csv(ruta: str | Path, *, delimitador: str = ",") -> list[dict[str, str]]:
+def leer_csv(ruta: PathLike, *, delimitador: str = ",") -> list[dict[str, str]]:
     """Lee un CSV básico y devuelve una lista de diccionarios.
 
     La primera fila del archivo se interpreta como cabecera. Se rechazan
@@ -56,8 +94,9 @@ def leer_csv(ruta: str | Path, *, delimitador: str = ",") -> list[dict[str, str]
     faltantes para ofrecer errores claros ante datos no homogéneos.
     """
 
-    with Path(ruta).open("r", encoding="utf-8", newline="") as archivo:
-        lector = csv.DictReader(archivo, delimiter=delimitador)
+    delimitador_validado = _validar_delimitador(delimitador)
+    with _validar_ruta(ruta).open("r", encoding="utf-8", newline="") as archivo:
+        lector = csv.DictReader(archivo, delimiter=delimitador_validado)
         if lector.fieldnames is None:
             raise ValueError("El CSV debe incluir una fila de cabecera")
 
@@ -85,7 +124,7 @@ def leer_csv(ruta: str | Path, *, delimitador: str = ",") -> list[dict[str, str]
 
 
 def escribir_csv(
-    ruta: str | Path,
+    ruta: PathLike,
     filas: Iterable[Mapping[str, Any]],
     *,
     delimitador: str = ",",
@@ -96,11 +135,14 @@ def escribir_csv(
     rechazan colecciones vacías, filas vacías y filas no homogéneas.
     """
 
+    delimitador_validado = _validar_delimitador(delimitador)
     filas_normalizadas = _normalizar_filas_csv(filas)
     campos = list(filas_normalizadas[0].keys())
 
-    with Path(ruta).open("w", encoding="utf-8", newline="") as archivo:
-        escritor = csv.DictWriter(archivo, fieldnames=campos, delimiter=delimitador)
+    with _validar_ruta(ruta).open("w", encoding="utf-8", newline="") as archivo:
+        escritor = csv.DictWriter(
+            archivo, fieldnames=campos, delimiter=delimitador_validado
+        )
         escritor.writeheader()
         escritor.writerows(filas_normalizadas)
 


### PR DESCRIPTION
### Motivation
- Evitar errores poco claros y comportamiento no determinista al recibir rutas, delimitadores CSV o textos inválidos en utilidades centrales de Cobra.
- Asegurar mensajes de error consistentes antes de delegar en librerías estándar y mantener la API pública canónica de los módulos afectados.

### Description
- Añade validación explícita de `os.PathLike`/`str` y mensajes deterministas en `src/pcobra/corelibs/serializacion.py` para `leer_json`, `escribir_json`, `leer_csv` y `escribir_csv`, además de comprobación del `delimitador` y manejo de errores JSON claros.
- Añade validación de entrada de texto en `src/pcobra/corelibs/regex.py` para `patron` y `texto`, conservando la conversión de `re.error` a `ValueError` en español.
- Extiende `src/pcobra/corelibs/compresion.py` y `src/pcobra/corelibs/configuracion.py` para aceptar `os.PathLike`, validar rutas vacías/tipos inválidos y producir errores claros al resolver bases o archivos inexistentes.
- No se agregaron nuevas API públicas ni se tocaron archivos de Lexer, Parser, AST, gramática o tokenización; `__all__` se mantiene en la superficie pública esperada.

### Testing
- Ejecutado `python -m compileall -q src/pcobra/corelibs/...` sobre los módulos modificados y la compilación fue satisfactoria (sin errores).
- Ejecutado `pytest -q tests/unit/test_corelibs_regex.py tests/unit/test_corelibs_pruebas.py tests/unit/test_usar_runtime_policy.py::test_usar_runtime_allowlist_y_flags_mantienen_contrato_estricto` y los tests dirigidos pasaron (`17 passed, 1 warning` en la ejecución parcial usada para verificación puntual).
- Ejecutado `python -m ruff check` sobre los archivos modificados y no se reportaron errores de lint relevantes.
- Una ejecución más amplia (`pytest -q tests/unit/test_corelibs.py tests/unit/test_corelibs_regex.py tests/unit/test_corelibs_pruebas.py tests/unit/test_usar_runtime_policy.py`) mostró fallos preexistentes en `tests/unit/test_usar_runtime_policy.py` (5 fallos) que no están relacionados con las modificaciones en estos módulos; las fallas parecen originarse en exportaciones/runtime de módulos como `datos`/`holobit`/`texto` y no en los cambios de validación aplicados aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48d2b119e883279bf5b70f083a4482)