### PR TITLE
Ajusta orden del mensaje para módulos no canónicos

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -117,8 +117,8 @@ def _rechazar_modulo_no_canonico(nombre: str) -> None:
     if nombre_normalizado in blocklist_normalizada or nombre_normalizado in equivalentes_normalizados:
         raise PermissionError(
             f"Importación no permitida en 'usar': '{nombre}'. "
-            "módulo externo no permitido en REPL estricto (solo alias oficiales Cobra). "
             "Es un módulo backend/no canónico y no forma parte de la API pública. "
+            "módulo externo no permitido en REPL estricto (solo alias oficiales Cobra). "
             f"Módulos permitidos: {', '.join(USAR_COBRA_PUBLIC_MODULES)}."
         )
 
@@ -128,8 +128,8 @@ def _rechazar_modulo_no_canonico(nombre: str) -> None:
     ):
         raise PermissionError(
             f"Importación no permitida en 'usar': '{nombre}'. "
-            "módulo externo no permitido en REPL estricto (solo alias oficiales Cobra). "
             "Es un módulo backend/no canónico y no forma parte de la API pública. "
+            "módulo externo no permitido en REPL estricto (solo alias oficiales Cobra). "
             f"Módulos permitidos: {', '.join(USAR_COBRA_PUBLIC_MODULES)}."
         )
 


### PR DESCRIPTION
### Motivation
- Aclarar el orden de las frases en los mensajes de error de `_rechazar_modulo_no_canonico` para que la explicación de "Es un módulo backend/no canónico y no forma parte de la API pública." aparezca inmediatamente después de la primera parte del mensaje.

### Description
- Reordena las frases en los dos `raise PermissionError(...)` dentro de `_rechazar_modulo_no_canonico` en `src/pcobra/cobra/usar_loader.py`, sin cambiar la allowlist, la lógica de validación, el tipo de excepción ni modificar otros archivos.

### Testing
- Se ejecutó `python -m py_compile src/pcobra/cobra/usar_loader.py` y `git diff --check`, y ambos completaron con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a520e5dc9008327aa5009b1948801ea)