### PR TITLE
Use generated python/__main__.py for PyInstaller spec and switch fallback to public `run`

### DIFF
--- a/src/pcobra/cobra_installer/runtime_builder.py
+++ b/src/pcobra/cobra_installer/runtime_builder.py
@@ -9,6 +9,9 @@ from typing import Mapping, Sequence
 
 import pcobra
 
+from pcobra.cobra.backends.python_adapter import PythonAdapter
+from pcobra.cobra.cli.execution_pipeline import prevalidar_y_parsear_codigo
+
 from .dependency_resolver import DependencyResolutionResult, resolve_project_dependencies
 from .manifest import create_manifest
 from .project import BuildOptions, BuildResult, CobraInstallerError, CobraProject, discover_project
@@ -38,6 +41,8 @@ class RuntimePreparationResult:
     documentation_dir: Path
     auxiliary_dir: Path
     entrypoint: Path
+    python_dir: Path | None = None
+    generated_code: Path | None = None
     copied_resources: Mapping[str, tuple[Path, ...]] = field(default_factory=dict)
     dependency_resolution: DependencyResolutionResult | None = None
     logs: tuple[str, ...] = ()
@@ -70,6 +75,7 @@ def prepare_runtime(
 
     runtime_root = target / "runtime"
     pcobra_runtime = runtime_root / "pcobra"
+    python_dir = target / "python"
     packages_dir = target / "packages"
     assets_dir = target / "assets"
     config_dir = target / "config"
@@ -77,6 +83,7 @@ def prepare_runtime(
     auxiliary_dir = target / "resources"
     for directory in (
         pcobra_runtime,
+        python_dir,
         packages_dir,
         assets_dir,
         config_dir,
@@ -110,8 +117,9 @@ def prepare_runtime(
         auxiliary_dir,
         root,
     )
-    entrypoint = target / "pyinstaller_entrypoint.py"
     source_entrypoint = normalized_project.entrypoint or normalized_options.entrypoint
+    generated_code = _write_transpiled_python_entrypoint(source_entrypoint, root, python_dir)
+    entrypoint = target / "pyinstaller_entrypoint.py"
     entrypoint.write_text(
         _pyinstaller_entrypoint_code(source_entrypoint, target), encoding="utf-8"
     )
@@ -128,6 +136,8 @@ def prepare_runtime(
         documentation_dir=documentation_dir,
         auxiliary_dir=auxiliary_dir,
         entrypoint=entrypoint,
+        python_dir=python_dir,
+        generated_code=generated_code,
         copied_resources={
             "runtime": runtime_copies,
             "packages": (*copied_hub_packages, *copied_explicit_packages, *copied_project_packages),
@@ -136,11 +146,13 @@ def prepare_runtime(
             "documentation": copied_docs,
             "auxiliary": copied_auxiliary,
             "entrypoint": (entrypoint,),
+            "python": (python_dir / "__main__.py",) if generated_code is not None else (),
         },
         dependency_resolution=dependency_resolution,
         logs=(
             f"Runtime Cobra copiado en {pcobra_runtime}.",
             f"Entrypoint Python para PyInstaller creado en {entrypoint}.",
+            f"Entrypoint Python transpilado creado en {python_dir / '__main__.py'}.",
         ),
     )
 
@@ -215,6 +227,41 @@ def package_current_project(project_root: str | Path | None = None, **kwargs: ob
 
     options = BuildOptions(project_root=project_root or Path.cwd(), **kwargs)
     return build_project(options)
+
+
+def _write_transpiled_python_entrypoint(
+    source_entrypoint: Path | None, project_root: Path, python_dir: Path
+) -> Path | None:
+    if source_entrypoint is None:
+        return None
+    source = Path(source_entrypoint).expanduser().resolve()
+    if not source.is_file():
+        return None
+
+    ast = prevalidar_y_parsear_codigo(source.read_text(encoding="utf-8"))
+    generated = PythonAdapter().compile(
+        ast,
+        {"source_file": source, "project_root": project_root},
+    )
+    generated_path = python_dir / f"{source.stem}.py"
+    generated_path.write_text(generated, encoding="utf-8")
+    (python_dir / "__main__.py").write_text(
+        _transpiled_entrypoint_code(generated_path.name), encoding="utf-8"
+    )
+    return generated_path
+
+
+def _transpiled_entrypoint_code(module_filename: str) -> str:
+    return (
+        '"""Entrypoint Python generado por cobra_installer."""\n'
+        "from __future__ import annotations\n\n"
+        "import runpy\n"
+        "from pathlib import Path\n\n"
+        "if __name__ == '__main__':\n"
+        "    runpy.run_path(\n"
+        f"        str(Path(__file__).with_name({module_filename!r})), run_name='__main__'\n"
+        "    )\n"
+    )
 
 
 def _copy_pcobra_runtime(destination_root: Path) -> tuple[Path, ...]:
@@ -362,13 +409,13 @@ def _pyinstaller_entrypoint_code(source_entrypoint: Path | None, build_dir: Path
         "    if not source_entrypoint.is_file():\n"
         "        raise SystemExit('No se encontró entrypoint Python generado ni fuente Cobra original.')\n"
         "    from pcobra.cobra.cli.cli import main as cobra_main\n"
-        "    raise SystemExit(cobra_main(['ejecutar', str(source_entrypoint)]))\n"
+        "    raise SystemExit(cobra_main(['run', str(source_entrypoint)]))\n"
     )
 
 
 _RUNTIME_COBRA_SUBPACKAGES = (
     # Importados por pcobra.__init__ y por las rutas de resolución/transpilación
-    # usadas por `pcobra.cobra.cli.cli ejecutar`.
+    # usadas por `pcobra.cobra.cli.cli run`.
     "architecture",
     "backends",
     "bindings",

--- a/src/pcobra/cobra_installer/spec_writer.py
+++ b/src/pcobra/cobra_installer/spec_writer.py
@@ -139,11 +139,12 @@ def _collect_datas(
     runtime: "RuntimePreparationResult",
     additional_datas: Sequence[tuple[Path | str, str]],
 ) -> tuple[tuple[str, str], ...]:
-    candidates: list[tuple[Path, str]] = [
+    candidates: list[tuple[Path | None, str]] = [
         (runtime.runtime_dir, "runtime/pcobra"),
         (runtime.corelibs_dir, "runtime/pcobra/corelibs"),
         (runtime.standard_library_dir, "runtime/pcobra/standard_library"),
         (runtime.cobra_dir, "runtime/pcobra/cobra"),
+        (runtime.python_dir, "python"),
         (runtime.packages_dir, "packages"),
         (runtime.assets_dir, "assets"),
         (runtime.config_dir, "config"),

--- a/tests/unit/test_cobra_installer_runtime_builder.py
+++ b/tests/unit/test_cobra_installer_runtime_builder.py
@@ -61,6 +61,12 @@ def test_prepare_runtime_copia_runtime_recursos_y_entrypoint_filtrados(tmp_path:
 
     assert isinstance(result, RuntimePreparationResult)
     py_compile.compile(str(result.entrypoint), doraise=True)
+    entrypoint_code = result.entrypoint.read_text(encoding="utf-8")
+    assert (result.python_dir / "__main__.py").is_file()
+    assert result.generated_code is not None and result.generated_code.is_file()
+    assert "generated_main = BASE_DIR / 'python' / '__main__.py'" in entrypoint_code
+    assert "cobra_main(['run', str(source_entrypoint)])" in entrypoint_code
+    assert "cobra_main(['ejecutar'" not in entrypoint_code
     assert (result.runtime_dir / "__init__.py").is_file()
     assert (result.runtime_dir / "core").is_dir()
     assert result.corelibs_dir.is_dir()
@@ -99,5 +105,7 @@ def test_prepare_runtime_acepta_dependencias_como_rutas_y_no_resuelve_si_se_omit
         ),
     )
 
+    assert (result.python_dir / "__main__.py").is_file()
+    assert result.generated_code is not None and result.generated_code.is_file()
     assert (result.packages_dir / "manual.co").read_bytes() == b"manual"
     assert result.dependency_resolution is None

--- a/tests/unit/test_cobra_installer_spec_writer.py
+++ b/tests/unit/test_cobra_installer_spec_writer.py
@@ -13,6 +13,7 @@ def _runtime_tree(tmp_path: Path) -> RuntimePreparationResult:
     corelibs_dir = runtime_dir / "corelibs"
     standard_library_dir = runtime_dir / "standard_library"
     cobra_dir = runtime_dir / "cobra"
+    python_dir = build_dir / "python"
     packages_dir = build_dir / "packages"
     assets_dir = build_dir / "assets"
     config_dir = build_dir / "config"
@@ -23,6 +24,7 @@ def _runtime_tree(tmp_path: Path) -> RuntimePreparationResult:
         corelibs_dir,
         standard_library_dir,
         cobra_dir,
+        python_dir,
         packages_dir,
         assets_dir,
         config_dir,
@@ -31,6 +33,7 @@ def _runtime_tree(tmp_path: Path) -> RuntimePreparationResult:
     ):
         path.mkdir(parents=True, exist_ok=True)
     entrypoint.write_text("print('entrypoint')\n", encoding="utf-8")
+    (python_dir / "__main__.py").write_text("print('generated')\n", encoding="utf-8")
     return RuntimePreparationResult(
         build_dir=build_dir,
         runtime_dir=runtime_dir,
@@ -43,6 +46,8 @@ def _runtime_tree(tmp_path: Path) -> RuntimePreparationResult:
         documentation_dir=documentation_dir,
         auxiliary_dir=auxiliary_dir,
         entrypoint=entrypoint,
+        python_dir=python_dir,
+        generated_code=python_dir / "main.py",
     )
 
 
@@ -67,6 +72,7 @@ def test_write_spec_onedir_incluye_runtime_recursos_imports_y_nombre(tmp_path: P
     assert str(runtime.entrypoint) in content
     assert "('" in content and "runtime/pcobra" in content
     assert "runtime/pcobra/corelibs" in content
+    assert "python" in content
     assert "packages" in content
     assert "assets" in content
     assert "config" in content


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where the PyInstaller spec referenced `pyinstaller_entrypoint.py` but the packaged runtime did not include a runnable `python/__main__.py`, causing builds to fall back to a legacy `ejecutar` path that is not present in the default public CLI profile.\n
### Description
- Generate a transpiled Python entrypoint during `prepare_runtime` and write `python/<entrypoint>.py` plus `python/__main__.py` so the PyInstaller bootstrap can execute a real Python `__main__`.\n
- Add `python_dir` and `generated_code` to `RuntimePreparationResult` and include the generated `python` directory in the runtime `copied_resources`.\n
- Include the `python` directory in the `.spec` `datas` written by `write_spec` so `BASE_DIR / 'python' / '__main__.py'` is packaged.\n
- Change the PyInstaller bootstrap fallback from the legacy `cobra_main(['ejecutar', ...])` to the public `cobra_main(['run', ...])`.\n
- Update unit tests (`tests/unit/test_cobra_installer_runtime_builder.py` and `tests/unit/test_cobra_installer_spec_writer.py`) to assert the generated entrypoint and the new fallback/`python` datas are present.

### Testing
- Ran `python -m pytest tests/unit/test_cobra_installer_runtime_builder.py tests/unit/test_cobra_installer_models.py tests/unit/test_cobra_installer_spec_writer.py`, and the suite passed (`14 passed`, `1 warning`).\n
- Ran static compilation with `python -m compileall src/pcobra/cobra_installer tests/unit/test_cobra_installer_runtime_builder.py tests/unit/test_cobra_installer_spec_writer.py`, and compilation completed without errors.\n
- Verified the modified unit tests that initially failed were fixed and now pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b5c77ef748327902ebc1f0354a226)