### PR TITLE
test: cubrir rechazo de módulo público inexistente en usar_modulo

### DIFF
--- a/tests/core/test_usar_policy_nuevas_corelibs.py
+++ b/tests/core/test_usar_policy_nuevas_corelibs.py
@@ -109,6 +109,21 @@ def test_repl_resuelve_nueva_corelib_con_nodo_usar_sin_parser_lexer(alias: str) 
     assert any(nombre in interprete.variables for nombre in exportes)
 
 
+def test_usar_modulo_inexistente_falla_con_excepcion_controlada() -> None:
+    assert "modulo_inexistente" not in USAR_COBRA_PUBLIC_MODULES
+
+    with pytest.raises((PermissionError, ValueError, FileNotFoundError, ImportError)) as excinfo:
+        usar_modulo("modulo_inexistente")
+
+    mensaje = str(excinfo.value).lower()
+    assert (
+        "fuera del catálogo" in mensaje
+        or "fuera del catalogo" in mensaje
+        or "no permitido" in mensaje
+        or "no encontrado" in mensaje
+    )
+
+
 def test_usar_datos_expone_filtrar_callable_sin_callback_cobra() -> None:
     exports = usar_modulo("datos")
 


### PR DESCRIPTION
### Motivation

- Asegurar que `usar_modulo("modulo_inexistente")` falla con una excepción controlada y un mensaje claro indicando que el módulo está fuera del catálogo, no permitido o no encontrado.

### Description

- Se añadió la prueba `test_usar_modulo_inexistente_falla_con_excepcion_controlada` en `tests/core/test_usar_policy_nuevas_corelibs.py`.
- La prueba comprueba que `"modulo_inexistente"` no está en `USAR_COBRA_PUBLIC_MODULES`, invoca `usar_modulo("modulo_inexistente")` y acepta `PermissionError`, `ValueError`, `FileNotFoundError` o `ImportError` como respuestas válidas, además de verificar que el mensaje contiene texto representativo del rechazo o no encontrado.
- No se modificó el catálogo público ni la lógica de producción, solo se añadió la cobertura de prueba.

### Testing

- Ejecutado `pytest tests/core/test_usar_policy_nuevas_corelibs.py::test_usar_modulo_inexistente_falla_con_excepcion_controlada -q`, prueba pasada.
- Ejecutado `pytest tests/core/test_usar_policy_nuevas_corelibs.py -q`, todo el archivo pasó (35 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4918ff971083278243dcccc2616c73)