### PR TITLE
test: derivar ruta oficial para módulo 'texto' en test REPL usar

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -707,7 +707,11 @@ def test_repl_usar_colision_multiple_sin_inyeccion_parcial(monkeypatch):
     modulo.a_snake = lambda texto: texto
     modulo.a_camel = lambda texto: texto
     modulo.quitar_prefijo = lambda texto, prefijo: texto.removeprefix(prefijo)
-    modulo.__file__ = "/workspace/pCobra/src/pcobra/corelibs/texto.py"
+    rel_path = usar_loader.REPL_COBRA_MODULE_INTERNAL_PATH_MAP["texto"]
+    ruta_oficial = (
+        Path(usar_loader.__file__).resolve().parents[3] / rel_path
+    ).resolve()
+    setattr(modulo, "__file__", str(ruta_oficial))
 
     monkeypatch.setattr(core_usar_loader, "obtener_modulo_cobra_oficial", lambda _nombre: modulo)
 


### PR DESCRIPTION
### Motivation
- Evitar una ruta absoluta hardcodeada en la prueba `test_repl_usar_colision_multiple_sin_inyeccion_parcial` y usar la ruta oficial derivada de la política de módulos REPL para que la prueba sea robusta en distintos entornos.
- Mantener intactas las garantías de atomicidad y comportamiento de colisiones sin tocar código de producción ni las políticas/licencias/allowlists relacionadas.

### Description
- Sustituí la asignación directa a `modulo.__file__` por el cálculo de la ruta oficial usando `usar_loader.REPL_COBRA_MODULE_INTERNAL_PATH_MAP["texto"]`, `Path(usar_loader.__file__).resolve().parents[3]` y `setattr(modulo, "__file__", str(ruta_oficial))` en `tests/unit/test_usar.py` dentro de `test_repl_usar_colision_multiple_sin_inyeccion_parcial`.
- No modifiqué código de producción, el parser, lexer, AST, transpiladores, mapas globales, allowlists ni la lógica de colisiones; sólo se cambió la forma en que el test construye la ruta del módulo simulado.

### Testing
- Ejecuté `pytest tests/unit/test_usar.py::test_repl_usar_colision_multiple_sin_inyeccion_parcial` y la prueba pasó correctamente.
- Verifiqué `git diff --check` para asegurar que no hay problemas de whitespace u otros errores en el diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5351f999d48327afe6ec413c90f8e8)