### PR TITLE
Use Page.open/close for packaging AlertDialog in IDLE (fix Flet 0.28+ compatibility)

### DIFF
--- a/src/pcobra/gui/idle.py
+++ b/src/pcobra/gui/idle.py
@@ -903,15 +903,19 @@ def main(page: "ft.Page"):
         )
 
         def cerrar_dialogo(_ev=None) -> None:
-            dialog.open = False
-            page.update()
+            cerrar = getattr(page, "close", None)
+            if callable(cerrar):
+                cerrar(dialog)
+            else:
+                dialog.open = False
+                page.update()
 
         def ejecutar_empaquetado(_ev=None) -> None:
             nombre = (nombre_input.value or "").strip() or proyecto_detectado.name
             icono = (icono_input.value or "").strip() or None
             target = selector_so.value or "current"
             mode = selector_modo.value or "onedir"
-            dialog.open = False
+            cerrar_dialogo()
             salida.value = "Iniciando empaquetado..."
             page.update()
 
@@ -977,9 +981,13 @@ def main(page: "ft.Page"):
                 ),
             ],
         )
-        page.dialog = dialog
-        dialog.open = True
-        page.update()
+        abrir = getattr(page, "open", None)
+        if callable(abrir):
+            abrir(dialog)
+        else:
+            page.dialog = dialog
+            dialog.open = True
+            page.update()
 
     def archivo_visible_permite_accion_paquete(accion: str) -> bool:
         """Valida que la ruta visible apunte a un paquete Cobra para acciones de paquete."""

--- a/tests/unit/test_gui_idle.py
+++ b/tests/unit/test_gui_idle.py
@@ -58,6 +58,12 @@ def _fake_flet():
     class TextButton(ElevatedButton):
         pass
 
+    class AlertDialog:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.open = kwargs.get("open", False)
+            self.actions = kwargs.get("actions", [])
+
     class Layout:
         def __init__(self, controls=None, **_kwargs):
             self.controls = controls or []
@@ -111,6 +117,7 @@ def _fake_flet():
     class Page:
         def __init__(self):
             self.controls = []
+            self.opened_controls = []
             self.update = MagicMock()
 
         def add(self, *args):
@@ -125,6 +132,15 @@ def _fake_flet():
             for arg in args:
                 _flatten(arg)
 
+        def open(self, control):
+            control.open = True
+            self.opened_controls.append(control)
+            self.update()
+
+        def close(self, control):
+            control.open = False
+            self.update()
+
     return SimpleNamespace(
         TextField=TextField,
         Text=Text,
@@ -132,6 +148,7 @@ def _fake_flet():
         Switch=Switch,
         ElevatedButton=ElevatedButton,
         TextButton=TextButton,
+        AlertDialog=AlertDialog,
         Row=Row,
         Column=Column,
         Container=Container,
@@ -1257,6 +1274,28 @@ def test_guardar_como_resuelve_src_programa_sin_extension_como_cobra(
     assert destino.read_text(encoding="utf-8") == "imprimir('programa')"
     assert salida.value == f"Archivo guardado: {destino}"
     assert ruta_input.value == str(destino)
+
+
+def test_empaquetar_muestra_dialogo_con_page_open(monkeypatch, tmp_path):
+    ft, page, _entrada, ruta_input, _salida, _abrir, _guardar_como = (
+        _preparar_idle_archivos(monkeypatch, tmp_path)
+    )
+    proyecto = idle.runtime.resolver_workspace_root_idle() / "app"
+    proyecto.mkdir(parents=True)
+    ruta_input.value = str(proyecto)
+    empaquetar = next(
+        c
+        for c in page.controls
+        if isinstance(c, ft.ElevatedButton) and c.text == "Empaquetar"
+    )
+
+    empaquetar.on_click(None)
+
+    assert len(page.opened_controls) == 1
+    dialog = page.opened_controls[0]
+    assert isinstance(dialog, ft.AlertDialog)
+    assert dialog.open is True
+    assert not hasattr(page, "dialog")
 
 
 def test_guardar_como_desde_dockerfile_conserva_nombre_sin_forzar_cobra(


### PR DESCRIPTION
### Motivation

- Flet 0.28.x pages do not use a `dialog` attribute, so assigning `page.dialog = ...` left the `AlertDialog` off the page and made the `Empaquetar` action non-functional on real pages.
- Ensure the packaging dialog is shown and closed correctly on modern `ft.Page` implementations while keeping a fallback for older page objects.

### Description

- Updated `src/pcobra/gui/idle.py` to prefer `page.close(dialog)` for dismissing the dialog and to use `page.open(dialog)` to show the dialog when those callables exist, with a legacy fallback that sets `dialog.open = True` and `page.dialog = dialog`.
- Reused the new close path when the user starts packaging by calling `cerrar_dialogo()` instead of setting `dialog.open = False` directly.
- Extended the GUI test doubles in `tests/unit/test_gui_idle.py` with an `AlertDialog` class, `Page.open/close` stubs and an `opened_controls` list, and added `test_empaquetar_muestra_dialogo_con_page_open` to assert the dialog is opened through `Page.open` and that `page.dialog` is not used.

### Testing

- Ran `python -m compileall -q src/pcobra/gui/idle.py tests/unit/test_gui_idle.py` and compilation succeeded.
- Ran `pytest -q tests/unit/test_gui_idle.py` and the suite passed: `42 passed, 1 warning`, including the new dialog regression test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b6df78d108327be3fa9e9629f6fb1)