### PR TITLE
Versiona y valida los lockfiles de CobraHub

### DIFF
--- a/src/pcobra/cobra/hub/lockfile.py
+++ b/src/pcobra/cobra/hub/lockfile.py
@@ -1,5 +1,280 @@
-"""API de lockfiles de Hub, separada para consumidores neutrales."""
+"""Lectura y escritura validada de ``cobra.lock``.
 
-from pcobra.cobra.hub.resolver import read_lockfile, write_lockfile
+La versión 1 se conserva como formato de intercambio legado; la versión 2
+mantiene los metadatos necesarios para resolver un paquete sin consultar la red.
+"""
 
-__all__ = ["read_lockfile", "write_lockfile"]
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+import re
+import tomllib
+from typing import Any, Mapping, Sequence
+
+from pcobra.cobra.hub.errors import PackageResolutionError
+from pcobra.cobra.hub.integrity import normalize_sha256
+from pcobra.cobra.hub.models import CobraHubResolution, LockedDependency
+from pcobra.cobra.packaging import normalizar_nombre_paquete, validar_version_paquete
+
+LOCKFILE_V1 = 1
+LOCKFILE_V2 = 2
+_KNOWN_VERSIONS = frozenset({LOCKFILE_V1, LOCKFILE_V2})
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_PROVIDER_SOURCES = frozenset({"installer-cache", "cobrahub", "cobrahub-cache"})
+
+
+@dataclass(frozen=True)
+class LockfileEntryV1:
+    """Entrada histórica mínima de un lockfile v1."""
+
+    name: str
+    version: str
+    source: str | None = None
+    sha256: str | None = None
+
+
+@dataclass(frozen=True)
+class LockfileEntryV2(LockfileEntryV1):
+    """Entrada v2 autocontenida, apta para resolución offline."""
+
+    package_type: str | None = None
+    artifact_type: str | None = None
+    artifact: str | None = None
+    exports: tuple[str, ...] = ()
+    capabilities: tuple[str, ...] = ()
+    extensions: tuple[Mapping[str, Any], ...] = ()
+    platforms: tuple[str, ...] = ()
+    architectures: tuple[str, ...] = ()
+    dependencies: Mapping[str, str] = field(default_factory=dict)
+
+
+def read_lockfile(path: str | Path) -> dict[str, LockedDependency]:
+    """Lee JSON/TOML v1 o v2 y devuelve entradas normalizadas."""
+
+    lock_path = Path(path)
+    try:
+        text = lock_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PackageResolutionError(f"No se pudo leer cobra.lock: {exc}") from exc
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        try:
+            data = tomllib.loads(text)
+        except tomllib.TOMLDecodeError as exc:
+            raise PackageResolutionError(
+                f"cobra.lock no es JSON ni TOML válido: {exc}"
+            ) from exc
+
+    version, entries = _extract_entries(data)
+    locked: dict[str, LockedDependency] = {}
+    for raw in entries:
+        entry = _parse_entry(raw, version, lock_path.parent)
+        if entry.name in locked:
+            raise PackageResolutionError(
+                f"cobra.lock contiene el paquete duplicado {entry.name}."
+            )
+        metadata = _v2_metadata(entry) if isinstance(entry, LockfileEntryV2) else {}
+        locked[entry.name] = LockedDependency(
+            name=entry.name,
+            version=entry.version,
+            source=entry.source,
+            sha256=entry.sha256,
+            metadata=metadata,
+        )
+    return locked
+
+
+def write_lockfile(
+    path: str | Path,
+    resolved: Mapping[str, CobraHubResolution | LockedDependency],
+    *,
+    version: int = LOCKFILE_V2,
+) -> None:
+    """Escribe JSON determinista; ``version=1`` habilita compatibilidad legacy."""
+
+    if type(version) is not int or version not in _KNOWN_VERSIONS:
+        raise PackageResolutionError(f"Versión de cobra.lock no soportada: {version!r}.")
+    entries = [_entry_from_resolution(item, version) for item in resolved.values()]
+    entries.sort(key=_sort_key)
+    payload = {"version": version, "packages": [_entry_dict(item) for item in entries]}
+    try:
+        Path(path).write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        raise PackageResolutionError(f"No se pudo escribir cobra.lock: {exc}") from exc
+
+
+def _extract_entries(data: Any) -> tuple[int, Sequence[Any]]:
+    if isinstance(data, list):
+        return LOCKFILE_V1, data
+    if not isinstance(data, Mapping):
+        raise PackageResolutionError("cobra.lock debe ser una lista o una tabla.")
+    raw_version = data.get("version", LOCKFILE_V1)
+    if type(raw_version) is not int or raw_version not in _KNOWN_VERSIONS:
+        raise PackageResolutionError(
+            f"Versión de esquema de cobra.lock no soportada: {raw_version!r}."
+        )
+    if "packages" not in data:
+        raise PackageResolutionError("cobra.lock no contiene la estructura packages.")
+    packages = data["packages"]
+    if isinstance(packages, list):
+        return raw_version, packages
+    if isinstance(packages, Mapping):
+        expanded = []
+        for name, value in packages.items():
+            if isinstance(value, Mapping):
+                expanded.append({"name": name, **value})
+            else:
+                expanded.append({"name": name, "version": value})
+        return raw_version, expanded
+    raise PackageResolutionError("packages debe ser una lista o una tabla.")
+
+
+def _parse_entry(raw: Any, version: int, base_dir: Path) -> LockfileEntryV1:
+    if not isinstance(raw, Mapping):
+        raise PackageResolutionError("cobra.lock contiene una entrada no válida.")
+    try:
+        name_value = raw.get("name")
+        version_value = raw.get("version")
+        if not isinstance(name_value, str) or not name_value.strip():
+            raise ValueError("name debe ser una cadena no vacía")
+        if not isinstance(version_value, str) or not version_value.strip():
+            raise ValueError("version debe ser una cadena no vacía")
+        name = normalizar_nombre_paquete(name_value)
+        package_version = validar_version_paquete(version_value)
+        sha256 = _optional_hash(raw)
+        source = _optional_string(raw.get("source"), "source")
+        source = _resolve_source(source, base_dir)
+        if version == LOCKFILE_V1:
+            return LockfileEntryV1(name, package_version, source, sha256)
+        return LockfileEntryV2(
+            name=name,
+            version=package_version,
+            source=source,
+            sha256=sha256,
+            package_type=_optional_string(raw.get("package_type"), "package_type"),
+            artifact_type=_optional_string(raw.get("artifact_type"), "artifact_type"),
+            artifact=_optional_string(raw.get("artifact"), "artifact"),
+            exports=_string_tuple(raw.get("exports", []), "exports"),
+            capabilities=_string_tuple(raw.get("capabilities", []), "capabilities"),
+            extensions=_mapping_tuple(raw.get("extensions", []), "extensions"),
+            platforms=_string_tuple(raw.get("platforms", []), "platforms"),
+            architectures=_string_tuple(raw.get("architectures", []), "architectures"),
+            dependencies=_dependencies(raw.get("dependencies", {})),
+        )
+    except (TypeError, ValueError) as exc:
+        raise PackageResolutionError(f"Entrada inválida en cobra.lock: {exc}") from exc
+
+
+def _optional_hash(raw: Mapping[str, Any]) -> str | None:
+    keys = [key for key in ("sha256", "checksum", "hash") if key in raw]
+    if not keys:
+        return None
+    value = raw[keys[0]]
+    if not isinstance(value, str):
+        raise ValueError("sha256 debe ser una cadena")
+    value = normalize_sha256(value)
+    if not _SHA256_RE.fullmatch(value):
+        raise ValueError("sha256 no es un hash SHA-256 válido")
+    return value
+
+
+def _optional_string(value: Any, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field_name} debe ser una cadena no vacía")
+    return value
+
+
+def _string_tuple(value: Any, field_name: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{field_name} debe ser una lista de cadenas")
+    return tuple(value)
+
+
+def _mapping_tuple(value: Any, field_name: str) -> tuple[Mapping[str, Any], ...]:
+    if not isinstance(value, list) or not all(isinstance(item, Mapping) for item in value):
+        raise ValueError(f"{field_name} debe ser una lista de tablas")
+    return tuple(dict(item) for item in value)
+
+
+def _dependencies(value: Any) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        raise ValueError("dependencies debe ser una tabla")
+    result: dict[str, str] = {}
+    for raw_name, raw_version in value.items():
+        if not isinstance(raw_name, str) or not isinstance(raw_version, str):
+            raise ValueError("dependencies debe relacionar nombres y versiones de texto")
+        result[normalizar_nombre_paquete(raw_name)] = validar_version_paquete(raw_version)
+    return result
+
+
+def _resolve_source(source: str | None, base_dir: Path) -> str | None:
+    if source is None or source in _PROVIDER_SOURCES:
+        return source
+    path = Path(source).expanduser()
+    return str((path if path.is_absolute() else base_dir / path).resolve())
+
+
+def _entry_from_resolution(item: CobraHubResolution | LockedDependency, version: int) -> LockfileEntryV1:
+    metadata = dict(item.metadata)
+    common = dict(name=item.name, version=item.version, source=item.source, sha256=item.sha256)
+    if version == LOCKFILE_V1:
+        return LockfileEntryV1(**common)
+    return LockfileEntryV2(
+        **common,
+        package_type=metadata.get("package_type"),
+        artifact_type=metadata.get("artifact_type"),
+        artifact=metadata.get("artifact") or str(getattr(item, "path", "")) or None,
+        exports=tuple(metadata.get("exports", ())),
+        capabilities=tuple(metadata.get("capabilities", ())),
+        extensions=tuple(metadata.get("extensions", ())),
+        platforms=tuple(metadata.get("platforms", metadata.get("platform", ()))),
+        architectures=tuple(metadata.get("architectures", metadata.get("architecture", ()))),
+        dependencies=dict(getattr(item, "dependencies", metadata.get("dependencies", {}))),
+    )
+
+
+def _entry_dict(entry: LockfileEntryV1) -> dict[str, Any]:
+    data = {"name": entry.name, "version": entry.version}
+    for key in ("source", "sha256"):
+        value = getattr(entry, key)
+        if value is not None:
+            data[key] = value
+    if isinstance(entry, LockfileEntryV2):
+        for key in ("package_type", "artifact_type", "artifact"):
+            value = getattr(entry, key)
+            if value is not None:
+                data[key] = value
+        data.update(
+            exports=list(entry.exports), capabilities=list(entry.capabilities),
+            extensions=[dict(item) for item in entry.extensions],
+            platforms=list(entry.platforms), architectures=list(entry.architectures),
+            dependencies=dict(sorted(entry.dependencies.items())),
+        )
+    return data
+
+
+def _v2_metadata(entry: LockfileEntryV2) -> dict[str, Any]:
+    return {key: value for key, value in _entry_dict(entry).items() if key not in {"name", "version", "source", "sha256"}}
+
+
+def _sort_key(entry: LockfileEntryV1) -> tuple[str, ...]:
+    return (
+        entry.name, entry.version, entry.source or "",
+        getattr(entry, "package_type", None) or "",
+        getattr(entry, "artifact_type", None) or "",
+        getattr(entry, "artifact", None) or "",
+    )
+
+
+__all__ = [
+    "LOCKFILE_V1", "LOCKFILE_V2", "LockfileEntryV1", "LockfileEntryV2",
+    "read_lockfile", "write_lockfile",
+]

--- a/src/pcobra/cobra/hub/resolver.py
+++ b/src/pcobra/cobra/hub/resolver.py
@@ -7,7 +7,6 @@ reinventar el formato ``.co`` ni la caché existente bajo ``pcobra.cobra``.
 
 from __future__ import annotations
 
-import json
 import re
 import tomllib
 from pathlib import Path
@@ -15,7 +14,7 @@ from typing import Any, Mapping, Sequence
 
 from pcobra.cobra.packaging import normalizar_nombre_paquete, validar_version_paquete
 from pcobra.cobra.hub.installation import CobraHubResolver
-from pcobra.cobra.hub.integrity import normalize_sha256
+from pcobra.cobra.hub.lockfile import read_lockfile, write_lockfile
 from pcobra.cobra.hub.models import (
     CobraHubResolution,
     DeclaredDependency,
@@ -45,8 +44,6 @@ _IMPORT_RE = re.compile(
     r"^\s*(?:usar\s+(?P<usar>\"[^\"]+\"|'[^']+'|[A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)+)|import\s+(?P<import>\"[^\"]+\"|'[^']+'))",
     re.MULTILINE,
 )
-_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
-_LOCK_VERSION = 1
 _IGNORED_DIRS = {
     ".git",
     ".hg",
@@ -200,97 +197,6 @@ def read_declared_dependencies(path: str | Path) -> dict[str, DeclaredDependency
             )
         declared[name] = DeclaredDependency(name=name, version=version, source=source)
     return declared
-
-
-def read_lockfile(path: str | Path) -> dict[str, LockedDependency]:
-    """Lee versiones y hashes desde ``cobra.lock`` JSON o TOML."""
-
-    lock_path = Path(path)
-    try:
-        text = lock_path.read_text(encoding="utf-8")
-    except OSError as exc:
-        raise CobraDependencyError(f"No se pudo leer cobra.lock: {exc}") from exc
-    try:
-        data = json.loads(text)
-    except json.JSONDecodeError:
-        try:
-            data = tomllib.loads(text)
-        except tomllib.TOMLDecodeError as exc:
-            raise CobraDependencyError(
-                f"cobra.lock no es JSON ni TOML válido: {exc}"
-            ) from exc
-
-    packages = data.get("packages") if isinstance(data, Mapping) else None
-    entries: Sequence[Any]
-    if isinstance(packages, list):
-        entries = packages
-    elif isinstance(packages, Mapping):
-        entries = [
-            (
-                {"name": name, **value}
-                if isinstance(value, Mapping)
-                else {"name": name, "version": value}
-            )
-            for name, value in packages.items()
-        ]
-    elif isinstance(data, list):
-        entries = data
-    else:
-        entries = []
-
-    locked: dict[str, LockedDependency] = {}
-    for entry in entries:
-        if (
-            not isinstance(entry, Mapping)
-            or "name" not in entry
-            or "version" not in entry
-        ):
-            raise CobraDependencyError(
-                "cobra.lock contiene una entrada de paquete inválida."
-            )
-        name = _normalize_dependency_name(str(entry["name"]))
-        version = validar_version_paquete(str(entry["version"]))
-        sha256 = entry.get("sha256") or entry.get("checksum") or entry.get("hash")
-        if isinstance(sha256, str):
-            sha256 = normalize_sha256(sha256)
-            if not _SHA256_RE.fullmatch(sha256):
-                raise CobraDependencyError(
-                    f"Hash SHA-256 inválido en cobra.lock para {name}."
-                )
-        else:
-            sha256 = None
-        source = _resolve_local_source(entry.get("source"), lock_path.parent)
-        locked[name] = LockedDependency(
-            name=name,
-            version=version,
-            sha256=sha256,
-            source=source,
-        )
-    return locked
-
-
-def write_lockfile(
-    path: str | Path, resolved: Mapping[str, CobraHubResolution]
-) -> None:
-    """Genera ``cobra.lock`` estable cuando no existe."""
-
-    lock_path = Path(path)
-    payload = {
-        "version": _LOCK_VERSION,
-        "packages": [
-            {
-                "name": item.name,
-                "version": item.version,
-                "sha256": item.sha256,
-                "source": item.source,
-            }
-            for item in sorted(resolved.values(), key=lambda value: value.name)
-        ],
-    }
-    lock_path.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
 
 
 def detect_cobra_imports(project_root: str | Path) -> set[str]:

--- a/src/pcobra/cobra_installer/dependency_resolver.py
+++ b/src/pcobra/cobra_installer/dependency_resolver.py
@@ -1,4 +1,13 @@
-"""Adaptador compatible para el resolvedor de grafos de CobraHub."""
+"""Adaptadores compatibles para el resolvedor de grafos de CobraHub."""
+
+from pathlib import Path
+from typing import Mapping
+
+from pcobra.cobra.hub.lockfile import (
+    read_lockfile as _read_lockfile,
+    write_lockfile as _write_lockfile,
+)
+from pcobra.cobra.hub.models import CobraHubResolution, LockedDependency
 
 from pcobra.cobra.hub.resolver import (
     CobraDependencyError,
@@ -7,10 +16,25 @@ from pcobra.cobra.hub.resolver import (
     LockedDependency,
     detect_cobra_imports,
     read_declared_dependencies,
-    read_lockfile,
     resolve_project_dependencies,
-    write_lockfile,
 )
+
+
+def read_lockfile(path: str | Path) -> dict[str, LockedDependency]:
+    """Conserva el punto de entrada histórico del instalador."""
+
+    return _read_lockfile(path)
+
+
+def write_lockfile(
+    path: str | Path,
+    resolved: Mapping[str, CobraHubResolution | LockedDependency],
+    *,
+    legacy_v1: bool = False,
+) -> None:
+    """Escribe v2, o v1 al solicitar explícitamente ``legacy_v1=True``."""
+
+    _write_lockfile(path, resolved, version=1 if legacy_v1 else 2)
 
 __all__ = [
     "CobraDependencyError",

--- a/tests/unit/test_cobra_installer_dependency_resolver.py
+++ b/tests/unit/test_cobra_installer_dependency_resolver.py
@@ -98,7 +98,14 @@ def test_resuelve_dependencia_cacheada_sin_cliente_remoto_y_lock_indica_cache(tm
     lock = json.loads((tmp_path / "cobra.lock").read_text(encoding="utf-8"))
     assert lock["packages"] == [
         {
+            "architectures": [],
+            "artifact": str(cached),
+            "capabilities": [],
+            "dependencies": {},
+            "exports": [],
+            "extensions": [],
             "name": "dep-cache",
+            "platforms": [],
             "version": "1.2.3",
             "sha256": result.resolved["dep-cache"].sha256,
             "source": "installer-cache",
@@ -308,16 +315,30 @@ def test_resuelve_proyecto_con_multiples_dependencias_hash_ruta_y_origen(
 
     lock = json.loads((fixture.project_root / "cobra.lock").read_text(encoding="utf-8"))
     assert lock == {
-        "version": 1,
+        "version": 2,
         "packages": [
             {
+                "architectures": [],
+                "artifact": str(fixture.cached_path),
+                "capabilities": [],
+                "dependencies": {},
+                "exports": [],
+                "extensions": [],
                 "name": "dep-cache",
+                "platforms": [],
                 "sha256": fixture.hashes["dep-cache"],
                 "source": "installer-cache",
                 "version": "1.2.3",
             },
             {
+                "architectures": [],
+                "artifact": str(fixture.remote_path),
+                "capabilities": [],
+                "dependencies": {},
+                "exports": [],
+                "extensions": [],
                 "name": "dep-remota",
+                "platforms": [],
                 "sha256": fixture.hashes["dep-remota"],
                 "source": "cobrahub",
                 "version": "2.0.0",

--- a/tests/unit/test_hub_lockfile.py
+++ b/tests/unit/test_hub_lockfile.py
@@ -1,0 +1,101 @@
+import json
+
+import pytest
+
+from pcobra.cobra.hub.errors import PackageResolutionError
+from pcobra.cobra.hub.lockfile import read_lockfile, write_lockfile
+from pcobra.cobra.hub.models import LockedDependency
+
+
+HASH = "a" * 64
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        '[{"name":"Demo_Pkg","version":"1.2.3","sha256":"' + HASH + '"}]',
+        'version = 1\n[[packages]]\nname = "Demo_Pkg"\nversion = "1.2.3"\nsha256 = "'
+        + HASH
+        + '"\n',
+        '[packages.demo_pkg]\nversion = "1.2.3"\nsha256 = "' + HASH + '"\n',
+    ],
+)
+def test_snapshot_lectura_v1_json_toml_y_tabla(tmp_path, contents):
+    path = tmp_path / "cobra.lock"
+    path.write_text(contents, encoding="utf-8")
+
+    assert read_lockfile(path) == {
+        "demo_pkg": LockedDependency("demo_pkg", "1.2.3", HASH, None)
+    }
+
+
+def test_snapshot_v2_conserva_metadatos_y_lectura_offline(tmp_path):
+    path = tmp_path / "cobra.lock"
+    path.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "packages": [{
+                    "name": "demo", "version": "1.0.0", "source": "cobrahub-cache",
+                    "sha256": HASH, "package_type": "library", "artifact_type": "co",
+                    "artifact": "demo.co", "exports": ["demo.api"],
+                    "capabilities": ["net"], "extensions": [{"name": "plug"}],
+                    "platforms": ["linux"], "architectures": ["x86_64"],
+                    "dependencies": {"base": "2.0.0"},
+                }],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    entry = read_lockfile(path)["demo"]
+    assert entry.source == "cobrahub-cache"
+    assert entry.metadata == {
+        "package_type": "library", "artifact_type": "co", "artifact": "demo.co",
+        "exports": ["demo.api"], "capabilities": ["net"],
+        "extensions": [{"name": "plug"}], "platforms": ["linux"],
+        "architectures": ["x86_64"], "dependencies": {"base": "2.0.0"},
+    }
+
+
+def test_reserializacion_v2_es_determinista(tmp_path):
+    path = tmp_path / "cobra.lock"
+    entries = {
+        "z": LockedDependency("z", "2.0.0", HASH, "cobrahub"),
+        "a": LockedDependency("a", "1.0.0", HASH, "installer-cache"),
+    }
+
+    write_lockfile(path, entries)
+    first = path.read_bytes()
+    write_lockfile(path, dict(reversed(entries.items())))
+
+    assert path.read_bytes() == first
+    assert [item["name"] for item in json.loads(first)["packages"]] == ["a", "z"]
+
+
+@pytest.mark.parametrize(
+    "payload, message",
+    [
+        ({"version": 3, "packages": []}, "no soportada"),
+        ({"version": 2, "other": []}, "packages"),
+        ({"version": 2, "packages": [{"name": "x", "version": "1.0.0", "sha256": "bad"}]}, "sha256"),
+        ({"version": 2, "packages": [{"name": "x", "version": 1}]}, "version"),
+        ({"version": 2, "packages": [{"version": "1.0.0"}]}, "name"),
+    ],
+)
+def test_rechaza_esquema_futuro_estructura_y_campos_invalidos(tmp_path, payload, message):
+    path = tmp_path / "cobra.lock"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(PackageResolutionError, match=message):
+        read_lockfile(path)
+
+
+def test_rechaza_duplicados_despues_de_normalizar(tmp_path):
+    path = tmp_path / "cobra.lock"
+    path.write_text(json.dumps([
+        {"name": "Demo_Pkg", "version": "1.0.0"},
+        {"name": "demo_pkg", "version": "1.0.0"},
+    ]), encoding="utf-8")
+
+    with pytest.raises(PackageResolutionError, match="duplicado"):
+        read_lockfile(path)


### PR DESCRIPTION
### Motivation

- Necesitamos un soporte explícito y validado para múltiples esquemas de `cobra.lock` (v1 legado y v2 rico) que permita resolución offline y evite ambigüedades o corrupción al leer/escribir el fichero.
- Hay que detectar y rechazar estructuras desconocidas, hashes inválidos, duplicados tras normalizar nombres y campos con tipos incorrectos para evitar fallos silenciosos en resolución de dependencias.

### Description

- Se añadió un módulo dedicado `src/pcobra/cobra/hub/lockfile.py` que implementa modelos `LockfileEntryV1` y `LockfileEntryV2`, lectura compatible JSON/TOML (lista raíz, `packages` como lista y `packages` como tabla), validación de esquema conocido y normalización de entradas. 【F:src/pcobra/cobra/hub/lockfile.py†L21-L50】【F:src/pcobra/cobra/hub/lockfile.py†L112-L135】
- La lectura ahora rechaza versiones de esquema desconocidas y estructuras inválidas con `PackageResolutionError`, valida nombres y versiones, normaliza y verifica SHA-256, y detecta paquetes duplicados después de normalizar nombres. 【F:src/pcobra/cobra/hub/lockfile.py†L71-L78】【F:src/pcobra/cobra/hub/lockfile.py†L138-L183】
- La escritura produce por defecto `version = 2` con orden estable y claves JSON deterministas; se expone una API neutral y una adaptación en `src/pcobra/cobra_installer/dependency_resolver.py` que mantiene `read_lockfile` y `write_lockfile` históricos y añade la opción explícita `legacy_v1=True` para generar v1 si es necesario. 【F:src/pcobra/cobra/hub/lockfile.py†L90-L109】【F:src/pcobra/cobra_installer/dependency_resolver.py†L29-L37】
- Se persisten metadatos v2 (origen, `package_type`, `artifact_type`, `artifact`, `sha256`, `exports`, `capabilities`, `extensions`, `platforms`, `architectures`, `dependencies`) y la serialización v2 es determinista (orden por nombre/version/origen/tipo/artefacto). 【F:src/pcobra/cobra/hub/lockfile.py†L230-L241】【F:src/pcobra/cobra/hub/lockfile.py†L244-L274】
- Se añadieron pruebas unitarias en `tests/unit/test_hub_lockfile.py` que cubren lecturas v1 JSON/TOML/tabla, manifiesto v2 con metadatos, reserialización determinista, rechazo de esquemas futuros/estructuras inválidas y duplicados tras normalizar. 【F:tests/unit/test_hub_lockfile.py†L13-L29】【F:tests/unit/test_hub_lockfile.py†L32-L73】

### Testing

- ✅ Ejecutadas pruebas dirigidas: `python -m pytest tests/unit/test_hub_lockfile.py tests/unit/test_cobra_installer_dependency_resolver.py tests/unit/test_hub_local_provider.py -q` y todas las pruebas relevantes al lockfile e instalador pasaron (28 passed, 1 warning).【F:tests/unit/test_hub_lockfile.py†L1-L29】
- ✅ Linter: `ruff check` sobre los ficheros modificados pasó sin errores.
- ✅ Compilación estática de bytecode: `python -m compileall -q src/pcobra/cobra/hub/lockfile.py src/pcobra/cobra/hub/resolver.py src/pcobra/cobra_installer/dependency_resolver.py` pasó sin errores.
- ⚠️ Suite completa: `python -m pytest -q` se ejecutó; el proceso mostró 544 pruebas pasadas, 8 omitidas y 5 fallos en tests de integración REPL/run independientes de este cambio; los tests unitarios añadidos/punteros al lockfile pasan íntegramente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59f50bf23c8327bd6f1fd65e219440)