### PR TITLE
test: make HubCommand publish assertions platform-neutral

### DIFF
--- a/tests/unit/test_cobrahub_cache.py
+++ b/tests/unit/test_cobrahub_cache.py
@@ -93,7 +93,7 @@ def test_cli_hub_publicar_delega_en_cobrahub_packages_sin_red():
         codigo = HubCommand().run(args)
 
     assert codigo == 0
-    publicar.assert_called_once_with("dist/demo.co")
+    publicar.assert_called_once_with(str(Path("dist/demo.co")))
 
 
 def test_cli_hub_buscar_imprime_resultados_normalizados(capsys):
@@ -184,4 +184,4 @@ def test_main_cobra_cli_hub_publicar_delega_sin_red():
         codigo = main(["hub", "publicar", "dist/demo.co"])
 
     assert codigo == 0
-    publicar.assert_called_once_with("dist/demo.co")
+    publicar.assert_called_once_with(str(Path("dist/demo.co")))


### PR DESCRIPTION
### Motivation
- Ensure publish-path assertions in hub tests are platform-neutral so tests do not fail on Windows due to path separator differences.

### Description
- Updated the two test expectations that asserted the publish call to use `str(Path("dist/demo.co"))` instead of a hard-coded POSIX string.

### Testing
- Ran `pytest -q tests/unit/test_cobrahub_cache.py` and the suite passed (`11 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4aa157c2148327abdb86154c1547a1)