### PR TITLE
feat(hub): support cobra-package-v2 manifests and serialize normalized lockfile metadata

### DIFF
--- a/src/pcobra/cobra/hub/installation.py
+++ b/src/pcobra/cobra/hub/installation.py
@@ -20,7 +20,12 @@ from pcobra.cobra.hub.errors import (
 from pcobra.cobra.hub.repository import PackageRepository
 from pcobra.cobra.hub.cache import CobraInstallerCache
 from pcobra.cobra.hub.integrity import normalize_sha256, sha256_file
-from pcobra.cobra.hub.models import CobraHubResolution
+from pcobra.cobra.hub.models import (
+    PACKAGE_FORMAT_V2,
+    CobraHubResolution,
+    PackageDistribution,
+    manifest_v2_from_dict,
+)
 from pcobra.cobra.hub.providers.local import LocalArtifactProvider
 from pcobra.cobra.packaging import (
     es_paquete_cobra,
@@ -53,6 +58,8 @@ class CobraHubResolver:
         *,
         expected_sha256: str | None = None,
         source: str | None = None,
+        platform: str = "any",
+        architecture: str = "any",
     ) -> CobraHubResolution:
         """Localiza/descarga ``name`` y valida versión, formato e integridad."""
 
@@ -83,6 +90,8 @@ class CobraHubResolver:
                 normalized_version,
                 expected_sha256=expected_sha256,
                 source=str(Path(source).expanduser().resolve()),
+                platform=platform,
+                architecture=architecture,
             )
 
         candidates: list[Path] = []
@@ -103,6 +112,8 @@ class CobraHubResolver:
                     normalized_version,
                     expected_sha256=expected_sha256,
                     source=cache_entry.source if cache_entry else str(candidate),
+                    platform=platform,
+                    architecture=architecture,
                 )
 
         if self.repository is None:
@@ -129,6 +140,8 @@ class CobraHubResolver:
             normalized_version,
             expected_sha256=expected_sha256 or downloaded.checksum,
             source="cobrahub",
+            platform=platform,
+            architecture=architecture,
         )
 
     def _cache_candidates(self, name: str, version: str) -> list[Path]:
@@ -142,6 +155,8 @@ class CobraHubResolver:
         *,
         expected_sha256: str | None,
         source: str,
+        platform: str = "any",
+        architecture: str = "any",
     ) -> CobraHubResolution:
         try:
             if not es_paquete_cobra(path):
@@ -184,6 +199,36 @@ class CobraHubResolver:
             if isinstance(raw_deps, dict)
             else {}
         )
+        metadata: dict[str, Any] = {}
+        if manifest.get("format") == PACKAGE_FORMAT_V2:
+            try:
+                manifest_v2 = manifest_v2_from_dict(manifest)
+                distribution = self._select_distribution(
+                    manifest_v2.distributions, platform, architecture
+                )
+            except PackageCompatibilityError:
+                raise
+            except (TypeError, ValueError) as exc:
+                raise PackageCompatibilityError(
+                    f"Manifiesto v2 incompatible para {name}: {exc}"
+                ) from exc
+            if distribution.type != "cobra-package":
+                raise PackageCompatibilityError(
+                    f"La distribución compatible de {name} es de tipo "
+                    f"{distribution.type!r}; este tipo todavía no es instalable."
+                )
+            metadata = {
+                "package_type": manifest_v2.package_type,
+                "requires_cobra": manifest_v2.requires_cobra,
+                "exports": list(manifest_v2.exports),
+                "capabilities": list(manifest_v2.capabilities),
+                "extensions": [item.as_dict() for item in manifest_v2.extensions],
+                "platforms": list(manifest_v2.platforms),
+                "architectures": list(manifest_v2.architectures),
+                "distributions": [item.as_dict() for item in manifest_v2.distributions],
+                "artifact_type": distribution.type,
+                "artifact": distribution.path,
+            }
         return CobraHubResolution(
             name=package_name,
             version=package_version,
@@ -191,7 +236,37 @@ class CobraHubResolver:
             sha256=digest,
             source=source,
             dependencies=dependencies,
+            metadata=metadata,
         )
