### PR TITLE
Endurecer validación y detección de duplicados en cobra.lock (v2)

### DIFF
--- a/src/pcobra/cobra/hub/lockfile.py
+++ b/src/pcobra/cobra/hub/lockfile.py
@@ -32,6 +32,7 @@ LOCKFILE_V2 = 2
 _KNOWN_VERSIONS = frozenset({LOCKFILE_V1, LOCKFILE_V2})
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _PROVIDER_SOURCES = frozenset({"installer-cache", "cobrahub", "cobrahub-cache"})
+_ROOT_KEYS = frozenset({"version", "packages"})
 _V2_ENTRY_KEYS = frozenset(
     {
         "name",
@@ -133,6 +134,14 @@ def write_lockfile(
         entries = [_entry_from_resolution(item, version) for item in resolved.values()]
     except (TypeError, ValueError) as exc:
         raise PackageResolutionError(f"Entrada inválida en cobra.lock: {exc}") from exc
+    normalized_names: set[str] = set()
+    for entry in entries:
+        normalized_name = normalizar_nombre_paquete(entry.name)
+        if normalized_name in normalized_names:
+            raise PackageResolutionError(
+                f"cobra.lock contiene el paquete duplicado {normalized_name}."
+            )
+        normalized_names.add(normalized_name)
     entries.sort(key=_sort_key)
     payload = {"version": version, "packages": [_entry_dict(item) for item in entries]}
     try:
@@ -156,6 +165,13 @@ def _extract_entries(data: Any) -> tuple[int, Sequence[Any]]:
         )
     if "packages" not in data:
         raise PackageResolutionError("cobra.lock no contiene la estructura packages.")
+    if raw_version == LOCKFILE_V2:
+        unknown_keys = set(data) - _ROOT_KEYS
+        if unknown_keys:
+            raise PackageResolutionError(
+                "cobra.lock v2 contiene claves desconocidas: "
+                + ", ".join(sorted(unknown_keys))
+            )
     packages = data["packages"]
     if isinstance(packages, list):
         return raw_version, packages
@@ -319,9 +335,10 @@ def _dependencies(value: Any) -> dict[str, str]:
             raise ValueError(
                 "dependencies debe relacionar nombres y versiones de texto"
             )
-        result[normalizar_nombre_paquete(raw_name)] = validar_version_paquete(
-            raw_version
-        )
+        name = normalizar_nombre_paquete(raw_name)
+        if name in result:
+            raise ValueError(f"dependencies contiene el paquete duplicado {name}")
+        result[name] = validar_version_paquete(raw_version)
     return result
 
 

--- a/tests/unit/test_hub_lockfile.py
+++ b/tests/unit/test_hub_lockfile.py
@@ -147,6 +147,7 @@ def test_lockfile_v2_serializa_solo_metadata_normalizada_y_permite_lectura_offli
     [
         ({"version": 3, "packages": []}, "no soportada"),
         ({"version": 2, "other": []}, "packages"),
+        ({"version": 2, "packages": [], "future": True}, "desconocidas"),
         (
             {
                 "version": 2,
@@ -181,6 +182,32 @@ def test_rechaza_duplicados_despues_de_normalizar(tmp_path):
 
     with pytest.raises(PackageResolutionError, match="duplicado"):
         read_lockfile(path)
+
+
+def test_rechaza_dependencias_duplicadas_despues_de_normalizar(tmp_path):
+    path = tmp_path / "cobra.lock"
+    path.write_text(
+        json.dumps(
+            _v2_entry(
+                dependencies={"Base_Pkg": "1.0.0", "base_pkg": "1.0.0"}
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PackageResolutionError, match="duplicado"):
+        read_lockfile(path)
+
+
+def test_escritura_rechaza_nombres_duplicados_despues_de_normalizar(tmp_path):
+    path = tmp_path / "cobra.lock"
+    entries = {
+        "primero": LockedDependency("Demo_Pkg", "1.0.0", HASH, "cobrahub"),
+        "segundo": LockedDependency("demo_pkg", "2.0.0", HASH, "cobrahub"),
+    }
+
+    with pytest.raises(PackageResolutionError, match="duplicado"):
+        write_lockfile(path, entries)
 
 
 def _v2_entry(**changes):


### PR DESCRIPTION
### Motivation

- Asegurar que los lockfiles v2 tengan un esquema conocido y rechazar estructuras o claves raíz desconocidas para evitar interpretaciones futuras inesperadas.
- Evitar colisiones silenciosas por nombres normalizados o dependencias con nombres duplicados tras normalización.
- Mantener compatibilidad de lectura con formatos históricos (v1 JSON/TOML, lista raíz y `packages` como lista/tabla) y conservar la escritura determinista de v2.

### Description

- Añadido `_ROOT_KEYS` y validación que rechaza claves raíz desconocidas en lockfiles v2 lanzando `PackageResolutionError` cuando exista contenido no reconocido.  
- Detecta y rechaza paquetes duplicados al escribir (`write_lockfile`) comparando nombres normalizados y levanta `PackageResolutionError` si hay colisiones.  
- Detecta y rechaza dependencias duplicadas tras normalizar nombres en `_dependencies`, devolviendo error si la tabla contiene el mismo paquete con variantes de nombre.  
- Conserva modelos separados `LockfileEntryV1` y `LockfileEntryV2`, persistencia de metadatos relevantes (origen, `package_type`, `artifact_type`, `artifact`, `sha256`, `exports`, `capabilities`, `extensions`, `platforms`, `architectures`, `distributions`, `dependencies`) y la serialización JSON determinista con orden estable.  
- No se modificaron Lexer ni Parser y se preservan los adaptadores históricos `read_lockfile` / `write_lockfile` expuestos en `cobra_installer/dependency_resolver.py` para compatibilidad legacy (opción `legacy_v1=True`).  
- Añadidas pruebas unitarias dirigidas para esquemas futuros, duplicados normalizados y duplicados en dependencias, y un caso que valida rechazo de claves raíz desconocidas en v2.

### Testing

- Ejecutadas pruebas unitarias específicas del módulo: `pytest -q tests/unit/test_hub_lockfile.py` — todas las pruebas del archivo superadas.  
- Ejecutada la suite de pruebas del paquete hub: `pytest -q tests/unit/test_hub_*.py` — 96 pruebas superadas, 1 warning.  
- Nota: una ejecución previa que combinaba `test_hub_lockfile.py` con `test_cobra_installer_dependency_resolver.py` mostró 2 fallos relacionados con expectativas antiguas sobre rutas absolutas de artefactos; esos casos no eran regresiones introducidas por estas validaciones y la suite dirigida del lockfile quedó verde tras los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a1189e80083279aaac38250beae2a)