### PR TITLE
test: validar disponibilidad de filtrar en usar "datos" (core)

### DIFF
--- a/tests/core/test_usar_policy_nuevas_corelibs.py
+++ b/tests/core/test_usar_policy_nuevas_corelibs.py
@@ -11,6 +11,7 @@ from pcobra.cobra.usar_policy import (
     USAR_COBRA_PUBLIC_MODULES,
     validar_contrato_modulos_canonicos_usar,
 )
+from pcobra.cobra.usar_loader import usar_modulo
 from pcobra.core.ast_nodes import NodoUsar
 from pcobra.core.interpreter import InterpretadorCobra
 
@@ -106,3 +107,10 @@ def test_repl_resuelve_nueva_corelib_con_nodo_usar_sin_parser_lexer(alias: str) 
     exportes = tuple(getattr(modulo, "__all__", ()))
     assert exportes
     assert any(nombre in interprete.variables for nombre in exportes)
+
+
+def test_usar_datos_expone_filtrar_callable_sin_callback_cobra() -> None:
+    exports = usar_modulo("datos")
+
+    assert "filtrar" in exports
+    assert callable(exports["filtrar"])


### PR DESCRIPTION
### Motivation
- Verificar que la API de `usar_modulo("datos")` exporta `filtrar` y que es `callable` sin depender de la ejecución completa de callbacks Cobra.

### Description
- Añadida la prueba `test_usar_datos_expone_filtrar_callable_sin_callback_cobra` en `tests/core/test_usar_policy_nuevas_corelibs.py` que importa `usar_modulo` y comprueba que `"filtrar" in exports` y `callable(exports["filtrar"])`.

### Testing
- Ejecutado `pytest tests/core/test_usar_policy_nuevas_corelibs.py -q` y la ejecución reportó `34 passed, 1 warning`, incluyendo la nueva prueba.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a491260fcc88327a46768bd3d27ede9)