### PR TITLE
Preservar rangos de dependencias CobraHub

### DIFF
--- a/src/pcobra/cobra/packaging.py
+++ b/src/pcobra/cobra/packaging.py
@@ -61,9 +61,8 @@ def manifest_from_dict(data: dict[str, Any]) -> PackageManifest:
     Mantiene compatibilidad con manifiestos históricos que solo declaran
     ``format``, ``name``, ``version``, ``files`` y ``checksums``. Las
     dependencias se normalizan con la misma política que los nombres de
-    paquete y, por ahora, solo aceptan versiones exactas SemVer; los rangos
-    no están soportados hasta que exista una política de resolución
-    documentada.
+    paquete, preservando literalmente la especificación de versión declarada
+    para mantener compatibilidad con manifiestos CobraHub existentes.
     """
     package_format = data.get("format")
     if package_format is None:
@@ -117,8 +116,9 @@ def _validar_dependencias_manifest(
 ) -> dict[str, str] | None:
     """Normaliza y valida las dependencias declaradas en un manifiesto.
 
-    Cobra todavía no define semántica para resolver rangos de versiones, por
-    lo que cada dependencia debe apuntar a una versión exacta SemVer simple.
+    Solo se valida y normaliza el nombre de cada dependencia. La especificación
+    de versión se preserva literalmente porque CobraHub ya acepta rangos (por
+    ejemplo, ``^1.0.0``) y otros metadatos enriquecidos históricos.
     """
     if dependencies is None:
         return None
@@ -128,14 +128,7 @@ def _validar_dependencias_manifest(
         name = normalizar_nombre_paquete(str(raw_name))
         if name in normalized_dependencies:
             raise ValueError(f"Dependencia duplicada tras normalizar: {name}")
-        try:
-            version = validar_version_paquete(str(raw_version))
-        except ValueError as exc:
-            raise ValueError(
-                f"Versión de dependencia inválida para {name}: "
-                "solo se aceptan versiones exactas SemVer"
-            ) from exc
-        normalized_dependencies[name] = version
+        normalized_dependencies[name] = str(raw_version)
 
     return normalized_dependencies
 

--- a/tests/unit/test_cobra_packaging.py
+++ b/tests/unit/test_cobra_packaging.py
@@ -68,7 +68,7 @@ def test_package_manifest_acepta_campos_extra_permitidos():
     assert manifest_to_dict(manifest) == expected
 
 
-def test_package_manifest_normaliza_dependencias_validas():
+def test_package_manifest_normaliza_nombres_y_preserva_specs_de_dependencias():
     manifest = manifest_from_dict(
         {
             "format": "cobra-package-v1",
@@ -77,15 +77,15 @@ def test_package_manifest_normaliza_dependencias_validas():
             "files": [],
             "checksums": {},
             "dependencies": {
-                "  Paquete Demo ": " 1.2.3 ",
-                "util.core": "2.0.0-beta.1+build.5",
+                "  Paquete Demo ": "^1.2.3",
+                "util.core": 2,
             },
         }
     )
 
     assert manifest.dependencies == {
-        "paquete-demo": "1.2.3",
-        "util.core": "2.0.0-beta.1+build.5",
+        "paquete-demo": "^1.2.3",
+        "util.core": "2",
     }
 
 
@@ -93,9 +93,6 @@ def test_package_manifest_normaliza_dependencias_validas():
     ("dependencies", "match"),
     [
         ({"demo/evil": "1.0.0"}, "Nombre de paquete inválido"),
-        ({"demo": ">=1.0.0"}, "solo se aceptan versiones exactas SemVer"),
-        ({"demo": "1.0"}, "solo se aceptan versiones exactas SemVer"),
-        ({"demo": "v1.0.0"}, "solo se aceptan versiones exactas SemVer"),
         ([], "dependencies como objeto"),
     ],
 )


### PR DESCRIPTION
### Motivation
- Corregir un fallo crítico que hacía que `validar_paquete()` rechazara manifiestos CobraHub que usan rangos o especificaciones no-SemVer (por ejemplo `^1.0.0`), lo que impedía publicar o leer metadatos de paquetes enriquecidos.
- Mantener compatibilidad con la contract histórica de CobraHub hasta que se defina y acuerde una política de resolución de rangos de versión.

### Description
- Cambia `_validar_dependencias_manifest()` para normalizar únicamente los nombres de dependencia usando `normalizar_nombre_paquete()` y preservar la especificación de versión tal cual (convertida a cadena con `str(raw_version)`).
- Actualiza la documentación en `manifest_from_dict()` y en `_validar_dependencias_manifest()` para explicar que las specs de versión se conservan por compatibilidad con CobraHub.
- Ajusta las pruebas en `tests/unit/test_cobra_packaging.py` para verificar que los nombres se normalizan y que las especificaciones de versión históricas (incluidos rangos) se preservan y se serializan como texto.
- Archivos modificados: `src/pcobra/cobra/packaging.py` y `tests/unit/test_cobra_packaging.py`.

### Testing
- Ejecuté `pytest tests/unit/test_cobra_packaging.py tests/unit/test_cli_cobrahub.py::test_publicar_paquete_preserva_manifiesto_enriquecido -q` y la ejecución final del conjunto objetivo pasó (`47 passed`).
- Las pruebas unitarias actualizadas confirman normalización de nombres, preservación de specs de versión (incluidos rangos) y serialización de valores no-string a texto, y todas pasaron en la ejecución mencionada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4aa32158508327a9229f8b854d94b5)