### PR TITLE
Añadir modelos validados de manifiesto CobraHub v2

### DIFF
--- a/src/pcobra/cobra/hub/__init__.py
+++ b/src/pcobra/cobra/hub/__init__.py
@@ -9,10 +9,19 @@ from pcobra.cobra.hub.errors import (
     PackageResolutionError,
 )
 from pcobra.cobra.hub.models import (
+    ARCHITECTURES,
+    DISTRIBUTION_TYPES,
+    PACKAGE_FORMATS,
+    PLATFORMS,
     CobraHubResolution,
     DeclaredDependency,
     DependencyResolutionResult,
     LockedDependency,
+    PackageDistribution,
+    PackageExtension,
+    PackageManifestV2,
+    manifest_v2_from_dict,
+    manifest_v2_to_dict,
 )
 from pcobra.cobra.hub.repository import (
     ArtifactProvider,
@@ -30,9 +39,11 @@ from pcobra.cobra.hub.transport import CobraHubTransport, HttpSession
 
 __all__ = [
     "ArtifactProvider",
+    "ARCHITECTURES",
     "CobraHubError",
     "CobraHubResolution",
     "DeclaredDependency",
+    "DISTRIBUTION_TYPES",
     "DependencyResolutionResult",
     "LockedDependency",
     "CobraHubTransport",
@@ -41,12 +52,19 @@ __all__ = [
     "HttpCobraHubRepository",
     "HttpSession",
     "LocalArtifactProvider",
+    "PACKAGE_FORMATS",
     "PackageCompatibilityError",
     "PackageIntegrityError",
     "PackageNotFoundError",
     "PackageProviderError",
     "PackageIndex",
+    "PackageDistribution",
+    "PackageExtension",
+    "PackageManifestV2",
     "PackageRepository",
     "PyPIProvider",
+    "PLATFORMS",
     "PackageResolutionError",
+    "manifest_v2_from_dict",
+    "manifest_v2_to_dict",
 ]

--- a/src/pcobra/cobra/hub/models.py
+++ b/src/pcobra/cobra/hub/models.py
@@ -4,7 +4,305 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+import re
 from typing import Any, Mapping
+
+
+PACKAGE_FORMAT_V2 = "cobra-package-v2"
+SUPPORTED_PACKAGE_FORMATS = frozenset({"cobra-package-v1", PACKAGE_FORMAT_V2})
+SUPPORTED_DISTRIBUTION_TYPES = frozenset(
+    {
+        "cobra-package",
+        "python-wheel",
+        "python-sdist",
+        "web-assets",
+        "javascript-package",
+        "rust-binary",
+        "wasm",
+        "native-binary",
+        "embedded",
+    }
+)
+SUPPORTED_PLATFORMS = frozenset(
+    {"any", "linux", "windows", "macos", "android", "ios", "freebsd", "browser"}
+)
+SUPPORTED_ARCHITECTURES = frozenset(
+    {"any", "x86", "x86_64", "armv7", "aarch64", "wasm32"}
+)
+
+_NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_.-]*[a-z0-9])?$")
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+_ENTRYPOINT_RE = re.compile(
+    r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*"
+    r":[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$"
+)
+
+
+def _object(value: Any, field_name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} debe ser un objeto JSON")
+    if not all(isinstance(key, str) for key in value):
+        raise ValueError(f"{field_name} solo admite claves de texto")
+    return value
+
+
+def _string(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field_name} debe ser una cadena no vacía")
+    return value
+
+
+def _string_list(value: Any, field_name: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) and item for item in value
+    ):
+        raise ValueError(f"{field_name} debe ser una lista de cadenas no vacías")
+    if len(value) != len(set(value)):
+        raise ValueError(f"{field_name} no admite valores duplicados")
+    return tuple(value)
+
+
+def _name(value: Any, field_name: str = "name") -> str:
+    text = _string(value, field_name)
+    if not _NAME_RE.fullmatch(text) or ".." in text:
+        raise ValueError(f"{field_name} inválido")
+    return text
+
+
+def _semver(value: Any, field_name: str) -> str:
+    text = _string(value, field_name)
+    if not _SEMVER_RE.fullmatch(text):
+        raise ValueError(f"{field_name} debe ser una versión SemVer exacta")
+    return text
+
+
+def _path(value: Any, field_name: str) -> str:
+    text = _string(value, field_name)
+    parts = text.split("/")
+    if (
+        "\\" in text
+        or text.startswith("/")
+        or re.match(r"^[A-Za-z]:", text)
+        or any(part in {"", ".", ".."} for part in parts)
+    ):
+        raise ValueError(f"{field_name} contiene una ruta insegura")
+    return text
+
+
+def _enum_list(value: Any, field_name: str, allowed: frozenset[str]) -> tuple[str, ...]:
+    values = _string_list(value, field_name)
+    invalid = set(values) - allowed
+    if invalid:
+        raise ValueError(
+            f"{field_name} contiene valores no soportados: {', '.join(sorted(invalid))}"
+        )
+    return values
+
+
+@dataclass(frozen=True)
+class PackageDistribution:
+    """Artefacto publicable descrito sin abrirlo ni ejecutar código suyo."""
+
+    type: str
+    path: str
+    platforms: tuple[str, ...] = ("any",)
+    architectures: tuple[str, ...] = ("any",)
+
+    @classmethod
+    def from_dict(cls, value: Any) -> "PackageDistribution":
+        data = _object(value, "distribution")
+        distribution_type = _string(data.get("type"), "distribution.type")
+        if distribution_type not in SUPPORTED_DISTRIBUTION_TYPES:
+            raise ValueError(f"Tipo de distribución no soportado: {distribution_type}")
+        return cls(
+            type=distribution_type,
+            path=_path(data.get("path"), "distribution.path"),
+            platforms=_enum_list(
+                data.get("platforms", ["any"]),
+                "distribution.platforms",
+                SUPPORTED_PLATFORMS,
+            ),
+            architectures=_enum_list(
+                data.get("architectures", ["any"]),
+                "distribution.architectures",
+                SUPPORTED_ARCHITECTURES,
+            ),
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "type": self.type,
+            "path": self.path,
+            "platforms": list(self.platforms),
+            "architectures": list(self.architectures),
+        }
+
+
+@dataclass(frozen=True)
+class PackageExtension:
+    """Declaración estática de una extensión; no resuelve su entrypoint."""
+
+    namespace: str
+    provider: str
+    capabilities: tuple[str, ...]
+    entrypoint: str
+
+    @classmethod
+    def from_dict(cls, value: Any) -> "PackageExtension":
+        data = _object(value, "extension")
+        namespace = _string(data.get("namespace"), "extension.namespace")
+        if not all(_IDENTIFIER_RE.fullmatch(part) for part in namespace.split(".")):
+            raise ValueError("extension.namespace inválido")
+        provider = _name(data.get("provider"), "extension.provider")
+        capabilities = _string_list(data.get("capabilities"), "extension.capabilities")
+        if not all(_NAME_RE.fullmatch(item) for item in capabilities):
+            raise ValueError("extension.capabilities contiene un nombre inválido")
+        entrypoint = _string(data.get("entrypoint"), "extension.entrypoint")
+        if not _ENTRYPOINT_RE.fullmatch(entrypoint):
+            raise ValueError("extension.entrypoint debe tener formato módulo:objeto")
+        return cls(namespace, provider, capabilities, entrypoint)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "namespace": self.namespace,
+            "provider": self.provider,
+            "capabilities": list(self.capabilities),
+            "entrypoint": self.entrypoint,
+        }
+
+
+@dataclass(frozen=True)
+class PackageManifestV2:
+    """Manifiesto Hub v2 validado exclusivamente mediante análisis de datos."""
+
+    format: str
+    name: str
+    version: str
+    package_type: str
+    requires_cobra: str
+    exports: tuple[str, ...]
+    capabilities: tuple[str, ...]
+    platforms: tuple[str, ...]
+    architectures: tuple[str, ...]
+    dependencies: Mapping[str, str]
+    distributions: tuple[PackageDistribution, ...]
+    extensions: tuple[PackageExtension, ...]
+    files: tuple[str, ...]
+    checksums: Mapping[str, str]
+
+    @classmethod
+    def from_dict(cls, value: Any) -> "PackageManifestV2":
+        data = _object(value, "manifest")
+        if data.get("format") != PACKAGE_FORMAT_V2:
+            raise ValueError(f"Formato de paquete no soportado: {data.get('format')}")
+        package_type = _string(data.get("package_type"), "package_type")
+        dependencies_data = _object(data.get("dependencies"), "dependencies")
+        dependencies = {
+            _name(key, "dependency.name"): _semver(version, f"dependencies.{key}")
+            for key, version in dependencies_data.items()
+        }
+        files = _string_list(data.get("files"), "files")
+        normalized_files = tuple(_path(item, "files") for item in files)
+        checksum_data = _object(data.get("checksums"), "checksums")
+        checksums: dict[str, str] = {}
+        for raw_path, raw_hash in checksum_data.items():
+            file_path = _path(raw_path, "checksums")
+            checksum = _string(raw_hash, f"checksums.{raw_path}")
+            if not _SHA256_RE.fullmatch(checksum):
+                raise ValueError(f"Checksum SHA-256 inválido para {raw_path}")
+            checksums[file_path] = checksum.lower()
+        if set(normalized_files) != set(checksums):
+            raise ValueError(
+                "files y checksums deben declarar exactamente las mismas rutas"
+            )
+        exports = tuple(
+            _path(item, "exports")
+            for item in _string_list(data.get("exports"), "exports")
+        )
+        if not set(exports) <= set(normalized_files):
+            raise ValueError("exports solo puede contener rutas declaradas en files")
+        capabilities = _string_list(data.get("capabilities"), "capabilities")
+        if not all(_NAME_RE.fullmatch(item) for item in capabilities):
+            raise ValueError("capabilities contiene un nombre inválido")
+        distributions_value = data.get("distributions")
+        extensions_value = data.get("extensions")
+        if not isinstance(distributions_value, list):
+            raise ValueError("distributions debe ser una lista")
+        if not isinstance(extensions_value, list):
+            raise ValueError("extensions debe ser una lista")
+        distributions = tuple(
+            PackageDistribution.from_dict(item) for item in distributions_value
+        )
+        if any(item.path not in normalized_files for item in distributions):
+            raise ValueError(
+                "Cada distribución debe apuntar a una ruta declarada en files"
+            )
+        return cls(
+            format=PACKAGE_FORMAT_V2,
+            name=_name(data.get("name")),
+            version=_semver(data.get("version"), "version"),
+            package_type=package_type,
+            requires_cobra=_semver(data.get("requires_cobra"), "requires_cobra"),
+            exports=exports,
+            capabilities=capabilities,
+            platforms=_enum_list(
+                data.get("platforms"), "platforms", SUPPORTED_PLATFORMS
+            ),
+            architectures=_enum_list(
+                data.get("architectures"), "architectures", SUPPORTED_ARCHITECTURES
+            ),
+            dependencies=dependencies,
+            distributions=distributions,
+            extensions=tuple(
+                PackageExtension.from_dict(item) for item in extensions_value
+            ),
+            files=normalized_files,
+            checksums=checksums,
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "format": self.format,
+            "name": self.name,
+            "version": self.version,
+            "package_type": self.package_type,
+            "requires_cobra": self.requires_cobra,
+            "exports": list(self.exports),
+            "capabilities": list(self.capabilities),
+            "platforms": list(self.platforms),
+            "architectures": list(self.architectures),
+            "dependencies": dict(self.dependencies),
+            "distributions": [item.as_dict() for item in self.distributions],
+            "extensions": [item.as_dict() for item in self.extensions],
+            "files": list(self.files),
+            "checksums": dict(self.checksums),
+        }
+
+
+def manifest_v2_from_dict(value: Any) -> PackageManifestV2:
+    """Fachada funcional para validar un manifiesto v2 sin cargar entrypoints."""
+    return PackageManifestV2.from_dict(value)
+
+
+def manifest_v2_to_dict(manifest: PackageManifestV2) -> dict[str, Any]:
+    return manifest.as_dict()
+
+
+# Nombres cortos y constantes descriptivas para consumidores que construyen
+# catálogos Hub. Los nombres principales permanecen explícitos y estables.
+ManifestV2 = PackageManifestV2
+DistributionV2 = PackageDistribution
+ExtensionV2 = PackageExtension
+PACKAGE_FORMATS = SUPPORTED_PACKAGE_FORMATS
+DISTRIBUTION_TYPES = SUPPORTED_DISTRIBUTION_TYPES
+PLATFORMS = SUPPORTED_PLATFORMS
+ARCHITECTURES = SUPPORTED_ARCHITECTURES
 
 
 @dataclass(frozen=True)

