### PR TITLE
test: cubrir carga de 'datos' en runtime GUI

### DIFF
--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -22,3 +22,14 @@ def test_ejecutar_codigo_permite_asignaciones_en_mismo_fragmento(
 def test_ejecutar_codigo_variable_inexistente_sigue_fallando():
     with pytest.raises(NameError, match="Variable no declarada"):
         runtime.ejecutar_codigo("imprimir(no_existe)")
+
+
+def test_ejecutar_codigo_carga_exports_de_datos_sin_importerror():
+    codigo = 'usar "datos"\nimprimir("datos cargado")'
+
+    try:
+        salida = runtime.ejecutar_codigo(codigo)
+    except ImportError as exc:  # pragma: no cover - mensaje de regresión
+        pytest.fail(f'No se esperaba ImportError al cargar datos: {exc}')
+
+    assert "datos cargado" in salida


### PR DESCRIPTION
### Motivation
- Asegurar que la instrucción `usar "datos"` carga e inyecta los exports sin lanzar `ImportError` y que el runtime produce la salida esperada.

### Description
- Añadida la prueba `test_ejecutar_codigo_carga_exports_de_datos_sin_importerror` en `tests/gui/test_gui_runtime_execution_scope.py` que ejecuta `usar "datos"\nimprimir("datos cargado")`, falla si ocurre `ImportError` y comprueba que la salida contiene `datos cargado`.

### Testing
- Ejecutado `pytest -q tests/gui/test_gui_runtime_execution_scope.py` y los tests del archivo pasaron (`5 passed`, `1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a490ccd2b6c832796fe7c8dbfc79283)