### PR TITLE
Allow .co source entrypoints in Cobra validation

### DIFF
--- a/src/pcobra/cobra_installer/validator.py
+++ b/src/pcobra/cobra_installer/validator.py
@@ -173,11 +173,11 @@ def _validate_entrypoint(project: CobraProject, root: Path, errors: list[Validat
         return
     if not _is_inside_project(entrypoint, root):
         errors.append(ValidationErrorDetail("entrypoint_outside_project", f"El entrypoint está fuera del proyecto: {entrypoint}", entrypoint, "entrypoint"))
-    if entrypoint.suffix.lower() != ".cobra":
+    if entrypoint.suffix.lower() not in COBRA_EXTENSIONS:
         errors.append(
             ValidationErrorDetail(
                 code="entrypoint_extension_invalid",
-                message=f"El entrypoint principal debe usar extensión .cobra: {entrypoint}",
+                message=f"El entrypoint principal debe usar extensión .cobra o .co: {entrypoint}",
                 path=entrypoint,
                 field="entrypoint",
             )

--- a/tests/unit/test_cobra_installer_models.py
+++ b/tests/unit/test_cobra_installer_models.py
@@ -235,13 +235,39 @@ def test_validate_project_acumula_errores_para_idle(tmp_path: Path) -> None:
 
     codes = {error.code for error in result.errors}
     assert not result.is_valid
-    assert "entrypoint_extension_invalid" in codes
+    assert "entrypoint_extension_invalid" not in codes
     assert "cobra_toml_syntax_invalid" in codes
     assert "documentation_outside_project" in codes
     assert "documentation_not_found" in codes
     assert "executable_name_invalid" in codes
     assert "icon_not_found" in codes
     assert "icon_extension_invalid" in codes
+
+
+def test_validate_project_acepta_entrypoint_co_fuente_texto(tmp_path: Path) -> None:
+    from pcobra.cobra_installer import CobraProject, validate_project
+
+    entrypoint = tmp_path / "main.co"
+    entrypoint.write_text("imprimir('hola')\n", encoding="utf-8")
+    (tmp_path / "cobra.toml").write_text('[project]\nname = "demo"\n', encoding="utf-8")
+
+    result = validate_project(CobraProject(project_root=tmp_path, entrypoint=entrypoint))
+
+    assert result.is_valid
+    assert result.errors == ()
+
+
+def test_validate_build_options_acepta_entrypoint_co_fuente_texto_descubierto(tmp_path: Path) -> None:
+    from pcobra.cobra_installer import BuildOptions
+    from pcobra.cobra_installer.validator import validate_build_options
+
+    entrypoint = tmp_path / "main.co"
+    entrypoint.write_text("imprimir('hola')\n", encoding="utf-8")
+    (tmp_path / "cobra.toml").write_text('[project]\nname = "demo"\n', encoding="utf-8")
+
+    options = validate_build_options(BuildOptions(project_root=tmp_path))
+
+    assert options.project_root == tmp_path
 
 
 def test_validate_project_acepta_proyecto_cobra_minimo(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Fix a high-priority validation bug where text `.co` entrypoints (e.g. `main.co` or `app.co`) were flagged as invalid during project validation and caused builds to fail before manifest generation.

### Description

- Relaxed entrypoint extension check in `src/pcobra/cobra_installer/validator.py` to accept both `.cobra` and `.co` by using `COBRA_EXTENSIONS` instead of only `.cobra`, and updated the error message accordingly.
- Left the existing distinction between binary `.co` packages and text `.co` sources intact via the `es_paquete_cobra` checks so binary packages are still rejected in the appropriate validation phase.
- Updated `tests/unit/test_cobra_installer_models.py` to stop expecting `entrypoint_extension_invalid` for `.co` sources and added two regression tests that assert a text `main.co` entrypoint is accepted both when provided directly and when discovered via `validate_build_options`.
- Changed files: `src/pcobra/cobra_installer/validator.py` and `tests/unit/test_cobra_installer_models.py`.

### Testing

- Ran `pytest -q tests/unit/test_cobra_installer_models.py` and the unit tests passed (12 passed, 1 warning).
- Compiled the validator module with `python -m py_compile src/pcobra/cobra_installer/validator.py` with no errors.
- Ran `git diff --check` with no trailing whitespace or other diff-check issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4aa67a3e508327a000fc1b8acd30d9)