### PR TITLE
feat(hub): separar contratos PackageIndex/ArtifactProvider y mover proveedor HTTP canónico

### DIFF
--- a/src/pcobra/cobra/hub/__init__.py
+++ b/src/pcobra/cobra/hub/__init__.py
@@ -15,13 +15,17 @@ from pcobra.cobra.hub.models import (
     LockedDependency,
 )
 from pcobra.cobra.hub.repository import (
+    ArtifactProvider,
     DownloadedPackage,
     HttpCobraHubRepository,
+    PackageIndex,
     PackageRepository,
 )
+from pcobra.cobra.hub.providers import GitHubReleaseProvider, PyPIProvider
 from pcobra.cobra.hub.transport import CobraHubTransport, HttpSession
 
 __all__ = [
+    "ArtifactProvider",
     "CobraHubError",
     "CobraHubResolution",
     "DeclaredDependency",
@@ -29,12 +33,15 @@ __all__ = [
     "LockedDependency",
     "CobraHubTransport",
     "DownloadedPackage",
+    "GitHubReleaseProvider",
     "HttpCobraHubRepository",
     "HttpSession",
     "PackageCompatibilityError",
     "PackageIntegrityError",
     "PackageNotFoundError",
     "PackageProviderError",
+    "PackageIndex",
     "PackageRepository",
+    "PyPIProvider",
     "PackageResolutionError",
 ]

--- a/src/pcobra/cobra/hub/providers/__init__.py
+++ b/src/pcobra/cobra/hub/providers/__init__.py
@@ -1,0 +1,7 @@
+"""Proveedores de índices y artefactos para paquetes Cobra."""
+
+from pcobra.cobra.hub.providers.github import GitHubReleaseProvider
+from pcobra.cobra.hub.providers.http import HttpCobraHubRepository
+from pcobra.cobra.hub.providers.pypi import PyPIProvider
+
+__all__ = ["GitHubReleaseProvider", "HttpCobraHubRepository", "PyPIProvider"]

--- a/src/pcobra/cobra/hub/providers/_experimental.py
+++ b/src/pcobra/cobra/hub/providers/_experimental.py
@@ -1,0 +1,48 @@
+"""Base segura para proveedores cuyo soporte todavía es experimental."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, NoReturn
+
+from pcobra.cobra.hub.errors import PackageProviderError
+from pcobra.cobra.hub.repository import DownloadedPackage
+from pcobra.cobra.packaging import PackageSearchResult
+
+
+class UnsupportedExperimentalProvider:
+    """Rechaza de forma controlada toda operación aún no implementada."""
+
+    provider_name = "experimental"
+
+    def _unsupported(self, operation: str) -> NoReturn:
+        raise PackageProviderError(
+            f"{self.provider_name}: la operación {operation!r} aún no está soportada"
+        )
+
+    def search(self, query: str) -> list[PackageSearchResult]:
+        self._unsupported("search")
+
+    def list_versions(self, name: str) -> list[str]:
+        self._unsupported("list_versions")
+
+    def get_metadata(self, name: str, version: str | None = None) -> dict[str, Any]:
+        self._unsupported("get_metadata")
+
+    def acquire(self, name: str, version: str | None = None) -> DownloadedPackage:
+        self._unsupported("acquire")
+
+    def verify(self, artifact: DownloadedPackage) -> bool:
+        self._unsupported("verify")
+
+    # Superficie legacy disponible para composición sin ejecutar herramientas externas.
+    def publish(
+        self, package_path: str | Path, metadata: dict[str, Any], checksum: str
+    ) -> bool:
+        self._unsupported("publish")
+
+    def download(self, name: str, version: str | None = None) -> DownloadedPackage:
+        self._unsupported("download")
+
+    def read_metadata(self, package_path: str | Path) -> dict[str, Any]:
+        self._unsupported("read_metadata")

--- a/src/pcobra/cobra/hub/providers/github.py
+++ b/src/pcobra/cobra/hub/providers/github.py
@@ -1,0 +1,12 @@
+"""Proveedor experimental para artefactos de GitHub Releases."""
+
+from pcobra.cobra.hub.providers._experimental import UnsupportedExperimentalProvider
+
+
+class GitHubReleaseProvider(UnsupportedExperimentalProvider):
+    """Reserva GitHub Releases sin descargar ni publicar artefactos todavía."""
+
+    provider_name = "GitHub Releases"
+
+
+__all__ = ["GitHubReleaseProvider"]

--- a/src/pcobra/cobra/hub/providers/http.py
+++ b/src/pcobra/cobra/hub/providers/http.py
@@ -1,0 +1,261 @@
+"""Proveedor HTTP canónico para CobraHub."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import urllib.parse
+from pathlib import Path
+from typing import Any
+
+from pcobra.cobra.hub.errors import (
+    CobraHubError,
+    PackageCompatibilityError,
+    PackageIntegrityError,
+    PackageNotFoundError,
+    PackageProviderError,
+    PackageResolutionError,
+)
+from pcobra.cobra.hub.repository import (
+    DownloadedPackage,
+    _cache_filename,
+    _normalizar_metadatos_paquete,
+    _normalizar_resultado_paquete,
+    _version_from_response,
+    json_dumps,
+    package_cache_dir,
+)
+from pcobra.cobra.hub.transport import CobraHubTransport
+from pcobra.cobra.packaging import (
+    PackageSearchResult,
+    normalizar_nombre_paquete,
+    validar_version_paquete,
+)
+
+
+class HttpCobraHubRepository:
+    """Repositorio CobraHub respaldado por HTTP usando un ``CobraHubClient``."""
+
+    def __init__(self, client: CobraHubTransport) -> None:
+        self.client = client
+
+    def publish(
+        self, package_path: str | Path, metadata: dict[str, Any], checksum: str
+    ) -> bool:
+        """Publica un paquete .co mediante la API HTTP de CobraHub."""
+        ruta = Path(package_path)
+        try:
+            metadata = _normalizar_metadatos_paquete(metadata)
+        except (TypeError, ValueError, KeyError) as exc:
+            raise PackageResolutionError(str(exc)) from exc
+        try:
+            with (
+                ruta.open("rb") as f,
+                self.client.session.post(
+                    f"{self.client.base_url}/paquetes",
+                    files={"file": f},
+                    data={"metadata": json_dumps(metadata)},
+                    headers={
+                        "X-Content-Checksum": checksum,
+                        "Idempotency-Key": checksum,
+                    },
+                    timeout=(
+                        self.client.CONNECT_TIMEOUT,
+                        self.client.READ_TIMEOUT,
+                    ),
+                ) as response,
+            ):
+                response.raise_for_status()
+            cache_path = package_cache_dir() / ruta.name
+            if ruta.resolve() != cache_path.resolve():
+                shutil.copy2(ruta, cache_path)
+        except CobraHubError:
+            raise
+        except Exception as exc:
+            raise PackageProviderError(str(exc)) from exc
+        return True
+
+    def search(self, query: str) -> list[PackageSearchResult]:
+        """Busca paquetes mediante la API HTTP de CobraHub."""
+        try:
+            with self.client.session.get(
+                f"{self.client.base_url}/paquetes",
+                params={"q": query},
+                timeout=(self.client.CONNECT_TIMEOUT, self.client.READ_TIMEOUT),
+            ) as response:
+                response.raise_for_status()
+                data = response.json() if hasattr(response, "json") else []
+            items = data.get("results", []) if isinstance(data, dict) else data
+            return [_normalizar_resultado_paquete(item) for item in list(items)]
+        except CobraHubError:
+            raise
+        except (TypeError, ValueError, KeyError) as exc:
+            raise PackageResolutionError(str(exc)) from exc
+        except Exception as exc:
+            raise PackageProviderError(str(exc)) from exc
+
+    def download(self, name: str, version: str | None = None) -> DownloadedPackage:
+        """Descarga un paquete por nombre y versión opcional en la caché local."""
+        try:
+            normalized_name = normalizar_nombre_paquete(name)
+            normalized_version = (
+                validar_version_paquete(version) if version is not None else None
+            )
+        except (TypeError, ValueError) as exc:
+            raise PackageResolutionError(str(exc)) from exc
+        cache_path = package_cache_dir() / _cache_filename(
+            normalized_name, normalized_version
+        )
+        try:
+            with self.client.session.get(
+                f"{self.client.base_url}/paquetes/{urllib.parse.quote(normalized_name)}",
+                **(
+                    {"params": {"version": normalized_version}}
+                    if normalized_version
+                    else {}
+                ),
+                timeout=(self.client.CONNECT_TIMEOUT, self.client.READ_TIMEOUT),
+                stream=True,
+            ) as response:
+                try:
+                    response.raise_for_status()
+                except Exception as exc:
+                    status = getattr(
+                        getattr(exc, "response", None), "status_code", None
+                    )
+                    status = status or getattr(response, "status_code", None)
+                    if status == 404:
+                        raise PackageNotFoundError(str(exc)) from exc
+                    raise PackageProviderError(str(exc)) from exc
+                checksum_servidor = response.headers.get("X-Content-Checksum")
+                version_servidor = _version_from_response(response)
+                if version_servidor:
+                    try:
+                        version_servidor = validar_version_paquete(version_servidor)
+                    except (TypeError, ValueError) as exc:
+                        raise PackageCompatibilityError(str(exc)) from exc
+                if version_servidor and version_servidor != normalized_version:
+                    cache_path = package_cache_dir() / _cache_filename(
+                        normalized_name, version_servidor
+                    )
+                sha256 = hashlib.sha256()
+                tamaño_total = 0
+
+                with open(cache_path, "wb") as out:
+                    for chunk in response.iter_content(
+                        chunk_size=self.client.CHUNK_SIZE
+                    ):
+                        if not chunk:
+                            continue
+                        tamaño_total += len(chunk)
+                        if tamaño_total > self.client.MAX_FILE_SIZE:
+                            out.close()
+                            os.unlink(cache_path)
+                            raise PackageIntegrityError(
+                                "Archivo descargado demasiado grande"
+                            )
+                        sha256.update(chunk)
+                        out.write(chunk)
+
+            digest = sha256.hexdigest()
+            if checksum_servidor and digest != checksum_servidor:
+                os.unlink(cache_path)
+                raise PackageIntegrityError("Verificación de integridad fallida")
+
+            return DownloadedPackage(
+                path=cache_path,
+                name=normalized_name,
+                version=version_servidor or normalized_version,
+                checksum=checksum_servidor or digest,
+            )
+        except CobraHubError:
+            if cache_path.exists():
+                os.unlink(cache_path)
+            raise
+        except Exception as exc:
+            if cache_path.exists():
+                os.unlink(cache_path)
+            raise PackageProviderError(str(exc)) from exc
+
+    def list_versions(self, name: str) -> list[str]:
+        """Lista las versiones publicadas de un paquete."""
+        metadata = self._get_package_resource(name, "versions")
+        values = (
+            metadata.get("versions", []) if isinstance(metadata, dict) else metadata
+        )
+        try:
+            return [validar_version_paquete(str(value)) for value in values]
+        except (TypeError, ValueError) as exc:
+            raise PackageResolutionError(str(exc)) from exc
+
+    def get_metadata(self, name: str, version: str | None = None) -> dict[str, Any]:
+        """Obtiene metadatos remotos para un paquete y versión opcional."""
+        metadata = self._get_package_resource(name, "metadata", version)
+        if not isinstance(metadata, dict):
+            raise PackageResolutionError("Los metadatos remotos no son un objeto")
+        return metadata
+
+    def acquire(self, name: str, version: str | None = None) -> DownloadedPackage:
+        """Adquiere un artefacto conservando ``download`` como alias histórico."""
+        return self.download(name, version)
+
+    def verify(self, artifact: DownloadedPackage) -> bool:
+        """Verifica que el artefacto exista y coincida con su checksum SHA-256."""
+        if not artifact.path.is_file():
+            raise PackageIntegrityError(f"No existe el artefacto: {artifact.path}")
+        if artifact.checksum is None:
+            raise PackageIntegrityError("El artefacto no incluye checksum")
+        digest = hashlib.sha256(artifact.path.read_bytes()).hexdigest()
+        if digest != artifact.checksum:
+            raise PackageIntegrityError("Verificación de integridad fallida")
+        return True
+
+    def _get_package_resource(
+        self, name: str, resource: str, version: str | None = None
+    ) -> Any:
+        try:
+            normalized_name = normalizar_nombre_paquete(name)
+            normalized_version = (
+                validar_version_paquete(version) if version is not None else None
+            )
+            with self.client.session.get(
+                f"{self.client.base_url}/paquetes/"
+                f"{urllib.parse.quote(normalized_name)}/{resource}",
+                **(
+                    {"params": {"version": normalized_version}}
+                    if normalized_version
+                    else {}
+                ),
+                timeout=(self.client.CONNECT_TIMEOUT, self.client.READ_TIMEOUT),
+            ) as response:
+                response.raise_for_status()
+                data = response.json()
+            if not isinstance(data, (dict, list)):
+                raise PackageResolutionError("Respuesta de índice no válida")
+            return data
+        except CobraHubError:
+            raise
+        except (TypeError, ValueError, KeyError) as exc:
+            raise PackageResolutionError(str(exc)) from exc
+        except Exception as exc:
+            raise PackageProviderError(str(exc)) from exc
+
+    def read_metadata(self, package_path: str | Path) -> dict[str, Any]:
+        """Lee metadatos de un paquete local usando el validador de paquetes Cobra."""
+        from pcobra.cobra.packaging import es_paquete_cobra, validar_paquete
+
+        if not es_paquete_cobra(package_path):
+            raise PackageIntegrityError(
+                "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
+            )
+        try:
+            info = validar_paquete(package_path)
+            return _normalizar_metadatos_paquete(info.manifest)
+        except CobraHubError:
+            raise
+        except Exception as exc:
+            raise PackageIntegrityError(str(exc)) from exc
+
+
+__all__ = ["HttpCobraHubRepository"]

--- a/src/pcobra/cobra/hub/providers/pypi.py
+++ b/src/pcobra/cobra/hub/providers/pypi.py
@@ -1,0 +1,12 @@
+"""Proveedor experimental para índices compatibles con PyPI."""
+
+from pcobra.cobra.hub.providers._experimental import UnsupportedExperimentalProvider
+
+
+class PyPIProvider(UnsupportedExperimentalProvider):
+    """Reserva la integración con PyPI sin instalar ni publicar paquetes."""
+
+    provider_name = "PyPI"
+
+
+__all__ = ["PyPIProvider"]

--- a/src/pcobra/cobra/hub/repository.py
+++ b/src/pcobra/cobra/hub/repository.py
@@ -8,35 +8,18 @@ versiones sin tocar las fases de análisis del lenguaje.
 
 from __future__ import annotations
 
-import hashlib
 import json
-import logging
 import os
-import shutil
-import urllib.parse
 from dataclasses import dataclass
 from email.message import Message
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
-from pcobra.cobra.hub.errors import (
-    CobraHubError,
-    PackageCompatibilityError,
-    PackageIntegrityError,
-    PackageNotFoundError,
-    PackageProviderError,
-    PackageResolutionError,
-)
-from pcobra.cobra.hub.transport import CobraHubTransport
 from pcobra.cobra.packaging import (
     PackageSearchResult,
     manifest_from_dict,
     manifest_to_dict,
-    normalizar_nombre_paquete,
-    validar_version_paquete,
 )
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -71,165 +54,27 @@ class PackageRepository(Protocol):
         ...
 
 
-class HttpCobraHubRepository:
-    """Repositorio CobraHub respaldado por HTTP usando un ``CobraHubClient``."""
+class PackageIndex(Protocol):
+    """Contrato de consulta de un índice de paquetes, sin adquirir artefactos."""
 
-    def __init__(self, client: CobraHubTransport) -> None:
-        self.client = client
+    def search(self, query: str) -> list[PackageSearchResult]: ...
 
-    def publish(
-        self, package_path: str | Path, metadata: dict[str, Any], checksum: str
-    ) -> bool:
-        """Publica un paquete .co mediante la API HTTP de CobraHub."""
-        ruta = Path(package_path)
-        try:
-            metadata = _normalizar_metadatos_paquete(metadata)
-        except (TypeError, ValueError, KeyError) as exc:
-            raise PackageResolutionError(str(exc)) from exc
-        try:
-            with ruta.open("rb") as f, self.client.session.post(
-                f"{self.client.base_url}/paquetes",
-                files={"file": f},
-                data={"metadata": json_dumps(metadata)},
-                headers={
-                    "X-Content-Checksum": checksum,
-                    "Idempotency-Key": checksum,
-                },
-                timeout=(
-                    self.client.CONNECT_TIMEOUT,
-                    self.client.READ_TIMEOUT,
-                ),
-            ) as response:
-                response.raise_for_status()
-            cache_path = package_cache_dir() / ruta.name
-            if ruta.resolve() != cache_path.resolve():
-                shutil.copy2(ruta, cache_path)
-        except CobraHubError:
-            raise
-        except Exception as exc:
-            raise PackageProviderError(str(exc)) from exc
-        return True
+    def list_versions(self, name: str) -> list[str]: ...
 
-    def search(self, query: str) -> list[PackageSearchResult]:
-        """Busca paquetes mediante la API HTTP de CobraHub."""
-        try:
-            with self.client.session.get(
-                f"{self.client.base_url}/paquetes",
-                params={"q": query},
-                timeout=(self.client.CONNECT_TIMEOUT, self.client.READ_TIMEOUT),
-            ) as response:
-                response.raise_for_status()
-                data = response.json() if hasattr(response, "json") else []
-            items = data.get("results", []) if isinstance(data, dict) else data
-            return [_normalizar_resultado_paquete(item) for item in list(items)]
-        except CobraHubError:
-            raise
-        except (TypeError, ValueError, KeyError) as exc:
-            raise PackageResolutionError(str(exc)) from exc
-        except Exception as exc:
-            raise PackageProviderError(str(exc)) from exc
+    def get_metadata(self, name: str, version: str | None = None) -> dict[str, Any]: ...
 
-    def download(self, name: str, version: str | None = None) -> DownloadedPackage:
-        """Descarga un paquete por nombre y versión opcional en la caché local."""
-        try:
-            normalized_name = normalizar_nombre_paquete(name)
-            normalized_version = (
-                validar_version_paquete(version) if version is not None else None
-            )
-        except (TypeError, ValueError) as exc:
-            raise PackageResolutionError(str(exc)) from exc
-        cache_path = package_cache_dir() / _cache_filename(
-            normalized_name, normalized_version
-        )
-        try:
-            with self.client.session.get(
-                f"{self.client.base_url}/paquetes/{urllib.parse.quote(normalized_name)}",
-                **(
-                    {"params": {"version": normalized_version}}
-                    if normalized_version
-                    else {}
-                ),
-                timeout=(self.client.CONNECT_TIMEOUT, self.client.READ_TIMEOUT),
-                stream=True,
-            ) as response:
-                try:
-                    response.raise_for_status()
-                except Exception as exc:
-                    status = getattr(getattr(exc, "response", None), "status_code", None)
-                    status = status or getattr(response, "status_code", None)
-                    if status == 404:
-                        raise PackageNotFoundError(str(exc)) from exc
-                    raise PackageProviderError(str(exc)) from exc
-                checksum_servidor = response.headers.get("X-Content-Checksum")
-                version_servidor = _version_from_response(response)
-                if version_servidor:
-                    try:
-                        version_servidor = validar_version_paquete(version_servidor)
-                    except (TypeError, ValueError) as exc:
-                        raise PackageCompatibilityError(str(exc)) from exc
-                if version_servidor and version_servidor != normalized_version:
-                    cache_path = package_cache_dir() / _cache_filename(
-                        normalized_name, version_servidor
-                    )
-                sha256 = hashlib.sha256()
-                tamaño_total = 0
 
-                with open(cache_path, "wb") as out:
-                    for chunk in response.iter_content(
-                        chunk_size=self.client.CHUNK_SIZE
-                    ):
-                        if not chunk:
-                            continue
-                        tamaño_total += len(chunk)
-                        if tamaño_total > self.client.MAX_FILE_SIZE:
-                            out.close()
-                            os.unlink(cache_path)
-                            raise PackageIntegrityError(
-                                "Archivo descargado demasiado grande"
-                            )
-                        sha256.update(chunk)
-                        out.write(chunk)
+class ArtifactProvider(Protocol):
+    """Contrato para adquirir y verificar artefactos de paquetes."""
 
-            digest = sha256.hexdigest()
-            if checksum_servidor and digest != checksum_servidor:
-                os.unlink(cache_path)
-                raise PackageIntegrityError("Verificación de integridad fallida")
+    def acquire(self, name: str, version: str | None = None) -> DownloadedPackage: ...
 
-            return DownloadedPackage(
-                path=cache_path,
-                name=normalized_name,
-                version=version_servidor or normalized_version,
-                checksum=checksum_servidor or digest,
-            )
-        except CobraHubError:
-            if cache_path.exists():
-                os.unlink(cache_path)
-            raise
-        except Exception as exc:
-            if cache_path.exists():
-                os.unlink(cache_path)
-            raise PackageProviderError(str(exc)) from exc
-
-    def read_metadata(self, package_path: str | Path) -> dict[str, Any]:
-        """Lee metadatos de un paquete local usando el validador de paquetes Cobra."""
-        from pcobra.cobra.packaging import es_paquete_cobra, validar_paquete
-
-        if not es_paquete_cobra(package_path):
-            raise PackageIntegrityError(
-                "No es un paquete Cobra: debe ser ZIP y contener cobra.pkg.json"
-            )
-        try:
-            info = validar_paquete(package_path)
-            return _normalizar_metadatos_paquete(info.manifest)
-        except CobraHubError:
-            raise
-        except Exception as exc:
-            raise PackageIntegrityError(str(exc)) from exc
+    def verify(self, artifact: DownloadedPackage) -> bool: ...
 
 
 def _normalizar_metadatos_paquete(metadata: dict[str, Any]) -> dict[str, Any]:
     """Devuelve metadatos canónicos preservando campos opcionales soportados."""
-    return manifest_to_dict(manifest_from_dict(dict(metadata)))
+    return cast(dict[str, Any], manifest_to_dict(manifest_from_dict(dict(metadata))))
 
 
 def _normalizar_lista_str(value: Any) -> list[str] | None:
@@ -342,9 +187,13 @@ def json_dumps(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True)
 
 
+from pcobra.cobra.hub.providers.http import HttpCobraHubRepository
+
 __all__ = [
+    "ArtifactProvider",
     "DownloadedPackage",
     "HttpCobraHubRepository",
+    "PackageIndex",
     "PackageRepository",
     "install_dir",
     "json_dumps",

--- a/tests/unit/test_hub_provider_contracts.py
+++ b/tests/unit/test_hub_provider_contracts.py
@@ -1,0 +1,99 @@
+"""Compatibilidad de los contratos de proveedores de CobraHub."""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from pcobra.cobra.cli.cobrahub_client import CobraHubClient
+from pcobra.cobra.cli.cobrahub_packages import CobraHubPackages
+from pcobra.cobra.hub import (
+    ArtifactProvider,
+    GitHubReleaseProvider,
+    PackageIndex,
+    PackageProviderError,
+    PackageRepository,
+    PyPIProvider,
+)
+from pcobra.cobra.hub.providers.http import HttpCobraHubRepository
+from pcobra.cobra.hub.repository import DownloadedPackage
+
+
+def test_package_repository_conserva_superficie_legacy() -> None:
+    assert {
+        "publish",
+        "search",
+        "download",
+        "read_metadata",
+    } <= PackageRepository.__dict__.keys()
+    assert list(inspect.signature(PackageRepository.download).parameters) == [
+        "self",
+        "name",
+        "version",
+    ]
+
+
+def test_nuevos_protocolos_separan_indice_y_artefactos() -> None:
+    assert {"search", "list_versions", "get_metadata"} <= PackageIndex.__dict__.keys()
+    assert {"acquire", "verify"} <= ArtifactProvider.__dict__.keys()
+
+
+def test_http_es_implementacion_canonica_y_reexport_compatible() -> None:
+    from pcobra.cobra.hub.repository import HttpCobraHubRepository as LegacyImport
+
+    assert LegacyImport is HttpCobraHubRepository
+    for method in (
+        "publish",
+        "search",
+        "download",
+        "read_metadata",
+        "list_versions",
+        "get_metadata",
+        "acquire",
+        "verify",
+    ):
+        assert callable(getattr(HttpCobraHubRepository, method))
+
+
+def test_http_acquire_delega_en_download_sin_cambiar_firma() -> None:
+    repository = HttpCobraHubRepository(MagicMock())
+    downloaded = DownloadedPackage(Path("demo.co"), "demo", "1.0.0", "abc")
+    repository.download = MagicMock(return_value=downloaded)  # type: ignore[method-assign]
+
+    assert repository.acquire("demo", "1.0.0") is downloaded
+    repository.download.assert_called_once_with("demo", "1.0.0")
+
+
+@pytest.mark.parametrize("provider_type", [PyPIProvider, GitHubReleaseProvider])
+@pytest.mark.parametrize(
+    ("method", "args"),
+    [
+        ("search", ("demo",)),
+        ("list_versions", ("demo",)),
+        ("get_metadata", ("demo",)),
+        ("acquire", ("demo",)),
+        ("verify", (DownloadedPackage(Path("demo.co"), "demo"),)),
+        ("publish", (Path("demo.co"), {}, "abc")),
+    ],
+)
+def test_proveedores_experimentales_fallan_de_forma_controlada(
+    provider_type: type, method: str, args: tuple[object, ...]
+) -> None:
+    with pytest.raises(PackageProviderError, match="aún no está soportada"):
+        getattr(provider_type(), method)(*args)
+
+
+def test_cliente_y_fachada_conservan_metodos_y_repositorio_inyectable() -> None:
+    assert {"publicar_paquete", "buscar_paquetes", "instalar_paquete"} <= (
+        CobraHubClient.__dict__.keys()
+    )
+    client = MagicMock(spec=CobraHubClient)
+    repository = MagicMock(spec=PackageRepository)
+
+    packages = CobraHubPackages(client, repository)
+
+    assert packages.client is client
+    assert packages.repository is repository


### PR DESCRIPTION
### Motivation

- Separar las responsabilidades de índice (búsqueda/versión/metadatos) y artefactos (adquisición/verificación) para facilitar extensiones de repositorios y proveedores sin tocar Lexer/Parser ni la fachada histórica.
- Mantener compatibilidad con la API pública existente (`PackageRepository`, `HttpCobraHubRepository`, `CobraHubClient`, `CobraHubPackages`) para no romper consumidores actuales.
- Proveer puntos de extensión seguros para integraciones experimentales (PyPI, GitHub Releases) que fallen de forma controlada hasta estar implementadas.

### Description

- Añade los protocolos `PackageIndex` y `ArtifactProvider` en `src/pcobra/cobra/hub/repository.py` para separar operaciones de consulta (`search`, `list_versions`, `get_metadata`) de adquisición/verificación (`acquire`, `verify`).
- Extrae la implementación HTTP canónica a `src/pcobra/cobra/hub/providers/http.py` implementando las nuevas operaciones y preservando las firmas públicas históricas de `HttpCobraHubRepository` para compatibilidad por reexport desde `hub.repository`.
- Añade proveedores experimentales `PyPIProvider` y `GitHubReleaseProvider` en `src/pcobra/cobra/hub/providers/` que heredan de una base segura que lanza `PackageProviderError` para operaciones no soportadas, sin ejecutar `pip` ni publicar/descargar artefactos.
- Conserva la fachada legacy `PackageRepository` y adapta `CobraHubPackages` para aceptar repositorios inyectables sin cambiar su API pública.
- Añade pruebas de compatibilidad en `tests/unit/test_hub_provider_contracts.py` que verifican la superficie de `PackageRepository`, la reexportación/compatibilidad de `HttpCobraHubRepository`, el comportamiento de `CobraHubClient`/`CobraHubPackages` y el fallo controlado de proveedores experimentales.

### Testing

- `pytest tests/unit/test_hub_provider_contracts.py` — 17 passed.
- Ejecuté la suite relacionada (varios tests de hub/cli) excluyendo un caso histórico incompatible y obtuve `67 passed, 1 deselected` en esa ejecución parcial.
- Ejecuté la suite relacionada completa y detecté un único fallo histórico ajeno a este cambio: `test_publicar_paquete_preserva_manifiesto_enriquecido` falla porque la prueba usa la restricción `cobra-core: ^1.0.0` mientras que el validador actual exige versiones SemVer exactas; no se modificó la validación ni la prueba para ocultar el fallo.
- Revisión estática: `ruff` y `mypy` sobre los módulos nuevos/afectados pasaron sin errores relevantes y `git diff --check` no reportó problemas, y se verificó que no se modificaron archivos de Lexer o Parser.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59ee5b24a0832780f808752d609e59)