### PR TITLE
Ensure public CLI profile excludes extended commands

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -194,9 +194,12 @@ class CommandRegistry:
             raise
 
     def _resolve_v2_command_routes(self, profile: str) -> List[CommandClassRoute]:
-        # Las rutas compat/de desarrollo permanecen en AppConfig.V2_COMMAND_ROUTES.
-        # La exposición pública se decide en register_base_commands() con
-        # PUBLIC_COMMANDS, después de construir los comandos y conocer sus names.
+        # Las rutas extendidas/compatibles permanecen declaradas en
+        # AppConfig.V2_COMMAND_ROUTES para el perfil de desarrollo. En el perfil
+        # público filtramos antes de construir/registrar subparsers para que
+        # comandos como installer, paquete y hub nunca lleguen a
+        # subparsers.choices ni a self.commands.
+        normalized_profile = str(profile).strip().lower() or PROFILE_PUBLIC
         if AppConfig.V2_COMMAND_CLASSES:
             routes = [
                 CommandClassRoute(cls.__module__, cls.__name__)
@@ -204,7 +207,18 @@ class CommandRegistry:
             ]
         else:
             routes = list(AppConfig.V2_COMMAND_ROUTES)
-        return routes
+
+        if normalized_profile != PROFILE_PUBLIC or AppConfig.V2_COMMAND_CLASSES:
+            return routes
+
+        public_v2_command_classes = {
+            "RunCommandV2",
+            "BuildCommandV2",
+            "TestCommandV2",
+            "ModCommandV2",
+            "ReplCommandV2",
+        }
+        return [route for route in routes if route.class_name in public_v2_command_classes]
 
     def _resolve_v1_command_routes(self) -> List[CommandClassRoute]:
         """Carga comandos v1 y difiere imports GUI/opcionales hasta el registro."""
@@ -394,7 +408,7 @@ class CliApplication:
             ui=selected_ui,
             profile=command_profile,
         )
-        self._enforce_public_startup_guard()
+        self._enforce_public_startup_guard(command_profile=command_profile)
         if command_profile != PROFILE_PUBLIC:
             menu_parser = self._subparsers.add_parser("menu", help=_("Modo interactivo"))
             menu_parser.set_defaults(cmd="menu")
@@ -721,9 +735,9 @@ class CliApplication:
         parsed = self.parser.parse_args(argv)
         return self._normalizar_flags_sesion(parsed)
 
-    def _enforce_public_startup_guard(self) -> None:
+    def _enforce_public_startup_guard(self, *, command_profile: str | None = None) -> None:
         """Bloquea exposición accidental de comandos no públicos ya registrados."""
-        command_profile = resolve_command_profile()
+        command_profile = command_profile or resolve_command_profile()
         selected_ui = getattr(self, "_selected_ui", "v2")
         if command_profile != PROFILE_PUBLIC or selected_ui != "v2":
             return

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -50,6 +50,26 @@ def test_cli_ui_v2_registra_repl_oficial_y_no_alias_interactive_legacy():
     assert "interactive" not in commands
 
 
+
+
+def test_cli_public_profile_does_not_register_extended_choices(monkeypatch):
+    monkeypatch.delenv("COBRA_DEV_MODE", raising=False)
+    monkeypatch.delenv("COBRA_CLI_COMMAND_PROFILE", raising=False)
+
+    app = cli_module.CliApplication()
+    app.initialize()
+    app._ensure_command_structure()
+
+    commands = set(app.command_registry.commands)
+    choices = set(app._subparsers.choices)
+
+    assert commands == set(PUBLIC_COMMANDS)
+    assert choices == set(PUBLIC_COMMANDS)
+    for command in ("installer", "paquete", "hub"):
+        assert command not in commands
+        assert command not in choices
+
+
 def test_cli_help_public_contract_snapshot():
     repo_root = Path(__file__).resolve().parents[2]
     result = subprocess.run(


### PR DESCRIPTION
### Motivation
- Evitar que comandos extendidos/legacy (`installer`, `paquete`, `hub`) lleguen a la estructura pública de la CLI por defecto y aparezcan en `subparsers.choices` o en `command_registry.commands` cuando no hay variables de entorno de desarrollo.
- Mantener el comportamiento por defecto seguro y alineado con el contrato público `PROFILE_PUBLIC` sin requerir `COBRA_DEV_MODE` ni `COBRA_CLI_COMMAND_PROFILE`.

### Description
- Filtrado temprano de rutas V2 en `CommandRegistry._resolve_v2_command_routes()` para que, cuando `profile == "public"`, solo se devuelvan rutas clase-oficiales públicas (Run/Build/Test/Mod/Repl) y no las rutas extendidas/compatibles. (modificado: `src/pcobra/cobra/cli/cli.py`).
- Reutiliza el `command_profile` resuelto al inicializar la estructura de comandos y lo pasa a la guardia pública para evitar resolverlo dos veces y aplicar la validación con el perfil correcto. (modificado: `src/pcobra/cobra/cli/cli.py`).
- Añadida prueba de regresión `test_cli_public_profile_does_not_register_extended_choices` que verifica en el entorno público por defecto (sin `COBRA_DEV_MODE` ni `COBRA_CLI_COMMAND_PROFILE`) que tanto `command_registry.commands` como `app._subparsers.choices` contienen únicamente `PUBLIC_COMMANDS` y excluyen `installer`, `paquete` y `hub`. (modificado: `tests/integration/test_cli_public_help_contract.py`).
- Cambios limitados a la capa de CLI y tests, sin tocar Lexer, Parser, AST, Core ni runtime.

### Testing
- Ejecutado: `pytest -q tests/integration/test_cli_public_help_contract.py tests/integration/test_cli_ui_v2.py tests/integration/test_cli_ayuda.py tests/unit/test_public_command_policy.py` y la suite objetivo pasó con éxito (20 passed, 1 skipped, 1 warning). 
- Las snapshots referenciadas `tests/integration/golden/cli_ui_v2_help_public.golden` y `tests/integration/golden/cli_help_public_snapshot.golden` fueron verificadas por las pruebas y coinciden con la salida esperada.
- Se comprobó que `subparsers.choices` y `command_registry.commands` no contienen los comandos extendidos en el perfil público por defecto.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a2ff64b18832791eef687ccbd94c2)