### PR TITLE
Incluir runtime pcobra.cobra y _stubs en build generado por `transpile`

### DIFF
--- a/src/pcobra/cobra_installer/transpile.py
+++ b/src/pcobra/cobra_installer/transpile.py
@@ -166,7 +166,7 @@ def _entrypoint_code(module_filename: str) -> str:
 def _copy_runtime(runtime_dir: Path) -> tuple[Path, ...]:
     pcobra_root = Path(pcobra.__file__).resolve().parent
     copied: list[Path] = []
-    for name in ("corelibs", "standard_library", "core"):
+    for name in ("cobra", "corelibs", "standard_library", "core", "_stubs"):
         source = pcobra_root / name
         if source.exists():
             destination = runtime_dir / name

--- a/tests/unit/test_cobra_installer_transpile.py
+++ b/tests/unit/test_cobra_installer_transpile.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import os
 import py_compile
+import subprocess
+import sys
 from pathlib import Path
 
 from pcobra.cobra_installer import (
@@ -50,7 +53,9 @@ def test_transpile_project_prepara_build_python_y_recursos(tmp_path: Path) -> No
     py_compile.compile(str(result.generated_code), doraise=True)
     py_compile.compile(str(result.entrypoint), doraise=True)
     assert (result.runtime_dir / "__init__.py").is_file()
+    assert (result.runtime_dir / "cobra" / "core" / "nativos").is_dir()
     assert result.corelibs_dir.is_dir()
+    assert (result.runtime_dir / "_stubs").is_dir()
     assert (result.runtime_dir / "standard_library").is_dir()
     assert (result.assets_dir / "assets" / "logo.txt").read_text(encoding="utf-8") == "asset"
     assert (result.config_dir / "config" / "settings.json").is_file()
@@ -81,3 +86,33 @@ def test_transpile_project_permite_omitir_resolucion_cobrahub(tmp_path: Path) ->
 
     assert result.generated_code.is_file()
     assert result.dependency_resolution is None
+
+
+def test_transpile_project_runtime_autonomo_ejecuta_codigo_generado(tmp_path: Path) -> None:
+    project_root = tmp_path / "app"
+    project_root.mkdir()
+    entrypoint = project_root / "main.cobra"
+    entrypoint.write_text("imprimir('runtime ok')\n", encoding="utf-8")
+
+    result = transpile_project(
+        CobraProject(project_root=project_root, entrypoint=entrypoint),
+        tmp_path / "build-runtime",
+        BuildOptions(
+            project_root=project_root,
+            entrypoint=entrypoint,
+            include_dependencies=False,
+        ),
+    )
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(result.runtime_dir.parent)
+    completed = subprocess.run(
+        [sys.executable, str(result.entrypoint)],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.stdout.strip() == "runtime ok"


### PR DESCRIPTION
### Motivation
- Arreglar fallo donde el código Python generado importaba rutas como `pcobra.cobra.core.nativos` pero el árbol de build sólo incluía `pcobra/core`, dejando el runtime incompleto y provocando errores al ejecutar el build sin `pcobra` instalado globalmente.
- Garantizar que la copia del runtime deje la estructura mínima necesaria para que la librería estándar y los corelibs funcionen en un entorno aislado.

### Description
- Modificado `_copy_runtime` en `src/pcobra/cobra_installer/transpile.py` para copiar además los paquetes `cobra` y `_stubs` además de `corelibs`, `standard_library` y `core`.
- Actualizadas las pruebas en `tests/unit/test_cobra_installer_transpile.py` para verificar la presencia de `cobra/core/nativos` y `_stubs` en el runtime copiado y se añadió una prueba end-to-end que ejecuta el `entrypoint` generado con `PYTHONPATH` apuntando solo al runtime preparado.
- No se cambió la API pública ni el formato del `TranspileResult`; los cambios sólo afectan la inclusión de recursos runtime en el árbol de build.

### Testing
- Ejecutado `pytest -q tests/unit/test_cobra_installer_transpile.py` y la suite relevante pasó con `3 passed, 1 warning`.
- Verificado byte-compile con `python -m py_compile src/pcobra/cobra_installer/transpile.py tests/unit/test_cobra_installer_transpile.py` y la comprobación fue satisfactoria.
- Ejecutada la prueba end-to-end que arranca el `entrypoint` generado con `PYTHONPATH` apuntando al runtime copiado y verificó que la salida es la esperada (`runtime ok`), confirmando que el build puede ejecutarse sin un `pcobra` global instalado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b4ee62cd883278fbdf9b9ec7d8942)