### PR TITLE
Limitar recursos sólo en procesos hijos del sandbox

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -84,8 +84,8 @@ from pcobra.cobra.core.runtime import (
     PrimitivaPeligrosaError,
     ejecutar_en_contenedor,
     ejecutar_en_sandbox,
-    limitar_memoria_mb,
     validar_dependencias,
+    limitar_memoria_mb,  # compatibilidad para tests/plugins; no se invoca en anfitrión
 )
 from pcobra.cobra.usar_policy import REPL_COBRA_MODULE_MAP
 
@@ -890,29 +890,13 @@ class InteractiveCommand(BaseCommand):
         try:
             # Validar y configurar límite de memoria
             memory_limit = getattr(args, "memory_limit", self.MEMORY_LIMIT_MB)
-            ignore_memory_limit = getattr(args, "ignore_memory_limit", False)
             if memory_limit <= 0:
                 mostrar_error(_("El límite de memoria debe ser positivo"))
                 return 1
 
-            try:
-                limitar_memoria_mb(memory_limit)
-            except NotImplementedError as e:
-                mostrar_advertencia(
-                    _("No se pudo aplicar el límite de memoria: {err}").format(err=e)
-                )
-            except RuntimeError as e:
-                if ignore_memory_limit:
-                    mostrar_advertencia(
-                        _("No se pudo aplicar el límite de memoria: {err}").format(
-                            err=e
-                        )
-                    )
-                else:
-                    mostrar_error(
-                        _("Error al establecer límite de memoria: {err}").format(err=e)
-                    )
-                    return 1
+            # El límite de memoria se valida aquí, pero no se aplica al proceso
+            # anfitrión del REPL. Los límites efectivos deben configurarse sólo
+            # dentro de procesos hijos aislados (sandbox/subprocesos).
 
             # Validar dependencias
             validar_dependencias("python", cli_toml_map())

--- a/src/pcobra/cobra/cli/services/run_service.py
+++ b/src/pcobra/cobra/cli/services/run_service.py
@@ -25,7 +25,7 @@ from pcobra.cobra.core.runtime import (
     InterpretadorCobra,
     PrimitivaPeligrosaError,
     construir_cadena,
-    limitar_cpu_segundos,
+    limitar_cpu_segundos,  # compatibilidad para tests/plugins; no se invoca en anfitrión
 )
 from pcobra.cobra.core.sandbox import ejecutar_en_contenedor as ejecutar_en_contenedor_docker
 from pcobra.cobra.transpilers import module_map
@@ -134,10 +134,6 @@ class RunService:
         return resolved_path
 
     def limitar_recursos(self, funcion: Any) -> int:
-        try:
-            limitar_cpu_segundos(self.execution_timeout)
-        except RuntimeError as exc:
-            raise TimeoutError(f"No se pudo establecer el límite de CPU: {exc}") from exc
         return funcion()
 
     def ejecutar_en_sandbox(
@@ -180,7 +176,12 @@ class RunService:
         )
 
         try:
-            salida = sandbox_module.ejecutar_en_sandbox(script, allow_insecure_fallback=allow_insecure_fallback)
+            salida = sandbox_module.ejecutar_en_sandbox(
+                script,
+                timeout=self.execution_timeout,
+                cpu_segundos=self.execution_timeout,
+                allow_insecure_fallback=allow_insecure_fallback,
+            )
             if salida:
                 mostrar_info(str(salida))
             return 0

--- a/src/pcobra/core/interpreter.py
+++ b/src/pcobra/core/interpreter.py
@@ -70,15 +70,7 @@ from .semantic_validators import (
     PrimitivaPeligrosaError,
 )
 from .semantico import AnalizadorSemantico
-from .cobra_config import (
-    limite_nodos,
-    limite_memoria_mb,
-    limite_cpu_segundos,
-)
-from .resource_limits import (
-    limitar_memoria_mb as _lim_mem,
-    limitar_cpu_segundos as _lim_cpu,
-)
+from .cobra_config import limite_nodos
 from .import_utils import (
     MODULES_PATH as _DEFAULT_MODULES_PATH,
     IMPORT_WHITELIST,
@@ -411,13 +403,6 @@ class InterpretadorCobra:
             "_unpack_sequence_": rp_symbols["guarded_unpack_sequence"],
         }
         compile_restricted = rp_symbols["compile_restricted"]
