### PR TITLE
Consolida mensaje de rechazo para módulos no canónicos en _rechazar_modulo_no_canonico

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -114,24 +114,21 @@ def _rechazar_modulo_no_canonico(nombre: str) -> None:
     blocklist_normalizada = {normalizar_nombre_usar(item) for item in USAR_BACKEND_BLOCKLIST}
     equivalentes_normalizados = {normalizar_nombre_usar(item) for item in _BACKEND_EQUIVALENTS}
 
+    mensaje_error_no_canonico = (
+        f"Importación no permitida en 'usar': '{nombre}'. "
+        "Es un módulo backend/no canónico y no forma parte de la API pública. "
+        "módulo externo no permitido en REPL estricto (solo alias oficiales Cobra). "
+        f"Módulos permitidos: {', '.join(USAR_COBRA_PUBLIC_MODULES)}."
+    )
+
     if nombre_normalizado in blocklist_normalizada or nombre_normalizado in equivalentes_normalizados:
-        raise PermissionError(
-            f"Importación no permitida en 'usar': '{nombre}'. "
-            "Es un módulo backend/no canónico y no forma parte de la API pública. "
-            "módulo externo no permitido en REPL estricto (solo alias oficiales Cobra). "
-            f"Módulos permitidos: {', '.join(USAR_COBRA_PUBLIC_MODULES)}."
-        )
+        raise PermissionError(mensaje_error_no_canonico)
 
     if any(
         nombre_normalizado == prefijo or nombre_normalizado.startswith(f"{prefijo}_")
         for prefijo in _BACKEND_PREFIXES
     ):
-        raise PermissionError(
-            f"Importación no permitida en 'usar': '{nombre}'. "
-            "Es un módulo backend/no canónico y no forma parte de la API pública. "
-            "módulo externo no permitido en REPL estricto (solo alias oficiales Cobra). "
-            f"Módulos permitidos: {', '.join(USAR_COBRA_PUBLIC_MODULES)}."
-        )
+        raise PermissionError(mensaje_error_no_canonico)
 
 def validar_nombre_modulo_usar(nombre: str, *, require_allowlist: bool = True) -> str:
     """Valida nombre de `usar` y opcionalmente exige contrato canónico exacto."""


### PR DESCRIPTION
### Motivation
- Unificar la construcción del mensaje de error para rechazos de módulos backend/no canónicos en `usar` para evitar duplicación y asegurar el orden exacto de las cuatro partes del mensaje requerido.
- Mantener intacta la lógica de validación y el tipo de excepción (`PermissionError`) mientras se mejora la mantenibilidad del código en `src/pcobra/cobra/usar_loader.py`.

### Description
- Introduce la variable local `mensaje_error_no_canonico` en la función `_rechazar_modulo_no_canonico` para consolidar el texto del `PermissionError` con las cuatro partes en el orden solicitado.
- Reemplaza las dos construcciones duplicadas de `PermissionError` por `raise PermissionError(mensaje_error_no_canonico)` en las rutas de bloqueo por blocklist/equivalentes y por prefijos backend.
- No se modificó ninguna otra lógica, tipo de excepción, names de funciones ni archivos fuera de `src/pcobra/cobra/usar_loader.py`.

### Testing
- Ejecuté `python -m pytest tests/integration/test_usar_canonical_surface_contract.py -q`, que pasó con `26 passed, 1 warning`.
- Ejecuté `python -m pytest tests/core/test_usar_policy_nuevas_corelibs.py tests/core/test_superficie_publica_canonica.py tests/test_usar_public_exports_snapshot.py tests/integration/test_usar_canonical_surface_contract.py tests/integration/test_usar_export_sanitation.py -q`, que devolvió `150 passed, 1 failed, 1 warning`.
- El fallo fue en `tests/integration/test_usar_export_sanitation.py::test_colision_en_usar_emite_advertencia_y_no_sobrescribe`, donde la prueba esperaba una advertencia `RuntimeWarning` y una coincidencia con la regex "colisión", pero la ejecución levantó un `NameError` con un mensaje distinto y no se emitió la advertencia; esto no está relacionado con los cambios hechos en `src/pcobra/cobra/usar_loader.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52107902648327bee69510fa9bde5f)