### PR TITLE
test: assert structured usar collision error

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -585,8 +585,12 @@ def test_repl_semantica_oficial_plana_libro_parser_legacy_colision_es_atomica(mo
     interp = InterpretadorCobra()
     interp.contextos[-1].define("es_finito", lambda _x: "ocupado")
 
-    with pytest.raises(NameError, match=r"símbolo 'es_finito' ya existe"):
+    with pytest.raises(NameError) as exc_info:
         _ejecutar_codigo('usar "numero"', interp)
+
+    mensaje = str(exc_info.value)
+    assert "'code': 'symbol_collision'" in mensaje
+    assert "'symbol': 'es_finito'" in mensaje
 
     assert interp.contextos[-1].get("es_finito")("x") == "ocupado"
     assert "es_infinito" not in interp.contextos[-1].values


### PR DESCRIPTION
### Motivation
- Reemplazar la comprobación basada en `pytest.raises(..., match=...)` por captura explícita del `NameError` para poder inspeccionar la excepción y verificar la metadata estructurada de colisión (`code` y `symbol`).

### Description
- En `tests/unit/test_usar.py` dentro de `test_repl_semantica_oficial_plana_libro_parser_legacy_colision_es_atomica` se sustituyó el bloque `with pytest.raises(NameError, match=...)` por `with pytest.raises(NameError) as exc_info:` y se añadieron las aserciones `mensaje = str(exc_info.value)` seguido de `assert "'code': 'symbol_collision'" in mensaje` y `assert "'symbol': 'es_finito'" in mensaje`, sin modificar las aserciones de atomicidad ni `src/pcobra/cobra/usar_loader.py`.

### Testing
- Ejecutado `pytest tests/unit/test_usar.py::test_repl_semantica_oficial_plana_libro_parser_legacy_colision_es_atomica` y la prueba pasó exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a534fef98508327990fdde5599af4dd)