### PR TITLE
Separar validación de versiones y compatibilidad en manifiestos Hub v2

### DIFF
--- a/src/pcobra/cobra/hub/models.py
+++ b/src/pcobra/cobra/hub/models.py
@@ -27,7 +27,7 @@ SUPPORTED_PLATFORMS = frozenset(
     {"any", "linux", "windows", "macos", "android", "ios", "freebsd", "browser"}
 )
 SUPPORTED_ARCHITECTURES = frozenset(
-    {"any", "x86", "x86_64", "armv7", "aarch64", "wasm32"}
+    {"any", "x86", "x86_64", "armv7", "arm64", "wasm32"}
 )
 
 _NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9_.-]*[a-z0-9])?$")
@@ -36,6 +36,11 @@ _SEMVER_RE = re.compile(
     r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
     r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+_VERSION_CONSTRAINT_RE = re.compile(
+    r"(?:>=|<=|>|<|==|!=)?"
+    r"(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*)){0,2}"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
 )
 _SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 _ENTRYPOINT_RE = re.compile(
@@ -82,6 +87,27 @@ def _semver(value: Any, field_name: str) -> str:
     return text
 
 
+def _version_constraint(value: Any, field_name: str) -> str:
+    """Valida una intersección estática de comparadores de versión Cobra."""
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field_name} debe ser una restricción de versiones válida")
+    text = value
+    clauses = text.split(",")
+    if not clauses or not all(
+        clause == clause.strip() and _VERSION_CONSTRAINT_RE.fullmatch(clause)
+        for clause in clauses
+    ):
+        raise ValueError(f"{field_name} debe ser una restricción de versiones válida")
+    return text
+
+
+def _namespace(value: Any, field_name: str) -> str:
+    text = _string(value, field_name)
+    if not all(_IDENTIFIER_RE.fullmatch(part) for part in text.split(".")):
+        raise ValueError(f"{field_name} debe ser un namespace válido")
+    return text
+
+
 def _path(value: Any, field_name: str) -> str:
     text = _string(value, field_name)
     parts = text.split("/")
@@ -103,6 +129,22 @@ def _enum_list(value: Any, field_name: str, allowed: frozenset[str]) -> tuple[st
             f"{field_name} contiene valores no soportados: {', '.join(sorted(invalid))}"
         )
     return values
+
+
+def _architectures(value: Any, field_name: str) -> tuple[str, ...]:
+    """Normaliza el alias histórico ``aarch64`` al valor contractual ``arm64``."""
+    values = _string_list(value, field_name)
+    allowed = SUPPORTED_ARCHITECTURES | {"aarch64"}
+    invalid = set(values) - allowed
+    if invalid:
+        raise ValueError(
+            f"{field_name} contiene valores no soportados: "
+            f"{', '.join(sorted(invalid))}"
+        )
+    normalized = tuple("arm64" if item == "aarch64" else item for item in values)
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(f"{field_name} no admite valores duplicados")
+    return normalized
 
 
 @dataclass(frozen=True)
@@ -128,10 +170,8 @@ class PackageDistribution:
                 "distribution.platforms",
                 SUPPORTED_PLATFORMS,
             ),
-            architectures=_enum_list(
-                data.get("architectures", ["any"]),
-                "distribution.architectures",
-                SUPPORTED_ARCHITECTURES,
+            architectures=_architectures(
+                data.get("architectures", ["any"]), "distribution.architectures"
             ),
         )
 
@@ -156,9 +196,7 @@ class PackageExtension:
     @classmethod
     def from_dict(cls, value: Any) -> "PackageExtension":
         data = _object(value, "extension")
-        namespace = _string(data.get("namespace"), "extension.namespace")
-        if not all(_IDENTIFIER_RE.fullmatch(part) for part in namespace.split(".")):
-            raise ValueError("extension.namespace inválido")
+        namespace = _namespace(data.get("namespace"), "extension.namespace")
         provider = _name(data.get("provider"), "extension.provider")
         capabilities = _string_list(data.get("capabilities"), "extension.capabilities")
         if not all(_NAME_RE.fullmatch(item) for item in capabilities):
