### PR TITLE
test: assert usar collision diagnostics

### DIFF
--- a/tests/unit/test_usar.py
+++ b/tests/unit/test_usar.py
@@ -694,8 +694,14 @@ def test_repl_usar_colision_policy_warn_alias_required_no_overwrite(monkeypatch)
     interp.configurar_politica_colision_usar("warn_alias_required")
     interp.contextos[-1].define("a_snake", lambda _texto: "ocupado")
 
-    with pytest.raises(NameError, match=r"Requiere alias explícito"):
+    with pytest.raises(NameError) as exc_info:
         _ejecutar_codigo('usar "texto"', interp)
+
+    mensaje = str(exc_info.value)
+    assert "'code': 'symbol_collision'" in mensaje
+    assert "'symbol': 'a_snake'" in mensaje
+    assert "'module': 'texto'" in mensaje
+    assert "'phase': 'preflight'" in mensaje
 
     assert interp.contextos[-1].get("a_snake")("x") == "ocupado"
     assert "a_camel" not in interp.contextos[-1].values


### PR DESCRIPTION
### Motivation
- Hacer la comprobación de la excepción en `test_repl_usar_colision_policy_warn_alias_required_no_overwrite` más explícita para validar los campos estructurados del diagnóstico de colisión (`code`, `symbol`, `module`, `phase`) en lugar de confiar solo en el texto del mensaje.

### Description
- Reemplacé el `with pytest.raises(NameError, match=...)` por `with pytest.raises(NameError) as exc_info:` en `tests/unit/test_usar.py` y añadí cuatro aserciones que inspeccionan `str(exc_info.value)` para verificar `"'code': 'symbol_collision'"`, `"'symbol': 'a_snake'"`, `"'module': 'texto'"` y `"'phase': 'preflight'"` mientras mantengo las aserciones posteriores sobre inyección atómica.

### Testing
- Ejecuté `pytest -q tests/unit/test_usar.py -k "semantica_oficial_plana_libro_parser_legacy_colision_es_atomica or colision_policy_warn_alias_required_no_overwrite or colision_multiple_sin_inyeccion_parcial" --maxfail=1 -vv` y los 3 tests seleccionados pasaron exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5353ef0a04832794dfbaa5decc4c3a)