### PR TITLE
Use SafeFileHistory for REPL history and add unit test

### DIFF
--- a/src/pcobra/cobra/cli/commands/interactive_cmd.py
+++ b/src/pcobra/cobra/cli/commands/interactive_cmd.py
@@ -1412,6 +1412,6 @@ class InteractiveCommand(BaseCommand):
         self.logger.debug(_("Finalizando REPL de Cobra"))
 
     def _construir_historial(self, history_path: str) -> Any:
-        if FileHistory is not None:
-            return FileHistory(history_path)
+        if SafeFileHistory is not None:
+            return SafeFileHistory(history_path)
         return _SessionHistoryFallback(history_path)

--- a/tests/unit/test_unicode_sanitize_repl.py
+++ b/tests/unit/test_unicode_sanitize_repl.py
@@ -125,6 +125,17 @@ def test_sanitize_source_for_tokenizer_no_muta_identificadores_unicode() -> None
     assert saneado == codigo
 
 
+def test_interactive_command_construye_historial_unicode_seguro(tmp_path):
+    if SafeFileHistory is None:
+        return
+
+    cmd = InteractiveCommand(MagicMock())
+
+    historial = cmd._construir_historial(str(tmp_path / ".cobra_history"))
+
+    assert isinstance(historial, SafeFileHistory)
+
+
 def test_interactive_command_sanitiza_surrogate_invalido_y_no_crashea(tmp_path):
     cmd = InteractiveCommand(MagicMock())
     capturado = {"history": [], "validar": []}


### PR DESCRIPTION
### Motivation

- Prevent Unicode/encoding errors when persisting REPL history by preferring a history implementation that safely handles surrogates and encoding issues.

### Description

- Replace `FileHistory` with `SafeFileHistory` in `InteractiveCommand._construir_historial` so the REPL uses the safer history backend when available.
- Keep the existing fallback to `_SessionHistoryFallback` when `SafeFileHistory` is not present.
- Add `test_interactive_command_construye_historial_unicode_seguro` to `tests/unit/test_unicode_sanitize_repl.py` to verify that `SafeFileHistory` is constructed when available.

### Testing

- Ran `pytest tests/unit/test_unicode_sanitize_repl.py::test_interactive_command_construye_historial_unicode_seguro` and the test passed (the test skips itself if `SafeFileHistory` is not available). 
- Existing sanitizer tests in `tests/unit/test_unicode_sanitize_repl.py` were also exercised and remain passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59e230fdc88327bf37ff5011404c63)