### PR TITLE
test: fijar import canónico de usar datos

### DIFF
--- a/tests/core/test_usar_policy_nuevas_corelibs.py
+++ b/tests/core/test_usar_policy_nuevas_corelibs.py
@@ -11,7 +11,7 @@ from pcobra.cobra.usar_policy import (
     USAR_COBRA_PUBLIC_MODULES,
     validar_contrato_modulos_canonicos_usar,
 )
-from pcobra.cobra.usar_loader import usar_modulo
+from pcobra.cobra.usar_loader import obtener_modulo_cobra_oficial, usar_modulo
 from pcobra.core.ast_nodes import NodoUsar
 from pcobra.core.interpreter import InterpretadorCobra
 
@@ -129,3 +129,17 @@ def test_usar_datos_expone_filtrar_callable_sin_callback_cobra() -> None:
 
     assert "filtrar" in exports
     assert callable(exports["filtrar"])
+
+
+def test_usar_datos_apunta_a_standard_library_y_loader_importa_nombre_correcto() -> None:
+    ruta_relativa = REPL_COBRA_MODULE_INTERNAL_PATH_MAP["datos"]
+
+    assert ruta_relativa == "src/pcobra/standard_library/datos.py"
+    assert (RAIZ_REPO / ruta_relativa).is_file()
+
+    modulo = obtener_modulo_cobra_oficial("datos")
+
+    assert modulo.__name__ == "pcobra.standard_library.datos"
+    assert modulo.__name__ != "pcobra.cobra.corelibs.datos"
+    assert getattr(modulo, "__file__", None) is not None
+    assert Path(modulo.__file__).resolve() == (RAIZ_REPO / ruta_relativa).resolve()


### PR DESCRIPTION
### Motivation
- Asegurar que el alias `usar "datos"` mantenga su ruta canónica y que el loader importe el módulo Python correcto para evitar resoluciones internas inseguras (p.ej. prevenir `pcobra.cobra.corelibs.datos`).

### Description
- Añade una prueba de regresión en `tests/core/test_usar_policy_nuevas_corelibs.py` que verifica que `REPL_COBRA_MODULE_INTERNAL_PATH_MAP["datos"]` apunta a `src/pcobra/standard_library/datos.py` y que `obtener_modulo_cobra_oficial("datos")` importa `pcobra.standard_library.datos` (sin modificar Lexer, Parser, tokens, gramática, nodos AST, transpiladores ni el parche de scope global del IDLE). 

### Testing
- Ejecuté `pytest tests/core/test_usar_policy_nuevas_corelibs.py -q` y la suite pasó (`36 passed, 1 warning`).
- Ejecuté `pytest tests/core/test_superficie_publica_canonica.py tests/core/test_usar_policy_nuevas_corelibs.py -q` y ambas pruebas pasaron (`110 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a04de124c83278bc7a86971621c1d)