### PR TITLE
Make global CLI version startup lightweight

### DIFF
--- a/src/pcobra/cli.py
+++ b/src/pcobra/cli.py
@@ -1,8 +1,10 @@
+import importlib.metadata
 import logging
 import os
 import secrets
 import shutil
 import sys
+import tomllib
 from importlib import import_module
 from pathlib import Path
 from typing import Iterable, List, Optional
@@ -39,6 +41,51 @@ _LEGACY_SHIM_ALIAS_CONTRACT = {
     "cli.cli": ("cli", "cli.cli"),
     "cobra.cli.cli": (),
 }
+
+
+def _resolve_pyproject_version() -> Optional[str]:
+    """Obtiene la versión declarada al ejecutar directamente desde fuentes."""
+
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    try:
+        metadata = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+    project = metadata.get("project")
+    if not isinstance(project, dict):
+        return None
+    version = project.get("version")
+    return str(version) if version else None
+
+
+def _resolve_cli_version() -> str:
+    """Resuelve la versión sin cargar la implementación completa de la CLI."""
+
+    env_version = os.environ.get("COBRA_CLI_VERSION")
+    if env_version:
+        return env_version
+
+    try:
+        return importlib.metadata.version("pcobra")
+    except importlib.metadata.PackageNotFoundError:
+        return _resolve_pyproject_version() or "dev"
+
+
+def _resolve_cli_commit() -> Optional[str]:
+    commit = os.environ.get("COBRA_CLI_COMMIT", "").strip()
+    if not commit or commit.lower() == "unknown":
+        return None
+    return commit
+
+
+def _format_cli_version() -> str:
+    commit = _resolve_cli_commit()
+    commit_suffix = f" (commit {commit})" if commit else ""
+    return f"%(prog)s {CLI_VERSION}{commit_suffix}"
+
+
+CLI_VERSION = _resolve_cli_version()
 
 # Habilita imports de submódulos canónicos como ``pcobra.cli.commands`` y
 # ``pcobra.cli.cli`` sin reemplazar ``pcobra.cli`` por otro objeto.
@@ -343,6 +390,25 @@ def _es_ayuda_global_temprana(argv: Optional[List[str]]) -> bool:
     return tokens in (["-h"], ["--help"], ["--ayuda"])
 
 
+def _es_version_global_temprana(argv: Optional[List[str]]) -> bool:
+    """Reconoce exclusivamente ``cobra --version`` y opciones neutrales."""
+
+    if not argv:
+        return False
+
+    opciones_neutras = {"--debug", "-v", "--verbose", "--no-color"}
+    tokens = [
+        token
+        for token in argv
+        if token not in opciones_neutras and not token.startswith("--verbose=")
+    ]
+    return tokens == ["--version"]
+
+
+def _mostrar_version_global_temprana() -> None:
+    print(_format_cli_version().replace("%(prog)s", "cobra", 1))
+
+
 def _mostrar_ayuda_global_temprana() -> None:
     """Imprime ayuda pública mínima sin importar comandos opcionales/runtime."""
 
@@ -407,6 +473,10 @@ def main(argumentos: Optional[List[str]] = None) -> int:
 
     if _es_ayuda_global_temprana(argv):
         _mostrar_ayuda_global_temprana()
+        return 0
+
+    if _es_version_global_temprana(argv):
+        _mostrar_version_global_temprana()
         return 0
 
     if flag_legacy_imports or env_legacy_imports:

--- a/src/pcobra/cobra/cli/cli.py
+++ b/src/pcobra/cobra/cli/cli.py
@@ -5,8 +5,6 @@ from types import SimpleNamespace
 import logging
 import os
 import sys
-import tomllib
-from importlib.metadata import PackageNotFoundError, version as package_version
 from os import environ
 from pathlib import Path
 from typing import List, Dict, Optional, Type, Any, ContextManager, Iterable
