### PR TITLE
test: separar POC de callback `filtrar` en runtime GUI

### DIFF
--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -64,7 +64,21 @@ def test_ejecutar_codigo_usar_numero_expone_es_finito_en_ruta_gui_runtime():
     assert "verdadero" in salida_normalizada
 
 
-def test_ejecutar_codigo_usar_datos_inyecta_filtrar_y_bloquea_callback_cobra_separado():
+def test_core_stdlib_usar_exports_datos_001_inyecta_filtrar_callable():
+    # CORE_STDLIB_USAR_EXPORTS_DATOS_001 solo valida que `usar "datos"`
+    # expone `filtrar` como símbolo callable en el runtime GUI. No ejecuta
+    # callbacks Cobra, porque ese soporte avanzado pertenece al POC separado
+    # CORE_DATA_FILTER_CALLBACK_001.
+    codigo = '''usar "datos"
+imprimir(filtrar)
+'''
+
+    salida = runtime.ejecutar_codigo(codigo)
+
+    assert "function filtrar" in salida
+
+
+def test_core_data_filter_callback_001_poc_filtrar_con_callback_cobra():
     codigo = '''usar "datos"
 
 func mayor_que_dos(n):
@@ -76,8 +90,15 @@ resultado = filtrar(numeros, mayor_que_dos)
 imprimir(resultado)
 '''
 
-    with pytest.raises(NameError, match="mayor_que_dos"):
-        runtime.ejecutar_codigo(codigo)
+    try:
+        salida = runtime.ejecutar_codigo(codigo)
+    except (NameError, TypeError, RuntimeError) as exc:
+        pytest.xfail(
+            "CORE_DATA_FILTER_CALLBACK_001: el runtime GUI aún no resuelve "
+            f"o ejecuta callbacks Cobra en datos.filtrar ({exc})"
+        )
+
+    assert "[3, 4]" in salida
 
 
 def test_ejecutar_codigo_modulo_inexistente_falla_controladamente():


### PR DESCRIPTION
### Motivation
- Separar la verificación mínima del contrato `usar "datos"` (que debe inyectar `filtrar` como símbolo callable) de la prueba avanzada que requiere ejecutar callbacks Cobra en `datos.filtrar` para evitar falsos fallos por soporte incompleto del runtime. 
- Dejar un POC explícito para `datos.filtrar` con callback Cobra que señale el bloqueo conocido como `CORE_DATA_FILTER_CALLBACK_001` si el runtime no resuelve o ejecuta callbacks Cobra.

### Description
- Modificado `tests/gui/test_gui_runtime_execution_scope.py` para reemplazar la prueba original por dos pruebas separadas: `test_core_stdlib_usar_exports_datos_001_inyecta_filtrar_callable` y `test_core_data_filter_callback_001_poc_filtrar_con_callback_cobra`.
- `test_core_stdlib_usar_exports_datos_001_inyecta_filtrar_callable` hace `usar "datos"` y `imprimir(filtrar)` y verifica que la salida contenga `"function filtrar"` para validar que `filtrar` queda inyectado como callable en el runtime GUI.
- `test_core_data_filter_callback_001_poc_filtrar_con_callback_cobra` incorpora el POC con `func mayor_que_dos(n)` y `resultado = filtrar(numeros, mayor_que_dos)` y convierte el fallo actual en `pytest.xfail` con la etiqueta `CORE_DATA_FILTER_CALLBACK_001` cuando el runtime lanza `NameError`, `TypeError` o `RuntimeError` por falta de soporte de callbacks Cobra.
- No se modificaron otras pruebas en el archivo salvo la reubicación y ajuste de expectativas descritas.

### Testing
- Ejecutado `pytest -q tests/gui/test_gui_runtime_execution_scope.py::test_core_stdlib_usar_exports_datos_001_inyecta_filtrar_callable tests/gui/test_gui_runtime_execution_scope.py::test_core_data_filter_callback_001_poc_filtrar_con_callback_cobra -q` y ambas pruebas pasaron.
- Ejecutado `pytest -q tests/gui/test_gui_runtime_execution_scope.py -q` y la ejecución completa falló debido a un `MemoryError` en el entorno durante la creación/inicialización del runtime, provocando fallos en varias pruebas de la suite.
- Ejecutado `pytest -q -s tests/gui/test_gui_runtime_execution_scope.py -q` y también falló por `MemoryError` durante la inicialización/captura del runtime en la ejecución completa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a0fc736e48327b56fcab44628b88e)