--- a/src/pcobra/cobra/packaging.py
+++ b/src/pcobra/cobra/packaging.py
@@ -36,6 +36,12 @@ __all__ = [
     "inspeccionar_paquete",
     "verificar_integridad",
     "es_paquete_cobra",
+    "PackageManifest",
+    "PackageManifestV2",
+    "PackageDistribution",
+    "PackageExtension",
+    "manifest_from_dict",
+    "manifest_to_dict",
 ]
 
 
@@ -55,7 +61,7 @@ class PackageManifest:
     dependencies: dict[str, str] | None = None
 
 
-def manifest_from_dict(data: dict[str, Any]) -> PackageManifest:
+def manifest_from_dict(data: dict[str, Any]) -> PackageManifest | PackageManifestV2:
     """Convierte un diccionario JSON en un manifiesto Cobra validado.
 
     Mantiene compatibilidad con manifiestos históricos que solo declaran
@@ -65,9 +71,13 @@ def manifest_from_dict(data: dict[str, Any]) -> PackageManifest:
     no están soportados hasta que exista una política de resolución
     documentada.
     """
+    if not isinstance(data, dict):
+        raise ValueError("El manifiesto debe ser un objeto JSON")
     package_format = data.get("format")
     if package_format is None:
         raise ValueError("El manifiesto no declara format")
