### PR TITLE
Desacoplar las excepciones de dominio de CobraHub

### DIFF
--- a/src/pcobra/cobra/hub/installation.py
+++ b/src/pcobra/cobra/hub/installation.py
@@ -9,12 +9,19 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from pcobra.cobra.hub.errors import (
+    CobraHubError,
+    PackageCompatibilityError,
+    PackageIntegrityError,
+    PackageNotFoundError,
+    PackageProviderError,
+    PackageResolutionError,
+)
 from pcobra.cobra.hub.repository import PackageRepository
 from pcobra.cobra.hub.cache import CobraInstallerCache
 from pcobra.cobra.hub.integrity import normalize_sha256, sha256_file
 from pcobra.cobra.hub.models import CobraHubResolution
 from pcobra.cobra.hub.providers.local import LocalArtifactProvider
-from pcobra.cobra_installer.project import CobraInstallerError
 from pcobra.cobra.packaging import (
     es_paquete_cobra,
     inspeccionar_paquete,
@@ -23,7 +30,7 @@ from pcobra.cobra.packaging import (
     validar_version_paquete,
 )
 
-__all__ = ["CobraInstallerError", "CobraHubResolution", "CobraHubResolver"]
+__all__ = ["CobraHubResolution", "CobraHubResolver"]
 
 
 class CobraHubResolver:
@@ -52,7 +59,10 @@ class CobraHubResolver:
         normalized_name = self._name(name)
         normalized_version = self._version(version, normalized_name)
         if expected_sha256:
-            expected_sha256 = normalize_sha256(expected_sha256)
+            try:
+                expected_sha256 = normalize_sha256(expected_sha256)
+            except ValueError as exc:
+                raise PackageIntegrityError(str(exc)) from exc
 
         if source and source not in {"installer-cache", "cobrahub", "cobrahub-cache"}:
             try:
@@ -63,8 +73,10 @@ class CobraHubResolver:
                     normalized_version,
                     expected_sha256=expected_sha256,
                 )
-            except Exception as exc:  # noqa: BLE001 - error de proveedor a CLI
-                raise CobraInstallerError(str(exc)) from exc
+            except CobraHubError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - frontera con proveedor externo
+                raise PackageProviderError(str(exc)) from exc
             return self._inspect_candidate(
                 artifact.path,
                 normalized_name,
@@ -94,15 +106,21 @@ class CobraHubResolver:
                 )
 
         if self.repository is None:
