### PR TITLE
Expose top-level Cobra functions as first-class values and generalize `filtrar` for iterables

### DIFF
--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -529,6 +529,11 @@ class InterpretadorCobra:
         self.estrategia = self.gestor_memoria.poblacion[0]
         self.op_memoria = 0
         self._eval_stack = set()
+        # Funciones Cobra declaradas en el AST fuente. Se mantiene separada del
+        # entorno de variables para que los optimizadores puedan eliminar nodos
+        # ``NodoFuncion`` sin impedir que sus nombres sigan siendo resolubles
+        # como valores/callbacks en expresiones.
+        self._funciones_declaradas_valor: dict[str, dict[str, object]] = {}
         # Último IR generado a partir del AST ejecutado
         self.ultimo_ir: Optional[InternalIRModule] = None
         # Restricción opcional para `usar` en REPL/evaluador incremental.
@@ -709,7 +714,12 @@ class InterpretadorCobra:
             raise RuntimeError(f"Ciclo de variables detectado en '{nombre}'")
         visitados.add(nombre)
         try:
-            valor = self.contextos[-1].get(nombre)
+            try:
+                valor = self.contextos[-1].get(nombre)
+            except NameError:
+                if nombre in self._funciones_declaradas_valor:
+                    return self._funciones_declaradas_valor[nombre]
+                raise
             self._validar_asignacion_autorreferente(nombre, valor)
             valor_resuelto = self._materializar_valor(
                 valor,
@@ -776,6 +786,25 @@ class InterpretadorCobra:
             "cuerpo": list(nodo.cuerpo),
             "scope_lexico": self.contextos[-1],
         }
