### PR TITLE
test: cover datos callbacks in GUI runtime

### DIFF
--- a/tests/core/test_usar_policy_nuevas_corelibs.py
+++ b/tests/core/test_usar_policy_nuevas_corelibs.py
@@ -133,6 +133,20 @@ def test_usar_datos_expone_filtrar_callable_sin_callback_cobra() -> None:
     assert callable(exports["longitud"])
 
 
+def test_corelibs_datos_mapear_permanece_wrapper_de_standard_library() -> None:
+    corelibs_datos = importlib.import_module("pcobra.corelibs.datos")
+    standard_datos = importlib.import_module("pcobra.standard_library.datos")
+
+    def doble(numero: int) -> int:
+        return numero * 2
+
+    assert corelibs_datos.mapear([1, 2, 3], doble) == [2, 4, 6]
+    assert corelibs_datos.mapear.__module__ == "pcobra.corelibs.datos"
+    assert corelibs_datos.mapear([1, 2, 3], doble) == standard_datos.mapear(
+        [1, 2, 3], doble
+    )
+
+
 def test_usar_datos_apunta_a_standard_library_y_loader_importa_nombre_correcto() -> None:
     ruta_relativa = REPL_COBRA_MODULE_INTERNAL_PATH_MAP["datos"]
 

--- a/tests/gui/test_gui_runtime_execution_scope.py
+++ b/tests/gui/test_gui_runtime_execution_scope.py
@@ -153,6 +153,27 @@ imprimir(resultado)
     assert "[2, 4, 6]" in salida
 
 
+def test_core_data_callbacks_mapear_y_filtrar_convivencia_en_gui_runtime():
+    codigo = '''usar "datos"
+
+func doble(n):
+    retorno n * 2
+fin
+
+func mayor_que_dos(n):
+    retorno n > 2
+fin
+
+imprimir(mapear([1, 2, 3], doble))
+imprimir(filtrar([1, 2, 3, 4], mayor_que_dos))
+'''
+
+    salida = runtime.ejecutar_codigo(codigo)
+
+    assert "[2, 4, 6]" in salida.splitlines()
+    assert "[3, 4]" in salida.splitlines()
+
+
 def test_ejecutar_codigo_modulo_inexistente_falla_controladamente():
     with pytest.raises(PermissionError) as excinfo:
         runtime.ejecutar_codigo('usar "modulo_inexistente"')


### PR DESCRIPTION
### Motivation
- Añadir cobertura de regresión que valide que `mapear` y `filtrar` aceptan callbacks definidos en Cobra cuando se usan desde el runtime GUI y que mantienen las salidas esperadas; además garantizar que la API de `corelibs` mantiene el wrapper hacia `standard_library`.

### Description
- Añadida la prueba `tests/gui/test_gui_runtime_execution_scope.py::test_core_data_callbacks_mapear_y_filtrar_convivencia_en_gui_runtime` que ejecuta `usar "datos"` y verifica que se imprimen `[2, 4, 6]` y `[3, 4]` cuando se pasan callbacks Cobra a `mapear` y `filtrar`.
- Añadida la prueba `tests/core/test_usar_policy_nuevas_corelibs.py::test_corelibs_datos_mapear_permanece_wrapper_de_standard_library` que importa `pcobra.corelibs.datos` y `pcobra.standard_library.datos` y verifica que `corelibs.datos.mapear` delega y produce el mismo resultado y que su `__module__` es `pcobra.corelibs.datos`.
- No se modificó código de lexer, parser, gramática, tokens, nodos AST, transpiladores ni lógica de runtime; solo se añadieron pruebas.

### Testing
- `python -m pytest tests/core -q` — OK (ejecución mostrada con pruebas verdes: 154 passed).
- `python -m pytest tests/gui/test_gui_runtime_execution_scope.py -q` — OK (archivo de pruebas ejecutado y la prueba nueva pasó; ejecución mostrada con 14 passed), aunque en este entorno pytest presentó un `MemoryError` al cerrar/formatar la sesión en alguna ejecución, los tests reportados pasaron.
- `python -m pytest tests/gui -q` — Parcialmente OK; la corrida mostró muchas pruebas pasadas (ej. 35 passed) pero en este entorno pytest falló internamente con `MemoryError` al formatear/reportar los resultados; las pruebas relevantes añadidas pasaron.
- `python -m pytest tests/unit/test_gui_runtime.py -q` — Las pruebas relacionadas se ejecutaron y pasaron cuando se lanzaron individualmente; en ejecuciones de suite completa en este entorno pytest arrojó `MemoryError` durante la finalización, sin indicar fallos de las pruebas en los casos ejecutados.

Nota: verificación interactiva local ejecutando `from pcobra.gui import runtime` y `runtime.ejecutar_codigo(...)` muestra las salidas `[2, 4, 6]` y `[3, 4]` para el fragmento probado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a204ff70c83278ba8f86577fc5640)