### PR TITLE
test: add GUI runtime mapear callback contract

### DIFF
--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -136,6 +136,23 @@ imprimir(resultado)
     assert "[3, 4]" in salida
 
 
+def test_core_data_mapear_callback_contract_001_poc_mapear_con_callback_cobra():
+    codigo = '''usar "datos"
+
+func doble(n):
+    retorno n * 2
+fin
+
+numeros = [1, 2, 3]
+resultado = mapear(numeros, doble)
+imprimir(resultado)
+'''
+
+    salida = runtime.ejecutar_codigo(codigo)
+
+    assert "[2, 4, 6]" in salida
+
+
 def test_ejecutar_codigo_modulo_inexistente_falla_controladamente():
     with pytest.raises(PermissionError) as excinfo:
         runtime.ejecutar_codigo('usar "modulo_inexistente"')


### PR DESCRIPTION
### Motivation
- Añadir un test de contrato/regresión que valide que `mapear` acepta un callback definido en Cobra y produce la salida esperada en el runtime GUI.

### Description
- Se añadió `test_core_data_mapear_callback_contract_001_poc_mapear_con_callback_cobra` en `tests/gui/test_gui_runtime_execution_scope.py` junto al POC de `filtrar`, usando el helper `runtime.ejecutar_codigo` y sin introducir POC con diccionarios Cobra.

### Testing
- Se ejecutó `pytest tests/gui/test_gui_runtime_execution_scope.py -q` y todos los tests pasaron (`14 passed`) con un único warning de deprecación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a1ed191b883279dd9048425646f2c)