### PR TITLE
Validar estrictamente entradas v2 de cobra.lock usando contratos Hub

### DIFF
--- a/src/pcobra/cobra/hub/lockfile.py
+++ b/src/pcobra/cobra/hub/lockfile.py
@@ -15,7 +15,15 @@ from typing import Any, Mapping, Sequence
 
 from pcobra.cobra.hub.errors import PackageResolutionError
 from pcobra.cobra.hub.integrity import normalize_sha256
-from pcobra.cobra.hub.models import CobraHubResolution, LockedDependency
+from pcobra.cobra.hub.models import (
+    CobraHubResolution,
+    LockedDependency,
+    PackageDistribution,
+    PackageExtension,
+    SUPPORTED_ARCHITECTURES,
+    SUPPORTED_DISTRIBUTION_TYPES,
+    SUPPORTED_PLATFORMS,
+)
 from pcobra.cobra.packaging import normalizar_nombre_paquete, validar_version_paquete
 
 LOCKFILE_V1 = 1
@@ -23,6 +31,25 @@ LOCKFILE_V2 = 2
 _KNOWN_VERSIONS = frozenset({LOCKFILE_V1, LOCKFILE_V2})
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _PROVIDER_SOURCES = frozenset({"installer-cache", "cobrahub", "cobrahub-cache"})
+_V2_ENTRY_KEYS = frozenset(
+    {
+        "name",
+        "version",
+        "source",
+        "sha256",
+        "package_type",
+        "requires_cobra",
+        "artifact_type",
+        "artifact",
+        "exports",
+        "capabilities",
+        "extensions",
+        "platforms",
+        "architectures",
+        "distributions",
+        "dependencies",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -101,7 +128,10 @@ def write_lockfile(
         raise PackageResolutionError(
             f"Versión de cobra.lock no soportada: {version!r}."
         )
-    entries = [_entry_from_resolution(item, version) for item in resolved.values()]
+    try:
+        entries = [_entry_from_resolution(item, version) for item in resolved.values()]
+    except (TypeError, ValueError) as exc:
+        raise PackageResolutionError(f"Entrada inválida en cobra.lock: {exc}") from exc
     entries.sort(key=_sort_key)
     payload = {"version": version, "packages": [_entry_dict(item) for item in entries]}
     try:
@@ -156,6 +186,17 @@ def _parse_entry(raw: Any, version: int, base_dir: Path) -> LockfileEntryV1:
         source = _resolve_source(source, base_dir)
         if version == LOCKFILE_V1:
             return LockfileEntryV1(name, package_version, source, sha256)
+        unknown_keys = set(raw) - _V2_ENTRY_KEYS
+        if unknown_keys:
+            raise ValueError(
+                "claves v2 desconocidas: " + ", ".join(sorted(unknown_keys))
+            )
+        artifact_type = _optional_string(raw.get("artifact_type"), "artifact_type")
+        if (
+            artifact_type is not None
+            and artifact_type not in SUPPORTED_DISTRIBUTION_TYPES
+        ):
+            raise ValueError(f"artifact_type no soportado: {artifact_type}")
         return LockfileEntryV2(
             name=name,
             version=package_version,
@@ -165,14 +206,22 @@ def _parse_entry(raw: Any, version: int, base_dir: Path) -> LockfileEntryV1:
             requires_cobra=_optional_string(
                 raw.get("requires_cobra"), "requires_cobra"
             ),
-            artifact_type=_optional_string(raw.get("artifact_type"), "artifact_type"),
-            artifact=_optional_string(raw.get("artifact"), "artifact"),
-            exports=_string_tuple(raw.get("exports", []), "exports"),
-            capabilities=_string_tuple(raw.get("capabilities", []), "capabilities"),
-            extensions=_mapping_tuple(raw.get("extensions", []), "extensions"),
-            platforms=_string_tuple(raw.get("platforms", []), "platforms"),
-            architectures=_string_tuple(raw.get("architectures", []), "architectures"),
-            distributions=_mapping_tuple(raw.get("distributions", []), "distributions"),
+            artifact_type=artifact_type,
+            artifact=_artifact(raw.get("artifact")),
+            exports=_unique_string_tuple(raw.get("exports", []), "exports"),
+            capabilities=_unique_string_tuple(
+                raw.get("capabilities", []), "capabilities"
+            ),
+            extensions=_extensions(raw.get("extensions", [])),
+            platforms=_supported_values(
+                raw.get("platforms", []), "platforms", SUPPORTED_PLATFORMS
+            ),
+            architectures=_supported_values(
+                raw.get("architectures", []),
+                "architectures",
+                SUPPORTED_ARCHITECTURES,
+            ),
+            distributions=_distributions(raw.get("distributions", [])),
             dependencies=_dependencies(raw.get("dependencies", {})),
         )
     except (TypeError, ValueError) as exc:
@@ -204,6 +253,48 @@ def _string_tuple(value: Any, field_name: str) -> tuple[str, ...]:
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         raise ValueError(f"{field_name} debe ser una lista de cadenas")
     return tuple(value)
+
+
+def _unique_string_tuple(value: Any, field_name: str) -> tuple[str, ...]:
+    values = _string_tuple(value, field_name)
+    if not all(values):
+        raise ValueError(f"{field_name} debe contener cadenas no vacías")
+    if len(values) != len(set(values)):
+        raise ValueError(f"{field_name} no admite valores duplicados")
+    return values
+
+
+def _supported_values(
+    value: Any, field_name: str, supported: frozenset[str]
+) -> tuple[str, ...]:
+    values = _unique_string_tuple(value, field_name)
+    invalid = set(values) - supported
+    if invalid:
+        raise ValueError(
+            f"{field_name} contiene valores no soportados: "
+            + ", ".join(sorted(invalid))
+        )
+    return values
+
+
+def _artifact(value: Any) -> str | None:
+    artifact = _optional_string(value, "artifact")
+    if artifact is None:
+        return None
+    # PackageDistribution es el contrato normativo para rutas de artefactos.
+    return PackageDistribution.from_dict(
+        {"type": "cobra-package", "path": artifact}
+    ).path
+
+
+def _extensions(value: Any) -> tuple[Mapping[str, Any], ...]:
+    mappings = _mapping_tuple(value, "extensions")
+    return tuple(PackageExtension.from_dict(item).as_dict() for item in mappings)
+
+
+def _distributions(value: Any) -> tuple[Mapping[str, Any], ...]:
+    mappings = _mapping_tuple(value, "distributions")
+    return tuple(PackageDistribution.from_dict(item).as_dict() for item in mappings)
 
 
 def _mapping_tuple(value: Any, field_name: str) -> tuple[Mapping[str, Any], ...]:
@@ -245,18 +336,32 @@ def _entry_from_resolution(
     )
     if version == LOCKFILE_V1:
         return LockfileEntryV1(**common)
+    artifact_type = _optional_string(metadata.get("artifact_type"), "artifact_type")
+    if artifact_type is not None and artifact_type not in SUPPORTED_DISTRIBUTION_TYPES:
+        raise ValueError(f"artifact_type no soportado: {artifact_type}")
+    artifact = metadata.get("artifact") or getattr(
+        getattr(item, "path", None), "name", None
+    )
     return LockfileEntryV2(
         **common,
         package_type=metadata.get("package_type"),
         requires_cobra=metadata.get("requires_cobra"),
-        artifact_type=metadata.get("artifact_type"),
-        artifact=metadata.get("artifact") or str(getattr(item, "path", "")) or None,
-        exports=tuple(metadata.get("exports", ())),
-        capabilities=tuple(metadata.get("capabilities", ())),
-        extensions=tuple(metadata.get("extensions", ())),
-        platforms=tuple(metadata.get("platforms", ())),
-        architectures=tuple(metadata.get("architectures", ())),
-        distributions=tuple(metadata.get("distributions", ())),
+        artifact_type=artifact_type,
+        artifact=_artifact(artifact),
+        exports=_unique_string_tuple(list(metadata.get("exports", ())), "exports"),
+        capabilities=_unique_string_tuple(
+            list(metadata.get("capabilities", ())), "capabilities"
+        ),
+        extensions=_extensions(list(metadata.get("extensions", ()))),
+        platforms=_supported_values(
+            list(metadata.get("platforms", ())), "platforms", SUPPORTED_PLATFORMS
+        ),
+        architectures=_supported_values(
+            list(metadata.get("architectures", ())),
+            "architectures",
+            SUPPORTED_ARCHITECTURES,
+        ),
+        distributions=_distributions(list(metadata.get("distributions", ()))),
         dependencies=dict(
             getattr(item, "dependencies", metadata.get("dependencies", {}))
         ),

--- a/tests/unit/test_hub_lockfile.py
+++ b/tests/unit/test_hub_lockfile.py
@@ -1,11 +1,11 @@
 import json
+from pathlib import Path
 
 import pytest
 
 from pcobra.cobra.hub.errors import PackageResolutionError
 from pcobra.cobra.hub.lockfile import read_lockfile, write_lockfile
-from pcobra.cobra.hub.models import LockedDependency
-
+from pcobra.cobra.hub.models import CobraHubResolution, LockedDependency
 
 HASH = "a" * 64
 
@@ -42,14 +42,21 @@ def test_snapshot_v2_conserva_metadatos_y_lectura_offline(tmp_path):
                         "source": "cobrahub-cache",
                         "sha256": HASH,
                         "package_type": "library",
-                        "artifact_type": "co",
+                        "artifact_type": "cobra-package",
                         "artifact": "demo.co",
                         "exports": ["demo.api"],
                         "capabilities": ["net"],
-                        "extensions": [{"name": "plug"}],
+                        "extensions": [
+                            {
+                                "namespace": "demo.plugins",
+                                "provider": "plug",
+                                "capabilities": ["net"],
+                                "entrypoint": "demo.plugin:Plugin",
+                            }
+                        ],
                         "platforms": ["linux"],
                         "architectures": ["x86_64"],
-                    "dependencies": {"base": "2.0.0"},
+                        "dependencies": {"base": "2.0.0"},
                     }
                 ],
             }
@@ -61,11 +68,18 @@ def test_snapshot_v2_conserva_metadatos_y_lectura_offline(tmp_path):
     assert entry.source == "cobrahub-cache"
     assert entry.metadata == {
         "package_type": "library",
-        "artifact_type": "co",
+        "artifact_type": "cobra-package",
         "artifact": "demo.co",
         "exports": ["demo.api"],
         "capabilities": ["net"],
-        "extensions": [{"name": "plug"}],
+        "extensions": [
+            {
+                "namespace": "demo.plugins",
+                "provider": "plug",
+                "capabilities": ["net"],
+                "entrypoint": "demo.plugin:Plugin",
+            }
+        ],
         "platforms": ["linux"],
         "architectures": ["x86_64"],
         "dependencies": {"base": "2.0.0"},
@@ -158,8 +172,8 @@ def test_rechaza_duplicados_despues_de_normalizar(tmp_path):
     path.write_text(
         json.dumps(
             [
-        {"name": "Demo_Pkg", "version": "1.0.0"},
-        {"name": "demo_pkg", "version": "1.0.0"},
+                {"name": "Demo_Pkg", "version": "1.0.0"},
+                {"name": "demo_pkg", "version": "1.0.0"},
             ]
         ),
         encoding="utf-8",
@@ -167,3 +181,101 @@ def test_rechaza_duplicados_despues_de_normalizar(tmp_path):
 
     with pytest.raises(PackageResolutionError, match="duplicado"):
         read_lockfile(path)
+
+
+def _v2_entry(**changes):
+    entry = {
+        "name": "demo",
+        "version": "1.0.0",
+        "artifact_type": "cobra-package",
+        "artifact": "dist/demo.co",
+        "exports": ["demo.api"],
+        "capabilities": ["net"],
+        "extensions": [],
+        "platforms": ["linux"],
+        "architectures": ["x86_64"],
+    }
+    entry.update(changes)
+    return {"version": 2, "packages": [entry]}
+
+
+@pytest.mark.parametrize(
+    "artifact",
+    ["../demo.co", "/tmp/demo.co", "C:\\temp\\demo.co", "dist\\demo.co", ""],
+)
+def test_v2_rechaza_rutas_de_artefacto_inseguras(tmp_path, artifact):
+    path = tmp_path / "cobra.lock"
+    path.write_text(json.dumps(_v2_entry(artifact=artifact)), encoding="utf-8")
+
+    with pytest.raises(PackageResolutionError, match="artifact|ruta insegura"):
+        read_lockfile(path)
+
+
+@pytest.mark.parametrize(
+    "changes, message",
+    [
+        ({"artifact_type": "desconocido"}, "artifact_type"),
+        ({"platforms": ["plan9"]}, "platforms"),
+        ({"architectures": ["mips"]}, "architectures"),
+        ({"exports": ["demo", "demo"]}, "duplicados"),
+        ({"capabilities": ["net", "net"]}, "duplicados"),
+        ({"platforms": ["linux", "linux"]}, "duplicados"),
+        ({"architectures": ["arm64", "arm64"]}, "duplicados"),
+        ({"campo_nuevo": True}, "desconocidas"),
+        (
+            {
+                "extensions": [
+                    {
+                        "namespace": "demo.plugins",
+                        "provider": "plug",
+                        "capabilities": ["net"],
+                        "entrypoint": "no-es-un-entrypoint",
+                    }
+                ]
+            },
+            "entrypoint",
+        ),
+    ],
+)
+def test_v2_rechaza_campos_fuera_de_los_contratos(tmp_path, changes, message):
+    path = tmp_path / "cobra.lock"
+    path.write_text(json.dumps(_v2_entry(**changes)), encoding="utf-8")
+
+    with pytest.raises(PackageResolutionError, match=message):
+        read_lockfile(path)
+
+
+def test_v1_mantiene_tolerancia_a_claves_historicas(tmp_path):
+    path = tmp_path / "cobra.lock"
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "packages": [
+                    {"name": "demo", "version": "1.0.0", "campo_antiguo": True}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert read_lockfile(path)["demo"].version == "1.0.0"
+
+
+def test_escritura_no_depende_del_directorio_de_trabajo(tmp_path, monkeypatch):
+    artifact = tmp_path / "cache" / "demo.co"
+    artifact.parent.mkdir()
+    artifact.touch()
+    resolution = CobraHubResolution("demo", "1.0.0", artifact, HASH, "cobrahub-cache")
+    first = tmp_path / "first.lock"
+    second = tmp_path / "second.lock"
+
+    write_lockfile(first, {"demo": resolution})
+    other_cwd = tmp_path / "other"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+    write_lockfile(second, {"demo": resolution})
+
+    assert first.read_bytes() == second.read_bytes()
+    assert json.loads(first.read_text())["packages"][0]["artifact"] == "demo.co"
+    assert str(Path(artifact).parent) not in first.read_text()


### PR DESCRIPTION
### Motivation

- Evitar artefactos inseguros y metadatos inválidos en lockfiles v2 reutilizando las validaciones ya definidas en los contratos de Hub.
- Mantener la tolerancia histórica de lockfiles v1 mientras se aplica validación estricta a v2 para resolver paquetes offline de forma segura.

### Description

- Añade validación exclusiva para entradas v2 en `src/pcobra/cobra/hub/lockfile.py`, incluyendo un conjunto permitido de claves v2 y rechazo de claves desconocidas mediante `PackageResolutionError`.
- Valida `artifact_type` contra `SUPPORTED_DISTRIBUTION_TYPES` y normaliza/valida `artifact` como ruta relativa segura (rechaza rutas absolutas, `..`, separadores Windows/mixtos y valores vacíos) usando `PackageDistribution`.
- Valida `platforms` y `architectures` contra `SUPPORTED_PLATFORMS` y `SUPPORTED_ARCHITECTURES`, convierte `extensions` mediante `PackageExtension.from_dict()` y `as_dict()`, y rechaza duplicados en `exports`, `capabilities`, `platforms` y `architectures`.
- Evita que `_entry_from_resolution` serialice rutas absolutas; en su lugar almacena un identificador estable del artefacto (nombre relativo) para que la escritura no dependa del directorio de trabajo.
- Cambios de prueba en `tests/unit/test_hub_lockfile.py` que cubren `../`, rutas absolutas POSIX y Windows, entrypoints inválidos, tipos/plataformas/arquitecturas no soportadas, duplicados, claves v2 desconocidas, tolerancia v1 histórica y escritura independiente del CWD.

### Testing

- Ejecuté `pytest -q tests/unit/test_hub_lockfile.py` y todas las pruebas específicas pasaron (28 passed). 
- Formateé con `python -m black --target-version py312` sobre los archivos modificados y volví a ejecutar las pruebas específicas; el chequeo de estilo y las pruebas dirigidas pasaron.
- Ejecuté la suite filtrada de Hub `pytest -q tests/unit -k 'hub and not lockfile'`, que devolvió 128 pruebas aprobadas y 1 fallo preexistente no relacionado con este cambio en `test_publicar_paquete_preserva_manifiesto_enriquecido` (fallo por validación SemVer en `cobra-core`).
- Verifiqué `git diff --check` y confirmé que no se tocaron Lexer ni Parser.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59fdcdf7cc83279830c2b3c78d0304)