@@ -20,6 +18,8 @@ from pcobra.cli import (
     COBRA_DEV_MODE_ENV,
     COBRA_LANG_ENV,
     SQLITE_DB_KEY_ENV,
+    CLI_VERSION,
+    _format_cli_version,
     ensure_sqlite_db_key_for_command,
     env_flag_activado,
 )
@@ -74,45 +74,6 @@ from pcobra.cobra.cli.utils.autocomplete import (
     files_completer,
 )
 
-
-# Metadata injected at build time, with package metadata fallback for editable installs.
-def _resolve_pyproject_version() -> Optional[str]:
-    pyproject_path = Path(__file__).resolve().parents[4] / "pyproject.toml"
-    try:
-        metadata = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        return None
-
-    version = metadata.get("project", {}).get("version")
-    return str(version) if version else None
-
-
-def _resolve_cli_version() -> str:
-    env_version = environ.get("COBRA_CLI_VERSION")
-    if env_version:
-        return env_version
-
-    try:
-        return package_version("pcobra")
-    except PackageNotFoundError:
-        pyproject_version = _resolve_pyproject_version()
-        return pyproject_version if pyproject_version else "dev"
-
-
-def _resolve_cli_commit() -> Optional[str]:
-    commit = environ.get("COBRA_CLI_COMMIT", "").strip()
-    if not commit or commit.lower() == "unknown":
-        return None
-    return commit
-
-
-def _format_cli_version() -> str:
-    commit = _resolve_cli_commit()
-    commit_suffix = f" (commit {commit})" if commit else ""
-    return f"%(prog)s {CLI_VERSION}{commit_suffix}"
-
-
-CLI_VERSION = _resolve_cli_version()
 
 assert_public_targets_contract(tuple(PUBLIC_BACKENDS), source="cobra cli bootstrap")
 LANG_CHOICES = tuple(PUBLIC_BACKENDS)

--- a/tests/unit/test_cli_startup_import_contract.py
+++ b/tests/unit/test_cli_startup_import_contract.py
@@ -1,8 +1,63 @@
 from __future__ import annotations
 
 import ast
