### PR TITLE
Ajusta ruta oficial en test de usar texto

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -681,7 +681,11 @@ def test_repl_usar_colision_policy_warn_alias_required_no_overwrite(monkeypatch)
     modulo.__all__ = ["a_snake", "a_camel"]
     modulo.a_snake = lambda texto: texto
     modulo.a_camel = lambda texto: texto
-    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/texto.py"
+    rel_path = usar_loader.REPL_COBRA_MODULE_INTERNAL_PATH_MAP["texto"]
+    ruta_oficial = (
+        Path(usar_loader.__file__).resolve().parents[3] / rel_path
+    ).resolve()
+    setattr(modulo, "__file__", str(ruta_oficial))
 
     monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
 


### PR DESCRIPTION
### Motivation
- Evitar rutas hardcodeadas en el test para asegurar que la prueba use la ruta oficial derivada del mapa interno y la ubicación real del paquete Cobra.

### Description
- En `tests/unit/test_usar.py::test_repl_usar_colision_policy_warn_alias_required_no_overwrite` se sustituyó la asignación literal de `modulo.__file__` por el cálculo de `rel_path` y `ruta_oficial` usando `usar_loader.REPL_COBRA_MODULE_INTERNAL_PATH_MAP["texto"]` y `Path(usar_loader.__file__).resolve().parents[3]`, y se aplica con `setattr(modulo, "__file__", str(ruta_oficial))`.

### Testing
- Se ejecutó `python -m py_compile tests/unit/test_usar.py` y la comprobación pasó; `git diff --check` también pasó; al ejecutar `pytest` sobre el test modificado `tests/unit/test_usar.py::test_repl_usar_colision_policy_warn_alias_required_no_overwrite` pytest produjo un `INTERNALERROR` por `MemoryError` al formatear el reporte, por lo que la prueba no finalizó con un resultado estándar.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5350e3ca348327820883fee8d7bf81)