### PR TITLE
Validar requires_cobra en lockfiles v2 y reutilizar validador de versiones

### DIFF
--- a/src/pcobra/cobra/hub/lockfile.py
+++ b/src/pcobra/cobra/hub/lockfile.py
@@ -23,6 +23,7 @@ from pcobra.cobra.hub.models import (
     SUPPORTED_ARCHITECTURES,
     SUPPORTED_DISTRIBUTION_TYPES,
     SUPPORTED_PLATFORMS,
+    validate_version_constraint,
 )
 from pcobra.cobra.packaging import normalizar_nombre_paquete, validar_version_paquete
 
@@ -203,9 +204,7 @@ def _parse_entry(raw: Any, version: int, base_dir: Path) -> LockfileEntryV1:
             source=source,
             sha256=sha256,
             package_type=_optional_string(raw.get("package_type"), "package_type"),
-            requires_cobra=_optional_string(
-                raw.get("requires_cobra"), "requires_cobra"
-            ),
+            requires_cobra=_optional_version_constraint(raw.get("requires_cobra")),
             artifact_type=artifact_type,
             artifact=_artifact(raw.get("artifact")),
             exports=_unique_string_tuple(raw.get("exports", []), "exports"),
@@ -247,6 +246,12 @@ def _optional_string(value: Any, field_name: str) -> str | None:
     if not isinstance(value, str) or not value:
         raise ValueError(f"{field_name} debe ser una cadena no vacía")
     return value
+
+
+def _optional_version_constraint(value: Any) -> str | None:
+    if value is None:
+        return None
+    return validate_version_constraint(value, "requires_cobra")
 
 
 def _string_tuple(value: Any, field_name: str) -> tuple[str, ...]:
