### PR TITLE
test: asegurar inyección de longitud desde datos en runtime GUI

### DIFF
--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -36,16 +36,23 @@ def test_ejecutar_codigo_carga_exports_de_datos_sin_importerror():
 
 
 def test_ejecutar_codigo_usar_datos_expone_longitud_para_listas():
+    # Regresión: `usar "datos"` debe inyectar `longitud` en el runtime GUI
+    # sin depender todavía de callbacks Cobra definidos por el usuario.
     codigo = '''usar "datos"
 
 numeros = [1, 2, 3, 4]
 imprimir(longitud(numeros))
 '''
 
-    salida = runtime.ejecutar_codigo(codigo)
+    try:
+        salida = runtime.ejecutar_codigo(codigo)
+    except ImportError as exc:  # pragma: no cover - mensaje de regresión
+        if "No se encontraron símbolos exportables" in str(exc):
+            pytest.fail(f'No se esperaba error de exports al cargar datos: {exc}')
+        raise
 
     assert "No se encontraron símbolos exportables" not in salida
-    assert "4" in salida
+    assert "4" in salida.splitlines()
 
 
 def test_ejecutar_codigo_usar_numero_expone_es_finito_en_ruta_gui_runtime():


### PR DESCRIPTION
### Motivation
- Evitar una regresión donde `usar "datos"` no inyectaba `longitud` en el runtime de la GUI y podía producir el error `No se encontraron símbolos exportables`.

### Description
- Se reforzó `test_ejecutar_codigo_usar_datos_expone_longitud_para_listas` en `tests/gui/test_gui_runtime_execution_scope.py` añadiendo un `try/except` que falla explícitamente si aparece el `ImportError` con el mensaje de símbolos exportables y comprobando que la salida contiene una línea exacta con `4` usando `splitlines()`.

### Testing
- Ejecuté `pytest -q tests/gui/test_gui_runtime_execution_scope.py` y todos los tests pasaron (`9 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a08dfc374832798b520cd2a457b73)