### PR TITLE
Actualizar prueba de carga de textos desde árbol

### DIFF
--- a/tests/gui/test_runtime_file_helpers.py
+++ b/tests/gui/test_runtime_file_helpers.py
@@ -315,8 +315,10 @@ def test_cargar_archivo_desde_arbol_reusa_apertura_y_valida_extension(tmp_path: 
     estado = runtime.GuiFileState()
     archivo_cobra = tmp_path / "desde_arbol.cobra"
     archivo_cobra.write_text("imprimir('arbol')", encoding="utf-8")
-    archivo_no_cobra = tmp_path / "nota.txt"
-    archivo_no_cobra.write_text("texto", encoding="utf-8")
+    archivo_texto = tmp_path / "nota.txt"
+    archivo_texto.write_text("texto", encoding="utf-8")
+    archivo_no_clasificado = tmp_path / "imagen.png"
+    archivo_no_clasificado.write_text("binario", encoding="utf-8")
 
     contenido, mensaje = runtime.cargar_archivo_desde_arbol(archivo_cobra, estado)
 
@@ -325,12 +327,17 @@ def test_cargar_archivo_desde_arbol_reusa_apertura_y_valida_extension(tmp_path: 
     assert estado.ruta == archivo_cobra.resolve()
     assert estado.contenido_cargado == "imprimir('arbol')"
 
-    try:
-        runtime.cargar_archivo_desde_arbol(archivo_no_cobra, estado)
-    except ValueError as exc:
-        assert "Selecciona un archivo Cobra" in str(exc)
-    else:
-        raise AssertionError("El árbol solo debe cargar archivos .co/.cobra")
+    contenido, mensaje = runtime.cargar_archivo_desde_arbol(archivo_texto, estado)
+
+    assert runtime.detectar_tipo_archivo(archivo_texto) == runtime.TIPO_ARCHIVO_TEXTO
+    assert not runtime.es_archivo_cobra(archivo_texto)
+    assert contenido == "texto"
+    assert mensaje == f"Archivo cargado: {archivo_texto.resolve()}"
+    assert estado.ruta == archivo_texto.resolve()
+    assert estado.contenido_cargado == "texto"
+
+    with pytest.raises(ValueError, match="archivo de texto del proyecto"):
+        runtime.cargar_archivo_desde_arbol(archivo_no_clasificado, estado)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation

- Corregir una prueba GUI obsoleta que todavía esperaba que `.txt` fuera rechazado por `cargar_archivo_desde_arbol()`, mientras que el runtime ahora acepta archivos clasificados como texto por `detectar_tipo_archivo()`.

### Description

- Actualiza `tests/gui/test_runtime_file_helpers.py::test_cargar_archivo_desde_arbol_reusa_apertura_y_valida_extension` para crear `nota.txt` y verificar que `cargar_archivo_desde_arbol()` lo carga correctamente y lo clasifica como `TIPO_ARCHIVO_TEXTO`.
- Sustituye el caso negativo anterior por `imagen.png` y comprueba que la llamada lanza `ValueError` con el mensaje que coincide con "archivo de texto del proyecto".
- Alinea la prueba con la política actual del runtime que abre archivos clasificados como texto mediante el helper validado sin modificar la lógica del runtime.

### Testing

- Ejecuté `pytest -q tests/gui/test_runtime_file_helpers.py::test_cargar_archivo_desde_arbol_reusa_apertura_y_valida_extension tests/unit/test_gui_runtime.py::test_accion_cargar_archivo_desde_arbol_filtra_extensiones` y ambas pruebas pasaron.
- Ejecuté `pytest -q tests/gui/test_runtime_file_helpers.py` y el módulo GUI completo pasó (31 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a72df6ba4832790c5f03f6014b19b)