### PR TITLE
Switch workflows to trigger on `master` and add regression test to prevent `work` branch reversion

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: [ work ]
+    branches: [ master ]
     tags: [ 'v*.*.*' ]
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ permissions:
 
 on:
   push:
-    branches: [ work ]
+    branches: [ master ]
   pull_request:
-    branches: [ work ]
+    branches: [ master ]
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: docker
 
 on:
   push:
-    branches: [ work ]
+    branches: [ master ]
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,7 +3,7 @@ name: Deploy Docs
 on:
   push:
     branches:
-      - work
+      - master
     tags:
       - 'v*'
   workflow_dispatch:

--- a/.github/workflows/runtime-stabilization-contract.yml
+++ b/.github/workflows/runtime-stabilization-contract.yml
@@ -5,9 +5,9 @@ permissions:
 
 on:
   pull_request:
-    branches: [ work ]
+    branches: [ master ]
   push:
-    branches: [ work ]
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/tests/test_workflows_yaml.py
+++ b/tests/test_workflows_yaml.py
@@ -48,3 +48,23 @@ def test_workflow_has_smoke_syntax_gate(workflow_filename: str, job_name: str) -
     assert "shell: pwsh" in content
     assert "python scripts/smoke_syntax.py" in content
     assert "python scripts/smoke_transpilers_syntax.py" in content
+
+
+@pytest.mark.parametrize(
+    "workflow_filename",
+    (
+        "build-binaries.yml",
+        "ci.yml",
+        "docker.yml",
+        "pages.yml",
+        "runtime-stabilization-contract.yml",
+    ),
+)
+def test_workflow_branch_triggers_target_default_branch(workflow_filename: str) -> None:
+    """Evita que los workflows críticos vuelvan a apuntar a la rama histórica work."""
+    workflow_path = WORKFLOWS_DIR / workflow_filename
+    content = workflow_path.read_text(encoding="utf-8")
+
+    assert "branches: [ work ]" not in content
+    assert "      - work" not in content
+    assert "branches: [ master ]" in content or "      - master" in content


### PR DESCRIPTION
### Motivation
- Update CI/workflow triggers to target the repository default branch (`master`) instead of the legacy `work` branch.
- Add a safeguard test to prevent workflows from accidentally reverting to the historical `work` branch trigger.

### Description
- Replaced branch trigger values from `work` to `master` in `build-binaries.yml`, `ci.yml`, `docker.yml`, `pages.yml`, and `runtime-stabilization-contract.yml`.
- Added a new parametrized test `test_workflow_branch_triggers_target_default_branch` to `tests/test_workflows_yaml.py` to assert workflows do not contain `branches: [ work ]` or `- work` and that they include `master`.

### Testing
- Ran the repository test suite with `pytest -q`, which included the new test `tests/test_workflows_yaml.py::test_workflow_branch_triggers_target_default_branch`.
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5759fae94083278571f5c20ef493a7)