### PR TITLE
test: cover numero import in GUI runtime

### DIFF
--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -46,3 +46,12 @@ imprimir(longitud(numeros))
 
     assert "No se encontraron símbolos exportables" not in salida
     assert "4" in salida
+
+
+def test_ejecutar_codigo_usar_numero_expone_es_finito_en_ruta_gui_runtime():
+    codigo = 'usar "numero"\nimprimir(es_finito(10))'
+
+    salida = runtime.ejecutar_codigo(codigo)
+    salida_normalizada = salida.strip().lower()
+
+    assert salida_normalizada == "verdadero" or "verdadero" in salida_normalizada


### PR DESCRIPTION
### Motivation
- Añadir una prueba de regresión que garantice que `pcobra.gui.runtime.ejecutar_codigo` acepta `usar "numero"` y que `imprimir(es_finito(10))` produce una salida que contiene o es `verdadero`.

### Description
- Se añadió `test_ejecutar_codigo_usar_numero_expone_es_finito_en_ruta_gui_runtime` en `tests/gui/test_gui_runtime_execution_scope.py` que ejecuta el fragmento `usar "numero"\nimprimir(es_finito(10))`, normaliza la salida con `strip().lower()` y afirma que sea exactamente `verdadero` o que la contenga, sin modificar `src/pcobra/corelibs/numero.py`.

### Testing
- Ejecuté `pytest tests/gui/test_gui_runtime_execution_scope.py -q` y la suite del archivo pasó exitosamente, y también ejecuté `pytest tests/gui/test_gui_runtime_execution_scope.py::test_ejecutar_codigo_usar_numero_expone_es_finito_en_ruta_gui_runtime -q` que pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4914cb305483279e5da4ce30fd65ca)