-        mem_limit = limite_memoria_mb()
-        cpu_limit = limite_cpu_segundos()
-        if mem_limit is not None:
-            _lim_mem(int(mem_limit))
-        if cpu_limit is not None:
-            _lim_cpu(int(cpu_limit))
-
         try:
             byte_code = compile_restricted(source, ruta_abs, "exec")
         except TimeoutError as e:
@@ -1484,13 +1469,6 @@ class InterpretadorCobra:
         max_nodos = max(limite_nodos(), len(ast) + 1)
         if total > max_nodos:
             raise RuntimeError(f"El AST excede el límite de {max_nodos} nodos")
-
-        mem = limite_memoria_mb()
-        if mem:
-            _lim_mem(mem)
-        cpu = limite_cpu_segundos()
-        if cpu:
-            _lim_cpu(cpu)
 
         self._asegurar_ast_tipado(ast, "pre_optimizacion")
         self._asegurar_ast_aciclico_por_identidad(ast, "pre_optimizacion")

--- a/src/pcobra/core/sandbox.py
+++ b/src/pcobra/core/sandbox.py
@@ -527,13 +527,18 @@ def _safe_import(name: str, globals: Any | None = None, locals: Any | None = Non
 
 
 def _run_in_subprocess(
-    codigo: str, timeout: float | None = None, memoria_mb: int | None = None
+    codigo: str,
+    timeout: float | None = None,
+    memoria_mb: int | None = None,
+    cpu_segundos: int | None = None,
 ) -> str:
     """Ejecuta ``codigo`` en un subproceso de Python sin restricciones.
 
     ``timeout`` define el tiempo máximo de ejecución en segundos. ``memoria_mb``
     establece el límite superior de memoria (en megabytes) utilizando
-    ``resource.RLIMIT_AS`` en sistemas POSIX. En Windows se lanza
+    ``resource.RLIMIT_AS`` y ``resource.RLIMIT_CPU`` en sistemas POSIX mediante
+    ``preexec_fn``, por lo que los límites sólo afectan al proceso hijo. En
+    Windows se lanza
     ``NotImplementedError`` cuando se solicita un límite de memoria y se emite
     ``ValueError`` si el parámetro no es positivo. Se lanza ``TimeoutError`` si
     el subproceso excede el tiempo y ``MemoryError`` si el proceso hijo supera
@@ -561,13 +566,21 @@ def _run_in_subprocess(
                 "El límite de memoria no está soportado en Windows"
             )
 
-        def limitar_memoria() -> None:
+    if cpu_segundos is not None and cpu_segundos <= 0:
+        raise ValueError("cpu_segundos debe ser un entero positivo")
+
+    if (memoria_mb is not None or cpu_segundos is not None) and os.name != "nt":
+
+        def limitar_recursos_hijo() -> None:
             import resource
 
-            limite = memoria_mb * 1024 * 1024
-            resource.setrlimit(resource.RLIMIT_AS, (limite, limite))
+            if memoria_mb is not None:
+                limite = memoria_mb * 1024 * 1024
+                resource.setrlimit(resource.RLIMIT_AS, (limite, limite))
+            if cpu_segundos is not None:
+                resource.setrlimit(resource.RLIMIT_CPU, (cpu_segundos, cpu_segundos))
 
-        preexec_fn = limitar_memoria
+        preexec_fn = limitar_recursos_hijo
 
     try:
         completed = subprocess.run(
@@ -590,15 +603,21 @@ def _run_in_subprocess(
 
 
 def _worker(
-    code_bytes: bytes, queue: multiprocessing.Queue, memoria_mb: int | None
+    code_bytes: bytes,
+    queue: multiprocessing.Queue,
+    memoria_mb: int | None,
+    cpu_segundos: int | None = None,
 ) -> None:
     """Ejecuta ``code_bytes`` en un proceso aislado y comunica el resultado."""
     try:
-        if memoria_mb is not None and os.name != "nt":
+        if (memoria_mb is not None or cpu_segundos is not None) and os.name != "nt":
             import resource
 
-            limite = memoria_mb * 1024 * 1024
-            resource.setrlimit(resource.RLIMIT_AS, (limite, limite))
+            if memoria_mb is not None:
+                limite = memoria_mb * 1024 * 1024
+                resource.setrlimit(resource.RLIMIT_AS, (limite, limite))
+            if cpu_segundos is not None:
+                resource.setrlimit(resource.RLIMIT_CPU, (cpu_segundos, cpu_segundos))
 
         builtins_dict = dict(_SANDBOX_BASE_BUILTINS)
         builtins_dict["__import__"] = _safe_import
@@ -629,13 +648,15 @@ def ejecutar_en_sandbox(
     codigo: str,
     timeout: int = 5,
     memoria_mb: int | None = None,
+    cpu_segundos: int | None = None,
     allow_insecure_fallback: bool = False,
 ) -> str:
     """Ejecuta una cadena de código Python de forma segura.
 
     El código se compila con :func:`compile_restricted` y se ejecuta en un
-    proceso hijo. ``timeout`` especifica el tiempo límite en segundos y
-    ``memoria_mb`` el máximo de memoria en megabytes. Se lanza ``TimeoutError``
+    proceso hijo. ``timeout`` especifica el tiempo límite en segundos,
+    ``memoria_mb`` el máximo de memoria en megabytes y ``cpu_segundos`` el
+    máximo de CPU. Se lanza ``TimeoutError``
     o ``MemoryError`` si se exceden estos límites.
 
     Por defecto no se permite fallback inseguro. Cuando
@@ -656,7 +677,10 @@ def ejecutar_en_sandbox(
                     "reason": "restricted_python_missing",
                 },
             )
