### PR TITLE
test: ajusta validación de módulo inexistente en runtime GUI

### DIFF
--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -102,5 +102,14 @@ imprimir(resultado)
 
 
 def test_ejecutar_codigo_modulo_inexistente_falla_controladamente():
-    with pytest.raises(PermissionError, match="modulo_inexistente"):
+    with pytest.raises(PermissionError) as excinfo:
         runtime.ejecutar_codigo('usar "modulo_inexistente"')
+
+    mensaje = str(excinfo.value)
+
+    assert "fuera del catálogo" in mensaje
+    assert (
+        "no permitido" in mensaje
+        or "no encontrado" in mensaje
+        or "modulo_inexistente" in mensaje
+    )


### PR DESCRIPTION
### Motivation
- Asegurar que el test pueda inspeccionar y afirmar sobre el texto de la excepción fuera del contexto de `pytest.raises`, evitando validaciones inalcanzables dentro del bloque que captura la excepción.

### Description
- Reemplaza `with pytest.raises(PermissionError, match="modulo_inexistente")` por `with pytest.raises(PermissionError) as excinfo:`, mueve la conversión `mensaje = str(excinfo.value)` y las aserciones fuera del `with`, y elimina la validación implícita con `match=` para comprobar explícitamente fragmentos esperados del mensaje de error.

### Testing
- Se ejecutó `pytest tests/gui/test_gui_runtime_execution_scope.py::test_ejecutar_codigo_modulo_inexistente_falla_controladamente -q` y la prueba pasó con éxito (`1 passed`) con una advertencia de deprecación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a116f4b6c83278c36082dd38dbeaa)