### PR TITLE
test: cover usar "texto" official contract

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -791,6 +791,31 @@ def test_repl_usar_datos_imprimir_longitud_lista_produce_3(monkeypatch, capsys):
     assert capsys.readouterr().out.strip().splitlines()[-1] == "3"
 
 
+def test_repl_usar_texto_oficial_mayusculas_contrato_actual(capsys):
+    from pcobra.cobra.usar_policy import (
+        REPL_COBRA_MODULE_INTERNAL_PATH_MAP,
+        USAR_RUNTIME_EXPORT_OVERRIDES,
+    )
+
+    modulo_texto = core_usar_loader.obtener_modulo_cobra_oficial("texto")
+
+    assert (
+        REPL_COBRA_MODULE_INTERNAL_PATH_MAP["texto"]
+        == "src/pcobra/standard_library/texto.py"
+    )
+    assert "mayusculas" in modulo_texto.__all__
+    assert "mayusculas" in USAR_RUNTIME_EXPORT_OVERRIDES["texto"]
+    assert "longitud" not in modulo_texto.__all__
+    assert "longitud" not in USAR_RUNTIME_EXPORT_OVERRIDES["texto"]
+
+    interp = InterpretadorCobra()
+    interp.configurar_restriccion_usar_repl({"texto": "texto"})
+
+    _ejecutar_codigo('usar "texto"\nimprimir(mayusculas("hola"))', interp)
+
+    assert capsys.readouterr().out.strip().splitlines()[-1] == "HOLA"
+
+
 def test_usar_texto_expone_superficie_publica_clave(monkeypatch):
     import pcobra.corelibs.texto as modulo_texto
 


### PR DESCRIPTION
### Motivation
- Añadir cobertura de regresión que verifique el contrato oficial de `usar "texto"` (ruta canónica y símbolos públicos preservados) para evitar introducir pruebas que exijan `longitud` cuando no forma parte del contrato.

### Description
- Se añadió la prueba `test_repl_usar_texto_oficial_mayusculas_contrato_actual` en `tests/unit/test_usar.py` que valida la ruta canónica `REPL_COBRA_MODULE_INTERNAL_PATH_MAP["texto"] == "src/pcobra/standard_library/texto.py"`, que `mayusculas` está en `__all__` y en `USAR_RUNTIME_EXPORT_OVERRIDES["texto"]`, que `longitud` no está exportada, y que `usar "texto"` expone `mayusculas` ejecutable en el intérprete.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar.py::test_repl_usar_texto_oficial_mayusculas_contrato_actual` y la prueba pasó correctamente; el comando devolvió `1 passed` con una advertencia deprecativa.
- Intenté ejecutar `pytest -q tests/unit/test_usar.py tests/unit/test_usar_public_contract.py`, que mostró 34 pruebas pasadas pero se detuvo por un `pytest` internal `MemoryError` del entorno y no por fallos de aserción.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a491c40f134832781518be53624c240)