### PR TITLE
docs: clarify canonical return recommendation

### DIFF
--- a/docs/LIBRO_PROGRAMACION_COBRA.md
+++ b/docs/LIBRO_PROGRAMACION_COBRA.md
@@ -499,7 +499,7 @@ Las herramientas de GUI, asistentes de IA o acciones de corrección automática 
 1. **Validación de entrada:** el código original se tokeniza con `Lexer` y se parsea con `Parser`. Si el fragmento de entrada no puede validarse, la herramienta debe informar el error en vez de inventar una corrección sintáctica.
 2. **Sintaxis existente:** la sugerencia no debe introducir tokens, palabras reservadas, operadores o construcciones ausentes del parser vigente. Si una forma no aparece en el índice de sintaxis ni es aceptada por `Parser`, queda fuera de las recomendaciones automáticas.
 3. **Trazabilidad al Libro:** cada recomendación debe mapearse a una regla concreta de este Libro, citando la sección aplicable (por ejemplo, `§3.3 Sentencias`, `§3.4 Funciones` o `§3.6 Módulos`).
-4. **Regresión obligatoria:** por cada recomendación nueva se añade un caso válido y uno inválido en `tests/gui/` o `tests/integration/`; además, el fragmento sugerido debe tener una prueba que confirme que `Parser` lo acepta.
+4. **Regresión obligatoria:** por cada recomendación nueva se añade un caso válido y un caso de contraste en `tests/gui/` o `tests/integration/`; el contraste puede ser una forma inválida o una forma aceptada pero no recomendada/no canónica. Además, el fragmento sugerido debe tener una prueba que confirme que `Parser` lo acepta.
 
 Motor real de sugerencias: Cobra mantiene `agix` como dependencia oficial y único nombre canónico para esta integración. Cualquier cambio de motor requiere una ADR aprobada que justifique el cambio de arquitectura. La fachada pública estable es `pcobra.ia.analizador_sugerencias`, que delega en `pcobra.ia.analizador_agix` y conserva el contrato de validación previa y posterior con `Lexer(codigo).tokenizar()` y `Parser(tokens).parsear()` antes de exponer sugerencias aplicables.
 
@@ -507,9 +507,9 @@ La salida visible de GUI/IA separa dos planos. **Errores de Lexer/Parser** son b
 
 Recomendaciones autorizadas actualmente:
 
-| Recomendación | Regla del Libro | Fragmento sugerido que debe aceptar `Parser` | Forma inválida cubierta por regresión |
+| Recomendación | Regla del Libro | Fragmento sugerido que debe aceptar `Parser` | Forma no recomendada o inválida cubierta por regresión |
 |---|---|---|---|
-| Usar `retorno` dentro de funciones. | `§3.3 Sentencias` y `§3.4 Funciones`. | `func saludar(nombre): retorno nombre fin` | `retornar nombre` |
+| Preferir `retorno` dentro de funciones como forma canónica. | `§3.3 Sentencias` y `§3.4 Funciones`. | `func saludar(nombre): retorno nombre fin` | `retornar nombre` como forma aceptada/no canónica |
 | Usar `usar` sin alias `como` y con importación plana. | `§3.6 Módulos`. | `usar "numero"` seguido de `es_finito(10)` | `usar "numero" como numero` |
 | Declarar funciones con `func` o `definir`. | `§3.4 Funciones`. | `func calcular_total(a, b): retorno a + b fin` | `funcion calcular_total(a, b): ...` |
 


### PR DESCRIPTION
### Motivation

- Evitar que la sección de regresión obligatoria sugiera que los contrastes siempre deben ser errores de parser, permitiendo también formas aceptadas pero no recomendadas/no canónicas.
- Hacer explícita la preferencia de la forma `retorno` como canonical sin declarar a `retornar nombre` como estrictamente inválida.

### Description

- Actualicé la redacción de la regla "Regresión obligatoria" para exigir un caso válido y un "caso de contraste" que puede ser inválido o aceptado pero no recomendado/no canónico. 
- Renombré la última columna de la tabla de recomendaciones a `Forma no recomendada o inválida cubierta por regresión`.
- Reformulé la entrada sobre retorno para `Preferir `retorno` dentro de funciones como forma canónica.` y cambié la celda final a `` `retornar nombre` como forma aceptada/no canónica ``.
- Dejé intactas las demás filas de la tabla (por ejemplo `usar "numero" como numero` y `funcion calcular_total(a, b): ...`).

### Testing

- Se buscó y verificó el contexto y las ocurrencias relevantes con `rg -n` y `nl -ba` para confirmar las líneas afectadas, y la búsqueda devolvió las entradas esperadas; éxito.
- Se inspeccionó el diff con `git diff -- docs/LIBRO_PROGRAMACION_COBRA.md` y `git diff --check` para validar el parche y no detectar problemas; éxito.
- Se comprobó el estado con `git status --short` para confirmar que el archivo `docs/LIBRO_PROGRAMACION_COBRA.md` fue modificado; éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48efe0865c83279fc8c7eaeefb6dd5)