### PR TITLE
Ocultar --target en el help de `cobra build` manteniendo el parseo

### DIFF
--- a/src/pcobra/cobra/cli/commands_v2/build_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/build_cmd.py
@@ -36,7 +36,9 @@ class BuildCommandV2(BaseCommand):
                 "Build an installer using the same options as 'cobra installer build'"
             ),
         )
-        register_installer_build_arguments(parser, include_project_path=False)
+        register_installer_build_arguments(
+            parser, include_project_path=False, hide_target_help=True
+        )
         parser.set_defaults(cmd=self)
         return parser
 

--- a/src/pcobra/cobra/cli/commands_v2/installer_cmd.py
+++ b/src/pcobra/cobra/cli/commands_v2/installer_cmd.py
@@ -46,7 +46,10 @@ class InstallerCommandV2(BaseCommand):
 
 
 def register_installer_build_arguments(
-    parser: argparse.ArgumentParser, *, include_project_path: bool = True
+    parser: argparse.ArgumentParser,
+    *,
+    include_project_path: bool = True,
+    hide_target_help: bool = False,
 ) -> None:
     """Registra las opciones canónicas de ``installer build`` en un parser."""
 
@@ -57,10 +60,15 @@ def register_installer_build_arguments(
             default=".",
             help="Ruta del proyecto Cobra a empaquetar",
         )
+    target_help = (
+        argparse.SUPPRESS
+        if hide_target_help
+        else "Sistema operativo objetivo: current, windows, linux o macos"
+    )
     parser.add_argument(
         "--target",
         default="current",
-        help="Sistema operativo objetivo: current, windows, linux o macos",
+        help=target_help,
     )
     parser.add_argument("--mode", choices=("onefile", "onedir"), default="onedir")
     parser.add_argument("--name", dest="name")

--- a/tests/unit/test_cli_v2_command_contract.py
+++ b/tests/unit/test_cli_v2_command_contract.py
@@ -166,6 +166,7 @@ def test_build_v2_help_expone_solo_alias_installer_y_no_flags_backend_legacy():
     assert "--tipo" not in help_text
     assert "--backend" not in help_text
     assert "--installer" in help_text
+    assert "--target" not in help_text
     assert "--tipos" not in help_text
 
 
@@ -192,8 +193,13 @@ def test_build_v2_parser_publico_registra_file_y_alias_installer():
     assert alias_args.installer is True
     assert alias_args.file == "."
 
-    with pytest.raises(SystemExit):
-        parser.parse_args(["programa.co", "--target", "python"])
+    alias_args_with_target = parser.parse_args(
+        ["--installer", ".", "--target", "linux"]
+    )
+    assert alias_args_with_target.installer is True
+    assert alias_args_with_target.file == "."
+    assert alias_args_with_target.target == "linux"
+    assert "--target" not in parser.format_help().lower()
 
 
 def test_run_v2_valida_seguridad_por_ruta_binding(monkeypatch):


### PR DESCRIPTION
### Motivation
- Evitar que la opción `--target` aparezca en el help público de `cobra build` mientras se mantiene su capacidad de parseo cuando se usa el alias `--installer`.
- Reutilizar el registrador de argumentos de `installer build` sin exponer flags internos en la interfaz pública v2.

### Description
- Añadido el parámetro opcional `hide_target_help: bool = False` en `register_installer_build_arguments()` para controlar si la ayuda de `--target` se muestra o se suprime.  
- Cuando `hide_target_help=True` la ayuda de `--target` se registra con `argparse.SUPPRESS`, y cuando es `False` se usa el texto de ayuda original.  
- Actualizado `BuildCommandV2.register_subparser()` para llamar a `register_installer_build_arguments(..., include_project_path=False, hide_target_help=True)` y así ocultar `--target` en `cobra build --help` pero permitir `cobra build --installer . --target ...`.  
- Ajustado el test de contrato v2 (`tests/unit/test_cli_v2_command_contract.py`) para verificar que `--target` no aparece en el help público de `build` y que `--installer` sigue pudiendo parsear `--target`.

### Testing
- Ejecutado `pytest -q tests/unit/test_cli_installer_cmd.py tests/unit/test_cli_v2_command_contract.py::test_build_v2_help_expone_solo_alias_installer_y_no_flags_backend_legacy tests/unit/test_cli_v2_command_contract.py::test_build_v2_parser_publico_registra_file_y_alias_installer`, y las pruebas objetivo relacionadas con este cambio pasaron (12 tests pasados).  
- Ejecutado `pytest -q tests/unit/test_cli_v2_command_contract.py` y se observaron fallos previos/externos no relacionados con la supresión de ayuda (errores de importación para algunos monkeypatch targets, falta de archivo de ejemplo y otros asuntos de contrato existentes).  
- Las modificaciones son limitadas a `src/pcobra/cobra/cli/commands_v2/installer_cmd.py`, `src/pcobra/cobra/cli/commands_v2/build_cmd.py` y la expectativa en `tests/unit/test_cli_v2_command_contract.py` para reflejar el comportamiento oculto de la ayuda de `--target`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a2952d0d48327b6d8e298ae0c41ff)