+
+    @staticmethod
+    def _select_distribution(
+        distributions: tuple[PackageDistribution, ...],
+        platform: str,
+        architecture: str,
+    ) -> PackageDistribution:
+        """Elige el primer artefacto compatible sin cargar ni ejecutar su código."""
+
+        compatible = [
+            item
+            for item in distributions
+            if (
+                platform == "any"
+                or "any" in item.platforms
+                or platform in item.platforms
+            )
+            and (
+                architecture == "any"
+                or "any" in item.architectures
+                or architecture in item.architectures
+            )
+        ]
+        if not compatible:
+            raise PackageCompatibilityError(
+                "No hay una distribución compatible con la plataforma "
+                f"{platform!r} y la arquitectura {architecture!r}."
+        )
+        return compatible[0]
 
     _sha256_file = staticmethod(sha256_file)
 

--- a/src/pcobra/cobra/hub/lockfile.py
+++ b/src/pcobra/cobra/hub/lockfile.py
@@ -40,6 +40,7 @@ class LockfileEntryV2(LockfileEntryV1):
     """Entrada v2 autocontenida, apta para resolución offline."""
 
     package_type: str | None = None
+    requires_cobra: str | None = None
     artifact_type: str | None = None
     artifact: str | None = None
     exports: tuple[str, ...] = ()
@@ -47,6 +48,7 @@ class LockfileEntryV2(LockfileEntryV1):
     extensions: tuple[Mapping[str, Any], ...] = ()
     platforms: tuple[str, ...] = ()
     architectures: tuple[str, ...] = ()
+    distributions: tuple[Mapping[str, Any], ...] = ()
     dependencies: Mapping[str, str] = field(default_factory=dict)
 
 
@@ -96,7 +98,9 @@ def write_lockfile(
     """Escribe JSON determinista; ``version=1`` habilita compatibilidad legacy."""
 
     if type(version) is not int or version not in _KNOWN_VERSIONS:
-        raise PackageResolutionError(f"Versión de cobra.lock no soportada: {version!r}.")
+        raise PackageResolutionError(
+            f"Versión de cobra.lock no soportada: {version!r}."
+        )
     entries = [_entry_from_resolution(item, version) for item in resolved.values()]
     entries.sort(key=_sort_key)
     payload = {"version": version, "packages": [_entry_dict(item) for item in entries]}
@@ -158,6 +162,9 @@ def _parse_entry(raw: Any, version: int, base_dir: Path) -> LockfileEntryV1:
             source=source,
             sha256=sha256,
             package_type=_optional_string(raw.get("package_type"), "package_type"),
+            requires_cobra=_optional_string(
+                raw.get("requires_cobra"), "requires_cobra"
+            ),
             artifact_type=_optional_string(raw.get("artifact_type"), "artifact_type"),
             artifact=_optional_string(raw.get("artifact"), "artifact"),
             exports=_string_tuple(raw.get("exports", []), "exports"),
@@ -165,6 +172,7 @@ def _parse_entry(raw: Any, version: int, base_dir: Path) -> LockfileEntryV1:
             extensions=_mapping_tuple(raw.get("extensions", []), "extensions"),
             platforms=_string_tuple(raw.get("platforms", []), "platforms"),
             architectures=_string_tuple(raw.get("architectures", []), "architectures"),
+            distributions=_mapping_tuple(raw.get("distributions", []), "distributions"),
             dependencies=_dependencies(raw.get("dependencies", {})),
         )
     except (TypeError, ValueError) as exc:
@@ -199,7 +207,9 @@ def _string_tuple(value: Any, field_name: str) -> tuple[str, ...]:
 
 
 def _mapping_tuple(value: Any, field_name: str) -> tuple[Mapping[str, Any], ...]:
