### PR TITLE
Prefer real pexpect for interactive persistence coverage

### DIFF
--- a/src/pcobra/_stubs/pexpect/__init__.py
+++ b/src/pcobra/_stubs/pexpect/__init__.py
@@ -39,6 +39,7 @@ class spawn:
     def __init__(
         self,
         command: Union[str, Sequence[str]],
+        args: Optional[Sequence[str]] = None,
         *,
         env: Optional[dict[str, str]] = None,
         encoding: str = "utf-8",
@@ -53,6 +54,11 @@ class spawn:
                 arg.decode(encoding) if isinstance(arg, bytes) else str(arg)
                 for arg in command
             ]
+        if args is not None:
+            cmd.extend(
+                arg.decode(encoding) if isinstance(arg, bytes) else str(arg)
+                for arg in args
+            )
         self._process = subprocess.Popen(
             cmd,
             shell=False,
@@ -144,4 +150,3 @@ class spawn:
 
 
 __all__ = ["EOF", "spawn", "TIMEOUT"]
-

--- a/tests/integration/test_interactive_persistence.py
+++ b/tests/integration/test_interactive_persistence.py
@@ -1,10 +1,15 @@
+import importlib.util
 import os
 import shlex
 import sys
 from pathlib import Path
 
 import pytest
-from pcobra._stubs import pexpect
+
+if importlib.util.find_spec("pexpect") is not None:
+    import pexpect
+else:
+    from pcobra._stubs import pexpect
 
 ROOT = Path(__file__).resolve().parents[2]
 PATCH_DIR = Path(__file__).parent
@@ -21,7 +26,10 @@ def _spawn(args="repl", extra_env=None):
     if extra_env:
         env.update(extra_env)
     return pexpect.spawn(
-        [sys.executable, "-m", "cli.cli", *shlex.split(args)], env=env, encoding="utf-8"
+        sys.executable,
+        args=["-m", "pcobra", *shlex.split(args)],
+        env=env,
+        encoding="utf-8",
     )
 
 

--- a/tests/unit/test_pexpect_stub.py
+++ b/tests/unit/test_pexpect_stub.py
@@ -22,3 +22,18 @@ def test_spawn_split_string_command_without_shell_injection() -> None:
 
     child.wait()
     assert child.exitstatus == 0
+
+
+def test_spawn_accepts_executable_and_args_like_real_pexpect() -> None:
+    """Admite separar el ejecutable de sus argumentos como ``pexpect`` real."""
+
+    child = pexpect.spawn(
+        sys.executable,
+        args=["-c", "print('firma compatible')"],
+        timeout=3,
+    )
+
+    child.expect("firma compatible")
+    child.expect(pexpect.EOF)
+    child.wait()
+    assert child.exitstatus == 0


### PR DESCRIPTION
### Motivation

- La prueba de persistencia interactiva debe preferir el paquete `pexpect` instalado y usar el mismo contrato de `spawn` que la API real para aumentar la fidelidad de la integración. 
- Mantener `_spawn` usando `sys.executable` garantiza que se lance el intérprete Python activo en el entorno de prueba.
- El stub interno debe ser compatible con la firma real de `pexpect.spawn` para evitar bifurcar la lógica de las pruebas.
- Verificar que el REPL publique el prompt inicial y que el `InterpretadorCobra` persista entre entradas sin tocar Lexer/Parser.

### Description

- Resuelvo dinámicamente `pexpect` con `importlib.util.find_spec("pexpect")` y solo uso `pcobra._stubs.pexpect` cuando no hay dependencia instalada, manteniendo compatibilidad de pruebas. 
- Actualizo `_spawn` para llamar al intérprete con `sys.executable` y pasar los argumentos a la API de `pexpect.spawn` como `args=[...]` en lugar de pasar un único string. 
- Extiendo el stub `pcobra._stubs.pexpect.spawn` para aceptar el parámetro `args: Optional[Sequence[str]]` y concatenar esos valores al comando ejecutado para emular la firma real. 
- Añadí una prueba unitaria `test_spawn_accepts_executable_and_args_like_real_pexpect` que valida la compatibilidad del stub con la firma `spawn(executable, args=...)`, y verifiqué manualmente que `ReplCommandV2.run` emite `">>> "` antes de leer y conserva la misma instancia de `InterpretadorCobra` entre entradas.

### Testing

- `python -m pytest tests/unit/test_pexpect_stub.py tests/integration/test_interactive_persistence.py -q` — 3 pruebas ejecutadas y todas pasaron. 
- `python -m pytest tests/cli/test_repl_error_recovery_contract.py tests/integration/test_run_repl_equivalence.py::test_repl_persistencia_entre_entradas_tras_error_intermedio_real tests/unit/test_repl_command_v2.py::test_repl_v2_prompts_primario_y_secundario_en_bloque -q` — conjunto dirigido de pruebas pasó (10 pruebas exitosas, 1 advertencia deprecatada sobre nombres de módulos). 
- `python -m ruff check tests/integration/test_interactive_persistence.py src/pcobra/_stubs/pexpect/__init__.py tests/unit/test_pexpect_stub.py` — comprobación de estilo pasó sin errores. 
- Las modificaciones no tocan Lexer ni Parser y las suites relacionadas de REPL y persistencia relevantes han sido verificadas exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b33bec7348327afa2884b4187f3fa)