### PR TITLE
test(cli): cover hidden build installer target

### DIFF
--- a/tests/unit/test_build_installer_help.py
+++ b/tests/unit/test_build_installer_help.py
@@ -1,0 +1,34 @@
+import pytest
+
+from pcobra.cobra.cli.cli import CliApplication
+
+
+def test_build_installer_target_is_hidden_from_public_help(capsys):
+    app = CliApplication()
+    app.initialize()
+
+    with pytest.raises(SystemExit) as exc_info:
+        app._parse_arguments(["build", "--help"])
+
+    assert exc_info.value.code == 0
+    help_output = capsys.readouterr().out
+    assert "--target" not in help_output
+    assert "--installer" in help_output
+
+
+def test_build_installer_still_accepts_hidden_target_option():
+    app = CliApplication()
+    app.initialize()
+
+    args = app._parse_arguments([
+        "build",
+        "--installer",
+        ".",
+        "--target",
+        "current",
+    ])
+
+    assert args.command == "build"
+    assert args.installer is True
+    assert args.file == "."
+    assert args.target == "current"


### PR DESCRIPTION
### Motivation
- Garantizar que la opción `--target` quede oculta del help público de `cobra build` pero siga presente en el parser para permitir `cobra build --installer . --target current`.

### Description
- Se añadió `tests/unit/test_build_installer_help.py` con dos tests que verifican que `--target` no aparece en `cobra build --help` y que `--target` sigue siendo aceptado con `--installer`.
- Se inspeccionó y no se modificó la llamada existente `register_installer_build_arguments(parser, include_project_path=False, hide_target_help=True)` en `build_cmd.py` ni la implementación en `installer_cmd.py` que usa `argparse.SUPPRESS` para ocultar el help.

### Testing
- Ejecutado `pytest -q tests/unit/test_build_installer_help.py` y los tests pasaron (2 passed, 1 warning).
- Se comprobó manualmente `python -m pcobra.cobra.cli.cli build --help` y `--target` no aparece en la salida, y se verificó que el parser acepta `--target current` cuando se usa `--installer`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a316d87b48327a53c1bfb1843ba4d)