### PR TITLE
Alinear exports de `datos` y reforzar prueba de `usar_modulo`

### DIFF
--- a/src/pcobra/corelibs/datos.py
+++ b/src/pcobra/corelibs/datos.py
@@ -48,6 +48,10 @@ combinar_tablas = _datos.combinar_tablas
 rellenar_nulos = _datos.rellenar_nulos
 desplegar_tabla = _datos.desplegar_tabla
 pivotar_tabla = _datos.pivotar_tabla
+invertir_tabla = _datos.invertir_tabla
+tomar = _datos.tomar
+
+
 def agregar(tabla, fila):
     """Wrapper público seguro hacia :mod:`pcobra.standard_library.datos`."""
     return _datos.agregar(tabla, fila)
@@ -115,6 +119,8 @@ PUBLIC_API_DATOS: tuple[str, ...] = (
     "valores",
     "longitud",
     "elemento",
+    "invertir_tabla",
+    "tomar",
 )
 
 

--- a/tests/core/test_usar_policy_nuevas_corelibs.py
+++ b/tests/core/test_usar_policy_nuevas_corelibs.py
@@ -129,6 +129,8 @@ def test_usar_datos_expone_filtrar_callable_sin_callback_cobra() -> None:
 
     assert "filtrar" in exports
     assert callable(exports["filtrar"])
+    assert "longitud" in exports
+    assert callable(exports["longitud"])
 
 
 def test_usar_datos_apunta_a_standard_library_y_loader_importa_nombre_correcto() -> None:


### PR DESCRIPTION
### Motivation
- Asegurar que la superficie pública reexportada por la corelib `datos` coincide con la implementación en `standard_library` y cumple el contrato de `usar` para exponer únicamente símbolos válidos y callables.
- Evitar discrepancias entre `__all__` de `pcobra.standard_library.datos` y la lista pública usada por `usar` que pueden provocar rechazos o inconsistencias en tiempo de ejecución.

### Description
- Añadí las reexportaciones `invertir_tabla` y `tomar` en `src/pcobra/corelibs/datos.py` para alinear la surface pública con `pcobra.standard_library.datos` y evitar desajustes entre wrappers y la implementación canónica.
- Actualicé `PUBLIC_API_DATOS` en `src/pcobra/corelibs/datos.py` para incluir `invertir_tabla` y `tomar`, y mantuve `filtrar` y `longitud` en la API pública tal como exige el contrato.
- Reforcé la prueba en `tests/core/test_usar_policy_nuevas_corelibs.py` para que `exports = usar_modulo("datos")` verifique además que `"longitud" in exports` y que `exports["longitud"]` es `callable`.
- Verifiqué que el loader de `usar` lee `__all__`, filtra candidatos y luego aplica `sanear_exportables_para_usar` y `build_and_validate_usar_symbol_metadata`, por lo que sólo se inyectan símbolos saneados y callables según la política vigente.

### Testing
- Ejecuté `python -m pytest tests/core/test_usar_policy_nuevas_corelibs.py -q` y la suite de ese archivo pasó con `36 passed, 1 warning`.
- Ejecuté comprobaciones estáticas (`git diff --check`) y no se detectaron errores de formato o conflictos en el diff modificado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a0633fe9883278f0218da9a58d842)