### PR TITLE
Do not apply resource limits to host process; validate public limit APIs and update tests

### DIFF
--- a/src/pcobra/core/resource_limits.py
+++ b/src/pcobra/core/resource_limits.py
@@ -43,33 +43,18 @@ def _cargar_psutil():
 
 
 def limitar_memoria_mb(mb: int) -> None:
-    """Restringe la memoria máxima del proceso actual."""
-    bytes_ = mb * 1024 * 1024
+    """Valida el límite de memoria sin modificar el proceso anfitrión.
+
+    Los límites efectivos de ejecución Cobra se aplican exclusivamente dentro
+    de procesos hijos descartables. Esta función se conserva por compatibilidad
+    con integraciones existentes, pero no llama a ``setrlimit`` sobre el
+    proceso actual para evitar contaminar CLI, REPL, IDLE o el runner de tests.
+    """
+    if mb <= 0:
+        raise ValueError("mb debe ser un entero positivo")
     if IS_WINDOWS:  # psutil.Process.rlimit no está soportado en Windows.
         _log_windows_skip_once()
-        return
-    try:
-        import resource
-    except ImportError as exc:
-        # Falta 'resource', se intenta 'psutil'.
-        logger.warning(
-            _("El módulo 'resource' no está disponible; se intentará 'psutil'."),
-            exc_info=exc,
-        )
-        _limitar_memoria_psutil(bytes_)
-        return
-    try:
-        resource.setrlimit(resource.RLIMIT_AS, (bytes_, bytes_))
-    except (OSError, ValueError) as exc:
-        # Error de configuración en 'resource'.
-        logger.warning(
-            _(
-                "No se pudo configurar el límite de memoria con 'resource'; "
-                "se intentará 'psutil'."
-            ),
-            exc_info=exc,
-        )
-        _limitar_memoria_psutil(bytes_)
+
 
 
 def _limitar_memoria_psutil(bytes_: int) -> bool:
@@ -111,32 +96,18 @@ def _limitar_memoria_psutil(bytes_: int) -> bool:
 
 
 def limitar_cpu_segundos(segundos: int) -> None:
-    """Limita el tiempo de CPU en segundos para este proceso."""
+    """Valida el límite de CPU sin modificar el proceso anfitrión.
+
+    Los límites efectivos de ejecución Cobra se aplican exclusivamente dentro
+    de procesos hijos descartables. Esta función se conserva por compatibilidad
+    con integraciones existentes, pero no llama a ``setrlimit`` sobre el
+    proceso actual para evitar contaminar CLI, REPL, IDLE o el runner de tests.
+    """
+    if segundos <= 0:
+        raise ValueError("segundos debe ser un entero positivo")
     if IS_WINDOWS:  # psutil.Process.rlimit no está soportado en Windows.
         _log_windows_skip_once()
-        return
-    try:
-        import resource
-    except ImportError as exc:
-        # Falta 'resource', se intenta 'psutil'.
-        logger.warning(
-            _("El módulo 'resource' no está disponible; se intentará 'psutil'."),
-            exc_info=exc,
-        )
-        _limitar_cpu_psutil(segundos)
-        return
-    try:
-        resource.setrlimit(resource.RLIMIT_CPU, (segundos, segundos))
-    except (OSError, ValueError) as exc:
-        # Error de configuración en 'resource'.
-        logger.warning(
-            _(
-                "No se pudo configurar el límite de CPU con 'resource'; "
-                "se intentará 'psutil'."
-            ),
-            exc_info=exc,
-        )
-        _limitar_cpu_psutil(segundos)
+
 
 
 def _limitar_cpu_psutil(segundos: int) -> bool:

--- a/tests/core/test_resource_limits.py
+++ b/tests/core/test_resource_limits.py
@@ -72,58 +72,34 @@ def test_limitar_cpu_sin_resource_y_psutil_sin_rlimit(monkeypatch, caplog):
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="resource module is Unix-specific")
-def test_limitar_memoria_sin_psutil_en_linux(monkeypatch, caplog):
+def test_limitar_memoria_no_usa_resource_ni_psutil_en_linux(monkeypatch, caplog):
     import resource
 
     def fail_setrlimit(*args, **kwargs):
-        raise OSError("fail")
+        raise AssertionError("no debe aplicarse setrlimit en el anfitrión")
 
     monkeypatch.setattr(resource, "setrlimit", fail_setrlimit)
     monkeypatch.delitem(sys.modules, "psutil", raising=False)
     monkeypatch.setattr(resource_limits, "IS_WINDOWS", False)
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(RuntimeError):
-            resource_limits.limitar_memoria_mb(1)
+        resource_limits.limitar_memoria_mb(1)
 
-    err_record = next(
-        (
-            r
-            for r in caplog.records
-            if (
-                "El módulo 'psutil' no está disponible para limitar la "
-                "memoria." in r.message
-            )
-        ),
-        None,
-    )
-    assert err_record and err_record.levelno == logging.ERROR
+    assert not caplog.records
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="resource module is Unix-specific")
-def test_limitar_cpu_sin_psutil_en_linux(monkeypatch, caplog):
+def test_limitar_cpu_no_usa_resource_ni_psutil_en_linux(monkeypatch, caplog):
     import resource
 
     def fail_setrlimit(*args, **kwargs):
