### PR TITLE
Registrar comandos v2-compatibles ocultos sin romper BaseCommand (paquete/hub)

### DIFF
--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import builtins
+import inspect
 from types import SimpleNamespace
 import logging
 import os
@@ -304,6 +305,51 @@ class CommandRegistry:
             )
         return routes
 
+    @staticmethod
+    def _command_supports_hidden_keyword(command: BaseCommand) -> bool:
+        """Indica si register_subparser acepta el keyword opcional hidden."""
+        try:
+            signature = inspect.signature(command.register_subparser)
+        except (TypeError, ValueError):
+            return False
+        parameter = signature.parameters.get("hidden")
+        if parameter is not None:
+            return parameter.kind in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+        return any(
+            param.kind == inspect.Parameter.VAR_KEYWORD
+            for param in signature.parameters.values()
+        )
+
+    @staticmethod
+    def _is_hidden_compatible_command(
+        command: BaseCommand, *, ui_effective: str, profile: str
+    ) -> bool:
+        """Detecta compatibilidad pública v2 oculta a partir del nombre del comando."""
+        normalized_profile = str(profile).strip().lower() or PROFILE_PUBLIC
+        return (
+            ui_effective == "v2"
+            and normalized_profile == PROFILE_PUBLIC
+            and is_public_v2_hidden_compat_command(command.name)
+        )
+
+    def _register_hidden_compatible_subparser(
+        self, command: BaseCommand, subparsers: Any
+    ) -> None:
+        """Registra un subparser compatible oculto sin ampliar BaseCommand."""
+        register_hidden_subparser = getattr(command, "register_hidden_subparser", None)
+        if callable(register_hidden_subparser):
+            register_hidden_subparser(subparsers)
+            return
+
+        if self._command_supports_hidden_keyword(command):
+            command.register_subparser(subparsers, hidden=True)  # type: ignore[call-arg]
+            return
+
+        command.register_subparser(subparsers)
+
     def register_base_commands(
         self,
         subparsers: Any,
@@ -394,7 +440,9 @@ class CommandRegistry:
             hidden_compatible_commands = [
                 cmd
                 for cmd in all_commands
-                if is_public_v2_hidden_compat_command(cmd.name)
+                if self._is_hidden_compatible_command(
+                    cmd, ui_effective=ui_effective, profile=normalized_profile
+                )
             ]
             self.hidden_compatible_commands = {
                 cmd.name: cmd for cmd in hidden_compatible_commands
@@ -416,9 +464,7 @@ class CommandRegistry:
 
         for command in hidden_compatible_commands:
             try:
-                command.register_subparser(
-                    subparsers, hidden=bool(getattr(command, "public_v2_hidden", False))
-                )
+                self._register_hidden_compatible_subparser(command, subparsers)
             except Exception as e:
                 logging.error(
                     f"Failed to register hidden compatible subparser for {command.name}: {e}"

--- a/src/pcobra/cobra/cli/commands/hub_cmd.py
+++ b/src/pcobra/cobra/cli/commands/hub_cmd.py
@@ -57,6 +57,10 @@ class HubCommand(BaseCommand):
         parser.set_defaults(cmd=self)
         return parser
 
+    def register_hidden_subparser(self, subparsers: Any) -> CustomArgumentParser:
+        """Registra el comando como compatibilidad pública v2 oculta."""
+        return self.register_subparser(subparsers, hidden=True)
+
     def run(self, args: Namespace) -> int:
         packages = CobraHubPackages(CobraHubClient())
         if args.accion == "publicar":

--- a/src/pcobra/cobra/cli/commands/package_cmd.py
+++ b/src/pcobra/cobra/cli/commands/package_cmd.py
@@ -96,6 +96,10 @@ class PaqueteCommand(BaseCommand):
         parser.set_defaults(cmd=self)
         return parser
 
+    def register_hidden_subparser(self, subparsers: Any) -> CustomArgumentParser:
+        """Registra el comando como compatibilidad pública v2 oculta."""
+        return self.register_subparser(subparsers, hidden=True)
+
     @staticmethod
     def _normalizar_nombre_legacy(nombre: str) -> Path:
         ruta = Path(nombre.replace("\\", "/"))

--- a/tests/cli/test_cli_alias_registration.py
+++ b/tests/cli/test_cli_alias_registration.py
@@ -23,9 +23,10 @@ def _command_parser(
     return parser, subparsers
 
 
-def test_aliases_legacy_de_paquete_siguen_registrados_en_cli_publica() -> None:
+def test_aliases_legacy_de_paquete_en_parser_oculto_v2_publico() -> None:
     _, comandos = _command_parser()
 
+    assert "paquete" not in comandos.choices.keys()
     paquete = comandos.choices["paquete"]
     acciones_paquete = _subparser_action(paquete)
 
@@ -41,16 +42,19 @@ def test_aliases_legacy_de_paquete_siguen_registrados_en_cli_publica() -> None:
     assert destinos_posicionales == ["fuente", "paquete"]
 
 
-def test_comandos_recomendados_de_hub_siguen_registrados_en_cli_publica() -> None:
+def test_comandos_recomendados_de_hub_en_parser_oculto_v2_publico() -> None:
     _, comandos = _command_parser()
 
+    assert "hub" not in comandos.choices.keys()
     hub = comandos.choices["hub"]
     acciones_hub = _subparser_action(hub)
 
     assert {"publicar", "buscar", "instalar"}.issubset(acciones_hub.choices)
 
 
-def test_comandos_legacy_de_modulos_siguen_registrados_en_perfil_desarrollo_v1() -> None:
+def test_comandos_legacy_de_modulos_siguen_registrados_en_perfil_desarrollo_v1() -> (
+    None
+):
     _, comandos = _command_parser(ui="v1", profile=PROFILE_DEVELOPMENT)
 
     modulos = comandos.choices["modulos"]


### PR DESCRIPTION
### Motivation

- Evitar exponer en el `help` y en las `choices` públicos de UI v2 los comandos de compatibilidad `paquete` y `hub` mientras se mantiene la capacidad de ejecutarlos en perfil `public`.
- No modificar la interfaz de `BaseCommand` para no romper implementaciones existentes.

### Description

- Añadí en `CommandRegistry` la lógica de detección de comandos ocultos v2 mediante `ui_effective == "v2"`, `profile == "public"` y la política pública v2, y centralicé el registro de estos subparsers ocultos. (`src/pcobra/cobra/cli/cli.py`).
- Implementé helper privados en `CommandRegistry`: `_command_supports_hidden_keyword`, `_is_hidden_compatible_command` y `_register_hidden_compatible_subparser` para soportar tres vías de registro (método opcional `register_hidden_subparser`, pasar `hidden=True` cuando la firma lo acepte, o fallback al registro normal). (`src/pcobra/cobra/cli/cli.py`).
- Añadí el método opcional `register_hidden_subparser()` en `PaqueteCommand` y `HubCommand` que reutiliza su `register_subparser(..., hidden=True)` sin tocar `BaseCommand`. (`src/pcobra/cobra/cli/commands/package_cmd.py`, `src/pcobra/cobra/cli/commands/hub_cmd.py`).
- Ajusté las pruebas de alias para validar que `paquete` y `hub` no aparecen en las claves públicas visibles pero mantienen sus subcomandos internos en los parsers ocultos. (`tests/cli/test_cli_alias_registration.py`).

### Testing

- Ejecuté `pytest -q tests/cli/test_cli_alias_registration.py` y la prueba modificada pasó correctamente.
- Ejecuté `pytest -q tests/cli/test_public_v2_commands_contract.py` y todas las pruebas relevantes pasaron correctamente.
- Ejecuté ambos tests combinados (`tests/cli/test_cli_alias_registration.py tests/cli/test_public_v2_commands_contract.py`) y los tests focalizados pasaron (11 passed, 1 warning).
- Ejecutar la suite completa `pytest -q tests/cli` mostró fallos en pruebas de REPL por un `MemoryError` al construir el intérprete, que es un problema independiente de los cambios realizados en el registro de subparsers (los tests relacionados con visibilidad y compatibilidad ocultos siguieron pasando).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a6e9e182c8327a66990c9c86cd2bd)