### PR TITLE
Enforce strict public CLI help contract

### DIFF
--- a/tests/integration/test_cli_ayuda.py
+++ b/tests/integration/test_cli_ayuda.py
@@ -15,6 +15,9 @@ def _env_without_sqlite_db_key() -> dict[str, str]:
     env = os.environ.copy()
     env.pop("SQLITE_DB_KEY", None)
     env.pop("COBRA_DEV_MODE", None)
+    env.pop("COBRA_CLI_COMMAND_PROFILE", None)
+    env.pop("COBRA_INTERNAL_ENABLE_LEGACY_CLI", None)
+    env.pop("COBRA_INTERNAL_LEGACY_TARGETS", None)
     return env
 
 
@@ -92,9 +95,15 @@ def test_cobra_help_snapshot_publico_no_expone_comandos_legacy(monkeypatch):
             main(["--help"])
         assert exc.value.code == 0
 
-    normalized_stdout = " ".join(out.getvalue().split())
+    stdout = out.getvalue()
+    normalized_stdout = " ".join(stdout.split())
     expected_snapshot = (
         Path(__file__).parent / "golden" / "cli_help_public_snapshot.golden"
     ).read_text(encoding="utf-8")
     assert " ".join(normalized_stdout.split()) == " ".join(expected_snapshot.split())
-    assert "\n  legacy " not in result.stdout.lower()
+    lower_stdout = stdout.lower()
+    for command in ("run", "build", "test", "mod", "repl"):
+        assert f" {command} " in f" {lower_stdout} "
+    for command in ("installer", "paquete", "hub"):
+        assert f" {command} " not in f" {lower_stdout} "
+    assert "\n  legacy " not in lower_stdout

--- a/tests/integration/test_cli_ui_v2.py
+++ b/tests/integration/test_cli_ui_v2.py
@@ -36,10 +36,14 @@ def test_cli_ui_v2_help_snapshot_publico_no_expone_legacy():
     )
     expected_snapshot = _leer_snapshot_texto(expected_snapshot)
     assert _normalizar(texto) == _normalizar(expected_snapshot.lower())
+    for command in ("run", "build", "test", "mod", "repl"):
+        assert f" {command} " in f" {texto} "
+    for command in ("installer", "paquete", "hub"):
+        assert f" {command} " not in f" {texto} "
     assert "\n  legacy " not in texto
 
 
-def test_cli_ui_v2_help_muestra_legacy_solo_con_flag_interno(monkeypatch):
+def test_cli_ui_v2_help_publico_no_expone_comandos_internos_con_flag_interno(monkeypatch):
     monkeypatch.setenv("COBRA_INTERNAL_ENABLE_LEGACY_CLI", "1")
     for module_name in (
         "cobra.cli.commands_v2",
@@ -52,7 +56,7 @@ def test_cli_ui_v2_help_muestra_legacy_solo_con_flag_interno(monkeypatch):
     registry = cli_reloaded.CommandRegistry()
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command")
-    commands = registry.register_base_commands(subparsers, ui="v2", profile="development")
+    commands = registry.register_base_commands(subparsers, ui="v2", profile="public")
     assert "legacy" not in commands
     assert set(commands) == {"run", "build", "test", "mod", "repl"}
 


### PR DESCRIPTION
### Motivation
- Asegurar que las pruebas de ayuda pública del CLI validen de forma estricta el contrato público de comandos y no se vean alteradas por variables de entorno internas. 
- Evitar que comandos internos/legacy como `installer`, `paquete` y `hub` aparezcan en el help público ni en los snapshots asociados.

### Description
- Se actualizaron `tests/integration/test_cli_ayuda.py` para limpiar variables de entorno internas (`COBRA_CLI_COMMAND_PROFILE`, `COBRA_INTERNAL_ENABLE_LEGACY_CLI`, `COBRA_INTERNAL_LEGACY_TARGETS`) y para validar explícitamente que sólo `run`, `build`, `test`, `mod`, `repl` aparecen en el help público y que `installer`, `paquete` y `hub` no aparecen. 
- Se añadieron comprobaciones equivalentes en `tests/integration/test_cli_ui_v2.py` para reforzar las mismas aserciones sobre el snapshot de UI v2 y la ausencia de comandos internos. 
- Se ajustó una prueba que registraba comandos con flag interno para que verifique explícitamente el perfil `public` y mantenga el conjunto estricto `{"run","build","test","mod","repl"}`. 
- Se verificó que `tests/integration/golden/cli_ui_v2_help_public.golden` ya estaba sincronizado con `tests/integration/golden/cli_help_public_snapshot.golden`, por lo que no fue necesario modificar los golden snapshots.

### Testing
- Ejecutado: `python -m pytest tests/integration/test_cli_public_help_contract.py tests/integration/test_cli_ayuda.py tests/integration/test_cli_ui_v2.py`.
- Resultado: las suites afectadas pasaron con `14 passed, 1 skipped, 1 warning` y sin fallos en las aserciones introducidas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a27b6aff483278fa2abbe2eaadb22)