### PR TITLE
Fix IDLE packaging bridge compatibility

### DIFF
--- a/src/pcobra/cobra_installer/idle_bridge.py
+++ b/src/pcobra/cobra_installer/idle_bridge.py
@@ -23,6 +23,8 @@ class IdlePackageResult:
 
     executable_path: Path | None
     dist_dir: Path
+    artifact_path: Path | None = None
+    output_dir: Path | None = None
 
 
 def package_current_project(
@@ -30,6 +32,7 @@ def package_current_project(
     ui_options: Mapping[str, Any] | object | None = None,
     progress_callback: ProgressCallback | None = None,
     error_callback: ErrorCallback | None = None,
+    **kwargs: object,
 ) -> IdlePackageResult:
     """Empaqueta el proyecto actual desde IDLE usando la API del instalador.
 
@@ -37,18 +40,31 @@ def package_current_project(
     un objeto simple) y este puente las convierte a :class:`BuildOptions`,
     conecta el callback de progreso al ``log_callback`` del builder y traduce
     errores controlados del instalador a mensajes orientados a usuario.
+
+    También acepta las palabras clave históricas del diálogo IDLE
+    (``name``, ``target``, ``mode``, ``icon`` y ``log_callback``) para mantener
+    compatibilidad con llamadas directas existentes.
     """
 
-    options = _build_options_from_idle(project_path, ui_options, progress_callback)
+    merged_options = _merge_ui_options(ui_options, kwargs)
+    callback = progress_callback or _pop_callback(merged_options, "log_callback")
+    options = _build_options_from_idle(project_path, merged_options, callback)
     try:
-        if progress_callback is not None:
-            progress_callback("Iniciando empaquetado del proyecto Cobra...")
+        if callback is not None:
+            callback("Iniciando empaquetado del proyecto Cobra...")
         result = build_project(project_path, options)
         dist_dir = Path(result.dist_dir or result.output_dir or result.artifact_path)
         executable_path = _resolve_executable_path(result.executable_name, dist_dir)
-        if progress_callback is not None:
-            progress_callback(f"Empaquetado completado en {dist_dir}.")
-        return IdlePackageResult(executable_path=executable_path, dist_dir=dist_dir)
+        artifact_path = result.artifact_path or executable_path
+        output_dir = result.output_dir or dist_dir
+        if callback is not None:
+            callback(f"Empaquetado completado en {dist_dir}.")
+        return IdlePackageResult(
+            executable_path=executable_path,
+            dist_dir=dist_dir,
+            artifact_path=artifact_path,
+            output_dir=output_dir,
+        )
     except CobraInstallerError as exc:
         message = _user_message_from_installer_error(exc)
         if error_callback is not None:
@@ -67,10 +83,7 @@ def package_from_idle(
 
     merged_options = _merge_ui_options(ui_options, kwargs)
     return package_current_project(
-        project_root,
-        merged_options,
-        progress_callback,
-        error_callback,
+        project_root, merged_options, progress_callback, error_callback
     )
 
 
@@ -95,7 +108,9 @@ def _build_options_from_idle(
     )
 
 
-def _ui_options_to_dict(ui_options: Mapping[str, Any] | object | None) -> dict[str, Any]:
+def _ui_options_to_dict(
+    ui_options: Mapping[str, Any] | object | None,
+) -> dict[str, Any]:
     if ui_options is None:
         return {}
     if isinstance(ui_options, Mapping):
@@ -115,7 +130,18 @@ def _merge_ui_options(
     return merged
 
 
-def _resolve_executable_path(executable_name: str | None, dist_dir: Path) -> Path | None:
+def _pop_callback(options: dict[str, Any], name: str) -> ProgressCallback | None:
+    callback = options.pop(name, None)
+    if callback is None:
+        return None
+    if not callable(callback):
+        raise TypeError(f"{name} debe ser callable")
+    return callback
+
+
+def _resolve_executable_path(
+    executable_name: str | None, dist_dir: Path
+) -> Path | None:
     if not executable_name:
         return None
     direct = dist_dir / executable_name

--- a/tests/unit/test_cobra_installer_idle_bridge.py
+++ b/tests/unit/test_cobra_installer_idle_bridge.py
@@ -6,10 +6,16 @@ from types import SimpleNamespace
 import pytest
 
 from pcobra.cobra_installer import idle_bridge
-from pcobra.cobra_installer.project import BuildOptions, BuildResult, CobraInstallerError
+from pcobra.cobra_installer.project import (
+    BuildOptions,
+    BuildResult,
+    CobraInstallerError,
+)
 
 
-def test_package_current_project_convierte_opciones_idle_e_invoca_builder(monkeypatch, tmp_path: Path) -> None:
+def test_package_current_project_convierte_opciones_idle_e_invoca_builder(
+    monkeypatch, tmp_path: Path
+) -> None:
     calls = []
     progress = []
     dist_dir = tmp_path / "dist"
@@ -44,7 +50,9 @@ def test_package_current_project_convierte_opciones_idle_e_invoca_builder(monkey
         progress.append,
     )
 
-    assert result == idle_bridge.IdlePackageResult(executable, dist_dir)
+    assert result == idle_bridge.IdlePackageResult(
+        executable, dist_dir, executable, dist_dir
+    )
     assert len(calls) == 1
     assert calls[0][0] == tmp_path
     options = calls[0][1]
@@ -65,12 +73,16 @@ def test_package_current_project_convierte_opciones_idle_e_invoca_builder(monkey
     ]
 
 
-def test_package_current_project_acepta_objeto_simple_de_opciones(monkeypatch, tmp_path: Path) -> None:
+def test_package_current_project_acepta_objeto_simple_de_opciones(
+    monkeypatch, tmp_path: Path
+) -> None:
     captured = []
 
     def fake_build_project(_project_path, options):
         captured.append(options)
-        return BuildResult(success=True, executable_name="app", dist_dir=tmp_path / "dist")
+        return BuildResult(
+            success=True, executable_name="app", dist_dir=tmp_path / "dist"
+        )
 
     monkeypatch.setattr(idle_bridge, "build_project", fake_build_project)
 
@@ -86,7 +98,9 @@ def test_package_current_project_acepta_objeto_simple_de_opciones(monkeypatch, t
     assert captured[0].install_pyinstaller is True
 
 
-def test_package_current_project_traduce_error_controlado(monkeypatch, tmp_path: Path) -> None:
+def test_package_current_project_traduce_error_controlado(
+    monkeypatch, tmp_path: Path
+) -> None:
     errors = []
 
     def fake_build_project(_project_path, _options):
@@ -97,21 +111,72 @@ def test_package_current_project_traduce_error_controlado(monkeypatch, tmp_path:
     with pytest.raises(RuntimeError, match="No se pudo empaquetar"):
         idle_bridge.package_current_project(tmp_path, {}, error_callback=errors.append)
 
-    assert errors == [
-        "No se pudo empaquetar el proyecto Cobra: no existe main.cobra"
-    ]
+    assert errors == ["No se pudo empaquetar el proyecto Cobra: no existe main.cobra"]
 
 
-def test_package_from_idle_es_alias_compatible_con_kwargs(monkeypatch, tmp_path: Path) -> None:
+def test_package_from_idle_es_alias_compatible_con_kwargs(
+    monkeypatch, tmp_path: Path
+) -> None:
     captured = []
 
-    def fake_package_current_project(project_root, ui_options, progress_callback, error_callback):
+    def fake_package_current_project(
+        project_root, ui_options, progress_callback, error_callback
+    ):
         captured.append((project_root, ui_options, progress_callback, error_callback))
-        return idle_bridge.IdlePackageResult(tmp_path / "dist" / "demo", tmp_path / "dist")
+        return idle_bridge.IdlePackageResult(
+            tmp_path / "dist" / "demo", tmp_path / "dist"
+        )
 
-    monkeypatch.setattr(idle_bridge, "package_current_project", fake_package_current_project)
+    monkeypatch.setattr(
+        idle_bridge, "package_current_project", fake_package_current_project
+    )
 
-    result = idle_bridge.package_from_idle(tmp_path, {"nombre": "demo"}, objetivo="linux")
+    result = idle_bridge.package_from_idle(
+        tmp_path, {"nombre": "demo"}, objetivo="linux"
+    )
 
     assert result.dist_dir == tmp_path / "dist"
     assert captured == [(tmp_path, {"nombre": "demo", "objetivo": "linux"}, None, None)]
+
+
+def test_package_current_project_acepta_kwargs_historicos_del_idle(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured = []
+    progress = []
+    dist_dir = tmp_path / "dist"
+    artifact = dist_dir / "demo"
+
+    def fake_build_project(project_path, options):
+        captured.append((project_path, options))
+        return BuildResult(
+            success=True,
+            artifact_path=artifact,
+            output_dir=dist_dir,
+            dist_dir=dist_dir,
+            executable_name="demo",
+        )
+
+    monkeypatch.setattr(idle_bridge, "build_project", fake_build_project)
+
+    result = idle_bridge.package_current_project(
+        tmp_path,
+        name="demo",
+        target="current",
+        mode="onedir",
+        icon=None,
+        log_callback=progress.append,
+    )
+
+    assert result.artifact_path == artifact
+    assert result.output_dir == dist_dir
+    assert result.dist_dir == dist_dir
+    assert result.executable_path == dist_dir / "demo"
+    assert captured[0][1].name == "demo"
+    assert captured[0][1].target == "current"
+    assert captured[0][1].mode == "onedir"
+    assert captured[0][1].icon is None
+    assert progress == [
+        "Iniciando empaquetado del proyecto Cobra...",
+        f"Empaquetado completado en {dist_dir}.",
+    ]


### PR DESCRIPTION
### Motivation
- The IDLE packaging dialog historically called `package_current_project(...)` with keyword options like `name` and `log_callback` and read `BuildResult`-style fields such as `artifact_path`, so the new bridge broke that workflow.
- Preserve backward compatibility so the existing IDLE UI does not raise `TypeError` or `AttributeError` when invoking the bridge.

### Description
- Expanded `IdlePackageResult` to include `artifact_path` and `output_dir` so callers that expect `BuildResult`-compatible fields keep working. 
- Made `package_current_project` accept historical IDLE keywords via `**kwargs`, merge them with `ui_options`, and route a supplied `log_callback` into the builder `log_callback` path via a new `_pop_callback` helper. 
- Populate `artifact_path`/`output_dir` from the runtime `BuildResult` and keep `executable_path`/`dist_dir` resolution logic unchanged. 
- Added unit tests covering the legacy keyword-call path and the restored result fields in `tests/unit/test_cobra_installer_idle_bridge.py`.

### Testing
- Ran `python -m pytest tests/unit/test_cobra_installer_idle_bridge.py -q` which completed successfully (`5 passed`) with one deprecation warning. 
- Ran the combined installer-related tests with `python -m pytest tests/unit/test_cobra_installer_runtime_builder.py tests/unit/test_cobra_installer_models.py tests/unit/test_cobra_installer_idle_bridge.py -q` and all tests passed (`19 passed`, 1 deprecation warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b727fc72c8327bae7a72ddad5d9d3)