-    if not isinstance(value, list) or not all(isinstance(item, Mapping) for item in value):
+    if not isinstance(value, list) or not all(
+        isinstance(item, Mapping) for item in value
+    ):
         raise ValueError(f"{field_name} debe ser una lista de tablas")
     return tuple(dict(item) for item in value)
 
@@ -210,8 +220,12 @@ def _dependencies(value: Any) -> dict[str, str]:
     result: dict[str, str] = {}
     for raw_name, raw_version in value.items():
         if not isinstance(raw_name, str) or not isinstance(raw_version, str):
-            raise ValueError("dependencies debe relacionar nombres y versiones de texto")
-        result[normalizar_nombre_paquete(raw_name)] = validar_version_paquete(raw_version)
+            raise ValueError(
+                "dependencies debe relacionar nombres y versiones de texto"
+            )
+        result[normalizar_nombre_paquete(raw_name)] = validar_version_paquete(
+            raw_version
+        )
     return result
 
 
@@ -222,22 +236,30 @@ def _resolve_source(source: str | None, base_dir: Path) -> str | None:
     return str((path if path.is_absolute() else base_dir / path).resolve())
 
 
-def _entry_from_resolution(item: CobraHubResolution | LockedDependency, version: int) -> LockfileEntryV1:
+def _entry_from_resolution(
+    item: CobraHubResolution | LockedDependency, version: int
+) -> LockfileEntryV1:
     metadata = dict(item.metadata)
-    common = dict(name=item.name, version=item.version, source=item.source, sha256=item.sha256)
+    common = dict(
+        name=item.name, version=item.version, source=item.source, sha256=item.sha256
+    )
     if version == LOCKFILE_V1:
         return LockfileEntryV1(**common)
     return LockfileEntryV2(
         **common,
         package_type=metadata.get("package_type"),
+        requires_cobra=metadata.get("requires_cobra"),
         artifact_type=metadata.get("artifact_type"),
         artifact=metadata.get("artifact") or str(getattr(item, "path", "")) or None,
         exports=tuple(metadata.get("exports", ())),
         capabilities=tuple(metadata.get("capabilities", ())),
         extensions=tuple(metadata.get("extensions", ())),
-        platforms=tuple(metadata.get("platforms", metadata.get("platform", ()))),
-        architectures=tuple(metadata.get("architectures", metadata.get("architecture", ()))),
-        dependencies=dict(getattr(item, "dependencies", metadata.get("dependencies", {}))),
+        platforms=tuple(metadata.get("platforms", ())),
+        architectures=tuple(metadata.get("architectures", ())),
+        distributions=tuple(metadata.get("distributions", ())),
+        dependencies=dict(
+            getattr(item, "dependencies", metadata.get("dependencies", {}))
+        ),
     )
 
 
@@ -248,26 +270,36 @@ def _entry_dict(entry: LockfileEntryV1) -> dict[str, Any]:
         if value is not None:
             data[key] = value
     if isinstance(entry, LockfileEntryV2):
-        for key in ("package_type", "artifact_type", "artifact"):
+        for key in ("package_type", "requires_cobra", "artifact_type", "artifact"):
             value = getattr(entry, key)
             if value is not None:
                 data[key] = value
         data.update(
-            exports=list(entry.exports), capabilities=list(entry.capabilities),
+            exports=list(entry.exports),
+            capabilities=list(entry.capabilities),
             extensions=[dict(item) for item in entry.extensions],
-            platforms=list(entry.platforms), architectures=list(entry.architectures),
+            platforms=list(entry.platforms),
+            architectures=list(entry.architectures),
             dependencies=dict(sorted(entry.dependencies.items())),
         )
+        if entry.distributions:
+            data["distributions"] = [dict(item) for item in entry.distributions]
     return data
 
 
 def _v2_metadata(entry: LockfileEntryV2) -> dict[str, Any]:
