### PR TITLE
test: assert numero es_finito GUI output

### DIFF
--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -61,7 +61,7 @@ def test_ejecutar_codigo_usar_numero_expone_es_finito_en_ruta_gui_runtime():
     salida = runtime.ejecutar_codigo(codigo)
     salida_normalizada = salida.strip().lower()
 
-    assert salida_normalizada == "verdadero" or "verdadero" in salida_normalizada
+    assert "verdadero" in salida_normalizada
 
 
 def test_ejecutar_codigo_usar_datos_inyecta_filtrar_y_bloquea_callback_cobra_separado():


### PR DESCRIPTION
### Motivation
- Evitar una aserción frágil en la prueba GUI que verifica que `usar "numero"` expone `es_finito` y que su impresión normalizada contiene la palabra `verdadero`.

### Description
- Cambiada la aserción en `tests/gui/test_gui_runtime_execution_scope.py` para usar `assert "verdadero" in salida_normalizada` en lugar de la comprobación previa más ambigua.

### Testing
- Ejecutado `pytest tests/gui/test_gui_runtime_execution_scope.py -q` y la suite pasó (9 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a0c99661883279f81347cb254b03a)