### PR TITLE
Fix prepare_runtime import-time architecture dependency

### DIFF
--- a/src/pcobra/cobra_installer/runtime_builder.py
+++ b/src/pcobra/cobra_installer/runtime_builder.py
@@ -318,6 +318,7 @@ def _pyinstaller_entrypoint_code(source_entrypoint: Path | None, build_dir: Path
 
 
 _RUNTIME_COBRA_SUBPACKAGES = (
+    "architecture",
     "bindings",
     "cli",
     "core",

--- a/tests/unit/test_cobra_installer_runtime_builder.py
+++ b/tests/unit/test_cobra_installer_runtime_builder.py
@@ -65,6 +65,7 @@ def test_prepare_runtime_copia_runtime_recursos_y_entrypoint_filtrados(tmp_path:
     assert (result.runtime_dir / "core").is_dir()
     assert result.corelibs_dir.is_dir()
     assert result.standard_library_dir.is_dir()
+    assert (result.cobra_dir / "architecture" / "backend_policy.py").is_file()
     assert (result.cobra_dir / "core" / "parser.py").is_file()
     assert (result.cobra_dir / "cli" / "cli.py").is_file()
     assert not (result.runtime_dir / "cobra" / "benchmarks").exists()


### PR DESCRIPTION
### Motivation

- Ensure the prepared runtime tree includes import-time dependencies needed by the bundled `pcobra` package because `pcobra/__init__.py` imports `pcobra.cobra.architecture.backend_policy` at import time and failing to copy that package caused `ModuleNotFoundError` in packaged apps.

### Description

- Add `"architecture"` to the `_RUNTIME_COBRA_SUBPACKAGES` allowlist in `src/pcobra/cobra_installer/runtime_builder.py` so `pcobra.cobra.architecture` is copied into the runtime tree.
- Add a unit-test assertion in `tests/unit/test_cobra_installer_runtime_builder.py` to verify `architecture/backend_policy.py` is present in the prepared runtime.

### Testing

- Ran `python -m pytest tests/unit/test_cobra_installer_runtime_builder.py -q` and the tests passed (`2 passed`, `1 warning`).
- Ran `python -m ruff check src/pcobra/cobra_installer/runtime_builder.py tests/unit/test_cobra_installer_runtime_builder.py` and no linting issues were reported.
- Ran `python -m py_compile src/pcobra/cobra_installer/runtime_builder.py tests/unit/test_cobra_installer_runtime_builder.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b57a720848327b6d9c17fab9fd829)