### PR TITLE
Valida metadata y resolución de dependencias del wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,29 @@ on:
 
 jobs:
 
+  wheel-dependency-resolution:
+    name: Wheel dependencies (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # Fijado a commit para seguridad de la cadena de suministro.
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build wheel from canonical pyproject.toml
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+      - name: Resolve wheel dependencies
+        run: python -m pip install --dry-run dist/*.whl
+      - name: Install wheel and dependencies
+        run: python -m pip install dist/*.whl
+      - name: Validate installed dependency set
+        run: python -m pip check
+
   critical-policy-contract-gates:
     name: Critical policy and contract gates
     if: github.event_name != 'schedule'

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+import zipfile
+from email.parser import BytesParser
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _is_optional(requirement: Requirement) -> bool:
+    """Indica si un Requires-Dist pertenece a un extra del proyecto."""
+
+    return requirement.marker is not None and "extra" in str(requirement.marker)
+
+
+def test_wheel_preserva_dependencias_obligatorias_de_pyproject(tmp_path: Path) -> None:
+    """Evita que el backend añada, elimine o modifique dependencias al publicar."""
+
+    with (REPO_ROOT / "pyproject.toml").open("rb") as pyproject_file:
+        project = tomllib.load(pyproject_file)["project"]
+    declared = {Requirement(value) for value in project["dependencies"]}
+
+    dist_dir = tmp_path / "dist"
+    subprocess.run(
+        [sys.executable, "-m", "build", "--wheel", "--outdir", str(dist_dir)],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    wheels = list(dist_dir.glob("*.whl"))
+    assert len(wheels) == 1, f"Se esperaba exactamente un wheel, encontrados: {wheels}"
+    with zipfile.ZipFile(wheels[0]) as wheel:
+        metadata_paths = [
+            name for name in wheel.namelist() if name.endswith(".dist-info/METADATA")
+        ]
+        assert len(metadata_paths) == 1, (
+            "El wheel debe contener un único *.dist-info/METADATA: "
+            f"{metadata_paths}"
+        )
+        metadata = BytesParser().parsebytes(wheel.read(metadata_paths[0]))
+
+    published = {
+        requirement
+        for value in metadata.get_all("Requires-Dist", [])
+        if not _is_optional(requirement := Requirement(value))
+    }
+    assert published == declared, (
+        "Las dependencias obligatorias del wheel difieren de [project].dependencies. "
+        f"Añadidas o modificadas: {sorted(map(str, published - declared))}; "
+        f"eliminadas o modificadas: {sorted(map(str, declared - published))}"
+    )


### PR DESCRIPTION
### Motivation

- Asegurar que el proceso de build no añada, elimine ni modifique las dependencias obligatorias declaradas en `[project].dependencies` de `pyproject.toml`.
- Verificar que el wheel resultante resuelve e instala correctamente con NumPy y SciPy compatibles con la metadata publicada de `agix>=1.9.0,<2`, `scipy`, `holobit-sdk` y `smooth-criminal` en Python 3.11, 3.12 y 3.13.

### Description

- Añade el test `tests/test_packaging_metadata.py` que lee `[project].dependencies` con `tomllib`, construye un wheel (`python -m build --wheel`), abre `*.dist-info/METADATA` con `zipfile` y compara los `Requires-Dist` obligatorios normalizados con `packaging.requirements.Requirement` contra lo declarado en `pyproject.toml`.
- Introduce un job CI `wheel-dependency-resolution` en `.github/workflows/ci.yml` con una matriz para `3.11`, `3.12` y `3.13` que: construye el wheel desde el `pyproject.toml` canónico, ejecuta resolución con `python -m pip install --dry-run dist/*.whl`, instala el wheel `python -m pip install dist/*.whl` y valida el conjunto instalado con `python -m pip check`.
- Conserva los límites existentes en `pyproject.toml` tras revisar la metadata de terceros (por ejemplo, `agix 1.9.0` declara `numpy<2.2,>=1.24` y `scipy<1.15,>=1.10`), por lo que no se amplió ni redujo innecesariamente ningún specifier.
- No se modificaron Lexer, Parser, sintaxis ni documentación del lenguaje; los cambios son focalizados en tests y workflow de CI.

### Testing

- `pytest tests/test_packaging_metadata.py tests/test_workflows_yaml.py -q` — todas las pruebas pasaron (`23 passed, 1 warning`).
- `python -m build --wheel --outdir dist` — wheel construido correctamente para las verificaciones locales de matriz.
- En entornos limpios por versión (3.11, 3.12, 3.13) se ejecutó: `python -m pip install --dry-run dist/*.whl` (resolución), `python -m pip install dist/*.whl` (instalación) y `python -m pip check`, y todos reportaron `No broken requirements found`.
- `python -m compileall -q tests/test_packaging_metadata.py` — compilación OK.
- `git diff --check` y verificación explícita de que no hay cambios en `src/pcobra/.../lexer.py` ni `parser.py` — OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59dd86e880832789bdeb2c8bb8a0d0)