### PR TITLE
test(gui): añadir prueba para `usar "datos"` y `longitud` en runtime

### DIFF
--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -33,3 +33,16 @@ def test_ejecutar_codigo_carga_exports_de_datos_sin_importerror():
         pytest.fail(f'No se esperaba ImportError al cargar datos: {exc}')
 
     assert "datos cargado" in salida
+
+
+def test_ejecutar_codigo_usar_datos_expone_longitud_para_listas():
+    codigo = '''usar "datos"
+
+numeros = [1, 2, 3, 4]
+imprimir(longitud(numeros))
+'''
+
+    salida = runtime.ejecutar_codigo(codigo)
+
+    assert "No se encontraron símbolos exportables" not in salida
+    assert "4" in salida


### PR DESCRIPTION
### Motivation
- Evitar una regresión en la carga de `usar "datos"` desde la GUI y verificar que la función `longitud` esté disponible en el `runtime.ejecutar_codigo` independientemente de si el módulo oficial es `pcobra.standard_library.datos` o `pcobra.corelibs.datos`.

### Description
- Se añadió la prueba `test_ejecutar_codigo_usar_datos_expone_longitud_para_listas` en `tests/gui/test_gui_runtime_execution_scope.py` que ejecuta `runtime.ejecutar_codigo` con `usar "datos"`, define `numeros = [1, 2, 3, 4]` e imprime `longitud(numeros)`, y afirma que no aparece `No se encontraron símbolos exportables` y que la salida contiene `4`.

### Testing
- Se ejecutó `pytest -q tests/gui/test_gui_runtime_execution_scope.py` y los tests terminaron correctamente con `6 passed` y `1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49108f73e48327b03c3d34e0ce5747)