### PR TITLE
Separar comandos visibles y registrados en CLI pública

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -44,9 +44,12 @@ from pcobra.cobra.cli.public_command_policy import (
     PROFILE_PUBLIC,
     PUBLIC_COMMANDS,
     PUBLIC_COMMANDS_CONTRACT,
-    filter_commands_for_profile,
+    PUBLIC_V2_HIDDEN_COMPAT_COMMANDS,
     filter_legacy_commands_for_profile,
+    is_public_v2_hidden_compat_command,
+    registered_commands_for_profile,
     resolve_command_profile,
+    visible_commands_for_profile,
 )
 from pcobra.cobra.architecture.overview import USER_ROUTE_BACKEND_ENTRYPOINT
 from pcobra.cobra.cli.plugin import (
@@ -112,7 +115,6 @@ CLI_VERSION = _resolve_cli_version()
 
 assert_public_targets_contract(tuple(PUBLIC_BACKENDS), source="cobra cli bootstrap")
 LANG_CHOICES = tuple(PUBLIC_BACKENDS)
-PUBLIC_V2_HIDDEN_COMPATIBLE_COMMANDS = frozenset({"paquete", "hub"})
 
 
 class CliErrorYaMostrado(Exception):
@@ -262,17 +264,30 @@ class CommandRegistry:
         if normalized_profile != PROFILE_PUBLIC or AppConfig.V2_COMMAND_CLASSES:
             return routes
 
-        public_v2_command_classes = {
-            "RunCommandV2",
-            "BuildCommandV2",
-            "TestCommandV2",
-            "ModCommandV2",
-            "ReplCommandV2",
-            "PaqueteCommand",
-            "HubCommand",
+        route_command_names = {
+            "RunCommandV2": "run",
+            "BuildCommandV2": "build",
+            "TestCommandV2": "test",
+            "ModCommandV2": "mod",
+            "ReplCommandV2": "repl",
+            "InstallerCommandV2": "installer",
+            "PaqueteCommand": "paquete",
+            "HubCommand": "hub",
         }
+        registered_names = registered_commands_for_profile(
+            (
+                command_name
+                for command_name in (
+                    route_command_names.get(route.class_name) for route in routes
+                )
+                if command_name is not None
+            ),
+            normalized_profile,
+        )
         return [
-            route for route in routes if route.class_name in public_v2_command_classes
+            route
+            for route in routes
+            if route_command_names.get(route.class_name) in registered_names
         ]
 
     def _resolve_v1_command_routes(self) -> List[CommandClassRoute]:
@@ -341,20 +356,18 @@ class CommandRegistry:
         all_commands = base_commands + plugin_commands
 
         if ui_effective == "v2":
-            hidden_compatible_names = PUBLIC_V2_HIDDEN_COMPATIBLE_COMMANDS
-            allowed_names = filter_commands_for_profile(
+            registered_names = registered_commands_for_profile(
                 (cmd.name for cmd in all_commands), normalized_profile
             )
-            if normalized_profile == PROFILE_PUBLIC:
-                # Opción A: `paquete` y `hub` permanecen registrados y
-                # ejecutables, pero se ocultan del contrato público visible.
-                allowed_names = set(allowed_names).union(hidden_compatible_names)
-            all_commands = [cmd for cmd in all_commands if cmd.name in allowed_names]
+            visible_names = visible_commands_for_profile(
+                (cmd.name for cmd in all_commands), normalized_profile
+            )
+            all_commands = [cmd for cmd in all_commands if cmd.name in registered_names]
             if normalized_profile == PROFILE_PUBLIC:
                 logging.getLogger(__name__).debug(
                     "Perfil público activo: comandos expuestos=%s; compatibles ocultos=%s",
-                    sorted(set(allowed_names).difference(hidden_compatible_names)),
-                    sorted(hidden_compatible_names),
+                    sorted(visible_names),
+                    sorted(PUBLIC_V2_HIDDEN_COMPAT_COMMANDS),
                 )
             elif normalized_profile == PROFILE_DEVELOPMENT:
                 logging.getLogger(__name__).debug(
@@ -378,15 +391,18 @@ class CommandRegistry:
         self.hidden_compatible_commands = {}
         hidden_compatible_commands = []
         if ui_effective == "v2" and normalized_profile == PROFILE_PUBLIC:
-            hidden_compatible_names = PUBLIC_V2_HIDDEN_COMPATIBLE_COMMANDS
             hidden_compatible_commands = [
-                cmd for cmd in all_commands if cmd.name in hidden_compatible_names
+                cmd
+                for cmd in all_commands
+                if is_public_v2_hidden_compat_command(cmd.name)
             ]
             self.hidden_compatible_commands = {
                 cmd.name: cmd for cmd in hidden_compatible_commands
             }
             all_commands = [
-                cmd for cmd in all_commands if cmd.name not in hidden_compatible_names
+                cmd
+                for cmd in all_commands
+                if not is_public_v2_hidden_compat_command(cmd.name)
             ]
 
         self.commands = {cmd.name: cmd for cmd in all_commands}

--- a/src/pcobra/cobra/cli/public_command_policy.py
+++ b/src/pcobra/cobra/cli/public_command_policy.py
@@ -8,6 +8,7 @@ from typing import Iterable
 # `repl` es comando público oficial en UI v2; no debe tratarse como alias legacy.
 PUBLIC_COMMANDS_CONTRACT: tuple[str, ...] = ("run", "build", "test", "mod", "repl")
 PUBLIC_COMMANDS: tuple[str, ...] = PUBLIC_COMMANDS_CONTRACT
+PUBLIC_V2_HIDDEN_COMPAT_COMMANDS: tuple[str, ...] = ("paquete", "hub")
 if PUBLIC_COMMANDS != PUBLIC_COMMANDS_CONTRACT:
     raise RuntimeError(
         "Contrato público inválido: PUBLIC_COMMANDS debe mantenerse en "
@@ -18,7 +19,6 @@ INTERNAL_COMMANDS: tuple[str, ...] = (
     "debug",
     "devops",
 )
-
 
 
 COMMAND_VISIBILITY_MATRIX_MARKDOWN = """| Clase | Comandos |
@@ -55,7 +55,25 @@ def resolve_command_profile(default: str = PROFILE_PUBLIC) -> str:
     return default
 
 
-def filter_commands_for_profile(command_names: Iterable[str], profile: str) -> set[str]:
+def _normalize_command_names(command_names: Iterable[str]) -> set[str]:
+    return {name.strip().lower() for name in command_names}
+
+
+def is_public_v2_visible_command(name: str) -> bool:
+    """Indica si `name` pertenece al contrato público visible de CLI v2."""
+
+    return name.strip().lower() in PUBLIC_COMMANDS
+
+
+def is_public_v2_hidden_compat_command(name: str) -> bool:
+    """Indica si `name` es compatibilidad pública v2 registrada pero oculta."""
+
+    return name.strip().lower() in PUBLIC_V2_HIDDEN_COMPAT_COMMANDS
+
+
+def visible_commands_for_profile(
+    command_names: Iterable[str], profile: str
+) -> set[str]:
     """Devuelve comandos visibles para `profile`.
 
     - `public`: solo la intersección entre `command_names` y `PUBLIC_COMMANDS`.
@@ -63,16 +81,46 @@ def filter_commands_for_profile(command_names: Iterable[str], profile: str) -> s
     """
 
     normalized_profile = str(profile).strip().lower() or PROFILE_PUBLIC
-    names = {name.strip().lower() for name in command_names}
+    names = _normalize_command_names(command_names)
 
     if normalized_profile == PROFILE_DEVELOPMENT:
         return names
 
-    allowed = set(PUBLIC_COMMANDS)
-    return names.intersection(allowed)
+    return {name for name in names if is_public_v2_visible_command(name)}
 
 
-def filter_legacy_commands_for_profile(command_names: Iterable[str], profile: str) -> set[str]:
+def registered_commands_for_profile(
+    command_names: Iterable[str], profile: str
+) -> set[str]:
+    """Devuelve comandos que deben registrarse como subparsers para `profile`.
+
+    En perfil público v2, `paquete` y `hub` son compatibilidad runtime: se
+    registran para poder ejecutarse, pero no forman parte de la capa visible.
+    """
+
+    normalized_profile = str(profile).strip().lower() or PROFILE_PUBLIC
+    names = _normalize_command_names(command_names)
+
+    if normalized_profile == PROFILE_DEVELOPMENT:
+        return names
+
+    return {
+        name
+        for name in names
+        if is_public_v2_visible_command(name)
+        or is_public_v2_hidden_compat_command(name)
+    }
+
+
+def filter_commands_for_profile(command_names: Iterable[str], profile: str) -> set[str]:
+    """Compatibilidad: alias de la capa visible de comandos v2."""
+
+    return visible_commands_for_profile(command_names, profile)
+
+
+def filter_legacy_commands_for_profile(
+    command_names: Iterable[str], profile: str
+) -> set[str]:
     """Devuelve comandos legacy visibles según perfil.
 
     La superficie v1/legacy queda reservada para sesiones de desarrollo y
@@ -91,12 +139,17 @@ def filter_legacy_commands_for_profile(command_names: Iterable[str], profile: st
 __all__ = [
     "PUBLIC_COMMANDS_CONTRACT",
     "PUBLIC_COMMANDS",
+    "PUBLIC_V2_HIDDEN_COMPAT_COMMANDS",
     "INTERNAL_COMMANDS",
     "COMMAND_VISIBILITY_MATRIX_MARKDOWN",
     "PROFILE_PUBLIC",
     "PROFILE_DEVELOPMENT",
     "COMMAND_PROFILES",
     "resolve_command_profile",
+    "is_public_v2_visible_command",
+    "is_public_v2_hidden_compat_command",
+    "visible_commands_for_profile",
+    "registered_commands_for_profile",
     "filter_commands_for_profile",
     "filter_legacy_commands_for_profile",
 ]

--- a/tests/unit/test_public_command_policy.py
+++ b/tests/unit/test_public_command_policy.py
@@ -4,6 +4,10 @@ from cobra.cli.public_command_policy import (
     PUBLIC_COMMANDS_CONTRACT,
     filter_commands_for_profile,
     filter_legacy_commands_for_profile,
+    is_public_v2_hidden_compat_command,
+    is_public_v2_visible_command,
+    registered_commands_for_profile,
+    visible_commands_for_profile,
 )
 
 
@@ -24,6 +28,22 @@ def test_filter_commands_publico_permite_solo_superficie_v2_publica():
         PROFILE_PUBLIC,
     )
     assert visibles == {"run", "build", "test", "mod", "repl"}
+
+
+def test_capas_publicas_v2_separan_visibles_de_registrados():
+    comandos = ("run", "build", "paquete", "hub", "installer")
+
+    assert visible_commands_for_profile(comandos, PROFILE_PUBLIC) == {"run", "build"}
+    assert registered_commands_for_profile(comandos, PROFILE_PUBLIC) == {
+        "run",
+        "build",
+        "paquete",
+        "hub",
+    }
+    assert is_public_v2_visible_command("run") is True
+    assert is_public_v2_visible_command("paquete") is False
+    assert is_public_v2_hidden_compat_command("paquete") is True
+    assert is_public_v2_hidden_compat_command("installer") is False
 
 
 def test_filter_commands_development_permite_toda_superficie_v2():


### PR DESCRIPTION
### Motivation
- Permitir que ciertos aliases legacy (`paquete`, `hub`) permanezcan registrados y ejecutables en el perfil público v2 sin formar parte del contrato público visible, manteniendo intacto `PUBLIC_COMMANDS_CONTRACT`.
- Simplificar y hacer explícita la distinción entre la capa de comandos "visibles" (para help/contrato) y la capa de comandos "registrados" (subparsers ejecutables). 

### Description
- Añade la constante `PUBLIC_V2_HIDDEN_COMPAT_COMMANDS = ("paquete", "hub")` y mantiene `PUBLIC_COMMANDS_CONTRACT` sin cambios en `src/pcobra/cobra/cli/public_command_policy.py`.
- Introduce helpers: `is_public_v2_visible_command`, `is_public_v2_hidden_compat_command`, `visible_commands_for_profile` y `registered_commands_for_profile`, además de `_normalize_command_names`, y mantiene `filter_commands_for_profile` como alias de la capa visible.
- Actualiza `__all__` para exportar únicamente las constantes/funciones necesarias (incluye las nuevas funciones y la constante de compatibilidad oculta).
- Modifica la resolución y registro de rutas en `src/pcobra/cobra/cli/cli.py` para usar la capa de "registrados" al decidir qué subparsers crear (`registered_commands_for_profile`) y usar la capa de "visibles" para exponer `CommandRegistry.commands`, snapshots/help y el contrato público (log/choices y `_PublicChoicesDict`).
- Ajusta la lógica que separa y registra subparsers ocultos para la compatibilidad (`paquete`/`hub`) usando las nuevas funciones en lugar de listas ad-hoc.
- Añade una prueba unitaria que valida la separación entre comandos visibles y registrados y actualiza la suite existente para cubrir el comportamiento (fichero `tests/unit/test_public_command_policy.py`).
- Formatea los archivos afectados con `black` para mantener el estilo.

### Testing
- Se ejecutó el formateador: `python -m black src/pcobra/cobra/cli/public_command_policy.py src/pcobra/cobra/cli/cli.py` y los archivos se reescribieron correctamente.
- Se ejecutaron las pruebas: `pytest tests/unit/test_public_command_policy.py tests/integration/test_cli_public_help_contract.py` y todas las pruebas pasaron (`15 passed, 1 warning`).
- Se verificó `git diff --check` sin errores antes de preparar el PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a645816f08327af238d2e9b7f771e)