### PR TITLE
test: preserve mapear dict results

### DIFF
--- a/tests/unit/test_standard_library_datos.py
+++ b/tests/unit/test_standard_library_datos.py
@@ -138,6 +138,13 @@ def test_mapear_acepta_lista_de_escalares():
     assert mapear([1, 2, 3], lambda x: x * 2) == [2, 4, 6]
 
 
+def test_mapear_preserva_resultados_mapping_como_dict():
+    tabla = [{"valor": 2}]
+    resultado = mapear(tabla, lambda fila: {"valor": fila["valor"] * 3})
+    assert resultado == [{"valor": 6}]
+    assert isinstance(resultado[0], dict)
+
+
 def test_reducir_con_y_sin_acumulador_inicial():
     tabla = _tabla_base()
     total = reducir(tabla, lambda acc, fila: acc + int(fila["valor"]), 0)


### PR DESCRIPTION
### Motivation
- Asegurar que `mapear` sigue devolviendo registros como `dict` al transformar tablas de registros, sin romper el soporte añadido para listas de escalares.

### Description
- Añadido `test_mapear_preserva_resultados_mapping_como_dict` en `tests/unit/test_standard_library_datos.py` que verifica el contenido transformado y que el elemento resultante es instancia de `dict`.

### Testing
- Ejecutados `pytest tests/unit/test_standard_library_datos.py -k 'mapear'` y `pytest tests/unit/test_standard_library_datos.py`, ambos completaron correctamente (los tests relacionados pasaron).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a1dc3f5a08327bd1ece3f40ab0025)