### PR TITLE
test(gui): avoid leaking resource caps in runtime tests

### DIFF
--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -20,6 +20,12 @@ def _deps_lexer_parser_reales() -> dict[str, object]:
     }
 
 
+def _desactivar_limites_recursos_interprete(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Evita que las pruebas del runtime GUI limiten el proceso de pytest."""
+    monkeypatch.setattr("pcobra.core.interpreter._lim_mem", lambda _mb: None)
+    monkeypatch.setattr("pcobra.core.interpreter._lim_cpu", lambda _segundos: None)
+
+
 @pytest.fixture(autouse=True)
 def _reset_cache(monkeypatch: pytest.MonkeyPatch):
     cache_clear = getattr(runtime.require_gui_dependencies, "cache_clear", None)
@@ -378,7 +384,8 @@ def test_normalizar_codigo_admite_none_y_texto() -> None:
     assert runtime.normalizar_codigo("imprimir('x')") == "imprimir('x')"
 
 
-def test_ejecutar_transpilar_tokens_y_ast() -> None:
+def test_ejecutar_transpilar_tokens_y_ast(monkeypatch: pytest.MonkeyPatch) -> None:
+    _desactivar_limites_recursos_interprete(monkeypatch)
     codigo = "imprimir('Hola')"
     assert runtime.ejecutar_codigo(codigo) == "Hola\n"
     assert runtime.transpilar_codigo(codigo, "python").strip()


### PR DESCRIPTION
### Motivation
- Prevent Cobra interpreter resource limits from leaking into the pytest process and causing downstream package-build tests to fail with `MemoryError` when `runtime.ejecutar_codigo` picks up `cobra.toml`'s `limite_memoria_mb` setting.

### Description
- Added a focused test helper ` _desactivar_limites_recursos_interprete` that monkeypatches `pcobra.core.interpreter._lim_mem` and `pcobra.core.interpreter._lim_cpu` to no-op, and updated `test_ejecutar_transpilar_tokens_y_ast` to invoke this helper before calling `runtime.ejecutar_codigo` so resource caps are not applied to the test runner.

### Testing
- Ran `python -m py_compile tests/unit/test_gui_runtime.py` and `pytest -q tests/unit/test_gui_runtime.py`, with the test run completing successfully (`77 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a955d11a48327be5dc478faf1f804)