+    if package_format == PACKAGE_FORMAT_V2:
+        return manifest_v2_from_dict(data)
     if package_format != PACKAGE_FORMAT:
         raise ValueError(f"Formato de paquete no soportado: {package_format}")
 
@@ -140,8 +150,10 @@ def _validar_dependencias_manifest(
     return normalized_dependencies
 
 
-def manifest_to_dict(manifest: PackageManifest) -> dict[str, Any]:
+def manifest_to_dict(manifest: PackageManifest | PackageManifestV2) -> dict[str, Any]:
     """Convierte un ``PackageManifest`` en un diccionario JSON-compatible."""
+    if isinstance(manifest, PackageManifestV2):
+        return manifest_v2_to_dict(manifest)
     data: dict[str, Any] = {
         "format": manifest.format,
         "name": manifest.name,
@@ -161,7 +173,9 @@ def manifest_to_dict(manifest: PackageManifest) -> dict[str, Any]:
             data[key] = (
                 list(value)
                 if isinstance(value, list)
-                else dict(value) if isinstance(value, dict) else value
+                else dict(value)
+                if isinstance(value, dict)
+                else value
             )
     return data
 
@@ -321,6 +335,11 @@ def construir_paquete(
     if manifest_path.exists():
         manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
         manifest = manifest_from_dict(manifest_data)
+        if isinstance(manifest, PackageManifestV2):
+            raise ValueError(
+                "La construcción de cobra-package-v2 requiere artefactos "
+                "predefinidos; construir_paquete conserva el contrato v1"
+            )
     else:
         manifest = PackageManifest(
             format=PACKAGE_FORMAT,
@@ -442,7 +461,7 @@ def _validar_entradas_zip(zf: zipfile.ZipFile) -> dict[str, zipfile.ZipInfo]:
 
 
 def _normalizar_lista_archivos(values: Any, *, field: str) -> set[str]:
-    if not isinstance(values, list):
+    if not isinstance(values, (list, tuple)):
         raise ValueError(f"El manifiesto debe declarar {field} como lista")
     return {_normalizar_ruta_paquete(str(value)) for value in values}
 
@@ -552,3 +571,16 @@ def verificar_integridad(package: str | Path) -> bool:
     """
     validar_paquete(package)
     return True
+
+
+# Se importa al final para conservar el límite histórico: los proveedores Hub
+# dependen de esta fachada v1, mientras que esta solo usa los modelos de datos
+# v2. No se carga ningún módulo indicado por un entrypoint del manifiesto.
+from pcobra.cobra.hub.models import (  # noqa: E402
+    PACKAGE_FORMAT_V2,
+    PackageDistribution,
+    PackageExtension,
+    PackageManifestV2,
+    manifest_v2_from_dict,
+    manifest_v2_to_dict,
+)

--- a/tests/unit/test_hub_manifest_v2.py
+++ b/tests/unit/test_hub_manifest_v2.py
@@ -1,0 +1,136 @@
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from pcobra.cobra.hub.models import (
+    DISTRIBUTION_TYPES,
+    PackageManifestV2,
+    manifest_v2_from_dict,
+)
+from pcobra.cobra.packaging import (
+    extraer_paquete,
+    inspeccionar_paquete,
+    manifest_from_dict,
+    validar_paquete,
+)
+
+
+def _manifest() -> dict:
+    digest = hashlib.sha256(b"wheel").hexdigest()
+    return {
+        "format": "cobra-package-v2",
+        "name": "demo.extension",
+        "version": "1.2.3-beta.1",
+        "package_type": "extension",
+        "requires_cobra": "2.0.0",
+        "exports": ["dist/demo.whl"],
+        "capabilities": ["transpiler.python"],
+        "platforms": ["linux", "windows"],
+        "architectures": ["x86_64", "aarch64"],
+        "dependencies": {"cobra.std": "2.0.0"},
+        "distributions": [
+            {
+                "type": "python-wheel",
+                "path": "dist/demo.whl",
+                "platforms": ["any"],
+                "architectures": ["any"],
+            }
+        ],
+        "extensions": [
+            {
+                "namespace": "cobra.transpilers",
+                "provider": "demo-provider",
+                "capabilities": ["transpiler.python"],
+                "entrypoint": "demo.plugin:Provider.create",
+            }
+        ],
+        "files": ["dist/demo.whl"],
+        "checksums": {"dist/demo.whl": digest},
+    }
+
+
+def test_manifest_v2_modela_todos_los_campos_y_distribuciones_permitidas():
+    data = _manifest()
+    data["distributions"] = [
+        {"type": kind, "path": "dist/demo.whl"} for kind in DISTRIBUTION_TYPES
+    ]
+
+    manifest = manifest_v2_from_dict(data)
+
+    assert isinstance(manifest, PackageManifestV2)
+    assert {item.type for item in manifest.distributions} == DISTRIBUTION_TYPES
+    assert manifest.extensions[0].entrypoint == "demo.plugin:Provider.create"
+    assert manifest.as_dict() == data | {
+        "distributions": [
+            {
+                "type": kind,
+                "path": "dist/demo.whl",
+                "platforms": ["any"],
+                "architectures": ["any"],
+            }
+            for kind in DISTRIBUTION_TYPES
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("version", "v1.2.3", "SemVer"),
+        ("platforms", ["plan9"], "no soportados"),
+        ("architectures", ["mips"], "no soportados"),
+        ("files", ["../demo.whl"], "ruta insegura"),
+        ("checksums", {"dist/demo.whl": "not-a-hash"}, "SHA-256"),
+        ("extensions", [{}], "namespace"),
+    ],
+)
+def test_manifest_v2_rechaza_valores_invalidos(field, value, match):
+    data = _manifest()
+    data[field] = value
+    with pytest.raises(ValueError, match=match):
+        manifest_v2_from_dict(data)
+
+
+@pytest.mark.parametrize(
+    "entrypoint",
+    [
+        "demo.plugin",
+        "demo.plugin:",
+        "demo-plugin:factory",
+        "demo:factory()",
+        " demo:factory",
+    ],
+)
+def test_manifest_v2_rechaza_entrypoints_no_estaticos(entrypoint):
+    data = _manifest()
+    data["extensions"][0]["entrypoint"] = entrypoint
+    with pytest.raises(ValueError, match="entrypoint"):
+        manifest_v2_from_dict(data)
+
+
+def test_fachadas_packaging_validan_y_extraen_v2_sin_importar_entrypoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    imported: list[str] = []
+    original_import = __import__
+    monkeypatch.setattr(
+        "builtins.__import__",
+        lambda name, *args, **kwargs: (
+            imported.append(name) or original_import(name, *args, **kwargs)
+        ),
+    )
+    package = tmp_path / "demo.co"
+    with zipfile.ZipFile(package, "w") as archive:
+        archive.writestr("cobra.pkg.json", json.dumps(_manifest()))
+        archive.writestr("dist/demo.whl", b"wheel")
+
+    assert isinstance(manifest_from_dict(_manifest()), PackageManifestV2)
+    assert inspeccionar_paquete(package).manifest["format"] == "cobra-package-v2"
+    assert validar_paquete(package).manifest["name"] == "demo.extension"
+    destination = extraer_paquete(package, tmp_path / "out")
+
+    assert (destination / "dist/demo.whl").read_bytes() == b"wheel"
+    assert "demo.plugin" not in imported


### PR DESCRIPTION
### Motivation

- Soportar un nuevo formato de manifiesto `cobra-package-v2` con metadatos y artefactos más ricos para CobraHub.
- Modelar y validar explícitamente campos avanzados como `package_type`, `requires_cobra`, `exports`, `capabilities`, `platforms`, `architectures`, `dependencies`, `distributions`, `extensions`, `files` y `checksums` sin ejecutar código del paquete.
- Mantener compatibilidad con el contrato histórico `cobra-package-v1` y evitar la importación/ejecución de entrypoints durante inspección o resolución.

### Description

- Se añadieron constantes y validaciones (`SemVer`, SHA-256, rutas seguras, nombres y entrypoints estáticos) y conjuntos admitidos de formatos, distribuciones, plataformas y arquitecturas en `src/pcobra/cobra/hub/models.py` (`PackageManifestV2`, `PackageDistribution`, `PackageExtension`, helpers `manifest_v2_from_dict` / `manifest_v2_to_dict`).
- `pcobra.cobra.packaging` fue adaptado para detectar `cobra-package-v2` en `manifest_from_dict` y delegar la validación en los nuevos modelos sin cambiar el comportamiento de lectura/validación/extracción v1, y `construir_paquete` mantiene y obliga el contrato v1 (lanza error si se intenta construir a partir de un manifiesto v2).
- Se movió la importación de los modelos v2 hacia el final del módulo `packaging` para evitar importaciones circulares y se exportaron los nuevos tipos y constantes desde la fachada pública de `pcobra.cobra.hub`.
- Se añadió una suite de pruebas `tests/unit/test_hub_manifest_v2.py` que cubre casos positivos y negativos (SemVer, hashes, rutas, plataformas, arquitecturas, distribuciones, extensiones y que no se importe el entrypoint durante la inspección/extracción).

### Testing

- Se ejecutó `pytest -q tests/unit/test_hub_manifest_v2.py tests/unit/test_cobra_packaging.py tests/unit/test_hub_import_boundaries.py tests/unit/test_hub_local_provider.py tests/unit/test_hub_provider_contracts.py` y todas las pruebas pasaron (`87 passed, 2 warnings`).
- Se ejecutaron comprobaciones de formato y lint con `ruff format --check` y `ruff check` sobre los ficheros modificados y ambas pasaron, y se aplicó el formateo automático donde fue necesario.
- Se verificó con `git diff --check` y una búsqueda explícita que no se modificaron Lexer ni Parser.
- La prueba integrada confirma que la fachada valida y extrae paquetes v2 sin importar ni ejecutar el `entrypoint` declarado (se comprueba que no hubo importaciones del módulo indicado en el manifiesto).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59f2c936a08327bbbe1ded34fa8397)