### PR TITLE
Bloquear guardado de paquetes Cobra desde editor

### DIFF
--- a/src/pcobra/gui/runtime.py
+++ b/src/pcobra/gui/runtime.py
@@ -535,6 +535,19 @@ def leer_archivo_texto(path: str | Path, *, encoding: str = "utf-8") -> str:
     return normalizar_ruta_archivo_gui(path).read_text(encoding=encoding)
 
 
+def _validar_guardado_como_texto(destino: str | Path) -> Path:
+    """Valida que una ruta pueda persistirse desde el editor de texto."""
+
+    ruta = Path(destino).expanduser().resolve()
+    if not archivo_permite_accion(ruta, ACCION_GUARDAR):
+        etiqueta = etiqueta_tipo_archivo(ruta)
+        raise ValueError(
+            f"{etiqueta} no se puede guardar desde el editor de texto. "
+            "Usa las acciones específicas para paquetes Cobra."
+        )
+    return ruta
+
+
 def escribir_archivo_texto(
     path: str | Path, contenido: str | None, *, encoding: str = "utf-8"
 ) -> str:
@@ -542,6 +555,7 @@ def escribir_archivo_texto(
 
     codigo = normalizar_codigo(contenido)
     destino = normalizar_ruta_archivo_gui(path)
+    _validar_guardado_como_texto(destino)
     destino.write_text(codigo, encoding=encoding)
     return codigo
 
@@ -656,6 +670,7 @@ def escribir_archivo_texto_validado(
     """
 
     destino = Path(path).expanduser().resolve()
+    _validar_guardado_como_texto(destino)
     if destino.exists() and destino.is_dir():
         raise NotADirectoryError(
             "La ruta indicada corresponde a un directorio; indica un archivo de texto del proyecto."

--- a/tests/unit/test_gui_runtime.py
+++ b/tests/unit/test_gui_runtime.py
@@ -155,6 +155,53 @@ def test_cargar_archivo_desde_arbol_no_lee_paquete_cobra_zip_como_texto(
     assert not estado.cambios_sin_guardar
 
 
+def test_guardar_archivo_activo_rechaza_paquete_cobra_seleccionado(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COBRA_IO_BASE_DIR", str(tmp_path))
+    paquete = tmp_path / "paquete.co"
+    with zipfile.ZipFile(paquete, "w") as zf:
+        zf.writestr("cobra.pkg.json", '{"name":"demo","version":"1.0.0"}')
+        zf.writestr("main.co", "imprimir('hola')\n")
+    contenido_original = paquete.read_bytes()
+    estado = runtime.GuiFileState(
+        ruta=paquete.resolve(),
+        contenido_cargado="",
+        cambios_sin_guardar=False,
+    )
+
+    with pytest.raises(ValueError, match="no se puede guardar desde el editor"):
+        runtime.guardar_archivo_activo("", estado)
+
+    assert paquete.read_bytes() == contenido_original
+    assert estado.ruta == paquete.resolve()
+    assert estado.contenido_cargado == ""
+    assert not estado.cambios_sin_guardar
+
+
+def test_guardar_archivo_activo_validado_rechaza_paquete_cobra_seleccionado(
+    tmp_path: Path,
+) -> None:
+    paquete = tmp_path / "paquete.co"
+    with zipfile.ZipFile(paquete, "w") as zf:
+        zf.writestr("cobra.pkg.json", '{"name":"demo","version":"1.0.0"}')
+        zf.writestr("main.co", "imprimir('hola')\n")
+    contenido_original = paquete.read_bytes()
+    estado = runtime.GuiFileState(
+        ruta=paquete.resolve(),
+        contenido_cargado="",
+        cambios_sin_guardar=False,
+    )
+
+    with pytest.raises(ValueError, match="no se puede guardar desde el editor"):
+        runtime.guardar_archivo_activo_validado("", estado)
+
+    assert paquete.read_bytes() == contenido_original
+    assert estado.ruta == paquete.resolve()
+    assert estado.contenido_cargado == ""
+    assert not estado.cambios_sin_guardar
+
+
 def test_detectar_tipo_archivo_clasifica_extensiones_y_nombres_conocidos() -> None:
     casos = {
         "main.cobra": runtime.TIPO_ARCHIVO_COBRA,


### PR DESCRIPTION
### Motivation
- Evitar que un paquete Cobra (`.co` ZIP con `cobra.pkg.json`) seleccionado en el árbol sea sobrescrito por la ruta de Guardar del editor de texto y por tanto se corrompa.

### Description
- Añadida la función de validación `
_validar_guardado_como_texto(destino)` que comprueba `archivo_permite_accion(ruta, ACCION_GUARDAR)` y lanza `ValueError` con mensaje claro si la ruta no permite guardado desde el editor de texto.
- Invocada la validación en `escribir_archivo_texto(...)` y en `escribir_archivo_texto_validado(...)` para proteger ambos flujos de escritura desde el editor (sandbox-normalizado y validado por IDLE).
- Añadidas pruebas `test_guardar_archivo_activo_rechaza_paquete_cobra_seleccionado` y `test_guardar_archivo_activo_validado_rechaza_paquete_cobra_seleccionado` que verifican que guardar sobre un paquete `.co` ZIP falla y no altera los bytes del ZIP, manteniendo el comportamiento previo de `cargar_archivo_desde_arbol`.

### Testing
- Ejecutados los tests específicos con `pytest` (`tests/unit/test_gui_runtime.py::test_guardar_archivo_activo_rechaza_paquete_cobra_seleccionado`, `tests/unit/test_gui_runtime.py::test_guardar_archivo_activo_validado_rechaza_paquete_cobra_seleccionado`, `tests/unit/test_gui_runtime.py::test_accion_guardar_archivo_activo`, `tests/unit/test_gui_runtime.py::test_cargar_archivo_desde_arbol_no_lee_paquete_cobra_zip_como_texto`) y todos pasaron (`4 passed`).
- Compilación estática con `python -m py_compile src/pcobra/gui/runtime.py tests/unit/test_gui_runtime.py` completada sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a9c6afd8c8327aea4beb415cc88dd)