### PR TITLE
test: refuerza cobertura de corelibs

### DIFF
--- a/tests/core/test_corelib_argumentos.py
+++ b/tests/core/test_corelib_argumentos.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import importlib
 import pytest
 
 import pcobra.corelibs.argumentos as argumentos
 
 
 def test_import_directo_y_all_presente() -> None:
+    modulo = importlib.import_module("pcobra.corelibs.argumentos")
+
+    assert modulo is argumentos
     assert isinstance(argumentos.__all__, list)
     assert "parsear_pares" in argumentos.__all__
+    assert callable(getattr(argumentos, "parsear_pares"))
 
 
 def test_parsear_pares_y_obtener_opcion_exitoso() -> None:

--- a/tests/core/test_corelib_compresion.py
+++ b/tests/core/test_corelib_compresion.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 from zipfile import ZipFile
 
 import pytest
@@ -8,8 +9,12 @@ import pcobra.corelibs.compresion as compresion
 
 
 def test_import_directo_y_all_presente() -> None:
+    modulo = importlib.import_module("pcobra.corelibs.compresion")
+
+    assert modulo is compresion
     assert isinstance(compresion.__all__, list)
     assert "crear_zip" in compresion.__all__
+    assert callable(getattr(compresion, "crear_zip"))
 
 
 def test_crear_listar_y_extraer_zip_con_tmp_path(tmp_path) -> None:

--- a/tests/core/test_corelib_configuracion.py
+++ b/tests/core/test_corelib_configuracion.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import importlib
 import pytest
 
 import pcobra.corelibs.configuracion as configuracion
 
 
 def test_import_directo_y_all_presente() -> None:
+    modulo = importlib.import_module("pcobra.corelibs.configuracion")
+
+    assert modulo is configuracion
     assert isinstance(configuracion.__all__, list)
     assert "leer_configuracion" in configuracion.__all__
+    assert callable(getattr(configuracion, "leer_configuracion"))
 
 
 def test_leer_ini_y_configuracion_con_tmp_path(tmp_path) -> None:

--- a/tests/core/test_corelib_cripto.py
+++ b/tests/core/test_corelib_cripto.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import importlib
 import pytest
 
 import pcobra.corelibs.cripto as cripto
 
 
 def test_import_directo_y_all_presente() -> None:
+    modulo = importlib.import_module("pcobra.corelibs.cripto")
+
+    assert modulo is cripto
     assert isinstance(cripto.__all__, list)
     assert "sha256" in cripto.__all__
+    assert callable(getattr(cripto, "sha256"))
 
 
 def test_hash_y_token_hexadecimal_exitosos() -> None:

--- a/tests/core/test_corelib_proceso.py
+++ b/tests/core/test_corelib_proceso.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import sys
 
 import pytest
@@ -8,8 +9,12 @@ import pcobra.corelibs.proceso as proceso
 
 
 def test_import_directo_y_all_presente() -> None:
+    modulo = importlib.import_module("pcobra.corelibs.proceso")
+
+    assert modulo is proceso
     assert isinstance(proceso.__all__, list)
     assert "ejecutar" in proceso.__all__
+    assert callable(getattr(proceso, "ejecutar"))
 
 
 def test_ejecutar_python_portable_ok() -> None:

--- a/tests/core/test_corelib_pruebas.py
+++ b/tests/core/test_corelib_pruebas.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import importlib
 import pytest
 
 import pcobra.corelibs.pruebas as pruebas
 
 
 def test_import_directo_y_all_presente() -> None:
+    modulo = importlib.import_module("pcobra.corelibs.pruebas")
+
+    assert modulo is pruebas
     assert isinstance(pruebas.__all__, list)
     assert "igual" in pruebas.__all__
+    assert callable(getattr(pruebas, "igual"))
 
 
 def test_aserciones_principales_exitosas() -> None:

--- a/tests/core/test_corelib_regex.py
+++ b/tests/core/test_corelib_regex.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import importlib
 import pytest
 
 import pcobra.corelibs.regex as regex
 
 
 def test_import_directo_y_all_presente() -> None:
+    modulo = importlib.import_module("pcobra.corelibs.regex")
+
+    assert modulo is regex
     assert isinstance(regex.__all__, list)
     assert "buscar" in regex.__all__
+    assert callable(getattr(regex, "buscar"))
 
 
 def test_buscar_reemplazar_y_encontrar_todos_exitosos() -> None:

