### PR TITLE
Incluir `gui` en la ayuda global temprana y generar la lista desde `PUBLIC_COMMANDS`

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -346,16 +346,28 @@ def _es_ayuda_global_temprana(argv: Optional[List[str]]) -> bool:
 def _mostrar_ayuda_global_temprana() -> None:
     """Imprime ayuda pública mínima sin importar comandos opcionales/runtime."""
 
+    from pcobra.cobra.cli.public_command_policy import PUBLIC_COMMANDS
+
+    comandos = ",".join(PUBLIC_COMMANDS)
+    descripciones = (
+        "Ejecuta un archivo Cobra.",
+        "Genera salida desde un archivo Cobra.",
+        "Ejecuta pruebas Cobra.",
+        "Gestiona módulos Cobra.",
+        "Inicia el modo interactivo.",
+        "Inicia la interfaz gráfica.",
+    )
+    lista_comandos = "\n".join(
+        f"  {comando:<6} {descripcion}"
+        for comando, descripcion in zip(PUBLIC_COMMANDS, descripciones, strict=True)
+    )
+
     print(
         "uso: cobra [-h] [--version] [--debug] [-v] "
-        "[--modo {cobra,transpilar,mixto}] {run,build,test,mod,repl} ...\n"
+        f"[--modo {{cobra,transpilar,mixto}}] {{{comandos}}} ...\n"
         "\n"
         "Lenguaje Cobra CLI. Comandos públicos:\n"
-        "  run    Ejecuta un archivo Cobra.\n"
-        "  build  Genera salida desde un archivo Cobra.\n"
-        "  test   Ejecuta pruebas Cobra.\n"
-        "  mod    Gestiona módulos Cobra.\n"
-        "  repl   Inicia el modo interactivo.\n"
+        f"{lista_comandos}\n"
         "\n"
         "Opciones:\n"
         "  -h, --help, --ayuda  Muestra esta ayuda y termina.\n"

--- a/tests/integration/test_cli_public_help_contract.py
+++ b/tests/integration/test_cli_public_help_contract.py
@@ -3,9 +3,12 @@ import os
 import re
 import subprocess
 import sys
+from io import StringIO
 from pathlib import Path
+from unittest.mock import patch
 
 import cobra.cli.cli as cli_module
+import pcobra.cli as public_cli
 from pcobra.cobra.cli.public_command_policy import PUBLIC_COMMANDS
 
 
@@ -24,6 +27,45 @@ def _public_env() -> dict[str, str]:
     env.pop("COBRA_INTERNAL_ENABLE_LEGACY_CLI", None)
     env.pop("COBRA_INTERNAL_LEGACY_TARGETS", None)
     return env
+
+
+def _comandos_en_ayuda_temprana(output: str) -> tuple[str, ...]:
+    bloque = output.split("Lenguaje Cobra CLI. Comandos públicos:\n", 1)[1]
+    bloque = bloque.split("\n\nOpciones:\n", 1)[0]
+    return tuple(linea.split()[0] for linea in bloque.splitlines())
+
+
+def _comandos_en_linea_de_uso(output: str) -> tuple[str, ...]:
+    coincidencias = re.findall(r"\{([a-z]+(?:,\s*[a-z]+)+)\}", output)
+    comandos = next(grupo for grupo in coincidencias if "run" in grupo.split(","))
+    return tuple(comando.strip() for comando in comandos.split(","))
+
+
+def test_cli_early_global_help_exposes_exact_public_commands():
+    with patch("sys.stdout", new_callable=StringIO) as output:
+        assert public_cli.main(["--help"]) == 0
+
+    ayuda = output.getvalue()
+    assert _comandos_en_ayuda_temprana(ayuda) == PUBLIC_COMMANDS
+    assert _comandos_en_linea_de_uso(ayuda) == PUBLIC_COMMANDS
+
+
+def test_cobra_entrypoint_early_help_exposes_exact_public_commands():
+    repo_root = Path(__file__).resolve().parents[2]
+    env = _public_env()
+    env["PATH"] = f"{repo_root / 'scripts' / 'bin'}{os.pathsep}{env.get('PATH', '')}"
+
+    for help_flag in ("--help", "-h"):
+        result = subprocess.run(
+            ["cobra", help_flag],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=str(repo_root),
+            env=env,
+        )
+        assert result.returncode == 0
+        assert _comandos_en_linea_de_uso(result.stdout) == PUBLIC_COMMANDS
 
 
 def test_cli_public_commands_contract_is_stable():


### PR DESCRIPTION
### Motivation

- Añadir `gui` a la ayuda global temprana y generar la línea de uso y la lista de comandos desde un contrato ligero para evitar dependencias del runtime o cargas de módulos pesados. 
- Mantener la representación de la ayuda mínima e independiente del intérprete, transpiladores y runtime de Flet.

### Description

- Actualiza `_mostrar_ayuda_global_temprana` en `src/pcobra/cli.py` para importar `PUBLIC_COMMANDS` desde `pcobra.cobra.cli.public_command_policy` y generar la línea de uso y la lista de comandos dinámicamente en vez de escribir el contrato manualmente. 
- Añade la descripción pública de `gui` en la ayuda temprana ("Inicia la interfaz gráfica.").
- Extiende `tests/integration/test_cli_public_help_contract.py` para comprobar la salida temprana: se agregaron funciones auxiliares para extraer los comandos de la ayuda y dos pruebas nuevas que validan que `pcobra.cli.main(["--help"])`, `cobra --help` y `cobra -h` exponen exactamente los comandos públicos (`run`, `build`, `test`, `mod`, `repl`, `gui`).
- Evita importar `pcobra.cobra.cli.cli` o `pcobra.cobra.cli.commands.flet_cmd` para generar la ayuda temprana, cumpliendo la restricción de no depender del runtime.

### Testing

- Ejecuté `pytest -q tests/integration/test_cli_public_help_contract.py` y las pruebas relevantes contra la ayuda temprana pasaron (incluyendo las nuevas pruebas de `pcobra.cli.main(["--help"])` y `cobra --help`/`-h`).
- Ejecuté `pytest -q tests/integration/test_cli_ui_v2.py` y la suite pasó sin errores.
- Verifiqué `git diff --check` y confirmé que Lexer y Parser no fueron modificados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59da16cc3883278f7c0d7429ab0f4e)