-            raise CobraInstallerError(
+            raise PackageNotFoundError(
                 f"Dependencia Cobra no encontrada en caché: {normalized_name}=={normalized_version}. "
                 "Configure CobraHub o precargue el paquete en la caché local."
             )
 
         try:
             downloaded = self.repository.download(normalized_name, normalized_version)
-        except Exception as exc:  # noqa: BLE001 - se traduce a error controlado
-            raise CobraInstallerError(
+        except CobraHubError:
+            raise
+        except FileNotFoundError as exc:
+            raise PackageNotFoundError(
+                f"No se encontró {normalized_name}=={normalized_version} en CobraHub: {exc}"
+            ) from exc
+        except Exception as exc:  # noqa: BLE001 - frontera con repositorio externo
+            raise PackageProviderError(
                 f"No se pudo descargar {normalized_name}=={normalized_version} desde CobraHub: {exc}"
             ) from exc
         return self._inspect_candidate(
@@ -130,8 +148,10 @@ class CobraHubResolver:
                 raise ValueError("el artefacto no es un paquete Cobra .co válido")
             validation = validar_paquete(path)
             inspection = inspeccionar_paquete(path)
-        except Exception as exc:  # noqa: BLE001 - se traduce a error controlado
-            raise CobraInstallerError(
+        except CobraHubError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - valida una distribución externa
+            raise PackageCompatibilityError(
                 f"Paquete Cobra inválido para {name}: {exc}"
             ) from exc
 
@@ -139,17 +159,17 @@ class CobraHubResolver:
         package_name = self._name(str(manifest.get("name", "")))
         package_version = self._version(str(manifest.get("version", "")), package_name)
         if package_name != name:
-            raise CobraInstallerError(
+            raise PackageCompatibilityError(
                 f"Paquete incorrecto: se esperaba {name}, pero el artefacto declara {package_name}."
             )
         if package_version != version:
-            raise CobraInstallerError(
+            raise PackageCompatibilityError(
                 f"Versión incorrecta para {name}: se esperaba {version}, pero el artefacto declara {package_version}."
             )
 
         digest = inspection.checksum or self._sha256_file(path)
         if expected_sha256 and digest.lower() != expected_sha256.lower():
-            raise CobraInstallerError(
+            raise PackageIntegrityError(
                 f"Hash inválido para {name}=={version}: se esperaba {expected_sha256}, se obtuvo {digest}."
             )
 
@@ -180,7 +200,7 @@ class CobraHubResolver:
         try:
             return normalizar_nombre_paquete(name)
         except ValueError as exc:
-            raise CobraInstallerError(
+            raise PackageResolutionError(
                 f"Nombre de paquete Cobra inválido: {name}"
             ) from exc
 
@@ -189,6 +209,6 @@ class CobraHubResolver:
         try:
             return validar_version_paquete(version)
         except ValueError as exc:
-            raise CobraInstallerError(
+            raise PackageResolutionError(
                 f"Versión inválida para {name}: {version}"
             ) from exc

--- a/src/pcobra/cobra/hub/resolver.py
+++ b/src/pcobra/cobra/hub/resolver.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from pcobra.cobra.packaging import normalizar_nombre_paquete, validar_version_paquete
+from pcobra.cobra.hub.errors import PackageResolutionError
 from pcobra.cobra.hub.installation import CobraHubResolver
 from pcobra.cobra.hub.lockfile import read_lockfile, write_lockfile
 from pcobra.cobra.hub.models import (
@@ -21,7 +22,6 @@ from pcobra.cobra.hub.models import (
     DependencyResolutionResult,
     LockedDependency,
 )
-from pcobra.cobra_installer.project import CobraInstallerError
 
 __all__ = [
     "CobraDependencyError",
@@ -36,7 +36,7 @@ __all__ = [
 ]
 
 
-class CobraDependencyError(CobraInstallerError):
+class CobraDependencyError(PackageResolutionError):
     """Error controlado de dependencias apto para CLI e IDLE."""
 
 

--- a/src/pcobra/cobra_installer/dependency_resolver.py
+++ b/src/pcobra/cobra_installer/dependency_resolver.py
@@ -8,16 +8,33 @@ from pcobra.cobra.hub.lockfile import (
     write_lockfile as _write_lockfile,
 )
 from pcobra.cobra.hub.models import CobraHubResolution, LockedDependency
+from pcobra.cobra.hub.errors import CobraHubError
+from pcobra.cobra_installer.project import CobraInstallerError
 
 from pcobra.cobra.hub.resolver import (
-    CobraDependencyError,
+    CobraDependencyError as _HubDependencyError,
     DeclaredDependency,
     DependencyResolutionResult,
     LockedDependency,
     detect_cobra_imports,
     read_declared_dependencies,
-    resolve_project_dependencies,
+    resolve_project_dependencies as _resolve_project_dependencies,
 )
+
+
+class CobraDependencyError(CobraInstallerError):
+    """Excepción histórica de resolución expuesta por CobraInstaller."""
+
+
+def resolve_project_dependencies(*args, **kwargs):
+    """Traduce los fallos de dominio para preservar la API del Installer."""
+
+    try:
+        return _resolve_project_dependencies(*args, **kwargs)
+    except _HubDependencyError as exc:
+        raise CobraDependencyError(str(exc)) from exc
+    except CobraHubError as exc:
+        raise CobraInstallerError(str(exc)) from exc
 
 
 def read_lockfile(path: str | Path) -> dict[str, LockedDependency]:

--- a/src/pcobra/cobra_installer/hub_resolver.py
+++ b/src/pcobra/cobra_installer/hub_resolver.py
@@ -1,6 +1,18 @@
 """Adaptador compatible del resolvedor de instalación CobraHub."""
 
-from pcobra.cobra.hub.installation import CobraHubResolver, CobraInstallerError
+from pcobra.cobra.hub.errors import CobraHubError
+from pcobra.cobra.hub.installation import CobraHubResolver as _HubResolver
 from pcobra.cobra.hub.models import CobraHubResolution
+from pcobra.cobra_installer.project import CobraInstallerError
+
+
+class CobraHubResolver(_HubResolver):
+    """Mantiene la excepción pública esperada por consumidores del Installer."""
+
+    def resolve(self, *args, **kwargs):
+        try:
+            return super().resolve(*args, **kwargs)
+        except CobraHubError as exc:
+            raise CobraInstallerError(str(exc)) from exc
 
 __all__ = ["CobraInstallerError", "CobraHubResolution", "CobraHubResolver"]

--- a/tests/unit/test_cobra_installer_dependency_resolver.py
+++ b/tests/unit/test_cobra_installer_dependency_resolver.py
@@ -185,6 +185,19 @@ def test_falla_si_import_no_esta_declarado(tmp_path):
         )
 
 
+def test_adaptador_historico_conserva_error_publico_de_dependencias(tmp_path):
+    from pcobra.cobra_installer.project import CobraInstallerError as PublicError
+
+    (tmp_path / "cobra.toml").write_text("", encoding="utf-8")
+    (tmp_path / "main.cobra").write_text("usar dep.modulo\n", encoding="utf-8")
+
+    with pytest.raises(CobraDependencyError) as exc_info:
+        resolve_project_dependencies(tmp_path)
+
+    assert isinstance(exc_info.value, PublicError)
+    assert exc_info.value.__cause__.__class__.__name__ == "CobraDependencyError"
+
+
 def test_falla_hash_de_lock(tmp_path):
     package = _package(tmp_path, name="dep", version="1.2.3")
     cache = tmp_path / "cache"

--- a/tests/unit/test_cobra_installer_hub_resolver.py
+++ b/tests/unit/test_cobra_installer_hub_resolver.py
@@ -5,6 +5,7 @@ import pytest
 from pcobra.cobra.hub.repository import DownloadedPackage
 from pcobra.cobra.packaging import construir_paquete
 from pcobra.cobra_installer.hub_resolver import CobraHubResolver
+from pcobra.cobra_installer.project import CobraInstallerError
 
 
 def _package(tmp_path, name="dep", version="1.2.3", dependencies=None):
@@ -181,3 +182,12 @@ def test_hub_resolver_reutiliza_cache_con_repo_configurado_sin_descargar(tmp_pat
     assert result.sha256 == expected_hash
     assert result.path == cached
     assert result.source == "installer-cache"
+
+
+def test_adaptador_historico_traduce_error_hub_a_error_installer(tmp_path):
+    resolver = CobraHubResolver(cache_dir=tmp_path / "cache")
+
+    with pytest.raises(CobraInstallerError, match="no encontrada") as exc_info:
+        resolver.resolve("inexistente", "1.0.0")
+
+    assert exc_info.value.__cause__.__class__.__name__ == "PackageNotFoundError"

--- a/tests/unit/test_hub_import_boundaries.py
+++ b/tests/unit/test_hub_import_boundaries.py
@@ -6,11 +6,13 @@ import pkgutil
 from pathlib import Path
 
 import pcobra.cobra.hub as hub
+from pcobra.cobra.hub.errors import PackageResolutionError
+from pcobra.cobra.hub.resolver import CobraDependencyError
 
 
-def test_hub_no_importa_cli_ni_gui():
-    """Todos los módulos de Hub deben poder evolucionar sin depender de las UI."""
-    prohibidos = ("pcobra.cobra.cli", "pcobra.gui")
+def test_hub_no_importa_installer_cli_ni_gui():
+    """Hub debe poder evolucionar sin depender de Installer ni presentación."""
+    prohibidos = ("pcobra.cobra_installer", "pcobra.cobra.cli", "pcobra.gui")
     for module_info in pkgutil.walk_packages(hub.__path__, f"{hub.__name__}."):
         module = importlib.import_module(module_info.name)
         source = Path(module.__file__).read_text(encoding="utf-8")
@@ -36,3 +38,7 @@ def test_hub_conserva_exports_publicos_del_repositorio():
     assert hub.PackageRepository
     assert hub.HttpCobraHubRepository
     assert hub.DownloadedPackage
+
+
+def test_error_de_dependencias_pertenece_al_dominio_hub():
+    assert issubclass(CobraDependencyError, PackageResolutionError)


### PR DESCRIPTION
### Motivation

- Separar el dominio de errores de `pcobra.cobra.hub` del instalador para tipificar fallos de resolución de paquetes con excepciones específicas de Hub.
- Mantener compatibilidad pública con los consumidores históricos del instalador traduciendo las excepciones de Hub a `CobraInstallerError`/`CobraDependencyError` únicamente en los adaptadores legados.

### Description

- Reemplacé el uso de `CobraInstallerError` dentro del núcleo Hub por las excepciones de dominio definidas en `src/pcobra/cobra/hub/errors.py` y ajusté las firmas públicas; `CobraDependencyError` ahora deriva de `PackageResolutionError`. (archivos modificados: `src/pcobra/cobra/hub/resolver.py`, `src/pcobra/cobra/hub/installation.py`).
- Clasifiqué los fallos del resolvedor como: `PackageProviderError` (errores de transporte/repositorio), `PackageNotFoundError` (paquetes ausentes), `PackageIntegrityError` (hashes inválidos), `PackageResolutionError` (conflictos/nombre/version) y `PackageCompatibilityError` (artefactos/distribuciones incompatibles). (ver `src/pcobra/cobra/hub/installation.py`).
- Conservé y amplié los adaptadores históricos en `src/pcobra/cobra_installer/hub_resolver.py` y `src/pcobra/cobra_installer/dependency_resolver.py` para traducir las excepciones Hub a la excepción pública del Installer cuando la compatibilidad lo requiere.
- Amplié pruebas de frontera y compatibilidad: prohibí imports desde `pcobra.cobra_installer` dentro de `pcobra.cobra.hub` y añadí regresiones que verifican la traducción de excepciones en los adaptadores. (archivos modificados: `tests/unit/test_hub_import_boundaries.py`, `tests/unit/test_cobra_installer_hub_resolver.py`, `tests/unit/test_cobra_installer_dependency_resolver.py`).
- No se cambiaron Lexer ni Parser ni se introdujo sintaxis nueva; cambios limitados y relacionados con el hallazgo de errores de dominio.

### Testing

- `pytest -q tests/unit/test_hub_import_boundaries.py tests/unit/test_cobra_installer_hub_resolver.py tests/unit/test_cobra_installer_dependency_resolver.py` — todos los tests de esas suites pasaron (20 passed, 1 warning). 
- `pytest -q tests/unit/test_hub_*.py tests/unit/test_cobra_installer_transpile.py` — suite relacionada pasada (77 passed, 1 warning).
- `ruff check` sobre los archivos modificados — comprobaciones estáticas pasadas.
- `git diff --check` y verificación explícita de que no se modificaron `lexer.py` ni `parser.py` — OK.
- Commit creado: `Desacopla errores de dominio de CobraHub` y pull request registrado con título "Desacoplar las excepciones de dominio de CobraHub".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59f9ac308c832790fedc65e46cbfca)