### PR TITLE
Ajustar mapear para iterables escalares

### DIFF
--- a/src/pcobra/standard_library/datos.py
+++ b/src/pcobra/standard_library/datos.py
@@ -559,12 +559,22 @@ def agregar(tabla: Iterable[Registro], fila: Registro) -> Tabla:
     return base
 
 
-def mapear(tabla: Iterable[Registro], transformacion: Callable[[Registro], Registro]) -> Tabla:
-    """Aplica ``transformacion`` por fila devolviendo una nueva tabla."""
+def mapear(tabla: Iterable[Any], transformacion: Callable[[Any], Any]) -> list[Any]:
+    """Aplica ``transformacion`` por fila devolviendo una nueva lista."""
 
     if not callable(transformacion):
         raise TypeError("transformacion debe ser callable")
-    return [dict(transformacion(dict(fila))) for fila in _materializar_tabla(tabla)]
+    try:
+        filas = _materializar_tabla(tabla)
+    except TypeError:
+        if isinstance(tabla, Mapping) or not isinstance(tabla, Iterable):
+            raise
+        filas = list(tabla)
+    resultado: list[Any] = []
+    for fila in filas:
+        valor = transformacion(dict(fila) if isinstance(fila, Mapping) else fila)
+        resultado.append(dict(valor) if isinstance(valor, Mapping) else valor)
+    return resultado
 
 
 def reducir(


### PR DESCRIPTION
### Motivation
- La implementación previa de `mapear` asumía siempre una tabla de registros y materializaba con `_materializar_tabla`, lo que rompía su uso con iterables escalares; se buscó igualar la estrategia ya usada por `filtrar` para soportar ambos casos.

### Description
- Modificado únicamente `src/pcobra/standard_library/datos.py::mapear` para aceptar `Iterable[Any]` y devolver `list[Any]` en lugar de `Tabla` cuando aplique.`
- Conservada la validación previa de `transformacion` con el mismo `TypeError("transformacion debe ser callable")`.
- Añadida la lógica de materialización: primero intentar `_materializar_tabla(tabla)` y, si lanza `TypeError` y la entrada es un `Iterable` no-`Mapping`, usar `list(tabla)` como fallback (mismo patrón que `filtrar`).
- Para cada fila se llama a `transformacion(dict(fila))` si la fila es `Mapping` (copia defensiva) o `transformacion(fila)` si no lo es; y para los resultados se agrega `dict(resultado)` si es `Mapping`, o el resultado tal cual si no lo es.
- Sólo se modificó `src/pcobra/standard_library/datos.py` (función `mapear`) y se creó el commit `Ajustar mapear para iterables escalares`.

### Testing
- Ejecuté comprobaciones unitarias focalizadas mediante un pequeño script con aserciones para `mapear` (tablas, escalares, copia defensiva y validación de callable), y todas las aserciones pasaron.
- Ejecuté `pytest` focalizado en las pruebas relacionadas con `datos` y contract tests relevantes: `tests/unit/test_standard_library_datos.py`, `tests/unit/test_datos_public_contract.py`, `tests/unit/test_usar.py::test_usar_datos_operaciones_basicas_agregar_mapear_filtrar` y `tests/integration/test_usar_public_contract_regression.py::test_usar_datos_incluye_filtrar_mapear_reducir`, resultando en 49 passed, 4 skipped.
- `git diff --check` y el commit de la modificación se realizaron correctamente.
- Nota: la ejecución completa de la suite (`python -m pytest -q -x`) falla en un test de CLI (`tests/cli/test_public_v2_commands_contract.py::test_public_v2_subcommands_match_contract_exactly`) por comandos públicos adicionales (`installer`, `hub`, `paquete`), lo que parece no estar relacionado con el cambio limitado a `mapear`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a1b8ba1b083279256cd93c900c9fb)