### PR TITLE
Restore installer BuildResult artifact path contract

### DIFF
--- a/src/pcobra/cobra_installer/runtime_builder.py
+++ b/src/pcobra/cobra_installer/runtime_builder.py
@@ -14,7 +14,7 @@ from .dependency_resolver import (
     DependencyResolutionResult,
     resolve_project_dependencies,
 )
-from .manifest import create_manifest, expected_artifact_path
+from .manifest import create_manifest
 from .project import (
     BuildOptions,
     BuildResult,
@@ -289,7 +289,7 @@ def build_project(
 
     return BuildResult(
         success=True,
-        artifact_path=expected_artifact_path(output_dir, name, normalized),
+        artifact_path=output_dir,
         project_root=Path(normalized.project_root),
         output_dir=output_dir,
         target=normalized.target,

--- a/tests/integration/test_cobra_installer_build.py
+++ b/tests/integration/test_cobra_installer_build.py
@@ -95,7 +95,7 @@ def test_installer_build_parametriza_modo_y_genera_manifest_sin_pyinstaller_real
     assert result.metadata["spec"] == str(spec_path)
     assert result.pyinstaller_version == "6.mock"
     assert result.mode is mode
-    assert result.artifact_path == tmp_path / expected_artifact
+    assert result.artifact_path == dist_dir
     assert manifest_payload["project"] == "demo-build"
     assert manifest_payload["backend"] == "python"
     assert manifest_payload["mode"] == mode.value


### PR DESCRIPTION
### Motivation
- Restore the public contract so `BuildResult.artifact_path` continues to point at the `dist` output directory (previous behavior) because a recent change made it point to the nested executable for `ONEDIR`, which broke existing unit tests.

### Description
- Remove the now-unused `expected_artifact_path` import and set `artifact_path = output_dir` in `build_project`, and update the parametrized integration test to assert `result.artifact_path == dist_dir` while leaving manifest `executable_path` calculation unchanged.

### Testing
- Ran `python -m pytest tests/unit/test_cobra_installer_transpile.py::test_build_project_orquesta_flujo_completo_con_callback tests/integration/test_cobra_installer_build.py -q` which succeeded (`3 passed`), ran `python -m ruff check src/pcobra/cobra_installer/runtime_builder.py tests/integration/test_cobra_installer_build.py` with no issues, and applied formatting with `black`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b7d57e07c832785e2dbdf43b4d0e0)