### PR TITLE
Prioriza distribuciones instalables en CobraHub

### DIFF
--- a/src/pcobra/cobra/hub/installation.py
+++ b/src/pcobra/cobra/hub/installation.py
@@ -212,11 +212,6 @@ class CobraHubResolver:
                 raise PackageCompatibilityError(
                     f"Manifiesto v2 incompatible para {name}: {exc}"
                 ) from exc
-            if distribution.type != "cobra-package":
-                raise PackageCompatibilityError(
-                    f"La distribución compatible de {name} es de tipo "
-                    f"{distribution.type!r}; este tipo todavía no es instalable."
-                )
             metadata = {
                 "package_type": manifest_v2.package_type,
                 "requires_cobra": manifest_v2.requires_cobra,
@@ -245,7 +240,7 @@ class CobraHubResolver:
         platform: str,
         architecture: str,
     ) -> PackageDistribution:
-        """Elige el primer artefacto compatible sin cargar ni ejecutar su código."""
+        """Elige un artefacto compatible e instalable sin ejecutar su código."""
 
         compatible = [
             item
@@ -265,8 +260,25 @@ class CobraHubResolver:
             raise PackageCompatibilityError(
                 "No hay una distribución compatible con la plataforma "
                 f"{platform!r} y la arquitectura {architecture!r}."
+            )
+
+        for distribution in compatible:
+            if distribution.type == "cobra-package":
+                return distribution
+
+        found_types = ", ".join(
+            repr(item)
+            for item in sorted({distribution.type for distribution in compatible})
         )
-        return compatible[0]
+        if len(compatible) == 1:
+            raise PackageCompatibilityError(
+                "La distribución compatible es de tipo "
+                f"{found_types}; este tipo todavía no es instalable."
+            )
+        raise PackageCompatibilityError(
+            f"Las distribuciones compatibles tienen los tipos {found_types}; "
+            "estos tipos todavía no son instalables."
+        )
 
     _sha256_file = staticmethod(sha256_file)
 

--- a/tests/unit/test_cobra_installer_hub_resolver.py
+++ b/tests/unit/test_cobra_installer_hub_resolver.py
@@ -4,6 +4,8 @@ import zipfile
 
 import pytest
 
+from pcobra.cobra.hub.errors import PackageCompatibilityError
+from pcobra.cobra.hub.models import PackageDistribution
 from pcobra.cobra.hub.repository import DownloadedPackage
 from pcobra.cobra.packaging import construir_paquete
 from pcobra.cobra_installer.hub_resolver import CobraHubResolver
@@ -176,6 +178,68 @@ def test_hub_resolver_rechaza_distribuciones_aun_no_instalables(
             platform="linux",
             architecture="x86_64",
         )
+
+
+def test_select_distribution_prioriza_cobra_package_compatible():
+    distributions = (
+        PackageDistribution(
+            type="python-wheel",
+            path="dist/dep.whl",
+            platforms=("linux",),
+            architectures=("x86_64",),
+        ),
+        PackageDistribution(
+            type="cobra-package",
+            path="dist/dep.co",
+            platforms=("linux",),
+            architectures=("x86_64",),
+        ),
+    )
+
+    selected = CobraHubResolver._select_distribution(distributions, "linux", "x86_64")
+
+    assert selected == distributions[1]
+
+
+def test_select_distribution_informa_tipos_compatibles_no_instalables():
+    distributions = (
+        PackageDistribution(type="python-wheel", path="dist/dep.whl"),
+        PackageDistribution(type="wasm", path="dist/dep.wasm"),
+    )
+
+    with pytest.raises(PackageCompatibilityError) as exc_info:
+        CobraHubResolver._select_distribution(distributions, "linux", "x86_64")
+
+    message = str(exc_info.value)
+    assert "'python-wheel'" in message
+    assert "'wasm'" in message
+    assert "no son instalables" in message
+
+
+def test_select_distribution_conserva_error_sin_coincidencia_de_entorno():
+    distributions = (
+        PackageDistribution(
+            type="cobra-package",
+            path="dist/windows.co",
+            platforms=("windows",),
+            architectures=("x86_64",),
+        ),
+        PackageDistribution(
+            type="cobra-package",
+            path="dist/arm.co",
+            platforms=("linux",),
+            architectures=("arm64",),
+        ),
+    )
+
+    with pytest.raises(
+        PackageCompatibilityError,
+        match=(
+            "No hay una distribución compatible con la plataforma 'linux' "
+            "y la arquitectura 'x86_64'\\."
+        ),
+    ):
+        CobraHubResolver._select_distribution(distributions, "linux", "x86_64")
 
 
 def test_hub_resolver_v1_conserva_resultado_historico_sin_metadata(tmp_path):


### PR DESCRIPTION
### Motivation

- Evitar seleccionar primero una distribución compatible pero no instalable y sólo después fallar por tipo, y en su lugar considerar plataforma, arquitectura y tipo de distribución conjuntamente.

### Description

- Cambia `CobraHubResolver._select_distribution` para filtrar por `platform` y `architecture` y priorizar `cobra-package` entre las distribuciones compatibles.
- Si hay distribuciones compatibles pero ninguna es instalable, lanza `PackageCompatibilityError` que lista explícitamente los tipos encontrados; si no hay coincidencia de entorno se conserva el error previo.
- Elimina la comprobación redundante de tipo en el caller y centraliza la validación en `_select_distribution` para seleccionar sólo artefactos instalables.
- Añade pruebas en `tests/unit/test_cobra_installer_hub_resolver.py` que verifican la prioridad de `cobra-package`, el mensaje cuando hay tipos compatibles no instalables y la preservación del error cuando no hay coincidencia de plataforma/arquitectura.

### Testing

- Ejecuté `pytest -q tests/unit/test_cobra_installer_hub_resolver.py` y todas las pruebas de ese archivo pasaron (`16 passed`).
- Formateé y comprobé estilo con `ruff format`/`ruff check` sobre los archivos modificados y ambas comprobaciones pasaron después del formateo.
- Ejecuté suites relacionadas con `pytest -q tests/unit/test_hub_manifest_v2.py tests/unit/test_hub_lockfile.py tests/unit/test_cobra_installer_dependency_resolver.py` obteniendo `72 passed` y `2 failed`, donde los 2 fallos son preexistentes y están relacionados con expectativas de rutas absolutas en tests de lockfile no introducidas por este cambio.
- Verifiqué con `git diff --check` y comprobé que no se modificaron archivos de `Lexer` ni `Parser` según las reglas del repositorio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a001f77288327a840a44adf3d00d7)