--- a/tests/core/test_corelib_registro.py
+++ b/tests/core/test_corelib_registro.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import logging
 
 import pytest
@@ -8,8 +9,12 @@ import pcobra.corelibs.registro as registro
 
 
 def test_import_directo_y_all_presente() -> None:
+    modulo = importlib.import_module("pcobra.corelibs.registro")
+
+    assert modulo is registro
     assert isinstance(registro.__all__, list)
     assert "configurar" in registro.__all__
+    assert callable(getattr(registro, "configurar"))
 
 
 def test_configurar_registro_en_archivo_temporal(tmp_path) -> None:

--- a/tests/core/test_corelib_ruta.py
+++ b/tests/core/test_corelib_ruta.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import importlib
 import pytest
 
 import pcobra.corelibs.ruta as ruta
 
 
 def test_import_directo_y_all_presente() -> None:
+    modulo = importlib.import_module("pcobra.corelibs.ruta")
+
+    assert modulo is ruta
     assert isinstance(ruta.__all__, list)
     assert "unir" in ruta.__all__
+    assert callable(getattr(ruta, "unir"))
 
 
 def test_unir_y_relativa_multiplataforma(tmp_path) -> None:

--- a/tests/core/test_corelib_serializacion.py
+++ b/tests/core/test_corelib_serializacion.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import importlib
 import pytest
 
 import pcobra.corelibs.serializacion as serializacion
 
 
 def test_import_directo_y_all_presente() -> None:
+    modulo = importlib.import_module("pcobra.corelibs.serializacion")
+
+    assert modulo is serializacion
     assert isinstance(serializacion.__all__, list)
     assert "codificar_json" in serializacion.__all__
+    assert callable(getattr(serializacion, "codificar_json"))
 
 
 def test_json_y_csv_exitosos_con_tmp_path(tmp_path) -> None:

--- a/tests/core/test_corelib_temporal.py
+++ b/tests/core/test_corelib_temporal.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 
 import pytest
@@ -8,8 +9,12 @@ import pcobra.corelibs.temporal as temporal
 
 
 def test_import_directo_y_all_presente() -> None:
+    modulo = importlib.import_module("pcobra.corelibs.temporal")
+
+    assert modulo is temporal
     assert isinstance(temporal.__all__, list)
     assert "limpiar" in temporal.__all__
+    assert callable(getattr(temporal, "limpiar"))
 
 
 def test_archivo_y_directorio_temporal_se_limpian() -> None:


### PR DESCRIPTION
### Motivation

- Asegurar que los tests bajo `tests/core/` verifiquen la importación directa de cada módulo canónico mediante `importlib.import_module(...)` además de las comprobaciones existentes de API.
- Garantizar que `__all__` esté declarado y que la función principal exportada sea invocable, sin alterar la API de producción.
- Mantener la verificación de casos exitosos, errores esperados y comportamiento multiplataforma usando recursos portables (`tmp_path`, `sys.executable`, `pathlib`, etc.).

### Description

- Se actualizaron 11 tests en `tests/core/` para añadir `import importlib` y comprobar `modulo = importlib.import_module("pcobra.corelibs.<módulo>")` y `assert modulo is <alias>`, además de `assert callable(getattr(..., "<función>") )` para la función principal exportada.
- Archivos modificados: `test_corelib_ruta.py`, `test_corelib_serializacion.py`, `test_corelib_proceso.py`, `test_corelib_registro.py`, `test_corelib_argumentos.py`, `test_corelib_pruebas.py`, `test_corelib_temporal.py`, `test_corelib_cripto.py`, `test_corelib_regex.py`, `test_corelib_compresion.py`, `test_corelib_configuracion.py`.
- No se realizaron cambios en código de producción; solo se reforzó la verificación en los tests unitarios.

### Testing

- Ejecutado: `python -m pytest tests/core/test_corelib_ruta.py tests/core/test_corelib_serializacion.py tests/core/test_corelib_proceso.py tests/core/test_corelib_registro.py tests/core/test_corelib_argumentos.py tests/core/test_corelib_pruebas.py tests/core/test_corelib_temporal.py tests/core/test_corelib_cripto.py tests/core/test_corelib_regex.py tests/core/test_corelib_compresion.py tests/core/test_corelib_configuracion.py -q` y todos los tests objetivo pasaron.
- Resultado: `33 passed, 1 warning` (advertencia deprecación externa existente sobre `core`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48d438841c8327babaca8f5405ee17)