### PR TITLE
Open auxiliary text/config files from IDLE tree

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -451,9 +451,8 @@ def listar_directorio_idle(
         if entry.is_dir():
             visibles.append(entry)
             continue
-        tipo_archivo = detectar_tipo_archivo(entry)
-        if tipo_archivo in TIPOS_ARCHIVO_TEXTO_IDLE or (
-            incluir_desconocidos and tipo_archivo == TIPO_ARCHIVO_DESCONOCIDO
+        if es_archivo_texto_visible_idle(
+            entry, incluir_desconocidos=incluir_desconocidos
         ):
             visibles.append(entry)
 
@@ -746,13 +745,26 @@ def recargar_archivo_activo(estado: GuiFileState) -> tuple[str, str]:
     return abrir_archivo_desde_ruta(estado.ruta, estado)
 
 
+def es_archivo_texto_visible_idle(
+    path: str | Path,
+    *,
+    incluir_desconocidos: bool = MOSTRAR_DESCONOCIDOS_COMO_TEXTO_IDLE,
+) -> bool:
+    """Indica si una ruta no directorio entra en la política textual del IDLE."""
+
+    tipo_archivo = detectar_tipo_archivo(path)
+    return tipo_archivo in TIPOS_ARCHIVO_TEXTO_IDLE or (
+        incluir_desconocidos and tipo_archivo == TIPO_ARCHIVO_DESCONOCIDO
+    )
+
+
 def cargar_archivo_desde_arbol(
     ruta: str | Path, estado: GuiFileState
 ) -> tuple[str, str]:
-    """Carga una entrada de árbol si es archivo Cobra y devuelve contenido/mensaje."""
+    """Carga una entrada textual visible del árbol y devuelve contenido/mensaje."""
 
-    if not es_archivo_cobra(ruta):
-        raise ValueError("Selecciona un archivo Cobra (.co o .cobra).")
+    if not es_archivo_texto_visible_idle(ruta):
+        raise ValueError("Selecciona un archivo de texto visible del proyecto.")
     return abrir_archivo_desde_ruta(ruta, estado)
 
 

--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -311,12 +311,14 @@ def test_helpers_archivo_cubren_nuevo_abrir_guardar_como_guardar_y_recargar(
     assert estado.cambios_sin_guardar is False
 
 
-def test_cargar_archivo_desde_arbol_reusa_apertura_y_valida_extension(tmp_path: Path):
+def test_cargar_archivo_desde_arbol_reusa_apertura_y_valida_politica_texto(tmp_path: Path):
     estado = runtime.GuiFileState()
     archivo_cobra = tmp_path / "desde_arbol.cobra"
     archivo_cobra.write_text("imprimir('arbol')", encoding="utf-8")
-    archivo_no_cobra = tmp_path / "nota.txt"
-    archivo_no_cobra.write_text("texto", encoding="utf-8")
+    archivo_texto = tmp_path / "README.md"
+    archivo_texto.write_text("# Documentación", encoding="utf-8")
+    archivo_desconocido = tmp_path / "binario.dat"
+    archivo_desconocido.write_text("texto desconocido", encoding="utf-8")
 
     contenido, mensaje = runtime.cargar_archivo_desde_arbol(archivo_cobra, estado)
 
@@ -325,12 +327,19 @@ def test_cargar_archivo_desde_arbol_reusa_apertura_y_valida_extension(tmp_path: 
     assert estado.ruta == archivo_cobra.resolve()
     assert estado.contenido_cargado == "imprimir('arbol')"
 
+    contenido, mensaje = runtime.cargar_archivo_desde_arbol(archivo_texto, estado)
+
+    assert contenido == "# Documentación"
+    assert mensaje == f"Archivo cargado: {archivo_texto.resolve()}"
+    assert estado.ruta == archivo_texto.resolve()
+    assert estado.contenido_cargado == "# Documentación"
+
     try:
-        runtime.cargar_archivo_desde_arbol(archivo_no_cobra, estado)
+        runtime.cargar_archivo_desde_arbol(archivo_desconocido, estado)
     except ValueError as exc:
-        assert "Selecciona un archivo Cobra" in str(exc)
+        assert "archivo de texto visible" in str(exc)
     else:
-        raise AssertionError("El árbol solo debe cargar archivos .co/.cobra")
+        raise AssertionError("El árbol solo debe cargar archivos visibles del IDLE")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -936,7 +936,7 @@ def test_accion_recargar_archivo_activo(
     assert mensaje == f"Archivo cargado: {archivo.resolve()}"
 
 
-def test_accion_cargar_archivo_desde_arbol_filtra_extensiones(
+def test_accion_cargar_archivo_desde_arbol_acepta_texto_visible(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
@@ -948,8 +948,16 @@ def test_accion_cargar_archivo_desde_arbol_filtra_extensiones(
 
     assert contenido == "imprimir('arbol')"
     assert mensaje == f"Archivo cargado: {archivo.resolve()}"
-    with pytest.raises(ValueError, match="archivo Cobra"):
-        runtime.cargar_archivo_desde_arbol(tmp_path / "notas.txt", estado)
+    notas = tmp_path / "notas.txt"
+    notas.write_text("apuntes", encoding="utf-8")
+    contenido, mensaje = runtime.cargar_archivo_desde_arbol(notas, estado)
+    assert contenido == "apuntes"
+    assert mensaje == f"Archivo cargado: {notas.resolve()}"
+
+    desconocido = tmp_path / "notas.bin"
+    desconocido.write_text("bin", encoding="utf-8")
+    with pytest.raises(ValueError, match="archivo de texto visible"):
+        runtime.cargar_archivo_desde_arbol(desconocido, estado)
 
 
 def test_require_flet_error_accionable(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- Fix a high-priority UX bug where auxiliary files (e.g. `README.md`, config files) were listed in the IDLE explorer but could not be opened because tree clicks were restricted to Cobra files only.
- Align the explorer listing and tree-click behavior so displayed entries are actually openable without weakening file-safety checks for unknown binaries.

### Description
- Added a shared visibility predicate `es_archivo_texto_visible_idle(path, *, incluir_desconocidos=...)` to express the IDLE textual-file policy and centralize file-type checks.
- Rewrote `listar_directorio_idle()` to use the new predicate for including non-directory entries and kept `listar_directorio_cobra()` as a legacy delegate.
- Relaxed `cargar_archivo_desde_arbol()` to accept any file that `es_archivo_texto_visible_idle()` permits and return a clearer error message for disallowed files.
- Updated tests to reflect the new policy in `tests/gui/test_runtime_file_helpers.py` and `tests/unit/test_gui_runtime.py` so auxiliary text/config files open from the tree while unknown types remain rejected.

### Testing
- Ran `pytest tests/gui/test_runtime_file_helpers.py -q` and it passed (`31 passed, 1 warning`).
- Ran the updated unit test `pytest tests/unit/test_gui_runtime.py::test_accion_cargar_archivo_desde_arbol_acepta_texto_visible -q` and it passed (`1 passed, 1 warning`).
- Ran the full GUI test suite `pytest tests/gui -q` and it passed (`66 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49e3ade4408327ab247c6fa66a4fb1)