### PR TITLE
Aísla los contratos oficiales de los transpiladores legacy

### DIFF
--- a/tests/integration/transpilers/backend_contracts.py
+++ b/tests/integration/transpilers/backend_contracts.py
@@ -38,7 +38,10 @@ CORE_RUNTIME_FEATURES: Final[tuple[str, ...]] = (
 
 OFFICIAL_TRANSPILERS: dict[str, tuple[str, str]] = {
     "python": ("pcobra.cobra.transpilers.transpiler.to_python", "TranspiladorPython"),
-    "javascript": ("pcobra.cobra.transpilers.transpiler.to_javascript", "TranspiladorJavaScript"),
+    "javascript": (
+        "pcobra.cobra.transpilers.transpiler.to_javascript",
+        "TranspiladorJavaScript",
+    ),
     "rust": ("pcobra.cobra.transpilers.transpiler.to_rust", "TranspiladorRust"),
 }
 
@@ -56,7 +59,10 @@ FEATURE_NODES = {
         NodoHolobit("hb", [1, 2, 3]),
         NodoTransformar(NodoIdentificador("hb"), NodoValor("rotar"), [NodoValor(90)]),
     ],
-    "graficar": lambda: [NodoHolobit("hb", [1, 2, 3]), NodoGraficar(NodoIdentificador("hb"))],
+    "graficar": lambda: [
+        NodoHolobit("hb", [1, 2, 3]),
+        NodoGraficar(NodoIdentificador("hb")),
+    ],
     "corelibs": lambda: [NodoLlamadaFuncion("longitud", [NodoValor("cobra")])],
     "standard_library": lambda: [NodoLlamadaFuncion("mostrar", [NodoValor("hola")])],
 }
@@ -83,7 +89,11 @@ PARTIAL_EXPECTATIONS: dict[str, dict[str, tuple[str, ...]]] = {
             "let hb = cobra_holobit([1, 2, 3]);",
             "__cobra_tipo__: 'holobit'",
         ),
-        "proyectar": ("function cobra_proyectar", "case '2d':", "cobra_proyectar(hb, '2d');"),
+        "proyectar": (
+            "function cobra_proyectar",
+            "case '2d':",
+            "cobra_proyectar(hb, '2d');",
+        ),
         "transformar": (
             "function cobra_transformar",
             "operacion === 'rotar'",
@@ -113,14 +123,20 @@ PARTIAL_EXPECTATIONS: dict[str, dict[str, tuple[str, ...]]] = {
             "fn cobra_transformar",
             'cobra_runtime_expect(cobra_transformar(&hb, &format!("{}", "rotar"), &[format!("{}", 90)]));',
         ),
-        "graficar": ("fn cobra_graficar", 'cobra_runtime_expect(cobra_graficar(&hb));'),
-        "corelibs": ('fn longitud<T: ToString>(valor: T) -> usize {', 'longitud("cobra");'),
-        "standard_library": ('fn mostrar<T: Display>(valor: T) {', 'mostrar("hola");'),
+        "graficar": ("fn cobra_graficar", "cobra_runtime_expect(cobra_graficar(&hb));"),
+        "corelibs": (
+            "fn longitud<T: ToString>(valor: T) -> usize {",
+            'longitud("cobra");',
+        ),
+        "standard_library": ("fn mostrar<T: Display>(valor: T) {", 'mostrar("hola");'),
     },
