### PR TITLE
test: refuerza auditoría de corelibs

### DIFF
--- a/tests/core/test_corelib_cripto.py
+++ b/tests/core/test_corelib_cripto.py
@@ -24,3 +24,16 @@ def test_hash_y_token_hexadecimal_exitosos() -> None:
 def test_token_rechaza_tamano_no_positivo() -> None:
     with pytest.raises(ValueError):
         cripto.token_seguro(0)
+
+
+def test_comparar_seguro_delega_en_compare_digest(monkeypatch) -> None:
+    llamadas = []
+
+    def fake_compare_digest(a: bytes, b: bytes) -> bool:
+        llamadas.append((a, b))
+        return True
+
+    monkeypatch.setattr(cripto.hmac, "compare_digest", fake_compare_digest)
+
+    assert cripto.comparar_seguro("cobra", b"cobra") is True
+    assert llamadas == [(b"cobra", b"cobra")]

--- a/tests/test_corelibs_compresion.py
+++ b/tests/test_corelibs_compresion.py
@@ -43,7 +43,13 @@ def test_validar_origen_para_listar_y_extraer(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize(
     "nombre",
-    ["../escape.txt", "..\\escape.txt", "/tmp/escape.txt", "C:/escape.txt"],
+    [
+        "../escape.txt",
+        "..\\escape.txt",
+        "docs/../escape.txt",
+        "/tmp/escape.txt",
+        "C:/escape.txt",
+    ],
 )
 def test_extraer_zip_rechaza_path_traversal(tmp_path: Path, nombre: str) -> None:
     origen = tmp_path / "malicioso.zip"

--- a/tests/test_corelibs_proceso.py
+++ b/tests/test_corelibs_proceso.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 
 import pytest
@@ -60,3 +61,18 @@ def test_timeout_devuelve_error_determinista() -> None:
 def test_rechaza_argumentos_texto_plano() -> None:
     with pytest.raises(TypeError, match="argumentos debe ser una secuencia explícita"):
         proceso.ejecutar(sys.executable, argumentos="--version")
+
+
+def test_ejecutar_usa_shell_false_por_defecto_y_shell_true_explicito(monkeypatch) -> None:
+    llamadas = []
+
+    def fake_run(*args, **kwargs):
+        llamadas.append(kwargs["shell"])
+        return subprocess.CompletedProcess(args[0], 0, "", "")
+
+    monkeypatch.setattr(proceso.subprocess, "run", fake_run)
+
+    proceso.ejecutar("python")
+    proceso.ejecutar("echo ok", shell=True)
+
+    assert llamadas == [False, True]

--- a/tests/test_corelibs_temporal.py
+++ b/tests/test_corelibs_temporal.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -57,3 +58,39 @@ def test_argumentos_invalidos_generan_mensajes_deterministas() -> None:
 
     with pytest.raises(ValueError, match="ruta no puede estar vacía"):
         temporal.limpiar("")
+
+
+def test_archivo_temporal_cierra_descriptor_con_mkstemp_monkeypatch(
+    monkeypatch, tmp_path: Path
+) -> None:
+    ruta = tmp_path / "cerrado.tmp"
+    descriptor = os.open(ruta, os.O_CREAT | os.O_RDWR)
+    cerrar_real = os.close
+    cerrados = []
+
+    def fake_mkstemp(*, prefix=None, suffix=None, text=True):
+        return descriptor, str(ruta)
+
+    def fake_close(fd: int) -> None:
+        cerrados.append(fd)
+        cerrar_real(fd)
+
+    monkeypatch.setattr(temporal.tempfile, "mkstemp", fake_mkstemp)
+    monkeypatch.setattr(temporal.os, "close", fake_close)
+
+    assert temporal.archivo_temporal() == str(ruta)
+    assert cerrados == [descriptor]
+
+
+def test_limpiar_no_falla_si_ruta_desaparece_durante_eliminacion(
+    monkeypatch, tmp_path: Path
+) -> None:
+    archivo = tmp_path / "desaparece.txt"
+    archivo.write_text("cobra", encoding="utf-8")
+
+    def fake_unlink(self):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(Path, "unlink", fake_unlink)
+
+    assert temporal.limpiar(archivo) is False


### PR DESCRIPTION
### Motivation

- Aumentar la cobertura de pruebas para verificar comportamientos de seguridad y robustez en las corelibs relacionadas con ejecución de procesos, compresión ZIP, criptografía y temporales.

### Description

- Añadidos/extendidos tests en `tests/test_corelibs_proceso.py` para verificar que `ejecutar` usa `shell=False` por defecto y solo activa `shell=True` cuando se pasa explícitamente.
- Ampliados casos en `tests/test_corelibs_compresion.py` para comprobar que `extraer_zip` rechaza entradas de path traversal como `../archivo` y segmentos `docs/../escape.txt` en rutas portables.
- Añadido test en `tests/core/test_corelib_cripto.py` que monkeypatchea `hmac.compare_digest` para asegurar que `cripto.comparar_seguro` delega en una comparación segura.
- Añadidos tests en `tests/test_corelibs_temporal.py` para confirmar que `temporal.archivo_temporal` cierra el descriptor devuelto por `tempfile.mkstemp` y que `temporal.limpiar` no falla si la ruta desaparece durante la eliminación.
- No se cambiaron las implementaciones de `src/pcobra/corelibs/*`; solo se reforzó la suite de tests para auditar los requisitos de seguridad y portabilidad.

### Testing

- Ejecutado: `pytest -q tests/test_corelibs_proceso.py tests/test_corelibs_compresion.py tests/core/test_corelib_cripto.py tests/test_corelibs_temporal.py` y todas las pruebas pasaron (`26 passed, 1 warning`), verificando los comportamientos esperados.
- Los tests usan `tmp_path`, objetos `Path` y comparaciones con `.as_posix()` para asegurar independencia de separadores entre Windows/Linux/macOS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48d94486588327b27e65daefd43834)