### PR TITLE
tests: set official module __file__ to internal path and update import expectation

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import ModuleType
 from unittest.mock import patch
 import sys
@@ -509,6 +510,11 @@ def test_repl_usar_rechazo_externo_emite_mensaje_canonico(monkeypatch, escenario
 
 def test_obtener_modulo_alias_cobra_usa_origen_oficial(monkeypatch):
     modulo_oficial = ModuleType("numero")
+    rel_path = usar_loader.REPL_COBRA_MODULE_INTERNAL_PATH_MAP["numero"]
+    ruta_oficial = (
+        Path(usar_loader.__file__).resolve().parents[3] / rel_path
+    ).resolve()
+    setattr(modulo_oficial, "__file__", str(ruta_oficial))
     modulo_oficial.es_finito = lambda valor: True
     monkeypatch.setitem(usar_loader.USAR_WHITELIST, "numero", "numero")
 
@@ -546,7 +552,7 @@ def test_obtener_modulo_alias_cobra_usa_origen_oficial(monkeypatch):
     modulo = usar_loader.obtener_modulo("numero")
 
     assert modulo is modulo_oficial
-    assert llamadas == {"oficial": 1, "importlib": 1}
+    assert llamadas == {"oficial": 1, "importlib": 0}
 
 
 def test_repl_semantica_oficial_plana_libro_parser_legacy_usar_numero_es_finito(monkeypatch):


### PR DESCRIPTION
### Motivation
- Ensure the test `test_obtener_modulo_alias_cobra_usa_origen_oficial` uses the repository's official internal path for the Cobra corelib so the resolver treats it as an official module.
- Align the test expectation so that `importlib` is not invoked when the official origin is available.

### Description
- Added `from pathlib import Path` and compute `ruta_oficial` using `usar_loader.REPL_COBRA_MODULE_INTERNAL_PATH_MAP` and `usar_loader.__file__` to derive the internal corelib path, then set `modulo_oficial.__file__` to that path.
- Updated the expected call counts for the controlled import attempts from `{"oficial": 1, "importlib": 1}` to `{"oficial": 1, "importlib": 0}`.

### Testing
- Ran the unit test `tests/unit/test_usar.py` containing `test_obtener_modulo_alias_cobra_usa_origen_oficial`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a534256576c8327bafdde2e00d90341)