### PR TITLE
Ordena mensaje de módulo no canónico en usar

### DIFF
--- a/src/pcobra/cobra/usar_loader.py
+++ b/src/pcobra/cobra/usar_loader.py
@@ -114,12 +114,21 @@ def _rechazar_modulo_no_canonico(nombre: str) -> None:
     blocklist_normalizada = {normalizar_nombre_usar(item) for item in USAR_BACKEND_BLOCKLIST}
     equivalentes_normalizados = {normalizar_nombre_usar(item) for item in _BACKEND_EQUIVALENTS}
 
-    mensaje_error_no_canonico = (
-        f"Importación no permitida en 'usar': '{nombre}'. "
-        "Es un módulo backend/no canónico y no forma parte de la API pública. "
-        "módulo externo no permitido en REPL estricto (solo alias oficiales Cobra). "
-        f"Módulos permitidos: {', '.join(USAR_COBRA_PUBLIC_MODULES)}."
+    partes_mensaje_error_no_canonico = [
+        f"Importación no permitida en 'usar': '{nombre}'.",
+        "Es un módulo backend/no canónico y no forma parte de la API pública.",
+    ]
+    detalle_repl_estricto = (
+        "módulo externo no permitido en REPL estricto (solo alias oficiales Cobra)."
     )
+    if detalle_repl_estricto:
+        partes_mensaje_error_no_canonico.append(detalle_repl_estricto)
+    if USAR_COBRA_PUBLIC_MODULES:
+        modulos_permitidos = ", ".join(USAR_COBRA_PUBLIC_MODULES)
+        partes_mensaje_error_no_canonico.append(
+            f"Módulos permitidos: {modulos_permitidos}."
+        )
+    mensaje_error_no_canonico = " ".join(partes_mensaje_error_no_canonico)
 
     if nombre_normalizado in blocklist_normalizada or nombre_normalizado in equivalentes_normalizados:
         raise PermissionError(mensaje_error_no_canonico)


### PR DESCRIPTION
### Motivation
- Asegurar que el texto de error en `_rechazar_modulo_no_canonico` se construya exactamente en el orden requerido: rechazo de importación, explicación backend/no canónica, detalle de REPL estricto (si existe) y lista de módulos permitidos (si existe). 

### Description
- En `src/pcobra/cobra/usar_loader.py` se reemplaza la concatenación literal de `mensaje_error_no_canonico` por una construcción por partes (`partes_mensaje_error_no_canonico`) que añade condicionalmente el `detalle_repl_estricto` y la lista formada a partir de `USAR_COBRA_PUBLIC_MODULES`, sin alterar la lógica de validación, la allowlist ni el tipo de excepción (`PermissionError`).

### Testing
- Se verificó la sintaxis con `python -m py_compile src/pcobra/cobra/usar_loader.py` y se hizo una comprobación directa llamando a `_rechazar_modulo_no_canonico('numpy')` confirmando que las porciones del mensaje aparecen en el orden solicitado; además se ejecutó `pytest -q tests/unit/test_usar_loader_public_api_contract.py` donde la compilación pasó pero una prueba falló por un error de sanitización no relacionado (`ValueError: too many values to unpack (expected 2)`), indicando que el cambio no introdujo errores de compilación ni cambió el comportamiento de excepción.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52123a63708327a04a84c56d97347a)