### PR TITLE
Desacoplar CobraHub de CLI y GUI

### DIFF
--- a/src/pcobra/cobra/cli/cobrahub_client.py
+++ b/src/pcobra/cobra/cli/cobrahub_client.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 from pcobra.cobra.cli.i18n import _
 from pcobra.cobra.cli.utils.messages import mostrar_error, mostrar_info
+from pcobra.cobra.hub.errors import PackageProviderError
 
 if TYPE_CHECKING:  # pragma: no cover - solo para tipado
     import requests
@@ -62,7 +63,7 @@ class CobraHubClient:
             "COBRAHUB_URL", "https://cobrahub.example.com/api"
         )
         if len(url) > 2048:  # Límite común para URLs
-            raise ValueError(_("URL de CobraHub demasiado larga"))
+            raise PackageProviderError(_("URL de CobraHub demasiado larga"))
         return url
 
     def _configurar_sesion(self) -> "requests.Session":

--- a/src/pcobra/cobra/cli/cobrahub_packages.py
+++ b/src/pcobra/cobra/cli/cobrahub_packages.py
@@ -13,6 +13,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.hub.errors import (
+    CobraHubError,
+    PackageIntegrityError,
+    PackageProviderError,
+)
 from pcobra.cobra.hub.repository import (
     HttpCobraHubRepository,
     PackageRepository,
@@ -72,10 +77,12 @@ def validar_cache() -> list[tuple[Path, bool, str | None]]:
     for path in listar_cache():
         try:
             if not es_paquete_cobra(path):
-                raise ValueError(
+                raise PackageIntegrityError(
                     "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
                 )
             validar_paquete(path)
+        except CobraHubError as exc:
+            resultados.append((path, False, _(str(exc))))
         except Exception as exc:
             resultados.append((path, False, str(exc)))
         else:
@@ -122,13 +129,17 @@ class CobraHubPackages:
             return False
         try:
             if not es_paquete_cobra(ruta):
-                raise ValueError(
+                raise PackageIntegrityError(
                     "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
                 )
             info = validar_paquete(ruta)
             self.repository.publish(ruta, dict(info.manifest), info.checksum)
             _mostrar_info(_("Paquete publicado correctamente"))
             return True
+        except CobraHubError as e:
+            logger.error(f"Error publicando paquete: {e}")
+            _mostrar_error(_("Error publicando paquete: {err}").format(err=_(str(e))))
+            return False
         except Exception as e:
             logger.error(f"Error publicando paquete: {e}")
             _mostrar_error(_("Error publicando paquete: {err}").format(err=str(e)))
@@ -140,6 +151,10 @@ class CobraHubPackages:
             return []
         try:
             return [result.as_dict() for result in self.repository.search(consulta)]
+        except CobraHubError as e:
+            logger.error(f"Error buscando paquetes: {e}")
+            _mostrar_error(_("Error buscando paquetes: {err}").format(err=_(str(e))))
+            return []
         except Exception as e:
             logger.error(f"Error buscando paquetes: {e}")
             _mostrar_error(_("Error buscando paquetes: {err}").format(err=str(e)))
@@ -164,8 +179,7 @@ class CobraHubPackages:
 
             if not es_paquete_cobra(cache_path):
                 os.unlink(cache_path)
-                _mostrar_error(_("La descarga no es un paquete Cobra válido"))
-                return False
+                raise PackageIntegrityError("La descarga no es un paquete Cobra válido")
 
             install_path = (
                 Path(destino).expanduser()
@@ -175,6 +189,12 @@ class CobraHubPackages:
             extraer_paquete(cache_path, install_path)
             _mostrar_info(_("Paquete instalado en {dest}").format(dest=install_path))
             return True
+        except CobraHubError as e:
+            logger.error(f"Error instalando paquete: {e}")
+            _mostrar_error(_("Error instalando paquete: {err}").format(err=_(str(e))))
+            if cache_path is not None and cache_path.exists():
+                cache_path.unlink(missing_ok=True)
+            return False
         except Exception as e:
             logger.error(f"Error instalando paquete: {e}")
             _mostrar_error(_("Error instalando paquete: {err}").format(err=str(e)))
@@ -187,7 +207,12 @@ class CobraHubPackages:
 
     def leer_metadatos(self, ruta: str | Path) -> dict[str, Any]:
         """Lee y devuelve el manifiesto/metadatos de un paquete local ``.co``."""
-        return self.repository.read_metadata(ruta)
+        try:
+            return self.repository.read_metadata(ruta)
+        except CobraHubError:
+            raise
+        except Exception as exc:
+            raise PackageProviderError(str(exc)) from exc
 
 
 __all__ = [

--- a/src/pcobra/cobra/hub/__init__.py
+++ b/src/pcobra/cobra/hub/__init__.py
@@ -1,13 +1,30 @@
 """Infraestructura de repositorios CobraHub."""
 
+from pcobra.cobra.hub.errors import (
+    CobraHubError,
+    PackageCompatibilityError,
+    PackageIntegrityError,
+    PackageNotFoundError,
+    PackageProviderError,
+    PackageResolutionError,
+)
 from pcobra.cobra.hub.repository import (
     DownloadedPackage,
     HttpCobraHubRepository,
     PackageRepository,
 )
+from pcobra.cobra.hub.transport import CobraHubTransport, HttpSession
 
 __all__ = [
+    "CobraHubError",
+    "CobraHubTransport",
     "DownloadedPackage",
     "HttpCobraHubRepository",
+    "HttpSession",
+    "PackageCompatibilityError",
+    "PackageIntegrityError",
+    "PackageNotFoundError",
+    "PackageProviderError",
     "PackageRepository",
+    "PackageResolutionError",
 ]

--- a/src/pcobra/cobra/hub/errors.py
+++ b/src/pcobra/cobra/hub/errors.py
@@ -1,0 +1,35 @@
+"""Excepciones de dominio de la infraestructura CobraHub."""
+
+
+class CobraHubError(Exception):
+    """Error base producido por una operación de CobraHub."""
+
+
+class PackageNotFoundError(CobraHubError):
+    """El paquete solicitado no existe en el proveedor."""
+
+
+class PackageIntegrityError(CobraHubError):
+    """El contenido de un paquete no supera su validación de integridad."""
+
+
+class PackageResolutionError(CobraHubError):
+    """No se puede resolver el nombre, la versión o los metadatos solicitados."""
+
+
+class PackageCompatibilityError(CobraHubError):
+    """El paquete o la versión devuelta no es compatible con la solicitud."""
+
+
+class PackageProviderError(CobraHubError):
+    """El proveedor o transporte de paquetes no pudo completar la operación."""
+
+
+__all__ = [
+    "CobraHubError",
+    "PackageCompatibilityError",
+    "PackageIntegrityError",
+    "PackageNotFoundError",
+    "PackageProviderError",
+    "PackageResolutionError",
+]

--- a/src/pcobra/cobra/hub/repository.py
+++ b/src/pcobra/cobra/hub/repository.py
@@ -17,9 +17,17 @@ import urllib.parse
 from dataclasses import dataclass
 from email.message import Message
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import Any, Protocol
 
-from pcobra.cobra.cli.i18n import _
+from pcobra.cobra.hub.errors import (
+    CobraHubError,
+    PackageCompatibilityError,
+    PackageIntegrityError,
+    PackageNotFoundError,
+    PackageProviderError,
+    PackageResolutionError,
+)
+from pcobra.cobra.hub.transport import CobraHubTransport
 from pcobra.cobra.packaging import (
     PackageSearchResult,
     manifest_from_dict,
@@ -27,9 +35,6 @@ from pcobra.cobra.packaging import (
     normalizar_nombre_paquete,
     validar_version_paquete,
 )
-
-if TYPE_CHECKING:  # pragma: no cover - solo para tipado
-    from pcobra.cobra.cli.cobrahub_client import CobraHubClient
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +74,7 @@ class PackageRepository(Protocol):
 class HttpCobraHubRepository:
     """Repositorio CobraHub respaldado por HTTP usando un ``CobraHubClient``."""
 
-    def __init__(self, client: "CobraHubClient") -> None:
+    def __init__(self, client: CobraHubTransport) -> None:
         self.client = client
 
     def publish(
@@ -77,9 +82,12 @@ class HttpCobraHubRepository:
     ) -> bool:
         """Publica un paquete .co mediante la API HTTP de CobraHub."""
         ruta = Path(package_path)
-        metadata = _normalizar_metadatos_paquete(metadata)
-        with ruta.open("rb") as f:
-            with self.client.session.post(
+        try:
+            metadata = _normalizar_metadatos_paquete(metadata)
+        except (TypeError, ValueError, KeyError) as exc:
+            raise PackageResolutionError(str(exc)) from exc
+        try:
+            with ruta.open("rb") as f, self.client.session.post(
                 f"{self.client.base_url}/paquetes",
                 files={"file": f},
                 data={"metadata": json_dumps(metadata)},
@@ -93,29 +101,43 @@ class HttpCobraHubRepository:
                 ),
             ) as response:
                 response.raise_for_status()
-        cache_path = package_cache_dir() / ruta.name
-        if ruta.resolve() != cache_path.resolve():
-            shutil.copy2(ruta, cache_path)
+            cache_path = package_cache_dir() / ruta.name
+            if ruta.resolve() != cache_path.resolve():
+                shutil.copy2(ruta, cache_path)
+        except CobraHubError:
+            raise
+        except Exception as exc:
+            raise PackageProviderError(str(exc)) from exc
         return True
 
     def search(self, query: str) -> list[PackageSearchResult]:
         """Busca paquetes mediante la API HTTP de CobraHub."""
-        with self.client.session.get(
-            f"{self.client.base_url}/paquetes",
-            params={"q": query},
-            timeout=(self.client.CONNECT_TIMEOUT, self.client.READ_TIMEOUT),
-        ) as response:
-            response.raise_for_status()
-            data = response.json() if hasattr(response, "json") else []
-        items = data.get("results", []) if isinstance(data, dict) else data
-        return [_normalizar_resultado_paquete(item) for item in list(items)]
+        try:
+            with self.client.session.get(
+                f"{self.client.base_url}/paquetes",
+                params={"q": query},
+                timeout=(self.client.CONNECT_TIMEOUT, self.client.READ_TIMEOUT),
+            ) as response:
+                response.raise_for_status()
+                data = response.json() if hasattr(response, "json") else []
+            items = data.get("results", []) if isinstance(data, dict) else data
+            return [_normalizar_resultado_paquete(item) for item in list(items)]
+        except CobraHubError:
+            raise
+        except (TypeError, ValueError, KeyError) as exc:
+            raise PackageResolutionError(str(exc)) from exc
+        except Exception as exc:
+            raise PackageProviderError(str(exc)) from exc
 
     def download(self, name: str, version: str | None = None) -> DownloadedPackage:
         """Descarga un paquete por nombre y versión opcional en la caché local."""
-        normalized_name = normalizar_nombre_paquete(name)
-        normalized_version = (
-            validar_version_paquete(version) if version is not None else None
-        )
+        try:
+            normalized_name = normalizar_nombre_paquete(name)
+            normalized_version = (
+                validar_version_paquete(version) if version is not None else None
+            )
+        except (TypeError, ValueError) as exc:
+            raise PackageResolutionError(str(exc)) from exc
         cache_path = package_cache_dir() / _cache_filename(
             normalized_name, normalized_version
         )
@@ -130,11 +152,21 @@ class HttpCobraHubRepository:
                 timeout=(self.client.CONNECT_TIMEOUT, self.client.READ_TIMEOUT),
                 stream=True,
             ) as response:
-                response.raise_for_status()
+                try:
+                    response.raise_for_status()
+                except Exception as exc:
+                    status = getattr(getattr(exc, "response", None), "status_code", None)
+                    status = status or getattr(response, "status_code", None)
+                    if status == 404:
+                        raise PackageNotFoundError(str(exc)) from exc
+                    raise PackageProviderError(str(exc)) from exc
                 checksum_servidor = response.headers.get("X-Content-Checksum")
                 version_servidor = _version_from_response(response)
                 if version_servidor:
-                    version_servidor = validar_version_paquete(version_servidor)
+                    try:
+                        version_servidor = validar_version_paquete(version_servidor)
+                    except (TypeError, ValueError) as exc:
+                        raise PackageCompatibilityError(str(exc)) from exc
                 if version_servidor and version_servidor != normalized_version:
                     cache_path = package_cache_dir() / _cache_filename(
                         normalized_name, version_servidor
@@ -152,14 +184,16 @@ class HttpCobraHubRepository:
                         if tamaño_total > self.client.MAX_FILE_SIZE:
                             out.close()
                             os.unlink(cache_path)
-                            raise ValueError(_("Archivo descargado demasiado grande"))
+                            raise PackageIntegrityError(
+                                "Archivo descargado demasiado grande"
+                            )
                         sha256.update(chunk)
                         out.write(chunk)
 
             digest = sha256.hexdigest()
             if checksum_servidor and digest != checksum_servidor:
                 os.unlink(cache_path)
-                raise ValueError(_("Verificación de integridad fallida"))
+                raise PackageIntegrityError("Verificación de integridad fallida")
 
             return DownloadedPackage(
                 path=cache_path,
@@ -167,21 +201,30 @@ class HttpCobraHubRepository:
                 version=version_servidor or normalized_version,
                 checksum=checksum_servidor or digest,
             )
-        except Exception:
+        except CobraHubError:
             if cache_path.exists():
                 os.unlink(cache_path)
             raise
+        except Exception as exc:
+            if cache_path.exists():
+                os.unlink(cache_path)
+            raise PackageProviderError(str(exc)) from exc
 
     def read_metadata(self, package_path: str | Path) -> dict[str, Any]:
         """Lee metadatos de un paquete local usando el validador de paquetes Cobra."""
         from pcobra.cobra.packaging import es_paquete_cobra, validar_paquete
 
         if not es_paquete_cobra(package_path):
-            raise ValueError(
+            raise PackageIntegrityError(
                 "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
             )
-        info = validar_paquete(package_path)
-        return _normalizar_metadatos_paquete(info.manifest)
+        try:
+            info = validar_paquete(package_path)
+            return _normalizar_metadatos_paquete(info.manifest)
+        except CobraHubError:
+            raise
+        except Exception as exc:
+            raise PackageIntegrityError(str(exc)) from exc
 
 
 def _normalizar_metadatos_paquete(metadata: dict[str, Any]) -> dict[str, Any]:

--- a/src/pcobra/cobra/hub/transport.py
+++ b/src/pcobra/cobra/hub/transport.py
@@ -1,0 +1,27 @@
+"""Contratos mínimos de transporte usados por el repositorio HTTP."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class HttpSession(Protocol):
+    """Sesión capaz de efectuar las operaciones HTTP requeridas por CobraHub."""
+
+    def get(self, url: str, **kwargs: Any) -> Any: ...
+
+    def post(self, url: str, **kwargs: Any) -> Any: ...
+
+
+class CobraHubTransport(Protocol):
+    """Configuración mínima que el repositorio necesita de un cliente HTTP."""
+
+    base_url: str
+    session: HttpSession
+    CONNECT_TIMEOUT: float
+    READ_TIMEOUT: float
+    MAX_FILE_SIZE: int
+    CHUNK_SIZE: int
+
+
+__all__ = ["CobraHubTransport", "HttpSession"]

--- a/tests/unit/test_hub_import_boundaries.py
+++ b/tests/unit/test_hub_import_boundaries.py
@@ -1,0 +1,38 @@
+"""Regresión de la frontera arquitectónica de CobraHub."""
+
+import ast
+import importlib
+import pkgutil
+from pathlib import Path
+
+import pcobra.cobra.hub as hub
+
+
+def test_hub_no_importa_cli_ni_gui():
+    """Todos los módulos de Hub deben poder evolucionar sin depender de las UI."""
+    prohibidos = ("pcobra.cobra.cli", "pcobra.gui")
+    for module_info in pkgutil.walk_packages(hub.__path__, f"{hub.__name__}."):
+        module = importlib.import_module(module_info.name)
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imports = [
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        ] + [
+            node.module or ""
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+        ]
+        assert not any(
+            imported.startswith(prohibido)
+            for imported in imports
+            for prohibido in prohibidos
+        ), f"{module_info.name} depende de una capa de presentación"
+
+
+def test_hub_conserva_exports_publicos_del_repositorio():
+    assert hub.PackageRepository
+    assert hub.HttpCobraHubRepository
+    assert hub.DownloadedPackage


### PR DESCRIPTION
### Motivation
- Evitar que la capa de repositorio de paquetes (CobraHub) dependa de la UI/CLI para permitir evolución independiente y pruebas aisladas.
- Exponer errores de dominio explícitos para distinguir fallos de resolución, integridad, compatibilidad y proveedor/transportes HTTP.
- Definir un contrato mínimo de transporte HTTP que describa `session`, timeouts, `MAX_FILE_SIZE` y `CHUNK_SIZE` sin asumir la implementación de la CLI.

### Description
- Añade `src/pcobra/cobra/hub/errors.py` con las excepciones de dominio: `CobraHubError`, `PackageNotFoundError`, `PackageIntegrityError`, `PackageResolutionError`, `PackageCompatibilityError` y `PackageProviderError`.
- Añade `src/pcobra/cobra/hub/transport.py` con los protocolos `HttpSession` y `CobraHubTransport` que definen la interfaz mínima requerida por el repositorio HTTP.
- Refactoriza `src/pcobra/cobra/hub/repository.py` para depender del protocolo `CobraHubTransport` y mapear `ValueError`/excepciones genéricas a las nuevas excepciones de dominio, preservando mensajes públicos cuando procede.
- Actualiza la fachada `src/pcobra/cobra/cli/cobrahub_packages.py` y `src/pcobra/cobra/cli/cobrahub_client.py` para capturar las excepciones de dominio y traducirlas/mostrar mensajes localizados mediante el sistema existente, manteniendo la API histórica (retornos booleanos/listas) para CLI/GUI/IDLE.
- Añade `tests/unit/test_hub_import_boundaries.py` que importa y analiza todos los módulos de `pcobra.cobra.hub` y falla si se detectan imports hacia `pcobra.cobra.cli` o `pcobra.gui`, además de verificar que `PackageRepository`, `HttpCobraHubRepository` y `DownloadedPackage` sigan exportados.
- Preserva la compatibilidad pública requerida y evita tocar Lexer/Parser.

### Testing
- Ejecuté `python -m pytest -q tests/unit/test_hub_import_boundaries.py tests/unit/test_cli_cobrahub.py -k 'not publicar_paquete_preserva_manifiesto_enriquecido' tests/unit/test_cobrahub_cache.py` y la ejecución final produjo `47 passed, 1 deselected, 1 warning`.
- Durante la validación inicial se observaron 2 fallos: uno por el método de lectura de código del test (arreglado) y otro preexistente en `test_publicar_paquete_preserva_manifiesto_enriquecido` debido a la validación normativa de dependencias (`^1.0.0` rechazado por requerir versiones SemVer exactas); ese comportamiento no se modificó en este cambio.
- Ejecuté comprobaciones adicionales: `python -m compileall -q ...` (compilación silenciosa del código modificado) y `ruff check` en los ficheros afectados, y `git diff --check`; todas las comprobaciones estáticas/reportes pasaron sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59eae259488327af67d1809489e7ac)