### PR TITLE
Normalize corelib stub file paths in usar regression tests

### DIFF
--- a/tests/integration/test_usar_public_contract_regression.py
+++ b/tests/integration/test_usar_public_contract_regression.py
@@ -122,8 +122,7 @@ def _modulo_datos_publico_stub() -> ModuleType:
     mod.filtrar = lambda tabla, condicion: [fila for fila in tabla if condicion(fila)]
     mod.mapear = lambda valores, fn=None: valores
     mod.reducir = lambda valores, fn=None, inicial=None: inicial if inicial is not None else valores[0]
-    mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/datos.py"
-    return mod
+    return _marcar_stub_como_oficial(mod, "datos")
 
 
 @pytest.mark.parametrize(
@@ -308,7 +307,10 @@ def test_usar_no_inyecta_simbolos_prohibidos_ni_objetos_backend(monkeypatch):
     mod.ok = lambda: "ok"
     mod.self = mod.append = mod.map = mod.filter = mod.unwrap = mod.expect = lambda *_args, **_kwargs: None
     mod.__danger__ = lambda: "boom"
-    mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/mod_ext.py"
+    ruta_mod_ext = (
+        Path(usar_loader.__file__).resolve().parents[3] / "src/pcobra/corelibs/mod_ext.py"
+    ).resolve()
+    setattr(mod, "__file__", str(ruta_mod_ext))
 
     simbolos_saneados, conflictos = core_usar_loader.sanitizar_exports_publicos(mod, "mod_ext")
 


### PR DESCRIPTION
### Motivation
- Evitar rutas absolutas hardcodeadas dentro del test `tests/integration/test_usar_public_contract_regression.py` que apuntan a `/workspace/pCobra/src/pcobra/corelibs/` para hacer los stubs más robustos y coherentes con la validación de módulos oficiales.
- Asegurar que los stubs que deben considerarse módulos oficiales se marquen de forma consistente usando la utilidad de test `_marcar_stub_como_oficial` en lugar de asignar manualmente `__file__`.

### Description
- Reemplacé la asignación directa `mod.__file__ = "/workspace/pCobra/src/pcobra/corelibs/datos.py"` por `return _marcar_stub_como_oficial(mod, "datos")` en la función `_modulo_datos_publico_stub`.
- Sustituí la asignación absoluta de `mod.__file__` en el caso de prueba de `mod_ext` por una ruta derivada de `usar_loader.__file__` usando `Path(usar_loader.__file__).resolve().parents[3] / "src/pcobra/corelibs/mod_ext.py"` y `setattr(mod, "__file__", str(ruta_mod_ext))`.
- No modifiqué `src/pcobra/cobra/usar_loader.py`, mapas contractuales, allowlists, lexer, parser, AST ni transpiladores; los cambios se limitan al archivo de test indicado.

### Testing
- Ejecuté `pytest -q tests/integration/test_usar_public_contract_regression.py` y todos los tests pasaron (`27 passed, 1 warning`).
- Ejecuté `git diff --check` y no reportó problemas de whitespace ni errores en el diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5347a7ce688327812d5aaaba55d952)