### PR TITLE
test: make `datos` import assertion explicit in GUI runtime test

### DIFF
--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -25,12 +25,12 @@ def test_ejecutar_codigo_variable_inexistente_sigue_fallando():
 
 
 def test_ejecutar_codigo_carga_exports_de_datos_sin_importerror():
-    codigo = 'usar "datos"\nimprimir("datos cargado")'
-
     try:
-        salida = runtime.ejecutar_codigo(codigo)
+        salida = runtime.ejecutar_codigo('usar "datos"\nimprimir("datos cargado")')
     except ImportError as exc:  # pragma: no cover - mensaje de regresión
-        pytest.fail(f'No se esperaba ImportError al cargar datos: {exc}')
+        if "No se encontraron símbolos exportables" in str(exc):
+            pytest.fail(f'No se esperaba ImportError al cargar datos: {exc}')
+        raise
 
     assert "datos cargado" in salida
 


### PR DESCRIPTION
### Motivation
- Asegurar que la prueba invoque exactamente `runtime.ejecutar_codigo('usar "datos"\nimprimir("datos cargado")')` y falle únicamente cuando se detecte la regresión específica del `ImportError` con el mensaje `No se encontraron símbolos exportables`.

### Description
- Se actualizó `tests/gui/test_gui_runtime_execution_scope.py` para llamar inline a `runtime.ejecutar_codigo('usar "datos"\nimprimir("datos cargado")')` y para manejar el `ImportError` revirtiendo la excepción salvo cuando su mensaje contiene `No se encontraron símbolos exportables`, en cuyo caso la prueba falla explícitamente.

### Testing
- Ejecuté `pytest -q tests/gui/test_gui_runtime_execution_scope.py` y la suite de prueba afectada pasó satisfactoriamente (9 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a07cfe3188327a8e2dd77c1844399)