### PR TITLE
Fix IDLE integration expectation for labeled file titles

### DIFF
--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -994,7 +994,7 @@ def test_main_acciones_publicas_de_archivo(monkeypatch, tmp_path):
     botones["Abrir"].on_click(None)
     assert entrada.value == "imprimir('abrir')"
     assert salida.value == f"Archivo cargado: {archivo_abrir.resolve()}"
-    assert estado_archivo.value == str(archivo_abrir.resolve())
+    assert estado_archivo.value == f"Archivo Cobra: {archivo_abrir.resolve()}"
     assert ruta_input.value == str(archivo_abrir.resolve())
     assert arbol.controls[0].value == _estado_workspace_proyecto(tmp_path)
 


### PR DESCRIPTION
### Motivation
- The GUI runtime now prepends a visible file-type label in the editor title (e.g. `Archivo Cobra: <path>`), so the IDLE integration test must be updated to expect this new format to keep CI green.

### Description
- Update the assertion in `tests/unit/test_gui_idle.py` to expect `Archivo Cobra: {archivo.resolve()}` for the active file title after opening a Cobra file.
- This aligns the test with the `crear_titulo_archivo` behavior that uses `etiqueta_tipo_archivo` to prefix titles when `estado.ruta` is set.

### Testing
- Ran `python -m pytest tests/unit/test_gui_idle.py::test_main_acciones_publicas_de_archivo -q` and it passed.
- Ran `python -m pytest tests/unit/test_gui_runtime.py::test_etiqueta_tipo_archivo_devuelve_textos_visibles tests/unit/test_gui_runtime.py::test_crear_titulo_archivo_antepone_etiqueta_y_conserva_asterisco tests/unit/test_gui_runtime.py::test_crear_titulo_archivo_sin_ruta_mantiene_texto_de_archivo_nuevo -q` and all three tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a861c1d2483278c1bdab1111de2d3)