### PR TITLE
test: lock public CLI invalid choices

### DIFF
--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -48,8 +49,6 @@ def test_cli_ui_v2_registra_repl_oficial_y_no_alias_interactive_legacy():
     assert "repl" in commands
     assert commands["repl"].__class__.__name__ == "ReplCommandV2"
     assert "interactive" not in commands
-
-
 
 
 def test_cli_public_profile_does_not_register_extended_choices(monkeypatch):
@@ -115,10 +114,27 @@ def test_cli_build_help_public_contract_no_expone_flags_backend():
     assert "--tipos" not in output
 
 
-
-
-
-
+def test_cli_public_invalid_extended_commands_do_not_appear_as_choices():
+    repo_root = Path(__file__).resolve().parents[2]
+    for legacy_command in ("installer", "paquete", "hub"):
+        result = subprocess.run(
+            [sys.executable, "-m", "cobra.cli.cli", legacy_command, "--help"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=str(repo_root),
+            env=_public_env(),
+        )
+        assert result.returncode != 0
+        lower_output = result.stderr.lower() + result.stdout.lower()
+        assert f"invalid choice: '{legacy_command}'" in lower_output
+        match = re.search(r"choose from ([^)]+)\)", lower_output)
+        assert match is not None
+        choices_message = match.group(1)
+        for command in PUBLIC_COMMANDS:
+            assert command in choices_message
+        for command in ("installer", "paquete", "hub"):
+            assert command not in choices_message
 
 
 def test_cli_help_public_contract_muestra_warning_migracion_en_comando_legacy():


### PR DESCRIPTION
### Motivation
- Asegurar que, en el perfil público, las opciones que muestra `argparse` provienen únicamente de `PUBLIC_COMMANDS` y que comandos extendidos/compatibles como `installer`, `paquete` y `hub` no aparecen en el mensaje de `choose from` cuando se invocan como tokens inválidos.

### Description
- Añadido el test `test_cli_public_invalid_extended_commands_do_not_appear_as_choices` en `tests/integration/test_cli_public_help_contract.py` que invoca `cobra.cli.cli` por `subprocess` con cada comando legacy y valida que `argparse` marque el token como `invalid choice` y que el bloque `choose from (...)` contiene solo los comandos en `PUBLIC_COMMANDS` y excluye `installer`, `paquete`, y `hub`.
- Se añadió la importación de `re` en el archivo de tests para extraer la lista de choices desde la salida de `argparse`.

### Testing
- Ejecutado `python -m pytest tests/integration/test_cli_public_help_contract.py -q` y el conjunto de pruebas del archivo completó correctamente con `8 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a32d56eb483278d2170b4b085c3d5)