### PR TITLE
Actualiza imports canónicos en snapshots Python revisados

### DIFF
--- a/tests/data/expected_examples/ejemplo.py
+++ b/tests/data/expected_examples/ejemplo.py
@@ -1,4 +1,4 @@
-from pcobra.core.nativos import *
+from pcobra.cobra.core.nativos import *
 import pcobra.corelibs as _pcobra_corelibs
 import pcobra.standard_library as _pcobra_standard_library
 globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})

--- a/tests/data/expected_examples/hola.py
+++ b/tests/data/expected_examples/hola.py
@@ -1,4 +1,4 @@
-from pcobra.core.nativos import *
+from pcobra.cobra.core.nativos import *
 import pcobra.corelibs as _pcobra_corelibs
 import pcobra.standard_library as _pcobra_standard_library
 globals().update({name: getattr(_pcobra_corelibs, name) for name in dir(_pcobra_corelibs) if not name.startswith('_')})


### PR DESCRIPTION
### Motivation
- Confirmar que el import canónico para el backend Python es `from pcobra.cobra.core.nativos import *` y corregir únicamente los snapshots que diferían solo en esa línea.

### Description
- Actualiza la primera línea en `tests/data/expected_examples/hola.py` y `tests/data/expected_examples/ejemplo.py` para usar `from pcobra.cobra.core.nativos import *` sin modificar otros snapshots, el transpilador ni la infraestructura de imports.

### Testing
- Comparé la salida de `TranspiladorPython` con los snapshots `hola` y `ejemplo` (coincidieron) y validé el Python generado con `ast.parse` (válido), ejecuté `pytest -q tests/integration/test_transpiladores.py` y `pytest -q tests/integration/test_transpilador_syntax.py::test_transpilador_syntax[python]` (pasaron), verifiqué que `STANDARD_IMPORTS` define el import canónico y comprobé que Lexer/Parser no cambiaron; noté que `tests/test_ejemplos_io.py` falla fuera del alcance de este cambio porque invoca el comando CLI retirado `transpilar`, y que los snapshots de decoradores se dejaron intactos tras detectar una sintaxis inválida preexistente en el Python generado para decoradores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a14ba5048832787b1b38a0d8b877a)