### PR TITLE
Corrige el ejemplo y cubre el arranque Unicode

### DIFF
--- a/src/pcobra/cobra/cli/utils/unicode_sanitize.py
+++ b/src/pcobra/cobra/cli/utils/unicode_sanitize.py
@@ -11,7 +11,7 @@ def sanitize_input(text: str) -> str:
     Ejemplos:
         >>> sanitize_input("Hola, こんにちは, مرحبا 🌍🚀")
         'Hola, こんにちは, مرحبا 🌍🚀'
-        >>> sanitize_input("\ud83d")
+        >>> sanitize_input(chr(0xD83D))
         '�'
     """
     if text is None:

--- a/tests/unit/test_unicode_sanitize_repl.py
+++ b/tests/unit/test_unicode_sanitize_repl.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -23,6 +27,52 @@ def _args() -> SimpleNamespace:
         debug=False,
         memory_limit=InteractiveCommand.MEMORY_LIMIT_MB,
     )
+
+
+def test_arranque_unicode_compila_importa_sanea_y_muestra_ayuda():
+    repo_root = Path(__file__).resolve().parents[2]
+    modulo = repo_root / "src/pcobra/cobra/cli/utils/unicode_sanitize.py"
+    compilacion = subprocess.run(
+        [sys.executable, "-m", "py_compile", str(modulo)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+
+    assert compilacion.returncode == 0, compilacion.stderr
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root / "src")
+    importacion = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from pcobra.cobra.cli.utils.unicode_sanitize import sanitize_input; "
+            "assert sanitize_input('Hola 🌍') == 'Hola 🌍'; "
+            "resultado = sanitize_input(chr(0xD83D)); "
+            "assert resultado == '\\uFFFD'; "
+            "assert all(not (0xD800 <= ord(ch) <= 0xDFFF) for ch in resultado)",
+        ],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert importacion.returncode == 0, importacion.stderr
+
+    env["PATH"] = os.pathsep.join(
+        [str(repo_root / "scripts/bin"), env.get("PATH", "")]
+    )
+    ayuda = subprocess.run(
+        ["cobra", "--help"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert ayuda.returncode == 0, ayuda.stderr
 
 
 def test_sanitize_input_multilingue_y_emoji_se_conserva():


### PR DESCRIPTION
### Motivation

- Evitar el uso de un literal surrogate en el docstring que puede ser problemático para herramientas de análisis y para subprocesses; usar `chr(0xD83D)` mantiene el mismo resultado visible `'�'` pero sin literales aislados. 
- Añadir una prueba dirigida de arranque Unicode que verifique que el módulo compila, se importa desde un subprocess limpio, sanea surrogates aislados y que el entrypoint CLI responde correctamente.
- Preservar la compatibilidad y no tocar `Lexer` ni `Parser` durante la corrección.

### Description

- Reemplazado el ejemplo del docstring en `src/pcobra/cobra/cli/utils/unicode_sanitize.py` de `sanitize_input("\ud83d")` por `sanitize_input(chr(0xD83D))` manteniendo el resultado esperado `'�'`.
- Añadida la prueba `test_arranque_unicode_compila_importa_sanea_y_muestra_ayuda` en `tests/unit/test_unicode_sanitize_repl.py` que compila el módulo con `py_compile`, lo importa en un subprocess independiente, comprueba `sanitize_input("Hola 🌍") == "Hola 🌍"`, verifica que `sanitize_input(chr(0xD83D)) == "\uFFFD"` y que no quedan code points entre `0xD800` y `0xDFFF`, y ejecuta `cobra --help` esperando código de salida cero.
- Pequeño reordenado de imports en el archivo de pruebas para acomodar las llamadas a `subprocess` y `Path`.
- Todos los cambios se guardaron en un commit local y no se modificaron `src/pcobra/cobra/core/lexer.py` ni `src/pcobra/cobra/core/parser.py`.

### Testing

- Ejecuté la prueba dirigida: `python -m pytest tests/unit/test_unicode_sanitize_repl.py::test_arranque_unicode_compila_importa_sanea_y_muestra_ayuda -q` y pasó correctamente (return code 0).
- Verifiqué que `python -m py_compile src/pcobra/cobra/cli/utils/unicode_sanitize.py` compila sin errores y que `PYTHONPATH=src PATH="$PWD/scripts/bin:$PATH" cobra --help` devuelve código de salida 0.
- Ejecutar la suite completa del archivo `tests/unit/test_unicode_sanitize_repl.py` mostró una prueba preexistente fallida (`test_interactive_command_sanitiza_surrogate_invalido_y_no_crashea`) en una ejecución anterior debido a un `_FakeHistory` sin `append_string`, pero la nueva prueba añadida pasó de forma aislada; el fallo detectado no fue introducido por este cambio.
- Comprobé `git diff --check` y verifiqué explícitamente que `Lexer` y `Parser` permanecen sin cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59d77d537c8327866d08ca9591f1b8)