### PR TITLE
test: tighten public CLI legacy command contract

### DIFF
--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -114,4 +114,8 @@ def test_cli_help_public_contract_muestra_warning_migracion_en_comando_legacy():
     assert result.returncode != 0
     lower_output = result.stderr.lower() + result.stdout.lower()
     assert "invalid choice: 'compilar'" in lower_output
-    assert "choose from run, build, test, mod, repl" in lower_output
+    choices_message = lower_output.split("invalid choice: 'compilar'", 1)[1]
+    for command in ("run", "build", "test", "mod", "repl"):
+        assert command in choices_message
+    for command in ("installer", "paquete", "hub"):
+        assert command not in choices_message


### PR DESCRIPTION
### Motivation
- Hacer la aserción del test más robusta frente a variaciones en el texto exacto y comprobar explícitamente el contrato público estricto de comandos (solo `run`, `build`, `test`, `mod`, `repl`).

### Description
- Actualiza `tests/integration/test_cli_public_help_contract.py` para que `test_cli_help_public_contract_muestra_warning_migracion_en_comando_legacy()` verifique primero que aparece `invalid choice: 'compilar'` y luego extraiga el mensaje de choices para comprobar que cada comando público permitido (`run`, `build`, `test`, `mod`, `repl`) está presente.
- Añade una comprobación explícita de que `installer`, `paquete` y `hub` no aparecen en el mensaje de choices públicos.
- No se modificó la lógica del CLI ni `CustomArgumentParser`, porque el texto esperado ya contiene la cadena con comillas y no fue necesario tocar la normalización de argparse.

### Testing
- Ejecutado el test específico con `python -m pytest tests/integration/test_cli_public_help_contract.py::test_cli_help_public_contract_muestra_warning_migracion_en_comando_legacy -q` y pasó correctamente.
- Ejecutado el archivo completo con `python -m pytest tests/integration/test_cli_public_help_contract.py -q` y todos los tests en ese archivo pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a2a9f7e948327b600d0fb3cf22784)