+}
+
+LEGACY_EXPERIMENTAL_PARTIAL_EXPECTATIONS: dict[str, dict[str, tuple[str, ...]]] = {
     "wasm": {
         "holobit": (
             '(import "pcobra:holobit" "cobra_holobit"',
-            '(drop (call $cobra_holobit (i32.const 1)))',
+            "(drop (call $cobra_holobit (i32.const 1)))",
         ),
         "proyectar": (
             "(func $cobra_proyectar",
@@ -134,10 +150,13 @@ PARTIAL_EXPECTATIONS: dict[str, dict[str, tuple[str, ...]]] = {
             "(func $cobra_graficar",
             "(drop (call $cobra_graficar (local.get $hb)))",
         ),
-        "corelibs": ('(import "pcobra:corelibs" "longitud"', '(call $longitud (i32.const 0))'),
+        "corelibs": (
+            '(import "pcobra:corelibs" "longitud"',
+            "(call $longitud (i32.const 0))",
+        ),
         "standard_library": (
             '(import "pcobra:standard_library" "mostrar"',
-            '(call $mostrar (i32.const 0))',
+            "(call $mostrar (i32.const 0))",
         ),
     },
     "go": {
@@ -150,16 +169,28 @@ PARTIAL_EXPECTATIONS: dict[str, dict[str, tuple[str, ...]]] = {
     },
     "cpp": {
         "holobit": ("auto hb = cobra_holobit({ 1, 2, 3 });",),
-        "proyectar": ("inline std::vector<double> cobra_proyectar", 'cobra_proyectar(hb, "2d");'),
-        "transformar": ("inline CobraHolobit cobra_transformar", 'cobra_transformar(hb, "rotar", {cobra_runtime_arg(90)});'),
+        "proyectar": (
+            "inline std::vector<double> cobra_proyectar",
+            'cobra_proyectar(hb, "2d");',
+        ),
+        "transformar": (
+            "inline CobraHolobit cobra_transformar",
+            'cobra_transformar(hb, "rotar", {cobra_runtime_arg(90)});',
+        ),
         "graficar": ("inline std::string cobra_graficar", "cobra_graficar(hb);"),
         "corelibs": ('longitud("cobra");',),
         "standard_library": ('mostrar("hola");',),
     },
     "java": {
         "holobit": ("Object hb = cobra_holobit(new double[]{1, 2, 3});",),
-        "proyectar": ("private static double[] cobra_proyectar", 'cobra_proyectar(hb, "2d")'),
-        "transformar": ("private static CobraHolobit cobra_transformar", 'cobra_transformar(hb, "rotar", 90)'),
+        "proyectar": (
+            "private static double[] cobra_proyectar",
+            'cobra_proyectar(hb, "2d")',
+        ),
+        "transformar": (
+            "private static CobraHolobit cobra_transformar",
+            'cobra_transformar(hb, "rotar", 90)',
+        ),
         "graficar": ("private static String cobra_graficar", "cobra_graficar(hb);"),
         "corelibs": ('longitud("cobra")',),
         "standard_library": ('mostrar("hola")',),
@@ -230,7 +261,9 @@ CANONICAL_FULL_PROGRAM_FIXTURE: Final[dict[str, object]] = {
     ],
 }
 
-PARTIAL_CONTRACT_ERROR_MARKERS: Final[dict[str, dict[str, tuple[str, ...]]]] = {
+OFFICIAL_PARTIAL_CONTRACT_ERROR_MARKERS: Final[
+    dict[str, dict[str, tuple[str, ...]]]
+] = {
     "javascript": {
         "proyectar": (
             "Runtime Holobit JavaScript: feature=${feature}; contrato partial; backend sin holobit_sdk;",
@@ -259,6 +292,11 @@ PARTIAL_CONTRACT_ERROR_MARKERS: Final[dict[str, dict[str, tuple[str, ...]]]] = {
             "cobra_holobit_partial_contract_error(",
         ),
     },
+}
+
+LEGACY_EXPERIMENTAL_PARTIAL_CONTRACT_ERROR_MARKERS: Final[
+    dict[str, dict[str, tuple[str, ...]]]
+] = {
     "go": {
         "proyectar": (
             "Runtime Holobit Go: feature=%s; contrato partial; backend sin holobit_sdk;",
@@ -275,36 +313,45 @@ PARTIAL_CONTRACT_ERROR_MARKERS: Final[dict[str, dict[str, tuple[str, ...]]]] = {
     },
     "cpp": {
         "proyectar": (
-            "Runtime Holobit C++: feature=\" + feature + \"; contrato partial; backend sin holobit_sdk;",
+            'Runtime Holobit C++: feature=" + feature + "; contrato partial; backend sin holobit_sdk;',
             "cobra_holobit_partial_contract_error(",
         ),
         "transformar": (
-            "Runtime Holobit C++: feature=\" + feature + \"; contrato partial; backend sin holobit_sdk;",
+            'Runtime Holobit C++: feature=" + feature + "; contrato partial; backend sin holobit_sdk;',
             "cobra_holobit_partial_contract_error(",
         ),
         "graficar": (
-            "Runtime Holobit C++: feature=\" + feature + \"; contrato partial; backend sin holobit_sdk;",
+            'Runtime Holobit C++: feature=" + feature + "; contrato partial; backend sin holobit_sdk;',
             "cobra_holobit_partial_contract_error(",
         ),
     },
     "java": {
         "proyectar": (
-            "Runtime Holobit Java: feature=\" + feature + \"; contrato partial; backend sin holobit_sdk;",
+            'Runtime Holobit Java: feature=" + feature + "; contrato partial; backend sin holobit_sdk;',
             "cobraHolobitPartialContractError(",
         ),
         "transformar": (
-            "Runtime Holobit Java: feature=\" + feature + \"; contrato partial; backend sin holobit_sdk;",
+            'Runtime Holobit Java: feature=" + feature + "; contrato partial; backend sin holobit_sdk;',
             "cobraHolobitPartialContractError(",
         ),
         "graficar": (
-            "Runtime Holobit Java: feature=\" + feature + \"; contrato partial; backend sin holobit_sdk;",
+            'Runtime Holobit Java: feature=" + feature + "; contrato partial; backend sin holobit_sdk;',
             "cobraHolobitPartialContractError(",
         ),
     },
     "wasm": {
-        "proyectar": ("backend wasm: contrato partial", "depende del host para la semántica completa"),
-        "transformar": ("backend wasm: contrato partial", "depende del host para la semántica completa"),
-        "graficar": ("backend wasm: contrato partial", "depende del host para la semántica completa"),
+        "proyectar": (
+            "backend wasm: contrato partial",
+            "depende del host para la semántica completa",
+        ),
+        "transformar": (
+            "backend wasm: contrato partial",
+            "depende del host para la semántica completa",
+        ),
+        "graficar": (
+            "backend wasm: contrato partial",
+            "depende del host para la semántica completa",
+        ),
     },
     "asm": {
         "proyectar": ("runtime de inspección/diagnóstico", "TRAP"),
@@ -313,30 +360,58 @@ PARTIAL_CONTRACT_ERROR_MARKERS: Final[dict[str, dict[str, tuple[str, ...]]]] = {
     },
 }
 
-OFFICIAL_PARTIAL_CONTRACT_ERROR_MARKERS: Final[dict[str, dict[str, tuple[str, ...]]]] = {
-    backend: PARTIAL_CONTRACT_ERROR_MARKERS[backend]
-    for backend in TRANSPILERS
-    if backend in PARTIAL_CONTRACT_ERROR_MARKERS
-}
 RUNTIME_HOOK_EXPECTATIONS: Final[dict[str, tuple[str, ...]]] = {
-    "python": ("def cobra_holobit", "def cobra_proyectar", "def cobra_transformar", "def cobra_graficar"),
-    "javascript": ("function cobra_holobit", "function cobra_proyectar", "function cobra_transformar", "function cobra_graficar"),
-    "rust": ("fn cobra_holobit", "fn cobra_proyectar", "fn cobra_transformar", "fn cobra_graficar"),
+    "python": (
+        "def cobra_holobit",
+        "def cobra_proyectar",
+        "def cobra_transformar",
+        "def cobra_graficar",
+    ),
+    "javascript": (
+        "function cobra_holobit",
+        "function cobra_proyectar",
+        "function cobra_transformar",
+        "function cobra_graficar",
+    ),
+    "rust": (
+        "fn cobra_holobit",
+        "fn cobra_proyectar",
+        "fn cobra_transformar",
+        "fn cobra_graficar",
+    ),
+}
+
+LEGACY_EXPERIMENTAL_RUNTIME_HOOK_EXPECTATIONS: Final[dict[str, tuple[str, ...]]] = {
     "wasm": (
         "(func $cobra_holobit",
         "(func $cobra_proyectar",
         "(func $cobra_transformar",
         "(func $cobra_graficar",
     ),
-    "go": ("func cobra_holobit", "func cobra_proyectar", "func cobra_transformar", "func cobra_graficar"),
-    "cpp": ("inline CobraHolobit cobra_holobit", "inline std::vector<double> cobra_proyectar", "inline CobraHolobit cobra_transformar", "inline std::string cobra_graficar"),
+    "go": (
+        "func cobra_holobit",
+        "func cobra_proyectar",
+        "func cobra_transformar",
+        "func cobra_graficar",
+    ),
+    "cpp": (
+        "inline CobraHolobit cobra_holobit",
+        "inline std::vector<double> cobra_proyectar",
+        "inline CobraHolobit cobra_transformar",
+        "inline std::string cobra_graficar",
+    ),
     "java": (
         "private static CobraHolobit cobra_holobit",
         "private static double[] cobra_proyectar",
         "private static CobraHolobit cobra_transformar",
         "private static String cobra_graficar",
     ),
-    "asm": ("cobra_holobit:", "cobra_proyectar:", "cobra_transformar:", "cobra_graficar:"),
+    "asm": (
+        "cobra_holobit:",
+        "cobra_proyectar:",
+        "cobra_transformar:",
+        "cobra_graficar:",
+    ),
 }
 
 

--- a/tests/integration/transpilers/test_language_equivalence_feature_contracts.py
+++ b/tests/integration/transpilers/test_language_equivalence_feature_contracts.py
@@ -37,11 +37,6 @@ TRANSPILER_FEATURE_CONSTANTS = {
     "python": ("pcobra.cobra.transpilers.transpiler.to_python", "PYTHON_FEATURE_NODE_SUPPORT"),
     "javascript": ("pcobra.cobra.transpilers.transpiler.to_js", "JAVASCRIPT_FEATURE_NODE_SUPPORT"),
     "rust": ("pcobra.cobra.transpilers.transpiler.to_rust", "RUST_FEATURE_NODE_SUPPORT"),
-    "go": ("pcobra.cobra.transpilers.transpiler.to_go", "GO_FEATURE_NODE_SUPPORT"),
-    "cpp": ("pcobra.cobra.transpilers.transpiler.to_cpp", "CPP_FEATURE_NODE_SUPPORT"),
-    "java": ("pcobra.cobra.transpilers.transpiler.to_java", "JAVA_FEATURE_NODE_SUPPORT"),
-    "wasm": ("pcobra.cobra.transpilers.transpiler.to_wasm", "WASM_FEATURE_NODE_SUPPORT"),
-    "asm": ("pcobra.cobra.transpilers.transpiler.to_asm", "ASM_FEATURE_NODE_SUPPORT"),
 }
 
 
@@ -140,21 +135,18 @@ PHASE1_ACCEPTANCE_MARKERS = {
     ("rust", "decoradores"): ("// @decorador", "// decorador aplicado:"),
     ("rust", "async"): ("async fn obtener_datos", "return fetch().await;"),
     ("rust", "imports_corelibs"): ("use crate::corelibs::*;", "use crate::standard_library::*;"),
-    ("go", "decoradores"): ("// @decorador", "// decorador aplicado:"),
-    ("go", "async"): ("func obtener_datos() any {", "return cobra_await(fetch())"),
-    ("go", "imports_corelibs"): ('"pcobra/corelibs"', '"pcobra/standard_library"'),
 }
 
 
 @pytest.mark.parametrize("backend,feature", tuple(PHASE1_ACCEPTANCE_MARKERS))
-def test_phase1_rust_go_acceptance_markers_are_present(backend: str, feature: str):
+def test_phase1_official_acceptance_markers_are_present(backend: str, feature: str):
     generated = _generate(backend, _feature_nodes(feature))
     for marker in PHASE1_ACCEPTANCE_MARKERS[(backend, feature)]:
         assert marker in generated
 
 
 @pytest.mark.parametrize("backend,feature", tuple(PHASE1_ACCEPTANCE_MARKERS))
-def test_phase1_rust_go_matches_golden_minimum_evidence(backend: str, feature: str):
+def test_phase1_official_matches_golden_minimum_evidence(backend: str, feature: str):
     generated = _generate(backend, _feature_nodes(feature)).strip() + "\n"
     golden = Path(__file__).parent / "golden_phase1" / f"{backend}.{feature}.golden"
     assert golden.exists(), f"Falta evidencia golden para {backend}/{feature}: {golden}"

--- a/tests/integration/transpilers/test_official_backends_contracts.py
+++ b/tests/integration/transpilers/test_official_backends_contracts.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from pcobra.cobra.transpilers.compatibility_matrix import BACKEND_COMPATIBILITY
+from pcobra.cobra.transpilers.targets import OFFICIAL_TARGETS
 from pcobra.cobra.architecture.backend_policy import PUBLIC_BACKENDS
 from pcobra.core.ast_nodes import (
     NodoAsignacion,
@@ -20,7 +21,7 @@ from pcobra.core.ast_nodes import (
     NodoTransformar,
     NodoValor,
 )
-from tests.integration.transpilers.backend_contracts import REQUIRED_FEATURES, TRANSPILERS
+from tests.integration.transpilers.backend_contracts import OFFICIAL_TRANSPILERS, REQUIRED_FEATURES, TRANSPILERS
 
 GOLDEN_DIR = Path(__file__).parent / "golden"
 
@@ -60,6 +61,10 @@ def test_public_backend_policy_exact_set_is_enforced() -> None:
     """Política pública exacta: solo python/javascript/rust."""
 
     assert PUBLIC_BACKENDS == ("python", "javascript", "rust")
+    assert OFFICIAL_TARGETS == PUBLIC_BACKENDS
+    assert set(TRANSPILERS) == set(OFFICIAL_TRANSPILERS) == set(OFFICIAL_TARGETS)
+    assert "go" not in OFFICIAL_TARGETS
+    assert "go" not in OFFICIAL_TRANSPILERS
 
 def _generate(language: str, nodes: list[object]) -> str:
     module_name, class_name = TRANSPILERS[language]


### PR DESCRIPTION
### Motivation

- Restringir el registro oficial de transpiladores y los contratos de prueba a los backends soportados oficialmente (Python, JavaScript y Rust).
- Evitar que expectativas históricas de Go, C++, Java, ASM y WASM formen parte del contrato oficial, preservándolas como evidencia legacy/experimental.

### Description

- tests/integration/transpilers/backend_contracts.py: mantiene `OFFICIAL_TRANSPILERS` y `TRANSPILERS` para `python`, `javascript` y `rust`, y separa las expectativas amplias en `LEGACY_EXPERIMENTAL_PARTIAL_EXPECTATIONS`, `LEGACY_EXPERIMENTAL_PARTIAL_CONTRACT_ERROR_MARKERS` y `LEGACY_EXPERIMENTAL_RUNTIME_HOOK_EXPECTATIONS` mientras expone las constantes oficiales para las pruebas. 
- tests/integration/transpilers/test_official_backends_contracts.py: añade aserciones de política que verifican que `OFFICIAL_TARGETS == PUBLIC_BACKENDS`, que `TRANSPILERS` coincide con `OFFICIAL_TRANSPILERS`, y que `go` no está presente en los registros oficiales. 
- tests/integration/transpilers/test_language_equivalence_feature_contracts.py: reduce `TRANSPILER_FEATURE_CONSTANTS` y los marcadores de aceptación de fase 1 para que sólo incluyan backends oficiales, renombra pruebas relacionadas a fase1 para reflejar el alcance oficial. 
- No se añadió ni importó ningún transpilador Go ni se implementó un acceso directo a `TRANSPILERS["go"]`, y no se modificaron Lexer ni Parser.

### Testing

- Ejecutadas las pruebas integradas relevantes con `pytest -q tests/integration/transpilers/test_official_backends_contracts.py tests/integration/transpilers/test_backend_contract_canonical_fixtures.py tests/integration/transpilers/test_language_equivalence_feature_contracts.py` y todas pasaron (`72 passed, 1 warning`).
- Verificaciones automatizadas realizadas: búsqueda de accesos directos a `TRANSPILERS["go"]` (ninguno hallado), comprobación python que valida que los conjuntos oficiales y legacy quedaron particionados correctamente (passed), y `git diff --check` sin errores.
- Comprobación de que no se tocaron `Lexer` ni `Parser` mediante `git diff --name-only | rg -i 'lexer|parser'` (ninguna modificación).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a13081ebc8327ae48b42d27f0849e)