### PR TITLE
Guardia pública: restringir superficie de comandos según PUBLIC_COMMANDS

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -41,6 +41,7 @@ from pcobra.cobra.cli.public_command_policy import (
     COMMAND_VISIBILITY_MATRIX_MARKDOWN,
     PROFILE_DEVELOPMENT,
     PROFILE_PUBLIC,
+    PUBLIC_COMMANDS,
     PUBLIC_COMMANDS_CONTRACT,
     filter_commands_for_profile,
     filter_legacy_commands_for_profile,
@@ -385,6 +386,7 @@ class CliApplication:
             ui=selected_ui,
             profile=command_profile,
         )
+        self._enforce_public_startup_guard()
         if command_profile != PROFILE_PUBLIC:
             menu_parser = self._subparsers.add_parser("menu", help=_("Modo interactivo"))
             menu_parser.set_defaults(cmd="menu")
@@ -712,13 +714,30 @@ class CliApplication:
         return self._normalizar_flags_sesion(parsed)
 
     def _enforce_public_startup_guard(self) -> None:
-        """Bloquea exposición accidental de rutas legacy en perfil público."""
+        """Bloquea exposición accidental de comandos no públicos ya registrados."""
         command_profile = resolve_command_profile()
         selected_ui = getattr(self, "_selected_ui", "v2")
-        if command_profile != PROFILE_PUBLIC:
+        if command_profile != PROFILE_PUBLIC or selected_ui != "v2":
             return
 
-        blocked_routes: list[str] = []
+        # Guardia estática mínima: en este punto la lista efectiva solo existe
+        # después de `CommandRegistry.register_base_commands()`.  Antes de ese
+        # registro no inferimos rutas desde imports/clases para evitar lógica
+        # frágil; la validación fuerte permanece centrada en el registry.
+        registered_commands = (
+            self.command_registry.commands
+            if self.command_registry is not None
+            else {}
+        )
+        if not registered_commands:
+            return
+
+        public_commands = {name.strip().lower() for name in PUBLIC_COMMANDS}
+        blocked_routes = sorted(
+            name
+            for name in registered_commands
+            if name.strip().lower() not in public_commands
+        )
 
         if not blocked_routes:
             return

--- a/tests/integration/test_cli_ui_v2.py
+++ b/tests/integration/test_cli_ui_v2.py
@@ -38,8 +38,8 @@ def test_cli_ui_v2_help_snapshot_publico_no_expone_legacy():
     assert _normalizar(texto) == _normalizar(expected_snapshot.lower())
     for command in ("run", "build", "test", "mod", "repl"):
         assert f" {command} " in f" {texto} "
-    for command in ("installer", "paquete", "hub"):
-        assert f" {command} " not in f" {texto} "
+    for command in ("installer", "paquete", "hub", "compilar", "ejecutar", "interactive"):
+        assert f"\n  {command} " not in texto
     assert "\n  legacy " not in texto
 
 
@@ -57,7 +57,8 @@ def test_cli_ui_v2_help_publico_no_expone_comandos_internos_con_flag_interno(mon
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command")
     commands = registry.register_base_commands(subparsers, ui="v2", profile="public")
-    assert "legacy" not in commands
+    for command in ("installer", "paquete", "hub", "compilar", "ejecutar", "interactive", "legacy"):
+        assert command not in commands
     assert set(commands) == {"run", "build", "test", "mod", "repl"}
 
 


### PR DESCRIPTION
### Motivation
- Evitar la exposición accidental de rutas/comandos no públicos cuando la CLI se ejecuta en el perfil público (UI v2). 
- Usar `PUBLIC_COMMANDS` como fuente de verdad para la superficie pública en lugar de inferir rutas fragilmente desde imports. 
- Mantener la comprobación mínima y no intrusiva para no romper comportamientos ni pruebas existentes, y desactivar la guardia en `PROFILE_DEVELOPMENT`.

### Description
- Importa `PUBLIC_COMMANDS` desde `src/pcobra/cobra/cli/public_command_policy.py` y usa esa tupla como lista de comandos públicos permitidos. 
- Ejecuta `_enforce_public_startup_guard()` justo después de `CommandRegistry.register_base_commands()` para validar la lista efectiva de comandos ya registrados en UI `v2`. 
- Implementa una guardia estática mínima que: no corre fuera de `PROFILE_PUBLIC` ni si la UI no es `v2`; no intenta inferir rutas si aún no hay comandos registrados; compara los nombres registrados (normalizados a minúsculas) contra `PUBLIC_COMMANDS` y lanza `RuntimeError` si hay comandos no públicos expuestos. 
- Refuerza el test de integración `tests/integration/test_cli_ui_v2.py` para asegurar que la ayuda pública y el registro de comandos no incluyan `installer`, `paquete`, `hub` ni rutas legacy como `compilar`, `ejecutar`, `interactive` o `legacy`.

### Testing
- `pytest tests/integration/test_cli_ui_v2.py -q` — pasó con éxito. 
- `pytest tests/integration/test_cli_ayuda.py::test_cobra_help_snapshot_publico_no_expone_comandos_legacy -q` — pasó con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a2bc022088327b79a775c5047b3a8)