### PR TITLE
test: cubrir exports de `datos` en runtime GUI

### DIFF
--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -55,3 +55,24 @@ def test_ejecutar_codigo_usar_numero_expone_es_finito_en_ruta_gui_runtime():
     salida_normalizada = salida.strip().lower()
 
     assert salida_normalizada == "verdadero" or "verdadero" in salida_normalizada
+
+
+def test_ejecutar_codigo_usar_datos_inyecta_filtrar_y_bloquea_callback_cobra_separado():
+    codigo = '''usar "datos"
+
+func mayor_que_dos(n):
+    retorno n > 2
+fin
+
+numeros = [1, 2, 3, 4]
+resultado = filtrar(numeros, mayor_que_dos)
+imprimir(resultado)
+'''
+
+    with pytest.raises(NameError, match="mayor_que_dos"):
+        runtime.ejecutar_codigo(codigo)
+
+
+def test_ejecutar_codigo_modulo_inexistente_falla_controladamente():
+    with pytest.raises(PermissionError, match="modulo_inexistente"):
+        runtime.ejecutar_codigo('usar "modulo_inexistente"')


### PR DESCRIPTION
### Motivation

- Reproducir y prevenir la regresión donde `usar "datos"` arrojaba `ImportError: No se encontraron símbolos exportables` al cargar exports públicos de `datos` desde el runtime GUI. 
- Documentar y aislar el bloqueo siguiente relacionado con callbacks Cobra (POC: `mayor_que_dos`), que es un problema distinto identificado como `CORE_DATA_FILTER_CALLBACK_001`.
- Mantener un parche mínimo y localizado sin tocar Lexer/Parser/AST/transpiladores ni scope global.

### Description

- Añadido test `test_ejecutar_codigo_usar_datos_inyecta_filtrar_y_bloquea_callback_cobra_separado` en `tests/gui/test_gui_runtime_execution_scope.py` para validar que `usar "datos"` inyecta `filtrar` y que el siguiente error es por resolución del callback Cobra (`NameError` sobre `mayor_que_dos`).
- Añadido test `test_ejecutar_codigo_modulo_inexistente_falla_controladamente` en el mismo archivo para asegurar que un `usar` a módulo no listado falla con un `PermissionError` controlado.
- No se realizaron cambios en código productivo de runtime; la corrección detectada en la investigación mostró que `REPL_COBRA_MODULE_INTERNAL_PATH_MAP` ya resolvía `datos` correctamente a `pcobra.standard_library.datos`, por lo que el PR aplica solo cobertura de regresión.

### Testing

- Ejecuté `pytest -q tests/gui/test_gui_runtime_execution_scope.py` y la suite pasó completamente; los nuevos tests fueron validados localmente.
- Ejecuté `pytest -q tests/unit/test_usar_core_all_exports.py` y `pytest -q tests/unit/test_usar_policy_contract.py`, y ambos pasaron sin errores.
- Ejecuté una corrida combinada (`tests/core`, `tests/gui`, `tests/unit/test_gui_runtime.py`, `tests/gui/test_gui_runtime_execution_scope.py`) que reportó `289 passed` antes de que `pytest` terminara con un `INTERNALERROR MemoryError` al formatear el reporte en este entorno; las ejecuciones focalizadas individuales pasaron por separado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49555445548327a014c0eb6e89a6c2)