+
+    def _registrar_funciones_declaradas_como_valores(self, ast) -> None:
+        """Registra funciones top-level para resolución por identificador.
+
+        Las llamadas directas pueden sobrevivir gracias a la ruta de llamada o
+        al inlining, pero cuando una función aparece como expresión
+        (``f = doble`` o ``filtrar(xs, predicado)``), el identificador debe
+        poder resolverse incluso si ``inline_functions`` eliminó el
+        ``NodoFuncion`` original del AST ejecutable. Esta tabla actúa como
+        fallback de solo funciones; las variables/imports del entorno activo
+        mantienen prioridad.
+        """
+        if not isinstance(ast, list):
+            return
+        for nodo in ast:
+            if isinstance(nodo, NodoFuncion):
+                self._funciones_declaradas_valor[nodo.nombre] = (
+                    self._construir_funcion(nodo)
+                )
 
     def _construir_clase(self, nodo, bases):
         return {
@@ -1463,6 +1492,7 @@ class InterpretadorCobra:
 
         self._asegurar_ast_tipado(ast, "pre_optimizacion")
         self._asegurar_ast_aciclico_por_identidad(ast, "pre_optimizacion")
+        self._registrar_funciones_declaradas_como_valores(ast)
         self._trace_debug("[AST BEFORE OPT]")
         self._trace_debug(self._resumir_ast(ast))
         if self._debug_resumen_ast_habilitado():

--- a/src/pcobra/standard_library/datos.py
+++ b/src/pcobra/standard_library/datos.py
@@ -646,13 +646,18 @@ def seleccionar_columnas(tabla: Iterable[Registro], columnas: Sequence[str]) -> 
     return resultado
 
 
-def filtrar(tabla: Iterable[Registro], condicion: Callable[[Registro], bool]) -> Tabla:
-    filas = _materializar_tabla(tabla)
-    resultado: Tabla = []
+def filtrar(tabla: Iterable[Any], condicion: Callable[[Any], bool]) -> list[Any]:
+    try:
+        filas = _materializar_tabla(tabla)
+    except TypeError:
+        if isinstance(tabla, Mapping) or not isinstance(tabla, Iterable):
+            raise
+        filas = list(tabla)
+    resultado: list[Any] = []
     for fila in filas:
         try:
             if condicion(fila):
-                resultado.append(dict(fila))
+                resultado.append(dict(fila) if isinstance(fila, Mapping) else fila)
         except Exception as exc:  # pragma: no cover - errores usuario
             raise ValueError(f"La condición de filtrado falló: {exc}") from exc
     return resultado

--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -78,6 +78,47 @@ imprimir(filtrar)
     assert "function filtrar" in salida
 
 
+def test_core_data_filter_callback_001_llamada_directa_a_funcion_cobra():
+    codigo = '''func doble(n):
+    retorno n * 2
+fin
+
+imprimir(doble(3))
+'''
+
+    salida = runtime.ejecutar_codigo(codigo)
+
+    assert "6" in salida.splitlines()
+
+
+def test_core_data_filter_callback_001_funcion_cobra_como_valor_callable():
+    codigo = '''func doble(n):
+    retorno n * 2
+fin
+
+f = doble
+imprimir(f(3))
+'''
+
+    salida = runtime.ejecutar_codigo(codigo)
+
+    assert "6" in salida.splitlines()
+
+
+def test_core_data_filter_callback_001_identificador_funcion_no_es_variable_inexistente():
+    codigo = '''func doble(n):
+    retorno n * 2
+fin
+
+imprimir(doble)
+'''
+
+    salida = runtime.ejecutar_codigo(codigo)
+
+    assert "Variable no declarada" not in salida
+    assert "doble" in salida
+
+
 def test_core_data_filter_callback_001_poc_filtrar_con_callback_cobra():
     codigo = '''usar "datos"
 
@@ -90,13 +131,7 @@ resultado = filtrar(numeros, mayor_que_dos)
 imprimir(resultado)
 '''
 
-    try:
-        salida = runtime.ejecutar_codigo(codigo)
-    except (NameError, TypeError, RuntimeError) as exc:
-        pytest.xfail(
-            "CORE_DATA_FILTER_CALLBACK_001: el runtime GUI aún no resuelve "
-            f"o ejecuta callbacks Cobra en datos.filtrar ({exc})"
-        )
+    salida = runtime.ejecutar_codigo(codigo)
 
     assert "[3, 4]" in salida
 


### PR DESCRIPTION
### Motivation

- Permitir que funciones declaradas en el AST top-level sean resolubles como valores/callbacks aun cuando los optimizadores eliminen los nodos `NodoFuncion` ejecutables. 
- Hacer que la función de la librería estándar `filtrar` soporte iterables genéricos además de tablas de registros, y que preserve el tipo de elemento cuando corresponda.

### Description

- Añadido el atributo `self._funciones_declaradas_valor: dict[str, dict[str, object]]` en `InterpretadorCobra` para mantener una tabla de funciones top-level como valores separada del `Environment`.
- Implementada la rutina `_registrar_funciones_declaradas_como_valores(ast)` que recorre el AST top-level y registra las `NodoFuncion` usando `_construir_funcion` como representación de valor, y se invoca en `ejecutar_ast` antes de las optimizaciones.
- Modificado `_resolver_identificador` para caer de forma segura en `self._funciones_declaradas_valor` si el entorno levanta `NameError`, devolviendo la representación registrada de la función cuando exista.
- Generalizada `filtrar` en `src/pcobra/standard_library/datos.py` para aceptar `Iterable[Any]` y devolver `list[Any]`, intentando materializar tablas con `_materializar_tabla` pero aceptando también otros iterables mediante `list(tabla)`, y preservando elementos no-Mapping (antes siempre se convertían a `dict`).
- Añadidos tests en `tests/gui/test_gui_runtime_execution_scope.py` que verifican llamadas directas a funciones Cobra, asignación de función a variable, impresión de identificador de función y el flujo de `filtrar` con callback Cobra.

### Testing

- Ejecutado `pytest tests/gui/test_gui_runtime_execution_scope.py::test_core_data_filter_callback_001_llamada_directa_a_funcion_cobra` y el test pasó.
- Ejecutado `pytest tests/gui/test_gui_runtime_execution_scope.py::test_core_data_filter_callback_001_funcion_cobra_como_valor_callable` y el test pasó.
- Ejecutado `pytest tests/gui/test_gui_runtime_execution_scope.py::test_core_data_filter_callback_001_identificador_funcion_no_es_variable_inexistente` y el test pasó.
- Ejecutado `pytest tests/gui/test_gui_runtime_execution_scope.py::test_core_data_filter_callback_001_poc_filtrar_con_callback_cobra` y el test pasó.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a172a517c8327bae14cbf9af71000)