### PR TITLE
Ignorar imports core y locales al detectar dependencias Cobra

### DIFF
--- a/src/pcobra/cobra_installer/dependency_resolver.py
+++ b/src/pcobra/cobra_installer/dependency_resolver.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from pcobra.cobra.packaging import normalizar_nombre_paquete, validar_version_paquete
+from pcobra.cobra.usar_loader import resolver_modulo_cobra_proyecto
+from pcobra.cobra.usar_policy import USAR_COBRA_ALLOWLIST
 from pcobra.cobra_installer.hub_resolver import (
     CobraHubResolution,
     CobraHubResolver,
@@ -306,7 +308,11 @@ def detect_cobra_imports(project_root: str | Path) -> set[str]:
         for match in _IMPORT_RE.finditer(text):
             raw = match.group("usar") or match.group("import") or ""
             module = raw.strip().strip("\"'")
-            if _is_local_import(module):
+            if (
+                _is_local_import(module)
+                or _is_builtin_import(module)
+                or _is_project_import(module, root, file)
+            ):
                 continue
             package = module.split(".", 1)[0]
             imports.add(_normalize_dependency_name(package))
@@ -328,6 +334,32 @@ def _is_local_import(module: str) -> bool:
         or "/" in module
         or "\\" in module
     )
+
+
+def _is_builtin_import(module: str) -> bool:
+    """Indica si ``module`` es un módulo público/core de ``usar``."""
+
+    package = module.split(".", 1)[0].strip().lower().replace("-", "_")
+    return package in USAR_COBRA_ALLOWLIST
+
+
+def _is_project_import(module: str, root: Path, current_file: Path) -> bool:
+    """Indica si ``module`` resuelve a un ``.co`` del proyecto actual."""
+
+    candidates = [module]
+    package = module.split(".", 1)[0]
+    if package != module:
+        candidates.append(package)
+
+    for candidate in candidates:
+        try:
+            resolver_modulo_cobra_proyecto(
+                candidate, project_root=root, current_file=current_file
+            )
+        except (FileNotFoundError, ValueError, OSError):
+            continue
+        return True
+    return False
 
 
 def _normalize_dependency_name(name: str) -> str:

--- a/tests/unit/test_cobra_installer_dependency_resolver.py
+++ b/tests/unit/test_cobra_installer_dependency_resolver.py
@@ -38,6 +38,27 @@ def test_detecta_imports_cobra_estaticos(tmp_path):
     assert detect_cobra_imports(tmp_path) == {"dep", "otra"}
 
 
+def test_ignora_modulos_core_de_usar(tmp_path):
+    (tmp_path / "main.cobra").write_text(
+        'usar "numero"\nimport "datos"\nusar dep.modulo\n', encoding="utf-8"
+    )
+
+    assert detect_cobra_imports(tmp_path) == {"dep"}
+
+
+def test_ignora_modulos_locales_del_proyecto(tmp_path):
+    (tmp_path / "util.co").write_text("var helper = 1\n", encoding="utf-8")
+    (tmp_path / "utilidades").mkdir()
+    (tmp_path / "utilidades" / "fechas.co").write_text(
+        "var hoy = 1\n", encoding="utf-8"
+    )
+    (tmp_path / "main.cobra").write_text(
+        'usar "util"\nusar utilidades.fechas\nusar dep.modulo\n', encoding="utf-8"
+    )
+
+    assert detect_cobra_imports(tmp_path) == {"dep"}
+
+
 def test_lee_dependencias_de_cobra_toml(tmp_path):
     (tmp_path / "cobra.toml").write_text(
         '[dependencies]\nDep = "1.2.3"\n[project]\ndependencies = ["otra==2.0.0"]\n',


### PR DESCRIPTION
### Motivation
- Evitar que imports `usar` que referencian módulos built-in de `usar` o módulos `.co` del propio proyecto se conviertan erróneamente en dependencias externas de CobraHub.
- Corregir la lógica de detección estática para que respete el allowlist canónico y la resolución de módulos de proyecto antes de añadir el prefijo de paquete a la lista de dependencias.

### Description
- Reutiliza la allowlist canónica de `usar` importando `USAR_COBRA_ALLOWLIST` y añade la comprobación `_is_builtin_import` para excluir módulos core (por ejemplo `numero`, `datos`).
- Añade `_is_project_import` que usa `resolver_modulo_cobra_proyecto` para detectar si un `usar` apunta a un `.co` local y así excluirlo como dependencia externa.
- Actualiza `detect_cobra_imports` para saltarse imports locales, core y de proyecto antes de normalizar el nombre de paquete externo.
- Añade dos pruebas unitarias que verifican que se ignoran los módulos core de `usar` y los módulos locales de proyecto (actualiza `tests/unit/test_cobra_installer_dependency_resolver.py`).

### Testing
- Ejecutado `pytest -q tests/unit/test_cobra_installer_dependency_resolver.py` y las pruebas automatizadas pasaron (`8 passed`).
- Compilación comprobada con `python -m py_compile src/pcobra/cobra_installer/dependency_resolver.py` y no reportó errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4aa8b9ccf883279e7a52fb1b64cdec)