### PR TITLE
test: validar que `mapear` acepta listas de escalares

### DIFF
--- a/tests/unit/test_standard_library_datos.py
+++ b/tests/unit/test_standard_library_datos.py
@@ -134,6 +134,10 @@ def test_funciones_coleccion_basicas_y_bordes():
     assert longitud(tabla) == 3
 
 
+def test_mapear_acepta_lista_de_escalares():
+    assert mapear([1, 2, 3], lambda x: x * 2) == [2, 4, 6]
+
+
 def test_reducir_con_y_sin_acumulador_inicial():
     tabla = _tabla_base()
     total = reducir(tabla, lambda acc, fila: acc + int(fila["valor"]), 0)


### PR DESCRIPTION
### Motivation
- Asegurar que la función `mapear` acepta listas de escalares sin romper el contrato existente para tablas de registros.

### Description
- Se añadió el test `test_mapear_acepta_lista_de_escalares` a `tests/unit/test_standard_library_datos.py` que verifica `mapear([1, 2, 3], lambda x: x * 2) == [2, 4, 6]` y se mantuvo la aserción existente sobre tablas de registros en `test_funciones_coleccion_basicas_y_bordes`.

### Testing
- Se ejecutaron `python -m pytest tests/unit/test_standard_library_datos.py -k 'mapear_acepta_lista_de_escalares or funciones_coleccion_basicas_y_bordes'` (resultado: `2 passed, 42 deselected`) y `python -m pytest tests/unit/test_standard_library_datos.py` (resultado: `40 passed, 4 skipped`, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a1cd798b483279b7c34aaa79d1af2)