-    return {key: value for key, value in _entry_dict(entry).items() if key not in {"name", "version", "source", "sha256"}}
+    return {
+        key: value
+        for key, value in _entry_dict(entry).items()
+        if key not in {"name", "version", "source", "sha256"}
+    }
 
 
 def _sort_key(entry: LockfileEntryV1) -> tuple[str, ...]:
     return (
-        entry.name, entry.version, entry.source or "",
+        entry.name,
+        entry.version,
+        entry.source or "",
         getattr(entry, "package_type", None) or "",
         getattr(entry, "artifact_type", None) or "",
         getattr(entry, "artifact", None) or "",
@@ -275,6 +307,10 @@ def _sort_key(entry: LockfileEntryV1) -> tuple[str, ...]:
 
 
 __all__ = [
-    "LOCKFILE_V1", "LOCKFILE_V2", "LockfileEntryV1", "LockfileEntryV2",
-    "read_lockfile", "write_lockfile",
+    "LOCKFILE_V1",
+    "LOCKFILE_V2",
+    "LockfileEntryV1",
+    "LockfileEntryV2",
+    "read_lockfile",
+    "write_lockfile",
 ]

--- a/tests/unit/test_cobra_installer_hub_resolver.py
+++ b/tests/unit/test_cobra_installer_hub_resolver.py
@@ -1,4 +1,6 @@
 import json
+import hashlib
+import zipfile
 
 import pytest
 
@@ -23,6 +25,46 @@ def _package(tmp_path, name="dep", version="1.2.3", dependencies=None):
         manifest["dependencies"] = dependencies
     (root / "cobra.pkg.json").write_text(json.dumps(manifest), encoding="utf-8")
     return construir_paquete(root)
+
+
+def _package_v2(tmp_path, distribution_type="cobra-package"):
+    package = tmp_path / f"dep-v2-{distribution_type}.co"
+    artifact = b"contenido estatico"
+    artifact_path = "dist/dep.co"
+    manifest = {
+        "format": "cobra-package-v2",
+        "name": "dep-v2",
+        "version": "2.1.0",
+        "package_type": "library",
+        "requires_cobra": ">=10.0,<11",
+        "exports": ["dep.api"],
+        "capabilities": ["net"],
+        "platforms": ["linux"],
+        "architectures": ["x86_64"],
+        "dependencies": {"base": "1.0.0"},
+        "distributions": [
+            {
+                "type": distribution_type,
+                "path": artifact_path,
+                "platforms": ["linux"],
+                "architectures": ["x86_64"],
+            }
+        ],
+        "extensions": [
+            {
+                "namespace": "cobra.extensions",
+                "provider": "dep-provider",
+                "capabilities": ["net"],
+                "entrypoint": "malicious.module:run",
+            }
+        ],
+        "files": [artifact_path],
+        "checksums": {artifact_path: hashlib.sha256(artifact).hexdigest()},
+    }
+    with zipfile.ZipFile(package, "w") as archive:
+        archive.writestr("cobra.pkg.json", json.dumps(manifest))
+        archive.writestr(artifact_path, artifact)
+    return package
 
 
 class FakeCobraHubRepository:
@@ -56,6 +98,93 @@ def test_hub_resolver_devuelve_paquete_cacheado_con_hash_ruta_y_origen(tmp_path)
     assert result.sha256 == expected_hash
     assert result.path == cached
     assert result.source == "installer-cache"
+
+
+def test_hub_resolver_v2_selecciona_cobra_package_y_normaliza_metadata(
+    tmp_path, monkeypatch
+):
+    imported = []
+    original_import = __import__
+    monkeypatch.setattr(
+        "builtins.__import__",
+        lambda name, *args, **kwargs: (
+            imported.append(name) or original_import(name, *args, **kwargs)
+        ),
+    )
+    package = _package_v2(tmp_path)
+
+    result = CobraHubResolver(cache_dir=tmp_path / "cache").resolve(
+        "dep-v2",
+        "2.1.0",
+        source=str(package),
+        platform="linux",
+        architecture="x86_64",
+    )
+
+    assert result.dependencies == {"base": "1.0.0"}
+    assert result.metadata == {
+        "package_type": "library",
+        "requires_cobra": ">=10.0,<11",
+        "exports": ["dep.api"],
+        "capabilities": ["net"],
+        "extensions": [
+            {
+                "namespace": "cobra.extensions",
+                "provider": "dep-provider",
+                "capabilities": ["net"],
+                "entrypoint": "malicious.module:run",
+            }
+        ],
+        "platforms": ["linux"],
+        "architectures": ["x86_64"],
+        "distributions": [
+            {
+                "type": "cobra-package",
+                "path": "dist/dep.co",
+                "platforms": ["linux"],
+                "architectures": ["x86_64"],
+            }
+        ],
+        "artifact_type": "cobra-package",
+        "artifact": "dist/dep.co",
+    }
+    assert "malicious.module" not in imported
+
+
+@pytest.mark.parametrize(
+    "distribution_type",
+    [
+        "python-wheel",
+        "python-sdist",
+        "javascript-package",
+        "rust-binary",
+        "wasm",
+        "native-binary",
+    ],
+)
+def test_hub_resolver_rechaza_distribuciones_aun_no_instalables(
+    tmp_path, distribution_type
+):
+    package = _package_v2(tmp_path, distribution_type)
+    with pytest.raises(
+        CobraInstallerError, match=f"{distribution_type!r}.*no es instalable"
+    ):
+        CobraHubResolver(cache_dir=tmp_path / "cache").resolve(
+            "dep-v2",
+            "2.1.0",
+            source=str(package),
+            platform="linux",
+            architecture="x86_64",
+        )
+
+
+def test_hub_resolver_v1_conserva_resultado_historico_sin_metadata(tmp_path):
+    package = _package(tmp_path)
+    result = CobraHubResolver(cache_dir=tmp_path / "cache").resolve(
+        "dep", "1.2.3", source=str(package)
+    )
+    assert result.metadata == {}
+    assert result.dependencies == {}
 
 
 def test_hub_resolver_descarga_desde_repositorio_mock_sin_red(tmp_path):

--- a/tests/unit/test_hub_lockfile.py
+++ b/tests/unit/test_hub_lockfile.py
@@ -35,14 +35,23 @@ def test_snapshot_v2_conserva_metadatos_y_lectura_offline(tmp_path):
         json.dumps(
             {
                 "version": 2,
-                "packages": [{
-                    "name": "demo", "version": "1.0.0", "source": "cobrahub-cache",
-                    "sha256": HASH, "package_type": "library", "artifact_type": "co",
-                    "artifact": "demo.co", "exports": ["demo.api"],
-                    "capabilities": ["net"], "extensions": [{"name": "plug"}],
-                    "platforms": ["linux"], "architectures": ["x86_64"],
+                "packages": [
+                    {
+                        "name": "demo",
+                        "version": "1.0.0",
+                        "source": "cobrahub-cache",
+                        "sha256": HASH,
+                        "package_type": "library",
+                        "artifact_type": "co",
+                        "artifact": "demo.co",
+                        "exports": ["demo.api"],
+                        "capabilities": ["net"],
+                        "extensions": [{"name": "plug"}],
+                        "platforms": ["linux"],
+                        "architectures": ["x86_64"],
                     "dependencies": {"base": "2.0.0"},
-                }],
+                    }
+                ],
             }
         ),
         encoding="utf-8",
@@ -51,10 +60,15 @@ def test_snapshot_v2_conserva_metadatos_y_lectura_offline(tmp_path):
     entry = read_lockfile(path)["demo"]
     assert entry.source == "cobrahub-cache"
     assert entry.metadata == {
-        "package_type": "library", "artifact_type": "co", "artifact": "demo.co",
-        "exports": ["demo.api"], "capabilities": ["net"],
-        "extensions": [{"name": "plug"}], "platforms": ["linux"],
-        "architectures": ["x86_64"], "dependencies": {"base": "2.0.0"},
+        "package_type": "library",
+        "artifact_type": "co",
+        "artifact": "demo.co",
+        "exports": ["demo.api"],
+        "capabilities": ["net"],
+        "extensions": [{"name": "plug"}],
+        "platforms": ["linux"],
+        "architectures": ["x86_64"],
+        "dependencies": {"base": "2.0.0"},
     }
 
 
@@ -73,17 +87,66 @@ def test_reserializacion_v2_es_determinista(tmp_path):
     assert [item["name"] for item in json.loads(first)["packages"]] == ["a", "z"]
 
 
+def test_lockfile_v2_serializa_solo_metadata_normalizada_y_permite_lectura_offline(
+    tmp_path,
+):
+    path = tmp_path / "cobra.lock"
+    entry = LockedDependency(
+        "demo",
+        "1.0.0",
+        HASH,
+        "cobrahub",
+        metadata={
+            "package_type": "library",
+            "requires_cobra": ">=10,<11",
+            "artifact_type": "cobra-package",
+            "artifact": "dist/demo.co",
+            "exports": ["demo.api"],
+            "capabilities": ["net"],
+            "extensions": [],
+            "platforms": ["linux"],
+            "architectures": ["x86_64"],
+            "distributions": [
+                {
+                    "type": "cobra-package",
+                    "path": "dist/demo.co",
+                    "platforms": ["linux"],
+                    "architectures": ["x86_64"],
+                }
+            ],
+            "dependencies": {"base": "2.0.0"},
+            "campo_interno": "no serializar",
+        },
+    )
+    write_lockfile(path, {"demo": entry})
+
+    payload = json.loads(path.read_text())
+    assert "campo_interno" not in payload["packages"][0]
+    offline = read_lockfile(path)["demo"]
+    assert offline.metadata["artifact"] == "dist/demo.co"
+    assert offline.metadata["requires_cobra"] == ">=10,<11"
+    assert offline.metadata["distributions"][0]["type"] == "cobra-package"
+
+
 @pytest.mark.parametrize(
     "payload, message",
     [
         ({"version": 3, "packages": []}, "no soportada"),
         ({"version": 2, "other": []}, "packages"),
-        ({"version": 2, "packages": [{"name": "x", "version": "1.0.0", "sha256": "bad"}]}, "sha256"),
+        (
+            {
+                "version": 2,
+                "packages": [{"name": "x", "version": "1.0.0", "sha256": "bad"}],
+            },
+            "sha256",
+        ),
         ({"version": 2, "packages": [{"name": "x", "version": 1}]}, "version"),
         ({"version": 2, "packages": [{"version": "1.0.0"}]}, "name"),
     ],
 )
-def test_rechaza_esquema_futuro_estructura_y_campos_invalidos(tmp_path, payload, message):
+def test_rechaza_esquema_futuro_estructura_y_campos_invalidos(
+    tmp_path, payload, message
+):
     path = tmp_path / "cobra.lock"
     path.write_text(json.dumps(payload), encoding="utf-8")
     with pytest.raises(PackageResolutionError, match=message):
@@ -92,10 +155,15 @@ def test_rechaza_esquema_futuro_estructura_y_campos_invalidos(tmp_path, payload,
 
 def test_rechaza_duplicados_despues_de_normalizar(tmp_path):
     path = tmp_path / "cobra.lock"
-    path.write_text(json.dumps([
+    path.write_text(
+        json.dumps(
+            [
         {"name": "Demo_Pkg", "version": "1.0.0"},
         {"name": "demo_pkg", "version": "1.0.0"},
-    ]), encoding="utf-8")
+            ]
+        ),
+        encoding="utf-8",
+    )
 
     with pytest.raises(PackageResolutionError, match="duplicado"):
         read_lockfile(path)

--- a/tests/unit/test_hub_manifest_v2.py
+++ b/tests/unit/test_hub_manifest_v2.py
@@ -110,6 +110,7 @@ def test_manifest_v2_normaliza_arm64_como_representacion_canonica(architecture):
     assert manifest.architectures == ("arm64",)
     assert manifest.distributions[0].architectures == ("arm64",)
     assert manifest.as_dict()["architectures"] == ["arm64"]
+    assert manifest.as_dict()["distributions"][0]["architectures"] == ["arm64"]
 
 
 def test_manifest_v2_exports_son_namespaces_y_no_rutas_de_files():
@@ -121,7 +122,9 @@ def test_manifest_v2_exports_son_namespaces_y_no_rutas_de_files():
     assert manifest.exports == ("cobra.demo.api", "cobra_demo.utilidades")
 
 
-@pytest.mark.parametrize("export", ["dist/demo.whl", ".cobra", "cobra..demo", "cobra-demo"])
+@pytest.mark.parametrize(
+    "export", ["dist/demo.whl", ".cobra", "cobra..demo", "cobra-demo"]
+)
 def test_manifest_v2_rechaza_exports_que_no_son_namespaces(export):
     data = _manifest()
     data["exports"] = [export]


### PR DESCRIPTION
### Motivation

- Detectar y exponer metadatos de manifiestos `cobra-package-v2` durante la inspección para permitir resolución offline y selección estática de distribuciones compatibles.
- Mantener intacto el flujo histórico v1 y su serialización, evitando romper compatibilidad con los snapshots existentes.
- Rechazar explícitamente tipos de distribución aún no instalables para evitar intentar instalaciones inseguras o incompletas.
- Serializar en `cobra.lock` solo los metadatos normalizados de v2 en orden determinista para permitir lectura offline y reproducibilidad.

### Description

- Añadida la propagación de `platform` y `architecture` a `CobraHubResolver.resolve()` y `_inspect_candidate()` para permitir selección estática de distribución compatible en `src/pcobra/cobra/hub/installation.py`.
- Implementada detección de `cobra-package-v2`, validación del manifiesto v2 mediante `manifest_v2_from_dict`, y copia normalizada de campos (`package_type`, `requires_cobra`, `exports`, `capabilities`, `extensions`, `platforms`, `architectures`, `distributions`) a `CobraHubResolution.metadata`; también se incluyen `artifact_type` y `artifact` de la distribución seleccionada.
- Añadida función determinista `_select_distribution()` que elige la primera distribución compatible con la `platform`/`architecture` solicitadas sin ejecutar entrypoints y soportando el comodín `any`.
- El flujo `.co` admite `cobra-package` como distribución instalable y se lanza `PackageCompatibilityError` con mensajes claros para wheels, sdists, JavaScript, Rust, WASM y binarios nativos todavía no instalables.
- Ajustado `src/pcobra/cobra/hub/lockfile.py` para extender el esquema v2 con `requires_cobra` y `distributions`, serializar únicamente los metadatos normalizados y mantener un orden determinista, además de preservar el `artifact` histórico en entradas v1 cuando procede.
- Añadidas pruebas unitarias en `tests/unit/test_hub_manifest_v2.py`, `tests/unit/test_hub_lockfile.py` y `tests/unit/test_cobra_installer_hub_resolver.py` que cubren paquete v2 → resolución → lockfile → lectura offline, rechazo de formatos no instalables y regresión v1.
- No se modificaron Lexer ni Parser y los cambios son mínimos y focalizados en resolver el hallazgo de metadatos v2.

### Testing

- Ejecutadas pruebas dirigidas con `python -m pytest -q tests/unit/test_hub_manifest_v2.py tests/unit/test_hub_lockfile.py tests/unit/test_cobra_installer_hub_resolver.py` y todas pasaron (59 passed).
- Ejecutadas suites relacionadas con el resolvedor e integraciones locales con `python -m pytest -q tests/unit/test_hub_*.py tests/unit/test_cobra_installer_dependency_resolver.py tests/unit/test_cobra_installer_hub_resolver.py` y pasaron (97 passed); linters de formato/estilo con `ruff` también pasaron.
- Ejecución de la suite completa `python -m pytest -q` alcanzó 544 pruebas superadas y 8 omitidas pero se detuvo por 5 fallos en tests de integración/REPL no relacionados con las modificaciones realizadas; las pruebas unitarias y las suites directamente afectadas por este cambio pasan completamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59fb5c991483278cb6963daacfa796)