### PR TITLE
feat(hub): resolución segura de artefactos Cobra locales

### DIFF
--- a/src/pcobra/cobra/hub/__init__.py
+++ b/src/pcobra/cobra/hub/__init__.py
@@ -21,7 +21,11 @@ from pcobra.cobra.hub.repository import (
     PackageIndex,
     PackageRepository,
 )
-from pcobra.cobra.hub.providers import GitHubReleaseProvider, PyPIProvider
+from pcobra.cobra.hub.providers import (
+    GitHubReleaseProvider,
+    LocalArtifactProvider,
+    PyPIProvider,
+)
 from pcobra.cobra.hub.transport import CobraHubTransport, HttpSession
 
 __all__ = [
@@ -36,6 +40,7 @@ __all__ = [
     "GitHubReleaseProvider",
     "HttpCobraHubRepository",
     "HttpSession",
+    "LocalArtifactProvider",
     "PackageCompatibilityError",
     "PackageIntegrityError",
     "PackageNotFoundError",

--- a/src/pcobra/cobra/hub/installation.py
+++ b/src/pcobra/cobra/hub/installation.py
@@ -13,6 +13,7 @@ from pcobra.cobra.hub.repository import PackageRepository
 from pcobra.cobra.hub.cache import CobraInstallerCache
 from pcobra.cobra.hub.integrity import normalize_sha256, sha256_file
 from pcobra.cobra.hub.models import CobraHubResolution
+from pcobra.cobra.hub.providers.local import LocalArtifactProvider
 from pcobra.cobra_installer.project import CobraInstallerError
 from pcobra.cobra.packaging import (
     es_paquete_cobra,
@@ -23,7 +24,6 @@ from pcobra.cobra.packaging import (
 )
 
 __all__ = ["CobraInstallerError", "CobraHubResolution", "CobraHubResolver"]
-
 
 
 class CobraHubResolver:
@@ -53,6 +53,25 @@ class CobraHubResolver:
         normalized_version = self._version(version, normalized_name)
         if expected_sha256:
             expected_sha256 = normalize_sha256(expected_sha256)
+
+        if source and source not in {"installer-cache", "cobrahub", "cobrahub-cache"}:
+            try:
+                artifact = LocalArtifactProvider(
+                    source, cache_dir=self.cache_dir
+                ).acquire(
+                    normalized_name,
+                    normalized_version,
+                    expected_sha256=expected_sha256,
+                )
+            except Exception as exc:  # noqa: BLE001 - error de proveedor a CLI
+                raise CobraInstallerError(str(exc)) from exc
+            return self._inspect_candidate(
+                artifact.path,
+                normalized_name,
+                normalized_version,
+                expected_sha256=expected_sha256,
+                source=str(Path(source).expanduser().resolve()),
+            )
 
         candidates: list[Path] = []
         if source:

--- a/src/pcobra/cobra/hub/models.py
+++ b/src/pcobra/cobra/hub/models.py
@@ -26,6 +26,7 @@ class DeclaredDependency:
 
     name: str
     version: str
+    source: str | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
 

--- a/src/pcobra/cobra/hub/providers/__init__.py
+++ b/src/pcobra/cobra/hub/providers/__init__.py
@@ -3,5 +3,11 @@
 from pcobra.cobra.hub.providers.github import GitHubReleaseProvider
 from pcobra.cobra.hub.providers.http import HttpCobraHubRepository
 from pcobra.cobra.hub.providers.pypi import PyPIProvider
+from pcobra.cobra.hub.providers.local import LocalArtifactProvider
 
-__all__ = ["GitHubReleaseProvider", "HttpCobraHubRepository", "PyPIProvider"]
+__all__ = [
+    "GitHubReleaseProvider",
+    "HttpCobraHubRepository",
+    "LocalArtifactProvider",
+    "PyPIProvider",
+]

--- a/src/pcobra/cobra/hub/providers/local.py
+++ b/src/pcobra/cobra/hub/providers/local.py
@@ -1,0 +1,154 @@
+"""Proveedor offline de artefactos Cobra almacenados en el sistema local."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+from pcobra.cobra.hub.errors import (
+    PackageIntegrityError,
+    PackageNotFoundError,
+    PackageResolutionError,
+)
+from pcobra.cobra.hub.integrity import normalize_sha256, sha256_file
+from pcobra.cobra.hub.repository import DownloadedPackage, package_cache_dir
+from pcobra.cobra.packaging import (
+    inspeccionar_paquete,
+    normalizar_nombre_paquete,
+    validar_paquete,
+    validar_version_paquete,
+)
+
+
+class LocalArtifactProvider:
+    """Localiza, valida y cachea un ``.co`` desde un archivo o directorio."""
+
+    def __init__(
+        self, source: str | Path, *, cache_dir: str | Path | None = None
+    ) -> None:
+        self.source = Path(source).expanduser().resolve()
+        self.cache_dir = (
+            Path(cache_dir).expanduser() if cache_dir else package_cache_dir()
+        )
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def acquire(
+        self,
+        name: str,
+        version: str | None = None,
+        *,
+        expected_sha256: str | None = None,
+    ) -> DownloadedPackage:
+        normalized_name = normalizar_nombre_paquete(name)
+        normalized_version = validar_version_paquete(version or "")
+        expected = normalize_sha256(expected_sha256)
+        candidate = self._locate(normalized_name, normalized_version)
+        digest = sha256_file(candidate)
+        if expected and digest != expected:
+            raise PackageIntegrityError(
+                f"Hash inválido para {normalized_name}=={normalized_version}: "
+                f"se esperaba {expected}, se obtuvo {digest}."
+            )
+
+        target = self.cache_dir / f"{normalized_name}-{normalized_version}-{digest}.co"
+        if not target.is_file():
+            fd, partial_name = tempfile.mkstemp(
+                prefix=f".{target.name}.", suffix=".partial", dir=self.cache_dir
+            )
+            os.close(fd)
+            partial = Path(partial_name)
+            try:
+                shutil.copyfile(candidate, partial)
+                self._validate_identity(partial, normalized_name, normalized_version)
+                if sha256_file(partial) != digest:
+                    raise PackageIntegrityError(
+                        "El artefacto cambió mientras se copiaba."
+                    )
+                os.replace(partial, target)
+            finally:
+                partial.unlink(missing_ok=True)
+        else:
+            self._validate_identity(target, normalized_name, normalized_version)
+            if sha256_file(target) != digest:
+                raise PackageIntegrityError(
+                    "La entrada reutilizada de caché está corrupta."
+                )
+        return DownloadedPackage(
+            path=target,
+            name=normalized_name,
+            version=normalized_version,
+            checksum=digest,
+        )
+
+    def verify(self, artifact: DownloadedPackage) -> bool:
+        try:
+            self._validate_identity(
+                artifact.path,
+                normalizar_nombre_paquete(artifact.name),
+                validar_version_paquete(artifact.version or ""),
+            )
+            return not artifact.checksum or sha256_file(
+                artifact.path
+            ) == normalize_sha256(artifact.checksum)
+        except (OSError, ValueError, PackageResolutionError):
+            return False
+
+    def _locate(self, name: str, version: str) -> Path:
+        if not self.source.exists():
+            raise PackageNotFoundError(f"La ruta local no existe: {self.source}")
+        if self.source.is_file():
+            if self.source.suffix != ".co":
+                raise PackageResolutionError(
+                    f"La ruta local no es un artefacto .co: {self.source}"
+                )
+            self._validate_identity(self.source, name, version)
+            return self.source
+        if not self.source.is_dir():
+            raise PackageResolutionError(
+                f"La ruta local no es archivo ni directorio: {self.source}"
+            )
+
+        matches: list[Path] = []
+        invalid: list[str] = []
+        for path in sorted(self.source.glob("*.co"), key=lambda item: item.name):
+            try:
+                self._validate_identity(path, name, version)
+            except PackageResolutionError as exc:
+                invalid.append(str(exc))
+            else:
+                matches.append(path)
+        if len(matches) > 1:
+            raise PackageResolutionError(
+                f"Directorio local ambiguo para {name}=={version}: "
+                + ", ".join(path.name for path in matches)
+            )
+        if not matches:
+            detail = f" ({'; '.join(invalid)})" if invalid else ""
+            raise PackageNotFoundError(
+                f"No se encontró {name}=={version} en {self.source}{detail}"
+            )
+        return matches[0]
+
+    @staticmethod
+    def _validate_identity(path: Path, name: str, version: str) -> None:
+        try:
+            inspection = validar_paquete(path)
+            manifest = inspection.manifest
+            actual_name = normalizar_nombre_paquete(str(manifest.get("name", "")))
+            actual_version = validar_version_paquete(str(manifest.get("version", "")))
+            # Fuerza también la lectura estructural usada por el Hub.
+            inspeccionar_paquete(path)
+        except (OSError, ValueError) as exc:
+            raise PackageResolutionError(
+                f"Artefacto local inválido {path}: {exc}"
+            ) from exc
+        if actual_name != name or actual_version != version:
+            raise PackageResolutionError(
+                f"Artefacto discordante {path}: declara {actual_name}=={actual_version}; "
+                f"se esperaba {name}=={version}."
+            )
+
+
+__all__ = ["LocalArtifactProvider"]

--- a/src/pcobra/cobra/hub/resolver.py
+++ b/src/pcobra/cobra/hub/resolver.py
@@ -17,7 +17,10 @@ from pcobra.cobra.packaging import normalizar_nombre_paquete, validar_version_pa
 from pcobra.cobra.hub.installation import CobraHubResolver
 from pcobra.cobra.hub.integrity import normalize_sha256
 from pcobra.cobra.hub.models import (
-    CobraHubResolution, DeclaredDependency, DependencyResolutionResult, LockedDependency,
+    CobraHubResolution,
+    DeclaredDependency,
+    DependencyResolutionResult,
+    LockedDependency,
 )
 from pcobra.cobra_installer.project import CobraInstallerError
 
@@ -36,9 +39,6 @@ __all__ = [
 
 class CobraDependencyError(CobraInstallerError):
     """Error controlado de dependencias apto para CLI e IDLE."""
-
-
-
 
 
 _IMPORT_RE = re.compile(
@@ -96,9 +96,9 @@ def resolve_project_dependencies(
     resolved: dict[str, CobraHubResolution] = {}
     requested_versions = {name: dep.version for name, dep in declared.items()}
     dependency_chains = {
-        name: f"proyecto -> {name}=={dep.version}"
-        for name, dep in declared.items()
+        name: f"proyecto -> {name}=={dep.version}" for name, dep in declared.items()
     }
+    requested_sources = {name: dep.source for name, dep in declared.items()}
     pending = sorted(requested_versions.items())
 
     while pending:
@@ -110,7 +110,7 @@ def resolve_project_dependencies(
             name,
             version,
             expected_sha256=lock_entry.sha256 if lock_entry else None,
-            source=lock_entry.source if lock_entry else None,
+            source=(lock_entry.source if lock_entry else requested_sources.get(name)),
         )
         if resolution.version != version:
             raise CobraDependencyError(
@@ -124,8 +124,7 @@ def resolve_project_dependencies(
             resolution.dependencies.items()
         ):
             chain = (
-                f"{dependency_chains[name]} -> "
-                f"{transitive_name}=={transitive_version}"
+                f"{dependency_chains[name]} -> {transitive_name}=={transitive_version}"
             )
             requested = requested_versions.get(transitive_name)
             if requested is not None and requested != transitive_version:
@@ -138,6 +137,12 @@ def resolve_project_dependencies(
                 )
             if requested is None:
                 requested_versions[transitive_name] = transitive_version
+                parent_source = requested_sources.get(name)
+                if parent_source:
+                    parent_path = Path(parent_source)
+                    requested_sources[transitive_name] = str(
+                        parent_path if parent_path.is_dir() else parent_path.parent
+                    )
                 dependency_chains[transitive_name] = chain
                 pending.append((transitive_name, transitive_version))
 
@@ -188,11 +193,12 @@ def read_declared_dependencies(path: str | Path) -> dict[str, DeclaredDependency
     for raw_name, raw_version in raw.items():
         name = _normalize_dependency_name(str(raw_name))
         version = _normalize_version_spec(raw_version, name)
+        source = _dependency_source(raw_version, name, toml_path.parent)
         if name in declared and declared[name].version != version:
             raise CobraDependencyError(
                 f"Conflicto de versiones declaradas para {name}: {declared[name].version} y {version}."
             )
-        declared[name] = DeclaredDependency(name=name, version=version)
+        declared[name] = DeclaredDependency(name=name, version=version, source=source)
     return declared
 
 
@@ -253,12 +259,12 @@ def read_lockfile(path: str | Path) -> dict[str, LockedDependency]:
                 )
         else:
             sha256 = None
-        source = entry.get("source")
+        source = _resolve_local_source(entry.get("source"), lock_path.parent)
         locked[name] = LockedDependency(
             name=name,
             version=version,
             sha256=sha256,
-            source=str(source) if source else None,
+            source=source,
         )
     return locked
 
@@ -349,6 +355,26 @@ def _normalize_version_spec(value: Any, name: str) -> str:
         raise CobraDependencyError(
             f"Versión inválida para {name}: use SemVer exacto MAJOR.MINOR.PATCH."
         ) from exc
+
+
+def _dependency_source(value: Any, name: str, base_dir: Path) -> str | None:
+    if not isinstance(value, Mapping) or value.get("source") is None:
+        return None
+    source = value["source"]
+    if not isinstance(source, str) or not source.strip():
+        raise CobraDependencyError(f"Ruta source inválida para {name}.")
+    return str((base_dir / Path(source).expanduser()).resolve())
+
+
+def _resolve_local_source(value: Any, base_dir: Path) -> str | None:
+    if not value:
+        return None
+    source = str(value)
+    path = Path(source).expanduser()
+    # Los identificadores históricos de proveedor no son rutas locales.
+    if source in {"installer-cache", "cobrahub", "cobrahub-cache"}:
+        return source
+    return str((path if path.is_absolute() else base_dir / path).resolve())
 
 
 def _parse_dependency_list(values: Sequence[Any]) -> dict[str, str]:

--- a/tests/unit/test_hub_local_provider.py
+++ b/tests/unit/test_hub_local_provider.py
@@ -1,0 +1,142 @@
+import json
+import shutil
+
+import pytest
+
+from pcobra.cobra.hub.errors import PackageIntegrityError, PackageResolutionError
+from pcobra.cobra.hub.providers.local import LocalArtifactProvider
+from pcobra.cobra_installer.dependency_resolver import (
+    read_declared_dependencies,
+    read_lockfile,
+    resolve_project_dependencies,
+)
+from pcobra.cobra.packaging import construir_paquete
+
+
+def _package(root, name="dep", version="1.2.3", dependencies=None):
+    project = root / f"src-{name}-{version}"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "main.cobra").write_text("var x = 1\n", encoding="utf-8")
+    manifest = {
+        "format": "cobra-package-v1",
+        "name": name,
+        "version": version,
+        "files": [],
+        "checksums": {},
+    }
+    if dependencies is not None:
+        manifest["dependencies"] = dependencies
+    (project / "cobra.pkg.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return construir_paquete(project, root / f"{name}-{version}.co")
+
+
+def test_proveedor_local_admite_ruta_directa_y_reutiliza_cache(tmp_path):
+    package = _package(tmp_path)
+    provider = LocalArtifactProvider(package, cache_dir=tmp_path / "cache")
+
+    first = provider.acquire("dep", "1.2.3")
+    first_mtime = first.path.stat().st_mtime_ns
+    second = provider.acquire("dep", "1.2.3")
+
+    assert first.path == second.path
+    assert first.path.name == f"dep-1.2.3-{first.checksum}.co"
+    assert second.path.stat().st_mtime_ns == first_mtime
+    assert not list((tmp_path / "cache").glob("*.partial"))
+
+
+def test_proveedor_local_busca_directorio_y_rechaza_ambiguedad(tmp_path):
+    package = _package(tmp_path)
+    provider = LocalArtifactProvider(tmp_path, cache_dir=tmp_path / "cache")
+    assert provider.acquire("dep", "1.2.3").name == "dep"
+
+    shutil.copy2(package, tmp_path / "copia.co")
+    with pytest.raises(PackageResolutionError, match="ambiguo"):
+        provider.acquire("dep", "1.2.3")
+
+
+def test_proveedor_local_rechaza_hash_e_identidad_discordante(tmp_path):
+    package = _package(tmp_path, name="otro", version="2.0.0")
+    provider = LocalArtifactProvider(package, cache_dir=tmp_path / "cache")
+
+    with pytest.raises(PackageResolutionError, match="discordante"):
+        provider.acquire("dep", "1.2.3")
+    with pytest.raises(PackageIntegrityError, match="Hash inválido"):
+        provider.acquire("otro", "2.0.0", expected_sha256="0" * 64)
+
+
+def test_toml_y_lock_resuelven_sources_relativos_a_su_archivo(tmp_path):
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "cobra.toml").write_text(
+        '[dependencies]\ndep = { version = "1.2.3", source = "../artifacts" }\n',
+        encoding="utf-8",
+    )
+    (project / "cobra.lock").write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "packages": {"dep": {"version": "1.2.3", "source": "../artifacts"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert read_declared_dependencies(project / "cobra.toml")["dep"].source == str(
+        artifacts
+    )
+    assert read_lockfile(project / "cobra.lock")["dep"].source == str(artifacts)
+
+
+def test_resolucion_offline_local_incluye_dependencia_transitiva(tmp_path):
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    _package(artifacts, name="child", version="2.0.0")
+    _package(artifacts, name="dep", version="1.2.3", dependencies={"child": "2.0.0"})
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "cobra.toml").write_text(
+        '[dependencies]\ndep = { version = "1.2.3", source = "../artifacts" }\n',
+        encoding="utf-8",
+    )
+    (project / "main.cobra").write_text("usar dep.modulo\n", encoding="utf-8")
+
+    result = resolve_project_dependencies(project)
+
+    assert set(result.resolved) == {"child", "dep"}
+    assert all(item.path.is_file() for item in result.resolved.values())
+
+
+def test_lock_v1_local_relativo_se_usa_offline(tmp_path):
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    package = _package(artifacts)
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "cobra.toml").write_text(
+        '[dependencies]\ndep = "1.2.3"\n', encoding="utf-8"
+    )
+    (project / "main.cobra").write_text("usar dep.modulo\n", encoding="utf-8")
+    from pcobra.cobra.hub.integrity import sha256_file
+
+    (project / "cobra.lock").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "packages": [
+                    {
+                        "name": "dep",
+                        "version": "1.2.3",
+                        "sha256": sha256_file(package),
+                        "source": "../artifacts",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert resolve_project_dependencies(project).resolved["dep"].source == str(
+        artifacts
+    )


### PR DESCRIPTION
### Motivation

- Permitir resolución offline determinista de artefactos `.co` referenciados desde `cobra.toml` o `cobra.lock` sin tocar Lexer/Parser ni la semántica de imports.

### Description

- Añade `LocalArtifactProvider` en `src/pcobra/cobra/hub/providers/local.py` que localiza artefactos por ruta directa o buscando en un directorio, valida manifiesto, identidad, versión, dependencias y checksums, y copia a caché con clave determinista `nombre-versión-sha256` usando un archivo parcial y `os.replace` atómico.
- Amplía el modelo declarativo añadiendo el campo opcional `source` en `DeclaredDependency` (`src/pcobra/cobra/hub/models.py`) y actualiza la lectura de `cobra.toml` para aceptar entradas del tipo `{ version = "0.1.0", source = "../ruta" }` resolviendo rutas relativas respecto al directorio del `cobra.toml` (`src/pcobra/cobra/hub/resolver.py`).
- Normaliza y resuelve de forma equivalente `source` locales en lockfiles v1/v2 y preserva identificadores históricos de proveedores remotos/caché; además propaga `source` local a dependencias transitivas cuando procede (`src/pcobra/cobra/hub/resolver.py`).
- Integra `LocalArtifactProvider` en `CobraHubResolver` para priorizar rutas locales suministradas y propagar el `source` efectivo (`src/pcobra/cobra/hub/installation.py`).
- Exporta el proveedor local desde el paquete de proveedores (`src/pcobra/cobra/hub/providers/__init__.py`) y no modifica Lexer ni Parser ni la detección semántica de imports.
- Añade tests offline completos en `tests/unit/test_hub_local_provider.py` que cubren ruta directa, directorio, ambigüedad, ruta TOML relativa, lockfile v1/v2, dependencia transitiva, hash incorrecto, identidad discordante y reutilización de caché.

### Testing

- Se ejecutó `python -m pytest -q tests/unit/test_hub_local_provider.py tests/unit/test_cobra_installer_dependency_resolver.py tests/unit/test_cobra_installer_hub_resolver.py tests/unit/test_hub_provider_contracts.py` y las pruebas relevantes pasaron (`38 passed` en la primera ejecución de conjunto específico). 
- Se ejecutó la suite ampliada `python -m pytest -q tests/unit/test_cobra_installer_*.py tests/unit/test_hub_*.py tests/unit/test_cobrahub_*.py` y todas las pruebas unitarias integradas pasaron (`118 passed, 1 warning`).
- Se verificó formato y lint con `ruff check` y `ruff format --check` sobre los archivos modificados y se aplicaron formateos, y se comprobó `git diff --check` y que no se modificaron `lexer` ni `parser` con `test -z "$(git diff --name-only | rg -i '(lexer|parser)' || true)"`.
- El cambio quedó comprometido en un único commit con mensaje `feat(hub): resolve local Cobra artifacts safely` y el árbol de trabajo quedó limpio tras el commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59f0dc40ec8327a59641c8e29351e7)