### PR TITLE
test: validate new corelib usar aliases

### DIFF
--- a/tests/core/test_usar_policy_nuevas_corelibs.py
+++ b/tests/core/test_usar_policy_nuevas_corelibs.py
@@ -15,6 +15,10 @@ from pcobra.core.ast_nodes import NodoUsar
 from pcobra.core.interpreter import InterpretadorCobra
 
 RAIZ_REPO = Path(__file__).resolve().parents[2]
+RUTAS_BASE_CORELIBS_USAR = (
+    RAIZ_REPO / "src/pcobra/corelibs",
+    RAIZ_REPO / "src/pcobra/standard_library",
+)
 
 ALIASES_NUEVAS_CORELIBS = (
     "ruta",
@@ -41,6 +45,26 @@ def _nombre_import_desde_ruta_interna(ruta_relativa: str) -> str:
     raise AssertionError(f"Ruta interna no soportada por el contrato: {ruta_relativa}")
 
 
+def _assert_ruta_interna_es_modulo_soportado(alias: str, ruta_relativa: str) -> Path:
+    """Valida que la ruta canónica apunte a un módulo Python permitido."""
+
+    ruta_interna = RAIZ_REPO / ruta_relativa
+    assert ruta_interna.exists(), (
+        f"No existe la ruta interna para usar {alias}: {ruta_relativa}"
+    )
+    assert ruta_interna.is_file(), (
+        f"La ruta interna para usar {alias} debe ser un archivo: {ruta_relativa}"
+    )
+    assert ruta_interna.suffix == ".py", (
+        f"La ruta interna para usar {alias} debe ser un módulo Python: {ruta_relativa}"
+    )
+    assert any(ruta_interna.is_relative_to(base) for base in RUTAS_BASE_CORELIBS_USAR), (
+        f"La ruta interna para usar {alias} debe estar bajo corelibs/ o "
+        f"standard_library/: {ruta_relativa}"
+    )
+    return ruta_interna
+
+
 @pytest.mark.parametrize("alias", ALIASES_NUEVAS_CORELIBS)
 def test_alias_nueva_corelib_cumple_contrato_publico_y_modulo_importable(
     alias: str,
@@ -51,10 +75,7 @@ def test_alias_nueva_corelib_cumple_contrato_publico_y_modulo_importable(
     assert alias in REPL_COBRA_MODULE_INTERNAL_PATH_MAP
 
     ruta_relativa = REPL_COBRA_MODULE_INTERNAL_PATH_MAP[alias]
-    ruta_interna = RAIZ_REPO / ruta_relativa
-    assert (
-        ruta_interna.exists()
-    ), f"No existe la ruta interna para usar {alias}: {ruta_relativa}"
+    _assert_ruta_interna_es_modulo_soportado(alias, ruta_relativa)
 
     modulo = importlib.import_module(_nombre_import_desde_ruta_interna(ruta_relativa))
     exportes = getattr(modulo, "__all__", None)


### PR DESCRIPTION
### Motivation
- Asegurar que los alias nuevos de corelibs para la instrucción `usar` estén correctamente expuestos y que las rutas internas apunten a módulos Python reales ubicados bajo `src/pcobra/corelibs/` o `src/pcobra/standard_library/` antes de importarlos y resolverlos en el REPL.

### Description
- Añadido `RUTAS_BASE_CORELIBS_USAR` para declarar las raíces permitidas de módulos usados por `usar`.
- Implementado `_assert_ruta_interna_es_modulo_soportado(alias, ruta_relativa)` que valida que la ruta exista, sea un archivo `.py` y esté bajo las rutas permitidas, y usado en el test en lugar de la comprobación simple previa.
- Conservadas las comprobaciones ya existentes que validan que cada `alias` esté en `USAR_COBRA_PUBLIC_MODULES`, que tenga entrada en `REPL_COBRA_MODULE_INTERNAL_PATH_MAP`, que el módulo sea importable y que exponga `__all__`, además de verificar el contrato de superficie y la resolución con `NodoUsar` e `InterpretadorCobra` sin pasar por Lexer/Parser.

### Testing
- Ejecutado `pytest -q tests/core/test_usar_policy_nuevas_corelibs.py` y los tests finalizaron correctamente con `33 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48d645f3d08327afc93c92a6490be6)