-            return _run_in_subprocess(codigo, timeout=timeout, memoria_mb=memoria_mb)
+            kwargs: dict[str, Any] = {"timeout": timeout, "memoria_mb": memoria_mb}
+            if cpu_segundos is not None:
+                kwargs["cpu_segundos"] = cpu_segundos
+            return _run_in_subprocess(codigo, **kwargs)
         raise RuntimeError(
             "La sandbox segura requiere RestrictedPython instalado. "
             "Instálalo o habilita allow_insecure_fallback=True solo en desarrollo."
@@ -669,7 +693,9 @@ def ejecutar_en_sandbox(
 
     code_bytes = marshal.dumps(byte_code)
     queue: multiprocessing.Queue = multiprocessing.Queue()
-    proc = multiprocessing.Process(target=_worker, args=(code_bytes, queue, memoria_mb))
+    proc = multiprocessing.Process(
+        target=_worker, args=(code_bytes, queue, memoria_mb, cpu_segundos)
+    )
     proc.start()
     proc.join(timeout)
 

--- a/tests/unit/test_resource_limits.py
+++ b/tests/unit/test_resource_limits.py
@@ -1,21 +1,52 @@
+import json
 import pytest
 
 resource = pytest.importorskip("resource")
 
-from core.resource_limits import limitar_memoria_mb, limitar_cpu_segundos
+from pcobra.cobra.cli.execution_pipeline import construir_script_sandbox_canonico
+from pcobra.core.sandbox import _run_in_subprocess, ejecutar_en_sandbox
 
 
-def test_limitar_memoria():
-    soft, hard = resource.getrlimit(resource.RLIMIT_AS)
-    limitar_memoria_mb(64)
-    new_soft, _ = resource.getrlimit(resource.RLIMIT_AS)
-    assert new_soft == 64 * 1024 * 1024
-    resource.setrlimit(resource.RLIMIT_AS, (soft, hard))
+def test_limites_bajo_nivel_se_aplican_solo_en_subproceso_hijo():
+    original_as = resource.getrlimit(resource.RLIMIT_AS)
+    original_cpu = resource.getrlimit(resource.RLIMIT_CPU)
+
+    salida = _run_in_subprocess(
+        "import json, resource; "
+        "print(json.dumps({"
+        "'as': resource.getrlimit(resource.RLIMIT_AS), "
+        "'cpu': resource.getrlimit(resource.RLIMIT_CPU)"
+        "}))",
+        memoria_mb=64,
+        cpu_segundos=1,
+    )
+
+    limites_hijo = json.loads(salida)
+    assert tuple(limites_hijo["as"]) == (64 * 1024 * 1024, 64 * 1024 * 1024)
+    assert tuple(limites_hijo["cpu"]) == (1, 1)
+    assert resource.getrlimit(resource.RLIMIT_AS) == original_as
+    assert resource.getrlimit(resource.RLIMIT_CPU) == original_cpu
 
 
-def test_limitar_cpu():
-    soft, hard = resource.getrlimit(resource.RLIMIT_CPU)
-    new_val = 1 if soft in (-1, 0) else soft
-    limitar_cpu_segundos(new_val)
-    assert resource.getrlimit(resource.RLIMIT_CPU)[0] == new_val
-    resource.setrlimit(resource.RLIMIT_CPU, (soft, hard))
+def test_programa_cobra_con_limites_no_contamina_proceso_anfitrion():
+    original_as = resource.getrlimit(resource.RLIMIT_AS)
+    original_cpu = resource.getrlimit(resource.RLIMIT_CPU)
+    codigo_cobra = 'imprimir "F-01"\n'
+    script = construir_script_sandbox_canonico(codigo_cobra)
+
+    salida = ejecutar_en_sandbox(
+        script,
+        timeout=20,
+        memoria_mb=256,
+        cpu_segundos=10,
+        allow_insecure_fallback=True,
+    )
+
+    assert "F-01" in salida
+    assert resource.getrlimit(resource.RLIMIT_AS) == original_as
+    assert resource.getrlimit(resource.RLIMIT_CPU) == original_cpu
+
+
+def test_limite_cpu_invalido_rechaza_antes_de_crear_subproceso():
+    with pytest.raises(ValueError, match="cpu_segundos"):
+        _run_in_subprocess("print('no debe ejecutarse')", cpu_segundos=0)


### PR DESCRIPTION
### Motivation
- Evitar que llamadas a `resource.setrlimit()` contaminen el proceso anfitrión (CLI/REPL/tests) moviendo la aplicación efectiva de límites al proceso hijo aislado. 
- Preservar intactos `src/pcobra/core/lexer.py` y `src/pcobra/core/parser.py` y mantener compatibilidad de nombres usados por tests/plugins.

### Description
- Extiende `src/pcobra/core/sandbox.py` para aceptar `cpu_segundos` y aplicar `resource.setrlimit()` únicamente en `preexec_fn` de `_run_in_subprocess()` y dentro de `_worker()` en el proceso hijo. 
- Elimina las invocaciones de límites en el intérprete (`src/pcobra/core/interpreter.py`) y evita aplicar límites en el proceso anfitrión desde `RunService.limitar_recursos()` y el flujo REPL; en su lugar se pasan los límites al sandbox hijo. 
- Mantiene las importaciones/entradas públicas (`limitar_memoria_mb`, `limitar_cpu_segundos`) para compatibilidad con tests/plugins pero documentadas como no aplicadas en el anfitrión. 
- Actualiza y añade una prueba de regresión en `tests/unit/test_resource_limits.py` que verifica que `RLIMIT_AS` y `RLIMIT_CPU` del proceso pytest no cambian tras ejecutar un programa Cobra con límites aplicados en procesos hijos.

### Testing
- Ejecutadas pruebas dirigidas de límites y sandbox: `tests/unit/test_resource_limits.py tests/unit/test_sandbox.py tests/unit/test_restricted_exec.py tests/unit/test_sandbox_allowlist.py`, resultado: todos los tests pasaron (36 passed, 1 warning). 
- Ejecutadas pruebas de integración relacionadas con run/REPL: `tests/integration/test_run_repl_equivalence.py::test_sandbox_normaliza_safe_mode_y_validadores_igual_en_run_y_repl` y `tests/test_interactive_cmd_no_console.py`, resultado: ambas pasaron (2 passed, 1 warning). 
- Se intentaron suites CLI/REPL más amplias; algunas fallaron por expectativas de mocks/monkeypatch previas no relacionadas con la presente lógica de límites (salida por stdout vs mock y un target monkeypatch inexistente), por lo que no se modificaron esas pruebas en este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a572e3980f88327a4eac2dce6e3ce09)