@@ -222,11 +260,9 @@ class PackageManifestV2:
                 "files y checksums deben declarar exactamente las mismas rutas"
             )
         exports = tuple(
-            _path(item, "exports")
+            _namespace(item, "exports")
             for item in _string_list(data.get("exports"), "exports")
         )
-        if not set(exports) <= set(normalized_files):
-            raise ValueError("exports solo puede contener rutas declaradas en files")
         capabilities = _string_list(data.get("capabilities"), "capabilities")
         if not all(_NAME_RE.fullmatch(item) for item in capabilities):
             raise ValueError("capabilities contiene un nombre inválido")
@@ -248,15 +284,15 @@ class PackageManifestV2:
             name=_name(data.get("name")),
             version=_semver(data.get("version"), "version"),
             package_type=package_type,
-            requires_cobra=_semver(data.get("requires_cobra"), "requires_cobra"),
+            requires_cobra=_version_constraint(
+                data.get("requires_cobra"), "requires_cobra"
+            ),
             exports=exports,
             capabilities=capabilities,
             platforms=_enum_list(
                 data.get("platforms"), "platforms", SUPPORTED_PLATFORMS
             ),
-            architectures=_enum_list(
-                data.get("architectures"), "architectures", SUPPORTED_ARCHITECTURES
-            ),
+            architectures=_architectures(data.get("architectures"), "architectures"),
             dependencies=dependencies,
             distributions=distributions,
             extensions=tuple(

--- a/tests/unit/test_hub_manifest_v2.py
+++ b/tests/unit/test_hub_manifest_v2.py
@@ -25,11 +25,11 @@ def _manifest() -> dict:
         "name": "demo.extension",
         "version": "1.2.3-beta.1",
         "package_type": "extension",
-        "requires_cobra": "2.0.0",
-        "exports": ["dist/demo.whl"],
+        "requires_cobra": ">=10.1,<11",
+        "exports": ["cobra.demo", "cobra.demo.api"],
         "capabilities": ["transpiler.python"],
         "platforms": ["linux", "windows"],
-        "architectures": ["x86_64", "aarch64"],
+        "architectures": ["x86_64", "arm64"],
         "dependencies": {"cobra.std": "2.0.0"},
         "distributions": [
             {
@@ -77,12 +77,89 @@ def test_manifest_v2_modela_todos_los_campos_y_distribuciones_permitidas():
 
 
 @pytest.mark.parametrize(
+    "constraint",
+    ["10", "10.1", "10.1.0", ">=10.1,<11", ">=10.1.0,!=10.2.0,<11.0.0"],
+)
+def test_manifest_v2_acepta_restricciones_cobra_estaticas(constraint):
+    data = _manifest()
+    data["requires_cobra"] = constraint
+
+    assert manifest_v2_from_dict(data).requires_cobra == constraint
+
+
+@pytest.mark.parametrize(
+    "constraint",
+    ["", "v10.1", ">=10.1,", ">=10.1, <11", ">=10.*", "__import__('os')"],
+)
+def test_manifest_v2_rechaza_restricciones_cobra_invalidas(constraint):
+    data = _manifest()
+    data["requires_cobra"] = constraint
+
+    with pytest.raises(ValueError, match="restricción de versiones"):
+        manifest_v2_from_dict(data)
+
+
+@pytest.mark.parametrize("architecture", ["arm64", "aarch64"])
+def test_manifest_v2_normaliza_arm64_como_representacion_canonica(architecture):
+    data = _manifest()
+    data["architectures"] = [architecture]
+    data["distributions"][0]["architectures"] = [architecture]
+
+    manifest = manifest_v2_from_dict(data)
+
+    assert manifest.architectures == ("arm64",)
+    assert manifest.distributions[0].architectures == ("arm64",)
+    assert manifest.as_dict()["architectures"] == ["arm64"]
+
+
+def test_manifest_v2_exports_son_namespaces_y_no_rutas_de_files():
+    data = _manifest()
+    data["exports"] = ["cobra.demo.api", "cobra_demo.utilidades"]
+
+    manifest = manifest_v2_from_dict(data)
+
+    assert manifest.exports == ("cobra.demo.api", "cobra_demo.utilidades")
+
+
+@pytest.mark.parametrize("export", ["dist/demo.whl", ".cobra", "cobra..demo", "cobra-demo"])
+def test_manifest_v2_rechaza_exports_que_no_son_namespaces(export):
+    data = _manifest()
+    data["exports"] = [export]
+
+    with pytest.raises(ValueError, match="namespace"):
+        manifest_v2_from_dict(data)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("files", ["../demo.whl"]),
+        ("files", ["/dist/demo.whl"]),
+        ("checksums", {"../dist/demo.whl": "0" * 64}),
+    ],
+)
+def test_manifest_v2_rechaza_rutas_inseguras_de_archivos(field, value):
+    data = _manifest()
+    data[field] = value
+
+    with pytest.raises(ValueError, match="ruta insegura"):
+        manifest_v2_from_dict(data)
+
+
+def test_manifest_v2_rechaza_ruta_insegura_de_distribucion():
+    data = _manifest()
+    data["distributions"][0]["path"] = "../demo.whl"
+
+    with pytest.raises(ValueError, match="ruta insegura"):
+        manifest_v2_from_dict(data)
+
+
+@pytest.mark.parametrize(
     ("field", "value", "match"),
     [
         ("version", "v1.2.3", "SemVer"),
         ("platforms", ["plan9"], "no soportados"),
         ("architectures", ["mips"], "no soportados"),
-        ("files", ["../demo.whl"], "ruta insegura"),
         ("checksums", {"dist/demo.whl": "not-a-hash"}, "SHA-256"),
         ("extensions", [{}], "namespace"),
     ],


### PR DESCRIPTION
### Motivation
- Separar la validación de versiones exactas y las restricciones de compatibilidad para evitar ejecución o resolución de paquetes durante la validación del manifiesto.
- Normalizar y documentar la representación canónica de la arquitectura `arm64` manteniendo compatibilidad con el alias histórico `aarch64`.
- Tratar `exports` como namespaces (API) independientes de las rutas de `files` y mantener las comprobaciones de ruta solo para archivos y distribuciones.

### Description
- Añadido `_VERSION_CONSTRAINT_RE` y el validador `_version_constraint` para validar expresiones estáticas como `>=10.1,<11` sin ejecutar código, y preservado `_semver` para versiones exactas (`PackageManifestV2.version`).
- Introducido `_namespace` para validar `exports` como namespaces y eliminado la obligación de que cada `export` sea una entrada en `files` (ahora `exports` no se tratan como rutas).
- Añadido `_architectures` que acepta el alias `aarch64` y normaliza ambos a la representación canónica `arm64` en el manifiesto y en `PackageDistribution`.
- Conservadas las validaciones de rutas seguras mediante `_path` exclusivamente para `files`, claves de `checksums` y `PackageDistribution.path`.
- Cambios aplicados en `src/pcobra/cobra/hub/models.py` y pruebas dirigidas añadidas/actualizadas en `tests/unit/test_hub_manifest_v2.py` para cubrir contrato completo, restricciones válidas/ inválidas, `arm64`/`aarch64`, exports como namespaces y rutas inseguras.
- No se modificaron Lexer ni Parser ni ningún archivo bajo `src/pcobra/cobra/core/`.

### Testing
- Ejecutadas las pruebas específicas con `python -m pytest tests/unit/test_hub_manifest_v2.py -q` y todos los casos añadidos pasaron (34 passed).
- Ejecutadas suites relacionadas con `pytest` con `python -m pytest tests/unit/test_hub_import_boundaries.py tests/unit/test_hub_lockfile.py tests/unit/test_cobra_installer_dependency_resolver.py -q` y todas pasaron (24 passed).
- Ejecutado el chequeo estático con `python -m ruff check src/pcobra/cobra/hub/models.py tests/unit/test_hub_manifest_v2.py` y no reportó problemas.
- Verificada la ausencia de cambios en rutas prohibidas y la consistencia del diff con `git diff --check`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59f816fc048327858d66a802839602)