### PR TITLE
Añadir regresiones de decoradores al transpilador Python

### DIFF
--- a/tests/test_transpilers.py
+++ b/tests/test_transpilers.py
@@ -1,3 +1,4 @@
+import ast
 import sys
 from pathlib import Path
 
@@ -18,6 +19,8 @@ from pcobra.core.ast_nodes import (
     NodoGarantia,
     NodoRetorno,
     NodoLlamadaFuncion,
+    NodoDecorador,
+    NodoFuncion,
     NodoExport,
     NodoUsar,
 )
@@ -38,6 +41,37 @@ def test_generate_code_asignacion_simple() -> None:
     codigo = transpiler.generate_code([nodo])
     assert "x = 1" in codigo
     assert transpiler.codigo == codigo
+
+
+def test_transpilador_python_funcion_con_decorador_emite_salto_contiguo() -> None:
+    nodo = NodoFuncion(
+        "saludar",
+        ["nombre"],
+        [NodoRetorno(NodoIdentificador("nombre"))],
+        decoradores=[NodoDecorador(NodoIdentificador("traza"))],
+    )
+
+    codigo = TranspiladorPython().generate_code([nodo])
+
+    assert "@traza\ndef saludar(nombre):" in codigo
+    ast.parse(codigo)
+
+
+def test_transpilador_python_funcion_con_dos_decoradores_preserva_orden() -> None:
+    nodo = NodoFuncion(
+        "saludar",
+        ["nombre"],
+        [NodoRetorno(NodoIdentificador("nombre"))],
+        decoradores=[
+            NodoDecorador(NodoIdentificador("traza")),
+            NodoDecorador(NodoIdentificador("medir")),
+        ],
+    )
+
+    codigo = TranspiladorPython().generate_code([nodo])
+
+    assert "@traza\n@medir\ndef saludar(nombre):" in codigo
+    ast.parse(codigo)
 
 
 def test_transpilador_python_usar_invoca_api_canonica() -> None:


### PR DESCRIPTION
### Motivation
- Asegurar que el transpilador Python emite decoradores con el salto de línea correcto para evitar regresiones como `@trazadef`.
- Verificar que el orden y los saltos de línea de múltiples decoradores se conservan en la salida generada.
- Validar la salida completa generada por el transpilador con `ast.parse` para proteger contra cambios sintácticos involuntarios.

### Description
- Se añadieron dos pruebas a `tests/test_transpilers.py` que construyen el AST con `NodoFuncion`, `NodoDecorador` y `NodoIdentificador` sin modificar el AST, Lexer ni Parser.
- Se importó `ast` y se añadió `NodoDecorador` y `NodoFuncion` a las importaciones en `tests/test_transpilers.py` para poder construir los casos de prueba.
- Se añadió la prueba `test_transpilador_python_funcion_con_decorador_emite_salto_contiguo` que exige la cadena contigua `@traza\ndef saludar(nombre):` en la salida.
- Se añadió la prueba `test_transpilador_python_funcion_con_dos_decoradores_preserva_orden` que verifica tanto el salto de línea como el orden de los decoradores y ambas pruebas validan la salida con `ast.parse`.

### Testing
- Ejecuté `python -m pytest tests/test_transpilers.py -k 'funcion_con_decorador_emite_salto_contiguo or funcion_con_dos_decoradores_preserva_orden'` y las 2 pruebas seleccionadas pasaron (2 passed).
- Ejecuté `python -m pytest tests/test_transpilers.py` y la suite relacionada pasó completamente (15 passed).
- Verifiqué `git diff --check` y que no hubo cambios en archivos de `lexer` ni `parser`, y los cambios fueron comprometidos con el mensaje `test: cubrir decoradores en transpilador Python` (commit `5257bec`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a090a0fe08327b6515d254113fb3a)