@@ -345,7 +350,7 @@ def _entry_from_resolution(
     return LockfileEntryV2(
         **common,
         package_type=metadata.get("package_type"),
-        requires_cobra=metadata.get("requires_cobra"),
+        requires_cobra=_optional_version_constraint(metadata.get("requires_cobra")),
         artifact_type=artifact_type,
         artifact=_artifact(artifact),
         exports=_unique_string_tuple(list(metadata.get("exports", ())), "exports"),

--- a/src/pcobra/cobra/hub/models.py
+++ b/src/pcobra/cobra/hub/models.py
@@ -7,8 +7,9 @@ from pathlib import Path
 import re
 from typing import Any, Mapping
 
-from pcobra.cobra.hub.compatibility import validate_version_constraint
-
+from pcobra.cobra.hub.compatibility import (
+    validate_version_constraint as _validate_version_constraint,
+)
 
 PACKAGE_FORMAT_V2 = "cobra-package-v2"
 SUPPORTED_PACKAGE_FORMATS = frozenset({"cobra-package-v1", PACKAGE_FORMAT_V2})
@@ -84,9 +85,9 @@ def _semver(value: Any, field_name: str) -> str:
     return text
 
 
-def _version_constraint(value: Any, field_name: str) -> str:
+def validate_version_constraint(value: Any, field_name: str) -> str:
     """Valida una intersección estática de comparadores de versión Cobra."""
-    return validate_version_constraint(value, field_name)
+    return _validate_version_constraint(value, field_name)
 
 
 def _namespace(value: Any, field_name: str) -> str:
@@ -272,7 +273,7 @@ class PackageManifestV2:
             name=_name(data.get("name")),
             version=_semver(data.get("version"), "version"),
             package_type=package_type,
-            requires_cobra=_version_constraint(
+            requires_cobra=validate_version_constraint(
                 data.get("requires_cobra"), "requires_cobra"
             ),
             exports=exports,

--- a/tests/unit/test_hub_lockfile.py
+++ b/tests/unit/test_hub_lockfile.py
@@ -262,6 +262,53 @@ def test_v1_mantiene_tolerancia_a_claves_historicas(tmp_path):
     assert read_lockfile(path)["demo"].version == "1.0.0"
 
 
+def test_v2_acepta_restriccion_requires_cobra_valida(tmp_path):
+    path = tmp_path / "cobra.lock"
+    path.write_text(json.dumps(_v2_entry(requires_cobra=">=1.2,<2")), encoding="utf-8")
+
+    assert read_lockfile(path)["demo"].metadata["requires_cobra"] == ">=1.2,<2"
+
+
+def test_v2_rechaza_restriccion_requires_cobra_mal_formada(tmp_path):
+    path = tmp_path / "cobra.lock"
+    path.write_text(json.dumps(_v2_entry(requires_cobra=">=1.2, <2")), encoding="utf-8")
+
+    with pytest.raises(PackageResolutionError, match="requires_cobra"):
+        read_lockfile(path)
+
+
+def test_v2_rechaza_requires_cobra_que_no_es_cadena(tmp_path):
+    path = tmp_path / "cobra.lock"
+    path.write_text(json.dumps(_v2_entry(requires_cobra=2)), encoding="utf-8")
+
+    with pytest.raises(PackageResolutionError, match="requires_cobra"):
+        read_lockfile(path)
+
+
+def test_v1_sigue_permitiendo_omitir_requires_cobra(tmp_path):
+    path = tmp_path / "cobra.lock"
+    path.write_text(
+        json.dumps({"version": 1, "packages": [{"name": "demo", "version": "1.0.0"}]}),
+        encoding="utf-8",
+    )
+
+    assert read_lockfile(path)["demo"].metadata == {}
+
+
+def test_v2_escribe_y_lee_restriccion_requires_cobra_determinista(tmp_path):
+    path = tmp_path / "cobra.lock"
+    entry = LockedDependency(
+        "demo", "1.0.0", HASH, "cobrahub", metadata={"requires_cobra": ">=1.2,<2"}
+    )
+
+    write_lockfile(path, {"demo": entry})
+    first = path.read_bytes()
+    write_lockfile(path, {"demo": entry})
+
+    assert path.read_bytes() == first
+    assert read_lockfile(path)["demo"].metadata["requires_cobra"] == ">=1.2,<2"
+
+
 def test_escritura_no_depende_del_directorio_de_trabajo(tmp_path, monkeypatch):
     artifact = tmp_path / "cache" / "demo.co"
     artifact.parent.mkdir()


### PR DESCRIPTION
### Motivation

- Evitar duplicación de la lógica/expresiones regulares de validación de restricciones de versión exponiendo un validador reutilizable. 
- Garantizar que el campo `requires_cobra` en lockfiles v2 se valide de forma consistente tanto al leer como al serializar sin alterar el comportamiento de lockfiles v1.

### Description

- Expone en `src/pcobra/cobra/hub/models.py` la función pública `validate_version_constraint` que delega en la implementación central de `compatibility` para evitar duplicar regex. 
- Importa y usa ese validador en `src/pcobra/cobra/hub/lockfile.py`, añadiendo la función `_optional_version_constraint` y aplicándola en `_parse_entry` para entradas v2 y en `_entry_from_resolution` al construir entradas para escritura. 
- Mantiene `requires_cobra` opcional para lockfiles v1 y no modifica el tratamiento existente de v1. 
- Añade pruebas en `tests/unit/test_hub_lockfile.py` que cubren: restricción válida, restricción mal formada, valor no cadena, lockfile v1 sin `requires_cobra` y round-trip determinista de escritura/lectura.

### Testing

- Ejecuté `pytest -q tests/unit/test_hub_lockfile.py` y las pruebas del archivo pasaron correctamente. 
- Ejecuté `pytest -q tests/unit/test_hub_manifest_v2.py tests/unit/test_hub_lockfile.py` y ambas suites unitarias pasaron (todos los tests en esos archivos). 
- Ejecuté la suite de linters/formatters y checks `ruff`/`black` y `git diff --check`, y no se detectaron problemas; además verifiqué que no se modificaron `Lexer` ni `Parser`. 
- La ejecución de `pytest -q tests/unit` muestra 5 fallos preexistentes en tests del REPL (`tests/unit/cli/commands_v2/test_repl_cmd_v2.py`) que son ajenos a este cambio y no afectan la validez de las modificaciones realizadas aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a0346617083278c7d33cb9108c023)