### PR TITLE
Aclarar política de visibilidad de comandos CLI

### DIFF
--- a/src/pcobra/cobra/cli/public_command_policy.py
+++ b/src/pcobra/cobra/cli/public_command_policy.py
@@ -24,8 +24,8 @@ INTERNAL_COMMANDS: tuple[str, ...] = (
 COMMAND_VISIBILITY_MATRIX_MARKDOWN = """| Clase | Comandos |
 |---|---|
 | Públicos (UI v2) | run, build, test, mod, repl |
-| Extendidos/compatibles de desarrollo | installer, paquete |
-| Internos (UI v2 / development) | legacy, debug, devops, hub |
+| Desarrollo (visibles solo con perfil `development`) | installer, paquete, hub |
+| Internos (UI v2 / development) | legacy, debug, devops |
 | Legacy públicos (UI v1) | *(ninguno; reservado a `development`)* |
 | Legacy internos (UI v1) | *(ninguno)* |
 | Legacy obsoletos (UI v1) | *(ninguno)* |
@@ -56,7 +56,11 @@ def resolve_command_profile(default: str = PROFILE_PUBLIC) -> str:
 
 
 def filter_commands_for_profile(command_names: Iterable[str], profile: str) -> set[str]:
-    """Devuelve el subconjunto de comandos visibles para `profile`."""
+    """Devuelve comandos visibles para `profile`.
+
+    - `public`: solo la intersección entre `command_names` y `PUBLIC_COMMANDS`.
+    - `development`: todos los comandos disponibles recibidos en `command_names`.
+    """
 
     normalized_profile = str(profile).strip().lower() or PROFILE_PUBLIC
     names = {name.strip().lower() for name in command_names}

--- a/tests/unit/test_public_command_policy.py
+++ b/tests/unit/test_public_command_policy.py
@@ -27,7 +27,18 @@ def test_filter_commands_publico_permite_solo_superficie_v2_publica():
 
 
 def test_filter_commands_development_permite_toda_superficie_v2():
-    comandos = ("run", "build", "test", "mod", "repl", "legacy", "debug")
+    comandos = (
+        "run",
+        "build",
+        "test",
+        "mod",
+        "repl",
+        "legacy",
+        "debug",
+        "installer",
+        "paquete",
+        "hub",
+    )
     visibles = filter_commands_for_profile(comandos, PROFILE_DEVELOPMENT)
     assert visibles == set(comandos)
 


### PR DESCRIPTION
### Motivation
- Mantener el contrato público de comandos intacto y dejar claro qué comandos solo deben estar visibles en el perfil de desarrollo. 
- Evitar ambigüedades en la documentación para que `filter_commands_for_profile` tenga un comportamiento explícito y verificable.

### Description
- Se mantiene `PUBLIC_COMMANDS_CONTRACT` exactamente como `("run", "build", "test", "mod", "repl")` sin cambios. 
- Se ajustó `COMMAND_VISIBILITY_MATRIX_MARKDOWN` para indicar que `installer`, `paquete` y `hub` son visibles solo con el perfil `development` y mover `hub` a esa categoría. 
- Se clarificó el docstring de `filter_commands_for_profile` explicando que con `public` devuelve la intersección con `PUBLIC_COMMANDS` y con `development` devuelve todos los comandos recibidos. 
- Se actualizó la prueba unitaria de `development` para incluir `installer`, `paquete` y `hub` en el conjunto de comandos esperados.

### Testing
- Se ejecutó `python -m pytest tests/unit/test_public_command_policy.py` y todas las pruebas unitarias del archivo pasaron (`5 passed, 1 warning`).
- Las modificaciones se limitaron a `src/pcobra/cobra/cli/public_command_policy.py` y `tests/unit/test_public_command_policy.py` y no cambiaron el contrato público ni la lógica de filtrado existente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a345ce84c8327925c0d45fdccd8c9)