### PR TITLE
Fix usar datos canonical resolution

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -512,6 +512,7 @@ def _obtener_modulo_cobra_oficial_compat(nombre: str):
         and getattr(wrapper_oficial, "__module__", "") != "pcobra.core.usar_loader"
     ):
         modulo = wrapper_oficial(nombre)
+        return modulo
     else:
         modulo = obtener_modulo_cobra_oficial(nombre)
 
@@ -591,6 +592,14 @@ def obtener_modulo(nombre: str, *, permitir_instalacion: bool = True):
 
     resolver_cls = imports_resolver.CobraImportResolver
     resolver_parcheado = getattr(resolver_cls, "__module__", "") != "pcobra.cobra.imports.resolver"
+    if nombre in USAR_COBRA_PUBLIC_MODULES:
+        try:
+            return _obtener_modulo_cobra_oficial_compat(nombre)
+        except ModuleNotFoundError as oficial_exc:
+            raise ImportError(
+                f"No se pudo resolver el módulo Cobra permitido '{nombre}' en runtime."
+            ) from oficial_exc
+
     if nombre not in USAR_COBRA_PUBLIC_MODULES and resolver_parcheado:
         _resolution, modulo = resolver_cls().load_module(nombre, fallback_backend="python")
         return modulo
@@ -602,14 +611,6 @@ def obtener_modulo(nombre: str, *, permitir_instalacion: bool = True):
             _resolution, modulo = resolver_cls().load_module(nombre, fallback_backend="python")
             return modulo
         except Exception:
-            if nombre in USAR_COBRA_PUBLIC_MODULES:
-                try:
-                    return _obtener_modulo_cobra_oficial_compat(nombre)
-                except ModuleNotFoundError as oficial_exc:
-                    raise ImportError(
-                        f"No se pudo resolver el módulo Cobra permitido '{nombre}' en runtime."
-                    ) from oficial_exc
-
             if not permitir_instalacion or os.environ.get("COBRA_USAR_INSTALL") != "1":
                 raise RuntimeError(
                     f"Módulo '{nombre}' no instalado y la instalación automática está deshabilitada."

--- a/src/pcobra/cobra/usar_policy.py
+++ b/src/pcobra/cobra/usar_policy.py
@@ -54,7 +54,9 @@ _USAR_CANONICAL_INTERNAL_PATHS: dict[str, str] = {
     "numero": "src/pcobra/corelibs/numero.py",
     # `texto` expone su API Cobra-facing desde corelibs para evitar inicializar agregadores.
     "texto": "src/pcobra/standard_library/texto.py",
-    # `datos` mantiene su API pública desde standard_library.
+    # `datos` mantiene la misma estrategia que `numero`: el alias público se
+    # resuelve por la ruta interna canónica declarada aquí.  En este caso el
+    # contrato runtime apunta explícitamente a standard_library.
     "datos": "src/pcobra/standard_library/datos.py",
     "logica": "src/pcobra/corelibs/logica.py",
     "asincrono": "src/pcobra/corelibs/asincrono.py",
@@ -168,7 +170,7 @@ CANONICAL_MODULE_SURFACE_CONTRACTS: dict[str, CanonicalModuleSurfaceContract] = 
         forbidden_symbols=("codecs", "re"),
     ),
     "datos": CanonicalModuleSurfaceContract(
-        required_functions=("filtrar", "mapear", "agregar", "longitud"),
+        required_functions=("filtrar", "mapear", "reducir", "longitud"),
         allowed_aliases={},
         forbidden_symbols=("itertools",),
     ),


### PR DESCRIPTION
### Motivation

- Alinear la resolución de `usar "datos"` con la estrategia canónica que ya usa `numero` y asegurar que el alias público apunte a una implementación real y verificable en runtime.
- Corregir el contrato de superficie para `datos` para requerir las funciones canónicas exportables exactas usadas por la API Cobra.
- Evitar que `datos` pase por rutas genéricas de import/resolver que rompan las garantías de seguridad/saneamiento de `usar` en REPL.

### Description

- Actualiza el mapa canónico interno para `datos` y documenta que su ruta oficial es `src/pcobra/standard_library/datos.py`. (modificado en `src/pcobra/cobra/usar_policy.py`).
- Ajusta el contrato de superficie `CANONICAL_MODULE_SURFACE_CONTRACTS['datos']` para requerir `("filtrar", "mapear", "reducir", "longitud")` en lugar de `agregar`.
- Modifica `obtener_modulo` en `src/pcobra/cobra/usar_loader.py` para resolver primero los módulos públicos canónicos (`USAR_COBRA_PUBLIC_MODULES`) mediante `_obtener_modulo_cobra_oficial_compat`, evitando la ruta genérica que provocaba resoluciones no deseadas.
- Mejora la compatibilidad legacy en `_obtener_modulo_cobra_oficial_compat` retornando el wrapper oficial cuando exista, manteniendo la verificación de que los módulos resueltos coincidan con las rutas canónicas cuando procede.
- El parche se mantiene localizado en la política/resolución de `usar` y no modifica lexer, parser, AST, transpiladores ni GUI.

### Testing

- Ejecuté una comprobación directa de resolución y exportaciones con un script ad-hoc (`python - <<'PY' ... PY`) que valida que `obtener_modulo_cobra_oficial`, `obtener_modulo` y `usar_modulo` resuelven `numero` y `datos` a las rutas canónicas y que `datos.__all__` contiene las exportaciones esperadas; resultado: OK.
- Ejecuté pruebas puntuales de integración relacionadas con `usar` y `datos` (`pytest` sobre varios tests de `tests/integration/...` mencionados en el transcript); los casos específicos sobre `datos` pasaron después de los cambios (varias invocaciones reportaron `OK` y conjuntos de tests específicos pasaron: 5 passed for the targeted set; later subset runs also passed).
- Ejecuté `pytest -q -k 'usar and datos'` y obtuve una ejecución mayoritaria verde con una única falla en `test_usar_datos_expone_longitud_y_metadata_canonica` que es consecuencia de un `monkeypatch` en la suite de tests que espera el símbolo `build_and_validate_usar_symbol_metadata` en `pcobra.core.interpreter` (atributo ausente) y no está relacionada con la resolución/contract de `datos` aplicada en este parche.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48ff6487f88327b7cc941e559b878c)