### PR TITLE
Reject normalized package path collisions

### DIFF
--- a/src/pcobra/cobra/packaging.py
+++ b/src/pcobra/cobra/packaging.py
@@ -162,11 +162,26 @@ def validar_paquete(package: str | Path) -> PackageInspection:
     checksums = _normalizar_checksums(manifest.get("checksums"))
 
     with zipfile.ZipFile(inspection.path) as zf:
-        real_files = {
-            _normalizar_ruta_paquete(info.filename)
-            for info in zf.infolist()
-            if not info.is_dir() and info.filename != MANIFEST_NAME
-        }
+        real_file_entries: dict[str, str] = {}
+        duplicate_files: dict[str, list[str]] = {}
+        for info in zf.infolist():
+            if info.is_dir() or info.filename == MANIFEST_NAME:
+                continue
+            normalized_name = _normalizar_ruta_paquete(info.filename)
+            previous_name = real_file_entries.get(normalized_name)
+            if previous_name is not None:
+                duplicate_files.setdefault(normalized_name, [previous_name]).append(info.filename)
+                continue
+            real_file_entries[normalized_name] = info.filename
+
+        if duplicate_files:
+            collisions = ", ".join(
+                f"{normalized} ({', '.join(entries)})"
+                for normalized, entries in sorted(duplicate_files.items())
+            )
+            raise ValueError(f"Entradas duplicadas en paquete tras normalizar rutas: {collisions}")
+
+        real_files = set(real_file_entries)
         extra_files = real_files - declared_files
         if extra_files:
             raise ValueError(f"Archivos no declarados en paquete: {', '.join(sorted(extra_files))}")
@@ -185,7 +200,7 @@ def validar_paquete(package: str | Path) -> PackageInspection:
             raise ValueError(f"Faltan checksums para archivos declarados: {', '.join(sorted(missing_checksums))}")
 
         for name in sorted(declared_files):
-            actual = _sha256_bytes(zf.read(name))
+            actual = _sha256_bytes(zf.read(real_file_entries[name]))
             if actual != checksums[name]:
                 raise ValueError(f"Integridad fallida para {name}")
     return inspection

--- a/tests/unit/test_cobra_packaging.py
+++ b/tests/unit/test_cobra_packaging.py
@@ -88,6 +88,26 @@ def test_validar_paquete_rechaza_archivo_extra_no_declarado(tmp_path: Path):
         validar_paquete(paquete)
 
 
+def test_validar_paquete_rechaza_entradas_duplicadas_tras_normalizar(tmp_path: Path):
+    contenido_valido = b"imprimir('validado')\n"
+    paquete = _crear_zip_con_manifest(
+        tmp_path,
+        {
+            "format": "cobra-package-v1",
+            "name": "demo",
+            "version": "1.0.0",
+            "files": ["src/main.cobra"],
+            "checksums": {"src/main.cobra": _sha256(contenido_valido)},
+        },
+        {
+            "src/main.cobra": contenido_valido,
+            "src//main.cobra": b"imprimir('sin validar')\n",
+        },
+    )
+
+    with pytest.raises(ValueError, match="Entradas duplicadas"):
+        validar_paquete(paquete)
+
 def test_validar_paquete_rechaza_checksum_ausente(tmp_path: Path):
     contenido = b"imprimir('hola')\n"
     paquete = _crear_zip_con_manifest(


### PR DESCRIPTION
### Motivation

- Prevent ZIP archive entries that normalize to the same package path from silently collapsing and allowing an unchecked archive member to overwrite a verified file during extraction. 
- Ensure checksum verification reads the actual ZIP member used during validation so integrity checks match the on-disk contents. 

### Description

- Replace the previous set-of-normalized-names approach with a normalized-to-raw-entry map (`real_file_entries`) and detect duplicates collected in `duplicate_files` inside `validar_paquete`. 
- Raise a clear `ValueError` listing colliding archive member names when two or more ZIP entries normalize to the same package path. 
- Use the `real_file_entries` map when computing checksums so verification reads the exact ZIP member that passed normalization. 
- Add a regression test `test_validar_paquete_rechaza_entradas_duplicadas_tras_normalizar` that constructs a ZIP with `src/main.cobra` and `src//main.cobra` and asserts validation rejects the package.

### Testing

- Ran `pytest -q tests/unit/test_cobra_packaging.py` and the suite passed with the new test included (`6 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a9336b190832782b37dc345cb9646)