### PR TITLE
Incluir Python transpilado en el .spec del instalador Cobra

### DIFF
--- a/src/pcobra/cobra_installer/runtime_builder.py
+++ b/src/pcobra/cobra_installer/runtime_builder.py
@@ -262,6 +262,7 @@ def build_project(
             runtime=runtime,
             output_dir=output_dir,
             executable_name=name,
+            additional_datas=((transpiled.generated_code, "."),),
         )
     )
 

--- a/tests/unit/test_cobra_installer_transpile.py
+++ b/tests/unit/test_cobra_installer_transpile.py
@@ -124,6 +124,9 @@ def test_build_project_orquesta_flujo_completo_con_callback(
     assert result.pyinstaller_version == "6.test"
     assert (project_root / "cobra.lock").is_file()
     assert calls and calls[0].name == "main.spec"
+    spec_content = calls[0].read_text(encoding="utf-8")
+    assert str(project_root / "build" / "python" / "main.py") in spec_content
+    assert "'.'" in spec_content
     assert any("1/12 Descubriendo" in item for item in progress)
     assert "pyinstaller simulado" in progress
     assert (project_root / "dist" / "cobra_build_manifest.json").is_file()


### PR DESCRIPTION
### Motivation

- PyInstaller analizaba solo el `__main__.py` generado y la entrada ejecutable no encontraba el módulo Python transpilado sibling, rompiendo el ejecutable en tiempo de inicio. 
- Se necesita que el orquestador `build_project` incluya explícitamente el código generado en la especificación para que `runpy.run_path(...with_name(...))` pueda resolverlo dentro del binario.

### Description

- Al escribir la `.spec` desde `build_project` se pasa `additional_datas=((transpiled.generated_code, "."),)` al `SpecBuildContext` para incluir el módulo transpilado en los datos empaquetados.     
- Se actualizó la prueba de orquestación `tests/unit/test_cobra_installer_transpile.py::test_build_project_orquesta_flujo_completo_con_callback` para verificar que el contenido del `.spec` contiene la ruta a `build/python/main.py` y la entrada de destino de datos `'.'`.
- Los cambios afectan `src/pcobra/cobra_installer/runtime_builder.py` (inclusión de `additional_datas`) y la prueba mencionada.

### Testing

- Se compiló estáticamente con `python -m py_compile` sobre los archivos modificados y no arrojó errores.  
- Se ejecutaron las pruebas unitarias relevantes con `pytest` sobre `tests/unit/test_cobra_installer_transpile.py` y `tests/unit/test_cobra_installer_spec_writer.py`, y todas pasaron (`5 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b6719d7bc8327ae2be7f84db7158f)