### PR TITLE
test: preserve dev-only CLI commands

### DIFF
--- a/tests/cli/test_public_v2_commands_contract.py
+++ b/tests/cli/test_public_v2_commands_contract.py
@@ -6,6 +6,26 @@ from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 from pcobra.cobra.cli.cli import AppConfig, CommandRegistry
 
 EXPECTED_PUBLIC_V2_COMMANDS = {"run", "build", "test", "mod", "repl"}
+EXPECTED_DEVELOPMENT_COMPAT_COMMANDS = {"installer", "paquete", "hub"}
+
+
+def test_app_config_v2_routes_keep_development_compat_commands() -> None:
+    routes = {
+        (route.module_path, route.class_name) for route in AppConfig.V2_COMMAND_ROUTES
+    }
+
+    assert (
+        "pcobra.cobra.cli.commands_v2.installer_cmd",
+        "InstallerCommandV2",
+    ) in routes
+    assert (
+        "pcobra.cobra.cli.commands.package_cmd",
+        "PaqueteCommand",
+    ) in routes
+    assert (
+        "pcobra.cobra.cli.commands.hub_cmd",
+        "HubCommand",
+    ) in routes
 
 
 def test_app_config_v2_routes_include_repl_command_v2() -> None:
@@ -39,6 +59,20 @@ def test_public_v2_subcommands_match_contract_exactly() -> None:
     )
 
     assert set(commands) == EXPECTED_PUBLIC_V2_COMMANDS
+
+
+def test_development_v2_subcommands_keep_compat_commands() -> None:
+    registry = CommandRegistry()
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+
+    commands = registry.register_base_commands(
+        subparsers,
+        ui="v2",
+        profile="development",
+    )
+
+    assert EXPECTED_DEVELOPMENT_COMPAT_COMMANDS.issubset(commands)
 
 
 def test_cli_public_backend_policy_is_exact() -> None:

--- a/tests/unit/test_cli_paquete.py
+++ b/tests/unit/test_cli_paquete.py
@@ -3,8 +3,15 @@ from io import StringIO
 import zipfile
 from unittest.mock import patch
 
+import pytest
+
 from cobra.cli.cli import main
 from cobra.cli.commands import modules_cmd
+
+
+@pytest.fixture(autouse=True)
+def _perfil_cli_desarrollo(monkeypatch):
+    monkeypatch.setenv("COBRA_CLI_COMMAND_PROFILE", "development")
 
 
 def _crear_fuente(tmp_path):

--- a/tests/unit/test_cobrahub_cache.py
+++ b/tests/unit/test_cobrahub_cache.py
@@ -3,6 +3,8 @@ from unittest.mock import patch
 import re
 from pathlib import Path
 
+import pytest
+
 from pcobra.cobra.cli.cobrahub_packages import (
     limpiar_cache,
     listar_cache,
@@ -10,6 +12,11 @@ from pcobra.cobra.cli.cobrahub_packages import (
 )
 from pcobra.cobra.cli.commands.hub_cmd import HubCommand
 from pcobra.cobra.packaging import construir_paquete, crear_paquete
+
+
+@pytest.fixture(autouse=True)
+def _perfil_cli_desarrollo(monkeypatch):
+    monkeypatch.setenv("COBRA_CLI_COMMAND_PROFILE", "development")
 
 
 def _crear_paquete_valido(tmp_path: Path, nombre: str = "demo") -> Path:


### PR DESCRIPTION
### Motivation
- Asegurar que `AppConfig.V2_COMMAND_ROUTES` mantiene las rutas de compatibilidad de desarrollo para `InstallerCommandV2`, `PaqueteCommand` y `HubCommand` sin exponerlas en el perfil público.
- Confiar en `filter_commands_for_profile()` para que el perfil `public` muestre únicamente la superficie pública oficial y obligar a las pruebas que invocan comandos internos a declarar explícitamente el perfil `development`.

### Description
- Añadí un test contractual que verifica que `AppConfig.V2_COMMAND_ROUTES` incluye `InstallerCommandV2`, `PaqueteCommand` y `HubCommand` y que las rutas V2 mantienen `repl` como comando público (`tests/cli/test_public_v2_commands_contract.py`).
- Añadí un test que valida que con `profile="development"` los comandos `installer`, `paquete` y `hub` están disponibles en el registro V2 (`tests/cli/test_public_v2_commands_contract.py`).
- Actualicé tests que invocaban directamente `paquete` y `hub` para fijar el perfil de CLI a `development` mediante un `pytest` fixture `autouse` que define `COBRA_CLI_COMMAND_PROFILE=development` (`tests/unit/test_cli_paquete.py`, `tests/unit/test_cobrahub_cache.py`).

### Testing
- Ejecuté `pytest tests/cli/test_public_v2_commands_contract.py tests/unit/test_public_command_policy.py tests/unit/test_cli_paquete.py tests/unit/test_cobrahub_cache.py -q` y todos los tests ejecutados pasaron (33 passed, 1 warning).
- Los cambios son pruebas/ajustes de test y no modifican la lógica de `filter_commands_for_profile()` ni eliminan ningún módulo o comando.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a2691f91c8327a555fb4786793383)