+import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 import tomllib
+
+
+FORBIDDEN_STARTUP_MODULE_PARTS = (
+    "interpreter",
+    "transpiler",
+    "transpilador",
+)
+FORBIDDEN_STARTUP_ROOTS = {"agix", "numpy", "flet"}
+
+
+def _run_lightweight_global_option(option: str) -> dict[str, object]:
+    probe = f"""
+import contextlib
+import io
+import json
+import sys
+from pcobra import cli
+
+stdout = io.StringIO()
+with contextlib.redirect_stdout(stdout):
+    result = cli.main([{option!r}])
+print(json.dumps({{"result": result, "stdout": stdout.getvalue(), "modules": sorted(sys.modules)}}))
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path("src").resolve())
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return json.loads(completed.stdout)
+
+
+def _assert_no_heavy_startup_modules(modules: list[str]) -> None:
+    offenders = [
+        module
+        for module in modules
+        if module.split(".", 1)[0] in FORBIDDEN_STARTUP_ROOTS
+        or any(part in module.lower() for part in FORBIDDEN_STARTUP_MODULE_PARTS)
+    ]
+    assert offenders == []
+
+
+def test_opciones_globales_no_cargan_runtime_pesado() -> None:
+    for option in ("--help", "-h", "--version"):
+        probe = _run_lightweight_global_option(option)
+        assert probe["result"] == 0
+        assert probe["stdout"]
+        _assert_no_heavy_startup_modules(probe["modules"])
 
 
 def test_cli_bootstrap_no_importa_comandos_directamente() -> None:

--- a/tests/unit/test_cli_version_resolution.py
+++ b/tests/unit/test_cli_version_resolution.py
@@ -2,11 +2,12 @@ import ast
 import tomllib
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Optional
 
 
 ROOT = Path(__file__).resolve().parents[2]
-CLI_PATH = ROOT / "src" / "pcobra" / "cobra" / "cli" / "cli.py"
+CLI_PATH = ROOT / "src" / "pcobra" / "cli.py"
 
 
 def _load_version_helpers(tmp_path: Path, env: dict[str, str], package_version):
@@ -23,14 +24,19 @@ def _load_version_helpers(tmp_path: Path, env: dict[str, str], package_version):
         for node in tree.body
         if isinstance(node, ast.FunctionDef) and node.name in wanted
     )
-    fake_cli = tmp_path / "src" / "pcobra" / "cobra" / "cli" / "cli.py"
+    fake_cli = tmp_path / "src" / "pcobra" / "cli.py"
     fake_cli.parent.mkdir(parents=True)
     fake_cli.write_text("", encoding="utf-8")
     namespace = {
         "__file__": str(fake_cli),
         "environ": env,
-        "PackageNotFoundError": PackageNotFoundError,
-        "package_version": package_version,
+        "importlib": SimpleNamespace(
+            metadata=SimpleNamespace(
+                version=package_version,
+                PackageNotFoundError=PackageNotFoundError,
+            )
+        ),
+        "os": type("FakeOs", (), {"environ": env}),
         "Path": Path,
         "tomllib": tomllib,
         "Optional": Optional,
@@ -80,6 +86,17 @@ def test_resolve_cli_version_usa_pyproject_sin_metadata_de_distribucion(tmp_path
 
 
 def test_resolve_cli_version_fallback_dev_si_no_hay_metadata_ni_pyproject(tmp_path):
+    def missing_distribution(_name: str) -> str:
+        raise PackageNotFoundError
+
+    helpers = _load_version_helpers(tmp_path, {}, missing_distribution)
+
+    assert helpers["_resolve_cli_version"]() == "dev"
+
+
+def test_resolve_cli_version_fallback_dev_si_project_no_es_tabla(tmp_path):
+    (tmp_path / "pyproject.toml").write_text('project = "invalid"\n', encoding="utf-8")
+
     def missing_distribution(_name: str) -> str:
         raise PackageNotFoundError
 


### PR DESCRIPTION
### Motivation

- Evitar cargar la implementación completa de la CLI solo para mostrar la versión o ayuda global, reduciendo imports pesados en arranques globales neutrales como `cobra --version`.

### Description

- Mueve la resolución mínima de versión al bootstrap ligero en `src/pcobra/cli.py` y añade funciones `_resolve_pyproject_version`, `_resolve_cli_version`, `_resolve_cli_commit` y `_format_cli_version`, devolviendo `dev` si no hay metadata ni `pyproject.toml`. 
- Reconoce y atiende tempranamente la invocación exacta `cobra --version` con `_es_version_global_temprana` y `_mostrar_version_global_temprana`, imprimiendo la versión y retornando 0 sin importar `pcobra.cobra.cli.cli`.
- Reutiliza `CLI_VERSION` y `_format_cli_version` desde el bootstrap ligero en el entrypoint canónico y elimina la implementación duplicada en `src/pcobra/cobra/cli/cli.py`.
- Adapta `tests/unit/test_cli_version_resolution.py` para cargar y probar las funciones desde `src/pcobra/cli.py` y amplía `tests/unit/test_cli_startup_import_contract.py` con subprocesses que ejecutan `--help`, `-h` y `--version` y comprueban que no se importan módulos pesados o no deseados.
- No se modificaron Lexer ni Parser ni se añaden tokens ni sintaxis nueva según las reglas de AGENTS.md.

### Testing

- Ejecutadas las pruebas específicas con `pytest -q tests/unit/test_cli_version_resolution.py tests/unit/test_cli_startup_import_contract.py` y ambas pruebas pasaron (todas las pruebas modificadas fueron exitosas, con una advertencia deprecatoria). 
- Comprobado el estilo/linters con `python -m ruff check` sobre los archivos modificados y no se reportaron errores. 
- Verificado que no se tocaron archivos de Lexer/Parser y que las comprobaciones de diff no mostraron problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59dbe1e6bc8327ba8d5824034f3e84)