-        raise OSError("fail")
+        raise AssertionError("no debe aplicarse setrlimit en el anfitrión")
 
     monkeypatch.setattr(resource, "setrlimit", fail_setrlimit)
     monkeypatch.delitem(sys.modules, "psutil", raising=False)
     monkeypatch.setattr(resource_limits, "IS_WINDOWS", False)
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(RuntimeError):
-            resource_limits.limitar_cpu_segundos(1)
+        resource_limits.limitar_cpu_segundos(1)
 
-    err_record = next(
-        (
-            r
-            for r in caplog.records
-            if (
-                "El módulo 'psutil' no está disponible para limitar la "
-                "CPU." in r.message
-            )
-        ),
-        None,
-    )
-    assert err_record and err_record.levelno == logging.ERROR
+    assert not caplog.records

--- a/tests/unit/test_resource_limits.py
+++ b/tests/unit/test_resource_limits.py
@@ -5,6 +5,7 @@ resource = pytest.importorskip("resource")
 
 from pcobra.cobra.cli.execution_pipeline import construir_script_sandbox_canonico
 from pcobra.core.sandbox import _run_in_subprocess, ejecutar_en_sandbox
+from pcobra.core.resource_limits import limitar_cpu_segundos, limitar_memoria_mb
 
 
 def test_limites_bajo_nivel_se_aplican_solo_en_subproceso_hijo():
@@ -50,3 +51,29 @@ def test_programa_cobra_con_limites_no_contamina_proceso_anfitrion():
 def test_limite_cpu_invalido_rechaza_antes_de_crear_subproceso():
     with pytest.raises(ValueError, match="cpu_segundos"):
         _run_in_subprocess("print('no debe ejecutarse')", cpu_segundos=0)
+
+
+def test_limitar_memoria_publica_no_contamina_proceso_anfitrion():
+    original = resource.getrlimit(resource.RLIMIT_AS)
+
+    limitar_memoria_mb(64)
+
+    assert resource.getrlimit(resource.RLIMIT_AS) == original
+
+
+def test_limitar_cpu_publica_no_contamina_proceso_anfitrion():
+    original = resource.getrlimit(resource.RLIMIT_CPU)
+
+    limitar_cpu_segundos(1)
+
+    assert resource.getrlimit(resource.RLIMIT_CPU) == original
+
+
+def test_limitar_memoria_publica_rechaza_valores_no_positivos():
+    with pytest.raises(ValueError):
+        limitar_memoria_mb(0)
+
+
+def test_limitar_cpu_publica_rechaza_valores_no_positivos():
+    with pytest.raises(ValueError):
+        limitar_cpu_segundos(0)

--- a/tests/unit/test_resource_limits_run_service.py
+++ b/tests/unit/test_resource_limits_run_service.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from pcobra.cobra.cli.services.run_service import RunService
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="resource module is Unix-specific")
+def test_run_service_sandbox_con_programa_cobra_no_contamina_anfitrion(monkeypatch):
+    import resource
+
+    llamadas_sandbox: list[dict[str, object]] = []
+
+    def fail_setrlimit(*_args, **_kwargs):
+        raise AssertionError("RunService no debe aplicar setrlimit en el anfitrión")
+
+    def fake_ejecutar_en_sandbox(_script, **kwargs):
+        llamadas_sandbox.append(kwargs)
+        return "ok\n"
+
+    monkeypatch.setattr(resource, "setrlimit", fail_setrlimit)
+    monkeypatch.setattr(
+        "pcobra.cobra.cli.services.run_service.sandbox_module.ejecutar_en_sandbox",
+        fake_ejecutar_en_sandbox,
+    )
+
+    servicio = RunService()
+    rc = servicio.ejecutar_en_sandbox(
+        'imprimir("ok")',
+        seguro=True,
+        extra_validators=None,
+        allow_insecure_fallback=True,
+    )
+
+    assert rc == 0
+    assert llamadas_sandbox
+    assert llamadas_sandbox[0]["cpu_segundos"] == servicio.execution_timeout


### PR DESCRIPTION
### Motivation

- Evitar que las funciones públicas de límites de recursos modifiquen el proceso anfitrión para no contaminar la CLI, REPL, IDLE o el runner de tests.
- Hacer las funciones públicas más seguras validando los parámetros de entrada y conservarlas por compatibilidad para integraciones que aplican límites en procesos hijos.

### Description

- Cambia `limitar_memoria_mb` y `limitar_cpu_segundos` para que solo validen valores positivos y documenten que no llaman a `setrlimit` en el proceso actual, manteniendo el comportamiento efectivo en procesos hijos desechables.
- Elimina la lógica que intentaba usar `resource.setrlimit` desde las funciones públicas, dejando las rutinas internas de `psutil` disponibles pero no invocadas automáticamente sobre el anfitrión.
- Ajusta y añade tests para garantizar que las nuevas funciones públicas no modifican los límites del proceso anfitrión y que rechazan valores no positivos.
- Añade `tests/unit/test_resource_limits_run_service.py` para verificar que `RunService` delega correctamente en la sandbox sin aplicar `setrlimit` en el anfitrión.

### Testing

- Ejecutados los tests unitarios y de core modificados incluyendo `tests/unit/test_resource_limits.py`, `tests/core/test_resource_limits.py` y el nuevo `tests/unit/test_resource_limits_run_service.py`.
- Todos los tests automatizados relacionados con límites de recursos pasaron con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a572dd153dc832798710b376f9d87dc)